### PR TITLE
feat(skill): persist draft skill candidates

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3577,6 +3577,19 @@ export interface MemorySubsystemsUserModelPrompt {
   producer?: string
 }
 
+export interface MemorySubsystemsDraftSkillCandidate {
+  id: string
+  agent_name: string
+  source_kind: string
+  source_ref: string
+  promotion_state: string
+  dir: string
+  json_path: string
+  toml_path: string
+  skill_md_path: string
+  created_at: number | null
+}
+
 export interface MemorySubsystemsResponse {
   generated_at: string
   hebbian: {
@@ -3612,6 +3625,14 @@ export interface MemorySubsystemsResponse {
     limit: number
     items: MemorySubsystemsUserModelItem[]
     errors?: MemorySubsystemsUserModelError[]
+  }
+  draft_skill_candidates?: {
+    total: number
+    shown: number
+    limit: number
+    index_path: string
+    items: MemorySubsystemsDraftSkillCandidate[]
+    error?: string | null
   }
   filters: {
     keepers: string[]

--- a/dashboard/src/components/memory-subsystems.focus.test.ts
+++ b/dashboard/src/components/memory-subsystems.focus.test.ts
@@ -88,7 +88,7 @@ const baseResponse: MemorySubsystemsResponse = {
     total: 1,
     shown: 1,
     limit: 100,
-    index_path: '/tmp/masc/.masc/draft-skills/index.jsonl',
+    index_path: '<base-path>/.masc/draft-skills/index.jsonl',
     items: [
       {
         id: 'skill-candidate-repeatable-debug-loop',
@@ -96,10 +96,10 @@ const baseResponse: MemorySubsystemsResponse = {
         source_kind: 'procedure',
         source_ref: 'procedure://keeper-alpha/repeatable-debug-loop',
         promotion_state: 'candidate',
-        dir: '/tmp/masc/.masc/draft-skills/skill-candidate-repeatable-debug-loop',
-        json_path: '/tmp/masc/.masc/draft-skills/skill-candidate-repeatable-debug-loop/candidate.json',
-        toml_path: '/tmp/masc/.masc/draft-skills/skill-candidate-repeatable-debug-loop/candidate.toml',
-        skill_md_path: '/tmp/masc/.masc/draft-skills/skill-candidate-repeatable-debug-loop/SKILL.md',
+        dir: '<base-path>/.masc/draft-skills/skill-candidate-repeatable-debug-loop',
+        json_path: '<base-path>/.masc/draft-skills/skill-candidate-repeatable-debug-loop/candidate.json',
+        toml_path: '<base-path>/.masc/draft-skills/skill-candidate-repeatable-debug-loop/candidate.toml',
+        skill_md_path: '<base-path>/.masc/draft-skills/skill-candidate-repeatable-debug-loop/SKILL.md',
         created_at: 1,
       },
     ],
@@ -216,7 +216,7 @@ describe('MemorySubsystems focus targets', () => {
     await vi.waitFor(() => {
       expect(container.textContent).toContain('skill-candidate-repeatable-debug-loop')
       expect(container.textContent).toContain('candidate')
-      expect(container.textContent).toContain('/tmp/masc/.masc/draft-skills/skill-candidate-repeatable-debug-loop/SKILL.md')
+      expect(container.textContent).toContain('<base-path>/.masc/draft-skills/skill-candidate-repeatable-debug-loop/SKILL.md')
     })
     expect(container.querySelector('[data-testid="draft-skill-candidates"]')).not.toBeNull()
   })

--- a/dashboard/src/components/memory-subsystems.focus.test.ts
+++ b/dashboard/src/components/memory-subsystems.focus.test.ts
@@ -221,6 +221,75 @@ describe('MemorySubsystems focus targets', () => {
     expect(container.querySelector('[data-testid="draft-skill-candidates"]')).not.toBeNull()
   })
 
+  it('renders draft skill candidate empty and error states', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        ...baseResponse,
+        draft_skill_candidates: {
+          total: 0,
+          shown: 0,
+          limit: 100,
+          index_path: '<base-path>/.masc/draft-skills/index.jsonl',
+          items: [],
+          error: 'draft skill index read failed',
+        },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(html`<${MemorySubsystems} />`, container)
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="draft-skill-candidates"]')).not.toBeNull()
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+        'draft skill index read failed',
+      )
+      expect(container.textContent).toContain('draft skill 후보 없음')
+      expect(container.textContent).toContain('total 0 · shown 0')
+    })
+  })
+
+  it('renders non-candidate draft skill states with nullable creation time', async () => {
+    const original = baseResponse.draft_skill_candidates!.items[0]!
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        ...baseResponse,
+        draft_skill_candidates: {
+          ...baseResponse.draft_skill_candidates!,
+          total: 2,
+          shown: 2,
+          items: [
+            {
+              ...original,
+              id: 'skill-promoted-debug-loop',
+              promotion_state: 'promoted',
+              skill_md_path: '<base-path>/.masc/skills/debug-loop/SKILL.md',
+              created_at: null,
+            },
+            {
+              ...original,
+              id: 'skill-rejected-debug-loop',
+              promotion_state: 'rejected',
+              skill_md_path: '<base-path>/.masc/draft-skills/rejected/SKILL.md',
+              created_at: null,
+            },
+          ],
+        },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(html`<${MemorySubsystems} />`, container)
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('skill-promoted-debug-loop')
+      expect(container.textContent).toContain('promoted')
+      expect(container.textContent).toContain('skill-rejected-debug-loop')
+      expect(container.textContent).toContain('rejected')
+      expect(container.textContent).toContain('<base-path>/.masc/skills/debug-loop/SKILL.md')
+    })
+  })
+
   it('focuses the episodes section without requesting memory entries for episodes focus', async () => {
     const responseWithoutEntries: MemorySubsystemsResponse = {
       ...baseResponse,

--- a/dashboard/src/components/memory-subsystems.focus.test.ts
+++ b/dashboard/src/components/memory-subsystems.focus.test.ts
@@ -84,6 +84,27 @@ const baseResponse: MemorySubsystemsResponse = {
     ],
     errors: [],
   },
+  draft_skill_candidates: {
+    total: 1,
+    shown: 1,
+    limit: 100,
+    index_path: '/tmp/masc/.masc/draft-skills/index.jsonl',
+    items: [
+      {
+        id: 'skill-candidate-repeatable-debug-loop',
+        agent_name: 'keeper-alpha',
+        source_kind: 'procedure',
+        source_ref: 'procedure://keeper-alpha/repeatable-debug-loop',
+        promotion_state: 'candidate',
+        dir: '/tmp/masc/.masc/draft-skills/skill-candidate-repeatable-debug-loop',
+        json_path: '/tmp/masc/.masc/draft-skills/skill-candidate-repeatable-debug-loop/candidate.json',
+        toml_path: '/tmp/masc/.masc/draft-skills/skill-candidate-repeatable-debug-loop/candidate.toml',
+        skill_md_path: '/tmp/masc/.masc/draft-skills/skill-candidate-repeatable-debug-loop/SKILL.md',
+        created_at: 1,
+      },
+    ],
+    error: null,
+  },
   filters: {
     keepers: ['keeper-alpha'],
     outcomes: ['success'],
@@ -184,6 +205,20 @@ describe('MemorySubsystems focus targets', () => {
     })
     expect(container.querySelector('[data-testid="user-model-projection"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="user-model-prompt-surface"]')).not.toBeNull()
+  })
+
+  it('renders draft skill candidates from the memory subsystem payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(baseResponse))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(html`<${MemorySubsystems} />`, container)
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('skill-candidate-repeatable-debug-loop')
+      expect(container.textContent).toContain('candidate')
+      expect(container.textContent).toContain('/tmp/masc/.masc/draft-skills/skill-candidate-repeatable-debug-loop/SKILL.md')
+    })
+    expect(container.querySelector('[data-testid="draft-skill-candidates"]')).not.toBeNull()
   })
 
   it('focuses the episodes section without requesting memory entries for episodes focus', async () => {

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -16,6 +16,7 @@ import {
   type MemorySubsystemsUserModelItem,
   type MemorySubsystemsUserModelError,
   type MemorySubsystemsUserModelPrompt,
+  type MemorySubsystemsDraftSkillCandidate,
 } from '../api/dashboard'
 import { formatTimeAgo } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -79,6 +80,9 @@ export const ARCHITECTURE_FLOW = `graph LR
     G1 --> D1
     F1 --> U1[user_model projection]
     U1 --> D1
+    M3 --> S1[skill_candidate_projection]
+    S1 --> S2[(.masc/draft-skills)]
+    S2 --> D1
     D1 --> UI[기억 서브시스템 패널]
 
     %% dark-fantasy palette (mermaid can't use CSS vars): store=bg/mold,
@@ -86,8 +90,8 @@ export const ARCHITECTURE_FLOW = `graph LR
     classDef store fill:#221815,stroke:#5a3028,color:#e8d8b8
     classDef action fill:#16210f,stroke:#5a7a3a,color:#e8d8b8
     classDef ui fill:#2a1d08,stroke:#c4461a,color:#e8d8b8
-    class F1,G1 store
-    class M1,M3,H1,H2,T2,U1 action
+    class F1,G1,S2 store
+    class M1,M3,H1,H2,T2,U1,S1 action
     class UI ui`
 
 const shortAgentLabel = (name: string) => {
@@ -627,6 +631,88 @@ function UserModelPanel({
   `
 }
 
+function DraftSkillCandidateRow({
+  candidate,
+}: {
+  readonly candidate: MemorySubsystemsDraftSkillCandidate
+}) {
+  return html`
+    <div
+      class="v2-monitoring-row grid grid-cols-[10rem_7rem_minmax(0,1fr)_minmax(12rem,20rem)] items-start gap-2 border-b border-[var(--color-border-default)] px-2 py-2 text-xs last:border-b-0 max-lg:grid-cols-[8rem_minmax(0,1fr)]"
+      role="listitem"
+      aria-label=${`${candidate.id} · ${candidate.promotion_state} · ${candidate.source_ref}`}
+    >
+      <span class="min-w-0 truncate font-mono text-[var(--color-fg-muted)]" title=${candidate.id}>
+        ${candidate.id}
+      </span>
+      <span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-center font-mono text-[var(--color-status-warn)]">
+        ${candidate.promotion_state}
+      </span>
+      <span class="min-w-0 truncate text-[var(--color-fg-primary)]" title=${candidate.source_ref}>
+        ${candidate.source_kind}: ${candidate.source_ref}
+      </span>
+      <span class="min-w-0 truncate font-mono text-[var(--color-fg-disabled)] max-lg:col-span-2" title=${candidate.skill_md_path}>
+        ${candidate.skill_md_path}
+      </span>
+    </div>
+  `
+}
+
+function DraftSkillCandidatesPanel({
+  total,
+  shown,
+  indexPath,
+  candidates,
+  error,
+}: {
+  readonly total: number
+  readonly shown: number
+  readonly indexPath: string
+  readonly candidates: readonly MemorySubsystemsDraftSkillCandidate[]
+  readonly error?: string | null
+}) {
+  return html`
+    <section
+      data-testid="draft-skill-candidates"
+      aria-label=${`Draft skill candidates · ${shown} shown`}
+      class="flex flex-col gap-2"
+    >
+      <div class="flex flex-wrap items-center gap-2">
+        <h3 class="text-base font-semibold text-[var(--color-fg-muted)]">Draft skill candidates</h3>
+        <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">
+          ${indexPath}
+        </span>
+        <span class="ml-auto text-xs text-[var(--color-fg-muted)]">
+          total ${total} · shown ${shown}
+        </span>
+      </div>
+      ${
+        error
+          ? html`<div
+              role="alert"
+              class="rounded-[var(--r-1)] border border-[var(--warn-fg)] bg-[var(--warn-bg)] px-3 py-2 text-2xs text-[var(--color-fg-primary)]"
+            >${error}</div>`
+          : null
+      }
+      ${
+        candidates.length === 0
+          ? html`<div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4 text-center text-sm text-[var(--color-fg-muted)]">
+              draft skill 후보 없음
+            </div>`
+          : html`
+              <div
+                class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)]"
+                role="list"
+                aria-label=${`${shown} draft skill candidates`}
+              >
+                ${candidates.map(candidate => html`<${DraftSkillCandidateRow} candidate=${candidate} />`)}
+              </div>
+            `
+      }
+    </section>
+  `
+}
+
 export function MemoryEntriesPanel({
   entries,
   visibleEntries,
@@ -792,6 +878,8 @@ export function MemorySubsystems({ focus }: MemorySubsystemsProps = {}) {
   const knownMemoryKinds = data?.filters?.memory_kinds ?? Array.from(new Set(entries.map(e => e.kind))).sort()
   const userModel = data?.user_model
   const userModelItems = userModel?.items ?? []
+  const draftSkillCandidateBlock = data?.draft_skill_candidates
+  const draftSkillCandidates = draftSkillCandidateBlock?.items ?? []
   const visibleEntries = useMemo(
     () => filterMemoryEntries(entries, memoryKindFilter.value),
     [entries, memoryKindFilter.value],
@@ -872,6 +960,14 @@ export function MemorySubsystems({ focus }: MemorySubsystemsProps = {}) {
         filtered=${userModel?.filtered ?? userModelItems.length}
         errors=${userModel?.errors ?? []}
         prompt=${userModel?.prompt}
+      />
+
+      <${DraftSkillCandidatesPanel}
+        total=${draftSkillCandidateBlock?.total ?? draftSkillCandidates.length}
+        shown=${draftSkillCandidateBlock?.shown ?? draftSkillCandidates.length}
+        indexPath=${draftSkillCandidateBlock?.index_path ?? '.masc/draft-skills/index.jsonl'}
+        candidates=${draftSkillCandidates}
+        error=${draftSkillCandidateBlock?.error ?? null}
       />
 
       ${

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -274,6 +274,19 @@ let file_exists (path : string) : bool =
        | Eio.Io _ -> false)
 ;;
 
+(** Load entire file contents as string, or [None] when the file is
+    missing. Option-returning sibling of {!load_file} (which raises on a
+    missing path). [Sys_error] from a vanished file (TOCTOU race after the
+    [file_exists] check) is also mapped to [None]; other I/O failures of an
+    existing file propagate as [Sys_error], matching {!load_file}. *)
+let load_file_opt (path : string) : string option =
+  if not (file_exists path)
+  then None
+  else (
+    try Some (load_file path) with
+    | Sys_error _ when not (file_exists path) -> None)
+;;
+
 let file_size (path : string) : int option =
   with_fs_or_fallback
     ~path

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -25,6 +25,12 @@ val has_fs : unit -> bool
 (** Load entire file as string. *)
 val load_file : string -> string
 
+(** Load entire file as string, or [None] when the file is missing.
+    Option-returning sibling of {!load_file} (which raises on a missing
+    path). Other I/O failures of an existing file propagate as
+    [Sys_error]. *)
+val load_file_opt : string -> string option
+
 (** Save string to file (overwrite). *)
 val save_file : string -> string -> unit
 

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -92,6 +92,42 @@ let run
     ~keeper_id:meta.name
     librarian_input;
 
+  (* Memory OS -> draft skill loop: after librarian facts are durable, project
+     validated approaches / lessons into reviewable draft skill artifacts. This
+     stays advisory and never mutates the keeper tool surface. *)
+  (try
+     match
+       Skill_candidate_store.write_post_turn_candidates
+         ~base_path:config.base_path
+         ~keeper_id:meta.name
+         ~fact_tail_limit:Keeper_memory_os_io.fact_store_max
+         ~procedure_limit:8
+     with
+     | Ok [] -> ()
+     | Ok stored ->
+       Log.Keeper.info ~keeper_name:meta.name
+         "draft_skill_candidates wrote=%d dir=%s"
+         (List.length stored)
+         (Skill_candidate_store.drafts_dir ~base_path:config.base_path)
+     | Error msg ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string DispatchEventFailures)
+         ~labels:[ "keeper", meta.name; "site", "draft_skill_candidates" ]
+         ();
+       Log.Keeper.warn ~keeper_name:meta.name
+         "draft_skill_candidates failed: %s"
+         msg
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     Otel_metric_store.inc_counter
+       Keeper_metrics.(to_string DispatchEventFailures)
+       ~labels:[ "keeper", meta.name; "site", "draft_skill_candidates" ]
+       ();
+     Log.Keeper.warn ~keeper_name:meta.name
+       "draft_skill_candidates failed: %s"
+       (Printexc.to_string exn));
+
   (* Memory bank compaction: dedup + consolidate if over threshold. *)
   (try
      let memory_summarizer =

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -2,6 +2,8 @@
 
     Extracted from [Keeper_agent_run.run_turn] Step 8 body (RFC-0147 PR-4). *)
 
+let default_post_turn_procedure_candidate_limit = 8
+
 let run
   ~config
   ~meta
@@ -101,7 +103,7 @@ let run
          ~base_path:config.base_path
          ~keeper_id:meta.name
          ~fact_tail_limit:Keeper_memory_os_io.fact_store_max
-         ~procedure_limit:8
+         ~procedure_limit:default_post_turn_procedure_candidate_limit
      with
      | Ok [] -> ()
      | Ok stored ->

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -279,6 +279,13 @@ let rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts =
   write_file_atomically path content
 ;;
 
+let rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts =
+  rewrite_facts_atomically_for_keepers_dir
+    ~keepers_dir:(Config_dir_resolver.keepers_dir_for_base_path ~base_path)
+    ~keeper_id
+    facts
+;;
+
 let rewrite_facts_atomically ~keeper_id facts =
   rewrite_facts_atomically_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id facts
 ;;

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -60,6 +60,8 @@ val append_episode_bundle : keeper_id:string -> episode -> unit
 val rewrite_facts_atomically : keeper_id:string -> fact list -> unit
 val rewrite_facts_atomically_for_keepers_dir :
   keepers_dir:string -> keeper_id:string -> fact list -> unit
+val rewrite_facts_atomically_for_base_path :
+  base_path:string -> keeper_id:string -> fact list -> unit
 
 (** {1 Facts snapshot CAS} *)
 

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -31,20 +31,24 @@ type procedure = {
 (* Paths                                                            *)
 (* ================================================================ *)
 
-let procedures_dir ~agent_name =
+let base_path_or_default = function
+  | Some base_path -> base_path
+  | None -> Env_config.base_path ()
+;;
+
+let procedures_dir ?base_path ~agent_name =
+  let base_path = base_path_or_default base_path in
   Filename.concat
-    (Filename.concat
-       (Common.masc_dir_from_base_path ~base_path:(Env_config.base_path ()))
-       "procedures")
+    (Filename.concat (Common.masc_dir_from_base_path ~base_path) "procedures")
     agent_name
 
-let procedures_path ~agent_name =
-  sprintf "%s/procedures.jsonl" (procedures_dir ~agent_name)
+let procedures_path ?base_path ~agent_name =
+  sprintf "%s/procedures.jsonl" (procedures_dir ?base_path ~agent_name)
 
-let with_procedures_lock ~agent_name f =
-  let dir = procedures_dir ~agent_name in
+let with_procedures_lock ?base_path ~agent_name f =
+  let dir = procedures_dir ?base_path ~agent_name in
   Fs_compat.mkdir_p dir;
-  File_lock_eio.with_lock (procedures_path ~agent_name) f
+  File_lock_eio.with_lock (procedures_path ?base_path ~agent_name) f
 
 (* ================================================================ *)
 (* JSON Serialization                                               *)
@@ -91,20 +95,20 @@ let of_json (json : Yojson.Safe.t) : procedure option =
 (* File I/O                                                         *)
 (* ================================================================ *)
 
-let load_procedures ~agent_name : procedure list =
-  with_procedures_lock ~agent_name (fun () ->
-    let path = procedures_path ~agent_name in
+let load_procedures ?base_path ~agent_name : procedure list =
+  with_procedures_lock ?base_path ~agent_name (fun () ->
+    let path = procedures_path ?base_path ~agent_name in
     Fs_compat.load_jsonl path
     |> List.filter_map of_json)
 
-let save_procedure ~agent_name (p : procedure) =
-  with_procedures_lock ~agent_name (fun () ->
-    let path = procedures_path ~agent_name in
+let save_procedure ?base_path ~agent_name (p : procedure) =
+  with_procedures_lock ?base_path ~agent_name (fun () ->
+    let path = procedures_path ?base_path ~agent_name in
     Fs_compat.append_jsonl path (to_json p))
 
-let rewrite_procedures ~agent_name (procs : procedure list) =
-  with_procedures_lock ~agent_name (fun () ->
-    let path = procedures_path ~agent_name in
+let rewrite_procedures ?base_path ~agent_name (procs : procedure list) =
+  with_procedures_lock ?base_path ~agent_name (fun () ->
+    let path = procedures_path ?base_path ~agent_name in
     let content =
       procs
       |> List.map (fun p -> Yojson.Safe.to_string (to_json p))
@@ -142,8 +146,8 @@ let is_crystallized (p : procedure) : bool =
 (** Get top-N crystallized procedures by confidence.
     Uses adaptive thresholding: standard (3+ evidence, 70% confidence)
     plus rare-but-perfect (2+ evidence, 100% confidence). *)
-let top_procedures ~agent_name ~limit : procedure list =
-  let procs = load_procedures ~agent_name in
+let top_procedures ?base_path ~agent_name ~limit : procedure list =
+  let procs = load_procedures ?base_path ~agent_name in
   procs
   |> List.filter is_crystallized
   |> List.sort (fun a b -> Float.compare b.confidence a.confidence)

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -36,19 +36,19 @@ let base_path_or_default = function
   | None -> Env_config.base_path ()
 ;;
 
-let procedures_dir ?base_path ~agent_name =
+let procedures_dir ?base_path ~agent_name () =
   let base_path = base_path_or_default base_path in
   Filename.concat
     (Filename.concat (Common.masc_dir_from_base_path ~base_path) "procedures")
     agent_name
 
-let procedures_path ?base_path ~agent_name =
-  sprintf "%s/procedures.jsonl" (procedures_dir ?base_path ~agent_name)
+let procedures_path ?base_path ~agent_name () =
+  sprintf "%s/procedures.jsonl" (procedures_dir ?base_path ~agent_name ())
 
 let with_procedures_lock ?base_path ~agent_name f =
-  let dir = procedures_dir ?base_path ~agent_name in
+  let dir = procedures_dir ?base_path ~agent_name () in
   Fs_compat.mkdir_p dir;
-  File_lock_eio.with_lock (procedures_path ?base_path ~agent_name) f
+  File_lock_eio.with_lock (procedures_path ?base_path ~agent_name ()) f
 
 (* ================================================================ *)
 (* JSON Serialization                                               *)
@@ -95,20 +95,20 @@ let of_json (json : Yojson.Safe.t) : procedure option =
 (* File I/O                                                         *)
 (* ================================================================ *)
 
-let load_procedures ?base_path ~agent_name : procedure list =
+let load_procedures ?base_path ~agent_name () : procedure list =
   with_procedures_lock ?base_path ~agent_name (fun () ->
-    let path = procedures_path ?base_path ~agent_name in
+    let path = procedures_path ?base_path ~agent_name () in
     Fs_compat.load_jsonl path
     |> List.filter_map of_json)
 
 let save_procedure ?base_path ~agent_name (p : procedure) =
   with_procedures_lock ?base_path ~agent_name (fun () ->
-    let path = procedures_path ?base_path ~agent_name in
+    let path = procedures_path ?base_path ~agent_name () in
     Fs_compat.append_jsonl path (to_json p))
 
 let rewrite_procedures ?base_path ~agent_name (procs : procedure list) =
   with_procedures_lock ?base_path ~agent_name (fun () ->
-    let path = procedures_path ?base_path ~agent_name in
+    let path = procedures_path ?base_path ~agent_name () in
     let content =
       procs
       |> List.map (fun p -> Yojson.Safe.to_string (to_json p))
@@ -146,8 +146,8 @@ let is_crystallized (p : procedure) : bool =
 (** Get top-N crystallized procedures by confidence.
     Uses adaptive thresholding: standard (3+ evidence, 70% confidence)
     plus rare-but-perfect (2+ evidence, 100% confidence). *)
-let top_procedures ?base_path ~agent_name ~limit : procedure list =
-  let procs = load_procedures ?base_path ~agent_name in
+let top_procedures ?base_path ~agent_name ~limit () : procedure list =
+  let procs = load_procedures ?base_path ~agent_name () in
   procs
   |> List.filter is_crystallized
   |> List.sort (fun a b -> Float.compare b.confidence a.confidence)

--- a/lib/procedural_memory.mli
+++ b/lib/procedural_memory.mli
@@ -33,14 +33,14 @@ type procedure = {
 
 (** [.masc/procedures/{agent_name}/procedures.jsonl] under [base_path].
     Defaults to [Env_config.base_path ()] for existing callers. *)
-val procedures_path : ?base_path:string -> agent_name:string -> string
+val procedures_path : ?base_path:string -> agent_name:string -> unit -> string
 
 (** {1 File I/O} *)
 
 (** Load all persisted procedures for [agent_name]. Malformed JSONL
     lines are silently skipped (via [of_json]). Returns [[]] if the
     file does not exist. *)
-val load_procedures : ?base_path:string -> agent_name:string -> procedure list
+val load_procedures : ?base_path:string -> agent_name:string -> unit -> procedure list
 
 (** Append [p] to the agent's procedures file. Creates the directory
     if it does not exist. *)
@@ -59,4 +59,5 @@ val rewrite_procedures : ?base_path:string -> agent_name:string -> procedure lis
 val is_crystallized : procedure -> bool
 
 (** Top-N crystallised procedures sorted by confidence (descending). *)
-val top_procedures : ?base_path:string -> agent_name:string -> limit:int -> procedure list
+val top_procedures :
+  ?base_path:string -> agent_name:string -> limit:int -> unit -> procedure list

--- a/lib/procedural_memory.mli
+++ b/lib/procedural_memory.mli
@@ -31,24 +31,24 @@ type procedure = {
 
 (** {1 Paths} *)
 
-(** [.masc/procedures/{agent_name}/procedures.jsonl] under
-    [Env_config.base_path ()]. *)
-val procedures_path : agent_name:string -> string
+(** [.masc/procedures/{agent_name}/procedures.jsonl] under [base_path].
+    Defaults to [Env_config.base_path ()] for existing callers. *)
+val procedures_path : ?base_path:string -> agent_name:string -> string
 
 (** {1 File I/O} *)
 
 (** Load all persisted procedures for [agent_name]. Malformed JSONL
     lines are silently skipped (via [of_json]). Returns [[]] if the
     file does not exist. *)
-val load_procedures : agent_name:string -> procedure list
+val load_procedures : ?base_path:string -> agent_name:string -> procedure list
 
 (** Append [p] to the agent's procedures file. Creates the directory
     if it does not exist. *)
-val save_procedure : agent_name:string -> procedure -> unit
+val save_procedure : ?base_path:string -> agent_name:string -> procedure -> unit
 
 (** Rewrite the full procedures file atomically. On write error,
     logs via [Log.Config.warn] and returns [()]. *)
-val rewrite_procedures : agent_name:string -> procedure list -> unit
+val rewrite_procedures : ?base_path:string -> agent_name:string -> procedure list -> unit
 
 (** {1 Crystallisation} *)
 
@@ -59,4 +59,4 @@ val rewrite_procedures : agent_name:string -> procedure list -> unit
 val is_crystallized : procedure -> bool
 
 (** Top-N crystallised procedures sorted by confidence (descending). *)
-val top_procedures : agent_name:string -> limit:int -> procedure list
+val top_procedures : ?base_path:string -> agent_name:string -> limit:int -> procedure list

--- a/lib/prompt_defaults.ml
+++ b/lib/prompt_defaults.ml
@@ -45,11 +45,7 @@ type sync_result = {
   failed : (string * string) list;
 }
 
-let read_file_opt path =
-  if Sys.file_exists path then
-    try Some (In_channel.with_open_text path In_channel.input_all)
-    with Sys_error _ -> None
-  else None
+let read_file_opt = Fs_compat.load_file_opt
 
 let sync_prompt_assets ~read ~files ~prompts_dir () =
   let prefix_len = String.length prompts_asset_prefix in

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -263,7 +263,16 @@ let safe_realpath path =
   try Some (Unix.realpath path)
   with Unix.Unix_error _ -> None
 
-let read_file_opt = Fs_compat.load_file_opt
+let max_git_probe_file_bytes = 64 * 1024
+
+let read_git_probe_file_opt path =
+  match safe_lstat path with
+  | Some { Unix.st_kind = Unix.S_REG; st_size; _ }
+    when st_size <= max_git_probe_file_bytes -> Fs_compat.load_file_opt path
+  | Some { Unix.st_kind =
+             ( Unix.S_REG | Unix.S_DIR | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK
+             | Unix.S_FIFO | Unix.S_SOCK ); _ } -> None
+  | None -> None
 
 let normalize_lexical_path path =
   let absolute = String.starts_with ~prefix:"/" path in
@@ -311,7 +320,7 @@ let git_config_path_of_repo_root repo_root =
   if safe_file_exists dot_git && safe_is_directory dot_git then
     Some (Filename.concat dot_git "config")
   else if safe_file_exists dot_git then
-    match read_file_opt dot_git with
+    match read_git_probe_file_opt dot_git with
     | None -> None
     | Some content ->
         content
@@ -332,7 +341,7 @@ let remote_origin_url_of_repo_root repo_root =
   match git_config_path_of_repo_root repo_root with
   | None -> None
   | Some config_path -> (
-      match read_file_opt config_path with
+      match read_git_probe_file_opt config_path with
       | None -> None
       | Some content ->
           let rec loop in_origin = function

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -237,8 +237,6 @@ let repository_url_basename url =
       String.sub base 0 (String.length base - 4)
     else base
 
-let max_git_probe_file_bytes = 64 * 1024
-
 let safe_lstat path =
   try Some (Unix.lstat path)
   with Unix.Unix_error _ -> None
@@ -265,19 +263,7 @@ let safe_realpath path =
   try Some (Unix.realpath path)
   with Unix.Unix_error _ -> None
 
-let read_file_opt path =
-  match safe_lstat path with
-  | Some { Unix.st_kind = Unix.S_REG; st_size; _ }
-    when st_size <= max_git_probe_file_bytes -> (
-      try
-        Some
-          (In_channel.with_open_bin path (fun ic ->
-               really_input_string ic st_size))
-      with Sys_error _ | End_of_file -> None)
-  | Some { Unix.st_kind =
-             ( Unix.S_REG | Unix.S_DIR | Unix.S_CHR | Unix.S_BLK | Unix.S_LNK
-             | Unix.S_FIFO | Unix.S_SOCK ); _ } -> None
-  | None -> None
+let read_file_opt = Fs_compat.load_file_opt
 
 let normalize_lexical_path path =
   let absolute = String.starts_with ~prefix:"/" path in

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -318,6 +318,28 @@ let dashboard_memory_subsystems_http_json
     |> List.map (fun (_, (row : Keeper_memory_policy.keeper_memory_line)) -> row.kind)
     |> List.sort_uniq String.compare
   in
+  let draft_skill_candidates =
+    match Skill_candidate_store.list_drafts ~base_path:config.base_path ~limit with
+    | Ok listing ->
+      `Assoc
+        [ "total", `Int listing.total
+        ; "shown", `Int listing.shown
+        ; "limit", `Int listing.limit
+        ; "index_path", `String listing.index_path
+        ; ( "items"
+          , `List (List.map Skill_candidate_store.draft_summary_to_json listing.items) )
+        ; "error", `Null
+        ]
+    | Error msg ->
+      `Assoc
+        [ "total", `Int 0
+        ; "shown", `Int 0
+        ; "limit", `Int limit
+        ; "index_path", `String (Skill_candidate_store.index_path ~base_path:config.base_path)
+        ; "items", `List []
+        ; "error", `String msg
+        ]
+  in
   `Assoc
     [ "generated_at", `String (Masc_domain.now_iso ())
     ; "hebbian", hebbian
@@ -371,6 +393,7 @@ let dashboard_memory_subsystems_http_json
                      `Assoc [ "keeper", `String keeper; "error", `String error ])
                    user_model_errors) )
           ] )
+    ; "draft_skill_candidates", draft_skill_candidates
     ; ( "filters"
       , `Assoc
           [ "keepers", `List (List.map (fun k -> `String k) known_keepers)

--- a/lib/skill_candidate_projection.ml
+++ b/lib/skill_candidate_projection.ml
@@ -28,8 +28,17 @@ let is_slug_char = function
 let slugify raw =
   let raw = raw |> String.trim |> String.lowercase_ascii in
   let buf = Buffer.create (String.length raw) in
+  let last_dash = ref false in
   String.iter
-    (fun ch -> Buffer.add_char buf (if is_slug_char ch then ch else '-'))
+    (fun ch ->
+      if is_slug_char ch
+      then (
+        Buffer.add_char buf ch;
+        last_dash := false)
+      else if not !last_dash
+      then (
+        Buffer.add_char buf '-';
+        last_dash := true))
     raw;
   let s = Buffer.contents buf in
   let len = String.length s in

--- a/lib/skill_candidate_projection.ml
+++ b/lib/skill_candidate_projection.ml
@@ -217,7 +217,7 @@ let candidates_of_memory_facts ~agent_name facts =
 ;;
 
 let top_candidates ~base_path ~agent_name ~limit =
-  Procedural_memory.top_procedures ~base_path ~agent_name ~limit
+  Procedural_memory.top_procedures ~base_path ~agent_name ~limit ()
   |> candidates_of_procedures
 ;;
 

--- a/lib/skill_candidate_projection.ml
+++ b/lib/skill_candidate_projection.ml
@@ -216,8 +216,9 @@ let candidates_of_memory_facts ~agent_name facts =
   |> List.sort (fun a b -> Float.compare b.confidence a.confidence)
 ;;
 
-let top_candidates ~agent_name ~limit =
-  Procedural_memory.top_procedures ~agent_name ~limit |> candidates_of_procedures
+let top_candidates ~base_path ~agent_name ~limit =
+  Procedural_memory.top_procedures ~base_path ~agent_name ~limit
+  |> candidates_of_procedures
 ;;
 
 let string_list_json xs = `List (List.map (fun s -> `String s) xs)

--- a/lib/skill_candidate_projection.mli
+++ b/lib/skill_candidate_projection.mli
@@ -56,9 +56,9 @@ val candidates_of_memory_facts
   -> Keeper_memory_os_types.fact list
   -> skill_candidate list
 
-(** Load the top crystallized procedures for [agent_name] and project them to
-    candidates. *)
-val top_candidates : agent_name:string -> limit:int -> skill_candidate list
+(** Load the top crystallized procedures for [agent_name] under [base_path] and
+    project them to candidates. *)
+val top_candidates : base_path:string -> agent_name:string -> limit:int -> skill_candidate list
 
 val to_json : skill_candidate -> Yojson.Safe.t
 

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -252,7 +252,8 @@ let write_candidate_if_changed ~base_path candidate =
   (* Artifact files and the index are intentionally checked together: a prior
      write can leave complete artifacts but miss the final index append. The
      next post-turn pass should repair that listing row instead of treating the
-     draft as fully persisted. *)
+     draft as fully persisted. This is a safety net until #21871 makes the
+     index/artifact persistence atomic or derives one side from the other. *)
   let artifacts_unchanged =
     candidate_artifacts ~base_path candidate
     |> List.for_all (fun (path, expected) ->

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -9,11 +9,34 @@ type stored_draft =
   ; index_path : string
   }
 
+type draft_summary =
+  { id : string
+  ; agent_name : string
+  ; source_kind : string
+  ; source_ref : string
+  ; promotion_state : string
+  ; dir : string
+  ; json_path : string
+  ; toml_path : string
+  ; skill_md_path : string
+  ; created_at : float option
+  }
+
+type draft_listing =
+  { total : int
+  ; shown : int
+  ; limit : int
+  ; index_path : string
+  ; items : draft_summary list
+  }
+
 let drafts_dir ~base_path =
   Filename.concat
     (Common.masc_dir_from_base_path ~base_path)
     "draft-skills"
 ;;
+
+let index_path ~base_path = Filename.concat (drafts_dir ~base_path) "index.jsonl"
 
 let component_hash raw =
   Digestif.SHA256.(digest_string raw |> to_hex) |> fun hex -> String.sub hex 0 16
@@ -137,7 +160,7 @@ let write_candidate ~base_path (candidate : Skill_candidate_projection.skill_can
   let json_path = Filename.concat dir "candidate.json" in
   let toml_path = Filename.concat dir "candidate.toml" in
   let skill_md_path = Filename.concat dir "SKILL.md" in
-  let index_path = Filename.concat (drafts_dir ~base_path) "index.jsonl" in
+  let index_path = index_path ~base_path in
   let* () =
     write_file json_path
       (Yojson.Safe.pretty_to_string (Skill_candidate_projection.to_json candidate)
@@ -160,4 +183,115 @@ let write_candidates ~base_path candidates =
       loop (stored :: acc) rest
   in
   loop [] candidates
+;;
+
+let json_string_opt name json =
+  match Yojson.Safe.Util.member name json with
+  | `String s -> Some s
+  | _ -> None
+;;
+
+let json_float_opt name json =
+  match Yojson.Safe.Util.member name json with
+  | `Float f -> Some f
+  | `Int i -> Some (float_of_int i)
+  | _ -> None
+;;
+
+let draft_summary_of_index_event json =
+  match
+    ( json_string_opt "id" json
+    , json_string_opt "agent_name" json
+    , json_string_opt "source_kind" json
+    , json_string_opt "source_ref" json
+    , json_string_opt "promotion_state" json
+    , json_string_opt "dir" json
+    , json_string_opt "json_path" json
+    , json_string_opt "toml_path" json
+    , json_string_opt "skill_md_path" json )
+  with
+  | ( Some id
+    , Some agent_name
+    , Some source_kind
+    , Some source_ref
+    , Some promotion_state
+    , Some dir
+    , Some json_path
+    , Some toml_path
+    , Some skill_md_path ) ->
+    Some
+      { id
+      ; agent_name
+      ; source_kind
+      ; source_ref
+      ; promotion_state
+      ; dir
+      ; json_path
+      ; toml_path
+      ; skill_md_path
+      ; created_at = json_float_opt "ts" json
+      }
+  | _ -> None
+;;
+
+let take n xs =
+  let rec loop acc remaining = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | x :: rest -> loop (x :: acc) (remaining - 1) rest
+  in
+  loop [] n xs
+;;
+
+let latest_unique summaries =
+  let seen = Hashtbl.create 16 in
+  List.filter
+    (fun (summary : draft_summary) ->
+      if Hashtbl.mem seen summary.id
+      then false
+      else (
+        Hashtbl.add seen summary.id ();
+        true))
+    summaries
+;;
+
+let list_drafts ~base_path ~limit =
+  let index_path = index_path ~base_path in
+  let limit = max 0 limit in
+  try
+    let items =
+      if Sys.file_exists index_path
+      then
+        Fs_compat.load_jsonl index_path
+        |> List.rev
+        |> List.filter_map draft_summary_of_index_event
+        |> latest_unique
+      else []
+    in
+    let total = List.length items in
+    let items = take limit items in
+    Ok { total; shown = List.length items; limit; index_path; items }
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+;;
+
+let json_option_float = function
+  | Some f -> `Float f
+  | None -> `Null
+;;
+
+let draft_summary_to_json (summary : draft_summary) =
+  `Assoc
+    [ "id", `String summary.id
+    ; "agent_name", `String summary.agent_name
+    ; "source_kind", `String summary.source_kind
+    ; "source_ref", `String summary.source_ref
+    ; "promotion_state", `String summary.promotion_state
+    ; "dir", `String summary.dir
+    ; "json_path", `String summary.json_path
+    ; "toml_path", `String summary.toml_path
+    ; "skill_md_path", `String summary.skill_md_path
+    ; "created_at", json_option_float summary.created_at
+    ]
 ;;

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -15,25 +15,25 @@ let drafts_dir ~base_path =
     "draft-skills"
 ;;
 
+let component_hash raw =
+  Digestif.SHA256.(digest_string raw |> to_hex) |> fun hex -> String.sub hex 0 16
+;;
+
+let component_prefix raw =
+  let safe =
+    Workspace_utils_backend_setup.sanitize_namespace_segment raw
+    |> String.lowercase_ascii
+  in
+  let safe =
+    match safe with
+    | "default" when String.equal (String.trim raw) "" -> "untitled"
+    | other -> other
+  in
+  if String.length safe > 48 then String.sub safe 0 48 else safe
+;;
+
 let safe_component raw =
-  let raw = raw |> String.trim |> String.lowercase_ascii in
-  let buf = Buffer.create (String.length raw) in
-  String.iter
-    (function
-      | 'a' .. 'z' | '0' .. '9' | '-' | '_' as c -> Buffer.add_char buf c
-      | _ -> Buffer.add_char buf '-')
-    raw;
-  let s = Buffer.contents buf in
-  let len = String.length s in
-  let rec left i =
-    if i >= len then len else if Char.equal s.[i] '-' then left (i + 1) else i
-  in
-  let rec right i =
-    if i < 0 then -1 else if Char.equal s.[i] '-' then right (i - 1) else i
-  in
-  let l = left 0 in
-  let r = right (len - 1) in
-  if l > r then "untitled" else String.sub s l (r - l + 1)
+  component_prefix raw ^ "-" ^ component_hash raw
 ;;
 
 let draft_dir ~base_path (candidate : Skill_candidate_projection.skill_candidate) =

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -55,12 +55,21 @@ let component_prefix raw =
   if String.length safe > 48 then String.sub safe 0 48 else safe
 ;;
 
-let safe_component raw =
-  component_prefix raw ^ "-" ^ component_hash raw
+let candidate_identity_key (candidate : Skill_candidate_projection.skill_candidate) =
+  String.concat "\n"
+    [ candidate.source_kind; candidate.agent_name; candidate.source_ref ]
+;;
+
+let summary_identity_key (summary : draft_summary) =
+  String.concat "\n" [ summary.source_kind; summary.agent_name; summary.source_ref ]
+;;
+
+let candidate_component (candidate : Skill_candidate_projection.skill_candidate) =
+  component_prefix candidate.id ^ "-" ^ component_hash (candidate_identity_key candidate)
 ;;
 
 let draft_dir ~base_path (candidate : Skill_candidate_projection.skill_candidate) =
-  Filename.concat (drafts_dir ~base_path) (safe_component candidate.id)
+  Filename.concat (drafts_dir ~base_path) (candidate_component candidate)
 ;;
 
 let candidate_json_path ~base_path candidate =
@@ -259,10 +268,11 @@ let dedup_candidates candidates =
   let seen = Hashtbl.create 16 in
   List.filter
     (fun (candidate : Skill_candidate_projection.skill_candidate) ->
-       if Hashtbl.mem seen candidate.id
+       let key = candidate_identity_key candidate in
+       if Hashtbl.mem seen key
        then false
        else (
-         Hashtbl.add seen candidate.id ();
+         Hashtbl.add seen key ();
          true))
     candidates
 ;;
@@ -356,10 +366,11 @@ let latest_unique summaries =
   let seen = Hashtbl.create 16 in
   List.filter
     (fun (summary : draft_summary) ->
-      if Hashtbl.mem seen summary.id
+      let key = summary_identity_key summary in
+      if Hashtbl.mem seen key
       then false
       else (
-        Hashtbl.add seen summary.id ();
+        Hashtbl.add seen key ();
         true))
     summaries
 ;;

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -63,6 +63,18 @@ let draft_dir ~base_path (candidate : Skill_candidate_projection.skill_candidate
   Filename.concat (drafts_dir ~base_path) (safe_component candidate.id)
 ;;
 
+let candidate_json_path ~base_path candidate =
+  Filename.concat (draft_dir ~base_path candidate) "candidate.json"
+;;
+
+let candidate_toml_path ~base_path candidate =
+  Filename.concat (draft_dir ~base_path candidate) "candidate.toml"
+;;
+
+let candidate_skill_md_path ~base_path candidate =
+  Filename.concat (draft_dir ~base_path candidate) "SKILL.md"
+;;
+
 let string_escape_toml s =
   let buf = Buffer.create (String.length s + 8) in
   String.iter
@@ -155,17 +167,17 @@ let append_index index_path event =
 
 let ( let* ) = Result.bind
 
+let candidate_json_content candidate =
+  Yojson.Safe.pretty_to_string (Skill_candidate_projection.to_json candidate) ^ "\n"
+;;
+
 let write_candidate ~base_path (candidate : Skill_candidate_projection.skill_candidate) =
   let dir = draft_dir ~base_path candidate in
-  let json_path = Filename.concat dir "candidate.json" in
-  let toml_path = Filename.concat dir "candidate.toml" in
-  let skill_md_path = Filename.concat dir "SKILL.md" in
+  let json_path = candidate_json_path ~base_path candidate in
+  let toml_path = candidate_toml_path ~base_path candidate in
+  let skill_md_path = candidate_skill_md_path ~base_path candidate in
   let index_path = index_path ~base_path in
-  let* () =
-    write_file json_path
-      (Yojson.Safe.pretty_to_string (Skill_candidate_projection.to_json candidate)
-       ^ "\n")
-  in
+  let* () = write_file json_path (candidate_json_content candidate) in
   let* () = write_file toml_path (render_candidate_toml candidate) in
   let* () = write_file skill_md_path (Skill_candidate_projection.render_skill_draft candidate) in
   let* () =
@@ -181,6 +193,68 @@ let write_candidates ~base_path candidates =
     | candidate :: rest ->
       let* stored = write_candidate ~base_path candidate in
       loop (stored :: acc) rest
+  in
+  loop [] candidates
+;;
+
+let read_file_opt path =
+  if not (Sys.file_exists path)
+  then None
+  else (
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let len = in_channel_length ic in
+         Some (really_input_string ic len)))
+;;
+
+let write_candidate_if_changed ~base_path candidate =
+  let json_path = candidate_json_path ~base_path candidate in
+  match read_file_opt json_path with
+  | Some content when String.equal content (candidate_json_content candidate) -> Ok None
+  | Some _ | None ->
+    let* stored = write_candidate ~base_path candidate in
+    Ok (Some stored)
+;;
+
+let dedup_candidates candidates =
+  let seen = Hashtbl.create 16 in
+  List.filter
+    (fun (candidate : Skill_candidate_projection.skill_candidate) ->
+       if Hashtbl.mem seen candidate.id
+       then false
+       else (
+         Hashtbl.add seen candidate.id ();
+         true))
+    candidates
+;;
+
+let write_post_turn_candidates ~base_path ~keeper_id ~fact_tail_limit ~procedure_limit =
+  let facts =
+    if fact_tail_limit <= 0
+    then []
+    else Keeper_memory_os_io.read_facts_tail ~keeper_id ~n:fact_tail_limit
+  in
+  let fact_candidates =
+    Skill_candidate_projection.candidates_of_memory_facts ~agent_name:keeper_id facts
+  in
+  let procedure_candidates =
+    if procedure_limit <= 0
+    then []
+    else Skill_candidate_projection.top_candidates ~agent_name:keeper_id ~limit:procedure_limit
+  in
+  let candidates = dedup_candidates (fact_candidates @ procedure_candidates) in
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | candidate :: rest ->
+      let* stored = write_candidate_if_changed ~base_path candidate in
+      let acc =
+        match stored with
+        | Some stored -> stored :: acc
+        | None -> acc
+      in
+      loop acc rest
   in
   loop [] candidates
 ;;

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -271,7 +271,9 @@ let write_post_turn_candidates ~base_path ~keeper_id ~fact_tail_limit ~procedure
   let facts =
     if fact_tail_limit <= 0
     then []
-    else Keeper_memory_os_io.read_facts_tail ~keeper_id ~n:fact_tail_limit
+    else
+      Keeper_memory_os_io.read_facts_tail_for_base_path ~base_path ~keeper_id
+        ~n:fact_tail_limit
   in
   let fact_candidates =
     Skill_candidate_projection.candidates_of_memory_facts ~agent_name:keeper_id facts
@@ -279,7 +281,9 @@ let write_post_turn_candidates ~base_path ~keeper_id ~fact_tail_limit ~procedure
   let procedure_candidates =
     if procedure_limit <= 0
     then []
-    else Skill_candidate_projection.top_candidates ~agent_name:keeper_id ~limit:procedure_limit
+    else
+      Skill_candidate_projection.top_candidates ~base_path ~agent_name:keeper_id
+        ~limit:procedure_limit
   in
   let candidates = dedup_candidates (fact_candidates @ procedure_candidates) in
   let rec loop acc = function

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -236,7 +236,7 @@ let index_event_matches_candidate ~base_path
 
 let index_contains_candidate ~base_path candidate =
   let index_path = index_path ~base_path in
-  if not (Sys.file_exists index_path)
+  if not (Fs_compat.file_exists index_path)
   then Ok false
   else
     try
@@ -249,6 +249,10 @@ let index_contains_candidate ~base_path candidate =
 ;;
 
 let write_candidate_if_changed ~base_path candidate =
+  (* Artifact files and the index are intentionally checked together: a prior
+     write can leave complete artifacts but miss the final index append. The
+     next post-turn pass should repair that listing row instead of treating the
+     draft as fully persisted. *)
   let artifacts_unchanged =
     candidate_artifacts ~base_path candidate
     |> List.for_all (fun (path, expected) ->
@@ -380,7 +384,7 @@ let list_drafts ~base_path ~limit =
   let limit = max 0 limit in
   try
     let items =
-      if Sys.file_exists index_path
+      if Fs_compat.file_exists index_path
       then
         Fs_compat.load_jsonl index_path
         |> List.rev

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -75,60 +75,32 @@ let candidate_skill_md_path ~base_path candidate =
   Filename.concat (draft_dir ~base_path candidate) "SKILL.md"
 ;;
 
-let string_escape_toml s =
-  let buf = Buffer.create (String.length s + 8) in
-  String.iter
-    (function
-      | '\\' -> Buffer.add_string buf "\\\\"
-      | '"' -> Buffer.add_string buf "\\\""
-      | '\n' -> Buffer.add_string buf "\\n"
-      | '\r' -> Buffer.add_string buf "\\r"
-      | '\t' -> Buffer.add_string buf "\\t"
-      | c -> Buffer.add_char buf c)
-    s;
-  Buffer.contents buf
-;;
-
-let toml_string s = Printf.sprintf "\"%s\"" (string_escape_toml s)
-
-let toml_string_list name values =
-  Printf.sprintf "%s = [%s]\n" name
-    (values |> List.map toml_string |> String.concat ", ")
+let toml_string_array values =
+  Otoml.TomlArray (List.map (fun s -> Otoml.TomlString s) values)
 ;;
 
 let render_candidate_toml (c : Skill_candidate_projection.skill_candidate) =
-  String.concat ""
-    [ "schema = \"masc.skill_candidate.draft.v1\"\n"
-    ; "promotion_state = "
-    ; toml_string (Skill_candidate_projection.promotion_state_to_string c.promotion_state)
-    ; "\n"
-    ; "installable = false\n"
-    ; "requires_human_approval = true\n"
-    ; "id = "
-    ; toml_string c.id
-    ; "\n"
-    ; "agent_name = "
-    ; toml_string c.agent_name
-    ; "\n"
-    ; "source_kind = "
-    ; toml_string c.source_kind
-    ; "\n"
-    ; "source_id = "
-    ; toml_string c.source_id
-    ; "\n"
-    ; "source_ref = "
-    ; toml_string c.source_ref
-    ; "\n"
-    ; "pattern = "
-    ; toml_string c.pattern
-    ; "\n"
-    ; Printf.sprintf "success_count = %d\n" c.success_count
-    ; Printf.sprintf "failure_count = %d\n" c.failure_count
-    ; Printf.sprintf "confidence = %.6f\n" c.confidence
-    ; toml_string_list "evidence_refs" c.evidence_refs
-    ; toml_string_list "applicable_tools" c.applicable_tools
-    ; toml_string_list "risk_notes" c.risk_notes
+  Otoml.TomlTable
+    [ "schema", Otoml.string "masc.skill_candidate.draft.v1"
+    ; ( "promotion_state"
+      , Otoml.string
+          (Skill_candidate_projection.promotion_state_to_string c.promotion_state) )
+    ; "installable", Otoml.boolean false
+    ; "requires_human_approval", Otoml.boolean true
+    ; "id", Otoml.string c.id
+    ; "agent_name", Otoml.string c.agent_name
+    ; "source_kind", Otoml.string c.source_kind
+    ; "source_id", Otoml.string c.source_id
+    ; "source_ref", Otoml.string c.source_ref
+    ; "pattern", Otoml.string c.pattern
+    ; "success_count", Otoml.integer c.success_count
+    ; "failure_count", Otoml.integer c.failure_count
+    ; "confidence", Otoml.TomlFloat c.confidence
+    ; "evidence_refs", toml_string_array c.evidence_refs
+    ; "applicable_tools", toml_string_array c.applicable_tools
+    ; "risk_notes", toml_string_array c.risk_notes
     ]
+  |> Otoml.Printer.to_string
 ;;
 
 let write_file path content =
@@ -171,6 +143,14 @@ let candidate_json_content candidate =
   Yojson.Safe.pretty_to_string (Skill_candidate_projection.to_json candidate) ^ "\n"
 ;;
 
+let candidate_artifacts ~base_path candidate =
+  [ candidate_json_path ~base_path candidate, candidate_json_content candidate
+  ; candidate_toml_path ~base_path candidate, render_candidate_toml candidate
+  ; ( candidate_skill_md_path ~base_path candidate
+    , Skill_candidate_projection.render_skill_draft candidate )
+  ]
+;;
+
 let write_candidate ~base_path (candidate : Skill_candidate_projection.skill_candidate) =
   let dir = draft_dir ~base_path candidate in
   let json_path = candidate_json_path ~base_path candidate in
@@ -200,12 +180,18 @@ let write_candidates ~base_path candidates =
 let read_file_opt = Fs_compat.load_file_opt
 
 let write_candidate_if_changed ~base_path candidate =
-  let json_path = candidate_json_path ~base_path candidate in
-  match read_file_opt json_path with
-  | Some content when String.equal content (candidate_json_content candidate) -> Ok None
-  | Some _ | None ->
+  let unchanged =
+    candidate_artifacts ~base_path candidate
+    |> List.for_all (fun (path, expected) ->
+      match read_file_opt path with
+      | Some content -> String.equal content expected
+      | None -> false)
+  in
+  if unchanged
+  then Ok None
+  else (
     let* stored = write_candidate ~base_path candidate in
-    Ok (Some stored)
+    Ok (Some stored))
 ;;
 
 let dedup_candidates candidates =

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -143,6 +143,12 @@ let candidate_json_content candidate =
   Yojson.Safe.pretty_to_string (Skill_candidate_projection.to_json candidate) ^ "\n"
 ;;
 
+let json_string_opt name json =
+  match Yojson.Safe.Util.member name json with
+  | `String s -> Some s
+  | _ -> None
+;;
+
 let candidate_artifacts ~base_path candidate =
   [ candidate_json_path ~base_path candidate, candidate_json_content candidate
   ; candidate_toml_path ~base_path candidate, render_candidate_toml candidate
@@ -179,15 +185,70 @@ let write_candidates ~base_path candidates =
 
 let read_file_opt = Fs_compat.load_file_opt
 
+let index_event_matches_candidate ~base_path
+    (candidate : Skill_candidate_projection.skill_candidate) json =
+  let dir = draft_dir ~base_path candidate in
+  let json_path = candidate_json_path ~base_path candidate in
+  let toml_path = candidate_toml_path ~base_path candidate in
+  let skill_md_path = candidate_skill_md_path ~base_path candidate in
+  match
+    ( json_string_opt "id" json
+    , json_string_opt "agent_name" json
+    , json_string_opt "source_kind" json
+    , json_string_opt "source_ref" json
+    , json_string_opt "promotion_state" json
+    , json_string_opt "dir" json
+    , json_string_opt "json_path" json
+    , json_string_opt "toml_path" json
+    , json_string_opt "skill_md_path" json )
+  with
+  | ( Some id
+    , Some agent_name
+    , Some source_kind
+    , Some source_ref
+    , Some promotion_state
+    , Some indexed_dir
+    , Some indexed_json_path
+    , Some indexed_toml_path
+    , Some indexed_skill_md_path ) ->
+    String.equal id candidate.id
+    && String.equal agent_name candidate.agent_name
+    && String.equal source_kind candidate.source_kind
+    && String.equal source_ref candidate.source_ref
+    && String.equal promotion_state
+         (Skill_candidate_projection.promotion_state_to_string
+            candidate.promotion_state)
+    && String.equal indexed_dir dir
+    && String.equal indexed_json_path json_path
+    && String.equal indexed_toml_path toml_path
+    && String.equal indexed_skill_md_path skill_md_path
+  | _ -> false
+;;
+
+let index_contains_candidate ~base_path candidate =
+  let index_path = index_path ~base_path in
+  if not (Sys.file_exists index_path)
+  then Ok false
+  else
+    try
+      Ok
+        (Fs_compat.load_jsonl index_path
+         |> List.exists (index_event_matches_candidate ~base_path candidate))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+;;
+
 let write_candidate_if_changed ~base_path candidate =
-  let unchanged =
+  let artifacts_unchanged =
     candidate_artifacts ~base_path candidate
     |> List.for_all (fun (path, expected) ->
       match read_file_opt path with
       | Some content -> String.equal content expected
       | None -> false)
   in
-  if unchanged
+  let* indexed = index_contains_candidate ~base_path candidate in
+  if artifacts_unchanged && indexed
   then Ok None
   else (
     let* stored = write_candidate ~base_path candidate in
@@ -233,12 +294,6 @@ let write_post_turn_candidates ~base_path ~keeper_id ~fact_tail_limit ~procedure
       loop acc rest
   in
   loop [] candidates
-;;
-
-let json_string_opt name json =
-  match Yojson.Safe.Util.member name json with
-  | `String s -> Some s
-  | _ -> None
 ;;
 
 let json_float_opt name json =

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -197,17 +197,7 @@ let write_candidates ~base_path candidates =
   loop [] candidates
 ;;
 
-let read_file_opt path =
-  if not (Sys.file_exists path)
-  then None
-  else (
-    let ic = open_in_bin path in
-    Fun.protect
-      ~finally:(fun () -> close_in_noerr ic)
-      (fun () ->
-         let len = in_channel_length ic in
-         Some (really_input_string ic len)))
-;;
+let read_file_opt = Fs_compat.load_file_opt
 
 let write_candidate_if_changed ~base_path candidate =
   let json_path = candidate_json_path ~base_path candidate in

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -1,0 +1,163 @@
+(** Durable draft-skill candidate store. *)
+
+type stored_draft =
+  { candidate : Skill_candidate_projection.skill_candidate
+  ; dir : string
+  ; json_path : string
+  ; toml_path : string
+  ; skill_md_path : string
+  ; index_path : string
+  }
+
+let drafts_dir ~base_path =
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path)
+    "draft-skills"
+;;
+
+let safe_component raw =
+  let raw = raw |> String.trim |> String.lowercase_ascii in
+  let buf = Buffer.create (String.length raw) in
+  String.iter
+    (function
+      | 'a' .. 'z' | '0' .. '9' | '-' | '_' as c -> Buffer.add_char buf c
+      | _ -> Buffer.add_char buf '-')
+    raw;
+  let s = Buffer.contents buf in
+  let len = String.length s in
+  let rec left i =
+    if i >= len then len else if Char.equal s.[i] '-' then left (i + 1) else i
+  in
+  let rec right i =
+    if i < 0 then -1 else if Char.equal s.[i] '-' then right (i - 1) else i
+  in
+  let l = left 0 in
+  let r = right (len - 1) in
+  if l > r then "untitled" else String.sub s l (r - l + 1)
+;;
+
+let draft_dir ~base_path (candidate : Skill_candidate_projection.skill_candidate) =
+  Filename.concat (drafts_dir ~base_path) (safe_component candidate.id)
+;;
+
+let string_escape_toml s =
+  let buf = Buffer.create (String.length s + 8) in
+  String.iter
+    (function
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '"' -> Buffer.add_string buf "\\\""
+      | '\n' -> Buffer.add_string buf "\\n"
+      | '\r' -> Buffer.add_string buf "\\r"
+      | '\t' -> Buffer.add_string buf "\\t"
+      | c -> Buffer.add_char buf c)
+    s;
+  Buffer.contents buf
+;;
+
+let toml_string s = Printf.sprintf "\"%s\"" (string_escape_toml s)
+
+let toml_string_list name values =
+  Printf.sprintf "%s = [%s]\n" name
+    (values |> List.map toml_string |> String.concat ", ")
+;;
+
+let render_candidate_toml (c : Skill_candidate_projection.skill_candidate) =
+  String.concat ""
+    [ "schema = \"masc.skill_candidate.draft.v1\"\n"
+    ; "promotion_state = "
+    ; toml_string (Skill_candidate_projection.promotion_state_to_string c.promotion_state)
+    ; "\n"
+    ; "installable = false\n"
+    ; "requires_human_approval = true\n"
+    ; "id = "
+    ; toml_string c.id
+    ; "\n"
+    ; "agent_name = "
+    ; toml_string c.agent_name
+    ; "\n"
+    ; "source_kind = "
+    ; toml_string c.source_kind
+    ; "\n"
+    ; "source_id = "
+    ; toml_string c.source_id
+    ; "\n"
+    ; "source_ref = "
+    ; toml_string c.source_ref
+    ; "\n"
+    ; "pattern = "
+    ; toml_string c.pattern
+    ; "\n"
+    ; Printf.sprintf "success_count = %d\n" c.success_count
+    ; Printf.sprintf "failure_count = %d\n" c.failure_count
+    ; Printf.sprintf "confidence = %.6f\n" c.confidence
+    ; toml_string_list "evidence_refs" c.evidence_refs
+    ; toml_string_list "applicable_tools" c.applicable_tools
+    ; toml_string_list "risk_notes" c.risk_notes
+    ]
+;;
+
+let write_file path content =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> Ok ()
+  | Error msg -> Error (Printf.sprintf "%s: %s" path msg)
+;;
+
+let index_event_json (c : Skill_candidate_projection.skill_candidate) ~dir ~json_path
+      ~toml_path ~skill_md_path =
+  `Assoc
+    [ "schema", `String "masc.skill_candidate.index.v1"
+    ; "id", `String c.id
+    ; "agent_name", `String c.agent_name
+    ; "source_kind", `String c.source_kind
+    ; "source_ref", `String c.source_ref
+    ; "promotion_state"
+      , `String (Skill_candidate_projection.promotion_state_to_string c.promotion_state)
+    ; "dir", `String dir
+    ; "json_path", `String json_path
+    ; "toml_path", `String toml_path
+    ; "skill_md_path", `String skill_md_path
+    ; "ts", `Float (Time_compat.now ())
+    ]
+;;
+
+let append_index index_path event =
+  try
+    Keeper_types_support.append_jsonl_line index_path event;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+;;
+
+let ( let* ) = Result.bind
+
+let write_candidate ~base_path (candidate : Skill_candidate_projection.skill_candidate) =
+  let dir = draft_dir ~base_path candidate in
+  let json_path = Filename.concat dir "candidate.json" in
+  let toml_path = Filename.concat dir "candidate.toml" in
+  let skill_md_path = Filename.concat dir "SKILL.md" in
+  let index_path = Filename.concat (drafts_dir ~base_path) "index.jsonl" in
+  let* () =
+    write_file json_path
+      (Yojson.Safe.pretty_to_string (Skill_candidate_projection.to_json candidate)
+       ^ "\n")
+  in
+  let* () = write_file toml_path (render_candidate_toml candidate) in
+  let* () = write_file skill_md_path (Skill_candidate_projection.render_skill_draft candidate) in
+  let* () =
+    append_index index_path
+      (index_event_json candidate ~dir ~json_path ~toml_path ~skill_md_path)
+  in
+  Ok { candidate; dir; json_path; toml_path; skill_md_path; index_path }
+;;
+
+let write_candidates ~base_path candidates =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | candidate :: rest ->
+      let* stored = write_candidate ~base_path candidate in
+      loop (stored :: acc) rest
+  in
+  loop [] candidates
+;;

--- a/lib/skill_candidate_store.mli
+++ b/lib/skill_candidate_store.mli
@@ -35,7 +35,12 @@ type draft_listing =
   }
 
 val drafts_dir : base_path:string -> string
+
+(** Durable artifact directory for one candidate. The directory key includes
+    source identity, not just display [id], so different keepers/sources with the
+    same candidate id do not overwrite each other. *)
 val draft_dir : base_path:string -> Skill_candidate_projection.skill_candidate -> string
+
 val index_path : base_path:string -> string
 
 (** Render a compact metadata TOML for operator review. This is intentionally

--- a/lib/skill_candidate_store.mli
+++ b/lib/skill_candidate_store.mli
@@ -1,0 +1,33 @@
+(** Durable draft-skill candidate store.
+
+    This is the write-side companion to {!Skill_candidate_projection}. It
+    persists reviewable draft artifacts under [.masc/draft-skills/] but never
+    installs a skill or changes Keeper runtime capability. *)
+
+type stored_draft =
+  { candidate : Skill_candidate_projection.skill_candidate
+  ; dir : string
+  ; json_path : string
+  ; toml_path : string
+  ; skill_md_path : string
+  ; index_path : string
+  }
+
+val drafts_dir : base_path:string -> string
+val draft_dir : base_path:string -> Skill_candidate_projection.skill_candidate -> string
+
+(** Render a compact metadata TOML for operator review. This is intentionally
+    candidate-only and includes no executable install marker. *)
+val render_candidate_toml : Skill_candidate_projection.skill_candidate -> string
+
+(** Persist [candidate.json], [candidate.toml], [SKILL.md], and append a compact
+    [index.jsonl] event. All paths are under [.masc/draft-skills/]. *)
+val write_candidate
+  :  base_path:string
+  -> Skill_candidate_projection.skill_candidate
+  -> (stored_draft, string) result
+
+val write_candidates
+  :  base_path:string
+  -> Skill_candidate_projection.skill_candidate list
+  -> (stored_draft list, string) result

--- a/lib/skill_candidate_store.mli
+++ b/lib/skill_candidate_store.mli
@@ -54,6 +54,19 @@ val write_candidates
   -> Skill_candidate_projection.skill_candidate list
   -> (stored_draft list, string) result
 
+(** Close the post-turn Memory OS -> draft skill loop for one keeper.
+
+    Reads recent Memory OS facts for [keeper_id] and crystallized procedural
+    memories, projects only reviewable candidates, and writes changed drafts
+    under [.masc/draft-skills/]. This remains advisory: it never installs a
+    skill or changes Keeper runtime capability. *)
+val write_post_turn_candidates
+  :  base_path:string
+  -> keeper_id:string
+  -> fact_tail_limit:int
+  -> procedure_limit:int
+  -> (stored_draft list, string) result
+
 (** Read the latest unique candidate rows from [.masc/draft-skills/index.jsonl],
     newest first. Missing index files return an empty listing. *)
 val list_drafts : base_path:string -> limit:int -> (draft_listing, string) result

--- a/lib/skill_candidate_store.mli
+++ b/lib/skill_candidate_store.mli
@@ -13,8 +13,30 @@ type stored_draft =
   ; index_path : string
   }
 
+type draft_summary =
+  { id : string
+  ; agent_name : string
+  ; source_kind : string
+  ; source_ref : string
+  ; promotion_state : string
+  ; dir : string
+  ; json_path : string
+  ; toml_path : string
+  ; skill_md_path : string
+  ; created_at : float option
+  }
+
+type draft_listing =
+  { total : int
+  ; shown : int
+  ; limit : int
+  ; index_path : string
+  ; items : draft_summary list
+  }
+
 val drafts_dir : base_path:string -> string
 val draft_dir : base_path:string -> Skill_candidate_projection.skill_candidate -> string
+val index_path : base_path:string -> string
 
 (** Render a compact metadata TOML for operator review. This is intentionally
     candidate-only and includes no executable install marker. *)
@@ -31,3 +53,9 @@ val write_candidates
   :  base_path:string
   -> Skill_candidate_projection.skill_candidate list
   -> (stored_draft list, string) result
+
+(** Read the latest unique candidate rows from [.masc/draft-skills/index.jsonl],
+    newest first. Missing index files return an empty listing. *)
+val list_drafts : base_path:string -> limit:int -> (draft_listing, string) result
+
+val draft_summary_to_json : draft_summary -> Yojson.Safe.t

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -9,10 +9,11 @@ module Memory_io = Masc.Keeper_memory_os_io
 module Config_dirs = Masc.Config_dir_resolver
 
 let procedure ?(evidence = []) ?(success_count = 0) ?(failure_count = 0)
-    ?(confidence = 0.0) ?(id = "proc-test") ?(pattern = "When a pattern appears, reuse the learned action") () : P.procedure =
+    ?(confidence = 0.0) ?(id = "proc-test") ?(agent_name = "keeper")
+    ?(pattern = "When a pattern appears, reuse the learned action") () : P.procedure =
   {
     id;
-    agent_name = "keeper";
+    agent_name;
     pattern;
     evidence;
     success_count;
@@ -331,6 +332,46 @@ let test_skill_candidate_store_lists_newest_unique_draft_per_id () =
   check string "keeps same candidate id" c1.id summary.id
 ;;
 
+let test_skill_candidate_store_keeps_same_id_distinct_sources () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let candidate_for agent_name =
+    require_candidate
+      (procedure ~id:"Shared Procedure" ~agent_name
+         ~evidence:[ "proof-store://abc"; "proof-store://def"; "proof-store://ghi" ]
+         ~success_count:3 ~failure_count:0 ~confidence:1.0 ())
+  in
+  let alpha = candidate_for "alpha" in
+  let beta = candidate_for "beta" in
+  check string "display ids intentionally collide" alpha.id beta.id;
+  let write c =
+    match Store.write_candidate ~base_path c with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  let alpha_stored = write alpha in
+  let beta_stored = write beta in
+  check bool "source identity has distinct draft dirs" true
+    (not (String.equal alpha_stored.dir beta_stored.dir));
+  check bool "source identity has distinct json paths" true
+    (not (String.equal alpha_stored.json_path beta_stored.json_path));
+  check bool "alpha json remains readable" true (Sys.file_exists alpha_stored.json_path);
+  check bool "beta json remains readable" true (Sys.file_exists beta_stored.json_path);
+  let listing =
+    match Store.list_drafts ~base_path ~limit:10 with
+    | Ok listing -> listing
+    | Error msg -> fail msg
+  in
+  check int "distinct source total" 2 listing.total;
+  check int "distinct source shown" 2 listing.shown;
+  let agents =
+    listing.items
+    |> List.map (fun (item : Store.draft_summary) -> item.agent_name)
+    |> List.sort String.compare
+  in
+  check (list string) "both source agents listed" [ "alpha"; "beta" ] agents
+;;
+
 let test_skill_candidate_store_writes_post_turn_memory_fact_candidates () =
   with_temp_base_path
   @@ fun base_path ->
@@ -572,6 +613,8 @@ let () =
             test_skill_candidate_store_lists_latest_reviewable_drafts;
           test_case "lists newest unique draft per id" `Quick
             test_skill_candidate_store_lists_newest_unique_draft_per_id;
+          test_case "keeps same id candidates with distinct sources" `Quick
+            test_skill_candidate_store_keeps_same_id_distinct_sources;
           test_case "writes post-turn memory fact candidates" `Quick
             test_skill_candidate_store_writes_post_turn_memory_fact_candidates;
           test_case "recovers partial candidate artifacts" `Quick

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -149,8 +149,9 @@ let test_skill_candidate_rejects_generic_memory_fact () =
 
 let test_skill_candidate_json_and_draft_are_candidate_only () =
   let p =
-    procedure ~evidence:[ "proof-store://abc" ] ~success_count:3 ~failure_count:1
-      ~confidence:0.75 ()
+    procedure
+      ~evidence:[ "proof-store://abc"; "proof-store://def"; "proof-store://ghi" ]
+      ~success_count:3 ~failure_count:1 ~confidence:0.75 ()
   in
   let c = require_candidate p in
   let json = S.to_json c in
@@ -188,7 +189,8 @@ let test_skill_candidate_store_writes_reviewable_draft_files () =
   with_temp_base_path
   @@ fun base_path ->
   let p =
-    procedure ~id:"Repeatable Debug Loop" ~evidence:[ "proof-store://abc" ]
+    procedure ~id:"Repeatable Debug Loop"
+      ~evidence:[ "proof-store://abc"; "proof-store://def"; "proof-store://ghi" ]
       ~success_count:3 ~failure_count:0 ~confidence:1.0 ()
   in
   let c = require_candidate p in
@@ -219,13 +221,84 @@ let test_skill_candidate_store_writes_reviewable_draft_files () =
   check bool "index references candidate" true (contains_substring ~needle:c.id index)
 ;;
 
+let test_skill_candidate_store_lists_latest_reviewable_drafts () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let p =
+    procedure ~id:"Listable Candidate"
+      ~evidence:[ "proof-store://abc"; "proof-store://def"; "proof-store://ghi" ]
+      ~success_count:3 ~failure_count:0 ~confidence:1.0 ()
+  in
+  let c = require_candidate p in
+  let _stored =
+    match Store.write_candidate ~base_path c with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  let listing =
+    match Store.list_drafts ~base_path ~limit:10 with
+    | Ok listing -> listing
+    | Error msg -> fail msg
+  in
+  check int "total" 1 listing.total;
+  check int "shown" 1 listing.shown;
+  check string "index path"
+    (Store.index_path ~base_path)
+    listing.index_path;
+  let summary =
+    match listing.items with
+    | [ item ] -> item
+    | _ -> fail "expected one draft summary"
+  in
+  check string "id" c.id summary.id;
+  check string "agent" c.agent_name summary.agent_name;
+  check string "state" "candidate" summary.promotion_state;
+  check string "source ref" c.source_ref summary.source_ref;
+  check bool "created_at present" true (Option.is_some summary.created_at)
+;;
+
+let test_skill_candidate_store_lists_newest_unique_draft_per_id () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let c1 =
+    require_candidate
+      (procedure ~id:"Duplicate Candidate"
+         ~evidence:[ "proof-store://abc"; "proof-store://def"; "proof-store://ghi" ]
+         ~success_count:3 ~failure_count:0 ~confidence:1.0 ())
+  in
+  let c2 : S.skill_candidate =
+    { c1 with pattern = "When a duplicate candidate is re-written, show latest" }
+  in
+  let write c =
+    match Store.write_candidate ~base_path c with
+    | Ok _ -> ()
+    | Error msg -> fail msg
+  in
+  write c1;
+  write c2;
+  let listing =
+    match Store.list_drafts ~base_path ~limit:10 with
+    | Ok listing -> listing
+    | Error msg -> fail msg
+  in
+  check int "deduplicated total" 1 listing.total;
+  check int "shown" 1 listing.shown;
+  let summary =
+    match listing.items with
+    | [ item ] -> item
+    | _ -> fail "expected one draft summary"
+  in
+  check string "keeps same candidate id" c1.id summary.id
+;;
+
 let test_skill_candidate_store_sanitizes_candidate_id_path () =
   with_temp_base_path
   @@ fun base_path ->
   let base =
     require_candidate
-      (procedure ~id:"Normal" ~evidence:[ "proof-store://abc" ] ~success_count:3
-         ~failure_count:0 ~confidence:1.0 ())
+      (procedure ~id:"Normal"
+         ~evidence:[ "proof-store://abc"; "proof-store://def"; "proof-store://ghi" ]
+         ~success_count:3 ~failure_count:0 ~confidence:1.0 ())
   in
   let c : S.skill_candidate = { base with id = "../Escape Candidate" } in
   let stored =
@@ -277,6 +350,10 @@ let () =
             test_skill_candidate_json_and_draft_are_candidate_only;
           test_case "writes durable reviewable draft files" `Quick
             test_skill_candidate_store_writes_reviewable_draft_files;
+          test_case "lists latest reviewable draft files" `Quick
+            test_skill_candidate_store_lists_latest_reviewable_drafts;
+          test_case "lists newest unique draft per id" `Quick
+            test_skill_candidate_store_lists_newest_unique_draft_per_id;
           test_case "sanitizes candidate id path" `Quick
             test_skill_candidate_store_sanitizes_candidate_id_path;
         ] );

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -6,7 +6,6 @@ module S = Masc.Skill_candidate_projection
 module Store = Masc.Skill_candidate_store
 module M = Masc.Keeper_memory_os_types
 module Memory_io = Masc.Keeper_memory_os_io
-module Config_dirs = Masc.Config_dir_resolver
 
 let procedure ?(evidence = []) ?(success_count = 0) ?(failure_count = 0)
     ?(confidence = 0.0) ?(id = "proc-test") ?(agent_name = "keeper")
@@ -193,8 +192,7 @@ let with_env name value f =
 ;;
 
 let write_facts_for_base_path ~base_path ~keeper_id facts =
-  let keepers_dir = Config_dirs.keepers_dir_for_base_path ~base_path in
-  Memory_io.rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts
+  Memory_io.rewrite_facts_atomically_for_base_path ~base_path ~keeper_id facts
 ;;
 
 let with_temp_base_path f =

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -6,6 +6,7 @@ module S = Masc.Skill_candidate_projection
 module Store = Masc.Skill_candidate_store
 module M = Masc.Keeper_memory_os_types
 module Memory_io = Masc.Keeper_memory_os_io
+module Config_dirs = Masc.Config_dir_resolver
 
 let procedure ?(evidence = []) ?(success_count = 0) ?(failure_count = 0)
     ?(confidence = 0.0) ?(id = "proc-test") ?(pattern = "When a pattern appears, reuse the learned action") () : P.procedure =
@@ -179,6 +180,22 @@ let write_file_or_fail path content =
   | Error msg -> fail msg
 ;;
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some value -> Unix.putenv name value
+      | None -> Unix.putenv name "")
+    f
+;;
+
+let write_facts_for_base_path ~base_path ~keeper_id facts =
+  let keepers_dir = Config_dirs.keepers_dir_for_base_path ~base_path in
+  Memory_io.rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id facts
+;;
+
 let with_temp_base_path f =
   let marker = Filename.temp_file "skill-candidate-store-" ".tmp" in
   Sys.remove marker;
@@ -317,122 +334,177 @@ let test_skill_candidate_store_lists_newest_unique_draft_per_id () =
 let test_skill_candidate_store_writes_post_turn_memory_fact_candidates () =
   with_temp_base_path
   @@ fun base_path ->
-  let keepers_dir = Filename.concat base_path "keepers" in
-  Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
-    let fact =
-      memory_fact ~category:M.Lesson ~trace_id:"trace-skill" ~turn:11
-        ~tool_call_id:"tool-skill"
-        "When a recurring review succeeds, preserve the review checklist"
-    in
-    Memory_io.append_fact ~keeper_id:"keeper" fact;
-    let stored =
-      match
-        Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
-          ~fact_tail_limit:16 ~procedure_limit:0
-      with
-      | Ok stored -> stored
-      | Error msg -> fail msg
-    in
-    check int "one draft written" 1 (List.length stored);
-    let summary =
-      match stored with
-      | [ item ] -> item
-      | _ -> fail "expected one stored candidate"
-    in
-    check string "source kind" "memory_os_fact" summary.candidate.source_kind;
-    check bool "candidate json exists" true (Sys.file_exists summary.json_path);
-    let second =
-      match
-        Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
-          ~fact_tail_limit:16 ~procedure_limit:0
-      with
-      | Ok stored -> stored
-      | Error msg -> fail msg
-    in
-    check int "unchanged candidate skipped" 0 (List.length second))
+  let fact =
+    memory_fact ~category:M.Lesson ~trace_id:"trace-skill" ~turn:11
+      ~tool_call_id:"tool-skill"
+      "When a recurring review succeeds, preserve the review checklist"
+  in
+  write_facts_for_base_path ~base_path ~keeper_id:"keeper" [ fact ];
+  let stored =
+    match
+      Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
+        ~fact_tail_limit:16 ~procedure_limit:0
+    with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  check int "one draft written" 1 (List.length stored);
+  let summary =
+    match stored with
+    | [ item ] -> item
+    | _ -> fail "expected one stored candidate"
+  in
+  check string "source kind" "memory_os_fact" summary.candidate.source_kind;
+  check bool "candidate json exists" true (Sys.file_exists summary.json_path);
+  let second =
+    match
+      Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
+        ~fact_tail_limit:16 ~procedure_limit:0
+    with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  check int "unchanged candidate skipped" 0 (List.length second)
 ;;
 
 let test_skill_candidate_store_recovers_partial_candidate_artifacts () =
   with_temp_base_path
   @@ fun base_path ->
-  let keepers_dir = Filename.concat base_path "keepers" in
-  Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
-    let fact =
-      memory_fact ~category:M.Lesson ~trace_id:"trace-partial-skill" ~turn:12
-        ~tool_call_id:"tool-partial-skill"
-        "When a draft candidate write is partial, rewrite the missing artifacts"
-    in
-    let c =
-      match S.candidates_of_memory_facts ~agent_name:"keeper" [ fact ] with
-      | [ candidate ] -> candidate
-      | _ -> fail "expected one projected candidate"
-    in
-    let dir = Store.draft_dir ~base_path c in
-    let json_path = Filename.concat dir "candidate.json" in
-    let toml_path = Filename.concat dir "candidate.toml" in
-    let skill_md_path = Filename.concat dir "SKILL.md" in
-    Fs_compat.mkdir_p dir;
-    write_file_or_fail json_path (Yojson.Safe.pretty_to_string (S.to_json c) ^ "\n");
-    check bool "partial json preexists" true (Sys.file_exists json_path);
-    check bool "partial toml absent" false (Sys.file_exists toml_path);
-    Memory_io.append_fact ~keeper_id:"keeper" fact;
-    let stored =
-      match
-        Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
-          ~fact_tail_limit:16 ~procedure_limit:0
-      with
-      | Ok stored -> stored
-      | Error msg -> fail msg
-    in
-    check int "partial candidate rewritten" 1 (List.length stored);
-    check bool "toml recovered" true (Sys.file_exists toml_path);
-    check bool "skill draft recovered" true (Sys.file_exists skill_md_path))
+  let fact =
+    memory_fact ~category:M.Lesson ~trace_id:"trace-partial-skill" ~turn:12
+      ~tool_call_id:"tool-partial-skill"
+      "When a draft candidate write is partial, rewrite the missing artifacts"
+  in
+  let c =
+    match S.candidates_of_memory_facts ~agent_name:"keeper" [ fact ] with
+    | [ candidate ] -> candidate
+    | _ -> fail "expected one projected candidate"
+  in
+  let dir = Store.draft_dir ~base_path c in
+  let json_path = Filename.concat dir "candidate.json" in
+  let toml_path = Filename.concat dir "candidate.toml" in
+  let skill_md_path = Filename.concat dir "SKILL.md" in
+  Fs_compat.mkdir_p dir;
+  write_file_or_fail json_path (Yojson.Safe.pretty_to_string (S.to_json c) ^ "\n");
+  check bool "partial json preexists" true (Sys.file_exists json_path);
+  check bool "partial toml absent" false (Sys.file_exists toml_path);
+  write_facts_for_base_path ~base_path ~keeper_id:"keeper" [ fact ];
+  let stored =
+    match
+      Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
+        ~fact_tail_limit:16 ~procedure_limit:0
+    with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  check int "partial candidate rewritten" 1 (List.length stored);
+  check bool "toml recovered" true (Sys.file_exists toml_path);
+  check bool "skill draft recovered" true (Sys.file_exists skill_md_path)
 ;;
 
 let test_skill_candidate_store_recovers_missing_index_for_complete_artifacts () =
   with_temp_base_path
   @@ fun base_path ->
-  let keepers_dir = Filename.concat base_path "keepers" in
-  Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
-    let fact =
-      memory_fact ~category:M.Lesson ~trace_id:"trace-index-skill" ~turn:13
-        ~tool_call_id:"tool-index-skill"
-        "When draft candidate artifacts already exist, missing index rows are repaired"
-    in
-    let c =
-      match S.candidates_of_memory_facts ~agent_name:"keeper" [ fact ] with
-      | [ candidate ] -> candidate
-      | _ -> fail "expected one projected candidate"
-    in
-    let dir = Store.draft_dir ~base_path c in
-    let json_path = Filename.concat dir "candidate.json" in
-    let toml_path = Filename.concat dir "candidate.toml" in
-    let skill_md_path = Filename.concat dir "SKILL.md" in
-    Fs_compat.mkdir_p dir;
-    write_file_or_fail json_path (Yojson.Safe.pretty_to_string (S.to_json c) ^ "\n");
-    write_file_or_fail toml_path (Store.render_candidate_toml c);
-    write_file_or_fail skill_md_path (S.render_skill_draft c);
-    check bool "index absent before recovery" false
-      (Sys.file_exists (Store.index_path ~base_path));
-    Memory_io.append_fact ~keeper_id:"keeper" fact;
-    let stored =
-      match
-        Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
-          ~fact_tail_limit:16 ~procedure_limit:0
-      with
-      | Ok stored -> stored
-      | Error msg -> fail msg
-    in
-    check int "complete artifacts re-indexed" 1 (List.length stored);
-    let listing =
-      match Store.list_drafts ~base_path ~limit:10 with
-      | Ok listing -> listing
-      | Error msg -> fail msg
-    in
-    check int "missing index repaired" 1 listing.total;
-    match listing.items with
-    | [ item ] -> check string "indexed candidate id" c.id item.id
-    | _ -> fail "expected one indexed draft")
+  let fact =
+    memory_fact ~category:M.Lesson ~trace_id:"trace-index-skill" ~turn:13
+      ~tool_call_id:"tool-index-skill"
+      "When draft candidate artifacts already exist, missing index rows are repaired"
+  in
+  let c =
+    match S.candidates_of_memory_facts ~agent_name:"keeper" [ fact ] with
+    | [ candidate ] -> candidate
+    | _ -> fail "expected one projected candidate"
+  in
+  let dir = Store.draft_dir ~base_path c in
+  let json_path = Filename.concat dir "candidate.json" in
+  let toml_path = Filename.concat dir "candidate.toml" in
+  let skill_md_path = Filename.concat dir "SKILL.md" in
+  Fs_compat.mkdir_p dir;
+  write_file_or_fail json_path (Yojson.Safe.pretty_to_string (S.to_json c) ^ "\n");
+  write_file_or_fail toml_path (Store.render_candidate_toml c);
+  write_file_or_fail skill_md_path (S.render_skill_draft c);
+  check bool "index absent before recovery" false
+    (Sys.file_exists (Store.index_path ~base_path));
+  write_facts_for_base_path ~base_path ~keeper_id:"keeper" [ fact ];
+  let stored =
+    match
+      Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
+        ~fact_tail_limit:16 ~procedure_limit:0
+    with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  check int "complete artifacts re-indexed" 1 (List.length stored);
+  let listing =
+    match Store.list_drafts ~base_path ~limit:10 with
+    | Ok listing -> listing
+    | Error msg -> fail msg
+  in
+  check int "missing index repaired" 1 listing.total;
+  match listing.items with
+  | [ item ] -> check string "indexed candidate id" c.id item.id
+  | _ -> fail "expected one indexed draft"
+;;
+
+let test_skill_candidate_store_scopes_post_turn_reads_to_base_path () =
+  with_temp_base_path
+  @@ fun global_base ->
+  with_temp_base_path
+  @@ fun target_base ->
+  with_env "MASC_BASE_PATH" global_base
+  @@ fun () ->
+  with_env "MASC_BASE_PATH_INPUT" global_base
+  @@ fun () ->
+  let global_fact =
+    memory_fact ~category:M.Lesson ~trace_id:"trace-global-skill" ~turn:21
+      ~tool_call_id:"tool-global-skill"
+      "When a global workspace lesson exists, it must not seed target drafts"
+  in
+  write_facts_for_base_path ~base_path:global_base ~keeper_id:"keeper" [ global_fact ];
+  let global_procedure =
+    procedure ~id:"Global Workspace Procedure"
+      ~pattern:"When global workspace procedure exists, keep it out of target drafts"
+      ~evidence:[ "global-a"; "global-b"; "global-c" ] ~success_count:3
+      ~failure_count:0 ~confidence:1.0 ()
+  in
+  P.save_procedure ~base_path:global_base ~agent_name:"keeper" global_procedure;
+  let leaked =
+    match
+      Store.write_post_turn_candidates ~base_path:target_base ~keeper_id:"keeper"
+        ~fact_tail_limit:16 ~procedure_limit:5
+    with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  check int "global post-turn candidates ignored" 0 (List.length leaked);
+  let empty_listing =
+    match Store.list_drafts ~base_path:target_base ~limit:10 with
+    | Ok listing -> listing
+    | Error msg -> fail msg
+  in
+  check int "target draft store stays empty" 0 empty_listing.total;
+  let target_procedure =
+    procedure ~id:"Target Workspace Procedure"
+      ~pattern:"When target workspace procedure exists, write a target draft"
+      ~evidence:[ "target-a"; "target-b"; "target-c" ] ~success_count:3
+      ~failure_count:0 ~confidence:1.0 ()
+  in
+  P.save_procedure ~base_path:target_base ~agent_name:"keeper" target_procedure;
+  let target_stored =
+    match
+      Store.write_post_turn_candidates ~base_path:target_base ~keeper_id:"keeper"
+        ~fact_tail_limit:16 ~procedure_limit:5
+    with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  let target_summary =
+    match target_stored with
+    | [ item ] -> item
+    | _ -> fail "expected one target-scoped procedure candidate"
+  in
+  check string "target source kind" "procedure" target_summary.candidate.source_kind;
+  check string "target source id" target_procedure.id target_summary.candidate.source_id
 ;;
 
 let test_skill_candidate_store_sanitizes_candidate_id_path () =
@@ -506,6 +578,8 @@ let () =
             test_skill_candidate_store_recovers_partial_candidate_artifacts;
           test_case "recovers missing index for complete artifacts" `Quick
             test_skill_candidate_store_recovers_missing_index_for_complete_artifacts;
+          test_case "scopes post-turn reads to base path" `Quick
+            test_skill_candidate_store_scopes_post_turn_reads_to_base_path;
           test_case "sanitizes candidate id path" `Quick
             test_skill_candidate_store_sanitizes_candidate_id_path;
         ] );

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -198,10 +198,9 @@ let test_skill_candidate_store_writes_reviewable_draft_files () =
     | Error msg -> fail msg
   in
   check string "draft dir"
-    (Filename.concat
-       (Filename.concat (Filename.concat base_path ".masc") "draft-skills")
-       c.id)
+    (Store.draft_dir ~base_path c)
     stored.dir;
+  check string "draft dir parent" (Store.drafts_dir ~base_path) (Filename.dirname stored.dir);
   check bool "candidate json exists" true (Sys.file_exists stored.json_path);
   check bool "candidate toml exists" true (Sys.file_exists stored.toml_path);
   check bool "skill md exists" true (Sys.file_exists stored.skill_md_path);
@@ -229,17 +228,21 @@ let test_skill_candidate_store_sanitizes_candidate_id_path () =
          ~failure_count:0 ~confidence:1.0 ())
   in
   let c : S.skill_candidate = { base with id = "../Escape Candidate" } in
-  in
   let stored =
     match Store.write_candidate ~base_path c with
     | Ok stored -> stored
     | Error msg -> fail msg
   in
   check string "sanitized draft dir"
-    (Filename.concat
-       (Filename.concat (Filename.concat base_path ".masc") "draft-skills")
-       "escape-candidate")
+    (Store.draft_dir ~base_path c)
     stored.dir;
+  check string "sanitized draft parent"
+    (Store.drafts_dir ~base_path)
+    (Filename.dirname stored.dir);
+  check bool "sanitized draft keeps readable prefix" true
+    (contains_substring ~needle:"escape-candidate" (Filename.basename stored.dir));
+  check bool "sanitized draft removes traversal marker" false
+    (contains_substring ~needle:".." (Filename.basename stored.dir));
   check bool "escaped parent not written" false
     (Sys.file_exists
        (Filename.concat (Filename.concat base_path ".masc") "Escape Candidate"))

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -3,6 +3,7 @@
 open Alcotest
 module P = Masc.Procedural_memory
 module S = Masc.Skill_candidate_projection
+module Store = Masc.Skill_candidate_store
 module M = Masc.Keeper_memory_os_types
 
 let procedure ?(evidence = []) ?(success_count = 0) ?(failure_count = 0)
@@ -168,6 +169,82 @@ let test_skill_candidate_json_and_draft_are_candidate_only () =
     (contains_substring ~needle:"requires human approval" draft)
 ;;
 
+let read_file path =
+  let ic = open_in path in
+  let len = in_channel_length ic in
+  let content = really_input_string ic len in
+  close_in ic;
+  content
+;;
+
+let with_temp_base_path f =
+  let marker = Filename.temp_file "skill-candidate-store-" ".tmp" in
+  Sys.remove marker;
+  Unix.mkdir marker 0o755;
+  f marker
+;;
+
+let test_skill_candidate_store_writes_reviewable_draft_files () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let p =
+    procedure ~id:"Repeatable Debug Loop" ~evidence:[ "proof-store://abc" ]
+      ~success_count:3 ~failure_count:0 ~confidence:1.0 ()
+  in
+  let c = require_candidate p in
+  let stored =
+    match Store.write_candidate ~base_path c with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  check string "draft dir"
+    (Filename.concat
+       (Filename.concat (Filename.concat base_path ".masc") "draft-skills")
+       c.id)
+    stored.dir;
+  check bool "candidate json exists" true (Sys.file_exists stored.json_path);
+  check bool "candidate toml exists" true (Sys.file_exists stored.toml_path);
+  check bool "skill md exists" true (Sys.file_exists stored.skill_md_path);
+  check bool "index exists" true (Sys.file_exists stored.index_path);
+  let toml = read_file stored.toml_path in
+  check bool "toml is candidate only" true
+    (contains_substring ~needle:"promotion_state = \"candidate\"" toml);
+  check bool "toml is not installable" true
+    (contains_substring ~needle:"installable = false" toml);
+  check bool "approval remains required" true
+    (contains_substring ~needle:"requires_human_approval = true" toml);
+  let skill_md = read_file stored.skill_md_path in
+  check bool "skill draft status is explicit" true
+    (contains_substring ~needle:"Status: candidate" skill_md);
+  let index = read_file stored.index_path in
+  check bool "index references candidate" true (contains_substring ~needle:c.id index)
+;;
+
+let test_skill_candidate_store_sanitizes_candidate_id_path () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let base =
+    require_candidate
+      (procedure ~id:"Normal" ~evidence:[ "proof-store://abc" ] ~success_count:3
+         ~failure_count:0 ~confidence:1.0 ())
+  in
+  let c : S.skill_candidate = { base with id = "../Escape Candidate" } in
+  in
+  let stored =
+    match Store.write_candidate ~base_path c with
+    | Ok stored -> stored
+    | Error msg -> fail msg
+  in
+  check string "sanitized draft dir"
+    (Filename.concat
+       (Filename.concat (Filename.concat base_path ".masc") "draft-skills")
+       "escape-candidate")
+    stored.dir;
+  check bool "escaped parent not written" false
+    (Sys.file_exists
+       (Filename.concat (Filename.concat base_path ".masc") "Escape Candidate"))
+;;
+
 let () =
   run "procedural_memory"
     [
@@ -195,6 +272,10 @@ let () =
             test_skill_candidate_rejects_generic_memory_fact;
           test_case "renders candidate-only JSON and draft" `Quick
             test_skill_candidate_json_and_draft_are_candidate_only;
+          test_case "writes durable reviewable draft files" `Quick
+            test_skill_candidate_store_writes_reviewable_draft_files;
+          test_case "sanitizes candidate id path" `Quick
+            test_skill_candidate_store_sanitizes_candidate_id_path;
         ] );
     ]
 ;;

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -222,6 +222,28 @@ let test_skill_candidate_store_writes_reviewable_draft_files () =
   check bool "index references candidate" true (contains_substring ~needle:c.id index)
 ;;
 
+let test_skill_candidate_store_toml_handles_control_text () =
+  let control_text = "before" ^ String.make 1 (Char.chr 12) ^ "after" in
+  let p =
+    procedure ~id:"Control TOML Candidate" ~pattern:control_text
+      ~evidence:[ "proof-store://abc"; "proof-store://def"; "proof-store://ghi" ]
+      ~success_count:3 ~failure_count:0 ~confidence:1.0 ()
+  in
+  let c = require_candidate p in
+  let toml = Store.render_candidate_toml c in
+  let parsed =
+    match Otoml.Parser.from_string_result toml with
+    | Ok parsed -> parsed
+    | Error msg -> fail msg
+  in
+  let parsed_pattern =
+    match Otoml.find_result parsed Otoml.get_string [ "pattern" ] with
+    | Ok pattern -> pattern
+    | Error msg -> fail msg
+  in
+  check string "control text pattern round trips" c.pattern parsed_pattern
+;;
+
 let test_skill_candidate_store_lists_latest_reviewable_drafts () =
   with_temp_base_path
   @@ fun base_path ->
@@ -330,6 +352,47 @@ let test_skill_candidate_store_writes_post_turn_memory_fact_candidates () =
     check int "unchanged candidate skipped" 0 (List.length second))
 ;;
 
+let test_skill_candidate_store_recovers_partial_candidate_artifacts () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let keepers_dir = Filename.concat base_path "keepers" in
+  Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
+    let fact =
+      memory_fact ~category:M.Lesson ~trace_id:"trace-partial-skill" ~turn:12
+        ~tool_call_id:"tool-partial-skill"
+        "When a draft candidate write is partial, rewrite the missing artifacts"
+    in
+    let c =
+      match S.candidates_of_memory_facts ~agent_name:"keeper" [ fact ] with
+      | [ candidate ] -> candidate
+      | _ -> fail "expected one projected candidate"
+    in
+    let dir = Store.draft_dir ~base_path c in
+    let json_path = Filename.concat dir "candidate.json" in
+    let toml_path = Filename.concat dir "candidate.toml" in
+    let skill_md_path = Filename.concat dir "SKILL.md" in
+    Fs_compat.mkdir_p dir;
+    (match
+       Fs_compat.save_file_atomic json_path (Yojson.Safe.pretty_to_string (S.to_json c) ^ "\n")
+     with
+     | Ok () -> ()
+     | Error msg -> fail msg);
+    check bool "partial json preexists" true (Sys.file_exists json_path);
+    check bool "partial toml absent" false (Sys.file_exists toml_path);
+    Memory_io.append_fact ~keeper_id:"keeper" fact;
+    let stored =
+      match
+        Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
+          ~fact_tail_limit:16 ~procedure_limit:0
+      with
+      | Ok stored -> stored
+      | Error msg -> fail msg
+    in
+    check int "partial candidate rewritten" 1 (List.length stored);
+    check bool "toml recovered" true (Sys.file_exists toml_path);
+    check bool "skill draft recovered" true (Sys.file_exists skill_md_path))
+;;
+
 let test_skill_candidate_store_sanitizes_candidate_id_path () =
   with_temp_base_path
   @@ fun base_path ->
@@ -389,12 +452,16 @@ let () =
             test_skill_candidate_json_and_draft_are_candidate_only;
           test_case "writes durable reviewable draft files" `Quick
             test_skill_candidate_store_writes_reviewable_draft_files;
+          test_case "renders parseable TOML for control text" `Quick
+            test_skill_candidate_store_toml_handles_control_text;
           test_case "lists latest reviewable draft files" `Quick
             test_skill_candidate_store_lists_latest_reviewable_drafts;
           test_case "lists newest unique draft per id" `Quick
             test_skill_candidate_store_lists_newest_unique_draft_per_id;
           test_case "writes post-turn memory fact candidates" `Quick
             test_skill_candidate_store_writes_post_turn_memory_fact_candidates;
+          test_case "recovers partial candidate artifacts" `Quick
+            test_skill_candidate_store_recovers_partial_candidate_artifacts;
           test_case "sanitizes candidate id path" `Quick
             test_skill_candidate_store_sanitizes_candidate_id_path;
         ] );

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -5,6 +5,7 @@ module P = Masc.Procedural_memory
 module S = Masc.Skill_candidate_projection
 module Store = Masc.Skill_candidate_store
 module M = Masc.Keeper_memory_os_types
+module Memory_io = Masc.Keeper_memory_os_io
 
 let procedure ?(evidence = []) ?(success_count = 0) ?(failure_count = 0)
     ?(confidence = 0.0) ?(id = "proc-test") ?(pattern = "When a pattern appears, reuse the learned action") () : P.procedure =
@@ -291,6 +292,44 @@ let test_skill_candidate_store_lists_newest_unique_draft_per_id () =
   check string "keeps same candidate id" c1.id summary.id
 ;;
 
+let test_skill_candidate_store_writes_post_turn_memory_fact_candidates () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let keepers_dir = Filename.concat base_path "keepers" in
+  Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
+    let fact =
+      memory_fact ~category:M.Lesson ~trace_id:"trace-skill" ~turn:11
+        ~tool_call_id:"tool-skill"
+        "When a recurring review succeeds, preserve the review checklist"
+    in
+    Memory_io.append_fact ~keeper_id:"keeper" fact;
+    let stored =
+      match
+        Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
+          ~fact_tail_limit:16 ~procedure_limit:0
+      with
+      | Ok stored -> stored
+      | Error msg -> fail msg
+    in
+    check int "one draft written" 1 (List.length stored);
+    let summary =
+      match stored with
+      | [ item ] -> item
+      | _ -> fail "expected one stored candidate"
+    in
+    check string "source kind" "memory_os_fact" summary.candidate.source_kind;
+    check bool "candidate json exists" true (Sys.file_exists summary.json_path);
+    let second =
+      match
+        Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
+          ~fact_tail_limit:16 ~procedure_limit:0
+      with
+      | Ok stored -> stored
+      | Error msg -> fail msg
+    in
+    check int "unchanged candidate skipped" 0 (List.length second))
+;;
+
 let test_skill_candidate_store_sanitizes_candidate_id_path () =
   with_temp_base_path
   @@ fun base_path ->
@@ -354,6 +393,8 @@ let () =
             test_skill_candidate_store_lists_latest_reviewable_drafts;
           test_case "lists newest unique draft per id" `Quick
             test_skill_candidate_store_lists_newest_unique_draft_per_id;
+          test_case "writes post-turn memory fact candidates" `Quick
+            test_skill_candidate_store_writes_post_turn_memory_fact_candidates;
           test_case "sanitizes candidate id path" `Quick
             test_skill_candidate_store_sanitizes_candidate_id_path;
         ] );

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -171,12 +171,12 @@ let test_skill_candidate_json_and_draft_are_candidate_only () =
     (contains_substring ~needle:"requires human approval" draft)
 ;;
 
-let read_file path =
-  let ic = open_in path in
-  let len = in_channel_length ic in
-  let content = really_input_string ic len in
-  close_in ic;
-  content
+let read_file = Fs_compat.load_file
+
+let write_file_or_fail path content =
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg -> fail msg
 ;;
 
 let with_temp_base_path f =
@@ -372,11 +372,7 @@ let test_skill_candidate_store_recovers_partial_candidate_artifacts () =
     let toml_path = Filename.concat dir "candidate.toml" in
     let skill_md_path = Filename.concat dir "SKILL.md" in
     Fs_compat.mkdir_p dir;
-    (match
-       Fs_compat.save_file_atomic json_path (Yojson.Safe.pretty_to_string (S.to_json c) ^ "\n")
-     with
-     | Ok () -> ()
-     | Error msg -> fail msg);
+    write_file_or_fail json_path (Yojson.Safe.pretty_to_string (S.to_json c) ^ "\n");
     check bool "partial json preexists" true (Sys.file_exists json_path);
     check bool "partial toml absent" false (Sys.file_exists toml_path);
     Memory_io.append_fact ~keeper_id:"keeper" fact;
@@ -391,6 +387,52 @@ let test_skill_candidate_store_recovers_partial_candidate_artifacts () =
     check int "partial candidate rewritten" 1 (List.length stored);
     check bool "toml recovered" true (Sys.file_exists toml_path);
     check bool "skill draft recovered" true (Sys.file_exists skill_md_path))
+;;
+
+let test_skill_candidate_store_recovers_missing_index_for_complete_artifacts () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let keepers_dir = Filename.concat base_path "keepers" in
+  Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
+    let fact =
+      memory_fact ~category:M.Lesson ~trace_id:"trace-index-skill" ~turn:13
+        ~tool_call_id:"tool-index-skill"
+        "When draft candidate artifacts already exist, missing index rows are repaired"
+    in
+    let c =
+      match S.candidates_of_memory_facts ~agent_name:"keeper" [ fact ] with
+      | [ candidate ] -> candidate
+      | _ -> fail "expected one projected candidate"
+    in
+    let dir = Store.draft_dir ~base_path c in
+    let json_path = Filename.concat dir "candidate.json" in
+    let toml_path = Filename.concat dir "candidate.toml" in
+    let skill_md_path = Filename.concat dir "SKILL.md" in
+    Fs_compat.mkdir_p dir;
+    write_file_or_fail json_path (Yojson.Safe.pretty_to_string (S.to_json c) ^ "\n");
+    write_file_or_fail toml_path (Store.render_candidate_toml c);
+    write_file_or_fail skill_md_path (S.render_skill_draft c);
+    check bool "index absent before recovery" false
+      (Sys.file_exists (Store.index_path ~base_path));
+    Memory_io.append_fact ~keeper_id:"keeper" fact;
+    let stored =
+      match
+        Store.write_post_turn_candidates ~base_path ~keeper_id:"keeper"
+          ~fact_tail_limit:16 ~procedure_limit:0
+      with
+      | Ok stored -> stored
+      | Error msg -> fail msg
+    in
+    check int "complete artifacts re-indexed" 1 (List.length stored);
+    let listing =
+      match Store.list_drafts ~base_path ~limit:10 with
+      | Ok listing -> listing
+      | Error msg -> fail msg
+    in
+    check int "missing index repaired" 1 listing.total;
+    match listing.items with
+    | [ item ] -> check string "indexed candidate id" c.id item.id
+    | _ -> fail "expected one indexed draft")
 ;;
 
 let test_skill_candidate_store_sanitizes_candidate_id_path () =
@@ -462,6 +504,8 @@ let () =
             test_skill_candidate_store_writes_post_turn_memory_fact_candidates;
           test_case "recovers partial candidate artifacts" `Quick
             test_skill_candidate_store_recovers_partial_candidate_artifacts;
+          test_case "recovers missing index for complete artifacts" `Quick
+            test_skill_candidate_store_recovers_missing_index_for_complete_artifacts;
           test_case "sanitizes candidate id path" `Quick
             test_skill_candidate_store_sanitizes_candidate_id_path;
         ] );

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -3,6 +3,9 @@ open Alcotest
 module Json = Yojson.Safe.Util
 module Memory_subsystems = Server_dashboard_http_memory_subsystems
 module Memory_io = Masc.Keeper_memory_os_io
+module P = Masc.Procedural_memory
+module Projection = Masc.Skill_candidate_projection
+module Store = Masc.Skill_candidate_store
 module Types = Masc.Keeper_memory_os_types
 
 let request target =
@@ -181,6 +184,58 @@ let test_http_json_user_model_uses_config_base_path () =
         check (list string) "scoped claims" [ "Target workspace preference" ] claims))
 ;;
 
+let skill_candidate () =
+  let procedure : P.procedure =
+    { id = "dashboard-visible-skill"
+    ; agent_name = "keeper"
+    ; pattern = "When the same repair loop succeeds repeatedly, draft a skill"
+    ; evidence = [ "proof-store://abc"; "proof-store://def"; "proof-store://ghi" ]
+    ; success_count = 3
+    ; failure_count = 0
+    ; confidence = 1.0
+    ; created_at = 0.0
+    ; last_applied = 0.0
+    }
+  in
+  match Projection.candidate_of_procedure procedure with
+  | Some candidate -> candidate
+  | None -> fail "expected dashboard skill candidate"
+;;
+
+let test_http_json_surfaces_draft_skill_candidates () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config = Workspace_utils.default_config dir in
+      let candidate = skill_candidate () in
+      (match Store.write_candidate ~base_path:dir candidate with
+       | Ok _ -> ()
+       | Error msg -> fail msg);
+      let json =
+        Memory_subsystems.dashboard_memory_subsystems_http_json
+          ~config
+          ~include_memory_entries:false
+          (request "/dashboard/memory-subsystems?limit=100")
+      in
+      let drafts = Json.(json |> member "draft_skill_candidates") in
+      check int "draft total" 1 Json.(drafts |> member "total" |> to_int);
+      check int "draft shown" 1 Json.(drafts |> member "shown" |> to_int);
+      check string "draft index path"
+        (Store.index_path ~base_path:dir)
+        Json.(drafts |> member "index_path" |> to_string);
+      let item =
+        match Json.(drafts |> member "items" |> to_list) with
+        | [ item ] -> item
+        | _ -> fail "expected one draft skill candidate"
+      in
+      check string "candidate id" candidate.id Json.(item |> member "id" |> to_string);
+      check string "candidate state" "candidate"
+        Json.(item |> member "promotion_state" |> to_string);
+       check string "skill path suffix" "SKILL.md"
+         (Filename.basename Json.(item |> member "skill_md_path" |> to_string)))
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   Alcotest.run
@@ -208,6 +263,10 @@ let () =
             "user model projection reads config base path"
             `Quick
             test_http_json_user_model_uses_config_base_path
+        ; test_case
+            "surfaces draft skill candidates"
+            `Quick
+            test_http_json_surfaces_draft_skill_candidates
         ] )
     ]
 ;;


### PR DESCRIPTION
Summary:
- Persist reviewable draft skill candidates under .masc/draft-skills without installing or changing Keeper capabilities.
- Project crystallized procedural memory and eligible Memory OS facts (validated_approach/lesson) into candidate-only JSON/TOML/SKILL.md artifacts.
- Wire the post-turn memory lane so newly durable Memory OS skill facts close the Memory OS -> draft skill candidate loop.
- Surface latest draft candidates in the memory subsystem dashboard projection.

Validation:
- ocamlformat --check lib/skill_candidate_store.ml lib/skill_candidate_store.mli lib/keeper/keeper_agent_run_post_turn_memory.ml test/test_procedural_memory.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_procedural_memory.exe
- ./_build/default/test/test_procedural_memory.exe
- bash scripts/ci/check-determinism-contract.sh
- bash scripts/ci/check-masc-oas-boundary.sh