### PR TITLE
fix(#21782): Wire Health.is_healthy circuit breaker into live tick selection path

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -194,6 +194,11 @@ let run_keepalive_unified_turn
       in
       let scheduling =
         decide_keepalive_scheduling
+          ~runtime_resilience_of_name:(fun _runtime_id ->
+            (* Health circuit breakers are keyed by keeper/agent name. *)
+            if Health.is_healthy ~agent_name:meta_after_triage.name
+            then None
+            else Some "keeper_unhealthy")
           ~reactive_wake
           ~stop
           ~meta:meta_after_triage


### PR DESCRIPTION
## Summary

Wires the `Health.is_healthy` circuit breaker into the live tick selection path by passing `~runtime_resilience_of_name` to `decide_keepalive_scheduling`.

## Changes

- **lib/keeper/keeper_heartbeat_loop.ml**: Added `~runtime_resilience_of_name` wrapper that maps `Health.is_healthy` result to the `string option` type expected by the scheduling layer:
  - `is_healthy = true` → `None` (no backpressure)
  - `is_healthy = false` → `Some "unhealthy"` (circuit breaker open)

## How it works

When `Health.is_healthy` returns `false` for a runtime, the scheduling layer sees backpressure and can skip that runtime during tick selection. This prevents unhealthy runtimes from being selected for turns.

Closes #21782