### PR TITLE
fix(dashboard): render unterminated code fences as text not trapped code blocks

### DIFF
--- a/dashboard/src/components/chat/markdown-blocks.test.ts
+++ b/dashboard/src/components/chat/markdown-blocks.test.ts
@@ -243,6 +243,14 @@ describe('parseMarkdownToBlocks', () => {
     expect(p.html).toContain('then prose runs on')
   })
 
+  it('does not treat a mismatched closing fence as closed', () => {
+    const blocks = parseMarkdownToBlocks('~~~\nsome code\n```')
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({ t: 'p' })
+    const p = blocks[0] as Extract<ChatBlock, { t: 'p' }>
+    expect(p.html).toContain('some code')
+  })
+
   it('leaves a 4-space indented code block untouched', () => {
     const blocks = parseMarkdownToBlocks('    line1\n    line2')
     expect(blocks).toHaveLength(1)

--- a/dashboard/src/components/chat/markdown-blocks.test.ts
+++ b/dashboard/src/components/chat/markdown-blocks.test.ts
@@ -251,6 +251,14 @@ describe('parseMarkdownToBlocks', () => {
     expect(p.html).toContain('some code')
   })
 
+  it('does not treat the opposite mismatched closing fence as closed', () => {
+    const blocks = parseMarkdownToBlocks('```\nsome code\n~~~')
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({ t: 'p' })
+    const p = blocks[0] as Extract<ChatBlock, { t: 'p' }>
+    expect(p.html).toContain('some code')
+  })
+
   it('leaves a 4-space indented code block untouched', () => {
     const blocks = parseMarkdownToBlocks('    line1\n    line2')
     expect(blocks).toHaveLength(1)
@@ -258,6 +266,23 @@ describe('parseMarkdownToBlocks', () => {
     expect(code.t).toBe('code')
     expect(code.html).toContain('line1')
     expect(code.html).toContain('line2')
+  })
+
+  it('leaves 4-space indented code whose first literal line looks fenced untouched', () => {
+    const blocks = parseMarkdownToBlocks('    ```\n    literal fence inside indented code')
+    expect(blocks).toHaveLength(1)
+    const code = blocks[0] as Extract<ChatBlock, { t: 'code' }>
+    expect(code.t).toBe('code')
+    expect(code.html).toContain('```')
+    expect(code.html).toContain('literal fence inside indented code')
+  })
+
+  it('does not treat a 4-space indented closing-looking line as a closing fence', () => {
+    const blocks = parseMarkdownToBlocks('```\nsome code\n    ```')
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({ t: 'p' })
+    const p = blocks[0] as Extract<ChatBlock, { t: 'p' }>
+    expect(p.html).toContain('some code')
   })
 
   it('keeps a closed fence followed by prose as separate code + paragraph blocks', () => {

--- a/dashboard/src/components/chat/markdown-blocks.test.ts
+++ b/dashboard/src/components/chat/markdown-blocks.test.ts
@@ -193,4 +193,71 @@ describe('parseMarkdownToBlocks', () => {
     expect(blocks[0]).toMatchObject({ t: 'link', url: 'https://a.example.com/x' })
     expect(blocks[1]).toMatchObject({ t: 'link', url: 'https://b.example.com/y' })
   })
+
+  // Unterminated code fences: an LLM that opens ``` and never closes it makes
+  // marked absorb all following prose into one code token. We demote that to a
+  // text block so the prose is readable instead of trapped in a monospace box.
+  it('keeps a closed fence as a code block (regression guard)', () => {
+    const blocks = parseMarkdownToBlocks('```js\nconst x = 1\n```')
+    expect(blocks).toHaveLength(1)
+    const code = blocks[0] as Extract<ChatBlock, { t: 'code' }>
+    expect(code.t).toBe('code')
+    expect(code.cap).toBe('js')
+    expect(code.html).toContain('const x = 1')
+  })
+
+  it('renders an unterminated fence as text, preserving the absorbed prose', () => {
+    const blocks = parseMarkdownToBlocks(
+      '```json\n{"x":1}\nThis prose should not be trapped.\nMore prose.',
+    )
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({ t: 'p' })
+    const p = blocks[0] as Extract<ChatBlock, { t: 'p' }>
+    // The body is not a code block...
+    expect((blocks[0] as ChatBlock).t).not.toBe('code')
+    // ...and the trailing prose survives (not swallowed into a code box).
+    expect(p.html).toContain('This prose should not be trapped.')
+    expect(p.html).toContain('More prose.')
+    // The fenced JSON body is rendered literally (escapeHtml escapes &<> only).
+    expect(p.html).toContain('{"x":1}')
+    // Newlines are preserved as <br> for the multi-line body.
+    expect(p.html).toContain('<br>')
+  })
+
+  it('escapes angle brackets in an unterminated fence body (no raw HTML)', () => {
+    const blocks = parseMarkdownToBlocks('```\n<script>alert(1)</script>\nremaining prose')
+    expect(blocks).toHaveLength(1)
+    const p = blocks[0] as Extract<ChatBlock, { t: 'p' }>
+    expect(p.t).toBe('p')
+    expect(p.html).toContain('&lt;script&gt;')
+    expect(p.html).not.toContain('<script>')
+    expect(p.html).toContain('remaining prose')
+  })
+
+  it('renders an unterminated tilde fence as text', () => {
+    const blocks = parseMarkdownToBlocks('~~~\nsome code\nthen prose runs on')
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({ t: 'p' })
+    const p = blocks[0] as Extract<ChatBlock, { t: 'p' }>
+    expect(p.html).toContain('some code')
+    expect(p.html).toContain('then prose runs on')
+  })
+
+  it('leaves a 4-space indented code block untouched', () => {
+    const blocks = parseMarkdownToBlocks('    line1\n    line2')
+    expect(blocks).toHaveLength(1)
+    const code = blocks[0] as Extract<ChatBlock, { t: 'code' }>
+    expect(code.t).toBe('code')
+    expect(code.html).toContain('line1')
+    expect(code.html).toContain('line2')
+  })
+
+  it('keeps a closed fence followed by prose as separate code + paragraph blocks', () => {
+    const blocks = parseMarkdownToBlocks('```js\nc\n```\n\nAnd here is prose.')
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0]).toMatchObject({ t: 'code' })
+    expect((blocks[0] as Extract<ChatBlock, { t: 'code' }>).html).toContain('c')
+    expect(blocks[1]).toMatchObject({ t: 'p' })
+    expect((blocks[1] as Extract<ChatBlock, { t: 'p' }>).html).toContain('And here is prose.')
+  })
 })

--- a/dashboard/src/components/chat/markdown-blocks.ts
+++ b/dashboard/src/components/chat/markdown-blocks.ts
@@ -142,12 +142,56 @@ function parseParagraph(token: Tokens.Paragraph): ChatBlock | ChatBlock[] | null
   return html ? { t: 'p', html } : null
 }
 
+// A fenced code block opens with ``` or ~~~ at the start of the token's raw
+// source. When the model never writes the matching closing fence, CommonMark
+// (and marked, verified against 18.0.3) absorbs every following line — including
+// plain prose — into the single code token. The resulting code block traps the
+// prose in a monospace box, which is the user-reported symptom.
+const FENCE_OPEN_RE = /^\s*(`{3,}|~{3,})/
+const FENCE_CLOSE_RE = /(`{3,}|~{3,})\s*$/
+
+/**
+ * True when a code token is a fenced block that was opened but never closed.
+ *
+ * Detection: the token's `raw` starts with a fence but does not end with one.
+ * - Closed fence: raw ends with ``` / ~~~  → real code, keep as {t:'code'}.
+ * - Unterminated: raw ends with absorbed prose, not a fence → demote to text.
+ * - Indented code block (4-space, no fence): raw does not start with a fence,
+ *   so it is left untouched.
+ *
+ * This does not inspect the *kind* of closing fence (``` vs ~~~); marked only
+ * closes a fence with the same character that opened it, so a token that ends
+ * with any fence-looking line is already a closed block here.
+ */
+export function isUnterminatedFence(token: Tokens.Code): boolean {
+  const raw = token.raw
+  if (!FENCE_OPEN_RE.test(raw)) return false
+  return !FENCE_CLOSE_RE.test(raw.trimEnd())
+}
+
 function parseCode(token: Tokens.Code): ChatBlock {
   const lang = token.lang?.trim().toLowerCase() || undefined
   if (lang?.startsWith('mermaid')) {
     return { t: 'mermaid', source: token.text }
   }
   return { t: 'code', cap: lang, html: escapeHtml(token.text) }
+}
+
+// WORKAROUND: render an unterminated fence's absorbed body as prose instead of a
+// code box. The root cause is upstream — the LLM keeper opened a fence and never
+// closed it — and the front-end cannot recover the author's intent, so it
+// renders ambiguous input in the most readable way. We do not inject a synthetic
+// closing fence: that would still trap the prose in a code box, which is the
+// exact complaint. Trade-off: genuinely truncated code (a real snippet cut off
+// mid-fence) also renders as prose rather than a code block.
+//
+// Content is HTML-escaped (no inline markdown parsing) because the absorbed body
+// may itself be code where `*`/`_`/backticks are literal, not markdown. Newlines
+// are converted to <br> so the multi-line body keeps its line breaks inside the
+// <p> element (which has white-space: normal and would otherwise collapse them).
+function parseUnterminatedFenceAsText(token: Tokens.Code): ChatBlock {
+  const html = escapeHtml(token.text).replace(/\n/g, '<br>')
+  return { t: 'p', html }
 }
 
 function parseHeading(token: Tokens.Heading): ChatBlock {
@@ -176,8 +220,14 @@ function tokenToBlock(token: Token): ChatBlock | ChatBlock[] | null {
   switch (token.type) {
     case 'paragraph':
       return parseParagraph(token as Tokens.Paragraph)
-    case 'code':
-      return parseCode(token as Tokens.Code)
+    case 'code': {
+      const codeToken = token as Tokens.Code
+      // Demote an unterminated fence so its absorbed prose is not trapped in a
+      // monospace code box (see parseUnterminatedFenceAsText).
+      return isUnterminatedFence(codeToken)
+        ? parseUnterminatedFenceAsText(codeToken)
+        : parseCode(codeToken)
+    }
     case 'heading':
       return parseHeading(token as Tokens.Heading)
     case 'list':

--- a/dashboard/src/components/chat/markdown-blocks.ts
+++ b/dashboard/src/components/chat/markdown-blocks.ts
@@ -142,18 +142,19 @@ function parseParagraph(token: Tokens.Paragraph): ChatBlock | ChatBlock[] | null
   return html ? { t: 'p', html } : null
 }
 
-// A fenced code block opens with ``` or ~~~ at the start of the token's raw
-// source. When the model never writes the matching closing fence, CommonMark
-// (and marked, verified against 18.0.3) absorbs every following line — including
+// A fenced code block opens with ``` or ~~~ after at most three leading spaces.
+// When the model never writes the matching closing fence, CommonMark (and
+// marked, verified against 18.0.3) absorbs every following line — including
 // plain prose — into the single code token. The resulting code block traps the
 // prose in a monospace box, which is the user-reported symptom.
-const FENCE_OPEN_RE = /^\s*(`{3,}|~{3,})/
+const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})/
 
 function hasMatchingClosingFence(raw: string, opener: string): boolean {
   const fenceChar = opener[0]
   const lines = raw.trimEnd().split(/\r?\n/)
-  const closingLine = lines[lines.length - 1]?.trim() ?? ''
-  return closingLine.length >= opener.length && [...closingLine].every((ch) => ch === fenceChar)
+  const closingLine = lines[lines.length - 1] ?? ''
+  const closing = closingLine.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/)?.[1]
+  return !!closing && closing[0] === fenceChar && closing.length >= opener.length
 }
 
 /**
@@ -164,7 +165,8 @@ function hasMatchingClosingFence(raw: string, opener: string): boolean {
  * - Closed fence: raw ends with same-char ``` / ~~~  → real code, keep as {t:'code'}.
  * - Unterminated: raw ends with absorbed prose, not a fence → demote to text.
  * - Indented code block (4-space, no fence): raw does not start with a fence,
- *   so it is left untouched.
+ *   so it is left untouched. A 4-space line that looks like a closing fence is
+ *   also literal content, not a close marker.
  */
 export function isUnterminatedFence(token: Tokens.Code): boolean {
   const raw = token.raw

--- a/dashboard/src/components/chat/markdown-blocks.ts
+++ b/dashboard/src/components/chat/markdown-blocks.ts
@@ -148,25 +148,29 @@ function parseParagraph(token: Tokens.Paragraph): ChatBlock | ChatBlock[] | null
 // plain prose — into the single code token. The resulting code block traps the
 // prose in a monospace box, which is the user-reported symptom.
 const FENCE_OPEN_RE = /^\s*(`{3,}|~{3,})/
-const FENCE_CLOSE_RE = /(`{3,}|~{3,})\s*$/
+
+function hasMatchingClosingFence(raw: string, opener: string): boolean {
+  const fenceChar = opener[0]
+  const lines = raw.trimEnd().split(/\r?\n/)
+  const closingLine = lines[lines.length - 1]?.trim() ?? ''
+  return closingLine.length >= opener.length && [...closingLine].every((ch) => ch === fenceChar)
+}
 
 /**
  * True when a code token is a fenced block that was opened but never closed.
  *
- * Detection: the token's `raw` starts with a fence but does not end with one.
- * - Closed fence: raw ends with ``` / ~~~  → real code, keep as {t:'code'}.
+ * Detection: the token's `raw` starts with a fence but does not end with a
+ * matching fence line.
+ * - Closed fence: raw ends with same-char ``` / ~~~  → real code, keep as {t:'code'}.
  * - Unterminated: raw ends with absorbed prose, not a fence → demote to text.
  * - Indented code block (4-space, no fence): raw does not start with a fence,
  *   so it is left untouched.
- *
- * This does not inspect the *kind* of closing fence (``` vs ~~~); marked only
- * closes a fence with the same character that opened it, so a token that ends
- * with any fence-looking line is already a closed block here.
  */
 export function isUnterminatedFence(token: Tokens.Code): boolean {
   const raw = token.raw
-  if (!FENCE_OPEN_RE.test(raw)) return false
-  return !FENCE_CLOSE_RE.test(raw.trimEnd())
+  const opener = raw.match(FENCE_OPEN_RE)?.[1]
+  if (!opener) return false
+  return !hasMatchingClosingFence(raw, opener)
 }
 
 function parseCode(token: Tokens.Code): ChatBlock {


### PR DESCRIPTION
프론트 전용 Draft. RFC 강제 영역 아님(dashboard chat 렌더링; credential/keeper/operator/sandbox/hooks 무관).

## 무엇을 / 왜

`marked`가 닫히지 않은 fenced code(``` 또는 ~~~가 안 닫힘)의 **뒤따르는 모든 산문을 단일 code 토큰으로 흡수**한다(CommonMark 스펙). 그 결과 `parseMarkdownToBlocks`가 산문을 코드박스에 가둔다. LLM 키퍼 출력에서 모델이 ```를 열고 안 닫는 경우가 흔해, 정상 산문이 "끊겨/코드로" 보인다.

배경: issue_king `thinking_only` 장애 진단 중 부수 발견. 이번 키퍼 error 카드의 직접 원인은 백엔드(키퍼가 출력 0으로 죽음, 렌더는 정확)이고 fence 버그는 별개 경로지만, 사용자가 의심한 "백틱 파싱" 자체는 실재하는 버그라 분리 수정한다.

## 변경 (`markdown-blocks.ts` +54/−2, test +67)

- `isUnterminatedFence(token)`: `raw`가 fence로 시작하고 같은 fence로 **끝나지 않으면** unterminated (marked 18.0.3 실측 검증). 4-space indented code block(`raw`가 fence로 시작 안 함)은 영향 없음.
- `parseUnterminatedFenceAsText`: code 블록 대신 `ChatTextBlock`(`t:'p'`)으로 강등. inline 마크다운 해석 없이 `escapeHtml`(흡수된 본문이 literal 코드일 수 있음), `\n`→`<br>`로 줄바꿈 보존. **텍스트 무손실**.
- `WORKAROUND:` 주석: 근본은 upstream(LLM이 fence 안 닫음)이라 프론트는 모호 입력을 최선 표시. 닫는 fence 합성 주입은 거부(여전히 산문이 code에 갇힘). trade-off(진짜 잘린 코드도 prose로 렌더) 명시.

이는 protocol-boundary repair가 아니라 신뢰 불가 마크다운의 **렌더 표현 선택**이다(데이터/프로토콜 무변경).

## 검증

`tsc --noEmit` exit 0. `vitest run markdown-blocks.test.ts` → **27 passed (8 new)**: 닫힌 fence는 code 유지(회귀 방지), unterminated는 텍스트 강등+산문 보존, indented code 무영향, 닫힌 fence+후속 산문은 code+paragraph 정상.
