### PR TITLE
docs: align product plan version truth

### DIFF
--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -9,10 +9,10 @@ code_refs:
 
 # Product Operating Plan
 
-> Current package version: v0.19.46
-> Latest changelog entry: v0.19.46 (2026-06-18)
+> Current package version: v0.19.47
+> Latest changelog entry: v0.19.47 (2026-06-20)
 > Latest published GitHub release: v0.19.45 (2026-06-17)
-> Updated: 2026-06-18
+> Updated: 2026-06-20
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 
 Execution companion for capsule-only workspace collaboration hardening:

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -11,7 +11,7 @@ code_refs:
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
 > Last Updated: 2026-05-24
-> Snapshot baseline: `dune-project` version `0.19.46`
+> Snapshot baseline: `dune-project` version `0.19.47`
 
 MASC (Multi-Agent Shared Context)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Agent-LLM-A, Provider-F, Agent-Code, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Workspace 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, dashboard/operator read visibility를 제공하며, MCP JSON-RPC 프로토콜을 통해 주요 AI IDE/CLI와 통합된다. Retired orchestration surfaces and internal references remain only as migration context.
 


### PR DESCRIPTION
## Summary
- Align `docs/PRODUCT-OPERATING-PLAN.md` with current `dune-project`/`ROADMAP.md` version truth (`v0.19.47`).
- Align `docs/spec/SPEC-INDEX.md` snapshot baseline with the same current package version.

## Verification
- `bash scripts/check-doc-truth.sh` PASS
- `git diff --check` PASS

No build run per maintainer instruction; docs-only hygiene fix.