### PR TITLE
feat(sidecars): preserve extended gate structured blocks

### DIFF
--- a/dashboard/src/api/schemas/keeper-chat-history.test.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.test.ts
@@ -194,6 +194,10 @@ describe('safeParseKeeperChatHistoryMessage', () => {
         role: 'assistant',
         blocks: [
           { t: 'p', html: 'hello' },
+          { t: 'code', cap: 'ocaml', html: 'let x = 1', source: 'let x = 1' },
+          { t: 'table', head: ['name', { v: 'count', num: true }], rows: [['a', '1']] },
+          { t: 'voice', secs: 3, wave: [0.2, 0.8], transcript: 'memo' },
+          { t: 'attach', name: 'clip.mp4', src: 'https://cdn.example/clip.mp4', kind: 'video' },
           { t: 'image', src: 'https://cdn.example/x.png', cap: 'screen' },
           { t: 'link', url: 'https://example.com', title: 'Example' },
         ],
@@ -201,6 +205,10 @@ describe('safeParseKeeperChatHistoryMessage', () => {
     )
     expect(out?.blocks).toEqual([
       { t: 'p', html: 'hello' },
+      { t: 'code', cap: 'ocaml', html: 'let x = 1', source: 'let x = 1' },
+      { t: 'table', head: ['name', { v: 'count', num: true }], rows: [['a', '1']] },
+      { t: 'voice', secs: 3, wave: [0.2, 0.8], transcript: 'memo' },
+      { t: 'attach', name: 'clip.mp4', src: 'https://cdn.example/clip.mp4', kind: 'video' },
       { t: 'image', src: 'https://cdn.example/x.png', cap: 'screen' },
       { t: 'link', url: 'https://example.com', title: 'Example' },
     ])

--- a/dashboard/src/api/schemas/keeper-chat-history.ts
+++ b/dashboard/src/api/schemas/keeper-chat-history.ts
@@ -80,14 +80,80 @@ export const KeeperChatHistoryAudioClipSchema = object({
 
 export type KeeperChatHistoryAudioClip = InferOutput<typeof KeeperChatHistoryAudioClipSchema>
 
+const KeeperChatTableCellSchema = union([
+  string(),
+  object({
+    v: string(),
+    num: optional(boolean()),
+    muted: optional(boolean()),
+  }),
+])
+
 // RFC-0235 P3: server-parsed rich chat blocks carried on persisted history
-// rows. Only the block types the backend currently emits are accepted at the
-// boundary; malformed block arrays cause the whole row to be dropped by
-// safeParseKeeperChatHistoryMessage so the transcript stays clean.
+// rows. Keep this aligned with keeper_chat_blocks.ml and the dashboard
+// renderer's ChatBlock union; malformed block arrays cause the whole row to be
+// dropped by safeParseKeeperChatHistoryMessage so the transcript stays clean.
 export const KeeperChatBlockSchema = union([
   object({
     t: literal('p'),
     html: string(),
+  }),
+  object({
+    t: literal('h4'),
+    html: string(),
+  }),
+  object({
+    t: literal('ul'),
+    items: array(string()),
+  }),
+  object({
+    t: literal('callout'),
+    severity: optional(union([literal('info'), literal('warn'), literal('bad')])),
+    html: string(),
+  }),
+  object({
+    t: literal('table'),
+    head: array(KeeperChatTableCellSchema),
+    rows: array(array(KeeperChatTableCellSchema)),
+  }),
+  object({
+    t: literal('code'),
+    cap: optional(string()),
+    html: string(),
+    source: optional(string()),
+  }),
+  object({
+    t: literal('mermaid'),
+    source: string(),
+    caption: optional(string()),
+  }),
+  object({
+    t: literal('svg'),
+    svg: string(),
+    cap: optional(string()),
+  }),
+  object({
+    t: literal('voice'),
+    secs: optional(number()),
+    wave: optional(array(number())),
+    via: optional(string()),
+    size: optional(string()),
+    transcript: optional(string()),
+    src: optional(string()),
+  }),
+  object({
+    t: literal('attach'),
+    name: string(),
+    dims: optional(string()),
+    src: optional(string()),
+    svg: optional(string()),
+    ph: optional(string()),
+    via: optional(string()),
+    size: optional(string()),
+    data: optional(string()),
+    mimeType: optional(string()),
+    sizeBytes: optional(number()),
+    kind: optional(string()),
   }),
   object({
     t: literal('image'),

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -17,6 +17,12 @@ type link_block = {
 
 type text_block = { html : string }
 
+type code_block = {
+  cap : string option;
+  html : string;
+  source : string option;
+}
+
 type fusion_block = {
   board_post_id : string;
   run_id : string;
@@ -24,6 +30,7 @@ type fusion_block = {
 
 type chat_block =
   | Text of text_block
+  | Code of code_block
   | Image of image_block
   | Link of link_block
   | Fusion of fusion_block
@@ -120,11 +127,38 @@ let push_text_fragment acc fragment =
 
 let md_image_re = Re.Pcre.re "!\\[([^\\]]*)\\]\\(([^)]+)\\)" |> Re.compile
 
+let code_fence_re =
+  Re.Pcre.re
+    "```([A-Za-z0-9_+.#-]*)[ \t]*\r?\n([\\s\\S]*?)\r?\n```[ \t]*(?:\r?\n|$)"
+  |> Re.compile
+
+type next_match =
+  | Image_match of Re.Group.t
+  | Code_match of Re.Group.t
+
+let earlier_match left right =
+  match left, right with
+  | None, None -> None
+  | Some _, None -> left
+  | None, Some _ -> right
+  | Some (Image_match image), Some (Code_match code) ->
+    if Re.Group.start code 0 <= Re.Group.start image 0 then right else left
+  | Some (Code_match code), Some (Image_match image) ->
+    if Re.Group.start code 0 <= Re.Group.start image 0 then left else right
+  | Some _, Some _ -> left
+
 let parse_text_to_blocks text : chat_block list =
   let rec scan acc last_index =
-    match Re.exec_opt ~pos:last_index md_image_re text with
-    | None -> push_text_fragment acc (String.sub text last_index (String.length text - last_index))
-    | Some group ->
+    let next_image =
+      Option.map (fun group -> Image_match group) (Re.exec_opt ~pos:last_index md_image_re text)
+    in
+    let next_code =
+      Option.map (fun group -> Code_match group) (Re.exec_opt ~pos:last_index code_fence_re text)
+    in
+    match earlier_match next_image next_code with
+    | None ->
+      push_text_fragment acc (String.sub text last_index (String.length text - last_index))
+    | Some (Image_match group) ->
       let start = Re.Group.start group 0 in
       let stop = Re.Group.stop group 0 in
       let before = String.sub text last_index (start - last_index) in
@@ -138,6 +172,16 @@ let parse_text_to_blocks text : chat_block list =
       else
         let fallback = String.sub text start (stop - start) in
         scan (push_text_fragment acc fallback) stop
+    | Some (Code_match group) ->
+      let start = Re.Group.start group 0 in
+      let stop = Re.Group.stop group 0 in
+      let before = String.sub text last_index (start - last_index) in
+      let lang = Re.Group.get group 1 |> String.trim in
+      let source = Re.Group.get group 2 in
+      let cap = if lang = "" then None else Some (String.lowercase_ascii lang) in
+      let acc = push_text_fragment acc before in
+      let acc = Code { cap; html = escape_html source; source = Some source } :: acc in
+      scan acc stop
   in
   List.rev (scan [] 0)
 ;;
@@ -145,6 +189,19 @@ let parse_text_to_blocks text : chat_block list =
 let block_to_yojson = function
   | Text { html } ->
     `Assoc [ ("t", `String "p"); ("html", `String html) ]
+  | Code { cap; html; source } ->
+    let fields = [ ("t", `String "code"); ("html", `String html) ] in
+    let fields =
+      match cap with
+      | None -> fields
+      | Some c -> fields @ [ ("cap", `String c) ]
+    in
+    let fields =
+      match source with
+      | None -> fields
+      | Some s -> fields @ [ ("source", `String s) ]
+    in
+    `Assoc fields
   | Image { src; cap } ->
     let fields = [ ("t", `String "image"); ("src", `String src) ] in
     let fields =
@@ -181,6 +238,11 @@ let block_of_yojson json : chat_block option =
     (match get_string "t" with
      | Some "p" ->
        Option.map (fun html -> Text { html }) (get_string "html")
+     | Some "code" ->
+       Option.bind (get_string "html") (fun html ->
+         let cap = get_string "cap" in
+         let source = get_string "source" in
+         Some (Code { cap; html; source }))
      | Some "image" ->
        Option.bind (get_string "src") (fun src ->
          let cap = get_string "cap" in

--- a/lib/keeper/keeper_chat_blocks.ml
+++ b/lib/keeper/keeper_chat_blocks.ml
@@ -17,10 +17,63 @@ type link_block = {
 
 type text_block = { html : string }
 
+type list_block = { items : string list }
+
+type callout_block = {
+  severity : string option;
+  html : string;
+}
+
+type table_cell =
+  | Cell_text of string
+  | Cell_value of {
+      v : string;
+      num : bool option;
+      muted : bool option;
+    }
+
+type table_block = {
+  head : table_cell list;
+  rows : table_cell list list;
+}
+
 type code_block = {
   cap : string option;
   html : string;
   source : string option;
+}
+
+type mermaid_block = {
+  source : string;
+  caption : string option;
+}
+
+type svg_block = {
+  svg : string;
+  cap : string option;
+}
+
+type voice_block = {
+  secs : float option;
+  wave : float list option;
+  via : string option;
+  size : string option;
+  transcript : string option;
+  src : string option;
+}
+
+type attach_block = {
+  name : string;
+  dims : string option;
+  src : string option;
+  svg : string option;
+  ph : string option;
+  via : string option;
+  size : string option;
+  data : string option;
+  mime_type : string option;
+  size_bytes : int option;
+  kind : string option;
 }
 
 type fusion_block = {
@@ -30,7 +83,15 @@ type fusion_block = {
 
 type chat_block =
   | Text of text_block
+  | Heading of text_block
+  | Unordered_list of list_block
+  | Callout of callout_block
+  | Table of table_block
   | Code of code_block
+  | Mermaid of mermaid_block
+  | Svg of svg_block
+  | Voice of voice_block
+  | Attach of attach_block
   | Image of image_block
   | Link of link_block
   | Fusion of fusion_block
@@ -94,6 +155,95 @@ let is_http_url url =
     | _ -> false
   with
   | _ -> false
+;;
+
+let has_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len && String.sub value 0 prefix_len = prefix
+;;
+
+let opt_string_field key = function
+  | None -> []
+  | Some value -> [ (key, `String value) ]
+;;
+
+let opt_bool_field key = function
+  | None -> []
+  | Some value -> [ (key, `Bool value) ]
+;;
+
+let opt_float_field key = function
+  | None -> []
+  | Some value -> [ (key, `Float value) ]
+;;
+
+let opt_int_field key = function
+  | None -> []
+  | Some value -> [ (key, `Int value) ]
+;;
+
+let table_cell_to_yojson = function
+  | Cell_text value -> `String value
+  | Cell_value { v; num; muted } ->
+    `Assoc
+      ([ ("v", `String v) ] @ opt_bool_field "num" num @ opt_bool_field "muted" muted)
+;;
+
+let table_cell_of_yojson = function
+  | `String value -> Some (Cell_text value)
+  | `Assoc fields ->
+    (match List.assoc_opt "v" fields with
+     | Some (`String v) ->
+       let bool_field key =
+         match List.assoc_opt key fields with
+         | Some (`Bool b) -> Some b
+         | _ -> None
+       in
+       Some (Cell_value { v; num = bool_field "num"; muted = bool_field "muted" })
+     | _ -> None)
+  | _ -> None
+;;
+
+let list_all_map f items =
+  let rec loop acc = function
+    | [] -> Some (List.rev acc)
+    | item :: rest ->
+      (match f item with
+       | None -> None
+       | Some value -> loop (value :: acc) rest)
+  in
+  loop [] items
+;;
+
+let string_list_of_yojson = function
+  | `List items ->
+    list_all_map
+      (function
+        | `String value -> Some value
+        | _ -> None)
+      items
+  | _ -> None
+;;
+
+let table_cells_of_yojson = function
+  | `List items -> list_all_map table_cell_of_yojson items
+  | _ -> None
+;;
+
+let table_rows_of_yojson = function
+  | `List rows -> list_all_map table_cells_of_yojson rows
+  | _ -> None
+;;
+
+let float_list_of_yojson = function
+  | `List items ->
+    list_all_map
+      (function
+        | `Float value -> Some value
+        | `Int value -> Some (float_of_int value)
+        | _ -> None)
+      items
+  | _ -> None
 ;;
 
 let line_to_block line : chat_block option =
@@ -180,7 +330,12 @@ let parse_text_to_blocks text : chat_block list =
       let source = Re.Group.get group 2 in
       let cap = if lang = "" then None else Some (String.lowercase_ascii lang) in
       let acc = push_text_fragment acc before in
-      let acc = Code { cap; html = escape_html source; source = Some source } :: acc in
+      let acc =
+        match cap with
+        | Some lang when has_prefix ~prefix:"mermaid" lang ->
+          Mermaid { source; caption = None } :: acc
+        | _ -> Code { cap; html = escape_html source; source = Some source } :: acc
+      in
       scan acc stop
   in
   List.rev (scan [] 0)
@@ -189,6 +344,26 @@ let parse_text_to_blocks text : chat_block list =
 let block_to_yojson = function
   | Text { html } ->
     `Assoc [ ("t", `String "p"); ("html", `String html) ]
+  | Heading { html } ->
+    `Assoc [ ("t", `String "h4"); ("html", `String html) ]
+  | Unordered_list { items } ->
+    `Assoc
+      [ ("t", `String "ul")
+      ; ("items", `List (List.map (fun item -> `String item) items))
+      ]
+  | Callout { severity; html } ->
+    `Assoc ([ ("t", `String "callout"); ("html", `String html) ]
+            @ opt_string_field "severity" severity)
+  | Table { head; rows } ->
+    `Assoc
+      [ ("t", `String "table")
+      ; ("head", `List (List.map table_cell_to_yojson head))
+      ; ( "rows"
+        , `List
+            (List.map
+               (fun row -> `List (List.map table_cell_to_yojson row))
+               rows) )
+      ]
   | Code { cap; html; source } ->
     let fields = [ ("t", `String "code"); ("html", `String html) ] in
     let fields =
@@ -202,6 +377,38 @@ let block_to_yojson = function
       | Some s -> fields @ [ ("source", `String s) ]
     in
     `Assoc fields
+  | Mermaid { source; caption } ->
+    `Assoc
+      ([ ("t", `String "mermaid"); ("source", `String source) ]
+       @ opt_string_field "caption" caption)
+  | Svg { svg; cap } ->
+    `Assoc ([ ("t", `String "svg"); ("svg", `String svg) ] @ opt_string_field "cap" cap)
+  | Voice { secs; wave; via; size; transcript; src } ->
+    let fields =
+      [ ("t", `String "voice") ]
+      @ opt_float_field "secs" secs
+      @ (match wave with
+         | None -> []
+         | Some values -> [ ("wave", `List (List.map (fun v -> `Float v) values)) ])
+      @ opt_string_field "via" via
+      @ opt_string_field "size" size
+      @ opt_string_field "transcript" transcript
+      @ opt_string_field "src" src
+    in
+    `Assoc fields
+  | Attach { name; dims; src; svg; ph; via; size; data; mime_type; size_bytes; kind } ->
+    `Assoc
+      ([ ("t", `String "attach"); ("name", `String name) ]
+       @ opt_string_field "dims" dims
+       @ opt_string_field "src" src
+       @ opt_string_field "svg" svg
+       @ opt_string_field "ph" ph
+       @ opt_string_field "via" via
+       @ opt_string_field "size" size
+       @ opt_string_field "data" data
+       @ opt_string_field "mimeType" mime_type
+       @ opt_int_field "sizeBytes" size_bytes
+       @ opt_string_field "kind" kind)
   | Image { src; cap } ->
     let fields = [ ("t", `String "image"); ("src", `String src) ] in
     let fields =
@@ -235,14 +442,81 @@ let block_of_yojson json : chat_block option =
       | Some (`String s) -> Some s
       | _ -> None
     in
+    let get_float key =
+      match List.assoc_opt key fields with
+      | Some (`Float f) -> Some f
+      | Some (`Int i) -> Some (float_of_int i)
+      | _ -> None
+    in
+    let get_int key =
+      match List.assoc_opt key fields with
+      | Some (`Int i) -> Some i
+      | _ -> None
+    in
     (match get_string "t" with
      | Some "p" ->
        Option.map (fun html -> Text { html }) (get_string "html")
+     | Some "h4" ->
+       Option.map (fun html -> Heading { html }) (get_string "html")
+     | Some "ul" ->
+       Option.bind (List.assoc_opt "items" fields) (fun items ->
+         Option.bind (string_list_of_yojson items) (fun items ->
+           if items = [] then None else Some (Unordered_list { items })))
+     | Some "callout" ->
+       Option.bind (get_string "html") (fun html ->
+         let severity =
+           match get_string "severity" with
+           | Some ("info" | "warn" | "bad" as severity) -> Some severity
+           | _ -> None
+         in
+         Some (Callout { severity; html }))
+     | Some "table" ->
+       Option.bind (List.assoc_opt "head" fields) (fun head_json ->
+         Option.bind (table_cells_of_yojson head_json) (fun head ->
+           Option.bind (List.assoc_opt "rows" fields) (fun rows_json ->
+             Option.map (fun rows -> Table { head; rows }) (table_rows_of_yojson rows_json))))
      | Some "code" ->
        Option.bind (get_string "html") (fun html ->
          let cap = get_string "cap" in
          let source = get_string "source" in
          Some (Code { cap; html; source }))
+     | Some "mermaid" ->
+       Option.bind (get_string "source") (fun source ->
+         Some (Mermaid { source; caption = get_string "caption" }))
+     | Some "svg" ->
+       Option.bind (get_string "svg") (fun svg ->
+         Some (Svg { svg; cap = get_string "cap" }))
+     | Some "voice" ->
+       let wave =
+         match List.assoc_opt "wave" fields with
+         | None -> None
+         | Some json -> float_list_of_yojson json
+       in
+       Some
+         (Voice
+            { secs = get_float "secs"
+            ; wave
+            ; via = get_string "via"
+            ; size = get_string "size"
+            ; transcript = get_string "transcript"
+            ; src = get_string "src"
+            })
+     | Some "attach" ->
+       Option.bind (get_string "name") (fun name ->
+         Some
+           (Attach
+              { name
+              ; dims = get_string "dims"
+              ; src = get_string "src"
+              ; svg = get_string "svg"
+              ; ph = get_string "ph"
+              ; via = get_string "via"
+              ; size = get_string "size"
+              ; data = get_string "data"
+              ; mime_type = get_string "mimeType"
+              ; size_bytes = get_int "sizeBytes"
+              ; kind = get_string "kind"
+              }))
      | Some "image" ->
        Option.bind (get_string "src") (fun src ->
          let cap = get_string "cap" in

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -5,6 +5,7 @@
     blocks verbatim.
 
     Supported shapes:
+    - Matched fenced code blocks become code blocks with escaped HTML and raw source.
     - Markdown images [![alt](url)] become image blocks.
     - Bare image URLs (png/jpg/gif/webp/svg) on their own line become image blocks.
     - Other standalone URLs become link blocks with a hostname-derived title.
@@ -23,6 +24,12 @@ type link_block = {
 
 type text_block = { html : string }
 
+type code_block = {
+  cap : string option;
+  html : string;
+  source : string option;
+}
+
 (** A reference from a keeper chat message to a fusion deliberation's board
     post (RFC-0252). Carries only ids — the dashboard lazy-fetches the board
     post by [board_post_id] and renders the panel answers + judge synthesis
@@ -35,6 +42,7 @@ type fusion_block = {
 
 type chat_block =
   | Text of text_block
+  | Code of code_block
   | Image of image_block
   | Link of link_block
   | Fusion of fusion_block

--- a/lib/keeper/keeper_chat_blocks.mli
+++ b/lib/keeper/keeper_chat_blocks.mli
@@ -5,7 +5,11 @@
     blocks verbatim.
 
     Supported shapes:
+    - Explicit server-provided dashboard blocks round-trip through the
+      codec: p, h4, ul, callout, table, code, mermaid, svg, voice, attach,
+      image, link, and fusion.
     - Matched fenced code blocks become code blocks with escaped HTML and raw source.
+    - Mermaid fenced code blocks become mermaid blocks with raw source.
     - Markdown images [![alt](url)] become image blocks.
     - Bare image URLs (png/jpg/gif/webp/svg) on their own line become image blocks.
     - Other standalone URLs become link blocks with a hostname-derived title.
@@ -24,10 +28,63 @@ type link_block = {
 
 type text_block = { html : string }
 
+type list_block = { items : string list }
+
+type callout_block = {
+  severity : string option;
+  html : string;
+}
+
+type table_cell =
+  | Cell_text of string
+  | Cell_value of {
+      v : string;
+      num : bool option;
+      muted : bool option;
+    }
+
+type table_block = {
+  head : table_cell list;
+  rows : table_cell list list;
+}
+
 type code_block = {
   cap : string option;
   html : string;
   source : string option;
+}
+
+type mermaid_block = {
+  source : string;
+  caption : string option;
+}
+
+type svg_block = {
+  svg : string;
+  cap : string option;
+}
+
+type voice_block = {
+  secs : float option;
+  wave : float list option;
+  via : string option;
+  size : string option;
+  transcript : string option;
+  src : string option;
+}
+
+type attach_block = {
+  name : string;
+  dims : string option;
+  src : string option;
+  svg : string option;
+  ph : string option;
+  via : string option;
+  size : string option;
+  data : string option;
+  mime_type : string option;
+  size_bytes : int option;
+  kind : string option;
 }
 
 (** A reference from a keeper chat message to a fusion deliberation's board
@@ -42,7 +99,15 @@ type fusion_block = {
 
 type chat_block =
   | Text of text_block
+  | Heading of text_block
+  | Unordered_list of list_block
+  | Callout of callout_block
+  | Table of table_block
   | Code of code_block
+  | Mermaid of mermaid_block
+  | Svg of svg_block
+  | Voice of voice_block
+  | Attach of attach_block
   | Image of image_block
   | Link of link_block
   | Fusion of fusion_block

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -260,7 +260,7 @@ let rich_embed_of_chat_block = function
       Some
         (Discord_rest_client.link_embed ~url ~title ~description:None
            ~image:None)
-  | Keeper_chat_blocks.Text _ | Keeper_chat_blocks.Fusion _ -> None
+  | Keeper_chat_blocks.Text _ | Keeper_chat_blocks.Code _ | Keeper_chat_blocks.Fusion _ -> None
 
 let rich_embeds_of_text text =
   text

--- a/lib/keeper/keeper_chat_discord.ml
+++ b/lib/keeper/keeper_chat_discord.ml
@@ -260,7 +260,17 @@ let rich_embed_of_chat_block = function
       Some
         (Discord_rest_client.link_embed ~url ~title ~description:None
            ~image:None)
-  | Keeper_chat_blocks.Text _ | Keeper_chat_blocks.Code _ | Keeper_chat_blocks.Fusion _ -> None
+  | Keeper_chat_blocks.Text _
+  | Keeper_chat_blocks.Heading _
+  | Keeper_chat_blocks.Unordered_list _
+  | Keeper_chat_blocks.Callout _
+  | Keeper_chat_blocks.Table _
+  | Keeper_chat_blocks.Code _
+  | Keeper_chat_blocks.Mermaid _
+  | Keeper_chat_blocks.Svg _
+  | Keeper_chat_blocks.Voice _
+  | Keeper_chat_blocks.Attach _
+  | Keeper_chat_blocks.Fusion _ -> None
 
 let rich_embeds_of_text text =
   text

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -125,7 +125,17 @@ let slack_block_of_chat_block = function
       Some (image_block_json ~url:src ~caption:cap)
   | Keeper_chat_blocks.Link { url; title; meta = _ } ->
       Some (link_block_json ~url ~title ~description:None)
-  | Keeper_chat_blocks.Text _ | Keeper_chat_blocks.Code _ | Keeper_chat_blocks.Fusion _ -> None
+  | Keeper_chat_blocks.Text _
+  | Keeper_chat_blocks.Heading _
+  | Keeper_chat_blocks.Unordered_list _
+  | Keeper_chat_blocks.Callout _
+  | Keeper_chat_blocks.Table _
+  | Keeper_chat_blocks.Code _
+  | Keeper_chat_blocks.Mermaid _
+  | Keeper_chat_blocks.Svg _
+  | Keeper_chat_blocks.Voice _
+  | Keeper_chat_blocks.Attach _
+  | Keeper_chat_blocks.Fusion _ -> None
 
 let content_blocks_of_text text =
   text

--- a/lib/keeper/keeper_chat_slack.ml
+++ b/lib/keeper/keeper_chat_slack.ml
@@ -125,7 +125,7 @@ let slack_block_of_chat_block = function
       Some (image_block_json ~url:src ~caption:cap)
   | Keeper_chat_blocks.Link { url; title; meta = _ } ->
       Some (link_block_json ~url ~title ~description:None)
-  | Keeper_chat_blocks.Text _ | Keeper_chat_blocks.Fusion _ -> None
+  | Keeper_chat_blocks.Text _ | Keeper_chat_blocks.Code _ | Keeper_chat_blocks.Fusion _ -> None
 
 let content_blocks_of_text text =
   text

--- a/sidecars/cli-connector/src/bot.py
+++ b/sidecars/cli-connector/src/bot.py
@@ -29,7 +29,7 @@ _shared_root = Path(__file__).resolve().parent.parent.parent / "shared"
 if str(_shared_root) not in sys.path:
     sys.path.insert(0, str(_shared_root))
 
-from gate_shared import GateClientBase, GateResponse, structured_plain_text  # noqa: E402
+from gate_shared import GateClientBase, GateResponse, response_text  # noqa: E402
 
 
 class CLIGateClient(GateClientBase):
@@ -50,7 +50,7 @@ def _strip_state(text: str) -> str:
 
 
 def _response_text(response: GateResponse) -> str:
-    return _strip_state(structured_plain_text(response.structured) or response.reply)
+    return _strip_state(response_text(response))
 
 
 async def _interactive_loop(client: CLIGateClient, keeper: str) -> None:

--- a/sidecars/cli-connector/src/bot.py
+++ b/sidecars/cli-connector/src/bot.py
@@ -29,7 +29,7 @@ _shared_root = Path(__file__).resolve().parent.parent.parent / "shared"
 if str(_shared_root) not in sys.path:
     sys.path.insert(0, str(_shared_root))
 
-from gate_shared import GateClientBase, GateResponse  # noqa: E402
+from gate_shared import GateClientBase, GateResponse, structured_plain_text  # noqa: E402
 
 
 class CLIGateClient(GateClientBase):
@@ -47,6 +47,10 @@ class CLIGateClient(GateClientBase):
 
 def _strip_state(text: str) -> str:
     return _RE_STATE_BLOCK.sub("", text).strip()
+
+
+def _response_text(response: GateResponse) -> str:
+    return _strip_state(structured_plain_text(response.structured) or response.reply)
 
 
 async def _interactive_loop(client: CLIGateClient, keeper: str) -> None:
@@ -130,8 +134,7 @@ async def _interactive_loop(client: CLIGateClient, keeper: str) -> None:
             idempotency_key=f"cli-{os.getpid()}-{msg_counter}",
         )
 
-        if response.ok and response.reply:
-            reply = _strip_state(response.reply)
+        if response.ok and (reply := _response_text(response)):
             print(f"\n\033[33m{reply}\033[0m")
             # Footer
             footer_parts: list[str] = []

--- a/sidecars/cli-connector/tests/test_bot.py
+++ b/sidecars/cli-connector/tests/test_bot.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import re
-
-from src.bot import _strip_state, CLIGateClient
+from src.bot import _response_text, _strip_state, CLIGateClient, GateResponse
 
 
 class TestStripState:
@@ -19,6 +17,27 @@ class TestStripState:
 
     def test_handles_empty(self) -> None:
         assert _strip_state("") == ""
+
+
+class TestResponseText:
+    def test_prefers_structured_plain_text(self) -> None:
+        response = GateResponse(
+            ok=True,
+            keeper_name="sangsu",
+            reply="fallback",
+            model_used="",
+            duration_ms=0,
+            tokens_used=0,
+            error="",
+            structured={
+                "blocks": [
+                    {"t": "p", "html": "hello &lt;cli&gt;"},
+                    {"t": "image", "src": "https://example.com/a.png"},
+                ]
+            },
+        )
+
+        assert _response_text(response) == "hello <cli>\n\nImage: https://example.com/a.png"
 
 
 class TestCLIGateClient:

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -25,7 +25,7 @@ if str(_shared_root) not in sys.path:
     sys.path.insert(0, str(_shared_root))
 
 from gate_shared.bindings_store import load_bindings  # noqa: E402
-from gate_shared.structured_content import structured_plain_text  # noqa: E402
+from gate_shared.structured_content import response_text  # noqa: E402
 
 from .config import get_config  # noqa: E402
 from .gate_client import GateClient, GateResponse  # noqa: E402
@@ -118,7 +118,7 @@ class IMessageBot:
         return redact_chat_guid(msg.chat_guid or msg.chat_identifier)
 
     def _response_text(self, response: GateResponse) -> str:
-        return structured_plain_text(response.structured) or response.reply
+        return response_text(response)
 
     async def _handle_message(self, msg: InboundMessage) -> bool:
         """Process one inbound message: gate dispatch + reply.

--- a/sidecars/imessage-bot/src/bot.py
+++ b/sidecars/imessage-bot/src/bot.py
@@ -13,15 +13,23 @@ import asyncio
 import logging
 import os
 import signal
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from gate_shared.bindings_store import load_bindings
+# Add shared module to path for direct imports in tests and tools. The
+# package entry point does the same before importing this module.
+_shared_root = Path(__file__).resolve().parent.parent.parent / "shared"
+if str(_shared_root) not in sys.path:
+    sys.path.insert(0, str(_shared_root))
 
-from .config import get_config
-from .gate_client import GateClient
-from .imessage_bridge import (
+from gate_shared.bindings_store import load_bindings  # noqa: E402
+from gate_shared.structured_content import structured_plain_text  # noqa: E402
+
+from .config import get_config  # noqa: E402
+from .gate_client import GateClient, GateResponse  # noqa: E402
+from .imessage_bridge import (  # noqa: E402
     InboundMessage,
     advance_cursor,
     redact_chat_guid,
@@ -29,7 +37,7 @@ from .imessage_bridge import (
     resolve_self_chat_guid,
     send_message,
 )
-from .status_store import ConnectorRuntimeStatus, StatusStore
+from .status_store import ConnectorRuntimeStatus, StatusStore  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -109,6 +117,9 @@ class IMessageBot:
     def _log_chat_ref(self, msg: InboundMessage) -> str:
         return redact_chat_guid(msg.chat_guid or msg.chat_identifier)
 
+    def _response_text(self, response: GateResponse) -> str:
+        return structured_plain_text(response.structured) or response.reply
+
     async def _handle_message(self, msg: InboundMessage) -> bool:
         """Process one inbound message: gate dispatch + reply.
 
@@ -131,7 +142,8 @@ class IMessageBot:
             message_rowid=msg.rowid,
         )
 
-        if response.ok and response.reply:
+        reply_text = self._response_text(response) if response.ok else ""
+        if response.ok and reply_text:
             target_chat_guid = self._resolve_reply_chat_guid(msg)
             if not target_chat_guid:
                 logger.error(
@@ -145,7 +157,7 @@ class IMessageBot:
                 self._last_message_at = datetime.now(tz=timezone.utc).isoformat()
                 return True
             sent = send_message(
-                text=response.reply,
+                text=reply_text,
                 chat_guid=target_chat_guid,
             )
             if sent:
@@ -154,7 +166,7 @@ class IMessageBot:
                     msg.sender,
                     self._log_chat_ref(msg) or "unknown",
                     redact_chat_guid(target_chat_guid),
-                    len(response.reply),
+                    len(reply_text),
                     response.keeper_name,
                     response.model_used,
                     response.duration_ms,

--- a/sidecars/imessage-bot/tests/test_bot.py
+++ b/sidecars/imessage-bot/tests/test_bot.py
@@ -77,6 +77,58 @@ class IMessageBotTests(unittest.IsolatedAsyncioTestCase):
         )
 
     @patch("src.bot.send_message", return_value=True)
+    @patch("src.bot.resolve_self_chat_guid", return_value="self-guid")
+    @patch("src.bot.GateClient")
+    @patch("src.bot.get_config")
+    async def test_handle_message_prefers_structured_reply_text(
+        self,
+        get_config_mock,
+        gate_client_cls,
+        resolve_self_chat_guid_mock,
+        send_message_mock,
+    ) -> None:
+        get_config_mock.return_value = self._config()
+        gate_client = gate_client_cls.return_value
+        gate_client.send_message = AsyncMock(
+            return_value=GateResponse(
+                ok=True,
+                keeper_name=DEFAULT_KEEPER,
+                reply="fallback reply",
+                model_used="test-model",
+                duration_ms=42,
+                tokens_used=12,
+                error="",
+                structured={
+                    "blocks": [
+                        {"t": "p", "html": "hello &lt;imessage&gt;"},
+                        {"t": "link", "url": "https://example.com", "title": "Example"},
+                    ]
+                },
+            )
+        )
+
+        bot = IMessageBot()
+        msg = InboundMessage(
+            rowid=17,
+            text="hello",
+            date=datetime.now(tz=timezone.utc),
+            service="iMessage",
+            sender="+15551234567",
+            chat_guid="source-guid",
+            chat_identifier="chat123",
+            display_name="Test",
+        )
+
+        ok = await bot._handle_message(msg)
+
+        self.assertTrue(ok)
+        resolve_self_chat_guid_mock.assert_called_once_with("/tmp/chat.db", "")
+        send_message_mock.assert_called_once_with(
+            text="hello <imessage>\n\nExample\nhttps://example.com",
+            chat_guid="self-guid",
+        )
+
+    @patch("src.bot.send_message", return_value=True)
     @patch("src.bot.resolve_self_chat_guid", return_value="")
     @patch("src.bot.GateClient")
     @patch("src.bot.get_config")

--- a/sidecars/shared/gate_shared/__init__.py
+++ b/sidecars/shared/gate_shared/__init__.py
@@ -16,7 +16,7 @@ from .diagnostics import (
 )
 from .gate_client_base import BreakerSnapshot, GateClientBase
 from .gate_response import GateResponse
-from .structured_content import response_text, structured_plain_text
+from .structured_content import SUPPORTED_BLOCK_TYPES, response_text, structured_plain_text
 
 __all__ = [
     "AutoFix",
@@ -29,6 +29,7 @@ __all__ = [
     "GateResponse",
     "NETWORK_TIMEOUT_SEC",
     "Severity",
+    "SUPPORTED_BLOCK_TYPES",
     "check_dependencies_installed",
     "exit_code_for",
     "render_fix_outcomes",

--- a/sidecars/shared/gate_shared/__init__.py
+++ b/sidecars/shared/gate_shared/__init__.py
@@ -16,7 +16,7 @@ from .diagnostics import (
 )
 from .gate_client_base import BreakerSnapshot, GateClientBase
 from .gate_response import GateResponse
-from .structured_content import structured_plain_text
+from .structured_content import response_text, structured_plain_text
 
 __all__ = [
     "AutoFix",
@@ -34,5 +34,6 @@ __all__ = [
     "render_fix_outcomes",
     "render_json",
     "render_pretty",
+    "response_text",
     "structured_plain_text",
 ]

--- a/sidecars/shared/gate_shared/__init__.py
+++ b/sidecars/shared/gate_shared/__init__.py
@@ -16,6 +16,7 @@ from .diagnostics import (
 )
 from .gate_client_base import BreakerSnapshot, GateClientBase
 from .gate_response import GateResponse
+from .structured_content import structured_plain_text
 
 __all__ = [
     "AutoFix",
@@ -33,4 +34,5 @@ __all__ = [
     "render_fix_outcomes",
     "render_json",
     "render_pretty",
+    "structured_plain_text",
 ]

--- a/sidecars/shared/gate_shared/structured_content.py
+++ b/sidecars/shared/gate_shared/structured_content.py
@@ -3,16 +3,69 @@
 from __future__ import annotations
 
 import html
+import re
 from typing import Any
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
 def _string(value: Any) -> str:
     return str(value) if isinstance(value, str) else ""
 
 
+def _html_text(value: Any) -> str:
+    text = _string(value)
+    if not text:
+        return ""
+    return html.unescape(_HTML_TAG_RE.sub("", text)).strip()
+
+
 def _text_part(raw: dict[str, Any]) -> str:
-    text = _string(raw.get("html"))
-    return html.unescape(text).strip()
+    return _html_text(raw.get("html"))
+
+
+def _heading_part(raw: dict[str, Any]) -> str:
+    text = _html_text(raw.get("html"))
+    return f"## {text}" if text else ""
+
+
+def _list_part(raw: dict[str, Any]) -> str:
+    items = raw.get("items")
+    if not isinstance(items, list):
+        return ""
+    lines = [f"- {text}" for item in items if (text := _html_text(item))]
+    return "\n".join(lines)
+
+
+def _callout_part(raw: dict[str, Any]) -> str:
+    body = _html_text(raw.get("html"))
+    if not body:
+        return ""
+    severity = _string(raw.get("severity")).strip()
+    label = f"Callout ({severity})" if severity else "Callout"
+    return f"{label}: {body}"
+
+
+def _table_cell_text(raw: Any) -> str:
+    if isinstance(raw, str):
+        return _html_text(raw)
+    if isinstance(raw, dict):
+        return _html_text(raw.get("v"))
+    return ""
+
+
+def _table_part(raw: dict[str, Any]) -> str:
+    head = raw.get("head")
+    rows = raw.get("rows")
+    if not isinstance(head, list) or not isinstance(rows, list):
+        return ""
+    rendered_rows = [[_table_cell_text(cell) for cell in head]]
+    for row in rows:
+        if isinstance(row, list):
+            rendered_rows.append([_table_cell_text(cell) for cell in row])
+    if not rendered_rows or not any(any(cell for cell in row) for row in rendered_rows):
+        return ""
+    return "\n".join(" | ".join(row) for row in rendered_rows)
 
 
 def _image_part(raw: dict[str, Any]) -> str:
@@ -36,6 +89,24 @@ def _code_part(raw: dict[str, Any]) -> str:
     return f"{fence}\n{source}\n```"
 
 
+def _mermaid_part(raw: dict[str, Any]) -> str:
+    source = _string(raw.get("source"))
+    if not source:
+        return ""
+    caption = _string(raw.get("caption")).strip()
+    prefix = f"Mermaid: {caption}\n" if caption else ""
+    return f"{prefix}```mermaid\n{source}\n```"
+
+
+def _svg_part(raw: dict[str, Any]) -> str:
+    source = _string(raw.get("svg"))
+    if not source:
+        return ""
+    caption = _string(raw.get("cap")).strip()
+    prefix = f"SVG: {caption}\n" if caption else "SVG\n"
+    return f"{prefix}```svg\n{source}\n```"
+
+
 def _link_part(raw: dict[str, Any]) -> str:
     url = _string(raw.get("url")).strip()
     if not url:
@@ -45,6 +116,46 @@ def _link_part(raw: dict[str, Any]) -> str:
     lines = [title or url, url]
     if meta and meta != title:
         lines.append(meta)
+    return "\n".join(lines)
+
+
+def _voice_part(raw: dict[str, Any]) -> str:
+    src = _string(raw.get("src")).strip()
+    transcript = _string(raw.get("transcript")).strip()
+    via = _string(raw.get("via")).strip()
+    lines = ["Audio"]
+    if via:
+        lines[0] = f"Audio ({via})"
+    if transcript:
+        lines.append(transcript)
+    if src:
+        lines.append(src)
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
+def _attach_part(raw: dict[str, Any]) -> str:
+    name = _string(raw.get("name")).strip()
+    src = _string(raw.get("src")).strip()
+    kind = _string(raw.get("kind")).strip()
+    if not name and not src:
+        return ""
+    label = "Attachment"
+    if kind:
+        label = f"Attachment ({kind})"
+    lines = [f"{label}: {name or src}"]
+    if src and src != name:
+        lines.append(src)
+    return "\n".join(lines)
+
+
+def _video_part(raw: dict[str, Any]) -> str:
+    src = _string(raw.get("src")).strip()
+    caption = _string(raw.get("cap")).strip() or _string(raw.get("name")).strip()
+    if not src and not caption:
+        return ""
+    lines = [f"Video: {caption or src}"]
+    if src and src != caption:
+        lines.append(src)
     return "\n".join(lines)
 
 
@@ -65,12 +176,30 @@ def _plain_part(raw: Any) -> str:
     block_type = raw.get("t")
     if block_type == "p":
         return _text_part(raw)
+    if block_type == "h4":
+        return _heading_part(raw)
+    if block_type == "ul":
+        return _list_part(raw)
+    if block_type == "callout":
+        return _callout_part(raw)
+    if block_type == "table":
+        return _table_part(raw)
     if block_type == "image":
         return _image_part(raw)
     if block_type == "code":
         return _code_part(raw)
+    if block_type == "mermaid":
+        return _mermaid_part(raw)
+    if block_type == "svg":
+        return _svg_part(raw)
     if block_type == "link":
         return _link_part(raw)
+    if block_type in ("voice", "audio"):
+        return _voice_part(raw)
+    if block_type == "attach":
+        return _attach_part(raw)
+    if block_type == "video":
+        return _video_part(raw)
     if block_type == "fusion":
         return _fusion_part(raw)
     return ""

--- a/sidecars/shared/gate_shared/structured_content.py
+++ b/sidecars/shared/gate_shared/structured_content.py
@@ -10,6 +10,25 @@ from .gate_response import GateResponse
 
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
+SUPPORTED_BLOCK_TYPES = frozenset(
+    {
+        "p",
+        "h4",
+        "ul",
+        "callout",
+        "table",
+        "image",
+        "code",
+        "mermaid",
+        "svg",
+        "link",
+        "voice",
+        "audio",
+        "attach",
+        "fusion",
+    }
+)
+
 
 def _string(value: Any) -> str:
     return str(value) if isinstance(value, str) else ""
@@ -150,17 +169,6 @@ def _attach_part(raw: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _video_part(raw: dict[str, Any]) -> str:
-    src = _string(raw.get("src")).strip()
-    caption = _string(raw.get("cap")).strip() or _string(raw.get("name")).strip()
-    if not src and not caption:
-        return ""
-    lines = [f"Video: {caption or src}"]
-    if src and src != caption:
-        lines.append(src)
-    return "\n".join(lines)
-
-
 def _fusion_part(raw: dict[str, Any]) -> str:
     board_post_id = _string(raw.get("board_post_id")).strip()
     if not board_post_id:
@@ -200,8 +208,6 @@ def _plain_part(raw: Any) -> str:
         return _voice_part(raw)
     if block_type == "attach":
         return _attach_part(raw)
-    if block_type == "video":
-        return _video_part(raw)
     if block_type == "fusion":
         return _fusion_part(raw)
     return ""

--- a/sidecars/shared/gate_shared/structured_content.py
+++ b/sidecars/shared/gate_shared/structured_content.py
@@ -6,6 +6,8 @@ import html
 import re
 from typing import Any
 
+from .gate_response import GateResponse
+
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
@@ -214,3 +216,8 @@ def structured_plain_text(structured: dict[str, Any] | None) -> str:
         return ""
     parts = [part for raw in raw_blocks if (part := _plain_part(raw))]
     return "\n\n".join(parts)
+
+
+def response_text(response: GateResponse) -> str:
+    """Return the renderable response body independent of reply vs structured shape."""
+    return structured_plain_text(response.structured) or response.reply

--- a/sidecars/shared/gate_shared/structured_content.py
+++ b/sidecars/shared/gate_shared/structured_content.py
@@ -1,0 +1,87 @@
+"""Structured GateResponse content helpers for sidecar connectors."""
+
+from __future__ import annotations
+
+import html
+from typing import Any
+
+
+def _string(value: Any) -> str:
+    return str(value) if isinstance(value, str) else ""
+
+
+def _text_part(raw: dict[str, Any]) -> str:
+    text = _string(raw.get("html"))
+    return html.unescape(text).strip()
+
+
+def _image_part(raw: dict[str, Any]) -> str:
+    src = _string(raw.get("src")).strip()
+    if not src:
+        return ""
+    caption = _string(raw.get("cap")).strip()
+    if caption:
+        return f"Image: {caption}\n{src}"
+    return f"Image: {src}"
+
+
+def _code_part(raw: dict[str, Any]) -> str:
+    source = _string(raw.get("source"))
+    if not source:
+        source = html.unescape(_string(raw.get("html")))
+    if not source:
+        return ""
+    cap = _string(raw.get("cap")).strip()
+    fence = f"```{cap}" if cap else "```"
+    return f"{fence}\n{source}\n```"
+
+
+def _link_part(raw: dict[str, Any]) -> str:
+    url = _string(raw.get("url")).strip()
+    if not url:
+        return ""
+    title = _string(raw.get("title")).strip()
+    meta = _string(raw.get("meta")).strip()
+    lines = [title or url, url]
+    if meta and meta != title:
+        lines.append(meta)
+    return "\n".join(lines)
+
+
+def _fusion_part(raw: dict[str, Any]) -> str:
+    board_post_id = _string(raw.get("board_post_id")).strip()
+    if not board_post_id:
+        return ""
+    run_id = _string(raw.get("run_id")).strip()
+    lines = ["Fusion result", f"board_post_id: {board_post_id}"]
+    if run_id:
+        lines.append(f"run_id: {run_id}")
+    return "\n".join(lines)
+
+
+def _plain_part(raw: Any) -> str:
+    if not isinstance(raw, dict):
+        return ""
+    block_type = raw.get("t")
+    if block_type == "p":
+        return _text_part(raw)
+    if block_type == "image":
+        return _image_part(raw)
+    if block_type == "code":
+        return _code_part(raw)
+    if block_type == "link":
+        return _link_part(raw)
+    if block_type == "fusion":
+        return _fusion_part(raw)
+    return ""
+
+
+def structured_plain_text(structured: dict[str, Any] | None) -> str:
+    """Project dashboard chat-block JSON into plain text for low-richness channels."""
+    if not isinstance(structured, dict):
+        return ""
+    raw_blocks = structured.get("blocks")
+    if not isinstance(raw_blocks, list):
+        return ""
+    parts = [part for raw in raw_blocks if (part := _plain_part(raw))]
+    return "\n\n".join(parts)

--- a/sidecars/shared/tests/test_structured_content.py
+++ b/sidecars/shared/tests/test_structured_content.py
@@ -11,6 +11,14 @@ class TestStructuredPlainText:
             {
                 "blocks": [
                     {"t": "p", "html": "hello &lt;world&gt;"},
+                    {"t": "h4", "html": "Plan"},
+                    {"t": "ul", "items": ["one", "two"]},
+                    {"t": "callout", "severity": "warn", "html": "careful"},
+                    {
+                        "t": "table",
+                        "head": ["name", {"v": "count", "num": True}],
+                        "rows": [["alpha", "2"]],
+                    },
                     {
                         "t": "code",
                         "cap": "python",
@@ -22,11 +30,30 @@ class TestStructuredPlainText:
                         "src": "https://example.com/chart.png",
                         "cap": "Chart",
                     },
+                    {"t": "mermaid", "source": "graph TD\nA-->B", "caption": "Flow"},
+                    {"t": "svg", "svg": "<svg><path /></svg>", "cap": "Icon"},
                     {
                         "t": "link",
                         "url": "https://example.com/post",
                         "title": "Post",
                         "meta": "example.com",
+                    },
+                    {
+                        "t": "voice",
+                        "src": "https://example.com/a.mp3",
+                        "transcript": "spoken memo",
+                        "via": "tts",
+                    },
+                    {
+                        "t": "attach",
+                        "name": "clip.mp4",
+                        "src": "https://example.com/clip.mp4",
+                        "kind": "video",
+                    },
+                    {
+                        "t": "video",
+                        "src": "https://example.com/demo.mp4",
+                        "cap": "Demo",
                     },
                     {"t": "fusion", "board_post_id": "p-123", "run_id": "fus-9"},
                 ]
@@ -34,10 +61,19 @@ class TestStructuredPlainText:
         )
 
         assert "hello <world>" in text
+        assert "## Plan" in text
+        assert "- one\n- two" in text
+        assert "Callout (warn): careful" in text
+        assert "name | count\nalpha | 2" in text
         assert '```python\nprint("<ok>")\n```' in text
         assert "Image: Chart" in text
         assert "https://example.com/chart.png" in text
+        assert "```mermaid\ngraph TD\nA-->B\n```" in text
+        assert "```svg\n<svg><path /></svg>\n```" in text
         assert "Post\nhttps://example.com/post\nexample.com" in text
+        assert "Audio (tts)\nspoken memo\nhttps://example.com/a.mp3" in text
+        assert "Attachment (video): clip.mp4\nhttps://example.com/clip.mp4" in text
+        assert "Video: Demo\nhttps://example.com/demo.mp4" in text
         assert "Fusion result\nboard_post_id: p-123\nrun_id: fus-9" in text
 
     def test_ignores_malformed_blocks(self) -> None:

--- a/sidecars/shared/tests/test_structured_content.py
+++ b/sidecars/shared/tests/test_structured_content.py
@@ -2,7 +2,36 @@
 
 from __future__ import annotations
 
-from gate_shared import GateResponse, response_text, structured_plain_text
+from gate_shared import (
+    GateResponse,
+    SUPPORTED_BLOCK_TYPES,
+    response_text,
+    structured_plain_text,
+)
+
+
+def test_supported_block_types_match_server_contract() -> None:
+    # Keep this in sync with keeper_chat_blocks.ml / keeper-chat-history.ts.
+    # "video" is intentionally absent as a top-level block kind; video files are
+    # represented as attachments with kind="video".
+    assert SUPPORTED_BLOCK_TYPES == frozenset(
+        {
+            "p",
+            "h4",
+            "ul",
+            "callout",
+            "table",
+            "image",
+            "code",
+            "mermaid",
+            "svg",
+            "link",
+            "voice",
+            "audio",
+            "attach",
+            "fusion",
+        }
+    )
 
 
 class TestStructuredPlainText:
@@ -50,11 +79,6 @@ class TestStructuredPlainText:
                         "src": "https://example.com/clip.mp4",
                         "kind": "video",
                     },
-                    {
-                        "t": "video",
-                        "src": "https://example.com/demo.mp4",
-                        "cap": "Demo",
-                    },
                     {"t": "fusion", "board_post_id": "p-123", "run_id": "fus-9"},
                 ]
             }
@@ -73,7 +97,6 @@ class TestStructuredPlainText:
         assert "Post\nhttps://example.com/post\nexample.com" in text
         assert "Audio (tts)\nspoken memo\nhttps://example.com/a.mp3" in text
         assert "Attachment (video): clip.mp4\nhttps://example.com/clip.mp4" in text
-        assert "Video: Demo\nhttps://example.com/demo.mp4" in text
         assert "Fusion result\nboard_post_id: p-123\nrun_id: fus-9" in text
 
     def test_ignores_malformed_blocks(self) -> None:

--- a/sidecars/shared/tests/test_structured_content.py
+++ b/sidecars/shared/tests/test_structured_content.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from gate_shared import structured_plain_text
+from gate_shared import GateResponse, response_text, structured_plain_text
 
 
 class TestStructuredPlainText:
@@ -81,3 +81,33 @@ class TestStructuredPlainText:
 
     def test_rejects_missing_blocks_array(self) -> None:
         assert structured_plain_text({"blocks": "bad"}) == ""
+
+
+class TestResponseText:
+    def test_prefers_structured_text_when_reply_is_empty(self) -> None:
+        response = GateResponse(
+            ok=True,
+            keeper_name="sangsu",
+            reply="",
+            model_used="",
+            duration_ms=0,
+            tokens_used=0,
+            error="",
+            structured={"blocks": [{"t": "p", "html": "approved"}]},
+        )
+
+        assert response_text(response) == "approved"
+
+    def test_falls_back_to_reply_without_structured_text(self) -> None:
+        response = GateResponse(
+            ok=True,
+            keeper_name="sangsu",
+            reply="plain reply",
+            model_used="",
+            duration_ms=0,
+            tokens_used=0,
+            error="",
+            structured=None,
+        )
+
+        assert response_text(response) == "plain reply"

--- a/sidecars/shared/tests/test_structured_content.py
+++ b/sidecars/shared/tests/test_structured_content.py
@@ -1,0 +1,47 @@
+"""Tests for shared structured GateResponse content projections."""
+
+from __future__ import annotations
+
+from gate_shared import structured_plain_text
+
+
+class TestStructuredPlainText:
+    def test_projects_dashboard_block_shapes(self) -> None:
+        text = structured_plain_text(
+            {
+                "blocks": [
+                    {"t": "p", "html": "hello &lt;world&gt;"},
+                    {
+                        "t": "code",
+                        "cap": "python",
+                        "html": "print(&quot;fallback&quot;)",
+                        "source": 'print("<ok>")',
+                    },
+                    {
+                        "t": "image",
+                        "src": "https://example.com/chart.png",
+                        "cap": "Chart",
+                    },
+                    {
+                        "t": "link",
+                        "url": "https://example.com/post",
+                        "title": "Post",
+                        "meta": "example.com",
+                    },
+                    {"t": "fusion", "board_post_id": "p-123", "run_id": "fus-9"},
+                ]
+            }
+        )
+
+        assert "hello <world>" in text
+        assert '```python\nprint("<ok>")\n```' in text
+        assert "Image: Chart" in text
+        assert "https://example.com/chart.png" in text
+        assert "Post\nhttps://example.com/post\nexample.com" in text
+        assert "Fusion result\nboard_post_id: p-123\nrun_id: fus-9" in text
+
+    def test_ignores_malformed_blocks(self) -> None:
+        assert structured_plain_text({"blocks": [{"t": "image"}]}) == ""
+
+    def test_rejects_missing_blocks_array(self) -> None:
+        assert structured_plain_text({"blocks": "bad"}) == ""

--- a/sidecars/slack-bot/src/bot.py
+++ b/sidecars/slack-bot/src/bot.py
@@ -265,6 +265,7 @@ class SlackGateBot:
                 model_used=response.model_used,
                 duration_ms=response.duration_ms,
                 tokens_used=response.tokens_used,
+                structured=response.structured,
             )
             text = fallback_text(reply)
             if thinking_ts:

--- a/sidecars/slack-bot/src/bot.py
+++ b/sidecars/slack-bot/src/bot.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from gate_shared import response_text
 from gate_shared.bindings_store import load_bindings, save_bindings
 from gate_shared.status_store import ConnectorRuntimeStatus, StatusStore
 
@@ -257,7 +258,8 @@ class SlackGateBot:
         thinking_ts: str,
     ) -> None:
         """Process gate response and update the thinking message."""
-        if response.ok and response.reply:
+        rendered_text = strip_state_blocks(response_text(response))
+        if response.ok and rendered_text:
             reply = strip_state_blocks(response.reply)
             blocks = response_blocks(
                 reply,
@@ -267,7 +269,7 @@ class SlackGateBot:
                 tokens_used=response.tokens_used,
                 structured=response.structured,
             )
-            text = fallback_text(reply)
+            text = fallback_text(rendered_text)
             if thinking_ts:
                 try:
                     app.client.chat_update(

--- a/sidecars/slack-bot/src/formatters.py
+++ b/sidecars/slack-bot/src/formatters.py
@@ -6,6 +6,7 @@ Strips [STATE] blocks and handles message length limits.
 
 from __future__ import annotations
 
+import html
 import re
 from typing import Any
 
@@ -13,6 +14,10 @@ SLACK_MESSAGE_LIMIT = 4000
 SLACK_MAX_BLOCKS = 50
 SLACK_BLOCK_TEXT_LIMIT = 3000
 TRUNCATION_NOTICE = "\n[truncated: Slack block limit]"
+STRUCTURED_TRUNCATION_TEMPLATE = (
+    ":warning: {count} structured block(s) omitted because Slack allows "
+    f"at most {SLACK_MAX_BLOCKS} blocks per message."
+)
 
 _RE_STATE_BLOCK = re.compile(
     r"\[STATE\].*?(?:\[/STATE\]|$)", re.DOTALL
@@ -106,22 +111,128 @@ def _append_truncation_notice(text: str) -> str:
     return text[:keep] + TRUNCATION_NOTICE
 
 
+def _structured_truncation_notice(omitted: int) -> dict[str, Any]:
+    return _section_block(
+        escape_mrkdwn_text(STRUCTURED_TRUNCATION_TEMPLATE.format(count=omitted))
+    )
+
+
+def _structured_text(value: Any) -> str:
+    return html.unescape(str(value)) if isinstance(value, str) else ""
+
+
+def _structured_raw_text(value: Any) -> str:
+    return str(value) if isinstance(value, str) else ""
+
+
+def _link_block(url: str, title: str, meta: str = "") -> dict[str, Any]:
+    label = escape_mrkdwn_text(title or url)
+    escaped_url = escape_mrkdwn_text(url)
+    suffix = f"\n{escape_mrkdwn_text(meta)}" if meta else ""
+    return _section_block(f"*<{escaped_url}|{label}>*{suffix}")
+
+
+def _image_block(url: str, caption: str = "") -> dict[str, Any]:
+    alt_text = caption or "image"
+    return {
+        "type": "image",
+        "image_url": url,
+        "alt_text": alt_text[:SLACK_BLOCK_TEXT_LIMIT],
+    }
+
+
+def _fusion_block(board_post_id: str, run_id: str = "") -> dict[str, Any]:
+    lines = ["*Fusion result*", f"board_post_id: {escape_mrkdwn_text(board_post_id)}"]
+    if run_id:
+        lines.append(f"run_id: {escape_mrkdwn_text(run_id)}")
+    return _section_block("\n".join(lines))
+
+
+def _code_block(source: str, cap: str = "") -> dict[str, Any]:
+    title = f"*Code:* `{escape_mrkdwn_text(cap)}`\n" if cap else ""
+    body = escape_mrkdwn_text(source)
+    return _section_block(f"{title}```\n{body}\n```")
+
+
+def _slack_block_from_structured(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    block_type = raw.get("t")
+    if block_type == "p":
+        text = _structured_text(raw.get("html"))
+        if not text:
+            return None
+        return _section_block(escape_mrkdwn_text(text))
+    if block_type == "image":
+        src = _structured_text(raw.get("src")).strip()
+        if not src:
+            return None
+        return _image_block(src, _structured_text(raw.get("cap")))
+    if block_type == "code":
+        source = _structured_raw_text(raw.get("source")) or _structured_text(raw.get("html"))
+        if not source:
+            return None
+        return _code_block(source, _structured_raw_text(raw.get("cap")).strip())
+    if block_type == "link":
+        url = _structured_text(raw.get("url")).strip()
+        if not url:
+            return None
+        title = _structured_text(raw.get("title")).strip() or url
+        meta = _structured_text(raw.get("meta")).strip()
+        return _link_block(url, title, meta)
+    if block_type == "fusion":
+        board_post_id = _structured_text(raw.get("board_post_id")).strip()
+        if not board_post_id:
+            return None
+        return _fusion_block(board_post_id, _structured_text(raw.get("run_id")).strip())
+    return None
+
+
+def structured_response_blocks(structured: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Project GateResponse structured chat blocks into Slack Block Kit blocks."""
+    if not isinstance(structured, dict):
+        return []
+    raw_blocks = structured.get("blocks")
+    if not isinstance(raw_blocks, list):
+        return []
+    blocks: list[dict[str, Any]] = []
+    for raw in raw_blocks:
+        block = _slack_block_from_structured(raw)
+        if block is not None:
+            blocks.append(block)
+    return blocks
+
+
+def _limit_blocks(blocks: list[dict[str, Any]], budget: int) -> list[dict[str, Any]]:
+    if budget <= 0:
+        return []
+    if len(blocks) <= budget:
+        return blocks
+    keep = max(0, budget - 1)
+    omitted = len(blocks) - keep
+    return blocks[:keep] + [_structured_truncation_notice(omitted)]
+
+
 def response_blocks(
     text: str,
     keeper_name: str = "",
     model_used: str = "",
     duration_ms: int = 0,
     tokens_used: int = 0,
+    structured: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Build Slack Block Kit blocks for a keeper response."""
     ctx = format_context_block(keeper_name, model_used, duration_ms, tokens_used)
-    text_budget = SLACK_MAX_BLOCKS - (1 if ctx is not None else 0)
-    chunks = chunk_text(escape_mrkdwn_text(text), limit=SLACK_BLOCK_TEXT_LIMIT)
-    if len(chunks) > text_budget:
-        chunks = chunks[:text_budget]
-        chunks[-1] = _append_truncation_notice(chunks[-1])
-
-    blocks: list[dict[str, Any]] = [_section_block(chunk) for chunk in chunks]
+    block_budget = SLACK_MAX_BLOCKS - (1 if ctx is not None else 0)
+    structured_blocks = structured_response_blocks(structured)
+    if structured_blocks:
+        blocks = _limit_blocks(structured_blocks, block_budget)
+    else:
+        chunks = chunk_text(escape_mrkdwn_text(text), limit=SLACK_BLOCK_TEXT_LIMIT)
+        if len(chunks) > block_budget:
+            chunks = chunks[:block_budget]
+            chunks[-1] = _append_truncation_notice(chunks[-1])
+        blocks = [_section_block(chunk) for chunk in chunks]
     if ctx is not None:
         blocks.append(ctx)
     return blocks

--- a/sidecars/slack-bot/src/formatters.py
+++ b/sidecars/slack-bot/src/formatters.py
@@ -154,6 +154,91 @@ def _code_block(source: str, cap: str = "") -> dict[str, Any]:
     return _section_block(f"{title}```\n{body}\n```")
 
 
+def _structured_list_block(raw: dict[str, Any]) -> dict[str, Any] | None:
+    items = raw.get("items")
+    if not isinstance(items, list):
+        return None
+    lines = [
+        f"- {escape_mrkdwn_text(_structured_text(item).strip())}"
+        for item in items
+        if _structured_text(item).strip()
+    ]
+    if not lines:
+        return None
+    return _section_block("\n".join(lines))
+
+
+def _structured_table_cell(raw: Any) -> str:
+    if isinstance(raw, dict):
+        return _structured_text(raw.get("v")).strip()
+    return _structured_text(raw).strip()
+
+
+def _structured_table_block(raw: dict[str, Any]) -> dict[str, Any] | None:
+    head = raw.get("head")
+    rows = raw.get("rows")
+    if not isinstance(head, list) or not isinstance(rows, list):
+        return None
+    rendered_rows = [[_structured_table_cell(cell) for cell in head]]
+    for row in rows:
+        if isinstance(row, list):
+            rendered_rows.append([_structured_table_cell(cell) for cell in row])
+    if not any(any(cell for cell in row) for row in rendered_rows):
+        return None
+    body = "\n".join(" | ".join(row) for row in rendered_rows)
+    return _section_block(f"```\n{escape_mrkdwn_text(body)}\n```")
+
+
+def _callout_block(raw: dict[str, Any]) -> dict[str, Any] | None:
+    body = _structured_text(raw.get("html")).strip()
+    if not body:
+        return None
+    severity = _structured_text(raw.get("severity")).strip()
+    label = f"*Callout ({escape_mrkdwn_text(severity)}):*" if severity else "*Callout:*"
+    return _section_block(f"{label} {escape_mrkdwn_text(body)}")
+
+
+def _voice_block(raw: dict[str, Any]) -> dict[str, Any] | None:
+    src = _structured_text(raw.get("src")).strip()
+    transcript = _structured_text(raw.get("transcript")).strip()
+    via = _structured_text(raw.get("via")).strip()
+    if not src and not transcript:
+        return None
+    label = f"*Audio ({escape_mrkdwn_text(via)}):*" if via else "*Audio:*"
+    lines = [label]
+    if transcript:
+        lines.append(escape_mrkdwn_text(transcript))
+    if src:
+        lines.append(escape_mrkdwn_text(src))
+    return _section_block("\n".join(lines))
+
+
+def _attach_block(raw: dict[str, Any]) -> dict[str, Any] | None:
+    name = _structured_text(raw.get("name")).strip()
+    src = _structured_text(raw.get("src")).strip()
+    kind = _structured_text(raw.get("kind")).strip()
+    if not name and not src:
+        return None
+    label = "Attachment"
+    if kind:
+        label = f"Attachment ({escape_mrkdwn_text(kind)})"
+    lines = [f"*{label}:* {escape_mrkdwn_text(name or src)}"]
+    if src and src != name:
+        lines.append(escape_mrkdwn_text(src))
+    return _section_block("\n".join(lines))
+
+
+def _video_block(raw: dict[str, Any]) -> dict[str, Any] | None:
+    src = _structured_text(raw.get("src")).strip()
+    caption = _structured_text(raw.get("cap")).strip() or _structured_text(raw.get("name")).strip()
+    if not src and not caption:
+        return None
+    lines = [f"*Video:* {escape_mrkdwn_text(caption or src)}"]
+    if src and src != caption:
+        lines.append(escape_mrkdwn_text(src))
+    return _section_block("\n".join(lines))
+
+
 def _slack_block_from_structured(raw: Any) -> dict[str, Any] | None:
     if not isinstance(raw, dict):
         return None
@@ -163,6 +248,17 @@ def _slack_block_from_structured(raw: Any) -> dict[str, Any] | None:
         if not text:
             return None
         return _section_block(escape_mrkdwn_text(text))
+    if block_type == "h4":
+        text = _structured_text(raw.get("html")).strip()
+        if not text:
+            return None
+        return _section_block(f"*{escape_mrkdwn_text(text)}*")
+    if block_type == "ul":
+        return _structured_list_block(raw)
+    if block_type == "callout":
+        return _callout_block(raw)
+    if block_type == "table":
+        return _structured_table_block(raw)
     if block_type == "image":
         src = _structured_text(raw.get("src")).strip()
         if not src:
@@ -173,6 +269,16 @@ def _slack_block_from_structured(raw: Any) -> dict[str, Any] | None:
         if not source:
             return None
         return _code_block(source, _structured_raw_text(raw.get("cap")).strip())
+    if block_type == "mermaid":
+        source = _structured_raw_text(raw.get("source"))
+        if not source:
+            return None
+        return _code_block(source, "mermaid")
+    if block_type == "svg":
+        source = _structured_raw_text(raw.get("svg"))
+        if not source:
+            return None
+        return _code_block(source, "svg")
     if block_type == "link":
         url = _structured_text(raw.get("url")).strip()
         if not url:
@@ -185,6 +291,12 @@ def _slack_block_from_structured(raw: Any) -> dict[str, Any] | None:
         if not board_post_id:
             return None
         return _fusion_block(board_post_id, _structured_text(raw.get("run_id")).strip())
+    if block_type in ("voice", "audio"):
+        return _voice_block(raw)
+    if block_type == "attach":
+        return _attach_block(raw)
+    if block_type == "video":
+        return _video_block(raw)
     return None
 
 

--- a/sidecars/slack-bot/tests/test_bot_structured_response.py
+++ b/sidecars/slack-bot/tests/test_bot_structured_response.py
@@ -1,0 +1,88 @@
+"""Bot-level tests for Slack structured GateResponse dispatch."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import Any, cast
+
+_sidecars_root = Path(__file__).resolve().parents[2]
+_shared_root = _sidecars_root / "shared"
+if str(_shared_root) not in sys.path:
+    sys.path.insert(0, str(_shared_root))
+
+_slack_bolt = types.ModuleType("slack_bolt")
+_socket_mode = types.ModuleType("slack_bolt.adapter.socket_mode")
+
+
+class _AppStub:
+    pass
+
+
+class _SocketModeHandlerStub:
+    pass
+
+
+setattr(_slack_bolt, "App", _AppStub)
+setattr(_socket_mode, "SocketModeHandler", _SocketModeHandlerStub)
+sys.modules.setdefault("slack_bolt", _slack_bolt)
+sys.modules.setdefault("slack_bolt.adapter", types.ModuleType("slack_bolt.adapter"))
+sys.modules.setdefault("slack_bolt.adapter.socket_mode", _socket_mode)
+
+_config = types.ModuleType("src.config")
+setattr(_config, "get_config", lambda: types.SimpleNamespace())
+sys.modules.setdefault("src.config", _config)
+
+from src.bot import SlackGateBot  # noqa: E402
+from src.gate_client import GateResponse  # noqa: E402
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.updates: list[dict[str, Any]] = []
+
+    def chat_update(self, **kwargs: Any) -> None:
+        self.updates.append(kwargs)
+
+
+class _App:
+    def __init__(self) -> None:
+        self.client = _Client()
+
+
+def _bot() -> SlackGateBot:
+    bot = cast(Any, SlackGateBot.__new__(SlackGateBot))
+    bot._messages_processed = 0
+    bot._messages_failed = 0
+    bot._last_message_at = ""
+    return cast(SlackGateBot, bot)
+
+
+def test_handle_response_sends_structured_only_success() -> None:
+    bot = _bot()
+    app = _App()
+    say_calls: list[dict[str, Any]] = []
+    response = GateResponse(
+        ok=True,
+        keeper_name="sangsu",
+        reply="",
+        model_used="",
+        duration_ms=0,
+        tokens_used=0,
+        error="",
+        structured={"blocks": [{"t": "p", "html": "approved"}]},
+    )
+
+    bot._handle_response(
+        response=response,
+        say=lambda **kwargs: say_calls.append(kwargs),
+        app=app,
+        channel_id="C123",
+        thinking_ts="123.456",
+    )
+
+    assert say_calls == []
+    assert app.client.updates[0]["text"] == "approved"
+    assert app.client.updates[0]["blocks"][0]["text"]["text"] == "approved"
+    assert bot._messages_processed == 1

--- a/sidecars/slack-bot/tests/test_formatters.py
+++ b/sidecars/slack-bot/tests/test_formatters.py
@@ -190,3 +190,49 @@ class TestStructuredResponseBlocks:
         assert blocks[2]["alt_text"] == "image"
         assert "*<https://example.com|Example>*" in blocks[3]["text"]["text"]
         assert "p-abc" in blocks[4]["text"]["text"]
+
+    def test_projects_extended_dashboard_block_shapes(self) -> None:
+        blocks = structured_response_blocks(
+            {
+                "blocks": [
+                    {"t": "h4", "html": "Plan"},
+                    {"t": "ul", "items": ["one", "two"]},
+                    {"t": "callout", "severity": "warn", "html": "careful"},
+                    {
+                        "t": "table",
+                        "head": ["name", {"v": "count", "num": True}],
+                        "rows": [["alpha", "2"]],
+                    },
+                    {"t": "mermaid", "source": "graph TD\nA-->B"},
+                    {"t": "svg", "svg": "<svg><path /></svg>"},
+                    {
+                        "t": "voice",
+                        "src": "https://example.com/a.mp3",
+                        "transcript": "spoken memo",
+                        "via": "tts",
+                    },
+                    {
+                        "t": "attach",
+                        "name": "clip.mp4",
+                        "src": "https://example.com/clip.mp4",
+                        "kind": "video",
+                    },
+                    {
+                        "t": "video",
+                        "src": "https://example.com/demo.mp4",
+                        "cap": "Demo",
+                    },
+                ]
+            }
+        )
+
+        assert len(blocks) == 9
+        assert blocks[0]["text"]["text"] == "*Plan*"
+        assert "- one\n- two" in blocks[1]["text"]["text"]
+        assert "*Callout (warn):* careful" in blocks[2]["text"]["text"]
+        assert "name | count\nalpha | 2" in blocks[3]["text"]["text"]
+        assert "*Code:* `mermaid`" in blocks[4]["text"]["text"]
+        assert "*Code:* `svg`" in blocks[5]["text"]["text"]
+        assert "*Audio (tts):*" in blocks[6]["text"]["text"]
+        assert "Attachment (video)" in blocks[7]["text"]["text"]
+        assert "*Video:* Demo" in blocks[8]["text"]["text"]

--- a/sidecars/slack-bot/tests/test_formatters.py
+++ b/sidecars/slack-bot/tests/test_formatters.py
@@ -10,6 +10,7 @@ from src.formatters import (
     fallback_text,
     format_context_block,
     response_blocks,
+    structured_response_blocks,
     strip_state_blocks,
 )
 
@@ -115,3 +116,77 @@ class TestResponseBlocks:
         assert "[truncated: Slack block limit]" in blocks[-2]["text"]["text"]
         for block in blocks[:-1]:
             assert len(block["text"]["text"]) <= SLACK_BLOCK_TEXT_LIMIT
+
+    def test_uses_structured_blocks_when_present(self) -> None:
+        structured = {
+            "blocks": [
+                {"t": "p", "html": "hello &lt;world&gt;"},
+                {
+                    "t": "code",
+                    "cap": "python",
+                    "html": "print(&quot;fallback&quot;)",
+                    "source": 'print("&lt;<ok>")',
+                },
+                {"t": "image", "src": "https://example.com/chart.png", "cap": "Chart"},
+                {
+                    "t": "link",
+                    "url": "https://example.com/post?a=1&b=2",
+                    "title": "Post <one>",
+                    "meta": "example.com",
+                },
+                {"t": "fusion", "board_post_id": "p-123", "run_id": "fus-9"},
+            ]
+        }
+        blocks = response_blocks(
+            "fallback",
+            keeper_name="sangsu",
+            structured=structured,
+        )
+
+        assert len(blocks) == 6
+        assert blocks[0]["text"]["text"] == "hello &lt;world&gt;"
+        assert "*Code:* `python`" in blocks[1]["text"]["text"]
+        assert 'print("&amp;lt;&lt;ok&gt;")' in blocks[1]["text"]["text"]
+        assert blocks[2]["type"] == "image"
+        assert blocks[2]["image_url"] == "https://example.com/chart.png"
+        assert "Post &lt;one&gt;" in blocks[3]["text"]["text"]
+        assert "a=1&amp;b=2" in blocks[3]["text"]["text"]
+        assert "board_post_id: p-123" in blocks[4]["text"]["text"]
+        assert blocks[5]["type"] == "context"
+
+    def test_malformed_structured_blocks_fall_back_to_text(self) -> None:
+        blocks = response_blocks("<fallback>", structured={"blocks": [{"t": "image"}]})
+        assert len(blocks) == 1
+        assert blocks[0]["text"]["text"] == "&lt;fallback&gt;"
+
+
+class TestStructuredResponseBlocks:
+    def test_projects_known_dashboard_block_shapes(self) -> None:
+        blocks = structured_response_blocks(
+            {
+                "blocks": [
+                    {"t": "p", "html": "hello &amp; goodbye"},
+                    {"t": "code", "html": "a &lt; b"},
+                    {"t": "image", "src": "https://example.com/a.png"},
+                    {
+                        "t": "link",
+                        "url": "https://example.com",
+                        "title": "Example",
+                    },
+                    {"t": "fusion", "board_post_id": "p-abc"},
+                ]
+            }
+        )
+
+        assert [block["type"] for block in blocks] == [
+            "section",
+            "section",
+            "image",
+            "section",
+            "section",
+        ]
+        assert blocks[0]["text"]["text"] == "hello &amp; goodbye"
+        assert "a &lt; b" in blocks[1]["text"]["text"]
+        assert blocks[2]["alt_text"] == "image"
+        assert "*<https://example.com|Example>*" in blocks[3]["text"]["text"]
+        assert "p-abc" in blocks[4]["text"]["text"]

--- a/sidecars/telegram-bot/src/bot.py
+++ b/sidecars/telegram-bot/src/bot.py
@@ -382,13 +382,26 @@ class TelegramGateBot:
             try:
                 await thinking_msg.edit_text(first_text, parse_mode=parse_mode)
             except Exception:
-                await update.effective_chat.send_message(first_text, parse_mode=parse_mode)
+                # HTML chunking is not tag-aware (chunk_text splits on
+                # newline/space at TELEGRAM_MESSAGE_LIMIT), so a chunk can land
+                # inside a tag/entity and Telegram rejects it with HTTP 400
+                # "can't parse entities". Degrade to plain text so the reply is
+                # never dropped instead of re-sending the same unparseable HTML.
+                await update.effective_chat.send_message(first_text, parse_mode=None)
 
             for i, chunk in enumerate(chunks[1:], 1):
                 msg_text = chunk
                 if footer and i == len(chunks) - 1:
                     msg_text = f"{chunk}\n\n{footer}"
-                await update.effective_chat.send_message(msg_text, parse_mode=parse_mode)
+                try:
+                    await update.effective_chat.send_message(
+                        msg_text, parse_mode=parse_mode
+                    )
+                except Exception:
+                    # Same tag-unaware chunking risk as above: fall back to
+                    # plain text so a parse error on one continuation chunk does
+                    # not drop the rest of the reply.
+                    await update.effective_chat.send_message(msg_text, parse_mode=None)
 
             self._messages_processed += 1
         elif response.error:

--- a/sidecars/telegram-bot/src/bot.py
+++ b/sidecars/telegram-bot/src/bot.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from gate_shared.bindings_store import load_bindings, save_bindings
+from gate_shared.structured_content import response_text
 from gate_shared.status_store import ConnectorRuntimeStatus, StatusStore
 
 from telegram import Message, Update
@@ -360,7 +361,7 @@ class TelegramGateBot:
             message_id=update.message.message_id,
         )
 
-        if response.ok and response.reply:
+        if response.ok and response_text(response):
             reply = strip_state_blocks(response.reply)
             rendered_reply, parse_mode = render_response_text(
                 reply,

--- a/sidecars/telegram-bot/src/bot.py
+++ b/sidecars/telegram-bot/src/bot.py
@@ -32,7 +32,13 @@ from telegram.ext import (
 )
 
 from .config import get_config
-from .formatters import chunk_text, format_footer, strip_state_blocks
+from .formatters import (
+    chunk_text,
+    format_footer,
+    format_footer_html,
+    render_response_text,
+    strip_state_blocks,
+)
 from .gate_client import GateClient
 
 logging.basicConfig(
@@ -356,28 +362,33 @@ class TelegramGateBot:
 
         if response.ok and response.reply:
             reply = strip_state_blocks(response.reply)
-            footer = format_footer(
+            rendered_reply, parse_mode = render_response_text(
+                reply,
+                response.structured,
+            )
+            footer_fn = format_footer_html if parse_mode == "HTML" else format_footer
+            footer = footer_fn(
                 keeper_name=response.keeper_name,
                 model_used=response.model_used,
                 duration_ms=response.duration_ms,
                 tokens_used=response.tokens_used,
             )
 
-            chunks = chunk_text(reply)
+            chunks = chunk_text(rendered_reply)
 
             first_text = chunks[0]
             if footer and len(chunks) == 1:
                 first_text = f"{first_text}\n\n{footer}"
             try:
-                await thinking_msg.edit_text(first_text)
+                await thinking_msg.edit_text(first_text, parse_mode=parse_mode)
             except Exception:
-                await update.effective_chat.send_message(first_text)
+                await update.effective_chat.send_message(first_text, parse_mode=parse_mode)
 
             for i, chunk in enumerate(chunks[1:], 1):
                 msg_text = chunk
                 if footer and i == len(chunks) - 1:
                     msg_text = f"{chunk}\n\n{footer}"
-                await update.effective_chat.send_message(msg_text)
+                await update.effective_chat.send_message(msg_text, parse_mode=parse_mode)
 
             self._messages_processed += 1
         elif response.error:

--- a/sidecars/telegram-bot/src/formatters.py
+++ b/sidecars/telegram-bot/src/formatters.py
@@ -107,6 +107,26 @@ def _html_link(url: str, label: str) -> str:
     return f'<a href="{safe_url}">{safe_label}</a>'
 
 
+def _structured_table_cell(raw: Any) -> str:
+    if isinstance(raw, dict):
+        return _structured_text(raw.get("v")).strip()
+    return _structured_text(raw).strip()
+
+
+def _structured_table_text(raw: dict[str, Any]) -> str:
+    head = raw.get("head")
+    rows = raw.get("rows")
+    if not isinstance(head, list) or not isinstance(rows, list):
+        return ""
+    rendered_rows = [[_structured_table_cell(cell) for cell in head]]
+    for row in rows:
+        if isinstance(row, list):
+            rendered_rows.append([_structured_table_cell(cell) for cell in row])
+    if not any(any(cell for cell in row) for row in rendered_rows):
+        return ""
+    return "\n".join(" | ".join(row) for row in rendered_rows)
+
+
 def _telegram_part_from_structured(raw: Any) -> str:
     if not isinstance(raw, dict):
         return ""
@@ -114,6 +134,29 @@ def _telegram_part_from_structured(raw: Any) -> str:
     if block_type == "p":
         text = html.unescape(_structured_text(raw.get("html")))
         return html.escape(text).strip()
+    if block_type == "h4":
+        text = html.unescape(_structured_text(raw.get("html"))).strip()
+        return f"<b>{html.escape(text)}</b>" if text else ""
+    if block_type == "ul":
+        items = raw.get("items")
+        if not isinstance(items, list):
+            return ""
+        lines = [
+            f"- {html.escape(html.unescape(_structured_text(item)).strip())}"
+            for item in items
+            if html.unescape(_structured_text(item)).strip()
+        ]
+        return "\n".join(lines)
+    if block_type == "callout":
+        body = html.unescape(_structured_text(raw.get("html"))).strip()
+        if not body:
+            return ""
+        severity = _structured_text(raw.get("severity")).strip()
+        label = f"Callout ({severity})" if severity else "Callout"
+        return f"<b>{html.escape(label)}:</b> {html.escape(body)}"
+    if block_type == "table":
+        table = _structured_table_text(raw)
+        return f"<pre>{html.escape(table)}</pre>" if table else ""
     if block_type == "image":
         src = _structured_text(raw.get("src")).strip()
         if not src:
@@ -128,6 +171,18 @@ def _telegram_part_from_structured(raw: Any) -> str:
             return ""
         cap = _structured_text(raw.get("cap")).strip()
         label = f"<b>Code: {html.escape(cap)}</b>\n" if cap else ""
+        return f"{label}<pre><code>{html.escape(source)}</code></pre>"
+    if block_type == "mermaid":
+        source = _structured_text(raw.get("source"))
+        if not source:
+            return ""
+        return f"<b>Mermaid</b>\n<pre><code>{html.escape(source)}</code></pre>"
+    if block_type == "svg":
+        source = _structured_text(raw.get("svg"))
+        if not source:
+            return ""
+        caption = _structured_text(raw.get("cap")).strip()
+        label = f"<b>SVG: {html.escape(caption)}</b>\n" if caption else "<b>SVG</b>\n"
         return f"{label}<pre><code>{html.escape(source)}</code></pre>"
     if block_type == "link":
         url = _structured_text(raw.get("url")).strip()
@@ -148,6 +203,39 @@ def _telegram_part_from_structured(raw: Any) -> str:
         ]
         if run_id:
             lines.append(f"run_id: <code>{html.escape(run_id)}</code>")
+        return "\n".join(lines)
+    if block_type in ("voice", "audio"):
+        src = _structured_text(raw.get("src")).strip()
+        transcript = _structured_text(raw.get("transcript")).strip()
+        via = _structured_text(raw.get("via")).strip()
+        if not src and not transcript:
+            return ""
+        label = f"Audio ({via})" if via else "Audio"
+        lines = [f"<b>{html.escape(label)}</b>"]
+        if transcript:
+            lines.append(html.escape(transcript))
+        if src:
+            lines.append(_html_link(src, src))
+        return "\n".join(lines)
+    if block_type == "attach":
+        name = _structured_text(raw.get("name")).strip()
+        src = _structured_text(raw.get("src")).strip()
+        kind = _structured_text(raw.get("kind")).strip()
+        if not name and not src:
+            return ""
+        label = f"Attachment ({kind})" if kind else "Attachment"
+        lines = [f"<b>{html.escape(label)}:</b> {html.escape(name or src)}"]
+        if src and src != name:
+            lines.append(_html_link(src, src))
+        return "\n".join(lines)
+    if block_type == "video":
+        src = _structured_text(raw.get("src")).strip()
+        caption = _structured_text(raw.get("cap")).strip() or _structured_text(raw.get("name")).strip()
+        if not src and not caption:
+            return ""
+        lines = [f"<b>Video:</b> {html.escape(caption or src)}"]
+        if src and src != caption:
+            lines.append(_html_link(src, src))
         return "\n".join(lines)
     return ""
 

--- a/sidecars/telegram-bot/src/formatters.py
+++ b/sidecars/telegram-bot/src/formatters.py
@@ -6,10 +6,11 @@ Strips [STATE] blocks and handles message length limits.
 
 from __future__ import annotations
 
+import html
 import re
-from collections.abc import Sequence
+from typing import Any
 
-from .config import TELEGRAM_MESSAGE_LIMIT
+TELEGRAM_MESSAGE_LIMIT = 4096
 
 _RE_STATE_BLOCK = re.compile(
     r"\[STATE\].*?(?:\[/STATE\]|$)", re.DOTALL
@@ -72,3 +73,106 @@ def format_footer(
     if not parts:
         return ""
     return f"_{'  |  '.join(parts)}_"
+
+
+def format_footer_html(
+    keeper_name: str,
+    model_used: str,
+    duration_ms: int,
+    tokens_used: int,
+) -> str:
+    """Format a compact footer for Telegram HTML parse mode."""
+    parts: list[str] = []
+    if keeper_name:
+        parts.append(keeper_name)
+    if duration_ms > 0:
+        secs = duration_ms / 1000.0
+        parts.append(f"{secs:.1f}s")
+    if model_used:
+        parts.append(model_used)
+    if tokens_used > 0:
+        parts.append(f"{tokens_used} tok")
+    if not parts:
+        return ""
+    return f"<i>{html.escape('  |  '.join(parts))}</i>"
+
+
+def _structured_text(value: Any) -> str:
+    return str(value) if isinstance(value, str) else ""
+
+
+def _html_link(url: str, label: str) -> str:
+    safe_url = html.escape(url, quote=True)
+    safe_label = html.escape(label or url)
+    return f'<a href="{safe_url}">{safe_label}</a>'
+
+
+def _telegram_part_from_structured(raw: Any) -> str:
+    if not isinstance(raw, dict):
+        return ""
+    block_type = raw.get("t")
+    if block_type == "p":
+        text = html.unescape(_structured_text(raw.get("html")))
+        return html.escape(text).strip()
+    if block_type == "image":
+        src = _structured_text(raw.get("src")).strip()
+        if not src:
+            return ""
+        caption = _structured_text(raw.get("cap")).strip() or "image"
+        return "Image: " + _html_link(src, caption)
+    if block_type == "code":
+        source = _structured_text(raw.get("source"))
+        if not source:
+            source = html.unescape(_structured_text(raw.get("html")))
+        if not source:
+            return ""
+        cap = _structured_text(raw.get("cap")).strip()
+        label = f"<b>Code: {html.escape(cap)}</b>\n" if cap else ""
+        return f"{label}<pre><code>{html.escape(source)}</code></pre>"
+    if block_type == "link":
+        url = _structured_text(raw.get("url")).strip()
+        if not url:
+            return ""
+        title = _structured_text(raw.get("title")).strip() or url
+        meta = _structured_text(raw.get("meta")).strip()
+        suffix = f"\n{html.escape(meta)}" if meta else ""
+        return _html_link(url, title) + suffix
+    if block_type == "fusion":
+        board_post_id = _structured_text(raw.get("board_post_id")).strip()
+        if not board_post_id:
+            return ""
+        run_id = _structured_text(raw.get("run_id")).strip()
+        lines = [
+            "<b>Fusion result</b>",
+            f"board_post_id: <code>{html.escape(board_post_id)}</code>",
+        ]
+        if run_id:
+            lines.append(f"run_id: <code>{html.escape(run_id)}</code>")
+        return "\n".join(lines)
+    return ""
+
+
+def structured_html_text(structured: dict[str, Any] | None) -> str:
+    """Project GateResponse structured chat blocks into Telegram HTML text."""
+    if not isinstance(structured, dict):
+        return ""
+    raw_blocks = structured.get("blocks")
+    if not isinstance(raw_blocks, list):
+        return ""
+    parts = [
+        part
+        for raw in raw_blocks
+        if (part := _telegram_part_from_structured(raw))
+    ]
+    return "\n\n".join(parts)
+
+
+def render_response_text(
+    text: str,
+    structured: dict[str, Any] | None = None,
+) -> tuple[str, str | None]:
+    """Return Telegram text plus parse mode for a keeper response."""
+    rendered = structured_html_text(structured)
+    if rendered:
+        return rendered, "HTML"
+    return text, None

--- a/sidecars/telegram-bot/src/formatters.py
+++ b/sidecars/telegram-bot/src/formatters.py
@@ -10,7 +10,7 @@ import html
 import re
 from typing import Any
 
-TELEGRAM_MESSAGE_LIMIT = 4096
+from .config import TELEGRAM_MESSAGE_LIMIT
 
 _RE_STATE_BLOCK = re.compile(
     r"\[STATE\].*?(?:\[/STATE\]|$)", re.DOTALL

--- a/sidecars/telegram-bot/tests/test_bot_structured_response.py
+++ b/sidecars/telegram-bot/tests/test_bot_structured_response.py
@@ -1,0 +1,129 @@
+"""Bot-level tests for Telegram structured GateResponse dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+_sidecars_root = Path(__file__).resolve().parents[2]
+_shared_root = _sidecars_root / "shared"
+if str(_shared_root) not in sys.path:
+    sys.path.insert(0, str(_shared_root))
+
+_telegram = types.ModuleType("telegram")
+_telegram_ext = types.ModuleType("telegram.ext")
+
+
+class _MessageStub:
+    pass
+
+
+class _UpdateStub:
+    pass
+
+
+class _ApplicationStub:
+    pass
+
+
+class _HandlerStub:
+    pass
+
+
+setattr(_telegram, "Message", _MessageStub)
+setattr(_telegram, "Update", _UpdateStub)
+setattr(_telegram_ext, "Application", _ApplicationStub)
+setattr(_telegram_ext, "CommandHandler", _HandlerStub)
+setattr(_telegram_ext, "ContextTypes", SimpleNamespace(DEFAULT_TYPE=object))
+setattr(_telegram_ext, "MessageHandler", _HandlerStub)
+setattr(_telegram_ext, "filters", SimpleNamespace(TEXT=object(), COMMAND=object()))
+sys.modules.setdefault("telegram", _telegram)
+sys.modules.setdefault("telegram.ext", _telegram_ext)
+
+_config = types.ModuleType("src.config")
+setattr(_config, "get_config", lambda: SimpleNamespace())
+setattr(_config, "TELEGRAM_MESSAGE_LIMIT", 4096)
+sys.modules.setdefault("src.config", _config)
+
+from src.bot import TelegramGateBot  # noqa: E402
+from src.gate_client import GateResponse  # noqa: E402
+
+
+class _ThinkingMessage:
+    def __init__(self) -> None:
+        self.edits: list[tuple[str, str | None]] = []
+
+    async def edit_text(self, text: str, parse_mode: str | None = None) -> None:
+        self.edits.append((text, parse_mode))
+
+
+class _Chat:
+    def __init__(self) -> None:
+        self.id = 42
+        self.thinking = _ThinkingMessage()
+        self.sent: list[tuple[str, str | None]] = []
+
+    async def send_message(
+        self,
+        text: str,
+        parse_mode: str | None = None,
+    ) -> _ThinkingMessage:
+        if text == "...":
+            return self.thinking
+        self.sent.append((text, parse_mode))
+        return self.thinking
+
+
+class _Gate:
+    async def send_telegram_message(self, **_kwargs: Any) -> GateResponse:
+        return GateResponse(
+            ok=True,
+            keeper_name="sangsu",
+            reply="",
+            model_used="",
+            duration_ms=0,
+            tokens_used=0,
+            error="",
+            structured={"blocks": [{"t": "p", "html": "approved"}]},
+        )
+
+
+def _bot() -> TelegramGateBot:
+    bot = cast(Any, TelegramGateBot.__new__(TelegramGateBot))
+    bot.cfg = SimpleNamespace(default_keeper="sangsu")
+    bot.gate = _Gate()
+    bot._bindings = {}
+    bot._messages_processed = 0
+    bot._messages_failed = 0
+    bot._last_message_at = ""
+
+    async def no_stream(
+        _update: object,
+        _keeper: str,
+        _text: str,
+        _thinking_msg: _ThinkingMessage,
+    ) -> bool:
+        return False
+
+    setattr(bot, "_stream_response", no_stream)
+    return cast(TelegramGateBot, bot)
+
+
+def test_handle_message_sends_structured_only_success() -> None:
+    bot = _bot()
+    chat = _Chat()
+    update = SimpleNamespace(
+        effective_chat=chat,
+        effective_user=SimpleNamespace(id=7, username="operator"),
+        message=SimpleNamespace(text="go", message_id=99),
+    )
+
+    asyncio.run(bot.handle_message(cast(Any, update), cast(Any, SimpleNamespace())))
+
+    assert chat.thinking.edits == [("approved\n\n<i>sangsu</i>", "HTML")]
+    assert chat.sent == []
+    assert bot._messages_processed == 1

--- a/sidecars/telegram-bot/tests/test_formatters.py
+++ b/sidecars/telegram-bot/tests/test_formatters.py
@@ -84,6 +84,14 @@ class TestStructuredHtmlText:
             {
                 "blocks": [
                     {"t": "p", "html": "hello &lt;world&gt;"},
+                    {"t": "h4", "html": "Plan"},
+                    {"t": "ul", "items": ["one", "two"]},
+                    {"t": "callout", "severity": "warn", "html": "careful"},
+                    {
+                        "t": "table",
+                        "head": ["name", {"v": "count", "num": True}],
+                        "rows": [["alpha", "2"]],
+                    },
                     {
                         "t": "code",
                         "cap": "python",
@@ -95,11 +103,30 @@ class TestStructuredHtmlText:
                         "src": "https://example.com/chart.png?a=1&b=2",
                         "cap": "Chart <A>",
                     },
+                    {"t": "mermaid", "source": "graph TD\nA-->B"},
+                    {"t": "svg", "svg": "<svg><path /></svg>", "cap": "Icon"},
                     {
                         "t": "link",
                         "url": "https://example.com/post",
                         "title": "Post <one>",
                         "meta": "example.com",
+                    },
+                    {
+                        "t": "voice",
+                        "src": "https://example.com/a.mp3",
+                        "transcript": "spoken memo",
+                        "via": "tts",
+                    },
+                    {
+                        "t": "attach",
+                        "name": "clip.mp4",
+                        "src": "https://example.com/clip.mp4",
+                        "kind": "video",
+                    },
+                    {
+                        "t": "video",
+                        "src": "https://example.com/demo.mp4",
+                        "cap": "Demo",
                     },
                     {"t": "fusion", "board_post_id": "p-123", "run_id": "fus-9"},
                 ]
@@ -107,13 +134,25 @@ class TestStructuredHtmlText:
         )
 
         assert "hello &lt;world&gt;" in result
+        assert "<b>Plan</b>" in result
+        assert "- one\n- two" in result
+        assert "<b>Callout (warn):</b> careful" in result
+        assert "<pre>name | count\nalpha | 2</pre>" in result
         assert "<b>Code: python</b>" in result
         assert '<pre><code>print(&quot;&lt;ok&gt;&quot;)</code></pre>' in result
         assert (
             'Image: <a href="https://example.com/chart.png?a=1&amp;b=2">'
             "Chart &lt;A&gt;</a>"
         ) in result
+        assert "<b>Mermaid</b>" in result
+        assert "graph TD\nA--&gt;B" in result
+        assert "<b>SVG: Icon</b>" in result
+        assert "&lt;svg&gt;&lt;path /&gt;&lt;/svg&gt;" in result
         assert '<a href="https://example.com/post">Post &lt;one&gt;</a>' in result
+        assert "<b>Audio (tts)</b>" in result
+        assert '<a href="https://example.com/a.mp3">https://example.com/a.mp3</a>' in result
+        assert "<b>Attachment (video):</b> clip.mp4" in result
+        assert "<b>Video:</b> Demo" in result
         assert "<b>Fusion result</b>" in result
         assert "board_post_id: <code>p-123</code>" in result
 

--- a/sidecars/telegram-bot/tests/test_formatters.py
+++ b/sidecars/telegram-bot/tests/test_formatters.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from src.formatters import chunk_text, format_footer, strip_state_blocks
+from src.formatters import (
+    chunk_text,
+    format_footer,
+    format_footer_html,
+    render_response_text,
+    strip_state_blocks,
+    structured_html_text,
+)
 
 
 class TestStripStateBlocks:
@@ -60,3 +67,70 @@ class TestFormatFooter:
         result = format_footer("sangsu", "", 1000, 0)
         assert "sangsu" in result
         assert "1.0s" in result
+
+
+class TestFormatFooterHtml:
+    def test_escapes_footer_fields(self) -> None:
+        result = format_footer_html("<keeper>", "qwen&sonnet", 1000, 2)
+        assert result == "<i>&lt;keeper&gt;  |  1.0s  |  qwen&amp;sonnet  |  2 tok</i>"
+
+    def test_empty_footer(self) -> None:
+        assert format_footer_html("", "", 0, 0) == ""
+
+
+class TestStructuredHtmlText:
+    def test_projects_dashboard_blocks_to_telegram_html(self) -> None:
+        result = structured_html_text(
+            {
+                "blocks": [
+                    {"t": "p", "html": "hello &lt;world&gt;"},
+                    {
+                        "t": "code",
+                        "cap": "python",
+                        "html": "print(&quot;fallback&quot;)",
+                        "source": 'print("<ok>")',
+                    },
+                    {
+                        "t": "image",
+                        "src": "https://example.com/chart.png?a=1&b=2",
+                        "cap": "Chart <A>",
+                    },
+                    {
+                        "t": "link",
+                        "url": "https://example.com/post",
+                        "title": "Post <one>",
+                        "meta": "example.com",
+                    },
+                    {"t": "fusion", "board_post_id": "p-123", "run_id": "fus-9"},
+                ]
+            }
+        )
+
+        assert "hello &lt;world&gt;" in result
+        assert "<b>Code: python</b>" in result
+        assert '<pre><code>print(&quot;&lt;ok&gt;&quot;)</code></pre>' in result
+        assert (
+            'Image: <a href="https://example.com/chart.png?a=1&amp;b=2">'
+            "Chart &lt;A&gt;</a>"
+        ) in result
+        assert '<a href="https://example.com/post">Post &lt;one&gt;</a>' in result
+        assert "<b>Fusion result</b>" in result
+        assert "board_post_id: <code>p-123</code>" in result
+
+    def test_ignores_malformed_blocks(self) -> None:
+        assert structured_html_text({"blocks": [{"t": "image"}]}) == ""
+
+
+class TestRenderResponseText:
+    def test_returns_html_mode_for_structured_blocks(self) -> None:
+        text, parse_mode = render_response_text(
+            "fallback",
+            {"blocks": [{"t": "p", "html": "structured"}]},
+        )
+        assert text == "structured"
+        assert parse_mode == "HTML"
+
+    def test_falls_back_to_plain_reply(self) -> None:
+        text, parse_mode = render_response_text("plain <reply>", None)
+        assert text == "plain <reply>"
+        assert parse_mode is None

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -97,6 +97,19 @@ let test_code_fence_preserves_markdown_image_literal () =
     ]
     (blocks_to_json_list blocks)
 
+let test_mermaid_fence_becomes_mermaid_block () =
+  let blocks = B.parse_text_to_blocks "```mermaid\ngraph TD\nA-->B\n```" in
+  Alcotest.(check (list yojson_testable))
+    "mermaid block"
+    [
+      `Assoc
+        [
+          ("t", `String "mermaid");
+          ("source", `String "graph TD\nA-->B");
+        ];
+    ]
+    (blocks_to_json_list blocks)
+
 let test_multiple_images_and_text_lines () =
   let blocks = B.parse_text_to_blocks "intro\n![a](https://x.com/1.jpg)\nhttps://x.com/2.gif\noutro" in
   Alcotest.(check (list yojson_testable))
@@ -160,8 +173,58 @@ let test_code_block_roundtrip () =
     Alcotest.(check (list yojson_testable))
       "code roundtrip json"
       (blocks_to_json_list original)
-      (blocks_to_json_list parsed)
+    (blocks_to_json_list parsed)
   | None -> Alcotest.fail "blocks_of_yojson rejected valid code block"
+
+let test_dashboard_rich_blocks_roundtrip () =
+  let original =
+    [
+      B.Heading { html = "Plan" };
+      B.Unordered_list { items = [ "one"; "two" ] };
+      B.Callout { severity = Some "warn"; html = "check this" };
+      B.Table
+        {
+          head =
+            [
+              B.Cell_text "name";
+              B.Cell_value { v = "count"; num = Some true; muted = None };
+            ];
+          rows = [ [ B.Cell_text "alpha"; B.Cell_text "2" ] ];
+        };
+      B.Mermaid { source = "graph TD\nA-->B"; caption = Some "flow" };
+      B.Svg { svg = "<svg></svg>"; cap = Some "mark" };
+      B.Voice
+        {
+          secs = Some 3.5;
+          wave = Some [ 0.1; 0.8 ];
+          via = Some "tts";
+          size = Some "24 KB";
+          transcript = Some "hello";
+          src = Some "https://example.com/a.mp3";
+        };
+      B.Attach
+        {
+          name = "clip.mp4";
+          dims = Some "1920x1080";
+          src = Some "https://example.com/clip.mp4";
+          svg = None;
+          ph = None;
+          via = Some "gate";
+          size = Some "8 MB";
+          data = None;
+          mime_type = Some "video/mp4";
+          size_bytes = Some 42;
+          kind = Some "video";
+        };
+    ]
+  in
+  match B.blocks_of_yojson (B.blocks_to_yojson original) with
+  | Some parsed ->
+    Alcotest.(check (list yojson_testable))
+      "dashboard rich block json"
+      (blocks_to_json_list original)
+      (blocks_to_json_list parsed)
+  | None -> Alcotest.fail "blocks_of_yojson rejected valid dashboard rich blocks"
 
 let test_non_http_markdown_image_becomes_text () =
   let blocks = B.parse_text_to_blocks "before ![alt](ftp://example.com/a.png) after" in
@@ -256,6 +319,8 @@ let () =
             test_code_fence_becomes_code_block;
           Alcotest.test_case "code fence preserves markdown image literal" `Quick
             test_code_fence_preserves_markdown_image_literal;
+          Alcotest.test_case "mermaid fence becomes mermaid block" `Quick
+            test_mermaid_fence_becomes_mermaid_block;
           Alcotest.test_case "multiple images and text lines" `Quick
             test_multiple_images_and_text_lines;
           Alcotest.test_case "empty lines ignored" `Quick
@@ -277,6 +342,8 @@ let () =
             test_blocks_of_yojson_roundtrip;
           Alcotest.test_case "code block roundtrip" `Quick
             test_code_block_roundtrip;
+          Alcotest.test_case "dashboard rich blocks roundtrip" `Quick
+            test_dashboard_rich_blocks_roundtrip;
           Alcotest.test_case "blocks_of_yojson rejects malformed" `Quick
             test_blocks_of_yojson_rejects_malformed;
           Alcotest.test_case "fusion block roundtrip" `Quick

--- a/test/test_keeper_chat_blocks.ml
+++ b/test/test_keeper_chat_blocks.ml
@@ -63,6 +63,40 @@ let test_inline_url_stays_in_text () =
     [ `Assoc [ ("t", `String "p"); ("html", `String "See https://example.com for more.") ] ]
     (blocks_to_json_list blocks)
 
+let test_code_fence_becomes_code_block () =
+  let blocks = B.parse_text_to_blocks "before\n```OCaml\nlet x = 1 < 2\n```\nafter" in
+  Alcotest.(check (list yojson_testable))
+    "code block with surrounding text"
+    [
+      `Assoc [ ("t", `String "p"); ("html", `String "before") ];
+      `Assoc
+        [
+          ("t", `String "code");
+          ("html", `String "let x = 1 &lt; 2");
+          ("cap", `String "ocaml");
+          ("source", `String "let x = 1 < 2");
+        ];
+      `Assoc [ ("t", `String "p"); ("html", `String "after") ];
+    ]
+    (blocks_to_json_list blocks)
+
+let test_code_fence_preserves_markdown_image_literal () =
+  let blocks =
+    B.parse_text_to_blocks "```md\n![alt](https://example.com/a.png)\n```"
+  in
+  Alcotest.(check (list yojson_testable))
+    "image syntax inside code stays code"
+    [
+      `Assoc
+        [
+          ("t", `String "code");
+          ("html", `String "![alt](https://example.com/a.png)");
+          ("cap", `String "md");
+          ("source", `String "![alt](https://example.com/a.png)");
+        ];
+    ]
+    (blocks_to_json_list blocks)
+
 let test_multiple_images_and_text_lines () =
   let blocks = B.parse_text_to_blocks "intro\n![a](https://x.com/1.jpg)\nhttps://x.com/2.gif\noutro" in
   Alcotest.(check (list yojson_testable))
@@ -116,6 +150,18 @@ let test_blocks_of_yojson_roundtrip () =
       (blocks_to_json_list original)
       (blocks_to_json_list parsed)
   | None -> Alcotest.fail "blocks_of_yojson rejected valid blocks"
+
+let test_code_block_roundtrip () =
+  let original =
+    [ B.Code { cap = Some "sh"; html = "echo &lt;ok&gt;"; source = Some "echo <ok>" } ]
+  in
+  match B.blocks_of_yojson (B.blocks_to_yojson original) with
+  | Some parsed ->
+    Alcotest.(check (list yojson_testable))
+      "code roundtrip json"
+      (blocks_to_json_list original)
+      (blocks_to_json_list parsed)
+  | None -> Alcotest.fail "blocks_of_yojson rejected valid code block"
 
 let test_non_http_markdown_image_becomes_text () =
   let blocks = B.parse_text_to_blocks "before ![alt](ftp://example.com/a.png) after" in
@@ -206,6 +252,10 @@ let () =
             test_standalone_non_image_url_becomes_link;
           Alcotest.test_case "inline url stays in text" `Quick
             test_inline_url_stays_in_text;
+          Alcotest.test_case "code fence becomes code block" `Quick
+            test_code_fence_becomes_code_block;
+          Alcotest.test_case "code fence preserves markdown image literal" `Quick
+            test_code_fence_preserves_markdown_image_literal;
           Alcotest.test_case "multiple images and text lines" `Quick
             test_multiple_images_and_text_lines;
           Alcotest.test_case "empty lines ignored" `Quick
@@ -225,6 +275,8 @@ let () =
         [
           Alcotest.test_case "blocks roundtrip through yojson" `Quick
             test_blocks_of_yojson_roundtrip;
+          Alcotest.test_case "code block roundtrip" `Quick
+            test_code_block_roundtrip;
           Alcotest.test_case "blocks_of_yojson rejects malformed" `Quick
             test_blocks_of_yojson_rejects_malformed;
           Alcotest.test_case "fusion block roundtrip" `Quick


### PR DESCRIPTION
## Summary
- Parse Keeper fenced code into dashboard-compatible `code` chat blocks with escaped `html`, raw `source`, and optional `cap` language metadata; `mermaid` fenced code now preserves as a `mermaid` block.
- Extend the server/dashboard chat-block boundary for richer dashboard shapes: `h4`, `ul`, `callout`, `table`, `code`, `mermaid`, `svg`, `voice`, `attach`, `image`, `link`, and `fusion`.
- Prevent dashboard history rows from being dropped when server-provided blocks include `code` or the richer block shapes already supported by the renderer.
- Project GateResponse structured chat blocks into Slack/Telegram/shared/plain connectors, including table/list/callout/mermaid/svg/audio/video-style fallbacks.
- Wire CLI/iMessage to prefer structured plain-text content when present, while keeping plain-text fallback when structured blocks are absent or malformed.

## Validation
- `ocamlformat --check lib/keeper/keeper_chat_blocks.ml lib/keeper/keeper_chat_blocks.mli lib/keeper/keeper_chat_slack.ml lib/keeper/keeper_chat_discord.ml test/test_keeper_chat_blocks.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_chat_blocks.exe`
- `./_build/default/test/test_keeper_chat_blocks.exe`
- `ruff check sidecars/shared/gate_shared/structured_content.py sidecars/shared/tests/test_structured_content.py sidecars/slack-bot/src/formatters.py sidecars/slack-bot/tests/test_formatters.py sidecars/telegram-bot/src/formatters.py sidecars/telegram-bot/tests/test_formatters.py`
- `pyright --outputjson sidecars/shared/gate_shared/structured_content.py sidecars/slack-bot/src/formatters.py sidecars/telegram-bot/src/formatters.py`
- `python3 -m pytest tests/test_structured_content.py` in `sidecars/shared`
- `python3 -m pytest tests/test_formatters.py` in `sidecars/slack-bot`
- `python3 -m pytest tests/test_bot.py` in `sidecars/cli-connector`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/api/schemas/keeper-chat-history.test.ts src/keeper-state.test.ts` in this worktree's `dashboard`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty false` in this worktree's `dashboard`
- `git diff --check`
- `bash scripts/ci/check-masc-oas-boundary.sh`

## Notes
- Running all sidecar pytest targets in one command is not valid locally because each sidecar has a `src` package and pytest import state collides; the passing targets above were run from each sidecar root.
- Telegram/iMessage pytest collection is not locally runnable in this Python environment because `pydantic_settings` is not installed. The touched Telegram formatter passes `ruff` and `pyright`; CI should run with sidecar dependencies.
- `pnpm --dir dashboard test ...` is not locally runnable from this worktree because `dashboard/node_modules` is absent. Targeted dashboard vitest/tsc were run via the root checkout's existing dashboard dev dependencies against this worktree's source.
