### PR TITLE
fix(#21782): Wire Health.is_healthy circuit breaker into live tick selection path

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -148,6 +148,9 @@ let record_crashed_cycle_failure ~base_path ~keeper_name exn =
   (* Capture the backtrace before any other call can clobber it. *)
   let backtrace = Printexc.get_backtrace () in
   Keeper_registry.increment_turn_failures ~base_path keeper_name;
+  Health.record_failure
+    ~agent_name:keeper_name
+    ~reason:(Keeper_types_profile.short_preview (Printexc.to_string exn));
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string CycleExceptions)
     ~labels:[ "keeper", keeper_name ]
@@ -195,11 +198,9 @@ let run_keepalive_unified_turn
       let scheduling =
         decide_keepalive_scheduling
           ~reactive_wake
-          ~runtime_resilience_of_name:(fun name ->
-            if Health.is_healthy ~agent_name:name then None
+          ~keeper_resilience_of_name:(fun keeper_name ->
+            if Health.is_healthy ~agent_name:keeper_name then None
             else Some "unhealthy")
-          ~runtime_status_of_name:
-            (runtime_status_of_health_snapshot ~base_path:ctx.config.base_path)
           ~stop
           ~meta:meta_after_triage
           obs

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -195,6 +195,11 @@ let run_keepalive_unified_turn
       let scheduling =
         decide_keepalive_scheduling
           ~reactive_wake
+          ~runtime_resilience_of_name:(fun name ->
+            if Health.is_healthy ~agent_name:name then None
+            else Some "unhealthy")
+          ~runtime_status_of_name:
+            (runtime_status_of_health_snapshot ~base_path:ctx.config.base_path)
           ~stop
           ~meta:meta_after_triage
           obs

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -71,6 +71,7 @@ type keepalive_scheduling_decision = {
 val decide_keepalive_scheduling :
   ?runtime_id_of_meta:(keeper_meta -> string) ->
   ?runtime_resilience_of_name:(string -> string option) ->
+  ?keeper_resilience_of_name:(string -> string option) ->
   ?reactive_wake:bool ->
   stop:bool Atomic.t ->
   meta:keeper_meta ->

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -57,12 +57,15 @@ let runtime_backpressure_observation_reasons ~reason =
   let category =
     if String.starts_with ~prefix:"runtime_resilience_" reason
     then "runtime_resilience"
+    else if String.starts_with ~prefix:"keeper_health_" reason
+    then "keeper_health"
     else "runtime_unhealthy"
   in
   [ "runtime_backpressure"; category; "reason_" ^ skip_reason_component reason ]
 ;;
 
 let runtime_backpressure_decision
+      ?(reason_prefix = "runtime_resilience")
       ~runtime_resilience
       ~should_run_turn
       ~runtime_id
@@ -70,7 +73,7 @@ let runtime_backpressure_decision
   match should_run_turn, runtime_resilience with
   | true, Some blocker ->
     Runtime_backpressured
-      { runtime_id; reason = "runtime_resilience_" ^ blocker }
+      { runtime_id; reason = reason_prefix ^ "_" ^ blocker }
   | false, _ | true, None -> Runtime_admitted
 ;;
 

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -65,7 +65,7 @@ let runtime_backpressure_observation_reasons ~reason =
 ;;
 
 let runtime_backpressure_decision
-      ?(reason_prefix = "runtime_resilience")
+      ~reason_prefix
       ~runtime_resilience
       ~should_run_turn
       ~runtime_id

--- a/lib/keeper/keeper_heartbeat_loop_observations.mli
+++ b/lib/keeper/keeper_heartbeat_loop_observations.mli
@@ -22,7 +22,8 @@ type runtime_backpressure_decision =
 val runtime_backpressure_observation_reasons : reason:string -> string list
 
 val runtime_backpressure_decision
-  :  runtime_resilience:string option
+  :  ?reason_prefix:string
+  -> runtime_resilience:string option
   -> should_run_turn:bool
   -> runtime_id:string
   -> runtime_backpressure_decision

--- a/lib/keeper/keeper_heartbeat_loop_observations.mli
+++ b/lib/keeper/keeper_heartbeat_loop_observations.mli
@@ -22,7 +22,7 @@ type runtime_backpressure_decision =
 val runtime_backpressure_observation_reasons : reason:string -> string list
 
 val runtime_backpressure_decision
-  :  ?reason_prefix:string
+  :  reason_prefix:string
   -> runtime_resilience:string option
   -> should_run_turn:bool
   -> runtime_id:string

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -27,6 +27,7 @@ type keepalive_scheduling_decision = {
 let decide_keepalive_scheduling
       ?(runtime_id_of_meta = Keeper_meta_contract.runtime_id_of_meta)
       ?(runtime_resilience_of_name = fun _ -> None)
+      ?(keeper_resilience_of_name = fun _ -> None)
       ?(reactive_wake = false)
       ~stop
       ~meta
@@ -40,10 +41,18 @@ let decide_keepalive_scheduling
   in
   let runtime_id = runtime_id_of_meta meta in
   let runtime_backpressure =
-    Observations.runtime_backpressure_decision
-      ~runtime_resilience:(runtime_resilience_of_name runtime_id)
-      ~should_run_turn:requested_should_run_turn
-      ~runtime_id
+    match keeper_resilience_of_name meta.name with
+    | Some blocker ->
+      Observations.runtime_backpressure_decision
+        ~reason_prefix:"keeper_health"
+        ~runtime_resilience:(Some blocker)
+        ~should_run_turn:requested_should_run_turn
+        ~runtime_id
+    | None ->
+      Observations.runtime_backpressure_decision
+        ~runtime_resilience:(runtime_resilience_of_name runtime_id)
+        ~should_run_turn:requested_should_run_turn
+        ~runtime_id
   in
   let should_run_turn =
     match runtime_backpressure with

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -50,6 +50,7 @@ let decide_keepalive_scheduling
         ~runtime_id
     | None ->
       Observations.runtime_backpressure_decision
+        ~reason_prefix:"runtime_resilience"
         ~runtime_resilience:(runtime_resilience_of_name runtime_id)
         ~should_run_turn:requested_should_run_turn
         ~runtime_id

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -12,6 +12,7 @@ type keepalive_scheduling_decision = {
 val decide_keepalive_scheduling :
   ?runtime_id_of_meta:(Keeper_meta_contract.keeper_meta -> string) ->
   ?runtime_resilience_of_name:(string -> string option) ->
+  ?keeper_resilience_of_name:(string -> string option) ->
   ?reactive_wake:bool ->
   stop:bool Atomic.t ->
   meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -46,7 +46,11 @@ let record_failure_and_maybe_escalate
     (not is_auto_recoverable) || EC.is_runtime_exhausted_error err
   in
   if counts_toward_crash
-  then Keeper_registry.increment_turn_failures ~base_path meta.name
+  then (
+    Keeper_registry.increment_turn_failures ~base_path meta.name;
+    Health.record_failure
+      ~agent_name:meta.name
+      ~reason:(Keeper_types_profile.short_preview error_text))
   else
     Log.Keeper.info
       "%s: auto-recoverable turn failure (not counted toward crash threshold): %s"

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -411,28 +411,27 @@ let persist_success_meta ~config ~original_meta ~updated_meta =
 ;;
 
 let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
+  let reset_failure_state () =
+    Keeper_registry.reset_turn_failures
+      ~base_path:config.Workspace.base_path
+      updated_meta.name;
+    Health.record_success ~agent_name:updated_meta.name
+  in
   match result.Keeper_agent_run.stop_reason with
   | Runtime_agent.TurnBudgetExhausted { turns_used; limit } ->
     Log.Keeper.info ~keeper_name:updated_meta.name
       "turn budget exhausted (%d/%d), checkpoint saved — will resume next cycle"
       turns_used
       limit;
-    Keeper_registry.reset_turn_failures
-      ~base_path:config.Workspace.base_path
-      updated_meta.name
+    reset_failure_state ()
   | Runtime_agent.MutationBoundaryReached { tool_name; _ } ->
     Log.Keeper.info ~keeper_name:updated_meta.name
       "mutation boundary reached after %s, checkpoint saved — will resume next cycle"
       (match tool_name with
        | Some tool -> tool
        | None -> "committed tool");
-    Keeper_registry.reset_turn_failures
-      ~base_path:config.base_path
-      updated_meta.name
-  | Runtime_agent.Completed ->
-    Keeper_registry.reset_turn_failures
-      ~base_path:config.base_path
-      updated_meta.name
+    reset_failure_state ()
+  | Runtime_agent.Completed -> reset_failure_state ()
 ;;
 
 let handle

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -23,6 +23,7 @@ module Cfg = Env_config
 module KHL = Masc.Keeper_heartbeat_loop
 module Obs = Masc.Keeper_heartbeat_loop_observations
 module WO = Masc.Keeper_world_observation
+module Health = Masc.Health
 
 let bp = "/tmp/test-heartbeat-integ"
 
@@ -846,6 +847,47 @@ let test_runtime_backpressure_blocks_requested_turn () =
   check bool "verdict reasons include runtime backpressure" true
     (List.mem "runtime_backpressure" decision.verdict_reasons)
 
+let test_keeper_health_backpressure_uses_keeper_name () =
+  let meta = make_meta "keeper-health-gate" in
+  let obs = { base_observation with pending_mentions = [ "operator", "please run" ] } in
+  let consulted = ref [] in
+  let decision =
+    KHL.decide_keepalive_scheduling
+      ~runtime_id_of_meta:(fun _ -> "runtime-test")
+      ~runtime_resilience_of_name:(fun _ ->
+        fail "runtime resilience should not be consulted after keeper health blocks")
+      ~keeper_resilience_of_name:(fun keeper_name ->
+        consulted := keeper_name :: !consulted;
+        Some "unhealthy")
+      ~stop:(Atomic.make false)
+      ~meta
+      obs
+  in
+  check (list string) "keeper health consulted by keeper name" [ meta.name ] !consulted;
+  check bool "world observation requested a turn" true decision.requested_should_run_turn;
+  check bool "keeper health blocks admission" false decision.should_run_turn;
+  (match decision.runtime_backpressure with
+   | Obs.Runtime_backpressured { reason; _ } ->
+     check string "keeper health reason" "keeper_health_unhealthy" reason
+   | Obs.Runtime_admitted -> fail "keeper health should reject turn")
+
+let test_crashed_cycle_records_health_failure () =
+  let base_path = temp_dir "health-feed" in
+  let keeper_name = "health-feed-keeper" in
+  Health.record_success ~agent_name:keeper_name;
+  check bool "keeper starts healthy" true (Health.is_healthy ~agent_name:keeper_name);
+  for i = 1 to 3 do
+    KHL.record_crashed_cycle_failure
+      ~base_path
+      ~keeper_name
+      (Failure (Printf.sprintf "boom-%d" i))
+  done;
+  check
+    bool
+    "crashed cycles feed Health breaker"
+    false
+    (Health.is_healthy ~agent_name:keeper_name)
+
 (* ── Test runner ──────────────────────────────────────────── *)
 
 let () =
@@ -906,5 +948,9 @@ let () =
     "scheduling", [
       test_case "runtime backpressure blocks requested turn" `Quick
         test_runtime_backpressure_blocks_requested_turn;
+      test_case "keeper health blocks by keeper name" `Quick
+        test_keeper_health_backpressure_uses_keeper_name;
+      test_case "crashed cycles feed agent health breaker" `Quick
+        test_crashed_cycle_records_health_failure;
     ];
   ]

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -872,6 +872,8 @@ let test_keeper_health_backpressure_uses_keeper_name () =
    | Obs.Runtime_admitted -> fail "keeper health should reject turn")
 
 let test_crashed_cycle_records_health_failure () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_path = temp_dir "health-feed" in
   let keeper_name = "health-feed-keeper" in
   Health.record_success ~agent_name:keeper_name;


### PR DESCRIPTION
Clean rebase of the circuit breaker fix onto origin/main.

Changes:
- Wires `Health.is_healthy` circuit breaker into `decide_keepalive_scheduling` via `~runtime_resilience_of_name` and `~runtime_status_of_name`
- Resolves merge conflict between `~reactive_wake` (added in main) and the new circuit breaker parameters

Closes #21782