### PR TITLE
feat(schedule): add board post convenience payload

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1843,6 +1843,8 @@ export interface DashboardScheduledAutomationRequest {
   expires_at_iso?: string | null
   payload_digest?: string
   payload_kind?: string | null
+  payload_target?: string | null
+  payload_summary?: string | null
   recurrence_summary?: string | null
   requires_separate_human_grant?: boolean
   approval_policy?: string | null

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -80,6 +80,23 @@ function lastExecutionLabel(request: DashboardScheduledAutomationRequest): strin
   return finishedAt === '-' ? status : `${status} ${finishedAt}`
 }
 
+function PayloadCell({ request }: { request: DashboardScheduledAutomationRequest }) {
+  const kind = request.payload_kind ?? '-'
+  const target = request.payload_target?.trim() || null
+  const summary = request.payload_summary?.trim() || null
+  return html`
+    <div class="max-w-[18rem]">
+      <div class="font-mono text-xs text-[var(--color-fg-secondary)]">${kind}</div>
+      ${target
+        ? html`<div class="mt-1 font-mono text-3xs text-[var(--color-fg-muted)]">${target}</div>`
+        : null}
+      ${summary
+        ? html`<div class="mt-1 truncate text-3xs text-[var(--color-fg-muted)]" title=${summary}>${summary}</div>`
+        : null}
+    </div>
+  `
+}
+
 function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest }) {
   const effectiveStatus = request.effective_status ?? request.status
   const readiness = request.execution_readiness ?? '-'
@@ -98,7 +115,7 @@ function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(readiness)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(action)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(request.risk_class)}</td>
-      <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${request.payload_kind ?? '-'}</td>
+      <td class="py-2 pr-3"><${PayloadCell} request=${request} /></td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${recurrenceLabel(request)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${lastExecutionLabel(request)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${formatDateTimeKo(dueIso)}</td>

--- a/lib/schedule_payload_projection.ml
+++ b/lib/schedule_payload_projection.ml
@@ -1,0 +1,63 @@
+let trim_nonempty value =
+  let trimmed = String.trim value in
+  if String.equal trimmed "" then None else Some trimmed
+;;
+
+let assoc_string key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> trim_nonempty value
+  | _ -> None
+;;
+
+let payload_fields payload =
+  match Schedule_domain.payload_to_yojson payload with
+  | `Assoc fields -> Some fields
+  | _ -> None
+;;
+
+let kind_of_payload payload =
+  Option.bind (payload_fields payload) (assoc_string "kind")
+;;
+
+let body_fields payload =
+  match payload_fields payload with
+  | Some fields ->
+    (match List.assoc_opt "body" fields with
+     | Some (`Assoc body) -> Some body
+     | _ -> None)
+  | None -> None
+;;
+
+let board_target body =
+  match assoc_string "thread_id" body, assoc_string "hearth" body with
+  | Some thread_id, _ -> Some ("thread:" ^ thread_id)
+  | None, Some hearth -> Some ("hearth:" ^ hearth)
+  | None, None -> Some "board:default"
+;;
+
+let truncate_summary text =
+  String.trim text
+  |> String_util.utf8_safe ~max_bytes:160 ~suffix:"..."
+  |> String_util.to_string
+;;
+
+let board_summary body =
+  match assoc_string "title" body, assoc_string "content" body with
+  | Some title, _ -> Some (truncate_summary title)
+  | None, Some content -> Some (truncate_summary content)
+  | None, None -> None
+;;
+
+let target_summary_of_payload payload =
+  match kind_of_payload payload, body_fields payload with
+  | Some "masc.board_post", Some body -> board_target body, board_summary body
+  | _ -> None, None
+;;
+
+let kind (request : Schedule_domain.schedule_request) =
+  kind_of_payload request.payload
+;;
+
+let target_summary (request : Schedule_domain.schedule_request) =
+  target_summary_of_payload request.payload
+;;

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1893,6 +1893,49 @@ let schedule_payload_kind request =
   | _ -> None
 ;;
 
+let assoc_nonempty_string key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) ->
+    let value = String.trim value in
+    if String.equal value "" then None else Some value
+  | _ -> None
+;;
+
+let schedule_payload_body_fields request =
+  match Schedule_domain.payload_to_yojson request.Schedule_domain.payload with
+  | `Assoc fields ->
+    (match List.assoc_opt "body" fields with
+     | Some (`Assoc body) -> Some body
+     | _ -> None)
+  | _ -> None
+;;
+
+let schedule_payload_board_target body =
+  match assoc_nonempty_string "thread_id" body, assoc_nonempty_string "hearth" body with
+  | Some thread_id, _ -> Some ("thread:" ^ thread_id)
+  | None, Some hearth -> Some ("hearth:" ^ hearth)
+  | None, None -> Some "board:default"
+;;
+
+let truncate_payload_summary text =
+  let text = String.trim text in
+  if String.length text <= 160 then text else String.sub text 0 157 ^ "..."
+;;
+
+let schedule_payload_board_summary body =
+  match assoc_nonempty_string "title" body, assoc_nonempty_string "content" body with
+  | Some title, _ -> Some (truncate_payload_summary title)
+  | None, Some content -> Some (truncate_payload_summary content)
+  | None, None -> None
+;;
+
+let schedule_payload_target_summary request =
+  match schedule_payload_kind request, schedule_payload_body_fields request with
+  | Some "masc.board_post", Some body ->
+    schedule_payload_board_target body, schedule_payload_board_summary body
+  | _ -> None, None
+;;
+
 let execution_record_dashboard_json (execution : Schedule_domain.execution_record) =
   match Schedule_domain.execution_record_to_yojson execution with
   | `Assoc fields ->
@@ -1914,6 +1957,7 @@ let schedule_request_dashboard_json
     if Schedule_domain.is_terminal request.status then None else Some request.due_at
   in
   let requires_grant = Schedule_domain.requires_separate_human_grant request in
+  let payload_target, payload_summary = schedule_payload_target_summary request in
   `Assoc
     [ "schedule_id", `String request.schedule_id
     ; "status", `String (Schedule_domain.schedule_status_to_string request.status)
@@ -1950,6 +1994,14 @@ let schedule_request_dashboard_json
       , match schedule_payload_kind request with
         | None -> `Null
         | Some kind -> `String kind )
+    ; ( "payload_target"
+      , match payload_target with
+        | None -> `Null
+        | Some target -> `String target )
+    ; ( "payload_summary"
+      , match payload_summary with
+        | None -> `Null
+        | Some summary -> `String summary )
     ; ( "last_execution"
       , match last_execution with
         | None -> `Null

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1884,58 +1884,6 @@ let schedule_fsm_state ~now state schedules =
   else "idle"
 ;;
 
-let schedule_payload_kind request =
-  match Schedule_domain.payload_to_yojson request.Schedule_domain.payload with
-  | `Assoc fields ->
-    (match List.assoc_opt "kind" fields with
-     | Some (`String kind) -> Some kind
-     | _ -> None)
-  | _ -> None
-;;
-
-let assoc_nonempty_string key fields =
-  match List.assoc_opt key fields with
-  | Some (`String value) ->
-    let value = String.trim value in
-    if String.equal value "" then None else Some value
-  | _ -> None
-;;
-
-let schedule_payload_body_fields request =
-  match Schedule_domain.payload_to_yojson request.Schedule_domain.payload with
-  | `Assoc fields ->
-    (match List.assoc_opt "body" fields with
-     | Some (`Assoc body) -> Some body
-     | _ -> None)
-  | _ -> None
-;;
-
-let schedule_payload_board_target body =
-  match assoc_nonempty_string "thread_id" body, assoc_nonempty_string "hearth" body with
-  | Some thread_id, _ -> Some ("thread:" ^ thread_id)
-  | None, Some hearth -> Some ("hearth:" ^ hearth)
-  | None, None -> Some "board:default"
-;;
-
-let truncate_payload_summary text =
-  let text = String.trim text in
-  if String.length text <= 160 then text else String.sub text 0 157 ^ "..."
-;;
-
-let schedule_payload_board_summary body =
-  match assoc_nonempty_string "title" body, assoc_nonempty_string "content" body with
-  | Some title, _ -> Some (truncate_payload_summary title)
-  | None, Some content -> Some (truncate_payload_summary content)
-  | None, None -> None
-;;
-
-let schedule_payload_target_summary request =
-  match schedule_payload_kind request, schedule_payload_body_fields request with
-  | Some "masc.board_post", Some body ->
-    schedule_payload_board_target body, schedule_payload_board_summary body
-  | _ -> None, None
-;;
-
 let execution_record_dashboard_json (execution : Schedule_domain.execution_record) =
   match Schedule_domain.execution_record_to_yojson execution with
   | `Assoc fields ->
@@ -1957,7 +1905,9 @@ let schedule_request_dashboard_json
     if Schedule_domain.is_terminal request.status then None else Some request.due_at
   in
   let requires_grant = Schedule_domain.requires_separate_human_grant request in
-  let payload_target, payload_summary = schedule_payload_target_summary request in
+  let payload_target, payload_summary =
+    Schedule_payload_projection.target_summary request
+  in
   `Assoc
     [ "schedule_id", `String request.schedule_id
     ; "status", `String (Schedule_domain.schedule_status_to_string request.status)
@@ -1991,7 +1941,7 @@ let schedule_request_dashboard_json
            else "no_separate_grant_required") )
     ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
     ; ( "payload_kind"
-      , match schedule_payload_kind request with
+      , match Schedule_payload_projection.kind request with
         | None -> `Null
         | Some kind -> `String kind )
     ; ( "payload_target"

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -136,29 +136,154 @@ let approved_by_from_args args =
       }
 ;;
 
+let has_arg args key = Option.is_some (Json_util.assoc_member_opt key args)
+
+let has_board_convenience_args args =
+  List.exists
+    (has_arg args)
+    [ "board_content"
+    ; "board_title"
+    ; "board_hearth"
+    ; "board_author"
+    ; "board_thread_id"
+    ; "board_ttl_hours"
+    ; "board_meta"
+    ]
+;;
+
+let optional_body_string args ~arg ~field fields =
+  match string_opt args arg with
+  | None -> Ok fields
+  | Some value -> Ok ((field, `String value) :: fields)
+;;
+
+let optional_body_int args ~arg ~field fields =
+  match Json_util.assoc_member_opt arg args with
+  | None -> Ok fields
+  | Some (`Int value) -> Ok ((field, `Int value) :: fields)
+  | Some _ -> Error (arg ^ " must be an integer")
+;;
+
+let optional_body_object args ~arg ~field fields =
+  match Json_util.assoc_member_opt arg args with
+  | None -> Ok fields
+  | Some (`Assoc _ as value) -> Ok ((field, value) :: fields)
+  | Some _ -> Error (arg ^ " must be an object")
+;;
+
+let board_post_payload_from_args args =
+  let* content = required_string args "board_content" in
+  let schema_version =
+    (* DET-OK: board_* is a stable convenience projection for the existing
+       masc.board_post v1 consumer. *)
+    optional_int args "payload_schema_version" |> Option.value ~default:1
+  in
+  if schema_version <> 1
+  then Error "board_* convenience fields only support payload_schema_version=1"
+  else
+    let* fields =
+      optional_body_string args ~arg:"board_title" ~field:"title"
+        [ "content", `String content ]
+    in
+    let* fields = optional_body_string args ~arg:"board_author" ~field:"author" fields in
+    let* fields = optional_body_string args ~arg:"board_hearth" ~field:"hearth" fields in
+    let* fields = optional_body_string args ~arg:"board_thread_id" ~field:"thread_id" fields in
+    let* fields = optional_body_int args ~arg:"board_ttl_hours" ~field:"ttl_hours" fields in
+    let* fields = optional_body_object args ~arg:"board_meta" ~field:"meta" fields in
+    Ok
+      (`Assoc
+        [ "kind", `String "masc.board_post"
+        ; "schema_version", `Int schema_version
+        ; "body", `Assoc (List.rev fields)
+        ])
+;;
+
+let generic_payload_from_args args =
+  let* kind = required_string args "payload_kind" in
+  let schema_version =
+    (* DET-OK: absent schema_version means the stable schedule payload v1
+       contract, not provider-derived guessing. *)
+    optional_int args "payload_schema_version" |> Option.value ~default:1
+  in
+  let* body =
+    match Json_util.assoc_member_opt "payload_body" args with
+    | None -> Ok (`Assoc [])
+    | Some (`Assoc _ as body) -> Ok body
+    | Some _ -> Error "payload_body must be an object"
+  in
+  Ok
+    (`Assoc
+      [ "kind", `String kind; "schema_version", `Int schema_version; "body", body ])
+;;
+
 let payload_from_args args =
   match Json_util.assoc_member_opt "payload" args with
   | Some (`Assoc _ as payload) -> Ok payload
   | Some _ -> Error "payload must be an object envelope"
   | None ->
-    let* kind = required_string args "payload_kind" in
-    let schema_version =
-      (* DET-OK: absent schema_version means the stable schedule payload v1
-         contract, not provider-derived guessing. *)
-      optional_int args "payload_schema_version" |> Option.value ~default:1
-    in
-    let* body =
-      match Json_util.assoc_member_opt "payload_body" args with
-      | None -> Ok (`Assoc [])
-      | Some (`Assoc _ as body) -> Ok body
-      | Some _ -> Error "payload_body must be an object"
-    in
-    Ok
-      (`Assoc
-        [ "kind", `String kind
-        ; "schema_version", `Int schema_version
-        ; "body", body
-        ])
+    if has_board_convenience_args args
+    then
+      if has_arg args "payload_body"
+      then Error "use either payload_body or board_* convenience fields, not both"
+      else
+        (match string_opt args "payload_kind" with
+         | None | Some "masc.board_post" -> board_post_payload_from_args args
+         | Some kind ->
+           Error
+             ("board_* convenience fields require payload_kind omitted or masc.board_post, got "
+              ^ kind))
+    else generic_payload_from_args args
+;;
+
+let payload_assoc_fields payload =
+  match Schedule_domain.payload_to_yojson payload with
+  | `Assoc fields -> Some fields
+  | _ -> None
+;;
+
+let assoc_string key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> trim_nonempty value
+  | _ -> None
+;;
+
+let payload_kind request =
+  Option.bind (payload_assoc_fields request.Schedule_domain.payload) (assoc_string "kind")
+;;
+
+let payload_body_fields request =
+  match payload_assoc_fields request.Schedule_domain.payload with
+  | Some fields ->
+    (match List.assoc_opt "body" fields with
+     | Some (`Assoc body) -> Some body
+     | _ -> None)
+  | None -> None
+;;
+
+let payload_board_target body =
+  match assoc_string "thread_id" body, assoc_string "hearth" body with
+  | Some thread_id, _ -> Some ("thread:" ^ thread_id)
+  | None, Some hearth -> Some ("hearth:" ^ hearth)
+  | None, None -> Some "board:default"
+;;
+
+let truncate_summary text =
+  let text = String.trim text in
+  if String.length text <= 160 then text else String.sub text 0 157 ^ "..."
+;;
+
+let payload_board_summary body =
+  match assoc_string "title" body, assoc_string "content" body with
+  | Some title, _ -> Some (truncate_summary title)
+  | None, Some content -> Some (truncate_summary content)
+  | None, None -> None
+;;
+
+let payload_target_summary request =
+  match payload_kind request, payload_body_fields request with
+  | Some "masc.board_post", Some body ->
+    payload_board_target body, payload_board_summary body
+  | _ -> None, None
 ;;
 
 let schedule_request_json ?last_execution (request : Schedule_domain.schedule_request) =
@@ -166,6 +291,7 @@ let schedule_request_json ?last_execution (request : Schedule_domain.schedule_re
     if Schedule_domain.is_terminal request.status then None else Some request.due_at
   in
   let requires_grant = Schedule_domain.requires_separate_human_grant request in
+  let payload_target, payload_summary = payload_target_summary request in
   match Schedule_domain.schedule_request_to_yojson request with
   | `Assoc fields ->
     `Assoc
@@ -192,8 +318,20 @@ let schedule_request_json ?last_execution (request : Schedule_domain.schedule_re
            , `String
                (if requires_grant
                 then "separate_human_grant_required"
-                else "no_separate_grant_required") )
+               else "no_separate_grant_required") )
          ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
+         ; ( "payload_kind"
+           , match payload_kind request with
+             | None -> `Null
+             | Some kind -> `String kind )
+         ; ( "payload_target"
+           , match payload_target with
+             | None -> `Null
+             | Some target -> `String target )
+         ; ( "payload_summary"
+           , match payload_summary with
+             | None -> `Null
+             | Some summary -> `String summary )
          ; ( "last_execution"
            , match last_execution with
              | None -> `Null

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -164,6 +164,14 @@ let optional_body_int args ~arg ~field fields =
   | Some _ -> Error (arg ^ " must be an integer")
 ;;
 
+let optional_nonnegative_body_int args ~arg ~field fields =
+  match Json_util.assoc_member_opt arg args with
+  | None -> Ok fields
+  | Some (`Int value) when value >= 0 -> Ok ((field, `Int value) :: fields)
+  | Some (`Int _) -> Error (arg ^ " must be non-negative")
+  | Some _ -> Error (arg ^ " must be an integer")
+;;
+
 let optional_body_object args ~arg ~field fields =
   match Json_util.assoc_member_opt arg args with
   | None -> Ok fields
@@ -188,7 +196,9 @@ let board_post_payload_from_args args =
     let* fields = optional_body_string args ~arg:"board_author" ~field:"author" fields in
     let* fields = optional_body_string args ~arg:"board_hearth" ~field:"hearth" fields in
     let* fields = optional_body_string args ~arg:"board_thread_id" ~field:"thread_id" fields in
-    let* fields = optional_body_int args ~arg:"board_ttl_hours" ~field:"ttl_hours" fields in
+    let* fields =
+      optional_nonnegative_body_int args ~arg:"board_ttl_hours" ~field:"ttl_hours" fields
+    in
     let* fields = optional_body_object args ~arg:"board_meta" ~field:"meta" fields in
     Ok
       (`Assoc

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -235,63 +235,14 @@ let payload_from_args args =
     else generic_payload_from_args args
 ;;
 
-let payload_assoc_fields payload =
-  match Schedule_domain.payload_to_yojson payload with
-  | `Assoc fields -> Some fields
-  | _ -> None
-;;
-
-let assoc_string key fields =
-  match List.assoc_opt key fields with
-  | Some (`String value) -> trim_nonempty value
-  | _ -> None
-;;
-
-let payload_kind request =
-  Option.bind (payload_assoc_fields request.Schedule_domain.payload) (assoc_string "kind")
-;;
-
-let payload_body_fields request =
-  match payload_assoc_fields request.Schedule_domain.payload with
-  | Some fields ->
-    (match List.assoc_opt "body" fields with
-     | Some (`Assoc body) -> Some body
-     | _ -> None)
-  | None -> None
-;;
-
-let payload_board_target body =
-  match assoc_string "thread_id" body, assoc_string "hearth" body with
-  | Some thread_id, _ -> Some ("thread:" ^ thread_id)
-  | None, Some hearth -> Some ("hearth:" ^ hearth)
-  | None, None -> Some "board:default"
-;;
-
-let truncate_summary text =
-  let text = String.trim text in
-  if String.length text <= 160 then text else String.sub text 0 157 ^ "..."
-;;
-
-let payload_board_summary body =
-  match assoc_string "title" body, assoc_string "content" body with
-  | Some title, _ -> Some (truncate_summary title)
-  | None, Some content -> Some (truncate_summary content)
-  | None, None -> None
-;;
-
-let payload_target_summary request =
-  match payload_kind request, payload_body_fields request with
-  | Some "masc.board_post", Some body ->
-    payload_board_target body, payload_board_summary body
-  | _ -> None, None
-;;
-
 let schedule_request_json ?last_execution (request : Schedule_domain.schedule_request) =
   let next_due_at =
     if Schedule_domain.is_terminal request.status then None else Some request.due_at
   in
   let requires_grant = Schedule_domain.requires_separate_human_grant request in
-  let payload_target, payload_summary = payload_target_summary request in
+  let payload_target, payload_summary =
+    Schedule_payload_projection.target_summary request
+  in
   match Schedule_domain.schedule_request_to_yojson request with
   | `Assoc fields ->
     `Assoc
@@ -321,7 +272,7 @@ let schedule_request_json ?last_execution (request : Schedule_domain.schedule_re
                else "no_separate_grant_required") )
          ; "payload_digest", `String (Schedule_domain.payload_digest request.payload)
          ; ( "payload_kind"
-           , match payload_kind request with
+           , match Schedule_payload_projection.kind request with
              | None -> `Null
              | Some kind -> `String kind )
          ; ( "payload_target"

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -245,6 +245,42 @@ let payload_from_args args =
     else generic_payload_from_args args
 ;;
 
+let assoc_string_opt key fields =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> trim_nonempty value
+  | _ -> None
+;;
+
+let validate_known_payload_request ~payload ~risk_class =
+  match payload with
+  | `Assoc fields ->
+    (match assoc_string_opt "kind" fields with
+     | Some "masc.board_post" ->
+       let* () =
+         match List.assoc_opt "schema_version" fields with
+         | Some (`Int 1) -> Ok ()
+         | Some (`Int _) -> Error "masc.board_post only supports payload_schema_version=1"
+         | Some _ -> Error "masc.board_post payload.schema_version must be an integer"
+         | None -> Error "masc.board_post payload requires schema_version=1"
+       in
+       if not (Schedule_domain.is_side_effecting risk_class)
+       then Error "masc.board_post requires a side-effecting risk_class such as workspace_write"
+       else (
+         match List.assoc_opt "body" fields with
+         | Some (`Assoc body) ->
+           (match assoc_string_opt "content" body with
+            | Some _ -> Ok ()
+            | None ->
+              Error
+                "masc.board_post payload requires non-empty body.content; use board_content for board schedules")
+         | Some _ -> Error "masc.board_post payload.body must be an object"
+         | None ->
+           Error
+             "masc.board_post payload requires object body with non-empty content; use board_content for board schedules")
+     | _ -> Ok ())
+  | _ -> Ok ()
+;;
+
 let schedule_request_json ?last_execution (request : Schedule_domain.schedule_request) =
   let next_due_at =
     if Schedule_domain.is_terminal request.status then None else Some request.due_at
@@ -337,6 +373,7 @@ let handle_create ~tool_name ~start_time ctx args =
   let result =
     let* payload = payload_from_args args in
     let* risk_class = risk_class_of_arg args in
+    let* () = validate_known_payload_request ~payload ~risk_class in
     let* source = source_of_arg args in
     let* recurrence = recurrence_of_arg args in
     let requested_at =

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -109,9 +109,29 @@ let create_schema =
         ~description:
           "Typed schedule payload envelope: {kind:string, schema_version:int, body:object}."
         "payload"
-    ; string_prop ~description:"Payload kind used when payload is omitted." "payload_kind"
-    ; integer_prop ~description:"Payload schema version used when payload is omitted." "payload_schema_version"
-    ; object_prop ~description:"Payload body used when payload is omitted." "payload_body"
+    ; string_prop
+        ~description:
+          "Payload kind used when payload is omitted. Supported server consumer today: masc.board_post."
+        "payload_kind"
+    ; integer_prop
+        ~description:"Payload schema version used when payload is omitted."
+        "payload_schema_version"
+    ; object_prop
+        ~description:
+          "Payload body used when payload is omitted. For board posts, prefer the board_* convenience fields unless you need the raw envelope."
+        "payload_body"
+    ; string_prop
+        ~description:
+          "Convenience for scheduling a board post. When payload/payload_body are omitted, this builds payload kind masc.board_post with schema_version=1. Use risk_class=workspace_write."
+        "board_content"
+    ; string_prop ~description:"Optional board-post title." "board_title"
+    ; string_prop
+        ~description:"Optional board hearth/destination for the scheduled post."
+        "board_hearth"
+    ; string_prop ~description:"Optional board post author. Defaults at dispatch time." "board_author"
+    ; string_prop ~description:"Optional board thread id." "board_thread_id"
+    ; integer_prop ~description:"Optional board post TTL in hours." "board_ttl_hours"
+    ; object_prop ~description:"Optional board post metadata object." "board_meta"
     ; string_prop ~enum:risk_classes "risk_class"
     ; bool_prop
         ~description:
@@ -218,7 +238,7 @@ let definition ~action ~id ~name ~description ~input_schema ~read_only =
 let definitions : definition list =
   [ definition ~action:Create_request ~id:"create" ~name:"masc_schedule_create"
       ~description:
-        "Create a durable scheduled internal automation request. For 'every day at 09:00 KST', use recurrence_kind=daily, recurrence_hour=9, recurrence_minute=0, recurrence_timezone=Asia/Seoul. For compact calendar rules, use recurrence_kind=cron with a 5-field recurrence_cron such as '0 9 * * 1-5'. Side-effecting requests start pending approval and require a later separate human grant."
+        "Create a durable scheduled internal automation request. For 'every day at 09:00 KST', use recurrence_kind=daily, recurrence_hour=9, recurrence_minute=0, recurrence_timezone=Asia/Seoul. For 'post this to board ops every morning', use board_content plus optional board_title/board_hearth with risk_class=workspace_write. For compact calendar rules, use recurrence_kind=cron with a 5-field recurrence_cron such as '0 9 * * 1-5'. Side-effecting requests start pending approval and require a later separate human grant."
       ~input_schema:create_schema ~read_only:false
   ; definition ~action:List_requests ~id:"list" ~name:"masc_schedule_list"
       ~description:"List durable scheduled internal automation requests."

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -2,9 +2,7 @@ open Alcotest
 open Masc
 
 let with_config f =
-  let path = Filename.temp_file "schedule_tool_wiring_test" "" in
-  Sys.remove path;
-  Unix.mkdir path 0o700;
+  let path = Filename.temp_dir "schedule_tool_wiring_test" "" in
   Fun.protect
     ~finally:(fun () ->
       let rec rm path =
@@ -258,6 +256,37 @@ let test_dispatch_create_board_post_convenience_payload () =
     (row |> member "payload_summary" |> to_string)
 ;;
 
+let test_dispatch_create_rejects_negative_board_ttl () =
+  with_config
+  @@ fun config ->
+  let args =
+    `Assoc
+      [ "schedule_id", `String "sched-negative-ttl"
+      ; "due_at_unix", `Float 200.0
+      ; "risk_class", `String "workspace_write"
+      ; "board_content", `String "Daily schedule fired"
+      ; "board_ttl_hours", `Int (-1)
+      ; "requested_by_id", `String "operator"
+      ; "scheduled_by_id", `String "scheduler-agent"
+      ]
+  in
+  (match
+     Tool_schedule.dispatch (schedule_ctx config)
+       ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+       ~args
+   with
+   | None -> fail "dispatch returned None"
+   | Some result ->
+     check bool "create rejects negative ttl" false (Tool_result.is_success result);
+     check (option string) "failure class" (Some "workflow_rejection")
+       (Option.map Tool_result.tool_failure_class_to_string
+          (Tool_result.failure_class result));
+     check string "message" "board_ttl_hours must be non-negative"
+       (Tool_result.message result));
+  let state = Schedule_store.read_state config in
+  check int "no schedule persisted" 0 (List.length state.schedules)
+;;
+
 let test_dispatch_cancel_persists_status () =
   with_config
   @@ fun config ->
@@ -470,6 +499,8 @@ let () =
             test_dispatch_create_derives_due_at_for_cron_recurrence
         ; test_case "dispatch create accepts board-post convenience payload" `Quick
             test_dispatch_create_board_post_convenience_payload
+        ; test_case "dispatch create rejects negative board ttl" `Quick
+            test_dispatch_create_rejects_negative_board_ttl
         ; test_case "dispatch cancel persists status" `Quick
             test_dispatch_cancel_persists_status
         ; test_case "dashboard projection surfaces schedule FSM" `Quick

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -287,6 +287,64 @@ let test_dispatch_create_rejects_negative_board_ttl () =
   check int "no schedule persisted" 0 (List.length state.schedules)
 ;;
 
+let test_dispatch_create_rejects_board_payload_without_content () =
+  with_config
+  @@ fun config ->
+  let args =
+    `Assoc
+      [ "schedule_id", `String "sched-board-empty"
+      ; "due_at_unix", `Float 200.0
+      ; "risk_class", `String "workspace_write"
+      ; "payload_kind", `String "masc.board_post"
+      ; "requested_by_id", `String "operator"
+      ; "scheduled_by_id", `String "scheduler-agent"
+      ]
+  in
+  (match
+     Tool_schedule.dispatch (schedule_ctx config)
+       ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+       ~args
+   with
+   | None -> fail "dispatch returned None"
+   | Some result ->
+     check bool "create rejects missing board content" false
+       (Tool_result.is_success result);
+     check string "message"
+       "masc.board_post payload requires non-empty body.content; use board_content for board schedules"
+       (Tool_result.message result));
+  let state = Schedule_store.read_state config in
+  check int "no schedule persisted" 0 (List.length state.schedules)
+;;
+
+let test_dispatch_create_rejects_read_only_board_payload () =
+  with_config
+  @@ fun config ->
+  let args =
+    `Assoc
+      [ "schedule_id", `String "sched-board-readonly"
+      ; "due_at_unix", `Float 200.0
+      ; "risk_class", `String "read_only"
+      ; "board_content", `String "Daily schedule fired"
+      ; "requested_by_id", `String "operator"
+      ; "scheduled_by_id", `String "scheduler-agent"
+      ]
+  in
+  (match
+     Tool_schedule.dispatch (schedule_ctx config)
+       ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+       ~args
+   with
+   | None -> fail "dispatch returned None"
+   | Some result ->
+     check bool "create rejects read-only board payload" false
+       (Tool_result.is_success result);
+     check string "message"
+       "masc.board_post requires a side-effecting risk_class such as workspace_write"
+       (Tool_result.message result));
+  let state = Schedule_store.read_state config in
+  check int "no schedule persisted" 0 (List.length state.schedules)
+;;
+
 let test_dispatch_cancel_persists_status () =
   with_config
   @@ fun config ->
@@ -501,6 +559,10 @@ let () =
             test_dispatch_create_board_post_convenience_payload
         ; test_case "dispatch create rejects negative board ttl" `Quick
             test_dispatch_create_rejects_negative_board_ttl
+        ; test_case "dispatch create rejects board payload without content" `Quick
+            test_dispatch_create_rejects_board_payload_without_content
+        ; test_case "dispatch create rejects read-only board payload" `Quick
+            test_dispatch_create_rejects_read_only_board_payload
         ; test_case "dispatch cancel persists status" `Quick
             test_dispatch_cancel_persists_status
         ; test_case "dashboard projection surfaces schedule FSM" `Quick

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -185,6 +185,79 @@ let test_dispatch_create_derives_due_at_for_cron_recurrence () =
        check (float 0.001) "derived due_at" 118800.0 request.due_at)
 ;;
 
+let test_dispatch_create_board_post_convenience_payload () =
+  with_config
+  @@ fun config ->
+  let args =
+    `Assoc
+      [ "schedule_id", `String "sched-board-post"
+      ; "due_at_unix", `Float 200.0
+      ; "risk_class", `String "workspace_write"
+      ; "board_title", `String "Scheduled check-in"
+      ; "board_content", `String "Daily schedule fired"
+      ; "board_hearth", `String "ops"
+      ; "board_author", `String "schedule-bot"
+      ; "board_ttl_hours", `Int 2
+      ; "board_meta", `Assoc [ "purpose", `String "operator-request" ]
+      ; "requested_by_id", `String "operator"
+      ; "scheduled_by_id", `String "scheduler-agent"
+      ]
+  in
+  (match
+     Tool_schedule.dispatch (schedule_ctx config)
+       ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+       ~args
+   with
+   | None -> fail "dispatch returned None"
+   | Some result ->
+     check bool "create succeeds" true (Tool_result.is_success result);
+     let data = Tool_result.data result in
+     let open Yojson.Safe.Util in
+     check string "result payload kind" "masc.board_post"
+       (data |> member "payload_kind" |> to_string);
+     check string "result payload target" "hearth:ops"
+       (data |> member "payload_target" |> to_string);
+     check string "result payload summary" "Scheduled check-in"
+       (data |> member "payload_summary" |> to_string);
+     check bool "result separate grant" true
+       (data |> member "requires_separate_human_grant" |> to_bool));
+  (match Schedule_store.get_schedule config ~schedule_id:"sched-board-post" with
+   | None -> fail "schedule missing"
+   | Some request ->
+     check string "status" "pending_approval"
+       (Schedule_domain.schedule_status_to_string request.status);
+     let payload = Schedule_domain.payload_to_yojson request.payload in
+     let open Yojson.Safe.Util in
+     check string "stored payload kind" "masc.board_post"
+       (payload |> member "kind" |> to_string);
+     check string "stored title" "Scheduled check-in"
+       (payload |> member "body" |> member "title" |> to_string);
+     check string "stored content" "Daily schedule fired"
+       (payload |> member "body" |> member "content" |> to_string);
+     check string "stored hearth" "ops"
+       (payload |> member "body" |> member "hearth" |> to_string);
+     check int "stored ttl" 2
+       (payload |> member "body" |> member "ttl_hours" |> to_int));
+  let dashboard =
+    Server_dashboard_http_runtime_info.scheduled_automation_dashboard_json config
+  in
+  let open Yojson.Safe.Util in
+  let row =
+    dashboard
+    |> member "requests"
+    |> to_list
+    |> function
+    | [ row ] -> row
+    | rows -> failf "expected one dashboard row, got %d" (List.length rows)
+  in
+  check string "dashboard payload kind" "masc.board_post"
+    (row |> member "payload_kind" |> to_string);
+  check string "dashboard payload target" "hearth:ops"
+    (row |> member "payload_target" |> to_string);
+  check string "dashboard payload summary" "Scheduled check-in"
+    (row |> member "payload_summary" |> to_string)
+;;
+
 let test_dispatch_cancel_persists_status () =
   with_config
   @@ fun config ->
@@ -395,6 +468,8 @@ let () =
             test_dispatch_create_persists_recurrence
         ; test_case "dispatch create derives due_at for cron recurrence" `Quick
             test_dispatch_create_derives_due_at_for_cron_recurrence
+        ; test_case "dispatch create accepts board-post convenience payload" `Quick
+            test_dispatch_create_board_post_convenience_payload
         ; test_case "dispatch cancel persists status" `Quick
             test_dispatch_cancel_persists_status
         ; test_case "dashboard projection surfaces schedule FSM" `Quick


### PR DESCRIPTION
## Summary
- Add `board_*` convenience inputs to `masc_schedule_create` so a keeper can schedule board posts without hand-building the raw `{kind,schema_version,body}` payload envelope.
- Normalize those inputs into the existing durable `masc.board_post` payload consumed by the server schedule runner; raw `payload` still wins, and `payload_body` cannot be mixed with `board_*` fields.
- Surface `payload_target` and `payload_summary` in schedule tool results and dashboard scheduled automation rows so operators can see where/what the schedule will do.

## Validation
- `ocamlformat --check lib/tool_schedule.ml lib/tool_schemas/tool_schemas_schedule.ml lib/server/server_dashboard_http_runtime_info.ml test/test_schedule_tool_wiring.ml`
- `scripts/dune-local.sh build test/test_schedule_tool_wiring.exe`
- `./_build/default/test/test_schedule_tool_wiring.exe`
- `npx tsc --noEmit --pretty` in `dashboard`
- `git diff --check`

## Notes
- This does not add a new scheduler or consumer. It makes the existing schedule store/runner/dashboard path usable for the current supported destination: `masc.board_post`.