### PR TITLE
feat(keeper): persist event and chat queue replay

### DIFF
--- a/lib/keeper/keeper_chat_consumer.ml
+++ b/lib/keeper/keeper_chat_consumer.ml
@@ -19,7 +19,16 @@ let start ~sw ~clock ~base_path ~handle_turn =
          match Keeper_turn_admission.in_flight ~base_path ~keeper_name with
          | Some _ -> ()
          | None -> (
-             let batch = Keeper_chat_queue.dequeue_batch ~keeper_name in
+             let batch =
+               try Keeper_chat_queue.dequeue_batch ~keeper_name with
+               | Eio.Cancel.Cancelled _ as e -> raise e
+               | exn ->
+                 Log.Keeper.warn
+                   "keeper_chat_consumer: dequeue_batch failed for keeper=%s: %s"
+                   keeper_name
+                   (Printexc.to_string exn);
+                 []
+             in
              (match batch with
               | _ :: _ :: _ ->
                   Log.Keeper.info

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -31,6 +31,9 @@ type queue_entry = {
 let schema = "keeper_chat_queue.v1"
 let persistence_file = "chat-queue.json"
 let persistence_base_path : string option Atomic.t = Atomic.make None
+let fail_next_persist_for_testing = Atomic.make false
+
+exception Persistence_failed of string
 
 (** Global registry protected by a single mutex.
     Per-keeper queues have their own mutex for independent enqueue/dequeue
@@ -128,6 +131,10 @@ let queue_of_list items =
   List.iter (fun item -> Queue.push item q) items;
   q
 
+let replace_queue q items =
+  Queue.clear q;
+  List.iter (fun item -> Queue.push item q) items
+
 let queue_to_yojson q =
   `Assoc
     [ ("schema", `String schema)
@@ -193,31 +200,47 @@ let load_snapshot ~base_path ~keeper_name =
            Queue.create ()))
 
 let persist_snapshot ~base_path ~keeper_name q =
-  match snapshot_path ~base_path ~keeper_name with
-  | Error msg -> Log.Keeper.warn "chat_queue_snapshot: %s" msg
+  if Atomic.exchange fail_next_persist_for_testing false
+  then Error "injected chat queue persist failure"
+  else match snapshot_path ~base_path ~keeper_name with
+  | Error msg -> Error msg
   | Ok path ->
     (try
        match save_json_atomic path (queue_to_yojson q) with
-       | Ok () -> ()
+       | Ok () -> Ok ()
        | Error msg ->
-         Log.Keeper.warn
-           "chat_queue_snapshot: failed to persist keeper=%s path=%s: %s"
-           keeper_name
-           path
-           msg
+         Error
+           (Printf.sprintf
+              "failed to persist keeper=%s path=%s: %s"
+              keeper_name
+              path
+              msg)
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
-       Log.Keeper.warn
-         "chat_queue_snapshot: persist raised keeper=%s path=%s: %s"
-         keeper_name
-         path
-         (Printexc.to_string exn))
+       Error
+         (Printf.sprintf
+            "persist raised keeper=%s path=%s: %s"
+            keeper_name
+            path
+            (Printexc.to_string exn)))
 
 let persist_if_configured ~keeper_name q =
   match Atomic.get persistence_base_path with
   | None -> ()
-  | Some base_path -> persist_snapshot ~base_path ~keeper_name q
+  | Some base_path ->
+    (match persist_snapshot ~base_path ~keeper_name q with
+     | Ok () -> ()
+     | Error msg -> raise (Persistence_failed msg))
+
+let persist_or_rollback ~keeper_name q ~before =
+  try persist_if_configured ~keeper_name q with
+  | Eio.Cancel.Cancelled _ as exn ->
+    replace_queue q before;
+    raise exn
+  | exn ->
+    replace_queue q before;
+    raise exn
 
 let persistence_configured () =
   match Atomic.get persistence_base_path with
@@ -232,25 +255,33 @@ let get_or_create_entry keeper_name =
       Hashtbl.add registry keeper_name entry;
       entry
 
-let enqueue ~keeper_name msg =
+let get_or_create_entry_locked keeper_name =
   Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      let entry = get_or_create_entry keeper_name in
-      Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
-          Queue.push msg entry.q;
-          persist_if_configured ~keeper_name entry.q))
+      get_or_create_entry keeper_name)
+
+let find_entry keeper_name =
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      Hashtbl.find_opt registry keeper_name)
+
+let enqueue ~keeper_name msg =
+  let entry = get_or_create_entry_locked keeper_name in
+  Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+      let before = queue_to_list entry.q in
+      Queue.push msg entry.q;
+      persist_or_rollback ~keeper_name entry.q ~before)
 
 let dequeue ~keeper_name =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      match Hashtbl.find_opt registry keeper_name with
-      | None -> None
-      | Some entry ->
-          Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
-              if Queue.is_empty entry.q
-              then None
-              else (
-                let msg = Queue.pop entry.q in
-                persist_if_configured ~keeper_name entry.q;
-                Some msg)))
+  match find_entry keeper_name with
+  | None -> None
+  | Some entry ->
+      Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+          if Queue.is_empty entry.q
+          then None
+          else (
+            let before = queue_to_list entry.q in
+            let msg = Queue.pop entry.q in
+            persist_or_rollback ~keeper_name entry.q ~before;
+            Some msg))
 
 let same_source a b =
   match (a, b) with
@@ -267,24 +298,24 @@ let same_source a b =
       false
 
 let dequeue_batch ~keeper_name =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      match Hashtbl.find_opt registry keeper_name with
-      | None -> []
-      | Some entry ->
-          Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
-              match Queue.take_opt entry.q with
-              | None -> []
-              | Some first ->
-                  let rec drain acc =
-                    match Queue.peek_opt entry.q with
-                    | Some next when same_source first.source next.source ->
-                        let next = Queue.pop entry.q in
-                        drain (next :: acc)
-                    | Some _ | None -> List.rev acc
-                  in
-                  let batch = first :: drain [] in
-                  persist_if_configured ~keeper_name entry.q;
-                  batch))
+  match find_entry keeper_name with
+  | None -> []
+  | Some entry ->
+      Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+          let before = queue_to_list entry.q in
+          match Queue.take_opt entry.q with
+          | None -> []
+          | Some first ->
+              let rec drain acc =
+                match Queue.peek_opt entry.q with
+                | Some next when same_source first.source next.source ->
+                    let next = Queue.pop entry.q in
+                    drain (next :: acc)
+                | Some _ | None -> List.rev acc
+              in
+              let batch = first :: drain [] in
+              persist_or_rollback ~keeper_name entry.q ~before;
+              batch)
 
 let merge_batch batch =
   match batch with
@@ -301,21 +332,20 @@ let merge_batch batch =
         }
 
 let length ~keeper_name =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      match Hashtbl.find_opt registry keeper_name with
-      | None -> 0
-      | Some entry ->
-          Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
-              Queue.length entry.q))
+  match find_entry keeper_name with
+  | None -> 0
+  | Some entry ->
+      Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+          Queue.length entry.q)
 
 let clear ~keeper_name =
-  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-      match Hashtbl.find_opt registry keeper_name with
-      | None -> ()
-      | Some entry ->
-          Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
-              Queue.clear entry.q;
-              persist_if_configured ~keeper_name entry.q))
+  match find_entry keeper_name with
+  | None -> ()
+  | Some entry ->
+      Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+          let before = queue_to_list entry.q in
+          Queue.clear entry.q;
+          persist_or_rollback ~keeper_name entry.q ~before)
 
 let all_keeper_names () =
   Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
@@ -333,19 +363,18 @@ let configure_persistence ~base_path =
         let q = load_snapshot ~base_path ~keeper_name in
         if Queue.length q > 0
         then
-          Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
-              match Hashtbl.find_opt registry keeper_name with
-              | Some entry ->
-                Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
-                    if Queue.is_empty entry.q then (
-                      Queue.iter (fun item -> Queue.push item entry.q) q;
-                      persist_if_configured ~keeper_name entry.q))
-              | None ->
-                let entry = { mutex = Eio.Mutex.create (); q } in
-                Hashtbl.add registry keeper_name entry))
+          let snapshot_items = queue_to_list q in
+          let entry = get_or_create_entry_locked keeper_name in
+          Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+              let before = queue_to_list entry.q in
+              replace_queue entry.q (snapshot_items @ before);
+              persist_or_rollback ~keeper_name entry.q ~before))
 
 module For_testing = struct
   let reset () =
+    Atomic.set fail_next_persist_for_testing false;
     Atomic.set persistence_base_path None;
     Eio.Mutex.use_rw ~protect:true registry_mutex (fun () -> Hashtbl.clear registry)
+
+  let fail_next_persist () = Atomic.set fail_next_persist_for_testing true
 end

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -4,7 +4,9 @@
     arrive while the keeper is already processing a previous message.
     When a stream finishes, the queue is drained automatically.
 
-    The queue is transient (not persisted).  Lost on server restart.
+    Queue contents can be mirrored to a per-keeper durable snapshot once
+    [configure_persistence] is called from server bootstrap.  This keeps
+    queued connector/dashboard follow-up messages replayable across restart.
 
     @since 2.145.0 *)
 
@@ -26,12 +28,196 @@ type queue_entry = {
   q : queued_message Queue.t;
 }
 
+let schema = "keeper_chat_queue.v1"
+let persistence_file = "chat-queue.json"
+let persistence_base_path : string option Atomic.t = Atomic.make None
+
 (** Global registry protected by a single mutex.
     Per-keeper queues have their own mutex for independent enqueue/dequeue
     parallelism; the global mutex is only for lookup/insertion into the
     registry. *)
 let registry_mutex = Eio.Mutex.create ()
 let registry : (string, queue_entry) Hashtbl.t = Hashtbl.create 16
+
+let valid_keeper_name name =
+  let valid_char = function
+    | 'A' .. 'Z' | 'a' .. 'z' | '0' .. '9' | '.' | '_' | '-' -> true
+    | _ -> false
+  in
+  (not (String.equal name "")) && String.for_all valid_char name
+
+let snapshot_path ~base_path ~keeper_name =
+  if valid_keeper_name keeper_name
+  then
+    Ok
+      (Filename.concat
+         (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+         persistence_file)
+  else Error (Printf.sprintf "invalid keeper name for chat queue snapshot: %s" keeper_name)
+
+let source_to_yojson = function
+  | Dashboard -> `Assoc [ ("kind", `String "dashboard") ]
+  | Discord { channel_id; user_id } ->
+    `Assoc
+      [ ("kind", `String "discord")
+      ; ("channel_id", `String channel_id)
+      ; ("user_id", `String user_id)
+      ]
+  | Slack { channel; user_id } ->
+    `Assoc
+      [ ("kind", `String "slack")
+      ; ("channel", `String channel)
+      ; ("user_id", `String user_id)
+      ]
+
+let source_of_yojson json =
+  match Json_util.get_string json "kind" with
+  | Some "dashboard" -> Ok Dashboard
+  | Some "discord" ->
+    let channel_id =
+      Json_util.get_string_with_default json ~key:"channel_id" ~default:""
+    in
+    let user_id = Json_util.get_string_with_default json ~key:"user_id" ~default:"" in
+    if String.trim channel_id = "" || String.trim user_id = ""
+    then Error "discord chat queue source requires channel_id and user_id"
+    else Ok (Discord { channel_id; user_id })
+  | Some "slack" ->
+    let channel = Json_util.get_string_with_default json ~key:"channel" ~default:"" in
+    let user_id = Json_util.get_string_with_default json ~key:"user_id" ~default:"" in
+    if String.trim channel = "" || String.trim user_id = ""
+    then Error "slack chat queue source requires channel and user_id"
+    else Ok (Slack { channel; user_id })
+  | Some kind -> Error (Printf.sprintf "unsupported chat queue source kind: %s" kind)
+  | None -> Error "chat queue source requires kind"
+
+let queued_message_to_yojson (msg : queued_message) =
+  `Assoc
+    [ ("content", `String msg.content)
+    ; ("user_blocks", Keeper_multimodal_input.user_blocks_to_yojson msg.user_blocks)
+    ; ("attachments", Keeper_multimodal_input.attachments_to_yojson msg.attachments)
+    ; ("timestamp", `Float msg.timestamp)
+    ; ("source", source_to_yojson msg.source)
+    ]
+
+let queued_message_of_yojson json =
+  match json with
+  | `Assoc _ ->
+    let content = Json_util.get_string_with_default json ~key:"content" ~default:"" in
+    (match Json_util.get_float json "timestamp" with
+     | None -> Error "chat queue message requires timestamp"
+     | Some timestamp ->
+       let attachments = Keeper_multimodal_input.parse_attachments json in
+       (match Keeper_multimodal_input.parse_user_blocks json with
+        | Error err -> Error err
+        | Ok user_blocks ->
+          (match Json_util.assoc_member_opt "source" json with
+           | None -> Error "chat queue message requires source"
+           | Some source_json ->
+             (match source_of_yojson source_json with
+              | Error err -> Error err
+              | Ok source -> Ok { content; user_blocks; attachments; timestamp; source }))))
+  | _ -> Error "chat queue message must be a JSON object"
+
+let queue_to_list q =
+  let acc = ref [] in
+  Queue.iter (fun item -> acc := item :: !acc) q;
+  List.rev !acc
+
+let queue_of_list items =
+  let q = Queue.create () in
+  List.iter (fun item -> Queue.push item q) items;
+  q
+
+let queue_to_yojson q =
+  `Assoc
+    [ ("schema", `String schema)
+    ; ("items", `List (List.map queued_message_to_yojson (queue_to_list q)))
+    ]
+
+let queue_of_yojson json =
+  match (Json_util.get_string json "schema", Json_util.assoc_member_opt "items" json) with
+  | Some s, _ when not (String.equal s schema) ->
+    Error (Printf.sprintf "unexpected chat queue snapshot schema: %s" s)
+  | None, _ -> Error "chat queue snapshot requires schema"
+  | Some _, Some (`List items) ->
+    let rec loop acc = function
+      | [] -> Ok (queue_of_list (List.rev acc))
+      | item :: rest ->
+        (match queued_message_of_yojson item with
+         | Ok parsed -> loop (parsed :: acc) rest
+         | Error err -> Error err)
+    in
+    loop [] items
+  | Some _, _ -> Error "chat queue snapshot requires items array"
+
+let save_json_atomic path json =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  json
+  |> Safe_ops.sanitize_json_utf8
+  |> Yojson.Safe.pretty_to_string
+  |> Fs_compat.save_file_atomic path
+
+let load_snapshot ~base_path ~keeper_name =
+  match snapshot_path ~base_path ~keeper_name with
+  | Error msg ->
+    Log.Keeper.warn "chat_queue_snapshot: %s" msg;
+    Queue.create ()
+  | Ok path ->
+    if not (Sys.file_exists path)
+    then Queue.create ()
+    else (
+      match Safe_ops.read_json_file_safe path with
+      | Error msg ->
+        Log.Keeper.warn
+          "chat_queue_snapshot: failed to read keeper=%s path=%s: %s"
+          keeper_name
+          path
+          msg;
+        Queue.create ()
+      | Ok json ->
+        (match queue_of_yojson json with
+         | Ok q ->
+           if Queue.length q > 0
+           then
+             Log.Keeper.info
+               "chat_queue_snapshot: restored %d queued messages for keeper=%s"
+               (Queue.length q)
+               keeper_name;
+           q
+         | Error msg ->
+           Log.Keeper.warn
+             "chat_queue_snapshot: failed to parse keeper=%s path=%s: %s"
+             keeper_name
+             path
+             msg;
+           Queue.create ()))
+
+let persist_snapshot ~base_path ~keeper_name q =
+  match snapshot_path ~base_path ~keeper_name with
+  | Error msg -> Log.Keeper.warn "chat_queue_snapshot: %s" msg
+  | Ok path ->
+    (try
+       match save_json_atomic path (queue_to_yojson q) with
+       | Ok () -> ()
+       | Error msg ->
+         Log.Keeper.warn
+           "chat_queue_snapshot: failed to persist keeper=%s path=%s: %s"
+           keeper_name
+           path
+           msg
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Keeper.warn
+         "chat_queue_snapshot: persist raised keeper=%s path=%s: %s"
+         keeper_name
+         path
+         (Printexc.to_string exn))
+
+let persist_if_configured ~keeper_name q =
+  match Atomic.get persistence_base_path with
+  | None -> ()
+  | Some base_path -> persist_snapshot ~base_path ~keeper_name q
 
 let get_or_create_entry keeper_name =
   match Hashtbl.find_opt registry keeper_name with
@@ -45,7 +231,8 @@ let enqueue ~keeper_name msg =
   Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
       let entry = get_or_create_entry keeper_name in
       Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
-          Queue.push msg entry.q))
+          Queue.push msg entry.q;
+          persist_if_configured ~keeper_name entry.q))
 
 let dequeue ~keeper_name =
   Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
@@ -53,7 +240,12 @@ let dequeue ~keeper_name =
       | None -> None
       | Some entry ->
           Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
-              if Queue.is_empty entry.q then None else Some (Queue.pop entry.q)))
+              if Queue.is_empty entry.q
+              then None
+              else (
+                let msg = Queue.pop entry.q in
+                persist_if_configured ~keeper_name entry.q;
+                Some msg)))
 
 let same_source a b =
   match (a, b) with
@@ -85,7 +277,9 @@ let dequeue_batch ~keeper_name =
                         drain (next :: acc)
                     | Some _ | None -> List.rev acc
                   in
-                  first :: drain []))
+                  let batch = first :: drain [] in
+                  persist_if_configured ~keeper_name entry.q;
+                  batch))
 
 let merge_batch batch =
   match batch with
@@ -115,8 +309,38 @@ let clear ~keeper_name =
       | None -> ()
       | Some entry ->
           Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
-              Queue.clear entry.q))
+              Queue.clear entry.q;
+              persist_if_configured ~keeper_name entry.q))
 
 let all_keeper_names () =
   Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
       Hashtbl.fold (fun name _ acc -> name :: acc) registry [])
+
+let configure_persistence ~base_path =
+  Atomic.set persistence_base_path (Some base_path);
+  let keepers_dir = Common.keepers_runtime_dir_of_base ~base_path in
+  if Sys.file_exists keepers_dir && Sys.is_directory keepers_dir
+  then
+    Sys.readdir keepers_dir
+    |> Array.iter (fun keeper_name ->
+      if valid_keeper_name keeper_name
+      then
+        let q = load_snapshot ~base_path ~keeper_name in
+        if Queue.length q > 0
+        then
+          Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+              match Hashtbl.find_opt registry keeper_name with
+              | Some entry ->
+                Eio.Mutex.use_rw ~protect:true entry.mutex (fun () ->
+                    if Queue.is_empty entry.q then (
+                      Queue.iter (fun item -> Queue.push item entry.q) q;
+                      persist_if_configured ~keeper_name entry.q))
+              | None ->
+                let entry = { mutex = Eio.Mutex.create (); q } in
+                Hashtbl.add registry keeper_name entry))
+
+module For_testing = struct
+  let reset () =
+    Atomic.set persistence_base_path None;
+    Eio.Mutex.use_rw ~protect:true registry_mutex (fun () -> Hashtbl.clear registry)
+end

--- a/lib/keeper/keeper_chat_queue.ml
+++ b/lib/keeper/keeper_chat_queue.ml
@@ -219,6 +219,11 @@ let persist_if_configured ~keeper_name q =
   | None -> ()
   | Some base_path -> persist_snapshot ~base_path ~keeper_name q
 
+let persistence_configured () =
+  match Atomic.get persistence_base_path with
+  | None -> false
+  | Some _ -> true
+
 let get_or_create_entry keeper_name =
   match Hashtbl.find_opt registry keeper_name with
   | Some entry -> entry

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -38,6 +38,10 @@ type queued_message = {
     snapshots into memory for queue-consumer replay. *)
 val configure_persistence : base_path:string -> unit
 
+(** [persistence_configured ()] reports whether durable snapshots are enabled
+    in this process. *)
+val persistence_configured : unit -> bool
+
 (** [enqueue keeper_name msg] adds [msg] to the tail of [keeper_name]'s
     queue.  Creates the queue lazily if it does not yet exist. *)
 val enqueue : keeper_name:string -> queued_message -> unit

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -4,7 +4,9 @@
     arrive while the keeper is already processing a previous message.
     When a stream finishes, the queue is drained automatically.
 
-    The queue is transient (not persisted).  Lost on server restart.
+    Once [configure_persistence] is called from server bootstrap, queue
+    mutations are mirrored to a per-keeper durable snapshot and replayed on
+    restart.
 
     Queue drain is handled by [Keeper_chat_consumer], started from
     server bootstrap.  The [source] field preserves connector context
@@ -30,6 +32,11 @@ type queued_message = {
 }
 
 (** {1 Queue operations} *)
+
+(** [configure_persistence base_path] enables durable per-keeper queue
+    snapshots under the runtime keeper directory and loads any non-empty
+    snapshots into memory for queue-consumer replay. *)
+val configure_persistence : base_path:string -> unit
 
 (** [enqueue keeper_name msg] adds [msg] to the tail of [keeper_name]'s
     queue.  Creates the queue lazily if it does not yet exist. *)
@@ -68,3 +75,7 @@ val clear : keeper_name:string -> unit
 (** [all_keeper_names ()] returns a snapshot list of all keeper names
     that currently have a queue in the registry. *)
 val all_keeper_names : unit -> string list
+
+module For_testing : sig
+  val reset : unit -> unit
+end

--- a/lib/keeper/keeper_chat_queue.mli
+++ b/lib/keeper/keeper_chat_queue.mli
@@ -6,7 +6,8 @@
 
     Once [configure_persistence] is called from server bootstrap, queue
     mutations are mirrored to a per-keeper durable snapshot and replayed on
-    restart.
+    restart. Snapshot rewrite failure aborts the mutation before a dequeued
+    message is acknowledged, keeping in-memory state and durable replay aligned.
 
     Queue drain is handled by [Keeper_chat_consumer], started from
     server bootstrap.  The [source] field preserves connector context
@@ -82,4 +83,5 @@ val all_keeper_names : unit -> string list
 
 module For_testing : sig
   val reset : unit -> unit
+  val fail_next_persist : unit -> unit
 end

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -770,6 +770,24 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
                    ])
            | other -> other
          in
+         let chat_queue =
+           let pending_messages =
+             match
+               try
+                 Eio.Fiber.yield ();
+                 Some ()
+               with
+               | Effect.Unhandled _ -> None
+             with
+             | None -> `Null
+             | Some () -> `Int (Keeper_chat_queue.length ~keeper_name:m.name)
+           in
+           `Assoc
+             [
+               ("pending_messages", pending_messages);
+               ("durable_replay_enabled", `Bool (Keeper_chat_queue.persistence_configured ()));
+             ]
+         in
 
          let json = `Assoc ([
            ("name", `String name);
@@ -952,6 +970,7 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            ("models_resolved", models_resolved);
            ("model_observability", model_observability);
            ("runtime_trust", runtime_trust);
+           ("chat_queue", chat_queue);
            ("runtime", runtime_surface_json config m);
            ("workspace", workspace_surface_json m);
            ("sources", source_provenance_json config m);

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -771,16 +771,18 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            | other -> other
          in
          let chat_queue =
+           (* [Keeper_chat_queue.length] reads behind a raw [Eio.Mutex], which
+              performs effects and raises [Effect.Unhandled] when no Eio scheduler
+              is running.  Production dispatch runs under [Eio_main.run] with
+              [Eio_guard.enable ()] (bin/main_eio.ml, bin/main_stdio_eio.ml,
+              bin/masc_worker_run.ml), so the depth is read there.  Pre-Eio /
+              non-Eio init paths (and unit tests that do not enable the guard)
+              report [`Null] instead of probing the scheduler via a side-effecting
+              [Eio.Fiber.yield] + [Effect.Unhandled] catch. *)
            let pending_messages =
-             match
-               try
-                 Eio.Fiber.yield ();
-                 Some ()
-               with
-               | Effect.Unhandled _ -> None
-             with
-             | None -> `Null
-             | Some () -> `Int (Keeper_chat_queue.length ~keeper_name:m.name)
+             if Eio_guard.is_ready ()
+             then `Int (Keeper_chat_queue.length ~keeper_name:m.name)
+             else `Null
            in
            `Assoc
              [

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -906,8 +906,10 @@ let start_keeper_loops
       (* Start queue consumer fiber for async queue drain.
          handle_turn wires process_single_turn for actual turn execution. *)
       (try
+         let base_path = (Mcp_server.workspace_config state).base_path in
+         Keeper_chat_queue.configure_persistence ~base_path;
          Keeper_chat_consumer.start ~sw ~clock
-           ~base_path:(Mcp_server.workspace_config state).base_path
+           ~base_path
            ~handle_turn:(fun ~sw ~keeper_name ~queued_message ->
              let open Server_routes_http_keeper_stream in
              let now = Time_compat.now () in

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -30,6 +30,15 @@ let check name cond =
     Printf.printf "  ✗ %s\n%!" name)
 ;;
 
+let raises f =
+  try
+    f ();
+    false
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | _ -> true
+;;
+
 let msg ?(attachments = []) ~content ~ts source =
   { Keeper_chat_queue.content; user_blocks = []; attachments; timestamp = ts; source }
 ;;
@@ -228,6 +237,56 @@ let test_persistence_replay () =
         (Keeper_chat_queue.dequeue_batch ~keeper_name = []))
 ;;
 
+let test_persist_failure_does_not_acknowledge_dequeue () =
+  Printf.printf "Test 6: failed dequeue persist keeps queue and snapshot aligned\n%!";
+  let base_path = temp_dir "keeper-chat-queue-persist-failure" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_chat_queue.For_testing.reset ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "chat-queue-persist-failure" in
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.configure_persistence ~base_path;
+      Keeper_chat_queue.enqueue ~keeper_name
+        (msg ~content:"must-not-ack" ~ts:1.0 Keeper_chat_queue.Dashboard);
+      Keeper_chat_queue.For_testing.fail_next_persist ();
+      check
+        "dequeue raises before acknowledging when snapshot rewrite fails"
+        (raises (fun () -> ignore (Keeper_chat_queue.dequeue_batch ~keeper_name)));
+      check
+        "in-memory queue rolls back after failed dequeue persist"
+        (Keeper_chat_queue.length ~keeper_name = 1);
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.configure_persistence ~base_path;
+      check
+        "stale snapshot replays the unacknowledged message exactly once"
+        (contents (Keeper_chat_queue.dequeue_batch ~keeper_name) = [ "must-not-ack" ]))
+;;
+
+let test_configure_persistence_prepends_snapshot_to_live_queue () =
+  Printf.printf "Test 7: restart snapshot prepends ahead of live bootstrap messages\n%!";
+  let base_path = temp_dir "keeper-chat-queue-prepend" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_chat_queue.For_testing.reset ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "chat-queue-prepend" in
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.configure_persistence ~base_path;
+      Keeper_chat_queue.enqueue ~keeper_name
+        (msg ~content:"snapshot-before-restart" ~ts:1.0 Keeper_chat_queue.Dashboard);
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.enqueue ~keeper_name
+        (msg ~content:"live-during-bootstrap" ~ts:2.0 Keeper_chat_queue.Dashboard);
+      Keeper_chat_queue.configure_persistence ~base_path;
+      check
+        "snapshot messages are not dropped when live queue is non-empty"
+        (contents (Keeper_chat_queue.dequeue_batch ~keeper_name)
+         = [ "snapshot-before-restart"; "live-during-bootstrap" ]))
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   test_same_source ();
@@ -235,6 +294,8 @@ let () =
   test_merge_batch ();
   test_in_flight_accessor ();
   test_persistence_replay ();
+  test_persist_failure_does_not_acknowledge_dequeue ();
+  test_configure_persistence_prepends_snapshot_to_live_queue ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_chat_coalescing.ml
+++ b/test/test_keeper_chat_coalescing.ml
@@ -10,6 +10,18 @@ open Masc
 
 let failures = ref 0
 
+let temp_dir prefix = Filename.temp_dir prefix ""
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+;;
+
 let check name cond =
   if cond
   then Printf.printf "  ✓ %s\n%!" name
@@ -38,6 +50,12 @@ let image_block ~attachment_id =
 ;;
 
 let contents batch = List.map (fun m -> m.Keeper_chat_queue.content) batch
+
+let chat_snapshot_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "chat-queue.json"
+;;
 
 let test_same_source () =
   Printf.printf "Test 1: same_source pairs reply routes correctly\n%!";
@@ -154,12 +172,69 @@ let test_in_flight_accessor () =
     (Keeper_turn_admission.in_flight ~base_path ~keeper_name = None)
 ;;
 
+let test_persistence_replay () =
+  Printf.printf "Test 5: queued chat messages persist and replay after restart\n%!";
+  let base_path = temp_dir "keeper-chat-queue-persistence" in
+  Fun.protect
+    ~finally:(fun () ->
+      Keeper_chat_queue.For_testing.reset ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "chat-queue-persistence" in
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.configure_persistence ~base_path;
+      Keeper_chat_queue.enqueue
+        ~keeper_name
+        { (msg ~content:"persist-1" ~ts:1.0 ~attachments:[ attachment ~id:"persist-a" ]
+             Keeper_chat_queue.Dashboard)
+          with
+          Keeper_chat_queue.user_blocks = [ image_block ~attachment_id:"persist-a" ]
+        };
+      Keeper_chat_queue.enqueue ~keeper_name
+        (msg ~content:"persist-2" ~ts:2.0 Keeper_chat_queue.Dashboard);
+      check
+        "snapshot file is written"
+        (Sys.file_exists (chat_snapshot_path ~base_path ~keeper_name));
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.configure_persistence ~base_path;
+      check
+        "restored keeper name is visible to consumer"
+        (List.mem keeper_name (Keeper_chat_queue.all_keeper_names ()));
+      let batch = Keeper_chat_queue.dequeue_batch ~keeper_name in
+      check "replayed batch preserves FIFO content" (contents batch = [ "persist-1"; "persist-2" ]);
+      check "queue is empty after replay drain" (Keeper_chat_queue.length ~keeper_name = 0);
+      (match batch with
+       | first :: _ ->
+         check
+           "replayed source route is preserved"
+           (Keeper_chat_queue.same_source
+              first.Keeper_chat_queue.source
+              Keeper_chat_queue.Dashboard);
+         check
+           "replayed attachment survives"
+           (List.map
+              (fun (a : Keeper_chat_store.attachment) -> a.Keeper_chat_store.id)
+              first.Keeper_chat_queue.attachments
+            = [ "persist-a" ]);
+         check
+           "replayed semantic user block survives"
+           (Keeper_multimodal_input.modalities first.Keeper_chat_queue.user_blocks
+            = [ "image" ])
+       | [] -> check "replayed batch is non-empty" false);
+      Keeper_chat_queue.For_testing.reset ();
+      Keeper_chat_queue.configure_persistence ~base_path;
+      check
+        "empty persisted queue does not replay after drain"
+        (Keeper_chat_queue.dequeue_batch ~keeper_name = []))
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   test_same_source ();
   test_dequeue_batch_runs ();
   test_merge_batch ();
   test_in_flight_accessor ();
+  test_persistence_replay ();
   if !failures > 0
   then (
     Printf.printf "FAILED: %d check(s)\n%!" !failures;

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -632,9 +632,15 @@ let test_status_surfaces_chat_queue_runtime () =
   let config = Workspace.default_config base in
   ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
   Eio_main.run @@ fun _env ->
+  (* Mirror production: the status handler runs under [Eio_main.run] with the
+     guard enabled (bin/main_eio.ml), so [Keeper_chat_queue.length] is read.
+     Disable on exit so other (non-Eio) cases keep reporting [`Null]. *)
+  Eio_guard.enable ();
   Masc.Keeper_chat_queue.For_testing.reset ();
   Fun.protect
-    ~finally:Masc.Keeper_chat_queue.For_testing.reset
+    ~finally:(fun () ->
+      Masc.Keeper_chat_queue.For_testing.reset ();
+      Eio_guard.disable ())
     (fun () ->
       Masc.Keeper_chat_queue.configure_persistence ~base_path:config.base_path;
       Masc.Keeper_chat_queue.enqueue

--- a/test/test_keeper_effective_meta_overlay.ml
+++ b/test/test_keeper_effective_meta_overlay.ml
@@ -102,6 +102,13 @@ let json_bool_field key = function
       | _ -> None)
   | _ -> None
 
+let json_int_field key = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`Int value) -> Some value
+      | _ -> None)
+  | _ -> None
+
 let json_assoc_field key = function
   | `Assoc fields -> (
       match List.assoc_opt key fields with
@@ -174,6 +181,19 @@ let status_goal_with ?(agent_name = "test-agent") ?name config =
   | None -> Alcotest.fail "status response missing goal"
 
 let status_goal config name = status_goal_with ~name config
+
+let status_json_with ?(agent_name = "test-agent") ?name config =
+  let args =
+    match name with
+    | Some name -> `Assoc [ ("name", `String name); ("fast", `Bool true) ]
+    | None -> `Assoc [ ("fast", `Bool true) ]
+  in
+  let result =
+    Status_detail.handle_keeper_status_config ~config ~agent_name args
+  in
+  if not (Profile.tool_result_success result) then
+    Alcotest.failf "status failed: %s" (Profile.tool_result_body result);
+  Yojson.Safe.from_string (Profile.tool_result_body result)
 
 let resolved_keeper_name config name =
   match
@@ -605,6 +625,38 @@ let test_status_cache_tracks_toml_overlay_changes () =
     "second cache goal after toml edit"
     (status_goal config name)
 
+let test_status_surfaces_chat_queue_runtime () =
+  with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
+  let name = "chatqueue-status" in
+  write_keeper_toml ~keepers_dir ~name ~sandbox_profile:"local" ~goal:"chat queue status";
+  let config = Workspace.default_config base in
+  ignore (seed_runtime_meta config name : Masc.Keeper_meta_contract.keeper_meta);
+  Eio_main.run @@ fun _env ->
+  Masc.Keeper_chat_queue.For_testing.reset ();
+  Fun.protect
+    ~finally:Masc.Keeper_chat_queue.For_testing.reset
+    (fun () ->
+      Masc.Keeper_chat_queue.configure_persistence ~base_path:config.base_path;
+      Masc.Keeper_chat_queue.enqueue
+        ~keeper_name:name
+        {
+          Masc.Keeper_chat_queue.content = "queued status probe";
+          user_blocks = [];
+          attachments = [];
+          timestamp = 1.0;
+          source = Masc.Keeper_chat_queue.Dashboard;
+        };
+      let status_json = status_json_with ~name config in
+      let chat_queue = json_assoc_field "chat_queue" status_json in
+      Alcotest.(check (option int))
+        "status exposes pending chat queue depth"
+        (Some 1)
+        (json_int_field "pending_messages" chat_queue);
+      Alcotest.(check (option bool))
+        "status exposes durable chat queue replay flag"
+        (Some true)
+        (json_bool_field "durable_replay_enabled" chat_queue))
+
 let test_keeper_list_row_surfaces_effective_meta_errors () =
   with_config_dir @@ fun ~base ~config_dir:_ ~keepers_dir ->
   let name = "badprofile" in
@@ -750,6 +802,8 @@ let () =
             `Quick test_missing_profile_source_fails_loud;
           Alcotest.test_case "status cache tracks TOML overlay edits" `Quick
             test_status_cache_tracks_toml_overlay_changes;
+          Alcotest.test_case "status surfaces chat queue runtime" `Quick
+            test_status_surfaces_chat_queue_runtime;
           Alcotest.test_case "keeper list surfaces effective meta errors"
             `Quick test_keeper_list_row_surfaces_effective_meta_errors;
           Alcotest.test_case

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1,8 +1,5 @@
 let temp_dir prefix =
-  let dir = Filename.temp_file prefix "" in
-  Unix.unlink dir;
-  Unix.mkdir dir 0o755;
-  dir
+  Filename.temp_dir prefix ""
 
 let rec rm_rf path =
   if Sys.file_exists path

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -1,3 +1,23 @@
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Unix.unlink path
+
+let snapshot_path ~base_path ~keeper_name =
+  Filename.concat
+    (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+    "event-queue.json"
+
 let () =
   let open Keeper_event_queue in
   let board_payload () =
@@ -161,5 +181,70 @@ let () =
   (match queue_of_yojson (`Assoc [ "schema", `String "wrong"; "items", `List [] ]) with
    | Ok _ -> Alcotest.fail "wrong queue snapshot schema should be rejected"
    | Error _ -> ());
+
+  (* --- durable snapshot store: persist/load and empty dequeue state --- *)
+  let base_path = temp_dir "keeper-event-queue-persistence" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-test" in
+      let q = enqueue empty board_stim |> fun q -> enqueue q bootstrap_stim in
+      Keeper_event_queue_persistence.persist ~base_path ~keeper_name q;
+      assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
+      let restored = Keeper_event_queue_persistence.load ~base_path ~keeper_name in
+      assert (length restored = 2);
+      let first, rest =
+        match dequeue restored with
+        | Some item -> item
+        | None -> Alcotest.fail "persisted queue should restore first stimulus"
+      in
+      assert (String.equal first.post_id "p1");
+      Keeper_event_queue_persistence.persist ~base_path ~keeper_name rest;
+      let second, rest =
+        match dequeue (Keeper_event_queue_persistence.load ~base_path ~keeper_name) with
+        | Some item -> item
+        | None -> Alcotest.fail "persisted queue should restore second stimulus"
+      in
+      assert (String.equal second.post_id "bootstrap");
+      Keeper_event_queue_persistence.persist ~base_path ~keeper_name rest;
+      assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
+
+  (* --- registry integration: CAS-successful enqueue persists and register reloads --- *)
+  let base_path = temp_dir "keeper-event-queue-registry" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-registry-test" in
+      let meta =
+        match
+          Masc.Keeper_meta_json_parse.meta_of_json
+            (`Assoc
+              [ "name", `String keeper_name
+              ; "agent_name", `String keeper_name
+              ; "trace_id", `String "trace-event-queue-registry-test"
+              ; "last_model_used", `String "llama:auto"
+              ; "tool_access", `List []
+              ])
+        with
+        | Ok meta -> meta
+        | Error msg -> Alcotest.fail ("meta parse failed: " ^ msg)
+      in
+      Masc.Keeper_registry.clear ();
+      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
+      assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
+      Masc.Keeper_registry.clear ();
+      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      let restored = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
+      assert (length restored = 1);
+      let replayed =
+        match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
+        | Some stim -> stim
+        | None -> Alcotest.fail "registry reload should replay pending stimulus"
+      in
+      assert (String.equal replayed.post_id "p1");
+      assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
   print_endline "test_keeper_event_queue: all passed"


### PR DESCRIPTION
## Summary
- Keep the existing per-keeper Event Layer queue durable replay regression coverage.
- Add durable `Keeper_chat_queue` snapshots for queued Dashboard/Discord/Slack follow-up messages under each keeper runtime directory.
- Load non-empty chat queue snapshots from server bootstrap before starting `Keeper_chat_consumer`, so restart-replayed messages become visible to the consumer.
- Preserve source route metadata, attachments, semantic user blocks, FIFO order, and fail closed on malformed snapshot timestamp/source data.
- Surface chat queue runtime state in `masc_keeper_status` as `chat_queue.pending_messages` plus `chat_queue.durable_replay_enabled` so operators and keepers can see pending replay pressure.

## Validation
- `ocamlformat --check lib/keeper/keeper_chat_queue.ml lib/keeper/keeper_chat_queue.mli lib/keeper/keeper_status_detail.ml lib/server/server_bootstrap_loops.ml test/test_keeper_chat_coalescing.ml test/test_keeper_effective_meta_overlay.ml test/test_keeper_event_queue.ml`
- `git diff --check`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_chat_coalescing.exe test/test_keeper_event_queue.exe test/test_keeper_effective_meta_overlay.exe`
- `./_build/default/test/test_keeper_chat_coalescing.exe`
- `./_build/default/test/test_keeper_event_queue.exe`
- `./_build/default/test/test_keeper_effective_meta_overlay.exe`
- `bash scripts/ci/check-determinism-contract.sh`
- `bash scripts/ci/check-masc-oas-boundary.sh`

## Notes
- Queue ownership stays in MASC. This does not move keeper lifecycle, queueing, or replay semantics into OAS.