### PR TITLE
feat(keeper): observe scheduled automation state

### DIFF
--- a/lib/keeper/keeper_context_layers.ml
+++ b/lib/keeper/keeper_context_layers.ml
@@ -6,6 +6,7 @@ type layer_id =
   | Namespace_state
   | Context_health
   | Autonomous_trigger
+  | Scheduled_automation
   | Continuity
   | Pending_mentions
   | Scope_messages
@@ -21,6 +22,7 @@ let ordered =
   ; Namespace_state
   ; Context_health
   ; Autonomous_trigger
+  ; Scheduled_automation
   ; Continuity
   ; Pending_mentions
   ; Scope_messages
@@ -38,11 +40,12 @@ let order_index = function
   | Namespace_state -> 2
   | Context_health -> 3
   | Autonomous_trigger -> 4
-  | Continuity -> 5
-  | Pending_mentions -> 6
-  | Scope_messages -> 7
-  | Claimable_work -> 8
-  | Board_activity -> 9
+  | Scheduled_automation -> 5
+  | Continuity -> 6
+  | Pending_mentions -> 7
+  | Scope_messages -> 8
+  | Claimable_work -> 9
+  | Board_activity -> 10
 ;;
 
 let assemble ~content_of =

--- a/lib/keeper/keeper_context_layers.mli
+++ b/lib/keeper/keeper_context_layers.mli
@@ -18,6 +18,7 @@ type layer_id =
   | Namespace_state
   | Context_health
   | Autonomous_trigger
+  | Scheduled_automation
   | Continuity
   | Pending_mentions
   | Scope_messages

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -189,6 +189,12 @@ let append_decision_record
                       - observation.claimable_task_count)) );
               ("failed_task_count", `Int observation.failed_task_count);
               ("pending_verification_count", `Int observation.pending_verification_count);
+              ( "scheduled_automation_active_count",
+                `Int observation.scheduled_automation.active_count );
+              ( "scheduled_automation_due_ready_count",
+                `Int observation.scheduled_automation.due_ready_count );
+              ( "scheduled_automation_blocked_approval_count",
+                `Int observation.scheduled_automation.blocked_approval_count );
               ("running_keeper_fiber_count", `Int observation.running_keeper_fiber_count);
             ] );
         ("claim_absolute_available", `Bool (observation.unclaimed_task_count > 0));

--- a/lib/keeper/keeper_unified_metrics_support.ml
+++ b/lib/keeper/keeper_unified_metrics_support.ml
@@ -454,6 +454,10 @@ let observed_triggers_of_observation
   let _ = meta in
   if observation.pending_verification_count > 0 then
     add "pending_verification";
+  if observation.scheduled_automation.due_ready_count > 0 then
+    add "scheduled_automation_due_ready";
+  if observation.scheduled_automation.blocked_approval_count > 0 then
+    add "scheduled_automation_blocked_approval";
   if observation.active_goals <> [] && observation.idle_seconds > 0 then
     add "idle_timeout_candidate";
   List.rev !triggers
@@ -477,6 +481,10 @@ let observed_affordances_of_observation
   if observation.failed_task_count > 0 then add "task_audit";
   if observation.pending_verification_count > 0 then
     add "task_verify";
+  if observation.scheduled_automation.due_ready_count > 0 then
+    add "schedule_dispatch_monitor";
+  if observation.scheduled_automation.blocked_approval_count > 0 then
+    add "schedule_grant_followup";
   List.rev !affordances
 
 let response_requests_confirmation (text : string) : bool =

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -185,6 +185,63 @@ let board_line_of_event
   else Observation_line line
 ;;
 
+let format_scheduled_automation_item
+    (item : Keeper_world_observation.scheduled_automation_item) : string =
+  let payload_kind =
+    match item.payload_kind with
+    | None -> "unknown"
+    | Some kind -> kind
+  in
+  Printf.sprintf
+    "- schedule_id=%s action=%s status=%s payload=%s recurrence=%S risk=%s due_at=%s"
+    item.schedule_id
+    item.action
+    item.status
+    payload_kind
+    item.recurrence_summary
+    item.risk_class
+    (Masc_domain.iso8601_of_unix_seconds item.due_at)
+;;
+
+let format_scheduled_automation_summary
+    (summary : Keeper_world_observation.scheduled_automation_observation)
+  : string option
+  =
+  let actionable =
+    summary.due_ready_count > 0 || summary.blocked_approval_count > 0
+  in
+  if (not actionable) && summary.active_count = 0
+  then None
+  else (
+    let ubuf = Buffer.create 256 in
+    Buffer.add_string ubuf "### Scheduled Automation\n";
+    Buffer.add_string ubuf
+      (Printf.sprintf
+         "- Active schedules: %d; ready: %d; blocked approval: %d\n"
+         summary.active_count
+         summary.due_ready_count
+         summary.blocked_approval_count);
+    (match summary.next_due_at with
+     | None -> ()
+     | Some due_at ->
+       Buffer.add_string ubuf
+         (Printf.sprintf
+            "- Next due: %s\n"
+            (Masc_domain.iso8601_of_unix_seconds due_at)));
+    if summary.items <> []
+    then (
+      Buffer.add_string ubuf "- Attention items:\n";
+      List.iter
+        (fun item ->
+           Buffer.add_string ubuf (format_scheduled_automation_item item);
+           Buffer.add_char ubuf '\n')
+        summary.items;
+      Buffer.add_string ubuf
+        "- Use masc_schedule_get for details; side-effecting schedules require a separate human grant before execution.\n");
+    Buffer.add_char ubuf '\n';
+    Some (Buffer.contents ubuf))
+;;
+
 let render_trusted_lines (lines : board_line list) : string =
   lines
   |> List.filter_map (function Trusted_line s -> Some s | Observation_line _ -> None)
@@ -840,7 +897,12 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
           ^ String.concat "\n" autonomous_trigger
           ^ "\n")
       else None
-    (* 6. Continuity — usually large and moderately stable, so keep it before
+    (* 6. Scheduled automation — durable MASC schedule store, not OAS/provider
+       state. Shows only identifiers and execution state so payload content does
+       not become trusted instruction text. *)
+    | Keeper_context_layers.Scheduled_automation ->
+      format_scheduled_automation_summary observation.scheduled_automation
+    (* 7. Continuity — usually large and moderately stable, so keep it before
        highly volatile reactive sections for better prefix reuse. Inject only
        forward-looking fields (Goal, Next plan, Next, OpenQuestions,
        Constraints). Backward-looking fields (Done, Progress, Decisions) are
@@ -859,7 +921,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
           ^ sanitized_continuity_for_prompt
           ^ "\n")
       else None
-    (* 7. Pending mentions — reactive trigger. *)
+    (* 8. Pending mentions — reactive trigger. *)
     | Keeper_context_layers.Pending_mentions ->
       if observation.pending_mentions <> [] then
         Some
@@ -868,7 +930,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
           ^ format_mentions observation.pending_mentions
           ^ "\n\n")
       else None
-    (* 8. Scope messages — reactive trigger. *)
+    (* 9. Scope messages — reactive trigger. *)
     | Keeper_context_layers.Scope_messages ->
       if observation.pending_scope_messages <> [] then
         Some
@@ -877,7 +939,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
           ^ format_scope_messages observation.pending_scope_messages
           ^ "\n\n")
       else None
-    (* 9. Claimable work — advisory operational guidance. Body lives at
+    (* 10. Claimable work — advisory operational guidance. Body lives at
        config/prompts/keeper.immediate_task_move.md. The OCaml side only owns
        the section header and the trailing blank line; the bullet prose stays in
        the markdown file alongside the other keeper prompts (see
@@ -891,7 +953,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
               Keeper_prompt_names.immediate_task_move
           ^ "\n")
       else None
-    (* 10. Board activity — reactive trigger.
+    (* 11. Board activity — reactive trigger.
        RFC-0247: partition by trust. Trusted = human-authored OR an explicit
        @mention (the Immediate-urgency actionable channel). Quarantined =
        fleet-authored narrative (self/peer/automation/unknown) — rendered inside

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -48,6 +48,33 @@ type pending_board_event =
       (* RFC-0247: computed at construction; drives trusted-vs-observational split *)
   }
 
+type scheduled_automation_item =
+  { schedule_id : string
+  ; action : string
+  ; status : string
+  ; payload_kind : string option
+  ; recurrence_summary : string
+  ; risk_class : string
+  ; due_at : float
+  }
+
+type scheduled_automation_observation =
+  { active_count : int
+  ; due_ready_count : int
+  ; blocked_approval_count : int
+  ; next_due_at : float option
+  ; items : scheduled_automation_item list
+  }
+
+let empty_scheduled_automation_observation =
+  { active_count = 0
+  ; due_ready_count = 0
+  ; blocked_approval_count = 0
+  ; next_due_at = None
+  ; items = []
+  }
+;;
+
 type world_observation =
   { pending_mentions : (string * string) list
   ; pending_board_events : pending_board_event list
@@ -61,6 +88,7 @@ type world_observation =
   ; provider_capacity_blocked_task_count : int
   ; failed_task_count : int
   ; pending_verification_count : int
+  ; scheduled_automation : scheduled_automation_observation
   ; backlog_updated_since_last_scheduled_autonomous : bool
   ; running_keeper_fiber_count : int
   ; connected_surfaces : Gate_surface.surface_presence list
@@ -78,6 +106,7 @@ type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Board_event_pending
   | Scope_message_pending
   | Scheduled_autonomous_turn
+  | Scheduled_automation_due
   | Idle_cooldown_elapsed of
       { idle_sec : int
       ; cooldown : int
@@ -190,6 +219,144 @@ let list_board_posts_after_cursor = Board_signal.list_posts_after_cursor
 module Continuity = Keeper_world_observation_continuity
 
 let read_continuity_summary = Continuity.read_continuity_summary
+
+let scheduled_automation_item_limit = 5
+
+let schedule_payload_kind (request : Schedule_domain.schedule_request) =
+  match Schedule_domain.payload_to_yojson request.payload with
+  | `Assoc fields ->
+    (match List.assoc_opt "kind" fields with
+     | Some (`String kind) -> Some kind
+     | _ -> None)
+  | _ -> None
+;;
+
+let schedule_effectively_expired ~now (request : Schedule_domain.schedule_request) =
+  let open Schedule_domain in
+  match request.status, request.expires_at with
+  | (Pending_approval | Scheduled | Due), Some expires_at when expires_at <= now ->
+    true
+  | ( Pending_approval | Scheduled | Due | Running | Succeeded | Failed | Rejected
+    | Cancelled | Expired )
+    , _ ->
+    false
+;;
+
+let schedule_effectively_active ~now (request : Schedule_domain.schedule_request) =
+  (not (Schedule_domain.is_terminal request.status))
+  && not (schedule_effectively_expired ~now request)
+;;
+
+let schedule_blocked_approval ~now state (request : Schedule_domain.schedule_request)
+  =
+  let open Schedule_domain in
+  request.due_at <= now
+  && (not (schedule_effectively_expired ~now request))
+  && Schedule_domain.requires_separate_human_grant request
+  &&
+  match request.status with
+  | Pending_approval -> true
+  | Due -> not (Schedule_store.has_current_approved_grant state request)
+  | Scheduled | Running | Succeeded | Failed | Rejected | Cancelled | Expired -> false
+;;
+
+let schedule_attention_item action (request : Schedule_domain.schedule_request) =
+  { schedule_id = request.schedule_id
+  ; action
+  ; status = Schedule_domain.schedule_status_to_string request.status
+  ; payload_kind = schedule_payload_kind request
+  ; recurrence_summary = Schedule_domain.recurrence_summary request.recurrence
+  ; risk_class = Schedule_domain.risk_class_to_string request.risk_class
+  ; due_at = request.due_at
+  }
+;;
+
+let compare_schedule_attention_item left right =
+  match compare left.due_at right.due_at with
+  | 0 -> String.compare left.schedule_id right.schedule_id
+  | cmp -> cmp
+;;
+
+let take n values =
+  let rec loop acc remaining = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | item :: rest -> loop (item :: acc) (remaining - 1) rest
+  in
+  loop [] n values
+;;
+
+let next_active_schedule_due_at ~now schedules =
+  schedules
+  |> List.filter (schedule_effectively_active ~now)
+  |> List.fold_left
+       (fun acc (request : Schedule_domain.schedule_request) ->
+          match acc with
+          | None -> Some request.due_at
+          | Some due_at -> Some (min due_at request.due_at))
+       None
+;;
+
+let schedule_query_failure_message = function
+  | Schedule_store.Corrupt_ledger_exn { primary_err; recovery_err } ->
+    (match recovery_err with
+     | None ->
+       Printf.sprintf
+         "schedule ledger corrupt while reading keeper observation: %s"
+         primary_err
+     | Some recovery_err ->
+       Printf.sprintf
+         "schedule ledger corrupt while reading keeper observation: %s; recovery: %s"
+         primary_err
+         recovery_err)
+  | exn -> Printexc.to_string exn
+;;
+
+let read_scheduled_automation_observation ~(config : Workspace.config) ~now =
+  try
+    let state = Schedule_store.read_state config in
+    let due_ready =
+      Schedule_store.due_execution_candidates state
+      |> List.filter (fun request -> not (schedule_effectively_expired ~now request))
+    in
+    let blocked =
+      state.schedules |> List.filter (schedule_blocked_approval ~now state)
+    in
+    let active_count =
+      state.schedules
+      |> List.fold_left
+           (fun count request ->
+              if schedule_effectively_active ~now request then count + 1 else count)
+           0
+    in
+    let due_items =
+      List.map (schedule_attention_item "dispatch_ready") due_ready
+    in
+    let blocked_items =
+      List.map (schedule_attention_item "approve_or_reject") blocked
+    in
+    { active_count
+    ; due_ready_count = List.length due_ready
+    ; blocked_approval_count = List.length blocked
+    ; next_due_at = next_active_schedule_due_at ~now state.schedules
+    ; items =
+        due_items @ blocked_items
+        |> List.sort compare_schedule_attention_item
+        |> take scheduled_automation_item_limit
+    }
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Otel_metric_store.inc_counter
+      Keeper_metrics.(to_string ObservationQueryFailures)
+      ~labels:
+        [ ( "operation"
+          , Runtime_observation_query_operation.(to_label Scheduled_automation) )
+        ]
+      ();
+    Log.Keeper.warn "%s" (schedule_query_failure_message exn);
+    empty_scheduled_automation_observation
+;;
 
 (** Board event cursor bootstrap window (seconds). *)
 let bootstrap_window_sec = Env_config.InternalTimers.bootstrap_window_sec
@@ -556,6 +723,9 @@ let observe
   in
   let running_keeper_fiber_count = count_running_keeper_fibers ~config in
   let idle_seconds = compute_idle_seconds ~meta in
+  let scheduled_automation =
+    read_scheduled_automation_observation ~config ~now:(Time_compat.now ())
+  in
   (* Defer the checkpoint load (file read + Yojson parse + sanitize + O(n)
      tool-pair repair) out of [observe]. Most cycles are no-op skips where
      the gate decides not to run; on those, [context_ratio] is never forced
@@ -585,6 +755,7 @@ let observe
   ; provider_capacity_blocked_task_count
   ; failed_task_count
   ; pending_verification_count
+  ; scheduled_automation
   ; backlog_updated_since_last_scheduled_autonomous
   ; running_keeper_fiber_count
   ; connected_surfaces =
@@ -606,6 +777,9 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   let provider_capacity_blocked_task_count =
     provider_capacity_blocked_task_count ~meta ~claimable_task_count ()
   in
+  let scheduled_automation =
+    read_scheduled_automation_observation ~config ~now:(Time_compat.now ())
+  in
   { pending_mentions = []
   ; pending_board_events = []
   ; pending_scope_messages = []
@@ -618,6 +792,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   ; provider_capacity_blocked_task_count
   ; failed_task_count
   ; pending_verification_count
+  ; scheduled_automation
   ; backlog_updated_since_last_scheduled_autonomous
   ; running_keeper_fiber_count = count_running_keeper_fibers ~config
   ; connected_surfaces =
@@ -654,12 +829,17 @@ let durable_signal_present
       in
       events
   in
+  let scheduled_automation =
+    read_scheduled_automation_observation ~config ~now:(Time_compat.now ())
+  in
   pending_mentions <> []
   || pending_board_events <> []
   || pending_scope_messages <> []
   || claimable_task_count > 0
   || failed_task_count > 0
   || pending_verification_count > 0
+  || scheduled_automation.due_ready_count > 0
+  || scheduled_automation.blocked_approval_count > 0
 ;;
 
 let actionable_signal_present (observation : world_observation) =
@@ -669,6 +849,8 @@ let actionable_signal_present (observation : world_observation) =
   || observation.claimable_task_count > 0
   || observation.failed_task_count > 0
   || observation.pending_verification_count > 0
+  || observation.scheduled_automation.due_ready_count > 0
+  || observation.scheduled_automation.blocked_approval_count > 0
 ;;
 
 let proactive_work_signal_present ~(meta : keeper_meta) (observation : world_observation) =
@@ -681,6 +863,8 @@ let proactive_work_signal_present ~(meta : keeper_meta) (observation : world_obs
   || observation.pending_board_events <> []
   || observation.pending_scope_messages <> []
   || task_backlog_signal
+  || observation.scheduled_automation.due_ready_count > 0
+  || observation.scheduled_automation.blocked_approval_count > 0
   || Option.is_some meta.current_task_id
 ;;
 
@@ -819,10 +1003,18 @@ let keeper_cycle_decision
         let has_actionable_tasks =
           observation.claimable_task_count > 0 || observation.failed_task_count > 0
         in
+        let has_actionable_schedule =
+          observation.scheduled_automation.due_ready_count > 0
+          || observation.scheduled_automation.blocked_approval_count > 0
+        in
         let idle_gate_elapsed = observation.idle_seconds >= idle_gate_sec in
         let cooldown_elapsed = since_last_scheduled_autonomous >= effective_cooldown in
         let backlog_elapsed =
           has_actionable_tasks
+          && since_last_scheduled_autonomous >= task_reactive_cooldown
+        in
+        let schedule_elapsed =
+          has_actionable_schedule
           && since_last_scheduled_autonomous >= task_reactive_cooldown
         in
         let backlog_fresh =
@@ -875,9 +1067,11 @@ let keeper_cycle_decision
         let backlog_drives_turn =
           (not reactive_wake) && (backlog_fresh || backlog_elapsed)
         in
+        let schedule_drives_turn = (not reactive_wake) && schedule_elapsed in
         let should_run =
           is_bootstrap
           || min_interval_elapsed
+          || schedule_drives_turn
           || (proactive_work_ready
               && (backlog_drives_turn || (idle_gate_elapsed && cooldown_elapsed)))
         in
@@ -942,7 +1136,8 @@ let keeper_cycle_decision
                         ; failed = observation.failed_task_count
                         })
                  else None)
-              ; (if backlog_fresh || backlog_elapsed
+              ; (if has_actionable_schedule then Some Scheduled_automation_due else None)
+              ; (if backlog_fresh || backlog_elapsed || schedule_elapsed
                  then Some Task_reactive_cooldown_elapsed
                  else None)
               ]

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -63,6 +63,28 @@ type pending_board_event = {
       trusted-vs-observational rendering split. *)
 }
 
+(** Read-only projection of one schedule row that needs keeper attention. *)
+type scheduled_automation_item = {
+  schedule_id : string;
+  action : string;
+  status : string;
+  payload_kind : string option;
+  recurrence_summary : string;
+  risk_class : string;
+  due_at : float;
+}
+
+(** Durable scheduled-automation summary from the MASC schedule store. *)
+type scheduled_automation_observation = {
+  active_count : int;
+  due_ready_count : int;
+  blocked_approval_count : int;
+  next_due_at : float option;
+  items : scheduled_automation_item list;
+}
+
+val empty_scheduled_automation_observation : scheduled_automation_observation
+
 (** Snapshot of the world as seen by a keeper at heartbeat time. *)
 type world_observation = {
   pending_mentions : (string * string) list;
@@ -105,6 +127,11 @@ type world_observation = {
   pending_verification_count : int;
   (** Number of tasks awaiting cross-agent verification. *)
 
+  scheduled_automation : scheduled_automation_observation;
+  (** Durable schedule-store state that needs keeper attention, such as due
+      requests ready to dispatch or side-effecting due requests blocked on a
+      separate human grant. *)
+
   backlog_updated_since_last_scheduled_autonomous : bool;
   (** [true] when the backlog changed after the keeper's last scheduled
       autonomous attempt. Lets task-triggered wakeups bypass cooldown once
@@ -133,6 +160,7 @@ type turn_reason =
   | Board_event_pending
   | Scope_message_pending
   | Scheduled_autonomous_turn
+  | Scheduled_automation_due
   | Idle_cooldown_elapsed of { idle_sec : int; cooldown : int }
   | Cooldown_elapsed
   | Task_backlog of { unclaimed : int; failed : int }
@@ -256,6 +284,11 @@ val read_continuity_summary :
   config:Workspace.config ->
   meta:Keeper_meta_contract.keeper_meta ->
   string
+
+val read_scheduled_automation_observation :
+  config:Workspace.config ->
+  now:float ->
+  scheduled_automation_observation
 
 (** Build a world observation from workspace state and keeper metadata.
 

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -6,7 +6,7 @@
     (proactive turns on a timer). [unified_turn_channel] is an alias
     retained for legacy callers.
 
-    [turn_reason] carries the 11 reasons a keeper *runs* a turn
+    [turn_reason] carries the reasons a keeper *runs* a turn
     (mention, board event, scope message, scheduled autonomous, idle
     cooldown elapsed with timers, etc.). Inline-record variants carry
     the timing fields the dashboard surfaces.
@@ -34,6 +34,7 @@ type turn_reason =
   | Board_event_pending
   | Scope_message_pending
   | Scheduled_autonomous_turn
+  | Scheduled_automation_due
   | Idle_cooldown_elapsed of
       { idle_sec : int
       ; cooldown : int
@@ -65,6 +66,7 @@ let turn_reason_to_string = function
   | Board_event_pending -> "board_event_pending"
   | Scope_message_pending -> "scope_message_pending"
   | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
+  | Scheduled_automation_due -> "scheduled_automation_due"
   | Idle_cooldown_elapsed _ -> "idle_cooldown_elapsed"
   | Cooldown_elapsed -> "cooldown_elapsed"
   | Task_backlog _ -> "task_backlog"

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -11,6 +11,7 @@ type turn_reason =
   | Board_event_pending
   | Scope_message_pending
   | Scheduled_autonomous_turn
+  | Scheduled_automation_due
   | Idle_cooldown_elapsed of
       { idle_sec : int
       ; cooldown : int

--- a/lib/runtime_observation_query_operation.ml
+++ b/lib/runtime_observation_query_operation.ml
@@ -3,6 +3,7 @@ type t =
   | Count_running_keeper_fibers
   | Cursor_stale
   | Board_events
+  | Scheduled_automation
   | Empty_run_reasons
   | Reconcile_read_meta
 
@@ -11,6 +12,7 @@ let to_label = function
   | Count_running_keeper_fibers -> "count_running_keeper_fibers"
   | Cursor_stale -> "cursor_stale"
   | Board_events -> "board_events"
+  | Scheduled_automation -> "scheduled_automation"
   | Empty_run_reasons -> "empty_run_reasons"
   | Reconcile_read_meta -> "reconcile_read_meta"
 ;;

--- a/lib/runtime_observation_query_operation.mli
+++ b/lib/runtime_observation_query_operation.mli
@@ -10,6 +10,7 @@ type t =
   | Count_running_keeper_fibers
   | Cursor_stale
   | Board_events
+  | Scheduled_automation
   | Empty_run_reasons
   | Reconcile_read_meta (** Supervisor reconcile-loop meta read failure (#14828 sweep). *)
 

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -82,6 +82,7 @@ let base_observation : WO.world_observation =
   ; provider_capacity_blocked_task_count = 0
   ; failed_task_count = 0
   ; pending_verification_count = 0
+  ; scheduled_automation = WO.empty_scheduled_automation_observation
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; running_keeper_fiber_count = 0
   ; connected_surfaces = []

--- a/test/test_keeper_context_layers.ml
+++ b/test/test_keeper_context_layers.ml
@@ -16,6 +16,7 @@ let all_layers =
     L.Namespace_state;
     L.Context_health;
     L.Autonomous_trigger;
+    L.Scheduled_automation;
     L.Continuity;
     L.Pending_mentions;
     L.Scope_messages;
@@ -49,7 +50,7 @@ let test_order_index_is_injective () =
     (List.length all_layers) (List.length sorted)
 
 let test_assemble_concatenates_present_in_order () =
-  (* Render a label for three layers spread across the order (positions 0, 3, 9)
+  (* Render a label for three layers spread across the order (positions 0, 3, 10)
      and nothing for the rest; assemble must yield them in ordered order. *)
   let content_of = function
     | L.Active_goals -> Some "A"
@@ -64,9 +65,9 @@ let test_assemble_empty_when_all_absent () =
   check string "no layers -> empty body" "" (L.assemble ~content_of:(fun _ -> None))
 
 let test_assemble_all_present_follows_ordered () =
-  (* Each layer renders its own order index; the result must read 0..9. *)
+  (* Each layer renders its own order index; the result must read 0..10. *)
   let content_of id = Some (string_of_int (L.order_index id)) in
-  check string "every layer present -> indices in order" "0123456789"
+  check string "every layer present -> indices in order" "012345678910"
     (L.assemble ~content_of)
 
 let () =

--- a/test/test_keeper_no_signal_silence.ml
+++ b/test/test_keeper_no_signal_silence.ml
@@ -118,6 +118,7 @@ let no_signal_obs : WO.world_observation =
   ; provider_capacity_blocked_task_count = 0
   ; failed_task_count = 0
   ; pending_verification_count = 0
+  ; scheduled_automation = WO.empty_scheduled_automation_observation
   ; backlog_updated_since_last_scheduled_autonomous = false
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []
@@ -131,6 +132,32 @@ let decide_no_signal () =
     ~reactive_wake:false
     ~meta
     no_signal_obs
+;;
+
+let schedule_attention_obs =
+  { no_signal_obs with
+    scheduled_automation =
+      { WO.empty_scheduled_automation_observation with
+        active_count = 1
+      ; due_ready_count = 1
+      }
+  }
+;;
+
+let schedule_ready_meta () =
+  let meta = warm_meta () in
+  let now = Time_compat.now () in
+  { meta with
+    proactive = { meta.proactive with cooldown_sec = 60 }
+  ; runtime =
+      { meta.runtime with
+        proactive_rt =
+          { meta.runtime.proactive_rt with
+            last_ts = now -. 120.0
+          ; consecutive_noop_count = 0
+          }
+      }
+  }
 ;;
 
 (* Core invariant (PR #21685): a warm keeper with no signal and no backlog
@@ -157,6 +184,21 @@ let test_no_signal_keeps_scheduled_channel () =
      | WO.Scheduled_autonomous -> true
      | WO.Reactive -> false)
 
+let test_scheduled_automation_attention_runs_after_task_cooldown () =
+  let meta = schedule_ready_meta () in
+  let d =
+    WO.keeper_cycle_decision
+      ~provider_cooldown_remaining_sec:no_provider_cooldown
+      ~reactive_wake:false
+      ~meta
+      schedule_attention_obs
+  in
+  check bool "scheduled automation attention runs" true d.should_run;
+  check bool "reason includes scheduled_automation_due" true
+    (List.mem
+       "scheduled_automation_due"
+       (WO.verdict_reasons_to_strings d.verdict))
+
 let () = init_runtime_default_for_tests ()
 
 let () =
@@ -171,6 +213,10 @@ let () =
             "no-signal silence keeps scheduled channel"
             `Quick
             test_no_signal_keeps_scheduled_channel
+        ; test_case
+            "scheduled automation attention runs after task cooldown"
+            `Quick
+            test_scheduled_automation_attention_runs_after_task_cooldown
         ] )
     ]
 ;;

--- a/test/test_keeper_reactive_wake_backlog_gate.ml
+++ b/test/test_keeper_reactive_wake_backlog_gate.ml
@@ -110,6 +110,7 @@ let global_backlog_obs : WO.world_observation =
   ; provider_capacity_blocked_task_count = 0
   ; failed_task_count = 0
   ; pending_verification_count = 0
+  ; scheduled_automation = WO.empty_scheduled_automation_observation
   ; backlog_updated_since_last_scheduled_autonomous = true
   ; running_keeper_fiber_count = 1
   ; connected_surfaces = []

--- a/test/test_keeper_surface_presence_prompt.ml
+++ b/test/test_keeper_surface_presence_prompt.ml
@@ -62,6 +62,7 @@ let base_observation : WO.world_observation =
     provider_capacity_blocked_task_count = 0;
     failed_task_count = 0;
     pending_verification_count = 0;
+    scheduled_automation = WO.empty_scheduled_automation_observation;
     backlog_updated_since_last_scheduled_autonomous = false;
     running_keeper_fiber_count = 0;
     connected_surfaces = [];

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -17,6 +17,7 @@ let base_observation : WO.world_observation =
     provider_capacity_blocked_task_count = 0;
     failed_task_count = 0;
     pending_verification_count = 0;
+    scheduled_automation = WO.empty_scheduled_automation_observation;
     backlog_updated_since_last_scheduled_autonomous = false;
     running_keeper_fiber_count = 0;
     connected_surfaces = [];
@@ -40,6 +41,32 @@ let sample_board_event : WO.pending_board_event =
     provenance = WO.Human_direct;
   }
 
+let scheduled_automation_observation : WO.scheduled_automation_observation =
+  { active_count = 2
+  ; due_ready_count = 1
+  ; blocked_approval_count = 1
+  ; next_due_at = Some 200.0
+  ; items =
+      [ { schedule_id = "sched-ready"
+        ; action = "dispatch_ready"
+        ; status = "due"
+        ; payload_kind = Some "masc.board_post"
+        ; recurrence_summary = "daily 09:00:00 Asia/Seoul"
+        ; risk_class = "read_only"
+        ; due_at = 200.0
+        }
+      ; { schedule_id = "sched-blocked"
+        ; action = "approve_or_reject"
+        ; status = "pending_approval"
+        ; payload_kind = Some "masc.board_post"
+        ; recurrence_summary = "one_shot"
+        ; risk_class = "workspace_write"
+        ; due_at = 180.0
+        }
+      ]
+  }
+;;
+
 let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
   let json =
     `Assoc
@@ -54,6 +81,39 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
   | Error e -> failwith ("meta_of_json failed: " ^ e)
 
 let minimal_meta : Masc.Keeper_meta_contract.keeper_meta = make_meta "test-keeper"
+
+let runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+;;
+
+let init_runtime_default_for_tests () =
+  let path = Filename.temp_file "keeper_schedule_observation_runtime_" ".toml" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc runtime_toml);
+  match Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
+;;
 
 let test_task_verify_affordance_for_keeper () =
   let meta = { minimal_meta with mention_targets = [ "analyst" ] } in
@@ -216,6 +276,40 @@ let test_pending_verification_trigger_for_verifier_tag () =
   check bool "pending_verification present for verifier-tagged keeper" true
     (List.mem "pending_verification" triggers)
 
+let test_scheduled_automation_triggers_and_affordances () =
+  let obs =
+    { base_observation with scheduled_automation = scheduled_automation_observation }
+  in
+  let triggers = UM.observed_triggers_of_observation obs in
+  check bool "due-ready schedule trigger present" true
+    (List.mem "scheduled_automation_due_ready" triggers);
+  check bool "blocked schedule trigger present" true
+    (List.mem "scheduled_automation_blocked_approval" triggers);
+  let affordances = UM.observed_affordances_of_observation obs in
+  check bool "dispatch monitor affordance present" true
+    (List.mem "schedule_dispatch_monitor" affordances);
+  check bool "grant followup affordance present" true
+    (List.mem "schedule_grant_followup" affordances)
+
+let test_scheduled_automation_prompt_section () =
+  Masc_test_deps.init_keeper_tool_registry ();
+  init_runtime_default_for_tests ();
+  let obs =
+    { base_observation with scheduled_automation = scheduled_automation_observation }
+  in
+  let _, user_msg =
+    Masc.Keeper_unified_prompt.build_prompt ~meta:minimal_meta ~base_path:"/tmp"
+      ~observation:obs ()
+  in
+  check bool "prompt includes schedule section" true
+    (contains_sub "### Scheduled Automation" user_msg);
+  check bool "prompt includes ready schedule id" true
+    (contains_sub "schedule_id=sched-ready" user_msg);
+  check bool "prompt includes blocked action" true
+    (contains_sub "action=approve_or_reject" user_msg);
+  check bool "prompt points to schedule detail tool" true
+    (contains_sub "masc_schedule_get" user_msg)
+
 let () =
   run "keeper_unified_verification_surface"
     [
@@ -250,5 +344,11 @@ let () =
           test_case
             "trigger: verifier-tagged keeper also sees pending_verification"
             `Quick test_pending_verification_trigger_for_verifier_tag;
+          test_case
+            "trigger: scheduled automation attention is observable"
+            `Quick test_scheduled_automation_triggers_and_affordances;
+          test_case
+            "prompt: scheduled automation section renders attention items"
+            `Quick test_scheduled_automation_prompt_section;
         ] );
     ]

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -384,6 +384,49 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
       (row |> member "last_execution" |> member "detail" |> member "kind" |> to_string)
 ;;
 
+let test_keeper_observation_surfaces_schedule_attention () =
+  with_config
+  @@ fun config ->
+  let now = 1_000.0 in
+  ignore
+    (create_schedule_exn config ~schedule_id:"sched-ready" ~due_at:(now -. 10.0)
+       ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
+       ~scheduled_by:(automated "scheduler-agent")
+       ()
+      : Schedule_domain.schedule_request);
+  ignore
+    (create_schedule_exn config ~schedule_id:"sched-blocked" ~due_at:(now -. 20.0)
+       ~risk_class:Schedule_domain.Workspace_write ~requested_by:(human "operator")
+       ~scheduled_by:(automated "scheduler-agent")
+       ()
+      : Schedule_domain.schedule_request);
+  ignore
+    (create_schedule_exn config ~schedule_id:"sched-future" ~due_at:(now +. 3600.0)
+       ~risk_class:Schedule_domain.Read_only ~requested_by:(human "operator")
+       ~scheduled_by:(automated "scheduler-agent")
+       ()
+      : Schedule_domain.schedule_request);
+  (match Schedule_store.refresh_due config ~now with
+   | Ok _ -> ()
+   | Error err -> fail (Schedule_store.store_error_to_string err));
+  let observation =
+    Keeper_world_observation.read_scheduled_automation_observation ~config ~now
+  in
+  check int "active count" 3 observation.active_count;
+  check int "due ready count" 1 observation.due_ready_count;
+  check int "blocked approval count" 1 observation.blocked_approval_count;
+  check (option (float 0.001)) "next due" (Some (now -. 20.0))
+    observation.next_due_at;
+  check int "attention items" 2 (List.length observation.items);
+  (match observation.items with
+   | blocked :: ready :: [] ->
+     check string "blocked schedule first" "sched-blocked" blocked.schedule_id;
+     check string "blocked action" "approve_or_reject" blocked.action;
+     check string "ready schedule second" "sched-ready" ready.schedule_id;
+     check string "ready action" "dispatch_ready" ready.action
+   | _ -> fail "expected blocked and ready attention rows")
+;;
+
 let () =
   run "Schedule_tool_wiring"
     [ ( "wiring"
@@ -399,6 +442,8 @@ let () =
             test_dispatch_cancel_persists_status
         ; test_case "dashboard projection surfaces schedule FSM" `Quick
             test_dashboard_projection_surfaces_schedule_fsm
+        ; test_case "keeper observation surfaces schedule attention" `Quick
+            test_keeper_observation_surfaces_schedule_attention
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Add a Keeper world-observation projection for durable scheduled automation state from the MASC schedule store.
- Surface due-ready and approval-blocked schedule attention in Keeper prompt context, trigger/affordance telemetry, and scheduled-autonomous run reasons.
- Keep the boundary MASC-owned: no OAS/provider changes, no schedule execution consumer changes, no payload-body injection into trusted prompt text.

## Validation
- ocamlformat --check on touched OCaml files
- git diff --check HEAD~1..HEAD
- scripts/dune-local.sh build test/test_schedule_tool_wiring.exe test/test_keeper_unified_verification_surface.exe test/test_keeper_context_layers.exe test/test_keeper_no_signal_silence.exe test/test_keeper_reactive_wake_backlog_gate.exe test/test_heartbeat_integration.exe
- ./_build/default/test/test_schedule_tool_wiring.exe
- ./_build/default/test/test_keeper_unified_verification_surface.exe
- ./_build/default/test/test_keeper_context_layers.exe
- ./_build/default/test/test_keeper_no_signal_silence.exe
- ./_build/default/test/test_keeper_reactive_wake_backlog_gate.exe
- ./_build/default/test/test_heartbeat_integration.exe

## Notes
- Due-ready and approval-blocked schedules are attention signals only; actual schedule dispatch remains in the existing server maintenance runner/consumer path.
- Side-effecting schedules still require a separate human grant before execution.