### PR TITLE
feat(memory): surface user model projection

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3569,6 +3569,14 @@ export interface MemorySubsystemsUserModelError {
   error: string
 }
 
+export interface MemorySubsystemsUserModelPrompt {
+  enabled: boolean
+  block_id: string
+  injection: string
+  runtime_hook: string
+  producer?: string
+}
+
 export interface MemorySubsystemsResponse {
   generated_at: string
   hebbian: {
@@ -3597,6 +3605,7 @@ export interface MemorySubsystemsResponse {
   user_model?: {
     schema: string
     source: string
+    prompt?: MemorySubsystemsUserModelPrompt
     total: number
     filtered: number
     shown: number

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3552,6 +3552,23 @@ export interface MemorySubsystemsMemoryEntryError {
   error_class: string
 }
 
+export interface MemorySubsystemsUserModelItem {
+  keeper: string
+  kind: 'preference' | 'constraint' | string
+  claim: string
+  source_ref: string
+  source_trace_id: string
+  source_turn: number
+  first_seen: number
+  last_verified_at: number | null
+  observed_by: string[]
+}
+
+export interface MemorySubsystemsUserModelError {
+  keeper: string
+  error: string
+}
+
 export interface MemorySubsystemsResponse {
   generated_at: string
   hebbian: {
@@ -3576,6 +3593,16 @@ export interface MemorySubsystemsResponse {
      *  the corresponding rows are absent from `items`; the rest of
      *  `items` is still trustworthy. */
     errors?: MemorySubsystemsMemoryEntryError[]
+  }
+  user_model?: {
+    schema: string
+    source: string
+    total: number
+    filtered: number
+    shown: number
+    limit: number
+    items: MemorySubsystemsUserModelItem[]
+    errors?: MemorySubsystemsUserModelError[]
   }
   filters: {
     keepers: string[]

--- a/dashboard/src/components/memory-subsystems.focus.test.ts
+++ b/dashboard/src/components/memory-subsystems.focus.test.ts
@@ -47,6 +47,13 @@ const baseResponse: MemorySubsystemsResponse = {
   user_model: {
     schema: 'masc.user_model.memory_projection.v1',
     source: 'memory_os_facts',
+    prompt: {
+      enabled: true,
+      block_id: 'user_model',
+      injection: 'extra_system_context',
+      runtime_hook: 'keeper_run_tools_hooks.before_turn_params',
+      producer: 'keeper_user_model',
+    },
     total: 2,
     filtered: 2,
     shown: 2,
@@ -171,10 +178,12 @@ describe('MemorySubsystems focus targets', () => {
 
     await vi.waitFor(() => {
       expect(container.textContent).toContain('User model')
+      expect(container.textContent).toContain('prompt on · user_model')
       expect(container.textContent).toContain('User prefers terse operational summaries')
       expect(container.textContent).toContain('Use worktrees for repo changes')
     })
     expect(container.querySelector('[data-testid="user-model-projection"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="user-model-prompt-surface"]')).not.toBeNull()
   })
 
   it('focuses the episodes section without requesting memory entries for episodes focus', async () => {

--- a/dashboard/src/components/memory-subsystems.focus.test.ts
+++ b/dashboard/src/components/memory-subsystems.focus.test.ts
@@ -44,6 +44,39 @@ const baseResponse: MemorySubsystemsResponse = {
       },
     ],
   },
+  user_model: {
+    schema: 'masc.user_model.memory_projection.v1',
+    source: 'memory_os_facts',
+    total: 2,
+    filtered: 2,
+    shown: 2,
+    limit: 100,
+    items: [
+      {
+        keeper: 'keeper-alpha',
+        kind: 'preference',
+        claim: 'User prefers terse operational summaries',
+        source_ref: 'memory-os-fact://keeper-alpha/trace-1/user-prefers-terse-operational-summaries',
+        source_trace_id: 'trace-1',
+        source_turn: 7,
+        first_seen: 1,
+        last_verified_at: 2,
+        observed_by: [],
+      },
+      {
+        keeper: 'keeper-alpha',
+        kind: 'constraint',
+        claim: 'Use worktrees for repo changes',
+        source_ref: 'memory-os-fact://keeper-alpha/trace-2/use-worktrees-for-repo-changes',
+        source_trace_id: 'trace-2',
+        source_turn: 8,
+        first_seen: 1,
+        last_verified_at: null,
+        observed_by: [],
+      },
+    ],
+    errors: [],
+  },
   filters: {
     keepers: ['keeper-alpha'],
     outcomes: ['success'],
@@ -128,6 +161,20 @@ describe('MemorySubsystems focus targets', () => {
       expect(focusMock.mock.contexts).toContain(target)
       expect(scrollIntoViewMock.mock.contexts).toContain(target)
     })
+  })
+
+  it('renders user model projection rows from memory facts', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(baseResponse))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(html`<${MemorySubsystems} />`, container)
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('User model')
+      expect(container.textContent).toContain('User prefers terse operational summaries')
+      expect(container.textContent).toContain('Use worktrees for repo changes')
+    })
+    expect(container.querySelector('[data-testid="user-model-projection"]')).not.toBeNull()
   })
 
   it('focuses the episodes section without requesting memory entries for episodes focus', async () => {

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -15,6 +15,7 @@ import {
   type MemorySubsystemsMemoryEntryError,
   type MemorySubsystemsUserModelItem,
   type MemorySubsystemsUserModelError,
+  type MemorySubsystemsUserModelPrompt,
 } from '../api/dashboard'
 import { formatTimeAgo } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -563,18 +564,35 @@ function UserModelPanel({
   total,
   filtered,
   errors,
+  prompt,
 }: {
   readonly items: readonly MemorySubsystemsUserModelItem[]
   readonly total: number
   readonly filtered: number
   readonly errors?: readonly MemorySubsystemsUserModelError[]
+  readonly prompt?: MemorySubsystemsUserModelPrompt
 }) {
+  const promptEnabled = prompt?.enabled ?? true
+  const promptBlockId = prompt?.block_id ?? 'user_model'
+  const promptInjection = prompt?.injection ?? 'extra_system_context'
+  const promptHook = prompt?.runtime_hook ?? 'keeper_run_tools_hooks.before_turn_params'
   return html`
     <section data-testid="user-model-projection" class="flex flex-col gap-2" aria-label=${`User model · ${items.length} rows`}>
       <div class="flex flex-wrap items-center gap-2">
         <h3 class="text-base font-semibold text-[var(--color-fg-muted)]">User model</h3>
         <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">
           memory_os preferences / constraints
+        </span>
+        <span
+          data-testid="user-model-prompt-surface"
+          class=${`rounded-[var(--r-1)] border px-1.5 py-0.5 font-mono text-2xs uppercase tracking-[var(--track-caps)] ${
+            promptEnabled
+              ? 'border-[var(--color-status-ok)] bg-[var(--color-bg-elevated)] text-[var(--color-status-ok)]'
+              : 'border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-disabled)]'
+          }`}
+          title=${`${promptHook} · ${promptInjection}`}
+        >
+          prompt ${promptEnabled ? 'on' : 'off'} · ${promptBlockId}
         </span>
         <span class="ml-auto text-xs text-[var(--color-fg-muted)]">
           total ${total} · filtered ${filtered} · shown ${items.length}
@@ -853,6 +871,7 @@ export function MemorySubsystems({ focus }: MemorySubsystemsProps = {}) {
         total=${userModel?.total ?? userModelItems.length}
         filtered=${userModel?.filtered ?? userModelItems.length}
         errors=${userModel?.errors ?? []}
+        prompt=${userModel?.prompt}
       />
 
       ${

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -13,6 +13,8 @@ import {
   type MemorySubsystemsEpisode,
   type MemorySubsystemsMemoryEntry,
   type MemorySubsystemsMemoryEntryError,
+  type MemorySubsystemsUserModelItem,
+  type MemorySubsystemsUserModelError,
 } from '../api/dashboard'
 import { formatTimeAgo } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -74,6 +76,8 @@ export const ARCHITECTURE_FLOW = `graph LR
 
     F1 --> D1
     G1 --> D1
+    F1 --> U1[user_model projection]
+    U1 --> D1
     D1 --> UI[기억 서브시스템 패널]
 
     %% dark-fantasy palette (mermaid can't use CSS vars): store=bg/mold,
@@ -82,7 +86,7 @@ export const ARCHITECTURE_FLOW = `graph LR
     classDef action fill:#16210f,stroke:#5a7a3a,color:#e8d8b8
     classDef ui fill:#2a1d08,stroke:#c4461a,color:#e8d8b8
     class F1,G1 store
-    class M1,M3,H1,H2,T2 action
+    class M1,M3,H1,H2,T2,U1 action
     class UI ui`
 
 const shortAgentLabel = (name: string) => {
@@ -530,6 +534,81 @@ function MemoryEntryRow({ entry }: { readonly entry: MemorySubsystemsMemoryEntry
   `
 }
 
+function UserModelRow({ item }: { readonly item: MemorySubsystemsUserModelItem }) {
+  const verifiedAt = item.last_verified_at ?? item.first_seen
+  return html`
+    <div
+      class="v2-monitoring-row grid grid-cols-[8rem_7rem_minmax(0,1fr)_7rem] items-start gap-2 border-b border-[var(--color-border-default)] px-2 py-2 text-xs last:border-b-0 max-md:grid-cols-[5.5rem_minmax(0,1fr)]"
+      role="listitem"
+      aria-label=${`${item.keeper} · ${item.kind} · ${item.claim}`}
+    >
+      <span class="truncate font-mono text-[var(--color-fg-muted)]" title=${item.keeper}>
+        ${item.keeper}
+      </span>
+      <span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-center font-mono text-[var(--color-accent-fg)]">
+        ${item.kind}
+      </span>
+      <span class="min-w-0 text-[var(--color-fg-primary)] max-md:col-span-2" title=${item.source_ref}>
+        ${item.claim}
+      </span>
+      <span class="text-right font-mono text-[var(--color-fg-disabled)] max-md:hidden">
+        ${formatTimeAgo(verifiedAt * 1000)}
+      </span>
+    </div>
+  `
+}
+
+function UserModelPanel({
+  items,
+  total,
+  filtered,
+  errors,
+}: {
+  readonly items: readonly MemorySubsystemsUserModelItem[]
+  readonly total: number
+  readonly filtered: number
+  readonly errors?: readonly MemorySubsystemsUserModelError[]
+}) {
+  return html`
+    <section data-testid="user-model-projection" class="flex flex-col gap-2" aria-label=${`User model · ${items.length} rows`}>
+      <div class="flex flex-wrap items-center gap-2">
+        <h3 class="text-base font-semibold text-[var(--color-fg-muted)]">User model</h3>
+        <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">
+          memory_os preferences / constraints
+        </span>
+        <span class="ml-auto text-xs text-[var(--color-fg-muted)]">
+          total ${total} · filtered ${filtered} · shown ${items.length}
+        </span>
+      </div>
+      ${
+        errors && errors.length > 0
+          ? html`<div
+              role="alert"
+              class="rounded-[var(--r-1)] border border-[var(--warn-fg)] bg-[var(--warn-bg)] px-3 py-2 text-2xs text-[var(--color-fg-primary)]"
+            >
+              ${errors.length} user-model source${errors.length > 1 ? 's' : ''} unavailable
+            </div>`
+          : null
+      }
+      ${
+        items.length === 0
+          ? html`<div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4 text-center text-sm text-[var(--color-fg-muted)]">
+              user model entries 없음
+            </div>`
+          : html`
+              <div
+                class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)]"
+                role="list"
+                aria-label=${`${items.length} user model entries`}
+              >
+                ${items.map(item => html`<${UserModelRow} item=${item} />`)}
+              </div>
+            `
+      }
+    </section>
+  `
+}
+
 export function MemoryEntriesPanel({
   entries,
   visibleEntries,
@@ -693,6 +772,8 @@ export function MemorySubsystems({ focus }: MemorySubsystemsProps = {}) {
   const totalEntries = data?.memory_entries?.total ?? entries.length
   const filteredEntries = data?.memory_entries?.filtered ?? entries.length
   const knownMemoryKinds = data?.filters?.memory_kinds ?? Array.from(new Set(entries.map(e => e.kind))).sort()
+  const userModel = data?.user_model
+  const userModelItems = userModel?.items ?? []
   const visibleEntries = useMemo(
     () => filterMemoryEntries(entries, memoryKindFilter.value),
     [entries, memoryKindFilter.value],
@@ -766,6 +847,13 @@ export function MemorySubsystems({ focus }: MemorySubsystemsProps = {}) {
             : null
         }
       </section>
+
+      <${UserModelPanel}
+        items=${userModelItems}
+        total=${userModel?.total ?? userModelItems.length}
+        filtered=${userModel?.filtered ?? userModelItems.length}
+        errors=${userModel?.errors ?? []}
+      />
 
       ${
         showMemoryEntries

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -74,6 +74,11 @@ let list_fact_store_keeper_ids () =
   list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir:(keepers_dir ())
 ;;
 
+let list_fact_store_keeper_ids_for_base_path ~base_path =
+  list_fact_store_keeper_ids_for_keepers_dir
+    ~keepers_dir:(Config_dir_resolver.keepers_dir_for_base_path ~base_path)
+;;
+
 let events_path_for_keepers_dir ~keepers_dir ~keeper_id =
   Filename.concat keepers_dir (keeper_id ^ ".events.jsonl")
 ;;
@@ -448,10 +453,22 @@ let read_facts_all_strict_for_keepers_dir ~keepers_dir ~keeper_id =
 let read_facts_all_strict ~keeper_id =
   read_facts_all_strict_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;
-let read_facts_tail ~keeper_id ~n =
-  read_lines_tail (facts_path ~keeper_id) ~n
+
+let read_facts_tail_for_keepers_dir ~keepers_dir ~keeper_id ~n =
+  read_lines_tail (facts_path_for_keepers_dir ~keepers_dir ~keeper_id) ~n
   |> List.filter_map (parse_json_line fact_of_json)
   |> take_last n
+;;
+
+let read_facts_tail ~keeper_id ~n =
+  read_facts_tail_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id ~n
+;;
+
+let read_facts_tail_for_base_path ~base_path ~keeper_id ~n =
+  read_facts_tail_for_keepers_dir
+    ~keepers_dir:(Config_dir_resolver.keepers_dir_for_base_path ~base_path)
+    ~keeper_id
+    ~n
 ;;
 
 (* RFC-0239 Q4: the per-keeper fact recall *retention target* — the size the

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -15,6 +15,10 @@ val facts_path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> strin
 val list_fact_store_keeper_ids : unit -> string list
 val list_fact_store_keeper_ids_for_keepers_dir : keepers_dir:string -> string list
 
+(** Base-path-scoped variant of {!list_fact_store_keeper_ids}; avoids ambient
+    config-dir reads in multi-workspace dashboard routes. *)
+val list_fact_store_keeper_ids_for_base_path : base_path:string -> string list
+
 val events_path : keeper_id:string -> string
 val events_path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
 val episodes_dir : keeper_id:string -> string
@@ -94,6 +98,7 @@ val read_facts_all_strict : keeper_id:string -> (fact list, string) result
 val read_facts_all_strict_for_keepers_dir :
   keepers_dir:string -> keeper_id:string -> (fact list, string) result
 val read_facts_tail : keeper_id:string -> n:int -> fact list
+val read_facts_tail_for_base_path : base_path:string -> keeper_id:string -> n:int -> fact list
 val read_events_tail : keeper_id:string -> n:int -> episode list
 val read_episodes_tail : keeper_id:string -> n:int -> episode list
 

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -272,10 +272,9 @@ let fact_is_current ~now (fact : fact) =
 
 (* The time a fact was last known good: [last_verified_at] if set, else
    [first_seen] (a never-re-verified fact is as old as its extraction). The SSOT
-   anchor for "how stale is this claim": the reconciler measures the re-ground
-   horizon from it, and recall measures staleness/ordering and unverified-volatile
-   suppression from it — they share this one definition rather than each inlining
-   the match, so a future change to the anchor rule (e.g. a [last_verified_at >=
+   anchor for "how stale is this claim": the reconciler, recall, and dashboard
+   user-model ordering share this one definition rather than each inlining the
+   match, so a future change to the anchor rule (e.g. a [last_verified_at >=
    first_seen] guard) cannot make those paths drift. *)
 let reference_time (f : fact) =
   match f.last_verified_at with

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -283,6 +283,19 @@ let reference_time (f : fact) =
   | None -> f.first_seen
 ;;
 
+let fact_is_user_model (fact : fact) =
+  match fact.category with
+  | Preference | Constraint -> true
+  | Blocker
+  | Code_change
+  | Ephemeral
+  | Fact
+  | Goal
+  | Lesson
+  | Validated_approach
+  | Unknown _ -> false
+;;
+
 type episode =
   { trace_id : string
   ; generation : int

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -153,6 +153,10 @@ val fact_is_current : now:float -> fact -> bool
     horizon) and recall (staleness marker, recall ordering, unverified-volatile
     suppression) so those paths cannot drift on the anchor rule. *)
 val reference_time : fact -> float
+
+(** Whether the fact belongs to the operator/user-model projection. *)
+val fact_is_user_model : fact -> bool
+
 (** A librarian extraction result: a summary plus structured claims. *)
 type episode =
   { trace_id : string

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -149,9 +149,9 @@ type fact =
 val fact_is_current : now:float -> fact -> bool
 
 (** The time a fact was last known good: [last_verified_at] if set, else
-    [first_seen]. The SSOT staleness anchor shared by the reconciler (re-ground
-    horizon) and recall (staleness marker, recall ordering, unverified-volatile
-    suppression) so those paths cannot drift on the anchor rule. *)
+    [first_seen]. The SSOT staleness anchor shared by the reconciler, recall,
+    and dashboard user-model ordering so those paths cannot drift on the anchor
+    rule. *)
 val reference_time : fact -> float
 
 (** Whether the fact belongs to the operator/user-model projection. *)

--- a/lib/keeper/keeper_user_model.ml
+++ b/lib/keeper/keeper_user_model.ml
@@ -56,18 +56,6 @@ let sanitize_atom text =
     | c -> c)
 ;;
 
-let eligible_category = function
-  | Preference | Constraint -> true
-  | Code_change | Fact | Blocker | Goal | Ephemeral | Validated_approach | Lesson
-  | Unknown _ -> false
-;;
-
-let fact_truth_anchor (memory_fact : Keeper_memory_os_types.fact) =
-  match memory_fact.last_verified_at with
-  | Some ts -> ts
-  | None -> memory_fact.first_seen
-;;
-
 let dedup_facts_by_claim (facts : Keeper_memory_os_types.fact list) =
   let seen = Hashtbl.create 16 in
   List.filter
@@ -84,9 +72,9 @@ let dedup_facts_by_claim (facts : Keeper_memory_os_types.fact list) =
 let rank_facts ~now facts =
   facts
   |> List.filter (fact_is_current ~now)
-  |> List.filter (fun (fact : fact) -> eligible_category fact.category)
+  |> List.filter fact_is_user_model
   |> List.sort (fun (a : fact) (b : fact) ->
-    compare (fact_truth_anchor b) (fact_truth_anchor a))
+    compare (reference_time b) (reference_time a))
   |> dedup_facts_by_claim
 ;;
 

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -252,14 +252,9 @@ let dashboard_memory_subsystems_http_json
              (_, (a : Keeper_memory_os_types.fact))
             (_, (b : Keeper_memory_os_types.fact))
             ->
-            (* DET-OK: absent [last_verified_at] falls back to [first_seen] so
-               legacy facts keep a deterministic dashboard ordering. *)
-            let a_ts = Option.value ~default:a.first_seen a.last_verified_at in
-            let b_ts =
-              Option.value ~default:b.first_seen b.last_verified_at
-              (* DET-OK: same deterministic legacy fallback as [a_ts]. *)
-            in
-            Float.compare b_ts a_ts)
+            Float.compare
+              (Keeper_memory_os_types.reference_time b)
+              (Keeper_memory_os_types.reference_time a))
     |> take limit
   in
   let filtered =

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -113,6 +113,16 @@ let load_user_model_facts ~(config : Workspace_utils.config) =
   |> fun (items, errors) -> List.rev items, List.rev errors
 ;;
 
+let user_model_prompt_json () =
+  `Assoc
+    [ "enabled", `Bool (Keeper_user_model.enabled ())
+    ; "block_id", `String (Prompt_block_id.to_string Prompt_block_id.User_model)
+    ; "injection", `String "extra_system_context"
+    ; "runtime_hook", `String "keeper_run_tools_hooks.before_turn_params"
+    ; "producer", `String "keeper_user_model"
+    ]
+;;
+
 let dashboard_memory_subsystems_http_json
       ~(config : Workspace_utils.config)
       ?include_memory_entries
@@ -344,6 +354,7 @@ let dashboard_memory_subsystems_http_json
       , `Assoc
           [ "schema", `String "masc.user_model.memory_projection.v1"
           ; "source", `String "memory_os_facts"
+          ; "prompt", user_model_prompt_json ()
           ; "total", `Int (List.length all_user_model_items)
           ; "filtered", `Int (List.length user_model_filtered)
           ; "shown", `Int (List.length user_model_items)

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -89,6 +89,47 @@ let load_memory_subsystems_entries ~(config : Workspace_utils.config) =
        rows, errors)
 ;;
 
+let memory_os_fact_is_current ~now (fact : Keeper_memory_os_types.fact) =
+  match fact.valid_until with
+  | None -> true
+  | Some valid_until -> valid_until > now
+;;
+
+let is_user_model_fact (fact : Keeper_memory_os_types.fact) =
+  match fact.category with
+  | Keeper_memory_os_types.Preference | Keeper_memory_os_types.Constraint -> true
+  | Keeper_memory_os_types.Blocker
+  | Keeper_memory_os_types.Code_change
+  | Keeper_memory_os_types.Ephemeral
+  | Keeper_memory_os_types.Fact
+  | Keeper_memory_os_types.Goal
+  | Keeper_memory_os_types.Lesson
+  | Keeper_memory_os_types.Validated_approach
+  | Keeper_memory_os_types.Unknown _ -> false
+;;
+
+let load_user_model_facts () =
+  let now = Time_compat.now () in
+  Keeper_memory_os_io.list_fact_store_keeper_ids ()
+  |> List.fold_left
+       (fun (items_acc, errors_acc) keeper ->
+         try
+           let items =
+             Keeper_memory_os_io.read_facts_tail
+               ~keeper_id:keeper
+               ~n:Keeper_memory_os_io.fact_store_max
+             |> List.filter is_user_model_fact
+             |> List.filter (memory_os_fact_is_current ~now)
+             |> List.map (fun fact -> keeper, fact)
+           in
+           List.rev_append items items_acc, errors_acc
+         with
+         | Eio.Cancel.Cancelled _ as exn -> raise exn
+         | exn -> items_acc, (keeper, Printexc.to_string exn) :: errors_acc)
+       ([], [])
+  |> fun (items, errors) -> List.rev items, List.rev errors
+;;
+
 let dashboard_memory_subsystems_http_json
       ~(config : Workspace_utils.config)
       ?include_memory_entries
@@ -146,11 +187,36 @@ let dashboard_memory_subsystems_http_json
       ; "ts_unix", `Float row.ts_unix
       ]
   in
+  let user_model_item_to_json
+        (keeper : string)
+        (fact : Keeper_memory_os_types.fact)
+    : Yojson.Safe.t
+    =
+    `Assoc
+      [ "keeper", `String keeper
+      ; "kind", `String (Keeper_memory_os_types.category_to_string fact.category)
+      ; "claim", `String fact.claim
+      ; ( "source_ref"
+        , `String
+            (Skill_candidate_projection.source_memory_fact_ref ~agent_name:keeper fact)
+        )
+      ; "source_trace_id", `String fact.source.trace_id
+      ; "source_turn", `Int fact.source.turn
+      ; "first_seen", `Float fact.first_seen
+      ; ( "last_verified_at"
+        , match fact.last_verified_at with
+          | Some ts -> `Float ts
+          | None -> `Null )
+      ; ( "observed_by"
+        , `List (List.map (fun keeper -> `String keeper) fact.observed_by) )
+      ]
+  in
   let all_memory_entries, memory_entry_errors =
     if include_memory_entries
     then load_memory_subsystems_entries ~config
     else [], []
   in
+  let all_user_model_items, user_model_errors = load_user_model_facts () in
   let memory_total = List.length all_memory_entries in
   let memory_filtered =
     all_memory_entries
@@ -176,6 +242,41 @@ let dashboard_memory_subsystems_http_json
              (_, (a : Keeper_memory_policy.keeper_memory_line))
               (_, (b : Keeper_memory_policy.keeper_memory_line))
             -> compare b.ts_unix a.ts_unix)
+    |> take limit
+  in
+  let user_model_filtered =
+    all_user_model_items
+    |> List.filter (fun (keeper, (fact : Keeper_memory_os_types.fact)) ->
+      let keeper_ok =
+        match keeper_filter with
+        | None -> true
+        | Some k -> String.equal keeper k
+      in
+      let search_ok =
+        match search with
+        | None -> true
+        | Some q ->
+          contains_ci keeper q
+          || contains_ci (Keeper_memory_os_types.category_to_string fact.category) q
+          || contains_ci fact.claim q
+      in
+      keeper_ok && search_ok)
+  in
+  let user_model_items =
+    user_model_filtered
+    |> List.sort
+         (fun
+             (_, (a : Keeper_memory_os_types.fact))
+            (_, (b : Keeper_memory_os_types.fact))
+            ->
+            (* DET-OK: absent [last_verified_at] falls back to [first_seen] so
+               legacy facts keep a deterministic dashboard ordering. *)
+            let a_ts = Option.value ~default:a.first_seen a.last_verified_at in
+            let b_ts =
+              Option.value ~default:b.first_seen b.last_verified_at
+              (* DET-OK: same deterministic legacy fallback as [a_ts]. *)
+            in
+            Float.compare b_ts a_ts)
     |> take limit
   in
   let filtered =
@@ -220,7 +321,9 @@ let dashboard_memory_subsystems_http_json
       |> List.concat_map (fun (e : Institution_eio.episode) -> e.participants)
     in
     let memory_keepers = List.map fst all_memory_entries in
-    episode_keepers @ memory_keepers |> List.sort_uniq String.compare
+    let user_model_keepers = List.map fst all_user_model_items in
+    episode_keepers @ memory_keepers @ user_model_keepers
+    |> List.sort_uniq String.compare
   in
   let known_memory_kinds =
     all_memory_entries
@@ -258,6 +361,26 @@ let dashboard_memory_subsystems_http_json
                        ; "error_class", `String error_class
                        ])
                    memory_entry_errors) )
+          ] )
+    ; ( "user_model"
+      , `Assoc
+          [ "schema", `String "masc.user_model.memory_projection.v1"
+          ; "source", `String "memory_os_facts"
+          ; "total", `Int (List.length all_user_model_items)
+          ; "filtered", `Int (List.length user_model_filtered)
+          ; "shown", `Int (List.length user_model_items)
+          ; "limit", `Int limit
+          ; ( "items"
+            , `List
+                (List.map
+                   (fun (keeper, fact) -> user_model_item_to_json keeper fact)
+                   user_model_items) )
+          ; ( "errors"
+            , `List
+                (List.map
+                   (fun (keeper, error) ->
+                     `Assoc [ "keeper", `String keeper; "error", `String error ])
+                   user_model_errors) )
           ] )
     ; ( "filters"
       , `Assoc

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -89,37 +89,20 @@ let load_memory_subsystems_entries ~(config : Workspace_utils.config) =
        rows, errors)
 ;;
 
-let memory_os_fact_is_current ~now (fact : Keeper_memory_os_types.fact) =
-  match fact.valid_until with
-  | None -> true
-  | Some valid_until -> valid_until > now
-;;
-
-let is_user_model_fact (fact : Keeper_memory_os_types.fact) =
-  match fact.category with
-  | Keeper_memory_os_types.Preference | Keeper_memory_os_types.Constraint -> true
-  | Keeper_memory_os_types.Blocker
-  | Keeper_memory_os_types.Code_change
-  | Keeper_memory_os_types.Ephemeral
-  | Keeper_memory_os_types.Fact
-  | Keeper_memory_os_types.Goal
-  | Keeper_memory_os_types.Lesson
-  | Keeper_memory_os_types.Validated_approach
-  | Keeper_memory_os_types.Unknown _ -> false
-;;
-
-let load_user_model_facts () =
+let load_user_model_facts ~(config : Workspace_utils.config) =
   let now = Time_compat.now () in
-  Keeper_memory_os_io.list_fact_store_keeper_ids ()
+  let base_path = config.base_path in
+  Keeper_memory_os_io.list_fact_store_keeper_ids_for_base_path ~base_path
   |> List.fold_left
        (fun (items_acc, errors_acc) keeper ->
          try
            let items =
-             Keeper_memory_os_io.read_facts_tail
+             Keeper_memory_os_io.read_facts_tail_for_base_path
+               ~base_path
                ~keeper_id:keeper
                ~n:Keeper_memory_os_io.fact_store_max
-             |> List.filter is_user_model_fact
-             |> List.filter (memory_os_fact_is_current ~now)
+             |> List.filter Keeper_memory_os_types.fact_is_user_model
+             |> List.filter (Keeper_memory_os_types.fact_is_current ~now)
              |> List.map (fun fact -> keeper, fact)
            in
            List.rev_append items items_acc, errors_acc
@@ -216,7 +199,7 @@ let dashboard_memory_subsystems_http_json
     then load_memory_subsystems_entries ~config
     else [], []
   in
-  let all_user_model_items, user_model_errors = load_user_model_facts () in
+  let all_user_model_items, user_model_errors = load_user_model_facts ~config in
   let memory_total = List.length all_memory_entries in
   let memory_filtered =
     all_memory_entries

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -2,6 +2,8 @@ open Alcotest
 
 module Json = Yojson.Safe.Util
 module Memory_subsystems = Server_dashboard_http_memory_subsystems
+module Memory_io = Masc.Keeper_memory_os_io
+module Types = Masc.Keeper_memory_os_types
 
 let request target =
   Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
@@ -82,6 +84,65 @@ let test_http_json_explicitly_disabled_entries_surface () =
         Json.(memory_entries |> member "items" |> to_list |> List.length))
 ;;
 
+let fact ?(category = Types.Preference) ?(trace_id = "trace-user-model")
+      ?(turn = 3) ?(first_seen = 10.0) ?last_verified_at claim
+  : Types.fact
+  =
+  { claim
+  ; category
+  ; external_ref = None
+  ; source = { trace_id; turn; tool_call_id = None }
+  ; observed_by = []
+  ; first_seen
+  ; valid_until = None
+  ; last_verified_at
+  ; schema_version = Types.schema_version
+  }
+;;
+
+let test_http_json_surfaces_user_model_projection () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let keepers_dir = Filename.concat dir "keepers" in
+      Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
+        Memory_io.append_fact
+          ~keeper_id:"sangsu"
+          (fact ~category:Types.Preference ~last_verified_at:20.0
+             "User prefers terse operational summaries");
+        Memory_io.append_fact
+          ~keeper_id:"sangsu"
+          (fact ~category:Types.Constraint ~trace_id:"trace-constraint" ~turn:4
+             "User requires worktree-first changes");
+        Memory_io.append_fact
+          ~keeper_id:"sangsu"
+          (fact ~category:Types.Fact "The repo uses OCaml");
+        let config = Workspace_utils.default_config dir in
+        let json =
+          Memory_subsystems.dashboard_memory_subsystems_http_json
+            ~config
+            ~include_memory_entries:false
+            (request "/dashboard/memory-subsystems?limit=100")
+        in
+        let user_model = Json.(json |> member "user_model") in
+        check string "schema" "masc.user_model.memory_projection.v1"
+          Json.(user_model |> member "schema" |> to_string);
+        check int "total" 2 Json.(user_model |> member "total" |> to_int);
+        check int "shown" 2 Json.(user_model |> member "shown" |> to_int);
+        let items = Json.(user_model |> member "items" |> to_list) in
+        let claims =
+          items |> List.map (fun item -> Json.(item |> member "claim" |> to_string))
+        in
+        check
+          (list string)
+          "preference and constraint only"
+          [ "User prefers terse operational summaries"
+          ; "User requires worktree-first changes"
+          ]
+          claims))
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   Alcotest.run
@@ -101,6 +162,10 @@ let () =
             "explicit disabled entries keeps empty surface"
             `Quick
             test_http_json_explicitly_disabled_entries_surface
+        ; test_case
+            "surfaces user model projection"
+            `Quick
+            test_http_json_surfaces_user_model_projection
         ] )
     ]
 ;;

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -127,6 +127,13 @@ let test_http_json_surfaces_user_model_projection () =
         let user_model = Json.(json |> member "user_model") in
         check string "schema" "masc.user_model.memory_projection.v1"
           Json.(user_model |> member "schema" |> to_string);
+        let prompt = Json.(user_model |> member "prompt") in
+        check string "prompt block id" "user_model"
+          Json.(prompt |> member "block_id" |> to_string);
+        check string "prompt injection" "extra_system_context"
+          Json.(prompt |> member "injection" |> to_string);
+        check string "prompt hook" "keeper_run_tools_hooks.before_turn_params"
+          Json.(prompt |> member "runtime_hook" |> to_string);
         check int "total" 2 Json.(user_model |> member "total" |> to_int);
         check int "shown" 2 Json.(user_model |> member "shown" |> to_int);
         let items = Json.(user_model |> member "items" |> to_list) in

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -18,10 +18,7 @@ let check_include target expected =
 ;;
 
 let temp_dir () =
-  let path = Filename.temp_file "memory_subsystems_dashboard_test" "" in
-  Sys.remove path;
-  Unix.mkdir path 0o755;
-  path
+  Filename.temp_dir "memory_subsystems_dashboard_test" ""
 ;;
 
 let rm_rf dir =
@@ -105,7 +102,10 @@ let test_http_json_surfaces_user_model_projection () =
   Fun.protect
     ~finally:(fun () -> rm_rf dir)
     (fun () ->
-      let keepers_dir = Filename.concat dir "keepers" in
+      let config = Workspace_utils.default_config dir in
+      let keepers_dir =
+        Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.base_path
+      in
       Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
         Memory_io.append_fact
           ~keeper_id:"sangsu"
@@ -118,7 +118,6 @@ let test_http_json_surfaces_user_model_projection () =
         Memory_io.append_fact
           ~keeper_id:"sangsu"
           (fact ~category:Types.Fact "The repo uses OCaml");
-        let config = Workspace_utils.default_config dir in
         let json =
           Memory_subsystems.dashboard_memory_subsystems_http_json
             ~config
@@ -141,6 +140,38 @@ let test_http_json_surfaces_user_model_projection () =
           ; "User requires worktree-first changes"
           ]
           claims))
+;;
+
+let test_http_json_user_model_uses_config_base_path () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config = Workspace_utils.default_config dir in
+      let base_keepers_dir =
+        Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.base_path
+      in
+      Memory_io.For_testing.with_keepers_dir base_keepers_dir (fun () ->
+        Memory_io.append_fact
+          ~keeper_id:"target"
+          (fact ~category:Types.Preference "Target workspace preference"));
+      let ambient_keepers_dir = Filename.concat dir "ambient-keepers" in
+      Memory_io.For_testing.with_keepers_dir ambient_keepers_dir (fun () ->
+        Memory_io.append_fact
+          ~keeper_id:"ambient"
+          (fact ~category:Types.Preference "Ambient workspace preference");
+        let json =
+          Memory_subsystems.dashboard_memory_subsystems_http_json
+            ~config
+            ~include_memory_entries:false
+            (request "/dashboard/memory-subsystems?limit=100")
+        in
+        let user_model = Json.(json |> member "user_model") in
+        let items = Json.(user_model |> member "items" |> to_list) in
+        let claims =
+          items |> List.map (fun item -> Json.(item |> member "claim" |> to_string))
+        in
+        check (list string) "scoped claims" [ "Target workspace preference" ] claims))
 ;;
 
 let () =
@@ -166,6 +197,10 @@ let () =
             "surfaces user model projection"
             `Quick
             test_http_json_surfaces_user_model_projection
+        ; test_case
+            "user model projection reads config base path"
+            `Quick
+            test_http_json_user_model_uses_config_base_path
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- expose Memory OS Preference/Constraint facts as a read-only `user_model` projection in the memory-subsystems dashboard JSON
- add dashboard types and a compact User model panel so Keeper/user preferences and constraints are visible with source refs
- surface the Keeper prompt usage metadata (`prompt.enabled`, `prompt.block_id=user_model`, `prompt.injection=extra_system_context`) so the dashboard explains how Keeper consumes the projection
- reuse the Memory OS user-model/reference-time SSOT in the prompt path
- cover the projection with OCaml HTTP JSON and dashboard focused tests

## Boundary
- MASC-only dashboard/read path
- no OAS/provider/model changes
- no new prompt-write semantics; the existing `Keeper_user_model.render_if_enabled` hook remains the Keeper consumption path, now visible from the dashboard surface

## Validation
- `ocamlformat --check lib/server/server_dashboard_http_memory_subsystems.ml test/test_server_dashboard_http_memory_subsystems.ml`
- `git diff --check`
- `ocamlc -stop-after parsing lib/server/server_dashboard_http_memory_subsystems.ml test/test_server_dashboard_http_memory_subsystems.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_server_dashboard_http_memory_subsystems.exe`
- `./_build/default/test/test_server_dashboard_http_memory_subsystems.exe`
- `pnpm typecheck`
- `pnpm exec vitest run --config vitest.config.ts src/components/memory-subsystems.focus.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/api/dashboard.ts src/components/memory-subsystems.ts src/components/memory-subsystems.focus.test.ts` (0 errors; test file ignored by current eslint config)
