### PR TITLE
fix(goal_store): prune goal_task_links on goal delete (fixes #21752)

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -477,25 +477,25 @@ let update_goal config ~goal_id f =
           Ok updated_goal)
 
 let delete_goal config ~goal_id =
-  let before = read_state config in
-  if not (List.exists (fun goal -> String.equal goal.id goal_id) before.goals) then
-    Error "Goal not found"
-  else begin
-    ignore
-      (update_state config (fun state ->
-           {
-             version = state.version + 1;
-             goals = List.filter (fun goal -> not (String.equal goal.id goal_id)) state.goals;
-             updated_at = Masc_domain.now_iso ();
-           }));
-    (* Clean up dangling goal_task_links for the deleted goal. *)
-    let links = Workspace_goal_index.read_goal_task_links config in
-    let filtered_links =
-      List.filter (fun (gid, _) -> not (String.equal gid goal_id)) links
-    in
-    Workspace_goal_index.write_goal_task_links config filtered_links;
+  let deleted =
+    Workspace_utils.with_file_lock config (goals_path config) (fun () ->
+      let state = read_state config in
+      if not (List.exists (fun goal -> String.equal goal.id goal_id) state.goals) then
+        Error "Goal not found"
+      else (
+        write_state
+          config
+          { version = state.version + 1
+          ; goals = List.filter (fun goal -> not (String.equal goal.id goal_id)) state.goals
+          ; updated_at = Masc_domain.now_iso ()
+          };
+        Ok ()))
+  in
+  match deleted with
+  | Error _ as error -> error
+  | Ok () ->
+    Workspace_goal_index.prune_links_for_goal config ~goal_id;
     Ok ()
-  end
 
 let sort_goals goals =
   let horizon_rank = function

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -488,6 +488,12 @@ let delete_goal config ~goal_id =
              goals = List.filter (fun goal -> not (String.equal goal.id goal_id)) state.goals;
              updated_at = Masc_domain.now_iso ();
            }));
+    (* Clean up dangling goal_task_links for the deleted goal. *)
+    let links = Workspace_goal_index.read_goal_task_links config in
+    let filtered_links =
+      List.filter (fun (gid, _) -> not (String.equal gid goal_id)) links
+    in
+    Workspace_goal_index.write_goal_task_links config filtered_links;
     Ok ()
   end
 

--- a/lib/workspace/workspace_goal_index.ml
+++ b/lib/workspace/workspace_goal_index.ml
@@ -156,6 +156,16 @@ let add_link_to_links links ~goal_id ~task_id =
   if !updated then links else links @ [ goal_id, [ task_id ] ]
 ;;
 
+let prune_links_for_goal config ~goal_id =
+  let goal_id = String.trim goal_id in
+  if String.equal goal_id "" then ()
+  else
+    with_file_lock config (goal_task_links_lock_path config) (fun () ->
+      let links = read_goal_task_links config in
+      let links = List.filter (fun (gid, _) -> not (String.equal gid goal_id)) links in
+      write_goal_task_links config links)
+;;
+
 let link_task_to_goal config ~goal_id ~task_id =
   let goal_id = String.trim goal_id in
   let task_id = String.trim task_id in

--- a/lib/workspace/workspace_goal_index.mli
+++ b/lib/workspace/workspace_goal_index.mli
@@ -56,6 +56,10 @@ val read_goal_task_links_r :
 val write_goal_task_links :
   Workspace_utils_backend_setup.config -> (string * string list) list -> unit
 
+(** Remove all links for [goal_id] under the goal-task-links file lock. *)
+val prune_links_for_goal :
+  Workspace_utils_backend_setup.config -> goal_id:string -> unit
+
 (** Add one task-to-goal link to the persistent registry. *)
 val link_task_to_goal :
   Workspace_utils_backend_setup.config -> goal_id:string -> task_id:string -> unit

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -102,6 +102,33 @@ let test_updated_at_also_refreshed () =
   let after = Goal_store.read_state config in
   check bool "updated_at refreshed" true (after.updated_at <> stale_ts)
 
+let test_delete_goal_prunes_goal_task_links () =
+  with_workspace
+  @@ fun config ->
+  let deleted = make_goal "g-1" "deleted goal" in
+  let preserved = make_goal "g-2" "preserved goal" in
+  Goal_store.write_state
+    config
+    { version = 1; updated_at = iso_now (); goals = [ deleted; preserved ] };
+  Workspace_goal_index.write_goal_task_links
+    config
+    [ "g-1", [ "task-a"; "task-b" ]; "g-2", [ "task-c" ] ];
+  (match Goal_store.delete_goal config ~goal_id:"g-1" with
+   | Ok () -> ()
+   | Error msg -> fail msg);
+  let links = Workspace_goal_index.read_goal_task_links config in
+  check bool
+    "deleted goal links removed"
+    false
+    (List.exists (fun (goal_id, _) -> String.equal goal_id "g-1") links);
+  check bool
+    "other goal links preserved"
+    true
+    (List.exists
+       (fun (goal_id, task_ids) ->
+          String.equal goal_id "g-2" && List.mem "task-c" task_ids)
+       links)
+
 let test_legacy_status_defaults_phase () =
   with_workspace @@ fun config ->
   Workspace.write_json config (Goal_store.goals_path config)
@@ -225,6 +252,8 @@ let () =
             test_delete_nonexistent_does_not_bump;
           test_case "updated_at also refreshed" `Quick
             test_updated_at_also_refreshed;
+          test_case "delete prunes goal_task_links" `Quick
+            test_delete_goal_prunes_goal_task_links;
           test_case "legacy status defaults phase" `Quick
             test_legacy_status_defaults_phase;
           test_case "blocked phase projects legacy status" `Quick

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -12,10 +12,7 @@ open Alcotest
 open Masc
 
 let temp_dir () =
-  let path = Filename.temp_file "goal_store_test" "" in
-  Sys.remove path;
-  Unix.mkdir path 0o755;
-  path
+  Filename.temp_dir "goal_store_test" ""
 
 let rm_rf dir =
   let rec rm path =

--- a/test/test_workspace_goal_index.ml
+++ b/test/test_workspace_goal_index.ml
@@ -14,15 +14,7 @@ let with_test_env f =
   Eio_main.run
   @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let tmp_dir =
-    Filename.concat
-      (Filename.get_temp_dir_name ())
-      (Printf.sprintf
-         "masc_goal_index_%d_%d"
-         (Unix.getpid ())
-         (int_of_float (Unix.gettimeofday () *. 1000.)))
-  in
-  Unix.mkdir tmp_dir 0o755;
+  let tmp_dir = Filename.temp_dir "masc_goal_index_" "" in
   let config = Workspace.default_config tmp_dir in
   let _ = Workspace.init config ~agent_name:(Some "claude") in
   try

--- a/test/test_workspace_goal_index.ml
+++ b/test/test_workspace_goal_index.ml
@@ -206,6 +206,26 @@ let test_add_task_persists_goal_link () =
        | Not_found -> false))
 ;;
 
+let test_prune_goal_links_preserves_other_goals () =
+  with_test_env (fun config ->
+    Workspace_goal_index.write_goal_task_links
+      config
+      [ "goal-a", [ "task-001"; "task-002" ]; "goal-b", [ "task-003" ] ];
+    Workspace_goal_index.prune_links_for_goal config ~goal_id:"goal-a";
+    let links = Workspace_goal_index.read_goal_task_links config in
+    check_bool
+      "deleted goal links removed"
+      false
+      (List.exists (fun (goal_id, _) -> String.equal goal_id "goal-a") links);
+    check_bool
+      "other goal links preserved"
+      true
+      (List.exists
+         (fun (goal_id, task_ids) ->
+            String.equal goal_id "goal-b" && List.mem "task-003" task_ids)
+         links))
+;;
+
 (* ── test suite ─────────────────────────────────────────────────────── *)
 
 let () =
@@ -228,6 +248,10 @@ let () =
               "add_task persists explicit goal link"
               `Quick
               test_add_task_persists_goal_link
+          ; test_case
+              "prune removes only deleted goal links"
+              `Quick
+              test_prune_goal_links_preserves_other_goals
           ] )
     ]
 ;;


### PR DESCRIPTION
## Problem

Issue #21752: When `Goal_store.delete_goal` removes a goal, it does not clean up `goal_task_links.json`. This leaves dangling references that accumulate over time and can cause confusion in goal-task association UI and queries.

## Root Cause

`delete_goal` (line 479) filters the goal out of `state.goals` but never touches `goal_task_links`.

## Fix

After removing the goal from state, read existing goal_task_links, filter out entries matching the deleted `goal_id`, and write the cleaned set back.

## Changes

`lib/goal/goal_store.ml` — 6 lines added in `delete_goal`