### PR TITLE
fix(dashboard): show scheduler computed prompt signal

### DIFF
--- a/dashboard/src/components/keeper-prompt-assembly-panel.test.ts
+++ b/dashboard/src/components/keeper-prompt-assembly-panel.test.ts
@@ -65,6 +65,8 @@ describe('buildKeeperPromptAssemblyReport', () => {
       'oas-hook',
     ])
     expect(report.stages.find(stage => stage.id === 'unified-world')?.promptCount).toBe(9)
+    expect(report.rows.find(row => row.promptKey === '(computed:world_observation)')?.source).toBe('computed')
+    expect(report.rows.find(row => row.promptKey === '(computed:scheduled_automation)')?.source).toBe('computed')
     expect(report.activePromptRoots).toEqual(['/tmp/.masc/config/prompts'])
     expect(report.rows.find(row => row.promptKey === 'keeper.world')?.source).toBe('override')
     expect(report.rows.find(row => row.promptKey === 'keeper.recovery_block')?.missing).toBe(true)
@@ -141,6 +143,7 @@ describe('buildKeeperPromptAssemblyReport', () => {
     expect(defaultRoute?.textContent).toContain('user')
     expect(defaultRoute?.textContent).toContain('final')
     expect(defaultRoute?.textContent).toContain('Final context')
+    expect(defaultRoute?.textContent).toContain('scheduler signals')
     expect(container.textContent).toContain('sent parts')
     expect(defaultRoute?.textContent).not.toContain('model-visible')
     expect(defaultRoute?.textContent).not.toMatch(/provider/i)
@@ -186,6 +189,7 @@ describe('buildKeeperPromptAssemblyReport', () => {
     expect(rawFileList?.hasAttribute('open')).toBe(false)
     expect(rawFileList?.querySelector('summary')?.textContent).toContain('Raw prompt files')
     expect(evidence?.textContent).toContain('keeper.world')
+    expect(evidence?.textContent).toContain('(computed:scheduled_automation)')
     expect(evidence?.textContent).toContain('fingerprint')
 
     const intro = container.querySelector('[data-prompt-recipe-intro]')

--- a/dashboard/src/components/keeper-prompt-assembly-panel.ts
+++ b/dashboard/src/components/keeper-prompt-assembly-panel.ts
@@ -24,6 +24,11 @@ type AssemblyLane =
 type WarningSeverity = 'critical' | 'warn' | 'info'
 type AssemblyStageRole = 'source_prep' | 'model_input' | 'evidence'
 
+interface AssemblyComputedRowSpec {
+  id: string
+  promptKey: string
+}
+
 interface AssemblyStageSpec {
   id: string
   order: number
@@ -33,6 +38,7 @@ interface AssemblyStageSpec {
   messageSlot: string
   summary: string
   promptKeys: string[]
+  computedRows?: AssemblyComputedRowSpec[]
 }
 
 export interface KeeperPromptAssemblyRow {
@@ -124,7 +130,7 @@ const STAGES: AssemblyStageSpec[] = [
     lane: 'user_message',
     role: 'model_input',
     messageSlot: 'user',
-    summary: 'Current task, workspace state, and turn intent.',
+    summary: 'Current task, workspace state, scheduler signals, and turn intent.',
     promptKeys: [
       'keeper.unified.system',
       'keeper.turn_intent',
@@ -135,6 +141,10 @@ const STAGES: AssemblyStageSpec[] = [
       'keeper.turn_intent.board_curation_guidance',
       'keeper.turn_intent.broadcast_guidance',
       'keeper.immediate_task_move',
+    ],
+    computedRows: [
+      { id: 'world-observation', promptKey: '(computed:world_observation)' },
+      { id: 'scheduled-automation', promptKey: '(computed:scheduled_automation)' },
     ],
   },
   {
@@ -270,7 +280,7 @@ function stageRows(rows: KeeperPromptAssemblyRow[], stage: AssemblyStageSpec): K
 function buildStages(rows: KeeperPromptAssemblyRow[]): KeeperPromptAssemblyStage[] {
   return STAGES.map(stage => {
     const rowsForStage = stageRows(rows, stage)
-    const promptCount = rowsForStage.filter(row => row.promptKey !== '(computed)').length
+    const promptCount = rowsForStage.filter(row => row.source !== 'computed').length
     return {
       id: stage.id,
       order: stage.order,
@@ -295,14 +305,19 @@ export function buildKeeperPromptAssemblyReport(
   const promptByKey = new Map(prompts.map(prompt => [prompt.key, prompt]))
   const rows: KeeperPromptAssemblyRow[] = []
 
-  for (const stage of STAGES) {
-    if (stage.promptKeys.length === 0) {
+  function pushComputedRows(stage: AssemblyStageSpec) {
+    const computedRows =
+      stage.computedRows ?? (stage.promptKeys.length === 0
+        ? [{ id: 'computed', promptKey: '(computed)' }]
+        : [])
+
+    for (const row of computedRows) {
       rows.push({
-        id: `${stage.id}:computed`,
+        id: `${stage.id}:${row.id}`,
         order: stage.order,
         title: stage.title,
         lane: stage.lane,
-        promptKey: '(computed)',
+        promptKey: row.promptKey,
         source: 'computed',
         hasOverride: false,
         filePath: null,
@@ -311,6 +326,12 @@ export function buildKeeperPromptAssemblyReport(
         fingerprint: '-',
         missing: false,
       })
+    }
+  }
+
+  for (const stage of STAGES) {
+    if (stage.promptKeys.length === 0) {
+      pushComputedRows(stage)
       continue
     }
 
@@ -332,6 +353,8 @@ export function buildKeeperPromptAssemblyReport(
         missing: !prompt || prompt.source === 'missing',
       })
     }
+
+    pushComputedRows(stage)
   }
 
   const keeperPrompts = prompts.filter(prompt =>


### PR DESCRIPTION
Summary:
- Mark world observation and scheduled automation as computed rows in the Keeper prompt recipe.
- Keep prompt file counts limited to real prompt registry rows while exposing dynamic scheduler signal provenance in build details.
- Update the focused prompt assembly panel tests.

Validation:
- pnpm install --offline
- pnpm run typecheck
- pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-prompt-assembly-panel.test.ts
- git diff --check