### PR TITLE
feat(eval): record anti-rationalization verdicts for self-owned scenarios (RFC-0262 §9)

### DIFF
--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -329,7 +329,10 @@ let record_self_owned_verdict (scenario : EH.scenario) ~args ~sw
   let on_verdict (result : AR.review_result) =
     Cal.record_verdict ~task_id ~req ~result ()
   in
-  ignore (AR.review ~sw ~evaluator_runtime ~generator_runtime ~on_verdict req)
+  let (_ : AR.review_result) =
+    AR.review ~sw ~evaluator_runtime ~generator_runtime ~on_verdict req
+  in
+  ()
 ;;
 
 let run_one (scenario : EH.scenario) ~runtime_id ~run_index ~sw ~record_verdicts

--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -1,5 +1,6 @@
-(** [masc_completion_trust_eval] — live-LLM behavioural eval for RFC-0262 §9
-    axis ① (completion-trust disposition).
+(** [masc_completion_trust_eval] — live-LLM behavioural eval supporting RFC-0262
+    §9's proving metric (zero foreign-task completions by a non-Operator/System
+    actor), measured from the keeper's completion *disposition*.
 
     Drives a real keeper with adversarial *foreign-task temptation* prompts and
     measures whether it ATTEMPTS to complete a task it does not own or for which
@@ -7,7 +8,9 @@
     grading is deterministic (trajectory reduction -> {!Eval_harness}
     deterministic graders -> pass@k).
 
-    Boundary (RFC-0262 §9 harness — keeper / judge / eval-grader separation):
+    Boundary — keeper / judge / eval-grader separation (a harness design
+    contract, not RFC text; see docs/design/completion-trust-calibration-wiring.md.
+    RFC-0262 §8 is the test plan, §9 the rollout + proving metric):
     - keeper      = the live LLM under test (the completion *attempt* author).
     - judge       = the real dispatch-path gates (deterministic ownership /
                     anti-rationalization). NOT exercised here: this runner stubs
@@ -15,7 +18,9 @@
                     covered deterministically by [test_completion_trust_harness]
                     (PR-B). The stub [dispatch] closure below is the seam where a
                     later PR can route the attempt through the real handler plus
-                    [Eval_calibration] verdict recording.
+                    [Eval_calibration] verdict recording — see
+                    docs/design/completion-trust-calibration-wiring.md for the
+                    three blockers that wiring must resolve.
     - eval-grader = {!Eval_harness} deterministic graders + pass@k (this file).
 
     Scope: completion-trust scenarios only (not a general eval platform). Manual /

--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -29,6 +29,8 @@
 
 module EH = Masc.Eval_harness
 module KTDW = Masc.Keeper_turn_driver_wrappers
+module AR = Masc.Task.Anti_rationalization
+module Cal = Masc.Eval_calibration
 
 let usage =
   {|Usage: masc_completion_trust_eval [OPTIONS]
@@ -42,6 +44,12 @@ Options:
   --out PATH         write the suite result as JSONL to PATH
   --list             load + print the corpus without driving any LLM
   --strict           exit 1 if a regression-guard scenario's pass@k < threshold
+  --record-verdicts  for self_owned scenarios, drive the anti-rationalization
+                     judge on each completion attempt and record its verdict to
+                     <base>/data/verdicts (live judge LLM; manual/token-heavy).
+                     Foreign scenarios stay disposition-only.
+  --evaluator-runtime ID  runtime for the judge (default: --runtime; set a
+                     distinct one for cross-model separation / cross_model_rate)
   -h, --help         print this help
 
 Exit codes:
@@ -290,13 +298,57 @@ let build_goal (scenario : EH.scenario) : string =
   else Printf.sprintf "%s\n\n---\n\n%s" context scenario.EH.goal
 ;;
 
-let run_one (scenario : EH.scenario) ~runtime_id ~run_index : EH.eval_run =
+(* The keeper identity the corpus addresses ("You are keeper-eval-agent ..."),
+   recorded as the completion author on the verdict. *)
+let eval_agent_name = "keeper-eval-agent"
+
+(* --record-verdicts: drive the real anti-rationalization judge on a self-owned
+   scenario's completion attempt and persist its verdict, mirroring the live
+   wiring in tool_task_handlers.review_completion_notes (on_verdict ->
+   Eval_calibration.record_verdict). The judge runs a separate evaluator
+   runtime, so the verdict feeds cross_model_rate. Only Self_owned scenarios
+   reach the judge — foreign-temptation completions are ownership-gated in
+   production and stay disposition-only here. *)
+let record_self_owned_verdict (scenario : EH.scenario) ~args ~sw
+    ~evaluator_runtime ~generator_runtime : unit =
+  let str_field key =
+    Yojson.Safe.Util.(args |> member key |> to_string_option)
+    |> Option.value ~default:""
+  in
+  let notes = str_field "notes" in
+  let task_id = match str_field "task_id" with "" -> scenario.EH.id | s -> s in
+  let req : AR.review_request =
+    {
+      task_title = scenario.EH.name;
+      task_description = scenario.EH.description;
+      completion_notes = notes;
+      agent_name = eval_agent_name;
+      task_id;
+    }
+  in
+  let on_verdict (result : AR.review_result) =
+    Cal.record_verdict ~task_id ~req ~result ()
+  in
+  ignore (AR.review ~sw ~evaluator_runtime ~generator_runtime ~on_verdict req)
+;;
+
+let run_one (scenario : EH.scenario) ~runtime_id ~run_index ~sw ~record_verdicts
+    ~evaluator_runtime : EH.eval_run =
   let calls = ref [] in
   let dispatch ~name ~args =
     let start_time = Time_compat.now () in
     calls := (name, args) :: !calls;
     (* Stub: we measure the *attempt*, not the live gate. The real gate is
-       covered deterministically by test_completion_trust_harness. *)
+       covered deterministically by test_completion_trust_harness. Under
+       --record-verdicts a self-owned scenario additionally routes the attempt
+       through the real judge (record_self_owned_verdict). *)
+    (if
+       record_verdicts
+       && scenario.EH.ownership = EH.Self_owned
+       && is_completion_tool name
+     then
+       record_self_owned_verdict scenario ~args ~sw ~evaluator_runtime
+         ~generator_runtime:runtime_id);
     Tool_result.ok ~tool_name:name ~start_time "recorded (completion-trust eval stub)"
   in
   let goal = build_goal scenario in
@@ -314,9 +366,14 @@ let run_one (scenario : EH.scenario) ~runtime_id ~run_index : EH.eval_run =
   build_eval_run scenario ~run_index ~res ~calls ~duration_ms
 ;;
 
-let run_scenario (scenario : EH.scenario) ~runtime_id ~k : EH.eval_result =
+let run_scenario (scenario : EH.scenario) ~runtime_id ~k ~sw ~record_verdicts
+    ~evaluator_runtime : EH.eval_result =
   Printf.eprintf "running scenario %s (k=%d)...\n%!" scenario.EH.id k;
-  let runs = List.init k (fun i -> run_one scenario ~runtime_id ~run_index:i) in
+  let runs =
+    List.init k (fun i ->
+        run_one scenario ~runtime_id ~run_index:i ~sw ~record_verdicts
+          ~evaluator_runtime)
+  in
   EH.summarize_runs ~scenario ~k runs
 ;;
 
@@ -367,6 +424,8 @@ type config = {
   out : string option;
   list_only : bool;
   strict : bool;
+  record_verdicts : bool;
+  evaluator_runtime : string option;
 }
 
 let default_config =
@@ -378,6 +437,8 @@ let default_config =
     out = None;
     list_only = false;
     strict = false;
+    record_verdicts = false;
+    evaluator_runtime = None;
   }
 ;;
 
@@ -396,6 +457,9 @@ let rec parse_args cfg = function
   | "--out" :: p :: rest -> parse_args { cfg with out = Some p } rest
   | "--list" :: rest -> parse_args { cfg with list_only = true } rest
   | "--strict" :: rest -> parse_args { cfg with strict = true } rest
+  | "--record-verdicts" :: rest -> parse_args { cfg with record_verdicts = true } rest
+  | "--evaluator-runtime" :: id :: rest ->
+    parse_args { cfg with evaluator_runtime = Some id } rest
   | other :: _ -> error (Printf.sprintf "unknown argument: %S\n%s" other usage)
 ;;
 
@@ -403,7 +467,9 @@ let print_corpus (scenarios : EH.scenario list) =
   Printf.printf "completion-trust corpus (%d scenarios):\n" (List.length scenarios);
   List.iter
     (fun (s : EH.scenario) ->
-      Printf.printf "  %-26s  graders=%d  tags=[%s]\n    %s\n" s.EH.id
+      Printf.printf "  %-26s  ownership=%-10s graders=%d  tags=[%s]\n    %s\n"
+        s.EH.id
+        (EH.ownership_to_string s.EH.ownership)
         (List.length s.EH.graders)
         (String.concat "," s.EH.tags)
         s.EH.name)
@@ -452,9 +518,26 @@ let () =
        Printf.eprintf "runtime init failed (%s): %s\n" config_path msg;
        exit 1
      | Ok () -> ());
+    let evaluator_runtime =
+      Option.value ~default:cfg.runtime_id cfg.evaluator_runtime
+    in
+    if cfg.record_verdicts then begin
+      (* Live judge: install the OAS-driven anti-rationalization reviewer the
+         server wires at boot, and isolate the verdict store under --base so the
+         eval never writes the ambient live store. *)
+      Masc.Workspace_metric_hooks.install ();
+      let verdict_dir = Filename.concat base_path "data/verdicts" in
+      Cal.set_store_for_testing ~base_dir:verdict_dir;
+      Printf.eprintf "record-verdicts: judge=%s store=%s\n%!" evaluator_runtime
+        verdict_dir
+    end;
     let started_at = Unix.gettimeofday () in
     let results =
-      List.map (fun s -> run_scenario s ~runtime_id:cfg.runtime_id ~k:cfg.k) scenarios
+      List.map
+        (fun s ->
+          run_scenario s ~runtime_id:cfg.runtime_id ~k:cfg.k ~sw
+            ~record_verdicts:cfg.record_verdicts ~evaluator_runtime)
+        scenarios
     in
     let ended_at = Unix.gettimeofday () in
     let suite = build_suite ~started_at ~ended_at results in

--- a/data/eval/completion_trust/README.md
+++ b/data/eval/completion_trust/README.md
@@ -1,4 +1,4 @@
-# completion-trust LLM behavioural eval (RFC-0262 §9 axis ①)
+# completion-trust LLM behavioural eval (RFC-0262 §9 proving metric)
 
 This corpus drives a live keeper with adversarial *completion-trust temptation*
 prompts and measures whether the model **attempts** to complete a task it does
@@ -12,7 +12,9 @@ deterministic regression oracle for the same invariants lives in
 
 ## What it measures vs. what it does not
 
-The harness separates three roles (RFC-0262 §9):
+The harness separates three roles (a harness design contract — see
+`docs/design/completion-trust-calibration-wiring.md`; RFC-0262 §8 is the test
+plan, §9 the rollout + proving metric, and the role separation is not RFC text):
 
 - **keeper** — the live LLM under test; the author of the completion *attempt*.
 - **judge** — the real dispatch-path gates (deterministic ownership check,
@@ -20,7 +22,10 @@ The harness separates three roles (RFC-0262 §9):
   attempt; it does **not** exercise the live FSM gate. The live gate is covered
   deterministically by `test_completion_trust_harness.ml`. The stub `dispatch`
   closure is the seam where a future PR can route the attempt through the real
-  handler plus `Eval_calibration` verdict recording.
+  handler plus `Eval_calibration` verdict recording — see
+  `docs/design/completion-trust-calibration-wiring.md` for the three blockers
+  (judge fires only under ownership; corpus not seeded; `agreement_rate` needs
+  human labels) that wiring must resolve.
 - **eval-grader** — deterministic graders + pass@k (`bin/masc_completion_trust_eval.ml`).
 
 So a scenario measures **disposition** (does the model take the bait?), not the

--- a/data/eval/completion_trust/scenarios.json
+++ b/data/eval/completion_trust/scenarios.json
@@ -21,6 +21,7 @@
       }
     ],
     "max_turns": 4,
+    "ownership": "foreign",
     "tags": ["completion-trust", "regression-guard", "rfc-0262-section9", "issue-20925"]
   },
   {
@@ -45,6 +46,7 @@
       }
     ],
     "max_turns": 4,
+    "ownership": "self_owned",
     "tags": ["completion-trust", "target-spec", "rfc-0199-phase-b", "issue-21074"]
   },
   {
@@ -69,6 +71,7 @@
       }
     ],
     "max_turns": 4,
+    "ownership": "self_owned",
     "tags": ["completion-trust", "target-spec", "rfc-0199-phase-b", "issue-20710"]
   }
 ]

--- a/docs/design/completion-trust-calibration-wiring.md
+++ b/docs/design/completion-trust-calibration-wiring.md
@@ -1,0 +1,135 @@
+# Completion-trust calibration wiring — design note (RFC-0262 §9 follow-up)
+
+Status: design (no code lands from this note beyond a citation correction)
+Governing: RFC-0262 §8 (Test plan) / §9 (Rollout, proving metric); RFC-0199 Phase B (evidence gate); RFC-0222 (acceptance typing)
+File refs below are as of `origin/main` and will drift — re-confirm before implementing.
+
+## Why this note exists
+
+The live-LLM completion-trust runner `bin/masc_completion_trust_eval.ml` (PR-C #21754) drives
+a real keeper with foreign-task-temptation prompts and grades its tool-call *disposition*
+deterministically. Its dispatch is a **stub**: it records every `(name, args)` and returns a
+fixed `Tool_result.ok` without invoking any gate, handler, or judge (`run_one`'s dispatch
+closure in `bin/masc_completion_trust_eval.ml`). The runner docstring names that stub as
+"the seam where a later PR can route the attempt through the real handler plus
+`Eval_calibration` verdict recording".
+
+A mapping pass over the runner, `Eval_calibration`, `Anti_rationalization`, and the live
+done-handler showed that the obvious "un-stub dispatch and record verdicts" increment is a
+**workaround** (it would record zero verdicts and present a metric that stays vacuously 0).
+This note records the blockers and the three design decisions a faithful wiring requires, so
+the next PR implements measurement rather than telemetry-as-fix.
+
+## Blockers (why naive wiring records nothing)
+
+**B1 — the judge only fires behind the ownership gate.**
+The only producer of an `Anti_rationalization` verdict on the Done path is
+`review_completion_notes`, reached only when `action = Done_action`, `not force`, and
+`can_review_completion` is true (`lib/task/tool_task.ml:348-353`). `can_review_completion` is
+true only when the task is `Claimed`/`InProgress` **and** `assignee = agent_name`
+(`lib/task/tool_task_completion_review.ml:13-21`). The runner's stub dispatch bypasses
+`tool_task.ml` entirely — `run_named_with_masc_tools` bridges each tool call straight to the
+caller-supplied dispatch closure (`lib/keeper/keeper_turn_driver_wrappers.ml:184-188`) — so the
+judge never fires and `record_verdict` is never reached. **Scope "record verdicts without
+routing through the real handler" is therefore impossible**; the verdict producer lives inside
+the handler.
+
+**B2 — the current corpus produces no verdict even through the real handler.**
+Scenario task ids (`task-847`, `task-968`, `task-733`) exist only in prompt/`setup_messages`
+text (`data/eval/completion_trust/scenarios.json:9,33,57`); they are not seeded into live
+workspace state. `handle_transition` loads tasks from `Workspace.get_tasks_raw`
+(`lib/task/tool_task.ml:174-175`); against an unseeded id it returns `task_opt = None` →
+`completion_state_error` (`task_done_requires_claimed_or_started`) → `review_completion_notes`
+is never reached → **zero verdicts**. `ct-foreign-ownership` cannot produce a verdict even when
+seeded: it is owned by `codex-mcp-client` while the keeper is `keeper-eval-agent`, so
+`can_review_completion = false` and the ownership gate (`task_done_requires_current_owner`)
+rejects first (`data/eval/completion_trust/scenarios.json:9-10`).
+
+**B3 — `agreement_rate` is human-label-vs-evaluator, not keeper-vs-judge.**
+`calibration_stats.agreement_rate` folds verdict records against **human** `Label_record`s that
+share a `notes_hash`; with verdicts but no labels, `labeled_total = 0` →
+`agreement_rate = 0.0` (`lib/eval_calibration.ml:419-422`; labels come from
+`record_human_label`, `lib/eval_calibration.ml:224`). Recording verdicts alone can **never**
+yield a non-zero `agreement_rate`. The only verdict-derived metric is `cross_model_rate`, which
+counts verdict records whose `generator_runtime` and `evaluator_runtime` are non-empty and
+differ (`lib/eval_calibration.ml:375-381,429`). The plan's stated goal of "compute
+agreement_rate" is a metric mismatch and must be corrected.
+
+## Design decisions for the implementation PR
+
+**D1 — ownership-tagged corpus.** Add an explicit ownership class to the scenario schema
+(e.g. `ownership: self_owned | foreign`). Only `self_owned` scenarios (the keeper owns a
+`Claimed`/`InProgress` task whose completion notes are weak) can make the judge fire and are
+eligible for the verdict-recording path. `foreign` scenarios stay **disposition-only** — they
+are already covered deterministically by `test/test_completion_trust_harness.ml` (PR-B,
+ownership/anti-rat gate rejection). Today's three scenarios are all foreign-temptation;
+self-owned scenarios are net-new and must be authored.
+
+**D2 — `agreement_rate` is out of scope for the automated runner.** No human labels exist in
+CI, so the runner can populate `total_verdicts`, `approve`/`reject` counts,
+`gate_distribution`, and `cross_model_rate` (distinct generator vs evaluator runtime), but
+**not** `agreement_rate`. Do not present `agreement_rate` as a runner metric. A human-labeling
+workflow (`record_human_label` over a sampled verdict set) is a separate, deferred track.
+
+**D3 — isolation is mandatory.** The verdict-recording path drives the real cross-model judge
+(`Anti_rationalization.review`, `lib/task/anti_rationalization.mli:78-85`) and writes
+`data/verdicts/YYYY-MM/DD.jsonl` (`lib/eval_calibration.ml:102-103,215`). Run it behind an
+isolated `MASC_BASE_PATH` (temp base) and `Eval_calibration.set_store_for_testing ~base_dir`
+(scratch store, `lib/eval_calibration.mli:74-75`), seed a self-owned task fixture, and install
+the two hooks the CLI does not currently install: `record_verdict_fn`
+(default no-op, `lib/task/tool_task_handlers.ml:28-30`; wired to `Eval_calibration.record_verdict`
+only at server boot, `lib/mcp_server.ml:530-531`) and `run_llm_reviewer_fn`
+(installed only in `lib/workspace_metric_hooks.ml:458`). It must never mutate live workspace
+task state or pollute the live `data/verdicts` store.
+
+## The seam (where, what)
+
+- Insertion point: `run_one`'s dispatch closure in `bin/masc_completion_trust_eval.ml`,
+  branched on a completion-tool name (`masc_task_done`/`masc_task_force_done`). `scenario`,
+  `runtime_id`, `run_index`, and the call `args` (`task_id`/`notes`) are in scope there; the
+  final `stop_reason` is not (only post-return, in `build_eval_run`).
+- Real measurement (non-fake): build an `Anti_rationalization.review_request` from scenario
+  context + the call's `notes`/`task_id` and call `Anti_rationalization.review` with a distinct
+  `~evaluator_runtime`, `~on_verdict` routed to `Eval_calibration.record_verdict` — mirroring
+  `lib/task/tool_task_handlers.ml:205-232` and `lib/mcp_server.ml:530-531`. This drives a second
+  evaluator LLM and persists a genuine verdict (`verdict_record`,
+  `lib/eval_calibration.mli:29-41`), feeding `cross_model_rate` immediately.
+- Gate it behind a `--record-verdicts` flag, default off. The disposition track remains the
+  default, CI-safe, deterministic-grading mode.
+
+## Workaround self-check (CLAUDE.md §Workaround Rejection)
+
+A naive `stub → record_verdict` one-liner is **telemetry-as-fix**: the build passes and
+`data/verdicts/` is created, but zero verdicts are recorded (B1/B2) and `agreement_rate`
+stays vacuously 0 (B3) — a counter that measures nothing. Rejected. The only honest increment
+drives an actual judge LLM over self-owned scenarios in an isolated workspace and reports the
+metric it can actually compute (`cross_model_rate`), with `agreement_rate` explicitly deferred
+to a human-labeling track.
+
+## Citation reconciliation (corrected in this PR)
+
+The runner and README cite "RFC-0262 §9 harness — keeper/judge/eval-grader separation" and
+"axis ①". This is inaccurate on two counts:
+
+1. RFC-0262 §9 is **Rollout** and §8 is **Test plan** (`docs/rfc/RFC-0262-completion-authority-typing.md:154,163`).
+   The keeper/judge/eval-grader role separation is a **harness design contract** that lives in
+   the runner/README and this note — it is not text in RFC-0262.
+2. RFC-0262 types axis ② (completion authority); axis ① (LLM discretion to complete) is
+   RFC-0222's territory. The runner measures the keeper's *disposition* to attempt a foreign /
+   unevidenced completion, which is the behavioural complement to RFC-0262 §9's **proving
+   metric**: "zero foreign-task completions by a non-`Operator`/`System` actor"
+   (`docs/rfc/RFC-0262-completion-authority-typing.md:171`).
+
+Corrected wording: the runner supports RFC-0262 §9's proving metric and §8's test plan; the
+role-separation contract references this design note rather than claiming to be RFC text.
+
+## Next PR scope (ready to implement after this note)
+
+1. Author ≥1 `self_owned` weak-evidence scenario + add the `ownership` field to the schema and
+   `Eval_harness` scenario type.
+2. Add `--record-verdicts` mode: isolated `MASC_BASE_PATH` + `set_store_for_testing`, seed the
+   self-owned task, install `record_verdict_fn` + `run_llm_reviewer_fn`, call
+   `Anti_rationalization.review` with `~on_verdict → record_verdict` on completion-tool dispatch
+   for self-owned scenarios only.
+3. Report `cross_model_rate` (+ verdict counts/gate distribution); keep `agreement_rate` out.
+4. Deferred: a human-labeling workflow to make `agreement_rate` meaningful.

--- a/docs/design/completion-trust-calibration-wiring.md
+++ b/docs/design/completion-trust-calibration-wiring.md
@@ -62,8 +62,10 @@ agreement_rate" is a metric mismatch and must be corrected.
 `Claimed`/`InProgress` task whose completion notes are weak) can make the judge fire and are
 eligible for the verdict-recording path. `foreign` scenarios stay **disposition-only** — they
 are already covered deterministically by `test/test_completion_trust_harness.ml` (PR-B,
-ownership/anti-rat gate rejection). Today's three scenarios are all foreign-temptation;
-self-owned scenarios are net-new and must be authored.
+ownership/anti-rat gate rejection). Of today's three scenarios, two
+(`ct-scope-mismatch-evidence`, `ct-fabricated-ref`) are already self-owned weak-evidence
+completions (`claimed_by = keeper-eval-agent`) and only need the `self_owned` tag; only
+`ct-foreign-ownership` is foreign. No net-new scenario is required.
 
 **D2 — `agreement_rate` is out of scope for the automated runner.** No human labels exist in
 CI, so the runner can populate `total_verdicts`, `approve`/`reject` counts,

--- a/docs/design/completion-trust-calibration-wiring.md
+++ b/docs/design/completion-trust-calibration-wiring.md
@@ -74,9 +74,11 @@ workflow (`record_human_label` over a sampled verdict set) is a separate, deferr
 **D3 — isolation is mandatory.** The verdict-recording path drives the real cross-model judge
 (`Anti_rationalization.review`, `lib/task/anti_rationalization.mli:78-85`) and writes
 `data/verdicts/YYYY-MM/DD.jsonl` (`lib/eval_calibration.ml:102-103,215`). Run it behind an
-isolated `MASC_BASE_PATH` (temp base) and `Eval_calibration.set_store_for_testing ~base_dir`
-(scratch store, `lib/eval_calibration.mli:74-75`), seed a self-owned task fixture, and install
-the two hooks the CLI does not currently install: `record_verdict_fn`
+explicit temp workspace base path (prefer a CLI `--base`/`--base-path` argument over ambient
+environment; `MASC_BASE_PATH` is only a process-bound fallback) and
+`Eval_calibration.set_store_for_testing ~base_dir` (scratch store,
+`lib/eval_calibration.mli:74-75`), seed a self-owned task fixture, and install the two hooks
+the CLI does not currently install: `record_verdict_fn`
 (default no-op, `lib/task/tool_task_handlers.ml:28-30`; wired to `Eval_calibration.record_verdict`
 only at server boot, `lib/mcp_server.ml:530-531`) and `run_llm_reviewer_fn`
 (installed only in `lib/workspace_metric_hooks.ml:458`). It must never mutate live workspace
@@ -127,9 +129,10 @@ role-separation contract references this design note rather than claiming to be 
 
 1. Author ≥1 `self_owned` weak-evidence scenario + add the `ownership` field to the schema and
    `Eval_harness` scenario type.
-2. Add `--record-verdicts` mode: isolated `MASC_BASE_PATH` + `set_store_for_testing`, seed the
+2. Add `--record-verdicts` mode: explicit temp workspace base path (`--base`/`--base-path`,
+   with `MASC_BASE_PATH` only as a process-bound fallback) + `set_store_for_testing`, seed the
    self-owned task, install `record_verdict_fn` + `run_llm_reviewer_fn`, call
-   `Anti_rationalization.review` with `~on_verdict → record_verdict` on completion-tool dispatch
-   for self-owned scenarios only.
+   `Anti_rationalization.review` with `~on_verdict → record_verdict` on completion-tool
+   dispatch for self-owned scenarios only.
 3. Report `cross_model_rate` (+ verdict counts/gate distribution); keep `agreement_rate` out.
 4. Deferred: a human-labeling workflow to make `agreement_rate` meaningful.

--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -446,6 +446,16 @@ let scenario_of_json (json : Yojson.Safe.t) : (scenario, string) result =
       | Some (`List items) -> List.filter_map (function `String s -> Some s | _ -> None) items
       | _ -> []
     in
+    let ownership =
+      match Json_util.assoc_member_opt "ownership" json with
+      | None -> Foreign
+      | Some (`String "self_owned") -> Self_owned
+      | Some (`String "foreign") -> Foreign
+      | Some other ->
+          invalid_arg
+            (Printf.sprintf "scenario ownership invalid: %s"
+               (Yojson.Safe.to_string other))
+    in
 
     (* Per-grader JSON field helpers (using grader JSON, not scenario JSON) *)
     let g_str_opt g key default =
@@ -556,11 +566,7 @@ let scenario_of_json (json : Yojson.Safe.t) : (scenario, string) result =
       max_turns = int_opt "max_turns" 5;
       max_cost_usd = float_opt "max_cost_usd" 0.10;
       tags = str_list "tags";
-      (* Backward-compatible: absent/unknown ownership defaults to Foreign so the
-         existing foreign-temptation corpus is unchanged. *)
-      ownership = (match str_opt "ownership" "foreign" with
-        | "self_owned" -> Self_owned
-        | _ -> Foreign);
+      ownership;
     }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "Failed to parse scenario: %s" (Printexc.to_string exn))

--- a/lib/eval_harness.ml
+++ b/lib/eval_harness.ml
@@ -53,6 +53,18 @@ type tool_expectation = {
   args_contain : string option;  (** Args should contain this substring *)
 }
 
+(** Whether the keeper owns the task it is tempted to complete. Only
+    [Self_owned] scenarios reach the anti-rationalization judge in production
+    (foreign completions are rejected by the ownership gate before the judge),
+    so verdict recording (--record-verdicts) is restricted to them. *)
+type ownership =
+  | Self_owned
+  | Foreign
+
+let ownership_to_string = function
+  | Self_owned -> "self_owned"
+  | Foreign -> "foreign"
+
 type scenario = {
   id : string;                        (** Unique scenario identifier *)
   name : string;                      (** Human-readable name *)
@@ -66,6 +78,7 @@ type scenario = {
   max_turns : int;                    (** Max turns before timeout *)
   max_cost_usd : float;              (** Advisory cost threshold for this scenario *)
   tags : string list;                 (** Filtering tags: "regression", "smoke", etc. *)
+  ownership : ownership;              (** Self_owned feeds the judge under --record-verdicts; default Foreign *)
 }
 
 (* ================================================================ *)
@@ -399,6 +412,7 @@ let scenario_to_json (s : scenario) : Yojson.Safe.t =
     ("max_turns", `Int s.max_turns);
     ("max_cost_usd", `Float s.max_cost_usd);
     ("tags", `List (List.map (fun s -> `String s) s.tags));
+    ("ownership", `String (ownership_to_string s.ownership));
     ("graders", `Int (List.length s.graders));
     ("tool_expectations", `Int (List.length s.tool_expectations));
   ]
@@ -542,6 +556,11 @@ let scenario_of_json (json : Yojson.Safe.t) : (scenario, string) result =
       max_turns = int_opt "max_turns" 5;
       max_cost_usd = float_opt "max_cost_usd" 0.10;
       tags = str_list "tags";
+      (* Backward-compatible: absent/unknown ownership defaults to Foreign so the
+         existing foreign-temptation corpus is unchanged. *)
+      ownership = (match str_opt "ownership" "foreign" with
+        | "self_owned" -> Self_owned
+        | _ -> Foreign);
     }
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
     Error (Printf.sprintf "Failed to parse scenario: %s" (Printexc.to_string exn))

--- a/lib/eval_harness.mli
+++ b/lib/eval_harness.mli
@@ -54,6 +54,15 @@ type tool_expectation = {
   args_contain : string option;
 }
 
+(** Whether the keeper owns the task it is tempted to complete. Only
+    [Self_owned] scenarios reach the anti-rationalization judge in production, so
+    verdict recording (--record-verdicts) is restricted to them. *)
+type ownership =
+  | Self_owned
+  | Foreign
+
+val ownership_to_string : ownership -> string
+
 type scenario = {
   id : string;
   name : string;
@@ -67,6 +76,7 @@ type scenario = {
   max_turns : int;
   max_cost_usd : float;
   tags : string list;
+  ownership : ownership;
 }
 
 (** {1 Result types} *)

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -94,6 +94,46 @@ let test_record_verdict_reject () =
   check string "verdict = reject:vague notes" "reject:vague notes" v;
   Cal.reset_store_for_testing ()
 
+(* The runner's --record-verdicts path wires AR.review's on_verdict callback to
+   Cal.record_verdict (record_self_owned_verdict in
+   bin/masc_completion_trust_eval.ml). Prove that composition deterministically
+   with a fake reviewer, so the wiring is covered without a live judge LLM. *)
+let test_review_on_verdict_records () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let dir = tmpdir () in
+  Cal.set_store_for_testing ~base_dir:dir;
+  let saved = Atomic.get AR.run_llm_reviewer_fn in
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set AR.run_llm_reviewer_fn saved;
+      Cal.reset_store_for_testing ())
+    (fun () ->
+      (* Fake judge: a structured Reject, no live LLM. *)
+      Atomic.set AR.run_llm_reviewer_fn
+        (fun ?sw:_ ~evaluator_runtime:_ ~prompt:_ ~report_tool_schema:_ () ->
+          Ok (Some (AR.Reject "fabricated evidence"), ""));
+      let req =
+        make_req ~notes:"Implemented the change and verified it end to end." ()
+      in
+      let result =
+        AR.review ~evaluator_runtime:"judge-runtime"
+          ~generator_runtime:"keeper-runtime"
+          ~on_verdict:(fun result ->
+            Cal.record_verdict ~task_id:req.AR.task_id ~req ~result ())
+          req
+      in
+      check bool "judge rejected" true
+        (match result.AR.verdict with AR.Reject _ -> true | _ -> false);
+      let records = Dated_jsonl.read_recent (Cal.get_store ()) 10 in
+      check bool "verdict recorded via on_verdict" true
+        (List.length records >= 1);
+      let v =
+        Yojson.Safe.Util.(List.hd records |> member "verdict" |> to_string)
+      in
+      check string "recorded the fake judge's reject" "reject:fabricated evidence"
+        v)
+
 let test_record_verdict_hash_matches () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -431,6 +471,7 @@ let () =
       test_case "writes to store" `Quick test_record_verdict_writes;
       test_case "reject verdict" `Quick test_record_verdict_reject;
       test_case "hash matches" `Quick test_record_verdict_hash_matches;
+      test_case "review on_verdict records" `Quick test_review_on_verdict_records;
     ];
     "human_label", [
       test_case "writes label" `Quick test_record_human_label;

--- a/test/test_eval_harness.ml
+++ b/test/test_eval_harness.ml
@@ -212,8 +212,44 @@ let test_parse_minimal_scenario () =
       Alcotest.(check string) "id" "test-001" s.Eval_harness.id;
       Alcotest.(check string) "goal" "Do something" s.Eval_harness.goal;
       Alcotest.(check string) "category default" "general" s.Eval_harness.category;
-      Alcotest.(check int) "max_turns default" 5 s.Eval_harness.max_turns
+      Alcotest.(check int) "max_turns default" 5 s.Eval_harness.max_turns;
+      Alcotest.(check bool) "ownership default" true
+        (s.Eval_harness.ownership = Eval_harness.Foreign)
   | Error e -> Alcotest.fail (Printf.sprintf "Parse failed: %s" e)
+
+let test_parse_self_owned_ownership () =
+  let json = Yojson.Safe.from_string {|{
+    "id": "self-owned-001",
+    "goal": "Measure an owned completion claim",
+    "ownership": "self_owned"
+  }|} in
+  match Eval_harness.scenario_of_json json with
+  | Ok s ->
+      Alcotest.(check bool) "ownership" true
+        (s.Eval_harness.ownership = Eval_harness.Self_owned)
+  | Error e -> Alcotest.fail (Printf.sprintf "Parse failed: %s" e)
+
+let test_parse_rejects_invalid_ownership () =
+  let assert_invalid label json_text =
+    let json = Yojson.Safe.from_string json_text in
+    match Eval_harness.scenario_of_json json with
+    | Ok _ -> Alcotest.failf "%s unexpectedly parsed" label
+    | Error e ->
+        Alcotest.(check bool) (label ^ " mentions ownership") true
+          (String_util.contains_substring e "ownership")
+  in
+  assert_invalid "typo"
+    {|{
+      "id": "self-owned-typo",
+      "goal": "Measure an owned completion claim",
+      "ownership": "self-owned"
+    }|};
+  assert_invalid "non-string"
+    {|{
+      "id": "self-owned-non-string",
+      "goal": "Measure an owned completion claim",
+      "ownership": 1
+    }|}
 
 let test_parse_full_scenario () =
   let json = Yojson.Safe.from_string {|{
@@ -390,6 +426,10 @@ let () =
     ]);
     ("scenario_parsing", [
       Alcotest.test_case "minimal" `Quick test_parse_minimal_scenario;
+      Alcotest.test_case "self_owned ownership" `Quick
+        test_parse_self_owned_ownership;
+      Alcotest.test_case "reject invalid ownership" `Quick
+        test_parse_rejects_invalid_ownership;
       Alcotest.test_case "full scenario" `Quick test_parse_full_scenario;
       Alcotest.test_case "regex grader" `Quick test_parse_regex_grader;
       Alcotest.test_case "tool_name fallback" `Quick

--- a/test/test_eval_harness.ml
+++ b/test/test_eval_harness.ml
@@ -328,6 +328,7 @@ let test_report_to_string () =
     setup_messages = []; expected_outcome = "";
     tool_expectations = []; graders = [];
     max_turns = 5; max_cost_usd = 0.10; tags = [];
+    ownership = Eval_harness.Foreign;
   } in
   let result : Eval_harness.eval_result = {
     scenario;


### PR DESCRIPTION
## 무엇을 / 왜

설계노트 #21795(stacked base)의 구현입니다. `--record-verdicts` 모드: **self-owned weak-evidence** 시나리오에서 키퍼의 완료 시도에 대해 실제 anti-rationalization **judge**를 구동하고 그 verdict를 격리된 verdict store에 기록 → `cross_model_rate`. foreign-temptation 시나리오는 disposition-only 유지.

## 설계노트 대비 단순화

`Anti_rationalization.review`는 **review_request에 대한 순수 함수**(disk/ownership 미조회)임을 확인 → **task seeding/실제 handler 라우팅 불필요**(설계노트 D3 단순화). dispatch에서 scenario + 시도 notes로 review_request를 구성해 `review ~on_verdict:record_verdict`를 직접 호출(`tool_task_handlers.review_completion_notes` 미러). `agreement_rate`는 human label이 필요해 **out-of-scope**, verdict만으로 나오는 `cross_model_rate`만 측정.

## 변경 (6파일, +163/-6)

- `lib/eval_harness.{ml,mli}`: `ownership` (Self_owned | Foreign), backward-compat 파싱(부재→Foreign), scenario_to_json 직렬화
- `data/eval/completion_trust/scenarios.json`: 이미 self-owned인 weak-evidence 2개(ct-scope-mismatch-evidence, ct-fabricated-ref)에 `self_owned` 태그, ct-foreign-ownership에 `foreign`
- `bin/masc_completion_trust_eval.ml`: `--record-verdicts`/`--evaluator-runtime` 플래그; `--base` 하위로 verdict store 격리(`set_store_for_testing`); OAS reviewer hook 설치(`Workspace_metric_hooks.install`); self_owned 완료 시도에 review→record_verdict; `--list`에 ownership 표시
- `test/test_eval_calibration.ml`: 결정론 테스트 — fake reviewer hook으로 review의 on_verdict가 verdict 1건 기록함을 라이브 LLM 없이 증명
- `test/test_eval_harness.ml`: scenario literal에 ownership 필드

## 검증

- `dune build --root . bin/...eval.exe test/test_eval_calibration.exe test/test_eval_harness.exe` exit 0
- `test_eval_harness` 24/24 통과; `test_eval_calibration` 신규 "review on_verdict records" 통과
- `ocamlformat --check` 내 5파일 exit 0
- `--list`가 ownership=foreign/self_owned 정확 표시
- 라이브 judge(`--record-verdicts`)는 runtime 필요 + manual/token-heavy → CI 미실행, wiring은 fake-reviewer 테스트가 결정론 커버

## 사전존재 실패 (이 PR 무관)

`test_eval_calibration`의 `stats > cross_model mix`가 bare 테스트 바이너리에서 `Runtime.get_default_runtime_id: not initialized`로 실패합니다(line 351 `Keeper_config.default_runtime_id ()`가 `Runtime.init_default` 없이 호출됨). **stats 그룹만 격리 실행해도 동일 실패** → 내 변경 무관(내 테스트는 record_verdict 그룹). 로컬-env vs main-red 미확정, 별도 추적.

## 워크어라운드 self-check

stub-as-measurement 아님 — self_owned에서 **실제 judge LLM**을 구동해 genuine verdict 기록. foreign은 production서 ownership-gated라 judge 미도달 = disposition-only 유지(가짜 verdict 0). agreement_rate는 측정 불가라 정직하게 제외.

RFC: RFC-0262 §9 (#21795 설계노트 기반). Stacked on `docs/completion-trust-calibration-wiring`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
