### PR TITLE
fix(ci): make build trigger a superset of the dune build graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,13 +240,14 @@ jobs:
           # never ran. The prefix list below (bin/ lib/ test/ proto/ config/)
           # missed build-graph dirs examples/ ppx/ ppx_tla/ test_lib/ tools/
           # and the root dune file, so a PR touching only those compiled
-          # nowhere yet reported success. Match any OCaml/dune source by
-          # suffix so the trigger is a superset by construction (a new
-          # top-level OCaml dir is covered without editing this list).
+          # nowhere yet reported success. Match any OCaml/dune source plus C
+          # foreign stubs by suffix so the trigger is a superset by
+          # construction (a new top-level OCaml dir is covered without editing
+          # this list).
           # Over-triggering on dune-excluded dirs (archive/, dashboard_bonsai/
           # per the root dune (dirs ...) stanza) is harmless: the Build job
           # runs but dune build skips those dirs.
-          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|.*\.ml$|.*\.mli$|.*\.mll$|.*\.mly$|(.*/)?dune$|scripts/ci-run-tests\.sh$|scripts/release-binary-smoke\.sh$|scripts/release-evidence\.sh$|scripts/install\.sh$|scripts/harness/contract/|scripts/harness/transport/|scripts/harness/lib/server_bootstrap\.sh$)'; then
+          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|.*\.ml$|.*\.mli$|.*\.mll$|.*\.mly$|.*\.c$|.*\.h$|(.*/)?dune$|scripts/ci-run-tests\.sh$|scripts/release-binary-smoke\.sh$|scripts/release-evidence\.sh$|scripts/install\.sh$|scripts/harness/contract/|scripts/harness/transport/|scripts/harness/lib/server_bootstrap\.sh$)'; then
             build=true
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,13 +241,13 @@ jobs:
           # missed build-graph dirs examples/ ppx/ ppx_tla/ test_lib/ tools/
           # and the root dune file, so a PR touching only those compiled
           # nowhere yet reported success. Match any OCaml/dune source plus C
-          # foreign stubs by suffix so the trigger is a superset by
-          # construction (a new top-level OCaml dir is covered without editing
-          # this list).
+          # foreign stubs by suffix so new source dirs are covered without
+          # editing this list, and keep explicit prefixes for Dune-declared
+          # non-source deps (e.g. tools/tlc_test_gen/test/fixtures/*.tla).
           # Over-triggering on dune-excluded dirs (archive/, dashboard_bonsai/
           # per the root dune (dirs ...) stanza) is harmless: the Build job
           # runs but dune build skips those dirs.
-          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|.*\.ml$|.*\.mli$|.*\.mll$|.*\.mly$|.*\.c$|.*\.h$|(.*/)?dune$|scripts/ci-run-tests\.sh$|scripts/release-binary-smoke\.sh$|scripts/release-evidence\.sh$|scripts/install\.sh$|scripts/harness/contract/|scripts/harness/transport/|scripts/harness/lib/server_bootstrap\.sh$)'; then
+          if has_match '^(bin/|lib/|test/|proto/|config/|tools/tlc_test_gen/|dune-project$|dune-workspace$|.*\.opam$|.*\.ml$|.*\.mli$|.*\.mll$|.*\.mly$|.*\.c$|.*\.h$|(.*/)?dune$|scripts/ci-run-tests\.sh$|scripts/release-binary-smoke\.sh$|scripts/release-evidence\.sh$|scripts/install\.sh$|scripts/harness/contract/|scripts/harness/transport/|scripts/harness/lib/server_bootstrap\.sh$)'; then
             build=true
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,20 @@ jobs:
             ci_core=true
           fi
 
-          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|scripts/ci-run-tests\.sh$|scripts/release-binary-smoke\.sh$|scripts/release-evidence\.sh$|scripts/install\.sh$|scripts/harness/contract/|scripts/harness/transport/|scripts/harness/lib/server_bootstrap\.sh$)'; then
+          # The build trigger must stay a SUPERSET of the dune build graph.
+          # ci-gate treats a skipped required job as PASS (see check() near
+          # line 1206), so any code-bearing PR that does NOT set build=true
+          # merges with a green "CI Gate" while the Build job (dune compile)
+          # never ran. The prefix list below (bin/ lib/ test/ proto/ config/)
+          # missed build-graph dirs examples/ ppx/ ppx_tla/ test_lib/ tools/
+          # and the root dune file, so a PR touching only those compiled
+          # nowhere yet reported success. Match any OCaml/dune source by
+          # suffix so the trigger is a superset by construction (a new
+          # top-level OCaml dir is covered without editing this list).
+          # Over-triggering on dune-excluded dirs (archive/, dashboard_bonsai/
+          # per the root dune (dirs ...) stanza) is harmless: the Build job
+          # runs but dune build skips those dirs.
+          if has_match '^(bin/|lib/|test/|proto/|config/|dune-project$|dune-workspace$|.*\.opam$|.*\.ml$|.*\.mli$|.*\.mll$|.*\.mly$|(.*/)?dune$|scripts/ci-run-tests\.sh$|scripts/release-binary-smoke\.sh$|scripts/release-evidence\.sh$|scripts/install\.sh$|scripts/harness/contract/|scripts/harness/transport/|scripts/harness/lib/server_bootstrap\.sh$)'; then
             build=true
           fi
 


### PR DESCRIPTION
## 목표

`CI Gate` 가 컴파일 없이 `success` 로 종료되는 경로를 닫는다 (#21814). `changes` job 의 `build` path 필터가 `dune build` 그래프보다 좁아, `tools/ ppx/ ppx_tla/ test_lib/ examples/` 또는 루트 `dune` 만 건드린 PR 은 Build job 이 skip 되고 `ci-gate` 가 skip 을 PASS 로 집계해 컴파일 에러가 green `CI Gate` 로 main 에 안착할 수 있었다.

## 변경

`.github/workflows/ci.yml` 의 `build` 트리거 정규식 1곳(+설명 주석). dir prefix 미러(누락 발생) 대신 **build 그래프의 superset by construction** 으로 전환 — OCaml/dune 소스 suffix(`.ml/.mli/.mll/.mly`, 모든 `dune`)를 매칭. 새 top-level OCaml dir 이 추가돼도 이 목록 수정 없이 자동 커버.

## 근거

- `ci.yml:236` build 필터: 포함 `bin/ lib/ test/ proto/ config/`. 누락 `examples/ ppx/ ppx_tla/ test_lib/ tools/` + 루트 `dune`.
- 루트 `dune` build 그래프 제외목록 = `.worktrees worktrees _build_codex_trpg archive dashboard_bonsai` → 나머지(위 누락 dir 포함)는 `dune build` 가 컴파일.
- `ci.yml:564` build job 은 `needs.changes.outputs.build == 'true'` 일 때만 실행; `ci.yml:1206` `ci-gate` 는 `skipped` 를 PASS 로 집계.
- 실증: PR #21778(dashboard-only) head = `Build and Test: skipped` + `CI Gate: success`. `ppx_tla` 는 `lib/dune` 의 `(pps ... ppx_tla)` preprocessor 라 깨지면 main lib 빌드가 깨질 수 있는데도 skip 됐다.

근거 출처: 2026-06-20 병합 게이트 적대 감사(17-agent). 본 벡터 2/2 독립 skeptic CONFIRMED.

## 검증 (로컬)

- 새 정규식을 경로 14종으로 테스트: `tools/*.ml ppx_tla/*.ml ppx/*/*.ml test_lib/*.ml examples/*.ml 루트 dune 중첩 dune *.mll bin/*.ml dune-project *.opam` → 전부 BUILD. `docs/*.md dashboard/src/*.ts README.md` → skip 유지(컴파일 불필요라 정상).
- `archive/*.ml` → BUILD (의도된 무해 over-trigger: dune build 가 archive 를 skip 하므로 빌드는 돌지만 결과 동일).
- `python3 -c "yaml.safe_load(...)"` → YAML OK. `actionlint` → 변경 라인(236-249)에 이슈 없음(line 77 SC2129 는 기존·무관).

## 경계 / RFC

- `.github/workflows/ci.yml` 단일 파일. RFC 게이트 대상 subsystem(credential / operator control / sandbox / dashboard credential / hooks / workflow docs) 미변경.
- 증상 억제가 아니라 root fix: build 트리거를 그래프의 superset 으로 만들어 drift 원인(hand-maintained prefix mirror)을 닫는다. 텔레메트리/문자열-분류기-보강/N-of-M 아님 — dir 열거(N-of-M) 대신 suffix 로 by-construction 닫음.

Fixes #21814.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
