### PR TITLE
refactor(memory-os): durable-write SSOT routing + unified staleness anchor (#21716)

### DIFF
--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -33,11 +33,10 @@ let ttl_expired ~now (fact : fact) =
    diverge from them (RFC-0247 §2.3 fold). *)
 let normalized_claim_key fact = normalize_claim fact.claim
 
-let verified_at fact =
-  match fact.last_verified_at with
-  | Some ts -> ts
-  | None -> fact.first_seen
-;;
+(* The dedup winner's recency anchor: the type-level {!reference_time} SSOT, so
+   GC's "which duplicate to keep" reads the same timestamp as recall ordering and
+   retention ranking. *)
+let verified_at = reference_time
 
 (* RFC-0247 (purge): the dedup winner is structural — the most-recently-verified
    row for a claim (else first-seen), tie-broken by file order. The prior GC

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -112,12 +112,10 @@ let episode_path ~keeper_id ~trace_id ~generation =
     (Printf.sprintf "%s-g%04d.json" trace_id generation)
 ;;
 
-let remove_noerr path =
-  try
-    if Sys.file_exists path then Sys.remove path
-  with
-  | Sys_error _ | Unix.Unix_error _ -> ()
-;;
+(* Raised when a durable atomic write fails. Distinct from [Failure] so the
+   facts-lock wrapper's lock-timeout handler ([with_facts_lock]) does not
+   misclassify a write error (e.g. ENOSPC) as a lock-acquisition timeout. *)
+exception Atomic_write_failed of string
 
 (* Run [f] against [oc] then close it, guaranteeing the descriptor is released
    on every exit. [close_out] runs inside the body so a flush failure (e.g.
@@ -135,31 +133,22 @@ let with_out_channel oc ~f =
        close_out oc)
 ;;
 
+(* Durable atomic write delegated to the Fs_compat durability SSOT:
+   tmp -> fsync(tmp) -> rename -> best-effort fsync(parent dir) — the same
+   primitive board and event-queue persistence use. A local fsync pair here would
+   duplicate (and could drift from) that durability boundary, so route through it.
+   NB: the primitive's boot-time atomic-orphan sweep is depth-1 from base_path and
+   does not currently reach the keepers dir, so a SIGKILL between write and rename
+   still leaves an uncollected [.atomic_*.tmp] here — a pre-existing gap (the old
+   hand-rolled temp was not swept either), tracked separately, not worsened here.
+   The Memory OS write contract raises on failure (unit return), so map [Error] to
+   [Atomic_write_failed]; the temp is already cleaned up by [save_file_atomic], and
+   [Eio.Cancel.Cancelled] is re-raised by it (RFC-0143), never swallowed. *)
 let write_file_atomically path content =
   ensure_dir (Filename.dirname path);
-  let rec open_tmp attempt =
-    (* PID/counter affect only the collision-resistant temp path;
-       NDT-OK: persisted content and final path stay input-derived, and O_EXCL
-       prevents accidental reuse before the checked close + rename. *)
-    let tmp = Printf.sprintf "%s.tmp.%d.%d" path (Unix.getpid ()) attempt in
-    try
-      let fd =
-        Unix.openfile tmp [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_EXCL ] 0o644
-      in
-      tmp, Unix.out_channel_of_descr fd
-    with
-    | Unix.Unix_error (Unix.EEXIST, _, _) -> open_tmp (attempt + 1)
-  in
-  let tmp, oc = open_tmp 0 in
-  (* The rename stays OUTSIDE [with_out_channel]: it runs only after the write
-     and close both succeed, and the exception path removes the temp file. *)
-  try
-    with_out_channel oc ~f:(fun oc -> output_string oc content);
-    Sys.rename tmp path
-  with
-  | exn ->
-    remove_noerr tmp;
-    raise exn
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg -> raise (Atomic_write_failed msg)
 ;;
 
 let generation_counter_path ~keeper_id ~trace_id =

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -33,7 +33,7 @@ let retention_rank ~now (f : fact) =
     then 0.0
     else durable_retention_tier
   in
-  let recency = match f.last_verified_at with Some t -> t | None -> f.first_seen in
+  let recency = reference_time f in
   tier +. recency
 ;;
 

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -82,12 +82,7 @@ let humanize_age seconds =
    self-delimited bracket distinguishing never-verified facts (anchored on
    [first_seen]) from facts confirmed long ago (anchored on [last_verified_at]). *)
 let staleness_marker ~now (fact : fact) =
-  let anchor =
-    match fact.last_verified_at with
-    | Some ts -> ts
-    | None -> fact.first_seen
-  in
-  let age = now -. anchor in
+  let age = now -. reference_time fact in
   if age < staleness_note_seconds
   then ""
   else (
@@ -110,11 +105,11 @@ let is_unverified_volatile ~now (fact : fact) =
   match fact.external_ref with
   | None -> false
   | Some _ ->
-    let anchor =
-      match fact.last_verified_at with
-      | Some ts -> ts
-      | None -> fact.first_seen
-    in
+    (* A fact is unverified volatile exactly when the P2 reconciler would consider
+       it past due for re-grounding: same anchor ([reference_time], the type-level
+       SSOT) and same horizon as [classify], so suppression and re-grounding can
+       never disagree on staleness. *)
+    let anchor = reference_time fact in
     now -. anchor > Keeper_memory_os_reconcile.default_grounding_horizon_seconds
 ;;
 
@@ -241,15 +236,11 @@ let dedup_by_claim facts =
     facts
 ;;
 
-(* RFC-0247 (purge): the truth anchor — [last_verified_at] when present, else
-   [first_seen]. Used as the structural recall order (most-recently-verified
-   first) and matches the anchor [retention_rank] and [staleness_marker] use, so
-   "kept", "ranked", and "marked stale" all read the same timestamp. *)
-let truth_anchor (fact : fact) =
-  match fact.last_verified_at with
-  | Some ts -> ts
-  | None -> fact.first_seen
-;;
+(* RFC-0247 (purge): the truth anchor used as the structural recall order
+   (most-recently-verified first). It is the type-level {!reference_time} SSOT, so
+   "kept" ([retention_rank]), "ranked" (here), and "marked stale"
+   ([staleness_marker]) all read the same timestamp by construction. *)
+let truth_anchor (fact : fact) = reference_time fact
 
 (* Filter to current, order by structural recency (the truth anchor), and dedup.
    RFC-0247 replaced the composite [score_fact] order with this single typed

--- a/lib/keeper/keeper_memory_os_reconcile.ml
+++ b/lib/keeper/keeper_memory_os_reconcile.ml
@@ -37,13 +37,9 @@ let verdict_to_string = function
    have its last_verified_at advanced by P3) before the TTL would hard-expire it. *)
 let default_grounding_horizon_seconds = volatile_external_ttl_seconds /. 2.0
 
-(* The reference time a fact was last known good: last_verified_at if set, else
-   first_seen — a never-re-verified fact is as old as its extraction. *)
-let reference_time (f : fact) =
-  match f.last_verified_at with
-  | Some t -> t
-  | None -> f.first_seen
-;;
+(* [reference_time] (the last-known-good anchor) is the SSOT in
+   {!Keeper_memory_os_types}; classify measures the re-ground horizon from it and
+   recall measures staleness from the same definition. *)
 
 let classify ~now ~horizon ~(verify : verify_fn) (f : fact) : verdict =
   match f.external_ref with

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -270,6 +270,19 @@ let fact_is_current ~now (fact : fact) =
   | Some ts -> ts >= now
 ;;
 
+(* The time a fact was last known good: [last_verified_at] if set, else
+   [first_seen] (a never-re-verified fact is as old as its extraction). The SSOT
+   anchor for "how stale is this claim": the reconciler measures the re-ground
+   horizon from it, and recall measures staleness/ordering and unverified-volatile
+   suppression from it — they share this one definition rather than each inlining
+   the match, so a future change to the anchor rule (e.g. a [last_verified_at >=
+   first_seen] guard) cannot make those paths drift. *)
+let reference_time (f : fact) =
+  match f.last_verified_at with
+  | Some t -> t
+  | None -> f.first_seen
+;;
+
 type episode =
   { trace_id : string
   ; generation : int

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -148,6 +148,11 @@ type fact =
     [valid_until] are durable and current. *)
 val fact_is_current : now:float -> fact -> bool
 
+(** The time a fact was last known good: [last_verified_at] if set, else
+    [first_seen]. The SSOT staleness anchor shared by the reconciler (re-ground
+    horizon) and recall (staleness marker, recall ordering, unverified-volatile
+    suppression) so those paths cannot drift on the anchor rule. *)
+val reference_time : fact -> float
 (** A librarian extraction result: a summary plus structured claims. *)
 type episode =
   { trace_id : string

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -2012,6 +2012,43 @@ let test_recall_no_prefix_for_non_volatile_fact () =
             (contains "[UNVERIFIED — re-check before acting]" block))))
 ;;
 
+(* RFC-0259 §3.5 + SSOT anchor: a volatile fact whose [last_verified_at] is recent
+   is NOT unverified-volatile even when [first_seen] is long past the horizon — a
+   re-grounded ref is fresh. This discriminates the staleness anchor: recall
+   measures age from the shared [reference_time] SSOT (last_verified_at when set,
+   else first_seen) rather than inlining its own match. Were the anchor
+   [first_seen], this old-but-re-verified fact would wrongly carry the hard
+   prefix; the false assertion below is the mutation guard for that drift. *)
+let test_recall_no_prefix_for_recently_verified_volatile_fact () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun keepers_dir ->
+        let keeper_id = "volatile-fresh-keeper" in
+        let now = 1_000_000.0 in
+        let horizon = Reconcile.default_grounding_horizon_seconds in
+        let fact =
+          { (fact_fixture ~now ()) with
+            Types.claim = "PR #21515 is still open"
+          ; Types.external_ref = Some { Types.kind = Types.Pr; id = "21515" }
+          ; Types.first_seen = now -. (horizon *. 3.0)
+          ; Types.last_verified_at = Some (now -. (horizon /. 2.0))
+          ; Types.valid_until = Some (now +. horizon)
+          }
+        in
+        Memory_io.append_fact ~keeper_id fact;
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
+        | None -> Alcotest.fail "expected Some block for a persisted volatile fact"
+        | Some block ->
+          Alcotest.(check bool)
+            "recently re-verified volatile fact does not carry the hard prefix"
+            false
+            (contains "[UNVERIFIED — re-check before acting]" block);
+          Alcotest.(check bool)
+            "recently re-verified volatile fact is still recalled"
+            true
+            (contains "PR #21515 is still open" block))))
+;;
+
 (* RFC-0259 recall suppression validation harness ------------------------------
    The P4 unit tests above pin the mechanism on single crafted facts. This
    harness measures the end-to-end effect on a mixed, realistic population:
@@ -3372,6 +3409,10 @@ let () =
             "non-volatile fact never gets the hard prefix"
             `Quick
             test_recall_no_prefix_for_non_volatile_fact
+        ; Alcotest.test_case
+            "recently re-verified volatile fact gets no hard prefix (anchor = reference_time)"
+            `Quick
+            test_recall_no_prefix_for_recently_verified_volatile_fact
         ; Alcotest.test_case
             "RFC-0259 suppression harness: stale neutralized, durable preserved"
             `Quick


### PR DESCRIPTION
## 요약

RFC-0259 추적 이슈 #21716의 잔여 finding 2건을 닫습니다 — keeper Memory OS fact-store의 **쓰기 내구성(durability)** 보강과 staleness anchor의 **SSOT 통합**. 적대 검증(perspective-diverse 4렌즈)에서 나온 두 finding을 반영해 범위를 정정했습니다.

- **②(fsync 부재, MED)** → 기존 durable-write SSOT(`Fs_compat.save_file_atomic`)로 라우팅
- **P4 cleanup(anchor SSOT 위반, MED)** → 인라인 사본 6곳을 단일 `reference_time`로 통합
- ③(demote terminal의 TTL 노출) → 의도적 tradeoff로 평가, 변경 없음

## 변경 내용

### 1. `write_file_atomically` → 기존 durability SSOT로 라우팅 (finding ②)
`lib/keeper/keeper_memory_os_io.ml`

기존 경로는 `output_string` → `close_out` → `Sys.rename`로 fsync가 전혀 없어, 크래시 시 데이터 블록이 page cache에만 남아 torn/truncated될 수 있었습니다.

처음엔 fsync를 직접 추가했으나, 적대 검증에서 **`lib/fs_compat/atomic_write.ml`에 이미 동일한 durability 경계**(tmp → fsync(tmp) → rename → best-effort fsync(parent dir) + 부팅 시 orphan sweep)가 같은 동기(2026-04-18 backlog.json truncation 사건)로 존재함이 드러났습니다. board/event-queue 영속화가 이미 이걸 씁니다. 따라서 durability primitive를 재발명하지 않고 **`Fs_compat.save_file_atomic`로 라우팅**합니다:

- fsync 쌍 + `Eio.Cancel.Cancelled` 재발생(RFC-0143) 획득
- 손으로 만든 중복 fsync_dir 제거(두 사본의 예외 정책 drift 방지)
- 단, `cleanup_atomic_orphans`(boot sweep)는 base_path 기준 depth-1만 스캔하고 keepers dir은 depth-3라 keeper의 `.atomic_*.tmp` orphan은 **현재 미수거**(아래 후속 참조) — 회귀는 아님(기존 `.tmp.<pid>`도 미수거였음)
- Memory OS write 계약(실패 시 raise)은 `Error`를 신규 **`exception Atomic_write_failed`** 로 매핑해 유지. `Failure`가 아닌 별도 타입으로 둔 이유: `with_facts_lock`이 `| Failure msg -> on_timeout("lock timeout…")`로 잡으므로, write 실패(예: ENOSPC)를 lock timeout으로 오분류하지 않게 하기 위함.

**threat model(정확히)**: `close_out`는 프로세스 크래시엔 이미 안전(OS page cache가 결국 persist). 이 변경은 **OS 크래시/전원 손실**에 대한 defense-in-depth(MED)입니다. macOS의 `Unix.fsync`=fsync(2)는 드라이브 캐시까지 강제하지 않으므로(F_FULLFSYNC 필요, stdlib 미노출) 전원 손실 완전 내구화는 별도과제 — 이 한계는 `Fs_compat` 모듈에 이미 문서화돼 있습니다.

### 2. staleness anchor SSOT 통합 (P4 cleanup)
`keeper_memory_os_types.ml`(+.mli), `reconcile.ml`, `recall.ml`, `policy.ml`, `gc.ml`

`match last_verified_at with Some t -> t | None -> first_seen` (fact가 마지막으로 known-good이던 시각)이 **6곳에 byte-identical 인라인**돼 있었습니다 — reconcile.classify, recall.is_unverified_volatile, recall.staleness_marker, recall.truth_anchor, policy.retention_rank, gc.verified_at. 같은 anchor를 여러 곳에서 따로 정의하는 것은 N-of-M drift 위험(워크어라운드 bar가 거부하는 패턴)입니다.

`reference_time : fact -> float`를 `fact`가 정의된 foundational module(`keeper_memory_os_types.ml`)에 SSOT로 두고 6곳 전부 이를 호출하도록 통합했습니다. anchor 규칙이 미래에 바뀌어도(예: `last_verified_at >= first_seen` 가드) 한 곳만 바꾸면 됩니다. 전부 byte-identical이라 동작 불변.

`staleness_marker`의 별도 `match last_verified_at`(Some→"last verified"/None→"unverified" 문구 선택)은 anchor 계산이 아니므로 그대로 유지했습니다.

### 3. discriminating 테스트 (mutation-verified)
`test/test_keeper_memory_os.ml`

`test_recall_no_prefix_for_recently_verified_volatile_fact`: **first_seen는 horizon 한참 전 + last_verified_at는 horizon 이내**인 volatile fact가 unverified prefix를 받지 않는지(=anchor가 last_verified_at인지) 검증. 기존 테스트는 두 시각이 모두 오래되어 anchor를 구별하지 못했습니다.

**mutation 검증**: `reference_time`을 first_seen만 반환하도록 깨뜨리면 **4개 테스트가 FAIL**(policy retention / gc dedup / recall staleness / recall suppression) — 단일 SSOT가 4개 소비처의 테스트로 가드됨을 확인.

## 평가했으나 변경하지 않은 것

- **finding ③ (demote terminal의 valid_until 노출)**: terminal로 demote된 fact가 valid_until(~horizon/2 이후)까지 recall에 노출되는 것은 의도적 tradeoff. demote-not-delete는 "PR이 merge됨"같은 참인 historical claim 보존이 목적이고, horizon 이후엔 `[UNVERIFIED — re-check before acting]` prefix + durable 아래 demote로 완화됨. 즉시 가림으로 바꾸면 참인 claim까지 사라지므로 recall 억제 의미론 변경 = RFC-0259 설계 결정 사안이라 범위 밖.
- **`unverified_volatile_prefix` 하드코딩(audit LOW)**: 이미 단일 named 상수. typed marker 승격은 render-only 문자열에 대한 over-engineering이라 SKIP.

## 후속 (별도 추적)

- **#21817**: orphan sweep(`cleanup_atomic_orphans`)이 base_path 기준 depth-1만 스캔하는데 keepers dir은 depth-3라 keeper의 `.atomic_*.tmp` orphan이 boot sweep에 미수거. **회귀 아님**(기존 `.tmp.<pid>` orphan도 미수거였음, 데이터 손실 아님). sweep root에 keepers dir 추가로 해소.

## 검증

- `dune build --root . lib/ -j 4` → exit 0 (0 errors)
- `dune exec --root . test/test_keeper_memory_os.exe -j 4` → **79 tests pass**
- mutation 검증(4 테스트 FAIL)으로 SSOT teeth 확인
- 적대 검증(perspective-diverse 4렌즈) 통과 + 발견된 finding 2건 반영(중복 제거 라우팅 + N-of-M 완결)
- 로컬 full-umbrella 빌드는 opam `agent_sdk` drift(`inconsistent assumptions over interface` — 세션 중 agent_sdk .cmxa 재빌드)로 agent_sdk 링크 test exe만 막힘. 타입 에러 0건. CI가 full-tree 게이트.

## 내구성의 테스트 한계 (정직한 명시)

fsync 자체는 관측 불가능한 syscall side-effect라 crash-consistency를 fault injection(kill -9 mid-write) 없이 단위 테스트로 증명할 수 없습니다. 가짜(vacuous) 테스트를 추가하지 않았고, 기존 write 경로 테스트(79건)가 라우팅 변경으로 인한 회귀가 없음을 보장합니다.

RFC-WAIVED: RFC-0259(volatile claim grounding/retraction/decay) 범위 내 durability finding 구현. issue #21716 ②항 + P4 anchor SSOT cleanup. 신규 설계 아님.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
