### PR TITLE
fix(dashboard): live-refresh fusion run-status panel on WS events and manual Refresh (RFC-0266 Phase 4)

### DIFF
--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -1,10 +1,19 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BoardPost } from '../../types'
 import { route } from '../../router'
-import { boardLoading, boardPosts } from '../../store'
+import { boardLoading, boardPosts, fusionRunsLoading, refreshBoard, refreshFusionRuns } from '../../store'
 import { FusionSurface } from './fusion-surface'
+
+// Mock only the refresh side effects; keep the real signals (boardLoading /
+// fusionRunsLoading) via ...actual so the component reads live state. The manual
+// Refresh button must fan out to BOTH refreshers — the run-status panel is a
+// second data source the board refresh cannot reach (RFC-0266 Phase 4).
+vi.mock('../../store', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../store')>()
+  return { ...actual, refreshBoard: vi.fn(), refreshFusionRuns: vi.fn() }
+})
 
 function boardPost(overrides: Partial<BoardPost> & { id: string; meta: BoardPost['meta'] }): BoardPost {
   const { id, meta, ...rest } = overrides
@@ -43,6 +52,9 @@ describe('FusionSurface', () => {
     route.value = { tab: 'fusion', params: {}, postId: null }
     boardLoading.value = false
     boardPosts.value = []
+    fusionRunsLoading.value = false
+    vi.mocked(refreshBoard).mockClear()
+    vi.mocked(refreshFusionRuns).mockClear()
   })
 
   afterEach(() => {
@@ -50,6 +62,7 @@ describe('FusionSurface', () => {
     container.remove()
     boardLoading.value = false
     boardPosts.value = []
+    fusionRunsLoading.value = false
     route.value = { tab: 'overview', params: {}, postId: null }
     window.location.hash = '#overview'
   })
@@ -183,5 +196,24 @@ describe('FusionSurface', () => {
 
     expect(container.querySelector('[data-testid="fusion-empty"]')).not.toBeNull()
     expect(container.textContent).toContain('No fusion runs found')
+  })
+
+  it('manual Refresh fans out to both the board-meta detail and the run-status registry', () => {
+    render(html`<${FusionSurface} />`, container)
+    const refresh = container.querySelector<HTMLButtonElement>('.fus-refresh')
+    expect(refresh).not.toBeNull()
+    refresh?.click()
+    // The run-status panel reads the fusionRuns signal, a source refreshBoard
+    // never touches; the button must trigger refreshFusionRuns too.
+    expect(vi.mocked(refreshBoard)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(refreshFusionRuns)).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables Refresh while the run registry is loading even when the board is idle', () => {
+    fusionRunsLoading.value = true
+    render(html`<${FusionSurface} />`, container)
+    const refresh = container.querySelector<HTMLButtonElement>('.fus-refresh')
+    expect(refresh?.disabled).toBe(true)
+    expect(refresh?.textContent).toContain('Refreshing')
   })
 })

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -2,7 +2,7 @@ import { html } from 'htm/preact'
 import { useMemo } from 'preact/hooks'
 import type { BoardPost } from '../../types'
 import { navigate, replaceRoute, route } from '../../router'
-import { boardLoading, boardPosts, refreshBoard } from '../../store'
+import { boardLoading, boardPosts, fusionRunsLoading, refreshBoard, refreshFusionRuns } from '../../store'
 import { TimeAgo } from '../common/time-ago'
 import { ringFocusClasses } from '../common/ring'
 import { AgentAvatar } from '../overview/agent-avatar'
@@ -389,9 +389,9 @@ export function FusionSurface() {
           <button
             type="button"
             class=${`fus-refresh ${ringFocusClasses()}`}
-            onClick=${() => void refreshBoard()}
-            disabled=${boardLoading.value}
-          >${boardLoading.value ? 'Refreshing...' : 'Refresh'}</button>
+            onClick=${() => { void refreshBoard(); void refreshFusionRuns() }}
+            disabled=${boardLoading.value || fusionRunsLoading.value}
+          >${boardLoading.value || fusionRunsLoading.value ? 'Refreshing...' : 'Refresh'}</button>
         </header>
 
         <${FusionRunsPanel} />

--- a/dashboard/src/refresh-scope.test.ts
+++ b/dashboard/src/refresh-scope.test.ts
@@ -14,6 +14,7 @@ describe('routeWantsRefreshTarget', () => {
     expect(routeWantsRefreshTarget(current, 'operator')).toBe(false)
     expect(routeWantsRefreshTarget(current, 'board')).toBe(false)
     expect(routeWantsRefreshTarget(current, 'activity')).toBe(false)
+    expect(routeWantsRefreshTarget(current, 'fusion')).toBe(false)
   })
 
   it('matches execution-backed routes without broadening fleet-health defaults', () => {
@@ -36,5 +37,12 @@ describe('routeWantsRefreshTarget', () => {
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'observatory' }), 'activity')).toBe(true)
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'observatory', view: 'activity' }), 'activity')).toBe(true)
     expect(routeWantsRefreshTarget(route('monitoring', { section: 'fleet-health' }), 'activity')).toBe(false)
+  })
+
+  it('keeps fusion refreshes scoped to the top-level fusion route', () => {
+    expect(routeWantsRefreshTarget(route('fusion'), 'fusion')).toBe(true)
+    expect(routeWantsRefreshTarget(route('board'), 'fusion')).toBe(false)
+    expect(routeWantsRefreshTarget(route('workspace', { section: 'board' }), 'fusion')).toBe(false)
+    expect(routeWantsRefreshTarget(route('monitoring', { section: 'agents' }), 'fusion')).toBe(false)
   })
 })

--- a/dashboard/src/refresh-scope.ts
+++ b/dashboard/src/refresh-scope.ts
@@ -1,6 +1,6 @@
 import type { RouteState } from './types'
 
-export type RouteRefreshTarget = 'execution' | 'board' | 'operator' | 'activity'
+export type RouteRefreshTarget = 'execution' | 'board' | 'operator' | 'activity' | 'fusion'
 
 export function routeWantsRefreshTarget(
   routeState: Pick<RouteState, 'tab' | 'params'>,
@@ -15,6 +15,10 @@ export function routeWantsRefreshTarget(
       return routeState.tab === 'command' && routeState.params.view !== 'inspector'
     case 'activity':
       return routeState.tab === 'monitoring' && routeState.params.section === 'observatory'
+    case 'fusion':
+      // The fusion run-status panel only mounts on the top-level fusion surface,
+      // so its registry refetch is scoped to that route (RFC-0266 Phase 4).
+      return routeState.tab === 'fusion'
   }
 }
 

--- a/dashboard/src/schemas/sse.test.ts
+++ b/dashboard/src/schemas/sse.test.ts
@@ -227,10 +227,11 @@ describe('parseSSEMessage', () => {
   })
 
   it('keeps fusion_run_status events so the RFC-0266 Phase 4 live panel refresh is not dropped', () => {
-    // Regression: the dashboard sse.ts dispatch has a `case 'fusion_run_status'`,
-    // but it is unreachable unless the type also passes this parse boundary.
-    // If this drops to null, the running -> completed/failed live flip silently
-    // stops working and the panel only updates on tab re-navigation.
+    // Regression: the live WS router (sse-store.ts routeServerPushEvent ->
+    // SIMPLE_ROUTES['fusion_run_status'] -> refreshFusionRuns) only sees the event
+    // if it first passes this parse boundary. If this drops to null, the
+    // running -> completed/failed live flip silently stops working and the panel
+    // only updates on the periodic poll / tab re-navigation.
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const msg = parseSSEMessage({
       type: 'fusion_run_status',

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -60,7 +60,8 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'masc/keeper_turn_complete',
   // RFC-0266 Phase 4: fusion run-status transitions (running -> completed/failed).
   // Must be in this closed allowlist or parseSSEMessage drops the event at the
-  // parse boundary, leaving the sse.ts dispatch case dead.
+  // parse boundary, before the live WS router (sse-store.ts routeServerPushEvent
+  // -> SIMPLE_ROUTES['fusion_run_status'] -> refreshFusionRuns) can dispatch it.
   'fusion_run_status',
   'client_input_approved',
   'client_input_rejected',

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -28,6 +28,7 @@ const namespaceTruthError = signal<unknown>(null)
 const refreshDashboard = vi.fn<() => Promise<void>>(async () => {})
 const refreshExecution = vi.fn<() => Promise<void>>(async () => {})
 const refreshBoard = vi.fn<() => void>(() => {})
+const refreshFusionRuns = vi.fn<() => void>(() => {})
 const invalidateDashboardCache = vi.fn<() => void>(() => {})
 const hydrateBoardSnapshot = vi.fn<(payload: unknown) => void>(() => {})
 const hydrateShellSnapshot = vi.fn<(payload: unknown, opts?: unknown) => void>(() => {})
@@ -63,6 +64,7 @@ async function loadSseStore() {
     refreshDashboard,
     refreshExecution,
     refreshBoard,
+    refreshFusionRuns,
     serverStatus,
     boardPosts,
     boardSortMode,
@@ -112,6 +114,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     refreshDashboard.mockResolvedValue(undefined)
     refreshExecution.mockClear()
     refreshBoard.mockClear()
+    refreshFusionRuns.mockClear()
     invalidateDashboardCache.mockClear()
     hydrateBoardSnapshot.mockClear()
     hydrateShellSnapshot.mockClear()
@@ -324,6 +327,36 @@ describe('setupSSEReaction reconnect hydration', () => {
     await flushAsyncWork()
 
     expect(refreshBoard).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes fusion_run_status to the registry refresh while on the fusion surface (RFC-0266 Phase 4)', async () => {
+    // The live transport is the WS router (this function); the fusion_run_status
+    // dispatch case in the legacy sse.ts handleEvent is dead. Without a
+    // SIMPLE_ROUTES entry the running -> completed/failed flip never reached
+    // refreshFusionRuns and the panel only updated on the ~120s periodic poll.
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'fusion', params: {}, postId: null }
+
+    // routeServerPushEvent dispatches on event.type alone; the run payload is
+    // irrelevant to the SIMPLE_ROUTES lookup, so it is omitted here.
+    sseStore.routeServerPushEvent({ type: 'fusion_run_status' })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshFusionRuns).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not refresh fusion runs off the fusion surface (route-scoped budget)', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'overview', params: {}, postId: null }
+
+    // routeServerPushEvent dispatches on event.type alone; the run payload is
+    // irrelevant to the SIMPLE_ROUTES lookup, so it is omitted here.
+    sseStore.routeServerPushEvent({ type: 'fusion_run_status' })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshFusionRuns).not.toHaveBeenCalled()
   })
 
   it('routes keeper_chat_appended pushes to the live chat refresh hook', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -33,6 +33,7 @@ import {
   refreshDashboard,
   refreshExecution,
   refreshBoard,
+  refreshFusionRuns,
   serverStatus,
   boardPosts,
   boardSortMode,
@@ -160,6 +161,10 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   reaction_changed:     { target: 'board' },
   // Observatory activity telemetry
   activity:             { target: 'activity', debounceMs: SSE_ACTIVITY_DEBOUNCE_MS },
+  // Fusion run registry — emitted by lib/fusion/fusion_sink.ml broadcast_run_status.
+  // Without this entry the live WS router dropped the event and the run-status
+  // panel only refreshed on the ~120s periodic poll / route revisit (RFC-0266 Phase 4).
+  fusion_run_status:    { target: 'fusion' },
 }
 
 const BOARD_HEARTH_REFRESH_EVENTS = new Set([
@@ -184,6 +189,7 @@ const REFRESH_FNS: Record<RefreshTarget, () => void> = {
   activity:  () => {
     for (const fn of _refreshActivityFns) fn()
   },
+  fusion:    () => { void refreshFusionRuns() },
 }
 
 function scheduleTargetRefresh(


### PR DESCRIPTION
## fix(dashboard): live-refresh the fusion run-status panel on WS events and manual Refresh (RFC-0266 Phase 4)

RFC-0266 Phase 4 (#21735) 의 약속은 "operator 폴링 없이 fusion 심의가 `running → completed/failed` 로 라이브 flip" 입니다. 적대 감사(5 렌즈) 결과 그 라이브 경로가 **실제 전송 계층에서 끊겨 있었습니다**. 두 갭을 함께 고칩니다.

### 갭 A (HIGH) — 라이브 WS 라우터가 `fusion_run_status` 를 디스패치하지 않음

대시보드의 라이브 전송은 **WebSocket** 입니다 (`app.ts:160` "WS/WSS is the sole dashboard transport... the SSE fallback path was removed"; `connectSSE` 는 호출자 0 = dead). WS 프레임은 `dashboard-ws.ts handleRawPush → parseSSEMessage → routeServerPushEvent`(`sse-store.ts`) 로 흐릅니다.

- `parseSSEMessage` 는 #21780 으로 `fusion_run_status` 를 통과시킵니다 (parse allowlist). 이 부분은 WS 경로에도 필요했고 유지됩니다.
- 그러나 **라이브 라우터 `routeServerPushEvent` 에는 `fusion_run_status` 처리가 전무** 했습니다 — `SIMPLE_ROUTES` / `PREFIX_ROUTES` / `KEEPER_LIFECYCLE` / hydrate 어디에도 없어 silently drop.
- `refreshFusionRuns()` 를 호출하던 유일한 디스패치는 `sse.ts handleEvent` 의 `case 'fusion_run_status'` 인데, `handleEvent → flushPending → connectSSE` 체인이 production 에서 dead 라 **한 번도 발화하지 않습니다**.
- 결과: 패널은 `startPeriodicRefresh` 의 ~120s 주기 폴링 / route 재방문으로만 갱신. 이벤트 기반 즉시 flip 은 동작 안 함.

**수정**: 기존 선언적 라우팅 패턴(`board_post → target:'board' → refreshBoard`)을 그대로 미러합니다.
- `refresh-scope.ts`: `RouteRefreshTarget` 에 `'fusion'` 추가 + `routeWantsRefreshTarget` 에 `case 'fusion': tab==='fusion'`. union 확장이 exhaustive switch 와 `Record<RefreshTarget,…>` 를 통해 누락을 tsc 레벨에서 강제합니다.
- `sse-store.ts`: `REFRESH_FNS.fusion = () => refreshFusionRuns()` + `SIMPLE_ROUTES.fusion_run_status = { target: 'fusion' }`. route-gating(`scheduleTargetRefresh`)이 "fusion 탭에 있을 때만 refetch" 를 보장 — 패널이 fusion route 에만 mount 되는 설계와 일치.

### 갭 B (MED) — 수동 Refresh 버튼이 registry 패널을 갱신하지 않음

fusion surface 는 **두 데이터 소스**를 렌더합니다: `boardPosts`(board-meta 상세) 와 `fusionRuns`(registry 패널). 수동 Refresh 버튼(`fusion-surface.ts`)은 `refreshBoard()` 만 호출해 registry 패널을 갱신하지 않았습니다. `tab-refresh.ts:76` 의 route 'fusion' → `['board','fusionRuns']` 와 불일치(버튼이 route 방문보다 약함).

**수정**: 버튼 onClick 을 `refreshBoard()` + `refreshFusionRuns()` 둘 다로, `disabled`/스피너를 `boardLoading || fusionRunsLoading` 으로 — SSE 끊김 시 operator 의 수동 fallback 을 완성.

### 검증 (로컬)

- `pnpm typecheck` (tsc --noEmit) clean.
- `pnpm lint` (eslint src) clean.
- `pnpm vitest run` — 신규 회귀 4종 포함 통과:
  - `routes fusion_run_status to the registry refresh while on the fusion surface` — 라이브 WS 라우터가 이제 dispatch (갭 A drift-guard).
  - `does not refresh fusion runs off the fusion surface (route-scoped budget)` — gating 검증.
  - `manual Refresh fans out to both the board-meta detail and the run-status registry` — 갭 B.
  - `disables Refresh while the run registry is loading even when the board is idle` — 갭 B gating.
- `#21780` 에 내가 남긴 오해 소지 주석(`schemas/sse.ts`, `schemas/sse.test.ts` 의 "sse.ts dispatch case") 을 라이브 WS 라우터 경로로 정정.

### 워크어라운드 게이트

해당 없음 — 누락된 디스패치를 기존 선언적 라우팅 패턴으로 *배선*. telemetry-as-fix / string 분류기 / N-of-M / cap-cooldown-dedup-repair 어느 것도 아님.

### 범위 밖 (동일 감사 — 별도 처리)

- (backend, MED) `lib/fusion/fusion_tool.ml append_chat_failure` 의 cancel-leak — `mark_completed` 가 suspending append 뒤에 있어 Cancelled 시 Running 잔존(#21784 의 형제 경로). 별도 OCaml PR.
- (LOW) 완료 시 생성된 fusion board post 가 fusion route 에서 board-meta 상세를 라이브 갱신하지 않음(`handleBoardPostCreated` meta-less prepend + `routeWantsRefreshTarget('fusion','board')` false). 별도 issue.

RFC-0266 §7 (VISIBILITY). Phase 4 (#21735) follow-up. SSE parse 등록 #21780 의 디스패치 절반을 라이브 전송에 마저 배선.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
