### PR TITLE
test(dashboard): assert memory-health metric values, not just keeper ids

### DIFF
--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -6,12 +6,11 @@ module Health = Server_dashboard_http_keeper_memory_health
 
 let test_now = 1_700_000_000.0
 
-let fresh_dir prefix =
-  let path = Filename.temp_file prefix ".dir" in
-  Sys.remove path;
-  Unix.mkdir path 0o755;
-  path
-;;
+(* [Filename.temp_dir] creates the directory atomically. The prior
+   temp_file -> remove -> mkdir form left a TOCTOU window where another process
+   could claim the path between the remove and the mkdir, which would flake this
+   regression gate. *)
+let fresh_dir prefix = Filename.temp_dir prefix ""
 
 let fact ?(external_ref = None) ?(valid_until = None) ~now claim =
   { Types.claim

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -4,6 +4,8 @@ module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
 module Health = Server_dashboard_http_keeper_memory_health
 
+let test_now = 1_700_000_000.0
+
 let fresh_dir prefix =
   let path = Filename.temp_file prefix ".dir" in
   Sys.remove path;
@@ -96,7 +98,7 @@ let with_env name value f =
 let test_uses_explicit_base_path_not_ambient_resolver () =
   Eio_main.run
   @@ fun _env ->
-  let now = 1_700_000_000.0 in
+  let now = test_now in
   let target_base = fresh_dir "masc-memory-health-target" in
   let ambient_base = fresh_dir "masc-memory-health-ambient" in
   let target_keepers_dir =
@@ -128,7 +130,7 @@ let test_uses_explicit_base_path_not_ambient_resolver () =
 let test_reports_per_keeper_metric_values () =
   Eio_main.run
   @@ fun _env ->
-  let now = 1_700_000_000.0 in
+  let now = test_now in
   let base = fresh_dir "masc-memory-health-metrics" in
   let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
   Io.rewrite_facts_atomically_for_keepers_dir
@@ -165,14 +167,16 @@ let test_reports_per_keeper_metric_values () =
     "cadence_counter_entries non-negative"
     true
     (int_field "cadence_counter_entries" json >= 0);
-  (* [generated_at] is present as a wall-clock float. *)
-  ignore (float_field "generated_at" json)
+  Alcotest.(check bool)
+    "generated_at is present as wall-clock float"
+    true
+    (float_field "generated_at" json >= 0.0)
 ;;
 
 let test_dry_run_gc_reports_expired_and_duplicates () =
   Eio_main.run
   @@ fun _env ->
-  let now = 1_700_000_000.0 in
+  let now = test_now in
   let base = fresh_dir "masc-memory-health-gc" in
   let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
   Io.rewrite_facts_atomically_for_keepers_dir
@@ -196,7 +200,7 @@ let test_dry_run_gc_reports_expired_and_duplicates () =
 let test_sorts_keepers_by_facts_bytes_desc () =
   Eio_main.run
   @@ fun _env ->
-  let now = 1_700_000_000.0 in
+  let now = test_now in
   let base = fresh_dir "masc-memory-health-sort" in
   let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
   Io.rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id:"small" [ fact ~now "x" ];
@@ -227,7 +231,7 @@ let test_empty_store_has_no_keepers_and_zero_totals () =
 let test_skips_corrupt_jsonl_keeper () =
   Eio_main.run
   @@ fun _env ->
-  let now = 1_700_000_000.0 in
+  let now = test_now in
   let base = fresh_dir "masc-memory-health-corrupt" in
   let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
   Io.rewrite_facts_atomically_for_keepers_dir

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -11,14 +11,14 @@ let fresh_dir prefix =
   path
 ;;
 
-let fact ~now claim =
+let fact ?(external_ref = None) ?(valid_until = None) ~now claim =
   { Types.claim
   ; Types.category = Types.Fact
-  ; Types.external_ref = None
+  ; Types.external_ref
   ; Types.source = { Types.trace_id = "health-test"; Types.turn = 1; Types.tool_call_id = None }
   ; Types.observed_by = []
   ; Types.first_seen = now
-  ; Types.valid_until = None
+  ; Types.valid_until
   ; Types.last_verified_at = Some now
   ; Types.schema_version = Types.schema_version
   }
@@ -39,6 +39,48 @@ let keeper_ids json =
          keepers
      | _ -> [])
   | _ -> []
+;;
+
+let assoc_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+;;
+
+let int_field name json =
+  match assoc_field name json with
+  | Some (`Int n) -> n
+  | _ -> Alcotest.failf "expected int field %S" name
+;;
+
+let float_field name json =
+  match assoc_field name json with
+  | Some (`Float f) -> f
+  | Some (`Int n) -> float_of_int n
+  | _ -> Alcotest.failf "expected float field %S" name
+;;
+
+let totals json =
+  match assoc_field "totals" json with
+  | Some t -> t
+  | None -> Alcotest.fail "expected totals object"
+;;
+
+let keeper_obj id json =
+  let keepers =
+    match assoc_field "keepers" json with
+    | Some (`List ks) -> ks
+    | _ -> []
+  in
+  match
+    List.find_opt
+      (fun k ->
+        match assoc_field "keeper_id" k with
+        | Some (`String s) -> String.equal s id
+        | _ -> false)
+      keepers
+  with
+  | Some k -> k
+  | None -> Alcotest.failf "keeper %S not present in snapshot" id
 ;;
 
 let with_env name value f =
@@ -76,6 +118,134 @@ let test_uses_explicit_base_path_not_ambient_resolver () =
     Alcotest.(check (list string)) "explicit base-path keeper ids" [ "target" ] (keeper_ids json))
 ;;
 
+(* The route computes [now] internally from the wall clock, so the dry-run GC
+   TTL check runs against the real current time. Fact horizons are therefore
+   pinned to the extremes — far past (always expired) or far future (always
+   live) — to stay deterministic without a clock seam. Claims avoid any external
+   reference marker ("PR #N", "issue #N", "PK-N") so [external_ref_of_claim] does
+   not re-derive a ref and perturb the [external_ref]/TTL counts. *)
+
+let test_reports_per_keeper_metric_values () =
+  Eio_main.run
+  @@ fun _env ->
+  let now = 1_700_000_000.0 in
+  let base = fresh_dir "masc-memory-health-metrics" in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  Io.rewrite_facts_atomically_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id:"solo"
+    [ fact ~now "alpha durable note one"
+    ; fact
+        ~now
+        ~external_ref:(Some { Types.kind = Types.Pr; Types.id = "1" })
+          (* Far-future horizon: serialized [valid_until] is preserved on read,
+             so this stays live regardless of the wall clock. *)
+        ~valid_until:(Some (now +. 1e12))
+        "beta tagged row two"
+    ];
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  let k = keeper_obj "solo" json in
+  Alcotest.(check int) "facts counted" 2 (int_field "facts" k);
+  Alcotest.(check bool) "facts_bytes positive" true (int_field "facts_bytes" k > 0);
+  Alcotest.(check int) "external_ref counted" 1 (int_field "external_ref" k);
+  Alcotest.(check int) "no events file: events 0" 0 (int_field "events" k);
+  Alcotest.(check int) "no events file: events_bytes 0" 0 (int_field "events_bytes" k);
+  Alcotest.(check (float 1e-9))
+    "ratio 0 when no events"
+    0.0
+    (float_field "events_to_facts_ratio" k);
+  Alcotest.(check int) "nothing expired" 0 (int_field "ttl_expired_on_disk" k);
+  Alcotest.(check int) "no duplicates" 0 (int_field "near_duplicate" k);
+  Alcotest.(check int) "totals.facts" 2 (int_field "facts" (totals json));
+  Alcotest.(check bool)
+    "totals.facts_bytes positive"
+    true
+    (int_field "facts_bytes" (totals json) > 0);
+  Alcotest.(check bool)
+    "cadence_counter_entries non-negative"
+    true
+    (int_field "cadence_counter_entries" json >= 0);
+  (* [generated_at] is present as a wall-clock float. *)
+  ignore (float_field "generated_at" json)
+;;
+
+let test_dry_run_gc_reports_expired_and_duplicates () =
+  Eio_main.run
+  @@ fun _env ->
+  let now = 1_700_000_000.0 in
+  let base = fresh_dir "masc-memory-health-gc" in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  Io.rewrite_facts_atomically_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id:"gc"
+    [ fact ~now "shared claim row"
+    ; fact ~now "shared claim row" (* duplicate normalized claim -> 1 dedup *)
+    ; fact ~now ~valid_until:(Some (now -. 1.0)) "expired horizon row" (* past TTL *)
+    ; fact ~now "live durable row"
+    ];
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  let k = keeper_obj "gc" json in
+  Alcotest.(check int) "all rows counted on disk" 4 (int_field "facts" k);
+  Alcotest.(check int) "one TTL-expired row" 1 (int_field "ttl_expired_on_disk" k);
+  Alcotest.(check int) "one duplicate row" 1 (int_field "near_duplicate" k);
+  (* dry_run must NOT rewrite the store: a fresh read still sees all 4 rows. *)
+  let reread = Io.read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id:"gc" in
+  Alcotest.(check int) "store untouched by dry-run gc" 4 (List.length reread)
+;;
+
+let test_sorts_keepers_by_facts_bytes_desc () =
+  Eio_main.run
+  @@ fun _env ->
+  let now = 1_700_000_000.0 in
+  let base = fresh_dir "masc-memory-health-sort" in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  Io.rewrite_facts_atomically_for_keepers_dir ~keepers_dir ~keeper_id:"small" [ fact ~now "x" ];
+  Io.rewrite_facts_atomically_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id:"large"
+    [ fact ~now "a much longer durable claim row number one"
+    ; fact ~now "a much longer durable claim row number two"
+    ; fact ~now "a much longer durable claim row number three"
+    ];
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  Alcotest.(check (list string))
+    "largest facts_bytes first"
+    [ "large"; "small" ]
+    (keeper_ids json)
+;;
+
+let test_empty_store_has_no_keepers_and_zero_totals () =
+  Eio_main.run
+  @@ fun _env ->
+  let base = fresh_dir "masc-memory-health-empty" in
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  Alcotest.(check (list string)) "no keepers" [] (keeper_ids json);
+  Alcotest.(check int) "totals.facts zero" 0 (int_field "facts" (totals json));
+  Alcotest.(check int) "totals.facts_bytes zero" 0 (int_field "facts_bytes" (totals json))
+;;
+
+let test_skips_corrupt_jsonl_keeper () =
+  Eio_main.run
+  @@ fun _env ->
+  let now = 1_700_000_000.0 in
+  let base = fresh_dir "masc-memory-health-corrupt" in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  Io.rewrite_facts_atomically_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id:"good"
+    [ fact ~now "valid durable row" ];
+  (* A malformed facts.jsonl makes the strict GC read raise; the route must skip
+     that keeper rather than abort the whole snapshot (the documented behavior). *)
+  let broken_path = Io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id:"broken" in
+  Out_channel.with_open_text broken_path (fun oc ->
+    Out_channel.output_string oc "{ this is not valid json\n");
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  Alcotest.(check (list string))
+    "corrupt keeper skipped, valid one kept"
+    [ "good" ]
+    (keeper_ids json)
+;;
+
 let () =
   Alcotest.run
     "server_dashboard_http_keeper_memory_health"
@@ -84,5 +254,27 @@ let () =
             "uses explicit request base path instead of ambient resolver"
             `Quick
             test_uses_explicit_base_path_not_ambient_resolver
+        ] )
+    ; ( "metrics"
+      , [ Alcotest.test_case
+            "reports per-keeper metric values"
+            `Quick
+            test_reports_per_keeper_metric_values
+        ; Alcotest.test_case
+            "dry-run gc reports expired and duplicate rows"
+            `Quick
+            test_dry_run_gc_reports_expired_and_duplicates
+        ; Alcotest.test_case
+            "sorts keepers by facts_bytes descending"
+            `Quick
+            test_sorts_keepers_by_facts_bytes_desc
+        ; Alcotest.test_case
+            "empty store yields no keepers and zero totals"
+            `Quick
+            test_empty_store_has_no_keepers_and_zero_totals
+        ; Alcotest.test_case
+            "skips a keeper with a corrupt facts.jsonl"
+            `Quick
+            test_skips_corrupt_jsonl_keeper
         ] )
     ]


### PR DESCRIPTION
## What
Add metric-value assertions to the keeper memory-health dashboard test.

## Why
The memory-health observability route landed in #21790 with one test that only
asserted the keeper-id list (request base-path scoping). A fresh-context
adversarial review of #21790 flagged — and an independent verify pass confirmed
— that the route's net-new metric serialization was entirely unverified: a
field swap, a hardcoded `0`, or an inverted sort comparator would all ship
green. That violates the repo's test-as-proof mandate for net-new logic.

#21790 was merged by the conveyor before the review completed, so this fills the
gap as a follow-up against `main` rather than on the (now-merged) branch.

## Tests added (`test/test_server_dashboard_http_keeper_memory_health.ml`)
- per-keeper metric values: `facts`, `facts_bytes`, `external_ref`, `events`,
  `events_to_facts_ratio`, `ttl_expired_on_disk`, `near_duplicate`, plus
  `totals`, `cadence_counter_entries`, and `generated_at`
- dry-run GC reports exactly one TTL-expired and one duplicate row, and leaves
  the store unmodified (re-read still sees all rows)
- keepers sorted by `facts_bytes` descending
- empty store → no keepers, zero totals
- a keeper with a malformed `facts.jsonl` is skipped (the documented
  skip-and-continue branch), not aborting the whole snapshot

All 6 cases pass locally (`dune exec test/test_server_dashboard_http_keeper_memory_health.exe`).

## Scope
Test-only. No production code change. Not an RFC-trigger subsystem.

The route computes `now` from the wall clock internally, so fact horizons are
pinned to the far past (always expired) / far future (always live) to keep the
TTL assertions deterministic without adding a clock seam.

Audit context: `~/me/reports/masc-memory-os-leak-stuck-audit-20260620-1614.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
