### PR TITLE
fix(fusion): finalize run registry before the suspending failure-append (RFC-0266 Phase 4 / #21784 follow-up)

### DIFF
--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -23,8 +23,10 @@ let append_chat_failure ~base_dir ~keeper ~run_id content =
      [mark_completed]는 순수 in-memory CAS(suspension 없음)라 취소 컨텍스트에서도 안전한
      반면, 아래 append는 Eio 파일 I/O라 셧다운/형제 fiber Switch.fail 시 Cancelled를
      재전파(아래 with 분기)하며 함수를 빠져나간다. finalize를 append *뒤* 에 두면 그 경로에서
-     run이 registry([global], 서버 수명)에 영구 "running"으로 남는다(prune는 Running을 evict
-     안 함 — fusion_run_registry.ml). #21784는 orchestrator-level Cancelled(handle fork match)
+     run이 registry([global], 서버 수명)에 "running"으로 남는다(prune는 Running을 evict 안 함
+     — fusion_run_registry.ml). 순수 프로세스 셧다운이면 global이 프로세스와 함께 소멸하므로,
+     *영구* 잔존은 프로세스가 살아남는 형제 Switch.fail/sub-switch 취소에 한한다. #21784는
+     orchestrator-level Cancelled(handle fork match)
      만 막았고 이 내부 append window는 못 막았다. Denied/Sink_failed/aborted 종료 분기가 모두
      이 함수를 경유하므로 같은 누수의 형제 경로다. *)
   Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok:false;
@@ -43,8 +45,9 @@ let append_chat_failure ~base_dir ~keeper ~run_id content =
        (Printexc.to_string exn));
   (* RFC-0266: 실패도 호출 키퍼를 ok=false로 깨워 "결과 안 옴" 폴링 대신 능동 통지한다
      (성공 경로의 fusion_sink.emit wake와 대칭). content가 실패 사유 라벨이 된다.
-     broadcast/wake는 suspending I/O라 append 성공 경로에서만 시도한다 — registry는 위에서
-     이미 갱신됐으므로 Cancelled로 여기 도달 못 해도 가시성은 보존된다. *)
+     broadcast/wake도 suspending I/O다. append가 Cancelled를 재전파하면 여기 도달하지 못하나
+     (generic append 실패는 warn 후 계속 진행해 도달한다), registry는 위에서 이미 갱신됐으므로
+     어느 경우든 가시성은 보존된다. *)
   Fusion_sink.broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
   Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
     ~resolved_answer:content ~board_post_id:""

--- a/lib/fusion/fusion_tool.ml
+++ b/lib/fusion/fusion_tool.ml
@@ -19,6 +19,15 @@ let append_chat_failure ~base_dir ~keeper ~run_id content =
      별도 "fusion/<run_id>" 스레드는 메인 오염을 막지 못하면서 한 run의 성공/실패만
      다른 lane으로 흩어지는 split-brain을 만든다. denied/sink_failed/aborted는 키퍼가
      다음 턴에 인지해야 할 운영 실패이므로 메인 lane이 옳다(run_id는 content에 포함). *)
+  (* RFC-0266 §7: 종료 상태(Completed{ok=false})를 *suspending append 이전* 에 확정한다.
+     [mark_completed]는 순수 in-memory CAS(suspension 없음)라 취소 컨텍스트에서도 안전한
+     반면, 아래 append는 Eio 파일 I/O라 셧다운/형제 fiber Switch.fail 시 Cancelled를
+     재전파(아래 with 분기)하며 함수를 빠져나간다. finalize를 append *뒤* 에 두면 그 경로에서
+     run이 registry([global], 서버 수명)에 영구 "running"으로 남는다(prune는 Running을 evict
+     안 함 — fusion_run_registry.ml). #21784는 orchestrator-level Cancelled(handle fork match)
+     만 막았고 이 내부 append window는 못 막았다. Denied/Sink_failed/aborted 종료 분기가 모두
+     이 함수를 경유하므로 같은 누수의 형제 경로다. *)
+  Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok:false;
   (try
      Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper ~content ();
      Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion"
@@ -26,7 +35,7 @@ let append_chat_failure ~base_dir ~keeper ~run_id content =
        ()
    with
    | Eio.Cancel.Cancelled _ as exn ->
-     (* 구조적 취소는 재전파. *)
+     (* 구조적 취소는 재전파. registry는 위에서 이미 Completed로 확정됨. *)
      raise exn
    | exn ->
      Log.Keeper.warn ~keeper_name:keeper
@@ -34,10 +43,8 @@ let append_chat_failure ~base_dir ~keeper ~run_id content =
        (Printexc.to_string exn));
   (* RFC-0266: 실패도 호출 키퍼를 ok=false로 깨워 "결과 안 옴" 폴링 대신 능동 통지한다
      (성공 경로의 fusion_sink.emit wake와 대칭). content가 실패 사유 라벨이 된다.
-     wake는 자체 예외 안전하므로 chat append 실패와 독립적으로 시도된다. *)
-  (* RFC-0266 §7: registry를 Completed{ok=false}로 갱신(가시성). wake와 무관하게
-     run 상태를 반영해야 하므로 별도 호출(Running 키퍼만 깨우는 wake와 달리 무조건). *)
-  Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok:false;
+     broadcast/wake는 suspending I/O라 append 성공 경로에서만 시도한다 — registry는 위에서
+     이미 갱신됐으므로 Cancelled로 여기 도달 못 해도 가시성은 보존된다. *)
   Fusion_sink.broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
   Fusion_sink.wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok:false
     ~resolved_answer:content ~board_post_id:""

--- a/test/fusion_core/test_fusion_run_registry.ml
+++ b/test/fusion_core/test_fusion_run_registry.ml
@@ -53,22 +53,44 @@ let test_mark_completed () =
   | None -> fail "failed run must remain visible as Completed{ok=false}"
 ;;
 
-let test_completed_status_survives_later_notification_failure () =
+(* Models the finalize-before-suspend invariant that fusion_tool.ml
+   [append_chat_failure] relies on after #21821. The real failure path does
+   [mark_completed] then a *suspending* chat append (Eio file I/O) that
+   re-raises [Eio.Cancel.Cancelled] on shutdown / sibling [Switch.fail]. The
+   registry does not distinguish which exception interrupts the append — only
+   the *position* of [mark_completed] relative to the raising step decides
+   whether the run is finalized or leaks. [Exit] therefore faithfully stands in
+   for that raise. [~finalize_first] is exactly the fix vs the bug. *)
+let simulate_failure_path ~finalize_first t ~run_id =
+  R.register_running t ~run_id ~keeper:"k" ~preset:"deep" ~started_at:3.0;
+  try
+    if finalize_first then R.mark_completed t ~run_id ~ok:false;
+    raise Exit (* the suspending append re-propagates Cancelled here *)
+  with
+  | Exit -> ()
+;;
+
+let test_finalize_before_suspend_keeps_completed () =
+  (* clean: mark_completed precedes the raising step -> run is Completed{ok=false}
+     even though the notification step never ran. This is the post-#21821 order. *)
   let t = R.create () in
-  R.register_running t ~run_id:"r-cancel-window" ~keeper:"k" ~preset:"deep" ~started_at:3.0;
-  (try
-     R.mark_completed t ~run_id:"r-cancel-window" ~ok:false;
-     raise Exit
-   with
-   | Exit -> ());
-  match R.get t ~run_id:"r-cancel-window" with
+  simulate_failure_path ~finalize_first:true t ~run_id:"clean";
+  (match R.get t ~run_id:"clean" with
+   | Some run ->
+     check (option bool) "finalize-before-raise -> Completed{ok=false}" (Some false)
+       (status_completed_ok run.R.status)
+   | None -> fail "run must remain visible");
+  (* buggy: mark_completed would follow the raising step -> it never runs and the
+     run leaks as Running forever (prune never evicts Running). This is the state
+     #21821 prevents; the contrast proves the ordering is load-bearing, not
+     incidental — mirrors the TLA+ clean/buggy bug-model at the unit level. *)
+  let t = R.create () in
+  simulate_failure_path ~finalize_first:false t ~run_id:"buggy";
+  match R.get t ~run_id:"buggy" with
   | Some run ->
-    check
-      (option bool)
-      "completion is durable before later append/wake failure"
-      (Some false)
-      (status_completed_ok run.R.status)
-  | None -> fail "run must remain visible after completion"
+    check bool "finalize-after-raise leaks Running (the bug)" true
+      (status_running run.R.status)
+  | None -> fail "run must remain visible"
 ;;
 
 let test_mark_unknown_is_noop () =
@@ -142,9 +164,9 @@ let () =
       , [ test_case "register then query" `Quick test_register_then_query
         ; test_case "mark completed (ok true/false)" `Quick test_mark_completed
         ; test_case
-            "completed status survives later notification failure"
+            "finalize before suspend keeps Completed (buggy order leaks Running)"
             `Quick
-            test_completed_status_survives_later_notification_failure
+            test_finalize_before_suspend_keeps_completed
         ; test_case "mark unknown run_id is a no-op" `Quick test_mark_unknown_is_noop
         ; test_case "list_runs is newest-first" `Quick test_list_newest_first
         ; test_case "prune keeps Running + recent completed" `Quick test_prune_keeps_running_and_recent

--- a/test/fusion_core/test_fusion_run_registry.ml
+++ b/test/fusion_core/test_fusion_run_registry.ml
@@ -53,6 +53,24 @@ let test_mark_completed () =
   | None -> fail "failed run must remain visible as Completed{ok=false}"
 ;;
 
+let test_completed_status_survives_later_notification_failure () =
+  let t = R.create () in
+  R.register_running t ~run_id:"r-cancel-window" ~keeper:"k" ~preset:"deep" ~started_at:3.0;
+  (try
+     R.mark_completed t ~run_id:"r-cancel-window" ~ok:false;
+     raise Exit
+   with
+   | Exit -> ());
+  match R.get t ~run_id:"r-cancel-window" with
+  | Some run ->
+    check
+      (option bool)
+      "completion is durable before later append/wake failure"
+      (Some false)
+      (status_completed_ok run.R.status)
+  | None -> fail "run must remain visible after completion"
+;;
+
 let test_mark_unknown_is_noop () =
   let t = R.create () in
   R.mark_completed t ~run_id:"ghost" ~ok:true;
@@ -123,6 +141,10 @@ let () =
     [ ( "rfc-0266-phase2"
       , [ test_case "register then query" `Quick test_register_then_query
         ; test_case "mark completed (ok true/false)" `Quick test_mark_completed
+        ; test_case
+            "completed status survives later notification failure"
+            `Quick
+            test_completed_status_survives_later_notification_failure
         ; test_case "mark unknown run_id is a no-op" `Quick test_mark_unknown_is_noop
         ; test_case "list_runs is newest-first" `Quick test_list_newest_first
         ; test_case "prune keeps Running + recent completed" `Quick test_prune_keeps_running_and_recent


### PR DESCRIPTION
## fix(fusion): finalize the run registry before the suspending failure-append (RFC-0266 Phase 4 follow-up)

#21784 의 후속(같은 누수의 형제 경로). 적대 감사(lifecycle 렌즈)에서 발견.

### 증상

`masc_fusion` 심의가 `Denied` / `Sink_failed` / 기타 예외로 끝나는 종료 분기에서, 실패 알림 chat append 도중 `Eio.Cancel.Cancelled` 가 발생하면 그 run 이 in-memory registry 에 **영구 "running"(심의중)** 으로 남습니다. dashboard fusion-runs 패널 / `masc_fusion_status` 가 거짓 "심의중" 을 보입니다.

### 근본 원인

`lib/fusion/fusion_tool.ml` 의 `append_chat_failure` 는 종료 3 분기(`Denied` line 91 / `Sink_failed` line 95 / generic `exception` line 112)가 공통으로 호출하는 finalize 경로입니다. 구조가:

```
(try append_assistant_message; chat_appended            (* Eio 파일 I/O — suspending *)
 with Cancelled as exn -> raise exn | exn -> warn);
mark_completed ~ok:false                                 (* <- append 뒤에 위치 *)
broadcast; wake
```

`append_assistant_message` 는 Eio 파일 I/O(`Fs_compat.append_file` → `Eio.Path.save`)라 suspension point 입니다. 셧다운 teardown 이나 형제 fiber 의 `Switch.fail` 이 이 append 중 Cancelled 를 주입하면, `with` 분기가 재전파(line 28-30)하며 함수가 **`mark_completed` 에 도달하기 전에** 빠져나갑니다. registry 는 process-lifetime `global` 이고 `prune` 은 `Running` 을 evict 하지 않으므로(`fusion_run_registry.ml`) run 이 영구 Running 으로 잔존합니다.

#21784 는 orchestrator-level Cancelled(`handle` fork 의 `match Fusion_orchestrator.run ... with exception Cancelled`)만 막았고, 그 커밋 메시지의 "every terminal branch marks it Completed (via append_chat_failure)" 단언이 바로 이 **append 내부 window** 로 깨집니다.

(참고: `fusion_sink.ml` 성공 경로의 `mark_completed`(line 272)도 suspending I/O 뒤에 있지만, emit 은 Cancelled 시 `Ok ()` 를 *return* 하지 않고 *raise* 하며, orchestrator(`fusion_orchestrator.ml:58-64`)가 이를 catch 하지 않고 전파해 `handle` fork 의 #21784 Cancelled 분기가 잡습니다 → **별도 누수 아님**. 그래서 이 PR 은 그 경로를 건드리지 않습니다.)

### 변경 (1줄 이동 + 주석)

`mark_completed`(순수 in-memory CAS, suspension 없음 → cancel-safe)를 suspending append **앞** 으로 이동합니다. finalize-before-suspend 가 성립해 어떤 종료 경로(취소 포함)에서도 run 이 Running 으로 남지 않습니다. `broadcast_run_status` / `wake_keeper_on_fusion_completion`(둘 다 suspending)은 append 성공 경로에 그대로 두되 — registry 는 이미 위에서 확정됐으므로 Cancelled 로 도달 못 해도 가시성은 보존됩니다. #21784 가 line 97 에서 쓴 것과 동일한 cancel-safe 불변식입니다.

### 검증

- `ocamlformat --check lib/fusion/fusion_tool.ml` 통과 (로컬, switch 5.4.1 / ocamlformat 0.29.0).
- `Fusion_run_registry.mark_completed` 의 `Running → Completed{ok=false}` 전이는 `test/fusion_core/test_fusion_run_registry.ml` 로 이미 unit-tested. 변경은 그 호출의 **위치만** 이동(같은 인자)이라 새 심볼/의존성 없음.
- OCaml 빌드는 CI 가 게이트(로컬 agent_sdk drift).

### 테스트에 대하여 (투명성)

별도 통합 테스트를 **추가하지 않았습니다**(#21784 와 동일 사유). `append_chat_failure` 는 `.mli` 미노출 내부 헬퍼이고, 그 fork-cancel 을 end-to-end 로 태우려면 net/orchestrator/policy 를 mock 하는 하네스가 필요한데 현재 fusion 테스트(`test_fusion_harness.ml`, majority 로직만)에 없습니다. 호출하는 `mark_completed` 자체는 unit-tested 이고 그것이 순수 CAS 라 "취소 중 안전" 은 코드 동작이 아니라 언어 보장입니다. 하네스 구축을 후속으로 남깁니다.

### Reachability (정직한 범위)

좁은 TOCTOU 입니다: (1) orchestrator 가 비-Cancelled 종료(Denied/Sink_failed/aborted)를 반환 AND (2) root-switch teardown / 형제 `Switch.fail` 이 실패-메시지 append 중 Cancelled 를 주입. **순수 프로세스 셧다운이면 `global` 자체가 프로세스와 함께 소멸**하므로 영구 누수가 아니고, 영구 잔존은 프로세스가 살아남는 root-switch 취소(supervised sub-switch cancel 등)에 한합니다. 그럼에도 fix 는 finalize-before-suspend 불변식을 모든 종료 경로에 무조건 성립시키는 zero-risk 정정입니다.

### 워크어라운드 게이트

해당 없음 — symptom 억제가 아니라 finalize 호출의 **위치를 cancel-safe 지점으로 교정**하는 구조적 fix. cap/cooldown/dedup/repair / telemetry-as-fix / string 분류기 / N-of-M 어느 것도 아님.

RFC-0266 §7 (VISIBILITY). Phase 4 (#21735) / #21784 follow-up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
