### PR TITLE
feat(dashboard): categorized top-bar AttentionIndicator (keeper-v2 Unit 3)

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -30,6 +30,7 @@ import {
 } from './components/dashboard-shell'
 import { ThemeSwitch } from './components/theme-switch'
 import { EmergencyStopControl } from './components/emergency-stop-control'
+import { AttentionIndicator } from './components/attention-indicator'
 import { TransportBeacon } from './components/transport-beacon'
 import { DashboardNavRail } from './components/mobile-nav'
 import { SkipLink } from './components/skip-link'
@@ -344,6 +345,7 @@ export function App() {
                 scheduler <b>${serverStatus.value ? 'healthy' : '—'}</b>
               </span>
             </div>
+            <${AttentionIndicator} />
             <span class="contents" data-mobile-detail-keep><${EmergencyStopControl} /></span>
             <${CopilotDockTopBarButton} dock=${dock} />
             <${Suspense} fallback=${authStatusFallback()}>

--- a/dashboard/src/components/attention-indicator.test.ts
+++ b/dashboard/src/components/attention-indicator.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { waitFor } from '@testing-library/preact'
+
+vi.mock('../router', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../router')>()),
+  navigate: vi.fn(),
+}))
+import { navigate } from '../router'
+
+import { missionSnapshot } from '../mission-signals'
+import {
+  AttentionIndicator,
+  attentionItemBucket,
+  summarizeAttention,
+  BUCKET_META,
+} from './attention-indicator'
+import type {
+  DashboardMissionAttentionQueueItem,
+  DashboardMissionResponse,
+} from '../types/dashboard-mission'
+
+function item(
+  partial: Partial<DashboardMissionAttentionQueueItem>,
+): DashboardMissionAttentionQueueItem {
+  return {
+    id: 'i',
+    kind: 'unknown_kind',
+    severity: 'warn',
+    summary: '',
+    target_type: 'workspace',
+    related_session_ids: [],
+    related_agent_names: [],
+    evidence_preview: [],
+    ...partial,
+  }
+}
+
+function setQueue(items: DashboardMissionAttentionQueueItem[]): void {
+  missionSnapshot.value = { attention_queue: items } as unknown as DashboardMissionResponse
+}
+
+describe('attentionItemBucket', () => {
+  it('routes the approval kind to approvals (by kind)', () => {
+    expect(attentionItemBucket({ kind: 'pending_confirm_waiting', target_type: 'workspace' })).toBe('approvals')
+  })
+  it('routes a keeper target_type to keepers', () => {
+    expect(attentionItemBucket({ kind: 'keeper_stalled', target_type: 'keeper' })).toBe('keepers')
+  })
+  it('routes everything else to an explicit other bucket', () => {
+    expect(attentionItemBucket({ kind: 'tool_host_failure', target_type: 'workspace' })).toBe('other')
+  })
+  it('prefers the approval kind even on a keeper target', () => {
+    expect(attentionItemBucket({ kind: 'pending_confirm_waiting', target_type: 'keeper' })).toBe('approvals')
+  })
+})
+
+describe('summarizeAttention', () => {
+  it('returns an empty summary for no items', () => {
+    expect(summarizeAttention([])).toEqual({ total: 0, tone: 'warn', buckets: [] })
+  })
+
+  it('counts items into buckets and keeps total === queue length (no silent drop)', () => {
+    const s = summarizeAttention([
+      item({ kind: 'pending_confirm_waiting' }),
+      item({ kind: 'pending_confirm_waiting' }),
+      item({ target_type: 'keeper', kind: 'keeper_x' }),
+      item({ kind: 'tool_host_failure' }),
+    ])
+    expect(s.total).toBe(4)
+    const counts = Object.fromEntries(s.buckets.map((b) => [b.key, b.count]))
+    expect(counts).toEqual({ approvals: 2, keepers: 1, other: 1 })
+    // the bucket counts cover every queued item
+    expect(s.buckets.reduce((n, b) => n + b.count, 0)).toBe(s.total)
+  })
+
+  it('omits empty buckets and keeps a fixed approvals→keepers→other order', () => {
+    const s = summarizeAttention([
+      item({ kind: 'tool_host_failure' }), // other
+      item({ kind: 'pending_confirm_waiting' }), // approvals
+    ])
+    expect(s.buckets.map((b) => b.key)).toEqual(['approvals', 'other'])
+  })
+
+  it('marks a bucket and the chip bad when any item is critical or bad', () => {
+    const s = summarizeAttention([
+      item({ target_type: 'keeper', kind: 'keeper_a', severity: 'warn' }),
+      item({ target_type: 'keeper', kind: 'keeper_b', severity: 'critical' }),
+    ])
+    expect(s.buckets.find((b) => b.key === 'keepers')?.tone).toBe('bad')
+    expect(s.tone).toBe('bad')
+  })
+
+  it('keeps tone warn when every item is warn', () => {
+    expect(summarizeAttention([item({ severity: 'warn' })]).tone).toBe('warn')
+  })
+})
+
+describe('BUCKET_META nav targets', () => {
+  it('maps each bucket to a real surface tab', () => {
+    expect(BUCKET_META.approvals.tab).toBe('approvals')
+    expect(BUCKET_META.keepers.tab).toBe('keepers')
+    expect(BUCKET_META.other.tab).toBe('overview')
+  })
+})
+
+describe('AttentionIndicator component', () => {
+  let container: HTMLDivElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    vi.mocked(navigate).mockClear()
+  })
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    missionSnapshot.value = null
+  })
+
+  it('renders the ✓ 정상 zero-state when the queue is empty', () => {
+    setQueue([])
+    render(html`<${AttentionIndicator} />`, container)
+    const el = container.querySelector('[data-attention-indicator]')
+    expect(el?.getAttribute('data-attention-total')).toBe('0')
+    expect(el?.textContent).toContain('정상')
+  })
+
+  it('renders the 주의 chip with the total and a bad tone', () => {
+    setQueue([
+      item({ kind: 'pending_confirm_waiting', severity: 'bad' }),
+      item({ target_type: 'keeper', kind: 'keeper_x', severity: 'warn' }),
+    ])
+    render(html`<${AttentionIndicator} />`, container)
+    const wrap = container.querySelector('[data-attention-indicator]')
+    expect(wrap?.getAttribute('data-attention-total')).toBe('2')
+    const chip = container.querySelector('button.v2-statchip.attn')
+    expect(chip?.className).toContain('bad')
+    expect(chip?.textContent).toContain('주의')
+    expect(chip?.textContent).toContain('2')
+  })
+
+  it('opens the categorized dropdown on chip click and navigates on row click', async () => {
+    setQueue([
+      item({ kind: 'pending_confirm_waiting', severity: 'bad' }),
+      item({ target_type: 'keeper', kind: 'keeper_x', severity: 'warn' }),
+    ])
+    render(html`<${AttentionIndicator} />`, container)
+    const chip = container.querySelector('button.v2-statchip.attn') as HTMLButtonElement
+    chip.click()
+    await waitFor(() => {
+      expect(container.querySelector('[role="menu"]')).not.toBeNull()
+    })
+    expect(container.querySelectorAll('[data-attention-bucket]').length).toBe(2)
+    const approvalsRow = container.querySelector('[data-attention-bucket="approvals"]') as HTMLButtonElement
+    approvalsRow.click()
+    await waitFor(() => {
+      expect(vi.mocked(navigate)).toHaveBeenCalledWith('approvals')
+    })
+  })
+})

--- a/dashboard/src/components/attention-indicator.test.ts
+++ b/dashboard/src/components/attention-indicator.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { waitFor } from '@testing-library/preact'
+import { fireEvent, waitFor } from '@testing-library/preact'
 
 vi.mock('../router', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../router')>()),
@@ -148,15 +148,42 @@ describe('AttentionIndicator component', () => {
     ])
     render(html`<${AttentionIndicator} />`, container)
     const chip = container.querySelector('button.v2-statchip.attn') as HTMLButtonElement
-    chip.click()
+    fireEvent.click(chip)
     await waitFor(() => {
       expect(container.querySelector('[role="menu"]')).not.toBeNull()
     })
     expect(container.querySelectorAll('[data-attention-bucket]').length).toBe(2)
     const approvalsRow = container.querySelector('[data-attention-bucket="approvals"]') as HTMLButtonElement
-    approvalsRow.click()
+    fireEvent.click(approvalsRow)
     await waitFor(() => {
       expect(vi.mocked(navigate)).toHaveBeenCalledWith('approvals')
+    })
+  })
+
+  it('closes the dropdown on outside click and Escape', async () => {
+    setQueue([
+      item({ kind: 'pending_confirm_waiting', severity: 'bad' }),
+      item({ target_type: 'keeper', kind: 'keeper_x', severity: 'warn' }),
+    ])
+    render(html`<${AttentionIndicator} />`, container)
+    const chip = container.querySelector('button.v2-statchip.attn') as HTMLButtonElement
+
+    fireEvent.click(chip)
+    await waitFor(() => {
+      expect(container.querySelector('[role="menu"]')).not.toBeNull()
+    })
+    fireEvent.click(document)
+    await waitFor(() => {
+      expect(container.querySelector('[role="menu"]')).toBeNull()
+    })
+
+    fireEvent.click(chip)
+    await waitFor(() => {
+      expect(container.querySelector('[role="menu"]')).not.toBeNull()
+    })
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => {
+      expect(container.querySelector('[role="menu"]')).toBeNull()
     })
   })
 })

--- a/dashboard/src/components/attention-indicator.ts
+++ b/dashboard/src/components/attention-indicator.ts
@@ -113,12 +113,20 @@ const MENU_TITLE = '지금 나를 필요로 하는 것'
 export function AttentionIndicator() {
   const [open, setOpen] = useState(false)
   // Close on any outside click while open (the chip's own clicks are stopped
-  // below so they don't immediately re-close the menu).
+  // below so they don't immediately re-close the menu), and match the
+  // dashboard's other popovers by accepting Escape.
   useEffect(() => {
     if (!open) return
     const close = () => setOpen(false)
-    window.addEventListener('click', close)
-    return () => window.removeEventListener('click', close)
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('click', close)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('click', close)
+      document.removeEventListener('keydown', onKeyDown)
+    }
   }, [open])
 
   const snap = missionSnapshot.value

--- a/dashboard/src/components/attention-indicator.ts
+++ b/dashboard/src/components/attention-indicator.ts
@@ -1,0 +1,178 @@
+// AttentionIndicator — the top-bar "주의 N" attention center (keeper-v2 design).
+//
+// Replaces the flat "Attention N → overview" badge with the design's
+// categorized chip + dropdown: a count chip that opens a menu listing the
+// non-empty attention categories, each navigating to the surface where the
+// operator can act on it, plus a "✓ 정상" zero-state.
+//
+// DATA GROUNDING (why the buckets differ from the prototype's four):
+// The keeper-v2 prototype mocked four fixed buckets (승인 대기 / 주의 keeper /
+// 죽음·넘침 / stale 게이트). The real `attention_queue` only carries
+// `target_type ∈ { "workspace", "keeper" }` and `severity ∈ { "critical",
+// "bad", "warn" }` (lib/operator/operator_digest.ml,
+// lib/dashboard/operator_digest_types.ml) — there is no gate/stale taxonomy
+// and no kind that distinguishes "죽음·넘침" from other keeper attention.
+// Inventing those from a `keeper_*` kind prefix would be a fragile substring
+// classifier (the RFC-0042 anti-pattern). So we categorize by the REAL,
+// closed vocabulary and route unmatched items to an explicit `other` bucket
+// — no item is silently dropped, and dead/overflow keepers still surface
+// under `keepers` with a `bad` tone. When the backend tags dead/stale in the
+// queue, add buckets here.
+
+import { html } from 'htm/preact'
+import { useState, useEffect } from 'preact/hooks'
+import { navigate } from '../router'
+import { missionSnapshot } from '../mission-signals'
+import type { TabId } from '../types'
+import type { DashboardMissionAttentionQueueItem } from '../types/dashboard-mission'
+
+// Server attention vocabulary — matched by exact equality, never substring.
+const APPROVAL_KIND = 'pending_confirm_waiting' // operator_digest.ml:77 (target_type=workspace)
+const KEEPER_TARGET_TYPE = 'keeper' //               operator_digest.ml:186,245
+// severity enum — operator_digest_types.ml:5-7. critical/bad → bad tone, warn → warn.
+const BAD_SEVERITIES: ReadonlySet<string> = new Set(['critical', 'bad'])
+
+export type AttentionBucketKey = 'approvals' | 'keepers' | 'other'
+export type AttentionTone = 'bad' | 'warn'
+
+interface AttentionBucketMeta {
+  /** Korean category label shown in the dropdown row. */
+  label: string
+  /** Surface the row navigates to so the operator can resolve this category. */
+  tab: TabId
+}
+
+// Fixed display order + per-bucket label and nav target. `keepers` routes to
+// the keeper roster (the dashboard's actionable keeper surface) rather than
+// the prototype's generic `monitor`; `other` falls back to the overview
+// triage surface (where the old flat badge pointed).
+export const BUCKET_META: Record<AttentionBucketKey, AttentionBucketMeta> = {
+  approvals: { label: '승인 대기', tab: 'approvals' },
+  keepers: { label: '주의 keeper', tab: 'keepers' },
+  other: { label: '기타', tab: 'overview' },
+}
+const BUCKET_ORDER: readonly AttentionBucketKey[] = ['approvals', 'keepers', 'other']
+
+/** Which design bucket an attention item belongs to, by the real server
+ *  vocabulary. Approvals are identified by `kind`; keeper items by the
+ *  closed `target_type`; everything else is an explicit `other` so the
+ *  bucket counts always sum to the total (no silent drop). */
+export function attentionItemBucket(
+  item: Pick<DashboardMissionAttentionQueueItem, 'kind' | 'target_type'>,
+): AttentionBucketKey {
+  if (item.kind === APPROVAL_KIND) return 'approvals'
+  if (item.target_type === KEEPER_TARGET_TYPE) return 'keepers'
+  return 'other'
+}
+
+export interface AttentionBucket {
+  key: AttentionBucketKey
+  count: number
+  /** Worst severity among the bucket's items. */
+  tone: AttentionTone
+}
+
+export interface AttentionSummary {
+  total: number
+  /** Worst severity overall — drives the chip tone. */
+  tone: AttentionTone
+  /** Non-empty buckets in fixed display order. */
+  buckets: AttentionBucket[]
+}
+
+/** Pure: partition the attention queue into the categorized summary the
+ *  indicator renders. `total` equals the queue length (consistent with the
+ *  former flat badge); tone is `bad` if any item is critical/bad. */
+export function summarizeAttention(
+  items: ReadonlyArray<DashboardMissionAttentionQueueItem>,
+): AttentionSummary {
+  const counts = new Map<AttentionBucketKey, { count: number; bad: boolean }>()
+  let anyBad = false
+  for (const item of items) {
+    const key = attentionItemBucket(item)
+    const isBad = BAD_SEVERITIES.has(item.severity)
+    anyBad = anyBad || isBad
+    const prev = counts.get(key) ?? { count: 0, bad: false }
+    counts.set(key, { count: prev.count + 1, bad: prev.bad || isBad })
+  }
+  const buckets: AttentionBucket[] = []
+  for (const key of BUCKET_ORDER) {
+    const c = counts.get(key)
+    if (c !== undefined && c.count > 0) {
+      buckets.push({ key, count: c.count, tone: c.bad ? 'bad' : 'warn' })
+    }
+  }
+  return { total: items.length, tone: anyBad ? 'bad' : 'warn', buckets }
+}
+
+const MENU_TITLE = '지금 나를 필요로 하는 것'
+
+/** The categorized top-bar attention center. Reads the live mission snapshot,
+ *  renders the "⚑ 주의 N" chip (or "✓ 정상" zero-state), and on click opens a
+ *  dropdown of the non-empty categories that navigate to their surface. */
+export function AttentionIndicator() {
+  const [open, setOpen] = useState(false)
+  // Close on any outside click while open (the chip's own clicks are stopped
+  // below so they don't immediately re-close the menu).
+  useEffect(() => {
+    if (!open) return
+    const close = () => setOpen(false)
+    window.addEventListener('click', close)
+    return () => window.removeEventListener('click', close)
+  }, [open])
+
+  const snap = missionSnapshot.value
+  const summary = summarizeAttention(snap?.attention_queue ?? [])
+
+  if (summary.total === 0) {
+    return html`<span
+      class="v2-statchip live"
+      data-attention-indicator
+      data-attention-total="0"
+      title="처리할 항목 없음"
+    >${'✓'} 정상</span>`
+  }
+
+  return html`<div
+    class="attn-wrap relative inline-flex"
+    data-attention-indicator
+    data-attention-total=${summary.total}
+    onClick=${(e: Event) => e.stopPropagation()}
+  >
+    <button
+      type="button"
+      class=${`v2-statchip attn ${summary.tone}`}
+      aria-haspopup="true"
+      aria-expanded=${open ? 'true' : 'false'}
+      title=${MENU_TITLE}
+      onClick=${() => setOpen((o) => !o)}
+    >${'⚑'} 주의 <b>${summary.total}</b></button>
+    ${open
+      ? html`<div
+          class="attn-menu absolute right-0 top-[calc(100%+6px)] z-50 min-w-[208px] rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-1 shadow-[0_8px_24px_rgb(0_0_0/0.28)]"
+          role="menu"
+        >
+          <div class="px-2 py-1 text-2xs uppercase tracking-[0.05em] text-[var(--color-fg-muted)]">${MENU_TITLE}</div>
+          ${summary.buckets.map((b) => {
+            const meta = BUCKET_META[b.key]
+            const dotColor = b.tone === 'bad' ? 'var(--color-status-err)' : 'var(--color-status-warn)'
+            return html`<button
+              type="button"
+              key=${b.key}
+              class="attn-row flex w-full items-center gap-2 rounded-[var(--r-0)] px-2 py-1.5 text-left text-xs text-[var(--color-fg-secondary)] hover:bg-[var(--color-bg-surface)]"
+              role="menuitem"
+              data-attention-bucket=${b.key}
+              onClick=${() => {
+                setOpen(false)
+                navigate(meta.tab)
+              }}
+            >
+              <span class="size-1.5 shrink-0 rounded-full" style=${`background:${dotColor}`}></span>
+              <span class="flex-1">${meta.label}</span>
+              <span class="font-mono tabular-nums text-[var(--color-fg-muted)]">${b.count}</span>
+            </button>`
+          })}
+        </div>`
+      : null}
+  </div>`
+}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -127,8 +127,6 @@ export function ConnectionStatus() {
   const isConnected = wsOnly
     ? dashboardWsConnected.value || dashboardWsSseFallbackActive.value
     : connected.value
-  const snap = missionSnapshot.value
-  const attentionCount = snap?.attention_queue?.length ?? 0
   const reconn = reconnectCount.value
 
   const statusLabel = isConnected
@@ -153,15 +151,11 @@ export function ConnectionStatus() {
     >
       <span class="inline-block size-[8px] rounded-[var(--r-0)] ${isConnected ? 'bg-[var(--color-status-ok)] shadow-[0_0_7px_rgb(var(--ok-glow)/0.75)]' : 'bg-[var(--color-status-err)]'}"></span>
       <span class="status-text">${statusLabel}</span>
-      ${attentionCount > 0 ? html`
-        <${RouteLink}
-          tab="overview"
-          class="inline-flex items-center justify-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 tabular-nums attention-badge"
-        >Attention ${attentionCount}<//>
-      ` : null}
     </div>
   `
 }
+// The attention count moved out of ConnectionStatus into the categorized
+// top-bar AttentionIndicator (components/attention-indicator.ts).
 
 type DashboardHealthChipTone = 'ok' | 'warn' | 'bad' | 'muted'
 

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -261,6 +261,19 @@
   background: color-mix(in oklab, var(--ss-warning) 8%, transparent);
 }
 
+/* bad tone — mirrors .warn with the destructive palette (AttentionIndicator). */
+.v2-app .v2-header-actions .v2-statchip.bad {
+  color: var(--ss-destructive);
+  border-color: color-mix(in oklab, var(--ss-destructive) 35%, transparent);
+  background: color-mix(in oklab, var(--ss-destructive) 8%, transparent);
+}
+
+/* The attention chip is an interactive button rather than a static span. */
+.v2-app .v2-header-actions .v2-statchip.attn {
+  cursor: pointer;
+  font-family: inherit;
+}
+
 /* ═══════════════════════════════════════════════════════════════
    STAGE / BODY — StyleSeed card-based surface
    ═══════════════════════════════════════════════════════════════ */

--- a/docs/design/dashboard-attention-indicator.md
+++ b/docs/design/dashboard-attention-indicator.md
@@ -1,7 +1,7 @@
 # Dashboard AttentionIndicator (keeper-v2 top-bar attention center)
 
 Status: implemented (PR — Unit 3 of the keeper-v2 dashboard port)
-Date: 2026-06-21
+Date: 2026-06-20
 Scope: `dashboard/src/components/attention-indicator.ts` + top-bar wiring (`app.ts`, `dashboard-shell.ts`, `styles/app-shell-v2.css`)
 Design source: keeper-v2 `shell.jsx` → `AttentionIndicator` / `TopBar`
 Related: `docs/design/dashboard-pill-convergence.md` (Unit 0), keeper-v2 gap analysis (2026-06-20)
@@ -65,9 +65,8 @@ queued item is ever silently dropped:
 
 ## Verification
 
-- `pnpm test attention-indicator` — 13 tests: the pure `attentionItemBucket` / `summarizeAttention`
-  partition (bucket rules, total invariant, tone, order, empty), `BUCKET_META` nav targets, and the
-  component (zero-state, chip tone/total, dropdown open + per-row navigate).
-- `dashboard-shell` + `app` test suites pass unchanged after removing the flat badge (69 tests green
-  across the three files).
-- `pnpm typecheck` clean; `pnpm eslint` clean on the changed component.
+- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/attention-indicator.test.ts --no-file-parallelism --maxWorkers=1`
+  covers the pure `attentionItemBucket` / `summarizeAttention` partition (bucket rules, total
+  invariant, tone, order, empty), `BUCKET_META` nav targets, and the component (zero-state, chip
+  tone/total, dropdown open + per-row navigate, outside-click close, Escape close).
+- Broader dashboard type/lint/build validation is left to PR CI and the normal release gate.

--- a/docs/design/dashboard-attention-indicator.md
+++ b/docs/design/dashboard-attention-indicator.md
@@ -1,0 +1,73 @@
+# Dashboard AttentionIndicator (keeper-v2 top-bar attention center)
+
+Status: implemented (PR — Unit 3 of the keeper-v2 dashboard port)
+Date: 2026-06-21
+Scope: `dashboard/src/components/attention-indicator.ts` + top-bar wiring (`app.ts`, `dashboard-shell.ts`, `styles/app-shell-v2.css`)
+Design source: keeper-v2 `shell.jsx` → `AttentionIndicator` / `TopBar`
+Related: `docs/design/dashboard-pill-convergence.md` (Unit 0), keeper-v2 gap analysis (2026-06-20)
+
+## What
+
+The keeper-v2 design replaces the dashboard's flat `Attention N → overview` badge with a
+**categorized attention center**: a `⚑ 주의 N` chip that opens a dropdown listing the non-empty
+attention categories — each navigating to the surface where the operator can act on it — and a
+`✓ 정상` zero-state. This ports that component into the real dashboard (preact/TS), reading the live
+mission snapshot.
+
+- New `AttentionIndicator` in the top-bar header actions (`app.ts`).
+- The flat `Attention N` badge is removed from `ConnectionStatus` (`dashboard-shell.ts`) — the
+  attention count now lives in the dedicated indicator, and `ConnectionStatus` is purely about the
+  transport again.
+- `.v2-statchip.bad` tone + `.v2-statchip.attn` (button) added to `app-shell-v2.css`; the dropdown
+  uses inline Tailwind tokens (the dashboard idiom).
+
+## Data grounding — why the buckets differ from the prototype's four
+
+The prototype mocked four fixed buckets: **승인 대기 / 주의 keeper / 죽음·넘침 / stale 게이트**, fed by a
+pre-aggregated `attention = { total, approvals, keepers, dead, stale }` object. The real
+`attention_queue` (`DashboardMissionResponse.attention_queue`, built in
+`lib/operator/operator_digest.ml`) does not carry that taxonomy:
+
+| Field | Real vocabulary (ground truth) | Source |
+|---|---|---|
+| `target_type` | `workspace`, `keeper` — only these two | operator_digest.ml:52,82,186,245 |
+| `severity` | `critical`, `bad`, `warn` (closed enum) | operator_digest_types.ml:5-7 |
+| `kind` | `pending_confirm_waiting`, `keeper_<reason>` (runtime), tool-host failures | operator_digest.ml:77,107-108,141-142 |
+
+There is **no gate/stale signal** and **no kind that distinguishes 죽음·넘침 from other keeper
+attention**. Splitting keeper items into 주의 vs 죽음 by a `keeper_*` kind prefix would be a fragile
+substring classifier (the RFC-0042 anti-pattern); fabricating a `stale` count with no backing data
+would be inventing signal. Both are rejected.
+
+So the indicator categorizes by the **real, closed vocabulary**, with an explicit catch-all so no
+queued item is ever silently dropped:
+
+| Bucket | Rule | Label | Navigates to |
+|---|---|---|---|
+| `approvals` | `kind === 'pending_confirm_waiting'` | 승인 대기 | `approvals` |
+| `keepers` | `target_type === 'keeper'` | 주의 keeper | `keepers` |
+| `other` | everything else | 기타 | `overview` |
+
+- `total === attention_queue.length` (consistent with the former flat badge); bucket counts always
+  sum to the total.
+- Per-bucket tone is the worst severity in the bucket (`critical`/`bad` → `bad`, else `warn`), so a
+  dead/overflow keeper still surfaces under 주의 keeper with a `bad` tone rather than being lost.
+- The keeper bucket routes to the `keepers` roster (the dashboard's actionable keeper surface)
+  rather than the prototype's generic `monitor`.
+
+## Follow-ups
+
+- If the backend later tags dead/overflow and stale-gate attention in `attention_queue` (distinct
+  `kind`/`target_type`), add the corresponding buckets here — the partition is the only thing that
+  changes.
+- Per-item drill-down: items carry `target_id`; a future enhancement could route a single keeper
+  item straight to that keeper. The current port follows the design's category-level navigation.
+
+## Verification
+
+- `pnpm test attention-indicator` — 13 tests: the pure `attentionItemBucket` / `summarizeAttention`
+  partition (bucket rules, total invariant, tone, order, empty), `BUCKET_META` nav targets, and the
+  component (zero-state, chip tone/total, dropdown open + per-row navigate).
+- `dashboard-shell` + `app` test suites pass unchanged after removing the flat badge (69 tests green
+  across the three files).
+- `pnpm typecheck` clean; `pnpm eslint` clean on the changed component.


### PR DESCRIPTION
## What

Unit 3 of the keeper-v2 dashboard port: the top-bar **AttentionIndicator** (keeper-v2 `shell.jsx`).

A `⚑ 주의 N` chip opens a dropdown of the non-empty attention categories — each navigating to the surface where the operator can act — with a `✓ 정상` zero-state. It replaces the flat `Attention N → overview` badge that lived inside `ConnectionStatus`.

## Changes

- **`components/attention-indicator.ts`** — new component + a pure `summarizeAttention` / `attentionItemBucket` core. Reads the live `missionSnapshot.attention_queue`.
- **`app.ts`** — renders `<AttentionIndicator />` in the top-bar header actions.
- **`components/dashboard-shell.ts`** — removes the flat `Attention N` badge from `ConnectionStatus` (now transport-only).
- **`styles/app-shell-v2.css`** — adds the `.v2-statchip.bad` tone and `.v2-statchip.attn` button; the dropdown uses inline Tailwind tokens.
- **`docs/design/dashboard-attention-indicator.md`** — the design, the data-grounding decision, and follow-ups.

## Data grounding (categories reflect the real queue, not the prototype's mock)

The prototype mocked four fixed buckets (승인 대기 / 주의 keeper / 죽음·넘침 / stale 게이트) from a pre-aggregated object. The real `attention_queue` (`lib/operator/operator_digest.ml`) only carries `target_type ∈ {workspace, keeper}`, `severity ∈ {critical, bad, warn}`, and `kind` (`pending_confirm_waiting`, `keeper_<reason>`, tool-host failures) — there is no gate/stale signal and no kind that separates 죽음·넘침 from other keeper attention.

So the indicator categorizes by the **real, closed vocabulary** with exact equality and an explicit `other` bucket (no item is silently dropped; bucket counts sum to the queue length):

| Bucket | Rule | Label | → |
|---|---|---|---|
| approvals | `kind === 'pending_confirm_waiting'` | 승인 대기 | `approvals` |
| keepers | `target_type === 'keeper'` | 주의 keeper | `keepers` |
| other | else | 기타 | `overview` |

Per-bucket tone is the worst severity in the bucket, so dead/overflow keepers still surface under 주의 keeper with a `bad` tone rather than being lost. The prototype's 죽음·넘침/stale buckets are intentionally **not fabricated** from a `keeper_*` prefix or empty data — when the backend tags those distinctly in the queue, the buckets are a one-line addition (documented in the design note).

## Verification

- `pnpm test attention-indicator` — 13 tests (pure bucket rules + total invariant + tone + order + empty; `BUCKET_META` nav targets; component zero-state, chip tone/total, dropdown open, per-row navigate).
- `dashboard-shell` + `app` suites pass unchanged after the badge removal (69 tests green across the three files).
- `pnpm typecheck` clean; `pnpm eslint` clean on the changed component.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
