### PR TITLE
fix(dashboard): harden mobile keeper detail layout

### DIFF
--- a/dashboard/src/components/keeper-detail-runtime.ts
+++ b/dashboard/src/components/keeper-detail-runtime.ts
@@ -263,7 +263,7 @@ export function KeeperLiveTruthPanel({
 
   return html`
     <div
-      class="v2-monitoring-detail w-full max-w-[calc(100vw-3rem)] rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4 lg:max-w-none"
+      class="v2-monitoring-detail min-w-0 w-full max-w-full overflow-x-hidden rounded-[var(--r-5)] border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] p-4"
       data-testid="keeper-live-truth"
     >
       <div class="flex flex-wrap items-start justify-between gap-3">

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -17,9 +17,9 @@ function KeeperModelChip({ keeper }: { keeper: Keeper }) {
   if (!display) return null
   return html`
     <span
-      class="inline-flex items-center py-0.5 px-2 rounded-[var(--r-1)] text-3xs font-mono bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-20)]"
+      class="inline-flex max-w-full min-w-0 items-center py-0.5 px-2 rounded-[var(--r-1)] text-3xs font-mono bg-[var(--accent-12)] text-[var(--color-accent-fg)] border border-[var(--accent-20)]"
       title=${`${display.label}: ${display.value}`}
-    >${display.value}</span>
+    ><span class="block min-w-0 truncate">${display.value}</span></span>
   `
 }
 
@@ -89,9 +89,9 @@ export function KeeperDetailHeaderInfo({
           ? html`<span aria-hidden="true">${keeper.emoji}</span>`
           : html`<${KeeperBadge} id=${keeper.name} size="lg" variant="sigil" />`}
       </div>
-      <div class="flex min-w-[12rem] flex-1 flex-col gap-0.5">
+      <div class="flex min-w-0 flex-1 flex-col gap-0.5">
         <div class="flex flex-wrap items-center gap-2.5">
-          <h2 id=${titleId} class="m-0 text-xl font-semibold text-[var(--color-fg-primary)]">${keeper.name}</h2>
+          <h2 id=${titleId} class="m-0 min-w-0 truncate text-xl font-semibold text-[var(--color-fg-primary)]">${keeper.name}</h2>
           <${KeeperPhaseAndStage}
             phase=${keeper.lifecycle_phase ?? keeper.phase}
             pipelineStage=${keeper.pipeline_stage}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -113,7 +113,7 @@ describe('KeeperWorkspaceRail', () => {
   it('labels unqualified attention flags as missing cause data', () => {
     const k = mkKeeper({ needs_attention: true })
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`)
-    expect(container.textContent).toContain('주의 플래그 있음 · 원인 미전달')
+    expect(container.textContent).toContain('runtime_attention.needs_attention=true · 원인/조치 미수신')
     expect(container.textContent).not.toContain('점검이 필요합니다')
   })
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -66,7 +66,7 @@ function attentionFallback(keeper: Keeper): string | null {
   if (reason && action) return `${reason} · ${action}`
   if (reason) return `주의 원인: ${reason}`
   if (action) return `다음 조치: ${action}`
-  return '주의 플래그 있음 · 원인 미전달'
+  return 'runtime_attention.needs_attention=true · 원인/조치 미수신'
 }
 
 type AttentionItem = { sev: 'bad' | 'warn'; text: string }

--- a/dashboard/src/styles/copilot-dock.css
+++ b/dashboard/src/styles/copilot-dock.css
@@ -183,12 +183,12 @@
   width: 22px;
   height: 22px;
   flex: none;
-  color: #10131a;
+  color: currentColor;
 }
 .dock-fab .spark svg {
   display: block;
-  color: #10131a;
-  stroke: #10131a;
+  color: currentColor;
+  stroke: currentColor;
 }
 .dock-fab kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 5px; border-radius: var(--radius-xs); background: color-mix(in oklab, var(--volt-ink) 16%, transparent); }
 
@@ -212,10 +212,18 @@
 
 @media (max-width: 900px) {
   .v2-app[data-mobile="true"] .dock-fab {
+    right: max(14px, env(safe-area-inset-right, 0px));
+    width: 44px;
+    height: 44px;
     bottom: calc(68px + env(safe-area-inset-bottom, 0px));
   }
 
   .v2-app[data-mobile="true"][data-keeper-detail-mode="true"] .dock-fab {
-    bottom: 22px;
+    bottom: calc(14px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .v2-app[data-mobile="true"] .dock-fab .spark {
+    width: 20px;
+    height: 20px;
   }
 }

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -50,7 +50,9 @@
     var(--kw-roster-w, 286px)
     minmax(0, 1fr)
     var(--kw-rail-w, 312px);
+  width: 100%;
   height: 100%;
+  min-width: 0;
   min-height: 0;
   position: relative;
   background: var(--color-bg-page);
@@ -73,8 +75,21 @@
  * The attribute is backed by keeperMobilePane so direct routes and roster
  * selection use the same pane switcher. */
 @media (max-width: 860px) {
-  .kw-grid { grid-template-columns: minmax(0, 1fr); overflow: hidden; }
+  .kw-grid {
+    grid-template-columns: minmax(0, 1fr);
+    max-width: 100vw;
+    overflow: hidden;
+  }
+  .kw-grid[data-detail="open"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
   .kw-grid[data-mobile-pane] { grid-template-rows: minmax(0, 1fr); }
+  .kw-chat,
+  .kw-detail,
+  .kw-roster {
+    min-width: 0;
+    max-width: 100%;
+  }
   .kw-grid[data-mobile-pane="roster"] .kw-chat,
   .kw-grid[data-mobile-pane="roster"] .kw-detail {
     display: none;
@@ -437,6 +452,7 @@
   right: 0;
   display: flex;
   width: max-content;
+  max-width: calc(100vw - 28px);
   min-width: 190px;
   flex-direction: column;
   gap: 2px;
@@ -460,6 +476,12 @@
   text-align: left;
   cursor: pointer;
   transition: color .15s, background .15s;
+}
+.kw-chat-command-item span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .kw-chat-command-item:hover {
   color: var(--color-fg-primary);
@@ -751,11 +773,14 @@
 .kw-list-empty { font-size: var(--fs-13); color: var(--color-fg-secondary); }
 .kw-tasktag {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 8px;
+  grid-template-areas:
+    "task-id task-state"
+    "task-title task-title";
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 5px 8px;
   align-items: start;
   width: 100%;
-  padding: 9px 11px;
+  padding: 10px 11px;
   border-radius: var(--r-1);
   background: var(--color-bg-elevated);
   border: 1px solid var(--color-border-divider);
@@ -767,16 +792,38 @@
 }
 .kw-tasktag:hover { background: var(--color-bg-hover); border-color: var(--color-border-default); }
 .kw-tasktag:focus-visible { outline: 2px solid var(--color-accent-fg-dim); outline-offset: 2px; }
-.kw-tasktag .tid { font-family: var(--font-mono); font-size: var(--fs-12); color: var(--color-accent-fg); white-space: nowrap; }
-.kw-tasktag .ttl {
+.kw-tasktag .tid {
+  grid-area: task-id;
   min-width: 0;
   overflow: hidden;
+  color: var(--color-accent-fg);
+  font-family: var(--font-mono);
+  font-size: var(--fs-12);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.kw-tasktag .ttl {
+  grid-area: task-title;
+  min-width: 0;
+  overflow: hidden;
+  overflow-wrap: anywhere;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   line-height: 1.35;
 }
-.kw-tasktag .tstate { align-self: start; font-size: var(--fs-11); color: var(--color-fg-secondary); white-space: nowrap; }
+.kw-tasktag .tstate {
+  grid-area: task-state;
+  align-self: start;
+  justify-self: end;
+  max-width: 10rem;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-11);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .kw-tasktag .tstate.review { color: var(--color-status-warn); }
 
 /* Recent tool calls: compact rows (status dot + name + duration + age) that
@@ -811,7 +858,17 @@
   font-size: var(--fs-13); font-weight: var(--fw-bold); transition: background .15s, border-color .15s;
 }
 .kw-detail-btn:hover { background: var(--color-bg-hover); border-color: var(--color-border-strong); }
-.kw-detail-btn .sub { font-weight: 400; color: var(--color-fg-secondary); font-size: var(--fs-12); }
+.kw-detail-btn > span:first-child { flex: none; }
+.kw-detail-btn .sub {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-12);
+  font-weight: 400;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* ════ DETAIL ("운영 상세") — reuse KeeperDetailBody, scrollable column ══ */
 .kw-detail { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--color-bg-page); }
@@ -820,7 +877,81 @@
   padding: 12px 18px; border-bottom: 1px solid var(--color-border-default);
   background: var(--color-bg-panel-alt);
 }
-.kw-detail-scroll { flex: 1; min-height: 0; overflow-y: auto; padding: 20px; }
+.kw-detail-head strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.kw-detail-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 20px;
+  overscroll-behavior: contain;
+}
+.kw-detail-scroll .v2-monitoring-panel,
+.kw-detail-scroll .v2-monitoring-surface {
+  min-width: 0;
+  max-width: 100%;
+}
+
+@media (max-width: 860px) {
+  [data-keeper-detail-mode="true"] .v2-shell-stage { padding: 6px; }
+  [data-keeper-detail-mode="true"] .v2-body { border-radius: var(--r-2); }
+  [data-keeper-detail-mode="true"] .v2-header-brand { max-width: calc(100vw - 86px); }
+
+  .kw-mobile-rail-drawer {
+    width: min(100vw, 380px);
+  }
+  .kw-rail-scroll {
+    gap: 18px;
+    padding: 16px 14px;
+  }
+  .kw-detail-head {
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 10px 12px;
+  }
+  .kw-detail-head .kw-act {
+    min-height: 40px;
+  }
+  .kw-detail-head strong {
+    flex: 1 1 11rem;
+  }
+  .kw-detail-scroll {
+    padding: 10px;
+  }
+}
+
+@media (max-width: 520px) {
+  .kw-vitals {
+    grid-template-columns: 1fr;
+  }
+  .kw-ctx-tok {
+    flex-wrap: wrap;
+  }
+  .kw-ctx-tok .lbl {
+    width: 100%;
+    margin-left: 0;
+  }
+  .kw-ctx-meta {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .kw-detail-btn {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    min-height: 44px;
+  }
+  .kw-detail-btn .sub {
+    width: 100%;
+    text-align: left;
+  }
+  .kw-detail-scroll {
+    padding: 8px;
+  }
+}
 
 /* ════ ATTENTION (rail, top) ════════════════════════════════════ */
 .kw-att-list { display: flex; flex-direction: column; gap: 7px; }


### PR DESCRIPTION
## Summary

- Hardened the mobile Keeper Fleet dashboard layout so the keeper context rail, owned-task rows, detail view, and command popover stay within the phone viewport.
- Replaced the vague unqualified attention fallback with the actual source signal: `runtime_attention.needs_attention=true · 원인/조치 미수신`.

## Product impact

- Mobile operators can open the context drawer and see runtime, context, task, and detail controls without task titles/status columns fighting for the same row.
- The "모델" cell no longer appears when no model was reported, and long runtime/model labels are constrained instead of forcing horizontal overflow.
- The mobile "운영 상세" path now uses a one-column grid instead of inheriting the desktop detail grid width.

## Evidence

- `pnpm exec vitest run src/components/keeper-workspace/keeper-workspace-rail.test.ts` passed.
- `pnpm run typecheck` passed.
- `pnpm exec eslint src/components/keeper-detail-runtime.ts src/components/keeper-detail-shell.ts src/components/keeper-workspace/keeper-workspace-rail.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts` passed.
- `git diff --check` passed.
- Playwright mobile smoke at `390x844` passed for chat load, command menu, context drawer, owned task row, detail button, and detail pane viewport bounds.

## Direct evidence

schema_version: 1
direct_ratio: 6/6
provenance: direct

- Mobile page identity: `MASC · Keeper Fleet`.
- Vite/framework overlay count: `0`.
- Command popover bbox: `left=112 right=302 width=190 viewport=390 withinViewport=true`.
- Context drawer bbox: `left=33 right=357 width=324 viewport=390 withinViewport=true`.
- First owned task bbox: `left=48 right=343 width=295 viewport=390 withinViewport=true`.
- Detail pane bbox after `운영 상세`: `left=33 right=357 width=324 viewport=390 withinViewport=true`.

## Review evidence

- The mobile detail grid specificity bug was found during the Playwright interaction loop and fixed with an explicit `@media (max-width: 860px)` override for `.kw-grid[data-detail="open"]`.
- Browser plugin was not available in this environment, so validation used Playwright CLI plus a temporary Playwright script outside the repo.
- Console output only showed dashboard PerformanceMonitor slow-frame warnings during interaction; no framework overlay or app crash was observed.

## Linked issue

n/a

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/mobile-dashboard-hardening-20260621` → `main` · 1 commit(s) · synced 2026-06-20T16:41:48Z

| sha | subject | date |
|---|---|---|
| `e4016bff1` | fix(dashboard): harden mobile keeper detail layout | 2026-06-20 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->