### PR TITLE
feat(voice): expose turn loop guidance

### DIFF
--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -295,14 +295,7 @@ let voice_agent_capability_fields ~(meta : keeper_meta) =
   ; ( "realtime_supported"
     , `Bool (realtime_configured || Voice_session_manager.realtime_supported active_mode) )
   ; ( "realtime_bridge"
-    , `Assoc
-        [ "configured", `Bool realtime_configured
-        ; "required_env", `String Voice_session_manager.realtime_bridge_env
-        ; ( "endpoint"
-          , match realtime_endpoint with
-            | Some endpoint -> `String endpoint
-            | None -> `Null )
-        ] )
+    , Voice_session_manager.realtime_bridge_public_json ?endpoint:realtime_endpoint () )
   ; ( "available_conversation_modes"
     , `List
         ([ `String "turn_based" ]

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -248,15 +248,69 @@ let append_assoc_fields json fields =
   | `Assoc existing -> `Assoc (existing @ fields)
   | other -> `Assoc (("voice_config", other) :: fields)
 
+let requested_conversation_mode ~(args : Yojson.Safe.t) =
+  match
+    Safe_ops.json_string_opt "conversation_mode" args
+    |> Option.map (fun raw -> String.lowercase_ascii (String.trim raw))
+  with
+  | None | Some "" | Some "turn_based" | Some "turn-based" ->
+    Ok Voice_session_manager.Turn_based
+  | Some ("realtime" | "realtime_bridge" | "realtime-bridge") ->
+    (match Voice_session_manager.realtime_bridge_endpoint () with
+     | Some endpoint -> Ok (Voice_session_manager.Realtime_bridge { endpoint })
+     | None ->
+       Error
+         (Tool_args.error_response_with
+            [ "message", `String "voice realtime bridge unavailable"
+            ; "error", `String "voice_realtime_bridge_unavailable"
+            ; "requested_conversation_mode", `String "realtime_bridge"
+            ; "required_env", `String Voice_session_manager.realtime_bridge_env
+            ; "fallback_conversation_mode", `String "turn_based"
+            ; "fallback_tool", `String "keeper_voice_session_start"
+            ]))
+  | Some mode ->
+    Error
+      (Tool_args.error_response_with
+         [ "message", `String "invalid voice conversation_mode"
+         ; "error", `String "invalid_voice_conversation_mode"
+         ; "conversation_mode", `String mode
+         ; ( "accepted_modes"
+           , `List [ `String "turn_based"; `String "realtime_bridge" ] )
+         ])
+
 let voice_agent_capability_fields ~(meta : keeper_meta) =
   let mgr = Keeper_voice_local.get_session_manager () in
   let active_session = Voice_session_manager.get_session mgr ~agent_id:meta.name in
-  [ "conversation_mode", `String "turn_based"
-  ; "transport_mode", `String "batch_stt_tts"
-  ; "realtime_supported", `Bool false
+  let active_mode =
+    match active_session with
+    | Some session -> Voice_session_manager.session_conversation_mode session
+    | None -> Voice_session_manager.Turn_based
+  in
+  let realtime_endpoint = Voice_session_manager.realtime_bridge_endpoint () in
+  let realtime_configured = Option.is_some realtime_endpoint in
+  [ ( "conversation_mode"
+    , `String (Voice_session_manager.string_of_conversation_mode active_mode) )
+  ; ( "transport_mode"
+    , `String (Voice_session_manager.transport_mode_of_conversation_mode active_mode) )
+  ; ( "realtime_supported"
+    , `Bool (realtime_configured || Voice_session_manager.realtime_supported active_mode) )
+  ; ( "realtime_bridge"
+    , `Assoc
+        [ "configured", `Bool realtime_configured
+        ; "required_env", `String Voice_session_manager.realtime_bridge_env
+        ; ( "endpoint"
+          , match realtime_endpoint with
+            | Some endpoint -> `String endpoint
+            | None -> `Null )
+        ] )
+  ; ( "available_conversation_modes"
+    , `List
+        ([ `String "turn_based" ]
+         @ if realtime_configured then [ `String "realtime_bridge" ] else []) )
   ; ( "voice_loop"
-    , Voice_session_manager.turn_based_voice_loop_json
-        ~session_active:(Option.is_some active_session) )
+    , Voice_session_manager.voice_loop_json
+        ~session_active:(Option.is_some active_session)
+        active_mode )
   ; "session_active", `Bool (Option.is_some active_session)
   ; ( "active_session"
     , match active_session with
@@ -307,9 +361,15 @@ let handle_session_start ~(meta : keeper_meta) ~(args : Yojson.Safe.t) =
     | Some s when s <> "" -> Some s
     | _ -> None
   in
-  let mgr = Keeper_voice_local.get_session_manager () in
-  let session = Voice_session_manager.start_session mgr ~agent_id:meta.name ?voice () in
-  Yojson.Safe.to_string (Voice_session_manager.session_to_json session)
+  match requested_conversation_mode ~args with
+  | Error response -> response
+  | Ok conversation_mode ->
+    let mgr = Keeper_voice_local.get_session_manager () in
+    let session =
+      Voice_session_manager.start_session mgr ~agent_id:meta.name ?voice
+        ~conversation_mode ()
+    in
+    Yojson.Safe.to_string (Voice_session_manager.session_to_json session)
 
 let handle_session_end ~(meta : keeper_meta) =
   let mgr = Keeper_voice_local.get_session_manager () in

--- a/lib/keeper/keeper_tool_voice_runtime.ml
+++ b/lib/keeper/keeper_tool_voice_runtime.ml
@@ -252,7 +252,11 @@ let voice_agent_capability_fields ~(meta : keeper_meta) =
   let mgr = Keeper_voice_local.get_session_manager () in
   let active_session = Voice_session_manager.get_session mgr ~agent_id:meta.name in
   [ "conversation_mode", `String "turn_based"
+  ; "transport_mode", `String "batch_stt_tts"
   ; "realtime_supported", `Bool false
+  ; ( "voice_loop"
+    , Voice_session_manager.turn_based_voice_loop_json
+        ~session_active:(Option.is_some active_session) )
   ; "session_active", `Bool (Option.is_some active_session)
   ; ( "active_session"
     , match active_session with

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -709,6 +709,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                 let tool_use_lines = [
                   "Tool-use guidance:";
                   "- If the user asks you to speak, use voice, make sound, or output TTS, prefer keeper_voice_session_start and keeper_voice_speak.";
+                  "- Voice sessions are turn-based: operator speech arrives as transcribed text through normal keeper turns; do not wait for a live duplex audio stream.";
                   "- Do not simulate spoken audio with plain text roleplay when a voice tool can handle the request.";
                   "- If voice execution fails, say that voice output is unavailable and continue in text.";
                 ] in

--- a/lib/tool_surface/tool_shard_types_schemas_voice.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_voice.ml
@@ -65,11 +65,11 @@ let voice_tools : Masc_domain.tool_schema list =
   ; { name = "keeper_voice_agent"
     ; description =
         "Get your own voice capability and configuration. Reports assigned voice, \
-         available voices, active turn-based voice session state, and \
-         voice_loop guidance: operator audio is transcribed to normal keeper text \
-         turns, while keeper output uses keeper_voice_speak and dashboard audio \
-         clips. realtime_supported=false means no full-duplex live audio stream is \
-         bound to keeper turns. No network required."
+         available voices, active voice session state, available conversation \
+         modes, and voice_loop guidance. Without MASC_VOICE_REALTIME_WS_URL, \
+         operator audio is transcribed to normal keeper text turns and keeper \
+         output uses keeper_voice_speak/dashboard audio clips. No network \
+         required."
     ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
     }
   ; { name = "keeper_voice_sessions"
@@ -78,9 +78,11 @@ let voice_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_voice_session_start"
     ; description =
-        "Start a turn-based voice session for this keeper. The result includes \
-         voice_loop guidance that tells the keeper and dashboard how operator \
-         speech is transcribed and how keeper output is played."
+        "Start a voice session for this keeper. Defaults to turn_based batch \
+         STT/TTS. conversation_mode=realtime_bridge is accepted only when \
+         MASC_VOICE_REALTIME_WS_URL points at a configured realtime audio bridge; \
+         otherwise the tool fails closed instead of pretending a duplex stream \
+         exists."
     ; input_schema =
         `Assoc
           [ "type", `String "object"
@@ -90,6 +92,16 @@ let voice_tools : Masc_domain.tool_schema list =
                   , `Assoc
                       [ "type", `String "string"
                       ; "description", `String "Optional session name"
+                      ] )
+                ; ( "conversation_mode"
+                  , `Assoc
+                      [ "type", `String "string"
+                      ; ( "enum"
+                        , `List [ `String "turn_based"; `String "realtime_bridge" ] )
+                      ; ( "description"
+                        , `String
+                            "Optional mode. realtime_bridge requires \
+                             MASC_VOICE_REALTIME_WS_URL." )
                       ] )
                 ] )
           ]

--- a/lib/tool_surface/tool_shard_types_schemas_voice.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_voice.ml
@@ -66,8 +66,10 @@ let voice_tools : Masc_domain.tool_schema list =
     ; description =
         "Get your own voice capability and configuration. Reports assigned voice, \
          available voices, active turn-based voice session state, and \
-         realtime_supported=false when no full-duplex live audio stream is bound to \
-         keeper turns. No network required."
+         voice_loop guidance: operator audio is transcribed to normal keeper text \
+         turns, while keeper output uses keeper_voice_speak and dashboard audio \
+         clips. realtime_supported=false means no full-duplex live audio stream is \
+         bound to keeper turns. No network required."
     ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
     }
   ; { name = "keeper_voice_sessions"
@@ -76,7 +78,9 @@ let voice_tools : Masc_domain.tool_schema list =
     }
   ; { name = "keeper_voice_session_start"
     ; description =
-        "Start a voice session for this keeper using the configured voice bridge."
+        "Start a turn-based voice session for this keeper. The result includes \
+         voice_loop guidance that tells the keeper and dashboard how operator \
+         speech is transcribed and how keeper output is played."
     ; input_schema =
         `Assoc
           [ "type", `String "object"

--- a/lib/voice/voice_session_manager.ml
+++ b/lib/voice/voice_session_manager.ml
@@ -102,6 +102,13 @@ let realtime_bridge_endpoint ?(getenv = Sys.getenv_opt) () =
     then None
     else Some endpoint
 
+let realtime_bridge_public_json ?endpoint () =
+  `Assoc
+    [ "configured", `Bool (Option.is_some endpoint)
+    ; "required_env", `String realtime_bridge_env
+    ; "endpoint", `Null
+    ]
+
 let session_conversation_mode session = session.conversation_mode
 
 let turn_based_voice_loop_json ~session_active =
@@ -140,8 +147,8 @@ let realtime_bridge_voice_loop_json ~session_active ~endpoint =
     ; "transport_mode", `String "websocket_audio_bridge"
     ; "realtime_supported", `Bool true
     ; "session_active", `Bool session_active
-    ; "bridge_endpoint", `String endpoint
     ; "protocol", `String "masc.voice.realtime_bridge.v1"
+    ; "realtime_bridge", realtime_bridge_public_json ~endpoint ()
     ; ( "operator_input"
       , `Assoc
           [ "capture", `String "dashboard_microphone_stream"
@@ -182,7 +189,12 @@ let session_to_json session =
   let bridge_endpoint =
     match mode with
     | Turn_based -> `Null
-    | Realtime_bridge { endpoint } -> `String endpoint
+    | Realtime_bridge _ -> `Null
+  in
+  let realtime_bridge =
+    match mode with
+    | Turn_based -> realtime_bridge_public_json ()
+    | Realtime_bridge { endpoint } -> realtime_bridge_public_json ~endpoint ()
   in
   `Assoc [
     ("session_id", `String session.session_id);
@@ -196,15 +208,15 @@ let session_to_json session =
     ("transport_mode", `String (transport_mode_of_conversation_mode mode));
     ("realtime_supported", `Bool (realtime_supported mode));
     ("realtime_bridge_endpoint", bridge_endpoint);
+    ("realtime_bridge", realtime_bridge);
     ("voice_loop", voice_loop_json ~session_active mode);
   ]
 
 let conversation_mode_of_json json =
   match Json_util.get_string json "conversation_mode" with
   | Some "realtime_bridge" | Some "realtime" ->
-    (match Json_util.get_string json "realtime_bridge_endpoint" with
-     | Some endpoint when valid_realtime_bridge_endpoint (String.trim endpoint) ->
-       Realtime_bridge { endpoint = String.trim endpoint }
+    (match realtime_bridge_endpoint () with
+     | Some endpoint -> Realtime_bridge { endpoint }
      | _ -> Turn_based)
   | _ -> Turn_based
 

--- a/lib/voice/voice_session_manager.ml
+++ b/lib/voice/voice_session_manager.ml
@@ -14,6 +14,10 @@ type session_status =
   | Idle
   | Suspended
 
+type conversation_mode =
+  | Turn_based
+  | Realtime_bridge of { endpoint : string }
+
 type session = {
   session_id: string;
   agent_id: string;
@@ -22,6 +26,7 @@ type session = {
   mutable last_activity: float;
   mutable turn_count: int;
   mutable status: session_status;
+  mutable conversation_mode: conversation_mode;
 }
 
 type t = {
@@ -67,6 +72,38 @@ let status_of_string_opt = function
   | "suspended" -> Some Suspended
   | _ -> None
 
+let string_of_conversation_mode = function
+  | Turn_based -> "turn_based"
+  | Realtime_bridge _ -> "realtime_bridge"
+
+let transport_mode_of_conversation_mode = function
+  | Turn_based -> "batch_stt_tts"
+  | Realtime_bridge _ -> "websocket_audio_bridge"
+
+let realtime_supported = function
+  | Turn_based -> false
+  | Realtime_bridge _ -> true
+
+let realtime_bridge_env = "MASC_VOICE_REALTIME_WS_URL"
+
+let has_prefix ~prefix s =
+  let prefix_len = String.length prefix in
+  String.length s >= prefix_len && String.sub s 0 prefix_len = prefix
+
+let valid_realtime_bridge_endpoint endpoint =
+  has_prefix ~prefix:"ws://" endpoint || has_prefix ~prefix:"wss://" endpoint
+
+let realtime_bridge_endpoint ?(getenv = Sys.getenv_opt) () =
+  match getenv realtime_bridge_env with
+  | None -> None
+  | Some raw ->
+    let endpoint = String.trim raw in
+    if endpoint = "" || not (valid_realtime_bridge_endpoint endpoint)
+    then None
+    else Some endpoint
+
+let session_conversation_mode session = session.conversation_mode
+
 let turn_based_voice_loop_json ~session_active =
   `Assoc
     [ "mode", `String "turn_based_batch"
@@ -97,11 +134,55 @@ let turn_based_voice_loop_json ~session_active =
           ] )
     ]
 
+let realtime_bridge_voice_loop_json ~session_active ~endpoint =
+  `Assoc
+    [ "mode", `String "realtime_bridge"
+    ; "transport_mode", `String "websocket_audio_bridge"
+    ; "realtime_supported", `Bool true
+    ; "session_active", `Bool session_active
+    ; "bridge_endpoint", `String endpoint
+    ; "protocol", `String "masc.voice.realtime_bridge.v1"
+    ; ( "operator_input"
+      , `Assoc
+          [ "capture", `String "dashboard_microphone_stream"
+          ; "handoff", `String "audio_frames_to_realtime_bridge"
+          ; "fallback_route", `String "POST /api/v1/voice/transcribe"
+          ] )
+    ; ( "keeper_output"
+      , `Assoc
+          [ "delivery", `String "assistant_audio_events_or_tts_audio_clip"
+          ; "fallback_tool", `String "keeper_voice_speak"
+          ; "browser_route", `String "GET /api/v1/voice/audio/<token>"
+          ] )
+    ; ( "keeper_next_actions"
+      , `List
+          [ `String
+              "Use the realtime bridge for live audio frames while the session \
+               is active."
+          ; `String
+              "Fall back to keeper_voice_speak and batch STT/TTS if the bridge \
+               disconnects."
+          ; `String
+              "Call keeper_voice_agent to inspect active realtime bridge state."
+          ] )
+    ]
+
+let voice_loop_json ~session_active = function
+  | Turn_based -> turn_based_voice_loop_json ~session_active
+  | Realtime_bridge { endpoint } ->
+    realtime_bridge_voice_loop_json ~session_active ~endpoint
+
 let session_to_json session =
   let session_active =
     match session.status with
     | Active -> true
     | Idle | Suspended -> false
+  in
+  let mode = session.conversation_mode in
+  let bridge_endpoint =
+    match mode with
+    | Turn_based -> `Null
+    | Realtime_bridge { endpoint } -> `String endpoint
   in
   `Assoc [
     ("session_id", `String session.session_id);
@@ -111,11 +192,21 @@ let session_to_json session =
     ("last_activity", `Float session.last_activity);
     ("turn_count", `Int session.turn_count);
     ("status", `String (string_of_status session.status));
-    ("conversation_mode", `String "turn_based");
-    ("transport_mode", `String "batch_stt_tts");
-    ("realtime_supported", `Bool false);
-    ("voice_loop", turn_based_voice_loop_json ~session_active);
+    ("conversation_mode", `String (string_of_conversation_mode mode));
+    ("transport_mode", `String (transport_mode_of_conversation_mode mode));
+    ("realtime_supported", `Bool (realtime_supported mode));
+    ("realtime_bridge_endpoint", bridge_endpoint);
+    ("voice_loop", voice_loop_json ~session_active mode);
   ]
+
+let conversation_mode_of_json json =
+  match Json_util.get_string json "conversation_mode" with
+  | Some "realtime_bridge" | Some "realtime" ->
+    (match Json_util.get_string json "realtime_bridge_endpoint" with
+     | Some endpoint when valid_realtime_bridge_endpoint (String.trim endpoint) ->
+       Realtime_bridge { endpoint = String.trim endpoint }
+     | _ -> Turn_based)
+  | _ -> Turn_based
 
 let session_of_json json =
   {
@@ -135,6 +226,7 @@ let session_of_json json =
       |> Option.value ~default:""
       |> status_of_string_opt
       |> Option.value ~default:Suspended;
+    conversation_mode = conversation_mode_of_json json;
   }
 
 (** {1 Creation} *)
@@ -192,13 +284,14 @@ let delete_session_file t agent_id =
 
 (** {1 Session Lifecycle} *)
 
-let start_session t ~agent_id ?voice () =
+let start_session t ~agent_id ?voice ?(conversation_mode = Turn_based) () =
   with_lock t (fun () ->
     (* Check if session already exists *)
     match Hashtbl.find_opt t.sessions agent_id with
     | Some existing ->
       existing.status <- Active;
       existing.last_activity <- Time_compat.now ();
+      existing.conversation_mode <- conversation_mode;
       save_session t existing;
       existing
     | None ->
@@ -216,6 +309,7 @@ let start_session t ~agent_id ?voice () =
         last_activity = now;
         turn_count = 0;
         status = Active;
+        conversation_mode;
       } in
       Hashtbl.add t.sessions agent_id session;
       save_session t session;

--- a/lib/voice/voice_session_manager.ml
+++ b/lib/voice/voice_session_manager.ml
@@ -67,7 +67,42 @@ let status_of_string_opt = function
   | "suspended" -> Some Suspended
   | _ -> None
 
+let turn_based_voice_loop_json ~session_active =
+  `Assoc
+    [ "mode", `String "turn_based_batch"
+    ; "transport_mode", `String "batch_stt_tts"
+    ; "realtime_supported", `Bool false
+    ; "session_active", `Bool session_active
+    ; ( "operator_input"
+      , `Assoc
+          [ "capture", `String "dashboard_microphone_or_audio_upload"
+          ; "server_route", `String "POST /api/v1/voice/transcribe"
+          ; "handoff", `String "transcribed_text_enters_normal_keeper_turn"
+          ] )
+    ; ( "keeper_output"
+      , `Assoc
+          [ "tool", `String "keeper_voice_speak"
+          ; "delivery", `String "tts_audio_clip"
+          ; "browser_route", `String "GET /api/v1/voice/audio/<token>"
+          ] )
+    ; ( "keeper_next_actions"
+      , `List
+          [ `String "Use keeper_voice_speak for audible keeper output."
+          ; `String
+              "Treat transcribed operator speech as normal text input; do not wait \
+               for a live duplex audio stream."
+          ; `String
+              "Call keeper_voice_agent to inspect whether a turn-based voice session \
+               is active."
+          ] )
+    ]
+
 let session_to_json session =
+  let session_active =
+    match session.status with
+    | Active -> true
+    | Idle | Suspended -> false
+  in
   `Assoc [
     ("session_id", `String session.session_id);
     ("agent_id", `String session.agent_id);
@@ -76,6 +111,10 @@ let session_to_json session =
     ("last_activity", `Float session.last_activity);
     ("turn_count", `Int session.turn_count);
     ("status", `String (string_of_status session.status));
+    ("conversation_mode", `String "turn_based");
+    ("transport_mode", `String "batch_stt_tts");
+    ("realtime_supported", `Bool false);
+    ("voice_loop", turn_based_voice_loop_json ~session_active);
   ]
 
 let session_of_json json =

--- a/lib/voice/voice_session_manager.mli
+++ b/lib/voice/voice_session_manager.mli
@@ -61,15 +61,18 @@ val realtime_bridge_endpoint : ?getenv:(string -> string option) -> unit -> stri
 (** Configured realtime voice bridge endpoint from [MASC_VOICE_REALTIME_WS_URL].
     Blank, non-[ws://], and non-[wss://] values are treated as unavailable. *)
 
+val realtime_bridge_public_json : ?endpoint:string -> unit -> Yojson.Safe.t
+(** Keeper-visible bridge metadata. The raw websocket endpoint stays
+    internal-only and is never serialized into this JSON. *)
+
 val session_conversation_mode : session -> conversation_mode
 
 (** {1 JSON conversion} *)
 
 val session_to_json : session -> Yojson.Safe.t
 (** Includes the durable session fields plus the dashboard/keeper-visible
-    turn-based voice-loop contract:
-    [conversation_mode="turn_based"], [transport_mode="batch_stt_tts"],
-    [realtime_supported=false], and [voice_loop]. *)
+    voice-loop contract. Realtime bridge JSON exposes configured metadata only;
+    the raw websocket endpoint is intentionally redacted. *)
 
 val turn_based_voice_loop_json : session_active:bool -> Yojson.Safe.t
 (** Structured capability contract for the current voice implementation.

--- a/lib/voice/voice_session_manager.mli
+++ b/lib/voice/voice_session_manager.mli
@@ -47,6 +47,16 @@ val status_of_string_opt : string -> session_status option
 (** {1 JSON conversion} *)
 
 val session_to_json : session -> Yojson.Safe.t
+(** Includes the durable session fields plus the dashboard/keeper-visible
+    turn-based voice-loop contract:
+    [conversation_mode="turn_based"], [transport_mode="batch_stt_tts"],
+    [realtime_supported=false], and [voice_loop]. *)
+
+val turn_based_voice_loop_json : session_active:bool -> Yojson.Safe.t
+(** Structured capability contract for the current voice implementation.
+    MASC voice sessions are batch STT/TTS loops: operator audio is first
+    transcribed to text, then delivered through the normal keeper turn;
+    keeper output uses [keeper_voice_speak] and dashboard audio clips. *)
 
 val session_of_json : Yojson.Safe.t -> session
 (** Decode failures on individual fields raise [Yojson] exceptions.

--- a/lib/voice/voice_session_manager.mli
+++ b/lib/voice/voice_session_manager.mli
@@ -23,6 +23,14 @@ type session_status =
 (** Wire-format strings: ["active"] / ["idle"] / ["suspended"]. See
     {!status_of_string_opt}. *)
 
+type conversation_mode =
+  | Turn_based
+  | Realtime_bridge of { endpoint : string }
+(** Voice loop transport mode. [Realtime_bridge] is only valid when an
+    operator-provided realtime bridge endpoint is configured; MASC still owns
+    session state and Keeper tool visibility, while the bridge owns live audio
+    frames. *)
+
 type session
 (** A single agent's active voice session. Mutable internals
     ([last_activity], [turn_count], [status]) are guarded by the
@@ -44,6 +52,17 @@ val status_of_string_opt : string -> session_status option
 (** [Some] only for the three wire-format names; any other input
     returns [None] (#8612 — never silently maps unknowns to [Idle]). *)
 
+val string_of_conversation_mode : conversation_mode -> string
+val transport_mode_of_conversation_mode : conversation_mode -> string
+val realtime_supported : conversation_mode -> bool
+val realtime_bridge_env : string
+
+val realtime_bridge_endpoint : ?getenv:(string -> string option) -> unit -> string option
+(** Configured realtime voice bridge endpoint from [MASC_VOICE_REALTIME_WS_URL].
+    Blank, non-[ws://], and non-[wss://] values are treated as unavailable. *)
+
+val session_conversation_mode : session -> conversation_mode
+
 (** {1 JSON conversion} *)
 
 val session_to_json : session -> Yojson.Safe.t
@@ -57,6 +76,8 @@ val turn_based_voice_loop_json : session_active:bool -> Yojson.Safe.t
     MASC voice sessions are batch STT/TTS loops: operator audio is first
     transcribed to text, then delivered through the normal keeper turn;
     keeper output uses [keeper_voice_speak] and dashboard audio clips. *)
+
+val voice_loop_json : session_active:bool -> conversation_mode -> Yojson.Safe.t
 
 val session_of_json : Yojson.Safe.t -> session
 (** Decode failures on individual fields raise [Yojson] exceptions.
@@ -72,7 +93,7 @@ val create : config_path:string -> t
     disk — call {!restore} for that. *)
 
 val start_session :
-  t -> agent_id:string -> ?voice:string -> unit -> session
+  t -> agent_id:string -> ?voice:string -> ?conversation_mode:conversation_mode -> unit -> session
 (** Re-activates an existing session if one is registered for
     [agent_id]; otherwise creates a fresh session with [voice]
     (defaulting to [Voice_bridge.get_voice_for_agent agent_id]) and

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -458,6 +458,16 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
     let voice = Yojson.Safe.Util.(member "voice" json |> to_string) in
     check bool "session_name is not persisted as voice" true
       (not (String.equal session_name voice));
+    let voice_loop = Yojson.Safe.Util.member "voice_loop" json in
+    check string "session start loop mode" "turn_based_batch"
+      Yojson.Safe.Util.(member "mode" voice_loop |> to_string);
+    check bool "session start loop active" true
+      Yojson.Safe.Util.(member "session_active" voice_loop |> to_bool);
+    check bool "session start realtime unsupported" false
+      Yojson.Safe.Util.(member "realtime_supported" voice_loop |> to_bool);
+    check string "session start output tool" "keeper_voice_speak"
+      Yojson.Safe.Util.(
+        member "keeper_output" voice_loop |> member "tool" |> to_string);
     ignore
       (Masc.Keeper_tool_voice_runtime.handle_voice_tool
          ~config
@@ -535,8 +545,17 @@ let test_keeper_voice_agent_reports_turn_based_capability () =
     let before = read_agent () in
     check string "conversation mode" "turn_based"
       Yojson.Safe.Util.(member "conversation_mode" before |> to_string);
+    check string "transport mode" "batch_stt_tts"
+      Yojson.Safe.Util.(member "transport_mode" before |> to_string);
     check bool "realtime unsupported" false
       Yojson.Safe.Util.(member "realtime_supported" before |> to_bool);
+    let before_loop = Yojson.Safe.Util.member "voice_loop" before in
+    check string "loop input route" "POST /api/v1/voice/transcribe"
+      Yojson.Safe.Util.(
+        member "operator_input" before_loop |> member "server_route" |> to_string);
+    check string "loop output route" "GET /api/v1/voice/audio/<token>"
+      Yojson.Safe.Util.(
+        member "keeper_output" before_loop |> member "browser_route" |> to_string);
     check bool "no active session" false
       Yojson.Safe.Util.(member "session_active" before |> to_bool);
     check bool "active_session is null" true
@@ -553,6 +572,12 @@ let test_keeper_voice_agent_reports_turn_based_capability () =
       Yojson.Safe.Util.(member "session_active" after |> to_bool);
     check string "active session agent" meta.name
       Yojson.Safe.Util.(member "active_session" after |> member "agent_id" |> to_string);
+    check string "active session loop mode" "turn_based_batch"
+      Yojson.Safe.Util.(
+        member "active_session" after
+        |> member "voice_loop"
+        |> member "mode"
+        |> to_string);
     end_session ())
 ;;
 

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -67,6 +67,22 @@ let mkdir_if_missing path =
   if not (Sys.file_exists path) then Unix.mkdir path 0o755
 ;;
 
+let contains_substring ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0 then true
+  else
+    let rec loop idx =
+      idx + needle_len <= haystack_len
+      && (String.sub haystack idx needle_len = needle || loop (idx + 1))
+    in
+    loop 0
+;;
+
+let check_json_omits label needle json =
+  check bool label false (contains_substring ~needle (Yojson.Safe.to_string json))
+;;
+
 let test_resolve_voice_aliases () =
   let elevenlabs = Option.get (Voice.resolve_adapter "elevenlabs") in
   check string "elevenlabs alias" "elevenlabs-direct" elevenlabs.canonical_name;
@@ -686,7 +702,7 @@ let test_keeper_voice_agent_reports_turn_based_capability () =
 ;;
 
 let test_keeper_voice_agent_reports_realtime_bridge_capability () =
-  let bridge_endpoint = "ws://127.0.0.1:9999/voice" in
+  let bridge_endpoint = "wss://token:secret@bridge.example/live?token=abc123" in
   with_env
     Masc.Voice_session_manager.realtime_bridge_env
     (Some bridge_endpoint)
@@ -728,8 +744,10 @@ let test_keeper_voice_agent_reports_realtime_bridge_capability () =
         let realtime_bridge = Yojson.Safe.Util.member "realtime_bridge" before in
         check bool "realtime bridge configured" true
           Yojson.Safe.Util.(member "configured" realtime_bridge |> to_bool);
-        check string "realtime bridge endpoint surfaced" bridge_endpoint
-          Yojson.Safe.Util.(member "endpoint" realtime_bridge |> to_string);
+        check bool "realtime bridge endpoint hidden" true
+          (Yojson.Safe.Util.member "endpoint" realtime_bridge = `Null);
+        check_json_omits "agent capability omits raw endpoint" bridge_endpoint before;
+        check_json_omits "agent capability omits endpoint secret" "secret" before;
         check
           (list string)
           "available realtime conversation modes"
@@ -751,17 +769,25 @@ let test_keeper_voice_agent_reports_realtime_bridge_capability () =
           Yojson.Safe.Util.(member "transport_mode" start_json |> to_string);
         check bool "realtime session supported" true
           Yojson.Safe.Util.(member "realtime_supported" start_json |> to_bool);
-        check string "realtime endpoint persisted" bridge_endpoint
-          Yojson.Safe.Util.(
-            member "realtime_bridge_endpoint" start_json |> to_string);
+        check bool "realtime endpoint not serialized" true
+          (Yojson.Safe.Util.member "realtime_bridge_endpoint" start_json = `Null);
+        check_json_omits "session start omits raw endpoint" bridge_endpoint start_json;
+        check_json_omits "session start omits endpoint secret" "secret" start_json;
         let voice_loop = Yojson.Safe.Util.member "voice_loop" start_json in
         check string "realtime loop mode" "realtime_bridge"
           Yojson.Safe.Util.(member "mode" voice_loop |> to_string);
         check string "realtime protocol" "masc.voice.realtime_bridge.v1"
           Yojson.Safe.Util.(member "protocol" voice_loop |> to_string);
-        check string "realtime loop bridge endpoint" bridge_endpoint
-          Yojson.Safe.Util.(member "bridge_endpoint" voice_loop |> to_string);
+        check bool "realtime loop bridge endpoint hidden" true
+          (Yojson.Safe.Util.member "bridge_endpoint" voice_loop = `Null);
+        let loop_bridge = Yojson.Safe.Util.member "realtime_bridge" voice_loop in
+        check bool "realtime loop bridge configured" true
+          Yojson.Safe.Util.(member "configured" loop_bridge |> to_bool);
+        check bool "realtime loop bridge endpoint hidden" true
+          (Yojson.Safe.Util.member "endpoint" loop_bridge = `Null);
         let after = read_agent () in
+        check_json_omits "active agent omits raw endpoint" bridge_endpoint after;
+        check_json_omits "active agent omits endpoint secret" "secret" after;
         check string "active realtime conversation mode" "realtime_bridge"
           Yojson.Safe.Util.(member "conversation_mode" after |> to_string);
         check string "active realtime session mode" "realtime_bridge"

--- a/test/test_voice_runtime_overlay.ml
+++ b/test/test_voice_runtime_overlay.ml
@@ -477,6 +477,43 @@ let test_keeper_voice_session_start_does_not_store_session_name_as_voice () =
          ()))
 ;;
 
+let test_voice_realtime_bridge_endpoint_validation () =
+  let getenv_missing _ = None in
+  check
+    (option string)
+    "missing bridge endpoint"
+    None
+    (Masc.Voice_session_manager.realtime_bridge_endpoint ~getenv:getenv_missing ());
+  let getenv_blank _ = Some "   " in
+  check
+    (option string)
+    "blank bridge endpoint"
+    None
+    (Masc.Voice_session_manager.realtime_bridge_endpoint ~getenv:getenv_blank ());
+  let getenv_http _ = Some "https://voice.example.test/ws" in
+  check
+    (option string)
+    "http bridge endpoint rejected"
+    None
+    (Masc.Voice_session_manager.realtime_bridge_endpoint ~getenv:getenv_http ());
+  let getenv_ws _ = Some " ws://127.0.0.1:9999/voice " in
+  check
+    (option string)
+    "ws bridge endpoint accepted"
+    (Some "ws://127.0.0.1:9999/voice")
+    (Masc.Voice_session_manager.realtime_bridge_endpoint ~getenv:getenv_ws ());
+  let getenv_wss _ = Some "wss://voice.example.test/live" in
+  check
+    (option string)
+    "wss bridge endpoint accepted"
+    (Some "wss://voice.example.test/live")
+    (Masc.Voice_session_manager.realtime_bridge_endpoint ~getenv:getenv_wss ())
+;;
+
+let json_string_list json =
+  Yojson.Safe.Util.to_list json |> List.map Yojson.Safe.Util.to_string
+;;
+
 let test_keeper_voice_session_end_reports_ended () =
   Eio_main.run
   @@ fun env ->
@@ -512,7 +549,61 @@ let test_keeper_voice_session_end_reports_ended () =
       (Yojson.Safe.Util.member "discarded_voice_queue_jobs" end_json = `Null))
 ;;
 
+let test_keeper_voice_session_start_realtime_requires_bridge_env () =
+  with_env Masc.Voice_session_manager.realtime_bridge_env None (fun () ->
+    Eio_main.run
+    @@ fun env ->
+    Eio.Switch.run
+    @@ fun sw ->
+    let net = Eio.Stdenv.net env in
+    let clock = Eio.Stdenv.clock env in
+    let mono_clock = Eio.Stdenv.mono_clock env in
+    Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+      let config = test_config () in
+      let meta = make_keeper_meta "voice-realtime-missing-bridge" in
+      ignore
+        (Masc.Keeper_tool_voice_runtime.handle_voice_tool
+           ~config
+           ~meta
+           ~name:"keeper_voice_session_end"
+           ~args:(`Assoc [])
+           ());
+      let raw =
+        Masc.Keeper_tool_voice_runtime.handle_voice_tool
+          ~config
+          ~meta
+          ~name:"keeper_voice_session_start"
+          ~args:(`Assoc [ "conversation_mode", `String "realtime_bridge" ])
+          ()
+      in
+      let json = Yojson.Safe.from_string raw in
+      check
+        string
+        "realtime start rejected"
+        "voice_realtime_bridge_unavailable"
+        Yojson.Safe.Util.(member "error" json |> to_string);
+      check
+        string
+        "bridge env surfaced"
+        Masc.Voice_session_manager.realtime_bridge_env
+        Yojson.Safe.Util.(member "required_env" json |> to_string);
+      check string "fallback mode surfaced" "turn_based"
+        Yojson.Safe.Util.(member "fallback_conversation_mode" json |> to_string);
+      let agent_raw =
+        Masc.Keeper_tool_voice_runtime.handle_voice_tool
+          ~config
+          ~meta
+          ~name:"keeper_voice_agent"
+          ~args:(`Assoc [])
+          ()
+      in
+      let agent_json = Yojson.Safe.from_string agent_raw in
+      check bool "rejected realtime start does not create session" false
+        Yojson.Safe.Util.(member "session_active" agent_json |> to_bool)))
+;;
+
 let test_keeper_voice_agent_reports_turn_based_capability () =
+  with_env Masc.Voice_session_manager.realtime_bridge_env None (fun () ->
   Eio_main.run
   @@ fun env ->
   Eio.Switch.run
@@ -549,6 +640,19 @@ let test_keeper_voice_agent_reports_turn_based_capability () =
       Yojson.Safe.Util.(member "transport_mode" before |> to_string);
     check bool "realtime unsupported" false
       Yojson.Safe.Util.(member "realtime_supported" before |> to_bool);
+    let realtime_bridge = Yojson.Safe.Util.member "realtime_bridge" before in
+    check bool "realtime bridge unconfigured" false
+      Yojson.Safe.Util.(member "configured" realtime_bridge |> to_bool);
+    check
+      string
+      "realtime bridge env surfaced"
+      Masc.Voice_session_manager.realtime_bridge_env
+      Yojson.Safe.Util.(member "required_env" realtime_bridge |> to_string);
+    check bool "realtime bridge endpoint absent" true
+      (Yojson.Safe.Util.member "endpoint" realtime_bridge = `Null);
+    check (list string) "available conversation modes" [ "turn_based" ]
+      Yojson.Safe.Util.(
+        member "available_conversation_modes" before |> json_string_list);
     let before_loop = Yojson.Safe.Util.member "voice_loop" before in
     check string "loop input route" "POST /api/v1/voice/transcribe"
       Yojson.Safe.Util.(
@@ -578,7 +682,100 @@ let test_keeper_voice_agent_reports_turn_based_capability () =
         |> member "voice_loop"
         |> member "mode"
         |> to_string);
-    end_session ())
+    end_session ()))
+;;
+
+let test_keeper_voice_agent_reports_realtime_bridge_capability () =
+  let bridge_endpoint = "ws://127.0.0.1:9999/voice" in
+  with_env
+    Masc.Voice_session_manager.realtime_bridge_env
+    (Some bridge_endpoint)
+    (fun () ->
+      Eio_main.run
+      @@ fun env ->
+      Eio.Switch.run
+      @@ fun sw ->
+      let net = Eio.Stdenv.net env in
+      let clock = Eio.Stdenv.clock env in
+      let mono_clock = Eio.Stdenv.mono_clock env in
+      Eio_context.with_test_env ~net ~clock ~mono_clock ~sw (fun () ->
+        let config = test_config () in
+        let meta = make_keeper_meta "voice-realtime-bridge-keeper" in
+        let read_agent () =
+          Masc.Keeper_tool_voice_runtime.handle_voice_tool
+            ~config
+            ~meta
+            ~name:"keeper_voice_agent"
+            ~args:(`Assoc [])
+            ()
+          |> Yojson.Safe.from_string
+        in
+        let end_session () =
+          ignore
+            (Masc.Keeper_tool_voice_runtime.handle_voice_tool
+               ~config
+               ~meta
+               ~name:"keeper_voice_session_end"
+               ~args:(`Assoc [])
+               ())
+        in
+        end_session ();
+        let before = read_agent () in
+        check string "default conversation mode" "turn_based"
+          Yojson.Safe.Util.(member "conversation_mode" before |> to_string);
+        check bool "realtime bridge makes realtime available" true
+          Yojson.Safe.Util.(member "realtime_supported" before |> to_bool);
+        let realtime_bridge = Yojson.Safe.Util.member "realtime_bridge" before in
+        check bool "realtime bridge configured" true
+          Yojson.Safe.Util.(member "configured" realtime_bridge |> to_bool);
+        check string "realtime bridge endpoint surfaced" bridge_endpoint
+          Yojson.Safe.Util.(member "endpoint" realtime_bridge |> to_string);
+        check
+          (list string)
+          "available realtime conversation modes"
+          [ "turn_based"; "realtime_bridge" ]
+          Yojson.Safe.Util.(
+            member "available_conversation_modes" before |> json_string_list);
+        let start_raw =
+          Masc.Keeper_tool_voice_runtime.handle_voice_tool
+            ~config
+            ~meta
+            ~name:"keeper_voice_session_start"
+            ~args:(`Assoc [ "conversation_mode", `String "realtime_bridge" ])
+            ()
+        in
+        let start_json = Yojson.Safe.from_string start_raw in
+        check string "realtime session mode" "realtime_bridge"
+          Yojson.Safe.Util.(member "conversation_mode" start_json |> to_string);
+        check string "realtime transport" "websocket_audio_bridge"
+          Yojson.Safe.Util.(member "transport_mode" start_json |> to_string);
+        check bool "realtime session supported" true
+          Yojson.Safe.Util.(member "realtime_supported" start_json |> to_bool);
+        check string "realtime endpoint persisted" bridge_endpoint
+          Yojson.Safe.Util.(
+            member "realtime_bridge_endpoint" start_json |> to_string);
+        let voice_loop = Yojson.Safe.Util.member "voice_loop" start_json in
+        check string "realtime loop mode" "realtime_bridge"
+          Yojson.Safe.Util.(member "mode" voice_loop |> to_string);
+        check string "realtime protocol" "masc.voice.realtime_bridge.v1"
+          Yojson.Safe.Util.(member "protocol" voice_loop |> to_string);
+        check string "realtime loop bridge endpoint" bridge_endpoint
+          Yojson.Safe.Util.(member "bridge_endpoint" voice_loop |> to_string);
+        let after = read_agent () in
+        check string "active realtime conversation mode" "realtime_bridge"
+          Yojson.Safe.Util.(member "conversation_mode" after |> to_string);
+        check string "active realtime session mode" "realtime_bridge"
+          Yojson.Safe.Util.(
+            member "active_session" after
+            |> member "conversation_mode"
+            |> to_string);
+        check string "active realtime loop mode" "realtime_bridge"
+          Yojson.Safe.Util.(
+            member "active_session" after
+            |> member "voice_loop"
+            |> member "mode"
+            |> to_string);
+        end_session ()))
 ;;
 
 let test_playback_timeout_parsers_and_budget () =
@@ -739,13 +936,25 @@ let () =
             `Quick
             test_keeper_voice_session_start_does_not_store_session_name_as_voice
         ; test_case
+            "realtime bridge endpoint validation"
+            `Quick
+            test_voice_realtime_bridge_endpoint_validation
+        ; test_case
             "session_end reports ended without queue field"
             `Quick
             test_keeper_voice_session_end_reports_ended
         ; test_case
+            "realtime session start requires bridge env"
+            `Quick
+            test_keeper_voice_session_start_realtime_requires_bridge_env
+        ; test_case
             "voice_agent reports turn-based capability"
             `Quick
             test_keeper_voice_agent_reports_turn_based_capability
+        ; test_case
+            "voice_agent reports realtime bridge capability"
+            `Quick
+            test_keeper_voice_agent_reports_realtime_bridge_capability
         ] )
     ; ( "playback_timeout"
       , [ test_case


### PR DESCRIPTION
## Summary
- expose a structured `voice_loop` contract in voice session JSON and `keeper_voice_agent`
- add an env-gated `realtime_bridge` conversation mode for voice sessions via `MASC_VOICE_REALTIME_WS_URL`
- make `keeper_voice_session_start conversation_mode=realtime_bridge` fail closed when no realtime bridge is configured, instead of pretending a duplex stream exists
- align voice tool descriptions with the new mode contract: default `turn_based` batch STT/TTS, optional bridge-backed realtime transport

## Validation
- `ocamlformat --check lib/voice/voice_session_manager.mli lib/voice/voice_session_manager.ml lib/keeper/keeper_tool_voice_runtime.ml lib/tool_surface/tool_shard_types_schemas_voice.ml test/test_voice_runtime_overlay.ml`
- `git diff --check`
- `ocamlc -stop-after parsing lib/voice/voice_session_manager.mli`
- `ocamlc -stop-after parsing lib/voice/voice_session_manager.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_tool_voice_runtime.ml`
- `ocamlc -stop-after parsing lib/tool_surface/tool_shard_types_schemas_voice.ml`
- `ocamlc -stop-after parsing test/test_voice_runtime_overlay.ml`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_voice_runtime_overlay.exe`
- `./_build/default/test/test_voice_runtime_overlay.exe`
