### PR TITLE
test(dashboard): keeper-memory-health 컴포넌트 커버리지 추가

### DIFF
--- a/dashboard/src/components/memory/keeper-memory-health.test.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { cleanup, render, screen, waitFor } from '@testing-library/preact'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  KeeperMemoryHealthKeeperEntry,
+  KeeperMemoryHealthResponse,
+} from '../../api/dashboard'
+
+// ── Mock API ──────────────────────────────────────────
+// KeeperMemoryHealth fetches via fetchKeeperMemoryHealth() inside useEffect.
+// Mocking the module lets us drive every render branch without a real HTTP call.
+
+const mockFetch = vi.fn<() => Promise<KeeperMemoryHealthResponse>>()
+
+vi.mock('../../api/dashboard', () => ({
+  fetchKeeperMemoryHealth: () => mockFetch(),
+}))
+
+// ── Import after mocks ────────────────────────────────
+
+import { KeeperMemoryHealth } from './keeper-memory-health'
+
+function makeEntry(
+  overrides: Partial<KeeperMemoryHealthKeeperEntry> = {},
+): KeeperMemoryHealthKeeperEntry {
+  return {
+    keeper_id: 'alpha',
+    facts: 10,
+    facts_bytes: 512,
+    events: 20,
+    events_bytes: 1024,
+    events_to_facts_ratio: 2,
+    ttl_expired_on_disk: 0,
+    near_duplicate: 0,
+    external_ref: 0,
+    ...overrides,
+  }
+}
+
+function makeResponse(
+  keepers: KeeperMemoryHealthKeeperEntry[],
+  totalsOverrides: Partial<KeeperMemoryHealthResponse['totals']> = {},
+): KeeperMemoryHealthResponse {
+  return {
+    generated_at: 1_700_000_000,
+    cadence_counter_entries: 3,
+    keepers,
+    totals: {
+      facts: 0,
+      facts_bytes: 0,
+      events_bytes: 0,
+      ttl_expired_on_disk: 0,
+      near_duplicate: 0,
+      ...totalsOverrides,
+    },
+  }
+}
+
+describe('KeeperMemoryHealth', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+  afterEach(() => cleanup())
+
+  // ── formatBytes (exercised via the totals strip) ──────
+  // formatBytes is module-private; assert it through rendered output:
+  //   < 1024            → "<n> B"
+  //   < 1024*1024       → "(n/1024).toFixed(1) KB"
+  //   otherwise         → "(n/1024/1024).toFixed(2) MB"
+  describe('formatBytes (via totals strip)', () => {
+    it('renders bytes under 1 KiB with a B suffix', async () => {
+      mockFetch.mockResolvedValue(makeResponse([], { facts_bytes: 512 }))
+      render(html`<${KeeperMemoryHealth} />`)
+      await waitFor(() => expect(screen.getByText('512 B')).not.toBeNull())
+    })
+
+    it('renders kibibyte-range values with one decimal and a KB suffix', async () => {
+      // 1536 / 1024 = 1.5
+      mockFetch.mockResolvedValue(makeResponse([], { facts_bytes: 1536 }))
+      render(html`<${KeeperMemoryHealth} />`)
+      await waitFor(() => expect(screen.getByText('1.5 KB')).not.toBeNull())
+    })
+
+    it('renders mebibyte-range values with two decimals and a MB suffix', async () => {
+      // 5 * 1024 * 1024 = 5242880 → "5.00 MB"
+      mockFetch.mockResolvedValue(makeResponse([], { events_bytes: 5_242_880 }))
+      render(html`<${KeeperMemoryHealth} />`)
+      await waitFor(() => expect(screen.getByText('5.00 MB')).not.toBeNull())
+    })
+  })
+
+  // ── isRowWarning boundary (via row class + ratio badge) ──
+  // Component operator is strict greater-than against threshold 2:
+  //   ratio === 2 → NOT a warning
+  //   ratio  > 2 → warning
+  describe('isRowWarning ratio boundary (threshold is > 2)', () => {
+    it('does not flag a row when the ratio equals the threshold (2)', async () => {
+      mockFetch.mockResolvedValue(
+        makeResponse([
+          makeEntry({ keeper_id: 'at-threshold', events_to_facts_ratio: 2, ttl_expired_on_disk: 0 }),
+        ]),
+      )
+      const { container } = render(html`<${KeeperMemoryHealth} />`)
+      await waitFor(() => expect(screen.getByText('at-threshold')).not.toBeNull())
+
+      expect(container.querySelector('.kmh-row--warn')).toBeNull()
+      // The ratio cell renders 2.00 inside a plain span, not a warn badge.
+      expect(container.querySelector('.kmh-badge--warn')).toBeNull()
+      expect(screen.getByText('2.00')).not.toBeNull()
+    })
+
+    it('flags a row when the ratio exceeds the threshold', async () => {
+      mockFetch.mockResolvedValue(
+        makeResponse([
+          makeEntry({ keeper_id: 'over-threshold', events_to_facts_ratio: 3, ttl_expired_on_disk: 0 }),
+        ]),
+      )
+      const { container } = render(html`<${KeeperMemoryHealth} />`)
+      await waitFor(() => expect(screen.getByText('over-threshold')).not.toBeNull())
+
+      expect(container.querySelector('.kmh-row--warn')).not.toBeNull()
+      // The ratio cell is wrapped in a warn badge showing 3.00.
+      const warnBadge = container.querySelector('.kmh-badge--warn')
+      expect(warnBadge).not.toBeNull()
+      expect(warnBadge!.textContent).toBe('3.00')
+    })
+
+    it('flags a row on ttl_expired_on_disk even when the ratio is at the threshold', async () => {
+      // isRowWarning is an OR: ratio>2 OR ttl_expired_on_disk>0.
+      mockFetch.mockResolvedValue(
+        makeResponse([
+          makeEntry({ keeper_id: 'ttl-expired', events_to_facts_ratio: 2, ttl_expired_on_disk: 4 }),
+        ]),
+      )
+      const { container } = render(html`<${KeeperMemoryHealth} />`)
+      await waitFor(() => expect(screen.getByText('ttl-expired')).not.toBeNull())
+
+      expect(container.querySelector('.kmh-row--warn')).not.toBeNull()
+    })
+  })
+
+  // ── render states ─────────────────────────────────────
+  describe('render states', () => {
+    it('shows the loading state before the fetch resolves', () => {
+      // Never-resolving promise keeps the component in its initial loading branch.
+      mockFetch.mockReturnValue(new Promise<KeeperMemoryHealthResponse>(() => {}))
+      render(html`<${KeeperMemoryHealth} />`)
+      expect(screen.getByText('로딩중...')).not.toBeNull()
+    })
+
+    it('shows the error state when the fetch rejects', async () => {
+      mockFetch.mockRejectedValue(new Error('boom'))
+      render(html`<${KeeperMemoryHealth} />`)
+      await waitFor(() => expect(screen.getByText('데이터 로드 실패: boom')).not.toBeNull())
+    })
+
+    it('shows the empty-keepers message when the response has no keepers', async () => {
+      mockFetch.mockResolvedValue(makeResponse([]))
+      render(html`<${KeeperMemoryHealth} />`)
+      await waitFor(() => expect(screen.getByText('등록된 키퍼 팩트 스토어 없음.')).not.toBeNull())
+    })
+
+    it('renders one table row per keeper with its id', async () => {
+      mockFetch.mockResolvedValue(
+        makeResponse([
+          makeEntry({ keeper_id: 'alpha' }),
+          makeEntry({ keeper_id: 'beta' }),
+        ]),
+      )
+      const { container } = render(html`<${KeeperMemoryHealth} />`)
+      await waitFor(() => expect(screen.getByText('alpha')).not.toBeNull())
+
+      const rows = container.querySelectorAll('tbody tr')
+      expect(rows.length).toBe(2)
+      expect(screen.getByText('beta')).not.toBeNull()
+      // The cadence counter total surfaces in the header strip.
+      expect(screen.getByText('키퍼 메모리 상태')).not.toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
프론트 전용 Draft. 테스트만 추가(컴포넌트 무변경). RFC-gated 영역 아님.

## 무엇을 / 왜

#21790이 `keeper-memory-health.ts`(185줄: `formatBytes`, `EVENTS_TO_FACTS_RATIO_WARN_THRESHOLD` 기반 `isRowWarning`, loading/error/empty/data 렌더 상태)를 **컴포넌트 테스트 없이** 머지해, lab-component 테스트 관습(sibling `memory-explore`는 `memory-explore.test.ts` 보유)이 깨졌다.

배경: 적대 리뷰 스윕에서 발견. 테스트는 fix worktree에 작성됐으나 #21790이 이미 squash-merge돼, `workflow-pr.md` #10(머지된 소스 브랜치 post-merge push 금지, masc#5303)에 따라 **main 기준 신규 PR**로 랜딩한다. 백엔드 metric 테스트(#21820, OCaml)와는 다른 레이어라 상보적.

## 변경 (`keeper-memory-health.test.ts` +182)

`verification-requests-panel.test.ts` 관용구를 따름: `fetchKeeperMemoryHealth` mock, happy-dom + `@testing-library/preact` 렌더, async fetch `waitFor`.

커버리지 10 tests:
- `formatBytes` B/KB/MB 분기
- `isRowWarning` 비율 경계 — 연산자가 strict `>` 임계 2임을 검증(ratio==2는 warn 안 함, ratio>2는 warn) + `ttl_expired_on_disk` OR 분기
- loading / error / empty / data 렌더 상태

컴포넌트는 수정하지 않음 — 실 버그 없음(경계 동작 정상).

## 검증

`npx vitest run keeper-memory-health.test.ts` → 10 passed. `npx tsc --noEmit` → exit 0. `npx eslint` → clean. (main의 컴포넌트 blob과 byte-identical 기준으로 작성, CI Dashboard job 재검증)