### PR TITLE
docs(rfc): RFC-0259 P5/P6 — Memory OS GC/cap-TTL + producer idempotency (C/E/F)

### DIFF
--- a/docs/rfc/RFC-0259-memory-os-volatile-claim-grounding-retraction-decay.md
+++ b/docs/rfc/RFC-0259-memory-os-volatile-claim-grounding-retraction-decay.md
@@ -2,9 +2,11 @@
 
 **Status**: Draft
 **Date**: 2026-06-19
-**Verified against base main**: `99d3716b72`
+**Verified against base main**: `99d3716b72` (P1–P4; the 2026-06-21 amendment re-verified §3.6/§3.7 against `c68c7d6500`)
 **Builds on**: [RFC-0247](./RFC-0247-memory-os-associative-graph-forgetting-brain.md) (purge of the composite score; "a fact's value is the librarian's judgment, not a number"), [RFC-0244](./RFC-0244-memory-os-tiered-stores.md) (tiered fact stores)
 **Supersedes intent of**: PR #21363 `feat(memory-os): stale decay mechanism with TTL-based GC` — **CLOSED, not merged** (`gh pr view 21363` → `state: CLOSED, mergedAt: null`). The fleet currently runs with no decay/grounding/retraction at all; this RFC re-states that need with a typed boundary instead of a flat TTL.
+
+**Amendment (2026-06-21, base main `c68c7d6500`)**: P1–P4 landed (#21644 P1, #21665 P2, #21668 P3, #21718 P4). This revision adds **P5 — GC activation + cap TTL-awareness** (§3.6) and **P6 — producer idempotency & anchor stability** (§3.7) from the 2026-06-20 Memory OS adversarial audit (`reports/masc-memory-os-leak-stuck-audit-20260620-1614.html`, Issue #21789, defects C/E/F). The audit's resource-leak findings (cadence table, write-path fd) were fixed at the source in PR #21787 and are out of scope here. Defect D (events/episodes unbounded append) is routed to RFC-0247 (forgetting charter) as a future amendment, tracked in Issue #21789 — deferred here because amending RFC-0247's `## §1`-style body would activate a pre-existing `rfc-enforcer` gap (R5 caller-context is unsatisfiable for `docs/rfc` in CI). All file:line references in §3.6/§3.7 re-verified against `c68c7d6500`.
 
 ## 1. Summary
 
@@ -60,7 +62,7 @@ PR #21363 (a flat TTL decay) tried to address #4 and was closed. This RFC narrow
 | Re-check PR/issue #X against truth | **external** (`gh`/GitHub API) | reconciler fiber |
 | Confirmed/contradicted decision from the diff | deterministic | reconciler |
 | Time-bound claim with no external referent | deterministic (TTL) | `category_valid_until` |
-| Which claim a new observation supersedes | LLM judgment | librarian (new schema field) |
+| Which claim a new observation supersedes | LLM judgment | librarian (shipped as the re-observe UPSERT, not a schema field; see §3.7) |
 | Recall suppression of unverified-volatile-past-horizon | deterministic | recall |
 
 The new boundary statement: **a claim that names verifiable external state must be grounded deterministically — the system can and must run the check itself.** Leaving it to the LLM (which only sees stale history) or to never-verify is what produced the bug.
@@ -92,6 +94,8 @@ for each keeper, for each fact with external_ref = Some r and (now - last_verifi
 
 ### 3.4 Retraction (P3)
 
+> **Superseded by §3.7:** the `supersedes : string list` episode field described below was never implemented; P3 shipped the in-place `merge_and_cap_facts` / `reobserve_fact` UPSERT (keyed on exact `normalize_claim`) instead. The original design is retained here for intent. P6 (§3.7) extends that shipped UPSERT.
+
 A single-claim removal under the facts lock (P3 must use the lock that PR #21529 added to GC). Note the two removal callers key differently and both must be supported by the same removal primitive:
 
 - **Reconciler** retracts on `Contradicted`, keyed on the fact's `external_ref` identity (it already holds the specific fact it re-checked).
@@ -101,6 +105,44 @@ A single-claim removal under the facts lock (P3 must use the lock that PR #21529
 
 A volatile claim that is past its `grounding_horizon` and unconfirmed is **suppressed** from the recall block (not merely annotated), or at minimum demoted below durable claims and rendered with a hard "UNVERIFIED — do not act without re-checking" prefix. This closes gap #5: the prompt stops asserting stale volatile truths.
 
+### 3.6 GC activation + cap TTL-awareness (P5)
+
+**Scope: disk-hygiene + retention-path determinism — no prompt-behavior change.** Recall already filters expired rows at read time (P4 / `fact_is_current`), so this phase does not change what a keeper sees; it stops expired rows accumulating on disk and makes the cap and the GC agree on what `valid_until` means. P5 must not be cited later as license for a read-side or symptom-suppression cap.
+
+P1 closed gap #4 at the type level — an `external_ref` claim now carries a finite `valid_until`. But **expiry only takes effect on disk through one path that is off by default**, and the always-on hot-path cap ignores `valid_until` entirely. So in a store below the cap threshold, an expired volatile row persists on disk indefinitely.
+
+Verified on `c68c7d6500`:
+
+- The sole disk path that drops a fact on `valid_until` expiry is `run_gc` (`keeper_memory_os_gc.ml:24-28` `ttl_expired`, partitioned at `:118-120`). A fleet-wide `rg` finds no other `now > valid_until` drop in `lib/`.
+- That GC fiber is **default-OFF** behind `MASC_KEEPER_MEMORY_OS_GC ~default:false` (`server_bootstrap_maintenance.ml:140-144`, "mirrors the consolidation gate").
+- The hot-path cap (`cap_facts` `keeper_memory_os_io.ml:510-531`, `merge_and_cap_facts:584+`) fires only when the store exceeds `fact_store_max = 384` (`fact_recall_window 256 + 128`, `io.ml:474/484`) and then sorts by `retention_rank` (`keeper_memory_os_policy.ml:29-38`). `retention_rank` takes `~now` but uses it **only to pick a tier** (durable `1.0e15` vs non-durable `0.0`, keyed on `external_ref`/`category_valid_until` being `Some`); it never tests whether *this* fact's `valid_until` has already passed.
+
+Net: a < 384-row store with GC off keeps expired rows on disk indefinitely (audit: `mad-improver` had 140/140 expired-`valid_until` rows, all 348 rows still present).
+
+**Boundary.** This is a **disk leak, not a prompt leak**: recall already filters expired rows at read time (`fact_is_current`, `keeper_memory_os_recall.ml:264`, predicate `keeper_memory_os_types.ml:267-271`), so a stale row never reaches the prompt. The fix is disk hygiene plus making the two retention paths agree.
+
+**Design — two deterministic gaps closed, not a new janitor:**
+
+1. **Dry-run-gated GC default flip.** A fleet-wide dry-run logs what each keeper's GC would prune; after review, `MASC_KEEPER_MEMORY_OS_GC` defaults ON. Same rollout discipline as the P2 reconciler and the consolidation fiber — the env knob and dry-run already exist.
+2. **Cap honors the typed `valid_until`.** The hot-path cap drops `valid_until < now` rows **before** ranking, via a pure helper (`partition_expired ~now`, reusing `gc.ml`'s `ttl_expired`) applied at the cap entry. Expiry then no longer depends solely on the 600s sweep being enabled; cap and GC enforce the *same* typed boundary.
+
+**Anti-workaround.** "Add a TTL prune janitor" is the cap/prune-as-fix signature and is rejected. The existing bound (`fact_store_max`) is unchanged; P5 only (a) turns on the existing GC behind its existing gate and (b) removes a determinism gap where the cap and the GC disagree about what `valid_until` means. No new cap, cooldown, or symptom counter.
+
+### 3.7 Producer idempotency & anchor stability (P6)
+
+**Correction to §3.4.** §3.4 described a librarian episode field `supersedes : string list`. That field was never implemented (the only `supersedes` *record field* in the tree is the unrelated `operator_judgment.ml:23`; the substring also appears in some function names/comments). The dedup that P3 actually shipped is the in-place **UPSERT**: `merge_and_cap_facts ~merge:(reobserve_fact ~now)` (`keeper_librarian_runtime.ml:554-560`), keyed on **exact `normalize_claim`** (`merge_episode_facts` `keeper_memory_os_io.ml:548-574`; `normalize_claim` SSOT `keeper_memory_os_types.ml:382-398`; `reobserve_fact` `keeper_memory_os_policy.ml:56-63`). P6 extends **that** mechanism. E and F share one root: the librarian re-extracts the same self-narrative every cycle with micro-rewording, so the producer is not idempotent.
+
+**E — semantic-dup re-mint bypasses exact dedup.** `normalize_claim` only lowercases, collapses whitespace, and trims. A reworded variant survives normalization with a *different* key, so `merge_episode_facts` takes the append branch and writes a new row (audit: one "All verification work complete: PR #21249" claim re-minted as 15–23 micro-variants).
+
+- **Fix (producer identity, not post-hoc dedup):** give the librarian episode a **stable claim identity** anchored to the referent (e.g. `external_ref` + claim-kind, or a producer-assigned stable claim-id), so an unchanged re-extraction UPSERTs the existing row instead of appending. This reuses the **existing** typed producer `external_ref_of_claim` (`keeper_memory_os_types.ml:131-205`) — a keyword-anchored tokenizer yielding a closed `{ Pr | Issue | Task; id }` sum with a deliberately conservative bar (bare `#123` → `None`) — so identity is a typed key, **not** a new substring/embedding classifier. This fixes *why the same claim is re-minted as a new row every cycle*.
+- **Anti-workaround (the trap):** adding fuzzy / semantic / embedding dedup is a **double signature violation** (string-classifier + dedup) under the CLAUDE.md bar and is **rejected** — it suppresses the 15–23-copy symptom and trains the fleet to treat clustering as the fix. RFC-0247 §3 already rejects read-side dedup; the root is producer identity.
+
+**F — re-mint freshness reset (anchor mutability).** When E's exact-key miss appends, the new row lands with `first_seen = now` (every producer stamps it: `keeper_librarian.ml:231`, `keeper_librarian_runtime.ml:435`) and `fact_valid_until` recomputes the 24 h volatile TTL from write-time `now` (`keeper_memory_os_types.ml:235-239`, `volatile_external_ttl_seconds = 86_400` at `:228`). `is_unverified_volatile` anchors on `last_verified_at` else `first_seen` (`keeper_memory_os_recall.ml:109-118`), so a reworded stale status claim re-enters with both the 24 h TTL **and** the 12 h grounding horizon (`default_grounding_horizon_seconds = ttl / 2 = 43_200`, `keeper_memory_os_reconcile.ml:38`) reset — no `UNVERIFIED` prefix (audit: `sangsu` #21363, 3/5 rows < 12 h).
+
+- **Fix (anchor immutability):** on re-observe of a stable-identity claim, **inherit** the prior row's `first_seen` (and `last_verified_at`) rather than stamping fresh — decay anchors to *first* observation, not latest mint. Depends on E's identity work.
+- **This amends the shipped P3, it is not additive.** The merged `reobserve_fact` (`keeper_memory_os_policy.ml:56-63`) currently does the opposite for the `external_ref` branch: on *every* producer re-observe it sets `valid_until = Some (now +. volatile_external_ttl_seconds)` and advances `last_verified_at = now`, with the comment asserting "re-observing IS re-verification." P6/F **reverses that rule for volatile claims**: the volatile-TTL / `last_verified_at` refresh moves off the producer merge path, and a stable-identity re-observe inherits the prior row's `first_seen`, `valid_until`, and `last_verified_at`. The producer no longer counts as re-verification.
+- **Edge that must be distinguished:** a legitimate reconciler re-verification (`Stale_open` verdict, `keeper_memory_os_reconcile.ml:128`) advances `last_verified_at` and *should* reset the horizon — the claim was actually re-checked against GitHub. A producer rewording must not. The rule: **only the reconciler (external re-verification) advances the anchor; producer re-extraction inherits it.** Conflating the two re-introduces F (and is precisely the live `reobserve_fact` rule this phase replaces).
+
 ## 4. Verification / harness
 
 Per the project's "good agents come from good harnesses" tenet:
@@ -109,6 +151,8 @@ Per the project's "good agents come from good harnesses" tenet:
 - **Property**: a false volatile claim is removed within K reconciler cycles; a still-true claim is preserved; `Unknown` never deletes; no durable judgment claim is ever dropped by this machinery.
 - **TLA+ (bug model)**: model `StaleVolatileClaim` + invariant `NoUnverifiedVolatileClaimSurvivesBeyondHorizon`; clean spec satisfies it, a `NeverReconcile` bug action violates it (mutation-testing pattern already used for `KeeperOASAdvanced.tla`).
 - **Live dry-run**: reconciler in dry-run logs what it *would* retract across the fleet before the gate is enabled (same rollout discipline as GC/consolidation).
+- **P5**: dry-run GC log fixture (mixed `valid_until` store → asserts `ttl_expired`/`written`); pure `partition_expired ~now` / cap-TTL helper test (durable `None` never dropped; expired dropped *before* ranking; expired not retained when fresh rows exist).
+- **P6**: reworded-variant test (two reworded episodes → one row once identity is stable); pure anchor test (same-identity re-observe preserves `first_seen`; reconciler-confirm advances `last_verified_at`; producer-rewording does not); TLA bug action `ReMintResetsAnchor` violates `NoUnverifiedVolatileClaimSurvivesBeyondHorizon`.
 
 ## 5. Tradeoffs & alternatives
 
@@ -122,6 +166,8 @@ Per the project's "good agents come from good harnesses" tenet:
 - Does not re-introduce the composite importance score (RFC-0247 stays).
 - Does not ground free-text judgment claims with no external referent — those keep relying on librarian judgment + (new) volatile TTL.
 - Does not change the durable-fact path for non-volatile knowledge.
+- Does **not** add post-hoc fuzzy/semantic/embedding dedup. Defect E is fixed at the producer's claim identity (P6), never by read-side clustering — that would be the string-classifier + dedup workaround signature.
+- Does **not** bound events/episodes append (defect D). That general retention concern is routed to RFC-0247 (forgetting charter) as a future amendment (tracked in Issue #21789), to be gated by the RFC-0228 recall@depth harness.
 
 ## 7. Phasing
 
@@ -129,7 +175,9 @@ Per the project's "good agents come from good harnesses" tenet:
 |---|---|---|
 | P1 | `external_ref` classification + volatile `valid_until` (decay even without reconciler) | typed, compile-time exhaustive |
 | P2 | reconciler fiber w/ injected `verify_external`, default-OFF + dry-run | live dry-run log reviewed |
-| P3 | retraction path (reconciler + librarian `supersedes`) under the facts lock | property + TLA tests green |
+| P3 | retraction path (reconciler + librarian re-observe upsert — shipped as the `merge_and_cap_facts`/`reobserve_fact` UPSERT, not the `supersedes` field this RFC originally described; see §3.7) under the facts lock | property + TLA tests green |
 | P4 | recall suppression/demotion of unverified-volatile | recall tests pin suppression |
+| P5 | GC default flip (dry-run-gated) + hot-path cap drops `valid_until < now` before ranking (defect C) — **disk-hygiene + retention-path determinism only, no prompt-behavior change** | dry-run log reviewed; pure-helper unit + property: durable never dropped, expired ≤ horizon removed |
+| P6 | producer idempotency: stable-identity upsert (E) + anchor inheritance on re-mint, reconciler-only horizon advance (F) | reworded→1-row test; `first_seen`-preservation unit; TLA `ReMintResetsAnchor` violates invariant |
 
-P1 alone closes root-cause gap #4 (immortal volatile facts) at the type level and is shippable independently.
+P1 alone closes root-cause gap #4 (immortal volatile facts) at the type level and is shippable independently. P5 is independent and shippable alone; within P6, the stable-identity work (E) precedes anchor inheritance (F).


### PR DESCRIPTION
## Summary

RFC-only amendment to **RFC-0259**, routing three of the four **semantic-change** defects from the 2026-06-20 Memory OS adversarial audit (Issue #21789) into typed phases. No code — design first, per the memory-subsystem RFC-first rule. The audit's two **resource-leak** defects were already fixed at the source in PR #21787 (merged).

Adds:
- **P5 — GC activation + cap TTL-awareness** (defect C). Disk-hygiene + retention-path determinism only (no prompt-behavior change; recall already filters expired rows). Turns on the existing dry-run-gated GC and makes the hot-path cap honor the same typed `valid_until` the GC uses.
- **P6 — producer idempotency & anchor stability** (defects E + F). A stable claim identity so an unchanged re-extraction UPSERTs instead of appending (E), and anchor inheritance on re-mint with a reconciler-only horizon advance (F). Explicitly **amends** the shipped `reobserve_fact` "re-observing IS re-verification" rule for volatile claims.
- A correction: §3.4's `supersedes` episode field was never implemented; P3 shipped the `merge_and_cap_facts`/`reobserve_fact` UPSERT keyed on exact `normalize_claim`, which P6 extends. §3.4/§3.1 now carry forward pointers.

## Why RFC, not a direct code PR

Each defect has a workaround trap the RFC explicitly closes, so a code-first fix would risk setting a workaround precedent:

- **E** — fuzzy/semantic/embedding dedup is **rejected** (string-classifier + dedup double signature). Root = producer identity (idempotent extraction reusing the existing typed `external_ref_of_claim`), not post-hoc clustering.
- **C** — a TTL prune janitor is **rejected** (cap-as-fix). Reframed as "cap and GC honor the same typed `valid_until` boundary" — closing a determinism gap, not adding a symptom-suppressor. The existing `fact_store_max` bound is unchanged.
- **F** — anchor immutability with a reconciler-only horizon advance, so a producer rewording cannot silently reset decay.

## Grounding & review

All file:line citations re-verified against current main `c68c7d6500` via a parallel grounding workflow (the issue's baseline `5c295f5e5e` had drifted — line numbers corrected throughout). A three-lens adversarial pass (workaround-signature / citation accuracy / RFC coherence) returned ship-with-fixes on all lenses; every finding is folded in (incl. the #21665 P2 citation correction and the F-vs-`reobserve_fact` consistency note).

## Scope

`docs/rfc/RFC-0259-*.md` only. No code. Each phase's implementation is gated as specified in the phasing table.

**Deferred:** defect D (events/episodes unbounded append) is routed to RFC-0247 (forgetting charter) but **not** amended here — amending RFC-0247's `## §1`-style body would activate a pre-existing `rfc-enforcer` gap (its R5 caller-context companion lives in `.tmp/`, which is gitignored and unreachable in CI; the `docs/rfc` enforcer step lacks the `--no-tmp-check` flag the `docs/design` step has). D's full design is captured in Issue #21789; landing it cleanly needs that workflow-consistency fix first. Issue #21789 stays open to track P5/P6 implementation + D.

RFC-WAIVED: this PR amends an RFC document; it does not modify credential/identity/operator/sandbox/dashboard-credential/hooks/workflow code subsystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
