### PR TITLE
feat(thompson): persist runtime priors

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -213,8 +213,17 @@ let record_runtime_toml_load_failure msg =
        Otel_metric_store.inc_counter
          metric_keeper_runtime_config_load_failures
          ~labels:[ "reason", reason ]
-         ())
+      ())
     reason
+
+let thompson_shutdown_hook_registered = Atomic.make false
+
+let ensure_thompson_persistence ~base_path =
+  Thompson_sampling.set_base_path base_path;
+  Thompson_sampling.load_stats ();
+  if Atomic.compare_and_set thompson_shutdown_hook_registered false true then
+    Shutdown.register ~name:"thompson_sampling_save" ~priority:24 (fun () ->
+      Thompson_sampling.save_stats ())
 
 let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     ?env ()
@@ -249,6 +258,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     Env_config_core.base_path_input_env_key
     (Option.value ~default:"" input_base_path);
   Unix.putenv Env_config_core.base_path_env_key base_path;
+  ensure_thompson_persistence ~base_path;
   bootstrap_base_path_config_root ~base_path;
   (* Apply keeper runtime overrides from the resolved config root's
      runtime.toml. Must run before any module that reads

--- a/lib/thompson/thompson_sampling.ml
+++ b/lib/thompson/thompson_sampling.ml
@@ -256,6 +256,22 @@ let stats_to_json (s : agent_stats) : Yojson.Safe.t =
     ("updated_at", `Float s.updated_at);
   ]
 
+let copy_stats (s : agent_stats) : agent_stats =
+  {
+    name = s.name;
+    alpha = s.alpha;
+    beta = s.beta;
+    selections = s.selections;
+    last_selected_at = s.last_selected_at;
+    total_votes_up = s.total_votes_up;
+    total_votes_down = s.total_votes_down;
+    posts_created = s.posts_created;
+    comments_created = s.comments_created;
+    skips = s.skips;
+    guard_penalties_total = s.guard_penalties_total;
+    updated_at = s.updated_at;
+  }
+
 let stats_of_json (json : Yojson.Safe.t) : agent_stats option =
   let name = Json_util.get_string_with_default json ~key:"name" ~default:"" in
   let alpha = Json_util.get_float json "alpha" |> Option.value ~default:0.0 in
@@ -283,6 +299,19 @@ let stats_of_json (json : Yojson.Safe.t) : agent_stats option =
     guard_penalties_total;
     updated_at;
   }
+
+let apply_vote_counts ~decay (s : agent_stats) ~votes_up ~votes_down =
+  let total = votes_up + votes_down in
+  if total > 0 then begin
+    let success_rate = float_of_int votes_up /. float_of_int total in
+    s.alpha <- (s.alpha -. 1.0) *. decay +. 1.0 +. success_rate;
+    s.beta <- (s.beta -. 1.0) *. decay +. 1.0 +. (1.0 -. success_rate);
+    s.alpha <- Float.max min_prior s.alpha;
+    s.beta <- Float.max min_prior s.beta;
+    s.total_votes_up <- s.total_votes_up + votes_up;
+    s.total_votes_down <- s.total_votes_down + votes_down;
+    s.updated_at <- Time_compat.now ()
+  end
 
 (** {1 Persistence} *)
 
@@ -317,21 +346,47 @@ let load_stats () =
         (Printexc.to_string e)
   end
 
+let stats_snapshot_for_persistence () =
+  let decay = Env_config.AgentSelection.vote_decay_factor in
+  with_ts_ro (fun () ->
+    let by_name =
+      Hashtbl.create (Hashtbl.length stats_table + Hashtbl.length pending_votes)
+    in
+    Hashtbl.iter
+      (fun name stats -> Hashtbl.replace by_name name (copy_stats stats))
+      stats_table;
+    Hashtbl.iter
+      (fun name (votes_up, votes_down) ->
+         if votes_up + votes_down > 0 then begin
+           let stats =
+             match Hashtbl.find_opt by_name name with
+             | Some stats -> stats
+             | None ->
+                 let stats = make_default_stats name in
+                 Hashtbl.replace by_name name stats;
+                 stats
+           in
+           apply_vote_counts ~decay stats ~votes_up ~votes_down
+         end)
+      pending_votes;
+    Hashtbl.fold (fun _ stats acc -> stats :: acc) by_name [])
+
 let save_stats () =
   let path = stats_path () in
   try
-    (* Serialise the table under the lock so a concurrent [record_*]
-       cannot [Hashtbl.replace] mid-iteration and corrupt the
-       iteration. *)
-    let content, count =
-      with_ts_ro (fun () ->
-        let buf = Buffer.create 4096 in
-        Hashtbl.iter (fun _ s ->
-          Buffer.add_string buf (Yojson.Safe.to_string (stats_to_json s));
-          Buffer.add_char buf '\n'
-        ) stats_table;
-        (Buffer.contents buf, Hashtbl.length stats_table))
-    in
+    (* Snapshot under the lock, then serialise the copies outside the
+       critical section. Pending votes are overlaid on the snapshot so a
+       graceful shutdown cannot lose batched feedback that has not reached
+       [flush_pending_votes] yet. *)
+    let snapshot = stats_snapshot_for_persistence () in
+    let buf = Buffer.create 4096 in
+    List.iter
+      (fun stats ->
+         Buffer.add_string buf (Yojson.Safe.to_string (stats_to_json stats));
+         Buffer.add_char buf '\n')
+      snapshot;
+    let content = Buffer.contents buf in
+    let count = List.length snapshot in
     Fs_compat.save_file path content;
     Log.Metrics.debug "thompson sampling saved stats for %d agents" count
   with
@@ -339,6 +394,12 @@ let save_stats () =
   | e ->
     Log.Thompson.error "Error saving stats: %s"
       (Printexc.to_string e)
+
+let persistence_configured () =
+  with_ts_ro (fun () -> Option.is_some !base_path_ref)
+
+let save_stats_if_configured () =
+  if persistence_configured () then save_stats ()
 
 (** {1 Feedback Updates} *)
 
@@ -350,7 +411,8 @@ let record_vote ~agent_name ~direction =
       | `Up -> (up + 1, down)
       | `Down -> (up, down + 1)
     in
-    Hashtbl.replace pending_votes agent_name (up', down'))
+    Hashtbl.replace pending_votes agent_name (up', down'));
+  save_stats_if_configured ()
 
 let flush_pending_votes () =
   (* [ts_mu] is documented as protecting [pending_votes], but this
@@ -376,20 +438,11 @@ let flush_pending_votes () =
     let total = votes_up + votes_down in
     if total > 0 then begin
       let s = get_stats agent_name in
-      let success_rate = float_of_int votes_up /. float_of_int total in
       with_ts_rw (fun () ->
-        (* Apply decay to existing priors, then add new evidence *)
-        s.alpha <- (s.alpha -. 1.0) *. decay +. 1.0 +. success_rate;
-        s.beta <- (s.beta -. 1.0) *. decay +. 1.0 +. (1.0 -. success_rate);
-        (* Clamp to minimum *)
-        s.alpha <- Float.max min_prior s.alpha;
-        s.beta <- Float.max min_prior s.beta;
-        (* Update totals *)
-        s.total_votes_up <- s.total_votes_up + votes_up;
-        s.total_votes_down <- s.total_votes_down + votes_down;
-        s.updated_at <- Time_compat.now ())
+        apply_vote_counts ~decay s ~votes_up ~votes_down)
     end
-  ) snapshot
+  ) snapshot;
+  if snapshot <> [] then save_stats_if_configured ()
 
 (* The record_* helpers below all mutate an [agent_stats] returned by
    [get_stats].  [get_stats] re-acquires [ts_mu] around the lookup, but
@@ -403,7 +456,8 @@ let record_selection ~agent_name =
   with_ts_rw (fun () ->
     s.selections <- s.selections + 1;
     s.last_selected_at <- Time_compat.now ();
-    s.updated_at <- Time_compat.now ())
+    s.updated_at <- Time_compat.now ());
+  save_stats_if_configured ()
 
 let record_action ~agent_name ~action =
   let s = get_stats agent_name in
@@ -412,7 +466,8 @@ let record_action ~agent_name ~action =
      | `Post -> s.posts_created <- s.posts_created + 1
      | `Comment -> s.comments_created <- s.comments_created + 1
      | `Skip -> s.skips <- s.skips + 1);
-    s.updated_at <- Time_compat.now ())
+    s.updated_at <- Time_compat.now ());
+  save_stats_if_configured ()
 
 (** {1 Quality Signal Integration} *)
 
@@ -450,7 +505,8 @@ let record_guard_penalty ~agent_name =
     s.beta <- s.beta +. guard_penalty_beta_nudge;
     s.beta <- Float.max min_prior s.beta;
     s.guard_penalties_total <- s.guard_penalties_total + 1;
-    s.updated_at <- Time_compat.now ())
+    s.updated_at <- Time_compat.now ());
+  save_stats_if_configured ()
 
 (** Record Post Verifier result into Thompson Sampling priors. *)
 let record_quality_signal ~agent_name ~(verdict : quality_verdict) =
@@ -462,7 +518,8 @@ let record_quality_signal ~agent_name ~(verdict : quality_verdict) =
      | Fail _ -> s.beta <- s.beta +. quality_fail_beta_penalty);
     s.alpha <- Float.max min_prior s.alpha;
     s.beta <- Float.max min_prior s.beta;
-    s.updated_at <- Time_compat.now ())
+    s.updated_at <- Time_compat.now ());
+  save_stats_if_configured ()
 
 (** {1 Selection Algorithm} *)
 

--- a/lib/thompson/thompson_sampling.ml
+++ b/lib/thompson/thompson_sampling.ml
@@ -75,9 +75,21 @@ let ts_mu = Eio.Mutex.create ()
 let with_ts_rw f = Eio_guard.with_mutex ts_mu f
 let with_ts_ro f = Eio_guard.with_mutex_ro ts_mu f
 
+let clear_in_memory_stats_unlocked () =
+  Hashtbl.clear stats_table;
+  Hashtbl.clear pending_votes
+;;
+
 (** Set base path for stats storage. Call during server init. *)
 let set_base_path path =
-  with_ts_rw (fun () -> base_path_ref := Some path)
+  with_ts_rw (fun () ->
+    let changed =
+      match !base_path_ref with
+      | Some current -> not (String.equal current path)
+      | None -> true
+    in
+    if changed then clear_in_memory_stats_unlocked ();
+    base_path_ref := Some path)
 
 (** Stats file path — uses cluster base_path, not execution directory *)
 let stats_path () =
@@ -320,6 +332,13 @@ let apply_vote_counts ~decay (s : agent_stats) ~votes_up ~votes_down =
 
 (** {1 Persistence} *)
 
+let replace_stats_snapshot parsed =
+  with_ts_rw (fun () ->
+    clear_in_memory_stats_unlocked ();
+    List.iter (fun s -> Hashtbl.replace stats_table s.name s) parsed;
+    Hashtbl.length stats_table)
+;;
+
 let load_stats () =
   let path = stats_path () in
   if Fs_compat.file_exists path then begin
@@ -345,9 +364,7 @@ let load_stats () =
         ) entries
       in
       let count =
-        with_ts_rw (fun () ->
-          List.iter (fun s -> Hashtbl.replace stats_table s.name s) parsed;
-          Hashtbl.length stats_table)
+        replace_stats_snapshot parsed
       in
       Log.Metrics.debug "thompson sampling loaded stats for %d agents" count
     with
@@ -355,6 +372,9 @@ let load_stats () =
     | e ->
       Log.Thompson.error "Error loading stats: %s"
         (Printexc.to_string e)
+  end else begin
+    let count = replace_stats_snapshot [] in
+    Log.Metrics.debug "thompson sampling loaded stats for %d agents" count
   end
 
 let stats_snapshot_for_persistence () =

--- a/lib/thompson/thompson_sampling.ml
+++ b/lib/thompson/thompson_sampling.ml
@@ -278,9 +278,9 @@ let stats_of_json (json : Yojson.Safe.t) : agent_stats option =
   let name = Json_util.get_string_with_default json ~key:"name" ~default:"" in
   if String.equal (String.trim name) "" then
     None
-  else
-  let alpha = Json_util.get_float json "alpha" |> Option.value ~default:0.0 in
-  let beta = Json_util.get_float json "beta" |> Option.value ~default:0.0 in
+  else match Json_util.get_float json "alpha", Json_util.get_float json "beta" with
+  | None, _ | _, None -> None
+  | Some alpha, Some beta ->
   let selections = Json_util.get_int json "selections" |> Option.value ~default:0 in
   let last_selected_at = Json_util.get_float json "last_selected_at" |> Option.value ~default:0.0 in
   let total_votes_up = Json_util.get_int json "total_votes_up" |> Option.value ~default:0 in
@@ -324,7 +324,13 @@ let load_stats () =
   let path = stats_path () in
   if Fs_compat.file_exists path then begin
     try
-      let entries = Fs_compat.load_jsonl path in
+      (* Boot-safe: malformed JSONL rows are dropped with diagnostics by
+         Fs_compat; any remaining I/O/schema exception is logged below and does
+         not abort server startup. *)
+      let entries, malformed = Fs_compat.load_jsonl_diagnostics path in
+      if malformed > 0 then
+        Log.Thompson.warn "Dropped %d malformed stats line(s) from %s"
+          malformed path;
       (* Parse outside the lock — [stats_of_json] is pure and avoids
          holding [ts_mu] across per-line work — then install the whole
          batch under one critical section. *)

--- a/lib/thompson/thompson_sampling.ml
+++ b/lib/thompson/thompson_sampling.ml
@@ -257,6 +257,8 @@ let stats_to_json (s : agent_stats) : Yojson.Safe.t =
   ]
 
 let copy_stats (s : agent_stats) : agent_stats =
+  (* Deep-copy safe: [agent_stats] stores only immutable primitive fields, no
+     nested refs/containers that could alias the live table. *)
   {
     name = s.name;
     alpha = s.alpha;
@@ -274,6 +276,9 @@ let copy_stats (s : agent_stats) : agent_stats =
 
 let stats_of_json (json : Yojson.Safe.t) : agent_stats option =
   let name = Json_util.get_string_with_default json ~key:"name" ~default:"" in
+  if String.equal (String.trim name) "" then
+    None
+  else
   let alpha = Json_util.get_float json "alpha" |> Option.value ~default:0.0 in
   let beta = Json_util.get_float json "beta" |> Option.value ~default:0.0 in
   let selections = Json_util.get_int json "selections" |> Option.value ~default:0 in

--- a/lib/thompson/thompson_sampling.ml
+++ b/lib/thompson/thompson_sampling.ml
@@ -387,8 +387,11 @@ let save_stats () =
       snapshot;
     let content = Buffer.contents buf in
     let count = List.length snapshot in
-    Fs_compat.save_file path content;
-    Log.Metrics.debug "thompson sampling saved stats for %d agents" count
+    match Fs_compat.save_file_atomic path content with
+    | Ok () ->
+        Log.Metrics.debug "thompson sampling saved stats for %d agents" count
+    | Error msg ->
+        Log.Thompson.error "Error saving stats: %s" msg
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | e ->

--- a/test/test_thompson_sampling.ml
+++ b/test/test_thompson_sampling.ml
@@ -9,6 +9,21 @@ open Masc
    identical behavior — the inversion changed plumbing, not the algorithm. *)
 let is_healthy = Health.is_healthy
 
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+
 (** {1 Beta Distribution Sampling Tests} *)
 
 let test_sample_beta_range () =
@@ -364,6 +379,53 @@ let test_selection_entropy_empty () =
   (* With some agents having selections, entropy should be positive *)
   check bool "entropy is non-negative" true (entropy >= 0.0)
 
+(** {1 Persistence Tests} *)
+
+let find_stats_row name rows =
+  let open Yojson.Safe.Util in
+  List.find_opt
+    (fun json -> json |> member "name" |> to_string = name)
+    rows
+
+let test_persistence_loads_and_saves_pending_votes () =
+  with_temp_dir "thompson-persistence" @@ fun base_path ->
+  let masc_dir = Workspace_utils.masc_dir_from_base_path ~base_path in
+  Fs_compat.mkdir_p masc_dir;
+  let path = Filename.concat masc_dir "autonomy_stats.jsonl" in
+  let loaded_agent = "persist-load-agent" in
+  let pending_agent = "persist-pending-agent" in
+  let existing =
+    `Assoc
+      [
+        ("name", `String loaded_agent);
+        ("alpha", `Float 3.0);
+        ("beta", `Float 2.0);
+        ("selections", `Int 7);
+        ("last_selected_at", `Float 10.0);
+        ("total_votes_up", `Int 4);
+        ("total_votes_down", `Int 1);
+        ("posts_created", `Int 2);
+        ("comments_created", `Int 3);
+        ("skips", `Int 1);
+        ("guard_penalties_total", `Int 0);
+        ("updated_at", `Float 11.0);
+      ]
+  in
+  Fs_compat.save_file path (Yojson.Safe.to_string existing ^ "\n");
+  Thompson_sampling.set_base_path base_path;
+  Thompson_sampling.load_stats ();
+  let loaded = Thompson_sampling.get_stats loaded_agent in
+  check (float 0.01) "loaded alpha" 3.0 loaded.alpha;
+  check int "loaded selections" 7 loaded.selections;
+  Thompson_sampling.record_vote ~agent_name:pending_agent ~direction:`Up;
+  let rows = Fs_compat.load_jsonl path in
+  match find_stats_row pending_agent rows with
+  | Some json ->
+      let open Yojson.Safe.Util in
+      check int "pending vote persisted" 1
+        (json |> member "total_votes_up" |> to_int)
+  | None -> fail "pending vote row not persisted"
+
 (** {1 Test Runner} *)
 
 let () =
@@ -413,5 +475,9 @@ let () =
     ];
     "monitoring", [
       test_case "selection entropy" `Quick test_selection_entropy_empty;
+    ];
+    "persistence", [
+      test_case "load stats and save pending votes" `Quick
+        test_persistence_loads_and_saves_pending_votes;
     ];
   ]

--- a/test/test_thompson_sampling.ml
+++ b/test/test_thompson_sampling.ml
@@ -457,11 +457,20 @@ let test_persistence_load_skips_corrupt_and_nameless_rows () =
         ("selections", `Int 99);
       ]
   in
+  let schema_mismatch =
+    `Assoc
+      [
+        ("name", `String "persist-schema-mismatch");
+        ("score", `Float 99.0);
+        ("selections", `Int 99);
+      ]
+  in
   Fs_compat.save_file path
     (String.concat "\n"
        [
          "{not-json";
          Yojson.Safe.to_string nameless;
+         Yojson.Safe.to_string schema_mismatch;
          Yojson.Safe.to_string valid;
          "";
        ]);
@@ -474,7 +483,13 @@ let test_persistence_load_skips_corrupt_and_nameless_rows () =
     Thompson_sampling.get_all_stats ()
     |> List.exists (fun (s : Thompson_sampling.agent_stats) -> String.equal s.name "")
   in
-  check bool "nameless schema row skipped" false has_empty_name
+  check bool "nameless schema row skipped" false has_empty_name;
+  let loaded_names =
+    Thompson_sampling.get_all_stats ()
+    |> List.map (fun (s : Thompson_sampling.agent_stats) -> s.name)
+  in
+  check bool "schema mismatch row skipped" false
+    (List.mem "persist-schema-mismatch" loaded_names)
 
 (** {1 Test Runner} *)
 

--- a/test/test_thompson_sampling.ml
+++ b/test/test_thompson_sampling.ml
@@ -387,11 +387,17 @@ let find_stats_row name rows =
     (fun json -> json |> member "name" |> to_string = name)
     rows
 
-let test_persistence_loads_and_saves_pending_votes () =
-  with_temp_dir "thompson-persistence" @@ fun base_path ->
+let stats_path_for_base_path base_path =
   let masc_dir = Workspace_utils.masc_dir_from_base_path ~base_path in
   Fs_compat.mkdir_p masc_dir;
-  let path = Filename.concat masc_dir "autonomy_stats.jsonl" in
+  Filename.concat masc_dir "autonomy_stats.jsonl"
+
+let stats_rows path =
+  if Fs_compat.file_exists path then Fs_compat.load_jsonl path else []
+
+let test_persistence_loads_and_saves_pending_votes () =
+  with_temp_dir "thompson-persistence" @@ fun base_path ->
+  let path = stats_path_for_base_path base_path in
   let loaded_agent = "persist-load-agent" in
   let pending_agent = "persist-pending-agent" in
   let existing =
@@ -428,9 +434,7 @@ let test_persistence_loads_and_saves_pending_votes () =
 
 let test_persistence_load_skips_corrupt_and_nameless_rows () =
   with_temp_dir "thompson-corrupt-persistence" @@ fun base_path ->
-  let masc_dir = Workspace_utils.masc_dir_from_base_path ~base_path in
-  Fs_compat.mkdir_p masc_dir;
-  let path = Filename.concat masc_dir "autonomy_stats.jsonl" in
+  let path = stats_path_for_base_path base_path in
   let valid_agent = "persist-valid-after-corrupt" in
   let valid =
     `Assoc
@@ -491,6 +495,56 @@ let test_persistence_load_skips_corrupt_and_nameless_rows () =
   check bool "schema mismatch row skipped" false
     (List.mem "persist-schema-mismatch" loaded_names)
 
+let test_persistence_base_path_switch_replaces_state () =
+  with_temp_dir "thompson-persistence-a" @@ fun base_a ->
+  with_temp_dir "thompson-persistence-b" @@ fun base_b ->
+  let path_a = stats_path_for_base_path base_a in
+  let path_b = stats_path_for_base_path base_b in
+  let agent_a = "persist-base-a-agent" in
+  let pending_a = "persist-base-a-pending" in
+  let agent_b = "persist-base-b-agent" in
+  let existing_a =
+    `Assoc
+      [
+        ("name", `String agent_a);
+        ("alpha", `Float 5.0);
+        ("beta", `Float 1.0);
+        ("selections", `Int 3);
+        ("last_selected_at", `Float 20.0);
+        ("total_votes_up", `Int 2);
+        ("total_votes_down", `Int 0);
+        ("posts_created", `Int 0);
+        ("comments_created", `Int 0);
+        ("skips", `Int 0);
+        ("guard_penalties_total", `Int 0);
+        ("updated_at", `Float 21.0);
+      ]
+  in
+  Fs_compat.save_file path_a (Yojson.Safe.to_string existing_a ^ "\n");
+  Thompson_sampling.set_base_path base_a;
+  Thompson_sampling.load_stats ();
+  check bool "base A row loaded" true
+    (Option.is_some (find_stats_row agent_a (stats_rows path_a)));
+  Thompson_sampling.record_vote ~agent_name:pending_a ~direction:`Up;
+  Thompson_sampling.set_base_path base_b;
+  Thompson_sampling.load_stats ();
+  let loaded_names =
+    Thompson_sampling.get_all_stats ()
+    |> List.map (fun (s : Thompson_sampling.agent_stats) -> s.name)
+  in
+  check bool "base A loaded row cleared after switching base" false
+    (List.mem agent_a loaded_names);
+  check bool "base A pending row cleared after switching base" false
+    (List.mem pending_a loaded_names);
+  Thompson_sampling.record_selection ~agent_name:agent_b;
+  let rows_b = stats_rows path_b in
+  check bool "base B file contains only B row" true
+    (Option.is_some (find_stats_row agent_b rows_b));
+  check bool "base B file does not inherit A loaded row" false
+    (Option.is_some (find_stats_row agent_a rows_b));
+  check bool "base B file does not inherit A pending row" false
+    (Option.is_some (find_stats_row pending_a rows_b))
+
 (** {1 Test Runner} *)
 
 let () =
@@ -546,5 +600,7 @@ let () =
         test_persistence_loads_and_saves_pending_votes;
       test_case "load skips corrupt and nameless rows" `Quick
         test_persistence_load_skips_corrupt_and_nameless_rows;
+      test_case "base path switch replaces loaded state" `Quick
+        test_persistence_base_path_switch_replaces_state;
     ];
   ]

--- a/test/test_thompson_sampling.ml
+++ b/test/test_thompson_sampling.ml
@@ -426,6 +426,56 @@ let test_persistence_loads_and_saves_pending_votes () =
         (json |> member "total_votes_up" |> to_int)
   | None -> fail "pending vote row not persisted"
 
+let test_persistence_load_skips_corrupt_and_nameless_rows () =
+  with_temp_dir "thompson-corrupt-persistence" @@ fun base_path ->
+  let masc_dir = Workspace_utils.masc_dir_from_base_path ~base_path in
+  Fs_compat.mkdir_p masc_dir;
+  let path = Filename.concat masc_dir "autonomy_stats.jsonl" in
+  let valid_agent = "persist-valid-after-corrupt" in
+  let valid =
+    `Assoc
+      [
+        ("name", `String valid_agent);
+        ("alpha", `Float 4.0);
+        ("beta", `Float 1.5);
+        ("selections", `Int 9);
+        ("last_selected_at", `Float 12.0);
+        ("total_votes_up", `Int 5);
+        ("total_votes_down", `Int 2);
+        ("posts_created", `Int 1);
+        ("comments_created", `Int 0);
+        ("skips", `Int 0);
+        ("guard_penalties_total", `Int 0);
+        ("updated_at", `Float 13.0);
+      ]
+  in
+  let nameless =
+    `Assoc
+      [
+        ("alpha", `Float 99.0);
+        ("beta", `Float 99.0);
+        ("selections", `Int 99);
+      ]
+  in
+  Fs_compat.save_file path
+    (String.concat "\n"
+       [
+         "{not-json";
+         Yojson.Safe.to_string nameless;
+         Yojson.Safe.to_string valid;
+         "";
+       ]);
+  Thompson_sampling.set_base_path base_path;
+  Thompson_sampling.load_stats ();
+  let loaded = Thompson_sampling.get_stats valid_agent in
+  check (float 0.01) "valid row loaded despite corrupt file prefix" 4.0 loaded.alpha;
+  check int "valid row selections loaded" 9 loaded.selections;
+  let has_empty_name =
+    Thompson_sampling.get_all_stats ()
+    |> List.exists (fun (s : Thompson_sampling.agent_stats) -> String.equal s.name "")
+  in
+  check bool "nameless schema row skipped" false has_empty_name
+
 (** {1 Test Runner} *)
 
 let () =
@@ -479,5 +529,7 @@ let () =
     "persistence", [
       test_case "load stats and save pending votes" `Quick
         test_persistence_loads_and_saves_pending_votes;
+      test_case "load skips corrupt and nameless rows" `Quick
+        test_persistence_load_skips_corrupt_and_nameless_rows;
     ];
   ]


### PR DESCRIPTION
Summary
- load Thompson priors from <base>/.masc/autonomy_stats.jsonl during server state creation after base-path normalization
- set the Thompson base path at runtime and register a single shutdown save hook
- make runtime Thompson feedback persist when base path is configured, including pending votes overlaid into saved snapshots
- keep load_stats boot-safe: malformed JSONL is logged/dropped, schema-mismatched rows without alpha/beta are skipped, and I/O/schema exceptions are logged without aborting startup
- add persistence regression tests for loading stats, saving pending votes, corrupt JSONL, and schema-mismatched rows

Validation
- ocamlformat --check lib/thompson/thompson_sampling.ml lib/server/server_runtime_bootstrap.ml test/test_thompson_sampling.ml
- git diff --check
- ocamlc -stop-after parsing lib/thompson/thompson_sampling.ml
- ocamlc -stop-after parsing lib/server/server_runtime_bootstrap.ml
- ocamlc -stop-after parsing test/test_thompson_sampling.ml
- attempted env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_thompson_sampling.exe; stopped after >90s with no compiler output, leaving full compile/test to CI per operator preference

Notes
- Earlier focused Dune attempts were blocked by local Dune/opam locks; this PR relies on GitHub CI for full OCaml build/test proof.
