### PR TITLE
fix(dashboard): suppress duplicate SurfaceLead title on own-header surfaces

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -88,7 +88,7 @@ describe('shouldRenderSurfaceLead', () => {
     },
   )
 
-  it.each(['monitoring', 'command', 'lab'] as const)(
+  it.each(['monitoring', 'command', 'lab', 'board'] as const)(
     'keeps the generic lead for %s (surface has no own header)',
     (tab) => {
       expect(shouldRenderSurfaceLead({ tab, params: {}, postId: null })).toBe(true)

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -81,13 +81,19 @@ describe('shouldRenderSurfaceLead', () => {
     })).toBe(false)
   })
 
-  it('keeps the generic lead for ordinary sectioned surfaces', () => {
-    expect(shouldRenderSurfaceLead({
-      tab: 'workspace',
-      params: { section: 'work' },
-      postId: null,
-    })).toBe(true)
-  })
+  it.each(['overview', 'approvals', 'fusion', 'workspace', 'logs', 'cockpit', 'settings'] as const)(
+    'suppresses the generic lead for %s (surface renders its own bespoke header)',
+    (tab) => {
+      expect(shouldRenderSurfaceLead({ tab, params: {}, postId: null })).toBe(false)
+    },
+  )
+
+  it.each(['monitoring', 'command', 'lab'] as const)(
+    'keeps the generic lead for %s (surface has no own header)',
+    (tab) => {
+      expect(shouldRenderSurfaceLead({ tab, params: {}, postId: null })).toBe(true)
+    },
+  )
 })
 
 describe('summarizeAttentionPreview', () => {

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1424,7 +1424,7 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
 // them — otherwise the screen shows a duplicate title: the generic <h2> nav
 // label stacked over the surface's own <h1>. When a surface component renders
 // its own top-of-body header, add its TabId here (keep this in sync with the
-// route registry). Verified against the v2 design audit (2026-06-21): the
+// route registry). Verified against the v2 design audit (2026-06-20): the
 // design gives every surface a single bespoke header plus a slim top-bar crumb,
 // with no generic lead.
 //

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1419,10 +1419,36 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
     && routeState.params.keeper.trim() !== ''
 }
 
-// Surfaces that render their own primary header and therefore do not need the
-// generic dashboard section lead above them. Keep this in sync with the route
-// registry; currently only the Connectors prototype surface uses its own header.
-const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set(['connectors'])
+// Surfaces that render their own primary header (a bespoke per-surface title
+// block) and therefore must NOT get the generic dashboard SurfaceLead above
+// them — otherwise the screen shows a duplicate title: the generic <h2> nav
+// label stacked over the surface's own <h1>. When a surface component renders
+// its own top-of-body header, add its TabId here (keep this in sync with the
+// route registry). Verified against the v2 design audit (2026-06-21): the
+// design gives every surface a single bespoke header plus a slim top-bar crumb,
+// with no generic lead.
+//
+//   overview   → overview/overview.ts  <header class="ov-head">      <h1>운영 개요</h1>
+//   approvals  → approvals-surface.ts  <header class="ov-head">      <h1>승인 · HITL 큐</h1>
+//   fusion     → fusion-surface.ts     <header class="ov-head fus-head"> <h1>Fusion</h1>
+//   workspace  → work.ts               <header class="wk-head">      <h1>작업 · 목표</h1>
+//   logs       → logs.ts               <header class="v2-logs-head">  <h1>이벤트 로그</h1>
+//   cockpit    → cockpit/cockpit.ts    <header class="cp-head">      <h1>Cockpit</h1>
+//   settings   → settings-surface.ts   <header class="set-content-h"> <h1>…</h1>
+//   connectors → connector-status.ts   (prototype surface, own header)
+//
+// Surfaces WITHOUT their own header (monitoring, command, lab, board) keep the
+// generic SurfaceLead, which supplies their title.
+const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set([
+  'overview',
+  'approvals',
+  'fusion',
+  'workspace',
+  'logs',
+  'cockpit',
+  'settings',
+  'connectors',
+])
 
 export function shouldRenderSurfaceLead(routeState: RouteState): boolean {
   if (isKeeperDetailDashboardRoute(routeState)) return false


### PR DESCRIPTION
## 목표

대시보드 surface의 중복 제목을 제거한다. 자체 bespoke 헤더를 그리는 surface가 generic `SurfaceLead`(nav 라벨 `<h2>` + 설명 + copy/solo 액션)를 위에 또 받아, 화면에 제목이 두 번 쌓였다. 예: `overview`는 SurfaceLead "Overview" 블록 위에 + 자체 `ov-head` "운영 개요"(`<h1>`) = 이중 제목 (라벨 언어까지 다름).

## 변경

`dashboard-shell.ts`의 `SURFACE_OWN_LEAD_IDS`에 자체 헤더 보유 surface 7종 추가 — `overview, approvals, fusion, workspace, logs, cockpit, settings` (기존 `connectors` 유지). `shouldRenderSurfaceLead`가 이들에 대해 `false`를 반환 → generic SurfaceLead 미렌더 → surface 고유 헤더 하나만 표시. 전역 헤더 칩(crumb)은 유지.

`connectors` 선례와 동일한 메커니즘. 워크어라운드가 아니라 기존 불변식("자체 헤더 보유 surface는 lead 제외")의 누락을 메우는 root fix.

## 근거 (v2 시안 대조)

2026-06-21 v2 디자인 적대 감사(surface별 병렬 audit + skeptic refute 검증). 시안은 surface마다 단일 bespoke 헤더 + 전역 얇은 top-bar crumb만 두고 generic lead가 없다.

| surface | 자체 헤더 | 판정 |
|---|---|---|
| overview / approvals / fusion / workspace / logs / cockpit / settings | `ov-head`/`wk-head`/`v2-logs-head`/`cp-head`/`set-content-h` + `<h1>` | lead 제외 (이 PR) |
| monitoring / command / lab | 없음 (dispatcher) | lead 유지 |
| board | `bd-feed-head` `<h2>` (피드+필터, 경계) | 이번 범위 제외 |

approvals/fusion/workspace/logs는 audit의 독립 skeptic이 refuted=false로 이중헤더 확정. overview/cockpit/settings는 소스 직접 검증.

## 검증 (로컬)

- vitest `dashboard-shell.test.ts`: 41 passed (제외 7종 + 유지 3종 `it.each` 추가)
- `tsc --noEmit`: 0 errors
- eslint `src/components/dashboard-shell.ts`: clean

## 경계 / 범위 밖

- UI 전용. credential / operator control / sandbox / dashboard credential component / hooks / workflow docs 미변경 → RFC 게이트 대상 아님.
- 전역 헤더(`v2-shell-header`)의 crumb+`<h1>` 중복, board, monitoring/command/lab의 시안 bespoke 헤더 부재(conformance gap)는 의도적으로 범위 밖 — 별도 논의/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
