### PR TITLE
fix(schedule): reject mixed payload and board convenience fields

### DIFF
--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -228,7 +228,10 @@ let generic_payload_from_args args =
 
 let payload_from_args args =
   match Json_util.assoc_member_opt "payload" args with
-  | Some (`Assoc _ as payload) -> Ok payload
+  | Some (`Assoc _ as payload) ->
+    if has_board_convenience_args args
+    then Error "use either payload or board_* convenience fields, not both"
+    else Ok payload
   | Some _ -> Error "payload must be an object envelope"
   | None ->
     if has_board_convenience_args args

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -287,6 +287,39 @@ let test_dispatch_create_rejects_negative_board_ttl () =
   check int "no schedule persisted" 0 (List.length state.schedules)
 ;;
 
+let test_dispatch_create_rejects_payload_mixed_with_board_fields () =
+  with_config
+  @@ fun config ->
+  let args =
+    `Assoc
+      [ "schedule_id", `String "sched-payload-board-mixed"
+      ; "due_at_unix", `Float 200.0
+      ; "risk_class", `String "workspace_write"
+      ; "payload", payload
+      ; "board_content", `String "Daily schedule fired"
+      ; "board_hearth", `String "ops"
+      ; "requested_by_id", `String "operator"
+      ; "scheduled_by_id", `String "scheduler-agent"
+      ]
+  in
+  (match
+     Tool_schedule.dispatch (schedule_ctx config)
+       ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+       ~args
+   with
+   | None -> fail "dispatch returned None"
+   | Some result ->
+     check bool "create rejects payload and board fields" false
+       (Tool_result.is_success result);
+     check (option string) "failure class" (Some "workflow_rejection")
+       (Option.map Tool_result.tool_failure_class_to_string
+          (Tool_result.failure_class result));
+     check string "message" "use either payload or board_* convenience fields, not both"
+       (Tool_result.message result));
+  let state = Schedule_store.read_state config in
+  check int "no schedule persisted" 0 (List.length state.schedules)
+;;
+
 let test_dispatch_create_rejects_board_payload_without_content () =
   with_config
   @@ fun config ->
@@ -602,6 +635,8 @@ let () =
             test_dispatch_create_board_post_convenience_payload
         ; test_case "dispatch create rejects negative board ttl" `Quick
             test_dispatch_create_rejects_negative_board_ttl
+        ; test_case "dispatch create rejects payload mixed with board fields" `Quick
+            test_dispatch_create_rejects_payload_mixed_with_board_fields
         ; test_case "dispatch create rejects board payload without content" `Quick
             test_dispatch_create_rejects_board_payload_without_content
         ; test_case "dispatch create rejects read-only board payload" `Quick


### PR DESCRIPTION
Follow-up to #21806 after review found that explicit `payload` silently wins over `board_*` convenience fields.

What changed:
- Reject `payload` + any `board_*` convenience field as a workflow rejection.
- Add a regression test that the ambiguous request returns `workflow_rejection` and persists no schedule.

Validation:
- `opam exec -- ocamlformat --check lib/tool_schedule.ml test/test_schedule_tool_wiring.ml`
- `git diff --check origin/main...HEAD`
- changed-file path/env/temp-file scan: no hits

Not run:
- `scripts/dune-local.sh build test/test_schedule_tool_wiring.exe` was blocked by an existing bare `dune exec --root ... ./bin/main_eio.exe -- --help` process; I did not override the Dune guard.
