### PR TITLE
fix(goal_store): report partial link cleanup failure

### DIFF
--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -476,12 +476,22 @@ let update_goal config ~goal_id f =
           write_state config next_state;
           Ok updated_goal)
 
+type delete_goal_outcome =
+  | Deleted
+  | Deleted_with_orphaned_links of string
+
+type delete_goal_error =
+  | Unknown_goal of string
+
+let delete_goal_error_to_string = function
+  | Unknown_goal msg -> msg
+
 let delete_goal config ~goal_id =
   let deleted =
     Workspace_utils.with_file_lock config (goals_path config) (fun () ->
       let state = read_state config in
       if not (List.exists (fun goal -> String.equal goal.id goal_id) state.goals) then
-        Error "Goal not found"
+        Error (Unknown_goal "Goal not found")
       else (
         write_state
           config
@@ -500,7 +510,7 @@ let delete_goal config ~goal_id =
        covers every goal/link mutation path. *)
     (try
        Workspace_goal_index.prune_links_for_goal config ~goal_id;
-       Ok ()
+       Ok Deleted
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
@@ -509,11 +519,13 @@ let delete_goal config ~goal_id =
          "goal_store.delete_goal: goal %s removed but goal_task_links prune failed: %s"
          goal_id
          detail;
-       Error
-         (Printf.sprintf
-            "goal deleted but failed to prune goal_task_links for %s: %s"
-            goal_id
-            detail))
+       let warning =
+         Printf.sprintf
+           "goal deleted but failed to prune goal_task_links for %s: %s"
+           goal_id
+           detail
+       in
+       Ok (Deleted_with_orphaned_links warning))
 
 let sort_goals goals =
   let horizon_rank = function

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -494,8 +494,26 @@ let delete_goal config ~goal_id =
   match deleted with
   | Error _ as error -> error
   | Ok () ->
-    Workspace_goal_index.prune_links_for_goal config ~goal_id;
-    Ok ()
+    (* This is best-effort cascade cleanup across two file stores, not a
+       cross-file transaction. A structural fix would either co-locate
+       goal-task links with goals or add a higher-level transaction lock that
+       covers every goal/link mutation path. *)
+    (try
+       Workspace_goal_index.prune_links_for_goal config ~goal_id;
+       Ok ()
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       let detail = Printexc.to_string exn in
+       Log.Misc.warn
+         "goal_store.delete_goal: goal %s removed but goal_task_links prune failed: %s"
+         goal_id
+         detail;
+       Error
+         (Printf.sprintf
+            "goal deleted but failed to prune goal_task_links for %s: %s"
+            goal_id
+            detail))
 
 let sort_goals goals =
   let horizon_rank = function

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -203,7 +203,9 @@ val update_goal :
 val delete_goal :
   Workspace_utils.config -> goal_id:string -> (unit, string) result
 (** Removes the goal whose [.id] matches.  Errors when the
-    id is unknown. *)
+    id is unknown.  Goal-task link cleanup is best-effort across
+    separate files; a cleanup failure returns [Error] after the goal
+    delete has already been committed. *)
 
 (** {1 List + upsert} *)
 

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -200,11 +200,24 @@ val update_goal :
     (with [updated_at] pre-stamped), normalises the result,
     and writes back.  Errors when the [goal_id] is unknown. *)
 
+type delete_goal_outcome =
+  | Deleted
+  | Deleted_with_orphaned_links of string
+
+type delete_goal_error =
+  | Unknown_goal of string
+
+val delete_goal_error_to_string : delete_goal_error -> string
+
 val delete_goal :
-  Workspace_utils.config -> goal_id:string -> (unit, string) result
-(** Removes the goal whose [.id] matches.  Errors when the
-    id is unknown.  Goal-task link cleanup is best-effort across
-    separate files; a cleanup failure returns [Error] after the goal
+  Workspace_utils.config ->
+  goal_id:string ->
+  (delete_goal_outcome, delete_goal_error) result
+(** Removes the goal whose [.id] matches.
+
+    Returns [Error (Unknown_goal _)] when the id is unknown and no delete was
+    committed. Goal-task link cleanup is best-effort across separate files; a
+    cleanup failure returns [Ok (Deleted_with_orphaned_links _)] after the goal
     delete has already been committed. *)
 
 (** {1 List + upsert} *)

--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -41,6 +41,15 @@ let respond_ok ~request reqd =
   Http.Response.json_value ~compress:true ~request (`Assoc [ ("ok", `Bool true) ]) reqd
 ;;
 
+let respond_ok_with_warning ~request reqd warning =
+  Http.Response.json_value
+    ~compress:true
+    ~request
+    (`Assoc
+      [ ("ok", `Bool true); ("partial_cleanup", `Bool true); ("warning", `String warning) ])
+    reqd
+;;
+
 let respond_error ?(status = `Bad_request) ~request reqd message =
   Http.Response.json_value ~status ~request
     (`Assoc [ ("ok", `Bool false); ("error", `String message) ])
@@ -418,9 +427,12 @@ let add_delete_action_routes router =
              | Some goal_id ->
              let config = (Mcp_server.workspace_config state) in
              match Goal_store.delete_goal config ~goal_id with
-             | Ok () -> respond_ok ~request:req reqd
-             | Error msg ->
-                 respond_error ~status:`Not_found ~request:req reqd msg
+             | Ok Goal_store.Deleted -> respond_ok ~request:req reqd
+             | Ok (Goal_store.Deleted_with_orphaned_links warning) ->
+                 respond_ok_with_warning ~request:req reqd warning
+             | Error err ->
+                 respond_error ~status:`Not_found ~request:req reqd
+                   (Goal_store.delete_goal_error_to_string err)
            with Yojson.Json_error _ ->
              respond_error ~request:req reqd (invalid_request "goal_id")
          )

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -57,8 +57,10 @@ let test_delete_goal_bumps_version () =
   let v_before = (Goal_store.read_state config).version in
   check int "initial version" 10 v_before;
   (match Goal_store.delete_goal config ~goal_id:"g-1" with
-   | Ok () -> ()
-   | Error e -> fail ("delete_goal failed: " ^ e));
+   | Ok Goal_store.Deleted -> ()
+   | Ok (Goal_store.Deleted_with_orphaned_links msg) ->
+     fail ("unexpected partial cleanup failure: " ^ msg)
+   | Error e -> fail ("delete_goal failed: " ^ Goal_store.delete_goal_error_to_string e));
   let v_after = (Goal_store.read_state config).version in
   check int "version bumped by 1" (v_before + 1) v_after
 
@@ -84,8 +86,8 @@ let test_delete_nonexistent_does_not_bump () =
     { version = 42; updated_at = iso_now (); goals = [g] };
   let v_before = (Goal_store.read_state config).version in
   (match Goal_store.delete_goal config ~goal_id:"ghost" with
-   | Error _ -> ()
-   | Ok () -> fail "expected error for missing goal");
+   | Error (Goal_store.Unknown_goal _) -> ()
+   | Ok _ -> fail "expected error for missing goal");
   let v_after = (Goal_store.read_state config).version in
   check int "version unchanged on error" v_before v_after
 
@@ -111,8 +113,10 @@ let test_delete_goal_prunes_goal_task_links () =
     config
     [ "g-1", [ "task-a"; "task-b" ]; "g-2", [ "task-c" ] ];
   (match Goal_store.delete_goal config ~goal_id:"g-1" with
-   | Ok () -> ()
-   | Error msg -> fail msg);
+   | Ok Goal_store.Deleted -> ()
+   | Ok (Goal_store.Deleted_with_orphaned_links msg) ->
+     fail ("unexpected partial cleanup failure: " ^ msg)
+   | Error msg -> fail (Goal_store.delete_goal_error_to_string msg));
   let links = Workspace_goal_index.read_goal_task_links config in
   check bool
     "deleted goal links removed"
@@ -137,14 +141,13 @@ let test_delete_goal_wraps_prune_failure_after_goal_delete () =
   Sys.remove links_path;
   Unix.mkdir links_path 0o755;
   (match Goal_store.delete_goal config ~goal_id:"g-1" with
-   | Ok () -> fail "expected prune failure to return contextual Error"
-   | Error msg ->
+   | Ok Goal_store.Deleted -> fail "expected prune failure to return partial cleanup"
+   | Ok (Goal_store.Deleted_with_orphaned_links msg) ->
      check bool
-       "error explains partial delete"
+       "partial cleanup carries detail"
        true
-       (String.starts_with
-          ~prefix:"goal deleted but failed to prune goal_task_links for g-1:"
-          msg));
+       (String.length msg > 0)
+   | Error msg -> fail (Goal_store.delete_goal_error_to_string msg));
   let goals = (Goal_store.read_state config).goals in
   check bool
     "goal deletion already committed"

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -126,6 +126,31 @@ let test_delete_goal_prunes_goal_task_links () =
           String.equal goal_id "g-2" && List.mem "task-c" task_ids)
        links)
 
+let test_delete_goal_wraps_prune_failure_after_goal_delete () =
+  with_workspace
+  @@ fun config ->
+  let deleted = make_goal "g-1" "deleted goal" in
+  Goal_store.write_state config
+    { version = 1; updated_at = iso_now (); goals = [ deleted ] };
+  Workspace_goal_index.write_goal_task_links config [ "g-1", [ "task-a" ] ];
+  let links_path = Workspace_goal_index.goal_task_links_path config in
+  Sys.remove links_path;
+  Unix.mkdir links_path 0o755;
+  (match Goal_store.delete_goal config ~goal_id:"g-1" with
+   | Ok () -> fail "expected prune failure to return contextual Error"
+   | Error msg ->
+     check bool
+       "error explains partial delete"
+       true
+       (String.starts_with
+          ~prefix:"goal deleted but failed to prune goal_task_links for g-1:"
+          msg));
+  let goals = (Goal_store.read_state config).goals in
+  check bool
+    "goal deletion already committed"
+    false
+    (List.exists (fun goal -> String.equal goal.Goal_store.id "g-1") goals)
+
 let test_legacy_status_defaults_phase () =
   with_workspace @@ fun config ->
   Workspace.write_json config (Goal_store.goals_path config)
@@ -251,6 +276,8 @@ let () =
             test_updated_at_also_refreshed;
           test_case "delete prunes goal_task_links" `Quick
             test_delete_goal_prunes_goal_task_links;
+          test_case "prune failure reports partial delete" `Quick
+            test_delete_goal_wraps_prune_failure_after_goal_delete;
           test_case "legacy status defaults phase" `Quick
             test_legacy_status_defaults_phase;
           test_case "blocked phase projects legacy status" `Quick


### PR DESCRIPTION
Follow-up to merged #21810.

Addresses the latest adversarial review note that `Goal_store.delete_goal` narrows but does not close the cross-file invariant window between `goals.json` and `goal_task_links.json`.

Changes:
- Documents that goal-task link cleanup is best-effort, not a cross-file transaction, and names the root-fix direction.
- Wraps non-cancellation failures from `Workspace_goal_index.prune_links_for_goal` so callers get a contextual `Error` after the goal delete has already committed instead of an opaque exception.
- Adds a regression test that forces `goal_task_links.json` write failure after goal deletion and asserts the partial-delete error contract.

Validation:
- `git diff --check origin/main...HEAD`
- `opam exec -- ocamlformat --check lib/goal/goal_store.ml lib/goal/goal_store.mli test/test_goal_store.ml`
- `scripts/dune-local.sh build test/test_goal_store.exe` was attempted, but local build is blocked by an existing bare Dune process plus a repo-local Dune lock held by another worktree build.
