### PR TITLE
fix(keeper): cooldown repeated provider 500s

### DIFF
--- a/lib/keeper/keeper_binding_health.ml
+++ b/lib/keeper/keeper_binding_health.ml
@@ -21,6 +21,9 @@ let hard_quota_cooldown_sec = Keeper_binding_health_config.hard_quota_cooldown_s
 let terminal_failure_cooldown_sec =
   Keeper_binding_health_config.terminal_failure_cooldown_sec
 
+let server_error_cooldown_sec =
+  Keeper_binding_health_config.server_error_cooldown_sec
+
 let soft_rate_limit_cooldown_sec =
   Keeper_binding_health_config.soft_rate_limit_cooldown_sec
 
@@ -56,6 +59,10 @@ let cooldown_config_for = Keeper_binding_health_config.cooldown_config_for
    resumable-session conflict is the motivating case: fallback is correct for
    the current call, but repeatedly attempting the same provider first on every
    later call only adds latency and silently degrades runtime diversity. *)
+(* [Server_error] represents upstream HTTP 5xx.  It is usually transient, but
+   OAS has already spent its owned retry/backoff by the time this reaches MASC;
+   a medium immediate cooldown prevents scheduled keeper cycles from paging
+   operators repeatedly on the same unhealthy cloud lane. *)
 (* [Soft_rate_limited] represents a transient HTTP 429 — provider is healthy
    but momentarily over its rate budget.  Distinct from [Failure] so a single
    event triggers an immediate (short) cooldown without waiting for the
@@ -67,6 +74,7 @@ type outcome =
   | Rejected
   | Hard_quota
   | Terminal_failure
+  | Server_error
   | Soft_rate_limited
   | Capacity_backpressure
 
@@ -482,8 +490,27 @@ let record t ~provider_key ~outcome ?error_kind ?error_reason
         state.cooldown_until <- new_until;
         Runtime_metrics.on_provider_cooldown
           ~provider:provider_key ~reason:"terminal_failure";
-        Otel_metric_store.observe_histogram Keeper_metrics.(to_string ProviderBlockDurationSec)
-          ~labels:[("provider", provider_key)] terminal_failure_cooldown_sec
+        Otel_metric_store.observe_histogram
+          Keeper_metrics.(to_string ProviderBlockDurationSec)
+          ~labels:[ ("provider", provider_key) ]
+          terminal_failure_cooldown_sec
+      end
+    | Server_error ->
+      (* Upstream HTTP 5xx can recover without operator action, so it should not
+         use terminal-failure blackout.  It still needs an immediate medium
+         cooldown because thresholded generic failures are shorter than many
+         keeper autonomous cadences and therefore fail to break repeated pages. *)
+      state.consecutive_failures <- state.consecutive_failures + 1;
+      bump_failure_fp ();
+      let new_until = now +. server_error_cooldown_sec in
+      if new_until > state.cooldown_until then begin
+        state.cooldown_until <- new_until;
+        Runtime_metrics.on_provider_cooldown
+          ~provider:provider_key ~reason:"server_error";
+        Otel_metric_store.observe_histogram
+          Keeper_metrics.(to_string ProviderBlockDurationSec)
+          ~labels:[ ("provider", provider_key) ]
+          server_error_cooldown_sec
       end)
 
 let record_success t ~provider_key ?latency_ms ?confidence ?cost_usd () =
@@ -504,6 +531,12 @@ let record_hard_quota t ~provider_key ?error_kind ?error_reason () =
 
 let record_terminal_failure t ~provider_key ?error_kind ?error_reason () =
   record t ~provider_key ~outcome:Terminal_failure ?error_kind ?error_reason
+    ~now:(Unix.gettimeofday ()) ()
+
+let record_server_error t ~provider_key ?error_kind ?error_reason () =
+  record t ~provider_key ~outcome:Server_error ?error_kind ?error_reason
+    (* NDT-OK: runtime provider-health telemetry boundary; deterministic tests
+       can exercise the underlying [record] path with an explicit [~now]. *)
     ~now:(Unix.gettimeofday ()) ()
 
 let record_soft_rate_limited t ~provider_key ?retry_after_s ?error_kind
@@ -849,6 +882,7 @@ type outcome_kind =
   | Outcome_rejected
   | Outcome_hard_quota
   | Outcome_terminal_failure
+  | Outcome_server_error
   | Outcome_soft_rate_limited
   | Outcome_capacity_backpressure
 
@@ -866,22 +900,25 @@ let outcome_matches kind ev =
   | Outcome_rejected, Rejected
   | Outcome_hard_quota, Hard_quota
   | Outcome_terminal_failure, Terminal_failure
+  | Outcome_server_error, Server_error
   | Outcome_soft_rate_limited, Soft_rate_limited
   | Outcome_capacity_backpressure, Capacity_backpressure -> true
   | Outcome_success,
-      (Failure | Rejected | Hard_quota | Terminal_failure | Soft_rate_limited | Capacity_backpressure)
+      (Failure | Rejected | Hard_quota | Terminal_failure | Server_error | Soft_rate_limited | Capacity_backpressure)
   | Outcome_failure,
-      (Success | Rejected | Hard_quota | Terminal_failure | Soft_rate_limited | Capacity_backpressure)
+      (Success | Rejected | Hard_quota | Terminal_failure | Server_error | Soft_rate_limited | Capacity_backpressure)
   | Outcome_rejected,
-      (Success | Failure | Hard_quota | Terminal_failure | Soft_rate_limited | Capacity_backpressure)
+      (Success | Failure | Hard_quota | Terminal_failure | Server_error | Soft_rate_limited | Capacity_backpressure)
   | Outcome_hard_quota,
-      (Success | Failure | Rejected | Terminal_failure | Soft_rate_limited | Capacity_backpressure)
+      (Success | Failure | Rejected | Terminal_failure | Server_error | Soft_rate_limited | Capacity_backpressure)
   | Outcome_terminal_failure,
-      (Success | Failure | Rejected | Hard_quota | Soft_rate_limited | Capacity_backpressure)
+      (Success | Failure | Rejected | Hard_quota | Server_error | Soft_rate_limited | Capacity_backpressure)
+  | Outcome_server_error,
+      (Success | Failure | Rejected | Hard_quota | Terminal_failure | Soft_rate_limited | Capacity_backpressure)
   | Outcome_soft_rate_limited,
-      (Success | Failure | Rejected | Hard_quota | Terminal_failure | Capacity_backpressure)
+      (Success | Failure | Rejected | Hard_quota | Terminal_failure | Server_error | Capacity_backpressure)
   | Outcome_capacity_backpressure,
-      (Success | Failure | Rejected | Hard_quota | Terminal_failure | Soft_rate_limited) -> false
+      (Success | Failure | Rejected | Hard_quota | Terminal_failure | Server_error | Soft_rate_limited) -> false
 
 (* Count [outcome] events recorded for [provider_key] within the last
    [window_s] seconds.  We piggyback on the same event ring used by

--- a/lib/keeper/keeper_binding_health.mli
+++ b/lib/keeper/keeper_binding_health.mli
@@ -38,6 +38,14 @@ val terminal_failure_cooldown_sec : float
 
     Env: [MASC_RUNTIME_TERMINAL_FAILURE_COOLDOWN_SEC]. *)
 
+val server_error_cooldown_sec : float
+(** Cooldown duration applied immediately on upstream HTTP 5xx server errors.
+    Default 300.0 (5 min), env [MASC_RUNTIME_SERVER_ERROR_COOLDOWN_SEC].
+
+    This is intentionally separate from {!cooldown_sec}: thresholded 30s
+    failure cooldown can expire between scheduled keeper cycles, repeatedly
+    paging operators for the same unhealthy provider lane. *)
+
 val soft_rate_limit_cooldown_sec : float
 (** Default cooldown applied immediately on a transient HTTP 429 (soft
     rate-limit) when no Retry-After hint is available.  Distinct from
@@ -238,6 +246,19 @@ val record_terminal_failure :
   unit ->
   unit
 
+(** Record an upstream HTTP 5xx server error.
+
+    A single 5xx triggers a medium cooldown so autonomous keeper cycles do not
+    repeatedly dispatch into the same unhealthy cloud lane after OAS has already
+    exhausted its provider-owned retry/backoff. *)
+val record_server_error :
+  t ->
+  provider_key:string ->
+  ?error_kind:error_kind ->
+  ?error_reason:string ->
+  unit ->
+  unit
+
 (** Record a transient HTTP 429 (rate-limit) response.
 
     Unlike {!record_failure}, a single soft rate-limit triggers an
@@ -400,6 +421,7 @@ type outcome_kind =
   | Outcome_rejected
   | Outcome_hard_quota
   | Outcome_terminal_failure
+  | Outcome_server_error
   | Outcome_soft_rate_limited
   | Outcome_capacity_backpressure
 

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -323,6 +323,7 @@ let operator_disposition (receipt : t)
           ~labels:[ "keeper", receipt.keeper_name; "site", Keeper_execution_receipt_failure_site.(to_label Unmapped_disposition) ]
           ();
         Log.Keeper.warn
+          ~keeper_name:receipt.keeper_name
           "operator_disposition: unmapped (outcome=%s runtime_outcome=%s \
            terminal_reason=%s completion_contract_result=%s error_kind=%s) — investigate \
            regression of #11651 silent-path fix"
@@ -631,6 +632,7 @@ let emit_operator_broadcast config (receipt : t) ~disposition ~reason =
       ()
   in
   Log.Keeper.warn
+    ~keeper_name:receipt.keeper_name
     "%s: operator_broadcast_required emitted disposition=%s reason=%s seq=%d"
     receipt.keeper_name
     (operator_disposition_kind_to_string disposition)
@@ -660,6 +662,7 @@ let append (config : Workspace.config) (receipt : t) =
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
      Log.Keeper.warn
+       ~keeper_name:receipt.keeper_name
        "%s: reaction ledger receipt append failed trace_id=%s: %s"
        receipt.keeper_name
        receipt.trace_id
@@ -682,6 +685,7 @@ let append (config : Workspace.config) (receipt : t) =
           ~labels:[ "keeper", receipt.keeper_name; "site", Keeper_execution_receipt_failure_site.(to_label Emit_failed) ]
           ();
         Log.Keeper.error
+          ~keeper_name:receipt.keeper_name
           "%s: operator_broadcast_required EMIT FAILED disposition=%s reason=%s exn=%s"
           receipt.keeper_name
           disposition_s
@@ -693,6 +697,7 @@ let append (config : Workspace.config) (receipt : t) =
         ~labels:[ "keeper", receipt.keeper_name; "reason", reason_s ]
         ();
       Log.Keeper.info
+        ~keeper_name:receipt.keeper_name
         "%s: operator_broadcast_required suppressed duplicate disposition=%s reason=%s turn=%s"
         receipt.keeper_name
         disposition_s
@@ -823,6 +828,7 @@ let emit_stale_keeper_broadcast
     ~labels:[ "keeper", keeper_name; "site", Keeper_execution_receipt_failure_site.(to_label Stale_broadcast) ]
     ();
   Log.Keeper.warn
+    ~keeper_name
     "%s: stale_keeper_broadcast emitted last_turn=%.0fs ago runtime=%s seq=%d"
     keeper_name
     stale_seconds

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -240,6 +240,7 @@ let run_named
 module For_testing = struct
   let checkpoint_after_attempt = checkpoint_after_attempt
   let success_selected_model_raw = success_selected_model_raw
+  let record_candidate_health_error = record_candidate_health_error
   let apply_accept = Keeper_turn_driver_try_provider.For_testing.apply_accept
   let last_tool_progress_context_string_of_messages messages =
     messages

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -153,6 +153,9 @@ module For_testing : sig
 
   val success_selected_model_raw : Runtime_candidate.t -> string option
 
+  val record_candidate_health_error :
+    keeper_name:string -> Runtime_candidate.t -> Agent_sdk.Error.sdk_error -> unit
+
   val apply_accept :
     runtime_id:string ->
     accept:(Agent_sdk_response.api_response -> bool) ->

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -325,6 +325,46 @@ let sdk_error_runtime_fallback_class (err : Agent_sdk.Error.sdk_error) :
   else if sdk_error_is_max_turns_exceeded err then Some fallback_class_max_turns
   else None
 
+let sdk_error_is_server_error (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError { status; _ })
+    when status >= 500 -> true
+  | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; _ })
+    when code >= 500 -> true
+  | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
+  | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError _)
+  | Agent_sdk.Error.Api
+      ( Llm_provider.Retry.RateLimited _
+      | Llm_provider.Retry.Overloaded _
+      | Llm_provider.Retry.AuthError _
+      | Llm_provider.Retry.InvalidRequest _
+      | Llm_provider.Retry.NotFound _
+      | Llm_provider.Retry.ContextOverflow _
+      | Llm_provider.Retry.NetworkError _
+      | Llm_provider.Retry.Timeout _ )
+  | Agent_sdk.Error.Provider
+      ( Llm_provider.Error.NetworkError _
+      | Llm_provider.Error.Timeout _
+      | Llm_provider.Error.RateLimit _
+      | Llm_provider.Error.AuthError _
+      | Llm_provider.Error.MissingApiKey _
+      | Llm_provider.Error.InvalidRequest _
+      | Llm_provider.Error.NotFound _
+      | Llm_provider.Error.CapacityExhausted _
+      | Llm_provider.Error.HardQuota _
+      | Llm_provider.Error.ProviderUnavailable _
+      | Llm_provider.Error.ProviderTerminal _
+      | Llm_provider.Error.ParseError _
+      | Llm_provider.Error.InvalidConfig _
+      | Llm_provider.Error.UnknownVariant _ )
+  | Agent_sdk.Error.Agent _
+  | Agent_sdk.Error.Mcp _
+  | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _
+  | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _
+  | Agent_sdk.Error.Internal _ -> false
+
 let record_candidate_health_error ~keeper_name candidate sdk_err =
   let error_reason = Agent_sdk.Error.to_string sdk_err in
   let health_keys = Runtime_candidate.health_keys candidate in
@@ -347,6 +387,18 @@ let record_candidate_health_error ~keeper_name candidate sdk_err =
     |> List.iter (fun provider_key ->
       let provider_key = scoped_provider_key ~keeper_name provider_key in
       Keeper_binding_health.record_terminal_failure
+        Keeper_binding_health.global
+        ~provider_key
+        ~error_kind
+        ~error_reason
+        ()))
+  else if sdk_error_is_server_error sdk_err
+  then (
+    let error_kind = health_error_kind "server_error" in
+    health_keys
+    |> List.iter (fun provider_key ->
+      let provider_key = scoped_provider_key ~keeper_name provider_key in
+      Keeper_binding_health.record_server_error
         Keeper_binding_health.global
         ~provider_key
         ~error_kind

--- a/lib/keeper/keeper_turn_driver_provider_attempt.ml
+++ b/lib/keeper/keeper_turn_driver_provider_attempt.ml
@@ -331,6 +331,7 @@ let sdk_error_is_server_error (err : Agent_sdk.Error.sdk_error) : bool =
     when status >= 500 -> true
   | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError { code; _ })
     when code >= 500 -> true
+  | Agent_sdk.Error.Provider (Llm_provider.Error.ProviderUnavailable _) -> true
   | Agent_sdk.Error.Api (Llm_provider.Retry.ServerError _)
   | Agent_sdk.Error.Provider (Llm_provider.Error.ServerError _)
   | Agent_sdk.Error.Api
@@ -352,7 +353,6 @@ let sdk_error_is_server_error (err : Agent_sdk.Error.sdk_error) : bool =
       | Llm_provider.Error.NotFound _
       | Llm_provider.Error.CapacityExhausted _
       | Llm_provider.Error.HardQuota _
-      | Llm_provider.Error.ProviderUnavailable _
       | Llm_provider.Error.ProviderTerminal _
       | Llm_provider.Error.ParseError _
       | Llm_provider.Error.InvalidConfig _

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -199,7 +199,11 @@ let run_keeper_cycle
                 (Keeper_agent_error.terminal_reason_code_of_sdk_error err)
             in
             let error_message = Agent_sdk.Error.to_string err in
-            Log.Keeper.error "%s: pre_dispatch failed: %s" meta.name error_message;
+            Log.Keeper.error
+              ~keeper_name:meta.name
+              "%s: pre_dispatch failed: %s"
+              meta.name
+              error_message;
             record_pre_dispatch_terminal_observation
               ~config
               ~meta
@@ -405,6 +409,7 @@ let run_keeper_cycle
                          ~labels:[ "keeper", entry.meta.name; "phase", Keeper_oas_execution_error_phase.(to_label Turn_start) ]
                          ();
                        Log.Keeper.warn
+                         ~keeper_name:entry.meta.name
                          "%s: turn-start write_meta_with_merge failed: %s"
                          entry.meta.name
                          err
@@ -432,6 +437,7 @@ let run_keeper_cycle
                     | Eio.Cancel.Cancelled _ -> ()
                     | e ->
                       Log.Keeper.warn
+                        ~keeper_name:meta.name
                         "%s: unsubscribe_event_bus in turn cleanup raised: %s"
                         meta.name
                         (Printexc.to_string e);
@@ -447,6 +453,7 @@ let run_keeper_cycle
                    | Eio.Cancel.Cancelled _ -> ()
                    | e ->
                      Log.Keeper.warn
+                       ~keeper_name:meta.name
                        "%s: mark_turn_finished in turn cleanup raised: %s"
                        meta.name
                        (Printexc.to_string e);
@@ -682,17 +689,30 @@ let run_keeper_cycle
                     then Log.Keeper.warn
                     else Log.Keeper.error
                   in
+                  let failure_context_ratio =
+                    if final_execution.max_context <= 0
+                    then 0.0
+                    else
+                      float_of_int prompt_timeout_estimate_tokens
+                      /. float_of_int final_execution.max_context
+                  in
                   log_keeper_cycle_failed
+                    ~keeper_name:meta.name
                     "%s: keeper cycle FAILED runtime=%s max_context=%d context_budget=%d \
-                     primary_budget=%d requested_override=%s latency=%dms%s error=%s"
+                     primary_budget=%d requested_override=%s estimated_input_tokens=%d \
+                     context_ratio=%.4f latency=%dms%s error=%s"
                     meta.name
-                    (final_execution.runtime_id)
+                    final_execution.runtime_id
                     final_execution.max_context
                     final_execution.max_context_resolution.effective_budget
                     final_execution.max_context_resolution.primary_budget
-                    (match final_execution.max_context_resolution.requested_override with
+                    (match
+                       final_execution.max_context_resolution.requested_override
+                     with
                      | Some requested -> string_of_int requested
                      | None -> "none")
+                    prompt_timeout_estimate_tokens
+                    failure_context_ratio
                     latency_ms
                     (if is_ambiguous_partial
                      then " (ambiguous partial commit)"
@@ -773,6 +793,7 @@ let run_keeper_cycle
                           ~labels:[ "keeper", meta.name; "reason", "ambiguous_partial" ]
                           ();
                         Log.Keeper.warn
+                          ~keeper_name:meta.name
                           "%s: ambiguous partial commit \
                            (committed_mutating_tools=[%s], turn_events=%d, \
                            payload_kinds=[%s], reason=%s); paused keeper and opened \
@@ -794,7 +815,10 @@ let run_keeper_cycle
                                sync_err
                                (short_preview e_str))
                         in
-                        Log.Keeper.error "%s" (Agent_sdk.Error.to_string combined_err);
+                        Log.Keeper.error
+                          ~keeper_name:meta.name
+                          "%s"
+                          (Agent_sdk.Error.to_string combined_err);
                         Otel_metric_store.inc_counter
                           Keeper_metrics.(to_string RuntimeSyncFailures)
                           ~labels:
@@ -863,10 +887,12 @@ dominant source of the observed CAS race exhaustion after
                      if is_version_conflict_error msg
                      then
                        Log.Keeper.warn
+                         ~keeper_name:updated_meta.name
                          "write_meta lost CAS race after retries (turn failure path): %s"
                          msg
                      else
                        Log.Keeper.error
+                         ~keeper_name:updated_meta.name
                          "write_meta failed after unified turn failure: %s"
                          msg);
                   Otel_metric_store.inc_counter
@@ -891,6 +917,7 @@ dominant source of the observed CAS race exhaustion after
                     let committed_tools = ambiguous_commit_tools in
                     let turn_event_summary = turn_event_bus in
                     Log.Keeper.info
+                      ~keeper_name:meta.name
                       "%s: reconcile-required failure latched as %s after \
                        committed_mutating_tools [%s] (turn_events=%d, payload_kinds=[%s])"
                       meta.name

--- a/lib/keeper/keeper_unified_turn_terminal_error.ml
+++ b/lib/keeper/keeper_unified_turn_terminal_error.ml
@@ -11,6 +11,7 @@ let handle ~config ~keeper_name ~attempt ~attempted_runtimes err =
       ~labels:[ "edge", "kcl_to_ktc_exhaustion" ]
       ();
     Log.Keeper.warn
+      ~keeper_name
       "%s: all runtimes exhausted (terminal) — last_err=%s attempt=%d \
        attempted_runtimes=[%s]"
       keeper_name
@@ -38,6 +39,7 @@ let handle ~config ~keeper_name ~attempt ~attempted_runtimes err =
         ]
       ();
     Log.Keeper.warn
+      ~keeper_name
       "%s: turn terminal (non-exhaustion error) — err=%s attempt=%d"
       keeper_name
       (Agent_sdk.Error.to_string err)

--- a/lib/keeper_runtime/keeper_binding_health_config.ml
+++ b/lib/keeper_runtime/keeper_binding_health_config.ml
@@ -137,6 +137,19 @@ let soft_rate_limit_max_clamp_sec =
     ~default:120.0
     ()
 
+(** Cooldown applied immediately on HTTP 5xx provider server errors.
+
+    Generic [record_failure] uses a short thresholded cooldown, which is too
+    weak for scheduled keeper turns: a minute-scale cadence can let the 30s
+    cooldown expire between every cycle, producing repeated operator pages
+    against the same unhealthy cloud lane. Five minutes suppresses the loop
+    while staying far shorter than hard-quota/terminal structural blackouts. *)
+let server_error_cooldown_sec =
+  read_float_setting
+    ~primary:"MASC_RUNTIME_SERVER_ERROR_COOLDOWN_SEC"
+    ~default:300.0
+    ()
+
 (** Synthetic backoff for [Capacity_backpressure] with no [retry_after_sec].
 
     5.0 s was too short — providers rotated back into selection before

--- a/lib/keeper_runtime/keeper_binding_health_config.mli
+++ b/lib/keeper_runtime/keeper_binding_health_config.mli
@@ -7,6 +7,9 @@ val hard_quota_cooldown_sec : float
 val terminal_failure_cooldown_sec : float
 val soft_rate_limit_cooldown_sec : float
 val soft_rate_limit_max_clamp_sec : float
+val server_error_cooldown_sec : float
+(** Cooldown applied immediately for upstream HTTP 5xx server errors.
+    Tunable via [MASC_RUNTIME_SERVER_ERROR_COOLDOWN_SEC]. *)
 val default_capacity_backpressure_backoff_sec : float
 (** Synthetic backoff applied when a [Capacity_backpressure] error arrives
     without an explicit [retry_after_sec] hint.  Sized below

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -326,6 +326,12 @@ let server_error_500 =
     (Retry.ServerError { status = 500; message = "Internal Server Error" })
 ;;
 
+let provider_unavailable =
+  SdkE.Provider
+    (Llm_provider.Error.ProviderUnavailable
+       { provider = "server-error-test"; detail = "HTTP 503 retry-after exhausted" })
+;;
+
 let test_soft_rate_limit_skips_same_credential_pool () =
   init_rate_limit_pool_runtime ();
   let retry =
@@ -417,6 +423,48 @@ let test_server_error_records_immediate_provider_cooldown () =
        ~window_s:BH.window_sec)
 ;;
 
+let test_provider_unavailable_records_server_error_cooldown () =
+  let candidate =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"provider-unavailable-test"
+      ~base_url:"https://provider-unavailable.example/v1"
+      ()
+    |> RC.of_provider_config ~max_concurrent:None
+  in
+  let keeper_name = "provider-unavailable-cooldown-test" in
+  let provider_key =
+    match RC.health_keys candidate with
+    | [ key ] -> keeper_name ^ "@" ^ key
+    | keys ->
+      Alcotest.failf
+        "expected one health key, got [%s]"
+        (String.concat "; " keys)
+  in
+  (match EC.recoverable_runtime_failure_reason provider_unavailable with
+   | Some EC.Server_error -> ()
+   | Some reason ->
+     Alcotest.failf
+       "expected server_error, got %s"
+       (EC.degraded_retry_reason_to_string reason)
+   | None -> Alcotest.fail "expected server_error recoverable reason");
+  KTD.For_testing.record_candidate_health_error ~keeper_name candidate provider_unavailable;
+  let info =
+    match BH.provider_info BH.global ~provider_key with
+    | Some info -> info
+    | None -> Alcotest.failf "expected provider info for %s" provider_key
+  in
+  Alcotest.(check bool) "provider unavailable opens cooldown" true info.in_cooldown;
+  Alcotest.(check int)
+    "provider unavailable outcome counted"
+    1
+    (BH.recent_outcome_count
+       BH.global
+       ~provider_key
+       ~outcome:BH.Outcome_server_error
+       ~window_s:BH.window_sec)
+;;
+
 let () =
   Alcotest.run
     "keeper_sdk_error_typed_bridge"
@@ -469,6 +517,10 @@ let () =
             "500 records immediate provider cooldown"
             `Quick
             test_server_error_records_immediate_provider_cooldown
+        ; Alcotest.test_case
+            "provider unavailable records server_error cooldown"
+            `Quick
+            test_provider_unavailable_records_server_error_cooldown
         ] )
     ]
 ;;

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -15,9 +15,11 @@
       Serialization / Io / Orchestration / Internal) *)
 
 module AE = Masc.Keeper_agent_error
+module BH = Masc.Keeper_binding_health
 module Code = Masc.Keeper_turn_terminal_code
 module EC = Masc.Keeper_error_classify
 module KTD = Masc.Keeper_turn_driver
+module RC = Runtime_candidate
 module SdkE = Agent_sdk.Error
 module Retry = Agent_sdk.Retry
 module Http = Llm_provider.Http_client
@@ -319,6 +321,11 @@ let soft_rate_limit_err =
        { retry_after = Some 30.0; message = "rate limited, retry later" })
 ;;
 
+let server_error_500 =
+  SdkE.Api
+    (Retry.ServerError { status = 500; message = "Internal Server Error" })
+;;
+
 let test_soft_rate_limit_skips_same_credential_pool () =
   init_rate_limit_pool_runtime ();
   let retry =
@@ -358,6 +365,56 @@ let test_soft_rate_limit_preserves_independent_pool_failover () =
       (EC.degraded_retry_reason_to_string fallback_reason)
       next_runtime
   | None -> Alcotest.fail "expected independent credential pool failover"
+;;
+
+let test_server_error_classifies_as_runtime_recoverable () =
+  Alcotest.(check bool)
+    "500 is not same-runtime transient retry"
+    false
+    (EC.is_transient_network_error server_error_500);
+  match EC.recoverable_runtime_failure_reason server_error_500 with
+  | Some EC.Server_error -> ()
+  | Some reason ->
+    Alcotest.failf
+      "expected server_error, got %s"
+      (EC.degraded_retry_reason_to_string reason)
+  | None -> Alcotest.fail "expected server_error recoverable reason"
+;;
+
+let test_server_error_records_immediate_provider_cooldown () =
+  let candidate =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"server-error-test"
+      ~base_url:"https://server-error.example/v1"
+      ()
+    |> RC.of_provider_config ~max_concurrent:None
+  in
+  let keeper_name = "server-error-cooldown-test" in
+  let provider_key =
+    match RC.health_keys candidate with
+    | [ key ] -> keeper_name ^ "@" ^ key
+    | keys ->
+      Alcotest.failf
+        "expected one health key, got [%s]"
+        (String.concat "; " keys)
+  in
+  KTD.For_testing.record_candidate_health_error ~keeper_name candidate server_error_500;
+  let info =
+    match BH.provider_info BH.global ~provider_key with
+    | Some info -> info
+    | None -> Alcotest.failf "expected provider info for %s" provider_key
+  in
+  Alcotest.(check bool) "server error opens cooldown" true info.in_cooldown;
+  Alcotest.(check int) "server error increments once" 1 info.consecutive_failures;
+  Alcotest.(check int)
+    "server error outcome counted"
+    1
+    (BH.recent_outcome_count
+       BH.global
+       ~provider_key
+       ~outcome:BH.Outcome_server_error
+       ~window_s:BH.window_sec)
 ;;
 
 let () =
@@ -404,6 +461,14 @@ let () =
             "soft rate limits preserve independent credential-pool failover"
             `Quick
             test_soft_rate_limit_preserves_independent_pool_failover
+        ; Alcotest.test_case
+            "500 classifies as recoverable server_error"
+            `Quick
+            test_server_error_classifies_as_runtime_recoverable
+        ; Alcotest.test_case
+            "500 records immediate provider cooldown"
+            `Quick
+            test_server_error_records_immediate_provider_cooldown
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- add a dedicated provider-health `server_error` outcome for upstream HTTP 5xx responses
- apply an immediate medium cooldown for repeated 5xx lanes via `MASC_RUNTIME_SERVER_ERROR_COOLDOWN_SEC` (default 300s)
- enrich keeper failure logs with structured `keeper_name`, estimated input tokens, and context ratio

## Why
Recent keeper logs showed repeated `ollama_cloud.deepseek-v4-flash` 500 failures on minute-scale autonomous cycles. The generic failure cooldown is thresholded and short, so it can expire between scheduled cycles and fail to break operator-page loops after OAS has already spent provider-owned retry/backoff.

## Validation
- `git diff --check`
- `opam exec -- ocamlformat --check lib/keeper/keeper_binding_health.ml`
- `bash scripts/ci/check-determinism-contract.sh`
- `env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_sdk_error_typed_bridge.exe`
- `_build/default/test/test_keeper_sdk_error_typed_bridge.exe` (10 tests, including 2 new 5xx cooldown tests)

## Out of scope
- live runtime config drift from 262144 to expected wider context is not changed here
- compaction policy is not changed here