### PR TITLE
fix(tools): restore web backends to raw_all_tool_schemas substrate (WebSearch core regression)

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -14,18 +14,25 @@ let dedupe_schemas (schemas : Masc_domain.tool_schema list) =
   List.rev unique
 
 
-(* Tools that are keeper-only (called via public_name by the keeper agent)
-   and must NOT be exposed as operator MCP tool calls.
-   masc_web_search / masc_web_fetch are reached via WebSearch / WebFetch
-   public_names from keeper context; operator never calls them directly. *)
-let keeper_only_masc_names =
-  [ "masc_web_search"; "masc_web_fetch" ]
+(* Project every descriptor-owned masc_* backend schema into the substrate so
+   the keeper tool universe knows the tool exists.  This includes the web
+   backends (masc_web_search / masc_web_fetch), which the LLM reaches via their
+   WebSearch / WebFetch public_names.
 
+   Do NOT trim "keeper-only" tools out of this projection to keep them off the
+   operator MCP surface.  [raw_all_tool_schemas] feeds BOTH the keeper universe
+   AND the public MCP surface (RFC-0218 §1.1), and the operator-surface
+   exclusion is enforced separately and downstream by [Tool_catalog.is_public_mcp]
+   / [public_mcp_surface_tools] (contract stated in tool_schemas_misc.mli).
+   Excluding the web backends here re-creates the #19864/#20060 split-brain:
+   the substrate denies a tool the keeper still dispatches, so [masc_web_search]
+   never enters [injected_masc_tool_names ()], [effective_core_tools] drops
+   WebSearch from the always-visible core, and every keeper turn prunes + WARNs
+   (~3.5k/day "AllowList pruned ... WebSearch"). *)
 let descriptor_owned_internal_tool_schemas : Masc_domain.tool_schema list =
   Keeper_tool_descriptor.public_descriptors
   |> List.filter_map (fun (descriptor : Keeper_tool_descriptor.t) ->
     if String.starts_with ~prefix:"masc_" descriptor.internal_name
-       && not (List.mem descriptor.internal_name keeper_only_masc_names)
     then
       Some
         { Masc_domain.name = descriptor.internal_name

--- a/test/test_tool_descriptors_gen.ml
+++ b/test/test_tool_descriptors_gen.ml
@@ -203,6 +203,43 @@ let test_web_tools_owned_by_keeper_descriptors () =
     [ "masc_web_search"; "masc_web_fetch" ]
 ;;
 
+(* Behavioral guard for the chain above. raw_all_tool_schemas presence is only
+   useful if it reaches the keeper's always-visible core: effective_core_tools
+   promotes a descriptor's public name (WebSearch) only when its internal name
+   (masc_web_search) is in injected_masc_tool_names (), which is populated from
+   raw_all_tool_schemas at startup (lib/mcp_server_eio.ml). The
+   keeper_only_masc_names trim broke exactly this chain: web backends absent
+   from raw -> never injected -> WebSearch never core -> pruned on every
+   non-web-shaped turn (RFC-0218 §1.1, ~3.5k/day "AllowList pruned WebSearch").
+   This asserts the substrate -> injected -> core chain end to end. *)
+let test_web_backends_reach_core_after_substrate_injection () =
+  let prior = Masc.Keeper_tool_dispatch_runtime.masc_schemas_snapshot () in
+  Fun.protect
+    ~finally:(fun () -> Masc.Keeper_tool_dispatch_runtime.set_masc_schemas prior)
+    (fun () ->
+      (* Simulate startup: lib/mcp_server_eio.ml feeds exactly this substrate. *)
+      Masc.Keeper_tool_dispatch_runtime.inject_masc_schemas
+        Masc.Config.raw_all_tool_schemas;
+      let injected =
+        Masc.Keeper_tool_dispatch_runtime.injected_masc_tool_names ()
+      in
+      List.iter
+        (fun name ->
+          Alcotest.(check bool)
+            (name ^ " injected from raw_all_tool_schemas substrate")
+            true
+            (List.mem name injected))
+        [ "masc_web_search"; "masc_web_fetch" ];
+      let core = Masc.Keeper_tool_dispatch_runtime.effective_core_tools () in
+      List.iter
+        (fun public_name ->
+          Alcotest.(check bool)
+            (public_name ^ " promoted to always-visible core")
+            true
+            (List.mem public_name core))
+        [ "WebSearch"; "WebFetch" ])
+;;
+
 let test_masc_tool_stats_name_matches () =
   let gen = find_by_name "masc_tool_stats" Tool_descriptors_gen.schemas in
   let hand = find_by_name "masc_tool_stats" Tool_schemas_misc.schemas in
@@ -287,6 +324,10 @@ let () =
             "owned by keeper descriptors"
             `Quick
             test_web_tools_owned_by_keeper_descriptors
+        ; Alcotest.test_case
+            "reach always-visible core after substrate injection"
+            `Quick
+            test_web_backends_reach_core_after_substrate_injection
         ] )
     ; ( "masc_tool_stats field-by-field"
       , [ Alcotest.test_case "name" `Quick test_masc_tool_stats_name_matches


### PR DESCRIPTION
## 무엇을 / 왜

키퍼가 web search를 "현재 schema에 없다"고 보고하고, 매 턴 `AllowList pruned ... WebSearch, WebFetch` WARN(RFC-0218 §1.1 실측 ~3.5k/day)이 발생하는 근본 원인을 수정한다.

근본은 `lib/config.ml`의 회귀다. `keeper_only_masc_names = ["masc_web_search"; "masc_web_fetch"]`가 `descriptor_owned_internal_tool_schemas`에서 이 두 도구를 `raw_all_tool_schemas`(substrate)에서 **trim**한다. 이는 `tool_schemas_misc.mli`의 명시된 계약을 위반한다:

> Descriptor-owned web backend names (`masc_web_search` / `masc_web_fetch`) are intentionally projected into `Config.raw_all_tool_schemas` ... Public-surface exclusion is enforced downstream by `Tool_catalog.is_public_mcp` / `public_mcp_surface_tools`, **not by trimming the raw inventory**.

`raw_all_tool_schemas`는 keeper universe와 public MCP 표면을 **모두** 먹인다(RFC-0218 §1.1, source #1). substrate에서 web 도구가 빠지면:

1. `inject_masc_schemas Config.raw_all_tool_schemas`(`mcp_server_eio.ml:96`)로 injected 안 됨 → `injected_masc_tool_names ()`에서 누락.
2. `effective_core_tools ()`(`keeper_tool_registry.ml:290-303`)는 descriptor public name을 core로 승격할지를 injection 여부로 판정 → `WebSearch`가 always-visible core에서 탈락.
3. `compute_tool_surface`(`keeper_run_tools_setup.ml`)는 `core`만 무조건 merge → web 도구는 턴 쿼리가 BM25-매치되거나 `keeper_tool_search` 명시 호출 시에만 등장 → 대부분 턴에 "schema에 없다".

이는 #19864가 만들고 #20060이 고친 split-brain의 **재도입**이다(RFC-0218 §1.1). operator-MCP 배제(주석이 의도한 것)는 이미 `public_mcp_surface_tools` allowlist(web 도구 미포함) + `is_public_mcp` 필터(`mcp_server_eio_tool_profile.ml:89`)로 **독립적으로** 보장된다. config.ml의 trim은 그 목적엔 redundant, 부수효과로만 해로운 잘못된 레버였다.

이름 drift는 root가 아니다(프롬프트·schema·dispatch 모두 `WebSearch`로 일관, snake 호출도 양방향 alias로 해결). 증상은 도구가 턴 표면에서 통째로 빠진 것이다.

## 변경 (`lib/config.ml`)

- `keeper_only_masc_names` 바인딩 + `descriptor_owned_internal_tool_schemas`의 `&& not (List.mem ... keeper_only_masc_names)` 배제 clause 제거.
- → masc_web_search / masc_web_fetch가 다시 raw_all_tool_schemas에 projection → injected → `effective_core_tools`가 WebSearch/WebFetch를 core로 승격 → 매 턴 키퍼 schema에 상존.
- 재도입 방지 주석 추가: substrate가 양쪽을 먹이며 operator 배제는 `is_public_mcp`가 별도로 한다는 계약을 명시(RFC-0218 §1.1 / tool_schemas_misc.mli 인용).
- `keeper_only_masc_names`는 config.ml 외 참조 0건(`rg` 확인)이라 dead binding 동반 제거.

operator MCP 표면은 `is_public_mcp`(= `public_mcp_surface_tools` allowlist 멤버십, web 도구 미포함)가 별도로 막으므로 **operator 노출 누출 없음**. RFC-0218 §2 non-goal("No change to the public MCP allowlist contents") 준수.

## 검증

- `dune build --root .` clean (RFC-0218 §8 게이트 1).
- 기존 `test_web_tools_owned_by_keeper_descriptors`(`test/test_tool_descriptors_gen.ml`)가 green으로 전환 — 이 테스트는 이미 올바른 불변식(masc_web_search/fetch가 raw_all_tool_schemas에 **present** + public_mcp_surface_tools에서 **absent**)을 단언하고 있었고, 배제 clause로 인해 모순/실패 상태였다. 이 fix가 테스트를 회귀 가드로 복원한다(RFC-0218 §8 게이트 2).
- **신규 behavioral 회귀 가드** `test_web_backends_reach_core_after_substrate_injection`(같은 파일) 추가 — `inject_masc_schemas Config.raw_all_tool_schemas` 후 `injected_masc_tool_names ()`에 `masc_web_search`/`masc_web_fetch`가 들어오고 `effective_core_tools ()`에 `WebSearch`/`WebFetch`가 always-visible core로 승격됨을 단언한다. substrate→injected→core 체인 전체를 핀으로 고정해 config.ml trim 회귀 재발을 잡는다. (이 test 파일 추가로 "Test Coverage Check"도 green 전환 — `9837e731be`.)
- **참고(무관)**: 같은 파일의 `test_masc_dashboard_*` 3건은 origin/main에서 이미 advisory-fail 중이다(generator `phase6_specs` ↔ misc descriptor drift, 본 PR과 무관). 별도 이슈 **#21845**로 기록. test 실행은 ci.yml상 advisory(비-게이팅)이고 `dune build`(컴파일)만 hard-required이므로 머지에는 영향 없다.

## RFC

- **RFC-0218** (Keeper tool-surface coherence + web-tooling roadmap) — 이 정확한 증상(`AllowList pruned WebSearch` ~3.5k/day)과 substrate-level root(`Config.is_raw_tool_name "masc_web_search" = false`)를 §1.1에 기록한 governing RFC. 본 PR은 §1.1 drift 클래스의 인스턴스 fix이며 §6 경계 원칙("substrate에서 파생, keeper-side 하드코딩 금지")을 따른다(하드코딩 배제 리스트를 *제거*).
- 관련: **RFC-0182** (masc descriptor projection), **RFC-0190** (descriptor visibility SSOT), **RFC-0064** (two-surface tool alias, Superseded).
- 권장 후속: RFC-0218 **Phase 1a** (startup coherence invariant, fail-fast) — 이 회귀를 boot 시점에 잡아 재발 방지. 별도 PR.

## 워크어라운드 아님 근거

회귀를 되돌려 문서화된 `.mli` 계약과 RFC-0218 §1.1 불변식을 **복원**하는 root fix다. telemetry-as-fix / string 분류기 / N-of-M / cap·cooldown·dedup·repair 시그니처 어디에도 해당하지 않는다. substrate가 dispatch하는 도구를 substrate가 다시 포함하도록 만든다.
