### PR TITLE
fix(tool_validation): unwrap Execute args object envelope

### DIFF
--- a/docs/ROOT-CAUSE-Execute-args-rejection.md
+++ b/docs/ROOT-CAUSE-Execute-args-rejection.md
@@ -37,7 +37,7 @@ Allowed top-level fields:
 | Field | Type | Required? |
 |---|---|---|
 | `executable` | string | required for single-process branch |
-| `argv` | array of strings | yes (single-process branch) |
+| `argv` | array of strings | optional; contains arguments after `executable` |
 | `pipeline` | array of `{executable, argv}` stages | alternative branch |
 | `env` | object | optional |
 | `cwd` | string | optional |
@@ -49,7 +49,7 @@ Allowed top-level fields:
 Schema properties:
 
 - `additionalProperties: false`
-- `oneOf`: either `executable`/`argv` **or** `pipeline`, never both.
+- `oneOf`: either `executable` with optional `argv` **or** `pipeline`, never both.
 
 Therefore **any of these inputs are rejected**:
 

--- a/docs/ROOT-CAUSE-Execute-args-rejection.md
+++ b/docs/ROOT-CAUSE-Execute-args-rejection.md
@@ -1,9 +1,9 @@
 # Root Cause: `Tool 'Execute' received unsupported field(s): args`
 
-> Scope: MASC (`~/me/workspace/yousleepwhen/masc`) `issue_king` keeper → `Execute` tool
+> Scope: repository-local MASC `Execute` tool validation path
 > Error observed:
-> `[2026-06-21 01:26:50] [WARN] [Keeper/issue_king] tool_policy_rejection: Execute — {"ok":false,"error":"Tool 'Execute' received unsupported field(s): args"}`
-> Date: 2026-06-21
+> `[WARN] [Keeper/issue_king] tool_policy_rejection: Execute — {"ok":false,"error":"Tool 'Execute' received unsupported field(s): args"}`
+> Date: 2026-06-20
 
 ---
 
@@ -186,7 +186,7 @@ Look at `config/keepers/issue_king.toml` and its runtime binding to see which pr
 
 ### 6.4 Check trajectory / telemetry
 
-Search `.masc/trajectories/`, `logs/`, or telemetry for the turn around `2026-06-21 01:26:50` for `issue_king`. The raw tool-call JSON should be present in the trajectory.
+Search `.masc/trajectories/`, `logs/`, or telemetry for the affected `issue_king` turn. The raw tool-call JSON should be present in the trajectory.
 
 ---
 
@@ -244,7 +244,7 @@ Search `.masc/trajectories/`, `logs/`, or telemetry for the turn around `2026-06
 
 ## 9. Next step
 
-1. Identify which provider `issue_king` was using at `2026-06-21 01:26:50`.
+1. Identify which provider `issue_king` was using for the affected turn.
 2. Add a one-line diagnostic log in `lib/tool_input_validation.ml:411` to print the rejected `input` JSON.
 3. Reproduce or wait for the next occurrence; inspect the raw LLM response.
 4. Apply the fix corresponding to the actual leak path (most likely Gemini `args` unwrap or model hallucination via flattened schema).

--- a/docs/ROOT-CAUSE-Execute-args-rejection.md
+++ b/docs/ROOT-CAUSE-Execute-args-rejection.md
@@ -93,9 +93,9 @@ The validation entry point in MASC is:
 
 ## 4. Why `args` can appear in the input
 
-The field name `args` is used in several places, but it is **never** a valid field inside the `Execute` schema. It can leak into the tool input through these paths:
+The field name `args` is used in several places, but it is **never** a valid field inside the `Execute` schema. It can reach the validation boundary through these paths:
 
-### 4.1 Gemini provider wire format
+### 4.1 Gemini provider wire format (normal path already unwraps)
 
 Gemini sends tool-call arguments under the key `functionCall.args`:
 
@@ -109,7 +109,7 @@ The parser unwraps `args` into `ToolUse.input`:
 ToolUse { id; name; input = args }
 ```
 
-If this unwrap has a bug (e.g., reading the wrong nesting level, or the response shape differing from expectation), the literal `{"args": ...}` object can become `ToolUse.input`, and MASC validation rejects it.
+Therefore the normal Gemini parser path is **not** evidence that Gemini leaks the literal wrapper into MASC. A Gemini-specific parser edge case remains possible only if raw response capture shows the parser received a response shape where `ToolUse.input` still became `{"args": ...}` after parsing.
 
 ### 4.2 Model emits `args` inside a text block
 
@@ -149,17 +149,17 @@ This is correct, but if any few-shot example, memory, or older prompt template s
 
 ---
 
-## 5. Most likely cause for `issue_king`
+## 5. Most defensible cause for `issue_king`
 
 `issue_king` is a normal keeper with no special `Execute` handling. It uses the same descriptor-backed tool surface as every other keeper.
 
-Given the error, the most likely scenarios are:
+The exact upstream source is **not yet proven** without a raw provider response or captured `ToolUse.input`. Given the current code, the defensible scenarios are:
 
-1. **Gemini parser edge case** — if `issue_king` is configured to use a Gemini-compatible provider, the `args` field from `functionCall.args` is being passed through without unwrap under some response shape.
-2. **Model hallucinated `args`** — the flattened OAS bridge schema plus a confused prompt caused the model to emit `{"args": ...}` instead of `{"executable": ..., "argv": ...}`.
-3. **Legacy alias not applied** — the model called `Execute` directly while thinking it was `execute_command`/`Bash`, and included a `command` or `args` field. (The error would normally say `command`/`cmd` is unsupported, but if the field is `args`, this scenario is also possible.)
+1. **Model hallucinated `args`** — the flattened OAS bridge schema plus a confused prompt caused the model to emit `{"args": ...}` instead of `{"executable": ..., "argv": ...}`.
+2. **Legacy alias not applied** — the model called `Execute` directly while thinking it was `execute_command`/`Bash`, and included a `command` or `args` field. (The error would normally say `command`/`cmd` is unsupported, but if the field is `args`, this scenario is also possible.)
+3. **Provider parser edge case** — possible only if capture proves a provider parser returned `ToolUse.input = {"args": ...}`. The normal Gemini non-streaming and streaming paths already unwrap `functionCall.args` into the inner object, so Gemini should not be treated as the leading suspect without that evidence.
 
-The error says **`args`**, not `command`/`cmd`, which points most strongly to **scenario 1 (Gemini)** or a model-level JSON hallucination.
+The error says **`args`**, not `command`/`cmd`, which is consistent with a model-level envelope hallucination or an unverified provider-specific parser edge. The read-side MASC normalization in this PR is still justified as defense-in-depth for that exact envelope shape; it should not be framed as proof that the Gemini parser is broken.
 
 ---
 
@@ -182,7 +182,7 @@ Add a log line in `lib/tool_input_validation.ml:411` to print `name` and the ful
 
 ### 6.3 Check provider binding for `issue_king`
 
-Look at `config/keepers/issue_king.toml` and its runtime binding to see which provider/model is used. If it is a Gemini model, focus on `backend_gemini.ml`.
+Look at `config/keepers/issue_king.toml` and its runtime binding to see which provider/model is used. If it is a Gemini model, compare raw `functionCall.args` with parsed `ToolUse.input`; do not assume a parser bug unless the parsed input still contains the outer `args` wrapper.
 
 ### 6.4 Check trajectory / telemetry
 
@@ -195,17 +195,18 @@ Search `.masc/trajectories/`, `logs/`, or telemetry for the affected `issue_king
 ### Immediate mitigation
 
 1. **Add defensive normalization in MASC for `Execute`**
-   - In `lib/keeper/keeper_tool_descriptor_resolution.ml` or `lib/keeper/keeper_tools_oas_handler.ml`, before calling `Tool_input_validation.validate`, normalize legacy shapes:
-     - If `input` has `args` object, unwrap it.
-     - If `input` has `command`/`cmd` string, rewrite to `executable`/`argv` (reuse OAS alias logic).
-   - This mirrors what OAS already does for `execute_command`/`Bash`/`Shell` aliases.
+   - In the validation boundary, unwrap only the exact provider/tool-call envelope shape:
+     `{"args": {"executable": ..., "argv": ...}}` → `{"executable": ..., "argv": ...}`.
+   - Keep `{"command": ...}`, `{"cmd": ...}`, `{"args": [...]}`, and mixed envelopes rejected unless a separate policy explicitly reintroduces legacy shell-string coercion.
+   - This preserves the typed argv contract while tolerating one narrow envelope shape that providers/models commonly use around function arguments.
 
-2. **Improve `tool_use_recovery.ml` to recognize `args`**
-   - Add `args` as an accepted tool-call envelope in text-block recovery.
+2. **Only consider `tool_use_recovery.ml` changes with separate evidence**
+   - Text-block recovery currently does not recognize `args`, so text that merely resembles a tool call should stay text.
+   - Add `args` as a recovery envelope only if there is evidence that valid provider/tool-call content is otherwise stranded in text blocks, and keep the same narrow inner-object validation.
 
-3. **Fix Gemini parser if `args` is leaking**
-   - Add an assertion in `backend_gemini.ml` that `ToolUse.input` never literally equals `{"args": ...}`.
-   - Add regression test with a mocked Gemini response containing nested `args`.
+3. **Add provider parser regression only if capture proves a leak**
+   - The normal Gemini parser already unwraps `functionCall.args` into `ToolUse.input`.
+   - If capture proves any provider returns parsed `ToolUse.input = {"args": ...}`, add a provider-local assertion/regression for that exact parser edge.
 
 ### Structural improvements
 
@@ -247,4 +248,4 @@ Search `.masc/trajectories/`, `logs/`, or telemetry for the affected `issue_king
 1. Identify which provider `issue_king` was using for the affected turn.
 2. Add a one-line diagnostic log in `lib/tool_input_validation.ml:411` to print the rejected `input` JSON.
 3. Reproduce or wait for the next occurrence; inspect the raw LLM response.
-4. Apply the fix corresponding to the actual leak path (most likely Gemini `args` unwrap or model hallucination via flattened schema).
+4. Apply the fix corresponding to the actual leak path (most likely model hallucination via flattened schema unless capture proves a provider parser edge).

--- a/docs/ROOT-CAUSE-Execute-args-rejection.md
+++ b/docs/ROOT-CAUSE-Execute-args-rejection.md
@@ -1,0 +1,250 @@
+# Root Cause: `Tool 'Execute' received unsupported field(s): args`
+
+> Scope: MASC (`~/me/workspace/yousleepwhen/masc`) `issue_king` keeper → `Execute` tool
+> Error observed:
+> `[2026-06-21 01:26:50] [WARN] [Keeper/issue_king] tool_policy_rejection: Execute — {"ok":false,"error":"Tool 'Execute' received unsupported field(s): args"}`
+> Date: 2026-06-21
+
+---
+
+## 1. What the error means
+
+The `Execute` tool received a JSON argument object that contains a field named `args`. The `Execute` tool schema is **closed** (`additionalProperties: false`), so any unexpected top-level field is rejected.
+
+The error is built in:
+
+- **`lib/tool_input_validation.ml:254`**
+  `Some (Printf.sprintf "received unsupported field(s): %s%s" names_text hint)`
+- **`lib/tool_input_validation.ml:411`**
+  `~message:(Printf.sprintf "Tool '%s' %s" name message)`
+
+which composes into:
+
+```
+Tool 'Execute' received unsupported field(s): args
+```
+
+---
+
+## 2. What `Execute` actually accepts
+
+Public name: `Execute`
+Internal name: `tool_execute`
+Schema location: `lib/tool_surface/tool_shard_types_schemas_execute.ml:233-278`
+
+Allowed top-level fields:
+
+| Field | Type | Required? |
+|---|---|---|
+| `executable` | string | required for single-process branch |
+| `argv` | array of strings | yes (single-process branch) |
+| `pipeline` | array of `{executable, argv}` stages | alternative branch |
+| `env` | object | optional |
+| `cwd` | string | optional |
+| `timeout_sec` | number | optional |
+| `stdin` | redirect object | optional |
+| `stdout` | redirect object | optional |
+| `stderr` | redirect object | optional |
+
+Schema properties:
+
+- `additionalProperties: false`
+- `oneOf`: either `executable`/`argv` **or** `pipeline`, never both.
+
+Therefore **any of these inputs are rejected**:
+
+```json
+{"args": ["ls", "-la"]}
+{"args": {"command": "ls -la"}}
+{"command": "ls -la"}
+{"cmd": "ls -la"}
+{"executable": "ls", "argv": ["-la"], "args": {}}
+```
+
+The correct shape is:
+
+```json
+{"executable": "ls", "argv": ["-la"]}
+```
+
+---
+
+## 3. Where the rejection happens in the call chain
+
+```
+issue_king turn
+  └─ OAS Agent.run_stream_blocks / run_blocks
+       └─ Pipeline.run_turn
+            └─ LLM provider response → ToolUse { name = "Execute"; input }
+                 └─ Agent_tools.execute_tools
+                      └─ Tool_input_validation.validate schema input
+                           └─ unsupported_arg_names detects "args"
+                                └─ Tool 'Execute' received unsupported field(s): args
+```
+
+The validation entry point in MASC is:
+
+- `lib/keeper/keeper_tools_oas_handler.ml:94` (`pre_validate_input`)
+- calls `lib/keeper/keeper_tool_descriptor_resolution.ml:112-122`
+- calls `lib/tool_input_validation.ml:350-463` (`validation_action`)
+- which calls `unsupported_arg_names` at `lib/tool_input_validation.ml:116-124`
+
+---
+
+## 4. Why `args` can appear in the input
+
+The field name `args` is used in several places, but it is **never** a valid field inside the `Execute` schema. It can leak into the tool input through these paths:
+
+### 4.1 Gemini provider wire format
+
+Gemini sends tool-call arguments under the key `functionCall.args`:
+
+- Request: `oas/lib/llm_provider/backend_gemini.ml:177`
+- Response: `oas/lib/llm_provider/backend_gemini.ml:436`
+- Streaming: `oas/lib/llm_provider/streaming.ml:977`
+
+The parser unwraps `args` into `ToolUse.input`:
+
+```ocaml
+ToolUse { id; name; input = args }
+```
+
+If this unwrap has a bug (e.g., reading the wrong nesting level, or the response shape differing from expectation), the literal `{"args": ...}` object can become `ToolUse.input`, and MASC validation rejects it.
+
+### 4.2 Model emits `args` inside a text block
+
+If the LLM emits tool-call-like JSON inside a text block, e.g.:
+
+```json
+{"name": "Execute", "args": {"command": "git status"}}
+```
+
+the OAS `tool_use_recovery.ml:103-144` does **not** recognize the `args` shape. It recognizes `input`, `arguments`, `parameters`, `tool_calls/function`, and bare `function`, but not `args`. The call would stay as text and not execute — unless MASC later parses it again somewhere else. However, if some intermediate layer tries to execute the text block as a tool call, the `args` field would reach validation.
+
+### 4.3 OAS bridge flattens the schema
+
+When MASC exposes `Execute` to OAS agents:
+
+- `masc/lib/tool_bridge.ml:150-210` (`params_of_json_schema`)
+- `masc/lib/runtime/runtime_agent.ml:1143-1178` (`run_with_masc_tools`)
+
+The schema is flattened into a flat `tool_param list`. This loses `oneOf`, `additionalProperties: false`, and mutual-exclusion constraints. The model may therefore generate invalid shapes more easily, including adding spurious fields like `args`.
+
+### 4.4 Legacy alias `execute_command` / `Bash` / `Shell`
+
+OAS has an alias layer (`oas/lib/agent/agent_tool_name_alias.ml:88-110`) that normalizes:
+
+- `execute_command` / `Bash` / `Shell` → `Execute`
+- Rewrites `{"command":"git status --short"}` → `{"executable":"git","argv":["status","--short"]}`
+
+But if the alias layer is **not** invoked (e.g., the model calls `Execute` directly, or the tool name is already `Execute`), no normalization happens. A `command`/`cmd`/`args` legacy field then reaches MASC validation and is rejected.
+
+### 4.5 Persona / prompt examples
+
+The `issue_king` persona (`config/personas/issue_king/profile.json`) and base keeper config (`config/keepers/base.toml`) explicitly instruct:
+
+> "PR 생성은 준비된 작업 브랜치에서 git push 후 별도 실행 축이 아니라 Execute typed argv 경로로 수행한다."
+
+This is correct, but if any few-shot example, memory, or older prompt template still shows an `args` or `command` wrapper, the model may copy it.
+
+---
+
+## 5. Most likely cause for `issue_king`
+
+`issue_king` is a normal keeper with no special `Execute` handling. It uses the same descriptor-backed tool surface as every other keeper.
+
+Given the error, the most likely scenarios are:
+
+1. **Gemini parser edge case** — if `issue_king` is configured to use a Gemini-compatible provider, the `args` field from `functionCall.args` is being passed through without unwrap under some response shape.
+2. **Model hallucinated `args`** — the flattened OAS bridge schema plus a confused prompt caused the model to emit `{"args": ...}` instead of `{"executable": ..., "argv": ...}`.
+3. **Legacy alias not applied** — the model called `Execute` directly while thinking it was `execute_command`/`Bash`, and included a `command` or `args` field. (The error would normally say `command`/`cmd` is unsupported, but if the field is `args`, this scenario is also possible.)
+
+The error says **`args`**, not `command`/`cmd`, which points most strongly to **scenario 1 (Gemini)** or a model-level JSON hallucination.
+
+---
+
+## 6. How to verify the exact cause
+
+### 6.1 Capture the raw LLM response
+
+Add temporary logging in the provider parser for the runtime used by `issue_king`:
+
+- If OpenAI-compatible: `oas/lib/llm_provider/backend_openai_parse.ml:268-286`
+- If Anthropic: `oas/lib/llm_provider/backend_anthropic.ml` / `oas/lib/llm_provider/api_common.ml:145-149`
+- If Gemini: `oas/lib/llm_provider/backend_gemini.ml:433-438`
+- If Ollama: `oas/lib/llm_provider/backend_ollama.ml:215-239`
+
+Log the raw response JSON and the resulting `ToolUse.input` before it reaches MASC.
+
+### 6.2 Capture the rejected input
+
+Add a log line in `lib/tool_input_validation.ml:411` to print `name` and the full `input` JSON when validation fails. This will show exactly what object contained `args`.
+
+### 6.3 Check provider binding for `issue_king`
+
+Look at `config/keepers/issue_king.toml` and its runtime binding to see which provider/model is used. If it is a Gemini model, focus on `backend_gemini.ml`.
+
+### 6.4 Check trajectory / telemetry
+
+Search `.masc/trajectories/`, `logs/`, or telemetry for the turn around `2026-06-21 01:26:50` for `issue_king`. The raw tool-call JSON should be present in the trajectory.
+
+---
+
+## 7. Recommended fixes
+
+### Immediate mitigation
+
+1. **Add defensive normalization in MASC for `Execute`**
+   - In `lib/keeper/keeper_tool_descriptor_resolution.ml` or `lib/keeper/keeper_tools_oas_handler.ml`, before calling `Tool_input_validation.validate`, normalize legacy shapes:
+     - If `input` has `args` object, unwrap it.
+     - If `input` has `command`/`cmd` string, rewrite to `executable`/`argv` (reuse OAS alias logic).
+   - This mirrors what OAS already does for `execute_command`/`Bash`/`Shell` aliases.
+
+2. **Improve `tool_use_recovery.ml` to recognize `args`**
+   - Add `args` as an accepted tool-call envelope in text-block recovery.
+
+3. **Fix Gemini parser if `args` is leaking**
+   - Add an assertion in `backend_gemini.ml` that `ToolUse.input` never literally equals `{"args": ...}`.
+   - Add regression test with a mocked Gemini response containing nested `args`.
+
+### Structural improvements
+
+4. **Preserve `additionalProperties: false` in the OAS bridge**
+   - Modify `lib/tool_bridge.ml` / `params_of_json_schema` to carry the closed-schema constraint into the OAS tool description, so the model is less likely to hallucinate extra fields.
+
+5. **Add a typed pre-check before OAS bridge**
+   - For `Execute`, validate/coerce the input immediately after provider parsing and before exposing it to the model loop, so bad shapes fail fast with a clearer error.
+
+6. **Audit persona/memory examples**
+   - Search all `.json` / `.toml` / `.md` under `config/` for any `Execute` example that uses `args`, `command`, or `cmd`, and replace with `executable`/`argv`.
+
+---
+
+## 8. Files to inspect / modify
+
+| File | Why |
+|---|---|
+| `config/keepers/issue_king.toml` | Provider/runtime binding for `issue_king` |
+| `config/personas/issue_king/profile.json` | Prompt examples mentioning Execute |
+| `config/keepers/base.toml` | Base prompt examples |
+| `oas/lib/llm_provider/backend_gemini.ml` | If provider is Gemini, check `args` unwrap |
+| `oas/lib/llm_provider/backend_openai_parse.ml` | If provider is OpenAI-compatible |
+| `oas/lib/llm_provider/backend_anthropic.ml` | If provider is Anthropic |
+| `oas/lib/llm_provider/backend_ollama.ml` | If provider is Ollama |
+| `oas/lib/agent/agent_tool_name_alias.ml` | Existing alias/normalization logic |
+| `oas/lib/agent/tool_use_recovery.ml` | Add `args` recognition |
+| `masc/lib/tool_bridge.ml` | Schema flattening issue |
+| `masc/lib/keeper/keeper_tool_descriptor_resolution.ml` | Where validation is invoked |
+| `masc/lib/keeper/keeper_tools_oas_handler.ml` | Pre-validation hook |
+| `masc/lib/tool_input_validation.ml` | Error origin; add diagnostic logging |
+| `masc/lib/tool_surface/tool_shard_types_schemas_execute.ml` | Canonical Execute schema |
+| `masc/lib/keeper/keeper_tool_execute_typed_input.ml` | Typed parsing rejection logic |
+
+---
+
+## 9. Next step
+
+1. Identify which provider `issue_king` was using at `2026-06-21 01:26:50`.
+2. Add a one-line diagnostic log in `lib/tool_input_validation.ml:411` to print the rejected `input` JSON.
+3. Reproduce or wait for the next occurrence; inspect the raw LLM response.
+4. Apply the fix corresponding to the actual leak path (most likely Gemini `args` unwrap or model hallucination via flattened schema).

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -85,8 +85,30 @@ let normalize_blank_optional_enum_args ?schema args =
   | _ -> args
 ;;
 
+let schema_property_names schema =
+  match Json_util.assoc_member_opt "properties" schema with
+  | Some (`Assoc props) -> List.map fst props
+  | _ -> []
+;;
+
+let schema_has_property_name schema name = List.mem name (schema_property_names schema)
+
+let is_execute_typed_argv_schema schema =
+  schema_has_property_name schema "executable"
+  && schema_has_property_name schema "argv"
+  && schema_has_property_name schema "pipeline"
+;;
+
+let normalize_execute_args_envelope ?schema args =
+  match schema, args with
+  | Some schema, `Assoc [ "args", (`Assoc _ as nested) ]
+    when is_execute_typed_argv_schema schema -> nested
+  | _ -> args
+;;
+
 let prepare_args ?schema ~name args =
   let args = strip_internal_marker_args args in
+  let args = normalize_execute_args_envelope ?schema args in
   normalize_blank_optional_enum_args ?schema args
 ;;
 
@@ -102,9 +124,7 @@ let schema_has_properties = function
 ;;
 
 let property_names schema =
-  match Json_util.assoc_member_opt "properties" schema with
-  | Some (`Assoc props) -> List.map fst props
-  | _ -> []
+  schema_property_names schema
 ;;
 
 let forbids_additional_properties schema =
@@ -123,7 +143,7 @@ let unsupported_arg_names schema = function
   | _ -> []
 ;;
 
-let schema_has_property schema name = List.mem name (property_names schema)
+let schema_has_property schema name = schema_has_property_name schema name
 
 let typed_shell_unsupported_field_hint schema names =
   let has_shell_fields =

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -99,16 +99,18 @@ let is_execute_typed_argv_schema schema =
   && schema_has_property_name schema "pipeline"
 ;;
 
-let normalize_execute_args_envelope ?schema args =
+let is_execute_tool_name name = String.equal name "Execute" || String.equal name "tool_execute"
+
+let normalize_execute_args_envelope ?schema ~name args =
   match schema, args with
   | Some schema, `Assoc [ "args", (`Assoc _ as nested) ]
-    when is_execute_typed_argv_schema schema -> nested
+    when is_execute_tool_name name && is_execute_typed_argv_schema schema -> nested
   | _ -> args
 ;;
 
 let prepare_args ?schema ~name args =
   let args = strip_internal_marker_args args in
-  let args = normalize_execute_args_envelope ?schema args in
+  let args = normalize_execute_args_envelope ?schema ~name args in
   normalize_blank_optional_enum_args ?schema args
 ;;
 

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -99,7 +99,16 @@ let is_execute_typed_argv_schema schema =
   && schema_has_property_name schema "pipeline"
 ;;
 
-let is_execute_tool_name name = String.equal name "Execute" || String.equal name "tool_execute"
+let execute_public_tool_name = "Execute"
+
+let is_execute_tool_name name =
+  let name = Tool_name_alias_axis.strip_mcp_masc_prefix name in
+  String.equal name execute_public_tool_name
+  ||
+  match Tool_name_alias_axis.internal_name_of_public execute_public_tool_name with
+  | Some internal_name -> String.equal name internal_name
+  | None -> false
+;;
 
 let normalize_execute_args_envelope ?schema ~name args =
   match schema, args with

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -900,6 +900,54 @@ let test_validate_args_execute_unwraps_args_object_envelope () =
       "expected Execute args object envelope to pass validation, got %s"
       (Yojson.Safe.to_string (Tool_result.data result))
 
+let test_validate_args_tool_execute_unwraps_args_object_envelope () =
+  let inner = `Assoc [ "executable", `String "pwd" ] in
+  let args = `Assoc [ "args", inner ] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:tool_execute_schema
+      ~name:"tool_execute"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool)
+      "internal tool_execute args object envelope unwrapped"
+      true
+      (Yojson.Safe.equal inner forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected tool_execute args object envelope to pass validation, got %s"
+      (Yojson.Safe.to_string (Tool_result.data result))
+
+let test_validate_args_execute_unwraps_pipeline_envelope () =
+  let inner =
+    `Assoc
+      [ ( "pipeline"
+        , `List
+            [ `Assoc [ "executable", `String "printf"; "argv", `List [ `String "x" ] ]
+            ; `Assoc [ "executable", `String "cat" ]
+            ] )
+      ]
+  in
+  let args = `Assoc [ "args", inner ] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:tool_execute_schema
+      ~name:"Execute"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool)
+      "pipeline args object envelope unwrapped"
+      true
+      (Yojson.Safe.equal inner forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected Execute pipeline args object envelope to pass validation, got %s"
+      (Yojson.Safe.to_string (Tool_result.data result))
+
 let test_validate_args_execute_rejects_args_array_envelope () =
   let args = `Assoc [ "args", `List [ `String "git"; `String "status" ] ] in
   match
@@ -946,6 +994,26 @@ let test_validate_args_execute_rejects_mixed_args_envelope () =
     let msg = Yojson.Safe.to_string (Tool_result.data result) in
     Alcotest.(check bool)
       "mixed envelope keeps args unsupported"
+      true
+      (string_contains msg "unsupported field(s): args")
+
+let test_validate_args_non_execute_rejects_args_object_envelope () =
+  let args = `Assoc [ "args", `Assoc [ "executable", `String "git" ] ] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:tool_execute_schema
+      ~name:"not_execute"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected non-Execute args envelope to be rejected, got %s"
+      (Yojson.Safe.to_string forwarded)
+  | Error result ->
+    let msg = Yojson.Safe.to_string (Tool_result.data result) in
+    Alcotest.(check bool)
+      "non-Execute name does not get Execute envelope normalization"
       true
       (string_contains msg "unsupported field(s): args")
 
@@ -2097,10 +2165,16 @@ let () =
         test_validate_args_tool_execute_accepts_typed_pipeline;
       Alcotest.test_case "Execute unwraps args object envelope" `Quick
         test_validate_args_execute_unwraps_args_object_envelope;
+      Alcotest.test_case "tool_execute unwraps args object envelope" `Quick
+        test_validate_args_tool_execute_unwraps_args_object_envelope;
+      Alcotest.test_case "Execute unwraps pipeline args envelope" `Quick
+        test_validate_args_execute_unwraps_pipeline_envelope;
       Alcotest.test_case "Execute rejects args array envelope" `Quick
         test_validate_args_execute_rejects_args_array_envelope;
       Alcotest.test_case "Execute rejects mixed args envelope" `Quick
         test_validate_args_execute_rejects_mixed_args_envelope;
+      Alcotest.test_case "non-Execute rejects args object envelope" `Quick
+        test_validate_args_non_execute_rejects_args_object_envelope;
       Alcotest.test_case "tool_execute write validation stays structural" `Quick
         test_tool_execute_write_validation_stays_structural;
       Alcotest.test_case "tool_execute find expression not rewritten" `Quick

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -874,6 +874,81 @@ let test_validate_args_tool_execute_accepts_typed_pipeline () =
       "expected typed tool_execute pipeline to pass validation, got %s"
       (Yojson.Safe.to_string (Tool_result.data result))
 
+let test_validate_args_execute_unwraps_args_object_envelope () =
+  let inner =
+    `Assoc
+      [ "executable", `String "git"
+      ; "argv", `List [ `String "status"; `String "--short" ]
+      ; "cwd", `String "/tmp"
+      ]
+  in
+  let args = `Assoc [ "args", inner ] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:tool_execute_schema
+      ~name:"Execute"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.(check bool)
+      "args object envelope unwrapped"
+      true
+      (Yojson.Safe.equal inner forwarded)
+  | Error result ->
+    Alcotest.failf
+      "expected Execute args object envelope to pass validation, got %s"
+      (Yojson.Safe.to_string (Tool_result.data result))
+
+let test_validate_args_execute_rejects_args_array_envelope () =
+  let args = `Assoc [ "args", `List [ `String "git"; `String "status" ] ] in
+  match
+    Tool_input_validation.validate_args
+      ~schema:tool_execute_schema
+      ~name:"Execute"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected Execute args array envelope to be rejected, got %s"
+      (Yojson.Safe.to_string forwarded)
+  | Error result ->
+    let msg = Yojson.Safe.to_string (Tool_result.data result) in
+    Alcotest.(check bool)
+      "unsupported args field remains rejected"
+      true
+      (string_contains msg "unsupported field(s): args")
+
+let test_validate_args_execute_rejects_mixed_args_envelope () =
+  let args =
+    `Assoc
+      [ ( "args"
+        , `Assoc
+            [ "executable", `String "git"
+            ; "argv", `List [ `String "status" ]
+            ] )
+      ; "cwd", `String "/tmp"
+      ]
+  in
+  match
+    Tool_input_validation.validate_args
+      ~schema:tool_execute_schema
+      ~name:"Execute"
+      ~args
+      ()
+  with
+  | Ok forwarded ->
+    Alcotest.failf
+      "expected mixed Execute args envelope to be rejected, got %s"
+      (Yojson.Safe.to_string forwarded)
+  | Error result ->
+    let msg = Yojson.Safe.to_string (Tool_result.data result) in
+    Alcotest.(check bool)
+      "mixed envelope keeps args unsupported"
+      true
+      (string_contains msg "unsupported field(s): args")
+
 let readonly_exec_input executable argv =
   match
     Keeper_tool_execute_typed_input.of_json
@@ -2020,6 +2095,12 @@ let () =
         test_validate_args_tool_execute_accepts_typed_exec;
       Alcotest.test_case "tool_execute accepts typed pipeline" `Quick
         test_validate_args_tool_execute_accepts_typed_pipeline;
+      Alcotest.test_case "Execute unwraps args object envelope" `Quick
+        test_validate_args_execute_unwraps_args_object_envelope;
+      Alcotest.test_case "Execute rejects args array envelope" `Quick
+        test_validate_args_execute_rejects_args_array_envelope;
+      Alcotest.test_case "Execute rejects mixed args envelope" `Quick
+        test_validate_args_execute_rejects_mixed_args_envelope;
       Alcotest.test_case "tool_execute write validation stays structural" `Quick
         test_tool_execute_write_validation_stays_structural;
       Alcotest.test_case "tool_execute find expression not rewritten" `Quick


### PR DESCRIPTION
## Summary

Fixes the `Execute` validation rejection documented in `docs/ROOT-CAUSE-Execute-args-rejection.md`:

```text
Tool 'Execute' received unsupported field(s): args
```

The narrow fix is to unwrap only the `Execute`/`tool_execute` provider/tool-call-style envelope shape:

```json
{"args": {"executable": "git", "argv": ["status", "--short"]}}
```

into the canonical typed Execute payload:

```json
{"executable": "git", "argv": ["status", "--short"]}
```

This does not reintroduce legacy shell strings. `{"command": ...}`, `{"cmd": ...}`, `{"args": ["git", "status"]}`, mixed envelopes, and non-Execute tool names remain rejected.

## Product impact

Keeps the typed argv contract intact while preventing a valid `Execute` args-object envelope from being rejected as an unsupported field.

## Evidence

Local checks:

- `git diff --check`
- `opam exec -- ocamlformat --check lib/tool_input_validation.ml test/test_tool_input_validation.ml`

Per operator direction, local Dune build/test is left to CI.

## Direct evidence

schema_version: 1

- Added `Tool_input_validation.normalize_execute_args_envelope`.
- Added tests for:
  - accepting a single `args` object envelope for `Execute`,
  - accepting the same envelope for internal `tool_execute`,
  - accepting pipeline form inside the envelope,
  - rejecting an `args` array envelope,
  - rejecting mixed `args` plus sibling fields,
  - rejecting the same envelope for a non-Execute tool name.

## Review evidence

- The patch is intentionally scoped by both tool name (`Execute`/`tool_execute`) and typed Execute schema shape (`executable`, `argv`, `pipeline`), so unrelated tools are unaffected.
- The canonical `Execute` schema remains closed with `additionalProperties=false`.
- The root-cause note does not claim a provider parser bug without raw response evidence.

## Linked issue

- Root-cause note: `docs/ROOT-CAUSE-Execute-args-rejection.md`
