### PR TITLE
fix(dashboard): stop unlayered .v2-app>* from clobbering overlay position

### DIFF
--- a/dashboard/src/styles/app-shell-v2-overlay-stacking.test.ts
+++ b/dashboard/src/styles/app-shell-v2-overlay-stacking.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+//
+// Regression guard for the `.v2-app > *` stacking rule (app-shell-v2.css).
+//
+// Tailwind v4's `.fixed` / `.absolute` / `.top-5` / `.right-5` utilities are
+// emitted inside `@layer utilities`, while every custom rule in app-shell-v2.css
+// is unlayered. Per the CSS cascade, unlayered declarations always beat layered
+// ones regardless of specificity — so a bare `.v2-app > * { position: relative }`
+// silently overrides the layered `.fixed` of any direct-child overlay, dropping
+// it into normal flow. That is exactly what pushed the toast host off-screen to
+// the bottom of the `h-screen; overflow-hidden` shell column.
+//
+// happy-dom resolves no cascade/layout, so this defect is invisible to a normal
+// component test. This guard asserts the SOURCE selector keeps positioned
+// overlays excluded, locking the fix against a future revert to the bare form.
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'postcss'
+
+const css = readFileSync(resolve(__dirname, 'app-shell-v2.css'), 'utf-8')
+
+interface ChildRule {
+  selector: string
+  decls: Record<string, string>
+}
+
+/** Every rule whose selector targets the direct children of `.v2-app`
+ *  (`.v2-app > *` …), with its declarations. */
+function v2AppChildRules(): ChildRule[] {
+  const rules: ChildRule[] = []
+  parse(css).walkRules((rule) => {
+    for (const selector of rule.selectors) {
+      if (!/^\.v2-app\s*>\s*\*/.test(selector)) continue
+      const decls: Record<string, string> = {}
+      rule.walkDecls((decl) => {
+        decls[decl.prop] = decl.value.trim()
+      })
+      rules.push({ selector, decls })
+    }
+  })
+  return rules
+}
+
+// The overlay classes that position themselves (Tailwind utility or custom
+// class) and therefore must NOT be forced back to position:relative.
+const EXCLUDED_OVERLAY_CLASSES = [':not(.fixed)', ':not(.absolute)', ':not(.dock-fab)', ':not(.twk-panel)']
+
+describe('app-shell-v2.css `.v2-app > *` stacking rule', () => {
+  it('positions in-flow children with position:relative and z-index:1', () => {
+    const positionRules = v2AppChildRules().filter((r) => r.decls.position !== undefined)
+    expect(positionRules.length).toBeGreaterThan(0)
+    for (const rule of positionRules) {
+      expect(rule.decls.position).toBe('relative')
+      expect(rule.decls['z-index']).toBe('1')
+    }
+  })
+
+  it('excludes every positioned overlay so the unlayered rule never clobbers a layered .fixed', () => {
+    const positionRules = v2AppChildRules().filter((r) => r.decls.position !== undefined)
+    for (const rule of positionRules) {
+      for (const exclusion of EXCLUDED_OVERLAY_CLASSES) {
+        expect(rule.selector).toContain(exclusion)
+      }
+    }
+  })
+
+  it('has no bare `.v2-app > *` rule that would force position onto overlays', () => {
+    const bare = v2AppChildRules().find(
+      (r) => /^\.v2-app\s*>\s*\*$/.test(r.selector) && r.decls.position !== undefined,
+    )
+    expect(bare).toBeUndefined()
+  })
+})

--- a/dashboard/src/styles/app-shell-v2-overlay-stacking.test.ts
+++ b/dashboard/src/styles/app-shell-v2-overlay-stacking.test.ts
@@ -3,16 +3,15 @@
 // Regression guard for the `.v2-app > *` stacking rule (app-shell-v2.css).
 //
 // Tailwind v4's `.fixed` / `.absolute` / `.top-5` / `.right-5` utilities are
-// emitted inside `@layer utilities`, while every custom rule in app-shell-v2.css
-// is unlayered. Per the CSS cascade, unlayered declarations always beat layered
-// ones regardless of specificity — so a bare `.v2-app > * { position: relative }`
-// silently overrides the layered `.fixed` of any direct-child overlay, dropping
-// it into normal flow. That is exactly what pushed the toast host off-screen to
-// the bottom of the `h-screen; overflow-hidden` shell column.
+// emitted inside `@layer utilities`. A bare unlayered `.v2-app > * { position:
+// relative }` silently overrides the layered `.fixed` of any direct-child
+// overlay, dropping it into normal flow. That is exactly what pushed the toast
+// host off-screen to the bottom of the `h-screen; overflow-hidden` shell column.
 //
 // happy-dom resolves no cascade/layout, so this defect is invisible to a normal
-// component test. This guard asserts the SOURCE selector keeps positioned
-// overlays excluded, locking the fix against a future revert to the bare form.
+// component test. This guard asserts the SOURCE rule stays in a lower cascade
+// layer than Tailwind utilities, locking the fix against a future unlayered
+// revert or overlay-class allowlist.
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -23,6 +22,26 @@ const css = readFileSync(resolve(__dirname, 'app-shell-v2.css'), 'utf-8')
 interface ChildRule {
   selector: string
   decls: Record<string, string>
+  layers: string[]
+}
+
+interface CssParent {
+  type: string
+  name?: string
+  params?: string
+  parent?: CssParent
+}
+
+function layerAncestors(rule: { parent?: CssParent }): string[] {
+  const layers: string[] = []
+  let parent = rule.parent
+  while (parent !== undefined) {
+    if (parent.type === 'atrule' && parent.name === 'layer' && parent.params !== undefined) {
+      layers.push(parent.params.trim())
+    }
+    parent = parent.parent
+  }
+  return layers
 }
 
 /** Every rule whose selector targets the direct children of `.v2-app`
@@ -36,15 +55,27 @@ function v2AppChildRules(): ChildRule[] {
       rule.walkDecls((decl) => {
         decls[decl.prop] = decl.value.trim()
       })
-      rules.push({ selector, decls })
+      rules.push({
+        selector,
+        decls,
+        layers: layerAncestors(rule),
+      })
     }
   })
   return rules
 }
 
-// The overlay classes that position themselves (Tailwind utility or custom
-// class) and therefore must NOT be forced back to position:relative.
-const EXCLUDED_OVERLAY_CLASSES = [':not(.fixed)', ':not(.absolute)', ':not(.dock-fab)', ':not(.twk-panel)']
+function topLevelLayerOrder(): string[] {
+  const order: string[] = []
+  parse(css).walkAtRules('layer', (rule) => {
+    if (rule.parent?.type !== 'root') return
+    if (rule.nodes !== undefined) return
+    for (const name of rule.params.split(',')) {
+      order.push(name.trim())
+    }
+  })
+  return order
+}
 
 describe('app-shell-v2.css `.v2-app > *` stacking rule', () => {
   it('positions in-flow children with position:relative and z-index:1', () => {
@@ -56,19 +87,25 @@ describe('app-shell-v2.css `.v2-app > *` stacking rule', () => {
     }
   })
 
-  it('excludes every positioned overlay so the unlayered rule never clobbers a layered .fixed', () => {
+  it('keeps the shell child positioning rule in the app-shell cascade layer', () => {
     const positionRules = v2AppChildRules().filter((r) => r.decls.position !== undefined)
     for (const rule of positionRules) {
-      for (const exclusion of EXCLUDED_OVERLAY_CLASSES) {
-        expect(rule.selector).toContain(exclusion)
-      }
+      expect(rule.layers).toContain('app-shell')
     }
   })
 
-  it('has no bare `.v2-app > *` rule that would force position onto overlays', () => {
-    const bare = v2AppChildRules().find(
-      (r) => /^\.v2-app\s*>\s*\*$/.test(r.selector) && r.decls.position !== undefined,
-    )
-    expect(bare).toBeUndefined()
+  it('declares app-shell before utilities so Tailwind positioning wins', () => {
+    const order = topLevelLayerOrder()
+    expect(order).toContain('app-shell')
+    expect(order).toContain('utilities')
+    expect(order.indexOf('app-shell')).toBeLessThan(order.indexOf('utilities'))
+  })
+
+  it('does not bake overlay class exclusions into the shell child selector', () => {
+    const positionRules = v2AppChildRules().filter((r) => r.decls.position !== undefined)
+    for (const rule of positionRules) {
+      expect(rule.selector).toBe('.v2-app > *')
+      expect(rule.selector).not.toContain(':not(')
+    }
   })
 })

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -165,8 +165,18 @@
     radial-gradient(900px 500px at -5% 110%, rgba(0, 0, 0, 0.02), transparent 60%);
 }
 
-/* Ensure shell children render above the decorative background. */
-.v2-app > * {
+/* Lift in-flow shell children above the decorative .v2-app::before plane
+   (z-index:0). Fixed/absolute overlays are excluded: they carry their own
+   position + z-[var(--z-overlay-*)] stacking, and forcing position:relative on
+   them would drop them into normal flow — which is what pushed the toast host
+   off-screen to the bottom of the h-screen column. The Tailwind .fixed/.absolute
+   utilities live in @layer utilities, which this unlayered rule would otherwise
+   override (unlayered styles always win over layered ones). .dock-fab and
+   .twk-panel position via custom classes rather than the utility, so they are
+   excluded by name as well.
+   Follow-up: migrate every overlay onto the .fixed utility or a shared overlay
+   class so this rule no longer has to enumerate them. */
+.v2-app > *:not(.fixed):not(.absolute):not(.dock-fab):not(.twk-panel) {
   position: relative;
   z-index: 1;
 }

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -14,7 +14,7 @@
    Defined at :root so v2-shell.css and shell components can share them.
    ═══════════════════════════════════════════════════════════════ */
 
-@layer theme-defaults, theme-overrides;
+@layer app-shell, theme-defaults, theme-overrides, utilities;
 
 @layer theme-defaults {
   :root {
@@ -166,19 +166,14 @@
 }
 
 /* Lift in-flow shell children above the decorative .v2-app::before plane
-   (z-index:0). Fixed/absolute overlays are excluded: they carry their own
-   position + z-[var(--z-overlay-*)] stacking, and forcing position:relative on
-   them would drop them into normal flow — which is what pushed the toast host
-   off-screen to the bottom of the h-screen column. The Tailwind .fixed/.absolute
-   utilities live in @layer utilities, which this unlayered rule would otherwise
-   override (unlayered styles always win over layered ones). .dock-fab and
-   .twk-panel position via custom classes rather than the utility, so they are
-   excluded by name as well.
-   Follow-up: migrate every overlay onto the .fixed utility or a shared overlay
-   class so this rule no longer has to enumerate them. */
-.v2-app > *:not(.fixed):not(.absolute):not(.dock-fab):not(.twk-panel) {
-  position: relative;
-  z-index: 1;
+   (z-index:0). Keep this in a lower cascade layer so Tailwind utilities and
+   unlayered overlay classes can define their own positioning without being
+   forced back into normal flow. */
+@layer app-shell {
+  .v2-app > * {
+    position: relative;
+    z-index: 1;
+  }
 }
 
 /* Density variants (data-density mirrors v2 tweak panel). */

--- a/dashboard/src/styles/paper-theme.test.ts
+++ b/dashboard/src/styles/paper-theme.test.ts
@@ -11,7 +11,7 @@ const appShellCss = readFileSync(appShellCssPath, 'utf-8')
 
 describe('paper-theme.css', () => {
   it('uses cascade layers rather than selector specificity to override v2 defaults', () => {
-    expect(appShellCss).toContain('@layer theme-defaults, theme-overrides;')
+    expect(appShellCss).toContain('@layer app-shell, theme-defaults, theme-overrides, utilities;')
     expect(paperCss).toContain('[data-theme="paper"] {')
     expect(paperCss).not.toContain('html[data-theme="paper"] {')
   })


### PR DESCRIPTION
## 증상

라이브 대시보드에서 토스트가 우상단(`top-5 right-5`)이 아니라 **화면 하단 밖(off-screen)**에 렌더되어 보이지 않는다.

## 근본 원인 (결정론적 + 라이브 + 빌드 확인)

- Tailwind v4의 `.fixed` / `.top-5` / `.right-5` 유틸은 `@layer utilities`(layered)에 emit되고, `app-shell-v2.css`의 `.v2-app > * { position: relative; z-index: 1 }`는 **unlayered**였다.
- CSS cascade상 **unlayered 선언은 layered 선언을 항상 이긴다**(specificity 무관). 그래서 `.v2-app`의 직접 자식인 토스트 컨테이너(`app.ts:423`, `common/toast.ts:168`)가 `position: fixed` 대신 `position: relative`로 강제되고, `top-5`/`right-5`가 flow상 위치(= `h-screen; overflow-hidden` 컬럼 맨 아래) 기준 오프셋이 되어 화면 밖으로 잘렸다.
- 라이브 prod 빌드(`:8935`) computed-style probe: `.fixed top-5 right-5` 합성 요소를 `.v2-app` 직접 자식으로 붙이면 `position: relative`, `document.body`에 붙이면 `'fixed'`(top: 20px, right: 20px). `.v2-app`은 `transform`/`filter`/`contain`/`will-change`/`perspective`가 모두 none이라 containing block을 만들지 않는다 — 유일한 원인은 `.v2-app > *` clobber.

## 영향 범위 (토스트만이 아님)

같은 unlayered 규칙이 `.v2-app` 직접 자식인 모든 positioned 오버레이를 `position: relative`로 강제했다:

- `ToastContainer` (보고된 버그)
- `AgentDetailOverlay` / `TaskDetailOverlay` / `ConfirmDialogOverlay` (`DialogOverlay` 루트 div, `fixed inset-0`)
- `DashboardStatusTray`, `DashboardFocusModeToggle`, `BundleStalenessBanner`
- `TweaksPanel`(`.twk-panel`)은 커스텀 클래스 positioning이라 **이미 깨져 있었다**

## 수정 — cascade layer

`.v2-app > *` 규칙을 `@layer app-shell`로 감싸고, app-shell을 `utilities`보다 **앞**(= 낮은 우선순위)에 선언한다:

```css
@layer app-shell, theme-defaults, theme-overrides, utilities;

@layer app-shell {
  .v2-app > * { position: relative; z-index: 1; }
}
```

- Tailwind 유틸이 사는 `@layer utilities`가 `@layer app-shell`을 이기므로 `.fixed`/`.top-5`/`.right-5`가 `.v2-app > *`를 override → 오버레이가 자기 positioning을 되찾는다.
- unlayered 커스텀 클래스(`.dock-fab`, `.twk-panel`)는 모든 layer를 이기므로 함께 복원된다(이미 깨졌던 `TweaksPanel` 포함).
- in-flow shell 자식(header / strips / `.v2-shell-stage`)은 경쟁 규칙이 없어 그대로 `position: relative; z-index: 1`로 장식 배경 `.v2-app::before`(z-index:0) 위에 유지된다.

**빌드 검증**: `vite build` 출력의 병합 `@layer` 순서가 `app-shell(0) < theme-defaults < theme-overrides < utilities(3) < theme < base < components`로 확정 — `app-shell`이 `utilities`보다 앞이라 utilities가 우선. 즉 runtime에서 `.fixed`가 `.v2-app > *`를 이긴다(isolated-file 테스트만으로는 병합 순서를 못 잡으므로 빌드 출력으로 직접 확인).

## 대안 기각

- **createPortal**: 토스트만 고치고 나머지 6개를 방치 = root cause가 하나인데 site별로 메우는 패치. `createPortal`은 `dashboard/src`에 전무(새 패턴 도입) + 노드를 `document.body`로 옮겨 `container.querySelector` 기반 토스트 테스트를 깨뜨린다.
- **`:not(.fixed):not(.absolute):not(.dock-fab):not(.twk-panel)` 셀렉터 enumeration**: 클래스명을 규칙에 박아 새 오버레이마다 재발하고 unlayered 클래스를 일일이 나열해야 한다. layer 방식은 enumeration 없이 cascade 레벨에서 근본 수정한다.

## 검증

- `dashboard/src/styles/app-shell-v2-overlay-stacking.test.ts` (신규): PostCSS AST로 `.v2-app > *` position 규칙이 `@layer app-shell` 안에 있고, app-shell이 utilities보다 앞에 선언되며, 셀렉터에 클래스 exclusion(`:not(...)`)을 박지 않았음을 단언. happy-dom은 cascade를 계산하지 못하므로 소스 구조 가드.
- `npm run typecheck` clean, `npm run lint` exit 0. `toast` / `toast.a11y` / `paper-theme`(layer 선언 갱신) + 신규 가드 테스트 30개 통과.
- `vite build` 출력의 병합 `@layer` 순서로 runtime cascade 확정(위) + 라이브 prod computed-style probe로 원인 경험 확인.

## Follow-up — #21848

- (해결됨) 클래스 enumeration 취약성은 본 PR의 layer 방식으로 제거됨.
- (잔여) Vite/Tailwind v4 빌드 출력에 app-shell CSS 블록이 두 번 직렬화되는 아티팩트(번들 비대 + cascade fragility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
