### PR TITLE
fix(fusion): surface web_tools in masc_fusion keeper tool schema (RFC-0252)

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -776,6 +776,13 @@ let masc_fusion_schema =
         "string"
         "Panel preset name from runtime.toml [fusion.presets]. Omitted uses \
          the configured default_preset."
+    ; property
+        "web_tools"
+        "boolean"
+        "When true, the panel and judge agents are given web_search / \
+         web_fetch tools to ground their answers. Defaults to false; the \
+         selected preset may also enable web tools on its own (the effective \
+         setting is this flag OR the preset's)."
     ]
 ;;
 
@@ -1187,7 +1194,9 @@ let internal_descriptors : t list =
          insights, and blind spots. Advisory only: this keeper turn continues \
          immediately and the synthesis arrives asynchronously on this keeper's \
          chat lane (also visible in the dashboard). Returns a status with a \
-         run_id. Gated by runtime.toml [fusion] (disabled by default)."
+         run_id. Set web_tools=true to let the panel and judge ground their \
+         answers with web_search / web_fetch. Gated by runtime.toml [fusion] \
+         (disabled by default)."
       ~input_schema:masc_fusion_schema
       (* RFC-0252 §159/§177: 심의 가치는 키퍼(이미 LLM)가 스스로 판단해
          masc_fusion 을 직접 호출하는 것으로 표현된다. 따라서 키퍼가 LLM 도구

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -286,8 +286,8 @@ let test_keeper_inventory_materializes_masc_fusion_schema () =
    web_search / web_fetch into the panel and judge. If the keeper-facing schema
    omits web_tools, the keeper LLM has no surfaced way to enable it (the field is
    only reachable by guessing the exact name). Assert the *materialized* schema —
-   what the keeper actually receives — declares it, so descriptor<->handler drift
-   on this arg fails the build. *)
+   what the keeper actually receives — declares it as a boolean, so
+   descriptor<->handler drift on this arg fails the build. *)
 let test_masc_fusion_schema_declares_web_tools () =
   match
     List.find_opt
@@ -308,7 +308,18 @@ let test_masc_fusion_schema_declares_web_tools () =
       check bool
         "masc_fusion schema declares web_tools (descriptor<->handler parity)"
         true
-        (List.mem_assoc "web_tools" props)
+        (List.mem_assoc "web_tools" props);
+      let web_tools_type =
+        match List.assoc_opt "web_tools" props with
+        | Some (`Assoc fields) -> List.assoc_opt "type" fields
+        | _ -> None
+      in
+      check (option string)
+        "masc_fusion web_tools schema type matches handler bool parser"
+        (Some "boolean")
+        (match web_tools_type with
+         | Some (`String value) -> Some value
+         | _ -> None)
 
 let test_keeper_oas_bundle_materializes_masc_fusion_tool () =
   let marker = Filename.temp_file "keeper-fusion-schema-" ".tmp" in

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -281,6 +281,35 @@ let test_keeper_inventory_materializes_masc_fusion_schema () =
   check bool "masc_fusion schema is materialized" true
     (List.mem "masc_fusion" Cases.all_keeper_tool_names)
 
+(* Drift-guard: Fusion_tool.handle reads web_tools (Tool_args.get_bool args
+   "web_tools") and fusion_orchestrator ORs it with the preset to inject
+   web_search / web_fetch into the panel and judge. If the keeper-facing schema
+   omits web_tools, the keeper LLM has no surfaced way to enable it (the field is
+   only reachable by guessing the exact name). Assert the *materialized* schema —
+   what the keeper actually receives — declares it, so descriptor<->handler drift
+   on this arg fails the build. *)
+let test_masc_fusion_schema_declares_web_tools () =
+  match
+    List.find_opt
+      (fun (schema : Masc_domain.tool_schema) ->
+        String.equal schema.name "masc_fusion")
+      (Cases.all_keeper_tool_schemas ())
+  with
+  | None -> fail "masc_fusion schema must be materialized"
+  | Some schema ->
+      let props =
+        match schema.input_schema with
+        | `Assoc fields -> (
+            match List.assoc_opt "properties" fields with
+            | Some (`Assoc props) -> props
+            | _ -> [])
+        | _ -> []
+      in
+      check bool
+        "masc_fusion schema declares web_tools (descriptor<->handler parity)"
+        true
+        (List.mem_assoc "web_tools" props)
+
 let test_keeper_oas_bundle_materializes_masc_fusion_tool () =
   let marker = Filename.temp_file "keeper-fusion-schema-" ".tmp" in
   Sys.remove marker;
@@ -344,6 +373,8 @@ let () =
             test_keeper_inventory_has_cases;
           test_case "keeper inventory materializes masc_fusion schema" `Quick
             test_keeper_inventory_materializes_masc_fusion_schema;
+          test_case "masc_fusion schema declares web_tools" `Quick
+            test_masc_fusion_schema_declares_web_tools;
           test_case "keeper OAS bundle materializes masc_fusion tool" `Quick
             test_keeper_oas_bundle_materializes_masc_fusion_tool;
         ] );


### PR DESCRIPTION
## 목적
`masc_fusion` 키퍼 도구의 descriptor 스키마에서 누락된 `web_tools` 인자를 표면에 노출한다.

## 배경 (적대 검증)
fusion 표면 노출 적대 감사(5 차원 × map→refute, 10 에이전트)에서 confirmed gap(med) 1건이 나왔다:
- `lib/fusion/fusion_tool.ml:58`이 `web_tools = Tool_args.get_bool args "web_tools" false`로 인자를 읽고,
- `lib/fusion/fusion_orchestrator.ml`이 `req.web_tools || preset.web_tools`로 panel·judge에 `web_search`/`web_fetch`를 주입하는 **독립적 live enabler**다.
- 그런데 키퍼-facing `masc_fusion_schema`는 `prompt`+`preset`만 선언 → 키퍼 LLM은 web_tools 존재를 볼 방법이 없었다. 스키마가 open(additionalProperties 없음)이고 SDK validator가 미선언 필드를 보존하므로 **정확한 이름을 추측해야만** 동작.
- RFC-0252/RFC-0266 어디에도 web_tools를 키퍼 입력에서 숨긴다는 언급이 없다 → descriptor↔handler **drift(사고)**, 의도된 비노출 아님. `lib/fusion/fusion_tool.mli:24`도 "prompt 필수; preset/web_tools 선택"으로 키퍼 인자임을 명시.

나머지 4 차원(visibility=Default 프롬프트 도달, dispatch 배선, runtime gate honesty, masc_fusion_status sibling)은 적대 refute를 견뎌 confirmed_correct였다.

## 변경
- `lib/keeper/keeper_tool_descriptor.ml`: `masc_fusion_schema`에 `web_tools` boolean property 추가 + 도구 description에 한 문장 추가.
- `test/test_keeper_tool_matrix.ml`: drift-guard 테스트 추가 — **materialized 키퍼 스키마**(`Cases.all_keeper_tool_schemas` = `keeper_universe_model_tools`)의 `properties`에 `web_tools`가 선언됐는지 assert. descriptor→키퍼 universe 전 경로를 검증해 향후 같은 drift를 빌드에서 차단.

## RFC
RFC-0252 (fusion panel+judge deliberation) — web_tools는 이 RFC의 web-grounding 기능(panel/judge web_search·web_fetch 주입)의 키퍼 노출분이다. 신규 기능이 아니라 기존 핸들러/orchestrator/panel/judge 지원과 descriptor 스키마의 drift를 일치시키는 root fix.

## 검증
- ocamlformat --check 통과(두 파일).
- 로컬 빌드 불가(lib/keeper는 agent_sdk 의존, 로컬 opam 0.93.2 vs pin drift) → 컴파일/테스트는 CI 게이트. drift-guard 테스트가 회귀 방지.

## 워크어라운드 시그니처
해당 없음. telemetry-as-fix / string-classifier / N-of-M / cap-cooldown-dedup-repair 아님 — 핸들러가 이미 받는 인자를 스키마에 선언하는 root fix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
