### PR TITLE
fix(keeper): volatile re-observe inherits anchor, not re-verification (RFC-0259 P6/F)

### DIFF
--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -39,25 +39,34 @@ let retention_rank ~now (f : fact) =
 
 (* RFC-0247 (purge): fold a re-observation of an existing fact into that fact.
    [existing] is the persisted row; [incoming] is the newly extracted claim with
-   the same normalized identity. The librarian re-extracting the same claim is
-   fresh evidence that the claim still holds, so [last_verified_at] advances to
-   [now] and the staleness marker resets. Identity and first-seen provenance are
-   preserved.
+   the same normalized identity. Identity and first-seen provenance are always
+   preserved (the merge returns [{ existing with ... }]).
 
-   RFC-0259 §3.2(b): re-observing IS re-verification, so a volatile (external-ref)
-   claim's decay horizon is refreshed from [now] — the disk re-derive anchors to
-   [first_seen], this anchors to the fresh sighting, so an actively-re-seen status
-   claim survives while an abandoned one decays. A non-volatile fact keeps its
-   [valid_until] (durable [None] or the original Ephemeral expiry).
+   RFC-0259 §3.7 (P6/F) — producer re-observation is NOT re-verification for a
+   volatile (external-ref) claim. This REVERSES the prior §3.2(b) rule. The
+   librarian re-extracting "PR #42 is open" from its own session history is not
+   evidence the PR is still open; only the grounding reconciler
+   ([Keeper_memory_os_reconcile], which checks the external referent) is real
+   re-verification. So a volatile re-observe INHERITS the prior row's anchor
+   unchanged ([first_seen], [last_verified_at], [valid_until]); the volatile TTL
+   and the [UNVERIFIED] grounding horizon keep ticking from the last *real*
+   verification (or first extraction). Advancing the anchor on every producer
+   re-extraction — the old behavior — let an actively re-extracted false claim
+   never age out and never render [UNVERIFIED] (RFC-0259 defect C1 residual
+   loop): the same false fact was re-injected into the prompt every cycle. Only
+   the reconciler advances the anchor ([keeper_memory_os_reconcile.ml],
+   [Stale_open] verdict); the producer inherits it.
+
+   A non-volatile fact ([external_ref = None]) has no external ground truth to
+   reconcile against, so re-extraction by the librarian is its only verification
+   signal and [last_verified_at] still advances. [valid_until] (durable [None]
+   or the original Ephemeral expiry) is preserved by [with].
 
    The prior merge also blended a confidence float and bumped an access counter;
    both fed the deleted composite score and are gone. There is no numeric
    strength to move — re-observation is a binary "seen again now". *)
 let reobserve_fact ~now ~existing ~incoming:(_ : fact) =
-  let valid_until =
-    match existing.external_ref with
-    | Some _ -> Some (now +. volatile_external_ttl_seconds)
-    | None -> existing.valid_until
-  in
-  { existing with last_verified_at = Some now; valid_until }
+  match existing.external_ref with
+  | Some _ -> existing
+  | None -> { existing with last_verified_at = Some now }
 ;;

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3213,24 +3213,38 @@ let test_fact_to_json_omits_external_ref_when_none () =
     (contains "external_ref" json_str)
 ;;
 
-let test_reobserve_refreshes_volatile_horizon () =
+(* RFC-0259 §3.7 (P6/F): producer re-observation is NOT re-verification for a
+   volatile (external-ref) claim. Re-extracting "PR #42 is OPEN" from session
+   history is not evidence the PR is still open — only the grounding reconciler
+   checks the external referent. So a producer re-observe INHERITS the prior
+   row's anchor unchanged ([first_seen], [last_verified_at], [valid_until]) and
+   the volatile TTL / [UNVERIFIED] horizon keeps ticking from the last real
+   verification. This reverses the prior "re-observing IS re-verification" rule,
+   which let an actively re-extracted false claim never age out and never render
+   [UNVERIFIED] (RFC-0259 defect C1 residual loop). The reconciler-side advance
+   (Stale_open) is exercised separately in the reconcile-io suite. *)
+let test_reobserve_volatile_inherits_anchor () =
   let now = 5_000_000.0 in
   let older = now -. 100_000.0 in
   let volatile =
     { (fact_fixture ~now:older ()) with
       Types.claim = "PR #42 is OPEN"
     ; Types.external_ref = Some { Types.kind = Types.Pr; Types.id = "42" }
+    ; Types.first_seen = older
+    ; Types.last_verified_at = Some older
     ; Types.valid_until = Some (older +. Types.volatile_external_ttl_seconds)
     }
   in
-  let refreshed = Policy.reobserve_fact ~now ~existing:volatile ~incoming:volatile in
-  match refreshed.Types.valid_until with
-  | None -> Alcotest.fail "volatile fact lost its horizon on reobserve"
-  | Some vu ->
-    Alcotest.(check (float 0.001))
-      "horizon re-anchored to now on re-observation"
-      (now +. Types.volatile_external_ttl_seconds)
-      vu
+  let merged = Policy.reobserve_fact ~now ~existing:volatile ~incoming:volatile in
+  Alcotest.(check (option (float 0.001)))
+    "valid_until inherited, NOT re-anchored to now (producer is not re-verification)"
+    (Some (older +. Types.volatile_external_ttl_seconds))
+    merged.Types.valid_until;
+  Alcotest.(check (option (float 0.001)))
+    "last_verified_at inherited (producer re-extraction does not advance the anchor)"
+    (Some older)
+    merged.Types.last_verified_at;
+  Alcotest.(check (float 0.001)) "first_seen preserved" older merged.Types.first_seen
 ;;
 
 let test_retention_rank_demotes_volatile () =
@@ -3550,9 +3564,9 @@ let () =
             `Quick
             test_fact_to_json_omits_external_ref_when_none
         ; Alcotest.test_case
-            "reobserve refreshes a volatile claim's horizon"
+            "reobserve inherits a volatile claim's anchor (RFC-0259 P6/F)"
             `Quick
-            test_reobserve_refreshes_volatile_horizon
+            test_reobserve_volatile_inherits_anchor
         ; Alcotest.test_case
             "retention rank demotes a volatile fact below durable"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -510,6 +510,59 @@ let test_librarian_ephemeral_fact_has_ttl () =
   | None -> Alcotest.fail "expected librarian output to parse"
 ;;
 
+(* RFC-0259 §3.2 producer boundary: a freshly extracted claim that names an
+   external referent is born volatile even when the librarian labels it as a
+   durable Fact. This locks the initial writer path, not just the pure
+   [fact_valid_until] helper: the first row gets a finite [valid_until] anchored
+   to its first extraction timestamp, and P6/F re-observe later inherits that
+   anchor instead of refreshing it. *)
+let test_librarian_external_ref_fact_is_born_volatile () =
+  let now = 1_000_000.0 in
+  let output =
+    `Assoc
+      [ "episode_summary", `String "external state claim"
+      ; ( "claims"
+        , `List
+            [ `Assoc
+                [ "claim", `String "PR #42 is OPEN and mergeable"
+                ; "confidence", `Float 0.9
+                ; "category", `String "fact"
+                ; "source_turn", `Int 0
+                ]
+            ] )
+      ; "open_items", `List []
+      ; "constraints", `List []
+      ; "preserved_tool_refs", `List []
+      ]
+    |> Yojson.Safe.to_string
+  in
+  let inp : Librarian.input =
+    { Librarian.trace_id = "trace-volatile-birth"
+    ; generation = 0
+    ; messages = [ text_message "PR #42 is OPEN and mergeable" ]
+    }
+  in
+  match Librarian.episode_of_output ~now ~generation:inp.generation inp output with
+  | Some { Types.claims = [ fact ]; _ } ->
+    Alcotest.(check string) "claim parsed" "PR #42 is OPEN and mergeable" fact.claim;
+    (match fact.external_ref with
+     | Some { Types.kind = Types.Pr; id = "42" } -> ()
+     | Some _ -> Alcotest.fail "expected PR #42 external_ref"
+     | None -> Alcotest.fail "expected external_ref at producer boundary");
+    Alcotest.(check (float 0.001)) "first_seen anchored to extraction time" now fact.first_seen;
+    Alcotest.(check (option (float 0.001)))
+      "volatile valid_until anchored to initial extraction"
+      (Some (now +. Types.volatile_external_ttl_seconds))
+      fact.valid_until;
+    Alcotest.(check (option (float 0.001)))
+      "initial extraction is the initial verification anchor"
+      (Some now)
+      fact.last_verified_at
+  | Some episode ->
+    Alcotest.failf "expected one claim, got %d" (List.length episode.Types.claims)
+  | None -> Alcotest.fail "expected librarian output to parse"
+;;
+
 let test_librarian_accepts_wrapped_json_output () =
   let inp : Librarian.input =
     { Librarian.trace_id = "trace-wrapped-json"
@@ -3320,6 +3373,10 @@ let () =
             "librarian-born ephemeral fact has TTL (RFC-0247 §2.3)"
             `Quick
             test_librarian_ephemeral_fact_has_ttl
+        ; Alcotest.test_case
+            "librarian-born external-ref fact has volatile TTL (RFC-0259 §3.2)"
+            `Quick
+            test_librarian_external_ref_fact_is_born_volatile
         ; Alcotest.test_case
             "librarian accepts wrapped json output"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3247,6 +3247,41 @@ let test_reobserve_volatile_inherits_anchor () =
   Alcotest.(check (float 0.001)) "first_seen preserved" older merged.Types.first_seen
 ;;
 
+let test_reobserve_nonvolatile_advances_anchor_and_preserves_expiry () =
+  let now = 5_000_000.0 in
+  let older = now -. 100_000.0 in
+  let expiry = older +. 3600.0 in
+  let existing =
+    { (fact_fixture ~now:older ()) with
+      Types.category = Types.Ephemeral
+    ; Types.external_ref = None
+    ; Types.first_seen = older
+    ; Types.last_verified_at = Some older
+    ; Types.valid_until = Some expiry
+    }
+  in
+  let incoming =
+    { existing with
+      Types.last_verified_at = Some now
+    ; Types.valid_until = Some (now +. Types.volatile_external_ttl_seconds)
+    }
+  in
+  let merged = Policy.reobserve_fact ~now ~existing ~incoming in
+  Alcotest.(check (option (float 0.001)))
+    "last_verified_at advanced for non-volatile re-observation"
+    (Some now)
+    merged.Types.last_verified_at;
+  Alcotest.(check (option (float 0.001)))
+    "existing valid_until preserved for non-volatile re-observation"
+    (Some expiry)
+    merged.Types.valid_until;
+  Alcotest.(check (float 0.001)) "first_seen preserved" older merged.Types.first_seen;
+  Alcotest.(check bool)
+    "external_ref remains absent"
+    true
+    (Option.is_none merged.Types.external_ref)
+;;
+
 let test_retention_rank_demotes_volatile () =
   let now = 1_000_000.0 in
   let durable = { (fact_fixture ~now ()) with Types.category = Types.Fact } in
@@ -3567,6 +3602,10 @@ let () =
             "reobserve inherits a volatile claim's anchor (RFC-0259 P6/F)"
             `Quick
             test_reobserve_volatile_inherits_anchor
+        ; Alcotest.test_case
+            "reobserve advances a non-volatile claim's anchor"
+            `Quick
+            test_reobserve_nonvolatile_advances_anchor_and_preserves_expiry
         ; Alcotest.test_case
             "retention rank demotes a volatile fact below durable"
             `Quick


### PR DESCRIPTION
## What

Implements **RFC-0259 P6/F** — producer re-observation is no longer treated as re-verification for a volatile (external-ref) claim. `reobserve_fact` now **inherits** the prior row's anchor instead of resetting it.

## Why (defect C1 residual loop)

A `verifier` keeper was observed stuck re-debunking the same false memory every turn. Root-cause verification (8-agent adversarial workflow against HEAD) found: the RFC-0259 P1–P4 marking/TTL layer landed, but `reobserve_fact` (`keeper_memory_os_policy.ml`) advanced `last_verified_at` and refreshed the 24h volatile TTL on **every** producer re-extraction, with the comment asserting "re-observing IS re-verification" (§3.2(b)).

Effect: the librarian re-extracting a stale `"PR #X open"` from its own session history reset both the 12h `[UNVERIFIED]` grounding horizon and the 24h hard TTL each cycle. The false fact never aged out and never rendered `[UNVERIFIED]`, so it was re-injected into the prompt indefinitely.

## The fix

```ocaml
let reobserve_fact ~now ~existing ~incoming:(_ : fact) =
  match existing.external_ref with
  | Some _ -> existing                                  (* volatile: inherit anchor *)
  | None   -> { existing with last_verified_at = Some now }  (* non-volatile: advance *)
```

- **Volatile** (`external_ref = Some`): inherit `first_seen` / `last_verified_at` / `valid_until` unchanged. The TTL and `[UNVERIFIED]` horizon keep ticking from the last *real* verification. Only the grounding reconciler (`keeper_memory_os_reconcile.ml`, `Stale_open` verdict — which actually checks the referent) advances the anchor; the producer inherits it.
- **Non-volatile** (`external_ref = None`): unchanged — re-extraction is its only verification signal, so `last_verified_at` still advances. (Behaviorally identical to the prior `None` branch.)

This **reverses** the shipped §3.2(b) rule; it is not additive (see RFC-0259 §3.7, "This amends the shipped P3").

## Scope

- Implements **F** (exact-key anchor inheritance) only. **E** (stable claim identity so a reworded re-extraction UPSERTs rather than appending a fresh row) is **deferred** — until E lands, a reworded variant still takes the append path and resets its own anchor. F and E are distinct fixes (anchor-inheritance vs identity-keying), not the same transformation across N sites; F is self-contained and monotonically correct on its own. Tracked in Issue #21789.
- `.mli` unchanged (signature identical).

## Test

`test_reobserve_refreshes_volatile_horizon` froze the old (defective) behavior as a passing test. Rewritten as `test_reobserve_volatile_inherits_anchor`: a volatile claim's `valid_until`, `last_verified_at`, and `first_seen` are all inherited on producer re-observe. Non-volatile advance is already covered by `test_reobserve_fact_refreshes_truth_anchor` (uses the non-volatile `fact_fixture`, still green).

## RFC

RFC-0259 §3.7 / P6 (design in #21831, Draft). Local OCaml build not run (per workflow norm); CI compiles + runs tests.

RFC-WAIVED: `lib/keeper/keeper_memory_os_policy.ml` is not in the credential/operator/sandbox/hooks RFC-gated set; the governing design is RFC-0259 (P1–P4 merged), this implements its §3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
