### PR TITLE
[codex] Preserve missing tool-call timing state

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -396,6 +396,40 @@ describe('keeper tool telemetry fetchers', () => {
     expect(entry?.semantic_outcome).toBe('blocked')
     expect(entry?.goal_ids).toEqual(['g-1', 'g-2'])
   })
+
+  it('keeps missing or malformed tool-call duration unmeasured', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(
+      new Response(JSON.stringify({
+        keeper: 'keeper-alpha',
+        count: 2,
+        source: 'tool_call_io',
+        entries: [
+          {
+            ts: 1,
+            keeper: 'keeper-alpha',
+            tool: 'keeper_context_status',
+            input: {},
+            output: 'ok',
+            success: true,
+          },
+          {
+            ts: 2,
+            keeper: 'keeper-alpha',
+            tool: 'keeper_board_post_get',
+            input: {},
+            output: 'ok',
+            success: true,
+            duration_ms: 'not recorded',
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperToolCalls('keeper-alpha')
+
+    expect(result.entries.map(entry => entry.duration_ms)).toEqual([null, null])
+  })
 })
 
 describe('fetchMemorySubsystems', () => {

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2771,7 +2771,7 @@ export type ToolCallEntry = {
   input: unknown
   output: string | ToolCallOutputBlob
   success: boolean
-  duration_ms: number
+  duration_ms: number | null
   model?: string
   trace_id?: string
   session_id?: string
@@ -2842,7 +2842,7 @@ function decodeToolCallEntry(raw: unknown): ToolCallEntry | null {
     input: raw.input,
     output: decodeToolCallOutput(raw.output),
     success: asBoolean(raw.success, false),
-    duration_ms: asNumber(raw.duration_ms, 0),
+    duration_ms: asNumber(raw.duration_ms) ?? null,
     model: asString(raw.model),
     trace_id: asString(raw.trace_id),
     session_id: asString(raw.session_id),

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2060,7 +2060,7 @@ function ToolTraceStep({ entry, output }: { entry: KeeperConversationEntry; outp
       : output.success === false || output.semantic_success === false
         ? 'bad'
         : 'ok'
-  const durLabel = output && output.duration_ms > 0 ? formatMsCompact(output.duration_ms) : ''
+  const durLabel = output?.duration_ms != null && output.duration_ms > 0 ? formatMsCompact(output.duration_ms) : ''
   const resultView = output ? toolOutputDisplay(output.output) : null
   const hasResult = resultView !== null && resultView.text.trim() !== ''
   // Expandable when there is anything to show: args, a result, or a still-pending

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -30,6 +30,7 @@ import { isKeeperToolActivityEvent, sseEventMatchesKeeper } from './keeper-sse-m
 
 // Delegated to lib/format-time (SSOT)
 const formatTimestamp = formatTimeHms
+const NO_DURATION_LABEL = '—'
 
 function FreshnessLine({ data }: { data: TelemetryFreshnessMetadata }) {
   const gap = coverageGapDisplay(data)
@@ -276,7 +277,7 @@ export function deriveKeeperToolCallDossier(
       label: 'latest',
       value: latest?.tool ?? 'none',
       detail: latest
-        ? `${formatTimestamp(latest.ts)} · ${toolCallStatusLabel(latest)} · ${latest.duration_ms != null ? formatMsCompact(latest.duration_ms) : 'duration 없음'}`
+        ? `${formatTimestamp(latest.ts)} · ${toolCallStatusLabel(latest)} · ${latest.duration_ms != null ? formatMsCompact(latest.duration_ms) : NO_DURATION_LABEL}`
         : 'no recent tool call',
       tone: latestTone,
       title: latest ? entryScopeLabel(latest) : undefined,
@@ -293,7 +294,7 @@ export function deriveKeeperToolCallDossier(
     {
       key: 'slowest',
       label: 'slowest',
-      value: slowest?.duration_ms != null ? formatMsCompact(slowest.duration_ms) : 'none',
+      value: slowest?.duration_ms != null ? formatMsCompact(slowest.duration_ms) : NO_DURATION_LABEL,
       detail: slowest ? `${slowest.tool} · ${entryScopeLabel(slowest)}` : 'no duration sample',
       tone: slowest?.duration_ms != null ? durationTone(slowest.duration_ms) : 'neutral',
     },
@@ -498,7 +499,7 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
         <span class="font-mono text-[var(--color-fg-secondary)] flex-shrink-0 w-16">${formatTimestamp(entry.ts)}</span>
         <span class="font-mono font-medium text-[var(--color-fg-secondary)] truncate flex-1" title=${entry.tool}>${entry.tool}</span>
         <span class=${`font-mono flex-shrink-0 w-16 text-right ${entry.duration_ms != null ? durationColor(entry.duration_ms) : 'text-[var(--color-fg-disabled)]'}`}>
-          ${entry.duration_ms != null ? formatMsCompact(entry.duration_ms) : '—'}
+          ${entry.duration_ms != null ? formatMsCompact(entry.duration_ms) : NO_DURATION_LABEL}
         </span>
         <span
           class=${`flex-shrink-0 w-5 text-center ${toolCallSucceeded(entry) ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-err)]'}`}

--- a/dashboard/src/components/keeper-tool-call-inspector.ts
+++ b/dashboard/src/components/keeper-tool-call-inspector.ts
@@ -154,7 +154,8 @@ function newestToolCall(entries: readonly ToolCallEntry[]): ToolCallEntry | null
 function slowestToolCall(entries: readonly ToolCallEntry[]): ToolCallEntry | null {
   let slowest: ToolCallEntry | null = null
   for (const entry of entries) {
-    if (slowest === null || entry.duration_ms > slowest.duration_ms) slowest = entry
+    if (entry.duration_ms == null) continue
+    if (slowest === null || slowest.duration_ms == null || entry.duration_ms > slowest.duration_ms) slowest = entry
   }
   return slowest
 }
@@ -275,7 +276,7 @@ export function deriveKeeperToolCallDossier(
       label: 'latest',
       value: latest?.tool ?? 'none',
       detail: latest
-        ? `${formatTimestamp(latest.ts)} · ${toolCallStatusLabel(latest)} · ${formatMsCompact(latest.duration_ms)}`
+        ? `${formatTimestamp(latest.ts)} · ${toolCallStatusLabel(latest)} · ${latest.duration_ms != null ? formatMsCompact(latest.duration_ms) : 'duration 없음'}`
         : 'no recent tool call',
       tone: latestTone,
       title: latest ? entryScopeLabel(latest) : undefined,
@@ -292,9 +293,9 @@ export function deriveKeeperToolCallDossier(
     {
       key: 'slowest',
       label: 'slowest',
-      value: slowest ? formatMsCompact(slowest.duration_ms) : 'none',
+      value: slowest?.duration_ms != null ? formatMsCompact(slowest.duration_ms) : 'none',
       detail: slowest ? `${slowest.tool} · ${entryScopeLabel(slowest)}` : 'no duration sample',
-      tone: slowest ? durationTone(slowest.duration_ms) : 'neutral',
+      tone: slowest?.duration_ms != null ? durationTone(slowest.duration_ms) : 'neutral',
     },
     {
       key: 'hot-tool',
@@ -331,7 +332,7 @@ export function deriveKeeperToolCallDossier(
       tone: 'bad',
     })
   }
-  if (slowest && slowest.duration_ms >= 2_000) {
+  if (slowest?.duration_ms != null && slowest.duration_ms >= 2_000) {
     issues.push({
       key: 'slow-call',
       label: 'slow call',
@@ -496,8 +497,8 @@ function ToolCallRow({ entry }: { entry: ToolCallEntry }) {
         <span class="font-mono ${cat.color} w-4 text-center flex-shrink-0">${cat.icon}</span>
         <span class="font-mono text-[var(--color-fg-secondary)] flex-shrink-0 w-16">${formatTimestamp(entry.ts)}</span>
         <span class="font-mono font-medium text-[var(--color-fg-secondary)] truncate flex-1" title=${entry.tool}>${entry.tool}</span>
-        <span class=${`font-mono flex-shrink-0 w-16 text-right ${durationColor(entry.duration_ms)}`}>
-          ${formatMsCompact(entry.duration_ms)}
+        <span class=${`font-mono flex-shrink-0 w-16 text-right ${entry.duration_ms != null ? durationColor(entry.duration_ms) : 'text-[var(--color-fg-disabled)]'}`}>
+          ${entry.duration_ms != null ? formatMsCompact(entry.duration_ms) : '—'}
         </span>
         <span
           class=${`flex-shrink-0 w-5 text-center ${toolCallSucceeded(entry) ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-err)]'}`}

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -198,6 +198,17 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
   }
 }
 
+function toolCallsForTurnWithoutDuration(): ToolCallsResponse {
+  const response = toolCallsForTurn()
+  return {
+    ...response,
+    entries: response.entries.map(entry => ({
+      ...entry,
+      duration_ms: null,
+    })),
+  }
+}
+
 beforeEach(() => {
   fetchKeeperToolCallsMock.mockResolvedValue(emptyToolCalls())
 })
@@ -521,6 +532,58 @@ describe('KeeperTurnInspector v2 drawer', () => {
     await waitFor(() => {
       expect(container.textContent).toContain('agent subturn T9001')
     })
+  })
+
+  it('keeps joined tool calls with missing duration unmeasured, not 0ms', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+    fetchKeeperToolCallsMock.mockResolvedValue(toolCallsForTurnWithoutDuration())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeTruthy()
+    })
+
+    const drawerText = container.querySelector('[data-testid="turn-detail-drawer"]')?.textContent ?? ''
+    expect(drawerText).toContain('keeper_board_post_get')
+    expect(drawerText).toContain('측정 없음')
+    expect(drawerText).not.toContain('0ms')
+    expect(drawerText).not.toContain('0.50s')
+
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-messages"]')!)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('duration 없음')
+    })
+  })
+
+  it('warns when the timing source fails while keeping turn records visible', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+    fetchKeeperToolCallsMock.mockRejectedValue(new Error('tool log unavailable'))
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    expect(container.textContent).toContain('tool-call timing source unavailable')
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeTruthy()
+    })
+
+    const drawerText = container.querySelector('[data-testid="turn-detail-drawer"]')?.textContent ?? ''
+    expect(drawerText).toContain('tool-call timing source unavailable')
+    expect(drawerText).toContain('tool log unavailable')
   })
 
   it('displays the token-economics stacked bar', async () => {

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -445,6 +445,11 @@ type TurnToolDetail = {
 type TurnInspectorData = {
   turns: TurnRecordsResponse
   toolCalls: ToolCallsResponse | null
+  toolCallError: string | null
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 function approxTokens(str: string): number {
@@ -896,12 +901,14 @@ function TurnDetailDrawer({
   row,
   source,
   toolEntries,
+  toolCallError,
   onClose,
 }: {
   keeperName: string
   row: TurnRecordRow
   source: string
   toolEntries: readonly ToolCallEntry[]
+  toolCallError: string | null
   onClose: () => void
 }) {
   const [tab, setTab] = useState('timeline')
@@ -957,6 +964,17 @@ function TurnDetailDrawer({
             <span class="sub-k">runtime</span>${row.record.runtime_profile}
           </span>
         </div>
+
+        ${toolCallError
+          ? html`
+            <div
+              class="mt-2 rounded-[var(--r-1)] border border-[var(--color-status-warn)]/40 bg-[var(--color-bg-surface)] px-2 py-1.5 text-2xs text-[var(--color-status-warn)]"
+              data-testid="turn-timing-source-warning"
+            >
+              tool-call timing source unavailable · ${toolCallError}
+            </div>
+          `
+          : null}
 
         <div class="kti-summary" data-testid="turn-summary-stats">
           <div class="kti-stat">
@@ -1134,9 +1152,12 @@ export function KeeperTurnInspector({
     void resource.load(async (signal) => {
       const [turns, toolCalls] = await Promise.all([
         fetchKeeperTurnRecords(keeperName, 50, { signal }),
-        fetchKeeperToolCalls(keeperName, 200, { signal }).catch(() => null),
+        fetchKeeperToolCalls(keeperName, 200, { signal }).then(
+          toolCalls => ({ toolCalls, toolCallError: null }),
+          error => ({ toolCalls: null, toolCallError: errorMessage(error) }),
+        ),
       ])
-      return { turns, toolCalls }
+      return { turns, toolCalls: toolCalls.toolCalls, toolCallError: toolCalls.toolCallError }
     })
     return () => {
       resource.cancel()
@@ -1145,6 +1166,7 @@ export function KeeperTurnInspector({
 
   const response = resource.state.value.data?.turns
   const toolEntries = resource.state.value.data?.toolCalls?.entries ?? []
+  const toolCallError = resource.state.value.data?.toolCallError ?? null
   const rows = response?.entries ?? EMPTY_TURN_RECORD_ROWS
   // Server returns oldest-first; show newest first.
   const sorted = useMemo(() => [...rows].reverse(), [rows])
@@ -1219,6 +1241,11 @@ export function KeeperTurnInspector({
               malformed ${response.skipped_rows}행 제외됨
             </span>`
           : null}
+        ${toolCallError
+          ? html`<span class="text-3xs text-[var(--color-status-warn)]" data-testid="turn-timing-source-warning">
+              tool-call timing source unavailable
+            </span>`
+          : null}
       </div>
       ${memoryOsPanel}
       ${userModelPanel}
@@ -1245,6 +1272,7 @@ export function KeeperTurnInspector({
             row=${selectedRow}
             source=${response?.source ?? 'turn_record'}
             toolEntries=${toolEntries}
+            toolCallError=${toolCallError}
             onClose=${() => setSelectedRow(null)}
           />`
         : null}

--- a/dashboard/src/components/session-trace/session-trace-state.test.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.test.ts
@@ -349,7 +349,7 @@ describe('buildTraceEvents', () => {
           turn: 1,
           round: 1,
           tool_name: 'keeper_fs_read',
-          args: { file_path: '/tmp/trajectory.txt' },
+          args: { file_path: 'trajectory.txt' },
           result: 'trajectory result',
           duration_ms: 50,
           gate: { status: 'pass' },
@@ -364,7 +364,7 @@ describe('buildTraceEvents', () => {
           ts: 1712397700,
           keeper: 'test',
           tool: 'keeper_fs_read',
-          input: { file_path: '/tmp/full.txt' },
+          input: { file_path: 'full.txt' },
           output: 'full file contents',
           success: true,
           duration_ms: 50,
@@ -379,10 +379,68 @@ describe('buildTraceEvents', () => {
     )
     const toolEvents = events.filter(e => e.kind === 'tool_call')
     expect(toolEvents).toHaveLength(1)
-    expect(toolEvents[0]!.toolArgs).toEqual({ file_path: '/tmp/full.txt' })
+    expect(toolEvents[0]!.toolArgs).toEqual({ file_path: 'full.txt' })
     expect(toolEvents[0]!.toolResult).toBe('full file contents')
     expect(toolEvents[0]!.detail.trace_origin).toBe('trajectory+tool_call_log')
     expect(toolEvents[0]!.detail.lane).toBe('runtime_mcp')
+  })
+
+  it('preserves trajectory duration when the richer tool-call row has no duration', () => {
+    const events = buildTraceEvents(
+      {
+        agent: 'test',
+        period: { from: '', to: '' },
+        events: [],
+        summary: { tasks_completed: 0, tasks_claimed: 0, messages_sent: 0, active_duration_minutes: 0, total_events: 0 },
+      },
+      {
+        keeper: 'test',
+        trace_id: 'trace-1',
+        generation: 1,
+        total_entries: 1,
+        showing: 1,
+        entries: [{
+          ts: 1712397700,
+          ts_iso: '2024-04-06T10:01:40Z',
+          turn: 1,
+          round: 1,
+          tool_name: 'keeper_fs_read',
+          args: { file_path: 'trajectory.txt' },
+          result: 'trajectory result',
+          duration_ms: 812,
+          gate: { status: 'pass' },
+          cost_usd: 0.001,
+          error: null,
+          execution_id: 'exec-1712397700000-duration',
+        }],
+      },
+      {
+        keeper: 'test',
+        count: 1,
+        entries: [{
+          ts: 1712397700,
+          keeper: 'test',
+          tool: 'keeper_fs_read',
+          input: { file_path: 'full.txt' },
+          output: 'full file contents',
+          success: true,
+          duration_ms: null,
+          trace_id: 'trace-1',
+          session_id: 'trace-1',
+          turn: 1,
+          keeper_turn_id: 1,
+          task_id: 'task-1',
+          lane: 'runtime_mcp',
+          execution_id: 'exec-1712397700000-duration',
+        }],
+      },
+    )
+    const toolEvents = events.filter(e => e.kind === 'tool_call')
+    expect(toolEvents).toHaveLength(1)
+    expect(toolEvents[0]!.duration_ms).toBe(812)
+    expect(toolEvents[0]!.toolArgs).toEqual({ file_path: 'full.txt' })
+    expect(toolEvents[0]!.toolResult).toBe('full file contents')
+    expect(toolEvents[0]!.detail.trace_origin).toBe('trajectory+tool_call_log')
   })
 
   it('creates synthetic tool_call rows from tool-call log when trajectory is missing', () => {

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -505,7 +505,7 @@ function enrichToolCallTrace(
     toolName: entry.tool,
     toolArgs: normalizeToolCallInput(entry.input) ?? event.toolArgs,
     toolResult: entry.success ? outputText : null,
-    duration_ms: entry.duration_ms ?? undefined,
+    duration_ms: entry.duration_ms ?? event.duration_ms,
     // Trajectory turn is trace-relative and pairs with `round`; the log's
     // session-absolute turn stays readable as detail.turn. Mixing the two
     // vocabularies in one T#R# badge would mislabel the row.

--- a/dashboard/src/components/session-trace/session-trace-state.ts
+++ b/dashboard/src/components/session-trace/session-trace-state.ts
@@ -451,7 +451,11 @@ function toolCallEntryMatchesTraceEvent(
   const entryTurn = entry.turn ?? entry.keeper_turn_id
   if (eventTurn != null && entryTurn != null && eventTurn !== entryTurn) return false
 
-  if (event.duration_ms != null && Math.abs(event.duration_ms - entry.duration_ms) > 1) return false
+  if (
+    event.duration_ms != null
+    && entry.duration_ms != null
+    && Math.abs(event.duration_ms - entry.duration_ms) > 1
+  ) return false
   if (toolEventSuccess(event) !== entry.success) return false
 
   return Math.abs(event.ts - (entry.ts * 1000)) <= TOOL_CALL_MATCH_WINDOW_MS
@@ -501,7 +505,7 @@ function enrichToolCallTrace(
     toolName: entry.tool,
     toolArgs: normalizeToolCallInput(entry.input) ?? event.toolArgs,
     toolResult: entry.success ? outputText : null,
-    duration_ms: entry.duration_ms,
+    duration_ms: entry.duration_ms ?? undefined,
     // Trajectory turn is trace-relative and pairs with `round`; the log's
     // session-absolute turn stays readable as detail.turn. Mixing the two
     // vocabularies in one T#R# badge would mislabel the row.
@@ -531,7 +535,7 @@ function toolCallEntryToSyntheticTrace(entry: ToolCallEntry, index: number): Uni
     toolName: entry.tool,
     toolArgs: normalizeToolCallInput(entry.input),
     toolResult: entry.success ? outputText : null,
-    duration_ms: entry.duration_ms,
+    duration_ms: entry.duration_ms ?? undefined,
     turn: entry.turn ?? entry.keeper_turn_id,
     executionId: entry.execution_id,
     error: entry.success ? null : outputText || 'tool call failed',


### PR DESCRIPTION
## Summary

Follow-up to #21841 review feedback.

- keep missing or malformed `/tool-calls` `duration_ms` as `null` instead of decoding it to measured `0ms`
- preserve tool-call timing-source fetch failures separately from "loaded successfully but no matching timing"
- surface timing-source degradation in the turn inspector while keeping turn records usable
- update tool-call inspector, chat trace steps, and session-trace enrichment to treat missing duration as unmeasured instead of numeric zero

## Why

#21841 removed the visible `0.50s` fabrication, but review found two remaining truth-boundary leaks:

1. the shared tool-call decoder still converted missing/invalid `duration_ms` into `0`
2. a `/tool-calls` fetch failure was indistinguishable from a successful empty timing source

This keeps timing provenance honest at the data boundary and on the operator surface.

## Validation

- `git diff --cached --check`
- `git diff --check`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/keeper-turn-inspector.test.ts src/api/dashboard.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm --dir dashboard exec eslint src/api/dashboard.ts src/components/keeper-turn-inspector.ts src/components/keeper-turn-inspector.test.ts src/components/keeper-tool-call-inspector.ts src/components/chat/primitives.ts src/components/session-trace/session-trace-state.ts`
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`

Full build is left to CI.
