### PR TITLE
feat(schedule): surface keeper next actions

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1820,6 +1820,8 @@ export interface DashboardScheduledAutomationRequest {
   effective_status?: string
   execution_readiness?: string
   operator_action?: string | null
+  keeper_next_tool?: string | null
+  keeper_next_action?: string | null
   risk_class: string
   approval_required: boolean
   source: string

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -104,7 +104,7 @@ function KeeperActionCell({ request }: { request: DashboardScheduledAutomationRe
   return html`
     <div class="max-w-[16rem]">
       ${nextTool
-        ? html`<div class="font-mono text-3xs text-[var(--color-fg-secondary)]">${nextTool}</div>`
+        ? html`<div class="truncate font-mono text-3xs text-[var(--color-fg-secondary)]">${nextTool}</div>`
         : null}
       ${nextAction
         ? html`<div class="mt-1 truncate text-3xs text-[var(--color-fg-muted)]" title=${nextAction}>${nextAction}</div>`

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -104,7 +104,7 @@ function KeeperActionCell({ request }: { request: DashboardScheduledAutomationRe
   return html`
     <div class="max-w-[16rem]">
       ${nextTool
-        ? html`<div class="truncate font-mono text-3xs text-[var(--color-fg-secondary)]">${nextTool}</div>`
+        ? html`<div class="truncate font-mono text-3xs text-[var(--color-fg-secondary)]" title=${nextTool}>${nextTool}</div>`
         : null}
       ${nextAction
         ? html`<div class="mt-1 truncate text-3xs text-[var(--color-fg-muted)]" title=${nextAction}>${nextAction}</div>`

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -97,6 +97,22 @@ function PayloadCell({ request }: { request: DashboardScheduledAutomationRequest
   `
 }
 
+function KeeperActionCell({ request }: { request: DashboardScheduledAutomationRequest }) {
+  const nextTool = request.keeper_next_tool?.trim() || null
+  const nextAction = request.keeper_next_action?.trim() || null
+  if (!nextTool && !nextAction) return html`<span class="text-xs text-[var(--color-fg-disabled)]">-</span>`
+  return html`
+    <div class="max-w-[16rem]">
+      ${nextTool
+        ? html`<div class="font-mono text-3xs text-[var(--color-fg-secondary)]">${nextTool}</div>`
+        : null}
+      ${nextAction
+        ? html`<div class="mt-1 truncate text-3xs text-[var(--color-fg-muted)]" title=${nextAction}>${nextAction}</div>`
+        : null}
+    </div>
+  `
+}
+
 function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest }) {
   const effectiveStatus = request.effective_status ?? request.status
   const readiness = request.execution_readiness ?? '-'
@@ -114,6 +130,7 @@ function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest
       </td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(readiness)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(action)}</td>
+      <td class="py-2 pr-3"><${KeeperActionCell} request=${request} /></td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${enumLabel(request.risk_class)}</td>
       <td class="py-2 pr-3"><${PayloadCell} request=${request} /></td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${recurrenceLabel(request)}</td>
@@ -194,6 +211,7 @@ export function ScheduledAutomationPanel({
                     <th class="pb-2 pr-3 font-medium">status</th>
                     <th class="pb-2 pr-3 font-medium">readiness</th>
                     <th class="pb-2 pr-3 font-medium">action</th>
+                    <th class="pb-2 pr-3 font-medium">keeper</th>
                     <th class="pb-2 pr-3 font-medium">risk</th>
                     <th class="pb-2 pr-3 font-medium">payload</th>
                     <th class="pb-2 pr-3 font-medium">recurrence</th>

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -134,6 +134,9 @@ describe('Tools', () => {
             effective_status: 'blocked_approval',
             execution_readiness: 'blocked_approval',
             operator_action: 'approve_or_reject',
+            keeper_next_tool: 'masc_schedule_get',
+            keeper_next_action:
+              'Inspect details, then wait for an explicit human decision before calling masc_schedule_approve or masc_schedule_reject.',
             risk_class: 'workspace_write',
             approval_required: true,
             source: 'operator_request',
@@ -159,6 +162,8 @@ describe('Tools', () => {
     expect(container.textContent).toContain('blocked approval')
     expect(container.textContent).toContain('raw pending approval')
     expect(container.textContent).toContain('approve or reject')
+    expect(container.textContent).toContain('masc_schedule_get')
+    expect(container.textContent).toContain('explicit human decision')
     expect(container.textContent).toContain('sched-1')
     expect(container.textContent).toContain('workspace write')
     expect(container.textContent).toContain('cron 0 9 * * 1-5 Asia/Seoul')

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -192,8 +192,13 @@ let format_scheduled_automation_item
     | None -> "unknown"
     | Some kind -> kind
   in
+  let next_tool =
+    match item.keeper_next_tool with
+    | None -> "none"
+    | Some tool -> tool
+  in
   Printf.sprintf
-    "- schedule_id=%s action=%s status=%s payload=%s recurrence=%S risk=%s due_at=%s"
+    "- schedule_id=%s action=%s status=%s payload=%s recurrence=%S risk=%s due_at=%s next_tool=%s next=%S"
     item.schedule_id
     item.action
     item.status
@@ -201,6 +206,8 @@ let format_scheduled_automation_item
     item.recurrence_summary
     item.risk_class
     (Masc_domain.iso8601_of_unix_seconds item.due_at)
+    next_tool
+    item.keeper_next_action
 ;;
 
 let format_scheduled_automation_summary

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -262,17 +262,12 @@ let schedule_blocked_approval ~now state (request : Schedule_domain.schedule_req
   | Scheduled | Running | Succeeded | Failed | Rejected | Cancelled | Expired -> false
 ;;
 
-let keeper_next_tool_for_schedule_action = function
-  | "dispatch_ready" | "approve_or_reject" -> Some "masc_schedule_get"
-  | _ -> None
+let keeper_next_tool_for_schedule_action =
+  Schedule_projection.keeper_next_tool_for_attention_action
 ;;
 
-let keeper_next_action_for_schedule_action = function
-  | "dispatch_ready" ->
-    "Inspect the schedule if needed and monitor dispatch; do not create a duplicate schedule."
-  | "approve_or_reject" ->
-    "Inspect details, then wait for an explicit human decision before calling masc_schedule_approve or masc_schedule_reject."
-  | _ -> "Inspect the schedule before taking action."
+let keeper_next_action_for_schedule_action =
+  Schedule_projection.keeper_next_action_for_attention_action
 ;;
 
 let schedule_attention_item action (request : Schedule_domain.schedule_request) =

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -262,24 +262,16 @@ let schedule_blocked_approval ~now state (request : Schedule_domain.schedule_req
   | Scheduled | Running | Succeeded | Failed | Rejected | Cancelled | Expired -> false
 ;;
 
-let keeper_next_tool_for_schedule_action =
-  Schedule_projection.keeper_next_tool_for_attention_action
-;;
-
-let keeper_next_action_for_schedule_action =
-  Schedule_projection.keeper_next_action_for_attention_action
-;;
-
 let schedule_attention_item action (request : Schedule_domain.schedule_request) =
   { schedule_id = request.schedule_id
-  ; action
+  ; action = Schedule_projection.attention_action_to_string action
   ; status = Schedule_domain.schedule_status_to_string request.status
   ; payload_kind = schedule_payload_kind request
   ; recurrence_summary = Schedule_domain.recurrence_summary request.recurrence
   ; risk_class = Schedule_domain.risk_class_to_string request.risk_class
   ; due_at = request.due_at
-  ; keeper_next_tool = keeper_next_tool_for_schedule_action action
-  ; keeper_next_action = keeper_next_action_for_schedule_action action
+  ; keeper_next_tool = Schedule_projection.keeper_next_tool_for_attention_action action
+  ; keeper_next_action = Schedule_projection.keeper_next_action_for_attention_action action
   }
 ;;
 
@@ -342,10 +334,12 @@ let read_scheduled_automation_observation ~(config : Workspace.config) ~now =
            0
     in
     let due_items =
-      List.map (schedule_attention_item "dispatch_ready") due_ready
+      List.map (schedule_attention_item Schedule_projection.Dispatch_ready) due_ready
     in
     let blocked_items =
-      List.map (schedule_attention_item "approve_or_reject") blocked
+      List.map
+        (schedule_attention_item Schedule_projection.Approve_or_reject)
+        blocked
     in
     { active_count
     ; due_ready_count = List.length due_ready

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -56,6 +56,8 @@ type scheduled_automation_item =
   ; recurrence_summary : string
   ; risk_class : string
   ; due_at : float
+  ; keeper_next_tool : string option
+  ; keeper_next_action : string
   }
 
 type scheduled_automation_observation =
@@ -260,6 +262,19 @@ let schedule_blocked_approval ~now state (request : Schedule_domain.schedule_req
   | Scheduled | Running | Succeeded | Failed | Rejected | Cancelled | Expired -> false
 ;;
 
+let keeper_next_tool_for_schedule_action = function
+  | "dispatch_ready" | "approve_or_reject" -> Some "masc_schedule_get"
+  | _ -> None
+;;
+
+let keeper_next_action_for_schedule_action = function
+  | "dispatch_ready" ->
+    "Inspect the schedule if needed and monitor dispatch; do not create a duplicate schedule."
+  | "approve_or_reject" ->
+    "Inspect details, then wait for an explicit human decision before calling masc_schedule_approve or masc_schedule_reject."
+  | _ -> "Inspect the schedule before taking action."
+;;
+
 let schedule_attention_item action (request : Schedule_domain.schedule_request) =
   { schedule_id = request.schedule_id
   ; action
@@ -268,6 +283,8 @@ let schedule_attention_item action (request : Schedule_domain.schedule_request) 
   ; recurrence_summary = Schedule_domain.recurrence_summary request.recurrence
   ; risk_class = Schedule_domain.risk_class_to_string request.risk_class
   ; due_at = request.due_at
+  ; keeper_next_tool = keeper_next_tool_for_schedule_action action
+  ; keeper_next_action = keeper_next_action_for_schedule_action action
   }
 ;;
 

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -72,6 +72,8 @@ type scheduled_automation_item = {
   recurrence_summary : string;
   risk_class : string;
   due_at : float;
+  keeper_next_tool : string option;
+  keeper_next_action : string;
 }
 
 (** Durable scheduled-automation summary from the MASC schedule store. *)

--- a/lib/schedule_projection.ml
+++ b/lib/schedule_projection.ml
@@ -1,0 +1,50 @@
+(* TEL-OK: pure schedule read-model projection; schedule tool/runner handlers own
+   execution telemetry. *)
+
+let schedule_get_tool = "masc_schedule_get"
+
+let inspect_before_action = "Inspect the schedule before taking action."
+
+let inspect_and_monitor_dispatch =
+  "Inspect the schedule if needed and monitor dispatch; do not create a duplicate schedule."
+;;
+
+let approval_decision_required =
+  "Inspect details, then wait for an explicit human decision before calling masc_schedule_approve or masc_schedule_reject."
+;;
+
+let wait_for_runner_tick =
+  "The schedule is due but the runner has not refreshed it yet; inspect if needed, otherwise wait for the runner tick."
+;;
+
+let inspect_expired_before_recreate =
+  "Inspect the expired schedule and recreate it with masc_schedule_create only if the operator still wants it."
+;;
+
+let keeper_next_tool_for_attention_action = function
+  | "dispatch_ready" | "approve_or_reject" -> Some schedule_get_tool
+  | _ -> None
+;;
+
+let keeper_next_action_for_attention_action = function
+  | "dispatch_ready" -> inspect_and_monitor_dispatch
+  | "approve_or_reject" -> approval_decision_required
+  | _ -> inspect_before_action
+;;
+
+let keeper_next_tool_for_execution_readiness = function
+  | "blocked_approval" | "awaiting_approval" | "due_pending_refresh" | "expired"
+  | "ready" | "approved" ->
+    Some schedule_get_tool
+  | "scheduled" | "running" | "terminal" -> None
+  | _ -> None
+;;
+
+let keeper_next_action_for_execution_readiness = function
+  | "blocked_approval" | "awaiting_approval" -> Some approval_decision_required
+  | "due_pending_refresh" -> Some wait_for_runner_tick
+  | "expired" -> Some inspect_expired_before_recreate
+  | "ready" | "approved" -> Some inspect_and_monitor_dispatch
+  | "scheduled" | "running" | "terminal" -> None
+  | _ -> None
+;;

--- a/lib/schedule_projection.ml
+++ b/lib/schedule_projection.ml
@@ -3,8 +3,6 @@
 
 let schedule_get_tool = "masc_schedule_get"
 
-let inspect_before_action = "Inspect the schedule before taking action."
-
 let inspect_and_monitor_dispatch =
   "Inspect the schedule if needed and monitor dispatch; do not create a duplicate schedule."
 ;;
@@ -21,30 +19,66 @@ let inspect_expired_before_recreate =
   "Inspect the expired schedule and recreate it with masc_schedule_create only if the operator still wants it."
 ;;
 
+type attention_action =
+  | Dispatch_ready
+  | Approve_or_reject
+
+let attention_action_to_string = function
+  | Dispatch_ready -> "dispatch_ready"
+  | Approve_or_reject -> "approve_or_reject"
+;;
+
+type execution_readiness =
+  | Blocked_approval
+  | Awaiting_approval
+  | Due_pending_refresh
+  | Expired
+  | Ready
+  | Approved
+  | Scheduled
+  | Running
+  | Terminal
+
+let execution_readiness_to_string = function
+  | Blocked_approval -> "blocked_approval"
+  | Awaiting_approval -> "awaiting_approval"
+  | Due_pending_refresh -> "due_pending_refresh"
+  | Expired -> "expired"
+  | Ready -> "ready"
+  | Approved -> "approved"
+  | Scheduled -> "scheduled"
+  | Running -> "running"
+  | Terminal -> "terminal"
+;;
+
+let operator_action_for_execution_readiness = function
+  | Blocked_approval | Awaiting_approval -> Some "approve_or_reject"
+  | Due_pending_refresh -> Some "wait_for_runner_tick"
+  | Expired -> Some "inspect_or_recreate"
+  | Ready | Approved -> Some "wait_for_dispatch"
+  | Scheduled | Running | Terminal -> None
+;;
+
 let keeper_next_tool_for_attention_action = function
-  | "dispatch_ready" | "approve_or_reject" -> Some schedule_get_tool
-  | _ -> None
+  | Dispatch_ready | Approve_or_reject -> Some schedule_get_tool
 ;;
 
 let keeper_next_action_for_attention_action = function
-  | "dispatch_ready" -> inspect_and_monitor_dispatch
-  | "approve_or_reject" -> approval_decision_required
-  | _ -> inspect_before_action
+  | Dispatch_ready -> inspect_and_monitor_dispatch
+  | Approve_or_reject -> approval_decision_required
 ;;
 
 let keeper_next_tool_for_execution_readiness = function
-  | "blocked_approval" | "awaiting_approval" | "due_pending_refresh" | "expired"
-  | "ready" | "approved" ->
+  | Blocked_approval | Awaiting_approval | Due_pending_refresh | Expired | Ready
+  | Approved ->
     Some schedule_get_tool
-  | "scheduled" | "running" | "terminal" -> None
-  | _ -> None
+  | Scheduled | Running | Terminal -> None
 ;;
 
 let keeper_next_action_for_execution_readiness = function
-  | "blocked_approval" | "awaiting_approval" -> Some approval_decision_required
-  | "due_pending_refresh" -> Some wait_for_runner_tick
-  | "expired" -> Some inspect_expired_before_recreate
-  | "ready" | "approved" -> Some inspect_and_monitor_dispatch
-  | "scheduled" | "running" | "terminal" -> None
-  | _ -> None
+  | Blocked_approval | Awaiting_approval -> Some approval_decision_required
+  | Due_pending_refresh -> Some wait_for_runner_tick
+  | Expired -> Some inspect_expired_before_recreate
+  | Ready | Approved -> Some inspect_and_monitor_dispatch
+  | Scheduled | Running | Terminal -> None
 ;;

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1818,47 +1818,47 @@ let schedule_effective_status ~now state (request : Schedule_domain.schedule_req
 
 let schedule_execution_readiness ~now state (request : Schedule_domain.schedule_request) =
   if schedule_effectively_expired ~now request
-  then "expired"
+  then Schedule_projection.Expired
   else if Schedule_domain.is_terminal request.status
-  then "terminal"
+  then Schedule_projection.Terminal
   else if request.status = Schedule_domain.Running
-  then "running"
+  then Schedule_projection.Running
   else if schedule_blocked_approval ~now state request
-  then "blocked_approval"
+  then Schedule_projection.Blocked_approval
   else if Schedule_store.has_current_approved_grant state request
-  then "approved"
+  then Schedule_projection.Approved
   else
     match request.status with
-    | Schedule_domain.Pending_approval -> "awaiting_approval"
-    | Scheduled when request.due_at <= now -> "due_pending_refresh"
-    | Scheduled -> "scheduled"
-    | Due -> "ready"
-    | Running -> "running"
-    | Succeeded | Failed | Rejected | Cancelled | Expired -> "terminal"
+    | Schedule_domain.Pending_approval -> Schedule_projection.Awaiting_approval
+    | Schedule_domain.Scheduled when request.due_at <= now ->
+      Schedule_projection.Due_pending_refresh
+    | Schedule_domain.Scheduled -> Schedule_projection.Scheduled
+    | Schedule_domain.Due -> Schedule_projection.Ready
+    | Schedule_domain.Running -> Schedule_projection.Running
+    | Schedule_domain.Succeeded
+    | Schedule_domain.Failed
+    | Schedule_domain.Rejected
+    | Schedule_domain.Cancelled
+    | Schedule_domain.Expired ->
+      Schedule_projection.Terminal
 ;;
 
-let schedule_operator_action ~now state (request : Schedule_domain.schedule_request) =
-  match schedule_execution_readiness ~now state request with
-  | "blocked_approval" | "awaiting_approval" -> `String "approve_or_reject"
-  | "due_pending_refresh" -> `String "wait_for_runner_tick"
-  | "expired" -> `String "inspect_or_recreate"
-  | "ready" | "approved" -> `String "wait_for_dispatch"
-  | "scheduled" | "running" | "terminal" -> `Null
-  | _ -> `Null
+let schedule_operator_action readiness =
+  match Schedule_projection.operator_action_for_execution_readiness readiness with
+  | Some action -> `String action
+  | None -> `Null
 ;;
 
-let schedule_keeper_next_tool = function
-  | readiness ->
-    (match Schedule_projection.keeper_next_tool_for_execution_readiness readiness with
-     | Some tool -> `String tool
-     | None -> `Null)
+let schedule_keeper_next_tool readiness =
+  match Schedule_projection.keeper_next_tool_for_execution_readiness readiness with
+  | Some tool -> `String tool
+  | None -> `Null
 ;;
 
-let schedule_keeper_next_action = function
-  | readiness ->
-    (match Schedule_projection.keeper_next_action_for_execution_readiness readiness with
-     | Some action -> `String action
-     | None -> `Null)
+let schedule_keeper_next_action readiness =
+  match Schedule_projection.keeper_next_action_for_execution_readiness readiness with
+  | Some action -> `String action
+  | None -> `Null
 ;;
 
 let schedule_fsm_state ~now state schedules =
@@ -1927,8 +1927,9 @@ let schedule_request_dashboard_json
     [ "schedule_id", `String request.schedule_id
     ; "status", `String (Schedule_domain.schedule_status_to_string request.status)
     ; "effective_status", `String (schedule_effective_status ~now state request)
-    ; "execution_readiness", `String execution_readiness
-    ; "operator_action", schedule_operator_action ~now state request
+    ; ( "execution_readiness"
+      , `String (Schedule_projection.execution_readiness_to_string execution_readiness) )
+    ; "operator_action", schedule_operator_action execution_readiness
     ; "keeper_next_tool", schedule_keeper_next_tool execution_readiness
     ; "keeper_next_action", schedule_keeper_next_action execution_readiness
     ; "risk_class", `String (Schedule_domain.risk_class_to_string request.risk_class)

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1848,28 +1848,17 @@ let schedule_operator_action ~now state (request : Schedule_domain.schedule_requ
 ;;
 
 let schedule_keeper_next_tool = function
-  | "blocked_approval" | "awaiting_approval" | "due_pending_refresh" | "expired"
-  | "ready" | "approved" ->
-    `String "masc_schedule_get"
-  | "scheduled" | "running" | "terminal" -> `Null
-  | _ -> `Null
+  | readiness ->
+    (match Schedule_projection.keeper_next_tool_for_execution_readiness readiness with
+     | Some tool -> `String tool
+     | None -> `Null)
 ;;
 
 let schedule_keeper_next_action = function
-  | "blocked_approval" | "awaiting_approval" ->
-    `String
-      "Inspect details, then wait for an explicit human decision before calling masc_schedule_approve or masc_schedule_reject."
-  | "due_pending_refresh" ->
-    `String
-      "The schedule is due but the runner has not refreshed it yet; inspect if needed, otherwise wait for the runner tick."
-  | "expired" ->
-    `String
-      "Inspect the expired schedule and recreate it with masc_schedule_create only if the operator still wants it."
-  | "ready" | "approved" ->
-    `String
-      "Monitor dispatch; do not create a duplicate schedule for this due item."
-  | "scheduled" | "running" | "terminal" -> `Null
-  | _ -> `Null
+  | readiness ->
+    (match Schedule_projection.keeper_next_action_for_execution_readiness readiness with
+     | Some action -> `String action
+     | None -> `Null)
 ;;
 
 let schedule_fsm_state ~now state schedules =

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1847,6 +1847,31 @@ let schedule_operator_action ~now state (request : Schedule_domain.schedule_requ
   | _ -> `Null
 ;;
 
+let schedule_keeper_next_tool = function
+  | "blocked_approval" | "awaiting_approval" | "due_pending_refresh" | "expired"
+  | "ready" | "approved" ->
+    `String "masc_schedule_get"
+  | "scheduled" | "running" | "terminal" -> `Null
+  | _ -> `Null
+;;
+
+let schedule_keeper_next_action = function
+  | "blocked_approval" | "awaiting_approval" ->
+    `String
+      "Inspect details, then wait for an explicit human decision before calling masc_schedule_approve or masc_schedule_reject."
+  | "due_pending_refresh" ->
+    `String
+      "The schedule is due but the runner has not refreshed it yet; inspect if needed, otherwise wait for the runner tick."
+  | "expired" ->
+    `String
+      "Inspect the expired schedule and recreate it with masc_schedule_create only if the operator still wants it."
+  | "ready" | "approved" ->
+    `String
+      "Monitor dispatch; do not create a duplicate schedule for this due item."
+  | "scheduled" | "running" | "terminal" -> `Null
+  | _ -> `Null
+;;
+
 let schedule_fsm_state ~now state schedules =
   let count status = schedule_status_count schedules status in
   let count_non_expired status =
@@ -1908,12 +1933,15 @@ let schedule_request_dashboard_json
   let payload_target, payload_summary =
     Schedule_payload_projection.target_summary request
   in
+  let execution_readiness = schedule_execution_readiness ~now state request in
   `Assoc
     [ "schedule_id", `String request.schedule_id
     ; "status", `String (Schedule_domain.schedule_status_to_string request.status)
     ; "effective_status", `String (schedule_effective_status ~now state request)
-    ; "execution_readiness", `String (schedule_execution_readiness ~now state request)
+    ; "execution_readiness", `String execution_readiness
     ; "operator_action", schedule_operator_action ~now state request
+    ; "keeper_next_tool", schedule_keeper_next_tool execution_readiness
+    ; "keeper_next_action", schedule_keeper_next_action execution_readiness
     ; "risk_class", `String (Schedule_domain.risk_class_to_string request.risk_class)
     ; "approval_required", `Bool request.approval_required
     ; "source", `String (Schedule_domain.schedule_source_to_string request.source)

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -54,6 +54,9 @@ let scheduled_automation_observation : WO.scheduled_automation_observation =
         ; recurrence_summary = "daily 09:00:00 Asia/Seoul"
         ; risk_class = "read_only"
         ; due_at = 200.0
+        ; keeper_next_tool = Some "masc_schedule_get"
+        ; keeper_next_action =
+            "Inspect the schedule if needed and monitor dispatch; do not create a duplicate schedule."
         }
       ; { schedule_id = "sched-blocked"
         ; action = "approve_or_reject"
@@ -62,6 +65,9 @@ let scheduled_automation_observation : WO.scheduled_automation_observation =
         ; recurrence_summary = "one_shot"
         ; risk_class = "workspace_write"
         ; due_at = 180.0
+        ; keeper_next_tool = Some "masc_schedule_get"
+        ; keeper_next_action =
+            "Inspect details, then wait for an explicit human decision before calling masc_schedule_approve or masc_schedule_reject."
         }
       ]
   }
@@ -308,7 +314,11 @@ let test_scheduled_automation_prompt_section () =
   check bool "prompt includes blocked action" true
     (contains_sub "action=approve_or_reject" user_msg);
   check bool "prompt points to schedule detail tool" true
-    (contains_sub "masc_schedule_get" user_msg)
+    (contains_sub "masc_schedule_get" user_msg);
+  check bool "prompt includes ready next action" true
+    (contains_sub "do not create a duplicate schedule" user_msg);
+  check bool "prompt includes approval next action" true
+    (contains_sub "masc_schedule_approve or masc_schedule_reject" user_msg)
 
 let () =
   run "keeper_unified_verification_surface"

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -508,6 +508,12 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     (due_row |> member "execution_readiness" |> to_string);
   check string "due action" "wait_for_runner_tick"
     (due_row |> member "operator_action" |> to_string);
+  check string "due keeper next tool" "masc_schedule_get"
+    (due_row |> member "keeper_next_tool" |> to_string);
+  check bool "due keeper action mentions runner tick" true
+    (String_util.contains_substring
+       (due_row |> member "keeper_next_action" |> to_string)
+       "runner tick");
   let blocked_row = find_request "sched-blocked" in
   check bool "blocked separate grant" true
     (blocked_row |> member "requires_separate_human_grant" |> to_bool);
@@ -519,6 +525,12 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     (blocked_row |> member "execution_readiness" |> to_string);
   check string "blocked action" "approve_or_reject"
     (blocked_row |> member "operator_action" |> to_string);
+  check string "blocked keeper next tool" "masc_schedule_get"
+    (blocked_row |> member "keeper_next_tool" |> to_string);
+  check bool "blocked keeper action mentions grant tools" true
+    (String_util.contains_substring
+       (blocked_row |> member "keeper_next_action" |> to_string)
+       "masc_schedule_approve or masc_schedule_reject");
   let expired_row = find_request "sched-expired-effective" in
   check string "expired effective status" "expired"
     (expired_row |> member "effective_status" |> to_string);
@@ -526,6 +538,12 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     (expired_row |> member "execution_readiness" |> to_string);
   check string "expired action" "inspect_or_recreate"
     (expired_row |> member "operator_action" |> to_string);
+  check string "expired keeper next tool" "masc_schedule_get"
+    (expired_row |> member "keeper_next_tool" |> to_string);
+  check bool "expired keeper action mentions recreate" true
+    (String_util.contains_substring
+       (expired_row |> member "keeper_next_action" |> to_string)
+       "masc_schedule_create");
   let exec_row =
     List.find_opt
       (fun row -> String.equal (row |> member "schedule_id" |> to_string) "sched-exec")
@@ -582,8 +600,18 @@ let test_keeper_observation_surfaces_schedule_attention () =
    | blocked :: ready :: [] ->
      check string "blocked schedule first" "sched-blocked" blocked.schedule_id;
      check string "blocked action" "approve_or_reject" blocked.action;
+     check (option string) "blocked next tool" (Some "masc_schedule_get")
+       blocked.keeper_next_tool;
+     check bool "blocked next action mentions grant tools" true
+       (String_util.contains_substring blocked.keeper_next_action
+          "masc_schedule_approve or masc_schedule_reject");
      check string "ready schedule second" "sched-ready" ready.schedule_id;
-     check string "ready action" "dispatch_ready" ready.action
+     check string "ready action" "dispatch_ready" ready.action;
+     check (option string) "ready next tool" (Some "masc_schedule_get")
+       ready.keeper_next_tool;
+     check bool "ready next action avoids duplicates" true
+       (String_util.contains_substring ready.keeper_next_action
+          "do not create a duplicate schedule")
    | _ -> fail "expected blocked and ready attention rows")
 ;;
 


### PR DESCRIPTION
## Summary
- add keeper_next_tool / keeper_next_action to scheduled-automation dashboard rows
- render next-action guidance in the dashboard scheduled automation table
- include next tool/action guidance in Keeper scheduled automation prompt attention items so Keepers do not infer from opaque action labels alone
- centralize schedule keeper guidance in Schedule_projection so dashboard JSON and Keeper prompt surfaces do not duplicate drift-prone strings

## Validation
- opam exec -- ocamlformat --check lib/schedule_projection.ml lib/keeper/keeper_world_observation.mli lib/keeper/keeper_world_observation.ml lib/keeper/keeper_unified_prompt.ml lib/server/server_dashboard_http_runtime_info.ml test/test_keeper_unified_verification_surface.ml test/test_schedule_tool_wiring.ml
- bash scripts/ci/check-telemetry-coverage.sh
- python3 scripts/check_test_coverage.py
- git diff --check origin/main...HEAD
- git diff --check
- ocamlc -stop-after parsing lib/schedule_projection.ml
- ocamlc -stop-after parsing lib/keeper/keeper_world_observation.ml
- ocamlc -stop-after parsing lib/server/server_dashboard_http_runtime_info.ml
- dashboard tsc --noEmit from the PR worktree using already-installed dashboard dependencies
- dashboard vitest run --config vitest.config.ts src/components/tools/tools-main.test.ts --no-file-parallelism --maxWorkers=1 from the PR worktree using already-installed dashboard dependencies

## Notes
- Full/focused Dune build was intentionally left to CI/manual per operator preference.
- The PR worktree does not keep its own dashboard node_modules; temporary Vitest cache was removed after the local check.
