### PR TITLE
fix(dashboard): drop redundant global header title (single-source headers 1/2)

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -58,8 +58,8 @@ describe('App v2 header chrome', () => {
     expect(container.querySelector('.v2-header-brand')).not.toBeNull()
     expect(container.querySelector('.v2-header-mark')).not.toBeNull()
     expect(container.querySelector('.v2-header-crumb')).not.toBeNull()
-    // The global chrome no longer renders a page title: each surface owns its
-    // own header (single source of truth), so the header carries only the crumb.
+    // The global chrome no longer renders a page title: surface-level headers
+    // own the title source of truth, so the shell header carries only the crumb.
     expect(container.querySelector('.v2-header-title')).toBeNull()
     expect(container.querySelector('.v2-header-actions')).not.toBeNull()
     expect(container.querySelector('.v2-shell-tabs')).toBeNull()

--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -58,7 +58,9 @@ describe('App v2 header chrome', () => {
     expect(container.querySelector('.v2-header-brand')).not.toBeNull()
     expect(container.querySelector('.v2-header-mark')).not.toBeNull()
     expect(container.querySelector('.v2-header-crumb')).not.toBeNull()
-    expect(container.querySelector('.v2-header-title')).not.toBeNull()
+    // The global chrome no longer renders a page title: each surface owns its
+    // own header (single source of truth), so the header carries only the crumb.
+    expect(container.querySelector('.v2-header-title')).toBeNull()
     expect(container.querySelector('.v2-header-actions')).not.toBeNull()
     expect(container.querySelector('.v2-shell-tabs')).toBeNull()
     expect(container.querySelector('.v2-app-header-status')).not.toBeNull()

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -330,7 +330,7 @@ export function App() {
                        (single source of truth), so the global chrome shows only the
                        crumb — matching the v2 design top bar, which carries a slim
                        breadcrumb and no page title. A title here duplicated every
-                       surface's own <h1>. */ ''}
+                       surface-level heading/header. */ ''}
                 </div>
               </div>
             </div>

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -326,9 +326,11 @@ export function App() {
                         `
                       : null}
                   </div>
-                  <h1 class="v2-header-title mt-1 min-w-0 truncate font-display text-xs font-semibold leading-tight tracking-normal text-[var(--color-fg-secondary)]">
-                    ${currentSection?.label ?? currentView?.label ?? 'Multi-Agent Namespace Console'}
-                  </h1>
+                  ${/* No title heading here: each surface owns its primary header
+                       (single source of truth), so the global chrome shows only the
+                       crumb — matching the v2 design top bar, which carries a slim
+                       breadcrumb and no page title. A title here duplicated every
+                       surface's own <h1>. */ ''}
                 </div>
               </div>
             </div>

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -46,6 +46,41 @@ describe('DashboardMain solo mode', () => {
   })
 })
 
+describe('DashboardMain primary heading', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    dashboardLoading.value = false
+    connected.value = true
+    namespaceTruthInitializing.value = false
+    document.title = 'MASC Dashboard'
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it.each([
+    ['monitoring', 'Keeper Fleet'],
+    ['command', 'Actions'],
+    ['lab', 'Tools'],
+    ['board', 'Board'],
+  ] as const)(
+    'renders the generic lead for %s as the primary h1',
+    (tab, label) => {
+      route.value = { tab, params: {}, postId: null }
+
+      render(h(DashboardMain, {}), container)
+
+      const leadTitle = container.querySelector('.v2-shell-panel h1')
+      expect(leadTitle?.textContent?.trim()).toBe(label)
+    },
+  )
+})
+
 describe('isKeeperDetailDashboardRoute', () => {
   it('detects monitor keeper detail drilldowns', () => {
     expect(isKeeperDetailDashboardRoute({

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -79,6 +79,18 @@ describe('DashboardMain primary heading', () => {
       expect(leadTitle?.textContent?.trim()).toBe(label)
     },
   )
+
+  it('renders a bespoke-header surface with one h1 and no generic lead h1', async () => {
+    route.value = { tab: 'overview', params: {}, postId: null }
+
+    render(h(DashboardMain, {}), container)
+
+    await waitFor(() => {
+      expect([...container.querySelectorAll('h1')].map(node => node.textContent?.trim()))
+        .toEqual(['운영 개요'])
+    }, { timeout: 5000 })
+    expect(container.querySelector('.v2-shell-panel h1')).toBeNull()
+  })
 })
 
 describe('isKeeperDetailDashboardRoute', () => {

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1415,7 +1415,7 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
 
 // Surfaces that render their own primary header (a bespoke per-surface title
 // block) and therefore must NOT get the generic dashboard SurfaceLead above
-// them — otherwise the screen shows a duplicate title: the generic <h2> nav
+// them — otherwise the screen shows a duplicate title: the generic <h1> nav
 // label stacked over the surface's own <h1>. When a surface component renders
 // its own top-of-body header, add its TabId here (keep this in sync with the
 // route registry). Verified against the v2 design audit (2026-06-20): the
@@ -1476,9 +1476,9 @@ function SurfaceLead() {
           />`
         : null}
       <div class="flex items-center gap-2">
-        <h2 class="text-lg font-semibold tracking-normal text-[var(--color-fg-secondary)] leading-tight">
+        <h1 class="text-lg font-semibold tracking-normal text-[var(--color-fg-secondary)] leading-tight">
           ${title}
-        </h2>
+        </h1>
         ${shareUrl !== ''
           ? html`<${CopyIdButton}
               value=${shareUrl}

--- a/dashboard/src/styles/v2-shell.css
+++ b/dashboard/src/styles/v2-shell.css
@@ -687,13 +687,6 @@ aside.v2-status-tray .tray-action-link:hover {
   color: var(--ss-brand);
 }
 
-.v2-shell-header .v2-header-title {
-  color: var(--ss-text-primary);
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
-
 /* Surface tabs inside the header */
 .v2-shell-tabs [role="tablist"] {
   border-color: var(--ss-border);


### PR DESCRIPTION
## 목표 (근본해결 1/2단계)

대시보드 제목 중복의 **systemic 근원**을 제거한다. 전역 shell 헤더가 `<h1 class="v2-header-title">`로 현재 surface 라벨을 **모든 비-compact surface에** 렌더해, 각 surface의 자체 bespoke 헤더(그리고 #21834 이전엔 generic SurfaceLead까지)와 제목이 중복됐다.

#21834(SurfaceLead 화이트리스트)는 중간 레이어를 7개 surface에만 가린 N-of-M band-aid였고, 이 전역 h1(#1 소스)은 손대지 않아 모든 surface에서 `전역 h1 + surface h1` 2겹이 남아 있었다.

## 변경

`app.ts`의 전역 헤더에서 `v2-header-title` `<h1>` 블록 제거 → 헤더 chrome은 **breadcrumb crumb만** 표시(시안 `.v2-top`과 동일: 얇은 crumb, 페이지 제목 없음). surface 자체 헤더가 **단일 제목 소스**가 된다.

- `app.ts`: 전역 h1 제거 (이유 주석 포함).
- `styles/v2-shell.css`: 고아가 된 `.v2-header-title` 규칙 제거.
- `app.test.ts`: `.v2-header-title` 부재를 단언(`toBeNull`)해 결정 잠금.

## 근거 (v2 시안)

시안 top bar(`shell.jsx` `TopBar`)는 `.crumb`(surface 라벨) + stat chips만 두고 **페이지 제목 h1이 없다**. 제목은 각 surface의 bespoke 헤더가 소유. 이 PR은 구현을 그 모델로 정렬한다.

## 검증 (로컬)

- `tsc --noEmit`: 0 errors
- vitest `app.test.ts`: 24 passed
- `npm run lint` (eslint src): clean

## 후속 (2/2단계, 별도 PR)

generic `SurfaceLead` + `SURFACE_OWN_LEAD_IDS` 화이트리스트 완전 제거 + headerless surface 4종(monitoring/board/command/lab)에 bespoke 헤더 추가 + SurfaceLead의 copy-link/solo-view affordance를 각 surface 헤더로 재배치. 그러면 제목 소스가 surface 헤더 1개로 수렴하고 화이트리스트가 불필요해진다.

## 경계

UI 전용. credential/operator/sandbox/hooks/workflow-docs 미변경 → RFC 게이트 대상 아님. 증상 억제 아닌 root fix(중복 소스 1개 제거).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
