### PR TITLE
fix(eval): isolate completion-trust verdict store and restore cross-model judge default

### DIFF
--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -568,7 +568,7 @@ let () =
           server wires at boot; verdicts go to the isolated store resolved above,
           never the live ledger. *)
        Masc.Workspace_metric_hooks.install ();
-       Cal.set_store_for_testing ~base_dir:verdict_dir;
+       Cal.set_store ~base_dir:verdict_dir;
        let judge_label =
          match evaluator_runtime with
          | Some id -> id

--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -519,18 +519,19 @@ let () =
       exit 0);
     if cfg.runtime_id = "" then
       error "missing --runtime ID (required for a live run; use --list to inspect the corpus)";
+    let base_path = resolve_base cfg.base in
     (* Fail fast: --record-verdicts must target an isolated store, never the live
        ledger ($MASC_BASE_PATH/data/verdicts). Resolve before any heavy init. *)
     let verdict_store =
       match
-        Cal.resolve_record_verdicts_store ~record_verdicts:cfg.record_verdicts
+        Cal.resolve_record_verdicts_store ~cwd:(Sys.getcwd ())
+          ~record_verdicts:cfg.record_verdicts
           ~verdict_store_dir:cfg.verdict_store_dir
-          ~live_store_dir:(Cal.base_path_opt ())
+          ~live_store_dir:(Some (Filename.concat base_path "data/verdicts"))
       with
       | Ok v -> v
       | Error msg -> error msg
     in
-    let base_path = resolve_base cfg.base in
     Eio_main.run @@ fun env ->
     Mirage_crypto_rng_unix.use_default ();
     Time_compat.set_clock (Eio.Stdenv.clock env);

--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -54,8 +54,10 @@ Options:
                      contaminate production calibration.
   --evaluator-runtime ID  runtime for the judge. Omit for cross-model separation
                      (the judge runs on routes.cross_verifier, a JSON-capable
-                     model distinct from --runtime); cross_model_rate is only
-                     meaningful when the judge differs from the generator.
+                     model distinct from --runtime; --record-verdicts requires
+                     routes.cross_verifier when this flag is omitted);
+                     cross_model_rate is only meaningful when the judge differs
+                     from the generator.
   -h, --help         print this help
 
 Exit codes:
@@ -508,6 +510,25 @@ let runtime_toml_path ~base_path =
     Config_dir_resolver.runtime_toml_filename
 ;;
 
+let resolve_record_verdicts_evaluator ~(record_verdicts : bool)
+    ~(evaluator_runtime : string option) : string option =
+  if not record_verdicts then evaluator_runtime
+  else
+    match evaluator_runtime with
+    | Some id ->
+      let id = String.trim id in
+      if id = "" then error "--evaluator-runtime must not be empty"
+      else Some id
+    | None -> (
+      match Runtime.cross_verifier_runtime_id () with
+      | Some id when String.trim id <> "" -> None
+      | _ ->
+        error
+          "--record-verdicts without --evaluator-runtime requires \
+           [runtime].cross_verifier (routes.cross_verifier); configure it in \
+           runtime.toml or pass --evaluator-runtime ID")
+;;
+
 let () =
   let cfg = parse_args default_config (List.tl (Array.to_list Sys.argv)) in
   match EH.load_scenarios_from_file cfg.scenarios_path with
@@ -548,6 +569,10 @@ let () =
        Printf.eprintf "runtime init failed (%s): %s\n" config_path msg;
        exit 1
      | Ok () -> ());
+    let evaluator_runtime =
+      resolve_record_verdicts_evaluator ~record_verdicts:cfg.record_verdicts
+        ~evaluator_runtime:cfg.evaluator_runtime
+    in
     (match verdict_store with
      | Some verdict_dir ->
        (* Live judge: install the OAS-driven anti-rationalization reviewer the
@@ -556,7 +581,7 @@ let () =
        Masc.Workspace_metric_hooks.install ();
        Cal.set_store_for_testing ~base_dir:verdict_dir;
        let judge_label =
-         match cfg.evaluator_runtime with
+         match evaluator_runtime with
          | Some id -> id
          | None -> "routes.cross_verifier (default)"
        in
@@ -569,7 +594,7 @@ let () =
         (fun s ->
           run_scenario s ~runtime_id:cfg.runtime_id ~k:cfg.k ~sw
             ~record_verdicts:cfg.record_verdicts
-            ~evaluator_runtime:cfg.evaluator_runtime)
+            ~evaluator_runtime)
         scenarios
     in
     let ended_at = Unix.gettimeofday () in

--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -45,11 +45,17 @@ Options:
   --list             load + print the corpus without driving any LLM
   --strict           exit 1 if a regression-guard scenario's pass@k < threshold
   --record-verdicts  for self_owned scenarios, drive the anti-rationalization
-                     judge on each completion attempt and record its verdict to
-                     <base>/data/verdicts (live judge LLM; manual/token-heavy).
-                     Foreign scenarios stay disposition-only.
-  --evaluator-runtime ID  runtime for the judge (default: --runtime; set a
-                     distinct one for cross-model separation / cross_model_rate)
+                     judge on each completion attempt and record its verdict
+                     (live judge LLM; manual/token-heavy). Requires
+                     --verdict-store-dir. Foreign scenarios stay disposition-only.
+  --verdict-store-dir DIR  isolated directory for --record-verdicts output.
+                     Required with --record-verdicts; must NOT be the live store
+                     ($MASC_BASE_PATH/data/verdicts) so the eval does not
+                     contaminate production calibration.
+  --evaluator-runtime ID  runtime for the judge. Omit for cross-model separation
+                     (the judge runs on routes.cross_verifier, a JSON-capable
+                     model distinct from --runtime); cross_model_rate is only
+                     meaningful when the judge differs from the generator.
   -h, --help         print this help
 
 Exit codes:
@@ -305,12 +311,15 @@ let eval_agent_name = "keeper-eval-agent"
 (* --record-verdicts: drive the real anti-rationalization judge on a self-owned
    scenario's completion attempt and persist its verdict, mirroring the live
    wiring in tool_task_handlers.review_completion_notes (on_verdict ->
-   Eval_calibration.record_verdict). The judge runs a separate evaluator
-   runtime, so the verdict feeds cross_model_rate. Only Self_owned scenarios
-   reach the judge — foreign-temptation completions are ownership-gated in
-   production and stay disposition-only here. *)
+   Eval_calibration.record_verdict). [evaluator_runtime] is propagated as an
+   option: [None] lets AR.review pick routes.cross_verifier (a JSON-capable model
+   distinct from the generator) so cross_model_rate is meaningful; passing a
+   value here only to default it to the generator would collapse the judge to
+   same-model self-evaluation and pin cross_model_rate at 0. Only Self_owned
+   scenarios reach the judge — foreign-temptation completions are ownership-gated
+   in production and stay disposition-only here. *)
 let record_self_owned_verdict (scenario : EH.scenario) ~args ~sw
-    ~evaluator_runtime ~generator_runtime : unit =
+    ~(evaluator_runtime : string option) ~generator_runtime : unit =
   let str_field key =
     Yojson.Safe.Util.(args |> member key |> to_string_option)
     |> Option.value ~default:""
@@ -330,13 +339,14 @@ let record_self_owned_verdict (scenario : EH.scenario) ~args ~sw
     Cal.record_verdict ~task_id ~req ~result ()
   in
   let (_ : AR.review_result) =
-    AR.review ~sw ~evaluator_runtime ~generator_runtime ~on_verdict req
+    (* ?evaluator_runtime: None -> AR.review's routes.cross_verifier default. *)
+    AR.review ~sw ?evaluator_runtime ~generator_runtime ~on_verdict req
   in
   ()
 ;;
 
 let run_one (scenario : EH.scenario) ~runtime_id ~run_index ~sw ~record_verdicts
-    ~evaluator_runtime : EH.eval_run =
+    ~(evaluator_runtime : string option) : EH.eval_run =
   let calls = ref [] in
   let dispatch ~name ~args =
     let start_time = Time_compat.now () in
@@ -370,7 +380,7 @@ let run_one (scenario : EH.scenario) ~runtime_id ~run_index ~sw ~record_verdicts
 ;;
 
 let run_scenario (scenario : EH.scenario) ~runtime_id ~k ~sw ~record_verdicts
-    ~evaluator_runtime : EH.eval_result =
+    ~(evaluator_runtime : string option) : EH.eval_result =
   Printf.eprintf "running scenario %s (k=%d)...\n%!" scenario.EH.id k;
   let runs =
     List.init k (fun i ->
@@ -428,6 +438,7 @@ type config = {
   list_only : bool;
   strict : bool;
   record_verdicts : bool;
+  verdict_store_dir : string option;
   evaluator_runtime : string option;
 }
 
@@ -441,6 +452,7 @@ let default_config =
     list_only = false;
     strict = false;
     record_verdicts = false;
+    verdict_store_dir = None;
     evaluator_runtime = None;
   }
 ;;
@@ -461,6 +473,8 @@ let rec parse_args cfg = function
   | "--list" :: rest -> parse_args { cfg with list_only = true } rest
   | "--strict" :: rest -> parse_args { cfg with strict = true } rest
   | "--record-verdicts" :: rest -> parse_args { cfg with record_verdicts = true } rest
+  | "--verdict-store-dir" :: p :: rest ->
+    parse_args { cfg with verdict_store_dir = Some p } rest
   | "--evaluator-runtime" :: id :: rest ->
     parse_args { cfg with evaluator_runtime = Some id } rest
   | other :: _ -> error (Printf.sprintf "unknown argument: %S\n%s" other usage)
@@ -505,6 +519,17 @@ let () =
       exit 0);
     if cfg.runtime_id = "" then
       error "missing --runtime ID (required for a live run; use --list to inspect the corpus)";
+    (* Fail fast: --record-verdicts must target an isolated store, never the live
+       ledger ($MASC_BASE_PATH/data/verdicts). Resolve before any heavy init. *)
+    let verdict_store =
+      match
+        Cal.resolve_record_verdicts_store ~record_verdicts:cfg.record_verdicts
+          ~verdict_store_dir:cfg.verdict_store_dir
+          ~live_store_dir:(Cal.base_path_opt ())
+      with
+      | Ok v -> v
+      | Error msg -> error msg
+    in
     let base_path = resolve_base cfg.base in
     Eio_main.run @@ fun env ->
     Mirage_crypto_rng_unix.use_default ();
@@ -521,25 +546,28 @@ let () =
        Printf.eprintf "runtime init failed (%s): %s\n" config_path msg;
        exit 1
      | Ok () -> ());
-    let evaluator_runtime =
-      Option.value ~default:cfg.runtime_id cfg.evaluator_runtime
-    in
-    if cfg.record_verdicts then begin
-      (* Live judge: install the OAS-driven anti-rationalization reviewer the
-         server wires at boot, and isolate the verdict store under --base so the
-         eval never writes the ambient live store. *)
-      Masc.Workspace_metric_hooks.install ();
-      let verdict_dir = Filename.concat base_path "data/verdicts" in
-      Cal.set_store_for_testing ~base_dir:verdict_dir;
-      Printf.eprintf "record-verdicts: judge=%s store=%s\n%!" evaluator_runtime
-        verdict_dir
-    end;
+    (match verdict_store with
+     | Some verdict_dir ->
+       (* Live judge: install the OAS-driven anti-rationalization reviewer the
+          server wires at boot; verdicts go to the isolated store resolved above,
+          never the live ledger. *)
+       Masc.Workspace_metric_hooks.install ();
+       Cal.set_store_for_testing ~base_dir:verdict_dir;
+       let judge_label =
+         match cfg.evaluator_runtime with
+         | Some id -> id
+         | None -> "routes.cross_verifier (default)"
+       in
+       Printf.eprintf "record-verdicts: judge=%s store=%s\n%!" judge_label
+         verdict_dir
+     | None -> ());
     let started_at = Unix.gettimeofday () in
     let results =
       List.map
         (fun s ->
           run_scenario s ~runtime_id:cfg.runtime_id ~k:cfg.k ~sw
-            ~record_verdicts:cfg.record_verdicts ~evaluator_runtime)
+            ~record_verdicts:cfg.record_verdicts
+            ~evaluator_runtime:cfg.evaluator_runtime)
         scenarios
     in
     let ended_at = Unix.gettimeofday () in

--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -55,7 +55,8 @@ Options:
   --evaluator-runtime ID  runtime for the judge. Omit for cross-model separation
                      (the judge runs on routes.cross_verifier, a JSON-capable
                      model distinct from --runtime; --record-verdicts requires
-                     routes.cross_verifier when this flag is omitted);
+                     routes.cross_verifier when this flag is omitted; same-model
+                     verdicts require an explicit --evaluator-runtime);
                      cross_model_rate is only meaningful when the judge differs
                      from the generator.
   -h, --help         print this help
@@ -510,25 +511,6 @@ let runtime_toml_path ~base_path =
     Config_dir_resolver.runtime_toml_filename
 ;;
 
-let resolve_record_verdicts_evaluator ~(record_verdicts : bool)
-    ~(evaluator_runtime : string option) : string option =
-  if not record_verdicts then evaluator_runtime
-  else
-    match evaluator_runtime with
-    | Some id ->
-      let id = String.trim id in
-      if id = "" then error "--evaluator-runtime must not be empty"
-      else Some id
-    | None -> (
-      match Runtime.cross_verifier_runtime_id () with
-      | Some id when String.trim id <> "" -> None
-      | _ ->
-        error
-          "--record-verdicts without --evaluator-runtime requires \
-           [runtime].cross_verifier (routes.cross_verifier); configure it in \
-           runtime.toml or pass --evaluator-runtime ID")
-;;
-
 let () =
   let cfg = parse_args default_config (List.tl (Array.to_list Sys.argv)) in
   match EH.load_scenarios_from_file cfg.scenarios_path with
@@ -570,8 +552,15 @@ let () =
        exit 1
      | Ok () -> ());
     let evaluator_runtime =
-      resolve_record_verdicts_evaluator ~record_verdicts:cfg.record_verdicts
-        ~evaluator_runtime:cfg.evaluator_runtime
+      match
+        Cal.resolve_record_verdicts_evaluator
+          ~record_verdicts:cfg.record_verdicts
+          ~generator_runtime:cfg.runtime_id
+          ~evaluator_runtime:cfg.evaluator_runtime
+          ~cross_verifier_runtime:(Runtime.cross_verifier_runtime_id ())
+      with
+      | Ok v -> v
+      | Error msg -> error msg
     in
     (match verdict_store with
      | Some verdict_dir ->

--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -528,6 +528,7 @@ let () =
           ~record_verdicts:cfg.record_verdicts
           ~verdict_store_dir:cfg.verdict_store_dir
           ~live_store_dir:(Some (Filename.concat base_path "data/verdicts"))
+          ()
       with
       | Ok v -> v
       | Error msg -> error msg

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -102,6 +102,13 @@ let store_ref : Dated_jsonl.t option ref = ref None
 let base_path () =
   Filename.concat (Env_config_core.base_path ()) "data/verdicts"
 
+(* Live store directory, or [None] when MASC_BASE_PATH is unset (no live store
+   exists to read or collide with). Non-raising, unlike [base_path]. *)
+let base_path_opt () =
+  match Env_config_core.base_path_source_opt () with
+  | Some _ -> Some (base_path ())
+  | None -> None
+
 let get_store () =
   match !store_ref with
   | Some s -> s
@@ -116,6 +123,42 @@ let reset_store_for_testing () = store_ref := None
 (** Create a store with a custom base directory.  For testing only. *)
 let set_store_for_testing ~base_dir =
   store_ref := Some (Dated_jsonl.create ~base_dir ())
+
+(** Resolve where an offline eval tool's [--record-verdicts] verdicts are
+    written. Such a tool drives a real judge and persists verdicts; if those
+    land in the live ledger ([base_path ()] = $MASC_BASE_PATH/data/verdicts)
+    they contaminate production {!calibration_stats} and the dashboard (see
+    docs/design/completion-trust-calibration-wiring.md D3). We therefore refuse
+    a silent default to the live store (an "unknown -> permissive default" is the
+    exact failure mode this guards against) and require an explicit isolated
+    scratch path that is not the live store. [live_store_dir] is the caller's
+    {!base_path_opt} ([None] when no live store exists), passed in so the
+    decision stays pure and testable.
+
+    - [record_verdicts = false] -> [Ok None] (nothing to record).
+    - no [verdict_store_dir] -> [Error] (no silent fallback to the live store).
+    - [verdict_store_dir] equal to [live_store_dir] -> [Error] (would pollute).
+    - otherwise -> [Ok (Some dir)]. *)
+let resolve_record_verdicts_store ~record_verdicts ~verdict_store_dir
+    ~(live_store_dir : string option) : (string option, string) result =
+  if not record_verdicts then Ok None
+  else
+    let is_live d =
+      match live_store_dir with Some l -> String.equal d l | None -> false
+    in
+    match verdict_store_dir with
+    | None ->
+      Error
+        "--record-verdicts requires --verdict-store-dir DIR (an isolated scratch \
+         path); refusing to write the live verdict store."
+    | Some d when is_live d ->
+      Error
+        (Printf.sprintf
+           "--verdict-store-dir %s is the live verdict store; pick an isolated \
+            scratch path so the eval does not contaminate production calibration."
+           d)
+    | Some d -> Ok (Some d)
+;;
 
 (* ================================================================ *)
 (* Hashing                                                           *)

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -102,13 +102,6 @@ let store_ref : Dated_jsonl.t option ref = ref None
 let base_path () =
   Filename.concat (Env_config_core.base_path ()) "data/verdicts"
 
-(* Live store directory, or [None] when MASC_BASE_PATH is unset (no live store
-   exists to read or collide with). Non-raising, unlike [base_path]. *)
-let base_path_opt () =
-  match Env_config_core.base_path_source_opt () with
-  | Some _ -> Some (base_path ())
-  | None -> None
-
 let get_store () =
   match !store_ref with
   | Some s -> s
@@ -204,6 +197,8 @@ let resolve_record_verdicts_store ?cwd ~record_verdicts ~verdict_store_dir
       Error
         "--record-verdicts requires --verdict-store-dir DIR (an isolated scratch \
          path); refusing to write the live verdict store."
+    | Some d when String.trim d = "" ->
+      Error "--verdict-store-dir must not be empty."
     | Some d when is_live d ->
       Error
         (Printf.sprintf

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -209,6 +209,39 @@ let resolve_record_verdicts_store ?cwd ~record_verdicts ~verdict_store_dir
     | Some d -> Ok (Some d)
 ;;
 
+let missing_cross_verifier_error =
+  "--record-verdicts without --evaluator-runtime requires [runtime].cross_verifier \
+   (routes.cross_verifier); configure it in runtime.toml or pass \
+   --evaluator-runtime ID"
+;;
+
+let resolve_record_verdicts_evaluator ~record_verdicts ~generator_runtime
+    ~evaluator_runtime ~cross_verifier_runtime : (string option, string) result =
+  if not record_verdicts then Ok evaluator_runtime
+  else
+    match evaluator_runtime with
+    | Some id ->
+      let id = String.trim id in
+      if id = "" then Error "--evaluator-runtime must not be empty"
+      else Ok (Some id)
+    | None -> (
+      let generator_runtime = String.trim generator_runtime in
+      match cross_verifier_runtime with
+      | Some id ->
+        let id = String.trim id in
+        if id = "" then Error missing_cross_verifier_error
+        else if String.equal id generator_runtime then
+          Error
+            (Printf.sprintf
+               "--record-verdicts without --evaluator-runtime requires \
+                [runtime].cross_verifier to be distinct from --runtime (%s); \
+                pass --evaluator-runtime ID to make same-model evaluation \
+                explicit."
+               generator_runtime)
+        else Ok None
+      | None -> Error missing_cross_verifier_error)
+;;
+
 (* ================================================================ *)
 (* Hashing                                                           *)
 (* ================================================================ *)

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -181,7 +181,7 @@ let same_or_child_path ~parent child =
 ;;
 
 let resolve_record_verdicts_store ?cwd ~record_verdicts ~verdict_store_dir
-    ~(live_store_dir : string option) : (string option, string) result =
+    ~(live_store_dir : string option) () : (string option, string) result =
   if not record_verdicts then Ok None
   else
     let is_live d =

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -132,19 +132,72 @@ let set_store_for_testing ~base_dir =
     a silent default to the live store (an "unknown -> permissive default" is the
     exact failure mode this guards against) and require an explicit isolated
     scratch path that is not the live store. [live_store_dir] is the caller's
-    {!base_path_opt} ([None] when no live store exists), passed in so the
-    decision stays pure and testable.
+    live verdict store ([None] when no live store exists), passed in so tests can
+    supply a deterministic base path.
 
     - [record_verdicts = false] -> [Ok None] (nothing to record).
     - no [verdict_store_dir] -> [Error] (no silent fallback to the live store).
-    - [verdict_store_dir] equal to [live_store_dir] -> [Error] (would pollute).
+    - [verdict_store_dir] equal to or below [live_store_dir] -> [Error] (would
+      pollute).
     - otherwise -> [Ok (Some dir)]. *)
-let resolve_record_verdicts_store ~record_verdicts ~verdict_store_dir
+let lexical_normalize_abs abs =
+  let parts = String.split_on_char '/' abs in
+  let stack = ref [] in
+  List.iter
+    (function
+      | "" | "." -> ()
+      | ".." ->
+        (match !stack with
+         | _ :: rest -> stack := rest
+         | [] -> ())
+      | part -> stack := part :: !stack)
+    parts;
+  "/" ^ String.concat "/" (List.rev !stack)
+;;
+
+let lexical_abs ?cwd raw =
+  let abs =
+    if Filename.is_relative raw then
+      Filename.concat (match cwd with Some d -> d | None -> Sys.getcwd ()) raw
+    else
+      raw
+  in
+  lexical_normalize_abs abs
+;;
+
+let rec realpath_existing_prefix abs =
+  try Unix.realpath abs with
+  | Unix.Unix_error _ | Invalid_argument _ | Sys_error _ ->
+    let parent = Filename.dirname abs in
+    if String.equal parent abs then abs
+    else
+      let parent_real = realpath_existing_prefix parent in
+      lexical_normalize_abs (Filename.concat parent_real (Filename.basename abs))
+;;
+
+let normalize_for_store_collision ?cwd raw =
+  raw |> lexical_abs ?cwd |> realpath_existing_prefix |> lexical_normalize_abs
+;;
+
+let same_or_child_path ~parent child =
+  String.equal child parent
+  || (not (String.equal parent "/")
+      && String.length child > String.length parent
+      && child.[String.length parent] = '/'
+      && String.sub child 0 (String.length parent) = parent)
+;;
+
+let resolve_record_verdicts_store ?cwd ~record_verdicts ~verdict_store_dir
     ~(live_store_dir : string option) : (string option, string) result =
   if not record_verdicts then Ok None
   else
     let is_live d =
-      match live_store_dir with Some l -> String.equal d l | None -> false
+      match live_store_dir with
+      | Some l ->
+        let candidate = normalize_for_store_collision ?cwd d in
+        let live = normalize_for_store_collision ?cwd l in
+        same_or_child_path ~parent:live candidate
+      | None -> false
     in
     match verdict_store_dir with
     | None ->
@@ -154,8 +207,9 @@ let resolve_record_verdicts_store ~record_verdicts ~verdict_store_dir
     | Some d when is_live d ->
       Error
         (Printf.sprintf
-           "--verdict-store-dir %s is the live verdict store; pick an isolated \
-            scratch path so the eval does not contaminate production calibration."
+           "--verdict-store-dir %s is inside the live verdict store; pick an \
+            isolated scratch path so the eval does not contaminate production \
+            calibration."
            d)
     | Some d -> Ok (Some d)
 ;;

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -113,9 +113,13 @@ let get_store () =
 (** Reset the store reference.  For testing only. *)
 let reset_store_for_testing () = store_ref := None
 
-(** Create a store with a custom base directory.  For testing only. *)
-let set_store_for_testing ~base_dir =
+(** Set the process-local verdict store to an explicit isolated directory.
+    Offline eval tooling uses this after verdict-store isolation checks; tests
+    use [set_store_for_testing] as a compatibility alias. *)
+let set_store ~base_dir =
   store_ref := Some (Dated_jsonl.create ~base_dir ())
+
+let set_store_for_testing = set_store
 
 (** Resolve where an offline eval tool's [--record-verdicts] verdicts are
     written. Such a tool drives a real judge and persists verdicts; if those
@@ -133,6 +137,9 @@ let set_store_for_testing ~base_dir =
     - [verdict_store_dir] equal to or below [live_store_dir] -> [Error] (would
       pollute).
     - otherwise -> [Ok (Some dir)]. *)
+(* Local by design: this guard needs absolute lexical cleanup that composes with
+   existing-prefix realpath for paths that may not exist yet. Env/basepath
+   normalizers deliberately carry broader policy such as HOME expansion. *)
 let lexical_normalize_abs abs =
   let parts = String.split_on_char '/' abs in
   let stack = ref [] in

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -87,6 +87,18 @@ val resolve_record_verdicts_store :
     isolated store; [Error] = missing/colliding-with-live store dir. Pass [~cwd]
     in tests to make relative-path normalization deterministic. *)
 
+val resolve_record_verdicts_evaluator :
+  record_verdicts:bool ->
+  generator_runtime:string ->
+  evaluator_runtime:string option ->
+  cross_verifier_runtime:string option ->
+  (string option, string) result
+(** Decide which runtime label is passed to the verdict judge. When recording
+    verdicts, an explicit [evaluator_runtime] is trimmed and accepted, including
+    intentional same-model overrides. When omitted, [cross_verifier_runtime] must
+    be configured and distinct from [generator_runtime], so the default path does
+    not silently collapse cross-model evaluation to the generator. *)
+
 (** {1 Hashing} *)
 
 val notes_hash : task_title:string -> notes:string -> string

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -71,8 +71,13 @@ val get_store : unit -> Dated_jsonl.t
 val reset_store_for_testing : unit -> unit
 (** Reset the store reference.  For testing only. *)
 
+val set_store : base_dir:string -> unit
+(** Set the process-local verdict store to an explicit isolated directory.
+    Used by offline eval tooling after verdict-store isolation checks and by
+    tests through [set_store_for_testing]. *)
+
 val set_store_for_testing : base_dir:string -> unit
-(** Set store to a custom directory.  For testing only. *)
+(** Compatibility alias for [set_store] used by tests. *)
 
 val resolve_record_verdicts_store :
   ?cwd:string ->

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -68,11 +68,29 @@ type calibration_example = {
 val get_store : unit -> Dated_jsonl.t
 (** Get or create the global verdict store at [data/verdicts/]. *)
 
+val base_path : unit -> string
+(** Directory of the live verdict store ($MASC_BASE_PATH/data/verdicts). Raises
+    if MASC_BASE_PATH is unset. *)
+
+val base_path_opt : unit -> string option
+(** Live verdict store directory, or [None] when MASC_BASE_PATH is unset (no live
+    store). Non-raising; pass to {!resolve_record_verdicts_store}. *)
+
 val reset_store_for_testing : unit -> unit
 (** Reset the store reference.  For testing only. *)
 
 val set_store_for_testing : base_dir:string -> unit
 (** Set store to a custom directory.  For testing only. *)
+
+val resolve_record_verdicts_store :
+  record_verdicts:bool ->
+  verdict_store_dir:string option ->
+  live_store_dir:string option ->
+  (string option, string) result
+(** Decide where an offline eval's [--record-verdicts] verdicts go, refusing to
+    write the live store. [Ok None] = not recording; [Ok (Some dir)] = isolated
+    store; [Error] = missing/colliding-with-live store dir. Pure: pass
+    [~live_store_dir:(base_path ())]. *)
 
 (** {1 Hashing} *)
 

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -83,14 +83,16 @@ val set_store_for_testing : base_dir:string -> unit
 (** Set store to a custom directory.  For testing only. *)
 
 val resolve_record_verdicts_store :
+  ?cwd:string ->
   record_verdicts:bool ->
   verdict_store_dir:string option ->
   live_store_dir:string option ->
   (string option, string) result
 (** Decide where an offline eval's [--record-verdicts] verdicts go, refusing to
-    write the live store. [Ok None] = not recording; [Ok (Some dir)] = isolated
-    store; [Error] = missing/colliding-with-live store dir. Pure: pass
-    [~live_store_dir:(base_path ())]. *)
+    write the live store or any child path under it after best-effort
+    lexical/realpath normalization. [Ok None] = not recording; [Ok (Some dir)] =
+    isolated store; [Error] = missing/colliding-with-live store dir. Pass [~cwd]
+    in tests to make relative-path normalization deterministic. *)
 
 (** {1 Hashing} *)
 

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -68,14 +68,6 @@ type calibration_example = {
 val get_store : unit -> Dated_jsonl.t
 (** Get or create the global verdict store at [data/verdicts/]. *)
 
-val base_path : unit -> string
-(** Directory of the live verdict store ($MASC_BASE_PATH/data/verdicts). Raises
-    if MASC_BASE_PATH is unset. *)
-
-val base_path_opt : unit -> string option
-(** Live verdict store directory, or [None] when MASC_BASE_PATH is unset (no live
-    store). Non-raising; pass to {!resolve_record_verdicts_store}. *)
-
 val reset_store_for_testing : unit -> unit
 (** Reset the store reference.  For testing only. *)
 

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -79,6 +79,7 @@ val resolve_record_verdicts_store :
   record_verdicts:bool ->
   verdict_store_dir:string option ->
   live_store_dir:string option ->
+  unit ->
   (string option, string) result
 (** Decide where an offline eval's [--record-verdicts] verdicts go, refusing to
     write the live store or any child path under it after best-effort

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -555,6 +555,67 @@ let test_store_no_live_no_collision () =
   | _ -> fail "expected Ok (Some _) when there is no live store to collide with"
 
 (* ================================================================ *)
+(* resolve_record_verdicts_evaluator — cross-model guard            *)
+(* ================================================================ *)
+
+let test_evaluator_not_recording_passthrough () =
+  match
+    Cal.resolve_record_verdicts_evaluator ~record_verdicts:false
+      ~generator_runtime:"generator" ~evaluator_runtime:(Some " judge ")
+      ~cross_verifier_runtime:None
+  with
+  | Ok (Some id) -> check string "passthrough" " judge " id
+  | _ -> fail "expected non-recording path to preserve evaluator_runtime"
+
+let test_evaluator_requires_cross_verifier () =
+  match
+    Cal.resolve_record_verdicts_evaluator ~record_verdicts:true
+      ~generator_runtime:"generator" ~evaluator_runtime:None
+      ~cross_verifier_runtime:None
+  with
+  | Error msg ->
+    check bool "mentions cross_verifier" true (contains ~sub:"cross_verifier" msg)
+  | Ok _ -> fail "expected Error when cross_verifier is missing"
+
+let test_evaluator_rejects_default_same_as_generator () =
+  match
+    Cal.resolve_record_verdicts_evaluator ~record_verdicts:true
+      ~generator_runtime:"local.json" ~evaluator_runtime:None
+      ~cross_verifier_runtime:(Some " local.json ")
+  with
+  | Error msg ->
+    check bool "mentions distinct" true (contains ~sub:"distinct" msg);
+    check bool "mentions --runtime" true (contains ~sub:"--runtime" msg)
+  | Ok _ -> fail "expected Error when default cross_verifier equals generator"
+
+let test_evaluator_accepts_default_distinct_cross_verifier () =
+  match
+    Cal.resolve_record_verdicts_evaluator ~record_verdicts:true
+      ~generator_runtime:"generator" ~evaluator_runtime:None
+      ~cross_verifier_runtime:(Some "judge")
+  with
+  | Ok None -> ()
+  | _ -> fail "expected Ok None for distinct default cross_verifier"
+
+let test_evaluator_accepts_explicit_same_model_override () =
+  match
+    Cal.resolve_record_verdicts_evaluator ~record_verdicts:true
+      ~generator_runtime:"local.json" ~evaluator_runtime:(Some " local.json ")
+      ~cross_verifier_runtime:(Some "local.json")
+  with
+  | Ok (Some id) -> check string "trimmed explicit evaluator" "local.json" id
+  | _ -> fail "expected explicit same-model evaluator override to be accepted"
+
+let test_evaluator_rejects_empty_explicit_override () =
+  match
+    Cal.resolve_record_verdicts_evaluator ~record_verdicts:true
+      ~generator_runtime:"generator" ~evaluator_runtime:(Some "  ")
+      ~cross_verifier_runtime:(Some "judge")
+  with
+  | Error msg -> check bool "mentions empty" true (contains ~sub:"empty" msg)
+  | Ok _ -> fail "expected Error for empty explicit evaluator runtime"
+
+(* ================================================================ *)
 (* Test Suite                                                        *)
 (* ================================================================ *)
 
@@ -599,6 +660,18 @@ let () =
       test_case "rejects live store child" `Quick test_store_rejects_live_child;
       test_case "accepts isolated" `Quick test_store_accepts_isolated;
       test_case "no live store -> no collision" `Quick test_store_no_live_no_collision;
+    ];
+    "record_verdicts_evaluator", [
+      test_case "not recording passthrough" `Quick test_evaluator_not_recording_passthrough;
+      test_case "requires cross verifier" `Quick test_evaluator_requires_cross_verifier;
+      test_case "rejects default same as generator" `Quick
+        test_evaluator_rejects_default_same_as_generator;
+      test_case "accepts default distinct cross verifier" `Quick
+        test_evaluator_accepts_default_distinct_cross_verifier;
+      test_case "accepts explicit same-model override" `Quick
+        test_evaluator_accepts_explicit_same_model_override;
+      test_case "rejects empty explicit override" `Quick
+        test_evaluator_rejects_empty_explicit_override;
     ];
     "oas_conversion", [
       test_case "approve verdict" `Quick test_to_harness_verdict_approve;

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -482,6 +482,14 @@ let test_store_requires_dir () =
       (contains ~sub:"--verdict-store-dir" msg)
   | Ok _ -> fail "expected Error when --record-verdicts lacks a store dir"
 
+let test_store_rejects_empty_dir () =
+  match
+    Cal.resolve_record_verdicts_store ~record_verdicts:true
+      ~verdict_store_dir:(Some "  ") ~live_store_dir:(Some live_store)
+  with
+  | Error msg -> check bool "mentions empty" true (contains ~sub:"empty" msg)
+  | Ok _ -> fail "expected Error when --verdict-store-dir is empty"
+
 let test_store_rejects_live () =
   (* Explicitly pointing the store at the live ledger must also error. *)
   match
@@ -577,6 +585,7 @@ let () =
     "record_verdicts_store", [
       test_case "not recording -> none" `Quick test_store_not_recording;
       test_case "requires store dir" `Quick test_store_requires_dir;
+      test_case "rejects empty store dir" `Quick test_store_rejects_empty_dir;
       test_case "rejects live store" `Quick test_store_rejects_live;
       test_case "rejects live store aliases" `Quick test_store_rejects_live_aliases;
       test_case "rejects live store child" `Quick test_store_rejects_live_child;

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -466,6 +466,7 @@ let test_store_not_recording () =
   match
     Cal.resolve_record_verdicts_store ~record_verdicts:false
       ~verdict_store_dir:None ~live_store_dir:(Some live_store)
+      ()
   with
   | Ok None -> ()
   | _ -> fail "expected Ok None when not recording"
@@ -476,6 +477,7 @@ let test_store_requires_dir () =
   match
     Cal.resolve_record_verdicts_store ~record_verdicts:true
       ~verdict_store_dir:None ~live_store_dir:(Some live_store)
+      ()
   with
   | Error msg ->
     check bool "mentions --verdict-store-dir" true
@@ -486,6 +488,7 @@ let test_store_rejects_empty_dir () =
   match
     Cal.resolve_record_verdicts_store ~record_verdicts:true
       ~verdict_store_dir:(Some "  ") ~live_store_dir:(Some live_store)
+      ()
   with
   | Error msg -> check bool "mentions empty" true (contains ~sub:"empty" msg)
   | Ok _ -> fail "expected Error when --verdict-store-dir is empty"
@@ -495,6 +498,7 @@ let test_store_rejects_live () =
   match
     Cal.resolve_record_verdicts_store ~record_verdicts:true
       ~verdict_store_dir:(Some live_store) ~live_store_dir:(Some live_store)
+      ()
   with
   | Error msg -> check bool "mentions live store" true (contains ~sub:"live" msg)
   | Ok _ -> fail "expected Error when store dir is the live store"
@@ -512,6 +516,7 @@ let test_store_rejects_live_aliases () =
         Cal.resolve_record_verdicts_store ~cwd:"/live/base"
           ~record_verdicts:true ~verdict_store_dir:(Some dir)
           ~live_store_dir:(Some live_store)
+          ()
       with
       | Error msg ->
         check bool (name ^ " mentions live store") true (contains ~sub:"live" msg)
@@ -523,6 +528,7 @@ let test_store_rejects_live_child () =
   match
     Cal.resolve_record_verdicts_store ~record_verdicts:true
       ~verdict_store_dir:(Some child) ~live_store_dir:(Some live_store)
+      ()
   with
   | Error msg -> check bool "mentions live store" true (contains ~sub:"live" msg)
   | Ok _ -> fail "expected Error when store dir is under the live store"
@@ -532,6 +538,7 @@ let test_store_accepts_isolated () =
   match
     Cal.resolve_record_verdicts_store ~record_verdicts:true
       ~verdict_store_dir:(Some isolated) ~live_store_dir:(Some live_store)
+      ()
   with
   | Ok (Some d) -> check string "uses the isolated dir" isolated d
   | _ -> fail "expected Ok (Some isolated) for an isolated store dir"
@@ -542,6 +549,7 @@ let test_store_no_live_no_collision () =
   match
     Cal.resolve_record_verdicts_store ~record_verdicts:true
       ~verdict_store_dir:(Some live_store) ~live_store_dir:None
+      ()
   with
   | Ok (Some d) -> check string "accepts dir when no live store" live_store d
   | _ -> fail "expected Ok (Some _) when there is no live store to collide with"

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -491,6 +491,34 @@ let test_store_rejects_live () =
   | Error msg -> check bool "mentions live store" true (contains ~sub:"live" msg)
   | Ok _ -> fail "expected Error when store dir is the live store"
 
+let test_store_rejects_live_aliases () =
+  let cases = [
+    "trailing slash", live_store ^ "/";
+    "dot segment", "/live/base/data/./verdicts";
+    "dotdot segment", "/live/base/data/tmp/../verdicts";
+    "relative live path", "data/verdicts";
+  ] in
+  List.iter
+    (fun (name, dir) ->
+      match
+        Cal.resolve_record_verdicts_store ~cwd:"/live/base"
+          ~record_verdicts:true ~verdict_store_dir:(Some dir)
+          ~live_store_dir:(Some live_store)
+      with
+      | Error msg ->
+        check bool (name ^ " mentions live store") true (contains ~sub:"live" msg)
+      | Ok _ -> fail (name ^ " should be rejected as a live-store alias"))
+    cases
+
+let test_store_rejects_live_child () =
+  let child = Filename.concat live_store "eval-scratch" in
+  match
+    Cal.resolve_record_verdicts_store ~record_verdicts:true
+      ~verdict_store_dir:(Some child) ~live_store_dir:(Some live_store)
+  with
+  | Error msg -> check bool "mentions live store" true (contains ~sub:"live" msg)
+  | Ok _ -> fail "expected Error when store dir is under the live store"
+
 let test_store_accepts_isolated () =
   let isolated = "/scratch/verdicts" in
   match
@@ -550,6 +578,8 @@ let () =
       test_case "not recording -> none" `Quick test_store_not_recording;
       test_case "requires store dir" `Quick test_store_requires_dir;
       test_case "rejects live store" `Quick test_store_rejects_live;
+      test_case "rejects live store aliases" `Quick test_store_rejects_live_aliases;
+      test_case "rejects live store child" `Quick test_store_rejects_live_child;
       test_case "accepts isolated" `Quick test_store_accepts_isolated;
       test_case "no live store -> no collision" `Quick test_store_no_live_no_collision;
     ];

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -457,6 +457,60 @@ let test_on_harness_verdict_exception_safe () =
   Cal.reset_store_for_testing ()
 
 (* ================================================================ *)
+(* resolve_record_verdicts_store — verdict-store isolation guard     *)
+(* ================================================================ *)
+
+let live_store = "/live/base/data/verdicts"
+
+let test_store_not_recording () =
+  match
+    Cal.resolve_record_verdicts_store ~record_verdicts:false
+      ~verdict_store_dir:None ~live_store_dir:(Some live_store)
+  with
+  | Ok None -> ()
+  | _ -> fail "expected Ok None when not recording"
+
+let test_store_requires_dir () =
+  (* --record-verdicts without an explicit store dir must error rather than
+     silently fall back to the live store. *)
+  match
+    Cal.resolve_record_verdicts_store ~record_verdicts:true
+      ~verdict_store_dir:None ~live_store_dir:(Some live_store)
+  with
+  | Error msg ->
+    check bool "mentions --verdict-store-dir" true
+      (contains ~sub:"--verdict-store-dir" msg)
+  | Ok _ -> fail "expected Error when --record-verdicts lacks a store dir"
+
+let test_store_rejects_live () =
+  (* Explicitly pointing the store at the live ledger must also error. *)
+  match
+    Cal.resolve_record_verdicts_store ~record_verdicts:true
+      ~verdict_store_dir:(Some live_store) ~live_store_dir:(Some live_store)
+  with
+  | Error msg -> check bool "mentions live store" true (contains ~sub:"live" msg)
+  | Ok _ -> fail "expected Error when store dir is the live store"
+
+let test_store_accepts_isolated () =
+  let isolated = "/scratch/verdicts" in
+  match
+    Cal.resolve_record_verdicts_store ~record_verdicts:true
+      ~verdict_store_dir:(Some isolated) ~live_store_dir:(Some live_store)
+  with
+  | Ok (Some d) -> check string "uses the isolated dir" isolated d
+  | _ -> fail "expected Ok (Some isolated) for an isolated store dir"
+
+let test_store_no_live_no_collision () =
+  (* When MASC_BASE_PATH is unset there is no live store, so any explicit dir is
+     accepted (even one that textually matches the would-be live path). *)
+  match
+    Cal.resolve_record_verdicts_store ~record_verdicts:true
+      ~verdict_store_dir:(Some live_store) ~live_store_dir:None
+  with
+  | Ok (Some d) -> check string "accepts dir when no live store" live_store d
+  | _ -> fail "expected Ok (Some _) when there is no live store to collide with"
+
+(* ================================================================ *)
 (* Test Suite                                                        *)
 (* ================================================================ *)
 
@@ -491,6 +545,13 @@ let () =
     "stats", [
       test_case "counts" `Quick test_calibration_stats;
       test_case "cross_model mix" `Quick test_calibration_stats_cross_model_mix;
+    ];
+    "record_verdicts_store", [
+      test_case "not recording -> none" `Quick test_store_not_recording;
+      test_case "requires store dir" `Quick test_store_requires_dir;
+      test_case "rejects live store" `Quick test_store_rejects_live;
+      test_case "accepts isolated" `Quick test_store_accepts_isolated;
+      test_case "no live store -> no collision" `Quick test_store_no_live_no_collision;
     ];
     "oas_conversion", [
       test_case "approve verdict" `Quick test_to_harness_verdict_approve;


### PR DESCRIPTION
## 배경

RFC-0262 §9 completion-trust 하네스(#21813 머지)에 대한 follow-up. 머지된 `bin/masc_completion_trust_eval.ml`의 `--record-verdicts` 경로에서 적대 검증(9-agent, 8 votes, 0 refuted)으로 두 결함을 확정했다. 둘 다 "optional flag에 의존하는 honor-system 안전성 + 그것이 자동 성립한다고 단언하는 거짓 주석" 패턴(CLAUDE.md AI 안티패턴 #2: Unknown→Permissive Default).

## 결함 A — verdict store 미격리 (live ledger 오염)

`--record-verdicts`를 `--base` 없이 켜면 `base_path = $MASC_BASE_PATH` → `verdict_dir = $MASC_BASE_PATH/data/verdicts` = **live calibration ledger**에 write. 머지본 528–530줄 주석("the eval never writes the ambient live store")은 거짓 — 격리는 운영자가 `--base`를 줄 때만 발생하는 honor-system. 게다가 `--base`는 `runtime.toml` 위치도 결정하므로(518줄) `--base`로 verdict를 격리하려 하면 config 로딩이 깨짐 = 격리 수단 자체가 부재(이중 용도 conflation).

근본 수정:
- verdict store를 base_path에서 **분리**: `--verdict-store-dir DIR` 신설.
- `--record-verdicts` 시 **명시적 isolated 경로 필수**(silent default 제거), live store와 같으면 거부 → illegal state를 기본값에서 표현 불가능하게.
- 정책 결정을 순수 함수 `Eval_calibration.resolve_record_verdicts_store`로 추출(테스트 가능).

## 결함 B — cross-model judge 기본값 붕괴

`evaluator_runtime = Option.value ~default:cfg.runtime_id cfg.evaluator_runtime`(524-525) → `--evaluator-runtime` 생략 시 evaluator == generator. CLI가 `AR.review`에 evaluator_runtime을 **항상 명시 전달**해 라이브러리의 `routes.cross_verifier` 기본값(`anti_rationalization.ml:576-580`)을 우회 → `cross_model_rate`(`eval_calibration.ml:375-381`, gen≠ev일 때만 증가)가 **기본 0**. `--record-verdicts`가 생산하려는 헤드라인 지표가 침묵 사망. 머지본 305-311줄 주석("judge runs a separate evaluator runtime")도 거짓이며, 라이브러리 스스로 `anti_rationalization.ml:754-761`에서 "cross-model separation not active" 경고를 낸다.

근본 수정:
- `evaluator_runtime`을 `string option`으로 3함수(`run_scenario`/`run_one`/`record_self_owned_verdict`)에 전파, `AR.review ?evaluator_runtime`로 호출 → None이면 라이브러리 cross_verifier 기본값 발화(의도된 cross-model separation 복원).

## 변경 파일

- `lib/eval_calibration.ml(.mli)`: 순수 helper `resolve_record_verdicts_store` + `base_path` 노출.
- `bin/masc_completion_trust_eval.ml`: `--verdict-store-dir` flag, fail-fast 검증, evaluator_runtime 옵션 전파, 거짓 주석/help 정정.
- `test/test_eval_calibration.ml`: store 격리 가드 4 케이스(not-recording / requires-dir / rejects-live / accepts-isolated).

## 검증

- `dune build --root .` (worktree 격리 빌드).
- `test_eval_calibration` (`record_verdicts_store` 그룹 4 케이스 포함).
- 결함 B의 행동 증명(`cross_model_rate` > 0)은 라이브 judge runtime이 필요 = manual.

## 워크어라운드 self-check

두 수정 모두 **permissive default를 제거하고 명시적 에러/옵션 전파로 대체** = 워크어라운드의 반대(근본 수정). 텔레메트리-as-fix / string-classifier / N-of-M / cap-cooldown-dedup-repair 시그니처 해당 없음.

## RFC

RFC-0262 §9 (proving metric: zero foreign-task completions). 설계 계약: `docs/design/completion-trust-calibration-wiring.md` D3 (verdict store 격리 의무) — 본 PR이 그 미구현 계약을 강제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
