### PR TITLE
fix(dashboard): keep v2 dark tokens out of styleseed

### DIFF
--- a/dashboard/src/styles/styleseed-theme.test.ts
+++ b/dashboard/src/styles/styleseed-theme.test.ts
@@ -5,6 +5,8 @@ import { resolve } from 'node:path'
 
 const cssPath = resolve(__dirname, 'styleseed-theme.css')
 const css = readFileSync(cssPath, 'utf-8')
+const v2ThemeCss = readFileSync(resolve(__dirname, 'v2-theme.css'), 'utf-8')
+const v2SkinTokensCss = readFileSync(resolve(__dirname, 'v2-skin-tokens.css'), 'utf-8')
 
 /**
  * Parse a CSS block for a given selector and return its declared custom
@@ -114,5 +116,19 @@ describe('styleseed-theme.css', () => {
     const darkPage = dark['--surface-page'] ?? ''
     const hexValue = (hex: string) => parseInt(hex.replace('#', ''), 16)
     expect(hexValue(darkCard)).toBeGreaterThan(hexValue(darkPage))
+  })
+
+  it('keeps later-loading dark v2 token sources out of StyleSeed', () => {
+    expect(v2ThemeCss).toContain(':root:not([data-theme="paper"]):not([data-theme="styleseed"])')
+    expect(v2ThemeCss).toContain('[data-theme="dark-fantasy"]')
+    expect(v2SkinTokensCss).toContain(
+      '[data-skin="v2"]:not([data-theme="paper"]):not([data-theme="styleseed"])'
+    )
+    expect(v2SkinTokensCss).toContain(
+      '[data-skin="v2"][data-volt="blood"]:not([data-theme="paper"]):not([data-theme="styleseed"])'
+    )
+    expect(v2SkinTokensCss).toContain(
+      '[data-skin="v2"][data-volt="ice"]:not([data-theme="paper"]):not([data-theme="styleseed"])'
+    )
   })
 })

--- a/dashboard/src/styles/v2-skin-tokens.css
+++ b/dashboard/src/styles/v2-skin-tokens.css
@@ -1,8 +1,9 @@
 /* ══════════════════════════════════════════════════════════════
    MASC v2 — High-contrast skin tokens
-   Loaded AFTER colors_and_type.css / global.css.
+   Loaded AFTER colors_and_type.css / global.css. The dark v2 token blocks
+   must yield to opt-in light themes; skin-v2.css carries the same guard.
    ══════════════════════════════════════════════════════════════ */
-[data-skin="v2"] {
+[data-skin="v2"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
   /* Surfaces — cool neutral charcoal, clean elevation steps */
   --bg-deep:        #08090d;
   --bg-panel:       #0f1015;
@@ -96,11 +97,11 @@
   --fs-t4: 9px;  --fw-t4: 600; --tr-t4: 0.2em;     /* dim · UPPER */
 }
 
-[data-skin="v2"][data-volt="blood"] {
+[data-skin="v2"][data-volt="blood"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
   --volt: var(--accent-blood); --volt-strong: #ff6a4d; --volt-dim: var(--accent-blood-dim);
   --volt-ink: #ffffff; --volt-glow: rgba(232,71,47,0.26); --volt-wash: rgba(232,71,47,0.10);
 }
-[data-skin="v2"][data-volt="ice"] {
+[data-skin="v2"][data-volt="ice"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
   --volt: var(--accent-ice); --volt-strong: #7ad8f6; --volt-dim: var(--accent-ice-dim);
   --volt-ink: #04121a; --volt-glow: rgba(70,198,240,0.24); --volt-wash: rgba(70,198,240,0.09);
   /* primary is now cyan → shift the info accent to violet to stay distinct */
@@ -110,4 +111,3 @@
 /* Ensure the skinned root/html/body fill the viewport. */
 [data-skin="v2"],
 [data-skin="v2"] body { height: 100%; }
-

--- a/dashboard/src/styles/v2-theme.css
+++ b/dashboard/src/styles/v2-theme.css
@@ -5,7 +5,7 @@
  * the LAST-loading theme layer (global.css), so its base values below are the
  * effective surface/text/accent palette for the whole dashboard; everything
  * else (--color-bg-page, --fg-*, soft/alpha slots, component tokens) derives
- * from them via var(). Paper theme remains opt-in via data-theme="paper".
+ * from them via var(). Paper and StyleSeed remain opt-in via data-theme.
  *
  * Palette: _ds Dark Fantasy (visceral / decay-forward) — wet stone, blood-
  * soaked wood, bone & bandage text. Status keeps the muted bile/ember/blood
@@ -14,7 +14,7 @@
  * Source: _ds .../colors_and_type.css + ui_kits/dashboard/styles/base.css
  */
 
-:root,
+:root:not([data-theme="paper"]):not([data-theme="styleseed"]),
 [data-theme="dark-fantasy"] {
   /* Dark-fantasy dashboard surfaces — 5-step warm-dark ramp */
   --bg-ink:        #0a0706;   /* page — pitch with a red undertone */


### PR DESCRIPTION
## Summary

- Guard later-loading dark v2 token sources so they do not override opt-in `styleseed` and `paper` themes.
- Keep `v2-theme.css` default dark tokens active for the no-theme default and explicit `dark-fantasy`.
- Add a StyleSeed regression guard that checks the dark token selectors keep the light-theme exclusions.

## Verification

- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/styles/styleseed-theme.test.ts src/styles/paper-theme.test.ts src/styles/app-shell-v2-overlay-stacking.test.ts`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vite build`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty false`
- Playwright desktop check: `http://127.0.0.1:5179/dashboard/`, `?theme=styleseed`, `?theme=paper`
- Playwright mobile check: 390x844 `?theme=styleseed`, `?theme=paper`

## Notes

- The local repro was `?theme=styleseed`: page/rail switched light, but content cards stayed dark because `v2-theme.css` and `v2-skin-tokens.css` re-applied dark `--bg-card` / text tokens after the StyleSeed theme files.
