### PR TITLE
fix(dashboard): keep Tailwind layer order; drop `utilities` from app-shell-v2 @layer (#21846 regression)

### DIFF
--- a/dashboard/src/styles/app-shell-v2-overlay-stacking.test.ts
+++ b/dashboard/src/styles/app-shell-v2-overlay-stacking.test.ts
@@ -94,11 +94,22 @@ describe('app-shell-v2.css `.v2-app > *` stacking rule', () => {
     }
   })
 
-  it('declares app-shell before utilities so Tailwind positioning wins', () => {
+  it('declares app-shell first and never redeclares a Tailwind-owned layer', () => {
+    // This top-level @layer statement is hoisted above Tailwind's own
+    // `@layer theme, base, components, utilities` in the built stylesheet, so
+    // it is what pins each named layer's order. Naming a Tailwind-owned layer
+    // here fixes that layer's slot and pushes the REST of Tailwind's layers
+    // behind it: naming `utilities` forced base/components above utilities, so
+    // Preflight (base) beat every utility class (#21846 regression). A
+    // single-file source check is the only place that catches it — the built
+    // cascade is invisible to happy-dom. app-shell must come first (lowest
+    // priority) so `.v2-app > *` ranks below Tailwind's `.fixed`/`.absolute`.
     const order = topLevelLayerOrder()
-    expect(order).toContain('app-shell')
-    expect(order).toContain('utilities')
-    expect(order.indexOf('app-shell')).toBeLessThan(order.indexOf('utilities'))
+    expect(order[0]).toBe('app-shell')
+    const tailwindOwned = ['theme', 'base', 'components', 'utilities']
+    for (const owned of tailwindOwned) {
+      expect(order).not.toContain(owned)
+    }
   })
 
   it('does not bake overlay class exclusions into the shell child selector', () => {

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -14,7 +14,19 @@
    Defined at :root so v2-shell.css and shell components can share them.
    ═══════════════════════════════════════════════════════════════ */
 
-@layer app-shell, theme-defaults, theme-overrides, utilities;
+/* Declare ONLY app-shell's own layers here — never a Tailwind-owned layer
+   (theme / base / components / utilities). The bundler hoists this statement
+   to the top of the built stylesheet, so it is what fixes each named layer's
+   position. Naming `utilities` here pinned it at index 3, which forced
+   Tailwind's own `theme, base, components, utilities` to emit AFTER it —
+   leaving base/components ABOVE utilities. Preflight (base) then beat every
+   utility class: list-style, h1 font-size, and margins all reset to their
+   element defaults (the #21846 cascade-layer regression).
+   app-shell stays first (lowest priority) so `.v2-app > *` (app-shell layer,
+   below) ranks under Tailwind's `.fixed`/`.absolute` (utilities) and overlays
+   keep position:fixed. theme-defaults/theme-overrides only carry :root token
+   values, so their position relative to Tailwind's layers is immaterial. */
+@layer app-shell, theme-defaults, theme-overrides;
 
 @layer theme-defaults {
   :root {

--- a/dashboard/src/styles/paper-theme.test.ts
+++ b/dashboard/src/styles/paper-theme.test.ts
@@ -11,7 +11,10 @@ const appShellCss = readFileSync(appShellCssPath, 'utf-8')
 
 describe('paper-theme.css', () => {
   it('uses cascade layers rather than selector specificity to override v2 defaults', () => {
-    expect(appShellCss).toContain('@layer app-shell, theme-defaults, theme-overrides, utilities;')
+    // Must NOT name a Tailwind-owned layer (utilities/base/components/theme);
+    // doing so reorders Tailwind's layers at build time. See #21846 regression
+    // guard in app-shell-v2-overlay-stacking.test.ts.
+    expect(appShellCss).toContain('@layer app-shell, theme-defaults, theme-overrides;')
     expect(paperCss).toContain('[data-theme="paper"] {')
     expect(paperCss).not.toContain('html[data-theme="paper"] {')
   })


### PR DESCRIPTION
## 문제

dashboard 전체 CSS가 dev(`localhost:5173`/`5174`)에서 붕괴 — Tailwind 유틸리티 클래스 전반이 무력화됩니다. `list-style`, `h1` font-size, margin 등이 요소 기본값으로 리셋되어 화면이 unstyled 상태로 렌더됩니다. 라이브(`:8935`)는 아직 `#21846` 이전 빌드를 서빙 중이라 정상이지만, 이 회귀가 배포되면 라이브도 동일하게 깨집니다.

## 원인

`#21846`이 토스트 오버레이 위치를 고치려고 `app-shell-v2.css`의 top-level `@layer` 선언에 `utilities`를 추가했습니다:

```css
@layer app-shell, theme-defaults, theme-overrides, utilities;
```

이 statement는 빌드 시 스타일시트 최상단으로 hoisting되어 각 layer의 위치를 확정합니다. `utilities`를 여기서 명명하면 그것이 index 3에 고정되고, Tailwind 자체의 `@layer theme, base, components, utilities`가 그 **뒤**로 emit됩니다. 결과적으로 `base`/`components`가 `utilities`보다 위(더 높은 우선순위)에 놓여, Preflight(`base`)가 모든 유틸리티 클래스를 이깁니다.

빌드 CSS layer 순서 (회귀 상태, dev 측정값):

```
app-shell(0) < theme-defaults < theme-overrides < utilities(3) < theme < base < components
```

cascade layer는 specificity보다 우선하므로, `ul{list-style:none}`(base)이 `.list-disc{list-style:disc}`(utilities)를 이기는 식으로 유틸이 전부 무력화됩니다. 측정값: `.list-disc → list-style:none`, `h1.text-sm → font-size:16px`.

## 수정

layer 선언에서 `utilities`를 제거해 Tailwind만 `utilities`를 소유하게 합니다:

```css
@layer app-shell, theme-defaults, theme-overrides;
```

빌드 CSS layer 순서 (수정 후, 빌드 파싱 검증값):

```
app-shell(0) < theme-defaults < theme-overrides < theme < base(5) < components(6) < utilities(7)
```

- `base(5) < utilities(7)`, `components(6) < utilities(7)` → **유틸리티 우선순위 복원**
- `app-shell`은 여전히 맨 앞(index 0) → `.v2-app > *`가 `.fixed`(utilities)보다 낮음 → **`#21846`의 오버레이 stacking fix가 그대로 유지**

회귀 해소와 오버레이 fix 보존은 trade-off가 아니라 한 수(`utilities` 제거)로 동시에 만족됩니다.

## 가드 테스트 강화

기존 `app-shell-v2-overlay-stacking.test.ts`는 `app-shell-v2.css` **단일 파일**만 파싱해 `app-shell < utilities`만 단언했고, Tailwind import를 못 봐서 "`utilities` 선언이 빌드 cascade를 재정렬한다"는 교차 파일 효과를 놓쳤습니다. 이게 회귀를 통과시킨 harness 결함입니다.

- `app-shell-v2-overlay-stacking.test.ts`: `app-shell`이 첫 번째이고 Tailwind 소유 layer(`theme`/`base`/`components`/`utilities`)를 재선언하지 않음을 단언 — 누가 다시 `utilities`를 넣으면 fail.
- `paper-theme.test.ts`: 박혀 있던 `utilities` 포함 문자열을 새 선언으로 갱신.

## 검증

- ✅ 가드 테스트 8개 통과 (강화 단언 포함)
- ✅ `tsc --noEmit` clean, `eslint` clean
- ✅ `vite build` 후 빌드 CSS의 canonical `@layer` 순서 파싱: `base`/`components < utilities` 확인

RFC-WAIVED: dashboard CSS cascade-layer 회귀 수정. credential/identity/operator-control/keeper-sandbox/dashboard-credential/hooks/workflow 등 RFC 게이트 subsystem에 해당하지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
