### PR TITLE
fix(dashboard): #21846이 역전시킨 Tailwind cascade layer 순서 복원

### DIFF
--- a/dashboard/src/styles/app-shell-v2-overlay-stacking.test.ts
+++ b/dashboard/src/styles/app-shell-v2-overlay-stacking.test.ts
@@ -1,19 +1,33 @@
 // @vitest-environment happy-dom
 //
-// Regression guard for the `.v2-app > *` stacking rule (app-shell-v2.css).
+// Regression guard for the cascade-layer ORDER that governs app-shell-v2.css.
 //
-// Tailwind v4's `.fixed` / `.absolute` / `.top-5` / `.right-5` utilities are
-// emitted inside `@layer utilities`. A bare unlayered `.v2-app > * { position:
-// relative }` silently overrides the layered `.fixed` of any direct-child
-// overlay, dropping it into normal flow. That is exactly what pushed the toast
-// host off-screen to the bottom of the `h-screen; overflow-hidden` shell column.
+// Two failure modes this file locks down, both seen in production:
 //
-// happy-dom resolves no cascade/layout, so this defect is invisible to a normal
-// component test. This guard asserts the SOURCE rule stays in a lower cascade
-// layer than Tailwind utilities, locking the fix against a future unlayered
-// revert or overlay-class allowlist.
+//  1. Overlay stacking: Tailwind v4's `.fixed` / `.absolute` / `.top-5` utilities
+//     live in `@layer utilities`. The `.v2-app > * { position: relative }` rule
+//     must sit in a layer BELOW utilities (it is in `@layer app-shell`) so it does
+//     not force positioned overlays (toast, modals) back into normal flow.
+//
+//  2. Cascade inversion (#21846): the canonical layer order is declared by a bare
+//     `@layer …;` statement at the top of app-shell-v2.css. Because Tailwind v4
+//     emits theme/base/components/utilities as cascade-layer BLOCKS (no leading
+//     order statement of its own) which the Vite plugin injects AFTER the imported
+//     stylesheets, whichever bare `@layer …;` statement is emitted first decides
+//     precedence. #21846 used `@layer app-shell, theme-defaults, theme-overrides,
+//     utilities;` — it pinned `utilities` before Tailwind's later base/components
+//     blocks, so those blocks appended AFTER utilities and BEAT every utility class
+//     (Preflight reset + components clobbered all of Tailwind). The statement must
+//     name base AND components BEFORE utilities to preserve Tailwind's internal
+//     `theme < base < components < utilities` order.
+//
+// happy-dom resolves no cascade/layout, so neither defect is visible to a DOM test.
+// These checks parse the SOURCE statement; they are a sound proxy for the merged
+// build order because (a) app-shell-v2.css is the SOLE source file declaring a
+// utilities-naming bare `@layer` statement (asserted below) and (b) Tailwind's own
+// blocks are emitted after it. The authoritative check remains `vite build` output.
 import { describe, expect, it } from 'vitest'
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { parse } from 'postcss'
 
@@ -65,16 +79,20 @@ function v2AppChildRules(): ChildRule[] {
   return rules
 }
 
-function topLevelLayerOrder(): string[] {
-  const order: string[] = []
-  parse(css).walkAtRules('layer', (rule) => {
+/** Names declared by each root-level bare `@layer a, b, c;` statement in [src]
+ *  (block form `@layer x { … }` is excluded — only ordering statements). */
+function bareLayerStatements(src: string): string[][] {
+  const statements: string[][] = []
+  parse(src).walkAtRules('layer', (rule) => {
     if (rule.parent?.type !== 'root') return
-    if (rule.nodes !== undefined) return
-    for (const name of rule.params.split(',')) {
-      order.push(name.trim())
-    }
+    if (rule.nodes !== undefined) return // block form, not an ordering statement
+    statements.push(rule.params.split(',').map((name) => name.trim()))
   })
-  return order
+  return statements
+}
+
+function topLevelLayerOrder(): string[] {
+  return bareLayerStatements(css).flat()
 }
 
 describe('app-shell-v2.css `.v2-app > *` stacking rule', () => {
@@ -94,11 +112,41 @@ describe('app-shell-v2.css `.v2-app > *` stacking rule', () => {
     }
   })
 
-  it('declares app-shell before utilities so Tailwind positioning wins', () => {
+  it('orders app-shell + Tailwind base/components before utilities, theming after', () => {
     const order = topLevelLayerOrder()
-    expect(order).toContain('app-shell')
-    expect(order).toContain('utilities')
-    expect(order.indexOf('app-shell')).toBeLessThan(order.indexOf('utilities'))
+    const idx = (name: string): number => {
+      const i = order.indexOf(name)
+      expect(i, `layer "${name}" must be named in the order statement`).toBeGreaterThanOrEqual(0)
+      return i
+    }
+    const utilities = idx('utilities')
+    // app-shell below utilities → positioned overlay utilities (.fixed) win (toast fix).
+    expect(idx('app-shell')).toBeLessThan(utilities)
+    // Tailwind's own layers must stay below utilities so utility classes override
+    // Preflight/base/components. #21846 pinned utilities ahead of base/components and
+    // inverted this, letting the Preflight reset clobber every utility class.
+    expect(idx('theme')).toBeLessThan(utilities)
+    expect(idx('base')).toBeLessThan(utilities)
+    expect(idx('components')).toBeLessThan(utilities)
+    // Theming layers above utilities so [data-theme="paper"] overrides win.
+    expect(idx('theme-defaults')).toBeGreaterThan(utilities)
+    expect(idx('theme-overrides')).toBeGreaterThan(utilities)
+  })
+
+  it('is the only source stylesheet that pins the utilities layer order', () => {
+    // The merged cascade order is set by the first bare `@layer …;` statement emitted
+    // before Tailwind's blocks. If another source file also declared a utilities-naming
+    // bare statement it could be emitted first and re-invert the cascade. Keep
+    // app-shell-v2.css the single authority so the checks above stay a sound proxy.
+    const dir = __dirname
+    const offenders = readdirSync(dir)
+      .filter((file) => file.endsWith('.css') && file !== 'app-shell-v2.css')
+      .filter((file) =>
+        bareLayerStatements(readFileSync(resolve(dir, file), 'utf-8')).some((names) =>
+          names.includes('utilities'),
+        ),
+      )
+    expect(offenders).toEqual([])
   })
 
   it('does not bake overlay class exclusions into the shell child selector', () => {

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -14,7 +14,24 @@
    Defined at :root so v2-shell.css and shell components can share them.
    ═══════════════════════════════════════════════════════════════ */
 
-@layer app-shell, theme-defaults, theme-overrides, utilities;
+/* ── Cascade layer order (SSOT) ──────────────────────────────────
+   This statement is the single source of truth for cascade-layer precedence.
+   It lives here (not in global.css) because the Tailwind v4 Vite plugin drops
+   bare `@layer` statements from the entry stylesheet, whereas a regular imported
+   file's statement survives bundling and is emitted near the top — ahead of the
+   Tailwind layer blocks (theme/base/components/utilities) that the plugin
+   injects later. So this statement is processed first and fixes the order.
+
+   The order must keep Tailwind's internal `theme < base < components <
+   utilities` so utility classes override Preflight/base/components. `app-shell`
+   sits below utilities so positioned overlay utilities (.fixed/.absolute) win;
+   `theme-defaults`/`theme-overrides` sit above utilities so theming overrides
+   win. Naming Tailwind's layers explicitly here pins them BEFORE utilities;
+   omitting them (or naming only utilities, as #21846 did) lets Tailwind's
+   later-emitted base/components blocks append AFTER utilities and invert the
+   cascade, clobbering every utility class. Do not name only a subset that
+   includes utilities. */
+@layer app-shell, theme, base, components, utilities, theme-defaults, theme-overrides;
 
 @layer theme-defaults {
   :root {

--- a/dashboard/src/styles/paper-theme.test.ts
+++ b/dashboard/src/styles/paper-theme.test.ts
@@ -11,7 +11,9 @@ const appShellCss = readFileSync(appShellCssPath, 'utf-8')
 
 describe('paper-theme.css', () => {
   it('uses cascade layers rather than selector specificity to override v2 defaults', () => {
-    expect(appShellCss).toContain('@layer app-shell, theme-defaults, theme-overrides, utilities;')
+    expect(appShellCss).toContain(
+      '@layer app-shell, theme, base, components, utilities, theme-defaults, theme-overrides;',
+    )
     expect(paperCss).toContain('[data-theme="paper"] {')
     expect(paperCss).not.toContain('html[data-theme="paper"] {')
   })


### PR DESCRIPTION
## 증상

대시보드 CSS가 전반적으로 깨져 보입니다(여백/정렬/색 등 Tailwind 유틸리티가 먹지 않음). 사용자 보고: "css 가 다 망가졌음".

## 근본 원인 (실측)

PR #21846(`850e1f1876`)이 오프스크린 오버레이(toast/모달)를 고치려고 `app-shell-v2.css`에 다음 bare 문장을 추가했습니다.

```css
@layer app-shell, theme-defaults, theme-overrides, utilities;
```

Tailwind v4는 `theme`/`base`/`components`/`utilities`를 **자체 순서 문장 없이 cascade-layer 블록으로** emit하고, Vite 플러그인이 그 블록을 import된 스타일시트 **뒤에** 주입합니다. 그래서 번들에서 **먼저 처리되는 bare `@layer` 문장이 순서를 결정**합니다.

위 문장은 일반 import 파일(app-shell-v2.css)에 있어 번들 맨 앞(offset 669)에서 처리되며 `utilities`를 일찍 고정합니다. 이후 등장한 Tailwind의 `base`/`components` 블록은 "새 이름"으로 `utilities` **뒤에** append되어 **cascade가 역전**됩니다.

`vite build` 출력으로 확인한 깨진 순서:

```
app-shell < theme-defaults < theme-overrides < utilities < properties < theme < base < components
```

→ `base`(Preflight 리셋)·`components`가 `utilities`보다 높은 우선순위 → 모든 유틸리티 클래스가 리셋/컴포넌트 스타일에 덮여 화면 전체가 붕괴합니다.

#21846에 동봉된 회귀 테스트는 `app-shell-v2.css`를 **단독 파싱**해 "app-shell이 utilities 앞"만 검사 → 병합 순서를 못 봐 **false-green**으로 통과했습니다.

## 수정

순서 문장에 Tailwind의 `theme`/`base`/`components`를 `utilities` **앞에 명시**해 Tailwind 내부 순서(`theme < base < components < utilities`)를 보존합니다.

```css
@layer app-shell, theme, base, components, utilities, theme-defaults, theme-overrides;
```

- `app-shell`은 `utilities` 아래 → 오버레이 유틸리티(`.fixed`/`.absolute`)가 이김 (#21846의 toast fix 유지).
- `theme`/`base`/`components`는 `utilities` 아래 → 유틸리티 클래스가 Preflight/base/components를 덮음 (정상 복원).
- `theme-defaults`/`theme-overrides`는 `utilities` 위 → `[data-theme="paper"]` 테마 override 유효.

순서 선언을 `global.css`가 아니라 `app-shell-v2.css`에 두는 이유: Tailwind v4 Vite 플러그인은 **entry 스타일시트의 bare `@layer` 문장을 드롭**하지만(실측: `@import` 전/후 모두 드롭됨), 일반 import 파일의 문장은 살아남아 번들 앞에서 순서를 통제합니다. 파일 상단 주석에 메커니즘을 기록했습니다.

## 검증

- `vite build` 산출물의 emitted `@layer` 순서가 정상 복원됨을 실측:
  `app-shell < theme < base < components < utilities < theme-defaults < theme-overrides`
- 회귀 테스트 강화 (병합-순서 불변식): `base`/`components`가 `utilities` **앞**임을 단언. 이전 테스트는 `app-shell < utilities`만 봤습니다.
- 다른 source 스타일시트가 `utilities`를 명명하는 bare `@layer` 문장을 두지 않음을 단언(cross-file guard) → app-shell-v2.css가 순서의 단일 권위로 유지.
- **bug-model 검증**: 깨진 문장으로 되돌리면 강화 테스트가 `"layer theme must be named in the order statement"`로 FAIL, 올바른 문장에서 PASS (clean 42/42, buggy 2 fail).
- `dashboard` 로컬: `vitest run src/styles` 42 passed, `tsc --noEmit` exit 0.

## 변경 파일

- `dashboard/src/styles/app-shell-v2.css` — 순서 문장 교정 + 메커니즘 주석.
- `dashboard/src/styles/app-shell-v2-overlay-stacking.test.ts` — 병합-순서 불변식 + cross-file guard로 강화.
- `dashboard/src/styles/paper-theme.test.ts` — 순서 문장 문자열 단언 갱신.

## 알려진 사항 (이 PR 범위 밖)

`scripts/dashboard-drift-check.sh`의 `text-px-literal` 게이트가 main에서 이미 실패 중입니다(`66 > baseline 12`). 이 PR과 무관한 pre-existing 상태이며(이 PR은 `text-[Npx]` 리터럴을 0개 추가), main 체크아웃에서 동일하게 재현됩니다. 별도로 추적이 필요합니다.

## 워크어라운드 self-check

- 텔레메트리-as-fix 아님(가시화가 아니라 cascade 순서를 실제 교정).
- string/substring 분류기 추가 없음.
- N-of-M 아님(단일 SSOT 문장으로 전체 순서를 한 번에 통제).
- cap/cooldown/dedup/repair 없음, catch-all 추가 없음.
- false-green 테스트를 병합-순서 불변식으로 교체(증상 억제가 아니라 회귀 오라클 강화).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
