### PR TITLE
feat(dashboard): resurrect keeper-v2 TopBar status chips + keeper breadcrumb

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -4,6 +4,7 @@ import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
 import { App, shouldSuppressFloatingChrome, shouldUseCompactDashboardChrome } from './app'
 import { route } from './router'
+import { selectedKeeper } from './components/keeper-detail-state'
 
 describe('App v2 header chrome', () => {
   let container: HTMLDivElement
@@ -14,6 +15,7 @@ describe('App v2 header chrome', () => {
     document.body.appendChild(container)
     window.location.hash = originalHash
     route.value = { tab: 'overview', params: {}, postId: null }
+    selectedKeeper.value = null
   })
 
   afterEach(() => {
@@ -21,6 +23,7 @@ describe('App v2 header chrome', () => {
     container.remove()
     window.location.hash = originalHash
     route.value = { tab: 'overview', params: {}, postId: null }
+    selectedKeeper.value = null
   })
 
   function renderApp() {
@@ -63,6 +66,76 @@ describe('App v2 header chrome', () => {
     expect(container.querySelector('.v2-shell-tabs')).toBeNull()
     expect(container.querySelector('.v2-app-header-status')).not.toBeNull()
     expect(container.querySelector('.v2-statchip.live')).not.toBeNull()
+  })
+
+  it('un-hides the header status chips on desktop (Unit 2 TopBar resurrection)', () => {
+    renderApp()
+    const status = container.querySelector('.v2-app-header-status')
+    expect(status).not.toBeNull()
+    // The wrapper was previously `hidden` with no un-hiding rule → display:none at
+    // all widths. It must now be `flex` (visible desktop, max-[900px]:hidden mobile).
+    expect(status?.classList.contains('hidden')).toBe(false)
+    expect(status?.classList.contains('flex')).toBe(true)
+    // Hidden ≤900px via the canonical desktop-only mechanism (single breakpoint SSOT,
+    // app-shell-v2.css @media (max-width:900px) .v2-desktop-header-only), matching the
+    // other desktop-only header items rather than a one-off Tailwind variant.
+    expect(status?.classList.contains('v2-desktop-header-only')).toBe(true)
+  })
+
+  it('pulses the live dot and renders Korean topbar copy', () => {
+    renderApp()
+    const live = container.querySelector('.v2-statchip.live')
+    expect(live).not.toBeNull()
+    // Live dot uses the LivePulseDot convention (animate-pulse) instead of a static dot.
+    expect(live?.querySelector('span.animate-pulse')).not.toBeNull()
+    expect(live?.textContent).toContain('실행 중')
+    expect(live?.textContent).not.toContain('running')
+    const sched = Array.from(container.querySelectorAll('.v2-app-header-status .v2-statchip'))
+      .find(el => !el.classList.contains('live'))
+    expect(sched?.textContent).toContain('스케줄러')
+    expect(sched?.textContent).not.toContain('scheduler')
+  })
+
+  it('appends the selected keeper to the breadcrumb on the keepers surface', () => {
+    route.value = { tab: 'keepers', params: { keeper: 'miso' }, postId: null }
+    renderApp()
+    const crumb = container.querySelector('.v2-header-crumb')
+    expect(crumb).not.toBeNull()
+    expect(crumb?.textContent).toContain('miso')
+  })
+
+  it('omits the keeper breadcrumb segment off the keepers surface', () => {
+    route.value = { tab: 'overview', params: { keeper: 'miso' }, postId: null }
+    renderApp()
+    const crumb = container.querySelector('.v2-header-crumb')
+    expect(crumb?.textContent).not.toContain('miso')
+  })
+
+  it('renders no keeper segment on keepers with no selection (no dangling slash)', () => {
+    // keepers is sectionless → with no keeper the crumb is exactly one span (the label),
+    // i.e. no trailing '/' and no empty keeper segment.
+    route.value = { tab: 'keepers', params: {}, postId: null }
+    renderApp()
+    const crumb = container.querySelector('.v2-header-crumb')
+    expect(crumb?.querySelectorAll('span').length).toBe(1)
+    expect(crumb?.textContent?.trim().endsWith('/')).toBe(false)
+  })
+
+  it('drops a whitespace-only keeper param from the breadcrumb', () => {
+    route.value = { tab: 'keepers', params: { keeper: '   ' }, postId: null }
+    renderApp()
+    const crumb = container.querySelector('.v2-header-crumb')
+    expect(crumb?.querySelectorAll('span').length).toBe(1)
+  })
+
+  it('falls back to the selected keeper when the route has no keeper param', () => {
+    // Mirrors keeper-detail-page resolution tier 2 (selectedKeeper) so the breadcrumb
+    // tracks the keeper the chat shows even when reached without a route param.
+    route.value = { tab: 'keepers', params: {}, postId: null }
+    selectedKeeper.value = { name: 'grimja' } as NonNullable<typeof selectedKeeper.value>
+    renderApp()
+    const crumb = container.querySelector('.v2-header-crumb')
+    expect(crumb?.textContent).toContain('grimja')
   })
 
   it('renders the main stage as a StyleSeed card (white, rounded-2xl, soft shadow)', () => {

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -35,6 +35,7 @@ import { TransportBeacon } from './components/transport-beacon'
 import { DashboardNavRail } from './components/mobile-nav'
 import { SkipLink } from './components/skip-link'
 import { selectedAgentName } from './components/agent-detail-selection'
+import { selectedKeeper } from './components/keeper-detail-state'
 import { selectedTask } from './components/goals/task-detail-selection'
 import { ToastContainer } from './components/common/toast'
 import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
@@ -268,6 +269,17 @@ export function App() {
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
+  // Breadcrumb trail for the keepers surface ends at the selected keeper, mirroring
+  // the design's `Keepers / {keeper.id}` crumb. Tracks the keeper the chat actually shows
+  // by following keeper-detail-page.ts's resolution: route param first (roster writes
+  // navigate('keepers', { keeper: name })), then the explicit `selectedKeeper` selection.
+  // The detail page's final `keepers.value[0]` fallback is intentionally NOT mirrored here:
+  // subscribing the root App to the high-frequency `keepers` list would re-render the whole
+  // tree on every heartbeat (the same P0 perf reason keeper-detail-page isolates that
+  // subscription). With no param and no selection the tail is omitted (honest under-display).
+  const crumbKeeper = currentTab === 'keepers'
+    ? (route.value.params.keeper?.trim() || selectedKeeper.value?.name || '')
+    : ''
   const isCodeSurface = currentTab === 'code'
   const widgetSoloMode = isWidgetSoloRoute(route.value)
   const keeperDetailMode = isKeeperDetailDashboardRoute(route.value)
@@ -325,6 +337,12 @@ export function App() {
                           <span class="truncate">${currentSection.label}</span>
                         `
                       : null}
+                    ${crumbKeeper
+                      ? html`
+                          <span class="text-[var(--color-warn)]">/</span>
+                          <span class="truncate">${crumbKeeper}</span>
+                        `
+                      : null}
                   </div>
                   <h1 class="v2-header-title mt-1 min-w-0 truncate font-display text-xs font-semibold leading-tight tracking-normal text-[var(--color-fg-secondary)]">
                     ${currentSection?.label ?? currentView?.label ?? 'Multi-Agent Namespace Console'}
@@ -336,13 +354,13 @@ export function App() {
           </div>
 
           <div class="v2-header-actions flex shrink-0 flex-wrap items-center justify-end gap-2 max-[1080px]:justify-between">
-            <div class="v2-app-header-status hidden items-center gap-2 max-[900px]:hidden" aria-label="Dashboard summary">
-              <span class="v2-statchip live" title="Live keepers reported by the shell snapshot">
-                <span class="inline-block size-2 rounded-full bg-[var(--color-status-ok)] shadow-[0_0_7px_rgb(var(--ok-glow)/0.75)]"></span>
-                ${shellCounts.value?.keepers ?? 0} running
+            <div class="v2-app-header-status v2-desktop-header-only flex items-center gap-2" aria-label="대시보드 요약">
+              <span class="v2-statchip live" title="셸 스냅샷 기준 실행 중 keeper 수">
+                <span class="inline-block size-2 animate-pulse rounded-full bg-[var(--color-status-ok)] shadow-[0_0_7px_rgb(var(--ok-glow)/0.75)]"></span>
+                ${shellCounts.value?.keepers ?? 0} 실행 중
               </span>
-              <span class="v2-statchip" title="Scheduler health inferred from server status">
-                scheduler <b>${serverStatus.value ? 'healthy' : '—'}</b>
+              <span class="v2-statchip" title="서버 상태로 추정한 스케줄러 상태">
+                스케줄러 <b>${serverStatus.value ? '정상' : '—'}</b>
               </span>
             </div>
             <${AttentionIndicator} />


### PR DESCRIPTION
## 무엇을 / 왜

keeper-v2 디자인의 **Keeper Agent** 표면 TopBar를 되살립니다 (keeper-v2 포팅 라인 Unit 2 — "TopBar resurrection"). 디자인 SSOT: claude.ai/design `keeper-v2/shell.jsx`의 `TopBar`.

`.v2-app-header-status`(실행 중 keeper 칩 + 스케줄러 칩)는 Tailwind `hidden`이 걸려 있고 이를 되돌리는 CSS 규칙이 없어 **모든 폭에서 `display:none`** 상태였습니다(죽은 칩). 갭 분석(`GAP-keeper-agent-2026-06-20.md`)의 Unit 2 항목입니다. 칩 스킨(`.v2-statchip` / `.live`)은 이미 `app-shell-v2.css`에 존재하므로 wrapper만 되살리면 디자인대로 렌더됩니다.

## 변경 (`dashboard/src/app.ts`)

1. **칩 un-hide**: wrapper를 `hidden` → `v2-desktop-header-only flex`로 교체. 다른 desktop-only 헤더 항목(TransportBeacon/ThemeSwitch 등)과 **동일한 단일 900px 브레이크포인트 SSOT**를 공유 — 일회성 Tailwind variant 대신 컨벤션 사용. 모두 기존 메커니즘이라 #21846 cascade-layer 회귀 위험 없음.
2. **live 도트 펄스**: 정적 도트에 `animate-pulse` 추가 (`common/live-pulse-dot.ts`의 `DOT_TONE.live` 컨벤션 일치, `prefers-reduced-motion`에서 `a11y.css`가 자동 정지).
3. **한국어화**: `N running` → `N 실행 중`, `scheduler healthy/—` → `스케줄러 정상/—`, `aria-label` 한국어화. (스케줄러 칩은 서버 상태 프록시 — 로컬에 스케줄 데이터가 없어 디자인의 예약 큐 pending/due를 **날조하지 않음**.)
4. **breadcrumb `/keeper.id`**: keepers 표면에서 선택된 keeper를 crumb 마지막 세그먼트로 추가. `keeper-detail-page` resolution을 미러(`route.params.keeper` → `selectedKeeper`)해 채팅이 보여주는 keeper와 동기화. 마지막 `keepers[0]` fallback은 **의도적으로 제외**(root App을 고빈도 `keepers` 리스트에 구독시키면 매 heartbeat마다 전체 재렌더 — keeper-detail-page가 그 구독을 격리하는 P0 perf 이유와 동일). 무param·무선택 시 tail 생략(honest under-display).

## 검증

- `tsc --noEmit`: 0 errors · `eslint src`: clean
- `vitest src/app.test.ts`: **31 passed** (신규 7 — un-hide/펄스/한국어 copy/breadcrumb 유무·무선택·공백·selectedKeeper fallback)
- **적대적 3-렌즈 리뷰 통과**: cascade-CSS(실제 `vite build` emitted CSS로 wrapper 숨김 규칙 0건·레이어 순서·≤900px hidden 우선순위 검증) / 디자인 fidelity·날조 데이터 감사 / 회귀·엣지케이스. 리뷰의 MEDIUM(breadcrumb fidelity)·NIT(desktop-only 컨벤션)·테스트 갭 모두 반영.

## 범위 밖 (의도적)

- 디자인의 `예약(schedule)` 표면-내비 칩 — 로컬에 schedule 표면/승인 데이터 부재(갭 분석). 별도 surface initiative.
- Unit 4+ (verified 배지/copy/regenerate)는 후속 PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
