### PR TITLE
[codex] Fix keeper history media reroute

### DIFF
--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -125,35 +125,35 @@ let run_named
              (no silent fallback to default — RFC-0207/RFC-0206 §2.1)"
             runtime_id))
   | Some assigned_runtime ->
-  (* RFC-0265: proactively reroute a turn whose input modality (image/audio/
-     document) the assigned runtime cannot accept to a capable configured runtime
-     ([\[runtime\].media_failover] order, else declaration order). Text turns
-     ([goal_blocks = None]) and modality-satisfied turns are untouched; when no
-     runtime qualifies the assigned runtime stands and the loud capability gate in
-     [Runtime_agent.run_blocks] rejects (the floor). The reroute is visible via a
-     WARN log (non-silent — RFC-0126/0145). *)
+  (* RFC-0265: proactively reroute a turn whose active input modality
+     (image/audio/document) the assigned runtime cannot accept to a capable
+     configured runtime ([\[runtime\].media_failover] order, else declaration
+     order). The active input includes both the current goal and prior
+     [initial_messages]; otherwise an image in history can poison the next
+     text-only follow-up and leak as a provider 400. Modality-satisfied turns are
+     untouched; when no runtime qualifies the assigned runtime stands and the
+     loud capability gate in [Runtime_agent.run_blocks] rejects (the floor). The
+     reroute is visible via a WARN log (non-silent — RFC-0126/0145). *)
   let runtime_id, runtime =
-    match goal_blocks with
-    | None | Some [] -> runtime_id, assigned_runtime
-    | Some blocks ->
-      (match
-         Runtime_agent.decide_modality_reroute_for_runtime
-           ~assigned:assigned_runtime
-           blocks
-       with
-       | Runtime_agent.No_reroute_needed | Runtime_agent.No_capable_runtime _ ->
-         runtime_id, assigned_runtime
-       | Runtime_agent.Reroute { to_runtime_id; reason } ->
-         (match Runtime.get_runtime_by_id to_runtime_id with
-          | None -> runtime_id, assigned_runtime
-          | Some rerouted ->
-            Log.Keeper.warn
-              "%s: RFC-0265 modality reroute %s -> %s (%s)"
-              keeper_name
-              runtime_id
-              to_runtime_id
-              reason;
-            to_runtime_id, rerouted))
+    match
+      Runtime_agent.decide_modality_reroute_for_runtime
+        ~assigned:assigned_runtime
+        ~initial_messages
+        (Option.value goal_blocks ~default:[])
+    with
+    | Runtime_agent.No_reroute_needed | Runtime_agent.No_capable_runtime _ ->
+      runtime_id, assigned_runtime
+    | Runtime_agent.Reroute { to_runtime_id; reason } ->
+      (match Runtime.get_runtime_by_id to_runtime_id with
+       | None -> runtime_id, assigned_runtime
+       | Some rerouted ->
+         Log.Keeper.warn
+           "%s: RFC-0265 modality reroute %s -> %s (%s)"
+           keeper_name
+           runtime_id
+           to_runtime_id
+           reason;
+         to_runtime_id, rerouted)
   in
   let error_runtime_id = runtime_id in
   let candidate =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -134,12 +134,20 @@ let run_named
      untouched; when no runtime qualifies the assigned runtime stands and the
      loud capability gate in [Runtime_agent.run_blocks] rejects (the floor). The
      reroute is visible via a WARN log (non-silent — RFC-0126/0145). *)
+  let current_goal_blocks =
+    match goal_blocks with
+    | Some blocks -> blocks
+    | None ->
+      (* A missing current block payload means the current keeper goal is
+         text-only; [initial_messages] still participate in reroute below. *)
+      []
+  in
   let runtime_id, runtime =
     match
       Runtime_agent.decide_modality_reroute_for_runtime
         ~assigned:assigned_runtime
         ~initial_messages
-        (Option.value goal_blocks ~default:[])
+        current_goal_blocks
     with
     | Runtime_agent.No_reroute_needed | Runtime_agent.No_capable_runtime _ ->
       runtime_id, assigned_runtime

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -373,6 +373,27 @@ let rec required_modalities_of_content_blocks
        | Agent_sdk.Types.ToolResult { content_blocks = None; _ } -> acc)
     [] blocks
 
+let content_blocks_of_messages (messages : Agent_sdk.Types.message list) =
+  List.concat_map
+    (fun (message : Agent_sdk.Types.message) -> message.content)
+    messages
+
+let content_blocks_for_run
+    ~(initial_messages : Agent_sdk.Types.message list)
+    ~(goal_blocks : Agent_sdk.Types.content_block list) =
+  content_blocks_of_messages initial_messages @ goal_blocks
+
+let required_modalities_of_messages (messages : Agent_sdk.Types.message list) =
+  messages
+  |> content_blocks_of_messages
+  |> required_modalities_of_content_blocks
+
+let required_modalities_for_run
+    ~(initial_messages : Agent_sdk.Types.message list)
+    ~(goal_blocks : Agent_sdk.Types.content_block list) =
+  content_blocks_for_run ~initial_messages ~goal_blocks
+  |> required_modalities_of_content_blocks
+
 let supported_modalities_of_capabilities
     (caps : Llm_provider.Capabilities.capabilities) =
   [ "text" ]
@@ -559,13 +580,16 @@ let decide_modality_reroute
     | None -> No_capable_runtime { required = required_modalities }
 
 (* Keeper-dispatch convenience (RFC-0265): gather candidates from the runtime
-   cache and decide a reroute for [assigned] given the turn's [blocks]. Pure
-   [decide_modality_reroute] over impure candidate gathering. *)
+   cache and decide a reroute for [assigned] given the active run view (prior
+   [initial_messages] plus current [blocks]). Pure [decide_modality_reroute] over
+   impure candidate gathering. *)
 let decide_modality_reroute_for_runtime ~(assigned : Runtime.t)
+    ?(initial_messages = [])
     (blocks : Agent_sdk.Types.content_block list) : reroute_decision =
   decide_modality_reroute
     ~assigned_caps:(input_capabilities_of_runtime assigned)
-    ~required_modalities:(required_modalities_of_content_blocks blocks)
+    ~required_modalities:
+      (required_modalities_for_run ~initial_messages ~goal_blocks:blocks)
     ~candidates:(media_reroute_candidates ~exclude:assigned.Runtime.id)
 
 module For_testing = struct
@@ -580,6 +604,10 @@ module For_testing = struct
     runtime_observation_for_terminal_config
   let decide_clock_for_idle = decide_clock_for_idle
   let required_modalities_of_content_blocks = required_modalities_of_content_blocks
+  let content_blocks_of_messages = content_blocks_of_messages
+  let content_blocks_for_run = content_blocks_for_run
+  let required_modalities_of_messages = required_modalities_of_messages
+  let required_modalities_for_run = required_modalities_for_run
   let caps_admit_required_modalities = caps_admit_required_modalities
   let validate_content_blocks_against_capabilities =
     validate_content_blocks_against_capabilities
@@ -811,10 +839,15 @@ let run_blocks
     ?goal_detail
     (goal_blocks : Agent_sdk.Types.content_block list)
   : (run_result, Agent_sdk.Error.sdk_error) result =
+  let validation_blocks =
+    content_blocks_for_run
+      ~initial_messages:config.initial_messages
+      ~goal_blocks
+  in
   match
     validate_content_blocks_for_config
       ~config
-      goal_blocks
+      validation_blocks
   with
   | Error _ as err -> err
   | Ok () ->

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -209,6 +209,15 @@ val decide_modality_reroute :
     the loud capability rejection as the floor). Deterministic: no I/O, no provider
     liveness (deferred to RFC-0260). *)
 
+val content_blocks_for_run :
+  initial_messages:Agent_sdk.Types.message list ->
+  goal_blocks:Agent_sdk.Types.content_block list ->
+  Agent_sdk.Types.content_block list
+(** Active content blocks for a single OAS run: prior [initial_messages] plus
+    the current goal blocks. Keeper reroute and the runtime capability floor use
+    this same view so media retained in history cannot bypass pre-dispatch
+    gating on a later text-only follow-up. *)
+
 val input_capabilities_of_runtime :
   Runtime.t -> Llm_provider.Capabilities.capabilities
 (** Effective input capabilities of a materialized runtime: provider caps overlaid
@@ -223,10 +232,12 @@ val media_reroute_candidates :
 
 val decide_modality_reroute_for_runtime :
   assigned:Runtime.t ->
+  ?initial_messages:Agent_sdk.Types.message list ->
   Agent_sdk.Types.content_block list ->
   reroute_decision
 (** Keeper-dispatch convenience: gather candidates from the runtime cache and
-    decide a reroute for [assigned] given the turn's content blocks. Composes
+    decide a reroute for [assigned] given the active run view: prior
+    [initial_messages] plus the current turn's content blocks. Composes
     [input_capabilities_of_runtime] / [media_reroute_candidates] /
     [decide_modality_reroute]. *)
 
@@ -251,6 +262,22 @@ module For_testing : sig
 
   val required_modalities_of_content_blocks :
     Agent_sdk.Types.content_block list -> string list
+
+  val content_blocks_of_messages :
+    Agent_sdk.Types.message list -> Agent_sdk.Types.content_block list
+
+  val content_blocks_for_run :
+    initial_messages:Agent_sdk.Types.message list ->
+    goal_blocks:Agent_sdk.Types.content_block list ->
+    Agent_sdk.Types.content_block list
+
+  val required_modalities_of_messages :
+    Agent_sdk.Types.message list -> string list
+
+  val required_modalities_for_run :
+    initial_messages:Agent_sdk.Types.message list ->
+    goal_blocks:Agent_sdk.Types.content_block list ->
+    string list
 
   val caps_admit_required_modalities :
     Llm_provider.Capabilities.capabilities -> string list -> bool

--- a/test/test_gate_keeper_backend.ml
+++ b/test/test_gate_keeper_backend.ml
@@ -622,6 +622,47 @@ let test_runtime_multimodal_gate_lists_required_modalities () =
   check (list string) "required modalities" [ "image"; "audio" ]
     (Runtime_agent.For_testing.required_modalities_of_content_blocks blocks)
 
+let test_runtime_multimodal_gate_includes_initial_messages () =
+  let initial_messages =
+    [
+      { Agent_sdk.Types.role = Agent_sdk.Types.User;
+        content =
+          [
+            Agent_sdk.Types.Text "previous image turn";
+            Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" ();
+          ];
+        name = None;
+        tool_call_id = None;
+        metadata = [] };
+    ]
+  in
+  check (list string) "history required modalities" [ "image" ]
+    (Runtime_agent.For_testing.required_modalities_of_messages initial_messages);
+  check (list string) "run required modalities" [ "image" ]
+    (Runtime_agent.For_testing.required_modalities_for_run
+       ~initial_messages
+       ~goal_blocks:[ Agent_sdk.Types.Text "text-only follow-up" ]);
+  let blocks =
+    Runtime_agent.For_testing.content_blocks_for_run
+      ~initial_messages
+      ~goal_blocks:[ Agent_sdk.Types.Text "text-only follow-up" ]
+  in
+  match
+    Runtime_agent.For_testing.validate_content_blocks_against_capabilities
+      ~provider_label:"test:text-only"
+      (multimodal_caps ())
+      blocks
+  with
+  | Ok () -> fail "expected image retained in history to be rejected"
+  | Error
+      (Agent_sdk.Error.Config
+         (Agent_sdk.Error.InvalidConfig { detail; _ })) ->
+      check bool "mentions unsupported history image" true
+        (String_util.string_contains_substring
+           ~needle:"unsupported image input"
+           detail)
+  | Error err -> fail ("unexpected error shape: " ^ Agent_sdk.Error.to_string err)
+
 let test_runtime_multimodal_gate_rejects_unsupported_image () =
   let blocks =
     [ Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" () ]
@@ -986,6 +1027,8 @@ let () =
             test_runtime_run_blocks_appends_multimodal_input_to_oas_agent;
           test_case "runtime multimodal gate lists required modalities" `Quick
             test_runtime_multimodal_gate_lists_required_modalities;
+          test_case "runtime multimodal gate includes initial messages" `Quick
+            test_runtime_multimodal_gate_includes_initial_messages;
           test_case "runtime multimodal gate model caps fail closed" `Quick
             test_runtime_multimodal_gate_model_caps_fail_closed;
           test_case "runtime multimodal gate rejects unsupported image" `Quick

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -27,6 +27,14 @@ let decide ~assigned ~required ~candidates =
     ~required_modalities:required
     ~candidates
 
+let message_with_blocks blocks =
+  { Agent_sdk.Types.role = Agent_sdk.Types.User
+  ; content = blocks
+  ; name = None
+  ; tool_call_id = None
+  ; metadata = []
+  }
+
 (* A text turn ([required = []]) is admitted by any runtime, so it never reroutes
    — the common path stays untouched. *)
 let test_text_turn_no_reroute () =
@@ -55,6 +63,30 @@ let test_image_turn_reroutes_to_first_capable () =
   check string "reroute to first capable in order"
     "reroute:vision_c:assigned runtime lacks image input"
     (decision_to_string (decide ~assigned:(caps ()) ~required:[ "image" ] ~candidates))
+
+(* Regression: media retained in initial history must drive the same reroute as
+   media in the current turn. The dashboard image turn succeeds first; the next
+   text-only follow-up still carries that image in OAS history. *)
+let test_initial_message_media_drives_reroute () =
+  let initial_messages =
+    [ message_with_blocks
+        [ Agent_sdk.Types.Text "previous image turn"
+        ; Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" ()
+        ]
+    ]
+  in
+  let required =
+    Runtime_agent.For_testing.required_modalities_for_run
+      ~initial_messages
+      ~goal_blocks:[ Agent_sdk.Types.Text "follow up" ]
+  in
+  check string "history image reroutes"
+    "reroute:vision_c:assigned runtime lacks image input"
+    (decision_to_string
+       (decide
+          ~assigned:(caps ())
+          ~required
+          ~candidates:[ ("text_b", caps ()); ("vision_c", caps ~image:true ()) ]))
 
 (* Candidate ordering is the caller's contract: with the same capable set in a
    different order, the first listed wins. This pins media_failover precedence. *)
@@ -108,6 +140,8 @@ let () =
             test_image_turn_on_capable_no_reroute
         ; test_case "reroute to first capable" `Quick
             test_image_turn_reroutes_to_first_capable
+        ; test_case "initial message media drives reroute" `Quick
+            test_initial_message_media_drives_reroute
         ; test_case "candidate order honored" `Quick test_candidate_order_is_honored
         ; test_case "no capable floor" `Quick test_no_capable_runtime_floor
         ; test_case "deterministic" `Quick test_decision_is_deterministic


### PR DESCRIPTION
## Summary

Fix keeper multimodal follow-up routing after an image turn.

The dashboard can successfully send an image turn, but that image remains in OAS `initial_messages`. A later text-only follow-up was routed as if it were text-only because `Keeper_turn_driver.run_named` only inspected current `goal_blocks`. Text-only runtimes such as `glm-5-turbo` then received historical image content and surfaced provider errors like:

`Invalid request: messages.content.type is invalid, allowed values: ['text']`

## Changes

- Use one active input view, `Runtime_agent.content_blocks_for_run`, for both keeper pre-dispatch reroute and the runtime capability floor.
- Route decisions now call `Runtime_agent.decide_modality_reroute_for_runtime ?initial_messages` directly so future callers do not have to remember to merge current goal blocks with history themselves.
- Include `initial_messages` content blocks when deciding whether a keeper turn needs media failover.
- Validate `initial_messages + goal_blocks` before provider dispatch so unsupported historical media fails closed inside MASC instead of leaking as provider 400.
- Add regression coverage for history-retained media driving reroute and runtime multimodal validation.

## Evidence

- Z.AI docs checked on 2026-06-21 KST:
  - `glm-5-turbo` guide lists text input only: https://docs.z.ai/guides/llm/glm-5-turbo.md
  - `glm-5v-turbo` guide lists image/video/text/file input: https://docs.z.ai/guides/vlm/glm-5v-turbo.md
  - Chat completion API separates text and vision request/model families: https://docs.z.ai/api-reference/llm/chat-completion.md

## Validation

- `ocamlformat --check lib/runtime/runtime_agent.ml lib/runtime/runtime_agent.mli lib/keeper/keeper_turn_driver.ml test/test_runtime_modality_reroute.ml test/test_gate_keeper_backend.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_runtime_modality_reroute.exe test/test_gate_keeper_backend.exe`
- `./_build/default/test/test_runtime_modality_reroute.exe` (8 tests)
- `./_build/default/test/test_gate_keeper_backend.exe` (53 tests)
