### PR TITLE
fix(keeper): retry thinking-only read-only accept rejection

### DIFF
--- a/docs/audit/2026-06-21-keeper-heuristic-realworld-gap-list.md
+++ b/docs/audit/2026-06-21-keeper-heuristic-realworld-gap-list.md
@@ -1,0 +1,322 @@
+---
+status: reference
+last_verified: 2026-06-21
+code_refs:
+  - lib/keeper/keeper_turn_driver_try_runtime.ml
+  - lib/keeper/keeper_turn_driver_try_provider.ml
+  - lib/keeper/keeper_tool_registry.ml
+  - lib/keeper/keeper_turn_driver_provider_attempt.ml
+  - lib/keeper/keeper_error_classify.ml
+  - lib/runtime/runtime_candidate.ml
+  - lib/keeper/keeper_world_observation_board_signal.ml
+  - lib/keeper/keeper_unified_metrics_support.ml
+  - lib/keeper/keeper_alerting.ml
+  - lib/keeper/keeper_runtime_trust_timeline.ml
+---
+
+# Keeper Heuristic Real-World Gap List
+
+> Date: 2026-06-21
+> Scope: MASC keeper/runtime heuristics that affect retry, wakeup,
+> observability, or operator escalation.
+> Method: adversarial read-through of keeper/runtime code paths after the
+> thinking-only read-only accept-rejection fix.
+> Status: findings documented; not all entries are bugs. Each entry names the
+> missing real-world fixture or operational example that would make the
+> heuristic defensible.
+
+## Inclusion criteria
+
+This list includes code when all of the following are true:
+
+- The implementation changes runtime behavior or operator-visible
+  classification.
+- The decision is driven by a string match, score, threshold, last-event
+  summary, or no-op/default stub.
+- The code lacks a concrete real-world example or fixture that shows the
+  intended behavior and the nearest false-positive/false-negative boundary.
+
+Out of scope: OAS provider/model transport internals, typed OAS response shape
+contracts, and pure documentation text. MASC should consume those surfaces
+through explicit boundary data rather than grow provider-specific behavior in
+OAS.
+
+## Summary
+
+| # | Surface | Current heuristic | Missing example class | Risk |
+|---|---------|-------------------|-----------------------|------|
+| 1 | Thinking-only read-only retry | accept reason substring gate | actual no-progress trace after read-only tool | retry can hide accept failures |
+| 2 | Last-tool effect context | only the final assistant tool call is inspected | multi-tool turn with earlier mutation | read-only label can be unsound |
+| 3 | Tool read-only registry | descriptor/capability fallback | mixed-mode tool contracts | checkpoint boundary can drift |
+| 4 | Provider error string classifiers | quota/capacity/terminal substrings | provider/CLI error corpus | wrong cooldown/escalation |
+| 5 | Keeper warn/recoverable classifier | typed bucket allow/deny list | operator-facing failure samples | noisy or silent incidents |
+| 6 | Runtime candidate neutral stubs | default 0/false/1.0/None | local runtime health examples | dashboards imply certainty |
+| 7 | Board wake/stigmergy match | mention substring and keyword score | Korean/punctuation/false-positive posts | irrelevant keeper wakeups |
+| 8 | Metrics/turn-mode classifiers | output prefixes and phrase search | multilingual turn transcripts | misleading autonomous status |
+| 9 | Alert scoring | uncalibrated keyword weights | incident/non-incident corpus | missed or inflated alerts |
+| 10 | Trust timeline severity | event-type substring severity | benign event names with trigger words | inaccurate timeline severity |
+
+## 1. Thinking-only read-only retry
+
+Evidence:
+- `lib/keeper/keeper_turn_driver_try_runtime.ml:69-78`
+- `lib/keeper/keeper_turn_driver_try_runtime.ml:251-257`
+
+Current behavior: typed `Accept_rejected` with
+`Accept_no_usable_progress` is retryable on the next runtime only when the
+free-form reason contains both `shape=thinking_only` and
+`last_tool_effect=read_only`.
+
+Missing real-world examples:
+- WebFetch/Read/Grep succeeds, then the runtime returns only thinking text.
+- A read-only tool returns an error or empty payload, then the runtime returns
+  only thinking text.
+- The last tool is read-only but an earlier tool in the same turn mutated
+  workspace or board state.
+- The rejection happens on the final candidate, where retry is intentionally
+  impossible.
+
+Operational risk: the fix is intentionally narrow, but its safety rests on a
+string-decorated reason. Without fixture traces for the false-positive
+boundary, a future reason-format change can silently stop retrying, or a
+misclassified read-only context can retry after a turn that already had side
+effects.
+
+Evidence fixture needed: a raw checkpoint/rejection fixture with multiple tools,
+including at least one read-only-only turn and one earlier-mutation turn.
+
+## 2. Last-tool effect context
+
+Evidence:
+- `lib/keeper/keeper_turn_driver_try_provider.ml:195-221`
+- `lib/keeper/keeper_turn_driver_try_provider.ml:224-234`
+
+Current behavior: the checkpoint scan records only the final assistant
+`ToolUse` and formats it as `last_tool=<name>; last_tool_effect=<read_only|mutating>`.
+
+Missing real-world examples:
+- A turn calls `Edit` then `Read`, and the model produces no deliverable.
+- A turn calls several read-only tools where only the last one is relevant to
+  the rejection.
+- A checkpoint includes tool-use blocks from multiple assistant messages after
+  compaction or resume.
+
+Operational risk: "last tool was read-only" is not the same as "this turn was
+read-only". Retry decisions built on the last tool alone can ignore earlier
+side effects.
+
+Evidence fixture needed: a checkpoint summary that includes `any_mutating_tool`,
+`last_tool_effect`, and `tool_effects_seen`, plus tests that pin the intended
+precedence.
+
+## 3. Tool read-only registry and checkpoint boundary
+
+Evidence:
+- `lib/keeper/keeper_tool_registry.ml:134-154`
+- `lib/tool_orchestration/tool_job.ml:38-47`
+
+Current behavior: read-only classification comes from keeper read-only sets,
+descriptor capabilities, idempotent capability, or input-aware descriptor
+resolution. Tool jobs use catalog metadata and fall back to write semantics for
+unknown tools.
+
+Missing real-world examples:
+- A mixed-mode public tool where the same tool name has both read and write
+  subcommands.
+- A descriptor with `Idempotent` capability but nontrivial external side
+  effects.
+- An unregistered tool that is read-only in practice but defaults to
+  `write:any` in scheduling.
+
+Operational risk: read-only status is consumed by retry, checkpoint boundary,
+governance risk, and scheduler resource keys. A single descriptor/capability
+mistake can fan out to multiple runtime policies.
+
+Evidence fixture needed: descriptor-level examples for mixed-mode tools,
+idempotent-but-mutating tools, and unknown tools, with expected boundary and
+resource-key behavior.
+
+## 4. Provider error string classifiers
+
+Evidence:
+- `lib/keeper/keeper_turn_driver_provider_attempt.ml:178-201`
+- `lib/keeper/keeper_turn_driver_provider_attempt.ml:221-240`
+
+Current behavior: hard quota, capacity backpressure, and terminal runtime
+failures are detected by substring indicators in provider/CLI error messages.
+
+Missing real-world examples:
+- Actual current OpenAI-compatible, Ollama Cloud, Claude CLI, and local runtime
+  error envelopes for 429, capacity, timeout, SSE parse, and JSON-RPC parse
+  cases.
+- A transient overload message that contains quota-like words but should remain
+  retryable.
+- A hard quota message wrapped in a CLI exception whose wording changes.
+
+Operational risk: these classifiers control health recording and fallback
+behavior. Misclassification can either keep hammering a quota-exhausted account
+or prematurely suppress a recoverable provider.
+
+Evidence fixture needed: a provider-error corpus with expected
+`hard_quota`, `capacity_backpressure`, `terminal_runtime_failure`, and
+`retryable` labels.
+
+## 5. Keeper warn/recoverable classification
+
+Evidence:
+- `lib/keeper/keeper_error_classify.ml:682-709`
+
+Current behavior: auto-recoverable errors are a small OR-list, and
+`should_warn_keeper_cycle_failed` warns for provider timeout and capacity
+backpressure while suppressing many typed MASC internal errors, including
+accept rejection and runtime exhausted.
+
+Missing real-world examples:
+- Operator-facing examples showing which keeper-cycle failures should page,
+  warn, or remain routine.
+- A thinking-only accept rejection after a read-only tool versus after a
+  mutating tool.
+- A provider timeout caused by a user-configured too-small wall-clock budget
+  versus a provider outage.
+
+Operational risk: the system can become quiet about failures that are
+actionable, or noisy about failures that the keeper will recover from
+automatically.
+
+Evidence fixture needed: a table of real log lines mapped to
+`auto_recoverable`, `warn_cycle_failed`, and expected operator action.
+
+## 6. Runtime candidate neutral stubs
+
+Evidence:
+- `lib/runtime/runtime_candidate.ml:107-112`
+- `lib/runtime/runtime_candidate.ml:158-172`
+- `lib/runtime/runtime_candidate.ml:189-222`
+
+Current behavior: several candidate helpers intentionally return neutral values
+after single-binding dispatch collapsed old multi-candidate machinery:
+context window hint is `0`, header sync is `false`, unmetered provider is
+`false`, threshold multipliers are `(1.0, 1.0)`, recovery evidence is `false`,
+and unhealthy local runtime filtering is a no-op.
+
+Missing real-world examples:
+- Local runtime with known context window and no auth.
+- Remote provider with provider-specific health cooldown.
+- A local endpoint that is unhealthy while another configured runtime URL is
+  healthy.
+
+Operational risk: neutral stubs are acceptable only if no decision relies on
+them. When dashboards, health gates, or context-budget math read these helpers,
+the neutral value looks like fact rather than "not modeled".
+
+Evidence fixture needed: an inventory of every remaining call site, marking
+each helper as display-only, dead compatibility, or behavior-affecting.
+
+## 7. Board wake and stigmergy matching
+
+Evidence:
+- `lib/keeper/keeper_world_observation_board_signal.ml:73-95`
+- `lib/keeper/keeper_world_observation_board_signal.ml:152-171`
+- `lib/keeper/keeper_world_observation_board_signal.ml:196-216`
+
+Current behavior: explicit mention uses lowercase substring search for
+`@target`; stigmergy splits goal text on spaces, keeps tokens longer than
+three characters, adds 5 points per substring hit, and wakes on any score above
+zero.
+
+Missing real-world examples:
+- Korean board posts where space-based tokenization is weak.
+- `@target` appearing inside code, URLs, quoted text, or another user's longer
+  identifier.
+- Multiple keepers with overlapping goals and short shared keywords.
+
+Operational risk: keepers can wake on irrelevant board noise, or miss relevant
+Korean/non-space-delimited posts. That directly affects parallel-agent
+scheduling pressure.
+
+Evidence fixture needed: a multilingual board-signal fixture set with explicit
+mention, false mention, goal overlap, and non-overlap cases.
+
+## 8. Metrics and turn-mode classifiers
+
+Evidence:
+- `lib/keeper/keeper_unified_metrics_support.ml:328-353`
+- `lib/keeper/keeper_unified_metrics_support.ml:431-436`
+- `lib/keeper/keeper_unified_metrics_support.ml:490-498`
+
+Current behavior: no-result errors are bucketed with prefix/substring checks;
+turn mode treats `SKIP:` text as skip text; confirmation requests are detected
+with `?`, English phrases, and a small Korean phrase list.
+
+Missing real-world examples:
+- A status update that says "let me know" but does not require confirmation.
+- Korean declarative text ending with a substring that looks like a question.
+- User content or tool output that begins with `SKIP:` but is not a keeper skip
+  decision.
+
+Operational risk: autonomous reports can mislabel a productive turn as a noop,
+or treat a status report as a blocked request for operator input.
+
+Evidence fixture needed: transcript fixtures for visible reply, tool-use-only,
+skip, noop, confirmation request, and non-confirmation status update.
+
+## 9. Alert scoring
+
+Evidence:
+- `lib/keeper/keeper_alerting.ml:155-207`
+- `lib/keeper/keeper_alerting.ml:209-245`
+
+Current behavior: alert score is a sum of keyword weights plus structural
+bonuses. The code already notes these values are heuristic and not empirically
+calibrated.
+
+Missing real-world examples:
+- Incident posts that should alert.
+- Similar words in non-incident discussion, documentation, or historical
+  summary that should not alert.
+- Combined low-alignment and multi-tool cases where the alert should or should
+  not cross the configured threshold.
+
+Operational risk: alert fatigue or missed incident escalation. The risk is
+larger because this code fans out to operator-facing alert channels and has
+dedup logic keyed only by keeper and reason list.
+
+Evidence fixture needed: a labeled incident/non-incident corpus with expected
+score bands and emitted reasons.
+
+## 10. Runtime trust timeline severity
+
+Evidence:
+- `lib/keeper/keeper_runtime_trust_timeline.ml:85-106`
+
+Current behavior: approval and transition timeline severity is inferred from
+event strings. `reject` makes a resolved approval bad; `failed` or `exhausted`
+makes a transition bad; `pause`, `stop`, `handoff`, or `compaction` makes it
+warn.
+
+Missing real-world examples:
+- Benign event names containing `stop`, `failed`, or `reject` as part of a
+  larger advisory or historical label.
+- Transition events where the typed operator signal severity should override
+  the event-type substring.
+- Approval decisions with provider-specific wording that includes `reject` but
+  is not a denied approval.
+
+Operational risk: timelines can overstate or understate severity, which weakens
+trust in keeper monitoring during incidents.
+
+Evidence fixture needed: timeline-event fixtures with typed severity expected
+outputs and examples that prove substring fallbacks are only fallback behavior.
+
+## Recommended follow-up test slices
+
+1. Add multi-tool accept-rejection fixtures that distinguish `last_tool_effect`
+   from `any_mutating_tool`.
+2. Add provider error corpus tests for hard quota, capacity backpressure,
+   terminal runtime failure, and retryable transient errors.
+3. Add multilingual board-signal fixtures for Korean goal text, mention false
+   positives, and overlapping keeper goals.
+4. Add transcript fixtures for confirmation detection, `SKIP:` turn mode, and
+   no-result error category mapping.
+5. Audit remaining `Runtime_candidate` neutral helper call sites and either
+   remove dead compatibility helpers or annotate behavior-affecting consumers.

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -268,6 +268,34 @@ let is_accept_no_usable_progress_error (err : Agent_sdk.Error.sdk_error) : bool 
   | None ->
     false
 
+let is_thinking_only_read_only_accept_rejection
+    (err : Agent_sdk.Error.sdk_error) : bool =
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some
+      (Keeper_turn_driver.Accept_rejected
+        { reason_kind = Some Keeper_turn_driver.Accept_no_usable_progress
+        ; reason
+        ; _
+        }) ->
+    String_util.contains_substring reason "shape=thinking_only"
+    && String_util.contains_substring reason "last_tool_effect=read_only"
+  | Some
+      ( Keeper_turn_driver.Accept_rejected _
+      | Keeper_turn_driver.Runtime_exhausted _
+      | Keeper_turn_driver.Capacity_backpressure _
+      | Keeper_turn_driver.Resumable_cli_session _
+      | Keeper_turn_driver.Admission_queue_rejected _
+      | Keeper_turn_driver.Admission_queue_timeout _
+      | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Provider_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
+      | Keeper_turn_driver.Ambiguous_post_commit _
+      | Keeper_turn_driver.Internal_unhandled_exception _
+      | Keeper_turn_driver.Internal_bridge_exception _
+      | Keeper_turn_driver.Internal_contract_rejected _ )
+  | None ->
+    false
+
 (* Classification of why a degraded retry is being attempted.  Closed set
    covering both producer paths: [phase_recovery_retry] (7 narrow reasons)
    and [recoverable_runtime_failure_reason] (broader set including raw
@@ -285,6 +313,7 @@ type degraded_retry_reason =
   | Rate_limit
   | Server_error
   | Auth_error
+  | Read_only_no_progress
 
 let degraded_retry_reason_to_string = function
   | Hard_quota -> "hard_quota"
@@ -298,6 +327,7 @@ let degraded_retry_reason_to_string = function
   | Rate_limit -> "rate_limit"
   | Server_error -> "server_error"
   | Auth_error -> "auth_error"
+  | Read_only_no_progress -> "read_only_no_progress"
 
 type degraded_retry =
   { next_runtime : string
@@ -372,6 +402,9 @@ let degraded_retry_after_recoverable_error
         (Keeper_turn_driver.Runtime_exhausted
            { reason = Keeper_turn_driver.Candidates_filtered_after_cycles; _ }) ->
         phase_recovery_retry Runtime_candidates_filtered
+    | Some (Keeper_turn_driver.Accept_rejected _)
+      when is_thinking_only_read_only_accept_rejection err ->
+        phase_recovery_retry Read_only_no_progress
     | Some
         (Keeper_turn_driver.Runtime_exhausted _)
     | Some (Keeper_turn_driver.Accept_rejected _)
@@ -419,6 +452,9 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
            arm previously returned [None]. Other arms below remain
            non-recoverable to keep the surface conservative. *)
         Some Runtime_exhausted
+    | Some (Keeper_turn_driver.Accept_rejected _)
+      when is_thinking_only_read_only_accept_rejection err ->
+        Some Read_only_no_progress
     | Some (Keeper_turn_driver.Accept_rejected _)
     | Some (Keeper_turn_driver.Admission_queue_rejected _)
     | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
@@ -600,7 +636,7 @@ let is_completion_contract_violation (_ : Agent_sdk.Error.sdk_error) : bool =
   false
 
 let degraded_reason_allows_candidate_cycle = function
-  | Hard_quota | Rate_limit -> false
+  | Hard_quota | Rate_limit | Read_only_no_progress -> false
   | Resumable_cli_session
   | Admission_queue_timeout
   | Provider_timeout
@@ -644,6 +680,7 @@ let degraded_rotation_after_recoverable_error
             ~effective_runtime
             candidates
         | Hard_quota
+        | Read_only_no_progress
         | Resumable_cli_session
         | Admission_queue_timeout
         | Provider_timeout

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -271,30 +271,9 @@ let is_accept_no_usable_progress_error (err : Agent_sdk.Error.sdk_error) : bool 
 let is_thinking_only_read_only_accept_rejection
     (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some
-      (Keeper_turn_driver.Accept_rejected
-        { reason_kind = Some Keeper_turn_driver.Accept_no_usable_progress
-        ; reason
-        ; _
-        }) ->
-    String_util.contains_substring reason "shape=thinking_only"
-    && String_util.contains_substring reason "last_tool_effect=read_only"
-  | Some
-      ( Keeper_turn_driver.Accept_rejected _
-      | Keeper_turn_driver.Runtime_exhausted _
-      | Keeper_turn_driver.Capacity_backpressure _
-      | Keeper_turn_driver.Resumable_cli_session _
-      | Keeper_turn_driver.Admission_queue_rejected _
-      | Keeper_turn_driver.Admission_queue_timeout _
-      | Keeper_turn_driver.Turn_timeout _
-      | Keeper_turn_driver.Provider_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
-      | Keeper_turn_driver.Ambiguous_post_commit _
-      | Keeper_turn_driver.Internal_unhandled_exception _
-      | Keeper_turn_driver.Internal_bridge_exception _
-      | Keeper_turn_driver.Internal_contract_rejected _ )
-  | None ->
-    false
+  | Some err ->
+    Keeper_turn_driver.accept_rejection_has_read_only_no_progress_retry_hint err
+  | None -> false
 
 (* Classification of why a degraded retry is being attempted.  Closed set
    covering both producer paths: [phase_recovery_retry] (7 narrow reasons)
@@ -565,6 +544,7 @@ let runtime_catalog_names () =
 
 let default_degraded_rotation_candidates
     ~catalog_names
+    ~(fallback_reason : degraded_retry_reason option)
     ~(base_runtime : string) =
   let normalized_base = normalized_runtime_id ~catalog_names base_runtime in
   let default_runtime =
@@ -574,7 +554,30 @@ let default_degraded_rotation_candidates
     normalized_runtime_id ~catalog_names
       (Runtime.get_default_runtime_id ())
   in
-  [ normalized_base; default_runtime; phase_recovery_runtime ]
+  let default_candidates = [ normalized_base; default_runtime; phase_recovery_runtime ] in
+  match fallback_reason with
+  | Some Read_only_no_progress ->
+    let tool_capable =
+      Runtime.get_runtimes ()
+      |> List.filter (fun (runtime : Runtime.t) -> runtime.model.tools_support)
+      |> List.map (fun (runtime : Runtime.t) ->
+             normalized_runtime_id ~catalog_names runtime.id)
+    in
+    dedupe_keep_order (default_candidates @ tool_capable)
+  | Some
+      ( Hard_quota
+      | Resumable_cli_session
+      | Admission_queue_timeout
+      | Provider_timeout
+      | Turn_timeout
+      | Runtime_candidates_filtered
+      | Runtime_exhausted
+      | Capacity_backpressure
+      | Rate_limit
+      | Server_error
+      | Auth_error )
+  | None ->
+    default_candidates
 
 let normalize_rotation_candidates ~catalog_names candidates =
   candidates
@@ -586,6 +589,7 @@ let normalize_rotation_candidates ~catalog_names candidates =
 
 let degraded_rotation_candidates
     ~catalog_names
+    ~(fallback_reason : degraded_retry_reason)
     ~(fallback_hint : string option)
     ~(base_runtime : string)
     ~(effective_runtime : string) =
@@ -593,7 +597,10 @@ let degraded_rotation_candidates
     normalized_runtime_id ~catalog_names effective_runtime
   in
   let raw_candidates =
-    default_degraded_rotation_candidates ~catalog_names ~base_runtime
+    default_degraded_rotation_candidates
+      ~catalog_names
+      ~fallback_reason:(Some fallback_reason)
+      ~base_runtime
   in
   let fallback_hint_candidate =
     match fallback_hint with
@@ -669,6 +676,7 @@ let degraded_rotation_after_recoverable_error
       let candidates =
         degraded_rotation_candidates
           ~catalog_names
+          ~fallback_reason
           ~fallback_hint
           ~base_runtime ~effective_runtime
       in

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -158,7 +158,9 @@ val degraded_retry_after_recoverable_error :
 
 (** Returns the next untried runtime in the same-turn recovery group for a
     whole-runtime failure. Uses the default degraded rotation candidate set
-    (base/default/phase-recovery).
+    (base/default/phase-recovery). Read-only no-progress accept rejections also
+    append configured tool-capable runtimes so a default-runtime
+    thinking-only response can still rotate to another safe tool-capable model.
 
     [fallback_hint], when provided, is prepended to the candidate list so
     that single-provider profiles can declare an immediate escalation
@@ -173,8 +175,9 @@ val degraded_retry_after_recoverable_error :
     filtering is applied. Non-contract transient infrastructure errors
     (provider timeout, server error, capacity backpressure) allow cycling
     through candidates again when all are exhausted, because the same runtime may
-    succeed on a subsequent attempt. Contract violations and quota/rate-limit
-    classes cap rotation.
+    succeed on a subsequent attempt. Contract violations, read-only no-progress
+    accept rejections, and quota/rate-limit classes cap rotation after the
+    candidate set is exhausted.
     @since 0.174.0 *)
 val degraded_rotation_after_recoverable_error :
   ?credential_pool_of_runtime_id:(string -> string option) ->

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -106,6 +106,7 @@ type degraded_retry_reason =
   | Rate_limit
   | Server_error
   | Auth_error
+  | Read_only_no_progress
 
 val degraded_retry_reason_to_string : degraded_retry_reason -> string
 
@@ -128,8 +129,10 @@ val fallback_runtime_for_unavailable_profile :
 
 (** Classifies an SDK error into a fallback reason label when the runtime
     failure is recoverable via [fallback_runtime] or [degraded_rotation].
-    Returns [None] for terminal errors (e.g. accept-rejected, ambiguous
-    post-commit) that should not trigger same-turn escalation.
+    Returns [None] for terminal errors (e.g. generic accept-rejected,
+    ambiguous post-commit) that should not trigger same-turn escalation. A
+    narrow built-in progress-contract rejection is recoverable only when the
+    response was thinking-only after a read-only tool.
 
     Status-code-aware rotation: raw API errors that are not wrapped in a MASC
     internal error are also classified when a different runtime may succeed:

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -249,4 +249,8 @@ module For_testing = struct
 
   let sdk_error_of_nonretryable_attempt_error =
     Keeper_turn_driver_try_runtime.sdk_error_of_nonretryable_attempt_error
+
+  let accept_no_progress_read_only_should_try_next =
+    Keeper_turn_driver_try_runtime.For_testing
+    .accept_no_progress_read_only_should_try_next
 end

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -169,4 +169,7 @@ module For_testing : sig
     original_error:Agent_sdk.Error.sdk_error ->
     Llm_provider.Http_client.http_error ->
     Agent_sdk.Error.sdk_error
+
+  val accept_no_progress_read_only_should_try_next :
+    Agent_sdk.Error.sdk_error -> bool
 end

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -26,6 +26,10 @@ include
       Keeper_internal_error.runtime_exhaustion_reason
      and type accept_rejection_kind =
       Keeper_internal_error.accept_rejection_kind
+     and type accept_response_shape =
+      Keeper_internal_error.accept_response_shape
+     and type tool_progress_effect =
+      Keeper_internal_error.tool_progress_effect
      and type masc_internal_error = Keeper_internal_error.masc_internal_error
 
 (** {1 Provider error helpers} *)

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -189,8 +189,10 @@ let body_timeout_for_attempt ?per_provider_timeout_s () =
 
 type last_tool_progress_context =
   { tool_name : string
-  ; tool_effect : string
+  ; tool_effect : Keeper_internal_error.tool_progress_effect
   }
+
+let last_tool_effect_to_string = Keeper_internal_error.tool_progress_effect_to_string
 
 let last_tool_use_of_messages (messages : Agent_sdk.Types.message list) =
   let last_tool_in_message (msg : Agent_sdk.Types.message) acc =
@@ -215,8 +217,8 @@ let last_tool_progress_context_of_messages messages =
     let tool_name = if tool_name = "" then "unknown" else tool_name in
     let tool_effect =
       if Keeper_tool_registry.is_read_only_with_input ~tool_name ~input
-      then "read_only"
-      else "mutating"
+      then Keeper_internal_error.Tool_effect_read_only
+      else Keeper_internal_error.Tool_effect_mutating
     in
     Some { tool_name; tool_effect }
 ;;
@@ -231,14 +233,19 @@ let accept_rejection_context_of_run_result (run_result : Runtime_agent.run_resul
 let format_last_tool_progress_context = function
   | None -> None
   | Some { tool_name; tool_effect } ->
-    Some (Printf.sprintf "last_tool=%s; last_tool_effect=%s" tool_name tool_effect)
+    Some
+      (Printf.sprintf
+         "last_tool=%s; last_tool_effect=%s"
+         tool_name
+         (last_tool_effect_to_string tool_effect))
 ;;
 
-let accept_rejected_error ~progress_context ~runtime_id
+let accept_rejected_error ~last_tool_context ~runtime_id
     ~(response : Agent_sdk_response.api_response) =
   let rejection =
     Keeper_tool_response.accept_rejection_of_response ~runtime_id response
   in
+  let progress_context = format_last_tool_progress_context last_tool_context in
   let rejection =
     match progress_context with
     | Some context when String.trim context <> "" ->
@@ -261,20 +268,24 @@ let accept_rejected_error ~progress_context ~runtime_id
              (Boundary_redaction.to_string
                 Boundary_redaction.runtime_model_label);
          reason_kind;
+         response_shape =
+           Option.map
+             Keeper_internal_error.accept_response_shape_of_agent_sdk
+             rejection.response_shape;
+         last_tool_effect =
+           Option.map
+             (fun context -> context.tool_effect)
+             last_tool_context;
          reason = rejection.reason;
        })
 
 let apply_accept ~runtime_id ~accept (run_result : Runtime_agent.run_result) =
   if accept run_result.response then Ok run_result
   else
-    let progress_context =
-      run_result
-      |> accept_rejection_context_of_run_result
-      |> format_last_tool_progress_context
-    in
+    let last_tool_context = accept_rejection_context_of_run_result run_result in
     Error
       (accept_rejected_error
-         ~progress_context
+         ~last_tool_context
          ~runtime_id
          ~response:run_result.response)
 

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -60,7 +60,7 @@ type try_provider_ctx =
 
 type last_tool_progress_context =
   { tool_name : string
-  ; tool_effect : string
+  ; tool_effect : Keeper_internal_error.tool_progress_effect
   }
 
 val run_try_provider :
@@ -73,10 +73,13 @@ val run_try_provider :
   * (string * Obj.t) option
 
 val accept_rejected_error :
-  progress_context:string option ->
+  last_tool_context:last_tool_progress_context option ->
   runtime_id:string ->
   response:Agent_sdk_response.api_response ->
   Agent_sdk.Error.sdk_error
+
+val accept_rejection_context_of_run_result :
+  Runtime_agent.run_result -> last_tool_progress_context option
 
 module For_testing : sig
   val max_execution_time_for_attempt :

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -68,30 +68,10 @@ let is_accept_rejected_sdk_error err =
 
 let accept_no_progress_read_only_should_try_next err =
   match Keeper_internal_error.classify_masc_internal_error err with
-  | Some
-      (Keeper_internal_error.Accept_rejected
-        { reason_kind = Some Keeper_internal_error.Accept_no_usable_progress
-        ; reason
-        ; _
-        }) ->
-    String_util.contains_substring reason "shape=thinking_only"
-    && String_util.contains_substring reason "last_tool_effect=read_only"
-  | Some
-      ( Keeper_internal_error.Accept_rejected _
-      | Keeper_internal_error.Runtime_exhausted _
-      | Keeper_internal_error.Capacity_backpressure _
-      | Keeper_internal_error.Resumable_cli_session _
-      | Keeper_internal_error.Admission_queue_timeout _
-      | Keeper_internal_error.Admission_queue_rejected _
-      | Keeper_internal_error.Turn_timeout _
-      | Keeper_internal_error.Provider_timeout _
-      | Keeper_internal_error.Max_tokens_ceiling_violation _
-      | Keeper_internal_error.Ambiguous_post_commit _
-      | Keeper_internal_error.Internal_unhandled_exception _
-      | Keeper_internal_error.Internal_bridge_exception _
-      | Keeper_internal_error.Internal_contract_rejected _ )
-  | None ->
-    false
+  | Some err ->
+    Keeper_internal_error.accept_rejection_has_read_only_no_progress_retry_hint
+      err
+  | None -> false
 
 let http_status_of_http_error = function
   | Some (Llm_provider.Http_client.HttpError { code; _ }) -> Some code
@@ -221,9 +201,13 @@ let run
          on_success ~provider_key:(Runtime_candidate.health_key candidate);
          Ok run_result
        | Ok run_result ->
+         let last_tool_context =
+           Keeper_turn_driver_try_provider.accept_rejection_context_of_run_result
+             run_result
+         in
          let err =
            Keeper_turn_driver_try_provider.accept_rejected_error
-             ~progress_context:None
+             ~last_tool_context
              ~runtime_id:ctx.error_runtime_id
              ~response:run_result.Runtime_agent.response
          in

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -66,6 +66,33 @@ let is_accept_rejected_sdk_error err =
   | None ->
     false
 
+let accept_no_progress_read_only_should_try_next err =
+  match Keeper_internal_error.classify_masc_internal_error err with
+  | Some
+      (Keeper_internal_error.Accept_rejected
+        { reason_kind = Some Keeper_internal_error.Accept_no_usable_progress
+        ; reason
+        ; _
+        }) ->
+    String_util.contains_substring reason "shape=thinking_only"
+    && String_util.contains_substring reason "last_tool_effect=read_only"
+  | Some
+      ( Keeper_internal_error.Accept_rejected _
+      | Keeper_internal_error.Runtime_exhausted _
+      | Keeper_internal_error.Capacity_backpressure _
+      | Keeper_internal_error.Resumable_cli_session _
+      | Keeper_internal_error.Admission_queue_timeout _
+      | Keeper_internal_error.Admission_queue_rejected _
+      | Keeper_internal_error.Turn_timeout _
+      | Keeper_internal_error.Provider_timeout _
+      | Keeper_internal_error.Max_tokens_ceiling_violation _
+      | Keeper_internal_error.Ambiguous_post_commit _
+      | Keeper_internal_error.Internal_unhandled_exception _
+      | Keeper_internal_error.Internal_bridge_exception _
+      | Keeper_internal_error.Internal_contract_rejected _ )
+  | None ->
+    false
+
 let http_status_of_http_error = function
   | Some (Llm_provider.Http_client.HttpError { code; _ }) -> Some code
   | _ -> None
@@ -223,7 +250,10 @@ let run
            ~http_status:(http_status_of_http_error http_err);
          match http_err with
          | Some http_err
-           when (not is_last) && Runtime_attempt_fsm.should_try_next http_err ->
+           when (not is_last)
+                && (Runtime_attempt_fsm.should_try_next http_err
+                    || accept_no_progress_read_only_should_try_next original_error)
+           ->
            loop checkpoint_after (Some http_err) rest
          | Some http_err ->
            Error
@@ -232,3 +262,8 @@ let run
            if is_last then Error err else loop checkpoint_after last_err rest)
   in
   loop resume_checkpoint last_err candidates
+
+module For_testing = struct
+  let accept_no_progress_read_only_should_try_next =
+    accept_no_progress_read_only_should_try_next
+end

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -144,6 +144,11 @@ let run_model_by_label
                                   (Boundary_redaction.to_string
                                      Boundary_redaction.runtime_model_label);
                               reason_kind;
+                              response_shape =
+                                Option.map
+                                  accept_response_shape_of_agent_sdk
+                                  rejection.response_shape;
+                              last_tool_effect = None;
                               reason = rejection.reason;
                             }))
                 | Error e -> Error e))

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -116,6 +116,65 @@ let accept_rejection_kind_of_string = function
   | _ -> None
 ;;
 
+type accept_response_shape =
+  | Accept_response_empty
+  | Accept_response_thinking_only
+  | Accept_response_blank_text_only
+  | Accept_response_tool_result_only
+  | Accept_response_media_only
+  | Accept_response_mixed_without_deliverable_content
+  | Accept_response_has_deliverable_content
+
+let accept_response_shape_to_string = function
+  | Accept_response_empty -> "empty"
+  | Accept_response_thinking_only -> "thinking_only"
+  | Accept_response_blank_text_only -> "blank_text_only"
+  | Accept_response_tool_result_only -> "tool_result_only"
+  | Accept_response_media_only -> "media_only"
+  | Accept_response_mixed_without_deliverable_content ->
+    "mixed_without_deliverable_content"
+  | Accept_response_has_deliverable_content -> "has_deliverable_content"
+;;
+
+let accept_response_shape_of_string = function
+  | "empty" -> Some Accept_response_empty
+  | "thinking_only" -> Some Accept_response_thinking_only
+  | "blank_text_only" -> Some Accept_response_blank_text_only
+  | "tool_result_only" -> Some Accept_response_tool_result_only
+  | "media_only" -> Some Accept_response_media_only
+  | "mixed_without_deliverable_content" ->
+    Some Accept_response_mixed_without_deliverable_content
+  | "has_deliverable_content" -> Some Accept_response_has_deliverable_content
+  | _ -> None
+;;
+
+let accept_response_shape_of_agent_sdk = function
+  | Agent_sdk.Response_shape.Empty -> Accept_response_empty
+  | Agent_sdk.Response_shape.Thinking_only -> Accept_response_thinking_only
+  | Agent_sdk.Response_shape.Blank_text_only -> Accept_response_blank_text_only
+  | Agent_sdk.Response_shape.Tool_result_only -> Accept_response_tool_result_only
+  | Agent_sdk.Response_shape.Media_only -> Accept_response_media_only
+  | Agent_sdk.Response_shape.Mixed_without_deliverable_content ->
+    Accept_response_mixed_without_deliverable_content
+  | Agent_sdk.Response_shape.Has_deliverable_content ->
+    Accept_response_has_deliverable_content
+;;
+
+type tool_progress_effect =
+  | Tool_effect_read_only
+  | Tool_effect_mutating
+
+let tool_progress_effect_to_string = function
+  | Tool_effect_read_only -> "read_only"
+  | Tool_effect_mutating -> "mutating"
+;;
+
+let tool_progress_effect_of_string = function
+  | "read_only" -> Some Tool_effect_read_only
+  | "mutating" -> Some Tool_effect_mutating
+  | _ -> None
+;;
+
 type masc_internal_error =
   | Runtime_exhausted of {
       runtime_id : string;
@@ -136,6 +195,8 @@ type masc_internal_error =
       scope : string;
       model : string option;
       reason_kind : accept_rejection_kind option;
+      response_shape : accept_response_shape option;
+      last_tool_effect : tool_progress_effect option;
       reason : string;
     }
   | Admission_queue_timeout of {
@@ -260,7 +321,8 @@ let masc_internal_error_to_json = function
         ("detail", `String detail);
         ("exit_code", Json_util.int_opt_to_json exit_code);
       ]
-  | Accept_rejected { scope; model; reason_kind; reason } ->
+  | Accept_rejected
+      { scope; model; reason_kind; response_shape; last_tool_effect; reason } ->
     `Assoc
       [
         ("kind", `String "accept_rejected");
@@ -269,6 +331,12 @@ let masc_internal_error_to_json = function
         ( "reason_kind",
           Json_util.string_opt_to_json
             (Option.map accept_rejection_kind_to_string reason_kind) );
+        ( "response_shape",
+          Json_util.string_opt_to_json
+            (Option.map accept_response_shape_to_string response_shape) );
+        ( "last_tool_effect",
+          Json_util.string_opt_to_json
+            (Option.map tool_progress_effect_to_string last_tool_effect) );
         ("reason", `String reason);
       ]
   | Admission_queue_timeout { keeper_name; runtime_id; wait_sec } ->
@@ -449,6 +517,30 @@ let runtime_id_of_masc_internal_error = function
   | Internal_bridge_exception _
   | Internal_contract_rejected _ -> "unknown"
 
+let accept_rejection_has_read_only_no_progress_retry_hint = function
+  | Accept_rejected
+      {
+        reason_kind = Some Accept_no_usable_progress;
+        response_shape = Some Accept_response_thinking_only;
+        last_tool_effect = Some Tool_effect_read_only;
+        _;
+      } ->
+    true
+  | Accept_rejected _
+  | Runtime_exhausted _
+  | Capacity_backpressure _
+  | Resumable_cli_session _
+  | Admission_queue_timeout _
+  | Admission_queue_rejected _
+  | Turn_timeout _
+  | Provider_timeout _
+  | Max_tokens_ceiling_violation _
+  | Ambiguous_post_commit _
+  | Internal_unhandled_exception _
+  | Internal_bridge_exception _
+  | Internal_contract_rejected _ ->
+    false
+
 let sdk_error_of_masc_internal_error err =
   Agent_sdk.Error.Internal
     (masc_internal_error_prefix ^ Yojson.Safe.to_string (masc_internal_error_to_json err))
@@ -546,6 +638,14 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                      Option.bind
                        (string_opt_of_assoc "reason_kind" json)
                        accept_rejection_kind_of_string;
+                   response_shape =
+                     Option.bind
+                       (string_opt_of_assoc "response_shape" json)
+                       accept_response_shape_of_string;
+                   last_tool_effect =
+                     Option.bind
+                       (string_opt_of_assoc "last_tool_effect" json)
+                       tool_progress_effect_of_string;
                    reason;
                  })
           | _ -> None)

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -44,6 +44,27 @@ type accept_rejection_kind =
 val accept_rejection_kind_to_string : accept_rejection_kind -> string
 val accept_rejection_kind_of_string : string -> accept_rejection_kind option
 
+type accept_response_shape =
+  | Accept_response_empty
+  | Accept_response_thinking_only
+  | Accept_response_blank_text_only
+  | Accept_response_tool_result_only
+  | Accept_response_media_only
+  | Accept_response_mixed_without_deliverable_content
+  | Accept_response_has_deliverable_content
+
+val accept_response_shape_to_string : accept_response_shape -> string
+val accept_response_shape_of_string : string -> accept_response_shape option
+val accept_response_shape_of_agent_sdk :
+  Agent_sdk.Response_shape.content_shape -> accept_response_shape
+
+type tool_progress_effect =
+  | Tool_effect_read_only
+  | Tool_effect_mutating
+
+val tool_progress_effect_to_string : tool_progress_effect -> string
+val tool_progress_effect_of_string : string -> tool_progress_effect option
+
 type masc_internal_error =
   | Runtime_exhausted of {
       runtime_id : string;
@@ -64,6 +85,8 @@ type masc_internal_error =
       scope : string;
       model : string option;
       reason_kind : accept_rejection_kind option;
+      response_shape : accept_response_shape option;
+      last_tool_effect : tool_progress_effect option;
       reason : string;
     }
   | Admission_queue_timeout of {
@@ -115,6 +138,9 @@ val summary_of_masc_internal_error : masc_internal_error -> string option
 val kind_of_masc_internal_error : masc_internal_error -> string
 
 val runtime_id_of_masc_internal_error : masc_internal_error -> string
+
+val accept_rejection_has_read_only_no_progress_retry_hint :
+  masc_internal_error -> bool
 
 val sdk_error_of_masc_internal_error :
   masc_internal_error -> Agent_sdk.Error.sdk_error

--- a/lib/keeper_tooling/keeper_tool_response.ml
+++ b/lib/keeper_tooling/keeper_tool_response.ml
@@ -24,6 +24,7 @@ type accept_rejection_kind =
 type accept_rejection =
   { kind : accept_rejection_kind
   ; reason : string
+  ; response_shape : Agent_sdk.Response_shape.content_shape option
   }
 
 let accept_rejection_kind_to_string = function
@@ -33,10 +34,12 @@ let accept_rejection_kind_to_string = function
 
 let response_accept_rejection (response : Agent_sdk.Types.api_response) =
   let shape = Agent_sdk.Response_shape.summarize response in
+  let response_shape = Agent_sdk.Response_shape.content_shape response shape in
   if not (Agent_sdk.Response_shape.has_deliverable_content shape) then
     Some
       { kind = No_usable_progress
       ; reason = Agent_sdk.Response_shape.diagnostic_summary response
+      ; response_shape = Some response_shape
       }
   else None
 ;;
@@ -52,12 +55,15 @@ let accept_rejection_of_response ~runtime_id response =
           rejection.reason
     }
   | None ->
+    let shape = Agent_sdk.Response_shape.summarize response in
     { kind = Predicate_rejected
     ; reason =
         Printf.sprintf
           "response rejected by accept (runtime=%s); \
            built_in_progress_contract=accepted"
           runtime_id
+    ; response_shape =
+        Some (Agent_sdk.Response_shape.content_shape response shape)
     }
 ;;
 

--- a/lib/keeper_tooling/keeper_tool_response.mli
+++ b/lib/keeper_tooling/keeper_tool_response.mli
@@ -17,6 +17,7 @@ type accept_rejection_kind =
 type accept_rejection =
   { kind : accept_rejection_kind
   ; reason : string
+  ; response_shape : Agent_sdk.Response_shape.content_shape option
   }
 
 val accept_rejection_kind_to_string : accept_rejection_kind -> string

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -288,6 +288,12 @@ max-context = 1024
 tools-support = true
 thinking-support = true
 
+[models.no_tool]
+api-name = "no-tool"
+max-context = 1024
+tools-support = false
+thinking-support = true
+
 [models.b]
 api-name = "b"
 max-context = 1024
@@ -301,6 +307,8 @@ tools-support = true
 thinking-support = true
 
 [same.a]
+
+[same.no_tool]
 
 [same.b]
 
@@ -332,12 +340,14 @@ let provider_unavailable =
        { provider = "server-error-test"; detail = "HTTP 503 retry-after exhausted" })
 ;;
 
-let read_only_no_progress_err =
+let read_only_no_progress_err ~scope =
   KTD.sdk_error_of_masc_internal_error
     (KTD.Accept_rejected
-       { scope = "same.b"
+       { scope
        ; model = None
        ; reason_kind = Some KTD.Accept_no_usable_progress
+       ; response_shape = Some KTD.Accept_response_thinking_only
+       ; last_tool_effect = Some KTD.Tool_effect_read_only
        ; reason =
            "response rejected by accept (runtime=same.b): shape=thinking_only; \
             stop_reason=end_turn; last_tool=WebFetch; last_tool_effect=read_only"
@@ -479,7 +489,8 @@ let test_provider_unavailable_records_server_error_cooldown () =
 
 let test_read_only_no_progress_rotates_to_default_runtime () =
   init_rate_limit_pool_runtime ();
-  (match EC.recoverable_runtime_failure_reason read_only_no_progress_err with
+  let err = read_only_no_progress_err ~scope:"same.b" in
+  (match EC.recoverable_runtime_failure_reason err with
    | Some EC.Read_only_no_progress -> ()
    | Some reason ->
      Alcotest.failf
@@ -491,7 +502,7 @@ let test_read_only_no_progress_rotates_to_default_runtime () =
       ~base_runtime:"same.b"
       ~effective_runtime:"same.b"
       ~attempted_runtimes:[ "same.b" ]
-      read_only_no_progress_err
+      err
   with
   | Some { EC.next_runtime = "same.a"; fallback_reason = EC.Read_only_no_progress } ->
     ()
@@ -501,6 +512,27 @@ let test_read_only_no_progress_rotates_to_default_runtime () =
       (EC.degraded_retry_reason_to_string fallback_reason)
       next_runtime
   | None -> Alcotest.fail "expected read-only no-progress rotation"
+;;
+
+let test_read_only_no_progress_default_runtime_uses_tool_capable_candidate () =
+  init_rate_limit_pool_runtime ();
+  let err = read_only_no_progress_err ~scope:"same.a" in
+  match
+    EC.degraded_rotation_after_recoverable_error
+      ~base_runtime:"same.a"
+      ~effective_runtime:"same.a"
+      ~attempted_runtimes:[ "same.a" ]
+      err
+  with
+  | Some { EC.next_runtime = "same.b"; fallback_reason = EC.Read_only_no_progress } ->
+    ()
+  | Some { next_runtime; fallback_reason } ->
+    Alcotest.failf
+      "expected read_only_no_progress -> same.b, got %s -> %s"
+      (EC.degraded_retry_reason_to_string fallback_reason)
+      next_runtime
+  | None ->
+    Alcotest.fail "expected read-only no-progress to rotate to a tool-capable runtime"
 ;;
 
 let () =
@@ -563,6 +595,10 @@ let () =
             "read-only no-progress accept rejection rotates to default runtime"
             `Quick
             test_read_only_no_progress_rotates_to_default_runtime
+        ; Alcotest.test_case
+            "default runtime read-only no-progress uses tool-capable candidate"
+            `Quick
+            test_read_only_no_progress_default_runtime_uses_tool_capable_candidate
         ] )
     ]
 ;;

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -332,6 +332,18 @@ let provider_unavailable =
        { provider = "server-error-test"; detail = "HTTP 503 retry-after exhausted" })
 ;;
 
+let read_only_no_progress_err =
+  KTD.sdk_error_of_masc_internal_error
+    (KTD.Accept_rejected
+       { scope = "same.b"
+       ; model = None
+       ; reason_kind = Some KTD.Accept_no_usable_progress
+       ; reason =
+           "response rejected by accept (runtime=same.b): shape=thinking_only; \
+            stop_reason=end_turn; last_tool=WebFetch; last_tool_effect=read_only"
+       })
+;;
+
 let test_soft_rate_limit_skips_same_credential_pool () =
   init_rate_limit_pool_runtime ();
   let retry =
@@ -465,6 +477,32 @@ let test_provider_unavailable_records_server_error_cooldown () =
        ~window_s:BH.window_sec)
 ;;
 
+let test_read_only_no_progress_rotates_to_default_runtime () =
+  init_rate_limit_pool_runtime ();
+  (match EC.recoverable_runtime_failure_reason read_only_no_progress_err with
+   | Some EC.Read_only_no_progress -> ()
+   | Some reason ->
+     Alcotest.failf
+       "expected read_only_no_progress, got %s"
+       (EC.degraded_retry_reason_to_string reason)
+   | None -> Alcotest.fail "expected read_only_no_progress recoverable reason");
+  match
+    EC.degraded_rotation_after_recoverable_error
+      ~base_runtime:"same.b"
+      ~effective_runtime:"same.b"
+      ~attempted_runtimes:[ "same.b" ]
+      read_only_no_progress_err
+  with
+  | Some { EC.next_runtime = "same.a"; fallback_reason = EC.Read_only_no_progress } ->
+    ()
+  | Some { next_runtime; fallback_reason } ->
+    Alcotest.failf
+      "expected read_only_no_progress -> same.a, got %s -> %s"
+      (EC.degraded_retry_reason_to_string fallback_reason)
+      next_runtime
+  | None -> Alcotest.fail "expected read-only no-progress rotation"
+;;
+
 let () =
   Alcotest.run
     "keeper_sdk_error_typed_bridge"
@@ -521,6 +559,10 @@ let () =
             "provider unavailable records server_error cooldown"
             `Quick
             test_provider_unavailable_records_server_error_cooldown
+        ; Alcotest.test_case
+            "read-only no-progress accept rejection rotates to default runtime"
+            `Quick
+            test_read_only_no_progress_rotates_to_default_runtime
         ] )
     ]
 ;;

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -182,7 +182,13 @@ let test_reject_reason_describes_thinking_only_response () =
   Alcotest.(check bool)
     "no-progress accept rejection is not runtime exhaustion"
     false
-    (Masc.Keeper_error_classify.is_runtime_exhausted_error err)
+    (Masc.Keeper_error_classify.is_runtime_exhausted_error err);
+  Alcotest.(check bool)
+    "thinking-only without read-only tool does not try next candidate"
+    false
+    (Masc.Keeper_turn_driver.For_testing
+     .accept_no_progress_read_only_should_try_next
+       err)
 
 let test_runtime_error_mapping_preserves_no_progress_accept_rejection () =
   let result =
@@ -292,7 +298,7 @@ let test_accept_reason_includes_last_tool_context () =
            ]
          ())
   in
-  let _err, reason_kind, reason = expect_accept_rejected result in
+  let err, reason_kind, reason = expect_accept_rejected result in
   Alcotest.(check bool)
     "reason kind is no usable progress"
     true
@@ -304,7 +310,62 @@ let test_accept_reason_includes_last_tool_context () =
   Alcotest.(check bool)
     "reason includes last tool effect"
     true
-    (contains ~needle:"last_tool_effect=mutating" reason)
+    (contains ~needle:"last_tool_effect=mutating" reason);
+  Alcotest.(check bool)
+    "thinking-only after mutating tool does not try next candidate"
+    false
+    (Masc.Keeper_turn_driver.For_testing
+     .accept_no_progress_read_only_should_try_next
+       err)
+
+let test_thinking_only_after_read_only_webfetch_can_try_next_candidate () =
+  let checkpoint =
+    checkpoint_with_messages
+      [
+        message
+          [
+            tool_use
+              ~input:(`Assoc [ ("url", `String "https://example.com") ])
+              "WebFetch";
+          ];
+      ]
+  in
+  let result =
+    Masc.Keeper_turn_driver.For_testing.apply_accept
+      ~runtime_id:"runtime.thinking-after-webfetch"
+      ~accept:Keeper_tool_response.response_has_text_or_tool_progress
+      (run_result
+         ~checkpoint
+         ~content:
+           [
+             Agent_sdk.Types.Thinking
+               { thinking_type = "reasoning"; content = "internal chain" };
+           ]
+         ())
+  in
+  let err, reason_kind, reason = expect_accept_rejected result in
+  Alcotest.(check bool)
+    "reason kind is no usable progress"
+    true
+    (reason_kind = Some Keeper_internal_error.Accept_no_usable_progress);
+  Alcotest.(check bool)
+    "reason identifies thinking-only shape"
+    true
+    (contains ~needle:"shape=thinking_only" reason);
+  Alcotest.(check bool)
+    "reason includes read-only tool name"
+    true
+    (contains ~needle:"last_tool=WebFetch" reason);
+  Alcotest.(check bool)
+    "reason includes read-only tool effect"
+    true
+    (contains ~needle:"last_tool_effect=read_only" reason);
+  Alcotest.(check bool)
+    "thinking-only after read-only tool tries next candidate"
+    true
+    (Masc.Keeper_turn_driver.For_testing
+     .accept_no_progress_read_only_should_try_next
+       err)
 
 let test_thinking_with_text_is_accepted () =
   let result =
@@ -586,6 +647,10 @@ let () =
             "accept rejection reason includes last tool context"
             `Quick
             test_accept_reason_includes_last_tool_context;
+          Alcotest.test_case
+            "thinking-only after read-only WebFetch tries next candidate"
+            `Quick
+            test_thinking_only_after_read_only_webfetch_can_try_next_candidate;
           Alcotest.test_case "thinking plus text is accepted" `Quick
             test_thinking_with_text_is_accepted;
           Alcotest.test_case "thinking plus tool use is accepted" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -188,7 +188,13 @@ let test_reject_reason_describes_thinking_only_response () =
     false
     (Masc.Keeper_turn_driver.For_testing
      .accept_no_progress_read_only_should_try_next
-       err)
+       err);
+  Alcotest.(check (option string))
+    "thinking-only without read-only tool is not runtime-recoverable"
+    None
+    (Option.map
+       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
 
 let test_runtime_error_mapping_preserves_no_progress_accept_rejection () =
   let result =
@@ -316,7 +322,13 @@ let test_accept_reason_includes_last_tool_context () =
     false
     (Masc.Keeper_turn_driver.For_testing
      .accept_no_progress_read_only_should_try_next
-       err)
+       err);
+  Alcotest.(check (option string))
+    "thinking-only after mutating tool is not runtime-recoverable"
+    None
+    (Option.map
+       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
 
 let test_thinking_only_after_read_only_webfetch_can_try_next_candidate () =
   let checkpoint =
@@ -365,7 +377,13 @@ let test_thinking_only_after_read_only_webfetch_can_try_next_candidate () =
     true
     (Masc.Keeper_turn_driver.For_testing
      .accept_no_progress_read_only_should_try_next
-       err)
+       err);
+  Alcotest.(check (option string))
+    "thinking-only after read-only tool is runtime-recoverable"
+    (Some "read_only_no_progress")
+    (Option.map
+       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
 
 let test_thinking_with_text_is_accepted () =
   let result =

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -137,6 +137,17 @@ let expect_accept_rejected result =
        Alcotest.failf "expected typed keeper error, got %s"
          (Agent_sdk.Error.to_string err))
 
+let accept_rejected_sdk_error ~response_shape ~last_tool_effect ~reason =
+  Keeper_internal_error.sdk_error_of_masc_internal_error
+    (Keeper_internal_error.Accept_rejected
+       { scope = "runtime.changed-diagnostic"
+       ; model = None
+       ; reason_kind = Some Keeper_internal_error.Accept_no_usable_progress
+       ; response_shape
+       ; last_tool_effect
+       ; reason
+       })
+
 let test_reject_reason_describes_thinking_only_response () =
   let result =
     Masc.Keeper_turn_driver.For_testing.apply_accept
@@ -384,6 +395,46 @@ let test_thinking_only_after_read_only_webfetch_can_try_next_candidate () =
     (Option.map
        Masc.Keeper_error_classify.degraded_retry_reason_to_string
        (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
+
+let test_read_only_retry_uses_typed_context_not_reason_tokens () =
+  let typed_err =
+    accept_rejected_sdk_error
+      ~response_shape:(Some Keeper_internal_error.Accept_response_thinking_only)
+      ~last_tool_effect:(Some Keeper_internal_error.Tool_effect_read_only)
+      ~reason:"diagnostic wording changed; no legacy retry tokens"
+  in
+  Alcotest.(check bool)
+    "typed thinking/read-only context retries despite changed wording"
+    true
+    (Masc.Keeper_turn_driver.For_testing
+     .accept_no_progress_read_only_should_try_next
+       typed_err);
+  Alcotest.(check (option string))
+    "typed thinking/read-only context is runtime-recoverable"
+    (Some "read_only_no_progress")
+    (Option.map
+       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason typed_err));
+  let string_only_err =
+    accept_rejected_sdk_error
+      ~response_shape:None
+      ~last_tool_effect:None
+      ~reason:
+        "legacy text only: shape=thinking_only; last_tool_effect=read_only"
+  in
+  Alcotest.(check bool)
+    "legacy reason tokens alone do not trigger retry"
+    false
+    (Masc.Keeper_turn_driver.For_testing
+     .accept_no_progress_read_only_should_try_next
+       string_only_err);
+  Alcotest.(check (option string))
+    "legacy reason tokens alone are not runtime-recoverable"
+    None
+    (Option.map
+       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason
+          string_only_err))
 
 let test_thinking_with_text_is_accepted () =
   let result =
@@ -669,6 +720,10 @@ let () =
             "thinking-only after read-only WebFetch tries next candidate"
             `Quick
             test_thinking_only_after_read_only_webfetch_can_try_next_candidate;
+          Alcotest.test_case
+            "read-only retry uses typed context, not reason tokens"
+            `Quick
+            test_read_only_retry_uses_typed_context_not_reason_tokens;
           Alcotest.test_case "thinking plus text is accepted" `Quick
             test_thinking_with_text_is_accepted;
           Alcotest.test_case "thinking plus tool use is accepted" `Quick


### PR DESCRIPTION
## Summary

Fix keeper runtime fallback for the narrow failure shape where a provider returns a thinking-only response after a read-only tool call.

- Keep the existing accept contract: thinking-only responses are still rejected as no usable progress.
- Keep generic `AcceptRejected` non-retryable.
- Carry `response_shape` and `last_tool_effect` through the typed MASC internal error envelope instead of parsing retry decisions from diagnostic text.
- Retry only when the typed rejection is `Accept_no_usable_progress`, `response_shape=thinking_only`, and `last_tool_effect=read_only`.
- When the failing runtime is also the default runtime, append configured `tools-support=true` runtimes to the degraded rotation candidate set.
- Add an adversarial audit list for other keeper/runtime heuristics that lack concrete real-world examples or fixture boundaries.

## Product impact

Keeper turns that hit a read-only `WebFetch`/read path and then receive a provider thinking-only response no longer fail the whole cycle while another safe tool-capable runtime remains available.

Mutating-tool, generic predicate rejection, and legacy string-only accept rejections remain terminal. This does not make thinking-only output successful; it only lets MASC retry a different runtime when no mutation can be duplicated.

## Evidence

- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_keeper_sdk_error_typed_bridge.exe test/test_keeper_turn_driver_accept.exe`
- `./_build/default/test/test_keeper_sdk_error_typed_bridge.exe` — 13 tests passed.
- `./_build/default/test/test_keeper_turn_driver_accept.exe` — 18 tests passed.
- `git diff --check`
- `opam exec -- ocamlformat --check lib/keeper/keeper_error_classify.ml lib/keeper/keeper_error_classify.mli lib/keeper/keeper_turn_driver.mli lib/keeper/keeper_turn_driver_try_provider.ml lib/keeper/keeper_turn_driver_try_provider.mli lib/keeper/keeper_turn_driver_try_runtime.ml lib/keeper/keeper_turn_driver_wrappers.ml lib/keeper_runtime/keeper_internal_error.ml lib/keeper_runtime/keeper_internal_error.mli lib/keeper_tooling/keeper_tool_response.ml lib/keeper_tooling/keeper_tool_response.mli test/test_keeper_sdk_error_typed_bridge.ml test/test_keeper_turn_driver_accept.ml`

## Direct evidence

schema_version: 1
direct_ratio: 5/5
provenance: direct

- Added typed `response_shape` and `last_tool_effect` fields to `Accept_rejected` envelopes and preserved JSON parsing compatibility for missing fields.
- Changed provider/runtime retry gates to use typed accept rejection context, not `reason` string tokens.
- Added default-runtime recovery coverage that skips `tools-support=false` profiles and selects the next tool-capable runtime.
- Added regression coverage that typed hints still retry if diagnostic wording changes, while legacy string-only tokens do not.
- Re-ran the focused build and both affected test executables successfully.

## Review evidence

Manual adversarial pass checked that this does not make all `AcceptRejected` failures retryable and does not accept thinking-only output as deliverable content. The retry path is limited to typed no-progress responses after read-only tools.

The OAS/MASC boundary stays intact: OAS owns response shape classification and provider transport; MASC owns keeper accept policy, side-effect safety, and runtime fallback.

## Linked issue

Operator-reported keeper runtime failure:

`accept_rejected ... shape=thinking_only ... last_tool=WebFetch; last_tool_effect=read_only`

<!-- COMMIT-LINEAGE:START -->
### Commit lineage (auto-synced)

`fix/thinking-only-readonly-retry` → `main` · 4 commit(s) · synced 2026-06-21T01:38:45Z

| sha | subject | date |
|---|---|---|
| `270d0ae40` | fix(keeper): retry thinking-only read-only accept rejection | 2026-06-20 |
| `ff7c2a438` | docs: audit keeper heuristic real-world gaps | 2026-06-20 |
| `59a9aec81` | fix(keeper): route read-only no-progress retries through live path | 2026-06-20 |
| `84bd2c47b` | fix(keeper): use typed read-only progress retry hints | 2026-06-20 |

<sub>Managed by `scripts/pr-sync-body.sh` — do not hand-edit between these markers. The code of record is the diff, not prose above this block.</sub>
<!-- COMMIT-LINEAGE:END -->