### PR TITLE
fix(dashboard): eliminate SurfaceLead whitelist; surfaces own their header (single-source 2/2)

### DIFF
--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -21,9 +21,10 @@ vi.mock('../../store', async (importOriginal) => {
 })
 
 vi.mock('../../router', () => ({
-  route: { value: { params: {} } },
+  route: { value: { tab: 'board', params: {}, postId: null } },
   navigate: vi.fn(),
   navigateToPost: vi.fn(),
+  hashForRoute: vi.fn(() => '#board'),
 }))
 
 vi.mock('../../api', () => ({

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -12,6 +12,7 @@ import { Select } from '../common/select'
 import { Checkbox } from '../common/checkbox'
 import { RichContent } from '../common/rich-content'
 import { CursorPagination } from '../common/pagination'
+import { SurfaceHeader } from '../common/surface-header'
 import { stripStateBlocks } from '../../keeper-message'
 import { route } from '../../router'
 import { keepers as dashboardKeepers, messages, refreshExecution } from '../../store'
@@ -1369,6 +1370,7 @@ export function BoardSurface() {
 
   return html`
     <div class="v2-board-surface ss-surface bg-surface-page text-text-primary">
+      <${SurfaceHeader} />
       <div class="bd-body">
         <${BdRail}
           activeSub=${activeSub}

--- a/dashboard/src/components/common/surface-header-actions.ts
+++ b/dashboard/src/components/common/surface-header-actions.ts
@@ -1,0 +1,52 @@
+// SurfaceHeaderActions — the copy-section-link + open-in-solo-view affordances
+// that a surface's own primary header carries. Extracted from the former
+// generic SurfaceLead (removed in the single-source header refactor) so that
+// each surface owns its header while the shared utility affordances live in one
+// place. Reads the live route to derive the share/solo URLs for the current
+// surface+section, so it works regardless of which surface header hosts it.
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import { ExternalLink } from 'lucide-preact'
+import { route } from '../../router'
+import { widgetSoloUrlForRoute } from '../widget-solo'
+import { CopyIdButton } from './copy-id-button'
+import { ringFocusClasses } from './ring'
+
+// window.location is the truth source (the router writes to it already), so the
+// copied link never diverges from the address bar. Returns '' when window is
+// unavailable (SSR / happy-dom without location) so the caller hides the
+// share affordance gracefully.
+function currentShareUrl(): string {
+  if (typeof window === 'undefined' || window.location === undefined) {
+    return ''
+  }
+  return window.location.href
+}
+
+export function SurfaceHeaderActions({ label }: { label: string }): VNode {
+  const soloUrl = widgetSoloUrlForRoute(route.value)
+  const shareUrl = currentShareUrl()
+  return html`
+    <div class="v2-surface-header-actions inline-flex items-center gap-2">
+      ${shareUrl !== ''
+        ? html`<${CopyIdButton}
+            value=${shareUrl}
+            label=${`Section link (${label})`}
+            ariaLabel="Copy current section URL"
+            size=${14}
+          />`
+        : null}
+      <a
+        href=${soloUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class=${`v2-shell-action inline-flex size-7 items-center justify-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
+        title="Open this surface in a solo view"
+        aria-label="Open this surface in a solo view"
+        data-testid="dashboard-widget-solo-link"
+      >
+        <${ExternalLink} size=${14} aria-hidden="true" />
+      </a>
+    </div>
+  `
+}

--- a/dashboard/src/components/common/surface-header.test.ts
+++ b/dashboard/src/components/common/surface-header.test.ts
@@ -40,4 +40,21 @@ describe('SurfaceHeader', () => {
     expect(container.querySelector('.v2-surface-header-actions')).not.toBeNull()
     expect(container.querySelector('[data-testid="dashboard-widget-solo-link"]')).not.toBeNull()
   })
+
+  it('renders parent breadcrumbs for section routes', () => {
+    route.value = { tab: 'lab', params: { section: 'keeper-memory-health' }, postId: null }
+    render(h(SurfaceHeader, {}), container)
+    const breadcrumb = container.querySelector('[data-testid="surface-breadcrumb"]')
+    expect(breadcrumb).not.toBeNull()
+    expect(breadcrumb?.getAttribute('data-surface-breadcrumb')).toBe('true')
+    expect(breadcrumb?.textContent).toContain('Lab')
+    expect(breadcrumb?.textContent).toContain('키퍼 메모리 상태')
+  })
+
+  it('does not duplicate the body header in widget solo mode', () => {
+    route.value = { tab: 'lab', params: { section: 'tools', solo: '1' }, postId: null }
+    render(h(SurfaceHeader, {}), container)
+    expect(container.querySelector('.v2-surface-header')).toBeNull()
+    expect(container.querySelector('[data-testid="dashboard-widget-solo-link"]')).toBeNull()
+  })
 })

--- a/dashboard/src/components/common/surface-header.test.ts
+++ b/dashboard/src/components/common/surface-header.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { h, render } from 'preact'
+import { SurfaceHeader } from './surface-header'
+import { route } from '../../router'
+
+describe('SurfaceHeader', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    route.value = { tab: 'overview', params: {}, postId: null }
+  })
+
+  // Each surface that does not render a richer bespoke header (monitoring,
+  // command, lab, board) opts into SurfaceHeader, which surfaces the current
+  // section/view label as the single primary h1. These labels match what the
+  // former generic SurfaceLead rendered (same currentSectionForRoute logic).
+  it.each([
+    ['monitoring', 'Keeper Fleet'],
+    ['command', 'Actions'],
+    ['lab', 'Tools'],
+    ['board', 'Board'],
+  ] as const)('renders the %s surface title as the primary h1', (tab, label) => {
+    route.value = { tab, params: {}, postId: null }
+    render(h(SurfaceHeader, {}), container)
+    const h1 = container.querySelector('header.v2-surface-header h1')
+    expect(h1?.textContent?.trim()).toBe(label)
+  })
+
+  it('carries the shared copy + solo-view affordances', () => {
+    route.value = { tab: 'board', params: {}, postId: null }
+    render(h(SurfaceHeader, {}), container)
+    expect(container.querySelector('.v2-surface-header-actions')).not.toBeNull()
+    expect(container.querySelector('[data-testid="dashboard-widget-solo-link"]')).not.toBeNull()
+  })
+})

--- a/dashboard/src/components/common/surface-header.ts
+++ b/dashboard/src/components/common/surface-header.ts
@@ -12,18 +12,87 @@
 // every surface's title.
 import { html } from 'htm/preact'
 import type { VNode } from 'preact'
-import { route } from '../../router'
+import type { TabId } from '../../types'
+import { hashForRoute, navigate, route } from '../../router'
 import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from '../../config/navigation'
+import { isWidgetSoloRoute } from '../widget-solo'
+import { Breadcrumb } from './breadcrumb'
+import type { BreadcrumbItem } from './breadcrumb'
 import { SurfaceHeaderActions } from './surface-header-actions'
 
-export function SurfaceHeader(): VNode {
+interface BreadcrumbCrumb {
+  label: string
+  navigableTab: TabId | null
+}
+
+function deriveBreadcrumbTrail(
+  tabLabel: string | null,
+  sectionLabel: string | null,
+  tabId: TabId | null,
+): BreadcrumbCrumb[] {
+  if (tabLabel === null && sectionLabel === null) return []
+  if (sectionLabel === null) {
+    return tabLabel !== null ? [{ label: tabLabel, navigableTab: null }] : []
+  }
+  if (tabLabel === null) {
+    return [{ label: sectionLabel, navigableTab: null }]
+  }
+  return [
+    { label: tabLabel, navigableTab: tabId },
+    { label: sectionLabel, navigableTab: null },
+  ]
+}
+
+function navigateCrumb(event: MouseEvent, tab: TabId): void {
+  if (
+    event.defaultPrevented
+    || event.button !== 0
+    || event.metaKey
+    || event.ctrlKey
+    || event.shiftKey
+    || event.altKey
+  ) {
+    return
+  }
+  event.preventDefault()
+  navigate(tab)
+}
+
+function breadcrumbItemsForTrail(trail: BreadcrumbCrumb[]): BreadcrumbItem[] {
+  return trail.map((crumb, index) => {
+    const current = index === trail.length - 1
+    if (crumb.navigableTab !== null && !current) {
+      return {
+        label: crumb.label,
+        href: hashForRoute(crumb.navigableTab),
+        onClick: (event: MouseEvent) => navigateCrumb(event, crumb.navigableTab!),
+      }
+    }
+    return { label: crumb.label, current }
+  })
+}
+
+export function SurfaceHeader(): VNode | null {
+  if (isWidgetSoloRoute(route.value)) return null
+
   const currentTab = route.value.tab
   const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
   const currentSection = currentSectionForRoute(route.value)
   const title = currentSection?.label ?? currentView?.label ?? 'Home'
   const description = currentSection?.description ?? currentView?.description ?? null
+  const trail = currentSection !== null
+    ? deriveBreadcrumbTrail(currentView?.label ?? null, currentSection.label, currentTab)
+    : []
   return html`
     <header class="v2-surface-header mb-3 flex flex-col gap-1.5" data-testid="surface-header">
+      ${trail.length > 0
+        ? html`<${Breadcrumb}
+            items=${breadcrumbItemsForTrail(trail)}
+            ariaLabel="Breadcrumb"
+            testId="surface-breadcrumb"
+            dataSurfaceBreadcrumb=${true}
+          />`
+        : null}
       <div class="flex items-center gap-2">
         <h1 class="text-lg font-semibold leading-tight tracking-normal text-[var(--color-fg-secondary)]">
           ${title}

--- a/dashboard/src/components/common/surface-header.ts
+++ b/dashboard/src/components/common/surface-header.ts
@@ -1,0 +1,38 @@
+// SurfaceHeader — generic per-surface header for surfaces that do not render a
+// richer bespoke header of their own (monitoring, board, command, lab). Shows
+// the current section/surface title + description (from the nav registry) plus
+// the shared header actions. Surfaces opt in by rendering <SurfaceHeader/> at
+// the top of their body.
+//
+// This replaces the former shell-level SurfaceLead, which decided per-surface
+// whether to render a generic lead via a hand-maintained allow-list
+// (SURFACE_OWN_LEAD_IDS) — an N-of-M list the compiler could not enforce.
+// Now each surface owns the decision to render its header (bespoke or this
+// generic one) at the call site, so there is a single, co-located source for
+// every surface's title.
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+import { route } from '../../router'
+import { DASHBOARD_NAV_ITEMS, currentSectionForRoute } from '../../config/navigation'
+import { SurfaceHeaderActions } from './surface-header-actions'
+
+export function SurfaceHeader(): VNode {
+  const currentTab = route.value.tab
+  const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
+  const currentSection = currentSectionForRoute(route.value)
+  const title = currentSection?.label ?? currentView?.label ?? 'Home'
+  const description = currentSection?.description ?? currentView?.description ?? null
+  return html`
+    <header class="v2-surface-header mb-3 flex flex-col gap-1.5" data-testid="surface-header">
+      <div class="flex items-center gap-2">
+        <h1 class="text-lg font-semibold leading-tight tracking-normal text-[var(--color-fg-secondary)]">
+          ${title}
+        </h1>
+        <${SurfaceHeaderActions} label=${title} />
+      </div>
+      ${description
+        ? html`<p class="m-0 max-w-[72rem] text-xs leading-[var(--lh-body)] text-[var(--color-fg-muted)]">${description}</p>`
+        : null}
+    </header>
+  `
+}

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, shouldRenderSurfaceLead, SideRail, summarizeAttentionPreview } from './dashboard-shell'
+import { DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, SideRail, summarizeAttentionPreview } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 import { dashboardLoading } from '../store'
@@ -63,23 +63,6 @@ describe('DashboardMain primary heading', () => {
     container.remove()
   })
 
-  it.each([
-    ['monitoring', 'Keeper Fleet'],
-    ['command', 'Actions'],
-    ['lab', 'Tools'],
-    ['board', 'Board'],
-  ] as const)(
-    'renders the generic lead for %s as the primary h1',
-    (tab, label) => {
-      route.value = { tab, params: {}, postId: null }
-
-      render(h(DashboardMain, {}), container)
-
-      const leadTitle = container.querySelector('.v2-shell-panel h1')
-      expect(leadTitle?.textContent?.trim()).toBe(label)
-    },
-  )
-
   it('renders a bespoke-header surface with one h1 and no generic lead h1', async () => {
     route.value = { tab: 'overview', params: {}, postId: null }
 
@@ -89,7 +72,7 @@ describe('DashboardMain primary heading', () => {
       expect([...container.querySelectorAll('h1')].map(node => node.textContent?.trim()))
         .toEqual(['운영 개요'])
     }, { timeout: 5000 })
-    expect(container.querySelector('.v2-shell-panel h1')).toBeNull()
+    expect(container.querySelector('.v2-surface-header h1')).toBeNull()
   })
 })
 
@@ -117,30 +100,6 @@ describe('isKeeperDetailDashboardRoute', () => {
       postId: null,
     })).toBe(false)
   })
-})
-
-describe('shouldRenderSurfaceLead', () => {
-  it('lets the Connectors prototype surface own its primary header', () => {
-    expect(shouldRenderSurfaceLead({
-      tab: 'connectors',
-      params: { section: 'connector-status' },
-      postId: null,
-    })).toBe(false)
-  })
-
-  it.each(['overview', 'approvals', 'fusion', 'workspace', 'logs', 'cockpit', 'settings'] as const)(
-    'suppresses the generic lead for %s (surface renders its own bespoke header)',
-    (tab) => {
-      expect(shouldRenderSurfaceLead({ tab, params: {}, postId: null })).toBe(false)
-    },
-  )
-
-  it.each(['monitoring', 'command', 'lab', 'board'] as const)(
-    'keeps the generic lead for %s (surface has no own header)',
-    (tab) => {
-      expect(shouldRenderSurfaceLead({ tab, params: {}, postId: null })).toBe(true)
-    },
-  )
 })
 
 describe('summarizeAttentionPreview', () => {

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -6,7 +6,7 @@ import type { GroundedVerdict, RouteState, TabId } from '../types'
 import type { DashboardCdalHealth, DashboardFleetSafetyHealth, DashboardKeeperReactionLedgerHealth, DashboardRuntimeResolution, Keeper } from '../types'
 import type { DashboardRuntimeProbePayload } from '../api/dashboard'
 import { fetchDashboardRuntimeProbe } from '../api/dashboard'
-import { hashForRoute, navigate, route } from '../router'
+import { route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
 import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
@@ -33,9 +33,7 @@ import {
 } from '../config/navigation'
 import { ObservatoryFilterBar } from './common/observatory-filter-bar'
 import { ChevronRight, ChevronLeft } from 'lucide-preact'
-import { ExternalLink } from 'lucide-preact'
 import { ScrollToTopButton } from './common/scroll-to-top'
-import { CopyIdButton } from './common/copy-id-button'
 import { formatElapsedCompact } from '../lib/format-time'
 import { unacknowledgedCount } from './common/error-notification-state'
 import { ErrorPanel } from './common/error-panel'
@@ -43,12 +41,10 @@ import { Bell } from 'lucide-preact'
 import { ringFocusClasses } from './common/ring'
 import { SurfaceIcon } from './surface-icon'
 import { governanceData } from './governance-signals'
-import { Breadcrumb, type BreadcrumbItem } from './common/breadcrumb'
 import { RouteLink } from './common/route-link'
 import {
   isWidgetSoloRoute,
   WidgetSoloBar,
-  widgetSoloUrlForRoute,
 } from './widget-solo'
 
 const buildIdentityOpen = signal(false)
@@ -1296,87 +1292,6 @@ function TabContent() {
   }
 }
 
-/** Pure: build the shareable URL for the current section. Uses
-    window.location as the truth source (the router writes to it
-    already) so we never diverge from what the browser address bar
-    shows. Returns empty string when window is unavailable
-    (SSR/happy-dom without location) so the caller can hide the
-    share affordance gracefully. */
-function currentSectionShareUrl(): string {
-  if (typeof window === 'undefined' || window.location === undefined) {
-    return ''
-  }
-  return window.location.href
-}
-
-/** Pure: derive the navigation trail rendered above the section title.
-    Each crumb is either a clickable ancestor (tab) or the terminal
-    leaf (current section label, non-navigable). Returns a flat array:
-    [] when both tab + section are absent (home / unknown),
-    [tab] when only tab is active (no section drilldown),
-    [tab, section] when the operator has drilled into a per-section view.
-
-    Why this exists: SurfaceLead previously rendered only the leaf
-    label (\"Discord\"). The parent tab (\"Connectors\") was implied by
-    the left nav but not surfaced in the content area — a newcomer
-    opening a deep link had to infer the hierarchy. Every modern web
-    app (GitHub / Linear / Notion / Vercel) renders the trail above
-    the page title for exactly this reason. */
-interface BreadcrumbCrumb {
-  label: string
-  navigableTab: TabId | null
-}
-function deriveBreadcrumbTrail(
-  tabLabel: string | null,
-  sectionLabel: string | null,
-  tabId: TabId | null,
-): BreadcrumbCrumb[] {
-  if (tabLabel === null && sectionLabel === null) return []
-  if (sectionLabel === null) {
-    return tabLabel !== null ? [{ label: tabLabel, navigableTab: null }] : []
-  }
-  if (tabLabel === null) {
-    return [{ label: sectionLabel, navigableTab: null }]
-  }
-  // Drilldown view — tab becomes a clickable parent crumb, section is
-  // the non-navigable leaf (you're already there, clicking it would
-  // be a no-op).
-  return [
-    { label: tabLabel, navigableTab: tabId },
-    { label: sectionLabel, navigableTab: null },
-  ]
-}
-
-function navigateCrumb(event: MouseEvent, tab: TabId): void {
-  if (
-    event.defaultPrevented
-    || event.button !== 0
-    || event.metaKey
-    || event.ctrlKey
-    || event.shiftKey
-    || event.altKey
-  ) {
-    return
-  }
-  event.preventDefault()
-  navigate(tab)
-}
-
-function breadcrumbItemsForTrail(trail: BreadcrumbCrumb[]): BreadcrumbItem[] {
-  return trail.map((crumb, index) => {
-    const current = index === trail.length - 1
-    if (crumb.navigableTab !== null && !current) {
-      return {
-        label: crumb.label,
-        href: hashForRoute(crumb.navigableTab),
-        onClick: (event: MouseEvent) => navigateCrumb(event, crumb.navigableTab!),
-      }
-    }
-    return { label: crumb.label, current }
-  })
-}
-
-
 /** Pure: compose the browser tab title from the current surface +
     section. Reference: every polished SPA (GitHub / Linear / Notion /
     Vercel) sets document.title so operators with multiple tabs open
@@ -1413,97 +1328,6 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
     && routeState.params.keeper.trim() !== ''
 }
 
-// Surfaces that render their own primary header (a bespoke per-surface title
-// block) and therefore must NOT get the generic dashboard SurfaceLead above
-// them — otherwise the screen shows a duplicate title: the generic <h1> nav
-// label stacked over the surface's own <h1>. When a surface component renders
-// its own top-of-body header, add its TabId here (keep this in sync with the
-// route registry). Verified against the v2 design audit (2026-06-20): the
-// design gives every surface a single bespoke header plus a slim top-bar crumb,
-// with no generic lead.
-//
-//   overview   → overview/overview.ts  <header class="ov-head">      <h1>운영 개요</h1>
-//   approvals  → approvals-surface.ts  <header class="ov-head">      <h1>승인 · HITL 큐</h1>
-//   fusion     → fusion-surface.ts     <header class="ov-head fus-head"> <h1>Fusion</h1>
-//   workspace  → work.ts               <header class="wk-head">      <h1>작업 · 목표</h1>
-//   logs       → logs.ts               <header class="v2-logs-head">  <h1>이벤트 로그</h1>
-//   cockpit    → cockpit/cockpit.ts    <header class="cp-head">      <h1>Cockpit</h1>
-//   settings   → settings-surface.ts   <header class="set-content-h"> <h1>…</h1>
-//   connectors → connector-status.ts   (prototype surface, own header)
-//
-// Surfaces WITHOUT their own header (monitoring, command, lab, board) keep the
-// generic SurfaceLead, which supplies their title.
-const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set([
-  'overview',
-  'approvals',
-  'fusion',
-  'workspace',
-  'logs',
-  'cockpit',
-  'settings',
-  'connectors',
-])
-
-export function shouldRenderSurfaceLead(routeState: RouteState): boolean {
-  if (isKeeperDetailDashboardRoute(routeState)) return false
-  return !SURFACE_OWN_LEAD_IDS.has(routeState.tab)
-}
-
-function SurfaceLead() {
-  const currentTab = route.value.tab
-  const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
-  const currentSection = currentSectionForRoute(route.value)
-  const soloUrl = widgetSoloUrlForRoute(route.value)
-
-  const description = currentSection?.description ?? currentView?.description ?? null
-  const title = currentSection?.label ?? currentView?.label ?? 'Home'
-  const shareUrl = currentSectionShareUrl()
-  // Only surface a trail when the operator has drilled into a section —
-  // otherwise the crumb would be \"Connectors\" right above a \"Connectors\"
-  // title, pure duplication.
-  const trail = currentSection !== null
-    ? deriveBreadcrumbTrail(currentView?.label ?? null, currentSection.label, currentTab)
-    : []
-
-  return html`
-    <div class="v2-shell-panel mb-3 flex flex-col gap-1.5">
-      ${trail.length > 0
-        ? html`<${Breadcrumb}
-            items=${breadcrumbItemsForTrail(trail)}
-            ariaLabel="Breadcrumb"
-            testId="surface-breadcrumb"
-            dataSurfaceBreadcrumb=${true}
-          />`
-        : null}
-      <div class="flex items-center gap-2">
-        <h1 class="text-lg font-semibold tracking-normal text-[var(--color-fg-secondary)] leading-tight">
-          ${title}
-        </h1>
-        ${shareUrl !== ''
-          ? html`<${CopyIdButton}
-              value=${shareUrl}
-              label=${`Section link (${title})`}
-              ariaLabel="Copy current section URL"
-              size=${14}
-            />`
-          : null}
-        <a
-          href=${soloUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          class=${`v2-shell-action inline-flex size-7 items-center justify-center rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-fg-muted)] hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
-          title="Open this surface in a solo view"
-          aria-label="Open this surface in a solo view"
-          data-testid="dashboard-widget-solo-link"
-        >
-          <${ExternalLink} size=${14} aria-hidden="true" />
-        </a>
-      </div>
-      ${description ? html`<p class="m-0 max-w-[72rem] text-xs leading-[var(--lh-body)] text-[var(--color-fg-muted)]">${description}</p>` : null}
-    </div>
-  `
-}
-
 export function DashboardMain() {
   useSurfaceDocumentTitle()
 
@@ -1515,7 +1339,6 @@ export function DashboardMain() {
   const soloMode = isWidgetSoloRoute(route.value)
   const immersiveSurface = route.value.tab === 'code' || route.value.tab === 'keepers'
   const keeperDetailRoute = isKeeperDetailDashboardRoute(route.value)
-  const renderSurfaceLead = shouldRenderSurfaceLead(route.value)
   const warmingBanner = namespaceTruthInitializing.value ? html`
     <div class=${`v2-shell-panel ${immersiveSurface
       ? 'shrink-0 border-b border-solid border-[var(--warn-20)] bg-[var(--warn-10)] px-4 py-1.5 text-center text-xs text-[var(--color-status-warn)]'
@@ -1560,7 +1383,6 @@ export function DashboardMain() {
 
   return html`
     ${warmingBanner}
-    ${renderSurfaceLead ? html`<${SurfaceLead} />` : null}
     ${keeperDetailRoute ? null : html`<${ObservatoryFilterBar} />`}
     <${ErrorBoundary} key=${routeLabel} label=${routeLabel || 'dashboard'}>
       <div class="animate-in fade-in slide-in-from-bottom-2 duration-[var(--t-slow)] fill-mode-both">

--- a/dashboard/src/components/lab.test.ts
+++ b/dashboard/src/components/lab.test.ts
@@ -23,6 +23,9 @@ async function loadLab() {
   vi.doMock('./memory/memory-explore', () => ({
     MemoryExplore: () => html`<div data-testid="lab-memory-explore">MemoryExplore</div>`,
   }))
+  vi.doMock('./memory/keeper-memory-health', () => ({
+    KeeperMemoryHealth: () => html`<div data-testid="lab-keeper-memory-health">KeeperMemoryHealth</div>`,
+  }))
   return import('./lab')
 }
 
@@ -47,6 +50,7 @@ describe('Lab', () => {
     vi.doUnmock('./design-canvas')
     vi.doUnmock('./lab-perf')
     vi.doUnmock('./memory/memory-explore')
+    vi.doUnmock('./memory/keeper-memory-health')
   })
 
   it('renders tools section by default', async () => {
@@ -88,6 +92,14 @@ describe('Lab', () => {
 
     render(html`<${Lab} />`, container)
     expect(container.querySelector('[data-testid="lab-memory-explore"]')).not.toBeNull()
+  })
+
+  it('renders keeper memory health section', async () => {
+    route.value.params = { section: 'keeper-memory-health' }
+    const { Lab } = await loadLab()
+
+    render(html`<${Lab} />`, container)
+    expect(container.querySelector('[data-testid="lab-keeper-memory-health"]')).not.toBeNull()
   })
 
   it('falls back to tools for unknown lab section', async () => {

--- a/dashboard/src/components/lab.test.ts
+++ b/dashboard/src/components/lab.test.ts
@@ -7,7 +7,7 @@ const route = { value: { tab: 'lab' as string, params: {} as Record<string, stri
 
 async function loadLab() {
   vi.resetModules()
-  vi.doMock('../router', () => ({ route }))
+  vi.doMock('../router', () => ({ route, hashForRoute: () => '#lab' }))
   vi.doMock('./tools/tools-main', () => ({
     Tools: () => html`<div data-testid="lab-tools">Tools</div>`,
   }))

--- a/dashboard/src/components/lab.ts
+++ b/dashboard/src/components/lab.ts
@@ -6,6 +6,7 @@ import { DesignCanvas } from './design-canvas'
 import { LabPerf } from './lab-perf'
 import { MemoryExplore } from './memory/memory-explore'
 import { KeeperMemoryHealth } from './memory/keeper-memory-health'
+import { SurfaceHeader } from './common/surface-header'
 
 type LabSection = 'tools' | 'harness' | 'design-canvas' | 'performance' | 'memory-explore' | 'keeper-memory-health'
 
@@ -28,6 +29,7 @@ export function Lab() {
 
   return html`
     <div class="v2-lab-surface ss-surface bg-surface-page flex flex-col gap-6" data-testid="lab-surface">
+      <${SurfaceHeader} />
       ${section === 'tools' ? html`
         <${Tools} />
       ` : null}

--- a/dashboard/src/components/operations-panel.test.ts
+++ b/dashboard/src/components/operations-panel.test.ts
@@ -13,7 +13,7 @@ async function flushUi(): Promise<void> {
 
 async function loadPanel() {
   vi.resetModules()
-  vi.doMock('../router', () => ({ route, replaceRoute: vi.fn() }))
+  vi.doMock('../router', () => ({ route, replaceRoute: vi.fn(), hashForRoute: () => '#command' }))
   vi.doMock('./ops', () => ({
     Ops: () => html`<div data-testid="ops">Ops</div>`,
   }))

--- a/dashboard/src/components/operations-panel.ts
+++ b/dashboard/src/components/operations-panel.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import { FilterChips } from './common/filter-chips'
+import { SurfaceHeader } from './common/surface-header'
 import { Ops } from './ops'
 import { Governance } from './governance'
 import { LabInspector } from './lab-inspector'
@@ -39,6 +40,7 @@ export function OperationsPanel() {
 
   return html`
     <div class="v2-command-surface flex flex-col gap-4">
+      <${SurfaceHeader} />
       <${FilterChips}
         chips=${VIEW_CHIPS}
         value=${view}

--- a/dashboard/src/components/status.ts
+++ b/dashboard/src/components/status.ts
@@ -7,6 +7,7 @@ import { lazy, Suspense } from 'preact/compat'
 import { route } from '../router'
 import { sectionItemsForTab } from '../config/navigation'
 import { LoadingState } from './common/feedback-state'
+import { SurfaceHeader } from './common/surface-header'
 
 export type StatusSection =
   | 'observatory' | 'journey' | 'agents' | 'runtime'
@@ -115,6 +116,7 @@ export function Status() {
 
   return html`
     <div class="v2-monitoring-surface flex flex-col gap-5">
+      <${SurfaceHeader} />
       <div class="transition-opacity duration-[var(--t-slow)]">
         <${Suspense} fallback=${sectionFallback(sectionLabel(section))}>
           ${renderSection(section)}

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -424,7 +424,10 @@ export const DASHBOARD_SECTION_ITEMS: Record<NonHomeTabId, DashboardSectionNavIt
 }
 
 function validSectionIds(tab: NonHomeTabId): SurfaceSectionId[] {
-  return DASHBOARD_SECTION_ITEMS[tab].map(item => item.id)
+  // Total: an unknown/unmapped tab has no sections. Guards against a route
+  // whose tab is not a section-bearing surface (e.g. partial routes in tests
+  // or a not-yet-registered surface) instead of crashing on undefined.map.
+  return (DASHBOARD_SECTION_ITEMS[tab] ?? []).map(item => item.id)
 }
 
 export function defaultParamsForTab(tabId: TabId): Record<string, string> {
@@ -433,7 +436,7 @@ export function defaultParamsForTab(tabId: TabId): Record<string, string> {
 
 export function sectionItemsForTab(tabId: TabId): DashboardSectionNavItem[] {
   if (isSectionlessSurface(tabId)) return []
-  return DASHBOARD_SECTION_ITEMS[tabId as NonHomeTabId]
+  return DASHBOARD_SECTION_ITEMS[tabId as NonHomeTabId] ?? []
 }
 
 export function visibleSectionItemsForTab(tabId: TabId): DashboardSectionNavItem[] {


### PR DESCRIPTION
## 목표 (근본해결 2/2)

대시보드 제목 중복의 **구조적 근원**을 제거한다: hand-maintained `SURFACE_OWN_LEAD_IDS` 화이트리스트(N-of-M 워크어라운드)와 이중 헤더 시스템을 없앤다. PR #21853(1/2)은 전역 헤더 h1을 제거했고, 이 PR은 generic `SurfaceLead` 자체를 제거해 **각 surface가 자신의 헤더를 소유**(단일 소스)하게 한다.

## 변경

- `dashboard-shell.ts`: `SurfaceLead` + `SURFACE_OWN_LEAD_IDS` + `shouldRenderSurfaceLead` + dead breadcrumb 헬퍼(`deriveBreadcrumbTrail`/`navigateCrumb`/`breadcrumbItemsForTrail`/`currentSectionShareUrl`) 제거 + 미사용 import 정리.
- `common/surface-header.ts` (신규): 자체 bespoke 헤더가 없는 surface(monitoring/board/command/lab)용 generic 헤더 — section/view 라벨 `<h1>` + description + 공유 actions. surface가 `<SurfaceHeader/>`를 직접 렌더(헤더 결정을 surface에 co-located).
- `common/surface-header-actions.ts` (신규): copy-link + solo-view affordance를 단일 정의로 추출(SurfaceLead에서 보존).
- `status.ts` / `board-surface.ts` / `operations-panel.ts` / `lab.ts`: 각 surface 본문 최상단에 `<SurfaceHeader/>` 배선.
- `config/navigation.ts`: `validSectionIds` / `sectionItemsForTab`를 total function(`?? []`)으로 강화 — unknown/unmapped tab에 crash 대신 빈 섹션 반환.

## 근거

PR #21834의 화이트리스트는 "자체 헤더 보유 surface를 set에 등록"하는 N-of-M 패턴(CLAUDE.md 워크어라운드 거부 기준 3번) — 새 bespoke 헤더 추가 시 등록 누락이 이중헤더 회귀를 낳는다. 이 PR은 헤더 렌더 결정을 각 surface에 co-located시켜 화이트리스트를 소멸시킨다(근접성으로 누락 방지). 시안(v2) 정합: surface마다 단일 bespoke 헤더 + 전역 얇은 crumb, generic lead 없음.

## 검증 (로컬)

- `tsc --noEmit`: 0 errors
- `npm run lint` (eslint src): clean
- vitest: `surface-header`(신규) / `dashboard-shell` / `board-surface` / `lab` / `operations-panel` / `status` / `navigation` 153 passed + `app` 24 passed
- route-reading 헤더가 노출한 surface 테스트들의 불완전 router mock(`hashForRoute` 누락, `route.tab` 누락)을 현실적으로 보강

## 경계 / 범위

- UI 전용. credential / operator control / sandbox / dashboard credential component / hooks / workflow docs 미변경 → RFC 게이트 대상 아님.
- `app.ts` 미변경 → 진행 중인 TopBar revival PR(#21861/#21862, app.ts)과 파일 충돌 없음(상보적).
- 증상 억제가 아니라 root fix: 워크어라운드(화이트리스트) 제거 + partial function total화(`?? []`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
