### PR TITLE
feat(dashboard): roster basepath, per-group counts, sigil + menu fidelity (keeper-v2 Unit 5a)

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -47,10 +47,10 @@ afterEach(() => {
 describe('KeeperWorkspaceRoster', () => {
   it('renders status groups with keeper rows', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const groups = Array.from(host.querySelectorAll('.kw-roster-group')).map(g => g.textContent)
-    expect(groups).toContain('실행 중')
-    expect(groups).toContain('대기 · 일시정지')
-    expect(groups).toContain('중지 · 종료됨')
+    const labels = Array.from(host.querySelectorAll('.kw-roster-group-label')).map(g => g.textContent)
+    expect(labels).toContain('실행 중')
+    expect(labels).toContain('대기 · 일시정지')
+    expect(labels).toContain('중지 · 종료됨')
     expect(host.querySelectorAll('.kw-kp-row').length).toBe(3)
   })
 
@@ -272,5 +272,56 @@ describe('KeeperWorkspaceRoster', () => {
     )
     // blocked-3 (score 3) > flagged (flag → score 1) > calm (score 0)
     expect(order).toEqual(['blocked-3', 'flagged', 'calm'])
+  })
+
+  it('shows the keeper basepath (sandbox_target) as the row sub-line, shortened with a full-path title', () => {
+    keepers.value = [mk({ name: 'miso', status: 'running', sandbox_target: '/Users/dancer/me/.worktrees/keeper-miso' })]
+    render(html`<${KeeperWorkspaceRoster} activeName="miso" />`, host)
+    const handle = host.querySelector('.kw-kp-handle') as HTMLElement
+    expect(handle?.textContent).toBe('…/.worktrees/keeper-miso')
+    expect(handle?.getAttribute('title')).toBe('/Users/dancer/me/.worktrees/keeper-miso')
+  })
+
+  it('falls back to the scope proxy when a keeper has no sandbox_target', () => {
+    keepers.value = [mk({ name: 'nobase', status: 'running', model: 'anthropic/claude-x' })]
+    render(html`<${KeeperWorkspaceRoster} activeName="nobase" />`, host)
+    const handle = host.querySelector('.kw-kp-handle') as HTMLElement
+    expect(handle?.textContent).toBe('anthropic/claude-x')
+  })
+
+  it('matches a search query against the basepath', () => {
+    keepers.value = [
+      mk({ name: 'alpha', status: 'running', sandbox_target: '/srv/worktrees/alpha-tree' }),
+      mk({ name: 'beta', status: 'running', sandbox_target: '/srv/worktrees/beta-tree' }),
+    ]
+    render(html`<${KeeperWorkspaceRoster} activeName="alpha" />`, host)
+    fireEvent.input(host.querySelector('.kw-roster-search') as HTMLInputElement, { target: { value: 'beta-tree' } })
+    const rows = host.querySelectorAll('.kw-kp-row')
+    expect(rows.length).toBe(1)
+    expect(rows[0]?.textContent).toContain('beta')
+  })
+
+  it('renders a per-group keeper count in the status group header', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    const counts = Array.from(host.querySelectorAll('.kw-roster-group-n')).map(n => n.textContent)
+    // FIXTURE: 1 running, 1 paused, 1 stopped
+    expect(counts).toEqual(['1', '1', '1'])
+  })
+
+  it('closes the row command menu on Escape only (not on any keypress) and on scroll', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    const open = () => fireEvent.click(host.querySelector('[data-testid="kw-roster-menu-sangsu"]') as HTMLButtonElement)
+
+    open()
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).not.toBeNull()
+    fireEvent.keyDown(document, { key: 'a' })
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).not.toBeNull() // a non-Esc key must NOT close it
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).toBeNull()
+
+    open()
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).not.toBeNull()
+    fireEvent.scroll(document)
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -275,11 +275,11 @@ describe('KeeperWorkspaceRoster', () => {
   })
 
   it('shows the keeper basepath (sandbox_target) as the row sub-line, shortened with a full-path title', () => {
-    keepers.value = [mk({ name: 'miso', status: 'running', sandbox_target: '/Users/dancer/me/.worktrees/keeper-miso' })]
+    keepers.value = [mk({ name: 'miso', status: 'running', sandbox_target: '/workspace/keepers/keeper-miso' })]
     render(html`<${KeeperWorkspaceRoster} activeName="miso" />`, host)
     const handle = host.querySelector('.kw-kp-handle') as HTMLElement
-    expect(handle?.textContent).toBe('…/.worktrees/keeper-miso')
-    expect(handle?.getAttribute('title')).toBe('/Users/dancer/me/.worktrees/keeper-miso')
+    expect(handle?.textContent).toBe('…/keepers/keeper-miso')
+    expect(handle?.getAttribute('title')).toBe('/workspace/keepers/keeper-miso')
   })
 
   it('falls back to the scope proxy when a keeper has no sandbox_target', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -80,7 +80,7 @@ const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
 
 /** Flattened roster item used by the virtualized render path. */
 type RosterItem =
-  | { type: 'header'; bucket: KeeperBucket; label: string }
+  | { type: 'header'; bucket: KeeperBucket; label: string; count: number }
   | { type: 'row'; keeper: Keeper }
 
 /** Switch to the shared VirtualList once the roster is long enough that DOM
@@ -118,9 +118,30 @@ function keeperScope(keeper: Keeper): string | null {
   return keeper.skill_primary ?? keeper.active_model ?? keeper.model ?? null
 }
 
+/** The keeper's sandbox location — the design's roster identity sub-line
+ *  (rails.jsx renders `k.basepath` here). The live field is `sandbox_target`
+ *  (keeper-detail-alert-strip.ts:252 uses the same field); for a `local`
+ *  profile it is the worktree root path, for `docker` the container target.
+ *  Unlike the alert strip, this deliberately does NOT fall back to
+ *  `sandbox_profile`: a bare 'local'/'docker' literal is not a useful roster
+ *  identity, so RosterRow falls through to the scope proxy (skill/model) instead. */
+function keeperBasepath(keeper: Keeper): string {
+  return keeper.sandbox_target?.trim() ?? ''
+}
+
+/** Local worktree roots are long absolute paths that end-ellipsis to an
+ *  unhelpful common prefix in the narrow column, so show the last two segments
+ *  (the identifying tail) with the full path in `title`. Non-path targets
+ *  (e.g. a docker target) are shown verbatim. */
+function shortBasepath(value: string): string {
+  if (!value.startsWith('/')) return value
+  const parts = value.split('/').filter(Boolean)
+  return parts.length <= 2 ? value : `…/${parts.slice(-2).join('/')}`
+}
+
 function matchesQuery(keeper: Keeper, q: string): boolean {
   if (!q) return true
-  const hay = `${keeper.name} ${keeper.koreanName ?? ''} ${keeperScope(keeper) ?? ''} ${keeper.model ?? ''}`.toLowerCase()
+  const hay = `${keeper.name} ${keeper.koreanName ?? ''} ${keeperScope(keeper) ?? ''} ${keeper.model ?? ''} ${keeperBasepath(keeper)}`.toLowerCase()
   return hay.includes(q.toLowerCase())
 }
 
@@ -141,6 +162,11 @@ function RosterRow({
   const tone = keeperStatusTone(keeper)
   const att = attentionCount(keeper)
   const scope = keeperScope(keeper)
+  const basepath = keeperBasepath(keeper)
+  // Design roster identity sub-line = basepath; fall back to the scope proxy
+  // when a keeper has no sandbox target yet so the row never loses its sub-label.
+  const handle = basepath ? shortBasepath(basepath) : scope
+  const handleTitle = basepath || scope || ''
   const activity = keeperActivityDisplay(keeper)
   const work = keeperWorkPreview(keeper)
   const select = () => onSelect(keeper.name)
@@ -158,12 +184,12 @@ function RosterRow({
         select()
       }}
     >
-      <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${bucket === 'running'} />
+      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
       <div class="kw-kp-meta">
         <div class="kw-kp-name">${keeper.koreanName ?? keeper.name}</div>
         <div class="kw-kp-sub">
           <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${bucket === 'running'} />${keeperPhaseLabel(keeper)}</span>
-          ${scope ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle">${scope}</span>` : null}
+          ${handle ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle" title=${handleTitle}>${handle}</span>` : null}
         </div>
         <div class="kw-kp-work" title=${work ?? ''}>${work ?? '최근 작업 요약 없음'}</div>
       </div>
@@ -322,11 +348,19 @@ export function KeeperWorkspaceRoster({
   useEffect(() => {
     if (!menu) return
     const close = () => setMenu(null)
+    // Esc closes the menu (was: any key — typing in the search box dismissed it);
+    // scroll closes it too (capture phase) so the row-anchored menu can't drift
+    // away from its row. Mirrors the design roster menu (rails.jsx).
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMenu(null)
+    }
     window.addEventListener('click', close)
-    window.addEventListener('keydown', close)
+    window.addEventListener('scroll', close, true)
+    window.addEventListener('keydown', onKey)
     return () => {
       window.removeEventListener('click', close)
-      window.removeEventListener('keydown', close)
+      window.removeEventListener('scroll', close, true)
+      window.removeEventListener('keydown', onKey)
     }
   }, [menu])
 
@@ -394,7 +428,7 @@ export function KeeperWorkspaceRoster({
     for (const group of GROUP_ORDER) {
       const rows = visible.filter(k => keeperBucket(k) === group.bucket)
       if (rows.length === 0) continue
-      items.push({ type: 'header', bucket: group.bucket, label: group.label })
+      items.push({ type: 'header', bucket: group.bucket, label: group.label, count: rows.length })
       for (const keeper of rows) {
         items.push({ type: 'row', keeper })
       }
@@ -411,7 +445,7 @@ export function KeeperWorkspaceRoster({
 
   function renderItem(item: RosterItem): VNode {
     if (item.type === 'header') {
-      return html`<div class="kw-roster-group v2-monitoring-row">${item.label}</div>`
+      return html`<div class="kw-roster-group v2-monitoring-row"><span class="kw-roster-group-label">${item.label}</span><span class="kw-roster-group-n">${item.count}</span></div>`
     }
     return html`<${RosterRow} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} />`
   }
@@ -471,7 +505,7 @@ export function KeeperWorkspaceRoster({
             />`
           : html`<div class="kw-roster-list">
               ${items.map(item => item.type === 'header'
-                ? html`<div class="kw-roster-group v2-monitoring-row" key=${`h:${item.bucket}`}>${item.label}</div>`
+                ? html`<div class="kw-roster-group v2-monitoring-row" key=${`h:${item.bucket}`}><span class="kw-roster-group-label">${item.label}</span><span class="kw-roster-group-n">${item.count}</span></div>`
                 : html`<${RosterRow} key=${item.keeper.name} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} style=${rowStyle} />`)}
             </div>`}
         `}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -178,9 +178,12 @@
 .kw-roster-list { flex: 1; overflow-y: auto; padding: 9px 8px; }
 .kw-roster-mini-list { display: flex; flex: 1; flex-direction: column; align-items: center; gap: 8px; overflow-y: auto; padding: 12px 8px; }
 .kw-roster-group {
+  display: flex; align-items: center; gap: 6px;
   font-size: var(--fs-11); font-weight: var(--fw-bold); letter-spacing: 0.14em; text-transform: uppercase; color: var(--color-fg-secondary);
   padding: 12px 8px 6px;
 }
+/* Per-group keeper count, right-aligned — mirrors the design roster's rg-n. */
+.kw-roster-group-n { margin-left: auto; letter-spacing: 0; color: var(--color-fg-muted); font-variant-numeric: tabular-nums; }
 .kw-roster-empty { padding: 30px 12px; text-align: center; color: var(--color-fg-secondary); font-size: var(--fs-13); }
 
 .kw-kp-mini {


### PR DESCRIPTION
## 무엇을 / 왜

keeper-v2 로스터 **Unit 5a — 데이터 fidelity**. 갭 분석이 "가장 반복된 로스터 갭"으로 지목한 항목들을 닫습니다(디자인 SSOT: `rails.jsx` `Roster`).

## 변경 (`keeper-workspace-roster.ts` + `keeper-workspace.css`)

1. **basepath 표시**: 로우 sub-line이 keeper basepath를 표시(`keeper.sandbox_target`). 긴 절대경로는 마지막 2세그먼트(`…/parent/leaf`)로 단축 + `title`에 전체 경로. sandbox_target 부재 시 기존 scope(skill/model)로 graceful fallback.
   - **데이터 grounding 교정**: 갭 문서는 `sandbox_root`라 했으나 그건 `KeeperTrustExecutionSummary`의 필드이고 `Keeper`에는 없음(tsc가 적발). 실제 필드는 `sandbox_target`(`keeper-detail-alert-strip.ts:252` 선례와 동일). docker 타깃(비-경로)은 단축하지 않고 그대로 표시.
2. **검색 hay에 basepath 추가**.
3. **그룹별 keeper 카운트**: 상태 그룹 헤더에 `.kw-roster-group-n`(우측 정렬 muted, 디자인 `rg-n` 대응).
4. **로우 sigil 40px → 38px** (디자인 + mini 로스터와 일치).
5. **메뉴 닫힘**: Escape에서만 닫힘(기존: 아무 키나 닫혀 검색 입력 중 닫히던 버그) + scroll(capture)에서 닫힘. 디자인 메뉴 동작과 일치.

## 검증

- `tsc --noEmit`: 0 errors · `eslint src`: clean
- `vitest` 로스터 테스트: **25 passed** (신규: basepath 표시+title, scope fallback, basepath 검색, 그룹 카운트, 메뉴 Esc-only+scroll)
- **적대적 2-렌즈 리뷰 통과**(grounding/correctness + 디자인 fidelity·날조 감사). 양 렌즈 baseline 재현(tsc 0/25 tests/eslint). LOW finding(alert-strip 대비 sandbox_profile fallback 생략)은 의도적 차이로 주석 명시.

## 범위 밖 (의도적 follow-up)

- rich mini-roster hover flyout(sigil+id+phase+basepath+runtime+attention)
- right-click-to-open-at-cursor (현재는 ⋯ 버튼 트리거)
- 그룹 헤더 `rg-dot` (시각 fidelity)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
