### PR TITLE
feat(schedule): surface keeper dashboard diagnostics

### DIFF
--- a/bin/env_knob_catalog.ml
+++ b/bin/env_knob_catalog.ml
@@ -19,6 +19,10 @@
    tool emits an "Unrecognized" entry and CI will surface it. *)
 
 let env_var_re = Str.regexp "\"\\(MASC_[A-Z][A-Z0-9_]*\\)\""
+let env_key_alias_re =
+  Str.regexp "let[ \t]+\\([A-Za-z_][A-Za-z0-9_']*\\)[ \t]*=[ \t]*\"\\(MASC_[A-Z][A-Z0-9_]*\\)\""
+
+let ident_re = Str.regexp "[A-Za-z_][A-Za-z0-9_']*"
 
 let typed_get_re =
   Str.regexp "get_\\(int\\|int_nonneg\\|float\\|float_nonneg\\|float_in_range\\|ratio\\|string\\|bool\\)"
@@ -159,9 +163,39 @@ let classification_of_doc = function
   | None -> (None, None)
   | Some doc -> (search_group category_re doc, search_group ops_class_re doc)
 
+let env_key_aliases arr =
+  let aliases = ref [] in
+  Array.iter
+    (fun line ->
+      try
+        let _ = Str.search_forward env_key_alias_re line 0 in
+        let ident = Str.matched_group 1 line in
+        let env_var = Str.matched_group 2 line in
+        aliases := (ident, env_var) :: !aliases
+      with Not_found | Invalid_argument _ -> ())
+    arr;
+  List.rev !aliases
+
+let alias_refs aliases line =
+  let refs = ref [] in
+  let pos = ref 0 in
+  (try
+     while !pos < String.length line do
+       let _ = Str.search_forward ident_re line !pos in
+       let ident = Str.matched_string line in
+       let next_pos = Str.match_end () in
+       (match List.assoc_opt ident aliases with
+        | Some env_var when not (List.mem env_var !refs) -> refs := env_var :: !refs
+        | Some _ | None -> ());
+       pos := next_pos
+     done
+   with Not_found -> ());
+  List.rev !refs
+
 let scan_file path =
   let lines = read_lines path in
   let arr = Array.of_list lines in
+  let aliases = env_key_aliases arr in
   let acc = ref [] in
   Array.iteri
     (fun i line ->
@@ -201,7 +235,37 @@ let scan_file path =
             :: !acc;
           pos := next_pos
         done
-      with Not_found -> ())
+      with Not_found -> ();
+      let kind =
+        let rec try_classify offset =
+          if offset > 2 || i - offset < 0 then String_lit
+          else
+            match classify_line arr.(i - offset) with
+            | Some k -> k
+            | None -> try_classify (offset + 1)
+        in
+        try_classify 0
+      in
+      match kind with
+      | String_lit -> ()
+      | Feature_flag | Entry_env | Typed_get _ ->
+        let refs = alias_refs aliases line in
+        List.iter
+          (fun env_var ->
+            let doc = doc_above arr i in
+            let category, ops_class = classification_of_doc doc in
+            acc :=
+              {
+                file = path;
+                line = i + 1;
+                env_var;
+                kind;
+                doc;
+                category;
+                ops_class;
+              }
+              :: !acc)
+          refs)
     arr;
   List.rev !acc
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1851,6 +1851,19 @@ export interface DashboardScheduledAutomationExecution {
   error?: string | null
 }
 
+export interface DashboardScheduledAutomationKeeperToolStatus {
+  name: string
+  registered_schema?: boolean
+  dispatch_registered?: boolean
+  direct_call_allowed?: boolean
+  visibility?: string
+  surfaces?: string[]
+  surface_count?: number
+  effect_domain?: string | null
+  read_only?: boolean | null
+  requires_actor_binding?: boolean | null
+}
+
 export interface DashboardScheduledAutomationRequest {
   schedule_id: string
   status: string
@@ -1858,6 +1871,7 @@ export interface DashboardScheduledAutomationRequest {
   execution_readiness?: string
   operator_action?: string | null
   keeper_next_tool?: string | null
+  keeper_next_tool_status?: DashboardScheduledAutomationKeeperToolStatus | null
   keeper_next_action?: string | null
   risk_class: string
   approval_required: boolean

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1882,12 +1882,20 @@ export interface DashboardScheduledAutomationRequest {
   expires_at_iso?: string | null
   payload_digest?: string
   payload_kind?: string | null
+  payload_support?: 'supported' | 'unsupported' | 'unknown'
   payload_target?: string | null
   payload_summary?: string | null
   recurrence_summary?: string | null
   requires_separate_human_grant?: boolean
   approval_policy?: string | null
   last_execution?: DashboardScheduledAutomationExecution | null
+}
+
+export interface DashboardScheduledAutomationPayloadSupport {
+  supported_kinds?: string[]
+  unsupported_request_count?: number
+  unsupported_kinds?: Array<{ kind: string; count: number }>
+  unknown_request_count?: number
 }
 
 export interface DashboardScheduledAutomation {
@@ -1899,6 +1907,7 @@ export interface DashboardScheduledAutomation {
   truncated: boolean
   counts: Record<string, number>
   derived_counts?: Record<string, number>
+  payload_support?: DashboardScheduledAutomationPayloadSupport
   fsm: DashboardScheduledAutomationFsm
   requests: DashboardScheduledAutomationRequest[]
 }

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -181,9 +181,17 @@ function PayloadCell({ request }: { request: DashboardScheduledAutomationRequest
   const kind = request.payload_kind ?? '-'
   const target = request.payload_target?.trim() || null
   const summary = request.payload_summary?.trim() || null
+  const support = request.payload_support
+  const supportTone: StatusChipTone =
+    support === 'supported' ? 'ok' : support === 'unsupported' ? 'bad' : 'neutral'
   return html`
     <div class="max-w-[18rem]">
-      <div class="font-mono text-xs text-[var(--color-fg-secondary)]">${kind}</div>
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="font-mono text-xs text-[var(--color-fg-secondary)]">${kind}</span>
+        ${support
+          ? html`<${StatusChip} tone=${supportTone} uppercase=${false}>${enumLabel(support)}<//>`
+          : null}
+      </div>
       ${target
         ? html`<div class="mt-1 font-mono text-3xs text-[var(--color-fg-muted)]">${target}</div>`
         : null}
@@ -349,6 +357,15 @@ export function ScheduledAutomationPanel({
   const blockedApproval = automation.derived_counts?.blocked_approval ?? 0
   const dueExecutionReady = automation.derived_counts?.due_execution_ready ?? 0
   const expiredEffective = automation.derived_counts?.expired_effective ?? 0
+  const unsupportedPayloads =
+    automation.payload_support?.unsupported_request_count
+      ?? automation.derived_counts?.unsupported_payload_kind
+      ?? 0
+  const unknownPayloads =
+    automation.payload_support?.unknown_request_count
+      ?? automation.derived_counts?.unknown_payload_kind
+      ?? 0
+  const unsupportedKinds = automation.payload_support?.unsupported_kinds ?? []
 
   return html`
     <div class="grid gap-4">
@@ -377,11 +394,34 @@ export function ScheduledAutomationPanel({
         <span class="text-[var(--color-fg-muted)]">
           expired <span class="font-mono text-[var(--color-fg-secondary)]">${expiredEffective.toLocaleString()}</span>
         </span>
+        <span class=${unsupportedPayloads > 0 ? 'text-[var(--color-danger-fg)]' : 'text-[var(--color-fg-muted)]'}>
+          unsupported payload <span class="font-mono">${unsupportedPayloads.toLocaleString()}</span>
+        </span>
+        ${unknownPayloads > 0
+          ? html`
+              <span class="text-[var(--color-warning-fg)]">
+                unknown payload <span class="font-mono">${unknownPayloads.toLocaleString()}</span>
+              </span>
+            `
+          : null}
         <span class="text-[var(--color-fg-muted)]">
           next due <span class="font-mono text-[var(--color-fg-secondary)]">${formatDateTimeKo(automation.fsm.next_due_at ?? null)}</span>
         </span>
         <span class="font-mono text-3xs text-[var(--color-fg-disabled)]">${automation.source ?? 'schedule_store'}</span>
       </div>
+
+      ${unsupportedKinds.length > 0
+        ? html`
+            <div class="flex flex-wrap gap-2">
+              ${unsupportedKinds.map(kind => html`
+                <span class="inline-flex items-center gap-1 rounded-[var(--r-0)] bg-[var(--err-soft)] px-2 py-1 text-2xs text-[var(--color-danger-fg)]">
+                  <span class="font-mono">${kind.count.toLocaleString()}</span>
+                  <span class="font-mono">${kind.kind}</span>
+                </span>
+              `)}
+            </div>
+          `
+        : null}
 
       <div class="flex flex-wrap gap-2">
         ${nonzeroCounts.length > 0

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -202,14 +202,55 @@ function PayloadCell({ request }: { request: DashboardScheduledAutomationRequest
   `
 }
 
+function keeperToolStatusTone(request: DashboardScheduledAutomationRequest): StatusChipTone {
+  const status = request.keeper_next_tool_status
+  if (!status) return 'neutral'
+  if (status.registered_schema === false || status.dispatch_registered === false) return 'bad'
+  if (status.direct_call_allowed === false) return 'warn'
+  return 'ok'
+}
+
+function keeperToolStatusLabel(request: DashboardScheduledAutomationRequest): string {
+  const status = request.keeper_next_tool_status
+  if (!status) return 'unknown'
+  if (status.registered_schema === false || status.dispatch_registered === false) return 'orphan'
+  if (status.direct_call_allowed === false) return 'blocked'
+  return 'callable'
+}
+
+function keeperToolSurfaceLabel(request: DashboardScheduledAutomationRequest): string {
+  const status = request.keeper_next_tool_status
+  if (!status) return 'surface unknown'
+  const surfaces = status.surfaces ?? []
+  const surfaceCount = status.surface_count ?? surfaces.length
+  if (surfaceCount <= 0) return 'no surface'
+  if (surfaceCount === 1 && surfaces[0]) return surfaces[0].replace(/_/g, ' ')
+  return `${surfaceCount} surfaces`
+}
+
 function KeeperActionCell({ request }: { request: DashboardScheduledAutomationRequest }) {
   const nextTool = request.keeper_next_tool?.trim() || null
   const nextAction = request.keeper_next_action?.trim() || null
+  const status = request.keeper_next_tool_status
+  const visibility = status?.visibility?.trim() || null
   if (!nextTool && !nextAction) return html`<span class="text-xs text-[var(--color-fg-disabled)]">-</span>`
   return html`
     <div class="max-w-[16rem]">
       ${nextTool
         ? html`<div class="truncate font-mono text-3xs text-[var(--color-fg-secondary)]" title=${nextTool}>${nextTool}</div>`
+        : null}
+      ${status
+        ? html`
+            <div class="mt-1 flex flex-wrap items-center gap-1">
+              <${StatusChip} tone=${keeperToolStatusTone(request)} uppercase=${false}>
+                ${keeperToolStatusLabel(request)}
+              <//>
+              ${visibility
+                ? html`<span class="rounded-[var(--r-0)] bg-[var(--color-bg-hover)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-muted)]">${visibility.replace(/_/g, ' ')}</span>`
+                : null}
+              <span class="rounded-[var(--r-0)] bg-[var(--color-bg-hover)] px-1.5 py-0.5 text-3xs text-[var(--color-fg-muted)]">${keeperToolSurfaceLabel(request)}</span>
+            </div>
+          `
         : null}
       ${nextAction
         ? html`<div class="mt-1 truncate text-3xs text-[var(--color-fg-muted)]" title=${nextAction}>${nextAction}</div>`

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -120,6 +120,14 @@ describe('Tools', () => {
           blocked_approval: 1,
           due_execution_ready: 0,
           expired_effective: 0,
+          unsupported_payload_kind: 1,
+          unknown_payload_kind: 0,
+        },
+        payload_support: {
+          supported_kinds: ['masc.board_post'],
+          unsupported_request_count: 1,
+          unsupported_kinds: [{ kind: 'test.reminder', count: 1 }],
+          unknown_request_count: 0,
         },
         fsm: {
           state: 'blocked_approval',
@@ -143,6 +151,7 @@ describe('Tools', () => {
             recurrence: { kind: 'cron', expression: '0 9 * * 1-5', timezone: 'Asia/Seoul' },
             recurrence_kind: 'cron',
             payload_kind: 'test.reminder',
+            payload_support: 'unsupported',
             due_at_iso: '2026-06-13T01:00:00Z',
             last_execution: {
               execution_id: 'exec-1',
@@ -171,6 +180,8 @@ describe('Tools', () => {
     expect(container.textContent).toContain('cron 0 9 * * 1-5 Asia/Seoul')
     expect(container.textContent).toContain('succeeded')
     expect(container.textContent).toContain('test.reminder')
+    expect(container.textContent).toContain('unsupported payload')
+    expect(container.textContent).toContain('unsupported')
     expect(container.querySelector('.v2-lab-table')).not.toBeNull()
     expect(container.querySelector('.v2-lab-row')).not.toBeNull()
   })

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -143,6 +143,18 @@ describe('Tools', () => {
             execution_readiness: 'blocked_approval',
             operator_action: 'approve_or_reject',
             keeper_next_tool: 'masc_schedule_get',
+            keeper_next_tool_status: {
+              name: 'masc_schedule_get',
+              registered_schema: true,
+              dispatch_registered: true,
+              direct_call_allowed: true,
+              visibility: 'hidden',
+              surfaces: [],
+              surface_count: 0,
+              effect_domain: 'read_only',
+              read_only: true,
+              requires_actor_binding: null,
+            },
             keeper_next_action:
               'Inspect details, then wait for the dashboard operator approval or rejection action to resolve this schedule.',
             risk_class: 'workspace_write',
@@ -175,6 +187,9 @@ describe('Tools', () => {
     expect(container.textContent).toContain('dashboard operator approval or rejection')
     expect(container.textContent).toContain('Approve')
     expect(container.textContent).toContain('Reject')
+    expect(container.textContent).toContain('callable')
+    expect(container.textContent).toContain('hidden')
+    expect(container.textContent).toContain('no surface')
     expect(container.textContent).toContain('sched-1')
     expect(container.textContent).toContain('workspace write')
     expect(container.textContent).toContain('cron 0 9 * * 1-5 Asia/Seoul')

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,9 +16,9 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 355 unique knobs across 9 modules.
 
-**Typed getter classification**: 20/203 tagged (`operator`: 20, `algorithm`: 0, `unclassified`: 183).
+**Typed getter classification**: 21/204 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 183).
 
-## Env_config_core (29 knobs; typed classification 0/7)
+## Env_config_core (29 knobs; typed classification 1/8)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -29,7 +29,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 230 |  |
 | `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 424 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_DATA_DIR` | string_literal | n/a | n/a | 437 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_DISABLE_HITL` | string_literal | n/a | n/a | 500 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
+| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
 | `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 467 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
 | `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 480 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,9 +16,9 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 355 unique knobs across 9 modules.
 
-**Typed getter classification**: 21/204 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 183).
+**Typed getter classification**: 20/203 tagged (`operator`: 20, `algorithm`: 0, `unclassified`: 183).
 
-## Env_config_core (29 knobs; typed classification 1/8)
+## Env_config_core (29 knobs; typed classification 0/7)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -29,7 +29,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 230 |  |
 | `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 424 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_DATA_DIR` | string_literal | n/a | n/a | 437 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
+| `MASC_DISABLE_HITL` | string_literal | n/a | n/a | 500 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
 | `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 467 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
 | `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 480 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,9 +16,9 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 355 unique knobs across 9 modules.
 
-**Typed getter classification**: 21/204 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 183).
+**Typed getter classification**: 21/208 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 187).
 
-## Env_config_core (29 knobs; typed classification 1/8)
+## Env_config_core (29 knobs; typed classification 1/12)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -30,8 +30,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 424 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_DATA_DIR` | string_literal | n/a | n/a | 437 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
 | `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 467 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
-| `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 480 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 471 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
+| `MASC_GOVERNANCE_LEVEL` | typed:string | unclassified | unclassified | 497 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 243 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 202 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
@@ -43,12 +43,12 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 476 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 477 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 409 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
-| `MASC_PARSE_WARN` | string_literal | n/a | n/a | 479 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_PARSE_WARN` | typed:bool | unclassified | unclassified | 492 | Whether to log parse warnings. Default: false. |
 | `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 425 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 516 | PubSub max messages per read. Default: 1000. |
 | `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 447 | Whether relay token calibration is enabled. Default: true. |
 | `MASC_STORAGE_TYPE` | string_literal | n/a | n/a | 404 | SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). |
-| `MASC_TELEMETRY_ENABLED` | string_literal | n/a | n/a | 478 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 488 | Whether telemetry tracking is enabled. Default: true. |
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 343 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 244 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1723,6 +1723,60 @@ let schedule_counts_json schedules =
        Schedule_domain.all_schedule_statuses)
 ;;
 
+let schedule_supported_payload_kinds =
+  List.sort_uniq String.compare Server_schedule_consumers.supported_payload_kinds
+;;
+
+let schedule_payload_kind_supported kind =
+  List.exists (String.equal kind) schedule_supported_payload_kinds
+;;
+
+let schedule_payload_support_status (request : Schedule_domain.schedule_request) =
+  match Schedule_payload_projection.kind request with
+  | Some kind when schedule_payload_kind_supported kind -> "supported"
+  | Some _ -> "unsupported"
+  | None -> "unknown"
+;;
+
+let schedule_payload_support_json schedules =
+  let bump kind counts =
+    let rec loop acc = function
+      | [] -> List.rev ((kind, 1) :: acc)
+      | (existing, count) :: rest when String.equal existing kind ->
+        List.rev_append acc ((existing, count + 1) :: rest)
+      | item :: rest -> loop (item :: acc) rest
+    in
+    loop [] counts
+  in
+  let unsupported_request_count, unknown_request_count, unsupported_kinds =
+    List.fold_left
+      (fun (unsupported_count, unknown_count, kind_counts)
+        (request : Schedule_domain.schedule_request) ->
+         match Schedule_payload_projection.kind request with
+         | Some kind when schedule_payload_kind_supported kind ->
+           unsupported_count, unknown_count, kind_counts
+         | Some kind -> unsupported_count + 1, unknown_count, bump kind kind_counts
+         | None -> unsupported_count, unknown_count + 1, kind_counts)
+      (0, 0, []) schedules
+  in
+  let unsupported_kinds =
+    unsupported_kinds
+    |> List.sort (fun (left_kind, left_count) (right_kind, right_count) ->
+      match compare right_count left_count with
+      | 0 -> String.compare left_kind right_kind
+      | order -> order)
+    |> List.map (fun (kind, count) ->
+      `Assoc [ "kind", `String kind; "count", `Int count ])
+  in
+  `Assoc
+    [ ( "supported_kinds"
+      , `List (List.map (fun kind -> `String kind) schedule_supported_payload_kinds) )
+    ; "unsupported_request_count", `Int unsupported_request_count
+    ; "unsupported_kinds", `List unsupported_kinds
+    ; "unknown_request_count", `Int unknown_request_count
+    ]
+;;
+
 let schedule_request_active (request : Schedule_domain.schedule_request) =
   not (Schedule_domain.is_terminal request.status)
 ;;
@@ -1962,6 +2016,7 @@ let schedule_request_dashboard_json
       , match Schedule_payload_projection.kind request with
         | None -> `Null
         | Some kind -> `String kind )
+    ; "payload_support", `String (schedule_payload_support_status request)
     ; ( "payload_target"
       , match payload_target with
         | None -> `Null
@@ -2013,6 +2068,18 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
     |> List.filter (fun request -> not (schedule_effectively_expired ~now request))
     |> List.length
   in
+  let payload_support = schedule_payload_support_json schedules in
+  let unsupported_payload_kind_count, unknown_payload_kind_count =
+    match payload_support with
+    | `Assoc fields ->
+      ( (match List.assoc_opt "unsupported_request_count" fields with
+         | Some (`Int count) -> count
+         | _ -> 0)
+      , (match List.assoc_opt "unknown_request_count" fields with
+         | Some (`Int count) -> count
+         | _ -> 0) )
+    | _ -> 0, 0
+  in
   let sorted =
     schedules
     |> List.sort (fun left right ->
@@ -2045,7 +2112,10 @@ let scheduled_automation_dashboard_json (config : Workspace.config) : Yojson.Saf
           ; "blocked_approval", `Int blocked_approval_count
           ; "due_execution_ready", `Int due_execution_ready_count
           ; "expired_effective", `Int expired_effective_count
+          ; "unsupported_payload_kind", `Int unsupported_payload_kind_count
+          ; "unknown_payload_kind", `Int unknown_payload_kind_count
           ] )
+    ; "payload_support", payload_support
     ; ( "fsm"
       , `Assoc
           [ "state", `String (schedule_fsm_state ~now state schedules)

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1903,10 +1903,59 @@ let schedule_operator_action readiness =
   | None -> `Null
 ;;
 
-let schedule_keeper_next_tool readiness =
-  match Schedule_projection.keeper_next_tool_for_execution_readiness readiness with
-  | Some tool -> `String tool
+let tool_projection_surfaces_for tool_name =
+  let surfaces = ref [] in
+  let add_surface surface =
+    if not (List.exists (String.equal surface) !surfaces)
+    then surfaces := surface :: !surfaces
+  in
+  if Tool_catalog.is_public_mcp tool_name then add_surface "public_mcp";
+  Capability_registry.all_projection_seeds_from Config.raw_all_tool_schemas
+  |> List.iter (fun (seed : Capability_registry.capability_seed) ->
+    let surface = Capability_registry.surface_to_string seed.projection.surface in
+    if
+      (not (String.equal surface "public_mcp"))
+      && (String.equal seed.projection.tool_name tool_name
+          || String.equal seed.projection.backend_tool_name tool_name)
+    then add_surface surface);
+  List.sort String.compare !surfaces
+;;
+
+let schedule_keeper_next_tool_status_json = function
   | None -> `Null
+  | Some tool_name ->
+    let registered_schema =
+      List.exists
+        (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name tool_name)
+        Config.raw_all_tool_schemas
+    in
+    let dispatch_registered = Option.is_some (Tool_dispatch.lookup_tag tool_name) in
+    let metadata = Tool_catalog.metadata tool_name in
+    let surfaces = tool_projection_surfaces_for tool_name in
+    let effect_domain =
+      match metadata.effect_domain with
+      | None -> `Null
+      | Some domain -> `String (Tool_catalog.effect_domain_to_string domain)
+    in
+    `Assoc
+      [ "name", `String tool_name
+      ; "registered_schema", `Bool registered_schema
+      ; "dispatch_registered", `Bool dispatch_registered
+      ; "direct_call_allowed", `Bool (Tool_catalog.allow_direct_call tool_name)
+      ; "visibility", `String (Tool_catalog.visibility_to_string metadata.visibility)
+      ; ( "surfaces"
+        , `List (List.map (fun surface -> `String surface) surfaces) )
+      ; "surface_count", `Int (List.length surfaces)
+      ; "effect_domain", effect_domain
+      ; ( "read_only"
+        , match metadata.readonly with
+          | None -> `Null
+          | Some read_only -> `Bool read_only )
+      ; ( "requires_actor_binding"
+        , match metadata.requires_actor_binding with
+          | None -> `Null
+          | Some requires_actor_binding -> `Bool requires_actor_binding )
+      ]
 ;;
 
 let schedule_keeper_next_action readiness =
@@ -1977,6 +2026,9 @@ let schedule_request_dashboard_json
     Schedule_payload_projection.target_summary request
   in
   let execution_readiness = schedule_execution_readiness ~now state request in
+  let keeper_next_tool =
+    Schedule_projection.keeper_next_tool_for_execution_readiness execution_readiness
+  in
   `Assoc
     [ "schedule_id", `String request.schedule_id
     ; "status", `String (Schedule_domain.schedule_status_to_string request.status)
@@ -1984,7 +2036,11 @@ let schedule_request_dashboard_json
     ; ( "execution_readiness"
       , `String (Schedule_projection.execution_readiness_to_string execution_readiness) )
     ; "operator_action", schedule_operator_action execution_readiness
-    ; "keeper_next_tool", schedule_keeper_next_tool execution_readiness
+    ; ( "keeper_next_tool"
+      , match keeper_next_tool with
+        | None -> `Null
+        | Some tool -> `String tool )
+    ; "keeper_next_tool_status", schedule_keeper_next_tool_status_json keeper_next_tool
     ; "keeper_next_action", schedule_keeper_next_action execution_readiness
     ; "risk_class", `String (Schedule_domain.risk_class_to_string request.risk_class)
     ; "approval_required", `Bool request.approval_required

--- a/reports/keeper-schedule-dashboard-todo-2026-06-21.html
+++ b/reports/keeper-schedule-dashboard-todo-2026-06-21.html
@@ -1,0 +1,851 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Keeper Schedule Dashboard Todo</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f4;
+      --panel: #ffffff;
+      --panel-2: #f0f4f7;
+      --ink: #172026;
+      --muted: #627078;
+      --line: #d7dfdf;
+      --line-strong: #aebbbb;
+      --blue: #196f8f;
+      --blue-soft: #dff0f5;
+      --gold: #9a6a16;
+      --gold-soft: #f6ead0;
+      --red: #a3443f;
+      --red-soft: #f9dedb;
+      --green: #35745b;
+      --green-soft: #dceee5;
+      --mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+      --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      background: var(--bg);
+      color: var(--ink);
+      font-family: var(--sans);
+      letter-spacing: 0;
+    }
+
+    body {
+      margin: 0;
+      min-width: 320px;
+    }
+
+    a {
+      color: var(--blue);
+      text-decoration-color: rgba(25, 111, 143, 0.35);
+    }
+
+    code {
+      border: 1px solid var(--line);
+      border-radius: 5px;
+      background: #f8faf9;
+      color: #243038;
+      font-family: var(--mono);
+      font-size: 0.92em;
+      padding: 0.08rem 0.28rem;
+    }
+
+    .shell {
+      min-height: 100vh;
+    }
+
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      border-bottom: 1px solid var(--line);
+      background: rgba(246, 247, 244, 0.94);
+      backdrop-filter: blur(10px);
+    }
+
+    .topbar-inner,
+    .page {
+      width: min(1220px, calc(100vw - 40px));
+      margin: 0 auto;
+    }
+
+    .topbar-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      min-height: 58px;
+    }
+
+    .brand {
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+      min-width: 0;
+    }
+
+    .brand-mark {
+      border: 1px solid var(--line-strong);
+      border-radius: 6px;
+      background: #172026;
+      color: #f7f5ec;
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      padding: 5px 7px;
+      white-space: nowrap;
+    }
+
+    .brand-title {
+      overflow: hidden;
+      color: #263239;
+      font-size: 0.92rem;
+      font-weight: 700;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .meta-line {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 8px;
+      color: var(--muted);
+      font-family: var(--mono);
+      font-size: 0.74rem;
+      white-space: nowrap;
+    }
+
+    .page {
+      padding: 34px 0 56px;
+    }
+
+    .hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
+      gap: 22px;
+      align-items: stretch;
+      margin-bottom: 22px;
+    }
+
+    .hero-main,
+    .snapshot,
+    .section {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+      box-shadow: 0 16px 40px rgba(29, 43, 47, 0.06);
+    }
+
+    .hero-main {
+      padding: 26px;
+    }
+
+    .eyebrow {
+      margin: 0 0 12px;
+      color: var(--gold);
+      font-family: var(--mono);
+      font-size: 0.74rem;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      color: #111a1f;
+      font-size: clamp(2rem, 5vw, 4.4rem);
+      line-height: 0.98;
+      letter-spacing: 0;
+    }
+
+    .lead {
+      max-width: 820px;
+      margin: 18px 0 0;
+      color: #3c4a52;
+      font-size: 1.05rem;
+      line-height: 1.65;
+    }
+
+    .verdict {
+      display: inline-flex;
+      align-items: center;
+      margin-top: 20px;
+      border: 1px solid #e2b1ad;
+      border-radius: 999px;
+      background: var(--red-soft);
+      color: var(--red);
+      font-size: 0.82rem;
+      font-weight: 700;
+      padding: 8px 12px;
+    }
+
+    .snapshot {
+      display: grid;
+      grid-template-rows: auto 1fr;
+      padding: 18px;
+    }
+
+    .snapshot h2,
+    .section h2 {
+      margin: 0;
+      color: #1c282f;
+      font-size: 1rem;
+      letter-spacing: 0;
+    }
+
+    .snapshot-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 10px;
+      margin-top: 16px;
+    }
+
+    .metric {
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      background: #fbfcfb;
+      padding: 12px;
+    }
+
+    .metric-label {
+      color: var(--muted);
+      font-size: 0.72rem;
+      text-transform: uppercase;
+    }
+
+    .metric-value {
+      display: block;
+      margin-top: 5px;
+      color: #18242b;
+      font-family: var(--mono);
+      font-size: 1rem;
+      font-weight: 700;
+      overflow-wrap: anywhere;
+    }
+
+    .status-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin: 0 0 22px;
+    }
+
+    .status {
+      min-height: 120px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+      padding: 16px;
+    }
+
+    .status strong {
+      display: block;
+      color: #1d2b32;
+      font-size: 0.92rem;
+    }
+
+    .status span {
+      display: block;
+      margin-top: 8px;
+      color: var(--muted);
+      font-size: 0.88rem;
+      line-height: 1.5;
+    }
+
+    .status.done {
+      border-color: #afd1c1;
+      background: var(--green-soft);
+    }
+
+    .status.partial {
+      border-color: #d7c08e;
+      background: var(--gold-soft);
+    }
+
+    .status.missing {
+      border-color: #e1aaa6;
+      background: var(--red-soft);
+    }
+
+    .section {
+      margin-top: 22px;
+      padding: 22px;
+    }
+
+    .section-header {
+      display: flex;
+      align-items: start;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 16px;
+    }
+
+    .section-subtitle {
+      margin: 6px 0 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+      line-height: 1.55;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--panel-2);
+      color: #415058;
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      padding: 5px 8px;
+      white-space: nowrap;
+    }
+
+    .evidence-list {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .evidence-list li {
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      background: #fbfcfb;
+      padding: 12px;
+      color: #324149;
+      font-size: 0.9rem;
+      line-height: 1.55;
+    }
+
+    .table-wrap {
+      overflow-x: auto;
+      border: 1px solid var(--line);
+      border-radius: 7px;
+    }
+
+    table {
+      width: 100%;
+      min-width: 780px;
+      border-collapse: collapse;
+      background: #ffffff;
+      font-size: 0.88rem;
+    }
+
+    th,
+    td {
+      border-bottom: 1px solid var(--line);
+      padding: 11px 12px;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      background: #f1f5f5;
+      color: #4d5e66;
+      font-size: 0.72rem;
+      text-transform: uppercase;
+    }
+
+    tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      font-size: 0.72rem;
+      font-weight: 700;
+      padding: 4px 8px;
+      white-space: nowrap;
+    }
+
+    .pill.done {
+      background: var(--green-soft);
+      color: var(--green);
+    }
+
+    .pill.partial {
+      background: var(--gold-soft);
+      color: var(--gold);
+    }
+
+    .pill.missing,
+    .pill.p0 {
+      background: var(--red-soft);
+      color: var(--red);
+    }
+
+    .pill.p1 {
+      background: var(--gold-soft);
+      color: var(--gold);
+    }
+
+    .pill.p2 {
+      background: var(--blue-soft);
+      color: var(--blue);
+    }
+
+    .findings {
+      display: grid;
+      gap: 14px;
+    }
+
+    .finding {
+      border: 1px solid var(--line);
+      border-left: 5px solid var(--blue);
+      border-radius: 8px;
+      background: #ffffff;
+      padding: 16px;
+    }
+
+    .finding.p0 {
+      border-left-color: var(--red);
+    }
+
+    .finding.p1 {
+      border-left-color: var(--gold);
+    }
+
+    .finding.p2 {
+      border-left-color: var(--blue);
+    }
+
+    .finding-title {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+      margin: 0;
+      color: #18242b;
+      font-size: 1rem;
+    }
+
+    .finding p {
+      margin: 10px 0 0;
+      color: #3d4a52;
+      line-height: 1.58;
+    }
+
+    .finding ul {
+      margin: 10px 0 0 18px;
+      padding: 0;
+      color: #37464e;
+      line-height: 1.62;
+    }
+
+    .order-list {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      counter-reset: order;
+    }
+
+    .order-list li {
+      counter-increment: order;
+      display: grid;
+      grid-template-columns: 34px 1fr;
+      gap: 10px;
+      align-items: start;
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      background: #fbfcfb;
+      padding: 12px;
+      color: #35444b;
+      line-height: 1.45;
+    }
+
+    .order-list li::before {
+      content: counter(order);
+      display: grid;
+      width: 28px;
+      height: 28px;
+      place-items: center;
+      border-radius: 50%;
+      background: #172026;
+      color: #ffffff;
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      font-weight: 700;
+    }
+
+    .done-list {
+      margin: 0;
+      padding-left: 20px;
+      color: #33434b;
+      line-height: 1.7;
+    }
+
+    .footer {
+      margin-top: 22px;
+      color: var(--muted);
+      font-size: 0.8rem;
+      text-align: center;
+    }
+
+    @media (max-width: 880px) {
+      .topbar-inner,
+      .page {
+        width: min(100vw - 24px, 1220px);
+      }
+
+      .topbar-inner {
+        align-items: start;
+        flex-direction: column;
+        justify-content: center;
+        padding: 10px 0;
+      }
+
+      .meta-line {
+        justify-content: flex-start;
+        white-space: normal;
+      }
+
+      .hero,
+      .status-grid,
+      .evidence-list,
+      .order-list {
+        grid-template-columns: 1fr;
+      }
+
+      .hero-main {
+        padding: 20px;
+      }
+
+      .section {
+        padding: 18px;
+      }
+    }
+
+    @media print {
+      .topbar {
+        position: static;
+      }
+
+      .hero-main,
+      .snapshot,
+      .section,
+      .status,
+      .finding {
+        box-shadow: none;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <header class="topbar">
+      <div class="topbar-inner">
+        <div class="brand">
+          <span class="brand-mark">MASC</span>
+          <span class="brand-title">Keeper Schedule Dashboard Todo</span>
+        </div>
+        <div class="meta-line">
+          <span>2026-06-21 KST</span>
+          <span>/</span>
+          <span>base 2eed0aa224</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="page">
+      <section class="hero">
+        <div class="hero-main">
+          <p class="eyebrow">Adversarial implementation audit</p>
+          <h1>Schedule substrate exists. Keeper scheduling is not done.</h1>
+          <p class="lead">
+            Durable records, recurrence metadata, runner ticks, dispatch signals, schedule tools, keeper observations,
+            and a Tools/Lab panel are implemented. The missing product work is operational: supported job consumers,
+            callable tool surfaces, first-screen dashboard visibility, live runtime parity, and a successful end-to-end
+            smoke proof.
+          </p>
+          <span class="verdict">Verdict: Partial, not production-complete</span>
+        </div>
+
+        <aside class="snapshot">
+          <h2>Live Snapshot</h2>
+          <div class="snapshot-grid">
+            <div class="metric">
+              <span class="metric-label">Runtime release</span>
+              <span class="metric-value">0.19.47</span>
+            </div>
+            <div class="metric">
+              <span class="metric-label">Runtime source</span>
+              <span class="metric-value">76d88e2bc0</span>
+            </div>
+            <div class="metric">
+              <span class="metric-label">Repo head</span>
+              <span class="metric-value">2eed0aa224</span>
+            </div>
+            <div class="metric">
+              <span class="metric-label">Schedule state</span>
+              <span class="metric-value">failed 2 / expired 2 / active 0</span>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section class="status-grid" aria-label="Status summary">
+        <div class="status done">
+          <strong>Implemented</strong>
+          <span>Domain, store, service, runner, signals, schedule tools, board-post consumer, prompt observation, Tools/Lab panel.</span>
+        </div>
+        <div class="status partial">
+          <strong>Partial</strong>
+          <span>Dashboard projection and keeper next-action model exist on main, but live runtime is behind and tool surfaces are inactive.</span>
+        </div>
+        <div class="status missing">
+          <strong>Missing</strong>
+          <span>Broad Keeper job consumers, operational dashboard card, UI actions, parser drift guard, and live happy-path smoke.</span>
+        </div>
+        <div class="status missing">
+          <strong>Current Risk</strong>
+          <span>Live schedules include unsupported payload kinds, so records can exist while the runner cannot actually do the work.</span>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <div>
+            <h2>Evidence</h2>
+            <p class="section-subtitle">Local code paths and live runtime endpoints used for the audit.</p>
+          </div>
+          <span class="tag">checked live + main</span>
+        </div>
+        <ul class="evidence-list">
+          <li><strong>Schedule core:</strong> <code>lib/schedule/schedule_domain.mli</code>, <code>schedule_store.mli</code>, <code>schedule_service.mli</code>, <code>schedule_runner.ml</code></li>
+          <li><strong>Runtime loop:</strong> <code>lib/server/server_bootstrap_maintenance.ml</code>, <code>lib/server/server_runtime_bootstrap.ml</code></li>
+          <li><strong>Consumer:</strong> <code>lib/server/server_schedule_consumers.ml</code> supports only <code>masc.board_post</code></li>
+          <li><strong>Tools:</strong> <code>lib/tool_schemas/tool_schemas_schedule.ml</code>, <code>lib/tool_schedule.ml</code>, <code>lib/keeper/keeper_tool_descriptor.ml</code></li>
+          <li><strong>Keeper prompt:</strong> <code>lib/keeper/keeper_world_observation.ml</code>, <code>lib/keeper/keeper_unified_prompt.ml</code>, <code>lib/schedule_projection.ml</code></li>
+          <li><strong>Dashboard:</strong> <code>server_dashboard_http_runtime_info.ml</code>, <code>dashboard/src/api/dashboard.ts</code>, <code>ScheduledAutomationPanel</code></li>
+          <li><strong>Live endpoint:</strong> <code>GET /health?full=1</code> reports runtime source <code>76d88e2bc0</code> while repo head is <code>2eed0aa224</code></li>
+          <li><strong>Live tools:</strong> schedule tools are registered and directly callable, but have <code>surfaces=[]</code> and <code>enabled_in_current_mode=false</code></li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <div>
+            <h2>Implementation Matrix</h2>
+            <p class="section-subtitle">What exists, what is partial, and what still blocks calling this complete.</p>
+          </div>
+          <span class="tag">feature readiness</span>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Area</th>
+                <th>Status</th>
+                <th>Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Durable schedule model</td>
+                <td><span class="pill done">Done</span></td>
+                <td>Actor/risk/status/source, recurrence, payload envelope, grants, execution records.</td>
+              </tr>
+              <tr>
+                <td>Durable store</td>
+                <td><span class="pill done">Done</span></td>
+                <td><code>schedules.json</code>, last-good recovery, due refresh, recurring reschedule, candidate lifecycle.</td>
+              </tr>
+              <tr>
+                <td>Schedule service</td>
+                <td><span class="pill done">Done</span></td>
+                <td>Create/list/get/approve/reject/cancel/due-candidate API. It intentionally does not execute work.</td>
+              </tr>
+              <tr>
+                <td>Runtime runner</td>
+                <td><span class="pill done">Done</span></td>
+                <td>Background maintenance fiber ticks <code>Schedule_runner.tick</code> and emits due/blocked signals.</td>
+              </tr>
+              <tr>
+                <td>Concrete job consumers</td>
+                <td><span class="pill partial">Partial</span></td>
+                <td>Only <code>masc.board_post</code> is accepted. Live records include unsupported payload kinds.</td>
+              </tr>
+              <tr>
+                <td>Schedule tools</td>
+                <td><span class="pill partial">Partial</span></td>
+                <td>Schemas and dispatch exist, but active dashboard tool surface exposure is empty.</td>
+              </tr>
+              <tr>
+                <td>Dashboard API projection</td>
+                <td><span class="pill partial">Partial</span></td>
+                <td>Main emits <code>scheduled_automation</code> request rows and keeper next actions. Live server is stale.</td>
+              </tr>
+              <tr>
+                <td>Dashboard UI</td>
+                <td><span class="pill partial">Partial</span></td>
+                <td>Tools/Lab panel renders the table. Main operational dashboard exposure is still missing.</td>
+              </tr>
+              <tr>
+                <td>Operator actions in UI</td>
+                <td><span class="pill missing">Missing</span></td>
+                <td>No approve/reject/cancel/get/create affordances or deep links.</td>
+              </tr>
+              <tr>
+                <td>Live happy-path proof</td>
+                <td><span class="pill missing">Missing</span></td>
+                <td>Current live state only proves terminal/unsupported/expired cases.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <div>
+            <h2>Adversarial Findings</h2>
+            <p class="section-subtitle">Prioritized work items. P0 items are correctness or trust blockers.</p>
+          </div>
+          <span class="tag">todo</span>
+        </div>
+        <div class="findings">
+          <article class="finding p0">
+            <h3 class="finding-title"><span class="pill p0">P0</span> Live dashboard is stale relative to inspected main</h3>
+            <p>Live runtime reports source snapshot <code>76d88e2bc0</code>, while repo head is <code>2eed0aa224</code>. The latest schedule dashboard and keeper next-action work cannot be assumed deployed.</p>
+            <ul>
+              <li>Rebuild/restart from current main.</li>
+              <li>Re-check <code>/api/v1/dashboard/tools</code>.</li>
+              <li>Require matching runtime/source identity or known binary commit before calling the dashboard current.</li>
+            </ul>
+          </article>
+
+          <article class="finding p0">
+            <h3 class="finding-title"><span class="pill p0">P0</span> Prompt suggests schedule tools that are not exposed</h3>
+            <p>Keeper prompt/read-model can recommend <code>masc_schedule_get</code>, <code>masc_schedule_approve</code>, and <code>masc_schedule_reject</code>, but live inventory reports every schedule tool with no active surface.</p>
+            <ul>
+              <li>Decide the intended schedule tool surface: operator-only, keeper-internal, or both.</li>
+              <li>Add all six <code>masc_schedule_*</code> tools to the proper catalog/surface.</li>
+              <li>Add regression coverage for descriptor registration and active exposure.</li>
+            </ul>
+          </article>
+
+          <article class="finding p0">
+            <h3 class="finding-title"><span class="pill p0">P0</span> Existing live schedules use unsupported payload kinds</h3>
+            <p>The only concrete consumer supports <code>masc.board_post</code>. Live records include <code>orphan_auto_release</code>, <code>keeper_surface_post</code>, <code>task_goal_generation</code>, and <code>backlog_depletion_check</code>.</p>
+            <ul>
+              <li>Add a consumer registry that declares supported payload kinds.</li>
+              <li>Implement or retire the currently observed payload kinds.</li>
+              <li>Surface unsupported payload kind counts and remediation in the dashboard.</li>
+            </ul>
+          </article>
+
+          <article class="finding p1">
+            <h3 class="finding-title"><span class="pill p1">P1</span> Dashboard exposure is buried in Tools/Lab</h3>
+            <p>The full panel is useful for investigation, but it is weak as system monitoring. Operators can miss blocked approvals or failed schedules unless they open the tool inventory page.</p>
+            <ul>
+              <li>Add a compact scheduled automation card to the overview/runtime/attention area.</li>
+              <li>Show FSM state, next due, blocked approval count, due-ready count, and unsupported failures.</li>
+              <li>Link to the full Tools/Lab table.</li>
+            </ul>
+          </article>
+
+          <article class="finding p1">
+            <h3 class="finding-title"><span class="pill p1">P1</span> UI is read-only where operators need decisions</h3>
+            <p>The panel renders readiness and approval policy, but does not let the operator inspect, approve, reject, cancel, or recreate from the dashboard.</p>
+            <ul>
+              <li>Add action affordances for get, approve, reject, cancel, and recreate.</li>
+              <li>Gate side-effecting actions behind the existing human grant model.</li>
+              <li>Render the result back into the row status or last-execution area.</li>
+            </ul>
+          </article>
+
+          <article class="finding p1">
+            <h3 class="finding-title"><span class="pill p1">P1</span> Runtime parser coverage is thin</h3>
+            <p>The TypeScript type and component fixture exist, but there is no strong runtime parser or schema drift guard around <code>scheduled_automation</code>.</p>
+            <ul>
+              <li>Add dashboard API normalization for the projection.</li>
+              <li>Totalize optional fields and warn on missing required fields.</li>
+              <li>Fixture active, blocked approval, unsupported failure, and stale projection cases.</li>
+            </ul>
+          </article>
+
+          <article class="finding p1">
+            <h3 class="finding-title"><span class="pill p1">P1</span> No live-safe happy-path smoke exists</h3>
+            <p>Current live state proves terminal and unsupported cases, not due approved supported schedule to successful execution record.</p>
+            <ul>
+              <li>Add a safe no-op payload kind or live-safe board-post smoke fixture.</li>
+              <li>Capture before/after dashboard projection evidence.</li>
+            </ul>
+          </article>
+
+          <article class="finding p2">
+            <h3 class="finding-title"><span class="pill p2">P2</span> Runner liveness is not first-class</h3>
+            <p>The panel derives schedule state, but does not show last runner tick, last dispatch attempt, or stale-runner warnings.</p>
+            <ul>
+              <li>Add last tick time, last tick error, and emitted/dispatch/rescheduled counters.</li>
+              <li>Surface stale-runner state in the overview card and full panel.</li>
+            </ul>
+          </article>
+
+          <article class="finding p2">
+            <h3 class="finding-title"><span class="pill p2">P2</span> Recurrence is under-explained operationally</h3>
+            <p>The model supports recurrence and fixed-offset timezone contracts, but the UI mainly displays summaries.</p>
+            <ul>
+              <li>Add previous-run, next-run, and recurrence explanation fields.</li>
+              <li>Test daily fixed-offset behavior around date boundaries.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <div>
+            <h2>Recommended Next Order</h2>
+            <p class="section-subtitle">Shortest path from partial substrate to trustworthy operator product.</p>
+          </div>
+          <span class="tag">execution order</span>
+        </div>
+        <ol class="order-list">
+          <li>Rebuild/restart runtime and re-check dashboard projection parity.</li>
+          <li>Fix schedule tool surface exposure or remove tool-call instructions from keeper prompts.</li>
+          <li>Add consumer registry plus unsupported payload visibility.</li>
+          <li>Move a compact schedule status card into the main operational dashboard.</li>
+          <li>Add one live-safe happy-path smoke.</li>
+          <li>Add dashboard parser and fixture tests around <code>scheduled_automation</code>.</li>
+        </ol>
+      </section>
+
+      <section class="section">
+        <div class="section-header">
+          <div>
+            <h2>Done Criteria</h2>
+            <p class="section-subtitle">Do not call Keeper scheduling complete until these are true.</p>
+          </div>
+          <span class="tag">release gate</span>
+        </div>
+        <ul class="done-list">
+          <li>Current runtime is built from current main or exposes a known binary commit.</li>
+          <li>The dashboard can show active, due, blocked, failed, and succeeded schedules.</li>
+          <li>The dashboard exposes blocked approvals in an operational surface, not only Tools/Lab.</li>
+          <li>Keeper prompts only mention schedule tools that are actually callable in that context.</li>
+          <li>Unsupported payload kinds cannot quietly become terminal surprises.</li>
+          <li>At least one supported schedule completes end-to-end and leaves an execution record visible in the dashboard.</li>
+        </ul>
+      </section>
+
+      <p class="footer">Generated from the Keeper schedule dashboard audit report. Saved as a standalone local HTML file.</p>
+    </main>
+  </div>
+</body>
+</html>

--- a/reports/keeper-schedule-dashboard-todo-2026-06-21.md
+++ b/reports/keeper-schedule-dashboard-todo-2026-06-21.md
@@ -1,0 +1,268 @@
+# Keeper Schedule Dashboard Todo
+
+Date: 2026-06-21 KST
+Scope: keeper scheduled automation implementation and dashboard exposure.
+Base revision inspected: `2eed0aa22454cec6b2ec747dbdb468890ea8527f` (`origin/main` at inspection time).
+
+## Verdict
+
+The schedule substrate is real, but the operator-facing product is not done.
+
+Implemented: durable schedule records, recurrence metadata, separate human grant policy, due scanning, dispatch signals, schedule tools, a board-post consumer, keeper prompt observations, and a Tools/Lab dashboard panel.
+
+Not done: broad keeper job execution, active tool-surface exposure, top-level system dashboard visibility, live deployment parity, and an end-to-end live happy-path proof. Current live data also contains schedules for payload kinds that the only server consumer does not support.
+
+## Evidence
+
+Code paths inspected:
+
+- Schedule domain/store/service/runner:
+  - `lib/schedule/schedule_domain.mli`
+  - `lib/schedule/schedule_store.mli`
+  - `lib/schedule/schedule_service.mli`
+  - `lib/schedule/schedule_runner.mli`
+  - `lib/schedule/schedule_runner.ml`
+- Server loop:
+  - `lib/server/server_bootstrap_maintenance.ml`
+  - `lib/server/server_runtime_bootstrap.ml`
+- Concrete consumers:
+  - `lib/server/server_schedule_consumers.ml`
+- Tool schema and dispatch:
+  - `lib/tool_schemas/tool_schemas_schedule.ml`
+  - `lib/tool_schedule.ml`
+  - `lib/keeper/keeper_tool_descriptor.ml`
+- Keeper read model and prompt:
+  - `lib/keeper/keeper_world_observation.ml`
+  - `lib/keeper/keeper_unified_prompt.ml`
+  - `lib/schedule_projection.ml`
+- Dashboard API and UI:
+  - `lib/server/server_dashboard_http_runtime_info.ml`
+  - `dashboard/src/api/dashboard.ts`
+  - `dashboard/src/components/tools/tools-main.ts`
+  - `dashboard/src/components/tools/scheduled-automation-panel.ts`
+  - `dashboard/src/components/tools/tools-main.test.ts`
+
+Live runtime checked:
+
+- `GET http://127.0.0.1:8935/health?full=1`
+- `GET http://127.0.0.1:8935/api/v1/dashboard/tools`
+- Live release: `0.19.47`
+- Live runtime source snapshot: `76d88e2bc0`
+- Repo head / inspected main: `2eed0aa224`
+- Runtime warning: source snapshot differs from server repo HEAD; rebuild/restart is required before trusting dashboard identity.
+- Live schedule projection exists with schema `masc.dashboard.scheduled_automation.v1`.
+- Live schedule counts: `failed=2`, `expired=2`, all active/due/blocked counts are `0`.
+- Live scheduled payload kinds:
+  - `backlog_depletion_check` -> expired
+  - `orphan_auto_release` -> failed, unsupported payload kind
+  - `task_goal_generation` -> expired
+  - `keeper_surface_post` -> failed, unsupported payload kind
+- Live schedule tools:
+  - `masc_schedule_create`
+  - `masc_schedule_list`
+  - `masc_schedule_get`
+  - `masc_schedule_cancel`
+  - `masc_schedule_approve`
+  - `masc_schedule_reject`
+- All live schedule tools report `direct_call_allowed=true` and `dispatch_registered=true`, but `surfaces=[]` and `enabled_in_current_mode=false`.
+
+## Implementation Matrix
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Durable schedule model | Done | Actor/risk/status/source, one-shot/interval/daily/cron recurrence, payload envelope, grants, execution records. |
+| Durable store | Done | `schedules.json`, last-good recovery, due refresh, recurring reschedule, due candidate start/complete/fail paths. |
+| Schedule service | Done | Create/list/get/approve/reject/cancel/due-candidate API. It intentionally does not execute work. |
+| Runtime runner | Done | Background maintenance fiber ticks `Schedule_runner.tick` and emits due/blocked signals. |
+| At-most-once signal ledger | Done | Signal files and signal-key ledger exist under `.masc/schedules`. |
+| Concrete job consumers | Partial | Only `masc.board_post` is accepted by `Server_schedule_consumers`. Existing live payload kinds are mostly unsupported. |
+| Schedule tools | Partial | Schemas and dispatch exist, but live dashboard says schedule tools have no active tool surface. |
+| Keeper prompt observation | Partial | Main has scheduled automation prompt/read-model wiring. Live runtime is behind and lacks the newest keeper next-action row fields. |
+| Dashboard API projection | Partial | Main emits `scheduled_automation` with request rows and keeper next actions. Live server is stale relative to main. |
+| Dashboard UI | Partial | Tools/Lab panel renders FSM, counts, requests, readiness, payload, recurrence, and last run. It is not visible in the first operational/system view. |
+| Operator actions in UI | Missing | The panel is read-only; no approve/reject/cancel/get/create affordances or deep links are wired. |
+| Live happy-path proof | Missing | No active due/approved supported schedule is present. Current live state only proves terminal/unsupported/expired cases. |
+
+## Adversarial Findings
+
+### P0-1: Live dashboard is stale relative to inspected main
+
+Current live runtime reports source snapshot `76d88e2bc0`, while repo head is `2eed0aa224`. The latest schedule dashboard and keeper next-action work is on main but cannot be assumed deployed.
+
+Impact: an operator looking at the dashboard can see incomplete schedule rows and may misdiagnose UI bugs that are actually stale binary/runtime identity.
+
+Todo:
+
+- Rebuild/restart the runtime from current main.
+- Re-check `/api/v1/dashboard/tools` after restart.
+- Require `runtime_repo_head_git_commit == server_repo_git_commit` or a known binary commit before calling the schedule dashboard current.
+
+Acceptance:
+
+- Runtime identity no longer warns about `76d88e2bc0` vs `2eed0aa224`.
+- `scheduled_automation.requests[*].keeper_next_tool` and `keeper_next_action` appear for non-terminal rows on a fresh runtime.
+
+### P0-2: Prompt suggests schedule tools that are not exposed in the active surface
+
+The keeper prompt/read-model can tell keepers to use `masc_schedule_get`, `masc_schedule_approve`, or `masc_schedule_reject`. Live tool inventory reports every `masc_schedule_*` tool with `surfaces=[]` and `enabled_in_current_mode=false`.
+
+Impact: the system can generate a next action that the active tool surface does not advertise as usable. This is a contract mismatch, not a cosmetic issue.
+
+Todo:
+
+- Decide the intended schedule tool surface: operator-only, keeper-internal, or both.
+- Add the six `masc_schedule_*` tools to the proper `Tool_catalog_surfaces` / keeper tool surface.
+- Add a regression test that checks both descriptor registration and active surface exposure.
+- If these tools must stay hidden, remove or rewrite keeper prompt actions that instruct keepers to call them.
+
+Acceptance:
+
+- Dashboard tool inventory shows schedule tools enabled on the intended surface.
+- Keeper prompt next actions only reference tools that the keeper can actually call.
+
+### P0-3: Existing live schedules use unsupported payload kinds
+
+The only concrete consumer supports `masc.board_post`. Live schedule records include `orphan_auto_release`, `keeper_surface_post`, `task_goal_generation`, and `backlog_depletion_check`.
+
+Impact: "schedule job" exists as a ledger, but not as a general Keeper schedule worker. Real-looking jobs either expire silently or fail as unsupported. This will erode trust quickly because the dashboard can show a schedule while the runner cannot do the work.
+
+Todo:
+
+- Add a consumer registry that declares supported payload kinds.
+- Implement or explicitly retire the currently observed payload kinds:
+  - `keeper_surface_post`
+  - `orphan_auto_release`
+  - `task_goal_generation`
+  - `backlog_depletion_check`
+- Surface unsupported payload kind counts in the dashboard summary.
+- Avoid permanently failing unsupported payloads without a remediation path, or make the terminal failure explicitly actionable.
+
+Acceptance:
+
+- Creating a schedule with an unsupported payload kind fails at create time or is displayed as unsupported before due time.
+- Existing unsupported schedule records have a documented migration/remediation path.
+
+### P1-1: Dashboard exposure is buried in Tools/Lab
+
+`ScheduledAutomationPanel` is mounted in the tools inventory page. That is useful for debugging, but weak for "system dashboard" monitoring.
+
+Impact: an operator watching the main dashboard/keeper detail/attention surfaces can miss a blocked approval or failed schedule unless they know to open Tools/Lab.
+
+Todo:
+
+- Add a compact scheduled automation card to the system overview or runtime/attention area.
+- Show at least: FSM state, next due, blocked approval count, due-ready count, failed unsupported count.
+- Link from the compact card to the full Tools/Lab panel.
+
+Acceptance:
+
+- Blocked approval and due-ready schedule states are visible without opening the tool inventory.
+- The full table remains available for investigation.
+
+### P1-2: UI is read-only where operators need decisions
+
+The panel renders `operator_action`, `approval_policy`, and readiness, but does not expose approve/reject/cancel/get actions.
+
+Impact: the dashboard tells the operator a decision is needed but forces a manual tool call outside the UI.
+
+Todo:
+
+- Add explicit action affordances for:
+  - `masc_schedule_get`
+  - `masc_schedule_approve`
+  - `masc_schedule_reject`
+  - `masc_schedule_cancel`
+- Gate side-effecting actions behind the existing human grant model.
+- Keep action results visible in the row's last execution / status area.
+
+Acceptance:
+
+- A blocked approval can be inspected and approved/rejected from the dashboard.
+- A terminal/expired schedule can be inspected and recreated intentionally.
+
+### P1-3: Runtime parser coverage is thin
+
+The TypeScript API type declares `scheduled_automation`, and the component test renders a fixture. There is no strong runtime parser or schema drift guard around this projection.
+
+Impact: backend field drift can silently degrade the UI. The live/main mismatch around newer row fields is exactly the kind of issue this should catch.
+
+Todo:
+
+- Add a dashboard API normalization/parser for `scheduled_automation`.
+- Totalize missing optional fields, but fail or warn on missing required fields such as `requests`, `counts`, and `fsm`.
+- Add fixture tests for:
+  - active scheduled item
+  - blocked approval
+  - unsupported payload failure
+  - stale/older projection without keeper next-action fields
+
+Acceptance:
+
+- A malformed `scheduled_automation` response produces an explicit UI/API warning instead of silent blank or partial rendering.
+
+### P1-4: No live-safe happy-path smoke exists
+
+Current live state proves terminal records and unsupported payload failures, not successful due dispatch.
+
+Impact: the runtime may look wired while the most important path, due approved supported schedule -> consumer dispatch -> execution record -> dashboard update, remains unproven.
+
+Todo:
+
+- Add a safe no-op or test-only schedule payload kind, or a live-safe `masc.board_post` smoke fixture.
+- Run the smoke against `/Users/dancer/me/.masc` only when explicitly intended.
+- Capture before/after dashboard projection evidence.
+
+Acceptance:
+
+- One due schedule transitions through ready/running/succeeded in a local smoke without corrupting operational board state.
+
+### P2-1: Runner liveness is not a first-class dashboard signal
+
+The schedule panel derives schedule state, but it does not show the last runner tick, last dispatch attempt, or stale-runner warning.
+
+Impact: if the scheduler fiber dies or stops ticking, operators may see stale scheduled rows without an obvious scheduler-health failure.
+
+Todo:
+
+- Add runner telemetry: last tick time, last tick error, emitted/dispatch/rescheduled counters.
+- Surface stale-runner state in the overview card and full panel.
+
+Acceptance:
+
+- Killing or breaking the schedule runner produces a visible dashboard warning.
+
+### P2-2: Recurrence is metadata-rich but operationally under-explained
+
+The model supports interval/daily/cron/fixed-offset timezone contracts, but the UI mainly displays summaries.
+
+Impact: recurring schedules can be hard to audit for "why did this run now?" or "when will it run next?".
+
+Todo:
+
+- Add next-run and previous-run fields for recurring schedules.
+- Add a recurrence explanation string in the projection.
+- Add tests for daily fixed-offset behavior around date boundaries.
+
+Acceptance:
+
+- A recurring schedule row explains last due, next due, timezone offset, and reschedule outcome.
+
+## Recommended Next Order
+
+1. Rebuild/restart runtime and re-check dashboard projection parity.
+2. Fix schedule tool surface exposure or remove tool-call instructions from keeper prompts.
+3. Add consumer registry plus unsupported payload visibility.
+4. Move a compact schedule status card into the main operational dashboard.
+5. Add one live-safe happy-path smoke.
+6. Add dashboard parser/fixture tests around `scheduled_automation`.
+
+## Done Criteria For This Feature
+
+Do not call Keeper scheduling "done" until all of these are true:
+
+- Current runtime is built from current main or exposes a known binary commit.
+- The dashboard can show active, due, blocked, failed, and succeeded schedules.
+- The dashboard exposes blocked approvals in an operational surface, not only Tools/Lab.
+- Keeper prompts only mention schedule tools that are actually callable in that context.
+- Unsupported payload kinds cannot quietly become terminal surprises.
+- At least one supported schedule completes end-to-end and leaves an execution record visible in the dashboard.

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -619,6 +619,21 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     (due_row |> member "operator_action" |> to_string);
   check string "due keeper next tool" "masc_schedule_get"
     (due_row |> member "keeper_next_tool" |> to_string);
+  let due_tool_status = due_row |> member "keeper_next_tool_status" in
+  check string "due keeper next tool status name" "masc_schedule_get"
+    (due_tool_status |> member "name" |> to_string);
+  check bool "due keeper next tool schema registered" true
+    (due_tool_status |> member "registered_schema" |> to_bool);
+  check bool "due keeper next tool dispatch registered" true
+    (due_tool_status |> member "dispatch_registered" |> to_bool);
+  check bool "due keeper next tool direct callable" true
+    (due_tool_status |> member "direct_call_allowed" |> to_bool);
+  check string "due keeper next tool hidden visibility" "hidden"
+    (due_tool_status |> member "visibility" |> to_string);
+  check int "due keeper next tool has no surface projection" 0
+    (due_tool_status |> member "surface_count" |> to_int);
+  check string "due keeper next tool read-only domain" "read_only"
+    (due_tool_status |> member "effect_domain" |> to_string);
   check bool "due keeper action mentions runner tick" true
     (String_util.contains_substring
        (due_row |> member "keeper_next_action" |> to_string)

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -26,6 +26,14 @@ let payload =
     ]
 ;;
 
+let board_post_payload =
+  `Assoc
+    [ "kind", `String "masc.board_post"
+    ; "schema_version", `Int 1
+    ; "body", `Assoc [ "content", `String "scheduled board post" ]
+    ]
+;;
+
 let create_fields =
   [ "due_at_unix", `Float 200.0
   ; "risk_class", `String "read_only"
@@ -461,6 +469,7 @@ let test_dispatch_cancel_persists_status () =
 let create_schedule_exn
   config
   ?expires_at
+  ?(payload = payload)
   ?recurrence
   ~schedule_id
   ~due_at
@@ -515,7 +524,8 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
       : Schedule_domain.schedule_request);
   ignore
     (create_schedule_exn config ~schedule_id:"sched-approval" ~due_at:future_due
-       ~risk_class:Schedule_domain.Workspace_write ~requested_by:(human "operator")
+       ~payload:board_post_payload ~risk_class:Schedule_domain.Workspace_write
+       ~requested_by:(human "operator")
        ~scheduled_by:(automated "scheduler-agent")
        ()
       : Schedule_domain.schedule_request);
@@ -557,6 +567,24 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     (json |> member "derived_counts" |> member "due_execution_ready" |> to_int);
   check int "expired effective count" 1
     (json |> member "derived_counts" |> member "expired_effective" |> to_int);
+  check int "unsupported payload count" 4
+    (json |> member "derived_counts" |> member "unsupported_payload_kind" |> to_int);
+  check int "unknown payload count" 0
+    (json |> member "derived_counts" |> member "unknown_payload_kind" |> to_int);
+  check int "payload support unsupported count" 4
+    (json |> member "payload_support" |> member "unsupported_request_count" |> to_int);
+  check int "payload support unknown count" 0
+    (json |> member "payload_support" |> member "unknown_request_count" |> to_int);
+  check string "supported payload kind" "masc.board_post"
+    (json |> member "payload_support" |> member "supported_kinds" |> to_list
+     |> List.hd |> to_string);
+  (match json |> member "payload_support" |> member "unsupported_kinds" |> to_list with
+   | unsupported :: _ ->
+     check string "unsupported payload kind" "test.reminder"
+       (unsupported |> member "kind" |> to_string);
+     check int "unsupported payload kind count" 4
+       (unsupported |> member "count" |> to_int)
+   | [] -> fail "expected unsupported payload kind summary");
   let requests = json |> member "requests" |> to_list in
   let find_request schedule_id =
     match
@@ -568,6 +596,8 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     | None -> fail ("schedule missing from dashboard projection: " ^ schedule_id)
   in
   let due_row = find_request "sched-due" in
+  check string "due payload unsupported" "unsupported"
+    (due_row |> member "payload_support" |> to_string);
   check string "due recurrence kind" "daily"
     (due_row |> member "recurrence_kind" |> to_string);
   check string "due recurrence object kind" "daily"
@@ -594,6 +624,8 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
        (due_row |> member "keeper_next_action" |> to_string)
        "runner tick");
   let blocked_row = find_request "sched-blocked" in
+  check string "blocked payload unsupported" "unsupported"
+    (blocked_row |> member "payload_support" |> to_string);
   check bool "blocked separate grant" true
     (blocked_row |> member "requires_separate_human_grant" |> to_bool);
   check string "blocked approval policy" "separate_human_grant_required"
@@ -611,6 +643,8 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
        (blocked_row |> member "keeper_next_action" |> to_string)
        "dashboard operator approval or rejection");
   let expired_row = find_request "sched-expired-effective" in
+  check string "expired payload unsupported" "unsupported"
+    (expired_row |> member "payload_support" |> to_string);
   check string "expired effective status" "expired"
     (expired_row |> member "effective_status" |> to_string);
   check string "expired readiness" "expired"
@@ -628,6 +662,9 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
       (fun row -> String.equal (row |> member "schedule_id" |> to_string) "sched-exec")
       requests
   in
+  let supported_row = find_request "sched-approval" in
+  check string "supported board payload" "supported"
+    (supported_row |> member "payload_support" |> to_string);
   match exec_row with
   | None -> fail "sched-exec missing from dashboard projection"
   | Some row ->


### PR DESCRIPTION
## Summary
- Add a Keeper scheduled automation dashboard audit/TODO report with point-in-time live-runtime evidence and P0/P1/P2 follow-up items.
- Surface scheduled-automation payload support from `Server_schedule_consumers.supported_payload_kinds`, including unsupported/unknown counts and per-row support labels in the dashboard API/UI.
- Expose keeper next-tool diagnostics for schedule rows: schema registration, dispatch/direct-call policy, visibility, projected surfaces, effect domain, read-only status, and actor-binding requirements.
- Fix the env-knob catalog generator so typed getter aliases such as `MASC_DISABLE_HITL` are captured, then regenerate `docs/runtime-tunables.md` from the fixed generator.
- Add focused backend projection and dashboard coverage for the new schedule diagnostics.

## Verification
- CI on head `7989f90936ee361d1cfb2e014354367c379c47a2`: `CI Gate`, `Build and Test`, `Dashboard`, `Lint`, `Health`, and changed-file `ocamlformat-check` passed.
- `git diff --check origin/main...HEAD`
- `opam exec -- ocamlformat --check lib/server/server_dashboard_http_runtime_info.ml test/test_schedule_tool_wiring.ml`
- Dashboard typecheck: `tsc --noEmit --pretty false`
- Dashboard tests: `src/components/tools/tools-main.test.ts` + `src/components/tools/scheduled-automation-panel.test.ts`
- Env-knob generator was run through the OCaml interpreter to a temp output and compared against `docs/runtime-tunables.md`.

## Notes
- This is not docs-only: it changes backend dashboard projection, dashboard API types/UI, tests, the env-knob catalog generator, and generated runtime-tunables docs.
- No local Dune build was run for the latest head per operator instruction; CI is the build/test authority for this PR.
- Live-runtime URLs in the audit report are point-in-time evidence from the report pass, not proof that the latest PR head is deployed in the local runtime.
- Schedule action tools remain hidden/no-surface where policy requires it; this PR makes those affordance gaps visible instead of widening operator surfaces.
