### PR TITLE
feat(dashboard): drag-resizable roster/rail panes with persisted widths (keeper-v2 Unit 8)

### DIFF
--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -40,6 +40,7 @@ import { KeeperDetailBody } from './keeper-detail-body'
 import { KeeperWorkspaceRoster } from './keeper-workspace/keeper-workspace-roster'
 import { KeeperWorkspaceChat } from './keeper-workspace/keeper-workspace-chat'
 import { KeeperWorkspaceRail } from './keeper-workspace/keeper-workspace-rail'
+import { beginPaneResize, rosterWidth, railWidth } from './keeper-workspace/keeper-workspace-pane-resize'
 import { ringFocusClasses } from './common/ring'
 
 const CLOSE_BUTTON_FOCUS_CLASS = ringFocusClasses({
@@ -121,23 +122,29 @@ function KeeperDetailResolver({
   return html`<${KeeperDetailContent} keeper=${keeper} routeSurface=${routeSurface} />`
 }
 
-function useIsKeeperWorkspaceMobile(): boolean {
+// Breakpoints mirror keeper-workspace.css responsive bands: at <=1180px the
+// context-rail column is dropped, at <=860px the layout collapses to a single
+// mobile pane.
+const KW_MOBILE_QUERY = '(max-width: 860px)'
+const KW_NARROW_QUERY = '(max-width: 1180px)'
+
+function useMatchMedia(query: string): boolean {
   const getInitial = () =>
     typeof window !== 'undefined' &&
     typeof window.matchMedia === 'function' &&
-    window.matchMedia('(max-width: 860px)').matches
-  const [isMobile, setIsMobile] = useState(getInitial)
+    window.matchMedia(query).matches
+  const [matches, setMatches] = useState(getInitial)
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
-    const media = window.matchMedia('(max-width: 860px)')
-    const update = () => setIsMobile(media.matches)
+    const media = window.matchMedia(query)
+    const update = () => setMatches(media.matches)
     update()
     media.addEventListener('change', update)
     return () => media.removeEventListener('change', update)
-  }, [])
+  }, [query])
 
-  return isMobile
+  return matches
 }
 
 const KeeperDetailContent = memo(function KeeperDetailContent({
@@ -163,7 +170,10 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
   const [configOverlayKeeper, setConfigOverlayKeeper] = useState<string | null>(null)
   const [rosterOpen, setRosterOpen] = useState(true)
   const [railOpen, setRailOpen] = useState(true)
-  const isMobile = useIsKeeperWorkspaceMobile()
+  const isMobile = useMatchMedia(KW_MOBILE_QUERY)
+  // <=1180px drops the rail column entirely (keeper-workspace.css), so the right
+  // resizer must not render there even when railOpen is still toggled on.
+  const isNarrow = useMatchMedia(KW_NARROW_QUERY)
   const routeKeeperParam = route.value.tab === 'keepers'
     ? route.value.params.keeper?.trim()
     : route.value.tab === 'monitoring' && route.value.params.section === 'agents'
@@ -375,15 +385,49 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
     setConfigOverlayKeeper(name)
   }
 
+  // Drag-resizable roster/rail columns in the desktop 3-pane chat view. Only set
+  // the width vars when the pane is open (mini/closed states keep their CSS-driven
+  // widths), and only outside detail/mobile layouts where the grid differs.
+  const paneResizable = !detailOpen && !isMobile
+  const gridStyle = paneResizable
+    ? {
+        ...(rosterOpen ? { '--kw-roster-w': `${rosterWidth.value}px` } : {}),
+        ...(railOpen ? { '--kw-rail-w': `${railWidth.value}px` } : {}),
+      }
+    : undefined
+
   return html`
     <div
       class="kw-grid v2-monitoring-surface"
+      style=${gridStyle}
       data-detail=${detailOpen ? 'open' : 'closed'}
       data-roster=${rosterOpen ? 'open' : 'mini'}
       data-rail=${railOpen ? 'open' : 'closed'}
       data-mobile-pane=${keeperMobilePane.value}
       data-route-focused-keeper=${keeper.name}
     >
+      ${paneResizable && rosterOpen
+        ? html`<div
+            class="kw-pane-resizer left"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="로스터 폭 조절"
+            title="드래그하여 로스터 폭 조절"
+            onPointerDown=${(e: PointerEvent) =>
+              beginPaneResize('roster', e, (e.currentTarget as HTMLElement).closest('.kw-grid') as HTMLElement)}
+          ></div>`
+        : null}
+      ${paneResizable && railOpen && !isNarrow
+        ? html`<div
+            class="kw-pane-resizer right"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="컨텍스트 레일 폭 조절"
+            title="드래그하여 컨텍스트 레일 폭 조절"
+            onPointerDown=${(e: PointerEvent) =>
+              beginPaneResize('rail', e, (e.currentTarget as HTMLElement).closest('.kw-grid') as HTMLElement)}
+          ></div>`
+        : null}
       <${KeeperWorkspaceRoster}
         activeName=${keeper.name}
         routeSurface=${routeSurface}

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -40,7 +40,7 @@ import { KeeperDetailBody } from './keeper-detail-body'
 import { KeeperWorkspaceRoster } from './keeper-workspace/keeper-workspace-roster'
 import { KeeperWorkspaceChat } from './keeper-workspace/keeper-workspace-chat'
 import { KeeperWorkspaceRail } from './keeper-workspace/keeper-workspace-rail'
-import { beginPaneResize, rosterWidth, railWidth } from './keeper-workspace/keeper-workspace-pane-resize'
+import { beginPaneResize, clampPaneWidth, rosterWidth, railWidth } from './keeper-workspace/keeper-workspace-pane-resize'
 import { ringFocusClasses } from './common/ring'
 
 const CLOSE_BUTTON_FOCUS_CLASS = ringFocusClasses({
@@ -391,8 +391,8 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
   const paneResizable = !detailOpen && !isMobile
   const gridStyle = paneResizable
     ? {
-        ...(rosterOpen ? { '--kw-roster-w': `${rosterWidth.value}px` } : {}),
-        ...(railOpen ? { '--kw-rail-w': `${railWidth.value}px` } : {}),
+        ...(rosterOpen ? { '--kw-roster-w': `${clampPaneWidth('roster', rosterWidth.value)}px` } : {}),
+        ...(railOpen ? { '--kw-rail-w': `${clampPaneWidth('rail', railWidth.value)}px` } : {}),
       }
     : undefined
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   beginPaneResize,
   clampPaneWidth,
@@ -13,6 +13,7 @@ afterEach(() => {
   rosterWidth.value = DEFAULT_ROSTER_WIDTH
   railWidth.value = DEFAULT_RAIL_WIDTH
   document.body.classList.remove('kw-resizing')
+  window.localStorage.clear()
 })
 
 describe('clampPaneWidth', () => {
@@ -31,6 +32,38 @@ describe('clampPaneWidth', () => {
   it('falls back to the minimum for non-finite input (defensive floor)', () => {
     expect(clampPaneWidth('roster', Number.NaN)).toBe(200)
     expect(clampPaneWidth('rail', Number.POSITIVE_INFINITY)).toBe(240)
+    expect(clampPaneWidth('roster', 'wide')).toBe(200)
+  })
+})
+
+describe('persisted pane widths', () => {
+  async function importWithStorage(seed: Record<string, unknown>) {
+    vi.resetModules()
+    window.localStorage.clear()
+    for (const [key, value] of Object.entries(seed)) {
+      window.localStorage.setItem(key, JSON.stringify(value))
+    }
+    return import('./keeper-workspace-pane-resize')
+  }
+
+  it('falls back to defaults for invalid stored value types', async () => {
+    const mod = await importWithStorage({
+      'kw.rosterWidth': 'wide',
+      'kw.railWidth': null,
+    })
+
+    expect(mod.rosterWidth.value).toBe(mod.DEFAULT_ROSTER_WIDTH)
+    expect(mod.railWidth.value).toBe(mod.DEFAULT_RAIL_WIDTH)
+  })
+
+  it('clamps persisted numeric widths on load', async () => {
+    const mod = await importWithStorage({
+      'kw.rosterWidth': 9999,
+      'kw.railWidth': 0,
+    })
+
+    expect(mod.rosterWidth.value).toBe(440)
+    expect(mod.railWidth.value).toBe(240)
   })
 })
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  beginPaneResize,
+  clampPaneWidth,
+  rosterWidth,
+  railWidth,
+  DEFAULT_ROSTER_WIDTH,
+  DEFAULT_RAIL_WIDTH,
+} from './keeper-workspace-pane-resize'
+
+afterEach(() => {
+  rosterWidth.value = DEFAULT_ROSTER_WIDTH
+  railWidth.value = DEFAULT_RAIL_WIDTH
+  document.body.classList.remove('kw-resizing')
+})
+
+describe('clampPaneWidth', () => {
+  it('clamps the roster to 200..440 and rounds', () => {
+    expect(clampPaneWidth('roster', 10)).toBe(200)
+    expect(clampPaneWidth('roster', 9999)).toBe(440)
+    expect(clampPaneWidth('roster', 312.6)).toBe(313)
+  })
+
+  it('clamps the rail to 240..480', () => {
+    expect(clampPaneWidth('rail', 0)).toBe(240)
+    expect(clampPaneWidth('rail', 9999)).toBe(480)
+    expect(clampPaneWidth('rail', 300)).toBe(300)
+  })
+
+  it('falls back to the minimum for non-finite input (defensive floor)', () => {
+    expect(clampPaneWidth('roster', Number.NaN)).toBe(200)
+    expect(clampPaneWidth('rail', Number.POSITIVE_INFINITY)).toBe(240)
+  })
+})
+
+describe('beginPaneResize', () => {
+  function pointer(type: string, clientX: number): MouseEvent {
+    // happy-dom lacks PointerEvent; a MouseEvent with the pointer* type name
+    // still triggers the listeners and carries clientX, which is all the
+    // handler reads.
+    return new MouseEvent(type, { clientX, bubbles: true })
+  }
+
+  it('updates the CSS var live during the drag WITHOUT touching the signal, then persists on release', () => {
+    const grid = document.createElement('div')
+    document.body.appendChild(grid)
+    const down = { clientX: 100, preventDefault: () => {} } as unknown as PointerEvent
+
+    beginPaneResize('roster', down, grid)
+    expect(document.body.classList.contains('kw-resizing')).toBe(true)
+
+    window.dispatchEvent(pointer('pointermove', 150)) // +50 → 286+50 = 336
+    expect(grid.style.getPropertyValue('--kw-roster-w')).toBe('336px')
+    // mid-drag the persisted signal must NOT change (no re-render of the subtree)
+    expect(rosterWidth.value).toBe(DEFAULT_ROSTER_WIDTH)
+
+    window.dispatchEvent(pointer('pointerup', 150))
+    expect(rosterWidth.value).toBe(336)
+    expect(document.body.classList.contains('kw-resizing')).toBe(false)
+
+    grid.remove()
+  })
+
+  it('clamps the rail and inverts the drag direction (grows when dragging left)', () => {
+    const grid = document.createElement('div')
+    document.body.appendChild(grid)
+    const down = { clientX: 500, preventDefault: () => {} } as unknown as PointerEvent
+
+    beginPaneResize('rail', down, grid) // startW = 312
+    window.dispatchEvent(pointer('pointermove', 400)) // dragging left 100 → 312+100 = 412
+    expect(grid.style.getPropertyValue('--kw-rail-w')).toBe('412px')
+    window.dispatchEvent(pointer('pointermove', 0)) // far left → clamp 480
+    expect(grid.style.getPropertyValue('--kw-rail-w')).toBe('480px')
+    window.dispatchEvent(pointer('pointerup', 0))
+    expect(railWidth.value).toBe(480)
+
+    grid.remove()
+  })
+
+  it('tears down on pointercancel (gesture stolen) — persists width, drops body class and listeners', () => {
+    const grid = document.createElement('div')
+    document.body.appendChild(grid)
+    beginPaneResize('roster', { clientX: 100, preventDefault: () => {} } as unknown as PointerEvent, grid)
+    window.dispatchEvent(pointer('pointermove', 140)) // 286+40 = 326
+    expect(grid.style.getPropertyValue('--kw-roster-w')).toBe('326px')
+
+    window.dispatchEvent(pointer('pointercancel', 140))
+    expect(rosterWidth.value).toBe(326) // last width is persisted
+    expect(document.body.classList.contains('kw-resizing')).toBe(false)
+
+    window.dispatchEvent(pointer('pointermove', 999)) // listener should be gone
+    expect(grid.style.getPropertyValue('--kw-roster-w')).toBe('326px') // unchanged
+    grid.remove()
+  })
+
+  it('stops responding to pointermove after release', () => {
+    const grid = document.createElement('div')
+    document.body.appendChild(grid)
+    beginPaneResize('roster', { clientX: 100, preventDefault: () => {} } as unknown as PointerEvent, grid)
+    window.dispatchEvent(pointer('pointermove', 130)) // 286+30 = 316
+    expect(grid.style.getPropertyValue('--kw-roster-w')).toBe('316px')
+    window.dispatchEvent(pointer('pointerup', 130))
+    expect(rosterWidth.value).toBe(316)
+    window.dispatchEvent(pointer('pointermove', 999)) // listener should be gone
+    expect(grid.style.getPropertyValue('--kw-roster-w')).toBe('316px') // unchanged
+    grid.remove()
+  })
+})

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.ts
@@ -28,13 +28,26 @@ export const DEFAULT_RAIL_WIDTH = 312
 
 /** Persisted column widths (px). Reads subscribe the component, but values only
  *  change on drag-end so re-renders stay rare. */
-export const rosterWidth = persistentSignal<number>({ key: 'kw.rosterWidth', defaultValue: DEFAULT_ROSTER_WIDTH })
-export const railWidth = persistentSignal<number>({ key: 'kw.railWidth', defaultValue: DEFAULT_RAIL_WIDTH })
+function persistedPaneWidth(kind: PaneKind, key: string, defaultValue: number) {
+  return persistentSignal<number>({
+    key,
+    defaultValue,
+    deserialize: raw => {
+      const parsed: unknown = JSON.parse(raw)
+      return typeof parsed === 'number' && Number.isFinite(parsed)
+        ? clampPaneWidth(kind, parsed)
+        : defaultValue
+    },
+  })
+}
+
+export const rosterWidth = persistedPaneWidth('roster', 'kw.rosterWidth', DEFAULT_ROSTER_WIDTH)
+export const railWidth = persistedPaneWidth('rail', 'kw.railWidth', DEFAULT_RAIL_WIDTH)
 
 /** Pure: clamp a candidate width to the pane's bounds (rounded to whole px). */
-export function clampPaneWidth(kind: PaneKind, px: number): number {
+export function clampPaneWidth(kind: PaneKind, px: unknown): number {
   const { min, max } = PANE_BOUNDS[kind]
-  if (!Number.isFinite(px)) return min
+  if (typeof px !== 'number' || !Number.isFinite(px)) return min
   return Math.max(min, Math.min(max, Math.round(px)))
 }
 
@@ -46,7 +59,7 @@ export function beginPaneResize(kind: PaneKind, event: PointerEvent, gridEl: HTM
   const { cssVar } = PANE_BOUNDS[kind]
   const sig = kind === 'roster' ? rosterWidth : railWidth
   const startX = event.clientX
-  const startW = sig.value
+  const startW = clampPaneWidth(kind, sig.value)
   const dir = kind === 'roster' ? 1 : -1
   let latest = startW
   document.body.classList.add('kw-resizing')

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.ts
@@ -1,0 +1,72 @@
+// Keeper workspace pane resize — drag-to-resize the roster and context-rail
+// columns of the 3-pane chat view, with widths persisted to localStorage.
+//
+// Ported from the v2 design (keepers.jsx startResize + rails.jsx usePersistentW):
+// the design lets the operator widen the roster or context rail and remembers it.
+// The local 3-pane is a CSS grid whose roster/rail columns are driven by the
+// `--kw-roster-w` / `--kw-rail-w` custom properties (keeper-workspace.css), so a
+// resize is just a clamped write to those vars + persistence.
+//
+// Perf: during a drag we set the CSS var DIRECTLY on the grid element every
+// pointermove (no signal write → no re-render of the heavy detail subtree, the
+// same reason keeper-detail-page isolates the keepers-list subscription). The
+// persistent signal is written once on pointerup.
+
+import { persistentSignal } from '../../lib/persistent-signal'
+
+export type PaneKind = 'roster' | 'rail'
+
+// Clamp ranges mirror the v2 design (keepers.jsx startResize: roster 200..440,
+// ctx 240..480). Named so a future column-width change has a single source.
+const PANE_BOUNDS: Record<PaneKind, { min: number; max: number; cssVar: string }> = {
+  roster: { min: 200, max: 440, cssVar: '--kw-roster-w' },
+  rail: { min: 240, max: 480, cssVar: '--kw-rail-w' },
+}
+
+export const DEFAULT_ROSTER_WIDTH = 286
+export const DEFAULT_RAIL_WIDTH = 312
+
+/** Persisted column widths (px). Reads subscribe the component, but values only
+ *  change on drag-end so re-renders stay rare. */
+export const rosterWidth = persistentSignal<number>({ key: 'kw.rosterWidth', defaultValue: DEFAULT_ROSTER_WIDTH })
+export const railWidth = persistentSignal<number>({ key: 'kw.railWidth', defaultValue: DEFAULT_RAIL_WIDTH })
+
+/** Pure: clamp a candidate width to the pane's bounds (rounded to whole px). */
+export function clampPaneWidth(kind: PaneKind, px: number): number {
+  const { min, max } = PANE_BOUNDS[kind]
+  if (!Number.isFinite(px)) return min
+  return Math.max(min, Math.min(max, Math.round(px)))
+}
+
+/** Start a pointer-drag resize of one pane. Sets the CSS var directly on the
+ *  grid element during the drag (no re-render), persists on release. The rail
+ *  grows when dragging left, so its delta is inverted. */
+export function beginPaneResize(kind: PaneKind, event: PointerEvent, gridEl: HTMLElement): void {
+  event.preventDefault()
+  const { cssVar } = PANE_BOUNDS[kind]
+  const sig = kind === 'roster' ? rosterWidth : railWidth
+  const startX = event.clientX
+  const startW = sig.value
+  const dir = kind === 'roster' ? 1 : -1
+  let latest = startW
+  document.body.classList.add('kw-resizing')
+
+  const onMove = (ev: PointerEvent) => {
+    latest = clampPaneWidth(kind, startW + dir * (ev.clientX - startX))
+    gridEl.style.setProperty(cssVar, `${latest}px`)
+  }
+  const onUp = () => {
+    document.body.classList.remove('kw-resizing')
+    window.removeEventListener('pointermove', onMove)
+    window.removeEventListener('pointerup', onUp)
+    // pointercancel fires (instead of pointerup) when the browser steals the
+    // gesture — touch interrupt, context menu, tab switch. Tearing down on both
+    // paths keeps body.kw-resizing / the move listener from leaking and still
+    // persists the last width.
+    window.removeEventListener('pointercancel', onUp)
+    sig.value = latest
+  }
+  window.addEventListener('pointermove', onMove)
+  window.addEventListener('pointerup', onUp)
+  window.addEventListener('pointercancel', onUp)
+}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -61,6 +61,36 @@
 .kw-grid[data-roster="mini"] { --kw-roster-w: 64px; }
 .kw-grid[data-rail="closed"] { --kw-rail-w: 0px; }
 
+/* Drag handles for resizing the roster / rail columns (Unit 8). Absolutely
+ * positioned over the column boundary (the grid is position:relative). z-index 4
+ * sits below the collapse toggles (z-index 5) so the small toggle button stays
+ * clickable while the rest of the full-height strip is draggable. */
+.kw-pane-resizer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 11px;
+  z-index: 4;
+  cursor: col-resize;
+  touch-action: none;
+}
+.kw-pane-resizer.left { left: var(--kw-roster-w, 286px); transform: translateX(-50%); }
+.kw-pane-resizer.right { right: var(--kw-rail-w, 312px); transform: translateX(50%); }
+.kw-pane-resizer::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background: transparent;
+  transition: background-color 120ms ease;
+}
+.kw-pane-resizer:hover::after,
+body.kw-resizing .kw-pane-resizer::after { background: var(--color-border-strong); }
+body.kw-resizing { cursor: col-resize; user-select: none; }
+
 /* Detail ("운영 상세") takes over the conversation + rail span as a
  * single scrollable column; roster stays for keeper switching. */
 .kw-grid[data-detail="open"] { grid-template-columns: var(--kw-roster-w, 286px) minmax(0, 1fr); }
@@ -69,6 +99,8 @@
   .kw-grid { grid-template-columns: var(--kw-roster-w, 248px) minmax(0, 1fr); }
   .kw-grid .kw-rail { display: none; }
   .kw-rail-toggle.right { display: none; }
+  /* Rail column is gone ≤1180px → its resize handle has nothing to drag. */
+  .kw-pane-resizer.right { display: none; }
 }
 /* Below 860px the workspace becomes master-detail: the roster and chat/detail
  * panes share one grid column, and JS flips data-mobile-pane after selection.
@@ -104,6 +136,8 @@
     height: 100%;
   }
   .kw-rail-toggle { display: none; }
+  /* Single-column master-detail layout has no resizable column boundaries. */
+  .kw-pane-resizer { display: none; }
   .kw-roster { border-right: 0; border-bottom: 0; }
   .kw-chat-head { flex-wrap: wrap; align-items: flex-start; min-width: 0; padding: 12px 14px; }
   .kw-chat-id { flex: 1 1 132px; }


### PR DESCRIPTION
## 무엇을 / 왜

keeper-v2 **Unit 8** — 3-pane 채팅 뷰의 로스터/컨텍스트 레일 컬럼을 **드래그로 폭 조절** + 폭을 localStorage에 persist. 기존엔 접기 토글만 있었고, 디자인(`rails.jsx` `usePersistentW`/`ColResizer`, `keepers.jsx` `startResize`)은 경계 드래그 + 폭 기억을 제공합니다.

## 변경

- **`keeper-workspace-pane-resize.ts`(신규)**: `clampPaneWidth`(roster 200..440, rail 240..480, 순수), `rosterWidth`/`railWidth` persistentSignal(localStorage), `beginPaneResize` 드래그 핸들러.
- **`keeper-detail-page.ts`**: `.kw-grid`에 `--kw-roster-w`/`--kw-rail-w`를 **pane이 열려 있을 때만** inline로 설정(mini/closed 상태는 CSS 기본값 유지 → 64px/0px collapse 안 깨짐). 데스크톱 3-pane 뷰에서 각 경계에 드래그 핸들 렌더.
- **CSS**: `.kw-pane-resizer` z-index 4(접기 토글 z-5보다 아래 → 토글 버튼은 클릭 가능, 나머지 strip은 드래그). right 핸들은 ≤1180px(rail 사라짐)에서 숨김, 둘 다 ≤860px(단일 컬럼)에서 숨김.

## 성능

드래그 중에는 grid element에 CSS 변수를 **직접** set(매 pointermove마다 signal 미갱신 → 무거운 detail 서브트리 재렌더 없음, keeper-detail-page가 keepers 리스트 구독을 격리하는 P0 이유와 동일). persist signal은 pointerup에 1회만 기록.

## 적대 리뷰 반영(LOW 2건)

fresh-context 적대 리뷰는 6개 probe 차원(CSS-var override / z-index 겹침 / responsive 밴드 / perf 무재렌더 / clamp)에서 모두 correct·PASS. 추가로 식별된 robustness 2건을 반영:

- **`pointercancel` 종료 경로**: 브라우저가 제스처를 가로채면(터치 중단/컨텍스트 메뉴/탭 전환) `pointerup` 없이 `pointercancel`만 발화 → cleanup 누락 시 전역 `body.kw-resizing`(col-resize 커서 + user-select:none)·pointermove 리스너 잔존. 이제 `beginPaneResize`가 두 경로 모두에서 teardown.
- **우측 resizer JS backstop**: 861–1180px에서 rail 컬럼이 사라지는데 우측 resizer는 CSS `display:none` 단독 게이팅이었음(좌측은 이미 `isMobile` JS 게이팅). `useMatchMedia(query)`로 일반화해 `max-width:1180px` 구독을 추가, 좌측과 대칭으로 이중 게이팅.

## 검증

- `tsc --noEmit`: 0 errors · `eslint`: clean
- `vitest`: pane-resize **7 passed**(clamp 경계/rounding/non-finite, 드래그 시 DOM-var만 갱신·signal 불변, pointerup persist, **pointercancel teardown**, listener 제거, rail 방향 반전·clamp) + keeper-detail-page **2 passed**(회귀 없음)

## 참고

디자인 대비 분리: 폭 동기화는 컬럼 경계만(헤더/모바일 무관). 모바일·detail·≤1180 레일부재 밴드는 JS+CSS 이중 게이팅.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
