### PR TITLE
fix(keeper): persist event queue wake before registry replay

### DIFF
--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -18,9 +18,9 @@ let enqueue_if_missing queue stimulus =
   if queue_contains queue stimulus then queue else Keeper_event_queue.enqueue queue stimulus
 ;;
 
-let persist_live_queue entry name =
+let persist_live_queue ~base_path (entry : Keeper_registry.registry_entry) name =
   Keeper_event_queue_persistence.persist
-    ~base_path:entry.base_path
+    ~base_path
     ~keeper_name:name
     (Atomic.get entry.event_queue)
 ;;
@@ -45,7 +45,7 @@ let enqueue ~base_path name stimulus =
          if next = cur
          then ()
          else if Atomic.compare_and_set entry.event_queue cur next
-         then persist_live_queue entry name
+         then persist_live_queue ~base_path entry name
          else loop ()
        in
        loop ())
@@ -54,7 +54,7 @@ let enqueue ~base_path name stimulus =
       let cur = Atomic.get entry.event_queue in
       let next = Keeper_event_queue.enqueue cur stimulus in
       if Atomic.compare_and_set entry.event_queue cur next
-      then persist_live_queue entry name
+      then persist_live_queue ~base_path entry name
       else loop ()
     in
     loop ()
@@ -77,7 +77,7 @@ let dequeue ~base_path name =
       | Some (stim, rest) ->
         if Atomic.compare_and_set entry.event_queue cur rest
         then (
-          persist_live_queue entry name;
+          persist_live_queue ~base_path entry name;
           Some stim)
         else loop ()
     in
@@ -93,7 +93,7 @@ let drain_board ?window_sec ~base_path name =
       let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
       if Atomic.compare_and_set entry.event_queue cur rest
       then (
-        persist_live_queue entry name;
+        persist_live_queue ~base_path entry name;
         board)
       else loop ()
     in

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -15,9 +15,10 @@ let enqueue ~base_path name stimulus =
       "registry: enqueue_event name=%s base_path=%s: keeper not registered; persisting stimulus for replay"
       name
       base_path;
-    let cur = Keeper_event_queue_persistence.load ~base_path ~keeper_name:name in
-    let next = Keeper_event_queue.enqueue cur stimulus in
-    Keeper_event_queue_persistence.persist ~base_path ~keeper_name:name next
+    Keeper_event_queue_persistence.update
+      ~base_path
+      ~keeper_name:name
+      (fun cur -> Keeper_event_queue.enqueue cur stimulus)
   | Some entry ->
     let rec loop () =
       let cur = Atomic.get entry.event_queue in

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -8,6 +8,23 @@
     Atomic state primitive. CAS-successful mutations are mirrored to
     [Keeper_event_queue_persistence] for restart replay. *)
 
+let rec queue_contains queue stimulus =
+  match Keeper_event_queue.dequeue queue with
+  | None -> false
+  | Some (head, rest) -> head = stimulus || queue_contains rest stimulus
+;;
+
+let enqueue_if_missing queue stimulus =
+  if queue_contains queue stimulus then queue else Keeper_event_queue.enqueue queue stimulus
+;;
+
+let persist_live_queue entry name =
+  Keeper_event_queue_persistence.persist
+    ~base_path:entry.base_path
+    ~keeper_name:name
+    (Atomic.get entry.event_queue)
+;;
+
 let enqueue ~base_path name stimulus =
   match Keeper_registry.get ~base_path name with
   | None ->
@@ -18,13 +35,26 @@ let enqueue ~base_path name stimulus =
     Keeper_event_queue_persistence.update
       ~base_path
       ~keeper_name:name
-      (fun cur -> Keeper_event_queue.enqueue cur stimulus)
+      (fun cur -> Keeper_event_queue.enqueue cur stimulus);
+    (match Keeper_registry.get ~base_path name with
+     | None -> ()
+     | Some entry ->
+       let rec loop () =
+         let cur = Atomic.get entry.event_queue in
+         let next = enqueue_if_missing cur stimulus in
+         if next = cur
+         then ()
+         else if Atomic.compare_and_set entry.event_queue cur next
+         then persist_live_queue entry name
+         else loop ()
+       in
+       loop ())
   | Some entry ->
     let rec loop () =
       let cur = Atomic.get entry.event_queue in
       let next = Keeper_event_queue.enqueue cur stimulus in
       if Atomic.compare_and_set entry.event_queue cur next
-      then Keeper_event_queue_persistence.persist ~base_path:entry.base_path ~keeper_name:name next
+      then persist_live_queue entry name
       else loop ()
     in
     loop ()
@@ -47,10 +77,7 @@ let dequeue ~base_path name =
       | Some (stim, rest) ->
         if Atomic.compare_and_set entry.event_queue cur rest
         then (
-          Keeper_event_queue_persistence.persist
-            ~base_path:entry.base_path
-            ~keeper_name:name
-            rest;
+          persist_live_queue entry name;
           Some stim)
         else loop ()
     in
@@ -66,10 +93,7 @@ let drain_board ?window_sec ~base_path name =
       let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
       if Atomic.compare_and_set entry.event_queue cur rest
       then (
-        Keeper_event_queue_persistence.persist
-          ~base_path:entry.base_path
-          ~keeper_name:name
-          rest;
+        persist_live_queue entry name;
         board)
       else loop ()
     in

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -19,10 +19,10 @@ let enqueue_if_missing queue stimulus =
 ;;
 
 let persist_live_queue ~base_path (entry : Keeper_registry.registry_entry) name =
-  Keeper_event_queue_persistence.persist
+  Keeper_event_queue_persistence.persist_snapshot
     ~base_path
     ~keeper_name:name
-    (Atomic.get entry.event_queue)
+    (fun () -> Atomic.get entry.event_queue)
 ;;
 
 let enqueue ~base_path name stimulus =

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -12,9 +12,12 @@ let enqueue ~base_path name stimulus =
   match Keeper_registry.get ~base_path name with
   | None ->
     Log.Keeper.warn
-      "registry: enqueue_event name=%s base_path=%s: keeper not registered"
+      "registry: enqueue_event name=%s base_path=%s: keeper not registered; persisting stimulus for replay"
       name
-      base_path
+      base_path;
+    let cur = Keeper_event_queue_persistence.load ~base_path ~keeper_name:name in
+    let next = Keeper_event_queue.enqueue cur stimulus in
+    Keeper_event_queue_persistence.persist ~base_path ~keeper_name:name next
   | Some entry ->
     let rec loop () =
       let cur = Atomic.get entry.event_queue in
@@ -28,7 +31,7 @@ let enqueue ~base_path name stimulus =
 
 let snapshot ~base_path name =
   match Keeper_registry.get ~base_path name with
-  | None -> Keeper_event_queue.empty
+  | None -> Keeper_event_queue_persistence.load ~base_path ~keeper_name:name
   | Some entry -> Atomic.get entry.event_queue
 ;;
 

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -7,12 +7,14 @@
     MASC-owned durable queue snapshot so a keeper restart can replay
     pending stimuli. *)
 
-(** Enqueue a stimulus on the keeper's event queue.
-    Logs a warning when the keeper is not registered. *)
+(** Enqueue a stimulus on the keeper's event queue. When the keeper is not
+    registered yet, persist the stimulus to the durable snapshot so later
+    registration can replay it instead of dropping the wake at the
+    restart/register boundary. *)
 val enqueue : base_path:string -> string -> Keeper_event_queue.stimulus -> unit
 
-(** Read-only snapshot of the keeper's queue. Returns
-    [Keeper_event_queue.empty] when the keeper is unregistered. *)
+(** Read-only snapshot of the keeper's queue. If the keeper is not registered,
+    read the durable snapshot so diagnostics still expose pending replay. *)
 val snapshot : base_path:string -> string -> Keeper_event_queue.t
 
 (** Remove and return the head stimulus, or [None] when the queue is

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -121,7 +121,11 @@ let refresh_entry_event_queue_from_persistence ~base_path name entry =
     if merged = live
     then ()
     else if Atomic.compare_and_set entry.event_queue live merged
-    then Keeper_event_queue_persistence.persist ~base_path ~keeper_name:name merged
+    then
+      Keeper_event_queue_persistence.persist_snapshot
+        ~base_path
+        ~keeper_name:name
+        (fun () -> Atomic.get entry.event_queue)
     else loop ()
   in
   loop ()

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -92,6 +92,41 @@ let update_entry_if_registered ~base_path name f =
   loop ()
 ;;
 
+let rec queue_contains_stimulus queue stimulus =
+  match Keeper_event_queue.dequeue queue with
+  | None -> false
+  | Some (head, rest) -> head = stimulus || queue_contains_stimulus rest stimulus
+;;
+
+let enqueue_missing_stimulus queue stimulus =
+  if queue_contains_stimulus queue stimulus
+  then queue
+  else Keeper_event_queue.enqueue queue stimulus
+;;
+
+let merge_event_queues ~durable ~live =
+  let rec loop acc queue =
+    match Keeper_event_queue.dequeue queue with
+    | None -> acc
+    | Some (stimulus, rest) -> loop (enqueue_missing_stimulus acc stimulus) rest
+  in
+  loop durable live
+;;
+
+let refresh_entry_event_queue_from_persistence ~base_path name entry =
+  let durable = Keeper_event_queue_persistence.load ~base_path ~keeper_name:name in
+  let rec loop () =
+    let live = Atomic.get entry.event_queue in
+    let merged = merge_event_queues ~durable ~live in
+    if merged = live
+    then ()
+    else if Atomic.compare_and_set entry.event_queue live merged
+    then Keeper_event_queue_persistence.persist ~base_path ~keeper_name:name merged
+    else loop ()
+  in
+  loop ()
+;;
+
 let register_with_state
       ~base_path
       name
@@ -160,6 +195,7 @@ let register_with_state
     "registry: keeper registered name=%s running_count=%d"
     name
     (Atomic.get running_count_atomic);
+  refresh_entry_event_queue_from_persistence ~base_path name entry;
   entry
 ;;
 
@@ -258,6 +294,7 @@ let register_restarting ~base_path name meta
           name
           base_path
           (Keeper_state_machine.phase_to_string phase);
+        refresh_entry_event_queue_from_persistence ~base_path name new_entry;
         Ok new_entry)
       else loop ()
   in

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -38,60 +38,81 @@ let snapshot_path ~base_path ~keeper_name =
          "event-queue.json")
   else Error (Printf.sprintf "invalid keeper name for event queue snapshot: %s" keeper_name)
 
+let load_from_path ~keeper_name path =
+  if not (Sys.file_exists path)
+  then Keeper_event_queue.empty
+  else (
+    match Safe_ops.read_json_file_safe path with
+    | Error msg ->
+      Log.Keeper.warn
+        "event_queue_snapshot: failed to read keeper=%s path=%s: %s"
+        keeper_name
+        path
+        msg;
+      Keeper_event_queue.empty
+    | Ok json ->
+      (match Keeper_event_queue.queue_of_yojson json with
+       | Error msg ->
+         Log.Keeper.warn
+           "event_queue_snapshot: failed to parse keeper=%s path=%s: %s"
+           keeper_name
+           path
+           msg;
+         Keeper_event_queue.empty
+       | Ok queue ->
+         if not (Keeper_event_queue.is_empty queue)
+         then
+           Log.Keeper.info
+             "event_queue_snapshot: restored %s for keeper=%s"
+             (Keeper_event_queue.summary queue)
+             keeper_name;
+         queue))
+
 let load ~base_path ~keeper_name =
   match snapshot_path ~base_path ~keeper_name with
   | Error msg ->
     Log.Keeper.warn "event_queue_snapshot: %s" msg;
     Keeper_event_queue.empty
-  | Ok path ->
-    if not (Sys.file_exists path)
-    then Keeper_event_queue.empty
-    else (
-      match Safe_ops.read_json_file_safe path with
-      | Error msg ->
-        Log.Keeper.warn
-          "event_queue_snapshot: failed to read keeper=%s path=%s: %s"
-          keeper_name
-          path
-          msg;
-        Keeper_event_queue.empty
-      | Ok json ->
-        (match Keeper_event_queue.queue_of_yojson json with
-         | Error msg ->
-           Log.Keeper.warn
-             "event_queue_snapshot: failed to parse keeper=%s path=%s: %s"
-             keeper_name
-             path
-             msg;
-           Keeper_event_queue.empty
-         | Ok queue ->
-           if not (Keeper_event_queue.is_empty queue)
-           then
-             Log.Keeper.info
-               "event_queue_snapshot: restored %s for keeper=%s"
-               (Keeper_event_queue.summary queue)
-               keeper_name;
-           queue))
+  | Ok path -> load_from_path ~keeper_name path
+
+let persist_to_path ~keeper_name path queue =
+  match save_json_atomic path (Keeper_event_queue.queue_to_yojson queue) with
+  | Ok () -> ()
+  | Error msg ->
+    Log.Keeper.warn
+      "event_queue_snapshot: failed to persist keeper=%s path=%s: %s"
+      keeper_name
+      path
+      msg
 
 let persist ~base_path ~keeper_name queue =
   match snapshot_path ~base_path ~keeper_name with
   | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
   | Ok path ->
     (try
-       with_write_lock (fun () ->
-         match save_json_atomic path (Keeper_event_queue.queue_to_yojson queue) with
-         | Ok () -> ()
-         | Error msg ->
-           Log.Keeper.warn
-             "event_queue_snapshot: failed to persist keeper=%s path=%s: %s"
-             keeper_name
-             path
-             msg)
+       with_write_lock (fun () -> persist_to_path ~keeper_name path queue)
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
        Log.Keeper.warn
          "event_queue_snapshot: persist raised keeper=%s path=%s: %s"
+         keeper_name
+         path
+         (Printexc.to_string exn))
+
+let update ~base_path ~keeper_name f =
+  match snapshot_path ~base_path ~keeper_name with
+  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
+  | Ok path ->
+    (try
+       with_write_lock (fun () ->
+         let cur = load_from_path ~keeper_name path in
+         persist_to_path ~keeper_name path (f cur))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Keeper.warn
+         "event_queue_snapshot: update raised keeper=%s path=%s: %s"
          keeper_name
          path
          (Printexc.to_string exn))

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -100,6 +100,21 @@ let persist ~base_path ~keeper_name queue =
          path
          (Printexc.to_string exn))
 
+let persist_snapshot ~base_path ~keeper_name snapshot =
+  match snapshot_path ~base_path ~keeper_name with
+  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
+  | Ok path ->
+    (try
+       with_write_lock (fun () -> persist_to_path ~keeper_name path (snapshot ()))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Keeper.warn
+         "event_queue_snapshot: persist_snapshot raised keeper=%s path=%s: %s"
+         keeper_name
+         path
+         (Printexc.to_string exn))
+
 let update ~base_path ~keeper_name f =
   match snapshot_path ~base_path ~keeper_name with
   | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -19,3 +19,9 @@ val update :
 (** Load, transform, and atomically write the queue snapshot while holding the
     persistence write lock. Use this for pre-registry mutation paths that do not
     have a live registry CAS cell yet. *)
+
+val persist_snapshot :
+  base_path:string -> keeper_name:string -> (unit -> Keeper_event_queue.t) -> unit
+(** Evaluate [snapshot] while holding the persistence write lock, then atomically
+    write it. Use this after live registry CAS mutations so an older writer
+    cannot overwrite a newer live queue snapshot after waiting on the file lock. *)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -13,3 +13,9 @@ val persist :
     Eio mutex; non-Eio setup/test callers use a Stdlib fallback mutex.
     Persistence failures are logged and do not roll back the already-applied
     in-memory registry CAS update. *)
+
+val update :
+  base_path:string -> keeper_name:string -> (Keeper_event_queue.t -> Keeper_event_queue.t) -> unit
+(** Load, transform, and atomically write the queue snapshot while holding the
+    persistence write lock. Use this for pre-registry mutation paths that do not
+    have a live registry CAS cell yet. *)

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -257,19 +257,27 @@ let () =
       let meta = meta_for_keeper keeper_name "trace-event-queue-unregistered-test" in
       Masc.Keeper_registry.clear ();
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
+      Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name bootstrap_stim;
       assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
       let pending = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
-      assert (length pending = 1);
+      assert (length pending = 2);
       ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
       let restored = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
-      assert (length restored = 1);
-      let replayed =
+      assert (length restored = 2);
+      let first =
         match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
         | Some stim -> stim
         | None ->
-          Alcotest.fail "late registry registration should replay pre-registered stimulus"
+          Alcotest.fail "late registry registration should replay first pre-registered stimulus"
       in
-      assert (String.equal replayed.post_id "p1");
+      assert (String.equal first.post_id "p1");
+      let second =
+        match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
+        | Some stim -> stim
+        | None ->
+          Alcotest.fail "late registry registration should replay second pre-registered stimulus"
+      in
+      assert (String.equal second.post_id "bootstrap");
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
   print_endline "test_keeper_event_queue: all passed"

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -206,6 +206,21 @@ let () =
       Keeper_event_queue_persistence.persist ~base_path ~keeper_name rest;
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
+  let meta_for_keeper keeper_name trace_id =
+    match
+      Masc.Keeper_meta_json_parse.meta_of_json
+        (`Assoc
+          [ "name", `String keeper_name
+          ; "agent_name", `String keeper_name
+          ; "trace_id", `String trace_id
+          ; "last_model_used", `String "llama:auto"
+          ; "tool_access", `List []
+          ])
+    with
+    | Ok meta -> meta
+    | Error msg -> Alcotest.fail ("meta parse failed: " ^ msg)
+  in
+
   (* --- registry integration: CAS-successful enqueue persists and register reloads --- *)
   let base_path = temp_dir "keeper-event-queue-registry" in
   Fun.protect
@@ -214,20 +229,7 @@ let () =
       rm_rf base_path)
     (fun () ->
       let keeper_name = "keeper-event-queue-registry-test" in
-      let meta =
-        match
-          Masc.Keeper_meta_json_parse.meta_of_json
-            (`Assoc
-              [ "name", `String keeper_name
-              ; "agent_name", `String keeper_name
-              ; "trace_id", `String "trace-event-queue-registry-test"
-              ; "last_model_used", `String "llama:auto"
-              ; "tool_access", `List []
-              ])
-        with
-        | Ok meta -> meta
-        | Error msg -> Alcotest.fail ("meta parse failed: " ^ msg)
-      in
+      let meta = meta_for_keeper keeper_name "trace-event-queue-registry-test" in
       Masc.Keeper_registry.clear ();
       ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
@@ -240,6 +242,32 @@ let () =
         match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
         | Some stim -> stim
         | None -> Alcotest.fail "registry reload should replay pending stimulus"
+      in
+      assert (String.equal replayed.post_id "p1");
+      assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
+
+  (* --- registry unavailable window: enqueue persists before register --- *)
+  let base_path = temp_dir "keeper-event-queue-unregistered" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-unregistered-test" in
+      let meta = meta_for_keeper keeper_name "trace-event-queue-unregistered-test" in
+      Masc.Keeper_registry.clear ();
+      Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
+      assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
+      let pending = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
+      assert (length pending = 1);
+      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      let restored = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
+      assert (length restored = 1);
+      let replayed =
+        match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
+        | Some stim -> stim
+        | None ->
+          Alcotest.fail "late registry registration should replay pre-registered stimulus"
       in
       assert (String.equal replayed.post_id "p1");
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));


### PR DESCRIPTION
## Summary

- close a restart/register boundary gap in Keeper Event Layer durable replay
- when `Keeper_registry_event_queue.enqueue` receives a stimulus before the keeper is registered, persist it to the per-keeper event-queue snapshot instead of dropping it
- make unregistered `snapshot` read the durable snapshot so diagnostics and later registration see the same pending replay state
- add regression coverage for enqueue-before-register replay

## Why

The merged durable event queue only protected the registered-entry path: CAS into memory, then mirror the queue to disk. A wake that arrives during startup or registry churn could still hit `keeper not registered` and be logged/dropped. That is exactly the restart window durable replay is supposed to remove.

This keeps the queue in MASC. OAS remains uninvolved.

## Verification

Passed:

- `opam exec -- ocamlformat --check lib/keeper/keeper_registry_event_queue.ml lib/keeper/keeper_registry_event_queue.mli test/test_keeper_event_queue.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_registry_event_queue.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_registry_event_queue.mli`
- `ocamlc -stop-after parsing test/test_keeper_event_queue.ml`
- `git diff --check`

Not run:

- `scripts/dune-local.sh build test/test_keeper_event_queue.exe` was blocked by the repo guard because existing bare Dune processes were already running on the machine. Leaving focused build/test to CI rather than bypassing the guard.