### PR TITLE
fix(keeper): keeper_person_note_set이 note 누락 시 기존 노트를 조용히 삭제하던 문제 수정

### DIFF
--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -109,9 +109,6 @@ let handle_person_note_set ~config ~(meta : keeper_meta) ~args =
   let speaker_id =
     String.trim (Safe_ops.json_string ~default:"" "speaker_id" args)
   in
-  (* note is NOT trimmed to emptiness-only: a blank note is the
-     deliberate tombstone (RFC-0229 §3.1). *)
-  let note = Safe_ops.json_string ~default:"" "note" args in
   if speaker_id = "" then
     Yojson.Safe.to_string
       (`Assoc
@@ -121,18 +118,37 @@ let handle_person_note_set ~config ~(meta : keeper_meta) ~args =
                keeper_surface_read roster." )
         ])
   else begin
-    Keeper_person_notes.set_note
-      ~base_dir:config.Workspace.base_path
-      ~keeper_name:meta.name
-      ~speaker_id
-      ~note
-      ();
-    Yojson.Safe.to_string
-      (`Assoc
-        [ "ok", `Bool true
-        ; "speaker_id", `String speaker_id
-        ; "cleared", `Bool (String.trim note = "")
-        ])
+    (* Distinguish field-absent (LLM omission) from field-present-empty:
+       [json_string_opt] returns [None] when [note] is absent and [Some s] when
+       it is present (including ""). An explicit "" is the deliberate tombstone
+       that clears the note (RFC-0229 §3.1); an omitted [note] must be rejected,
+       not silently cleared. The prior [json_string ~default:""] collapsed both
+       to "", so a keeper that omitted [note] silently deleted an existing note
+       (OAS anti-pattern #2: Unknown -> Permissive Default). The structural
+       dispatch-level gap (in-process dispatch skips required validation) is
+       tracked in #21875. *)
+    match Safe_ops.json_string_opt "note" args with
+    | None ->
+      Yojson.Safe.to_string
+        (`Assoc
+          [ ( "error"
+            , `String
+                "note is required. Send an empty string to clear (tombstone) \
+                 an existing note." )
+          ])
+    | Some note ->
+      Keeper_person_notes.set_note
+        ~base_dir:config.Workspace.base_path
+        ~keeper_name:meta.name
+        ~speaker_id
+        ~note
+        ();
+      Yojson.Safe.to_string
+        (`Assoc
+          [ "ok", `Bool true
+          ; "speaker_id", `String speaker_id
+          ; "cleared", `Bool (String.trim note = "")
+          ])
   end
 ;;
 

--- a/test/dune
+++ b/test/dune
@@ -209,6 +209,7 @@
   test_keeper_unified_metacognition
   test_keeper_surface_post
   test_keeper_person_notes
+  test_keeper_person_note_set_handler
   test_fact_retention_reachability
   test_keeper_surface_read
   test_keeper_surface_presence_prompt
@@ -510,6 +511,7 @@
   test_keeper_unified_metacognition
   test_keeper_surface_post
   test_keeper_person_notes
+  test_keeper_person_note_set_handler
   test_fact_retention_reachability
   test_keeper_surface_read
   test_keeper_surface_presence_prompt

--- a/test/test_keeper_person_note_set_handler.ml
+++ b/test/test_keeper_person_note_set_handler.ml
@@ -1,0 +1,137 @@
+(* RFC-0229 — keeper_person_note_set handler contract.
+
+   In-process tool dispatch does not validate schema "required" fields (#21875),
+   so the handler must self-enforce them. The schema declares [note] required,
+   yet the handler previously read it via [Safe_ops.json_string ~default:""],
+   which collapsed field-absent (LLM omission) and field-present-empty
+   (deliberate RFC-0229 §3.1 tombstone) to the same "". A keeper that omitted
+   [note] therefore silently cleared an existing note and got ok:true.
+
+   These tests pin the corrected contract: an omitted [note] is rejected and
+   leaves an existing note intact, while an explicit empty string still clears
+   (the deliberate tombstone). *)
+
+open Masc
+
+module N = Keeper_person_notes
+module H = Keeper_tool_in_process_runtime
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let temp_base_path prefix =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
+let with_base_dir f =
+  let base_dir = temp_base_path "keeper-person-note-handler" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () -> f base_dir)
+
+let keeper_name = "person-note-handler-keeper"
+
+let make_meta () =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [
+          ("name", `String keeper_name);
+          ("agent_name", `String "person-note-handler-agent");
+          ("trace_id", `String "trace-person-note");
+          ("runtime_id", `String "ollama_cloud.deepseek-v4-flash");
+        ])
+  with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("meta_of_json_fixture failed: " ^ err)
+
+let note_for store_dir speaker_id =
+  List.assoc_opt speaker_id (N.notes ~base_dir:store_dir ~keeper_name)
+
+let result_has_error json_str =
+  match Yojson.Safe.from_string json_str with
+  | `Assoc fields -> List.mem_assoc "error" fields
+  | _ -> false
+
+let result_field_bool json_str key =
+  match Yojson.Safe.from_string json_str with
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with Some (`Bool b) -> Some b | _ -> None)
+  | _ -> None
+
+(* The regression: omitting note must not clear an existing note. *)
+let test_omitted_note_rejected_and_preserves () =
+  with_base_dir (fun base_dir ->
+      let config = Workspace.default_config base_dir in
+      let meta = make_meta () in
+      let store_dir = config.Workspace.base_path in
+      N.set_note ~base_dir:store_dir ~keeper_name ~speaker_id:"111"
+        ~note:"existing impression" ();
+      let result =
+        H.handle_person_note_set ~config ~meta
+          ~args:(`Assoc [ ("speaker_id", `String "111") ])
+      in
+      Alcotest.(check bool)
+        "omitted note returns an error" true (result_has_error result);
+      Alcotest.(check (option string))
+        "existing note preserved on omission" (Some "existing impression")
+        (note_for store_dir "111"))
+
+(* Deliberate tombstone (RFC-0229 §3.1): an explicit empty string clears. *)
+let test_explicit_empty_note_clears () =
+  with_base_dir (fun base_dir ->
+      let config = Workspace.default_config base_dir in
+      let meta = make_meta () in
+      let store_dir = config.Workspace.base_path in
+      N.set_note ~base_dir:store_dir ~keeper_name ~speaker_id:"222"
+        ~note:"to be erased" ();
+      let result =
+        H.handle_person_note_set ~config ~meta
+          ~args:
+            (`Assoc [ ("speaker_id", `String "222"); ("note", `String "") ])
+      in
+      Alcotest.(check (option bool))
+        "explicit empty note reports cleared" (Some true)
+        (result_field_bool result "cleared");
+      Alcotest.(check (option string))
+        "explicit empty note tombstones" None (note_for store_dir "222"))
+
+let test_note_value_set () =
+  with_base_dir (fun base_dir ->
+      let config = Workspace.default_config base_dir in
+      let meta = make_meta () in
+      let store_dir = config.Workspace.base_path in
+      let result =
+        H.handle_person_note_set ~config ~meta
+          ~args:
+            (`Assoc
+              [
+                ("speaker_id", `String "333");
+                ("note", `String "store owner");
+              ])
+      in
+      Alcotest.(check (option bool))
+        "note value reports not-cleared" (Some false)
+        (result_field_bool result "cleared");
+      Alcotest.(check (option string))
+        "note value stored" (Some "store owner") (note_for store_dir "333"))
+
+let () =
+  Alcotest.run "keeper_person_note_set_handler"
+    [
+      ( "required-note",
+        [
+          Alcotest.test_case "omitted note rejected, existing preserved" `Quick
+            test_omitted_note_rejected_and_preserves;
+          Alcotest.test_case "explicit empty note clears (tombstone)" `Quick
+            test_explicit_empty_note_clears;
+          Alcotest.test_case "note value is stored" `Quick test_note_value_set;
+        ] );
+    ]


### PR DESCRIPTION
## 목적

`keeper_person_note_set`에서 키퍼가 `note`를 누락하면 **기존 노트가 조용히 삭제되고 `ok:true`가 반환**되던 데이터-손실 경로를 차단한다.

## 배경

키퍼 internal(in-process) tool dispatch는 스키마 `required` 필드를 검증하지 않는다(PUBLIC 경로만 `Tool_input_validation.validate_args`를 거침; `keeper_tool_descriptor_resolution.ml:124-144`). 따라서 in-process 핸들러는 required 필드를 직접 self-enforce해야 한다.

`handle_person_note_set`은 `note`(스키마상 required)를 `Safe_ops.json_string ~default:""`로 읽었다. 이 getter는 **필드 부재(LLM 누락)와 필드 존재-빈값(RFC-0229 §3.1의 의도적 tombstone)을 모두 `""`로 흡수**한다(`safe_ops.ml:476-479` `| _ -> default`). 결과적으로 키퍼가 `{speaker_id}`만 보내 `note`를 누락하면 `note=""`로 해석 → `set_note ~note:""` → 빈 tombstone row append → reader(latest-wins, blank 제거)에서 기존 노트 소실. OAS 코드 생성 안티패턴 #2(Unknown → Permissive Default)의 파괴적 사례.

## 변경

`lib/keeper/keeper_tool_in_process_runtime.ml` `handle_person_note_set`:
- `note`를 `Safe_ops.json_string_opt`로 읽어 **부재(`None`)와 존재-빈값(`Some ""`)을 구분**.
  - `None`(누락) → `note is required` 에러 반환. `set_note` 미호출 → 기존 노트 보존.
  - `Some s`(존재, `""` 포함) → 그대로 `set_note`. 명시적 빈 문자열은 의도적 tombstone으로 유지(RFC-0229 §3.1 동작 불변).
- `speaker_id` 가드(`speaker_id is required`)와 `cleared` 응답 필드는 그대로.

## 테스트

`test/test_keeper_person_note_set_handler.ml` (핸들러 E2E, store 효과까지 검증):
- **누락 거부 + 보존**: `{speaker_id:"111"}`(note 누락) → 에러 반환 + 기존 노트 `"existing impression"` 보존(회귀 테스트).
- **명시적 빈값 tombstone**: `{speaker_id, note:""}` → `cleared:true` + store에서 제거.
- **값 저장**: `{speaker_id, note:"store owner"}` → `cleared:false` + 저장.

## RFC / 이슈

- RFC-0229 §3.1/§3.2: blank note = 의도적 tombstone(이 동작은 명시적 `""`에 대해 그대로 보존).
- 구조적 근본(in-process dispatch가 required를 검증하지 않음 — defense-in-depth)은 #21875로 추적. 본 PR은 그 단일 confirmed instance를 수정.

## 검증

- `ocamlformat --check` 양쪽 파일 PASS.
- 컴파일/테스트는 CI(Build and Test)에서 검증. `lib/keeper`는 로컬 agent_sdk pin drift로 로컬 빌드 불가 → ocamlformat이 유일한 로컬 게이트.

## 워크어라운드 시그니처 점검

해당 없음. 본 변경은 symptom 억제가 아니라 **올바른 typed 파싱**(부재 vs 명시적 빈값 구분, Parse-don't-validate)이며, 단일 confirmed 사이트 수정이라 N-of-M 패치가 아니다. 구조적 defense-in-depth는 별도 이슈(#21875)로 분리.
