### PR TITLE
[codex] fix runtime multimodal history capability gate

### DIFF
--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -852,15 +852,10 @@ let run_blocks
     ?goal_detail
     (goal_blocks : Agent_sdk.Types.content_block list)
   : (run_result, Agent_sdk.Error.sdk_error) result =
-  let validation_blocks =
-    content_blocks_for_run
-      ~initial_messages:config.initial_messages
-      ~goal_blocks
-  in
   match
     validate_content_blocks_for_config
       ~config
-      validation_blocks
+      goal_blocks
   with
   | Error _ as err -> err
   | Ok () ->

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -479,6 +479,16 @@ let validate_content_blocks_against_capabilities
              ~supported
              ~reason:"provider does not support combined non-text modalities")
 
+let validate_content_blocks_for_run_against_capabilities
+    ~(provider_label : string)
+    (caps : Llm_provider.Capabilities.capabilities)
+    ~(initial_messages : Agent_sdk.Types.message list)
+    ~(goal_blocks : Agent_sdk.Types.content_block list) =
+  validate_content_blocks_against_capabilities
+    ~provider_label
+    caps
+    (content_blocks_for_run ~initial_messages ~goal_blocks)
+
 let apply_runtime_model_input_capabilities
     (caps : Llm_provider.Capabilities.capabilities)
     (model_caps : Runtime_schema.model_capabilities) =
@@ -537,11 +547,12 @@ let media_reroute_candidates ~(exclude : string) :
 
 let validate_content_blocks_for_config
     ~(config : config)
-    (blocks : Agent_sdk.Types.content_block list) =
-  validate_content_blocks_against_capabilities
+    (goal_blocks : Agent_sdk.Types.content_block list) =
+  validate_content_blocks_for_run_against_capabilities
     ~provider_label:(provider_label config.provider_cfg)
     (input_capabilities_for_config config)
-    blocks
+    ~initial_messages:config.initial_messages
+    ~goal_blocks
 
 (* RFC-0265: capability-driven proactive runtime reroute. A pure decision from
    the turn's required input modalities and the candidate runtimes' declared
@@ -609,6 +620,8 @@ module For_testing = struct
   let required_modalities_of_messages = required_modalities_of_messages
   let required_modalities_for_run = required_modalities_for_run
   let caps_admit_required_modalities = caps_admit_required_modalities
+  let validate_content_blocks_for_run_against_capabilities =
+    validate_content_blocks_for_run_against_capabilities
   let validate_content_blocks_against_capabilities =
     validate_content_blocks_against_capabilities
   let apply_runtime_model_input_capabilities =

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -282,6 +282,13 @@ module For_testing : sig
   val caps_admit_required_modalities :
     Llm_provider.Capabilities.capabilities -> string list -> bool
 
+  val validate_content_blocks_for_run_against_capabilities :
+    provider_label:string ->
+    Llm_provider.Capabilities.capabilities ->
+    initial_messages:Agent_sdk.Types.message list ->
+    goal_blocks:Agent_sdk.Types.content_block list ->
+    (unit, Agent_sdk.Error.sdk_error) result
+
   val validate_content_blocks_against_capabilities :
     provider_label:string ->
     Llm_provider.Capabilities.capabilities ->

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -27,6 +27,20 @@ let decide ~assigned ~required ~candidates =
     ~required_modalities:required
     ~candidates
 
+let string_contains haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0 then true
+  else
+    let rec loop index =
+      index + needle_len <= haystack_len
+      && (String.sub haystack index needle_len = needle || loop (index + 1))
+    in
+    loop 0
+
+let check_contains label ~needle haystack =
+  check bool label true (string_contains haystack needle)
+
 let message_with_blocks blocks =
   { Agent_sdk.Types.role = Agent_sdk.Types.User
   ; content = blocks
@@ -109,6 +123,34 @@ let test_no_capable_runtime_floor () =
        (decide ~assigned:(caps ()) ~required:[ "image" ]
           ~candidates:[ ("text_b", caps ()); ("audio_c", caps ~audio:true ()) ]))
 
+(* Regression: when no configured runtime can accept media, the final floor gate
+   must validate prior history too. Otherwise a text-only follow-up after a
+   vision turn leaks image history to the provider and fails as a provider 400
+   (for example "messages.content.type is invalid, allowed values: ['text']"). *)
+let test_history_media_floor_rejects_before_provider () =
+  let initial_messages =
+    [ message_with_blocks
+        [ Agent_sdk.Types.Text "previous image turn"
+        ; Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" ()
+        ]
+    ]
+  in
+  match
+    Runtime_agent.For_testing.validate_content_blocks_for_run_against_capabilities
+      ~provider_label:"glm-coding.glm-5-turbo"
+      (caps ())
+      ~initial_messages
+      ~goal_blocks:[ Agent_sdk.Types.Text "follow up" ]
+  with
+  | Ok () -> fail "expected history image to be rejected before provider dispatch"
+  | Error (Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })) ->
+      check string "field" "multimodal_input" field;
+      check_contains "mentions unsupported image" ~needle:"unsupported image input" detail;
+      check_contains "mentions required modality" ~needle:"required=image" detail;
+      check_contains "mentions text-only support" ~needle:"supported=text" detail
+  | Error err ->
+      failf "expected InvalidConfig, got %s" (Agent_sdk.Error.to_string err)
+
 (* The decision is a pure function: identical inputs yield identical output. *)
 let test_decision_is_deterministic () =
   let candidates = [ ("text_b", caps ()); ("vision_c", caps ~image:true ()) ] in
@@ -144,6 +186,8 @@ let () =
             test_initial_message_media_drives_reroute
         ; test_case "candidate order honored" `Quick test_candidate_order_is_honored
         ; test_case "no capable floor" `Quick test_no_capable_runtime_floor
+        ; test_case "history media floor rejects before provider" `Quick
+            test_history_media_floor_rejects_before_provider
         ; test_case "deterministic" `Quick test_decision_is_deterministic
         ] )
     ; ( "caps_admit_required_modalities"


### PR DESCRIPTION
## Summary
- Validate prior conversation media as part of the runtime multimodal capability floor gate, not only the current goal blocks.
- Add a regression test for the screenshot-class failure: a text-only follow-up after a vision/image turn must be rejected by MASC capability validation before provider dispatch.

## Root Cause
The reroute decision already considered `initial_messages + goal_blocks`, so a prior image could trigger a capable-runtime reroute. But when no capable runtime existed, the final capability gate inside `Runtime_agent.run_blocks` still validated only `goal_blocks`. That allowed prior image history to reach text-only providers and surface as provider 400 errors such as `messages.content.type is invalid, allowed values: [text]`.

## Validation
- `git diff --check`
- `opam exec -- ocamlformat --check lib/runtime/runtime_agent.ml lib/runtime/runtime_agent.mli test/test_runtime_modality_reroute.ml`
- Attempted `scripts/dune-local.sh build test/test_runtime_modality_reroute.exe`; initially blocked by existing bare Dune builds on the machine. Retried with `MASC_DUNE_ALLOW_BARE_DUNE=1`, but stopped the focused build after prolonged contention to avoid worsening local Dune pressure. CI should be treated as the OCaml build/test authority for this draft.

## Notes
This is intentionally backend/runtime-side rather than dashboard-only, so dashboard, connector, queue, and resumed keeper turns share the same fail-closed behavior.