### PR TITLE
feat(log): add before_seq cursor for event-log backward pagination

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -10,6 +10,7 @@ vi.mock('./dev-token', () => ({
 
 import {
   fetchDashboardShell,
+  fetchLogs,
   fetchDashboardExecutionTrust,
   fetchDashboardGovernance,
   fetchDashboardGoalDetail,
@@ -2165,5 +2166,52 @@ describe('fetchCostLatency', () => {
     expect(result.perAgent[0]?.p95_ms).toBeNull()
     expect(result.matrix.providers).toEqual(['runtime'])
     expect(result.matrix.models).toEqual(['runtime_lane_7'])
+  })
+})
+
+describe('fetchLogs', () => {
+  function stubLogsFetch() {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ total: 0, entries: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  function requestedUrl(fetchMock: ReturnType<typeof vi.fn>): string {
+    return String(fetchMock.mock.calls[0]?.[0])
+  }
+
+  it('sets before_seq for backward "load older" paging', async () => {
+    const fetchMock = stubLogsFetch()
+
+    await fetchLogs({ limit: 200, level: 'INFO', before_seq: 4096 })
+
+    const params = new URLSearchParams(requestedUrl(fetchMock).split('?')[1] ?? '')
+    expect(params.get('before_seq')).toBe('4096')
+    expect(params.get('limit')).toBe('200')
+    expect(params.get('level')).toBe('INFO')
+  })
+
+  it('omits before_seq when negative (no cursor)', async () => {
+    const fetchMock = stubLogsFetch()
+
+    await fetchLogs({ before_seq: -1 })
+
+    const params = new URLSearchParams(requestedUrl(fetchMock).split('?')[1] ?? '')
+    expect(params.has('before_seq')).toBe(false)
+  })
+
+  it('combines before_seq and since_seq into a bounded window', async () => {
+    const fetchMock = stubLogsFetch()
+
+    await fetchLogs({ since_seq: 10, before_seq: 20 })
+
+    const params = new URLSearchParams(requestedUrl(fetchMock).split('?')[1] ?? '')
+    expect(params.get('since_seq')).toBe('10')
+    expect(params.get('before_seq')).toBe('20')
   })
 })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -128,6 +128,7 @@ export async function fetchLogs(opts?: {
   level?: string
   module?: string
   since_seq?: number
+  before_seq?: number
   category?: string
   exclude_category?: string
 }): Promise<LogsResponse> {
@@ -137,6 +138,9 @@ export async function fetchLogs(opts?: {
   if (opts?.module) params.set('module', opts.module)
   if (typeof opts?.since_seq === 'number' && opts.since_seq >= 0) {
     params.set('since_seq', String(opts.since_seq))
+  }
+  if (typeof opts?.before_seq === 'number' && opts.before_seq >= 0) {
+    params.set('before_seq', String(opts.before_seq))
   }
   if (opts?.category) params.set('category', opts.category)
   if (opts?.exclude_category) params.set('exclude_category', opts.exclude_category)

--- a/dashboard/src/api/schemas/logs.test.ts
+++ b/dashboard/src/api/schemas/logs.test.ts
@@ -55,6 +55,7 @@ describe('parseLogsResponse', () => {
         min_level: 1,
         module: '',
         since_seq: null,
+        before_seq: 42,
       },
       returned: 2,
       latest_seq: 43,
@@ -69,6 +70,10 @@ describe('parseLogsResponse', () => {
     expect(out.retention?.scope).toBe('dashboard_logs')
     expect(out.retention?.capacity).toBe(50000)
     expect(out.query?.applied_level).toBe('INFO')
+    // before_seq is the backward "load older" cursor echoed in the query meta.
+    expect(out.query?.before_seq).toBe(42)
+    // oldest_seq is the cursor the UI passes back as before_seq to page older.
+    expect(out.oldest_seq).toBe(42)
     expect(out.latest_seq).toBe(43)
   })
 

--- a/dashboard/src/api/schemas/logs.ts
+++ b/dashboard/src/api/schemas/logs.ts
@@ -75,6 +75,7 @@ export interface LogsQuery {
   min_level?: number
   module?: string
   since_seq?: number | null
+  before_seq?: number | null
   category?: string
   exclude_category?: string
 }

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -1,5 +1,5 @@
 import { h } from 'preact'
-import { cleanup, render, waitFor } from '@testing-library/preact'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { LogEntry } from '../api/dashboard'
 import { logDiagnosticCause, summarizeLogWindow } from './logs'
@@ -18,6 +18,14 @@ function entry(overrides: Partial<LogEntry>): LogEntry {
     category: null,
     ...overrides,
   }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(innerResolve => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
 }
 
 async function loadLogs(
@@ -145,10 +153,70 @@ describe('log diagnostics', () => {
 describe('LogViewer Code links', () => {
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.clearAllMocks()
     vi.resetModules()
     vi.doUnmock('../api/dashboard.js')
     window.location.hash = ''
+  })
+
+  it('preserves delta rows when an older page resolves after auto-refresh', async () => {
+    vi.useFakeTimers()
+    const olderPage = deferred<{ total: number; entries: LogEntry[] }>()
+    const fetchLogs = vi.fn((opts?: { since_seq?: number; before_seq?: number }) => {
+      if (typeof opts?.before_seq === 'number') {
+        return olderPage.promise
+      }
+      if (typeof opts?.since_seq === 'number') {
+        return Promise.resolve({
+          total: 3,
+          entries: [entry({ seq: 11, module: 'Keeper', message: 'delta fresh' })],
+        })
+      }
+      return Promise.resolve({
+        total: 2,
+        entries: [
+          entry({ seq: 10, module: 'Keeper', message: 'newest visible' }),
+          entry({ seq: 9, module: 'Keeper', message: 'oldest visible' }),
+        ],
+      })
+    })
+    const { LogViewer } = await loadLogs(fetchLogs)
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() => expect(container.textContent).toContain('oldest visible'))
+    const loadOlderButton = container.querySelector(
+      '[data-testid="logs-load-older"]',
+    ) as HTMLButtonElement | null
+    expect(loadOlderButton).not.toBeNull()
+
+    await act(async () => {
+      fireEvent.click(loadOlderButton!)
+    })
+    await waitFor(() =>
+      expect(fetchLogs).toHaveBeenCalledWith(expect.objectContaining({ before_seq: 9 })),
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+    await waitFor(() => expect(container.textContent).toContain('delta fresh'))
+
+    await act(async () => {
+      olderPage.resolve({
+        total: 3,
+        entries: [entry({ seq: 8, module: 'Keeper', message: 'older page' })],
+      })
+      await olderPage.promise
+    })
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('delta fresh')
+      expect(container.textContent).toContain('newest visible')
+      expect(container.textContent).toContain('oldest visible')
+      expect(container.textContent).toContain('older page')
+    })
+    expect(fetchLogs).toHaveBeenCalledWith(expect.objectContaining({ since_seq: 10 }))
   })
 
   it('links safe structured log file details back to the Code IDE route', async () => {

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -73,6 +73,7 @@ const EMPTY_LOG_ENTRIES: LogEntry[] = []
 
 let moduleDebounceTimer: ReturnType<typeof setTimeout> | null = null
 let latestRequestId = 0
+let logQueryGeneration = 0
 
 function MetaTag({ children }: { children: unknown }) {
   return html`<${StatusChip} tone="neutral" uppercase=${false}>${children}</${StatusChip}>`
@@ -475,6 +476,7 @@ async function loadLogs(mode: LoadMode = 'reset') {
   const requestId = ++latestRequestId
 
   if (mode === 'reset') {
+    logQueryGeneration += 1
     displayCap.value = logLimit.value
     noMoreOlder.value = false
     return logResource.load(async () => {
@@ -545,6 +547,7 @@ export async function loadOlder() {
     return
   }
   if (olderLoading.value) return
+  const startedGeneration = logQueryGeneration
   olderLoading.value = true
   try {
     const resp = await fetchLogs({
@@ -555,18 +558,22 @@ export async function loadOlder() {
       category: categoryFilter.value || undefined,
       exclude_category: hideFsmTransitions.value ? 'fsm' : undefined,
     })
+    if (startedGeneration !== logQueryGeneration) return
     const incoming = sortLogEntries(resp.entries)
     if (incoming.length === 0) {
       noMoreOlder.value = true
       return
     }
-    const cap = currentEntries.length + incoming.length
-    const nextEntries = mergeLogEntries(currentEntries, incoming, cap)
+    const latestState = logResource.state.value
+    if (latestState.status !== 'loaded') return
+    const latestEntries = latestState.data.entries
+    const cap = latestEntries.length + incoming.length
+    const nextEntries = mergeLogEntries(latestEntries, incoming, cap)
     displayCap.value = Math.max(displayCap.value, nextEntries.length)
     // latestSeq stays untouched: older paging only extends the tail, the
     // newest-cursor for delta polling is unaffected.
     logResource.state.value = loaded({
-      ...s.data,
+      ...latestState.data,
       entries: nextEntries,
       total: resp.total,
     })

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -52,13 +52,20 @@ const levelFilter = signal('INFO')
 const moduleInput = signal('')
 const appliedModuleFilter = signal('')
 const autoRefresh = signal(true)
-const logLimit = signal(200)
+const DEFAULT_LOG_LIMIT = 200
+const logLimit = signal(DEFAULT_LOG_LIMIT)
 const providerLogProvider = signal('')
 const providerLogLines = signal(200)
 const latestSeq = signal<number | null>(null)
 const categoryFilter = signal('')
 const hideFsmTransitions = signal(false)
 const expandedLogSeq = signal<number | null>(null)
+// "load older" backward paging: [displayCap] is the max rows kept in view. It
+// starts at the per-request limit and only grows as older pages are appended,
+// so the delta poller's merge does not trim history the operator paged into.
+const displayCap = signal(DEFAULT_LOG_LIMIT)
+const olderLoading = signal(false)
+const noMoreOlder = signal(false)
 
 const POLL_INTERVAL_MS = 3000
 const ESTIMATED_LOG_ROW_HEIGHT = 78
@@ -468,6 +475,8 @@ async function loadLogs(mode: LoadMode = 'reset') {
   const requestId = ++latestRequestId
 
   if (mode === 'reset') {
+    displayCap.value = logLimit.value
+    noMoreOlder.value = false
     return logResource.load(async () => {
       const resp = await fetchLogs({
         limit: logLimit.value,
@@ -501,7 +510,10 @@ async function loadLogs(mode: LoadMode = 'reset') {
     const s = logResource.state.value
     const currentEntries = s.status === 'loaded' ? s.data.entries : []
     const incoming = sortLogEntries(resp.entries)
-    const nextEntries = mergeLogEntries(currentEntries, incoming, logLimit.value)
+    // Cap at displayCap (>= logLimit once older pages are loaded) so a delta
+    // poll never drops history the operator paged into via "load older".
+    const cap = Math.max(displayCap.value, logLimit.value)
+    const nextEntries = mergeLogEntries(currentEntries, incoming, cap)
 
     latestSeq.value = latestLogSeq(nextEntries)
     logResource.state.value = loaded({
@@ -512,6 +524,56 @@ async function loadLogs(mode: LoadMode = 'reset') {
   } catch {
     if (requestId !== latestRequestId) return
     // Delta failures don't overwrite loaded state — keep existing data visible
+  }
+}
+
+function oldestLogSeq(entries: readonly LogEntry[]): number | null {
+  if (entries.length === 0) return null
+  return entries.reduce((min, entry) => Math.min(min, entry.seq), entries[0]?.seq ?? 0)
+}
+
+// "load older" backward paging: fetch entries strictly older than the smallest
+// seq currently shown and append them, growing displayCap so neither this merge
+// nor the delta poller trims the existing rows.
+export async function loadOlder() {
+  const s = logResource.state.value
+  if (s.status !== 'loaded') return
+  const currentEntries = s.data.entries
+  const oldest = oldestLogSeq(currentEntries)
+  if (oldest === null || oldest <= 0) {
+    noMoreOlder.value = true
+    return
+  }
+  if (olderLoading.value) return
+  olderLoading.value = true
+  try {
+    const resp = await fetchLogs({
+      limit: logLimit.value,
+      level: levelFilter.value,
+      module: appliedModuleFilter.value || undefined,
+      before_seq: oldest,
+      category: categoryFilter.value || undefined,
+      exclude_category: hideFsmTransitions.value ? 'fsm' : undefined,
+    })
+    const incoming = sortLogEntries(resp.entries)
+    if (incoming.length === 0) {
+      noMoreOlder.value = true
+      return
+    }
+    const cap = currentEntries.length + incoming.length
+    const nextEntries = mergeLogEntries(currentEntries, incoming, cap)
+    displayCap.value = Math.max(displayCap.value, nextEntries.length)
+    // latestSeq stays untouched: older paging only extends the tail, the
+    // newest-cursor for delta polling is unaffected.
+    logResource.state.value = loaded({
+      ...s.data,
+      entries: nextEntries,
+      total: resp.total,
+    })
+  } catch {
+    // Keep existing data on failure; the affordance stays available for retry.
+  } finally {
+    olderLoading.value = false
   }
 }
 
@@ -1067,6 +1129,26 @@ export function LogViewer() {
                 className="v2-logs-stream"
               />
             `}
+
+        ${logEntries.length > 0
+          ? html`
+              <div class="v2-logs-load-older flex items-center justify-center px-4 py-3">
+                ${noMoreOlder.value
+                  ? html`<span class="text-2xs text-[var(--color-fg-muted)]">더 오래된 기록이 없습니다.</span>`
+                  : html`
+                      <button
+                        type="button"
+                        class="logs-refresh-btn rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-2xs font-medium text-[var(--color-fg-muted)]"
+                        data-testid="logs-load-older"
+                        onClick=${() => { void loadOlder() }}
+                        disabled=${olderLoading.value}
+                      >
+                        ${olderLoading.value ? '불러오는 중...' : '이전 기록 더 보기'}
+                      </button>
+                    `}
+              </div>
+            `
+          : null}
       </section>
     </div>
   `

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -627,6 +627,7 @@ module Ring = struct
 
   let recent ?(limit = 200) ?(min_level = 0) ?(module_filter = "")
       ?since_seq
+      ?before_seq
       ?(order = `Newest_first)
       ?category_filter
       ?exclude_category
@@ -635,14 +636,25 @@ module Ring = struct
     if t = 0 then []
     else begin
       let start = max 0 (t - capacity) in
+      (* [since_seq] raises the lower bound (entries strictly newer than the
+         cursor); [before_seq] lowers the upper bound (entries strictly older
+         than the cursor). For retained slots in [start, t-1] the entry seq
+         equals its scan index [i] (seq is assigned monotonically and the ring
+         only retains the last [capacity] entries), so seq comparisons reduce
+         to index bounds. The two cursors compose into a bounded window. *)
       let start =
         match since_seq with
         | Some seq -> max start (seq + 1)
         | None -> start
       in
+      let upper =
+        match before_seq with
+        | Some seq -> min (t - 1) (seq - 1)
+        | None -> t - 1
+      in
       let entries = ref [] in
       let count = ref 0 in
-      let i = ref (t - 1) in
+      let i = ref upper in
       while !i >= start && !count < limit do
         let e = buf.(!i mod capacity) in
         let level_ok = level_to_int e.level >= min_level in

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -143,11 +143,17 @@ module Ring : sig
     ?min_level:int ->
     ?module_filter:string ->
     ?since_seq:int ->
+    ?before_seq:int ->
     ?order:[< `Newest_first | `Oldest_first > `Newest_first ] ->
     ?category_filter:string ->
     ?exclude_category:string list ->
     unit ->
     entry list
+  (** Read a slice of the in-memory ring, newest-first by default.
+      [since_seq] returns only entries strictly newer than the cursor (forward
+      delta polling); [before_seq] returns only entries strictly older than the
+      cursor (backward "load older" paging). Both are inclusive-exclusive on the
+      cursor and compose into a bounded window when supplied together. *)
 
   val entry_to_json : entry -> Yojson.Safe.t
   val entry_of_json : Yojson.Safe.t -> entry

--- a/lib/server/server_dashboard_logs_json.ml
+++ b/lib/server/server_dashboard_logs_json.ml
@@ -25,6 +25,7 @@ let build
       ~min_level
       ~module_filter
       ~since_seq
+      ~before_seq
       ~category_filter
       ~exclude_category
       (entries : Log.Ring.entry list)
@@ -67,6 +68,7 @@ let build
              ; "min_level", `Int min_level
              ; "module", `String module_filter
              ; "since_seq", Json_util.int_option_to_yojson since_seq
+             ; "before_seq", Json_util.int_option_to_yojson before_seq
              ; "category", Json_util.string_opt_to_json category_filter
              ; ( "exclude_category"
                , match exclude_category with

--- a/lib/server/server_dashboard_logs_json.mli
+++ b/lib/server/server_dashboard_logs_json.mli
@@ -10,6 +10,7 @@ val build
   -> min_level:int
   -> module_filter:string
   -> since_seq:int option
+  -> before_seq:int option
   -> category_filter:string option
   -> exclude_category:string list option
   -> Log.Ring.entry list

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -397,6 +397,13 @@ let add_routes ~sw ~clock router =
                  let seq = Server_utils.int_query_param req "since_seq" ~default:(-1) in
                  if seq < 0 then None else Some seq
            in
+           let before_seq =
+             match Server_utils.query_param req "before_seq" with
+             | None -> None
+             | Some _ ->
+                 let seq = Server_utils.int_query_param req "before_seq" ~default:(-1) in
+                 if seq < 0 then None else Some seq
+           in
            let module_filter = match Server_utils.query_param req "module" with
              | Some v -> v
              | None -> ""
@@ -415,12 +422,12 @@ let add_routes ~sw ~clock router =
            in
            let entries =
              Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq
-               ?category_filter ?exclude_category ()
+               ?before_seq ?category_filter ?exclude_category ()
            in
            let json =
              dashboard_logs_json ~config:(Mcp_server.workspace_config state) ~limit
                ~level_filter ~applied_level ~min_level ~module_filter ~since_seq
-               ~category_filter ~exclude_category entries
+               ~before_seq ~category_filter ~exclude_category entries
            in
            Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_dashboard_setup.mli
+++ b/lib/server/server_routes_http_routes_dashboard_setup.mli
@@ -13,6 +13,7 @@ val dashboard_logs_json :
   min_level:int ->
   module_filter:string ->
   since_seq:int option ->
+  before_seq:int option ->
   category_filter:string option ->
   exclude_category:string list option ->
   Log.Ring.entry list ->

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -86,6 +86,54 @@ let test_recent_since_seq_returns_only_new_entries () =
     [ warn_message; info_message ]
     (List.map (fun (entry : Log.Ring.entry) -> entry.message) entries)
 
+let test_recent_before_seq_returns_only_older_entries () =
+  (* Backward "load older" paging: [before_seq] must return entries strictly
+     older than the cursor, newest-first, respecting [limit], and compose with
+     [since_seq] into a bounded window. *)
+  let module_name = "TestLogBefore" in
+  let baseline = latest_seq () in
+  let messages =
+    List.init 3 (fun i ->
+      Printf.sprintf "before page msg %d %f" i (Unix.gettimeofday ()))
+  in
+  List.iter (fun m -> Log.info ~ctx:module_name "%s" m) messages;
+  (* Newest-first within this module: [m2; m1; m0]. *)
+  let scoped () =
+    Log.Ring.recent ~limit:10 ~module_filter:module_name ~since_seq:baseline ()
+  in
+  let seqs =
+    List.map (fun (entry : Log.Ring.entry) -> entry.seq, entry.message) (scoped ())
+  in
+  let seq_of message =
+    match List.find_opt (fun (_, m) -> String.equal m message) seqs with
+    | Some (seq, _) -> seq
+    | None -> Alcotest.fail (Printf.sprintf "seq not found for %s" message)
+  in
+  let m0 = List.nth messages 0 in
+  let m1 = List.nth messages 1 in
+  let m2 = List.nth messages 2 in
+  let names entries =
+    List.map (fun (entry : Log.Ring.entry) -> entry.message) entries
+  in
+  (* Strictly older than m2 → m1, m0 (newest-first). *)
+  Alcotest.(check (list string)) "before_seq excludes the cursor entry"
+    [ m1; m0 ]
+    (names
+       (Log.Ring.recent ~limit:10 ~module_filter:module_name
+          ~before_seq:(seq_of m2) ()));
+  (* limit caps the page, keeping the newest of the older slice. *)
+  Alcotest.(check (list string)) "before_seq respects limit"
+    [ m1 ]
+    (names
+       (Log.Ring.recent ~limit:1 ~module_filter:module_name
+          ~before_seq:(seq_of m2) ()));
+  (* since_seq lower bound + before_seq upper bound → bounded window {m1}. *)
+  Alcotest.(check (list string)) "before_seq composes with since_seq"
+    [ m1 ]
+    (names
+       (Log.Ring.recent ~limit:10 ~module_filter:module_name
+          ~since_seq:(seq_of m0) ~before_seq:(seq_of m2) ()))
+
 let oas_record ?(level = Agent_sdk.Log.Info) ~module_name ~message fields =
   Agent_sdk.Log.
     {
@@ -222,6 +270,8 @@ let () =
           test_legacy_traceln_records_metadata;
         Alcotest.test_case "recent since_seq returns only new entries" `Quick
           test_recent_since_seq_returns_only_new_entries;
+        Alcotest.test_case "recent before_seq returns only older entries" `Quick
+          test_recent_before_seq_returns_only_older_entries;
         Alcotest.test_case
           "oas bridge promotes MCP server failures"
           `Quick test_oas_bridge_promotes_mcp_server_failures_to_error;


### PR DESCRIPTION
## 요약

이벤트 로그 라우트는 지금까지 `since_seq`로 **새 행만** 전방 조회했고, 과거 이력으로 거슬러 올라가는 경로가 없었습니다 (KEEPER-V2 gap: event-log "load older" 부재). `before_seq` 백워드 커서를 추가해 대시보드가 더 오래된 페이지를 불러올 수 있도록 했습니다.

## 변경 내용

### Backend (OCaml)
- `lib/masc_log/log.ml` / `log.mli` — `Ring.recent`에 `?before_seq:int` 추가. seq가 커서보다 **엄격히 작은** 항목을 newest-first로 최대 `limit`개 반환. `since_seq`(하한)와 조합 시 bounded window로 동작하며, `before_seq` 미지정 시 기존 동작 불변.
- `lib/server/server_routes_http_routes_dashboard.ml` — `before_seq` 쿼리 파라미터를 `since_seq`와 동일하게 파싱(`int_query_param ~default:(-1)` 후 `>= 0` 가드, 음수/부재는 커서 없음). `Ring.recent`와 응답 빌더로 전달.
- `lib/server/server_dashboard_logs_json.ml` / `.mli`, `..._setup.mli` — 응답 `query` 메타에 `before_seq` 에코 (additive, 스키마 비파괴).

### Frontend (Preact + TS)
- `dashboard/src/api/dashboard.ts` — `fetchLogs` opts에 `before_seq?: number` 추가, `since_seq`와 동일한 음수 가드로 쿼리 파라미터 설정.
- `dashboard/src/api/schemas/logs.ts` — `LogsQuery`에 `before_seq?: number | null` 추가.
- `dashboard/src/components/logs.ts` — 리스트 하단에 "이전 기록 더 보기" 버튼 추가. 현재 표시된 최소 seq를 `before_seq`로 넘겨 과거 페이지를 append하고, `displayCap`를 키워 delta 폴러가 기존 행을 잘라내지 않도록 함. 더 오래된 기록이 없으면 안내 문구로 전환.

## 검증
- Backend: `dune build` (repo root) PASS. `test_masc_log.exe` 10 tests PASS (신규 `recent before_seq returns only older entries` 포함 — older-only / limit / since_seq 조합 검증).
- Frontend: `pnpm typecheck` PASS, `pnpm lint` PASS, `vitest run` (dashboard.test / schemas/logs.test / components/logs.test) 68 tests PASS (신규 `fetchLogs > before_seq` 3 케이스 + 스키마 `before_seq` 에코 포함).

## 경계
이 변경은 MASC 로그 서브시스템 + 대시보드에 한정되며, OAS(provider/model/transport/Agent Turn lifecycle)는 건드리지 않았습니다. credential/operator/repo/hooks/workflow 등 RFC 보호 서브시스템 비대상.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
