### PR TITLE
feat(turn-record): ground inspector model/finish/namespace/fsm fields from backend (RFC-0233)

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -18,6 +18,7 @@ import {
   fetchDashboardTools,
   fetchKeeperToolCalls,
   fetchKeeperToolStats,
+  fetchKeeperTurnRecords,
   fetchDashboardMemory,
   fetchDashboardMission,
   fetchDashboardMissionBriefing,
@@ -429,6 +430,55 @@ describe('keeper tool telemetry fetchers', () => {
     const result = await fetchKeeperToolCalls('keeper-alpha')
 
     expect(result.entries.map(entry => entry.duration_ms)).toEqual([null, null])
+  })
+
+  it('grounds turn-record model / finish_reason, leaving absent fields undefined', async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify({
+        keeper: 'keeper-alpha',
+        count: 2,
+        source: 'turn_record',
+        entries: [
+          {
+            record: {
+              keeper: 'keeper-alpha',
+              trace_id: 'trace-grounded',
+              absolute_turn: 7,
+              ts: 10,
+              runtime_profile: 'local',
+              model: 'deepseek-v4-flash',
+              finish_reason: 'completed',
+              blocks: [],
+              execution_ids: [],
+            },
+            diff_vs_prev: null,
+          },
+          {
+            // RFC-0233 §2.3: error turn omits model/finish_reason — must
+            // decode to undefined, never a fabricated "stop"/placeholder.
+            record: {
+              keeper: 'keeper-alpha',
+              trace_id: 'trace-grounded',
+              absolute_turn: 8,
+              ts: 11,
+              runtime_profile: 'local',
+              blocks: [],
+              execution_ids: [],
+            },
+            diff_vs_prev: null,
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperTurnRecords('keeper-alpha')
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/keeper-alpha/turn-records')
+    expect(result.entries[0]?.record.model).toBe('deepseek-v4-flash')
+    expect(result.entries[0]?.record.finish_reason).toBe('completed')
+    expect(result.entries[1]?.record.model).toBeUndefined()
+    expect(result.entries[1]?.record.finish_reason).toBeUndefined()
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2905,6 +2905,11 @@ export type TurnRecordEntry = {
   absolute_turn: number
   blocks: TurnBlock[]
   runtime_profile: string
+  // RFC-0233 §2.3 — grounded from the backend turn record (boundary-redacted
+  // model label + keeper stop reason). Absent (undefined) on error turns and
+  // pre-grounding rows; the inspector renders absence, never a fabricated value.
+  model?: string
+  finish_reason?: string
   temperature?: number
   thinking_budget?: number
   enable_thinking?: boolean
@@ -3039,6 +3044,8 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     absolute_turn,
     blocks: decodeTurnBlockList(raw.blocks),
     runtime_profile,
+    model: asString(raw.model),
+    finish_reason: asString(raw.finish_reason),
     temperature: asNumber(raw.temperature),
     thinking_budget: asNumber(raw.thinking_budget),
     enable_thinking: typeof raw.enable_thinking === 'boolean' ? raw.enable_thinking : undefined,

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -176,6 +176,8 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           absolute_turn: 42,
           ts: 1_781_587_560,
           runtime_profile: 'local',
+          model: 'deepseek-v4-flash',
+          finish_reason: 'completed',
           input_tokens: 2400,
           output_tokens: 280,
           blocks: [
@@ -470,6 +472,66 @@ describe('KeeperTurnInspector v2 drawer', () => {
     await waitFor(() => {
       expect(container.textContent).toContain('실행 메타데이터')
     })
+  })
+
+  it('grounds model / finish_reason from the record and marks deferred fields n/a', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-meta"]')!)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('실행 메타데이터')
+    })
+
+    const meta = container.querySelector('.kti-kv')?.textContent ?? ''
+    // grounded from the backend turn record (RFC-0233 §2.3)
+    expect(meta).toContain('deepseek-v4-flash')
+    expect(meta).toContain('completed')
+    // finish_reason is no longer the fabricated hardcoded 'stop'
+    expect(meta).not.toContain('stop')
+    // namespace / fsm.state are not captured in MASC — honest absence, not a guess
+    expect(meta).toContain('namespace')
+    expect(meta).toContain('fsm.state')
+    expect(meta).toContain('n/a')
+  })
+
+  it('renders finish_reason absence as n/a without fabricating a value', async () => {
+    const response = turnRecordsWithMemoryOs()
+    // strip the grounded meta fields → simulate an error turn / pre-grounding row
+    response.entries[1] = {
+      ...response.entries[1]!,
+      record: {
+        ...response.entries[1]!.record,
+        model: undefined,
+        finish_reason: undefined,
+      },
+    }
+    fetchKeeperTurnRecordsMock.mockResolvedValue(response)
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-meta"]')!)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('실행 메타데이터')
+    })
+
+    const meta = container.querySelector('.kti-kv')?.textContent ?? ''
+    expect(meta).not.toContain('stop')
+    expect(meta).not.toContain('deepseek-v4-flash')
+    expect(meta).toContain('n/a')
   })
 
   it('displays summary stats in the stat strip', async () => {

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -483,7 +483,10 @@ function thinkingChipLabel(record: TurnRecordEntry): string {
 
 function buildInjectedCtx(record: TurnRecordEntry, ctxPct: number, tokIn: number): string {
   return `# namespace snapshot
-fsm.state      = —
+namespace      = n/a
+fsm.state      = n/a
+model          = ${record.model ?? 'n/a'}
+finish_reason  = ${record.finish_reason ?? 'n/a'}
 ctx.window     = ${ctxPct.toFixed(1)}%   (${tokIn.toLocaleString()} / 200,000 tok)
 keeper.turn    = T${record.absolute_turn}
 thinking       = ${thinkingStateLabel(record)}
@@ -869,10 +872,10 @@ function MetaTab({ record, t, source }: { record: TurnRecordEntry; t: TurnDetail
       </div>
       <div class="kti-sec-h" style=${{ marginTop: '16px' }}><h4>실행 메타데이터</h4></div>
       <div class="kti-kv">
-        <span class="k">model</span><span class="v">—</span>
+        <span class="k">model</span><span class="v">${record.model ?? 'n/a'}</span>
         <span class="k">runtime</span><span class="v">${record.runtime_profile}</span>
-        <span class="k">namespace</span><span class="v">—</span>
-        <span class="k">fsm.state</span><span class="v">—</span>
+        <span class="k">namespace</span><span class="v">n/a</span>
+        <span class="k">fsm.state</span><span class="v">n/a</span>
         <span class="k">input tokens</span><span class="v">${t.tokIn.toLocaleString()}</span>
         <span class="k">output tokens</span><span class="v">${t.tokOut.toLocaleString()}</span>
         <span class="k">ctx window</span><span class="v">${t.ctxPct.toFixed(1)}% / 200K</span>
@@ -882,7 +885,7 @@ function MetaTab({ record, t, source }: { record: TurnRecordEntry; t: TurnDetail
         <span class="k">tool calls</span><span class="v">${t.tools.length}</span>
         <span class="k">measured phase duration</span><span class="v">${t.measuredDurationMs != null ? formatMsCompact(t.measuredDurationMs) : 'none'}</span>
         <span class="k">est. cost</span><span class="v">$${t.cost.toFixed(3)}</span>
-        <span class="k">finish_reason</span><span class="v">stop</span>
+        <span class="k">finish_reason</span><span class="v">${record.finish_reason ?? 'n/a'}</span>
         <span class="k">source</span><span class="v">${source}</span>
       </div>
     </div>
@@ -957,8 +960,8 @@ function TurnDetailDrawer({
           <span class="kti-chip">
             <span class="sub-k">thinking</span>${thinkingChipLabel(row.record)}
           </span>
-          <span class="kti-chip ok">
-            stop
+          <span class="kti-chip${row.record.finish_reason ? ' ok' : ''}">
+            <span class="sub-k">finish</span>${row.record.finish_reason ?? 'n/a'}
           </span>
           <span class="kti-chip">
             <span class="sub-k">runtime</span>${row.record.runtime_profile}

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -682,12 +682,25 @@ let run_turn
             }
           | Ok _ | Error _ -> { input_tokens = None; output_tokens = None }
         in
+        (* RFC-0233 §2.3 — views derive, no view-side repair: ground the
+           inspector's [model] and [finish_reason] in the same refs the
+           execution receipt already records this turn. [model] is the
+           RFC-0132 boundary-redacted runtime label; [finish_reason] is
+           the keeper stop reason serialized through the receipt SSOT
+           ([Keeper_execution_receipt.stop_reason_to_string]). Both are
+           [None] on the error path (receipt refs unset), never a
+           fabricated value. *)
         Keeper_turn_record_writer.write
           ~config
           ~keeper_name:meta.name
           ~trace_id
           ~absolute_turn:manifest_keeper_turn_id
           ~runtime_profile:runtime_id_string
+          ~model:!receipt_model_used_ref
+          ~finish_reason:
+            (Option.map
+               Keeper_execution_receipt.stop_reason_to_string
+               !receipt_stop_reason_ref)
           ~sampling:
             { temperature = Some temperature
             ; thinking_budget = tctx.thinking_budget

--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -4,6 +4,8 @@ let write
       ~trace_id
       ~absolute_turn
       ~runtime_profile
+      ~model
+      ~finish_reason
       ~sampling
       ~usage
       ~execution_ids
@@ -18,6 +20,8 @@ let write
     ; turn_ref = Some (Ids.Turn_ref.make ~trace_id ~absolute_turn)
     ; blocks
     ; runtime_profile
+    ; model
+    ; finish_reason
     ; sampling
     ; usage
     ; ts = Time_compat.now ()

--- a/lib/keeper/keeper_turn_record_writer.mli
+++ b/lib/keeper/keeper_turn_record_writer.mli
@@ -11,6 +11,8 @@ val write :
   trace_id:string ->
   absolute_turn:int ->
   runtime_profile:string ->
+  model:string option ->
+  finish_reason:string option ->
   sampling:Turn_record.sampling ->
   usage:Turn_record.usage ->
   execution_ids:Ids.Execution_id.t list ->

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -23,6 +23,8 @@ type t =
   ; turn_ref : Ids.Turn_ref.t option
   ; blocks : prompt_block list
   ; runtime_profile : string
+  ; model : string option
+  ; finish_reason : string option
   ; sampling : sampling
   ; usage : usage
   ; ts : float
@@ -52,6 +54,8 @@ let to_json (r : t) : Yojson.Safe.t =
      ; ("runtime_profile", `String r.runtime_profile)
      ]
     @ opt_field "turn_ref" Ids.Turn_ref.to_yojson r.turn_ref
+    @ opt_field "model" (fun v -> `String v) r.model
+    @ opt_field "finish_reason" (fun v -> `String v) r.finish_reason
     @ opt_field "temperature" (fun v -> `Float v) r.sampling.temperature
     @ opt_field "thinking_budget" (fun v -> `Int v) r.sampling.thinking_budget
     @ opt_field "enable_thinking" (fun v -> `Bool v) r.sampling.enable_thinking
@@ -141,6 +145,8 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
       let* profile_json = require "runtime_profile" fields in
       let* runtime_profile = as_string "runtime_profile" profile_json in
       let* turn_ref = opt_member "turn_ref" fields as_turn_ref in
+      let* model = opt_member "model" fields as_string in
+      let* finish_reason = opt_member "finish_reason" fields as_string in
       let* temperature = opt_member "temperature" fields as_float in
       let* thinking_budget = opt_member "thinking_budget" fields as_int in
       let* enable_thinking = opt_member "enable_thinking" fields as_bool in
@@ -156,6 +162,8 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; turn_ref
         ; blocks
         ; runtime_profile
+        ; model
+        ; finish_reason
         ; sampling = { temperature; thinking_budget; enable_thinking }
         ; usage = { input_tokens; output_tokens }
         ; ts

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -38,6 +38,17 @@ type t =
        [option] so pre-§7 rows decode as [None]. *)
   ; blocks : prompt_block list (* assembly order *)
   ; runtime_profile : string
+  ; model : string option
+    (* RFC-0233 §2.2/§2.3 — boundary-redacted runtime model label, the
+       same value the execution receipt surfaces (RFC-0132 redaction
+       SSOT). [option] so error turns and pre-grounding rows decode as
+       [None]; the inspector renders absence rather than a fabricated
+       name. *)
+  ; finish_reason : string option
+    (* RFC-0233 §2.3 — keeper turn stop reason, serialized via the
+       receipt SSOT [Keeper_execution_receipt.stop_reason_to_string].
+       [None] when the turn errored before a stop reason was recorded;
+       an unknown reason is never collapsed to a fake "stop". *)
   ; sampling : sampling
   ; usage : usage
   ; ts : float

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -45,6 +45,8 @@ let sample_record () : Turn_record.t =
       ; sample_block Prompt_block_id.Memory_os_recall "cccc"
       ]
   ; runtime_profile = "ollama_cloud.deepseek-v4-flash"
+  ; model = Some "deepseek-v4-flash"
+  ; finish_reason = Some "completed"
   ; sampling =
       { temperature = Some 0.3; thinking_budget = Some 1500; enable_thinking = Some true }
   ; usage = { input_tokens = Some 18000; output_tokens = Some 412 }
@@ -77,6 +79,8 @@ let test_codec_roundtrip () =
            && String.equal a.digest b.digest)
          record.blocks decoded.blocks);
     check string "runtime_profile" record.runtime_profile decoded.runtime_profile;
+    check (option string) "model" record.model decoded.model;
+    check (option string) "finish_reason" record.finish_reason decoded.finish_reason;
     check (option (float 0.0001)) "temperature" record.sampling.temperature
       decoded.sampling.temperature;
     check (option int) "thinking_budget" record.sampling.thinking_budget
@@ -92,14 +96,29 @@ let test_codec_roundtrip () =
 let test_codec_optional_fields_absent () =
   let record =
     { (sample_record ()) with
-      sampling = { temperature = None; thinking_budget = None; enable_thinking = None }
+      model = None
+    ; finish_reason = None
+    ; sampling = { temperature = None; thinking_budget = None; enable_thinking = None }
     ; usage = { input_tokens = None; output_tokens = None }
     ; turn_ref = None
     }
   in
-  match Turn_record.of_json (Turn_record.to_json record) with
+  let json = Turn_record.to_json record in
+  (* RFC-0233 §2.3: absent meta fields are omitted from the wire, never
+     emitted as a fabricated value (no "stop", no placeholder model). *)
+  (match json with
+   | `Assoc fields ->
+     check bool "finish_reason key omitted when None" false
+       (List.mem_assoc "finish_reason" fields);
+     check bool "model key omitted when None" false
+       (List.mem_assoc "model" fields)
+   | _ -> fail "to_json did not produce an object");
+  match Turn_record.of_json json with
   | Error e -> failf "decode failed: %s" e
   | Ok decoded ->
+    check (option string) "model absent stays None" None decoded.model;
+    check (option string) "finish_reason absent stays None (not \"stop\")" None
+      decoded.finish_reason;
     check (option (float 0.0001)) "temperature absent" None
       decoded.sampling.temperature;
     check (option int) "input_tokens absent" None decoded.usage.input_tokens;


### PR DESCRIPTION
## 목적

Turn Inspector UI는 완성되어 있지만 `model` / `finish_reason` / `namespace` / `fsm.state`를 **프론트엔드에서 날조**하고 있었다 (KEEPER-V2 gap P0). 서버 `TurnRecordEntry`가 이 값들을 담지 않아 inspector가 `model = "—"`, `finish_reason = "stop"` (하드코딩), `namespace/fsm.state = "—"`로 표시했다. 백엔드 turn record에 **실제로 존재하는** 값만 grounding 하고, 존재하지 않는 값은 날조하지 않고 부재(`n/a`)로 정직하게 표시한다.

## RFC-0233 인용

`docs/rfc/RFC-0233-turn-observability-execution-identity.md`

§2.3 "Views derive; no view-side repair":

> - Dashboard turn inspector reads TurnRecord (blocks, sampling, usage) and renders block-diff between turns.

inspector가 하드코딩 `"stop"`을 출력하던 것은 이 원칙(뷰는 record에서 파생, 뷰-사이드 보수 금지) 위반이었다. §2.2는 `turn_record` 타입을 정의하며, 본 PR은 그 타입에 **additive optional 필드**만 추가한다 (§3 non-goals "No new telemetry pipeline", "No OAS API change" 준수 — OAS는 건드리지 않음).

## Grounded vs Deferred (4개 메타 필드)

| 필드 | 상태 | 근거 |
|------|------|------|
| **model** | ✅ Grounded | MASC turn-record 구성 지점(`keeper_agent_run.ml`)에서 `!receipt_model_used_ref` (string option)로 이미 가용. execution receipt가 surface 하는 것과 동일한 RFC-0132 boundary-redacted runtime model label. |
| **finish_reason** | ✅ Grounded | `!receipt_stop_reason_ref` (`Runtime_agent.stop_reason` option)를 receipt SSOT `Keeper_execution_receipt.stop_reason_to_string`로 직렬화. closed variant exhaustive 매핑이라 unknown이 가짜 `"stop"`으로 붕괴되지 않음. error turn에서는 `None`. |
| **namespace** | ⏸ Deferred | MASC keeper 모델에 namespace 개념이 존재하지 않음 (`rg namespace lib/keeper` 결과 keeper identity는 `keeper`/`meta.name` 뿐). 값을 만들어내려면 의미를 발명해야 하므로 grounding 불가. UI는 `n/a`로 부재 표시. |
| **fsm.state** | ⏸ Deferred | keeper lifecycle/turn FSM 상태가 turn-record 기록 지점(단일 turn 실행 tail)에서 캡처되지 않음. 올바른 FSM 상태를 surface 하려면 turn lifecycle 전반에 새 캡처 plumbing이 필요 — 본 PR(메타 필드 한정) 범위 밖. UI는 `n/a`로 부재 표시. |

정직한 subset(2/4 grounding)이 날조보다 낫다는 contract 원칙을 따랐다.

## 변경 내용

**Backend**
- `lib/types/turn_record.{ml,mli}`: `type t`에 `model : string option`, `finish_reason : string option` 추가. `to_json`/`of_json` additive(None이면 wire에서 생략). 기존 consumer 무영향.
- `lib/keeper/keeper_turn_record_writer.{ml,mli}`: `~model` / `~finish_reason` 파라미터 추가.
- `lib/keeper/keeper_agent_run.ml`: 구성 지점에서 receipt ref들로 grounding (error path는 `None`, 가짜 값 없음).

**Frontend**
- `dashboard/src/api/dashboard.ts`: `TurnRecordEntry`에 `model?`, `finish_reason?` 추가 + `decodeTurnRecordEntry` 디코드.
- `dashboard/src/components/keeper-turn-inspector.ts`: `model`/`finish_reason`를 record의 실제 값으로 렌더, 하드코딩 `"stop"`/`"—"` 제거. `namespace`/`fsm.state`는 `n/a`로 정직하게 표시.

**Tests**
- `test/test_turn_record.ml`: codec round-trip에 두 필드 추가, 부재 시 `None` 유지 + wire에서 key 생략 검증 (unknown finish_reason이 `"stop"`으로 defaulting 되지 않음).
- `dashboard/src/api/dashboard.test.ts`: 디코드가 두 필드를 surface, 부재 시 `undefined` 검증.
- `dashboard/src/components/keeper-turn-inspector.test.ts`: inspector가 실제 값 렌더 vs 부재(`n/a`) 렌더 검증.

## Deferred follow-up (이 PR 범위 밖, 별도 작업)

- **namespace / fsm.state grounding**: MASC에 keeper namespace 개념 도입 여부, turn-record 기록 지점까지 FSM 상태 plumbing — RFC 단위 설계 필요.
- **실제 transcript content / 실제 tool call I/O** surfacing (더 큰 별도 후속 작업).

## 검증

- Backend: `dune build --root .` → exit 0. `dune exec test/test_turn_record.exe` → 12 tests pass.
- Frontend: `npx tsc --noEmit` clean, `eslint` clean(소스 파일), `npx vitest run` → 69 tests pass (touched files).

RFC-WAIVED: 본 변경은 credential/identity/operator/sandbox/hooks subsystem이 아닌 turn observability(RFC-0233 PR-4 후속)에 한정됨. RFC-0233 §2.3 인용으로 설계 근거 충족.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
