### PR TITLE
feat(dashboard): right-click roster menu + group status dots (keeper-v2 Unit 5b)

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -136,6 +136,53 @@ describe('KeeperWorkspaceRoster', () => {
     expect(host.querySelector('[data-testid="kw-roster-menu"]')).toBeNull()
   })
 
+  it('opens the command menu on right-click (contextmenu) without selecting the row', () => {
+    const onSelect = vi.fn()
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" onSelect=${onSelect} />`, host)
+    const rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
+    const sangsuRow = rows.find(r => r.textContent?.includes('sangsu')) as HTMLElement
+
+    // fireEvent returns false when the (cancelable) event had preventDefault
+    // called — i.e. the native browser context menu is suppressed.
+    const notPrevented = fireEvent.contextMenu(sangsuRow, { clientX: 120, clientY: 80 })
+    expect(notPrevented).toBe(false)
+
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).not.toBeNull()
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')?.textContent).toContain('sangsu')
+    expect(host.querySelector('[data-testid="kw-roster-menu-open-chat"]')).not.toBeNull()
+    expect(navigate).not.toHaveBeenCalled()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('opens the command menu on right-click of a mini-roster sigil', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" mini=${true} />`, host)
+    const minis = Array.from(host.querySelectorAll('.kw-kp-mini')) as HTMLElement[]
+    const ramaMini = minis.find(b => (b.getAttribute('aria-label') ?? '').includes('rama')) as HTMLElement
+
+    fireEvent.contextMenu(ramaMini, { clientX: 60, clientY: 200 })
+
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')).not.toBeNull()
+    expect(host.querySelector('[data-testid="kw-roster-menu"]')?.textContent).toContain('rama')
+  })
+
+  it('renders a status-toned dot in each group header (rg-dot)', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    const groupDotTone = (label: string): string | undefined => {
+      const header = Array.from(host.querySelectorAll('.kw-roster-group')).find(
+        g => g.querySelector('.kw-roster-group-label')?.textContent === label,
+      )
+      return header?.querySelector('.kw-dot')?.className
+    }
+    // running → ok (green), paused → warn (amber), offline → idle (no tone class)
+    expect(groupDotTone('실행 중')).toContain('ok')
+    expect(groupDotTone('대기 · 일시정지')).toContain('warn')
+    const offlineDot = groupDotTone('중지 · 종료됨')
+    expect(offlineDot).toBeDefined()
+    expect(offlineDot).not.toContain('ok')
+    expect(offlineDot).not.toContain('warn')
+    expect(offlineDot).not.toContain('bad')
+  })
+
   it('filters by search query', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     const search = host.querySelector('.kw-roster-search') as HTMLInputElement
@@ -232,6 +279,9 @@ describe('KeeperWorkspaceRoster', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="keeper-0" />`, host)
     expect(host.querySelector('.virtual-list-spacer')).not.toBeNull()
     expect(host.querySelector('.kw-roster-list')).not.toBeNull()
+    // The windowed path renders the group header through the same renderHeader(),
+    // so the status dot must appear here too (all 60 keepers are running → ok).
+    expect(host.querySelector('.kw-roster-group .kw-dot.ok')).not.toBeNull()
   })
 
   it('renders the sort select defaulting to status order', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -32,6 +32,7 @@ import {
   keeperStatusTone,
   keeperPhaseLabel,
   type KeeperBucket,
+  type DotTone,
 } from './keeper-workspace-shared'
 
 type RosterFilter = 'all' | 'run' | 'att'
@@ -77,6 +78,15 @@ const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
   { bucket: 'paused', label: '대기 · 일시정지' },
   { bucket: 'offline', label: '중지 · 종료됨' },
 ]
+
+/** Group-header status dot tone (design rails.jsx `.rg-dot` colored by groupCls).
+ *  Reuses the shared StatusDot vocabulary instead of a bespoke dot so the header
+ *  marker matches the per-row dots: running→ok, paused→warn, offline→idle. */
+const GROUP_BUCKET_TONE: Record<KeeperBucket, DotTone> = {
+  running: 'ok',
+  paused: 'warn',
+  offline: 'idle',
+}
 
 /** Flattened roster item used by the virtualized render path. */
 type RosterItem =
@@ -178,6 +188,7 @@ function RosterRow({
       style=${style}
       aria-current=${active ? 'true' : 'false'}
       onClick=${select}
+      onContextMenu=${(event: MouseEvent) => onMenu(keeper, event)}
       onKeyDown=${(event: KeyboardEvent) => {
         if (event.key !== 'Enter' && event.key !== ' ') return
         event.preventDefault()
@@ -202,11 +213,7 @@ function RosterRow({
         class="kw-kp-more v2-monitoring-action"
         aria-label=${`${keeper.name} 명령`}
         title="keeper 명령"
-        onClick=${(event: MouseEvent) => {
-          event.preventDefault()
-          event.stopPropagation()
-          onMenu(keeper, event)
-        }}
+        onClick=${(event: MouseEvent) => onMenu(keeper, event)}
         data-testid=${`kw-roster-menu-${keeper.name}`}
       >
         <${MoreHorizontal} size=${15} aria-hidden="true" />
@@ -219,10 +226,12 @@ function MiniRosterRow({
   keeper,
   active,
   onSelect,
+  onMenu,
 }: {
   keeper: Keeper
   active: boolean
   onSelect: (name: string) => void
+  onMenu: (keeper: Keeper, event: MouseEvent) => void
 }) {
   const bucket = keeperBucket(keeper)
   const tone = keeperStatusTone(keeper)
@@ -235,6 +244,7 @@ function MiniRosterRow({
       aria-label=${label}
       title=${label}
       onClick=${() => onSelect(keeper.name)}
+      onContextMenu=${(event: MouseEvent) => onMenu(keeper, event)}
     >
       <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
       <${StatusDot} tone=${tone} pulse=${bucket === 'running'} />
@@ -396,16 +406,33 @@ export function KeeperWorkspaceRoster({
   }
 
   const openMenu = (keeper: Keeper, event: MouseEvent) => {
+    // Centralized here so both entry points behave: the ⋯ button click and a
+    // right-click on the row. preventDefault suppresses the browser's native
+    // context menu on right-click; stopPropagation keeps a ⋯ click from also
+    // selecting the row (the click would otherwise bubble to the row onClick).
+    event.preventDefault()
+    event.stopPropagation()
     const target = event.currentTarget as HTMLElement
-    const rect = target.getBoundingClientRect()
     const rosterRect = target.closest('.kw-roster')?.getBoundingClientRect() ?? { left: 0, top: 0 }
+    // Right-click anchors the menu at the cursor (design rails.jsx openMenu); the
+    // ⋯ button right-aligns the menu just below itself.
+    let anchorRight: number
+    let anchorTop: number
+    if (event.type === 'contextmenu') {
+      anchorRight = event.clientX + MENU_WIDTH
+      anchorTop = event.clientY
+    } else {
+      const rect = target.getBoundingClientRect()
+      anchorRight = rect.right
+      anchorTop = rect.bottom + MENU_VIEWPORT_MARGIN
+    }
     const viewportX = Math.max(
       MENU_VIEWPORT_MARGIN,
-      Math.min(rect.right - MENU_WIDTH, window.innerWidth - MENU_WIDTH - MENU_VIEWPORT_MARGIN),
+      Math.min(anchorRight - MENU_WIDTH, window.innerWidth - MENU_WIDTH - MENU_VIEWPORT_MARGIN),
     )
     const viewportY = Math.max(
       MENU_VIEWPORT_MARGIN,
-      Math.min(rect.bottom + MENU_VIEWPORT_MARGIN, window.innerHeight - MENU_ESTIMATED_HEIGHT - MENU_VIEWPORT_MARGIN),
+      Math.min(anchorTop, window.innerHeight - MENU_ESTIMATED_HEIGHT - MENU_VIEWPORT_MARGIN),
     )
     setMenu({
       keeper,
@@ -443,9 +470,15 @@ export function KeeperWorkspaceRoster({
   const rowStyle = 'content-visibility:auto;contain-intrinsic-size:auto 58px'
   const miniRows = sortRows(all)
 
+  // Single source for the group header so the windowed and non-windowed render
+  // paths can't drift (they previously inlined the header markup separately).
+  function renderHeader(item: Extract<RosterItem, { type: 'header' }>): VNode {
+    return html`<div class="kw-roster-group v2-monitoring-row" key=${`h:${item.bucket}`}><${StatusDot} tone=${GROUP_BUCKET_TONE[item.bucket]} /><span class="kw-roster-group-label">${item.label}</span><span class="kw-roster-group-n">${item.count}</span></div>`
+  }
+
   function renderItem(item: RosterItem): VNode {
     if (item.type === 'header') {
-      return html`<div class="kw-roster-group v2-monitoring-row"><span class="kw-roster-group-label">${item.label}</span><span class="kw-roster-group-n">${item.count}</span></div>`
+      return renderHeader(item)
     }
     return html`<${RosterRow} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} />`
   }
@@ -458,7 +491,7 @@ export function KeeperWorkspaceRoster({
     <aside class=${`kw-roster${mini ? ' mini' : ''} v2-monitoring-surface`} aria-label="키퍼 로스터">
       ${mini
         ? html`<div class="kw-roster-mini-list">
-            ${miniRows.map(k => html`<${MiniRosterRow} key=${k.name} keeper=${k} active=${k.name === activeName} onSelect=${select} />`)}
+            ${miniRows.map(k => html`<${MiniRosterRow} key=${k.name} keeper=${k} active=${k.name === activeName} onSelect=${select} onMenu=${openMenu} />`)}
           </div>`
         : html`
           <div class="kw-roster-head v2-monitoring-toolbar">
@@ -505,7 +538,7 @@ export function KeeperWorkspaceRoster({
             />`
           : html`<div class="kw-roster-list">
               ${items.map(item => item.type === 'header'
-                ? html`<div class="kw-roster-group v2-monitoring-row" key=${`h:${item.bucket}`}><span class="kw-roster-group-label">${item.label}</span><span class="kw-roster-group-n">${item.count}</span></div>`
+                ? renderHeader(item)
                 : html`<${RosterRow} key=${item.keeper.name} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} style=${rowStyle} />`)}
             </div>`}
         `}


### PR DESCRIPTION
## 무엇을 / 왜

keeper-v2 **Unit 5b** — 로스터(rails.jsx `Roster`)의 두 미비점을 채웁니다.
1. 디자인은 행 **우클릭**으로 keeper 명령 메뉴를 cursor 위치에 열지만, 로컬은 trailing `⋯` 버튼으로만 열렸습니다.
2. 디자인 그룹 헤더는 상태 색 dot(`.rg-dot`)을 표시하지만, 로컬 헤더엔 라벨+카운트만 있었습니다.

(#21868 Unit 5a follow-up. mini hover flyout + peek-expand는 mini 64px 고정폭 모델과의 상호작용 설계가 필요해 별도 follow-up으로 보류.)

## 변경

- **우클릭 메뉴**: 로스터 행과 mini-roster sigil에 `onContextMenu` → 기존 `KeeperRosterMenu`를 cursor 위치에 연다.
- **`openMenu` 일반화**: `contextmenu` 이벤트는 cursor(`clientX/Y`) 기준(좌상단을 포인터에 정렬), `⋯` 버튼은 기존대로 버튼 아래 우측 정렬. `preventDefault`/`stopPropagation`을 `openMenu`로 중앙화 — 우클릭의 네이티브 메뉴 억제 + 버튼/우클릭이 행 선택으로 새지 않게.
- **그룹 status dot**: 헤더 라벨 앞에 `StatusDot`(공유 dot 어휘 재사용) — running→ok, paused→warn, offline→idle.
- **헤더 마크업 dedup**: virtual/비-virtual 두 렌더 경로가 각자 인라인하던 그룹 헤더를 단일 `renderHeader()`로 통합(둘 다 dot 렌더, key 보존).

**CSS 변경 없음**: 메뉴는 `.kw-kp-menu`, dot은 `.kw-dot` 재사용.

## 검증

- `tsc --noEmit`: 0 errors · `eslint`: clean
- `vitest`: roster **28 passed**(우클릭 행 메뉴+네이티브 억제+무선택, 우클릭 mini sigil, 버킷별 헤더 dot 톤) + keeper-workspace/detail-page **69 passed**(회귀 없음)
- fresh-context 적대 리뷰

## 참고

데이터/디자인 grounding: 우클릭 메뉴는 기존 lifecycle action 메뉴를 그대로 연다(새 액션 추가 없음). dot 톤은 keeper 행 dot과 동일 어휘(`StatusDot`)라 시각 일관.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
