### PR TITLE
feat(board): carry turn_ref origin on keeper-authored board posts (RFC-0233 §7)

### DIFF
--- a/lib/board_types/board_types.ml
+++ b/lib/board_types/board_types.ml
@@ -161,6 +161,17 @@ type post_origin = {
   fusion_run_id: string option;
 }
 
+(* RFC-0233 §7: constructor for a keeper-authored post's origin. A keeper post
+   is the output of a specific keeper turn, so [turn_ref] is the turn-level join
+   key and [source] names the producing channel (e.g. "keeper_speech",
+   "keeper_alert"). [fusion_run_id] is always [None] here: fusion's
+   server-root-switch fork has its own constructor at the fusion sink. [turn_ref]
+   stays optional so callers that cannot reach a mint-once-safe turn reference
+   still set [source] (origin present, turn_ref absent) rather than fabricating
+   one. *)
+let keeper_authored_origin ?turn_ref ~source () : post_origin =
+  { turn_ref; source = Some source; fusion_run_id = None }
+
 type post = {
   id: Post_id.t;
   author: Agent_id.t;

--- a/lib/board_types/board_types.mli
+++ b/lib/board_types/board_types.mli
@@ -101,6 +101,13 @@ type post_origin = {
   fusion_run_id : string option;
 }
 
+val keeper_authored_origin :
+  ?turn_ref:Ids.Turn_ref.t -> source:string -> unit -> post_origin
+(** RFC-0233 §7: build the [origin] of a keeper-authored board post.
+    [fusion_run_id] is always [None] (fusion has its own origin at the sink);
+    [source] names the producing channel; [turn_ref] is the turn-level join key
+    and is [None] only when no mint-once-safe reference is reachable. *)
+
 type post = {
   id : Post_id.t;
   author : Agent_id.t;

--- a/lib/keeper/keeper_alerting.ml
+++ b/lib/keeper/keeper_alerting.ml
@@ -295,10 +295,19 @@ let post_keeper_alert_board
     | None -> Board.Internal
   in
   let meta_json = Some (`Assoc [ ("source", `String "keeper_alert_board") ]) in
+  (* RFC-0233 §7: stamp the typed origin so an alert board post is no longer
+     origin-less. [turn_ref] is [None] here (scoped down, not fabricated):
+     [post_keeper_alert_board] only receives [~alert_text], and its sole caller
+     [maybe_emit_interesting_alert] runs post-turn where [meta] is no longer a
+     mint-once-safe turn reference (trace_id may have rotated on handoff). Root
+     fix: thread the turn's minted [turn_ref] from the turn loop into the alert
+     path when alert emission is wired back into the keeper turn — same
+     "mint once, thread down" pattern used for keeper_speech. *)
+  let origin = Board.keeper_authored_origin ~source:"keeper_alert" () in
   match
     Board_dispatch.create_post ~author ~content:alert_text
       ~post_kind:Board.System_post ?meta_json
-      ~visibility ~ttl_hours:24 ?hearth:hearth_opt ()
+      ~visibility ~ttl_hours:24 ?hearth:hearth_opt ~origin ()
   with
   | Ok _ -> Alert_sent (Some "board_posted")
   | Error e -> Alert_failed (Some (Board.show_board_error e))

--- a/lib/keeper/keeper_social_model.mli
+++ b/lib/keeper/keeper_social_model.mli
@@ -87,6 +87,7 @@ val derive_failure_state :
   social_state * transition_reason
 
 val apply_to_result :
+  ?turn_ref:Ids.Turn_ref.t ->
   meta:Keeper_meta_contract.keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   previous_state:social_state option ->

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -52,6 +52,16 @@ let run_keeper_cycle
      pre-dispatch checks (see turn_livelock guard below), leaving silent
      skip paths without a turn correlator. *)
   let keeper_turn_id = meta.runtime.usage.total_turns + 1 in
+  (* RFC-0233 §7.2 (mint once, thread down): mint the turn's join key from this
+     single pre-turn snapshot — the same (trace_id, total_turns + 1) pair the
+     manifest and Turn_record stamp — and thread it into the success handler so
+     a keeper-authored board post carries [origin.turn_ref]. Never re-derive at
+     a downstream seam from a post-lifecycle meta (trace_id rotates on handoff). *)
+  let turn_ref =
+    Ids.Turn_ref.make
+      ~trace_id:(Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+      ~absolute_turn:keeper_turn_id
+  in
   let runtime_manifest_context : Keeper_runtime_manifest.turn_context =
     { manifest_keeper_name = meta.name
     ; manifest_agent_name = Some meta.agent_name
@@ -974,6 +984,7 @@ dominant source of the observed CAS race exhaustion after
                       ~last_provider_timeout_budget:turn_state.last_provider_timeout_budget
                       ~current_turn_blocker_info:turn_state.current_turn_blocker_info
                       ~keeper_turn_id
+                      ~turn_ref
                       result
                   in
                   (* Cycle 45: KeeperTaskAcquisition.tla TurnComplete post-action. *)

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -449,11 +449,15 @@ let handle
       ~last_provider_timeout_budget
       ~current_turn_blocker_info
       ~keeper_turn_id
+      ?(turn_ref : Ids.Turn_ref.t option)
       result
   =
   let explicit_accountability_claim = Social.extract_accountability_claim result in
+  (* RFC-0233 §7: the social model may author a keeper board post (request-help);
+     thread the turn's minted join key so that post carries [origin.turn_ref]. *)
   let result, social_state, social_transition_reason =
-    Social.apply_to_result ~meta ~observation ~previous_state:previous_social_state result
+    Social.apply_to_result ?turn_ref ~meta ~observation
+      ~previous_state:previous_social_state result
   in
   let turn_cost = turn_cost result in
   let lifecycle =

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -21,5 +21,6 @@ val handle
        Keeper_turn_runtime_budget.provider_timeout_budget option
   -> current_turn_blocker_info:Keeper_meta_contract.blocker_info option
   -> keeper_turn_id:int
+  -> ?turn_ref:Ids.Turn_ref.t
   -> Keeper_agent_run.run_result
   -> Keeper_meta_contract.keeper_meta

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.ml
@@ -288,8 +288,8 @@ let request_help_post_body ~(meta : keeper_meta)
       "retry condition: external capability or operator guidance becomes available";
     ]
 
-let deliver_request_help_post ~(meta : keeper_meta)
-    ~(state : Types.social_state) =
+let deliver_request_help_post ?(turn_ref : Ids.Turn_ref.t option)
+    ~(meta : keeper_meta) ~(state : Types.social_state) () =
   match state.blocker with
   | None -> Request_help_failed
   | Some blocker when should_dedupe_request_help ~meta ~blocker:(Some blocker)
@@ -313,10 +313,15 @@ let deliver_request_help_post ~(meta : keeper_meta)
               ( "need", Json_util.string_opt_to_json state.need );
             ])
       in
+      (* RFC-0233 §7: a keeper request-help post is the output of this keeper's
+         turn; stamp the typed origin so the dashboard/board can trace it back
+         to the producing turn. [turn_ref] is minted once upstream (keeper turn)
+         and threaded down; [None] only on paths that cannot reach it. *)
+      let origin = Board.keeper_authored_origin ?turn_ref ~source:"keeper_speech" () in
       match
         Board_dispatch.create_post ~author:meta.name ~title ~body ~content:body
           ~post_kind:Board.Automation_post ?meta_json
-          ~visibility:Board.Internal ~ttl_hours:24 ~hearth:"keepers" ()
+          ~visibility:Board.Internal ~ttl_hours:24 ~hearth:"keepers" ~origin ()
       with
       | Ok _ -> Request_help_posted
       | Error _ -> Request_help_failed
@@ -365,13 +370,14 @@ let transition (previous_state : state option) (input : input) =
     in
     (state, output, Types.Protocol_violation_no_tools_no_social_headers)
 
-let apply_output_to_result ~(meta : keeper_meta)
+let apply_output_to_result ?(turn_ref : Ids.Turn_ref.t option)
+    ~(meta : keeper_meta)
     ~(result : Keeper_agent_run.run_result)
     ~(visible_response_body : string) (state : Types.social_state) =
   let tool_names = Keeper_agent_result.tool_names result in
   match state.speech_act, state.delivery_surface with
   | Request_help, Board_post when tool_names = [] ->
-      (match deliver_request_help_post ~meta ~state with
+      (match deliver_request_help_post ?turn_ref ~meta ~state () with
       | Request_help_posted ->
           ({ result with response_text = "" }, state)
       | Request_help_deduped | Request_help_failed ->
@@ -391,7 +397,7 @@ let apply_output_to_result ~(meta : keeper_meta)
          is intentionally left non-empty (#20870 watermark-stall failure mode). *)
       ({ result with response_text = visible_response_body }, state)
 
-let apply_to_result ~(meta : keeper_meta)
+let apply_to_result ?(turn_ref : Ids.Turn_ref.t option) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(previous_state : Types.social_state option)
     (result : Keeper_agent_run.run_result) =
@@ -414,7 +420,8 @@ let apply_to_result ~(meta : keeper_meta)
   let state, output, transition_reason = transition prior_state input in
   let social_state = to_social_state state output in
   let result, social_state =
-    apply_output_to_result ~meta ~result ~visible_response_body social_state
+    apply_output_to_result ?turn_ref ~meta ~result ~visible_response_body
+      social_state
   in
   (result, social_state, transition_reason)
 

--- a/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_bdi_speech_v1.mli
@@ -25,6 +25,7 @@ type output = {
 }
 
 val apply_to_result :
+  ?turn_ref:Ids.Turn_ref.t ->
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.ml
@@ -169,13 +169,13 @@ let visible_response_body_of_result (result : Keeper_agent_run.run_result) =
   let _, response_body = Protocol.parse_header_block result.response_text in
   Keeper_text_processing.strip_internal_reply_markup response_body |> String.trim
 
-let apply_to_result ~(meta : keeper_meta)
+let apply_to_result ?(turn_ref : Ids.Turn_ref.t option) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(previous_state : Types.social_state option)
     (result : Keeper_agent_run.run_result) =
   let has_text_reply = visible_response_body_of_result result <> "" in
   let base_result, base_state, base_reason =
-    Bdi.apply_to_result ~meta ~observation ~previous_state result
+    Bdi.apply_to_result ?turn_ref ~meta ~observation ~previous_state result
   in
   let state =
     if should_overlay_ledger base_reason then

--- a/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.mli
+++ b/lib/keeper/social_model/keeper_social_model_magentic_ledger_v1.mli
@@ -3,6 +3,7 @@ open Keeper_meta_contract
 open Keeper_types_profile
 
 val apply_to_result :
+  ?turn_ref:Ids.Turn_ref.t ->
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->

--- a/lib/keeper/social_model/keeper_social_model_registry.ml
+++ b/lib/keeper/social_model/keeper_social_model_registry.ml
@@ -9,16 +9,16 @@ let active_model_of_meta (meta : keeper_meta) =
   | Some model_id -> model_id
   | None -> Types.default_model_id
 
-let apply_to_result ~(meta : keeper_meta)
+let apply_to_result ?(turn_ref : Ids.Turn_ref.t option) ~(meta : keeper_meta)
     ~(observation : Keeper_world_observation.world_observation)
     ~(previous_state : Types.social_state option)
     (result : Keeper_agent_run.run_result) =
   match active_model_of_meta meta with
   | Types.Bdi_speech_v1 ->
-      Keeper_social_model_bdi_speech_v1.apply_to_result ~meta ~observation
-        ~previous_state result
+      Keeper_social_model_bdi_speech_v1.apply_to_result ?turn_ref ~meta
+        ~observation ~previous_state result
   | Types.Magentic_ledger_v1 ->
-      Keeper_social_model_magentic_ledger_v1.apply_to_result ~meta
+      Keeper_social_model_magentic_ledger_v1.apply_to_result ?turn_ref ~meta
         ~observation ~previous_state result
 
 let derive_failure_state ~(meta : keeper_meta)

--- a/lib/keeper/social_model/keeper_social_model_registry.mli
+++ b/lib/keeper/social_model/keeper_social_model_registry.mli
@@ -3,6 +3,7 @@ open Keeper_meta_contract
 open Keeper_types_profile
 
 val apply_to_result :
+  ?turn_ref:Ids.Turn_ref.t ->
   meta:keeper_meta ->
   observation:Keeper_world_observation.world_observation ->
   previous_state:Keeper_social_model_types.social_state option ->

--- a/test/test_board_post_origin.ml
+++ b/test/test_board_post_origin.ml
@@ -131,6 +131,45 @@ let test_malformed_origin_preserves_post () =
   | None -> Alcotest.fail "row dropped on malformed turn_ref (must be preserved)"
 ;;
 
+(* Producer side (RFC-0233 §7): the keeper-authored origin constructor used by
+   keeper_speech (request-help posts) and keeper_alert. Pins that a keeper post
+   carries [origin.turn_ref = Some _] and a typed [source], with
+   [fusion_run_id = None] (fusion has its own constructor at the sink). *)
+let test_keeper_authored_origin_with_turn_ref () =
+  let tr = Ids.Turn_ref.make ~trace_id:"keeper-trace" ~absolute_turn:7 in
+  let origin = Board.keeper_authored_origin ~source:"keeper_speech" ~turn_ref:tr () in
+  Alcotest.(check (option string)) "source set" (Some "keeper_speech") origin.source;
+  Alcotest.(check (option string))
+    "turn_ref threaded" (Some "keeper-trace#7")
+    (Option.map Ids.Turn_ref.to_string origin.turn_ref);
+  Alcotest.(check bool) "fusion_run_id None" true (Option.is_none origin.fusion_run_id);
+  (* End-to-end: the post created with this origin carries turn_ref through the
+     board codec (create -> encode -> decode). *)
+  let store = Board_core.create_store () in
+  let post = create store ~origin ~content:"keeper speech request-help" in
+  let decoded =
+    match decode (Board_core.post_to_yojson post) with
+    | Some p -> p
+    | None -> Alcotest.fail "encode/decode dropped the keeper post"
+  in
+  match decoded.origin with
+  | Some (o : Board.post_origin) ->
+    Alcotest.(check (option string))
+      "post carries turn_ref" (Some "keeper-trace#7")
+      (Option.map Ids.Turn_ref.to_string o.turn_ref);
+    Alcotest.(check (option string)) "post carries source" (Some "keeper_speech") o.source
+  | None -> Alcotest.fail "keeper post origin lost in round trip"
+;;
+
+let test_keeper_authored_origin_without_turn_ref () =
+  (* Scoped-down path (e.g. keeper_alert): origin is present with a typed source
+     but no fabricated turn_ref. *)
+  let origin = Board.keeper_authored_origin ~source:"keeper_alert" () in
+  Alcotest.(check (option string)) "source set" (Some "keeper_alert") origin.source;
+  Alcotest.(check bool) "turn_ref None (not fabricated)" true (Option.is_none origin.turn_ref);
+  Alcotest.(check bool) "fusion_run_id None" true (Option.is_none origin.fusion_run_id)
+;;
+
 let test_index_lookup_hit_and_miss () =
   let store = Board_core.create_store () in
   let tr = Ids.Turn_ref.make ~trace_id:"idx-trace" ~absolute_turn:9 in
@@ -199,6 +238,14 @@ let () =
             "malformed origin -> None, post preserved"
             `Quick
             (with_eio test_malformed_origin_preserves_post)
+        ; Alcotest.test_case
+            "keeper-authored origin carries turn_ref"
+            `Quick
+            (with_eio test_keeper_authored_origin_with_turn_ref)
+        ; Alcotest.test_case
+            "keeper-authored origin without turn_ref (scoped)"
+            `Quick
+            (with_eio test_keeper_authored_origin_without_turn_ref)
         ] )
     ; ( "index"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 무엇을 / 왜

KEEPER-V2 gap (P1): "every keeper-authored board post should carry `turn_ref`; actual: only `fusion_sink.ml` sets origin, and with `turn_ref=None`." 오늘 keeper speech(request-help)와 keeper alert는 board post를 `origin` 없이 생성하므로, 대시보드/board가 post를 그 post를 만든 turn으로 역추적할 수 없습니다.

이 PR은 keeper-authored board post에 typed `origin = { turn_ref; source; fusion_run_id = None }`을 stamping합니다.

## RFC-0233 §7 인용

`docs/rfc/RFC-0233-turn-observability-execution-identity.md` §7.2:

> 5. board post gains a typed `origin`; keeper-originated posts carry the turn that produced them.

> **Flow** (mint once at the turn boundary, thread down — never re-derive downstream)

§7.2 Bidirectional navigation contract:

> chat turn → board post(s): fusion today; then state-block lifecycle and **keeper-authored posts as they gain `origin`**.

이 PR이 바로 그 "keeper-authored posts as they gain `origin`" 절을 구현합니다. §7.2의 "mint once, thread down — never re-derive downstream" 원칙을 그대로 따릅니다.

## 변경 내용

### 1. Pure 생성자 (`lib/board_types/board_types.ml` + `.mli`)
`keeper_authored_origin ?turn_ref ~source ()` 추가. `fusion_run_id = None` 고정(fusion은 sink에 자체 생성자 보유). `source`는 channel 라벨(기존 `fusion_sink`의 `source = Some "fusion"` 관습과 동일 — typed substring classifier가 아니라 provenance 라벨). `turn_ref`는 optional로, mint-once-safe 참조에 도달할 수 없을 때만 `None`.

> 주: §7.2 설계 스니펫의 `source : Surface_ref.t`는 현행 `post_origin`에서 `source : string option`으로 구현돼 있습니다(board_types→Surface_ref 의존성 cycle 회피, `board_types.ml:151-153`에 문서화). 본 PR은 as-built 타입을 따릅니다.

### 2. keeper_speech turn_ref threading (완전 성공)
`Keeper_unified_turn.run_keeper_cycle`에서 turn 경계의 단일 pre-turn snapshot으로 `turn_ref`를 **한 번** mint(`Ids.Turn_ref.make ~trace_id ~absolute_turn:keeper_turn_id`, manifest/Turn_record가 stamping하는 동일 pair)하고, 다음 경로로 thread down 합니다:

`run_keeper_cycle` → `Keeper_unified_turn_success.handle ~turn_ref` → `Social.apply_to_result ?turn_ref` → registry → `bdi_speech_v1.apply_to_result` → `apply_output_to_result` → `deliver_request_help_post` → `create_post ~origin`(`source = "keeper_speech"`, `turn_ref = Some _`).

post-lifecycle meta에서 재유도하지 않습니다(handoff 시 trace_id가 rotate되어 join key가 달라짐 — §7.2 경고).

### 3. keeper_alert (의도적 scope-down, turn_ref=None)
`post_keeper_alert_board`에 `origin = { source = Some "keeper_alert"; turn_ref = None; fusion_run_id = None }` 추가. "origin이 전혀 없음" gap은 해소됩니다.

turn_ref threading을 하지 않은 이유(주석에도 명시):
- `post_keeper_alert_board`는 `~alert_text`만 받고, 유일한 호출자 `maybe_emit_interesting_alert`는 현재 in-tree 호출자가 없습니다(alert emission이 turn loop에 미연결).
- alert는 post-turn에 발생하므로 `meta`가 mint-once-safe turn 참조가 아닙니다.
- **turn_ref를 날조하지 않습니다**(honest partial > fabrication). 근본 해결: alert emission이 turn loop에 재연결될 때 minted turn_ref를 thread down(keeper_speech와 동일 패턴). 후속 작업으로 제안합니다.

### 4. `fusion_sink.ml` 미변경
`turn_ref = None`은 의도된 동작(fusion은 out-of-band server-root-switch fork)이므로 손대지 않았습니다.

## 테스트

`test/test_board_post_origin.ml`에 producer-side 케이스 2개 추가:
- `keeper-authored origin carries turn_ref`: helper가 `source`/`turn_ref`를 thread하고 `fusion_run_id = None`임을 확인 + create→encode→decode 라운드트립으로 board post가 `origin.turn_ref = Some "keeper-trace#7"`을 carry함을 end-to-end 증명.
- `keeper-authored origin without turn_ref (scoped)`: scoped-down 경로에서 origin은 present(typed source)이되 turn_ref는 날조되지 않음(`None`) 확인.

```
Test Successful in 0.130s. 8 tests run.
  [OK] codec  3   keeper-authored origin carries turn_ref.
  [OK] codec  4   keeper-authored origin without turn_ref (scoped).
```

## Build / Verify

- `dune build --root .` → `BUILD_EXIT=0` (nested-worktree라 `--root .` 사용), 에러 없음.
- `dune exec --root . test/test_board_post_origin.exe` → 8 tests pass.

## 경계 (Architecture)

OAS는 Agent Turn lifecycle을 소유하고, MASC는 channel 전반의 keeper turn을 orchestrate합니다. board는 그 channel 중 하나이며 keeper-authored board post는 특정 keeper turn의 output입니다. 이 변경은 전적으로 MASC 내부이며 OAS를 건드리지 않습니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
