### PR TITLE
fix(keeper): separate strict read-only retry safety

### DIFF
--- a/lib/keeper/keeper_tool_registry.ml
+++ b/lib/keeper/keeper_tool_registry.ml
@@ -139,6 +139,14 @@ let is_effectively_read_only_tool (name : string) : bool =
   || Keeper_tool_descriptor_resolution.capability_has Tool_capability.Idempotent name
 ;;
 
+let is_strictly_read_only_tool (name : string) : bool =
+  (* Unlike [is_effectively_read_only_tool], this intentionally excludes
+     idempotent-but-mutating tools. Use it for retry paths that require no
+     committed mutation rather than merely retry-safe mutation. *)
+  is_keeper_read_only_tool name
+  || Keeper_tool_descriptor_resolution.capability_has Tool_capability.Read_only name
+;;
+
 let has_mutating_side_effect (name : string) : bool =
   not (is_effectively_read_only_tool name)
 ;;
@@ -152,6 +160,16 @@ let is_read_only_with_input ~(tool_name : string) ~(input : Yojson.Safe.t) : boo
   match Keeper_tool_descriptor_resolution.readonly_for_tool_call ~tool_name ~input with
   | Some readonly -> readonly
   | None -> is_effectively_read_only_tool tool_name
+;;
+
+let is_strictly_read_only_with_input
+      ~(tool_name : string)
+      ~(input : Yojson.Safe.t)
+  : bool
+  =
+  match Keeper_tool_descriptor_resolution.readonly_for_tool_call ~tool_name ~input with
+  | Some readonly -> readonly
+  | None -> is_strictly_read_only_tool tool_name
 ;;
 
 let descriptor_boundary_exempt tool_name =

--- a/lib/keeper/keeper_tool_registry.mli
+++ b/lib/keeper/keeper_tool_registry.mli
@@ -44,12 +44,24 @@ val is_keeper_read_only_tool : string -> bool
     read-only/idempotent classification. *)
 val is_effectively_read_only_tool : string -> bool
 
+(** Strict non-mutating read-only check. Unlike
+    [is_effectively_read_only_tool], this excludes idempotent-but-mutating
+    tools. Use it when a caller needs "no committed mutation" rather than
+    "retry-safe enough". *)
+val is_strictly_read_only_tool : string -> bool
+
 (** Negation of [is_effectively_read_only_tool]. *)
 val has_mutating_side_effect : string -> bool
 
 (** Input-aware read-only check for tools that mix read-only and mutating
     subcommands within one tool name. *)
 val is_read_only_with_input :
+  tool_name:string -> input:Yojson.Safe.t -> bool
+
+(** Input-aware strict read-only check. This uses descriptor
+    [readonly_of_input] when present and otherwise falls back to
+    [is_strictly_read_only_tool]. *)
+val is_strictly_read_only_with_input :
   tool_name:string -> input:Yojson.Safe.t -> bool
 
 (** Input-aware main-worktree boundary check: returns [true] when the tool

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -216,7 +216,7 @@ let last_tool_progress_context_of_messages messages =
     let tool_name = String.trim tool_name in
     let tool_name = if tool_name = "" then "unknown" else tool_name in
     let tool_effect =
-      if Keeper_tool_registry.is_read_only_with_input ~tool_name ~input
+      if Keeper_tool_registry.is_strictly_read_only_with_input ~tool_name ~input
       then Keeper_internal_error.Tool_effect_read_only
       else Keeper_internal_error.Tool_effect_mutating
     in

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -662,6 +662,43 @@ let test_readonly_policy_projects_to_input_aware_registry () =
        ~tool_name:"tool_write_file"
        ~input:(`Assoc [ "path", `String "x"; "content", `String "y" ]))
 
+let test_strict_readonly_policy_excludes_workspace_mutations () =
+  let search_input = `Assoc [ "pattern", `String "Keeper_tool_descriptor" ] in
+  Alcotest.(check bool)
+    "Grep public alias is strict read-only"
+    true
+    (Registry.is_strictly_read_only_with_input ~tool_name:"Grep" ~input:search_input);
+  Alcotest.(check bool)
+    "Read public alias is strict read-only"
+    true
+    (Registry.is_strictly_read_only_with_input
+       ~tool_name:"Read"
+       ~input:(`Assoc [ "file_path", `String "lib/keeper/keeper_tool_registry.ml" ]));
+  Alcotest.(check bool)
+    "WebFetch public alias is strict read-only"
+    true
+    (Registry.is_strictly_read_only_with_input
+       ~tool_name:"WebFetch"
+       ~input:(`Assoc [ "url", `String "https://example.com" ]));
+  Alcotest.(check bool)
+    "keeper_board_post remains mutating for no-side-effect retry"
+    false
+    (Registry.is_strictly_read_only_with_input
+       ~tool_name:"keeper_board_post"
+       ~input:(`Assoc [ "title", `String "t"; "body", `String "b" ]));
+  Alcotest.(check bool)
+    "keeper_broadcast remains mutating for no-side-effect retry"
+    false
+    (Registry.is_strictly_read_only_with_input
+       ~tool_name:"keeper_broadcast"
+       ~input:(`Assoc [ "message", `String "hello" ]));
+  Alcotest.(check bool)
+    "masc_transition remains mutating for no-side-effect retry"
+    false
+    (Registry.is_strictly_read_only_with_input
+       ~tool_name:"masc_transition"
+       ~input:(`Assoc [ "task_id", `String "t1"; "status", `String "done" ]))
+
 let test_mcp_context_policy_uses_descriptor_resolution () =
   Alcotest.(check (list string))
     "safe inline tools project from descriptors"
@@ -975,6 +1012,10 @@ let () =
             "descriptor read-only policy projects to input-aware registry"
             `Quick
             test_readonly_policy_projects_to_input_aware_registry
+        ; test_case
+            "strict read-only policy excludes workspace mutations"
+            `Quick
+            test_strict_readonly_policy_excludes_workspace_mutations
         ; test_case
             "MCP context policy uses descriptor resolution"
             `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -285,6 +285,29 @@ let test_last_tool_context_classifies_checkpoint_tool_use () =
     (Some "last_tool=Write; last_tool_effect=mutating")
     write_context
 
+let test_last_tool_context_treats_workspace_mutations_as_mutating () =
+  let cases =
+    [
+      ( "keeper_board_post"
+      , `Assoc [ "title", `String "t"; "body", `String "b" ] );
+      "keeper_broadcast", `Assoc [ "message", `String "hello" ];
+      ( "masc_transition"
+      , `Assoc [ "task_id", `String "t1"; "status", `String "done" ] );
+    ]
+  in
+  List.iter
+    (fun (tool_name, input) ->
+       let context =
+         Masc.Keeper_turn_driver.For_testing
+         .last_tool_progress_context_string_of_messages
+           [ message [ tool_use ~input tool_name ] ]
+       in
+       Alcotest.(check (option string))
+         (tool_name ^ " context")
+         (Some (Printf.sprintf "last_tool=%s; last_tool_effect=mutating" tool_name))
+         context)
+    cases
+
 let test_accept_reason_includes_last_tool_context () =
   let checkpoint =
     checkpoint_with_messages
@@ -395,6 +418,58 @@ let test_thinking_only_after_read_only_webfetch_can_try_next_candidate () =
     (Option.map
        Masc.Keeper_error_classify.degraded_retry_reason_to_string
        (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
+
+let test_thinking_only_after_workspace_mutation_stays_terminal () =
+  let cases =
+    [
+      ( "keeper_board_post"
+      , `Assoc [ "title", `String "t"; "body", `String "b" ] );
+      "keeper_broadcast", `Assoc [ "message", `String "hello" ];
+      ( "masc_transition"
+      , `Assoc [ "task_id", `String "t1"; "status", `String "done" ] );
+    ]
+  in
+  List.iter
+    (fun (tool_name, input) ->
+       let checkpoint =
+         checkpoint_with_messages
+           [ message [ tool_use ~input tool_name ] ]
+       in
+       let result =
+         Masc.Keeper_turn_driver.For_testing.apply_accept
+           ~runtime_id:("runtime.thinking-after-" ^ tool_name)
+           ~accept:Keeper_tool_response.response_has_text_or_tool_progress
+           (run_result
+              ~checkpoint
+              ~content:
+                [
+                  Agent_sdk.Types.Thinking
+                    { thinking_type = "reasoning"; content = "internal chain" };
+                ]
+              ())
+       in
+       let err, reason_kind, reason = expect_accept_rejected result in
+       Alcotest.(check bool)
+         (tool_name ^ " reason kind")
+         true
+         (reason_kind = Some Keeper_internal_error.Accept_no_usable_progress);
+       Alcotest.(check bool)
+         (tool_name ^ " reason marks mutation")
+         true
+         (contains ~needle:"last_tool_effect=mutating" reason);
+       Alcotest.(check bool)
+         (tool_name ^ " does not try next candidate")
+         false
+         (Masc.Keeper_turn_driver.For_testing
+          .accept_no_progress_read_only_should_try_next
+            err);
+       Alcotest.(check (option string))
+         (tool_name ^ " is not runtime-recoverable")
+         None
+         (Option.map
+            Masc.Keeper_error_classify.degraded_retry_reason_to_string
+            (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err)))
+    cases
 
 let test_read_only_retry_uses_typed_context_not_reason_tokens () =
   let typed_err =
@@ -713,6 +788,10 @@ let () =
           Alcotest.test_case "last tool context classifies checkpoint tools" `Quick
             test_last_tool_context_classifies_checkpoint_tool_use;
           Alcotest.test_case
+            "last tool context treats workspace mutations as mutating"
+            `Quick
+            test_last_tool_context_treats_workspace_mutations_as_mutating;
+          Alcotest.test_case
             "accept rejection reason includes last tool context"
             `Quick
             test_accept_reason_includes_last_tool_context;
@@ -720,6 +799,10 @@ let () =
             "thinking-only after read-only WebFetch tries next candidate"
             `Quick
             test_thinking_only_after_read_only_webfetch_can_try_next_candidate;
+          Alcotest.test_case
+            "thinking-only after workspace mutation stays terminal"
+            `Quick
+            test_thinking_only_after_workspace_mutation_stays_terminal;
           Alcotest.test_case
             "read-only retry uses typed context, not reason tokens"
             `Quick


### PR DESCRIPTION
## Summary

Adversarial hardening follow-up for #21866.

- Split strict non-mutating read-only checks from the broader "effectively read-only / idempotent" retry-safe classification.
- Use the strict input-aware read-only check when building the `last_tool_effect` that gates `read_only_no_progress` fallback.
- Add regression coverage that workspace mutations (`keeper_board_post`, `keeper_broadcast`, `masc_transition`) stay `mutating` and terminal after a thinking-only no-progress response.

## Product impact

The prior recovery path still retries after genuine read-only tools like `WebFetch`, `Read`, and `Grep`.

The follow-up removes a weak proof boundary: idempotent or workspace-scoped mutating tools must not be treated as "no committed mutation" for the no-side-effect runtime retry path.

## Evidence

- `git diff --check`
- `opam exec -- ocamlformat --check lib/keeper/keeper_tool_registry.ml lib/keeper/keeper_tool_registry.mli lib/keeper/keeper_turn_driver_try_provider.ml test/test_keeper_tool_descriptor_registry_integrity.ml test/test_keeper_turn_driver_accept.ml`
- Local Dune build was started, then stopped at user request: CI will run the build/test suite.

## Direct evidence

schema_version: 1
direct_ratio: 4/4
provenance: direct

- New strict APIs: `is_strictly_read_only_tool`, `is_strictly_read_only_with_input`.
- `last_tool_progress_context_of_messages` now uses strict read-only classification for retry-safety evidence.
- Registry tests prove strict read-only includes `Grep`/`Read`/`WebFetch` and excludes workspace mutation tools.
- Accept/retry tests prove thinking-only after workspace mutation does not try the next candidate and is not runtime-recoverable.

## Review evidence

Adversarial finding: the original "no side effect" statement was stronger than the previous predicate, because the old predicate reused an "effectively read-only" helper whose documented meaning included idempotent retry-safe tools. This PR narrows the retry gate to actual non-mutating read-only tools.

## Base

Follow-up to merged #21866.
