### PR TITLE
feat(dashboard): copy button on assistant chat messages (keeper-v2 Unit 4)

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -384,6 +384,37 @@ describe('ChatTranscript', () => {
     expect(onClick.mock.calls[0]?.[0].id).toBe('a1')
   })
 
+  it('copies the message text from an assistant message copy button', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(globalThis.navigator, { clipboard: { writeText } })
+    const target = entry({
+      id: 'a1',
+      role: 'assistant',
+      source: 'direct_assistant',
+      label: 'sangsu',
+      text: '복사할 응답 본문',
+    })
+
+    render(
+      html`<${ChatTranscript} entries=${[target]} emptyText="empty" variant="messenger" />`,
+      container,
+    )
+
+    const copy = container.querySelector('[data-testid="chat-message-copy"]') as HTMLButtonElement
+    expect(copy).not.toBeNull()
+    fireEvent.click(copy)
+    expect(writeText).toHaveBeenCalledWith('복사할 응답 본문')
+  })
+
+  it('does not render a copy button on user messages', () => {
+    const target = entry({ id: 'u1', role: 'user', text: '내 질문' })
+    render(
+      html`<${ChatTranscript} entries=${[target]} emptyText="empty" variant="messenger" />`,
+      container,
+    )
+    expect(container.querySelector('[data-testid="chat-message-copy"]')).toBeNull()
+  })
+
   it('renders a thinking placeholder when the model is reasoning', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -8,6 +8,7 @@ import { ringFocusClasses } from '../common/ring'
 import { collectAttachments } from './attachments'
 import { parseMarkdownToBlocks } from './markdown-blocks'
 import { showToast } from '../common/toast'
+import { copyToClipboard } from '../common/copyable-code'
 import { useVoiceInput } from './voice-input'
 import { Mic, Square } from 'lucide-preact'
 
@@ -603,13 +604,12 @@ function codeBlockText(htmlContent: string, source?: string): string {
   return htmlContent
 }
 
-async function copyCodeToClipboard(text: string): Promise<void> {
-  try {
-    await navigator.clipboard.writeText(text)
-    showToast('코드를 복사했습니다', 'success')
-  } catch {
-    showToast('복사하지 못했습니다', 'error')
-  }
+// Reuse the canonical clipboard helper (common/copyable-code) — it carries the
+// execCommand fallback for non-secure contexts — and just layer the toast on its
+// boolean result so the message text matches what was copied.
+async function copyWithToast(text: string, successMessage: string): Promise<void> {
+  const ok = await copyToClipboard(text)
+  showToast(ok ? successMessage : '복사하지 못했습니다', ok ? 'success' : 'error')
 }
 
 function ChatCodeBlock({ cap, html: htmlContent, source }: { cap?: string; html: string; source?: string }) {
@@ -647,7 +647,7 @@ function ChatCodeBlock({ cap, html: htmlContent, source }: { cap?: string; html:
           class="chat-block-code-copy"
           aria-label="코드 복사"
           title="복사"
-          onClick=${() => { void copyCodeToClipboard(plain) }}
+          onClick=${() => { void copyWithToast(plain, '코드를 복사했습니다') }}
         >
           복사
         </button>
@@ -1754,6 +1754,22 @@ function ChatMessageBubble({
                 data-testid="chat-message-action"
               >
                 ${action.label}
+              </button>
+            `
+          : null}
+        ${richTextRole && hasRealText
+          ? html`
+              <button
+                type="button"
+                class=${`border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] ${CHAT_FOCUS_RING} ${
+                  isMessenger ? 'rounded-[var(--r-1)] px-2.5 py-1' : 'rounded-[var(--r-0)] px-3 py-1'
+                }`}
+                onClick=${() => { void copyWithToast(entry.text, '메시지를 복사했습니다') }}
+                title="메시지 복사"
+                aria-label="메시지 복사"
+                data-testid="chat-message-copy"
+              >
+                복사
               </button>
             `
           : null}


### PR DESCRIPTION
## 무엇을 / 왜

keeper-v2 **Unit 4** (frontend 슬라이스) — 디자인 메시지 피드백 행(`messages.jsx` `Feedback`, `showCopy`)은 assistant 응답에 **복사** 어포던스를 제공하지만, 라이브 transcript엔 코드블록 단위 복사만 있었습니다. assistant 메시지 전체를 복사하는 버튼을 추가합니다.

명명된 SSOT `keeper-v2/Keeper Agent v2.html`(→ `keepers.jsx` 합성 → `messages.jsx` `Message`/`Feedback`)을 직접 grounding해 정조준했습니다.

## 변경

- **canonical clipboard 헬퍼 재사용**: 로컬 `copyCodeToClipboard`를 제거하고, canonical `copyToClipboard`(`common/copyable-code`, **execCommand fallback=비보안 컨텍스트 대응** 포함)를 감싸는 `copyWithToast(text, message)` 래퍼로 교체(boolean 결과에 toast). 코드블록은 `'코드를 복사했습니다'` 그대로. (적대 리뷰 SSOT finding 반영: 동명 재구현 제거 + fallback 획득.)
- **메시지 복사 버튼**: `ChatMessageBubble` action footer에 `복사` 버튼. `richTextRole && hasRealText`(assistant/system + 실텍스트)로 게이팅, `entry.text`를 `copyToClipboard(..., '메시지를 복사했습니다')`로 복사. `data-testid="chat-message-copy"`.

## 범위 / grounding

**frontend copy 어포던스만** 포팅. 디자인 Feedback의 **verified 배지 / regenerate / 추천 후속질문**은 **백엔드 게이팅**(영속 turn에 verified 플래그·suggestion 목록·live reply loop 부재)이라 **날조하지 않고 제외**.

공유 transcript 컴포넌트이므로 버튼은 모든 채팅 surface(keeper workspace, board post 상세, keeper 상세)의 assistant 응답에 표시 — 디자인(`!isUser`에 copy 표시)과 일치.

## 검증

- `tsc --noEmit`: 0 errors · `eslint`: clean
- `vitest`: primitives **85 passed**(assistant 복사·user 미표시 신규 2종) + chat/keeper-shared **182 passed**(헬퍼 일반화 회귀 없음)
- fresh-context 적대 리뷰(공유 컴포넌트 blast-radius 중심)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
