### PR TITLE
fix(keeper): summarize tool effects for read-only retry

### DIFF
--- a/docs/audit/2026-06-21-keeper-heuristic-realworld-gap-list.md
+++ b/docs/audit/2026-06-21-keeper-heuristic-realworld-gap-list.md
@@ -45,8 +45,8 @@ OAS.
 
 | # | Surface | Current heuristic | Missing example class | Risk |
 |---|---------|-------------------|-----------------------|------|
-| 1 | Thinking-only read-only retry | accept reason substring gate | actual no-progress trace after read-only tool | retry can hide accept failures |
-| 2 | Last-tool effect context | only the final assistant tool call is inspected | multi-tool turn with earlier mutation | read-only label can be unsound |
+| 1 | Thinking-only read-only retry | typed response/effect gate | read-only error/empty payload trace | retry can hide accept failures |
+| 2 | Last-tool effect context | final tool plus turn-wide effect summary | compaction/resume multi-message fixture | read-only label can be unsound |
 | 3 | Tool read-only registry | descriptor/capability fallback | mixed-mode tool contracts | checkpoint boundary can drift |
 | 4 | Provider error string classifiers | quota/capacity/terminal substrings | provider/CLI error corpus | wrong cooldown/escalation |
 | 5 | Keeper warn/recoverable classifier | typed bucket allow/deny list | operator-facing failure samples | noisy or silent incidents |
@@ -64,26 +64,21 @@ Evidence:
 
 Current behavior: typed `Accept_rejected` with
 `Accept_no_usable_progress` is retryable on the next runtime only when the
-free-form reason contains both `shape=thinking_only` and
-`last_tool_effect=read_only`.
+typed response shape is `thinking_only`, the final tool is `read_only`, and the
+turn-wide checkpoint summary reports `any_mutating_tool=false`.
 
 Missing real-world examples:
-- WebFetch/Read/Grep succeeds, then the runtime returns only thinking text.
 - A read-only tool returns an error or empty payload, then the runtime returns
   only thinking text.
-- The last tool is read-only but an earlier tool in the same turn mutated
-  workspace or board state.
 - The rejection happens on the final candidate, where retry is intentionally
   impossible.
 
-Operational risk: the fix is intentionally narrow, but its safety rests on a
-string-decorated reason. Without fixture traces for the false-positive
-boundary, a future reason-format change can silently stop retrying, or a
-misclassified read-only context can retry after a turn that already had side
-effects.
+Operational risk: the fix is intentionally narrow. The earlier string-decorated
+reason gate is now typed, but remaining confidence still depends on broader
+fixture traces for read-only tool failures and final-candidate behavior.
 
 Evidence fixture needed: a raw checkpoint/rejection fixture with multiple tools,
-including at least one read-only-only turn and one earlier-mutation turn.
+including final-candidate and read-only error/empty-payload cases.
 
 ## 2. Last-tool effect context
 
@@ -91,23 +86,22 @@ Evidence:
 - `lib/keeper/keeper_turn_driver_try_provider.ml:195-221`
 - `lib/keeper/keeper_turn_driver_try_provider.ml:224-234`
 
-Current behavior: the checkpoint scan records only the final assistant
-`ToolUse` and formats it as `last_tool=<name>; last_tool_effect=<read_only|mutating>`.
+Current behavior: the checkpoint scan records the final assistant `ToolUse` and
+a turn-wide effect summary:
+`last_tool=<name>; last_tool_effect=<read_only|mutating>; any_mutating_tool=<bool>; tool_effects_seen=<...>`.
 
 Missing real-world examples:
-- A turn calls `Edit` then `Read`, and the model produces no deliverable.
 - A turn calls several read-only tools where only the last one is relevant to
   the rejection.
 - A checkpoint includes tool-use blocks from multiple assistant messages after
   compaction or resume.
 
-Operational risk: "last tool was read-only" is not the same as "this turn was
-read-only". Retry decisions built on the last tool alone can ignore earlier
-side effects.
+Operational risk: the original "last tool was read-only" false-positive is
+covered by `any_mutating_tool`, but compaction/resume checkpoint shape can still
+hide relevant tool-use history if it is not preserved in the checkpoint.
 
-Evidence fixture needed: a checkpoint summary that includes `any_mutating_tool`,
-`last_tool_effect`, and `tool_effects_seen`, plus tests that pin the intended
-precedence.
+Evidence fixture needed: multi-message checkpoint fixtures after compaction or
+resume, plus tests that pin which checkpoint spans are authoritative.
 
 ## 3. Tool read-only registry and checkpoint boundary
 
@@ -310,8 +304,8 @@ outputs and examples that prove substring fallbacks are only fallback behavior.
 
 ## Recommended follow-up test slices
 
-1. Add multi-tool accept-rejection fixtures that distinguish `last_tool_effect`
-   from `any_mutating_tool`.
+1. Add compaction/resume checkpoint fixtures that prove the turn-wide
+   `any_mutating_tool` summary still sees the authoritative tool-use span.
 2. Add provider error corpus tests for hard quota, capacity backpressure,
    terminal runtime failure, and retryable transient errors.
 3. Add multilingual board-signal fixtures for Korean goal text, mention false

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -161,6 +161,7 @@ module For_testing : sig
     keeper_name:string -> Runtime_candidate.t -> Agent_sdk.Error.sdk_error -> unit
 
   val apply_accept :
+    ?initial_messages:Agent_sdk.Types.message list ->
     runtime_id:string ->
     accept:(Agent_sdk_response.api_response -> bool) ->
     Runtime_agent.run_result ->

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -190,37 +190,75 @@ let body_timeout_for_attempt ?per_provider_timeout_s () =
 type last_tool_progress_context =
   { tool_name : string
   ; tool_effect : Keeper_internal_error.tool_progress_effect
+  ; any_mutating_tool : bool
+  ; tool_effects_seen : Keeper_internal_error.tool_progress_effect list
   }
 
 let last_tool_effect_to_string = Keeper_internal_error.tool_progress_effect_to_string
 
-let last_tool_use_of_messages (messages : Agent_sdk.Types.message list) =
-  let last_tool_in_message (msg : Agent_sdk.Types.message) acc =
+let classify_tool_effect ~tool_name ~input =
+  if Keeper_tool_registry.is_strictly_read_only_with_input ~tool_name ~input
+  then Keeper_internal_error.Tool_effect_read_only
+  else Keeper_internal_error.Tool_effect_mutating
+;;
+
+let dedupe_tool_effects effects =
+  effects
+  |> List.fold_left
+       (fun acc tool_effect ->
+          if List.mem tool_effect acc then acc else tool_effect :: acc)
+       []
+  |> List.rev
+;;
+
+let tool_uses_of_messages (messages : Agent_sdk.Types.message list) =
+  let tool_uses_in_message (msg : Agent_sdk.Types.message) acc =
     if msg.role <> Agent_sdk.Types.Assistant
     then acc
     else
       List.fold_left
         (fun acc -> function
-          | Agent_sdk.Types.ToolUse { name; input; _ } -> Some (name, input)
+          | Agent_sdk.Types.ToolUse { name; input; _ } -> (name, input) :: acc
           | _ -> acc)
         acc
         msg.content
   in
-  List.fold_left (fun acc msg -> last_tool_in_message msg acc) None messages
+  List.fold_left (fun acc msg -> tool_uses_in_message msg acc) [] messages
+  |> List.rev
 ;;
 
 let last_tool_progress_context_of_messages messages =
-  match last_tool_use_of_messages messages with
-  | None -> None
-  | Some (tool_name, input) ->
+  match tool_uses_of_messages messages with
+  | [] -> None
+  | tool_uses ->
+    let tool_effects =
+      List.map
+        (fun (tool_name, input) -> classify_tool_effect ~tool_name ~input)
+        tool_uses
+    in
+    let last_tool_name, last_input =
+      match List.rev tool_uses with
+      | (tool_name, input) :: _ -> tool_name, input
+      | [] -> "unknown", `Assoc []
+    in
+    let tool_name = last_tool_name in
     let tool_name = String.trim tool_name in
     let tool_name = if tool_name = "" then "unknown" else tool_name in
-    let tool_effect =
-      if Keeper_tool_registry.is_strictly_read_only_with_input ~tool_name ~input
-      then Keeper_internal_error.Tool_effect_read_only
-      else Keeper_internal_error.Tool_effect_mutating
+    let tool_effect = classify_tool_effect ~tool_name ~input:last_input in
+    let any_mutating_tool =
+      List.exists
+        (function
+          | Keeper_internal_error.Tool_effect_mutating -> true
+          | Keeper_internal_error.Tool_effect_read_only -> false)
+        tool_effects
     in
-    Some { tool_name; tool_effect }
+    Some
+      {
+        tool_name;
+        tool_effect;
+        any_mutating_tool;
+        tool_effects_seen = dedupe_tool_effects tool_effects;
+      }
 ;;
 
 let accept_rejection_context_of_run_result (run_result : Runtime_agent.run_result) =
@@ -232,12 +270,20 @@ let accept_rejection_context_of_run_result (run_result : Runtime_agent.run_resul
 
 let format_last_tool_progress_context = function
   | None -> None
-  | Some { tool_name; tool_effect } ->
+  | Some { tool_name; tool_effect; any_mutating_tool; tool_effects_seen } ->
+    let effects_seen =
+      tool_effects_seen
+      |> List.map last_tool_effect_to_string
+      |> String.concat ","
+    in
     Some
       (Printf.sprintf
-         "last_tool=%s; last_tool_effect=%s"
+         "last_tool=%s; last_tool_effect=%s; any_mutating_tool=%b; \
+          tool_effects_seen=%s"
          tool_name
-         (last_tool_effect_to_string tool_effect))
+         (last_tool_effect_to_string tool_effect)
+         any_mutating_tool
+         effects_seen)
 ;;
 
 let accept_rejected_error ~last_tool_context ~runtime_id
@@ -276,6 +322,14 @@ let accept_rejected_error ~last_tool_context ~runtime_id
            Option.map
              (fun context -> context.tool_effect)
              last_tool_context;
+         any_mutating_tool =
+           Option.map
+             (fun context -> context.any_mutating_tool)
+             last_tool_context;
+         tool_effects_seen =
+           (match last_tool_context with
+            | Some context -> context.tool_effects_seen
+            | None -> []);
          reason = rejection.reason;
        })
 

--- a/lib/keeper/keeper_turn_driver_try_provider.ml
+++ b/lib/keeper/keeper_turn_driver_try_provider.ml
@@ -261,11 +261,23 @@ let last_tool_progress_context_of_messages messages =
       }
 ;;
 
-let accept_rejection_context_of_run_result (run_result : Runtime_agent.run_result) =
+let rec drop_matching_prefix ~prefix messages =
+  match prefix, messages with
+  | [], rest -> rest
+  | p :: ps, m :: ms when p = m -> drop_matching_prefix ~prefix:ps ms
+  | _ :: _, _ -> messages
+;;
+
+let accept_rejection_context_of_run_result
+      ?(initial_messages = [])
+      (run_result : Runtime_agent.run_result)
+  =
   match run_result.checkpoint with
   | None -> None
   | Some checkpoint ->
-    last_tool_progress_context_of_messages checkpoint.Agent_sdk.Checkpoint.messages
+    checkpoint.Agent_sdk.Checkpoint.messages
+    |> drop_matching_prefix ~prefix:initial_messages
+    |> last_tool_progress_context_of_messages
 ;;
 
 let format_last_tool_progress_context = function
@@ -333,10 +345,17 @@ let accept_rejected_error ~last_tool_context ~runtime_id
          reason = rejection.reason;
        })
 
-let apply_accept ~runtime_id ~accept (run_result : Runtime_agent.run_result) =
+let apply_accept
+      ?(initial_messages = [])
+      ~runtime_id
+      ~accept
+      (run_result : Runtime_agent.run_result)
+  =
   if accept run_result.response then Ok run_result
   else
-    let last_tool_context = accept_rejection_context_of_run_result run_result in
+    let last_tool_context =
+      accept_rejection_context_of_run_result ~initial_messages run_result
+    in
     Error
       (accept_rejected_error
          ~last_tool_context
@@ -524,7 +543,10 @@ let run_try_provider
     let result =
       match result with
       | Ok run_result ->
-        apply_accept ~runtime_id:ctx.error_runtime_id ~accept:ctx.accept
+        apply_accept
+          ~initial_messages:ctx.initial_messages
+          ~runtime_id:ctx.error_runtime_id
+          ~accept:ctx.accept
           run_result
       | Error _ as err -> err
     in

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -61,6 +61,8 @@ type try_provider_ctx =
 type last_tool_progress_context =
   { tool_name : string
   ; tool_effect : Keeper_internal_error.tool_progress_effect
+  ; any_mutating_tool : bool
+  ; tool_effects_seen : Keeper_internal_error.tool_progress_effect list
   }
 
 val run_try_provider :

--- a/lib/keeper/keeper_turn_driver_try_provider.mli
+++ b/lib/keeper/keeper_turn_driver_try_provider.mli
@@ -81,7 +81,9 @@ val accept_rejected_error :
   Agent_sdk.Error.sdk_error
 
 val accept_rejection_context_of_run_result :
-  Runtime_agent.run_result -> last_tool_progress_context option
+  ?initial_messages:Agent_sdk.Types.message list ->
+  Runtime_agent.run_result ->
+  last_tool_progress_context option
 
 module For_testing : sig
   val max_execution_time_for_attempt :
@@ -96,6 +98,7 @@ module For_testing : sig
     Agent_sdk.Hooks.turn_params
 
   val apply_accept :
+    ?initial_messages:Agent_sdk.Types.message list ->
     runtime_id:string ->
     accept:(Agent_sdk_response.api_response -> bool) ->
     Runtime_agent.run_result ->

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -203,6 +203,7 @@ let run
        | Ok run_result ->
          let last_tool_context =
            Keeper_turn_driver_try_provider.accept_rejection_context_of_run_result
+             ~initial_messages:ctx.try_provider_ctx.initial_messages
              run_result
          in
          let err =

--- a/lib/keeper/keeper_turn_driver_wrappers.ml
+++ b/lib/keeper/keeper_turn_driver_wrappers.ml
@@ -149,6 +149,8 @@ let run_model_by_label
                                   accept_response_shape_of_agent_sdk
                                   rejection.response_shape;
                               last_tool_effect = None;
+                              any_mutating_tool = None;
+                              tool_effects_seen = [];
                               reason = rejection.reason;
                             }))
                 | Error e -> Error e))

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -197,6 +197,8 @@ type masc_internal_error =
       reason_kind : accept_rejection_kind option;
       response_shape : accept_response_shape option;
       last_tool_effect : tool_progress_effect option;
+      any_mutating_tool : bool option;
+      tool_effects_seen : tool_progress_effect list;
       reason : string;
     }
   | Admission_queue_timeout of {
@@ -285,6 +287,26 @@ let string_opt_of_assoc key json =
   Json_field.string json key |> Json_field.to_option
 ;;
 
+let bool_opt_of_assoc key = function
+  | `Assoc fields -> (
+    match List.assoc_opt key fields with
+    | Some (`Bool value) -> Some value
+    | _ -> None)
+  | _ -> None
+;;
+
+let tool_progress_effects_to_json effects =
+  `List
+    (List.map
+       (fun tool_effect -> `String (tool_progress_effect_to_string tool_effect))
+       effects)
+;;
+
+let tool_progress_effects_of_assoc key json =
+  string_list_of_assoc key json
+  |> List.filter_map tool_progress_effect_of_string
+;;
+
 let masc_internal_error_to_json = function
   | Runtime_exhausted { runtime_id; reason } ->
     let runtime_id = runtime_id_to_string runtime_id in
@@ -322,7 +344,16 @@ let masc_internal_error_to_json = function
         ("exit_code", Json_util.int_opt_to_json exit_code);
       ]
   | Accept_rejected
-      { scope; model; reason_kind; response_shape; last_tool_effect; reason } ->
+      {
+        scope;
+        model;
+        reason_kind;
+        response_shape;
+        last_tool_effect;
+        any_mutating_tool;
+        tool_effects_seen;
+        reason;
+      } ->
     `Assoc
       [
         ("kind", `String "accept_rejected");
@@ -337,6 +368,11 @@ let masc_internal_error_to_json = function
         ( "last_tool_effect",
           Json_util.string_opt_to_json
             (Option.map tool_progress_effect_to_string last_tool_effect) );
+        ( "any_mutating_tool",
+          (match any_mutating_tool with
+           | Some value -> `Bool value
+           | None -> `Null) );
+        ("tool_effects_seen", tool_progress_effects_to_json tool_effects_seen);
         ("reason", `String reason);
       ]
   | Admission_queue_timeout { keeper_name; runtime_id; wait_sec } ->
@@ -523,9 +559,11 @@ let accept_rejection_has_read_only_no_progress_retry_hint = function
         reason_kind = Some Accept_no_usable_progress;
         response_shape = Some Accept_response_thinking_only;
         last_tool_effect = Some Tool_effect_read_only;
+        any_mutating_tool = Some false;
+        tool_effects_seen;
         _;
       } ->
-    true
+    tool_effects_seen <> []
   | Accept_rejected _
   | Runtime_exhausted _
   | Capacity_backpressure _
@@ -646,6 +684,9 @@ let parse_masc_internal_error_json (json : Yojson.Safe.t) :
                      Option.bind
                        (string_opt_of_assoc "last_tool_effect" json)
                        tool_progress_effect_of_string;
+                   any_mutating_tool = bool_opt_of_assoc "any_mutating_tool" json;
+                   tool_effects_seen =
+                     tool_progress_effects_of_assoc "tool_effects_seen" json;
                    reason;
                  })
           | _ -> None)

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -87,6 +87,8 @@ type masc_internal_error =
       reason_kind : accept_rejection_kind option;
       response_shape : accept_response_shape option;
       last_tool_effect : tool_progress_effect option;
+      any_mutating_tool : bool option;
+      tool_effects_seen : tool_progress_effect list;
       reason : string;
     }
   | Admission_queue_timeout of {

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -348,6 +348,8 @@ let read_only_no_progress_err ~scope =
        ; reason_kind = Some KTD.Accept_no_usable_progress
        ; response_shape = Some KTD.Accept_response_thinking_only
        ; last_tool_effect = Some KTD.Tool_effect_read_only
+       ; any_mutating_tool = Some false
+       ; tool_effects_seen = [ KTD.Tool_effect_read_only ]
        ; reason =
            "response rejected by accept (runtime=same.b): shape=thinking_only; \
             stop_reason=end_turn; last_tool=WebFetch; last_tool_effect=read_only"

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -137,7 +137,13 @@ let expect_accept_rejected result =
        Alcotest.failf "expected typed keeper error, got %s"
          (Agent_sdk.Error.to_string err))
 
-let accept_rejected_sdk_error ~response_shape ~last_tool_effect ~reason =
+let accept_rejected_sdk_error
+    ?any_mutating_tool
+    ?(tool_effects_seen = [])
+    ~response_shape
+    ~last_tool_effect
+    ~reason
+    () =
   Keeper_internal_error.sdk_error_of_masc_internal_error
     (Keeper_internal_error.Accept_rejected
        { scope = "runtime.changed-diagnostic"
@@ -145,6 +151,8 @@ let accept_rejected_sdk_error ~response_shape ~last_tool_effect ~reason =
        ; reason_kind = Some Keeper_internal_error.Accept_no_usable_progress
        ; response_shape
        ; last_tool_effect
+       ; any_mutating_tool
+       ; tool_effects_seen
        ; reason
        })
 
@@ -278,11 +286,15 @@ let test_last_tool_context_classifies_checkpoint_tool_use () =
   in
   Alcotest.(check (option string))
     "read-only alias context"
-    (Some "last_tool=Read; last_tool_effect=read_only")
+    (Some
+       "last_tool=Read; last_tool_effect=read_only; any_mutating_tool=false; \
+        tool_effects_seen=read_only")
     read_context;
   Alcotest.(check (option string))
     "mutating alias context"
-    (Some "last_tool=Write; last_tool_effect=mutating")
+    (Some
+       "last_tool=Write; last_tool_effect=mutating; any_mutating_tool=true; \
+        tool_effects_seen=mutating")
     write_context
 
 let test_last_tool_context_treats_workspace_mutations_as_mutating () =
@@ -304,7 +316,11 @@ let test_last_tool_context_treats_workspace_mutations_as_mutating () =
        in
        Alcotest.(check (option string))
          (tool_name ^ " context")
-         (Some (Printf.sprintf "last_tool=%s; last_tool_effect=mutating" tool_name))
+         (Some
+            (Printf.sprintf
+               "last_tool=%s; last_tool_effect=mutating; any_mutating_tool=true; \
+                tool_effects_seen=mutating"
+               tool_name))
          context)
     cases
 
@@ -352,6 +368,14 @@ let test_accept_reason_includes_last_tool_context () =
     true
     (contains ~needle:"last_tool_effect=mutating" reason);
   Alcotest.(check bool)
+    "reason includes any mutating summary"
+    true
+    (contains ~needle:"any_mutating_tool=true" reason);
+  Alcotest.(check bool)
+    "reason includes effects seen"
+    true
+    (contains ~needle:"tool_effects_seen=mutating" reason);
+  Alcotest.(check bool)
     "thinking-only after mutating tool does not try next candidate"
     false
     (Masc.Keeper_turn_driver.For_testing
@@ -359,6 +383,72 @@ let test_accept_reason_includes_last_tool_context () =
        err);
   Alcotest.(check (option string))
     "thinking-only after mutating tool is not runtime-recoverable"
+    None
+    (Option.map
+       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
+
+let test_thinking_only_after_mutation_then_read_does_not_try_next_candidate () =
+  let checkpoint =
+    checkpoint_with_messages
+      [
+        message
+          [
+            tool_use
+              ~input:
+                (`Assoc
+                  [
+                    ("title", `String "checkpoint");
+                    ("body", `String "keeper posted progress");
+                  ])
+              "keeper_board_post";
+          ];
+        message
+          [ tool_use ~input:(`Assoc [ ("file_path", `String "dune") ]) "Read" ];
+      ]
+  in
+  let result =
+    Masc.Keeper_turn_driver.For_testing.apply_accept
+      ~runtime_id:"runtime.thinking-after-mutation-then-read"
+      ~accept:Keeper_tool_response.response_has_text_or_tool_progress
+      (run_result
+         ~checkpoint
+         ~content:
+           [
+             Agent_sdk.Types.Thinking
+               { thinking_type = "reasoning"; content = "internal chain" };
+           ]
+         ())
+  in
+  let err, reason_kind, reason = expect_accept_rejected result in
+  Alcotest.(check bool)
+    "reason kind is no usable progress"
+    true
+    (reason_kind = Some Keeper_internal_error.Accept_no_usable_progress);
+  Alcotest.(check bool)
+    "last tool remains visible"
+    true
+    (contains ~needle:"last_tool=Read" reason);
+  Alcotest.(check bool)
+    "last tool remains read-only"
+    true
+    (contains ~needle:"last_tool_effect=read_only" reason);
+  Alcotest.(check bool)
+    "earlier mutation is summarized"
+    true
+    (contains ~needle:"any_mutating_tool=true" reason);
+  Alcotest.(check bool)
+    "effects seen captures both classes"
+    true
+    (contains ~needle:"tool_effects_seen=mutating,read_only" reason);
+  Alcotest.(check bool)
+    "earlier mutation disables read-only retry"
+    false
+    (Masc.Keeper_turn_driver.For_testing
+     .accept_no_progress_read_only_should_try_next
+       err);
+  Alcotest.(check (option string))
+    "earlier mutation is not runtime-recoverable"
     None
     (Option.map
        Masc.Keeper_error_classify.degraded_retry_reason_to_string
@@ -406,6 +496,14 @@ let test_thinking_only_after_read_only_webfetch_can_try_next_candidate () =
     "reason includes read-only tool effect"
     true
     (contains ~needle:"last_tool_effect=read_only" reason);
+  Alcotest.(check bool)
+    "reason includes no-mutating summary"
+    true
+    (contains ~needle:"any_mutating_tool=false" reason);
+  Alcotest.(check bool)
+    "reason includes read-only effects seen"
+    true
+    (contains ~needle:"tool_effects_seen=read_only" reason);
   Alcotest.(check bool)
     "thinking-only after read-only tool tries next candidate"
     true
@@ -476,7 +574,10 @@ let test_read_only_retry_uses_typed_context_not_reason_tokens () =
     accept_rejected_sdk_error
       ~response_shape:(Some Keeper_internal_error.Accept_response_thinking_only)
       ~last_tool_effect:(Some Keeper_internal_error.Tool_effect_read_only)
+      ~any_mutating_tool:false
+      ~tool_effects_seen:[ Keeper_internal_error.Tool_effect_read_only ]
       ~reason:"diagnostic wording changed; no legacy retry tokens"
+      ()
   in
   Alcotest.(check bool)
     "typed thinking/read-only context retries despite changed wording"
@@ -496,6 +597,7 @@ let test_read_only_retry_uses_typed_context_not_reason_tokens () =
       ~last_tool_effect:None
       ~reason:
         "legacy text only: shape=thinking_only; last_tool_effect=read_only"
+      ()
   in
   Alcotest.(check bool)
     "legacy reason tokens alone do not trigger retry"
@@ -795,6 +897,10 @@ let () =
             "accept rejection reason includes last tool context"
             `Quick
             test_accept_reason_includes_last_tool_context;
+          Alcotest.test_case
+            "thinking-only after mutation then read does not try next candidate"
+            `Quick
+            test_thinking_only_after_mutation_then_read_does_not_try_next_candidate;
           Alcotest.test_case
             "thinking-only after read-only WebFetch tries next candidate"
             `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -454,6 +454,72 @@ let test_thinking_only_after_mutation_then_read_does_not_try_next_candidate () =
        Masc.Keeper_error_classify.degraded_retry_reason_to_string
        (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
 
+let test_historical_mutation_does_not_block_current_read_only_retry () =
+  let history_messages =
+    [
+      message
+        [
+          tool_use
+            ~input:
+              (`Assoc
+                [
+                  ("title", `String "old checkpoint");
+                  ("body", `String "previous turn posted progress");
+                ])
+            "keeper_board_post";
+        ];
+    ]
+  in
+  let current_attempt_messages =
+    [ message [ tool_use ~input:(`Assoc [ ("file_path", `String "dune") ]) "Read" ] ]
+  in
+  let checkpoint =
+    checkpoint_with_messages (history_messages @ current_attempt_messages)
+  in
+  let result =
+    Masc.Keeper_turn_driver.For_testing.apply_accept
+      ~initial_messages:history_messages
+      ~runtime_id:"runtime.thinking-after-historical-mutation-current-read"
+      ~accept:Keeper_tool_response.response_has_text_or_tool_progress
+      (run_result
+         ~checkpoint
+         ~content:
+           [
+             Agent_sdk.Types.Thinking
+               { thinking_type = "reasoning"; content = "internal chain" };
+           ]
+         ())
+  in
+  let err, reason_kind, reason = expect_accept_rejected result in
+  Alcotest.(check bool)
+    "reason kind is no usable progress"
+    true
+    (reason_kind = Some Keeper_internal_error.Accept_no_usable_progress);
+  Alcotest.(check bool)
+    "current last tool remains visible"
+    true
+    (contains ~needle:"last_tool=Read" reason);
+  Alcotest.(check bool)
+    "historical mutation is not counted as current attempt mutation"
+    true
+    (contains ~needle:"any_mutating_tool=false" reason);
+  Alcotest.(check bool)
+    "effects seen only includes current attempt read-only tool"
+    true
+    (contains ~needle:"tool_effects_seen=read_only" reason);
+  Alcotest.(check bool)
+    "current read-only no-progress tries next candidate"
+    true
+    (Masc.Keeper_turn_driver.For_testing
+     .accept_no_progress_read_only_should_try_next
+       err);
+  Alcotest.(check (option string))
+    "current read-only no-progress is runtime-recoverable"
+    (Some "read_only_no_progress")
+    (Option.map
+       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
+
 let test_thinking_only_after_read_only_webfetch_can_try_next_candidate () =
   let checkpoint =
     checkpoint_with_messages
@@ -901,6 +967,10 @@ let () =
             "thinking-only after mutation then read does not try next candidate"
             `Quick
             test_thinking_only_after_mutation_then_read_does_not_try_next_candidate;
+          Alcotest.test_case
+            "historical mutation does not block current read-only retry"
+            `Quick
+            test_historical_mutation_does_not_block_current_read_only_retry;
           Alcotest.test_case
             "thinking-only after read-only WebFetch tries next candidate"
             `Quick


### PR DESCRIPTION
## Summary
- add turn-wide tool effect summary to accept-rejection diagnostics (`any_mutating_tool`, `tool_effects_seen`)
- require `any_mutating_tool=false` before treating thinking-only read-only accept rejection as runtime-recoverable
- add fixture for `Write -> Read -> thinking_only` so earlier mutation blocks retry
- update the heuristic gap audit note for the closed last-tool false-positive slice

## Validation
- `git diff --check origin/main...HEAD`
- `ocamlformat --inplace` on changed OCaml files
- Local focused Dune build was started but stopped at user direction; CI owns build/test validation for this PR.
