### PR TITLE
feat(schedule): add wake-signal feed to scheduled automation panel (RFC-0234)

### DIFF
--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -99,6 +99,22 @@ describe('selectWakeSignals', () => {
     expect(signals.map(s => s.id)).toEqual(['s-live'])
   })
 
+  it('excludes running rows because they already woke', () => {
+    const signals = selectWakeSignals(
+      automation([
+        request({
+          schedule_id: 's-running',
+          next_due_at: 100,
+          status: 'running',
+          effective_status: 'running',
+          execution_readiness: 'running',
+        }),
+        request({ schedule_id: 's-live', next_due_at: 200, execution_readiness: 'scheduled' }),
+      ]),
+    )
+    expect(signals.map(s => s.id)).toEqual(['s-live'])
+  })
+
   it('keeps due-but-blocked rows — they are still pending wakes', () => {
     const signals = selectWakeSignals(
       automation([

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -1,0 +1,178 @@
+import { html } from 'htm/preact'
+import { render } from 'preact'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type {
+  DashboardScheduledAutomation,
+  DashboardScheduledAutomationRequest,
+} from '../../api/dashboard'
+import { ScheduledAutomationPanel, selectWakeSignals } from './scheduled-automation-panel'
+
+function request(
+  overrides: Partial<DashboardScheduledAutomationRequest> & { schedule_id: string },
+): DashboardScheduledAutomationRequest {
+  return {
+    status: 'scheduled',
+    risk_class: 'read_only',
+    approval_required: false,
+    source: 'schedule_store',
+    ...overrides,
+  }
+}
+
+function automation(
+  requests: DashboardScheduledAutomationRequest[],
+): DashboardScheduledAutomation {
+  return {
+    request_count: requests.length,
+    request_limit: 50,
+    truncated: false,
+    counts: {},
+    fsm: { state: 'idle', active_count: requests.length, terminal_count: 0 },
+    requests,
+  }
+}
+
+describe('selectWakeSignals', () => {
+  it('returns an empty list for missing automation', () => {
+    expect(selectWakeSignals(null)).toEqual([])
+    expect(selectWakeSignals(undefined)).toEqual([])
+  })
+
+  it('orders upcoming wakes soonest-first and reads id/at/kind/risk verbatim', () => {
+    const signals = selectWakeSignals(
+      automation([
+        request({
+          schedule_id: 's-late',
+          next_due_at: 2000,
+          next_due_at_iso: '2026-06-21T02:00:00Z',
+          payload_kind: 'masc.board_post',
+          risk_class: 'side_effecting',
+          execution_readiness: 'scheduled',
+        }),
+        request({
+          schedule_id: 's-soon',
+          next_due_at: 1000,
+          payload_kind: 'masc.keeper_nudge',
+          risk_class: 'read_only',
+          execution_readiness: 'ready',
+        }),
+      ]),
+    )
+
+    expect(signals.map(s => s.id)).toEqual(['s-soon', 's-late'])
+    expect(signals[0]).toMatchObject({
+      id: 's-soon',
+      at: 1000,
+      kind: 'masc.keeper_nudge',
+      risk: 'read_only',
+      readiness: 'ready',
+    })
+    // risk is the backend value, never a fabricated default
+    expect(signals[1]?.risk).toBe('side_effecting')
+  })
+
+  it('falls back to due_at when next_due_at is absent', () => {
+    const signals = selectWakeSignals(
+      automation([request({ schedule_id: 's', due_at: 1500, execution_readiness: 'scheduled' })]),
+    )
+    expect(signals).toHaveLength(1)
+    expect(signals[0]?.at).toBe(1500)
+  })
+
+  it('drops rows with no concrete wake time (not a signal)', () => {
+    const signals = selectWakeSignals(
+      automation([request({ schedule_id: 's-nodue', execution_readiness: 'scheduled' })]),
+    )
+    expect(signals).toEqual([])
+  })
+
+  it('excludes terminal/expired readiness and terminal statuses', () => {
+    const signals = selectWakeSignals(
+      automation([
+        request({ schedule_id: 's-term', next_due_at: 100, execution_readiness: 'terminal' }),
+        request({ schedule_id: 's-exp', next_due_at: 200, execution_readiness: 'expired' }),
+        request({ schedule_id: 's-cancelled', next_due_at: 300, status: 'cancelled', effective_status: 'cancelled' }),
+        request({ schedule_id: 's-live', next_due_at: 400, execution_readiness: 'scheduled' }),
+      ]),
+    )
+    expect(signals.map(s => s.id)).toEqual(['s-live'])
+  })
+
+  it('keeps due-but-blocked rows — they are still pending wakes', () => {
+    const signals = selectWakeSignals(
+      automation([
+        request({
+          schedule_id: 's-blocked',
+          next_due_at: 100,
+          execution_readiness: 'blocked_approval',
+          status: 'pending_approval',
+        }),
+      ]),
+    )
+    expect(signals.map(s => s.id)).toEqual(['s-blocked'])
+    expect(signals[0]?.readiness).toBe('blocked_approval')
+  })
+
+  it('uses the recurrence label as kind when payload_kind is absent', () => {
+    const signals = selectWakeSignals(
+      automation([
+        request({
+          schedule_id: 's-recur',
+          next_due_at: 100,
+          recurrence: { kind: 'interval', interval_sec: 60 },
+          execution_readiness: 'scheduled',
+        }),
+      ]),
+    )
+    expect(signals[0]?.kind).toBe('every 60s')
+  })
+})
+
+describe('ScheduledAutomationPanel wake-signal feed', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('renders the .sch-signals feed with the soonest signal first', () => {
+    render(
+      html`<${ScheduledAutomationPanel}
+        automation=${automation([
+          request({ schedule_id: 's-soon', next_due_at: 1000, payload_kind: 'masc.keeper_nudge', execution_readiness: 'ready' }),
+          request({ schedule_id: 's-late', next_due_at: 2000, payload_kind: 'masc.board_post', execution_readiness: 'scheduled' }),
+        ])}
+      />`,
+      container,
+    )
+
+    const feed = container.querySelector('[data-testid="sch-signals"]')
+    expect(feed).not.toBeNull()
+    const items = container.querySelectorAll('[data-testid="sch-signal"]')
+    expect(items).toHaveLength(2)
+    expect(items[0]?.textContent).toContain('s-soon')
+    expect(items[0]?.textContent).toContain('masc.keeper_nudge')
+    expect(items[0]?.textContent).toContain('risk')
+  })
+
+  it('renders an explicit empty state when there are no upcoming wakes', () => {
+    render(
+      html`<${ScheduledAutomationPanel}
+        automation=${automation([
+          request({ schedule_id: 's-term', next_due_at: 1000, execution_readiness: 'terminal' }),
+        ])}
+      />`,
+      container,
+    )
+
+    expect(container.querySelector('[data-testid="sch-signals-empty"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="sch-signals"]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -95,10 +95,11 @@ export interface WakeSignal {
   tone: StatusChipTone
 }
 
-// Readiness / status values that mean the schedule will not wake again — these
-// are history, not upcoming signals, so they are excluded from the feed.
-const TERMINAL_WAKE_READINESS: ReadonlySet<string> = new Set(['terminal', 'expired'])
-const TERMINAL_WAKE_STATUS: ReadonlySet<string> = new Set([
+// Readiness / status values that are not upcoming wake signals. Terminal rows
+// are history, and running rows have already woken.
+const NON_UPCOMING_WAKE_READINESS: ReadonlySet<string> = new Set(['terminal', 'expired', 'running'])
+const NON_UPCOMING_WAKE_STATUS: ReadonlySet<string> = new Set([
+  'running',
   'terminal',
   'expired',
   'cancelled',
@@ -118,8 +119,8 @@ export function selectWakeSignals(
     if (at == null) continue
     const readiness = request.execution_readiness ?? null
     const status = request.effective_status ?? request.status
-    if (readiness != null && TERMINAL_WAKE_READINESS.has(readiness)) continue
-    if (TERMINAL_WAKE_STATUS.has(status)) continue
+    if (readiness != null && NON_UPCOMING_WAKE_READINESS.has(readiness)) continue
+    if (NON_UPCOMING_WAKE_STATUS.has(status)) continue
     signals.push({
       id: request.schedule_id,
       at,

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -72,6 +72,97 @@ function recurrenceLabel(request: DashboardScheduledAutomationRequest): string {
   return enumLabel(kind)
 }
 
+/**
+ * RFC-0234 §10 "Dashboard and operator UX" — a wake-signal feed surfaces the
+ * upcoming scheduler wakes ("future rows with ... due time, payload summary,
+ * and risk") ordered soonest-first. The scheduler is a turn-start channel
+ * (RFC-0234 §2: proactive turn mechanisms decide whether an agent should wake);
+ * this feed answers "what wakes next" rather than auditing every row like the
+ * full table below.
+ *
+ * Every field is read verbatim from what the backend already emits (#21852):
+ * id = schedule_id, at = next_due_at ?? due_at, kind = payload_kind (else the
+ * recurrence label), risk = risk_class. Nothing is fabricated — a row without a
+ * concrete next wake time is not a signal and is dropped.
+ */
+export interface WakeSignal {
+  id: string
+  at: number
+  atIso: string | null
+  kind: string
+  risk: string
+  readiness: string
+  tone: StatusChipTone
+}
+
+// Readiness / status values that mean the schedule will not wake again — these
+// are history, not upcoming signals, so they are excluded from the feed.
+const TERMINAL_WAKE_READINESS: ReadonlySet<string> = new Set(['terminal', 'expired'])
+const TERMINAL_WAKE_STATUS: ReadonlySet<string> = new Set([
+  'terminal',
+  'expired',
+  'cancelled',
+  'succeeded',
+  'failed',
+  'rejected',
+])
+
+export function selectWakeSignals(
+  automation: DashboardScheduledAutomation | null | undefined,
+): WakeSignal[] {
+  if (!automation) return []
+  const signals: WakeSignal[] = []
+  for (const request of automation.requests ?? []) {
+    const at = request.next_due_at ?? request.due_at ?? null
+    // No concrete wake time → no signal to surface (parse, don't validate).
+    if (at == null) continue
+    const readiness = request.execution_readiness ?? null
+    const status = request.effective_status ?? request.status
+    if (readiness != null && TERMINAL_WAKE_READINESS.has(readiness)) continue
+    if (TERMINAL_WAKE_STATUS.has(status)) continue
+    signals.push({
+      id: request.schedule_id,
+      at,
+      atIso: request.next_due_at_iso ?? request.due_at_iso ?? null,
+      kind: request.payload_kind?.trim() || recurrenceLabel(request),
+      risk: request.risk_class,
+      readiness: readiness ?? status,
+      tone: automationTone(readiness ?? status),
+    })
+  }
+  return signals.sort((a, b) => a.at - b.at)
+}
+
+function WakeSignalFeed({ signals }: { signals: WakeSignal[] }) {
+  if (signals.length === 0) {
+    return html`
+      <div class="sch-signals text-xs text-[var(--color-fg-muted)]" data-testid="sch-signals-empty">
+        예정된 wake signal 없음
+      </div>
+    `
+  }
+  return html`
+    <ul class="sch-signals grid gap-1" data-testid="sch-signals">
+      ${signals.map(
+        signal => html`
+          <li
+            class="sch-signal flex flex-wrap items-center gap-x-3 gap-y-1 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-hover)] px-2 py-1"
+            data-testid="sch-signal"
+          >
+            <span class="sch-signal-at font-mono text-xs text-[var(--color-fg-secondary)]">
+              ${formatDateTimeKo(signal.atIso ?? signal.at)}
+            </span>
+            <${StatusChip} tone=${signal.tone} uppercase=${false}>${enumLabel(signal.readiness)}<//>
+            <span class="sch-signal-kind font-mono text-2xs text-[var(--color-fg-muted)]">${signal.kind}</span>
+            <span class="sch-signal-id font-mono text-3xs text-[var(--color-fg-disabled)]">${signal.id}</span>
+            <span class="sch-signal-risk text-2xs text-[var(--color-fg-muted)]">risk ${enumLabel(signal.risk)}</span>
+          </li>
+        `,
+      )}
+    </ul>
+  `
+}
+
 function lastExecutionLabel(request: DashboardScheduledAutomationRequest): string {
   const execution = request.last_execution
   if (!execution) return '-'
@@ -157,6 +248,7 @@ export function ScheduledAutomationPanel({
   const nonzeroCounts = Object.entries(automation.counts ?? {})
     .filter(([, count]) => count > 0)
   const rows = automation.requests ?? []
+  const wakeSignals = selectWakeSignals(automation)
   const dueEffective = automation.derived_counts?.due_effective ?? 0
   const blockedApproval = automation.derived_counts?.blocked_approval ?? 0
   const dueExecutionReady = automation.derived_counts?.due_execution_ready ?? 0
@@ -199,6 +291,13 @@ export function ScheduledAutomationPanel({
         ${nonzeroCounts.length > 0
           ? nonzeroCounts.map(([name, count]) => html`<${CountChip} name=${name} count=${count} />`)
           : html`<span class="text-xs text-[var(--color-fg-muted)]">active schedule 없음</span>`}
+      </div>
+
+      <div class="grid gap-2">
+        <div class="text-3xs uppercase tracking-wider text-[var(--color-fg-disabled)]">
+          upcoming wake signals
+        </div>
+        <${WakeSignalFeed} signals=${wakeSignals} />
       </div>
 
       ${rows.length > 0


### PR DESCRIPTION
## 목적

`scheduled-automation-panel.ts`는 모든 schedule 요청을 `schedule_id` 정렬의 평면 테이블로만 보여준다. 운영자가 "다음에 무엇이 깨우는가(upcoming wake)"를 빠르게 읽을 turn-start 채널 뷰가 없다. RFC-0234 §10이 명시한 wake-signal feed(`.sch-signals`)를 추가한다 — 예정된 wake를 빠른 순서로, `at`/`kind`/`id`/`risk`만 압축해서 표시.

## RFC 인용

`docs/rfc/RFC-0234-scheduled-internal-automation.md`

§10 "Dashboard and operator UX":

> Dashboard surfaces:
> - Scheduled: future rows with requester, scheduler, due time, payload summary, and risk.

§2 (turn-start 성격):

> - proactive turn mechanisms decide whether an agent should wake; they do not carry an operator-authored future action request.

§4 data model은 `risk_class`, `due_at`를 typed 필드로 정의한다 (날조 아님). 관련: RFC-0069 (Awareness Channel Split) — wake-signal feed는 scheduler turn-start awareness를 dashboard에 노출하는 read 채널이다. OAS turn lifecycle은 건드리지 않음 (OAS가 turn을 소유; MASC는 wake를 schedule/surface).

## #21869 관계

#21869 (`audit/keeper-schedule-dashboard-todo-20260621`)는 **docs-only** (reports/ 2개 파일, "no Dune build run"). 코드 충돌 없음. 해당 audit이 P1-1 "Dashboard exposure is buried in Tools/Lab", P1-2 "UI is read-only where operators need decisions"로 지적한 노출 격차의 read-only 슬라이스를 본 PR이 구현한다. audit 보고서 자체는 수정하지 않는다.

## Grounding: 데이터는 이미 백엔드에 존재 (backend 변경 0)

at/kind/id/risk는 #21852 (`feat(schedule): surface keeper next actions`)가 이미 dashboard tools API로 emit 한다:

- **id** = `schedule_id`
- **at** = `next_due_at` (없으면 `due_at`) / `*_iso`
- **kind** = `payload_kind` (없으면 recurrence label)
- **risk** = `risk_class`

`server_dashboard_http_runtime_info.ml`이 `Schedule_domain.risk_class_to_string` 등으로 이미 직렬화하고, `DashboardScheduledAutomationRequest` 타입이 이 필드들을 이미 담는다. 따라서 **추가 백엔드 직렬화 불필요** — 본 PR은 프론트엔드 파생 뷰만 추가한다 (additive, 기존 테이블/타입 무변경).

## 변경 내용 (frontend-only)

`dashboard/src/components/tools/scheduled-automation-panel.ts`:
- `selectWakeSignals(automation)` — pure exported helper. `requests`에서 구체적 wake 시각(`next_due_at ?? due_at`)이 있고 terminal/expired가 아닌 행만 골라 wake 시각 오름차순 정렬. wake 시각 없는 행은 signal이 아니므로 drop (parse, don't validate). terminal 판정은 명시 상수(`TERMINAL_WAKE_READINESS`, `TERMINAL_WAKE_STATUS`)로.
- `WakeSignalFeed` — `.sch-signals` 리스트 렌더(`at` / readiness chip / `kind` / `id` / `risk`). 빈 경우 명시적 empty state(`sch-signals-empty`).
- panel에 "upcoming wake signals" 섹션을 count chips와 기존 테이블 사이에 삽입. 기존 테이블은 그대로 유지(전체 audit 뷰).

`risk_class`는 백엔드 값을 그대로 표시 — 값이 없거나 unknown이어도 가짜 기본값을 만들지 않는다.

## 테스트

`dashboard/src/components/tools/scheduled-automation-panel.test.ts` (신규):
- `selectWakeSignals`: 빈/누락 automation → `[]`; 오름차순 정렬 + id/at/kind/risk verbatim; `due_at` fallback; wake 시각 없는 행 제외; terminal/expired readiness + terminal status 제외; due-but-blocked 행은 유지(아직 pending wake); payload_kind 없을 때 recurrence label.
- 렌더: `.sch-signals` feed가 soonest-first로 렌더; upcoming wake 없을 때 `sch-signals-empty`.

## 범위 / Deferred

- **DEFER**: card actions (approve/deny/cancel) — read-only feed만. RFC-0234 §10 "UI must make self-approval impossible"는 별도 mutation 슬라이스(#21869 P1-2)에서 다룬다.
- 본 PR은 read-only 표시에 한정.

## 검증

- Backend: OCaml 파일 변경 0건 → `dune build` 대상 변경 없음 (origin/main 기준 green 유지).
- Frontend: `npx tsc --noEmit` → exit 0; `eslint` (touched files) → clean; `npx vitest run` (touched + tools-main) → 12 tests pass.

패키지 매니저: pnpm (pnpm-lock.yaml).

RFC-WAIVED: scheduler dashboard는 credential/operator/sandbox/hooks 보호 목록에 속하지 않음. RFC-0234 §10 인용으로 설계 근거 충족; 프론트엔드 read-only 파생 뷰.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
