### PR TITLE
fix(dashboard): render keeper thinking trace as sanitized markdown with newlines

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1722,6 +1722,39 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     expect(bundle?.textContent).toContain('곧 답합니다')
   })
 
+  it('renders thinking text as sanitized markdown with newlines preserved', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a',
+            text: '답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            traceSteps: [{ kind: 'think', text: '첫째 줄 **강조**\n둘째 줄\n\n<script>alert(1)</script>' }],
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const think = container.querySelector('[data-chat-trace-step="think"] .chat-block-tstep-text') as HTMLElement
+    expect(think).not.toBeNull()
+    // Newline-preserving container (raw interpolation folded these to one line).
+    expect(think.className).toContain('whitespace-pre-wrap')
+    expect(think.className).toContain('markdown-body')
+    // Markdown is rendered, not shown as literal `**강조**`.
+    expect(think.querySelector('strong')?.textContent).toBe('강조')
+    // Both source lines survive the round-trip.
+    expect(think.textContent).toContain('첫째 줄')
+    expect(think.textContent).toContain('둘째 줄')
+    // Untrusted model markup is stripped (no executable script element).
+    expect(think.querySelector('script')).toBeNull()
+  })
+
   it('keeps the flat per-row tool bubbles when grouping is off (default)', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -472,6 +472,17 @@ function renderInlineHtml(raw: string): { __html: string } {
   return { __html: sanitizeHtml(linkifyHtml(raw)) }
 }
 
+// Trace-step thinking text: render through the same sanitized markdown path the
+// assistant message body uses (purifyHtml(marked.parse(...))) so newlines and
+// inline formatting survive. Raw `${step.text}` interpolation collapsed both —
+// the model emits multi-line reasoning and the single-span layout folded it into
+// one run-on line. purifyHtml strips untrusted model markup (XSS coverage in
+// primitives.test.ts); `whitespace-pre-wrap` on the container preserves the
+// newlines marked leaves between paragraphs.
+function traceStepMarkdown(raw: string): { __html: string } {
+  return { __html: purifyHtml(marked.parse(raw) as string) }
+}
+
 function highlightJson(obj: unknown): string {
   const s = JSON.stringify(obj, null, 2)
   return sanitizeHtml(
@@ -966,8 +977,11 @@ function ChatTraceStep({ step }: { step: ChatTraceStep }) {
         <div class="min-w-0 flex-1">
           <div class="chat-block-tstep-row">
             <span class="chat-block-tstep-kind">Thinking</span>
-            <span class="chat-block-tstep-text">${step.text}</span>
           </div>
+          <div
+            class="chat-block-tstep-text markdown-body whitespace-pre-wrap break-words"
+            dangerouslySetInnerHTML=${traceStepMarkdown(step.text)}
+          />
         </div>
       </div>
     `

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -205,6 +205,10 @@
 
 .chat-block-tstep-text {
   min-width: 0;
+  /* Preserve the model's newlines (the think/reason text carries multi-line
+     reasoning that single-line flow folded into one run-on line). */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .chat-block-reason-detail {


### PR DESCRIPTION
## 목표
키퍼 턴 상세의 "Thinking" trace가 개행 없이 한 줄로 뭉치고 markdown이 리터럴로 보이는 문제를 수정한다.

## 증상
`ChatTraceStep`의 `think` 스텝이 `${step.text}`를 단일 inline `<span>`으로 렌더 → 모델의 다행(multi-line) reasoning이 HTML whitespace folding으로 한 줄로 붕괴. `.chat-block-tstep-text`에 white-space 규칙이 없고 markdown 파싱도 없어 `**강조**`가 리터럴로 노출.

## 변경
- `traceStepMarkdown()` helper 추가 — 메시지 본문과 동일한 sanitized markdown 경로(`purifyHtml(marked.parse(...))`) 재사용.
- `think` 스텝을 라벨 아래 `markdown-body whitespace-pre-wrap break-words` 블록으로 렌더 → 개행 + inline rich.
- `.chat-block-tstep-text`에 `white-space: pre-wrap; overflow-wrap: anywhere;` 추가 → `reason` 스텝도 개행 보존 혜택.

## 변경 파일
- `dashboard/src/components/chat/primitives.ts` (helper + think 스텝)
- `dashboard/src/styles/chat-blocks-v2.css` (개행 보존)
- `dashboard/src/components/chat/primitives.test.ts` (신규 테스트)

## 로컬 검증
- `npx vitest run src/components/chat/primitives.test.ts` → 84 passed (0 failed).
- 신규 테스트: markdown 렌더(`**강조**`→`<strong>`), 개행 보존(첫째/둘째 줄 생존), 비신뢰 markup 차단(`<script>` 제거) 검증.

## 미검증
- 시각적 렌더(스크린샷) 미촬영 — CSS pre-wrap + markdown-body 조합은 메시지 본문에서 검증된 패턴 재사용.
- 빌드/타입체크는 CI에서.

## 범위 밖 (별도 처리)
적대 감사로 확인된 인접 결함은 이 PR에 포함하지 않음:
- tool-status: 완료된 턴의 null 출력이 영구 'pending'으로 표시 (dashboard correctness, 후속 PR)
- BDI/SOCIAL_MODEL 헤더 누수 = 구조화 출력 부재 (RFC-0242 확장 대상; tool-calling 공존 설계 미해결)
- thinking↔tool 인터리빙 순서 소실 (stream/state 구조 변경, 후속)

RFC 영향 없음: `dashboard/src/components/chat` 렌더링 한정 (credential/operator/hooks/workflow subsystem 무관).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
