### PR TITLE
feat(settings): wire MCP tool list and system-log tail to live backend

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -3,12 +3,72 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { fireEvent, waitFor } from '@testing-library/preact'
-import { SettingsSurface } from './settings-surface'
+import {
+  SettingsSurface,
+  mcpExposedToolNames,
+  logEntryToSysRow,
+  logRowStatus,
+} from './settings-surface'
+import type { DashboardToolInventoryItem } from '../api/dashboard'
+import type { LogEntry } from '../api/schemas/logs'
 import { DashboardMain } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 import { dashboardLoading } from '../store'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
+
+const apiMock = vi.hoisted(() => ({
+  fetchLogs: vi.fn(),
+  fetchDashboardTools: vi.fn(),
+}))
+
+vi.mock('../api/dashboard.js', async () => {
+  const actual = await vi.importActual<typeof import('../api/dashboard')>('../api/dashboard')
+  return {
+    ...actual,
+    fetchLogs: apiMock.fetchLogs,
+    fetchDashboardTools: apiMock.fetchDashboardTools,
+  }
+})
+
+function makeLogEntry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    seq: 1,
+    ts: '2026-06-21T16:24:51Z',
+    level: 'INFO',
+    source: 'structured',
+    module: 'Keeper',
+    message: 'booted',
+    keeper_name: null,
+    turn_id: null,
+    category: null,
+    details: null,
+    ...overrides,
+  }
+}
+
+function makeToolItem(overrides: Partial<DashboardToolInventoryItem> = {}): DashboardToolInventoryItem {
+  return {
+    name: 'tool',
+    description: '',
+    category: 'uncategorized',
+    enabled_in_current_mode: false,
+    direct_call_allowed: false,
+    doc_refs: [],
+    prompt_hints: [],
+    surfaces: [],
+    visibility: 'public',
+    lifecycle: 'stable',
+    implementationStatus: 'implemented',
+    tier: 'standard',
+    ...overrides,
+  }
+}
+
+function stubEmptyApi() {
+  apiMock.fetchLogs.mockResolvedValue({ total: 0, entries: [] })
+  apiMock.fetchDashboardTools.mockResolvedValue({ tool_inventory: { count: 0, tools: [] } })
+}
 
 const navigate = vi.fn()
 vi.mock('../router', async () => {
@@ -25,6 +85,9 @@ describe('SettingsSurface', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    apiMock.fetchLogs.mockReset()
+    apiMock.fetchDashboardTools.mockReset()
+    stubEmptyApi()
   })
 
   afterEach(() => {
@@ -95,22 +158,35 @@ describe('SettingsSurface', () => {
     expect(buttons()[2]!.getAttribute('data-active')).toBe('true')
   })
 
-  it('log filter chips filter rows', async () => {
+  it('log filter chips filter live rows from the ring', async () => {
+    // 6 ring entries mapped to rows: tool(/masc_/)=3, success(ok)=3, failure(fail)=2.
+    apiMock.fetchLogs.mockResolvedValue({
+      total: 6,
+      entries: [
+        makeLogEntry({ seq: 6, level: 'INFO', message: 'masc_start 완료' }),
+        makeLogEntry({ seq: 5, level: 'INFO', message: 'masc_compact 완료' }),
+        makeLogEntry({ seq: 4, level: 'WARN', message: '컨텍스트 91% — compact 예약' }),
+        makeLogEntry({ seq: 3, level: 'ERROR', message: 'masc_trace_window 실패' }),
+        makeLogEntry({ seq: 2, level: 'ERROR', message: 'restart failed (3/3)' }),
+        makeLogEntry({ seq: 1, level: 'INFO', message: 'handoff 시작' }),
+      ],
+    })
+
     render(html`<${SettingsSurface} />`, container)
 
     const logsNav = container.querySelector('[data-testid="settings-nav-logs"]') as HTMLElement
     await fireEvent.click(logsNav)
 
     const allRows = () => container.querySelectorAll('[data-testid="log-row"]')
-    expect(allRows().length).toBe(10)
+    await waitFor(() => expect(allRows().length).toBe(6))
 
     const toolFilter = container.querySelector('[data-filter="tool"]') as HTMLButtonElement
     await fireEvent.click(toolFilter)
-    expect(allRows().length).toBe(7)
+    expect(allRows().length).toBe(3)
 
     const successFilter = container.querySelector('[data-filter="success"]') as HTMLButtonElement
     await fireEvent.click(successFilter)
-    expect(allRows().length).toBe(4)
+    expect(allRows().length).toBe(3)
 
     const failureFilter = container.querySelector('[data-filter="failure"]') as HTMLButtonElement
     await fireEvent.click(failureFilter)
@@ -118,7 +194,33 @@ describe('SettingsSurface', () => {
 
     const allFilter = container.querySelector('[data-filter="all"]') as HTMLButtonElement
     await fireEvent.click(allFilter)
-    expect(allRows().length).toBe(10)
+    expect(allRows().length).toBe(6)
+  })
+
+  it('shows the live MCP exposed-tools list from the capability registry', async () => {
+    apiMock.fetchDashboardTools.mockResolvedValue({
+      tool_inventory: {
+        count: 2,
+        tools: [
+          makeToolItem({ name: 'masc_handoff', surfaces: ['public_mcp'] }),
+          makeToolItem({ name: 'masc_start', surfaces: ['public_mcp'] }),
+          makeToolItem({ name: 'internal_only', surfaces: ['internal'] }),
+        ],
+      },
+    })
+
+    render(html`<${SettingsSurface} />`, container)
+
+    const mcpNav = container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement
+    await fireEvent.click(mcpNav)
+
+    await waitFor(() => {
+      const labels = Array.from(container.querySelectorAll('.set-row .mono')).map(n => n.textContent)
+      expect(labels).toContain('masc_handoff')
+      expect(labels).toContain('masc_start')
+      // internal-only tools are not exposed over public MCP.
+      expect(labels).not.toContain('internal_only')
+    })
   })
 })
 
@@ -128,6 +230,9 @@ describe('SettingsSurface shell route', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
+    apiMock.fetchLogs.mockReset()
+    apiMock.fetchDashboardTools.mockReset()
+    stubEmptyApi()
     dashboardLoading.value = false
     connected.value = true
     namespaceTruthInitializing.value = false
@@ -150,5 +255,47 @@ describe('SettingsSurface shell route', () => {
     await waitFor(() => {
       expect(document.title).toBe('MASC · Settings')
     })
+  })
+})
+
+describe('settings read-surface helpers', () => {
+  it('mcpExposedToolNames keeps only public_mcp tools, sorted', () => {
+    const names = mcpExposedToolNames([
+      makeToolItem({ name: 'masc_start', surfaces: ['public_mcp'] }),
+      makeToolItem({ name: 'masc_handoff', surfaces: ['public_mcp', 'keeper'] }),
+      makeToolItem({ name: 'internal_only', surfaces: ['internal'] }),
+      makeToolItem({ name: 'no_surface', surfaces: [] }),
+    ])
+    expect(names).toEqual(['masc_handoff', 'masc_start'])
+  })
+
+  it('mcpExposedToolNames returns [] for empty inventory (no fabrication)', () => {
+    expect(mcpExposedToolNames([])).toEqual([])
+  })
+
+  it('logRowStatus derives status from level only', () => {
+    expect(logRowStatus('ERROR')).toBe('fail')
+    expect(logRowStatus('error')).toBe('fail')
+    expect(logRowStatus('WARN')).toBe('warn')
+    expect(logRowStatus('INFO')).toBe('ok')
+    expect(logRowStatus('DEBUG')).toBe('ok')
+  })
+
+  it('logEntryToSysRow maps a ring entry to [time, level, identity, message, status]', () => {
+    const row = logEntryToSysRow(
+      makeLogEntry({
+        ts: '2026-06-21T16:24:51Z',
+        level: 'ERROR',
+        keeper_name: 'drifter',
+        module: 'Keeper',
+        message: 'masc_trace_window 실패',
+      }),
+    )
+    expect(row).toEqual(['16:24:51', 'error', 'drifter', 'masc_trace_window 실패', 'fail'])
+  })
+
+  it('logEntryToSysRow falls back to module then (root) for identity', () => {
+    expect(logEntryToSysRow(makeLogEntry({ keeper_name: null, module: 'Server' }))[2]).toBe('Server')
+    expect(logEntryToSysRow(makeLogEntry({ keeper_name: null, module: '' }))[2]).toBe('(root)')
   })
 })

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -1,9 +1,14 @@
 // MASC Dashboard — Settings surface (keeper-v2 port)
-// Local-state-only operator console. No backend wiring.
+// Read surfaces (MCP exposed-tools list, system-log tail) are wired to live
+// backend data. Write surfaces (Save changes, VerifyBtn, runtime defaults /
+// model routing) remain local-state stubs — see the deferred list in the PR
+// that introduced the read wiring.
 
 import { html } from 'htm/preact'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import { navigate } from '../router'
+import { fetchLogs, fetchDashboardTools } from '../api/dashboard.js'
+import type { LogEntry, DashboardToolInventoryItem } from '../api/dashboard.js'
 import type { ComponentChildren } from 'preact'
 
 type SectionId =
@@ -54,15 +59,21 @@ const SET_GROUPS: [string, SectionId[]][] = [
   ['관측 · 표시', ['logs', 'notify', 'display']],
 ]
 
-const MCP_TOOLS = [
-  'masc_start',
-  'masc_handoff',
-  'masc_compact',
-  'masc_amplitude_query',
-  'masc_trace_window',
-  'masc_board_metrics',
-  'masc_git_blame',
-]
+// Tools exposed over the public MCP server, derived from the live capability
+// registry (`/api/v1/dashboard/tools`). The "public_mcp" surface is the
+// registry's own exposure signal — see lib/tool_misc_introspection.ml
+// (Tool_catalog.is_public_mcp). Unknown/empty inventory yields an empty list
+// (no fabricated tool names).
+const MCP_PUBLIC_SURFACE = 'public_mcp'
+const SETTINGS_LOG_LIMIT = 50
+const SETTINGS_LOG_POLL_MS = 3000
+
+export function mcpExposedToolNames(items: readonly DashboardToolInventoryItem[]): string[] {
+  return items
+    .filter(item => item.surfaces.includes(MCP_PUBLIC_SURFACE))
+    .map(item => item.name)
+    .sort((a, b) => a.localeCompare(b))
+}
 
 const RUNTIMES = [
   { name: 'oas·seoul-1', endpoint: 'oas://seoul-1.masc.run', region: 'ap-northeast-2', kind: 'OAS', keepers: 3 },
@@ -78,18 +89,43 @@ const APPROVAL_ACTIONS: [string, string, string][] = [
   ['읽기 전용 도구', 'auto', 'query·trace·blame 등'],
 ]
 
-const SYS_LOG: [string, string, string, string, string][] = [
-  ['16:24:51', 'info', 'masc-improver', 'masc_amplitude_query 완료', 'ok'],
-  ['16:24:48', 'info', 'masc-improver', 'masc_amplitude_query 호출 (D0–D3)', 'run'],
-  ['16:23:10', 'warn', 'nick0cave', '컨텍스트 91% — compact 예약', 'warn'],
-  ['16:22:55', 'info', 'sangsu', 'masc_git_blame 완료', 'ok'],
-  ['16:21:02', 'error', 'drifter', 'masc_trace_window 실패 — context overflow', 'fail'],
-  ['16:20:40', 'info', 'qa-king', 'HandingOff → sangsu 인계 시작', 'run'],
-  ['16:19:33', 'info', 'nick0cave', 'masc_compact 완료 (−64%)', 'ok'],
-  ['16:18:12', 'error', 'drifter', 'masc_start 재시작 실패 (3/3)', 'fail'],
-  ['16:17:50', 'info', 'scholar', 'masc_board_metrics 완료', 'ok'],
-  ['16:16:04', 'warn', 'analyst', 'search/index 색인 실패 1건', 'warn'],
-]
+// System-log row: [time, level, identity, message, status]. Derived from live
+// ring entries (`/api/v1/dashboard/logs`) — the same source the Logs surface
+// polls. Status is derived from the entry level only (error→fail, warn→warn,
+// else→ok); the in-progress "run" state is not knowable from a settled ring
+// entry, so it is never fabricated.
+type SysLogRow = [string, string, string, string, string]
+
+const SETTINGS_LOG_LEVEL_FAIL = 'error'
+const SETTINGS_LOG_LEVEL_WARN = 'warn'
+
+export function logRowStatus(level: string): 'ok' | 'warn' | 'fail' {
+  const normalized = level.toLowerCase()
+  if (normalized === SETTINGS_LOG_LEVEL_FAIL) return 'fail'
+  if (normalized === SETTINGS_LOG_LEVEL_WARN) return 'warn'
+  return 'ok'
+}
+
+function logRowClock(ts: string): string {
+  const match = ts.match(/T(\d{2}:\d{2}:\d{2})/)
+  if (match?.[1]) return match[1]
+  const date = new Date(ts)
+  if (!Number.isNaN(date.getTime())) {
+    return date.toLocaleTimeString('ko-KR', {
+      hour12: false,
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  }
+  return ts
+}
+
+export function logEntryToSysRow(entry: LogEntry): SysLogRow {
+  const level = entry.level.toLowerCase()
+  const identity = entry.keeper_name?.trim() || entry.module?.trim() || '(root)'
+  return [logRowClock(entry.ts), level, identity, entry.message, logRowStatus(entry.level)]
+}
 
 function SetToggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => void }) {
   return html`
@@ -247,7 +283,39 @@ function LogFilter({
 
 function LogViewer() {
   const [filter, setFilter] = useState<LogFilter>('all')
-  const rows = SYS_LOG.filter(r => {
+  const [allRows, setAllRows] = useState<SysLogRow[]>([])
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+
+  useEffect(() => {
+    let active = true
+    let timer: ReturnType<typeof setInterval> | null = null
+
+    const tick = async () => {
+      try {
+        const resp = await fetchLogs({ limit: SETTINGS_LOG_LIMIT })
+        if (!active) return
+        const rows = [...resp.entries]
+          .sort((a, b) => b.seq - a.seq)
+          .map(logEntryToSysRow)
+        setAllRows(rows)
+        setStatus('ready')
+      } catch {
+        if (!active) return
+        // No fabricated rows on failure — surface the error state instead.
+        setStatus('error')
+      }
+    }
+
+    void tick()
+    timer = setInterval(() => { void tick() }, SETTINGS_LOG_POLL_MS)
+
+    return () => {
+      active = false
+      if (timer) clearInterval(timer)
+    }
+  }, [])
+
+  const rows = allRows.filter(r => {
     if (filter === 'all') return true
     if (filter === 'tool') return /masc_/.test(r[3])
     if (filter === 'success') return r[4] === 'ok'
@@ -256,6 +324,10 @@ function LogViewer() {
   })
 
   const filters: LogFilter[] = ['all', 'tool', 'success', 'failure']
+  const emptyLabel =
+    status === 'loading' ? '로그를 불러오는 중…'
+    : status === 'error' ? '시스템 로그를 불러오지 못했습니다.'
+    : '조건에 맞는 로그가 없습니다.'
 
   return html`
     <div class="log-view" data-testid="log-viewer">
@@ -271,7 +343,9 @@ function LogViewer() {
         <span class="log-live"><span class="tps-dot"></span>tail -f</span>
       </div>
       <div class="log-stream mono" data-testid="log-stream">
-        ${rows.map((r, i) => html`
+        ${rows.length === 0
+          ? html`<div class="log-empty" data-testid="log-empty">${emptyLabel}</div>`
+          : rows.map((r, i) => html`
           <div key=${i} class=${`log-line ${r[1]}`} data-testid="log-row">
             <span class="lt">${r[0]}</span>
             <span class=${`ll ${r[1]}`}>${r[1]}</span>
@@ -294,12 +368,33 @@ export function SettingsSurface() {
   const [tokenShown, setTokenShown] = useState(false)
   const [sessionExpiry, setSessionExpiry] = useState('8시간')
 
-  // mcp
+  // mcp — exposed tools come from the live capability registry (public_mcp surface)
   const [mcpUrl, setMcpUrl] = useState('https://masc.local/mcp')
   const [transport, setTransport] = useState('http')
-  const [tools, setTools] = useState<Record<string, boolean>>(
-    Object.fromEntries(MCP_TOOLS.map(t => [t, true])),
-  )
+  const [mcpTools, setMcpTools] = useState<string[]>([])
+  const [tools, setTools] = useState<Record<string, boolean>>({})
+
+  useEffect(() => {
+    let active = true
+    void (async () => {
+      try {
+        const resp = await fetchDashboardTools()
+        if (!active) return
+        const names = mcpExposedToolNames(resp.tool_inventory?.tools ?? [])
+        setMcpTools(names)
+        // Listed tools are, by definition, currently exposed over public MCP.
+        // The per-tool toggle is a local view control; expose/unexpose
+        // persistence is deferred (no backend write endpoint yet).
+        setTools(Object.fromEntries(names.map(n => [n, true])))
+      } catch {
+        if (!active) return
+        // No fabricated tool names on failure.
+        setMcpTools([])
+        setTools({})
+      }
+    })()
+    return () => { active = false }
+  }, [])
 
   // runtime defaults
   const [defRuntime, setDefRuntime] = useState('oas·seoul-1')
@@ -493,11 +588,13 @@ export function SettingsSurface() {
                 ${transport === 'stdio' && html`<span>spawn: masc-mcp serve --stdio · framing: ndjson · pid 8421</span>`}
                 ${transport === 'sse' && html`<span>GET ${mcpUrl}/sse · keep-alive 15s · event: message</span>`}
               </div>
-              <div class="set-sub-h">Exposed tools (${Object.values(tools).filter(Boolean).length}/${MCP_TOOLS.length})</div>
-              ${MCP_TOOLS.map(t => html`
+              <div class="set-sub-h">Exposed tools (${Object.values(tools).filter(Boolean).length}/${mcpTools.length})</div>
+              ${mcpTools.length === 0
+                ? html`<div class="set-hint" data-testid="mcp-tools-empty">노출된 MCP 도구가 없습니다.</div>`
+                : mcpTools.map(t => html`
                 <${SetRow} key=${t} label=${html`<span class="mono" style=${{ fontSize: '12.5px' }}>${t}</span>`}>
                   <${SetToggle}
-                    on=${tools[t]}
+                    on=${tools[t] ?? false}
                     onChange=${(v: boolean) => setTools(p => ({ ...p, [t]: v }))}
                   />
                 <//>


### PR DESCRIPTION
## 요약

Settings surface(`dashboard/src/components/settings-surface.ts`)는 모든 read 패널이 하드코딩 상수로 채워진 prototype이었습니다. 백엔드가 이미 존재하는 두 read 스텁을 실데이터 fetch로 교체했습니다(허위 데이터 없음).

## 변경 내용 (wired)

### 1. MCP "Exposed tools" 목록 → 실 capability registry
- 기존: 하드코딩된 7개 이름 배열 `MCP_TOOLS`(`masc_start`, …)과 `tools` 전체 true 가짜 상태.
- 변경: `fetchDashboardTools()`(`/api/v1/dashboard/tools`)의 `tool_inventory.tools`를 `surfaces.includes('public_mcp')`로 필터링. `public_mcp`는 레지스트리 자체의 노출 신호(`lib/tool_misc_introspection.ml`의 `Tool_catalog.is_public_mcp`)이며, FE에서 이미 `tool-state.ts`/`tool-full-inventory.ts`가 쓰는 검증된 패턴.
- 빈/에러 시 빈 목록(가짜 이름 없음). 노출된 도구가 없으면 안내 문구 표시.

### 2. 시스템 로그 뷰어 → 실 로그 ring tail
- 기존: 정적 `SYS_LOG` 배열(가짜 timestamp/agent/메시지/status 10행).
- 변경: `fetchLogs({ limit })`(`/api/v1/dashboard/logs`, Logs surface와 동일 소스)를 3초 폴링하여 ring entry를 `[time, level, identity, message, status]`로 매핑. status는 level에서만 파생(error→fail, warn→warn, else→ok); ring entry로 알 수 없는 in-progress `run`은 절대 날조하지 않음. 로딩/에러/빈 상태 표시.

순수 매핑 로직(`mcpExposedToolNames`, `logEntryToSysRow`, `logRowStatus`)은 export하여 단위 테스트.

## Deferred (이 PR 범위 밖, 후속)

- **Runtime defaults & model routing**: `/api/v1/runtime/config/raw`는 raw TOML `source_text`만 노출. 구조화된 runtime-defaults 엔드포인트가 없어 FE TOML 파싱은 날조 위험 → 별도 백엔드 엔드포인트 RFC/추가 필요. **stub 유지**.
- **Save changes / VerifyBtn 영속화**: write 경로. Settings "Save"가 keeper/host config 영속화로 이어지면 RFC-protected `lib/keeper/host_config_*` 영역. 본 PR은 read-only만 다루므로 **stub 유지** (write 시 RFC 선행).

## 검증
- Frontend: `pnpm typecheck` PASS, `pnpm lint`(eslint src) PASS(0 errors), `vitest run src/components/settings-surface.test.ts` → 13 tests PASS. 신규: MCP 목록 public_mcp 필터, 로그 라이브 행 필터(tool/success/failure), 순수 헬퍼 5종.
- Backend: OCaml/dune 파일 변경 0건(`git diff --stat`은 .ts 2개만). 백엔드 엔드포인트는 이미 존재하여 신규 OCaml 없음.

## 경계
OAS(provider/model/transport/Agent Turn lifecycle) 미변경. credential/operator/repo/hooks/workflow 등 RFC-protected 서브시스템 미변경(read-only wiring).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
