### PR TITLE
fix(dashboard): distinguish missing tool output from in-flight pending

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1802,6 +1802,64 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     const step = container.querySelector('[data-chat-trace-step="tool"]')
     expect(step?.querySelector('.chat-block-tstep-status.pending')).not.toBeNull()
   })
+
+  it('marks an unjoined tool step as missing once the owning turn has settled', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({ id: 'tool-unjoined-settled', label: 'keeper_board_comment', turnRef: 'trace-s#1' }),
+          entry({
+            id: 'a-settled',
+            text: '답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            turnRef: 'trace-s#1',
+            streamState: null,
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+      />`,
+      container,
+    )
+
+    const bundle = container.querySelector('[data-chat-turn-bundle]')
+    expect(bundle).not.toBeNull()
+    const step = bundle?.querySelector('[data-chat-trace-step="tool"]')
+    // Settled turn + never-joined output is a real gap, not an indefinite pending.
+    expect(step?.querySelector('.chat-block-tstep-status.missing')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
+    // The gap is surfaced in the card header so silent failures are visible.
+    expect(bundle?.textContent).toContain('결과 누락 1')
+  })
+
+  it('keeps an unjoined tool step pending while the owning turn is still streaming', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({ id: 'tool-unjoined-live', label: 'keeper_board_comment', turnRef: 'trace-l#1' }),
+          entry({
+            id: 'a-live',
+            text: '응답 작성 중',
+            role: 'assistant',
+            source: 'direct_assistant',
+            turnRef: 'trace-l#1',
+            streamState: 'streaming',
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+      />`,
+      container,
+    )
+
+    const bundle = container.querySelector('[data-chat-turn-bundle]')
+    const step = bundle?.querySelector('[data-chat-trace-step="tool"]')
+    // Output may still arrive while the turn streams, so keep it pending.
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+    expect(bundle?.textContent).not.toContain('결과 누락')
+  })
 })
 
 describe('ChatMessageBubble — workspace source badge (C2)', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2054,25 +2054,36 @@ function ToolCallBubble({ entry }: { entry: KeeperConversationEntry }) {
   `
 }
 
-const TOOL_STATUS_TITLE: Record<'pending' | 'ok' | 'bad', string> = {
+const TOOL_STATUS_TITLE: Record<'pending' | 'missing' | 'ok' | 'bad', string> = {
   pending: '출력 대기 중',
+  missing: '결과 누락 — 턴이 끝났는데 출력이 도착하지 않음',
   ok: '성공',
   bad: '실패',
 }
 
+// A tool call's output is legitimately "pending" only while its turn is still
+// streaming. Once the owning assistant turn has settled (streamState null), an
+// output that never joined will never arrive — so an indefinite "pending" dot
+// hides a real gap (e.g. a call whose tool_use_id was empty and never joined).
+function isTurnStreaming(state: KeeperConversationEntry['streamState']): boolean {
+  return state === 'opening' || state === 'thinking' || state === 'streaming' || state === 'finalizing'
+}
+
 // One step of a grouped tool-trace card: a single tool call rendered from REAL
 // data only. Name + input args come from the chat entry; status, duration and
-// result are joined from the tool-call output store (null until hydration
-// lands, or forever for calls that carried no provider id — surfaced as a muted
-// "pending" dot rather than miscoloured as a failure).
-function ToolTraceStep({ entry, output }: { entry: KeeperConversationEntry; output: ToolCallEntry | null }) {
+// result are joined from the tool-call output store. A null output is "pending"
+// while the turn streams; once the turn has settled (turnSettled) a still-null
+// output is "missing" (unknown outcome) rather than an indefinite "pending".
+function ToolTraceStep({ entry, output, turnSettled = false }: { entry: KeeperConversationEntry; output: ToolCallEntry | null; turnSettled?: boolean }) {
   const [open, setOpen] = useState(false)
   const name = entry.label || 'tool'
   const displayArgs = prettyJsonish(entry.text || '')
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
-  const status: 'pending' | 'ok' | 'bad' =
+  const status: 'pending' | 'missing' | 'ok' | 'bad' =
     output === null
-      ? 'pending'
+      ? turnSettled
+        ? 'missing'
+        : 'pending'
       : output.success === false || output.semantic_success === false
         ? 'bad'
         : 'ok'
@@ -2116,7 +2127,7 @@ function ToolTraceStep({ entry, output }: { entry: KeeperConversationEntry; outp
                       <pre class="m-0 max-h-64 overflow-y-auto whitespace-pre-wrap break-all text-2xs">${resultView.text}</pre>
                     `
                   : output === null
-                    ? html`<div class="chat-block-tool-label">출력 대기 중…</div>`
+                    ? html`<div class="chat-block-tool-label">${turnSettled ? '결과 없음 — 출력이 도착하지 않음' : '출력 대기 중…'}</div>`
                     : null}
               </div>
             `
@@ -2133,15 +2144,20 @@ function ToolTraceStep({ entry, output }: { entry: KeeperConversationEntry; outp
 function ToolTraceCard({
   tools,
   traceSteps = [],
+  turnSettled = false,
 }: {
   tools: KeeperConversationEntry[]
   traceSteps?: ChatTraceStep[]
+  turnSettled?: boolean
 }) {
   const [open, setOpen] = useState(true)
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
   const failN = steps.filter(
     (s) => s.output !== null && (s.output.success === false || s.output.semantic_success === false),
   ).length
+  // Surface unjoined outputs as "missing" only once the turn has settled — while
+  // it streams they are still legitimately pending, not a gap.
+  const missingN = turnSettled ? steps.filter((s) => s.output === null).length : 0
   const totalMs = steps.reduce((sum, s) => sum + (s.output?.duration_ms ?? 0), 0)
   const durLabel = totalMs > 0 ? formatMsCompact(totalMs) : null
   const stepN = traceSteps.length + tools.length
@@ -2161,6 +2177,7 @@ function ToolTraceCard({
         <span class="chat-block-trace-meta">
           ${tools.length > 0 ? html`<span>도구 ${tools.length}</span>` : null}
           ${failN > 0 ? html`<span class="text-[var(--color-status-err)]">실패 ${failN}</span>` : null}
+          ${missingN > 0 ? html`<span class="text-[var(--color-status-warn)]">결과 누락 ${missingN}</span>` : null}
           ${durLabel ? html`<span class="tnum">${durLabel}</span>` : null}
         </span>
       </button>
@@ -2169,7 +2186,7 @@ function ToolTraceCard({
             <div class="chat-block-trace-steps">
               <span class="chat-block-trace-rail"></span>
               ${traceSteps.map((step, index) => html`<${ChatTraceStep} key=${`trace-${index}`} step=${step} />`)}
-              ${steps.map(({ entry, output }) => html`<${ToolTraceStep} key=${entry.id} entry=${entry} output=${output} />`)}
+              ${steps.map(({ entry, output }) => html`<${ToolTraceStep} key=${entry.id} entry=${entry} output=${output} turnSettled=${turnSettled} />`)}
             </div>
           `
         : null}
@@ -2193,9 +2210,12 @@ function TurnWorkBundle({
   action?: ChatTranscriptAction
 }) {
   const traceSteps = assistant.traceSteps ?? []
+  // The bundle owns the settled assistant entry, so an unjoined tool output here
+  // is a real gap (not in-flight) once the turn stops streaming.
+  const turnSettled = !isTurnStreaming(assistant.streamState)
   return html`
     <div class="chat-turn-bundle" data-chat-turn-bundle>
-      <${ToolTraceCard} tools=${tools} traceSteps=${traceSteps} />
+      <${ToolTraceCard} tools=${tools} traceSteps=${traceSteps} turnSettled=${turnSettled} />
       <${ChatMessageBubble}
         entry=${assistant}
         showMetadata=${showMetadata !== false}

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -191,6 +191,12 @@
   background: var(--color-fg-disabled);
 }
 
+/* Turn has settled but the tool output never joined — a real gap, distinct from
+   the muted in-flight "pending" dot and from a reported failure. */
+.chat-block-tstep-status.missing {
+  background: var(--color-status-warn);
+}
+
 .chat-block-tstep-dur {
   font-family: var(--font-mono);
   font-size: var(--fs-2xs);


### PR DESCRIPTION
## 목표
키퍼 턴 상세에서 **출력이 join되지 않은 tool 호출이 턴 종료 후에도 영구 '출력 대기 중(pending)'으로 표시되어, 실제 누락(silent failure)과 진행 중을 구분할 수 없는 문제**를 수정한다.

## 증상
`ToolTraceStep`의 status는 `output===null`을 무조건 `'pending'`(muted 회색 점)으로 매핑한다. 그러나 `tool_use_id`가 비어 join 키가 없는 호출은 영원히 null로 남는다(`tool-call-output-store.ts`의 join은 `tool_use_id`에만 의존). 결과적으로 *진행 중*과 *영구 미수신(누락)*이 같은 회색 점으로 보여, 끝난 턴에서 실패가 '대기 중'으로 위장된다.

근거: `#21851`이 "missing duration을 0ms로 날조하지 말라"는 truth-boundary를 세웠고, 이 PR은 그 다음 경계 — "끝난 턴의 미join = pending이 아니라 missing" — 를 채운다.

## 변경
- `isTurnStreaming(streamState)` 추가 — `opening|thinking|streaming|finalizing`만 streaming, `null`은 settled.
- `TurnWorkBundle`이 소유 assistant entry의 `streamState`로 `turnSettled`를 계산해 `ToolTraceCard`→`ToolTraceStep`에 전달.
- `ToolTraceStep`: `output===null`일 때 turn이 settled면 `'missing'`(amber), streaming이면 `'pending'`(회색) 유지.
- `ToolTraceCard` 헤더에 `결과 누락 N` 표시(settled 한정) — silent failure를 한눈에 가시화.
- `.chat-block-tstep-status.missing` CSS(amber, 회색 pending·빨강 bad와 구분).
- **bare tool-group 경로(소유 assistant 없음)는 turnSettled=false 기본 → pending 유지** (턴 완료 여부 불명이므로 보수적).

## 변경 파일
- `dashboard/src/components/chat/primitives.ts`
- `dashboard/src/styles/chat-blocks-v2.css`
- `dashboard/src/components/chat/primitives.test.ts`

## 로컬 검증
- `npx vitest run src/components/chat/primitives.test.ts` → 87 passed (0 failed).
- 신규 테스트: (1) settled 턴 + 미join → `missing` + 헤더 `결과 누락 1`, (2) streaming 턴 + 미join → `pending` 유지. 기존 "marks a tool step pending until its output is joined"(bare 경로)는 그대로 통과.

## 범위 / 워크어라운드 판정
이 PR은 **state 매핑 correctness fix**이지 symptom 억제가 아니다(렌더러에 직교 신호 추가). 근본 원인인 **join seam(빈/합성 tool_use_id, OAS pre-dispatch rejection이 log row 미생성)은 OCaml 측 별도 작업**으로, 후속 이슈에 정리한다(아래). 대시보드는 그 gap을 정직하게 표시할 뿐 gap 자체를 만들지 않는다.

미검증: 시각 렌더 스크린샷 미촬영, 빌드/타입체크는 CI.

RFC 영향 없음: `dashboard/src/components/chat` 렌더링 한정.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
