### PR TITLE
feat(dashboard): backward pagination for the event log (before_seq)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -128,6 +128,7 @@ export async function fetchLogs(opts?: {
   level?: string
   module?: string
   since_seq?: number
+  before_seq?: number
   category?: string
   exclude_category?: string
 }): Promise<LogsResponse> {
@@ -137,6 +138,10 @@ export async function fetchLogs(opts?: {
   if (opts?.module) params.set('module', opts.module)
   if (typeof opts?.since_seq === 'number' && opts.since_seq >= 0) {
     params.set('since_seq', String(opts.since_seq))
+  }
+  // Backward "load older" cursor — entries strictly older than this seq.
+  if (typeof opts?.before_seq === 'number' && opts.before_seq >= 0) {
+    params.set('before_seq', String(opts.before_seq))
   }
   if (opts?.category) params.set('category', opts.category)
   if (opts?.exclude_category) params.set('exclude_category', opts.exclude_category)

--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -192,6 +192,59 @@ describe('LogViewer Code links', () => {
     )
   })
 
+  it('loads older entries via the oldest-held seq as the before_seq cursor', async () => {
+    const fetchLogs = vi.fn().mockImplementation((opts?: { before_seq?: number }) => {
+      if (typeof opts?.before_seq === 'number') {
+        return Promise.resolve({
+          total: 4,
+          entries: [entry({ seq: 98, message: 'older-98' }), entry({ seq: 97, message: 'older-97' })],
+        })
+      }
+      return Promise.resolve({
+        total: 4,
+        latest_seq: 100,
+        entries: [entry({ seq: 100, message: 'newest-100' }), entry({ seq: 99, message: 'newest-99' })],
+      })
+    })
+    const { LogViewer } = await loadLogs(fetchLogs)
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="logs-load-older"]')).not.toBeNull(),
+    )
+    ;(container.querySelector('[data-testid="logs-load-older"]') as HTMLButtonElement).click()
+
+    // The oldest entry currently held (seq 99) becomes the exclusive before_seq cursor.
+    await waitFor(() =>
+      expect(fetchLogs).toHaveBeenCalledWith(expect.objectContaining({ before_seq: 99 })),
+    )
+  })
+
+  it('marks the load-older affordance exhausted when no older entries come back', async () => {
+    const fetchLogs = vi.fn().mockImplementation((opts?: { before_seq?: number }) => {
+      if (typeof opts?.before_seq === 'number') {
+        return Promise.resolve({ total: 1, entries: [] })
+      }
+      return Promise.resolve({
+        total: 1,
+        latest_seq: 100,
+        entries: [entry({ seq: 100, message: 'only-100' })],
+      })
+    })
+    const { LogViewer } = await loadLogs(fetchLogs)
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-testid="logs-load-older"]')).not.toBeNull(),
+    )
+    ;(container.querySelector('[data-testid="logs-load-older"]') as HTMLButtonElement).click()
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="logs-load-older"]')).toBeNull()
+      expect(container.querySelector('.v2-logs-older-end')).not.toBeNull()
+    })
+  })
+
   it('renders enabled provider log tail from the configured provider path', async () => {
     const fetchLogs = vi.fn().mockResolvedValue({ total: 0, entries: [] })
     const fetchProviderLogsCatalog = vi.fn().mockResolvedValue({

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -58,6 +58,13 @@ const providerLogLines = signal(200)
 const latestSeq = signal<number | null>(null)
 const categoryFilter = signal('')
 const hideFsmTransitions = signal(false)
+// Backward-pagination window: starts at logLimit and grows by a page each time
+// the operator loads older entries, so the live delta cap preserves what was
+// pulled in instead of trimming back to the default tail size.
+const logWindowLimit = signal(200)
+// Loading flag + "no more history" flag for the load-older affordance.
+const loadingOlder = signal(false)
+const olderExhausted = signal(false)
 const expandedLogSeq = signal<number | null>(null)
 
 const POLL_INTERVAL_MS = 3000
@@ -136,7 +143,7 @@ const LOG_KIND_LABELS: Record<LogDisplayKind, string> = {
   log: 'LOG',
 }
 
-type LoadMode = 'reset' | 'delta'
+type LoadMode = 'reset' | 'delta' | 'older'
 type FailureEnvelope = {
   surface: string
   entity_kind: string
@@ -468,6 +475,9 @@ async function loadLogs(mode: LoadMode = 'reset') {
   const requestId = ++latestRequestId
 
   if (mode === 'reset') {
+    // A fresh load collapses the window back to one page and re-arms load-older.
+    logWindowLimit.value = logLimit.value
+    olderExhausted.value = false
     return logResource.load(async () => {
       const resp = await fetchLogs({
         limit: logLimit.value,
@@ -486,6 +496,55 @@ async function loadLogs(mode: LoadMode = 'reset') {
     })
   }
 
+  if (mode === 'older') {
+    const s = logResource.state.value
+    if (s.status !== 'loaded') return
+    const currentEntries = s.data.entries
+    if (currentEntries.length === 0 || loadingOlder.value || olderExhausted.value) return
+    const before = currentEntries.reduce(
+      (min, entry) => Math.min(min, entry.seq),
+      currentEntries[0]?.seq ?? 0,
+    )
+    if (before <= 0) {
+      // seq 0 is the oldest entry the ring can hold — nothing older exists.
+      olderExhausted.value = true
+      return
+    }
+    loadingOlder.value = true
+    try {
+      const resp = await fetchLogs({
+        limit: logLimit.value,
+        level: levelFilter.value,
+        module: appliedModuleFilter.value || undefined,
+        before_seq: before,
+        category: categoryFilter.value || undefined,
+        exclude_category: hideFsmTransitions.value ? 'fsm' : undefined,
+      })
+      if (requestId !== latestRequestId) return
+      const incoming = sortLogEntries(resp.entries)
+      const fresh = incoming.filter(entry => entry.seq < before)
+      if (fresh.length === 0) {
+        olderExhausted.value = true
+        return
+      }
+      // Grow the window so the live delta below preserves these older entries.
+      logWindowLimit.value += logLimit.value
+      const nextEntries = mergeLogEntries(currentEntries, fresh, logWindowLimit.value)
+      // Older entries never change the newest seq → leave latestSeq untouched.
+      logResource.state.value = loaded({
+        ...s.data,
+        entries: nextEntries,
+        total: resp.total,
+      })
+    } catch {
+      if (requestId !== latestRequestId) return
+      // A failed older-load keeps the current view; the operator can retry.
+    } finally {
+      loadingOlder.value = false
+    }
+    return
+  }
+
   // delta mode — update existing loaded data
   try {
     const resp = await fetchLogs({
@@ -501,7 +560,7 @@ async function loadLogs(mode: LoadMode = 'reset') {
     const s = logResource.state.value
     const currentEntries = s.status === 'loaded' ? s.data.entries : []
     const incoming = sortLogEntries(resp.entries)
-    const nextEntries = mergeLogEntries(currentEntries, incoming, logLimit.value)
+    const nextEntries = mergeLogEntries(currentEntries, incoming, logWindowLimit.value)
 
     latestSeq.value = latestLogSeq(nextEntries)
     logResource.state.value = loaded({
@@ -1067,6 +1126,24 @@ export function LogViewer() {
                 className="v2-logs-stream"
               />
             `}
+
+        ${logEntries.length > 0
+          ? html`
+              <div class="v2-logs-older">
+                ${olderExhausted.value
+                  ? html`<span class="v2-logs-older-end text-2xs text-[var(--color-fg-muted)]">이전 로그를 모두 불러왔습니다</span>`
+                  : html`<button
+                      type="button"
+                      class="v2-logs-older-btn rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-2xs font-medium text-[var(--color-fg-secondary)] transition-colors hover:bg-[var(--color-bg-hover)] hover:text-[var(--color-fg-primary)] disabled:opacity-50"
+                      disabled=${loadingOlder.value}
+                      onClick=${() => { void loadLogs('older') }}
+                      data-testid="logs-load-older"
+                    >
+                      ${loadingOlder.value ? '불러오는 중…' : '이전 로그 더 보기'}
+                    </button>`}
+              </div>
+            `
+          : null}
       </section>
     </div>
   `

--- a/lib/masc_log/log.ml
+++ b/lib/masc_log/log.ml
@@ -627,6 +627,7 @@ module Ring = struct
 
   let recent ?(limit = 200) ?(min_level = 0) ?(module_filter = "")
       ?since_seq
+      ?before_seq
       ?(order = `Newest_first)
       ?category_filter
       ?exclude_category
@@ -640,9 +641,17 @@ module Ring = struct
         | Some seq -> max start (seq + 1)
         | None -> start
       in
+      (* Backward pagination: cap the newest-end of the scan at before_seq-1 so
+         only entries strictly older than the cursor are returned. Mirrors the
+         exclusive since_seq lower bound. *)
+      let upper =
+        match before_seq with
+        | Some seq -> min (t - 1) (seq - 1)
+        | None -> t - 1
+      in
       let entries = ref [] in
       let count = ref 0 in
-      let i = ref (t - 1) in
+      let i = ref upper in
       while !i >= start && !count < limit do
         let e = buf.(!i mod capacity) in
         let level_ok = level_to_int e.level >= min_level in

--- a/lib/masc_log/log.mli
+++ b/lib/masc_log/log.mli
@@ -143,11 +143,17 @@ module Ring : sig
     ?min_level:int ->
     ?module_filter:string ->
     ?since_seq:int ->
+    ?before_seq:int ->
     ?order:[< `Newest_first | `Oldest_first > `Newest_first ] ->
     ?category_filter:string ->
     ?exclude_category:string list ->
     unit ->
     entry list
+  (** [since_seq] is an exclusive lower bound (entries newer than it — live
+      tailing); [before_seq] is an exclusive upper bound (entries older than it
+      — backward "load older" pagination). With [`Newest_first] and [limit] this
+      returns the [limit] most-recent entries strictly older than [before_seq],
+      so a client pages backwards by passing the oldest seq it has seen. *)
 
   val entry_to_json : entry -> Yojson.Safe.t
   val entry_of_json : Yojson.Safe.t -> entry

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -397,6 +397,15 @@ let add_routes ~sw ~clock router =
                  let seq = Server_utils.int_query_param req "since_seq" ~default:(-1) in
                  if seq < 0 then None else Some seq
            in
+           (* Backward "load older" cursor: clients pass the oldest seq they hold
+              to fetch the next page of entries strictly older than it. *)
+           let before_seq =
+             match Server_utils.query_param req "before_seq" with
+             | None -> None
+             | Some _ ->
+                 let seq = Server_utils.int_query_param req "before_seq" ~default:(-1) in
+                 if seq < 0 then None else Some seq
+           in
            let module_filter = match Server_utils.query_param req "module" with
              | Some v -> v
              | None -> ""
@@ -414,7 +423,7 @@ let add_routes ~sw ~clock router =
                  | xs -> Some xs
            in
            let entries =
-             Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq
+             Log.Ring.recent ~limit ~min_level ~module_filter ?since_seq ?before_seq
                ?category_filter ?exclude_category ()
            in
            let json =

--- a/test/test_masc_log.ml
+++ b/test/test_masc_log.ml
@@ -86,6 +86,35 @@ let test_recent_since_seq_returns_only_new_entries () =
     [ warn_message; info_message ]
     (List.map (fun (entry : Log.Ring.entry) -> entry.message) entries)
 
+let test_recent_before_seq_returns_only_older_entries () =
+  (* Backward "load older" pagination: before_seq is an exclusive upper bound,
+     so the cursor entry itself and anything newer are excluded. *)
+  let module_name = "TestLogBefore" in
+  let msg_a = Printf.sprintf "before a %f" (Unix.gettimeofday ()) in
+  let msg_b = Printf.sprintf "before b %f" (Unix.gettimeofday ()) in
+  let msg_c = Printf.sprintf "before c %f" (Unix.gettimeofday ()) in
+  Log.info ~ctx:module_name "%s" msg_a;
+  Log.info ~ctx:module_name "%s" msg_b;
+  Log.info ~ctx:module_name "%s" msg_c;
+  let seq_of message =
+    match find_entry ~module_name ~message with
+    | Some (entry : Log.Ring.entry) -> entry.seq
+    | None -> Alcotest.failf "entry %s not found in ring" message
+  in
+  let seq_c = seq_of msg_c in
+  let older =
+    Log.Ring.recent ~limit:10 ~module_filter:module_name ~before_seq:seq_c ()
+  in
+  Alcotest.(check (list string)) "older-than-c messages, newest first"
+    [ msg_b; msg_a ]
+    (List.map (fun (entry : Log.Ring.entry) -> entry.message) older);
+  (* Boundary: nothing is older than the first entry. *)
+  let seq_a = seq_of msg_a in
+  let none =
+    Log.Ring.recent ~limit:10 ~module_filter:module_name ~before_seq:seq_a ()
+  in
+  Alcotest.(check int) "nothing older than the first entry" 0 (List.length none)
+
 let oas_record ?(level = Agent_sdk.Log.Info) ~module_name ~message fields =
   Agent_sdk.Log.
     {
@@ -222,6 +251,8 @@ let () =
           test_legacy_traceln_records_metadata;
         Alcotest.test_case "recent since_seq returns only new entries" `Quick
           test_recent_since_seq_returns_only_new_entries;
+        Alcotest.test_case "recent before_seq returns only older entries" `Quick
+          test_recent_before_seq_returns_only_older_entries;
         Alcotest.test_case
           "oas bridge promotes MCP server failures"
           `Quick test_oas_bridge_promotes_mcp_server_failures_to_error;


### PR DESCRIPTION
## 무엇을 / 왜

WAVE-PLAN **R5** (backend Wave 1) — 인메모리 로그 ring은 `since_seq`(커서보다 **새** 항목, 라이브 tailing)만 지원했고, 대시보드 로그 뷰어는 **과거로 backward 페이지네이션**할 수단이 없었습니다. `before_seq`(커서보다 **엄격히 오래된** 항목)를 end-to-end로 추가합니다.

(사용자가 keeper-v2 frontend 포팅 완료 후 "backend Wave 1로 전환" 선택. PR-C turn-record grounding은 이미 머지 확인됨.)

## 변경

- **`Log.Ring.recent ?before_seq`** (`lib/masc_log/log.ml`/`.mli`): exclusive 상한, `since_seq`(exclusive 하한)와 대칭. 스캔의 newest 인덱스를 `before_seq-1`로 캡 → 커서보다 오래된 `limit`개의 최신 항목 반환.
- **라우트** (`server_routes_http_routes_dashboard.ml`): `before_seq` query param 파싱(음수→None, `since_seq` 미러) + recent로 전달. 응답은 이미 `oldest_seq`를 emit하므로 클라이언트가 다음 커서로 사용.
- **frontend** (`logs.ts`): `'older'` 로드 모드가 `before_seq = 현재 보유 최소 seq`로 fetch 후 append. `logWindowLimit` 신호가 로드마다 한 페이지씩 성장 → 라이브 delta 폴이 불러온 과거를 기본 tail 크기로 trim하지 않고 **보존**. `이전 로그 더 보기` 버튼 + 소진 시 `이전 로그를 모두 불러왔습니다` 상태.

## 검증

- `dune`: `lib/masc_log` 빌드; `test_masc_log` **10/10** (신규 "recent before_seq returns only older entries" = exclusivity + 경계); server lib가 라우트 변경 포함 빌드.
- `dashboard`: `tsc` clean, `eslint` clean, `logs.test.ts` **11/11** (신규 before_seq 커서 + exhaustion).
- fresh-context 적대 리뷰.

## 설계 노트

- `before_seq`/`since_seq`는 정확한 대칭(둘 다 exclusive). ring이 `seq mod capacity`로 저장하므로 반복 인덱스 `i`=seq → 상한 캡만으로 구현, 추가 자료구조 0.
- **window 성장 ↔ delta 상호작용**: 과거 로드로 window가 400이 되면 delta 폴 cap도 400이라 과거가 보존됨(과거 로드 전엔 기본 200 tail 동작 그대로). reset이 window/exhausted를 재무장.

**RFC**: `masc_log`는 credential/operator/keeper-sandbox RFC-게이트 대상이 아니며, log RFC(0079 encoder/0103 retention/0020 queue)는 pagination을 규율하지 않음 → 추가 query 커서에 governing RFC 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
