### PR TITLE
fix(keeper): cap honors valid_until on the retention path (RFC-0259 P5 / defect C)

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -553,6 +553,7 @@ let extract_and_append_with_provider
           let (_ : Keeper_memory_os_io.fact_merge_stats) =
             File_lock_eio.with_lock ?clock (Keeper_memory_os_io.facts_path ~keeper_id) (fun () ->
               Keeper_memory_os_io.merge_and_cap_facts
+                ~now
                 ~keeper_id
                 ~merge:(Keeper_memory_os_policy.reobserve_fact ~now)
                 ~incoming:episode.Keeper_memory_os_types.claims

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -521,17 +521,24 @@ let read_facts_for_rewrite ~keeper_id =
    hysteresis ([trigger] > [keep]) keeps this off the per-turn hot path — a
    rewrite happens only once every ([trigger] - [keep]) appended facts. Returns
    the number of facts dropped. *)
-let cap_facts ~keeper_id ~keep ~trigger ~rank =
+let cap_facts ~now ~keeper_id ~keep ~trigger ~rank =
   let path = facts_path ~keeper_id in
   let all = read_facts_for_rewrite ~keeper_id in
-  let total = List.length all in
-  if total <= trigger
+  (* RFC-0259 §3.6 (P5): drop [valid_until]-expired rows before the trigger gate
+     and before ranking, so an under-cap store does not retain expired rows on
+     disk until the off-by-default GC sweep. Durable facts are never expired. *)
+  let live, expired = partition_expired ~now all in
+  let total = List.length live in
+  if expired = [] && total <= trigger
   then 0
   else (
     let kept =
-      all
-      |> List.stable_sort (fun a b -> Float.compare (rank b) (rank a))
-      |> take_first keep
+      if total <= trigger
+      then live
+      else
+        live
+        |> List.stable_sort (fun a b -> Float.compare (rank b) (rank a))
+        |> take_first keep
     in
     let content =
       match kept with
@@ -541,7 +548,7 @@ let cap_facts ~keeper_id ~keep ~trigger ~rank =
         ^ "\n"
     in
     write_file_atomically path content;
-    total - List.length kept)
+    List.length all - List.length kept)
 ;;
 
 type fact_merge_stats =
@@ -595,27 +602,33 @@ let merge_episode_facts ~merge ~existing ~incoming =
    that carries claims; the librarian runs at most once per turn after an LLM
    call, so a full rewrite of at most [trigger] facts is off the hot path. An
    empty [incoming] with the store already under [trigger] is a no-op. *)
-let merge_and_cap_facts ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
+let merge_and_cap_facts ~now ~keeper_id ~merge ~incoming ~keep ~trigger ~rank =
   let existing = read_facts_for_rewrite ~keeper_id in
   let merged_list, merged, appended = merge_episode_facts ~merge ~existing ~incoming in
-  let total = List.length merged_list in
+  (* RFC-0259 §3.6 (P5): drop [valid_until]-expired rows on the same boundary the
+     GC sweep uses, before the trigger gate and ranking, so an under-cap store
+     does not retain expired rows on disk. Expired rows are counted in [dropped]
+     alongside rank evictions. Durable facts ([valid_until = None]) are never
+     expired, so durable knowledge is never evicted here. *)
+  let live, expired = partition_expired ~now merged_list in
+  let total = List.length live in
   let no_incoming = match incoming with [] -> true | _ :: _ -> false in
-  if no_incoming && total <= trigger
+  if no_incoming && expired = [] && total <= trigger
   then { merged; appended; dropped = 0 }
   else (
-    let kept, dropped =
+    let kept, rank_dropped =
       if total <= trigger
-      then merged_list, 0
+      then live, 0
       else (
         let kept =
-          merged_list
+          live
           |> List.stable_sort (fun a b -> Float.compare (rank b) (rank a))
           |> take_first keep
         in
         kept, total - List.length kept)
     in
     rewrite_facts_atomically ~keeper_id kept;
-    { merged; appended; dropped })
+    { merged; appended; dropped = rank_dropped + List.length expired })
 ;;
 
 let read_events_tail ~keeper_id ~n =

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -125,9 +125,17 @@ val read_all_facts : keeper_id:string -> fact list
 (** When the fact store exceeds [trigger], keep the [keep] highest-[rank]ed
     facts and atomically rewrite the file; otherwise no-op. Returns the number
     of facts dropped. The hysteresis ([trigger] > [keep]) keeps rewrites off the
-    per-turn hot path. *)
+    per-turn hot path. RFC-0259 §3.6 (P5): rows expired at [now] (typed
+    [valid_until] boundary) are dropped before the trigger gate and ranking, so
+    an under-cap store does not retain them; expired rows count toward the
+    returned total. *)
 val cap_facts :
-  keeper_id:string -> keep:int -> trigger:int -> rank:(fact -> float) -> int
+  now:float
+  -> keeper_id:string
+  -> keep:int
+  -> trigger:int
+  -> rank:(fact -> float)
+  -> int
 
 (** Outcome of a [merge_and_cap_facts] write: how many incoming claims were
     folded into an existing fact ([merged]), persisted as new facts
@@ -143,9 +151,13 @@ type fact_merge_stats =
     in via [merge] (so confidence/access/verification evolve) instead of
     appending an immortal duplicate — then apply the [keep]/[trigger]/[rank]
     retention cap, all in a single atomic rewrite. Replaces the blind append +
-    [cap_facts] pair, giving the store write-time dedup. *)
+    [cap_facts] pair, giving the store write-time dedup. RFC-0259 §3.6 (P5): rows
+    expired at [now] are dropped on the same [valid_until] boundary the GC sweep
+    uses, before the trigger gate, so the librarian write path keeps the on-disk
+    store free of expired rows even below the cap; they count toward [dropped]. *)
 val merge_and_cap_facts :
-  keeper_id:string
+  now:float
+  -> keeper_id:string
   -> merge:(existing:fact -> incoming:fact -> fact)
   -> incoming:fact list
   -> keep:int

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -277,6 +277,19 @@ let fact_is_current ~now (fact : fact) =
   | Some ts -> ts >= now
 ;;
 
+(* RFC-0259 §3.6 (P5): split a fact list into (live, expired-at-[now]) on the
+   typed [valid_until] boundary. The cap path ([Keeper_memory_os_io.cap_facts] /
+   [merge_and_cap_facts]) calls this so it drops expired rows on the SAME
+   boundary the GC sweep uses ([Keeper_memory_os_gc.ttl_expired]), instead of
+   leaving them on disk until the off-by-default 600s sweep happens to run.
+   Durable facts ([valid_until = None]) are always live, so this never evicts
+   durable knowledge. This is retention-path determinism (cap and GC agree on
+   what [valid_until] means), not a new read-side filter — recall already drops
+   expired rows via [fact_is_current]. *)
+let partition_expired ~now (facts : fact list) =
+  List.partition (fact_is_current ~now) facts
+;;
+
 (* The time a fact was last known good: [last_verified_at] if set, else
    [first_seen] (a never-re-verified fact is as old as its extraction). The SSOT
    anchor for "how stale is this claim": the reconciler, recall, and dashboard

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -154,6 +154,12 @@ type fact =
     [valid_until] are durable and current. *)
 val fact_is_current : now:float -> fact -> bool
 
+(** RFC-0259 §3.6 (P5): partition facts into [(live, expired)] at [now] on the
+    [valid_until] boundary ([fact_is_current]). The cap path drops the expired
+    partition so on-disk retention honours the same [valid_until] the GC sweep
+    does. Durable facts ([valid_until = None]) are always in [live]. *)
+val partition_expired : now:float -> fact list -> fact list * fact list
+
 (** The time a fact was last known good: [last_verified_at] if set, else
     [first_seen]. The SSOT staleness anchor shared by the reconciler, recall,
     and dashboard user-model ordering so those paths cannot drift on the anchor

--- a/test/memory_os_brain_harness.ml
+++ b/test/memory_os_brain_harness.ml
@@ -265,6 +265,7 @@ let scenario_truth_anchor_refresh () =
     (* Replicates keeper_librarian_runtime.ml exactly: upsert via reobserve_fact. *)
     let stats =
       Memory_io.merge_and_cap_facts
+        ~now:later
         ~keeper_id:kid
         ~merge:(Policy.reobserve_fact ~now:later)
         ~incoming

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1666,6 +1666,7 @@ let test_gc_waits_for_fact_writer_lock () =
         Eio.Promise.await allow_writer;
         let (_ : Memory_io.fact_merge_stats) =
           Memory_io.merge_and_cap_facts
+            ~now
             ~keeper_id
             ~merge:(Policy.reobserve_fact ~now)
             ~incoming:[ fresh ]
@@ -1821,6 +1822,7 @@ let test_recall_scans_whole_bounded_store () =
         in
         let cap_stats =
           Memory_io.merge_and_cap_facts
+            ~now
             ~keeper_id
             ~merge:(Policy.reobserve_fact ~now)
             ~incoming:(head :: cap_fillers)
@@ -2392,7 +2394,7 @@ let test_cap_facts_keeps_top_ranked () =
     (* rank by source turn (a surviving structural field): keep the 3 highest
        (fact-08/09/10), drop 7. *)
     let dropped =
-      Memory_io.cap_facts ~keeper_id ~keep:3 ~trigger:5 ~rank:(fun f ->
+      Memory_io.cap_facts ~now ~keeper_id ~keep:3 ~trigger:5 ~rank:(fun f ->
         float_of_int f.Types.source.turn)
     in
     Alcotest.(check int) "dropped count" 7 dropped;
@@ -2407,10 +2409,103 @@ let test_cap_facts_keeps_top_ranked () =
       remaining;
     (* below trigger now (3 <= 5): no-op, nothing dropped. *)
     let dropped2 =
-      Memory_io.cap_facts ~keeper_id ~keep:3 ~trigger:5 ~rank:(fun f ->
+      Memory_io.cap_facts ~now ~keeper_id ~keep:3 ~trigger:5 ~rank:(fun f ->
         float_of_int f.Types.source.turn)
     in
     Alcotest.(check int) "no-op below trigger" 0 dropped2)
+;;
+
+(* RFC-0259 §3.6 (P5): the cap drops valid_until-expired rows on the same typed
+   boundary the GC sweep uses. Pure split — durable (None) and fresh stay live,
+   expired goes to the second partition, order preserved. *)
+let test_partition_expired_splits_on_valid_until () =
+  let now = 1_000_000.0 in
+  let base = fact_fixture ~now () in
+  let durable = { base with Types.claim = "durable"; Types.valid_until = None } in
+  let expired = { base with Types.claim = "expired"; Types.valid_until = Some (now -. 1.0) } in
+  let fresh = { base with Types.claim = "fresh"; Types.valid_until = Some (now +. days 1) } in
+  let live, gone = Types.partition_expired ~now [ durable; expired; fresh ] in
+  Alcotest.(check (list string))
+    "live keeps durable + fresh in order"
+    [ "durable"; "fresh" ]
+    (List.map (fun f -> f.Types.claim) live);
+  Alcotest.(check (list string))
+    "expired partition holds only the expired row"
+    [ "expired" ]
+    (List.map (fun f -> f.Types.claim) gone)
+;;
+
+(* RFC-0259 §3.6 (P5): cap_facts evicts an expired row even when the store is far
+   below [trigger] (the disk-leak the off-by-default GC sweep would otherwise
+   miss), and never evicts a durable row. Re-running is a no-op once clean. *)
+let test_cap_drops_expired_below_trigger () =
+  with_temp_keepers_dir (fun _ ->
+    let keeper_id = "virtual-memory-keeper" in
+    let now = 1_000_000.0 in
+    let base = fact_fixture ~now () in
+    let durable = { base with Types.claim = "durable-keep"; Types.valid_until = None } in
+    let expired =
+      { base with Types.claim = "expired-drop"; Types.valid_until = Some (now -. 1.0) }
+    in
+    let fresh =
+      { base with Types.claim = "fresh-keep"; Types.valid_until = Some (now +. days 1) }
+    in
+    List.iter (Memory_io.append_fact ~keeper_id) [ durable; expired; fresh ];
+    let dropped =
+      Memory_io.cap_facts
+        ~now
+        ~keeper_id
+        ~keep:Memory_io.fact_recall_window
+        ~trigger:Memory_io.fact_store_max
+        ~rank:(Policy.retention_rank ~now)
+    in
+    Alcotest.(check int) "one expired row dropped below trigger" 1 dropped;
+    let remaining =
+      List.map (fun f -> f.Types.claim) (Memory_io.read_all_facts ~keeper_id)
+    in
+    Alcotest.(check bool) "durable survives" true (List.mem "durable-keep" remaining);
+    Alcotest.(check bool) "fresh survives" true (List.mem "fresh-keep" remaining);
+    Alcotest.(check bool) "expired evicted" false (List.mem "expired-drop" remaining);
+    let dropped2 =
+      Memory_io.cap_facts
+        ~now
+        ~keeper_id
+        ~keep:Memory_io.fact_recall_window
+        ~trigger:Memory_io.fact_store_max
+        ~rank:(Policy.retention_rank ~now)
+    in
+    Alcotest.(check int) "idempotent: no-op once clean" 0 dropped2)
+;;
+
+(* RFC-0259 §3.6 (P5): the production librarian write path (merge_and_cap_facts)
+   evicts expired rows even with no incoming claims and the store below trigger,
+   counting them in [dropped]. This is the load-bearing fix — an idle-ish keeper
+   that stops extracting must not keep expired volatile rows on disk. *)
+let test_merge_and_cap_drops_expired_no_incoming () =
+  with_temp_keepers_dir (fun _ ->
+    let keeper_id = "virtual-memory-keeper" in
+    let now = 1_000_000.0 in
+    let base = fact_fixture ~now () in
+    let durable = { base with Types.claim = "durable"; Types.valid_until = None } in
+    let expired =
+      { base with Types.claim = "expired"; Types.valid_until = Some (now -. 1.0) }
+    in
+    List.iter (Memory_io.append_fact ~keeper_id) [ durable; expired ];
+    let stats =
+      Memory_io.merge_and_cap_facts
+        ~now
+        ~keeper_id
+        ~merge:(Policy.reobserve_fact ~now)
+        ~incoming:[]
+        ~keep:Memory_io.fact_recall_window
+        ~trigger:Memory_io.fact_store_max
+        ~rank:(Policy.retention_rank ~now)
+    in
+    Alcotest.(check int) "expired counted in dropped" 1 stats.Memory_io.dropped;
+    let remaining =
+      List.map (fun f -> f.Types.claim) (Memory_io.read_all_facts ~keeper_id)
+    in
+    Alcotest.(check (list string)) "only durable remains" [ "durable" ] remaining)
 ;;
 
 let test_recall_context_renders_sanitized_memory () =
@@ -2598,6 +2693,7 @@ let test_merge_and_cap_upserts_reobserved_claim () =
     in
     let stats =
       Memory_io.merge_and_cap_facts
+        ~now
         ~keeper_id
         ~merge:(Policy.reobserve_fact ~now)
         ~incoming:[ reobserved ]
@@ -2634,6 +2730,7 @@ let test_merge_and_cap_appends_distinct_and_caps () =
     in
     let stats =
       Memory_io.merge_and_cap_facts
+        ~now
         ~keeper_id
         ~merge:(Policy.reobserve_fact ~now)
         ~incoming:[ mk 1; mk 2; mk 3 ]
@@ -3382,6 +3479,7 @@ let test_merge_and_cap_upserts_same_claim_id () =
     in
     let stats =
       Memory_io.merge_and_cap_facts
+        ~now
         ~keeper_id
         ~merge:(Policy.reobserve_fact ~now)
         ~incoming:[ reworded ]
@@ -3431,6 +3529,7 @@ let test_merge_and_cap_no_over_merge_distinct_conclusions () =
     in
     let stats =
       Memory_io.merge_and_cap_facts
+        ~now
         ~keeper_id
         ~merge:(Policy.reobserve_fact ~now)
         ~incoming:[ merged ]
@@ -3725,6 +3824,18 @@ let () =
             "cap_facts keeps top-ranked (RFC-0239 Q4)"
             `Quick
             test_cap_facts_keeps_top_ranked
+        ; Alcotest.test_case
+            "partition_expired splits on valid_until (RFC-0259 P5)"
+            `Quick
+            test_partition_expired_splits_on_valid_until
+        ; Alcotest.test_case
+            "cap_facts drops expired below trigger (RFC-0259 P5)"
+            `Quick
+            test_cap_drops_expired_below_trigger
+        ; Alcotest.test_case
+            "merge_and_cap drops expired with no incoming (RFC-0259 P5)"
+            `Quick
+            test_merge_and_cap_drops_expired_no_incoming
         ; Alcotest.test_case
             "merge_and_cap upserts re-observed claim (RFC-0243)"
             `Quick


### PR DESCRIPTION
## What

Defect **C** from Issue #21789 (Memory OS adversarial audit): the hot-path fact
cap honors the typed `valid_until` boundary, so expired volatile rows stop
accumulating on disk. Implements RFC-0259 **§3.6 (P5)** — already merged as RFC
text (#21831). No prompt-behavior change.

## Why

`retention_rank` is TTL-blind: it takes `~now` only to pick a durable-vs-volatile
tier, never tests whether *this* row's `valid_until` has passed. The sole disk
path that drops an expired row is `run_gc`, which is off by default. So a store
below the 384-row cap threshold keeps expired rows on disk indefinitely (audit:
a keeper with 140/140 expired-`valid_until` rows retained all 348).

Per RFC-0259 §3.6 this is **retention-path determinism, not a new janitor** — the
cap and the GC must agree on what `valid_until` means. Recall already filters
expired rows at read time (`fact_is_current`), so disk hygiene here does not
change what a keeper sees.

## Change

- `Keeper_memory_os_types.partition_expired ~now` — splits a fact list into
  `(live, expired)` on the same `fact_is_current` boundary the GC sweep and
  recall already use. Durable facts (`valid_until = None`) are always live.
- `cap_facts` / `merge_and_cap_facts` drop the expired partition **before** the
  trigger gate and **before** ranking, and count it in `dropped`. `~now` is
  threaded in (the librarian write path already has it).
- This fixes the under-cap leak: an expired row is now evicted on the write path
  even when the store is far below trigger.

## Scope boundary

The `MASC_KEEPER_MEMORY_OS_GC` **default flip** (§3.6 item 1) needs a live fleet
dry-run before flipping and is left for that operator gate — it is the idle-store
backstop. This PR closes the always-on write-path leak.

## Tests

- `partition_expired` split: durable + fresh stay live, expired partitioned, order preserved.
- `cap_facts` drops one expired row below trigger, keeps durable + fresh, idempotent re-run is a no-op.
- `merge_and_cap_facts` (production librarian path) drops expired with **no incoming claims** and counts it in `dropped`; only durable remains.

Property held throughout: a durable fact (`valid_until = None`) is never evicted by the expiry path.

RFC: RFC-0259 §3.6 (P5). Tracker: Issue #21789 (defect C). Not a workaround — the
cap already exists; this makes it honor the typed boundary it currently ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
