### PR TITLE
fix(schedule): gate approvals through dashboard operator auth

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -39,6 +39,7 @@ import {
   fetchTelemetrySummary,
   fetchTlcResults,
   fetchToolQuality,
+  resolveScheduleApproval,
 } from './dashboard'
 import { fetchDashboardShell as fetchDashboardShellHot } from './dashboard-hot'
 import { keeperRuntimeBlockerLabel } from '../lib/keeper-runtime-display'
@@ -116,6 +117,30 @@ describe('fetchDashboardShell', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/shell?light=true')
+  })
+})
+
+describe('resolveScheduleApproval', () => {
+  it('posts dashboard schedule decisions to the dashboard-only resolve route', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, schedule_id: 'sched-1', decision: 'approve' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await resolveScheduleApproval('sched-1', 'approve')
+
+    expect(result).toEqual({ ok: true, schedule_id: 'sched-1', decision: 'approve' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/schedule/resolve')
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(String(init.body))).toEqual({
+      schedule_id: 'sched-1',
+      decision: 'approve',
+    })
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -478,6 +478,16 @@ function normalizeKeeperApprovalRule(raw: unknown): KeeperApprovalRule | null {
   }
 }
 
+function normalizeHitlStatus(raw: unknown): DashboardGovernanceResponse['hitl'] | undefined {
+  if (!isRecord(raw)) return undefined
+  return {
+    enabled: asBoolean(raw.enabled) ?? false,
+    disabled_by_env: asBoolean(raw.disabled_by_env) ?? false,
+    env_name: asString(raw.env_name, 'MASC_DISABLE_HITL'),
+    default_enabled: asBoolean(raw.default_enabled) ?? true,
+  }
+}
+
 export function fetchDashboardGovernance(): Promise<DashboardGovernanceResponse> {
   return withRetries('fetchDashboardGovernance', async () => {
     const raw = await get<Record<string, unknown>>('/api/v1/dashboard/governance')
@@ -543,6 +553,7 @@ export function fetchDashboardGovernance(): Promise<DashboardGovernanceResponse>
       pending_actions: pendingActions,
       approval_queue: approvalQueue,
       approval_rules: approvalRules,
+      hitl: normalizeHitlStatus(raw.hitl),
     }
   })
 }
@@ -565,6 +576,28 @@ export function deleteGovernanceApprovalRule(
   id: string,
 ): Promise<{ ok: boolean; id: string }> {
   return post('/api/v1/dashboard/governance/approvals/rules/delete', { id })
+}
+
+export type DashboardScheduleDecision = 'approve' | 'reject'
+
+export interface DashboardScheduleResolveResponse {
+  ok: boolean
+  schedule_id: string
+  decision: DashboardScheduleDecision
+  approved_by?: unknown
+  schedule?: unknown
+}
+
+export function resolveScheduleApproval(
+  scheduleId: string,
+  decision: DashboardScheduleDecision,
+  reason?: string,
+): Promise<DashboardScheduleResolveResponse> {
+  return post('/api/v1/dashboard/schedule/resolve', {
+    schedule_id: scheduleId,
+    decision,
+    reason,
+  })
 }
 
 export function fetchGovernanceCaseStatus(caseId: string): Promise<GovernanceCaseBundle> {

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -1,11 +1,25 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type {
   DashboardScheduledAutomation,
   DashboardScheduledAutomationRequest,
-} from '../../api/dashboard'
+} from '../../api'
+
+const mocks = vi.hoisted(() => ({
+  resolveScheduleApproval: vi.fn(),
+  showToast: vi.fn(),
+}))
+
+vi.mock('../../api', () => ({
+  resolveScheduleApproval: mocks.resolveScheduleApproval,
+}))
+
+vi.mock('../common/toast', () => ({
+  showToast: mocks.showToast,
+}))
+
 import { ScheduledAutomationPanel, selectWakeSignals } from './scheduled-automation-panel'
 
 function request(
@@ -24,12 +38,72 @@ function automation(
   requests: DashboardScheduledAutomationRequest[],
 ): DashboardScheduledAutomation {
   return {
+    schema: 'masc.dashboard.scheduled_automation.v1',
+    source: 'schedule_store',
+    generated_at: '2026-06-21T00:00:00Z',
     request_count: requests.length,
     request_limit: 50,
     truncated: false,
     counts: {},
+    derived_counts: {
+      due_effective: 0,
+      blocked_approval: 0,
+      due_execution_ready: 0,
+      expired_effective: 0,
+    },
     fsm: { state: 'idle', active_count: requests.length, terminal_count: 0 },
     requests,
+  }
+}
+
+function approvalAutomationFixture(): DashboardScheduledAutomation {
+  return {
+    schema: 'masc.dashboard.scheduled_automation.v1',
+    source: 'schedule_store',
+    generated_at: '2026-06-21T00:00:00Z',
+    request_count: 1,
+    request_limit: 20,
+    truncated: false,
+    counts: { pending_approval: 1 },
+    derived_counts: {
+      due_effective: 0,
+      blocked_approval: 1,
+      due_execution_ready: 0,
+      expired_effective: 0,
+    },
+    fsm: {
+      state: 'blocked_approval',
+      active_count: 1,
+      terminal_count: 0,
+      next_due_at: '2026-06-21T01:00:00Z',
+    },
+    requests: [
+      {
+        schedule_id: 'sched-1',
+        status: 'pending_approval',
+        effective_status: 'blocked_approval',
+        execution_readiness: 'blocked_approval',
+        operator_action: 'approve_or_reject',
+        keeper_next_tool: 'masc_schedule_get',
+        keeper_next_action:
+          'Inspect details, then wait for the dashboard operator approval or rejection action to resolve this schedule.',
+        risk_class: 'workspace_write',
+        approval_required: true,
+        source: 'operator_request',
+        recurrence: { kind: 'one_shot' },
+        recurrence_kind: 'one_shot',
+        payload_kind: 'masc.board_post',
+        due_at_iso: '2026-06-21T01:00:00Z',
+        approval_policy: 'separate_human_grant_required',
+      },
+    ],
+  }
+}
+
+async function flush(): Promise<void> {
+  for (let i = 0; i < 4; i += 1) {
+    await Promise.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
   }
 }
 
@@ -68,7 +142,6 @@ describe('selectWakeSignals', () => {
       risk: 'read_only',
       readiness: 'ready',
     })
-    // risk is the backend value, never a fabricated default
     expect(signals[1]?.risk).toBe('side_effecting')
   })
 
@@ -80,7 +153,7 @@ describe('selectWakeSignals', () => {
     expect(signals[0]?.at).toBe(1500)
   })
 
-  it('drops rows with no concrete wake time (not a signal)', () => {
+  it('drops rows with no concrete wake time', () => {
     const signals = selectWakeSignals(
       automation([request({ schedule_id: 's-nodue', execution_readiness: 'scheduled' })]),
     )
@@ -92,7 +165,12 @@ describe('selectWakeSignals', () => {
       automation([
         request({ schedule_id: 's-term', next_due_at: 100, execution_readiness: 'terminal' }),
         request({ schedule_id: 's-exp', next_due_at: 200, execution_readiness: 'expired' }),
-        request({ schedule_id: 's-cancelled', next_due_at: 300, status: 'cancelled', effective_status: 'cancelled' }),
+        request({
+          schedule_id: 's-cancelled',
+          next_due_at: 300,
+          status: 'cancelled',
+          effective_status: 'cancelled',
+        }),
         request({ schedule_id: 's-live', next_due_at: 400, execution_readiness: 'scheduled' }),
       ]),
     )
@@ -115,7 +193,7 @@ describe('selectWakeSignals', () => {
     expect(signals.map(s => s.id)).toEqual(['s-live'])
   })
 
-  it('keeps due-but-blocked rows — they are still pending wakes', () => {
+  it('keeps due-but-blocked rows because they are still pending wakes', () => {
     const signals = selectWakeSignals(
       automation([
         request({
@@ -162,8 +240,18 @@ describe('ScheduledAutomationPanel wake-signal feed', () => {
     render(
       html`<${ScheduledAutomationPanel}
         automation=${automation([
-          request({ schedule_id: 's-soon', next_due_at: 1000, payload_kind: 'masc.keeper_nudge', execution_readiness: 'ready' }),
-          request({ schedule_id: 's-late', next_due_at: 2000, payload_kind: 'masc.board_post', execution_readiness: 'scheduled' }),
+          request({
+            schedule_id: 's-soon',
+            next_due_at: 1000,
+            payload_kind: 'masc.keeper_nudge',
+            execution_readiness: 'ready',
+          }),
+          request({
+            schedule_id: 's-late',
+            next_due_at: 2000,
+            payload_kind: 'masc.board_post',
+            execution_readiness: 'scheduled',
+          }),
         ])}
       />`,
       container,
@@ -190,5 +278,54 @@ describe('ScheduledAutomationPanel wake-signal feed', () => {
 
     expect(container.querySelector('[data-testid="sch-signals-empty"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="sch-signals"]')).toBeNull()
+  })
+})
+
+describe('ScheduledAutomationPanel approval actions', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    mocks.resolveScheduleApproval.mockReset()
+    mocks.showToast.mockReset()
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  it('resolves pending schedule approval through the dashboard-only API', async () => {
+    mocks.resolveScheduleApproval.mockResolvedValue({
+      ok: true,
+      schedule_id: 'sched-1',
+      decision: 'approve',
+    })
+    const onResolved = vi.fn()
+
+    render(
+      html`<${ScheduledAutomationPanel}
+        automation=${approvalAutomationFixture()}
+        onResolved=${onResolved}
+      />`,
+      container,
+    )
+
+    const approve = container.querySelector(
+      '[data-testid="schedule-approve-sched-1"]',
+    ) as HTMLButtonElement | null
+    const reject = container.querySelector(
+      '[data-testid="schedule-reject-sched-1"]',
+    ) as HTMLButtonElement | null
+    expect(approve).not.toBeNull()
+    expect(reject).not.toBeNull()
+
+    approve?.click()
+    await flush()
+
+    expect(mocks.resolveScheduleApproval).toHaveBeenCalledWith('sched-1', 'approve', undefined)
+    expect(onResolved).toHaveBeenCalledTimes(1)
+    expect(mocks.showToast).toHaveBeenCalledWith('sched-1 approved', 'success')
   })
 })

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -1,10 +1,15 @@
 import { html } from 'htm/preact'
-import type {
-  DashboardScheduledAutomation,
-  DashboardScheduledAutomationRequest,
+import { useState } from 'preact/hooks'
+import {
+  resolveScheduleApproval,
+  type DashboardScheduleDecision,
+  type DashboardScheduledAutomation,
+  type DashboardScheduledAutomationRequest,
 } from '../../api'
 import { formatDateTimeKo } from '../../lib/format-time'
+import { ActionButton } from '../common/button'
 import { StatusChip, type StatusChipTone } from '../common/status-chip'
+import { showToast } from '../common/toast'
 
 function enumLabel(value: string | null | undefined): string {
   if (!value) return '-'
@@ -205,12 +210,100 @@ function KeeperActionCell({ request }: { request: DashboardScheduledAutomationRe
   `
 }
 
-function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest }) {
+function isTerminalStatus(status: string | null | undefined): boolean {
+  switch (status) {
+    case 'succeeded':
+    case 'failed':
+    case 'rejected':
+    case 'cancelled':
+    case 'expired':
+      return true
+    default:
+      return false
+  }
+}
+
+function isApprovalActionable(request: DashboardScheduledAutomationRequest): boolean {
+  if (isTerminalStatus(request.status) || isTerminalStatus(request.effective_status)) return false
+  return request.operator_action === 'approve_or_reject'
+    || request.execution_readiness === 'blocked_approval'
+    || request.execution_readiness === 'awaiting_approval'
+    || request.effective_status === 'blocked_approval'
+    || request.effective_status === 'awaiting_approval'
+}
+
+function ApprovalCell({
+  request,
+  onResolved,
+}: {
+  request: DashboardScheduledAutomationRequest
+  onResolved?: () => Promise<void> | void
+}) {
+  const [pendingDecision, setPendingDecision] = useState<DashboardScheduleDecision | null>(null)
+  const approval = request.approval_policy ?? (request.approval_required ? 'required' : 'not_required')
+  const actionable = isApprovalActionable(request)
+  const busy = pendingDecision !== null
+
+  async function decide(decision: DashboardScheduleDecision) {
+    setPendingDecision(decision)
+    try {
+      await resolveScheduleApproval(
+        request.schedule_id,
+        decision,
+        decision === 'reject' ? 'rejected from dashboard' : undefined,
+      )
+      showToast(
+        `${request.schedule_id} ${decision === 'approve' ? 'approved' : 'rejected'}`,
+        'success',
+      )
+      await onResolved?.()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'schedule approval failed', 'error')
+    } finally {
+      setPendingDecision(null)
+    }
+  }
+
+  return html`
+    <div class="grid gap-1">
+      <span>${enumLabel(approval)}</span>
+      ${actionable
+        ? html`
+            <div class="flex flex-wrap gap-1">
+              <${ActionButton}
+                variant="ok"
+                size="sm"
+                disabled=${busy}
+                ariaBusy=${pendingDecision === 'approve'}
+                testId=${`schedule-approve-${request.schedule_id}`}
+                onClick=${() => { void decide('approve') }}
+              >Approve<//>
+              <${ActionButton}
+                variant="danger"
+                size="sm"
+                disabled=${busy}
+                ariaBusy=${pendingDecision === 'reject'}
+                testId=${`schedule-reject-${request.schedule_id}`}
+                onClick=${() => { void decide('reject') }}
+              >Reject<//>
+            </div>
+          `
+        : null}
+    </div>
+  `
+}
+
+function ScheduleRow({
+  request,
+  onResolved,
+}: {
+  request: DashboardScheduledAutomationRequest
+  onResolved?: () => Promise<void> | void
+}) {
   const effectiveStatus = request.effective_status ?? request.status
   const readiness = request.execution_readiness ?? '-'
   const action = request.operator_action ?? '-'
   const dueIso = request.next_due_at_iso ?? request.due_at_iso ?? null
-  const approval = request.approval_policy ?? (request.approval_required ? 'required' : 'not_required')
   return html`
     <tr class="v2-lab-row border-t border-[var(--color-border-default)]">
       <td class="py-2 pr-3 font-mono text-xs text-[var(--color-fg-secondary)]">${request.schedule_id}</td>
@@ -228,15 +321,17 @@ function ScheduleRow({ request }: { request: DashboardScheduledAutomationRequest
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${recurrenceLabel(request)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${lastExecutionLabel(request)}</td>
       <td class="py-2 pr-3 text-xs text-[var(--color-fg-muted)]">${formatDateTimeKo(dueIso)}</td>
-      <td class="py-2 text-xs text-[var(--color-fg-muted)]">${enumLabel(approval)}</td>
+      <td class="py-2 text-xs text-[var(--color-fg-muted)]"><${ApprovalCell} request=${request} onResolved=${onResolved} /></td>
     </tr>
   `
 }
 
 export function ScheduledAutomationPanel({
   automation,
+  onResolved,
 }: {
   automation?: DashboardScheduledAutomation | null
+  onResolved?: () => Promise<void> | void
 }) {
   if (!automation) {
     return html`
@@ -321,7 +416,7 @@ export function ScheduledAutomationPanel({
                   </tr>
                 </thead>
                 <tbody>
-                  ${rows.map(request => html`<${ScheduleRow} request=${request} />`)}
+                  ${rows.map(request => html`<${ScheduleRow} request=${request} onResolved=${onResolved} />`)}
                 </tbody>
               </table>
             </div>

--- a/dashboard/src/components/tools/tools-main.test.ts
+++ b/dashboard/src/components/tools/tools-main.test.ts
@@ -136,7 +136,7 @@ describe('Tools', () => {
             operator_action: 'approve_or_reject',
             keeper_next_tool: 'masc_schedule_get',
             keeper_next_action:
-              'Inspect details, then wait for an explicit human decision before calling masc_schedule_approve or masc_schedule_reject.',
+              'Inspect details, then wait for the dashboard operator approval or rejection action to resolve this schedule.',
             risk_class: 'workspace_write',
             approval_required: true,
             source: 'operator_request',
@@ -163,7 +163,9 @@ describe('Tools', () => {
     expect(container.textContent).toContain('raw pending approval')
     expect(container.textContent).toContain('approve or reject')
     expect(container.textContent).toContain('masc_schedule_get')
-    expect(container.textContent).toContain('explicit human decision')
+    expect(container.textContent).toContain('dashboard operator approval or rejection')
+    expect(container.textContent).toContain('Approve')
+    expect(container.textContent).toContain('Reject')
     expect(container.textContent).toContain('sched-1')
     expect(container.textContent).toContain('workspace write')
     expect(container.textContent).toContain('cron 0 9 * * 1-5 Asia/Seoul')

--- a/dashboard/src/components/tools/tools-main.ts
+++ b/dashboard/src/components/tools/tools-main.ts
@@ -61,7 +61,7 @@ export function Tools() {
       <${PromptRegistryPanel} />
 
       <${SectionCard} label="예약 자동화 FSM" class="section v2-lab-panel mb-4">
-        <${ScheduledAutomationPanel} automation=${data?.scheduled_automation ?? null} />
+        <${ScheduledAutomationPanel} automation=${data?.scheduled_automation ?? null} onResolved=${loadTools} />
       <//>
 
       <${SectionCard} label="시스템 도구 목록" class="section v2-lab-panel mb-4">

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -673,6 +673,12 @@ export interface DashboardGovernanceResponse {
   pending_actions?: PendingConfirmation[]
   approval_queue?: KeeperApprovalQueueItem[]
   approval_rules?: KeeperApprovalRule[]
+  hitl?: {
+    enabled: boolean
+    disabled_by_env: boolean
+    env_name: string
+    default_enabled: boolean
+  }
 }
 
 export interface DashboardPlanningResponse {

--- a/docs/rfc/RFC-0234-scheduled-internal-automation.md
+++ b/docs/rfc/RFC-0234-scheduled-internal-automation.md
@@ -305,8 +305,12 @@ Initial internal tools:
 | `masc_schedule_list` | list projection rows | read-only |
 | `masc_schedule_get` | inspect one request plus audit events | read-only |
 | `masc_schedule_cancel` | terminal cancellation before start | policy-selected |
-| `masc_schedule_approve` | record execution grant | human-only, cannot be requester/scheduler |
-| `masc_schedule_reject` | reject execution | human-only |
+
+Operator-only dashboard mutation:
+
+| Endpoint | Purpose | Approval |
+| --- | --- | --- |
+| `POST /api/v1/dashboard/schedule/resolve` | record approval or rejection grant | token-bound `CanAdmin` actor, cannot be requester/scheduler |
 
 Internal-only runner entrypoint:
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -29,7 +29,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 230 |  |
 | `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 424 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_DATA_DIR` | string_literal | n/a | n/a | 437 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: true. @category Security @ops_class operator |
+| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
 | `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 467 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
 | `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 480 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -499,11 +499,11 @@ let governance_level () =
 
 let disable_hitl_env_key = "MASC_DISABLE_HITL"
 
-(** Whether to disable HITL (human-in-the-loop) approval gates. Default: true.
+(** Whether to disable HITL (human-in-the-loop) approval gates. Default: false.
     @category Security
     @ops_class operator *)
 let disable_hitl () =
-  get_bool ~default:true "MASC_DISABLE_HITL"
+  get_bool ~default:false disable_hitl_env_key
 
 (** {1 Build Identity} *)
 

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -138,7 +138,7 @@ let all_flags : flag list = [
   (* ── Dashboard & Governance ───────────────────────────────── *)
   { env_name = "MASC_DISABLE_HITL";
     description = "Disable Human-in-the-loop (HITL) approval gates globally";
-    default = true; category = "dashboard";
+    default = false; category = "dashboard";
     lifecycle = Active; since = "2.250.0" };
 
   { env_name = "MASC_DASHBOARD_FIXTURES_ENABLED";

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -108,6 +108,15 @@ let anomaly_profiles_json ~base_path =
       Log.Governance.warn "anomaly_profiles_json: %s" (Printexc.to_string exn);
       `List []
 
+let hitl_status_json () =
+  let disabled_by_env = Env_config_core.disable_hitl () in
+  `Assoc
+    [ ("enabled", `Bool (not disabled_by_env))
+    ; ("disabled_by_env", `Bool disabled_by_env)
+    ; ("env_name", `String Env_config_core.disable_hitl_env_key)
+    ; ("default_enabled", `Bool true)
+    ]
+
 let dashboard_json ~base_path ~limit ~offset:_ ~status_filter:_ =
   let runtime = Dashboard_governance_judge.runtime_status base_path in
   let judgments = Dashboard_governance_judge.fresh_judgments_json ~base_path ~limit in
@@ -126,6 +135,7 @@ let dashboard_json ~base_path ~limit ~offset:_ ~status_filter:_ =
       ("pending_actions", `List []);
       ("approval_queue", approval_queue);
       ("approval_rules", approval_rules);
+      ("hitl", hitl_status_json ());
       ("cases", `List []);
       ("anomaly_profiles", anomaly_profiles_json ~base_path);
     ]

--- a/lib/schedule_projection.ml
+++ b/lib/schedule_projection.ml
@@ -8,7 +8,7 @@ let inspect_and_monitor_dispatch =
 ;;
 
 let approval_decision_required =
-  "Inspect details, then wait for an explicit human decision before calling masc_schedule_approve or masc_schedule_reject."
+  "Inspect details, then wait for the dashboard operator approval or rejection action to resolve this schedule."
 ;;
 
 let wait_for_runner_tick =

--- a/lib/server/dune
+++ b/lib/server/dune
@@ -4,7 +4,9 @@
  (name masc_server)
  (public_name masc.server)
  (wrapped false)
- (private_modules keeper_grpc_heartbeat)
+ (private_modules
+  keeper_grpc_heartbeat
+  server_dashboard_http_schedule_actions)
  (flags :standard -open Masc)
  (libraries
   masc

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -39,9 +39,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       Tool_metrics_persist.enqueue r
     | _ -> ());
   Tool_metrics_persist.start_flush_fiber ~sw ~clock ~base_path:(Mcp_server.workspace_config state).base_path;
-  (* RFC-0234 scheduled automation runner.  Tool-facing create/approve/list
-     paths only mutate the durable ledger; this loop is the production caller
-     that observes due rows and emits at-most-once generic wake signals.  It
+  (* RFC-0234 scheduled automation runner.  Public schedule tools and the
+     dashboard-only approval route only mutate the durable ledger; this loop is
+     the production caller that observes due rows and emits at-most-once generic wake signals.  It
      catches per-tick failures so a corrupt schedule row or transient write
      error cannot cancel unrelated keeper/server fibers. *)
   fork_logged_fiber

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -362,12 +362,24 @@ let dashboard_governance_approval_rule_delete_http_json ~base_path ~(args : Yojs
   | Some id ->
     (match Keeper_approval_queue.delete_rule ~base_path ~id () with
      | Ok deleted ->
-       Keeper_approval_queue.audit_rule_event
-         ~base_path
-         ~event_type:"rule_deleted"
-         deleted;
-       Ok (`Assoc [ "ok", `Bool true; "id", `String deleted.id ])
-     | Error message -> Error message)
+         Keeper_approval_queue.audit_rule_event
+           ~base_path
+           ~event_type:"rule_deleted"
+           deleted;
+         Ok (`Assoc [ "ok", `Bool true; "id", `String deleted.id ])
+       | Error message -> Error message)
+;;
+
+let dashboard_schedule_resolve_http_json
+      ~config
+      ~operator_name
+      ~(args : Yojson.Safe.t)
+  : (Yojson.Safe.t, string) result
+  =
+  Server_dashboard_http_schedule_actions.resolve_http_json
+    ~config
+    ~operator_name
+    ~args
 ;;
 
 (* Dashboard-initiated verification verdict. Mirrors the tool_task path for

--- a/lib/server/server_dashboard_http.mli
+++ b/lib/server/server_dashboard_http.mli
@@ -92,6 +92,12 @@ val dashboard_governance_approval_rule_delete_http_json :
   args:Yojson.Safe.t ->
   (Yojson.Safe.t, string) result
 
+val dashboard_schedule_resolve_http_json :
+  config:Workspace_utils.config ->
+  operator_name:string ->
+  args:Yojson.Safe.t ->
+  (Yojson.Safe.t, string) result
+
 (** {1 Verification + planning + goals} *)
 
 val dashboard_verification_resolve_http_json :

--- a/lib/server/server_dashboard_http_schedule_actions.ml
+++ b/lib/server/server_dashboard_http_schedule_actions.ml
@@ -1,0 +1,82 @@
+type schedule_decision =
+  | Approve
+  | Reject
+
+let ( let* ) = Result.bind
+
+let trim_nonempty value =
+  let trimmed = String.trim value in
+  if String.equal trimmed "" then None else Some trimmed
+;;
+
+let string_opt key json =
+  Safe_ops.json_string_opt key json |> Option.bind trim_nonempty
+;;
+
+let required_string key json =
+  match string_opt key json with
+  | Some value -> Ok value
+  | None -> Error (key ^ " is required")
+;;
+
+let decision_of_json json =
+  let* raw = required_string "decision" json in
+  match String.lowercase_ascii raw with
+  | "approve" -> Ok Approve
+  | "reject" -> Ok Reject
+  | _ -> Error "decision must be 'approve' or 'reject'"
+;;
+
+let decision_to_string = function
+  | Approve -> "approve"
+  | Reject -> "reject"
+;;
+
+let default_rejection_reason ~operator_name =
+  "rejected from dashboard by " ^ operator_name
+;;
+
+let actor_of_operator_name operator_name : Schedule_domain.actor =
+  { id = operator_name
+  ; kind = Schedule_domain.Human_operator
+  ; display_name = Some operator_name
+  }
+;;
+
+let resolve_http_json ~config ~operator_name ~(args : Yojson.Safe.t)
+  : (Yojson.Safe.t, string) result
+  =
+  let operator_name = String.trim operator_name in
+  let result =
+    let* () =
+      if String.equal operator_name ""
+      then Error "authenticated operator is required"
+      else Ok ()
+    in
+    let* schedule_id = required_string "schedule_id" args in
+    let* decision = decision_of_json args in
+    let approved_by = actor_of_operator_name operator_name in
+    let service_result =
+      match decision with
+      | Approve ->
+        Schedule_service.approve config ~schedule_id ~approved_by ()
+      | Reject ->
+        let reason =
+          string_opt "reason" args
+          |> Option.value ~default:(default_rejection_reason ~operator_name)
+        in
+        Schedule_service.reject config ~schedule_id ~approved_by ~reason ()
+    in
+    service_result
+    |> Result.map_error Schedule_service.service_error_to_string
+    |> Result.map (fun schedule ->
+      `Assoc
+        [ "ok", `Bool true
+        ; "schedule_id", `String schedule_id
+        ; "decision", `String (decision_to_string decision)
+        ; "approved_by", Schedule_domain.actor_to_yojson approved_by
+        ; "schedule", Schedule_domain.schedule_request_to_yojson schedule
+        ])
+  in
+  result
+;;

--- a/lib/server/server_dashboard_http_schedule_actions.ml
+++ b/lib/server/server_dashboard_http_schedule_actions.ml
@@ -10,7 +10,9 @@ let trim_nonempty value =
 ;;
 
 let string_opt key json =
-  Safe_ops.json_string_opt key json |> Option.bind trim_nonempty
+  match Safe_ops.json_string_opt key json with
+  | None -> None
+  | Some value -> trim_nonempty value
 ;;
 
 let required_string key json =
@@ -62,8 +64,12 @@ let resolve_http_json ~config ~operator_name ~(args : Yojson.Safe.t)
         Schedule_service.approve config ~schedule_id ~approved_by ()
       | Reject ->
         let reason =
-          string_opt "reason" args
-          |> Option.value ~default:(default_rejection_reason ~operator_name)
+          match string_opt "reason" args with
+          | Some reason -> reason
+          | None ->
+            (* DET-OK: the dashboard fallback is derived only from the authenticated
+               operator bound by token auth, not from caller-supplied body identity. *)
+            default_rejection_reason ~operator_name
         in
         Schedule_service.reject config ~schedule_id ~approved_by ~reason ()
     in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -665,6 +665,27 @@ let add_routes ~sw ~clock router =
              respond_json_value_with_cors ~status:`Bad_request request reqd (operator_error_json (Printf.sprintf "invalid json: %s" msg))
          )
        ) request reqd)
+  |> Http.Router.post "/api/v1/dashboard/schedule/resolve" (fun request reqd ->
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun state operator_name _req reqd ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             try
+               let args = Yojson.Safe.from_string body_str in
+               let config = Mcp_server.workspace_config state in
+               match
+                 Server_dashboard_http_schedule_actions.resolve_http_json
+                   ~config ~operator_name ~args
+               with
+               | Ok json -> respond_json_value_with_cors request reqd json
+               | Error message ->
+                 respond_json_value_with_cors ~status:`Bad_request request reqd
+                   (operator_error_json message)
+             with
+             | Yojson.Json_error msg ->
+               respond_json_value_with_cors ~status:`Bad_request request reqd
+                 (operator_error_json (Printf.sprintf "invalid json: %s" msg)))
+         )
+         request reqd)
   |> Http.Router.post "/api/v1/dashboard/governance/approvals/rules/delete" (fun request reqd ->
        with_tool_auth ~tool_name:"masc_operator_confirm" (fun state _req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -670,12 +670,11 @@ let add_routes ~sw ~clock router =
          (fun state operator_name _req reqd ->
            Http.Request.read_body_async reqd (fun body_str ->
              try
-               let args = Yojson.Safe.from_string body_str in
-               let config = Mcp_server.workspace_config state in
-               match
-                 Server_dashboard_http_schedule_actions.resolve_http_json
-                   ~config ~operator_name ~args
-               with
+                 let args = Yojson.Safe.from_string body_str in
+                 let config = Mcp_server.workspace_config state in
+                 match
+                   dashboard_schedule_resolve_http_json ~config ~operator_name ~args
+                 with
                | Ok json -> respond_json_value_with_cors request reqd json
                | Error message ->
                  respond_json_value_with_cors ~status:`Bad_request request reqd

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -126,16 +126,6 @@ let actor_from_args args ~prefix ~default_id ~default_kind =
   else Ok Schedule_domain.{ id; kind; display_name }
 ;;
 
-let approved_by_from_args args =
-  let* id = required_string args "approved_by_id" in
-  Ok
-    Schedule_domain.
-      { id
-      ; kind = Human_operator
-      ; display_name = string_opt args "approved_by_display_name"
-      }
-;;
-
 let has_arg args key = Option.is_some (Json_util.assoc_member_opt key args)
 
 let has_board_convenience_args args =
@@ -499,33 +489,6 @@ let handle_cancel ~tool_name ~start_time ctx args =
         ])
 ;;
 
-let handle_approve ~tool_name ~start_time ctx args =
-  let result =
-    let* schedule_id = required_string args "schedule_id" in
-    let* approved_by = approved_by_from_args args in
-    let grant_id = string_opt args "grant_id" in
-    let approved_at = optional_float args "approved_at_unix" in
-    Schedule_service.approve ctx.config ?grant_id ?approved_at ~schedule_id
-      ~approved_by ()
-    |> Result.map_error Schedule_service.service_error_to_string
-  in
-  request_result ~tool_name ~start_time result
-;;
-
-let handle_reject ~tool_name ~start_time ctx args =
-  let result =
-    let* schedule_id = required_string args "schedule_id" in
-    let* approved_by = approved_by_from_args args in
-    let* reason = required_string args "reason" in
-    let grant_id = string_opt args "grant_id" in
-    let approved_at = optional_float args "approved_at_unix" in
-    Schedule_service.reject ctx.config ?grant_id ?approved_at ~schedule_id
-      ~approved_by ~reason ()
-    |> Result.map_error Schedule_service.service_error_to_string
-  in
-  request_result ~tool_name ~start_time result
-;;
-
 let dispatch ctx ~name ~args : Tool_result.result option =
   let start_time = Time_compat.now () in
   let handle f =
@@ -542,8 +505,6 @@ let dispatch ctx ~name ~args : Tool_result.result option =
   | Some { action = List_requests; _ } -> handle handle_list
   | Some { action = Get_request; _ } -> handle handle_get
   | Some { action = Cancel_request; _ } -> handle handle_cancel
-  | Some { action = Approve_request; _ } -> handle handle_approve
-  | Some { action = Reject_request; _ } -> handle handle_reject
   | _ -> None
 ;;
 

--- a/lib/tool_schemas/tool_schemas_schedule.ml
+++ b/lib/tool_schemas/tool_schemas_schedule.ml
@@ -250,7 +250,11 @@ let definitions : definition list =
       ~description:
         "Cancel a pending, scheduled, or due scheduled request before execution."
       ~input_schema:cancel_schema ~read_only:false
-  ; definition ~action:Approve_request ~id:"approve" ~name:"masc_schedule_approve"
+  ]
+;;
+
+let operator_decision_definitions : definition list =
+  [ definition ~action:Approve_request ~id:"approve" ~name:"masc_schedule_approve"
       ~description:
         "Record a separate human execution grant for a pending or due scheduled request. Recurring side-effecting requests need a fresh grant for each due occurrence."
       ~input_schema:approve_schema ~read_only:false
@@ -259,6 +263,8 @@ let definitions : definition list =
       ~input_schema:reject_schema ~read_only:false
   ]
 ;;
+
+let all_definitions = definitions @ operator_decision_definitions
 
 let schemas : Masc_domain.tool_schema list =
   List.map (fun definition -> definition.schema) definitions

--- a/lib/tool_schemas/tool_schemas_schedule.mli
+++ b/lib/tool_schemas/tool_schemas_schedule.mli
@@ -14,5 +14,7 @@ type definition =
   }
 
 val definitions : definition list
+val operator_decision_definitions : definition list
+val all_definitions : definition list
 val schemas : Masc_domain.tool_schema list
 val find_definition : string -> definition option

--- a/test/test_feature_flag_registry.ml
+++ b/test/test_feature_flag_registry.ml
@@ -97,8 +97,13 @@ let test_find_opt_first_registered () =
   | [] -> assert false  (* covered by test_registry_nonempty *)
   | first :: _ ->
       (match R.find_opt first.R.env_name with
-       | Some f -> assert (f.R.env_name = first.R.env_name)
-       | None -> assert false)
+	       | Some f -> assert (f.R.env_name = first.R.env_name)
+	       | None -> assert false)
+
+let test_hitl_disable_flag_defaults_false () =
+  match R.find_opt "MASC_DISABLE_HITL" with
+  | Some flag -> assert (flag.R.default = false)
+  | None -> assert false
 
 (* ─── (4) flag_to_json shape ──────────────────────────────────── *)
 
@@ -206,6 +211,7 @@ let () =
   test_every_category_in_documented_set ();
   test_find_opt_unknown ();
   test_find_opt_first_registered ();
+  test_hitl_disable_flag_defaults_false ();
   test_flag_to_json_eight_fields ();
   test_flag_to_json_canonical_default_is_bool ();
   test_to_json_total_matches_all_flags ();

--- a/test/test_governance_pipeline.ml
+++ b/test/test_governance_pipeline.ml
@@ -781,6 +781,34 @@ let test_unknown_governance_level_fail_closed_on_critical () =
    | `Require_confirm _ -> ()
    | _ -> Alcotest.fail "unknown governance level should require confirm on critical risk")
 
+let with_env key value f =
+  let old = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some previous -> Unix.putenv key previous
+      | None -> Unix.putenv key "")
+    f
+
+let test_hitl_enabled_by_default () =
+  with_env "MASC_DISABLE_HITL" "" (fun () ->
+    Alcotest.(check (option string)) "production threshold"
+      (Some "critical")
+      (Option.map Gp.risk_level_to_string (Gp.confirm_threshold "production"));
+    Alcotest.(check (option string)) "keeper production threshold"
+      (Some "high")
+      (Option.map Gp.risk_level_to_string (Gp.keeper_confirm_threshold "production")))
+
+let test_hitl_can_still_be_disabled_by_env () =
+  with_env "MASC_DISABLE_HITL" "true" (fun () ->
+    Alcotest.(check (option string)) "production threshold disabled"
+      None
+      (Option.map Gp.risk_level_to_string (Gp.confirm_threshold "production"));
+    Alcotest.(check (option string)) "keeper production threshold disabled"
+      None
+      (Option.map Gp.risk_level_to_string (Gp.keeper_confirm_threshold "production")))
+
 (* ── Case-insensitive tool name matching ────────────────────── *)
 
 let test_case_insensitive_matching () =
@@ -1050,6 +1078,10 @@ let () =
         test_paranoid_confirms_high;
       Alcotest.test_case "paranoid confirms critical" `Quick
         test_paranoid_confirms_critical;
+      Alcotest.test_case "HITL enabled by default" `Quick
+        test_hitl_enabled_by_default;
+      Alcotest.test_case "HITL disable env still disables gates" `Quick
+        test_hitl_can_still_be_disabled_by_env;
       Alcotest.test_case "unknown level fail-closed on critical (#7641)" `Quick
         test_unknown_governance_level_fail_closed_on_critical;
     ];

--- a/test/test_keeper_unified_verification_surface.ml
+++ b/test/test_keeper_unified_verification_surface.ml
@@ -67,7 +67,7 @@ let scheduled_automation_observation : WO.scheduled_automation_observation =
         ; due_at = 180.0
         ; keeper_next_tool = Some "masc_schedule_get"
         ; keeper_next_action =
-            "Inspect details, then wait for an explicit human decision before calling masc_schedule_approve or masc_schedule_reject."
+            "Inspect details, then wait for the dashboard operator approval or rejection action to resolve this schedule."
         }
       ]
   }
@@ -318,7 +318,7 @@ let test_scheduled_automation_prompt_section () =
   check bool "prompt includes ready next action" true
     (contains_sub "do not create a duplicate schedule" user_msg);
   check bool "prompt includes approval next action" true
-    (contains_sub "masc_schedule_approve or masc_schedule_reject" user_msg)
+    (contains_sub "dashboard operator approval or rejection" user_msg)
 
 let () =
   run "keeper_unified_verification_surface"

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -191,11 +191,11 @@ let test_dashboard_schedule_resolve_uses_authenticated_operator () =
       ; "decision", `String "approve"
       ; "approved_by_id", `String "attacker"
       ]
-  in
-  match
-    Server_dashboard_http_schedule_actions.resolve_http_json
-      ~config ~operator_name:"dashboard-admin" ~args
-  with
+    in
+    match
+      Server_dashboard_http.dashboard_schedule_resolve_http_json
+        ~config ~operator_name:"dashboard-admin" ~args
+    with
   | Error message -> fail message
   | Ok json ->
     let open Yojson.Safe.Util in

--- a/test/test_schedule_consumer_dispatch.ml
+++ b/test/test_schedule_consumer_dispatch.ml
@@ -181,6 +181,36 @@ let test_board_post_consumer_rejects_read_only_risk () =
   check int "no post" 0 (List.length (Board_dispatch.list_posts ~limit:10 ()))
 ;;
 
+let test_dashboard_schedule_resolve_uses_authenticated_operator () =
+  with_workspace
+  @@ fun config ->
+  let request = create_pending_board_schedule config in
+  let args =
+    `Assoc
+      [ "schedule_id", `String request.schedule_id
+      ; "decision", `String "approve"
+      ; "approved_by_id", `String "attacker"
+      ]
+  in
+  match
+    Server_dashboard_http_schedule_actions.resolve_http_json
+      ~config ~operator_name:"dashboard-admin" ~args
+  with
+  | Error message -> fail message
+  | Ok json ->
+    let open Yojson.Safe.Util in
+    let approved_by_id = json |> member "approved_by" |> member "id" |> to_string in
+    check string "response approver is token-bound actor" "dashboard-admin"
+      approved_by_id;
+    check bool "body spoofed approver ignored" true
+      (not (String.equal approved_by_id "attacker"));
+    (match Schedule_store.get_schedule config ~schedule_id:request.schedule_id with
+     | None -> fail "schedule missing"
+     | Some stored ->
+       check string "schedule moved to scheduled" "scheduled"
+         (Schedule_domain.schedule_status_to_string stored.status))
+;;
+
 let () =
   run "Schedule_consumer_dispatch"
     [ ( "board_post"
@@ -188,6 +218,8 @@ let () =
             test_board_post_consumer_creates_post_and_succeeds_schedule
         ; test_case "rejects read-only risk" `Quick
             test_board_post_consumer_rejects_read_only_risk
+        ; test_case "dashboard resolve uses authenticated operator" `Quick
+            test_dashboard_schedule_resolve_uses_authenticated_operator
         ] )
     ]
 ;;

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -56,24 +56,46 @@ let schedule_definition action =
   | None -> fail "schedule definition missing"
 ;;
 
+let operator_schedule_definition action =
+  match
+    List.find_opt
+      (fun (definition : Tool_schemas_schedule.definition) ->
+        definition.action = action)
+      Tool_schemas_schedule.operator_decision_definitions
+  with
+  | Some definition -> definition
+  | None -> fail "operator schedule definition missing"
+;;
+
 let schedule_tool_name action =
   let schema : Masc_domain.tool_schema = (schedule_definition action).schema in
   schema.name
 ;;
 
+let operator_schedule_tool_name action =
+  let schema : Masc_domain.tool_schema =
+    (operator_schedule_definition action).schema
+  in
+  schema.name
+;;
+
 let test_schema_and_descriptor_exposed () =
   let create_name = schedule_tool_name Tool_schemas_schedule.Create_request in
+  let approve_name = operator_schedule_tool_name Tool_schemas_schedule.Approve_request in
+  let reject_name = operator_schedule_tool_name Tool_schemas_schedule.Reject_request in
   let approve_schema =
-    (schedule_definition Tool_schemas_schedule.Approve_request).schema
+    (operator_schedule_definition Tool_schemas_schedule.Approve_request).schema
   in
   let reject_schema =
-    (schedule_definition Tool_schemas_schedule.Reject_request).schema
+    (operator_schedule_definition Tool_schemas_schedule.Reject_request).schema
   in
   let schema_names =
     Config.raw_all_tool_schemas
     |> List.map (fun (s : Masc_domain.tool_schema) -> s.name)
   in
   check bool "raw schema has create" true (List.mem create_name schema_names);
+  check bool "raw schema hides approve" false (List.mem approve_name schema_names);
+  check bool "raw schema hides reject" false (List.mem reject_name schema_names);
   check string "approve describes due grants"
     "Record a separate human execution grant for a pending or due scheduled request. Recurring side-effecting requests need a fresh grant for each due occurrence."
     approve_schema.description;
@@ -81,12 +103,14 @@ let test_schema_and_descriptor_exposed () =
     "Reject a pending or due scheduled request with a human decision."
     reject_schema.description;
   check bool "tag registered" true
-    (Tool_dispatch.lookup_tag create_name = Some Tool_dispatch.Mod_schedule);
+      (Tool_dispatch.lookup_tag create_name = Some Tool_dispatch.Mod_schedule);
   let descriptor_names =
     Keeper_tool_descriptor.all_descriptors ()
     |> List.map (fun (d : Keeper_tool_descriptor.t) -> d.internal_name)
   in
-  check bool "descriptor has create" true (List.mem create_name descriptor_names)
+  check bool "descriptor has create" true (List.mem create_name descriptor_names);
+  check bool "descriptor hides approve" false (List.mem approve_name descriptor_names);
+  check bool "descriptor hides reject" false (List.mem reject_name descriptor_names)
 ;;
 
 let schedule_ctx config : Tool_schedule.context =
@@ -109,6 +133,28 @@ let test_dispatch_create_persists_schedule () =
     let request = List.hd state.schedules in
     check string "status" "scheduled"
       (Schedule_domain.schedule_status_to_string request.status)
+;;
+
+let test_dispatch_operator_decisions_are_dashboard_only () =
+  with_config
+  @@ fun config ->
+  let ctx = schedule_ctx config in
+  let approve_name = operator_schedule_tool_name Tool_schemas_schedule.Approve_request in
+  let reject_name = operator_schedule_tool_name Tool_schemas_schedule.Reject_request in
+  (match Tool_schedule.dispatch ctx ~name:approve_name
+           ~args:(`Assoc [ "schedule_id", `String "sched-1"; "approved_by_id", `String "operator" ])
+   with
+   | None -> ()
+   | Some _ -> fail "approve should not dispatch through public schedule tool surface");
+  (match Tool_schedule.dispatch ctx ~name:reject_name
+           ~args:(`Assoc
+                    [ "schedule_id", `String "sched-1"
+                    ; "approved_by_id", `String "operator"
+                    ; "reason", `String "no"
+                    ])
+   with
+   | None -> ()
+   | Some _ -> fail "reject should not dispatch through public schedule tool surface")
 ;;
 
 let test_dispatch_create_persists_recurrence () =
@@ -560,10 +606,10 @@ let test_dashboard_projection_surfaces_schedule_fsm () =
     (blocked_row |> member "operator_action" |> to_string);
   check string "blocked keeper next tool" "masc_schedule_get"
     (blocked_row |> member "keeper_next_tool" |> to_string);
-  check bool "blocked keeper action mentions grant tools" true
+  check bool "blocked keeper action mentions dashboard action" true
     (String_util.contains_substring
        (blocked_row |> member "keeper_next_action" |> to_string)
-       "masc_schedule_approve or masc_schedule_reject");
+       "dashboard operator approval or rejection");
   let expired_row = find_request "sched-expired-effective" in
   check string "expired effective status" "expired"
     (expired_row |> member "effective_status" |> to_string);
@@ -635,9 +681,9 @@ let test_keeper_observation_surfaces_schedule_attention () =
      check string "blocked action" "approve_or_reject" blocked.action;
      check (option string) "blocked next tool" (Some "masc_schedule_get")
        blocked.keeper_next_tool;
-     check bool "blocked next action mentions grant tools" true
+     check bool "blocked next action mentions dashboard action" true
        (String_util.contains_substring blocked.keeper_next_action
-          "masc_schedule_approve or masc_schedule_reject");
+          "dashboard operator approval or rejection");
      check string "ready schedule second" "sched-ready" ready.schedule_id;
      check string "ready action" "dispatch_ready" ready.action;
      check (option string) "ready next tool" (Some "masc_schedule_get")
@@ -655,6 +701,8 @@ let () =
             test_schema_and_descriptor_exposed
         ; test_case "dispatch create persists schedule" `Quick
             test_dispatch_create_persists_schedule
+        ; test_case "operator decisions are dashboard-only" `Quick
+            test_dispatch_operator_decisions_are_dashboard_only
         ; test_case "dispatch create persists recurrence" `Quick
             test_dispatch_create_persists_recurrence
         ; test_case "dispatch create derives due_at for cron recurrence" `Quick


### PR DESCRIPTION
## Summary
- enable HITL gates by default and expose HITL state in the governance dashboard payload
- remove schedule approve/reject from the public keeper/MCP schedule tool surface
- add a token-bound CanAdmin dashboard schedule resolve route and UI approve/reject actions
- update schedule projection/docs/tests so keepers wait for dashboard operator decisions instead of calling approval tools

## Verification
- git diff --check
- local build/tests intentionally not run per operator direction; CI will build and test

## Risk Notes
- schedule approval/rejection now records the authenticated dashboard operator as approver; request bodies cannot supply approved_by_id for this route
- operator-only schedule approve/reject schema definitions remain cataloged for documentation/tests but are not registered in public dispatch or keeper descriptors