### PR TITLE
feat(turn-record): surface real transcript + tool I/O in turn inspector (RFC-0233)

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -19,6 +19,7 @@ import {
   fetchKeeperToolCalls,
   fetchKeeperToolStats,
   fetchKeeperTurnRecords,
+  fetchKeeperTurnTranscript,
   fetchDashboardMemory,
   fetchDashboardMission,
   fetchDashboardMissionBriefing,
@@ -479,6 +480,56 @@ describe('keeper tool telemetry fetchers', () => {
     expect(result.entries[0]?.record.finish_reason).toBe('completed')
     expect(result.entries[1]?.record.model).toBeUndefined()
     expect(result.entries[1]?.record.finish_reason).toBeUndefined()
+  })
+})
+
+describe('fetchKeeperTurnTranscript', () => {
+  it('encodes the turn_ref join key and decodes operator/keeper lines (RFC-0233 §7)', async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify({
+        keeper: 'keeper-alpha',
+        turn_ref: 'trace-xyz#3',
+        found: true,
+        source: 'keeper_chat_store',
+        user: [{ role: 'user', content: 'request A', ts: 10 }],
+        assistant: [
+          { role: 'assistant', content: 'reply A', ts: 11 },
+          { role: 'assistant', content: 'failed', ts: 12, kind: 'transport_failure' },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperTurnTranscript('keeper-alpha', 'trace-xyz#3')
+
+    // The '#' must be percent-encoded so it reaches the server as a query value.
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      '/api/v1/keepers/keeper-alpha/turn-transcript?turn_ref=trace-xyz%233',
+    )
+    expect(result.found).toBe(true)
+    expect(result.user[0]?.content).toBe('request A')
+    expect(result.assistant[0]?.content).toBe('reply A')
+    expect(result.assistant[1]?.kind).toBe('transport_failure')
+  })
+
+  it('decodes explicit absence (found=false) without fabricating lines', async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify({
+        keeper: 'keeper-alpha',
+        turn_ref: 'trace-xyz#99',
+        found: false,
+        source: 'keeper_chat_store',
+        user: [],
+        assistant: [],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperTurnTranscript('keeper-alpha', 'trace-xyz#99')
+
+    expect(result.found).toBe(false)
+    expect(result.user).toEqual([])
+    expect(result.assistant).toEqual([])
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3255,6 +3255,80 @@ export function fetchKeeperTurnRecords(
   })
 }
 
+// ── Keeper turn transcript (RFC-0233 §7) ────────────────
+// The operator request + keeper response for one turn, joined server-side
+// on the turn_ref "<trace_id>#<absolute_turn>". Lazily fetched by the turn
+// inspector so the transcript (which can be large) never bloats the
+// turn-records list. Content is the same load-time redacted view the chat
+// history endpoint serves (RFC-0132); `found` is false when no persisted
+// row carries the requested turn_ref, in which case the inspector renders
+// explicit absence rather than a fabricated transcript.
+
+export type TurnTranscriptLine = {
+  role: string
+  content: string
+  ts?: number
+  // Writer-declared row kind; present (e.g. 'transport_failure') only on
+  // non-utterance assistant rows so the inspector can mark a failed reply
+  // distinctly rather than quoting it as the keeper's own words.
+  kind?: string
+}
+
+export type TurnTranscript = {
+  keeper: string
+  turn_ref: string
+  found: boolean
+  source: string
+  user: TurnTranscriptLine[]
+  assistant: TurnTranscriptLine[]
+}
+
+function decodeTurnTranscriptLine(raw: unknown): TurnTranscriptLine | null {
+  if (!isRecord(raw)) return null
+  const role = asString(raw.role)
+  if (!role) return null
+  return {
+    role,
+    content: asString(raw.content) ?? '',
+    ts: asNumber(raw.ts),
+    kind: asString(raw.kind),
+  }
+}
+
+function decodeTurnTranscript(raw: unknown): TurnTranscript | null {
+  if (!isRecord(raw)) return null
+  const keeper = asString(raw.keeper)
+  const turn_ref = asString(raw.turn_ref)
+  if (!keeper || !turn_ref) return null
+  const decodeLines = (value: unknown): TurnTranscriptLine[] =>
+    asRecordArray(value)
+      .map(decodeTurnTranscriptLine)
+      .filter((line): line is TurnTranscriptLine => line !== null)
+  return {
+    keeper,
+    turn_ref,
+    found: asBoolean(raw.found, false) ?? false,
+    source: asString(raw.source) ?? 'keeper_chat_store',
+    user: decodeLines(raw.user),
+    assistant: decodeLines(raw.assistant),
+  }
+}
+
+export function fetchKeeperTurnTranscript(
+  name: string,
+  turnRef: string,
+  opts?: AbortableRequestOptions,
+): Promise<TurnTranscript> {
+  return get<Record<string, unknown>>(
+    `/api/v1/keepers/${encodeURIComponent(name)}/turn-transcript?turn_ref=${encodeURIComponent(turnRef)}`,
+    { signal: opts?.signal },
+  ).then((raw) => {
+    const decoded = decodeTurnTranscript(raw)
+    if (!decoded) throw new Error('유효하지 않은 keeper turn transcript payload')
+    return decoded
+  })
+}
+
 // ── Unified telemetry ──────────────────────────────────
 
 export type TelemetrySource =

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact'
 import { html } from 'htm/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fetchKeeperToolCalls, fetchKeeperTurnRecords, type ToolCallsResponse, type TurnRecordsResponse } from '../api/dashboard'
+import { fetchKeeperToolCalls, fetchKeeperTurnRecords, fetchKeeperTurnTranscript, type ToolCallsResponse, type TurnRecordsResponse, type TurnTranscript } from '../api/dashboard'
 import {
   initialTurnRowForTimestamp,
   initialTurnRowForTurnRef,
@@ -14,11 +14,35 @@ vi.mock('../api/dashboard', () => {
   return {
     fetchKeeperToolCalls: vi.fn(),
     fetchKeeperTurnRecords: vi.fn(),
+    fetchKeeperTurnTranscript: vi.fn(),
   }
 })
 
 const fetchKeeperToolCallsMock = vi.mocked(fetchKeeperToolCalls)
 const fetchKeeperTurnRecordsMock = vi.mocked(fetchKeeperTurnRecords)
+const fetchKeeperTurnTranscriptMock = vi.mocked(fetchKeeperTurnTranscript)
+
+function emptyTranscript(): TurnTranscript {
+  return {
+    keeper: 'albini',
+    turn_ref: 'trace-active#42',
+    found: false,
+    source: 'keeper_chat_store',
+    user: [],
+    assistant: [],
+  }
+}
+
+function transcriptForTurn(): TurnTranscript {
+  return {
+    keeper: 'albini',
+    turn_ref: 'trace-active#42',
+    found: true,
+    source: 'keeper_chat_store',
+    user: [{ role: 'user', content: 'deploy the staging build', ts: 1_781_587_540 }],
+    assistant: [{ role: 'assistant', content: 'staging build deployed', ts: 1_781_587_560 }],
+  }
+}
 
 function emptyToolCalls(): ToolCallsResponse {
   return {
@@ -297,6 +321,7 @@ describe('KeeperMemoryOsRecallPanel', () => {
 describe('KeeperTurnInspector v2 drawer', () => {
   beforeEach(() => {
     fetchKeeperToolCallsMock.mockResolvedValue(toolCallsForTurn())
+    fetchKeeperTurnTranscriptMock.mockResolvedValue(emptyTranscript())
     Object.defineProperty(navigator, 'clipboard', {
       value: {
         writeText: vi.fn().mockResolvedValue(undefined),
@@ -623,6 +648,120 @@ describe('KeeperTurnInspector v2 drawer', () => {
     await waitFor(() => {
       expect(container.textContent).toContain('duration 없음')
     })
+  })
+
+  it('renders real tool call input and output in the messages tab (RFC-0233)', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeTruthy()
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-messages"]')!)
+
+    await waitFor(() => {
+      const text = container.textContent ?? ''
+      // Real tool I/O joined from the tool-call log by execution_id.
+      expect(text).toContain('요청 · input')
+      expect(text).toContain('응답 · result')
+      expect(text).toContain('post_id')
+      expect(text).toContain('p-1')
+    })
+    const text = container.textContent ?? ''
+    // The deferred placeholders must be gone.
+    expect(text).not.toContain('도구 결과는 별도 execution trace 에서 확인')
+  })
+
+  it('renders explicit tool I/O absence when no tool-call entry matches the execution (RFC-0233)', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+    // execution_id 'exec-42' on the record has no matching tool-call entry.
+    fetchKeeperToolCallsMock.mockResolvedValue(emptyToolCalls())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeTruthy()
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-messages"]')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-tool-io-absent"]')).toBeTruthy()
+    })
+    // No fabricated result text.
+    expect(container.textContent ?? '').not.toContain('응답 · result')
+  })
+
+  it('renders the real operator request and keeper response from the transcript (RFC-0233 §7)', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+    fetchKeeperTurnTranscriptMock.mockResolvedValue(transcriptForTurn())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeTruthy()
+    })
+
+    // Transcript is fetched lazily for the open turn's join key.
+    expect(fetchKeeperTurnTranscriptMock).toHaveBeenCalledWith(
+      'albini',
+      'trace-active#42',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
+
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-messages"]')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-transcript-user"]')?.textContent ?? '').toContain(
+        'deploy the staging build',
+      )
+    })
+    expect(container.querySelector('[data-testid="turn-transcript-assistant"]')?.textContent ?? '').toContain(
+      'staging build deployed',
+    )
+    const text = container.textContent ?? ''
+    expect(text).not.toContain('직전 operator 요청 — 본 대화의 사용자 메시지')
+    expect(text).not.toContain('keeper 응답 — 본 턴의 출력 메시지')
+  })
+
+  it('renders explicit transcript absence when the turn has no joinable rows (RFC-0233 §7)', async () => {
+    fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
+    fetchKeeperTurnTranscriptMock.mockResolvedValue(emptyTranscript())
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-detail-drawer"]')).toBeTruthy()
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-messages"]')!)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="turn-transcript-user-absent"]')).toBeTruthy()
+    })
+    expect(container.querySelector('[data-testid="turn-transcript-assistant-absent"]')).toBeTruthy()
   })
 
   it('warns when the timing source fails while keeping turn records visible', async () => {

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -10,19 +10,26 @@
 
 import { html } from 'htm/preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
-import { fetchKeeperToolCalls, fetchKeeperTurnRecords } from '../api/dashboard'
+import {
+  fetchKeeperToolCalls,
+  fetchKeeperTurnRecords,
+  fetchKeeperTurnTranscript,
+} from '../api/dashboard'
 import type {
   KeeperUserModelItem,
   KeeperUserModelSnapshot,
   MemoryOsEpisodeSummary,
   MemoryOsTurnRecordSnapshot,
   ToolCallEntry,
+  ToolCallOutputBlob,
   ToolCallsResponse,
   TurnBlock,
   TurnBlockDiff,
   TurnRecordEntry,
   TurnRecordRow,
   TurnRecordsResponse,
+  TurnTranscript,
+  TurnTranscriptLine,
   TelemetryFreshnessMetadata,
 } from '../api/dashboard'
 import { formatTimeHms } from '../lib/format-time'
@@ -440,6 +447,13 @@ type TurnToolDetail = {
   durationMs: number | null
   agentSubturn: number | null
   keeperTurn: number | null
+  // RFC-0233 §1.1: the real tool call I/O, joined from the tool-call log on
+  // execution_id (already boundary-redacted at write in keeper_tool_call_log).
+  // [matched] is false when no tool-call entry carried this execution id —
+  // the inspector renders explicit absence, never a fabricated result.
+  matched: boolean
+  input: unknown
+  output: string | ToolCallOutputBlob | null
 }
 
 type TurnInspectorData = {
@@ -518,6 +532,34 @@ function toolStatusLabel(status: TurnToolDetail['status']): string {
   if (status === 'ok') return 'success'
   if (status === 'bad') return 'error'
   return 'unmatched'
+}
+
+// Tool input args as copyable text. Strings pass through; structured input is
+// pretty-printed JSON.
+function toolInputText(input: unknown): string {
+  if (input == null) return ''
+  if (typeof input === 'string') return input
+  try {
+    return JSON.stringify(input, null, 2)
+  } catch {
+    return String(input)
+  }
+}
+
+// Tool output as copyable text. A string is the result verbatim; a blob ref
+// (output spilled out-of-line by the server) yields its stored preview.
+function toolOutputText(output: string | ToolCallOutputBlob | null): string {
+  if (output == null) return ''
+  if (typeof output === 'string') return output
+  return output._blob.preview
+}
+
+// Provenance line for a blob-backed output so the operator knows the preview is
+// truncated, with the sha to fetch the full payload elsewhere.
+function toolOutputMeta(output: string | ToolCallOutputBlob | null): string | null {
+  if (output == null || typeof output === 'string') return null
+  const { bytes, mime, sha256 } = output._blob
+  return `blob · ${bytes}B · ${mime} · ${sha256.slice(0, 12)}`
 }
 
 function toolCallIndexByExecutionId(entries: readonly ToolCallEntry[]): Map<string, ToolCallEntry> {
@@ -617,6 +659,9 @@ function buildTurnDetail(
       durationMs: entry?.duration_ms ?? null,
       agentSubturn: entry?.turn ?? null,
       keeperTurn: entry?.keeper_turn_id ?? null,
+      matched: entry !== null,
+      input: entry?.input ?? null,
+      output: entry?.output ?? null,
     }
   })
   tools.forEach(tool => {
@@ -697,12 +742,6 @@ function CodeCard({ cap, text, htmlContent, tokens }: { cap: string; text: strin
   `
 }
 
-function jsonHighlight(obj: unknown): string {
-  return JSON.stringify(obj, null, 2)
-    .replace(/("[^"]+"):/g, '<span class="jk">$1</span>:')
-    .replace(/: ("[^"]*")/g, ': <span class="js">$1</span>')
-}
-
 function TimelineTab({ t }: { t: TurnDetail }) {
   const measuredCount = t.phases.filter(p => p.durationMs != null).length
   const unknownCount = t.phases.length - measuredCount
@@ -747,14 +786,105 @@ function TimelineTab({ t }: { t: TurnDetail }) {
   `
 }
 
-function MessagesTab({ keeperName, t }: { keeperName: string; t: TurnDetail }) {
+// Lazy-loaded transcript state for the open turn (RFC-0233 §7). Distinct from
+// `null` (not yet requested) so the renderer can show loading vs absence.
+type TranscriptView =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'loaded'; data: TurnTranscript }
+
+// Map the async-resource state to a transcript view. Error wins over a stale
+// data value; absence of both reads as still-loading (the lazy fetch fires on
+// drawer open).
+function toTranscriptView(state: {
+  loading: boolean
+  error: string | null
+  data: TurnTranscript | null
+}): TranscriptView {
+  if (state.error) return { kind: 'error', message: state.error }
+  if (state.data) return { kind: 'loaded', data: state.data }
+  return { kind: 'loading' }
+}
+
+// One operator request line. Renders the real persisted content; explicit
+// absence when the turn carried no joinable user row.
+function OperatorLine({ line, seq }: { line: TurnTranscriptLine | null; seq: number }) {
+  return html`
+    <div class="kti-msg">
+      <div class="kti-msg-h">
+        <span class="kti-msg-role user">user</span>
+        <span class="who">operator</span>
+        <span class="seq">#${seq}</span>
+      </div>
+      ${line
+        ? html`<div class="kti-msg-b" data-testid="turn-transcript-user">${line.content}</div>`
+        : html`<div class="kti-msg-b kti-msg-absent" data-testid="turn-transcript-user-absent">
+            operator 요청이 이 턴에 기록되지 않았습니다 (turn_ref 미연결 또는 보존 윈도 밖)
+          </div>`}
+    </div>
+  `
+}
+
+// One keeper response line. A transport-failure row is labelled distinctly and
+// never presented as the keeper's own utterance.
+function KeeperLine({
+  keeperName,
+  line,
+  seq,
+}: {
+  keeperName: string
+  line: TurnTranscriptLine | null
+  seq: number
+}) {
+  const isFailure = line?.kind === 'transport_failure'
+  return html`
+    <div class="kti-msg">
+      <div class="kti-msg-h">
+        <span class="kti-msg-role assistant">assistant</span>
+        <span class="who">${keeperName}</span>
+        ${isFailure
+          ? html`<span class="pill bad" data-testid="turn-transcript-assistant-failure">transport failure</span>`
+          : null}
+        <span class="seq">#${seq}</span>
+      </div>
+      ${line
+        ? html`<div class="kti-msg-b" data-testid="turn-transcript-assistant">${line.content}</div>`
+        : html`<div class="kti-msg-b kti-msg-absent" data-testid="turn-transcript-assistant-absent">
+            keeper 응답이 이 턴에 기록되지 않았습니다
+          </div>`}
+    </div>
+  `
+}
+
+function MessagesTab({
+  keeperName,
+  t,
+  transcript,
+}: {
+  keeperName: string
+  t: TurnDetail
+  transcript: TranscriptView
+}) {
   let seq = 0
+  const userLines = transcript.kind === 'loaded' ? transcript.data.user : []
+  const assistantLines = transcript.kind === 'loaded' ? transcript.data.assistant : []
+  // 2 synthetic (system + context) + real user lines + tools + real assistant
+  // lines. Falls back to one placeholder slot each while loading/absent.
+  const userSlots = userLines.length || 1
+  const assistantSlots = assistantLines.length || 1
+  const messageCount = 2 + userSlots + t.tools.length + assistantSlots
   return html`
     <div class="kti-sec">
       <div class="kti-sec-h">
         <h4>모델에 전달된 시퀀스</h4>
-        <span class="n">${3 + t.tools.length + 1} 메시지</span>
+        <span class="n">${messageCount} 메시지</span>
       </div>
+      ${transcript.kind === 'loading'
+        ? html`<div class="text-2xs text-[var(--color-fg-muted)] px-1 pb-1" data-testid="turn-transcript-loading">전사 불러오는 중…</div>`
+        : null}
+      ${transcript.kind === 'error'
+        ? html`<div class="text-2xs text-[var(--color-status-warn)] px-1 pb-1" data-testid="turn-transcript-error">전사 불러오기 실패 · ${transcript.message}</div>`
+        : null}
       <div class="kti-seq-rail">
         <div class="kti-msg">
           <div class="kti-msg-h">
@@ -772,14 +902,9 @@ function MessagesTab({ keeperName, t }: { keeperName: string; t: TurnDetail }) {
           </div>
           <div class="kti-msg-b mono">${t.injectedCtx}</div>
         </div>
-        <div class="kti-msg">
-          <div class="kti-msg-h">
-            <span class="kti-msg-role user">user</span>
-            <span class="who">operator</span>
-            <span class="seq">#${++seq}</span>
-          </div>
-          <div class="kti-msg-b">[직전 operator 요청 — 본 대화의 사용자 메시지]</div>
-        </div>
+        ${userLines.length
+          ? userLines.map(line => html`<${OperatorLine} line=${line} seq=${++seq} />`)
+          : html`<${OperatorLine} line=${null} seq=${++seq} />`}
         ${t.tools.map((tool, i) => html`
           <div key=${i} class="kti-tool">
             <div class="kti-tool-h">
@@ -796,40 +921,30 @@ function MessagesTab({ keeperName, t }: { keeperName: string; t: TurnDetail }) {
                 : html`<span class="seq">duration 없음</span>`}
             </div>
             <div class="kti-tool-b">
-              <${CodeCard}
-                cap="실행 식별자"
-                text=${JSON.stringify({
-                  execution_id: tool.id,
-                  tool_name: tool.toolName,
-                  keeper_turn: tool.keeperTurn,
-                  agent_subturn: tool.agentSubturn,
-                  duration_ms: tool.durationMs,
-                }, null, 2)}
-                htmlContent=${jsonHighlight({
-                  execution_id: tool.id,
-                  tool_name: tool.toolName,
-                  keeper_turn: tool.keeperTurn,
-                  agent_subturn: tool.agentSubturn,
-                  duration_ms: tool.durationMs,
-                })}
-                tokens=${approxTokens(JSON.stringify({ execution_id: tool.id }))}
-              />
-              <${CodeCard}
-                cap="응답 · result"
-                text="[도구 결과는 별도 execution trace 에서 확인]"
-                tokens=${approxTokens('[도구 결과는 별도 execution trace 에서 확인]')}
-              />
+              ${tool.matched
+                ? html`
+                  <${CodeCard}
+                    cap="요청 · input"
+                    text=${toolInputText(tool.input)}
+                    tokens=${approxTokens(toolInputText(tool.input))}
+                  />
+                  <${CodeCard}
+                    cap=${toolOutputMeta(tool.output) ? `응답 · result (${toolOutputMeta(tool.output)})` : '응답 · result'}
+                    text=${toolOutputText(tool.output)}
+                    tokens=${approxTokens(toolOutputText(tool.output))}
+                  />
+                `
+                : html`
+                  <div class="kti-msg-b kti-msg-absent" data-testid="turn-tool-io-absent">
+                    이 execution(${tool.id.slice(0, 24)})의 tool-call I/O를 tool-call 로그에서 찾지 못했습니다 (보존 윈도 밖이거나 미기록)
+                  </div>
+                `}
             </div>
           </div>
         `)}
-        <div class="kti-msg">
-          <div class="kti-msg-h">
-            <span class="kti-msg-role assistant">assistant</span>
-            <span class="who">${keeperName}</span>
-            <span class="seq">#${++seq}</span>
-          </div>
-          <div class="kti-msg-b">[keeper 응답 — 본 턴의 출력 메시지]</div>
-        </div>
+        ${assistantLines.length
+          ? assistantLines.map(line => html`<${KeeperLine} keeperName=${keeperName} line=${line} seq=${++seq} />`)
+          : html`<${KeeperLine} keeperName=${keeperName} line=${null} seq=${++seq} />`}
       </div>
     </div>
   `
@@ -916,6 +1031,22 @@ function TurnDetailDrawer({
 }) {
   const [tab, setTab] = useState('timeline')
   const t = buildTurnDetail(keeperName, row.record, toolEntries)
+
+  // RFC-0233 §7: lazily fetch this turn's transcript by its join key
+  // "<trace_id>#<absolute_turn>". Loaded per-open so the (potentially large)
+  // transcript never bloats the turn-records list.
+  const turnRef = `${row.record.trace_id}#${row.record.absolute_turn}`
+  const transcriptResource = useManagedAsyncResource<TurnTranscript | null>(null)
+  useEffect(() => {
+    void transcriptResource.load((signal) =>
+      fetchKeeperTurnTranscript(keeperName, turnRef, { signal }),
+    )
+    return () => {
+      transcriptResource.cancel()
+    }
+  }, [keeperName, turnRef, transcriptResource])
+
+  const transcript = toTranscriptView(transcriptResource.state.value)
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -1040,7 +1171,7 @@ function TurnDetailDrawer({
 
         <div class="kti-body">
           ${tab === 'timeline' && html`<${TimelineTab} t=${t} />`}
-          ${tab === 'messages' && html`<${MessagesTab} keeperName=${keeperName} t=${t} />`}
+          ${tab === 'messages' && html`<${MessagesTab} keeperName=${keeperName} t=${t} transcript=${transcript} />`}
           ${tab === 'context' && html`<${ContextTab} t=${t} />`}
           ${tab === 'meta' && html`<${MetaTab} record=${row.record} t=${t} source=${source} />`}
         </div>

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -989,3 +989,69 @@ let to_json_array ?base_dir (messages : chat_message list) : Yojson.Safe.t =
               @ opt_string_field "turn_ref"
                   (Option.map Ids.Turn_ref.to_string m.turn_ref)))
        messages)
+
+(* RFC-0233 §7: a turn's transcript derived by an exact join on the
+   persisted [turn_ref] ("<trace_id>#<absolute_turn>"). The inspector
+   needs the operator request that opened the turn and the keeper reply
+   it produced; both are stamped with the same turn_ref by
+   {!append_turn} on the dashboard reply path
+   (server_routes_http_keeper_stream.ml). Tool rows are excluded — they
+   carry only the call args, while the full tool I/O (input + output) is
+   surfaced by the tool-call store keyed on [execution_id]. *)
+type turn_transcript = {
+  user : chat_message list;
+  assistant : chat_message list;
+}
+
+let transcript_of_messages (messages : chat_message list) ~turn_ref :
+    turn_transcript =
+  let matches (m : chat_message) =
+    match m.turn_ref with
+    | Some tr -> Ids.Turn_ref.equal tr turn_ref
+    | None -> false
+  in
+  let user, assistant =
+    List.fold_left
+      (fun (user, assistant) (m : chat_message) ->
+        if not (matches m) then (user, assistant)
+        else
+          match m.role with
+          | Role.User -> (m :: user, assistant)
+          | Role.Assistant -> (user, m :: assistant)
+          (* Tool rows join via execution_id in the tool-call store, not
+             via the transcript. *)
+          | Role.Tool -> (user, assistant))
+      ([], []) messages
+  in
+  { user = List.rev user; assistant = List.rev assistant }
+
+let transcript_line_to_json (m : chat_message) : Yojson.Safe.t =
+  `Assoc
+    ([ ("role", `String (Role.to_label m.role));
+       ("content", `String m.content);
+     ]
+    @ (match m.ts with Some t -> [ ("ts", `Float t) ] | None -> [])
+      (* Surface the writer-declared kind so the inspector can tell a
+         transport failure apart from a real keeper utterance, exactly as
+         the chat history endpoint does — a failure marker is never quoted
+         back as the keeper's own words. *)
+    @ (match m.kind with
+       | Row_kind.Utterance -> []
+       | Row_kind.Transport_failure ->
+           [ ("kind", `String (Row_kind.to_label m.kind)) ]))
+
+let turn_transcript_to_json ~keeper ~turn_ref (t : turn_transcript) :
+    Yojson.Safe.t =
+  (* [found] is false when no persisted row carries this turn_ref (old
+     rows, rows outside the retained window, or a turn that produced no
+     chat lines). The caller renders explicit absence, never a fabricated
+     transcript. *)
+  let found = t.user <> [] || t.assistant <> [] in
+  `Assoc
+    [ ("keeper", `String keeper);
+      ("turn_ref", `String (Ids.Turn_ref.to_string turn_ref));
+      ("found", `Bool found);
+      ("source", `String "keeper_chat_store");
+      ("user", `List (List.map transcript_line_to_json t.user));
+      ("assistant", `List (List.map transcript_line_to_json t.assistant));
+    ]

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -273,3 +273,38 @@ val load_page :
     when present. When [base_dir] is supplied, the history endpoint marks
     audio clips as [expired] when the underlying MP3 file is gone. *)
 val to_json_array : ?base_dir:string -> chat_message list -> Yojson.Safe.t
+
+(** {1 Turn transcript (RFC-0233 §7)} *)
+
+(** A keeper turn's transcript, derived by an exact join on the persisted
+    [turn_ref]. [user] holds the operator request line(s) that opened the
+    turn; [assistant] holds the keeper response line(s) (utterance and
+    typed transport-failure markers). Tool rows are excluded — their full
+    I/O is surfaced by the tool-call store keyed on [execution_id]. Both
+    lists are empty when no persisted row carries the requested
+    [turn_ref] (old rows, redacted, or outside the retained window). *)
+type turn_transcript = {
+  user : chat_message list;
+  assistant : chat_message list;
+}
+
+val transcript_of_messages :
+  chat_message list -> turn_ref:Ids.Turn_ref.t -> turn_transcript
+(** [transcript_of_messages msgs ~turn_ref] partitions the rows whose
+    persisted [turn_ref] equals [turn_ref] into operator [user] lines and
+    keeper [assistant] lines, preserving input order. A row with a
+    different or absent [turn_ref] is excluded — exact-key join only, no
+    timestamp-window fuzzing (RFC-0233 §7 "no fuzzy attribution"). Pass
+    {!load}-produced messages so the content is already the redacted view
+    (RFC-0132); this function does not re-redact. *)
+
+val turn_transcript_to_json :
+  keeper:string ->
+  turn_ref:Ids.Turn_ref.t ->
+  turn_transcript ->
+  Yojson.Safe.t
+(** [turn_transcript_to_json ~keeper ~turn_ref t] renders the dashboard
+    turn-transcript payload: [keeper], [turn_ref], [found] (false when
+    both line lists are empty), [source], and the [user]/[assistant]
+    line arrays. Each line carries [role]/[content]/[ts] and, for
+    non-utterance assistant rows, the writer-declared [kind]. *)

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -599,6 +599,50 @@ let handle_keeper_get_subroutes state req request reqd =
         ("entries", `List entries);
       ] in
       Http.Response.json_value ~compress:true ~request:req json reqd
+  else if ends_with "/turn-transcript" then
+    (* RFC-0233 §7: serve one keeper turn's operator request + keeper
+       response by an exact join on the persisted chat row turn_ref
+       ("<trace_id>#<absolute_turn>"). Lazily fetched by the turn
+       inspector so the transcript (which can be large) never bloats the
+       turn-records list. Content is the load-time redacted view the chat
+       history endpoint already serves (RFC-0132); an unmatched turn_ref
+       returns [found:false] rather than a fabricated transcript. *)
+    let name = extract_name "/turn-transcript" in
+    if String.length name = 0 then
+      respond_error reqd "keeper name is required"
+    else if not (Keeper_config.validate_name name) then
+      Http.Response.json_value ~status:`Bad_request
+        (`Assoc
+           [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])
+        reqd
+    else (
+      match Server_utils.query_param req "turn_ref" with
+      | None ->
+        Http.Response.json_value ~status:`Bad_request
+          (`Assoc
+             [("error", `String "turn_ref query parameter is required")])
+          reqd
+      | Some turn_ref_str ->
+        (match Ids.Turn_ref.of_string turn_ref_str with
+         | None ->
+           Http.Response.json_value ~status:`Bad_request
+             (`Assoc
+                [ ( "error",
+                    `String
+                      (Printf.sprintf "invalid turn_ref: %s" turn_ref_str) )
+                ])
+             reqd
+         | Some turn_ref ->
+           let base_dir = (Mcp_server.workspace_config state).base_path in
+           let messages = Keeper_chat_store.load ~base_dir ~keeper_name:name in
+           let transcript =
+             Keeper_chat_store.transcript_of_messages messages ~turn_ref
+           in
+           let json =
+             Keeper_chat_store.turn_transcript_to_json ~keeper:name ~turn_ref
+               transcript
+           in
+           Http.Response.json_value ~compress:true ~request:req json reqd))
   else if ends_with "/trajectory" then
     let name = extract_name "/trajectory" in
     if String.length name = 0 then

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -1148,6 +1148,76 @@ let test_turn_ref_malformed_reads_none () =
       | messages ->
           Alcotest.failf "expected 1 message, got %d" (List.length messages))
 
+(* RFC-0233 §7: transcript_of_messages joins persisted rows on the exact
+   turn_ref, partitions operator/keeper lines, and excludes rows of other
+   turns. turn_transcript_to_json reports found=true and surfaces the
+   content. *)
+let test_transcript_of_messages_joins_turn_ref () =
+  let base_dir = temp_base_path "keeper-chat-store-transcript" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-transcript" in
+      let tref_a = Ids.Turn_ref.make ~trace_id:"trace-xyz" ~absolute_turn:3 in
+      let tref_b = Ids.Turn_ref.make ~trace_id:"trace-xyz" ~absolute_turn:4 in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"request A"
+        ~user_attachments:[] ~turn_ref:tref_a ~assistant_content:"reply A" ();
+      K.append_turn ~base_dir ~keeper_name ~user_content:"request B"
+        ~user_attachments:[] ~turn_ref:tref_b ~assistant_content:"reply B" ();
+      let messages = K.load ~base_dir ~keeper_name in
+      let t = K.transcript_of_messages messages ~turn_ref:tref_a in
+      (match t.user with
+       | [ m ] ->
+           Alcotest.(check string) "operator request content" "request A"
+             m.content
+       | other ->
+           Alcotest.failf "expected 1 user line, got %d" (List.length other));
+      (match t.assistant with
+       | [ m ] ->
+           Alcotest.(check string) "keeper reply content" "reply A" m.content
+       | other ->
+           Alcotest.failf "expected 1 assistant line, got %d"
+             (List.length other));
+      (* Turn B's rows must not leak into turn A's transcript. *)
+      List.iter
+        (fun (m : K.chat_message) ->
+          Alcotest.(check bool)
+            "no turn-B content in turn-A transcript" false
+            (contains_substring m.content "B"))
+        (t.user @ t.assistant);
+      let json =
+        K.turn_transcript_to_json ~keeper:keeper_name ~turn_ref:tref_a t
+      in
+      let s = Yojson.Safe.to_string json in
+      Alcotest.(check bool) "found=true when rows present" true
+        (contains_substring s "\"found\":true");
+      Alcotest.(check bool) "turn_ref echoed" true
+        (contains_substring s "trace-xyz#3"))
+
+(* An unmatched turn_ref yields empty lists and found=false — explicit
+   absence, never a fabricated transcript. *)
+let test_transcript_absent_returns_empty () =
+  let base_dir = temp_base_path "keeper-chat-store-transcript-absent" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-transcript-absent" in
+      let tref = Ids.Turn_ref.make ~trace_id:"trace-present" ~absolute_turn:1 in
+      K.append_turn ~base_dir ~keeper_name ~user_content:"hi"
+        ~user_attachments:[] ~turn_ref:tref ~assistant_content:"hello" ();
+      let messages = K.load ~base_dir ~keeper_name in
+      let missing =
+        Ids.Turn_ref.make ~trace_id:"trace-absent" ~absolute_turn:99
+      in
+      let t = K.transcript_of_messages messages ~turn_ref:missing in
+      Alcotest.(check int) "no user lines" 0 (List.length t.user);
+      Alcotest.(check int) "no assistant lines" 0 (List.length t.assistant);
+      let json =
+        K.turn_transcript_to_json ~keeper:keeper_name ~turn_ref:missing t
+      in
+      Alcotest.(check bool) "found=false when no rows match" true
+        (contains_substring (Yojson.Safe.to_string json) "\"found\":false"))
+
 let () =
   Alcotest.run "keeper_chat_store"
     [
@@ -1241,5 +1311,11 @@ let () =
             `Quick test_turn_ref_persisted_on_turn_rows;
           Alcotest.test_case "malformed turn_ref reads as None (RFC-0233 §7)"
             `Quick test_turn_ref_malformed_reads_none;
+          Alcotest.test_case
+            "transcript_of_messages joins turn_ref (RFC-0233 §7)" `Quick
+            test_transcript_of_messages_joins_turn_ref;
+          Alcotest.test_case
+            "transcript absent returns empty + found=false (RFC-0233 §7)"
+            `Quick test_transcript_absent_returns_empty;
         ] );
     ]


### PR DESCRIPTION
## 요약

Turn Inspector(`dashboard/src/components/keeper-turn-inspector.ts`)의 "메시지" 탭이
지금까지 placeholder 만 보여주던 두 영역을 실제 MASC 저장 데이터로 채웁니다.

- **transcript**: operator 요청 + keeper 응답 텍스트 (`[직전 operator 요청 …]`,
  `[keeper 응답 …]` placeholder 제거)
- **tool call I/O**: 실제 입력 args + 출력 result (`[도구 결과는 별도 execution
  trace 에서 확인]` placeholder 제거, 복사 가능)

이는 PR #21880(`feat/turn-record-meta-grounding`, model/finish 그라운딩)에서
명시적으로 deferred 했던 KEEPER-V2 P2 두 항목의 후속 작업입니다.

## Stacked vs Independent — Independent (base: `main`)

PR #21880 은 이미 `main` 에 머지되었습니다 (`gh pr view 21880 --json state` →
`MERGED`, 2026-06-21 03:02 UTC, squash 커밋 `61c7621`). 따라서 stack 대상이
없으며, 본 PR 은 **`origin/main` 에서 독립 분기**합니다. transcript 는 크고
턴마다 lazy-load 가 적합하므로 turn-records 리스트 payload 를 부풀리지 않도록
별도 엔드포인트로 분리했습니다 (lead 가 제안한 선호안과 일치).

## 데이터 소스

| 영역 | 소스 | 조인 키 |
|------|------|---------|
| transcript | `Keeper_chat_store.load` (이미 redaction 적용) | `turn_ref` = `"<trace_id>#<absolute_turn>"` (RFC-0233 §7) |
| tool call I/O | 기존 `/tool-calls` 엔드포인트의 `ToolCallEntry.input`/`output` | `execution_id` (RFC-0233 §1.1) |

- **tool I/O 는 프론트엔드 전용 변경**: 데이터(`input`/`output`)는 이미
  `/tool-calls` 로 서빙되어 inspector 가 `execution_id` 로 인덱싱 중이었습니다.
  렌더만 placeholder → 실제 값으로 교체했습니다. 새 엔드포인트 불필요.
- **transcript 는 신규 lazy 엔드포인트**:
  `GET /api/v1/keepers/:name/turn-transcript?turn_ref=<...>`.
  서버가 `turn_ref` 정확 조인으로 operator(user)/keeper(assistant) 라인을
  분리해 반환합니다. dashboard 의 일반 chat 경로(`append_turn`)는 user·assistant
  라인을 같은 `turn_ref` 로 동시에 기록하므로 조인이 성립합니다.

## NO FABRICATION / 부재 처리

- transcript 조인 미스(구 row, redacted, 보존 윈도 밖) → `found:false` + 빈
  배열, UI 는 명시적 부재 문구(`turn-transcript-user-absent` 등) 렌더. 30분
  timestamp window 같은 fuzzy 귀속 없음 (RFC-0233 §7 "no fuzzy attribution").
- tool I/O 가 `execution_id` 로 매칭되지 않으면 `turn-tool-io-absent` 부재
  문구 렌더, 가짜 result 미생성.
- transport_failure assistant row 는 `kind` 로 구분해 별도 라벨링(키퍼의
  발화로 인용하지 않음).

## Redaction (RFC-0132)

- transcript content 는 `Keeper_chat_store.load` 가 반환하는 **load-time
  redacted view** 그대로이며, 이는 기존 `/chat/history` 엔드포인트가 이미
  대시보드에 서빙하는 동일 뷰입니다. 새 누출 경로 없음. 신규 pure 함수
  `transcript_of_messages` 는 재-redaction 하지 않고 `load` 출력만 받습니다.
- tool I/O 의 `input`/`output` 은 `keeper_tool_call_log` 가 write 시점에 model
  라벨을 neutral runtime 으로 redact 한 값으로, 기존 tool-call inspector 가
  쓰는 동일 뷰입니다.

## 변경 파일

- `lib/keeper/keeper_chat_store.{ml,mli}` — pure `transcript_of_messages` +
  `turn_transcript_to_json` (RFC-0233 §7 turn_ref 조인)
- `lib/server/server_dashboard_http_keeper_api.ml` — `/turn-transcript` 라우트
- `dashboard/src/api/dashboard.ts` — `TurnTranscript` 타입 + 디코더 +
  `fetchKeeperTurnTranscript`
- `dashboard/src/components/keeper-turn-inspector.ts` — 실제 tool I/O + transcript
  렌더, lazy fetch, 부재 상태
- 테스트: `test/test_keeper_chat_store.ml` (OCaml 조인/부재 라운드트립),
  `dashboard/src/api/dashboard.test.ts` (디코드 + turn_ref 인코딩),
  `dashboard/src/components/keeper-turn-inspector.test.ts` (실제 I/O·transcript
  vs 부재 렌더)

## 빌드 / 테스트 결과

- `dune build --root . test/test_keeper_chat_store.exe` → exit 0
- `dune exec --root . test/test_keeper_chat_store.exe` → 37 tests, 신규 2건 포함
  35건 통과. **사전 존재 실패 1건**: `test_direct_owner_context_excludes_connector_turns`
  (#8) — standalone `dune exec` 시 "No Eio fs context → Memory backend" 환경
  문제. 본 변경(순수 additive) 적용 전 clean base 에서도 동일 실패 확인(35
  tests, 동일 assertion). 본 PR 과 무관.
- `cd dashboard && pnpm run typecheck` → exit 0
- `npx eslint` (touched files) → 0 errors
- `npx vitest run` (touched files) → 2 files, 75 tests passed

## RFC

RFC-0233 (Typed turn observability) — §7 "`Turn_ref`: chat ↔ board turn-identity
reference" 가 정확히 이 조인(turn_ref → chat)을 가능케 하는 메커니즘입니다.
§2.3 "Views derive; no view-side repair" 원칙에 따라 조인은 서버에서 수행하고
UI 는 렌더만 합니다. RFC-0132 (Redaction SSOT) 준수: 동일 redacted view 서빙.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
