### PR TITLE
test(keeper): update gc-writer-lock test for P5 cap expiry (follow-up #21895)

### DIFF
--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1691,8 +1691,17 @@ let test_gc_waits_for_fact_writer_lock () =
       | Some report -> report
       | None -> Alcotest.fail "expected GC to finish after writer releases lock"
     in
-    Alcotest.(check int) "gc sees writer's committed fact" 2 report.GC.total_input;
-    Alcotest.(check int) "gc drops only the expired fact" 1 report.ttl_expired;
+    (* RFC-0259 §3.6 (P5): the writer's merge_and_cap now drops the expired row
+       on the same valid_until boundary GC uses, so by the time GC runs the
+       expired fact is already reclaimed — GC reads only the fresh fact and finds
+       nothing to expire. The lock-ordering assertion above (GC waits for the
+       writer's lock) is this test's subject; GC-drops-expired on an untouched
+       store is covered by test_gc_dry_run_and_rewrite. *)
+    Alcotest.(check int) "gc sees only the writer's committed fact" 1 report.GC.total_input;
+    Alcotest.(check int)
+      "writer's cap already reclaimed the expired fact"
+      0
+      report.ttl_expired;
     let survivors = Memory_io.read_facts_all ~keeper_id in
     Alcotest.(check int) "fresh fact survives GC" 1 (List.length survivors);
     Alcotest.(check bool)


### PR DESCRIPTION
Follow-up to #21895 (RFC-0259 P5). That PR made `merge_and_cap_facts` drop `valid_until`-expired rows on the write path; `test_gc_waits_for_fact_writer_lock` predated P5 and asserted GC still sees + drops the expired fact. Post-P5 the writer cap reclaims it, so GC sees only the fresh fact.

The test is **advisory** (continue-on-error), so #21895 merged green despite the stale assertions — this is the fix-forward (the merged branch cannot be pushed to; masc#5303).

- `total_input` 2 -> 1, `ttl_expired` 1 -> 0; lock-ordering subject unchanged.
- GC-drops-expired on an untouched store stays covered by `test_gc_dry_run_and_rewrite`.

Verified locally: `dune exec test/test_keeper_memory_os.exe` -> **89 tests run, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)