### PR TITLE
fix(keeper): replay in-flight event queue stimuli after crash

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -186,6 +186,7 @@ let run_keepalive_unified_turn
   then { meta = meta_after_triage; cycle_crashed = false }
   else (
     let consumed_stimuli = ref [] in
+    let consumed_stimuli_turn_completed = ref false in
     try
       let event_intake =
         heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events
@@ -393,22 +394,36 @@ let run_keepalive_unified_turn
           meta_after_triage)
         else if should_run_turn
         then (
-          run_keeper_cycle
-            ~ctx
-            ~meta_after_triage
-            ~stop
-            ~obs
-            ~turn_decision
-            ~shared_context
-            ())
+          let meta_after_cycle =
+            run_keeper_cycle
+              ~ctx
+              ~meta_after_triage
+              ~stop
+              ~obs
+              ~turn_decision
+              ~shared_context
+              ()
+          in
+          consumed_stimuli_turn_completed := true;
+          meta_after_cycle)
         else meta_after_triage
       in
+      (* Event intake dequeues before the admission/pressure gates above.
+         Only ack after [run_keeper_cycle] actually returns; otherwise put the
+         lease back so a non-exception skip does not drop the stimulus. *)
       if !consumed_stimuli <> []
       then
-        Keeper_registry_event_queue.ack_consumed
-          ~base_path:ctx.config.base_path
-          meta_after_triage.name
-          !consumed_stimuli;
+        if !consumed_stimuli_turn_completed
+        then
+          Keeper_registry_event_queue.ack_consumed
+            ~base_path:ctx.config.base_path
+            meta_after_triage.name
+            !consumed_stimuli
+        else
+          Keeper_registry_event_queue.requeue_front
+            ~base_path:ctx.config.base_path
+            meta_after_triage.name
+            !consumed_stimuli;
       { meta = meta_after_cycle; cycle_crashed = false }
     with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -52,6 +52,7 @@ let record_recovery_stimulus_turn_started =
 type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
+  consumed_stimuli : Keeper_event_queue.stimulus list;
 }
 
 let consume_single_heartbeat_stimulus = Stimulus_intake.consume_single_heartbeat_stimulus
@@ -184,10 +185,12 @@ let run_keepalive_unified_turn
   if not proactive_warmup_elapsed
   then { meta = meta_after_triage; cycle_crashed = false }
   else (
+    let consumed_stimuli = ref [] in
     try
       let event_intake =
         heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events
       in
+      consumed_stimuli := event_intake.consumed_stimuli;
       let pending_board_events = event_intake.pending_board_events in
       let obs =
         Keeper_world_observation.observe
@@ -400,11 +403,20 @@ let run_keepalive_unified_turn
             ())
         else meta_after_triage
       in
+      if !consumed_stimuli <> []
+      then
+        Keeper_registry_event_queue.ack_consumed
+          ~base_path:ctx.config.base_path
+          meta_after_triage.name;
       { meta = meta_after_cycle; cycle_crashed = false }
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
     | Keeper_registry.Keeper_fiber_crash as e -> raise e
     | exn ->
+      Keeper_registry_event_queue.requeue_front
+        ~base_path:ctx.config.base_path
+        meta_after_triage.name
+        !consumed_stimuli;
       (* T6 audit: keep the fiber alive, but surface the crash as a
          turn failure so the caller does not dispatch
          [Turn_succeeded] for a cycle that never completed. *)

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -407,7 +407,8 @@ let run_keepalive_unified_turn
       then
         Keeper_registry_event_queue.ack_consumed
           ~base_path:ctx.config.base_path
-          meta_after_triage.name;
+          meta_after_triage.name
+          !consumed_stimuli;
       { meta = meta_after_cycle; cycle_crashed = false }
     with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -51,6 +51,7 @@ val with_in_turn_liveness_pulse :
 type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
+  consumed_stimuli : Keeper_event_queue.stimulus list;
 }
 
 val heartbeat_event_intake :

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -54,6 +54,7 @@ let record_recovery_stimulus_turn_started
 type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
+  consumed_stimuli : Keeper_event_queue.stimulus list;
 }
 
 let consume_single_heartbeat_stimulus
@@ -136,7 +137,7 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
       ~base_path:ctx.config.base_path
       meta_after_triage.name
   in
-  let queued_observations, consumed_stimulus_count =
+  let queued_observations, consumed_stimuli =
     match board_batch with
     | [] ->
       (match
@@ -144,10 +145,11 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
            ~base_path:ctx.config.base_path
            meta_after_triage.name
        with
-       | None -> [], 0
-       | Some stim -> consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim, 1)
-    | batch -> consume_board_stimulus_batch ~meta_after_triage batch, List.length batch
+       | None -> [], []
+       | Some stim -> consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim, [ stim ])
+    | batch -> consume_board_stimulus_batch ~meta_after_triage batch, batch
   in
+  let consumed_stimulus_count = List.length consumed_stimuli in
   let pending_board_events =
     List.fold_left
       (fun acc (event : Keeper_world_observation.pending_board_event) ->
@@ -168,5 +170,5 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
       pending_board_events
       (List.rev queued_observations)
   in
-  { pending_board_events; consumed_stimulus_count }
+  { pending_board_events; consumed_stimulus_count; consumed_stimuli }
 ;;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -35,6 +35,7 @@ val record_recovery_stimulus_turn_started
 type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
+  consumed_stimuli : Keeper_event_queue.stimulus list;
 }
 
 (** [consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim]

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -18,6 +18,13 @@ let enqueue_if_missing queue stimulus =
   if queue_contains queue stimulus then queue else Keeper_event_queue.enqueue queue stimulus
 ;;
 
+let requeue_missing_front queue stimuli =
+  let missing =
+    List.filter (fun stimulus -> not (queue_contains queue stimulus)) stimuli
+  in
+  Keeper_event_queue.prepend_list missing queue
+;;
+
 let persist_live_queue ~base_path (entry : Keeper_registry.registry_entry) name =
   Keeper_event_queue_persistence.persist_snapshot
     ~base_path
@@ -60,6 +67,36 @@ let enqueue ~base_path name stimulus =
     loop ()
 ;;
 
+let requeue_front ~base_path name stimuli =
+  match stimuli with
+  | [] -> ()
+  | _ ->
+    (match Keeper_registry.get ~base_path name with
+     | None ->
+       Keeper_event_queue_persistence.update
+         ~base_path
+         ~keeper_name:name
+         (fun cur -> requeue_missing_front cur stimuli);
+       Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name
+     | Some entry ->
+       let rec loop () =
+         let cur = Atomic.get entry.event_queue in
+         let next = requeue_missing_front cur stimuli in
+         if next = cur
+         then ()
+         else if Atomic.compare_and_set entry.event_queue cur next
+         then (
+           persist_live_queue ~base_path entry name;
+           Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name)
+         else loop ()
+       in
+       loop ())
+;;
+
+let ack_consumed ~base_path name =
+  Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name
+;;
+
 let snapshot ~base_path name =
   match Keeper_registry.get ~base_path name with
   | None -> Keeper_event_queue_persistence.load ~base_path ~keeper_name:name
@@ -75,6 +112,10 @@ let dequeue ~base_path name =
       match Keeper_event_queue.dequeue cur with
       | None -> None
       | Some (stim, rest) ->
+        Keeper_event_queue_persistence.record_inflight
+          ~base_path
+          ~keeper_name:name
+          [ stim ];
         if Atomic.compare_and_set entry.event_queue cur rest
         then (
           persist_live_queue ~base_path entry name;
@@ -91,6 +132,10 @@ let drain_board ?window_sec ~base_path name =
     let rec loop () =
       let cur = Atomic.get entry.event_queue in
       let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
+      Keeper_event_queue_persistence.record_inflight
+        ~base_path
+        ~keeper_name:name
+        board;
       if Atomic.compare_and_set entry.event_queue cur rest
       then (
         persist_live_queue ~base_path entry name;

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -112,12 +112,12 @@ let dequeue ~base_path name =
       match Keeper_event_queue.dequeue cur with
       | None -> None
       | Some (stim, rest) ->
-        Keeper_event_queue_persistence.record_inflight
-          ~base_path
-          ~keeper_name:name
-          [ stim ];
         if Atomic.compare_and_set entry.event_queue cur rest
         then (
+          Keeper_event_queue_persistence.record_inflight
+            ~base_path
+            ~keeper_name:name
+            [ stim ];
           persist_live_queue ~base_path entry name;
           Some stim)
         else loop ()
@@ -132,12 +132,9 @@ let drain_board ?window_sec ~base_path name =
     let rec loop () =
       let cur = Atomic.get entry.event_queue in
       let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
-      Keeper_event_queue_persistence.record_inflight
-        ~base_path
-        ~keeper_name:name
-        board;
       if Atomic.compare_and_set entry.event_queue cur rest
       then (
+        Keeper_event_queue_persistence.record_inflight ~base_path ~keeper_name:name board;
         persist_live_queue ~base_path entry name;
         board)
       else loop ()

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -77,24 +77,24 @@ let requeue_front ~base_path name stimuli =
          ~base_path
          ~keeper_name:name
          (fun cur -> requeue_missing_front cur stimuli);
-       Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name
+       Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name stimuli
      | Some entry ->
        let rec loop () =
          let cur = Atomic.get entry.event_queue in
          let next = requeue_missing_front cur stimuli in
          if next = cur
-         then ()
+         then Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name stimuli
          else if Atomic.compare_and_set entry.event_queue cur next
          then (
            persist_live_queue ~base_path entry name;
-           Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name)
+           Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name stimuli)
          else loop ()
        in
        loop ())
 ;;
 
-let ack_consumed ~base_path name =
-  Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name
+let ack_consumed ~base_path name stimuli =
+  Keeper_event_queue_persistence.ack_inflight ~base_path ~keeper_name:name stimuli
 ;;
 
 let snapshot ~base_path name =
@@ -112,12 +112,12 @@ let dequeue ~base_path name =
       match Keeper_event_queue.dequeue cur with
       | None -> None
       | Some (stim, rest) ->
+        Keeper_event_queue_persistence.record_inflight
+          ~base_path
+          ~keeper_name:name
+          [ stim ];
         if Atomic.compare_and_set entry.event_queue cur rest
         then (
-          Keeper_event_queue_persistence.record_inflight
-            ~base_path
-            ~keeper_name:name
-            [ stim ];
           persist_live_queue ~base_path entry name;
           Some stim)
         else loop ()
@@ -132,9 +132,9 @@ let drain_board ?window_sec ~base_path name =
     let rec loop () =
       let cur = Atomic.get entry.event_queue in
       let board, rest = Keeper_event_queue.drain_board_window ?window_sec cur in
+      Keeper_event_queue_persistence.record_inflight ~base_path ~keeper_name:name board;
       if Atomic.compare_and_set entry.event_queue cur rest
       then (
-        Keeper_event_queue_persistence.record_inflight ~base_path ~keeper_name:name board;
         persist_live_queue ~base_path entry name;
         board)
       else loop ()

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -26,10 +26,10 @@ val dequeue : base_path:string -> string -> Keeper_event_queue.stimulus option
     but before the turn completes, the stimuli must remain replayable. *)
 val requeue_front : base_path:string -> string -> Keeper_event_queue.stimulus list -> unit
 
-val ack_consumed : base_path:string -> string -> unit
-(** Acknowledge the current in-flight lease after a keepalive turn completes.
-    Until this runs, a restart reloads the leased stimuli for at-least-once
-    replay. *)
+val ack_consumed :
+  base_path:string -> string -> Keeper_event_queue.stimulus list -> unit
+(** Acknowledge consumed stimuli after a keepalive turn completes. Until this
+    runs, a restart reloads the leased stimuli for at-least-once replay. *)
 
 (** Drain stimuli intended for board reactivity. [window_sec] caps the
     age of stimuli returned to the caller. *)

--- a/lib/keeper/keeper_registry_event_queue.mli
+++ b/lib/keeper/keeper_registry_event_queue.mli
@@ -21,6 +21,16 @@ val snapshot : base_path:string -> string -> Keeper_event_queue.t
     empty or the keeper is unregistered. *)
 val dequeue : base_path:string -> string -> Keeper_event_queue.stimulus option
 
+(** Put previously drained stimuli back at the front of the queue. This is a
+    crash-recovery primitive: if the keepalive cycle dies after dequeue/drain
+    but before the turn completes, the stimuli must remain replayable. *)
+val requeue_front : base_path:string -> string -> Keeper_event_queue.stimulus list -> unit
+
+val ack_consumed : base_path:string -> string -> unit
+(** Acknowledge the current in-flight lease after a keepalive turn completes.
+    Until this runs, a restart reloads the leased stimuli for at-least-once
+    replay. *)
+
 (** Drain stimuli intended for board reactivity. [window_sec] caps the
     age of stimuli returned to the caller. *)
 val drain_board :

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -83,6 +83,15 @@ let dequeue (queue : t) : (stimulus * t) option =
      | [] -> None
      | s :: rest -> Some (s, { front = rest; back_rev = []; length = queue.length - 1 }))
 
+let prepend_list stimuli queue =
+  match stimuli with
+  | [] -> queue
+  | _ ->
+    { front = stimuli @ to_list queue
+    ; back_rev = []
+    ; length = queue.length + List.length stimuli
+    }
+
 let dedup_by_post_id ?(window_seconds = 60.0) (queue : t) : t =
   let within_window a b =
     Float.abs (a.arrived_at -. b.arrived_at) <= window_seconds

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -98,10 +98,19 @@ val is_empty : t -> bool
 val enqueue : t -> stimulus -> t
 (** [enqueue q s] appends [s] to the back of [q] in O(1). Always succeeds. *)
 
+val to_list : t -> stimulus list
+(** Return the FIFO contents. *)
+
 val dequeue : t -> (stimulus * t) option
 (** [dequeue q] removes and returns the front of [q], or [None] when
     empty. The Policy Layer must call this at the start of every
     [emit] turn to honour the KeeperEventQueue [TurnDequeue] action. *)
+
+val prepend_list : stimulus list -> t -> t
+(** [prepend_list stimuli q] puts [stimuli] back at the front of [q] while
+    preserving [stimuli]'s order. Used when a keepalive cycle crashes after
+    draining stimuli but before completing the turn, so restart/retry keeps an
+    at-least-once replay boundary. *)
 
 val dedup_by_post_id : ?window_seconds:float -> t -> t
 (** Drops later duplicates of the same [post_id] when their

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -38,6 +38,33 @@ let snapshot_path ~base_path ~keeper_name =
          "event-queue.json")
   else Error (Printf.sprintf "invalid keeper name for event queue snapshot: %s" keeper_name)
 
+let inflight_path ~base_path ~keeper_name =
+  if valid_keeper_name keeper_name
+  then
+    Ok
+      (Filename.concat
+         (Filename.concat (Common.keepers_runtime_dir_of_base ~base_path) keeper_name)
+         "event-queue-inflight.json")
+  else Error (Printf.sprintf "invalid keeper name for event queue inflight: %s" keeper_name)
+
+let rec queue_contains queue stimulus =
+  match Keeper_event_queue.dequeue queue with
+  | None -> false
+  | Some (head, rest) -> head = stimulus || queue_contains rest stimulus
+
+let append_missing queue stimuli =
+  List.fold_left
+    (fun acc stimulus ->
+       if queue_contains acc stimulus then acc else Keeper_event_queue.enqueue acc stimulus)
+    queue
+    stimuli
+
+let prepend_missing queue stimuli =
+  let missing =
+    List.filter (fun stimulus -> not (queue_contains queue stimulus)) stimuli
+  in
+  Keeper_event_queue.prepend_list missing queue
+
 let load_from_path ~keeper_name path =
   if not (Sys.file_exists path)
   then Keeper_event_queue.empty
@@ -69,11 +96,14 @@ let load_from_path ~keeper_name path =
          queue))
 
 let load ~base_path ~keeper_name =
-  match snapshot_path ~base_path ~keeper_name with
-  | Error msg ->
+  match snapshot_path ~base_path ~keeper_name, inflight_path ~base_path ~keeper_name with
+  | Error msg, _ | _, Error msg ->
     Log.Keeper.warn "event_queue_snapshot: %s" msg;
     Keeper_event_queue.empty
-  | Ok path -> load_from_path ~keeper_name path
+  | Ok pending_path, Ok inflight_path ->
+    let pending = load_from_path ~keeper_name pending_path in
+    let inflight = load_from_path ~keeper_name inflight_path in
+    prepend_missing pending (Keeper_event_queue.to_list inflight)
 
 let persist_to_path ~keeper_name path queue =
   match save_json_atomic path (Keeper_event_queue.queue_to_yojson queue) with
@@ -128,6 +158,42 @@ let update ~base_path ~keeper_name f =
      | exn ->
        Log.Keeper.warn
          "event_queue_snapshot: update raised keeper=%s path=%s: %s"
+         keeper_name
+         path
+         (Printexc.to_string exn))
+
+let record_inflight ~base_path ~keeper_name stimuli =
+  match stimuli with
+  | [] -> ()
+  | _ -> (
+  match inflight_path ~base_path ~keeper_name with
+  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
+  | Ok path ->
+    (try
+       with_write_lock (fun () ->
+         let cur = load_from_path ~keeper_name path in
+         persist_to_path ~keeper_name path (append_missing cur stimuli))
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Keeper.warn
+         "event_queue_snapshot: record_inflight raised keeper=%s path=%s: %s"
+         keeper_name
+         path
+         (Printexc.to_string exn)))
+
+let ack_inflight ~base_path ~keeper_name =
+  match inflight_path ~base_path ~keeper_name with
+  | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
+  | Ok path ->
+    (try
+       with_write_lock (fun () ->
+         persist_to_path ~keeper_name path Keeper_event_queue.empty)
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Log.Keeper.warn
+         "event_queue_snapshot: ack_inflight raised keeper=%s path=%s: %s"
          keeper_name
          path
          (Printexc.to_string exn))

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -65,6 +65,16 @@ let prepend_missing queue stimuli =
   in
   Keeper_event_queue.prepend_list missing queue
 
+let remove_stimuli queue stimuli =
+  match stimuli with
+  | [] -> queue
+  | _ ->
+    let remove stimulus = List.exists (fun target -> target = stimulus) stimuli in
+    queue
+    |> Keeper_event_queue.to_list
+    |> List.filter (fun stimulus -> not (remove stimulus))
+    |> Keeper_event_queue.of_list
+
 let load_from_path ~keeper_name path =
   if not (Sys.file_exists path)
   then Keeper_event_queue.empty
@@ -182,13 +192,17 @@ let record_inflight ~base_path ~keeper_name stimuli =
          path
          (Printexc.to_string exn)))
 
-let ack_inflight ~base_path ~keeper_name =
+let ack_inflight ~base_path ~keeper_name stimuli =
+  match stimuli with
+  | [] -> ()
+  | _ -> (
   match inflight_path ~base_path ~keeper_name with
   | Error msg -> Log.Keeper.warn "event_queue_snapshot: %s" msg
   | Ok path ->
     (try
        with_write_lock (fun () ->
-         persist_to_path ~keeper_name path Keeper_event_queue.empty)
+         let cur = load_from_path ~keeper_name path in
+         persist_to_path ~keeper_name path (remove_stimuli cur stimuli))
      with
      | Eio.Cancel.Cancelled _ as exn -> raise exn
      | exn ->
@@ -196,4 +210,4 @@ let ack_inflight ~base_path ~keeper_name =
          "event_queue_snapshot: ack_inflight raised keeper=%s path=%s: %s"
          keeper_name
          path
-         (Printexc.to_string exn))
+         (Printexc.to_string exn)))

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -65,6 +65,9 @@ let prepend_missing queue stimuli =
   in
   Keeper_event_queue.prepend_list missing queue
 
+let queue_of_list stimuli =
+  List.fold_left Keeper_event_queue.enqueue Keeper_event_queue.empty stimuli
+
 let remove_stimuli queue stimuli =
   match stimuli with
   | [] -> queue
@@ -73,7 +76,7 @@ let remove_stimuli queue stimuli =
     queue
     |> Keeper_event_queue.to_list
     |> List.filter (fun stimulus -> not (remove stimulus))
-    |> Keeper_event_queue.of_list
+    |> queue_of_list
 
 let load_from_path ~keeper_name path =
   if not (Sys.file_exists path)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -30,8 +30,11 @@ val record_inflight :
   base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit
 (** Mark drained stimuli as in-flight before they are removed from the pending
     snapshot. [load] merges these rows back in front of pending rows, giving a
-    restart at-least-once replay boundary until {!ack_inflight} clears them. *)
+    restart at-least-once replay boundary until {!ack_inflight} acknowledges
+    them. *)
 
-val ack_inflight : base_path:string -> keeper_name:string -> unit
-(** Clear the in-flight lease file after the heartbeat turn has completed or
-    after the stimuli have been requeued into the pending snapshot. *)
+val ack_inflight :
+  base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit
+(** Remove acknowledged stimuli from the in-flight lease after the heartbeat
+    turn has completed or after those stimuli have been requeued into the
+    pending snapshot. *)

--- a/lib/keeper_runtime/keeper_event_queue_persistence.mli
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.mli
@@ -25,3 +25,13 @@ val persist_snapshot :
 (** Evaluate [snapshot] while holding the persistence write lock, then atomically
     write it. Use this after live registry CAS mutations so an older writer
     cannot overwrite a newer live queue snapshot after waiting on the file lock. *)
+
+val record_inflight :
+  base_path:string -> keeper_name:string -> Keeper_event_queue.stimulus list -> unit
+(** Mark drained stimuli as in-flight before they are removed from the pending
+    snapshot. [load] merges these rows back in front of pending rows, giving a
+    restart at-least-once replay boundary until {!ack_inflight} clears them. *)
+
+val ack_inflight : base_path:string -> keeper_name:string -> unit
+(** Clear the in-flight lease file after the heartbeat turn has completed or
+    after the stimuli have been requeued into the pending snapshot. *)

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -244,6 +244,7 @@ let () =
         | None -> Alcotest.fail "registry reload should replay pending stimulus"
       in
       assert (String.equal replayed.post_id "p1");
+      Masc.Keeper_registry_event_queue.ack_consumed ~base_path keeper_name;
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
   (* --- registry unavailable window: enqueue persists before register --- *)
@@ -278,6 +279,57 @@ let () =
           Alcotest.fail "late registry registration should replay second pre-registered stimulus"
       in
       assert (String.equal second.post_id "bootstrap");
+      Masc.Keeper_registry_event_queue.ack_consumed ~base_path keeper_name;
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
+
+  (* --- crash recovery: consumed stimuli can be put back for replay --- *)
+  let base_path = temp_dir "keeper-event-queue-requeue-front" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-requeue-front-test" in
+      let meta = meta_for_keeper keeper_name "trace-event-queue-requeue-front-test" in
+      Masc.Keeper_registry.clear ();
+      ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
+      Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
+      Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name bootstrap_stim;
+      let consumed =
+        match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
+        | Some stim -> stim
+        | None -> Alcotest.fail "dequeue should consume the first queued stimulus"
+      in
+      assert (String.equal consumed.post_id "p1");
+      let restart_replay = Keeper_event_queue_persistence.load ~base_path ~keeper_name in
+      assert (length restart_replay = 2);
+      let replay_head =
+        match dequeue restart_replay with
+        | Some (stim, _) -> stim
+        | None -> Alcotest.fail "restart replay should keep consumed stimulus before ack"
+      in
+      assert (String.equal replay_head.post_id "p1");
+      Masc.Keeper_registry_event_queue.requeue_front
+        ~base_path
+        keeper_name
+        [ consumed ];
+      assert (length (Keeper_event_queue_persistence.load ~base_path ~keeper_name) = 2);
+      Masc.Keeper_registry_event_queue.requeue_front
+        ~base_path
+        keeper_name
+        [ consumed ];
+      assert (length (Keeper_event_queue_persistence.load ~base_path ~keeper_name) = 2);
+      let replayed =
+        match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
+        | Some stim -> stim
+        | None -> Alcotest.fail "requeued stimulus should replay first"
+      in
+      assert (String.equal replayed.post_id "p1");
+      let second =
+        match Masc.Keeper_registry_event_queue.dequeue ~base_path keeper_name with
+        | Some stim -> stim
+        | None -> Alcotest.fail "original second stimulus should remain queued"
+      in
+      assert (String.equal second.post_id "bootstrap"));
 
   print_endline "test_keeper_event_queue: all passed"

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -206,6 +206,30 @@ let () =
       Keeper_event_queue_persistence.persist ~base_path ~keeper_name rest;
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
+  (* --- durable in-flight store: ack removes only consumed stimuli --- *)
+  let base_path = temp_dir "keeper-event-queue-inflight-partial-ack" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-inflight-partial-ack-test" in
+      Keeper_event_queue_persistence.record_inflight
+        ~base_path
+        ~keeper_name
+        [ board_stim; bootstrap_stim ];
+      Keeper_event_queue_persistence.ack_inflight
+        ~base_path
+        ~keeper_name
+        [ board_stim ];
+      let restored = Keeper_event_queue_persistence.load ~base_path ~keeper_name in
+      assert (length restored = 1);
+      let remaining, rest =
+        match dequeue restored with
+        | Some item -> item
+        | None -> Alcotest.fail "partial ack should leave unrelated in-flight stimulus"
+      in
+      assert (String.equal remaining.post_id "bootstrap");
+      assert (is_empty rest));
+
   let meta_for_keeper keeper_name trace_id =
     match
       Masc.Keeper_meta_json_parse.meta_of_json
@@ -244,7 +268,7 @@ let () =
         | None -> Alcotest.fail "registry reload should replay pending stimulus"
       in
       assert (String.equal replayed.post_id "p1");
-      Masc.Keeper_registry_event_queue.ack_consumed ~base_path keeper_name;
+      Masc.Keeper_registry_event_queue.ack_consumed ~base_path keeper_name [ replayed ];
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
   (* --- registry unavailable window: enqueue persists before register --- *)
@@ -279,7 +303,10 @@ let () =
           Alcotest.fail "late registry registration should replay second pre-registered stimulus"
       in
       assert (String.equal second.post_id "bootstrap");
-      Masc.Keeper_registry_event_queue.ack_consumed ~base_path keeper_name;
+      Masc.Keeper_registry_event_queue.ack_consumed
+        ~base_path
+        keeper_name
+        [ first; second ];
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
   (* --- crash recovery: consumed stimuli can be put back for replay --- *)


### PR DESCRIPTION
## Summary
- add an in-flight event queue snapshot so drained keeper stimuli survive restart until ack
- merge pending + in-flight queue snapshots during keeper registration/load for at-least-once replay
- requeue consumed stimuli on keepalive cycle crash and ack the in-flight lease after successful cycle completion
- add regression coverage for restart replay before ack and duplicate-safe requeue

## Context
The adversarial gap review said keeper runtime event queues could lose operator/mention/fusion wake signals across restart. Current main already has durable pending snapshots, but dequeue/drain removed stimuli from the durable snapshot before the turn completed. A hard restart in that window could still drop the stimulus. This PR makes the drained window explicit with event-queue-inflight.json.

## Validation
- git diff --check origin/main...HEAD
- opam exec -- ocamlformat --check changed OCaml files
- opam exec -- ocamlc -stop-after parsing changed OCaml files

## Not Run
- scripts/dune-local.sh build test/test_keeper_event_queue.exe: refused with code 75 because machine-wide bare Dune processes are active. CI remains the build authority for this PR.