### PR TITLE
feat(settings): serve resolved runtime defaults and model routing

### DIFF
--- a/bin/env_knob_catalog.ml
+++ b/bin/env_knob_catalog.ml
@@ -19,6 +19,10 @@
    tool emits an "Unrecognized" entry and CI will surface it. *)
 
 let env_var_re = Str.regexp "\"\\(MASC_[A-Z][A-Z0-9_]*\\)\""
+let env_key_alias_re =
+  Str.regexp "let[ \t]+\\([A-Za-z_][A-Za-z0-9_']*\\)[ \t]*=[ \t]*\"\\(MASC_[A-Z][A-Z0-9_]*\\)\""
+
+let ident_re = Str.regexp "[A-Za-z_][A-Za-z0-9_']*"
 
 let typed_get_re =
   Str.regexp "get_\\(int\\|int_nonneg\\|float\\|float_nonneg\\|float_in_range\\|ratio\\|string\\|bool\\)"
@@ -159,9 +163,39 @@ let classification_of_doc = function
   | None -> (None, None)
   | Some doc -> (search_group category_re doc, search_group ops_class_re doc)
 
+let env_key_aliases arr =
+  let aliases = ref [] in
+  Array.iter
+    (fun line ->
+      try
+        let _ = Str.search_forward env_key_alias_re line 0 in
+        let ident = Str.matched_group 1 line in
+        let env_var = Str.matched_group 2 line in
+        aliases := (ident, env_var) :: !aliases
+      with Not_found | Invalid_argument _ -> ())
+    arr;
+  List.rev !aliases
+
+let alias_refs aliases line =
+  let refs = ref [] in
+  let pos = ref 0 in
+  (try
+     while !pos < String.length line do
+       let _ = Str.search_forward ident_re line !pos in
+       let ident = Str.matched_string line in
+       let next_pos = Str.match_end () in
+       (match List.assoc_opt ident aliases with
+        | Some env_var when not (List.mem env_var !refs) -> refs := env_var :: !refs
+        | Some _ | None -> ());
+       pos := next_pos
+     done
+   with Not_found -> ());
+  List.rev !refs
+
 let scan_file path =
   let lines = read_lines path in
   let arr = Array.of_list lines in
+  let aliases = env_key_aliases arr in
   let acc = ref [] in
   Array.iteri
     (fun i line ->
@@ -201,7 +235,37 @@ let scan_file path =
             :: !acc;
           pos := next_pos
         done
-      with Not_found -> ())
+      with Not_found -> ();
+      let kind =
+        let rec try_classify offset =
+          if offset > 2 || i - offset < 0 then String_lit
+          else
+            match classify_line arr.(i - offset) with
+            | Some k -> k
+            | None -> try_classify (offset + 1)
+        in
+        try_classify 0
+      in
+      match kind with
+      | String_lit -> ()
+      | Feature_flag | Entry_env | Typed_get _ ->
+        let refs = alias_refs aliases line in
+        List.iter
+          (fun env_var ->
+            let doc = doc_above arr i in
+            let category, ops_class = classification_of_doc doc in
+            acc :=
+              {
+                file = path;
+                line = i + 1;
+                env_var;
+                kind;
+                doc;
+                category;
+                ops_class;
+              }
+              :: !acc)
+          refs)
     arr;
   List.rev !acc
 

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -32,6 +32,7 @@ import {
   fetchMemorySubsystems,
   fetchRuntimeProviders,
   fetchRuntimeTomlConfig,
+  fetchRuntimeDefaults,
   fetchRuntimeModelMetrics,
   patchKeeperConfig,
   saveRuntimeTomlConfig,
@@ -2339,5 +2340,43 @@ describe('fetchLogs', () => {
     const params = new URLSearchParams(requestedUrl(fetchMock).split('?')[1] ?? '')
     expect(params.get('since_seq')).toBe('10')
     expect(params.get('before_seq')).toBe('20')
+  })
+})
+
+describe('fetchRuntimeDefaults', () => {
+  it('reads the resolved runtime-defaults surface and parses it', async () => {
+    const rawResponse = {
+      generated_at_iso: '2026-06-21T00:00:00Z',
+      dashboard_surface: '/api/v1/dashboard/runtime-defaults',
+      source: 'runtime_config',
+      config_path: '/cfg/runtime.toml',
+      default_runtime_id: 'openai.gpt-4o',
+      default_model: 'gpt-4o',
+      default_max_context: 128000,
+      runtimes: [
+        { id: 'openai.gpt-4o', provider: 'OpenAI', model: 'gpt-4o', max_context: 128000, is_default: true },
+      ],
+      model_routing: {
+        keeper_assignments: [{ keeper: 'analyst', runtime_id: 'openai.gpt-4o' }],
+        librarian_runtime_id: null,
+        cross_verifier_runtime_id: null,
+        media_failover: [],
+      },
+    }
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(rawResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchRuntimeDefaults()
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/runtime-defaults')
+    expect(result.default_runtime_id).toBe('openai.gpt-4o')
+    expect(result.default_model).toBe('gpt-4o')
+    expect(result.runtimes[0]?.is_default).toBe(true)
+    expect(result.model_routing.keeper_assignments[0]?.keeper).toBe('analyst')
   })
 })

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -29,6 +29,13 @@ import {
 } from './schemas/dashboard-config'
 import { parseLogsResponse, type LogEntry, type LogsResponse } from './schemas/logs'
 import {
+  parseRuntimeDefaultsResponse,
+  type RuntimeDefaultsResponse,
+  type RuntimeEntry,
+  type KeeperAssignment,
+  type ModelRouting,
+} from './schemas/runtime-defaults'
+import {
   parseProviderLogTailResponse,
   parseProviderLogsCatalogResponse,
   type ProviderLogCatalogEntry,
@@ -115,6 +122,8 @@ function decodeDashboardFeedMetadata(raw: Record<string, unknown>): DashboardFee
 
 export type { LogEntry, LogsResponse }
 export { LogsSchemaDriftError } from './schemas/logs'
+export { RuntimeDefaultsSchemaDriftError } from './schemas/runtime-defaults'
+export type { RuntimeDefaultsResponse, RuntimeEntry, KeeperAssignment, ModelRouting }
 export type {
   ProviderLogCatalogEntry,
   ProviderLogsCatalogResponse,
@@ -2492,6 +2501,16 @@ function normalizeRuntimeTomlConfig(raw: unknown): RuntimeTomlConfig {
 export async function fetchRuntimeTomlConfig(): Promise<RuntimeTomlConfig> {
   await ensureDevToken()
   return get<unknown>('/api/v1/runtime/config/raw').then(normalizeRuntimeTomlConfig)
+}
+
+// Structured, already-resolved runtime defaults / model routing (runtime.toml
+// SSOT). Public read — no credentials, no raw TOML; the Settings surface
+// consumes this instead of re-parsing TOML on the client.
+export async function fetchRuntimeDefaults(
+  opts?: AbortableRequestOptions,
+): Promise<RuntimeDefaultsResponse> {
+  const raw = await get<unknown>('/api/v1/dashboard/runtime-defaults', { signal: opts?.signal })
+  return parseRuntimeDefaultsResponse(raw)
 }
 
 export async function saveRuntimeTomlConfig(sourceText: string): Promise<RuntimeTomlConfig> {

--- a/dashboard/src/api/schemas/runtime-defaults.test.ts
+++ b/dashboard/src/api/schemas/runtime-defaults.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  RuntimeDefaultsSchemaDriftError,
+  parseRuntimeDefaultsResponse,
+} from './runtime-defaults'
+
+function validResponse(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    generated_at_iso: '2026-06-21T00:00:00Z',
+    dashboard_surface: '/api/v1/dashboard/runtime-defaults',
+    source: 'runtime_config',
+    config_path: '/cfg/runtime.toml',
+    default_runtime_id: 'openai.gpt-4o',
+    default_model: 'gpt-4o',
+    default_max_context: 128000,
+    runtimes: [
+      { id: 'openai.gpt-4o', provider: 'OpenAI', model: 'gpt-4o', max_context: 128000, is_default: true },
+      { id: 'anthropic.sonnet', provider: 'Anthropic', model: 'claude-sonnet-4', max_context: 200000, is_default: false },
+    ],
+    model_routing: {
+      keeper_assignments: [{ keeper: 'analyst', runtime_id: 'anthropic.sonnet' }],
+      librarian_runtime_id: 'openai.gpt-4o',
+      cross_verifier_runtime_id: null,
+      media_failover: ['openai.gpt-4o'],
+    },
+    ...overrides,
+  }
+}
+
+describe('parseRuntimeDefaultsResponse', () => {
+  it('parses a fully resolved response', () => {
+    const out = parseRuntimeDefaultsResponse(validResponse())
+    expect(out.default_runtime_id).toBe('openai.gpt-4o')
+    expect(out.default_model).toBe('gpt-4o')
+    expect(out.runtimes).toHaveLength(2)
+    expect(out.runtimes[0]!.is_default).toBe(true)
+    expect(out.model_routing.keeper_assignments[0]).toEqual({
+      keeper: 'analyst',
+      runtime_id: 'anthropic.sonnet',
+    })
+    expect(out.model_routing.cross_verifier_runtime_id).toBeNull()
+  })
+
+  it('accepts an unresolved (null/empty) config without fabricating defaults', () => {
+    const out = parseRuntimeDefaultsResponse(
+      validResponse({
+        config_path: null,
+        default_runtime_id: null,
+        default_model: null,
+        default_max_context: null,
+        runtimes: [],
+        model_routing: {
+          keeper_assignments: [],
+          librarian_runtime_id: null,
+          cross_verifier_runtime_id: null,
+          media_failover: [],
+        },
+      }),
+    )
+    expect(out.default_runtime_id).toBeNull()
+    expect(out.default_model).toBeNull()
+    expect(out.runtimes).toHaveLength(0)
+    expect(out.model_routing.keeper_assignments).toHaveLength(0)
+  })
+
+  it('throws schema drift when a runtime entry is missing a required field', () => {
+    expect(() =>
+      parseRuntimeDefaultsResponse(
+        validResponse({
+          runtimes: [{ id: 'x', provider: 'p' /* missing model/max_context/is_default */ }],
+        }),
+      ),
+    ).toThrow(RuntimeDefaultsSchemaDriftError)
+  })
+
+  it('throws schema drift when model_routing is absent', () => {
+    const bad = validResponse()
+    delete bad.model_routing
+    expect(() => parseRuntimeDefaultsResponse(bad)).toThrow(RuntimeDefaultsSchemaDriftError)
+  })
+})

--- a/dashboard/src/api/schemas/runtime-defaults.ts
+++ b/dashboard/src/api/schemas/runtime-defaults.ts
@@ -1,0 +1,69 @@
+// Runtime defaults / model routing schema — schema-at-boundary for
+// `GET /api/v1/dashboard/runtime-defaults`.
+//
+// The backend serves the ALREADY-RESOLVED runtime config (runtime.toml SSOT,
+// populated by Runtime.init_default) — see
+// lib/server/server_dashboard_runtime_defaults_json.ml. The frontend consumes
+// this structured projection instead of re-parsing the raw TOML exposed by
+// /api/v1/runtime/config/raw. Unresolved config surfaces null/[] (no fabricated
+// defaults), so every cursor-like field is nullable rather than defaulted.
+
+import {
+  array,
+  boolean,
+  nullable,
+  number,
+  object,
+  optional,
+  string,
+  type BaseIssue,
+  type InferOutput,
+} from 'valibot'
+import { parseOrThrow, SchemaDriftError } from './drift-error'
+
+const RuntimeEntrySchema = object({
+  id: string(),
+  provider: string(),
+  model: string(),
+  max_context: number(),
+  is_default: boolean(),
+})
+
+const KeeperAssignmentSchema = object({
+  keeper: string(),
+  runtime_id: string(),
+})
+
+const ModelRoutingSchema = object({
+  keeper_assignments: array(KeeperAssignmentSchema),
+  librarian_runtime_id: nullable(string()),
+  cross_verifier_runtime_id: nullable(string()),
+  media_failover: array(string()),
+})
+
+const RuntimeDefaultsResponseSchema = object({
+  generated_at_iso: optional(string()),
+  dashboard_surface: optional(string()),
+  source: optional(string()),
+  config_path: nullable(string()),
+  default_runtime_id: nullable(string()),
+  default_model: nullable(string()),
+  default_max_context: nullable(number()),
+  runtimes: array(RuntimeEntrySchema),
+  model_routing: ModelRoutingSchema,
+})
+
+export type RuntimeEntry = InferOutput<typeof RuntimeEntrySchema>
+export type KeeperAssignment = InferOutput<typeof KeeperAssignmentSchema>
+export type ModelRouting = InferOutput<typeof ModelRoutingSchema>
+export type RuntimeDefaultsResponse = InferOutput<typeof RuntimeDefaultsResponseSchema>
+
+export class RuntimeDefaultsSchemaDriftError extends SchemaDriftError {
+  constructor(issues: readonly BaseIssue<unknown>[]) {
+    super('runtime_defaults', issues)
+  }
+}
+
+export function parseRuntimeDefaultsResponse(data: unknown): RuntimeDefaultsResponse {
+  return parseOrThrow(RuntimeDefaultsSchemaDriftError, RuntimeDefaultsResponseSchema, data)
+}

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -250,6 +250,24 @@ describe('SettingsSurface', () => {
     expect(container.querySelectorAll('[data-testid="routing-assignment"]').length).toBe(0)
   })
 
+  it('runtime nodes section uses the resolved registry without sample targets', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    const runtimesNav = container.querySelector('[data-testid="settings-nav-runtimes"]') as HTMLElement
+    await fireEvent.click(runtimesNav)
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="runtime-node"]').length).toBe(3)
+    })
+    const text = container.textContent ?? ''
+    expect(text).toContain('rt-a')
+    expect(text).toContain('rt-b')
+    expect(text).toContain('rt-c')
+    expect(text).toContain('m1')
+    expect(text).not.toContain('oas://seoul-1.masc.run')
+    expect(text).not.toContain('local·docker')
+  })
+
   it('log filter chips filter live rows from the ring', async () => {
     // 6 ring entries mapped to rows: tool(/masc_/)=3, success(ok)=3, failure(fail)=2.
     apiMock.fetchLogs.mockResolvedValue({

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -11,6 +11,7 @@ import {
 } from './settings-surface'
 import type { DashboardToolInventoryItem } from '../api/dashboard'
 import type { LogEntry } from '../api/schemas/logs'
+import type { RuntimeDefaultsResponse } from '../api/schemas/runtime-defaults'
 import { DashboardMain } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
@@ -20,6 +21,7 @@ import { namespaceTruthInitializing } from '../namespace-truth-store'
 const apiMock = vi.hoisted(() => ({
   fetchLogs: vi.fn(),
   fetchDashboardTools: vi.fn(),
+  fetchRuntimeDefaults: vi.fn(),
 }))
 
 vi.mock('../api/dashboard.js', async () => {
@@ -28,6 +30,7 @@ vi.mock('../api/dashboard.js', async () => {
     ...actual,
     fetchLogs: apiMock.fetchLogs,
     fetchDashboardTools: apiMock.fetchDashboardTools,
+    fetchRuntimeDefaults: apiMock.fetchRuntimeDefaults,
   }
 })
 
@@ -65,9 +68,40 @@ function makeToolItem(overrides: Partial<DashboardToolInventoryItem> = {}): Dash
   }
 }
 
+function makeRuntimeDefaults(
+  overrides: Partial<RuntimeDefaultsResponse> = {},
+): RuntimeDefaultsResponse {
+  return {
+    generated_at_iso: '2026-06-21T00:00:00Z',
+    dashboard_surface: '/api/v1/dashboard/runtime-defaults',
+    source: 'runtime_config',
+    config_path: '/cfg/runtime.toml',
+    default_runtime_id: 'rt-a',
+    default_model: 'm1',
+    default_max_context: 128000,
+    runtimes: [
+      { id: 'rt-a', provider: 'P', model: 'm1', max_context: 128000, is_default: true },
+      { id: 'rt-b', provider: 'P', model: 'm2', max_context: 128000, is_default: false },
+      { id: 'rt-c', provider: 'P', model: 'm3', max_context: 128000, is_default: false },
+    ],
+    model_routing: {
+      keeper_assignments: [{ keeper: 'analyst', runtime_id: 'rt-b' }],
+      librarian_runtime_id: null,
+      cross_verifier_runtime_id: null,
+      media_failover: [],
+    },
+    ...overrides,
+  }
+}
+
+function stubRuntimeDefaults(value: RuntimeDefaultsResponse = makeRuntimeDefaults()) {
+  apiMock.fetchRuntimeDefaults.mockResolvedValue(value)
+}
+
 function stubEmptyApi() {
   apiMock.fetchLogs.mockResolvedValue({ total: 0, entries: [] })
   apiMock.fetchDashboardTools.mockResolvedValue({ tool_inventory: { count: 0, tools: [] } })
+  stubRuntimeDefaults()
 }
 
 const navigate = vi.fn()
@@ -87,6 +121,7 @@ describe('SettingsSurface', () => {
     document.body.appendChild(container)
     apiMock.fetchLogs.mockReset()
     apiMock.fetchDashboardTools.mockReset()
+    apiMock.fetchRuntimeDefaults.mockReset()
     stubEmptyApi()
   })
 
@@ -149,6 +184,8 @@ describe('SettingsSurface', () => {
     await fireEvent.click(runtimeNav)
 
     const seg = () => container.querySelector('[data-testid="set-seg"]') as HTMLElement
+    // The Default runtime segmented control renders from resolved runtime config.
+    await waitFor(() => expect(seg()).not.toBeNull())
     const buttons = () => Array.from(seg().querySelectorAll('button'))
     expect(buttons().length).toBeGreaterThanOrEqual(3)
     expect(buttons()[0]!.getAttribute('data-active')).toBe('true')
@@ -156,6 +193,61 @@ describe('SettingsSurface', () => {
     await fireEvent.click(buttons()[2]!)
     expect(buttons()[0]!.getAttribute('data-active')).toBe('false')
     expect(buttons()[2]!.getAttribute('data-active')).toBe('true')
+  })
+
+  it('Default runtime/model options come from the resolved runtime config', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    const runtimeNav = container.querySelector('[data-testid="settings-nav-runtime"]') as HTMLElement
+    await fireEvent.click(runtimeNav)
+
+    await waitFor(() => {
+      const segLabels = Array.from(
+        container.querySelectorAll('[data-testid="set-seg"] button'),
+      ).map(b => b.textContent?.trim())
+      // runtime ids from the mocked registry, not the old hardcoded oas-* strings
+      expect(segLabels).toContain('rt-a')
+      expect(segLabels).toContain('rt-b')
+      expect(segLabels).toContain('rt-c')
+      expect(segLabels).not.toContain('oas·seoul-1')
+    })
+  })
+
+  it('routing section shows resolved keeper assignments read-only', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    const routingNav = container.querySelector('[data-testid="settings-nav-routing"]') as HTMLElement
+    await fireEvent.click(routingNav)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="routing-default-model"]')?.textContent).toBe('m1')
+      const assignments = Array.from(
+        container.querySelectorAll('[data-testid="routing-assignment"]'),
+      ).map(n => n.textContent)
+      expect(assignments).toEqual(['rt-b'])
+    })
+  })
+
+  it('routing section reports no assignments without fabricating rows', async () => {
+    stubRuntimeDefaults(
+      makeRuntimeDefaults({
+        model_routing: {
+          keeper_assignments: [],
+          librarian_runtime_id: null,
+          cross_verifier_runtime_id: null,
+          media_failover: [],
+        },
+      }),
+    )
+    render(html`<${SettingsSurface} />`, container)
+
+    const routingNav = container.querySelector('[data-testid="settings-nav-routing"]') as HTMLElement
+    await fireEvent.click(routingNav)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="routing-assignments-empty"]')).not.toBeNull()
+    })
+    expect(container.querySelectorAll('[data-testid="routing-assignment"]').length).toBe(0)
   })
 
   it('log filter chips filter live rows from the ring', async () => {
@@ -232,6 +324,7 @@ describe('SettingsSurface shell route', () => {
     document.body.appendChild(container)
     apiMock.fetchLogs.mockReset()
     apiMock.fetchDashboardTools.mockReset()
+    apiMock.fetchRuntimeDefaults.mockReset()
     stubEmptyApi()
     dashboardLoading.value = false
     connected.value = true

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -74,12 +74,6 @@ export function mcpExposedToolNames(items: readonly DashboardToolInventoryItem[]
     .sort((a, b) => a.localeCompare(b))
 }
 
-const RUNTIMES = [
-  { name: 'oas·seoul-1', endpoint: 'oas://seoul-1.masc.run', region: 'ap-northeast-2', kind: 'OAS', keepers: 3 },
-  { name: 'oas·tokyo-2', endpoint: 'oas://tokyo-2.masc.run', region: 'ap-northeast-1', kind: 'OAS', keepers: 2 },
-  { name: 'local·docker', endpoint: 'unix:///var/run/masc.sock', region: 'local', kind: 'Docker', keepers: 1 },
-]
-
 const APPROVAL_ACTIONS: [string, string, string][] = [
   ['git push / merge', 'always', '원격 브랜치에 쓰기'],
   ['배포 (infra/deploy)', 'always', 'deploy 트리거'],
@@ -500,8 +494,9 @@ export function SettingsSurface() {
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
 
   // Resolved runtime options (de-duplicated, derived from the live registry).
-  const runtimeIdOptions = (runtimeDefaults?.runtimes ?? []).map(r => r.id)
-  const runtimeModelOptions = [...new Set((runtimeDefaults?.runtimes ?? []).map(r => r.model))]
+  const runtimeEntries = runtimeDefaults?.runtimes ?? []
+  const runtimeIdOptions = runtimeEntries.map(r => r.id)
+  const runtimeModelOptions = [...new Set(runtimeEntries.map(r => r.model))]
   const keeperAssignments = runtimeDefaults?.model_routing.keeper_assignments ?? []
   const librarianRuntime = runtimeDefaults?.model_routing.librarian_runtime_id ?? null
   const crossVerifierRuntime = runtimeDefaults?.model_routing.cross_verifier_runtime_id ?? null
@@ -647,25 +642,26 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'runtimes' && html`
-              <div class="set-hint" style=${{ marginBottom: '12px' }}>Registered runtime targets. Keepers run on one of these.</div>
-              ${RUNTIMES.map(rt => html`
-                <div key=${rt.name} class="set-rt">
-                  <div class="set-rt-top">
-                    <span class="set-rt-name mono">${rt.name}</span>
-                    <span class="set-rt-kind">${rt.kind}</span>
-                    <span class="set-rt-keepers">keeper ${rt.keepers}</span>
-                    <${VerifyBtn} label="Check" />
-                  </div>
-                  <div class="set-rt-row">
-                    <span class="sub-k">endpoint</span>
-                    <input class="set-input mono" defaultValue=${rt.endpoint} />
-                  </div>
-                  <div class="set-rt-row">
-                    <span class="sub-k">region</span>
-                    <span class="mono" style=${{ fontSize: '12px', color: 'var(--text-mid)' }}>${rt.region}</span>
-                  </div>
-                </div>
-              `)}
+              <div class="set-hint" style=${{ marginBottom: '12px' }}>Registered runtime targets resolved from runtime.toml.</div>
+              ${runtimeEntries.length === 0
+                ? html`<div class="set-hint" data-testid="runtime-nodes-empty">등록된 런타임이 없습니다.</div>`
+                : runtimeEntries.map(rt => html`
+                    <div key=${rt.id} class="set-rt" data-testid="runtime-node">
+                      <div class="set-rt-top">
+                        <span class="set-rt-name mono">${rt.id}</span>
+                        <span class="set-rt-kind">${rt.provider}</span>
+                        ${rt.is_default ? html`<span class="set-rt-keepers">default</span>` : null}
+                      </div>
+                      <div class="set-rt-row">
+                        <span class="sub-k">model</span>
+                        <span class="mono" style=${{ fontSize: '12px', color: 'var(--text-mid)' }}>${rt.model}</span>
+                      </div>
+                      <div class="set-rt-row">
+                        <span class="sub-k">max context</span>
+                        <span class="mono" style=${{ fontSize: '12px', color: 'var(--text-mid)' }}>${rt.max_context}</span>
+                      </div>
+                    </div>
+                  `)}
               <button type="button" class="set-add">＋ Add runtime</button>
             `}
 

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -1,14 +1,13 @@
 // MASC Dashboard — Settings surface (keeper-v2 port)
-// Read surfaces (MCP exposed-tools list, system-log tail) are wired to live
-// backend data. Write surfaces (Save changes, VerifyBtn, runtime defaults /
-// model routing) remain local-state stubs — see the deferred list in the PR
-// that introduced the read wiring.
+// Read surfaces (MCP exposed-tools list, system-log tail, runtime defaults /
+// model routing) are wired to live backend data. Write surfaces (Save changes,
+// VerifyBtn, expose/unexpose persistence) remain local-state stubs.
 
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { navigate } from '../router'
-import { fetchLogs, fetchDashboardTools } from '../api/dashboard.js'
-import type { LogEntry, DashboardToolInventoryItem } from '../api/dashboard.js'
+import { fetchDashboardTools, fetchLogs, fetchRuntimeDefaults } from '../api/dashboard.js'
+import type { DashboardToolInventoryItem, LogEntry, RuntimeDefaultsResponse } from '../api/dashboard.js'
 import type { ComponentChildren } from 'preact'
 
 type SectionId =
@@ -396,19 +395,34 @@ export function SettingsSurface() {
     return () => { active = false }
   }, [])
 
-  // runtime defaults
-  const [defRuntime, setDefRuntime] = useState('oas·seoul-1')
-  const [defModel, setDefModel] = useState('claude-sonnet-4')
+  // runtime defaults / model routing — resolved from runtime.toml (SSOT)
+  const [runtimeDefaults, setRuntimeDefaults] = useState<RuntimeDefaultsResponse | null>(null)
+  const [defRuntime, setDefRuntime] = useState('')
+  const [defModel, setDefModel] = useState('')
   const [maxPar, setMaxPar] = useState(6)
   const [compactAt, setCompactAt] = useState(85)
   const [autoCompact, setAutoCompact] = useState(true)
 
-  // routing / policy
-  const [routing, setRouting] = useState<Record<string, string>>({
-    analysis: 'claude-sonnet-4',
-    heavy: 'claude-opus-4',
-    cheap: 'claude-haiku-4',
-  })
+  useEffect(() => {
+    let active = true
+    void (async () => {
+      try {
+        const resp = await fetchRuntimeDefaults()
+        if (!active) return
+        setRuntimeDefaults(resp)
+        // Seed the selectors with the resolved defaults (unknown → left blank,
+        // never a fabricated default).
+        if (resp.default_runtime_id) setDefRuntime(resp.default_runtime_id)
+        if (resp.default_model) setDefModel(resp.default_model)
+      } catch {
+        if (!active) return
+        setRuntimeDefaults(null)
+      }
+    })()
+    return () => { active = false }
+  }, [])
+
+  // policy
   const [approve, setApprove] = useState<Record<string, string>>(
     Object.fromEntries(APPROVAL_ACTIONS.map(a => [a[0], a[1]])),
   )
@@ -484,6 +498,13 @@ export function SettingsSurface() {
   const [clock24, setClock24] = useState(true)
 
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
+
+  // Resolved runtime options (de-duplicated, derived from the live registry).
+  const runtimeIdOptions = (runtimeDefaults?.runtimes ?? []).map(r => r.id)
+  const runtimeModelOptions = [...new Set((runtimeDefaults?.runtimes ?? []).map(r => r.model))]
+  const keeperAssignments = runtimeDefaults?.model_routing.keeper_assignments ?? []
+  const librarianRuntime = runtimeDefaults?.model_routing.librarian_runtime_id ?? null
+  const crossVerifierRuntime = runtimeDefaults?.model_routing.cross_verifier_runtime_id ?? null
 
   return html`
     <main class="v2-shell-surface settings-surf ss-surface bg-surface-page text-text-primary" data-screen-label="설정" data-testid="settings-surface">
@@ -602,11 +623,15 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'runtime' && html`
-              <${SetRow} label="Default runtime" hint="Where new keepers start">
-                <${SetSeg} value=${defRuntime} options=${['oas·seoul-1', 'oas·tokyo-2', 'local·docker']} onChange=${setDefRuntime} />
+              <${SetRow} label="Default runtime" hint="Resolved from runtime.toml [runtime].default">
+                ${runtimeIdOptions.length === 0
+                  ? html`<span class="set-hint" data-testid="runtime-default-empty">런타임 설정을 불러오지 못했습니다.</span>`
+                  : html`<${SetSeg} value=${defRuntime} options=${runtimeIdOptions} onChange=${setDefRuntime} />`}
               <//>
-              <${SetRow} label="Default model" hint="Used when no routing rule matches">
-                <${SetSeg} value=${defModel} options=${['claude-haiku-4', 'claude-sonnet-4', 'claude-opus-4']} onChange=${setDefModel} />
+              <${SetRow} label="Default model" hint="API model of the default runtime">
+                ${runtimeModelOptions.length === 0
+                  ? html`<span class="set-hint">—</span>`
+                  : html`<${SetSeg} value=${defModel} options=${runtimeModelOptions} onChange=${setDefModel} />`}
               <//>
               <${SetRow} label="Max concurrent keepers" hint="In this namespace">
                 <${SetStepper} v=${maxPar} set=${setMaxPar} min=${1} max=${12} />
@@ -645,20 +670,26 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'routing' && html`
-              <div class="set-hint" style=${{ marginBottom: '12px' }}>Automatically pick a model per task.kind.</div>
-              ${([
-                ['analysis', '분석 · 리서치'],
-                ['heavy', '복잡한 추론 · 대규모 리팩터'],
-                ['cheap', '단순 작업 · 분류'],
-              ] as const).map(([k, lbl]) => html`
-                <${SetRow} key=${k} label=${lbl} hint=${`task.kind = ${k}`}>
-                  <${SetSeg}
-                    value=${routing[k]}
-                    options=${['claude-haiku-4', 'claude-sonnet-4', 'claude-opus-4']}
-                    onChange=${(v: string) => setRouting(p => ({ ...p, [k]: v }))}
-                  />
-                <//>
-              `)}
+              <div class="set-hint" style=${{ marginBottom: '12px' }}>
+                Resolved model routing from runtime.toml (SSOT). Read-only — edit runtime.toml to change.
+              </div>
+              <${SetRow} label="Default model" hint="Used when no keeper assignment matches">
+                <span class="mono" data-testid="routing-default-model">${runtimeDefaults?.default_model ?? '—'}</span>
+              <//>
+              ${librarianRuntime
+                ? html`<${SetRow} label="Librarian runtime" hint="[runtime].librarian"><span class="mono">${librarianRuntime}</span><//>`
+                : null}
+              ${crossVerifierRuntime
+                ? html`<${SetRow} label="Cross-verifier runtime" hint="[runtime].cross_verifier"><span class="mono">${crossVerifierRuntime}</span><//>`
+                : null}
+              <div class="set-sub-h">Keeper assignments (${keeperAssignments.length})</div>
+              ${keeperAssignments.length === 0
+                ? html`<div class="set-hint" data-testid="routing-assignments-empty">명시적 keeper 할당이 없습니다 — 모두 기본 런타임을 사용합니다.</div>`
+                : keeperAssignments.map(a => html`
+                    <${SetRow} key=${a.keeper} label=${a.keeper} hint="keeper → runtime">
+                      <span class="mono" data-testid="routing-assignment">${a.runtime_id}</span>
+                    <//>
+                  `)}
             `}
 
             ${sec === 'prompts' && html`

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,9 +16,9 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 355 unique knobs across 9 modules.
 
-**Typed getter classification**: 21/204 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 183).
+**Typed getter classification**: 21/208 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 187).
 
-## Env_config_core (29 knobs; typed classification 1/8)
+## Env_config_core (29 knobs; typed classification 1/12)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -30,8 +30,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 424 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_DATA_DIR` | string_literal | n/a | n/a | 437 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
 | `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 467 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
-| `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 480 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 471 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
+| `MASC_GOVERNANCE_LEVEL` | typed:string | unclassified | unclassified | 497 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 243 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 202 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
@@ -43,12 +43,12 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 476 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 477 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 409 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
-| `MASC_PARSE_WARN` | string_literal | n/a | n/a | 479 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_PARSE_WARN` | typed:bool | unclassified | unclassified | 492 | Whether to log parse warnings. Default: false. |
 | `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 425 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 516 | PubSub max messages per read. Default: 1000. |
 | `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 447 | Whether relay token calibration is enabled. Default: true. |
 | `MASC_STORAGE_TYPE` | string_literal | n/a | n/a | 404 | SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). |
-| `MASC_TELEMETRY_ENABLED` | string_literal | n/a | n/a | 478 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 488 | Whether telemetry tracking is enabled. Default: true. |
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 343 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 244 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 

--- a/lib/server/server_dashboard_runtime_defaults_json.ml
+++ b/lib/server/server_dashboard_runtime_defaults_json.ml
@@ -1,0 +1,110 @@
+(* Dashboard /runtime-defaults endpoint JSON builder.
+
+   Serves the structured, ALREADY-RESOLVED runtime defaults and model routing
+   that the runtime actually uses — the singletons populated by
+   [Runtime.init_default] at startup (runtime.toml SSOT). This does NOT re-parse
+   runtime.toml; the frontend consumes the resolved structure directly instead
+   of the raw TOML source_text exposed by [/api/v1/runtime/config/raw].
+
+   No fabricated defaults: when the runtime config is uninitialized the
+   singletons hold [None]/[[]] and surface as null/empty arrays. The resolving
+   accessors that [failwith] on an unset default (e.g. [get_default_runtime_id])
+   are intentionally avoided — the option-returning [get_default_runtime] is the
+   only default source used here. *)
+
+(* [Runtime.t] record fields ([provider], [model], [binding]) and the nested
+   [Runtime_schema] record labels ([display_name], [api_name], [max_context],
+   [is_default]) need to be in scope for field access. *)
+open Runtime_schema
+
+type runtime_entry =
+  { id : string
+  ; provider : string
+  ; model : string
+  ; max_context : int
+  ; is_default : bool
+  }
+
+type resolved =
+  { default_runtime_id : string option
+  ; default_model : string option
+  ; default_max_context : int option
+  ; runtimes : runtime_entry list
+  ; keeper_assignments : (string * string) list
+  ; librarian_runtime_id : string option
+  ; cross_verifier_runtime_id : string option
+  ; media_failover : string list
+  ; config_path : string option
+  }
+
+let string_opt_json = function
+  | Some s -> `String s
+  | None -> `Null
+;;
+
+let int_opt_json = function
+  | Some i -> `Int i
+  | None -> `Null
+;;
+
+let runtime_entry_json (e : runtime_entry) : Yojson.Safe.t =
+  `Assoc
+    [ "id", `String e.id
+    ; "provider", `String e.provider
+    ; "model", `String e.model
+    ; "max_context", `Int e.max_context
+    ; "is_default", `Bool e.is_default
+    ]
+;;
+
+let keeper_assignment_json (keeper, runtime_id) : Yojson.Safe.t =
+  `Assoc [ "keeper", `String keeper; "runtime_id", `String runtime_id ]
+;;
+
+let build ~generated_at_iso (r : resolved) : Yojson.Safe.t =
+  `Assoc
+    [ "generated_at_iso", `String generated_at_iso
+    ; "dashboard_surface", `String "/api/v1/dashboard/runtime-defaults"
+    ; "source", `String "runtime_config"
+    ; "config_path", string_opt_json r.config_path
+    ; "default_runtime_id", string_opt_json r.default_runtime_id
+    ; "default_model", string_opt_json r.default_model
+    ; "default_max_context", int_opt_json r.default_max_context
+    ; "runtimes", `List (List.map runtime_entry_json r.runtimes)
+    ; ( "model_routing"
+      , `Assoc
+          [ ( "keeper_assignments"
+            , `List (List.map keeper_assignment_json r.keeper_assignments) )
+          ; "librarian_runtime_id", string_opt_json r.librarian_runtime_id
+          ; "cross_verifier_runtime_id", string_opt_json r.cross_verifier_runtime_id
+          ; "media_failover", `List (List.map (fun s -> `String s) r.media_failover)
+          ] )
+    ]
+;;
+
+let resolved_of_runtime () : resolved =
+  let default = Runtime.get_default_runtime () in
+  let entry (rt : Runtime.t) : runtime_entry =
+    { id = rt.id
+    ; provider = rt.provider.display_name
+    ; model = rt.model.api_name
+    ; max_context = rt.model.max_context
+    ; is_default = rt.binding.is_default
+    }
+  in
+  { default_runtime_id = Option.map (fun (rt : Runtime.t) -> rt.id) default
+  ; default_model = Option.map (fun (rt : Runtime.t) -> rt.model.api_name) default
+  ; default_max_context =
+      Option.map (fun (rt : Runtime.t) -> rt.model.max_context) default
+  ; runtimes = List.map entry (Runtime.get_runtimes ())
+  ; keeper_assignments = Runtime.keeper_assignments ()
+  ; librarian_runtime_id = Runtime.librarian_runtime_id ()
+  ; cross_verifier_runtime_id = Runtime.cross_verifier_runtime_id ()
+  ; media_failover = Runtime.media_failover ()
+  ; config_path = Runtime.config_path ()
+  }
+;;
+
+let current ~generated_at_iso () : Yojson.Safe.t =
+  build ~generated_at_iso (resolved_of_runtime ())
+;;

--- a/lib/server/server_dashboard_runtime_defaults_json.ml
+++ b/lib/server/server_dashboard_runtime_defaults_json.ml
@@ -8,7 +8,7 @@
 
    No fabricated defaults: when the runtime config is uninitialized the
    singletons hold [None]/[[]] and surface as null/empty arrays. The resolving
-   accessors that [failwith] on an unset default (e.g. [get_default_runtime_id])
+   accessors that raise on an unset default (e.g. [get_default_runtime_id])
    are intentionally avoided — the option-returning [get_default_runtime] is the
    only default source used here. *)
 

--- a/lib/server/server_dashboard_runtime_defaults_json.mli
+++ b/lib/server/server_dashboard_runtime_defaults_json.mli
@@ -1,0 +1,35 @@
+(** Dashboard [/api/v1/dashboard/runtime-defaults] endpoint JSON builder.
+
+    Serves the structured, already-resolved runtime defaults and model routing
+    (runtime.toml SSOT, populated by [Runtime.init_default]). Unknown /
+    uninitialized state surfaces as [null]/[[]] — no fabricated defaults. *)
+
+type runtime_entry =
+  { id : string
+  ; provider : string
+  ; model : string
+  ; max_context : int
+  ; is_default : bool
+  }
+
+type resolved =
+  { default_runtime_id : string option
+  ; default_model : string option
+  ; default_max_context : int option
+  ; runtimes : runtime_entry list
+  ; keeper_assignments : (string * string) list
+  ; librarian_runtime_id : string option
+  ; cross_verifier_runtime_id : string option
+  ; media_failover : string list
+  ; config_path : string option
+  }
+
+val build : generated_at_iso:string -> resolved -> Yojson.Safe.t
+(** Pure JSON encoder over the resolved structure. *)
+
+val resolved_of_runtime : unit -> resolved
+(** Snapshot the runtime config singletons. Uses only option-returning
+    accessors, so it never raises on an uninitialized default. *)
+
+val current : generated_at_iso:string -> unit -> Yojson.Safe.t
+(** [build] applied to {!resolved_of_runtime}. *)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -319,6 +319,18 @@ let add_routes ~sw ~clock router =
          Http.Response.json_value ~compress:true ~request:req json reqd
        in
        with_tool_auth ~tool_name:"masc_runtime_ollama_probe" handle request reqd)
+  |> Http.Router.get "/api/v1/dashboard/runtime-defaults" (fun request reqd ->
+       (* Structured, already-resolved runtime defaults / model routing for the
+          Settings surface. Read-only projection of the runtime.toml SSOT
+          singletons (no credentials, no raw TOML), so a public read mirrors the
+          other dashboard read surfaces. *)
+       with_public_read (fun _state req reqd ->
+         let json =
+           Server_dashboard_runtime_defaults_json.current
+             ~generated_at_iso:(Masc_domain.now_iso ()) ()
+         in
+         Http.Response.json_value ~compress:true ~request:req json reqd)
+         request reqd)
   |> Http.Router.get "/api/v1/runtime/config/raw" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
          (fun _state _agent_name req reqd ->

--- a/test/dune
+++ b/test/dune
@@ -645,6 +645,14 @@
  (modules test_runtime_config_validity)
  (libraries masc_test_deps))
 
+; Dashboard /runtime-defaults JSON builder — resolved defaults + model routing
+; projection, plus the no-fabrication (null/empty) contract.
+
+(test
+ (name test_runtime_defaults_json)
+ (modules test_runtime_defaults_json)
+ (libraries masc_test_deps))
+
 ; RFC-0266: fusion async-completion wake — closed-sum classification +
 ; actionable pending_board_event delivery.
 

--- a/test/test_runtime_defaults_json.ml
+++ b/test/test_runtime_defaults_json.ml
@@ -1,0 +1,97 @@
+module J = Server_dashboard_runtime_defaults_json
+
+let member k json = Yojson.Safe.Util.member k json
+
+let test_build_resolved_serializes_defaults_and_routing () =
+  let resolved : J.resolved =
+    { default_runtime_id = Some "openai.gpt-4o"
+    ; default_model = Some "gpt-4o"
+    ; default_max_context = Some 128000
+    ; runtimes =
+        [ { id = "openai.gpt-4o"
+          ; provider = "OpenAI"
+          ; model = "gpt-4o"
+          ; max_context = 128000
+          ; is_default = true
+          }
+        ; { id = "anthropic.sonnet"
+          ; provider = "Anthropic"
+          ; model = "claude-sonnet-4"
+          ; max_context = 200000
+          ; is_default = false
+          }
+        ]
+    ; keeper_assignments = [ "analyst", "anthropic.sonnet" ]
+    ; librarian_runtime_id = Some "openai.gpt-4o"
+    ; cross_verifier_runtime_id = None
+    ; media_failover = [ "openai.gpt-4o" ]
+    ; config_path = Some "/cfg/runtime.toml"
+    }
+  in
+  let json = J.build ~generated_at_iso:"2026-06-21T00:00:00Z" resolved in
+  Alcotest.(check string)
+    "default_runtime_id" "openai.gpt-4o"
+    (member "default_runtime_id" json |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "default_model" "gpt-4o"
+    (member "default_model" json |> Yojson.Safe.Util.to_string);
+  Alcotest.(check int)
+    "default_max_context" 128000
+    (member "default_max_context" json |> Yojson.Safe.Util.to_int);
+  Alcotest.(check string)
+    "source" "runtime_config"
+    (member "source" json |> Yojson.Safe.Util.to_string);
+  let runtimes = member "runtimes" json |> Yojson.Safe.Util.to_list in
+  Alcotest.(check int) "runtimes length" 2 (List.length runtimes);
+  let first = List.hd runtimes in
+  Alcotest.(check string) "runtime id" "openai.gpt-4o"
+    (member "id" first |> Yojson.Safe.Util.to_string);
+  Alcotest.(check bool) "runtime is_default" true
+    (member "is_default" first |> Yojson.Safe.Util.to_bool);
+  let routing = member "model_routing" json in
+  let assignments = member "keeper_assignments" routing |> Yojson.Safe.Util.to_list in
+  Alcotest.(check int) "assignments length" 1 (List.length assignments);
+  Alcotest.(check string) "assignment keeper" "analyst"
+    (member "keeper" (List.hd assignments) |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string) "assignment runtime_id" "anthropic.sonnet"
+    (member "runtime_id" (List.hd assignments) |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string) "librarian routing" "openai.gpt-4o"
+    (member "librarian_runtime_id" routing |> Yojson.Safe.Util.to_string)
+
+let test_build_uninitialized_emits_null_not_fabricated_default () =
+  (* No fabrication: an unresolved runtime config surfaces null/empty, never a
+     fake default model or runtime. *)
+  let resolved : J.resolved =
+    { default_runtime_id = None
+    ; default_model = None
+    ; default_max_context = None
+    ; runtimes = []
+    ; keeper_assignments = []
+    ; librarian_runtime_id = None
+    ; cross_verifier_runtime_id = None
+    ; media_failover = []
+    ; config_path = None
+    }
+  in
+  let json = J.build ~generated_at_iso:"2026-06-21T00:00:00Z" resolved in
+  Alcotest.(check bool) "default_runtime_id is null" true
+    (member "default_runtime_id" json = `Null);
+  Alcotest.(check bool) "default_model is null" true
+    (member "default_model" json = `Null);
+  Alcotest.(check int) "runtimes empty" 0
+    (member "runtimes" json |> Yojson.Safe.Util.to_list |> List.length);
+  let routing = member "model_routing" json in
+  Alcotest.(check int) "assignments empty" 0
+    (member "keeper_assignments" routing |> Yojson.Safe.Util.to_list |> List.length);
+  Alcotest.(check bool) "cross_verifier null" true
+    (member "cross_verifier_runtime_id" routing = `Null)
+
+let () =
+  Alcotest.run "runtime_defaults_json"
+    [ ( "build",
+        [ Alcotest.test_case "serializes resolved defaults and routing" `Quick
+            test_build_resolved_serializes_defaults_and_routing;
+          Alcotest.test_case "uninitialized emits null (no fabrication)" `Quick
+            test_build_uninitialized_emits_null_not_fabricated_default;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

Settings surface의 "runtime defaults & model routing"가 고정 문자열(`oas·seoul-1`, `claude-sonnet-4`, task.kind analysis/heavy/cheap)로 하드코딩돼 있었습니다 — raw TOML(`/api/v1/runtime/config/raw`)만 노출돼 구조화된 read 경로가 없었기 때문입니다 (KEEPER-V2 P0 gap). 이미 **resolve된** 런타임 설정을 서빙하는 read 엔드포인트를 추가하고 Settings를 실데이터로 연결했습니다.

## Grounding (resolved-config 출처)

- `lib/runtime/runtime.ml` — runtime.toml SSOT. `Runtime.init_default`가 startup에 파싱해 singleton(Atomic)에 채웁니다. FE에서 TOML을 재파싱하지 않고 이 resolve된 구조를 그대로 서빙합니다 (이전 PR #21890에서 flag한 fabrication 위험 회피).
- 사용 accessor(전부 option/`[]` 안전 — 미초기화 시 raise 안 함): `get_default_runtime`(option), `get_runtimes`, `keeper_assignments`, `librarian_runtime_id`, `cross_verifier_runtime_id`, `media_failover`, `config_path`. raise하는 `get_default_runtime_id`는 의도적으로 피했습니다.

## 변경 내용

### Backend
- `lib/server/server_dashboard_runtime_defaults_json.ml/.mli` — pure 빌더(`build`) + singleton 스냅샷(`resolved_of_runtime`/`current`). default runtime/model, runtimes 목록, `model_routing`(keeper_assignments + librarian/cross_verifier + media_failover) 직렬화. 미초기화 → null/`[]` (날조 없음).
- `lib/server/server_routes_http_routes_dashboard.ml` — `GET /api/v1/dashboard/runtime-defaults` 추가. `with_public_read`(자격증명/raw TOML 미포함, 다른 dashboard read surface와 동일).
- `test/test_runtime_defaults_json.ml` (+ `test/dune`) — alcotest 2종: resolved 직렬화, 미초기화 no-fabrication.

### Frontend
- `dashboard/src/api/schemas/runtime-defaults.ts` — valibot schema-at-boundary(parse-don't-validate, drift error). `dashboard/src/api/dashboard.ts` — `fetchRuntimeDefaults()`.
- `dashboard/src/components/settings-surface.ts` — Runtime 섹션의 Default runtime/Default model을 resolve된 값+옵션으로 연결(미해결 → blank, 날조 없음). Routing 섹션의 가짜 task.kind 셀렉터를 **실제 resolve된 routing**(default model + keeper→runtime 할당 + librarian/cross_verifier) read-only 표시로 교체.
- 테스트: schema(`runtime-defaults.test.ts`), fetch(`dashboard.test.ts`), 컴포넌트 wiring 4종(`settings-surface.test.ts`).

## Deferred (PR 범위 밖)
- **per-task-kind routing 편집기**(analysis/heavy/cheap → model): 백엔드에 해당 개념이 없음(실 routing은 keeper-assignment 기반). 제품 결정 + write 엔드포인트 필요 → read-only 표시로 대체, 편집은 deferred.
- **Save / VerifyBtn 영속화**: write 경로. runtime.toml 쓰기는 별도 write API/권한 필요 → deferred (이전 PR과 동일).

## RFC-gate
runtime 설정은 host_config/credential이 아닙니다. 이 엔드포인트는 resolve된 routing의 **순수 read**이며 `lib/keeper/host_config_*`/credential 경로를 건드리지 않습니다(additive-safe). `pr-rfc-check.sh` PASS.

## 검증
- Backend: `dune build --root .` exit 0. `test_runtime_defaults_json.exe` 2/2 PASS.
- Frontend: `pnpm typecheck` PASS, `pnpm lint`(eslint src) PASS(0 errors), `vitest run`(schemas/runtime-defaults + dashboard + settings-surface) 68 PASS.

## 경계
OAS(provider/model/transport) 미변경 — routing 설정은 MASC 소유. OAS는 provider transport 소유로 분리 유지.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
