### PR TITLE
fix(dashboard): grow log delta-merge cap when paged so load-older rows survive (#21879 review)

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -2,7 +2,12 @@ import { h } from 'preact'
 import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { LogEntry } from '../api/dashboard'
-import { logDiagnosticCause, summarizeLogWindow } from './logs'
+import {
+  deltaMergeCap,
+  logDiagnosticCause,
+  mergeLogEntries,
+  summarizeLogWindow,
+} from './logs'
 
 function entry(overrides: Partial<LogEntry>): LogEntry {
   return {
@@ -147,6 +152,47 @@ describe('log diagnostics', () => {
     expect(summary.topCauses).toContainEqual({ cause: 'provider_timeout', count: 1 })
     expect(summary.topCauses).toHaveLength(1)
     expect(summary.topModules[0]).toEqual({ module: 'Keeper', count: 2 })
+  })
+})
+
+describe('deltaMergeCap (load-older erosion guard)', () => {
+  it('keeps a fixed newest-N sliding window when not paged', () => {
+    const current = [entry({ seq: 10 }), entry({ seq: 9 })]
+    const incoming = [entry({ seq: 11 })]
+    // un-paged: cap stays at the base limit regardless of how many rows exist,
+    // so old rows roll off and memory stays bounded.
+    expect(deltaMergeCap(current, incoming, false, 200)).toBe(200)
+    expect(deltaMergeCap(current, incoming, false, 2)).toBe(2)
+  })
+
+  it('grows the cap to fit current rows plus genuinely-new rows when paged', () => {
+    const current = [entry({ seq: 10 }), entry({ seq: 9 }), entry({ seq: 8 })]
+    const incoming = [entry({ seq: 11 })] // 1 fresh
+    // paged: cap must cover every currently shown row (3) + the fresh row (1).
+    expect(deltaMergeCap(current, incoming, true, 2)).toBe(4)
+  })
+
+  it('counts only non-overlapping incoming rows as fresh when paged', () => {
+    const current = [entry({ seq: 10 }), entry({ seq: 9 })]
+    // seq 10 overlaps the current window; only seq 11 is genuinely new.
+    const incoming = [entry({ seq: 11 }), entry({ seq: 10 })]
+    expect(deltaMergeCap(current, incoming, true, 2)).toBe(3)
+  })
+
+  it('prevents the delta poll from evicting paged-in older rows over multiple cycles', () => {
+    // Reproduces the erosion: base limit 2, operator paged a third (older) row
+    // in (seq 8). Each delta poll appends one newer row. With the buggy cap
+    // (max(displayCap, limit) == 3) the newest-first slice would drop seq 8.
+    let current = [entry({ seq: 10 }), entry({ seq: 9 }), entry({ seq: 8, message: 'paged older' })]
+    for (const fresh of [11, 12, 13]) {
+      const incoming = [entry({ seq: fresh, message: `delta ${fresh}` })]
+      const cap = deltaMergeCap(current, incoming, true, 2)
+      current = mergeLogEntries(current, incoming, cap)
+      // the paged-in oldest row must survive every cycle
+      expect(current.some(e => e.seq === 8)).toBe(true)
+    }
+    // after 3 delta cycles all rows are retained, none evicted
+    expect(current.map(e => e.seq)).toEqual([13, 12, 11, 10, 9, 8])
   })
 })
 

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -61,9 +61,13 @@ const categoryFilter = signal('')
 const hideFsmTransitions = signal(false)
 const expandedLogSeq = signal<number | null>(null)
 // "load older" backward paging: [displayCap] is the max rows kept in view. It
-// starts at the per-request limit and only grows as older pages are appended,
-// so the delta poller's merge does not trim history the operator paged into.
+// starts at the per-request limit and grows as older pages are appended AND as
+// the delta poller adds newer rows on top of a paged-open view, so neither path
+// evicts history the operator paged into. [pagedOlder] records whether the view
+// has been expanded past the base limit; while it is false the delta poller
+// keeps a fixed newest-N sliding window (bounded memory, steady state).
 const displayCap = signal(DEFAULT_LOG_LIMIT)
+const pagedOlder = signal(false)
 const olderLoading = signal(false)
 const noMoreOlder = signal(false)
 
@@ -173,7 +177,7 @@ function latestLogSeq(entries: LogEntry[]): number | null {
   return entries.reduce((max, entry) => Math.max(max, entry.seq), entries[0]?.seq ?? 0)
 }
 
-function mergeLogEntries(
+export function mergeLogEntries(
   current: LogEntry[],
   incoming: LogEntry[],
   maxEntries: number,
@@ -184,6 +188,27 @@ function mergeLogEntries(
   return [...merged.values()]
     .sort((a, b) => b.seq - a.seq)
     .slice(0, Math.max(1, maxEntries))
+}
+
+// Cap for the delta poll's merge with the currently loaded rows.
+// Un-paged steady state: a fixed newest-N sliding window ([baseLimit]) so memory
+// stays bounded and old rows roll off as new ones arrive.
+// Paged-open (operator used "load older"): keep EVERY currently shown row plus
+// the genuinely-new (non-overlapping) incoming rows, so newest-first slicing in
+// [mergeLogEntries] cannot evict the just-paged-in oldest rows on the next poll.
+export function deltaMergeCap(
+  current: readonly LogEntry[],
+  incoming: readonly LogEntry[],
+  pagedOlder: boolean,
+  baseLimit: number,
+): number {
+  if (!pagedOlder) return baseLimit
+  const currentSeqs = new Set(current.map(entry => entry.seq))
+  const freshCount = incoming.reduce(
+    (n, entry) => (currentSeqs.has(entry.seq) ? n : n + 1),
+    0,
+  )
+  return current.length + freshCount
 }
 
 function sourceLabel(source: string): string {
@@ -478,6 +503,7 @@ async function loadLogs(mode: LoadMode = 'reset') {
   if (mode === 'reset') {
     logQueryGeneration += 1
     displayCap.value = logLimit.value
+    pagedOlder.value = false
     noMoreOlder.value = false
     return logResource.load(async () => {
       const resp = await fetchLogs({
@@ -512,10 +538,9 @@ async function loadLogs(mode: LoadMode = 'reset') {
     const s = logResource.state.value
     const currentEntries = s.status === 'loaded' ? s.data.entries : []
     const incoming = sortLogEntries(resp.entries)
-    // Cap at displayCap (>= logLimit once older pages are loaded) so a delta
-    // poll never drops history the operator paged into via "load older".
-    const cap = Math.max(displayCap.value, logLimit.value)
+    const cap = deltaMergeCap(currentEntries, incoming, pagedOlder.value, logLimit.value)
     const nextEntries = mergeLogEntries(currentEntries, incoming, cap)
+    displayCap.value = Math.max(logLimit.value, nextEntries.length)
 
     latestSeq.value = latestLogSeq(nextEntries)
     logResource.state.value = loaded({
@@ -570,6 +595,9 @@ export async function loadOlder() {
     const cap = latestEntries.length + incoming.length
     const nextEntries = mergeLogEntries(latestEntries, incoming, cap)
     displayCap.value = Math.max(displayCap.value, nextEntries.length)
+    // Mark the view as paged-open so the delta poller grows its cap for new
+    // rows instead of slicing the just-loaded older rows back off.
+    pagedOlder.value = true
     // latestSeq stays untouched: older paging only extends the tail, the
     // newest-cursor for delta polling is unaffected.
     logResource.state.value = loaded({


### PR DESCRIPTION
## 배경 (adversarial review of #21879)

#21879("load older" backward pagination) 머지 후 fresh-context 적대 리뷰에서 발견한 **P2 동작 결함**을 고칩니다. OCaml `Ring.recent ?before_seq` 코어는 sound(wrap 불변식·경계 수학 검증 통과). 결함은 프론트 delta-poll 경로에 있었습니다.

## 증상

`logs.ts`에서 `displayCap`(뷰에 유지할 최대 행수)은 `loadOlder`/`reset`에서만 커지고, **3초 delta poll 경로는 읽기만** 했습니다. 운영자가 "이전 기록 더 보기"로 오래된 N행을 로드한 뒤(current=N, displayCap=N), 매 delta poll이 K개 새 행을 append할 때 `mergeLogEntries(current, incoming, cap=N)`가 newest-first 정렬 후 `slice(0, N)` → **방금 페이징한 가장 오래된 K행을 제거**합니다. `autoRefresh`가 기본 ON + `POLL_INTERVAL_MS=3000`이라, 페이징한 기록이 수초 내 화면 하단에서 사라집니다 — 기능의 목적과 in-code 주석 모두에 모순.

기존 테스트는 페이징 직후 1 delta 사이클만(count == displayCap) 커버해 erosion을 노출하지 못했습니다.

## 수정 (근본)

delta poll의 merge cap을 뷰 상태에 맞게 계산합니다:
- **미페이징 정상 상태**: 고정 newest-N sliding window(`baseLimit`) — 메모리 bounded, 오래된 행 roll-off (기존 동작 유지).
- **페이징됨**(`pagedOlder`): 현재 표시 중인 모든 행 + 실제로 새로운(겹치지 않는) incoming 행을 모두 유지 → newest-first 슬라이싱이 방금 페이징한 가장 오래된 행을 제거하지 못함.

- `pagedOlder` 시그널 추가: `loadOlder`가 실제로 오래된 행을 로드하면 `true`, `reset`에서 `false`.
- cap 결정 로직을 순수 함수 `deltaMergeCap(current, incoming, pagedOlder, baseLimit)`로 추출(테스트 가능).
- `mergeLogEntries`도 export하여 end-to-end 보존 검증.
- 오해 소지 주석 2곳 교정(delta poll이 "절대 trim 안 함"이라는 과장 제거 → 실제 보장 명시).

## 테스트

`logs.test.ts`에 `deltaMergeCap` describe 블록 추가(4 케이스):
- 미페이징 → baseLimit sliding window
- 페이징 → current + fresh 만큼 cap 성장
- 겹치는 incoming은 fresh로 안 셈(dedup)
- **erosion 재현**: baseLimit=2, seq 8을 페이징 후 3회 delta(seq 11/12/13)에서 seq 8이 매 사이클 생존 → 최종 `[13,12,11,10,9,8]` 전부 보존

`npx vitest run src/components/logs.test.ts` → 14/14 PASS. typecheck/lint는 CI Dashboard/Lint 게이트가 검증.

## 경계
프론트엔드 전용(2 파일). OCaml/OAS/백엔드 미변경.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
