### PR TITLE
fix(dashboard): gate missing tool output on hydration coverage

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1852,6 +1852,7 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
         ]}
         emptyText="empty"
         groupToolCalls=${true}
+        toolOutputsCoveredThroughMs=${Date.parse('2026-03-24T00:00:01.000Z')}
       />`,
       container,
     )
@@ -1864,6 +1865,66 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     expect(step?.querySelector('.chat-block-tstep-status.pending')).toBeNull()
     // The gap is surfaced in the card header so silent failures are visible.
     expect(bundle?.textContent).toContain('결과 누락 1')
+  })
+
+  it('keeps a settled unjoined tool step pending until tool outputs hydrate', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({ id: 'tool-unjoined-before-hydration', label: 'keeper_board_comment', turnRef: 'trace-h#1' }),
+          entry({
+            id: 'a-before-hydration',
+            text: '답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            turnRef: 'trace-h#1',
+            streamState: null,
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+      />`,
+      container,
+    )
+
+    const bundle = container.querySelector('[data-chat-turn-bundle]')
+    const step = bundle?.querySelector('[data-chat-trace-step="tool"]')
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+    expect(bundle?.textContent).not.toContain('결과 누락')
+  })
+
+  it('keeps a settled unjoined tool step pending when only older output hydration completed', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({
+            id: 'tool-unjoined-after-old-hydration',
+            label: 'keeper_board_comment',
+            timestamp: '2026-03-24T00:00:10.000Z',
+            turnRef: 'trace-old#1',
+          }),
+          entry({
+            id: 'a-after-old-hydration',
+            text: '답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            turnRef: 'trace-old#1',
+            streamState: null,
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        toolOutputsCoveredThroughMs=${Date.parse('2026-03-24T00:00:01.000Z')}
+      />`,
+      container,
+    )
+
+    const bundle = container.querySelector('[data-chat-turn-bundle]')
+    const step = bundle?.querySelector('[data-chat-trace-step="tool"]')
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+    expect(bundle?.textContent).not.toContain('결과 누락')
   })
 
   it('keeps an unjoined tool step pending while the owning turn is still streaming', () => {

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1927,6 +1927,40 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     expect(bundle?.textContent).not.toContain('결과 누락')
   })
 
+  it('keeps a settled unjoined tool step pending when it predates the hydrated tool-output tail', () => {
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          toolEntry({
+            id: 'tool-unjoined-before-covered-tail',
+            label: 'keeper_board_comment',
+            timestamp: '2026-03-24T00:00:05.000Z',
+            turnRef: 'trace-tail#1',
+          }),
+          entry({
+            id: 'a-before-covered-tail',
+            text: '답합니다',
+            role: 'assistant',
+            source: 'direct_assistant',
+            turnRef: 'trace-tail#1',
+            streamState: null,
+          }),
+        ]}
+        emptyText="empty"
+        groupToolCalls=${true}
+        toolOutputsCoveredSinceMs=${Date.parse('2026-03-24T00:00:10.000Z')}
+        toolOutputsCoveredThroughMs=${Date.parse('2026-03-24T00:00:20.000Z')}
+      />`,
+      container,
+    )
+
+    const bundle = container.querySelector('[data-chat-turn-bundle]')
+    const step = bundle?.querySelector('[data-chat-trace-step="tool"]')
+    expect(step?.querySelector('.chat-block-tstep-status.pending')).not.toBeNull()
+    expect(step?.querySelector('.chat-block-tstep-status.missing')).toBeNull()
+    expect(bundle?.textContent).not.toContain('결과 누락')
+  })
+
   it('keeps an unjoined tool step pending while the owning turn is still streaming', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1852,6 +1852,7 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
         ]}
         emptyText="empty"
         groupToolCalls=${true}
+        toolOutputsCoveredSinceMs=${Date.parse('2026-03-24T00:00:00.000Z')}
         toolOutputsCoveredThroughMs=${Date.parse('2026-03-24T00:00:01.000Z')}
       />`,
       container,

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2085,11 +2085,14 @@ function isTurnStreaming(state: KeeperConversationEntry['streamState']): boolean
 
 function isToolOutputCoveredByHydration(
   entry: KeeperConversationEntry,
+  coveredSinceMs: number | null | undefined,
   coveredThroughMs: number | null | undefined,
 ): boolean {
   if (coveredThroughMs == null) return false
   const timestampMs = entry.timestamp ? Date.parse(entry.timestamp) : NaN
-  return Number.isFinite(timestampMs) && timestampMs <= coveredThroughMs
+  return Number.isFinite(timestampMs)
+    && (coveredSinceMs == null || timestampMs >= coveredSinceMs)
+    && timestampMs <= coveredThroughMs
 }
 
 // One step of a grouped tool-trace card: a single tool call rendered from REAL
@@ -2168,17 +2171,19 @@ function ToolTraceCard({
   tools,
   traceSteps = [],
   turnComplete = false,
+  toolOutputsCoveredSinceMs = null,
   toolOutputsCoveredThroughMs = null,
 }: {
   tools: KeeperConversationEntry[]
   traceSteps?: ChatTraceStep[]
   turnComplete?: boolean
+  toolOutputsCoveredSinceMs?: number | null
   toolOutputsCoveredThroughMs?: number | null
 }) {
   const [open, setOpen] = useState(true)
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
   const canMarkMissingForEntry = (entry: KeeperConversationEntry): boolean =>
-    turnComplete && isToolOutputCoveredByHydration(entry, toolOutputsCoveredThroughMs)
+    turnComplete && isToolOutputCoveredByHydration(entry, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs)
   const failN = steps.filter(
     (s) => s.output !== null && (s.output.success === false || s.output.semantic_success === false),
   ).length
@@ -2232,6 +2237,7 @@ function TurnWorkBundle({
   showMetadata,
   variant,
   showSourceBadge,
+  toolOutputsCoveredSinceMs,
   toolOutputsCoveredThroughMs,
   action,
 }: {
@@ -2240,6 +2246,7 @@ function TurnWorkBundle({
   showMetadata?: boolean
   variant: ChatTranscriptVariant
   showSourceBadge: boolean
+  toolOutputsCoveredSinceMs: number | null
   toolOutputsCoveredThroughMs: number | null
   action?: ChatTranscriptAction
 }) {
@@ -2253,6 +2260,7 @@ function TurnWorkBundle({
         tools=${tools}
         traceSteps=${traceSteps}
         turnComplete=${turnComplete}
+        toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
         toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
       />
       <${ChatMessageBubble}
@@ -2368,10 +2376,11 @@ function renderChatTranscriptBody(opts: {
   showMetadata?: boolean
   variant: ChatTranscriptVariant
   showSourceBadge: boolean
+  toolOutputsCoveredSinceMs: number | null
   toolOutputsCoveredThroughMs: number | null
   action?: ChatTranscriptAction
 }): VNode[] {
-  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredThroughMs, action } = opts
+  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs, action } = opts
   const units = buildChatRenderUnits(entries, groupToolCalls)
   const out: VNode[] = []
   // Track the last NON-NULL calendar day rather than only the immediately
@@ -2401,6 +2410,7 @@ function renderChatTranscriptBody(opts: {
         showMetadata=${showMetadata}
         variant=${variant}
         showSourceBadge=${showSourceBadge}
+        toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
         toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
         action=${action}
       />`)
@@ -2439,6 +2449,7 @@ export function ChatTranscript({
   showDayDividers = false,
   groupToolCalls = false,
   showSourceBadge = false,
+  toolOutputsCoveredSinceMs = null,
   toolOutputsCoveredThroughMs = null,
   action,
 }: {
@@ -2454,6 +2465,7 @@ export function ChatTranscript({
   // Default false so non-workspace surfaces keep the flat per-row ToolCallBubble.
   groupToolCalls?: boolean
   showSourceBadge?: boolean
+  toolOutputsCoveredSinceMs?: number | null
   toolOutputsCoveredThroughMs?: number | null
   action?: ChatTranscriptAction
 }) {
@@ -2465,16 +2477,19 @@ export function ChatTranscript({
     [entries],
   )
   const toolOutputSignature = useMemo(
-    () => entries
-      .filter(entry => entry.role === 'tool')
-      .map((entry) => {
-        const output = lookupToolCallOutput(entry.id)
-        return output
-          ? `${entry.id}:${output.success}:${output.semantic_success ?? ''}:${output.duration_ms}:${toolOutputDisplay(output.output)?.text.length ?? 0}`
-          : `${entry.id}:pending`
-      })
-      .join('|'),
-    [entries, toolCallOutputsById.value],
+    () => {
+      const coverageSig = `${toolOutputsCoveredSinceMs ?? ''}:${toolOutputsCoveredThroughMs ?? ''}`
+      return entries
+        .filter(entry => entry.role === 'tool')
+        .map((entry) => {
+          const output = lookupToolCallOutput(entry.id)
+          return output
+            ? `${entry.id}:${output.success}:${output.semantic_success ?? ''}:${output.duration_ms}:${toolOutputDisplay(output.output)?.text.length ?? 0}`
+            : `${entry.id}:pending:${coverageSig}`
+        })
+        .join('|')
+    },
+    [entries, toolCallOutputsById.value, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs],
   )
 
   const scrollToBottom = () => {
@@ -2540,6 +2555,7 @@ export function ChatTranscript({
               showMetadata,
               variant,
               showSourceBadge,
+              toolOutputsCoveredSinceMs,
               toolOutputsCoveredThroughMs,
               action,
             })}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2075,27 +2075,36 @@ const TOOL_STATUS_TITLE: Record<'pending' | 'missing' | 'ok' | 'bad', string> = 
   bad: '실패',
 }
 
-// A tool call's output is legitimately "pending" only while its turn is still
-// streaming. Once the owning assistant turn has settled (streamState null), an
-// output that never joined will never arrive — so an indefinite "pending" dot
-// hides a real gap (e.g. a call whose tool_use_id was empty and never joined).
+// A tool call's output is legitimately "pending" while its turn is still
+// streaming, or before the separate tool-output hydration surface has loaded.
+// Once both have settled, an output that never joined is a gap (e.g. a call
+// whose tool_use_id was empty and never joined), not indefinite "pending".
 function isTurnStreaming(state: KeeperConversationEntry['streamState']): boolean {
   return state === 'opening' || state === 'thinking' || state === 'streaming' || state === 'finalizing'
+}
+
+function isToolOutputCoveredByHydration(
+  entry: KeeperConversationEntry,
+  coveredThroughMs: number | null | undefined,
+): boolean {
+  if (coveredThroughMs == null) return false
+  const timestampMs = entry.timestamp ? Date.parse(entry.timestamp) : NaN
+  return Number.isFinite(timestampMs) && timestampMs <= coveredThroughMs
 }
 
 // One step of a grouped tool-trace card: a single tool call rendered from REAL
 // data only. Name + input args come from the chat entry; status, duration and
 // result are joined from the tool-call output store. A null output is "pending"
-// while the turn streams; once the turn has settled (turnSettled) a still-null
-// output is "missing" (unknown outcome) rather than an indefinite "pending".
-function ToolTraceStep({ entry, output, turnSettled = false }: { entry: KeeperConversationEntry; output: ToolCallEntry | null; turnSettled?: boolean }) {
+// until the owning turn and output hydration have both settled; after that, a
+// still-null output is "missing" (unknown outcome).
+function ToolTraceStep({ entry, output, canMarkMissing = false }: { entry: KeeperConversationEntry; output: ToolCallEntry | null; canMarkMissing?: boolean }) {
   const [open, setOpen] = useState(false)
   const name = entry.label || 'tool'
   const displayArgs = prettyJsonish(entry.text || '')
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
   const status: 'pending' | 'missing' | 'ok' | 'bad' =
     output === null
-      ? turnSettled
+      ? canMarkMissing
         ? 'missing'
         : 'pending'
       : output.success === false || output.semantic_success === false
@@ -2141,7 +2150,7 @@ function ToolTraceStep({ entry, output, turnSettled = false }: { entry: KeeperCo
                       <pre class="m-0 max-h-64 overflow-y-auto whitespace-pre-wrap break-all text-2xs">${resultView.text}</pre>
                     `
                   : output === null
-                    ? html`<div class="chat-block-tool-label">${turnSettled ? '결과 없음 — 출력이 도착하지 않음' : '출력 대기 중…'}</div>`
+                    ? html`<div class="chat-block-tool-label">${canMarkMissing ? '결과 없음 — 출력이 도착하지 않음' : '출력 대기 중…'}</div>`
                     : null}
               </div>
             `
@@ -2158,20 +2167,24 @@ function ToolTraceStep({ entry, output, turnSettled = false }: { entry: KeeperCo
 function ToolTraceCard({
   tools,
   traceSteps = [],
-  turnSettled = false,
+  turnComplete = false,
+  toolOutputsCoveredThroughMs = null,
 }: {
   tools: KeeperConversationEntry[]
   traceSteps?: ChatTraceStep[]
-  turnSettled?: boolean
+  turnComplete?: boolean
+  toolOutputsCoveredThroughMs?: number | null
 }) {
   const [open, setOpen] = useState(true)
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
+  const canMarkMissingForEntry = (entry: KeeperConversationEntry): boolean =>
+    turnComplete && isToolOutputCoveredByHydration(entry, toolOutputsCoveredThroughMs)
   const failN = steps.filter(
     (s) => s.output !== null && (s.output.success === false || s.output.semantic_success === false),
   ).length
-  // Surface unjoined outputs as "missing" only once the turn has settled — while
-  // it streams they are still legitimately pending, not a gap.
-  const missingN = turnSettled ? steps.filter((s) => s.output === null).length : 0
+  // Surface unjoined outputs as "missing" only once the turn and output
+  // hydration have both settled.
+  const missingN = steps.filter((s) => s.output === null && canMarkMissingForEntry(s.entry)).length
   const totalMs = steps.reduce((sum, s) => sum + (s.output?.duration_ms ?? 0), 0)
   const durLabel = totalMs > 0 ? formatMsCompact(totalMs) : null
   const stepN = traceSteps.length + tools.length
@@ -2200,7 +2213,12 @@ function ToolTraceCard({
             <div class="chat-block-trace-steps">
               <span class="chat-block-trace-rail"></span>
               ${traceSteps.map((step, index) => html`<${ChatTraceStep} key=${`trace-${index}`} step=${step} />`)}
-              ${steps.map(({ entry, output }) => html`<${ToolTraceStep} key=${entry.id} entry=${entry} output=${output} turnSettled=${turnSettled} />`)}
+              ${steps.map(({ entry, output }) => html`<${ToolTraceStep}
+                key=${entry.id}
+                entry=${entry}
+                output=${output}
+                canMarkMissing=${canMarkMissingForEntry(entry)}
+              />`)}
             </div>
           `
         : null}
@@ -2214,6 +2232,7 @@ function TurnWorkBundle({
   showMetadata,
   variant,
   showSourceBadge,
+  toolOutputsCoveredThroughMs,
   action,
 }: {
   tools: KeeperConversationEntry[]
@@ -2221,15 +2240,21 @@ function TurnWorkBundle({
   showMetadata?: boolean
   variant: ChatTranscriptVariant
   showSourceBadge: boolean
+  toolOutputsCoveredThroughMs: number | null
   action?: ChatTranscriptAction
 }) {
   const traceSteps = assistant.traceSteps ?? []
-  // The bundle owns the settled assistant entry, so an unjoined tool output here
-  // is a real gap (not in-flight) once the turn stops streaming.
-  const turnSettled = !isTurnStreaming(assistant.streamState)
+  // The bundle owns the assistant entry, but output hydration is a separate
+  // async surface. Only mark gaps after that surface has successfully loaded.
+  const turnComplete = !isTurnStreaming(assistant.streamState)
   return html`
     <div class="chat-turn-bundle" data-chat-turn-bundle>
-      <${ToolTraceCard} tools=${tools} traceSteps=${traceSteps} turnSettled=${turnSettled} />
+      <${ToolTraceCard}
+        tools=${tools}
+        traceSteps=${traceSteps}
+        turnComplete=${turnComplete}
+        toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
+      />
       <${ChatMessageBubble}
         entry=${assistant}
         showMetadata=${showMetadata !== false}
@@ -2343,9 +2368,10 @@ function renderChatTranscriptBody(opts: {
   showMetadata?: boolean
   variant: ChatTranscriptVariant
   showSourceBadge: boolean
+  toolOutputsCoveredThroughMs: number | null
   action?: ChatTranscriptAction
 }): VNode[] {
-  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, action } = opts
+  const { entries, showDayDividers, groupToolCalls, showMetadata, variant, showSourceBadge, toolOutputsCoveredThroughMs, action } = opts
   const units = buildChatRenderUnits(entries, groupToolCalls)
   const out: VNode[] = []
   // Track the last NON-NULL calendar day rather than only the immediately
@@ -2375,6 +2401,7 @@ function renderChatTranscriptBody(opts: {
         showMetadata=${showMetadata}
         variant=${variant}
         showSourceBadge=${showSourceBadge}
+        toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}
         action=${action}
       />`)
     } else if (unit.entry.role === 'tool') {
@@ -2412,6 +2439,7 @@ export function ChatTranscript({
   showDayDividers = false,
   groupToolCalls = false,
   showSourceBadge = false,
+  toolOutputsCoveredThroughMs = null,
   action,
 }: {
   entries: KeeperConversationEntry[]
@@ -2426,6 +2454,7 @@ export function ChatTranscript({
   // Default false so non-workspace surfaces keep the flat per-row ToolCallBubble.
   groupToolCalls?: boolean
   showSourceBadge?: boolean
+  toolOutputsCoveredThroughMs?: number | null
   action?: ChatTranscriptAction
 }) {
   const scrollerRef = useRef<HTMLDivElement | null>(null)
@@ -2511,6 +2540,7 @@ export function ChatTranscript({
               showMetadata,
               variant,
               showSourceBadge,
+              toolOutputsCoveredThroughMs,
               action,
             })}
       </div>

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -48,7 +48,10 @@ import { AttachDraftChip, ChatComposer, ChatTranscript, STREAM_STALL_THRESHOLD_S
 import { showToast } from './common/toast'
 import { TextInput } from './common/input'
 import { shellAuthSummary } from '../store'
-import { toolCallOutputsCoveredThroughMs } from '../tool-call-output-store'
+import {
+  toolCallOutputsCoveredSinceMs,
+  toolCallOutputsCoveredThroughMs,
+} from '../tool-call-output-store'
 
 
 const KEEPER_CHAT_METADATA_VISIBLE_KEY = 'masc_keeper_chat_metadata_visible'
@@ -660,6 +663,7 @@ export function KeeperConversationPanel({
               showDayDividers=${true}
               groupToolCalls=${true}
               showSourceBadge=${true}
+              toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
               toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
               action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
             />
@@ -789,6 +793,7 @@ export function KeeperConversationPanel({
           variant="messenger"
           size="primary"
           groupToolCalls=${true}
+          toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
           toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
           action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
         />
@@ -902,6 +907,7 @@ export function KeeperConversationPanel({
             variant="messenger"
             size="default"
             groupToolCalls=${true}
+            toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
             toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
             action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
           />

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -48,6 +48,7 @@ import { AttachDraftChip, ChatComposer, ChatTranscript, STREAM_STALL_THRESHOLD_S
 import { showToast } from './common/toast'
 import { TextInput } from './common/input'
 import { shellAuthSummary } from '../store'
+import { toolCallOutputsCoveredThroughMs } from '../tool-call-output-store'
 
 
 const KEEPER_CHAT_METADATA_VISIBLE_KEY = 'masc_keeper_chat_metadata_visible'
@@ -659,6 +660,7 @@ export function KeeperConversationPanel({
               showDayDividers=${true}
               groupToolCalls=${true}
               showSourceBadge=${true}
+              toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
               action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
             />
           </div>
@@ -787,6 +789,7 @@ export function KeeperConversationPanel({
           variant="messenger"
           size="primary"
           groupToolCalls=${true}
+          toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
           action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
         />
 
@@ -899,6 +902,7 @@ export function KeeperConversationPanel({
             variant="messenger"
             size="default"
             groupToolCalls=${true}
+            toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
             action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
           />
         </div>

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -32,7 +32,7 @@ const {
   streamKeeperMessage: vi.fn(),
 }))
 const { fetchKeeperToolCalls } = vi.hoisted(() => ({
-  fetchKeeperToolCalls: vi.fn(async () => ({ entries: [] })),
+  fetchKeeperToolCalls: vi.fn(async (): Promise<{ entries: ToolCallEntry[] }> => ({ entries: [] })),
 }))
 
 vi.mock('./api/mcp', () => ({ callMcpTool }))
@@ -82,12 +82,19 @@ import {
   upsertPendingKeeperChatRequest,
 } from './keeper-chat-pending'
 import { KEEPER_HISTORY_TAIL_MESSAGES } from './config/constants'
+import {
+  resetToolCallOutputs,
+  toolCallOutputsCoveredSinceMs,
+  toolCallOutputsCoveredThroughMs,
+} from './tool-call-output-store'
 import type { KeeperChatStreamEvent } from './api'
+import type { ToolCallEntry } from './api/dashboard'
 import type { KeeperConversationAttachment, KeeperStatusDetail } from './types'
 
 beforeEach(() => {
   fetchKeeperToolCalls.mockReset()
   fetchKeeperToolCalls.mockResolvedValue({ entries: [] })
+  resetToolCallOutputs()
 })
 
 describe('noteKeeperChatAppended', () => {
@@ -183,6 +190,39 @@ describe('hydrateKeeperChatHistory', () => {
     await hydrateKeeperChatHistory('echo')
 
     expect(fetchKeeperToolCalls).toHaveBeenCalledWith('echo', 200)
+  })
+
+  it('bounds tool-output hydration to the returned output tail', async () => {
+    fetchKeeperChatHistory.mockResolvedValue([])
+    fetchKeeperToolCalls.mockResolvedValue({
+      entries: [
+        {
+          ts: 1_780_000_010,
+          keeper: 'echo',
+          tool: 'keeper_context_status',
+          input: {},
+          output: 'ok',
+          success: true,
+          duration_ms: 12,
+          tool_use_id: 'toolu_recent',
+        },
+      ],
+    })
+
+    await hydrateKeeperChatHistory('echo')
+
+    expect(toolCallOutputsCoveredSinceMs('echo')).toBe(1_780_000_010_000)
+    expect(toolCallOutputsCoveredThroughMs('echo')).not.toBeNull()
+  })
+
+  it('does not treat an empty tool-output fetch as unbounded coverage', async () => {
+    fetchKeeperChatHistory.mockResolvedValue([])
+    fetchKeeperToolCalls.mockResolvedValue({ entries: [] })
+
+    await hydrateKeeperChatHistory('echo')
+
+    expect(toolCallOutputsCoveredSinceMs('echo')).toBe(Number.POSITIVE_INFINITY)
+    expect(toolCallOutputsCoveredThroughMs('echo')).not.toBeNull()
   })
 
   it('allows a retry after a failed fetch', async () => {

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -195,6 +195,17 @@ export async function hydrateKeeperChatHistory(
 // horizon keeps every visible row eligible for output join.
 const TOOL_OUTPUT_FETCH_LIMIT = KEEPER_HISTORY_TAIL_MESSAGES
 
+function toolOutputCoveredSinceMs(entries: readonly { ts: number }[], limit: number): number | null {
+  if (entries.length < limit) return null
+  const oldestMs = entries.reduce((oldest, entry) => {
+    const ms = entry.ts * 1000
+    return Number.isFinite(ms) ? Math.min(oldest, ms) : oldest
+  }, Number.POSITIVE_INFINITY)
+  // Saturated response with no parseable timestamp: do not mark any older
+  // unjoined tool row missing, because the fetched tail's lower bound is unknown.
+  return Number.isFinite(oldestMs) ? oldestMs : Number.POSITIVE_INFINITY
+}
+
 /** Best-effort hydration of tool-call outputs into the shared store so the
  *  chat ToolCallBubble can join results onto transcript rows by tool_use_id.
  *  Failures are swallowed (logged): the transcript must render with or without
@@ -204,7 +215,11 @@ async function hydrateKeeperToolOutputs(keeperName: string): Promise<void> {
   try {
     const response = await fetchKeeperToolCalls(keeperName, TOOL_OUTPUT_FETCH_LIMIT)
     recordToolCallOutputs(response.entries)
-    markToolCallOutputsHydrated(keeperName, coveredThroughMs)
+    markToolCallOutputsHydrated(
+      keeperName,
+      coveredThroughMs,
+      toolOutputCoveredSinceMs(response.entries, TOOL_OUTPUT_FETCH_LIMIT),
+    )
   } catch (err) {
     markToolCallOutputsHydrationFailed(keeperName)
     const message = err instanceof Error ? err.message : String(err)

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -10,7 +10,12 @@ import {
   streamKeeperMessage,
 } from './api/keeper'
 import { fetchKeeperToolCalls } from './api/dashboard'
-import { recordToolCallOutputs } from './tool-call-output-store'
+import {
+  markToolCallOutputsHydrated,
+  markToolCallOutputsHydrating,
+  markToolCallOutputsHydrationFailed,
+  recordToolCallOutputs,
+} from './tool-call-output-store'
 import { asString, isRecord } from './components/common/normalize'
 import { invalidateDashboardCache, refreshDashboard } from './store'
 import { isAbortError } from './lib/async-state'
@@ -195,10 +200,13 @@ const TOOL_OUTPUT_FETCH_LIMIT = KEEPER_HISTORY_TAIL_MESSAGES
  *  Failures are swallowed (logged): the transcript must render with or without
  *  tool outputs. */
 async function hydrateKeeperToolOutputs(keeperName: string): Promise<void> {
+  const coveredThroughMs = markToolCallOutputsHydrating(keeperName)
   try {
     const response = await fetchKeeperToolCalls(keeperName, TOOL_OUTPUT_FETCH_LIMIT)
     recordToolCallOutputs(response.entries)
+    markToolCallOutputsHydrated(keeperName, coveredThroughMs)
   } catch (err) {
+    markToolCallOutputsHydrationFailed(keeperName)
     const message = err instanceof Error ? err.message : String(err)
     console.warn(`[keeper] tool-call output hydration failed for ${keeperName}:`, message)
   }

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -192,17 +192,17 @@ export async function hydrateKeeperChatHistory(
 
 // Match the visible chat history window. A keeper that calls many tools can
 // easily have >100 tool rows inside the 200-row transcript; using the same
-// horizon keeps every visible row eligible for output join.
+// horizon keeps every visible recent row eligible for output join.
 const TOOL_OUTPUT_FETCH_LIMIT = KEEPER_HISTORY_TAIL_MESSAGES
 
-function toolOutputCoveredSinceMs(entries: readonly { ts: number }[], limit: number): number | null {
-  if (entries.length < limit) return null
+function toolOutputCoveredSinceMs(entries: readonly { ts: number }[]): number {
   const oldestMs = entries.reduce((oldest, entry) => {
     const ms = entry.ts * 1000
     return Number.isFinite(ms) ? Math.min(oldest, ms) : oldest
   }, Number.POSITIVE_INFINITY)
-  // Saturated response with no parseable timestamp: do not mark any older
-  // unjoined tool row missing, because the fetched tail's lower bound is unknown.
+  // The backend filters a global recent tool-call tail by keeper, so a short
+  // response is not proof that no older matching keeper rows exist. Only the
+  // timestamp span actually returned by this fetch is safe to mark covered.
   return Number.isFinite(oldestMs) ? oldestMs : Number.POSITIVE_INFINITY
 }
 
@@ -218,7 +218,7 @@ async function hydrateKeeperToolOutputs(keeperName: string): Promise<void> {
     markToolCallOutputsHydrated(
       keeperName,
       coveredThroughMs,
-      toolOutputCoveredSinceMs(response.entries, TOOL_OUTPUT_FETCH_LIMIT),
+      toolOutputCoveredSinceMs(response.entries),
     )
   } catch (err) {
     markToolCallOutputsHydrationFailed(keeperName)

--- a/dashboard/src/tool-call-output-store.test.ts
+++ b/dashboard/src/tool-call-output-store.test.ts
@@ -2,9 +2,13 @@ import { afterEach, describe, expect, it } from 'vitest'
 import type { ToolCallEntry } from './api/dashboard'
 import {
   lookupToolCallOutput,
+  markToolCallOutputsHydrated,
+  markToolCallOutputsHydrating,
   recordToolCallOutputs,
   resetToolCallOutputs,
   toolCallOutputsById,
+  toolCallOutputsCoveredSinceMs,
+  toolCallOutputsCoveredThroughMs,
 } from './tool-call-output-store'
 
 function toolCall(overrides: Partial<ToolCallEntry> = {}): ToolCallEntry {
@@ -78,5 +82,21 @@ describe('tool-call-output-store', () => {
     const stored = lookupToolCallOutput('tool-toolu_blob')?.output
     expect(typeof stored).toBe('object')
     expect(stored).toMatchObject({ _blob: { preview: 'preview…' } })
+  })
+
+  it('tracks bounded hydration coverage for tail-limited output fetches', () => {
+    markToolCallOutputsHydrating('sangsu')
+    markToolCallOutputsHydrated('sangsu', 2_000, 1_000)
+
+    expect(toolCallOutputsCoveredSinceMs('sangsu')).toBe(1_000)
+    expect(toolCallOutputsCoveredThroughMs('sangsu')).toBe(2_000)
+  })
+
+  it('merges unbounded hydration coverage without retaining an old lower bound', () => {
+    markToolCallOutputsHydrated('sangsu', 2_000, 1_000)
+    markToolCallOutputsHydrated('sangsu', 3_000, null)
+
+    expect(toolCallOutputsCoveredSinceMs('sangsu')).toBeNull()
+    expect(toolCallOutputsCoveredThroughMs('sangsu')).toBe(3_000)
   })
 })

--- a/dashboard/src/tool-call-output-store.ts
+++ b/dashboard/src/tool-call-output-store.ts
@@ -24,6 +24,7 @@ export const toolCallOutputsById = signal<Map<string, ToolCallEntry>>(new Map())
 
 interface ToolCallOutputHydrationState {
   inFlight: number
+  coveredSinceMs: number | null
   coveredThroughMs: number | null
   failed: boolean
 }
@@ -35,7 +36,12 @@ function keeperKey(keeperName: string): string {
 }
 
 function currentHydrationState(keeperName: string): ToolCallOutputHydrationState {
-  return toolCallOutputHydrationByKeeper.value[keeperName] ?? { inFlight: 0, coveredThroughMs: null, failed: false }
+  return toolCallOutputHydrationByKeeper.value[keeperName] ?? {
+    inFlight: 0,
+    coveredSinceMs: null,
+    coveredThroughMs: null,
+    failed: false,
+  }
 }
 
 function updateHydrationState(
@@ -48,6 +54,7 @@ function updateHydrationState(
   const next = update(current)
   if (
     current.inFlight === next.inFlight
+    && current.coveredSinceMs === next.coveredSinceMs
     && current.coveredThroughMs === next.coveredThroughMs
     && current.failed === next.failed
   ) return
@@ -69,9 +76,21 @@ export function markToolCallOutputsHydrating(keeperName: string): number {
   return startedAtMs
 }
 
-export function markToolCallOutputsHydrated(keeperName: string, coveredThroughMs: number): void {
+function mergeCoveredSince(current: number | null, next: number | null): number | null {
+  if (current == null || next == null) return null
+  return Math.min(current, next)
+}
+
+export function markToolCallOutputsHydrated(
+  keeperName: string,
+  coveredThroughMs: number,
+  coveredSinceMs: number | null = null,
+): void {
   updateHydrationState(keeperName, current => ({
     inFlight: Math.max(0, current.inFlight - 1),
+    coveredSinceMs: current.coveredThroughMs == null
+      ? coveredSinceMs
+      : mergeCoveredSince(current.coveredSinceMs, coveredSinceMs),
     coveredThroughMs: Math.max(current.coveredThroughMs ?? 0, coveredThroughMs),
     failed: false,
   }))
@@ -90,6 +109,11 @@ export function markToolCallOutputsHydrationFailed(keeperName: string): void {
 export function toolCallOutputsCoveredThroughMs(keeperName: string): number | null {
   const key = keeperKey(keeperName)
   return key ? (toolCallOutputHydrationByKeeper.value[key]?.coveredThroughMs ?? null) : null
+}
+
+export function toolCallOutputsCoveredSinceMs(keeperName: string): number | null {
+  const key = keeperKey(keeperName)
+  return key ? (toolCallOutputHydrationByKeeper.value[key]?.coveredSinceMs ?? null) : null
 }
 
 /** Merge tool-call entries into the store, keyed by tool_use_id. Entries

--- a/dashboard/src/tool-call-output-store.ts
+++ b/dashboard/src/tool-call-output-store.ts
@@ -22,6 +22,76 @@ const TOOL_ENTRY_ID_PREFIX = 'tool-'
 // Replaced (not mutated) on each merge so signal subscribers re-render.
 export const toolCallOutputsById = signal<Map<string, ToolCallEntry>>(new Map())
 
+interface ToolCallOutputHydrationState {
+  inFlight: number
+  coveredThroughMs: number | null
+  failed: boolean
+}
+
+export const toolCallOutputHydrationByKeeper = signal<Record<string, ToolCallOutputHydrationState>>({})
+
+function keeperKey(keeperName: string): string {
+  return keeperName.trim()
+}
+
+function currentHydrationState(keeperName: string): ToolCallOutputHydrationState {
+  return toolCallOutputHydrationByKeeper.value[keeperName] ?? { inFlight: 0, coveredThroughMs: null, failed: false }
+}
+
+function updateHydrationState(
+  keeperName: string,
+  update: (current: ToolCallOutputHydrationState) => ToolCallOutputHydrationState,
+): void {
+  const key = keeperKey(keeperName)
+  if (!key) return
+  const current = currentHydrationState(key)
+  const next = update(current)
+  if (
+    current.inFlight === next.inFlight
+    && current.coveredThroughMs === next.coveredThroughMs
+    && current.failed === next.failed
+  ) return
+  toolCallOutputHydrationByKeeper.value = {
+    ...toolCallOutputHydrationByKeeper.value,
+    [key]: next,
+  }
+}
+
+export function markToolCallOutputsHydrating(keeperName: string): number {
+  const startedAtMs = Date.now()
+  const key = keeperKey(keeperName)
+  if (!key) return startedAtMs
+  updateHydrationState(key, current => ({
+    ...current,
+    inFlight: current.inFlight + 1,
+    failed: false,
+  }))
+  return startedAtMs
+}
+
+export function markToolCallOutputsHydrated(keeperName: string, coveredThroughMs: number): void {
+  updateHydrationState(keeperName, current => ({
+    inFlight: Math.max(0, current.inFlight - 1),
+    coveredThroughMs: Math.max(current.coveredThroughMs ?? 0, coveredThroughMs),
+    failed: false,
+  }))
+}
+
+export function markToolCallOutputsHydrationFailed(keeperName: string): void {
+  const key = keeperKey(keeperName)
+  if (!key) return
+  updateHydrationState(key, current => ({
+    ...current,
+    inFlight: Math.max(0, current.inFlight - 1),
+    failed: true,
+  }))
+}
+
+export function toolCallOutputsCoveredThroughMs(keeperName: string): number | null {
+  const key = keeperKey(keeperName)
+  return key ? (toolCallOutputHydrationByKeeper.value[key]?.coveredThroughMs ?? null) : null
+}
+
 /** Merge tool-call entries into the store, keyed by tool_use_id. Entries
  *  without a tool_use_id are skipped — they have no stable join key to the
  *  chat transcript (and their output was not persisted either, since the log
@@ -52,4 +122,5 @@ export function lookupToolCallOutput(toolEntryId: string): ToolCallEntry | null 
 /** Test/teardown helper: drop all recorded outputs. */
 export function resetToolCallOutputs(): void {
   toolCallOutputsById.value = new Map()
+  toolCallOutputHydrationByKeeper.value = {}
 }


### PR DESCRIPTION
## Summary
- Prevent settled tool calls from being marked missing before the separate tool-output hydration surface has covered that tool row.
- Track keeper tool-output hydration coverage by successful fetch start time instead of a sticky ready boolean.
- Add regressions for pre-hydration and older-hydration races.

## Verification
- vitest run --config vitest.config.ts src/components/chat/primitives.test.ts src/tool-call-output-store.test.ts --no-file-parallelism --maxWorkers=1
- tsc --noEmit --pretty false
- eslint src/components/chat/primitives.ts src/components/chat/primitives.test.ts src/components/keeper-shared.ts src/keeper-actions.ts src/tool-call-output-store.ts
- git diff --check origin/main...HEAD

Follow-up to merged #21892.