### PR TITLE
fix(dashboard): fusion 결론 fallback + 보관 만료 표시 (chat 카드)

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -2036,6 +2036,59 @@ describe('fusion chat card', () => {
     expect(container.querySelector('[data-fusion-detail]')?.textContent).toContain('불러오지 못했습니다')
   })
 
+  it('falls back to the persisted conclusion text when the board fetch fails', async () => {
+    vi.mocked(fetchBoardPost).mockRejectedValue(new Error('boom'))
+    render(html`<${ChatTranscript} entries=${[fusionEntry()]} emptyText="empty" />`, container)
+    fireEvent.click(container.querySelector('[data-fusion-card] button') as HTMLButtonElement)
+    await flushUi()
+    const fallback = container.querySelector('[data-fusion-fallback]')
+    expect(fallback).not.toBeNull()
+    expect(fallback?.textContent).toContain('answer — done')
+  })
+
+  it('falls back to the persisted conclusion text when the board post has no panel/judge', async () => {
+    vi.mocked(fetchBoardPost).mockResolvedValue({
+      meta: { source: 'fusion', panel: [], judge: null },
+    } as unknown as Awaited<ReturnType<typeof fetchBoardPost>>)
+    render(html`<${ChatTranscript} entries=${[fusionEntry()]} emptyText="empty" />`, container)
+    fireEvent.click(container.querySelector('[data-fusion-card] button') as HTMLButtonElement)
+    await flushUi()
+    const fallback = container.querySelector('[data-fusion-fallback]')
+    expect(fallback).not.toBeNull()
+    expect(fallback?.textContent).toContain('answer — done')
+    expect(container.querySelector('[data-fusion-detail]')?.textContent).not.toContain('비어 있습니다')
+  })
+
+  it('does not show the fallback conclusion when panel/judge load successfully', async () => {
+    vi.mocked(fetchBoardPost).mockResolvedValue({
+      meta: {
+        source: 'fusion',
+        panel: [{ model: 'm1', status: 'answered', answer: 'A' }],
+        judge: { status: 'synthesized', decision: 'd', resolved_answer: 'R' },
+      },
+    } as unknown as Awaited<ReturnType<typeof fetchBoardPost>>)
+    render(html`<${ChatTranscript} entries=${[fusionEntry()]} emptyText="empty" />`, container)
+    fireEvent.click(container.querySelector('[data-fusion-card] button') as HTMLButtonElement)
+    await flushUi()
+    expect(container.querySelector('[data-fusion-fallback]')).toBeNull()
+  })
+
+  it('shows a retention note in the expanded detail', async () => {
+    vi.mocked(fetchBoardPost).mockResolvedValue({
+      meta: {
+        source: 'fusion',
+        panel: [],
+        judge: { status: 'synthesized', decision: 'd', resolved_answer: 'R' },
+      },
+    } as unknown as Awaited<ReturnType<typeof fetchBoardPost>>)
+    render(html`<${ChatTranscript} entries=${[fusionEntry()]} emptyText="empty" />`, container)
+    fireEvent.click(container.querySelector('[data-fusion-card] button') as HTMLButtonElement)
+    await flushUi()
+    const retention = container.querySelector('[data-fusion-retention]')
+    expect(retention).not.toBeNull()
+    expect(retention?.textContent).toContain('만료')
+  })
+
   it('renders judge.synthesis as markdown (not the raw resolved_answer dump)', async () => {
     vi.mocked(fetchBoardPost).mockResolvedValue({
       meta: {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1240,7 +1240,7 @@ function FusionPanelRow({ entry }: { entry: FusionPanelEntry }) {
   `
 }
 
-function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: string }) {
+function ChatFusionCard({ boardPostId, runId, fallbackText }: { boardPostId: string; runId?: string; fallbackText?: string }) {
   const [expanded, setExpanded] = useState(false)
   const [state, setState] = useState<{
     status: 'idle' | 'loading' | 'loaded' | 'error'
@@ -1304,7 +1304,12 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
               ? html`<div class="text-xs text-[var(--color-fg-secondary,#9da7b3)]">불러오는 중…</div>`
               : null}
             ${state.status === 'error'
-              ? html`<div class="text-xs text-[var(--color-danger,#e06c75)]">상세를 불러오지 못했습니다: ${state.error}</div>`
+              ? html`
+                <div class="text-xs text-[var(--color-danger,#e06c75)]">상세를 불러오지 못했습니다: ${state.error}</div>
+                ${fallbackText && fallbackText.trim()
+                  ? html`<div class="mt-1" data-fusion-fallback><${FusionMarkdown} text=${fallbackText} /></div>`
+                  : null}
+              `
               : null}
             ${state.status === 'loaded'
               ? html`
@@ -1331,10 +1336,13 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
                   `
                   : null}
                 ${state.panel.length === 0 && !state.judge
-                  ? html`<div class="text-xs text-[var(--color-fg-secondary,#9da7b3)]">패널/심판 상세가 비어 있습니다.</div>`
+                  ? fallbackText && fallbackText.trim()
+                    ? html`<div class="mt-1" data-fusion-fallback><${FusionMarkdown} text=${fallbackText} /></div>`
+                    : html`<div class="text-xs text-[var(--color-fg-secondary,#9da7b3)]">패널/심판 상세가 비어 있습니다.</div>`
                   : null}
               `
               : null}
+            <div class="text-2xs text-[var(--color-fg-muted,#6b7280)]" data-fusion-retention>심의 상세는 board 보관 기간이 지나면 만료됩니다.</div>
           </div>
         `
         : null}
@@ -1342,7 +1350,7 @@ function ChatFusionCard({ boardPostId, runId }: { boardPostId: string; runId?: s
   `
 }
 
-function ChatBlock({ block }: { block: ChatBlock }) {
+function ChatBlock({ block, fallbackText }: { block: ChatBlock; fallbackText?: string }) {
   switch (block.t) {
     case 'p': return html`<${ChatTextBlock} html=${block.html} />`
     case 'h4': return html`<${ChatHeadingBlock} html=${block.html} />`
@@ -1360,15 +1368,15 @@ function ChatBlock({ block }: { block: ChatBlock }) {
     case 'trace': return html`<${ChatTraceBlock} trace=${block.trace} />`
     case 'link': return html`<${ChatLinkBlock} url=${block.url} title=${block.title} desc=${block.desc} meta=${block.meta} fav=${block.fav} kind=${block.kind} />`
     case 'broadcast': return html`<${ChatBroadcastBlock} scope=${block.scope} via=${block.via} note=${block.note} recipients=${block.recipients} />`
-    case 'fusion': return html`<${ChatFusionCard} boardPostId=${block.board_post_id} runId=${block.run_id} />`
+    case 'fusion': return html`<${ChatFusionCard} boardPostId=${block.board_post_id} runId=${block.run_id} fallbackText=${fallbackText} />`
     default: return null
   }
 }
 
-function ChatBlocks({ blocks }: { blocks: ChatBlock[] }) {
+function ChatBlocks({ blocks, fallbackText }: { blocks: ChatBlock[]; fallbackText?: string }) {
   return html`
     <div class="flex flex-col gap-3" data-chat-blocks>
-      ${blocks.map((b, i) => html`<${ChatBlock} key=${i} block=${b} />`)}
+      ${blocks.map((b, i) => html`<${ChatBlock} key=${i} block=${b} fallbackText=${fallbackText} />`)}
     </div>
   `
 }
@@ -1824,7 +1832,7 @@ function ChatMessageBubble({
                   >${renderStructuredFailureText(messageText)}</pre>
                 `
               : hasEffectiveBlocks
-              ? html`<${ChatBlocks} blocks=${effectiveBlocks} />`
+              ? html`<${ChatBlocks} blocks=${effectiveBlocks} fallbackText=${entry.text} />`
               : html`
                   <div
                     class=${`markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)] ${isCollapsible && messageCollapsed ? 'max-h-96 overflow-hidden' : ''}`}


### PR DESCRIPTION
## 목적

fusion 심의 결과의 **대시보드 노출 적대 검증**에서 확정된 두 MED gap을 프론트엔드에서 보강한다.

- gap #2: chat 카드가 있으면 결론 텍스트가 억제됨 → board 만료/삭제 후 결론을 못 읽음
- gap #1: 심의 상세가 board 보관 기간에 묶여 있는데 사용자에게 표시가 없음

(백엔드 gap #3 = `fusion_sink.mli` 계약 정정은 별도 sibling 변경)

## 배경

키퍼 chat row 렌더는 `hasEffectiveBlocks ? <ChatBlocks/> : <text>` 상호배제다(`primitives.ts`). `'fusion'`이 `CARD_BLOCK_TYPES`에 속해 fusion row는 카드만 렌더하고, `fusion_sink`가 chat row에 영속한 결론(`entry.text` = "Fusion deliberation … — decision\n\nresolved_answer")은 **prose로 렌더되지 않는다**. 결론은 카드 안에서만 보이는데, 카드는 board post lazy-fetch에 의존한다. board post TTL(~7일) 만료 후 fetch가 빈/에러 상태를 반환하면 결론이 chat UI에서 **복구 불가**해진다(디스크엔 남아 있음).

## 변경

`dashboard/src/components/chat/primitives.ts`:
- **gap #2 결론 fallback**: 영속된 결론 텍스트(`entry.text`)를 `ChatBlocks → ChatBlock → ChatFusionCard`로 optional `fallbackText`로 흘린다(typed, fusion 외 블록은 무영향). `ChatFusionCard`의 **error 상태**(상세 fetch 실패)와 **empty 상태**(panel/judge 없음)에서 `FusionMarkdown`으로 결론을 렌더한다. loaded(정상) 경로는 무변경.
- **gap #1 retention note**: 카드 펼침 상세(`data-fusion-detail`)에 muted 한 줄("심의 상세는 board 보관 기간이 지나면 만료됩니다.")을 추가. TTL 숫자는 하드코딩하지 않음(SSOT는 백엔드 `board_post_ttl_hours`, drift 회피).

## 검증

- `dashboard/src/components/chat/primitives.test.ts`에 4개 테스트 추가: error 상태 fallback 표시 / empty 상태 fallback 표시(+"비어 있습니다" 미표시) / loaded 상태 fallback 미표시 / retention note 렌더. `npx vitest run primitives.test.ts` → **92 passed**.
- `npm run build`(tsc + vite) PASS. `npx eslint` PASS.

## 범위 밖 (follow-up)

- `/fusion` run-detail surface(`fusion-surface.ts`)에도 동일 retention note를 둘 수 있으나, 본 PR은 chat 카드 경로에 한정. durability 근본(board TTL 외 영속 store)은 feature/RFC 결정으로 별도.

## 워크어라운드 시그니처 점검

해당 없음. 영속된 결론을 표면화하고 보관 한계를 고지하는 변경으로, symptom 억제(telemetry-as-fix / string 분류기 / N-of-M / cap-cooldown-dedup-repair)가 아니다.
