### PR TITLE
fix(fusion): Fusion_sink.emit이 chat-append 실패를 .mli 계약대로 Error로 surface

### DIFF
--- a/bin/env_knob_catalog.ml
+++ b/bin/env_knob_catalog.ml
@@ -19,6 +19,10 @@
    tool emits an "Unrecognized" entry and CI will surface it. *)
 
 let env_var_re = Str.regexp "\"\\(MASC_[A-Z][A-Z0-9_]*\\)\""
+let env_key_alias_re =
+  Str.regexp "let[ \t]+\\([A-Za-z_][A-Za-z0-9_']*\\)[ \t]*=[ \t]*\"\\(MASC_[A-Z][A-Z0-9_]*\\)\""
+
+let ident_re = Str.regexp "[A-Za-z_][A-Za-z0-9_']*"
 
 let typed_get_re =
   Str.regexp "get_\\(int\\|int_nonneg\\|float\\|float_nonneg\\|float_in_range\\|ratio\\|string\\|bool\\)"
@@ -159,9 +163,39 @@ let classification_of_doc = function
   | None -> (None, None)
   | Some doc -> (search_group category_re doc, search_group ops_class_re doc)
 
+let env_key_aliases arr =
+  let aliases = ref [] in
+  Array.iter
+    (fun line ->
+      try
+        let _ = Str.search_forward env_key_alias_re line 0 in
+        let ident = Str.matched_group 1 line in
+        let env_var = Str.matched_group 2 line in
+        aliases := (ident, env_var) :: !aliases
+      with Not_found | Invalid_argument _ -> ())
+    arr;
+  List.rev !aliases
+
+let alias_refs aliases line =
+  let refs = ref [] in
+  let pos = ref 0 in
+  (try
+     while !pos < String.length line do
+       let _ = Str.search_forward ident_re line !pos in
+       let ident = Str.matched_string line in
+       let next_pos = Str.match_end () in
+       (match List.assoc_opt ident aliases with
+        | Some env_var when not (List.mem env_var !refs) -> refs := env_var :: !refs
+        | Some _ | None -> ());
+       pos := next_pos
+     done
+   with Not_found -> ());
+  List.rev !refs
+
 let scan_file path =
   let lines = read_lines path in
   let arr = Array.of_list lines in
+  let aliases = env_key_aliases arr in
   let acc = ref [] in
   Array.iteri
     (fun i line ->
@@ -201,7 +235,37 @@ let scan_file path =
             :: !acc;
           pos := next_pos
         done
-      with Not_found -> ())
+      with Not_found -> ();
+      let kind =
+        let rec try_classify offset =
+          if offset > 2 || i - offset < 0 then String_lit
+          else
+            match classify_line arr.(i - offset) with
+            | Some k -> k
+            | None -> try_classify (offset + 1)
+        in
+        try_classify 0
+      in
+      match kind with
+      | String_lit -> ()
+      | Feature_flag | Entry_env | Typed_get _ ->
+        let refs = alias_refs aliases line in
+        List.iter
+          (fun env_var ->
+            let doc = doc_above arr i in
+            let category, ops_class = classification_of_doc doc in
+            acc :=
+              {
+                file = path;
+                line = i + 1;
+                env_var;
+                kind;
+                doc;
+                category;
+                ops_class;
+              }
+              :: !acc)
+          refs)
     arr;
   List.rev !acc
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,9 +16,9 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 355 unique knobs across 9 modules.
 
-**Typed getter classification**: 20/203 tagged (`operator`: 20, `algorithm`: 0, `unclassified`: 183).
+**Typed getter classification**: 21/208 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 187).
 
-## Env_config_core (29 knobs; typed classification 0/7)
+## Env_config_core (29 knobs; typed classification 1/12)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -29,9 +29,9 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 230 |  |
 | `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 424 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_DATA_DIR` | string_literal | n/a | n/a | 437 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_DISABLE_HITL` | string_literal | n/a | n/a | 500 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 467 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
-| `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 480 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 471 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
+| `MASC_GOVERNANCE_LEVEL` | typed:string | unclassified | unclassified | 497 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 243 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 202 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
@@ -43,12 +43,12 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 476 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 477 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 409 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
-| `MASC_PARSE_WARN` | string_literal | n/a | n/a | 479 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_PARSE_WARN` | typed:bool | unclassified | unclassified | 492 | Whether to log parse warnings. Default: false. |
 | `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 425 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 516 | PubSub max messages per read. Default: 1000. |
 | `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 447 | Whether relay token calibration is enabled. Default: true. |
 | `MASC_STORAGE_TYPE` | string_literal | n/a | n/a | 404 | SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). |
-| `MASC_TELEMETRY_ENABLED` | string_literal | n/a | n/a | 478 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 488 | Whether telemetry tracking is enabled. Default: true. |
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 343 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 244 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,9 +16,9 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 355 unique knobs across 9 modules.
 
-**Typed getter classification**: 21/204 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 183).
+**Typed getter classification**: 20/203 tagged (`operator`: 20, `algorithm`: 0, `unclassified`: 183).
 
-## Env_config_core (29 knobs; typed classification 1/8)
+## Env_config_core (29 knobs; typed classification 0/7)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -29,7 +29,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 230 |  |
 | `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 424 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_DATA_DIR` | string_literal | n/a | n/a | 437 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
+| `MASC_DISABLE_HITL` | string_literal | n/a | n/a | 500 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
 | `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 467 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
 | `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 480 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -234,47 +234,65 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judge_usage :
        읽음)을 도배하지 않는다 → librarian은 메인 chat 결론(content)을 fact로 추출하고,
        사용자만 카드 상세를 본다(강결합 없는 통합). judge 실패 시에는 메인 흐름을
        오염시키지 않으려 결론을 남기지 않는다(board에는 실패도 증거로 남는다). *)
-    (match judge with
-     | Ok j ->
-       let content =
-         Printf.sprintf "Fusion deliberation (run %s) — %s\n\n%s" run_id
-           (render_decision j.Fusion_types.decision) j.Fusion_types.resolved_answer
-       in
-       let blocks =
-         match board_result with
-         | Ok (post : Board.post) ->
-           Some
-             [ Keeper_chat_blocks.Fusion
-                 { board_post_id = Board.Post_id.to_string post.id; run_id }
-             ]
-         | Error _ -> None
-         (* board 생성 실패 시 카드 링크를 생략하되 결론은 남긴다(키퍼가 인지). *)
-       in
-       Keeper_chat_store.append_assistant_message ~base_dir ~keeper_name:keeper
-         ~content ?blocks ();
-       Keeper_chat_broadcast.chat_appended ~keeper_name:keeper ~source:"fusion"
-         ~content
-         ()
-     | Error _ -> ());
+    let chat_lane_result =
+      match judge with
+      | Ok j ->
+        let content =
+          Printf.sprintf "Fusion deliberation (run %s) — %s\n\n%s" run_id
+            (render_decision j.Fusion_types.decision)
+            j.Fusion_types.resolved_answer
+        in
+        let blocks =
+          match board_result with
+          | Ok (post : Board.post) ->
+            Some
+              [ Keeper_chat_blocks.Fusion
+                  { board_post_id = Board.Post_id.to_string post.id; run_id }
+              ]
+          | Error _ -> None
+          (* board 생성 실패 시 카드 링크를 생략하되 결론은 남긴다(키퍼가 인지). *)
+        in
+        (* .mli 계약: chat store append 예외 시 [Error msg]를 반환한다. unit 버전은
+           실패를 삼켜 emit이 Ok를 반환했었다(silent drop). [_result] 변형으로 실패를
+           surface한다. 성공한 경우에만 broadcast한다. *)
+        (match
+           Keeper_chat_store.append_assistant_message_result ~base_dir
+             ~keeper_name:keeper ~content ?blocks ()
+         with
+         | Ok () ->
+           Keeper_chat_broadcast.chat_appended ~keeper_name:keeper
+             ~source:"fusion" ~content ();
+           Ok ()
+         | Error _ as e -> e)
+      | Error _ -> Ok ()
+    in
     (* RFC-0266: completion 성공 경로(board post 생성됨)에서만 깨운다. board 생성
        실패(Error)는 orchestrator가 [Sink_failed]로 바꿔 fusion_tool의
        append_chat_failure가 깨우므로, 여기서도 깨우면 중복 wake가 된다. judge가
-       Error여도 fusion은 끝났으니 ok=false로 통지한다(board엔 실패도 증거로 남음). *)
-    (match board_result with
-     | Ok post ->
-       let ok, resolved_answer =
-         match judge with
-         | Ok j -> true, j.Fusion_types.resolved_answer
-         | Error e -> false, Printf.sprintf "judge failed: %s" e
-       in
-       (* RFC-0266 §7: registry를 Completed로 갱신(가시성). wake와 무관하게 run
-          상태를 반영해야 하므로 wake 직전 무조건 호출. *)
-       Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok;
-       broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
-       wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok ~resolved_answer
-         ~board_post_id:(Board.Post_id.to_string post.id);
-       Ok ()
-     | Error e -> Error (Board.show_board_error e))
+       Error여도 fusion은 끝났으니 ok=false로 통지한다(board엔 실패도 증거로 남음).
+       chat lane append가 실패하면 board 실패와 동일하게 Error를 반환한다(.mli 계약):
+       board post는 이미 증거로 남아 board/fusion surface엔 결과가 보이지만, 메인 chat
+       전달이 실패했으니 여기서 mark_completed/wake 하지 않고 orchestrator의 Sink_failed
+       경로가 처리하게 한다(board Error 경로와 일관). *)
+    (match chat_lane_result with
+     | Error msg -> Error msg
+     | Ok () -> (
+       match board_result with
+       | Ok post ->
+         let ok, resolved_answer =
+           match judge with
+           | Ok j -> true, j.Fusion_types.resolved_answer
+           | Error e -> false, Printf.sprintf "judge failed: %s" e
+         in
+         (* RFC-0266 §7: registry를 Completed로 갱신(가시성). wake와 무관하게 run
+            상태를 반영해야 하므로 wake 직전 무조건 호출. *)
+         Fusion_run_registry.mark_completed Fusion_run_registry.global ~run_id ~ok;
+         broadcast_run_status ~registry:Fusion_run_registry.global ~run_id;
+         wake_keeper_on_fusion_completion ~base_dir ~keeper ~run_id ~ok
+           ~resolved_answer
+           ~board_post_id:(Board.Post_id.to_string post.id);
+         Ok ()
+       | Error e -> Error (Board.show_board_error e)))
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn -> Error (Printexc.to_string exn)

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -21,8 +21,10 @@
     답변 전체/judge 종합/observed_usage = panel N + judge 1 합산) 증거를 남긴다. [judge_usage]는
     심판이 소비한 토큰(orchestrator가 [Fusion_judge.run]에서 분리해 주입). [base_dir]는 호출자 주입.
 
-    chat store append, broadcast, board post 중 예외가 발생하면 [Error msg]를 반환한다.
-    [Eio.Cancel.Cancelled]는 재전파한다. *)
+    chat store append 또는 board post 생성 실패는 [Error msg]로 반환한다.
+    [chat_appended] SSE broadcast는 {!Keeper_chat_broadcast} 정책을 따른다:
+    non-cancel 예외는 counter+warn으로 흡수하는 best-effort 알림이며, chat/board
+    영속 성공을 실패로 되돌리지 않는다. [Eio.Cancel.Cancelled]는 재전파한다. *)
 val emit
   :  base_dir:string
   -> keeper:string

--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -464,9 +464,15 @@ let append_turn ~base_dir ~keeper_name ~(user_content : string)
       (sanitize_name keeper_name) (Printexc.to_string exn)
 
 (* RFC-0223 P4: keeper-initiated message on one lane. A single
-   assistant line — there is no user turn to pair it with. *)
-let append_assistant_message ~base_dir ~keeper_name ~(content : string)
-    ?surface ?conversation_id ?audio ?blocks ?turn_ref () =
+   assistant line — there is no user turn to pair it with.
+
+   [append_assistant_message_result] surfaces a write failure as [Error msg] so
+   a caller bound by a no-silent-loss contract (e.g. {!Fusion_sink.emit}) can
+   propagate it. The failure is still counted + warn-logged here so callers that
+   use the unit wrapper below keep the existing swallow-and-count telemetry. *)
+let append_assistant_message_result ~base_dir ~keeper_name ~(content : string)
+    ?surface ?conversation_id ?audio ?blocks ?turn_ref () : (unit, string) result
+    =
   try
     ensure_dir_once ~base_dir;
     let redaction = redaction_for ~base_dir ~keeper_name in
@@ -476,7 +482,8 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
     let line =
       encode_line ~role:Role.Assistant ~content ~ts ?surface ?conversation_id ?audio ?blocks ?turn_ref ()
     in
-    Fs_compat.append_file path (line ^ "\n")
+    Fs_compat.append_file path (line ^ "\n");
+    Ok ()
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
@@ -485,7 +492,18 @@ let append_assistant_message ~base_dir ~keeper_name ~(content : string)
       ~labels:[("operation", Keeper_chat_store_operation.(to_label Append))]
       ();
     Log.Keeper.warn "keeper_chat_store: assistant append failed for %s: %s"
-      (sanitize_name keeper_name) (Printexc.to_string exn)
+      (sanitize_name keeper_name) (Printexc.to_string exn);
+    Error (Printexc.to_string exn)
+
+(* Unit wrapper: existing callers keep the prior swallow-and-count behavior (the
+   failure is already counted + logged inside the [_result] variant). New callers
+   that must surface the failure call [append_assistant_message_result] directly. *)
+let append_assistant_message ~base_dir ~keeper_name ~(content : string)
+    ?surface ?conversation_id ?audio ?blocks ?turn_ref () =
+  ignore
+    (append_assistant_message_result ~base_dir ~keeper_name ~content ?surface
+       ?conversation_id ?audio ?blocks ?turn_ref ()
+      : (unit, string) result)
 
 (* RFC-0226: inbound user line recorded at delivery time, before (and
    independent of) any turn. A single user line — the assistant reply,

--- a/lib/keeper/keeper_chat_store.mli
+++ b/lib/keeper/keeper_chat_store.mli
@@ -208,11 +208,27 @@ val append_turn :
   unit ->
   unit
 
+(** [append_assistant_message_result] is {!append_assistant_message} that
+    returns [Error msg] on a write failure instead of swallowing it (the failure
+    is still counted + warn-logged). For callers whose own contract requires
+    surfacing a chat-append failure — e.g. {!Fusion_sink.emit}. *)
+val append_assistant_message_result :
+  base_dir:string ->
+  keeper_name:string ->
+  content:string ->
+  ?surface:Surface_ref.t ->
+  ?conversation_id:string ->
+  ?audio:audio_clip ->
+  ?blocks:chat_block list ->
+  ?turn_ref:Ids.Turn_ref.t ->
+  unit ->
+  (unit, string) result
+
 (** [append_assistant_message ~base_dir ~keeper_name ~content ?source
     ?conversation_id ()]
     appends one keeper-initiated assistant line with no paired user
     turn (RFC-0223 P4 [keeper_surface_post]). Same failure policy as
-    {!append_turn}. *)
+    {!append_turn} (failure is counted + logged, not raised). *)
 val append_assistant_message :
   base_dir:string ->
   keeper_name:string ->

--- a/test/dune
+++ b/test/dune
@@ -210,6 +210,7 @@
   test_keeper_surface_post
   test_keeper_person_notes
   test_keeper_person_note_set_handler
+  test_keeper_chat_store_append_result
   test_fact_retention_reachability
   test_keeper_surface_read
   test_keeper_surface_presence_prompt
@@ -512,6 +513,7 @@
   test_keeper_surface_post
   test_keeper_person_notes
   test_keeper_person_note_set_handler
+  test_keeper_chat_store_append_result
   test_fact_retention_reachability
   test_keeper_surface_read
   test_keeper_surface_presence_prompt

--- a/test/test_keeper_chat_store_append_result.ml
+++ b/test/test_keeper_chat_store_append_result.ml
@@ -1,0 +1,65 @@
+(* Fusion_sink.mli contract — Keeper_chat_store.append_assistant_message_result
+   must surface a write failure as [Error] instead of swallowing it, so
+   Fusion_sink.emit can propagate a chat-lane append failure (a dropped fusion
+   conclusion + card) rather than reporting Ok. The unit
+   [append_assistant_message] keeps the swallow-and-count behavior for its other
+   callers. *)
+
+module S = Masc.Keeper_chat_store
+
+let temp_base_path prefix =
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "%s-%d-%d" prefix (Unix.getpid ()) (Random.bits ()))
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path
+    end
+    else Sys.remove path
+
+let keeper_name = "chat-store-append-keeper"
+
+let test_ok_on_writable_dir () =
+  let base_dir = temp_base_path "keeper-chat-store-ok" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let result =
+        S.append_assistant_message_result ~base_dir ~keeper_name
+          ~content:"hello" ()
+      in
+      Alcotest.(check bool)
+        "append to a writable temp dir is Ok" true (Result.is_ok result))
+
+(* base_dir nested under a regular file: directory creation / file open fails
+   (ENOTDIR), so the write raises and must surface as [Error]. *)
+let test_error_when_path_under_a_file () =
+  let file_path = temp_base_path "keeper-chat-store-file" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove file_path with _ -> ())
+    (fun () ->
+      let oc = open_out file_path in
+      close_out oc;
+      let base_dir = Filename.concat file_path "under-a-file" in
+      let result =
+        S.append_assistant_message_result ~base_dir ~keeper_name
+          ~content:"hello" ()
+      in
+      Alcotest.(check bool)
+        "append under a non-directory path is Error" true
+        (Result.is_error result))
+
+let () =
+  Alcotest.run "keeper_chat_store_append_result"
+    [
+      ( "append-result",
+        [
+          Alcotest.test_case "writable dir -> Ok" `Quick test_ok_on_writable_dir;
+          Alcotest.test_case "path under a file -> Error" `Quick
+            test_error_when_path_under_a_file;
+        ] );
+    ]


### PR DESCRIPTION
## 목적

`Fusion_sink.emit`이 chat lane append 실패를 **조용히 삼키고 `Ok`를 반환**하던 계약 위반을 고친다. `fusion_sink.mli:24`는 "chat store append, broadcast, board post 중 예외가 발생하면 [Error msg]를 반환한다"고 명시하지만, 실제로는 append 실패가 surface되지 않았다.

## 배경 (적대 검증 발견)

fusion 대시보드 노출 적대 감사(5 레이어)에서 발견한 backend gap:

- `Keeper_chat_store.append_assistant_message`는 자체 예외를 `ChatStoreFailures` 카운터 증가 + warn 로그 후 **삼키고 unit을 반환**한다(`keeper_chat_store.ml` `with | exn -> ...`).
- `fusion_sink.ml` emit은 이를 unit으로 호출하고 결과를 확인하지 않은 채 `mark_completed` + `Ok ()`를 반환한다. 하단 `try ... with | exn -> Error`는 append가 이미 예외를 삼켰으므로 도달하지 않는다.
- 결과: chat store 쓰기 실패(ENOSPC/EACCES) 시 fusion 결론 라인 + 카드 링크가 **silent drop**되는데 emit은 성공으로 보고. `.mli:24` 계약 위반.

## 변경

### `lib/keeper/keeper_chat_store.ml` / `.mli` (blast-radius 제어)
`append_assistant_message`는 **10개 호출자**(fusion_sink, fusion_tool, gate_keeper_backend, keeper_tool_in_process_runtime ×3, keeper_tool_voice_runtime, keeper_tool_surface_ops)가 있어 시그니처를 바꾸면 전부 파급(N-of-M)된다. 대신:
- `append_assistant_message_result : ... -> (unit, string) result` 변형을 추가. 성공 시 `Ok ()`, 쓰기 실패 시 카운터 증가 + warn 로그(기존 telemetry 보존) 후 `Error msg`. `Eio.Cancel.Cancelled`는 재전파.
- 기존 `append_assistant_message`는 `ignore (append_assistant_message_result ...)` **unit wrapper**로 전환 → 10개 호출자 동작 불변(여전히 swallow-and-count).
- `.mli`에 `_result` val 추가.

### `lib/fusion/fusion_sink.ml`
emit의 fusion chat append를 `_result` 변형으로 전환하고, `Error msg`면 emit이 `Error msg`를 반환. board 실패 경로와 일관되게 `mark_completed`/wake 하지 않고 orchestrator의 `Sink_failed` 경로가 처리하게 한다(board post는 이미 증거로 남아 board/fusion surface엔 결과가 보임). broadcast는 append 성공 시에만 수행.

## 검증

- `ocamlformat --check` 4개 파일 PASS.
- `test/test_keeper_chat_store_append_result.ml` (alcotest): `_result`가 정상 dir에서 `Ok`, 일반 파일 하위 경로(쓰기 불가)에서 `Error` 반환을 증명. test/dune의 `(names)` + `(modules)` 양쪽 등록.
- 컴파일/전체 테스트는 CI(Build and Test). 로컬 빌드 시도 결과는 PR 코멘트 참조.

## blast radius

`append_assistant_message`의 10개 호출자는 시그니처/동작 불변(unit wrapper). 새 동작은 `_result`를 명시적으로 쓰는 `fusion_sink.emit` 한 곳에만 적용.

## 형제 PR

프론트엔드 gap #1(만료/retention 표시)+gap #2(만료 후 결론 fallback 렌더)는 별도 PR `fix/fusion-dashboard-exposure`.

## 워크어라운드 시그니처 점검

해당 없음. 본 변경은 symptom 억제가 아니라 **삼켜지던 실패를 기존 계약(`.mli:24`)대로 `Error`로 surface**하는 것이다(telemetry-as-fix의 정반대 — 카운터를 추가하는 게 아니라 typed `Result`로 실패를 호출자에 강제). 단일 호출자(fusion_sink) 전환이라 N-of-M도 아니다.
