### PR TITLE
feat(keeper): persist delegation request drafts

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3729,6 +3729,18 @@ export interface MemorySubsystemsDraftSkillCandidate {
   created_at: number | null
 }
 
+export interface MemorySubsystemsDelegationRequest {
+  id: string
+  requester: string
+  topic: string
+  goal: string | null
+  promotion_state: string
+  dir: string
+  json_path: string
+  task_seed_md_path: string
+  created_at: number | null
+}
+
 export interface MemorySubsystemsResponse {
   generated_at: string
   hebbian: {
@@ -3771,6 +3783,14 @@ export interface MemorySubsystemsResponse {
     limit: number
     index_path: string
     items: MemorySubsystemsDraftSkillCandidate[]
+    error?: string | null
+  }
+  delegation_requests?: {
+    total: number
+    shown: number
+    limit: number
+    index_path: string
+    items: MemorySubsystemsDelegationRequest[]
     error?: string | null
   }
   filters: {

--- a/dashboard/src/components/memory-subsystems.focus.test.ts
+++ b/dashboard/src/components/memory-subsystems.focus.test.ts
@@ -105,6 +105,26 @@ const baseResponse: MemorySubsystemsResponse = {
     ],
     error: null,
   },
+  delegation_requests: {
+    total: 1,
+    shown: 1,
+    limit: 100,
+    index_path: '<base-path>/.masc/delegation-requests/index.jsonl',
+    items: [
+      {
+        id: 'delegation-rendering-review',
+        requester: 'keeper-alpha',
+        topic: 'Review non-dashboard rendering',
+        goal: 'connector parity',
+        promotion_state: 'candidate',
+        dir: '<base-path>/.masc/delegation-requests/delegation-rendering-review',
+        json_path: '<base-path>/.masc/delegation-requests/delegation-rendering-review/request.json',
+        task_seed_md_path: '<base-path>/.masc/delegation-requests/delegation-rendering-review/TASK_SEED.md',
+        created_at: 1,
+      },
+    ],
+    error: null,
+  },
   filters: {
     keepers: ['keeper-alpha'],
     outcomes: ['success'],
@@ -245,6 +265,48 @@ describe('MemorySubsystems focus targets', () => {
         'draft skill index read failed',
       )
       expect(container.textContent).toContain('draft skill 후보 없음')
+      expect(container.textContent).toContain('total 0 · shown 0')
+    })
+  })
+
+  it('renders delegation requests from the memory subsystem payload', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(baseResponse))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(html`<${MemorySubsystems} />`, container)
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('delegation-rendering-review')
+      expect(container.textContent).toContain('Review non-dashboard rendering')
+      expect(container.textContent).toContain('<base-path>/.masc/delegation-requests/delegation-rendering-review/TASK_SEED.md')
+    })
+    expect(container.querySelector('[data-testid="delegation-requests"]')).not.toBeNull()
+  })
+
+  it('renders delegation request empty and error states', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        ...baseResponse,
+        delegation_requests: {
+          total: 0,
+          shown: 0,
+          limit: 100,
+          index_path: '<base-path>/.masc/delegation-requests/index.jsonl',
+          items: [],
+          error: 'delegation request index read failed',
+        },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(html`<${MemorySubsystems} />`, container)
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="delegation-requests"]')).not.toBeNull()
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+        'delegation request index read failed',
+      )
+      expect(container.textContent).toContain('delegation request 없음')
       expect(container.textContent).toContain('total 0 · shown 0')
     })
   })

--- a/dashboard/src/components/memory-subsystems.ts
+++ b/dashboard/src/components/memory-subsystems.ts
@@ -17,6 +17,7 @@ import {
   type MemorySubsystemsUserModelError,
   type MemorySubsystemsUserModelPrompt,
   type MemorySubsystemsDraftSkillCandidate,
+  type MemorySubsystemsDelegationRequest,
 } from '../api/dashboard'
 import { formatTimeAgo } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
@@ -713,6 +714,88 @@ function DraftSkillCandidatesPanel({
   `
 }
 
+function DelegationRequestRow({
+  request,
+}: {
+  readonly request: MemorySubsystemsDelegationRequest
+}) {
+  return html`
+    <div
+      class="v2-monitoring-row grid grid-cols-[10rem_7rem_minmax(0,1fr)_minmax(12rem,20rem)] items-start gap-2 border-b border-[var(--color-border-default)] px-2 py-2 text-xs last:border-b-0 max-lg:grid-cols-[8rem_minmax(0,1fr)]"
+      role="listitem"
+      aria-label=${`${request.id} · ${request.promotion_state} · ${request.topic}`}
+    >
+      <span class="min-w-0 truncate font-mono text-[var(--color-fg-muted)]" title=${request.id}>
+        ${request.id}
+      </span>
+      <span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-center font-mono text-[var(--color-status-warn)]">
+        ${request.promotion_state}
+      </span>
+      <span class="min-w-0 truncate text-[var(--color-fg-primary)]" title=${request.topic}>
+        ${request.requester}: ${request.topic}
+      </span>
+      <span class="min-w-0 truncate font-mono text-[var(--color-fg-disabled)] max-lg:col-span-2" title=${request.task_seed_md_path}>
+        ${request.task_seed_md_path}
+      </span>
+    </div>
+  `
+}
+
+function DelegationRequestsPanel({
+  total,
+  shown,
+  indexPath,
+  requests,
+  error,
+}: {
+  readonly total: number
+  readonly shown: number
+  readonly indexPath: string
+  readonly requests: readonly MemorySubsystemsDelegationRequest[]
+  readonly error?: string | null
+}) {
+  return html`
+    <section
+      data-testid="delegation-requests"
+      aria-label=${`Delegation requests · ${shown} shown`}
+      class="flex flex-col gap-2"
+    >
+      <div class="flex flex-wrap items-center gap-2">
+        <h3 class="text-base font-semibold text-[var(--color-fg-muted)]">Delegation requests</h3>
+        <span class="font-mono text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">
+          ${indexPath}
+        </span>
+        <span class="ml-auto text-xs text-[var(--color-fg-muted)]">
+          total ${total} · shown ${shown}
+        </span>
+      </div>
+      ${
+        error
+          ? html`<div
+              role="alert"
+              class="rounded-[var(--r-1)] border border-[var(--warn-fg)] bg-[var(--warn-bg)] px-3 py-2 text-2xs text-[var(--color-fg-primary)]"
+            >${error}</div>`
+          : null
+      }
+      ${
+        requests.length === 0
+          ? html`<div class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4 text-center text-sm text-[var(--color-fg-muted)]">
+              delegation request 없음
+            </div>`
+          : html`
+              <div
+                class="v2-monitoring-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)]"
+                role="list"
+                aria-label=${`${shown} delegation requests`}
+              >
+                ${requests.map(request => html`<${DelegationRequestRow} request=${request} />`)}
+              </div>
+            `
+      }
+    </section>
+  `
+}
+
 export function MemoryEntriesPanel({
   entries,
   visibleEntries,
@@ -880,6 +963,8 @@ export function MemorySubsystems({ focus }: MemorySubsystemsProps = {}) {
   const userModelItems = userModel?.items ?? []
   const draftSkillCandidateBlock = data?.draft_skill_candidates
   const draftSkillCandidates = draftSkillCandidateBlock?.items ?? []
+  const delegationRequestBlock = data?.delegation_requests
+  const delegationRequests = delegationRequestBlock?.items ?? []
   const visibleEntries = useMemo(
     () => filterMemoryEntries(entries, memoryKindFilter.value),
     [entries, memoryKindFilter.value],
@@ -968,6 +1053,14 @@ export function MemorySubsystems({ focus }: MemorySubsystemsProps = {}) {
         indexPath=${draftSkillCandidateBlock?.index_path ?? '.masc/draft-skills/index.jsonl'}
         candidates=${draftSkillCandidates}
         error=${draftSkillCandidateBlock?.error ?? null}
+      />
+
+      <${DelegationRequestsPanel}
+        total=${delegationRequestBlock?.total ?? delegationRequests.length}
+        shown=${delegationRequestBlock?.shown ?? delegationRequests.length}
+        indexPath=${delegationRequestBlock?.index_path ?? '.masc/delegation-requests/index.jsonl'}
+        requests=${delegationRequests}
+        error=${delegationRequestBlock?.error ?? null}
       />
 
       ${

--- a/lib/dune
+++ b/lib/dune
@@ -17,6 +17,7 @@
   keeper_tool_call_log_context
   board_metric_hooks_adapter
   workspace_metric_hooks
+  review_artifact_store
   keeper_types_profile_persona
   keeper_types_profile_persona_defaults
   keeper_types_profile_oas_env

--- a/lib/dune
+++ b/lib/dune
@@ -16,8 +16,7 @@
   sse_jsonrpc_filter
   keeper_tool_call_log_context
   board_metric_hooks_adapter
-  workspace_metric_hooks
-  review_artifact_store
+  workspace_metric_hooks review_artifact_store
   keeper_types_profile_persona
   keeper_types_profile_persona_defaults
   keeper_types_profile_oas_env

--- a/lib/keeper/keeper_agent_run_post_turn_memory.ml
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.ml
@@ -18,6 +18,7 @@ let run
   ~post_turn_t0
   ~runtime_id
   ~inference_telemetry
+  ?deliberation_execution
   ()
   =
   (* RFC-0257: snapshot the per-keeper tool-emission accumulator synchronously
@@ -93,6 +94,46 @@ let run
     ~runtime_id
     ~keeper_id:meta.name
     librarian_input;
+
+  (* Advisory delegation request drafts: keep review artifact persistence on the
+     same bounded post-turn memory lane as draft-skill projection, not on the
+     decision-record append path. *)
+  (try
+     match deliberation_execution with
+     | None -> ()
+     | Some execution -> (
+       match
+         Keeper_delegation_request_store.write_execution_result
+           ~base_path:config.base_path
+           ~requester:meta.name
+           ~goal:meta.goal
+           execution
+       with
+       | Ok [] -> ()
+       | Ok stored ->
+         Log.Keeper.info ~keeper_name:meta.name
+           "delegation_requests wrote=%d dir=%s"
+           (List.length stored)
+           (Keeper_delegation_request_store.requests_dir
+              ~base_path:config.base_path)
+       | Error msg ->
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string DispatchEventFailures)
+           ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
+           ();
+         Log.Keeper.warn ~keeper_name:meta.name
+           "delegation_requests failed: %s"
+           msg)
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     Otel_metric_store.inc_counter
+       Keeper_metrics.(to_string DispatchEventFailures)
+       ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
+       ();
+     Log.Keeper.warn ~keeper_name:meta.name
+       "delegation_requests failed: %s"
+       (Printexc.to_string exn));
 
   (* Memory OS -> draft skill loop: after librarian facts are durable, project
      validated approaches / lessons into reviewable draft skill artifacts. This

--- a/lib/keeper/keeper_agent_run_post_turn_memory.mli
+++ b/lib/keeper/keeper_agent_run_post_turn_memory.mli
@@ -22,6 +22,7 @@ val run :
   post_turn_t0:float ->
   runtime_id:string ->
   inference_telemetry:Agent_sdk.Types.inference_telemetry option ->
+  ?deliberation_execution:Keeper_deliberation.execution_result ->
   unit ->
   unit
 (** Run the full post-turn memory series.
@@ -31,4 +32,8 @@ val run :
     the [post_turn_ms] metric written to the decision log.
 
     [inference_telemetry] is [result.response.telemetry] from the OAS
-    result; it is optional because some providers do not emit telemetry. *)
+    result; it is optional because some providers do not emit telemetry.
+
+    [deliberation_execution], when available, is persisted as advisory
+    delegation request artifacts on this post-turn memory lane rather than on
+    the decision-record append path. *)

--- a/lib/keeper/keeper_delegation_request.ml
+++ b/lib/keeper/keeper_delegation_request.ml
@@ -55,19 +55,19 @@ let truncate ~max_len text =
   in
   prefix
 
+let optional_identity_component ~field = function
+  | None -> field ^ ":none"
+  | Some value -> field ^ ":some:" ^ value
+;;
+
 let digest_id ~requester ?goal ~topic ~reason () =
-  let goal_text =
-    match goal with
-    | Some text -> text
-    | None -> ""
-  in
   let raw =
     String.concat "\n"
       [
         requester;
         topic;
         reason;
-        goal_text;
+        optional_identity_component ~field:"goal" goal;
       ]
   in
   let hex = Digest.to_hex (Digest.string raw) in

--- a/lib/keeper/keeper_delegation_request.ml
+++ b/lib/keeper/keeper_delegation_request.ml
@@ -73,6 +73,16 @@ let digest_id ~requester ?goal ~topic ~reason () =
   let hex = Digest.to_hex (Digest.string raw) in
   "delegation-" ^ String.sub hex 0 12
 
+let identity_key request =
+  String.concat "\n"
+    [
+      request.id;
+      request.requester;
+      request.topic;
+      request.reason;
+      optional_identity_component ~field:"goal" request.goal;
+    ]
+
 let task_seed ~requester ?goal ~topic ~reason () =
   let title_topic = topic |> compact_whitespace |> truncate ~max_len:80 in
   let title =

--- a/lib/keeper/keeper_delegation_request.mli
+++ b/lib/keeper/keeper_delegation_request.mli
@@ -32,6 +32,10 @@ type t = {
 val make :
   requester:string -> ?goal:string -> topic:string -> reason:string -> unit -> t
 
+val identity_key : t -> string
+(** Stable artifact/index identity. Keeps [None] distinct from [Some ""]-style
+    inputs after normalization so stores do not duplicate that encoding. *)
+
 val of_action :
   requester:string ->
   ?goal:string ->

--- a/lib/keeper/keeper_delegation_request_store.ml
+++ b/lib/keeper/keeper_delegation_request_store.ml
@@ -1,0 +1,386 @@
+(** Durable review surface for keeper delegation requests. *)
+
+type stored_request =
+  { request : Keeper_delegation_request.t
+  ; dir : string
+  ; json_path : string
+  ; task_seed_md_path : string
+  ; index_path : string
+  }
+
+type request_summary =
+  { id : string
+  ; requester : string
+  ; topic : string
+  ; goal : string option
+  ; promotion_state : string
+  ; dir : string
+  ; json_path : string
+  ; task_seed_md_path : string
+  ; created_at : float option
+  }
+
+type request_listing =
+  { total : int
+  ; shown : int
+  ; limit : int
+  ; index_path : string
+  ; items : request_summary list
+  }
+
+let requests_dir ~base_path =
+  Filename.concat
+    (Common.masc_dir_from_base_path ~base_path)
+    "delegation-requests"
+;;
+
+let index_path ~base_path = Filename.concat (requests_dir ~base_path) "index.jsonl"
+
+let component_hash raw =
+  Digestif.SHA256.(digest_string raw |> to_hex) |> fun hex -> String.sub hex 0 16
+;;
+
+let component_prefix raw =
+  let safe =
+    Workspace_utils_backend_setup.sanitize_namespace_segment raw
+    |> String.lowercase_ascii
+  in
+  let safe =
+    match safe with
+    | "default" when String.equal (String.trim raw) "" -> "untitled"
+    | other -> other
+  in
+  if String.length safe > 48 then String.sub safe 0 48 else safe
+;;
+
+let request_identity_key (request : Keeper_delegation_request.t) =
+  String.concat "\n"
+    [ request.id
+    ; request.requester
+    ; request.topic
+    ; request.reason
+    ; Option.value ~default:"" request.goal
+    ]
+;;
+
+let summary_identity_key (summary : request_summary) = summary.id
+
+let request_component request =
+  component_prefix request.Keeper_delegation_request.id
+  ^ "-"
+  ^ component_hash (request_identity_key request)
+;;
+
+let request_dir ~base_path request =
+  Filename.concat (requests_dir ~base_path) (request_component request)
+;;
+
+let request_json_path ~base_path request =
+  Filename.concat (request_dir ~base_path request) "request.json"
+;;
+
+let request_task_seed_md_path ~base_path request =
+  Filename.concat (request_dir ~base_path request) "TASK_SEED.md"
+;;
+
+let write_file path content =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> Ok ()
+  | Error msg -> Error (Printf.sprintf "%s: %s" path msg)
+;;
+
+let request_json_content request =
+  Yojson.Safe.pretty_to_string (Keeper_delegation_request.to_json request) ^ "\n"
+;;
+
+let render_task_seed_md (request : Keeper_delegation_request.t) =
+  let goal =
+    match request.goal with
+    | Some goal -> [ ""; "## Goal"; ""; goal ]
+    | None -> []
+  in
+  let tags =
+    match request.task_seed.tags with
+    | [] -> []
+    | tags -> "" :: "## Tags" :: "" :: List.map (fun tag -> "- `" ^ tag ^ "`") tags
+  in
+  String.concat "\n"
+    ([ "# " ^ request.task_seed.title
+     ; ""
+     ; "- Requester: `" ^ request.requester ^ "`"
+     ; "- State: `"
+       ^ Keeper_delegation_request.promotion_state_to_string
+           request.promotion_state
+       ^ "`"
+     ; "- Source action: `" ^ request.source_action ^ "`"
+     ; ""
+     ; "## Topic"
+     ; ""
+     ; request.topic
+     ; ""
+     ; "## Reason"
+     ; ""
+     ; (if String.trim request.reason = "" then "(no reason supplied)" else request.reason)
+     ]
+     @ goal
+     @ [ ""
+       ; "## Promotion Contract"
+       ; ""
+       ; request.task_seed.description
+       ]
+     @ tags
+     @ [ "" ])
+;;
+
+let request_artifacts ~base_path request =
+  [ request_json_path ~base_path request, request_json_content request
+  ; request_task_seed_md_path ~base_path request, render_task_seed_md request
+  ]
+;;
+
+let index_event_json request ~dir ~json_path ~task_seed_md_path =
+  `Assoc
+    [ "schema", `String "masc.keeper_delegation_request.index.v1"
+    ; "id", `String request.Keeper_delegation_request.id
+    ; "requester", `String request.requester
+    ; "topic", `String request.topic
+    ; "goal", Json_util.string_opt_to_json request.goal
+    ; ( "promotion_state"
+      , `String
+          (Keeper_delegation_request.promotion_state_to_string
+             request.promotion_state) )
+    ; "dir", `String dir
+    ; "json_path", `String json_path
+    ; "task_seed_md_path", `String task_seed_md_path
+    ; "ts", `Float (Time_compat.now ())
+    ]
+;;
+
+let append_index index_path event =
+  try
+    Keeper_types_support.append_jsonl_line index_path event;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+;;
+
+let ( let* ) = Result.bind
+
+let write_request ~base_path request =
+  let dir = request_dir ~base_path request in
+  let json_path = request_json_path ~base_path request in
+  let task_seed_md_path = request_task_seed_md_path ~base_path request in
+  let index_path = index_path ~base_path in
+  let* () = write_file json_path (request_json_content request) in
+  let* () = write_file task_seed_md_path (render_task_seed_md request) in
+  let* () =
+    append_index index_path
+      (index_event_json request ~dir ~json_path ~task_seed_md_path)
+  in
+  Ok { request; dir; json_path; task_seed_md_path; index_path }
+;;
+
+let write_requests ~base_path requests =
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | request :: rest ->
+      let* stored = write_request ~base_path request in
+      loop (stored :: acc) rest
+  in
+  loop [] requests
+;;
+
+let read_file_opt = Fs_compat.load_file_opt
+
+let json_string_opt name json =
+  match Yojson.Safe.Util.member name json with
+  | `String s -> Some s
+  | _ -> None
+;;
+
+let json_float_opt name json =
+  match Yojson.Safe.Util.member name json with
+  | `Float f -> Some f
+  | `Int i -> Some (float_of_int i)
+  | _ -> None
+;;
+
+let index_event_matches_request ~base_path request json =
+  let dir = request_dir ~base_path request in
+  let json_path = request_json_path ~base_path request in
+  let task_seed_md_path = request_task_seed_md_path ~base_path request in
+  match
+    ( json_string_opt "id" json
+    , json_string_opt "requester" json
+    , json_string_opt "topic" json
+    , json_string_opt "promotion_state" json
+    , json_string_opt "dir" json
+    , json_string_opt "json_path" json
+    , json_string_opt "task_seed_md_path" json )
+  with
+  | ( Some id
+    , Some requester
+    , Some topic
+    , Some promotion_state
+    , Some indexed_dir
+    , Some indexed_json_path
+    , Some indexed_task_seed_md_path ) ->
+    String.equal id request.Keeper_delegation_request.id
+    && String.equal requester request.requester
+    && String.equal topic request.topic
+    && String.equal promotion_state
+         (Keeper_delegation_request.promotion_state_to_string
+            request.promotion_state)
+    && String.equal indexed_dir dir
+    && String.equal indexed_json_path json_path
+    && String.equal indexed_task_seed_md_path task_seed_md_path
+  | _ -> false
+;;
+
+let index_contains_request ~base_path request =
+  let index_path = index_path ~base_path in
+  if not (Fs_compat.file_exists index_path)
+  then Ok false
+  else
+    try
+      Ok
+        (Fs_compat.load_jsonl index_path
+         |> List.exists (index_event_matches_request ~base_path request))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+;;
+
+let write_request_if_changed ~base_path request =
+  let artifacts_unchanged =
+    request_artifacts ~base_path request
+    |> List.for_all (fun (path, expected) ->
+      match read_file_opt path with
+      | Some content -> String.equal content expected
+      | None -> false)
+  in
+  let* indexed = index_contains_request ~base_path request in
+  if artifacts_unchanged && indexed
+  then Ok None
+  else (
+    let* stored = write_request ~base_path request in
+    Ok (Some stored))
+;;
+
+let write_execution_result ~base_path ~requester ?goal execution =
+  let requests =
+    Keeper_delegation_request.of_execution_result ~requester ?goal execution
+  in
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | request :: rest ->
+      let* stored = write_request_if_changed ~base_path request in
+      let acc =
+        match stored with
+        | Some stored -> stored :: acc
+        | None -> acc
+      in
+      loop acc rest
+  in
+  loop [] requests
+;;
+
+let request_summary_of_index_event json =
+  match
+    ( json_string_opt "id" json
+    , json_string_opt "requester" json
+    , json_string_opt "topic" json
+    , json_string_opt "promotion_state" json
+    , json_string_opt "dir" json
+    , json_string_opt "json_path" json
+    , json_string_opt "task_seed_md_path" json )
+  with
+  | ( Some id
+    , Some requester
+    , Some topic
+    , Some promotion_state
+    , Some dir
+    , Some json_path
+    , Some task_seed_md_path ) ->
+    let goal =
+      match Yojson.Safe.Util.member "goal" json with
+      | `String goal -> Some goal
+      | _ -> None
+    in
+    Some
+      { id
+      ; requester
+      ; topic
+      ; goal
+      ; promotion_state
+      ; dir
+      ; json_path
+      ; task_seed_md_path
+      ; created_at = json_float_opt "ts" json
+      }
+  | _ -> None
+;;
+
+let take n xs =
+  let rec loop acc remaining = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | x :: rest -> loop (x :: acc) (remaining - 1) rest
+  in
+  loop [] n xs
+;;
+
+let latest_unique summaries =
+  let seen = Hashtbl.create 16 in
+  List.filter
+    (fun (summary : request_summary) ->
+       let key = summary_identity_key summary in
+       if Hashtbl.mem seen key
+       then false
+       else (
+         Hashtbl.add seen key ();
+         true))
+    summaries
+;;
+
+let list_requests ~base_path ~limit =
+  let index_path = index_path ~base_path in
+  let limit = max 0 limit in
+  try
+    let items =
+      if Fs_compat.file_exists index_path
+      then
+        Fs_compat.load_jsonl index_path
+        |> List.rev
+        |> List.filter_map request_summary_of_index_event
+        |> latest_unique
+      else []
+    in
+    let total = List.length items in
+    let items = take limit items in
+    Ok { total; shown = List.length items; limit; index_path; items }
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+;;
+
+let json_option_float = function
+  | Some f -> `Float f
+  | None -> `Null
+;;
+
+let request_summary_to_json (summary : request_summary) =
+  `Assoc
+    [ "id", `String summary.id
+    ; "requester", `String summary.requester
+    ; "topic", `String summary.topic
+    ; "goal", Json_util.string_opt_to_json summary.goal
+    ; "promotion_state", `String summary.promotion_state
+    ; "dir", `String summary.dir
+    ; "json_path", `String summary.json_path
+    ; "task_seed_md_path", `String summary.task_seed_md_path
+    ; "created_at", json_option_float summary.created_at
+    ]
+;;

--- a/lib/keeper/keeper_delegation_request_store.ml
+++ b/lib/keeper/keeper_delegation_request_store.ml
@@ -53,13 +53,18 @@ let component_prefix raw =
   if String.length safe > 48 then String.sub safe 0 48 else safe
 ;;
 
+let optional_identity_component ~field = function
+  | None -> field ^ ":none"
+  | Some value -> field ^ ":some:" ^ value
+;;
+
 let request_identity_key (request : Keeper_delegation_request.t) =
   String.concat "\n"
     [ request.id
     ; request.requester
     ; request.topic
     ; request.reason
-    ; Option.value ~default:"" request.goal
+    ; optional_identity_component ~field:"goal" request.goal
     ]
 ;;
 

--- a/lib/keeper/keeper_delegation_request_store.ml
+++ b/lib/keeper/keeper_delegation_request_store.ml
@@ -36,44 +36,16 @@ let requests_dir ~base_path =
 
 let index_path ~base_path = Filename.concat (requests_dir ~base_path) "index.jsonl"
 
-let component_hash raw =
-  Digestif.SHA256.(digest_string raw |> to_hex) |> fun hex -> String.sub hex 0 16
-;;
-
-let component_prefix raw =
-  let safe =
-    Workspace_utils_backend_setup.sanitize_namespace_segment raw
-    |> String.lowercase_ascii
-  in
-  let safe =
-    match safe with
-    | "default" when String.equal (String.trim raw) "" -> "untitled"
-    | other -> other
-  in
-  if String.length safe > 48 then String.sub safe 0 48 else safe
-;;
-
-let optional_identity_component ~field = function
-  | None -> field ^ ":none"
-  | Some value -> field ^ ":some:" ^ value
-;;
-
 let request_identity_key (request : Keeper_delegation_request.t) =
-  String.concat "\n"
-    [ request.id
-    ; request.requester
-    ; request.topic
-    ; request.reason
-    ; optional_identity_component ~field:"goal" request.goal
-    ]
+  Keeper_delegation_request.identity_key request
 ;;
 
 let summary_identity_key (summary : request_summary) = summary.id
 
 let request_component request =
-  component_prefix request.Keeper_delegation_request.id
-  ^ "-"
-  ^ component_hash (request_identity_key request)
+  Review_artifact_store.component
+    ~display_id:request.Keeper_delegation_request.id
+    ~identity_key:(request_identity_key request)
 ;;
 
 let request_dir ~base_path request =
@@ -86,13 +58,6 @@ let request_json_path ~base_path request =
 
 let request_task_seed_md_path ~base_path request =
   Filename.concat (request_dir ~base_path request) "TASK_SEED.md"
-;;
-
-let write_file path content =
-  Fs_compat.mkdir_p (Filename.dirname path);
-  match Fs_compat.save_file_atomic path content with
-  | Ok () -> Ok ()
-  | Error msg -> Error (Printf.sprintf "%s: %s" path msg)
 ;;
 
 let request_json_content request =
@@ -162,29 +127,30 @@ let index_event_json request ~dir ~json_path ~task_seed_md_path =
     ]
 ;;
 
-let append_index index_path event =
-  try
-    Keeper_types_support.append_jsonl_line index_path event;
-    Ok ()
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
-;;
-
 let ( let* ) = Result.bind
 
+let stored_request ~base_path request =
+  { request
+  ; dir = request_dir ~base_path request
+  ; json_path = request_json_path ~base_path request
+  ; task_seed_md_path = request_task_seed_md_path ~base_path request
+  ; index_path = index_path ~base_path
+  }
+;;
+
 let write_request ~base_path request =
-  let dir = request_dir ~base_path request in
-  let json_path = request_json_path ~base_path request in
-  let task_seed_md_path = request_task_seed_md_path ~base_path request in
-  let index_path = index_path ~base_path in
-  let* () = write_file json_path (request_json_content request) in
-  let* () = write_file task_seed_md_path (render_task_seed_md request) in
+  let stored = stored_request ~base_path request in
   let* () =
-    append_index index_path
-      (index_event_json request ~dir ~json_path ~task_seed_md_path)
+    Review_artifact_store.write_artifacts
+      ~index_path:stored.index_path
+      ~artifacts:(request_artifacts ~base_path request)
+      ~index_event:
+        (index_event_json request
+           ~dir:stored.dir
+           ~json_path:stored.json_path
+           ~task_seed_md_path:stored.task_seed_md_path)
   in
-  Ok { request; dir; json_path; task_seed_md_path; index_path }
+  Ok stored
 ;;
 
 let write_requests ~base_path requests =
@@ -196,8 +162,6 @@ let write_requests ~base_path requests =
   in
   loop [] requests
 ;;
-
-let read_file_opt = Fs_compat.load_file_opt
 
 let json_string_opt name json =
   match Yojson.Safe.Util.member name json with
@@ -244,34 +208,20 @@ let index_event_matches_request ~base_path request json =
   | _ -> false
 ;;
 
-let index_contains_request ~base_path request =
-  let index_path = index_path ~base_path in
-  if not (Fs_compat.file_exists index_path)
-  then Ok false
-  else
-    try
-      Ok
-        (Fs_compat.load_jsonl index_path
-         |> List.exists (index_event_matches_request ~base_path request))
-    with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
-;;
-
 let write_request_if_changed ~base_path request =
-  let artifacts_unchanged =
-    request_artifacts ~base_path request
-    |> List.for_all (fun (path, expected) ->
-      match read_file_opt path with
-      | Some content -> String.equal content expected
-      | None -> false)
+  let stored = stored_request ~base_path request in
+  let* changed =
+    Review_artifact_store.write_if_changed
+      ~index_path:stored.index_path
+      ~artifacts:(request_artifacts ~base_path request)
+      ~index_event:
+        (index_event_json request
+           ~dir:stored.dir
+           ~json_path:stored.json_path
+           ~task_seed_md_path:stored.task_seed_md_path)
+      ~matches:(index_event_matches_request ~base_path request)
   in
-  let* indexed = index_contains_request ~base_path request in
-  if artifacts_unchanged && indexed
-  then Ok None
-  else (
-    let* stored = write_request ~base_path request in
-    Ok (Some stored))
+  if changed then Ok (Some stored) else Ok None
 ;;
 
 let write_execution_result ~base_path ~requester ?goal execution =
@@ -328,47 +278,17 @@ let request_summary_of_index_event json =
   | _ -> None
 ;;
 
-let take n xs =
-  let rec loop acc remaining = function
-    | _ when remaining <= 0 -> List.rev acc
-    | [] -> List.rev acc
-    | x :: rest -> loop (x :: acc) (remaining - 1) rest
-  in
-  loop [] n xs
-;;
-
-let latest_unique summaries =
-  let seen = Hashtbl.create 16 in
-  List.filter
-    (fun (summary : request_summary) ->
-       let key = summary_identity_key summary in
-       if Hashtbl.mem seen key
-       then false
-       else (
-         Hashtbl.add seen key ();
-         true))
-    summaries
-;;
-
 let list_requests ~base_path ~limit =
   let index_path = index_path ~base_path in
   let limit = max 0 limit in
-  try
-    let items =
-      if Fs_compat.file_exists index_path
-      then
-        Fs_compat.load_jsonl index_path
-        |> List.rev
-        |> List.filter_map request_summary_of_index_event
-        |> latest_unique
-      else []
-    in
-    let total = List.length items in
-    let items = take limit items in
-    Ok { total; shown = List.length items; limit; index_path; items }
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+  let* (total, items) =
+    Review_artifact_store.list_index
+      ~index_path
+      ~limit
+      ~of_json:request_summary_of_index_event
+      ~identity_key:summary_identity_key
+  in
+  Ok { total; shown = List.length items; limit; index_path; items }
 ;;
 
 let json_option_float = function

--- a/lib/keeper/keeper_delegation_request_store.mli
+++ b/lib/keeper/keeper_delegation_request_store.mli
@@ -1,0 +1,64 @@
+(** Durable review surface for keeper delegation requests.
+
+    This store persists [propose_spawn] projections as reviewable artifacts under
+    [.masc/delegation-requests/]. It never spawns agents and never mutates the
+    task graph; a human or existing operator workflow must promote a request. *)
+
+type stored_request =
+  { request : Keeper_delegation_request.t
+  ; dir : string
+  ; json_path : string
+  ; task_seed_md_path : string
+  ; index_path : string
+  }
+
+type request_summary =
+  { id : string
+  ; requester : string
+  ; topic : string
+  ; goal : string option
+  ; promotion_state : string
+  ; dir : string
+  ; json_path : string
+  ; task_seed_md_path : string
+  ; created_at : float option
+  }
+
+type request_listing =
+  { total : int
+  ; shown : int
+  ; limit : int
+  ; index_path : string
+  ; items : request_summary list
+  }
+
+val requests_dir : base_path:string -> string
+val index_path : base_path:string -> string
+val request_dir : base_path:string -> Keeper_delegation_request.t -> string
+
+val render_task_seed_md : Keeper_delegation_request.t -> string
+
+val write_request
+  :  base_path:string
+  -> Keeper_delegation_request.t
+  -> (stored_request, string) result
+
+val write_requests
+  :  base_path:string
+  -> Keeper_delegation_request.t list
+  -> (stored_request list, string) result
+
+val write_request_if_changed
+  :  base_path:string
+  -> Keeper_delegation_request.t
+  -> (stored_request option, string) result
+
+val write_execution_result
+  :  base_path:string
+  -> requester:string
+  -> ?goal:string
+  -> Keeper_deliberation.execution_result
+  -> (stored_request list, string) result
+
+val list_requests : base_path:string -> limit:int -> (request_listing, string) result
+val request_summary_to_json : request_summary -> Yojson.Safe.t

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -30,6 +30,42 @@ let append_decision_record
     ?error
     ?terminal_reason
     () : unit =
+  (try
+     match deliberation_execution with
+     | None -> ()
+     | Some execution -> (
+       match
+         Keeper_delegation_request_store.write_execution_result
+           ~base_path:config.base_path
+           ~requester:meta.name
+           ~goal:meta.goal
+           execution
+       with
+       | Ok [] -> ()
+       | Ok stored ->
+         Log.Keeper.info ~keeper_name:meta.name
+           "delegation_requests wrote=%d dir=%s"
+           (List.length stored)
+           (Keeper_delegation_request_store.requests_dir
+              ~base_path:config.base_path)
+       | Error msg ->
+         Otel_metric_store.inc_counter
+           Keeper_metrics.(to_string DispatchEventFailures)
+           ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
+           ();
+         Log.Keeper.warn ~keeper_name:meta.name
+           "delegation_requests failed: %s"
+           msg)
+   with
+   | Eio.Cancel.Cancelled _ as exn -> raise exn
+   | exn ->
+     Otel_metric_store.inc_counter
+       Keeper_metrics.(to_string DispatchEventFailures)
+       ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
+       ();
+     Log.Keeper.warn ~keeper_name:meta.name
+       "delegation_requests failed: %s"
+       (Printexc.to_string exn));
   let now_ts = Time_compat.now () in
   let trigger_signals = observed_triggers_of_observation ~meta observation in
   let affordances = observed_affordances_of_observation ~meta observation in

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -30,42 +30,6 @@ let append_decision_record
     ?error
     ?terminal_reason
     () : unit =
-  (try
-     match deliberation_execution with
-     | None -> ()
-     | Some execution -> (
-       match
-         Keeper_delegation_request_store.write_execution_result
-           ~base_path:config.base_path
-           ~requester:meta.name
-           ~goal:meta.goal
-           execution
-       with
-       | Ok [] -> ()
-       | Ok stored ->
-         Log.Keeper.info ~keeper_name:meta.name
-           "delegation_requests wrote=%d dir=%s"
-           (List.length stored)
-           (Keeper_delegation_request_store.requests_dir
-              ~base_path:config.base_path)
-       | Error msg ->
-         Otel_metric_store.inc_counter
-           Keeper_metrics.(to_string DispatchEventFailures)
-           ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
-           ();
-         Log.Keeper.warn ~keeper_name:meta.name
-           "delegation_requests failed: %s"
-           msg)
-   with
-   | Eio.Cancel.Cancelled _ as exn -> raise exn
-   | exn ->
-     Otel_metric_store.inc_counter
-       Keeper_metrics.(to_string DispatchEventFailures)
-       ~labels:[ "keeper", meta.name; "site", "delegation_requests" ]
-       ();
-     Log.Keeper.warn ~keeper_name:meta.name
-       "delegation_requests failed: %s"
-       (Printexc.to_string exn));
   let now_ts = Time_compat.now () in
   let trigger_signals = observed_triggers_of_observation ~meta observation in
   let affordances = observed_affordances_of_observation ~meta observation in

--- a/lib/review_artifact_store.ml
+++ b/lib/review_artifact_store.ml
@@ -1,0 +1,120 @@
+(** Shared append-only artifact/index helpers for review-only stores. *)
+
+let component_hash raw =
+  Digestif.SHA256.(digest_string raw |> to_hex) |> fun hex -> String.sub hex 0 16
+;;
+
+let component_prefix raw =
+  let safe =
+    Workspace_utils_backend_setup.sanitize_namespace_segment raw
+    |> String.lowercase_ascii
+  in
+  let safe =
+    match safe with
+    | "default" when String.equal (String.trim raw) "" -> "untitled"
+    | other -> other
+  in
+  if String.length safe > 48 then String.sub safe 0 48 else safe
+;;
+
+let component ~display_id ~identity_key =
+  component_prefix display_id ^ "-" ^ component_hash identity_key
+;;
+
+let write_file path content =
+  Fs_compat.mkdir_p (Filename.dirname path);
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> Ok ()
+  | Error msg -> Error (Printf.sprintf "%s: %s" path msg)
+;;
+
+let append_index index_path event =
+  try
+    Keeper_types_support.append_jsonl_line index_path event;
+    Ok ()
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+;;
+
+let ( let* ) = Result.bind
+
+let write_artifacts ~index_path ~artifacts ~index_event =
+  let rec loop = function
+    | [] -> append_index index_path index_event
+    | (path, content) :: rest ->
+      let* () = write_file path content in
+      loop rest
+  in
+  loop artifacts
+;;
+
+let artifacts_unchanged artifacts =
+  List.for_all
+    (fun (path, expected) ->
+       match Fs_compat.load_file_opt path with
+       | Some content -> String.equal content expected
+       | None -> false)
+    artifacts
+;;
+
+let index_contains ~index_path ~matches =
+  if not (Fs_compat.file_exists index_path)
+  then Ok false
+  else
+    try
+      Ok (Fs_compat.load_jsonl index_path |> List.exists matches)
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+;;
+
+let write_if_changed ~index_path ~artifacts ~index_event ~matches =
+  let* indexed = index_contains ~index_path ~matches in
+  if artifacts_unchanged artifacts && indexed
+  then Ok false
+  else (
+    let* () = write_artifacts ~index_path ~artifacts ~index_event in
+    Ok true)
+;;
+
+let take n xs =
+  let rec loop acc remaining = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | x :: rest -> loop (x :: acc) (remaining - 1) rest
+  in
+  loop [] n xs
+;;
+
+let latest_unique ~identity_key summaries =
+  let seen = Hashtbl.create 16 in
+  List.filter
+    (fun summary ->
+       let key = identity_key summary in
+       if Hashtbl.mem seen key
+       then false
+       else (
+         Hashtbl.add seen key ();
+         true))
+    summaries
+;;
+
+let list_index ~index_path ~limit ~of_json ~identity_key =
+  let limit = max 0 limit in
+  try
+    let items =
+      if Fs_compat.file_exists index_path
+      then
+        Fs_compat.load_jsonl index_path
+        |> List.rev
+        |> List.filter_map of_json
+        |> latest_unique ~identity_key
+      else []
+    in
+    let total = List.length items in
+    Ok (total, take limit items)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+;;

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -340,6 +340,37 @@ let dashboard_memory_subsystems_http_json
         ; "error", `String msg
         ]
   in
+  let delegation_requests =
+    match
+      Keeper_delegation_request_store.list_requests ~base_path:config.base_path
+        ~limit
+    with
+    | Ok listing ->
+      `Assoc
+        [ "total", `Int listing.total
+        ; "shown", `Int listing.shown
+        ; "limit", `Int listing.limit
+        ; "index_path", `String listing.index_path
+        ; ( "items"
+          , `List
+              (List.map
+                 Keeper_delegation_request_store.request_summary_to_json
+                 listing.items) )
+        ; "error", `Null
+        ]
+    | Error msg ->
+      `Assoc
+        [ "total", `Int 0
+        ; "shown", `Int 0
+        ; "limit", `Int limit
+        ; ( "index_path"
+          , `String
+              (Keeper_delegation_request_store.index_path
+                 ~base_path:config.base_path) )
+        ; "items", `List []
+        ; "error", `String msg
+        ]
+  in
   `Assoc
     [ "generated_at", `String (Masc_domain.now_iso ())
     ; "hebbian", hebbian
@@ -394,6 +425,7 @@ let dashboard_memory_subsystems_http_json
                    user_model_errors) )
           ] )
     ; "draft_skill_candidates", draft_skill_candidates
+    ; "delegation_requests", delegation_requests
     ; ( "filters"
       , `Assoc
           [ "keepers", `List (List.map (fun k -> `String k) known_keepers)

--- a/lib/skill_candidate_store.ml
+++ b/lib/skill_candidate_store.ml
@@ -38,23 +38,6 @@ let drafts_dir ~base_path =
 
 let index_path ~base_path = Filename.concat (drafts_dir ~base_path) "index.jsonl"
 
-let component_hash raw =
-  Digestif.SHA256.(digest_string raw |> to_hex) |> fun hex -> String.sub hex 0 16
-;;
-
-let component_prefix raw =
-  let safe =
-    Workspace_utils_backend_setup.sanitize_namespace_segment raw
-    |> String.lowercase_ascii
-  in
-  let safe =
-    match safe with
-    | "default" when String.equal (String.trim raw) "" -> "untitled"
-    | other -> other
-  in
-  if String.length safe > 48 then String.sub safe 0 48 else safe
-;;
-
 let candidate_identity_key (candidate : Skill_candidate_projection.skill_candidate) =
   String.concat "\n"
     [ candidate.source_kind; candidate.agent_name; candidate.source_ref ]
@@ -65,7 +48,9 @@ let summary_identity_key (summary : draft_summary) =
 ;;
 
 let candidate_component (candidate : Skill_candidate_projection.skill_candidate) =
-  component_prefix candidate.id ^ "-" ^ component_hash (candidate_identity_key candidate)
+  Review_artifact_store.component
+    ~display_id:candidate.id
+    ~identity_key:(candidate_identity_key candidate)
 ;;
 
 let draft_dir ~base_path (candidate : Skill_candidate_projection.skill_candidate) =
@@ -112,13 +97,6 @@ let render_candidate_toml (c : Skill_candidate_projection.skill_candidate) =
   |> Otoml.Printer.to_string
 ;;
 
-let write_file path content =
-  Fs_compat.mkdir_p (Filename.dirname path);
-  match Fs_compat.save_file_atomic path content with
-  | Ok () -> Ok ()
-  | Error msg -> Error (Printf.sprintf "%s: %s" path msg)
-;;
-
 let index_event_json (c : Skill_candidate_projection.skill_candidate) ~dir ~json_path
       ~toml_path ~skill_md_path =
   `Assoc
@@ -135,15 +113,6 @@ let index_event_json (c : Skill_candidate_projection.skill_candidate) ~dir ~json
     ; "skill_md_path", `String skill_md_path
     ; "ts", `Float (Time_compat.now ())
     ]
-;;
-
-let append_index index_path event =
-  try
-    Keeper_types_support.append_jsonl_line index_path event;
-    Ok ()
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
 ;;
 
 let ( let* ) = Result.bind
@@ -166,20 +135,30 @@ let candidate_artifacts ~base_path candidate =
   ]
 ;;
 
+let stored_candidate ~base_path candidate =
+  { candidate
+  ; dir = draft_dir ~base_path candidate
+  ; json_path = candidate_json_path ~base_path candidate
+  ; toml_path = candidate_toml_path ~base_path candidate
+  ; skill_md_path = candidate_skill_md_path ~base_path candidate
+  ; index_path = index_path ~base_path
+  }
+;;
+
 let write_candidate ~base_path (candidate : Skill_candidate_projection.skill_candidate) =
-  let dir = draft_dir ~base_path candidate in
-  let json_path = candidate_json_path ~base_path candidate in
-  let toml_path = candidate_toml_path ~base_path candidate in
-  let skill_md_path = candidate_skill_md_path ~base_path candidate in
-  let index_path = index_path ~base_path in
-  let* () = write_file json_path (candidate_json_content candidate) in
-  let* () = write_file toml_path (render_candidate_toml candidate) in
-  let* () = write_file skill_md_path (Skill_candidate_projection.render_skill_draft candidate) in
+  let stored = stored_candidate ~base_path candidate in
   let* () =
-    append_index index_path
-      (index_event_json candidate ~dir ~json_path ~toml_path ~skill_md_path)
+    Review_artifact_store.write_artifacts
+      ~index_path:stored.index_path
+      ~artifacts:(candidate_artifacts ~base_path candidate)
+      ~index_event:
+        (index_event_json candidate
+           ~dir:stored.dir
+           ~json_path:stored.json_path
+           ~toml_path:stored.toml_path
+           ~skill_md_path:stored.skill_md_path)
   in
-  Ok { candidate; dir; json_path; toml_path; skill_md_path; index_path }
+  Ok stored
 ;;
 
 let write_candidates ~base_path candidates =
@@ -191,8 +170,6 @@ let write_candidates ~base_path candidates =
   in
   loop [] candidates
 ;;
-
-let read_file_opt = Fs_compat.load_file_opt
 
 let index_event_matches_candidate ~base_path
     (candidate : Skill_candidate_projection.skill_candidate) json =
@@ -234,39 +211,26 @@ let index_event_matches_candidate ~base_path
   | _ -> false
 ;;
 
-let index_contains_candidate ~base_path candidate =
-  let index_path = index_path ~base_path in
-  if not (Fs_compat.file_exists index_path)
-  then Ok false
-  else
-    try
-      Ok
-        (Fs_compat.load_jsonl index_path
-         |> List.exists (index_event_matches_candidate ~base_path candidate))
-    with
-    | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
-;;
-
 let write_candidate_if_changed ~base_path candidate =
   (* Artifact files and the index are intentionally checked together: a prior
      write can leave complete artifacts but miss the final index append. The
      next post-turn pass should repair that listing row instead of treating the
      draft as fully persisted. This is a safety net until #21871 makes the
      index/artifact persistence atomic or derives one side from the other. *)
-  let artifacts_unchanged =
-    candidate_artifacts ~base_path candidate
-    |> List.for_all (fun (path, expected) ->
-      match read_file_opt path with
-      | Some content -> String.equal content expected
-      | None -> false)
+  let stored = stored_candidate ~base_path candidate in
+  let* changed =
+    Review_artifact_store.write_if_changed
+      ~index_path:stored.index_path
+      ~artifacts:(candidate_artifacts ~base_path candidate)
+      ~index_event:
+        (index_event_json candidate
+           ~dir:stored.dir
+           ~json_path:stored.json_path
+           ~toml_path:stored.toml_path
+           ~skill_md_path:stored.skill_md_path)
+      ~matches:(index_event_matches_candidate ~base_path candidate)
   in
-  let* indexed = index_contains_candidate ~base_path candidate in
-  if artifacts_unchanged && indexed
-  then Ok None
-  else (
-    let* stored = write_candidate ~base_path candidate in
-    Ok (Some stored))
+  if changed then Ok (Some stored) else Ok None
 ;;
 
 let dedup_candidates candidates =
@@ -358,47 +322,17 @@ let draft_summary_of_index_event json =
   | _ -> None
 ;;
 
-let take n xs =
-  let rec loop acc remaining = function
-    | _ when remaining <= 0 -> List.rev acc
-    | [] -> List.rev acc
-    | x :: rest -> loop (x :: acc) (remaining - 1) rest
-  in
-  loop [] n xs
-;;
-
-let latest_unique summaries =
-  let seen = Hashtbl.create 16 in
-  List.filter
-    (fun (summary : draft_summary) ->
-      let key = summary_identity_key summary in
-      if Hashtbl.mem seen key
-      then false
-      else (
-        Hashtbl.add seen key ();
-        true))
-    summaries
-;;
-
 let list_drafts ~base_path ~limit =
   let index_path = index_path ~base_path in
   let limit = max 0 limit in
-  try
-    let items =
-      if Fs_compat.file_exists index_path
-      then
-        Fs_compat.load_jsonl index_path
-        |> List.rev
-        |> List.filter_map draft_summary_of_index_event
-        |> latest_unique
-      else []
-    in
-    let total = List.length items in
-    let items = take limit items in
-    Ok { total; shown = List.length items; limit; index_path; items }
-  with
-  | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> Error (Printf.sprintf "%s: %s" index_path (Printexc.to_string exn))
+  let* (total, items) =
+    Review_artifact_store.list_index
+      ~index_path
+      ~limit
+      ~of_json:draft_summary_of_index_event
+      ~identity_key:summary_identity_key
+  in
+  Ok { total; shown = List.length items; limit; index_path; items }
 ;;
 
 let json_option_float = function

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module D = Masc.Keeper_deliberation
 module R = Masc.Keeper_delegation_request
+module RS = Masc.Keeper_delegation_request_store
 module Keeper_types = Keeper_types
 
 let has_prompt_root path =
@@ -23,6 +24,29 @@ let () =
   let prompts_dir = Filename.concat (repo_root ()) "config/prompts" in
   Prompt_registry.set_markdown_dir prompts_dir;
   Masc.Prompt_defaults.init ()
+
+let temp_dir () = Filename.temp_dir "keeper_delegation_request_store_test" ""
+
+let rm_rf dir =
+  let rec rm path =
+    if Sys.file_exists path
+    then
+      if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun entry -> rm (Filename.concat path entry));
+        Unix.rmdir path)
+      else Sys.remove path
+  in
+  try rm dir with
+  | _ -> ()
+;;
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+;;
 
 (* ---------- Triage tests ---------- *)
 
@@ -604,8 +628,9 @@ let test_delegation_request_json_uses_stable_array_shape () =
     |> json_list_items "empty delegation requests"
   in
   check int "empty request list" 0 (List.length empty);
+  let delegation_obs = D.{ base_obs with active_goal_count = 1 } in
   let single_result =
-    D.execute_structured_result base_obs
+    D.execute_structured_result delegation_obs
       D.
         {
           action =
@@ -626,7 +651,7 @@ let test_delegation_request_json_uses_stable_array_shape () =
         (json_string_field "schema" request_json)
   | _ -> fail "expected one request JSON");
   let multi_result =
-    D.execute_structured_result base_obs
+    D.execute_structured_result delegation_obs
       D.
         {
           action =
@@ -666,6 +691,88 @@ let test_delegation_request_title_truncates_utf8_boundary () =
   check string "title stops before partial codepoint"
     ("Delegate: " ^ String.make 79 'a')
     request.task_seed.title
+
+let test_delegation_request_store_writes_reviewable_artifacts () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let request =
+        R.make ~requester:"planner" ~goal:"connector parity"
+          ~topic:"Review non-dashboard rendering"
+          ~reason:"existing channels lose rich blocks"
+          ()
+      in
+      let stored =
+        match RS.write_request ~base_path:dir request with
+        | Ok stored -> stored
+        | Error msg -> fail msg
+      in
+      check bool "request json exists" true (Sys.file_exists stored.json_path);
+      check bool "task seed exists" true (Sys.file_exists stored.task_seed_md_path);
+      check string "index path" (RS.index_path ~base_path:dir) stored.index_path;
+      let json = Yojson.Safe.from_file stored.json_path in
+      check string "request schema" "masc.keeper_delegation_request.v1"
+        (json_string_field "schema" json);
+      let task_seed_md = read_file stored.task_seed_md_path in
+      check bool "promotion contract visible" true
+        (contains_substring task_seed_md "not a direct child-agent spawn");
+      let listing =
+        match RS.list_requests ~base_path:dir ~limit:10 with
+        | Ok listing -> listing
+        | Error msg -> fail msg
+      in
+      check int "listing total" 1 listing.total;
+      match listing.items with
+      | [ item ] ->
+        check string "listing id" request.id item.id;
+        check string "listing requester" "planner" item.requester
+      | _ -> fail "expected one delegation request summary")
+;;
+
+let test_delegation_request_store_dedups_unchanged_execution () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let obs = D.{ base_obs with active_goal_count = 1 } in
+      let execution =
+        D.execute_structured_result obs
+          D.
+            { action =
+                ProposeSpawn
+                  { topic = "Review connector routing"; reason = "needs owner" }
+            ; reasoning = "delegate one task"
+            ; confidence = 0.8
+            }
+      in
+      let first =
+        match
+          RS.write_execution_result ~base_path:dir ~requester:"planner"
+            ~goal:"connector parity"
+            execution
+        with
+        | Ok stored -> stored
+        | Error msg -> fail msg
+      in
+      let second =
+        match
+          RS.write_execution_result ~base_path:dir ~requester:"planner"
+            ~goal:"connector parity"
+            execution
+        with
+        | Ok stored -> stored
+        | Error msg -> fail msg
+      in
+      check int "first write" 1 (List.length first);
+      check int "second unchanged write" 0 (List.length second);
+      let listing =
+        match RS.list_requests ~base_path:dir ~limit:10 with
+        | Ok listing -> listing
+        | Error msg -> fail msg
+      in
+      check int "deduped listing total" 1 listing.total)
+;;
 
 let test_parse_json_with_code_fences_rejected () =
   let raw =
@@ -1277,6 +1384,10 @@ let () =
             test_delegation_request_id_includes_goal;
           test_case "delegation request truncates utf8 at boundary" `Quick
             test_delegation_request_title_truncates_utf8_boundary;
+          test_case "delegation request store writes reviewable artifacts" `Quick
+            test_delegation_request_store_writes_reviewable_artifacts;
+          test_case "delegation request store dedups unchanged execution" `Quick
+            test_delegation_request_store_dedups_unchanged_execution;
         ] );
       ( "parse_deliberation_response",
         [

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -6,6 +6,8 @@ module Memory_io = Masc.Keeper_memory_os_io
 module P = Masc.Procedural_memory
 module Projection = Masc.Skill_candidate_projection
 module Store = Masc.Skill_candidate_store
+module Delegation_request = Masc.Keeper_delegation_request
+module Delegation_store = Masc.Keeper_delegation_request_store
 module Types = Masc.Keeper_memory_os_types
 
 let request target =
@@ -237,6 +239,47 @@ let test_http_json_surfaces_draft_skill_candidates () =
          (Filename.basename Json.(item |> member "skill_md_path" |> to_string)))
 ;;
 
+let test_http_json_surfaces_delegation_requests () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+      let config = Workspace_utils.default_config dir in
+      let delegation =
+        Delegation_request.make ~requester:"planner"
+          ~goal:"ship connector parity"
+          ~topic:"Review non-dashboard rendering"
+          ~reason:"existing channels lose rich blocks"
+          ()
+      in
+      (match Delegation_store.write_request ~base_path:dir delegation with
+       | Ok _ -> ()
+       | Error msg -> fail msg);
+      let json =
+        Memory_subsystems.dashboard_memory_subsystems_http_json
+          ~config
+          ~include_memory_entries:false
+          (request "/dashboard/memory-subsystems?limit=100")
+      in
+      let requests = Json.(json |> member "delegation_requests") in
+      check int "delegation total" 1 Json.(requests |> member "total" |> to_int);
+      check int "delegation shown" 1 Json.(requests |> member "shown" |> to_int);
+      check string "delegation index path"
+        (Delegation_store.index_path ~base_path:dir)
+        Json.(requests |> member "index_path" |> to_string);
+      let item =
+        match Json.(requests |> member "items" |> to_list) with
+        | [ item ] -> item
+        | _ -> fail "expected one delegation request"
+      in
+      check string "delegation id" delegation.id
+        Json.(item |> member "id" |> to_string);
+      check string "delegation requester" "planner"
+        Json.(item |> member "requester" |> to_string);
+      check string "task seed suffix" "TASK_SEED.md"
+        (Filename.basename Json.(item |> member "task_seed_md_path" |> to_string)))
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   Alcotest.run
@@ -268,6 +311,10 @@ let () =
             "surfaces draft skill candidates"
             `Quick
             test_http_json_surfaces_draft_skill_candidates
+        ; test_case
+            "surfaces delegation requests"
+            `Quick
+            test_http_json_surfaces_delegation_requests
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- persist keeper propose_spawn delegation requests under .masc/delegation-requests/ as request.json, TASK_SEED.md, and index.jsonl
- surface delegation_requests in the dashboard memory-subsystems JSON and UI next to draft skill candidates
- best-effort write delegation request drafts when decision records receive deliberation_execution

## Boundary
- does not spawn child agents
- does not call OAS swarm/orchestration APIs
- leaves promotion to existing operator/task routing flows

## Validation
- scripts/dune-local.sh build test/test_keeper_deliberation.exe test/test_server_dashboard_http_memory_subsystems.exe
- ./_build/default/test/test_keeper_deliberation.exe
- ./_build/default/test/test_server_dashboard_http_memory_subsystems.exe
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/memory-subsystems.focus.test.ts
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- pnpm --dir dashboard exec eslint src/components/memory-subsystems.ts src/components/memory-subsystems.focus.test.ts src/api/dashboard.ts (source files clean; test file is ignored by config warning)
