### PR TITLE
fix(keeper): gate checkpoint multimodal input

### DIFF
--- a/bin/env_knob_catalog.ml
+++ b/bin/env_knob_catalog.ml
@@ -19,6 +19,10 @@
    tool emits an "Unrecognized" entry and CI will surface it. *)
 
 let env_var_re = Str.regexp "\"\\(MASC_[A-Z][A-Z0-9_]*\\)\""
+let env_key_alias_re =
+  Str.regexp "let[ \t]+\\([A-Za-z_][A-Za-z0-9_']*\\)[ \t]*=[ \t]*\"\\(MASC_[A-Z][A-Z0-9_]*\\)\""
+
+let ident_re = Str.regexp "[A-Za-z_][A-Za-z0-9_']*"
 
 let typed_get_re =
   Str.regexp "get_\\(int\\|int_nonneg\\|float\\|float_nonneg\\|float_in_range\\|ratio\\|string\\|bool\\)"
@@ -159,9 +163,39 @@ let classification_of_doc = function
   | None -> (None, None)
   | Some doc -> (search_group category_re doc, search_group ops_class_re doc)
 
+let env_key_aliases arr =
+  let aliases = ref [] in
+  Array.iter
+    (fun line ->
+      try
+        let _ = Str.search_forward env_key_alias_re line 0 in
+        let ident = Str.matched_group 1 line in
+        let env_var = Str.matched_group 2 line in
+        aliases := (ident, env_var) :: !aliases
+      with Not_found | Invalid_argument _ -> ())
+    arr;
+  List.rev !aliases
+
+let alias_refs aliases line =
+  let refs = ref [] in
+  let pos = ref 0 in
+  (try
+     while !pos < String.length line do
+       let _ = Str.search_forward ident_re line !pos in
+       let ident = Str.matched_string line in
+       let next_pos = Str.match_end () in
+       (match List.assoc_opt ident aliases with
+        | Some env_var when not (List.mem env_var !refs) -> refs := env_var :: !refs
+        | Some _ | None -> ());
+       pos := next_pos
+     done
+   with Not_found -> ());
+  List.rev !refs
+
 let scan_file path =
   let lines = read_lines path in
   let arr = Array.of_list lines in
+  let aliases = env_key_aliases arr in
   let acc = ref [] in
   Array.iteri
     (fun i line ->
@@ -201,7 +235,37 @@ let scan_file path =
             :: !acc;
           pos := next_pos
         done
-      with Not_found -> ())
+      with Not_found -> ();
+      let kind =
+        let rec try_classify offset =
+          if offset > 2 || i - offset < 0 then String_lit
+          else
+            match classify_line arr.(i - offset) with
+            | Some k -> k
+            | None -> try_classify (offset + 1)
+        in
+        try_classify 0
+      in
+      match kind with
+      | String_lit -> ()
+      | Feature_flag | Entry_env | Typed_get _ ->
+        let refs = alias_refs aliases line in
+        List.iter
+          (fun env_var ->
+            let doc = doc_above arr i in
+            let category, ops_class = classification_of_doc doc in
+            acc :=
+              {
+                file = path;
+                line = i + 1;
+                env_var;
+                kind;
+                doc;
+                category;
+                ops_class;
+              }
+              :: !acc)
+          refs)
     arr;
   List.rev !acc
 

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,9 +16,9 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 355 unique knobs across 9 modules.
 
-**Typed getter classification**: 21/204 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 183).
+**Typed getter classification**: 21/208 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 187).
 
-## Env_config_core (29 knobs; typed classification 1/8)
+## Env_config_core (29 knobs; typed classification 1/12)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -30,8 +30,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 424 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_DATA_DIR` | string_literal | n/a | n/a | 437 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
 | `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 467 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
-| `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 480 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 471 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
+| `MASC_GOVERNANCE_LEVEL` | typed:string | unclassified | unclassified | 497 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 243 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 202 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
@@ -43,12 +43,12 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 476 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 477 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 409 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
-| `MASC_PARSE_WARN` | string_literal | n/a | n/a | 479 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_PARSE_WARN` | typed:bool | unclassified | unclassified | 492 | Whether to log parse warnings. Default: false. |
 | `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 425 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 516 | PubSub max messages per read. Default: 1000. |
 | `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 447 | Whether relay token calibration is enabled. Default: true. |
 | `MASC_STORAGE_TYPE` | string_literal | n/a | n/a | 404 | SSOT for the MASC_STORAGE_TYPE env-var name (issue 8352). |
-| `MASC_TELEMETRY_ENABLED` | string_literal | n/a | n/a | 478 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 488 | Whether telemetry tracking is enabled. Default: true. |
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 343 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 244 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -142,10 +142,16 @@ let run_named
          text-only; [initial_messages] still participate in reroute below. *)
       []
   in
+  let checkpoint_messages =
+    match oas_checkpoint with
+    | None -> []
+    | Some (checkpoint : Agent_sdk.Checkpoint.t) -> checkpoint.messages
+  in
   let runtime_id, runtime =
     match
       Runtime_agent.decide_modality_reroute_for_runtime
         ~assigned:assigned_runtime
+        ~checkpoint_messages
         ~initial_messages
         current_goal_blocks
     with

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -378,21 +378,42 @@ let content_blocks_of_messages (messages : Agent_sdk.Types.message list) =
     (fun (message : Agent_sdk.Types.message) -> message.content)
     messages
 
+let checkpoint_messages = function
+  | None -> []
+  | Some (checkpoint : Agent_sdk.Checkpoint.t) -> checkpoint.messages
+
+let content_blocks_for_run_with_checkpoint
+    ~(checkpoint_messages : Agent_sdk.Types.message list)
+    ~(initial_messages : Agent_sdk.Types.message list)
+    ~(goal_blocks : Agent_sdk.Types.content_block list) =
+  content_blocks_of_messages initial_messages
+  @ content_blocks_of_messages checkpoint_messages
+  @ goal_blocks
+
 let content_blocks_for_run
     ~(initial_messages : Agent_sdk.Types.message list)
     ~(goal_blocks : Agent_sdk.Types.content_block list) =
-  content_blocks_of_messages initial_messages @ goal_blocks
+  content_blocks_for_run_with_checkpoint ~checkpoint_messages:[] ~initial_messages
+    ~goal_blocks
 
 let required_modalities_of_messages (messages : Agent_sdk.Types.message list) =
   messages
   |> content_blocks_of_messages
   |> required_modalities_of_content_blocks
 
+let required_modalities_for_run_with_checkpoint
+    ~(checkpoint_messages : Agent_sdk.Types.message list)
+    ~(initial_messages : Agent_sdk.Types.message list)
+    ~(goal_blocks : Agent_sdk.Types.content_block list) =
+  content_blocks_for_run_with_checkpoint ~checkpoint_messages ~initial_messages
+    ~goal_blocks
+  |> required_modalities_of_content_blocks
+
 let required_modalities_for_run
     ~(initial_messages : Agent_sdk.Types.message list)
     ~(goal_blocks : Agent_sdk.Types.content_block list) =
-  content_blocks_for_run ~initial_messages ~goal_blocks
-  |> required_modalities_of_content_blocks
+  required_modalities_for_run_with_checkpoint ~checkpoint_messages:[]
+    ~initial_messages ~goal_blocks
 
 let supported_modalities_of_capabilities
     (caps : Llm_provider.Capabilities.capabilities) =
@@ -479,15 +500,29 @@ let validate_content_blocks_against_capabilities
              ~supported
              ~reason:"provider does not support combined non-text modalities")
 
-let validate_content_blocks_for_run_against_capabilities
+let validate_content_blocks_for_run_against_capabilities_with_checkpoint
     ~(provider_label : string)
     (caps : Llm_provider.Capabilities.capabilities)
+    ~(checkpoint_messages : Agent_sdk.Types.message list)
     ~(initial_messages : Agent_sdk.Types.message list)
     ~(goal_blocks : Agent_sdk.Types.content_block list) =
   validate_content_blocks_against_capabilities
     ~provider_label
     caps
-    (content_blocks_for_run ~initial_messages ~goal_blocks)
+    (content_blocks_for_run_with_checkpoint ~checkpoint_messages ~initial_messages
+       ~goal_blocks)
+
+let validate_content_blocks_for_run_against_capabilities
+    ~(provider_label : string)
+    (caps : Llm_provider.Capabilities.capabilities)
+    ~(initial_messages : Agent_sdk.Types.message list)
+    ~(goal_blocks : Agent_sdk.Types.content_block list) =
+  validate_content_blocks_for_run_against_capabilities_with_checkpoint
+    ~provider_label
+    caps
+    ~checkpoint_messages:[]
+    ~initial_messages
+    ~goal_blocks
 
 let apply_runtime_model_input_capabilities
     (caps : Llm_provider.Capabilities.capabilities)
@@ -546,11 +581,13 @@ let media_reroute_candidates ~(exclude : string) :
        (r.Runtime.id, input_capabilities_of_runtime r))
 
 let validate_content_blocks_for_config
+    ?oas_checkpoint
     ~(config : config)
     (goal_blocks : Agent_sdk.Types.content_block list) =
-  validate_content_blocks_for_run_against_capabilities
+  validate_content_blocks_for_run_against_capabilities_with_checkpoint
     ~provider_label:(provider_label config.provider_cfg)
     (input_capabilities_for_config config)
+    ~checkpoint_messages:(checkpoint_messages oas_checkpoint)
     ~initial_messages:config.initial_messages
     ~goal_blocks
 
@@ -595,12 +632,14 @@ let decide_modality_reroute
    [initial_messages] plus current [blocks]). Pure [decide_modality_reroute] over
    impure candidate gathering. *)
 let decide_modality_reroute_for_runtime ~(assigned : Runtime.t)
+    ?(checkpoint_messages = [])
     ?(initial_messages = [])
     (blocks : Agent_sdk.Types.content_block list) : reroute_decision =
   decide_modality_reroute
     ~assigned_caps:(input_capabilities_of_runtime assigned)
     ~required_modalities:
-      (required_modalities_for_run ~initial_messages ~goal_blocks:blocks)
+      (required_modalities_for_run_with_checkpoint ~checkpoint_messages ~initial_messages
+         ~goal_blocks:blocks)
     ~candidates:(media_reroute_candidates ~exclude:assigned.Runtime.id)
 
 module For_testing = struct
@@ -617,11 +656,17 @@ module For_testing = struct
   let required_modalities_of_content_blocks = required_modalities_of_content_blocks
   let content_blocks_of_messages = content_blocks_of_messages
   let content_blocks_for_run = content_blocks_for_run
+  let content_blocks_for_run_with_checkpoint =
+    content_blocks_for_run_with_checkpoint
   let required_modalities_of_messages = required_modalities_of_messages
   let required_modalities_for_run = required_modalities_for_run
+  let required_modalities_for_run_with_checkpoint =
+    required_modalities_for_run_with_checkpoint
   let caps_admit_required_modalities = caps_admit_required_modalities
   let validate_content_blocks_for_run_against_capabilities =
     validate_content_blocks_for_run_against_capabilities
+  let validate_content_blocks_for_run_against_capabilities_with_checkpoint =
+    validate_content_blocks_for_run_against_capabilities_with_checkpoint
   let validate_content_blocks_against_capabilities =
     validate_content_blocks_against_capabilities
   let apply_runtime_model_input_capabilities =
@@ -854,6 +899,7 @@ let run_blocks
   : (run_result, Agent_sdk.Error.sdk_error) result =
   match
     validate_content_blocks_for_config
+      ?oas_checkpoint
       ~config
       goal_blocks
   with

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -232,14 +232,15 @@ val media_reroute_candidates :
 
 val decide_modality_reroute_for_runtime :
   assigned:Runtime.t ->
+  ?checkpoint_messages:Agent_sdk.Types.message list ->
   ?initial_messages:Agent_sdk.Types.message list ->
   Agent_sdk.Types.content_block list ->
   reroute_decision
 (** Keeper-dispatch convenience: gather candidates from the runtime cache and
     decide a reroute for [assigned] given the active run view: prior
-    [initial_messages] plus the current turn's content blocks. Composes
-    [input_capabilities_of_runtime] / [media_reroute_candidates] /
-    [decide_modality_reroute]. *)
+    [initial_messages], checkpoint resume messages, plus the current turn's
+    content blocks. Composes [input_capabilities_of_runtime] /
+    [media_reroute_candidates] / [decide_modality_reroute]. *)
 
 module For_testing : sig
   val request_runtime_fields_on_base_config :
@@ -271,10 +272,22 @@ module For_testing : sig
     goal_blocks:Agent_sdk.Types.content_block list ->
     Agent_sdk.Types.content_block list
 
+  val content_blocks_for_run_with_checkpoint :
+    checkpoint_messages:Agent_sdk.Types.message list ->
+    initial_messages:Agent_sdk.Types.message list ->
+    goal_blocks:Agent_sdk.Types.content_block list ->
+    Agent_sdk.Types.content_block list
+
   val required_modalities_of_messages :
     Agent_sdk.Types.message list -> string list
 
   val required_modalities_for_run :
+    initial_messages:Agent_sdk.Types.message list ->
+    goal_blocks:Agent_sdk.Types.content_block list ->
+    string list
+
+  val required_modalities_for_run_with_checkpoint :
+    checkpoint_messages:Agent_sdk.Types.message list ->
     initial_messages:Agent_sdk.Types.message list ->
     goal_blocks:Agent_sdk.Types.content_block list ->
     string list
@@ -285,6 +298,14 @@ module For_testing : sig
   val validate_content_blocks_for_run_against_capabilities :
     provider_label:string ->
     Llm_provider.Capabilities.capabilities ->
+    initial_messages:Agent_sdk.Types.message list ->
+    goal_blocks:Agent_sdk.Types.content_block list ->
+    (unit, Agent_sdk.Error.sdk_error) result
+
+  val validate_content_blocks_for_run_against_capabilities_with_checkpoint :
+    provider_label:string ->
+    Llm_provider.Capabilities.capabilities ->
+    checkpoint_messages:Agent_sdk.Types.message list ->
     initial_messages:Agent_sdk.Types.message list ->
     goal_blocks:Agent_sdk.Types.content_block list ->
     (unit, Agent_sdk.Error.sdk_error) result

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -151,6 +151,48 @@ let test_history_media_floor_rejects_before_provider () =
   | Error err ->
       failf "expected InvalidConfig, got %s" (Agent_sdk.Error.to_string err)
 
+(* Regression: OAS resume checkpoints are provider input too. A prior image can
+   live only in [oas_checkpoint.messages], not in MASC [initial_messages]; that
+   still must drive reroute/floor validation before the provider sees it. *)
+let test_checkpoint_media_drives_reroute_and_floor () =
+  let checkpoint_messages =
+    [ message_with_blocks
+        [ Agent_sdk.Types.Text "checkpoint image turn"
+        ; Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" ()
+        ]
+    ]
+  in
+  let required =
+    Runtime_agent.For_testing.required_modalities_for_run_with_checkpoint
+      ~initial_messages:[]
+      ~checkpoint_messages
+      ~goal_blocks:[ Agent_sdk.Types.Text "text-only follow up" ]
+  in
+  check (list string) "checkpoint image required" [ "image" ] required;
+  check string "checkpoint image reroutes"
+    "reroute:vision_c:assigned runtime lacks image input"
+    (decision_to_string
+       (decide
+          ~assigned:(caps ())
+          ~required
+          ~candidates:[ ("text_b", caps ()); ("vision_c", caps ~image:true ()) ]));
+  match
+    Runtime_agent.For_testing
+    .validate_content_blocks_for_run_against_capabilities_with_checkpoint
+      ~provider_label:"glm-coding.glm-5-turbo"
+      (caps ())
+      ~initial_messages:[]
+      ~checkpoint_messages
+      ~goal_blocks:[ Agent_sdk.Types.Text "text-only follow up" ]
+  with
+  | Ok () -> fail "expected checkpoint image to be rejected before provider dispatch"
+  | Error (Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; detail })) ->
+      check string "field" "multimodal_input" field;
+      check_contains "mentions unsupported image" ~needle:"unsupported image input" detail;
+      check_contains "mentions required modality" ~needle:"required=image" detail
+  | Error err ->
+      failf "expected InvalidConfig, got %s" (Agent_sdk.Error.to_string err)
+
 (* The decision is a pure function: identical inputs yield identical output. *)
 let test_decision_is_deterministic () =
   let candidates = [ ("text_b", caps ()); ("vision_c", caps ~image:true ()) ] in
@@ -188,6 +230,8 @@ let () =
         ; test_case "no capable floor" `Quick test_no_capable_runtime_floor
         ; test_case "history media floor rejects before provider" `Quick
             test_history_media_floor_rejects_before_provider
+        ; test_case "checkpoint media drives reroute and floor" `Quick
+            test_checkpoint_media_drives_reroute_and_floor
         ; test_case "deterministic" `Quick test_decision_is_deterministic
         ] )
     ; ( "caps_admit_required_modalities"


### PR DESCRIPTION
## Summary

Fix the keeper multimodal capability gate for resumed OAS checkpoints.

The dashboard can send a vision turn, then the next text-only follow-up resumes an OAS checkpoint whose `messages` still contain the prior image block. Before this change, RFC-0265 reroute/floor validation only looked at `initial_messages + goal_blocks`, so checkpoint-only media could bypass the pre-dispatch gate and leak to a text-only provider as a 400 like:

`messages.content.type is invalid, allowed values: ['text']`

This PR makes checkpoint resume messages part of the active input view for:

- modality reroute selection in `Keeper_turn_driver.run_named`
- runtime multimodal floor validation in `Runtime_agent.run_blocks`
- regression coverage for checkpoint-only image history

## Validation

- `opam exec -- ocamlformat --check lib/runtime/runtime_agent.ml lib/runtime/runtime_agent.mli lib/keeper/keeper_turn_driver.ml test/test_runtime_modality_reroute.ml`
- `git diff --check origin/main..HEAD`
- `gtimeout 240 env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/runtime/.masc_runtime.objs/byte/runtime_agent.cmo`

Attempted but did not complete locally:

- `gtimeout 420 env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_runtime_modality_reroute.exe` timed out with no compiler diagnostic after entering Dune.
- `gtimeout 300 env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/masc.cma` timed out with no compiler diagnostic after entering Dune.
