### PR TITLE
fix(dashboard): interleave think and tool steps by occurrence time in work trace

### DIFF
--- a/dashboard/src/components/chat/primitives-interleave.test.ts
+++ b/dashboard/src/components/chat/primitives-interleave.test.ts
@@ -19,7 +19,11 @@ describe('interleaveTraceAndTools', () => {
     output: null,
   })
   const labels = (items: ReturnType<typeof interleaveTraceAndTools>) =>
-    items.map((i) => (i.kind === 'trace' ? `think:${i.step.text}` : `tool:${i.entry.id}`))
+    items.map((i) => {
+      if (i.kind === 'tool') return `tool:${i.entry.id}`
+      // think/reason carry `text`; the tool variant of ChatTraceStep does not.
+      return `think:${'text' in i.step ? i.step.text : i.step.name}`
+    })
 
   it('interleaves think and tool by occurrence time (think -> tool -> think -> tool)', () => {
     const out = interleaveTraceAndTools(

--- a/dashboard/src/components/chat/primitives-interleave.test.ts
+++ b/dashboard/src/components/chat/primitives-interleave.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+// Unit tests for the render-time think<->tool interleaving in ToolTraceCard.
+// Pure-function level so the ordering contract is asserted without the jsdom
+// render harness: the merge must preserve occurrence order (think -> tool ->
+// think -> tool) and fall back to the legacy two-section order when a step has
+// no timestamp.
+import { describe, expect, it } from 'vitest'
+import type { ChatTraceStep, KeeperConversationEntry } from '../../types'
+import { interleaveTraceAndTools } from './primitives'
+
+describe('interleaveTraceAndTools', () => {
+  const think = (text: string, ts?: string): ChatTraceStep =>
+    ts === undefined ? { kind: 'think', text } : { kind: 'think', text, ts }
+  // Tool entries only need `id` and `timestamp` for ordering; interleave reads
+  // nothing else off them.
+  const tool = (id: string, ts: string) => ({
+    entry: { id, role: 'tool', timestamp: ts } as unknown as KeeperConversationEntry,
+    output: null,
+  })
+  const labels = (items: ReturnType<typeof interleaveTraceAndTools>) =>
+    items.map((i) => (i.kind === 'trace' ? `think:${i.step.text}` : `tool:${i.entry.id}`))
+
+  it('interleaves think and tool by occurrence time (think -> tool -> think -> tool)', () => {
+    const out = interleaveTraceAndTools(
+      [
+        think('A', '2026-06-21T00:00:01.000Z'),
+        think('B', '2026-06-21T00:00:03.000Z'),
+      ],
+      [
+        tool('X', '2026-06-21T00:00:02.000Z'),
+        tool('Y', '2026-06-21T00:00:04.000Z'),
+      ],
+    )
+    expect(labels(out)).toEqual(['think:A', 'tool:X', 'think:B', 'tool:Y'])
+  })
+
+  it('keeps the legacy two-section order when think steps carry no timestamp', () => {
+    // Absent ts (backend-normalized steps) sorts as '' and precedes any tool,
+    // so thinks stay grouped above tools — matching the pre-change render.
+    const out = interleaveTraceAndTools(
+      [think('A'), think('B')],
+      [tool('X', '2026-06-21T00:00:02.000Z')],
+    )
+    expect(labels(out)).toEqual(['think:A', 'think:B', 'tool:X'])
+  })
+
+  it('places an earlier tool before a later think', () => {
+    const out = interleaveTraceAndTools(
+      [think('A', '2026-06-21T00:00:05.000Z')],
+      [tool('X', '2026-06-21T00:00:01.000Z')],
+    )
+    expect(labels(out)).toEqual(['tool:X', 'think:A'])
+  })
+
+  it('preserves stable trace-then-tool order on equal timestamps', () => {
+    // Stable sort keeps the input order (trace before tool) when timestamps tie.
+    const out = interleaveTraceAndTools(
+      [think('A', '2026-06-21T00:00:01.000Z')],
+      [tool('X', '2026-06-21T00:00:01.000Z')],
+    )
+    expect(labels(out)).toEqual(['think:A', 'tool:X'])
+  })
+
+  it('handles empty inputs without error', () => {
+    expect(interleaveTraceAndTools([], [])).toEqual([])
+    expect(
+      labels(interleaveTraceAndTools([think('A', '2026-06-21T00:00:01.000Z')], [])),
+    ).toEqual(['think:A'])
+    expect(
+      labels(interleaveTraceAndTools([], [tool('X', '2026-06-21T00:00:01.000Z')])),
+    ).toEqual(['tool:X'])
+  })
+})

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2478,8 +2478,8 @@ function traceStepsSignature(entry: KeeperConversationEntry): string {
   const steps = entry.traceSteps
   if (!steps?.length) return ''
   return steps.map((step) => {
-    if (step.kind === 'think') return `think:${step.text.length}`
-    if (step.kind === 'reason') return `reason:${step.text.length}:${step.detail?.length ?? 0}`
+    if (step.kind === 'think') return `think:${step.text.length}:${step.ts ?? ''}`
+    if (step.kind === 'reason') return `reason:${step.text.length}:${step.detail?.length ?? 0}:${step.ts ?? ''}`
     return `tool:${step.name}:${step.status ?? ''}:${step.dur ?? ''}:${step.result?.length ?? 0}`
   }).join(',')
 }

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2181,8 +2181,11 @@ type TraceOrderItem =
 function traceOrderTs(item: TraceOrderItem): string {
   // ISO-8601 strings sort lexicographically == chronologically. A step without
   // `ts` (backend-normalized, no timestamp surfaced from the wire) sorts first.
-  if (item.kind === 'trace') return item.step.ts ?? ''
-  return item.entry.timestamp ?? ''
+  if (item.kind === 'tool') return item.entry.timestamp ?? ''
+  // Only think/reason carry `ts`; the tool variant of ChatTraceStep does not
+  // (and is never a 'trace' item here, but narrow for type safety).
+  const step = item.step
+  return step.kind === 'tool' ? '' : step.ts ?? ''
 }
 
 export function interleaveTraceAndTools(

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2167,6 +2167,41 @@ function ToolTraceStep({ entry, output, canMarkMissing = false }: { entry: Keepe
 // card placed above the answer bubble. The step list is visible by default so
 // operators can see thinking progress, tool names, and status without opening
 // each raw args/result body.
+// Interleave think/reason trace steps with tool entries by occurrence time so
+// the card shows the real think -> tool -> think order instead of two separate
+// blocks. This is a render-time merge only: tool entries keep their
+// entry-based output join (lookupToolCallOutput) and trace steps keep their
+// markdown render path. No data-structure change, so #21892 missing/aggregate
+// counts and the ToolTraceStep status taxonomy (pending/missing/ok/bad) are
+// preserved.
+type TraceOrderItem =
+  | { kind: 'trace'; step: ChatTraceStep }
+  | { kind: 'tool'; entry: KeeperConversationEntry; output: ToolCallEntry | null }
+
+function traceOrderTs(item: TraceOrderItem): string {
+  // ISO-8601 strings sort lexicographically == chronologically. A step without
+  // `ts` (backend-normalized, no timestamp surfaced from the wire) sorts first.
+  if (item.kind === 'trace') return item.step.ts ?? ''
+  return item.entry.timestamp ?? ''
+}
+
+export function interleaveTraceAndTools(
+  traceSteps: ChatTraceStep[],
+  toolSteps: { entry: KeeperConversationEntry; output: ToolCallEntry | null }[],
+): TraceOrderItem[] {
+  const traceItems: TraceOrderItem[] = traceSteps.map((step) => ({ kind: 'trace', step }))
+  const toolItems: TraceOrderItem[] = toolSteps.map(({ entry, output }) => ({ kind: 'tool', entry, output }))
+  // trace-then-tool concat is the stable fallback order: Array.prototype.sort
+  // is stable, so equal (or absent) timestamps preserve this input order,
+  // matching the legacy two-section render as a baseline.
+  return [...traceItems, ...toolItems].sort((a, b) => {
+    const ta = traceOrderTs(a)
+    const tb = traceOrderTs(b)
+    if (ta === tb) return 0
+    return ta < tb ? -1 : 1
+  })
+}
+
 function ToolTraceCard({
   tools,
   traceSteps = [],
@@ -2184,6 +2219,10 @@ function ToolTraceCard({
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
   const canMarkMissingForEntry = (entry: KeeperConversationEntry): boolean =>
     turnComplete && isToolOutputCoveredByHydration(entry, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs)
+  // Merge think/reason steps and tool entries into a single occurrence-ordered
+  // sequence. Aggregates below (failN/missingN/totalMs/stepN) stay entry-based,
+  // so #21892 missing detection and the status taxonomy are unaffected.
+  const ordered = interleaveTraceAndTools(traceSteps, steps)
   const failN = steps.filter(
     (s) => s.output !== null && (s.output.success === false || s.output.semantic_success === false),
   ).length
@@ -2217,13 +2256,15 @@ function ToolTraceCard({
         ? html`
             <div class="chat-block-trace-steps">
               <span class="chat-block-trace-rail"></span>
-              ${traceSteps.map((step, index) => html`<${ChatTraceStep} key=${`trace-${index}`} step=${step} />`)}
-              ${steps.map(({ entry, output }) => html`<${ToolTraceStep}
-                key=${entry.id}
-                entry=${entry}
-                output=${output}
-                canMarkMissing=${canMarkMissingForEntry(entry)}
-              />`)}
+              ${ordered.map((item, index) =>
+                item.kind === 'trace'
+                  ? html`<${ChatTraceStep} key=${`trace-${index}`} step=${item.step} />`
+                  : html`<${ToolTraceStep}
+                      key=${`tool-${item.entry.id}`}
+                      entry=${item.entry}
+                      output=${item.output}
+                      canMarkMissing=${canMarkMissingForEntry(item.entry)}
+                    />`)}
             </div>
           `
         : null}

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -207,7 +207,7 @@ describe('thread history merge & persistence', () => {
     expect(thread[0]?.id).toBe('assistant-history')
     expect(thread[0]?.delivery).toBe('history')
     expect(thread[0]?.traceSteps).toEqual([
-      { kind: 'think', text: 'checking context' },
+      { kind: 'think', text: 'checking context', ts: expect.any(String) },
     ])
   })
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -271,12 +271,12 @@ function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
   const kind = asString(raw.kind)
   if (kind === 'think') {
     const text = asString(raw.text)
-    return text !== undefined ? { kind, text } : null
+    return text !== undefined ? withoutUndefined({ kind, text, ts: asString(raw.ts) }) : null
   }
   if (kind === 'reason') {
     const text = asString(raw.text)
     return text !== undefined
-      ? withoutUndefined({ kind: 'reason', text, detail: asString(raw.detail) ?? undefined })
+      ? withoutUndefined({ kind: 'reason', text, detail: asString(raw.detail) ?? undefined, ts: asString(raw.ts) })
       : null
   }
   if (kind === 'tool') {
@@ -843,15 +843,19 @@ export function appendAssistantThinkingDelta(name: string, entryId: string, delt
   updateThreadEntry(name, entryId, entry => {
     const existing = entry.traceSteps ?? []
     const last = existing[existing.length - 1]
+    // Stamp the occurrence time on a NEW think step so the work-trace card can
+    // interleave it with tool entries by occurrence order. When consecutive
+    // deltas merge into the same step, the first stamp is preserved: the step
+    // began at that time, not when the latest fragment arrived.
     const traceSteps: ChatTraceStep[] =
       last?.kind === 'think'
         ? [
             ...existing.slice(0, -1),
-            { kind: 'think', text: `${last.text}${delta}` },
+            { kind: 'think', text: `${last.text}${delta}`, ts: last.ts },
           ]
         : [
             ...existing,
-            { kind: 'think', text: delta.trimStart() },
+            { kind: 'think', text: delta.trimStart(), ts: new Date().toISOString() },
           ]
     return {
       ...entry,

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -184,7 +184,7 @@ describe('applyKeeperStreamEvent', () => {
     expect(entry?.streamState).toBe('thinking')
     expect(entry?.delivery).toBe('streaming')
     expect(entry?.traceSteps).toEqual([
-      { kind: 'think', text: 'reasoning about the problem...' },
+      { kind: 'think', text: 'reasoning about the problem...', ts: expect.any(String) },
     ])
   })
 
@@ -203,7 +203,7 @@ describe('applyKeeperStreamEvent', () => {
 
     const entry = keeperThreads.value.sangsu?.find(item => item.id === 'reply-1')
     expect(entry?.traceSteps).toEqual([
-      { kind: 'think', text: 'checking tools' },
+      { kind: 'think', text: 'checking tools', ts: expect.any(String) },
     ])
   })
 })

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -820,8 +820,11 @@ export type ChatImageBlock = { t: 'image'; src?: string; ph?: string; cap?: stri
 export type ChatSvgBlock = { t: 'svg'; svg: string; cap?: string }
 export type ChatMermaidBlock = { t: 'mermaid'; source: string; caption?: string }
 
-export type ChatTraceThinkStep = { kind: 'think'; text: string }
-export type ChatTraceReasonStep = { kind: 'reason'; text: string; detail?: string }
+// `ts` (ISO-8601) lets ToolTraceCard interleave think/reason steps with tool
+// entries by occurrence time. Absent on backend-normalized steps (no timestamp
+// surfaced from the wire), which then sort first as a legacy fallback.
+export type ChatTraceThinkStep = { kind: 'think'; text: string; ts?: string }
+export type ChatTraceReasonStep = { kind: 'reason'; text: string; detail?: string; ts?: string }
 export type ChatTraceToolStep = { kind: 'tool'; name: string; status?: 'ok' | 'err'; dur?: string; args?: unknown; result?: string }
 export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceToolStep
 export type ChatTraceBlock = { t: 'trace'; trace: ChatTraceStep[] }


### PR DESCRIPTION
## 목표
Keeper 턴 상세(작업 과정 카드)에서 모델의 실제 작업 순서(`think → tool → think → tool`)가 두 덩어리(생각 전체 → 도구 전체)로만 보여, 어느 생각 다음에 어떤 도구가 실행됐는지 운영자가 볼 수 없는 문제를 해결한다.

## 접근: 렌더 타임 interleave (entry 구조 보존)
`ToolTraceCard`에서 think/reason step과 tool entry를 **발생 시각(timestamp)으로 정렬 병합**해 단일 순회로 렌더한다. tool entry는 entry 기반 output join(`lookupToolCallOutput`)을 그대로 유지하므로 #21892의 missing/집계와 `ToolTraceStep` status taxonomy(pending/missing/ok/bad, `semantic_success`)가 변경되지 않는다.

## 설계 문서 옵션 C 기각 근거 (적대 검증)
설계 문서(`reports/masc-keeper-turn-interleaving-design-20260621.html`)의 옵션 C(tool을 `assistant.traceSteps`의 `kind:'tool'` step으로 이동)는 적대 검증(26 agent / 5 lens)에서 기각됐다.
- **B1/P1**: `ChatTraceToolStep`에 `tool_use_id`가 없어 output-store join이 단절(silent 회귀).
- **A2/P2**: `status:'ok'|'err'` 2-state는 `semantic_success`(blocked/timeout)를 담지 못해 transport-성공/semantic-실패가 ok로 위장.
- **E3/P2**: #21892의 `missingN`/`failN` 집계가 entry output 기반이라 step 기반에서 유지 불가.

3/5 lens가 렌더 타임 interleave를, 2/5가 option C를 structural change(step에 join 복구 = ToolCallEntry 복제)와 함께만 채택 가능으로 판정. 순수 option C 지지 0건.

## 변경
- `types/core.ts`: think/reason step에 `ts?: string` 추가.
- `keeper-state.ts`: `appendAssistantThinkingDelta`에서 새 think step에 `ts` 부여(delta 병합 시 첫 ts 유지); `normalizeTraceStep`에서 백엔드 `ts` 추출(존재 시).
- `components/chat/primitives.ts`: `interleaveTraceAndTools` merge 함수(export); `ToolTraceCard` 단일 순회. 집계(failN/missingN/totalMs/stepN)는 entry 기반 유지.
- 테스트: `primitives-interleave.test.ts`(인터리빙 순서 5 case); 기존 strict `toEqual` 3곳에 `ts: expect.any(String)`.

## 검증 상태
- 로컬 빌드/테스트 미실행(사용자 지시: 빌드는 CI만). CI `Build and Test` + `Test Coverage Check`로 검증한다.
- self-review(best-programmer): think-only / tool-only / flat(`groupToolCalls=false`) 경로 무결. `groupToolCalls` 기본값은 false지만 `keeper-shared.ts`가 `groupToolCalls=${true}`로 명시 전달(3곳)하므로 턴 상세에 적용된다. 정렬은 ISO-8601 사전순=시간순, ts 부재 시 stable fallback으로 legacy 2-섹션 순서 보존.

## 비고
- RFC/workaround gate 대상 아니다(chat 렌더링, 워크어라운드 시그니처 없음).
- #21748(OPEN, 같은 `keeper-state.ts` 경로)과 충돌 영역 최소: traceSteps는 think/reason 전용 유지, 추가된 `ts`는 `sameConversationEntry`(role+text 매칭)에 영향을 주지 않는다.

Co-Authored-By: Claude <noreply@anthropic.com>
