### PR TITLE
fix(ws): cache stale ack threshold env reads

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -733,10 +733,11 @@ let dashboard_delta_for_sse session sse_event =
 
 (** TTL cache for env-var reads on the fan-out hot path.
 
-    [client_buffer_limit_bytes] and [slice_index_enabled] are both
-    invoked once per session per broadcast, so a 100-session fanout
-    at 1000 broadcasts/sec produced 200k [Sys.getenv_opt] calls per
-    second per var.  The earlier docstring claimed the read was
+    [client_buffer_limit_bytes], [dashboard_ack_stale_threshold_s],
+    and [slice_index_enabled] are invoked once per session per broadcast,
+    so a 100-session fanout at 1000 broadcasts/sec produced hundreds of
+    thousands of [Sys.getenv_opt] calls per second.  The earlier docstring
+    claimed the read was
     "atomic hash lookup", but [Env_config_core.raw_value_opt] runs
     [Sys.getenv_opt] which on glibc is a linear search of the
     process [environ] array — far from free.
@@ -765,9 +766,21 @@ let client_buffer_limit_bytes () =
     value
   end
 
+let dashboard_ack_stale_threshold_cache : (float * float) Atomic.t =
+  Atomic.make (Float.neg_infinity, 30.0)
+
 let dashboard_ack_stale_threshold_s () =
-  Env_config_core.get_float_nonneg ~default:30.0
-    "MASC_WS_ACK_STALE_THRESHOLD_SEC"
+  let now = Time_compat.now () in
+  let last_at, cached = Atomic.get dashboard_ack_stale_threshold_cache in
+  if now -. last_at < env_cache_ttl_s then cached
+  else begin
+    let value =
+      Env_config_core.get_float_nonneg ~default:30.0
+        "MASC_WS_ACK_STALE_THRESHOLD_SEC"
+    in
+    Atomic.set dashboard_ack_stale_threshold_cache (now, value);
+    value
+  end
 
 let dashboard_ack_is_stale
     ~now
@@ -828,6 +841,8 @@ let slice_index_enabled () =
     Production code never calls this. *)
 let __test_reset_env_caches () =
   Atomic.set client_buffer_limit_cache (Float.neg_infinity, 0);
+  Atomic.set dashboard_ack_stale_threshold_cache
+    (Float.neg_infinity, 30.0);
   Atomic.set slice_index_enabled_cache (Float.neg_infinity, true)
 
 let send_dashboard_or_raw_sse session sse_event =

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -60,6 +60,8 @@
     [dashboard_delta_for_sse], [env_cache_ttl_s],
     [client_buffer_limit_cache] /
     [client_buffer_limit_bytes],
+    [dashboard_ack_stale_threshold_cache] /
+    [dashboard_ack_stale_threshold_s],
     [session_is_backpressured],
     [max_inbound_frame_bytes] /
     [max_inbound_message_bytes],
@@ -444,6 +446,7 @@ val __test_slice_index_remove_session : string -> unit
 val __test_reset_env_caches : unit -> unit
 (** Test-only seam: resets the
     {!client_buffer_limit_bytes} and
+    {!dashboard_ack_stale_threshold_s} and
     {!slice_index_enabled} caches so the next call
     re-reads the environment. *)
 

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -376,7 +376,9 @@ val client_buffer_limit_bytes : unit -> int
 
 val dashboard_ack_stale_threshold_s : unit -> float
 (** Resolved max age for the latest [dashboard/ack] before outbound dashboard
-    sends are considered stale.  [0.0] disables stale-ACK backpressure. *)
+    sends are considered stale.  [0.0] disables stale-ACK backpressure.
+    Cached for [env_cache_ttl_s] seconds; the test resets the cache via
+    {!__test_reset_env_caches}. *)
 
 val dashboard_ack_is_stale :
   now:float ->

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -584,16 +584,31 @@ let test_backpressure_ack_stale_predicate () =
        ~last_delta_seq:7 ~last_ack_seq:6 ~threshold_s:0.0)
 
 let test_backpressure_ack_stale_threshold_reads_env () =
+  Ws.__test_reset_env_caches ();
   with_env_var "MASC_WS_ACK_STALE_THRESHOLD_SEC" "0" (fun () ->
     Alcotest.(check (float 0.001)) "env=0 disables stale-ack gate"
       0.0 (Ws.dashboard_ack_stale_threshold_s ()));
+  Ws.__test_reset_env_caches ();
   with_env_var "MASC_WS_ACK_STALE_THRESHOLD_SEC" "0.25" (fun () ->
     Alcotest.(check (float 0.001)) "env float is read"
       0.25 (Ws.dashboard_ack_stale_threshold_s ()))
 
+let test_backpressure_ack_stale_threshold_cache_resets () =
+  Ws.__test_reset_env_caches ();
+  with_env_var "MASC_WS_ACK_STALE_THRESHOLD_SEC" "7.5" (fun () ->
+    Alcotest.(check (float 0.001)) "initial threshold"
+      7.5 (Ws.dashboard_ack_stale_threshold_s ());
+    Unix.putenv "MASC_WS_ACK_STALE_THRESHOLD_SEC" "12.25";
+    Alcotest.(check (float 0.001)) "cached threshold holds"
+      7.5 (Ws.dashboard_ack_stale_threshold_s ());
+    Ws.__test_reset_env_caches ();
+    Alcotest.(check (float 0.001)) "reset observes env change"
+      12.25 (Ws.dashboard_ack_stale_threshold_s ()))
+
 let test_backpressure_gate_stale_ack_throttles_delivery () =
   let name = MetricStore.metric_ws_throttled_deliveries in
   let before = read_counter name in
+  Ws.__test_reset_env_caches ();
   with_env_var "MASC_WS_ACK_STALE_THRESHOLD_SEC" "0.001" (fun () ->
     let session = Ws.new_session ~id:"stale-ack" ~wsd:(Obj.magic ()) in
     Atomic.set session.dashboard_auth (Ws.Authenticated { agent = None });
@@ -1115,6 +1130,8 @@ let () =
         test_backpressure_ack_stale_predicate;
       Alcotest.test_case "ack stale threshold reads env" `Quick
         test_backpressure_ack_stale_threshold_reads_env;
+      Alcotest.test_case "ack stale threshold cache reset" `Quick
+        test_backpressure_ack_stale_threshold_cache_resets;
       Alcotest.test_case "stale ack throttles delivery before send" `Quick
         test_backpressure_gate_stale_ack_throttles_delivery;
     ]);


### PR DESCRIPTION
## Summary
- cache `MASC_WS_ACK_STALE_THRESHOLD_SEC` with the existing WS fanout env TTL cache
- include the stale-ack threshold in `__test_reset_env_caches`
- add regression coverage for env reads, cache retention, and explicit cache reset

## Validation
- `ocamlformat -i lib/server/server_mcp_transport_ws.ml lib/server/server_mcp_transport_ws.mli test/test_ws_transport.ml`
- `ocamlformat --check lib/server/server_mcp_transport_ws.ml lib/server/server_mcp_transport_ws.mli test/test_ws_transport.ml`
- `git diff --check`
- `gtimeout 120 env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/server/.masc_server.objs/byte/server_mcp_transport_ws.cmi`
- `gtimeout 180 env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build lib/server/.masc_server.objs/byte/server_mcp_transport_ws.cmo`

## Validation limits
- `gtimeout 240 env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_ws_transport.exe` timed out after 240s without compiler diagnostics.
- Narrow test object build reached the existing shared test harness failure before this test module: `test/deps/masc_test_deps.ml` references missing alias `Masc.Keeper_meta_json_parse`.
