### PR TITLE
docs: design — keeper turn-detail thinking↔tool interleaving preservation (concern #5)

### DIFF
--- a/docs/keeper-turn-interleaving-design.html
+++ b/docs/keeper-turn-interleaving-design.html
@@ -97,7 +97,7 @@ flowchart TD
   subgraph S["라이브 스트림 · keeper-stream.ts"]
     direction TB
     THv["THINKING_DELTA"] -->|"appendAssistantThinkingDelta()"| TS["assistant.traceSteps<br/>kind:'think' 만 누적"]
-    TCv["TOOL_CALL_START (:76)"] -->|"insertThreadEntryBefore(assistantEntryId) (:81)"| TE["tool entry 들<br/>assistant entry <b>앞</b>으로 hoist"]
+    TCv["TOOL_CALL_START"] -->|"insertThreadEntryBefore() (anchor 36ac1ebd)"| TE["tool entry 들<br/>assistant entry <b>앞</b>으로 hoist"]
   end
   TS --> CARD
   TE --> CARD

--- a/docs/keeper-turn-interleaving-design.html
+++ b/docs/keeper-turn-interleaving-design.html
@@ -4,7 +4,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>설계서 — Keeper 턴 상세: thinking↔tool 인터리빙 보존</title>
-<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.6/dist/mermaid.min.js"
+        integrity="sha384-qX9VvWkP79m/O121ZE6sOYp0nf/pldQgtvWDbkpzi+3mUo4Wn4Ix4cFzNPay3VaB"
+        crossorigin="anonymous"></script>
 <script>
   mermaid.initialize({ startOnLoad: true, theme: 'dark', securityLevel: 'loose' });
 </script>
@@ -61,14 +63,14 @@
     <span><b>상태</b> <span class="tag draft">Draft (설계 검토용)</span></span>
     <span><b>작성</b> 2026-06-21</span>
     <span><b>출처</b> 턴 상세 적대 감사 concern #5</span>
-    <span><b>연관</b> #21913(구현 PR), #21748 (thinking-trace mis-attribution), #21889(머지), #21892(머지)</span>
+    <span><b>연관</b> #21913(구현 PR), open issue #21748 (thinking-trace mis-attribution), #21889(머지), #21892(머지)</span>
     <span><b>대상 repo</b> masc / dashboard</span>
   </div>
 </header>
 
 <div class="callout key">
   <h4>요약 (TL;DR)</h4>
-  <p>키퍼 턴 상세에서 모델이 <code>think → tool → think → tool</code> 순으로 작업해도 화면에는 <code>[생각 블록 전체][도구 블록 전체]</code> 두 덩어리로만 보여, <b>어느 생각 다음에 어떤 도구가 실행됐는지</b>를 운영자가 볼 수 없다. 원인은 (1) 라이브 스트림이 모든 tool entry를 assistant entry <i>앞으로</i> hoist하고, (2) <code>ToolTraceCard</code>가 thinking과 tool을 <i>두 섹션으로 분리</i> 렌더하기 때문이다. <b>핵심:</b> 타입(<code>ChatTraceToolStep</code>)과 렌더러(<code>ChatTraceStep</code> 컴포넌트)는 인터리빙 표현력을 일부 갖고 있지만, 순수 <code>kind:'tool'</code> migration은 tool output join/status taxonomy를 잃는다. 현행 구현 #21913은 <b>render-time timestamp merge</b> — think/reason step의 <code>ts</code>와 tool entry의 <code>timestamp</code>를 정렬 키로 써 #21892 missing/output 집계를 보존한다. 후속 hardening 권장안은 같은 구조를 유지하되 wall-clock 대신 turn-local <code>occurrenceSeq</code>를 도입해 same-ms/tie 리스크를 제거하는 것이다.</p>
+  <p>키퍼 턴 상세에서 모델이 <code>think → tool → think → tool</code> 순으로 작업해도 화면에는 <code>[생각 블록 전체][도구 블록 전체]</code> 두 덩어리로만 보여, <b>어느 생각 다음에 어떤 도구가 실행됐는지</b>를 운영자가 볼 수 없다. 원인은 (1) 라이브 스트림이 모든 tool entry를 assistant entry <i>앞으로</i> hoist하고, (2) <code>ToolTraceCard</code>가 thinking과 tool을 <i>두 섹션으로 분리</i> 렌더하기 때문이다. <b>핵심:</b> 타입(<code>ChatTraceToolStep</code>)과 렌더러(<code>ChatTraceStep</code> 컴포넌트)는 인터리빙 표현력을 일부 갖고 있지만, 순수 <code>kind:'tool'</code> migration은 tool output join/status taxonomy를 잃는다. 현행 구현 #21913은 <b>render-time timestamp merge</b> — think/reason step의 <code>ts</code>와 tool entry의 <code>timestamp</code>를 정렬 키로 써 #21892 missing/output 집계를 보존한다. same-ms tie/clock-skew를 완전히 배제하지는 못하므로, 향후 optional hardening으로 turn-local <code>occurrenceSeq</code>를 도입할 수 있다.</p>
 </div>
 
 <div class="callout warn">
@@ -108,14 +110,14 @@ flowchart TD
   CARD --> OUT["화면: [생각][생각]…[도구][도구]<br/><b>교차 순서 소실</b>"]
 </div>
 
-<h3>2.2 근거 (file:line, 직접 검증)</h3>
+<h3>2.2 근거 (함수/타입 이름 + anchor commit)</h3>
 <table>
   <thead><tr><th>지점</th><th>코드</th><th>동작</th></tr></thead>
   <tbody>
-    <tr><td>tool entry hoist</td><td class="fileref">keeper-stream.ts:76–88</td><td><code>TOOL_CALL_START</code> → <code>insertThreadEntryBefore(keeperName, assistantEntryId, …)</code> — 모든 도구 entry를 단일 assistant entry <b>앞</b>에 삽입. tool entry는 <code>timestamp: new Date().toISOString()</code>(:88) 보유.</td></tr>
-    <tr><td>thinking 누적</td><td class="fileref">keeper-state.ts:841–858</td><td><code>appendAssistantThinkingDelta()</code>가 <code>traceSteps</code>에 <b><code>kind:'think'</code>만</b> append하고 새 step에 <code>ts</code>를 부여한다. tool 스텝은 여전히 traceSteps로 옮기지 않는다.</td></tr>
-    <tr><td>그룹핑</td><td class="fileref">primitives.ts:2374–2404</td><td><code>buildChatRenderUnits</code>가 <code>canAppendToolToRun</code> 기준(turnRef/인접)으로 연속 tool entry를 한 <code>toolGroup</code>으로 fold. tool run + 직후 assistant → 단일 <code>turnBundle</code>.</td></tr>
-    <tr><td>현재 interleave 구현</td><td class="fileref">primitives.ts:2178–2236</td><td>#21913 이후 <code>interleaveTraceAndTools</code>가 trace step과 tool entry를 단일 ordered list로 합성한다. 정렬 키는 trace <code>ts</code>와 tool <code>timestamp</code>이며, 같은 값이면 stable fallback으로 legacy trace-then-tool 순서를 보존한다.</td></tr>
+    <tr><td>tool entry hoist</td><td class="fileref">keeper-stream.ts:insertThreadEntryBefore (anchor 36ac1ebd)</td><td><code>TOOL_CALL_START</code> → <code>insertThreadEntryBefore(keeperName, assistantEntryId, …)</code> — 모든 도구 entry를 단일 assistant entry <b>앞</b>에 삽입. tool entry는 <code>timestamp: new Date().toISOString()</code> 보유.</td></tr>
+    <tr><td>thinking 누적</td><td class="fileref">keeper-state.ts:appendAssistantThinkingDelta (anchor 36ac1ebd)</td><td><code>appendAssistantThinkingDelta()</code>가 <code>traceSteps</code>에 <b><code>kind:'think'</code>만</b> append하고 새 step에 <code>ts</code>를 부여한다. tool 스텝은 여전히 traceSteps로 옮기지 않는다.</td></tr>
+    <tr><td>그룹핑</td><td class="fileref">primitives.ts:buildChatRenderUnits (anchor 36ac1ebd)</td><td><code>buildChatRenderUnits</code>가 <code>canAppendToolToRun</code> 기준(turnRef/인접)으로 연속 tool entry를 한 <code>toolGroup</code>으로 fold. tool run + 직후 assistant → 단일 <code>turnBundle</code>.</td></tr>
+    <tr><td>현재 interleave 구현</td><td class="fileref">primitives.ts:interleaveTraceAndTools (anchor 36ac1ebd)</td><td>#21913 이후 <code>interleaveTraceAndTools</code>가 trace step과 tool entry를 단일 ordered list로 합성한다. 정렬 키는 trace <code>ts</code>와 tool <code>timestamp</code>이며, 같은 값이면 stable fallback으로 legacy trace-then-tool 순서를 보존한다.</td></tr>
   </tbody>
 </table>
 
@@ -123,7 +125,7 @@ flowchart TD
 <div class="callout root">
   <h4>원래 순서 정보는 <i>존재</i>했지만 두 곳에서 폐기됐다</h4>
   <ul>
-    <li><b>(a) 스트림 hoist</b> — <span class="fileref">keeper-stream.ts:81</span>: tool entry를 assistant 앞으로 삽입하는 순간, 그 도구가 "어느 thinking 세그먼트 다음"이었는지가 사라진다. #21913 이전에는 tool의 <code>timestamp</code>만 남고 thinking 델타에는 세그먼트별 timestamp가 없었다.</li>
+    <li><b>(a) 스트림 hoist</b> — <span class="fileref">keeper-stream.ts:insertThreadEntryBefore (anchor 36ac1ebd)</span>: tool entry를 assistant 앞으로 삽입하는 순간, 그 도구가 "어느 thinking 세그먼트 다음"이었는지가 사라진다. #21913 이전에는 tool의 <code>timestamp</code>만 남고 thinking 델타에는 세그먼트별 timestamp가 없었다.</li>
     <li><b>(b) 2-섹션 렌더</b> — #21913 이전 <code>ToolTraceCard</code>는 <code>traceSteps</code>(생각)와 <code>tools</code>(도구)를 별도 입력으로 받아 순서대로 합치지 않고 두 섹션으로 그렸다. #21913 이후 이 문제는 timestamp merge로 완화됐다.</li>
   </ul>
 </div>
@@ -132,7 +134,7 @@ flowchart TD
 <div class="callout key">
   <h4>"새 기능"이 아니라 "미배선"</h4>
   <p><code>ChatTraceStep</code> 유니온은 이미 tool 변형을 포함한다:</p>
-  <pre>// types/core.ts:825–826
+  <pre>// types/core.ts:ChatTraceStep union (anchor 36ac1ebd)
 export type ChatTraceToolStep = { kind: 'tool'; name: string; status?: 'ok'|'err'; dur?: string; args?: unknown; result?: string }
 export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceToolStep</pre>
   <p>그리고 <code>ChatTraceStep</code> 렌더 컴포넌트(primitives.ts)는 <code>kind:'tool'</code> 스텝을 이미 그릴 수 있다. 다만 이 타입은 tool output join/status SSOT가 아니므로 순수 migration 대상은 아니다. 핵심은 <b>렌더러 표현력은 일부 이미 있지만, 현재 data path는 monotonic occurrence ordering key를 공유하지 않는다</b>는 점이다. #21913은 <code>ts</code>/<code>timestamp</code>로 이 간극을 좁혔지만, wall-clock tie를 완전히 제거하지는 않는다.</p>
@@ -160,18 +162,18 @@ flowchart TD
       <td><code>ToolTraceCard</code>에서 <code>traceSteps</code>+<code>tools</code>를 <code>ts</code>/<code>timestamp</code>로 정렬해 단일 <code>.map</code>. think/reason step은 optional <code>ts</code>, tool entry는 기존 <code>timestamp</code>를 사용한다.</td>
       <td>렌더만 (primitives.ts)</td>
       <td>낮음~중간</td>
-      <td><span class="rec">채택/구현됨</span> — 기존 tool entry를 유지해 output join, missing 집계, status taxonomy를 보존한다. 단, wall-clock timestamp tie/clock skew에는 취약할 수 있어 후속 <code>occurrenceSeq</code> 보강이 필요하다.</td>
+      <td><span class="rec">채택/구현됨</span> — 기존 tool entry를 유지해 output join, missing 집계, status taxonomy를 보존한다. 단, wall-clock timestamp tie/clock skew에는 취약할 수 있어 optional <code>occurrenceSeq</code> hardening을 고려할 수 있다.</td>
     </tr>
     <tr>
       <td><b>A2. occurrenceSeq hardening</b></td>
-      <td>live turn마다 단일 counter를 두고 think/reason step과 tool entry에 같은 counter에서 발급한 <code>occurrenceSeq</code>를 stamp한다. 정렬은 <code>occurrenceSeq</code> 우선, legacy는 기존 timestamp fallback.</td>
+      <td>live turn마다 dashboard frontend per-turn state의 단일 counter를 두고, 동일 JS 이벤트 루프에서 think/reason step과 tool entry에 같은 counter에서 발급한 <code>occurrenceSeq</code>를 stamp한다. 정렬은 <code>occurrenceSeq</code> 우선, legacy는 기존 timestamp fallback.</td>
       <td>stream + state + 렌더</td>
       <td>중간</td>
-      <td><span class="rec">권장 후속</span> — #21913의 entry-SSOT 보존 장점을 유지하면서 same-ms tie를 제거한다. 단일 counter가 turn-local SSOT여야 하며, 서로 다른 clock/counter를 섞으면 회귀한다.</td>
+      <td><span class="rec">optional follow-up / future hardening</span> — #21913의 entry-SSOT 보존 장점을 유지하면서 same-ms tie를 제거할 수 있다. 실제 재현/로그는 아직 수집되지 않았다. 단일 counter는 turn-local SSOT이며, 서로 다른 clock/counter를 섞으면 회귀한다.</td>
     </tr>
     <tr>
       <td><b>B. thinkAnchor 기록</b></td>
-      <td><span class="fileref">keeper-stream.ts:81</span>에서 tool 삽입 시 현재 <code>assistantEntry.traceSteps.length</code>(또는 thinking-char offset)를 tool entry에 <code>thinkAnchor</code>로 저장. 카드가 그 anchor 뒤에 도구 배치</td>
+      <td><span class="fileref">keeper-stream.ts:insertThreadEntryBefore (anchor 36ac1ebd)</span>에서 tool 삽입 시 현재 <code>assistantEntry.traceSteps.length</code>(또는 thinking-char offset)를 tool entry에 <code>thinkAnchor</code>로 저장. 카드가 그 anchor 뒤에 도구 배치</td>
       <td>stream + state + 렌더</td>
       <td>중간</td>
       <td>기존 entry 구조 유지하며 위치 <i>재구성</i>. anchor 계산 정확도에 의존. tool은 여전히 sibling entry라 두 자료구조를 동기화해야 함.</td>
@@ -193,13 +195,24 @@ flowchart TD
   </tbody>
 </table>
 
+<h3>5.1 침습도 정량 지표</h3>
+<table>
+  <thead><tr><th>옵션</th><th>변경 파일</th><th>public type 변경</th><th>기타</th></tr></thead>
+  <tbody>
+    <tr><td>A (#21913)</td><td><code>primitives.ts</code> 위주</td><td><code>ts?: string</code> 2건</td><td>렌더만</td></tr>
+    <tr><td>A2</td><td><code>types/core.ts</code>, <code>keeper-state.ts</code>, <code>keeper-stream.ts</code>, <code>primitives.ts</code></td><td><code>occurrenceSeq?: number</code> 2~3건</td><td>stream+state</td></tr>
+    <tr><td>B</td><td>A2와 유사 + anchor 필드 추가</td><td><code>thinkAnchor?: number</code> 추가</td><td>stream+state</td></tr>
+    <tr><td>C</td><td><code>keeper-stream.ts</code>, <code>keeper-state.ts</code>, <code>primitives.ts</code></td><td><code>ChatTraceToolStep</code> 확대 필요</td><td>구조 변경</td></tr>
+  </tbody>
+</table>
+
 <h2>6. 현행 권장안 + 근거</h2>
 <div class="callout ok">
   <h4>옵션 A — #21913 render-time timestamp merge + A2 sequence hardening</h4>
   <ol>
     <li><b>기존 tool entry를 보존</b>: <code>lookupToolCallOutput(entry.id)</code>, semantic status, missing aggregation이 그대로 유지된다.</li>
     <li><b>#21913 구현 상태</b>: think/reason step에 optional <code>ts</code>를 추가하고, tool entry의 기존 <code>timestamp</code>와 함께 <code>interleaveTraceAndTools</code>에서 정렬한다.</li>
-    <li><b>후속 보강</b>: live turn마다 단일 <code>occurrenceSeq</code> 카운터를 두고, think/reason 세그먼트 시작과 tool <code>CALL_START</code>에서 같은 카운터를 증가시킨 뒤 그 값으로 정렬한다.</li>
+    <li><b>후속 보강(optional)</b>: live turn마다 dashboard frontend per-turn state에 단일 <code>occurrenceSeq</code> 카운터를 두고, 동일 JS 이벤트 루프에서 think/reason 세그먼트 시작과 tool <code>CALL_START</code>에서 같은 카운터를 증가시킨 뒤 그 값으로 정렬한다. 별도의 동기화(Atomic/Mutex 등)는 이 레이어에서 필요 없다.</li>
     <li><b>카드 렌더만 단일 순회로 단순화</b>: <code>ToolTraceCard</code>의 thinking/tools 2-섹션 분기를 occurrence-ordered 단일 리스트로 바꾼다.</li>
   </ol>
   <p class="small">옵션 C는 구조적으로 깔끔해 보이지만 현재 타입으로는 output join/status 손실이 크다. 장기적으로 tool step을 SSOT로 삼으려면 <code>ToolCallEntry</code>급 식별자와 상태 모델을 먼저 통합해야 한다.</p>
@@ -209,18 +222,18 @@ flowchart TD
 <table>
   <thead><tr><th>단계</th><th>파일</th><th>변경</th></tr></thead>
   <tbody>
-    <tr><td>1 (#21913)</td><td class="fileref">types/core.ts</td><td><code>ChatTraceThinkStep</code>/<code>ChatTraceReasonStep</code>에 optional <code>ts</code> 추가. <code>ChatTraceToolStep</code>는 output join SSOT가 아니므로 순수 migration 대상으로 쓰지 않는다.</td></tr>
-    <tr><td>2 (#21913)</td><td class="fileref">keeper-state.ts</td><td><code>appendAssistantThinkingDelta</code>가 새 think step에 <code>ts</code>를 부여하고, consecutive delta merge에서는 최초 <code>ts</code>를 보존한다.</td></tr>
-    <tr><td>3 (#21913)</td><td class="fileref">primitives.ts (ToolTraceCard)</td><td><code>interleaveTraceAndTools</code>를 추가해 trace step <code>ts</code>와 tool entry <code>timestamp</code>로 sort한다. output join/missing/status aggregate는 기존 tool entry 기반으로 유지한다.</td></tr>
-    <tr><td>4 (후속)</td><td class="fileref">keeper-state.ts / keeper-stream.ts / primitives.ts</td><td>live turn 안에 단일 occurrence counter를 두고, think/reason 세그먼트 시작과 <code>TOOL_CALL_START</code>에서 같은 counter를 증가시켜 각각 trace step과 tool entry에 <code>occurrenceSeq</code>를 stamp한다. 정렬은 sequence 우선, legacy는 timestamp fallback.</td></tr>
-    <tr><td>5 (후속)</td><td class="fileref">primitives-interleave.test.ts</td><td><code>think A → tool X → think B → tool Y</code> 순서, same-millisecond timestamp tie에서 sequence 우선 정렬, sequence 없는 legacy fallback을 순수 함수 수준에서 고정한다.</td></tr>
+    <tr><td>1 (#21913)</td><td class="fileref">types/core.ts (anchor 36ac1ebd)</td><td><code>ChatTraceThinkStep</code>/<code>ChatTraceReasonStep</code>에 optional <code>ts</code> 추가. <code>ChatTraceToolStep</code>는 output join SSOT가 아니므로 순수 migration 대상으로 쓰지 않는다.</td></tr>
+    <tr><td>2 (#21913)</td><td class="fileref">keeper-state.ts:appendAssistantThinkingDelta (anchor 36ac1ebd)</td><td><code>appendAssistantThinkingDelta</code>가 새 think step에 <code>ts</code>를 부여하고, consecutive delta merge에서는 최초 <code>ts</code>를 보존한다.</td></tr>
+    <tr><td>3 (#21913)</td><td class="fileref">primitives.ts:interleaveTraceAndTools (anchor 36ac1ebd)</td><td><code>interleaveTraceAndTools</code>를 추가해 trace step <code>ts</code>와 tool entry <code>timestamp</code>로 sort한다. output join/missing/status aggregate는 기존 tool entry 기반으로 유지한다.</td></tr>
+    <tr><td>4 (후속)</td><td class="fileref">keeper-state.ts / keeper-stream.ts / primitives.ts (anchor 36ac1ebd 기준)</td><td>live turn 안에 단일 occurrence counter를 두고, think/reason 세그먼트 시작과 <code>TOOL_CALL_START</code>에서 같은 counter를 증가시켜 각각 trace step과 tool entry에 <code>occurrenceSeq</code>를 stamp한다. 정렬은 sequence 우선, legacy는 timestamp fallback. counter는 dashboard frontend의 per-turn state에 살아 있으며, 동일 JS 이벤트 루프에서 think/tool 이벤트가 순차 처리되므로 별도 동기화(Atomic/Mutex 등)는 필요 없다.</td></tr>
+    <tr><td>5 (후속)</td><td class="fileref">primitives-interleave.test.ts (신규)</td><td><code>think A → tool X → think B → tool Y</code> 순서, same-millisecond timestamp tie에서 sequence 우선 정렬, sequence 없는 legacy fallback을 순수 함수 수준에서 고정한다.</td></tr>
   </tbody>
 </table>
 
 <h2>8. 테스트 계획</h2>
 <ul>
   <li><b>인터리빙 보존</b>: <code>[think A, tool X, think B, tool Y]</code> 스트림 → 렌더 DOM 순서가 정확히 A·X·B·Y인지 단언.</li>
-  <li><b>timestamp tie 회귀</b>: #21913 현재 구현은 <code>ts</code>/<code>timestamp</code> 정렬이므로 same-ms tie에 취약할 수 있다. 후속 보강에서는 think step과 tool entry의 wall-clock timestamp가 같은 경우에도 <code>occurrenceSeq</code>가 A·X·B·Y 순서를 결정하는지 단언한다.</li>
+  <li><b>timestamp tie 회귀</b>: #21913 현재 구현은 <code>ts</code>/<code>timestamp</code> 정렬이므로 same-ms tie에 취약할 수 있다. §8 테스트 계획에 <code>ts</code>와 <code>timestamp</code>가 동일 ms인 synthetic <code>[think A, tool X, think B, tool Y]</code> 케이스를 추가해 stable-sort fallback이 trace-then-tool로 되돌아가지 않는지(또는 <code>occurrenceSeq</code> 후속 보강 시 A·X·B·Y 순서를 결정하는지) 단언한다. 실제 재현/로그는 아직 수집되지 않았다.</li>
   <li><b>output join 보존</b>: interleave 후에도 tool output/missing/status가 기존 <code>ToolCallEntry</code> 기반으로 유지되는지 확인.</li>
   <li><b>회귀</b>: 기존 think-only 턴, tool-only 턴, flat(<code>groupToolCalls=false</code>) 경로가 그대로 동작.</li>
   <li><b>#21892 연동</b>: settled 턴의 미join tool 스텝이 통합 배열에서도 <code>missing</code>으로 표시되는지.</li>
@@ -230,17 +243,17 @@ flowchart TD
 <div class="callout warn">
   <h4>충돌 · 좌표</h4>
   <ul>
-    <li><b>#21913 구현 SSOT</b>: 현행 구현은 #21913이며 정렬 키는 <code>ts</code>/<code>timestamp</code>다. #21748("assistant thinking-trace mis-attribution across identical-text turns")은 같은 <code>keeper-state.ts</code>/<code>keeper-stream.ts</code> traceStep 경로를 다루므로, 후속 변경은 #21913 위에서 rebase/통합해야 한다.</li>
+    <li><b>#21913 구현 SSOT</b>: 현행 구현은 #21913이며 정렬 키는 <code>ts</code>/<code>timestamp</code>다. open issue #21748("assistant thinking-trace mis-attribution across identical-text turns")은 같은 <code>keeper-state.ts</code>/<code>keeper-stream.ts</code> traceStep 경로를 다루므로, 후속 변경은 #21913 위에서 rebase/통합해야 한다.</li>
     <li><b>순수 옵션 C의 이중 자료구조</b>: tool을 step으로 옮기면, tool을 sibling entry로 읽던 다른 소비자(툴 실행 추적 패널, 그룹핑)와의 동기화/이중화를 정리해야 한다 — 잘못하면 한쪽만 갱신되는 silent drift.</li>
     <li><b>timestamp 기반 잔여 리스크</b>: <code>ts</code>/<code>timestamp</code>만으로는 same-ms tie나 clock skew를 구조적으로 배제하지 못한다. 이 문서의 <code>occurrenceSeq</code>는 이 잔여 리스크를 제거하기 위한 후속 hardening이다.</li>
-    <li><b>sequence 없는 legacy/history step</b>: <code>occurrenceSeq</code>가 없는 기존/backend-normalized step은 #21913의 timestamp fallback으로 남는다. 완전한 과거 재구성은 별도 backend sequence surface가 필요하다.</li>
+    <li><b>sequence 없는 legacy/history step</b>: <code>occurrenceSeq</code>가 없는 기존/backend-normalized step은 다음 3단계 fallback으로 정렬한다. (1) <code>occurrenceSeq</code>가 있으면 오름차순. (2) 없으면 <code>ts</code>/<code>timestamp</code> 오름차순. (3) 둘 다 없으면 원본 배열 순서(<code>traceSteps</code> 먼저, <code>tools</code> 나중에 concat된 순서)를 유지한다. 완전한 과거 재구성은 별도 backend sequence surface가 필요하다.</li>
     <li><b>sequence SSOT drift</b>: think/reason과 tool이 서로 다른 카운터나 서로 다른 clock을 쓰면 tie/clock-skew 문제가 재발한다. 카운터는 turn/entry 단위의 단일 ordered source여야 한다.</li>
     <li><b>스트림 재정렬 부작용</b>: hoist 제거가 자동 스크롤/스트리밍 표시(<code>streamState</code>)와 상호작용할 수 있어 라이브 회귀 테스트 필요.</li>
   </ul>
 </div>
 
 <hr />
-<p class="small">근거: 턴 상세 적대 감사(9-에이전트 워크플로) + 직접 spot-verify. 현재 구현 file:line은 2026-06-21 기준 origin/main에서 확인. #21913 이전 2-섹션 흐름도는 문제 원인 설명용이며, 현행 구현 좌표는 #21913이다.</p>
+<p class="small">근거: 턴 상세 적대 감사(9-에이전트 워크플로) + 직접 spot-verify. 코드 인용은 #21913 머지 커밋(anchor <code>36ac1ebdd5a0275a1825dad0fa325e509ccfd78d</code>)의 함수/타입 이름 위주이며, 정확한 line 번호는 리팩토링에 따라 부패할 수 있다. Mermaid는 CDN 버전 고정 + SRI를 사용하며, 오프라인/에어갭 환경에서는 <code>assets/</code> 아래 vendor할 수 있다. #21913 이전 2-섹션 흐름도는 문제 원인 설명용이며, 현행 구현 좌표는 #21913이다.</p>
 
 </div>
 </body>

--- a/docs/keeper-turn-interleaving-design.html
+++ b/docs/keeper-turn-interleaving-design.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>설계서 — Keeper 턴 상세: thinking↔tool 인터리빙 보존</title>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<script>
+  mermaid.initialize({ startOnLoad: true, theme: 'dark', securityLevel: 'loose' });
+</script>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --panel2: #1d212b; --fg: #d7dce5; --fg-dim: #8b93a3;
+    --acc: #6ea8fe; --ok: #4ec9a3; --warn: #e2b341; --err: #e06c75; --border: #2a2f3a;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font-family: -apple-system, "Apple SD Gothic Neo", "Pretendard", system-ui, sans-serif;
+    line-height: 1.65; font-size: 15px;
+  }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 40px 28px 120px; }
+  header.doc { border-bottom: 1px solid var(--border); padding-bottom: 20px; margin-bottom: 8px; }
+  h1 { font-size: 26px; margin: 0 0 10px; letter-spacing: -0.01em; }
+  h2 { font-size: 20px; margin: 40px 0 12px; padding-top: 12px; border-top: 1px solid var(--border); letter-spacing: -0.01em; }
+  h3 { font-size: 16px; margin: 24px 0 8px; color: var(--acc); }
+  p { margin: 10px 0; }
+  code { font-family: var(--mono); font-size: 0.86em; background: var(--panel2); padding: 1px 6px; border-radius: 4px; color: #c8d3e6; }
+  pre { background: var(--panel2); border: 1px solid var(--border); border-radius: 8px; padding: 14px 16px; overflow-x: auto; font-family: var(--mono); font-size: 13px; line-height: 1.5; }
+  .meta { display: flex; flex-wrap: wrap; gap: 8px 18px; color: var(--fg-dim); font-size: 13px; margin-top: 6px; }
+  .meta b { color: var(--fg); font-weight: 600; }
+  .tag { display: inline-block; font-size: 12px; padding: 2px 9px; border-radius: 999px; border: 1px solid var(--border); background: var(--panel); color: var(--fg-dim); }
+  .tag.draft { color: var(--warn); border-color: #5a4a1f; }
+  table { width: 100%; border-collapse: collapse; margin: 14px 0; font-size: 13.5px; }
+  th, td { text-align: left; padding: 9px 11px; border: 1px solid var(--border); vertical-align: top; }
+  th { background: var(--panel2); color: var(--fg); font-weight: 600; }
+  td code { white-space: nowrap; }
+  .callout { border: 1px solid var(--border); border-left-width: 3px; border-radius: 8px; padding: 12px 16px; margin: 16px 0; background: var(--panel); }
+  .callout.root { border-left-color: var(--err); }
+  .callout.key { border-left-color: var(--acc); }
+  .callout.ok { border-left-color: var(--ok); }
+  .callout.warn { border-left-color: var(--warn); }
+  .callout h4 { margin: 0 0 6px; font-size: 14px; }
+  .mermaid { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 18px; margin: 16px 0; text-align: center; }
+  ul, ol { margin: 8px 0; padding-left: 22px; }
+  li { margin: 5px 0; }
+  .fileref { font-family: var(--mono); font-size: 0.84em; color: var(--ok); }
+  .rec { color: var(--ok); font-weight: 600; }
+  .no { color: var(--err); }
+  .small { color: var(--fg-dim); font-size: 13px; }
+  hr { border: none; border-top: 1px solid var(--border); margin: 28px 0; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header class="doc">
+  <h1>설계서 — Keeper 턴 상세: thinking↔tool 인터리빙 보존</h1>
+  <div class="meta">
+    <span><b>상태</b> <span class="tag draft">Draft (설계 검토용)</span></span>
+    <span><b>작성</b> 2026-06-21</span>
+    <span><b>출처</b> 턴 상세 적대 감사 concern #5</span>
+    <span><b>연관</b> #21748 (thinking-trace mis-attribution), #21889(머지), #21892(머지)</span>
+    <span><b>대상 repo</b> masc / dashboard</span>
+  </div>
+</header>
+
+<div class="callout key">
+  <h4>요약 (TL;DR)</h4>
+  <p>키퍼 턴 상세에서 모델이 <code>think → tool → think → tool</code> 순으로 작업해도 화면에는 <code>[생각 블록 전체][도구 블록 전체]</code> 두 덩어리로만 보여, <b>어느 생각 다음에 어떤 도구가 실행됐는지</b>를 운영자가 볼 수 없다. 원인은 (1) 라이브 스트림이 모든 tool entry를 assistant entry <i>앞으로</i> hoist하고, (2) <code>ToolTraceCard</code>가 thinking과 tool을 <i>두 섹션으로 분리</i> 렌더하기 때문이다. <b>핵심:</b> 타입(<code>ChatTraceToolStep</code>)과 렌더러(<code>ChatTraceStep</code> 컴포넌트)는 이미 인터리빙을 표현할 수 있는데 <b>스트림 빌더가 think-only만 emit</b>한다. 권장안은 통합 <code>traceSteps</code> 배열에 <code>kind:'tool'</code> 스텝도 순서대로 append하는 <b>옵션 C</b>(구조적 표현) — 재구성이 아니라 표현력 배선이다.</p>
+</div>
+
+<h2>1. 문제 정의 (concern #5)</h2>
+<p>사용자 관찰: <i>"Thinking 중간에 Tools가 나오는 배치는 못 보는건가? 이게 어떻게 묶이는건지."</i></p>
+<p>턴 상세 transcript는 한 턴의 작업 과정을 <b>"작업 과정"</b> 카드(<code>ToolTraceCard</code>)로 보여준다. 그러나 모델의 실제 작업 순서(생각과 도구 호출의 교차)가 렌더링에서 소실되어, 운영자는 다음을 판단할 수 없다:</p>
+<ul>
+  <li>특정 도구가 <b>어느 추론 단계 직후</b>에 실행됐는가</li>
+  <li>도구 결과가 그 다음 생각에 반영됐는가(인과 순서)</li>
+  <li>생각만 길게 하고 도구는 마지막에 몰아친 것인지, 생각-도구를 번갈아 한 것인지</li>
+</ul>
+<p>이 정보는 키퍼가 "생각만 맴돌다 멈추는"(thinking-only/no-progress) 패턴을 운영자가 진단할 때 직접적 단서가 된다. concern #3(thinking 루프)과 같은 뿌리의 관측성 문제다.</p>
+
+<h2>2. As-Is — 현재 동작</h2>
+<p>대상 표면은 <code>groupToolCalls=true</code> 경로(<span class="fileref">keeper-shared.ts</span>)이며 <code>buildChatRenderUnits</code> → <code>TurnWorkBundle</code> → <code>ToolTraceCard</code>로 렌더된다.</p>
+
+<h3>2.1 데이터 흐름</h3>
+<div class="mermaid">
+flowchart TD
+  subgraph S["라이브 스트림 · keeper-stream.ts"]
+    direction TB
+    THv["THINKING_DELTA"] -->|"appendAssistantThinkingDelta()"| TS["assistant.traceSteps<br/>kind:'think' 만 누적"]
+    TCv["TOOL_CALL_START (:76)"] -->|"insertThreadEntryBefore(assistantEntryId) (:81)"| TE["tool entry 들<br/>assistant entry <b>앞</b>으로 hoist"]
+  end
+  TS --> CARD
+  TE --> CARD
+  subgraph CARD["ToolTraceCard 렌더 (primitives.ts)"]
+    direction TB
+    A["1) traceSteps.map → 생각 블록 전체"]
+    B["2) tools.map → 도구 블록 전체"]
+    A --> B
+  end
+  CARD --> OUT["화면: [생각][생각]…[도구][도구]<br/><b>교차 순서 소실</b>"]
+</div>
+
+<h3>2.2 근거 (file:line, 직접 검증)</h3>
+<table>
+  <thead><tr><th>지점</th><th>코드</th><th>동작</th></tr></thead>
+  <tbody>
+    <tr><td>tool entry hoist</td><td class="fileref">keeper-stream.ts:76–88</td><td><code>TOOL_CALL_START</code> → <code>insertThreadEntryBefore(keeperName, assistantEntryId, …)</code> — 모든 도구 entry를 단일 assistant entry <b>앞</b>에 삽입. tool entry는 <code>timestamp: new Date().toISOString()</code>(:88) 보유.</td></tr>
+    <tr><td>thinking 누적</td><td class="fileref">keeper-state.ts:841–858</td><td><code>appendAssistantThinkingDelta()</code>가 <code>traceSteps</code>에 <b><code>kind:'think'</code>만</b> append(:850, :854). tool 스텝은 절대 안 들어감.</td></tr>
+    <tr><td>그룹핑</td><td class="fileref">primitives.ts:2259 · 2289</td><td><code>buildChatRenderUnits</code>가 <code>canAppendToolToRun</code> 기준(turnRef/인접)으로 연속 tool entry를 한 <code>toolGroup</code>으로 fold. tool run + 직후 assistant → 단일 <code>turnBundle</code>.</td></tr>
+    <tr><td>2-섹션 렌더</td><td class="fileref">primitives.ts (ToolTraceCard)</td><td><code>traceSteps.map(…)</code> <b>다음</b> <code>tools.map(…)</code> — 생각 전체를 먼저, 도구 전체를 나중에. 헤더 단계 수는 <code>traceSteps.length + tools.length</code>로 함께 세지만 렌더는 비-인터리브 2블록.</td></tr>
+  </tbody>
+</table>
+
+<h3>2.3 정보 손실 지점</h3>
+<div class="callout root">
+  <h4>순서 정보는 <i>존재</i>하지만 두 곳에서 폐기된다</h4>
+  <ul>
+    <li><b>(a) 스트림 hoist</b> — <span class="fileref">keeper-stream.ts:81</span>: tool entry를 assistant 앞으로 삽입하는 순간, 그 도구가 "어느 thinking 세그먼트 다음"이었는지가 사라진다. tool의 <code>timestamp</code>는 남지만 thinking 델타에는 세그먼트별 timestamp가 없다.</li>
+    <li><b>(b) 2-섹션 렌더</b> — <code>ToolTraceCard</code>가 <code>traceSteps</code>(생각)와 <code>tools</code>(도구)를 별도 입력으로 받아 순서대로 합치지 않고 두 섹션으로 그린다.</li>
+  </ul>
+</div>
+
+<h2>3. 핵심 통찰 — 표현력은 이미 있다</h2>
+<div class="callout key">
+  <h4>"새 기능"이 아니라 "미배선"</h4>
+  <p><code>ChatTraceStep</code> 유니온은 이미 tool 변형을 포함한다:</p>
+  <pre>// types/core.ts:825–826
+export type ChatTraceToolStep = { kind: 'tool'; name: string; status?: 'ok'|'err'; dur?: string; args?: unknown; result?: string }
+export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceToolStep</pre>
+  <p>그리고 <code>ChatTraceStep</code> 렌더 컴포넌트(primitives.ts)는 <code>kind:'tool'</code> 스텝을 이미 그릴 수 있다. <b>유일한 공백</b>은 entry 레벨 <code>traceSteps</code> 빌더(<code>appendAssistantThinkingDelta</code>)가 <code>kind:'think'</code>만 emit한다는 것. 즉 단일 순서 배열로 인터리빙을 표현할 길이 타입·렌더러엔 열려 있는데 stream 핸들러만 안 쓴다.</p>
+</div>
+
+<h2>4. To-Be — 제안 설계</h2>
+<div class="mermaid">
+flowchart TD
+  subgraph S2["라이브 스트림 (수정)"]
+    direction TB
+    TH2["THINKING_DELTA"] -->|"append kind:'think'"| U["통합 traceSteps<br/>kind:'think' | 'tool' 시간순 인터리브"]
+    TC2["TOOL_CALL_START / _END"] -->|"append kind:'tool' (+status/dur 후속 패치)"| U
+  end
+  U --> C2["ToolTraceCard<br/>traceSteps 단일 순회 렌더"]
+  C2 --> O2["화면: 생각 → 도구 → 생각 → 도구<br/><b>실제 순서 보존</b>"]
+</div>
+<p>도구 호출을 sibling entry로 따로 두지 않고, 발생 시점에 assistant의 <b>같은 <code>traceSteps</code> 배열</b>에 <code>kind:'tool'</code> 스텝으로 append한다. 렌더러는 이미 그 순서대로 그릴 수 있으므로 카드 변경이 최소화된다.</p>
+
+<h2>5. 설계 옵션 비교</h2>
+<table>
+  <thead><tr><th>옵션</th><th>메커니즘</th><th>변경 레이어</th><th>침습도</th><th>트레이드오프</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><b>A. 카드 sort-merge</b></td>
+      <td><code>ToolTraceCard</code>에서 <code>traceSteps</code>+<code>tools</code>를 timestamp로 정렬해 단일 <code>.map</code></td>
+      <td>렌더만 (primitives.ts)</td>
+      <td>낮음</td>
+      <td><span class="no">불충분</span> — 상류 hoist로 tool의 thinking-상대 위치가 이미 소실. thinking 델타엔 세그먼트 timestamp가 없어 정렬 키가 부정확. <b>단독으로는 순서 복원 불가.</b></td>
+    </tr>
+    <tr>
+      <td><b>B. thinkAnchor 기록</b></td>
+      <td><span class="fileref">keeper-stream.ts:81</span>에서 tool 삽입 시 현재 <code>assistantEntry.traceSteps.length</code>(또는 thinking-char offset)를 tool entry에 <code>thinkAnchor</code>로 저장. 카드가 그 anchor 뒤에 도구 배치</td>
+      <td>stream + state + 렌더</td>
+      <td>중간</td>
+      <td>기존 entry 구조 유지하며 위치 <i>재구성</i>. anchor 계산 정확도에 의존. tool은 여전히 sibling entry라 두 자료구조를 동기화해야 함.</td>
+    </tr>
+    <tr>
+      <td><b class="rec">C. 통합 traceSteps (권장)</b></td>
+      <td>tool 발생 시 assistant의 <code>traceSteps</code>에 <code>kind:'tool'</code> 스텝을 순서대로 append. <code>TOOL_CALL_END</code>에서 status/dur 후속 패치. 카드는 단일 배열 순회</td>
+      <td>stream + state (+ 카드 소폭)</td>
+      <td>중간</td>
+      <td><span class="rec">인터리빙을 <i>구조적으로</i> 표현</span> — 타입/렌더러 이미 지원. 재구성 불필요. 단 tool entry를 sibling으로도 두던 기존 소비자(그룹핑/툴 패널)와의 이중화 정리 필요.</td>
+    </tr>
+    <tr>
+      <td><b>D. timestamp 표면화</b></td>
+      <td>각 스텝에 상대 시각/순번 배지 표시 (A~C와 병행 가능)</td>
+      <td>렌더만</td>
+      <td>낮음</td>
+      <td>보조책. 순서를 <i>복원</i>하진 않지만 운영자가 순번을 추론하게 함. thinking 델타 timestamp 부재가 한계.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>6. 권장안 + 근거</h2>
+<div class="callout ok">
+  <h4>옵션 C — 통합 <code>traceSteps</code></h4>
+  <ol>
+    <li><b>표현력이 이미 존재</b>: <code>ChatTraceToolStep</code> 타입 + 렌더러가 인터리브를 그릴 수 있어, "새 표현"이 아니라 "배선"이다. 재구성(옵션 A/B)보다 결정론적.</li>
+    <li><b>순서가 source-of-truth</b>: 발생 시점에 한 배열에 순서대로 쌓으면 timestamp 정렬·anchor 계산 같은 휴리스틱이 불필요.</li>
+    <li><b>카드 단순화</b>: <code>ToolTraceCard</code>의 2-섹션 분기를 단일 순회로 줄여 렌더 복잡도 감소.</li>
+  </ol>
+  <p class="small">옵션 D(순번 배지)를 병행해 점진 도입 가능: 먼저 D로 관측성 보강 → C로 구조 전환.</p>
+</div>
+
+<h2>7. 구현 계획 (스케치, 코드 아님)</h2>
+<table>
+  <thead><tr><th>단계</th><th>파일</th><th>변경</th></tr></thead>
+  <tbody>
+    <tr><td>1</td><td class="fileref">keeper-state.ts</td><td><code>appendAssistantToolStep(keeper, entryId, {name,...})</code> 추가 — assistant <code>traceSteps</code>에 <code>kind:'tool'</code> append. <code>TOOL_CALL_END</code>용 <code>patchAssistantToolStep</code>(status/dur/result 채우기).</td></tr>
+    <tr><td>2</td><td class="fileref">keeper-stream.ts:76–95</td><td><code>TOOL_CALL_START/ARGS/END</code> 핸들러를 sibling <code>insertThreadEntryBefore</code> 대신(또는 병행) step append로 라우팅. 두 경로 이중화 시 SSOT 결정.</td></tr>
+    <tr><td>3</td><td class="fileref">primitives.ts (ToolTraceCard)</td><td>2-섹션(<code>traceSteps</code> then <code>tools</code>)을 단일 <code>traceSteps</code> 순회로. 헤더의 도구/실패/<code>결과 누락</code> 카운트는 <code>kind:'tool'</code> 스텝에서 집계.</td></tr>
+    <tr><td>4</td><td class="fileref">buildChatRenderUnits</td><td>tool이 step으로 흡수되면 별도 <code>toolGroup</code> 그룹핑 로직 정리 — 기존 flat 경로(<code>groupToolCalls=false</code>) 회귀 방지.</td></tr>
+  </tbody>
+</table>
+
+<h2>8. 테스트 계획</h2>
+<ul>
+  <li><b>인터리빙 보존</b>: <code>[think A, tool X, think B, tool Y]</code> 스트림 → 렌더 DOM 순서가 정확히 A·X·B·Y인지 단언.</li>
+  <li><b>status/dur 후속 패치</b>: <code>TOOL_CALL_END</code> 후 해당 tool 스텝의 status(ok/err)·dur 갱신 확인.</li>
+  <li><b>회귀</b>: 기존 think-only 턴, tool-only 턴, flat(<code>groupToolCalls=false</code>) 경로가 그대로 동작.</li>
+  <li><b>#21892 연동</b>: settled 턴의 미join tool 스텝이 통합 배열에서도 <code>missing</code>으로 표시되는지.</li>
+</ul>
+
+<h2>9. 리스크 · 미해결 질문</h2>
+<div class="callout warn">
+  <h4>충돌 · 좌표</h4>
+  <ul>
+    <li><b>#21748 동일 영역</b>: "assistant thinking-trace mis-attribution across identical-text turns"가 <code>keeper-state.ts</code>/<code>keeper-stream.ts</code>의 같은 traceStep 경로를 다룬다. <b>본 설계는 #21748에 합류</b>해 단일 SSOT로 진행 권장(중복 PR 회피).</li>
+    <li><b>이중 자료구조</b>: tool을 step으로 옮기면, tool을 sibling entry로 읽던 다른 소비자(툴 실행 추적 패널, 그룹핑)와의 동기화/이중화를 정리해야 한다 — 잘못하면 한쪽만 갱신되는 silent drift.</li>
+    <li><b>thinking 세그먼트 timestamp 부재</b>: 옵션 A/D의 정렬·배지 정확도 한계. 옵션 C는 발생순 append라 이 문제를 우회.</li>
+    <li><b>스트림 재정렬 부작용</b>: hoist 제거가 자동 스크롤/스트리밍 표시(<code>streamState</code>)와 상호작용할 수 있어 라이브 회귀 테스트 필요.</li>
+  </ul>
+</div>
+
+<hr />
+<p class="small">근거: 턴 상세 적대 감사(9-에이전트 워크플로) + 직접 spot-verify. 모든 file:line은 2026-06-21 기준 origin/main에서 확인. 표현력(타입/렌더러)은 존재, 빌더 미배선이 핵심. 본 문서는 코드 변경이 아닌 설계 검토용 Draft이며, 구현은 #21748 맥락에서 진행 권장.</p>
+
+</div>
+</body>
+</html>

--- a/docs/keeper-turn-interleaving-design.html
+++ b/docs/keeper-turn-interleaving-design.html
@@ -61,14 +61,19 @@
     <span><b>상태</b> <span class="tag draft">Draft (설계 검토용)</span></span>
     <span><b>작성</b> 2026-06-21</span>
     <span><b>출처</b> 턴 상세 적대 감사 concern #5</span>
-    <span><b>연관</b> #21748 (thinking-trace mis-attribution), #21889(머지), #21892(머지)</span>
+    <span><b>연관</b> #21913(구현 PR), #21748 (thinking-trace mis-attribution), #21889(머지), #21892(머지)</span>
     <span><b>대상 repo</b> masc / dashboard</span>
   </div>
 </header>
 
 <div class="callout key">
   <h4>요약 (TL;DR)</h4>
-  <p>키퍼 턴 상세에서 모델이 <code>think → tool → think → tool</code> 순으로 작업해도 화면에는 <code>[생각 블록 전체][도구 블록 전체]</code> 두 덩어리로만 보여, <b>어느 생각 다음에 어떤 도구가 실행됐는지</b>를 운영자가 볼 수 없다. 원인은 (1) 라이브 스트림이 모든 tool entry를 assistant entry <i>앞으로</i> hoist하고, (2) <code>ToolTraceCard</code>가 thinking과 tool을 <i>두 섹션으로 분리</i> 렌더하기 때문이다. <b>핵심:</b> 타입(<code>ChatTraceToolStep</code>)과 렌더러(<code>ChatTraceStep</code> 컴포넌트)는 이미 인터리빙을 표현할 수 있는데 <b>스트림 빌더가 think-only만 emit</b>한다. 권장안은 통합 <code>traceSteps</code> 배열에 <code>kind:'tool'</code> 스텝도 순서대로 append하는 <b>옵션 C</b>(구조적 표현) — 재구성이 아니라 표현력 배선이다.</p>
+  <p>키퍼 턴 상세에서 모델이 <code>think → tool → think → tool</code> 순으로 작업해도 화면에는 <code>[생각 블록 전체][도구 블록 전체]</code> 두 덩어리로만 보여, <b>어느 생각 다음에 어떤 도구가 실행됐는지</b>를 운영자가 볼 수 없다. 원인은 (1) 라이브 스트림이 모든 tool entry를 assistant entry <i>앞으로</i> hoist하고, (2) <code>ToolTraceCard</code>가 thinking과 tool을 <i>두 섹션으로 분리</i> 렌더하기 때문이다. <b>핵심:</b> 타입(<code>ChatTraceToolStep</code>)과 렌더러(<code>ChatTraceStep</code> 컴포넌트)는 인터리빙 표현력을 일부 갖고 있지만, 순수 <code>kind:'tool'</code> migration은 tool output join/status taxonomy를 잃는다. 현행 권장안은 #21913의 <b>render-time occurrence merge</b> — think/reason step에 <code>ts</code>를 찍고 기존 tool entry timestamp와 정렬해 #21892 missing/output 집계를 보존하는 방식이다.</p>
+</div>
+
+<div class="callout warn">
+  <h4>2026-06-21 결정 보정</h4>
+  <p>초기 설계는 옵션 C(도구를 <code>traceSteps</code> 안으로 이동)를 권장했지만, #21913 구현 리뷰에서 순수 옵션 C는 거부됐다. 이유는 <code>ChatTraceToolStep</code>에 <code>tool_use_id</code>가 없어 output store join을 끊고, status를 <code>ok|err</code>로 축소하며, #21892의 missing/aggregate 계산을 깨기 때문이다. 이 문서는 #21913의 render-time merge 결정을 SSOT로 따른다.</p>
 </div>
 
 <h2>1. 문제 정의 (concern #5)</h2>
@@ -151,11 +156,11 @@ flowchart TD
   <thead><tr><th>옵션</th><th>메커니즘</th><th>변경 레이어</th><th>침습도</th><th>트레이드오프</th></tr></thead>
   <tbody>
     <tr>
-      <td><b>A. 카드 sort-merge</b></td>
-      <td><code>ToolTraceCard</code>에서 <code>traceSteps</code>+<code>tools</code>를 timestamp로 정렬해 단일 <code>.map</code></td>
+      <td><b class="rec">A. 카드 occurrence merge (#21913)</b></td>
+      <td><code>ToolTraceCard</code>에서 <code>traceSteps</code>+<code>tools</code>를 timestamp로 정렬해 단일 <code>.map</code>. think/reason step에는 <code>ts</code>를 추가한다.</td>
       <td>렌더만 (primitives.ts)</td>
-      <td>낮음</td>
-      <td><span class="no">불충분</span> — 상류 hoist로 tool의 thinking-상대 위치가 이미 소실. thinking 델타엔 세그먼트 timestamp가 없어 정렬 키가 부정확. <b>단독으로는 순서 복원 불가.</b></td>
+      <td>낮음~중간</td>
+      <td><span class="rec">채택</span> — 기존 tool entry를 유지해 output join, missing 집계, status taxonomy를 보존한다. 단, think/reason에 occurrence timestamp를 stamp해야 하며 timestamp 없는 backend-normalized step은 legacy two-section fallback으로 둔다.</td>
     </tr>
     <tr>
       <td><b>B. thinkAnchor 기록</b></td>
@@ -165,11 +170,11 @@ flowchart TD
       <td>기존 entry 구조 유지하며 위치 <i>재구성</i>. anchor 계산 정확도에 의존. tool은 여전히 sibling entry라 두 자료구조를 동기화해야 함.</td>
     </tr>
     <tr>
-      <td><b class="rec">C. 통합 traceSteps (권장)</b></td>
+      <td><b>C. 통합 traceSteps</b></td>
       <td>tool 발생 시 assistant의 <code>traceSteps</code>에 <code>kind:'tool'</code> 스텝을 순서대로 append. <code>TOOL_CALL_END</code>에서 status/dur 후속 패치. 카드는 단일 배열 순회</td>
       <td>stream + state (+ 카드 소폭)</td>
       <td>중간</td>
-      <td><span class="rec">인터리빙을 <i>구조적으로</i> 표현</span> — 타입/렌더러 이미 지원. 재구성 불필요. 단 tool entry를 sibling으로도 두던 기존 소비자(그룹핑/툴 패널)와의 이중화 정리 필요.</td>
+      <td><span class="no">순수 migration은 기각</span> — <code>ChatTraceToolStep</code>에는 output-store join에 필요한 식별자와 현재 status taxonomy가 부족하다. 이를 보완하려면 사실상 <code>ToolCallEntry</code>를 중복하는 구조 변경이 필요하다.</td>
     </tr>
     <tr>
       <td><b>D. timestamp 표면화</b></td>
@@ -181,32 +186,32 @@ flowchart TD
   </tbody>
 </table>
 
-<h2>6. 권장안 + 근거</h2>
+<h2>6. 현행 권장안 + 근거</h2>
 <div class="callout ok">
-  <h4>옵션 C — 통합 <code>traceSteps</code></h4>
+  <h4>옵션 A — #21913 render-time occurrence merge</h4>
   <ol>
-    <li><b>표현력이 이미 존재</b>: <code>ChatTraceToolStep</code> 타입 + 렌더러가 인터리브를 그릴 수 있어, "새 표현"이 아니라 "배선"이다. 재구성(옵션 A/B)보다 결정론적.</li>
-    <li><b>순서가 source-of-truth</b>: 발생 시점에 한 배열에 순서대로 쌓으면 timestamp 정렬·anchor 계산 같은 휴리스틱이 불필요.</li>
-    <li><b>카드 단순화</b>: <code>ToolTraceCard</code>의 2-섹션 분기를 단일 순회로 줄여 렌더 복잡도 감소.</li>
+    <li><b>기존 tool entry를 보존</b>: <code>lookupToolCallOutput(entry.id)</code>, semantic status, missing aggregation이 그대로 유지된다.</li>
+    <li><b>순서 복원에 필요한 최소 데이터만 추가</b>: live think/reason step에 <code>ts</code>를 stamp하고, tool entry의 기존 <code>timestamp</code>와 stable sort한다.</li>
+    <li><b>카드 렌더만 단일 순회로 단순화</b>: <code>ToolTraceCard</code>의 thinking/tools 2-섹션 분기를 occurrence-ordered 단일 리스트로 바꾼다.</li>
   </ol>
-  <p class="small">옵션 D(순번 배지)를 병행해 점진 도입 가능: 먼저 D로 관측성 보강 → C로 구조 전환.</p>
+  <p class="small">옵션 C는 구조적으로 깔끔해 보이지만 현재 타입으로는 output join/status 손실이 크다. 장기적으로 tool step을 SSOT로 삼으려면 <code>ToolCallEntry</code>급 식별자와 상태 모델을 먼저 통합해야 한다.</p>
 </div>
 
-<h2>7. 구현 계획 (스케치, 코드 아님)</h2>
+<h2>7. 구현 계획 (#21913 기준)</h2>
 <table>
   <thead><tr><th>단계</th><th>파일</th><th>변경</th></tr></thead>
   <tbody>
-    <tr><td>1</td><td class="fileref">keeper-state.ts</td><td><code>appendAssistantToolStep(keeper, entryId, {name,...})</code> 추가 — assistant <code>traceSteps</code>에 <code>kind:'tool'</code> append. <code>TOOL_CALL_END</code>용 <code>patchAssistantToolStep</code>(status/dur/result 채우기).</td></tr>
-    <tr><td>2</td><td class="fileref">keeper-stream.ts:76–95</td><td><code>TOOL_CALL_START/ARGS/END</code> 핸들러를 sibling <code>insertThreadEntryBefore</code> 대신(또는 병행) step append로 라우팅. 두 경로 이중화 시 SSOT 결정.</td></tr>
-    <tr><td>3</td><td class="fileref">primitives.ts (ToolTraceCard)</td><td>2-섹션(<code>traceSteps</code> then <code>tools</code>)을 단일 <code>traceSteps</code> 순회로. 헤더의 도구/실패/<code>결과 누락</code> 카운트는 <code>kind:'tool'</code> 스텝에서 집계.</td></tr>
-    <tr><td>4</td><td class="fileref">buildChatRenderUnits</td><td>tool이 step으로 흡수되면 별도 <code>toolGroup</code> 그룹핑 로직 정리 — 기존 flat 경로(<code>groupToolCalls=false</code>) 회귀 방지.</td></tr>
+    <tr><td>1</td><td class="fileref">types/core.ts</td><td><code>ChatTraceThinkStep</code>/<code>ChatTraceReasonStep</code>에 optional <code>ts</code> 추가. <code>ChatTraceToolStep</code>는 output join SSOT가 아니므로 순수 migration 대상으로 쓰지 않는다.</td></tr>
+    <tr><td>2</td><td class="fileref">keeper-state.ts</td><td>live thinking step 생성 시 <code>new Date().toISOString()</code>로 occurrence timestamp를 stamp하고, consecutive delta merge에서는 최초 timestamp를 보존. backend-normalized step의 <code>ts</code>도 통과시킨다.</td></tr>
+    <tr><td>3</td><td class="fileref">primitives.ts (ToolTraceCard)</td><td><code>interleaveTraceAndTools</code>를 추가해 trace step과 tool entry를 occurrence time으로 stable sort한다. output join/missing/status aggregate는 기존 tool entry 기반으로 유지한다.</td></tr>
+    <tr><td>4</td><td class="fileref">primitives-interleave.test.ts</td><td><code>think A → tool X → think B → tool Y</code> 순서와 timestamp 없는 legacy fallback을 순수 함수 수준에서 고정한다.</td></tr>
   </tbody>
 </table>
 
 <h2>8. 테스트 계획</h2>
 <ul>
   <li><b>인터리빙 보존</b>: <code>[think A, tool X, think B, tool Y]</code> 스트림 → 렌더 DOM 순서가 정확히 A·X·B·Y인지 단언.</li>
-  <li><b>status/dur 후속 패치</b>: <code>TOOL_CALL_END</code> 후 해당 tool 스텝의 status(ok/err)·dur 갱신 확인.</li>
+  <li><b>output join 보존</b>: interleave 후에도 tool output/missing/status가 기존 <code>ToolCallEntry</code> 기반으로 유지되는지 확인.</li>
   <li><b>회귀</b>: 기존 think-only 턴, tool-only 턴, flat(<code>groupToolCalls=false</code>) 경로가 그대로 동작.</li>
   <li><b>#21892 연동</b>: settled 턴의 미join tool 스텝이 통합 배열에서도 <code>missing</code>으로 표시되는지.</li>
 </ul>
@@ -215,15 +220,15 @@ flowchart TD
 <div class="callout warn">
   <h4>충돌 · 좌표</h4>
   <ul>
-    <li><b>#21748 동일 영역</b>: "assistant thinking-trace mis-attribution across identical-text turns"가 <code>keeper-state.ts</code>/<code>keeper-stream.ts</code>의 같은 traceStep 경로를 다룬다. <b>본 설계는 #21748에 합류</b>해 단일 SSOT로 진행 권장(중복 PR 회피).</li>
+    <li><b>#21913 구현 SSOT</b>: 현행 구현은 #21913이다. #21748("assistant thinking-trace mis-attribution across identical-text turns")은 같은 <code>keeper-state.ts</code>/<code>keeper-stream.ts</code> traceStep 경로를 다루므로, 후속 변경은 #21913 위에서 rebase/통합해야 한다.</li>
     <li><b>이중 자료구조</b>: tool을 step으로 옮기면, tool을 sibling entry로 읽던 다른 소비자(툴 실행 추적 패널, 그룹핑)와의 동기화/이중화를 정리해야 한다 — 잘못하면 한쪽만 갱신되는 silent drift.</li>
-    <li><b>thinking 세그먼트 timestamp 부재</b>: 옵션 A/D의 정렬·배지 정확도 한계. 옵션 C는 발생순 append라 이 문제를 우회.</li>
+    <li><b>backend-normalized thinking timestamp 부재</b>: timestamp가 없는 기존/history step은 legacy two-section fallback으로 남는다. 완전한 과거 재구성은 별도 backend timestamp surface가 필요하다.</li>
     <li><b>스트림 재정렬 부작용</b>: hoist 제거가 자동 스크롤/스트리밍 표시(<code>streamState</code>)와 상호작용할 수 있어 라이브 회귀 테스트 필요.</li>
   </ul>
 </div>
 
 <hr />
-<p class="small">근거: 턴 상세 적대 감사(9-에이전트 워크플로) + 직접 spot-verify. 모든 file:line은 2026-06-21 기준 origin/main에서 확인. 표현력(타입/렌더러)은 존재, 빌더 미배선이 핵심. 본 문서는 코드 변경이 아닌 설계 검토용 Draft이며, 구현은 #21748 맥락에서 진행 권장.</p>
+<p class="small">근거: 턴 상세 적대 감사(9-에이전트 워크플로) + 직접 spot-verify. 모든 file:line은 2026-06-21 기준 origin/main에서 확인. 본 문서는 코드 변경이 아닌 설계 검토용 Draft이며, 현행 구현 좌표는 #21913이다.</p>
 
 </div>
 </body>

--- a/docs/keeper-turn-interleaving-design.html
+++ b/docs/keeper-turn-interleaving-design.html
@@ -68,7 +68,7 @@
 
 <div class="callout key">
   <h4>요약 (TL;DR)</h4>
-  <p>키퍼 턴 상세에서 모델이 <code>think → tool → think → tool</code> 순으로 작업해도 화면에는 <code>[생각 블록 전체][도구 블록 전체]</code> 두 덩어리로만 보여, <b>어느 생각 다음에 어떤 도구가 실행됐는지</b>를 운영자가 볼 수 없다. 원인은 (1) 라이브 스트림이 모든 tool entry를 assistant entry <i>앞으로</i> hoist하고, (2) <code>ToolTraceCard</code>가 thinking과 tool을 <i>두 섹션으로 분리</i> 렌더하기 때문이다. <b>핵심:</b> 타입(<code>ChatTraceToolStep</code>)과 렌더러(<code>ChatTraceStep</code> 컴포넌트)는 인터리빙 표현력을 일부 갖고 있지만, 순수 <code>kind:'tool'</code> migration은 tool output join/status taxonomy를 잃는다. 현행 권장안은 #21913의 <b>render-time occurrence merge</b> — think/reason step에 <code>ts</code>를 찍고 기존 tool entry timestamp와 정렬해 #21892 missing/output 집계를 보존하는 방식이다.</p>
+  <p>키퍼 턴 상세에서 모델이 <code>think → tool → think → tool</code> 순으로 작업해도 화면에는 <code>[생각 블록 전체][도구 블록 전체]</code> 두 덩어리로만 보여, <b>어느 생각 다음에 어떤 도구가 실행됐는지</b>를 운영자가 볼 수 없다. 원인은 (1) 라이브 스트림이 모든 tool entry를 assistant entry <i>앞으로</i> hoist하고, (2) <code>ToolTraceCard</code>가 thinking과 tool을 <i>두 섹션으로 분리</i> 렌더하기 때문이다. <b>핵심:</b> 타입(<code>ChatTraceToolStep</code>)과 렌더러(<code>ChatTraceStep</code> 컴포넌트)는 인터리빙 표현력을 일부 갖고 있지만, 순수 <code>kind:'tool'</code> migration은 tool output join/status taxonomy를 잃는다. 현행 권장안은 #21913의 <b>render-time occurrence merge</b> — 단일 turn-local <code>occurrenceSeq</code>를 think/reason step과 tool entry 양쪽에 찍고 그 순서로 정렬해 #21892 missing/output 집계를 보존하는 방식이다.</p>
 </div>
 
 <div class="callout warn">
@@ -135,7 +135,7 @@ flowchart TD
   <pre>// types/core.ts:825–826
 export type ChatTraceToolStep = { kind: 'tool'; name: string; status?: 'ok'|'err'; dur?: string; args?: unknown; result?: string }
 export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceToolStep</pre>
-  <p>그리고 <code>ChatTraceStep</code> 렌더 컴포넌트(primitives.ts)는 <code>kind:'tool'</code> 스텝을 이미 그릴 수 있다. <b>유일한 공백</b>은 entry 레벨 <code>traceSteps</code> 빌더(<code>appendAssistantThinkingDelta</code>)가 <code>kind:'think'</code>만 emit한다는 것. 즉 단일 순서 배열로 인터리빙을 표현할 길이 타입·렌더러엔 열려 있는데 stream 핸들러만 안 쓴다.</p>
+  <p>그리고 <code>ChatTraceStep</code> 렌더 컴포넌트(primitives.ts)는 <code>kind:'tool'</code> 스텝을 이미 그릴 수 있다. 다만 이 타입은 tool output join/status SSOT가 아니므로 순수 migration 대상은 아니다. 핵심은 <b>렌더러 표현력은 일부 이미 있지만, 현재 data path는 occurrence ordering key를 공유하지 않는다</b>는 점이다.</p>
 </div>
 
 <h2>4. To-Be — 제안 설계</h2>
@@ -143,13 +143,13 @@ export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTrace
 flowchart TD
   subgraph S2["라이브 스트림 (수정)"]
     direction TB
-    TH2["THINKING_DELTA"] -->|"append kind:'think'"| U["통합 traceSteps<br/>kind:'think' | 'tool' 시간순 인터리브"]
-    TC2["TOOL_CALL_START / _END"] -->|"append kind:'tool' (+status/dur 후속 패치)"| U
+    TH2["THINKING_DELTA"] -->|"stamp traceStep.occurrenceSeq"| U["렌더 합성 view<br/>traceSteps + tool entries 발생순 인터리브"]
+    TC2["TOOL_CALL_START / _END"] -->|"stamp toolEntry.occurrenceSeq<br/>keep output/status entry SSOT"| U
   end
   U --> C2["ToolTraceCard<br/>traceSteps 단일 순회 렌더"]
   C2 --> O2["화면: 생각 → 도구 → 생각 → 도구<br/><b>실제 순서 보존</b>"]
 </div>
-<p>도구 호출을 sibling entry로 따로 두지 않고, 발생 시점에 assistant의 <b>같은 <code>traceSteps</code> 배열</b>에 <code>kind:'tool'</code> 스텝으로 append한다. 렌더러는 이미 그 순서대로 그릴 수 있으므로 카드 변경이 최소화된다.</p>
+<p>도구 호출은 output join/status/missing 집계의 SSOT인 sibling entry로 유지한다. 대신 live stream 발생 시점에 thinking step과 tool entry 양쪽에 같은 turn-local <code>occurrenceSeq</code>를 stamp하고, <code>ToolTraceCard</code>가 렌더 직전에 두 입력을 sequence로 합성한다. 이 방식은 tool entry 기반 집계를 보존하면서 화면 순서만 실제 발생순으로 복원한다.</p>
 
 <h2>5. 설계 옵션 비교</h2>
 <table>
@@ -157,10 +157,10 @@ flowchart TD
   <tbody>
     <tr>
       <td><b class="rec">A. 카드 occurrence merge (#21913)</b></td>
-      <td><code>ToolTraceCard</code>에서 <code>traceSteps</code>+<code>tools</code>를 timestamp로 정렬해 단일 <code>.map</code>. think/reason step에는 <code>ts</code>를 추가한다.</td>
+      <td><code>ToolTraceCard</code>에서 <code>traceSteps</code>+<code>tools</code>를 turn-local <code>occurrenceSeq</code>로 정렬해 단일 <code>.map</code>. think/reason step과 tool entry는 같은 카운터에서 발급된 sequence를 가진다.</td>
       <td>렌더만 (primitives.ts)</td>
       <td>낮음~중간</td>
-      <td><span class="rec">채택</span> — 기존 tool entry를 유지해 output join, missing 집계, status taxonomy를 보존한다. 단, think/reason에 occurrence timestamp를 stamp해야 하며 timestamp 없는 backend-normalized step은 legacy two-section fallback으로 둔다.</td>
+      <td><span class="rec">채택</span> — 기존 tool entry를 유지해 output join, missing 집계, status taxonomy를 보존한다. 단, wall-clock timestamp가 아니라 스트림 발생 순서를 나타내는 단조 증가 sequence를 stamp해야 하며 sequence 없는 backend-normalized step은 legacy two-section fallback으로 둔다.</td>
     </tr>
     <tr>
       <td><b>B. thinkAnchor 기록</b></td>
@@ -191,7 +191,7 @@ flowchart TD
   <h4>옵션 A — #21913 render-time occurrence merge</h4>
   <ol>
     <li><b>기존 tool entry를 보존</b>: <code>lookupToolCallOutput(entry.id)</code>, semantic status, missing aggregation이 그대로 유지된다.</li>
-    <li><b>순서 복원에 필요한 최소 데이터만 추가</b>: live think/reason step에 <code>ts</code>를 stamp하고, tool entry의 기존 <code>timestamp</code>와 stable sort한다.</li>
+    <li><b>순서 복원에 필요한 최소 데이터만 추가</b>: live turn마다 단일 <code>occurrenceSeq</code> 카운터를 두고, think/reason 세그먼트 시작과 tool <code>CALL_START</code>에서 같은 카운터를 증가시킨 뒤 그 값으로 정렬한다.</li>
     <li><b>카드 렌더만 단일 순회로 단순화</b>: <code>ToolTraceCard</code>의 thinking/tools 2-섹션 분기를 occurrence-ordered 단일 리스트로 바꾼다.</li>
   </ol>
   <p class="small">옵션 C는 구조적으로 깔끔해 보이지만 현재 타입으로는 output join/status 손실이 크다. 장기적으로 tool step을 SSOT로 삼으려면 <code>ToolCallEntry</code>급 식별자와 상태 모델을 먼저 통합해야 한다.</p>
@@ -201,16 +201,17 @@ flowchart TD
 <table>
   <thead><tr><th>단계</th><th>파일</th><th>변경</th></tr></thead>
   <tbody>
-    <tr><td>1</td><td class="fileref">types/core.ts</td><td><code>ChatTraceThinkStep</code>/<code>ChatTraceReasonStep</code>에 optional <code>ts</code> 추가. <code>ChatTraceToolStep</code>는 output join SSOT가 아니므로 순수 migration 대상으로 쓰지 않는다.</td></tr>
-    <tr><td>2</td><td class="fileref">keeper-state.ts</td><td>live thinking step 생성 시 <code>new Date().toISOString()</code>로 occurrence timestamp를 stamp하고, consecutive delta merge에서는 최초 timestamp를 보존. backend-normalized step의 <code>ts</code>도 통과시킨다.</td></tr>
-    <tr><td>3</td><td class="fileref">primitives.ts (ToolTraceCard)</td><td><code>interleaveTraceAndTools</code>를 추가해 trace step과 tool entry를 occurrence time으로 stable sort한다. output join/missing/status aggregate는 기존 tool entry 기반으로 유지한다.</td></tr>
-    <tr><td>4</td><td class="fileref">primitives-interleave.test.ts</td><td><code>think A → tool X → think B → tool Y</code> 순서와 timestamp 없는 legacy fallback을 순수 함수 수준에서 고정한다.</td></tr>
+    <tr><td>1</td><td class="fileref">types/core.ts</td><td><code>ChatTraceThinkStep</code>/<code>ChatTraceReasonStep</code>에 optional <code>occurrenceSeq</code> 추가. <code>ChatTraceToolStep</code>는 output join SSOT가 아니므로 순수 migration 대상으로 쓰지 않는다.</td></tr>
+    <tr><td>2</td><td class="fileref">keeper-state.ts / keeper-stream.ts</td><td>live turn 안에 단일 occurrence counter를 두고, think/reason 세그먼트 시작과 <code>TOOL_CALL_START</code>에서 같은 counter를 증가시켜 각각 trace step과 tool entry에 stamp한다. consecutive delta merge에서는 최초 <code>occurrenceSeq</code>를 보존한다.</td></tr>
+    <tr><td>3</td><td class="fileref">primitives.ts (ToolTraceCard)</td><td><code>interleaveTraceAndTools</code>를 추가해 trace step과 tool entry를 <code>occurrenceSeq</code>로 sort한다. output join/missing/status aggregate는 기존 tool entry 기반으로 유지한다.</td></tr>
+    <tr><td>4</td><td class="fileref">primitives-interleave.test.ts</td><td><code>think A → tool X → think B → tool Y</code> 순서, same-millisecond timestamp tie, sequence 없는 legacy fallback을 순수 함수 수준에서 고정한다.</td></tr>
   </tbody>
 </table>
 
 <h2>8. 테스트 계획</h2>
 <ul>
   <li><b>인터리빙 보존</b>: <code>[think A, tool X, think B, tool Y]</code> 스트림 → 렌더 DOM 순서가 정확히 A·X·B·Y인지 단언.</li>
+  <li><b>timestamp tie 회귀</b>: think step과 tool entry의 wall-clock timestamp가 같은 경우에도 <code>occurrenceSeq</code>가 A·X·B·Y 순서를 결정하는지 단언.</li>
   <li><b>output join 보존</b>: interleave 후에도 tool output/missing/status가 기존 <code>ToolCallEntry</code> 기반으로 유지되는지 확인.</li>
   <li><b>회귀</b>: 기존 think-only 턴, tool-only 턴, flat(<code>groupToolCalls=false</code>) 경로가 그대로 동작.</li>
   <li><b>#21892 연동</b>: settled 턴의 미join tool 스텝이 통합 배열에서도 <code>missing</code>으로 표시되는지.</li>
@@ -221,8 +222,9 @@ flowchart TD
   <h4>충돌 · 좌표</h4>
   <ul>
     <li><b>#21913 구현 SSOT</b>: 현행 구현은 #21913이다. #21748("assistant thinking-trace mis-attribution across identical-text turns")은 같은 <code>keeper-state.ts</code>/<code>keeper-stream.ts</code> traceStep 경로를 다루므로, 후속 변경은 #21913 위에서 rebase/통합해야 한다.</li>
-    <li><b>이중 자료구조</b>: tool을 step으로 옮기면, tool을 sibling entry로 읽던 다른 소비자(툴 실행 추적 패널, 그룹핑)와의 동기화/이중화를 정리해야 한다 — 잘못하면 한쪽만 갱신되는 silent drift.</li>
-    <li><b>backend-normalized thinking timestamp 부재</b>: timestamp가 없는 기존/history step은 legacy two-section fallback으로 남는다. 완전한 과거 재구성은 별도 backend timestamp surface가 필요하다.</li>
+    <li><b>순수 옵션 C의 이중 자료구조</b>: tool을 step으로 옮기면, tool을 sibling entry로 읽던 다른 소비자(툴 실행 추적 패널, 그룹핑)와의 동기화/이중화를 정리해야 한다 — 잘못하면 한쪽만 갱신되는 silent drift.</li>
+    <li><b>sequence 없는 legacy/history step</b>: <code>occurrenceSeq</code>가 없는 기존/backend-normalized step은 legacy two-section fallback으로 남는다. 완전한 과거 재구성은 별도 backend sequence surface가 필요하다.</li>
+    <li><b>sequence SSOT drift</b>: think/reason과 tool이 서로 다른 카운터나 서로 다른 clock을 쓰면 tie/clock-skew 문제가 재발한다. 카운터는 turn/entry 단위의 단일 ordered source여야 한다.</li>
     <li><b>스트림 재정렬 부작용</b>: hoist 제거가 자동 스크롤/스트리밍 표시(<code>streamState</code>)와 상호작용할 수 있어 라이브 회귀 테스트 필요.</li>
   </ul>
 </div>

--- a/docs/keeper-turn-interleaving-design.html
+++ b/docs/keeper-turn-interleaving-design.html
@@ -68,12 +68,12 @@
 
 <div class="callout key">
   <h4>요약 (TL;DR)</h4>
-  <p>키퍼 턴 상세에서 모델이 <code>think → tool → think → tool</code> 순으로 작업해도 화면에는 <code>[생각 블록 전체][도구 블록 전체]</code> 두 덩어리로만 보여, <b>어느 생각 다음에 어떤 도구가 실행됐는지</b>를 운영자가 볼 수 없다. 원인은 (1) 라이브 스트림이 모든 tool entry를 assistant entry <i>앞으로</i> hoist하고, (2) <code>ToolTraceCard</code>가 thinking과 tool을 <i>두 섹션으로 분리</i> 렌더하기 때문이다. <b>핵심:</b> 타입(<code>ChatTraceToolStep</code>)과 렌더러(<code>ChatTraceStep</code> 컴포넌트)는 인터리빙 표현력을 일부 갖고 있지만, 순수 <code>kind:'tool'</code> migration은 tool output join/status taxonomy를 잃는다. 현행 권장안은 #21913의 <b>render-time occurrence merge</b> — 단일 turn-local <code>occurrenceSeq</code>를 think/reason step과 tool entry 양쪽에 찍고 그 순서로 정렬해 #21892 missing/output 집계를 보존하는 방식이다.</p>
+  <p>키퍼 턴 상세에서 모델이 <code>think → tool → think → tool</code> 순으로 작업해도 화면에는 <code>[생각 블록 전체][도구 블록 전체]</code> 두 덩어리로만 보여, <b>어느 생각 다음에 어떤 도구가 실행됐는지</b>를 운영자가 볼 수 없다. 원인은 (1) 라이브 스트림이 모든 tool entry를 assistant entry <i>앞으로</i> hoist하고, (2) <code>ToolTraceCard</code>가 thinking과 tool을 <i>두 섹션으로 분리</i> 렌더하기 때문이다. <b>핵심:</b> 타입(<code>ChatTraceToolStep</code>)과 렌더러(<code>ChatTraceStep</code> 컴포넌트)는 인터리빙 표현력을 일부 갖고 있지만, 순수 <code>kind:'tool'</code> migration은 tool output join/status taxonomy를 잃는다. 현행 구현 #21913은 <b>render-time timestamp merge</b> — think/reason step의 <code>ts</code>와 tool entry의 <code>timestamp</code>를 정렬 키로 써 #21892 missing/output 집계를 보존한다. 후속 hardening 권장안은 같은 구조를 유지하되 wall-clock 대신 turn-local <code>occurrenceSeq</code>를 도입해 same-ms/tie 리스크를 제거하는 것이다.</p>
 </div>
 
 <div class="callout warn">
   <h4>2026-06-21 결정 보정</h4>
-  <p>초기 설계는 옵션 C(도구를 <code>traceSteps</code> 안으로 이동)를 권장했지만, #21913 구현 리뷰에서 순수 옵션 C는 거부됐다. 이유는 <code>ChatTraceToolStep</code>에 <code>tool_use_id</code>가 없어 output store join을 끊고, status를 <code>ok|err</code>로 축소하며, #21892의 missing/aggregate 계산을 깨기 때문이다. 이 문서는 #21913의 render-time merge 결정을 SSOT로 따른다.</p>
+  <p>초기 설계는 옵션 C(도구를 <code>traceSteps</code> 안으로 이동)를 권장했지만, #21913 구현 리뷰에서 순수 옵션 C는 거부됐다. 이유는 <code>ChatTraceToolStep</code>에 <code>tool_use_id</code>가 없어 output store join을 끊고, status를 <code>ok|err</code>로 축소하며, #21892의 missing/aggregate 계산을 깨기 때문이다. 이 문서는 #21913의 render-time merge 결정을 SSOT로 따르되, #21913의 실제 정렬 키는 <code>ts</code>/<code>timestamp</code>이고 <code>occurrenceSeq</code>는 아직 구현되지 않은 후속 보강 항목으로 구분한다.</p>
 </div>
 
 <h2>1. 문제 정의 (concern #5)</h2>
@@ -86,8 +86,8 @@
 </ul>
 <p>이 정보는 키퍼가 "생각만 맴돌다 멈추는"(thinking-only/no-progress) 패턴을 운영자가 진단할 때 직접적 단서가 된다. concern #3(thinking 루프)과 같은 뿌리의 관측성 문제다.</p>
 
-<h2>2. As-Is — 현재 동작</h2>
-<p>대상 표면은 <code>groupToolCalls=true</code> 경로(<span class="fileref">keeper-shared.ts</span>)이며 <code>buildChatRenderUnits</code> → <code>TurnWorkBundle</code> → <code>ToolTraceCard</code>로 렌더된다.</p>
+<h2>2. As-Is — #21913 이전 문제 경로</h2>
+<p>대상 표면은 <code>groupToolCalls=true</code> 경로(<span class="fileref">keeper-shared.ts</span>)이며 <code>buildChatRenderUnits</code> → <code>TurnWorkBundle</code> → <code>ToolTraceCard</code>로 렌더된다. 아래 흐름도는 #21913 이전의 문제 구조를 설명한다. 현재 <code>origin/main</code>은 #21913으로 <code>interleaveTraceAndTools</code>가 들어와 2-섹션 렌더 자체는 해소됐고, 잔여 리스크는 timestamp 정렬 키다.</p>
 
 <h3>2.1 데이터 흐름</h3>
 <div class="mermaid">
@@ -99,7 +99,7 @@ flowchart TD
   end
   TS --> CARD
   TE --> CARD
-  subgraph CARD["ToolTraceCard 렌더 (primitives.ts)"]
+  subgraph CARD["ToolTraceCard 렌더 (pre-#21913 primitives.ts)"]
     direction TB
     A["1) traceSteps.map → 생각 블록 전체"]
     B["2) tools.map → 도구 블록 전체"]
@@ -113,18 +113,18 @@ flowchart TD
   <thead><tr><th>지점</th><th>코드</th><th>동작</th></tr></thead>
   <tbody>
     <tr><td>tool entry hoist</td><td class="fileref">keeper-stream.ts:76–88</td><td><code>TOOL_CALL_START</code> → <code>insertThreadEntryBefore(keeperName, assistantEntryId, …)</code> — 모든 도구 entry를 단일 assistant entry <b>앞</b>에 삽입. tool entry는 <code>timestamp: new Date().toISOString()</code>(:88) 보유.</td></tr>
-    <tr><td>thinking 누적</td><td class="fileref">keeper-state.ts:841–858</td><td><code>appendAssistantThinkingDelta()</code>가 <code>traceSteps</code>에 <b><code>kind:'think'</code>만</b> append(:850, :854). tool 스텝은 절대 안 들어감.</td></tr>
-    <tr><td>그룹핑</td><td class="fileref">primitives.ts:2259 · 2289</td><td><code>buildChatRenderUnits</code>가 <code>canAppendToolToRun</code> 기준(turnRef/인접)으로 연속 tool entry를 한 <code>toolGroup</code>으로 fold. tool run + 직후 assistant → 단일 <code>turnBundle</code>.</td></tr>
-    <tr><td>2-섹션 렌더</td><td class="fileref">primitives.ts (ToolTraceCard)</td><td><code>traceSteps.map(…)</code> <b>다음</b> <code>tools.map(…)</code> — 생각 전체를 먼저, 도구 전체를 나중에. 헤더 단계 수는 <code>traceSteps.length + tools.length</code>로 함께 세지만 렌더는 비-인터리브 2블록.</td></tr>
+    <tr><td>thinking 누적</td><td class="fileref">keeper-state.ts:841–858</td><td><code>appendAssistantThinkingDelta()</code>가 <code>traceSteps</code>에 <b><code>kind:'think'</code>만</b> append하고 새 step에 <code>ts</code>를 부여한다. tool 스텝은 여전히 traceSteps로 옮기지 않는다.</td></tr>
+    <tr><td>그룹핑</td><td class="fileref">primitives.ts:2374–2404</td><td><code>buildChatRenderUnits</code>가 <code>canAppendToolToRun</code> 기준(turnRef/인접)으로 연속 tool entry를 한 <code>toolGroup</code>으로 fold. tool run + 직후 assistant → 단일 <code>turnBundle</code>.</td></tr>
+    <tr><td>현재 interleave 구현</td><td class="fileref">primitives.ts:2178–2236</td><td>#21913 이후 <code>interleaveTraceAndTools</code>가 trace step과 tool entry를 단일 ordered list로 합성한다. 정렬 키는 trace <code>ts</code>와 tool <code>timestamp</code>이며, 같은 값이면 stable fallback으로 legacy trace-then-tool 순서를 보존한다.</td></tr>
   </tbody>
 </table>
 
 <h3>2.3 정보 손실 지점</h3>
 <div class="callout root">
-  <h4>순서 정보는 <i>존재</i>하지만 두 곳에서 폐기된다</h4>
+  <h4>원래 순서 정보는 <i>존재</i>했지만 두 곳에서 폐기됐다</h4>
   <ul>
-    <li><b>(a) 스트림 hoist</b> — <span class="fileref">keeper-stream.ts:81</span>: tool entry를 assistant 앞으로 삽입하는 순간, 그 도구가 "어느 thinking 세그먼트 다음"이었는지가 사라진다. tool의 <code>timestamp</code>는 남지만 thinking 델타에는 세그먼트별 timestamp가 없다.</li>
-    <li><b>(b) 2-섹션 렌더</b> — <code>ToolTraceCard</code>가 <code>traceSteps</code>(생각)와 <code>tools</code>(도구)를 별도 입력으로 받아 순서대로 합치지 않고 두 섹션으로 그린다.</li>
+    <li><b>(a) 스트림 hoist</b> — <span class="fileref">keeper-stream.ts:81</span>: tool entry를 assistant 앞으로 삽입하는 순간, 그 도구가 "어느 thinking 세그먼트 다음"이었는지가 사라진다. #21913 이전에는 tool의 <code>timestamp</code>만 남고 thinking 델타에는 세그먼트별 timestamp가 없었다.</li>
+    <li><b>(b) 2-섹션 렌더</b> — #21913 이전 <code>ToolTraceCard</code>는 <code>traceSteps</code>(생각)와 <code>tools</code>(도구)를 별도 입력으로 받아 순서대로 합치지 않고 두 섹션으로 그렸다. #21913 이후 이 문제는 timestamp merge로 완화됐다.</li>
   </ul>
 </div>
 
@@ -135,10 +135,10 @@ flowchart TD
   <pre>// types/core.ts:825–826
 export type ChatTraceToolStep = { kind: 'tool'; name: string; status?: 'ok'|'err'; dur?: string; args?: unknown; result?: string }
 export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceToolStep</pre>
-  <p>그리고 <code>ChatTraceStep</code> 렌더 컴포넌트(primitives.ts)는 <code>kind:'tool'</code> 스텝을 이미 그릴 수 있다. 다만 이 타입은 tool output join/status SSOT가 아니므로 순수 migration 대상은 아니다. 핵심은 <b>렌더러 표현력은 일부 이미 있지만, 현재 data path는 occurrence ordering key를 공유하지 않는다</b>는 점이다.</p>
+  <p>그리고 <code>ChatTraceStep</code> 렌더 컴포넌트(primitives.ts)는 <code>kind:'tool'</code> 스텝을 이미 그릴 수 있다. 다만 이 타입은 tool output join/status SSOT가 아니므로 순수 migration 대상은 아니다. 핵심은 <b>렌더러 표현력은 일부 이미 있지만, 현재 data path는 monotonic occurrence ordering key를 공유하지 않는다</b>는 점이다. #21913은 <code>ts</code>/<code>timestamp</code>로 이 간극을 좁혔지만, wall-clock tie를 완전히 제거하지는 않는다.</p>
 </div>
 
-<h2>4. To-Be — 제안 설계</h2>
+<h2>4. To-Be — 후속 hardening 설계</h2>
 <div class="mermaid">
 flowchart TD
   subgraph S2["라이브 스트림 (수정)"]
@@ -149,18 +149,25 @@ flowchart TD
   U --> C2["ToolTraceCard<br/>traceSteps 단일 순회 렌더"]
   C2 --> O2["화면: 생각 → 도구 → 생각 → 도구<br/><b>실제 순서 보존</b>"]
 </div>
-<p>도구 호출은 output join/status/missing 집계의 SSOT인 sibling entry로 유지한다. 대신 live stream 발생 시점에 thinking step과 tool entry 양쪽에 같은 turn-local <code>occurrenceSeq</code>를 stamp하고, <code>ToolTraceCard</code>가 렌더 직전에 두 입력을 sequence로 합성한다. 이 방식은 tool entry 기반 집계를 보존하면서 화면 순서만 실제 발생순으로 복원한다.</p>
+<p>#21913은 이미 도구 호출을 output join/status/missing 집계의 SSOT인 sibling entry로 유지하고, <code>ToolTraceCard</code>에서 trace step과 tool entry를 렌더 직전에 합성한다. 후속 hardening은 정렬 키만 wall-clock <code>ts</code>/<code>timestamp</code>에서 turn-local <code>occurrenceSeq</code>로 바꾸거나 보강한다. 이 방식은 tool entry 기반 집계를 보존하면서 same-ms/tie에도 화면 순서를 실제 발생순으로 고정한다.</p>
 
 <h2>5. 설계 옵션 비교</h2>
 <table>
   <thead><tr><th>옵션</th><th>메커니즘</th><th>변경 레이어</th><th>침습도</th><th>트레이드오프</th></tr></thead>
   <tbody>
     <tr>
-      <td><b class="rec">A. 카드 occurrence merge (#21913)</b></td>
-      <td><code>ToolTraceCard</code>에서 <code>traceSteps</code>+<code>tools</code>를 turn-local <code>occurrenceSeq</code>로 정렬해 단일 <code>.map</code>. think/reason step과 tool entry는 같은 카운터에서 발급된 sequence를 가진다.</td>
+      <td><b class="rec">A. 카드 timestamp merge (#21913 현재)</b></td>
+      <td><code>ToolTraceCard</code>에서 <code>traceSteps</code>+<code>tools</code>를 <code>ts</code>/<code>timestamp</code>로 정렬해 단일 <code>.map</code>. think/reason step은 optional <code>ts</code>, tool entry는 기존 <code>timestamp</code>를 사용한다.</td>
       <td>렌더만 (primitives.ts)</td>
       <td>낮음~중간</td>
-      <td><span class="rec">채택</span> — 기존 tool entry를 유지해 output join, missing 집계, status taxonomy를 보존한다. 단, wall-clock timestamp가 아니라 스트림 발생 순서를 나타내는 단조 증가 sequence를 stamp해야 하며 sequence 없는 backend-normalized step은 legacy two-section fallback으로 둔다.</td>
+      <td><span class="rec">채택/구현됨</span> — 기존 tool entry를 유지해 output join, missing 집계, status taxonomy를 보존한다. 단, wall-clock timestamp tie/clock skew에는 취약할 수 있어 후속 <code>occurrenceSeq</code> 보강이 필요하다.</td>
+    </tr>
+    <tr>
+      <td><b>A2. occurrenceSeq hardening</b></td>
+      <td>live turn마다 단일 counter를 두고 think/reason step과 tool entry에 같은 counter에서 발급한 <code>occurrenceSeq</code>를 stamp한다. 정렬은 <code>occurrenceSeq</code> 우선, legacy는 기존 timestamp fallback.</td>
+      <td>stream + state + 렌더</td>
+      <td>중간</td>
+      <td><span class="rec">권장 후속</span> — #21913의 entry-SSOT 보존 장점을 유지하면서 same-ms tie를 제거한다. 단일 counter가 turn-local SSOT여야 하며, 서로 다른 clock/counter를 섞으면 회귀한다.</td>
     </tr>
     <tr>
       <td><b>B. thinkAnchor 기록</b></td>
@@ -181,37 +188,39 @@ flowchart TD
       <td>각 스텝에 상대 시각/순번 배지 표시 (A~C와 병행 가능)</td>
       <td>렌더만</td>
       <td>낮음</td>
-      <td>보조책. 순서를 <i>복원</i>하진 않지만 운영자가 순번을 추론하게 함. thinking 델타 timestamp 부재가 한계.</td>
+      <td>보조책. 순서를 <i>복원</i>하진 않지만 운영자가 순번을 추론하게 함. #21913 이전에는 thinking 델타 timestamp 부재가 한계였고, #21913 이후에도 wall-clock tie 리스크는 남는다.</td>
     </tr>
   </tbody>
 </table>
 
 <h2>6. 현행 권장안 + 근거</h2>
 <div class="callout ok">
-  <h4>옵션 A — #21913 render-time occurrence merge</h4>
+  <h4>옵션 A — #21913 render-time timestamp merge + A2 sequence hardening</h4>
   <ol>
     <li><b>기존 tool entry를 보존</b>: <code>lookupToolCallOutput(entry.id)</code>, semantic status, missing aggregation이 그대로 유지된다.</li>
-    <li><b>순서 복원에 필요한 최소 데이터만 추가</b>: live turn마다 단일 <code>occurrenceSeq</code> 카운터를 두고, think/reason 세그먼트 시작과 tool <code>CALL_START</code>에서 같은 카운터를 증가시킨 뒤 그 값으로 정렬한다.</li>
+    <li><b>#21913 구현 상태</b>: think/reason step에 optional <code>ts</code>를 추가하고, tool entry의 기존 <code>timestamp</code>와 함께 <code>interleaveTraceAndTools</code>에서 정렬한다.</li>
+    <li><b>후속 보강</b>: live turn마다 단일 <code>occurrenceSeq</code> 카운터를 두고, think/reason 세그먼트 시작과 tool <code>CALL_START</code>에서 같은 카운터를 증가시킨 뒤 그 값으로 정렬한다.</li>
     <li><b>카드 렌더만 단일 순회로 단순화</b>: <code>ToolTraceCard</code>의 thinking/tools 2-섹션 분기를 occurrence-ordered 단일 리스트로 바꾼다.</li>
   </ol>
   <p class="small">옵션 C는 구조적으로 깔끔해 보이지만 현재 타입으로는 output join/status 손실이 크다. 장기적으로 tool step을 SSOT로 삼으려면 <code>ToolCallEntry</code>급 식별자와 상태 모델을 먼저 통합해야 한다.</p>
 </div>
 
-<h2>7. 구현 계획 (#21913 기준)</h2>
+<h2>7. 구현 상태와 후속 계획</h2>
 <table>
   <thead><tr><th>단계</th><th>파일</th><th>변경</th></tr></thead>
   <tbody>
-    <tr><td>1</td><td class="fileref">types/core.ts</td><td><code>ChatTraceThinkStep</code>/<code>ChatTraceReasonStep</code>에 optional <code>occurrenceSeq</code> 추가. <code>ChatTraceToolStep</code>는 output join SSOT가 아니므로 순수 migration 대상으로 쓰지 않는다.</td></tr>
-    <tr><td>2</td><td class="fileref">keeper-state.ts / keeper-stream.ts</td><td>live turn 안에 단일 occurrence counter를 두고, think/reason 세그먼트 시작과 <code>TOOL_CALL_START</code>에서 같은 counter를 증가시켜 각각 trace step과 tool entry에 stamp한다. consecutive delta merge에서는 최초 <code>occurrenceSeq</code>를 보존한다.</td></tr>
-    <tr><td>3</td><td class="fileref">primitives.ts (ToolTraceCard)</td><td><code>interleaveTraceAndTools</code>를 추가해 trace step과 tool entry를 <code>occurrenceSeq</code>로 sort한다. output join/missing/status aggregate는 기존 tool entry 기반으로 유지한다.</td></tr>
-    <tr><td>4</td><td class="fileref">primitives-interleave.test.ts</td><td><code>think A → tool X → think B → tool Y</code> 순서, same-millisecond timestamp tie, sequence 없는 legacy fallback을 순수 함수 수준에서 고정한다.</td></tr>
+    <tr><td>1 (#21913)</td><td class="fileref">types/core.ts</td><td><code>ChatTraceThinkStep</code>/<code>ChatTraceReasonStep</code>에 optional <code>ts</code> 추가. <code>ChatTraceToolStep</code>는 output join SSOT가 아니므로 순수 migration 대상으로 쓰지 않는다.</td></tr>
+    <tr><td>2 (#21913)</td><td class="fileref">keeper-state.ts</td><td><code>appendAssistantThinkingDelta</code>가 새 think step에 <code>ts</code>를 부여하고, consecutive delta merge에서는 최초 <code>ts</code>를 보존한다.</td></tr>
+    <tr><td>3 (#21913)</td><td class="fileref">primitives.ts (ToolTraceCard)</td><td><code>interleaveTraceAndTools</code>를 추가해 trace step <code>ts</code>와 tool entry <code>timestamp</code>로 sort한다. output join/missing/status aggregate는 기존 tool entry 기반으로 유지한다.</td></tr>
+    <tr><td>4 (후속)</td><td class="fileref">keeper-state.ts / keeper-stream.ts / primitives.ts</td><td>live turn 안에 단일 occurrence counter를 두고, think/reason 세그먼트 시작과 <code>TOOL_CALL_START</code>에서 같은 counter를 증가시켜 각각 trace step과 tool entry에 <code>occurrenceSeq</code>를 stamp한다. 정렬은 sequence 우선, legacy는 timestamp fallback.</td></tr>
+    <tr><td>5 (후속)</td><td class="fileref">primitives-interleave.test.ts</td><td><code>think A → tool X → think B → tool Y</code> 순서, same-millisecond timestamp tie에서 sequence 우선 정렬, sequence 없는 legacy fallback을 순수 함수 수준에서 고정한다.</td></tr>
   </tbody>
 </table>
 
 <h2>8. 테스트 계획</h2>
 <ul>
   <li><b>인터리빙 보존</b>: <code>[think A, tool X, think B, tool Y]</code> 스트림 → 렌더 DOM 순서가 정확히 A·X·B·Y인지 단언.</li>
-  <li><b>timestamp tie 회귀</b>: think step과 tool entry의 wall-clock timestamp가 같은 경우에도 <code>occurrenceSeq</code>가 A·X·B·Y 순서를 결정하는지 단언.</li>
+  <li><b>timestamp tie 회귀</b>: #21913 현재 구현은 <code>ts</code>/<code>timestamp</code> 정렬이므로 same-ms tie에 취약할 수 있다. 후속 보강에서는 think step과 tool entry의 wall-clock timestamp가 같은 경우에도 <code>occurrenceSeq</code>가 A·X·B·Y 순서를 결정하는지 단언한다.</li>
   <li><b>output join 보존</b>: interleave 후에도 tool output/missing/status가 기존 <code>ToolCallEntry</code> 기반으로 유지되는지 확인.</li>
   <li><b>회귀</b>: 기존 think-only 턴, tool-only 턴, flat(<code>groupToolCalls=false</code>) 경로가 그대로 동작.</li>
   <li><b>#21892 연동</b>: settled 턴의 미join tool 스텝이 통합 배열에서도 <code>missing</code>으로 표시되는지.</li>
@@ -221,16 +230,17 @@ flowchart TD
 <div class="callout warn">
   <h4>충돌 · 좌표</h4>
   <ul>
-    <li><b>#21913 구현 SSOT</b>: 현행 구현은 #21913이다. #21748("assistant thinking-trace mis-attribution across identical-text turns")은 같은 <code>keeper-state.ts</code>/<code>keeper-stream.ts</code> traceStep 경로를 다루므로, 후속 변경은 #21913 위에서 rebase/통합해야 한다.</li>
+    <li><b>#21913 구현 SSOT</b>: 현행 구현은 #21913이며 정렬 키는 <code>ts</code>/<code>timestamp</code>다. #21748("assistant thinking-trace mis-attribution across identical-text turns")은 같은 <code>keeper-state.ts</code>/<code>keeper-stream.ts</code> traceStep 경로를 다루므로, 후속 변경은 #21913 위에서 rebase/통합해야 한다.</li>
     <li><b>순수 옵션 C의 이중 자료구조</b>: tool을 step으로 옮기면, tool을 sibling entry로 읽던 다른 소비자(툴 실행 추적 패널, 그룹핑)와의 동기화/이중화를 정리해야 한다 — 잘못하면 한쪽만 갱신되는 silent drift.</li>
-    <li><b>sequence 없는 legacy/history step</b>: <code>occurrenceSeq</code>가 없는 기존/backend-normalized step은 legacy two-section fallback으로 남는다. 완전한 과거 재구성은 별도 backend sequence surface가 필요하다.</li>
+    <li><b>timestamp 기반 잔여 리스크</b>: <code>ts</code>/<code>timestamp</code>만으로는 same-ms tie나 clock skew를 구조적으로 배제하지 못한다. 이 문서의 <code>occurrenceSeq</code>는 이 잔여 리스크를 제거하기 위한 후속 hardening이다.</li>
+    <li><b>sequence 없는 legacy/history step</b>: <code>occurrenceSeq</code>가 없는 기존/backend-normalized step은 #21913의 timestamp fallback으로 남는다. 완전한 과거 재구성은 별도 backend sequence surface가 필요하다.</li>
     <li><b>sequence SSOT drift</b>: think/reason과 tool이 서로 다른 카운터나 서로 다른 clock을 쓰면 tie/clock-skew 문제가 재발한다. 카운터는 turn/entry 단위의 단일 ordered source여야 한다.</li>
     <li><b>스트림 재정렬 부작용</b>: hoist 제거가 자동 스크롤/스트리밍 표시(<code>streamState</code>)와 상호작용할 수 있어 라이브 회귀 테스트 필요.</li>
   </ul>
 </div>
 
 <hr />
-<p class="small">근거: 턴 상세 적대 감사(9-에이전트 워크플로) + 직접 spot-verify. 모든 file:line은 2026-06-21 기준 origin/main에서 확인. 본 문서는 코드 변경이 아닌 설계 검토용 Draft이며, 현행 구현 좌표는 #21913이다.</p>
+<p class="small">근거: 턴 상세 적대 감사(9-에이전트 워크플로) + 직접 spot-verify. 현재 구현 file:line은 2026-06-21 기준 origin/main에서 확인. #21913 이전 2-섹션 흐름도는 문제 원인 설명용이며, 현행 구현 좌표는 #21913이다.</p>
 
 </div>
 </body>


### PR DESCRIPTION
## 목적
턴 상세 적대 감사 **concern #5**(thinking↔tool 인터리빙 소실)의 **설계서**를 추가한다. **코드 변경 없음** — 설계 검토 + #21748 구현 좌표용.

## 배경
키퍼 턴 상세는 한 턴의 작업을 `[생각 블록 전체][도구 블록 전체]` 2덩어리로 렌더한다. 모델이 `think → tool → think → tool`로 작업해도 운영자는 **어느 추론 다음에 어떤 도구가 실행됐는지** 볼 수 없다. concern #3(thinking 루프)과 같은 뿌리의 관측성 문제.

## 설계서 내용 (`docs/keeper-turn-interleaving-design.html`)
- **As-Is / To-Be** Mermaid 다이어그램
- **순서 손실 2지점** (file:line 검증):
  - `keeper-stream.ts:76–88` — `TOOL_CALL_START`이 tool entry를 assistant entry **앞**으로 hoist
  - `ToolTraceCard` — `traceSteps`(생각) then `tools`(도구) 2섹션 렌더
- **핵심 통찰**: `ChatTraceToolStep`(types/core.ts:825) 타입 + 렌더러는 **이미 인터리빙 지원**, `appendAssistantThinkingDelta`(keeper-state.ts:841–858)가 `kind:'think'`만 emit하는 **미배선**이 공백
- **옵션 비교 4종**: A(sort-merge)=불충분 / B(thinkAnchor)=재구성 / **C(통합 traceSteps)=권장** / D(순번 배지)=보조
- 구현 계획 · 테스트 계획 · 리스크 (이중 자료구조 drift, 스트림 재정렬 부작용)

## 권장안
**옵션 C** — tool 발생 시 assistant의 `traceSteps`에 `kind:'tool'` 스텝을 순서대로 append. timestamp 정렬·anchor 계산 같은 휴리스틱(비결정론) 없이 발생순 append(결정론). 타입·렌더러가 이미 지원하므로 재구성이 아닌 배선.

## 좌표 / 주의
- 구현은 **#21748**(assistant thinking-trace mis-attribution, 같은 `keeper-stream`/`keeper-state` SSOT)에 합류 권장 — 경쟁 PR/이중 자료구조 drift 회피.
- 인접 진행: **#21900**(RFC-0233, turn inspector tool I/O surfacing) 방금 머지 — tool I/O 영역이 활발히 변화 중이라 구현 전 재확인 필요.
- 형식: `docs/reverse-engineering-design.html` 선례를 따른 standalone HTML(Mermaid CDN).

## 범위
설계서 1파일 추가만. 코드/동작 변경 없음. RFC 영향 없음(docs 한정).

근거: 9-에이전트 적대 워크플로 + 직접 spot-verify(2026-06-21 origin/main). 사이드: #21889·#21892(머지, 같은 턴 상세 표면 fix).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
