### PR TITLE
docs(runtime-tunables): regenerate env-knob catalog after #21898 (main green 복구)

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -16,9 +16,9 @@ the categorization roadmap. Newly-added typed getters in
 
 **Total**: 355 unique knobs across 9 modules.
 
-**Typed getter classification**: 21/204 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 183).
+**Typed getter classification**: 20/203 tagged (`operator`: 20, `algorithm`: 0, `unclassified`: 183).
 
-## Env_config_core (29 knobs; typed classification 1/8)
+## Env_config_core (29 knobs; typed classification 0/7)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -29,7 +29,7 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 230 |  |
 | `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 424 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
 | `MASC_DATA_DIR` | string_literal | n/a | n/a | 437 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
+| `MASC_DISABLE_HITL` | string_literal | n/a | n/a | 500 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
 | `MASC_GIT_FETCH_TIMEOUT_SEC` | string_literal | n/a | n/a | 467 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
 | `MASC_GOVERNANCE_LEVEL` | string_literal | n/a | n/a | 480 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |


### PR DESCRIPTION
## 목적

main을 green으로 복구한다. 현재 origin/main이 `docs/runtime-tunables.md` staleness 검사에서 red이며, 이로 인해 모든 OCaml PR의 CI Gate가 차단된다(예: fusion 백엔드 #21908).

## 배경

`#21898 fix(schedule): gate approvals through dashboard operator auth`이 `lib/config/env_config_*.ml`의 typed getter를 변경하면서 `docs/runtime-tunables.md`를 재생성하지 않고 머지되었다. CI의 env-knob 카탈로그 검사는 doc이 코드와 일치하는지 비교하므로, 불일치 상태에서 Build and Test가 `docs/runtime-tunables.md is stale relative to lib/config/env_config_*.ml`로 실패한다.

## 변경

`dune exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md`로 결정론적 재생성. 손으로 편집하지 않았다(CI가 같은 generator로 비교).

diff(3줄): typed getter 분류 21/204→20/203, Env_config_core 1/8→0/7, `MASC_DISABLE_HITL` 항목이 현재 코드 상태(string_literal)로 갱신.

## 검증

- generator exit 0 (`wrote docs/runtime-tunables.md (entries=355 files=10)`).
- 전체 빌드는 CI(Build and Test)에서 검증.

## 워크어라운드 시그니처 점검

해당 없음. 생성물(doc)을 코드와 재동기화하는 결정론적 재생성이며 symptom 억제가 아니다.
