### PR TITLE
fix(dashboard): harden frontend connection recovery

### DIFF
--- a/dashboard/src/api/dev-token.test.ts
+++ b/dashboard/src/api/dev-token.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  devTokenBootstrapStatus,
+  ensureDevToken,
+  resetDevTokenBootstrap,
+  type DevTokenBootstrapStatus,
+} from './dev-token'
+
+const {
+  clearStoredToken,
+  currentDashboardActor,
+  fetchWithTimeout,
+  getStoredToken,
+  getStoredTokenMeta,
+  isRemoteAccess,
+  setStoredToken,
+} = vi.hoisted(() => ({
+  clearStoredToken: vi.fn(),
+  currentDashboardActor: vi.fn(),
+  fetchWithTimeout: vi.fn(),
+  getStoredToken: vi.fn(),
+  getStoredTokenMeta: vi.fn(),
+  isRemoteAccess: vi.fn(),
+  setStoredToken: vi.fn(),
+}))
+
+vi.mock('./core', () => ({
+  clearStoredToken,
+  currentDashboardActor,
+  fetchWithTimeout,
+  getStoredToken,
+  getStoredTokenMeta,
+  isRemoteAccess,
+  setStoredToken,
+}))
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function setBootstrapStatus(value: DevTokenBootstrapStatus): void {
+  ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = value
+}
+
+describe('ensureDevToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetDevTokenBootstrap()
+    setBootstrapStatus('idle')
+    getStoredToken.mockReturnValue(null)
+    getStoredTokenMeta.mockReturnValue(null)
+    currentDashboardActor.mockReturnValue('dashboard')
+    isRemoteAccess.mockReturnValue(false)
+  })
+
+  it('retries after a transient network bootstrap failure in the same page load', async () => {
+    fetchWithTimeout
+      .mockRejectedValueOnce(new Error('server not ready'))
+      .mockResolvedValueOnce(jsonResponse({
+        token: 'fresh-dev-token',
+        actor: 'dashboard',
+        scope: 'admin',
+      }))
+
+    await ensureDevToken()
+    expect(devTokenBootstrapStatus.value).toBe('network')
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+    expect(setStoredToken).not.toHaveBeenCalled()
+
+    await ensureDevToken()
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(2)
+    expect(setStoredToken).toHaveBeenCalledWith('fresh-dev-token', {
+      source: 'dev',
+      actor: 'dashboard',
+      scope: 'admin',
+    })
+    expect(devTokenBootstrapStatus.value).toBe('ok')
+  })
+
+  it('keeps a successful bootstrap memoized for the page load', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(jsonResponse({
+      token: 'loopback-dev-token',
+      actor: 'dashboard',
+      scope: 'admin',
+    }))
+
+    await ensureDevToken()
+    await ensureDevToken()
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+    expect(setStoredToken).toHaveBeenCalledTimes(1)
+    expect(devTokenBootstrapStatus.value).toBe('ok')
+  })
+
+  it('does not keep retrying a disabled loopback dev-token endpoint', async () => {
+    fetchWithTimeout.mockResolvedValueOnce(new Response('not found', { status: 404 }))
+
+    await ensureDevToken()
+    await ensureDevToken()
+
+    expect(fetchWithTimeout).toHaveBeenCalledTimes(1)
+    expect(setStoredToken).not.toHaveBeenCalled()
+    expect(devTokenBootstrapStatus.value).toBe('no_endpoint')
+  })
+})

--- a/dashboard/src/api/dev-token.ts
+++ b/dashboard/src/api/dev-token.ts
@@ -38,6 +38,10 @@ interface DevTokenBootstrapPayload {
   scope?: unknown
 }
 
+function isRetryableDevTokenStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500
+}
+
 function shouldRefreshDevToken(): boolean {
   const token = getStoredToken()
   const meta = getStoredTokenMeta()
@@ -77,12 +81,16 @@ export async function ensureDevToken(): Promise<void> {
           clearStoredToken()
         }
         ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'no_endpoint'
+        if (isRetryableDevTokenStatus(res.status)) {
+          devTokenBootstrapPromise = null
+        }
         return
       }
       const payload = (await res.json()) as DevTokenBootstrapPayload
       const token = typeof payload.token === 'string' ? payload.token.trim() : ''
       if (!token) {
         ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'no_endpoint'
+        devTokenBootstrapPromise = null
         return
       }
       const actor = typeof payload.actor === 'string' ? payload.actor.trim() : 'dashboard'
@@ -105,6 +113,7 @@ export async function ensureDevToken(): Promise<void> {
       ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'ok'
     } catch {
       ;(devTokenBootstrapStatus as { value: DevTokenBootstrapStatus }).value = 'network'
+      devTokenBootstrapPromise = null
     }
   })()
   return devTokenBootstrapPromise

--- a/dashboard/src/components/ide/ide-lsp-client.test.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.test.ts
@@ -35,6 +35,10 @@ class MockWebSocket {
     this.onopen?.(new Event('open'))
   }
 
+  message(payload: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent)
+  }
+
   close(event: Partial<Pick<CloseEvent, 'code' | 'reason' | 'wasClean'>> = {}): void {
     if (this.readyState === MockWebSocket.CLOSED) return
     this.readyState = MockWebSocket.CLOSED
@@ -143,6 +147,29 @@ describe('LspConnection', () => {
     socket.close({ code: 1011, reason: 'server restart', wasClean: false })
 
     await expect(hover).resolves.toBeNull()
+    conn.dispose()
+  })
+
+  it('ignores stale socket events after reconnecting', async () => {
+    installWebSocketMock()
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    const oldSocket = mockSockets[0]!
+    oldSocket.open()
+
+    conn.connect()
+    const currentSocket = mockSockets[1]!
+    currentSocket.open()
+
+    const hover = conn.requestHover('lib/keeper/current.ml', 0, 0)
+    expect(currentSocket.sent).toHaveLength(2)
+
+    oldSocket.close({ code: 1006, wasClean: false })
+    oldSocket.message({ id: 3, result: { contents: 'stale' } })
+
+    currentSocket.message({ id: 3, result: { contents: 'current' } })
+
+    await expect(hover).resolves.toEqual({ contents: 'current' })
     conn.dispose()
   })
 

--- a/dashboard/src/components/ide/ide-lsp-client.test.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.test.ts
@@ -189,6 +189,32 @@ describe('LspConnection', () => {
     expect(mockSockets).toHaveLength(1)
   })
 
+  it('notifies readiness after initial connect and reconnect initialize', async () => {
+    vi.useFakeTimers()
+    installWebSocketMock()
+    const onReady = vi.fn()
+    const conn = new LspConnection(() => {}, () => {}, onReady)
+    conn.connect()
+    const firstSocket = mockSockets[0]!
+    firstSocket.open()
+    const firstInitialize = JSON.parse(firstSocket.sent[0]!) as { id: number }
+    firstSocket.message({ id: firstInitialize.id, result: {} })
+    await Promise.resolve()
+
+    expect(onReady).toHaveBeenCalledTimes(1)
+
+    firstSocket.close({ code: 1006, wasClean: false })
+    vi.advanceTimersByTime(5000)
+    const secondSocket = mockSockets[1]!
+    secondSocket.open()
+    const secondInitialize = JSON.parse(secondSocket.sent[0]!) as { id: number }
+    secondSocket.message({ id: secondInitialize.id, result: {} })
+    await Promise.resolve()
+
+    expect(onReady).toHaveBeenCalledTimes(2)
+    conn.dispose()
+  })
+
   it('routes notification send failures through reconnect instead of throwing', async () => {
     vi.useFakeTimers()
     installWebSocketMock()

--- a/dashboard/src/components/ide/ide-lsp-client.test.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.test.ts
@@ -20,6 +20,7 @@ class MockWebSocket {
   onmessage: ((event: MessageEvent) => void) | null = null
   onerror: ((event: Event) => void) | null = null
   onclose: ((event: CloseEvent) => void) | null = null
+  failSend = false
 
   constructor(readonly url: string) {
     mockSockets.push(this)
@@ -27,6 +28,7 @@ class MockWebSocket {
 
   send(data: string): void {
     if (this.readyState !== MockWebSocket.OPEN) throw new Error('socket not open')
+    if (this.failSend) throw new Error('send failed')
     this.sent.push(data)
   }
 
@@ -185,5 +187,29 @@ describe('LspConnection', () => {
     vi.advanceTimersByTime(5000)
 
     expect(mockSockets).toHaveLength(1)
+  })
+
+  it('routes notification send failures through reconnect instead of throwing', async () => {
+    vi.useFakeTimers()
+    installWebSocketMock()
+    const errors: unknown[] = []
+    const conn = new LspConnection(() => {}, err => errors.push(err))
+    conn.connect()
+    const socket = mockSockets[0]!
+    socket.open()
+    const initialize = JSON.parse(socket.sent[0]!) as { id: number }
+    socket.message({ id: initialize.id, result: {} })
+    await Promise.resolve()
+
+    expect(socket.sent).toHaveLength(2)
+    socket.failSend = true
+
+    expect(() => conn.notifyDidOpen('lib/keeper/current.ml', 'ocaml')).not.toThrow()
+    expect(errors).toHaveLength(1)
+    expect(socket.readyState).toBe(MockWebSocket.CLOSED)
+
+    vi.advanceTimersByTime(5000)
+    expect(mockSockets).toHaveLength(2)
+    conn.dispose()
   })
 })

--- a/dashboard/src/components/ide/ide-lsp-client.test.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.test.ts
@@ -5,6 +5,10 @@ import {
   lspDiagnosticSnapshot,
   resolveLspDiagnosticFilePath,
 } from './ide-lsp-client'
+import {
+  TRANSPORT_RETRY_BASE_MS,
+  TRANSPORT_RETRY_MAX_ATTEMPTS,
+} from '../../config/constants'
 
 const mockSockets: MockWebSocket[] = []
 
@@ -59,6 +63,7 @@ function installWebSocketMock(): void {
 
 afterEach(() => {
   vi.useRealTimers()
+  vi.restoreAllMocks()
   vi.unstubAllGlobals()
   lspDiagnosticSnapshot.value = new Map()
   mockSockets.length = 0
@@ -187,6 +192,69 @@ describe('LspConnection', () => {
     vi.advanceTimersByTime(5000)
 
     expect(mockSockets).toHaveLength(1)
+  })
+
+  it('uses exponential reconnect delays while the LSP socket stays down', () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    installWebSocketMock()
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    const firstSocket = mockSockets[0]!
+
+    firstSocket.close({ code: 1006, wasClean: false })
+    vi.advanceTimersByTime(TRANSPORT_RETRY_BASE_MS - 1)
+    expect(mockSockets).toHaveLength(1)
+    vi.advanceTimersByTime(1)
+    expect(mockSockets).toHaveLength(2)
+
+    mockSockets[1]!.close({ code: 1006, wasClean: false })
+    vi.advanceTimersByTime((TRANSPORT_RETRY_BASE_MS * 2) - 1)
+    expect(mockSockets).toHaveLength(2)
+    vi.advanceTimersByTime(1)
+    expect(mockSockets).toHaveLength(3)
+    conn.dispose()
+  })
+
+  it('stops reconnecting after the retry budget is exhausted', () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    installWebSocketMock()
+    const errors: unknown[] = []
+    const conn = new LspConnection(() => {}, err => errors.push(err))
+    conn.connect()
+
+    for (let attempt = 1; attempt <= TRANSPORT_RETRY_MAX_ATTEMPTS; attempt += 1) {
+      mockSockets[mockSockets.length - 1]!.close({ code: 1006, wasClean: false })
+      vi.advanceTimersByTime(60_000)
+      expect(mockSockets).toHaveLength(attempt + 1)
+    }
+
+    mockSockets[mockSockets.length - 1]!.close({ code: 1006, wasClean: false })
+    vi.advanceTimersByTime(60_000)
+
+    expect(mockSockets).toHaveLength(TRANSPORT_RETRY_MAX_ATTEMPTS + 1)
+    expect(errors.some(err => err instanceof Error && err.message.includes('exhausted'))).toBe(true)
+    conn.dispose()
+  })
+
+  it('does not reconnect after terminal LSP close codes', async () => {
+    vi.useFakeTimers()
+    installWebSocketMock()
+    const errors: unknown[] = []
+    const conn = new LspConnection(() => {}, err => errors.push(err))
+    conn.connect()
+    const socket = mockSockets[0]!
+    socket.open()
+    const hover = conn.requestHover('lib/keeper/current.ml', 0, 0)
+
+    socket.close({ code: 4401, reason: 'unauthorized', wasClean: false })
+    vi.advanceTimersByTime(60_000)
+
+    await expect(hover).resolves.toBeNull()
+    expect(mockSockets).toHaveLength(1)
+    expect(errors.some(err => err instanceof Error && err.message.includes('4401'))).toBe(true)
+    conn.dispose()
   })
 
   it('notifies readiness after initial connect and reconnect initialize', async () => {

--- a/dashboard/src/components/ide/ide-lsp-client.test.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.test.ts
@@ -1,9 +1,62 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   clearLspDiagnosticSnapshot,
+  LspConnection,
   lspDiagnosticSnapshot,
   resolveLspDiagnosticFilePath,
 } from './ide-lsp-client'
+
+const mockSockets: MockWebSocket[] = []
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readyState = MockWebSocket.CONNECTING
+  sent: string[] = []
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+
+  constructor(readonly url: string) {
+    mockSockets.push(this)
+  }
+
+  send(data: string): void {
+    if (this.readyState !== MockWebSocket.OPEN) throw new Error('socket not open')
+    this.sent.push(data)
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  close(event: Partial<Pick<CloseEvent, 'code' | 'reason' | 'wasClean'>> = {}): void {
+    if (this.readyState === MockWebSocket.CLOSED) return
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.({
+      code: event.code ?? 1000,
+      reason: event.reason ?? '',
+      wasClean: event.wasClean ?? true,
+    } as CloseEvent)
+  }
+}
+
+function installWebSocketMock(): void {
+  mockSockets.length = 0
+  vi.stubGlobal('WebSocket', MockWebSocket)
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  lspDiagnosticSnapshot.value = new Map()
+  mockSockets.length = 0
+})
 
 describe('resolveLspDiagnosticFilePath', () => {
   afterEach(() => {
@@ -73,5 +126,37 @@ describe('clearLspDiagnosticSnapshot', () => {
 
     expect(lspDiagnosticSnapshot.value.has('lib/keeper/old.ml')).toBe(false)
     expect(lspDiagnosticSnapshot.value.get('lib/keeper/current.ml')).toHaveLength(1)
+  })
+})
+
+describe('LspConnection', () => {
+  it('settles pending requests when the socket closes', async () => {
+    installWebSocketMock()
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    const socket = mockSockets[0]!
+    socket.open()
+
+    const hover = conn.requestHover('lib/keeper/current.ml', 0, 0)
+    expect(socket.sent).toHaveLength(2)
+
+    socket.close({ code: 1011, reason: 'server restart', wasClean: false })
+
+    await expect(hover).resolves.toBeNull()
+    conn.dispose()
+  })
+
+  it('cancels scheduled reconnect when disposed', () => {
+    vi.useFakeTimers()
+    installWebSocketMock()
+    const conn = new LspConnection(() => {}, () => {})
+    conn.connect()
+    const socket = mockSockets[0]!
+
+    socket.close({ code: 1006, wasClean: false })
+    conn.dispose()
+    vi.advanceTimersByTime(5000)
+
+    expect(mockSockets).toHaveLength(1)
   })
 })

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -400,13 +400,7 @@ export class LspConnection {
       if (this.ws === ws) this.ws = null
       this.initialized = false
       this.rejectPending(new Error(lspCloseReason(event)))
-      if (!this.disposed) {
-        this.clearReconnectTimer()
-        this.reconnectTimer = setTimeout(() => {
-          this.reconnectTimer = null
-          if (!this.disposed) this.connect()
-        }, 5000)
-      }
+      this.scheduleReconnect()
     }
 
     ws.onerror = (err) => {
@@ -451,19 +445,53 @@ export class LspConnection {
         return
       }
       const id = this.nextId++
+      const currentSocket = this.ws
       this.pending.set(id, { resolve, reject })
       try {
-        this.ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+        currentSocket.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
       } catch (err) {
         this.pending.delete(id)
-        reject(err)
+        const reason = err instanceof Error ? err : new Error(String(err))
+        this.handleSocketSendFailure(currentSocket, reason)
+        reject(reason)
       }
     })
   }
 
-  private sendNotification(method: string, params: unknown): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return
-    this.ws.send(JSON.stringify({ jsonrpc: '2.0', method, params }))
+  private sendNotification(method: string, params: unknown): boolean {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return false
+    const currentSocket = this.ws
+    try {
+      currentSocket.send(JSON.stringify({ jsonrpc: '2.0', method, params }))
+      return true
+    } catch (err) {
+      const reason = err instanceof Error ? err : new Error(String(err))
+      this.handleSocketSendFailure(currentSocket, reason)
+      return false
+    }
+  }
+
+  private handleSocketSendFailure(ws: WebSocket, reason: Error): void {
+    if (this.disposed || this.ws !== ws) return
+    this.onError(reason)
+    this.ws = null
+    this.initialized = false
+    this.rejectPending(reason)
+    try {
+      ws.close()
+    } catch {
+      // Ignore close failures; the reconnect timer below owns recovery.
+    }
+    this.scheduleReconnect()
+  }
+
+  private scheduleReconnect(): void {
+    if (this.disposed) return
+    this.clearReconnectTimer()
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      if (!this.disposed) this.connect()
+    }, 5000)
   }
 
   private async initialize(): Promise<void> {
@@ -481,8 +509,7 @@ export class LspConnection {
           },
         },
       })
-      this.sendNotification('initialized', {})
-      this.initialized = true
+      this.initialized = this.sendNotification('initialized', {})
     } catch (err) {
       if (!this.disposed) {
         console.error('[LSP] initialize failed:', err)

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -16,7 +16,13 @@ import {
 import { StateField, StateEffect, RangeSetBuilder, type Extension } from '@codemirror/state'
 import { signal } from '@preact/signals'
 import { normalizeIdeContextFilePath } from './ide-state'
-import { DEFAULT_MASC_ORIGIN } from '../../config/constants'
+import {
+  DEFAULT_MASC_ORIGIN,
+  TRANSPORT_RETRY_BASE_MS,
+  TRANSPORT_RETRY_JITTER_MS,
+  TRANSPORT_RETRY_MAX_ATTEMPTS,
+  TRANSPORT_RETRY_MAX_MS,
+} from '../../config/constants'
 import { DEFAULT_LANGUAGE_ID } from './ide-language'
 
 // ── Types ─────────────────────────────────────────────────────────
@@ -65,6 +71,8 @@ export interface LspDiagnosticAnchor {
 }
 
 export const lspDiagnosticSnapshot = signal<ReadonlyMap<string, ReadonlyArray<LspDiagnosticAnchor>>>(new Map())
+
+const LSP_TERMINAL_CLOSE_CODES = new Set([1008, 4401, 4403])
 
 export interface SelectedAnnotation {
   readonly id: string
@@ -366,6 +374,8 @@ export class LspConnection {
   private disposed = false
   private initialized = false
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectAttempts = 0
+  private reconnectDelayMs = TRANSPORT_RETRY_BASE_MS
 
   constructor(
     private readonly onDiagnostics: (uri: string | undefined, diags: ReadonlyMap<number, LspDiagnostic[]>) => void,
@@ -397,11 +407,16 @@ export class LspConnection {
     }
 
     ws.onclose = (event) => {
-      if (this.ws !== ws) return
-      if (this.ws === ws) this.ws = null
+      if (this.disposed || this.ws !== ws) return
+      this.ws = null
       this.initialized = false
-      this.rejectPending(new Error(lspCloseReason(event)))
-      this.scheduleReconnect()
+      const reason = new Error(lspCloseReason(event))
+      this.rejectPending(reason)
+      if (shouldReconnectLspClose(event)) {
+        this.scheduleReconnect()
+      } else {
+        this.onError(reason)
+      }
     }
 
     ws.onerror = (err) => {
@@ -488,11 +503,20 @@ export class LspConnection {
 
   private scheduleReconnect(): void {
     if (this.disposed) return
-    this.clearReconnectTimer()
+    if (this.reconnectTimer !== null) return
+    if (this.reconnectAttempts >= TRANSPORT_RETRY_MAX_ATTEMPTS) {
+      this.onError(new Error('LSP reconnect attempts exhausted'))
+      return
+    }
+    const delayMs =
+      Math.min(this.reconnectDelayMs, TRANSPORT_RETRY_MAX_MS)
+      + Math.random() * TRANSPORT_RETRY_JITTER_MS
+    this.reconnectAttempts += 1
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
       if (!this.disposed) this.connect()
-    }, 5000)
+    }, delayMs)
+    this.reconnectDelayMs = Math.min(this.reconnectDelayMs * 2, TRANSPORT_RETRY_MAX_MS)
   }
 
   private async initialize(): Promise<void> {
@@ -511,7 +535,10 @@ export class LspConnection {
         },
       })
       this.initialized = this.sendNotification('initialized', {})
-      if (this.initialized) this.onReady()
+      if (this.initialized) {
+        this.resetReconnectBackoff()
+        this.onReady()
+      }
     } catch (err) {
       if (!this.disposed) {
         console.error('[LSP] initialize failed:', err)
@@ -613,6 +640,11 @@ export class LspConnection {
     this.reconnectTimer = null
   }
 
+  private resetReconnectBackoff(): void {
+    this.reconnectAttempts = 0
+    this.reconnectDelayMs = TRANSPORT_RETRY_BASE_MS
+  }
+
   private rejectPending(reason: Error): void {
     for (const [, { reject }] of this.pending) {
       reject(reason)
@@ -631,6 +663,10 @@ function lspCloseReason(event: CloseEvent): string {
   const code = event.code ? ` ${event.code}` : ''
   const reason = event.reason ? `: ${event.reason}` : ''
   return `WebSocket closed${code}${reason}`
+}
+
+function shouldReconnectLspClose(event: CloseEvent): boolean {
+  return !LSP_TERMINAL_CLOSE_CODES.has(event.code)
 }
 
 export function resolveLspDiagnosticFilePath(

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -370,6 +370,7 @@ export class LspConnection {
   constructor(
     private readonly onDiagnostics: (uri: string | undefined, diags: ReadonlyMap<number, LspDiagnostic[]>) => void,
     private readonly onError: (err: unknown) => void,
+    private readonly onReady: () => void = () => {},
   ) {}
 
   connect(): void {
@@ -510,6 +511,7 @@ export class LspConnection {
         },
       })
       this.initialized = this.sendNotification('initialized', {})
+      if (this.initialized) this.onReady()
     } catch (err) {
       if (!this.disposed) {
         console.error('[LSP] initialize failed:', err)
@@ -773,6 +775,16 @@ const lspViewPlugin = ViewPlugin.fromClass(
           }
         },
         (err) => console.error('[LSP] connection error:', err),
+        () => {
+          const currentFilePath = this.filePath
+          if (currentFilePath !== '') {
+            this.conn.notifyDidOpen(
+              currentFilePath,
+              languageIdFromPath(currentFilePath) ?? DEFAULT_LANGUAGE_ID,
+            )
+          }
+          this.scheduleRefresh()
+        },
       )
       this.conn.connect()
       this.onAnnotationSelect = (e: Event) => {

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -359,12 +359,13 @@ interface PendingRequest {
   reject: (reason: unknown) => void
 }
 
-class LspConnection {
+export class LspConnection {
   private ws: WebSocket | null = null
   private nextId = 1
   private pending = new Map<number, PendingRequest>()
   private disposed = false
   private initialized = false
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(
     private readonly onDiagnostics: (uri: string | undefined, diags: ReadonlyMap<number, LspDiagnostic[]>) => void,
@@ -373,13 +374,14 @@ class LspConnection {
 
   connect(): void {
     if (this.disposed) return
+    this.clearReconnectTimer()
     const origin = typeof window !== 'undefined' ? window.location.origin : DEFAULT_MASC_ORIGIN
     const wsUrl = origin.replace(/^http/, 'ws') + '/api/v1/ide/lsp'
     const ws = new WebSocket(wsUrl)
     this.ws = ws
 
     ws.onopen = () => {
-      if (this.disposed) { ws.close(); return }
+      if (this.disposed || this.ws !== ws) { ws.close(); return }
       this.initialize()
     }
 
@@ -392,10 +394,16 @@ class LspConnection {
       }
     }
 
-    ws.onclose = () => {
+    ws.onclose = (event) => {
+      if (this.ws === ws) this.ws = null
       this.initialized = false
+      this.rejectPending(new Error(lspCloseReason(event)))
       if (!this.disposed) {
-        setTimeout(() => { if (!this.disposed) this.connect() }, 5000)
+        this.clearReconnectTimer()
+        this.reconnectTimer = setTimeout(() => {
+          this.reconnectTimer = null
+          if (!this.disposed) this.connect()
+        }, 5000)
       }
     }
 
@@ -441,7 +449,12 @@ class LspConnection {
       }
       const id = this.nextId++
       this.pending.set(id, { resolve, reject })
-      this.ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+      try {
+        this.ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+      } catch (err) {
+        this.pending.delete(id)
+        reject(err)
+      }
     })
   }
 
@@ -554,14 +567,25 @@ class LspConnection {
 
   dispose(): void {
     this.disposed = true
-    for (const [, { reject }] of this.pending) {
-      reject(new Error('Connection disposed'))
-    }
-    this.pending.clear()
+    this.clearReconnectTimer()
+    this.rejectPending(new Error('Connection disposed'))
     if (this.ws) {
       this.ws.close()
       this.ws = null
     }
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer === null) return
+    clearTimeout(this.reconnectTimer)
+    this.reconnectTimer = null
+  }
+
+  private rejectPending(reason: Error): void {
+    for (const [, { reject }] of this.pending) {
+      reject(reason)
+    }
+    this.pending.clear()
   }
 }
 
@@ -569,6 +593,12 @@ class LspConnection {
 
 function toFileUri(filePath: string): string {
   return `file://${filePath}`
+}
+
+function lspCloseReason(event: CloseEvent): string {
+  const code = event.code ? ` ${event.code}` : ''
+  const reason = event.reason ? `: ${event.reason}` : ''
+  return `WebSocket closed${code}${reason}`
 }
 
 export function resolveLspDiagnosticFilePath(

--- a/dashboard/src/components/ide/ide-lsp-client.ts
+++ b/dashboard/src/components/ide/ide-lsp-client.ts
@@ -386,6 +386,7 @@ export class LspConnection {
     }
 
     ws.onmessage = (event) => {
+      if (this.disposed || this.ws !== ws) return
       try {
         const msg = JSON.parse(event.data)
         this.handleMessage(msg)
@@ -395,6 +396,7 @@ export class LspConnection {
     }
 
     ws.onclose = (event) => {
+      if (this.ws !== ws) return
       if (this.ws === ws) this.ws = null
       this.initialized = false
       this.rejectPending(new Error(lspCloseReason(event)))
@@ -408,6 +410,7 @@ export class LspConnection {
     }
 
     ws.onerror = (err) => {
+      if (this.disposed || this.ws !== ws) return
       console.error('[LSP] WebSocket error:', err)
       this.onError(err)
     }

--- a/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.test.ts
@@ -7,6 +7,8 @@ import {
 } from './keeper-cursor-overlay'
 
 afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
   vi.unstubAllGlobals()
 })
 
@@ -75,7 +77,12 @@ describe('getKeeperColor', () => {
   })
 
   it('connects to the dedicated cursor stream endpoint', () => {
-    const instances: Array<{ readonly url: string; close: () => void }> = []
+    const instances: Array<{
+      readonly url: string
+      onmessage: ((event: MessageEvent) => void) | null
+      onerror: ((event: Event) => void) | null
+      close: () => void
+    }> = []
     class MockEventSource {
       onmessage: ((event: MessageEvent) => void) | null = null
       onerror: ((event: Event) => void) | null = null
@@ -95,5 +102,55 @@ describe('getKeeperColor', () => {
     expect(instances[0]?.url).toBe('http://localhost:8935/api/v1/ide/cursors/stream')
     cleanup()
     expect(instances[0]?.close).toHaveBeenCalled()
+  })
+
+  it('cancels cursor stream reconnect timers during cleanup', () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const instances: Array<{
+      readonly url: string
+      onmessage: ((event: MessageEvent) => void) | null
+      onerror: ((event: Event) => void) | null
+      close: () => void
+    }> = []
+    class MockEventSource {
+      onmessage: ((event: MessageEvent) => void) | null = null
+      onerror: ((event: Event) => void) | null = null
+      readonly url: string
+
+      constructor(url: string) {
+        this.url = url
+        instances.push(this)
+      }
+
+      close = vi.fn()
+    }
+    vi.stubGlobal('EventSource', MockEventSource)
+
+    const onUpdate = vi.fn()
+    const cleanup = connectKeeperCursorStream('http://localhost:8935', onUpdate)
+    instances[0]!.onmessage?.({
+      data: JSON.stringify({
+        cursors: [{
+          keeper_id: 'sangsu',
+          file_path: 'lib/a.ml',
+          line: 24,
+          column: 2,
+          focus_mode: 'editing',
+          last_update: Date.now(),
+        }],
+      }),
+    } as MessageEvent)
+    expect(onUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      active_file: 'lib/a.ml',
+    }))
+
+    instances[0]!.onerror?.(new Event('error'))
+    cleanup()
+    vi.advanceTimersByTime(1_000)
+
+    expect(instances).toHaveLength(1)
+    expect(instances[0]!.close).toHaveBeenCalled()
   })
 })

--- a/dashboard/src/components/ide/keeper-cursor-overlay.ts
+++ b/dashboard/src/components/ide/keeper-cursor-overlay.ts
@@ -5,6 +5,7 @@
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
+import { createSseTransport } from '../../transports/sse-transport'
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -406,28 +407,21 @@ export function connectKeeperCursorStream(
   baseUrl: string,
   onUpdate: (overlay: KeeperCursorOverlay) => void,
 ): () => void {
-  const eventSource = new EventSource(`${baseUrl}/api/v1/ide/cursors/stream`)
-  
-  eventSource.onmessage = (event) => {
-    try {
-      const data = JSON.parse(event.data)
-      onUpdate(normalizeKeeperCursorSnapshot(data))
-    } catch (err) {
-      console.error('Keeper cursor stream parse error:', err)
+  const transport = createSseTransport(`${baseUrl}/api/v1/ide/cursors/stream`)
+  const unsubscribe = transport.subscribe((event) => {
+    if (event.type === 'message') {
+      onUpdate(normalizeKeeperCursorSnapshot(event.data))
+      return
     }
-  }
-  
-  eventSource.onerror = (err) => {
-    console.error('Keeper cursor stream error:', err)
-    // Reconnect after delay
-    setTimeout(() => {
-      eventSource.close()
-      connectKeeperCursorStream(baseUrl, onUpdate)
-    }, 3000)
-  }
-  
+    if (event.type === 'error') {
+      console.error('Keeper cursor stream error:', event.error)
+    }
+  })
+  transport.connect()
+
   return () => {
-    eventSource.close()
+    unsubscribe()
+    transport.disconnect()
   }
 }
 

--- a/dashboard/src/transports/sse-transport.test.ts
+++ b/dashboard/src/transports/sse-transport.test.ts
@@ -133,6 +133,22 @@ describe('createSseTransport', () => {
     expect(instances).toHaveLength(2)
   })
 
+  it('coalesces duplicate error events into one pending reconnect', () => {
+    const transport = createSseTransport('/mcp', {
+      retryBaseMs: 100,
+      retryJitterMs: 0,
+      retryMaxAttempts: 10,
+    })
+    transport.connect()
+    instances[0]!.simulateOpen()
+
+    instances[0]!.simulateError()
+    instances[0]!.simulateError()
+    vi.advanceTimersByTime(100)
+
+    expect(instances).toHaveLength(2)
+  })
+
   it('keeps reconnecting after retryMaxAttempts and emits close once', () => {
     const events: { type: string }[] = []
     const transport = createSseTransport('/mcp', {

--- a/dashboard/src/transports/sse-transport.ts
+++ b/dashboard/src/transports/sse-transport.ts
@@ -22,6 +22,7 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
   }
 
   const scheduleReconnect = () => {
+    if (reconnectTimer) return
     if (reconnectAttempts >= retryMaxAttempts && !closeNotified) {
       closeNotified = true
       notify({ type: 'close' })
@@ -30,7 +31,10 @@ export function createSseTransport(url: string, opts: TransportOptions = {}): Tr
     const maxMs = opts.retryMaxMs ?? TRANSPORT_RETRY_MAX_MS
     const backoff = Math.min(retryMs, maxMs)
     const jitter = Math.random() * retryJitterMs
-    reconnectTimer = setTimeout(connect, backoff + jitter)
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      connect()
+    }, backoff + jitter)
     retryMs = Math.min(retryMs * 2, maxMs)
   }
 


### PR DESCRIPTION
## Summary
- reject in-flight IDE LSP JSON-RPC requests when the WebSocket closes so refresh/hover promises do not hang after reconnect
- keep only one scheduled IDE LSP reconnect, cancel it on dispose, and ignore stale socket events from older connections
- bound IDE LSP reconnects with shared retry/backoff constants and stop retrying on terminal auth/policy close codes
- recover IDE LSP `send()` failures through the same reconnect path instead of throwing from dashboard UI code
- refresh the current editor LSP state after reconnect by re-sending `didOpen` and scheduling a refresh once initialization completes
- retry transient loopback dev-token bootstrap failures while still memoizing success and disabled-endpoint responses
- route the IDE keeper cursor SSE helper through the shared SSE transport so cleanup cancels pending reconnects
- coalesce duplicate SSE transport error events into a single pending reconnect timer

## Why
The dashboard has several active frontend connection paths: the main dashboard WS/MCP bootstrap path, the IDE LSP WebSocket, and smaller SSE helpers. A server restart, transient close, send failure, cleanup race, auth/policy close, or startup race could previously leave pending promises unresolved, retry forever, skip the editor refresh after reconnect, resurrect a cleaned-up cursor SSE stream, or memoize a failed dev-token bootstrap for the rest of the page load.

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/transports/sse-transport.test.ts src/components/ide/keeper-cursor-overlay.test.ts src/api/dev-token.test.ts src/components/ide/ide-lsp-client.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec vitest run --config vitest.config.ts src/api/mcp.test.ts -t "dev-token bootstrap" --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/components/ide/ide-lsp-client.ts src/components/ide/ide-lsp-client.test.ts src/components/ide/keeper-cursor-overlay.ts src/components/ide/keeper-cursor-overlay.test.ts src/transports/sse-transport.ts src/transports/sse-transport.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
