### PR TITLE
fix(dashboard): surface all live attribution gates, not just the known allow-list

### DIFF
--- a/dashboard/src/components/attribution-panel.test.ts
+++ b/dashboard/src/components/attribution-panel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { AttributionEvent, AttributionOutcome } from '../api/attribution'
-import { filterAttributionEvents } from './attribution-panel'
+import { filterAttributionEvents, gatesToRender } from './attribution-panel'
 
 function makeEvent(
   overrides: Partial<{
@@ -109,5 +109,39 @@ describe('filterAttributionEvents', () => {
     // Gate + text where text does not match within the gate subset.
     const noMatch = filterAttributionEvents(gateFiltered, 'signature')
     expect(noMatch).toHaveLength(0)
+  })
+})
+
+describe('gatesToRender', () => {
+  const known = ['cdal_verdict', 'verification', 'keeper_fsm'] as const
+
+  it('keeps the known gates first, in declared order', () => {
+    expect(gatesToRender(known, [])).toEqual(['cdal_verdict', 'verification', 'keeper_fsm'])
+  })
+
+  it('appends a data gate that is not in the known set (no silent drop)', () => {
+    // The bug class: a backend-emitted gate absent from the known allow-list
+    // would never get a card. The union surfaces it instead.
+    expect(gatesToRender(known, ['exec_policy'])).toEqual([
+      'cdal_verdict', 'verification', 'keeper_fsm', 'exec_policy',
+    ])
+  })
+
+  it('does not duplicate a data gate already in the known set', () => {
+    expect(gatesToRender(known, ['verification', 'keeper_fsm'])).toEqual([
+      'cdal_verdict', 'verification', 'keeper_fsm',
+    ])
+  })
+
+  it('sorts the appended extras for stable ordering', () => {
+    expect(gatesToRender(known, ['zeta_gate', 'alpha_gate'])).toEqual([
+      'cdal_verdict', 'verification', 'keeper_fsm', 'alpha_gate', 'zeta_gate',
+    ])
+  })
+
+  it('surfaces exec_policy even when it is missing from the known set', () => {
+    // Regression guard: exec_policy is a live backend attribution gate
+    // (lib/exec_policy/exec_policy.ml). It must never be silently uncategorized.
+    expect(gatesToRender(known, ['exec_policy', 'verification'])).toContain('exec_policy')
   })
 })

--- a/dashboard/src/components/attribution-panel.ts
+++ b/dashboard/src/components/attribution-panel.ts
@@ -26,17 +26,34 @@ import { isAbortError } from '../lib/async-state'
 const POLL_INTERVAL_MS = 5_000
 const RECENT_LIMIT = 50
 
-// Known gates. Gates not yet wired (accountability, workspace_task, etc.) will
-// show zero counts so the operator sees which sources are live.
+// Gates rendered as cards even before they emit, so the operator sees the full
+// known set with zero counts. Backend-emitted gates outside this list are
+// appended from the live attribution data (see gatesToRender) so none is
+// silently dropped. Backend currently emits accountability, exec_policy,
+// keeper_fsm and verification (lib `Attribution.* ~gate:"..."`); the rest are
+// forward-declared and show zero until their source is wired.
 const KNOWN_GATES = [
   'cdal_verdict',
   'verification',
+  'exec_policy',
   'keeper_fsm',
   'worker_dev_tools',
   'accountability',
   'oas_completion',
   'agent_lifecycle',
 ] as const
+
+// Render order: the known set first (stable, including empty placeholders), then
+// any other gate present in live data, sorted. A backend gate missing from
+// KNOWN_GATES still gets a card instead of being silently uncategorized.
+export function gatesToRender(
+  known: readonly string[],
+  dataGates: Iterable<string>,
+): string[] {
+  const knownSet = new Set<string>(known)
+  const extras = [...dataGates].filter(g => !knownSet.has(g)).sort()
+  return [...known, ...extras]
+}
 
 function outcomeLabel(a: Attribution): string {
   switch (a.outcome.kind) {
@@ -279,6 +296,7 @@ export function AttributionPanel() {
 
   const byGate = new Map<string, GateSummary>()
   for (const g of summary.value?.gates ?? []) byGate.set(g.gate, g)
+  const visibleGates = gatesToRender(KNOWN_GATES, byGate.keys())
 
   // Gate filter runs server-side (see fetchAttributionRecent above), so
   // `recent.value` is already gate-filtered. Text filter composes on top.
@@ -305,7 +323,7 @@ export function AttributionPanel() {
       </div>
 
       <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-        ${KNOWN_GATES.map(gate => html`
+        ${visibleGates.map(gate => html`
           <${GateCard}
             gate=${gate}
             summary=${byGate.get(gate) ?? null}

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -110,6 +110,7 @@ export type AttributionOrigin = 'det' | 'nondet'
 export type AttributionGate =
   | 'cdal_verdict'
   | 'verification'
+  | 'exec_policy'
   | 'accountability'
   | 'keeper_fsm'
   | 'oas_completion'


### PR DESCRIPTION
## 무엇을 / 왜

Attribution 패널(`attribution-panel.ts`)은 gate별 GateCard를 **하드코딩 `KNOWN_GATES` allow-list만 순회**(`KNOWN_GATES.map`)해서 렌더합니다. 그래서 backend가 emit하지만 이 리스트에 없는 gate는 `byGate` 데이터에 존재해도 **카드가 영영 안 그려지고 pass/fail 카운트가 조용히 사라집니다**(silent uncategorized).

실제 누락 사례: **`exec_policy`** — `lib/exec_policy/exec_policy.ml`이 `Attribution.passed/policy_failed ~gate:"exec_policy"`를 emit하는 **live gate**인데 frontend `KNOWN_GATES`에는 없어, 운영자 관찰 화면에서 exec_policy gate의 결과가 보이지 않았습니다.

이건 한 gate의 문제가 아니라 **하드코딩 allow-list가 미지 gate를 조용히 버리는 클래스 결함**입니다(software-development.md "Silent Failure 사전 방지").

## 변경

- **`gatesToRender(known, dataGates)`** (순수 export 함수): known set을 먼저(안정적 순서 + 빈 placeholder), 그 뒤에 live summary에 실제 존재하는 미지 gate를 정렬해 append. → silent-drop을 **일반적으로** 제거(미래 backend gate도 자동 surface, N-of-M 한-gate 패치 회피).
- **`exec_policy`를 `KNOWN_GATES`에 추가** — 0건일 때도 안정적 placeholder 카드 노출.
- **stale 주석 정정** — 기존 주석은 `accountability`를 "not yet wired"로 표기했으나 실제로는 wired(`keeper_accountability.ml`이 `gate:"accountability"` emit + 이미 리스트에 있음). 또 존재하지 않는 `workspace_task`를 예시로 들고 있었음. 둘 다 정정.

backend가 현재 emit하는 attribution gate는 **정확히 4종**(전부 string literal, 검증됨): `accountability`, `exec_policy`, `keeper_fsm`, `verification`.

## 범위 / 경계

- frontend **관찰 surface only**. attribution-panel은 `/api/attribution`을 읽어 read-only 렌더하는 observation 화면 → credential/operator-control/keeper-sandbox/hooks/workflow RFC-gate **비대상**.
- backend 무변경. gate emission 경로(`Attribution.*`)는 그대로.
- `cdal_verdict`/`worker_dev_tools`/`oas_completion`/`agent_lifecycle`은 KNOWN_GATES에 남겨둠(현재 미emit이나 forward-decl placeholder로 0건 표시 — 제거는 scope 밖).

## Workaround Signature self-check

- 텔레메트리-as-fix ❌ (카운터 추가 아님 — 이미 존재하는 데이터를 **보이게** 함, drop을 fix)
- string/substring 분류기 ❌ (allow-list 의존을 **줄이는** union, exact Set membership)
- N-of-M ❌ (union이 **모든** gate를 generic하게 surface — 한 gate씩 메우는 패치의 반대)

## 검증

- `tsc --noEmit`: clean (전체 프로젝트)
- `eslint` (attribution-panel.ts): clean
- `vitest`: **16/16** — 기존 11(filterAttributionEvents) + 신규 5(gatesToRender: known 순서 보존 / 미지 data gate append / 중복 비추가 / extras 정렬 / **exec_policy regression guard**)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
