### PR TITLE
[codex] Fix dashboard context follow-up

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { shellAuthSummary, tasks } from '../../store'
 import { navigate } from '../../router'
 import { callMcpTool } from '../../api/mcp'
+import { requestConfirm } from '../common/confirm-dialog'
 import { KeeperWorkspaceRail } from './keeper-workspace-rail'
 import type { Keeper, Task } from '../../types'
 
@@ -29,6 +30,10 @@ vi.mock('../../router', () => ({
 
 vi.mock('../../api/mcp', () => ({
   callMcpTool: vi.fn().mockResolvedValue('{"before_tokens":1000,"after_tokens":800,"phase_after":"Running"}'),
+}))
+
+vi.mock('../common/confirm-dialog', () => ({
+  requestConfirm: vi.fn().mockResolvedValue(true),
 }))
 
 function mkKeeper(partial: Partial<Keeper>): Keeper {
@@ -157,17 +162,45 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('compact ratio_gate는 50%입니다')
   })
 
-  it('runs operator compaction through the existing MCP tool', async () => {
+  it('runs overflow compaction without force through the existing MCP tool', async () => {
     shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
-    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, phase: 'Overflowed' })} onToggleDetail=${() => {}} />`)
     fireEvent.click(getByRole('button', { name: '지금 compact' }))
 
     await waitFor(() => {
       expect(callMcpTool).toHaveBeenCalledWith('masc_keeper_compact', {
         name: 'masc-improver',
+        force: false,
+      })
+    })
+    expect(requestConfirm).not.toHaveBeenCalled()
+  })
+
+  it('confirms before forcing compaction on running keepers', async () => {
+    shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
+    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, phase: 'Running' })} onToggleDetail=${() => {}} />`)
+    fireEvent.click(getByRole('button', { name: '지금 compact' }))
+
+    await waitFor(() => {
+      expect(requestConfirm).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Force keeper compact',
+        confirmText: 'Force compact',
+      }))
+      expect(callMcpTool).toHaveBeenCalledWith('masc_keeper_compact', {
+        name: 'masc-improver',
         force: true,
       })
     })
+  })
+
+  it('does not compact running keepers when force confirmation is cancelled', async () => {
+    vi.mocked(requestConfirm).mockResolvedValueOnce(false)
+    shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
+    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, phase: 'Running' })} onToggleDetail=${() => {}} />`)
+    fireEvent.click(getByRole('button', { name: '지금 compact' }))
+
+    await waitFor(() => expect(requestConfirm).toHaveBeenCalled())
+    expect(callMcpTool).not.toHaveBeenCalled()
   })
 
   it('fires onToggleDetail from the 운영 상세 button', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -15,6 +15,7 @@ import { KeeperWorkspaceRecentTools } from './keeper-workspace-tool-calls'
 import { formatDuration } from '../../lib/format-time'
 import { callMcpTool } from '../../api/mcp'
 import { showToast } from '../common/toast'
+import { requestConfirm } from '../common/confirm-dialog'
 import { dashboardAuthAccess } from '../../lib/dashboard-auth-access'
 import { errorToString } from '../../lib/format-string'
 import { refreshAfterRuntimeAction } from '../keeper-detail-helpers'
@@ -123,6 +124,14 @@ function compactionGatePct(keeper: Keeper): number {
   return Math.max(1, Math.min(99, Math.round(ratio * 100)))
 }
 
+function compactRequiresForce(keeper: Keeper): boolean {
+  const phase = (keeper.phase ?? keeper.lifecycle_phase ?? '').toLowerCase()
+  if (phase === 'overflowed' || phase === 'paused' || phase === 'compacting') return false
+  if (phase === 'running' || phase === 'failing') return true
+  const status = keeper.status.toLowerCase()
+  return status === 'running' || status === 'active' || status === 'busy' || status === 'failing'
+}
+
 function ContextSection({ keeper }: { keeper: Keeper }): VNode {
   const [compacting, setCompacting] = useState(false)
   const pct = contextPercent(keeper)
@@ -153,11 +162,21 @@ function ContextSection({ keeper }: { keeper: Keeper }): VNode {
       return
     }
     void (async () => {
+      const force = compactRequiresForce(keeper)
+      if (force) {
+        const confirmed = await requestConfirm({
+          title: 'Force keeper compact',
+          message: `${keeper.name} is not in an explicit overflow/paused compaction phase. Run masc_keeper_compact with force=true?`,
+          confirmText: 'Force compact',
+          tone: 'warning',
+        })
+        if (!confirmed) return
+      }
       setCompacting(true)
       try {
         const raw = await callMcpTool('masc_keeper_compact', {
           name: keeper.name,
-          force: true,
+          force,
         })
         const parsed = JSON.parse(raw) as {
           before_tokens?: number

--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -719,22 +719,37 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
               ~registry_entry
           in
 
+          let primary_max_context =
+            let resolution =
+              Keeper_context_runtime.resolve_max_context_resolution_of_meta m
+            in
+            resolution.effective_budget
+          in
           let context =
             match last_metrics with
             | Some metrics ->
+                let context_tokens = Safe_ops.json_int "context_tokens" metrics in
+                let raw_context_max = Safe_ops.json_int "context_max" metrics in
+                let context_max =
+                  if raw_context_max > 0 then raw_context_max else primary_max_context
+                in
+                let raw_context_ratio =
+                  Safe_ops.json_float "context_ratio" metrics
+                in
+                let context_ratio =
+                  if raw_context_ratio > 0.0 || context_tokens <= 0 || context_max <= 0
+                  then raw_context_ratio
+                  else float_of_int context_tokens /. float_of_int context_max
+                in
                 `Assoc [
                   ("source", `String "metrics");
-                  ("context_ratio", `Float (Safe_ops.json_float "context_ratio" metrics));
-                  ("context_tokens", `Int (Safe_ops.json_int "context_tokens" metrics));
-                  ("context_max", `Int (Safe_ops.json_int "context_max" metrics));
+                  ("context_ratio", `Float context_ratio);
+                  ("context_tokens", `Int context_tokens);
+                  ("context_max", `Int context_max);
                   ("message_count", `Int (Safe_ops.json_int "message_count" metrics));
                 ]
             | None ->
-                (let primary_max_context =
-                   Keeper_turn_runtime_budget.resolved_max_context_for_turn
-                     ~meta:m
-                 in
-                     let base_dir = Keeper_types_profile.session_base_dir config in
+                (let base_dir = Keeper_types_profile.session_base_dir config in
                      let (_session, ctx_opt) =
                        Keeper_execution.load_context_from_checkpoint
                          ~max_checkpoint_messages:m.compaction.max_checkpoint_messages

--- a/test/test_dashboard_keeper_worker_degrade_source.ml
+++ b/test/test_dashboard_keeper_worker_degrade_source.ml
@@ -83,14 +83,24 @@ let test_degraded_row_shape_keeps_dashboard_contract () =
   check_contains "agent field remains present" src "(\"agent\", `Null)";
   check_contains "runtime identity field remains present" src "(\"runtime_id\", runtime_id_json)"
 
-let test_checkpoint_context_max_uses_runtime_budget () =
+let test_context_max_fallback_uses_pure_runtime_budget () =
   let src = load_source target_file in
   check_contains
-    "checkpoint fallback resolves runtime context max"
+    "dashboard context max resolves runtime context budget"
     src
-    "Keeper_turn_runtime_budget.resolved_max_context_for_turn";
+    "Keeper_context_runtime.resolve_max_context_resolution_of_meta m";
+  check_contains
+    "metrics zero context max falls back to runtime budget"
+    src
+    "if raw_context_max > 0 then raw_context_max else primary_max_context";
+  check_contains
+    "missing metrics ratio is recomputed from tokens and runtime budget"
+    src
+    "float_of_int context_tokens /. float_of_int context_max";
   check bool "summary fallback does not hardcode zero context max" false
     (contains ~needle:"let primary_max_context = 0 in" src)
+  ; check bool "dashboard read path avoids turn resolver side effects" false
+      (contains ~needle:"Keeper_turn_runtime_budget.resolved_max_context_for_turn" src)
 
 let () =
   run
@@ -105,8 +115,8 @@ let () =
             `Quick
             test_degraded_row_shape_keeps_dashboard_contract
         ; test_case
-            "checkpoint context max uses runtime budget"
+            "context max fallback uses pure runtime budget"
             `Quick
-            test_checkpoint_context_max_uses_runtime_budget
+            test_context_max_fallback_uses_pure_runtime_budget
         ] )
     ]


### PR DESCRIPTION
## Summary

Follow-up to #21891 adversarial review.

- Backfill dashboard keeper `context_max` from the pure runtime budget even when the latest metrics row exists but reports `context_max <= 0`.
- Recompute a missing/zero context ratio from `context_tokens / context_max` after the backfill.
- Avoid the turn-budget helper in the dashboard read path; use `Keeper_context_runtime.resolve_max_context_resolution_of_meta` directly to avoid turn-only logging side effects.
- Change the keeper rail compact action so safe phases (`Overflowed`, `Paused`, `Compacting`) use `force=false`, while `Running`/`Failing` compaction requires a confirmation before sending `force=true`.

## Root Cause

#21891 fixed the checkpoint fallback path, but it still trusted the latest metrics snapshot whenever one existed. A metrics snapshot with `context_max: 0` prevented the checkpoint fallback from running and could keep rendering `tokens / -`. The compact button also sent `force=true` unconditionally, bypassing the backend phase precondition without a confirmation step.

## Validation

- `pnpm install --offline --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm exec vitest run --config vitest.config.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts --no-file-parallelism --maxWorkers=1` (`17` tests passed)
- `git diff --check`
- `ocamlformat --check lib/dashboard/dashboard_http_keeper.ml test/test_dashboard_keeper_worker_degrade_source.ml`
- Playwright rendered smoke with Browser plugin absent: `http://localhost:5176/dashboard/#keepers?keeper=albini` -> click `지금 compact` -> `Force keeper compact` dialog visible. Screenshot: `/tmp/masc-context-followup-confirm.png`

OCaml targeted build was attempted via `scripts/dune-local.sh build test/test_dashboard_keeper_worker_degrade_source.exe`, but the wrapper refused to start because other bare Dune processes were already running. I did not bypass that guard; CI should cover the OCaml build/test path.