### PR TITLE
fix(keeper): surface passive completion stalls

### DIFF
--- a/dashboard/src/components/fsm-hub-types.ts
+++ b/dashboard/src/components/fsm-hub-types.ts
@@ -398,9 +398,8 @@ export function operatorDispositionLabel(value: string | null | undefined): stri
 }
 
 /** Korean labels for `execution.operator_disposition_reason`. Backend
- *  emits 13 closed-sum values via
- *  `Keeper_execution_receipt.operator_disposition_reason_to_string`
- *  (lib/keeper/keeper_execution_receipt.ml:427-441). Paired with
+ *  emits 15 closed-sum values via
+ *  `Keeper_execution_receipt.operator_disposition_reason_to_string`. Paired with
  *  {!operatorDispositionLabel} at every emit site — same atomic
  *  coverage as the attention_reason / next_human_action pair fixed
  *  by #16355. */
@@ -410,9 +409,12 @@ const OPERATOR_DISPOSITION_REASON_LABELS: Record<string, string> = {
   preflight_config_error: '실행 전 설정 오류',
   degraded_retry: '저하 상태 재시도',
   runtime_fallback: '런타임 폴백',
+  transient_runtime_retry: '일시적 런타임 재시도',
   provider_runtime_error: '런타임 호출 오류',
   internal_error: '내부 오류',
   tool_route_recoverable_failure: '도구 라우팅 복구 가능 실패',
+  completion_contract_unsatisfied: '완료 계약 미충족',
+  turn_budget_exhausted: '턴 예산 소진',
   turn_livelock_blocked: '턴 livelock 차단',
   cancelled: '취소됨',
   phase_skipped: 'phase 건너뜀',

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -142,6 +142,18 @@ let is_auto_recoverable_turn_budget_terminal =
   Keeper_terminal_reason.is_auto_recoverable_turn_budget_terminal
 ;;
 
+let completion_contract_satisfied = function
+  | Contract_satisfied_completion | Contract_satisfied_execution -> true
+  | Contract_unknown
+  | Contract_not_dispatched
+  | Contract_violated
+  | Contract_surface_mismatch
+  | Contract_no_capable_provider
+  | Contract_claim_only_after_owned_task
+  | Contract_needs_execution_progress
+  | Contract_passive_only -> false
+;;
+
 let operator_disposition (receipt : t)
   : operator_disposition_kind * operator_disposition_reason
   =
@@ -246,13 +258,15 @@ let operator_disposition (receipt : t)
     Disp_pass, Reason_turn_budget_exhausted
   | Config_or_auth _
   | Provider_runtime_failure _
+  | Turn_budget_exhausted _
   | Pre_dispatch_success _
   | Other _ ->
     (* Generic fall-through. [Config_or_auth] and
        [Provider_runtime_failure] are caught by the guarded branches above
        (their constructors force [preflight_config_failure] /
-       [provider_runtime_failure] true), so only [Pre_dispatch_success] and
-       [Other] reach here in practice; the first two are listed to keep the
+       [provider_runtime_failure] true), so only [Turn_budget_exhausted],
+       [Pre_dispatch_success], and [Other] reach here in practice;
+       [Config_or_auth] and [Provider_runtime_failure] are listed to keep the
        match exhaustive without a wildcard. *)
     let tool_route_failure =
       List.mem
@@ -276,6 +290,22 @@ let operator_disposition (receipt : t)
       || receipt.runtime_outcome = Runtime_passed_to_next_model
     then Disp_pass_next_model, Reason_runtime_fallback
     else if
+      match terminal_reason with
+      | Keeper_terminal_reason.Turn_budget_exhausted _ -> true
+      | Runtime_exhausted _
+      | Config_or_auth _
+      | Provider_runtime_failure _
+      | Completion_contract_violation _
+      | Turn_livelock _
+      | Internal_error _
+      | Auto_recoverable_budget _
+      | Pre_dispatch_success _
+      | Other _ -> false
+    then
+      if completion_contract_satisfied receipt.completion_contract_result
+      then Disp_pass, Reason_turn_budget_exhausted
+      else Disp_alert_exhausted, Reason_turn_budget_exhausted
+    else if
       receipt.outcome = `Ok
       && receipt.runtime_outcome = Runtime_not_dispatched
       && receipt.completion_contract_result = Contract_not_dispatched
@@ -288,6 +318,7 @@ let operator_disposition (receipt : t)
        | Completion_contract_violation _
        | Turn_livelock _
        | Internal_error _
+       | Turn_budget_exhausted _
        | Auto_recoverable_budget _
        | Other _ -> false)
     then Disp_pass, Reason_healthy

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -93,6 +93,7 @@ type operator_disposition_reason =
   | Reason_provider_runtime_error
   | Reason_internal_error
   | Reason_tool_route_recoverable_failure
+  | Reason_completion_contract_unsatisfied
   | Reason_turn_budget_exhausted
   | Reason_turn_livelock_blocked
   | Reason_cancelled
@@ -109,6 +110,7 @@ let operator_disposition_reason_to_string = function
   | Reason_provider_runtime_error -> "provider_runtime_error"
   | Reason_internal_error -> "internal_error"
   | Reason_tool_route_recoverable_failure -> "tool_route_recoverable_failure"
+  | Reason_completion_contract_unsatisfied -> "completion_contract_unsatisfied"
   | Reason_turn_budget_exhausted -> "turn_budget_exhausted"
   | Reason_turn_livelock_blocked -> "turn_livelock_blocked"
   | Reason_cancelled -> "cancelled"
@@ -152,6 +154,19 @@ let completion_contract_satisfied = function
   | Contract_claim_only_after_owned_task
   | Contract_needs_execution_progress
   | Contract_passive_only -> false
+;;
+
+let completion_contract_unsatisfied = function
+  | Contract_violated
+  | Contract_claim_only_after_owned_task
+  | Contract_needs_execution_progress
+  | Contract_passive_only -> true
+  | Contract_unknown
+  | Contract_not_dispatched
+  | Contract_surface_mismatch
+  | Contract_no_capable_provider
+  | Contract_satisfied_completion
+  | Contract_satisfied_execution -> false
 ;;
 
 let operator_disposition (receipt : t)
@@ -305,6 +320,8 @@ let operator_disposition (receipt : t)
       if completion_contract_satisfied receipt.completion_contract_result
       then Disp_pass, Reason_turn_budget_exhausted
       else Disp_alert_exhausted, Reason_turn_budget_exhausted
+    else if completion_contract_unsatisfied receipt.completion_contract_result
+    then Disp_pause_human, Reason_completion_contract_unsatisfied
     else if
       receipt.outcome = `Ok
       && receipt.runtime_outcome = Runtime_not_dispatched

--- a/lib/keeper/keeper_execution_receipt.mli
+++ b/lib/keeper/keeper_execution_receipt.mli
@@ -250,6 +250,7 @@ type operator_disposition_reason =
   | Reason_provider_runtime_error
   | Reason_internal_error
   | Reason_tool_route_recoverable_failure
+  | Reason_completion_contract_unsatisfied
   | Reason_turn_budget_exhausted
   | Reason_turn_livelock_blocked
   | Reason_cancelled

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -284,7 +284,11 @@ type t =
 let stop_reason_to_string = function
   | Runtime_agent.Completed -> "completed"
   | Runtime_agent.TurnBudgetExhausted { turns_used; limit } ->
-    Printf.sprintf "turn_budget_exhausted:%d/%d" turns_used limit
+    Printf.sprintf
+      "%s:%d/%d"
+      Keeper_terminal_reason.terminal_prefix_turn_budget_exhausted
+      turns_used
+      limit
   | Runtime_agent.MutationBoundaryReached { turns_used; tool_name } ->
     (match tool_name with
      | Some tool -> Printf.sprintf "mutation_boundary:%s:%d" tool turns_used

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -106,6 +106,33 @@ let terminal_reason_from_receipt receipt =
            "completion_contract_unsatisfied")
   | None -> None
 
+let receipt_contract_attention_reason receipt =
+  let completion_contract_result =
+    json_string_opt_member "completion_contract_result" receipt
+    |> Option.map (fun value -> String.lowercase_ascii (String.trim value))
+  in
+  let terminal_reason_code =
+    json_string_opt_member "terminal_reason_code" receipt
+    |> Option.map (fun value -> String.lowercase_ascii (String.trim value))
+  in
+  let turn_budget_exhausted =
+    match terminal_reason_code with
+    | Some code -> String.starts_with ~prefix:"turn_budget_exhausted" code
+    | None -> false
+  in
+  match completion_contract_result with
+  | Some
+      ( ("violated" | "claim_only_after_owned_task" | "needs_execution_progress"
+        | "passive_only")
+        as reason ) ->
+      Some ("completion_contract_result:" ^ reason)
+  | Some
+      ( ("unknown" | "not_dispatched" | "surface_mismatch" | "no_capable_provider")
+        as reason )
+    when turn_budget_exhausted ->
+      Some ("completion_contract_result:" ^ reason)
+  | Some _ | None -> None
+
 (* JSON-deserialization boundary: maps a runtime_blocker_class wire
    string into a typed [Keeper_turn_disposition.t]. The previous
    variant returned a [terminal_reason_code] wire string that the
@@ -311,8 +338,24 @@ let receipt_operator_disposition receipt =
 
 let effective_disposition_fields ~fallback_disposition ~fallback_reason
     latest_receipt =
-  match Option.bind latest_receipt receipt_operator_disposition with
-  | Some (operator_disposition, operator_disposition_reason) ->
+  let contract_attention_reason =
+    Option.bind latest_receipt receipt_contract_attention_reason
+  in
+  match
+    ( contract_attention_reason,
+      Option.bind latest_receipt receipt_operator_disposition )
+  with
+  | Some disposition_reason, Some (operator_disposition, operator_disposition_reason) ->
+      ( "Blocked",
+        disposition_reason,
+        operator_disposition,
+        operator_disposition_reason )
+  | Some disposition_reason, None ->
+      ( "Blocked",
+        disposition_reason,
+        "pause_human",
+        "completion_contract_unsatisfied" )
+  | None, Some (operator_disposition, operator_disposition_reason) ->
       let disposition, disposition_reason =
         display_disposition_of_operator ~operator_disposition
           ~operator_disposition_reason
@@ -321,7 +364,7 @@ let effective_disposition_fields ~fallback_disposition ~fallback_reason
         disposition_reason,
         operator_disposition,
         operator_disposition_reason )
-  | None ->
+  | None, None ->
       let operator_disposition, operator_disposition_reason =
         operator_disposition_of_display ~disposition:fallback_disposition
           ~disposition_reason:fallback_reason

--- a/lib/keeper_runtime/keeper_terminal_reason.ml
+++ b/lib/keeper_runtime/keeper_terminal_reason.ml
@@ -23,6 +23,7 @@
 let terminal_prefix_max_turns_exceeded = "agent_error_max_turns_exceeded"
 let terminal_prefix_execution_timeout = "agent_error_execution_timeout"
 let terminal_prefix_idle_timeout = "agent_error_idle_timeout"
+let terminal_prefix_turn_budget_exhausted = "turn_budget_exhausted"
 
 (* SSOT for the two retry-recoverable transient wire codes inside the
    [api_error_*] / [Provider_runtime_failure] family. These are the wire
@@ -54,6 +55,7 @@ type t =
   | Completion_contract_violation of string
   | Turn_livelock of string
   | Internal_error of string
+  | Turn_budget_exhausted of string
   | Auto_recoverable_budget of string
   | Pre_dispatch_success of string
   | Other of string
@@ -90,6 +92,8 @@ let of_wire wire =
   then Turn_livelock wire
   else if String.equal lowered "internal_error"
   then Internal_error wire
+  else if String.starts_with ~prefix:terminal_prefix_turn_budget_exhausted lowered
+  then Turn_budget_exhausted wire
   else if is_auto_recoverable_turn_budget_terminal lowered
   then Auto_recoverable_budget wire
   else if String.equal lowered "pre_dispatch_success"
@@ -108,6 +112,7 @@ let to_wire = function
   | Completion_contract_violation wire -> wire
   | Turn_livelock wire -> wire
   | Internal_error wire -> wire
+  | Turn_budget_exhausted wire -> wire
   | Auto_recoverable_budget wire -> wire
   | Pre_dispatch_success wire -> wire
   | Other wire -> wire
@@ -141,6 +146,7 @@ let is_transient_provider_runtime_failure = function
   | Completion_contract_violation _
   | Turn_livelock _
   | Internal_error _
+  | Turn_budget_exhausted _
   | Auto_recoverable_budget _
   | Pre_dispatch_success _
   | Other _ -> false

--- a/lib/keeper_runtime/keeper_terminal_reason.mli
+++ b/lib/keeper_runtime/keeper_terminal_reason.mli
@@ -129,6 +129,11 @@ val terminal_prefix_max_turns_exceeded : string
 
 val terminal_prefix_execution_timeout : string
 val terminal_prefix_idle_timeout : string
+val terminal_prefix_turn_budget_exhausted : string
+(** Wire prefix emitted for [Runtime_agent.TurnBudgetExhausted]. This is not
+    part of [is_auto_recoverable_turn_budget_terminal]: it is a completed
+    runtime stop reason, so receipt classification must inspect completion
+    contract evidence before deciding pass vs attention. *)
 
 (** {1 Transient provider-runtime wire codes (SSOT)}
 

--- a/lib/keeper_runtime/keeper_terminal_reason.mli
+++ b/lib/keeper_runtime/keeper_terminal_reason.mli
@@ -79,6 +79,13 @@ type t =
   | Internal_error of string
   (** Exact wire ["internal_error"] (modulo case). Payload is the original
           string, carried only for [to_wire] round-trip fidelity. *)
+  | Turn_budget_exhausted of string
+  (** Wire [String.starts_with ~prefix:"turn_budget_exhausted"], emitted from
+          [Runtime_agent.TurnBudgetExhausted]. Unlike
+          [Auto_recoverable_budget], this is a completed runtime stop reason,
+          so the receipt classifier must inspect completion-contract evidence
+          before deciding whether it is safe to pass. Payload is the original
+          string. *)
   | Auto_recoverable_budget of string
   (** Wire matches one of the turn/time-budget cut-off prefixes
           ([agent_error_max_turns_exceeded] / [agent_error_execution_timeout]

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -336,11 +336,26 @@ let composite_execution_config_drift execution =
 
 let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_activation_readiness_json
 
+let composite_execution_budget_unsatisfied_reason execution =
+  match lower_string_opt (json_string "completion_contract_result" execution) with
+  | Some
+      ( ("unknown" | "violated" | "surface_mismatch" | "no_capable_provider"
+        | "claim_only_after_owned_task" | "needs_execution_progress" | "passive_only")
+        as reason ) -> Some ("completion_contract_result:" ^ reason)
+  | Some _
+  | None -> None
+;;
+
+let composite_execution_turn_budget_exhausted execution =
+  string_opt_has_prefix
+    (json_string "terminal_reason_code" execution)
+    ~prefix:"turn_budget_exhausted"
+;;
+
 let composite_execution_budget_exhausted_pass execution =
   string_opt_is_any (json_string "operator_disposition" execution) [ "pass" ]
-  && string_opt_has_prefix
-       (json_string "terminal_reason_code" execution)
-       ~prefix:"turn_budget_exhausted"
+  && composite_execution_turn_budget_exhausted execution
+  && Option.is_none (composite_execution_budget_unsatisfied_reason execution)
   &&
   match lower_string_opt (json_string "operator_disposition_reason" execution) with
   | None -> true
@@ -454,6 +469,12 @@ let composite_runtime_attention ~snapshot ~execution =
     | Some _ as reason -> reason
     | None when not blocked -> None
     | None ->
+      (match
+       ( composite_execution_turn_budget_exhausted execution,
+         composite_execution_budget_unsatisfied_reason execution )
+       with
+       | true, Some reason -> Some reason
+       | _ ->
       (match json_string "operator_disposition_reason" execution with
        | Some value -> String_util.trim_to_option value
        | _ ->
@@ -462,7 +483,7 @@ let composite_runtime_attention ~snapshot ~execution =
           | _ when needs_attention && composite_execution_config_drift execution ->
             Some "keeper_runtime_override_drift"
           | _ when blocked -> Some "runtime_blocked"
-          | _ -> None))
+          | _ -> None)))
   in
   let reason =
     match execution_reason with

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -336,11 +336,22 @@ let composite_execution_config_drift execution =
 
 let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_activation_readiness_json
 
+let composite_execution_completion_unsatisfied_reason execution =
+  match lower_string_opt (json_string "completion_contract_result" execution) with
+  | Some
+      ( ("violated" | "claim_only_after_owned_task" | "needs_execution_progress"
+        | "passive_only")
+        as reason ) -> Some ("completion_contract_result:" ^ reason)
+  | Some _
+  | None -> None
+;;
+
 let composite_execution_budget_unsatisfied_reason execution =
   match lower_string_opt (json_string "completion_contract_result" execution) with
   | Some
-      ( ("unknown" | "violated" | "surface_mismatch" | "no_capable_provider"
-        | "claim_only_after_owned_task" | "needs_execution_progress" | "passive_only")
+      ( ("unknown" | "not_dispatched" | "violated" | "surface_mismatch"
+        | "no_capable_provider" | "claim_only_after_owned_task" | "needs_execution_progress"
+        | "passive_only")
         as reason ) -> Some ("completion_contract_result:" ^ reason)
   | Some _
   | None -> None
@@ -367,6 +378,7 @@ let composite_execution_budget_exhausted_pass execution =
 let composite_execution_blocked execution =
   composite_execution_claim_no_eligible execution
   || composite_execution_contract_blocked execution
+  || Option.is_some (composite_execution_completion_unsatisfied_reason execution)
   || string_opt_is_any (json_string "operator_disposition" execution) [ "pause_human" ]
   || (match lower_string_opt (json_string "terminal_reason_code" execution) with
       | Some terminal ->
@@ -467,23 +479,26 @@ let composite_runtime_attention ~snapshot ~execution =
     then Some "claim_scope_no_eligible"
     else match composite_execution_contract_blocker_reason execution with
     | Some _ as reason -> reason
-    | None when not blocked -> None
-    | None ->
-      (match
-       ( composite_execution_turn_budget_exhausted execution,
-         composite_execution_budget_unsatisfied_reason execution )
-       with
-       | true, Some reason -> Some reason
-       | _ ->
-      (match json_string "operator_disposition_reason" execution with
-       | Some value -> String_util.trim_to_option value
-       | _ ->
-         (match json_string "terminal_reason_code" execution with
-          | Some value -> String_util.trim_to_option value
-          | _ when needs_attention && composite_execution_config_drift execution ->
-            Some "keeper_runtime_override_drift"
-          | _ when blocked -> Some "runtime_blocked"
-          | _ -> None)))
+    | None -> (
+      match composite_execution_completion_unsatisfied_reason execution with
+      | Some _ as reason -> reason
+      | None when not blocked -> None
+      | None ->
+        (match
+           ( composite_execution_turn_budget_exhausted execution,
+             composite_execution_budget_unsatisfied_reason execution )
+         with
+         | true, Some reason -> Some reason
+         | _ ->
+           (match json_string "operator_disposition_reason" execution with
+            | Some value -> String_util.trim_to_option value
+            | _ ->
+              (match json_string "terminal_reason_code" execution with
+               | Some value -> String_util.trim_to_option value
+               | _ when needs_attention && composite_execution_config_drift execution ->
+                 Some "keeper_runtime_override_drift"
+               | _ when blocked -> Some "runtime_blocked"
+               | _ -> None))))
   in
   let reason =
     match execution_reason with

--- a/test/test_keeper_disposition_budget.ml
+++ b/test/test_keeper_disposition_budget.ml
@@ -37,6 +37,7 @@ let () =
     (fun s -> check ("expected-not-recoverable: " ^ s) (not (pred s)))
     [ "agent_error_token_budget_exceeded:kind=output,used=100,limit=50"
     ; "agent_error_cost_budget_exceeded:spent_usd=1.00,limit_usd=0.50"
+    ; "turn_budget_exhausted:8/8"
     ; "agent_error_guardrail_violation:validator=x"
     ; "agent_error_tripwire_violation:tripwire=y"
     ; "agent_error_idle_detected:consecutive_idle_turns=3"

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -164,6 +164,55 @@ let test_snapshot_uses_receipt_runtime_model_when_decision_absent () =
          (snapshot |> member "execution" |> member "provider_selected_model" |> to_string))
 ;;
 
+let test_budget_not_dispatched_receipt_marks_attention () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       let keeper_name = "runtime-trust-budget-not-dispatched" in
+       let meta = make_meta keeper_name in
+       let receipt_store =
+         Masc.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+       in
+       Dated_jsonl.append
+         receipt_store
+         (`Assoc
+             [ "ended_at", `String "2026-06-01T00:00:00Z"
+             ; "operator_disposition", `String "pass"
+             ; "operator_disposition_reason", `String "healthy"
+             ; "terminal_reason_code", `String "turn_budget_exhausted:8/8"
+             ; "completion_contract_result", `String "not_dispatched"
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       Alcotest.(check string)
+         "display disposition"
+         "Blocked"
+         (snapshot |> member "disposition" |> to_string);
+       Alcotest.(check string)
+         "display reason"
+         "completion_contract_result:not_dispatched"
+         (snapshot |> member "disposition_reason" |> to_string);
+       Alcotest.(check bool)
+         "needs attention"
+         true
+         (snapshot |> member "needs_attention" |> to_bool);
+       Alcotest.(check string)
+         "operator disposition remains receipt truth"
+         "pass"
+         (snapshot |> member "operator_disposition" |> to_string);
+       Alcotest.(check string)
+         "operator disposition reason remains receipt truth"
+         "healthy"
+         (snapshot |> member "operator_disposition_reason" |> to_string))
+;;
+
 let test_model_observability_uses_runtime_trust_selected_model () =
   let runtime_trust =
     `Assoc
@@ -257,6 +306,10 @@ let () =
             "status model observability reuses runtime-trust selected model"
             `Quick
             test_model_observability_uses_runtime_trust_selected_model
+        ; Alcotest.test_case
+            "budget not-dispatched receipt marks runtime-trust attention"
+            `Quick
+            test_budget_not_dispatched_receipt_marks_attention
         ; Alcotest.test_case
             "status model observability reuses runtime-trust execution selected model"
             `Quick

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -166,6 +166,19 @@ let frozen_completion_contract_satisfied = function
   | R.Contract_passive_only -> false
 ;;
 
+let frozen_completion_contract_unsatisfied = function
+  | R.Contract_violated
+  | R.Contract_claim_only_after_owned_task
+  | R.Contract_needs_execution_progress
+  | R.Contract_passive_only -> true
+  | R.Contract_unknown
+  | R.Contract_not_dispatched
+  | R.Contract_surface_mismatch
+  | R.Contract_no_capable_provider
+  | R.Contract_satisfied_completion
+  | R.Contract_satisfied_execution -> false
+;;
+
 let frozen_is_transient_provider_runtime_failure terminal_reason =
   String.equal terminal_reason "api_error_timeout"
   || String.equal terminal_reason "api_error_network"
@@ -263,6 +276,8 @@ let frozen_operator_disposition (receipt : R.t)
       if frozen_completion_contract_satisfied receipt.completion_contract_result
       then R.Disp_pass, R.Reason_turn_budget_exhausted
       else R.Disp_alert_exhausted, R.Reason_turn_budget_exhausted
+    else if frozen_completion_contract_unsatisfied receipt.completion_contract_result
+    then R.Disp_pause_human, R.Reason_completion_contract_unsatisfied
     else if
       receipt.outcome = `Ok
       && receipt.runtime_outcome = R.Runtime_not_dispatched
@@ -503,6 +518,25 @@ let () =
   check
     (Printf.sprintf
        "satisfied turn budget exhaustion want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want)
+;;
+
+let () =
+  let receipt =
+    { base_receipt with
+      terminal_reason_code = "completed"
+    ; outcome = `Ok
+    ; runtime_outcome = R.Runtime_completed
+    ; completion_contract_result = R.Contract_passive_only
+    }
+  in
+  let got = R.operator_disposition receipt in
+  let want = R.Disp_pause_human, R.Reason_completion_contract_unsatisfied in
+  check
+    (Printf.sprintf
+       "completed passive-only receipt want=%s got=%s"
        (disp_pair_to_string want)
        (disp_pair_to_string got))
     (got = want)

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -58,6 +58,7 @@ let roundtrip_corpus =
   ; "agent_error_max_turns_exceeded:turns=8,limit=8"
   ; "agent_error_execution_timeout:elapsed_sec=120.0,timeout_sec=120.0,turn_count=7,max_turns=8"
   ; "agent_error_idle_timeout:idle_sec=120.0,idle_timeout_sec=120.0,turn_count=7,max_turns=8"
+  ; "turn_budget_exhausted:8/8"
     (* genuine Other (preserve-don't-fix) *)
   ; "provider_error_server:500"
   ; "provider_error_missing_api_key"
@@ -141,11 +142,28 @@ let string_contains_ci = String_util.contains_substring_ci
 let frozen_terminal_prefix_max_turns_exceeded = "agent_error_max_turns_exceeded"
 let frozen_terminal_prefix_execution_timeout = "agent_error_execution_timeout"
 let frozen_terminal_prefix_idle_timeout = "agent_error_idle_timeout"
+let frozen_terminal_prefix_turn_budget_exhausted = "turn_budget_exhausted"
 
 let frozen_is_auto_recoverable_turn_budget_terminal terminal_reason =
   String.starts_with ~prefix:frozen_terminal_prefix_max_turns_exceeded terminal_reason
   || String.starts_with ~prefix:frozen_terminal_prefix_execution_timeout terminal_reason
   || String.starts_with ~prefix:frozen_terminal_prefix_idle_timeout terminal_reason
+;;
+
+let frozen_is_turn_budget_exhausted_terminal terminal_reason =
+  String.starts_with ~prefix:frozen_terminal_prefix_turn_budget_exhausted terminal_reason
+;;
+
+let frozen_completion_contract_satisfied = function
+  | R.Contract_satisfied_completion | R.Contract_satisfied_execution -> true
+  | R.Contract_unknown
+  | R.Contract_not_dispatched
+  | R.Contract_violated
+  | R.Contract_surface_mismatch
+  | R.Contract_no_capable_provider
+  | R.Contract_claim_only_after_owned_task
+  | R.Contract_needs_execution_progress
+  | R.Contract_passive_only -> false
 ;;
 
 let frozen_is_transient_provider_runtime_failure terminal_reason =
@@ -240,6 +258,11 @@ let frozen_operator_disposition (receipt : R.t)
       receipt.runtime_fallback_applied
       || receipt.runtime_outcome = R.Runtime_passed_to_next_model
     then R.Disp_pass_next_model, R.Reason_runtime_fallback
+    else if frozen_is_turn_budget_exhausted_terminal terminal_reason
+    then
+      if frozen_completion_contract_satisfied receipt.completion_contract_result
+      then R.Disp_pass, R.Reason_turn_budget_exhausted
+      else R.Disp_alert_exhausted, R.Reason_turn_budget_exhausted
     else if
       receipt.outcome = `Ok
       && receipt.runtime_outcome = R.Runtime_not_dispatched
@@ -343,7 +366,9 @@ let completion_contract_results =
   ; R.Contract_no_capable_provider
   ; R.Contract_surface_mismatch
   ; R.Contract_needs_execution_progress
+  ; R.Contract_passive_only
   ; R.Contract_satisfied_completion
+  ; R.Contract_satisfied_execution
   ]
 
 let outcomes = [ `Ok; `Error; `Cancelled; `Skipped ]
@@ -445,6 +470,39 @@ let () =
   check
     (Printf.sprintf
        "provider timeout marker disposition want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want)
+;;
+
+let () =
+  let code = "turn_budget_exhausted:12704/12704" in
+  let passive_receipt =
+    { base_receipt with
+      terminal_reason_code = code
+    ; outcome = `Ok
+    ; runtime_outcome = R.Runtime_completed
+    ; completion_contract_result = R.Contract_passive_only
+    }
+  in
+  let got = R.operator_disposition passive_receipt in
+  let want = R.Disp_alert_exhausted, R.Reason_turn_budget_exhausted in
+  check
+    (Printf.sprintf
+       "passive turn budget exhaustion want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want);
+  let executed_receipt =
+    { passive_receipt with
+      completion_contract_result = R.Contract_satisfied_execution
+    }
+  in
+  let got = R.operator_disposition executed_receipt in
+  let want = R.Disp_pass, R.Reason_turn_budget_exhausted in
+  check
+    (Printf.sprintf
+       "satisfied turn budget exhaustion want=%s got=%s"
        (disp_pair_to_string want)
        (disp_pair_to_string got))
     (got = want)

--- a/test/test_server_dashboard_composite_attention.ml
+++ b/test/test_server_dashboard_composite_attention.ml
@@ -40,6 +40,20 @@ let completed_budget_execution =
     ]
 ;;
 
+let passive_budget_execution =
+  `Assoc
+    [ "latest_receipt_present", `Bool true
+    ; "recorded_at", `String "2999-01-01T00:00:00Z"
+    ; "completion_contract_result", `String "passive_only"
+    ; "operator_disposition", `String "pass"
+    ; "operator_disposition_reason", `String "healthy"
+    ; "terminal_reason_code", `String "turn_budget_exhausted:1070/1070"
+    ; "error", `Null
+    ; "claim_scope", `Assoc [ "status", `String "ok" ]
+    ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
+    ]
+;;
+
 let test_contract_blocker_marks_attention () =
   let execution = execution "surface_mismatch" in
   let attention =
@@ -100,6 +114,22 @@ let test_completed_budget_exhaustion_is_not_blocked () =
   check (option string) "reason" None attention.cra_reason
 ;;
 
+let test_passive_budget_exhaustion_is_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:passive_budget_execution
+  in
+  check bool "blocked" true attention.cra_blocked;
+  check bool "needs_attention" true attention.cra_needs_attention;
+  check string "state" "blocked" attention.cra_state;
+  check
+    (option string)
+    "reason"
+    (Some "completion_contract_result:passive_only")
+    attention.cra_reason
+;;
+
 let () =
   run
     "server_dashboard_composite_attention"
@@ -113,6 +143,10 @@ let () =
             "pass/healthy turn-budget exhaustion is not blocked"
             `Quick
             test_completed_budget_exhaustion_is_not_blocked
+        ; test_case
+            "passive turn-budget exhaustion is blocked"
+            `Quick
+            test_passive_budget_exhaustion_is_blocked
         ] )
     ]
 ;;

--- a/test/test_server_dashboard_composite_attention.ml
+++ b/test/test_server_dashboard_composite_attention.ml
@@ -54,6 +54,34 @@ let passive_budget_execution =
     ]
 ;;
 
+let completed_passive_execution =
+  `Assoc
+    [ "latest_receipt_present", `Bool true
+    ; "recorded_at", `String "2999-01-01T00:00:00Z"
+    ; "completion_contract_result", `String "passive_only"
+    ; "operator_disposition", `String "pass"
+    ; "operator_disposition_reason", `String "healthy"
+    ; "terminal_reason_code", `String "completed"
+    ; "error", `Null
+    ; "claim_scope", `Assoc [ "status", `String "ok" ]
+    ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
+    ]
+;;
+
+let not_dispatched_budget_execution =
+  `Assoc
+    [ "latest_receipt_present", `Bool true
+    ; "recorded_at", `String "2999-01-01T00:00:00Z"
+    ; "completion_contract_result", `String "not_dispatched"
+    ; "operator_disposition", `String "pass"
+    ; "operator_disposition_reason", `String "healthy"
+    ; "terminal_reason_code", `String "turn_budget_exhausted:1070/1070"
+    ; "error", `Null
+    ; "claim_scope", `Assoc [ "status", `String "ok" ]
+    ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
+    ]
+;;
+
 let test_contract_blocker_marks_attention () =
   let execution = execution "surface_mismatch" in
   let attention =
@@ -130,6 +158,38 @@ let test_passive_budget_exhaustion_is_blocked () =
     attention.cra_reason
 ;;
 
+let test_completed_passive_receipt_is_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:completed_passive_execution
+  in
+  check bool "blocked" true attention.cra_blocked;
+  check bool "needs_attention" true attention.cra_needs_attention;
+  check string "state" "blocked" attention.cra_state;
+  check
+    (option string)
+    "reason"
+    (Some "completion_contract_result:passive_only")
+    attention.cra_reason
+;;
+
+let test_not_dispatched_budget_exhaustion_is_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:not_dispatched_budget_execution
+  in
+  check bool "blocked" true attention.cra_blocked;
+  check bool "needs_attention" true attention.cra_needs_attention;
+  check string "state" "blocked" attention.cra_state;
+  check
+    (option string)
+    "reason"
+    (Some "completion_contract_result:not_dispatched")
+    attention.cra_reason
+;;
+
 let () =
   run
     "server_dashboard_composite_attention"
@@ -147,6 +207,14 @@ let () =
             "passive turn-budget exhaustion is blocked"
             `Quick
             test_passive_budget_exhaustion_is_blocked
+        ; test_case
+            "completed passive receipt is blocked"
+            `Quick
+            test_completed_passive_receipt_is_blocked
+        ; test_case
+            "not-dispatched turn-budget exhaustion is blocked"
+            `Quick
+            test_not_dispatched_budget_exhaustion_is_blocked
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- classify runtime `turn_budget_exhausted:*` terminal codes explicitly instead of letting them fall through to healthy
- mark turn-budget exhaustion as pass only when completion-contract evidence is satisfied execution/completion
- surface `passive_only` / unsatisfied completion-contract receipts as operator attention even when the runtime reports `completed`
- keep persisted stale receipts honest across runtime-trust, composite attention, and dashboard reason labels

## Root cause
Live `issue_king` receipts showed `completion_contract_result=passive_only` with both `completed` and `turn_budget_exhausted:*` terminal reasons. The receipt classifier and dashboard trust layers treated `Ok + Runtime_completed` or persisted `pass/healthy` as healthy without checking completion-contract evidence, hiding a real passive loop behind an OK dashboard state.

## Tests
- `ocamlformat --check lib/keeper_runtime/keeper_terminal_reason.ml lib/keeper_runtime/keeper_terminal_reason.mli lib/keeper/keeper_execution_receipt.ml lib/server/server_dashboard_http_composite_claims.ml test/test_keeper_terminal_reason_typed.ml test/test_keeper_disposition_budget.ml test/test_server_dashboard_composite_attention.ml`
- `scripts/dune-local.sh build test/test_keeper_terminal_reason_typed.exe test/test_keeper_disposition_budget.exe test/test_server_dashboard_composite_attention.exe test/test_keeper_runtime_trust_snapshot.exe`
- `./_build/default/test/test_keeper_terminal_reason_typed.exe`
- `./_build/default/test/test_keeper_disposition_budget.exe`
- `./_build/default/test/test_server_dashboard_composite_attention.exe`
- `./_build/default/test/test_keeper_runtime_trust_snapshot.exe`

## Not run
- `pnpm --dir dashboard typecheck` (worktree has no `node_modules`; CI dashboard job will cover this)
