### PR TITLE
fix(dashboard): repair client websocket reconnect

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -253,13 +253,37 @@ let respond_ws_upgrade_unavailable ?(message = "websocket transport disabled") r
   let response = Httpun.Response.create ~headers `Service_unavailable in
   safe_reqd_respond reqd response body
 
+let respond_ws_upgrade_bad_request message reqd =
+  let body =
+    Yojson.Safe.to_string (`Assoc [ ("error", `String message) ])
+  in
+  let headers =
+    Httpun.Headers.of_list
+      [ ("content-type", "application/json")
+      ; ("content-length", string_of_int (String.length body))
+      ]
+  in
+  let response = Httpun.Response.create ~headers `Bad_request in
+  safe_reqd_respond reqd response body
+
 let handle_websocket_upgrade reqd =
   if not (Transport_metrics.ws_enabled ())
   then respond_ws_upgrade_unavailable reqd
-  else
+  else if not (Transport_metrics.ws_same_origin_ready ())
+  then
     respond_ws_upgrade_unavailable
-      ~message:"same-origin websocket upgrade is disabled; use /ws discovery ws_url"
+      ~message:"WebSocket transport not ready"
       reqd
+  else
+    match
+      Server_mcp_transport_ws.upgrade_connection
+        ?sw:(Eio_context.get_switch_opt ())
+        ?clock:(Eio_context.get_clock_opt ())
+        ~on_message:Server_mcp_transport_ws.dispatch_inbound_message
+        reqd
+    with
+    | Ok () -> ()
+    | Error msg -> respond_ws_upgrade_bad_request msg reqd
 
 (** Method/path dispatcher for MCP-validated requests. Caller is
     responsible for rate limiting and origin/protocol-version checks

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -2,9 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, SideRail, summarizeAttentionPreview } from './dashboard-shell'
+import { ConnectionStatus, DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, SideRail, summarizeAttentionPreview } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
+import { dashboardWsConnected, dashboardWsLastError, dashboardWsReady, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
 import { dashboardLoading } from '../store'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
 
@@ -73,6 +74,50 @@ describe('DashboardMain primary heading', () => {
         .toEqual(['운영 개요'])
     }, { timeout: 5000 })
     expect(container.querySelector('.v2-surface-header h1')).toBeNull()
+  })
+})
+
+describe('ConnectionStatus', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    connected.value = false
+    dashboardWsConnected.value = false
+    dashboardWsReady.value = false
+    dashboardWsSseFallbackActive.value = false
+    dashboardWsLastError.value = null
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    connected.value = false
+    dashboardWsConnected.value = false
+    dashboardWsReady.value = false
+    dashboardWsSseFallbackActive.value = false
+    dashboardWsLastError.value = null
+  })
+
+  it('uses WS readiness instead of the legacy SSE connected signal in WS-only mode', () => {
+    dashboardWsConnected.value = true
+    dashboardWsReady.value = true
+
+    render(h(ConnectionStatus, {}), container)
+
+    expect(container.textContent).toContain('Connected')
+    expect(container.textContent).not.toContain('Reconnecting')
+  })
+
+  it('shows handshaking instead of reconnecting while the WS hello is pending', () => {
+    dashboardWsConnected.value = true
+    dashboardWsReady.value = false
+
+    render(h(ConnectionStatus, {}), container)
+
+    expect(container.textContent).toContain('Connecting WS')
+    expect(container.textContent).not.toContain('Reconnecting')
   })
 })
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -9,7 +9,7 @@ import { fetchDashboardRuntimeProbe } from '../api/dashboard'
 import { route } from '../router'
 import { connected, reconnectCount, lastDisconnectedAt } from '../sse'
 import { dashboardWsOnlyEnabled } from '../dashboard-ws-cutover'
-import { dashboardWsConnected, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
+import { dashboardWsConnected, dashboardWsLastError, dashboardWsReady, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
 import { isKeeperPaused } from '../lib/keeper-predicates'
 import { dashboardLoading, executionError, keepers, serverStatus, shellCounts, shellRuntimeResolution, tasksByStatus } from '../store'
 import { missionSnapshot, missionLoading } from '../mission-signals'
@@ -120,33 +120,69 @@ function describeReconnecting(args: {
 
 export function ConnectionStatus() {
   const wsOnly = dashboardWsOnlyEnabled()
-  const isConnected = wsOnly
-    ? dashboardWsConnected.value || dashboardWsSseFallbackActive.value
-    : connected.value
   const reconn = reconnectCount.value
-
-  const statusLabel = isConnected
-    ? reconn > 0 ? 'Reconnected' : 'Connected'
-    : describeReconnecting({
-        disconnectedAt: lastDisconnectedAt.value,
-        now: Date.now(),
-        reconnects: reconn,
-      }).label
-  const titleAttr = isConnected
-    ? reconn > 0 ? `Reconnect attempts ${reconn}` : ''
-    : describeReconnecting({
-        disconnectedAt: lastDisconnectedAt.value,
-        now: Date.now(),
-        reconnects: reconn,
-      }).title
+  const reconnecting = describeReconnecting({
+    disconnectedAt: lastDisconnectedAt.value,
+    now: Date.now(),
+    reconnects: reconn,
+  })
+  const status = (() => {
+    if (wsOnly) {
+      if (dashboardWsReady.value) {
+        return {
+          tone: 'ok' as const,
+          label: reconn > 0 ? 'Reconnected' : 'Connected',
+          title: reconn > 0 ? `Reconnect attempts ${reconn}` : '',
+        }
+      }
+      if (dashboardWsSseFallbackActive.value) {
+        return {
+          tone: 'warn' as const,
+          label: 'SSE fallback',
+          title: dashboardWsLastError.value
+            ? `Client WS degraded: ${dashboardWsLastError.value}`
+            : 'Client WS degraded; SSE fallback is carrying events.',
+        }
+      }
+      if (dashboardWsConnected.value) {
+        return {
+          tone: 'warn' as const,
+          label: 'Connecting WS',
+          title: 'Client WS socket is open; waiting for dashboard/hello.',
+        }
+      }
+    } else if (connected.value) {
+      return {
+        tone: 'ok' as const,
+        label: reconn > 0 ? 'Reconnected' : 'Connected',
+        title: reconn > 0 ? `Reconnect attempts ${reconn}` : '',
+      }
+    }
+    return {
+      tone: 'err' as const,
+      label: reconnecting.label,
+      title: reconnecting.title,
+    }
+  })()
+  const isConnected = status.tone === 'ok'
+  const textClass = status.tone === 'warn'
+    ? 'text-[var(--color-status-warn)]'
+    : isConnected
+      ? 'text-[var(--color-status-ok)]'
+      : 'text-[var(--color-status-err)]'
+  const dotClass = status.tone === 'warn'
+    ? 'bg-[var(--color-status-warn)]'
+    : isConnected
+      ? 'bg-[var(--color-status-ok)] shadow-[0_0_7px_rgb(var(--ok-glow)/0.75)]'
+      : 'bg-[var(--color-status-err)]'
 
   return html`
     <div
-      class="v2-shell-panel flex items-center gap-1.5 whitespace-nowrap text-xs ${isConnected ? 'text-[var(--color-status-ok)]' : 'text-[var(--color-status-err)]'}"
-      title=${titleAttr || undefined}
+      class="v2-shell-panel flex items-center gap-1.5 whitespace-nowrap text-xs ${textClass}"
+      title=${status.title || undefined}
     >
-      <span class="inline-block size-[8px] rounded-[var(--r-0)] ${isConnected ? 'bg-[var(--color-status-ok)] shadow-[0_0_7px_rgb(var(--ok-glow)/0.75)]' : 'bg-[var(--color-status-err)]'}"></span>
-      <span class="status-text">${statusLabel}</span>
+      <span class="inline-block size-[8px] rounded-[var(--r-0)] ${dotClass}"></span>
+      <span class="status-text">${status.label}</span>
     </div>
   `
 }

--- a/dashboard/src/components/status-tray.test.ts
+++ b/dashboard/src/components/status-tray.test.ts
@@ -87,6 +87,32 @@ describe('summarizeStatusTray', () => {
     expect(summary.items.transport.detail).toContain('dashboard/ping')
   })
 
+  it('marks WS-only transport as handshaking when the socket is open but hello is not ready', () => {
+    const summary = summarizeStatusTray({
+      wsOnly: true,
+      sseConnected: false,
+      wsConnected: true,
+      wsReady: false,
+      wsLastEventAt: 0,
+      wsEventCount60s: 0,
+      wsLastPongAt: 0,
+      wsLastPongLatencyMs: null,
+      wsLastError: null,
+      reconnectCount: 0,
+      lastDisconnectedAt: 0,
+      keepers: [],
+      staleKeeperNames: new Set(),
+      tasks: [],
+      journalEntries: [],
+      unacknowledgedErrors: 0,
+      now: NOW,
+    })
+
+    expect(summary.items.transport.tone).toBe('warn')
+    expect(summary.items.transport.value).toBe('handshake')
+    expect(summary.items.transport.detail).toContain('dashboard/hello')
+  })
+
   it('rolls stale keeper, verification, and error counts into tray items', () => {
     const summary = summarizeStatusTray({
       wsOnly: false,

--- a/dashboard/src/components/status-tray.ts
+++ b/dashboard/src/components/status-tray.ts
@@ -182,6 +182,15 @@ function computeTransportItem(input: TransportInput): StatusTrayItem {
             : 'client WS degraded; SSE fallback is live',
         }
       }
+      if (input.wsConnected && !input.wsReady) {
+        return {
+          key: 'transport',
+          tone: 'warn',
+          label: 'Client',
+          value: 'handshake',
+          detail: 'client WS socket is open; waiting for dashboard/hello before route events resume',
+        }
+      }
       return {
         key: 'transport',
         tone: 'err',

--- a/dashboard/src/components/transport-beacon.test.ts
+++ b/dashboard/src/components/transport-beacon.test.ts
@@ -49,11 +49,12 @@ describe('computeBeaconView', () => {
     expect(view.title).toContain('dashboard/ping')
   })
 
-  it('returns red when wsOnly, socket connected but handshake not ready', () => {
+  it('returns yellow when wsOnly, socket connected but handshake not ready', () => {
     const view = computeBeaconView(beaconInput({
       ready: false,
     }))
-    expect(view.state).toBe('red')
+    expect(view.state).toBe('yellow')
+    expect(view.label).toBe('Client WS · handshaking')
   })
 
   it('returns yellow when wsOnly, ready, but no event has ever arrived', () => {

--- a/dashboard/src/components/transport-beacon.ts
+++ b/dashboard/src/components/transport-beacon.ts
@@ -70,6 +70,13 @@ export function computeBeaconView(args: {
           : 'Client WS is degraded; SSE fallback is carrying events.',
       }
     }
+    if (args.connected && !args.ready) {
+      return {
+        state: 'yellow',
+        label: 'Client WS · handshaking',
+        title: 'Client WS socket is open; waiting for dashboard/hello before route events resume.',
+      }
+    }
     return {
       state: 'red',
       label: 'Client WS · disconnected',

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -18,7 +18,6 @@ import {
 import { parseWebSocketSseFrames } from './dashboard-ws-parse'
 import { clearStoredToken, setStoredToken } from './api/core'
 import {
-  DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES,
   DASHBOARD_WS_HEARTBEAT_INTERVAL_MS,
   DASHBOARD_WS_HEARTBEAT_RPC_TIMEOUT_MS,
   DASHBOARD_WS_RPC_TIMEOUT_MS,
@@ -107,11 +106,15 @@ function installControlledDiscovery(): Array<(response: Response) => void> {
   return resolvers
 }
 
-function wsDiscoveryResponse(wsUrl = 'ws://localhost:3000/ws'): Response {
+function wsDiscoveryResponse(
+  wsUrl: string | null = 'ws://localhost:3000/ws',
+  overrides: Record<string, unknown> = {},
+): Response {
   return new Response(JSON.stringify({
     enabled: true,
     listening: true,
     ws_url: wsUrl,
+    ...overrides,
   }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
@@ -417,6 +420,49 @@ describe('dashboard websocket route subscriptions', () => {
     expect(mockSockets).toHaveLength(1)
   })
 
+  it('prefers the current page origin when same-origin upgrade is advertised', async () => {
+    mockSockets.length = 0
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal('fetch', vi.fn(async () => wsDiscoveryResponse('ws://127.0.0.1:5173/ws', {
+      same_origin_upgrade_enabled: true,
+      same_origin_upgrade_path: '/ws',
+      same_origin_ws_url: 'ws://127.0.0.1:5173/ws',
+    })))
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+
+    expect(mockSockets).toHaveLength(1)
+    expect(mockSockets[0]!.url).toBe('ws://localhost:3000/ws')
+  })
+
+  it('derives the current-origin upgrade URL from same_origin_ws_url when the path is omitted', async () => {
+    mockSockets.length = 0
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal('fetch', vi.fn(async () => wsDiscoveryResponse('ws://127.0.0.1:5173/ws', {
+      same_origin_upgrade_enabled: true,
+      same_origin_ws_url: 'ws://127.0.0.1:5173/ws?transport=dashboard',
+    })))
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+
+    expect(mockSockets).toHaveLength(1)
+    expect(mockSockets[0]!.url).toBe('ws://localhost:3000/ws?transport=dashboard')
+  })
+
+  it('falls back to the advertised websocket URL when same-origin upgrade is disabled', async () => {
+    mockSockets.length = 0
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.stubGlobal('fetch', vi.fn(async () => wsDiscoveryResponse('ws://127.0.0.1:8937/', {
+      same_origin_upgrade_enabled: false,
+      same_origin_ws_url: 'ws://localhost:3000/ws',
+    })))
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+
+    expect(mockSockets).toHaveLength(1)
+    expect(mockSockets[0]!.url).toBe('ws://127.0.0.1:8937/')
+  })
+
   it('retries discovery when the server withholds ws_url for this host', async () => {
     vi.useFakeTimers()
     mockSockets.length = 0
@@ -531,7 +577,7 @@ describe('dashboard websocket route subscriptions', () => {
     expect(mockSockets[0]!.url).toBe('ws://localhost:3000/ws')
   })
 
-  it('invalidates cached discovery after repeated failures before it is ready', async () => {
+  it('does not cache websocket discovery before hello succeeds', async () => {
     vi.useFakeTimers()
     mockSockets.length = 0
     vi.stubGlobal('WebSocket', MockWebSocket)
@@ -545,23 +591,13 @@ describe('dashboard websocket route subscriptions', () => {
     expect(staleSocket.url).toBe('ws://localhost:3000/ws?stale')
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
-    // The cache is only invalidated after a threshold of consecutive failures,
-    // so the first reconnects still reuse the cached stale URL.
-    for (let i = 0; i < DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES - 1; i += 1) {
-      mockSockets[mockSockets.length - 1]!.close({ code: 1006, reason: 'connect failed', wasClean: false })
-      await vi.advanceTimersByTimeAsync(60_000)
-      await flushPromises()
-      expect(fetchMock).toHaveBeenCalledTimes(1)
-    }
-
-    // The threshold failure clears the cache and falls back to /ws discovery.
-    mockSockets[mockSockets.length - 1]!.close({ code: 1006, reason: 'connect failed', wasClean: false })
+    staleSocket.close({ code: 1006, reason: 'connect failed', wasClean: false })
     await vi.advanceTimersByTimeAsync(60_000)
     await flushPromises()
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(mockSockets).toHaveLength(1 + DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES)
-    expect(mockSockets[DASHBOARD_WS_DISCOVERY_CACHE_MAX_FAILURES]!.url).toBe('ws://localhost:3000/ws?fresh')
+    expect(mockSockets).toHaveLength(2)
+    expect(mockSockets[1]!.url).toBe('ws://localhost:3000/ws?fresh')
   })
 
   it('stops reconnecting after a fatal policy violation close', async () => {
@@ -654,6 +690,7 @@ describe('dashboard websocket route subscriptions', () => {
 
     setStoredToken('fresh-token', { source: 'dev', actor: 'dashboard' })
     await flushPromises()
+    await flushPromises()
 
     expect(mockSockets).toHaveLength(2)
     const retry = mockSockets[1]!
@@ -675,6 +712,7 @@ describe('dashboard websocket route subscriptions', () => {
     expect(staleHello.params.token).toBe('stale-token')
 
     setStoredToken('fresh-token', { source: 'manual' })
+    await flushPromises()
     await flushPromises()
 
     expect(staleSocket.readyState).toBe(MockWebSocket.CLOSED)

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -96,6 +96,50 @@ function sameOriginWebSocketUrl(wsUrl: string): boolean {
   }
 }
 
+function currentOriginWebSocketUrl(pathOrUrl: string): string | null {
+  if (typeof window === 'undefined' || typeof window.location === 'undefined') return null
+  if (window.location.protocol !== 'https:' && window.location.protocol !== 'http:') return null
+  try {
+    const parsed = new URL(pathOrUrl, window.location.href)
+    parsed.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    parsed.host = window.location.host
+    return parsed.toString()
+  } catch {
+    return null
+  }
+}
+
+function sameOriginUpgradePath(data: DashboardWsDiscovery): string | null {
+  const upgradePath = nonBlankString(data.same_origin_upgrade_path)
+  if (upgradePath) return upgradePath
+  const sameOriginWsUrl = nonBlankString(data.same_origin_ws_url)
+  if (!sameOriginWsUrl) return null
+  try {
+    const baseUrl = typeof window !== 'undefined' && typeof window.location !== 'undefined'
+      ? window.location.href
+      : 'http://localhost/'
+    const parsed = new URL(sameOriginWsUrl, baseUrl)
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch {
+    return null
+  }
+}
+
+function preferredDiscoveredWsUrl(data: DashboardWsDiscovery): string | null {
+  if (data.same_origin_upgrade_enabled === true) {
+    const upgradePath = sameOriginUpgradePath(data)
+    if (upgradePath) {
+      const wsUrl = currentOriginWebSocketUrl(upgradePath)
+      if (wsUrl) return wsUrl
+    }
+  }
+  const wsUrl = nonBlankString(data.ws_url)
+  if (wsUrl) return wsUrl
+  const sameOriginWsUrl = nonBlankString(data.same_origin_ws_url)
+  if (sameOriginWsUrl && sameOriginWebSocketUrl(sameOriginWsUrl)) return sameOriginWsUrl
+  return null
+}
+
 function readCachedWsUrl(): string | null {
   const storage = sessionStorageOrNull()
   if (!storage) return null
@@ -180,6 +224,9 @@ function discoveryUnavailableReason(data: DashboardWsDiscovery): string {
     const sameOriginWsUrl = nonBlankString(data.same_origin_ws_url)
     if (sameOriginWsUrl && data.same_origin_upgrade_enabled !== true) {
       return 'standalone websocket URL unavailable; same-origin upgrade disabled'
+    }
+    if (data.same_origin_upgrade_enabled === true) {
+      return 'same-origin websocket URL unavailable'
     }
     return 'websocket URL unavailable'
   }
@@ -425,7 +472,7 @@ async function discoverWsUrl(): Promise<DashboardWsDiscoveryResult> {
       reason: discoveryUnavailableReason(data),
     }
   }
-  const wsUrl = nonBlankString(data.ws_url)
+  const wsUrl = preferredDiscoveredWsUrl(data)
   if (data.listening !== true || !wsUrl) {
     return {
       wsUrl: null,
@@ -707,11 +754,8 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
   try {
     ws = new WebSocket(wsUrl)
   } catch (err) {
-    // Cache only values that constructed successfully: writing before
-    // [new WebSocket(...)] would persist a malformed/incompatible URL
-    // through the next reconnect, adding an extra failure+backoff cycle
-    // before discovery is retried. Also invalidate the cache after repeated
-    // construction failures so a stale entry does not survive.
+    // A constructor failure proves this URL is unusable for the current
+    // browser. Keep it out of the cache and let reconnect rediscover.
     maybeInvalidateDiscoveryCache()
     batch(() => {
       dashboardWsLastError.value = errorToString(err)
@@ -720,11 +764,6 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     return
   }
   socket = ws
-  // Cache the URL only after the WebSocket constructor accepted it.
-  // Persisting before construction would leave a bad value in the cache
-  // for the next reconnect attempt; persisting after means cache only
-  // ever holds URLs that at minimum parsed without throwing.
-  if (!discovery.fromCache) writeCachedWsUrl(wsUrl)
   ws.onopen = () => {
     if (socket !== ws) return
     dashboardWsConnected.value = true
@@ -737,6 +776,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     })
       .then(() => {
         if (socket !== ws) return
+        if (!discovery.fromCache) writeCachedWsUrl(wsUrl)
         resetDiscoveryCacheFailures()
         batch(() => {
           dashboardWsReady.value = true

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -125,7 +125,7 @@ export default defineConfig(({ command }) => {
             '/api': proxyTarget,
             '/mcp': { target: proxyTarget },
             '/sse': { target: proxyTarget },
-            '/ws': { target: proxyTarget },
+            '/ws': { target: proxyTarget, ws: true },
             '/yjs': { target: proxyTarget, ws: true },
           },
         }


### PR DESCRIPTION
## Summary
- Wire main_eio /ws upgrade requests to the real same-origin WebSocket transport instead of the stale 503 stub.
- Prefer the browser's current origin when /ws discovery advertises same-origin upgrade, and cache discovery only after dashboard/hello succeeds.
- Fix WS-only dashboard status chips so handshaking/ready/fallback states do not reuse the legacy SSE reconnect signal.
- Enable Vite /ws WebSocket proxying for local dashboard dev.

## Verification
- env NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/dashboard-ws.test.ts src/components/transport-beacon.test.ts src/components/status-tray.test.ts src/components/dashboard-shell.test.ts
- env NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit
- env NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/eslint src/dashboard-ws.ts src/components/transport-beacon.ts src/components/status-tray.ts src/components/dashboard-shell.ts
- ocamlformat --check bin/main_eio.ml
- git diff --check

## Evidence boundary
- Local Dune build was intentionally not run; CI should build OCaml.
- Current live runtime still runs the old binary and returns 503 for direct /ws upgrade: same-origin websocket upgrade is disabled; use /ws discovery ws_url. This PR fixes the source path that must be rebuilt/redeployed.