### PR TITLE
fix(dashboard): link chat board post references

### DIFF
--- a/dashboard/src/components/chat/chat-linkify.ts
+++ b/dashboard/src/components/chat/chat-linkify.ts
@@ -1,0 +1,36 @@
+const URL_RE = /(^|[\s(>])(https?:\/\/[^\s<)]+[^\s<).,!?:;])/g
+const BOARD_POST_ID_RE = /(^|[\s([{"'`>])(p-[a-f0-9]{32})(?=$|[\s)\].,!?:;}"'`<])/gi
+const ANCHOR_RE = /(<a\b[\s\S]*?<\/a>)/gi
+const HTML_TAG_RE = /(<[^>]+>)/g
+
+function boardPostHref(postId: string): string {
+  return `#board?post=${encodeURIComponent(postId)}`
+}
+
+function linkifyTextSegment(raw: string): string {
+  return raw
+    .replace(
+      BOARD_POST_ID_RE,
+      (_match, prefix: string, postId: string) =>
+        `${prefix}<a class="inline-link" href="${boardPostHref(postId)}" title="보드 게시글 열기">${postId}</a>`,
+    )
+    .replace(
+      URL_RE,
+      '$1<a class="inline-link" href="$2" target="_blank" rel="noopener noreferrer">$2</a>',
+    )
+}
+
+/** Linkify plain URLs and MASC board post ids without touching existing tags. */
+export function linkifyHtmlReferences(raw: string): string {
+  if (!raw || (!raw.includes('http') && !/\bp-[a-f0-9]{32}\b/i.test(raw))) return raw
+  return raw
+    .split(ANCHOR_RE)
+    .map((anchorPart) => {
+      if (/^<a\b/i.test(anchorPart)) return anchorPart
+      return anchorPart
+        .split(HTML_TAG_RE)
+        .map((part, i) => (i % 2 === 1 ? part : linkifyTextSegment(part)))
+        .join('')
+    })
+    .join('')
+}

--- a/dashboard/src/components/chat/markdown-blocks.test.ts
+++ b/dashboard/src/components/chat/markdown-blocks.test.ts
@@ -176,6 +176,15 @@ describe('parseMarkdownToBlocks', () => {
     expect((blocks[0] as Extract<ChatBlock, { t: 'p' }>).html).toContain('<a')
   })
 
+  it('links generated board post ids to the board detail route', () => {
+    const postId = 'p-59e2917e15de5367e81b2244a8f5095a'
+    const blocks = parseMarkdownToBlocks(`올렸다. 보드에 ${postId}.`)
+    expect(blocks).toHaveLength(1)
+    const html = (blocks[0] as Extract<ChatBlock, { t: 'p' }>).html
+    expect(html).toContain(`href="#board?post=${postId}"`)
+    expect(html).toContain('title="보드 게시글 열기"')
+  })
+
   // Per-line superset: a soft-wrapped paragraph (single newlines, no blank line)
   // that interleaves prose with a standalone-URL line must still yield the card,
   // matching the line-based parser the render path supersedes.

--- a/dashboard/src/components/chat/markdown-blocks.ts
+++ b/dashboard/src/components/chat/markdown-blocks.ts
@@ -1,6 +1,7 @@
 import { marked, type Token, type Tokens } from 'marked'
 import { sanitizeHtml as purifyHtml } from '../../lib/dompurify'
 import type { ChatBlock, ChatCalloutSeverity, ChatTableCellValue } from '../../types'
+import { linkifyHtmlReferences } from './chat-linkify'
 
 function escapeHtml(raw: string): string {
   return raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
@@ -37,20 +38,6 @@ function standaloneUrlBlock(text: string): ChatBlock | null {
   return { t: 'link', url: trimmed, title: hostnameTitle(trimmed), meta: hostnameTitle(trimmed) }
 }
 
-/** Linkify plain URLs without touching existing HTML tags. */
-function linkifyHtml(raw: string): string {
-  if (!raw || raw.indexOf('http') === -1) return raw
-  const linkRe = /(^|[\s(>])(https?:\/\/[^\s<)]+[^\s<).,!?:;])/g
-  return raw
-    .split(/(<[^>]+>)/g)
-    .map((part, i) =>
-      i % 2 === 1
-        ? part
-        : part.replace(linkRe, '$1<a class="inline-link" href="$2" target="_blank" rel="noopener noreferrer">$2</a>'),
-    )
-    .join('')
-}
-
 function sanitizeHtml(raw: string): string {
   return purifyHtml(raw)
 }
@@ -59,7 +46,7 @@ function inlineHtml(raw: string): string {
   const trimmed = raw.trim()
   if (!trimmed) return ''
   const parsed = marked.parseInline(trimmed) as string
-  return sanitizeHtml(linkifyHtml(parsed))
+  return sanitizeHtml(linkifyHtmlReferences(parsed))
 }
 
 function cellValue(raw: string): ChatTableCellValue {
@@ -89,11 +76,11 @@ function parseBlockquote(token: Tokens.Blockquote): ChatBlock {
     .replace(/^<blockquote>\s*/i, '')
     .replace(/<\/blockquote>\s*$/i, '')
     .trim()
-  return { t: 'callout', severity, html: sanitizeHtml(linkifyHtml(body)) }
+  return { t: 'callout', severity, html: sanitizeHtml(linkifyHtmlReferences(body)) }
 }
 
 function parseList(token: Tokens.List): ChatBlock {
-  const items = token.items.map((item) => sanitizeHtml(linkifyHtml(marked.parseInline(item.text) as string)))
+  const items = token.items.map((item) => sanitizeHtml(linkifyHtmlReferences(marked.parseInline(item.text) as string)))
   return { t: 'ul', items }
 }
 
@@ -218,7 +205,7 @@ function parseHtml(token: Tokens.HTML): ChatBlock | null {
     return { t: 'svg', svg: trimmed, cap: undefined }
   }
   // Treat other top-level HTML as a paragraph after sanitization.
-  const html = sanitizeHtml(linkifyHtml(trimmed)).trim()
+  const html = sanitizeHtml(linkifyHtmlReferences(trimmed)).trim()
   return html ? { t: 'p', html } : null
 }
 

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1786,6 +1786,30 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     expect(think.querySelector('script')).toBeNull()
   })
 
+  it('renders board post ids in assistant prose as board detail links', () => {
+    const postId = 'p-59e2917e15de5367e81b2244a8f5095a'
+    render(
+      html`<${ChatTranscript}
+        entries=${[
+          entry({
+            id: 'a-board-link',
+            text: `올렸다. 보드에 ${postId}.`,
+            role: 'assistant',
+            source: 'direct_assistant',
+          }),
+        ]}
+        emptyText="empty"
+        variant="messenger"
+      />`,
+      container,
+    )
+
+    const link = container.querySelector(`a[href="#board?post=${postId}"]`) as HTMLAnchorElement | null
+    expect(link).not.toBeNull()
+    expect(link?.textContent).toBe(postId)
+    expect(link?.getAttribute('title')).toBe('보드 게시글 열기')
+  })
+
   it('keeps the flat per-row tool bubbles when grouping is off (default)', () => {
     render(
       html`<${ChatTranscript}

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -7,6 +7,7 @@ import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'pr
 import { ringFocusClasses } from '../common/ring'
 import { collectAttachments } from './attachments'
 import { parseMarkdownToBlocks } from './markdown-blocks'
+import { linkifyHtmlReferences } from './chat-linkify'
 import { showToast } from '../common/toast'
 import { copyToClipboard } from '../common/copyable-code'
 import { useVoiceInput } from './voice-input'
@@ -453,14 +454,6 @@ function ChatArtifactPreview({
 
 // --- Keeper v2 rich block helpers -------------------------------------------------
 
-function linkifyHtml(raw: string): string {
-  if (!raw || raw.indexOf('http') === -1 || raw.indexOf('<a ') !== -1) return raw
-  return raw.replace(
-    /(^|[\s(>])(https?:\/\/[^\s<)]+[^\s<).,!?:;])/g,
-    '$1<a class="inline-link" href="$2" target="_blank" rel="noopener noreferrer">$2</a>',
-  )
-}
-
 function sanitizeHtml(raw: string): string {
   return purifyHtml(raw)
 }
@@ -470,7 +463,7 @@ function sanitizeSvg(raw: string): string {
 }
 
 function renderInlineHtml(raw: string): { __html: string } {
-  return { __html: sanitizeHtml(linkifyHtml(raw)) }
+  return { __html: sanitizeHtml(linkifyHtmlReferences(raw)) }
 }
 
 // Trace-step thinking text: render through the same sanitized markdown path the


### PR DESCRIPTION
Summary:
- Auto-link generated MASC board post ids in dashboard chat prose to the board detail route.
- Share linkification between markdown blocks and inline transcript rendering so assistant text and rich blocks behave consistently.

Validation:
- pnpm exec vitest run --config vitest.config.ts src/components/chat/markdown-blocks.test.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1
- pnpm exec tsc --noEmit --pretty false
- pnpm exec eslint src/components/chat/chat-linkify.ts src/components/chat/markdown-blocks.ts src/components/chat/primitives.ts src/components/chat/markdown-blocks.test.ts src/components/chat/primitives.test.ts