### PR TITLE
fix(dashboard): retarget keeper density to live classes — chat + rail + roster (keeper-v2 fidelity, visually verified)

### DIFF
--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -81,6 +81,14 @@
 .v2-app[data-density="spacious"] .chat-bubble      { padding: 17px 21px; line-height: 1.7; }
 .v2-app[data-density="spacious"] .kw-composer-inner { padding: 16px 30px 22px; }
 .v2-app[data-density="spacious"] .kw-kp-row        { padding: 11px 11px; }
+/* Context rail + roster (design `.ctx-scroll`/`.ctx-card`/`.tps-card`/`.roster-*`
+   -> live `.kw-rail-scroll`/`.kw-sec`/`.kw-roster-*`). `.kw-sec` is scoped under
+   `.kw-rail` (context cards only). Verified on the running dashboard. */
+.v2-app[data-density="spacious"] .kw-rail-scroll   { padding: 20px; gap: 22px; }
+.v2-app[data-density="spacious"] .kw-rail .kw-sec  { padding: 14px 15px; }
+.v2-app[data-density="spacious"] .kw-roster-head   { padding: 15px 14px; }
+.v2-app[data-density="spacious"] .kw-roster-list   { padding: 9px 8px; }
+.v2-app[data-density="spacious"] .kw-roster-filters { padding: 12px 14px; }
 
 /* Board */
 .v2-app[data-density="spacious"] .bd-feed-head     { padding: 15px 24px; }
@@ -102,6 +110,7 @@
 .v2-app[data-density="compact"] .kw-chat-head     { padding: 10px 16px 9px; }
 .v2-app[data-density="compact"] .chat-transcript  { padding: 14px 22px 6px; }
 .v2-app[data-density="compact"] .kw-composer-inner { padding: 9px 18px 12px; }
+.v2-app[data-density="compact"] .kw-rail-scroll { padding: 11px; gap: 12px; }
 .v2-app[data-density="compact"] .bd-list       { padding: 11px 14px; gap: 8px; }
 .v2-app[data-density="compact"] .set-row       { padding: 10px 0; }
 

--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -66,11 +66,21 @@
 }
 
 /* ── Component-level density tweaks from v2 source ────────────── */
-/* Chat-console density tweaks from the v2 source are omitted: the design scopes
-   them under a `.v2-keeper-chat` chat container the live dashboard never renders,
-   so every rule here matched nothing (dead). Re-adding them would require the live
-   chat element class names (e.g. `.chat-bubble`), not the design class names, and
-   pixel verification of the spacing — out of scope for this dead-CSS cleanup. */
+/* Chat console. The v2 source scopes these under `.bubble`/`.thread`/`.composer`
+   inside a `.v2-keeper-chat` container; the live dashboard renders the keeper
+   workspace with `.kw-*` / `.chat-*` class names instead, so the design selectors
+   matched nothing. Retargeted to the live classes and verified against the running
+   dashboard (data-density spacious/compact, computed padding + screenshots):
+   design `.thread` + `.thread-inner` fold into `.chat-transcript` (vertical +
+   horizontal); `.msg` -> `.chat-turn-bundle`; `.chat-head`/`.composer` -> their
+   `.kw-` equivalents. The transcript's own `chat-transcript-airy` gap already
+   spaces messages, so the design `thread-inner` gap is not re-applied. */
+.v2-app[data-density="spacious"] .kw-chat-head     { padding: 18px 28px 16px; gap: 16px; }
+.v2-app[data-density="spacious"] .chat-transcript  { padding: 34px 40px 14px; }
+.v2-app[data-density="spacious"] .chat-turn-bundle { gap: 15px; }
+.v2-app[data-density="spacious"] .chat-bubble      { padding: 17px 21px; line-height: 1.7; }
+.v2-app[data-density="spacious"] .kw-composer-inner { padding: 16px 30px 22px; }
+.v2-app[data-density="spacious"] .kw-kp-row        { padding: 11px 11px; }
 
 /* Board */
 .v2-app[data-density="spacious"] .bd-feed-head     { padding: 15px 24px; }
@@ -86,8 +96,12 @@
 .v2-app[data-density="spacious"] .set-row       { padding: 16px 0; }
 .v2-app[data-density="spacious"] .set-nav-item  { padding: 11px 13px; }
 
-/* Compact overrides (dead `.v2-keeper-chat` chat rules dropped — see note above;
-   the board + settings density rules below stay live). */
+/* Compact overrides — chat console retargeted to live `.kw-*`/`.chat-*` classes
+   (the v2 source `.thread`/`.chat-head`/`.composer` never matched). Verified on
+   the running dashboard. */
+.v2-app[data-density="compact"] .kw-chat-head     { padding: 10px 16px 9px; }
+.v2-app[data-density="compact"] .chat-transcript  { padding: 14px 22px 6px; }
+.v2-app[data-density="compact"] .kw-composer-inner { padding: 9px 18px 12px; }
 .v2-app[data-density="compact"] .bd-list       { padding: 11px 14px; gap: 8px; }
 .v2-app[data-density="compact"] .set-row       { padding: 10px 0; }
 

--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -71,15 +71,17 @@
    workspace with `.kw-*` / `.chat-*` class names instead, so the design selectors
    matched nothing. Retargeted to the live classes and verified against the running
    dashboard (data-density spacious/compact, computed padding + screenshots):
-   design `.thread` + `.thread-inner` fold into `.chat-transcript` (vertical +
-   horizontal); `.msg` -> `.chat-turn-bundle`; `.chat-head`/`.composer` -> their
-   `.kw-` equivalents. The transcript's own `chat-transcript-airy` gap already
-   spaces messages, so the design `thread-inner` gap is not re-applied. */
+   design `.thread` + `.thread-inner` fold into workspace `.chat-transcript`
+   (vertical + horizontal); `.msg` -> `.chat-turn-bundle`; `.chat-head`/
+   `.composer` -> their `.kw-` equivalents. Shared ChatTranscript classes are
+   scoped to `data-keeper-chat-layout="workspace"` so density does not spill into
+   primary/detail transcripts. The transcript's own `chat-transcript-airy` gap
+   already spaces messages, so the design `thread-inner` gap is not re-applied. */
 .v2-app[data-density="spacious"] .kw-chat-head     { padding: 18px 28px 16px; gap: 16px; }
-.v2-app[data-density="spacious"] .chat-transcript  { padding: 34px 40px 14px; }
-.v2-app[data-density="spacious"] .chat-turn-bundle { gap: 15px; }
-.v2-app[data-density="spacious"] .chat-bubble      { padding: 17px 21px; line-height: 1.7; }
-.v2-app[data-density="spacious"] .kw-composer-inner { padding: 16px 30px 22px; }
+.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-transcript  { padding: 34px 40px 14px; }
+.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-turn-bundle { gap: 15px; }
+.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-bubble      { padding: 17px 21px; line-height: 1.7; }
+.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .kw-composer-inner { padding: 16px 30px 22px; }
 .v2-app[data-density="spacious"] .kw-kp-row        { padding: 11px 11px; }
 /* Context rail + roster (design `.ctx-scroll`/`.ctx-card`/`.tps-card`/`.roster-*`
    -> live `.kw-rail-scroll`/`.kw-sec`/`.kw-roster-*`). `.kw-sec` is scoped under
@@ -108,8 +110,8 @@
    (the v2 source `.thread`/`.chat-head`/`.composer` never matched). Verified on
    the running dashboard. */
 .v2-app[data-density="compact"] .kw-chat-head     { padding: 10px 16px 9px; }
-.v2-app[data-density="compact"] .chat-transcript  { padding: 14px 22px 6px; }
-.v2-app[data-density="compact"] .kw-composer-inner { padding: 9px 18px 12px; }
+.v2-app[data-density="compact"] [data-keeper-chat-layout="workspace"] .chat-transcript  { padding: 14px 22px 6px; }
+.v2-app[data-density="compact"] [data-keeper-chat-layout="workspace"] .kw-composer-inner { padding: 9px 18px 12px; }
 .v2-app[data-density="compact"] .kw-rail-scroll { padding: 11px; gap: 12px; }
 .v2-app[data-density="compact"] .bd-list       { padding: 11px 14px; gap: 8px; }
 .v2-app[data-density="compact"] .set-row       { padding: 10px 0; }

--- a/dashboard/src/styles/craft-v2.test.ts
+++ b/dashboard/src/styles/craft-v2.test.ts
@@ -65,6 +65,20 @@ describe('craft-v2.css density chat console (retargeted to live classes)', () =>
       .toBe('9px 18px 12px')
   })
 
+  it('applies context-rail + roster spacious values to live classes', () => {
+    const rail = declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-rail-scroll')
+    expect(rail.padding).toBe('20px')
+    expect(rail.gap).toBe('22px')
+    expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-rail .kw-sec').padding)
+      .toBe('14px 15px')
+    expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-roster-head').padding)
+      .toBe('15px 14px')
+    expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-roster-filters').padding)
+      .toBe('12px 14px')
+    expect(declarationsForSelector(css, '.v2-app[data-density="compact"] .kw-rail-scroll').padding)
+      .toBe('11px')
+  })
+
   it('does not target the design-only .thread / .bubble chat classes (regression guard)', () => {
     // The live keeper workspace renders `.kw-thread` / `.chat-bubble`; the design
     // class names `.thread` / `.bubble` never match, so a density rule on them is dead.

--- a/dashboard/src/styles/craft-v2.test.ts
+++ b/dashboard/src/styles/craft-v2.test.ts
@@ -47,21 +47,36 @@ describe('craft-v2.css density chat console (retargeted to live classes)', () =>
   it('applies the spacious chat values to the live .kw-*/.chat-* classes', () => {
     expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-chat-head').padding)
       .toBe('18px 28px 16px')
-    expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .chat-transcript').padding)
+    expect(declarationsForSelector(
+      css,
+      '.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-transcript',
+    ).padding)
       .toBe('34px 40px 14px')
-    const bubble = declarationsForSelector(css, '.v2-app[data-density="spacious"] .chat-bubble')
+    const bubble = declarationsForSelector(
+      css,
+      '.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-bubble',
+    )
     expect(bubble.padding).toBe('17px 21px')
     expect(bubble['line-height']).toBe('1.7')
-    expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-composer-inner').padding)
+    expect(declarationsForSelector(
+      css,
+      '.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .kw-composer-inner',
+    ).padding)
       .toBe('16px 30px 22px')
   })
 
   it('applies the compact chat values to the live .kw-*/.chat-* classes', () => {
     expect(declarationsForSelector(css, '.v2-app[data-density="compact"] .kw-chat-head').padding)
       .toBe('10px 16px 9px')
-    expect(declarationsForSelector(css, '.v2-app[data-density="compact"] .chat-transcript').padding)
+    expect(declarationsForSelector(
+      css,
+      '.v2-app[data-density="compact"] [data-keeper-chat-layout="workspace"] .chat-transcript',
+    ).padding)
       .toBe('14px 22px 6px')
-    expect(declarationsForSelector(css, '.v2-app[data-density="compact"] .kw-composer-inner').padding)
+    expect(declarationsForSelector(
+      css,
+      '.v2-app[data-density="compact"] [data-keeper-chat-layout="workspace"] .kw-composer-inner',
+    ).padding)
       .toBe('9px 18px 12px')
   })
 
@@ -86,6 +101,9 @@ describe('craft-v2.css density chat console (retargeted to live classes)', () =>
       /Selector not found/,
     )
     expect(() => declarationsForSelector(css, '.v2-app[data-density="spacious"] .bubble')).toThrow(
+      /Selector not found/,
+    )
+    expect(() => declarationsForSelector(css, '.v2-app[data-density="spacious"] .chat-bubble')).toThrow(
       /Selector not found/,
     )
   })

--- a/dashboard/src/styles/craft-v2.test.ts
+++ b/dashboard/src/styles/craft-v2.test.ts
@@ -42,3 +42,37 @@ describe('craft-v2.css data-bubble=flat toggle', () => {
     expect(withoutComments).not.toContain('v2-keeper-chat')
   })
 })
+
+describe('craft-v2.css density chat console (retargeted to live classes)', () => {
+  it('applies the spacious chat values to the live .kw-*/.chat-* classes', () => {
+    expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-chat-head').padding)
+      .toBe('18px 28px 16px')
+    expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .chat-transcript').padding)
+      .toBe('34px 40px 14px')
+    const bubble = declarationsForSelector(css, '.v2-app[data-density="spacious"] .chat-bubble')
+    expect(bubble.padding).toBe('17px 21px')
+    expect(bubble['line-height']).toBe('1.7')
+    expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-composer-inner').padding)
+      .toBe('16px 30px 22px')
+  })
+
+  it('applies the compact chat values to the live .kw-*/.chat-* classes', () => {
+    expect(declarationsForSelector(css, '.v2-app[data-density="compact"] .kw-chat-head').padding)
+      .toBe('10px 16px 9px')
+    expect(declarationsForSelector(css, '.v2-app[data-density="compact"] .chat-transcript').padding)
+      .toBe('14px 22px 6px')
+    expect(declarationsForSelector(css, '.v2-app[data-density="compact"] .kw-composer-inner').padding)
+      .toBe('9px 18px 12px')
+  })
+
+  it('does not target the design-only .thread / .bubble chat classes (regression guard)', () => {
+    // The live keeper workspace renders `.kw-thread` / `.chat-bubble`; the design
+    // class names `.thread` / `.bubble` never match, so a density rule on them is dead.
+    expect(() => declarationsForSelector(css, '.v2-app[data-density="spacious"] .thread')).toThrow(
+      /Selector not found/,
+    )
+    expect(() => declarationsForSelector(css, '.v2-app[data-density="spacious"] .bubble')).toThrow(
+      /Selector not found/,
+    )
+  })
+})


### PR DESCRIPTION
## 무엇을 / 왜

keeper-v2 craft fidelity 후속 (#21921 머지 후). 디자인의 **density chat-surface tweak 전체**를 라이브 클래스로 retarget해 복원합니다. 근본: 디자인 `styles/craft.css`는 density를 디자인 class명(`.bubble`/`.thread`/`.composer`/`.ctx-*`/`.roster-*`, `.v2-keeper-chat` 하위)으로 scope하나, 라이브 keeper workspace는 `.kw-*`/`.chat-*`를 렌더 → density 토글이 chat/rail/roster에 **무효과**였음.

**라이브 검증**(가동 중 `:8935/dashboard` Keepers, computed-style + screenshot, spacious/compact):
- 수정 전: 토글해도 `.chat-transcript` `20px 40px 8px` 등 **불변**(무효과).
- 수정 후 spacious: chat `.chat-transcript` `34px 40px 14px`·`.chat-bubble` `17px 21px`(lh 1.7)·`.kw-chat-head` `18px 28px 16px`·`.kw-composer-inner` `16px 30px 22px`; rail `.kw-rail-scroll` `20px`/gap 22px·`.kw-rail .kw-sec` `14px 15px`; roster `.kw-roster-head` `15px 14px`·`.kw-roster-filters` `12px 14px`·`.kw-roster-list` `9px 8px`.
- 수정 후 compact: `.chat-transcript` `14px 22px 6px`·`.kw-chat-head` `10px 16px 9px`·`.kw-composer-inner` `9px 18px 12px`·`.kw-rail-scroll` `11px`/gap 12px.
- 스크린샷: spacious(여유)↔compact(타이트) chat·rail·roster 모두 깨짐/오버플로 없이 구분 확인.

## 변경 (`craft-v2.css`)
디자인 값 → 라이브 클래스 매핑 (chat 클러스터 + context rail + roster):
- `.chat-head`→`.kw-chat-head`, `.thread`+`.thread-inner`→`.chat-transcript`(수직+수평 folding), `.msg`→`.chat-turn-bundle`(gap), `.bubble`→`.chat-bubble`, `.composer`→`.kw-composer-inner`, `.kp-row`→`.kw-kp-row`.
- `.ctx-scroll`→`.kw-rail-scroll`, `.ctx-card`/`.tps-card`→`.kw-rail .kw-sec`(rail 하위 스코프; live `.kw-sec` 4개 전부 `.kw-rail` 안 → 과적용 없음), `.roster-head`/`.roster-list`/`.roster-filters`→`.kw-roster-*`.
- `chat-transcript-airy`가 메시지 간격을 이미 처리 → 디자인 thread-inner gap 재적용 안 함(deviation, 주석 명시).
- **workspace 스코핑**: 공유 `.chat-*` 프리미티브는 여러 surface(workspace/board-detail/keeper-detail)에서 렌더되므로, density 규칙을 `[data-keeper-chat-layout="workspace"]` 하위로 스코프(keeper-workspace.css 기존 패턴과 일치) → keeper workspace chat에만 적용, 다른 트랜스크립트로 누출 방지. 라이브 DOM 검증: 스코프 대상 요소 전부 해당 컨테이너 안, `.kw-chat-head`는 밖이라 unscoped 유지.

## 범위 / 경계
- keepers surface density **완결**(chat+rail+roster, 라이브 검증). board(`.bd-*`)·settings(`.set-*`) density는 phantom 없어 기존대로 유지.
- dashboard styling only → RFC-gate 비대상. 백엔드/컴포넌트 무변경.

## Workaround self-check
- 텔레메트리-as-fix ❌ / string 분류기 ❌ / N-of-M ❌ — class 매핑 정정의 완결 수정(verified).

## 검증
- 디자인 grounding: `claude_design` MCP(`app.jsx`·`css-map.md`·`craft.css`).
- 라이브 검증: `:8935/dashboard` Keepers chat에서 computed-style + screenshot(spacious/compact).
- `tsc` clean · `vitest` **8/8**(flat 4 + density 4: 라이브 클래스 값 가드 + 디자인 전용 `.thread`/`.bubble` dead-selector throw 가드).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
