### PR TITLE
fix(dashboard): refresh keeper sidebar from execution ssot

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -10,6 +10,7 @@ vi.mock('./dev-token', () => ({
 
 import {
   fetchDashboardShell,
+  fetchDashboardExecution,
   fetchLogs,
   fetchDashboardExecutionTrust,
   fetchDashboardGovernance,
@@ -119,6 +120,38 @@ describe('fetchDashboardShell', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/shell?light=true')
+  })
+})
+
+describe('fetchDashboardExecution', () => {
+  it('uses the cached execution endpoint by default', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ agents: [], tasks: [], messages: [], keepers: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchDashboardExecution()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/execution')
+  })
+
+  it('requests a forced execution snapshot when asked', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ agents: [], tasks: [], messages: [], keepers: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchDashboardExecution({ force: true })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/execution?force=1')
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -291,8 +291,13 @@ export async function fetchFusionRuns(
   return parseFusionRunsResponse(raw)
 }
 
-export function fetchDashboardExecution(opts?: AbortableRequestOptions): Promise<DashboardExecutionResponse> {
-  return get('/api/v1/dashboard/execution', { signal: opts?.signal })
+type DashboardExecutionRequestOptions = AbortableRequestOptions & {
+  force?: boolean
+}
+
+export function fetchDashboardExecution(opts?: DashboardExecutionRequestOptions): Promise<DashboardExecutionResponse> {
+  const query = opts?.force ? '?force=1' : ''
+  return get(`/api/v1/dashboard/execution${query}`, { signal: opts?.signal })
 }
 
 export type DashboardExecutionTrustKeeper = Record<string, unknown> & {

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -40,7 +40,13 @@ import { KeeperDetailBody } from './keeper-detail-body'
 import { KeeperWorkspaceRoster } from './keeper-workspace/keeper-workspace-roster'
 import { KeeperWorkspaceChat } from './keeper-workspace/keeper-workspace-chat'
 import { KeeperWorkspaceRail } from './keeper-workspace/keeper-workspace-rail'
-import { beginPaneResize, clampPaneWidth, rosterWidth, railWidth } from './keeper-workspace/keeper-workspace-pane-resize'
+import {
+  beginPaneResize,
+  clampPaneWidth,
+  effectiveRosterWidthForViewport,
+  rosterWidth,
+  railWidth,
+} from './keeper-workspace/keeper-workspace-pane-resize'
 import { ringFocusClasses } from './common/ring'
 
 const CLOSE_BUTTON_FOCUS_CLASS = ringFocusClasses({
@@ -391,7 +397,7 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
   const paneResizable = !detailOpen && !isMobile
   const gridStyle = paneResizable
     ? {
-        ...(rosterOpen ? { '--kw-roster-w': `${clampPaneWidth('roster', rosterWidth.value)}px` } : {}),
+        ...(rosterOpen ? { '--kw-roster-w': `${effectiveRosterWidthForViewport(rosterWidth.value, isNarrow)}px` } : {}),
         ...(railOpen ? { '--kw-rail-w': `${clampPaneWidth('rail', railWidth.value)}px` } : {}),
       }
     : undefined

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.test.ts
@@ -3,9 +3,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   beginPaneResize,
   clampPaneWidth,
+  effectiveRosterWidthForViewport,
   rosterWidth,
   railWidth,
   DEFAULT_ROSTER_WIDTH,
+  NARROW_ROSTER_WIDTH,
   DEFAULT_RAIL_WIDTH,
 } from './keeper-workspace-pane-resize'
 
@@ -33,6 +35,20 @@ describe('clampPaneWidth', () => {
     expect(clampPaneWidth('roster', Number.NaN)).toBe(200)
     expect(clampPaneWidth('rail', Number.POSITIVE_INFINITY)).toBe(240)
     expect(clampPaneWidth('roster', 'wide')).toBe(200)
+  })
+})
+
+describe('effectiveRosterWidthForViewport', () => {
+  it('caps the default roster width on the narrow two-column workspace', () => {
+    expect(effectiveRosterWidthForViewport(DEFAULT_ROSTER_WIDTH, true)).toBe(NARROW_ROSTER_WIDTH)
+  })
+
+  it('keeps narrower user-selected roster widths while narrow', () => {
+    expect(effectiveRosterWidthForViewport(220, true)).toBe(220)
+  })
+
+  it('uses the persisted roster width on the full desktop workspace', () => {
+    expect(effectiveRosterWidthForViewport(360, false)).toBe(360)
   })
 })
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-pane-resize.ts
@@ -24,6 +24,7 @@ const PANE_BOUNDS: Record<PaneKind, { min: number; max: number; cssVar: string }
 }
 
 export const DEFAULT_ROSTER_WIDTH = 286
+export const NARROW_ROSTER_WIDTH = 248
 export const DEFAULT_RAIL_WIDTH = 312
 
 /** Persisted column widths (px). Reads subscribe the component, but values only
@@ -49,6 +50,13 @@ export function clampPaneWidth(kind: PaneKind, px: unknown): number {
   const { min, max } = PANE_BOUNDS[kind]
   if (typeof px !== 'number' || !Number.isFinite(px)) return min
   return Math.max(min, Math.min(max, Math.round(px)))
+}
+
+/** Pure: desktop uses the persisted roster width, but the <=1180px layout drops
+ *  the right rail, so keep the left roster within that narrower grid budget. */
+export function effectiveRosterWidthForViewport(px: unknown, narrow: boolean): number {
+  const clamped = clampPaneWidth('roster', px)
+  return narrow ? Math.min(clamped, NARROW_ROSTER_WIDTH) : clamped
 }
 
 /** Start a pointer-drag resize of one pane. Sets the CSS var directly on the

--- a/dashboard/src/components/mobile-nav.ts
+++ b/dashboard/src/components/mobile-nav.ts
@@ -79,6 +79,7 @@ export function DashboardNavRail({
       <aside
         id="dashboard-side-rail"
         aria-label="Sidebar navigation"
+        data-collapsed=${effectiveCollapsed ? 'true' : 'false'}
         data-testid="dashboard-nav-rail"
         class="v2-shell-rail ${sideRailWidthClass} shrink-0 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] ${sideRailResponsiveClass}"
       >

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -25,8 +25,8 @@ const boardOffset = signal(0)
 const namespaceTruth = signal<unknown>(null)
 const namespaceTruthError = signal<unknown>(null)
 
-const refreshDashboard = vi.fn<() => Promise<void>>(async () => {})
-const refreshExecution = vi.fn<() => Promise<void>>(async () => {})
+const refreshDashboard = vi.fn<(opts?: { force?: boolean }) => Promise<void>>(async () => {})
+const refreshExecution = vi.fn<(opts?: { force?: boolean }) => Promise<void>>(async () => {})
 const refreshBoard = vi.fn<() => void>(() => {})
 const refreshFusionRuns = vi.fn<() => void>(() => {})
 const invalidateDashboardCache = vi.fn<() => void>(() => {})
@@ -240,7 +240,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     await flushAsyncWork()
 
     expect(refreshExecution).toHaveBeenCalledTimes(1)
-    expect(refreshExecution).toHaveBeenCalledWith()
+    expect(refreshExecution).toHaveBeenCalledWith({ force: true })
 
     cleanup()
   })
@@ -259,7 +259,25 @@ describe('setupSSEReaction reconnect hydration', () => {
     await flushAsyncWork()
 
     expect(refreshExecution).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).toHaveBeenCalledWith({ force: true })
+
     cleanup()
+  })
+
+  it('forces execution refresh on keeper turn complete for live roster status', async () => {
+    const { sseStore } = await loadSseStore()
+    route.value = { tab: 'keepers', params: { keeper: 'qa-king' }, postId: null }
+
+    sseStore.routeServerPushEvent({
+      type: 'keeper_turn_complete',
+      name: 'qa-king',
+      turn: 42,
+    })
+    vi.advanceTimersByTime(1_000)
+    await flushAsyncWork()
+
+    expect(refreshExecution).toHaveBeenCalledTimes(1)
+    expect(refreshExecution).toHaveBeenCalledWith({ force: true })
   })
 
   it('normalizes MASC broadcast aliases before route-scoped execution refresh', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -129,6 +129,7 @@ type RefreshTarget = RouteRefreshTarget
 interface SimpleRoute {
   target: RefreshTarget
   debounceMs?: number
+  force?: boolean
 }
 
 // Route table maps SSE event type → refresh target. Only entries whose
@@ -141,10 +142,11 @@ const SIMPLE_ROUTES: Record<string, SimpleRoute> = {
   // Broadcasts — emitted by lib/mcp_tool_runtime_comm.ml
   broadcast:           { target: 'execution' },
   // Keeper lifecycle (also triggers operator refresh via handler)
-  keeper_handoff:       { target: 'execution' },
-  keeper_compaction:    { target: 'execution' },
-  keeper_guardrail:     { target: 'execution' },
-  keeper_phase_changed: { target: 'execution' },
+  keeper_handoff:       { target: 'execution', force: true },
+  keeper_compaction:    { target: 'execution', force: true },
+  keeper_guardrail:     { target: 'execution', force: true },
+  keeper_phase_changed: { target: 'execution', force: true },
+  keeper_turn_complete: { target: 'execution', force: true },
   // Board content — emitted by lib/mcp_tool_runtime_board.ml
   board_post:          { target: 'board' },
   'masc/board_post':    { target: 'board' },
@@ -458,9 +460,13 @@ export function routeServerPushEvent(event: SSEEvent): void {
   const routedType = normalizeSSEDispatchType(event.type)
   const simpleRoute = SIMPLE_ROUTES[routedType]
   if (simpleRoute) {
+    const refreshFn =
+      simpleRoute.force && simpleRoute.target === 'execution'
+        ? () => { void refreshExecution({ force: true }) }
+        : REFRESH_FNS[simpleRoute.target]
     scheduleTargetRefresh(
       simpleRoute.target,
-      REFRESH_FNS[simpleRoute.target],
+      refreshFn,
       simpleRoute.debounceMs,
     )
     if (BOARD_HEARTH_REFRESH_EVENTS.has(routedType)) {

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -1028,12 +1028,16 @@ export function hydrateExecutionSnapshot(data: DashboardExecutionResponse): void
   executionLoaded.value = true
 }
 
+let nextExecutionForce = false
+
 async function doFetchExecution(): Promise<void> {
+  const force = nextExecutionForce
+  nextExecutionForce = false
   executionLoading.value = true
   executionError.value = null
   try {
     const { fetchDashboardExecution } = await import('./api/dashboard')
-    const data = await fetchDashboardExecution()
+    const data = await fetchDashboardExecution({ force })
     hydrateExecutionSnapshot(data)
   } catch (err) {
     console.warn('[Dashboard] execution fetch error:', err)
@@ -1051,6 +1055,7 @@ const executionScheduler = new FetchScheduler(doFetchExecution, {
 
 export async function refreshExecution(opts?: RefreshOptions): Promise<void> {
   if (opts?.force) {
+    nextExecutionForce = true
     executionScheduler.requestNow()
   } else {
     executionScheduler.request()

--- a/dashboard/src/styles/v2-shell.css
+++ b/dashboard/src/styles/v2-shell.css
@@ -73,6 +73,12 @@
   margin-bottom: 8px;
 }
 
+#dashboard-side-rail.v2-shell-rail[data-collapsed="true"] .nav-brand {
+  justify-content: center;
+  padding: 8px 6px;
+  margin-bottom: 6px;
+}
+
 #dashboard-side-rail.v2-shell-rail .nav-brand .nb-title {
   font-family: var(--v2-font-display);
   font-size: 14px;
@@ -261,6 +267,11 @@
   transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
 }
 
+#dashboard-side-rail.v2-shell-rail[data-collapsed="true"] .nav-link-collapsed {
+  width: 38px;
+  height: 38px;
+}
+
 #dashboard-side-rail.v2-shell-rail .nav-link-collapsed:hover {
   background: var(--v2-surface-subtle);
   color: var(--v2-accent-brand);
@@ -285,6 +296,10 @@
   color: var(--v2-text-dim);
   font-family: var(--v2-font-mono);
   font-size: 11px;
+}
+
+#dashboard-side-rail.v2-shell-rail[data-collapsed="true"] .nav-footer {
+  padding: 8px 6px;
 }
 
 /* ═══════════════════════════════════════════════════════════════

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -328,13 +328,14 @@ let with_cached_dashboard_surface_metadata
   | other -> other
 ;;
 
-let execution_query_json ~actor ~fixture ~full_mode ~light ~default_light_request =
+let execution_query_json ~actor ~fixture ~full_mode ~light ~default_light_request ~force =
   `Assoc
     [ "actor", Json_util.string_opt_to_json actor
     ; "fixture", Json_util.string_opt_to_json fixture
     ; "full", `Bool full_mode
     ; "light", `Bool light
     ; "default_light_request", `Bool default_light_request
+    ; "force", `Bool force
     ]
 ;;
 
@@ -711,6 +712,7 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
     execution_actor_for_request ~base_path:config.base_path request
   in
   let full_mode = bool_query_param request "full" ~default:false in
+  let force = bool_query_param request "force" ~default:false in
   let light = not full_mode in
   let query =
     execution_query_json
@@ -718,8 +720,10 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
       ~fixture
       ~full_mode
       ~light
-      ~default_light_request:(fixture = None && actor = None && not full_mode)
+      ~default_light_request:(fixture = None && actor = None && not full_mode && not force)
+      ~force
   in
+  let default_light_cache_key = "execution:default:light" in
   let compute ?actor ?fixture ~light () =
     let started_at = Unix.gettimeofday () in
     run_dashboard_compute
@@ -748,20 +752,62 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
                 ])
   in
   match fixture, actor, full_mode with
+  | None, None, false when force ->
+    let timeout_sec = Env_config_runtime.Dashboard.execution_timeout_sec in
+    let compute_and_track () =
+      Server_dashboard_http_cache.mark_cached_surface_attempt execution_cache;
+      try
+        let json = compute ~light:true () in
+        Server_dashboard_http_cache.mark_cached_surface_success execution_cache json;
+        Server_dashboard_http_cache.cached_surface_json execution_cache
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn;
+        raise exn
+    in
+    (match
+       Eio.Time.with_timeout clock timeout_sec (fun () -> Ok (compute_and_track ()))
+     with
+     | Ok json -> json
+     | Error `Timeout ->
+       let exn = Dashboard_cache.Compute_timeout (default_light_cache_key, false) in
+       Server_dashboard_http_cache.mark_cached_surface_error execution_cache exn;
+       Log.Dashboard.warn
+         "dashboard execution force refresh timed out: %s (%.0fs)"
+         default_light_cache_key
+         timeout_sec;
+       `Assoc
+         [ "error", `String "computation_timeout"
+         ; "message",
+           `String
+             (Printf.sprintf
+                "Dashboard %s timed out after %.0fs"
+                default_light_cache_key
+                timeout_sec)
+         ; "generated_at", `String (Masc_domain.now_iso ())
+         ; "timeout_kind", `String "owner"
+         ; "timeout_sec", `Float timeout_sec
+         ; "key", `String default_light_cache_key
+         ])
+    |> with_execution_metadata
+         ~config
+         ~cache_key:default_light_cache_key
+         ~query
   | None, None, false ->
     (* Default light mode: stay instant after first success, but avoid
          serving the empty initializing payload forever when proactive warm-up
          misses its first build window. *)
     Server_dashboard_http_cache.cached_surface_or_first_success_json
       execution_cache
-      ~cache_key:"execution:default:light"
+      ~cache_key:default_light_cache_key
       ~ttl:deep_surface_cache_ttl_s
       ~clock
       ~timeout_sec:Env_config_runtime.Dashboard.execution_timeout_sec
       (compute ~light:true)
     |> with_execution_metadata
          ~config
-         ~cache_key:"execution:default:light"
+         ~cache_key:default_light_cache_key
          ~query
   | _ ->
     (* Parameterized requests (fixture/actor/full): on-demand with SWR cache.

--- a/lib/server/server_dashboard_http_execution_surfaces.mli
+++ b/lib/server/server_dashboard_http_execution_surfaces.mli
@@ -166,9 +166,10 @@ val dashboard_execution_http_json :
   Yojson.Safe.t
 (** Implements the dashboard execution HTTP route.
     Reads through the per-request actor / fixture /
-    light-mode query params, then routes via
+    light-mode / force query params, then routes via
     [Dashboard_cache.get_or_compute_with_timeout] with
-    a 120 s TTL. *)
+    a 120 s TTL.  Default light [force=true] bypasses the
+    default execution cache once and updates it on success. *)
 
 val dashboard_execution_trust_http_json :
   state:Mcp_server.server_state ->


### PR DESCRIPTION
## Summary
- force `/api/v1/dashboard/execution?force=1` for keeper lifecycle SSE refreshes so the keeper roster/sidebar does not sit on the 120s execution cache
- route `keeper_turn_complete` into the execution SSOT refresh path while keeping route-scoped budgets intact
- cap keeper workspace roster width in the <=1180px two-column layout and tighten collapsed global rail padding

## Evidence
- Live backend supports forced execution refresh: `/api/v1/dashboard/execution?force=1` returned a newer `generated_at_iso` than cached `/execution` on 2026-06-21 KST
- `pnpm exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/sse-store.test.ts src/components/keeper-workspace/keeper-workspace-pane-resize.test.ts src/components/keeper-detail.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run lint`
- Playwright rendered check at 1120x900: collapsed rail 56px, brand padding 6px/6px, first icon link 38px, keeper roster CSS var 248px, context rail hidden

## Notes
- Draft PR per repo workflow.
