### PR TITLE
docs(chat): state cross-clock caveat in traceOrderTs comment (follow-up to #21913/#21915)

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2180,8 +2180,11 @@ type TraceOrderItem =
   | { kind: 'tool'; entry: KeeperConversationEntry; output: ToolCallEntry | null }
 
 function traceOrderTs(item: TraceOrderItem): string {
-  // ISO-8601 strings sort lexicographically == chronologically. A step without
-  // `ts` (backend-normalized, no timestamp surfaced from the wire) sorts first.
+  // ISO-8601 strings sort lexicographically within one clock domain. This merge
+  // spans two: think/reason `ts` is stamped on the client when the delta
+  // arrives, tool `entry.timestamp` comes from the server (ts_unix). Live
+  // ordering is best-effort chronological and can cross within ~1 RTT; a step
+  // without `ts` (backend-normalized, no timestamp from the wire) sorts first.
   if (item.kind === 'tool') return item.entry.timestamp ?? ''
   // Only think/reason carry `ts`; the tool variant of ChatTraceStep does not
   // (and is never a 'trace' item here, but narrow for type safety).


### PR DESCRIPTION
## Summary
Tightens the `traceOrderTs` comment in `dashboard/src/components/chat/primitives.ts` to state the cross-clock caveat.

The comment claimed ISO-8601 lexicographic sort " == chronologically", which only holds within one clock domain. This render-time merge spans two: think/reason `ts` is stamped on the client when the delta arrives (`keeper-state.ts`, `new Date().toISOString()`), tool `entry.timestamp` comes from the server (`ts_unix`). Tightens the comment to state the best-effort nature and the ~1-RTT crossing window.

## Context
Follow-up to #21913 (merged before this landed) and aligns the code comment with the design doc #21915, which now frames this as an accepted trade-off. Original finding: [#21913 issuecomment-4761447614](https://github.com/jeong-sik/masc/pull/21913#issuecomment-4761447614); doc reconciliation: [#21915 issuecomment-4761522696](https://github.com/jeong-sik/masc/pull/21915#issuecomment-4761522696).

## Verification
- Comment-only change (verified: no executable code lines changed).
- Adversarially verified the factual claim against `keeper-state.ts` (think `ts` = client stamp at the streaming-merge path; tool `timestamp` = `ts_unix`).

Co-Authored-By: Claude <noreply@anthropic.com>
