### PR TITLE
fix(dashboard): distribute identical-text turns' trace 1:1 (#21748)

### DIFF
--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -243,7 +243,10 @@ describe('thread history merge & persistence', () => {
     ])
 
     const thread = keeperThreads.value.echo ?? []
-    const traceTextOf = (id: string) => thread.find(e => e.id === id)?.traceSteps?.[0]?.text
+    const traceTextOf = (id: string) => {
+      const step = thread.find(e => e.id === id)?.traceSteps?.[0]
+      return step && 'text' in step ? step.text : undefined
+    }
     // Each history row carries its OWN local trace, not the other's.
     expect(traceTextOf('hist-a')).toBe('first turn reasoning')
     expect(traceTextOf('hist-b')).toBe('second turn reasoning')

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -211,6 +211,44 @@ describe('thread history merge & persistence', () => {
     ])
   })
 
+  it('distributes identical-text assistant turns trace 1:1 across history rows (#21748)', () => {
+    // Two local optimistic assistants with the SAME reply text but distinct
+    // thinking traces. Before the fix, both history rows matched the FIRST
+    // local source via the role+text fallback, so the second row inherited the
+    // first turn's trace.
+    appendThreadEntry('echo', entry({
+      id: 'local-a',
+      role: 'assistant',
+      text: 'done',
+      rawText: 'done',
+      delivery: 'delivered',
+      streamState: null,
+      timestamp: '2026-06-10T00:00:01.000Z',
+    }))
+    appendThreadEntry('echo', entry({
+      id: 'local-b',
+      role: 'assistant',
+      text: 'done',
+      rawText: 'done',
+      delivery: 'delivered',
+      streamState: null,
+      timestamp: '2026-06-10T00:00:02.000Z',
+    }))
+    appendAssistantThinkingDelta('echo', 'local-a', 'first turn reasoning')
+    appendAssistantThinkingDelta('echo', 'local-b', 'second turn reasoning')
+
+    mergeServerHistoryEntries('echo', [
+      entry({ id: 'hist-a', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:01.000Z' }),
+      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z' }),
+    ])
+
+    const thread = keeperThreads.value.echo ?? []
+    const traceTextOf = (id: string) => thread.find(e => e.id === id)?.traceSteps?.[0]?.text
+    // Each history row carries its OWN local trace, not the other's.
+    expect(traceTextOf('hist-a')).toBe('first turn reasoning')
+    expect(traceTextOf('hist-b')).toBe('second turn reasoning')
+  })
+
   it('keeps local entries the server has not persisted yet', () => {
     appendThreadEntry('echo', entry({ id: 'local-1', text: 'not yet saved' }))
 

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -911,15 +911,28 @@ function entryTimeMs(entry: KeeperConversationEntry): number {
 function mergeLocalAssistantTraceSteps(
   historyEntry: KeeperConversationEntry,
   localEntries: KeeperConversationEntry[],
+  // Tracks local trace sources already claimed by an earlier history row.
+  // Without it, two identical-text assistant history rows both match the FIRST
+  // local source via the role+text fallback in sameConversationEntry, so the
+  // second turn inherits the first turn's trace (#21748). Each source is
+  // consumed at most once → 1:1 distribution.
+  // Contract: localEntries are in append order, which mirrors the chronological
+  // order of historyEntries, so the Nth identical-text history row maps to the
+  // Nth local source. A server-minted id handshake (R3, not yet landed) would
+  // make this exact without the ordering assumption; until then local
+  // optimistic entries carry no turn_ref, so id-keyed matching is not possible.
+  consumed: Set<string>,
 ): KeeperConversationEntry {
   if (historyEntry.role !== 'assistant') return historyEntry
   const localTraceSource = localEntries.find(
     entry =>
       entry.role === 'assistant'
       && (entry.traceSteps?.length ?? 0) > 0
+      && !consumed.has(entry.id)
       && sameConversationEntry(entry, historyEntry),
   )
   if (!localTraceSource?.traceSteps?.length) return historyEntry
+  consumed.add(localTraceSource.id)
   return {
     ...historyEntry,
     traceSteps: localTraceSource.traceSteps,
@@ -934,7 +947,11 @@ function replaceThread(name: string, entries: KeeperConversationEntry[]): void {
   // refresh / probe / recover.
   if (entries.length === 0) return
   const existing = keeperThreads.value[name] ?? []
-  const historyEntries = entries.map(entry => mergeLocalAssistantTraceSteps(entry, existing))
+  // Shared across the map so each local trace source is claimed at most once
+  // (see mergeLocalAssistantTraceSteps): identical-text turns no longer steal
+  // each other's trace (#21748).
+  const consumed = new Set<string>()
+  const historyEntries = entries.map(entry => mergeLocalAssistantTraceSteps(entry, existing, consumed))
   const localEntries = existing.filter(
     entry => {
       const coveredByHistory = historyEntries.some(historyEntry => sameConversationEntry(entry, historyEntry))


### PR DESCRIPTION
## 목표
#21748 해결 — 동일 텍스트 assistant 턴이 2개 이상일 때 한 턴의 thinking trace가 다른 history 행에 mis-attribute되는 버그.

## 원인
`mergeLocalAssistantTraceSteps`(`keeper-state.ts:911`)가 local trace source를 `sameConversationEntry`의 **role+text fallback**(`:895`)으로 매칭. local optimistic assistant는 local-minted id ≠ server id라 id 매칭이 빗나가 text fallback으로 떨어지고, 동일 텍스트 history 행이 모두 같은 **첫 local source**를 집어 두 번째 턴에 첫 턴 trace가 실린다.

## 접근: consumed Set 1:1 분배
`mergeLocalAssistantTraceSteps`에 공유 `consumed: Set<string>`을 추가. 각 local trace source를 최대 한 history 행에만 매칭 → 동일 텍스트 N행이 N개 source를 1:1로 분배(N번째 history ↔ N번째 local source). 단일 파일, ~6 LoC.

## 설계 검증 (6-agent 워크플로우, 3 접근)
- **A) turnRef 매칭 — 기각**: local optimistic assistant가 turnRef를 갖지 않음(`keeper-actions.ts:341-353`·`:656-667`에서 미세팅). turnRef 우선 단이 항상 한쪽 null로 fallback 낙하 → 미해결. R3 id-handshake와 페어링해야만.
- **C) fallback 제거 — 기각(결정적 회귀)**: id 안 맞으면 trace 소실 → 모든 턴의 작업 과정 카드가 reload 후 사라짐.
- **B) used-set — 채택**: 현재 인프라로 단독 동작하는 유일한 접근.

## 회귀 · 한계
- 발생순 가정: localEntries append 순서 = historyEntries chronological 순서(adjudicate: 통상 성립, 결정적 아님). 계약 주석으로 명시. R3 handshake가 도입되면 id 기반으로 교체 가능(그때 consumed는 중복 제거 대상).
- cancelled optimistic 잔존 공존 엣지(`appendThreadEntry` push-only + `abortKeeperThreadMessage`가 array 제거 안 함): 동시 동일 텍스트 optimistic은 `sendKeeperThreadMessage` abort로 발생 빈도 낮음. 별도 이슈로 추적.
- tool row dedup(`tool-<tool_call_id>`), continuity folding: 영향 없음(assistant trace 매칭에 한정).

## 검증 상태
- 로컬 빌드/테스트 미실행(사용자 지시: 빌드는 CI만). CI `Dashboard`(tsc+vite+vitest) + `Test Coverage Check`로 검증.
- 테스트: 동일 텍스트 2 local assistant + 2 trace → 2 history 행이 각각 자기 trace 갖는지 1:1 단언.

Refs #21748.

Co-Authored-By: Claude <noreply@anthropic.com>
