### PR TITLE
feat(eval-harness): typed required-selectors for tool-call-quality benchmark

### DIFF
--- a/benchmarks/data/tool_call_quality_cases.json
+++ b/benchmarks/data/tool_call_quality_cases.json
@@ -8,6 +8,13 @@
       "category": "tool_use",
       "keeper_profiles": ["bench-analyst", "bench-executor"],
       "forbidden_tools": ["tool_execute"],
+      "forbidden_selectors": [
+        { "type": "descriptor_id", "value": "agent.execute" }
+      ],
+      "required_selectors": [
+        { "type": "eval_tag", "value": "capability_introspection" },
+        { "type": "descriptor_id", "value": "agent.read_file" }
+      ],
       "max_tool_calls": 3,
       "success_checks": [
         { "path": "$.status", "equals": "completed" },
@@ -15,12 +22,12 @@
       ],
       "arg_checks": [
         {
-          "tool_name": "keeper_tool_search",
+          "selector": { "type": "eval_tag", "value": "capability_introspection" },
           "path": "$.query",
           "contains": "prompt_fingerprint"
         },
         {
-          "tool_name": "tool_read_file",
+          "selector": { "type": "descriptor_id", "value": "agent.read_file" },
           "path": "$.path",
           "contains": "keeper_tool_call_log"
         }
@@ -53,6 +60,10 @@
       "category": "recovery_required",
       "keeper_profiles": ["bench-verifier"],
       "forbidden_tools": [],
+      "required_selectors": [
+        { "type": "eval_tag", "value": "capability_introspection" },
+        { "type": "descriptor_id", "value": "agent.read_file" }
+      ],
       "max_tool_calls": 4,
       "success_checks": [
         { "path": "$.status", "equals": "completed" },
@@ -60,12 +71,12 @@
       ],
       "arg_checks": [
         {
-          "tool_name": "keeper_tool_search",
+          "selector": { "type": "eval_tag", "value": "capability_introspection" },
           "path": "$.query",
           "contains": "keeper_agent_run"
         },
         {
-          "tool_name": "tool_read_file",
+          "selector": { "type": "descriptor_id", "value": "agent.read_file" },
           "path": "$.path",
           "contains": "keeper_agent_run.ml"
         }
@@ -82,6 +93,11 @@
       "category": "multi_step",
       "keeper_profiles": ["bench-executor", "bench-verifier"],
       "forbidden_tools": [],
+      "required_selectors": [
+        { "type": "eval_tag", "value": "capability_introspection" },
+        { "type": "descriptor_id", "value": "agent.execute" },
+        { "type": "descriptor_id", "value": "masc.board.post" }
+      ],
       "max_tool_calls": 4,
       "success_checks": [
         { "path": "$.status", "equals": "completed" },
@@ -89,7 +105,7 @@
       ],
       "arg_checks": [
         {
-          "tool_name": "masc_board_post",
+          "selector": { "type": "descriptor_id", "value": "masc.board.post" },
           "path": "$.body",
           "contains": "verified"
         }

--- a/lib/core/eval_tool_selector.ml
+++ b/lib/core/eval_tool_selector.ml
@@ -127,3 +127,7 @@ let matches selector call =
         (Some expected)
         (receipt_label_value key call.route_evidence)
   | Eval_tag expected -> List.exists (String.equal expected) (eval_tags call.route_evidence)
+
+let requires_route_evidence = function
+  | Tool_name _ -> false
+  | Descriptor_id _ | Runtime_handler _ | Receipt_label _ | Eval_tag _ -> true

--- a/lib/core/eval_tool_selector.mli
+++ b/lib/core/eval_tool_selector.mli
@@ -35,3 +35,8 @@ val of_yojson : Yojson.Safe.t -> (t, string) result
 val matches : t -> call -> bool
 (** [matches selector call] returns [true] when the selector matches the
     call's tool name or descriptor route evidence. *)
+
+val requires_route_evidence : t -> bool
+(** [requires_route_evidence selector] is [false] only for legacy
+    [Tool_name] selectors. Descriptor/runtime/receipt/eval-tag selectors
+    cannot be evaluated against name-only evidence. *)

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark.ml
@@ -22,9 +22,15 @@ let default_evidence_path = Tool_call_quality_benchmark_loader.default_evidence_
 let load_cases_from_file = Tool_call_quality_benchmark_loader.load_cases_from_file
 let load_runs_from_file = Tool_call_quality_benchmark_loader.load_runs_from_file
 let score_run = Tool_call_quality_benchmark_scoring.score_run
+let route_evidence_issues =
+  Tool_call_quality_benchmark_evidence_quality.route_evidence_issues
+
 let summarize = Tool_call_quality_benchmark_summary.summarize
 let json_check_to_yojson = Tool_call_quality_benchmark_render.json_check_to_yojson
 let case_score_to_yojson = Tool_call_quality_benchmark_render.case_score_to_yojson
+let evidence_quality_issue_to_yojson =
+  Tool_call_quality_benchmark_render.evidence_quality_issue_to_yojson
+
 let summary_row_to_yojson = Tool_call_quality_benchmark_render.summary_row_to_yojson
 let benchmark_summary_to_yojson =
   Tool_call_quality_benchmark_render.benchmark_summary_to_yojson

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark.mli
@@ -11,6 +11,10 @@ include
      and type tool_call = Tool_call_quality_benchmark_types.tool_call
      and type run_status = Tool_call_quality_benchmark_types.run_status
      and type evidence_run = Tool_call_quality_benchmark_types.evidence_run
+     and type evidence_quality_issue_kind =
+      Tool_call_quality_benchmark_types.evidence_quality_issue_kind
+     and type evidence_quality_issue =
+      Tool_call_quality_benchmark_types.evidence_quality_issue
      and type case_score = Tool_call_quality_benchmark_types.case_score
      and type summary_view = Tool_call_quality_benchmark_types.summary_view
      and type summary_row = Tool_call_quality_benchmark_types.summary_row
@@ -26,6 +30,9 @@ val load_runs_from_file : string -> (evidence_run list, string) Result.t
 val score_run :
   cases:benchmark_case list -> evidence_run -> case_score option
 
+val route_evidence_issues :
+  cases:benchmark_case list -> runs:evidence_run list -> evidence_quality_issue list
+
 val summarize :
      cases:benchmark_case list
   -> runs:evidence_run list
@@ -36,6 +43,7 @@ val summarize :
 
 val json_check_to_yojson : json_check -> Yojson.Safe.t
 val case_score_to_yojson : case_score -> Yojson.Safe.t
+val evidence_quality_issue_to_yojson : evidence_quality_issue -> Yojson.Safe.t
 val summary_row_to_yojson : summary_row -> Yojson.Safe.t
 val benchmark_summary_to_yojson : benchmark_summary -> Yojson.Safe.t
 val summary_rows_to_csv : view:summary_view -> benchmark_summary -> string

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_evidence_quality.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_evidence_quality.ml
@@ -1,0 +1,61 @@
+module Hashtbl = Stdlib.Hashtbl
+module List = Stdlib.List
+module String = Stdlib.String
+
+open Tool_call_quality_benchmark_types
+
+let semantic_selectors (benchmark_case : benchmark_case) =
+  let arg_selectors =
+    benchmark_case.arg_checks |> List.map (fun check -> check.selector)
+  in
+  benchmark_case.forbidden_selectors @ benchmark_case.required_selectors
+  @ arg_selectors
+  |> List.filter Eval_tool_selector.requires_route_evidence
+
+let route_evidence_has_semantic_fields = function
+  | Some (`Assoc fields) ->
+      List.exists
+        (fun (key, _value) ->
+          String.equal key "descriptor_id"
+          || String.equal key "runtime_handler"
+          || String.equal key "receipt_labels"
+          || String.equal key "eval_tags")
+        fields
+  | _ -> false
+
+let cases_by_id cases =
+  cases
+  |> List.to_seq
+  |> Stdlib.Seq.map (fun benchmark_case -> (benchmark_case.id, benchmark_case))
+  |> Hashtbl.of_seq
+
+let route_evidence_issues ~cases ~runs =
+  let case_table = cases_by_id cases in
+  runs
+  |> List.concat_map (fun (run : evidence_run) ->
+         match run.status, Hashtbl.find_opt case_table run.case_id with
+         | Run_ok, Some benchmark_case
+           when List.mem run.keeper_profile benchmark_case.keeper_profiles ->
+             let selectors = semantic_selectors benchmark_case in
+             if List.equal (=) selectors [] then []
+             else
+               let selector_labels = List.map Eval_tool_selector.label selectors in
+               run.tool_calls
+               |> List.mapi (fun tool_call_index (call : tool_call) ->
+                      if route_evidence_has_semantic_fields call.route_evidence then
+                        None
+                      else
+                        Some
+                          {
+                            kind = Missing_route_evidence;
+                            case_id = run.case_id;
+                            provider = run.provider;
+                            model = run.model;
+                            keeper_profile = run.keeper_profile;
+                            run_id = run.run_id;
+                            tool_call_index;
+                            tool_name = call.tool_name;
+                            selector_labels;
+                          })
+               |> List.filter_map (fun issue -> issue)
+         | _ -> [])

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_evidence_quality.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_evidence_quality.ml
@@ -12,16 +12,40 @@ let semantic_selectors (benchmark_case : benchmark_case) =
   @ arg_selectors
   |> List.filter Eval_tool_selector.requires_route_evidence
 
+(* A semantic selector matches route_evidence only when the relevant field
+   carries a usable value: a non-empty descriptor/handler string, a non-empty
+   eval-tag list, or a receipt-label assoc with at least one non-empty string
+   value. Empty values ([{"descriptor_id": ""}], [{"eval_tags": []}], ...)
+   cannot match any parsed selector, because Eval_tool_selector.of_yojson
+   rejects empty selector values, so they are not route evidence. This mirrors
+   {!Eval_tool_selector.matches}, which reads the same fields via
+   Json_util.assoc_string_opt / json_string_list_member / the receipt_labels
+   assoc and likewise yields no match for empty values. Checking only key
+   presence here would let vacuous evidence pass the gate. *)
 let route_evidence_has_semantic_fields = function
-  | Some (`Assoc fields) ->
-      List.exists
-        (fun (key, _value) ->
-          String.equal key "descriptor_id"
-          || String.equal key "runtime_handler"
-          || String.equal key "receipt_labels"
-          || String.equal key "eval_tags")
-        fields
-  | _ -> false
+  | Some json ->
+      let has_string field =
+        Option.is_some (Json_util.assoc_string_opt field json)
+      in
+      let has_eval_tags =
+        match Json_util.json_string_list_member "eval_tags" json with
+        | [] -> false
+        | _ :: _ -> true
+      in
+      let has_receipt_label =
+        match Json_util.assoc_member_opt "receipt_labels" json with
+        | Some (`Assoc receipt_fields) ->
+            List.exists
+              (fun (_key, value) ->
+                match value with
+                | `String text -> not (String.equal (String.trim text) "")
+                | _ -> false)
+              receipt_fields
+        | _ -> false
+      in
+      has_string "descriptor_id" || has_string "runtime_handler" || has_eval_tags
+      || has_receipt_label
+  | None -> false
 
 let cases_by_id cases =
   cases

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_evidence_quality.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_evidence_quality.mli
@@ -1,0 +1,18 @@
+(** Evidence-quality gates for tool-call benchmark runs.
+
+    These checks validate the benchmark evidence itself before model/tool
+    behavior is interpreted. They are intentionally separate from scoring:
+    missing route evidence is a harness/data-quality failure, not proof that
+    the model chose the wrong tool. *)
+
+val route_evidence_issues :
+     cases:Tool_call_quality_benchmark_types.benchmark_case list
+  -> runs:Tool_call_quality_benchmark_types.evidence_run list
+  -> Tool_call_quality_benchmark_types.evidence_quality_issue list
+(** [route_evidence_issues ~cases ~runs] reports every tool call from a
+    scored run whose case uses descriptor/runtime/receipt/eval-tag selectors
+    but whose evidence lacks usable [route_evidence].
+
+    Legacy name-only cases do not require route evidence. Runs that are not
+    [Run_ok], unknown cases, and runs for non-declared keeper profiles are
+    ignored in the same spirit as {!Tool_call_quality_benchmark_scoring.score_run}. *)

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_evidence_quality.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_evidence_quality.mli
@@ -5,6 +5,13 @@
     missing route evidence is a harness/data-quality failure, not proof that
     the model chose the wrong tool. *)
 
+val route_evidence_has_semantic_fields : Yojson.Safe.t option -> bool
+(** [route_evidence_has_semantic_fields evidence] is [true] when [evidence]
+    carries at least one non-empty semantic field (descriptor_id,
+    runtime_handler, eval_tags, or receipt_labels) usable for selector
+    matching. Empty strings, empty lists, and empty assocs are treated as
+    missing, matching {!Eval_tool_selector.matches}. *)
+
 val route_evidence_issues :
      cases:Tool_call_quality_benchmark_types.benchmark_case list
   -> runs:Tool_call_quality_benchmark_types.evidence_run list
@@ -12,6 +19,15 @@ val route_evidence_issues :
 (** [route_evidence_issues ~cases ~runs] reports every tool call from a
     scored run whose case uses descriptor/runtime/receipt/eval-tag selectors
     but whose evidence lacks usable [route_evidence].
+
+    Once a case carries at least one semantic selector, {e every} tool call in
+    its scored runs must carry usable route evidence: a selector cannot be
+    known in advance to target a particular call, and a call without evidence
+    cannot be evaluated at all. [route_evidence] is "usable" only when a field
+    carries a non-empty value — an empty descriptor/handler string, an empty
+    eval-tag list, or an empty receipt-label assoc is treated as missing,
+    matching {!Eval_tool_selector.matches}, which yields no match for empty
+    values.
 
     Legacy name-only cases do not require route evidence. Runs that are not
     [Run_ok], unknown cases, and runs for non-declared keeper profiles are

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.ml
@@ -100,10 +100,19 @@ let parse_json_check json =
   }
 
 let parse_arg_check json =
-  let* tool_name = required_string_field json "tool_name" in
+  let* selector =
+    match member_opt "selector" json with
+    | Some value ->
+        (match Eval_tool_selector.of_yojson value with
+         | Ok selector -> Ok selector
+         | Error msg -> errorf "invalid arg_check selector: %s" msg)
+    | None ->
+        let* tool_name = required_string_field json "tool_name" in
+        Ok (Eval_tool_selector.Tool_name tool_name)
+  in
   let* path = required_string_field json "path" in
   Ok {
-    tool_name;
+    selector;
     path;
     equals = member_opt "equals" json;
     contains = Json_util.get_string json "contains";
@@ -147,6 +156,7 @@ let benchmark_case_of_yojson json =
   let* prompt = required_string_field json "prompt" in
   let* forbidden_tools = string_list_field json "forbidden_tools" in
   let* forbidden_selectors = selector_list_field json "forbidden_selectors" in
+  let* required_selectors = selector_list_field json "required_selectors" in
   let* category =
     Json_util.get_string json "category"
     |> Option.value ~default:"tool_use"
@@ -166,6 +176,7 @@ let benchmark_case_of_yojson json =
     keeper_profiles;
     forbidden_tools;
     forbidden_selectors;
+    required_selectors;
     max_tool_calls;
     success_checks;
     arg_checks;

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_loader.mli
@@ -48,8 +48,10 @@ val load_cases_from_file :
     - [category] defaults to [["tool_use"]] when absent;
       unknown categories return [Error "unknown tool-call-quality
       category: <other>"]
-    - [forbidden_tools] / [forbidden_selectors] / [arg_checks]
-      default to empty lists
+    - [forbidden_tools] / [forbidden_selectors] /
+      [required_selectors] / [arg_checks] default to empty lists.
+      [arg_checks] accepts either legacy [tool_name] or a structured
+      [selector] using the same schema as [required_selectors].
     - [recovery_policy] defaults to [None] (case has no recovery
       requirement)
 

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_render.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_render.ml
@@ -52,6 +52,23 @@ let json_check_to_yojson (check : json_check) =
       ("present", Option.fold ~none:`Null ~some:(fun value -> `Bool value) check.present);
     ]
 
+let evidence_quality_issue_kind_to_string = function
+  | Missing_route_evidence -> "missing_route_evidence"
+
+let evidence_quality_issue_to_yojson (issue : evidence_quality_issue) =
+  `Assoc
+    [
+      ("kind", `String (evidence_quality_issue_kind_to_string issue.kind));
+      ("case_id", `String issue.case_id);
+      ("provider", `String issue.provider);
+      ("model", `String issue.model);
+      ("keeper_profile", `String issue.keeper_profile);
+      ("run_id", Option.fold ~none:`Null ~some:(fun value -> `String value) issue.run_id);
+      ("tool_call_index", `Int issue.tool_call_index);
+      ("tool_name", `String issue.tool_name);
+      ("selector_labels", `List (List.map (fun value -> `String value) issue.selector_labels));
+    ]
+
 let summary_row_to_yojson (row : summary_row) =
   `Assoc
     [

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_render.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_render.mli
@@ -38,6 +38,12 @@ val json_check_to_yojson :
     [present].  [equals] retains its original [Yojson.Safe.t] shape
     (any JSON value is permitted as a comparand). *)
 
+val evidence_quality_issue_to_yojson :
+  Tool_call_quality_benchmark_types.evidence_quality_issue -> Yojson.Safe.t
+(** [evidence_quality_issue_to_yojson issue] renders one benchmark
+    evidence-quality diagnostic. These diagnostics describe harness/evidence
+    incompleteness, not model behavior. *)
+
 val summary_row_to_yojson :
   Tool_call_quality_benchmark_types.summary_row -> Yojson.Safe.t
 (** [summary_row_to_yojson row] renders one aggregate row.  22

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.ml
@@ -127,6 +127,20 @@ let required_selector_satisfied (run : evidence_run) selector =
 let required_selectors_satisfied (benchmark_case : benchmark_case) (run : evidence_run) =
   List.for_all (required_selector_satisfied run) benchmark_case.required_selectors
 
+let semantic_selectors_evaluable (benchmark_case : benchmark_case) (run : evidence_run) =
+  let selectors =
+    benchmark_case.forbidden_selectors
+    @ benchmark_case.required_selectors
+    @ List.map (fun check -> check.selector) benchmark_case.arg_checks
+  in
+  if not (List.exists Eval_tool_selector.requires_route_evidence selectors) then true
+  else
+    List.exists
+      (fun call ->
+         Tool_call_quality_benchmark_evidence_quality.route_evidence_has_semantic_fields
+           call.route_evidence)
+      run.tool_calls
+
 let forbidden_tool_used (benchmark_case : benchmark_case) (run : evidence_run) =
   match benchmark_case.category with
   | Tool_forbidden -> Stdlib.List.length run.tool_calls > 0
@@ -217,6 +231,7 @@ let score_run ~cases (run : evidence_run) =
     | None -> None
     | Some benchmark_case ->
         if not (List.mem run.keeper_profile benchmark_case.keeper_profiles) then None
+        else if not (semantic_selectors_evaluable benchmark_case run) then None
         else
           let task_pass = task_pass_score benchmark_case run in
           let tool_selection =

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.ml
@@ -94,9 +94,12 @@ let evaluate_json_check ~(target : Yojson.Safe.t option) (check : json_check) =
   in
   present_ok && equals_ok && contains_ok && min_int_ok
 
+let selector_call_view (call : tool_call) : Eval_tool_selector.call =
+  { tool_name = call.tool_name; route_evidence = call.route_evidence }
+
 let arg_check_passes (run : evidence_run) (check : arg_check) =
   let predicate call =
-    String.equal call.tool_name check.tool_name
+    Eval_tool_selector.matches check.selector (selector_call_view call)
     && evaluate_json_check ~target:(Some call.input)
          { path = check.path
          ; equals = check.equals
@@ -108,16 +111,21 @@ let arg_check_passes (run : evidence_run) (check : arg_check) =
   List.exists predicate run.tool_calls
 
 let tool_sequence (run : evidence_run) =
-  run.tool_calls |> List.map (fun call -> call.tool_name)
-
-let selector_call_view (call : tool_call) : Eval_tool_selector.call =
-  { tool_name = call.tool_name; route_evidence = call.route_evidence }
+  run.tool_calls |> List.map (fun (call : tool_call) -> call.tool_name)
 
 let forbidden_call_used_by_case (benchmark_case : benchmark_case) (call : tool_call) =
   List.exists (String.equal call.tool_name) benchmark_case.forbidden_tools
   || List.exists
        (fun selector -> Eval_tool_selector.matches selector (selector_call_view call))
        benchmark_case.forbidden_selectors
+
+let required_selector_satisfied (run : evidence_run) selector =
+  List.exists
+    (fun call -> Eval_tool_selector.matches selector (selector_call_view call))
+    run.tool_calls
+
+let required_selectors_satisfied (benchmark_case : benchmark_case) (run : evidence_run) =
+  List.for_all (required_selector_satisfied run) benchmark_case.required_selectors
 
 let forbidden_tool_used (benchmark_case : benchmark_case) (run : evidence_run) =
   match benchmark_case.category with
@@ -212,7 +220,10 @@ let score_run ~cases (run : evidence_run) =
         else
           let task_pass = task_pass_score benchmark_case run in
           let tool_selection =
-            if forbidden_tool_used benchmark_case run then 0.0 else 1.0
+            if forbidden_tool_used benchmark_case run
+               || not (required_selectors_satisfied benchmark_case run)
+            then 0.0
+            else 1.0
           in
           let arg_validity = arg_validity_score benchmark_case run in
           let recovery = recovery_score benchmark_case run task_pass in

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.mli
@@ -52,8 +52,8 @@ val score_run :
     | Axis | Definition |
     |---|---|
     | `task_pass` | reported [task_success = true] AND every [success_check] passes against [final_result] |
-    | `tool_selection` | [0.0] if any forbidden tool name or forbidden selector is used; otherwise [1.0]. [Tool_forbidden] cases require zero calls. |
-    | `arg_validity` | [1.0] if no `arg_checks`; otherwise mean of per-check pass rate (each check passes iff at least one matching tool call satisfies it) |
+    | `tool_selection` | [0.0] if any forbidden tool name/selector is used or any required selector is missing; otherwise [1.0]. [Tool_forbidden] cases require zero calls. |
+    | `arg_validity` | [1.0] if no `arg_checks`; otherwise mean of per-check pass rate (each check passes iff at least one selector-matching tool call satisfies it) |
     | `recovery` | [1.0] for cases without [recovery_policy.required = true]; otherwise [1.0] iff [task_pass = 1.0] AND a successful call exists after at least one failure AND the failure count is within [max_failures_before_success] |
     | `efficiency` | [Tool_forbidden]: [1.0] if zero calls else [0.0]. Otherwise: [1.0 - (over_limit / max_tool_calls)], floored at [0.0]; [max_tool_calls <= 0] forces zero-call requirement |
 

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_scoring.mli
@@ -23,6 +23,10 @@ val score_run :
     - [run.keeper_profile] is not in the case's
       [keeper_profiles] (a run on the wrong profile is
       structurally invalid).
+    - the case uses descriptor/runtime/receipt/eval-tag selectors
+      but none of the run's tool calls carry usable [route_evidence]
+      (missing evidence is a data-quality failure, not proof that the
+      model chose the wrong tool).
 
     {2 Composite score formula (pinned)}
 

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_summary.ml
@@ -105,7 +105,7 @@ let modal_ratio values =
       Some (Stdlib.Float.of_int best /. Stdlib.Float.of_int (List.length values))
 
 let tool_sequence (run : evidence_run) =
-  run.tool_calls |> List.map (fun call -> call.tool_name)
+  run.tool_calls |> List.map (fun (call : tool_call) -> call.tool_name)
 
 let summary_key_of_run view (run : evidence_run) =
   match view with

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.ml
@@ -30,7 +30,7 @@ type json_check = {
 }
 
 type arg_check = {
-  tool_name : string;
+  selector : Eval_tool_selector.t;
   path : string;
   equals : Yojson.Safe.t option;
   contains : string option;
@@ -51,6 +51,7 @@ type benchmark_case = {
   keeper_profiles : string list;
   forbidden_tools : string list;
   forbidden_selectors : Eval_tool_selector.t list;
+  required_selectors : Eval_tool_selector.t list;
   max_tool_calls : int;
   success_checks : json_check list;
   arg_checks : arg_check list;
@@ -89,6 +90,21 @@ type evidence_run = {
   cost_usd : float option;
   status : run_status;
   tool_calls : tool_call list;
+}
+
+type evidence_quality_issue_kind =
+  | Missing_route_evidence
+
+type evidence_quality_issue = {
+  kind : evidence_quality_issue_kind;
+  case_id : string;
+  provider : string;
+  model : string;
+  keeper_profile : string;
+  run_id : string option;
+  tool_call_index : int;
+  tool_name : string;
+  selector_labels : string list;
 }
 
 type case_score = {

--- a/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.mli
+++ b/lib/tool_call_quality_benchmark/tool_call_quality_benchmark_types.mli
@@ -14,7 +14,7 @@ type json_check = {
 }
 
 type arg_check = {
-  tool_name : string;
+  selector : Eval_tool_selector.t;
   path : string;
   equals : Yojson.Safe.t option;
   contains : string option;
@@ -35,6 +35,7 @@ type benchmark_case = {
   keeper_profiles : string list;
   forbidden_tools : string list;
   forbidden_selectors : Eval_tool_selector.t list;
+  required_selectors : Eval_tool_selector.t list;
   max_tool_calls : int;
   success_checks : json_check list;
   arg_checks : arg_check list;
@@ -73,6 +74,21 @@ type evidence_run = {
   cost_usd : float option;
   status : run_status;
   tool_calls : tool_call list;
+}
+
+type evidence_quality_issue_kind =
+  | Missing_route_evidence
+
+type evidence_quality_issue = {
+  kind : evidence_quality_issue_kind;
+  case_id : string;
+  provider : string;
+  model : string;
+  keeper_profile : string;
+  run_id : string option;
+  tool_call_index : int;
+  tool_name : string;
+  selector_labels : string list;
 }
 
 type case_score = {

--- a/scripts/harness_tool_call_quality.sh
+++ b/scripts/harness_tool_call_quality.sh
@@ -3,10 +3,11 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_DIR="${TOOL_CALL_QUALITY_OUT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/tool-call-quality.XXXXXX")}"
-CASES_PATH="${TOOL_CALL_QUALITY_CASES_PATH:-${ROOT_DIR}/benchmark/tool_call_quality_cases.json}"
+CASES_PATH="${TOOL_CALL_QUALITY_CASES_PATH:-${ROOT_DIR}/benchmarks/data/tool_call_quality_cases.json}"
 EVIDENCE_PATH="${TOOL_CALL_QUALITY_EVIDENCE_PATH:-${ROOT_DIR}/test/fixtures/tool_call_quality_benchmark/evidence_runs.json}"
 FORMAT="${TOOL_CALL_QUALITY_FORMAT:-json}"
 VIEW="${TOOL_CALL_QUALITY_VIEW:-provider-model-keeper}"
+REQUIRE_ROUTE_EVIDENCE="${TOOL_CALL_QUALITY_REQUIRE_ROUTE_EVIDENCE:-1}"
 CLI_EXE="${ROOT_DIR}/_build/default/test/tool_call_quality_benchmark_cli.exe"
 
 MODELS="${TOOL_CALL_QUALITY_MODELS:-}"
@@ -35,7 +36,7 @@ Usage:
   scripts/harness_tool_call_quality.sh [--cases PATH] [--evidence PATH] [--format json|csv]
                                        [--view provider-model-keeper|provider-model|keeper]
                                        [--artifact-dir DIR] [--models CSV] [--keepers CSV]
-                                       [--case-ids CSV]
+                                       [--case-ids CSV] [--no-require-route-evidence]
   scripts/harness_tool_call_quality.sh --live --models provider:model[,provider:model]
                                        [--keepers CSV] [--case-ids CSV]
                                        [--repeats N] [--timeout-sec N]
@@ -450,6 +451,7 @@ tool_calls_for_evidence() {
           success: (.success // false),
           input: (.input // {}),
           output: (.output // null),
+          route_evidence: (.route_evidence // null),
           duration_ms: (.duration_ms // null)
         }
     ]
@@ -985,6 +987,9 @@ run_live_harness() {
     if [[ -n "${KEEPERS}" ]]; then
       args+=(--keepers "${KEEPERS}")
     fi
+    if [[ "${REQUIRE_ROUTE_EVIDENCE}" == "1" ]]; then
+      args+=(--require-route-evidence)
+    fi
     "${CLI_EXE}" "${args[@]}"
   )
 
@@ -1010,6 +1015,9 @@ run_evidence_summary() {
     fi
     if [[ -n "${KEEPERS}" ]]; then
       args+=(--keepers "${KEEPERS}")
+    fi
+    if [[ "${REQUIRE_ROUTE_EVIDENCE}" == "1" ]]; then
+      args+=(--require-route-evidence)
     fi
     "${CLI_EXE}" "${args[@]}"
   )
@@ -1049,6 +1057,14 @@ while [[ $# -gt 0 ]]; do
     --keepers)
       KEEPERS="$2"
       shift 2
+      ;;
+    --require-route-evidence)
+      REQUIRE_ROUTE_EVIDENCE=1
+      shift
+      ;;
+    --no-require-route-evidence)
+      REQUIRE_ROUTE_EVIDENCE=0
+      shift
       ;;
     --live)
       LIVE_MODE=1

--- a/test/fixtures/tool_call_quality_benchmark/evidence_runs.json
+++ b/test/fixtures/tool_call_quality_benchmark/evidence_runs.json
@@ -24,6 +24,10 @@
           "tool_name": "keeper_tool_search",
           "success": true,
           "duration_ms": 24.0,
+          "route_evidence": {
+            "descriptor_id": "keeper.tool_search",
+            "eval_tags": ["capability_introspection"]
+          },
           "input": {
             "query": "prompt_fingerprint keeper_tool_call_log"
           }
@@ -32,6 +36,10 @@
           "tool_name": "tool_read_file",
           "success": true,
           "duration_ms": 31.0,
+          "route_evidence": {
+            "descriptor_id": "agent.read_file",
+            "eval_tags": []
+          },
           "input": {
             "path": "lib/keeper_tool_call_log.ml"
           }
@@ -62,6 +70,10 @@
           "tool_name": "keeper_tool_search",
           "success": true,
           "duration_ms": 23.0,
+          "route_evidence": {
+            "descriptor_id": "keeper.tool_search",
+            "eval_tags": ["capability_introspection"]
+          },
           "input": {
             "query": "prompt_fingerprint keeper_tool_call_log"
           }
@@ -70,6 +82,10 @@
           "tool_name": "tool_read_file",
           "success": true,
           "duration_ms": 33.0,
+          "route_evidence": {
+            "descriptor_id": "agent.read_file",
+            "eval_tags": []
+          },
           "input": {
             "path": "lib/keeper_tool_call_log.ml"
           }
@@ -100,6 +116,10 @@
           "tool_name": "keeper_tool_search",
           "success": true,
           "duration_ms": 19.0,
+          "route_evidence": {
+            "descriptor_id": "keeper.tool_search",
+            "eval_tags": ["capability_introspection"]
+          },
           "input": {
             "query": "prompt_fingerprint keeper_tool_call_log"
           }
@@ -108,6 +128,10 @@
           "tool_name": "tool_execute",
           "success": true,
           "duration_ms": 48.0,
+          "route_evidence": {
+            "descriptor_id": "agent.execute",
+            "eval_tags": []
+          },
           "input": {
             "cmd": "rg prompt_fingerprint lib"
           }
@@ -116,6 +140,10 @@
           "tool_name": "tool_read_file",
           "success": true,
           "duration_ms": 30.0,
+          "route_evidence": {
+            "descriptor_id": "agent.read_file",
+            "eval_tags": []
+          },
           "input": {
             "path": "lib/keeper_tool_call_log.ml"
           }
@@ -167,6 +195,10 @@
           "tool_name": "tool_read_file",
           "success": false,
           "duration_ms": 15.0,
+          "route_evidence": {
+            "descriptor_id": "agent.read_file",
+            "eval_tags": []
+          },
           "input": {
             "path": "lib/missing_file.ml"
           }
@@ -175,6 +207,10 @@
           "tool_name": "keeper_tool_search",
           "success": true,
           "duration_ms": 20.0,
+          "route_evidence": {
+            "descriptor_id": "keeper.tool_search",
+            "eval_tags": ["capability_introspection"]
+          },
           "input": {
             "query": "keeper_agent_run prompt_fingerprint"
           }
@@ -183,6 +219,10 @@
           "tool_name": "tool_read_file",
           "success": true,
           "duration_ms": 34.0,
+          "route_evidence": {
+            "descriptor_id": "agent.read_file",
+            "eval_tags": []
+          },
           "input": {
             "path": "lib/keeper/keeper_agent_run.ml"
           }
@@ -213,6 +253,10 @@
           "tool_name": "tool_read_file",
           "success": false,
           "duration_ms": 18.0,
+          "route_evidence": {
+            "descriptor_id": "agent.read_file",
+            "eval_tags": []
+          },
           "input": {
             "path": "lib/missing_file.ml"
           }
@@ -221,6 +265,10 @@
           "tool_name": "keeper_tool_search",
           "success": true,
           "duration_ms": 24.0,
+          "route_evidence": {
+            "descriptor_id": "keeper.tool_search",
+            "eval_tags": ["capability_introspection"]
+          },
           "input": {
             "query": "keeper_agent_run prompt_fingerprint"
           }
@@ -229,6 +277,10 @@
           "tool_name": "tool_read_file",
           "success": true,
           "duration_ms": 39.0,
+          "route_evidence": {
+            "descriptor_id": "agent.read_file",
+            "eval_tags": []
+          },
           "input": {
             "path": "lib/keeper/keeper_agent_run.ml"
           }
@@ -237,6 +289,10 @@
           "tool_name": "tool_read_file",
           "success": true,
           "duration_ms": 22.0,
+          "route_evidence": {
+            "descriptor_id": "agent.read_file",
+            "eval_tags": []
+          },
           "input": {
             "path": "lib/keeper/keeper_agent_run.ml"
           }

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -39,7 +39,11 @@ let json_check_status_completed : Tool_call_quality_benchmark.json_check =
     present = None;
   }
 
-let selector_case ?(forbidden_tools = []) ?(forbidden_selectors = []) () :
+let selector_case
+    ?(forbidden_tools = [])
+    ?(forbidden_selectors = [])
+    ?(required_selectors = [])
+    () :
     Tool_call_quality_benchmark.benchmark_case =
   {
     id = "selector_case";
@@ -48,21 +52,33 @@ let selector_case ?(forbidden_tools = []) ?(forbidden_selectors = []) () :
     keeper_profiles = [ "bench-selector" ];
     forbidden_tools;
     forbidden_selectors;
+    required_selectors;
     max_tool_calls = 3;
     success_checks = [ json_check_status_completed ];
     arg_checks = [];
     recovery_policy = None;
   }
 
-let selector_tool_call ?route_evidence tool_name :
+let selector_tool_call ?route_evidence ?(input = `Assoc []) tool_name :
     Tool_call_quality_benchmark.tool_call =
   {
     tool_name;
     success = true;
-    input = `Assoc [];
+    input;
     output = None;
     route_evidence;
     duration_ms = None;
+  }
+
+let selector_arg_check ?contains selector path :
+    Tool_call_quality_benchmark.arg_check =
+  {
+    selector;
+    path;
+    equals = None;
+    contains;
+    min_int = None;
+    present = None;
   }
 
 let selector_run tool_calls : Tool_call_quality_benchmark.evidence_run =
@@ -200,7 +216,137 @@ let test_forbidden_selector_matches_eval_tag_evidence () =
       check (float 0.0001) "tool selection failed" 0.0 score.tool_selection
   | None -> fail "score_run unexpectedly returned None"
 
-let test_loader_parses_forbidden_selectors () =
+let test_required_selector_matches_eval_tag_evidence () =
+  let route_evidence =
+    `Assoc
+      [
+        ("descriptor_id", `String "keeper.surface.read");
+        ("eval_tags", `List [ `String "surface_context_read" ]);
+      ]
+  in
+  let case =
+    selector_case
+      ~required_selectors:[ Eval_tool_selector.Eval_tag "surface_context_read" ]
+      ()
+  in
+  let run = selector_run [ selector_tool_call ~route_evidence "renamed_surface_read" ] in
+  match Tool_call_quality_benchmark.score_run ~cases:[ case ] run with
+  | Some score ->
+      check bool "required eval tag permits pass" true score.passed;
+      check (float 0.0001) "tool selection passed" 1.0 score.tool_selection
+  | None -> fail "score_run unexpectedly returned None"
+
+let test_missing_required_selector_degrades_selection () =
+  let case =
+    selector_case
+      ~required_selectors:[ Eval_tool_selector.Descriptor_id "keeper.surface.read" ]
+      ()
+  in
+  let run = selector_run [ selector_tool_call "keeper_tool_search" ] in
+  match Tool_call_quality_benchmark.score_run ~cases:[ case ] run with
+  | Some score ->
+      check bool "missing required selector fails pass" false score.passed;
+      check (float 0.0001) "tool selection failed" 0.0 score.tool_selection
+  | None -> fail "score_run unexpectedly returned None"
+
+let test_arg_check_matches_descriptor_evidence () =
+  let route_evidence =
+    `Assoc [ ("descriptor_id", `String "keeper.surface.read") ]
+  in
+  let case =
+    {
+      (selector_case ())
+      with
+      arg_checks =
+        [
+          selector_arg_check
+            ~contains:"discord"
+            (Eval_tool_selector.Descriptor_id "keeper.surface.read")
+            "$.surface";
+        ];
+    }
+  in
+  let run =
+    selector_run
+      [
+        selector_tool_call
+          ~route_evidence
+          ~input:(`Assoc [ ("surface", `String "discord") ])
+          "renamed_surface_read";
+      ]
+  in
+  match Tool_call_quality_benchmark.score_run ~cases:[ case ] run with
+  | Some score ->
+      check bool "descriptor arg check permits pass" true score.passed;
+      check (float 0.0001) "arg validity passed" 1.0 score.arg_validity
+  | None -> fail "score_run unexpectedly returned None"
+
+let test_missing_arg_selector_degrades_arg_validity () =
+  let case =
+    {
+      (selector_case ())
+      with
+      arg_checks =
+        [
+          selector_arg_check
+            (Eval_tool_selector.Eval_tag "surface_context_read")
+            "$.surface";
+        ];
+    }
+  in
+  let run =
+    selector_run
+      [
+        selector_tool_call
+          ~input:(`Assoc [ ("surface", `String "discord") ])
+          "keeper_tool_search";
+      ]
+  in
+  match Tool_call_quality_benchmark.score_run ~cases:[ case ] run with
+  | Some score ->
+      check bool "missing selector fails pass" false score.passed;
+      check (float 0.0001) "arg validity failed" 0.0 score.arg_validity
+  | None -> fail "score_run unexpectedly returned None"
+
+let test_route_evidence_quality_accepts_default_fixture () =
+  let cases, runs = load_fixture () in
+  let issues = Tool_call_quality_benchmark.route_evidence_issues ~cases ~runs in
+  check int "default fixture issue count" 0 (List.length issues)
+
+let test_route_evidence_quality_reports_semantic_case_gaps () =
+  let case =
+    selector_case
+      ~required_selectors:[ Eval_tool_selector.Descriptor_id "keeper.surface.read" ]
+      ()
+  in
+  let missing_evidence_run =
+    selector_run [ selector_tool_call "renamed_surface_read" ]
+  in
+  let issues =
+    Tool_call_quality_benchmark.route_evidence_issues ~cases:[ case ]
+      ~runs:[ missing_evidence_run ]
+  in
+  check int "missing route evidence issue count" 1 (List.length issues);
+  let issue = List.hd issues in
+  check string "issue case id" "selector_case"
+    issue.Tool_call_quality_benchmark.case_id;
+  check string "issue tool name" "renamed_surface_read" issue.tool_name;
+  check bool "issue carries selector label" true
+    (List.mem "descriptor_id:keeper.surface.read" issue.selector_labels);
+  let route_evidence =
+    `Assoc [ ("descriptor_id", `String "keeper.surface.read") ]
+  in
+  let evidenced_run =
+    selector_run
+      [ selector_tool_call ~route_evidence "renamed_surface_read" ]
+  in
+  let clean_issues =
+    Tool_call_quality_benchmark.route_evidence_issues ~cases:[ case ]
+      ~runs:[ evidenced_run ]
+  in
+  check int "evidenced run issue count" 0 (List.length clean_issues)
+
+let test_loader_parses_selector_backed_case_fields () =
   let path = Filename.temp_file "tool-call-quality-selectors" ".json" in
   Fun.protect
     ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
@@ -218,18 +364,34 @@ let test_loader_parses_forbidden_selectors () =
         {"type": "descriptor_id", "value": "masc.agent.card"},
         {"type": "receipt_label", "key": "family", "value": "profile_lookup"}
       ],
+      "required_selectors": [
+        {"type": "eval_tag", "value": "surface_context_read"}
+      ],
       "max_tool_calls": 3,
       "success_checks": [
         {"path": "$.status", "equals": "completed"}
       ],
-      "arg_checks": []
+      "arg_checks": [
+        {
+          "selector": {"type": "descriptor_id", "value": "keeper.surface.read"},
+          "path": "$.surface",
+          "contains": "discord"
+        }
+      ]
     }
   ]
 }|};
       match Tool_call_quality_benchmark.load_cases_from_file path with
       | Ok [ case ] ->
           check int "selector count" 2
-            (List.length case.Tool_call_quality_benchmark.forbidden_selectors)
+            (List.length case.Tool_call_quality_benchmark.forbidden_selectors);
+          check int "required selector count" 1
+            (List.length case.Tool_call_quality_benchmark.required_selectors);
+          check int "arg check count" 1
+            (List.length case.Tool_call_quality_benchmark.arg_checks);
+          let arg_check = List.hd case.Tool_call_quality_benchmark.arg_checks in
+          check string "arg check selector" "descriptor_id:keeper.surface.read"
+            (Eval_tool_selector.label arg_check.Tool_call_quality_benchmark.selector)
       | Ok cases ->
           fail
             (Printf.sprintf "expected one parsed case, got %d"
@@ -248,7 +410,19 @@ let () =
              test_forbidden_selector_matches_descriptor_evidence;
            test_case "forbidden selector matches eval tag evidence" `Quick
              test_forbidden_selector_matches_eval_tag_evidence;
-           test_case "loader parses forbidden selectors" `Quick
-             test_loader_parses_forbidden_selectors;
+           test_case "required selector matches eval tag evidence" `Quick
+             test_required_selector_matches_eval_tag_evidence;
+           test_case "missing required selector degrades selection" `Quick
+             test_missing_required_selector_degrades_selection;
+           test_case "arg check matches descriptor evidence" `Quick
+             test_arg_check_matches_descriptor_evidence;
+           test_case "missing arg selector degrades arg validity" `Quick
+             test_missing_arg_selector_degrades_arg_validity;
+           test_case "route evidence quality accepts default fixture" `Quick
+             test_route_evidence_quality_accepts_default_fixture;
+           test_case "route evidence quality reports semantic gaps" `Quick
+             test_route_evidence_quality_reports_semantic_case_gaps;
+           test_case "loader parses selector-backed case fields" `Quick
+             test_loader_parses_selector_backed_case_fields;
          ]);
     ]

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -8,8 +8,17 @@ let fixture_runs repo_root =
   Filename.concat repo_root
     "test/fixtures/tool_call_quality_benchmark/evidence_runs.json"
 
+(* Under [dune runtest] the cwd is the sandbox dir, not the repo root, so the
+   benchmark fixtures (which live at repo-root [benchmarks/data/...] and are not
+   sandbox deps) are unreachable via [Sys.getcwd ()]. dune exports the real
+   workspace source root as DUNE_SOURCEROOT; resolve fixtures against it and
+   fall back to cwd for direct (non-dune) invocation. Mirrors
+   test_disk_hygiene_script.ml / test_ci_run_tests_script.ml. *)
+let repo_source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with Some root -> root | None -> Sys.getcwd ()
+
 let load_fixture () =
-  let repo_root = Sys.getcwd () in
+  let repo_root = repo_source_root () in
   let cases =
     match Tool_call_quality_benchmark.load_cases_from_file (fixture_cases repo_root) with
     | Ok v -> v

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -462,10 +462,6 @@ let test_loader_parses_legacy_tool_name_arg_check () =
                (List.length cases))
       | Error msg -> fail ("load_cases_from_file failed: " ^ msg))
 
-(* A semantic selector cannot match route_evidence whose field is present but
-   empty, so the gate must treat empty values as missing evidence (anti-pattern:
-   empty -> permissive "has evidence"). Each variant below would have passed the
-   gate when it only checked key presence. *)
 (* When a case uses semantic selectors but none of the run's tool calls carry
    usable route_evidence, scoring cannot distinguish "wrong tool" from
    "missing evidence". Per the evidence-quality contract, such runs are excluded
@@ -482,6 +478,10 @@ let test_unavailable_route_evidence_excludes_run_from_scoring () =
   | Some _ -> fail "score_run should return None when route evidence is unavailable"
   | None -> ()
 
+(* A semantic selector cannot match route_evidence whose field is present but
+   empty, so the gate must treat empty values as missing evidence (anti-pattern:
+   empty -> permissive "has evidence"). Each variant below would have passed the
+   gate when it only checked key presence. *)
 let test_route_evidence_quality_treats_empty_evidence_as_missing () =
   let case =
     selector_case

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -251,7 +251,10 @@ let test_missing_required_selector_degrades_selection () =
       ~required_selectors:[ Eval_tool_selector.Descriptor_id "keeper.surface.read" ]
       ()
   in
-  let run = selector_run [ selector_tool_call "keeper_tool_search" ] in
+  let route_evidence = `Assoc [ ("descriptor_id", `String "keeper.tool_search") ] in
+  let run =
+    selector_run [ selector_tool_call ~route_evidence "keeper_tool_search" ]
+  in
   match Tool_call_quality_benchmark.score_run ~cases:[ case ] run with
   | Some score ->
       check bool "missing required selector fails pass" false score.passed;
@@ -303,10 +306,14 @@ let test_missing_arg_selector_degrades_arg_validity () =
         ];
     }
   in
+  let route_evidence =
+    `Assoc [ ("eval_tags", `List [ `String "other_tag" ]) ]
+  in
   let run =
     selector_run
       [
         selector_tool_call
+          ~route_evidence
           ~input:(`Assoc [ ("surface", `String "discord") ])
           "keeper_tool_search";
       ]
@@ -459,6 +466,22 @@ let test_loader_parses_legacy_tool_name_arg_check () =
    empty, so the gate must treat empty values as missing evidence (anti-pattern:
    empty -> permissive "has evidence"). Each variant below would have passed the
    gate when it only checked key presence. *)
+(* When a case uses semantic selectors but none of the run's tool calls carry
+   usable route_evidence, scoring cannot distinguish "wrong tool" from
+   "missing evidence". Per the evidence-quality contract, such runs are excluded
+   from scoring rather than penalized as model failures. *)
+let test_unavailable_route_evidence_excludes_run_from_scoring () =
+  let case =
+    selector_case
+      ~required_selectors:
+        [ Eval_tool_selector.Descriptor_id "keeper.surface.read" ]
+      ()
+  in
+  let run = selector_run [ selector_tool_call "keeper_tool_search" ] in
+  match Tool_call_quality_benchmark.score_run ~cases:[ case ] run with
+  | Some _ -> fail "score_run should return None when route evidence is unavailable"
+  | None -> ()
+
 let test_route_evidence_quality_treats_empty_evidence_as_missing () =
   let case =
     selector_case
@@ -513,5 +536,7 @@ let () =
              test_loader_parses_legacy_tool_name_arg_check;
            test_case "route evidence quality treats empty fields as missing"
              `Quick test_route_evidence_quality_treats_empty_evidence_as_missing;
+           test_case "unavailable route evidence excludes run from scoring"
+             `Quick test_unavailable_route_evidence_excludes_run_from_scoring;
          ]);
     ]

--- a/test/test_tool_call_quality_benchmark.ml
+++ b/test/test_tool_call_quality_benchmark.ml
@@ -407,6 +407,82 @@ let test_loader_parses_selector_backed_case_fields () =
                (List.length cases))
       | Error msg -> fail ("load_cases_from_file failed: " ^ msg))
 
+(* Regression guard for the legacy [tool_name] arg_check shape: case JSON that
+   predates typed selectors carries a bare ["tool_name"] field instead of a
+   ["selector"] object. parse_arg_check must keep parsing it as
+   [Eval_tool_selector.Tool_name], so removing that fallback fails here. *)
+let test_loader_parses_legacy_tool_name_arg_check () =
+  let path = Filename.temp_file "tool-call-quality-legacy" ".json" in
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+      Fs_compat.save_file path
+        {|{
+  "cases": [
+    {
+      "id": "legacy_arg_check_case",
+      "prompt": "synthetic legacy arg_check case",
+      "category": "tool_use",
+      "keeper_profiles": ["bench-selector"],
+      "forbidden_tools": [],
+      "forbidden_selectors": [],
+      "required_selectors": [],
+      "max_tool_calls": 3,
+      "success_checks": [
+        {"path": "$.status", "equals": "completed"}
+      ],
+      "arg_checks": [
+        {
+          "tool_name": "tool_read_file",
+          "path": "$.path",
+          "contains": "keeper_tool_call_log"
+        }
+      ]
+    }
+  ]
+}|};
+      match Tool_call_quality_benchmark.load_cases_from_file path with
+      | Ok [ case ] ->
+          check int "arg check count" 1
+            (List.length case.Tool_call_quality_benchmark.arg_checks);
+          let arg_check = List.hd case.Tool_call_quality_benchmark.arg_checks in
+          check string "legacy tool_name selector" "tool_name:tool_read_file"
+            (Eval_tool_selector.label
+               arg_check.Tool_call_quality_benchmark.selector)
+      | Ok cases ->
+          fail
+            (Printf.sprintf "expected one parsed case, got %d"
+               (List.length cases))
+      | Error msg -> fail ("load_cases_from_file failed: " ^ msg))
+
+(* A semantic selector cannot match route_evidence whose field is present but
+   empty, so the gate must treat empty values as missing evidence (anti-pattern:
+   empty -> permissive "has evidence"). Each variant below would have passed the
+   gate when it only checked key presence. *)
+let test_route_evidence_quality_treats_empty_evidence_as_missing () =
+  let case =
+    selector_case
+      ~required_selectors:
+        [ Eval_tool_selector.Descriptor_id "keeper.surface.read" ]
+      ()
+  in
+  let empty_evidence_run route_evidence =
+    selector_run [ selector_tool_call ~route_evidence "renamed_surface_read" ]
+  in
+  List.iter
+    (fun (label, route_evidence) ->
+      let issues =
+        Tool_call_quality_benchmark.route_evidence_issues ~cases:[ case ]
+          ~runs:[ empty_evidence_run route_evidence ]
+      in
+      check int (label ^ " issue count") 1 (List.length issues))
+    [
+      ("empty descriptor_id", `Assoc [ ("descriptor_id", `String "") ]);
+      ("blank runtime_handler", `Assoc [ ("runtime_handler", `String "  ") ]);
+      ("empty eval_tags", `Assoc [ ("eval_tags", `List []) ]);
+      ("empty receipt_labels", `Assoc [ ("receipt_labels", `Assoc []) ]);
+    ]
+
 let () =
   run "tool_call_quality_benchmark"
     [
@@ -433,5 +509,9 @@ let () =
              test_route_evidence_quality_reports_semantic_case_gaps;
            test_case "loader parses selector-backed case fields" `Quick
              test_loader_parses_selector_backed_case_fields;
+           test_case "loader parses legacy tool_name arg check" `Quick
+             test_loader_parses_legacy_tool_name_arg_check;
+           test_case "route evidence quality treats empty fields as missing"
+             `Quick test_route_evidence_quality_treats_empty_evidence_as_missing;
          ]);
     ]

--- a/test/tool_call_quality_benchmark_cli.ml
+++ b/test/tool_call_quality_benchmark_cli.ml
@@ -50,7 +50,9 @@ let () =
       ("--view", Arg.Set_string view, "Summary view: provider-model-keeper, provider-model, keeper");
       ("--require-route-evidence",
        Arg.Set require_route_evidence,
-       "Fail if selector-backed cases have tool calls without route_evidence");
+       "Fail if selector-backed cases have tool calls without usable \
+        route_evidence (default: off; pass this flag in CI/live benchmarking \
+        to enforce evidence quality)");
       ("--models",
        Arg.String (fun value -> model_filters := parse_csv_arg value),
        "Comma-separated provider:model filters");

--- a/test/tool_call_quality_benchmark_cli.ml
+++ b/test/tool_call_quality_benchmark_cli.ml
@@ -37,6 +37,7 @@ let () =
   let artifact_dir = ref "" in
   let emit_canary_path = ref "" in
   let view = ref "provider-model-keeper" in
+  let require_route_evidence = ref false in
   let model_filters : string list ref = ref [] in
   let keeper_filters : string list ref = ref [] in
   let specs =
@@ -47,6 +48,9 @@ let () =
       ("--artifact-dir", Arg.Set_string artifact_dir, "Write summary artifacts to this directory");
       ("--emit-canary", Arg.Set_string emit_canary_path, "Write keeper benchmark canary recommendation JSON to this path");
       ("--view", Arg.Set_string view, "Summary view: provider-model-keeper, provider-model, keeper");
+      ("--require-route-evidence",
+       Arg.Set require_route_evidence,
+       "Fail if selector-backed cases have tool calls without route_evidence");
       ("--models",
        Arg.String (fun value -> model_filters := parse_csv_arg value),
        "Comma-separated provider:model filters");
@@ -78,6 +82,21 @@ let () =
   let canary_manifest =
     Keeper_benchmark_canary.build_manifest summary
   in
+  let route_evidence_issues =
+    Tool_call_quality_benchmark.route_evidence_issues ~cases ~runs
+  in
+  let evidence_quality_json =
+    `Assoc
+      [
+        ("route_evidence_required", `Bool !require_route_evidence);
+        ("route_evidence_issue_count", `Int (List.length route_evidence_issues));
+        ( "route_evidence_issues",
+          `List
+            (List.map
+               Tool_call_quality_benchmark.evidence_quality_issue_to_yojson
+               route_evidence_issues) );
+      ]
+  in
   let view =
     match String.lowercase_ascii (String.trim !view) with
     | "provider-model-keeper" -> Tool_call_quality_benchmark.By_provider_model_keeper
@@ -93,6 +112,7 @@ let () =
             ("cases_path", `String !cases_path);
             ("evidence_path", `String !evidence_path);
             ("summary", Tool_call_quality_benchmark.benchmark_summary_to_yojson summary);
+            ("evidence_quality", evidence_quality_json);
             ("keeper_benchmark_canary",
              Keeper_benchmark_canary.manifest_to_yojson canary_manifest);
             ("rows", summary_rows_json view summary);
@@ -124,4 +144,9 @@ let () =
    | None -> ());
   print_string output;
   if String.length output = 0 || output.[String.length output - 1] <> '\n' then
-    print_newline ()
+    print_newline ();
+  if !require_route_evidence && not (List.equal (=) route_evidence_issues []) then (
+    prerr_endline
+      (Printf.sprintf "route_evidence completeness failed: %d issue(s)"
+         (List.length route_evidence_issues));
+    exit 2)


### PR DESCRIPTION
## 요약
tool-call-quality 벤치마크 하네스의 selector 추상화를 완성합니다. 기존 `forbidden_selectors`(typed)와 대칭으로 `required_selectors`를 추가하고, `arg_check`의 매칭을 raw `tool_name` 문자열 대신 typed `Eval_tool_selector.t`로 전환합니다.

## 동기
main에는 `forbidden_selectors`(typed selector)가 이미 있으나 대칭인 `required_selectors`가 없고, `arg_check`는 여전히 `tool_name` 문자열로 매칭했습니다. typed selector 추상화가 절반만 적용된 상태로, 벤치마크 케이스가 도구를 문자열 이름으로만 식별해 descriptor/runtime/receipt/eval-tag 경로를 구분하지 못했습니다. 이 PR은 문자열 매칭을 제거하고 typed selector로 일원화합니다.

## 변경
- `benchmark_case.required_selectors : Eval_tool_selector.t list` 추가 — run이 모든 required selector를 만족하지 못하면 케이스 실패(scoring). forbidden-tool 게이트와 대칭.
- `arg_check.tool_name : string` → `selector : Eval_tool_selector.t` (문자열 식별자 제거).
- `requires_route_evidence` — selector variant에 대한 exhaustive match. legacy `Tool_name`만 name-only, descriptor/runtime/receipt/eval-tag은 route evidence 필요.
- typed `evidence_quality` 모듈(`Missing_route_evidence` closed variant) — ad-hoc 문자열 대체.
- 테스트 +190줄, 벤치마크 케이스 데이터/픽스처 갱신, `.ml`/`.mli` 동반.

## 출처 (provenance)
방치된 worktree(`codex/tool-quality-required-selectors-20260615`)에 미커밋 상태로 있던 작업을 발굴해 current main 위로 cherry-pick(충돌 0). 같은 worktree에 섞여 있던 무관 작업(`keeper_turn_event` 대시보드 노출, RFC-0238 로드맵 문서)은 selector 하네스로 범위를 좁히기 위해 제외했습니다.

## 검증
- 로컬 빌드/테스트는 CI(Build and Test)에 위임.
- cherry-pick 충돌 0. 대상 selector/benchmark 파일은 stale base 이후 main 드리프트 0 (drift는 제외한 dashboard/test 파일 2개뿐).

RFC-WAIVED: eval_tool_selector / tool_call_quality_benchmark는 RFC-게이트 subsystem(credential/repo/operator/sandbox/dashboard-credential/hooks/workflow)에 해당하지 않음. 하네스 평가 코드.

WORKAROUND-WAIVED: STRING_CLASSIFIER false-positive — 이 PR은 문자열 분류기를 추가하는 게 아니라 제거합니다. `arg_check.tool_name : string` → `selector : Eval_tool_selector.t`로 전환하고 `required_selectors`를 typed로 추가해, 벤치마크가 문자열 이름 매칭 대신 typed selector(descriptor/runtime/receipt/eval-tag)로 일원화합니다. 게이트가 본문의 "string"/"문자열" 키워드에 반응한 것이며, 변경 방향은 string→typed로 안티패턴을 닫는 쪽입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
