### PR TITLE
fix(dashboard): themed scrollbar for keeper workspace scroll areas (keeper-v2 craft fidelity)

### DIFF
--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -283,8 +283,15 @@
    variant — user bubbles render `.chat-bubble.user` directly, covered above. */
 
 /* ── Scrollbar treatment ──────────────────────────────────────── */
+/* Keeper workspace scroll areas render `.kw-thread`/`.kw-rail-scroll`/
+   `.kw-roster-list`; the design class names (`.thread`/`.ctx-scroll`/
+   `.roster-list`) are kept for other surfaces, the `.kw-*` ones added so the
+   keeper workspace gets the same 10px themed scrollbar (verified live). */
 .v2-app .dashboard-main-scroll::-webkit-scrollbar,
 .v2-app .v2-shell-rail::-webkit-scrollbar,
+.v2-app .kw-thread::-webkit-scrollbar,
+.v2-app .kw-rail-scroll::-webkit-scrollbar,
+.v2-app .kw-roster-list::-webkit-scrollbar,
 .v2-app .thread::-webkit-scrollbar,
 .v2-app .ctx-scroll::-webkit-scrollbar,
 .v2-app .roster-list::-webkit-scrollbar,
@@ -300,6 +307,9 @@
 
 .v2-app .dashboard-main-scroll::-webkit-scrollbar-thumb,
 .v2-app .v2-shell-rail::-webkit-scrollbar-thumb,
+.v2-app .kw-thread::-webkit-scrollbar-thumb,
+.v2-app .kw-rail-scroll::-webkit-scrollbar-thumb,
+.v2-app .kw-roster-list::-webkit-scrollbar-thumb,
 .v2-app .thread::-webkit-scrollbar-thumb,
 .v2-app .ctx-scroll::-webkit-scrollbar-thumb,
 .v2-app .roster-list::-webkit-scrollbar-thumb,
@@ -317,6 +327,9 @@
   transition: background var(--dur);
 }
 
+.v2-app .kw-thread::-webkit-scrollbar-thumb:hover,
+.v2-app .kw-rail-scroll::-webkit-scrollbar-thumb:hover,
+.v2-app .kw-roster-list::-webkit-scrollbar-thumb:hover,
 .v2-app .thread::-webkit-scrollbar-thumb:hover,
 .v2-app .ctx-scroll::-webkit-scrollbar-thumb:hover,
 .v2-app .roster-list::-webkit-scrollbar-thumb:hover,

--- a/dashboard/src/styles/craft-v2.test.ts
+++ b/dashboard/src/styles/craft-v2.test.ts
@@ -94,6 +94,17 @@ describe('craft-v2.css density chat console (retargeted to live classes)', () =>
       .toBe('11px')
   })
 
+  it('gives the keeper workspace scroll areas the themed webkit scrollbar', () => {
+    // The design scoped the scrollbar to `.thread`/`.ctx-scroll`/`.roster-list`;
+    // the keeper workspace renders `.kw-thread`/`.kw-rail-scroll`/`.kw-roster-list`,
+    // so those need to be in the selector list to get the 10px themed bar.
+    expect(declarationsForSelector(css, '.v2-app .kw-thread::-webkit-scrollbar').width).toBe('10px')
+    expect(declarationsForSelector(css, '.v2-app .kw-rail-scroll::-webkit-scrollbar').width).toBe('10px')
+    expect(declarationsForSelector(css, '.v2-app .kw-roster-list::-webkit-scrollbar').width).toBe('10px')
+    expect(declarationsForSelector(css, '.v2-app .kw-thread::-webkit-scrollbar-thumb')['background-clip'])
+      .toBe('padding-box')
+  })
+
   it('does not target the design-only .thread / .bubble chat classes (regression guard)', () => {
     // The live keeper workspace renders `.kw-thread` / `.chat-bubble`; the design
     // class names `.thread` / `.bubble` never match, so a density rule on them is dead.


### PR DESCRIPTION
## 무엇을 / 왜

keeper-v2 craft fidelity 후속 (#21927 density 머지 후). craft 스크롤바 트리트먼트가 디자인 class명(`.thread`/`.ctx-scroll`/`.roster-list`)을 타깃했으나, keeper workspace는 `.kw-thread`/`.kw-rail-scroll`/`.kw-roster-list`를 렌더 → 해당 스크롤 영역(채팅 thread·컨텍스트 레일·로스터)이 default webkit 스크롤바로 폴백(전역 Firefox `scrollbar-width: thin`만 적용).

## 변경 (`craft-v2.css`)
- 스크롤바 selector 목록 3그룹(base/thumb/thumb:hover)에 `.kw-thread`/`.kw-rail-scroll`/`.kw-roster-list`를 **additive**로 추가(디자인명은 타 surface용으로 보존) → keeper workspace 스크롤 영역도 10px 테마 thumb 적용.
- keeper craft 레이어 fidelity 완결(flat #21921 · density #21927 · scrollbar).

## 범위 / 경계
- dashboard styling only → RFC-gate 비대상. additive(기존 selector 제거 없음)라 회귀 위험 최소.
- 라이브 확인: `.kw-thread`/`.kw-rail-scroll`/`.kw-roster-list` 가동 중 대시보드 DOM에 실재.

## 검증
- `tsc` clean · `vitest` **9/9** (`.kw-*` 스크롤 클래스가 10px width + padding-box thumb 보유 가드 추가).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
