### PR TITLE
docs(dashboard): fix stale gate_rejected + dead sse supervisor comments

### DIFF
--- a/dashboard/src/components/keeper-detail-outcomes.ts
+++ b/dashboard/src/components/keeper-detail-outcomes.ts
@@ -14,7 +14,8 @@ import { MutedSpan, DetailCard } from './keeper-detail-kpi'
 //     Counters pulled from [Keeper_transition_audit] (50-entry ring):
 //       ✅ successes.substantive_turns
 //       ⚠️ failures.turn_failed
-//       🚫 failures.gate_rejected (always 0 until CDAL #7531)
+//       🚫 failures.gate_rejected (live — counts Turn_gate_rejected audits from
+//          the keeper guards; source: lib/dashboard/dashboard_http_keeper_outcomes.ml)
 //     Rendered as compact inline counters + a stacked proportion bar.
 //     Secondary row lists compactions_ok / handoffs_ok as chips.
 //

--- a/dashboard/src/sse.ts
+++ b/dashboard/src/sse.ts
@@ -1031,7 +1031,6 @@ function handleEvent(event: SSEEvent): void {
       const p = (event.payload ?? {}) as Record<string, unknown>
       const runtimeId = asString(p.runtime_id) ?? 'unknown'
       const branch = asString(p.branch) ?? 'unknown'
-      // supervisor extracted for future use
       const connected = p.connected === true
       const entries = Array.isArray(p.entries) ? p.entries.length : 0
       addTypedJournalEntry(


### PR DESCRIPTION
## 무엇을 / 왜

discovery 적대 감사(wevzh113v)에서 확인된 **stale/dead 코드 주석 2건** 정정 — 둘 다 백엔드/코드로 검증된 misleading 주석.

- **`keeper-detail-outcomes.ts:17`**: `gate_rejected` 카운터 주석이 "always 0 until CDAL #7531"이라 표기 → 실제로는 **live**. `dashboard_http_keeper_outcomes.ml:38`이 `Keeper_transition_audit.Turn_gate_rejected`마다 `fail_gate_rejected`를 증가시키고 `:117`에서 `gate_rejected`로 emit, keeper guards가 mark. 주석이 `🚫 거절` 행을 dead로 오인하게 만듦 → live 소스로 정정.
- **`sse.ts:1034`**: `ide:presence` 핸들러의 `// supervisor extracted for future use` 주석 제거 — 해당 블록(runtime_id/branch/connected/entries만 추출)에 supervisor 변수가 없는 leftover dead 주석.

## 범위 / 검증
- **주석만 변경, 동작 무변경**. dashboard styling/logic 무관, RFC-gate 비대상.
- `tsc --noEmit` clean · `eslint` clean. (added lines<10 → test-coverage 게이트 비대상; 동작 변화 없어 테스트 추가 불요)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
