### PR TITLE
fix(server): pass ~force:false to execution_query_json broadcast (unblock main red from #21928)

### DIFF
--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -662,7 +662,8 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
                    ~fixture:None
                    ~full_mode:false
                    ~light:true
-                   ~default_light_request:true));
+                   ~default_light_request:true
+                   ~force:false));
       !broadcast_namespace_truth_ref state)
 ;;
 


### PR DESCRIPTION
## Summary
Passes the missing `~force:false` argument to the `execution_query_json` call in the `broadcast_cached_surface` `on_result` path (`lib/server/server_dashboard_http_execution_surfaces.ml:660-666`).

## Root cause — main is red
#21928 added a required `~force:bool` argument to `execution_query_json` (`:331`) and updated the HTTP handler call site to pass it, but missed this server-side broadcast call site. The under-applied call breaks `dune build @install --force` under `warn-error=+a`. main `1a56183844` (#21928) is CI-failure; `90d98c58f7` before it was success. This is blocking every PR built on current main (incl. #21929, #21930).

## Fix
`~force:false`. This broadcast re-emits a just-computed cached surface as an `execution_snapshot`; it sits before the `force` match arm and represents normal (non-force) propagation, so `false` preserves the pre-#21928 behavior. The HTTP handler already reads `force` from the request query param and passes it; only this broadcast site was missed.

## Verification
- Type-guaranteed: supplies the missing required labeled argument.
- `~force:false` chosen from the call site's position (pre-force-arm, non-force path) and `force`'s default (`bool_query_param ~default:false`).
- CI is the build authority for the full `warn-error=+a` build (local worktree dune context was uncooperative for a fast scoped check).

Unblocks main + #21929 + #21930 once merged.

Co-Authored-By: Claude <noreply@anthropic.com>
