### PR TITLE
feat(keeper): Mid_turn_no_progress kill-class에 첫 producer 배선 (RFC-0012)

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 355 unique knobs across 9 modules.
+**Total**: 356 unique knobs across 9 modules.
 
-**Typed getter classification**: 21/208 tagged (`operator`: 21, `algorithm`: 0, `unclassified`: 187).
+**Typed getter classification**: 22/209 tagged (`operator`: 22, `algorithm`: 0, `unclassified`: 187).
 
 ## Env_config_core (29 knobs; typed classification 1/12)
 
@@ -189,120 +189,121 @@ the categorization roadmap. Newly-added typed getters in
 |---|---|---|---|---|---|
 | `MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 99 |  |
 
-## Env_config_runtime (114 knobs; typed classification 4/90)
+## Env_config_runtime (115 knobs; typed classification 5/91)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 588 | Per-agent burst capacity. Default: 50. |
-| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 585 | Per-agent requests per second. Default: 20. |
+| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 617 | Per-agent burst capacity. Default: 50. |
+| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 614 | Per-agent requests per second. Default: 20. |
 | `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 312 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
 | `MASC_APPROVAL_JANITOR_ENABLED` | typed:bool | unclassified | unclassified | 385 | Enable the periodic approval_janitor sweep fiber.  Default: true. Set MASC_APPROVAL_JANITOR_ENABLED=false to disable ... |
 | `MASC_APPROVAL_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 393 | Sweep interval in seconds.  Default: 60s (every minute). Operators tolerate up to a minute of "approval still pending... |
-| `MASC_BOARD_BACKEND` | string_literal | n/a | n/a | 475 | Board backend type as a typed selector (e.g. "jsonl", "pg"). |
-| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 471 | Flush interval for board persistence (seconds). Default: 30. |
-| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 819 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
+| `MASC_BOARD_BACKEND` | string_literal | n/a | n/a | 504 | Board backend type as a typed selector (e.g. "jsonl", "pg"). |
+| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 500 | Flush interval for board persistence (seconds). Default: 30. |
+| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 848 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
 | `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 73 | Maximum total number of cache entries (default 1000) |
 | `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 69 | Maximum size of a single cache entry value in bytes (default 100KB) |
-| `MASC_CANCELLATION_CLEANUP_SEC` | typed:float | unclassified | unclassified | 831 | Cancellation token cleanup interval (seconds). Default: 300 (5 min). |
+| `MASC_CANCELLATION_CLEANUP_SEC` | typed:float | unclassified | unclassified | 860 | Cancellation token cleanup interval (seconds). Default: 300 (5 min). |
 | `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 187 | Token cleanup max age (seconds) |
 | `MASC_CDAL_ENABLED` | feature_flag | n/a | n/a | 335 | Enable contract-driven proof capture. Default: true. |
 | `MASC_CDAL_GATE_ENABLED` | feature_flag | n/a | n/a | 339 | Block task completion when CDAL verdict is Violated/Inconclusive. Default: false. |
 | `MASC_CDAL_VERDICT_LOOKUP_LIMIT` | typed:int | unclassified | unclassified | 346 | Max verdicts to scan when looking up the latest verdict by task_id. Beyond this limit, older entries are silently ski... |
 | `MASC_CLAIM_TTL_SECONDS` | typed:float | unclassified | unclassified | 96 | Maximum time a task can stay Claimed/InProgress without agent heartbeat before being auto-released back to Todo (seco... |
-| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 666 |  |
-| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 662 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
-| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 664 |  |
-| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 705 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
-| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 719 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
-| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 657 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
-| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 729 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
-| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 762 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
-| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 749 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
-| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 694 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 689 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
-| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 738 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
-| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 653 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
-| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 649 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
-| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 645 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
+| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 695 |  |
+| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 691 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
+| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 693 |  |
+| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 734 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
+| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 748 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
+| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 686 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
+| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 758 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
+| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 791 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
+| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 778 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
+| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 723 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 718 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
+| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 767 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
+| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 682 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
+| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 678 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
+| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 674 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
 | `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 85 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
-| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 792 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
-| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 780 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
-| `MASC_FULL_SURFACE` | feature_flag | n/a | n/a | 508 | Full tool surface override. Default: false. Re-readable within the process; callers should still document the effecti... |
+| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 821 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
+| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 809 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
+| `MASC_FULL_SURFACE` | feature_flag | n/a | n/a | 537 | Full tool surface override. Default: false. Re-readable within the process; callers should still document the effecti... |
 | `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 287 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
 | `MASC_GRPC_PORT` | string_literal | n/a | n/a | 283 | gRPC server port. Default: 8936. |
 | `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 291 | gRPC client target address. Derived from grpc_port when unset. |
 | `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 317 |  |
-| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 847 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
-| `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` | typed:float | unclassified | unclassified | 823 | Keeper world observation bootstrap window (seconds). Default: 300 (5 min). |
+| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 876 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
+| `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` | typed:float | unclassified | unclassified | 852 | Keeper world observation bootstrap window (seconds). Default: 300 (5 min). |
 | `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 417 | {1 Keeper Max-Turn Watchdog (RFC-0109 P4)} Opt-in keeper-level wall-clock watchdog. Default disabled — opt-in via [... |
+| `MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC` | typed:float | Timeouts | operator | 465 | In-turn progress-silence threshold in seconds; produces [Mid_turn_no_progress] when a running turn records no progres... |
 | `MASC_KEEPER_STALE_RUN_SEC` | typed:float | unclassified | unclassified | 437 | {1 Keeper Stale-Run Window (RFC-0250)} Default-on wall-clock window for the no-turn-produced case, distinct from the ... |
 | `MASC_KEEPER_ZOMBIE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 10 | Threshold for keeper agents (longer grace period, default 1 hour) |
-| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 811 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
-| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 815 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
-| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 513 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
+| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 840 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
+| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 844 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 542 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
 | `MASC_LLAMA_MAX_TOKENS` | typed:int | unclassified | unclassified | 160 | Upper bound for local runtime requests. Callers may request less, but never more than this cap. Falls back to MASC_LL... |
 | `MASC_LOCAL_MAX_TOKENS` | typed:int | unclassified | unclassified | 158 | Upper bound for local runtime requests. Callers may request less, but never more than this cap. Falls back to MASC_LL... |
-| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 600 | Local runtime cooldown (seconds). |
-| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 596 | Enable local runtime debug logging. Default: false. |
-| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 606 | Local worker heartbeat interval (seconds). Default: 60. |
-| `MASC_LOCAL_WORKER_MAX_TOKENS` | typed:int | unclassified | unclassified | 603 | Local worker max tokens per request. Default: 1024. |
+| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 629 | Local runtime cooldown (seconds). |
+| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 625 | Enable local runtime debug logging. Default: false. |
+| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 635 | Local worker heartbeat interval (seconds). Default: 60. |
+| `MASC_LOCAL_WORKER_MAX_TOKENS` | typed:int | unclassified | unclassified | 632 | Local worker max tokens per request. Default: 1024. |
 | `MASC_LOCK_EXPIRY_WARNING_SEC` | typed:float | unclassified | unclassified | 28 | Lock expiry warning threshold (seconds before expiry) |
 | `MASC_LOCK_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 24 | Default lock timeout (seconds). Reduced from 1800s (30 min) to 120s (2 min) — file locks should fail fast; a 30-min... |
 | `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 229 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted... |
-| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 803 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
-| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 614 | SSE drain interval (seconds). Default: 2.0. |
+| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 832 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 643 | SSE drain interval (seconds). Default: 2.0. |
 | `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 108 | Orchestrator agent name |
 | `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 104 | Orchestrator check interval (seconds) |
 | `MASC_ORCHESTRATOR_MIN_PRIORITY` | typed:int | unclassified | unclassified | 111 |  |
 | `MASC_ORCHESTRATOR_TIMEOUT` | typed:int | unclassified | unclassified | 114 |  |
-| `MASC_PROC_MIN_CONFIDENCE` | typed:float | unclassified | unclassified | 488 | Minimum confidence for crystallization, clamped to [0, 1]. Default: 0.7. |
-| `MASC_PROC_MIN_EVIDENCE` | typed:int | unclassified | unclassified | 484 | Minimum evidence count for crystallization. Default: 3. |
-| `MASC_PROVIDER_RUN_TTL_SEC` | typed:float | unclassified | unclassified | 835 | Provider run finished TTL (seconds). Default: 3600 (1 hour). |
-| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 547 | Extra public tools (comma-separated names). |
-| `MASC_PULSE_MAX_CONSUMER_FAILURES` | typed:int | unclassified | unclassified | 495 | Max consecutive consumer failures before recovery. Default: 3. |
-| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 582 | Burst capacity. Default: 150. |
-| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 579 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 861 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
+| `MASC_PROC_MIN_CONFIDENCE` | typed:float | unclassified | unclassified | 517 | Minimum confidence for crystallization, clamped to [0, 1]. Default: 0.7. |
+| `MASC_PROC_MIN_EVIDENCE` | typed:int | unclassified | unclassified | 513 | Minimum evidence count for crystallization. Default: 3. |
+| `MASC_PROVIDER_RUN_TTL_SEC` | typed:float | unclassified | unclassified | 864 | Provider run finished TTL (seconds). Default: 3600 (1 hour). |
+| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 576 | Extra public tools (comma-separated names). |
+| `MASC_PULSE_MAX_CONSUMER_FAILURES` | typed:int | unclassified | unclassified | 524 | Max consecutive consumer failures before recovery. Default: 3. |
+| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 611 | Burst capacity. Default: 150. |
+| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 608 | Requests per second. Default: 100. |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 890 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
 | `MASC_RELAY_TARGET_AGENT` | typed:string | unclassified | unclassified | 124 | {1 Relay Configuration} |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 853 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
-| `MASC_SESSION_LIVE_TURN_WINDOW_SEC` | typed:float | unclassified | unclassified | 807 | Team session live turn window (seconds). Default: 300 (5 min). |
+| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 882 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
+| `MASC_SESSION_LIVE_TURN_WINDOW_SEC` | typed:float | unclassified | unclassified | 836 | Team session live turn window (seconds). Default: 300 (5 min). |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 36 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 40 | Rate limit window (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 45 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
-| `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` | feature_flag | n/a | n/a | 954 | Enable the Shell IR approval policy gate. Default: true (RFC-0254 — the autonomous policy is a strict safety improv... |
-| `MASC_SHELL_IR_PATH_JAIL_ENABLED` | feature_flag | n/a | n/a | 968 | Apply the workspace path jail [Exec_policy.validate_shell_ir_paths] to keeper Execute commands. Default: true. Re-rea... |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 887 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 875 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 903 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
-| `MASC_SLOT_YIELD_ENABLED` | feature_flag | n/a | n/a | 447 | Release LLM slot during tool execution so other agents can use it. Default: false. Set MASC_SLOT_YIELD_ENABLED=true t... |
-| `MASC_SMART_HB_BASE_INTERVAL_SEC` | typed:float | unclassified | unclassified | 623 | Base heartbeat interval (seconds), clamped [5, 300]. Default: 30. |
-| `MASC_SMART_HB_IDLE_MULTIPLIER` | typed:float | unclassified | unclassified | 628 | Idle multiplier for interval, clamped [1, 10]. Default: 3. |
-| `MASC_SMART_HB_IDLE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 633 | Idle threshold (seconds) before multiplier kicks in, clamped [60, 3600]. Default: 300. |
+| `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` | feature_flag | n/a | n/a | 983 | Enable the Shell IR approval policy gate. Default: true (RFC-0254 — the autonomous policy is a strict safety improv... |
+| `MASC_SHELL_IR_PATH_JAIL_ENABLED` | feature_flag | n/a | n/a | 997 | Apply the workspace path jail [Exec_policy.validate_shell_ir_paths] to keeper Execute commands. Default: true. Re-rea... |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 916 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 904 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 932 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
+| `MASC_SLOT_YIELD_ENABLED` | feature_flag | n/a | n/a | 476 | Release LLM slot during tool execution so other agents can use it. Default: false. Set MASC_SLOT_YIELD_ENABLED=true t... |
+| `MASC_SMART_HB_BASE_INTERVAL_SEC` | typed:float | unclassified | unclassified | 652 | Base heartbeat interval (seconds), clamped [5, 300]. Default: 30. |
+| `MASC_SMART_HB_IDLE_MULTIPLIER` | typed:float | unclassified | unclassified | 657 | Idle multiplier for interval, clamped [1, 10]. Default: 3. |
+| `MASC_SMART_HB_IDLE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 662 | Idle threshold (seconds) before multiplier kicks in, clamped [60, 3600]. Default: 300. |
 | `MASC_SPAWN_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 138 | Grace period before timeout — sends SIGTERM for checkpoint opportunity (seconds). |
 | `MASC_SPAWN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 134 | Default spawn timeout for agent processes (seconds). Used by spawn.ml, spawn_eio.ml, and tool_relay.ml. Higher value ... |
-| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 827 | SSE buffer TTL (seconds). Default: 300 (5 min). |
-| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 839 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
+| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 856 | SSE buffer TTL (seconds). Default: 300 (5 min). |
+| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 868 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
 | `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 328 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
 | `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 61 | Default polling interval (seconds) |
 | `MASC_TEMPO_MAX_INTERVAL_SEC` | typed:float | unclassified | unclassified | 57 | Maximum polling interval (seconds) - for idle tempo |
 | `MASC_TEMPO_MIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 53 | Minimum polling interval (seconds) - for urgent tempo |
-| `MASC_TOOL_DESCRIPTION_BUDGET` | string_literal | n/a | n/a | 535 | Tool description budget (max chars). None = unlimited. |
-| `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | unclassified | unclassified | 543 | Read-only tool retry limit. Default: 2. |
-| `MASC_TOOL_TIMEOUT_BOARD_SEC` | typed:int | Timeouts | operator | 530 | Board write outer MCP tool-call timeout, clamped to [5, 300] seconds. Default: 90 seconds (#10569). @category Timeout... |
-| `MASC_TOOL_TIMEOUT_DEFAULT_SEC` | typed:int | Timeouts | operator | 522 | Default outer MCP tool-call timeout, clamped to [5, 300] seconds. Board writes have a separate timeout below so opera... |
+| `MASC_TOOL_DESCRIPTION_BUDGET` | string_literal | n/a | n/a | 564 | Tool description budget (max chars). None = unlimited. |
+| `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | unclassified | unclassified | 572 | Read-only tool retry limit. Default: 2. |
+| `MASC_TOOL_TIMEOUT_BOARD_SEC` | typed:int | Timeouts | operator | 559 | Board write outer MCP tool-call timeout, clamped to [5, 300] seconds. Default: 90 seconds (#10569). @category Timeout... |
+| `MASC_TOOL_TIMEOUT_DEFAULT_SEC` | typed:int | Timeouts | operator | 551 | Default outer MCP tool-call timeout, clamped to [5, 300] seconds. Board writes have a separate timeout below so opera... |
 | `MASC_USE_H2` | string_literal | n/a | n/a | 306 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
 | `MASC_VERIFICATION_FSM_ENABLED` | feature_flag | n/a | n/a | 352 | Enable AwaitingVerification state and cross-agent approval. Default: false. |
 | `MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC` | typed:float | unclassified | unclassified | 362 | Interval for verification timeout check fiber (seconds). Default: 60. Issue #7549. |
 | `MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC` | typed:float | unclassified | unclassified | 357 | Maximum time a task may remain AwaitingVerification before surfacing an operator-visible timeout. Default: 24h. |
 | `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 302 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 563 |  |
-| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 556 |  |
-| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 550 |  |
-| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 553 |  |
-| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | unclassified | unclassified | 571 |  |
-| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 567 |  |
-| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 559 |  |
-| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 938 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 592 |  |
+| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 585 |  |
+| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 579 |  |
+| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 582 |  |
+| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | unclassified | unclassified | 600 |  |
+| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 596 |  |
+| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 588 |  |
+| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 967 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
 | `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 298 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
 | `MASC_WS_PORT` | string_literal | n/a | n/a | 294 | WebSocket server port. Default: 8937. |
 | `MASC_ZOMBIE_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 14 | Cleanup loop interval (seconds) |

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -438,6 +438,35 @@ module Keeper_stale_run = struct
     if v > 0.0 then Some v else None
 end
 
+(** {1 Keeper mid-turn progress watchdog (RFC-0012)}
+
+    Opt-in progress-silence window for the in-turn case. Distinct from
+    [Keeper_max_turn_watchdog] (wall-clock "one attempt taking too long",
+    produces [In_turn_hung]) and [Keeper_stale_run] (no turn produced at all,
+    produces [Idle_turn]): this keys on
+    [current_turn_observation.last_progress_at] while a turn IS running,
+    producing [Mid_turn_no_progress] when no forward-progress event
+    (tool_completed / sdk-turn boundary) has been recorded for longer than the
+    threshold.
+
+    Opt-in ([None] when unset) — NOT default-on — because progress is currently
+    stamped only on tool/sdk-boundary events
+    ([Keeper_registry.record_turn_progress] call sites in [keeper_hooks_oas.ml]),
+    not on thinking/text deltas. A default-on window would false-fire on a
+    legitimately long single-attempt thinking turn on a slow local model.
+    Operators enable per runtime; RFC-0012 recommends [300.0] when enabling. *)
+module Keeper_mid_turn_progress = struct
+  (** In-turn progress-silence threshold in seconds; produces
+      [Mid_turn_no_progress] when a running turn records no progress event for
+      this long. [None] / 0 disables (opt-in). RFC-0012 recommends 300 when
+      enabling. @category Timeouts @ops_class operator *)
+  let timeout_sec_opt () =
+    let v =
+      get_float ~default:0.0 "MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC"
+    in
+    if v > 0.0 then Some v else None
+end
+
 (** {1 Slot Scheduling} *)
 
 module Slot = struct

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -219,6 +219,25 @@ module Keeper_stale_run : sig
       [1800.0] (30 min). *)
 end
 
+(** {1 Keeper mid-turn progress watchdog (RFC-0012)} *)
+
+module Keeper_mid_turn_progress : sig
+  val timeout_sec_opt : unit -> float option
+  (** [timeout_sec_opt ()] returns the in-turn progress-silence threshold
+      when [MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC] is positive, or [None]
+      when unset / zero / negative.
+
+      Distinct from [Keeper_max_turn_watchdog] (wall-clock, [In_turn_hung]) and
+      [Keeper_stale_run] (no-turn, [Idle_turn]): keys on
+      [current_turn_observation.last_progress_at] while a turn is running,
+      producing [Mid_turn_no_progress] when no progress event has been recorded
+      for longer than the threshold.
+
+      Opt-in ([None] default): progress is stamped only on tool/sdk-boundary
+      events, so a default-on window could false-fire on a long single-attempt
+      thinking turn. RFC-0012 recommends [300.0] when enabling. *)
+end
+
 (** {1 Slot scheduling} *)
 
 module Slot : sig

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -47,6 +47,45 @@ let assess_stale_run
       (Keeper_registry.Stale_turn_timeout
          (Keeper_registry_types.Idle_turn { stall_seconds = stall }))
   else None
+;;
+
+(** RFC-0012: pure in-turn progress-silence assessment.
+
+    Returns [Some (Stale_turn_timeout (Mid_turn_no_progress { ... }))] — giving
+    the previously-producerless [Mid_turn_no_progress] variant its first real
+    producer — when the keeper is [Running] with a turn in progress
+    ([in_turn = Some obs]) whose [last_progress_at] is older than
+    [progress_timeout]. Returns [None] otherwise (not running, no turn in
+    progress, or progress recorded within the window).
+
+    Pure: like [assess_stale_run], the caller stamps the reason via
+    [Keeper_registry.set_failure_reason] and invokes
+    [emit_stale_keeper_broadcast]; the next sweep's [watchdog_stop_pending]
+    routes the [Stale_turn_timeout _] to crash recovery. Keys on
+    [last_progress_at] (tool_completed / sdk-turn boundary events recorded by
+    [Keeper_registry.record_turn_progress]), never on raw turn wall-clock, so
+    it is orthogonal to [In_turn_hung] (wall-clock) and [Idle_turn] (no-turn). *)
+let assess_in_turn_progress
+    ~(phase : Keeper_state_machine.phase)
+    ~(in_turn : Keeper_registry_types.turn_observation option)
+    ~(now : float)
+    ~(progress_timeout : float)
+    : Keeper_registry.failure_reason option
+  =
+  match in_turn with
+  | Some obs
+    when Bool.(phase = Keeper_state_machine.Running)
+         && now -. obs.last_progress_at > progress_timeout ->
+    Some
+      (Keeper_registry.Stale_turn_timeout
+         (Keeper_registry_types.Mid_turn_no_progress
+            { active_seconds = now -. obs.started_at
+            ; since_progress_seconds = now -. obs.last_progress_at
+            ; progress_timeout_threshold = progress_timeout
+            ; last_progress_kind = obs.last_progress_kind
+            }))
+  | Some _ | None -> None
+;;
 
 type sweep_acc =
   { to_restart : (Keeper_registry.registry_entry * string) list
@@ -311,37 +350,66 @@ let sweep_and_recover (ctx : _ context) =
             producer); when stale, stamp the reason and invoke the
             dead [emit_stale_keeper_broadcast] (its first call site).
             The next sweep's [watchdog_stop_pending] routes it to
-            crash recovery exactly as [In_turn_hung]. *)
-         (match Env_config_runtime.Keeper_stale_run.threshold_sec_opt () with
+            crash recovery exactly as [In_turn_hung].
+
+            RFC-0012: the in-turn counterpart. When a turn IS running
+            but [last_progress_at] is older than
+            [Keeper_mid_turn_progress.timeout_sec_opt],
+            [assess_in_turn_progress] produces [Mid_turn_no_progress] —
+            giving that closed variant its first producer. Both windows are
+            independent opt-in knobs and ride the same [Stale_turn_timeout]
+            crash-recovery routing; the no-turn [Idle_turn] takes precedence
+            when both would fire. *)
+         let stale_run_reason =
+           match Env_config_runtime.Keeper_stale_run.threshold_sec_opt () with
+           | None -> None
+           | Some threshold ->
+             assess_stale_run
+               ~phase:entry.phase
+               ~in_turn:entry.current_turn_observation
+               ~last_turn_ts:entry.meta.runtime.usage.last_turn_ts
+               ~now
+               ~threshold
+         in
+         let reason =
+           match stale_run_reason with
+           | Some _ -> stale_run_reason
+           | None ->
+             (match Env_config_runtime.Keeper_mid_turn_progress.timeout_sec_opt () with
+              | None -> None
+              | Some progress_timeout ->
+                assess_in_turn_progress
+                  ~phase:entry.phase
+                  ~in_turn:entry.current_turn_observation
+                  ~now
+                  ~progress_timeout)
+         in
+         (match reason with
           | None -> acc
-          | Some threshold ->
-            (match
-               assess_stale_run
-                 ~phase:entry.phase
-                 ~in_turn:entry.current_turn_observation
-                 ~last_turn_ts:entry.meta.runtime.usage.last_turn_ts
-                 ~now
-                 ~threshold
-             with
-             | None -> acc
-             | Some reason ->
-               let stall = now -. entry.meta.runtime.usage.last_turn_ts in
-               Keeper_registry.set_failure_reason
-                 ~base_path
-                 entry.name
-                 (Some reason);
-               Keeper_execution_receipt.emit_stale_keeper_broadcast
-                 ctx.config
-                 ~keeper_name:entry.name
-                 ~agent_name:entry.meta.agent_name
-                 ~runtime_id:(Keeper_meta_contract.runtime_id_of_meta entry.meta)
-                 ~trace_id:
-                   (Keeper_id.Trace_id.to_string entry.meta.runtime.trace_id)
-                 ~generation:entry.meta.runtime.generation
-                 ~failure_reason:(Some reason)
-                 ~stale_seconds:stall
-                 ~last_turn_ts:entry.meta.runtime.usage.last_turn_ts;
-               acc))
+          | Some reason ->
+            (* [stale_seconds] is a display/telemetry value, not an FSM
+               transition: [Mid_turn_no_progress] reports time since last
+               recorded progress; every other reason (i.e. [Idle_turn])
+               preserves the original no-turn [now -. last_turn_ts]. *)
+            let stale_seconds =
+              match reason with
+              | Keeper_registry.Stale_turn_timeout
+                  (Keeper_registry_types.Mid_turn_no_progress
+                     { since_progress_seconds; _ }) -> since_progress_seconds
+              | _ -> now -. entry.meta.runtime.usage.last_turn_ts
+            in
+            Keeper_registry.set_failure_reason ~base_path entry.name (Some reason);
+            Keeper_execution_receipt.emit_stale_keeper_broadcast
+              ctx.config
+              ~keeper_name:entry.name
+              ~agent_name:entry.meta.agent_name
+              ~runtime_id:(Keeper_meta_contract.runtime_id_of_meta entry.meta)
+              ~trace_id:(Keeper_id.Trace_id.to_string entry.meta.runtime.trace_id)
+              ~generation:entry.meta.runtime.generation
+              ~failure_reason:(Some reason)
+              ~stale_seconds
+              ~last_turn_ts:entry.meta.runtime.usage.last_turn_ts;
+            acc)
        | Some `Stopped -> { acc with to_unregister = entry :: acc.to_unregister }
        | Some (`Crashed msg) -> queue_crashed_entry acc entry msg)
   in

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -357,9 +357,9 @@ let sweep_and_recover (ctx : _ context) =
             [Keeper_mid_turn_progress.timeout_sec_opt],
             [assess_in_turn_progress] produces [Mid_turn_no_progress] —
             giving that closed variant its first producer. Both windows are
-            independent opt-in knobs and ride the same [Stale_turn_timeout]
-            crash-recovery routing; the no-turn [Idle_turn] takes precedence
-            when both would fire. *)
+            independent; only the mid-turn progress window is opt-in. They ride
+            the same [Stale_turn_timeout] crash-recovery routing; the no-turn
+            [Idle_turn] takes precedence when both would fire. *)
          let stale_run_reason =
            match Env_config_runtime.Keeper_stale_run.threshold_sec_opt () with
            | None -> None

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -88,6 +88,21 @@ val assess_stale_run :
     turn ([last_turn_ts > 0]), and [now] exceeds [last_turn_ts] by more than
     [threshold]. [None] otherwise. Exposed for regression tests. *)
 
+val assess_in_turn_progress :
+     phase:Keeper_state_machine.phase
+  -> in_turn:Keeper_registry_types.turn_observation option
+  -> now:float
+  -> progress_timeout:float
+  -> Keeper_registry.failure_reason option
+(** RFC-0012: pure in-turn progress-silence assessment. Returns
+    [Some (Stale_turn_timeout (Mid_turn_no_progress { ... }))] — the
+    [Mid_turn_no_progress] variant's first real producer — when [phase = Running]
+    with a turn in progress ([in_turn = Some obs]) whose [last_progress_at] is
+    older than [progress_timeout]. [None] otherwise (not running, no turn in
+    progress, or progress recorded within the window). Keys on recorded progress
+    events, orthogonal to the wall-clock [In_turn_hung] and no-turn [Idle_turn].
+    Exposed for regression tests. *)
+
 val failure_reason_policy_decision_for_test :
   Keeper_registry.failure_reason option -> Keeper_failure_policy.decision option
 (** Pure supervisor-side bridge from registry failure reasons into the

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2249,6 +2249,100 @@ let test_assess_stale_run () =
           ~now:300.0
           ~threshold:150.0))
 
+let test_assess_in_turn_progress () =
+  let make_turn_obs ~started_at ~last_progress_at ~last_progress_kind =
+    let open Masc.Keeper_registry_types in
+    ({ turn_id = 1
+     ; started_at
+     ; last_progress_at
+     ; last_progress_kind
+     ; turn_phase = Packed Turn_prompting
+     ; decision_stage = Packed Decision_undecided
+     ; measurement = None
+     ; measurement_bind_count = 0
+     ; selected_model = None
+     }
+      : Masc.Keeper_registry_types.turn_observation)
+  in
+  (* hung mid-turn: Running, turn live, last progress 400s ago, threshold 300s →
+     Some (Stale_turn_timeout (Mid_turn_no_progress { since_progress=400 })). *)
+  (match
+     Sup.assess_in_turn_progress
+       ~phase:KSM.Running
+       ~in_turn:
+         (Some
+            (make_turn_obs
+               ~started_at:1000.0
+               ~last_progress_at:1000.0
+               ~last_progress_kind:(Some "tool_completed:foo")))
+       ~now:1400.0
+       ~progress_timeout:300.0
+   with
+   | Some
+       (Reg.Stale_turn_timeout
+          (Reg.Mid_turn_no_progress
+             { since_progress_seconds
+             ; active_seconds
+             ; progress_timeout_threshold
+             ; last_progress_kind
+             })) ->
+     check int "since_progress=400" 400 (int_of_float since_progress_seconds);
+     check int "active=400" 400 (int_of_float active_seconds);
+     check int "threshold=300" 300 (int_of_float progress_timeout_threshold);
+     check
+       (option string)
+       "last_progress_kind preserved"
+       (Some "tool_completed:foo")
+       last_progress_kind
+   | _ -> check bool "hung must stamp Mid_turn_no_progress{400}" false true);
+  (* progressing: last progress only 100s ago → None. *)
+  check bool "recent progress → None" true
+    (Option.is_none
+       (Sup.assess_in_turn_progress
+          ~phase:KSM.Running
+          ~in_turn:
+            (Some
+               (make_turn_obs
+                  ~started_at:1000.0
+                  ~last_progress_at:1300.0
+                  ~last_progress_kind:(Some "tool_completed:bar")))
+          ~now:1400.0
+          ~progress_timeout:300.0));
+  (* boundary: since_progress exactly == threshold → None (strict >). *)
+  check bool "boundary since==threshold → None" true
+    (Option.is_none
+       (Sup.assess_in_turn_progress
+          ~phase:KSM.Running
+          ~in_turn:
+            (Some
+               (make_turn_obs
+                  ~started_at:1000.0
+                  ~last_progress_at:1000.0
+                  ~last_progress_kind:None))
+          ~now:1300.0
+          ~progress_timeout:300.0));
+  (* no turn in progress → None (mid-turn contract needs Some obs). *)
+  check bool "no turn → None" true
+    (Option.is_none
+       (Sup.assess_in_turn_progress
+          ~phase:KSM.Running
+          ~in_turn:None
+          ~now:9999.0
+          ~progress_timeout:300.0));
+  (* not-running: Crashed with a silent turn → None. *)
+  check bool "crashed → None" true
+    (Option.is_none
+       (Sup.assess_in_turn_progress
+          ~phase:KSM.Crashed
+          ~in_turn:
+            (Some
+               (make_turn_obs
+                  ~started_at:1000.0
+                  ~last_progress_at:1000.0
+                  ~last_progress_kind:None))
+          ~now:1400.0
+          ~progress_timeout:300.0))
+
 let () =
   run "keeper_supervisor" [
     "backoff", [
@@ -2405,5 +2499,10 @@ let () =
       test_case
         "assess_stale_run covers frozen/fresh/in-turn/fresh-start/not-running/boundary"
         `Quick test_assess_stale_run;
+    ];
+    "mid_turn_progress_window", [
+      test_case
+        "assess_in_turn_progress covers hung/progressing/boundary/no-turn/not-running"
+        `Quick test_assess_in_turn_progress;
     ];
   ]


### PR DESCRIPTION
## 목표

RFC-0012(Mid-Turn Progress Probe)의 닫힌 kill-class 변종 `Mid_turn_no_progress`에 **첫 producer를 배선**한다. 변종은 정의·소비자 4곳이 이미 존재하나 **producer가 0개**라 런타임에서 결코 발화하지 못하는 half-built 상태였다(sibling `Idle_turn`이 RFC-0250에서 받은 처치와 동형).

## 배경 (코드 그라운딩)

- 변종 `Mid_turn_no_progress { active_seconds; since_progress_seconds; progress_timeout_threshold; last_progress_kind }`는 `keeper_registry_types_kill_class.ml:37`에 존재. 소비자 4곳(to_string / terminal_code / receipt / status_bridge)이 모두 exhaustive match arm을 이미 가짐 → producer 추가는 **순수 additive**(컴파일 깨짐 없음).
- progress 신호 인프라는 **이미 구현돼 있음**: `turn_observation.last_progress_at`(`keeper_registry_types.ml:124`)가 `record_turn_progress`(`keeper_hooks_oas.ml`의 `tool_completed:*` / `sdk_before_turn` / `sdk_after_turn`)로 능동 갱신됨. 즉 RFC-0012가 "추가하자"던 `last_progress_at`는 이미 land 상태.
- 누락된 것은 **이 신호를 timeout 비교로 소비해 변종을 생산하는 코드**뿐. `last_progress_at`를 timeout과 비교하는 소비자는 전무했음(검증: 11개 occurrence 전수, 생산·timeout-소비 사이트 0).

## 변경

| 파일 | 변경 |
|---|---|
| `lib/config/env_config_runtime.ml/.mli` | `Keeper_mid_turn_progress.timeout_sec_opt`(opt-in env knob `MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC`, 미설정/0이면 `None`=비활성) |
| `lib/keeper/keeper_supervisor.ml/.mli` | pure `assess_in_turn_progress`(`assess_stale_run` 대칭) — Running + 진행 중 turn의 `last_progress_at`가 threshold보다 오래되면 `Stale_turn_timeout (Mid_turn_no_progress {...})` 반환 |
| `lib/keeper/keeper_supervisor.ml` (sweep) | idle(`Idle_turn`) 우선 + in-turn(`Mid_turn_no_progress`) 차선으로 reason 산출. 두 knob은 독립. 동일 `set_failure_reason` + `emit_stale_keeper_broadcast` 경로 재사용 |
| `test/test_keeper_supervisor.ml` | `assess_in_turn_progress` 5케이스(hung 발화/진행 중 무발화/경계 strict/turn 없음/non-Running) |
| `docs/runtime-tunables.md` | env_knob_catalog 재생성(`@category Timeouts @ops_class operator`, 신규 1행 + 라인번호 shift) |

## 설계 근거 / 경계

- **opt-in인 이유**: progress는 tool/sdk-boundary 이벤트에만 stamp되고 thinking/text delta엔 stamp되지 않는다. default-on 윈도우는 느린 local 모델의 정상적 장기 단일-attempt thinking turn을 오kill할 수 있다. 그래서 default `None`(비활성)으로 두고 operator가 per-runtime 활성화(RFC-0012 권장 300s). sibling `Keeper_max_turn_watchdog`(In_turn_hung)·`Keeper_stale_run`(Idle_turn)과 동일한 opt-in 관습.
- **FSM/라우팅 변경 0**: `set_failure_reason (Stale_turn_timeout (...))`는 sweep의 `watchdog_stop_pending`가 inner 변종이 아닌 `Stale_turn_timeout _` wildcard로 라우팅하므로 `Idle_turn`과 동일하게 crash-recovery에 자동 합류. 새 전이 추가 없음.
- **typed variant producer**(워크어라운드 아님): counter/string-분류기/cap-suppression이 아니라, 닫힌 sum type의 producerless 변종에 첫 producer를 다는 RFC-0250 동형 작업. 데이터 손실을 visible하게 만드는 게 아니라 감지→복구 경로를 실제로 연결.

## RFC

- **RFC-0012 (Mid-Turn Progress Probe, Draft)** — 이 PR이 그 §Proposal의 producer 부분을 구현.
- 단, RFC-0012가 "Related code"로 인용한 `lib/keeper/keeper_stale_watchdog.ml`은 이후 리팩터링으로 main에 부재(로직이 `keeper_supervisor`/`keeper_supervisor_launch` sweep로 이동)하고, 변종 shape도 RFC의 1-필드 제안보다 풍부한 4-필드로 이미 land됨. 따라서 구현은 RFC 텍스트가 아닌 **현재 sweep 아키텍처**에 맞췄다. RFC-0012를 현행 아키텍처로 amend하는 작업은 후속 PR로 분리.

RFC-WAIVED: keeper_supervisor lifecycle 변경은 mandatory-RFC subsystem 목록(credential/repo/operator/sandbox/hooks/workflow) 밖이며, 거버닝 RFC-0012를 발견·인용함.

## 미포함 (의도적 범위 제한)

- **default-on 전환**: thinking-delta progress stamping 선행 필요(RFC-0271 thinking-budget 커플링). 별 RFC.
- **hung fiber 즉시 cancellation**: wall-clock hard limit은 기존 `In_turn_hung`(`Keeper_max_turn_watchdog`)이 담당. 이 PR은 progress-based **detection** producer 배선만.

## 검증

- ocamlformat `--check` PASS(편집 5파일).
- `assess_in_turn_progress` 5케이스 단위 테스트(순수 함수).
- docs 재생성 diff = 신규 1행 + 라인번호 shift only(분류 flip 0, 카운트 operator 21→22).
- 컴파일/실행은 CI(`test_keeper_supervisor.exe`).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## CI 의존성 (inherited main-red)

이 PR 작성 시점 main(`1a56183844`, #21928)이 **무관한 컴파일 에러로 RED**다: `server_dashboard_http_execution_surfaces.ml:660`의 `execution_query_json` 호출부가 `~force` 인자를 빠뜨렸다(def는 line 331에서 `~force` 요구). 병렬 세션의 **#21937**이 이를 수정 중(`~force:false`). 그 PR 머지 후 이 브랜치를 rebase하면 CI green 예상. 내 변경(lib/config·lib/keeper)은 독립 빌드 PASS(`dune build lib/config lib/keeper` rc=0).
