### PR TITLE
fix(keeper): fast fail autonomous no-work budget loops

### DIFF
--- a/lib/keeper/keeper_no_progress_loop_detector.ml
+++ b/lib/keeper/keeper_no_progress_loop_detector.ml
@@ -56,7 +56,7 @@ let update_streak_gauge keeper_name value =
 let turn_made_progress ~strong_evidence ~surface_requires_evidence =
   strong_evidence || not surface_requires_evidence
 
-let record_turn ?threshold_override ~keeper_name ~made_progress =
+let record_turn ?threshold_override ~keeper_name ~made_progress () =
   with_lock (fun () ->
     let s = get_or_create keeper_name in
     if not made_progress then begin

--- a/lib/keeper/keeper_no_progress_loop_detector.ml
+++ b/lib/keeper/keeper_no_progress_loop_detector.ml
@@ -56,13 +56,17 @@ let update_streak_gauge keeper_name value =
 let turn_made_progress ~strong_evidence ~surface_requires_evidence =
   strong_evidence || not surface_requires_evidence
 
-let record_turn ~keeper_name ~made_progress =
+let record_turn ?threshold_override ~keeper_name ~made_progress =
   with_lock (fun () ->
     let s = get_or_create keeper_name in
     if not made_progress then begin
       s.streak <- s.streak + 1;
       update_streak_gauge keeper_name s.streak;
-      let t = threshold () in
+      let t =
+        match threshold_override with
+        | Some n when n > 0 -> n
+        | Some _ | None -> threshold ()
+      in
       if s.streak >= t && not s.detected_latched then begin
         s.detected_latched <- true;
         Otel_metric_store.inc_counter

--- a/lib/keeper/keeper_no_progress_loop_detector.mli
+++ b/lib/keeper/keeper_no_progress_loop_detector.mli
@@ -53,7 +53,7 @@ val turn_made_progress :
     where waiting for the product default would burn another autonomous budgeted
     turn. Non-positive overrides are ignored. *)
 val record_turn :
-  ?threshold_override:int -> keeper_name:string -> made_progress:bool -> record_outcome
+  ?threshold_override:int -> keeper_name:string -> made_progress:bool -> unit -> record_outcome
 
 (** Current consecutive no-progress count for [keeper_name]. *)
 val current_streak : keeper_name:string -> int

--- a/lib/keeper/keeper_no_progress_loop_detector.mli
+++ b/lib/keeper/keeper_no_progress_loop_detector.mli
@@ -47,8 +47,13 @@ val turn_made_progress :
     no-progress turn and resets when a turn makes progress. Generalises the
     earlier literal silent speech-act match so a keeper that re-posts its
     "nothing to do" conclusion (a no-progress board post) also accrues the
-    streak. *)
-val record_turn : keeper_name:string -> made_progress:bool -> record_outcome
+    streak.
+
+    [threshold_override] is for high-confidence runtime containment signals
+    where waiting for the product default would burn another autonomous budgeted
+    turn. Non-positive overrides are ignored. *)
+val record_turn :
+  ?threshold_override:int -> keeper_name:string -> made_progress:bool -> record_outcome
 
 (** Current consecutive no-progress count for [keeper_name]. *)
 val current_streak : keeper_name:string -> int

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -48,6 +48,31 @@ let apply_lifecycle ~config ~base_dir ~meta ~final_execution ~current_turn_block
   lifecycle
 ;;
 
+let no_work_budget_threshold_override
+      ~stop_reason
+      ~has_current_task
+      ~active_goal_ids
+      ~strong_evidence
+      ~surface_requires_evidence
+      ~observation
+  =
+  let budget_exhausted =
+    match stop_reason with
+    | Runtime_agent.TurnBudgetExhausted _ -> true
+    | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
+  in
+  let no_work_scope = (not has_current_task) && active_goal_ids = [] in
+  if
+    budget_exhausted
+    && no_work_scope
+    && (not strong_evidence)
+    && surface_requires_evidence
+    && Keeper_unified_metrics_support.is_scheduled_autonomous_cycle_of_observation
+         observation
+  then Some 1
+  else None
+;;
+
 let apply_loop_detectors ~config ~observation ~social_state updated_meta result =
   (* RFC-0239 §3 R3: feed the loop detector a semantic no-progress verdict
      instead of the literal speech_act. A turn makes progress if it produced
@@ -72,29 +97,20 @@ let apply_loop_detectors ~config ~observation ~social_state updated_meta result 
       ~surface_requires_evidence
   in
   let threshold_override =
-    let budget_exhausted =
-      match result.Keeper_agent_run.stop_reason with
-      | Runtime_agent.TurnBudgetExhausted _ -> true
-      | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
-    in
-    let no_work_scope =
-      Option.is_none updated_meta.Keeper_meta_contract.current_task_id
-      && updated_meta.Keeper_meta_contract.active_goal_ids = []
-    in
-    if
-      budget_exhausted
-      && no_work_scope
-      && (not strong_evidence)
-      && surface_requires_evidence
-      && KUM.is_scheduled_autonomous_cycle_of_observation observation
-    then Some 1
-    else None
+    no_work_budget_threshold_override
+      ~stop_reason:result.Keeper_agent_run.stop_reason
+      ~has_current_task:(Option.is_some updated_meta.Keeper_meta_contract.current_task_id)
+      ~active_goal_ids:updated_meta.Keeper_meta_contract.active_goal_ids
+      ~strong_evidence
+      ~surface_requires_evidence
+      ~observation
   in
   match
     Keeper_no_progress_loop_detector.record_turn
       ?threshold_override
       ~keeper_name:updated_meta.Keeper_meta_contract.name
       ~made_progress
+      ()
   with
   | Keeper_no_progress_loop_detector.Normal -> updated_meta
   | Keeper_no_progress_loop_detector.Loop_detected { streak; threshold } ->
@@ -110,6 +126,10 @@ let apply_loop_detectors ~config ~observation ~social_state updated_meta result 
       ~previous_streak
       ~was_latched
 ;;
+
+module For_testing = struct
+  let no_work_budget_threshold_override = no_work_budget_threshold_override
+end
 
 let append_metrics_snapshot
       ~config

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -48,7 +48,7 @@ let apply_lifecycle ~config ~base_dir ~meta ~final_execution ~current_turn_block
   lifecycle
 ;;
 
-let apply_loop_detectors ~config ~social_state updated_meta result =
+let apply_loop_detectors ~config ~observation ~social_state updated_meta result =
   (* RFC-0239 §3 R3: feed the loop detector a semantic no-progress verdict
      instead of the literal speech_act. A turn makes progress if it produced
      durable evidence (substantive tool calls or validated output); a turn that
@@ -71,8 +71,28 @@ let apply_loop_detectors ~config ~social_state updated_meta result =
       ~strong_evidence
       ~surface_requires_evidence
   in
+  let threshold_override =
+    let budget_exhausted =
+      match result.Keeper_agent_run.stop_reason with
+      | Runtime_agent.TurnBudgetExhausted _ -> true
+      | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
+    in
+    let no_work_scope =
+      Option.is_none updated_meta.Keeper_meta_contract.current_task_id
+      && updated_meta.Keeper_meta_contract.active_goal_ids = []
+    in
+    if
+      budget_exhausted
+      && no_work_scope
+      && (not strong_evidence)
+      && surface_requires_evidence
+      && KUM.is_scheduled_autonomous_cycle_of_observation observation
+    then Some 1
+    else None
+  in
   match
     Keeper_no_progress_loop_detector.record_turn
+      ?threshold_override
       ~keeper_name:updated_meta.Keeper_meta_contract.name
       ~made_progress
   with
@@ -480,7 +500,9 @@ let handle
       ~update_proactive_rt:true
       result
   in
-  let updated_meta = apply_loop_detectors ~config ~social_state updated_meta result in
+  let updated_meta =
+    apply_loop_detectors ~config ~observation ~social_state updated_meta result
+  in
   append_metrics_snapshot
     ~config
     ~meta

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -5,6 +5,17 @@
     success path and must be called at most once per turn.
     [Keeper_unified_turn.run_keeper_cycle] is the expected caller. *)
 
+module For_testing : sig
+  val no_work_budget_threshold_override
+    :  stop_reason:Runtime_agent.stop_reason
+    -> has_current_task:bool
+    -> active_goal_ids:string list
+    -> strong_evidence:bool
+    -> surface_requires_evidence:bool
+    -> observation:Keeper_world_observation.world_observation
+    -> int option
+end
+
 val handle
   :  config:Workspace.config
   -> base_dir:string

--- a/test/test_keeper_wake_tombstone.ml
+++ b/test/test_keeper_wake_tombstone.ml
@@ -18,7 +18,7 @@ let with_eio f () = Eio_main.run @@ fun _env -> f ()
 let latch keeper =
   let threshold = D.threshold () in
   for _ = 1 to threshold do
-    D.record_turn ~keeper_name:keeper ~made_progress:false |> ignore
+    D.record_turn ~keeper_name:keeper ~made_progress:false () |> ignore
   done
 
 let is_suppressed origin keeper =
@@ -49,7 +49,7 @@ let test_progress_clears_tombstone () =
     true (is_suppressed T.Board_reactive "tombstone-c");
   (* A progress turn resets the detector latch; the gate reads that state, so
      wake is re-allowed without any tombstone-store mutation. *)
-  D.record_turn ~keeper_name:"tombstone-c" ~made_progress:true |> ignore;
+  D.record_turn ~keeper_name:"tombstone-c" ~made_progress:true () |> ignore;
   Alcotest.(check bool) "wake re-allowed after progress turn"
     false (is_suppressed T.Board_reactive "tombstone-c")
 

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -10,6 +10,8 @@
 
 module D = Masc.Keeper_no_progress_loop_detector
 module Metrics = Masc.Otel_metric_store
+module Success = Masc.Keeper_unified_turn_success.For_testing
+module WO = Masc.Keeper_world_observation
 
 (* Detector now uses Eio.Mutex (was Stdlib.Mutex; the latter raised EDEADLK
    under any fiber contention). Every public entry needs an Eio fiber
@@ -21,10 +23,46 @@ let detected_count keeper =
     "masc_keeper_no_progress_loop_detected_total"
     ~labels:[ ("keeper", keeper) ] ()
 
-let record_turn = D.record_turn
+let record_turn ~keeper_name ~made_progress =
+  D.record_turn ~keeper_name ~made_progress ()
 
 let ignore_outcome = function
   | D.Normal | D.Loop_detected _ | D.Loop_reset _ -> ()
+
+let scheduled_observation : WO.world_observation =
+  { pending_mentions = []
+  ; pending_board_events = []
+  ; pending_scope_messages = []
+  ; idle_seconds = 0
+  ; active_goals = []
+  ; continuity_summary = ""
+  ; context_ratio = lazy 0.0
+  ; unclaimed_task_count = 0
+  ; claimable_task_count = 0
+  ; provider_capacity_blocked_task_count = 0
+  ; failed_task_count = 0
+  ; pending_verification_count = 0
+  ; scheduled_automation = WO.empty_scheduled_automation_observation
+  ; backlog_updated_since_last_scheduled_autonomous = false
+  ; running_keeper_fiber_count = 0
+  ; connected_surfaces = []
+  }
+
+let no_work_budget_override
+      ?(stop_reason = Runtime_agent.TurnBudgetExhausted { turns_used = 1; limit = 1 })
+      ?(has_current_task = false)
+      ?(active_goal_ids = [])
+      ?(strong_evidence = false)
+      ?(surface_requires_evidence = true)
+      observation
+  =
+  Success.no_work_budget_threshold_override
+    ~stop_reason
+    ~has_current_task
+    ~active_goal_ids
+    ~strong_evidence
+    ~surface_requires_evidence
+    ~observation
 
 let test_streak_increments () =
   D.reset_all_for_test ();
@@ -73,7 +111,7 @@ let test_threshold_override_fires_early () =
   D.reset_all_for_test ();
   let k = "test-keeper-fast-latch" in
   let before = detected_count k in
-  (match record_turn ~threshold_override:1 ~keeper_name:k ~made_progress:false with
+  (match D.record_turn ~threshold_override:1 ~keeper_name:k ~made_progress:false () with
    | D.Loop_detected { streak; threshold } ->
      Alcotest.(check int) "fast latch streak" 1 streak;
      Alcotest.(check int) "fast latch threshold" 1 threshold
@@ -81,6 +119,32 @@ let test_threshold_override_fires_early () =
   Alcotest.(check (float 0.0001)) "fast latch increments counter"
     (before +. 1.0) (detected_count k);
   Alcotest.(check int) "streak retained" 1 (D.current_streak ~keeper_name:k)
+
+let test_no_work_budget_override_predicate () =
+  Alcotest.(check (option int)) "scheduled no-work budget exhaustion fast-fails"
+    (Some 1)
+    (no_work_budget_override scheduled_observation);
+  let reactive_observation =
+    { scheduled_observation with pending_mentions = [ ("operator", "wake") ] }
+  in
+  Alcotest.(check (option int)) "reactive observation keeps default threshold"
+    None
+    (no_work_budget_override reactive_observation);
+  Alcotest.(check (option int)) "active task keeps default threshold"
+    None
+    (no_work_budget_override ~has_current_task:true scheduled_observation);
+  Alcotest.(check (option int)) "active goal keeps default threshold"
+    None
+    (no_work_budget_override ~active_goal_ids:[ "goal-1" ] scheduled_observation);
+  Alcotest.(check (option int)) "strong evidence keeps default threshold"
+    None
+    (no_work_budget_override ~strong_evidence:true scheduled_observation);
+  Alcotest.(check (option int)) "visible reply keeps default threshold"
+    None
+    (no_work_budget_override ~surface_requires_evidence:false scheduled_observation);
+  Alcotest.(check (option int)) "completed stop keeps default threshold"
+    None
+    (no_work_budget_override ~stop_reason:Runtime_agent.Completed scheduled_observation)
 
 let test_latched_no_repeat_while_streak_grows () =
   D.reset_all_for_test ();
@@ -205,6 +269,8 @@ let () =
             `Quick (with_eio test_threshold_crossing_fires_counter);
           Alcotest.test_case "threshold override fires early"
             `Quick (with_eio test_threshold_override_fires_early);
+          Alcotest.test_case "scheduled autonomous no-work override predicate"
+            `Quick test_no_work_budget_override_predicate;
           Alcotest.test_case "latched: no repeat while streak grows"
             `Quick (with_eio test_latched_no_repeat_while_streak_grows);
           Alcotest.test_case "latch releases on reset, then re-fires"

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -69,6 +69,19 @@ let test_threshold_crossing_fires_counter () =
     (before +. 1.0) (detected_count k);
   ()
 
+let test_threshold_override_fires_early () =
+  D.reset_all_for_test ();
+  let k = "test-keeper-fast-latch" in
+  let before = detected_count k in
+  (match record_turn ~threshold_override:1 ~keeper_name:k ~made_progress:false with
+   | D.Loop_detected { streak; threshold } ->
+     Alcotest.(check int) "fast latch streak" 1 streak;
+     Alcotest.(check int) "fast latch threshold" 1 threshold
+   | D.Normal | D.Loop_reset _ -> Alcotest.fail "expected fast loop detection");
+  Alcotest.(check (float 0.0001)) "fast latch increments counter"
+    (before +. 1.0) (detected_count k);
+  Alcotest.(check int) "streak retained" 1 (D.current_streak ~keeper_name:k)
+
 let test_latched_no_repeat_while_streak_grows () =
   D.reset_all_for_test ();
   let k = "test-keeper-latched" in
@@ -190,6 +203,8 @@ let () =
         [
           Alcotest.test_case "fires counter at threshold"
             `Quick (with_eio test_threshold_crossing_fires_counter);
+          Alcotest.test_case "threshold override fires early"
+            `Quick (with_eio test_threshold_override_fires_early);
           Alcotest.test_case "latched: no repeat while streak grows"
             `Quick (with_eio test_latched_no_repeat_while_streak_grows);
           Alcotest.test_case "latch releases on reset, then re-fires"


### PR DESCRIPTION
## Root cause
- Scheduled-autonomous turns repeatedly entered a no-progress loop after a passive `Commit`-style finish: turn budget exhaustion + no active task/goal + no substantive evidence.
- Existing no-progress detector waited for 10 consecutive non-progress turns, so a keeper could consume an entire autonomous turn budget repeatedly.

## Fix
- Add optional fast-threshold override to `Keeper_no_progress_loop_detector.record_turn`.
- In unified turn success path, classify high-confidence autonomous no-progress as immediate loop detection:
  - stop reason `TurnBudgetExhausted`
  - no `current_task_id`
  - empty `active_goal_ids`
  - no substantial evidence
  - scheduled-autonomous cycle
- Preserve old default semantics by using `threshold = 10` when override is absent.
- Add unit coverage for override behavior in `test_no_progress_loop_detector`.
