### PR TITLE
fix(dashboard): pass ~force:false to broadcast execution_query_json (main red)

### DIFF
--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -662,7 +662,8 @@ let start_execution_refresh_loop ~state ~sw ~clock ~net ~mono_clock =
                    ~fixture:None
                    ~full_mode:false
                    ~light:true
-                   ~default_light_request:true));
+                   ~default_light_request:true
+                   ~force:false));
       !broadcast_namespace_truth_ref state)
 ;;
 


### PR DESCRIPTION
## 목표
main red 복구. #21928이 `execution_query_json`에 필수 `~force` 인자를 추가했으나 broadcast 호출(`:660`)을 미갱신 → partial application → OCaml `warn-error=+a` 빌드 fail → main red.

## 변경
`server_dashboard_http_execution_surfaces.ml:660` broadcast `execution_query_json` 호출에 `~force:false` 추가. broadcast는 `cached_surface_json` 기반이라 HTTP force-refresh가 아님 → `false`가 snapshot 의도에 부합(emit JSON의 `"force"` 필드는 쿼리 강제 여부를 나타냄). 다른 호출(`:719`)은 이미 request의 force param을 전달 중.

## 검증
- 다른 partial application 없음(`:331` 정의 / `:660`·`:719` 호출만; `:719`는 정상).
- 로컬 빌드 금지(사용자 지시: 빌드는 CI만). CI `Lint`(OCaml `warn-error=+a`)로 검증 — 이 PR의 Lint pass = main red 복구 확인.

## 배경
#21932(Dashboard #21748 작업)의 Lint job이 이 main 회귀를 상속해 fail. #21932 자체는 dashboard-TS만 변경하므로 무관. 이 PR로 main을 green으로 복구하면 #21932 rebase 후 머지 가능.

Refs #21928.

Co-Authored-By: Claude <noreply@anthropic.com>
