### PR TITLE
Improve dashboard board post link display

### DIFF
--- a/dashboard/src/components/chat/chat-linkify.ts
+++ b/dashboard/src/components/chat/chat-linkify.ts
@@ -3,6 +3,15 @@ const BOARD_POST_ID_RE = /(^|[\s([{"'`>])(p-[a-f0-9]{32})(?=$|[\s)\].,!?:;}"'`<]
 const ANCHOR_RE = /(<a\b[\s\S]*?<\/a>)/gi
 const HTML_TAG_RE = /(<[^>]+>)/g
 
+function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 function boardPostHref(postId: string): string {
   return `#board?post=${encodeURIComponent(postId)}`
 }
@@ -13,11 +22,14 @@ function boardPostLabel(postId: string): string {
 
 function boardPostLink(postId: string): string {
   const label = boardPostLabel(postId)
+  const escapedPostId = escapeHtml(postId)
+  const escapedLabel = escapeHtml(label)
+  const title = `보드 글 ${escapedPostId} 열기`
   return [
     `<a class="inline-link chat-board-post-link" href="${boardPostHref(postId)}"`,
-    ` title="보드 글 ${postId} 열기" aria-label="보드 글 ${postId} 열기" data-board-post-id="${postId}">`,
+    ` title="${title}" aria-label="${title}" data-board-post-id="${escapedPostId}">`,
     '<span class="chat-board-post-link-kind">보드 글</span>',
-    `<span class="chat-board-post-link-id">${label}</span>`,
+    `<span class="chat-board-post-link-id">${escapedLabel}</span>`,
     '</a>',
   ].join('')
 }

--- a/dashboard/src/components/chat/chat-linkify.ts
+++ b/dashboard/src/components/chat/chat-linkify.ts
@@ -7,12 +7,27 @@ function boardPostHref(postId: string): string {
   return `#board?post=${encodeURIComponent(postId)}`
 }
 
+function boardPostLabel(postId: string): string {
+  return postId.length <= 8 ? postId : postId.slice(0, 8)
+}
+
+function boardPostLink(postId: string): string {
+  const label = boardPostLabel(postId)
+  return [
+    `<a class="inline-link chat-board-post-link" href="${boardPostHref(postId)}"`,
+    ` title="보드 글 ${postId} 열기" aria-label="보드 글 ${postId} 열기" data-board-post-id="${postId}">`,
+    '<span class="chat-board-post-link-kind">보드 글</span>',
+    `<span class="chat-board-post-link-id">${label}</span>`,
+    '</a>',
+  ].join('')
+}
+
 function linkifyTextSegment(raw: string): string {
   return raw
     .replace(
       BOARD_POST_ID_RE,
       (_match, prefix: string, postId: string) =>
-        `${prefix}<a class="inline-link" href="${boardPostHref(postId)}" title="보드 게시글 열기">${postId}</a>`,
+        `${prefix}${boardPostLink(postId)}`,
     )
     .replace(
       URL_RE,

--- a/dashboard/src/components/chat/markdown-blocks.test.ts
+++ b/dashboard/src/components/chat/markdown-blocks.test.ts
@@ -178,6 +178,7 @@ describe('parseMarkdownToBlocks', () => {
 
   it('links generated board post ids to the board detail route', () => {
     const postId = 'p-59e2917e15de5367e81b2244a8f5095a'
+    const label = postId.slice(0, 8)
     const blocks = parseMarkdownToBlocks(`올렸다. 보드에 ${postId}.`)
     expect(blocks).toHaveLength(1)
     const html = (blocks[0] as Extract<ChatBlock, { t: 'p' }>).html
@@ -186,7 +187,7 @@ describe('parseMarkdownToBlocks', () => {
     expect(html).toContain(`data-board-post-id="${postId}"`)
     expect(html).toContain(`title="보드 글 ${postId} 열기"`)
     expect(html).toContain('보드 글')
-    expect(html).toContain('p-59e291')
+    expect(html).toContain(label)
   })
 
   // Per-line superset: a soft-wrapped paragraph (single newlines, no blank line)

--- a/dashboard/src/components/chat/markdown-blocks.test.ts
+++ b/dashboard/src/components/chat/markdown-blocks.test.ts
@@ -182,7 +182,11 @@ describe('parseMarkdownToBlocks', () => {
     expect(blocks).toHaveLength(1)
     const html = (blocks[0] as Extract<ChatBlock, { t: 'p' }>).html
     expect(html).toContain(`href="#board?post=${postId}"`)
-    expect(html).toContain('title="보드 게시글 열기"')
+    expect(html).toContain('class="inline-link chat-board-post-link"')
+    expect(html).toContain(`data-board-post-id="${postId}"`)
+    expect(html).toContain(`title="보드 글 ${postId} 열기"`)
+    expect(html).toContain('보드 글')
+    expect(html).toContain('p-59e291')
   })
 
   // Per-line superset: a soft-wrapped paragraph (single newlines, no blank line)

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1788,6 +1788,7 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
 
   it('renders board post ids in assistant prose as board detail links', () => {
     const postId = 'p-59e2917e15de5367e81b2244a8f5095a'
+    const label = postId.slice(0, 8)
     render(
       html`<${ChatTranscript}
         entries=${[
@@ -1811,7 +1812,7 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     expect(link?.getAttribute('aria-label')).toBe(`보드 글 ${postId} 열기`)
     expect(link?.getAttribute('title')).toBe(`보드 글 ${postId} 열기`)
     expect(link?.textContent).toContain('보드 글')
-    expect(link?.textContent).toContain('p-59e291')
+    expect(link?.textContent).toContain(label)
   })
 
   it('keeps the flat per-row tool bubbles when grouping is off (default)', () => {

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1806,8 +1806,12 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
 
     const link = container.querySelector(`a[href="#board?post=${postId}"]`) as HTMLAnchorElement | null
     expect(link).not.toBeNull()
-    expect(link?.textContent).toBe(postId)
-    expect(link?.getAttribute('title')).toBe('보드 게시글 열기')
+    expect(link?.classList.contains('chat-board-post-link')).toBe(true)
+    expect(link?.getAttribute('data-board-post-id')).toBe(postId)
+    expect(link?.getAttribute('aria-label')).toBe(`보드 글 ${postId} 열기`)
+    expect(link?.getAttribute('title')).toBe(`보드 글 ${postId} 열기`)
+    expect(link?.textContent).toContain('보드 글')
+    expect(link?.textContent).toContain('p-59e291')
   })
 
   it('keeps the flat per-row tool bubbles when grouping is off (default)', () => {

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -147,7 +147,6 @@
   border-radius: var(--r-0);
   background: var(--accent-10);
   color: var(--color-accent-fg);
-  font-family: var(--font-mono);
   font-weight: 600;
   line-height: 1.45;
   text-decoration: none;
@@ -173,6 +172,7 @@
 .chat-board-post-link-id {
   min-width: 0;
   overflow: hidden;
+  font-family: var(--font-mono);
   text-overflow: ellipsis;
 }
 

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -135,6 +135,57 @@
   white-space: nowrap;
 }
 
+.chat-board-post-link {
+  display: inline-flex;
+  max-width: min(100%, 18rem);
+  min-width: 0;
+  align-items: baseline;
+  gap: 0.35rem;
+  vertical-align: baseline;
+  padding: 0.05rem 0.4rem;
+  border: 1px solid var(--accent-30);
+  border-radius: var(--r-0);
+  background: var(--accent-10);
+  color: var(--color-accent-fg);
+  font-family: var(--font-mono);
+  font-weight: 600;
+  line-height: 1.45;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.chat-board-post-link:hover {
+  border-color: var(--color-accent-fg-dim);
+  background: var(--accent-20);
+  color: var(--color-accent-fg);
+  text-decoration: none;
+}
+
+.chat-board-post-link-kind {
+  flex: none;
+  font-family: var(--font-ui);
+  font-size: var(--fs-10);
+  font-weight: 700;
+  letter-spacing: 0;
+  color: var(--color-fg-primary);
+}
+
+.chat-board-post-link-id {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 560px) {
+  .chat-board-post-link {
+    max-width: 100%;
+  }
+
+  .chat-board-post-link-id {
+    max-width: 13ch;
+  }
+}
+
 /* ════ Keeper v2 multimodal composer ════ */
 
 .composer {


### PR DESCRIPTION
## Summary
- render inline board post ids as compact `보드 글` chips instead of raw full ids
- keep the full board post id in href, title, aria-label, and data attribute
- add chat parser/render tests for the richer board-post link markup

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/components/chat/markdown-blocks.test.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run lint`
- Playwright render check at `http://localhost:5174/dashboard/#keepers?keeper=albini`: found 1 `.chat-board-post-link`, chip text `보드 글p-59e291`, href `#board?post=p-59e2917e15de5367e81b2244a8f5095a`, element 136x27px