### PR TITLE
feat(dashboard): cache fleet-composite envelope to avoid per-poll N+1 reads

### DIFF
--- a/lib/server/server_dashboard_http_composite_enrich.ml
+++ b/lib/server/server_dashboard_http_composite_enrich.ml
@@ -54,17 +54,36 @@ let dashboard_keeper_composite_json
 ;;
 
 let dashboard_fleet_composite_json ~(config : Workspace.config) () : Yojson.Safe.t =
-  let entries = Keeper_registry.all ~base_path:config.base_path () in
-  let snapshots = List.map (dashboard_keeper_composite_json ~config) entries in
-  `Assoc
-    (* generated_at is a unix-second number (not ISO8601 string) to match the
-       sibling timestamps in this same envelope (snapshots[].started_at /
-       last_progress_at / ended_at are all `Float) and the dashboard's
-       runtime-attention staleness arithmetic (fleet-fsm-matrix.ts:558 computes
-       `generatedAt - latest`, which requires a number). The dashboard valibot
-       schema FleetCompositeSnapshotSchema declares generated_at: number(). *)
-    [ "generated_at", `Float (Unix.gettimeofday ())
-    ; "count", `Int (List.length snapshots)
-    ; "snapshots", `List snapshots
-    ]
+  (* Cache the fleet-composite envelope so each dashboard poll does not re-run
+     the sequential [List.map] over keepers. Every [dashboard_keeper_composite_json]
+     reaches [Keeper_secret_projection.dashboard_status_json], a synchronous disk
+     read, so N keepers cost N reads per uncached hit. Mirrors the [/tool-stats]
+     endpoint (keeper_api.ml) — the same [Dashboard_cache.get_or_compute] +
+     [Domain_pool_ref.submit_io_or_inline] layer, keyed by [base_path] so distinct
+     workspaces do not cross-contaminate. [generated_at] is stamped at compute
+     time; the dashboard already treats it as a possibly-stale value for
+     runtime-attention arithmetic (fleet-fsm-matrix.ts). This is a fleet-level
+     envelope cache, not a second per-keeper cache layered on the projection
+     rebuild cycle (RFC-0029 §3 non-goal), so it does not re-introduce
+     projection-staleness drift. *)
+  let cache_key =
+    Printf.sprintf "dashboard:fleet-composite:%s" config.base_path
+  in
+  Dashboard_cache.get_or_compute cache_key
+    ~ttl:Server_dashboard_http_core_cache.standard_cache_ttl_s
+    (fun () ->
+      Domain_pool_ref.submit_io_or_inline (fun () ->
+        let entries = Keeper_registry.all ~base_path:config.base_path () in
+        let snapshots = List.map (dashboard_keeper_composite_json ~config) entries in
+        `Assoc
+          (* generated_at is a unix-second number (not ISO8601 string) to match the
+             sibling timestamps in this same envelope (snapshots[].started_at /
+             last_progress_at / ended_at are all `Float) and the dashboard's
+             runtime-attention staleness arithmetic (fleet-fsm-matrix.ts:558 computes
+             `generatedAt - latest`, which requires a number). The dashboard valibot
+             schema FleetCompositeSnapshotSchema declares generated_at: number(). *)
+          [ "generated_at", `Float (Unix.gettimeofday ())  (* NDT-OK: compute-time wall-clock; envelope SWR-cached per-TTL; HTTP/WS response surface, not replayable *)
+          ; "count", `Int (List.length snapshots)
+          ; "snapshots", `List snapshots
+          ]))
 ;;

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -982,6 +982,23 @@ let test_dashboard_shell_light_includes_runtime_health_ssot () =
      | `Assoc _ -> true
      | _ -> false)
 
+let test_dashboard_fleet_composite_envelope_is_cached () =
+  (* [dashboard_fleet_composite_json] caches the fleet envelope so a second poll
+     inside the TTL returns the cached compute (identical generated_at) rather
+     than re-running the sequential N-keeper read path. Each keeper reaches
+     [Keeper_secret_projection.dashboard_status_json] (a synchronous disk
+     read), so an uncached poll costs N reads. This guards that regression. *)
+  with_test_env @@ fun ~env:_ ~sw:_ ~config ->
+  ignore (Workspace.init config ~agent_name:None);
+  let json1 = Server_dashboard_http.dashboard_fleet_composite_json ~config () in
+  let json2 = Server_dashboard_http.dashboard_fleet_composite_json ~config () in
+  let open Yojson.Safe.Util in
+  let gen1 = json1 |> member "generated_at" |> to_float in
+  let gen2 = json2 |> member "generated_at" |> to_float in
+  Alcotest.(check bool)
+    "second fleet-composite poll hits cache (identical generated_at)"
+    true (gen1 = gen2)
+
 let test_dashboard_shell_separates_configured_and_persisted_keeper_counts () =
   with_test_env @@ fun ~env:_ ~sw:_ ~config ->
   ignore (Workspace.init config ~agent_name:None);
@@ -1268,5 +1285,7 @@ let () =
             test_project_snapshot_wire_returns_snapshot_when_populated;
           test_case "telemetry n default is bounded (freeze guard)" `Quick
             test_telemetry_n_default_is_bounded;
+          test_case "fleet-composite envelope is cached across polls" `Quick
+            test_dashboard_fleet_composite_envelope_is_cached;
         ] );
     ]


### PR DESCRIPTION
## What

`dashboard_fleet_composite_json` ran a sequential `List.map` over all keepers on every dashboard poll. Each keeper reached `Keeper_secret_projection.dashboard_status_json` (a synchronous disk read via `open_in_bin`), so N keepers cost N reads per uncached hit. Two call sites (`server_dashboard_http_keeper_api.ml:950`, `server_runtime_bootstrap.ml:928`) hit this with no cache wrapping, while sibling surfaces (tool-stats, operator digest, shell) are already cached — fleet-composite was the only exposed N+1.

## Change

Wrap the fleet envelope in the same `Dashboard_cache.get_or_compute` + `Domain_pool_ref.submit_io_or_inline` layer already used by the `/tool-stats` endpoint (`keeper_api.ml:325`). Keyed by `base_path` so distinct workspaces do not cross-contaminate. TTL = `standard_cache_ttl_s` (60s). Placement inside the function (not at call sites) so both call sites and future callers get the cache for free.

`generated_at` is now stamped at compute time (cached). The dashboard already treats it as a possibly-stale value for runtime-attention staleness arithmetic (`fleet-fsm-matrix.ts`), consistent with the existing SWR model.

## RFC-0029 §3 relationship

This is a **fleet-level envelope cache**, not a second per-keeper cache layered on the projection rebuild cycle. RFC-0029 §3 non-goal forbids layering a second cache on top of the projection rebuild SSOT. The fleet envelope is the aggregation result consumed by the HTTP/WS surface, cached at the dashboard cache tier already used by every other surface — not a per-keeper projection cache.

## Verification

- ocamlformat --check: pass
- New test asserts the second fleet-composite poll hits the cache (identical `generated_at`)
- Build/test: CI

## Note on the originally-cited line

An earlier review cited `keeper_api.ml:325` (the /tool-stats endpoint) as the N+1. That endpoint is already cached (`get_or_compute` + `submit_io_or_inline`, PRs #19088/#19097). The real N+1 is the adjacent `dashboard_fleet_composite_json` in `composite_enrich.ml:56`, which this PR fixes.

Co-Authored-By: Claude <noreply@anthropic.com>
