### PR TITLE
model turn-record sampling params (top_p, max_tokens) and stop dashboard fabrication

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2995,6 +2995,8 @@ export type TurnRecordEntry = {
   model?: string
   finish_reason?: string
   temperature?: number
+  top_p?: number
+  max_tokens?: number
   thinking_budget?: number
   enable_thinking?: boolean
   input_tokens?: number
@@ -3131,6 +3133,8 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     model: asString(raw.model),
     finish_reason: asString(raw.finish_reason),
     temperature: asNumber(raw.temperature),
+    top_p: asNumber(raw.top_p),
+    max_tokens: asNumber(raw.max_tokens),
     thinking_budget: asNumber(raw.thinking_budget),
     enable_thinking: typeof raw.enable_thinking === 'boolean' ? raw.enable_thinking : undefined,
     input_tokens: asNumber(raw.input_tokens),

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -592,21 +592,18 @@ describe('KeeperTurnInspector v2 drawer', () => {
         expect(container.textContent).toContain('샘플링 파라미터')
       })
 
-      const params = container.querySelector('.kti-params')?.textContent ?? ''
-      // real, record-backed sampling fields are surfaced
-      expect(params).toContain('temperature')
-      expect(params).toContain('0.7')
-      expect(params).toContain('top_p')
-      expect(params).toContain('0.9')
-      expect(params).toContain('max_tokens')
-      expect(params).toContain('8,192')
-      expect(params).toContain('thinking_budget')
-      expect(params).toContain('2048')
-      expect(params).toContain('enable_thinking')
-      expect(params).toContain(expected)
-      // fabricated, non-modeled literals are gone
-      expect(params).not.toContain('0.95')
-      expect(params).not.toContain('4,096')
+      const params = Array.from(container.querySelectorAll('.kti-param')).map(
+        el => el.textContent ?? ''
+      )
+      // each record-backed sampling field renders in its own chip
+      expect(params).toContain('temperature0.7')
+      expect(params).toContain('top_p0.9')
+      expect(params).toContain('max_tokens8,192')
+      expect(params).toContain('thinking_budget2048')
+      expect(params).toContain(`enable_thinking${expected}`)
+      // fabricated defaults must not appear as chips
+      expect(params).not.toContain('top_p0.95')
+      expect(params).not.toContain('max_tokens4,096')
     },
   )
 
@@ -638,17 +635,18 @@ describe('KeeperTurnInspector v2 drawer', () => {
       expect(container.textContent).toContain('샘플링 파라미터')
     })
 
-    const params = container.querySelector('.kti-params')?.textContent ?? ''
-    expect(params).toContain('temperature')
-    expect(params).toContain('top_p')
-    expect(params).toContain('max_tokens')
-    expect(params).toContain('thinking_budget')
-    expect(params).toContain('enable_thinking')
-    // absence is rendered as em-dash, not fabricated defaults
-    const emDashCount = (params.match(/—/g) || []).length
-    expect(emDashCount).toBeGreaterThanOrEqual(5)
-    expect(params).not.toContain('0.95')
-    expect(params).not.toContain('4,096')
+    const params = Array.from(container.querySelectorAll('.kti-param')).map(
+      el => el.textContent ?? ''
+    )
+    // absence is rendered as an exact chip value of em-dash
+    expect(params).toContain('temperature—')
+    expect(params).toContain('top_p—')
+    expect(params).toContain('max_tokens—')
+    expect(params).toContain('thinking_budget—')
+    expect(params).toContain('enable_thinking—')
+    // fabricated defaults must not appear as chips
+    expect(params).not.toContain('top_p0.95')
+    expect(params).not.toContain('max_tokens4,096')
   })
 
   it('displays summary stats in the stat strip', async () => {

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -559,50 +559,56 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(meta).toContain('n/a')
   })
 
-  it('renders sampling params from the record without fabricating top_p/max_tokens', async () => {
-    const response = turnRecordsWithMemoryOs()
-    response.entries[1] = {
-      ...response.entries[1]!,
-      record: {
-        ...response.entries[1]!.record,
-        temperature: 0.7,
-        top_p: 0.9,
-        max_tokens: 8192,
-        thinking_budget: 2048,
-        enable_thinking: true,
-      },
-    }
-    fetchKeeperTurnRecordsMock.mockResolvedValue(response)
+  it.each([
+    { enableThinking: true, expected: 'on' },
+    { enableThinking: false, expected: 'off' },
+  ] as Array<{ enableThinking: boolean; expected: string }>)(
+    'renders sampling params from the record without fabricating top_p/max_tokens ($expected)',
+    async ({ enableThinking, expected }) => {
+      const response = turnRecordsWithMemoryOs()
+      response.entries[1] = {
+        ...response.entries[1]!,
+        record: {
+          ...response.entries[1]!.record,
+          temperature: 0.7,
+          top_p: 0.9,
+          max_tokens: 8192,
+          thinking_budget: 2048,
+          enable_thinking: enableThinking,
+        },
+      }
+      fetchKeeperTurnRecordsMock.mockResolvedValue(response)
 
-    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+      const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
 
-    await waitFor(() => {
-      expect(container.textContent).toContain('T42')
-    })
+      await waitFor(() => {
+        expect(container.textContent).toContain('T42')
+      })
 
-    fireEvent.click(container.querySelector('.kti-turn-summary')!)
-    fireEvent.click(container.querySelector('[data-testid="turn-tab-meta"]')!)
+      fireEvent.click(container.querySelector('.kti-turn-summary')!)
+      fireEvent.click(container.querySelector('[data-testid="turn-tab-meta"]')!)
 
-    await waitFor(() => {
-      expect(container.textContent).toContain('샘플링 파라미터')
-    })
+      await waitFor(() => {
+        expect(container.textContent).toContain('샘플링 파라미터')
+      })
 
-    const params = container.querySelector('.kti-params')?.textContent ?? ''
-    // real, record-backed sampling fields are surfaced
-    expect(params).toContain('temperature')
-    expect(params).toContain('0.7')
-    expect(params).toContain('top_p')
-    expect(params).toContain('0.9')
-    expect(params).toContain('max_tokens')
-    expect(params).toContain('8,192')
-    expect(params).toContain('thinking_budget')
-    expect(params).toContain('2048')
-    expect(params).toContain('enable_thinking')
-    expect(params).toContain('on')
-    // fabricated, non-modeled literals are gone
-    expect(params).not.toContain('0.95')
-    expect(params).not.toContain('4,096')
-  })
+      const params = container.querySelector('.kti-params')?.textContent ?? ''
+      // real, record-backed sampling fields are surfaced
+      expect(params).toContain('temperature')
+      expect(params).toContain('0.7')
+      expect(params).toContain('top_p')
+      expect(params).toContain('0.9')
+      expect(params).toContain('max_tokens')
+      expect(params).toContain('8,192')
+      expect(params).toContain('thinking_budget')
+      expect(params).toContain('2048')
+      expect(params).toContain('enable_thinking')
+      expect(params).toContain(expected)
+      // fabricated, non-modeled literals are gone
+      expect(params).not.toContain('0.95')
+      expect(params).not.toContain('4,096')
+    },
+  )
 
   it('renders sampling param absence as — when the record omits them', async () => {
     const response = turnRecordsWithMemoryOs()

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -559,6 +559,92 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(meta).toContain('n/a')
   })
 
+  it('renders sampling params from the record without fabricating top_p/max_tokens', async () => {
+    const response = turnRecordsWithMemoryOs()
+    response.entries[1] = {
+      ...response.entries[1]!,
+      record: {
+        ...response.entries[1]!.record,
+        temperature: 0.7,
+        top_p: 0.9,
+        max_tokens: 8192,
+        thinking_budget: 2048,
+        enable_thinking: true,
+      },
+    }
+    fetchKeeperTurnRecordsMock.mockResolvedValue(response)
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-meta"]')!)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('샘플링 파라미터')
+    })
+
+    const params = container.querySelector('.kti-params')?.textContent ?? ''
+    // real, record-backed sampling fields are surfaced
+    expect(params).toContain('temperature')
+    expect(params).toContain('0.7')
+    expect(params).toContain('top_p')
+    expect(params).toContain('0.9')
+    expect(params).toContain('max_tokens')
+    expect(params).toContain('8,192')
+    expect(params).toContain('thinking_budget')
+    expect(params).toContain('2048')
+    expect(params).toContain('enable_thinking')
+    expect(params).toContain('on')
+    // fabricated, non-modeled literals are gone
+    expect(params).not.toContain('0.95')
+    expect(params).not.toContain('4,096')
+  })
+
+  it('renders sampling param absence as — when the record omits them', async () => {
+    const response = turnRecordsWithMemoryOs()
+    response.entries[1] = {
+      ...response.entries[1]!,
+      record: {
+        ...response.entries[1]!.record,
+        temperature: undefined,
+        top_p: undefined,
+        max_tokens: undefined,
+        thinking_budget: undefined,
+        enable_thinking: undefined,
+      },
+    }
+    fetchKeeperTurnRecordsMock.mockResolvedValue(response)
+
+    const { container } = render(html`<${KeeperTurnInspector} keeperName="albini" />`)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('T42')
+    })
+
+    fireEvent.click(container.querySelector('.kti-turn-summary')!)
+    fireEvent.click(container.querySelector('[data-testid="turn-tab-meta"]')!)
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('샘플링 파라미터')
+    })
+
+    const params = container.querySelector('.kti-params')?.textContent ?? ''
+    expect(params).toContain('temperature')
+    expect(params).toContain('top_p')
+    expect(params).toContain('max_tokens')
+    expect(params).toContain('thinking_budget')
+    expect(params).toContain('enable_thinking')
+    // absence is rendered as em-dash, not fabricated defaults
+    const emDashCount = (params.match(/—/g) || []).length
+    expect(emDashCount).toBeGreaterThanOrEqual(5)
+    expect(params).not.toContain('0.95')
+    expect(params).not.toContain('4,096')
+  })
+
   it('displays summary stats in the stat strip', async () => {
     fetchKeeperTurnRecordsMock.mockResolvedValue(turnRecordsWithMemoryOs())
 

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -492,7 +492,7 @@ function thinkingStateLabel(record: TurnRecordEntry): string {
 function thinkingChipLabel(record: TurnRecordEntry): string {
   if (record.enable_thinking === true) return 'on'
   if (record.enable_thinking === false) return 'off'
-  return 'unknown'
+  return '—'
 }
 
 function buildInjectedCtx(record: TurnRecordEntry, ctxPct: number, tokIn: number): string {
@@ -981,9 +981,10 @@ function MetaTab({ record, t, source }: { record: TurnRecordEntry; t: TurnDetail
       <div class="kti-sec-h"><h4>샘플링 파라미터</h4></div>
       <div class="kti-params">
         <span class="kti-param">temperature<b>${record.temperature ?? '—'}</b></span>
-        <span class="kti-param">top_p<b>0.95</b></span>
-        <span class="kti-param">max_tokens<b>4,096</b></span>
+        <span class="kti-param">top_p<b>${record.top_p ?? '—'}</b></span>
+        <span class="kti-param">max_tokens<b>${record.max_tokens?.toLocaleString() ?? '—'}</b></span>
         <span class="kti-param">thinking_budget<b>${record.thinking_budget ?? '—'}</b></span>
+        <span class="kti-param">enable_thinking<b>${thinkingChipLabel(record)}</b></span>
       </div>
       <div class="kti-sec-h" style=${{ marginTop: '16px' }}><h4>실행 메타데이터</h4></div>
       <div class="kti-kv">
@@ -1194,6 +1195,8 @@ function TurnRow({
       : null
   const sampling = [
     record.temperature != null ? `t=${record.temperature}` : null,
+    record.top_p != null ? `p=${record.top_p}` : null,
+    record.max_tokens != null ? `tok=${record.max_tokens}` : null,
     record.thinking_budget != null ? `think=${record.thinking_budget}` : null,
     record.enable_thinking === false ? 'no-think' : null,
   ].filter(Boolean)

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -703,6 +703,13 @@ let run_turn
                !receipt_stop_reason_ref)
           ~sampling:
             { temperature = Some temperature
+            ; top_p = None
+              (* TODO: top_p is not yet threaded through Keeper_run_context /
+                 Keeper_turn_driver / Runtime_agent_context. The dashboard
+                 previously fabricated 0.95; we now render absence until the
+                 runtime pipeline exposes the effective value. See PR
+                 description for adversarial gap analysis. *)
+            ; max_tokens = Some max_tokens
             ; thinking_budget = tctx.thinking_budget
             ; enable_thinking = tctx.thinking_enabled
             }

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -709,7 +709,10 @@ let run_turn
                  previously fabricated 0.95; we now render absence until the
                  runtime pipeline exposes the effective value. See PR
                  description for adversarial gap analysis. *)
-            ; max_tokens = Some max_tokens
+            ; max_tokens =
+                (match pre_dispatch_max_tokens_error with
+                 | None -> Some max_tokens
+                 | Some _ -> None)
             ; thinking_budget = tctx.thinking_budget
             ; enable_thinking = tctx.thinking_enabled
             }

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -6,6 +6,8 @@ type prompt_block =
 
 type sampling =
   { temperature : float option
+  ; top_p : float option
+  ; max_tokens : int option
   ; thinking_budget : int option
   ; enable_thinking : bool option
   }
@@ -57,6 +59,8 @@ let to_json (r : t) : Yojson.Safe.t =
     @ opt_field "model" (fun v -> `String v) r.model
     @ opt_field "finish_reason" (fun v -> `String v) r.finish_reason
     @ opt_field "temperature" (fun v -> `Float v) r.sampling.temperature
+    @ opt_field "top_p" (fun v -> `Float v) r.sampling.top_p
+    @ opt_field "max_tokens" (fun v -> `Int v) r.sampling.max_tokens
     @ opt_field "thinking_budget" (fun v -> `Int v) r.sampling.thinking_budget
     @ opt_field "enable_thinking" (fun v -> `Bool v) r.sampling.enable_thinking
     @ opt_field "input_tokens" (fun v -> `Int v) r.usage.input_tokens
@@ -148,6 +152,8 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
       let* model = opt_member "model" fields as_string in
       let* finish_reason = opt_member "finish_reason" fields as_string in
       let* temperature = opt_member "temperature" fields as_float in
+      let* top_p = opt_member "top_p" fields as_float in
+      let* max_tokens = opt_member "max_tokens" fields as_int in
       let* thinking_budget = opt_member "thinking_budget" fields as_int in
       let* enable_thinking = opt_member "enable_thinking" fields as_bool in
       let* input_tokens = opt_member "input_tokens" fields as_int in
@@ -164,7 +170,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; runtime_profile
         ; model
         ; finish_reason
-        ; sampling = { temperature; thinking_budget; enable_thinking }
+        ; sampling = { temperature; top_p; max_tokens; thinking_budget; enable_thinking }
         ; usage = { input_tokens; output_tokens }
         ; ts
         }

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -19,6 +19,8 @@ type prompt_block =
 
 type sampling =
   { temperature : float option
+  ; top_p : float option
+  ; max_tokens : int option
   ; thinking_budget : int option
   ; enable_thinking : bool option
   }

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -48,7 +48,12 @@ let sample_record () : Turn_record.t =
   ; model = Some "deepseek-v4-flash"
   ; finish_reason = Some "completed"
   ; sampling =
-      { temperature = Some 0.3; thinking_budget = Some 1500; enable_thinking = Some true }
+      { temperature = Some 0.3
+      ; top_p = Some 0.9
+      ; max_tokens = Some 8192
+      ; thinking_budget = Some 1500
+      ; enable_thinking = Some true
+      }
   ; usage = { input_tokens = Some 18000; output_tokens = Some 412 }
   ; ts = 1781200000.5
   }
@@ -83,6 +88,10 @@ let test_codec_roundtrip () =
     check (option string) "finish_reason" record.finish_reason decoded.finish_reason;
     check (option (float 0.0001)) "temperature" record.sampling.temperature
       decoded.sampling.temperature;
+    check (option (float 0.0001)) "top_p" record.sampling.top_p
+      decoded.sampling.top_p;
+    check (option int) "max_tokens" record.sampling.max_tokens
+      decoded.sampling.max_tokens;
     check (option int) "thinking_budget" record.sampling.thinking_budget
       decoded.sampling.thinking_budget;
     check (option bool) "enable_thinking" record.sampling.enable_thinking
@@ -98,7 +107,13 @@ let test_codec_optional_fields_absent () =
     { (sample_record ()) with
       model = None
     ; finish_reason = None
-    ; sampling = { temperature = None; thinking_budget = None; enable_thinking = None }
+    ; sampling =
+        { temperature = None
+        ; top_p = None
+        ; max_tokens = None
+        ; thinking_budget = None
+        ; enable_thinking = None
+        }
     ; usage = { input_tokens = None; output_tokens = None }
     ; turn_ref = None
     }
@@ -111,7 +126,11 @@ let test_codec_optional_fields_absent () =
      check bool "finish_reason key omitted when None" false
        (List.mem_assoc "finish_reason" fields);
      check bool "model key omitted when None" false
-       (List.mem_assoc "model" fields)
+       (List.mem_assoc "model" fields);
+     check bool "top_p key omitted when None" false
+       (List.mem_assoc "top_p" fields);
+     check bool "max_tokens key omitted when None" false
+       (List.mem_assoc "max_tokens" fields)
    | _ -> fail "to_json did not produce an object");
   match Turn_record.of_json json with
   | Error e -> failf "decode failed: %s" e
@@ -121,6 +140,8 @@ let test_codec_optional_fields_absent () =
       decoded.finish_reason;
     check (option (float 0.0001)) "temperature absent" None
       decoded.sampling.temperature;
+    check (option (float 0.0001)) "top_p absent" None decoded.sampling.top_p;
+    check (option int) "max_tokens absent" None decoded.sampling.max_tokens;
     check (option int) "input_tokens absent" None decoded.usage.input_tokens;
     check bool "turn_ref absent" true (decoded.turn_ref = None)
 


### PR DESCRIPTION
## Summary

Properly model `top_p` and `max_tokens` in the keeper turn-record pipeline and stop the dashboard from fabricating default values. `max_tokens` is now populated from the effective runtime value; `top_p` is modeled through the type/codec/UI but intentionally left unpopulated because the runtime pipeline does not yet thread it through to the turn-record write site.

## Changes

- `lib/types/turn_record.{ml,mli}`
  - Extend `sampling` with `top_p : float option` and `max_tokens : int option`.
  - Update JSON encode/decode to emit/parse the new fields and omit absent keys.
- `lib/keeper/keeper_agent_run.ml`
  - Write the effective `max_tokens` into the turn record.
  - Write `top_p = None` with an explicit TODO/gap comment documenting that it is not yet available at this call site.
- `dashboard/src/api/dashboard.ts`
  - Add `top_p?` and `max_tokens?` to `TurnRecordEntry` and decoder.
- `dashboard/src/components/keeper-turn-inspector.ts`
  - Render record-backed `top_p` and `max_tokens` in the sampling params panel.
  - Replace fabricated `0.95` / `4,096` chips with `—` when absent.
  - Include `top_p` and `max_tokens` in the turn-row sampling summary chips.
  - Render absent `enable_thinking` as `—` instead of `unknown` for consistency.
- `test/test_turn_record.ml`
  - Cover `top_p` and `max_tokens` in the round-trip test.
  - Assert absent `top_p` / `max_tokens` keys are omitted from JSON.
- `dashboard/src/components/keeper-turn-inspector.test.ts`
  - Add tests verifying record-backed sampling params and absence rendering.

## Adversarial evaluation / known gaps

1. **`top_p` population gap.**
   - `top_p` is configured via `Llm_provider.Provider_config.t` / `Agent_sdk.Builder`, but MASC's runtime-execution/run-context types (`Keeper_turn_runtime_budget.runtime_execution`, `Keeper_run_context.run_context`, `Keeper_turn_driver.run_named`, `Runtime_agent_context.config`) do not carry it. Therefore `keeper_agent_run.ml` has no clean source for the effective `top_p` at turn-record write time.
   - Risk: the dashboard could regress to fabrication if we do not document this explicitly. The new code renders `—` when absent, which is the conservative, non-misleading behavior.
   - Remediation path: extend the runtime context with the effective `top_p` (or provider config snapshot) and pass it through `Keeper_turn_driver` → `Keeper_agent_run.run_turn` → `Keeper_turn_record_writer.write`.

2. **`max_tokens` source.**
   - Populated from the local `max_tokens` value already validated inside `keeper_agent_run.ml`. This is the effective token cap used for the LLM call, so it is accurate.

3. **Backwards compatibility.**
   - Both fields are optional in JSON and decoded defensively. Old records without them decode as `None` and render as `—`.

## Validation

- `npx tsc --noEmit --pretty` in `dashboard/` passes.
- `npx vitest run src/components/keeper-turn-inspector.test.ts` passes.
- Focused `dune` type-check targets are running for the touched OCaml targets; full `dune build` / `dune runtest` is left to CI per the repo's local-build policy.
