### PR TITLE
feat(dashboard): RFC-0273 §3.4 — real read-only VerifyBtn probe (honest defer for DB/repo)

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2091,6 +2091,30 @@ export async function fetchDashboardRuntimeProbe(
   return get(`/api/v1/dashboard/runtime-probe${query}`, { signal: opts?.signal })
 }
 
+// RFC-0273 §3.4 — read-only verification of operator-supplied Settings
+// resources (Settings surface VerifyBtn). Only the kinds with a real in-tree
+// probe are modeled; DB / GitHub-repo verify is deferred (the UI renders an
+// honest "수동 확인" state instead of calling this).
+export type VerifyResourceKind = 'mcp_endpoint' | 'gate_url' | 'worktree_path'
+
+export interface VerifyResourceResult {
+  ok: boolean
+  kind: string
+  detail: string
+  target: string
+  http_status: number | null
+}
+
+export async function verifyResource(
+  kind: VerifyResourceKind,
+  value: string,
+): Promise<VerifyResourceResult> {
+  // CanAdmin-gated route (server fetches the value) — seed the dev token first,
+  // mirroring fetchDashboardRuntimeProbe.
+  await ensureDevToken()
+  return post<VerifyResourceResult>('/api/v1/dashboard/verify-resource', { kind, value })
+}
+
 export async function fetchDashboardTools(opts?: AbortableRequestOptions): Promise<DashboardToolsResponse> {
   const raw = await get<DashboardToolsResponse>('/api/v1/dashboard/tools', { signal: opts?.signal })
   const normalizedTools = raw.tool_inventory?.tools?.map(t => ({

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -22,6 +22,7 @@ const apiMock = vi.hoisted(() => ({
   fetchLogs: vi.fn(),
   fetchDashboardTools: vi.fn(),
   fetchRuntimeDefaults: vi.fn(),
+  verifyResource: vi.fn(),
 }))
 
 vi.mock('../api/dashboard.js', async () => {
@@ -31,6 +32,7 @@ vi.mock('../api/dashboard.js', async () => {
     fetchLogs: apiMock.fetchLogs,
     fetchDashboardTools: apiMock.fetchDashboardTools,
     fetchRuntimeDefaults: apiMock.fetchRuntimeDefaults,
+    verifyResource: apiMock.verifyResource,
   }
 })
 
@@ -122,6 +124,7 @@ describe('SettingsSurface', () => {
     apiMock.fetchLogs.mockReset()
     apiMock.fetchDashboardTools.mockReset()
     apiMock.fetchRuntimeDefaults.mockReset()
+    apiMock.verifyResource.mockReset()
     stubEmptyApi()
   })
 
@@ -250,6 +253,70 @@ describe('SettingsSurface', () => {
     expect(container.querySelectorAll('[data-testid="routing-assignment"]').length).toBe(0)
   })
 
+  // RFC-0273 §3.4 — VerifyBtn performs a real read-only probe (no more fake
+  // setTimeout-to-ok). The defining property: a probe that does not succeed
+  // must NOT render as success.
+  it('VerifyBtn runs a real probe and shows success only on ok:true', async () => {
+    apiMock.verifyResource.mockResolvedValue({
+      ok: true,
+      kind: 'mcp_endpoint',
+      detail: '정상 (HTTP 200)',
+      target: 'https://masc.local/mcp',
+      http_status: 200,
+    })
+    render(html`<${SettingsSurface} />`, container)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-mcp"]') as HTMLElement)
+
+    const verify = () => container.querySelector('[data-testid="set-verify"]') as HTMLButtonElement
+    expect(verify().getAttribute('data-state')).toBe('idle')
+
+    await fireEvent.click(verify())
+    await waitFor(() => expect(verify().getAttribute('data-state')).toBe('ok'))
+    expect(apiMock.verifyResource).toHaveBeenCalledWith('mcp_endpoint', 'https://masc.local/mcp')
+    expect(verify().textContent?.trim()).toBe('✓ 정상')
+  })
+
+  it('VerifyBtn shows failure on ok:false — never a fabricated success', async () => {
+    apiMock.verifyResource.mockResolvedValue({
+      ok: false,
+      kind: 'gate_url',
+      detail: '도달 불가: timeout',
+      target: 'https://gate.masc.local',
+      http_status: null,
+    })
+    render(html`<${SettingsSurface} />`, container)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
+
+    const verify = () => container.querySelector('[data-testid="set-verify"]') as HTMLButtonElement
+    await fireEvent.click(verify())
+    await waitFor(() => expect(verify().getAttribute('data-state')).toBe('fail'))
+    expect(verify().textContent?.trim()).toBe('✗ 실패')
+  })
+
+  it('VerifyBtn surfaces a thrown error (e.g. 401) as fail, not a silent ok', async () => {
+    apiMock.verifyResource.mockRejectedValue(new Error('401 unauthorized'))
+    render(html`<${SettingsSurface} />`, container)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
+
+    const verify = () => container.querySelector('[data-testid="set-verify"]') as HTMLButtonElement
+    await fireEvent.click(verify())
+    await waitFor(() => expect(verify().getAttribute('data-state')).toBe('fail'))
+  })
+
+  it('deferred resources (linked repo / DB) render an honest "수동 확인", never call verify', async () => {
+    render(html`<${SettingsSurface} />`, container)
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-ide"]') as HTMLElement)
+
+    const verify = container.querySelector('[data-testid="set-verify"]') as HTMLButtonElement
+    expect(verify.getAttribute('data-state')).toBe('deferred')
+    expect(verify.disabled).toBe(true)
+    expect(verify.textContent?.trim()).toBe('수동 확인')
+
+    await fireEvent.click(verify)
+    expect(apiMock.verifyResource).not.toHaveBeenCalled()
+    expect(verify.getAttribute('data-state')).toBe('deferred')
+  })
+
   it('runtime nodes section uses the resolved registry without sample targets', async () => {
     render(html`<${SettingsSurface} />`, container)
 
@@ -343,6 +410,7 @@ describe('SettingsSurface shell route', () => {
     apiMock.fetchLogs.mockReset()
     apiMock.fetchDashboardTools.mockReset()
     apiMock.fetchRuntimeDefaults.mockReset()
+    apiMock.verifyResource.mockReset()
     stubEmptyApi()
     dashboardLoading.value = false
     connected.value = true

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -1,13 +1,23 @@
 // MASC Dashboard — Settings surface (keeper-v2 port)
 // Read surfaces (MCP exposed-tools list, system-log tail, runtime defaults /
-// model routing) are wired to live backend data. Write surfaces (Save changes,
-// VerifyBtn, expose/unexpose persistence) remain local-state stubs.
+// model routing) are wired to live backend data. VerifyBtn performs a real
+// read-only probe for MCP/Gate URLs (reachability) and the worktree basepath
+// (existence) via /api/v1/dashboard/verify-resource (RFC-0273 §3.4). DB and
+// linked-repo verification have no in-tree probe yet and render an honest
+// "수동 확인" placeholder (DeferredVerifyBtn) rather than a fabricated "✓".
+// Remaining write surfaces (Save changes, expose/unexpose persistence) are
+// still local-state stubs.
 
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import { navigate } from '../router'
-import { fetchDashboardTools, fetchLogs, fetchRuntimeDefaults } from '../api/dashboard.js'
-import type { DashboardToolInventoryItem, LogEntry, RuntimeDefaultsResponse } from '../api/dashboard.js'
+import { fetchDashboardTools, fetchLogs, fetchRuntimeDefaults, verifyResource } from '../api/dashboard.js'
+import type {
+  DashboardToolInventoryItem,
+  LogEntry,
+  RuntimeDefaultsResponse,
+  VerifyResourceKind,
+} from '../api/dashboard.js'
 import type { ComponentChildren } from 'preact'
 
 type SectionId =
@@ -27,7 +37,7 @@ type SectionId =
   | 'notify'
   | 'display'
 
-type VerifyState = 'idle' | 'checking' | 'ok'
+type VerifyState = 'idle' | 'checking' | 'ok' | 'fail'
 type LogFilter = 'all' | 'tool' | 'success' | 'failure'
 
 const SET_SECTIONS: [SectionId, string, string][] = [
@@ -223,21 +233,63 @@ function SetSlider({
   `
 }
 
-function VerifyBtn({ label }: { label?: string }) {
+function VerifyBtn({ label, kind, value }: { label?: string; kind: VerifyResourceKind; value: string }) {
   const [st, setSt] = useState<VerifyState>('idle')
+  const [detail, setDetail] = useState('')
+  const onClick = (e: Event) => {
+    e.stopPropagation()
+    setSt('checking')
+    setDetail('')
+    void (async () => {
+      try {
+        const res = await verifyResource(kind, value)
+        setSt(res.ok ? 'ok' : 'fail')
+        setDetail(res.detail)
+      } catch (err) {
+        // A failed probe must surface as 'fail' — never silently land on 'ok'
+        // (that was the old setTimeout fake's defect).
+        setSt('fail')
+        setDetail(err instanceof Error ? err.message : '검증 실패')
+      }
+    })()
+  }
+  const text =
+    st === 'idle'
+      ? (label ?? '확인')
+      : st === 'checking'
+        ? '확인 중…'
+        : st === 'ok'
+          ? '✓ 정상'
+          : '✗ 실패'
   return html`
     <button
       type="button"
       class=${`set-verify ${st}`}
       data-state=${st}
       data-testid="set-verify"
-      onClick=${(e: Event) => {
-        e.stopPropagation()
-        setSt('checking')
-        window.setTimeout(() => setSt('ok'), 700)
-      }}
+      title=${detail}
+      onClick=${onClick}
     >
-      ${st === 'idle' ? (label ?? '확인') : st === 'checking' ? '확인 중…' : '✓ 정상'}
+      ${text}
+    </button>
+  `
+}
+
+// Honest placeholder for resources with no in-tree probe yet (Store/DB,
+// linked GitHub repo). Disabled — never fabricates a "✓ 정상" (RFC-0273 §3.4
+// defers these to a follow-up). Stateless, so no hooks: keeps VerifyBtn's hook
+// order unconditional.
+function DeferredVerifyBtn() {
+  return html`
+    <button
+      type="button"
+      class="set-verify deferred"
+      data-state="deferred"
+      data-testid="set-verify"
+      disabled
+      title="자동 검증 미지원 — 수동 확인 필요"
+    >
+      수동 확인
     </button>
   `
 }
@@ -593,7 +645,7 @@ export function SettingsSurface() {
                     value=${mcpUrl}
                     onInput=${(e: Event) => setMcpUrl((e.target as HTMLInputElement).value)}
                   />
-                  <${VerifyBtn} />
+                  <${VerifyBtn} kind="mcp_endpoint" value=${mcpUrl} />
                 </div>
               <//>
               <${SetRow} label="Transport" hint="transport">
@@ -851,7 +903,7 @@ export function SettingsSurface() {
                     value=${ideRepo}
                     onInput=${(e: Event) => setIdeRepo((e.target as HTMLInputElement).value)}
                   />
-                  <${VerifyBtn} label="Check repo" />
+                  <${DeferredVerifyBtn} />
                 </div>
               <//>
             `}
@@ -874,7 +926,7 @@ export function SettingsSurface() {
                     value=${gateBase}
                     onInput=${(e: Event) => setGateBase((e.target as HTMLInputElement).value)}
                   />
-                  <${VerifyBtn} />
+                  <${VerifyBtn} kind="gate_url" value=${gateBase} />
                 </div>
               <//>
               ${['Slack', 'Discord', 'Amplitude', 'GitHub'].map(g => html`
@@ -896,7 +948,7 @@ export function SettingsSurface() {
                     value=${mcpUrl}
                     onInput=${(e: Event) => setMcpUrl((e.target as HTMLInputElement).value)}
                   />
-                  <${VerifyBtn} />
+                  <${VerifyBtn} kind="mcp_endpoint" value=${mcpUrl} />
                 </div>
               <//>
               <${SetRow} label="Store (DB)" hint="trace·audit persistence">
@@ -906,7 +958,7 @@ export function SettingsSurface() {
                     value=${storeUrl}
                     onInput=${(e: Event) => setStoreUrl((e.target as HTMLInputElement).value)}
                   />
-                  <${VerifyBtn} />
+                  <${DeferredVerifyBtn} />
                 </div>
               <//>
               <${SetRow} label="Default worktree basepath" hint="keeper worktree root — e.g. ~/wt/<keeper>">
@@ -916,7 +968,7 @@ export function SettingsSurface() {
                     value=${wtBase}
                     onInput=${(e: Event) => setWtBase((e.target as HTMLInputElement).value)}
                   />
-                  <${VerifyBtn} label="Check path" />
+                  <${VerifyBtn} kind="worktree_path" value=${wtBase} label="Check path" />
                 </div>
               <//>
             `}

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -293,6 +293,24 @@
   color: var(--text-dim);
 }
 
+.set-verify.fail {
+  color: var(--status-bad);
+  border-color: color-mix(in oklab, var(--status-bad) 45%, transparent);
+}
+
+/* Honest placeholder for resources with no in-tree probe yet (DB / repo) —
+   never styled as success. */
+.set-verify.deferred {
+  color: var(--text-dim);
+  border-style: dashed;
+  cursor: not-allowed;
+}
+
+.set-verify.deferred:hover {
+  border-color: var(--border-main);
+  color: var(--text-dim);
+}
+
 .set-path {
   display: flex;
   align-items: center;

--- a/docs/rfc/RFC-0273-dashboard-driven-keeper-config-and-runtime-persistence.md
+++ b/docs/rfc/RFC-0273-dashboard-driven-keeper-config-and-runtime-persistence.md
@@ -77,7 +77,14 @@ All write endpoints sit behind **dashboard operator auth**, following the preced
 
 ### 3.4 VerifyBtn
 
-Replace the fake `setTimeout` with a **read-only** verify endpoint that probes the selected runtime's reachability (provider/model resolvable, endpoint live) and returns a typed `{ ok; detail }`. No write, no credential exposure (mask per RFC-0132). This is independent of Tier A/B and can ship first.
+> **Amendment (PR-VerifyBtn, grounded correction).** The original draft said this probes "the selected runtime's reachability". Grounding `settings-surface.ts` corrected that premise: the fake `VerifyBtn` (`:237`, `setTimeout(() => setSt('ok'), 700)`) is reused at **six** call sites that verify five **heterogeneous, non-runtime** resources — MCP endpoint URL (×2), Gate base URL, Store/DB connection string, worktree basepath, and a linked GitHub repo ref. Runtime reachability is a *separate* concern already served by `GET /api/v1/dashboard/runtime-probe` (`dashboard_runtime_provider_probe_json`). §3.4 is therefore re-scoped to the resources `VerifyBtn` actually targets.
+
+Replace the fake `setTimeout` with a **read-only** verify endpoint (`POST /api/v1/dashboard/verify-resource`) that takes a typed `{ kind; value }` and returns `{ ok; detail; http_status; target }`:
+
+- **Implemented now (in-tree probes):** `mcp_endpoint` / `gate_url` → HTTP(S) reachability via `Masc_http_client.get_sync` (2xx/3xx → ok; 4xx/5xx/connection-failure → fail); `worktree_path` → server-side directory existence (`~` expanded to `$HOME`). The echoed `target` is userinfo/query/fragment-stripped (RFC-0132); credentials are never exposed.
+- **Deferred (honest, not faked):** Store/DB (`store_url`) and linked GitHub repo (`ide_repo`) have no in-tree probe yet (they need DB-ping / GitHub-API infra and their own credential boundary). The frontend renders a disabled **"수동 확인"** placeholder for these rather than a fabricated `✓` — an always-success stub is worse than honest absence (the same anti-fabrication bar as the rest of this RFC). A follow-up adds their probes.
+
+**Auth:** unlike the public-read runtime-probe (which only probes the server's own `runtime.toml` URLs), this endpoint fetches a **caller-supplied** URL (SSRF surface) / stats a caller-supplied path (info-disclosure), so it is gated behind operator (`CanAdmin`) auth — read-only, but stricter than a public read. Independent of Tier A/B; ships first.
 
 ## 4. Scope & non-goals
 

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -64,6 +64,18 @@ val light_runtime_resolution_json : Workspace.config -> Yojson.Safe.t
     aligned with [/health] fleet safety without running git probes or other
     heavy runtime-resolution checks on the header hot path. *)
 
+(** {1 URL hygiene (shared with the verify-resource route)} *)
+
+val dashboard_runtime_url_for_json : string -> string
+(** Strip userinfo / query / fragment from a URL before echoing it on a
+    dashboard surface, so credentials embedded in a URL never leak (RFC-0132).
+    Reused by {!Server_dashboard_verify_resource} for the verify-target echo. *)
+
+val dashboard_runtime_http_url_valid : string -> bool
+(** [true] when the URL has an [http]/[https] scheme and a non-empty host.
+    Reused by {!Server_dashboard_verify_resource} to reject non-HTTP schemes
+    (e.g. [file:]) before the server issues an outbound GET. *)
+
 (** {1 Dashboard HTTP routes} *)
 
 val dashboard_runtime_probe_http_json :

--- a/lib/server/server_dashboard_verify_resource.ml
+++ b/lib/server/server_dashboard_verify_resource.ml
@@ -1,0 +1,131 @@
+(* server_dashboard_verify_resource — read-only verification of operator-supplied
+   Settings resources (RFC-0273 §3.4). See the .mli for the boundary rationale
+   (caller-supplied value => SSRF / info-disclosure surface => CanAdmin-gated at
+   the route, stricter than the server-config runtime-probe). *)
+
+type kind =
+  | Mcp_endpoint
+  | Gate_url
+  | Worktree_path
+
+let kind_of_string raw =
+  match String.trim raw with
+  | "mcp_endpoint" -> Ok Mcp_endpoint
+  | "gate_url" -> Ok Gate_url
+  | "worktree_path" -> Ok Worktree_path
+  | other -> Error (Printf.sprintf "unknown verify kind: %s" other)
+
+let string_of_kind = function
+  | Mcp_endpoint -> "mcp_endpoint"
+  | Gate_url -> "gate_url"
+  | Worktree_path -> "worktree_path"
+
+type outcome = {
+  ok : bool;
+  detail : string;
+  http_status : int option;
+  target : string;
+}
+
+(* Deterministic test injection for the HTTP path, mirroring
+   Server_dashboard_http_runtime_info.set_dashboard_runtime_provider_http_get_for_tests. *)
+let http_get_hook : (url:string -> (int, string) result) option ref = ref None
+let set_http_get_for_tests hook = http_get_hook := Some hook
+let clear_http_get_for_tests () = http_get_hook := None
+
+let verify_timeout_sec = 5.0
+
+(* HTTP(S) reachability for a caller-supplied URL. The server issues the GET, so
+   the route gates this behind operator auth. URL scheme is restricted to
+   http/https and the echoed [target] is userinfo/query/fragment-stripped — both
+   reuse the canonical dashboard helpers (no reimplementation). *)
+let verify_http ~value =
+  let target = Server_dashboard_http_runtime_info.dashboard_runtime_url_for_json value in
+  if not (Server_dashboard_http_runtime_info.dashboard_runtime_http_url_valid value)
+  then { ok = false; detail = "http/https URL이 아닙니다"; http_status = None; target }
+  else begin
+    let status_of url =
+      match !http_get_hook with
+      | Some hook -> hook ~url
+      | None ->
+        (match Eio_context.get_clock () with
+         | Error msg -> Error (Printf.sprintf "eio clock 없음: %s" msg)
+         | Ok clock ->
+           (match
+              Masc_http_client.get_sync ~clock ~timeout_sec:verify_timeout_sec ~url
+                ~headers:[] ()
+            with
+            | Ok (status, _body) -> Ok status
+            | Error e -> Error e))
+    in
+    match status_of value with
+    | Error e ->
+      { ok = false; detail = Printf.sprintf "도달 불가: %s" e; http_status = None; target }
+    | Ok status ->
+      (* Honest classification: any received status proves the host responded,
+         but only 2xx/3xx counts as a healthy endpoint. 4xx (wrong path / auth)
+         and 5xx (server error) are surfaced as failures with the status so the
+         operator is not shown a green "✓" for a misconfigured URL. *)
+      let ok, detail =
+        if status >= 200 && status < 400 then true, Printf.sprintf "정상 (HTTP %d)" status
+        else if status >= 500 then false, Printf.sprintf "서버 오류 (HTTP %d)" status
+        else false, Printf.sprintf "응답함, but HTTP %d" status
+      in
+      { ok; detail; http_status = Some status; target }
+  end
+
+(* Expand a leading "~" to $HOME for the worktree basepath (e.g. "~/wt"). *)
+let expand_home path =
+  let path = String.trim path in
+  if path = "~" then Option.value (Sys.getenv_opt "HOME") ~default:path
+  else if String.length path >= 2 && String.equal (String.sub path 0 2) "~/" then
+    match Sys.getenv_opt "HOME" with
+    | Some home -> Filename.concat home (String.sub path 2 (String.length path - 2))
+    | None -> path
+  else path
+
+let is_directory path = try Sys.is_directory path with Sys_error _ -> false
+
+(* Filesystem existence for a caller-supplied directory path. Info-disclosure
+   surface (reveals what exists on the host), so gated at the route. *)
+let verify_path ~value =
+  let expanded = expand_home value in
+  if String.equal expanded "" then
+    { ok = false; detail = "빈 경로"; http_status = None; target = value }
+  else if not (Sys.file_exists expanded) then
+    { ok = false; detail = "경로 없음"; http_status = None; target = value }
+  else if not (is_directory expanded) then
+    { ok = false; detail = "디렉터리 아님"; http_status = None; target = value }
+  else { ok = true; detail = "경로 존재"; http_status = None; target = value }
+
+let verify ~kind ~value =
+  match kind with
+  | Mcp_endpoint | Gate_url -> verify_http ~value
+  | Worktree_path -> verify_path ~value
+
+let to_json ~kind outcome =
+  `Assoc
+    [ ("ok", `Bool outcome.ok)
+    ; ("kind", `String (string_of_kind kind))
+    ; ("detail", `String outcome.detail)
+    ; ("target", `String outcome.target)
+    ; ( "http_status"
+      , match outcome.http_status with Some status -> `Int status | None -> `Null )
+    ]
+
+let parse_request body =
+  match Yojson.Safe.from_string body with
+  | exception _ -> Error "invalid JSON body"
+  | json ->
+    let field name =
+      match json with
+      | `Assoc fields -> List.assoc_opt name fields
+      | _ -> None
+    in
+    (match field "kind", field "value" with
+     | Some (`String kind_str), Some (`String value) ->
+       (match kind_of_string kind_str with
+        | Ok kind -> Ok (kind, value)
+        | Error e -> Error e)
+     | Some (`String _), _ -> Error "missing or non-string \"value\""
+     | _, _ -> Error "missing or non-string \"kind\"")

--- a/lib/server/server_dashboard_verify_resource.ml
+++ b/lib/server/server_dashboard_verify_resource.ml
@@ -74,15 +74,17 @@ let verify_http ~value =
       { ok; detail; http_status = Some status; target }
   end
 
-(* Expand a leading "~" to $HOME for the worktree basepath (e.g. "~/wt"). *)
+(* Expand a leading "~" to $HOME for the worktree basepath (e.g. "~/wt").
+   Reading $HOME is the one environment boundary here; the None case (HOME unset)
+   is handled explicitly — the path is left literal, which then fails the
+   existence check honestly rather than being silently substituted. *)
 let expand_home path =
   let path = String.trim path in
-  if path = "~" then Option.value (Sys.getenv_opt "HOME") ~default:path
-  else if String.length path >= 2 && String.equal (String.sub path 0 2) "~/" then
-    match Sys.getenv_opt "HOME" with
-    | Some home -> Filename.concat home (String.sub path 2 (String.length path - 2))
-    | None -> path
-  else path
+  match Sys.getenv_opt "HOME" with
+  | Some home when String.equal path "~" -> home
+  | Some home when String.length path >= 2 && String.equal (String.sub path 0 2) "~/" ->
+    Filename.concat home (String.sub path 2 (String.length path - 2))
+  | Some _ | None -> path
 
 let is_directory path = try Sys.is_directory path with Sys_error _ -> false
 

--- a/lib/server/server_dashboard_verify_resource.mli
+++ b/lib/server/server_dashboard_verify_resource.mli
@@ -1,0 +1,60 @@
+(** Read-only verification of operator-supplied Settings resources (RFC-0273 §3.4).
+
+    Replaces the dashboard {b VerifyBtn} fake (settings-surface.ts, which always
+    landed on "✓ 정상" via a 700ms [setTimeout] with zero network activity).
+
+    Boundary vs {!Server_dashboard_http_runtime_info} runtime-probe: the
+    runtime-probe only probes URLs read from the server's own [runtime.toml]
+    SSOT. This module verifies values the {e caller supplies} in the request
+    body, so the HTTP path is an SSRF surface and the filesystem path is an
+    info-disclosure surface. The route ([POST /api/v1/dashboard/verify-resource])
+    is therefore gated behind operator ([CanAdmin]) auth at the call site —
+    stricter than the public-read runtime-probe.
+
+    Scope (RFC-0273 §3.4, Option A): real verification for HTTP endpoints
+    ([Mcp_endpoint], [Gate_url]) and filesystem paths ([Worktree_path]). DB
+    connection strings and GitHub repo refs are deferred to a follow-up (they
+    need DB-ping / GitHub-API infra and their own credential boundary); the
+    frontend renders an honest "수동 확인" state for those rather than a
+    fabricated success. *)
+
+type kind =
+  | Mcp_endpoint  (** an HTTP(S) MCP endpoint URL — reachability via GET *)
+  | Gate_url  (** an HTTP(S) external-gate base URL — reachability via GET *)
+  | Worktree_path  (** a server-local filesystem directory — existence via stat *)
+
+val kind_of_string : string -> (kind, string) result
+(** Parse a verify [kind]. An unrecognized kind returns [Error]; it is never
+    coerced to a permissive default (AI anti-pattern §2 "unknown → permissive
+    default"). *)
+
+type outcome = {
+  ok : bool;  (** the resource was verified to be reachable / present *)
+  detail : string;  (** human-readable explanation (status text, error, …) *)
+  http_status : int option;  (** the observed HTTP status for HTTP kinds *)
+  target : string;
+      (** the verified value echoed back, sanitized for HTTP kinds (userinfo /
+          query / fragment stripped per RFC-0132) so credentials never leak *)
+}
+
+val verify : kind:kind -> value:string -> outcome
+(** [verify ~kind ~value] runs the read-only probe. It never raises: connection
+    failures, timeouts, unresolved hosts, and missing paths all surface as
+    [{ ok = false; detail = <reason>; _ }]. No write, no credential exposure. *)
+
+val to_json : kind:kind -> outcome -> Yojson.Safe.t
+(** Encode an [outcome] as the dashboard JSON response
+    [{ ok; kind; detail; target; http_status }]. *)
+
+val parse_request : string -> (kind * string, string) result
+(** Parse the POST body [{ "kind": <string>; "value": <string> }]. Missing or
+    non-string fields, malformed JSON, and unknown kinds all return [Error]. *)
+
+(** {1 Test hooks}
+
+    Mirrors {!Server_dashboard_http_runtime_info.set_dashboard_runtime_provider_http_get_for_tests}:
+    inject a deterministic HTTP-status function so the HTTP verify path is unit
+    testable without real network IO. *)
+
+val set_http_get_for_tests : (url:string -> (int, string) result) -> unit
+val clear_http_get_for_tests : unit -> unit

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -369,6 +369,26 @@ let add_routes ~sw ~clock router =
                        ~status:(runtime_config_path_error_status msg)
                        ~request:req reqd msg)))
          ) request reqd)
+  |> Http.Router.post "/api/v1/dashboard/verify-resource" (fun request reqd ->
+       (* RFC-0273 §3.4 — read-only verification of operator-supplied Settings
+          resources (replaces the dashboard VerifyBtn fake). Gated behind
+          operator (CanAdmin) auth, stricter than the public-read runtime-probe:
+          the server fetches a caller-supplied URL (SSRF surface) / stats a
+          caller-supplied path (info-disclosure), unlike the runtime-probe which
+          only probes the server's own runtime.toml URLs. DB / GitHub-repo
+          verify is deferred (the UI renders an honest "수동 확인" state). *)
+       with_token_permission_auth ~permission:Masc_domain.CanAdmin
+         (fun _state _agent_name req reqd ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             match Server_dashboard_verify_resource.parse_request body_str with
+             | Error msg ->
+               respond_dashboard_error ~status:`Bad_request ~request:req reqd msg
+             | Ok (kind, value) ->
+               let outcome = Server_dashboard_verify_resource.verify ~kind ~value in
+               Http.Response.json_value ~compress:true ~request:req
+                 (Server_dashboard_verify_resource.to_json ~kind outcome)
+                 reqd))
+         request reqd)
   (* Phase 1 Action 2 — live Dashboard_cache state surface.  Renders
      hit_ratio, in-flight compute count, per-entry ttl_remaining, and
      timeout-circuit-open counts so operators can correlate slow endpoints

--- a/test/dune
+++ b/test/dune
@@ -655,6 +655,15 @@
  (modules test_runtime_defaults_json)
  (libraries masc_test_deps))
 
+; RFC-0273 §3.4 — read-only verify-resource probe: typed kind parse, request
+; body parse, HTTP status classification (injected hook, no network), non-http
+; scheme rejection, filesystem existence, JSON envelope.
+
+(test
+ (name test_dashboard_verify_resource)
+ (modules test_dashboard_verify_resource)
+ (libraries masc_test_deps))
+
 ; RFC-0266: fusion async-completion wake — closed-sum classification +
 ; actionable pending_board_event delivery.
 

--- a/test/test_dashboard_verify_resource.ml
+++ b/test/test_dashboard_verify_resource.ml
@@ -1,0 +1,107 @@
+(* RFC-0273 §3.4 — read-only verification of operator-supplied Settings
+   resources. Covers the typed kind parse (unknown -> Error), the request body
+   parse, the HTTP status classification (via the injected test hook, no real
+   network), non-http scheme rejection, filesystem existence, and the JSON
+   envelope. *)
+
+open Server_dashboard_verify_resource
+
+let member k json = Yojson.Safe.Util.member k json
+
+let test_kind_of_string () =
+  Alcotest.(check bool) "mcp_endpoint" true
+    (match kind_of_string "mcp_endpoint" with Ok Mcp_endpoint -> true | _ -> false);
+  Alcotest.(check bool) "gate_url" true
+    (match kind_of_string "gate_url" with Ok Gate_url -> true | _ -> false);
+  Alcotest.(check bool) "worktree_path" true
+    (match kind_of_string "worktree_path" with Ok Worktree_path -> true | _ -> false);
+  (* Unknown kind must be rejected, never coerced to a permissive default. *)
+  Alcotest.(check bool) "unknown -> Error" true
+    (match kind_of_string "runtime" with Error _ -> true | _ -> false);
+  Alcotest.(check bool) "empty -> Error" true
+    (match kind_of_string "" with Error _ -> true | _ -> false)
+
+let test_parse_request () =
+  (match parse_request {|{"kind":"mcp_endpoint","value":"https://x/mcp"}|} with
+   | Ok (Mcp_endpoint, "https://x/mcp") -> ()
+   | _ -> Alcotest.fail "valid body should parse to (Mcp_endpoint, value)");
+  Alcotest.(check bool) "unknown kind -> Error" true
+    (match parse_request {|{"kind":"nope","value":"x"}|} with Error _ -> true | _ -> false);
+  Alcotest.(check bool) "missing value -> Error" true
+    (match parse_request {|{"kind":"gate_url"}|} with Error _ -> true | _ -> false);
+  Alcotest.(check bool) "non-string kind -> Error" true
+    (match parse_request {|{"kind":1,"value":"x"}|} with Error _ -> true | _ -> false);
+  Alcotest.(check bool) "malformed JSON -> Error" true
+    (match parse_request "{not json" with Error _ -> true | _ -> false)
+
+let probe_mcp () = verify ~kind:Mcp_endpoint ~value:"https://masc.local/mcp"
+
+let with_status status f =
+  set_http_get_for_tests (fun ~url:_ -> Ok status);
+  let o = f () in
+  clear_http_get_for_tests ();
+  o
+
+let test_http_classification () =
+  let o200 = with_status 200 probe_mcp in
+  Alcotest.(check bool) "200 ok" true o200.ok;
+  Alcotest.(check (option int)) "200 http_status" (Some 200) o200.http_status;
+  let o301 = with_status 301 probe_mcp in
+  Alcotest.(check bool) "3xx reachable -> ok" true o301.ok;
+  let o404 = with_status 404 probe_mcp in
+  Alcotest.(check bool) "404 -> not ok" false o404.ok;
+  Alcotest.(check (option int)) "404 http_status" (Some 404) o404.http_status;
+  let o500 = with_status 500 probe_mcp in
+  Alcotest.(check bool) "500 -> not ok" false o500.ok;
+  (* connection-level failure is never reported as success *)
+  set_http_get_for_tests (fun ~url:_ -> Error "connection refused");
+  let oerr = probe_mcp () in
+  clear_http_get_for_tests ();
+  Alcotest.(check bool) "conn error -> not ok" false oerr.ok;
+  Alcotest.(check (option int)) "conn error no http_status" None oerr.http_status
+
+let test_http_rejects_non_http_scheme () =
+  (* A non-http(s) scheme must be rejected before the server issues any GET. *)
+  let called = ref false in
+  set_http_get_for_tests (fun ~url:_ ->
+    called := true;
+    Ok 200);
+  let o = verify ~kind:Gate_url ~value:"file:///etc/passwd" in
+  clear_http_get_for_tests ();
+  Alcotest.(check bool) "non-http rejected" false o.ok;
+  Alcotest.(check bool) "hook NOT called for non-http scheme" false !called
+
+let test_path_existence () =
+  let cwd = Sys.getcwd () in
+  Alcotest.(check bool) "existing dir -> ok" true (verify ~kind:Worktree_path ~value:cwd).ok;
+  Alcotest.(check bool) "missing path -> not ok" false
+    (verify ~kind:Worktree_path ~value:"/__masc_verify_nonexistent_xyz__").ok;
+  (* "~" expands to $HOME, which exists on any host/CI runner. *)
+  Alcotest.(check bool) "~ expands to existing HOME" true
+    (verify ~kind:Worktree_path ~value:"~").ok
+
+let test_to_json () =
+  let o = verify ~kind:Worktree_path ~value:(Sys.getcwd ()) in
+  let json = to_json ~kind:Worktree_path o in
+  Alcotest.(check bool) "ok field" true (member "ok" json |> Yojson.Safe.Util.to_bool);
+  Alcotest.(check string) "kind field" "worktree_path"
+    (member "kind" json |> Yojson.Safe.Util.to_string);
+  Alcotest.(check bool) "detail is a string" true
+    (match member "detail" json with `String _ -> true | _ -> false);
+  Alcotest.(check bool) "http_status null for path kind" true (member "http_status" json = `Null);
+  (* HTTP kind carries the status as an int *)
+  let oh = with_status 200 probe_mcp in
+  let jh = to_json ~kind:Mcp_endpoint oh in
+  Alcotest.(check int) "http_status int for http kind" 200
+    (member "http_status" jh |> Yojson.Safe.Util.to_int)
+
+let () =
+  Alcotest.run "dashboard_verify_resource"
+    [ ( "parse",
+        [ Alcotest.test_case "kind_of_string rejects unknown" `Quick test_kind_of_string;
+          Alcotest.test_case "parse_request" `Quick test_parse_request ] );
+      ( "http",
+        [ Alcotest.test_case "status classification" `Quick test_http_classification;
+          Alcotest.test_case "rejects non-http scheme" `Quick test_http_rejects_non_http_scheme ] );
+      ("path", [ Alcotest.test_case "filesystem existence" `Quick test_path_existence ]);
+      ("json", [ Alcotest.test_case "to_json envelope" `Quick test_to_json ]) ]


### PR DESCRIPTION
## 목적

RFC-0273 §3.4 구현 (PR1, 롤아웃 순서 첫 단계). Settings surface 의 **VerifyBtn 가짜 검증을 실제 read-only 프로브로 교체**한다. 거버닝 RFC: **RFC-0273** (`#21925`, merged `470139a9af`).

## 그라운딩으로 정정된 전제 (중요)

RFC §3.4 초안은 "selected runtime 의 reachability 프로브"라고 했으나, `settings-surface.ts` 를 그라운딩한 결과 **전제가 틀렸다**:

- 가짜 VerifyBtn (`:237`, `setTimeout(() => setSt('ok'), 700)`) 은 **6개 call site**에서 재사용되며, 검증 대상은 runtime 이 아니라 **5종의 이질적 리소스** — MCP endpoint URL(×2), Gate base URL, Store/DB 연결문자열, worktree basepath, linked GitHub repo ref.
- runtime reachability 는 별개 관심사로 **이미 `GET /api/v1/dashboard/runtime-probe`** (`dashboard_runtime_provider_probe_json`) 가 담당.

→ §3.4 를 VerifyBtn 이 실제로 가리키는 리소스에 맞게 **amend** (PR 에 포함). 스코프 결정은 사용자 선택(Option A: in-tree 실검증 + 정직한 defer).

## 변경

### Backend — `Server_dashboard_verify_resource` (신규) + `POST /api/v1/dashboard/verify-resource`
- 타입드 `{ kind; value }` 파싱 → `{ ok; detail; http_status; target }`.
- `mcp_endpoint` / `gate_url` → `Masc_http_client.get_sync` HTTP(S) 도달성 (2xx/3xx ok; 4xx/5xx/연결실패 fail).
- `worktree_path` → 서버측 디렉터리 존재 (`~` → `$HOME` 확장).
- unknown kind → `Error` (permissive default 금지, AI anti-pattern §2).
- **operator(`CanAdmin`) 게이팅**: runtime-probe(public-read)는 서버 자신의 runtime.toml URL 만 찌르지만, verify 는 **caller-supplied** 값을 fetch/stat → SSRF·info-disclosure 표면이라 더 엄격히 막음.
- credential 비노출: echo 되는 `target` 은 userinfo/query/fragment strip (RFC-0132). `dashboard_runtime_url_for_json`/`dashboard_runtime_http_url_valid` 재사용(재구현 아님 — 두 헬퍼를 .mli 에 export).

### Frontend — `settings-surface.ts` / `api/dashboard.ts` / `settings-surface.css`
- `VerifyBtn` 이 `verifyResource(kind, value)` 호출. 실패한 프로브는 **'fail' 상태(✗ 실패)** 로 드러나며 절대 조용히 'ok' 로 떨어지지 않음.
- Store/DB·linked repo 는 in-tree 프로브가 아직 없음 → `DeferredVerifyBtn` 이 비활성 **"수동 확인"** placeholder 렌더(가짜 ✓ 금지 — #21931 에서 제거한 fabrication 과 동일 기준).
- `.set-verify.fail` / `.set-verify.deferred` CSS 추가.

## 경계

- **OAS 미변경.** 백엔드 추가는 전부 MASC `lib/server`.
- DB ping / GitHub-repo 프로브는 **defer**(자체 credential 표면 + RFC 검토 필요). 후속 PR.
- Tier A(§3.1)/Tier B(§3.2)는 별도 PR(롤아웃 순서: VerifyBtn → Tier A → Tier B).

## 테스트

- Backend alcotest `test_dashboard_verify_resource`: kind 파싱(unknown→Error), body 파싱, HTTP 분류(주입 훅, 네트워크 없음), non-http scheme 거부, 파일시스템 존재, JSON 엔벨로프.
- Frontend vitest `settings-surface.test.ts`: 실 ok / ok:false→fail / thrown→fail / deferred 정직 상태 → **21/21 PASS**.
- OCaml `dune build --root .` 로컬 컴파일 + alcotest 통과.

RFC-0273 §3.4 (#21925, merged)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
