### PR TITLE
test(dashboard): pin trace cross under inverted finalize order (#21950)

### DIFF
--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -252,6 +252,64 @@ describe('thread history merge & persistence', () => {
     expect(traceTextOf('hist-b')).toBe('second turn reasoning')
   })
 
+  it('observes trace cross when finalize order inverts append order (#21950, pre-R3)', () => {
+    // Reverse-finalize scenario: local-a is appended FIRST but finalizes
+    // LATER (ts=02); local-b is appended SECOND but finalizes EARLIER (ts=01).
+    // The server sends history chronological (earliest first): [hist-b(01), hist-a(02)].
+    //
+    // consumed Set still guarantees the 1:1 invariant — each local trace source
+    // is claimed at most once, so no row duplicates another row's trace. What
+    // it CANNOT guarantee is the *correct-row* mapping: mergeLocalAssistantTraceSteps
+    // matches by append order (appendThreadEntry push-to-end, keeper-state.ts:769)
+    // while server history is chronological, and finalize stamps `timestamp: new Date().toISOString()`
+    // at COMPLETION time (keeper-actions.ts:447 etc.), not append time. When those
+    // two orders diverge, the trace CROSSES.
+    //
+    // This is a known limitation tracked in #21950, NOT a regression: the
+    // pre-#21932 code duplicated the FIRST trace on BOTH rows (strictly worse).
+    // R3 server-minted id handshake will remove the role+text fallback and make
+    // the pairing deterministic — when it lands, flip the two `toBe` expectations
+    // below to the correct pairing (hist-a <-> 'turn-a reasoning', hist-b <-> 'turn-b').
+    appendThreadEntry('echo', entry({
+      id: 'local-a',
+      role: 'assistant',
+      text: 'done',
+      rawText: 'done',
+      delivery: 'delivered',
+      streamState: null,
+      timestamp: '2026-06-10T00:00:02.000Z', // appended first, finalized LATER
+    }))
+    appendThreadEntry('echo', entry({
+      id: 'local-b',
+      role: 'assistant',
+      text: 'done',
+      rawText: 'done',
+      delivery: 'delivered',
+      streamState: null,
+      timestamp: '2026-06-10T00:00:01.000Z', // appended second, finalized EARLIER
+    }))
+    appendAssistantThinkingDelta('echo', 'local-a', 'turn-a reasoning')
+    appendAssistantThinkingDelta('echo', 'local-b', 'turn-b reasoning')
+
+    mergeServerHistoryEntries('echo', [
+      entry({ id: 'hist-b', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:01.000Z' }),
+      entry({ id: 'hist-a', role: 'assistant', text: 'done', rawText: 'done', delivery: 'history', timestamp: '2026-06-10T00:00:02.000Z' }),
+    ])
+
+    const thread = keeperThreads.value.echo ?? []
+    const traceTextOf = (id: string) => {
+      const step = thread.find(e => e.id === id)?.traceSteps?.[0]
+      return step && 'text' in step ? step.text : undefined
+    }
+    // 1:1 invariant holds even under inverted finalize order: each row carries
+    // a DISTINCT trace (no row duplicates the other).
+    expect(traceTextOf('hist-a')).not.toBe(traceTextOf('hist-b'))
+    // KNOWN CROSS (#21950): under inverted finalize order the pairing inverts.
+    // The correct pairing (hist-a <-> 'turn-a reasoning') is blocked pre-R3.
+    expect(traceTextOf('hist-a')).toBe('turn-b reasoning')
+    expect(traceTextOf('hist-b')).toBe('turn-a reasoning')
+  })
+
   it('keeps local entries the server has not persisted yet', () => {
     appendThreadEntry('echo', entry({ id: 'local-1', text: 'not yet saved' }))
 


### PR DESCRIPTION
## 목표
#21748(PR #21932 consumed Set 1:1 분배)의 잔여 한계를 재현 테스트로 고정. 역순 finalize / 동일초 commit 시 trace가 틀린 행에 교차 부여되는 silent mis-attribution을 관찰 가능하게 만들어, CI가 이 영역의 회귀를 감지하도록 한다.

## 변경
`dashboard/src/keeper-state.test.ts`에 단위 테스트 1개 추가. 역순 timestamp(local-a append 첫번째·finalize `ts=02`, local-b append 두번째·finalize `ts=01`) + 서버 history chronological `[hist-b(01), hist-a(02)]` 셋업으로 consumed Set의 한계 창을 재현.

단언:
- **1:1 불변량 고정**: `hist-a.trace !== hist-b.trace` (consumed Set이 보장하는 것 — 각 local source 최대 1회 소비).
- **교차 동작 관찰**: `hist-a = 'turn-b reasoning'`, `hist-b = 'turn-a reasoning'` (현재 코드의 실제 동작, #21950 known limitation).

## 설계 결정 — `it.fails` 대신 관찰 테스트(passing)
- vitest `it.fails`(expected-to-fail)를 프로젝트에서 기존 사용한 적 없음(`rg` 0건).
- "빌드는 CI만" 원칙하에 `it.fails`가 CI reporter에서 pass로 처리됨을 로컬로 검증 불가 → 새 검증 공백 위험.
- 관찰 테스트는 현재 동작을 정확히 문서화하므로 CI가 보장하는 범위 안. R3 도입 시 이 테스트가 fail로 뒤집혀 자연스러운 업데이트 신호.

## 검증
- 로컬 빌드/테스트 미실행(사용자 지시: 빌드는 CI만). CI `Dashboard`(tsc+vite+vitest)로 검증.
- 이 테스트는 passing이어야 함(현재 코드의 실제 동작 관찰). CI red 시 내 추적(교차 방향)이 틀렸음을 의미 — 즉시 조사.

## 한계 / 후속
- 근본 fix는 #21950이 추적하는 **R3 server-minted id handshake**. 이 테스트는 known limitation을 고정할 뿐 고치지 않는다.
- R3 PR에서는 이 테스트의 `toBe` 기댓값을 올바른 페어링(hist-a ↔ local-a)으로 뒤집어야 한다(주석에 명시).

Refs #21950.

Co-Authored-By: Claude <noreply@anthropic.com>
