### PR TITLE
fix(dashboard): enforce ScheduleFilterKey exhaustiveness, drop dead optional chaining

### DIFF
--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1846,7 +1846,10 @@ function ConnectorValueCell({
 }
 
 function ConnectorBindingKeeperLink({ binding }: { binding: DiscordConfiguredBinding }) {
-  const keeperName = binding.keeper_name?.trim()
+  // keeper_name is a required non-null field on DiscordConfiguredBinding (valibot
+  // string()), so no optional chaining; the empty-string guard below stays since
+  // string() still permits ''.
+  const keeperName = binding.keeper_name.trim()
   if (!keeperName) {
     return html`
       <div class="cn-bind-row" data-binding-channel=${binding.channel_id}>

--- a/dashboard/src/components/tools/scheduled-automation-panel.test.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.test.ts
@@ -20,7 +20,7 @@ vi.mock('../common/toast', () => ({
   showToast: mocks.showToast,
 }))
 
-import { ScheduledAutomationPanel, selectWakeSignals } from './scheduled-automation-panel'
+import { ScheduledAutomationPanel, selectWakeSignals, filterMatches } from './scheduled-automation-panel'
 
 function request(
   overrides: Partial<DashboardScheduledAutomationRequest> & { schedule_id: string },
@@ -549,5 +549,25 @@ describe('ScheduledAutomationPanel', () => {
     expect(container.textContent).not.toContain('승인 — grant 발급')
     expect(container.textContent).not.toContain('거부')
     expect(container.textContent).not.toContain('취소')
+  })
+})
+
+describe('filterMatches', () => {
+  it('matches each ScheduleFilterKey against the right request shape', () => {
+    expect(filterMatches('all', request({ schedule_id: 'a' }))).toBe(true)
+    expect(filterMatches('ready', request({ schedule_id: 'r', execution_readiness: 'ready' }))).toBe(true)
+    expect(filterMatches('ready', request({ schedule_id: 'r2', execution_readiness: 'scheduled' }))).toBe(false)
+    expect(filterMatches('scheduled', request({ schedule_id: 's', status: 'scheduled' }))).toBe(true)
+    expect(filterMatches('terminal', request({ schedule_id: 't', status: 'succeeded' }))).toBe(true)
+    expect(filterMatches('terminal', request({ schedule_id: 't2', status: 'scheduled' }))).toBe(false)
+    expect(filterMatches('pending', request({ schedule_id: 'p', status: 'pending_approval' }))).toBe(true)
+    expect(filterMatches('due', request({ schedule_id: 'd', effective_status: 'due' }))).toBe(true)
+  })
+
+  it('throws on an out-of-union filter key instead of silently showing all', () => {
+    // Simulates a future ScheduleFilterKey added to the type/UI but missing a
+    // switch case: the assertNever default must surface the gap (Error) rather
+    // than fall through to `return true`. `as never` stands in for that bypass.
+    expect(() => filterMatches('archived' as never, request({ schedule_id: 'x' }))).toThrow()
   })
 })

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -104,7 +104,7 @@ function assertNever(value: never): never {
   throw new Error(`Unhandled schedule filter key: ${String(value)}`)
 }
 
-function filterMatches(filter: ScheduleFilterKey, request: DashboardScheduledAutomationRequest): boolean {
+export function filterMatches(filter: ScheduleFilterKey, request: DashboardScheduledAutomationRequest): boolean {
   if (filter === 'all') return true
   const status = normalized(effectiveStatus(request))
   const readiness = normalized(request.execution_readiness)

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -100,6 +100,10 @@ function compactTimeLabel(value: string | null | undefined): string {
   return `${hh}:${mm}`
 }
 
+function assertNever(value: never): never {
+  throw new Error(`Unhandled schedule filter key: ${String(value)}`)
+}
+
 function filterMatches(filter: ScheduleFilterKey, request: DashboardScheduledAutomationRequest): boolean {
   if (filter === 'all') return true
   const status = normalized(effectiveStatus(request))
@@ -117,7 +121,9 @@ function filterMatches(filter: ScheduleFilterKey, request: DashboardScheduledAut
     case 'terminal':
       return ['succeeded', 'failed', 'rejected', 'expired', 'cancelled', 'canceled'].includes(status)
     default:
-      return true
+      // Exhaustiveness: a new ScheduleFilterKey must fail to compile here rather
+      // than silently fall through to "show all" (Unknown->Permissive-Default).
+      return assertNever(filter)
   }
 }
 


### PR DESCRIPTION
## 무엇을 / 왜

#21940([codex] keeper-v2 parity, merged)의 적대적 grounding 리뷰에서 confirmed된 latent 안티패턴 2건을 수정합니다. 둘 다 non-blocking이라 #21940은 그대로 머지됐고, 소스 PR이 닫혀 이 후속 fixup은 중복이 아닙니다. 리뷰 코멘트: #21940#issuecomment-4761779773 (단, 그 코멘트는 첫 항목 파일 경로를 `schedule-surface.ts`로 오기재 — 실제는 `tools/scheduled-automation-panel.ts`. 본 PR에서 정정).

## 변경

### 1. `ScheduleFilterKey` exhaustiveness 강제 (`scheduled-automation-panel.ts`)
`filterMatches`가 closed union `ScheduleFilterKey`(6멤버) switch를 `default: return true`로 닫아 TS exhaustiveness를 억제했습니다. 현재는 6멤버 전부 처리돼 dead이나, **미래에 7번째 key가 추가되면 컴파일 에러 대신 silent "전체 표시"로 fall-through** — `software-development.md` §2 *Unknown→Permissive-Default* 안티패턴.

- `default: return true` → 로컬 `assertNever(filter)` (`connector-status.ts`의 기존 패턴과 동일; 공유 util이 없고 "무리한 추상화보다 코드 반복" 원칙에 따라 로컬 정의).
- default 분기는 타입상 unreachable → **런타임 동작 무변경** (panel 테스트 16/16 그대로 green).
- §2 "unknown은 Error로" 준수: 타입 우회 시 silent show-all 대신 Error.

### 2. non-null 파싱 필드의 불필요한 optional chaining (`connector-status.ts`)
`ConnectorBindingKeeperLink`가 `binding.keeper_name?.trim()`를 호출하나, `keeper_name`은 valibot 스키마에서 non-null 보장(`gate-connectors.ts:48` `keeper_name: string()` — `optional()`/`nullable()` 없음 → 타입 `string`, 부재 시 상류 parse가 throw). `software-development.md`의 *optional-chaining on internal non-nullable state* 안티패턴.

- `binding.keeper_name?.trim()` → `binding.keeper_name.trim()`.
- 뒤의 `if (!keeperName)` 빈문자열 가드는 **유지** (`string()`이 `''`를 허용하므로 정당).

## 범위 / 경계
- dashboard TS-only, +11/−2 (2파일). 백엔드/CSS/렌더 무변경.
- RFC-gate **비대상**: `credential*`/operator/keeper-sandbox/hooks/workflow 경로 무관 (connector-status는 connector 표시 컴포넌트로 `credential*` prefix 아님, credential 로직 미변경).

## Workaround self-check
- 본 PR은 워크어라운드를 **제거**합니다(permissive default + optional-chaining 둘 다 워크어라운드 거부 기준의 근본 fix 방향). 텔레메트리-as-fix ❌ / string 분류기 ❌ / N-of-M ❌ / cap·cooldown·dedup·repair ❌.

## 검증
- `tsc --noEmit` clean (exit 0).
- `connector-status.test.ts` 36/36, `scheduled-automation-panel.test.ts` 19/19 (filterMatches 직접 단위 테스트 추가: key→boolean 의미 + 새 throw 경로).
- **새 throw 경로 런타임 테스트**: `filterMatches('archived' as never, …)`가 `toThrow` — assertNever default가 out-of-union key에 silent show-all 대신 Error를 surface함을 실증. coverage gate는 opt-out이 아니라 이 실제 테스트로 충족.
- **Exhaustiveness negative-proof (compile-time)**: `ScheduleFilterKey`에 `'archived'` 7번째 key를 임시 추가 → `tsc` 실패 `TS2345: Argument of type '"archived"' is not assignable to parameter of type 'never'` (assertNever 호출 지점). 되돌린 뒤 clean 재확인.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
