### PR TITLE
docs(http_server_eio): correct misleading mli comment about run/start internals

### DIFF
--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -6,18 +6,18 @@
     dependency).  Includes built-in routes for [/health],
     [/ready], plus the streamable MCP endpoint.
 
-    Internal: ~25+ helpers stay private — exception
+    Internal: helpers stay private — exception
     \[Shutdown] (graceful-shutdown signaling), the 5 built-in
     handlers ([health_handler], [ready_handler],
     [mcp_post_handler], [mcp_get_handler]),
     \[default_routes] (the route table assembled from those
     handlers), \[with_streamable_mcp_request_handler],
     \[make_request_handler] (router → request_handler
-    converter), \[error_handler] (httpun connection error
-    handler), \[run] (server accept loop with backoff), and
-    \[start] (Eio_main entry with signal handlers).  External
-    callers reach the server through the [Server_bootstrap_*]
-    facade modules instead of these internals.
+    converter), and \[error_handler] (httpun connection error
+    handler).  The server accept loop and [Eio_main] entry point
+    live in the [Server_bootstrap_*] facade modules rather than
+    in this file.  External callers reach the server through
+    those facade modules instead of these internals.
 
     @see <https://github.com/anmonteiro/httpun> httpun
     documentation *)

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -14,10 +14,12 @@
     handlers), \[with_streamable_mcp_request_handler],
     \[make_request_handler] (router → request_handler
     converter), and \[error_handler] (httpun connection error
-    handler).  The server accept loop and [Eio_main] entry point
-    live in the [Server_bootstrap_*] facade modules rather than
-    in this file.  External callers reach the server through
-    those facade modules instead of these internals.
+    handler).  The server accept loop lives in the
+    [Server_bootstrap_*] facade modules; the [Eio_main] entry
+    point (with signal handlers) lives in the executable
+    [bin/main_eio.ml] (and sibling [bin/*_eio.ml] binaries).
+    External callers reach the server through the facade modules
+    instead of these internals.
 
     @see <https://github.com/anmonteiro/httpun> httpun
     documentation *)


### PR DESCRIPTION
## What

Corrects a misleading comment in `lib/http_server_eio.mli` that claimed the module contained internal helpers `[run]` (server accept loop) and `[start]` (Eio_main entry). The implementation file (`lib/http_server_eio.ml`) ends at the `Router.Make(...).dispatch` module and does not contain those helpers.

## Why

This was flagged during adversarial verification of `reports/adversarial-keeper-audit-2026-06-21.html` (§7.1 "Interface/implementation mismatch"). The inaccurate comment makes it hard to reason about where the server lifecycle actually lives, which matters for the broader Eio capability/supervision audit.

## Changes

- `lib/http_server_eio.mli`: removed `[run]` and `[start]` from the list of private helpers and clarified that the accept loop / Eio_main entry live in the `Server_bootstrap_*` facade modules.

## Verification

- Read `lib/http_server_eio.mli` and `lib/http_server_eio.ml` end-to-end.
- Confirmed `.ml` ends at line 640 with `Router.Make(...).dispatch` and has no `run`/`start` definitions.
- Comment-only change; no OCaml interface or behavior change.
- Full `dune build` was not run per repo guidance to use focused wrappers; a comment edit has no compilation surface.

## Adversarial-evaluation section

- **Claim verified**: `.mli:16-23` vs `.ml:640` mismatch — the `.mli` listed `run`/`start` that do not exist in the `.ml`.
- **What remains**: this is a cosmetic/documentation fix only. The broader Eio_context global capability, supervisor switch SPOF, and HTTP pool lifecycle issues remain open and are tracked in #21959, #21960, and the master audit issue #21954.
- **Blast radius**: none. No code paths are changed.
