### PR TITLE
feat(dashboard): keeper-turn observability honesty (Wave 1)

### DIFF
--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -648,7 +648,8 @@ export function CopilotDockFab({ dock }: { dock: CopilotDockApi }) {
       aria-label="Open Chat Dock"
       title="Chat Dock 열기 (⌘J)"
     >
-      <span class="spark"><${MessageCircle} size=${22} strokeWidth=${2.4} aria-hidden="true" /></span>
+      <span class="spark"><${MessageCircle} size=${20} strokeWidth=${2.4} aria-hidden="true" /></span>
+      <span class="dock-fab-label">Chat</span>
     </button>
   `
 }

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -501,7 +501,7 @@ namespace      = n/a
 fsm.state      = n/a
 model          = ${record.model ?? 'n/a'}
 finish_reason  = ${record.finish_reason ?? 'n/a'}
-ctx.window     = ${ctxPct.toFixed(1)}%   (${tokIn.toLocaleString()} / 200,000 tok)
+ctx.window     = ${ctxPct.toFixed(1)}%   (${tokIn.toLocaleString()} / 200,000 tok, 가정)
 keeper.turn    = T${record.absolute_turn}
 thinking       = ${thinkingStateLabel(record)}
 thinking.budget= ${record.thinking_budget ?? '—'}
@@ -762,7 +762,7 @@ function TimelineTab({ t }: { t: TurnDetail }) {
             </div>
             <div class="kti-wf-track">
               <div
-                class="kti-wf-bar kti-k-${p.kind}"
+                class=${`kti-wf-bar kti-k-${p.kind}${p.durationSource === 'not_recorded' ? ' is-unmeasured' : ''}`}
                 title=${phaseDurationTitle(p)}
                 style=${{
                   left: `${(p.visualOffsetMs / t.visualTotalMs) * 100}%`,
@@ -993,13 +993,13 @@ function MetaTab({ record, t, source }: { record: TurnRecordEntry; t: TurnDetail
         <span class="k">fsm.state</span><span class="v">n/a</span>
         <span class="k">input tokens</span><span class="v">${t.tokIn.toLocaleString()}</span>
         <span class="k">output tokens</span><span class="v">${t.tokOut.toLocaleString()}</span>
-        <span class="k">ctx window</span><span class="v">${t.ctxPct.toFixed(1)}% / 200K</span>
+        <span class="k">ctx window · 200K 가정</span><span class="v">${t.ctxPct.toFixed(1)}% / 200K</span>
         <span class="k">keeper turn</span><span class="v">T${record.absolute_turn}</span>
         <span class="k">agent subturns</span><span class="v">${formatTurnList(uniqueNumbers(t.tools.map(tool => tool.agentSubturn)))}</span>
         <span class="k">thinking</span><span class="v">${thinkingStateLabel(record)}</span>
         <span class="k">tool calls</span><span class="v">${t.tools.length}</span>
         <span class="k">measured phase duration</span><span class="v">${t.measuredDurationMs != null ? formatMsCompact(t.measuredDurationMs) : 'none'}</span>
-        <span class="k">est. cost</span><span class="v">$${t.cost.toFixed(3)}</span>
+        <span class="k">est. cost · Claude 가격</span><span class="v">$${t.cost.toFixed(3)}</span>
         <span class="k">finish_reason</span><span class="v">${record.finish_reason ?? 'n/a'}</span>
         <span class="k">source</span><span class="v">${source}</span>
       </div>

--- a/dashboard/src/styles/copilot-dock.css
+++ b/dashboard/src/styles/copilot-dock.css
@@ -171,13 +171,14 @@
 /* ── triggers: FAB + top-bar button ── */
 .dock-fab {
   position: fixed; right: 22px; bottom: 22px; z-index: 55;
-  width: 50px; height: 50px; padding: 0; display: flex; align-items: center; justify-content: center; gap: 0;
+  height: 50px; padding: 0 18px 0 14px; display: flex; align-items: center; justify-content: center; gap: 8px;
   border-radius: var(--radius-pill); border: 1px solid var(--volt);
   background: var(--volt); color: var(--volt-ink);
   font-family: var(--font-ui); font-weight: 600; font-size: 12.5px; cursor: pointer;
   box-shadow: 0 8px 24px rgba(0,0,0,0.4), 0 0 18px var(--volt-glow); transition: 0.16s;
 }
 .dock-fab:hover { background: var(--volt-strong); transform: translateY(-1px); }
+.dock-fab-label { line-height: 1; letter-spacing: 0.01em; }
 .dock-fab .spark {
   display: inline-flex;
   align-items: center;
@@ -280,8 +281,11 @@
     right: max(14px, env(safe-area-inset-right, 0px));
     width: 44px;
     height: 44px;
+    padding: 0;
     bottom: calc(68px + env(safe-area-inset-bottom, 0px));
   }
+  /* On mobile the FAB reverts to an icon-only 44px circle (no room for the label). */
+  .v2-app[data-mobile="true"] .dock-fab-label { display: none; }
 
   .v2-app[data-mobile="true"][data-keeper-detail-mode="true"] .dock-fab {
     bottom: calc(14px + env(safe-area-inset-bottom, 0px));

--- a/dashboard/src/styles/keeper-turn-inspector.css
+++ b/dashboard/src/styles/keeper-turn-inspector.css
@@ -386,6 +386,14 @@
 .kti-k-reason { background: var(--color-status-info); }
 .kti-k-tool { background: var(--color-accent-fg); }
 .kti-k-gen { background: var(--color-status-ok); }
+/* Unmeasured phases (durationSource === 'not_recorded'): no real duration, so
+   the bar is a placeholder, not a measurement. Hatch + dim it so it never reads
+   as a measured span alongside the tool bars that carry real ms. */
+.kti-wf-bar.is-unmeasured {
+  opacity: 0.5;
+  background-image: repeating-linear-gradient(135deg, color-mix(in oklab, var(--color-bg-page) 60%, transparent) 0 5px, transparent 5px 10px);
+  border: 1px dashed color-mix(in oklab, var(--color-fg-muted) 45%, transparent);
+}
 
 .kti-wf-foot {
   display: flex;


### PR DESCRIPTION
## 목표
keeper turn 관측 패널의 정직성 개선 — 측정값이 아닌 것을 측정된 것처럼 표시하던 문제(빈 채팅 버튼, 미측정 phase의 실선 bar, 하드코딩 ctx-window/cost) 수정.

## 변경 (Wave 1, 프론트 정직화)

1. **채팅 dock FAB 글자 라벨** (`copilot-dock.ts` + `.css`): 아이콘 전용 fab에 "Chat" 글자 추가. 데스크톱은 pill(아이콘+글자), 모바일(@media)은 공간 부족으로 아이콘만 44px 유지(label 숨김).
2. **미측정 phase bar 시각 분리** (`keeper-turn-inspector.ts` + `.css`): `durationSource === 'not_recorded'`인 phase(컨텍스트 조립/Thinking/응답 생성)는 실측이 아닌데도 실선 bar로 그려져 측정된 것처럼 보였다(괴상한 파란/회색 bar). `is-unmeasured` 클래스로 hatched(대각 스트라이프)+디밍하여 측정 bar(tool의 3ms/2ms)와 구분.
3. **토큰 경제 가짜 근거 명시** (`keeper-turn-inspector.ts`): `ctxPct`는 200K 하드코딩, `cost`는 Claude $3/$15 하드코딩 — 런타임(runtime.toml의 `num-ctx`/`price-input`/`price-output`)과 불일치. turn-record가 이 값을 안 가져서 프론트가 하드코딩 사용 중. 라벨에 "200K 가정" / "Claude 가격"으로 근거 명시.

## 검증
- 로컬 빌드/테스트 미실행(사용자 지시: 빌드는 CI만). CI `Dashboard`(tsc+vite+vitest)로 검증.
- 본 PR은 dashboard TS/CSS만 변경 (OCaml 무관). RFC subsystem 아님 → rfc 게이트 PASS.

## Wave 2 (별도 PR, 백엔드)
진짜 값 와이어링: `turn_record.t`에 `context_window` / `price_input` / `price_output` / `request_latency_ms` 필드 추가 → emit에서 runtime binding + OAS telemetry로 채우기 → 본 패널에서 하드코딩 대신 진짜 값 표시. agent_delegation RFC 게이트 대상(turn_record/keeper lib).

## 한계
- Wave 1은 가짜를 **드러낼** 뿐 진짜로 만들지 않는다. 진짜는 Wave 2.
- phase duration(컨텍스트 조립/Thinking/응답 생성)은 OAS가 `request_latency_ms`(전체)만 측정 — phase별 분할은 어디에도 없어 Wave 2에서도 전체 시간만 가능.

Co-Authored-By: Claude <noreply@anthropic.com>
