### PR TITLE
feat(dashboard): RFC-0273 §3.1 — reject unknown tool names in set_policy writes

### DIFF
--- a/docs/rfc/RFC-0273-dashboard-driven-keeper-config-and-runtime-persistence.md
+++ b/docs/rfc/RFC-0273-dashboard-driven-keeper-config-and-runtime-persistence.md
@@ -48,19 +48,22 @@ This is entirely MASC-side config-persistence orchestration. OAS owns provider/m
 
 ### 3.1 Tier A — keeper_meta config writes (persona / instructions / tool permissions)
 
-Replace the single stringly `"set_policy"` action with a **typed action sum** so the compiler enforces exhaustiveness and unknown actions are rejected (not coerced to a permissive default):
+> **Amendment (PR-TierA, grounded correction).** The original draft assumed (a) persona/instructions need a *new* write path, (b) the tool-permission panel is a generic `Record<string,boolean>` needing reshape, and (c) `keeper-detail-page.ts:9` should swap to a v2 panel. Grounding `origin/main` corrected all three:
+> - **instructions** already persists via the production panel (`keeper-config-panel.ts` `saveConfig` → `patchKeeperConfig` → `POST /api/v1/keepers/:name/config`); **tool_access/tool_denylist** already persists via `saveToolDenylist` → `setKeeperToolPolicy` → `POST /api/v1/keepers/:name/tools` (action `set_policy`). Adding `Set_persona`/`Set_instructions` to `/tools` would duplicate `/config` (and silently weaken its auth: `/config` is `CanAdmin`, `/tools` is tool-auth).
+> - The production panel **already renders tool permissions masc-tool-keyed** from `KeeperConfig.tools` (`tool_access[]`/`resolved_allowlist[]`/`tool_denylist[]` + counts). The generic `Record<string,boolean>` only exists in `keeper-config-panel-v2.ts`, a dead local-state stub rendered nowhere.
+> - Swapping `keeper-detail-page.ts:9` to the v2 stub would **regress** the production editors (goals, will/needs/desires, sandbox/network, runtime_id, denylist, …) the stub does not implement.
+>
+> Tier A is therefore re-scoped to the **one genuine net-new gap**: the `set_policy` write accepts unknown tool names and persists them silently. There is no static per-tool "risk badge" field (risk is *computed* by `Governance_pipeline_risk.assess_risk`), so that part is dropped too.
 
-```ocaml
-type keeper_config_action =
-  | Set_policy of { tool_access : string list; tool_denylist : string list }
-  | Set_persona of string option
-  | Set_instructions of string
-(* parse from JSON: unknown action -> Error, never a silent default *)
-```
+**Implemented:** `set_policy` (`server_dashboard_http_keeper_api_post.ml`) now rejects **newly-added** `tool_access` names that are not in the keeper tool candidate universe (`Keeper_tool_policy.tool_access_lookup_of_meta`.`candidate_names`) with a `400`, instead of persisting them — previously such names were accepted then silently dropped at runtime (`tool_access_lookup_of_meta` keeps only `candidate_set` members), giving the operator no feedback (AI anti-pattern §2 "unknown → permissive default"). Properties:
 
-- Each action parses a **typed payload**, validates its concrete invariants, and produces an updated `keeper_meta`, persisted via the existing `write_meta_with_merge ~merge:heartbeat_fields_from_disk` CAS path. This generalizes the proven `set_policy` flow rather than adding a parallel one.
-- **Tool-permission panel reshape (gap #304):** the panel's `perm` becomes `masc_*`-tool-keyed rows (tool name + risk badge from the tool descriptor registry + access toggle) instead of generic `Record<string, boolean>`. Only then does `perm` map onto `tool_access`/`tool_denylist`. `tool_access` entries are validated against the known masc tool-name set; **unknown tool names are rejected** (`Error`), never silently accepted (AI anti-pattern §2 "unknown → permissive default").
-- Validation: `persona`/`instructions` length bounds; `tool_access ⊆ known_masc_tools`; `tool_denylist` likewise.
+- **Delta-only**: only names not already on the keeper are validated, so a legacy keeper carrying a stale/renamed name stays editable (no breaking the existing record).
+- **Membership mirrors the runtime exactly** — raw against `candidate_names` (no alias expansion, since the runtime does not alias-expand `tool_access`); `candidate_names` already includes core tools via `effective_core_tools`, so no separate core bypass.
+- **Scope honesty**: `tool_access` (allow_set) is largely telemetry/compat — runtime execution reach is `candidate_set − deny_set`, not the allowlist (`keeper_tool_policy.ml:227-230`). So this is a *write-time honesty* fix (no silent-drop, no junk in `keeper_meta`), not an execution-security gate. `tool_denylist` is left unvalidated: denying an unknown name is a harmless no-op and the denylist is alias-expanded, so a strict check would false-reject.
+
+The validation is a pure helper (`unknown_added_tool_names`) so it is unit-tested without a server harness.
+
+**Out (deferred / not needed):** the typed `keeper_config_action` sum spanning persona/instructions (duplicates `/config`), the v2-panel swap (regresses production), the panel reshape (already masc-tool-keyed in production), and a static risk badge (no SSOT — risk is computed). A persona editor, if ever wanted, is a separate follow-up exposing `keeper_meta.persona` (the field exists but no production UI edits it).
 
 ### 3.2 Tier B — runtime.toml writes (model/runtime assignment + Settings runtime-defaults)
 

--- a/docs/rfc/RFC-0273-dashboard-driven-keeper-config-and-runtime-persistence.md
+++ b/docs/rfc/RFC-0273-dashboard-driven-keeper-config-and-runtime-persistence.md
@@ -65,6 +65,8 @@ The validation is a pure helper (`unknown_added_tool_names`) so it is unit-teste
 
 **Out (deferred / not needed):** the typed `keeper_config_action` sum spanning persona/instructions (duplicates `/config`), the v2-panel swap (regresses production), the panel reshape (already masc-tool-keyed in production), and a static risk badge (no SSOT — risk is computed). A persona editor, if ever wanted, is a separate follow-up exposing `keeper_meta.persona` (the field exists but no production UI edits it).
 
+> **Governance note (deferred, not abandoned):** the typed `keeper_config_action` sum is intentionally postponed while `/api/v1/keepers/:name/tools` has only one action (`set_policy`). When a second keeper config action is introduced, the stringly dispatch must be promoted to a typed sum so the compiler enforces exhaustiveness and unknown actions are rejected (AI anti-pattern §2 / `#4`). Until then, a single-variant sum would be over-engineering (Simplicity First).
+
 ### 3.2 Tier B — runtime.toml writes (model/runtime assignment + Settings runtime-defaults)
 
 A new host_config write endpoint editing `runtime.toml`:

--- a/lib/server/server_dashboard_http_keeper_api_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_post.ml
@@ -10,6 +10,25 @@ let dedupe_tool_names names =
   Json_util.dedupe_keep_order
     (names |> List.map String.trim |> List.filter (fun name -> name <> ""))
 
+(* RFC-0273 §3.1 — names newly added to a keeper's tool_access (not already
+   present) that are not known candidate tools.
+
+   Returned names are the ones a write should reject instead of persisting
+   silently: the runtime drops unknown tool_access entries at
+   [Keeper_tool_policy.tool_access_lookup_of_meta], so without this check an
+   operator typo is accepted then silently ignored (AI anti-pattern §2). The
+   check is delta-only — names already on the keeper are grandfathered so a
+   legacy keeper carrying a stale/renamed name can still be edited. Membership
+   is raw against [candidate_names] (no alias expansion), matching the runtime
+   keep-rule exactly; [candidate_names] already includes core tools via
+   effective_core_tools, so no separate core bypass is needed. tool_denylist is
+   intentionally not validated here: denying an unknown name is a harmless no-op
+   and the denylist is alias-expanded, so a strict check would false-reject. *)
+let unknown_added_tool_names ~candidate_names ~existing ~requested =
+  requested
+  |> List.filter (fun name -> not (List.mem name existing))
+  |> List.filter (fun name -> not (List.mem name candidate_names))
+
 let json_list_length = function
   | `List l -> List.length l
   | _ -> 0
@@ -83,15 +102,25 @@ let handle_keeper_tools_post state req reqd =
                      | Some `Null -> Error "tool_access required"
                      | None | Some _ -> Error "tool_access must be an array of strings"
                    in
-                   Result.map
-                     (fun tool_access ->
-                       {
-                         meta with
-                         tool_access;
-                         tool_denylist = deny;
-                         updated_at = Keeper_meta_contract.now_iso ();
-                       })
-                     tool_access_result
+                   Result.bind tool_access_result (fun tool_access ->
+                     let lookup = Keeper_tool_policy.tool_access_lookup_of_meta meta in
+                     match
+                       unknown_added_tool_names
+                         ~candidate_names:lookup.Keeper_tool_policy.candidate_names
+                         ~existing:meta.tool_access ~requested:tool_access
+                     with
+                     | [] ->
+                         Ok
+                           {
+                             meta with
+                             tool_access;
+                             tool_denylist = deny;
+                             updated_at = Keeper_meta_contract.now_iso ();
+                           }
+                     | unknown ->
+                         Error
+                           (Printf.sprintf "unknown tool name(s) in tool_access: %s"
+                              (String.concat ", " unknown)))
                | "" -> Error "action required (set_policy)"
                | other -> Error (Printf.sprintf "unknown action: %s" other)
              in

--- a/lib/server/server_dashboard_http_keeper_api_post.mli
+++ b/lib/server/server_dashboard_http_keeper_api_post.mli
@@ -5,6 +5,19 @@ module Http = Http_server_eio
 include module type of Server_dashboard_http_keeper_api_types
 
 val dedupe_tool_names : string list -> string list
+
+(** [unknown_added_tool_names ~candidate_names ~existing ~requested] returns the
+    names in [requested] that are newly added (not in [existing]) and not in
+    [candidate_names] (the keeper tool candidate universe). A non-empty result
+    is the set a [set_policy] write rejects (RFC-0273 §3.1) instead of silently
+    persisting unknown tool names. Delta-only: pre-existing names are
+    grandfathered so legacy keepers stay editable. *)
+val unknown_added_tool_names :
+  candidate_names:string list ->
+  existing:string list ->
+  requested:string list ->
+  string list
+
 val json_list_length : Yojson.Safe.t -> int
 val trajectory_line_ts : Trajectory.trajectory_line -> float
 val dedupe_thinking_lines :

--- a/test/dune
+++ b/test/dune
@@ -2340,3 +2340,11 @@
  (name test_keeper_adversarial_review)
  (modules test_keeper_adversarial_review)
  (libraries masc_test_deps))
+
+; RFC-0273 §3.1 — set_policy tool_access delta validation (reject newly-added
+; unknown tool names; grandfather pre-existing names).
+
+(test
+ (name test_keeper_tool_access_validation)
+ (modules test_keeper_tool_access_validation)
+ (libraries masc_test_deps))

--- a/test/test_keeper_tool_access_validation.ml
+++ b/test/test_keeper_tool_access_validation.ml
@@ -1,0 +1,56 @@
+(* RFC-0273 §3.1 — set_policy tool_access validation (delta-only known-name
+   check). Pure-function coverage of Server_dashboard_http_keeper_api_post
+   .unknown_added_tool_names: newly-added names must be known candidates; names
+   already on the keeper are grandfathered; removals are always allowed. *)
+
+module P = Server_dashboard_http_keeper_api_post
+
+let check_names msg expected actual = Alcotest.(check (list string)) msg expected actual
+
+let candidates = [ "masc_status"; "WebSearch"; "WebFetch"; "masc_board_post" ]
+
+let test_all_known_accepted () =
+  check_names "all known -> nothing rejected" []
+    (P.unknown_added_tool_names ~candidate_names:candidates ~existing:[]
+       ~requested:[ "masc_status"; "WebSearch" ])
+
+let test_unknown_rejected () =
+  check_names "newly-added unknown -> rejected" [ "masc_bogus" ]
+    (P.unknown_added_tool_names ~candidate_names:candidates ~existing:[]
+       ~requested:[ "masc_status"; "masc_bogus" ])
+
+let test_legacy_grandfathered () =
+  (* A stale/renamed name already persisted on the keeper is NOT re-validated,
+     so a legacy keeper stays editable. *)
+  check_names "pre-existing unknown grandfathered" []
+    (P.unknown_added_tool_names ~candidate_names:candidates
+       ~existing:[ "masc_renamed_old" ]
+       ~requested:[ "masc_renamed_old"; "masc_status" ])
+
+let test_new_unknown_amid_legacy () =
+  check_names "only the newly-added unknown is reported" [ "masc_typo" ]
+    (P.unknown_added_tool_names ~candidate_names:candidates
+       ~existing:[ "masc_renamed_old" ]
+       ~requested:[ "masc_renamed_old"; "masc_status"; "masc_typo" ])
+
+let test_removal_allowed () =
+  check_names "removing a name -> nothing rejected" []
+    (P.unknown_added_tool_names ~candidate_names:candidates
+       ~existing:[ "masc_status"; "WebSearch" ] ~requested:[ "masc_status" ])
+
+let test_multiple_unknown_reported_in_order () =
+  check_names "all newly-added unknowns reported in request order"
+    [ "z_bad"; "a_bad" ]
+    (P.unknown_added_tool_names ~candidate_names:candidates ~existing:[]
+       ~requested:[ "masc_status"; "z_bad"; "WebFetch"; "a_bad" ])
+
+let () =
+  Alcotest.run "keeper_tool_access_validation"
+    [ ( "delta",
+        [ Alcotest.test_case "all known accepted" `Quick test_all_known_accepted;
+          Alcotest.test_case "unknown rejected" `Quick test_unknown_rejected;
+          Alcotest.test_case "legacy grandfathered" `Quick test_legacy_grandfathered;
+          Alcotest.test_case "new unknown amid legacy" `Quick test_new_unknown_amid_legacy;
+          Alcotest.test_case "removal allowed" `Quick test_removal_allowed;
+          Alcotest.test_case "multiple unknown in order" `Quick
+            test_multiple_unknown_reported_in_order ] ) ]


### PR DESCRIPTION
## 목적

RFC-0273 §3.1 Tier A (PR2). 거버닝 RFC: **RFC-0273** (`#21925`, merged). 그라운딩으로 §3.1 스코프를 **실제 net-new gap 하나**로 좁힘.

## 그라운딩으로 정정된 전제 (중요)

§3.1 초안은 (a) persona/instructions 쓰기 경로 신설, (b) perm을 `Record<string,boolean>`→masc-tool-keyed reshape, (c) `keeper-detail-page.ts:9`를 v2 패널로 swap을 가정했으나, `origin/main` 그라운딩이 셋 다 반증:

- **instructions/tool_access 쓰기는 프로덕션 패널에 이미 존재** — `keeper-config-panel.ts`의 `saveConfig`→`patchKeeperConfig`(POST /config), `saveToolDenylist`→`setKeeperToolPolicy`(POST /tools `set_policy`). `/tools`에 Set_persona/Set_instructions 추가 = `/config` 중복 + auth 약화(/config=CanAdmin, /tools=tool-auth).
- 프로덕션 패널은 **이미 masc-tool-keyed**(`KeeperConfig.tools`: `tool_access[]`/`resolved_allowlist[]`/`tool_denylist[]`). boolean map은 **렌더 안 되는 죽은 stub** `keeper-config-panel-v2.ts`에만 존재.
- v2 swap 시 프로덕션이 편집하는 goals/will/needs/sandbox/runtime_id/denylist 등 **전부 회귀**.
- risk badge는 **정적 SSOT 없음**(governance가 계산) → drop.

## 변경 (유일한 net-new gap)

`set_policy`(`server_dashboard_http_keeper_api_post.ml`)가 **미지의 tool 이름을 silent 영속화**(런타임이 `tool_access_lookup_of_meta`에서 silent drop → operator 무피드백, anti-pattern §2)하던 것을, **신규 추가된 tool_access 이름이 candidate 미속이면 400 거부**로 수정.

- **delta-only**: 키퍼에 이미 있는 이름은 grandfather → legacy 키퍼(stale/renamed 이름 보유)도 편집 가능.
- **런타임과 정확히 일치**: raw `candidate_names` 멤버십(alias 확장 안 함 — 런타임도 tool_access를 alias-expand 안 함; core tool은 `effective_core_tools` 통해 이미 포함).
- **정직성 범위**: `tool_access`(allow_set)는 사실상 telemetry/compat — 실행 reach는 `candidate_set − deny_set`(`keeper_tool_policy.ml:227-230`). 따라서 이건 **write-time 정직성 수정**(silent-drop·junk 제거)이지 실행-보안 게이트가 아님(과장 금지). `tool_denylist`는 미검증(unknown deny는 무해 no-op + alias-expanded → strict 검사 false-reject 위험).
- 검증은 **순수 헬퍼 `unknown_added_tool_names`**로 추출 → 서버 하네스 없이 단위 테스트.

## 경계

- **OAS 미변경.** keeper write 경계 불가침. 단일 set_policy 핸들러 + .mli export + 테스트 + RFC amend.
- Tier B(§3.2, runtime.toml)는 별도 PR(#21943 가이드: `set_runtime_id_for_keeper` 재사용).

## 테스트

- alcotest `test_keeper_tool_access_validation`: all-known 수용 / unknown 거부 / legacy grandfather / new-unknown-amid-legacy / removal 허용 / multiple-unknown 순서보존 → **6/6 PASS**.
- 로컬 `dune --root .` 컴파일 + alcotest 통과(masc_server 전체 빌드).

RFC-0273 §3.1 (#21925, merged)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
