### PR TITLE
feat(keeper): tool-aware no-progress watchdog (P1-4a, RFC-0197)

### DIFF
--- a/docs/design/tool-aware-no-progress-watchdog.md
+++ b/docs/design/tool-aware-no-progress-watchdog.md
@@ -12,12 +12,22 @@ PR #21938 gave the `Mid_turn_no_progress` kill-class its first producer:
 flags a `Running` keeper whose `current_turn_observation.last_progress_at`
 (`lib/keeper/keeper_registry_types.ml:124`) is older than the configured window.
 
-`last_progress_at` is stamped by `Keeper_registry.record_turn_progress` only on
-three event kinds (`lib/keeper/keeper_hooks_oas.ml`): `sdk_before_turn`,
-`sdk_after_turn`, and `tool_completed:<name>`. It is NOT stamped while a single
-tool call is in flight (between `ToolCalled` and `ToolCompleted`). A legitimate
-long-running tool (a multi-minute build, a slow MCP call) therefore records no
-progress for its whole duration.
+`last_progress_at` is stamped by `Keeper_registry.record_turn_progress` on many
+events. Directly in `keeper_hooks_oas.ml` these include `sdk_before_turn`,
+`sdk_after_turn`, and `tool_completed:<name>` (`:276`, `:283`, `:519`). Most SSE
+events during model streaming also stamp progress via
+`keeper_agent_run_turn_helpers.registry_progress_on_event` (`:108-109`), e.g.
+`sse_message_start`, `sse_content_block_start`, `sse_tool_block_start`,
+`sse_text_delta`, `sse_thinking_delta`, `sse_tool_arg_delta`, `sse_content_delta`,
+`sse_content_block_stop`, and `sse_message_delta`; admission yield/resume
+(`slot_yield`/`slot_resume` at `:288/296`) stamps it as well.
+
+Because streaming tool-call generation stamps progress continuously, the real
+unstamped gap is not the whole "tool-involved turn" but the single tool
+execution window: after the SSE stream ends and the runtime actually executes
+the tool, until `tool_completed:<name>` is recorded. A legitimate long-running
+tool (a multi-minute build, a slow MCP call) can stay in this window longer than
+the progress timeout.
 
 If the operator enables the window (`MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC`),
 `assess_in_turn_progress` classifies active tool execution as no-progress. This
@@ -30,9 +40,15 @@ is exactly what RFC-0197 forbids:
 - Point 4: "only introduce cancellation after the execution region is tool-aware
   and can prove no active tool call is in flight."
 
-The producer is opt-in and default-off, so this is not a live defect; it is the
-precondition that makes the P1-5 signal safe to enable (and any future
-cancellation safe per point 4).
+The producer is opt-in and default-off, so this is not a live defect. Making the
+advisory `Mid_turn_no_progress` signal tool-aware is the precondition that makes
+the P1-5 signal safe to enable.
+
+This PR does not make cancellation safe per RFC-0197 point 4. The mirror is a
+lagging copy (§5), so it can prove only that the count was zero at the last
+drain, not at the exact instant a cancellation decision is made. A future
+cancellation gate will need a stronger seam—either a synchronous authoritative
+read of `pending_tool_count` or a "lag ≤ X + pre-cancel recheck" protocol.
 
 ## 2. What already exists (grounding)
 
@@ -42,7 +58,14 @@ cancellation safe per point 4).
   events that validates transitions and drops invalid ones (`:109`), updated
   under an `Atomic` CAS (`:160`). It is leak-safe: the count comes from a
   validated transition function, not a naive increment/decrement pair, so a
-  dropped or out-of-order event cannot wedge the count.
+  dropped or out-of-order event cannot wedge the count. The same holds for tool
+  errors: `ToolCompleted` carries `output = Error _` and the FSM transition
+  decrements the count. The only remaining wedge is a hard crash that emits no
+  terminal event at all; that is covered by the `In_turn_hung` backstop (§6).
+- The registry's `update_entry_if_registered` (`keeper_registry_setup.ml:80-88`)
+  uses an `Atomic.compare_and_set` retry loop, so concurrent
+  `record_turn_progress` and `record_turn_tool_inflight` writes to the same
+  `current_turn_observation` cannot lose updates.
 - The event bus already observes `ToolCalled` (`lib/keeper/keeper_event_bridge.ml:79`,
   `:236`), so RFC-0197 point 2's "observe" half is shipped.
 - RFC-0197 point 4 is already honored at the OAS-idle boundary:
@@ -116,7 +139,7 @@ turn-scoped data. When the turn ends, `mark_turn_finished` clears
 ```
 (* keeper_supervisor.ml assess_in_turn_progress *)
 | Some obs
-  when Bool.(phase = Keeper_state_machine.Running)
+  when phase = Keeper_state_machine.Running
        && obs.active_tool_count = 0          (* NEW: exclude active tool work *)
        && now -. obs.last_progress_at > progress_timeout -> Some (... Mid_turn_no_progress ...)
 | Some _ | None -> None
@@ -132,8 +155,9 @@ emission), matching RFC-0197 point 3. A turn with no tool in flight and a stale
   single authoritative value (the FSM); the registry field is a derived copy
   with no independent lifecycle, so it cannot leak. Cost: the event bus gains
   one optional callback parameter, and the mirror lags the true count by at most
-  one drain interval (negligible against a ≥300 s no-progress window, and the
-  background drain keeps it fresh).
+  one drain interval. That lag is negligible against a ≥300 s no-progress window
+  (the background drain keeps it fresh), but it is why this mirror is only an
+  advisory signal, not a point-in-time proof for RFC-0197 point 4 cancellation.
 - **Query the event bus from the sweep** (rejected): the bus is not globally
   registered (§3). Making it queryable would require a keeper-keyed table with
   its own create/unsubscribe lifecycle and cross-fiber synchronization — more
@@ -198,8 +222,10 @@ after the window.
 ## 9. RFC disposition
 
 This implements RFC-0197 Replacement Direction points 2–3 for the MASC
-no-progress watchdog and extends the RFC-0012 producer. It introduces one
-contract change (`turn_observation.active_tool_count`). Recommendation: land
+no-progress watchdog and extends the RFC-0012 producer. It does not implement
+point 4 (cancellation safety); that remains future work and will require a
+stronger, point-in-time seam than the lagging mirror used here. It introduces
+one contract change (`turn_observation.active_tool_count`). Recommendation: land
 under RFC-0197 as its named implementation (cite RFC-0197 + RFC-0012 in the PR);
 a new RFC is not warranted because no new lifecycle contract is created — the
 field mirrors an existing authoritative value. `lib/keeper/keeper_supervisor.ml`

--- a/docs/design/tool-aware-no-progress-watchdog.md
+++ b/docs/design/tool-aware-no-progress-watchdog.md
@@ -1,0 +1,207 @@
+# Tool-aware no-progress watchdog (P1-4a)
+
+Status: Design (pre-implementation)
+Governing RFC: RFC-0197 (runtime-attempt watchdog, per-candidate wrap) — Replacement Direction points 2–4
+Extends: RFC-0012 (Mid-Turn Progress Probe) — the `Mid_turn_no_progress` producer wired in PR #21938 (`3449f60cd`)
+Scope: MASC keeper no-progress watchdog only. OAS execution-idle tool-awareness is a separate slice (P1-4b, see §8).
+
+## 1. Problem
+
+PR #21938 gave the `Mid_turn_no_progress` kill-class its first producer:
+`Keeper_supervisor.assess_in_turn_progress` (`lib/keeper/keeper_supervisor.ml:68`)
+flags a `Running` keeper whose `current_turn_observation.last_progress_at`
+(`lib/keeper/keeper_registry_types.ml:124`) is older than the configured window.
+
+`last_progress_at` is stamped by `Keeper_registry.record_turn_progress` only on
+three event kinds (`lib/keeper/keeper_hooks_oas.ml`): `sdk_before_turn`,
+`sdk_after_turn`, and `tool_completed:<name>`. It is NOT stamped while a single
+tool call is in flight (between `ToolCalled` and `ToolCompleted`). A legitimate
+long-running tool (a multi-minute build, a slow MCP call) therefore records no
+progress for its whole duration.
+
+If the operator enables the window (`MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC`),
+`assess_in_turn_progress` classifies active tool execution as no-progress. This
+is exactly what RFC-0197 forbids:
+
+- Point 2: "MASC should observe `ToolCalled` / `ToolCompleted` and avoid
+  classifying active tool work as provider idle."
+- Point 3: "If a turn appears stuck while a tool is active, report it as active
+  tool execution, not provider timeout."
+- Point 4: "only introduce cancellation after the execution region is tool-aware
+  and can prove no active tool call is in flight."
+
+The producer is opt-in and default-off, so this is not a live defect; it is the
+precondition that makes the P1-5 signal safe to enable (and any future
+cancellation safe per point 4).
+
+## 2. What already exists (grounding)
+
+- `pending_tool_count : int` is maintained in `keeper_unified_turn_event_bus`
+  (`lib/keeper/keeper_unified_turn_event_bus.ml:13`). It is computed by
+  `record_fsm_tool_transitions` (`:70`), an FSM over `ToolCalled`/`ToolCompleted`
+  events that validates transitions and drops invalid ones (`:109`), updated
+  under an `Atomic` CAS (`:160`). It is leak-safe: the count comes from a
+  validated transition function, not a naive increment/decrement pair, so a
+  dropped or out-of-order event cannot wedge the count.
+- The event bus already observes `ToolCalled` (`lib/keeper/keeper_event_bridge.ml:79`,
+  `:236`), so RFC-0197 point 2's "observe" half is shipped.
+- RFC-0197 point 4 is already honored at the OAS-idle boundary:
+  `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` is parsed but deliberately NOT
+  forwarded to OAS "until OAS proves active tool execution is excluded from idle
+  accounting" (`lib/config/env_config_keeper.ml:419-420`).
+- `In_turn_hung` (wall-clock, `Keeper_max_turn_watchdog`) remains the absolute
+  backstop for a turn that never terminates, independent of progress.
+
+## 3. Constraint that picks the seam
+
+The event-bus instance is created per-turn inside the turn-execution call stack
+(`lib/keeper/keeper_unified_turn.ml:357`) and `unsubscribe`d at turn end (`:383`).
+It is not registered in any global table keyed by keeper. The supervisor sweep
+is a separate periodic loop that iterates registry entries and only sees
+`entry.current_turn_observation` (`lib/keeper/keeper_supervisor.ml:369`).
+
+Therefore the sweep cannot reach `pending_tool_count` by querying the event bus
+(`get_state : t -> event_bus_state`, `keeper_unified_turn_event_bus.mli:51`).
+The in-flight signal must be made visible through the one structure the sweep
+already reads: `turn_observation`.
+
+## 4. Design
+
+Add an `active_tool_count : int` field to `turn_observation`, maintained as a
+**write-through mirror** of the authoritative `pending_tool_count`, and have
+`assess_in_turn_progress` treat a positive count as active tool execution.
+
+### 4.1 Mirror via injected callback (no reverse dependency)
+
+The event bus must not depend on `Keeper_registry` (that would reverse the
+dependency direction; `keeper_unified_turn` and `keeper_hooks_oas` already depend
+on the registry, not the other way around). Inject a callback instead:
+
+```
+(* keeper_unified_turn_event_bus *)
+val create :
+  keeper_name:string -> turn_id:int ->
+  ?on_pending_count_change:(int -> unit) -> unit -> t
+```
+
+`drain` invokes `on_pending_count_change new_pending_tool_count` in the
+CAS-success branch (`:160`), next to the existing `emit_fsm_transition`, only
+when the count actually changes. Both the foreground drain
+(`keeper_unified_turn.ml:368`) and the `start_background_drain` fiber (`:378`)
+run through `drain`, so the mirror stays current without a separate poll.
+
+The turn flow supplies the callback when it creates the bus:
+
+```
+(* keeper_unified_turn.ml, at create site :357 *)
+~on_pending_count_change:(fun count ->
+   Keeper_registry.record_turn_tool_inflight ~base_path name ~count)
+```
+
+### 4.2 Registry mirror write
+
+```
+(* keeper_registry_setup.ml, alongside record_turn_progress *)
+let record_turn_tool_inflight ~base_path name ~count =
+  update_entry_if_registered ~base_path name (fun e ->
+    update_current_turn e (fun obs -> { obs with active_tool_count = count }))
+```
+
+This writes only the mirror field; it does not touch `last_progress_at` or any
+turn-scoped data. When the turn ends, `mark_turn_finished` clears
+`current_turn_observation`, so the mirror cannot leak across turns.
+
+### 4.3 Assessment
+
+```
+(* keeper_supervisor.ml assess_in_turn_progress *)
+| Some obs
+  when Bool.(phase = Keeper_state_machine.Running)
+       && obs.active_tool_count = 0          (* NEW: exclude active tool work *)
+       && now -. obs.last_progress_at > progress_timeout -> Some (... Mid_turn_no_progress ...)
+| Some _ | None -> None
+```
+
+A turn with a tool in flight is reported as active tool execution (no producer
+emission), matching RFC-0197 point 3. A turn with no tool in flight and a stale
+`last_progress_at` still produces `Mid_turn_no_progress` (P1-5 behavior preserved).
+
+## 5. Why this seam (tradeoffs)
+
+- **Write-through mirror of `pending_tool_count`** (chosen): the count stays a
+  single authoritative value (the FSM); the registry field is a derived copy
+  with no independent lifecycle, so it cannot leak. Cost: the event bus gains
+  one optional callback parameter, and the mirror lags the true count by at most
+  one drain interval (negligible against a ≥300 s no-progress window, and the
+  background drain keeps it fresh).
+- **Query the event bus from the sweep** (rejected): the bus is not globally
+  registered (§3). Making it queryable would require a keeper-keyed table with
+  its own create/unsubscribe lifecycle and cross-fiber synchronization — more
+  surface and more failure modes than a mirror field.
+- **Independent hook counter in `keeper_hooks_oas`** (rejected): incrementing on
+  `pre_tool_use` and decrementing on `post_tool_use` duplicates `pending_tool_count`
+  and re-derives the lifecycle by hand. A missed decrement on a tool-error path
+  wedges the count above zero and silently disables the watchdog. Duplicated
+  mutable state that can drift is the anti-pattern this design avoids.
+- **Stamp `last_progress_at` on tool start** (rejected as insufficient): it only
+  shifts the window to the tool's start; a tool that runs longer than the window
+  still false-fires. RFC-0197 point 2 requires excluding active tool work
+  entirely, which needs an in-flight signal, not a timestamp.
+
+## 6. Layering (where each concern lives)
+
+- Per-tool runaway (a hung subprocess/MCP call): owned by the tool substrate's
+  own budget (RFC-0197 point 2), not this watchdog.
+- A turn that never terminates regardless of tool state: `In_turn_hung`
+  wall-clock backstop. Excluding active tool from no-progress does not weaken
+  this — a genuinely hung turn still hits the absolute bound.
+- Model stall with no tool and no output: this watchdog (`Mid_turn_no_progress`),
+  now gated on `active_tool_count = 0`.
+
+## 7. Changes and acceptance
+
+Files (≤5, additive):
+
+1. `lib/keeper/keeper_registry_types.ml` / `.mli` — add `active_tool_count : int`
+   to `turn_observation`; default `0` at turn start.
+2. `lib/keeper/keeper_registry_setup.ml` — `record_turn_tool_inflight`.
+3. `lib/keeper/keeper_unified_turn_event_bus.ml` / `.mli` — `?on_pending_count_change`
+   on `create`, invoked in `drain` on count change.
+4. `lib/keeper/keeper_unified_turn.ml` — pass the mirror callback at the create site.
+5. `lib/keeper/keeper_supervisor.ml` — gate `assess_in_turn_progress` on
+   `active_tool_count = 0`.
+
+Tests:
+
+- `assess_in_turn_progress`: tool in flight (`active_tool_count = 1`) + stale
+  `last_progress_at` → `None`; no tool (`= 0`) + stale → `Some Mid_turn_no_progress`
+  (P1-5 regression); count returns to `0` → no-progress resumes.
+- event bus: a `ToolCalled` then `ToolCompleted` drain sequence invokes
+  `on_pending_count_change` with `1` then `0`; a `ToolCompleted` with no prior
+  `ToolCalled` does not drive the count below `0` (FSM drop path).
+
+Acceptance: with the producer enabled, a turn executing one long tool emits no
+`Mid_turn_no_progress`; a turn stalled with no tool in flight still emits it
+after the window.
+
+## 8. Out of scope
+
+- **P1-4b (OAS execution-idle tool-awareness)**: making the OAS execution-idle
+  watchdog exclude active tool execution so MASC can forward
+  `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` (`env_config_keeper.ml:419-420`). That
+  change lives in the OAS repo at the turn-lifecycle boundary and ships
+  separately.
+- Turning the producer on by default. This design makes the signal tool-aware;
+  the default-off posture is unchanged. Enabling is an operator decision once
+  tool-awareness has fleet evidence.
+
+## 9. RFC disposition
+
+This implements RFC-0197 Replacement Direction points 2–3 for the MASC
+no-progress watchdog and extends the RFC-0012 producer. It introduces one
+contract change (`turn_observation.active_tool_count`). Recommendation: land
+under RFC-0197 as its named implementation (cite RFC-0197 + RFC-0012 in the PR);
+a new RFC is not warranted because no new lifecycle contract is created — the
+field mirrors an existing authoritative value. `lib/keeper/keeper_supervisor.ml`
+and the touched modules are outside the mandatory-RFC subsystem list, so the
+hard gate does not fire; the PR body cites RFC-0197 explicitly.

--- a/docs/design/tool-aware-no-progress-watchdog.md
+++ b/docs/design/tool-aware-no-progress-watchdog.md
@@ -1,6 +1,6 @@
 # Tool-aware no-progress watchdog (P1-4a)
 
-Status: Design (pre-implementation)
+Status: Implemented (this PR; tests cover the consumer gate and the FSM count, the drain→callback glue is integration-covered — see §7)
 Governing RFC: RFC-0197 (runtime-attempt watchdog, per-candidate wrap) — Replacement Direction points 2–4
 Extends: RFC-0012 (Mid-Turn Progress Probe) — the `Mid_turn_no_progress` producer wired in PR #21938 (`3449f60cd`)
 Scope: MASC keeper no-progress watchdog only. OAS execution-idle tool-awareness is a separate slice (P1-4b, see §8).
@@ -197,12 +197,20 @@ Files (≤5, additive):
 
 Tests:
 
-- `assess_in_turn_progress`: tool in flight (`active_tool_count = 1`) + stale
-  `last_progress_at` → `None`; no tool (`= 0`) + stale → `Some Mid_turn_no_progress`
-  (P1-5 regression); count returns to `0` → no-progress resumes.
-- event bus: a `ToolCalled` then `ToolCompleted` drain sequence invokes
-  `on_pending_count_change` with `1` then `0`; a `ToolCompleted` with no prior
-  `ToolCalled` does not drive the count below `0` (FSM drop path).
+- `assess_in_turn_progress` (added, `test_keeper_supervisor.ml`): tool in flight
+  (`active_tool_count = 1`) + stale `last_progress_at` → `None`; in flight far past
+  the threshold (`= 3`, 9000 s stale) → `None` (count-gated, not timing); count
+  back to `0` + stale → `Some Mid_turn_no_progress` (P1-5 behavior preserved).
+- FSM count (existing, `test_keeper_unified_turn_event_bus.ml`):
+  `record_fsm_tool_transitions` already covers `ToolCalled`/`ToolCompleted`
+  balance, pending residue, and the no-prior-`ToolCalled` drop path that keeps
+  the count from going below `0`.
+- The `drain` → `on_pending_count_change` glue and the `record_turn_tool_inflight`
+  registry write are integration-covered: both ends (FSM count, consumer gate)
+  are unit-tested, and the glue is a single `old <> new` conditional plus a
+  write-through. Driving `drain` in isolation needs a live `Keeper_event_bus`
+  subscription, which has no unit harness here; this is recorded rather than
+  fabricated.
 
 Acceptance: with the producer enabled, a turn executing one long tool emits no
 `Mid_turn_no_progress`; a turn stalled with no tool in flight still emits it

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -108,6 +108,13 @@ val mark_turn_started : base_path:string -> string -> unit
 val record_turn_progress :
   base_path:string -> string -> event_kind:string -> unit
 
+(** RFC-0197 (P1-4a): write-through mirror of the turn event bus
+    [pending_tool_count] into the live turn's [active_tool_count]. No-op when no
+    turn is active. Does not touch [last_progress_at]. Read by
+    [Keeper_supervisor.assess_in_turn_progress] to exclude active tool execution
+    from the [Mid_turn_no_progress] window. *)
+val record_turn_tool_inflight : base_path:string -> string -> count:int -> unit
+
 (** Mark the beginning of an SDK turn within an existing keeper turn.
 
     The Agent SDK [run_loop] iterates N SDK turns inside a single MASC

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -440,6 +440,7 @@ let mark_turn_started ~base_path name =
       ; started_at = now
       ; last_progress_at = now
       ; last_progress_kind = Some "turn_started"
+      ; active_tool_count = 0
       ; turn_phase = Packed Turn_prompting
       ; decision_stage = Packed Decision_undecided
       ; measurement = None
@@ -459,6 +460,20 @@ let record_turn_progress ~base_path name ~event_kind =
   let now = Time_compat.now () in
   update_entry_if_registered ~base_path name (fun e ->
     update_current_turn e (stamp_turn_progress ~now ~event_kind))
+;;
+
+(* RFC-0197 (P1-4a): write-through mirror of the turn event bus
+   [pending_tool_count] into the live [turn_observation]. The supervisor sweep
+   only reads [current_turn_observation] (the event bus is a per-turn call-stack
+   value, not globally reachable), so the tool-in-flight count is surfaced here
+   for [Keeper_supervisor.assess_in_turn_progress] to exclude active tool work
+   from the no-progress window. Does not touch [last_progress_at]: a tool
+   running silently is "active tool execution", not progress. A [None]
+   [current_turn_observation] (turn already ended) is a no-op, so a late
+   background-drain callback after [mark_turn_finished] cannot leak. *)
+let record_turn_tool_inflight ~base_path name ~count =
+  update_entry_if_registered ~base_path name (fun e ->
+    update_current_turn e (fun obs -> { obs with active_tool_count = count }))
 ;;
 
 (* RFC-0045: SDK-turn boundary reset.  Resets in-turn FSM fields without touching keeper-turn-scoped data ([turn_id], [started_at], [selected_model], [measurement], [measurement_bind_count]).  Bypasse... *)

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -123,6 +123,7 @@ and turn_observation =
   ; started_at : float
   ; last_progress_at : float
   ; last_progress_kind : string option
+  ; active_tool_count : int
   ; turn_phase : packed_turn_phase
   ; decision_stage : packed_decision_stage
   ; measurement : turn_measurement option

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -523,6 +523,13 @@ and turn_observation = {
   last_progress_kind : string option;
       (** Low-cardinality label for the progress signal that most recently
           refreshed [last_progress_at]. *)
+  active_tool_count : int;
+      (** Write-through mirror of the turn event bus [pending_tool_count]
+          (tools issued but not yet completed). Maintained from the
+          authoritative FSM via [record_turn_tool_inflight]; the supervisor
+          sweep reads it to exclude active tool execution from the
+          [Mid_turn_no_progress] no-progress window (RFC-0197 points 2-3).
+          [0] outside any tool call. *)
   turn_phase : packed_turn_phase;
   decision_stage : packed_decision_stage;
   measurement : turn_measurement option;

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -75,6 +75,13 @@ let assess_in_turn_progress
   match in_turn with
   | Some obs
     when Bool.(phase = Keeper_state_machine.Running)
+         (* RFC-0197 points 2-3: a turn with a tool in flight is active tool
+            execution, not no-progress. [active_tool_count] mirrors the event
+            bus [pending_tool_count] (via [record_turn_tool_inflight]). A long
+            silent tool call therefore does not produce [Mid_turn_no_progress];
+            a hung tool is bounded by the tool substrate budget and the
+            wall-clock [In_turn_hung] watchdog, not this signal. *)
+         && obs.active_tool_count = 0
          && now -. obs.last_progress_at > progress_timeout ->
     Some
       (Keeper_registry.Stale_turn_timeout

--- a/lib/keeper/keeper_unified_turn.ml
+++ b/lib/keeper/keeper_unified_turn.ml
@@ -369,6 +369,14 @@ let run_keeper_cycle
                in
                let turn_event_bus_state =
                  Keeper_unified_turn_event_bus.create
+                 (* RFC-0197 P1-4a: mirror the in-flight tool count into the
+                    live turn_observation so the supervisor sweep excludes
+                    active tool execution from the no-progress window. *)
+                   ~on_pending_count_change:(fun count ->
+                     Keeper_registry.record_turn_tool_inflight
+                       ~base_path:config.base_path
+                       meta.name
+                       ~count)
                    ~keeper_name:meta.name
                    ~turn_id:keeper_turn_id
                    ()

--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -33,9 +33,10 @@ type t =
   ; event_bus_sub : Agent_sdk_metrics_bridge.handle option
   ; drain_cancel : drain_cancel_state Atomic.t
   ; state : event_bus_state Atomic.t
+  ; on_pending_count_change : int -> unit
   }
 
-let create ~keeper_name ~turn_id () =
+let create ?(on_pending_count_change = fun _ -> ()) ~keeper_name ~turn_id () =
   let event_bus_sub =
     match Keeper_event_bus.get () with
     | Some bus ->
@@ -56,6 +57,7 @@ let create ~keeper_name ~turn_id () =
         ; tracker = Keeper_unified_turn_types.create_turn_tool_event_tracker ()
         ; pending_tool_count = 0
         }
+  ; on_pending_count_change
   }
 ;;
 
@@ -173,6 +175,11 @@ let drain ?(site = "unspecified") t =
            ~turn_id:t.turn_id
            ~pending_count:new_state.pending_tool_count)
         transitions;
+      (* Mirror the in-flight count to the registry only when it moved, so the
+         supervisor sweep can exclude active tool execution (RFC-0197 P1-4a).
+         The count is the authoritative FSM value, not a re-derived counter. *)
+      if old.pending_tool_count <> new_state.pending_tool_count
+      then t.on_pending_count_change new_state.pending_tool_count;
       new_summary)
     else update ()
   in

--- a/lib/keeper/keeper_unified_turn_event_bus.mli
+++ b/lib/keeper/keeper_unified_turn_event_bus.mli
@@ -6,7 +6,17 @@
 
 type t
 
-val create : keeper_name:string -> turn_id:int -> unit -> t
+(** [on_pending_count_change] is invoked with the new [pending_tool_count]
+    whenever a drain changes it (RFC-0197 P1-4a). Used to mirror the in-flight
+    tool count into the registry's live [turn_observation] so the supervisor
+    sweep can exclude active tool execution from the no-progress window.
+    Defaults to a no-op. *)
+val create :
+  ?on_pending_count_change:(int -> unit)
+  -> keeper_name:string
+  -> turn_id:int
+  -> unit
+  -> t
 
 val drain
   :  ?site:string

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2256,6 +2256,7 @@ let test_assess_in_turn_progress () =
      ; started_at
      ; last_progress_at
      ; last_progress_kind
+     ; active_tool_count = 0
      ; turn_phase = Packed Turn_prompting
      ; decision_stage = Packed Decision_undecided
      ; measurement = None
@@ -2263,6 +2264,14 @@ let test_assess_in_turn_progress () =
      ; selected_model = None
      }
       : Masc.Keeper_registry_types.turn_observation)
+  in
+  (* RFC-0197 P1-4a: a turn_observation with [n] tools in flight, reusing
+     [make_turn_obs] for the shared fields. *)
+  let make_turn_obs_with_tools ~active_tool_count ~started_at ~last_progress_at
+        ~last_progress_kind =
+    { (make_turn_obs ~started_at ~last_progress_at ~last_progress_kind) with
+      Masc.Keeper_registry_types.active_tool_count
+    }
   in
   (* hung mid-turn: Running, turn live, last progress 400s ago, threshold 300s →
      Some (Stale_turn_timeout (Mid_turn_no_progress { since_progress=400 })). *)
@@ -2341,7 +2350,55 @@ let test_assess_in_turn_progress () =
                   ~last_progress_at:1000.0
                   ~last_progress_kind:None))
           ~now:1400.0
-          ~progress_timeout:300.0))
+          ~progress_timeout:300.0));
+  (* RFC-0197 P1-4a: a tool in flight is active tool execution, not no-progress.
+     Same stale 400s>300s window as the hung case above, but active_tool_count=1
+     suppresses the producer → None. *)
+  check bool "tool in flight → None (not no-progress)" true
+    (Option.is_none
+       (Sup.assess_in_turn_progress
+          ~phase:KSM.Running
+          ~in_turn:
+            (Some
+               (make_turn_obs_with_tools
+                  ~active_tool_count:1
+                  ~started_at:1000.0
+                  ~last_progress_at:1000.0
+                  ~last_progress_kind:(Some "tool_completed:foo")))
+          ~now:1400.0
+          ~progress_timeout:300.0));
+  (* The suppression is count-gated, not timing: a long silent tool stays
+     excluded no matter how far past the threshold. *)
+  check bool "tool in flight far past threshold → None" true
+    (Option.is_none
+       (Sup.assess_in_turn_progress
+          ~phase:KSM.Running
+          ~in_turn:
+            (Some
+               (make_turn_obs_with_tools
+                  ~active_tool_count:3
+                  ~started_at:1000.0
+                  ~last_progress_at:1000.0
+                  ~last_progress_kind:None))
+          ~now:10000.0
+          ~progress_timeout:300.0));
+  (* Once the tools complete (count back to 0) a genuinely stalled turn still
+     produces Mid_turn_no_progress, so the gate suppresses only while in flight. *)
+  (match
+     Sup.assess_in_turn_progress
+       ~phase:KSM.Running
+       ~in_turn:
+         (Some
+            (make_turn_obs
+               ~started_at:1000.0
+               ~last_progress_at:1000.0
+               ~last_progress_kind:(Some "tool_completed:foo")))
+       ~now:1400.0
+       ~progress_timeout:300.0
+   with
+   | Some (Reg.Stale_turn_timeout (Reg.Mid_turn_no_progress _)) -> ()
+   | _ ->
+     check bool "count back to 0 still fires no-progress" false true)
 
 let () =
   run "keeper_supervisor" [


### PR DESCRIPTION
## 목표

P1-4a — RFC-0197 Replacement Direction point 2-3을 MASC no-progress watchdog에 적용. 방금 머지된 P1-5(`Mid_turn_no_progress` producer, #21938 `3449f60cd`)를 **tool-aware로 완성**한다. 설계 문서 + 구현 + 테스트.

## 문제

`assess_in_turn_progress`(`keeper_supervisor.ml`)는 `last_progress_at`만 본다. 이 신호는 SSE 스트리밍 이벤트로는 stamp되지만 **단일 tool 실행 윈도우**(SSE 종료 후 runtime이 tool 실행 → `tool_completed` 사이)에는 stamp되지 않는다. 긴 tool(멀티분 빌드, 느린 MCP 호출)을 켜진 윈도우가 no-progress로 오분류 = RFC-0197 point 2-3 위반.

## 설계 결정 (docs/design/tool-aware-no-progress-watchdog.md)

authoritative leak-safe `pending_tool_count`(event_bus FSM `record_fsm_tool_transitions`)를 **callback 주입**(`on_pending_count_change`)으로 `turn_observation.active_tool_count`에 write-through mirror → `assess_in_turn_progress`가 `active_tool_count = 0`일 때만 `Mid_turn_no_progress` 방출.

- mirror는 FSM 값의 derived copy(독립 lifecycle 0) → **leak 불가**. `None` observation 시 write는 no-op이라 turn 종료 후 late drain도 안전.
- event_bus는 registry 역의존 없음(callback 주입).
- hung tool은 tool substrate budget + wall-clock `In_turn_hung`가 backstop(이 신호 아님).

## 변경 (10 files)

| 파일 | 변경 |
|---|---|
| `keeper_registry_types.ml/.mli` | `turn_observation.active_tool_count : int` |
| `keeper_registry_setup.ml` | `record_turn_tool_inflight` (mirror write, no-op when no turn) |
| `keeper_registry.mli` | `val record_turn_tool_inflight` |
| `keeper_unified_turn_event_bus.ml/.mli` | `?on_pending_count_change`, drain의 count 변경 시 호출 |
| `keeper_unified_turn.ml` | create site에 mirror callback 주입 |
| `keeper_supervisor.ml` | assess를 `active_tool_count = 0`로 gate |
| `test/test_keeper_supervisor.ml` | tool-aware 케이스 3종 |
| `docs/design/...md` | 설계 문서 |

## 검증

- `dune build lib/keeper --root .` rc=0, `test_keeper_supervisor.exe` rc=0.
- `mid_turn_progress_window` 그룹 **통과**: tool in flight(count=1) + stale → None / far past threshold(count=3) → None / count 0 + stale → fires(P1-5 보존).
- ocamlformat 적용.
- **테스트 커버리지(정직)**: 소비자 gate(assess) + FSM count(`record_fsm_tool_transitions`, 기존)는 unit-tested. drain→callback 글루는 통합 경로(`old<>new` 조건 + write-through) — drain 단독 테스트는 live Keeper_event_bus 구독이 필요해 unit harness 없음, 날조 대신 설계 §7에 기록.

## 범위 밖

- P1-4b(OAS execution-idle tool-aware → `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` forward): OAS turn-lifecycle 경계, 별도.
- producer default-on 전환: 이 PR은 신호를 tool-aware로 만들 뿐, default-off 유지.

RFC-WAIVED: RFC-0197 Replacement Direction point 2-3 구현(거버닝 RFC 인용) + RFC-0012 producer 확장. 신규 lifecycle contract 없음(기존 authoritative 값 mirror). touched 모듈(`keeper_supervisor` 등)은 mandatory-RFC subsystem 밖.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
