### PR TITLE
style(dashboard): de-drift off-grid v2 spacing to the 2px rhythm (theme-agnostic)

### DIFF
--- a/dashboard/src/styles/copilot-dock.css
+++ b/dashboard/src/styles/copilot-dock.css
@@ -55,7 +55,7 @@
 .dock-picker { position: relative; flex: none; }
 .dock-picker-btn {
   display: flex; align-items: center; gap: var(--sp-2);
-  padding: 3px 9px 3px 3px; border-radius: var(--radius-pill);
+  padding: 3px 10px 3px 3px; border-radius: var(--radius-pill);
   border: 1px solid var(--border-main); background: var(--bg-card); cursor: pointer; transition: 0.14s;
 }
 .dock-picker-btn:hover { border-color: var(--border-highlight); }

--- a/dashboard/src/styles/deck.css
+++ b/dashboard/src/styles/deck.css
@@ -27,7 +27,7 @@
 .deck-tabs .deck-tab-count {
   font-family: var(--font-mono); font-size: var(--fs-10);
   color: var(--color-fg-disabled); font-weight: var(--fw-med);
-  padding: 1px 5px; background: var(--color-bg-hover);
+  padding: 1px 6px; background: var(--color-bg-hover);
   border-radius: var(--r-0); min-width: 18px; text-align: center;
 }
 .deck-tabs button.is-active .deck-tab-count { color: var(--color-fg-secondary); background: var(--color-bg-hover); }
@@ -119,7 +119,7 @@
   z-index: 1;
 }
 .deck-table tbody td {
-  padding: 7px 12px;
+  padding: 8px 12px;
   border-bottom: 1px solid var(--color-border-default);
   color: var(--color-fg-primary); vertical-align: middle;
 }
@@ -163,7 +163,7 @@
 .pr-link:hover, .sb-link:hover { color: var(--brass-1); }
 .pr-state {
   display: inline-block; width: 8px; height: 8px; border-radius: var(--radius-circle);
-  margin-right: 5px; vertical-align: middle;
+  margin-right: 6px; vertical-align: middle;
 }
 .pr-state.open { background: var(--ok); }
 .pr-state.draft { background: var(--idle); }

--- a/dashboard/src/styles/drawer.css
+++ b/dashboard/src/styles/drawer.css
@@ -92,7 +92,7 @@
 .json-section:last-child { border-bottom: none; }
 .json-head {
   display: flex; align-items: center; gap: var(--sp-1h);
-  padding: 5px 10px; cursor: pointer; user-select: none;
+  padding: 6px 10px; cursor: pointer; user-select: none;
   font-size: var(--fs-11);
 }
 .json-head:hover { background: var(--color-bg-hover); }

--- a/dashboard/src/styles/keeper-turn-inspector.css
+++ b/dashboard/src/styles/keeper-turn-inspector.css
@@ -99,7 +99,7 @@
   color: var(--color-fg-muted);
   border: 1px solid var(--color-border-default);
   background: var(--color-bg-elevated);
-  padding: 3px 9px;
+  padding: 3px 10px;
   border-radius: var(--radius-pill);
   white-space: nowrap;
 }
@@ -126,7 +126,7 @@
 
 .kti-stat {
   background: var(--color-bg-surface);
-  padding: 11px 14px;
+  padding: 12px 14px;
   min-width: 0;
 }
 
@@ -141,7 +141,7 @@
   font-family: var(--font-mono);
   font-size: var(--fs-16);
   color: var(--color-fg-primary);
-  margin-top: 5px;
+  margin-top: 6px;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -211,7 +211,7 @@
 .kti-tok-legend {
   display: flex;
   gap: var(--sp-4);
-  margin-top: 9px;
+  margin-top: 10px;
   font-size: var(--fs-11);
   color: var(--color-fg-muted);
 }
@@ -296,7 +296,7 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--sp-3);
-  margin: 0 0 9px;
+  margin: 0 0 10px;
 }
 
 .kti-sec-h h4 {
@@ -400,7 +400,7 @@
   align-items: center;
   justify-content: space-between;
   margin-top: var(--sp-3);
-  padding-top: 11px;
+  padding-top: 12px;
   border-top: 1px solid var(--color-border-default);
   font-size: var(--fs-11);
   color: var(--color-fg-disabled);
@@ -420,7 +420,7 @@
 .kti-wf-legend span {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   font-size: var(--fs-10);
   color: var(--color-fg-disabled);
 }
@@ -435,14 +435,14 @@
 .kti-copy {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   background: none;
   border: 1px solid var(--color-border-default);
   color: var(--color-fg-disabled);
   border-radius: var(--r-1);
   font-family: var(--font-ui);
   font-size: var(--fs-10);
-  padding: 3px 9px;
+  padding: 3px 10px;
   cursor: pointer;
   transition: 0.14s;
   white-space: nowrap;
@@ -520,8 +520,8 @@
 .kti-tool-h {
   display: flex;
   align-items: center;
-  gap: 9px;
-  padding: 9px 12px;
+  gap: 10px;
+  padding: 10px 12px;
   background: var(--color-bg-hover);
 }
 
@@ -542,7 +542,7 @@
   font-size: var(--fs-9);
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  padding: 2px 7px;
+  padding: 2px 8px;
   border-radius: var(--radius-pill);
 }
 
@@ -578,7 +578,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 7px 11px;
+  padding: 8px 12px;
   background: var(--color-bg-hover);
   border-bottom: 1px solid var(--color-border-muted);
 }
@@ -679,7 +679,7 @@
 
 .kti-ctx-card pre {
   margin: 0;
-  padding: 11px 13px;
+  padding: 12px 14px;
   max-height: 340px;
   overflow: auto;
   font-family: var(--font-mono);
@@ -694,14 +694,14 @@
 .kti-params {
   display: flex;
   flex-wrap: wrap;
-  gap: 7px;
+  gap: 8px;
   margin-bottom: 4px;
 }
 
 .kti-param {
   font-family: var(--font-mono);
   font-size: var(--fs-11);
-  padding: 4px 11px;
+  padding: 4px 12px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--color-border-default);
   background: var(--color-bg-elevated);

--- a/dashboard/src/styles/rail.css
+++ b/dashboard/src/styles/rail.css
@@ -71,7 +71,7 @@
 }
 .tool-chip {
   display: inline-flex; align-items: center; gap: var(--sp-1);
-  padding: 2px 7px;
+  padding: 2px 8px;
   background: var(--color-bg-elevated);
   border: 1px solid var(--color-border-strong);
   border-radius: var(--r-4);

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -20,7 +20,7 @@
   & code {
     background: var(--color-bg-elevated);
     color: var(--brass-1);
-    padding: 1px 5px;
+    padding: 1px 6px;
     border-radius: var(--r-1);
     font-size: 0.9em; /* intentional: relative em scales with parent context — not replaceable with px-based --fs-* tokens */
   }

--- a/dashboard/src/styles/v2-overview.css
+++ b/dashboard/src/styles/v2-overview.css
@@ -145,7 +145,7 @@
 }
 
 .v2-overview-rollup {
-  margin-top: 18px;
+  margin-top: 20px;
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-md);
   background: color-mix(in oklab, var(--bg-panel) 72%, transparent);


### PR DESCRIPTION
# ci:skip-test-coverage

## 목적

"패딩·마진 전체 개선" — v2 컴포넌트의 **off-grid spacing을 2px rhythm으로 de-drift**(skin-v2 "one rhythm" 의도). **theme-agnostic raw px**로만 변경.

## P1(paper) 대응 — 브라우저 검증 후 토큰화에서 raw de-drift로 피벗

초안은 raw px를 `var(--sp-N)`로 토큰화했으나, P1 리뷰(paper collapse)를 **브라우저로 검증**한 결과:
- **collapse는 없음**: `--sp-*`는 `tokens.css:root`에 전역 정의(8px, 4px-base)가 있어 paper에서도 resolve(`getComputedStyle`: v2 `--sp-2`=6px, **paper `--sp-2`=8px**, `--sp-4`=16px). v2·paper 둘 다 정상 렌더(스크린샷 확인).
- **단, 토큰화는 paper 값을 바꿈**: `--sp`는 테마-의존이라 raw `10px`→`var(--sp-4)`는 v2=10px(동일)이나 **paper=16px**. **px fallback도 무력**(`:root --sp`가 항상 resolve, var가 fallback 이김).
- → P1의 우려(paper 영향)를 결정적으로 해소하려 **토큰화를 버리고 raw de-drift로 피벗**: off-grid 홀수(5/7/9/11/18/22) → 가까운 grid(6/8/10/12/20/24), **raw px 유지**. `--sp` 테마-의존을 회피 → **paper/styleseed는 v2와 동일한 de-drift만 받음**(스케일 이동 없음).

## 변경

7파일 24선언: keeper-turn-inspector(16), deck(3), copilot-dock/drawer/ui/v2-overview/rail(각 1). on-grid 값 + 1/2/3px 미세 hairline 미변경. 고-churn 코어(dashboard/chat/code) + ds-cockpit-kit 제외.

## 검증

- `vite build` green.
- **브라우저 in-browser 검증**: v2 기본 + paper 테마 둘 다 렌더 정상(collapse 없음, spacing 일관). `getComputedStyle`로 --sp 테마별 값 실측.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
