### PR TITLE
fix(keeper): exhaustive keeper tool-exposure tag match (drop Some _ -> true fail-open)

### DIFF
--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -140,12 +140,35 @@ let keeper_supported_masc_schemas (schemas : Masc_domain.tool_schema list) =
       true
     else
       (match Tool_dispatch.lookup_tag name with
+       (* Privileged / internal surfaces denied from keeper exposure. *)
        | Some Tool_dispatch.Mod_inline
        | Some Tool_dispatch.Mod_compact
        | Some Tool_dispatch.Mod_operator
        | Some Tool_dispatch.Mod_control ->
            false
-       | Some _ -> true
+       (* Keeper-allowed surfaces enumerated explicitly (no [Some _ ->]
+          wildcard) so that adding a new [Tool_dispatch.module_tag] variant
+          fails to compile here, forcing a deliberate keeper-exposure
+          decision (default deny) rather than being silently injected into
+          every keeper's schema set and made executable. CLAUDE.md "FSM
+          Sparse Match" rule (no catch-all on a security boundary) +
+          RFC-0006 (keeper surface) + RFC-0042 (closed-sum discipline). This
+          arm set is exactly what the former [Some _ -> true] admitted, so
+          runtime behaviour is unchanged. *)
+       | Some Tool_dispatch.Mod_plan
+       | Some Tool_dispatch.Mod_local_runtime
+       | Some Tool_dispatch.Mod_run
+       | Some Tool_dispatch.Mod_agent
+       | Some Tool_dispatch.Mod_task
+       | Some Tool_dispatch.Mod_state
+       | Some Tool_dispatch.Mod_agent_timeline
+       | Some Tool_dispatch.Mod_schedule
+       | Some Tool_dispatch.Mod_misc
+       | Some Tool_dispatch.Mod_library
+       | Some Tool_dispatch.Mod_external
+       | Some Tool_dispatch.Mod_shard
+       | Some Tool_dispatch.Mod_keeper_task ->
+           true
        | None -> false)
   in
   (* masc_board_* tools that have keeper_board_* wrappers with auto-injected


### PR DESCRIPTION
## 무엇을 / 왜

키퍼 tool-노출 게이트(`keeper_tool_policy.ml` `supported_in_keeper`)의 `match Tool_dispatch.lookup_tag name with ... | Some _ -> true` 와일드카드를 **모든 `module_tag` variant 명시 enumeration**으로 교체합니다. 동작은 그대로(현재 deny 4종 / allow 13종 유지)이고, 와일드카드 제거로 **새 `module_tag` variant가 추가되면 이 지점에서 컴파일 에러**가 나도록 강제합니다.

### 결함 (latent fail-open, security boundary)

`supported_in_keeper=true`는 `masc_*` 도구를 키퍼의 노출 스키마 집합에 주입하고 실행 가능하게 만듭니다 (`inject_masc_schemas` → `keeper_base_candidate_tool_names`(:195) → `candidate_set` → `can_execute`(:263-270)). 현재 명시 deny되는 4종(`Mod_inline`/`Mod_compact`/`Mod_operator`/`Mod_control`)은 operator/control 등 privileged surface입니다.

`Some _ -> true` 와일드카드 때문에, **`module_tag` closed sum에 새 privileged variant(예: 미래 `Mod_admin`/`Mod_credential`)가 추가되면 컴파일러가 누락을 못 잡고 기본값이 키퍼-노출+실행**이 됩니다. `module_tag`는 실제로 변동하는 closed sum입니다 (`tool_tag_types.ml:14-31`, 17 variant; `tool_dispatch.ml`의 "Mod_handover, Mod_heartbeat, Mod_auth removed" 주석이 추가/제거 이력 방증). 이는 AI-codegen anti-pattern #2(unknown → permissive default) + CLAUDE.md "FSM Sparse Match"(security boundary에 catch-all 금지) 위반입니다.

코드베이스의 의도된 규율은 exhaustive match입니다: 같은 sum을 `mcp_server_eio_execute.ml`(dispatch 경로)이 와일드카드 없이 17종 전부 매치합니다. 단, 그건 dispatch wiring을 강제할 뿐 keeper-exposure 결정은 강제하지 않아 이 게이트의 누락을 못 막습니다.

## 변경

- `lib/keeper/keeper_tool_policy.ml`: `Some _ -> true` → allow 13종 명시(`Mod_plan`/`Mod_local_runtime`/`Mod_run`/`Mod_agent`/`Mod_task`/`Mod_state`/`Mod_agent_timeline`/`Mod_schedule`/`Mod_misc`/`Mod_library`/`Mod_external`/`Mod_shard`/`Mod_keeper_task`) → `true`. deny 4종은 그대로. `None -> false` 그대로.

## 범위 / 경계 (Surgical)

- **동작 무변경**: 명시한 allow 13종은 와일드카드가 admit하던 것과 정확히 동일. 어떤 도구도 새로 노출/차단되지 않습니다.
- **정책 변경은 별도**: finder 분석은 `Mod_local_runtime`(local runtime control)이 현재 키퍼-노출되는 게 부적절할 수 있다고 지적했으나, 그건 *동작 변경*이라 본 PR 범위 밖입니다. 어떤 태그를 deny할지는 RFC-0006(keeper surface) 정책 결정으로 분리합니다. 본 PR은 순수 exhaustiveness 하드닝입니다.

## RFC

- RFC-0006 (keeper surface and sandbox) — 키퍼 노출 surface 지배 RFC. 본 변경은 그 게이트의 exhaustiveness 하드닝(신규 아키텍처 아님).
- RFC-0042 (keeper terminal code closed-sum) — closed-sum exhaustive match 규율과 정합.

## Workaround self-check

본 PR은 워크어라운드를 **제거**합니다(catch-all `_ ->` 삭제 = CLAUDE.md 거부 체크리스트 #4의 역방향, 근본 fix). 텔레메트리-as-fix ❌ / string 분류기 ❌ / N-of-M ❌ / cap·cooldown·dedup·repair ❌. 새 catch-all 추가 ❌(제거).

## 검증

- exhaustiveness: deny 4 + allow 13 + None = `module_tag` 17 variant 전부 (`tool_tag_types.ml:14-31` 대조), 중복/누락 0. 새 variant 추가 시 컴파일 에러로 노출 결정 강제.
- 컴파일/Lint은 CI(warnings-as-errors)가 권위 검증. Draft 상태로 결과 확인 후 Ready 전환.

## ci:skip-test-coverage

이 변경의 정합성은 **컴파일러(exhaustive match)가 강제**하며 런타임 동작은 불변입니다. 가치(미래 variant의 silent 노출 방지)는 본질적으로 런타임 테스트로 포착 불가합니다(아직 없는 variant를 테스트할 수 없음). allow-path 동작 보존은 기존 `test/test_keeper_tool_policy_masc_surface.ml`이 이미 검증합니다(board read 도구 노출 유지). 따라서 신규 런타임 테스트는 불변 동작 재검에 그쳐 실질 coverage가 없으므로 `# ci:skip-test-coverage`를 적용합니다. (#21958과 달리 본 변경은 런타임-testable가 아님.)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
