### PR TITLE
feat(turn-record): wire real runtime context window + pricing (RFC-0233 §8)

### DIFF
--- a/.tmp/rfc-0233-caller-context.md
+++ b/.tmp/rfc-0233-caller-context.md
@@ -1,0 +1,37 @@
+# RFC-0233 Caller Context (§8 Amendment)
+
+Owner request, 2026-06-21 (keeper-turn observability `/goal`):
+
+- The keeper-turn inspector's token-economy panel fabricated two values:
+  a hardcoded 200K context window and hardcoded Claude $3/$15 pricing,
+  applied to every runtime. For a non-Claude runtime (e.g.
+  `glm-coding.glm-5-turbo`) the ctx-fill% and cost were therefore wrong.
+- Token counts were already real (`usage.input_tokens`/`output_tokens`); only
+  the window denominator and the price rates were fabricated constants.
+- Ground the panel in real runtime facts, or render honest absence — never a
+  fabricated value.
+
+Design constraints:
+
+- `context_window` + `price_input_per_million`/`price_output_per_million` are
+  added as `option` fields on `Turn_record.t`; `None` renders "미상" (unknown),
+  consistent with the existing `model`/`finish_reason` absence contract (§2.3).
+- Source real facts from the runtime binding MASC already retains at boot
+  (`Runtime.t.binding.price_input`/`price_output`, runtime.ml:19) via a sibling
+  projection `Runtime.pricing_of_runtime_id`; `context_window` is the
+  keeper-resolved `max_context` already in scope at the write site.
+- No OAS change: price is an operator-config concern; OAS's
+  `Provider_runtime_binding` catalog omits price by design and is untouched.
+- Cost is derived in the view (real price × real tokens), not stored as a
+  precomputed number — views-derive (§2.3).
+- `context_window` is the keeper compaction budget, not the Ollama-only
+  `num_ctx` transport cap (documented caveat, §8.4).
+
+Verification expectation:
+
+- The amended RFC passes the local rfc-enforcer (R1–R5, including this
+  caller-context file).
+- `test_turn_record.ml` proves the three new fields round-trip and that the
+  absent case omits the keys / decodes `None`.
+- The dashboard inspector renders "미상" when the fields are absent and a
+  real `%` / `$` when present.

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3027,6 +3027,14 @@ export type TurnRecordEntry = {
   enable_thinking?: boolean
   input_tokens?: number
   output_tokens?: number
+  // RFC-0233 §8 — runtime model metadata. context_window is the keeper-resolved
+  // effective token budget (the ctx-fill% denominator); the two prices are USD
+  // per 1M tokens declared on the runtime binding. Absent (undefined) when the
+  // runtime is unknown or the operator left runtime.toml unset; the inspector
+  // renders "미상" (unknown) rather than a fabricated 200K / Claude $3·$15.
+  context_window?: number
+  price_input_per_million?: number
+  price_output_per_million?: number
   ts: number
 }
 
@@ -3165,6 +3173,9 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     enable_thinking: typeof raw.enable_thinking === 'boolean' ? raw.enable_thinking : undefined,
     input_tokens: asNumber(raw.input_tokens),
     output_tokens: asNumber(raw.output_tokens),
+    context_window: asNumber(raw.context_window),
+    price_input_per_million: asNumber(raw.price_input_per_million),
+    price_output_per_million: asNumber(raw.price_output_per_million),
     ts,
   }
 }

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -204,6 +204,9 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           finish_reason: 'completed',
           input_tokens: 2400,
           output_tokens: 280,
+          context_window: 203000,
+          price_input_per_million: 0.27,
+          price_output_per_million: 1.1,
           blocks: [
             { block: 'system', bytes: 1200, digest: '1111222233334444' },
             { block: 'user_model', bytes: 728, digest: '99887766554433221100' },
@@ -674,6 +677,10 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(stats).toContain('도구')
     expect(stats).toContain('1')
     expect(stats).toContain('추정비용')
+    // RFC-0233 §8: turn 42 fixture carries real context_window + prices, so
+    // the nullable ctxPct/cost render grounded values — not "미상". Guards the
+    // number|null widening against a regression that drops the grounded path.
+    expect(stats).not.toContain('미상')
   })
 
   it('joins tool-call duration and agent subturn by execution_id', async () => {

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -430,8 +430,10 @@ type TurnDetail = {
   traceId: string
   tokIn: number
   tokOut: number
-  ctxPct: number
-  cost: number
+  // RFC-0233 §8 — null when context_window/price are absent on the record
+  // (runtime unknown or operator left runtime.toml unset); render "미상".
+  ctxPct: number | null
+  cost: number | null
   measuredDurationMs: number | null
   visualTotalMs: number
   phases: TurnPhase[]
@@ -495,13 +497,22 @@ function thinkingChipLabel(record: TurnRecordEntry): string {
   return '—'
 }
 
-function buildInjectedCtx(record: TurnRecordEntry, ctxPct: number, tokIn: number): string {
+// RFC-0233 §8 — compact "NNNK" form of the runtime's context window, or
+// "미상" when the record has no context_window (render absence, not 200K).
+function formatCtxWindowK(cw: number | null | undefined): string {
+  return cw != null ? `${Math.round(cw / 1000)}K` : '미상'
+}
+
+function buildInjectedCtx(record: TurnRecordEntry, ctxPct: number | null, tokIn: number): string {
+  const ctxLine = ctxPct != null
+    ? `${ctxPct.toFixed(1)}%   (${tokIn.toLocaleString()} / ${record.context_window?.toLocaleString() ?? '미상'} tok)`
+    : `미상   (${tokIn.toLocaleString()} / 미상 tok, runtime 미구성)`
   return `# namespace snapshot
 namespace      = n/a
 fsm.state      = n/a
 model          = ${record.model ?? 'n/a'}
 finish_reason  = ${record.finish_reason ?? 'n/a'}
-ctx.window     = ${ctxPct.toFixed(1)}%   (${tokIn.toLocaleString()} / 200,000 tok, 가정)
+ctx.window     = ${ctxLine}
 keeper.turn    = T${record.absolute_turn}
 thinking       = ${thinkingStateLabel(record)}
 thinking.budget= ${record.thinking_budget ?? '—'}
@@ -625,8 +636,18 @@ function buildTurnDetail(
   const traceId = `${record.trace_id}_${String(record.absolute_turn).padStart(4, '0')}`
   const tokIn = record.input_tokens ?? Math.max(1, Math.round(record.blocks.reduce((sum, b) => sum + b.bytes, 0) / 4))
   const tokOut = record.output_tokens ?? 120
-  const ctxPct = Math.min(100, (tokIn / 200_000) * 100)
-  const cost = (tokIn * 3 + tokOut * 15) / 1e6
+  // RFC-0233 §8 — ctx-fill% and cost grounded in runtime.toml-declared facts.
+  // context_window is the keeper-resolved effective budget (replaces the
+  // hardcoded 200K); prices are USD/1M from the binding (replace Claude $3/$15).
+  // Either is null when the record lacks the fact — the view renders "미상".
+  const ctxPct =
+    record.context_window != null && record.context_window > 0
+      ? Math.min(100, (tokIn / record.context_window) * 100)
+      : null
+  const cost =
+    record.price_input_per_million != null && record.price_output_per_million != null
+      ? (tokIn * record.price_input_per_million + tokOut * record.price_output_per_million) / 1e6
+      : null
   const toolIndex = toolCallIndexByExecutionId(toolEntries)
 
   const phases: TurnPhase[] = [{
@@ -994,13 +1015,13 @@ function MetaTab({ record, t, source }: { record: TurnRecordEntry; t: TurnDetail
         <span class="k">fsm.state</span><span class="v">n/a</span>
         <span class="k">input tokens</span><span class="v">${t.tokIn.toLocaleString()}</span>
         <span class="k">output tokens</span><span class="v">${t.tokOut.toLocaleString()}</span>
-        <span class="k">ctx window · 200K 가정</span><span class="v">${t.ctxPct.toFixed(1)}% / 200K</span>
+        <span class="k">ctx window${record.context_window != null ? '' : ' · 미상'}</span><span class="v">${t.ctxPct != null ? `${t.ctxPct.toFixed(1)}% / ${record.context_window?.toLocaleString() ?? '미상'}` : '미상'}</span>
         <span class="k">keeper turn</span><span class="v">T${record.absolute_turn}</span>
         <span class="k">agent subturns</span><span class="v">${formatTurnList(uniqueNumbers(t.tools.map(tool => tool.agentSubturn)))}</span>
         <span class="k">thinking</span><span class="v">${thinkingStateLabel(record)}</span>
         <span class="k">tool calls</span><span class="v">${t.tools.length}</span>
         <span class="k">measured phase duration</span><span class="v">${t.measuredDurationMs != null ? formatMsCompact(t.measuredDurationMs) : 'none'}</span>
-        <span class="k">est. cost · Claude 가격</span><span class="v">$${t.cost.toFixed(3)}</span>
+        <span class="k">est. cost${record.price_input_per_million != null ? '' : ' · 가격 미구성'}</span><span class="v">${t.cost != null ? `$${t.cost.toFixed(3)}` : '미상'}</span>
         <span class="k">finish_reason</span><span class="v">${record.finish_reason ?? 'n/a'}</span>
         <span class="k">source</span><span class="v">${source}</span>
       </div>
@@ -1130,14 +1151,14 @@ function TurnDetailDrawer({
           </div>
           <div class="kti-stat">
             <div class="k">추정비용</div>
-            <div class="v ok">$${t.cost.toFixed(2)}</div>
+            <div class="v ok">${t.cost != null ? `$${t.cost.toFixed(2)}` : '미상'}</div>
           </div>
         </div>
 
         <div class="kti-tok" data-testid="turn-token-bar">
           <div class="kti-tok-top">
             <span class="lbl">토큰 경제</span>
-            <span class="ctxpct">컨텍스트 ${t.ctxPct.toFixed(1)}% / 200K</span>
+            <span class="ctxpct">${t.ctxPct != null ? `컨텍스트 ${t.ctxPct.toFixed(1)}% / ${formatCtxWindowK(record.context_window)}` : '컨텍스트 미상'}</span>
           </div>
           <div class="kti-tok-bar">
             <span

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -433,6 +433,7 @@ type TurnDetail = {
   // RFC-0233 §8 — null when context_window/price are absent on the record
   // (runtime unknown or operator left runtime.toml unset); render "미상".
   ctxPct: number | null
+  contextWindow: number | null
   cost: number | null
   measuredDurationMs: number | null
   visualTotalMs: number
@@ -719,6 +720,7 @@ function buildTurnDetail(
     tokIn,
     tokOut,
     ctxPct,
+    contextWindow: record.context_window ?? null,
     cost,
     measuredDurationMs,
     visualTotalMs,
@@ -1158,7 +1160,7 @@ function TurnDetailDrawer({
         <div class="kti-tok" data-testid="turn-token-bar">
           <div class="kti-tok-top">
             <span class="lbl">토큰 경제</span>
-            <span class="ctxpct">${t.ctxPct != null ? `컨텍스트 ${t.ctxPct.toFixed(1)}% / ${formatCtxWindowK(record.context_window)}` : '컨텍스트 미상'}</span>
+            <span class="ctxpct">${t.ctxPct != null ? `컨텍스트 ${t.ctxPct.toFixed(1)}% / ${formatCtxWindowK(t.contextWindow)}` : '컨텍스트 미상'}</span>
           </div>
           <div class="kti-tok-bar">
             <span

--- a/docs/rfc/RFC-0233-turn-observability-execution-identity.md
+++ b/docs/rfc/RFC-0233-turn-observability-execution-identity.md
@@ -392,6 +392,138 @@ foundational-record-field rule).
   the board post's `origin`.
 - API: `/chat/history` and `BoardPost` JSON carry `turn_ref` / `origin` for
   new rows and `null`/absent for legacy rows.
+
+## §8 Amendment (2026-06-21) — runtime model metadata: context window + pricing
+
+### §8.1 Problem — the dashboard fabricated the context window and the price
+
+The turn inspector rendered a token-economy panel whose denominator and
+price rates were hardcoded constants, not facts from the record:
+
+- `keeper-turn-inspector.ts:628` computed `ctxPct = (tokIn / 200_000) * 100`
+  — a hardcoded 200K denominator for every runtime.
+- `keeper-turn-inspector.ts:629` computed `cost = (tokIn*3 + tokOut*15)/1e6`
+  — hardcoded Claude Sonnet $3/$15 per million for every runtime.
+
+The token counts themselves were already real (`usage.input_tokens` /
+`output_tokens`), so the only fabricated values were the window and the
+price. For a non-Claude runtime (e.g. `glm-coding.glm-5-turbo`) the panel
+therefore showed a wrong ctx-fill% against an irrelevant 200K ceiling and a
+cost against Claude rates. The data to fix this already lived in the
+process: `Runtime.t.binding` retains `price_input`/`price_output`/`num_ctx`
+(`lib/runtime/runtime.ml:19`, `lib/runtime/runtime_schema.mli:116-119`) in
+the boot-populated `runtimes_ref` singleton, and the keeper's resolved
+effective budget (`max_context`) is already in scope at the write site. The
+record simply never stored them, forcing the view to fabricate — a
+view-side-repair violation of §2.3.
+
+### §8.2 Design — three option fields, populated from retained runtime facts
+
+```ocaml
+; context_window : int option
+    (* keeper-resolved effective context budget — the ctx% denominator *)
+; price_input_per_million : float option
+    (* USD per 1M input tokens from the runtime binding *)
+; price_output_per_million : float option
+    (* USD per 1M output tokens from the runtime binding *)
+```
+
+- `context_window` is the `max_context` parameter at
+  `lib/keeper/keeper_agent_run.ml:693` — the keeper compaction budget the
+  turn actually operates against. Stored as `Some max_context`.
+- The two prices come from `Runtime.pricing_of_runtime_id`
+  (`lib/runtime/runtime.ml:386`): a sibling of the existing
+  `max_context_of_runtime_id` / `thinking_support_of_runtime_id`
+  projections, projecting `rt.binding.price_input` / `price_output` off the
+  retained singleton via `get_runtime_by_id`. No new holder, no threading,
+  no re-parse.
+- All three are `option`: `None` when the runtime is unknown or the operator
+  left the rates unset in runtime.toml. The view renders "미상" (unknown),
+  never a fabricated value — the same absence contract `model` and
+  `finish_reason` already follow (§2.3).
+- Cost is **not** stored: the view derives it from `price_*_per_million ×
+  real token counts`, per the views-derive principle (§2.3).
+
+### §8.3 Boundary invariant (unchanged from §3)
+
+No OAS change. MASC reads the runtime binding it already materialized at
+boot (`Runtime.t.binding`); OAS's `Provider_runtime_binding` catalog — which
+deliberately omits price ("OAS owns identity/capability, not pricing") — is
+untouched. Price is MASC's operator-config concern, sourced from
+runtime.toml.
+
+### §8.4 Non-goals
+
+- No backfill: legacy rows decode all three as `None`; the view renders
+  "미상" for them.
+- `context_window` is the **keeper compaction budget**, not the provider's
+  per-request `num_ctx` cap. `num_ctx` is an Ollama-only transport detail
+  (`oas/lib/llm_provider/backend_ollama.ml`: honored by Ollama only); the
+  keeper resolver does not consult it, and conflating the two would mis-state
+  the window for any Ollama binding where the operator set `num-ctx` below
+  the model ceiling. For the current fleet (glm/deepseek/claude, none
+  Ollama-bound) `max_context` is the effective window. A future wave that
+  needs the provider-enforced cap should add a separate
+  `provider_context_window` field rather than overload this one.
+- No OAS `request_latency_ms` (phase duration) — that is a separate
+  amendment (Wave 2b); this amendment is context window + pricing only.
+
+### §8.5 Migration
+
+Single PR, dependency-ordered. Each builds fully (`dune build --root .`) so
+the shared-record field addition catches every literal construction site
+(the compiler forces `writer.ml` + `test_turn_record.ml`).
+
+1. **Type + codec** — `lib/types/turn_record.{mli,ml}`: three option fields
+   on `t`; `to_json` via `opt_field`, `of_json` via `opt_member` (mirrors
+   `model`/`finish_reason`/`temperature`).
+2. **Runtime projection** — `lib/runtime/runtime.{ml,mli}`:
+   `pricing_of_runtime_id : string -> float option * float option`, sibling
+   to `max_context_of_runtime_id`.
+3. **Writer + emit** — `lib/keeper/keeper_turn_record_writer.{ml,mli}`:
+   three labeled args + record fields; `lib/keeper/keeper_agent_run.ml:693`
+   binds `price_*` from `Runtime.pricing_of_runtime_id runtime_id_string`
+   and passes `~context_window:(Some max_context)`.
+4. **Dashboard API** — `lib/server/server_dashboard_http_keeper_api.ml:551`
+   needs **no edit**: it serializes via `Turn_record.to_json`, so the new
+   fields auto-flow.
+5. **Frontend** — `dashboard/src/api/dashboard.ts`: `TurnRecordEntry` type +
+   `decodeTurnRecordEntry` (hand-rolled decoder, no schema auto-pickup);
+   `keeper-turn-inspector.ts`: `TurnDetail.ctxPct`/`cost` widen to
+   `number | null`, compute from real `context_window`/prices, render "미상"
+   when absent (replaces the Wave-1 "200K 가정" / "Claude 가격" labels).
+
+### §8.6 Workaround guards (rejected per CLAUDE.md §워크어라운드)
+
+1. Keeping the hardcoded 200K / Claude $3·$15 in the dashboard as "the fix"
+   — the exact fabrication this amendment removes. → real runtime facts.
+2. Storing a precomputed `cost_usd` number — collapses two facts (prices ×
+   tokens) into one derived value at write time, losing the rates and
+   blocking per-field absence rendering. → store price rates + token counts;
+   derive cost in the view (§2.3).
+3. Re-parsing runtime.toml per turn (the `fusion_config_loader` pattern) —
+   diverges from the boot-validated config and parses a ~900-line file on
+   the turn-record hot path. → read the retained `Runtime` singleton.
+4. Threading price up from `runtime_adapter.binding_to_provider_config` —
+   duplicates the SSOT already retained in the `Runtime` singleton (where
+   price is read once as a boolean signal then discarded). →
+   `pricing_of_runtime_id` projection.
+5. Sourcing `context_window` from `binding.num_ctx` — conflates the keeper
+   compaction budget with an Ollama-only transport KV-cache cap and would
+   mis-state the window (see §8.4). → `max_context`.
+
+### §8.7 Verification harness
+
+- Unit (`test/test_turn_record.ml`): round-trip of all three new fields
+  (`Some`); the absent case (`None`) omits the JSON keys and decodes `None`
+  (no fabricated 200K / $3·$15 on the wire).
+- Frontend (`dashboard/src/components/keeper-turn-inspector.test.ts`): a
+  grounded fixture (real `context_window` + prices) renders a `$` cost and a
+  `%` fill, not "미상" — guards the `number | null` widening.
+- Behavioral: a `glm-coding.glm-5-turbo` turn (empty binding — no price set)
+  records `context_window = Some <model max-context>` and `price_* = None`,
+  so the inspector shows the real ctx% and "미상" cost; a turn on a priced
+  runtime shows a real derived cost.
 - FE: turn inspector opens the correct turn by id (not by window) given
   `turn_ref`; a board post navigates to its anchored chat turn and back.
   tsc + vitest, including a board↔chat navigation test.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -690,6 +690,16 @@ let run_turn
            ([Keeper_execution_receipt.stop_reason_to_string]). Both are
            [None] on the error path (receipt refs unset), never a
            fabricated value. *)
+        (* RFC-0233 §8 — ground ctx-window/cost in real runtime facts so the
+           dashboard stops fabricating 200K / Claude $3·$15. [context_window]
+           is the keeper-resolved effective budget ([max_context]); pricing
+           comes from the runtime binding retained in the Runtime singleton
+           ([Runtime.pricing_of_runtime_id] projects binding.price_input/output
+           — both option, None when the operator left runtime.toml unset, in
+           which case the dashboard renders absence rather than a default). *)
+        let (price_input_per_million, price_output_per_million) =
+          Runtime.pricing_of_runtime_id runtime_id_string
+        in
         Keeper_turn_record_writer.write
           ~config
           ~keeper_name:meta.name
@@ -701,6 +711,9 @@ let run_turn
             (Option.map
                Keeper_execution_receipt.stop_reason_to_string
                !receipt_stop_reason_ref)
+          ~context_window:(Some max_context)
+          ~price_input_per_million
+          ~price_output_per_million
           ~sampling:
             { temperature = Some temperature
             ; top_p = None

--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -6,6 +6,9 @@ let write
       ~runtime_profile
       ~model
       ~finish_reason
+      ~context_window
+      ~price_input_per_million
+      ~price_output_per_million
       ~sampling
       ~usage
       ~execution_ids
@@ -22,6 +25,9 @@ let write
     ; runtime_profile
     ; model
     ; finish_reason
+    ; context_window
+    ; price_input_per_million
+    ; price_output_per_million
     ; sampling
     ; usage
     ; ts = Time_compat.now ()

--- a/lib/keeper/keeper_turn_record_writer.mli
+++ b/lib/keeper/keeper_turn_record_writer.mli
@@ -13,6 +13,9 @@ val write :
   runtime_profile:string ->
   model:string option ->
   finish_reason:string option ->
+  context_window:int option ->
+  price_input_per_million:float option ->
+  price_output_per_million:float option ->
   sampling:Turn_record.sampling ->
   usage:Turn_record.usage ->
   execution_ids:Ids.Execution_id.t list ->

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -384,6 +384,21 @@ let preserve_thinking_of_runtime_id (id : string) : bool option =
   | None -> None
 ;;
 
+(* RFC-0233 §8 — per-million-token pricing declared on the [id] binding's
+   runtime.toml table. Projects straight off the retained [rt.binding]
+   (price_input/price_output are [Runtime_schema.binding] option fields),
+   same shape as [max_context_of_runtime_id]. Returns (None, None) when the
+   runtime is unknown OR the operator left the rates unset — the turn-record
+   writer stores those Nones so the dashboard renders cost absence ("미상")
+   rather than fabricating Claude $3/$15 defaults. Partial config (only one
+   rate set) is preserved field-by-field; the cost view then cannot compute
+   and also renders absence. *)
+let pricing_of_runtime_id (id : string) : float option * float option =
+  match get_runtime_by_id id with
+  | Some rt -> (rt.binding.price_input, rt.binding.price_output)
+  | None -> (None, None)
+;;
+
 (* fail-fast: uninitialized = startup-ordering bug, NOT a recoverable
    condition. 이전 [| None -> "tool_strict"] 하드코딩 fallback 은 90 사이트에
    조작된 id 를 흘리는 Unknown→Permissive 안티패턴이라 제거했다 (RFC-0206 §2.1).

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -131,6 +131,13 @@ val preserve_thinking_of_runtime_id : string -> bool option
     preserve Qwen3.6 reasoning traces on OpenAI-compatible runtimes that
     support it without spraying explicit false fields at every provider. *)
 
+val pricing_of_runtime_id : string -> float option * float option
+(** [(price_input, price_output)] per-million-token USD rates declared on the
+    runtime [id] binding in runtime.toml, or [(None, None)] when the runtime is
+    not configured or the operator left the rates unset.  Consumed by the
+    turn-record writer (RFC-0233 §8) so the dashboard renders actual cost or
+    absence rather than a fabricated Claude default. *)
+
 val get_default_runtime_id : unit -> string
 (** @raise Failure if {!init_default} has not run. No silent fallback
     (RFC-0206 §2.1): an unresolved default is a startup-ordering bug, not a

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -27,6 +27,9 @@ type t =
   ; runtime_profile : string
   ; model : string option
   ; finish_reason : string option
+  ; context_window : int option
+  ; price_input_per_million : float option
+  ; price_output_per_million : float option
   ; sampling : sampling
   ; usage : usage
   ; ts : float
@@ -58,6 +61,9 @@ let to_json (r : t) : Yojson.Safe.t =
     @ opt_field "turn_ref" Ids.Turn_ref.to_yojson r.turn_ref
     @ opt_field "model" (fun v -> `String v) r.model
     @ opt_field "finish_reason" (fun v -> `String v) r.finish_reason
+    @ opt_field "context_window" (fun v -> `Int v) r.context_window
+    @ opt_field "price_input_per_million" (fun v -> `Float v) r.price_input_per_million
+    @ opt_field "price_output_per_million" (fun v -> `Float v) r.price_output_per_million
     @ opt_field "temperature" (fun v -> `Float v) r.sampling.temperature
     @ opt_field "top_p" (fun v -> `Float v) r.sampling.top_p
     @ opt_field "max_tokens" (fun v -> `Int v) r.sampling.max_tokens
@@ -151,6 +157,9 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
       let* turn_ref = opt_member "turn_ref" fields as_turn_ref in
       let* model = opt_member "model" fields as_string in
       let* finish_reason = opt_member "finish_reason" fields as_string in
+      let* context_window = opt_member "context_window" fields as_int in
+      let* price_input_per_million = opt_member "price_input_per_million" fields as_float in
+      let* price_output_per_million = opt_member "price_output_per_million" fields as_float in
       let* temperature = opt_member "temperature" fields as_float in
       let* top_p = opt_member "top_p" fields as_float in
       let* max_tokens = opt_member "max_tokens" fields as_int in
@@ -170,6 +179,9 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; runtime_profile
         ; model
         ; finish_reason
+        ; context_window
+        ; price_input_per_million
+        ; price_output_per_million
         ; sampling = { temperature; top_p; max_tokens; thinking_budget; enable_thinking }
         ; usage = { input_tokens; output_tokens }
         ; ts

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -51,6 +51,21 @@ type t =
        receipt SSOT [Keeper_execution_receipt.stop_reason_to_string].
        [None] when the turn errored before a stop reason was recorded;
        an unknown reason is never collapsed to a fake "stop". *)
+  ; context_window : int option
+    (* RFC-0233 §8 — keeper-resolved effective context budget (tokens) for
+       this turn, the denominator the dashboard ctx-fill% uses. [None] on
+       legacy rows or the error path; the inspector renders absence rather
+       than the fabricated 200K. This is the keeper compaction ceiling
+       ([max_context]), NOT the provider's per-request num-ctx cap (an
+       Ollama-only transport detail). *)
+  ; price_input_per_million : float option
+    (* RFC-0233 §8 — USD per 1M input tokens declared on the runtime
+       binding in runtime.toml. [None] when the operator left it unset;
+       the inspector renders cost absence rather than a fabricated Claude
+       $3/$15 default. *)
+  ; price_output_per_million : float option
+    (* RFC-0233 §8 — USD per 1M output tokens, same source/absence rule as
+       [price_input_per_million]. *)
   ; sampling : sampling
   ; usage : usage
   ; ts : float

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -47,6 +47,9 @@ let sample_record () : Turn_record.t =
   ; runtime_profile = "ollama_cloud.deepseek-v4-flash"
   ; model = Some "deepseek-v4-flash"
   ; finish_reason = Some "completed"
+  ; context_window = Some 131072
+  ; price_input_per_million = Some 0.15
+  ; price_output_per_million = Some 0.6
   ; sampling =
       { temperature = Some 0.3
       ; top_p = Some 0.9
@@ -86,6 +89,11 @@ let test_codec_roundtrip () =
     check string "runtime_profile" record.runtime_profile decoded.runtime_profile;
     check (option string) "model" record.model decoded.model;
     check (option string) "finish_reason" record.finish_reason decoded.finish_reason;
+    check (option int) "context_window" record.context_window decoded.context_window;
+    check (option (float 0.0001)) "price_input_per_million"
+      record.price_input_per_million decoded.price_input_per_million;
+    check (option (float 0.0001)) "price_output_per_million"
+      record.price_output_per_million decoded.price_output_per_million;
     check (option (float 0.0001)) "temperature" record.sampling.temperature
       decoded.sampling.temperature;
     check (option (float 0.0001)) "top_p" record.sampling.top_p
@@ -107,6 +115,9 @@ let test_codec_optional_fields_absent () =
     { (sample_record ()) with
       model = None
     ; finish_reason = None
+    ; context_window = None
+    ; price_input_per_million = None
+    ; price_output_per_million = None
     ; sampling =
         { temperature = None
         ; top_p = None
@@ -119,8 +130,9 @@ let test_codec_optional_fields_absent () =
     }
   in
   let json = Turn_record.to_json record in
-  (* RFC-0233 §2.3: absent meta fields are omitted from the wire, never
-     emitted as a fabricated value (no "stop", no placeholder model). *)
+  (* RFC-0233 §2.3/§8: absent meta fields are omitted from the wire, never
+     emitted as a fabricated value (no "stop", no placeholder model, no
+     fabricated 200K window or Claude $3/$15 price). *)
   (match json with
    | `Assoc fields ->
      check bool "finish_reason key omitted when None" false
@@ -130,7 +142,11 @@ let test_codec_optional_fields_absent () =
      check bool "top_p key omitted when None" false
        (List.mem_assoc "top_p" fields);
      check bool "max_tokens key omitted when None" false
-       (List.mem_assoc "max_tokens" fields)
+       (List.mem_assoc "max_tokens" fields);
+     check bool "context_window key omitted when None" false
+       (List.mem_assoc "context_window" fields);
+     check bool "price_input_per_million key omitted when None" false
+       (List.mem_assoc "price_input_per_million" fields)
    | _ -> fail "to_json did not produce an object");
   match Turn_record.of_json json with
   | Error e -> failf "decode failed: %s" e
@@ -138,6 +154,11 @@ let test_codec_optional_fields_absent () =
     check (option string) "model absent stays None" None decoded.model;
     check (option string) "finish_reason absent stays None (not \"stop\")" None
       decoded.finish_reason;
+    check (option int) "context_window absent stays None" None decoded.context_window;
+    check (option (float 0.0001)) "price_input_per_million absent" None
+      decoded.price_input_per_million;
+    check (option (float 0.0001)) "price_output_per_million absent" None
+      decoded.price_output_per_million;
     check (option (float 0.0001)) "temperature absent" None
       decoded.sampling.temperature;
     check (option (float 0.0001)) "top_p absent" None decoded.sampling.top_p;


### PR DESCRIPTION
## 목표

keeper-turn 관측 패널이 **하드코딩 200K / Claude $3·$15** 로 가짜 값을 보여주던 문제의 근본 해결 (Wave 2a). 토큰 수는 이미 진짜였고, 컨텍스트 윈도우 분모와 가격만 상수로 고정돼 있어 non-Claude 런타임(glm 등)에서 ctx%와 비용이 틀렸다.

## 변경 (RFC-0233 §8)

`Turn_record.t` 에 3개 option 필드 추가 (absence → "미상" 렌더, fabricate 금지 — §2.3 철학):

- `context_window : int option` — keeper가 해석한 effective budget (ctx% 분모)
- `price_input_per_million` / `price_output_per_million : float option` — runtime binding 의 USD/1M 가격

데이터는 MASC가 이미 보유한 사실에서:

- `context_window` = write site 의 `max_context` param (이미 스코프에 있음).
- 가격 = 신규 `Runtime.pricing_of_runtime_id` (기존 `max_context_of_runtime_id` sibling — boot 시 구축된 `Runtime` singleton 의 `rt.binding.price_input/output` projection). 새 holder·threading·재파싱 없음.

비용은 view 가 real price × real token 으로 derive (저장 아님, §2.3 views-derive).

적대 검증 워크플로(6 agent)가 사전 설계 2가지를 반박: (1) price 는 도달 불가라는 가정 → **REFUTED**, `Runtime.t` 가 binding(price 포함)을 singleton 에 보존; (2) max_context 가 정확한 분모 → universal REFUTED(num_ctx 는 Ollama 전용이라 별개) 이지만 fleet(non-Ollama) 에서는 정확, RFC §8.4 에 caveat 명시.

## 파일

- `lib/runtime/runtime.{ml,mli}`: `pricing_of_runtime_id` sibling projection
- `lib/types/turn_record.{ml,mli}`: 3 option 필드 + codec (opt_field/opt_member)
- `lib/keeper/keeper_turn_record_writer.{ml,mli}`: 3 labeled arg
- `lib/keeper/keeper_agent_run.ml:693`: `Runtime.pricing_of_runtime_id` lookup + `~context_window:(Some max_context)`
- `dashboard/src/api/dashboard.ts`: `TurnRecordEntry` type + decoder (3 필드)
- `dashboard/src/components/keeper-turn-inspector.ts`: `ctxPct`/`cost` 를 `number | null` 로, real 값으로 계산, "미상" 렌더 (Wave 1 "200K 가정"/"Claude 가격" 라벨을 조건부로 교체)
- `test/test_turn_record.ml`: roundtrip + absent 검증 (3 필드)
- `docs/rfc/RFC-0233-*.md`: §8 amendment
- `.tmp/rfc-0233-caller-context.md`: R5 caller-context (force-add)

`server_dashboard_http_keeper_api.ml:551` 은 `Turn_record.to_json` 직접 사용이라 수정 불필요 (자동 전파). OAS 무변경 (`Provider_runtime_binding` catalog 는 price 를 의도적으로 안 가짐).

## 검증

- 빌드/테스트 미실행 (사용자 지시: 빌드는 CI만). CI Dashboard(tsc+vite+vitest) + Lint(OCaml) + CI Gate + rfc-enforcer 로 검증.
- `test_turn_record.ml`: 3 필드 roundtrip + absent 시 JSON 키 생략/None 디코드 (가짜 200K/$3·$15 가 wire 에 안 남음).
- `keeper-turn-inspector.test.ts`: grounded fixture(real context_window + price) 가 "미상" 이 아닌 `$`/`%` 를 렌더.

## 범위 밖 (별도)

- **Wave 2b**: phase duration (`request_latency_ms`, OAS telemetry). OAS 경계 주의. 별도 amendment.
- `glm-coding.glm-5-turbo` binding 은 price 미설정 → 정직하게 "미상" 표시 (operator 가 runtime.toml 에 가격 추가 시 real 비용 표시).

Co-Authored-By: Claude <noreply@anthropic.com>
