### PR TITLE
fix(tool-blob-store): raise on failed blob write (stop silent keeper tool-output loss)

### DIFF
--- a/lib/tool_blob_store/tool_blob_store.ml
+++ b/lib/tool_blob_store/tool_blob_store.ml
@@ -45,8 +45,17 @@ let put t ~bytes ~mime =
   let path = shard_path t sha256 in
   if not (Fs_compat.file_exists path) then begin
     ensure_parent_dir path;
-    let _ : (unit, string) result = Fs_compat.save_file_atomic path bytes in
-    ()
+    (* Propagate a failed write instead of swallowing it. Returning [Stored]
+       after [save_file_atomic] failed produced a blob marker for bytes that
+       were never persisted, so the keeper permanently lost the full tool
+       output (only the preview survived). The sole caller,
+       [Tool_bridge.maybe_externalize], already catches storage failures and
+       falls back to the inline bytes (its docstring promises exactly this);
+       raising here is what activates that fallback. *)
+    match Fs_compat.save_file_atomic path bytes with
+    | Ok () -> ()
+    | Error msg ->
+        raise (Sys_error (Printf.sprintf "tool_blob_store.put: %s" msg))
   end;
   Tool_output.Stored {
     sha256;

--- a/lib/tool_blob_store/tool_blob_store.mli
+++ b/lib/tool_blob_store/tool_blob_store.mli
@@ -23,7 +23,11 @@ val put : t -> bytes:string -> mime:string -> Tool_output.t
     [preview] is the first ~200 sanitized chars of [bytes] (control bytes
     replaced with [?], whitespace collapsed to spaces).
 
-    Idempotent: re-putting the same bytes is a no-op (file already exists). *)
+    Idempotent: re-putting the same bytes is a no-op (file already exists).
+
+    @raises Sys_error if the blob write fails (disk full, EACCES, ...). Callers
+    that must not lose bytes should catch this and fall back to the inline
+    payload rather than emitting a marker for bytes that were never persisted. *)
 
 val fetch : t -> sha256:string -> string option
 (** Retrieve bytes by sha256. Returns [None] if not in store. *)

--- a/test/test_tool_blob_store.ml
+++ b/test/test_tool_blob_store.ml
@@ -217,6 +217,25 @@ let test_repeated_put_no_dup () =
         "fetched content matches" (Some payload)
         (B.fetch store ~sha256:sha))
 
+(* --- Storage-failure contract --- *)
+
+(* [put] must surface a storage failure (raise) rather than silently returning
+   a [Stored] marker for bytes it never persisted. Here [base_path] is a
+   regular file, so the blob store directory cannot be created and the write
+   cannot land. Using a file (not a chmod) makes the failure structural
+   (ENOTDIR), so the test holds even when run as root. *)
+let test_put_raises_on_unwritable_store () =
+  let file = Filename.temp_file "masc_blob_unwritable" "" in
+  let store = B.create ~base_path:file in
+  let raised =
+    try
+      let _ = B.put store ~bytes:(String.make 5000 'x') ~mime:"text/plain" in
+      false
+    with _ -> true
+  in
+  (try Sys.remove file with _ -> ());
+  Alcotest.(check bool) "put raises on unwritable store" true raised
+
 (* --- Entry point --- *)
 
 let () =
@@ -250,5 +269,10 @@ let () =
         [
           Alcotest.test_case "repeated put no dup" `Quick
             test_repeated_put_no_dup;
+        ] );
+      ( "storage failure",
+        [
+          Alcotest.test_case "put raises on unwritable store" `Quick
+            test_put_raises_on_unwritable_store;
         ] );
     ]


### PR DESCRIPTION
## 무엇을 / 왜

`Tool_blob_store.put`(`lib/tool_blob_store/tool_blob_store.ml:48`)이 `let _ : (unit,string) result = Fs_compat.save_file_atomic path bytes in`로 write 결과를 폐기하고 `Stored`를 무조건 반환했다. write 실패(ENOSPC/EACCES/fd 고갈) 시 전체 tool-output bytes가 **디스크에도(write 실패) inline에도(caller가 blob marker로 대체) 없어** 영구 손실 — keeper는 ~200자 preview만 보게 된다.

유일 caller `Tool_bridge.maybe_externalize`(`lib/tool_bridge.ml:88-101`)는 이미 `put`을 `try ... with | Eio.Cancel.Cancelled _ as e -> raise e | _ -> msg`로 감싸 storage 실패 시 inline bytes로 fallback한다(docstring: "the keeper never loses tool output bytes due to a storage hiccup"). 그러나 `put`이 실패를 **신호하지 않아 그 fallback이 dead**였다.

## 변경

- `tool_blob_store.ml`: `save_file_atomic`가 `Error`면 `Sys_error`를 raise(이전엔 swallow). 성공/idempotent(already-exists) 경로는 불변.
- `tool_blob_store.mli`: `@raises Sys_error` 문서화.
- caller 변경 **불필요** — 기존 `try/with`가 raise를 잡아 inline fallback을 활성화. 이게 docstring이 약속한 동작이다.
- `test_tool_blob_store.ml`: storage-failure contract test 추가(`base_path`를 일반 파일로 두어 blob dir 생성 불가 → put이 raise. chmod 아닌 구조적 ENOTDIR이라 root 실행에도 견고).

## 설계 노트 (raise vs Result)

caller가 이미 exception-based(`try/with`)이고 `put`은 lib 내 caller가 1개뿐이라, raise가 (a) 기존 문서화된 fallback을 그대로 활성화하고 (b) 시그니처 변경으로 인한 5개 test 파일 ripple을 피한다. `Sys_error`는 IO 실패의 표준 예외이며 `failwith` 아님(예외를 제어 흐름이 아닌 예외적 IO 실패에 사용). caller가 Result-based였다면 Result 전파가 맞으나, 여기선 exception 계약이 기존 표면과 정합.

## 범위 / 경계

- `lib/tool_blob_store/` + 그 단일 caller(미변경) + 해당 test. 다른 sink/subsystem 무관.
- RFC-gate 비대상: credential/operator/keeper-sandbox/dashboard-credential/hooks/workflow 경로 아님.

## Workaround self-check

워크어라운드를 **제거**한다(swallow → 실패 신호의 근본 fix). telemetry-as-fix ❌(counter 아님, 실제 bytes 보존) / string 분류기 ❌ / cap·cooldown·dedup·repair ❌. **N-of-M 아님**: 이 PR은 `tool_blob_store` sink의 **완결 root fix**다. #21990이 추적하는 다른 sink들(`write_json` 공유 sink=schedule/operator/goal, `board_core_persist`, `keeper_memory_bank`)은 **독립적인 별개 코드**로 각자의 fix가 필요하고 일부는 RFC-gated(operator)다 — 동일 변환의 부분 적용이 아니라 서로 다른 sink다. codemod로 일괄 가능한 단일 변환이 아니므로 N-of-M 시그니처에 해당하지 않는다.

## 검증

- `dune build test/test_tool_blob_store.exe --root .` exit 0 (worktree root).
- `test_tool_blob_store` 13/13 통과(기존 12 + 새 storage-failure contract test). 회귀 0.
- save_file_atomic-Error 특정 경로의 결정론적 단위테스트는 비현실적(mkdir 성공 후 disk-full류만 발생)이라, contract test(put이 storage 실패에 raise)로 계약을 lock하고 success/idempotent 경로 불변은 기존 테스트가 검증. 실패 신호→fallback의 end-to-end는 caller의 기존 try/with로 보장.

Refs #21990.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
