### PR TITLE
[v2] Wave 1 — canonical design tokens (color/type/spacing/radius/shadow/fonts)

### DIFF
--- a/dashboard/src/styles/ds-theme-tokens.css
+++ b/dashboard/src/styles/ds-theme-tokens.css
@@ -18,19 +18,20 @@
 @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=EB+Garamond:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono:wght@400;500;700&family=Noto+Sans+KR:wght@300;400;500;600;700;900&family=Share+Tech+Mono&display=swap');
 
 /* Local fonts — served from dashboard/public/assets/fonts via Vite.
-   Cinzel-Regular.ttf is present; NotoSansKR-Regular.ttf should be added
-   to the same directory when available (the Google import above keeps
-   Noto Sans KR working until then). */
+   Both Cinzel-Regular.ttf and NotoSansKR-Regular.ttf are present. The URL
+   carries the Vite base prefix (/dashboard/) so the @font-face resolves at
+   runtime; without it the request 404s under the deployed base. Matches the
+   tested declaration in fonts.css. */
 @font-face {
   font-family: 'Cinzel';
-  src: url('/assets/fonts/Cinzel-Regular.ttf') format('truetype');
+  src: url('/dashboard/assets/fonts/Cinzel-Regular.ttf') format('truetype');
   font-weight: 400 700;
   font-display: swap;
 }
 
 @font-face {
   font-family: 'Noto Sans KR';
-  src: url('/assets/fonts/NotoSansKR-Regular.ttf') format('truetype');
+  src: url('/dashboard/assets/fonts/NotoSansKR-Regular.ttf') format('truetype');
   font-weight: 300 700;
   font-display: swap;
 }

--- a/dashboard/src/styles/ds-theme-tokens.test.ts
+++ b/dashboard/src/styles/ds-theme-tokens.test.ts
@@ -88,8 +88,10 @@ describe('ds-theme-tokens.css', () => {
     expect(theme['--brick']).toBe('#8B3A3A')
   })
 
-  it('contains local @font-face rules pointing to public/assets/fonts', () => {
-    expect(css).toContain("src: url('/assets/fonts/Cinzel-Regular.ttf') format('truetype')")
-    expect(css).toContain("src: url('/assets/fonts/NotoSansKR-Regular.ttf') format('truetype')")
+  it('contains local @font-face rules pointing to public/assets/fonts under the Vite base', () => {
+    // URLs carry the /dashboard/ Vite base prefix so the @font-face resolves
+    // at runtime (a bare /assets/... path 404s under the deployed base).
+    expect(css).toContain("src: url('/dashboard/assets/fonts/Cinzel-Regular.ttf') format('truetype')")
+    expect(css).toContain("src: url('/dashboard/assets/fonts/NotoSansKR-Regular.ttf') format('truetype')")
   })
 })

--- a/dashboard/src/styles/skin-v2.css
+++ b/dashboard/src/styles/skin-v2.css
@@ -33,11 +33,12 @@ html[data-skin="v2"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
   --border-soft:      #1e1f29;
   --border-highlight: #3b3d4e;
 
-  /* Text — bone, pushed bright for reading */
+  /* Text — bone, pushed bright for reading (raised contrast on mid/dim
+     so 9–11px labels, eyebrows and captions stay legible on dark ground) */
   --text-bright:  #f7f1e6;
   --text-primary: #e3dacb;
-  --text-mid:     #c0b7a6;
-  --text-dim:     #968fa1;
+  --text-mid:     #cabfac;
+  --text-dim:     #a59db0;
 
   /* Accents — vivid */
   --accent-blood:     #e8472f;

--- a/dashboard/src/styles/v2-skin-tokens.css
+++ b/dashboard/src/styles/v2-skin-tokens.css
@@ -11,6 +11,7 @@
   --bg-card:        #1b1c25;
   --bg-card-hover:  #23242f;
   --bg-sunken:      #0a0b0f;
+  --bg-well:        #06070a;   /* deepest: code/shell/tool wells inside cards */
 
   /* Borders — crisper, cooler */
   --border-main:      #282a36;
@@ -21,8 +22,8 @@
      so 9–11px labels, eyebrows and captions stay legible on dark ground) */
   --text-bright:  #f7f1e6;
   --text-primary: #e3dacb;
-  --text-mid:     #c0b7a6;
-  --text-dim:     #968fa1;
+  --text-mid:     #cabfac;
+  --text-dim:     #a59db0;
 
   /* Accents — vivid */
   --accent-blood:     #e8472f;


### PR DESCRIPTION
## Goal

Wave-1 foundation of the pixel-perfect v2 design port. Align masc's dashboard v2-skin token layer to the Claude-Design prototype (`keeper-v2/styles/{colors_and_type,v2}.css`) so every downstream surface PR stacks on one canonical token spine.

## Strategy B — prototype is canonical SSOT

The prototype token system is the source of truth for the v2 skin. The bulk port already landed in a prior wave (`ds-theme-tokens.css` cites the prototype `colors_and_type.css` as Source, and matches `--space-1..8` / `--radius-xs..pill` / dark-fantasy palette / paper sub-tokens exactly). This PR closes the remaining value drift in the live `[data-skin="v2"]` dark spine plus a font-resolution bug.

## Files changed

- `dashboard/src/styles/skin-v2.css` — dark v2 spine: `--text-mid` `#c0b7a6 → #cabfac`, `--text-dim` `#968fa1 → #a59db0` (match prototype `v2.css` lines 30-31).
- `dashboard/src/styles/v2-skin-tokens.css` — same two text tokens; added missing `--bg-well: #06070a` (prototype defines it as the deepest well; this file was the only v2 token block lacking it).
- `dashboard/src/styles/ds-theme-tokens.css` — fixed `@font-face` URLs from `/assets/fonts/...` to `/dashboard/assets/fonts/...` so Cinzel + Noto Sans KR resolve under the Vite `base: '/dashboard/'` (the bare path 404s). Matches the tested declaration in `fonts.css`.
- `dashboard/src/styles/ds-theme-tokens.test.ts` — updated the assertion that pinned the old (404-ing) bare font URL.

## Legacy drift purged

- `--text-mid` / `--text-dim`: two off-prototype hex values in both v2 token blocks → realigned to the prototype's higher-contrast bone tones.
- `--bg-well`: missing in `v2-skin-tokens.css` → added.
- Broken `/assets/fonts/...` `@font-face` (would 404 at runtime under the `/dashboard/` base) → corrected.

### Deliberately NOT changed (not drift)

The `[data-skin="v2"][data-theme="paper"]` block keeps masc's warm parchment paper-theme palette (`var(--paper)` / `var(--brass)`), which intentionally overrides the prototype's cooler gray v2-paper spine. This is a tested decision (`skin-v2-paper.test.ts`: "uses the paper-theme palette instead of the old gray v2 paper spine"). Reverting it would break that test and revert an intentional product choice — out of scope.

Fonts (rule 3): both `Cinzel-Regular.ttf` and `NotoSansKR-Regular.ttf` already exist in `public/assets/fonts/`; this PR only corrects the URL so they actually load. No file copy needed.

## Verification

Run from `dashboard/` (node_modules symlinked from the main worktree):

```
$ tsc --noEmit
tsc exit: 0

$ vitest run --config vitest.config.ts src/styles/
 Test Files  13 passed (13)
      Tests  52 passed (52)
```

Token/theme/font tests specifically: `skin-v2-paper.test.ts`, `styleseed-theme.test.ts`, `fonts.test.ts`, `ds-theme-tokens.test.ts`, `paper-theme.test.ts` — all green (20/20).

## Scope

Tokens only (color/type/spacing/radius/shadow/fonts). No feature components restyled. **Stacked base for per-surface v2 PRs.**

This touches only token CSS (no credential/hooks/operator subsystem) — no RFC gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
