### PR TITLE
feat(keeper): typed TaskCreate deliberation action (goal-gated, RFC-0034/0267 governance review)

### DIFF
--- a/config/prompts/keeper.deliberation.md
+++ b/config/prompts/keeper.deliberation.md
@@ -20,9 +20,10 @@ Available actions (pick exactly one):
 - board_post: Post to the community board. Requires content and optional hearth.
 - board_comment: Comment on a board post. Requires post_id and content.
 - board_vote: Vote on a board post. Requires post_id and direction (up/down).
+- task_create: Create a task for active goal work when no unclaimed task exists. Requires title, description, and optional priority.
 - propose_spawn: Propose a delegation request for operator/keeper routing. Requires topic and reason. This records a MASC task seed; it does not directly spawn an agent.{{multi_step_line}}
 
-When self_directed_explore triggers, prefer actions that create value: board_post, board_comment, or broadcast. Avoid noop unless truly nothing is worth doing. (To create a task, call the `keeper_task_create` tool directly in your next turn — it is not a deliberation action.)
+When active goals exist but no unclaimed task exists, prefer task_create for a concrete next step. When self_directed_explore triggers, prefer actions that create value: board_post, board_comment, or broadcast. Avoid noop unless truly nothing is worth doing.
 
 Respond with ONLY the tool input object for schema `keeper_deliberation_decision` in this exact shape:
 {"action":"<action_name>","params":{<action_specific_params>},"reasoning":"<brief_explanation>","confidence":<0.0_to_1.0>}
@@ -30,5 +31,6 @@ Respond with ONLY the tool input object for schema `keeper_deliberation_decision
 Examples:
 {"action":"noop","params":{"reason":"No urgent triggers"},"reasoning":"All triggers are low priority","confidence":0.9}
 {"action":"task_claim","params":{"task_id":"task-123","reason":"Matches my goal"},"reasoning":"Unclaimed task aligns with keeper goal","confidence":0.7}
+{"action":"task_create","params":{"title":"Add regression test for goal-scoped task creation","description":"Create a focused test that proves keepers can seed concrete tasks from active goal work when the backlog is empty.","priority":2},"reasoning":"Active goal has no claimable task","confidence":0.72}
 {"action":"broadcast","params":{"message":"Status update: monitoring active goals"},"reasoning":"Team needs workspace update","confidence":0.6}
 {"action":"board_post","params":{"content":"Noticed recurring pattern in board posts about memory search quality","hearth":"observation"},"reasoning":"Self-directed exploration found a pattern worth sharing","confidence":0.65}{{multi_step_example}}

--- a/config/prompts/keeper.turn_intent.md
+++ b/config/prompts/keeper.turn_intent.md
@@ -1,7 +1,7 @@
 ---
 description: keeper unified turn intent block (prepended via "## Turn Intent" after unified.system render)
 category: keeper
-template_variables: [board_activity_guidance, claim_guidance_a, claim_guidance_b, board_post_guidance, board_curation_guidance, broadcast_guidance, state_block_instruction]
+template_variables: [board_activity_guidance, claim_guidance_a, claim_guidance_b, task_create_guidance, board_post_guidance, board_curation_guidance, broadcast_guidance, state_block_instruction]
 ---
 
 Use the world state below as raw context.
@@ -12,7 +12,7 @@ Your checkpoint survives across cycles — focus on doing one meaningful unit of
 Your conversation history is preserved across cycles — use that context to avoid repeating the same actions.
 
 Act through tools, not declarations. Call the tool directly.
-{{board_activity_guidance}}{{claim_guidance_a}}{{claim_guidance_b}}{{board_post_guidance}}{{board_curation_guidance}}{{broadcast_guidance}}- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior "stay silent", "wait for new work", or stale repo/blocker claims without re-checking the live world state.
+{{board_activity_guidance}}{{claim_guidance_a}}{{claim_guidance_b}}{{task_create_guidance}}{{board_post_guidance}}{{board_curation_guidance}}{{broadcast_guidance}}- Treat continuity as advisory prior context, not as a command. Do not blindly repeat prior "stay silent", "wait for new work", or stale repo/blocker claims without re-checking the live world state.
 - If continuity says there is nothing to do but this turn still has backlog, repo delta, or a scheduled autonomous trigger, treat that mismatch as actionable and investigate it before going silent.
 - Nothing genuinely actionable after checking? End your turn with the [STATE] block.
 

--- a/lib/keeper/keeper_delegation_request.ml
+++ b/lib/keeper/keeper_delegation_request.ml
@@ -161,7 +161,7 @@ let rec of_action ~requester ?goal = function
   | MultiStep actions ->
       List.concat_map (of_action ~requester ?goal) actions
   | Noop _ | BoardPost _ | BoardComment _ | BoardVote _ | TaskClaim _
-  | Broadcast _ ->
+  | TaskCreate _ | Broadcast _ ->
       []
 
 

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -45,6 +45,7 @@ type deliberation_action =
   | BoardComment of { post_id: string; content: string }
   | BoardVote of { post_id: string; direction: string }
   | TaskClaim of { task_id: string; reason: string }
+  | TaskCreate of { title: string; description: string; priority: int option }
   | Broadcast of { message: string }
   | ProposeSpawn of { topic: string; reason: string }
   | MultiStep of deliberation_action list
@@ -55,6 +56,7 @@ let rec deliberation_action_to_string = function
   | BoardComment _ -> "board_comment"
   | BoardVote _ -> "board_vote"
   | TaskClaim _ -> "task_claim"
+  | TaskCreate _ -> "task_create"
   | Broadcast _ -> "broadcast"
   | ProposeSpawn _ -> "propose_spawn"
   | MultiStep actions ->
@@ -69,6 +71,7 @@ let deliberation_action_to_policy_label = function
   | BoardComment _ -> "board_comment"
   | BoardVote _ -> "board_vote"
   | TaskClaim _ -> "task_claim"
+  | TaskCreate _ -> "task_create"
   | Broadcast _ -> "broadcast"
   | ProposeSpawn _ -> "propose_spawn"
   | MultiStep _ -> "multi_step"
@@ -104,6 +107,17 @@ let rec deliberation_action_to_json = function
           ("task_id", `String task_id);
           ("reason", `String reason);
         ]
+  | TaskCreate { title; description; priority } ->
+      `Assoc
+        ([
+           ("type", `String "task_create");
+           ("title", `String title);
+           ("description", `String description);
+         ]
+         @
+         match priority with
+         | Some priority -> [ ("priority", `Int priority) ]
+         | None -> [])
   | Broadcast { message } ->
       `Assoc [ ("type", `String "broadcast"); ("message", `String message) ]
   | ProposeSpawn { topic; reason } ->
@@ -440,6 +454,9 @@ let rec legality_error (obs : world_observation) = function
   | TaskClaim _ ->
       if obs.unclaimed_task_count > 0 then None
       else Some "task_claim requires unclaimed tasks"
+  | TaskCreate _ ->
+      if obs.active_goal_count > 0 && obs.unclaimed_task_count = 0 then None
+      else Some "task_create requires active goals and no unclaimed tasks"
   | Broadcast _ ->
       if has_operational_signal obs then None
       else Some "broadcast requires an operational signal"
@@ -566,6 +583,18 @@ let rec parse_action_from_json (json : Yojson.Safe.t)
       let reason = Safe_ops.json_string ~default:"" "reason" params in
       if task_id = "" then Error "task_claim requires non-empty task_id"
       else Ok (TaskClaim { task_id; reason })
+  | "task_create" ->
+      let title = Safe_ops.json_string ~default:"" "title" params |> String.trim in
+      let description =
+        Safe_ops.json_string ~default:"" "description" params |> String.trim
+      in
+      let priority =
+        Safe_ops.json_int_opt "priority" params
+        |> Option.map (fun value -> max 1 (min 5 value))
+      in
+      if title = "" then Error "task_create requires non-empty title"
+      else if description = "" then Error "task_create requires non-empty description"
+      else Ok (TaskCreate { title; description; priority })
   | "broadcast" ->
       let message = Safe_ops.json_string ~default:"" "message" params in
       if message = "" then Error "broadcast requires non-empty message"
@@ -670,7 +699,7 @@ let structured_result_schema : structured_result Agent_sdk.Structured.schema =
       [
         {
           Agent_sdk.Types.name = "action";
-          description = "One of: noop, task_claim, broadcast, board_post, board_comment, board_vote, propose_spawn, multi_step.";
+          description = "One of: noop, task_claim, task_create, broadcast, board_post, board_comment, board_vote, propose_spawn, multi_step.";
           param_type = Agent_sdk.Types.String;
           required = true;
         };

--- a/lib/keeper/keeper_deliberation.mli
+++ b/lib/keeper/keeper_deliberation.mli
@@ -28,6 +28,7 @@ type deliberation_action =
   | BoardComment of { post_id: string; content: string }
   | BoardVote of { post_id: string; direction: string }
   | TaskClaim of { task_id: string; reason: string }
+  | TaskCreate of { title: string; description: string; priority: int option }
   | Broadcast of { message: string }
   | ProposeSpawn of { topic: string; reason: string }
   | MultiStep of deliberation_action list

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -546,6 +546,13 @@ let fallback_externalized_bullet key =
        keeper_board_curation_submit with a concise snapshot."
   else if String.equal key Keeper_prompt_names.turn_intent_broadcast_guidance then
     Some "- Need to share broadly? Call keeper_broadcast."
+  else if String.equal key Keeper_prompt_names.turn_intent_task_create_guidance then
+    Some
+      "- Active goal work is present but no claimable task is available. \
+       If the goal has a concrete next step, create it with \
+       `keeper_task_create` using a clear title, description, priority, and \
+       the goal link. Do not wait for a human to pre-split obvious goal work \
+       into tasks."
   else if String.equal key Keeper_prompt_names.immediate_task_move then
     Some
       "- Claimable backlog exists. `keeper_task_claim {}` may claim the next \
@@ -717,6 +724,14 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
     && not meta.paused
     && Option.is_none meta.current_task_id
   in
+  let show_task_create_guidance =
+    observation.active_goals <> []
+    && observation.claimable_task_count = 0
+    && observation.provider_capacity_blocked_task_count = 0
+    && tool_allowed "keeper_task_create"
+    && not meta.paused
+    && Option.is_none meta.current_task_id
+  in
   (* Turn intent body and each conditional guidance bullet live as markdown
      under config/prompts/. The OCaml side only computes the boolean toggle
      for each bullet and loads the prose via Prompt_registry; the prose
@@ -744,6 +759,11 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
       ~enabled:(tool_allowed "keeper_broadcast")
       Keeper_prompt_names.turn_intent_broadcast_guidance
   in
+  let task_create_guidance =
+    load_externalized_bullet
+      ~enabled:show_task_create_guidance
+      Keeper_prompt_names.turn_intent_task_create_guidance
+  in
   let claim_guidance_a =
     load_externalized_bullet
       ~enabled:show_claim_guidance
@@ -759,6 +779,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
       ("board_activity_guidance", board_activity_guidance);
       ("claim_guidance_a", claim_guidance_a);
       ("claim_guidance_b", claim_guidance_b);
+      ("task_create_guidance", task_create_guidance);
       ("board_post_guidance", board_post_guidance);
       ("board_curation_guidance", board_curation_guidance);
       ("broadcast_guidance", broadcast_guidance);

--- a/lib/keeper_metrics/keeper_prompt_names.ml
+++ b/lib/keeper_metrics/keeper_prompt_names.ml
@@ -34,6 +34,7 @@ let turn_intent_board_activity_guidance = "keeper.turn_intent.board_activity_gui
 let turn_intent_board_post_guidance = "keeper.turn_intent.board_post_guidance"
 let turn_intent_board_curation_guidance = "keeper.turn_intent.board_curation_guidance"
 let turn_intent_broadcast_guidance = "keeper.turn_intent.broadcast_guidance"
+let turn_intent_task_create_guidance = "keeper.turn_intent.task_create_guidance"
 
 (** User-prompt "Claimable Work" section body, emitted when a claimable backlog
     is visible and the keeper holds no task. *)

--- a/lib/keeper_metrics/keeper_prompt_names.mli
+++ b/lib/keeper_metrics/keeper_prompt_names.mli
@@ -30,6 +30,7 @@ val turn_intent_board_activity_guidance : string
 val turn_intent_board_post_guidance : string
 val turn_intent_board_curation_guidance : string
 val turn_intent_broadcast_guidance : string
+val turn_intent_task_create_guidance : string
 
 (** User-prompt "Claimable Work" section template key. *)
 val immediate_task_move : string

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -171,6 +171,16 @@ let test_action_to_policy_label_task_claim () =
     (D.deliberation_action_to_policy_label
        (D.TaskClaim { task_id = "t-1"; reason = "needed" }))
 
+let test_action_to_policy_label_task_create () =
+  check string "task_create policy label" "task_create"
+    (D.deliberation_action_to_policy_label
+       (D.TaskCreate
+          {
+            title = "Create scoped task";
+            description = "Seed active goal work";
+            priority = Some 2;
+          }))
+
 let test_action_to_json_roundtrip () =
   let action = D.BoardPost { content = "hello"; hearth = None } in
   let json = D.deliberation_action_to_json action in
@@ -390,6 +400,9 @@ let test_prompt_contains_action_list () =
   check bool "mentions task_claim action" true
     (try ignore (Str.search_forward (Str.regexp_string "task_claim") prompt 0); true
      with Not_found -> false);
+  check bool "mentions task_create action" true
+    (try ignore (Str.search_forward (Str.regexp_string "task_create") prompt 0); true
+     with Not_found -> false);
   check bool "mentions broadcast action" true
     (try ignore (Str.search_forward (Str.regexp_string "broadcast") prompt 0); true
      with Not_found -> false);
@@ -424,6 +437,22 @@ let test_parse_valid_task_claim_json () =
           check string "task_id" "task-99" task_id;
           check string "reason" "Matches my goal" reason
       | _ -> fail "expected TaskClaim action"
+
+let test_parse_valid_task_create_json () =
+  let raw =
+    {|{"action":"task_create","params":{"title":"Add focused regression test","description":"Create a narrow test for active-goal task seeding.","priority":2},"reasoning":"Active goal has no claimable task","confidence":0.72}|}
+  in
+  match D.parse_deliberation_response raw with
+  | Error msg -> fail ("expected Ok, got Error: " ^ msg)
+  | Ok (action, reasoning, confidence) ->
+      (match action with
+       | D.TaskCreate { title; description; priority } ->
+           check string "title" "Add focused regression test" title;
+           check string "description" "Create a narrow test for active-goal task seeding." description;
+           check (option int) "priority" (Some 2) priority
+       | _ -> fail "expected TaskCreate action");
+      check string "reasoning" "Active goal has no claimable task" reasoning;
+      check (float 0.01) "confidence" 0.72 confidence
 
 let test_parse_valid_broadcast_json () =
   let raw =
@@ -472,6 +501,40 @@ let test_legality_verdict_rejects_illegal_task_claim () =
       check bool "mentions unclaimed tasks" true
         (contains_substring msg "unclaimed tasks")
   | D.Legal -> fail "expected illegal task_claim without unclaimed tasks"
+
+let test_legality_verdict_allows_task_create_for_empty_goal_scope () =
+  let obs =
+    D.{ base_obs with active_goal_count = 1; unclaimed_task_count = 0 }
+  in
+  match
+    D.legality_verdict obs
+      (D.TaskCreate
+         {
+           title = "Seed goal task";
+           description = "Create concrete work for the active goal";
+           priority = None;
+         })
+  with
+  | D.Legal -> ()
+  | D.Illegal msg -> fail ("expected legal task_create, got: " ^ msg)
+
+let test_legality_verdict_rejects_task_create_without_goal () =
+  let obs =
+    D.{ base_obs with active_goal_count = 0; unclaimed_task_count = 0 }
+  in
+  match
+    D.legality_verdict obs
+      (D.TaskCreate
+         {
+           title = "Seed goal task";
+           description = "Create concrete work for the active goal";
+           priority = None;
+         })
+  with
+  | D.Illegal msg ->
+      check bool "mentions active goals" true
+        (contains_substring msg "active goals")
+  | D.Legal -> fail "expected illegal task_create without active goals"
 
 let test_legality_verdict_rejects_nested_multistep () =
   let obs =
@@ -1303,6 +1366,8 @@ let () =
             test_action_to_policy_label_board_post;
           test_case "task_claim to policy label" `Quick
             test_action_to_policy_label_task_claim;
+          test_case "task_create to policy label" `Quick
+            test_action_to_policy_label_task_create;
           test_case "action to json roundtrip" `Quick
             test_action_to_json_roundtrip;
           test_case "noop to json preserves reason" `Quick
@@ -1366,6 +1431,10 @@ let () =
         [
           test_case "rejects illegal task_claim" `Quick
             test_legality_verdict_rejects_illegal_task_claim;
+          test_case "allows task_create for empty goal scope" `Quick
+            test_legality_verdict_allows_task_create_for_empty_goal_scope;
+          test_case "rejects task_create without goal" `Quick
+            test_legality_verdict_rejects_task_create_without_goal;
           test_case "rejects nested multi_step" `Quick
             test_legality_verdict_rejects_nested_multistep;
           test_case "keeps legal action" `Quick
@@ -1394,6 +1463,8 @@ let () =
           test_case "parse valid noop" `Quick test_parse_valid_noop_json;
           test_case "parse valid task_claim" `Quick
             test_parse_valid_task_claim_json;
+          test_case "parse valid task_create" `Quick
+            test_parse_valid_task_create_json;
           test_case "parse valid broadcast" `Quick
             test_parse_valid_broadcast_json;
           test_case "parse JSON with code fences rejected" `Quick


### PR DESCRIPTION
## 목표

keeper가 **active goal 작업은 있는데 claim 가능한 task가 없을 때**, 사람이 goal을 task로 쪼개주길 기다리지 않고 `keeper_task_create`로 직접 구체적 다음 단계를 생성하도록 한다. `keeper_task_create` 툴은 이미 존재(#7114)하므로 이 PR은 *capability* 추가가 아니라 **deliberation-level 표현 + 프롬프트 유도**다.

> 방치 worktree 적대 탐색에서 발견한 dropped work(미커밋, 9일 방치)를 fresh `origin/main` 위에 재구성했다. 원본은 9일 전 main 기준이라 그동안 새로 생긴 `keeper_delegation_request.of_action` 소비처에서 exhaustive match가 깨졌고, 이를 추가 처리했다.

## 변경 내용

- `deliberation_action`에 **typed 변형** `TaskCreate of { title; description; priority: int option }` 추가 (`.ml`/`.mli` 양쪽). `to_string`/`policy_label`/`to_json`/`parse`/`legality_error` 전 분기 exhaustive 처리(catch-all 없음).
- `legality_error`: `TaskCreate`는 `active_goal_count > 0 && unclaimed_task_count = 0`일 때만 legal. 즉 **claim할 task가 있으면 생성 불가** — 기존 backlog 소비를 우선.
- parse: 비어있지 않은 title/description 강제, `priority`는 `1..5`로 clamp.
- `keeper.turn_intent` 가이드(`turn_intent_task_create_guidance`): `active_goals ≠ [] && claimable_task_count = 0 && provider_capacity_blocked_task_count = 0 && tool_allowed "keeper_task_create" && not paused && current_task 없음`일 때만 노출.
- `keeper_delegation_request.of_action`: `TaskCreate`는 delegation/spawn이 아닌 직접 액션이므로 `TaskClaim`과 같은 no-delegation 그룹에 배치(컴파일 exhaustiveness 복구).
- 테스트(`test_keeper_deliberation.ml` +71): parse 검증/legality 게이트/priority clamp.

## 거버넌스 트레이드오프 (owner 결정 필요 — Draft 유지 사유)

이 변경은 **의도적으로 제약된 영역**에 들어간다. 자율 리뷰가 아니라 owner의 정책 판단이 필요해 Draft로 연다.

- **RFC-0034 (Task Oscillation Mitigation)**: keeper의 claim/release 루프(oscillation)가 관측된 바 있다. "claimable task 없으면 직접 만들어라"는 nudge는 idle keeper가 task를 과생성해 oscillation을 재유발할 수 있다. 본 PR은 `keeper_task_create_goal_open_limit`(goal당 open task 상한, `keeper_tool_task_runtime.ml`)에 **의존**해 폭주를 bound한다고 가정한다. 이 cap이 충분한지 owner 확인이 필요하다.
- **RFC-0267 (task↔goal explicit assignment)**: task↔goal 연결을 **명시적 할당** 모델로 가는 방향이다. keeper 자율 생성이 이 방향과 정합하는지(생성된 task가 goal에 올바르게 linked되는지) 검토 필요.

대안: nudge를 끄고 변형/legality/parse만 두는 것(표현은 typed로 확보, 자율 생성 정책은 보류)도 가능하다. 어느 쪽을 택할지 owner 판단을 요청한다.

## 로컬 검증

- `dune build --root . @check` (worktree는 `--root .` 필수 — nested worktree dune root trap)
- `dune build --root . test/...` + `test_keeper_deliberation` 실행
- ocamlformat 0.29.0 clean

## 범위 밖

- task↔goal 자동 linkage(RFC-0267 본체) 미포함.
- oscillation cooldown 강화(RFC-0034 본체) 미포함 — 기존 open-limit cap에 의존.

RFC-0034, RFC-0267 인용. keeper deliberation behavioral change이며 credential/operator/sandbox subsystem은 건드리지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
