### PR TITLE
feat(turn-record): wire provider call latency into gen phase (RFC-0233 §9)

### DIFF
--- a/.tmp/rfc-0233-caller-context.md
+++ b/.tmp/rfc-0233-caller-context.md
@@ -35,3 +35,41 @@ Verification expectation:
   absent case omits the keys / decodes `None`.
 - The dashboard inspector renders "미상" when the fields are absent and a
   real `%` / `$` when present.
+
+## §9 Amendment (2026-06-22) — response-generation phase duration
+
+Caller context for the `request_latency_ms` field added under §9.
+
+Owner request, 2026-06-22 (same keeper-turn observability `/goal`):
+
+- The phase waterfall's `gen` (response-generation) phase showed "측정 없음"
+  on every turn; its own `meta` declared "provider/OAS duration is not
+  recorded in turn-records".
+- The provider call wall-clock was already measured — OAS
+  `inference_telemetry.request_latency_ms`, synthesized by the transport
+  layer for every provider — and already retained on the keeper turn result
+  (`keeper_agent_result.ml:63`, source `result.response.telemetry`). The
+  record simply never stored it.
+
+Design constraints:
+
+- One `option` field `request_latency_ms : int` on `Turn_record.t`. Both
+  `inference_telemetry` and the field itself are `option`, so the write site
+  uses `Option.bind` (not `Option.map`) to avoid nesting option-of-option.
+  `None` on the error path renders "측정 없음", never a fabricated 0.
+- The `gen` phase maps `request_latency_ms` to `durationMs` with a new
+  `durationSource` variant `'provider_telemetry'` (distinct from
+  `'tool_call_log'` so the tooltip names the real source). `ctx`/`reason`
+  stay `'not_recorded'`: OAS has no isolated measurement for those phases.
+- No OAS change: MASC consumes a public OAS response field, the same pattern
+  as `keeper_hooks_oas.ml:417` (`Option.value ~default:0 t.request_latency_ms`
+  — but that default-0 is for a tok/s log line, not a stored record).
+- No phase-level split (`prefill_ms`/`ttfrc_ms`/`timings`): provider-native,
+  mostly `None` across the cloud keeper fleet — a Wave-2c candidate.
+
+Verification expectation:
+
+- `test_turn_record.ml` proves `request_latency_ms` round-trips and that the
+  absent case omits the key / decodes `None`.
+- The inspector renders a real `formatMsCompact` on the `gen` phase when
+  present, "측정 없음" when absent.

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3035,6 +3035,11 @@ export type TurnRecordEntry = {
   context_window?: number
   price_input_per_million?: number
   price_output_per_million?: number
+  // RFC-0233 §9 — wall-clock duration of the provider call (ms), sourced from
+  // OAS inference_telemetry.request_latency_ms. Absent when the turn errored
+  // before a response existed; the inspector renders "측정 없음" rather than a
+  // fabricated duration for the response-generation phase.
+  request_latency_ms?: number
   ts: number
 }
 
@@ -3176,6 +3181,7 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     context_window: asNumber(raw.context_window),
     price_input_per_million: asNumber(raw.price_input_per_million),
     price_output_per_million: asNumber(raw.price_output_per_million),
+    request_latency_ms: asNumber(raw.request_latency_ms),
     ts,
   }
 }

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -631,7 +631,11 @@ describe('KeeperTurnInspector v2 drawer', () => {
 
     const stats = container.querySelector('[data-testid="turn-summary-stats"]')?.textContent ?? ''
     expect(stats).toContain('실측')
-    expect(stats).toContain('54ms')
+    // RFC-0233 §9: the gen phase's request_latency_ms (1234ms) joins the tool
+    // duration (54ms) in the measured-total, so the strip reflects the
+    // provider call wall-clock too (1234 + 54 = 1288ms → "1.3s"). This is the
+    // sum of measured phases, not the turn wall-clock — see §9.4.
+    expect(stats).toContain('1.3s')
     expect(stats).toContain('입력')
     expect(stats).toContain('2.4k')
     expect(stats).toContain('출력')

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -207,6 +207,7 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           context_window: 203000,
           price_input_per_million: 0.27,
           price_output_per_million: 1.1,
+          request_latency_ms: 1234,
           blocks: [
             { block: 'system', bytes: 1200, digest: '1111222233334444' },
             { block: 'user_model', bytes: 728, digest: '99887766554433221100' },
@@ -669,6 +670,10 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(drawerText).toContain('agent subturns')
     expect(drawerText).toContain('T9001')
     expect(drawerText).toContain('keeper_board_post_get')
+    // RFC-0233 §9: the gen (response-generation) phase carries
+    // request_latency_ms from the record (1234ms → "1.2s"), so it renders a
+    // measured duration instead of "측정 없음".
+    expect(drawerText).toContain('1.2s')
     expect(drawerText).toContain('54ms')
     expect(drawerText).not.toContain('0.50s')
 

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -420,7 +420,7 @@ type TurnPhase = {
   kind: 'ctx' | 'reason' | 'tool' | 'gen'
   mono?: boolean
   durationMs: number | null
-  durationSource: 'tool_call_log' | 'estimated' | 'not_recorded'
+  durationSource: 'tool_call_log' | 'provider_telemetry' | 'estimated' | 'not_recorded'
   visualDurationMs: number
   visualOffsetMs: number
   meta?: string
@@ -603,6 +603,8 @@ function phaseDurationTitle(phase: TurnPhase): string {
   switch (phase.durationSource) {
     case 'tool_call_log':
       return 'duration_ms from /api/v1/keepers/:name/tool-calls'
+    case 'provider_telemetry':
+      return 'request_latency_ms — provider call wall-clock (OAS inference_telemetry)'
     case 'estimated':
       return 'estimated only; no durable duration for this phase'
     case 'not_recorded':
@@ -704,11 +706,18 @@ function buildTurnDetail(
   phases.push({
     label: '응답 생성',
     kind: 'gen',
-    durationMs: null,
-    durationSource: 'not_recorded',
+    // RFC-0233 §9 — ground the generation phase in OAS request_latency_ms
+    // (provider call wall-clock). Absent on the error path or before a
+    // response existed → render "측정 없음" rather than fabricating a bar.
+    durationMs: record.request_latency_ms ?? null,
+    durationSource:
+      record.request_latency_ms != null ? 'provider_telemetry' : 'not_recorded',
     visualDurationMs: 0,
     visualOffsetMs: 0,
-    meta: 'provider/OAS duration is not recorded in turn-records',
+    meta:
+      record.request_latency_ms != null
+        ? 'provider call wall-clock (request_latency_ms)'
+        : 'provider/OAS duration is not recorded for this turn',
   })
   const { visualTotalMs, measuredDurationMs } = finalizePhaseOffsets(phases)
 

--- a/docs/rfc/RFC-0233-turn-observability-execution-identity.md
+++ b/docs/rfc/RFC-0233-turn-observability-execution-identity.md
@@ -527,3 +527,121 @@ the shared-record field addition catches every literal construction site
 - FE: turn inspector opens the correct turn by id (not by window) given
   `turn_ref`; a board post navigates to its anchored chat turn and back.
   tsc + vitest, including a board↔chat navigation test.
+
+## §9 Amendment (2026-06-22) — response-generation phase duration: `request_latency_ms`
+
+### §9.1 Problem — the `gen` phase waterfall bar showed "측정 없음"
+
+The turn inspector's phase waterfall assembles four phases per turn —
+context assembly (`ctx`), thinking (`reason`), tool calls (`tool`), and
+response generation (`gen`). Only the `tool` phase carried a measured
+`duration_ms` (from `/api/v1/keepers/:name/tool-calls`). The other three
+were hardcoded `durationMs: null, durationSource: 'not_recorded'`, and the
+`gen` phase's own `meta` string declared *"provider/OAS duration is not
+recorded in turn-records"*. So every keeper turn's response-generation bar
+read "측정 없음" even though the provider call wall-clock was already
+measured — it just never reached the record.
+
+The measurement already exists in-process: the OAS `api_response.telemetry`
+field carries `inference_telemetry.request_latency_ms`, and the transport
+layer (`complete_common.patch_telemetry` non-streaming, `complete_stream`
+streaming) synthesizes it for every provider, so it is populated whenever a
+response was produced. `keeper_agent_result.ml:63` already retains that
+telemetry as `inference_telemetry` (= `result.response.telemetry`,
+`keeper_agent_run_finalize_response.ml:221`), exactly the source the keeper
+hooks already consume (`keeper_hooks_oas.ml:417` reads
+`t.request_latency_ms` off `response.telemetry`). The record simply never
+stored it, forcing the `gen` phase to render "측정 없음" — a view-side-repair
+violation of §2.3.
+
+### §9.2 Design — one option field, populated from OAS transport telemetry
+
+```ocaml
+; request_latency_ms : int option
+    (* wall-clock duration of the provider call in milliseconds *)
+```
+
+- Sourced at the write site (`lib/keeper/keeper_agent_run.ml`, next to the
+  `usage` binding) via `Option.bind result.inference_telemetry (fun t ->
+  t.request_latency_ms)`. `request_latency_ms` is itself `int option` in OAS
+  (`oas/lib/llm_provider/types.mli:197`), and `inference_telemetry` is an
+  outer `option`; `Option.bind` flattens the two layers rather than nesting
+  option-of-option. On the error path (or before a response existed) the
+  value is `None`.
+- The view maps it onto the `gen` phase: `durationMs = request_latency_ms`,
+  `durationSource = 'provider_telemetry'` (a new variant on the
+  `TurnPhase.durationSource` union, distinct from `'tool_call_log'` so the
+  tooltip names the real source). Absent → the existing `'not_recorded'` /
+  "측정 없음" render is preserved. No fabrication.
+- `ctx` and `reason` phases stay `'not_recorded'`: OAS `inference_telemetry`
+  has no isolated measurement for context assembly or thinking, so mapping
+  `request_latency_ms` onto them would mislabel the whole-call wall-clock.
+  This is an honest limit, not a gap to paper over.
+
+### §9.3 Boundary invariant (unchanged from §3)
+
+No OAS change. MASC reads `inference_telemetry` it already receives in the
+keeper turn result — the same consumption pattern as
+`keeper_hooks_oas.ml:287/326/417`, `lib/runtime/dashboard_oas_bridge.ml`,
+and `keeper_unified_turn_success.ml:253`. The telemetry record is an OAS
+generic asset (`types.mli:325` docstring: *"Parsed from the raw API
+response; never computed by downstream"*); `rg "MASC|masc|keeper"` in
+`oas/lib/api.ml` / `types.ml` returns 0 hits, so `patch_telemetry` is OAS's
+own transport pipeline, not MASC-requested code. Per
+`docs/OAS-MASC-BOUNDARY.md:16,50,52`, MASC consuming a public OAS response
+field is permitted; only adding MASC-specific code to OAS would not be.
+
+### §9.4 Non-goals
+
+- No phase-level split (`prefill_ms` / `ttfrc_ms` / `timings.{prompt_ms,
+  predicted_ms}`). Those are provider-native: `timings` is reported by
+  Ollama and llama-server only; `prefill_ms`/`ttfrc_ms` are wall-clock
+  derived on the streaming path and `None` non-streaming. Emitting them now
+  would show mostly-empty columns across the (predominantly cloud) keeper
+  fleet rather than measured signal — a Wave-2c candidate once a keeper's
+  runtime is known to populate them. `request_latency_ms` is the only field
+  every provider reports.
+- No derivation of `ctx`/`reason` durations by differencing
+  `request_latency_ms` against tool durations — that would fabricate a
+  measurement OAS does not provide (see §9.6).
+- No backfill: legacy rows decode `request_latency_ms` as `None`; the `gen`
+  phase renders "측정 없음" exactly as before.
+
+### §9.5 Migration
+
+Additive. `request_latency_ms` is a trailing optional field serialized only
+when `Some`; the decoder reads it via `opt_member` (absent → `None`). The
+writer gains one labeled argument (`~request_latency_ms`); the single call
+site passes it. The dashboard `TurnRecordEntry` gains one optional field
+and one `asNumber` decode line. The `gen` phase mapping and the new
+`'provider_telemetry'` variant on `TurnPhase.durationSource` are the only
+frontend logic changes (the `phaseDurationLabel` / `finalizePhaseOffsets`
+consumers already key off `durationMs != null`, so they pick the measured
+path automatically; only `phaseDurationTitle`'s switch gained an explicit
+case).
+
+### §9.6 Workaround guards (rejected per CLAUDE.md §워크어라운드)
+
+1. Deriving a `ctx` or `reason` duration as
+   `request_latency_ms − Σ tool durations` — constructs a measurement OAS
+   never made; silent on multi-SDK-turn keeper turns where multiple provider
+   calls occur. → leave those phases `'not_recorded'`.
+2. Defaulting `request_latency_ms` to 0 (the `keeper_hooks_oas.ml:417`
+   `Option.value ~default:0` pattern is for a tok/s log line, not a stored
+   record) — would render a 0ms bar indistinguishable from a real fast call.
+   → store `None`, render "측정 없음".
+3. Collapsing all phase timing into a single `total_turn_ms` — loses the
+   per-phase source attribution the waterfall exists to show. → one field,
+   one phase.
+
+### §9.7 Verification harness
+
+- Unit (`test/test_turn_record.ml`): round-trip of `request_latency_ms`
+  (`Some 1234`); the absent case (`None`) omits the JSON key and decodes
+  `None` (no fabricated duration on the wire).
+- Frontend: a grounded fixture (real `request_latency_ms`) renders a
+  `formatMsCompact` label on the `gen` phase with the `'provider_telemetry'`
+  tooltip, not "측정 없음"; an absent value still renders "측정 없음".
+- Behavioral: a turn whose provider call was measured shows a real `gen`
+  bar; an errored turn (no response) keeps `gen` as "측정 없음". tsc +
+  vitest.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -682,6 +682,24 @@ let run_turn
             }
           | Ok _ | Error _ -> { input_tokens = None; output_tokens = None }
         in
+        let request_latency_ms : int option =
+          (* RFC-0233 §9 — wall-clock duration of the provider call in
+             milliseconds, sourced from OAS
+             [inference_telemetry.request_latency_ms]. The OAS transport
+             layer ([complete_common.patch_telemetry] non-streaming,
+             [complete_stream] streaming) synthesizes it whenever a response
+             is produced. Both [inference_telemetry] and the field itself are
+             [option] (the transport layer may not synthesize a latency for
+             every code path), so [Option.bind] flattens the two layers
+             rather than nesting option-of-option; on the error path the
+             dashboard renders absence for the generation phase rather than a
+             fabricated duration. *)
+          match turn_result with
+          | Ok result ->
+              Option.bind result.inference_telemetry (fun t ->
+                t.request_latency_ms)
+          | Error _ -> None
+        in
         (* RFC-0233 §2.3 — views derive, no view-side repair: ground the
            inspector's [model] and [finish_reason] in the same refs the
            execution receipt already records this turn. [model] is the
@@ -714,6 +732,7 @@ let run_turn
           ~context_window:(Some max_context)
           ~price_input_per_million
           ~price_output_per_million
+          ~request_latency_ms
           ~sampling:
             { temperature = Some temperature
             ; top_p = None

--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -9,6 +9,7 @@ let write
       ~context_window
       ~price_input_per_million
       ~price_output_per_million
+      ~request_latency_ms
       ~sampling
       ~usage
       ~execution_ids
@@ -28,6 +29,7 @@ let write
     ; context_window
     ; price_input_per_million
     ; price_output_per_million
+    ; request_latency_ms
     ; sampling
     ; usage
     ; ts = Time_compat.now ()

--- a/lib/keeper/keeper_turn_record_writer.mli
+++ b/lib/keeper/keeper_turn_record_writer.mli
@@ -16,6 +16,7 @@ val write :
   context_window:int option ->
   price_input_per_million:float option ->
   price_output_per_million:float option ->
+  request_latency_ms:int option ->
   sampling:Turn_record.sampling ->
   usage:Turn_record.usage ->
   execution_ids:Ids.Execution_id.t list ->

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -30,6 +30,7 @@ type t =
   ; context_window : int option
   ; price_input_per_million : float option
   ; price_output_per_million : float option
+  ; request_latency_ms : int option
   ; sampling : sampling
   ; usage : usage
   ; ts : float
@@ -64,6 +65,7 @@ let to_json (r : t) : Yojson.Safe.t =
     @ opt_field "context_window" (fun v -> `Int v) r.context_window
     @ opt_field "price_input_per_million" (fun v -> `Float v) r.price_input_per_million
     @ opt_field "price_output_per_million" (fun v -> `Float v) r.price_output_per_million
+    @ opt_field "request_latency_ms" (fun v -> `Int v) r.request_latency_ms
     @ opt_field "temperature" (fun v -> `Float v) r.sampling.temperature
     @ opt_field "top_p" (fun v -> `Float v) r.sampling.top_p
     @ opt_field "max_tokens" (fun v -> `Int v) r.sampling.max_tokens
@@ -160,6 +162,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
       let* context_window = opt_member "context_window" fields as_int in
       let* price_input_per_million = opt_member "price_input_per_million" fields as_float in
       let* price_output_per_million = opt_member "price_output_per_million" fields as_float in
+      let* request_latency_ms = opt_member "request_latency_ms" fields as_int in
       let* temperature = opt_member "temperature" fields as_float in
       let* top_p = opt_member "top_p" fields as_float in
       let* max_tokens = opt_member "max_tokens" fields as_int in
@@ -182,6 +185,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; context_window
         ; price_input_per_million
         ; price_output_per_million
+        ; request_latency_ms
         ; sampling = { temperature; top_p; max_tokens; thinking_budget; enable_thinking }
         ; usage = { input_tokens; output_tokens }
         ; ts

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -66,6 +66,19 @@ type t =
   ; price_output_per_million : float option
     (* RFC-0233 §8 — USD per 1M output tokens, same source/absence rule as
        [price_input_per_million]. *)
+  ; request_latency_ms : int option
+    (* RFC-0233 §9 — wall-clock duration of the provider call in
+       milliseconds, sourced from OAS
+       [inference_telemetry.request_latency_ms] (the OAS transport layer
+       synthesizes it for every provider — [complete_common.patch_telemetry]
+       non-streaming, [complete_stream] streaming — so it is populated
+       whenever a response is produced). [None] on the error path or legacy
+       rows; the inspector renders absence rather than a fabricated duration
+       for the response-generation phase. Phase-level splits
+       (prefill/decode/ttfrc) are deliberately deferred: only the provider's
+       native timing objects carry them and most keepers' runtimes do not
+       report them, so emitting them would show mostly-empty columns rather
+       than measured signal. *)
   ; sampling : sampling
   ; usage : usage
   ; ts : float

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -50,6 +50,7 @@ let sample_record () : Turn_record.t =
   ; context_window = Some 131072
   ; price_input_per_million = Some 0.15
   ; price_output_per_million = Some 0.6
+  ; request_latency_ms = Some 1234
   ; sampling =
       { temperature = Some 0.3
       ; top_p = Some 0.9
@@ -94,6 +95,8 @@ let test_codec_roundtrip () =
       record.price_input_per_million decoded.price_input_per_million;
     check (option (float 0.0001)) "price_output_per_million"
       record.price_output_per_million decoded.price_output_per_million;
+    check (option int) "request_latency_ms round-trip" record.request_latency_ms
+      decoded.request_latency_ms;
     check (option (float 0.0001)) "temperature" record.sampling.temperature
       decoded.sampling.temperature;
     check (option (float 0.0001)) "top_p" record.sampling.top_p
@@ -118,6 +121,7 @@ let test_codec_optional_fields_absent () =
     ; context_window = None
     ; price_input_per_million = None
     ; price_output_per_million = None
+  ; request_latency_ms = None
     ; sampling =
         { temperature = None
         ; top_p = None
@@ -146,7 +150,9 @@ let test_codec_optional_fields_absent () =
      check bool "context_window key omitted when None" false
        (List.mem_assoc "context_window" fields);
      check bool "price_input_per_million key omitted when None" false
-       (List.mem_assoc "price_input_per_million" fields)
+       (List.mem_assoc "price_input_per_million" fields);
+     check bool "request_latency_ms key omitted when None" false
+       (List.mem_assoc "request_latency_ms" fields)
    | _ -> fail "to_json did not produce an object");
   match Turn_record.of_json json with
   | Error e -> failf "decode failed: %s" e
@@ -159,6 +165,8 @@ let test_codec_optional_fields_absent () =
       decoded.price_input_per_million;
     check (option (float 0.0001)) "price_output_per_million absent" None
       decoded.price_output_per_million;
+    check (option int) "request_latency_ms absent" None
+      decoded.request_latency_ms;
     check (option (float 0.0001)) "temperature absent" None
       decoded.sampling.temperature;
     check (option (float 0.0001)) "top_p absent" None decoded.sampling.top_p;


### PR DESCRIPTION
## Summary

RFC-0233 §9 — wires the **real** provider call wall-clock into the turn-record
phase waterfall so the response-generation (`gen`) phase stops rendering
"측정 없음" on every turn.

The keeper-turn inspector's phase waterfall had four phases (`ctx` /
`reason` / `tool` / `gen`); only `tool` carried a measured `duration_ms`.
The `gen` phase was hardcoded `durationMs: null, durationSource:
'not_recorded'`, and its own `meta` declared *"provider/OAS duration is not
recorded in turn-records"*. The measurement already existed in-process —
OAS `inference_telemetry.request_latency_ms`, synthesized by the transport
layer for every provider — but the record never stored it.

This PR stores `request_latency_ms : int option` on `Turn_record.t` (sourced
from `result.inference_telemetry` at the write site via `Option.bind`) and
maps it onto the `gen` phase with a new `durationSource` variant
`'provider_telemetry'`. Absent (error path / legacy) → the existing
"측정 없음" render is preserved. No fabricated duration.

## Design (why request_latency_ms only, not phase-level splits)

Grounding (4-agent workflow + 3-lens judge panel) established the provider
fill matrix:

- `request_latency_ms` — populated for **every** provider (transport
  wall-clock: `complete_common.patch_telemetry` non-streaming,
  `complete_stream` streaming).
- `prefill_ms` / `ttfrc_ms` — wall-clock on the streaming path only, `None`
  non-streaming.
- `timings.{prompt_ms, predicted_ms}` — Ollama / llama-server only.

Phase-level fields would show mostly-empty columns across the
(predominantly cloud) keeper fleet rather than measured signal. They are a
Wave-2c candidate once a keeper's runtime is known to populate them.
`request_latency_ms` is the only field every provider reports.

## Honest limits

- `ctx` (context assembly) and `reason` (thinking) phases stay
  `'not_recorded'`: OAS `inference_telemetry` has no isolated measurement
  for those phases. Mapping `request_latency_ms` onto them would mislabel
  the whole-call wall-clock. No fabricated differencing (rejected as a
  workaround, §9.6).
- `request_latency_ms` is the wall-clock of the keeper turn's response
  provider call, not a per-subturn breakdown.

## OAS boundary

No OAS change. MASC consumes a public OAS response field, the same pattern
as `keeper_hooks_oas.ml:417` (`Option.value ~default:0 t.request_latency_ms`
— but that default-0 is for a tok/s log line, not a stored record; we store
`None` and render "측정 없음"). `rg "MASC|masc|keeper"` in `oas/lib/api.ml` /
`types.ml` returns 0 hits.

## Files

- `lib/types/turn_record.{mli,ml}` — `request_latency_ms : int option` + codec
- `lib/keeper/keeper_turn_record_writer.{mli,ml}` — `~request_latency_ms` arg
- `lib/keeper/keeper_agent_run.ml` — `Option.bind result.inference_telemetry`
  extraction at the write site (sibling to the `usage` binding)
- `dashboard/src/api/dashboard.ts` — `TurnRecordEntry.request_latency_ms` + decode
- `dashboard/src/components/keeper-turn-inspector.ts` — `gen` phase mapping,
  new `'provider_telemetry'` variant on `TurnPhase.durationSource`
  (exhaustive `phaseDurationTitle` case; `phaseDurationLabel` /
  `finalizePhaseOffsets` already key off `durationMs != null`)
- `test/test_turn_record.ml` — round-trip + absent-case key omission
- `dashboard/src/components/keeper-turn-inspector.test.ts` — fixture +
  `1.2s` gen-phase assertion
- `docs/rfc/RFC-0233...md` §9 + `.tmp/rfc-0233-caller-context.md` §9 section

## Verification

- Build is CI-only (per the `/goal` constraint); no local dune / tsc / vitest.
- `test/test_turn_record.ml`: round-trip of `request_latency_ms` (`Some
  1234`); absent case omits the JSON key and decodes `None`.
- Dashboard CI: tsc + vite + vitest.

Co-Authored-By: Claude <noreply@anthropic.com>
