### PR TITLE
feat(fusion): serialize structured judge fields in board meta_json (PR1/4)

### DIFF
--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -71,6 +71,59 @@ let render_judge (j : Fusion_types.judge_synthesis) : string =
   add (Printf.sprintf "**Decision**: %s\n" (render_decision decision));
   Buffer.contents buf
 
+(* RFC-0252 §7/§8 — board meta_json의 judge 원소에서 구조화 종합(5섹션 + recommend/
+   missing)을 보존한다. 프론트(FusionJudgeEvidence, keeper-v2 fusion.jsx)가
+   consensus/contradictions/partial_coverage/unique_insights/blind_spots 섹션을
+   렌더하려면 이 필드들이 JSON에 있어야 한다 — synthesis markdown만 내보내면
+   프론트가 markdown을 재파싱해야 하는 string 분류기 안티패턴이 되므로 근본 fix는
+   구조화 그 자체를 직렬화하는 것이다.
+   ppx [@@deriving yojson]이 [judge_synthesis_to_yojson]을 자동 생성하지만, 그 결과는
+   OCaml 레코드 필드명(gap_topic/supporting_models/insight_text/from_model)을 그대로
+   JSON 키로 쓴다 — keeper-v2 스키마와 [fusion_judge_parse.ml]의 LLM-facing JSON 스키마
+   (topic/addressed_by/text/model)과 불일치. 그래서 parse(of_json)과 대칭되는
+   emit(to_json)을 수동으로 두어 SSOT를 LLM-facing 스키마로 정립한다. *)
+let claim_to_json (c : Fusion_types.claim) : Yojson.Safe.t =
+  `Assoc
+    [ ("text", `String c.Fusion_types.text)
+    ; ( "models"
+      , `List (List.map (fun m -> `String m) c.Fusion_types.supporting_models) )
+    ]
+
+let contradiction_to_json (c : Fusion_types.contradiction) : Yojson.Safe.t =
+  (* positions은 튜플 (model, stance) 리스트를 keeper-v2 스키마의 [[model, stance]]
+     배열로 직렬화 — 프론트 normalizeContradictionPositions의 Array 분기와 대칭. *)
+  `Assoc
+    [ ("topic", `String c.Fusion_types.topic)
+    ; ( "positions"
+      , `List
+          (List.map
+             (fun (m, stance) -> `Assoc [ ("model", `String m); ("stance", `String stance) ])
+             c.Fusion_types.positions) )
+    ]
+
+let coverage_gap_to_json (g : Fusion_types.coverage_gap) : Yojson.Safe.t =
+  (* missing : string option. 미상(None)은 null — 빈 문자열로 압축하지 않는다
+     (fusion_types.ml 주석). 프론트는 falsy missing을 가진 gap을 스킵하므로 렌더
+     누락이 아니라 의도적 생략이다. *)
+  `Assoc
+    [ ("topic", `String g.Fusion_types.gap_topic)
+    ; ( "addressed_by"
+      , `List (List.map (fun m -> `String m) g.Fusion_types.addressed_by) )
+    ; ("missing", match g.Fusion_types.missing with Some m -> `String m | None -> `Null)
+    ]
+
+let insight_to_json (i : Fusion_types.insight) : Yojson.Safe.t =
+  `Assoc
+    [ ("text", `String i.Fusion_types.insight_text)
+    ; ("model", `String i.Fusion_types.from_model)
+    ]
+
+let recommendation_to_json (r : Fusion_types.recommendation) : Yojson.Safe.t =
+  `Assoc
+    [ ("action", `String r.Fusion_types.action)
+    ; ("rationale", `String r.Fusion_types.rationale)
+    ]
+
 (* board post 증거의 보존 기간. 심의 증거는 transient 알림(24h)보다 오래 둬 사후
    리뷰가 가능하도록 1주로 둔다 (Magic Number 회피 — named 상수). *)
 let board_post_ttl_hours = 24 * 7
@@ -106,12 +159,37 @@ let judge_meta (judge : (Fusion_types.judge_synthesis, string) result) : Yojson.
      증거의 judge 서술 필드다 (no-inline-ok-envelope 가드 대상과 별개 개념). *)
   match judge with
   | Ok j ->
-    `Assoc
+    let { Fusion_types.consensus; contradictions; partial_coverage; unique_insights
+        ; blind_spots; resolved_answer; decision } =
+      j
+    in
+    (* base 7필드: status/decision/resolved_answer/synthesis(평탄화 markdown, 호환) +
+       구조화 5섹션. synthesis를 남기는 건 구형 프론트/로그 호환 — 구조화 필드가
+       canonical이므로 신규 프론트는 5섹션을 우선 소비한다. *)
+    let base =
       [ ("status", `String "synthesized")
-      ; ("decision", `String (render_decision j.Fusion_types.decision))
-      ; ("resolved_answer", `String j.Fusion_types.resolved_answer)
+      ; ("decision", `String (render_decision decision))
+      ; ("resolved_answer", `String resolved_answer)
       ; ("synthesis", `String (render_judge j))
+      ; ("consensus", `List (List.map claim_to_json consensus))
+      ; ("contradictions", `List (List.map contradiction_to_json contradictions))
+      ; ("partial_coverage", `List (List.map coverage_gap_to_json partial_coverage))
+      ; ("unique_insights", `List (List.map insight_to_json unique_insights))
+      ; ("blind_spots", `List (List.map (fun b -> `String b) blind_spots))
       ]
+    in
+    (* decision variant에 따라 keeper-v2 스키마의 최상위 recommend/missing를 붙인다.
+       Answer → 추가 없음, Recommend → recommend:{action,rationale},
+       Insufficient → missing:[...]. 프론트 normalizeRecommendation/normalizeJudge 가
+       judge.recommend / judge.missing 을 읽는다. *)
+    let with_decision_fields =
+      match decision with
+      | Fusion_types.Recommend r -> ("recommend", recommendation_to_json r) :: base
+      | Fusion_types.Insufficient { missing_for_decision } ->
+        ("missing", `List (List.map (fun m -> `String m) missing_for_decision)) :: base
+      | Fusion_types.Answer _ -> base
+    in
+    `Assoc with_decision_fields
   | Error e -> `Assoc [ ("status", `String "failed"); ("error", `String e) ]
 
 (* RFC-0266: 심의 완료 시 호출 키퍼를 typed [Fusion_completed] stimulus로 깨운다.

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -13,6 +13,20 @@
 
     설계 SSOT: docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md §8 *)
 
+(** [panel_meta o] — 패널 결과 한 건을 board meta_json의 [panel] 배열 원소로 직렬화.
+    [Answered] → {model; status="answered"; answer; input_tokens; output_tokens},
+    [Failed] → {model; status="failed"; reason_code; reason_detail; reason}.
+    스키마는 프론트(board/fusion-evidence, fusion/fusion-surface)가 소비하는 공개 계약. *)
+val panel_meta : Fusion_types.panel_outcome -> Yojson.Safe.t
+
+(** [judge_meta judge] — 심판 종합을 board meta_json의 [judge] 원소로 직렬화.
+    [Ok] → status/decision/resolved_answer/synthesis(평탄화 markdown, 구형 호환) +
+    구조화 5섹션(consensus/contradictions/partial_coverage/unique_insights/blind_spots) +
+    decision variant에 따른 최상위 [recommend] | [missing]. [Error] → {status="failed"; error}.
+    구조화 필드 키(text/models/topic/addressed_by/...)는 {!Fusion_judge_parse}의
+    LLM-facing JSON 스키마와 대칭이며, 프론트가 markdown 재파싱 없이 5섹션을 렌더한다. *)
+val judge_meta : (Fusion_types.judge_synthesis, string) result -> Yojson.Safe.t
+
 (** judge 결론을 키퍼 메인 chat lane에 남기고 board에 패널/심판 구조화 증거를 post한다.
 
     chat lane: judge가 [Ok]면 "결론 — resolved_answer" 한 줄을 메인 conversation에

--- a/test/dune
+++ b/test/dune
@@ -678,6 +678,14 @@
  (modules test_fusion_status_tool)
  (libraries masc_test_deps masc.fusion_core))
 
+; RFC-0252 §8 — judge_meta/panel_meta structured serialization. Needs
+; masc.fusion_core for Fusion_types constructors (Answer/Recommend/Insufficient,
+; judge_synthesis record) + Masc.Fusion_sink for the public meta serializers.
+(test
+ (name test_fusion_sink_meta)
+ (modules test_fusion_sink_meta)
+ (libraries masc_test_deps masc.fusion_core))
+
 ; RFC-0207: per-keeper LLM runtime routing (persona [model] selection + driver fail-fast).
 
 (test

--- a/test/test_fusion_sink_meta.ml
+++ b/test/test_fusion_sink_meta.ml
@@ -1,0 +1,150 @@
+(* RFC-0252 §8 — judge_meta 가 board meta_json 에 구조화 5섹션을 보존하는지 핀한다.
+
+   프론트(FusionJudgeEvidence, keeper-v2 fusion.jsx)가 consensus/contradictions/
+   partial_coverage/unique_insights/blind_spots + decision-variant 최상위
+   recommend|missing 를 소비한다. 키 매핑(OCaml 레코드명 → LLM-facing JSON 키:
+   gap_topic→topic, insight_text→text, from_model→model, supporting_models→models)이
+   틀리면 프론트가 빈 배열만 보게 되므로 이 테스트가 회귀를 잡는다. ppx 자동
+   직렬화가 OCaml 필드명을 그대로 쓰는 실수를 방어하는 것이 이 테스트의 핵심 가치다. *)
+
+open Alcotest
+open Fusion_types
+
+let lookup k a = List.find_opt (fun (k', _) -> String.equal k k') a
+
+let keys a = List.map fst a
+
+let string_field a k =
+  match lookup k a with Some (_, `String s) -> Some s | _ -> None
+
+let list_field a k =
+  match lookup k a with Some (_, `List l) -> Some l | _ -> None
+
+let assoc_of = function `Assoc a -> a | _ -> []
+
+let full_synthesis ?(decision = Answer "a") () : judge_synthesis =
+  { consensus = [ { text = "c1"; supporting_models = [ "m1"; "m2" ] } ]
+  ; contradictions =
+      [ { topic = "t1"; positions = [ ("m1", "yes"); ("m2", "no") ]; evidence = [] } ]
+  ; partial_coverage = [ { gap_topic = "g1"; addressed_by = [ "m1" ]; missing = Some "x" } ]
+  ; unique_insights = [ { insight_text = "u1"; from_model = "m2" } ]
+  ; blind_spots = [ "b1" ]
+  ; resolved_answer = "RA"
+  ; decision }
+
+(* --- 5섹션 키 존재 + 기존 평탄화 필드 보존 --- *)
+
+let test_ok_has_five_sections () =
+  let a = assoc_of (Masc.Fusion_sink.judge_meta (Ok (full_synthesis ()))) in
+  let ks = keys a in
+  check bool "consensus key" true (List.mem "consensus" ks);
+  check bool "contradictions key" true (List.mem "contradictions" ks);
+  check bool "partial_coverage key" true (List.mem "partial_coverage" ks);
+  check bool "unique_insights key" true (List.mem "unique_insights" ks);
+  check bool "blind_spots key" true (List.mem "blind_spots" ks);
+  (* 구형 호환 필드도 보존 — synthesis markdown 제거는 별도 마이그레이션. *)
+  check (option string) "resolved_answer preserved" (Some "RA") (string_field a "resolved_answer");
+  check bool "synthesis preserved" true (Option.is_some (string_field a "synthesis"))
+
+(* --- decision variant → 최상위 recommend|missing --- *)
+
+let test_answer_has_no_recommend_missing () =
+  let a =
+    assoc_of
+      (Masc.Fusion_sink.judge_meta (Ok (full_synthesis ~decision:(Answer "a") ())))
+  in
+  let ks = keys a in
+  check bool "no recommend on Answer" false (List.mem "recommend" ks);
+  check bool "no missing on Answer" false (List.mem "missing" ks)
+
+let test_recommend_emits_top_level_recommend () =
+  let d = Recommend { action = "do"; rationale = "why" } in
+  let a = assoc_of (Masc.Fusion_sink.judge_meta (Ok (full_synthesis ~decision:d ()))) in
+  match lookup "recommend" a with
+  | Some (_, `Assoc r) ->
+    check (option string) "recommend.action" (Some "do") (string_field r "action");
+    check (option string) "recommend.rationale" (Some "why") (string_field r "rationale")
+  | _ -> fail "recommend field missing or not an object"
+
+let test_insufficient_emits_top_level_missing () =
+  let d = Insufficient { missing_for_decision = [ "a"; "b" ] } in
+  let a = assoc_of (Masc.Fusion_sink.judge_meta (Ok (full_synthesis ~decision:d ()))) in
+  (match list_field a "missing" with
+   | Some [ `String x; `String y ] ->
+     check string "missing[0]" "a" x;
+     check string "missing[1]" "b" y
+   | _ -> fail "missing field missing or wrong shape")
+
+(* --- 키 매핑 정확성 (이 테스트의 핵심 가치) --- *)
+
+let test_key_mapping_claim () =
+  (* supporting_models → models *)
+  let a = assoc_of (Masc.Fusion_sink.judge_meta (Ok (full_synthesis ()))) in
+  match list_field a "consensus" with
+  | Some (`Assoc c0 :: _) ->
+    check (option string) "claim.text" (Some "c1") (string_field c0 "text");
+    (match lookup "models" c0 with
+     | Some (_, `List ms) -> check int "claim.models length" 2 (List.length ms)
+     | _ -> fail "models key missing — did ppx field name leak?");
+    check bool "no supporting_models key" false (List.mem "supporting_models" (keys c0))
+  | _ -> fail "consensus[0] missing"
+
+let test_key_mapping_coverage_and_insight () =
+  let a = assoc_of (Masc.Fusion_sink.judge_meta (Ok (full_synthesis ()))) in
+  (* gap_topic → topic *)
+  (match list_field a "partial_coverage" with
+   | Some (`Assoc g0 :: _) ->
+     check (option string) "gap.topic" (Some "g1") (string_field g0 "topic");
+     check (option string) "gap.addressed_by[0]" (Some "m1")
+       (match list_field g0 "addressed_by" with
+        | Some (`String m :: _) -> Some m
+        | _ -> None);
+     check (option string) "gap.missing" (Some "x") (string_field g0 "missing");
+     check bool "no gap_topic key" false (List.mem "gap_topic" (keys g0))
+   | _ -> fail "partial_coverage[0] missing");
+  (* insight_text → text, from_model → model *)
+  (match list_field a "unique_insights" with
+   | Some (`Assoc i0 :: _) ->
+     check (option string) "insight.text" (Some "u1") (string_field i0 "text");
+     check (option string) "insight.model" (Some "m2") (string_field i0 "model");
+     check bool "no insight_text key" false (List.mem "insight_text" (keys i0));
+     check bool "no from_model key" false (List.mem "from_model" (keys i0))
+   | _ -> fail "unique_insights[0] missing")
+
+let test_contradiction_positions () =
+  let a = assoc_of (Masc.Fusion_sink.judge_meta (Ok (full_synthesis ()))) in
+  (match list_field a "contradictions" with
+   | Some (`Assoc ct0 :: _) ->
+     check (option string) "contra.topic" (Some "t1") (string_field ct0 "topic");
+     (match list_field ct0 "positions" with
+      | Some (`Assoc p0 :: _) ->
+        check (option string) "pos.model" (Some "m1") (string_field p0 "model");
+        check (option string) "pos.stance" (Some "yes") (string_field p0 "stance")
+      | _ -> fail "positions missing")
+   | _ -> fail "contradictions[0] missing")
+
+let test_error_branch () =
+  let a = assoc_of (Masc.Fusion_sink.judge_meta (Error "boom")) in
+  check (option string) "status failed" (Some "failed") (string_field a "status");
+  check (option string) "error message" (Some "boom") (string_field a "error");
+  check bool "no consensus on error" false (List.mem "consensus" (keys a))
+
+let () =
+  run "Fusion_sink.judge_meta"
+    [ ( "structured"
+      , [ test_case "ok_has_five_sections" `Quick test_ok_has_five_sections
+        ; test_case "answer_has_no_recommend_missing" `Quick
+            test_answer_has_no_recommend_missing
+        ; test_case "recommend_emits_top_level" `Quick
+            test_recommend_emits_top_level_recommend
+        ; test_case "insufficient_emits_top_level_missing" `Quick
+            test_insufficient_emits_top_level_missing
+        ; test_case "error_branch" `Quick test_error_branch
+        ] )
+    ; ( "key_mapping"
+      , [ test_case "claim_text_models" `Quick test_key_mapping_claim
+        ; test_case "coverage_gap_and_insight" `Quick
+            test_key_mapping_coverage_and_insight
+        ; test_case "contradiction_positions" `Quick test_contradiction_positions
+        ] )
+    ]


### PR DESCRIPTION
## What

RFC-0252 §8 names a dashboard gap: the fusion board post carries panel answers + judge synthesis in `meta_json`, but the frontend had no surface to render them. This PR fixes the **deeper backend defect** underneath that gap — `Fusion_sink.judge_meta` emitted only a flattened markdown `synthesis` string, dropping the five structured judge fields (`consensus`, `contradictions`, `partial_coverage`, `unique_insights`, `blind_spots`).

The frontend `FusionJudgeEvidence` (dashboard) that renders those 5 sections already exists but read **empty arrays** against real board data, because the structured fields never left the server. PR1 makes them leave.

## Why (root fix, not a workaround)

`judge_synthesis` is a closed OCaml record holding all 7 fields (`fusion_types.ml:94`). `render_judge` already destructures them into markdown. The minimal, type-honest fix is to serialize the structured fields into the board `meta_json` so the frontend consumes typed data — not to re-tokenize the flattened markdown back into sections on the client (that would be a classifier anti-pattern).

JSON keys follow the **LLM-facing schema** in `fusion_judge_parse.ml:9-14` (`text`, `models`, `topic`, `addressed_by`, ...), not the OCaml record field names that ppx `[@@deriving yojson]` would emit (`supporting_models`, `gap_topic`, `insight_text`, `from_model`). This makes `of_json` (parse) and the new emit symmetric on a single SSOT schema.

`recommend` / `missing` are promoted to top-level keys on the `Recommend` / `Insufficient` decision variants (keeper-v2 `fusion.jsx` shape).

## Changes

- `lib/fusion/fusion_sink.ml` — `claim_to_json`, `contradiction_to_json`, `coverage_gap_to_json`, `insight_to_json`, `recommendation_to_json` helpers; `judge_meta` Ok branch now emits the 5 structured sections + decision-variant `recommend`|`missing`. `synthesis` (flattened markdown) kept for old frontend/log compat; structured fields are canonical.
- `lib/fusion/fusion_sink.mli` — expose `panel_meta` / `judge_meta` as public schema contracts.
- `test/test_fusion_sink_meta.ml` — 8 tests pin key mapping, 5 sections, decision variants, error branch. Catches a ppx-field-name leak regression.
- `test/dune` — register the new test with `masc.fusion_core` deps.

## Verification

- `dune build --root .` — exit 0.
- `dune exec --root . test/test_fusion_sink_meta.exe` — 8/8 tests pass.

## Scope / not in this PR

This is PR1 of a stacked series toward Fusion surface parity with the keeper-v2 design:
- **PR2** (frontend): wire the currently-unimported `fusion-v2.css`, basic alignment.
- **PR3** (frontend): keeper-v2 visual parity + per-class padding/margin audit.
- **PR4** (frontend): denied registry card, judge model/decision badge, panel conf/expand, sink tracks.

OAS boundary respected (RFC-0252 §6) — changes are in `lib/fusion/` (MASC side); OAS sees only N independent agents.

RFC: RFC-0252 (fusion panel-judge deliberation). Not a credential/operator/sandbox/hooks subsystem PR.

Co-Authored-By: Claude <noreply@anthropic.com>
