### PR TITLE
fix(server): MCP session persist wrote nothing + leaked fd on error

### DIFF
--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -169,8 +169,14 @@ let sessions_file_path () =
 let save_sessions_to_file () =
   let path = sessions_file_path () in
   let dir = Filename.dirname path in
-  if not (Stdlib.Sys.file_exists dir) then
-    try Unix.mkdir dir 0o755 with Unix.Unix_error _ -> ();
+  (* [begin]/[end] close the [then] branch so the trailing [;] sequences into
+     the rest of the function. Without them, OCaml absorbs [; let versions =
+     ... in <body>] into the [Unix.Unix_error] handler, so the serialize/write
+     ran only when [mkdir] raised — i.e. never on the happy path (dir already
+     present or mkdir succeeds), silently persisting nothing. *)
+  if not (Stdlib.Sys.file_exists dir) then begin
+    try Unix.mkdir dir 0o755 with Unix.Unix_error _ -> ()
+  end;
   let versions = Atomic.get protocol_version_by_session in
   let profiles = Atomic.get mcp_profile_by_session in
   let timestamps = Atomic.get session_last_active_sse in
@@ -229,9 +235,26 @@ let save_sessions_to_file () =
   let json = `Assoc [ "sessions", `Assoc json_entries ] in
   let tmp_path = path ^ ".tmp" in
   let oc = open_out tmp_path in
-  output_string oc (Yojson.Basic.to_string json);
-  output_char oc '\n';
-  close_out oc;
+  (* Release the fd on every exit path. A mid-write/flush [Sys_error] (disk
+     full, I/O error) previously skipped [close_out] and leaked [oc]; this
+     runs once per reap cycle and the sole caller swallows the error, so the
+     leak accumulated across cycles until fd exhaustion. [flush] stays inside
+     the body so a flush failure still surfaces (caught below, tmp removed,
+     re-raised) rather than renaming a truncated file; [close_out_noerr] in
+     the finally only releases the fd. Mirrors [atomic_write_file] in
+     server_routes_http_routes_sidecar.ml. *)
+  (try
+     Eio_guard.protect
+       ~finally:(fun () -> close_out_noerr oc)
+       (fun () ->
+         output_string oc (Yojson.Basic.to_string json);
+         output_char oc '\n';
+         flush oc)
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+     (try Sys.remove tmp_path with Sys_error _ -> ());
+     raise exn);
   Unix.rename tmp_path path
 
 (** Load session state from disk. Restores protocol versions, profiles,

--- a/test/dune
+++ b/test/dune
@@ -1130,6 +1130,14 @@
  (modules test_voice_config)
  (libraries alcotest yojson masc.voice_config))
 
+; MCP HTTP session persistence: save/forget/load round-trip through the
+; fd-safe write path (close_out_noerr finally guard).
+
+(test
+ (name test_server_mcp_session_persist)
+ (modules test_server_mcp_session_persist)
+ (libraries alcotest masc_server unix))
+
 ; Focused dashboard nudge feed projection.
 
 (test

--- a/test/test_server_mcp_session_persist.ml
+++ b/test/test_server_mcp_session_persist.ml
@@ -1,0 +1,64 @@
+(** Round-trip persistence test for MCP HTTP session state.
+
+    Exercises [Server_mcp_transport_http_session.save_sessions_to_file] and
+    [load_sessions_from_file] through the fd-safe write path: register session
+    state, persist, forget the in-memory entry, reload from disk, and assert it
+    was restored.
+
+    The fd-leak fix ([close_out_noerr] in a finally guard) cannot be exercised
+    deterministically from a black-box test: the leak only triggers on a
+    mid-write/flush I/O error (disk full), which is not reproducible here. This
+    test locks the happy-path contract the refactor must preserve — a
+    save/forget/load cycle restores state and leaves no [.tmp] residue. *)
+
+open Alcotest
+module Session = Server_mcp_transport_http_session
+
+(* Run [f] with the process cwd pointed at a fresh temp directory so the
+   base-path resolver (Sys.getcwd-driven) writes the persistence file under it.
+   A dedicated test executable keeps the resolver's base-path cache clean, so
+   the first resolution (inside [f]) binds to this temp dir. *)
+let with_temp_cwd f =
+  let unique =
+    Printf.sprintf "masc-session-persist-%d-%d" (Unix.getpid ())
+      (int_of_float (Unix.gettimeofday () *. 1000.))
+  in
+  let tmp = Filename.concat (Filename.get_temp_dir_name ()) unique in
+  Unix.mkdir tmp 0o755;
+  let prev = Sys.getcwd () in
+  Sys.chdir tmp;
+  Fun.protect
+    ~finally:(fun () ->
+      Sys.chdir prev;
+      let rec rm path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then begin
+            Array.iter (fun e -> rm (Filename.concat path e)) (Sys.readdir path);
+            (try Unix.rmdir path with _ -> ())
+          end
+          else try Sys.remove path with _ -> ()
+      in
+      rm tmp)
+    (fun () -> f tmp)
+
+let test_roundtrip () =
+  with_temp_cwd (fun _tmp ->
+    let sid = "persist-roundtrip-session" in
+    let version = Session.mcp_protocol_version_default in
+    Session.remember_protocol_version sid version;
+    check bool "session known before save" true (Session.is_known_session sid);
+    Session.save_sessions_to_file ();
+    let path = Session.sessions_file_path () in
+    check bool "persistence file written" true (Sys.file_exists path);
+    check bool "no .tmp residue after save" false
+      (Sys.file_exists (path ^ ".tmp"));
+    (* Drop in-memory state, then restore it from disk. *)
+    Session.forget_mcp_session sid;
+    check bool "session forgotten" false (Session.is_known_session sid);
+    Session.load_sessions_from_file ();
+    check bool "session restored from disk" true (Session.is_known_session sid))
+
+let () =
+  run "server_mcp_session_persist"
+    [ ( "persistence"
+      , [ test_case "save/forget/load round-trip" `Quick test_roundtrip ] ) ]


### PR DESCRIPTION
## 무엇을 / 왜

`save_sessions_to_file`(`lib/server/server_mcp_transport_http_session.ml`)에 **한 함수 안 두 결함**. 둘 다 save→forget→load round-trip 테스트로 발견.

### 1. write가 실행되지 않음 (dangling semicolon — 더 심각)

```ocaml
if not (Sys.file_exists dir) then
  try Unix.mkdir dir 0o755 with Unix.Unix_error _ -> ();
let versions = ... in
...
Unix.rename tmp_path path
```

OCaml은 `try ... with` 핸들러를 우측으로 최대 확장한다. 그래서 `; let versions = ... in <함수 나머지 전체>`가 **`Unix.Unix_error` 핸들러 본문으로 흡수**된다. 결과: 직렬화+write는 **`mkdir`가 예외를 던질 때만** 실행 — 즉 happy path에선 절대 실행 안 됨(`dir`이 이미 존재하거나 mkdir 성공). 프로덕션에선 `.masc`가 항상 존재 → `if`가 false → **함수가 아무것도 영속화하지 않음**.

이 무동작이 드러나지 않은 이유: `load_sessions_from_file`이 파일 부재를 "clean 시작"으로 처리(클라이언트가 재handshake)하기 때문 — graceful degradation 뒤에 숨음.

**Fix**: then-branch를 `begin`/`end`로 닫아 trailing `;`가 함수 나머지로 sequence되게 함.

### 2. (이제 도달 가능해진) write 경로의 fd leak

bare `open_out` + write + `close_out`에 finally 가드가 없었다. write 도중 또는 close 시점 flush의 `Sys_error`(disk full / I/O error)가 `close_out`를 건너뛰어 **fd 누수** + tmp 잔존. 이 write는 session reap cycle(주기적 백그라운드 루프)마다 1회 실행되고 유일 caller가 `Sys_error`를 잡아 로그만 남기므로 → 누수가 누적되어 프로세스 fd 한계 도달 시 이후 모든 socket accept/file open 실패 = **프로세스 전역 장애**.

**Fix**: `Eio_guard.protect`의 finally(`close_out_noerr`)로 모든 종료 경로에서 fd 해제, 실패 시 tmp 제거 후 **re-raise**. `flush`를 protected body에 두어 flush 실패도 표면화(truncated 파일을 rename하지 않음). `Eio.Cancel.Cancelled`는 변경 없이 전파. 검증된 sibling idiom(`server_routes_http_routes_sidecar.ml:245` `atomic_write_file`, 이미 CI 통과)을 미러.

## 검증

- `dune build --root . test/test_server_mcp_session_persist.exe` exit 0 (worktree root, `--root .`로 main 아닌 worktree 빌드 강제).
- `ocamlformat --check` 두 .ml 파일 exit 0.
- `test_server_mcp_session_persist`: save → forget → load round-trip이 disk 경유로 state를 복원하고 `.tmp` 잔여물 없음을 확인. **이 테스트는 fix 이전 코드에선 FAIL**(write가 실행 안 됨 — 결함 1을 표면화), fix 이후 `Test Successful`.
- fd-leak error-branch(disk-full-mid-write)는 black-box로 결정론적 재현 불가 — fix는 구조적(검증된 sibling idiom 미러)이고 happy path는 round-trip 테스트로 lock.

## 범위 / 경계

- `lib/server/server_mcp_transport_http_session.ml` 1개 함수 + 신규 테스트 1개 + `test/dune` 등록. 다른 모듈 무관.
- RFC-gate 비대상: credential/operator-control/keeper-sandbox/dashboard-credential/hooks/workflow 경로 아님(서버 MCP transport 세션 영속화). `pr-rfc-check.sh` PASS.

## Workaround self-check

워크어라운드 **아님** — 두 silent 결함의 근본 fix.
- telemetry-as-fix ❌ (counter 아님). string 분류기 ❌. cap·cooldown·dedup·repair ❌.
- N-of-M ❌ — resource-leak-on-error-path 클래스의 유일 미보호 사이트(적대적 hunt가 lib/keeper·lib/server의 fd/lock/switch/registry 획득을 전수 추적, 나머지 전부 보호됨 확인). dangling-`;`도 이 함수 1개. #21990(write_json silent-swallow)과 다른 클래스.
- catch-all `_ ->` ❌ — `with exn`은 tmp 정리 후 **re-raise**(silent 흡수 아님), `Cancelled` 명시 전파.

## 발견 경로

적대적 resource-leak hunt(단일 agent, error-path 미해제 추적, refute-default verify)가 fd-leak(결함 2)을 confirmed. 회귀 테스트 작성 중 round-trip이 FAIL → 직렬화/write가 도달 불가임을 노출 → dangling-`;`(결함 1) 발견. file:line·핸들러 흡수 파싱·caller swallow·sibling 패턴을 코드로 직접 재검증.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
