### PR TITLE
fix(server): bound dashboard metrics caches keyed by client window param

### DIFF
--- a/lib/server/server_routes_http_routes_provider_runs.ml
+++ b/lib/server/server_routes_http_routes_provider_runs.ml
@@ -12,6 +12,14 @@ type dashboard_json_cache_entry =
   }
 
 let dashboard_metrics_cache_ttl_s = 60.0
+
+(* Per-cache entry ceiling. The [window]/[bucket_min] query params are folded
+   into the cache key unclamped (see [add_routes]), and these endpoints are
+   public reads, so distinct client-supplied values would otherwise grow each
+   table without bound (memory-exhaustion vector). The legitimate dashboard
+   uses a small fixed set of windows, so this ceiling is never reached in
+   normal operation; past it, the least-recently-refreshed entry is evicted. *)
+let dashboard_metrics_cache_max_entries = 128
 let dashboard_metrics_cache_mu = Stdlib.Mutex.create ()
 let dashboard_model_metrics_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
 let dashboard_cost_latency_cache : (string, dashboard_json_cache_entry) Hashtbl.t = Hashtbl.create 8
@@ -84,6 +92,9 @@ let cached_dashboard_json ~sync_first ~sw ~cache ~key ~placeholder ~compute =
       match Hashtbl.find_opt cache key with
       | Some entry -> entry
       | None ->
+          evict_oldest_if_full
+            ~max_entries:dashboard_metrics_cache_max_entries
+            ~age_of:(fun e -> e.updated_at) cache;
           let entry = new_cache_entry () in
           Hashtbl.add cache key entry;
           entry

--- a/lib/server_utils.ml
+++ b/lib/server_utils.ml
@@ -20,6 +20,25 @@ let bool_query_param request key ~default =
 
 let clamp ~min_v ~max_v v = max min_v (min max_v v)
 
+(** Bound an in-memory cache keyed partly by client-supplied input. When
+    [cache] holds at least [max_entries] entries, evict the single entry with
+    the smallest [age_of] (the least-recently-refreshed), so a caller that
+    inserts on every miss keeps the table bounded over process lifetime. Call
+    immediately before adding a new key. No-op below the cap. *)
+let evict_oldest_if_full ~max_entries ~age_of cache =
+  if Hashtbl.length cache >= max_entries then
+    match
+      Hashtbl.fold
+        (fun k v acc ->
+          let age = age_of v in
+          match acc with
+          | Some (_, oldest) when oldest <= age -> acc
+          | Some _ | None -> Some (k, age))
+        cache None
+    with
+    | Some (k, _) -> Hashtbl.remove cache k
+    | None -> ()
+
 let take = List.take
 let drop = List.drop
 

--- a/lib/server_utils.mli
+++ b/lib/server_utils.mli
@@ -33,6 +33,13 @@ val clamp : min_v:int -> max_v:int -> int -> int
 (** [clamp ~min_v ~max_v v] returns [v] bounded to
     [\[min_v, max_v\]]. *)
 
+val evict_oldest_if_full :
+  max_entries:int -> age_of:('a -> float) -> ('k, 'a) Hashtbl.t -> unit
+(** [evict_oldest_if_full ~max_entries ~age_of cache] removes the single entry
+    with the smallest [age_of] value when [cache] already holds [max_entries]
+    or more, otherwise a no-op. Call before inserting a new key to keep a cache
+    keyed partly by client input bounded over process lifetime. *)
+
 val take : int -> 'a list -> 'a list
 (** [take n xs] is [List.take n xs] re-exported so callers using
     [open Server_utils] do not need to also open Stdlib's [List]

--- a/test/dune
+++ b/test/dune
@@ -1138,6 +1138,13 @@
  (modules test_server_mcp_session_persist)
  (libraries alcotest masc_server unix))
 
+; Bounded-cache eviction guard for client-keyed dashboard metrics caches.
+
+(test
+ (name test_server_utils_bounded_cache)
+ (modules test_server_utils_bounded_cache)
+ (libraries alcotest masc))
+
 ; Focused dashboard nudge feed projection.
 
 (test

--- a/test/test_server_utils_bounded_cache.ml
+++ b/test/test_server_utils_bounded_cache.ml
@@ -1,0 +1,63 @@
+(** Tests for [Server_utils.evict_oldest_if_full] — the bound that keeps
+    client-keyed dashboard caches from growing without limit. *)
+
+open Alcotest
+
+(* Values are their own age, so [~age_of:Fun.id] makes the smallest float the
+   "oldest" entry. *)
+let age_of = Fun.id
+
+let test_noop_below_cap () =
+  let cache = Hashtbl.create 8 in
+  Hashtbl.replace cache "a" 1.0;
+  Hashtbl.replace cache "b" 2.0;
+  Masc.Server_utils.evict_oldest_if_full ~max_entries:10 ~age_of cache;
+  check int "no eviction below cap" 2 (Hashtbl.length cache);
+  check bool "a kept" true (Hashtbl.mem cache "a");
+  check bool "b kept" true (Hashtbl.mem cache "b")
+
+let test_evicts_oldest_at_cap () =
+  let cache = Hashtbl.create 8 in
+  Hashtbl.replace cache "a" 10.0;
+  Hashtbl.replace cache "b" 20.0;
+  Hashtbl.replace cache "c" 30.0;
+  Hashtbl.replace cache "d" 40.0;
+  (* length (4) >= max_entries (4): evict the smallest-age entry ("a"). *)
+  Masc.Server_utils.evict_oldest_if_full ~max_entries:4 ~age_of cache;
+  check int "one entry evicted at cap" 3 (Hashtbl.length cache);
+  check bool "oldest (a) removed" false (Hashtbl.mem cache "a");
+  check bool "newest (d) kept" true (Hashtbl.mem cache "d");
+  check bool "b kept" true (Hashtbl.mem cache "b");
+  check bool "c kept" true (Hashtbl.mem cache "c")
+
+(* Insert-on-miss with eviction-before-insert keeps the table at the cap no
+   matter how many distinct keys arrive — the unbounded-growth scenario. *)
+let test_stays_bounded_under_churn () =
+  let cache = Hashtbl.create 8 in
+  let max_entries = 16 in
+  for i = 1 to max_entries + 500 do
+    Masc.Server_utils.evict_oldest_if_full ~max_entries ~age_of cache;
+    Hashtbl.replace cache (string_of_int i) (float_of_int i)
+  done;
+  check bool "bounded at or below cap" true
+    (Hashtbl.length cache <= max_entries);
+  (* The survivors are the most-recently-inserted keys (highest ages). *)
+  check bool "latest key present" true
+    (Hashtbl.mem cache (string_of_int (max_entries + 500)));
+  check bool "earliest key evicted" false (Hashtbl.mem cache "1")
+
+let test_empty_cache () =
+  let cache : (string, float) Hashtbl.t = Hashtbl.create 8 in
+  Masc.Server_utils.evict_oldest_if_full ~max_entries:4 ~age_of cache;
+  check int "empty stays empty" 0 (Hashtbl.length cache)
+
+let () =
+  run "server_utils_bounded_cache"
+    [ ( "evict_oldest_if_full"
+      , [ test_case "no-op below cap" `Quick test_noop_below_cap
+        ; test_case "evicts oldest at cap" `Quick test_evicts_oldest_at_cap
+        ; test_case "stays bounded under churn" `Quick
+            test_stays_bounded_under_churn
+        ; test_case "empty cache no-op" `Quick test_empty_cache
+        ] )
+    ]


### PR DESCRIPTION
## 무엇을 / 왜

세 public read 엔드포인트가 client `window`(+`bucket_min`) 쿼리 파라미터를 **clamp 없이** cache key로 사용한다:

- `/api/v1/models/metrics` — key `[base_path; window; bucket_min]` (`server_routes_http_routes_provider_runs.ml:174-179`)
- `/api/v1/dashboard/keeper-costs` — key `[base_path; window]` (`:200-202`)
- `/api/v1/dashboard/cost-latency` — key `[base_path; window]` (`:225-230`)

`window = int_query_param req "window"`(`server_utils.ml:7`)는 임의 정수를 그대로 반환(clamp 없음). `cached_dashboard_json`(`:84-89`)은 miss마다 `Hashtbl.add`하고 **remove/evict/cap이 전혀 없다**(`rg 'Hashtbl.(remove|reset|clear)'` → 0건). 세 엔드포인트는 `with_public_read`(미인증).

→ `?window=1`, `?window=2`, … 를 반복하면 distinct 정수마다 영구 entry(키 + 전체 Yojson payload)가 쌓여 **Hashtbl이 무한 증가** = public 경로 메모리 고갈 벡터.

대조: `dashboard_feed_limit`(`:162`)는 `clamp ~min_v:1 ~max_v:200`으로 묶여 있어 `limit`-keyed 캐시(keeper-decisions 등)는 bounded. `window`/`bucket_min` 축만 누락.

## 왜 input clamp가 아니라 cache bound인가

`window`는 **분 단위**(lookback `since_unix = now - window*60`)라 의미상 상한이 없고, `[1, 10080]`(1주)로 clamp해도 distinct key가 수천 개 가능 → clamp만으론 cardinality를 못 묶는다. **client 입력이 일부 key가 되는 캐시는 eviction 정책이 있어야 한다**(캐시는 본래 bounded).

## 변경

- `server_utils.ml` + `.mli`: generic `evict_oldest_if_full ~max_entries ~age_of cache` 추가 — `length >= max_entries`면 `age_of` 최소(least-recently-refreshed) entry 1개 제거, 미만이면 no-op.
- `provider_runs.ml`: `cached_dashboard_json`의 miss 분기에서 insert 직전 호출, `dashboard_metrics_cache_max_entries = 128`. 헬퍼가 받는 6개 캐시 전부에 uniform 적용.

정상 동작 불변: legit 대시보드는 소수의 고정 window만 사용 → cap 미도달 → eviction 발생 안 함(발생 시에도 recompute일 뿐).

## 검증

- `dune build --root . lib/ test/test_server_utils_bounded_cache.exe` (worktree root, `--root .`).
- `ocamlformat --check` 4파일 exit 0.
- `test_server_utils_bounded_cache`: cap에서 oldest 축출 / cap 미만 no-op / **unbounded distinct-key churn(cap+500 insert) 후에도 length ≤ cap** / empty no-op. 마지막 케이스가 정확히 이 PR이 막는 무한 증가 시나리오를 재현·검증.

## 범위 / 경계

- `server_utils`(generic helper) + `provider_runs`(1 helper 호출 + 상수) + 신규 테스트. 다른 모듈 무관.
- RFC-gate 비대상: dashboard read route + generic util. credential/operator-control/keeper-sandbox/dashboard-credential-component/hooks/workflow 아님. `pr-rfc-check.sh` PASS.

## Workaround self-check

- **"cap" 워크어라운드 시그니처 아님**: manifesto가 경계하는 cap/cooldown은 *처리율·큐 백프레셔 증상 억제*(예: "force a turn after the cap"). 이건 **bounded cache** — client 입력이 key가 되는 캐시는 eviction이 정상 설계이고, eviction 없는 게 버그(unbounded growth). LRU eviction은 root fix.
- telemetry-as-fix ❌(counter 아님). string 분류기 ❌. dedup/repair ❌.
- N-of-M ❌ — unbounded-growth hunt가 server/keeper/board/economy/telemetry/attribution/discovery_cache/bounded_event_dedupe 전수, 나머지 컨테이너는 전부 bounded(remove/reset/cap/roster-bounded keyspace) 확인. 이 패치는 유일하게 confirmed된 unbounded 사이트의 완결 fix.
- catch-all `_ ->` ❌.

## 발견 경로

적대적 unbounded-growth hunt(단일 agent, 장수 컨테이너의 add 경로 vs remove/cap 대조, refute-default). confirmed 1건(0.85). file:line·int_query_param clamp 부재·eviction 부재·`limit` clamp 대조를 origin/main 코드로 직접 재검증.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
