### PR TITLE
fix(server): bound stale-token warn-log dedup table in server_auth

### DIFF
--- a/lib/server/server_auth.ml
+++ b/lib/server/server_auth.ml
@@ -285,6 +285,12 @@ let sanitize_dashboard_actor_name raw =
    is emitted at most once per [warn_cooldown_sec] per token prefix. *)
 let warn_cooldown_sec = 300.0
 
+(* Ceiling on distinct token-hash prefixes retained for log dedup. The prefix
+   is derived from client bearer tokens (16^8 keyspace), so without a cap the
+   table grows with every rotated/invalid token over process lifetime. The
+   cooldown gates log frequency per prefix, not table size. *)
+let stale_token_warn_log_max_entries = 1024
+
 let stale_token_warn_log : (string, float) Hashtbl.t = Hashtbl.create 16
 let stale_token_warn_mu = Eio.Mutex.create ()
 
@@ -306,6 +312,13 @@ let record_dashboard_actor_fallback
       | None -> true
     in
     if really_should_log then (
+      (* Bound the dedup table before inserting a new prefix. Guard on absence
+         so refreshing an existing prefix after cooldown does not evict an
+         unrelated entry. Reuses the same helper as the dashboard caches. *)
+      (if not (Hashtbl.mem stale_token_warn_log fb.token_hash_prefix) then
+         Server_utils.evict_oldest_if_full
+           ~max_entries:stale_token_warn_log_max_entries ~age_of:Fun.id
+           stale_token_warn_log);
       Hashtbl.replace stale_token_warn_log fb.token_hash_prefix now;
       Log.Auth.warn "%s"
         (Auth_error_kind.dashboard_actor_fallback_log_message fb));
@@ -314,6 +327,12 @@ let record_dashboard_actor_fallback
     Otel_metric_store.metric_silent_dashboard_actor_fallback
     ~labels:(Auth_error_kind.dashboard_actor_fallback_metric_labels fb)
     ()
+
+(* Exposed for testing: current size of the dedup table, used to assert the
+   bound holds under churn. *)
+let stale_token_warn_log_entry_count () =
+  Eio.Mutex.use_ro stale_token_warn_mu @@ fun () ->
+  Hashtbl.length stale_token_warn_log
 
 let dashboard_actor_for_request ~base_path request =
   match auth_token_from_request request with

--- a/lib/server/server_auth.mli
+++ b/lib/server/server_auth.mli
@@ -126,6 +126,14 @@ val record_dashboard_actor_fallback :
     Reverse Engineering Design Map §개선 #2 (request identity state
     machine). *)
 
+val stale_token_warn_log_max_entries : int
+(** Ceiling on distinct token-hash prefixes retained for warn-log dedup.
+    Exposed for testing the bound. *)
+
+val stale_token_warn_log_entry_count : unit -> int
+(** Current number of tracked token-hash prefixes. Exposed for testing that
+    [record_dashboard_actor_fallback] keeps the dedup table bounded. *)
+
 val dashboard_actor_for_request :
   base_path:string -> Httpun.Request.t -> string option
 (** Resolve the dashboard actor name from the request. *)

--- a/test/dune
+++ b/test/dune
@@ -1145,6 +1145,13 @@
  (modules test_server_utils_bounded_cache)
  (libraries alcotest masc))
 
+; Warn-log dedup table stays bounded under distinct token-hash-prefix churn.
+
+(test
+ (name test_server_auth_warn_log_bound)
+ (modules test_server_auth_warn_log_bound)
+ (libraries alcotest masc masc_server eio_main))
+
 ; Focused dashboard nudge feed projection.
 
 (test

--- a/test/test_server_auth_warn_log_bound.ml
+++ b/test/test_server_auth_warn_log_bound.ml
@@ -1,0 +1,29 @@
+(** Verifies [Server_auth.record_dashboard_actor_fallback] keeps its warn-log
+    dedup table bounded under an unbounded stream of distinct token-hash
+    prefixes (the memory-growth scenario for stale/rotated client tokens). *)
+
+open Alcotest
+
+let test_warn_log_table_bounded () =
+  Eio_main.run @@ fun _env ->
+  let cap = Server_auth.stale_token_warn_log_max_entries in
+  let inserted = cap + 500 in
+  for i = 1 to inserted do
+    Server_auth.record_dashboard_actor_fallback
+      { Masc.Auth_error_kind.outcome = Masc.Auth_error_kind.Outcome_none
+      ; token_hash_prefix = Printf.sprintf "prefix-%d" i
+      }
+  done;
+  let count = Server_auth.stale_token_warn_log_entry_count () in
+  check bool "table stays at or below the cap" true (count <= cap);
+  (* If the evict call were missing the table would hold all [inserted]
+     distinct prefixes; assert eviction actually fired. *)
+  check bool "eviction happened (not unbounded)" true (count < inserted)
+
+let () =
+  run "server_auth_warn_log_bound"
+    [ ( "dedup_table"
+      , [ test_case "bounded under distinct-prefix churn" `Quick
+            test_warn_log_table_bounded
+        ] )
+    ]


### PR DESCRIPTION
## 무엇을 / 왜

`record_dashboard_actor_fallback`(`lib/server/server_auth.ml`)는 warn 로그를 `stale_token_warn_log`(`:288`)로 dedup한다 — client bearer 토큰 SHA-256의 **8 hex prefix**를 key로 하는 Hashtbl. `Hashtbl.replace`(`:309`)가 distinct prefix마다 entry를 추가하고 **remove/evict/cap이 전혀 없다**. `warn_cooldown_sec`(300s)는 prefix별 **로깅 빈도**만 제한하지 테이블 크기가 아니다.

→ rotate되거나 invalid한 모든 bearer 토큰이 dashboard auth를 칠 때마다 영구 entry가 남아 토큰 churn에 따라 테이블이 프로세스 수명 동안 무한 증가(keyspace 16^8). #22007이 고친 dashboard metrics 캐시와 **동일한 unbounded-growth 클래스**.

## 변경

- `stale_token_warn_log_max_entries = 1024` 상수 추가.
- `record_dashboard_actor_fallback`의 insert 직전, **신규 prefix일 때만**(`not (Hashtbl.mem ...)` 가드) `Server_utils.evict_oldest_if_full`(#22007에서 추가) 호출 → least-recently-seen prefix 1개 축출. 기존 prefix를 cooldown 후 refresh할 때는 무관한 entry를 떨구지 않음.
- **auth 로직 무변경**: 토큰 resolution / credential 저장 / auth 결정은 그대로. 이 PR은 observability/log-dedup 테이블만 bound.

## 검증

- `dune build --root . lib/ test/test_server_auth_warn_log_bound.exe` exit 0 (worktree root).
- `ocamlformat --check` 3파일 exit 0. determinism gate 로컬 PASS.
- `test_server_auth_warn_log_bound`: Eio 하에서 `record_dashboard_actor_fallback`를 cap+500개 distinct prefix로 호출 → 테이블이 cap 이하 유지 + `< inserted`(축출 실제 발생) 확인. evict가 빠지면 1524개 전부 보유 → 회귀 시 FAIL.
- `evict_oldest_if_full` 자체 bound는 #22007의 `test_server_utils_bounded_cache`가 이미 검증(LRU/cap/churn).

## 범위 / 경계

- `lib/server/server_auth.ml` + `.mli`(test seam 2개: `stale_token_warn_log_max_entries`, `stale_token_warn_log_entry_count`) + 신규 테스트 1개 + `test/dune`.
- RFC 고지: `server_auth.ml`은 auth 표면이나, 변경은 **auth 결정 로직이 아닌 log-dedup 테이블 bound**(credential/identity/operator-control/keeper-sandbox/dashboard-credential-component/hooks/workflow 경로 미변경). `pr-rfc-check.sh` 결과를 따른다.

## Workaround self-check

- N-of-M ❌ — unbounded-growth hunt가 찾은 **두 confirmed 사이트 중 두 번째**(첫째=dashboard 캐시 #22007). 한 사이트만 고치고 다른 sink를 unbounded로 남기는 게 오히려 class 미완결이라, #22007이 만든 helper를 재사용해 클래스를 닫는다. 동일 변환의 부분 적용이 아니라 hunt가 열거한 사이트의 완결.
- telemetry-as-fix ❌(counter 아님). string 분류기 ❌. "cap" = bounded cache/table의 정상 설계(백프레셔 억제 아님), eviction 없는 게 버그.
- catch-all `_ ->` ❌. `(if not mem then evict);`는 괄호로 닫아 dangling-`;` 트랩 회피.

Refs #22007.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
