### PR TITLE
fix(exec): release fd on error path in bash_history compact

### DIFF
--- a/lib/exec/bash_history.ml
+++ b/lib/exec/bash_history.ml
@@ -259,12 +259,18 @@ let compact ~base_path ~keeper_name =
       let entries = load_entries path in
       let keep = drop (List.length entries - compact_to) entries in
       let oc = open_out path in
-      List.iter
-        (fun e ->
-           output_string oc (Yojson.Safe.to_string (entry_to_json e));
-           output_char oc '\n')
-        keep;
-      close_out_no_err oc))
+      (* Release the fd on every exit path. A mid-write [Sys_error] (disk full
+         / I/O error) would otherwise skip [close_out_no_err] and leak the fd
+         while leaving a truncated history file. Mirrors the [Eio_guard.protect]
+         used by [count_lines]/[load_entries] above. *)
+      Eio_guard.protect
+        ~finally:(fun () -> close_out_no_err oc)
+        (fun () ->
+           List.iter
+             (fun e ->
+                output_string oc (Yojson.Safe.to_string (entry_to_json e));
+                output_char oc '\n')
+             keep)))
 ;;
 
 (* --- suggest (query) --- *)

--- a/test/test_exec_core.ml
+++ b/test/test_exec_core.ml
@@ -657,6 +657,26 @@ let test_history_compaction () =
   in
   check int "all 15 preserved" 15 (List.length results)
 
+let test_history_compaction_triggers () =
+  with_p11_base_path @@ fun base_path ->
+  let module H = Masc_exec.Bash_history in
+  (* Exceed max_entries (10_000) so [compact] actually rewrites the file via
+     the fd-protected write path (not the no-op branch above). *)
+  for i = 1 to 10_001 do
+    Result.get_ok
+      (H.append ~base_path ~keeper_name:"compact-trigger"
+         { ts = float_of_int i; cmd_hash = string_of_int i; cmd_prefix = "cmd";
+           semantic_kind = "Unknown"; duration_ms = 10; success = true })
+  done;
+  H.compact ~base_path ~keeper_name:"compact-trigger";
+  let results =
+    H.suggest ~base_path ~keeper_name:"compact-trigger" ~pattern:"cmd"
+      ~limit:20_000
+  in
+  (* compact keeps the last compact_to (1_000) entries; the rewrite went
+     through the Eio_guard.protect wrapper and produced a valid file. *)
+  check int "compacted to compact_to" 1_000 (List.length results)
+
 
 let () =
   run "exec_core"
@@ -753,5 +773,7 @@ let () =
             test_history_cmd_hash;
           test_case "compaction preserves entries below threshold"
             `Quick test_history_compaction;
+          test_case "compaction above threshold rewrites to compact_to"
+            `Slow test_history_compaction_triggers;
         ] );
     ]


### PR DESCRIPTION
## 무엇을 / 왜

`Bash_history.compact`(`lib/exec/bash_history.ml:261`)가 history 파일을 bare `open_out path`로 열고 `List.iter (output_string; output_char) keep` 후 `close_out_no_err`를 **성공 경로에서만** 호출한다(finally 가드 없음).

```ocaml
let oc = open_out path in
List.iter (fun e -> output_string oc ...; output_char oc '\n') keep;
close_out_no_err oc   (* write 중 Sys_error 발생 시 도달 못 함 *)
```

write 도중 `Sys_error`(disk full / I/O error)가 나면 `close_out_no_err`를 건너뛰어 **fd가 누수**된다. `open_out`이 먼저 truncate하므로 truncated history 파일도 남는다. server `save_sessions_to_file`(#22006)과 동일 shape.

`compact`는 이 모듈의 **유일한 미보호 I/O 경로**다 — 형제 reader `count_lines`(:204)/`load_entries`(:220)는 이미 `Eio_guard.protect`로 감싸고, `append`(:188)는 `Sys_error`를 명시 `close_out_no_err` + `Error` arm으로 처리한다.

## 변경

`compact`의 write를 형제와 동일하게 `Eio_guard.protect ~finally:(fun () -> close_out_no_err oc)`로 감싼다. 모든 종료 경로에서 fd 해제. 성공 시 동작 불변.

## 범위 / 심각도 (정직)

- `compact`는 export되고 "call periodically (e.g. after each append)"로 문서화돼 있으나, **현재 production caller가 없다**(keeper exec 경로는 `append`만 배선, `compact` 미배선; `rg` 확인 — 호출처 0건, def 파일 + test 제외). 따라서 지금은 *active leak*이 아니라 **public API의 latent leak** — 문서화된 wiring이 추가되는 순간 누수. severity를 과장하지 않는다.
- 그럼에도 fix하는 이유: (a) 실제 correctness 결함(미보호 fd), (b) 파일 자신의 idiom으로 trivial fix, (c) 모듈의 protect-discipline 일관성 완성(다른 모든 I/O 경로는 이미 보호됨).

## 검증

- `dune build --root . lib/ test/test_exec_core.exe` (worktree root).
- `ocamlformat --check` 2파일 exit 0. determinism gate 로컬 PASS.
- 신규 테스트 `compaction above threshold rewrites to compact_to`(`Slow`): max_entries(10_000) 초과로 append → `compact`가 **실제 보호된 write 경로로 rewrite** → 파일이 compact_to(1_000)로 축소됨을 확인. 기존 테스트는 below-threshold no-op만 커버.
- error-branch(disk-full-mid-write)는 black-box 결정론적 재현 불가 — fix는 구조적(형제 idiom 미러), happy path는 위 테스트로 lock(#22006과 동일 논리).

## 범위 / 경계

- `lib/exec/bash_history.ml` 1개 함수 + 기존 test 파일에 케이스 1개. 다른 모듈 무관.
- RFC-gate 비대상: exec history(credential/operator-control/keeper-sandbox/dashboard-credential/hooks/workflow 아님). `pr-rfc-check.sh` 결과 따름.

## Workaround self-check

워크어라운드 아님 — 미보호 fd 해제의 근본 fix. telemetry-as-fix ❌. string 분류기 ❌. cap/dedup/repair ❌. catch-all `_ ->` ❌(`Eio_guard.protect` finally는 close만). N-of-M: resource-leak 클래스의 미감사 디렉토리(lib/exec) hunt에서 confirmed된 사이트의 완결(server #22006과 동일 idiom).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
