### PR TITLE
fix(keeper): stop two turn-path catch-alls swallowing Eio Cancelled

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -662,16 +662,23 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                     | _ -> 24
                   in
                   let window_minutes = window_hours * 60 in
-                  (try
-                     Model_inference_metrics.compute
-                       ~base_path:ctx.config.base_path
-                       ~window_minutes
-                     |> Model_inference_metrics.render_keeper_prompt_feedback
-                   with exn ->
-                     Log.Keeper.warn
-                       "%s: telemetry feedback render failed: %s"
-                       meta.name (Printexc.to_string exn);
-                     "")
+                  (* compute reads JSONL via Eio (Fs_compat.fold_jsonl_lines),
+                     a cancellation point, so a bare catch-all here would
+                     swallow [Eio.Cancel.Cancelled] and let a cancelled turn
+                     keep building its prompt. Route through the RFC-0106 SSOT
+                     combinator, which re-raises Cancelled and recovers others
+                     (matches the trajectory-finalize handlers below). *)
+                  Cancel_safe.protect
+                    ~on_exn:(fun exn ->
+                      Log.Keeper.warn
+                        "%s: telemetry feedback render failed: %s"
+                        meta.name (Printexc.to_string exn);
+                      "")
+                    (fun () ->
+                      Model_inference_metrics.compute
+                        ~base_path:ctx.config.base_path
+                        ~window_minutes
+                      |> Model_inference_metrics.render_keeper_prompt_feedback)
                 | Some false | None -> ""
               in
               let soft_parts = List.filter

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -281,26 +281,30 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
                   (* Ensure full session dir tree, not just base_dir (issue #3019) *)
                   ignore (Keeper_fs.ensure_dir (Filename.concat base_dir trace_id));
                   let bundle_paths =
-                    try
-                      Keeper_alerting_path.ensure_sandbox_bundle_for_profile
-                        ~config:ctx.config ~name:p.name
-                        ~sandbox_profile
-                    with exn ->
-                      (* Surface masc-improver/sangsu sandbox boot
-                         silent-failure (2026-05-05).  Keeper_fs.ensure_dir
-                         raises on filesystem error; the previous [ignore]
-                         discarded it.  Now we log + emit a Otel_metric_store
-                         counter so the dashboard makes failure visible
-                         without aborting keeper boot. *)
-                      Log.Keeper.error
-                        "create_keeper sandbox bundle init raised: keeper=%s exn=%s"
-                        p.name (Printexc.to_string exn);
-                      Otel_metric_store.inc_counter
-                        Keeper_metrics.(to_string LifecycleDispatchRejections)
-                        ~labels:[("keeper", p.name);
-                                 ("event", "sandbox_bundle_init_raised")]
-                        ();
-                      []
+                    (* Surface masc-improver/sangsu sandbox boot
+                       silent-failure (2026-05-05).  Keeper_fs.ensure_dir
+                       raises on filesystem error; the previous [ignore]
+                       discarded it.  Now we log + emit a Otel_metric_store
+                       counter so the dashboard makes failure visible
+                       without aborting keeper boot.  ensure_dir runs under an
+                       Eio.Mutex and re-raises [Eio.Cancel.Cancelled], so route
+                       through the RFC-0106 SSOT combinator: a bare catch-all
+                       would swallow Cancelled and let a cancelled create keep
+                       booting a keeper that should not exist. *)
+                    Cancel_safe.protect
+                      ~on_exn:(fun exn ->
+                        Log.Keeper.error
+                          "create_keeper sandbox bundle init raised: keeper=%s exn=%s"
+                          p.name (Printexc.to_string exn);
+                        Otel_metric_store.inc_counter
+                          Keeper_metrics.(to_string LifecycleDispatchRejections)
+                          ~labels:[("keeper", p.name);
+                                   ("event", "sandbox_bundle_init_raised")]
+                          ();
+                        [])
+                      (fun () ->
+                        Keeper_alerting_path.ensure_sandbox_bundle_for_profile
+                          ~config:ctx.config ~name:p.name ~sandbox_profile)
                   in
                   List.iter (fun bp ->
                     if not (Sys.file_exists bp) then begin

--- a/test/dune
+++ b/test/dune
@@ -1145,6 +1145,13 @@
  (modules test_server_utils_bounded_cache)
  (libraries alcotest masc))
 
+; RFC-0106 cancel-safe combinator: re-raises Cancelled, routes others.
+
+(test
+ (name test_cancel_safe)
+ (modules test_cancel_safe)
+ (libraries alcotest masc_cancel_safe eio))
+
 ; Warn-log dedup table stays bounded under distinct token-hash-prefix churn.
 
 (test

--- a/test/test_cancel_safe.ml
+++ b/test/test_cancel_safe.ml
@@ -1,0 +1,58 @@
+(** Tests for [Cancel_safe.protect]/[observe] — the RFC-0106 SSOT that
+    re-raises [Eio.Cancel.Cancelled] (so cooperative cancellation propagates)
+    while routing any other exception to [on_exn]. The keeper turn/create hot
+    paths delegate to this combinator; its correctness is what makes those
+    catch-alls cancel-safe. *)
+
+open Alcotest
+
+let test_reraises_cancelled () =
+  let on_exn_called = ref false in
+  let reraised = ref false in
+  (try
+     ignore
+       (Cancel_safe.protect
+          ~on_exn:(fun _ ->
+            on_exn_called := true;
+            0)
+          (fun () -> raise (Eio.Cancel.Cancelled (Failure "boom"))))
+   with
+   | Eio.Cancel.Cancelled _ -> reraised := true);
+  check bool "Cancelled propagated to caller" true !reraised;
+  check bool "on_exn NOT invoked for Cancelled" false !on_exn_called
+
+let test_routes_other_exn () =
+  let r =
+    Cancel_safe.protect ~on_exn:(fun _ -> 42) (fun () -> raise (Failure "x"))
+  in
+  check int "on_exn result becomes the value" 42 r
+
+let test_passes_through_success () =
+  let r = Cancel_safe.protect ~on_exn:(fun _ -> 0) (fun () -> 7) in
+  check int "success value returned unchanged" 7 r
+
+let test_observe_routes_then_reraises () =
+  let logged = ref false in
+  Cancel_safe.observe
+    ~on_exn:(fun _ -> logged := true)
+    (fun () -> raise (Failure "y"));
+  check bool "observe routes other exn to on_exn" true !logged;
+  let reraised = ref false in
+  (try
+     Cancel_safe.observe
+       ~on_exn:(fun _ -> ())
+       (fun () -> raise (Eio.Cancel.Cancelled (Failure "z")))
+   with
+   | Eio.Cancel.Cancelled _ -> reraised := true);
+  check bool "observe re-raises Cancelled" true !reraised
+
+let () =
+  run "cancel_safe"
+    [ ( "protect"
+      , [ test_case "re-raises Cancelled" `Quick test_reraises_cancelled
+        ; test_case "routes other exn to on_exn" `Quick test_routes_other_exn
+        ; test_case "passes through success" `Quick test_passes_through_success
+        ; test_case "observe routes then re-raises Cancelled" `Quick
+            test_observe_routes_then_reraises
+        ] )
+    ]


### PR DESCRIPTION
## 무엇을 / 왜

keeper turn/create hot path의 두 catch-all이 `try <body> with exn -> <recover>`로 **`Eio.Cancel.Cancelled`를 흡수**(re-raise 안 함)한다. body는 Eio cancellation point에 도달하고 callee가 Cancelled를 re-raise하므로, 턴이 도중에 취소되면 그 취소가 조용히 삼켜지고 턴이 계속 진행된다.

### #1 `keeper_turn.ml:670` (telemetry-feedback render)

```ocaml
(try
   Model_inference_metrics.compute ~base_path:ctx.config.base_path ~window_minutes
   |> Model_inference_metrics.render_keeper_prompt_feedback
 with exn -> Log.Keeper.warn "..."; "")
```

`compute`→`read_all_entries`→`Fs_compat.fold_jsonl_lines`(`Eio.Buf_read`, cancellation point). reader는 Cancelled를 모든 arm에서 re-raise(`model_inference_metrics_reader.ml:51/79/99/111`)하므로 :670에 도달→흡수. **같은 함수의 trajectory-finalize 핸들러 2개(:772/:785)는 `Eio.Cancel.Cancelled _ as e -> raise e | exn -> ...`로 올바르게 처리** — :670만 divergent.

### #2 `keeper_turn_up_create.ml:288` (sandbox bundle init)

```ocaml
try Keeper_alerting_path.ensure_sandbox_bundle_for_profile ~config ~name ~sandbox_profile
with exn -> Log.Keeper.error "..."; Otel_metric_store.inc_counter ...; []
```

`ensure_sandbox_bundle_for_profile`→`Keeper_fs.ensure_dir`(`Eio.Mutex.use_rw` cancellation point). ensure_dir는 Cancelled를 `deferred_exn`에 담아 `Printexc.raise_with_backtrace`로 re-raise(`keeper_fs.ml:59`)→:288 도달→흡수. 취소된 create가 빈 bundle paths로 keeper boot을 계속.

## 변경

두 사이트를 **`Cancel_safe.protect ~on_exn`**(RFC-0106 SSOT 콤비네이터)으로 교체. `protect`는 `Eio.Cancel.Cancelled`를 verbatim re-raise하고 그 외 예외만 `~on_exn`으로 라우팅(`cancel_safe.ml:27` `try f () with Eio.Cancel.Cancelled _ as e -> raise e | exn -> on_exn exn`). 비-Cancelled 경로의 recovery 값(`""`/`[]`)과 로깅·counter 부수효과는 불변. ad-hoc try/with를 SSOT로 바꿔 패턴을 강제.

## 검증

- `dune build --root . lib/ test/test_cancel_safe.exe` exit 0 (worktree root, keeper 변경 컴파일).
- `ocamlformat --check` 3파일 exit 0. determinism gate 로컬 PASS.
- **신규 `test_cancel_safe`** (4 케이스): `protect`가 Cancelled re-raise / 다른 예외→on_exn / 성공 passthrough, `observe` 동일. cancel-safe SSOT는 그간 **테스트가 없었음**(RFC-0106 P0 critical인데). fixed call site는 이 SSOT에 위임하므로 cancel-safety가 이 테스트로 고정됨.
- call site의 cancellation propagation 자체는 turn 드라이버 깊숙이 inline이라 단독 테스트 불가 → correctness를 테스트 가능한 SSOT로 이동(combinator 위임).

## 범위 / 경계

- `lib/keeper/keeper_turn.ml` + `keeper_turn_up_create.ml` 각 1개 핸들러 + 신규 SSOT 테스트 + `test/dune`. 다른 모듈 무관.
- RFC: **RFC-0106**(cancel-safe try-with discipline)의 SSOT 헬퍼 적용. keeper turn lifecycle은 agent_delegation gated subsystem(credential/gh/host_config/sandbox/shell/operator/dashboard-credential/hooks/workflow)에 해당하지 않음. `pr-rfc-check.sh` 결과 따름.

## Workaround self-check

워크어라운드 아님 — silent cancellation-absorption의 근본 fix. telemetry-as-fix ❌(counter는 기존 부수효과 유지일 뿐 fix 본체는 re-raise). string 분류기 ❌. cap/dedup/repair ❌. **catch-all 추가 아님 — 제거**(ad-hoc `with exn ->`를 SSOT 콤비네이터로 교체, Cancelled re-raise 강제). N-of-M: Cancelled-absorption hunt가 lib/keeper·server·exec·process·board에서 찾은 confirmed 2건 모두 fix(나머지는 re-raise/sync-body로 refuted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
