### PR TITLE
fix(dashboard): guard empty agent name in briefing latest_message_to

### DIFF
--- a/lib/dashboard/dashboard_briefing_agents.ml
+++ b/lib/dashboard/dashboard_briefing_agents.ml
@@ -129,7 +129,13 @@ let latest_message_to agent_name messages =
       let content = String.lowercase_ascii message.content in
       let from_self = String.equal (String.lowercase_ascii (String.trim message.from_agent)) lowered in
       let mentioned =
-        String.contains content '@'
+        (* [lowered] can be "" for a degenerate agent record with an empty or
+           whitespace-only name (agent_of_yojson accepts "name":""; the brief
+           loop does not drop empties — cf. the [agent_name <> ""] guard on the
+           event path). Without this length check [String.get lowered 0] would
+           raise Invalid_argument and crash the briefing fiber. *)
+        String.length lowered > 0
+        && String.contains content '@'
         && (String.contains content (String.get lowered 0)
             || String.contains content (String.get lowered (String.length lowered - 1)))
       in

--- a/lib/dashboard/dashboard_briefing_agents.mli
+++ b/lib/dashboard/dashboard_briefing_agents.mli
@@ -111,6 +111,13 @@ type archived_agent_meta = {
 
 (** {1 Brief builder} *)
 
+val latest_message_to :
+  string -> Masc_domain.message list -> Masc_domain.message option
+(** [latest_message_to agent_name messages] returns the most recent message
+    that mentions [agent_name] and was not sent by it. Exposed for testing:
+    tolerates an empty/whitespace-only [agent_name] (returns [None] rather than
+    raising). *)
+
 val build_agent_briefs :
   Workspace.config ->
   session_context list ->

--- a/test/test_dashboard_briefing.ml
+++ b/test/test_dashboard_briefing.ml
@@ -397,11 +397,38 @@ let test_dashboard_briefing_keeper_tool_audit_uses_decision_log () =
       check bool "decision log still reports empty tool list" true
         ((brief |> member "latest_tool_names" |> to_list) = []))
 
+let make_message ~seq ~from_agent ~content : Types.message =
+  { seq;
+    from_agent;
+    msg_type = "broadcast";
+    content;
+    mention = None;
+    timestamp = "";
+    trace_context = None;
+    expires_at = None;
+    relevance = "medium" }
+
+(* Regression: a degenerate agent record with an empty/whitespace name must not
+   crash latest_message_to (String.get on an empty [lowered]). *)
+let test_latest_message_to_empty_name_safe () =
+  let msgs = [ make_message ~seq:1 ~from_agent:"alice" ~content:"hey @bob ping" ] in
+  (match Dashboard_briefing_agents.latest_message_to "" msgs with
+   | None -> ()
+   | Some _ -> Alcotest.fail "empty name must not match a mention");
+  (match Dashboard_briefing_agents.latest_message_to "   " msgs with
+   | None -> ()
+   | Some _ -> Alcotest.fail "whitespace name must not match a mention");
+  match Dashboard_briefing_agents.latest_message_to "bob" msgs with
+  | Some (m : Types.message) -> Alcotest.(check int) "matched seq" 1 m.seq
+  | None -> Alcotest.fail "expected @bob mention to match"
+
 let () =
   Alcotest.run "Dashboard Mission"
     [
       ( "read_model",
         [
+          Alcotest.test_case "latest_message_to tolerates empty agent name"
+            `Quick test_latest_message_to_empty_name_safe;
           Alcotest.test_case "projection groups root-cause lanes" `Quick
             test_dashboard_briefing_projection;
           Alcotest.test_case "http mission keeps full contract" `Quick


### PR DESCRIPTION
## 무엇을 / 왜

`latest_message_to`(`lib/dashboard/dashboard_briefing_agents.ml:125`)가 `lowered = lowercase(trim agent_name)`를 `String.get lowered 0` / `String.get lowered (String.length lowered - 1)`로 인덱싱(mention 판정, :133-134). `agent_name`이 빈 문자열/공백뿐이면 `lowered = ""`→`String.get ""`가 **`Invalid_argument`로 raise**→briefing fold(per-agent brief 조립)가 크래시(렌더 대신 중단).

`agent_name`은 on-disk `agent.name`(via `agent_of_yojson`, `"name":""` 허용)에서 옴. brief 루프는 빈 이름을 드롭하지 않음. **같은 파일이 event 경로는 `agent_name <> ""`로 이미 가드**(`read_recent_workspace_event_lines`, :233) — 빈 이름은 codebase가 인지하는 가능성이고 `latest_message_to` 경로만 가드 누락(inconsistency). 함수가 선언 타입(`string`)에 partial = total-functions 위반(user-core.xml).

## 변경

`mentioned` 판정에 `String.length lowered > 0 &&` 선행 가드 추가 → `lowered=""`면 mention 미성립(None 반환, raise 없음). `String.contains '@'`만이 유일 gate였고 lowered 길이와 무관했음. 함수를 total로. (heuristic 자체의 loose함은 별도 품질 이슈로 미변경.)

## 검증

- `dune build --root . lib/ test/test_dashboard_briefing.exe` exit 0 (worktree root).
- `ocamlformat --check` 3파일 exit 0. determinism gate 로컬 PASS.
- 신규 테스트 `latest_message_to tolerates empty agent name`: 빈/공백 이름→`None`(raise 없음), 실이름→`@mention` 정상 매칭. **결정론적**(순수 함수, fix 이전 코드에선 `Invalid_argument`로 FAIL). `latest_message_to`를 .mli에 노출(test seam, "exposed for testing").

## 범위 / 심각도 (정직)

- `lib/dashboard/dashboard_briefing_agents.ml` 1개 함수 + `.mli` val 1개 노출 + 기존 test에 케이스 1개.
- **Latent**: 빈 agent.name을 persist하는 normal write path는 미발견(degenerate/손상/hand-edit 레코드 트리거). 그러나 read-only dashboard 경로가 corruptible 영속 상태를 처리하므로 partial 함수는 bad-state 크래시 대기. severity 과장 안 함.
- RFC-gate 비대상: dashboard **briefing**(credential component 아님). `pr-rfc-check.sh` 결과 따름.

## Workaround self-check

워크어라운드 아님 — partial 함수를 total로 만드는 근본 fix. telemetry-as-fix ❌. string 분류기 ❌. cap/dedup/repair ❌. catch-all `_ ->` ❌. N-of-M: partial-function hunt(미감사 dir runtime/cdal/dashboard/multimodal/economy/trajectory)에서 confirmed된 유일 사이트(나머지는 length/empty 가드로 refuted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
