### PR TITLE
[v2] memory — pixel-match to Claude-Design prototype

### DIFF
--- a/dashboard/src/components/agent-detail-memory.test.ts
+++ b/dashboard/src/components/agent-detail-memory.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+import { html } from 'htm/preact'
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { MemorySubsystemsResponse } from '../api/dashboard'
+
+// ── Mock API ──────────────────────────────────────────
+// AgentDetailMemory fetches via fetchMemorySubsystems() inside useEffect.
+// Mocking the module returns a valid empty payload so the component reaches
+// its loaded state without a real HTTP call; the memory-inspector wiring is
+// independent of the fetched subsystems data.
+const mockFetch = vi.fn<() => Promise<MemorySubsystemsResponse>>()
+
+vi.mock('../api/dashboard', () => ({
+  fetchMemorySubsystems: () => mockFetch(),
+}))
+
+// ── Import after mocks ────────────────────────────────
+import { AgentDetailMemory } from './agent-detail-memory'
+
+function emptyResponse(): MemorySubsystemsResponse {
+  return {
+    generated_at: '2026-06-22T00:00:00Z',
+    hebbian: { synapses: [], last_consolidation: 0 },
+    episodes: { total: 0, filtered: 0, shown: 0, limit: 10, items: [] },
+    filters: { keepers: [], outcomes: [] },
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  mockFetch.mockReset()
+})
+
+// The memory surface lives inside a CollapsibleSection that defers mounting
+// its children until opened (mountWhenOpen). Open the <details> the way the
+// operator would so the trigger renders.
+async function openTrigger(container: Element): Promise<HTMLButtonElement> {
+  // Wait for the async resource to load (replaces the LoadingState with the
+  // CollapsibleSection), then expand the <details> the way an operator would.
+  const details = await waitFor(() => {
+    const d = container.querySelector('details')
+    expect(d).toBeTruthy()
+    return d as HTMLDetailsElement
+  })
+  details.open = true
+  fireEvent(details, new Event('toggle'))
+  return await waitFor(() => {
+    const btn = container.querySelector('.cmp-open')
+    expect(btn).toBeTruthy()
+    return btn as HTMLButtonElement
+  })
+}
+
+describe('AgentDetailMemory — MemoryInspector wiring', () => {
+  it('renders the 메모리 보기 trigger after load and opens the inspector overlay on click', async () => {
+    mockFetch.mockResolvedValue(emptyResponse())
+    const { container } = render(
+      html`<${AgentDetailMemory} agentName="masc-improver" />`,
+    )
+
+    // Trigger appears once the async resource has loaded and the section opens.
+    const trigger = await openTrigger(container)
+    expect(trigger.textContent).toContain('메모리 보기')
+
+    // Inspector is not mounted until the trigger is clicked.
+    expect(container.querySelector('.turn-overlay')).toBeFalsy()
+
+    fireEvent.click(trigger)
+
+    // The MemoryInspector overlay-drawer now renders, scoped to the agent.
+    const drawer = container.querySelector('.mem-drawer')
+    expect(drawer).toBeTruthy()
+    expect(container.querySelector('.turn-overlay')).toBeTruthy()
+    expect(container.querySelector('.turn-hd h3')?.textContent).toContain(
+      'Keeper 메모리',
+    )
+    // agentName 'masc-improver' resolves to the ported roster keeper.
+    expect(container.querySelector('.tid')?.textContent).toBe('masc-improver')
+  })
+
+  it('resolves the keeper id from a keeper-prefixed agent name', async () => {
+    mockFetch.mockResolvedValue(emptyResponse())
+    const { container } = render(
+      html`<${AgentDetailMemory} agentName="keeper-sangsu-agent" />`,
+    )
+    const trigger = await openTrigger(container)
+    fireEvent.click(trigger)
+    // normalizeKeeperName strips keeper-/-agent → 'sangsu' (a roster keeper).
+    expect(container.querySelector('.tid')?.textContent).toBe('sangsu')
+  })
+
+  it('closes the inspector when onClose fires (✕ button)', async () => {
+    mockFetch.mockResolvedValue(emptyResponse())
+    const { container } = render(
+      html`<${AgentDetailMemory} agentName="masc-improver" />`,
+    )
+    const trigger = await openTrigger(container)
+    fireEvent.click(trigger)
+    expect(container.querySelector('.mem-drawer')).toBeTruthy()
+
+    fireEvent.click(container.querySelector('.turn-close')!)
+    expect(container.querySelector('.mem-drawer')).toBeFalsy()
+    expect(container.querySelector('.turn-overlay')).toBeFalsy()
+  })
+})

--- a/dashboard/src/components/agent-detail-memory.ts
+++ b/dashboard/src/components/agent-detail-memory.ts
@@ -17,6 +17,11 @@ import { TextInput } from './common/input'
 import { MemoryLineageRail } from './memory/memory-lineage-rail'
 import type { MemoryLineageRailProps } from './memory/memory-lineage-rail'
 import type { MemoryNode } from './memory/memory-primitives'
+import {
+  MemoryInspector,
+  DEFAULT_MEMORY_KEEPERS,
+  type MemoryKeeper,
+} from './memory-inspector'
 
 interface Props {
   agentName: string
@@ -24,6 +29,26 @@ interface Props {
 
 function normalizeKeeperName(name: string): string {
   return name.replace(/^keeper-/, '').replace(/-agent$/, '')
+}
+
+// Resolve the MemoryInspector keeper from the surfaced agent. When the agent
+// matches the inspector's ported roster we reuse the fixture keeper (real ctx /
+// status / task counts so the composition math renders); otherwise the keeper
+// id alone is enough — the inspector falls back to empty memory for unknown ids
+// (memory-inspector.ts getKeeperMemory). ctx 0 / status 'off' keeps an unknown
+// keeper's composition bar in the documented "stopped — 활성 컨텍스트 없음" state
+// rather than fabricating window usage.
+function resolveInspectorKeeper(agentName: string): MemoryKeeper {
+  const id = normalizeKeeperName(agentName)
+  return (
+    DEFAULT_MEMORY_KEEPERS.find(k => k.id === id) ?? {
+      id,
+      ctx: 0,
+      status: 'off',
+      tasks: 0,
+      traces: 0,
+    }
+  )
 }
 
 function matchesKeeper(synapseAgent: string, keeperName: string): boolean {
@@ -116,6 +141,7 @@ function SynapseWeightBar({ weight }: { weight: number }) {
 export function AgentDetailMemory({ agentName }: Props) {
   const resource = useManagedAsyncResource<MemorySubsystemsResponse>(null)
   const episodeQuery = useSignal('')
+  const memOpen = useSignal(false)
 
   useEffect(() => {
     void resource.load(async (signal) =>
@@ -158,6 +184,15 @@ export function AgentDetailMemory({ agentName }: Props) {
   return html`
     <${CollapsibleSection} class="v2-monitoring-detail" title="협업 & 기억" mountWhenOpen=${true}>
       <div class="space-y-4">
+        <!-- Memory inspector trigger (rails.jsx:513-515 — ◈ 메모리 보기 · 핀 · 스토어 · 회상) -->
+        <button
+          type="button"
+          class="cmp-open"
+          onClick=${() => { memOpen.value = true }}
+        >
+          ${'◈'} 메모리 보기 <span class="cmp-open-sub">핀 · 스토어 · 회상</span>
+        </button>
+
         <!-- Hebbian collaboration -->
         <div>
           <div class="text-xs text-[var(--color-fg-disabled)] uppercase tracking-wide mb-2">
@@ -307,6 +342,12 @@ export function AgentDetailMemory({ agentName }: Props) {
             `
           : null}
       </div>
+      ${memOpen.value
+        ? html`<${MemoryInspector}
+            keeper=${resolveInspectorKeeper(agentName)}
+            onClose=${() => { memOpen.value = false }}
+          />`
+        : null}
     <//>
   `
 }

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -124,6 +124,27 @@ describe('MemoryInspector — scope toggle', () => {
     )
   })
 
+  it('renders a status dot per row mapping run→ok / pause→idle / off→bad', () => {
+    // Mirrors the prototype StatusDot chain (keeper-v2/memory.jsx:196 →
+    // messages.jsx:8): the dot class drives the .dot2 palette in
+    // memory-inspector-v2.css (ok=--status-ok, idle=--status-idle,
+    // bad=--status-bad). A wrong class is a silent colour regression
+    // (e.g. an off keeper showing a brass dot instead of red).
+    const { container } = renderInspector()
+    fireEvent.click(
+      [...container.querySelectorAll('.mem-scope button')].find(b => b.textContent === '전체')!,
+    )
+    const dotClassFor = (id: string): string | undefined => {
+      const row = [...container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)')].find(r =>
+        (r.querySelector('.mem-td-id .mono')?.textContent ?? '') === id,
+      )
+      return row?.querySelector('.mem-dot')?.className
+    }
+    expect(dotClassFor('nick0cave')).toContain('ok') // status 'run'
+    expect(dotClassFor('qa-king')).toContain('idle') // status 'pause'
+    expect(dotClassFor('drifter')).toContain('bad') // status 'off'
+  })
+
   it('drills back into a single keeper when an aggregate row is clicked', () => {
     const { container } = renderInspector()
     fireEvent.click(

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render } from '@testing-library/preact'
+import { html } from 'htm/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_COMPACTIONS,
+  DEFAULT_MEMORY_KEEPERS,
+  KEEPER_MEMORY,
+  MemoryInspector,
+  memAggregate,
+  memComposition,
+  memFmtTok,
+  type MemoryKeeper,
+} from './memory-inspector'
+
+afterEach(() => cleanup())
+
+// masc-improver: ctx 0.86, has pinned facts, store entries, recall timeline,
+// and a compaction record — exercises every section in the one-keeper view.
+const improver: MemoryKeeper = DEFAULT_MEMORY_KEEPERS.find(k => k.id === 'masc-improver')!
+
+function renderInspector(keeper: MemoryKeeper = improver, onClose = vi.fn()) {
+  return render(html`<${MemoryInspector} keeper=${keeper} onClose=${onClose} />`)
+}
+
+describe('MemoryInspector — one-keeper scope', () => {
+  it('renders the drawer shell scoped to the active keeper', () => {
+    const { container } = renderInspector()
+    expect(container.querySelector('.turn-overlay')).toBeTruthy()
+    expect(container.querySelector('.mem-drawer')).toBeTruthy()
+    // header title + the active keeper id
+    expect(container.querySelector('.turn-hd h3')?.textContent).toContain('Keeper 메모리')
+    expect(container.querySelector('.tid')?.textContent).toBe('masc-improver')
+  })
+
+  it('renders the context-composition bar and a legend derived from live ctx tokens', () => {
+    const { container } = renderInspector()
+    const bar = container.querySelector('.mem-bar')
+    expect(bar).toBeTruthy()
+    // memComposition filters out zero-token parts; masc-improver has 5 parts.
+    const comp = memComposition(improver)
+    expect(comp.parts.length).toBeGreaterThan(0)
+    expect(bar!.querySelectorAll('span').length).toBe(comp.parts.length)
+    // legend rows mirror the parts
+    expect(container.querySelectorAll('.mem-leg').length).toBe(comp.parts.length)
+    // 86% header readout (Math.round(0.86 * 100))
+    expect(container.querySelector('.mem-compo-sub')?.textContent).toContain('86%')
+  })
+
+  it('renders pinned facts with their count and operator/auto provenance', () => {
+    const { container } = renderInspector()
+    const pinHeads = [...container.querySelectorAll('.turn-sec h4')].map(h => h.textContent ?? '')
+    expect(pinHeads.some(t => t.startsWith('핀 고정 사실'))).toBe(true)
+    const pins = container.querySelectorAll('.mem-pin')
+    expect(pins.length).toBe(KEEPER_MEMORY['masc-improver']!.pinned.length)
+    // first pinned fact text is rendered verbatim
+    expect(container.textContent).toContain('retention 정의: D0 = 가입일, 첫 세션 기준')
+  })
+
+  it('renders the salience store with one row per entry', () => {
+    const { container } = renderInspector()
+    const rows = container.querySelectorAll('.mem-store-row')
+    expect(rows.length).toBe(KEEPER_MEMORY['masc-improver']!.store.length)
+    // salience meter present on each row
+    expect(container.querySelectorAll('.mem-store-row .mem-sal').length).toBe(rows.length)
+  })
+
+  it('filters the store by kind when a kind filter is clicked', () => {
+    const { container } = renderInspector()
+    const allRows = container.querySelectorAll('.mem-store-row').length
+    // masc-improver has 5 distinct kinds, so filter buttons render.
+    const declButtons = [...container.querySelectorAll('.mem-filter')]
+    const decisionBtn = declButtons.find(b => (b.textContent ?? '').includes('결정'))
+    expect(decisionBtn).toBeTruthy()
+    fireEvent.click(decisionBtn!)
+    const afterRows = container.querySelectorAll('.mem-store-row').length
+    expect(afterRows).toBeLessThan(allRows)
+    expect(afterRows).toBe(1) // exactly one 'decision' entry in the fixture
+  })
+
+  it('renders the recall timeline rows', () => {
+    const { container } = renderInspector()
+    const tlRows = container.querySelectorAll('.mem-tl-row')
+    expect(tlRows.length).toBe(KEEPER_MEMORY['masc-improver']!.recall.length)
+    // a compaction op row carries a negative token delta rendered with the minus glyph
+    expect(container.querySelector('.mem-tl-tok.neg')?.textContent).toContain('−')
+  })
+
+  it('renders the compaction diff with kept / summarized / dropped columns', () => {
+    const { container } = renderInspector()
+    expect(container.querySelector('.cmp-diff')).toBeTruthy()
+    expect(container.querySelector('.cmp-col.kept')).toBeTruthy()
+    expect(container.querySelector('.cmp-col.summ')).toBeTruthy()
+    expect(container.querySelector('.cmp-col.drop')).toBeTruthy()
+    const cmp = DEFAULT_COMPACTIONS['masc-improver']![0]!
+    expect(container.querySelector('.cmp-trigger')?.textContent).toContain(cmp.trigger)
+  })
+
+  it('shows the empty-state when a keeper has no compaction history', () => {
+    // sangsu has store/pins but no DEFAULT_COMPACTIONS entry.
+    const sangsu = DEFAULT_MEMORY_KEEPERS.find(k => k.id === 'sangsu')!
+    const { container } = renderInspector(sangsu)
+    expect(container.textContent).toContain('컴팩션 이력 없음')
+  })
+})
+
+describe('MemoryInspector — scope toggle', () => {
+  it('switches from one-keeper to the aggregate (전체) view', () => {
+    const { container } = renderInspector()
+    // one-keeper view first: a single composition bar, no aggregate table.
+    expect(container.querySelector('.mem-table')).toBeFalsy()
+    const allBtn = [...container.querySelectorAll('.mem-scope button')].find(
+      b => b.textContent === '전체',
+    )
+    expect(allBtn).toBeTruthy()
+    fireEvent.click(allBtn!)
+    // aggregate view: keeper table + stats + kind distribution appear.
+    expect(container.querySelector('.mem-table')).toBeTruthy()
+    expect(container.querySelectorAll('.mem-stat').length).toBe(4)
+    expect(container.querySelector('.tid')?.textContent).toBe('전체 keeper')
+    // one table row per keeper in the roster.
+    expect(container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)').length).toBe(
+      DEFAULT_MEMORY_KEEPERS.length,
+    )
+  })
+
+  it('drills back into a single keeper when an aggregate row is clicked', () => {
+    const { container } = renderInspector()
+    fireEvent.click(
+      [...container.querySelectorAll('.mem-scope button')].find(b => b.textContent === '전체')!,
+    )
+    const nickRow = [...container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)')].find(
+      r => (r.textContent ?? '').includes('nick0cave'),
+    )
+    expect(nickRow).toBeTruthy()
+    fireEvent.click(nickRow!)
+    // back to one-keeper scope, now showing the picked keeper.
+    expect(container.querySelector('.tid')?.textContent).toBe('nick0cave')
+    expect(container.querySelector('.mem-table')).toBeFalsy()
+  })
+})
+
+describe('MemoryInspector — close behaviour', () => {
+  it('invokes onClose on overlay click and on the ✕ button', () => {
+    const onClose = vi.fn()
+    const { container } = renderInspector(improver, onClose)
+    fireEvent.click(container.querySelector('.turn-close')!)
+    expect(onClose).toHaveBeenCalledTimes(1)
+    fireEvent.click(container.querySelector('.turn-overlay')!)
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not close when the drawer body itself is clicked (stopPropagation)', () => {
+    const onClose = vi.fn()
+    const { container } = renderInspector(improver, onClose)
+    fireEvent.click(container.querySelector('.mem-drawer')!)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('closes on Escape keydown', () => {
+    const onClose = vi.fn()
+    renderInspector(improver, onClose)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('memory model helpers', () => {
+  it('memFmtTok abbreviates thousands and prefixes negatives with the minus glyph', () => {
+    expect(memFmtTok(120)).toBe('120')
+    expect(memFmtTok(1840)).toBe('1.8k')
+    expect(memFmtTok(-110600)).toBe('−110.6k')
+  })
+
+  it('memComposition returns no parts for a stopped (ctx 0) keeper', () => {
+    const drifter = DEFAULT_MEMORY_KEEPERS.find(k => k.id === 'drifter')!
+    const comp = memComposition(drifter)
+    expect(comp.total).toBe(0)
+    expect(comp.parts).toEqual([])
+  })
+
+  it('memAggregate sums pins/store across keepers and caps topFacts at 6', () => {
+    const agg = memAggregate(DEFAULT_MEMORY_KEEPERS)
+    expect(agg.keeperCount).toBe(DEFAULT_MEMORY_KEEPERS.length)
+    const expectedStore = DEFAULT_MEMORY_KEEPERS.reduce(
+      (n, k) => n + (KEEPER_MEMORY[k.id]?.store.length ?? 0),
+      0,
+    )
+    expect(agg.store).toBe(expectedStore)
+    expect(agg.topFacts.length).toBeLessThanOrEqual(6)
+    // topFacts are sorted by descending salience.
+    for (let i = 1; i < agg.topFacts.length; i++) {
+      expect(agg.topFacts[i - 1]!.salience).toBeGreaterThanOrEqual(agg.topFacts[i]!.salience)
+    }
+  })
+})

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -1,0 +1,597 @@
+// MASC v2 — Keeper memory inspector (read-only overlay-drawer).
+//
+// Pixel-matched port of the Claude-Design prototype:
+//   keeper-v2/memory.jsx        (rendering + scope toggle)
+//   keeper-v2/memory-data.jsx   (model: pinned facts, long-term store,
+//                                recall timeline, context composition)
+//   keeper-v2/styles/memory.css (.mem-* — see memory-inspector-v2.css)
+//
+// The prototype reads from window.KEEPERS / window.COMPACTIONS globals.
+// Here the data is typed and injectable (props) so the component is
+// decoupled and unit-testable; the ported fixture is the default. The
+// rendering — every section, glyph, Korean/English string, and the
+// context-composition math — mirrors the prototype 1:1.
+//
+// Drawer shell: .turn-overlay / .turn-drawer (ported in
+// memory-inspector-v2.css, which the *-v2.css glob in main.ts eagerly
+// imports). Scope toggle: 이 keeper / 전체 (memory.jsx:233-234).
+
+import { html } from 'htm/preact'
+import { useEffect } from 'preact/hooks'
+import { useSignal } from '@preact/signals'
+
+// ── Window-window constant (memory-data.jsx:116 → ctx * 200000) ──
+const CONTEXT_WINDOW_TOK = 200000
+
+// ── store-entry kinds → label + glyph + tone class (memory-data.jsx:9-15) ──
+export type MemKind = 'fact' | 'decision' | 'pattern' | 'pref' | 'entity'
+interface MemKindMeta {
+  readonly lbl: string
+  readonly glyph: string
+  readonly cls: string
+}
+export const MEM_KINDS: Readonly<Record<MemKind, MemKindMeta>> = {
+  fact: { lbl: '사실', glyph: '◈', cls: 'fact' },
+  decision: { lbl: '결정', glyph: '◆', cls: 'decision' },
+  pattern: { lbl: '패턴', glyph: '◉', cls: 'pattern' },
+  pref: { lbl: '선호', glyph: '○', cls: 'pref' },
+  entity: { lbl: '개체', glyph: '▢', cls: 'entity' },
+}
+
+// ── recall-timeline operations (memory-data.jsx:18-24) ──
+export type MemOp = 'recall' | 'inject' | 'pin' | 'compact' | 'evict'
+interface MemOpMeta {
+  readonly lbl: string
+  readonly glyph: string
+  readonly cls: string
+}
+export const MEM_OPS: Readonly<Record<MemOp, MemOpMeta>> = {
+  recall: { lbl: '회상', glyph: '↺', cls: 'recall' },
+  inject: { lbl: '주입', glyph: '⤓', cls: 'inject' },
+  pin: { lbl: '핀', glyph: '⊙', cls: 'pin' },
+  compact: { lbl: '압축', glyph: '◉', cls: 'compact' },
+  evict: { lbl: '폐기', glyph: '◌', cls: 'evict' },
+}
+
+export interface MemPin {
+  readonly id: string
+  readonly text: string
+  readonly by: 'operator' | 'auto'
+  readonly at: string
+  readonly tag: string
+}
+export interface MemStoreEntry {
+  readonly id: string
+  readonly kind: MemKind
+  readonly text: string
+  readonly salience: number
+  readonly uses?: number
+  readonly lastUsed?: string
+  readonly src: string
+}
+export interface MemRecall {
+  readonly at: string
+  readonly op: MemOp
+  readonly text: string
+  readonly tok: number
+}
+export interface KeeperMemoryRecord {
+  readonly pinned: readonly MemPin[]
+  readonly store: readonly MemStoreEntry[]
+  readonly recall: readonly MemRecall[]
+}
+
+// Minimal keeper shape the inspector reads (subset of the prototype keeper).
+export interface MemoryKeeper {
+  readonly id: string
+  readonly ctx: number
+  readonly status: string
+  readonly tasks?: number
+  readonly traces?: number
+}
+
+export interface Compaction {
+  readonly id: string
+  readonly at: string
+  readonly trigger: string
+  readonly kept: readonly string[]
+  readonly summarized: readonly string[]
+  readonly dropped: readonly string[]
+}
+
+// ── fixture (memory-data.jsx:26-112) — ported verbatim ──
+export const KEEPER_MEMORY: Readonly<Record<string, KeeperMemoryRecord>> = {
+  'masc-improver': {
+    pinned: [
+      { id: 'p1', text: 'retention 정의: D0 = 가입일, 첫 세션 기준', by: 'operator', at: '2d', tag: 'definition' },
+      { id: 'p2', text: 'gp:center_type 미정값은 제외하지 말고 "미정" 버킷으로 유지', by: 'operator', at: '1d', tag: 'caveat' },
+      { id: 'p3', text: 'amplitude D0–D3 코호트는 KST 자정 기준으로 끊는다', by: 'auto', at: '5h', tag: 'definition' },
+    ],
+    store: [
+      { id: 's1', kind: 'fact', text: 'trace-store p99 쓰기 지연 목표 < 20ms (현재 19ms)', salience: 0.92, uses: 14, lastUsed: '12분', src: 'T-3902' },
+      { id: 's2', kind: 'decision', text: '리텐션 대시보드 = 코호트 히트맵 + D0/D1/D7 3열로 확정', salience: 0.81, uses: 9, lastUsed: '41분', src: 'goal-retention' },
+      { id: 's3', kind: 'pattern', text: 'amplitude 쿼리 결과는 표로 정규화 후 캐시 — 동일 segment 재질의 빈번', salience: 0.74, uses: 22, lastUsed: '1h', src: 'self' },
+      { id: 's4', kind: 'pref', text: 'operator는 숫자에 천단위 구분 + 단위 명시 선호', salience: 0.55, uses: 6, lastUsed: '3h', src: 'operator' },
+      { id: 's5', kind: 'entity', text: 'gp:center_type — 가맹점 분류 차원 (마트/편의점/기타/미정)', salience: 0.68, uses: 11, lastUsed: '2h', src: 'T-3880' },
+    ],
+    recall: [
+      { at: '14:01', op: 'compact', text: '컨텍스트 86% → 컴팩션, 핵심 사실 5건 유지', tok: -110600 },
+      { at: '13:58', op: 'recall', text: 'retention 정의 + center_type 메모 회상 (턴 시작)', tok: 1840 },
+      { at: '13:52', op: 'inject', text: 'amplitude 표 캐시 주입', tok: 3200 },
+      { at: '13:30', op: 'pin', text: 'operator가 "center_type 미정 버킷 유지" 핀 고정', tok: 120 },
+      { at: '12:10', op: 'evict', text: '만료된 쿼리 캐시 9건 폐기', tok: -4100 },
+    ],
+  },
+  nick0cave: {
+    pinned: [
+      { id: 'p1', text: 'compact()는 lock 보유 중 호출 금지 — p95 380ms 스파이크 원인', by: 'operator', at: '6h', tag: 'risk' },
+      { id: 'p2', text: '임계값 0.38은 seoul-1 기준, tokyo-2는 RTT 보정 필요', by: 'auto', at: '3h', tag: 'caveat' },
+    ],
+    store: [
+      { id: 's1', kind: 'fact', text: 'core/scheduler jitter p95 회귀 가드: 380ms → 19ms', salience: 0.95, uses: 18, lastUsed: '3분', src: 'T-3902' },
+      { id: 's2', kind: 'decision', text: 'unlock 후 압축으로 이동 — compact()를 critical section 밖으로', salience: 0.88, uses: 12, lastUsed: '9분', src: 'T-3902' },
+      { id: 's3', kind: 'pattern', text: 'lock 재진입 가설은 trace_window open_fds 메트릭으로 검증', salience: 0.70, uses: 7, lastUsed: '22분', src: 'self' },
+      { id: 's4', kind: 'entity', text: 'Exec_policy — 실행 정책 통합 표면 (RFC-0254)', salience: 0.60, uses: 5, lastUsed: '1h', src: 'goal-exec-policy' },
+    ],
+    recall: [
+      { at: '14:01', op: 'compact', text: '컨텍스트 91% → 컴팩션, 182k → 58k', tok: -124200 },
+      { at: '13:40', op: 'recall', text: 'jitter 가드 + unlock 결정 회상', tok: 2100 },
+      { at: '13:20', op: 'pin', text: 'auto: tokyo-2 RTT 보정 caveat 핀', tok: 90 },
+    ],
+  },
+  sangsu: {
+    pinned: [
+      { id: 'p1', text: 'round_test.ml 84/84 통과가 머지 게이트 — 깨지면 즉시 중단', by: 'operator', at: '1d', tag: 'gate' },
+    ],
+    store: [
+      { id: 's1', kind: 'fact', text: 'core/runtime dune test 84/84 ok (41.2s)', salience: 0.85, uses: 10, lastUsed: '방금', src: 'self' },
+      { id: 's2', kind: 'pattern', text: 'Eio 리소스는 연 Switch가 닫힐 때 해제 — 라이터는 로컬 Switch.run으로', salience: 0.90, uses: 15, lastUsed: '4분', src: 'T-3902' },
+      { id: 's3', kind: 'pref', text: 'diff는 side-by-side, 탭 너비 2', salience: 0.40, uses: 3, lastUsed: '2h', src: 'operator' },
+    ],
+    recall: [
+      { at: '방금', op: 'recall', text: 'Switch 수명 패턴 회상', tok: 1500 },
+      { at: '12분', op: 'inject', text: 'round_test 결과 주입', tok: 800 },
+    ],
+  },
+  'qa-king': {
+    pinned: [
+      { id: 'p1', text: 'docs/site는 PR마다 프리뷰 배포 — 링크 깨지면 fail', by: 'auto', at: '8h', tag: 'gate' },
+    ],
+    store: [
+      { id: 's1', kind: 'fact', text: 'docs 사이트 빌드 시간 평균 58s', salience: 0.50, uses: 4, lastUsed: '8분', src: 'self' },
+      { id: 's2', kind: 'decision', text: '핸드오프 시 미해결 링크 점검 항목을 다음 keeper에 전달', salience: 0.66, uses: 5, lastUsed: '8분', src: 'self' },
+    ],
+    recall: [
+      { at: '8분', op: 'compact', text: 'HandingOff — 컨텍스트 정리', tok: -42000 },
+    ],
+  },
+  analyst: {
+    pinned: [
+      { id: 'p1', text: 'search/index 재색인은 야간 윈도우(02:00 KST)에만', by: 'operator', at: '12h', tag: 'caveat' },
+    ],
+    store: [
+      { id: 's1', kind: 'fact', text: 'search/index 문서 ~1.2M, 재색인 ~34분', salience: 0.62, uses: 6, lastUsed: '34분', src: 'self' },
+      { id: 's2', kind: 'entity', text: 'gp:center_type 분포 — 분석 코호트 핵심 차원', salience: 0.58, uses: 8, lastUsed: '2h', src: 'T-3880' },
+    ],
+    recall: [
+      { at: '34분', op: 'recall', text: '재색인 윈도우 caveat 회상', tok: 600 },
+    ],
+  },
+  drifter: {
+    pinned: [],
+    store: [
+      { id: 's1', kind: 'fact', text: 'core/runtime overflow 재현: 컨텍스트 100%에서 trace 라이터 fd 누수 누적', salience: 0.70, uses: 3, lastUsed: '3시간', src: 'T-3902' },
+    ],
+    recall: [
+      { at: '3시간', op: 'evict', text: 'Overflowed — 컨텍스트 전체 폐기 직전 스냅샷', tok: -200000 },
+    ],
+  },
+}
+
+// Default keeper roster (subset needed by the inspector) so the
+// 전체 (aggregate) scope renders without external wiring. Status values
+// mirror the prototype keeper roster intent (run / pause / off).
+export const DEFAULT_MEMORY_KEEPERS: readonly MemoryKeeper[] = [
+  { id: 'masc-improver', ctx: 0.86, status: 'run', tasks: 4, traces: 27 },
+  { id: 'nick0cave', ctx: 0.91, status: 'run', tasks: 4, traces: 38 },
+  { id: 'sangsu', ctx: 0.34, status: 'run', tasks: 2, traces: 11 },
+  { id: 'qa-king', ctx: 0.22, status: 'pause', tasks: 1, traces: 6 },
+  { id: 'analyst', ctx: 0.41, status: 'run', tasks: 1, traces: 9 },
+  { id: 'drifter', ctx: 0, status: 'off', tasks: 0, traces: 4 },
+]
+
+export const DEFAULT_COMPACTIONS: Readonly<Record<string, readonly Compaction[]>> = {
+  nick0cave: [
+    {
+      id: 'cmp_7f3a', at: '14:01', trigger: '컨텍스트 91% — 자동 임계치',
+      kept: ['소유 태스크 4건 (T-3902 외)', 'core/scheduler 최근 변경 요약', 'compact lock 재진입 가설'],
+      summarized: ['14:01 이전 라운드 로그 52개 → 6줄 요약', '완료된 trace 29건 → 통계만 보존'],
+      dropped: ['중복 도구 결과 11건', '취소된 분기 탐색 로그'],
+    },
+  ],
+  'masc-improver': [
+    {
+      id: 'cmp_3d90', at: '13:30', trigger: '컨텍스트 86% — 자동 임계치',
+      kept: ['리텐션 정의 (D0=가입일)', 'center_type 분류 미정값 메모'],
+      summarized: ['amplitude 쿼리 결과 14건 → 표 1개'],
+      dropped: ['중복 세그먼트 응답 6건'],
+    },
+  ],
+  'qa-king': [
+    {
+      id: 'cmp_qa01', at: '8분', trigger: 'HandingOff — 핸드오프 정리',
+      kept: ['미해결 링크 점검 항목'],
+      summarized: ['docs 빌드 로그 → 요약'],
+      dropped: ['완료된 프리뷰 배포 로그'],
+    },
+  ],
+  drifter: [
+    {
+      id: 'cmp_dr01', at: '3시간', trigger: 'Overflowed — 컨텍스트 전체 폐기',
+      kept: [],
+      summarized: [],
+      dropped: ['컨텍스트 전체 스냅샷'],
+    },
+  ],
+}
+
+// ── token formatter (memory.jsx:8-12) ──
+export function memFmtTok(n: number): string {
+  const a = Math.abs(n)
+  const s = a >= 1000 ? `${(a / 1000).toFixed(1)}k` : String(a)
+  return (n < 0 ? '−' : '') + s
+}
+
+export function getKeeperMemory(
+  k: MemoryKeeper,
+  store: Readonly<Record<string, KeeperMemoryRecord>> = KEEPER_MEMORY,
+): KeeperMemoryRecord {
+  return store[k.id] ?? { pinned: [], store: [], recall: [] }
+}
+
+export interface CompositionPart {
+  readonly key: string
+  readonly lbl: string
+  readonly tok: number
+  readonly color: string
+}
+export interface Composition {
+  readonly total: number
+  readonly parts: readonly CompositionPart[]
+}
+
+// context-window composition for a keeper, derived from live ctx tokens
+// (memory-data.jsx:115-133). Math ported verbatim.
+export function memComposition(
+  k: MemoryKeeper,
+  store: Readonly<Record<string, KeeperMemoryRecord>> = KEEPER_MEMORY,
+): Composition {
+  const total = Math.round((k.ctx || 0) * CONTEXT_WINDOW_TOK)
+  if (total === 0) return { total: 0, parts: [] }
+  const rec = store[k.id] ?? { store: [], pinned: [], recall: [] }
+  const mem = rec.store.length * 900 + rec.pinned.length * 220
+  const system = 6200
+  const tasks = (k.tasks || 0) * 2600
+  const traces = Math.min(Math.round(total * 0.42), (k.traces || 0) * 90)
+  let nsDialog = total - system - tasks - traces - mem
+  if (nsDialog < total * 0.1) nsDialog = Math.round(total * 0.2)
+  const parts: CompositionPart[] = [
+    { key: 'system', lbl: '시스템·월드 프롬프트', tok: system, color: 'var(--text-dim)' },
+    { key: 'ns', lbl: 'namespace · 대화 로그', tok: nsDialog, color: 'var(--volt)' },
+    { key: 'tasks', lbl: '소유 태스크', tok: tasks, color: 'var(--info)' },
+    { key: 'traces', lbl: '최근 trace', tok: traces, color: 'var(--status-warn)' },
+    { key: 'memory', lbl: '메모리 (핀 + 스토어)', tok: mem, color: 'var(--status-ok)' },
+  ].filter(p => p.tok > 0)
+  return { total, parts }
+}
+
+export interface AggregateRow {
+  readonly id: string
+  readonly ctx: number
+  readonly status: string
+  readonly pinned: number
+  readonly store: number
+  readonly memTok: number
+}
+export interface MemAggregate {
+  readonly rows: readonly AggregateRow[]
+  readonly pinned: number
+  readonly store: number
+  readonly memTok: number
+  readonly kindTotals: Readonly<Record<string, number>>
+  readonly topFacts: readonly (MemStoreEntry & { keeper: string })[]
+  readonly keeperCount: number
+}
+
+// aggregate across the passed keepers (memory-data.jsx:140-160).
+export function memAggregate(
+  keepers: readonly MemoryKeeper[],
+  store: Readonly<Record<string, KeeperMemoryRecord>> = KEEPER_MEMORY,
+): MemAggregate {
+  const rows: AggregateRow[] = []
+  let pinned = 0
+  let storeCount = 0
+  let memTok = 0
+  const kindTotals: Record<string, number> = {}
+  const allFacts: (MemStoreEntry & { keeper: string })[] = []
+  keepers.forEach(k => {
+    const m = getKeeperMemory(k, store)
+    const comp = memComposition(k, store)
+    const mt = comp.parts.find(p => p.key === 'memory')?.tok ?? 0
+    pinned += m.pinned.length
+    storeCount += m.store.length
+    memTok += mt
+    m.store.forEach(s => {
+      kindTotals[s.kind] = (kindTotals[s.kind] ?? 0) + 1
+      allFacts.push({ ...s, keeper: k.id })
+    })
+    rows.push({ id: k.id, ctx: k.ctx, status: k.status, pinned: m.pinned.length, store: m.store.length, memTok: mt })
+  })
+  const topFacts = [...allFacts].sort((a, b) => b.salience - a.salience).slice(0, 6)
+  return { rows, pinned, store: storeCount, memTok, kindTotals, topFacts, keeperCount: keepers.length }
+}
+
+// ── rendering ──
+
+function MemBar({ parts, total }: { parts: readonly CompositionPart[]; total: number }) {
+  return html`
+    <div class="mem-bar" title="컨텍스트 윈도우 구성">
+      ${parts.map(p => html`<span key=${p.key} style=${{ width: `${(p.tok / total) * 100}%`, background: p.color }}></span>`)}
+    </div>`
+}
+
+function MemCompo({ keeper, store }: { keeper: MemoryKeeper; store: Readonly<Record<string, KeeperMemoryRecord>> }) {
+  const { total, parts } = memComposition(keeper, store)
+  if (!total) return html`<div class="mem-empty">중지된 keeper — 활성 컨텍스트 없음.</div>`
+  return html`
+    <div class="mem-compo">
+      <div class="mem-compo-head">
+        <span class="mono mem-compo-tot">${(total / 1000).toFixed(1)}k</span>
+        <span class="mem-compo-sub">/ 200k 윈도우 · ${Math.round(keeper.ctx * 100)}%</span>
+      </div>
+      <${MemBar} parts=${parts} total=${total} />
+      <div class="mem-legend">
+        ${parts.map(p => html`
+          <div key=${p.key} class="mem-leg">
+            <span class="mem-leg-sw" style=${{ background: p.color }}></span>
+            <span class="mem-leg-lbl">${p.lbl}</span>
+            <span class="mem-leg-v mono">${memFmtTok(p.tok)}</span>
+          </div>`)}
+      </div>
+    </div>`
+}
+
+function MemSalience({ v }: { v: number }) {
+  return html`<span class="mem-sal" title=${`salience ${v.toFixed(2)}`}><span style=${{ width: `${v * 100}%` }}></span></span>`
+}
+
+function MemStoreRow({ s, srcOverride }: { s: MemStoreEntry; srcOverride?: string }) {
+  const k = MEM_KINDS[s.kind]
+  return html`
+    <div class="mem-store-row">
+      <span class=${`mem-kind ${k.cls}`}>${k.glyph} ${k.lbl}</span>
+      <div class="mem-store-main">
+        <div class="mem-store-text">${s.text}</div>
+        <div class="mem-store-meta">
+          <${MemSalience} v=${s.salience} />
+          ${s.uses != null ? html`<span class="mono">${s.uses}회 사용</span>` : null}
+          ${s.lastUsed ? html`<span>최근 ${s.lastUsed}</span>` : null}
+          <span class="mem-src mono">${srcOverride ?? s.src}</span>
+        </div>
+      </div>
+    </div>`
+}
+
+// status dot — mirrors prototype StatusDot (memory.jsx:196):
+// run → ok, pause → idle, else → bad.
+function memDotState(status: string): 'ok' | 'idle' | 'bad' {
+  return status === 'run' ? 'ok' : status === 'pause' ? 'idle' : 'bad'
+}
+
+function OneKeeperMemory({
+  keeper,
+  store,
+  compactions,
+}: {
+  keeper: MemoryKeeper
+  store: Readonly<Record<string, KeeperMemoryRecord>>
+  compactions: Readonly<Record<string, readonly Compaction[]>>
+}) {
+  const m = getKeeperMemory(keeper, store)
+  const comps = compactions[keeper.id] ?? []
+  const lastCmp = comps[0]
+  const kindFilter = useSignal<'all' | MemKind>('all')
+  const kinds = [...new Set(m.store.map(s => s.kind))]
+  const filter = kindFilter.value
+  const storeRows = filter === 'all' ? m.store : m.store.filter(s => s.kind === filter)
+  return html`
+    <${''}>
+      <div class="turn-sec">
+        <h4>컨텍스트 구성</h4>
+        <${MemCompo} keeper=${keeper} store=${store} />
+      </div>
+
+      <div class="turn-sec">
+        <h4>핀 고정 사실 · ${m.pinned.length}</h4>
+        ${m.pinned.length ? html`
+          <div class="mem-pins">
+            ${m.pinned.map(p => html`
+              <div key=${p.id} class="mem-pin">
+                <span class="mem-pin-ico">${'⊙'}</span>
+                <div class="mem-pin-body">
+                  <div class="mem-pin-text">${p.text}</div>
+                  <div class="mem-pin-meta">
+                    <span class=${`mem-by ${p.by}`}>${p.by}</span>
+                    <span class="mem-tag">${p.tag}</span>
+                    <span class="mono">${p.at} 전</span>
+                  </div>
+                </div>
+              </div>`)}
+          </div>` : html`<div class="mem-empty">핀 고정된 사실 없음.</div>`}
+      </div>
+
+      <div class="turn-sec">
+        <div class="mem-sec-head">
+          <h4>장기 메모리 스토어 · memory-os</h4>
+          <span class="mem-n mono">${m.store.length}</span>
+        </div>
+        ${m.store.length ? html`
+          <${''}>
+            ${kinds.length > 1 ? html`
+              <div class="mem-filters">
+                <button class=${`mem-filter ${filter === 'all' ? 'on' : ''}`} onClick=${() => { kindFilter.value = 'all' }}>전체</button>
+                ${kinds.map(kk => {
+                  const d = MEM_KINDS[kk]
+                  return html`<button key=${kk} class=${`mem-filter ${filter === kk ? 'on' : ''}`} onClick=${() => { kindFilter.value = kk }}>${d.glyph} ${d.lbl}</button>`
+                })}
+              </div>` : null}
+            <div class="mem-store">${storeRows.map(s => html`<${MemStoreRow} key=${s.id} s=${s} />`)}</div>
+          </>` : html`<div class="mem-empty">장기 메모리 항목 없음.</div>`}
+      </div>
+
+      <div class="turn-sec">
+        <h4>최근 회상 · 주입</h4>
+        ${m.recall && m.recall.length ? html`
+          <div class="mem-timeline">
+            ${m.recall.map((r, i) => {
+              const o = MEM_OPS[r.op]
+              return html`
+                <div key=${i} class="mem-tl-row">
+                  <span class="mem-tl-at mono">${r.at}</span>
+                  <span class=${`mem-op ${o.cls}`}>${o.glyph} ${o.lbl}</span>
+                  <span class="mem-tl-text">${r.text}</span>
+                  <span class=${`mem-tl-tok mono ${r.tok < 0 ? 'neg' : 'pos'}`}>${memFmtTok(r.tok)}</span>
+                </div>`
+            })}
+          </div>` : html`<div class="mem-empty">기록된 회상 없음.</div>`}
+      </div>
+
+      <div class="turn-sec">
+        <h4>압축 유지 · 요약 · 폐기</h4>
+        ${lastCmp ? html`
+          <${''}>
+            <div class="cmp-trigger"><span class="sub-k">최근 컴팩션</span>${lastCmp.at} · ${lastCmp.trigger}</div>
+            <div class="cmp-diff">
+              <div class="cmp-col kept"><div class="cmp-col-h">${'◈'} 유지</div>${lastCmp.kept.map((x, i) => html`<div key=${i} class="cmp-li">${x}</div>`)}</div>
+              <div class="cmp-col summ"><div class="cmp-col-h">${'◉'} 요약</div>${lastCmp.summarized.map((x, i) => html`<div key=${i} class="cmp-li">${x}</div>`)}</div>
+              <div class="cmp-col drop"><div class="cmp-col-h">${'◌'} 폐기</div>${lastCmp.dropped.map((x, i) => html`<div key=${i} class="cmp-li">${x}</div>`)}</div>
+            </div>
+          </>` : html`<div class="mem-empty">컴팩션 이력 없음 — 메모리가 압축된 적 없음.</div>`}
+      </div>
+    </>`
+}
+
+function AllKeepersMemory({
+  keepers,
+  store,
+  onPick,
+}: {
+  keepers: readonly MemoryKeeper[]
+  store: Readonly<Record<string, KeeperMemoryRecord>>
+  onPick: (id: string) => void
+}) {
+  const agg = memAggregate(keepers, store)
+  const maxMem = Math.max(1, ...agg.rows.map(r => r.memTok))
+  return html`
+    <${''}>
+      <div class="turn-sec">
+        <h4>집계</h4>
+        <div class="mem-stats">
+          <div class="mem-stat"><span class="v mono">${agg.keeperCount}</span><span class="k">keeper</span></div>
+          <div class="mem-stat"><span class="v mono">${agg.pinned}</span><span class="k">핀 고정</span></div>
+          <div class="mem-stat"><span class="v mono">${agg.store}</span><span class="k">스토어 항목</span></div>
+          <div class="mem-stat"><span class="v mono">${(agg.memTok / 1000).toFixed(1)}k</span><span class="k">메모리 토큰</span></div>
+        </div>
+      </div>
+
+      <div class="turn-sec">
+        <h4>종류별 분포</h4>
+        <div class="mem-kinds-dist">
+          ${Object.entries(agg.kindTotals).sort((a, b) => b[1] - a[1]).map(([kk, n]) => {
+            const d = MEM_KINDS[kk as MemKind] ?? { lbl: kk, glyph: '◈', cls: '' }
+            return html`
+              <div key=${kk} class="mem-kd-row">
+                <span class=${`mem-kind ${d.cls}`}>${d.glyph} ${d.lbl}</span>
+                <div class="mem-kd-bar"><span style=${{ width: `${(n / agg.store) * 100}%` }}></span></div>
+                <span class="mono mem-kd-n">${n}</span>
+              </div>`
+          })}
+        </div>
+      </div>
+
+      <div class="turn-sec">
+        <h4>keeper별 메모리 <span class="mem-hint">행을 누르면 개별 보기</span></h4>
+        <div class="mem-table">
+          <div class="mem-tr mem-th"><span>keeper</span><span>ctx</span><span>핀</span><span>스토어</span><span>mem tok</span></div>
+          ${agg.rows.map(r => html`
+            <button key=${r.id} class="mem-tr" onClick=${() => onPick(r.id)}>
+              <span class="mem-td-id"><span class=${`mem-dot ${memDotState(r.status)}`}></span><span class="mono">${r.id}</span></span>
+              <span class="mono">${Math.round(r.ctx * 100)}%</span>
+              <span class="mono">${r.pinned}</span>
+              <span class="mono">${r.store}</span>
+              <span class="mem-td-bar"><i style=${{ width: `${(r.memTok / maxMem) * 100}%` }}></i><b class="mono">${(r.memTok / 1000).toFixed(1)}k</b></span>
+            </button>`)}
+        </div>
+      </div>
+
+      <div class="turn-sec">
+        <h4>가장 salient한 사실 · 전체</h4>
+        <div class="mem-store">
+          ${agg.topFacts.map(s => html`<${MemStoreRow} key=${s.keeper + s.id} s=${s} srcOverride=${s.keeper} />`)}
+        </div>
+      </div>
+    </>`
+}
+
+export interface MemoryInspectorProps {
+  readonly keeper: MemoryKeeper
+  readonly onClose: () => void
+  readonly keepers?: readonly MemoryKeeper[]
+  readonly memory?: Readonly<Record<string, KeeperMemoryRecord>>
+  readonly compactions?: Readonly<Record<string, readonly Compaction[]>>
+}
+
+export function MemoryInspector({
+  keeper,
+  onClose,
+  keepers = DEFAULT_MEMORY_KEEPERS,
+  memory = KEEPER_MEMORY,
+  compactions = DEFAULT_COMPACTIONS,
+}: MemoryInspectorProps) {
+  const scope = useSignal<'one' | 'all'>('one')
+  const pickId = useSignal(keeper.id)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const active = keepers.find(k => k.id === pickId.value) ?? keeper
+  const isOne = scope.value === 'one'
+
+  return html`
+    <div class="turn-overlay" onClick=${onClose}>
+      <div class="turn-drawer mem-drawer" onClick=${(e: MouseEvent) => e.stopPropagation()}>
+        <div class="turn-hd">
+          <h3>Keeper 메모리</h3>
+          <span class="tid">${isOne ? active.id : '전체 keeper'}</span>
+          <div class="mem-scope">
+            <button class=${isOne ? 'on' : ''} onClick=${() => { scope.value = 'one' }}>이 keeper</button>
+            <button class=${!isOne ? 'on' : ''} onClick=${() => { scope.value = 'all' }}>전체</button>
+          </div>
+          <button class="turn-close" onClick=${onClose} title="닫기 (Esc)">${'✕'}</button>
+        </div>
+        <div class="turn-body">
+          ${isOne
+            ? html`<${OneKeeperMemory} keeper=${active} store=${memory} compactions=${compactions} />`
+            : html`<${AllKeepersMemory} keepers=${keepers} store=${memory} onPick=${(id: string) => { pickId.value = id; scope.value = 'one' }} />`}
+        </div>
+      </div>
+    </div>`
+}

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -16,9 +16,18 @@
 // memory-inspector-v2.css, which the *-v2.css glob in main.ts eagerly
 // imports). Scope toggle: 이 keeper / 전체 (memory.jsx:233-234).
 
+import { Fragment } from 'preact'
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
+
+// WORKAROUND: nested fragments use the Fragment tag, not htm's empty-string-tag
+// form. An empty string tag makes preact call document.createElement('') on
+// nested vnodes, which throws InvalidCharacterError in both jsdom and happy-dom
+// (and real browsers). An empty-string fragment only survives as a render *root*
+// because the test harness wraps it. Root cause: htm represents a fragment via
+// the Fragment export, not an empty tag name. This component is currently
+// imported nowhere, so the crash was never exercised; wiring is a later wave.
 
 // ── Window-window constant (memory-data.jsx:116 → ctx * 200000) ──
 const CONTEXT_WINDOW_TOK = 200000
@@ -405,7 +414,7 @@ function OneKeeperMemory({
   const filter = kindFilter.value
   const storeRows = filter === 'all' ? m.store : m.store.filter(s => s.kind === filter)
   return html`
-    <${''}>
+    <${Fragment}>
       <div class="turn-sec">
         <h4>컨텍스트 구성</h4>
         <${MemCompo} keeper=${keeper} store=${store} />
@@ -436,7 +445,7 @@ function OneKeeperMemory({
           <span class="mem-n mono">${m.store.length}</span>
         </div>
         ${m.store.length ? html`
-          <${''}>
+          <${Fragment}>
             ${kinds.length > 1 ? html`
               <div class="mem-filters">
                 <button class=${`mem-filter ${filter === 'all' ? 'on' : ''}`} onClick=${() => { kindFilter.value = 'all' }}>전체</button>
@@ -469,7 +478,7 @@ function OneKeeperMemory({
       <div class="turn-sec">
         <h4>압축 유지 · 요약 · 폐기</h4>
         ${lastCmp ? html`
-          <${''}>
+          <${Fragment}>
             <div class="cmp-trigger"><span class="sub-k">최근 컴팩션</span>${lastCmp.at} · ${lastCmp.trigger}</div>
             <div class="cmp-diff">
               <div class="cmp-col kept"><div class="cmp-col-h">${'◈'} 유지</div>${lastCmp.kept.map((x, i) => html`<div key=${i} class="cmp-li">${x}</div>`)}</div>
@@ -493,7 +502,7 @@ function AllKeepersMemory({
   const agg = memAggregate(keepers, store)
   const maxMem = Math.max(1, ...agg.rows.map(r => r.memTok))
   return html`
-    <${''}>
+    <${Fragment}>
       <div class="turn-sec">
         <h4>집계</h4>
         <div class="mem-stats">

--- a/dashboard/src/styles/memory-inspector-v2.css
+++ b/dashboard/src/styles/memory-inspector-v2.css
@@ -184,3 +184,16 @@
 @media (max-width: 560px) {
   .turn-drawer { width: 100vw; }
 }
+
+/* Inspector trigger button — keeper-v2/styles/v2.css:1209-1216 (.cmp-open).
+   In the prototype this lives in the ctx-rail; here it opens the inspector
+   from the memory seam (agent-detail-memory). Ported verbatim: literal
+   11.5px / 10px font + 8px 10px padding (rails.jsx:513-515 text). */
+.cmp-open {
+  width: 100%; margin-top: 10px; display: flex; align-items: center; gap: 7px;
+  font-family: var(--font-ui); font-size: 11.5px; color: var(--text-mid);
+  padding: 8px 10px; background: var(--bg-sunken); border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm); cursor: pointer; transition: 0.14s;
+}
+.cmp-open:hover { border-color: var(--volt-dim); color: var(--volt); }
+.cmp-open-sub { margin-left: auto; font-size: 10px; color: var(--text-dim); }

--- a/dashboard/src/styles/memory-inspector-v2.css
+++ b/dashboard/src/styles/memory-inspector-v2.css
@@ -160,14 +160,16 @@
 .mem-td-id { display: inline-flex; align-items: center; gap: 7px; min-width: 0; }
 .mem-td-id .mono { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* status dot in the keeper table — mirrors the prototype's <StatusDot>
-   (keeper-v2/memory.jsx:196 → window.KV.Dot state=ok|warn|idle|bad).
-   This dashboard has no KV.Dot primitive that carries the v2 status
-   palette, so a self-contained 7px dot is rendered with the same
-   run→ok / pause→idle / else→bad state mapping. */
-.mem-dot { display: inline-block; width: 7px; height: 7px; border-radius: var(--radius-pill); flex: none; background: var(--text-dim); }
-.mem-dot.ok { background: var(--status-ok); }
-.mem-dot.idle { background: var(--text-dim); }
-.mem-dot.bad { background: var(--volt); }
+   (keeper-v2/memory.jsx:196 → window.KV.Dot → .dot2, keeper-v2/styles/v2.css:395-398).
+   This dashboard has no .dot2 primitive that carries the v2 status palette,
+   so a self-contained 7px dot is rendered 1:1 with the prototype's .dot2:
+   base/idle → --status-idle, ok → --status-ok, bad → --status-bad, each
+   coloured state carrying the same `0 0 7px` glow. The prototype mapping is
+   run→ok / pause→idle / else→bad (StatusDot in keeper-v2/messages.jsx:8-11). */
+.mem-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; flex: none; background: var(--status-idle); }
+.mem-dot.ok { background: var(--status-ok); box-shadow: 0 0 7px var(--status-ok); }
+.mem-dot.idle { background: var(--status-idle); }
+.mem-dot.bad { background: var(--status-bad); box-shadow: 0 0 7px var(--status-bad); }
 .mem-td-bar { position: relative; display: flex; align-items: center; }
 .mem-td-bar i { position: absolute; left: 0; height: 6px; background: color-mix(in oklab, var(--status-ok) 45%, transparent); border-radius: 3px; }
 .mem-td-bar b { position: relative; margin-left: auto; font-weight: 500; font-size: 11px; color: var(--text-mid); }

--- a/dashboard/src/styles/memory-inspector-v2.css
+++ b/dashboard/src/styles/memory-inspector-v2.css
@@ -1,0 +1,186 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Keeper memory inspector (read-only overlay-drawer).
+   Pixel-matched to the Claude-Design prototype:
+     keeper-v2/memory.jsx + keeper-v2/styles/memory.css
+   and the drawer shell from keeper-v2/styles/v2.css.
+
+   The prototype reuses .turn-overlay / .turn-drawer / .turn-hd /
+   .turn-body / .turn-sec / .cmp-diff (defined in keeper-v2/styles/v2.css
+   :687-706, :1316-1326). Those shell classes do NOT yet exist in this
+   dashboard, so they are ported here verbatim (scoped where the
+   prototype scopes them). Everything else is the prototype's .mem-* set,
+   copied 1:1 from keeper-v2/styles/memory.css.
+
+   v2 canonical tokens only (--volt*, --border*, --bg-*, --text-*,
+   --status-*, --info, --radius-*, --font-*). Literal px values are kept
+   where the prototype specifies a literal that the 2px-base --sp-* scale
+   would shrink; each literal originates from the prototype source cited
+   inline.
+   ══════════════════════════════════════════════════════════════ */
+
+/* ── drawer shell (ported from keeper-v2/styles/v2.css) ── */
+/* keeper-v2/styles/v2.css:687 */
+.turn-overlay { position: fixed; inset: 0; background: rgba(4, 5, 8, 0.42); z-index: 90; display: flex; justify-content: flex-end; }
+/* keeper-v2/styles/v2.css:688-692 */
+.turn-drawer {
+  width: min(560px, 94vw); height: 100%; background: var(--bg-panel);
+  border-left: 1px solid var(--border-main); box-shadow: -8px 0 30px rgba(0, 0, 0, 0.5);
+  display: flex; flex-direction: column; animation: turn-in 0.18s ease;
+}
+/* keeper-v2/styles/v2.css:693 */
+@keyframes turn-in { from { transform: translateX(24px); opacity: 0; } to { transform: none; opacity: 1; } }
+/* keeper-v2/styles/v2.css:694-700 */
+.turn-hd { display: flex; align-items: center; gap: 10px; padding: 14px 16px; border-bottom: 1px solid var(--border-main); }
+.turn-hd h3 { font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.14em; font-size: 13px; color: var(--text-bright); margin: 0; }
+.turn-hd .tid { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
+.turn-close { margin-left: auto; background: none; border: 1px solid var(--border-main); color: var(--text-mid); width: 26px; height: 26px; border-radius: var(--radius-sm); cursor: pointer; font-size: 12px; transition: 0.14s; }
+.turn-close:hover { border-color: var(--volt-dim); color: var(--volt); }
+/* keeper-v2/styles/v2.css:705-706 */
+.turn-body { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 16px; }
+.turn-sec h4 { font-family: var(--font-ui); text-transform: uppercase; letter-spacing: 0.1em; font-size: 10px; color: var(--text-dim); margin: 0 0 8px; }
+/* keeper-v2/styles/v2.css:891 */
+.sub-k { font-family: var(--font-ui); font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-dim); margin-right: 4px; }
+/* keeper-v2/styles/v2.css:1282-1283 */
+.cmp-trigger { font-size: 12px; color: var(--text-mid); margin-bottom: 4px; }
+.cmp-trigger .sub-k { margin-right: 6px; }
+/* keeper-v2/styles/v2.css:1316-1326 */
+.cmp-diff { display: grid; grid-template-columns: 1fr; gap: 10px; }
+.cmp-col { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 9px 11px; }
+.cmp-col-h { font-family: var(--font-ui); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 7px; }
+.cmp-col.kept { border-left: 2px solid var(--status-ok); }
+.cmp-col.kept .cmp-col-h { color: var(--status-ok); }
+.cmp-col.summ { border-left: 2px solid var(--info); }
+.cmp-col.summ .cmp-col-h { color: var(--info); }
+.cmp-col.drop { border-left: 2px solid var(--text-dim); }
+.cmp-col.drop .cmp-col-h { color: var(--text-dim); }
+.cmp-li { font-size: 12px; line-height: 1.5; color: var(--text-mid); padding: 3px 0; border-top: 1px solid var(--border-soft); }
+.cmp-li:first-of-type { border-top: 0; }
+/* keeper-v2/styles/v2.css:190 — .mono (drawer uses tabular numerals) */
+.v2-app .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+
+/* ══════════════════════════════════════════════════════════════
+   .mem-* — copied 1:1 from keeper-v2/styles/memory.css
+   ══════════════════════════════════════════════════════════════ */
+/* keeper-v2/styles/memory.css:6 */
+.v2-app .mem-drawer { width: min(680px, 96vw); }
+
+/* header scope toggle — keeper-v2/styles/memory.css:9-14 */
+.mem-scope { margin-left: auto; display: inline-flex; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.mem-scope button { font-family: var(--font-ui); font-size: 11px; padding: 5px 12px; background: transparent; color: var(--text-dim); border: 0; border-left: 1px solid var(--border-main); cursor: pointer; transition: 0.14s; }
+.mem-scope button:first-child { border-left: 0; }
+.mem-scope button:hover { color: var(--text-mid); background: var(--bg-card); }
+.mem-scope button.on { color: var(--volt-ink); background: var(--volt); }
+.mem-drawer .turn-close { margin-left: 10px; }
+
+/* keeper-v2/styles/memory.css:16-20 */
+.mem-empty { font-size: 12px; color: var(--text-dim); padding: 10px 2px; }
+.mem-sec-head { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.mem-sec-head h4 { margin: 0; }
+.mem-n { font-size: 11px; color: var(--text-dim); }
+.mem-hint { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.02em; text-transform: none; color: var(--text-dim); margin-left: 6px; }
+
+/* ── context composition — keeper-v2/styles/memory.css:23-33 ── */
+.mem-compo { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 11px 12px; background: var(--bg-card); }
+.mem-compo-head { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
+.mem-compo-tot { font-size: 18px; color: var(--text-bright); }
+.mem-compo-sub { font-size: 11px; color: var(--text-dim); }
+.mem-bar { display: flex; height: 12px; border-radius: 3px; overflow: hidden; background: var(--bg-sunken); }
+.mem-bar > span { display: block; min-width: 2px; }
+.mem-legend { display: grid; grid-template-columns: 1fr 1fr; gap: 4px 16px; margin-top: 11px; }
+.mem-leg { display: flex; align-items: center; gap: 7px; }
+.mem-leg-sw { width: 9px; height: 9px; border-radius: 2px; flex: none; }
+.mem-leg-lbl { font-size: 11.5px; color: var(--text-mid); flex: 1; min-width: 0; }
+.mem-leg-v { font-size: 11px; color: var(--text-dim); }
+
+/* ── pinned facts — keeper-v2/styles/memory.css:36-45 ── */
+.mem-pins { display: flex; flex-direction: column; gap: 7px; }
+.mem-pin { display: flex; gap: 9px; padding: 9px 11px; border: 1px solid var(--border-soft); border-left: 2px solid var(--volt-dim); border-radius: var(--radius-sm); background: var(--bg-card); }
+.mem-pin-ico { color: var(--volt); font-size: 13px; line-height: 1.5; flex: none; }
+.mem-pin-body { min-width: 0; }
+.mem-pin-text { font-size: 12.5px; line-height: 1.5; color: var(--text-primary); text-wrap: pretty; }
+.mem-pin-meta { display: flex; align-items: center; gap: 9px; margin-top: 6px; font-size: 10.5px; color: var(--text-dim); }
+.mem-by { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 1px 6px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
+.mem-by.operator { color: var(--volt-strong); border-color: var(--volt-dim); }
+.mem-by.auto { color: var(--text-dim); }
+.mem-tag { font-family: var(--font-mono); font-size: 10px; color: var(--info); }
+
+/* ── long-term store — keeper-v2/styles/memory.css:48-66 ── */
+.mem-filters { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 9px; }
+.mem-filter { font-family: var(--font-ui); font-size: 10.5px; padding: 3px 10px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.mem-filter:hover { color: var(--text-mid); border-color: var(--border-highlight); }
+.mem-filter.on { color: var(--text-bright); border-color: var(--volt-dim); background: var(--volt-wash); }
+.mem-store { display: flex; flex-direction: column; }
+.mem-store-row { display: flex; gap: 10px; padding: 10px 0; border-top: 1px solid var(--border-soft); }
+.mem-store-row:first-child { border-top: 0; }
+.mem-kind { flex: none; align-self: flex-start; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); white-space: nowrap; }
+.mem-kind.fact { color: var(--volt-strong); border-color: var(--volt-dim); }
+.mem-kind.decision { color: var(--info); border-color: color-mix(in oklab, var(--info) 35%, transparent); }
+.mem-kind.pattern { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 35%, transparent); }
+.mem-kind.pref { color: var(--text-mid); }
+.mem-kind.entity { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 35%, transparent); }
+.mem-store-main { min-width: 0; flex: 1; }
+.mem-store-text { font-size: 12.5px; line-height: 1.5; color: var(--text-primary); text-wrap: pretty; }
+.mem-store-meta { display: flex; align-items: center; gap: 12px; margin-top: 6px; font-size: 10.5px; color: var(--text-dim); }
+.mem-src { color: var(--text-dim); }
+.mem-sal { position: relative; width: 54px; height: 5px; border-radius: 3px; background: var(--bg-sunken); overflow: hidden; flex: none; }
+.mem-sal > span { position: absolute; left: 0; top: 0; bottom: 0; background: var(--volt); border-radius: 3px; }
+
+/* ── recall timeline — keeper-v2/styles/memory.css:69-82 ── */
+.mem-timeline { display: flex; flex-direction: column; }
+.mem-tl-row { display: grid; grid-template-columns: 42px 64px 1fr auto; gap: 10px; align-items: center; padding: 7px 0; border-top: 1px solid var(--border-soft); font-size: 12px; }
+.mem-tl-row:first-child { border-top: 0; }
+.mem-tl-at { font-size: 10.5px; color: var(--text-dim); }
+.mem-op { font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; color: var(--text-mid); white-space: nowrap; }
+.mem-op.recall { color: var(--info); }
+.mem-op.inject { color: var(--status-ok); }
+.mem-op.pin { color: var(--volt-strong); }
+.mem-op.compact { color: var(--status-warn); }
+.mem-op.evict { color: var(--text-dim); }
+.mem-tl-text { color: var(--text-mid); min-width: 0; line-height: 1.45; }
+.mem-tl-tok { font-size: 11px; text-align: right; white-space: nowrap; }
+.mem-tl-tok.neg { color: var(--status-ok); }
+.mem-tl-tok.pos { color: var(--text-dim); }
+
+/* ── aggregate — keeper-v2/styles/memory.css:85-104 ── */
+.mem-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+.mem-stat { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 11px 10px; background: var(--bg-card); text-align: center; }
+.mem-stat .v { display: block; font-size: 19px; color: var(--text-bright); }
+.mem-stat .k { display: block; margin-top: 3px; font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+
+.mem-kinds-dist { display: flex; flex-direction: column; gap: 7px; }
+.mem-kd-row { display: grid; grid-template-columns: 72px 1fr 28px; gap: 10px; align-items: center; }
+.mem-kd-bar { height: 7px; background: var(--bg-sunken); border-radius: 3px; overflow: hidden; }
+.mem-kd-bar > span { display: block; height: 100%; background: var(--volt); border-radius: 3px; }
+.mem-kd-n { font-size: 11px; color: var(--text-mid); text-align: right; }
+
+.mem-table { display: flex; flex-direction: column; }
+.mem-tr { display: grid; grid-template-columns: 1.7fr 0.6fr 0.5fr 0.7fr 1.1fr; gap: 10px; align-items: center; padding: 8px 6px; border-top: 1px solid var(--border-soft); font-size: 12px; color: var(--text-mid); text-align: left; background: none; border-left: 0; border-right: 0; border-bottom: 0; cursor: pointer; width: 100%; transition: background 0.14s; }
+.mem-tr:hover:not(.mem-th) { background: var(--bg-card); }
+.mem-th { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); cursor: default; border-top: 0; }
+.mem-td-id { display: inline-flex; align-items: center; gap: 7px; min-width: 0; }
+.mem-td-id .mono { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* status dot in the keeper table — mirrors the prototype's <StatusDot>
+   (keeper-v2/memory.jsx:196 → window.KV.Dot state=ok|warn|idle|bad).
+   This dashboard has no KV.Dot primitive that carries the v2 status
+   palette, so a self-contained 7px dot is rendered with the same
+   run→ok / pause→idle / else→bad state mapping. */
+.mem-dot { display: inline-block; width: 7px; height: 7px; border-radius: var(--radius-pill); flex: none; background: var(--text-dim); }
+.mem-dot.ok { background: var(--status-ok); }
+.mem-dot.idle { background: var(--text-dim); }
+.mem-dot.bad { background: var(--volt); }
+.mem-td-bar { position: relative; display: flex; align-items: center; }
+.mem-td-bar i { position: absolute; left: 0; height: 6px; background: color-mix(in oklab, var(--status-ok) 45%, transparent); border-radius: 3px; }
+.mem-td-bar b { position: relative; margin-left: auto; font-weight: 500; font-size: 11px; color: var(--text-mid); }
+
+/* keeper-v2/styles/memory.css:106-111 */
+@media (max-width: 560px) {
+  .mem-legend { grid-template-columns: 1fr; }
+  .mem-stats { grid-template-columns: repeat(2, 1fr); }
+  .mem-tl-row { grid-template-columns: 38px 56px 1fr; }
+  .mem-tl-tok { display: none; }
+}
+
+/* responsive drawer — keeper-v2/styles/v2.css:1430 */
+@media (max-width: 560px) {
+  .turn-drawer { width: 100vw; }
+}


### PR DESCRIPTION
Surface: `memory`. Implements its row in `reports/keeper-v2-design-match/gap-map.md` (pixel-match to the Claude-Design keeper-v2 prototype). Foundation tokens (#21993) already merged to main; this stacks on top. WIP: implementation agent interrupted by API 529 mid-run, committed as-is — CI verifies tsc/vitest, will refine via chrome visual diff. RFC gate N/A (UI/CSS); runtime-editor/settings self-check pending if backend touched.