### PR TITLE
[v2] runtime-editor — pixel-match to Claude-Design prototype

### DIFF
--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -354,6 +354,102 @@ describe('RuntimeTomlEditor', () => {
     expect(container.querySelector('textarea')).not.toBeNull()
   })
 
+  it('renders all six section-nav entries with the prototype labels', async () => {
+    apiMocks.fetchRuntimeTomlConfig.mockResolvedValueOnce(richConfig)
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-routing"]')).not.toBeNull()
+    })
+
+    const nav = container.querySelector('nav.rt-nav') as HTMLElement
+    expect(nav.getAttribute('aria-label')).toBe('런타임 편집기 섹션')
+
+    const expected: Array<[string, string]> = [
+      ['routing', '라우팅'],
+      ['providers', '프로바이더'],
+      ['models', '모델'],
+      ['bindings', '바인딩 · 런타임 id'],
+      ['assignments', 'keeper 배정'],
+      ['toml', 'runtime.toml'],
+    ]
+    for (const [id, label] of expected) {
+      const button = container.querySelector(`[data-testid="runtime-toml-nav-${id}"]`) as HTMLButtonElement | null
+      expect(button, `nav button for ${id}`).not.toBeNull()
+      expect(button?.textContent).toContain(label)
+    }
+  })
+
+  it('defaults to the routing section with the structured editor visible and raw TOML hidden', async () => {
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-section-title"]')?.textContent).toBe('라우팅')
+    })
+
+    const routingNav = container.querySelector('[data-testid="runtime-toml-nav-routing"]') as HTMLButtonElement
+    expect(routingNav.getAttribute('aria-pressed')).toBe('true')
+
+    const structured = container.querySelector('[data-testid="runtime-toml-structured"]') as HTMLElement
+    const toml = container.querySelector('[data-testid="runtime-toml-section"]') as HTMLElement
+    expect(structured.classList.contains('hidden')).toBe(false)
+    expect(toml.classList.contains('hidden')).toBe(true)
+  })
+
+  it('switches sections from the nav, updating title, aria-pressed and visibility', async () => {
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-nav-models"]')).not.toBeNull()
+    })
+
+    // Switch to a different structured section: title updates, structured stays mounted+visible.
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-models"]') as HTMLButtonElement)
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-section-title"]')?.textContent).toBe('모델')
+    })
+    expect((container.querySelector('[data-testid="runtime-toml-nav-models"]') as HTMLButtonElement).getAttribute('aria-pressed')).toBe('true')
+    expect((container.querySelector('[data-testid="runtime-toml-nav-routing"]') as HTMLButtonElement).getAttribute('aria-pressed')).toBe('false')
+    expect((container.querySelector('[data-testid="runtime-toml-structured"]') as HTMLElement).classList.contains('hidden')).toBe(false)
+    expect((container.querySelector('[data-testid="runtime-toml-section"]') as HTMLElement).classList.contains('hidden')).toBe(true)
+
+    // Switch to the raw TOML section: structured hides, raw TOML view becomes visible.
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-toml"]') as HTMLButtonElement)
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="runtime-toml-section-title"]')?.textContent).toBe('runtime.toml')
+    })
+    expect((container.querySelector('[data-testid="runtime-toml-structured"]') as HTMLElement).classList.contains('hidden')).toBe(true)
+    expect((container.querySelector('[data-testid="runtime-toml-section"]') as HTMLElement).classList.contains('hidden')).toBe(false)
+  })
+
+  it('keeps the raw-TOML editor path working after navigating into the toml section', async () => {
+    render(html`<${RuntimeTomlEditor} />`, container)
+
+    await waitFor(() => {
+      expect((container.querySelector('textarea') as HTMLTextAreaElement | null)?.value).toBe(baseConfig.source_text)
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-nav-toml"]') as HTMLButtonElement)
+    await waitFor(() => {
+      expect((container.querySelector('[data-testid="runtime-toml-section"]') as HTMLElement).classList.contains('hidden')).toBe(false)
+    })
+
+    const textarea = container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement
+    const nextSource = `${baseConfig.source_text}# edited in toml view\n`
+    fireEvent.input(textarea, { target: { value: nextSource } })
+
+    await waitFor(() => {
+      expect((container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement).disabled).toBe(false)
+      expect(container.querySelector('[data-testid="runtime-toml-status"]')?.textContent).toContain('modified')
+    })
+
+    fireEvent.click(container.querySelector('[data-testid="runtime-toml-save"]') as HTMLButtonElement)
+    await waitFor(() => {
+      expect(apiMocks.saveRuntimeTomlConfig).toHaveBeenCalledWith(nextSource)
+    })
+    expect((container.querySelector('[data-testid="runtime-toml-source"]') as HTMLTextAreaElement).value).toBe(nextSource)
+  })
+
   it('keeps the dirty draft when save validation fails', async () => {
     apiMocks.saveRuntimeTomlConfig.mockRejectedValueOnce(new Error('runtime config parse failed'))
     render(html`<${RuntimeTomlEditor} />`, container)

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -8,6 +8,7 @@ import {
 } from '../api/dashboard'
 import { errorToString } from '../lib/format-string'
 import {
+  parseRuntimeTomlEnvironment,
   runtimeTomlImpactSummary,
   type RuntimeTomlImpactSummary,
 } from '../lib/runtime-toml-config'
@@ -105,6 +106,43 @@ const editorFocusClasses = ringFocusClasses({
   offset: 0,
 })
 
+// rt-* shell section nav. Section ids + Korean labels + glyphs are lifted 1:1
+// from the Claude-Design prototype runtime-editor.jsx:8-15 (RT_SECS). The
+// glyphs are the prototype's exact characters — do not substitute lucide icons,
+// the prototype uses these literal glyphs.
+type RuntimeSectionId =
+  | 'routing'
+  | 'providers'
+  | 'models'
+  | 'bindings'
+  | 'assignments'
+  | 'toml'
+
+interface RuntimeSection {
+  readonly id: RuntimeSectionId
+  readonly label: string
+  readonly glyph: string
+}
+
+const RUNTIME_SECTIONS: readonly RuntimeSection[] = [
+  { id: 'routing', label: '라우팅', glyph: '◷' },
+  { id: 'providers', label: '프로바이더', glyph: '◇' },
+  { id: 'models', label: '모델', glyph: '▤' },
+  { id: 'bindings', label: '바인딩 · 런타임 id', glyph: '◈' },
+  { id: 'assignments', label: 'keeper 배정', glyph: '⊙' },
+  { id: 'toml', label: 'runtime.toml', glyph: '{ }' },
+]
+
+function runtimeSectionTitle(sec: RuntimeSectionId): string {
+  return RUNTIME_SECTIONS.find(s => s.id === sec)?.label ?? ''
+}
+
+function runtimeStatusToneClass(statusLabel: string): string {
+  if (statusLabel === 'modified' || statusLabel === 'saving') return 'is-modified'
+  if (statusLabel === 'saved') return 'is-saved'
+  return ''
+}
+
 export function RuntimeTomlEditor() {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const lineGutterRef = useRef<HTMLPreElement | null>(null)
@@ -114,6 +152,7 @@ export function RuntimeTomlEditor() {
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+  const [section, setSection] = useState<RuntimeSectionId>('routing')
 
   const dirty = config !== null && draft !== config.source_text
 
@@ -236,6 +275,95 @@ export function RuntimeTomlEditor() {
     () => (config !== null && dirty ? runtimeTomlImpactSummary(config.source_text, draft) : null),
     [config, dirty, draft],
   )
+  const environment = useMemo(() => parseRuntimeTomlEnvironment(draft), [draft])
+  const runtimeCount = environment.bindings.length
+  const providerCount = environment.providers.length
+
+  // Structured sections (routing/providers/models/bindings/assignments) all map
+  // to RuntimeEnvironmentEditor, which already wires the parsed Provider × Model
+  // × Binding state to the runtime.toml draft. The toml section keeps the raw
+  // textarea + toolbar. All section bodies stay mounted in the DOM and visibility
+  // is toggled via the nav, so the editor wiring is never torn down on switch.
+  const structuredActive = section !== 'toml'
+  const tomlActive = section === 'toml'
+
+  const toolbar = html`
+    <div class="v2-monitoring-toolbar sticky top-0 z-10 -mx-1 bg-[var(--color-bg-surface)]/95 px-1 py-2 backdrop-blur">
+      <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div class="min-w-0">
+          <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">path</div>
+          <div class="truncate font-mono text-xs text-[var(--color-fg-primary)]" data-testid="runtime-toml-path">
+            ${path}
+          </div>
+        </div>
+        <div class="flex shrink-0 flex-wrap items-center gap-2">
+          <${ActionButton}
+            variant="ghost"
+            size="sm"
+            onClick=${handleCopyPath}
+            disabled=${loadState === 'loading'}
+            ariaLabel="runtime.toml 경로 복사"
+            title="경로 복사"
+            testId="runtime-toml-copy-path"
+            class="inline-flex items-center gap-1"
+          >
+            <${Copy} size=${13} strokeWidth=${2.25} aria-hidden="true" />
+            <span>경로</span>
+          <//>
+          <${ActionButton}
+            variant="ghost"
+            size="sm"
+            onClick=${handleReset}
+            disabled=${!dirty || saving}
+            ariaLabel="runtime.toml 변경 되돌리기"
+            title="변경 되돌리기"
+            testId="runtime-toml-reset"
+            class="inline-flex items-center gap-1"
+          >
+            <${RotateCcw} size=${13} strokeWidth=${2.25} aria-hidden="true" />
+            <span>되돌리기</span>
+          <//>
+          <${ActionButton}
+            variant="ghost"
+            size="sm"
+            onClick=${handleRefresh}
+            disabled=${saving || loadState === 'loading'}
+            ariaBusy=${loadState === 'loading'}
+            ariaLabel="runtime.toml 다시 불러오기"
+            title="다시 불러오기"
+            testId="runtime-toml-refresh"
+            class="inline-flex items-center gap-1"
+          >
+            <${RefreshCcw} size=${13} strokeWidth=${2.25} aria-hidden="true" />
+            <span>새로고침</span>
+          <//>
+          <${ActionButton}
+            variant="primary"
+            size="sm"
+            onClick=${handleSave}
+            disabled=${!dirty || saving || loadState === 'loading'}
+            ariaBusy=${saving}
+            ariaLabel="runtime.toml 라이브 적용"
+            title="라이브 적용"
+            testId="runtime-toml-save"
+            class="inline-flex items-center gap-1"
+          >
+            <${Save} size=${13} strokeWidth=${2.25} aria-hidden="true" />
+            <span>${saving ? '적용 중' : '라이브 적용'}</span>
+          <//>
+        </div>
+      </div>
+      <div
+        class="mt-2 flex flex-wrap items-center gap-2 text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]"
+        data-testid="runtime-toml-stats"
+      >
+        <span>${stats.lineCount} lines</span>
+        <span>${stats.charCount} chars</span>
+        <span>${dirty ? 'unsaved' : 'synced'}</span>
+      </div>
+      ${impact ? html`<${RuntimeTomlImpactPreview} impact=${impact} />` : null}
+    </div>
+  `
 
   return html`
     <${SectionCard}
@@ -243,147 +371,120 @@ export function RuntimeTomlEditor() {
       label="runtime.toml"
       testId="runtime-toml-editor"
       right=${html`
+        <!-- status pill — prototype rt-head status chrome (runtime-editor.jsx:129
+             .rt-save scale). is-modified/is-saved tone from runtime-editor-v2.css. -->
         <span
-          class="rounded-[var(--r-0)] border border-[var(--color-border-subtle)] px-2 py-0.5 text-2xs font-medium uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]"
+          class="rt-status ${runtimeStatusToneClass(statusLabel)}"
           data-testid="runtime-toml-status"
         >
           ${statusLabel}
         </span>
       `}
     >
-      <div class="flex flex-col gap-3">
-        <div class="v2-monitoring-toolbar sticky top-0 z-10 -mx-1 bg-[var(--color-bg-surface)]/95 px-1 py-2 backdrop-blur">
-          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-            <div class="min-w-0">
-              <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">path</div>
-              <div class="truncate font-mono text-xs text-[var(--color-fg-primary)]" data-testid="runtime-toml-path">
-                ${path}
+      ${loadState === 'loading'
+        ? html`
+          ${toolbar}
+          ${error ? html`<${ErrorState} message=${error} />` : null}
+          <${LoadingState}>runtime.toml 불러오는 중...<//>
+        `
+        : html`
+          <!-- rt-shell: 218px section-nav + fluid content (runtime-editor.jsx:110,
+               runtime.css:6). -->
+          <div class="rt-shell">
+            <nav class="rt-nav" aria-label="런타임 편집기 섹션">
+              <div class="rt-nav-h">
+                <div class="eyebrow">Operator</div>
+                <div class="rt-nav-title">런타임 편집기</div>
+                <div class="rt-nav-sub mono">config/runtime.toml</div>
+              </div>
+              ${RUNTIME_SECTIONS.map(s => html`
+                <button
+                  key=${s.id}
+                  type="button"
+                  class="rt-nav-item ${section === s.id ? 'on' : ''}"
+                  aria-pressed=${section === s.id}
+                  data-testid=${`runtime-toml-nav-${s.id}`}
+                  onClick=${() => setSection(s.id)}
+                >
+                  <span class="rt-nav-gl mono">${s.glyph}</span><span>${s.label}</span>
+                </button>
+              `)}
+              <div class="rt-nav-foot mono">${runtimeCount} 런타임 · ${providerCount} 프로바이더</div>
+            </nav>
+
+            <div class="rt-content">
+              <header class="rt-head">
+                <h1 data-testid="runtime-toml-section-title">${runtimeSectionTitle(section)}</h1>
+              </header>
+
+              <div class="rt-body">
+                ${error ? html`<${ErrorState} message=${error} />` : null}
+                ${notice ? html`
+                  <div
+                    class="px-1 text-xs text-[var(--color-status-ok)]"
+                    role="status"
+                    data-testid="runtime-toml-notice"
+                  >
+                    ${notice}
+                  </div>
+                ` : null}
+
+                <!-- structured editor — routing/providers/models/bindings/
+                     assignments (runtime-editor.jsx:135-231). Kept mounted; the
+                     nav toggles visibility so editor state survives section
+                     switches. -->
+                <div class=${structuredActive ? '' : 'hidden'} data-testid="runtime-toml-structured">
+                  <${RuntimeEnvironmentEditor}
+                    sourceText=${draft}
+                    dirty=${dirty}
+                    disabled=${loadState !== 'loaded'}
+                    saving=${saving}
+                    onDraftChange=${(nextSourceText: string) => {
+                      setDraft(nextSourceText)
+                      setNotice(null)
+                    }}
+                    onSave=${(nextSourceText?: string) => {
+                      void handleSave(nextSourceText)
+                    }}
+                  />
+                </div>
+
+                <!-- toml section — read-only raw view with the working textarea +
+                     toolbar (runtime-editor.jsx:233-242). -->
+                <div class=${tomlActive ? 'flex flex-col gap-3' : 'hidden'} data-testid="runtime-toml-section">
+                  ${toolbar}
+                  <div
+                    class="v2-monitoring-code-frame grid min-h-[32rem] max-h-[72vh] grid-cols-[3.5rem_minmax(0,1fr)] overflow-hidden rounded-[var(--r-1)] border border-[var(--input-border)] bg-[var(--input-bg)]"
+                    data-testid="runtime-toml-code-frame"
+                  >
+                    <pre
+                      ref=${lineGutterRef}
+                      class="select-none overflow-hidden border-r border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-3 text-right font-mono text-xs leading-relaxed text-[var(--color-fg-disabled)]"
+                      aria-hidden="true"
+                      data-testid="runtime-toml-line-numbers"
+                    >${lineNumbers}</pre>
+                    <textarea
+                      ref=${textareaRef}
+                      class="min-h-[32rem] w-full resize-y overflow-auto border-0 bg-transparent px-3 py-3 font-mono text-xs leading-relaxed text-[var(--color-fg-primary)] outline-none ${editorFocusClasses}"
+                      aria-label="runtime.toml source"
+                      data-testid="runtime-toml-source"
+                      value=${draft}
+                      rows=${32}
+                      wrap="off"
+                      spellcheck=${false}
+                      autocapitalize="off"
+                      autocorrect="off"
+                      disabled=${saving}
+                      onInput=${handleEditorInput}
+                      onKeyDown=${handleEditorKeyDown}
+                      onScroll=${handleEditorScroll}
+                    ></textarea>
+                  </div>
+                </div>
               </div>
             </div>
-            <div class="flex shrink-0 flex-wrap items-center gap-2">
-              <${ActionButton}
-                variant="ghost"
-                size="sm"
-                onClick=${handleCopyPath}
-                disabled=${loadState === 'loading'}
-                ariaLabel="runtime.toml 경로 복사"
-                title="경로 복사"
-                testId="runtime-toml-copy-path"
-                class="inline-flex items-center gap-1"
-              >
-                <${Copy} size=${13} strokeWidth=${2.25} aria-hidden="true" />
-                <span>경로</span>
-              <//>
-              <${ActionButton}
-                variant="ghost"
-                size="sm"
-                onClick=${handleReset}
-                disabled=${!dirty || saving}
-                ariaLabel="runtime.toml 변경 되돌리기"
-                title="변경 되돌리기"
-                testId="runtime-toml-reset"
-                class="inline-flex items-center gap-1"
-              >
-                <${RotateCcw} size=${13} strokeWidth=${2.25} aria-hidden="true" />
-                <span>되돌리기</span>
-              <//>
-              <${ActionButton}
-                variant="ghost"
-                size="sm"
-                onClick=${handleRefresh}
-                disabled=${saving || loadState === 'loading'}
-                ariaBusy=${loadState === 'loading'}
-                ariaLabel="runtime.toml 다시 불러오기"
-                title="다시 불러오기"
-                testId="runtime-toml-refresh"
-                class="inline-flex items-center gap-1"
-              >
-                <${RefreshCcw} size=${13} strokeWidth=${2.25} aria-hidden="true" />
-                <span>새로고침</span>
-              <//>
-              <${ActionButton}
-                variant="primary"
-                size="sm"
-                onClick=${handleSave}
-                disabled=${!dirty || saving || loadState === 'loading'}
-                ariaBusy=${saving}
-                ariaLabel="runtime.toml 라이브 적용"
-                title="라이브 적용"
-                testId="runtime-toml-save"
-                class="inline-flex items-center gap-1"
-              >
-                <${Save} size=${13} strokeWidth=${2.25} aria-hidden="true" />
-                <span>${saving ? '적용 중' : '라이브 적용'}</span>
-              <//>
-            </div>
           </div>
-          <div
-            class="mt-2 flex flex-wrap items-center gap-2 text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]"
-            data-testid="runtime-toml-stats"
-          >
-            <span>${stats.lineCount} lines</span>
-            <span>${stats.charCount} chars</span>
-            <span>${dirty ? 'unsaved' : 'synced'}</span>
-          </div>
-          ${impact ? html`<${RuntimeTomlImpactPreview} impact=${impact} />` : null}
-        </div>
-
-        ${error ? html`<${ErrorState} message=${error} />` : null}
-        ${notice ? html`
-          <div
-            class="px-1 text-xs text-[var(--color-status-ok)]"
-            role="status"
-            data-testid="runtime-toml-notice"
-          >
-            ${notice}
-          </div>
-        ` : null}
-
-        ${loadState === 'loading'
-          ? html`<${LoadingState}>runtime.toml 불러오는 중...<//>`
-          : html`
-            <${RuntimeEnvironmentEditor}
-              sourceText=${draft}
-              dirty=${dirty}
-              disabled=${loadState !== 'loaded'}
-              saving=${saving}
-              onDraftChange=${(nextSourceText: string) => {
-                setDraft(nextSourceText)
-                setNotice(null)
-              }}
-              onSave=${(nextSourceText?: string) => {
-                void handleSave(nextSourceText)
-              }}
-            />
-            <div
-              class="v2-monitoring-code-frame mt-4 grid min-h-[32rem] max-h-[72vh] grid-cols-[3.5rem_minmax(0,1fr)] overflow-hidden rounded-[var(--r-1)] border border-[var(--input-border)] bg-[var(--input-bg)]"
-              data-testid="runtime-toml-code-frame"
-            >
-              <pre
-                ref=${lineGutterRef}
-                class="select-none overflow-hidden border-r border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-3 text-right font-mono text-xs leading-relaxed text-[var(--color-fg-disabled)]"
-                aria-hidden="true"
-                data-testid="runtime-toml-line-numbers"
-              >${lineNumbers}</pre>
-              <textarea
-                ref=${textareaRef}
-                class="min-h-[32rem] w-full resize-y overflow-auto border-0 bg-transparent px-3 py-3 font-mono text-xs leading-relaxed text-[var(--color-fg-primary)] outline-none ${editorFocusClasses}"
-                aria-label="runtime.toml source"
-                data-testid="runtime-toml-source"
-                value=${draft}
-                rows=${32}
-                wrap="off"
-                spellcheck=${false}
-                autocapitalize="off"
-                autocorrect="off"
-                disabled=${saving}
-                onInput=${handleEditorInput}
-                onKeyDown=${handleEditorKeyDown}
-                onScroll=${handleEditorScroll}
-              ></textarea>
-            </div>
-          `}
-      </div>
+        `}
     <//>
   `
 }

--- a/dashboard/src/styles/runtime-editor-v2.css
+++ b/dashboard/src/styles/runtime-editor-v2.css
@@ -1,0 +1,508 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Runtime config editor (structured rt-* shell).
+   Pixel-matched to the Claude-Design prototype:
+     "v2 2/project/keeper-v2/styles/runtime.css".
+   Every value below cites that prototype file by line (runtime.css:N).
+   Tokens are the canonical v2 foundation (ds-theme-tokens.css), which
+   aliases the prototype's --volt / --bg-* / --border-* / --text-* / --radius-*
+   names 1:1. Scoped to [data-skin="v2"] so it does not bleed into v1.
+   ══════════════════════════════════════════════════════════════ */
+
+/* The prototype renders the editor inline (no fixed overlay) inside the
+   Settings "runtimes" section, so we drop the prototype's .rt-overlay
+   fixed-position wrapper and keep the .rt-shell as an embedded panel. */
+
+html[data-skin="v2"] .rt-shell {
+  /* runtime.css:6 — grid 218px nav + fluid content. Embedded (not min(1080px)
+     overlay) so it fills the Settings panel column. */
+  display: grid;
+  grid-template-columns: 218px minmax(0, 1fr);
+  min-height: 32rem;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-highlight);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.55); /* runtime.css:6 */
+}
+
+/* nav — runtime.css:9 */
+html[data-skin="v2"] .rt-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 16px 12px;
+  background: var(--bg-deep);
+  border-right: 1px solid var(--border-main);
+}
+html[data-skin="v2"] .rt-nav-h { padding: 4px 8px 14px; } /* runtime.css:10 */
+html[data-skin="v2"] .rt-nav-h .eyebrow {
+  /* runtime.css:11 */
+  font-family: var(--font-ui);
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+html[data-skin="v2"] .rt-nav-title {
+  /* runtime.css:12 */
+  font-family: var(--font-display);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 15px;
+  color: var(--text-bright);
+  margin-top: 4px;
+}
+html[data-skin="v2"] .rt-nav-sub {
+  /* runtime.css:13 */
+  font-size: 10.5px;
+  color: var(--text-dim);
+  margin-top: 3px;
+}
+html[data-skin="v2"] .rt-nav-item {
+  /* runtime.css:14 */
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 11px;
+  border: 0;
+  background: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-dim);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  cursor: pointer;
+  transition: 0.14s;
+  text-align: left;
+}
+html[data-skin="v2"] .rt-nav-item:hover {
+  /* runtime.css:15 */
+  color: var(--text-mid);
+  background: var(--bg-card);
+}
+html[data-skin="v2"] .rt-nav-item.on {
+  /* runtime.css:16 */
+  color: var(--text-bright);
+  background: var(--volt-wash);
+  box-shadow: inset 0 0 0 1px var(--volt-dim);
+}
+html[data-skin="v2"] .rt-nav-gl {
+  /* runtime.css:17 */
+  width: 18px;
+  flex: none;
+  color: var(--text-dim);
+  font-size: 12px;
+}
+html[data-skin="v2"] .rt-nav-item.on .rt-nav-gl { color: var(--volt); } /* runtime.css:18 */
+html[data-skin="v2"] .rt-nav-foot {
+  /* runtime.css:19 */
+  margin-top: auto;
+  padding: 10px 8px 2px;
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+/* content — runtime.css:22 */
+html[data-skin="v2"] .rt-content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+html[data-skin="v2"] .rt-head {
+  /* runtime.css:23 */
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 24px 15px;
+  border-bottom: 1px solid var(--border-soft);
+}
+html[data-skin="v2"] .rt-head h1 {
+  /* runtime.css:24 */
+  font-family: var(--font-display);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 18px;
+  color: var(--text-bright);
+  margin: 0;
+}
+html[data-skin="v2"] .rt-head-actions {
+  /* runtime.css:25 */
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+html[data-skin="v2"] .rt-status {
+  /* status pill — mirrors the prototype's .rt-save chrome at pill scale
+     so the existing runtime-toml-status testid keeps a v2 look. */
+  font-family: var(--font-ui);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 4px 9px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main);
+  color: var(--text-dim);
+}
+html[data-skin="v2"] .rt-status.is-modified {
+  color: var(--volt);
+  border-color: var(--volt-dim);
+}
+html[data-skin="v2"] .rt-status.is-saved { color: var(--status-ok); }
+html[data-skin="v2"] .rt-save {
+  /* runtime.css:26 */
+  font-family: var(--font-ui);
+  font-size: 12px;
+  padding: 7px 15px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--volt-dim);
+  background: var(--volt-wash);
+  color: var(--volt);
+  cursor: pointer;
+  transition: 0.14s;
+}
+html[data-skin="v2"] .rt-save:hover { background: var(--volt); color: var(--volt-ink); } /* runtime.css:27 */
+html[data-skin="v2"] .rt-save:disabled { opacity: 0.5; cursor: not-allowed; }
+html[data-skin="v2"] .rt-close {
+  /* runtime.css:28 */
+  width: 30px;
+  height: 30px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main);
+  background: none;
+  color: var(--text-mid);
+  cursor: pointer;
+}
+html[data-skin="v2"] .rt-close:hover { border-color: var(--volt-dim); color: var(--volt); } /* runtime.css:29 */
+html[data-skin="v2"] .rt-body {
+  /* runtime.css:30 */
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px 40px;
+}
+
+html[data-skin="v2"] .rt-note {
+  /* runtime.css:32 */
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--text-dim);
+  margin-bottom: 14px;
+}
+html[data-skin="v2"] .rt-input {
+  /* runtime.css:33 — local --bg-well fallback (the prototype's deepest well
+     #06070a) resolves to canonical --bg-sunken, which the foundation does not
+     distinguish from --bg-well. See bg-well note at end of file. */
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  padding: 7px 10px;
+  color: var(--text-bright);
+  font-size: 12px;
+}
+html[data-skin="v2"] .rt-input:focus { outline: none; border-color: var(--volt-dim); } /* runtime.css:34 */
+
+/* routing lanes — runtime.css:37 */
+html[data-skin="v2"] .rt-lane {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 0;
+  border-top: 1px solid var(--border-soft);
+}
+html[data-skin="v2"] .rt-lane:first-of-type { border-top: 0; } /* runtime.css:38 */
+html[data-skin="v2"] .rt-lane-l { flex: 1; min-width: 0; } /* runtime.css:39 */
+html[data-skin="v2"] .rt-lane-lbl { font-size: 13px; color: var(--text-primary); } /* runtime.css:40 */
+html[data-skin="v2"] .rt-lane-hint {
+  /* runtime.css:41 */
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-top: 3px;
+}
+html[data-skin="v2"] .rt-lane-c {
+  /* runtime.css:42 */
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: none;
+}
+html[data-skin="v2"] .rt-select {
+  /* runtime.css:43 */
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  padding: 7px 10px;
+  color: var(--text-bright);
+  font-size: 12px;
+  cursor: pointer;
+  min-width: 248px;
+}
+html[data-skin="v2"] .rt-select:focus { outline: none; border-color: var(--volt-dim); } /* runtime.css:44 */
+html[data-skin="v2"] .rt-warn { font-size: 11px; color: var(--status-bad); white-space: nowrap; } /* runtime.css:45 */
+html[data-skin="v2"] .rt-ok { font-size: 11px; color: var(--status-ok); white-space: nowrap; } /* runtime.css:46 */
+
+/* provider cards — runtime.css:49 */
+html[data-skin="v2"] .rt-cards { display: flex; flex-direction: column; gap: 12px; }
+html[data-skin="v2"] .rt-card {
+  /* runtime.css:50 */
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  padding: 13px 15px;
+}
+html[data-skin="v2"] .rt-card-h {
+  /* runtime.css:51 */
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 11px;
+}
+html[data-skin="v2"] .rt-card-id { font-size: 13px; color: var(--volt-strong); } /* runtime.css:52 */
+html[data-skin="v2"] .rt-card-name { font-size: 12.5px; color: var(--text-bright); } /* runtime.css:53 */
+html[data-skin="v2"] .rt-proto {
+  /* runtime.css:54 */
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-dim);
+  border: 1px solid var(--border-main);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+}
+html[data-skin="v2"] .rt-field {
+  /* runtime.css:55 */
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 7px;
+}
+html[data-skin="v2"] .rt-field .sub-k {
+  min-width: 78px; /* runtime.css:56 */
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+}
+html[data-skin="v2"] .rt-field .rt-input { flex: 1; } /* runtime.css:57 */
+html[data-skin="v2"] .rt-cred {
+  /* runtime.css:58 */
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+html[data-skin="v2"] .rt-cred-type {
+  /* runtime.css:59 */
+  font-size: 10px;
+  color: var(--info);
+  border: 1px solid color-mix(in oklab, var(--info) 30%, transparent);
+  padding: 2px 7px;
+  border-radius: var(--radius-pill);
+  flex: none;
+}
+html[data-skin="v2"] .rt-cred .rt-input { flex: 1; } /* runtime.css:60 */
+html[data-skin="v2"] .rt-cred-none { font-size: 11.5px; color: var(--text-dim); } /* runtime.css:61 */
+html[data-skin="v2"] .rt-caps {
+  /* runtime.css:62 */
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 11px;
+}
+html[data-skin="v2"] .rt-cap {
+  /* runtime.css:63 */
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main);
+  color: var(--text-dim);
+}
+html[data-skin="v2"] .rt-cap.on {
+  /* runtime.css:64 */
+  color: var(--status-ok);
+  border-color: color-mix(in oklab, var(--status-ok) 32%, transparent);
+}
+html[data-skin="v2"] .rt-cap.tcf {
+  /* runtime.css:65 */
+  color: var(--info);
+  border-color: color-mix(in oklab, var(--info) 28%, transparent);
+}
+
+/* models — runtime.css:68 */
+html[data-skin="v2"] .rt-search {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  padding: 9px 12px;
+  color: var(--text-bright);
+  font-size: 12px;
+  margin-bottom: 12px;
+}
+html[data-skin="v2"] .rt-search:focus { outline: none; border-color: var(--volt-dim); } /* runtime.css:69 */
+html[data-skin="v2"] .rt-models { display: flex; flex-direction: column; gap: 9px; } /* runtime.css:70 */
+html[data-skin="v2"] .rt-model {
+  /* runtime.css:71 */
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  padding: 11px 13px;
+}
+html[data-skin="v2"] .rt-model-h {
+  /* runtime.css:72 */
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 9px;
+}
+html[data-skin="v2"] .rt-model-id { font-size: 12.5px; color: var(--text-bright); } /* runtime.css:73 */
+html[data-skin="v2"] .rt-model-api { font-size: 11px; color: var(--text-dim); } /* runtime.css:74 */
+html[data-skin="v2"] .rt-model-ctx { margin-left: auto; font-size: 10.5px; color: var(--text-mid); } /* runtime.css:75 */
+
+/* bindings — runtime.css:78 */
+html[data-skin="v2"] .rt-binds { display: flex; flex-direction: column; gap: 9px; }
+html[data-skin="v2"] .rt-bind {
+  /* runtime.css:79 */
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  padding: 10px 13px;
+}
+html[data-skin="v2"] .rt-bind.is-default { border-color: var(--volt-dim); background: var(--volt-wash); } /* runtime.css:80 */
+html[data-skin="v2"] .rt-radio {
+  /* runtime.css:81 */
+  flex: none;
+  background: none;
+  border: 0;
+  color: var(--text-dim);
+  font-size: 15px;
+  cursor: pointer;
+  padding: 0;
+}
+html[data-skin="v2"] .rt-radio.on { color: var(--volt); } /* runtime.css:82 */
+html[data-skin="v2"] .rt-bind-main { flex: 1; min-width: 0; } /* runtime.css:83 */
+html[data-skin="v2"] .rt-bind-key {
+  /* runtime.css:84 */
+  font-size: 12.5px;
+  color: var(--text-bright);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+html[data-skin="v2"] .rt-default-tag {
+  /* runtime.css:85 */
+  font-family: var(--font-ui);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--volt);
+  border: 1px solid var(--volt-dim);
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+}
+html[data-skin="v2"] .rt-bind-sub { font-size: 10.5px; color: var(--text-dim); margin-top: 3px; } /* runtime.css:86 */
+html[data-skin="v2"] .rt-bind-fields { display: flex; gap: 10px; flex: none; } /* runtime.css:87 */
+html[data-skin="v2"] .rt-mini {
+  /* runtime.css:88 */
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-family: var(--font-ui);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+html[data-skin="v2"] .rt-input-sm {
+  /* runtime.css:89 */
+  width: 58px;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  padding: 5px 7px;
+  color: var(--text-bright);
+  font-size: 11.5px;
+}
+html[data-skin="v2"] .rt-input-sm:focus { outline: none; border-color: var(--volt-dim); } /* runtime.css:90 */
+
+/* assignments — runtime.css:93 */
+html[data-skin="v2"] .rt-assigns { display: flex; flex-direction: column; }
+html[data-skin="v2"] .rt-assign {
+  /* runtime.css:94 */
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 9px 0;
+  border-top: 1px solid var(--border-soft);
+}
+html[data-skin="v2"] .rt-assign:first-of-type { border-top: 0; } /* runtime.css:95 */
+html[data-skin="v2"] .rt-assign-k {
+  /* runtime.css:96 */
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: 150px;
+  flex: none;
+  font-size: 12.5px;
+  color: var(--text-bright);
+}
+html[data-skin="v2"] .rt-assign-tag { font-size: 10.5px; color: var(--text-dim); } /* runtime.css:97 */
+html[data-skin="v2"] .rt-assign-tag.pin { color: var(--volt-strong); } /* runtime.css:98 */
+
+/* toml — runtime.css:101 */
+html[data-skin="v2"] .rt-toml-wrap {
+  /* runtime.css:101 — --bg-well → --bg-sunken (see note below) */
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-sunken);
+}
+html[data-skin="v2"] .rt-toml-bar {
+  /* runtime.css:102 */
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg-panel-alt);
+  border-bottom: 1px solid var(--border-soft);
+  font-size: 11px;
+  color: var(--text-dim);
+}
+html[data-skin="v2"] .rt-toml-bar .mono { color: var(--text-mid); } /* runtime.css:103 */
+html[data-skin="v2"] .rt-toml-ro { font-size: 10px; } /* runtime.css:104 */
+html[data-skin="v2"] .rt-copy {
+  /* runtime.css:105 */
+  margin-left: auto;
+  background: none;
+  border: 1px solid var(--border-main);
+  color: var(--text-mid);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  padding: 4px 11px;
+  cursor: pointer;
+}
+html[data-skin="v2"] .rt-copy:hover { border-color: var(--volt-dim); color: var(--volt); } /* runtime.css:106 */
+
+/* shared mono helper — the prototype relies on a global .mono utility
+   (colors_and_type.css). Re-state it scoped so rt-* mono labels render in
+   the canonical mono face inside this surface. */
+html[data-skin="v2"] .rt-shell .mono { font-family: var(--font-mono); }
+
+/* responsive — runtime.css:137 */
+@media (max-width: 720px) {
+  html[data-skin="v2"] .rt-shell { grid-template-columns: 1fr; }
+  html[data-skin="v2"] .rt-nav { flex-direction: row; overflow-x: auto; }
+  html[data-skin="v2"] .rt-nav-h,
+  html[data-skin="v2"] .rt-nav-foot { display: none; }
+  html[data-skin="v2"] .rt-select { min-width: 160px; }
+}
+
+/* ──────────────────────────────────────────────────────────────
+   --bg-well note: the Claude-Design prototype distinguishes three depths —
+   --bg-deep / --bg-sunken / --bg-well (deepest, #06070a, used for code/shell
+   wells). The canonical v2 foundation (ds-theme-tokens.css) only aliases
+   --bg-sunken (→ --bg-surface-muted) and does not define --bg-well. Rather
+   than invent a hex that would drift from the foundation, the toml well and
+   rt-input wells use --bg-sunken (the nearest canonical depth). If the
+   foundation later adds --bg-well, swap these two declarations. */

--- a/dashboard/src/styles/runtime-editor-v2.css
+++ b/dashboard/src/styles/runtime-editor-v2.css
@@ -187,9 +187,7 @@ html[data-skin="v2"] .rt-note {
   margin-bottom: 14px;
 }
 html[data-skin="v2"] .rt-input {
-  /* runtime.css:33 — local --bg-well fallback (the prototype's deepest well
-     #06070a) resolves to canonical --bg-sunken, which the foundation does not
-     distinguish from --bg-well. See bg-well note at end of file. */
+  /* runtime.css:33 */
   background: var(--bg-sunken);
   border: 1px solid var(--border-main);
   border-radius: var(--radius-sm);
@@ -452,11 +450,13 @@ html[data-skin="v2"] .rt-assign-tag.pin { color: var(--volt-strong); } /* runtim
 
 /* toml — runtime.css:101 */
 html[data-skin="v2"] .rt-toml-wrap {
-  /* runtime.css:101 — --bg-well → --bg-sunken (see note below) */
+  /* runtime.css:101 — --bg-well (#06070a) is defined by the v2 foundation
+     (skin-v2.css / v2-skin-tokens.css), so use it verbatim instead of the
+     nearer --bg-sunken to keep the prototype's deepest code-well depth. */
   border: 1px solid var(--border-main);
   border-radius: var(--radius-sm);
   overflow: hidden;
-  background: var(--bg-sunken);
+  background: var(--bg-well);
 }
 html[data-skin="v2"] .rt-toml-bar {
   /* runtime.css:102 */
@@ -489,6 +489,21 @@ html[data-skin="v2"] .rt-copy:hover { border-color: var(--volt-dim); color: var(
    the canonical mono face inside this surface. */
 html[data-skin="v2"] .rt-shell .mono { font-family: var(--font-mono); }
 
+/* toml code well — runtime.css:107-108 */
+html[data-skin="v2"] .rt-toml {
+  margin: 0;
+  padding: 14px 16px;
+  overflow-x: auto;
+  max-height: 60vh;
+}
+html[data-skin="v2"] .rt-toml code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.65;
+  color: var(--text-primary);
+  white-space: pre;
+}
+
 /* responsive — runtime.css:137 */
 @media (max-width: 720px) {
   html[data-skin="v2"] .rt-shell { grid-template-columns: 1fr; }
@@ -497,12 +512,3 @@ html[data-skin="v2"] .rt-shell .mono { font-family: var(--font-mono); }
   html[data-skin="v2"] .rt-nav-foot { display: none; }
   html[data-skin="v2"] .rt-select { min-width: 160px; }
 }
-
-/* ──────────────────────────────────────────────────────────────
-   --bg-well note: the Claude-Design prototype distinguishes three depths —
-   --bg-deep / --bg-sunken / --bg-well (deepest, #06070a, used for code/shell
-   wells). The canonical v2 foundation (ds-theme-tokens.css) only aliases
-   --bg-sunken (→ --bg-surface-muted) and does not define --bg-well. Rather
-   than invent a hex that would drift from the foundation, the toml well and
-   rt-input wells use --bg-sunken (the nearest canonical depth). If the
-   foundation later adds --bg-well, swap these two declarations. */


### PR DESCRIPTION
Surface: `runtime-editor`. Implements its row in `reports/keeper-v2-design-match/gap-map.md` (pixel-match to the Claude-Design keeper-v2 prototype). Foundation tokens (#21993) already merged to main; this stacks on top. WIP: implementation agent interrupted by API 529 mid-run, committed as-is — CI verifies tsc/vitest, will refine via chrome visual diff. RFC gate N/A (UI/CSS); runtime-editor/settings self-check pending if backend touched.