### PR TITLE
[v2] settings — pixel-match to Claude-Design prototype (WIP)

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -570,14 +570,16 @@ describe('LogViewer Code links', () => {
     expect(container.textContent).toContain('lifecycle event')
 
     // Rows render newest-seq-first (sortLogEntries: b.seq - a.seq), so the tool
-    // entry (seq 1) is the last row, not the first. Select it by its kind cell
-    // instead of by position so the assertion tracks the intended row.
-    const toolRow = [...container.querySelectorAll('[data-testid="logs-row"]')].find(
-      r => r.querySelector('.v2-logs-kind')?.getAttribute('data-kind') === 'tool',
-    ) as HTMLDivElement
+    // entry (seq 1) is the last row, not the first. Select it by its kind marker.
+    const toolRow = [...container.querySelectorAll('[data-testid="logs-row"]')].find((row: Element) => {
+      const rowKind = row.getAttribute('data-kind')
+      const cellKind = row.querySelector('.v2-logs-kind')?.getAttribute('data-kind')
+      return rowKind === 'tool' || cellKind === 'tool'
+    }) as HTMLDivElement
+    expect(toolRow).not.toBeNull()
     fireEvent.click(toolRow.querySelector('.v2-logs-line') as Element)
     await waitFor(() =>
-      expect(container.querySelector('.v2-logs-kind-grid')?.textContent).toContain('tool'),
+      expect((toolRow as HTMLDivElement).querySelector('.v2-logs-kind-grid')?.textContent).toContain('tool'),
     )
   })
 })

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -383,6 +383,60 @@ describe('SettingsSurface', () => {
     })
   })
 
+  it('renders the fusion preset section (panel families + judge) read-only', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-fusion"]') as HTMLElement)
+
+    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('패널·심판 심의')
+    // trio preset lanes: 3 panel models + 1 judge, with prototype labels.
+    const lanes = container.querySelectorAll('.set-fus-lane')
+    expect(lanes.length).toBe(2)
+    const models = Array.from(container.querySelectorAll('.set-fus-model')).map(n => n.textContent)
+    expect(models).toContain('ollama_cloud.deepseek-v4-flash')
+    expect(models).toContain('glm-coding.glm-5-turbo')
+    expect(models).toContain('ollama_cloud.minimax-m3')
+    expect(container.querySelector('.set-fus-model.judge')?.textContent).toBe('deepseek.deepseek-v4-pro')
+    expect(container.querySelector('[data-testid="set-toggle"]')?.getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('renders the tool-group policy with exec-guard and last_turn_safe', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-policy"]') as HTMLElement)
+
+    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('도구 정책')
+    // 11 named tool groups from tool_policy.toml.
+    expect(container.querySelectorAll('[data-testid="set-tg-row"]').length).toBe(11)
+    // execute group carries the 3-layer guard badge; voice is opt-in.
+    const kinds = Array.from(container.querySelectorAll('.set-tg-kind')).map(n => n.textContent?.trim())
+    expect(kinds).toContain('3-layer guard')
+    expect(kinds).toContain('opt-in')
+    // exec-guard pipeline: validate_command → destructive_guard → write_gate.
+    const guardSteps = Array.from(
+      container.querySelectorAll('[data-testid="set-guard"] .set-guard-step'),
+    ).map(n => n.textContent)
+    expect(guardSteps).toEqual(['validate_command', 'destructive_guard', 'write_gate'])
+    expect(container.querySelectorAll('[data-testid="set-guard"] .set-guard-arrow').length).toBe(2)
+    // last_turn_safe chips carry the .safe modifier.
+    expect(container.querySelectorAll('.set-tg-chip.safe').length).toBeGreaterThan(0)
+  })
+
+  it('shows Discord trigger radios only while the Discord gate is on', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    await fireEvent.click(container.querySelector('[data-testid="settings-nav-gate"]') as HTMLElement)
+
+    // Discord gate defaults on → trigger radios visible with prototype values.
+    const triggers = () => Array.from(container.querySelectorAll('[data-testid="set-trigger"]'))
+    expect(triggers().length).toBe(4)
+    const vals = triggers().map(t => t.querySelector('.mono')?.textContent)
+    expect(vals).toEqual(['mention_or_thread', 'mention_only', 'all', 'user_only'])
+    // default selection is mention_or_thread; controls are read-only previews.
+    expect(triggers()[0]!.classList.contains('on')).toBe(true)
+    expect((triggers()[0] as HTMLButtonElement).disabled).toBe(true)
+  })
+
   it('opens the live runtime.toml editor from runtime management', async () => {
     const runtimeConfig = {
       ok: true,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -406,8 +406,9 @@ describe('SettingsSurface', () => {
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-policy"]') as HTMLElement)
 
     expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('도구 정책')
-    // 11 named tool groups from tool_policy.toml.
+    // 11 named groups in the prototype snapshot.
     expect(container.querySelectorAll('[data-testid="set-tg-row"]').length).toBe(11)
+    expect(container.textContent).toContain('현재는 live tool-policy 연동이 없어 prototype 표기 스냅샷으로 표시합니다.')
     // execute group carries the 3-layer guard badge; voice is opt-in.
     const kinds = Array.from(container.querySelectorAll('.set-tg-kind')).map(n => n.textContent?.trim())
     expect(kinds).toContain('3-layer guard')

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -106,10 +106,12 @@ const FUSION: FusionConfig = {
   maxToolCallsPerPanel: 0,
 }
 
-// tool_policy.toml named groups referenced by keeper tool_access lists —
+// Tool-group catalog for the prototype settings surface snapshot.
 // keeper-v2 settings.jsx:85-97 (TOOL_GROUPS). kind 'local' = [groups.*]
 // (keeper-local), 'masc' = [masc.*] (server). guard/optin map to the
 // [groups.execute] 3-layer guard and opt-in voice group.
+// NOTE: read-only snapshot only; live tool_policy/tier policy data is not yet
+// projected from backend policy SSOT.
 type ToolGroup = {
   readonly id: string
   readonly kind: 'local' | 'masc'
@@ -131,7 +133,8 @@ const TOOL_GROUPS: readonly ToolGroup[] = [
   { id: 'masc.goal', kind: 'masc', tools: ['masc_goal_list', 'masc_goal_upsert', 'masc_goal_transition', 'masc_goal_verify'] },
 ]
 // [groups.last_turn_safe] — keeper-v2 settings.jsx:99. On a keeper's final
-// turn, allowed tools are intersected with this set.
+// turn, allowed tools are intersected with this set. Snapshot from the
+// prototype settings view; backend parity is deferred.
 const LAST_TURN_SAFE: readonly string[] = ['keeper_board_post', 'keeper_board_comment', 'keeper_board_curation_submit', 'keeper_context_status', 'extend_turns', 'keeper_time_now', 'keeper_tool_search', 'keeper_broadcast', 'keeper_tasks_list', 'keeper_task_done', 'masc_tasks', 'masc_transition', 'tool_read_file', 'tool_search_files', 'tool_execute', 'masc_web_search', 'masc_web_fetch']
 // tool_execute 3-layer deterministic guard — keeper-v2 settings.jsx:101
 // ([groups.execute]).
@@ -819,6 +822,9 @@ export function SettingsSurface() {
             ${sec === 'policy' && html`
               <div class="set-hint" style=${{ marginBottom: '12px' }}>
                 keeper 의 <span class="mono">tool_access</span> 는 named 그룹(<span class="mono">tool_policy.toml</span>)의 도구를 참조합니다. 여기서 namespace 기본 부여 그룹과 안전장치를 관리합니다.
+              </div>
+              <div class="set-hint" style=${{ marginBottom: '12px' }}>
+                현재는 live tool-policy 연동이 없어 prototype 표기 스냅샷으로 표시합니다. 런타임 도구 정책이 SSOT로 연동되면 값이 교체됩니다.
               </div>
               <div class="set-sub-h">도구 그룹 부여</div>
               ${TOOL_GROUPS.map(g => html`

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -27,7 +27,9 @@ const SET_SECTIONS: [SectionId, string, string][] = [
   ['runtimes', 'Runtimes', '런타임 관리'],
   ['routing', 'Routing', '모델 라우팅'],
   ['prompts', 'Prompts', '기본 프롬프트'],
-  ['policy', 'Policy', '승인 정책'],
+  // keeper-v2 settings.jsx:35-36 — Fusion '패널·심판 심의', Policy '도구 정책'.
+  ['fusion', 'Fusion', '패널·심판 심의'],
+  ['policy', 'Policy', '도구 정책'],
   ['lifecycle', 'Lifecycle', 'keeper 수명'],
   ['sandbox', 'Sandbox', '샌드박스'],
   ['ide', 'IDE', 'IDE · 편집기'],
@@ -42,7 +44,9 @@ const SET_GROUPS: [string, SectionId[]][] = [
   // KO group labels per keeper-v2 settings.jsx SET_GROUPS — matches the
   // Korean section names below (avoids EN-header / KO-item bilingual mismatch).
   ['계정', ['account']],
-  ['Keeper 운영', ['runtime', 'routing', 'prompts', 'lifecycle', 'policy']],
+  // keeper-v2 settings.jsx:49 — 'Keeper 운영' group order: runtime · routing ·
+  // prompts · fusion · lifecycle · policy.
+  ['Keeper 운영', ['runtime', 'routing', 'prompts', 'fusion', 'lifecycle', 'policy']],
   ['인프라 · 실행', ['runtimes', 'sandbox', 'paths']],
   ['연결 · 통합', ['mcp', 'gate', 'ide']],
   ['관측 · 표시', ['logs', 'notify', 'display']],
@@ -68,12 +72,77 @@ export function mcpExposedToolNames(items: readonly DashboardToolInventoryItem[]
     .sort((a, b) => a.localeCompare(b))
 }
 
-const APPROVAL_ACTIONS: [string, string, string][] = [
-  ['git push / merge', 'always', '원격 브랜치에 쓰기'],
-  ['배포 (infra/deploy)', 'always', 'deploy 트리거'],
-  ['외부 호출 (Slack·Discord 발신)', 'risky', '외부로 메시지 전송'],
-  ['파일 쓰기 (worktree)', 'auto', 'keeper 워크트리 내 편집'],
-  ['읽기 전용 도구', 'auto', 'query·trace·blame 등'],
+// [fusion] preset shape from config/runtime.toml [fusion] — keeper-v2
+// settings.jsx:68-81 (FUSION). Describes the trio preset structure (panel
+// families, judge, timeouts). Read-only preview; no fusion config write
+// endpoint exists yet, so these are the documented config defaults, not live
+// values.
+type FusionConfig = {
+  readonly enabled: boolean
+  readonly defaultPreset: string
+  readonly maxConcurrentPanels: number
+  readonly perHourBudget: number
+  readonly webTools: boolean
+  readonly panel: readonly string[]
+  readonly judge: string
+  readonly panelTimeoutS: number
+  readonly judgeTimeoutS: number
+  readonly maxToolCallsPerPanel: number
+}
+const FUSION: FusionConfig = {
+  enabled: true,
+  defaultPreset: 'trio',
+  maxConcurrentPanels: 2,
+  perHourBudget: 20,
+  webTools: false,
+  panel: [
+    'ollama_cloud.deepseek-v4-flash',
+    'glm-coding.glm-5-turbo',
+    'ollama_cloud.minimax-m3',
+  ],
+  judge: 'deepseek.deepseek-v4-pro',
+  panelTimeoutS: 300,
+  judgeTimeoutS: 300,
+  maxToolCallsPerPanel: 0,
+}
+
+// tool_policy.toml named groups referenced by keeper tool_access lists —
+// keeper-v2 settings.jsx:85-97 (TOOL_GROUPS). kind 'local' = [groups.*]
+// (keeper-local), 'masc' = [masc.*] (server). guard/optin map to the
+// [groups.execute] 3-layer guard and opt-in voice group.
+type ToolGroup = {
+  readonly id: string
+  readonly kind: 'local' | 'masc'
+  readonly tools: readonly string[]
+  readonly guard?: boolean
+  readonly optin?: boolean
+}
+const TOOL_GROUPS: readonly ToolGroup[] = [
+  { id: 'base', kind: 'local', tools: ['keeper_time_now', 'keeper_context_status', 'keeper_memory_search', 'keeper_memory_write', 'keeper_tool_search', 'keeper_tools_list'] },
+  { id: 'board_core', kind: 'local', tools: ['keeper_board_get', 'keeper_board_post', 'keeper_board_comment', 'keeper_board_vote', 'keeper_board_list', 'keeper_board_curation_read', 'keeper_board_curation_submit'] },
+  { id: 'workspace_core', kind: 'local', tools: ['keeper_tasks_list', 'keeper_task_claim', 'keeper_task_create', 'keeper_task_done', 'keeper_broadcast'] },
+  { id: 'filesystem', kind: 'local', tools: ['tool_read_file'] },
+  { id: 'workspace_write', kind: 'local', tools: ['tool_edit_file', 'tool_write_file'] },
+  { id: 'execute', kind: 'local', guard: true, tools: ['tool_execute'] },
+  { id: 'library', kind: 'local', tools: ['keeper_library_search', 'keeper_library_read'] },
+  { id: 'voice', kind: 'local', optin: true, tools: ['keeper_voice_speak', 'keeper_voice_listen', 'keeper_voice_agent', 'keeper_voice_sessions'] },
+  { id: 'masc.essential', kind: 'masc', tools: ['masc_status', 'masc_web_search', 'masc_web_fetch'] },
+  { id: 'masc.workspace', kind: 'masc', tools: ['masc_tasks', 'masc_claim_next', 'masc_transition', 'masc_add_task', 'masc_agents', 'masc_broadcast', 'masc_messages', 'masc_heartbeat'] },
+  { id: 'masc.goal', kind: 'masc', tools: ['masc_goal_list', 'masc_goal_upsert', 'masc_goal_transition', 'masc_goal_verify'] },
+]
+// [groups.last_turn_safe] — keeper-v2 settings.jsx:99. On a keeper's final
+// turn, allowed tools are intersected with this set.
+const LAST_TURN_SAFE: readonly string[] = ['keeper_board_post', 'keeper_board_comment', 'keeper_board_curation_submit', 'keeper_context_status', 'extend_turns', 'keeper_time_now', 'keeper_tool_search', 'keeper_broadcast', 'keeper_tasks_list', 'keeper_task_done', 'masc_tasks', 'masc_transition', 'tool_read_file', 'tool_search_files', 'tool_execute', 'masc_web_search', 'masc_web_fetch']
+// tool_execute 3-layer deterministic guard — keeper-v2 settings.jsx:101
+// ([groups.execute]).
+const EXEC_GUARD: readonly string[] = ['validate_command', 'destructive_guard', 'write_gate']
+// [discord].trigger_policy — keeper-v2 settings.jsx:103-108. env
+// MASC_DISCORD_TRIGGER_POLICY overrides.
+const DISCORD_TRIGGER: readonly [string, string][] = [
+  ['mention_or_thread', '스레드 자동 응답, 일반 채널은 멘션 필요 (기본)'],
+  ['mention_only', '@멘션된 메시지만 응답'],
+  ['all', '모든 메시지에 응답'],
+  ['user_only', '특정 사용자(snowflake)만'],
 ]
 
 // System-log row: [time, level, identity, message, status]. Derived from live
@@ -418,10 +487,21 @@ export function SettingsSurface() {
     return () => { active = false }
   }, [])
 
-  // policy
-  const [approve, setApprove] = useState<Record<string, string>>(
-    Object.fromEntries(APPROVAL_ACTIONS.map(a => [a[0], a[1]])),
+  // policy — tool-group grants (namespace default-grant per [groups.*]); opt-in groups
+  // start off. keeper-v2 settings.jsx:177.
+  const [grant, setGrant] = useState<Record<string, boolean>>(
+    Object.fromEntries(TOOL_GROUPS.map(g => [g.id, !g.optin])),
   )
+
+  // fusion (config/runtime.toml [fusion]) — keeper-v2 settings.jsx:178-182
+  const [fusionOn, setFusionOn] = useState(FUSION.enabled)
+  const [fusionPreset, setFusionPreset] = useState(FUSION.defaultPreset)
+  const [fusionPanels, setFusionPanels] = useState(FUSION.maxConcurrentPanels)
+  const [fusionBudget, setFusionBudget] = useState(FUSION.perHourBudget)
+  const [fusionWeb, setFusionWeb] = useState(FUSION.webTools)
+
+  // discord trigger policy (gate section) — keeper-v2 settings.jsx:183
+  const [discordTrigger, setDiscordTrigger] = useState('mention_or_thread')
 
   // lifecycle
   const [idleDrain, setIdleDrain] = useState(30)
@@ -699,21 +779,82 @@ export function SettingsSurface() {
               </div>
             `}
 
-            ${sec === 'policy' && html`
-              <div class="set-policy-legend">
-                <span><b class="mono">always</b> require approval</span>
-                <span><b class="mono">risky</b> only when risky</span>
-                <span><b class="mono">auto</b> allow automatically</span>
+            ${sec === 'fusion' && html`
+              <div class="set-hint" style=${{ marginBottom: '12px' }}>
+                <span class="mono">masc_fusion</span> 의 out-of-band 심의 루프 (RFC-0252). 서로 다른 모델 패밀리로 패널을 구성해 관점 다양성을 확보하고, 심판이 종합합니다. fusion이 발화 가치 있는지는 keeper가 판단하고 게이트는 남용만 막습니다.
               </div>
-              ${APPROVAL_ACTIONS.map(([action, , hint]) => html`
-                <${SetRow} key=${action} label=${action} hint=${hint}>
-                  <${SetSeg}
-                    value=${approve[action]}
-                    options=${['always', 'risky', 'auto']}
-                    onChange=${(v: string) => setApprove(p => ({ ...p, [action]: v }))}
-                  />
+              <${SetRow} label="Fusion 심의" hint="끄면 masc_fusion 호출이 게이트에서 Deny 반환">
+                <${SetToggle} on=${fusionOn} onChange=${setFusionOn} />
+              <//>
+              ${fusionOn && html`
+                <${SetRow} label="기본 프리셋" hint="default_preset">
+                  <${SetSeg} value=${fusionPreset} options=${['trio']} onChange=${setFusionPreset} />
                 <//>
+                <${SetRow} label="동시 패널 수" hint="max_concurrent_panels · Async_agent.all 상한">
+                  <${SetStepper} v=${fusionPanels} set=${setFusionPanels} min=${1} max=${8} />
+                <//>
+                <${SetRow} label="시간당 발화 budget" hint="[fusion.gate].per_hour_budget · UTC hour bucket">
+                  <${SetStepper} v=${fusionBudget} set=${setFusionBudget} min=${1} max=${100} />
+                <//>
+                <${SetRow} label="패널·심판 웹 도구" hint="web_search / web_fetch 주입 여부">
+                  <${SetToggle} on=${fusionWeb} onChange=${setFusionWeb} />
+                <//>
+                <div class="set-sub-h">trio 프리셋</div>
+                <div class="set-fus-preset">
+                  <div class="set-fus-lane">
+                    <div class="set-fus-lane-h">panel · ${FUSION.panel.length}</div>
+                    ${FUSION.panel.map(id => html`<div key=${id} class="set-fus-model mono">${id}</div>`)}
+                  </div>
+                  <div class="set-fus-lane">
+                    <div class="set-fus-lane-h">judge</div>
+                    <div class="set-fus-model judge mono">${FUSION.judge}</div>
+                  </div>
+                </div>
+                <div class="set-mcp-detail mono" style=${{ marginTop: '10px' }}>
+                  panel_timeout ${FUSION.panelTimeoutS}s · judge_timeout ${FUSION.judgeTimeoutS}s · max_tool_calls_per_panel ${FUSION.maxToolCallsPerPanel} (0 = 무제한)
+                </div>
+              `}
+            `}
+
+            ${sec === 'policy' && html`
+              <div class="set-hint" style=${{ marginBottom: '12px' }}>
+                keeper 의 <span class="mono">tool_access</span> 는 named 그룹(<span class="mono">tool_policy.toml</span>)의 도구를 참조합니다. 여기서 namespace 기본 부여 그룹과 안전장치를 관리합니다.
+              </div>
+              <div class="set-sub-h">도구 그룹 부여</div>
+              ${TOOL_GROUPS.map(g => html`
+                <div key=${g.id} class="set-tg-row" data-testid="set-tg-row">
+                  <div class="set-tg-l">
+                    <div class="set-tg-head">
+                      <span class="set-tg-id mono">${g.id}</span>
+                      <span class=${`set-tg-kind ${g.kind}`}>${g.kind}</span>
+                      ${g.guard ? html`<span class="set-tg-kind guard">3-layer guard</span>` : null}
+                      ${g.optin ? html`<span class="set-tg-kind optin">opt-in</span>` : null}
+                    </div>
+                    <div class="set-tg-tools">${g.tools.map(t => html`<span key=${t} class="set-tg-chip mono">${t}</span>`)}</div>
+                  </div>
+                  <${SetToggle}
+                    on=${grant[g.id] ?? false}
+                    onChange=${(v: boolean) => setGrant(p => ({ ...p, [g.id]: v }))}
+                  />
+                </div>
               `)}
+
+              <div class="set-sub-h">tool_execute 가드 — 3계층 결정적</div>
+              <div class="set-hint" style=${{ marginBottom: '8px' }}>
+                셸 타입된 argv 명령은 세 계층을 순차 통과해야 실행됩니다. redirection/tee 또는 직접 file write 우회는 여기서 막힙니다.
+              </div>
+              <div class="set-guard" data-testid="set-guard">
+                ${EXEC_GUARD.map((step, i) => html`
+                  ${i > 0 ? html`<span key=${`a${i}`} class="set-guard-arrow">→</span>` : null}
+                  <span key=${step} class="set-guard-step mono">${step}</span>
+                `)}
+              </div>
+
+              <div class="set-sub-h">마지막 턴 안전 도구 — last_turn_safe</div>
+              <div class="set-hint" style=${{ marginBottom: '8px' }}>
+                keeper 의 마지막 턴에서는 허용 도구가 이 집합과 교집합됩니다 (${LAST_TURN_SAFE.length}개).
+              </div>
+              <div class="set-tg-tools">${LAST_TURN_SAFE.map(t => html`<span key=${t} class="set-tg-chip mono safe">${t}</span>`)}</div>
             `}
 
             ${sec === 'lifecycle' && html`
@@ -872,6 +1013,30 @@ export function SettingsSurface() {
                   <${SetToggle} on=${gateOn[g]} onChange=${(v: boolean) => setGateOn(p => ({ ...p, [g]: v }))} />
                 <//>
               `)}
+              ${gateOn.Discord && html`
+                <div class="set-sub-h">Discord 트리거 정책</div>
+                <div class="set-hint" style=${{ marginBottom: '8px' }}>
+                  어떤 인바운드 이벤트에 봇이 응답할지 — <span class="mono">[discord].trigger_policy</span> · env <span class="mono">MASC_DISCORD_TRIGGER_POLICY</span> 우선.
+                </div>
+                ${DISCORD_TRIGGER.map(([val, hint]) => html`
+                  <button
+                    type="button"
+                    key=${val}
+                    class=${`set-trigger ${discordTrigger === val ? 'on' : ''}`}
+                    data-testid="set-trigger"
+                    data-active=${discordTrigger === val ? 'true' : 'false'}
+                    aria-disabled="true"
+                    disabled
+                    onClick=${() => setDiscordTrigger(val)}
+                  >
+                    <span class="set-trigger-radio"></span>
+                    <span class="set-trigger-l">
+                      <span class="mono">${val}</span>
+                      <span class="set-trigger-hint">${hint}</span>
+                    </span>
+                  </button>
+                `)}
+              `}
             `}
 
             ${sec === 'paths' && html`

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -8,6 +8,7 @@ export const SETTINGS_ROUTE_SECTION_IDS = [
   'runtimes',
   'routing',
   'prompts',
+  'fusion',
   'policy',
   'lifecycle',
   'sandbox',

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -334,8 +334,8 @@
 
 .set-mcp-detail {
   margin: -4px 0 4px;
-  padding: 8px 12px;
-  background: var(--bg-sunken);
+  padding: 8px 11px;
+  background: var(--bg-well);
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-xs);
   font-size: 11px;
@@ -451,7 +451,8 @@
   border: 1px solid var(--border-main);
   border-radius: var(--radius-sm);
   overflow: hidden;
-  background: var(--bg-sunken);
+  /* keeper-v2 styles/surfaces.css:506 — well (deepest), not sunken */
+  background: var(--bg-well);
 }
 
 .log-filters {

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -754,6 +754,207 @@
   color: var(--volt);
 }
 
+/* tool-group policy — keeper-v2 styles/surfaces.css:555-565 (.set-tg-*) */
+.set-tg-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.set-tg-l {
+  flex: 1;
+  min-width: 0;
+}
+
+.set-tg-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-bottom: 7px;
+}
+
+.set-tg-id {
+  font-size: 12.5px;
+  color: var(--text-bright);
+}
+
+.set-tg-kind {
+  font-family: var(--font-ui);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  border: 1px solid var(--border-soft);
+  color: var(--text-dim);
+}
+
+.set-tg-kind.masc {
+  color: var(--volt);
+  border-color: var(--volt-dim);
+  background: var(--volt-wash);
+}
+
+.set-tg-kind.guard {
+  color: var(--status-warn);
+  border-color: color-mix(in oklab, var(--status-warn) 45%, transparent);
+}
+
+.set-tg-kind.optin {
+  color: var(--text-mid);
+}
+
+.set-tg-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.set-tg-chip {
+  font-size: 10.5px;
+  padding: 2px 7px;
+  background: var(--bg-well);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xs);
+  color: var(--text-mid);
+}
+
+.set-tg-chip.safe {
+  border-color: color-mix(in oklab, var(--status-ok) 35%, transparent);
+  color: color-mix(in oklab, var(--status-ok) 80%, var(--text-mid));
+}
+
+/* tool_execute 3-layer guard — keeper-v2 styles/surfaces.css:567-569 */
+.set-guard {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 9px;
+  padding: 4px 0 4px;
+}
+
+.set-guard-step {
+  font-size: 12px;
+  padding: 6px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  color: var(--text-bright);
+  box-shadow: inset 0 0 0 1px var(--volt-wash);
+}
+
+.set-guard-arrow {
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+/* fusion preset — keeper-v2 styles/surfaces.css:572-577 (.set-fus-*) */
+.set-fus-preset {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+.set-fus-lane {
+  padding: 11px 13px;
+  background: var(--bg-well);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+}
+
+.set-fus-lane-h {
+  font-family: var(--font-ui);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 8px;
+}
+
+.set-fus-model {
+  font-size: 12px;
+  color: var(--text-mid);
+  padding: 5px 9px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xs);
+  margin-bottom: 5px;
+}
+
+.set-fus-model:last-child {
+  margin-bottom: 0;
+}
+
+.set-fus-model.judge {
+  color: var(--volt);
+  border-color: var(--volt-dim);
+  background: var(--volt-wash);
+}
+
+/* Discord trigger radios — keeper-v2 styles/surfaces.css:580-587 (.set-trigger*) */
+.set-trigger {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  margin-bottom: 6px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: 0.14s;
+}
+
+.set-trigger:hover {
+  border-color: var(--volt-dim);
+}
+
+.set-trigger.on {
+  border-color: var(--volt-dim);
+  background: var(--volt-wash);
+}
+
+.set-trigger:disabled {
+  cursor: not-allowed;
+}
+
+.set-trigger-radio {
+  flex: none;
+  width: 15px;
+  height: 15px;
+  margin-top: 2px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border-highlight);
+  transition: 0.14s;
+}
+
+.set-trigger.on .set-trigger-radio {
+  border-color: var(--volt);
+  box-shadow: inset 0 0 0 3px var(--volt);
+}
+
+.set-trigger-l {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.set-trigger-l .mono {
+  font-size: 12.5px;
+  color: var(--text-bright);
+}
+
+.set-trigger-hint {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
 /* v2.css utility classes referenced by the surface but not imported globally */
 .act {
   font-family: var(--font-ui);


### PR DESCRIPTION
Surface: `settings`. Implements its row in `reports/keeper-v2-design-match/gap-map.md` (pixel-match to the Claude-Design keeper-v2 prototype). Foundation tokens (#21993) already merged to main; this stacks on top. WIP: implementation agent interrupted by API 529 mid-run, committed as-is — CI verifies tsc/vitest, will refine via chrome visual diff. RFC gate N/A (UI/CSS); runtime-editor/settings self-check pending if backend touched.