### PR TITLE
[v2] ide-work — pixel-match to Claude-Design prototype

### DIFF
--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -361,6 +361,76 @@ describe('Work', () => {
       expect(cards[1]?.textContent).toContain('완료')
     })
 
+    // Pixel-match: .wk-gstatus carries a semantic status variant class so the
+    // prototype's ok/warn/bad/volt color rules (work-v2.css) apply.
+    it('applies the semantic status variant class to the goal status chip', () => {
+      goals.value = [
+        { id: 'G-ok', horizon: 'short', title: 'Active', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-warn', horizon: 'short', title: 'At risk', priority: 2, status: 'at_risk', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-bad', horizon: 'short', title: 'Blocked', priority: 2, status: 'blocked', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-volt', horizon: 'short', title: 'Verifying', priority: 2, status: 'verifying', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+      ]
+      tasks.value = []
+
+      const { container } = render(html`<${Work} />`)
+
+      const chipFor = (id: string) =>
+        container.querySelector(`[data-goal-id="${id}"] .wk-gstatus`)
+      expect(chipFor('G-ok')?.classList.contains('ok')).toBe(true)
+      expect(chipFor('G-warn')?.classList.contains('warn')).toBe(true)
+      expect(chipFor('G-bad')?.classList.contains('bad')).toBe(true)
+      expect(chipFor('G-volt')?.classList.contains('volt')).toBe(true)
+    })
+
+    it('falls back to the ok status variant for unknown goal statuses', () => {
+      goals.value = [
+        { id: 'G-x', horizon: 'short', title: 'Mystery', priority: 2, status: 'something_new', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+      ]
+      tasks.value = []
+
+      const { container } = render(html`<${Work} />`)
+
+      const chip = container.querySelector('[data-goal-id="G-x"] .wk-gstatus')
+      expect(chip?.classList.contains('ok')).toBe(true)
+      // unknown status text is passed through verbatim
+      expect(chip?.textContent).toContain('something_new')
+    })
+
+    // Pixel-match: the completion-approval pill (.wk-approval, volt theme) and
+    // verifier chips (.wk-vchip, mono) render when a goal requires approval.
+    it('renders the completion-approval pill and verifier chips', () => {
+      goals.value = [
+        {
+          id: 'G-1',
+          horizon: 'short',
+          title: 'Goal needing approval',
+          priority: 9,
+          status: 'verifying',
+          phase: 'executing',
+          require_completion_approval: true,
+          verifier_policy: {
+            inherit_mode: 'replace',
+            principals: [{ id: 'operator' }, { id: 'sangsu' }],
+          },
+          created_at: '2026-01-01',
+          updated_at: '2026-01-01',
+        },
+      ]
+      tasks.value = []
+
+      const { container } = render(html`<${Work} />`)
+
+      const approval = container.querySelector('[data-goal-id="G-1"] .wk-approval')
+      expect(approval).toBeTruthy()
+      expect(approval?.textContent).toContain('완료 승인')
+
+      // open the card to expose the verifier policy chips
+      fireEvent.click(container.querySelector('[data-goal-id="G-1"] .wk-goal-h')!)
+      const chips = Array.from(container.querySelectorAll('[data-goal-id="G-1"] .wk-vchip'))
+      expect(chips.map(c => c.textContent)).toEqual(['operator', 'sangsu'])
+      expect(chips.every(c => c.classList.contains('mono'))).toBe(true)
+    })
+
     it('does not render a task dossier sidebar for route-selected tasks', () => {
       routeSignal.value = {
         tab: 'workspace',

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -101,6 +101,23 @@ function goalStatusLabel(status: string): string {
   return GOAL_STATUS_LABEL[status] ?? status
 }
 
+// Goal status → semantic css class for .wk-gstatus variants.
+// Prototype data.jsx:355 maps active→ok, at_risk→warn, blocked→bad, verifying→volt
+// (default cls 'ok'). Repo statuses (active/completed/paused/cancelled) folded in.
+const GOAL_STATUS_CLASS: Record<string, 'ok' | 'warn' | 'bad' | 'volt'> = {
+  active: 'ok',
+  completed: 'ok',
+  at_risk: 'warn',
+  paused: 'warn',
+  blocked: 'bad',
+  cancelled: 'bad',
+  verifying: 'volt',
+}
+
+function goalStatusClass(status: string): 'ok' | 'warn' | 'bad' | 'volt' {
+  return GOAL_STATUS_CLASS[status] ?? 'ok'
+}
+
 // ── Goal horizon mapping ────────────────────────────────────────────────────
 
 interface HorizonMeta {
@@ -317,7 +334,7 @@ function GoalCard({
       <button type="button" class="wk-goal-h" onClick=${onToggle} aria-expanded=${open}>
         <span class="wk-caret" aria-hidden="true">${open ? '\u25BE' : '\u25B8'}</span>
         <span class="wk-prio mono" title=${`우선순위 ${goal.priority}`}>P${goal.priority}</span>
-        <span class="wk-gstatus">${goalStatusLabel(goal.status)}</span>
+        <span class=${`wk-gstatus ${goalStatusClass(goal.status)}`}>${goalStatusLabel(goal.status)}</span>
         <span class="wk-goal-title">${goal.title}</span>
         <span class="wk-goal-ns mono">${horizon.label}</span>
         <span class="wk-spacer"></span>

--- a/dashboard/src/styles/ide-v2.css
+++ b/dashboard/src/styles/ide-v2.css
@@ -556,7 +556,8 @@
 .ide-v2-drawer {
   flex: none;
   border-top: 1px solid var(--border-main);
-  background: var(--color-bg-page);
+  /* prototype surfaces.css:695 — well (deepest), not bg-page/bg-deep */
+  background: var(--bg-well);
   display: flex;
   flex-direction: column;
   max-height: 200px;

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -191,38 +191,61 @@
   width: 12px;
 }
 
+/* wk-prio: prototype v2.css:815 — square chip (radius-xs), mono via .mono utility */
 .wk-prio {
   flex: none;
-  font-family: var(--font-mono);
   font-size: 10px;
-  letter-spacing: 0.02em;
-  padding: 2px 7px;
-  border-radius: var(--radius-pill);
-  border: 1px solid var(--border-soft);
   color: var(--text-mid);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  padding: 1px 6px;
 }
 
-.wk-gstatus,
-.wk-approval {
+/* wk-gstatus: prototype v2.css:816 — pill, ui font, semantic status variants below */
+.wk-gstatus {
   flex: none;
   font-family: var(--font-ui);
   font-size: 9.5px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  padding: 2px 7px;
+  letter-spacing: 0.06em;
+  padding: 2px 8px;
   border-radius: var(--radius-pill);
-  border: 1px solid var(--border-soft);
+  border: 1px solid var(--border-main);
+  color: var(--text-dim);
 }
 
-.wk-gstatus {
-  color: var(--text-mid);
-  background: color-mix(in oklab, var(--bg-sunken) 70%, transparent);
+/* wk-gstatus semantic variants: prototype v2.css:817-820 */
+.wk-gstatus.ok {
+  color: var(--status-ok);
+  border-color: color-mix(in oklab, var(--status-ok) 38%, transparent);
 }
 
-.wk-approval {
+.wk-gstatus.warn {
   color: var(--status-warn);
-  border-color: color-mix(in oklab, var(--status-warn) 36%, transparent);
-  background: color-mix(in oklab, var(--status-warn) 10%, transparent);
+  border-color: color-mix(in oklab, var(--status-warn) 40%, transparent);
+  background: color-mix(in oklab, var(--status-warn) 8%, transparent);
+}
+
+.wk-gstatus.bad {
+  color: var(--status-bad);
+  border-color: color-mix(in oklab, var(--status-bad) 42%, transparent);
+  background: color-mix(in oklab, var(--status-bad) 8%, transparent);
+}
+
+.wk-gstatus.volt {
+  color: var(--volt-strong);
+  border-color: var(--volt-dim);
+  background: var(--volt-wash);
+}
+
+/* wk-approval: prototype v2.css:821 — volt theme (was warn) */
+.wk-approval {
+  flex: none;
+  font-size: 10px;
+  color: var(--volt-strong);
+  border: 1px solid var(--volt-dim);
+  background: var(--volt-wash);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
 }
 
 .wk-goal-title {
@@ -284,7 +307,8 @@
 }
 
 .wk-seg.done { background: var(--status-ok); }
-.wk-seg.verify { background: var(--status-warn); }
+/* wk-seg.verify: prototype v2.css:823 — volt-strong (was status-warn) */
+.wk-seg.verify { background: var(--volt-strong); }
 .wk-seg.wip { background: var(--volt); }
 .wk-seg.blocked { background: var(--status-bad); }
 
@@ -333,13 +357,14 @@
   margin-bottom: 7px;
 }
 
+/* wk-vchip: prototype v2.css:827 — square (radius-xs), volt theme, mono via .mono utility */
 .wk-vchip {
-  font-size: 10px;
+  font-size: 9.5px;
+  color: var(--volt-strong);
+  border: 1px solid var(--volt-dim);
+  border-radius: var(--radius-xs);
   padding: 1px 6px;
-  border-radius: var(--radius-pill);
-  border: 1px solid var(--border-soft);
-  background: var(--bg-sunken);
-  color: var(--text-mid);
+  background: var(--volt-wash);
 }
 
 /* ── Claimable backlog ────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Goal
Pixel-match the v2 **ide-work** surface to the Claude-Design prototype (`work.jsx` / `ide.jsx`). Token-alignment only — no structural rebuild. The IDE editor (CodeMirror re-arch) is intentionally left as-is.

## Gap map

| surface | before | after (prototype) | citation |
|---|---|---|---|
| `.wk-seg.verify` | `var(--status-warn)` | `var(--volt-strong)` | v2.css:823 |
| `.wk-approval` | warn theme (`status-warn`, radius-pill, 2px 7px, uppercase) | volt theme: `color volt-strong`, `border volt-dim`, `bg volt-wash`, `radius-pill`, `font-size 10px`, `padding 2px 8px` | v2.css:821 |
| `.wk-gstatus` | single generic style, no variants | base (`font-ui 9.5px`, `letter-spacing .06em`, `padding 2px 8px`, `radius-pill`, `border border-main`, `color text-dim`) + `.ok/.warn/.bad/.volt` variants | v2.css:816–820 |
| `.wk-prio` | `radius-pill`, explicit mono, `letter-spacing .02em`, `padding 2px 7px`, `border-soft` | `radius-xs`, `font-size 10px`, `color text-mid`, `border border-main`, `padding 1px 6px` (mono via `.mono` utility) | v2.css:815 |
| `.wk-vchip` | `radius-pill`, `bg-sunken`, `border-soft`, `text-mid`, 10px | `radius-xs`, `font-size 9.5px`, `color volt-strong`, `border volt-dim`, `bg volt-wash`, `padding 1px 6px` (mono via `.mono`) | v2.css:827 |
| `.ide-v2-drawer` bg | `var(--color-bg-page)` (→ `--bg-deep` #08090d) | `var(--bg-well)` (#06070a) | surfaces.css:695 |

## Behavioral change (component)
- `work.ts`: `.wk-gstatus` now emits a semantic variant class via new `goalStatusClass()` (active/completed→ok, at_risk/paused→warn, blocked/cancelled→bad, verifying→volt, unknown→ok). Mirrors prototype `goalMeta`/`GOAL_STATUS` (data.jsx:355) so the new CSS variants apply.

## Token verification
All aliases resolve under `[data-skin=v2][data-volt=brass]` (skin-v2.css): `--volt-strong` #f0c373, `--volt-dim`, `--volt-wash` rgba(224,176,87,0.10), `--status-ok/warn/bad`, `--radius-xs` 3px, `--radius-pill` 999px, `--bg-well` #06070a, `--font-ui`, `--border-main` #282a36. `.mono` utility (tokens.css:395) supplies the mono font for `wk-prio`/`wk-vchip` (prototype relies on the same utility; the chips themselves set no font-family). No literal-px overrides were needed (all values map cleanly to existing tokens).

## Scope discipline
work-v2.css: only `.wk-*` rules touched. surfaces-v2.css: untouched. ide-v2.css: only `.ide-v2-drawer` background.

## Tests
Added 3 behavioral vitest tests (`work.test.ts`, render + assert classes/text):
- semantic status variant class applied per goal status (ok/warn/bad/volt)
- unknown status falls back to `ok` variant + passes label through verbatim
- completion-approval pill + verifier chips render (chips carry `mono`)

```
$ npx tsc --noEmit         → exit 0 (clean)
$ npx vitest run src/components/work.test.ts
  Test Files  1 passed (1)
       Tests  19 passed (19)   (16 existing + 3 new)
```

## Remaining gaps
None known for the listed targets. The IDE editor remains the intentional CodeMirror re-arch (out of scope per task).

RFC gate N/A (UI/CSS).
