### PR TITLE
[v2] composer — pixel-match to Claude-Design prototype

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -2426,3 +2426,83 @@ describe('ChatMessageBubble — rich markdown rendering of assistant prose', () 
     expect(container.querySelector('[data-chat-block="code"]')).toBeNull()
   })
 })
+
+// Pixel-match of the v2 composer to the Claude-Design prototype (composer.jsx /
+// styles/v2.css). jsdom does not apply the .css files, so these assert the
+// markup contract the CSS depends on: the textarea must be a flush, borderless
+// element with NO inline Tailwind box styling (border/rounded/padding/bg/
+// control-textarea) — all box styling lives in .composer textarea (chat.css).
+describe('ChatComposer v2 prototype surface', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  function renderComposer() {
+    render(
+      html`<${ChatComposer}
+        draft=""
+        placeholder="메시지 입력..."
+        disabled=${false}
+        streaming=${false}
+        onDraftChange=${() => {}}
+        onSend=${() => {}}
+      />`,
+      container,
+    )
+  }
+
+  it('renders the composer box, tools, and send button structure', () => {
+    renderComposer()
+    expect(container.querySelector('.composer')).not.toBeNull()
+    expect(container.querySelector('.composer-box')).not.toBeNull()
+    expect(container.querySelector('.composer-tools')).not.toBeNull()
+    expect(container.querySelector('.composer-tools .send')).not.toBeNull()
+    // attachment ctool always present
+    expect(container.querySelector('.composer-tools .ctool')).not.toBeNull()
+  })
+
+  it('renders a flush borderless textarea with no inline box styling', () => {
+    renderComposer()
+    const textarea = container.querySelector('.composer-box textarea') as HTMLTextAreaElement
+    expect(textarea).not.toBeNull()
+    const cls = textarea.className
+    // flush class hook present
+    expect(cls).toContain('composer-textarea')
+    // no inline Tailwind border / radius / padding / background / utility that
+    // would draw a nested box inside .composer-box (prototype has none).
+    expect(cls).not.toContain('control-textarea')
+    expect(cls).not.toMatch(/\bborder\b/)
+    expect(cls).not.toMatch(/\brounded/)
+    expect(cls).not.toMatch(/\bpx-/)
+    expect(cls).not.toMatch(/\bpy-/)
+    expect(cls).not.toMatch(/\bbg-\[/)
+  })
+
+  it('keeps send and attach controls operational', () => {
+    const onSend = vi.fn()
+    render(
+      html`<${ChatComposer}
+        draft="hello"
+        placeholder="메시지 입력..."
+        disabled=${false}
+        streaming=${false}
+        onDraftChange=${() => {}}
+        onSend=${onSend}
+      />`,
+      container,
+    )
+    const send = container.querySelector('.composer-tools .send') as HTMLButtonElement
+    expect(send).not.toBeNull()
+    expect(send.disabled).toBe(false)
+    send.click()
+    expect(onSend).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2912,11 +2912,15 @@ export function ChatComposer({
             `
           : null}
         <div class=${boxClass}>
+          <!-- Flush borderless textarea: prototype composer.jsx <textarea> has
+               no inline styling; all box styling (border:0, outline:0,
+               transparent bg, padding:9px 0) comes from .composer textarea in
+               chat.css (mirrors styles/v2.css:932-936). Removing the prior
+               inline Tailwind (control-textarea + border + rounded + px/py +
+               bg + focus ring) drops the nested box the prototype lacks. -->
           <textarea
             ref=${textareaRef}
-            class=${(isPrimary
-              ? 'control-textarea min-h-30 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-4 py-4 text-base leading-loose'
-              : 'control-textarea min-h-24 rounded-card border border-[var(--color-border-default)] bg-[var(--color-bg-panel-alt)] px-3 py-3 text-base leading-loose') + ` ${CHAT_FOCUS_RING}`}
+            class="composer-textarea"
             placeholder=${placeholder}
             aria-label="메시지 입력"
             value=${draft}

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -250,7 +250,7 @@ describe('KeeperConversationPanel', () => {
     expect(shell?.classList.contains('h-[clamp(30rem,calc(100svh-13rem),52rem)]')).toBe(true)
     expect(container.querySelector('.chat-transcript-airy')).not.toBeNull()
     expect(container.querySelector('.chat-transcript-airy')?.classList.contains('flex-1')).toBe(true)
-    expect(container.querySelector('.min-h-30')).not.toBeNull()
+    expect(container.querySelector('.composer-textarea')).not.toBeNull()
     expect(container.textContent).toContain('@sangsu')
     expect(container.textContent).not.toContain('Enter로 전송')
   })

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -190,7 +190,11 @@
 
 .composer {
   flex: none;
-  padding: var(--sp-3) var(--sp-4) var(--sp-4);
+  /* prototype styles/v2.css:912 — padding: 12px 24px 16px.
+     24px horizontal must be a literal: under [data-skin=v2] the 2px-base
+     --sp-* ladder tops at --sp-9 (24px), but vertical 12/16 are off-scale,
+     so the whole shorthand is set in literal px to pixel-match. */
+  padding: 12px 24px 16px;
   border-top: 1px solid var(--color-border-default);
   background: linear-gradient(0deg, var(--color-bg-surface), var(--color-bg-page));
 }
@@ -213,7 +217,8 @@
   gap: 10px;
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
-  border-radius: var(--r-1);
+  /* prototype styles/v2.css:927 — border-radius: var(--radius-md) (6px). */
+  border-radius: var(--radius-md);
   padding: 6px 6px 6px 14px;
   transition: border-color 0.15s, box-shadow 0.15s;
 }
@@ -236,7 +241,8 @@
   outline: 0;
   background: transparent;
   color: var(--color-fg-primary);
-  font-size: var(--fs-sm, 14px);
+  /* prototype styles/v2.css:934 — font-size: 14.5px. */
+  font-size: var(--fs-composer-input, 14.5px);
   line-height: 1.5;
   padding: 9px 0;
   max-height: 160px;
@@ -260,7 +266,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--r-0);
+  /* prototype styles/v2.css:941 — border-radius: var(--radius-sm) (4px). */
+  border-radius: var(--radius-sm);
   border: 1px solid var(--color-border-default);
   background: var(--color-bg-panel-alt);
   color: var(--color-fg-muted);
@@ -282,12 +289,14 @@
 .send {
   height: 34px;
   padding: 0 16px;
-  border-radius: var(--r-0);
+  /* prototype styles/v2.css:946 — border-radius: var(--radius-sm) (4px). */
+  border-radius: var(--radius-sm);
   cursor: pointer;
   background: var(--color-accent-fg);
   color: var(--color-bg-surface);
   border: 1px solid var(--color-accent-fg);
-  font-size: var(--fs-xs, 12px);
+  /* prototype styles/v2.css:948 — font-size: 12.5px. */
+  font-size: var(--fs-composer-send, 12.5px);
   font-weight: 600;
   letter-spacing: 0.04em;
   display: inline-flex;

--- a/dashboard/src/styles/skin-v2.css
+++ b/dashboard/src/styles/skin-v2.css
@@ -112,6 +112,13 @@ html[data-skin="v2"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {
   --fs-t2: 16px; --fw-t2: 600; --tr-t2: 0;         /* bright · sentence */
   --fs-t3: 11px; --fw-t3: 600; --tr-t3: 0.14em;    /* mid · UPPER */
   --fs-t4: 9px;  --fw-t4: 600; --tr-t4: 0.2em;     /* dim · UPPER */
+
+  /* Composer input/control sizes — half-pixel literals from the
+     Claude-Design prototype (composer.jsx via styles/v2.css). The 2px-base
+     --fs-* ladder has no 14.5/12.5 step, so these are named to pixel-match:
+     textarea 14.5px (v2.css:934), send 12.5px (v2.css:948). */
+  --fs-composer-input: 14.5px;  /* prototype styles/v2.css:934 */
+  --fs-composer-send:  12.5px;  /* prototype styles/v2.css:948 */
 }
 
 html[data-skin="v2"][data-volt="blood"]:not([data-theme="paper"]):not([data-theme="styleseed"]) {


### PR DESCRIPTION
## Goal
Pixel-match the v2 chat composer surface to the Claude-Design prototype (`composer.jsx` / `styles/v2.css`). The composer was using legacy radius tokens and a Tailwind-styled textarea that drew a nested box the prototype does not have.

## Gap-map
| Surface | EXISTENCE | Size | Confidence | Result |
|---|---|---|---|---|
| chat composer | partial | M | high | pixel-matched |

## Changes (each px/token cited to prototype)
**`src/styles/chat.css`**
- `.composer` horizontal padding `--sp-3 --sp-4 --sp-4` (8/10px) → literal `12px 24px 16px` — prototype `styles/v2.css:912`. 24px is the intended horizontal padding; under `[data-skin=v2]` the 2px-base `--sp-*` ladder makes the vertical 12/16 off-scale, so the full shorthand is a literal px with a comment.
- `.composer-box` radius `var(--r-1)` (3px) → `var(--radius-md)` (6px) — prototype `styles/v2.css:927` (`--radius-md` defined 6px at `skin-v2.css:81`, matches `v2.css:68`).
- `.ctool` radius `var(--r-0)` (2px) → `var(--radius-sm)` (4px) — prototype `styles/v2.css:941`.
- `.send` radius `var(--r-0)` (2px) → `var(--radius-sm)` (4px) — prototype `styles/v2.css:946`.
- `.composer textarea` font-size `var(--fs-sm,14px)` → `var(--fs-composer-input,14.5px)` — prototype `styles/v2.css:934`.
- `.send` font-size `var(--fs-xs,12px)` → `var(--fs-composer-send,12.5px)` — prototype `styles/v2.css:948`.

**`src/styles/skin-v2.css`**
- Added the half-pixel composer font-size tokens the prototype uses (the `--fs-*` ladder has no 14.5/12.5 step): `--fs-composer-input: 14.5px` (`v2.css:934`), `--fs-composer-send: 12.5px` (`v2.css:948`).

**`src/components/chat/primitives.ts`**
- FLUSH borderless textarea: removed inline Tailwind `control-textarea min-h-* rounded-* border border-[...] bg-[...] px-* py-* text-base leading-loose` + focus ring. Prototype `<textarea>` (`composer.jsx`) carries NO inline styling; all box styling (border:0, outline:0, transparent bg, `padding:9px 0`) comes from `.composer textarea` in chat.css, mirroring `styles/v2.css:932-936`. Only a `composer-textarea` class hook remains. Send/tool/attach/voice behavior unchanged.

## Token-alias verification
- `--radius-md` → 6px (`skin-v2.css:81`) == prototype `v2.css:68`.
- `--radius-sm` → 4px (`skin-v2.css:80`) == prototype `v2.css:66`.
- `--fs-composer-input` 14.5px / `--fs-composer-send` 12.5px == prototype literals.

## Tests
Added `describe('ChatComposer v2 prototype surface')` in `primitives.test.ts` (jsdom does not apply .css, so these assert the markup contract the CSS relies on):
- composer box / tools / send / ctool structure present
- textarea is flush: has `composer-textarea`, has NO `control-textarea` / `border` / `rounded` / `px-` / `py-` / `bg-[` inline classes
- send button operational (click → `onSend` once)

## Verify
```
$ npx tsc --noEmit         # EXIT=0, no errors
$ npx vitest run src/components/chat/primitives.test.ts
  Test Files  1 passed (1)
       Tests  101 passed (101)
$ npx vitest run primitives.a11y.test.ts styles/craft-v2.test.ts
  Test Files  2 passed (2)
       Tests  14 passed (14)
```

## Remaining gaps
- Slash-command palette (`.slashmenu*`) and live `.rec-bar` recording styling exist in the prototype `v2.css` but are out of scope for this composer box/textarea/button task.
- Visual diff not captured in-browser (jsdom does not render CSS); changes are token/literal substitutions verified against prototype source.

RFC gate N/A (UI/CSS).
