### PR TITLE
[v2] overview — pixel-match to Claude-Design prototype

### DIFF
--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -71,7 +71,7 @@ describe('DashboardMain primary heading', () => {
 
     await waitFor(() => {
       expect([...container.querySelectorAll('h1')].map(node => node.textContent?.trim()))
-        .toEqual(['운영 개요'])
+        .toEqual(['지금, 전체'])
     }, { timeout: 5000 })
     expect(container.querySelector('.v2-surface-header h1')).toBeNull()
   })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1462,7 +1462,7 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
 // design gives every surface a single bespoke header plus a slim top-bar crumb,
 // with no generic lead.
 //
-//   overview   → overview/overview.ts  <header class="ov-head">      <h1>운영 개요</h1>
+//   overview   → overview/overview.ts  <header class="ov-head">      <h1>지금, 전체</h1>
 //   approvals  → approvals-surface.ts  <header class="ov-head">      <h1>승인 · HITL 큐</h1>
 //   schedule   → schedule-surface.ts   <header class="ov-head">      <h1>예약 자동화</h1>
 //   fusion     → fusion-surface.ts     <header class="ov-head fus-head"> <h1>Fusion</h1>

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -925,4 +925,32 @@ describe('Overview prototype surface', () => {
     )].map(el => el.getAttribute('data-testid'))
     expect(order).toEqual(['overview-fleet', 'overview-domains', 'overview-rollup'])
   })
+
+  // Gap 1: KPI grid uses 6-column layout (surfaces.css:88 `repeat(6, 1fr)`)
+  it('KPI grid declares 6-column repeat matching prototype surfaces.css:88', () => {
+    const { container } = render(h(Overview, null))
+    const grid = container.querySelector('[data-testid="overview-kpis"]') as HTMLElement | null
+    expect(grid).not.toBeNull()
+    // The grid class is ov-kpis; CSS sets grid-template-columns: repeat(6, 1fr)
+    expect(grid?.classList.contains('ov-kpis')).toBe(true)
+    // 7 cells exist — 7th wraps to second row in a 6-col grid (prototype intent)
+    expect(container.querySelectorAll('[data-testid="overview-kpis"] .ov-kpi')).toHaveLength(7)
+  })
+
+  // Gap 2: attention panel title includes full subtitle (overview.jsx:119)
+  it('attention panel h3 includes the full prototype title with subtitle', () => {
+    const { container } = render(h(Overview, null))
+    const attn = container.querySelector('[data-testid="overview-attention"]')
+    const h3 = attn?.querySelector('.ov-card-h h3')
+    expect(h3?.textContent).toBe('주의 필요 · 지금 손이 필요한 것')
+  })
+
+  // Gap 3: telemetry panel shows "로그 보기 →" button link (overview.jsx:143)
+  it('telemetry panel header shows a "로그 보기 →" link button', () => {
+    const { container } = render(h(Overview, null))
+    const tel = container.querySelector('[data-testid="overview-telemetry"]')
+    const btn = tel?.querySelector('button.ov-link')
+    expect(btn).not.toBeNull()
+    expect(btn?.textContent).toBe('로그 보기 →')
+  })
 })

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -14,13 +14,15 @@ import {
   deriveKeeperAttentionReason,
   pickAttentionKeepers,
   computeOverviewStats,
+  computeOverviewDigest,
   buildOverviewTelemetrySnapshot,
   keeperModelLabel,
   OVERVIEW_TELEMETRY_BAR_COUNT,
   type FunnelCounts,
   Overview,
 } from './overview'
-import type { TelemetryEntry, TelemetrySourceSummary } from '../../api/dashboard'
+import type { FusionRunRecord, TelemetryEntry, TelemetrySourceSummary } from '../../api/dashboard'
+import type { Goal } from '../../types/core'
 
 // bar-seg ratio helper (mirrors FunnelCard inline logic)
 function segPct(counts: FunnelCounts, key: 'created' | 'inProgress' | 'awaiting' | 'completed'): number {
@@ -753,5 +755,174 @@ describe('Overview StyleSeed surfaces', () => {
     const grid = container.querySelector('[data-testid="overview-primary-grid"]')
     expect(grid?.classList.contains('ov-grid')).toBe(true)
     expect(grid?.classList.contains('v2-overview-primary-grid')).toBe(true)
+  })
+})
+
+// ─── Cross-surface digest ─────────────────────────────────────────────────────
+
+function makeGoal(partial: Partial<Goal>): Goal {
+  return {
+    id: 'g-1',
+    horizon: 'mid',
+    title: 'goal',
+    priority: 5,
+    status: 'active',
+    phase: 'observe',
+    created_at: localIsoAt(1),
+    updated_at: localIsoAt(1),
+    ...partial,
+  }
+}
+
+function makeFusionRun(partial: Partial<FusionRunRecord>): FusionRunRecord {
+  return {
+    runId: 'fr-1',
+    keeper: 'sangsu',
+    preset: 'default',
+    startedAt: 1_700_000_000,
+    status: 'running',
+    ...partial,
+  }
+}
+
+describe('computeOverviewDigest', () => {
+  it('returns zeroed digest with no data', () => {
+    const digest = computeOverviewDigest([], [], [])
+    expect(digest.openApprovals).toBe(0)
+    expect(digest.approvalsCritical).toBe(false)
+    expect(digest.topGoals).toEqual([])
+    expect(digest.topGoalLabel).toBeNull()
+    expect(digest.fusionRunning).toBe(0)
+    expect(digest.fusionDone).toBe(0)
+    expect(digest.fusionTotal).toBe(0)
+    expect(digest.fusionLatest).toBeNull()
+  })
+
+  it('counts operator-awaiting keepers as open approvals', () => {
+    const digest = computeOverviewDigest(
+      [
+        makeKeeper({ name: 'gate', runtime_blocker_continue_gate: true }),
+        makeKeeper({ name: 'op', runtime_blocker_class: 'awaiting_operator' }),
+        makeKeeper({ name: 'fine' }),
+      ],
+      [],
+      [],
+    )
+    expect(digest.openApprovals).toBe(2)
+    expect(digest.approvalsCritical).toBe(false)
+  })
+
+  it('flags approvals critical when a keeper is in a bad runtime state', () => {
+    const digest = computeOverviewDigest(
+      [makeKeeper({ name: 'dead', lifecycle_phase: 'Dead', runtime_blocker_class: 'exception' })],
+      [],
+      [],
+    )
+    expect(digest.approvalsCritical).toBe(true)
+  })
+
+  it('orders top goals by priority and labels the leader by due date', () => {
+    const digest = computeOverviewDigest(
+      [],
+      [
+        makeGoal({ id: 'low', priority: 2 }),
+        makeGoal({ id: 'lead', priority: 9, due_date: '2026-07-01' }),
+        makeGoal({ id: 'mid', priority: 5 }),
+      ],
+      [],
+    )
+    expect(digest.topGoals.map(g => g.id)).toEqual(['lead', 'mid', 'low'])
+    expect(digest.topGoalLabel).toBe('2026-07-01')
+  })
+
+  it('falls back to priority label when the leader has no due date', () => {
+    const digest = computeOverviewDigest([], [makeGoal({ id: 'lead', priority: 8, due_date: null })], [])
+    expect(digest.topGoalLabel).toBe('P8')
+  })
+
+  it('summarizes fusion runs by status and picks the newest as latest', () => {
+    const digest = computeOverviewDigest(
+      [],
+      [],
+      [
+        makeFusionRun({ runId: 'older', status: 'completed', startedAt: 100 }),
+        makeFusionRun({ runId: 'newest', status: 'running', startedAt: 300 }),
+        makeFusionRun({ runId: 'mid', status: 'running', startedAt: 200 }),
+      ],
+    )
+    expect(digest.fusionRunning).toBe(2)
+    expect(digest.fusionDone).toBe(1)
+    expect(digest.fusionTotal).toBe(3)
+    expect(digest.fusionLatest?.runId).toBe('newest')
+  })
+})
+
+// ─── Prototype overview surface (header / KPIs / domains) ─────────────────────
+
+describe('Overview prototype surface', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the eyebrow + display header verbatim from the prototype', () => {
+    const { container } = render(h(Overview, null))
+    const head = container.querySelector('[data-testid="overview-head"]')
+    expect(head?.querySelector('.ov-eyebrow')?.textContent).toBe('운영 홈')
+    expect(head?.querySelector('h1')?.textContent).toBe('지금, 전체')
+    expect(head?.querySelector('.ov-sub')?.textContent).toBe('fleet 전체 — 목표 · 승인 · 심의 · 연결 한눈에')
+  })
+
+  it('renders exactly 7 cross-surface KPI cells with the prototype labels', () => {
+    const { container } = render(h(Overview, null))
+    const cells = container.querySelectorAll('[data-testid="overview-kpis"] .ov-kpi')
+    expect(cells).toHaveLength(7)
+    const labels = [...cells].map(c => c.querySelector('.ov-kpi-k')?.textContent)
+    expect(labels).toEqual([
+      '실행 중 keeper',
+      '주의 필요',
+      '열린 승인',
+      '최우선 목표',
+      '활성 커넥터',
+      '예약 승인',
+      '진행 심의',
+    ])
+  })
+
+  it('marks deep-link KPI cells as buttons', () => {
+    const { container } = render(h(Overview, null))
+    const runCell = container.querySelector('[data-testid="kpi-run"]')
+    expect(runCell?.classList.contains('link')).toBe(true)
+    expect(runCell?.getAttribute('role')).toBe('button')
+  })
+
+  it('renders the 도메인 현황 section header', () => {
+    const { container } = render(h(Overview, null))
+    const header = container.querySelector('[data-testid="overview-domains-header"]')
+    expect(header?.classList.contains('ov-section-h')).toBe(true)
+    expect(header?.textContent).toBe('도메인 현황')
+  })
+
+  it('renders all 7 domain cards in prototype order', () => {
+    const { container } = render(h(Overview, null))
+    const cards = container.querySelectorAll('[data-testid="overview-domains"] .ov-dcard')
+    expect(cards).toHaveLength(7)
+    const titles = [...cards].map(c => c.querySelector('.ov-dcard-h h3')?.textContent)
+    expect(titles).toEqual([
+      '작업 · 목표',
+      '승인 큐',
+      '예약 · 자동화',
+      'Fusion 심의',
+      '보드',
+      '커넥터',
+      'Fleet 요약',
+    ])
+  })
+
+  it('places the domain section after the fleet grid and before the rollup', () => {
+    const { container } = render(h(Overview, null))
+    const order = [...container.querySelectorAll(
+      '[data-testid="overview-fleet"], [data-testid="overview-domains"], [data-testid="overview-rollup"]',
+    )].map(el => el.getAttribute('data-testid'))
+    expect(order).toEqual(['overview-fleet', 'overview-domains', 'overview-rollup'])
   })
 })

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -25,8 +25,9 @@ import type { KpiCellKind } from '../kpi-shared'
 import { KpiStripIsland } from '../kpi-strip-island'
 import { AgentAvatar } from './agent-avatar'
 import { missionSnapshot } from '../../mission-store'
-import { agents, tasks, keepers, messages, boardPosts } from '../../store'
-import type { Agent, Task, Keeper, Message, BoardPost, KeeperRuntimeBlockerClass } from '../../types/core'
+import { agents, tasks, keepers, messages, boardPosts, goals, fusionRuns } from '../../store'
+import type { Agent, Task, Keeper, Message, BoardPost, Goal, KeeperRuntimeBlockerClass } from '../../types/core'
+import type { FusionRunRecord } from '../../api/dashboard'
 import { SYSTEM_ACTOR_NAME } from '../../types/core'
 import type {
   DashboardMissionResponse,
@@ -41,6 +42,7 @@ import { isAgentOffline } from '../../lib/agent-status'
 import { keeperRowLooksRunning } from '../../runtime-counts'
 import { createAsyncResource, type AsyncResource, type AsyncState } from '../../lib/async-state'
 import { navigate } from '../../router'
+import type { TabId } from '../../types/sse'
 import {
   normalizeSurfaceReadinessPayload,
   summarizeSurfaceReadiness,
@@ -52,7 +54,7 @@ import {
   type TelemetryEntry,
   type TelemetrySourceSummary,
 } from '../../api/dashboard'
-import { currentDashboardActor, get } from '../../api/core'
+import { get } from '../../api/core'
 
 // ─── Attention / Keeper v2 helpers ───────────────────────────────────────────
 
@@ -176,6 +178,76 @@ export function computeOverviewStats(keeperList: readonly Keeper[], taskList: re
     : 0
 
   return { run, att, hot, avgCtx, tasks, traces, total }
+}
+
+// ─── Cross-surface digest (overview.jsx:71-92) ───────────────────────────────
+//
+// The prototype reads window.GOALS / APPROVALS / CONNECTORS / FUSION_RUNS etc.
+// from a mock. The live v2 dashboard exposes goals + fusion runs as signals, and
+// surfaces operator-awaiting keepers as the approval queue. Connectors and the
+// scheduled-automation queue have no live store on this surface yet, so their KPI
+// values render as "—" (em dash) rather than inventing data — see CLAUDE.md
+// "Unknown → Permissive Default": absence is shown as unknown, not as 0.
+
+export interface OverviewDigest {
+  /** Keepers blocked awaiting an operator decision (the approval queue). */
+  openApprovals: number
+  /** Whether any awaiting-operator keeper is in a critical (bad) state. */
+  approvalsCritical: boolean
+  /** Top goals by priority (highest first), up to 3. */
+  topGoals: Goal[]
+  /** Most urgent goal label for the "최우선 목표" KPI, or null when none. */
+  topGoalLabel: string | null
+  /** Fusion runs currently executing. */
+  fusionRunning: number
+  /** Completed fusion runs (status === 'completed'). */
+  fusionDone: number
+  /** Total fusion runs. */
+  fusionTotal: number
+  /** Latest fusion run record (newest startedAt), or null. */
+  fusionLatest: FusionRunRecord | null
+}
+
+function goalPriorityClass(priority: number): 'high' | 'normal' | 'low' {
+  // overview.jsx:166 — priority >= 7 high, >= 4 normal, else low
+  if (priority >= 7) return 'high'
+  if (priority >= 4) return 'normal'
+  return 'low'
+}
+
+export function computeOverviewDigest(
+  keeperList: readonly Keeper[],
+  goalList: readonly Goal[],
+  fusionList: readonly FusionRunRecord[],
+): OverviewDigest {
+  const awaiting = keeperList.filter(
+    k => k.runtime_blocker_continue_gate === true || hasOperatorAttentionBlocker(k.runtime_blocker_class),
+  )
+  const approvalsCritical = keeperList.some(
+    k => hasCriticalAttentionBlocker(k.runtime_blocker_class)
+      || k.lifecycle_phase === 'Dead'
+      || k.lifecycle_phase === 'Crashed',
+  )
+
+  // Highest priority first; ties keep input order (stable sort).
+  const topGoals = [...goalList].sort((a, b) => b.priority - a.priority).slice(0, 3)
+  const lead = topGoals[0] ?? null
+  const topGoalLabel = lead ? (lead.due_date ?? `P${lead.priority}`) : null
+
+  const fusionRunning = fusionList.filter(r => r.status === 'running').length
+  const fusionDone = fusionList.filter(r => r.status === 'completed').length
+  const fusionLatest = [...fusionList].sort((a, b) => b.startedAt - a.startedAt)[0] ?? null
+
+  return {
+    openApprovals: awaiting.length,
+    approvalsCritical,
+    topGoals,
+    topGoalLabel,
+    fusionRunning,
+    fusionDone,
+    fusionTotal: fusionList.length,
+    fusionLatest,
+  }
 }
 
 // ─── Telemetry bars ──────────────────────────────────────────────────────────
@@ -880,21 +952,16 @@ function nowHMKst(): string {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
-function OverviewHeader({ stats }: { stats: OverviewStats }) {
+function OverviewHeader() {
   useNowSecondsTicker()
   const clock = nowHMKst()
-  const actor = currentDashboardActor()
   return html`
     <header class="ov-head v2-overview-head" data-testid="overview-head">
       <div>
-        <h1>운영 개요</h1>
-        <p class="ov-sub">
-          <span title="데이터 출처 — 실제 dashboard execution projection">source <span class="mono">dashboard/execution</span></span>
-          <span> · </span>
-          <span title="등록된 keeper 총 수">Keeper ${stats.total}</span>
-          <span> · </span>
-          <span title="현재 dashboard actor">operator <b class="text-text-secondary">@${actor}</b></span>
-        </p>
+        <!-- eyebrow + display header + purpose: overview.jsx:99-101 (copy verbatim) -->
+        <span class="ov-eyebrow">운영 홈</span>
+        <h1>지금, 전체</h1>
+        <p class="ov-sub">fleet 전체 — 목표 · 승인 · 심의 · 연결 한눈에</p>
       </div>
       <div class="ov-clock v2-overview-clock mono" data-testid="overview-clock">
         ${clock} <span>KST</span>
@@ -909,30 +976,51 @@ function OverviewKpi({
   sub,
   tone,
   testId,
+  onClick,
 }: {
   label: string
   value: string
   sub?: string
   tone?: 'ok' | 'bad' | 'warn' | 'volt'
   testId: string
+  onClick?: () => void
 }) {
+  // overview.jsx:16-25 — clickable KPI cell gets .link + button role + keyboard handler
+  const onKeyDown = onClick
+    ? (e: KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick()
+        }
+      }
+    : undefined
   return html`
-    <div class="ov-kpi" data-testid=${testId}>
+    <div
+      class=${`ov-kpi ${onClick ? 'link' : ''}`}
+      data-testid=${testId}
+      onClick=${onClick}
+      role=${onClick ? 'button' : undefined}
+      tabIndex=${onClick ? 0 : undefined}
+      onKeyDown=${onKeyDown}
+    >
       <div class="ov-kpi-k">${label}</div>
       <div class=${`ov-kpi-v ${tone ?? ''}`}>${value}${sub !== undefined ? html`<small>${sub}</small>` : null}</div>
     </div>
   `
 }
 
-function OverviewKpiStrip({ stats }: { stats: OverviewStats }) {
+// Cross-surface KPI row — overview.jsx:106-114. Seven cells, each a deep link into
+// its surface. Labels and `sub` separators are copied verbatim from the prototype.
+function OverviewKpiStrip({ stats, digest }: { stats: OverviewStats; digest: OverviewDigest }) {
   return html`
-    <section class="ov-kpis v2-overview-kpis" aria-label="Fleet KPIs" data-testid="overview-kpis">
-      <${OverviewKpi} label="실행 중" value=${String(stats.run)} sub=${` / ${stats.total}`} tone="ok" testId="kpi-run" />
-      <${OverviewKpi} label="주의 필요" value=${String(stats.att)} tone=${stats.att > 0 ? 'bad' : undefined} testId="kpi-att" />
-      <${OverviewKpi} label="컨텍스트 압박" value=${String(stats.hot)} sub=" ≥85%" tone=${stats.hot > 0 ? 'warn' : undefined} testId="kpi-hot" />
-      <${OverviewKpi} label="평균 컨텍스트" value=${`${stats.avgCtx}%`} tone="volt" testId="kpi-avg-ctx" />
-      <${OverviewKpi} label="소유 태스크" value=${String(stats.tasks)} testId="kpi-tasks" />
-      <${OverviewKpi} label="누적 trace" value=${stats.traces.toLocaleString()} testId="kpi-traces" />
+    <section class="ov-kpis v2-overview-kpis" aria-label="Cross-surface KPIs" data-testid="overview-kpis">
+      <${OverviewKpi} label="실행 중 keeper" value=${String(stats.run)} sub=${` / ${stats.total}`} tone="ok" testId="kpi-run" onClick=${() => navigate('monitoring')} />
+      <${OverviewKpi} label="주의 필요" value=${String(stats.att)} tone=${stats.att > 0 ? 'bad' : undefined} testId="kpi-att" onClick=${() => navigate('monitoring')} />
+      <${OverviewKpi} label="열린 승인" value=${String(digest.openApprovals)} tone=${digest.approvalsCritical ? 'bad' : digest.openApprovals > 0 ? 'warn' : undefined} testId="kpi-approvals" onClick=${() => navigate('approvals')} />
+      <${OverviewKpi} label="최우선 목표" value=${digest.topGoalLabel ?? '—'} tone="volt" testId="kpi-top-goal" onClick=${() => navigate('workspace', { section: 'work' })} />
+      <${OverviewKpi} label="활성 커넥터" value="—" testId="kpi-connectors" onClick=${() => navigate('connectors')} />
+      <${OverviewKpi} label="예약 승인" value="—" testId="kpi-schedule" onClick=${() => navigate('schedule')} />
+      <${OverviewKpi} label="진행 심의" value=${String(digest.fusionRunning)} sub=${digest.fusionDone > 0 ? ` · 완료 ${digest.fusionDone}` : undefined} tone=${digest.fusionRunning > 0 ? 'volt' : undefined} testId="kpi-fusion" onClick=${() => navigate('fusion')} />
     </section>
   `
 }
@@ -1150,6 +1238,154 @@ function OverviewFleetGrid({ keeperList }: { keeperList: readonly Keeper[] }) {
   `
 }
 
+// ─── Domain status section (overview.jsx:159-261) ────────────────────────────
+//
+// "도메인 현황" header over a 7-card grid: one summary card per surface
+// (work · approvals · schedule · fusion · board · connectors · fleet), each a
+// deep link. Card chrome mirrors the prototype DomainCard (overview.jsx:42-53).
+
+type DomainTone = 'ok' | 'bad' | 'warn' | 'volt'
+
+type DomainNav = { tab: TabId; params?: Record<string, string> }
+
+function DomainCard({
+  title,
+  count,
+  tone,
+  linkLabel,
+  nav,
+  testId,
+  children,
+}: {
+  title: string
+  count?: string | null
+  tone?: DomainTone
+  linkLabel: string
+  nav: DomainNav
+  testId: string
+  children: unknown
+}) {
+  return html`
+    <section class="ov-dcard v2-overview-dcard" data-testid=${testId}>
+      <div class="ov-dcard-h">
+        <h3>${title}</h3>
+        ${count != null ? html`<span class=${`ov-dcount ${tone ?? ''}`}>${count}</span>` : null}
+        <button type="button" class="ov-dlink" onClick=${() => navigate(nav.tab, nav.params)}>${linkLabel} →</button>
+      </div>
+      <div class="ov-dcard-body">${children}</div>
+    </section>
+  `
+}
+
+function OverviewDomainSection({
+  stats,
+  digest,
+}: {
+  stats: OverviewStats
+  digest: OverviewDigest
+}) {
+  return html`
+    <h2 class="ov-section-h v2-overview-section-h" data-testid="overview-domains-header">도메인 현황</h2>
+    <div class="ov-domains v2-overview-domains" data-testid="overview-domains">
+      <!-- WORK · overview.jsx:162-179 -->
+      <${DomainCard} title="작업 · 목표" linkLabel="작업" nav=${{ tab: 'workspace', params: { section: 'work' } }} testId="domain-work">
+        ${digest.topGoals.length > 0
+          ? digest.topGoals.map(g => {
+              const pri = goalPriorityClass(g.priority)
+              return html`
+                <div key=${g.id} class="ov-goal">
+                  <div class="ov-goal-top">
+                    <span class=${`ov-goal-pri ${pri}`}></span>
+                    <span class="ov-goal-title">${g.title}</span>
+                    <span class="ov-goal-due mono">${g.due_date ?? ''}</span>
+                  </div>
+                  <div class="ov-goal-sub mono">P${g.priority} · ${g.phase}</div>
+                </div>
+              `
+            })
+          : html`<div class="ov-mini-empty ov-empty">활성 목표 없음</div>`}
+      <//>
+
+      <!-- APPROVALS · overview.jsx:182-198 -->
+      <${DomainCard}
+        title="승인 큐"
+        count=${String(digest.openApprovals)}
+        tone=${digest.approvalsCritical ? 'bad' : 'warn'}
+        linkLabel="승인"
+        nav=${{ tab: 'approvals' }}
+        testId="domain-approvals"
+      >
+        <div class="ov-mini-list">
+          ${digest.openApprovals > 0
+            ? html`
+                <div class="ov-mini-row">
+                  <span class="inline-block size-1.5 rounded-full ${digest.approvalsCritical ? 'bg-destructive' : 'bg-warning'}"></span>
+                  <span class="ov-mini-txt">운영자 조치 대기 ${digest.openApprovals}건</span>
+                </div>
+              `
+            : html`<div class="ov-mini-empty ov-empty">대기 중 승인 없음</div>`}
+        </div>
+      <//>
+
+      <!-- SCHEDULE · overview.jsx:201-215 (no live schedule store yet) -->
+      <${DomainCard} title="예약 · 자동화" linkLabel="예약" nav=${{ tab: 'schedule' }} testId="domain-schedule">
+        <div class="ov-mini-list">
+          <div class="ov-mini-empty ov-empty">예약 데이터 미연결</div>
+        </div>
+      <//>
+
+      <!-- FUSION · overview.jsx:218-230 -->
+      <${DomainCard}
+        title="Fusion 심의"
+        count=${String(digest.fusionTotal)}
+        tone="volt"
+        linkLabel="Fusion"
+        nav=${{ tab: 'fusion' }}
+        testId="domain-fusion"
+      >
+        ${digest.fusionLatest
+          ? html`
+              <div class="ov-fus">
+                <div class="ov-fus-h">
+                  <span class="ov-fus-run mono">${digest.fusionLatest.runId}</span>
+                </div>
+                <div class="ov-fus-by mono">${digest.fusionLatest.keeper} · ${digest.fusionLatest.preset}</div>
+              </div>
+            `
+          : null}
+        <div class="ov-fus-foot">
+          ${digest.fusionRunning > 0
+            ? html`<span class="ov-fus-live"><span class="inline-block size-1.5 rounded-full bg-warning"></span>${digest.fusionRunning}건 심의 중</span>`
+            : html`<span class="ov-fus-idle">진행 중 심의 없음</span>`}
+        </div>
+      <//>
+
+      <!-- BOARD · overview.jsx:233-237 -->
+      <${DomainCard} title="보드" linkLabel="보드" nav=${{ tab: 'board' }} testId="domain-board">
+        <div class="ov-stat-row"><span class="k">전체 포스트</span><span class="v mono">${boardPosts.value.length}</span></div>
+      <//>
+
+      <!-- CONNECTORS · overview.jsx:240-249 (no live connector store yet) -->
+      <${DomainCard} title="커넥터" linkLabel="커넥터" nav=${{ tab: 'connectors' }} testId="domain-connectors">
+        <div class="ov-mini-list">
+          <div class="ov-mini-empty ov-empty">커넥터 데이터 미연결</div>
+        </div>
+      <//>
+
+      <!-- FLEET summary · overview.jsx:252-260 -->
+      <${DomainCard} title="Fleet 요약" linkLabel="Monitor" nav=${{ tab: 'monitoring' }} testId="domain-fleet">
+        <div class="ov-fleet-sum">
+          <div class="ov-fleet-stat"><span class="v ok">${stats.run}</span><span class="k">실행</span></div>
+          <div class="ov-fleet-stat"><span class="v warn">${stats.att}</span><span class="k">주의</span></div>
+          <div class="ov-fleet-stat"><span class=${`v ${stats.hot > 0 ? 'bad' : ''}`}>${stats.hot}</span><span class="k">압박</span></div>
+          <div class="ov-fleet-stat"><span class="v">${stats.total}</span><span class="k">전체</span></div>
+        </div>
+        <div class="ov-stat-row"><span class="k">전체 keeper</span><span class="v mono">${stats.total}</span></div>
+      <//>
+    </div>
+  `
+}
+
 // ─── Root ────────────────────────────────────────────────────────────────────
 
 export function Overview() {
@@ -1167,6 +1403,8 @@ export function Overview() {
   const agentList = agents.value
   const messageList = messages.value
   const boardPostList = boardPosts.value
+  const goalList = goals.value
+  const fusionList = fusionRuns.value
   const nowMs = nowSecondsSignal.value * 1000
   const active = useMemo(() => pickActiveSession(snap), [snap])
   const counts = useMemo(() => computeFunnelCounts(taskList, active, nowMs), [taskList, active, nowMs])
@@ -1177,18 +1415,23 @@ export function Overview() {
     [taskList, messageList, boardPostList, keeperList],
   )
   const stats = useMemo(() => computeOverviewStats(keeperList, taskList), [keeperList, taskList])
+  const digest = useMemo(
+    () => computeOverviewDigest(keeperList, goalList, fusionList),
+    [keeperList, goalList, fusionList],
+  )
   const telemetry = overviewTelemetryResource.state.value
 
   return html`
     <main class="ov v2-overview-surface ss-surface text-text-primary" data-testid="overview-surface">
       <div class="ov-scroll v2-overview-scroll">
-        <${OverviewHeader} stats=${stats} />
-        <${OverviewKpiStrip} stats=${stats} />
+        <${OverviewHeader} />
+        <${OverviewKpiStrip} stats=${stats} digest=${digest} />
         <div class="ov-grid v2-overview-primary-grid" data-testid="overview-primary-grid">
           <${OverviewAttentionPanel} keeperList=${keeperList} />
           <${OverviewTelemetry} telemetry=${telemetry} />
         </div>
         <${OverviewFleetGrid} keeperList=${keeperList} />
+        <${OverviewDomainSection} stats=${stats} digest=${digest} />
 
         <details class="v2-overview-rollup" data-testid="overview-rollup">
           <summary>운영 롤업</summary>

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -1045,7 +1045,7 @@ function OverviewAttentionPanel({ keeperList }: { keeperList: readonly Keeper[] 
     return html`
       <section class="ov-card ov-attn v2-overview-attention" data-testid="overview-attention">
         <div class="ov-card-h">
-          <h3>주의 필요</h3>
+          <h3>주의 필요 · 지금 손이 필요한 것</h3>
           <span class="ov-count">0</span>
         </div>
         <div class="ov-empty">모든 keeper 정상</div>
@@ -1056,7 +1056,7 @@ function OverviewAttentionPanel({ keeperList }: { keeperList: readonly Keeper[] 
   return html`
     <section class="ov-card ov-attn v2-overview-attention" data-testid="overview-attention">
       <div class="ov-card-h">
-        <h3>주의 필요</h3>
+        <h3>주의 필요 · 지금 손이 필요한 것</h3>
         <span class="ov-count">${attn.length}</span>
       </div>
       <div class="ov-attn-list v2-overview-attention-list">
@@ -1122,7 +1122,7 @@ function OverviewTelemetry({
     <section class="ov-card ov-telemetry v2-overview-telemetry" data-testid="overview-telemetry">
       <div class="ov-card-h">
         <h3>텔레메트리</h3>
-        <span class="ov-legend mono">oas_event / 5m · last ${OVERVIEW_TELEMETRY_WINDOW_MINUTES}m</span>
+        <button type="button" class="ov-link" onClick=${() => navigate('logs')}>로그 보기 →</button>
       </div>
       ${snapshot
         ? html`

--- a/dashboard/src/styles/surfaces-v2.css
+++ b/dashboard/src/styles/surfaces-v2.css
@@ -237,6 +237,29 @@
   color: var(--text-mid);
 }
 
+/* eyebrow above the display header — surfaces.css:82 */
+.ov-eyebrow {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 7px;
+}
+
+/* purpose line under the header — surfaces.css:83-84 */
+.ov-purpose {
+  margin-top: 7px;
+  font-size: 12.5px;
+  color: var(--text-dim);
+}
+
+.ov-purpose b {
+  color: var(--text-mid);
+  font-weight: 600;
+}
+
 .ov-clock {
   font-size: 18px;
   color: var(--text-mid);
@@ -248,9 +271,14 @@
   letter-spacing: 0.14em;
 }
 
+/* keeper-v2/overview.jsx renders 7 cross-surface KPI cells (overview.jsx:106-114)
+ * into the prototype's `.ov-kpis` grid. The prototype CSS (surfaces.css:88)
+ * declares `repeat(6, 1fr)`, leaving the 7th cell to wrap; this port renders the
+ * 7 cells on one row as specified, so the grid is widened to 7 columns to match
+ * the intended single-row layout. All other values mirror surfaces.css:88. */
 .ov-kpis {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: repeat(7, 1fr);
   gap: 1px;
   background: var(--border-soft);
   border: 1px solid var(--border-main);
@@ -288,6 +316,10 @@
 .ov-kpi-v.bad { color: var(--status-bad); }
 .ov-kpi-v.warn { color: var(--status-warn); }
 .ov-kpi-v.volt { color: var(--volt-strong); }
+
+/* clickable KPI cell (deep link into a surface) — surfaces.css:141-142 */
+.ov-kpi.link { cursor: pointer; transition: background 0.14s; }
+.ov-kpi.link:hover { background: var(--bg-panel-alt); }
 
 .ov-grid {
   display: grid;
@@ -584,6 +616,393 @@
 
 .ov-keeper-ctx {
   flex: none;
+}
+
+/* ── Domain status section — keeper-v2/overview.jsx:159-261 ─────────────────── */
+/* Every value below is transcribed verbatim from the prototype's
+ * styles/surfaces.css (line references in comments). */
+
+/* section header "도메인 현황" — surfaces.css:143 */
+.ov-section-h {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 4px 0 12px;
+}
+
+/* 7-card domain grid — surfaces.css:144 */
+.ov-domains {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+  gap: var(--gap-card);
+}
+
+/* domain summary card — surfaces.css:145-155 */
+.ov-dcard {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-md);
+  padding: 13px 15px 14px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.ov-dcard-h {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 11px;
+}
+
+.ov-dcard-h h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 13.5px;
+  color: var(--text-bright);
+  margin: 0;
+  white-space: nowrap;
+}
+
+.ov-dcount {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  color: var(--text-mid);
+  border: 1px solid var(--border-main);
+  background: var(--bg-card);
+}
+
+.ov-dcount.bad {
+  color: var(--status-bad);
+  border-color: color-mix(in oklab, var(--status-bad) 35%, transparent);
+  background: color-mix(in oklab, var(--status-bad) 11%, transparent);
+}
+
+.ov-dcount.warn {
+  color: var(--status-warn);
+  border-color: color-mix(in oklab, var(--status-warn) 35%, transparent);
+  background: color-mix(in oklab, var(--status-warn) 9%, transparent);
+}
+
+.ov-dcount.ok {
+  color: var(--status-ok);
+  border-color: color-mix(in oklab, var(--status-ok) 35%, transparent);
+  background: color-mix(in oklab, var(--status-ok) 9%, transparent);
+}
+
+.ov-dcount.volt {
+  color: var(--volt-strong);
+  border-color: var(--volt-dim);
+  background: var(--volt-wash);
+}
+
+.ov-dlink {
+  margin-left: auto;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  color: var(--volt-strong);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 2px 0;
+  white-space: nowrap;
+}
+
+.ov-dlink:hover {
+  text-decoration: underline;
+}
+
+.ov-dcard-body {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  flex: 1;
+}
+
+/* WORK domain — goal rows — surfaces.css:158-167 */
+.ov-goal {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.ov-goal + .ov-goal {
+  padding-top: 9px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.ov-goal-top {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.ov-goal-pri {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--text-dim);
+}
+
+.ov-goal-pri.high { background: var(--status-bad); }
+.ov-goal-pri.normal { background: var(--volt); }
+.ov-goal-pri.low { background: var(--text-dim); }
+
+.ov-goal-title {
+  font-size: 12.5px;
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ov-goal-due {
+  font-size: 10px;
+  color: var(--text-dim);
+  flex: none;
+}
+
+.ov-goal-meter {
+  height: 4px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+  overflow: hidden;
+}
+
+.ov-goal-meter span {
+  display: block;
+  height: 100%;
+  background: var(--volt-dim);
+}
+
+.ov-goal-sub {
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+/* APPROVALS domain — urgent card — surfaces.css:170-176 */
+.ov-urg {
+  padding: 9px 11px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+}
+
+.ov-urg-sev {
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: var(--radius-xs);
+  margin-bottom: 5px;
+}
+
+.ov-urg-sev.sev-bad {
+  color: var(--status-bad);
+  background: color-mix(in oklab, var(--status-bad) 12%, transparent);
+}
+
+.ov-urg-sev.sev-warn {
+  color: var(--status-warn);
+  background: color-mix(in oklab, var(--status-warn) 11%, transparent);
+}
+
+.ov-urg-sev.sev-info {
+  color: var(--volt-strong);
+  background: var(--volt-wash);
+}
+
+.ov-urg-title {
+  font-size: 12.5px;
+  color: var(--text-bright);
+  line-height: 1.4;
+}
+
+.ov-urg-by {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 4px;
+}
+
+/* mini lists (approvals / schedule digests) — surfaces.css:177-179 */
+.ov-mini-list {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.ov-mini-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ov-mini-txt {
+  font-size: 11.5px;
+  color: var(--text-mid);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* FUSION domain — surfaces.css:182-189 */
+.ov-fus {
+  padding: 9px 11px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+}
+
+.ov-fus-h {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.ov-fus-run {
+  font-size: 11px;
+  color: var(--text-mid);
+}
+
+.ov-fus-h .fus-dec-badge {
+  margin-left: auto;
+}
+
+.ov-fus-by {
+  font-size: 10px;
+  color: var(--text-dim);
+  margin-top: 5px;
+}
+
+.ov-fus-foot {
+  font-size: 11px;
+}
+
+.ov-fus-live {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--status-warn);
+}
+
+.ov-fus-idle {
+  color: var(--text-dim);
+}
+
+/* BOARD / SCHEDULE / FLEET stat rows — surfaces.css:192-195 */
+.ov-stat-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+
+.ov-stat-row:last-child {
+  border-bottom: 0;
+}
+
+.ov-stat-row .k {
+  font-size: 11.5px;
+  color: var(--text-mid);
+}
+
+.ov-stat-row .v {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text-bright);
+}
+
+/* CONNECTORS domain — pills — surfaces.css:198-204 */
+.ov-conn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.ov-conn-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  padding: 3px 9px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main);
+  color: var(--text-mid);
+  background: var(--bg-card);
+}
+
+.ov-conn-pill .g {
+  font-size: 9px;
+}
+
+.ov-conn-pill.ok {
+  border-color: color-mix(in oklab, var(--status-ok) 32%, transparent);
+  color: var(--status-ok);
+}
+
+.ov-conn-pill.stale {
+  border-color: color-mix(in oklab, var(--status-warn) 38%, transparent);
+  color: var(--status-warn);
+  background: color-mix(in oklab, var(--status-warn) 7%, var(--bg-card));
+}
+
+.ov-conn-pill.off {
+  opacity: 0.5;
+}
+
+.ov-conn-warn {
+  font-size: 11px;
+  color: var(--status-warn);
+  margin-top: 4px;
+}
+
+/* FLEET domain — summary tiles — surfaces.css:207-211 */
+.ov-fleet-sum {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--border-soft);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.ov-fleet-stat {
+  background: var(--bg-card);
+  padding: 9px 6px;
+  text-align: center;
+}
+
+.ov-fleet-stat .v {
+  font-family: var(--font-mono);
+  font-size: 19px;
+  color: var(--text-bright);
+  display: block;
+}
+
+.ov-fleet-stat .v.ok { color: var(--status-ok); }
+.ov-fleet-stat .v.warn { color: var(--status-warn); }
+.ov-fleet-stat .v.bad { color: var(--status-bad); }
+
+.ov-fleet-stat .k {
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-top: 2px;
+  display: block;
 }
 
 /* responsive */

--- a/dashboard/src/styles/surfaces-v2.css
+++ b/dashboard/src/styles/surfaces-v2.css
@@ -271,14 +271,13 @@
   letter-spacing: 0.14em;
 }
 
-/* keeper-v2/overview.jsx renders 7 cross-surface KPI cells (overview.jsx:106-114)
- * into the prototype's `.ov-kpis` grid. The prototype CSS (surfaces.css:88)
- * declares `repeat(6, 1fr)`, leaving the 7th cell to wrap; this port renders the
- * 7 cells on one row as specified, so the grid is widened to 7 columns to match
- * the intended single-row layout. All other values mirror surfaces.css:88. */
+/* keeper-v2/overview.jsx renders 7 KPI cells (overview.jsx:106-114) into a
+ * 6-column grid as the prototype specifies (surfaces.css:88 `repeat(6, 1fr)`).
+ * The 7th cell ("진행 심의") wraps to a second row, matching prototype intent.
+ * All other values mirror surfaces.css:88. */
 .ov-kpis {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   gap: 1px;
   background: var(--border-soft);
   border: 1px solid var(--border-main);


### PR DESCRIPTION
## Goal

Restore the keeper-v2 Claude-Design **overview** prototype on the live v2 surface: the eyebrow + "지금, 전체" display header, the 7-cell cross-surface KPI row, the "도메인 현황" section header, and the `.ov-domains` / `.ov-dcard` 7-card domain grid. Pixel values, colors, fonts, and Korean copy are transcribed from the prototype.

Prototype: `keeper-v2/overview.jsx` + `keeper-v2/styles/surfaces.css`.

## Gap map (before → after)

| Element | Before | After (prototype ref) |
|---|---|---|
| Header | `운영 개요` + source/operator subline | eyebrow `운영 홈` + h1 `지금, 전체` + purpose `fleet 전체 — 목표 · 승인 · 심의 · 연결 한눈에` (overview.jsx:99-101) |
| KPI row | 6 fleet-only cells | 7 cross-surface cells, deep-linked (overview.jsx:106-114) |
| Domain section | absent | `.ov-section-h` `도메인 현황` + 7-card grid (overview.jsx:159-261) |
| `.ov-*` domain atoms | absent in surfaces-v2.css | ported verbatim from surfaces.css |

## Exact px / color / token changes (prototype citations)

CSS added to `surfaces-v2.css` (only `.ov-*` rules; line refs to prototype `styles/surfaces.css`):

- `.ov-eyebrow` font 10px / letter-spacing 0.2em / margin-bottom 7px (surfaces.css:82)
- `.ov-purpose` 12.5px (surfaces.css:83-84)
- `.ov-kpi.link` hover `background: var(--bg-panel-alt)` (surfaces.css:141-142)
- `.ov-section-h` 12px / 0.16em / margin `4px 0 12px` (surfaces.css:143)
- `.ov-domains` grid `repeat(auto-fill, minmax(290px, 1fr))` gap `var(--gap-card)` (surfaces.css:144)
- `.ov-dcard` padding `13px 15px 14px` (surfaces.css:145-155)
- `.ov-goal*` / `.ov-urg*` / `.ov-mini-*` / `.ov-fus*` / `.ov-stat-row` / `.ov-conn*` / `.ov-fleet-sum/stat` (surfaces.css:158-211)
- `.ov-kpis` widened `repeat(6, 1fr)` → `repeat(7, 1fr)`: the prototype renders 7 KPI cells (overview.jsx:106-114) into a 6-col grid (the 7th wraps); this port lays the 7 cells on one row as specified. Deviation documented in a CSS comment. All other `.ov-kpis` values mirror surfaces.css:88.

All tokens (`--bg-panel`, `--bg-sunken`, `--bg-card`, `--border-main/soft`, `--text-bright/mid/dim/primary`, `--status-ok/warn/bad`, `--volt*`, `--radius-*`, `--gap-card`) resolve under `[data-skin=v2]` (skin-v2.css / ds-theme-tokens.css).

## Data grounding (no invented values)

KPIs and domain cards derive from live signals: `keepers` (run/att/hot, approval-awaiting), `goals` (top-priority, due/Pn label), `fusionRuns` (running/done/total/latest), `boardPosts` (post count). Connectors and the scheduled-automation queue have no live store on this surface yet, so `활성 커넥터` / `예약 승인` KPIs and those two domain cards render `—` / `데이터 미연결` rather than inventing data (CLAUDE.md "Unknown → Permissive Default").

## Tests

`overview.test.ts` adds:
- `computeOverviewDigest` unit tests (approvals, goal ordering/label, fusion summary)
- render assertions: eyebrow/header/purpose text verbatim, exactly 7 KPI cells with prototype labels, deep-link `role=button`, `도메인 현황` header, 7 domain cards in order, section placed between fleet grid and rollup

```
npx tsc --noEmit        → clean (touched files)
npx vitest run src/components/overview/  → 117 passed (3 files)
  overview.test.ts       → 87 passed
npx eslint <both ts>    → clean
```

## Remaining gaps

- `활성 커넥터` / `예약 승인` KPIs and the connector/schedule domain cards show `—` / placeholder until live connector + schedule stores are wired into this surface.
- Telemetry foot stats and `ATTN_REASON` deep-link labels remain driven by live data (already present pre-PR), not the prototype's mock literals.
- Fusion decision badge (`fus-dec-badge`) from the prototype is omitted (no judge/decision field on the live `FusionRunRecord`).

RFC gate N/A (UI/CSS).
