### PR TITLE
[v2] logs — pixel-match to Claude-Design prototype

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -473,3 +473,47 @@ describe('LogViewer Code links', () => {
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-nested&operation_id=op-nested&worker_run_id=wr-nested&q=turn-8')
   })
 })
+
+describe('LogViewer kind column', () => {
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+    vi.resetModules()
+    vi.doUnmock('../api/dashboard.js')
+    window.location.hash = ''
+  })
+
+  it('renders the logs surface with the kind column header and a kind cell per row', async () => {
+    const fetchLogs = vi.fn().mockResolvedValue({
+      total: 1,
+      entries: [
+        entry({
+          seq: 42,
+          level: 'INFO',
+          source: 'structured',
+          module: 'keeper_tool',
+          message: 'read file',
+          category: 'tool',
+          details: { tool_name: 'tool_read_file', file_path: 'lib/runtime.ml' },
+        }),
+      ],
+    })
+    const { LogViewer } = await loadLogs(fetchLogs)
+    const { container } = render(h(LogViewer, {}))
+
+    await waitFor(() => expect(container.textContent).toContain('read file'))
+
+    // The table header carries the kind ("유형") column the --v2-logs-cols grid sizes.
+    const header = container.querySelector('.v2-logs-table-header') as HTMLElement | null
+    expect(header).not.toBeNull()
+    const headerLabels = [...header!.querySelectorAll('span')].map(s => s.textContent)
+    expect(headerLabels).toContain('유형')
+
+    // Each row exposes a kind cell with the resolved label + data-kind attribute.
+    const kindCell = container.querySelector('.v2-logs-kind') as HTMLElement | null
+    expect(kindCell).not.toBeNull()
+    expect(kindCell!.getAttribute('data-kind')).toBe('tool')
+    expect(kindCell!.textContent).toBe('TOOL')
+  })
+})

--- a/dashboard/src/styles/v2-logs.css
+++ b/dashboard/src/styles/v2-logs.css
@@ -8,7 +8,9 @@
  */
 
 .v2-logs-surface {
-  --v2-logs-cols: 92px minmax(150px, 230px) 112px minmax(0, 1fr) 24px;
+  /* kind column 104px — pixel-match to prototype logs.css:15 (--lg-cols).
+     Literal px (not --sp-*): 2px-base --sp-* would shrink this fixed column. */
+  --v2-logs-cols: 92px minmax(150px, 230px) 104px minmax(0, 1fr) 24px;
   --v2-logs-top-glow: rgb(var(--brass-glow) / 0.04);
   display: flex;
   flex-direction: column;
@@ -50,7 +52,8 @@
   font-family: var(--font-display);
   font-size: 22px;
   font-weight: 600;
-  letter-spacing: 0;
+  /* -0.01em — pixel-match to prototype logs.css:20 (.lg-head-l h1). */
+  letter-spacing: -0.01em;
 }
 
 .v2-logs-sub {


### PR DESCRIPTION
## Gap map

| Surface element | Prototype (`keeper-v2/styles/logs.css`) | v2 before | v2 after |
|---|---|---|---|
| kind column width | `104px` (logs.css:15, `--lg-cols`) | `112px` | `104px` |
| h1 letter-spacing | `-0.01em` (logs.css:20, `.lg-head-l h1`) | `0` | `-0.01em` |

## Exact changes + citations

`dashboard/src/styles/v2-logs.css`
- `.v2-logs-surface { --v2-logs-cols: ... }`: kind column `112px` → `104px`. Matches prototype `keeper-v2/styles/logs.css:15` (`--lg-cols: 92px minmax(150px, 230px) 104px minmax(0, 1fr) 24px`). Kept as literal px with a comment — a 2px-base `--sp-*` would shrink this fixed column.
- `.v2-logs-head h1 { letter-spacing }`: `0` → `-0.01em`. Matches prototype `keeper-v2/styles/logs.css:20` (`.lg-head-l h1 { ... letter-spacing: -0.01em; ... }`).

`dashboard/src/components/logs.test.ts`
- Added `describe('LogViewer kind column')` behavioral test: renders `LogViewer`, asserts the `.v2-logs-table-header` carries the `유형` (kind) column and that a tool-category entry renders a `.v2-logs-kind` cell with `data-kind="tool"` and label `TOOL`. Satisfies the coverage gate for the covered-line surface and documents the kind-column contract the CSS sizes.

## Verification

- `npx tsc --noEmit` → exit 0, clean (no errors for touched files).
- `npx vitest run src/components/logs.test.ts` → Test Files 1 passed (1), Tests 15 passed (15).

## RFC gate

RFC gate N/A — no credential/identity/operator/sandbox/hooks/workflow surface touched; CSS literal + test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
