### PR TITLE
[v2] board — pixel-match to Claude-Design prototype

### DIFF
--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -977,4 +977,42 @@ describe('BoardSurface Component', () => {
 
     expect(categoryVisibleLimits.value.article).toBe(PAGE_SIZE)
   })
+
+  it('renders the operator author sigil with the "OP" glyph and .op modifier', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'op-post',
+        title: '기술 탐색: operator broadcast',
+        body: 'operator authored content',
+        author: 'operator',
+        post_kind: 'direct',
+      }),
+    ]
+
+    const { container } = render(h(BoardSurface, null))
+
+    const sigil = container.querySelector<HTMLElement>('.bd-sigil')
+    expect(sigil).not.toBeNull()
+    expect(sigil?.classList.contains('op')).toBe(true)
+    expect(sigil?.textContent).toBe('OP')
+  })
+
+  it('renders a keeper author sigil with a 2-letter monogram and no .op modifier', () => {
+    boardPosts.value = [
+      makePost({
+        id: 'kp-post',
+        title: '기술 탐색: keeper note',
+        body: 'keeper authored content',
+        author: 'sangsu',
+        post_kind: 'direct',
+      }),
+    ]
+
+    const { container } = render(h(BoardSurface, null))
+
+    const sigil = container.querySelector<HTMLElement>('.bd-sigil')
+    expect(sigil).not.toBeNull()
+    expect(sigil?.classList.contains('op')).toBe(false)
+    expect(sigil?.textContent).toBe('SA')
+  })
 })

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -342,8 +342,10 @@ function BoardSummary() {
 
 // ── Author sigil (v2) ──────────────────────────────────────────────
 function BdAuthor({ name, size = 24 }: { name: string; size?: number }) {
-  const label = name.slice(0, 2).toUpperCase()
   const isOperator = name.toLowerCase() === 'operator' || name.toLowerCase() === 'dashboard'
+  // Prototype board.jsx:8 renders the operator avatar as the literal "OP"
+  // glyph; keepers use a 2-letter monogram (SigilBadge style, fleet.jsx:8).
+  const label = isOperator ? 'OP' : name.slice(0, 2).toUpperCase()
   return html`<span class=${`bd-sigil ${isOperator ? 'op' : ''}`} style=${{ width: size, height: size }}>${label}</span>`
 }
 

--- a/dashboard/src/styles/board-v2.css
+++ b/dashboard/src/styles/board-v2.css
@@ -783,25 +783,29 @@
 }
 
 /* ════ AUTHOR SIGIL ════ */
+/* Prototype SigilBadge style (fleet.jsx:8 -> .sigil v2.css:286-291): solid
+   fill + dark monogram, no border. The prototype's operator avatar
+   (board.jsx:8) is the .msg-av.op variant (v2.css:485): solid var(--volt)
+   fill with var(--volt-ink) glyph, inline borderRadius:5 / fontSize:9.
+   The 5px radius is a literal in the prototype (board.jsx:8 borderRadius:5),
+   not --radius-sm (4px), so it is set as a literal px here. */
 .v2-board-surface .bd-sigil {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--radius-sm);
+  border-radius: 5px; /* prototype board.jsx:8 inline borderRadius:5 (literal, not --radius-sm=4px) */
   font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  color: var(--text-bright);
-  background: var(--bg-sunken);
-  border: 1px solid var(--border-soft);
+  font-size: 9px; /* prototype board.jsx:8 fontSize:9 */
+  font-weight: 700; /* prototype v2.css:291 .sigil font-weight:700 */
+  letter-spacing: 0;
+  color: var(--volt-ink); /* prototype v2.css:485 .msg-av.op color:var(--volt-ink) */
+  background: var(--volt); /* solid volt fill, prototype v2.css:485 .msg-av.op background:var(--volt) */
   flex: none;
 }
 
 .v2-board-surface .bd-sigil.op {
-  background: var(--volt-wash);
-  color: var(--volt-strong);
-  border-color: var(--volt-dim);
+  background: var(--volt); /* solid fill, not volt-wash; prototype v2.css:485 .msg-av.op */
+  color: var(--volt-ink); /* prototype v2.css:485 .msg-av.op color:var(--volt-ink) */
 }
 
 .v2-board-surface .bd-mobile-queues {

--- a/dashboard/src/styles/board-v2.test.ts
+++ b/dashboard/src/styles/board-v2.test.ts
@@ -33,3 +33,37 @@ describe('board-v2.css mobile detail overlay', () => {
     expect(declarations.width).toBe('100%')
   })
 })
+
+function ruleDecls(selector: string): Record<string, string> {
+  const declarations: Record<string, string> = {}
+  parse(css).walkRules((rule) => {
+    // skip rules nested inside @media so the base-layer decls are read
+    if (rule.parent?.type === 'atrule') return
+    if (!rule.selectors.includes(selector)) return
+    rule.walkDecls((decl) => {
+      declarations[decl.prop] = decl.value.trim()
+    })
+  })
+  return declarations
+}
+
+describe('board-v2.css author sigil (SigilBadge prototype parity)', () => {
+  it('renders the base sigil as a solid volt fill with a 5px radius and dark glyph', () => {
+    const decls = ruleDecls('.v2-board-surface .bd-sigil')
+
+    // prototype board.jsx:8 inline borderRadius:5 — literal, not --radius-sm (4px)
+    expect(decls['border-radius']).toBe('5px')
+    // solid fill (prototype v2.css:485 .msg-av.op background:var(--volt)), not a wash
+    expect(decls.background).toBe('var(--volt)')
+    expect(decls.color).toBe('var(--volt-ink)')
+    expect(decls['font-weight']).toBe('700')
+  })
+
+  it('keeps the operator sigil on a solid volt fill rather than volt-wash', () => {
+    const decls = ruleDecls('.v2-board-surface .bd-sigil.op')
+
+    expect(decls.background).toBe('var(--volt)')
+    expect(decls.background).not.toBe('var(--volt-wash)')
+    expect(decls.color).toBe('var(--volt-ink)')
+  })
+})


### PR DESCRIPTION
## Gap map

| Surface | Element | Prototype | Before | After |
|---|---|---|---|---|
| board | author/operator avatar sigil | SigilBadge (`.sigil`) — solid fill + dark monogram, no border; operator = `.msg-av.op` solid `var(--volt)` + `var(--volt-ink)`, inline `borderRadius:5` / `fontSize:9` | text-initials on `var(--bg-sunken)` + 1px border, `--radius-sm` (4px); `.op` used `var(--volt-wash)` | solid `var(--volt)` fill, `var(--volt-ink)` glyph, no border, **5px radius**; `.op` solid volt (not wash); operator glyph fixed to literal `OP` |

## Exact changes + citations

`dashboard/src/styles/board-v2.css` `.v2-board-surface .bd-sigil`:
- `border-radius: var(--radius-sm)` (4px) -> `border-radius: 5px` — prototype `board.jsx:8` inline `borderRadius:5` is a literal, not a token (`--radius-sm` resolves to 4px, `ds-theme-tokens.css:86` / `skin-v2.css:80`). Set as literal px with comment per pixel discipline.
- `background: var(--bg-sunken)` -> `background: var(--volt)` — solid fill, prototype `styles/v2.css:485` `.msg-av.op { background: var(--volt) }`.
- `color: var(--text-bright)` -> `color: var(--volt-ink)` — prototype `styles/v2.css:485` `.msg-av.op { color: var(--volt-ink) }`.
- removed `border: 1px solid var(--border-soft)` — prototype `.sigil` (`styles/v2.css:286-291`) has no border.
- `letter-spacing: 0.02em` -> `letter-spacing: 0` — prototype `.sigil` (`styles/v2.css:290`) `letter-spacing: 0`.
- kept `font-size: 9px` (prototype `board.jsx:8` `fontSize:9`), `font-weight: 700` (prototype `styles/v2.css:291`).

`.v2-board-surface .bd-sigil.op`:
- `background: var(--volt-wash)` -> `background: var(--volt)` (solid, not wash), `color: var(--volt-strong)` -> `var(--volt-ink)`, removed `border-color: var(--volt-dim)` — all per prototype `.msg-av.op` (`styles/v2.css:485`).

`dashboard/src/components/board/board-surface.ts` `BdAuthor`:
- operator glyph fixed to literal `OP` (prototype `board.jsx:8` renders `OP`), keepers keep the 2-letter monogram (SigilBadge style, `fleet.jsx:8`).

## Tests (COVERAGE GATE — meaningful behavioral tests included)

`dashboard/src/components/board/board-surface.test.ts`: operator post renders `.bd-sigil.op` with `OP`; keeper post renders `.bd-sigil` (no `.op`) with 2-letter monogram.
`dashboard/src/styles/board-v2.test.ts`: base sigil = solid `var(--volt)` fill, `5px` radius, `var(--volt-ink)` glyph, `700` weight; `.op` = solid volt (asserts not `var(--volt-wash)`).

```
npx vitest run src/styles/board-v2.test.ts src/components/board/board-surface.test.ts
Test Files  2 passed (2)
     Tests  60 passed (60)

npx tsc --noEmit
0 errors (clean)
```

RFC gate N/A — dashboard v2 presentation only; no credential/identity/operator-control/sandbox/hooks/workflow surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
