### PR TITLE
[RFC-0233 §10] time-to-first-token (ttfrc_ms) in gen phase

### DIFF
--- a/.tmp/rfc-0233-caller-context.md
+++ b/.tmp/rfc-0233-caller-context.md
@@ -73,3 +73,35 @@ Verification expectation:
   absent case omits the key / decodes `None`.
 - The inspector renders a real `formatMsCompact` on the `gen` phase when
   present, "측정 없음" when absent.
+
+## §10 Amendment (2026-06-22) — time-to-first-token: `ttfrc_ms`
+
+Caller context (R5): the Wave-2c field surfaces OAS
+`inference_telemetry.ttfrc_ms` through the same write path as §9
+(`keeper_agent_run.ml` → `Keeper_turn_record_writer` → `Turn_record.to_json`
+→ dashboard decoder). The field is populated across the streaming keeper
+fleet (provider-agnostic wall-clock at the first SSE chunk,
+`complete_stream.ml:573-574`); non-streaming turns and the error path leave
+it `None`. The decode (post-first-chunk) split is intentionally not derived
+(§9.6 fabrication guard) — `ttfrc_ms` is shown as a separate `gen`-phase
+annotation, never subtracted.
+
+Design constraints:
+
+- One `option` field `ttfrc_ms : float` on `Turn_record.t`. Same
+  `Option.bind` pattern as `request_latency_ms` (both `inference_telemetry`
+  and the field are `option`). `float`, not `int`, matching the OAS type.
+- The `gen` phase keeps `durationMs = request_latency_ms` (end-to-end) and
+  adds a separate `TurnPhase.ttfrcMs`; `phaseDurationLabel` appends
+  `· 첫 {formatMsCompact(ttfrc)}` only when both are present.
+- `prefill_ms`/`timings` stay deferred (§9.4): cloud keepers do not report
+  them, so a full prefill/decode split (option A) was rejected for empty
+  columns. `ttfrc_ms` is the one phase-level field every streaming provider
+  reports.
+
+Verification expectation:
+
+- `test_turn_record.ml` proves `ttfrc_ms` round-trips (`Some 567.8`) and
+  that the absent case omits the key / decodes `None`.
+- The inspector renders `"· 첫 568ms"` alongside the `gen` phase duration
+  when present, leaving the label at its end-to-end form when absent.

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3040,6 +3040,14 @@ export type TurnRecordEntry = {
   // before a response existed; the inspector renders "측정 없음" rather than a
   // fabricated duration for the response-generation phase.
   request_latency_ms?: number
+  // RFC-0233 §10 — time-to-first-response-chunk (ms, wall-clock), sourced from
+  // OAS inference_telemetry.ttfrc_ms. Unlike request_latency_ms (end-to-end),
+  // this isolates time-to-first-token on the streaming path; the streaming
+  // transport fills it for every provider, so it is populated across the
+  // streaming keeper fleet. Absent for non-streaming turns and on the error
+  // path. The decode (post-first-chunk) duration is NOT derived from
+  // request_latency_ms - ttfrc_ms (§9.6 fabrication guard).
+  ttfrc_ms?: number
   ts: number
 }
 
@@ -3182,6 +3190,7 @@ function decodeTurnRecordEntry(raw: unknown): TurnRecordEntry | null {
     price_input_per_million: asNumber(raw.price_input_per_million),
     price_output_per_million: asNumber(raw.price_output_per_million),
     request_latency_ms: asNumber(raw.request_latency_ms),
+    ttfrc_ms: asNumber(raw.ttfrc_ms),
     ts,
   }
 }

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -208,6 +208,7 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
           price_input_per_million: 0.27,
           price_output_per_million: 1.1,
           request_latency_ms: 1234,
+          ttfrc_ms: 567.8,
           blocks: [
             { block: 'system', bytes: 1200, digest: '1111222233334444' },
             { block: 'user_model', bytes: 728, digest: '99887766554433221100' },
@@ -674,10 +675,12 @@ describe('KeeperTurnInspector v2 drawer', () => {
     expect(drawerText).toContain('agent subturns')
     expect(drawerText).toContain('T9001')
     expect(drawerText).toContain('keeper_board_post_get')
-    // RFC-0233 §9: the gen (response-generation) phase carries
-    // request_latency_ms from the record (1234ms → "1.2s"), so it renders a
-    // measured duration instead of "측정 없음".
+    // RFC-0233 §9/§10: the gen (response-generation) phase carries
+    // request_latency_ms from the record (1234ms → "1.2s") plus ttfrc_ms
+    // (567.8ms → "568ms"), so it renders a measured duration with the
+    // time-to-first-token instead of "측정 없음".
     expect(drawerText).toContain('1.2s')
+    expect(drawerText).toContain('첫 568ms')
     expect(drawerText).toContain('54ms')
     expect(drawerText).not.toContain('0.50s')
 

--- a/dashboard/src/components/keeper-turn-inspector.ts
+++ b/dashboard/src/components/keeper-turn-inspector.ts
@@ -421,6 +421,10 @@ type TurnPhase = {
   mono?: boolean
   durationMs: number | null
   durationSource: 'tool_call_log' | 'provider_telemetry' | 'estimated' | 'not_recorded'
+  // RFC-0233 §10 — time-to-first-token for the gen phase (null when not
+  // recorded). Kept separate from durationMs (end-to-end request_latency_ms)
+  // so the post-first-chunk decode split is never derived (§9.6 guard).
+  ttfrcMs?: number | null
   visualDurationMs: number
   visualOffsetMs: number
   meta?: string
@@ -594,7 +598,16 @@ function formatTurnList(values: number[]): string {
 }
 
 function phaseDurationLabel(phase: TurnPhase): string {
-  if (phase.durationMs != null) return formatMsCompact(phase.durationMs)
+  if (phase.durationMs != null) {
+    const base = formatMsCompact(phase.durationMs)
+    // RFC-0233 §10 — show time-to-first-token alongside the gen phase's
+    // end-to-end duration when ttfrc_ms is recorded. No decode split: the
+    // post-first-chunk duration is NOT derived (§9.6 fabrication guard).
+    if (phase.kind === 'gen' && phase.ttfrcMs != null) {
+      return `${base} · 첫 ${formatMsCompact(phase.ttfrcMs)}`
+    }
+    return base
+  }
   if (phase.durationSource === 'estimated') return '추정'
   return '측정 없음'
 }
@@ -712,11 +725,16 @@ function buildTurnDetail(
     durationMs: record.request_latency_ms ?? null,
     durationSource:
       record.request_latency_ms != null ? 'provider_telemetry' : 'not_recorded',
+    // RFC-0233 §10 — time-to-first-token. Populated on the streaming path for
+    // every provider; null for non-streaming turns and on the error path.
+    ttfrcMs: record.ttfrc_ms ?? null,
     visualDurationMs: 0,
     visualOffsetMs: 0,
     meta:
       record.request_latency_ms != null
-        ? 'provider call wall-clock (request_latency_ms)'
+        ? record.ttfrc_ms != null
+          ? `provider call wall-clock (request_latency_ms) · 첫 토큰 ${formatMsCompact(record.ttfrc_ms)} (ttfrc_ms)`
+          : 'provider call wall-clock (request_latency_ms)'
         : 'provider/OAS duration is not recorded for this turn',
   })
   const { visualTotalMs, measuredDurationMs } = finalizePhaseOffsets(phases)

--- a/docs/rfc/RFC-0233-turn-observability-execution-identity.md
+++ b/docs/rfc/RFC-0233-turn-observability-execution-identity.md
@@ -645,3 +645,69 @@ case).
 - Behavioral: a turn whose provider call was measured shows a real `gen`
   bar; an errored turn (no response) keeps `gen` as "측정 없음". tsc +
   vitest.
+
+## §10 Amendment (2026-06-22) — time-to-first-token: `ttfrc_ms`
+
+### §10.1 Problem
+
+§9 wired the `gen` phase to `request_latency_ms` (end-to-end provider call
+wall-clock), but the inspector still cannot distinguish *time-to-first-token*
+— how long the user waited before the first response chunk appeared — from
+the full generation duration. This is the half of latency users perceive
+("why is it thinking before it starts typing?").
+
+### §10.2 Design
+
+Add `ttfrc_ms : float option` to `Turn_record.t`, sourced from OAS
+`inference_telemetry.ttfrc_ms` (Time-To-First-Response-Chunk, wall-clock).
+Unlike `request_latency_ms`, this isolates the wait for the first SSE chunk.
+The inspector renders it alongside the `gen` phase's end-to-end duration
+(`"1.2s · 첫 568ms"`), never as a fabricated split.
+
+### §10.3 Provider fill matrix (grounding)
+
+`ttfrc_ms` is the one phase-level signal populated across the keeper fleet:
+the OAS streaming transport (`complete_stream.ml:573-574`) sets it as a
+provider-agnostic wall-clock measurement as soon as the first SSE chunk
+arrives. The keeper default fleet (deepseek-v4-flash / deepseek-v4-pro /
+glm-4-7-coding / minimax-m3, all `openai-compatible-http` + `streaming`)
+reports `Some` for every turn. Non-streaming turns and the error path leave
+it `None`.
+
+`prefill_ms` and `timings.{prompt_ms, predicted_ms}` remain deferred
+(§9.4): only Ollama/llama-server report them natively, so emitting them
+would show mostly-empty columns across the predominantly-cloud fleet.
+
+### §10.4 Why a single field (B), not a phase split (A)
+
+A full prefill/decode split (option A) was rejected by the grounding
+workflow: cloud keepers do not populate `prefill_ms`/`timings`, so the
+decode sub-phase would be `None` for the majority of turns. `ttfrc_ms` is
+the only phase-level field the streaming transport fills for every
+provider, so it alone carries fleet-wide signal. Option B (single field)
+captures that signal at ~10 LOC without the empty-column cost.
+
+### §10.5 Honesty guard (§9.6 reaffirmed)
+
+The decode (post-first-chunk) duration is intentionally NOT derived as
+`request_latency_ms - ttfrc_ms`. That difference would be indistinguishable
+from a measurement yet is an arithmetic artifact; decode stays
+`not_recorded` until a provider reports it natively. `ttfrc_ms` is shown as
+a separate annotation, never subtracted into a phase bar.
+
+### §10.6 Inspector wiring
+
+`TurnPhase.ttfrcMs` (number | null, separate from `durationMs`). The `gen`
+phase populates it from `record.ttfrc_ms`; `phaseDurationLabel` appends
+`· 첫 {formatMsCompact(ttfrc)}` when both `request_latency_ms` and
+`ttfrc_ms` are present; the `meta` tooltip notes both sources. Absent
+`ttfrc_ms` leaves the `gen` label at its end-to-end form.
+
+### §10.7 Verification harness
+
+- Unit (`test/test_turn_record.ml`): round-trip of `ttfrc_ms`
+  (`Some 567.8`); the absent case (`None`) omits the JSON key and decodes
+  `None`.
+- Frontend: a grounded fixture (`ttfrc_ms: 567.8`) renders `"첫 568ms"`
+  alongside the `gen` phase duration; an absent value leaves the label
+  unchanged. tsc + vitest.

--- a/lib/keeper/keeper_agent_run.ml
+++ b/lib/keeper/keeper_agent_run.ml
@@ -700,6 +700,21 @@ let run_turn
                 t.request_latency_ms)
           | Error _ -> None
         in
+        let ttfrc_ms : float option =
+          (* RFC-0233 §10 — time-to-first-response-chunk (wall-clock, ms),
+             sourced from OAS [inference_telemetry.ttfrc_ms]. The streaming
+             transport ([complete_stream]) fills it for every provider on the
+             first SSE chunk, so it is populated across the streaming keeper
+             fleet; non-streaming turns and the error path leave it [None].
+             Both [inference_telemetry] and the field are [option], so
+             [Option.bind] flattens (same pattern as [request_latency_ms]
+             above). The decode (post-first-chunk) duration is NOT derived
+             from request_latency_ms - ttfrc_ms (§9.6 fabrication guard). *)
+          match turn_result with
+          | Ok result ->
+              Option.bind result.inference_telemetry (fun t -> t.ttfrc_ms)
+          | Error _ -> None
+        in
         (* RFC-0233 §2.3 — views derive, no view-side repair: ground the
            inspector's [model] and [finish_reason] in the same refs the
            execution receipt already records this turn. [model] is the
@@ -733,6 +748,7 @@ let run_turn
           ~price_input_per_million
           ~price_output_per_million
           ~request_latency_ms
+          ~ttfrc_ms
           ~sampling:
             { temperature = Some temperature
             ; top_p = None

--- a/lib/keeper/keeper_turn_record_writer.ml
+++ b/lib/keeper/keeper_turn_record_writer.ml
@@ -10,6 +10,7 @@ let write
       ~price_input_per_million
       ~price_output_per_million
       ~request_latency_ms
+      ~ttfrc_ms
       ~sampling
       ~usage
       ~execution_ids
@@ -30,6 +31,7 @@ let write
     ; price_input_per_million
     ; price_output_per_million
     ; request_latency_ms
+    ; ttfrc_ms
     ; sampling
     ; usage
     ; ts = Time_compat.now ()

--- a/lib/keeper/keeper_turn_record_writer.mli
+++ b/lib/keeper/keeper_turn_record_writer.mli
@@ -17,6 +17,7 @@ val write :
   price_input_per_million:float option ->
   price_output_per_million:float option ->
   request_latency_ms:int option ->
+  ttfrc_ms:float option ->
   sampling:Turn_record.sampling ->
   usage:Turn_record.usage ->
   execution_ids:Ids.Execution_id.t list ->

--- a/lib/types/turn_record.ml
+++ b/lib/types/turn_record.ml
@@ -31,6 +31,7 @@ type t =
   ; price_input_per_million : float option
   ; price_output_per_million : float option
   ; request_latency_ms : int option
+  ; ttfrc_ms : float option
   ; sampling : sampling
   ; usage : usage
   ; ts : float
@@ -66,6 +67,7 @@ let to_json (r : t) : Yojson.Safe.t =
     @ opt_field "price_input_per_million" (fun v -> `Float v) r.price_input_per_million
     @ opt_field "price_output_per_million" (fun v -> `Float v) r.price_output_per_million
     @ opt_field "request_latency_ms" (fun v -> `Int v) r.request_latency_ms
+    @ opt_field "ttfrc_ms" (fun v -> `Float v) r.ttfrc_ms
     @ opt_field "temperature" (fun v -> `Float v) r.sampling.temperature
     @ opt_field "top_p" (fun v -> `Float v) r.sampling.top_p
     @ opt_field "max_tokens" (fun v -> `Int v) r.sampling.max_tokens
@@ -163,6 +165,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
       let* price_input_per_million = opt_member "price_input_per_million" fields as_float in
       let* price_output_per_million = opt_member "price_output_per_million" fields as_float in
       let* request_latency_ms = opt_member "request_latency_ms" fields as_int in
+      let* ttfrc_ms = opt_member "ttfrc_ms" fields as_float in
       let* temperature = opt_member "temperature" fields as_float in
       let* top_p = opt_member "top_p" fields as_float in
       let* max_tokens = opt_member "max_tokens" fields as_int in
@@ -186,6 +189,7 @@ let of_json (json : Yojson.Safe.t) : (t, string) result =
         ; price_input_per_million
         ; price_output_per_million
         ; request_latency_ms
+        ; ttfrc_ms
         ; sampling = { temperature; top_p; max_tokens; thinking_budget; enable_thinking }
         ; usage = { input_tokens; output_tokens }
         ; ts

--- a/lib/types/turn_record.mli
+++ b/lib/types/turn_record.mli
@@ -75,10 +75,25 @@ type t =
        whenever a response is produced). [None] on the error path or legacy
        rows; the inspector renders absence rather than a fabricated duration
        for the response-generation phase. Phase-level splits
-       (prefill/decode/ttfrc) are deliberately deferred: only the provider's
-       native timing objects carry them and most keepers' runtimes do not
-       report them, so emitting them would show mostly-empty columns rather
-       than measured signal. *)
+       (prefill/decode) are deliberately deferred: only the provider's
+       native timing objects carry prefill/predicted durations and most
+       keepers' runtimes do not report them, so emitting them would show
+       mostly-empty columns rather than measured signal. [ttfrc_ms] is the
+       one phase-level signal every streaming provider reports, so it is
+       lifted to its own §10 field below. *)
+  ; ttfrc_ms : float option
+    (* RFC-0233 §10 — time-to-first-response-chunk in milliseconds
+       (wall-clock), sourced from OAS [inference_telemetry.ttfrc_ms]. Unlike
+       [request_latency_ms] (end-to-end), this measures only the wait for
+       the first response chunk, isolating time-to-first-token on the
+       streaming path. The OAS streaming transport ([complete_stream]) fills
+       it for every provider as soon as the first SSE chunk arrives, so it
+       is populated across the (streaming) keeper fleet; non-streaming turns
+       and the error path leave it [None]. The decode (post-first-chunk)
+       duration is intentionally NOT derived as
+       request_latency_ms - ttfrc_ms: that would fabricate a number
+       indistinguishable from a measurement (§9.6), so decode stays
+       not_recorded until a provider reports it natively. *)
   ; sampling : sampling
   ; usage : usage
   ; ts : float

--- a/test/test_turn_record.ml
+++ b/test/test_turn_record.ml
@@ -51,6 +51,7 @@ let sample_record () : Turn_record.t =
   ; price_input_per_million = Some 0.15
   ; price_output_per_million = Some 0.6
   ; request_latency_ms = Some 1234
+  ; ttfrc_ms = Some 567.8
   ; sampling =
       { temperature = Some 0.3
       ; top_p = Some 0.9
@@ -97,6 +98,8 @@ let test_codec_roundtrip () =
       record.price_output_per_million decoded.price_output_per_million;
     check (option int) "request_latency_ms round-trip" record.request_latency_ms
       decoded.request_latency_ms;
+    check (option (float 0.0001)) "ttfrc_ms round-trip" record.ttfrc_ms
+      decoded.ttfrc_ms;
     check (option (float 0.0001)) "temperature" record.sampling.temperature
       decoded.sampling.temperature;
     check (option (float 0.0001)) "top_p" record.sampling.top_p
@@ -122,6 +125,7 @@ let test_codec_optional_fields_absent () =
     ; price_input_per_million = None
     ; price_output_per_million = None
   ; request_latency_ms = None
+  ; ttfrc_ms = None
     ; sampling =
         { temperature = None
         ; top_p = None
@@ -152,7 +156,9 @@ let test_codec_optional_fields_absent () =
      check bool "price_input_per_million key omitted when None" false
        (List.mem_assoc "price_input_per_million" fields);
      check bool "request_latency_ms key omitted when None" false
-       (List.mem_assoc "request_latency_ms" fields)
+       (List.mem_assoc "request_latency_ms" fields);
+     check bool "ttfrc_ms key omitted when None" false
+       (List.mem_assoc "ttfrc_ms" fields)
    | _ -> fail "to_json did not produce an object");
   match Turn_record.of_json json with
   | Error e -> failf "decode failed: %s" e
@@ -167,6 +173,8 @@ let test_codec_optional_fields_absent () =
       decoded.price_output_per_million;
     check (option int) "request_latency_ms absent" None
       decoded.request_latency_ms;
+    check (option (float 0.0001)) "ttfrc_ms absent" None
+      decoded.ttfrc_ms;
     check (option (float 0.0001)) "temperature absent" None
       decoded.sampling.temperature;
     check (option (float 0.0001)) "top_p absent" None decoded.sampling.top_p;


### PR DESCRIPTION
## 목표
RFC-0233 §10 — keeper-turn inspector gen phase에 time-to-first-token(`ttfrc_ms`) 추가.

## 배경
§9(Wave 2b, #21997)가 gen phase를 `request_latency_ms`(end-to-end)에 연결. 하지만 사용자가 체감하는 지연의 절반 — 첫 토큰까지의 대기 — 는 보이지 않았음.

## 결정: B (ttfrc_ms 단일 추가)
7-agent grounding + 3-lens judge(simplicity/richness/honesty, 2:1 B):
- `ttfrc_ms`는 streaming 전 provider가 보고하는 유일한 phase-level 신호(`complete_stream.ml:573-574`, provider 무관 wall-clock). keeper 기본 fleet(deepseek/glm/minimax, 전부 streaming)이 모두 `Some`.
- `prefill_ms`/`timings`는 cloud keeper가 안 채워 A(풍부 분할)는 mostly-empty columns 재현 → 기각(§9.4).

## 정직성
- decode = `request_latency_ms - ttfrc_ms` derive 금지(§9.6 fabrication guard). `ttfrc_ms`는 별도 annotation.
- 부재(non-streaming/에러) 시 `None` → gen label end-to-end 형태 유지.

## 변경
- OCaml: `Turn_record.ttfrc_ms:float option` + codec; writer `~ttfrc_ms`; `keeper_agent_run.ml` write site(`Option.bind`, §9 동일 패턴).
- Frontend: `TurnRecordEntry.ttfrc_ms` + decoder; `TurnPhase.ttfrcMs`; `phaseDurationLabel`이 gen + ttfrc일 때 `"· 첫 X"` 추가; meta tooltip에 ttfrc 소스.
- Test: `test_turn_record.ml` roundtrip + absence; inspector fixture(`ttfrc_ms: 567.8` → `"첫 568ms"`).
- RFC-0233 §10 + `.tmp/rfc-0233-caller-context.md` §10.

## OAS 경계
OAS 코드 변경 0건 — MASC가 공개 OAS response 필드를 소비만 함(§9 동일 패턴).

## 검증
빌드 CI만(사용자 지시).

RFC: RFC-0233 §10 (이 PR에서 추가)
