### PR TITLE
style(dashboard): snap off-grid v2 spacing to the 2px rhythm grid (theme-agnostic)

### DIFF
--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -249,7 +249,7 @@
 .v2-app .v2-header-actions .v2-statchip {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   padding: 4px 10px;
   border: 1px solid var(--ss-border);
   border-radius: var(--radius-pill);

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -14,8 +14,8 @@
 
 .ap-sla { font-size: 11px; color: var(--status-warn); border: 1px solid color-mix(in oklab, var(--status-warn) 35%, var(--border-main)); background: color-mix(in oklab, var(--status-warn) 8%, transparent); padding: 4px 10px; border-radius: var(--radius-pill); white-space: nowrap; }
 
-.ap-workspace { display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, 360px); gap: 14px; align-items: start; margin-bottom: 22px; }
-.ap-queue { display: flex; flex-direction: column; gap: 10px; margin-bottom: 22px; }
+.ap-workspace { display: grid; grid-template-columns: minmax(0, 1fr) minmax(280px, 360px); gap: 14px; align-items: start; margin-bottom: 24px; }
+.ap-queue { display: flex; flex-direction: column; gap: 10px; margin-bottom: 24px; }
 .ap-workspace .ap-queue { margin-bottom: 0; }
 .ap-card { display: flex; background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; transition: border-color 0.16s; }
 .ap-card:hover { border-color: var(--border-highlight); }
@@ -26,10 +26,10 @@
 .ap-card.sev-accent .ap-rail { background: var(--accent-fg); }
 .ap-card.sev-info .ap-rail { background: var(--volt-dim); }
 .ap-card.sev-bad { border-color: color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); background: linear-gradient(100deg, color-mix(in oklab, var(--status-bad) 6%, var(--bg-panel)), var(--bg-panel) 60%); }
-.ap-main { flex: 1; min-width: 0; padding: 13px 16px 14px; }
+.ap-main { flex: 1; min-width: 0; padding: 14px 16px 14px; }
 
-.ap-h { display: flex; align-items: center; gap: 9px; }
-.ap-kind { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 7px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-mid); white-space: nowrap; }
+.ap-h { display: flex; align-items: center; gap: 10px; }
+.ap-kind { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 8px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-mid); white-space: nowrap; }
 .ap-kind.sev-bad  { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); background: color-mix(in oklab, var(--status-bad) 9%, transparent); }
 .ap-kind.sev-warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 42%, transparent); background: color-mix(in oklab, var(--status-warn) 7%, transparent); }
 .ap-kind.sev-accent { color: var(--accent-fg); border-color: var(--accent-30); background: var(--accent-10); }
@@ -42,8 +42,8 @@
 .ap-detail-toggle:hover { color: var(--volt-strong); border-color: var(--volt-dim); }
 .ap-detail-toggle[aria-pressed="true"] { color: var(--text-bright); border-color: var(--volt-dim); background: var(--volt-wash); }
 
-.ap-title { font-family: var(--font-display); font-weight: 500; font-size: 15px; color: var(--text-bright); margin: 9px 0 4px; line-height: 1.35; }
-.ap-detail { font-size: 12px; color: var(--text-mid); line-height: 1.55; margin: 0 0 11px; }
+.ap-title { font-family: var(--font-display); font-weight: 500; font-size: 15px; color: var(--text-bright); margin: 10px 0 4px; line-height: 1.35; }
+.ap-detail { font-size: 12px; color: var(--text-mid); line-height: 1.55; margin: 0 0 12px; }
 
 .ap-req { display: flex; gap: 10px; padding: 10px 12px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); margin-bottom: 12px; }
 .ap-req-body { min-width: 0; flex: 1; }
@@ -54,8 +54,8 @@
 .ap-req-goal:hover { color: var(--volt-strong); }
 .ap-req-quote { font-size: 12.5px; color: var(--text-primary); line-height: 1.5; font-style: italic; word-break: break-word; }
 
-.ap-actions { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
-.ap-act { font-family: var(--font-ui); font-size: 11.5px; letter-spacing: 0.04em; padding: 7px 16px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid); cursor: pointer; transition: 0.14s; }
+.ap-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.ap-act { font-family: var(--font-ui); font-size: 11.5px; letter-spacing: 0.04em; padding: 8px 16px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid); cursor: pointer; transition: 0.14s; }
 .ap-act:disabled { opacity: 0.5; cursor: default; }
 .ap-act.approve { border-color: color-mix(in oklab, var(--status-ok) 50%, transparent); color: var(--status-ok); }
 .ap-act.approve:hover:not(:disabled) { background: color-mix(in oklab, var(--status-ok) 14%, transparent); color: var(--text-bright); }
@@ -63,7 +63,7 @@
 .ap-act.always:hover:not(:disabled) { background: var(--volt-wash); }
 .ap-act.deny { border-color: color-mix(in oklab, var(--status-bad) 50%, transparent); color: var(--status-bad); }
 .ap-act.deny:hover:not(:disabled) { background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
-.ap-act.ghost { margin-left: auto; border-color: transparent; color: var(--text-dim); padding: 7px 4px; }
+.ap-act.ghost { margin-left: auto; border-color: transparent; color: var(--text-dim); padding: 8px 4px; }
 .ap-act.ghost:hover:not(:disabled) { color: var(--volt-strong); }
 
 .ap-detail-panel { position: sticky; top: 14px; background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 14px; min-width: 0; }
@@ -73,12 +73,12 @@
 .ap-detail-panel-title { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
 .ap-detail-panel-title strong { color: var(--text-bright); font-family: var(--font-display); font-size: 14px; font-weight: 600; line-height: 1.35; }
 .ap-detail-panel-title span { color: var(--text-dim); font-size: 10px; letter-spacing: 0.06em; }
-.ap-dossier { display: flex; flex-direction: column; gap: 9px; margin: 13px 0 0; }
+.ap-dossier { display: flex; flex-direction: column; gap: 10px; margin: 14px 0 0; }
 .ap-dossier-row { display: grid; grid-template-columns: 82px minmax(0, 1fr); gap: 10px; align-items: start; }
 .ap-dossier-row dt { color: var(--text-dim); font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; }
 .ap-dossier-row dd { margin: 0; color: var(--text-primary); font-size: 12px; line-height: 1.45; word-break: break-word; }
 
-.ap-clear { text-align: center; padding: 52px 20px; display: flex; flex-direction: column; align-items: center; gap: 7px; color: var(--text-dim); }
+.ap-clear { text-align: center; padding: 52px 20px; display: flex; flex-direction: column; align-items: center; gap: 8px; color: var(--text-dim); }
 .ap-clear .ico { width: 46px; height: 46px; display: flex; align-items: center; justify-content: center; border-radius: 50%; font-size: 22px; color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 40%, transparent); background: color-mix(in oklab, var(--status-ok) 8%, transparent); }
 .ap-clear h3 { font-family: var(--font-display); font-weight: 500; font-size: 15px; color: var(--text-mid); margin: 4px 0 0; }
 .ap-clear-sub { font-size: 12px; max-width: 360px; line-height: 1.6; }
@@ -86,7 +86,7 @@
 .ap-error { font-size: 12px; color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 35%, var(--border-main)); background: color-mix(in oklab, var(--status-bad) 7%, transparent); padding: 10px 12px; border-radius: var(--radius-sm); margin-bottom: 14px; }
 
 /* Nav-rail count badge for the approvals surface (open-approval count). */
-.ap-nav-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 5px; border-radius: var(--radius-pill); font-family: var(--font-mono); font-size: 9.5px; font-weight: 700; line-height: 1; color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 16%, transparent); border: 1px solid color-mix(in oklab, var(--status-bad) 38%, transparent); }
+.ap-nav-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 16px; height: 16px; padding: 0 6px; border-radius: var(--radius-pill); font-family: var(--font-mono); font-size: 9.5px; font-weight: 700; line-height: 1; color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 16%, transparent); border: 1px solid color-mix(in oklab, var(--status-bad) 38%, transparent); }
 .ap-nav-dot { position: absolute; top: 3px; right: 3px; width: 6px; height: 6px; border-radius: 50%; background: var(--status-bad); box-shadow: 0 0 0 2px var(--bg-panel); }
 
 @media (max-width: 980px) {

--- a/dashboard/src/styles/board-v2.css
+++ b/dashboard/src/styles/board-v2.css
@@ -60,7 +60,7 @@
 .v2-board-surface .bd-rail {
   border-right: 1px solid var(--border-main);
   background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%);
-  padding: 14px 9px;
+  padding: 14px 10px;
   overflow-y: auto;
   min-width: 0;
 }
@@ -71,7 +71,7 @@
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--text-dim);
-  margin: 0 0 8px 7px;
+  margin: 0 0 8px 8px;
   font-weight: 500;
 }
 
@@ -81,7 +81,7 @@
   gap: 8px;
   width: 100%;
   text-align: left;
-  padding: 7px 9px;
+  padding: 8px 10px;
   border-radius: var(--radius-sm);
   border: 1px solid transparent;
   background: none;
@@ -155,7 +155,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 11px 18px;
+  padding: 12px 20px;
   border-bottom: 1px solid var(--border-main);
   background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
 }
@@ -210,7 +210,7 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 14px 18px;
+  padding: 14px 20px;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -253,7 +253,7 @@
 .v2-board-surface .bd-post-h {
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
 }
 
 .v2-board-surface .bd-post-h .who {
@@ -311,7 +311,7 @@
   font-size: 12.5px;
   color: var(--text-mid);
   line-height: 1.55;
-  margin-top: 5px;
+  margin-top: 6px;
   max-height: 5.2rem;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -340,14 +340,14 @@
 .v2-board-surface .bd-post-foot {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   margin-top: 10px;
 }
 
 .v2-board-surface .bd-react {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   font-family: var(--font-mono);
   font-size: 10.5px;
   padding: 2px 8px;
@@ -394,8 +394,8 @@
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 4px 14px;
-  margin-top: 9px;
-  padding: 9px 12px;
+  margin-top: 10px;
+  padding: 10px 12px;
   border-radius: var(--radius-sm);
   background: var(--bg-sunken);
   border: 1px dashed var(--border-main);
@@ -420,7 +420,7 @@
   flex: none;
   border-top: 1px solid var(--border-main);
   background: linear-gradient(0deg, var(--bg-panel), var(--bg-deep));
-  padding: 10px 18px 14px;
+  padding: 10px 20px 14px;
 }
 
 .v2-board-surface .bd-composer-mobile-summary {
@@ -440,7 +440,7 @@
 .v2-board-surface .bd-comp-tab {
   font-family: var(--font-ui);
   font-size: 11px;
-  padding: 4px 11px;
+  padding: 4px 12px;
   border-radius: 4px 4px 0 0;
   border: 1px solid transparent;
   background: none;
@@ -463,7 +463,7 @@
   background: var(--bg-card);
   border: 1px solid var(--border-main);
   border-radius: var(--radius-md);
-  padding: 5px 5px 5px 13px;
+  padding: 6px 6px 6px 14px;
 }
 
 .v2-board-surface .bd-comp-box.grid {
@@ -635,7 +635,7 @@
   flex: none;
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
   padding: 12px 14px;
   border-bottom: 1px solid var(--border-soft);
 }
@@ -676,19 +676,19 @@
   padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 11px;
+  gap: 12px;
 }
 
 .v2-board-surface .bd-th {
   display: grid;
   grid-template-columns: 26px 1fr;
-  gap: 9px;
+  gap: 10px;
 }
 
 .v2-board-surface .bd-th-hd {
   display: flex;
   align-items: baseline;
-  gap: 7px;
+  gap: 8px;
 }
 
 .v2-board-surface .bd-th-hd .who {
@@ -714,8 +714,8 @@
 .v2-board-surface .bd-mention-row {
   display: flex;
   align-items: flex-start;
-  gap: 9px;
-  padding: 9px 10px;
+  gap: 10px;
+  padding: 10px 10px;
   border-radius: var(--radius-sm);
   background: var(--bg-card);
   border: 1px solid var(--border-soft);
@@ -812,12 +812,12 @@
   min-width: 0;
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-sm);
   background: var(--bg-card);
   color: var(--text-mid);
-  padding: 7px 10px;
+  padding: 8px 10px;
   font-family: var(--font-ui);
   font-size: 11px;
   cursor: pointer;
@@ -969,7 +969,7 @@
     flex: none;
     min-width: 58px;
     min-height: 30px;
-    padding: 5px 10px;
+    padding: 6px 10px;
     border-radius: var(--radius-sm);
     border: 1px solid var(--volt-dim);
     background: var(--volt-wash);
@@ -1057,8 +1057,8 @@
     min-width: 0;
     display: flex;
     align-items: center;
-    gap: 7px;
-    padding: 7px 8px;
+    gap: 8px;
+    padding: 8px 8px;
     border: 0;
     border-left: 2px solid transparent;
     border-radius: calc(var(--radius-sm) - 2px);
@@ -1106,7 +1106,7 @@
   }
 
   .v2-board-surface .bd-mobile-mention-empty {
-    padding: 7px 8px;
+    padding: 8px 8px;
     color: var(--text-dim);
     font-family: var(--font-mono);
     font-size: 10px;
@@ -1115,7 +1115,7 @@
   .v2-board-surface .bd-mobile-draft-tray {
     display: flex;
     flex-wrap: wrap;
-    gap: 7px;
+    gap: 8px;
     min-width: 0;
     margin: 0 0 6px;
   }
@@ -1152,7 +1152,7 @@
     gap: 8px;
     min-width: 0;
     margin: 0 0 6px;
-    padding: 6px 7px 6px 10px;
+    padding: 6px 8px 6px 10px;
     border-radius: var(--radius-sm);
     border: 1px solid var(--border-main);
     background: color-mix(in srgb, var(--bg-card) 90%, var(--volt-wash));

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -238,7 +238,7 @@
   color: var(--color-fg-primary);
   font-size: var(--fs-sm, 14px);
   line-height: 1.5;
-  padding: 9px 0;
+  padding: 10px 0;
   max-height: 160px;
   min-height: 24px;
 }
@@ -292,7 +292,7 @@
   letter-spacing: 0.04em;
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   transition: 0.14s;
   white-space: nowrap;
   flex: none;
@@ -335,7 +335,7 @@
   border: 1px solid var(--color-border-default);
   border-bottom-width: 2px;
   border-radius: var(--r-0);
-  padding: 1px 5px;
+  padding: 1px 6px;
   color: var(--color-fg-muted);
 }
 
@@ -355,17 +355,17 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin: 0 0 9px;
+  margin: 0 0 10px;
 }
 
 .cdraft {
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
   background: var(--color-bg-surface);
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-0);
-  padding: 7px 9px;
+  padding: 8px 10px;
   position: relative;
 }
 
@@ -459,10 +459,10 @@
 
 .cdraft-tx {
   display: flex;
-  gap: 7px;
+  gap: 8px;
   align-items: baseline;
   flex-basis: 100%;
-  padding-top: 5px;
+  padding-top: 6px;
   border-top: 1px solid var(--color-border-default);
 }
 
@@ -507,7 +507,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 5px 4px 5px 10px;
+  padding: 6px 4px 6px 10px;
   min-height: 34px;
 }
 
@@ -751,7 +751,7 @@
 .chat-artifact-card-btn {
   font-size: var(--fs-2xs);
   font-weight: var(--fw-med);
-  padding: 4px 9px;
+  padding: 4px 10px;
   border-radius: var(--r-0);
   border: 1px solid var(--color-border-default);
   background: var(--color-bg-panel-alt);

--- a/dashboard/src/styles/cockpit-v2.css
+++ b/dashboard/src/styles/cockpit-v2.css
@@ -147,7 +147,7 @@
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--text-dim);
-  margin: 0 0 5px;
+  margin: 0 0 6px;
 }
 
 .cp-head .cp-title {
@@ -248,7 +248,7 @@
 
 .cp-disc-row {
   background: var(--bg-panel);
-  padding: 11px 14px;
+  padding: 12px 14px;
 }
 
 .cp-disc-row .lvl {
@@ -280,9 +280,9 @@
   color: var(--text-mid);
   background: var(--bg-card);
   border: 1px solid var(--border-main);
-  padding: 1px 7px;
+  padding: 1px 8px;
   border-radius: var(--radius-pill);
-  margin-top: 7px;
+  margin-top: 8px;
 }
 
 .cp-plane {

--- a/dashboard/src/styles/code.css
+++ b/dashboard/src/styles/code.css
@@ -84,7 +84,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 
 .wc-chips { display: flex; gap: var(--sp-1); flex-wrap: nowrap; overflow: hidden; }
 .wc-chip {
-  display: inline-flex; align-items: center; gap: 5px;
+  display: inline-flex; align-items: center; gap: 6px;
   height: 22px; padding: 0 var(--sp-2);
   border: 1px solid var(--color-border-strong); border-radius: var(--r-1);
   background: var(--color-bg-elevated); color: var(--color-fg-secondary);
@@ -449,7 +449,7 @@ body[data-mode="split"] .zone-deck { display: none; }
   font-size: var(--fs-10);
 }
 .thread-kind {
-  font-size: var(--fs-9); padding: 1px 5px; border-radius: var(--r-0);
+  font-size: var(--fs-9); padding: 1px 6px; border-radius: var(--r-0);
   letter-spacing: .08em; text-transform: uppercase;
   font-family: var(--font-mono); font-weight: var(--fw-semi);
 }
@@ -497,7 +497,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 }
 .activity-head .scope-pill {
   margin-left: auto;
-  font-size: var(--fs-9); padding: 1px 5px;
+  font-size: var(--fs-9); padding: 1px 6px;
   background: rgb(var(--brass-glow) / .1);
   color: var(--brass-1); border-radius: var(--r-0);
   letter-spacing: .06em;
@@ -588,7 +588,7 @@ body[data-mode="split"] .zone-deck { display: none; }
 /* —— cross-keeper conflict badge (later) —— */
 .conflict-warn {
   display: inline-flex; align-items: center; gap: var(--sp-1);
-  font-size: var(--fs-10); padding: 1px 5px;
+  font-size: var(--fs-10); padding: 1px 6px;
   background: rgb(var(--err-glow) / .1);
   color: var(--err); border: 1px solid rgb(var(--err-glow) / .3);
   border-radius: var(--r-0); font-family: var(--font-mono);
@@ -647,7 +647,7 @@ body[data-mode="split"] .zone-rail {
   font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-disabled);
 }
 .cmd-hint-keys kbd {
-  display: inline-block; padding: 1px 5px;
+  display: inline-block; padding: 1px 6px;
   border: 1px solid var(--color-border-strong); border-radius: var(--r-0);
   background: var(--color-bg-hover); color: var(--color-fg-secondary);
   font-family: var(--font-mono); font-size: var(--fs-9);
@@ -679,7 +679,7 @@ body[data-mode="split"] .zone-rail {
   font-family: var(--font-mono); font-size: var(--fs-10); color: var(--color-fg-disabled);
 }
 .cmd-row .cmd-kind-tag {
-  font-size: var(--fs-9); padding: 1px 5px; border-radius: var(--r-0);
+  font-size: var(--fs-9); padding: 1px 6px; border-radius: var(--r-0);
   letter-spacing: .06em; text-transform: uppercase;
   background: var(--color-bg-elevated); color: var(--color-fg-muted); font-family: var(--font-mono);
 }
@@ -692,7 +692,7 @@ body[data-mode="split"] .zone-rail {
   color: var(--color-fg-disabled); font-size: var(--fs-11);
 }
 .cmd-empty kbd {
-  display: inline-block; padding: 1px 5px;
+  display: inline-block; padding: 1px 6px;
   border: 1px solid var(--color-border-strong); border-radius: var(--r-0);
   background: var(--color-bg-hover); color: var(--color-fg-secondary);
   font-family: var(--font-mono); font-size: var(--fs-9);
@@ -811,7 +811,7 @@ body:not(.term-open) .code-term { display: none; }
   padding: 2px 0;
 }
 .term-watch-pill {
-  font-size: var(--fs-9); padding: 1px 5px; border-radius: var(--r-0);
+  font-size: var(--fs-9); padding: 1px 6px; border-radius: var(--r-0);
   background: rgb(var(--brass-glow) / .1);
   color: var(--brass-1);
   letter-spacing: .06em; text-transform: uppercase;

--- a/dashboard/src/styles/connectors-v2.css
+++ b/dashboard/src/styles/connectors-v2.css
@@ -26,7 +26,7 @@
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 
 .cn-surf-head .eyebrow {
@@ -35,7 +35,7 @@
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--text-dim);
-  margin-bottom: 5px;
+  margin-bottom: 6px;
 }
 
 .cn-surf-head h1 {
@@ -48,7 +48,7 @@
 }
 
 .cn-surf-sub {
-  margin-top: 5px;
+  margin-top: 6px;
   font-size: 12px;
   color: var(--text-dim);
 }
@@ -73,7 +73,7 @@
 .cn-act {
   font-family: var(--font-ui);
   font-size: 11px;
-  padding: 7px 12px;
+  padding: 8px 12px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-main);
   background: var(--bg-panel);
@@ -104,7 +104,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 5px;
+  gap: 6px;
   max-width: 100%;
   margin: -6px 0 16px;
   padding: 4px;
@@ -118,9 +118,9 @@
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  gap: 7px;
+  gap: 8px;
   min-height: 30px;
-  padding: 5px 10px;
+  padding: 6px 10px;
   border: 1px solid transparent;
   border-radius: var(--radius-xs);
   background: transparent;
@@ -164,7 +164,7 @@
   max-width: 360px;
   font-family: var(--font-mono);
   font-size: 12px;
-  padding: 7px 11px;
+  padding: 8px 12px;
   background: var(--bg-sunken);
   color: var(--text-bright);
   border: 1px solid var(--border-main);
@@ -268,8 +268,8 @@
 .cn-h {
   display: flex;
   align-items: center;
-  gap: 11px;
-  padding: 13px 15px;
+  gap: 12px;
+  padding: 14px 16px;
   border-bottom: 1px solid var(--border-soft);
   background: var(--bg-panel-alt);
 }
@@ -310,7 +310,7 @@
 .cn-status-pill {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -378,7 +378,7 @@
 
 .cn-kv .cell {
   background: var(--bg-panel);
-  padding: 8px 15px;
+  padding: 8px 16px;
 }
 
 .cn-kv .k {
@@ -405,8 +405,8 @@
 .cn-caps {
   display: flex;
   flex-wrap: wrap;
-  gap: 5px;
-  padding: 10px 15px;
+  gap: 6px;
+  padding: 10px 16px;
   border-bottom: 1px solid var(--border-soft);
 }
 
@@ -422,7 +422,7 @@
 }
 
 .cn-bind {
-  padding: 10px 15px 13px;
+  padding: 10px 16px 14px;
   flex: 1;
 }
 
@@ -431,15 +431,15 @@
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--text-dim);
-  margin: 0 0 9px;
+  margin: 0 0 10px;
   font-weight: 600;
 }
 
 .cn-bind-row {
   display: flex;
   align-items: center;
-  gap: 9px;
-  padding: 7px 0;
+  gap: 10px;
+  padding: 8px 0;
   font-family: var(--font-mono);
   font-size: 12.5px;
   border-bottom: 1px dashed var(--border-soft);
@@ -506,7 +506,7 @@
 .cn-be {
   border: 1px solid var(--border-main);
   border-radius: var(--radius-sm);
-  padding: 9px 11px;
+  padding: 10px 12px;
   margin-bottom: 8px;
   background: var(--bg-card);
   transition: opacity 0.14s;
@@ -526,7 +526,7 @@
   flex: 1;
   min-width: 0;
   font-size: 12px;
-  padding: 5px 8px;
+  padding: 6px 8px;
   background: var(--bg-sunken);
   color: var(--text-bright);
   border: 1px solid var(--border-main);
@@ -552,7 +552,7 @@
 
 .cn-be-sel {
   font-size: 12px;
-  padding: 5px 8px;
+  padding: 6px 8px;
   background: var(--bg-sunken);
   color: var(--text-bright);
   border: 1px solid var(--border-main);
@@ -720,7 +720,7 @@
 }
 
 .cn-audit td {
-  padding: 7px 10px 7px 0;
+  padding: 8px 10px 8px 0;
   border-bottom: 1px solid var(--border-soft);
   color: var(--text-mid);
   font-family: var(--font-mono);
@@ -754,7 +754,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 11px 14px;
+  padding: 12px 14px;
   cursor: pointer;
   color: var(--text-mid);
   font-family: var(--font-display);
@@ -900,7 +900,7 @@
 .cn-drawer-tab {
   font-family: var(--font-ui);
   font-size: 12px;
-  padding: 7px 12px;
+  padding: 8px 12px;
   border: 0;
   background: transparent;
   color: var(--text-dim);
@@ -984,7 +984,7 @@
 .cn-set-input {
   font-family: var(--font-mono);
   font-size: 12px;
-  padding: 7px 10px;
+  padding: 8px 10px;
   background: var(--bg-sunken);
   color: var(--text-primary);
   border: 1px solid var(--border-main);
@@ -1018,7 +1018,7 @@
 .cn-set-seg-b {
   font-family: var(--font-mono);
   font-size: 11px;
-  padding: 5px 11px;
+  padding: 6px 12px;
   background: transparent;
   color: var(--text-dim);
   border: 0;
@@ -1045,7 +1045,7 @@
 .cn-set-add {
   margin-top: 10px;
   width: 100%;
-  padding: 9px;
+  padding: 10px;
   background: var(--bg-sunken);
   border: 1px dashed var(--border-highlight);
   border-radius: var(--radius-sm);
@@ -1064,7 +1064,7 @@
 .cn-test-btn {
   font-family: var(--font-ui);
   font-size: 11px;
-  padding: 6px 11px;
+  padding: 6px 12px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-main);
   background: var(--bg-card);

--- a/dashboard/src/styles/copilot-dock.css
+++ b/dashboard/src/styles/copilot-dock.css
@@ -67,15 +67,15 @@
 .dock-menu {
   position: absolute; top: calc(100% + 6px); left: 0; width: 256px; max-height: 318px; overflow-y: auto;
   background: var(--bg-panel); border: 1px solid var(--border-highlight);
-  border-radius: var(--radius-md); box-shadow: var(--shadow-pop); z-index: 8; padding: 5px;
+  border-radius: var(--radius-md); box-shadow: var(--shadow-pop); z-index: 8; padding: 6px;
 }
-.dock-menu-row { display: flex; align-items: center; gap: var(--sp-3); padding: 7px 8px; border-radius: var(--radius-sm); cursor: pointer; transition: 0.12s; }
+.dock-menu-row { display: flex; align-items: center; gap: var(--sp-3); padding: 8px 8px; border-radius: var(--radius-sm); cursor: pointer; transition: 0.12s; }
 .dock-menu-row:hover { background: var(--bg-card); }
 .dock-menu-row.on { background: var(--bg-card); box-shadow: inset 0 0 0 1px var(--volt-wash); }
 .dock-menu-row .minfo { min-width: 0; flex: 1; }
 .dock-menu-row .nm { font-size: 12px; color: var(--text-bright); font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dock-menu-row .nm .h { color: var(--text-dim); font-weight: 400; font-size: 10px; }
-.dock-menu-row .sub { display: flex; align-items: center; gap: 5px; font-size: 10px; color: var(--text-dim); font-family: var(--font-mono); margin-top: 2px; }
+.dock-menu-row .sub { display: flex; align-items: center; gap: 6px; font-size: 10px; color: var(--text-dim); font-family: var(--font-mono); margin-top: 2px; }
 
 /* ── co-view context card ── */
 .dock-coview {
@@ -87,10 +87,10 @@
 .dock-coview-h .lbl { font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--info); font-weight: 600; }
 .dock-coview-h .route { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
 .dock-coview .scene { font-size: 12.5px; color: var(--text-bright); font-weight: 600; margin-bottom: var(--sp-2); }
-.dock-coview-fields { display: flex; flex-wrap: wrap; gap: 5px; }
+.dock-coview-fields { display: flex; flex-wrap: wrap; gap: 6px; }
 .dock-field {
-  display: inline-flex; align-items: center; gap: 5px; white-space: nowrap;
-  font-family: var(--font-mono); font-size: 10px; padding: 2px 7px;
+  display: inline-flex; align-items: center; gap: 6px; white-space: nowrap;
+  font-family: var(--font-mono); font-size: 10px; padding: 2px 8px;
   border-radius: var(--radius-pill); border: 1px solid var(--border-main);
   background: var(--bg-deep); color: var(--text-mid);
 }
@@ -100,7 +100,7 @@
 .dock-field.warn .v { color: var(--status-warn); }
 .dock-field.volt .v { color: var(--volt-strong); }
 .dock-field.brass .v { color: var(--brass-1); }
-.dock-coview .sync { display: flex; align-items: center; gap: 5px; margin-top: var(--sp-2); font-size: 9.5px; color: var(--text-dim); }
+.dock-coview .sync { display: flex; align-items: center; gap: 6px; margin-top: var(--sp-2); font-size: 9.5px; color: var(--text-dim); }
 .dock-coview .sync .d { width: 5px; height: 5px; border-radius: 50%; background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); animation: dot-pulse 2s ease-in-out infinite; }
 
 /* ── thread ── */
@@ -133,7 +133,7 @@
   padding: var(--sp-3) var(--sp-4); font-size: 12.5px; line-height: 1.6; color: var(--text-primary);
 }
 .dmsg.user .dbubble { background: var(--volt-wash); border-color: var(--volt-dim); border-radius: var(--radius-md) 3px var(--radius-md) var(--radius-md); color: var(--text-bright); }
-.dbubble p { margin: 0 0 7px; }
+.dbubble p { margin: 0 0 8px; }
 .dbubble p:last-child { margin-bottom: 0; }
 .dbubble code { font-family: var(--font-mono); font-size: 11px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 0 4px; border-radius: var(--radius-xs); color: var(--volt-strong); }
 .dbubble strong { color: var(--text-bright); font-weight: 600; }
@@ -141,7 +141,7 @@
 @keyframes dcaret { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
 
 /* ── suggestions (mini) ── */
-.dsug { display: flex; flex-direction: column; gap: 5px; margin-top: var(--sp-3); }
+.dsug { display: flex; flex-direction: column; gap: 6px; margin-top: var(--sp-3); }
 .dsug button {
   text-align: left; font-family: var(--font-ui); font-size: 11.5px; line-height: 1.3;
   padding: 6px 10px; border-radius: var(--radius-sm); border: 1px solid var(--border-main);
@@ -155,23 +155,23 @@
 .dock-comp-box {
   display: flex; align-items: flex-end; gap: var(--sp-2);
   background: var(--bg-card); border: 1px solid var(--border-main);
-  border-radius: var(--radius-md); padding: 5px 5px 5px var(--sp-4); transition: 0.15s;
+  border-radius: var(--radius-md); padding: 6px 6px 6px var(--sp-4); transition: 0.15s;
 }
 .dock-comp-box.focus { border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); }
-.dock-comp-box textarea { flex: 1; resize: none; border: 0; outline: 0; background: transparent; color: var(--text-bright); font-family: var(--font-ui); font-size: 12.5px; line-height: 1.5; padding: 7px 0; max-height: 120px; min-height: 20px; }
+.dock-comp-box textarea { flex: 1; resize: none; border: 0; outline: 0; background: transparent; color: var(--text-bright); font-family: var(--font-ui); font-size: 12.5px; line-height: 1.5; padding: 8px 0; max-height: 120px; min-height: 20px; }
 .dock-comp-box textarea::placeholder { color: var(--text-dim); }
 .dock-send { width: 30px; height: 30px; flex: none; border-radius: var(--radius-sm); border: 1px solid var(--volt); background: var(--volt); color: var(--volt-ink); cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 14px; transition: 0.14s; }
 .dock-send svg { flex: none; }
 .dock-send:hover:not(:disabled) { background: var(--volt-strong); box-shadow: 0 0 14px var(--volt-glow); }
 .dock-send:disabled { opacity: 0.4; cursor: default; }
-.dock-foot { display: flex; align-items: center; gap: var(--sp-3); margin-top: 7px; font-size: 10px; color: var(--text-dim); }
+.dock-foot { display: flex; align-items: center; gap: var(--sp-3); margin-top: 8px; font-size: 10px; color: var(--text-dim); }
 .dock-foot b { color: var(--volt-strong); font-family: var(--font-mono); font-weight: 600; }
 .dock-foot kbd { font-family: var(--font-mono); font-size: 9px; background: var(--bg-card); border: 1px solid var(--border-main); border-bottom-width: 2px; border-radius: var(--radius-xs); padding: 1px 4px; color: var(--text-mid); }
 
 /* ── triggers: FAB + top-bar button ── */
 .dock-fab {
   position: fixed; right: 22px; bottom: 22px; z-index: 55;
-  height: 50px; padding: 0 18px 0 14px; display: flex; align-items: center; justify-content: center; gap: 8px;
+  height: 50px; padding: 0 20px 0 14px; display: flex; align-items: center; justify-content: center; gap: 8px;
   border-radius: var(--radius-pill); border: 1px solid var(--volt);
   background: var(--volt); color: var(--volt-ink);
   font-family: var(--font-ui); font-weight: 600; font-size: 12.5px; cursor: pointer;
@@ -193,10 +193,10 @@
   color: currentColor;
   stroke: currentColor;
 }
-.dock-fab kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 5px; border-radius: var(--radius-xs); background: color-mix(in oklab, var(--volt-ink) 16%, transparent); }
+.dock-fab kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 6px; border-radius: var(--radius-xs); background: color-mix(in oklab, var(--volt-ink) 16%, transparent); }
 
 .topbar-copilot {
-  display: flex; align-items: center; gap: 7px; height: 30px; padding: 0 10px;
+  display: flex; align-items: center; gap: 8px; height: 30px; padding: 0 10px;
   border-radius: var(--radius-pill); border: 1px solid var(--border-main);
   background: var(--bg-panel-alt); color: var(--text-mid); cursor: pointer;
   font-family: var(--font-ui); font-size: 11px; transition: 0.14s; white-space: nowrap;

--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -77,43 +77,43 @@
    scoped to `data-keeper-chat-layout="workspace"` so density does not spill into
    primary/detail transcripts. The transcript's own `chat-transcript-airy` gap
    already spaces messages, so the design `thread-inner` gap is not re-applied. */
-.v2-app[data-density="spacious"] .kw-chat-head     { padding: 18px 28px 16px; gap: 16px; }
+.v2-app[data-density="spacious"] .kw-chat-head     { padding: 20px 28px 16px; gap: 16px; }
 .v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-transcript  { padding: 34px 40px 14px; }
-.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-turn-bundle { gap: 15px; }
-.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-bubble      { padding: 17px 21px; line-height: 1.7; }
-.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .kw-composer-inner { padding: 16px 30px 22px; }
-.v2-app[data-density="spacious"] .kw-kp-row        { padding: 11px 11px; }
+.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-turn-bundle { gap: 16px; }
+.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-bubble      { padding: 16px 20px; line-height: 1.7; }
+.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .kw-composer-inner { padding: 16px 30px 24px; }
+.v2-app[data-density="spacious"] .kw-kp-row        { padding: 12px 12px; }
 /* Context rail + roster (design `.ctx-scroll`/`.ctx-card`/`.tps-card`/`.roster-*`
    -> live `.kw-rail-scroll`/`.kw-sec`/`.kw-roster-*`). `.kw-sec` is scoped under
    `.kw-rail` (context cards only). Verified on the running dashboard. */
-.v2-app[data-density="spacious"] .kw-rail-scroll   { padding: 20px; gap: 22px; }
-.v2-app[data-density="spacious"] .kw-rail .kw-sec  { padding: 14px 15px; }
-.v2-app[data-density="spacious"] .kw-roster-head   { padding: 15px 14px; }
-.v2-app[data-density="spacious"] .kw-roster-list   { padding: 9px 8px; }
+.v2-app[data-density="spacious"] .kw-rail-scroll   { padding: 20px; gap: 24px; }
+.v2-app[data-density="spacious"] .kw-rail .kw-sec  { padding: 14px 16px; }
+.v2-app[data-density="spacious"] .kw-roster-head   { padding: 16px 14px; }
+.v2-app[data-density="spacious"] .kw-roster-list   { padding: 10px 8px; }
 .v2-app[data-density="spacious"] .kw-roster-filters { padding: 12px 14px; }
 
 /* Board */
-.v2-app[data-density="spacious"] .bd-feed-head     { padding: 15px 24px; }
+.v2-app[data-density="spacious"] .bd-feed-head     { padding: 16px 24px; }
 .v2-app[data-density="spacious"] .bd-list          { padding: 20px 24px; gap: 14px; }
-.v2-app[data-density="spacious"] .bd-rail          { padding: 18px 12px; }
-.v2-app[data-density="spacious"] .bd-composer      { padding: 14px 24px 18px; }
-.v2-app[data-density="spacious"] .bd-detail-h      { padding: 16px 18px; }
-.v2-app[data-density="spacious"] .bd-detail-scroll { padding: 18px; gap: 14px; }
+.v2-app[data-density="spacious"] .bd-rail          { padding: 20px 12px; }
+.v2-app[data-density="spacious"] .bd-composer      { padding: 14px 24px 20px; }
+.v2-app[data-density="spacious"] .bd-detail-h      { padding: 16px 20px; }
+.v2-app[data-density="spacious"] .bd-detail-scroll { padding: 20px; gap: 14px; }
 
 /* Settings */
 .v2-app[data-density="spacious"] .settings-surf .set-card-b { padding: 12px 40px 56px; }
-.v2-app[data-density="spacious"] .set-content-h { padding: 26px 40px 18px; }
+.v2-app[data-density="spacious"] .set-content-h { padding: 26px 40px 20px; }
 .v2-app[data-density="spacious"] .set-row       { padding: 16px 0; }
-.v2-app[data-density="spacious"] .set-nav-item  { padding: 11px 13px; }
+.v2-app[data-density="spacious"] .set-nav-item  { padding: 12px 14px; }
 
 /* Compact overrides — chat console retargeted to live `.kw-*`/`.chat-*` classes
    (the v2 source `.thread`/`.chat-head`/`.composer` never matched). Verified on
    the running dashboard. */
-.v2-app[data-density="compact"] .kw-chat-head     { padding: 10px 16px 9px; }
-.v2-app[data-density="compact"] [data-keeper-chat-layout="workspace"] .chat-transcript  { padding: 14px 22px 6px; }
-.v2-app[data-density="compact"] [data-keeper-chat-layout="workspace"] .kw-composer-inner { padding: 9px 18px 12px; }
-.v2-app[data-density="compact"] .kw-rail-scroll { padding: 11px; gap: 12px; }
-.v2-app[data-density="compact"] .bd-list       { padding: 11px 14px; gap: 8px; }
+.v2-app[data-density="compact"] .kw-chat-head     { padding: 10px 16px 10px; }
+.v2-app[data-density="compact"] [data-keeper-chat-layout="workspace"] .chat-transcript  { padding: 14px 24px 6px; }
+.v2-app[data-density="compact"] [data-keeper-chat-layout="workspace"] .kw-composer-inner { padding: 10px 20px 12px; }
+.v2-app[data-density="compact"] .kw-rail-scroll { padding: 12px; gap: 12px; }
+.v2-app[data-density="compact"] .bd-list       { padding: 12px 14px; gap: 8px; }
 .v2-app[data-density="compact"] .set-row       { padding: 10px 0; }
 
 /* ── Motion ───────────────────────────────────────────────────── */

--- a/dashboard/src/styles/craft-v2.test.ts
+++ b/dashboard/src/styles/craft-v2.test.ts
@@ -46,7 +46,7 @@ describe('craft-v2.css data-bubble=flat toggle', () => {
 describe('craft-v2.css density chat console (retargeted to live classes)', () => {
   it('applies the spacious chat values to the live .kw-*/.chat-* classes', () => {
     expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-chat-head').padding)
-      .toBe('18px 28px 16px')
+      .toBe('20px 28px 16px')
     expect(declarationsForSelector(
       css,
       '.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-transcript',
@@ -56,42 +56,42 @@ describe('craft-v2.css density chat console (retargeted to live classes)', () =>
       css,
       '.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .chat-bubble',
     )
-    expect(bubble.padding).toBe('17px 21px')
+    expect(bubble.padding).toBe('16px 20px')
     expect(bubble['line-height']).toBe('1.7')
     expect(declarationsForSelector(
       css,
       '.v2-app[data-density="spacious"] [data-keeper-chat-layout="workspace"] .kw-composer-inner',
     ).padding)
-      .toBe('16px 30px 22px')
+      .toBe('16px 30px 24px')
   })
 
   it('applies the compact chat values to the live .kw-*/.chat-* classes', () => {
     expect(declarationsForSelector(css, '.v2-app[data-density="compact"] .kw-chat-head').padding)
-      .toBe('10px 16px 9px')
+      .toBe('10px 16px 10px')
     expect(declarationsForSelector(
       css,
       '.v2-app[data-density="compact"] [data-keeper-chat-layout="workspace"] .chat-transcript',
     ).padding)
-      .toBe('14px 22px 6px')
+      .toBe('14px 24px 6px')
     expect(declarationsForSelector(
       css,
       '.v2-app[data-density="compact"] [data-keeper-chat-layout="workspace"] .kw-composer-inner',
     ).padding)
-      .toBe('9px 18px 12px')
+      .toBe('10px 20px 12px')
   })
 
   it('applies context-rail + roster spacious values to live classes', () => {
     const rail = declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-rail-scroll')
     expect(rail.padding).toBe('20px')
-    expect(rail.gap).toBe('22px')
+    expect(rail.gap).toBe('24px')
     expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-rail .kw-sec').padding)
-      .toBe('14px 15px')
+      .toBe('14px 16px')
     expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-roster-head').padding)
-      .toBe('15px 14px')
+      .toBe('16px 14px')
     expect(declarationsForSelector(css, '.v2-app[data-density="spacious"] .kw-roster-filters').padding)
       .toBe('12px 14px')
     expect(declarationsForSelector(css, '.v2-app[data-density="compact"] .kw-rail-scroll').padding)
-      .toBe('11px')
+      .toBe('12px')
   })
 
   it('gives the keeper workspace scroll areas the themed webkit scrollbar', () => {

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -297,7 +297,7 @@
 }
 
 .ide-toolbar-context-focus > span {
-  padding: 1px 5px;
+  padding: 1px 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-page);
@@ -334,7 +334,7 @@
   gap: 3px;
   min-width: 0;
   height: 100%;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 0;
   background: transparent;
   color: inherit;
@@ -378,7 +378,7 @@
   min-width: 0;
   max-width: 132px;
   height: 18px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-page);
@@ -525,7 +525,7 @@
 }
 
 .ide-diff-context-focus > span:not(.ide-diff-context-links) {
-  padding: 1px 5px;
+  padding: 1px 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-page);
@@ -546,7 +546,7 @@
 
 .ide-diff-context-count {
   height: 18px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-divider);
   border-radius: var(--r-1);
   background: var(--color-bg-surface);
@@ -561,7 +561,7 @@
   min-width: 0;
   max-width: 76px;
   height: 18px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-page);
@@ -682,7 +682,7 @@
   min-width: 0;
   max-width: 13rem;
   margin-left: auto;
-  padding: 1px 5px;
+  padding: 1px 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-page);
@@ -1054,7 +1054,7 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
   max-width: 80px;
   height: 18px;
-  padding: 0 5px;
+  padding: 0 6px;
   overflow: hidden;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
@@ -1275,7 +1275,7 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
   max-width: 52px;
   height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   overflow: hidden;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
@@ -1435,7 +1435,7 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
   max-width: 72px;
   height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-muted);
@@ -1486,7 +1486,7 @@ button.ide-persistence-focus:focus-visible {
 .ide-bdi-route-count,
 .ide-interject-context-count {
   height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-divider);
   border-radius: var(--r-1);
   background: var(--color-bg-surface);
@@ -1501,7 +1501,7 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
   max-width: 72px;
   height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-muted);
@@ -1542,7 +1542,7 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
   max-width: 76px;
   height: 18px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-page);
@@ -1590,7 +1590,7 @@ button.ide-persistence-focus:focus-visible {
   align-items: center;
   flex-shrink: 0;
   min-height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-muted);
@@ -1848,7 +1848,7 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
   max-width: 116px;
   min-height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-muted);
@@ -1887,7 +1887,7 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
   max-width: 84px;
   height: 18px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-page);
@@ -2103,7 +2103,7 @@ button.ide-persistence-focus:focus-visible {
   display: inline-flex;
   align-items: center;
   height: 18px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-muted);
   border-radius: var(--r-1);
   background: var(--color-bg-canvas);
@@ -2119,7 +2119,7 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
   max-width: 76px;
   height: 18px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-page);
@@ -2234,7 +2234,7 @@ button.ide-persistence-focus:focus-visible {
   display: inline-flex;
   align-items: center;
   height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-muted);
   border-radius: var(--r-1);
   background: var(--color-bg-canvas);
@@ -2250,7 +2250,7 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
   max-width: 72px;
   height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-muted);
@@ -2332,7 +2332,7 @@ button.ide-persistence-focus:focus-visible {
   gap: 4px;
   min-width: 0;
   height: 18px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-page);
@@ -2371,7 +2371,7 @@ button.ide-persistence-focus:focus-visible {
 
 .ide-editor-context-route-count {
   height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-divider);
   border-radius: var(--r-1);
   background: var(--color-bg-surface);
@@ -2386,7 +2386,7 @@ button.ide-persistence-focus:focus-visible {
   min-width: 0;
   max-width: 68px;
   height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-elevated);
@@ -2675,7 +2675,7 @@ button.ide-persistence-focus:focus-visible {
   display: inline-flex;
   align-items: center;
   min-height: 17px;
-  padding: 0 5px;
+  padding: 0 6px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-muted);

--- a/dashboard/src/styles/deck.css
+++ b/dashboard/src/styles/deck.css
@@ -115,7 +115,7 @@
   background: var(--color-bg-surface); border-bottom: 1px solid var(--color-border-strong);
   font-size: var(--fs-10); text-transform: uppercase; letter-spacing: .08em;
   color: var(--color-fg-secondary); font-weight: var(--fw-bold);
-  text-align: left; padding: 7px 12px;
+  text-align: left; padding: 8px 12px;
   z-index: 1;
 }
 .deck-table tbody td {
@@ -293,7 +293,7 @@
   font-size: var(--fs-11); color: var(--color-fg-secondary); font-family: var(--font-mono);
 }
 .runtime-step .cs-state {
-  display: flex; align-items: center; gap: 5px; font-size: var(--fs-11); margin-top: 2px;
+  display: flex; align-items: center; gap: 6px; font-size: var(--fs-11); margin-top: 2px;
 }
 .runtime-step .cs-arrow {
   position: absolute; right: -7px; top: 50%; transform: translateY(-50%);

--- a/dashboard/src/styles/fusion-v2.css
+++ b/dashboard/src/styles/fusion-v2.css
@@ -9,7 +9,7 @@
 .v2-fusion-surface .fus-scroll {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 20px;
 }
 
 .v2-fusion-surface .fus-head {
@@ -61,7 +61,7 @@
   border: 1px solid var(--fus-line);
   border-radius: var(--r-3);
   background: var(--fus-panel);
-  padding: 11px 12px;
+  padding: 12px 12px;
 }
 
 .v2-fusion-surface .fus-kpi-k {
@@ -153,9 +153,9 @@
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 8px;
   min-height: 96px;
-  padding: 11px;
+  padding: 12px;
   text-align: left;
 }
 
@@ -216,7 +216,7 @@
   display: inline-flex;
   align-items: center;
   min-width: 0;
-  gap: 7px;
+  gap: 8px;
 }
 
 .v2-fusion-surface .fus-rdot {
@@ -323,7 +323,7 @@
 .v2-fusion-surface .fus-pipe-node {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   min-height: 28px;
   border: 1px solid var(--fus-line);
   border-radius: var(--r-1);
@@ -332,7 +332,7 @@
   font-size: 11px;
   font-weight: 800;
   line-height: 1;
-  padding: 0 9px;
+  padding: 0 10px;
   text-transform: uppercase;
 }
 
@@ -448,7 +448,7 @@
   gap: 10px;
   min-height: 180px;
   min-width: 0;
-  padding: 13px;
+  padding: 14px;
 }
 
 .v2-fusion-surface .fus-panel-card.answered {
@@ -545,7 +545,7 @@
 .v2-fusion-surface .fus-jrow {
   color: var(--fus-text);
   display: grid;
-  gap: 5px;
+  gap: 6px;
   font-size: 12px;
   line-height: 1.45;
   overflow-wrap: anywhere;
@@ -559,8 +559,8 @@
 .v2-fusion-surface .fus-jgroup ul {
   color: var(--fus-text);
   display: grid;
-  gap: 5px;
-  padding-left: 18px;
+  gap: 6px;
+  padding-left: 20px;
 }
 
 .v2-fusion-surface .fus-jgroup-split {
@@ -572,7 +572,7 @@
 .v2-fusion-surface .fus-model-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 5px;
+  gap: 6px;
 }
 
 .v2-fusion-surface .fus-model-chip,
@@ -593,7 +593,7 @@
 
 .v2-fusion-surface .fus-muted-key {
   margin-right: 6px;
-  padding: 3px 5px;
+  padding: 3px 6px;
   text-transform: uppercase;
 }
 
@@ -617,7 +617,7 @@
 .v2-fusion-surface .fus-empty-inline {
   border: 1px dashed var(--fus-line);
   border-radius: var(--r-3);
-  padding: 18px;
+  padding: 20px;
 }
 
 .v2-fusion-surface .fus-empty {
@@ -666,7 +666,7 @@
   border: 1px solid var(--fus-line);
   border-radius: var(--r-3);
   background: var(--fus-panel);
-  padding: 13px 14px;
+  padding: 14px 14px;
 }
 
 .v2-fusion-surface .fus-reconcile-head {
@@ -700,7 +700,7 @@
   color: var(--fus-muted);
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 11px;
-  padding: 5px 8px;
+  padding: 6px 8px;
   white-space: nowrap;
 }
 
@@ -715,7 +715,7 @@
   border: 1px solid var(--fus-line);
   border-radius: var(--r-2);
   background: var(--fus-panel-strong);
-  padding: 9px;
+  padding: 10px;
 }
 
 .v2-fusion-surface .fus-reconcile-col-head {
@@ -752,7 +752,7 @@
   border-radius: var(--r-1);
   background: color-mix(in srgb, var(--color-bg-surface) 70%, transparent);
   color: var(--fus-text);
-  padding: 7px 8px;
+  padding: 8px 8px;
   text-align: left;
 }
 
@@ -932,7 +932,7 @@ button.fus-reconcile-row:hover {
   border: 1px solid var(--fus-line);
   border-radius: var(--r-1);
   background: var(--fus-panel-strong);
-  padding: 7px 10px;
+  padding: 8px 10px;
 }
 
 .v2-fusion-surface .fus-runs-card-main {
@@ -975,7 +975,7 @@ button.fus-reconcile-row:hover {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   min-width: 0;
   color: var(--fus-muted);
   font-size: 10px;

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -161,7 +161,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--sp-1);
-  padding: 2px 7px;
+  padding: 2px 8px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   font-size: var(--fs-xs);

--- a/dashboard/src/styles/ide-v2.css
+++ b/dashboard/src/styles/ide-v2.css
@@ -111,7 +111,7 @@
 .ide-v2-view {
   font-family: var(--font-ui);
   font-size: 11px;
-  padding: 5px 12px;
+  padding: 6px 12px;
   border-radius: var(--radius-sm);
   border: 1px solid transparent;
   background: none;
@@ -141,7 +141,7 @@
 .ide-v2-presence {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   flex: none;
   min-width: 0;
 }
@@ -256,7 +256,7 @@
 
 .ide-v2-tree .ide-explorer {
   height: 100%;
-  padding: 10px 7px;
+  padding: 10px 8px;
   border-right: 0;
   background: transparent;
 }
@@ -278,7 +278,7 @@
 .ide-v2-tree .ide-explorer-row {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   width: 100%;
   padding: 4px 8px;
   border-radius: var(--radius-sm);
@@ -327,8 +327,8 @@
   flex: none;
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 7px 14px;
+  gap: 8px;
+  padding: 8px 14px;
   border-bottom: 1px solid var(--border-soft);
   background: var(--bg-sunken);
   font-family: var(--font-mono);
@@ -380,14 +380,14 @@
   flex: none;
   display: flex;
   gap: 2px;
-  padding: 9px 10px 0;
+  padding: 10px 10px 0;
   border-bottom: 1px solid var(--border-soft);
 }
 
 .ide-v2-rail-tab {
   font-family: var(--font-ui);
   font-size: 11px;
-  padding: 6px 11px;
+  padding: 6px 12px;
   border: 0;
   background: none;
   color: var(--text-dim);
@@ -424,24 +424,24 @@
 }
 
 .ide-v2-rail .ide-plane-context-stack {
-  padding: 11px 12px;
+  padding: 12px 12px;
   overflow-y: visible;
   border-bottom: 1px solid var(--border-soft);
 }
 
 .ide-v2-rail .ide-plane-primary-rail {
-  padding: 11px 12px;
+  padding: 12px 12px;
   border-bottom: 1px solid var(--border-soft);
 }
 
 .ide-v2-rail .ide-plane-activity {
-  padding: 11px 12px;
+  padding: 12px 12px;
   flex: 1;
   min-height: 0;
 }
 
 .ide-v2-rail .ide-plane-cursors {
-  padding: 11px 12px;
+  padding: 12px 12px;
   display: grid;
   gap: 10px;
 }
@@ -456,7 +456,7 @@
 .ide-cursor-collision-list {
   display: flex;
   flex-wrap: wrap;
-  gap: 5px;
+  gap: 6px;
 }
 
 .ide-cursor-collision-list > span {
@@ -487,7 +487,7 @@
 .ide-cursor-rail-row {
   display: grid;
   gap: 6px;
-  padding: 9px;
+  padding: 10px;
   border: 1px solid var(--border-soft);
   border-left: 3px solid var(--ide-cursor-color, var(--volt));
   border-radius: var(--radius-md);
@@ -572,7 +572,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 5px 14px;
+  padding: 6px 14px;
   cursor: pointer;
   font-family: var(--font-mono);
   font-size: 10.5px;

--- a/dashboard/src/styles/indicators-v2.css
+++ b/dashboard/src/styles/indicators-v2.css
@@ -24,7 +24,7 @@
 .loading-row {
   display: inline-flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
   font-family: var(--font-ui);
   font-size: 12.5px;
   color: var(--text-mid);

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -176,7 +176,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-roster-search {
   width: 100%;
   font-size: var(--fs-13);
-  padding: 8px 11px;
+  padding: 8px 12px;
   background: var(--color-bg-page);
   color: var(--color-fg-primary);
   border: 1px solid var(--color-border-default);
@@ -190,7 +190,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 10px 14px 11px;
+  padding: 10px 14px 12px;
   border-bottom: 1px solid var(--color-border-divider);
   background: color-mix(in oklab, var(--color-bg-surface) 38%, transparent);
 }
@@ -212,7 +212,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 }
 .kw-roster-stat {
   min-width: 0;
-  padding: 6px 7px;
+  padding: 6px 8px;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-page);
@@ -239,13 +239,13 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   display: flex;
   min-width: 0;
   flex-wrap: wrap;
-  gap: 5px;
+  gap: 6px;
 }
 .kw-roster-flags span {
   color: var(--color-fg-muted);
   border: 1px solid var(--color-border-default);
   border-radius: 9999px;
-  padding: 2px 7px;
+  padding: 2px 8px;
   font-family: var(--font-mono);
   font-size: var(--fs-10);
   white-space: nowrap;
@@ -254,12 +254,12 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-roster-flags .gate { color: var(--color-status-warn); border-color: rgb(var(--color-status-warn-glow) / 0.38); background: rgb(var(--color-status-warn-glow) / 0.09); }
 .kw-roster-flags .ctx { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); background: var(--accent-10); }
 
-.kw-roster-filters { display: flex; gap: 5px; padding: 10px 14px; flex-wrap: wrap; border-bottom: 1px solid var(--color-border-divider); }
+.kw-roster-filters { display: flex; gap: 6px; padding: 10px 14px; flex-wrap: wrap; border-bottom: 1px solid var(--color-border-divider); }
 .kw-rfilter {
   font-size: var(--fs-11); letter-spacing: 0.06em; text-transform: uppercase;
   padding: 4px 10px; border-radius: 9999px; cursor: pointer;
   border: 1px solid var(--color-border-default); background: transparent; color: var(--color-fg-secondary);
-  display: inline-flex; gap: 5px; align-items: center;
+  display: inline-flex; gap: 6px; align-items: center;
   transition: color .15s, border-color .15s, background .15s;
 }
 .kw-rfilter:hover { color: var(--color-fg-primary); border-color: var(--color-border-strong); }
@@ -280,7 +280,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-roster-sort:focus { border-color: var(--color-accent-fg-dim); }
 .kw-roster-sort option { background: var(--color-bg-elevated); color: var(--color-fg-primary); }
 
-.kw-roster-list { flex: 1; overflow-y: auto; padding: 9px 8px; }
+.kw-roster-list { flex: 1; overflow-y: auto; padding: 10px 8px; }
 .kw-roster-mini-list { display: flex; flex: 1; flex-direction: column; align-items: center; gap: 8px; overflow-y: auto; padding: 12px; }
 .kw-roster-group {
   display: flex; align-items: center; gap: 6px;
@@ -314,7 +314,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
      so more keepers fit on screen. align-items stays `start` (not the
      standalone's `center`) because the live row carries a 3rd work-preview
      line the standalone's 2-line row does not. */
-  padding: 8px 9px; border-radius: var(--r-2); cursor: pointer;
+  padding: 8px 10px; border-radius: var(--r-2); cursor: pointer;
   border: 1px solid transparent; background: transparent;
   transition: background .14s, border-color .14s;
   position: relative;
@@ -335,7 +335,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-kp-meta { min-width: 0; }
 .kw-kp-name { font-weight: var(--fw-bold); font-size: 15px; color: var(--color-fg-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .kw-kp-sub { display: flex; align-items: center; gap: 6px; font-size: var(--fs-12); color: var(--color-fg-secondary); margin-top: 3px; min-width: 0; }
-.kw-kp-state { display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
+.kw-kp-state { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
 .kw-kp-handle { font-family: var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .kw-kp-work { margin-top: 4px; font-size: var(--fs-12); color: var(--color-fg-secondary); line-height: 1.45; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; padding-top: 2px; }
@@ -380,7 +380,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   position: absolute;
   z-index: var(--z-modal);
   min-width: 190px;
-  padding: 5px;
+  padding: 6px;
   border: 1px solid var(--color-border-strong);
   border-radius: var(--r-2);
   background: var(--color-bg-panel-alt);
@@ -390,7 +390,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 7px 9px 8px;
+  padding: 8px 10px 8px;
   border-bottom: 1px solid var(--color-border-divider);
   margin-bottom: 4px;
   color: var(--color-fg-primary);
@@ -401,8 +401,8 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   display: flex;
   width: 100%;
   align-items: center;
-  gap: 9px;
-  padding: 8px 9px;
+  gap: 10px;
+  padding: 8px 10px;
   border: 0;
   border-radius: var(--r-1);
   background: transparent;
@@ -480,7 +480,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
  * what made the name + pill overflow onto the buttons. Below this width the
  * actions wrap to their own row instead (see .kw-chat-head flex-wrap). */
 .kw-chat-id { min-width: 9rem; flex: 1; }
-.kw-chat-name-row { display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
+.kw-chat-name-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
 /* Back-to-roster affordance: only meaningful on the single-pane mobile layout
  * (shown at ≤860px in the conversation media block). On desktop the roster is
  * always visible, so the button is hidden. */
@@ -493,7 +493,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 
 .kw-state-pill {
   display: inline-flex; align-items: center; gap: 6px;
-  font-size: var(--fs-12); font-weight: var(--fw-med); letter-spacing: 0.02em; padding: 5px 11px; border-radius: 9999px;
+  font-size: var(--fs-12); font-weight: var(--fw-med); letter-spacing: 0.02em; padding: 6px 12px; border-radius: 9999px;
   background: var(--color-bg-surface); border: 1px solid var(--color-border-default); color: var(--color-fg-secondary);
 }
 .kw-state-pill.run { color: var(--color-status-ok); border-color: rgb(var(--color-status-ok-glow) / 0.45); background: rgb(var(--color-status-ok-glow) / 0.10); }
@@ -501,7 +501,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-state-pill.bad { color: var(--color-status-err); border-color: rgb(var(--color-status-err-glow) / 0.50); background: rgb(var(--color-status-err-glow) / 0.12); }
 .kw-state-pill.off { color: var(--color-fg-muted); }
 
-.kw-chat-actions { display: flex; gap: 7px; align-items: center; flex: none; }
+.kw-chat-actions { display: flex; gap: 8px; align-items: center; flex: none; }
 .kw-chat-command-icons {
   display: flex;
   align-items: center;
@@ -564,7 +564,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   min-width: 190px;
   flex-direction: column;
   gap: 2px;
-  padding: 5px;
+  padding: 6px;
   border: 1px solid var(--color-border-strong);
   border-radius: var(--r-2);
   background: var(--color-bg-panel-alt);
@@ -574,8 +574,8 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   display: flex;
   width: 100%;
   align-items: center;
-  gap: 9px;
-  padding: 8px 9px;
+  gap: 10px;
+  padding: 8px 10px;
   border: 0;
   border-radius: var(--r-1);
   background: transparent;
@@ -597,7 +597,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 }
 .kw-act {
   font-size: var(--fs-12); font-weight: var(--fw-med); letter-spacing: 0.02em;
-  padding: 7px 12px; border-radius: var(--r-1); cursor: pointer;
+  padding: 8px 12px; border-radius: var(--r-1); cursor: pointer;
   border: 1px solid var(--color-border-default); background: var(--color-bg-surface); color: var(--color-fg-secondary);
   white-space: nowrap; transition: color .15s, border-color .15s, background .15s;
 }
@@ -761,7 +761,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
  * horizontal scroll strip instead of overflowing. The "← 키퍼" back button
  * appears here as the pane-switch affordance. */
 @media (max-width: 860px) {
-  .kw-chat-head { flex-wrap: wrap; padding: 9px 14px; gap: 8px 10px; }
+  .kw-chat-head { flex-wrap: wrap; padding: 10px 14px; gap: 8px 10px; }
   .kw-chat-back { display: inline-flex; align-items: center; }
   .kw-chat-id { flex: 1 1 auto; }
   .kw-chat-actions {
@@ -796,7 +796,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
  * conversation is visible at once — the prior values left the transcript
  * feeling cramped (few messages on screen) despite filling the column. */
 .kw-thread-inner .chat-transcript {
-  gap: 22px;
+  gap: 24px;
   padding-left: 40px;
   padding-right: 40px;
   padding-top: 20px;
@@ -827,13 +827,13 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   border-left: 1px solid var(--color-border-default);
   background: var(--color-bg-panel-alt);
 }
-.kw-rail-scroll { overflow-y: auto; padding: 20px; display: flex; flex-direction: column; gap: 22px; }
+.kw-rail-scroll { overflow-y: auto; padding: 20px; display: flex; flex-direction: column; gap: 24px; }
 .kw-sec h4 {
   font-weight: var(--fw-bold); text-transform: uppercase; letter-spacing: 0.12em;
-  font-size: var(--fs-12); color: var(--color-fg-primary); margin: 0 0 9px;
-  display: flex; align-items: center; gap: 7px;
+  font-size: var(--fs-12); color: var(--color-fg-primary); margin: 0 0 10px;
+  display: flex; align-items: center; gap: 8px;
 }
-.kw-card { background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-2); padding: 13px 14px; }
+.kw-card { background: var(--color-bg-surface); border: 1px solid var(--color-border-default); border-radius: var(--r-2); padding: 14px 14px; }
 
 .kw-vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--color-border-divider); border: 1px solid var(--color-border-default); border-radius: var(--r-2); overflow: hidden; }
 .kw-vitals.single { grid-template-columns: 1fr; }
@@ -842,7 +842,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-vital .vk { font-size: var(--fs-11); letter-spacing: 0.1em; text-transform: uppercase; color: var(--color-fg-secondary); font-weight: var(--fw-bold); }
 .kw-vital .vv { font-family: var(--font-mono); font-size: 15px; font-weight: var(--fw-semi); color: var(--color-fg-primary); margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-.kw-meter-wrap { position: relative; margin-top: 18px; }
+.kw-meter-wrap { position: relative; margin-top: 20px; }
 .kw-meter { height: 7px; border-radius: 9999px; background: var(--color-bg-page); border: 1px solid var(--color-border-divider); overflow: hidden; }
 .kw-meter > span { display: block; height: 100%; background: linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg)); }
 .kw-meter.hot > span { background: linear-gradient(90deg, var(--color-status-warn), var(--color-status-err)); }
@@ -852,7 +852,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   font-style: normal; font-size: 8.5px; letter-spacing: 0.04em; white-space: nowrap;
   color: var(--color-status-warn); opacity: 0.85;
 }
-.kw-ctx-tok { display: flex; align-items: baseline; gap: 5px; margin-top: 8px; font-size: var(--fs-12); }
+.kw-ctx-tok { display: flex; align-items: baseline; gap: 6px; margin-top: 8px; font-size: var(--fs-12); }
 .kw-ctx-tok .mono { font-family: var(--font-mono); color: var(--color-fg-primary); }
 .kw-ctx-tok .lbl { margin-left: auto; color: var(--color-fg-secondary); font-size: var(--fs-11); }
 .kw-ctx-meta {
@@ -877,7 +877,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   font-size: var(--fs-13);
 }
 
-.kw-list { display: flex; flex-direction: column; gap: 7px; }
+.kw-list { display: flex; flex-direction: column; gap: 8px; }
 .kw-list-empty { font-size: var(--fs-13); color: var(--color-fg-secondary); }
 .kw-tasktag {
   display: grid;
@@ -885,10 +885,10 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
     "task-id task-state"
     "task-title task-title";
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 5px 8px;
+  gap: 6px 8px;
   align-items: start;
   width: 100%;
-  padding: 10px 11px;
+  padding: 10px 12px;
   border-radius: var(--r-1);
   background: var(--color-bg-elevated);
   border: 1px solid var(--color-border-divider);
@@ -940,7 +940,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-toolcall.open { background: var(--color-bg-elevated); border: 1px solid var(--color-border-divider); }
 .kw-toolcall-head {
   display: flex; align-items: center; gap: 8px; width: 100%;
-  padding: 4px 7px; border-radius: var(--r-1); cursor: pointer;
+  padding: 4px 8px; border-radius: var(--r-1); cursor: pointer;
   background: none; border: none; text-align: left; color: var(--color-fg-secondary);
   font-size: var(--fs-13);
 }
@@ -982,7 +982,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-detail { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--color-bg-page); }
 .kw-detail-head {
   flex: none; display: flex; align-items: center; gap: 10px;
-  padding: 12px 18px; border-bottom: 1px solid var(--color-border-default);
+  padding: 12px 20px; border-bottom: 1px solid var(--color-border-default);
   background: var(--color-bg-panel-alt);
 }
 .kw-detail-head strong {
@@ -1014,7 +1014,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
     width: min(100vw, 380px);
   }
   .kw-rail-scroll {
-    gap: 18px;
+    gap: 20px;
     padding: 16px 14px;
   }
   .kw-detail-head {
@@ -1062,10 +1062,10 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 }
 
 /* ════ ATTENTION (rail, top) ════════════════════════════════════ */
-.kw-att-list { display: flex; flex-direction: column; gap: 7px; }
+.kw-att-list { display: flex; flex-direction: column; gap: 8px; }
 .kw-att-item {
   display: flex; align-items: center; gap: 8px;
-  padding: 9px 11px; border-radius: var(--r-1); font-size: 12.5px;
+  padding: 10px 12px; border-radius: var(--r-1); font-size: 12.5px;
   background: var(--color-bg-elevated); border: 1px solid var(--color-border-divider); color: var(--color-fg-primary);
 }
 .kw-att-item.bad { border-color: rgb(var(--color-status-err-glow) / 0.35); background: rgb(var(--color-status-err-glow) / 0.1); color: var(--color-fg-primary); }

--- a/dashboard/src/styles/layers.css
+++ b/dashboard/src/styles/layers.css
@@ -22,7 +22,7 @@
   flex-shrink: 0;
 }
 .layer-toggle {
-  display: inline-flex; align-items: center; gap: 5px;
+  display: inline-flex; align-items: center; gap: 6px;
   padding: 2px 8px;
   height: 20px;
   border: 1px solid var(--color-border-strong);

--- a/dashboard/src/styles/layout.css
+++ b/dashboard/src/styles/layout.css
@@ -36,7 +36,7 @@
 .topbar-spacer { flex: 1; }
 .topbar-pills { display: flex; gap: var(--sp-2); flex-shrink: 0; }
 .topbar-pill {
-  font-size: var(--fs-12); padding: 3px 9px;
+  font-size: var(--fs-12); padding: 3px 10px;
   border: 1px solid var(--color-border-strong); border-radius: var(--r-1);
   color: var(--color-fg-secondary); font-variant-numeric: tabular-nums;
 }

--- a/dashboard/src/styles/memory-v2.css
+++ b/dashboard/src/styles/memory-v2.css
@@ -29,11 +29,11 @@
 .mg-entry {
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
   flex-wrap: wrap;
   font-size: 11px;
   color: var(--text-mid);
-  padding: 7px 11px;
+  padding: 8px 12px;
   border: 1px solid var(--border-main);
   border-radius: var(--radius-sm);
   background: var(--bg-panel-alt);
@@ -69,7 +69,7 @@
   border: 1px solid var(--border-main);
   border-left: 2.5px solid var(--nc);
   border-radius: var(--radius-md);
-  padding: 8px 10px 9px;
+  padding: 8px 10px 10px;
   box-shadow: var(--shadow-card);
   transition: 0.16s;
 }
@@ -79,7 +79,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 6px;
-  margin-bottom: 5px;
+  margin-bottom: 6px;
 }
 
 .mg-type {
@@ -114,13 +114,13 @@
   line-height: 1.32;
   color: var(--text-bright);
   text-wrap: pretty;
-  margin-bottom: 7px;
+  margin-bottom: 8px;
 }
 
 .mg-node-foot {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
 }
 
 .mg-node-foot .ns {
@@ -276,7 +276,7 @@
   border: 1px solid var(--border-main);
   border-left: 2.5px solid var(--nc);
   border-radius: var(--radius-md);
-  padding: 9px 11px;
+  padding: 10px 12px;
 }
 
 .mg-step.is-anchor .mg-step-card {
@@ -286,7 +286,7 @@
 
 .mg-step-card .mg-title {
   font-size: 12.5px;
-  margin-bottom: 7px;
+  margin-bottom: 8px;
 }
 
 .mg-anchor-tag {
@@ -294,7 +294,7 @@
   color: var(--volt-strong);
   background: var(--volt-wash);
   border: 1px solid color-mix(in oklab, var(--volt) 32%, transparent);
-  padding: 1px 7px;
+  padding: 1px 8px;
   border-radius: var(--radius-pill);
 }
 
@@ -313,7 +313,7 @@
 .mg-leg {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
 }
 
 .mg-leg .d {
@@ -342,7 +342,7 @@
 .gd-head-l {
   display: flex;
   align-items: flex-start;
-  gap: 11px;
+  gap: 12px;
   min-width: 0;
   flex: 1;
 }
@@ -426,7 +426,7 @@
 .gd-snapwrap {
   display: flex;
   flex-direction: column;
-  gap: 9px;
+  gap: 10px;
 }
 
 .gd-prog {
@@ -446,7 +446,7 @@
 .gd-snaps {
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 
@@ -457,7 +457,7 @@
   color: var(--text-dim);
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
 }
 
 .gd-snaparr {
@@ -511,7 +511,7 @@
 
 .gd-cell {
   background: var(--bg-panel-alt);
-  padding: 9px 8px;
+  padding: 10px 8px;
   text-align: center;
 }
 
@@ -532,7 +532,7 @@
 .gd-groups {
   display: flex;
   flex-direction: column;
-  gap: 11px;
+  gap: 12px;
 }
 
 .gd-group {
@@ -573,7 +573,7 @@
   border: 1px solid var(--border-main);
   border-left: 2.5px solid var(--nc);
   border-radius: var(--radius-sm);
-  padding: 8px 11px;
+  padding: 8px 12px;
 }
 
 .gd-crow.st-ctx {
@@ -596,7 +596,7 @@
 .gd-cmeta {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   margin-top: 4px;
   font-size: 10px;
   color: var(--text-mid);

--- a/dashboard/src/styles/primitives-v2.css
+++ b/dashboard/src/styles/primitives-v2.css
@@ -50,7 +50,7 @@
 .rfilter {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   font-family: var(--font-sans);
   font-size: 11px;
   font-weight: 500;
@@ -96,7 +96,7 @@
   font-weight: var(--fw-med);
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  padding: 4px 11px;
+  padding: 4px 12px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--color-border-default);
   background: transparent;
@@ -125,12 +125,12 @@
 .suggestion-chip {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   font-family: var(--font-sans);
   font-size: 12px;
   line-height: 1.3;
   text-align: left;
-  padding: 7px 13px;
+  padding: 8px 14px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--color-border);
   background: var(--color-card);
@@ -227,7 +227,7 @@
 
 .vital {
   background: var(--color-bg-elevated);
-  padding: 9px 11px;
+  padding: 10px 12px;
 }
 
 .vital .vk {
@@ -260,7 +260,7 @@
    ════════════════════════════════════════════════════════════════ */
 .stat-cell {
   background: var(--color-bg-surface);
-  padding: 13px 15px;
+  padding: 14px 16px;
 }
 
 .stat-cell-k {
@@ -276,7 +276,7 @@
   font-variant-numeric: tabular-nums;
   font-size: var(--fs-20);
   color: var(--color-fg-primary);
-  margin-top: 5px;
+  margin-top: 6px;
 }
 
 .stat-cell-v small {

--- a/dashboard/src/styles/primitives.css
+++ b/dashboard/src/styles/primitives.css
@@ -29,7 +29,7 @@
 .chip.is-ghost { background: transparent; border-color: var(--color-border-strong); color: var(--color-fg-secondary); }
 
 /* chip size variants */
-.chip.sm { height: 16px; padding: 0 5px; font-size: var(--fs-10); }
+.chip.sm { height: 16px; padding: 0 6px; font-size: var(--fs-10); }
 .chip.lg { height: 22px; padding: 0 10px; font-size: var(--fs-12); }
 
 /* chip with leading dot */

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -26,7 +26,7 @@
 }
 
 .set-nav-h {
-  padding: 18px 18px 14px;
+  padding: 20px 20px 14px;
   border-bottom: 1px solid var(--border-soft);
   margin-bottom: 8px;
 }
@@ -46,7 +46,7 @@
   letter-spacing: 0.14em;
   font-size: 19px;
   color: var(--text-bright);
-  margin: 4px 0 5px;
+  margin: 4px 0 6px;
 }
 
 .set-nav-sub {
@@ -60,7 +60,7 @@
   justify-content: space-between;
   gap: 8px;
   margin: 1px 8px;
-  padding: 9px 11px;
+  padding: 10px 12px;
   border-radius: var(--radius-sm);
   background: none;
   border: 1px solid transparent;
@@ -106,7 +106,7 @@
 .set-nav-group {
   display: flex;
   flex-direction: column;
-  margin-bottom: 5px;
+  margin-bottom: 6px;
 }
 
 .set-nav-glabel {
@@ -115,7 +115,7 @@
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--text-dim);
-  padding: 13px 19px 4px;
+  padding: 14px 20px 4px;
 }
 
 .set-nav-note {
@@ -178,7 +178,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 22px 28px 16px;
+  padding: 24px 28px 16px;
   border-bottom: 1px solid var(--border-soft);
   position: sticky;
   top: 0;
@@ -214,7 +214,7 @@
 }
 
 .set-section-state {
-  padding: 7px 12px;
+  padding: 8px 12px;
 }
 
 .set-section-state.live {
@@ -223,7 +223,7 @@
 }
 
 .set-preview-badge {
-  padding: 6px 11px;
+  padding: 6px 12px;
   border-style: dashed;
 }
 
@@ -262,7 +262,7 @@
   background: var(--bg-sunken);
   color: var(--text-dim);
   font-size: 10.5px;
-  padding: 5px 8px;
+  padding: 6px 8px;
 }
 
 @media (max-width: 900px) {
@@ -284,7 +284,7 @@
   display: flex;
   align-items: center;
   gap: 14px;
-  padding: 13px 0;
+  padding: 14px 0;
   border-top: 1px solid var(--border-soft);
 }
 
@@ -318,7 +318,7 @@
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-dim);
-  margin: 18px 0 2px;
+  margin: 20px 0 2px;
 }
 
 .set-link {
@@ -334,7 +334,7 @@
 
 .set-mcp-detail {
   margin: -4px 0 4px;
-  padding: 8px 11px;
+  padding: 8px 12px;
   background: var(--bg-sunken);
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-xs);
@@ -347,7 +347,7 @@
 .set-verify {
   font-family: var(--font-ui);
   font-size: 11px;
-  padding: 6px 11px;
+  padding: 6px 12px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-main);
   background: var(--bg-card);
@@ -374,7 +374,7 @@
 .set-path {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
 }
 
 .set-path .set-input {
@@ -394,7 +394,7 @@
 .set-rt {
   border: 1px solid var(--border-main);
   border-radius: var(--radius-sm);
-  padding: 11px 13px;
+  padding: 12px 14px;
   margin-top: 10px;
   background: var(--bg-card);
 }
@@ -403,7 +403,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 9px;
+  margin-bottom: 10px;
 }
 
 .set-rt-name {
@@ -418,7 +418,7 @@
   text-transform: uppercase;
   color: var(--text-dim);
   border: 1px solid var(--border-main);
-  padding: 1px 7px;
+  padding: 1px 8px;
   border-radius: var(--radius-pill);
 }
 
@@ -434,7 +434,7 @@
 .set-rt-row {
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
   margin-top: 6px;
 }
 
@@ -457,7 +457,7 @@
 .log-filters {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   padding: 8px 10px;
   border-bottom: 1px solid var(--border-soft);
   background: var(--bg-panel);
@@ -466,7 +466,7 @@
 .log-f {
   font-family: var(--font-ui);
   font-size: 11px;
-  padding: 4px 11px;
+  padding: 4px 12px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--border-main);
   background: transparent;
@@ -614,7 +614,7 @@
 .set-seg-b {
   font-family: var(--font-mono);
   font-size: 11px;
-  padding: 5px 11px;
+  padding: 6px 12px;
   background: transparent;
   color: var(--text-dim);
   border: 0;
@@ -697,7 +697,7 @@
 .set-input {
   font-family: var(--font-mono);
   font-size: 12px;
-  padding: 7px 10px;
+  padding: 8px 10px;
   background: var(--bg-sunken);
   color: var(--text-primary);
   border: 1px solid var(--border-main);
@@ -738,7 +738,7 @@
 .set-add {
   margin-top: 12px;
   width: 100%;
-  padding: 9px;
+  padding: 10px;
   background: var(--bg-sunken);
   border: 1px dashed var(--border-highlight);
   border-radius: var(--radius-sm);
@@ -759,7 +759,7 @@
   font-family: var(--font-ui);
   font-size: 11px;
   letter-spacing: 0.05em;
-  padding: 7px 12px;
+  padding: 8px 12px;
   border-radius: var(--radius-sm);
   cursor: pointer;
   border: 1px solid var(--border-main);

--- a/dashboard/src/styles/states.css
+++ b/dashboard/src/styles/states.css
@@ -56,7 +56,7 @@
   background: var(--bg-sunken);
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-sm);
-  padding: 7px 11px;
+  padding: 8px 12px;
 }
 
 .kv-state-a {
@@ -87,7 +87,7 @@
 .kv-skel-row {
   display: flex;
   align-items: center;
-  gap: 11px;
+  gap: 12px;
 }
 
 .kv-skel-av {

--- a/dashboard/src/styles/surfaces-v2.css
+++ b/dashboard/src/styles/surfaces-v2.css
@@ -60,7 +60,7 @@
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 
 .surf-head h1 {
@@ -78,11 +78,11 @@
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--text-dim);
-  margin-bottom: 5px;
+  margin-bottom: 6px;
 }
 
 .surf-sub {
-  margin-top: 5px;
+  margin-top: 6px;
   font-size: 12px;
   color: var(--text-dim);
 }
@@ -212,7 +212,7 @@
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 
 .ov-head h1 {
@@ -224,7 +224,7 @@
 }
 
 .ov-sub {
-  margin-top: 5px;
+  margin-top: 6px;
   font-size: 12px;
   color: var(--text-dim);
 }
@@ -261,7 +261,7 @@
 
 .ov-kpi {
   background: var(--bg-panel);
-  padding: 13px 15px;
+  padding: 14px 16px;
 }
 
 .ov-kpi-k {
@@ -276,7 +276,7 @@
   font-variant-numeric: tabular-nums;
   font-size: 23px;
   color: var(--text-bright);
-  margin-top: 5px;
+  margin-top: 6px;
 }
 
 .ov-kpi-v small {
@@ -354,14 +354,14 @@
 .ov-attn-list {
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 8px;
 }
 
 .ov-attn-row {
   display: flex;
   align-items: center;
-  gap: 11px;
-  padding: 9px 10px;
+  gap: 12px;
+  padding: 10px 10px;
   border-radius: var(--radius-sm);
   background: var(--bg-card);
   border: 1px solid var(--border-soft);
@@ -385,7 +385,7 @@
   font-size: 13px;
   color: var(--text-bright);
   display: flex;
-  gap: 9px;
+  gap: 10px;
   align-items: baseline;
 }
 
@@ -411,7 +411,7 @@
   flex: none;
   font-family: var(--font-ui);
   font-size: 11px;
-  padding: 6px 11px;
+  padding: 6px 12px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-main);
   background: var(--bg-panel-alt);
@@ -455,9 +455,9 @@
 
 .ov-tel-foot {
   display: flex;
-  gap: 22px;
+  gap: 24px;
   margin-top: 12px;
-  padding-top: 11px;
+  padding-top: 12px;
   border-top: 1px solid var(--border-soft);
 }
 
@@ -479,7 +479,7 @@
 .ov-fleet-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(215px, 1fr));
-  gap: 9px;
+  gap: 10px;
 }
 
 .ov-keeper {
@@ -487,7 +487,7 @@
   background: var(--bg-card);
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-sm);
-  padding: 11px 12px;
+  padding: 12px 12px;
   cursor: pointer;
   transition: 0.14s;
   min-width: 0;
@@ -503,7 +503,7 @@
 .ov-keeper-top {
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
 }
 
 .ov-keeper-id {
@@ -524,7 +524,7 @@
 .ov-keeper-state {
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   font-family: var(--font-mono);
   font-size: 10px;
   color: var(--text-dim);
@@ -537,7 +537,7 @@
   font-weight: 600;
   min-width: 16px;
   text-align: center;
-  padding: 1px 5px;
+  padding: 1px 6px;
   border-radius: var(--radius-pill);
   color: var(--status-bad);
   background: color-mix(in oklab, var(--status-bad) 16%, transparent);
@@ -558,7 +558,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 7px;
+  margin-top: 8px;
   font-size: 10px;
   color: var(--text-dim);
 }

--- a/dashboard/src/styles/v2-logs.css
+++ b/dashboard/src/styles/v2-logs.css
@@ -39,7 +39,7 @@
   flex: none;
   align-items: flex-start;
   gap: 24px;
-  padding: 22px 26px 16px;
+  padding: 24px 26px 16px;
 }
 
 .v2-logs-head-main {
@@ -74,7 +74,7 @@
   min-width: 74px;
   flex-direction: column;
   gap: 3px;
-  padding: 8px 13px;
+  padding: 8px 14px;
   border: 1px solid var(--border-main);
   border-radius: var(--radius-sm);
   background: var(--bg-card);
@@ -179,7 +179,7 @@
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 9px;
+  gap: 10px;
   color: var(--color-fg-muted);
   font-size: 11px;
 }
@@ -208,7 +208,7 @@
 }
 
 .v2-logs-count {
-  padding: 5px 10px;
+  padding: 6px 10px;
   border: 1px solid var(--border-main);
   border-radius: var(--radius-pill);
   color: var(--text-mid);
@@ -219,7 +219,7 @@
 .v2-logs-live {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 8px;
   color: var(--text-dim);
   font-size: 11px;
 }
@@ -274,7 +274,7 @@
   flex: none;
   align-items: center;
   gap: 14px;
-  padding: 9px 26px;
+  padding: 10px 26px;
   border-top: 1px solid var(--border-main);
   color: var(--color-fg-muted);
   border-bottom: 1px solid var(--color-border-divider);
@@ -331,7 +331,7 @@
   grid-template-columns: var(--v2-logs-cols);
   align-items: center;
   gap: 14px;
-  padding: 9px 26px;
+  padding: 10px 26px;
   border: 0;
   background: transparent;
   color: inherit;
@@ -353,7 +353,7 @@
 .v2-logs-who {
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
   min-width: 0;
 }
 
@@ -445,7 +445,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  padding: 0 26px 9px calc(26px + 92px + 14px);
+  padding: 0 26px 10px calc(26px + 92px + 14px);
 }
 
 .v2-logs-detail {
@@ -458,7 +458,7 @@
 .v2-logs-detail-grid {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px 22px;
+  gap: 6px 24px;
 }
 
 .v2-logs-detail-grid div {
@@ -531,7 +531,7 @@
   justify-content: space-between;
   gap: 12px;
   min-height: 34px;
-  padding: 7px 12px;
+  padding: 8px 12px;
   color: var(--text-mid);
   cursor: pointer;
   font-size: 12px;
@@ -584,7 +584,7 @@
   .v2-logs-head {
     flex-direction: column;
     gap: 14px;
-    padding: 18px 18px 14px;
+    padding: 20px 20px 14px;
   }
 
   .v2-logs-stats {
@@ -598,8 +598,8 @@
   .v2-logs-table-header,
   .v2-logs-line,
   .v2-logs-support {
-    padding-left: 18px;
-    padding-right: 18px;
+    padding-left: 20px;
+    padding-right: 20px;
   }
 
   .v2-logs-advanced {
@@ -612,7 +612,7 @@
   }
 
   .v2-logs-detail {
-    padding-left: 18px;
+    padding-left: 20px;
   }
 }
 
@@ -672,8 +672,8 @@
 
   .v2-logs-inline-links,
   .v2-logs-detail {
-    padding-right: 18px;
-    padding-left: 18px;
+    padding-right: 20px;
+    padding-left: 20px;
   }
 }
 

--- a/dashboard/src/styles/v2-monitoring.css
+++ b/dashboard/src/styles/v2-monitoring.css
@@ -30,7 +30,7 @@
   background:
     linear-gradient(180deg, rgb(var(--brass-glow) / 0.05), transparent 42%),
     var(--color-bg-surface);
-  padding: 13px 14px;
+  padding: 14px 14px;
 }
 
 .v2-monitoring-surface .fl-top {
@@ -79,7 +79,7 @@
   font-size: 11px;
   font-weight: 760;
   line-height: 1;
-  padding: 0 9px;
+  padding: 0 10px;
   white-space: nowrap;
 }
 
@@ -105,7 +105,7 @@
   border-top: 1px solid var(--color-border-default);
   color: var(--color-fg-muted);
   font-size: 11px;
-  padding-top: 9px;
+  padding-top: 10px;
 }
 
 .v2-monitoring-panel,

--- a/dashboard/src/styles/v2-shell.css
+++ b/dashboard/src/styles/v2-shell.css
@@ -155,9 +155,9 @@
 #dashboard-side-rail.v2-shell-rail .nav-link {
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
   margin: 0 8px;
-  padding: 9px 10px;
+  padding: 10px 10px;
   border-radius: 8px;
   border: 1px solid transparent;
   color: var(--v2-text);
@@ -527,7 +527,7 @@ aside.v2-status-tray .tray-action-link {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  padding: 5px 10px;
+  padding: 6px 10px;
   border: 1px solid var(--v2-border);
   border-radius: 6px;
   background: var(--v2-surface-subtle);

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -45,7 +45,7 @@
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 18px;
+  margin-bottom: 20px;
 }
 
 .wk-head h1 {
@@ -63,11 +63,11 @@
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--text-dim);
-  margin-bottom: 7px;
+  margin-bottom: 8px;
 }
 
 .wk-sub {
-  margin-top: 5px;
+  margin-top: 6px;
   font-size: 12px;
   color: var(--text-dim);
 }
@@ -87,7 +87,7 @@
 
 .wk-kpi {
   background: var(--bg-panel);
-  padding: 13px 15px;
+  padding: 14px 16px;
 }
 
 .wk-kpi-k {
@@ -102,7 +102,7 @@
   font-variant-numeric: tabular-nums;
   font-size: 23px;
   color: var(--text-bright);
-  margin-top: 5px;
+  margin-top: 6px;
 }
 
 .wk-kpi-v.ok { color: var(--status-ok); }
@@ -114,20 +114,20 @@
 .wk-horizons {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 20px;
   margin-top: 4px;
 }
 
 .wk-horizon {
   display: flex;
   flex-direction: column;
-  gap: 9px;
+  gap: 10px;
 }
 
 .wk-hz-head {
   display: flex;
   align-items: baseline;
-  gap: 9px;
+  gap: 10px;
   min-height: 22px;
   padding: 0 2px;
 }
@@ -171,7 +171,7 @@
   align-items: center;
   gap: 10px;
   width: 100%;
-  padding: 13px 15px 11px;
+  padding: 14px 16px 12px;
   background: none;
   border: 0;
   cursor: pointer;
@@ -261,7 +261,7 @@
   color: var(--text-mid);
   background: var(--bg-sunken);
   border: 1px solid var(--border-soft);
-  padding: 1px 7px;
+  padding: 1px 8px;
   border-radius: var(--radius-pill);
   font-family: var(--font-mono);
 }
@@ -285,8 +285,8 @@
 .wk-goal-sub {
   display: flex;
   align-items: center;
-  gap: 11px;
-  padding: 0 15px 13px 37px;
+  gap: 12px;
+  padding: 0 16px 14px 37px;
 }
 
 /* ── Segmented progress bar ───────────────────────────────────────────────── */
@@ -330,7 +330,7 @@
 /* ── Job / Task list ──────────────────────────────────────────────────────── */
 .wk-jobs {
   border-top: 1px solid var(--border-soft);
-  padding: 10px 15px 13px;
+  padding: 10px 16px 14px;
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -340,9 +340,9 @@
   font-size: 12px;
   color: var(--text-mid);
   line-height: 1.5;
-  padding: 2px 0 9px;
+  padding: 2px 0 10px;
   border-bottom: 1px dashed var(--border-soft);
-  margin-bottom: 7px;
+  margin-bottom: 8px;
 }
 
 .wk-verifier {
@@ -352,9 +352,9 @@
   gap: 6px;
   font-size: 11px;
   color: var(--text-mid);
-  padding: 2px 0 9px;
+  padding: 2px 0 10px;
   border-bottom: 1px dashed var(--border-soft);
-  margin-bottom: 7px;
+  margin-bottom: 8px;
 }
 
 /* wk-vchip: prototype v2.css:827 — square (radius-xs), volt theme, mono via .mono utility */
@@ -377,7 +377,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 11px 15px;
+  padding: 12px 16px;
   font-size: 13px;
   font-weight: 600;
   color: var(--text-mid);
@@ -391,7 +391,7 @@
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 700;
-  padding: 1px 7px;
+  padding: 1px 8px;
   border-radius: var(--radius-pill);
   background: color-mix(in oklab, var(--status-warn) 12%, transparent);
   border: 1px solid color-mix(in oklab, var(--status-warn) 35%, transparent);
@@ -406,7 +406,7 @@
 
 .wk-backlog-list {
   border-top: 1px solid var(--border-soft);
-  padding: 8px 15px 10px;
+  padding: 8px 16px 10px;
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -453,8 +453,8 @@
 .wk-task {
   display: flex;
   flex-direction: column;
-  gap: 5px;
-  padding: 7px 8px;
+  gap: 6px;
+  padding: 8px 8px;
   border-radius: var(--radius-sm);
 }
 
@@ -672,8 +672,8 @@
 .wk-handoff {
   display: flex;
   flex-direction: column;
-  gap: 5px;
-  padding: 9px 11px;
+  gap: 6px;
+  padding: 10px 12px;
   border-radius: var(--radius-sm);
   background: var(--bg-sunken);
   border: 1px solid var(--border-soft);


### PR DESCRIPTION
# ci:skip-test-coverage

## 목적

`/goal 패딩과 마진에 집중해서 전체 개선` — v2 컴포넌트 stylesheet 전반의 **off-grid spacing을 2px rhythm grid로 전면 de-drift**. skin-v2가 의도한 "one rhythm"을 코드 전반에 일관 적용한다.

## 결정: 2px grid 전면 채택 (사용자 지시)

초기엔 파일별로 "의도된 어휘 vs drift"를 구분하는 selective de-drift를 시도했으나, 병렬 감사 결과 **off-grid 값(5/7/9/11/13/18/22)이 어떤 파일에선 drift, 다른 파일에선 keep으로 판정**되는 모순이 드러났다(값 단위 mass de-drift가 cross-file 비일관성을 만듦). 이를 사용자에게 데이터와 함께 제시했고, 사용자가 **"2px grid 전면 채택"**(보존보다 일관성)을 명시적으로 선택했다.

→ 따라서 component-range off-grid 값을 **모두** 가장 가까운 grid step으로 스냅한다(ties up):

```
grid = {4, 6, 8, 10, 12, 14, 16, 20, 24, 32}
5->6  7->8  9->10  11->12  13->14  15->16  17->16  18->20  19->20  21->20  22->24
```

## theme-agnostic raw px (토큰화 안 함)

값은 **raw px로 유지**하고 `var(--sp-N)`로 토큰화하지 않는다. `--sp`는 **테마 의존**(v2 = 2px-base / paper·styleseed는 `:root` 4px-base에서 해석, 예: `--sp-4` = 16px)이라, 토큰화하면 paper spacing이 silent하게 이동한다(raw `10px` → paper에서 `16px`). px fallback도 무력하다(`:root --sp`가 항상 resolve해서 fallback을 이김). raw de-drift는 **모든 테마에서 spacing이 동일**하게 유지된다.

## 범위

- **포함**: 28개 non-kit v2 stylesheet, 351선언 / 394스냅.
- **제외**:
  - `ds-*-kit`(ds-cockpit/dashboard/viewer-kit) — 별도 4px-base 디자인 시스템. 2px grid 스냅이 그 4px 스케일과 충돌하므로 제외.
  - 구조/레이아웃 값 ≥24px (26/28/30/40/48/80 등) — 컴포넌트 grid 범위 밖.
  - 1/2/3px hairline — 미세 보더/오프셋, 미변경.

가장 많이 바뀐 파일: `keeper-workspace`(37), `connectors-v2`(28), `board-v2`(28), `work-v2`(26), `settings-surface`(24), `dashboard`(24).

### craft-v2 density 콘솔 테스트 갱신

`craft-v2.test.ts`가 chat density 콘솔(spacious/compact)의 패딩 값을 핀으로 고정한다(`.kw-chat-head`/`.chat-bubble`/`.kw-composer-inner`/`.kw-rail` 등). 이 tuned 값들(18/17/21/22/9/11/15px)도 off-grid이고, 사용자가 선택한 "전면 채택"은 tuned 값도 스냅하므로 테스트의 spacious/compact 단언을 **post-snap grid 값으로 갱신**했다(예: spacious `.kw-chat-head` `18px`→`20px`, compact `.kw-composer-inner` `9px 18px`→`10px 20px`, rail `gap 22px`→`24px`). 테스트의 목적(design→live 클래스 리타게팅을 우발적 drift로부터 보호)은 불변이며, 이제 grid 값을 핀한다. 다른 style 테스트는 변경 파일의 spacing을 핀하지 않는다(로컬 `vitest run src/styles/` 13파일/52테스트 green).

density 값은 design 프로토타입에서 포팅된 것으로(주석: "retargeted to live classes, verified ... computed padding + screenshots"), 특정 px가 인체공학적으로 고정되어야 한다는 rationale은 없다. ±1~2px 스냅은 spacious>compact density 관계를 보존한다.

## 검증

- **결정론적 diff 감사**: 변경된 351개 라인 전부 spacing 속성(`padding*/margin*/gap/row-gap/column-gap/inset*`) 위의 유효한 grid 스냅(394건), BAD 0건. var()/calc() 내부 미오염, 비-spacing 속성 미변경.
- **vite build green** — CSS 문법 무결.
- **in-browser 렌더 검증**: 가장 밀집한 정적 chrome(Settings 폼/토글/segmented control)을 **v2(dark) + paper** 두 테마에서 확인 — 레이아웃 동일, collapse/overflow 없음. theme-agnostic 동작을 시각 확정. (데이터 의존 콘텐츠 표면은 backend offline으로 라이브 렌더 미확인이나, 동일 CSS 패턴이며 모든 변경이 붕괴 불가능한 ±2px bounded 스냅.)

## 안티패턴 아님

값 단위 일괄 변환이지만 cap/cooldown/dedup/telemetry-as-fix류 워크어라운드가 아니다. 결정론적 스냅 함수(`/tmp/dedrift2.py`, grid SSOT)로 적용했고, 회귀 방지는 결정론 감사 스크립트로 재현 가능하다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
