### PR TITLE
[RFC-0274 Wave A] Thread Workspace.config.base_path through approval queue

### DIFF
--- a/lib/governance_pipeline.ml
+++ b/lib/governance_pipeline.ml
@@ -308,7 +308,7 @@ let auto_approval_soft_forbidden ~tool_name ~input =
   destructive_tool_or_op ~tool_name ~input
 ;;
 
-let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock ()
+let to_oas_approval_callback ~config ~governance_level ~keeper_name ?meta ?clock ()
   : Agent_sdk.Hooks.approval_callback
   =
   let queue_risk_level = function
@@ -374,7 +374,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
       let runtime_contract =
         Option.map
           (fun keeper_meta ->
-             Keeper_runtime_contract.runtime_contract_json ?config keeper_meta)
+             Keeper_runtime_contract.runtime_contract_json ?config:(Some config) keeper_meta)
           meta
       in
       let sandbox_profile, backend, sandbox_target =
@@ -388,9 +388,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
       in
       let selected_model = selected_model_of_meta meta in
       let risk_level = queue_risk_level risk in
-      let base_path =
-        Option.map (fun (config : Workspace.config) -> config.base_path) config
-      in
+      let base_path = (config : Workspace.config).base_path in
       let hard_forbidden =
         runtime_auto_approval_blocked meta
         || risk = Critical
@@ -408,7 +406,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
         then None
         else
           Keeper_approval_queue.find_matching_rule
-            ?base_path
+            ~base_path
             ~keeper_name
             ~tool_name
             ~input
@@ -421,7 +419,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
       if (not forbidden) && always_approve
       then (
         Keeper_approval_queue.audit_approval_event
-          ?base_path
+          ~base_path
           ~event_type:"auto_approved_always"
           ~id:(Printf.sprintf "auto_always_%s_%s" keeper_name tool_name)
           ~keeper_name
@@ -443,7 +441,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
         match rule_match with
            | Some matched ->
              Keeper_approval_queue.audit_approval_event
-               ?base_path
+               ~base_path
                ~event_type:"auto_approved_rule_match"
                ~id:(Printf.sprintf "auto_%s_%s" keeper_name matched.rule_id)
                ~keeper_name
@@ -467,7 +465,7 @@ let to_oas_approval_callback ?config ~governance_level ~keeper_name ?meta ?clock
                ~keeper_name
                ~tool_name
                ~input
-               ?base_path
+               ~base_path
                ?turn_id
                ?task_id
                ?goal_id

--- a/lib/governance_pipeline.mli
+++ b/lib/governance_pipeline.mli
@@ -104,7 +104,7 @@ val combinatorial_risk_escalation :
     escalate risk to at least High. Otherwise return base_risk unchanged. *)
 
 val to_oas_approval_callback :
-  ?config:Workspace.config ->
+  config:Workspace.config ->
   governance_level:string ->
   keeper_name:string ->
   ?meta:Keeper_meta_contract.keeper_meta ->

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -87,7 +87,7 @@ let audit_today_path base_dir =
   Filename.concat dir day
 ;;
 
-let get_audit_store ?base_path () =
+let get_audit_store ~base_path () =
   let report_failure exn =
     Keeper_fd_pressure.note_exception ~site:"approval_audit.store_create" exn;
     Otel_metric_store.inc_counter
@@ -103,25 +103,20 @@ let get_audit_store ?base_path () =
     None
   in
   try
-    let base =
-      match base_path with
-      | Some base -> base
-      | None -> Env_config_core.base_path ()
-    in
     match
       mutex_protect_allow_reentrant audit_stores_mu (fun () ->
         try
           Ok
-            (match Hashtbl.find_opt audit_stores base with
+            (match Hashtbl.find_opt audit_stores base_path with
              | Some store -> Some store
              | None ->
                let dir =
                  Filename.concat
-                   (Common.masc_dir_from_base_path ~base_path:base)
+                   (Common.masc_dir_from_base_path ~base_path)
                    "audit-approvals"
                in
                let store = Dated_jsonl.create ~base_dir:dir () in
-               Hashtbl.replace audit_stores base store;
+               Hashtbl.replace audit_stores base_path store;
                Some store)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
@@ -135,7 +130,7 @@ let get_audit_store ?base_path () =
 ;;
 
 let audit_approval_event
-      ?base_path
+      ~base_path
       ~event_type
       ~id
       ~keeper_name
@@ -159,7 +154,7 @@ let audit_approval_event
   let decision =
     decision |> Option.map approval_audit_decision_to_string |> Option.value ~default:""
   in
-  match get_audit_store ?base_path () with
+  match get_audit_store ~base_path () with
   | None -> ()
   | Some store ->
     let json =
@@ -203,9 +198,9 @@ let audit_approval_event
       | exn -> record_queue_failure ~keeper_name ~site:"audit_append" ~id ~event_type exn)
 ;;
 
-let audit_rule_event ?base_path ~event_type (rule : approval_rule) =
+let audit_rule_event ~base_path ~event_type (rule : approval_rule) =
   audit_approval_event
-    ?base_path
+    ~base_path
     ~event_type
     ~id:rule.id
     ~keeper_name:rule.keeper_name
@@ -225,11 +220,11 @@ let audit_scan_window ?keeper_name n =
     max 500 (max n 1 * 64)
 ;;
 
-let read_recent_audit ?base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list =
+let read_recent_audit ~base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list =
   if n <= 0
   then []
   else (
-    match get_audit_store ?base_path () with
+    match get_audit_store ~base_path () with
     | None -> []
     | Some store ->
       try
@@ -335,7 +330,7 @@ let create_entry
       ?selected_model
       ?disposition
       ?disposition_reason
-      ?audit_base_path
+      ~audit_base_path
       ~resolver
       ~on_resolution
       ()
@@ -455,7 +450,7 @@ let record_pending (entry : pending_approval) =
     entry.tool_name
     (risk_level_to_string entry.risk_level);
   audit_approval_event
-    ?base_path:entry.audit_base_path
+    ~base_path:entry.audit_base_path
     ~event_type:"pending"
     ~id:entry.id
     ~keeper_name:entry.keeper_name
@@ -474,7 +469,7 @@ let record_pending (entry : pending_approval) =
   broadcast_pending entry
 ;;
 
-let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
+let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
   let decision_str = approval_decision_to_string decision in
   Log.Keeper.info
     "HITL_APPROVAL_RESOLVED: id=%s keeper=%s tool=%s decision=%s"
@@ -483,7 +478,7 @@ let resolve_entry ?base_path (entry : pending_approval) (decision : decision) =
     entry.tool_name
     decision_str;
   audit_approval_event
-    ?base_path
+    ~base_path:base_path
     ~event_type:"resolved"
     ~id:entry.id
     ~keeper_name:entry.keeper_name
@@ -627,7 +622,7 @@ let submit_and_await
       ~tool_name
       ~input
       ~risk_level
-      ?base_path
+      ~base_path
       ?turn_id
       ?task_id
       ?goal_id
@@ -664,7 +659,7 @@ let submit_and_await
       ?selected_model
       ?disposition
       ?disposition_reason
-      ?audit_base_path:base_path
+      ~audit_base_path:base_path
       ~resolver:(Some resolver)
       ~on_resolution:None
       ()
@@ -697,7 +692,7 @@ let submit_and_await
        | `Timeout ->
          let reason = Printf.sprintf "approval timeout after %.0fs" timeout_s in
          audit_approval_event
-           ?base_path:entry.audit_base_path
+           ~base_path:entry.audit_base_path
            ~event_type:"approval_timeout"
            ~id
            ~keeper_name
@@ -724,7 +719,7 @@ let submit_and_await
        | None ->
          let reason = "approval await cancelled before operator decision" in
          audit_approval_event
-           ?base_path:entry.audit_base_path
+           ~base_path:entry.audit_base_path
            ~event_type:"cancelled"
            ~id
            ~keeper_name
@@ -749,7 +744,7 @@ let submit_pending
       ~tool_name
       ~input
       ~risk_level
-      ?base_path
+      ~base_path
       ?turn_id
       ?task_id
       ?goal_id
@@ -806,7 +801,7 @@ let submit_pending
           ?selected_model
           ?disposition
           ?disposition_reason
-          ?audit_base_path:base_path
+          ~audit_base_path:base_path
           ~resolver:None
           ~on_resolution:(Some on_resolution)
           ()
@@ -832,7 +827,7 @@ let resolve_error_to_string = function
   | Already_resolved id -> Printf.sprintf "approval %s already resolved" id
 ;;
 
-let remember_rule_for_entry ?base_path ?created_by (entry : pending_approval) =
+let remember_rule_for_entry ~base_path ?created_by (entry : pending_approval) =
   let rememberable =
     match entry.risk_level with
     | Low | Medium -> true
@@ -844,7 +839,7 @@ let remember_rule_for_entry ?base_path ?created_by (entry : pending_approval) =
     try
       let rule, created =
         upsert_rule
-          ?base_path
+          ~base_path:base_path
           ~keeper_name:entry.keeper_name
           ~tool_name:entry.tool_name
           ~input:entry.input
@@ -856,7 +851,7 @@ let remember_rule_for_entry ?base_path ?created_by (entry : pending_approval) =
           ~source_approval_id:entry.id
           ()
       in
-      if created then audit_rule_event ?base_path ~event_type:"rule_created" rule;
+      if created then audit_rule_event ~base_path:base_path ~event_type:"rule_created" rule;
       Some rule
     with
     | Eio.Cancel.Cancelled _ as e -> raise e
@@ -873,7 +868,7 @@ let remember_rule_for_entry ?base_path ?created_by (entry : pending_approval) =
 ;;
 
 let resolve_with_policy
-      ?base_path
+      ~base_path
       ~id
       ~(decision : Agent_sdk.Hooks.approval_decision)
       ?(remember_rule = false)
@@ -894,10 +889,10 @@ let resolve_with_policy
     let remembered_rule =
       match decision with
       | Agent_sdk.Hooks.Approve when remember_rule ->
-        remember_rule_for_entry ?base_path ?created_by entry
+        remember_rule_for_entry ~base_path ?created_by entry
       | _ -> None
     in
-    resolve_entry ?base_path entry decision;
+    resolve_entry ~base_path entry decision;
     Ok { remembered_rule }
 ;;
 
@@ -906,13 +901,25 @@ let resolve_with_policy
     [Error (Already_resolved _)] if the atomic update found no matching
     entry (concurrent resolve race).
     Called from the dashboard approval HTTP handler
-    ([server_dashboard_http.ml]) and MCP runtime. *)
+    ([server_dashboard_http.ml]) and MCP runtime.
+
+    [base_path] is sourced from the entry's captured [audit_base_path]
+    rather than threaded from the caller: the convenience wrapper takes
+    only an [id], so the entry is the authoritative workspace source
+    (RFC-0274 Wave A). *)
 let resolve ~id ~(decision : Agent_sdk.Hooks.approval_decision)
   : (unit, resolve_error) result
   =
-  match resolve_with_policy ~id ~decision () with
-  | Ok _ -> Ok ()
-  | Error _ as err -> err
+  (* The entry is the authoritative base_path source for the convenience
+     wrapper: it has no caller-threaded [base_path], and the pending map
+     is per-workspace so the entry's captured [audit_base_path] is the
+     workspace that owns the approval. RFC-0274 Wave A. *)
+  match SMap.find_opt id (Atomic.get pending) with
+  | None -> Error (Not_found id)
+  | Some entry ->
+    (match resolve_with_policy ~base_path:entry.audit_base_path ~id ~decision () with
+     | Ok _ -> Ok ()
+     | Error _ as err -> err)
 ;;
 
 (* ── Query ────────────────────────────────────────────────── *)
@@ -1034,7 +1041,7 @@ let expire_stale ~max_wait_s =
          entry.keeper_name
          entry.tool_name;
        audit_approval_event
-         ?base_path:entry.audit_base_path
+         ~base_path:entry.audit_base_path
          ~event_type:"expired"
          ~id
          ~keeper_name:entry.keeper_name

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -44,7 +44,7 @@ type pending_approval =
   ; selected_model : string option
   ; disposition : string option
   ; disposition_reason : string option
-  ; audit_base_path : string option
+  ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
   }
@@ -95,10 +95,10 @@ val approval_audit_decision_to_string : approval_audit_decision -> string
 (** {1 Rule store (persisted)} *)
 
 (** List every persisted rule for the given [base_path]. *)
-val list_rules : ?base_path:string -> unit -> approval_rule list
+val list_rules : base_path:string -> unit -> approval_rule list
 
 (** Render the persisted rules as a dashboard-facing JSON document. *)
-val list_rules_dashboard_json : ?base_path:string -> unit -> Yojson.Safe.t
+val list_rules_dashboard_json : base_path:string -> unit -> Yojson.Safe.t
 
 (** Per-keeper policy summary projection consumed by the dashboard. *)
 val policy_summary_json :
@@ -110,7 +110,7 @@ val policy_summary_json :
     [(keeper_name, tool_name, request_fingerprint)] key. Save errors
     are logged but not surfaced to the caller. *)
 val upsert_rule :
-  ?base_path:string ->
+  base_path:string ->
   keeper_name:string ->
   tool_name:string ->
   input:Yojson.Safe.t ->
@@ -125,12 +125,12 @@ val upsert_rule :
 
 (** Delete the rule whose [id] matches. *)
 val delete_rule :
-  ?base_path:string -> id:string -> unit -> (approval_rule, string) result
+  base_path:string -> id:string -> unit -> (approval_rule, string) result
 
 (** Find a rule that satisfies the given keeper / tool / input
     request, updating [last_matched_at] and [match_count] on hit. *)
 val find_matching_rule :
-  ?base_path:string ->
+  base_path:string ->
   keeper_name:string ->
   tool_name:string ->
   input:Yojson.Safe.t ->
@@ -144,7 +144,7 @@ val find_matching_rule :
 (** {1 Audit log} *)
 
 val audit_approval_event :
-  ?base_path:string ->
+  base_path:string ->
   event_type:string ->
   id:string ->
   keeper_name:string ->
@@ -167,12 +167,12 @@ val audit_approval_event :
   unit
 
 val audit_rule_event :
-  ?base_path:string -> event_type:string -> approval_rule -> unit
+  base_path:string -> event_type:string -> approval_rule -> unit
 
 (** Read recent audit entries (default last 20), optionally filtered
     by keeper. *)
 val read_recent_audit :
-  ?base_path:string ->
+  base_path:string ->
   ?keeper_name:string ->
   ?n:int ->
   unit ->
@@ -199,7 +199,7 @@ val submit_and_await :
   tool_name:string ->
   input:Yojson.Safe.t ->
   risk_level:risk_level ->
-  ?base_path:string ->
+  base_path:string ->
   ?turn_id:int ->
   ?task_id:string ->
   ?goal_id:string ->
@@ -225,7 +225,7 @@ val submit_pending :
   tool_name:string ->
   input:Yojson.Safe.t ->
   risk_level:risk_level ->
-  ?base_path:string ->
+  base_path:string ->
   ?turn_id:int ->
   ?task_id:string ->
   ?goal_id:string ->
@@ -247,7 +247,7 @@ val submit_pending :
     as a rule. Returns [Not_found] when [id] is absent or
     [Already_resolved] on concurrent-resolve race. *)
 val resolve_with_policy :
-  ?base_path:string ->
+  base_path:string ->
   id:string ->
   decision:Agent_sdk.Hooks.approval_decision ->
   ?remember_rule:bool ->

--- a/lib/keeper/keeper_approval_queue_rules.ml
+++ b/lib/keeper/keeper_approval_queue_rules.ml
@@ -100,12 +100,7 @@ let mutex_protect_allow_reentrant mutex f =
 
 let with_rules_lock f = mutex_protect_allow_reentrant rules_mu f
 
-let rules_path ?base_path () =
-  let base_path =
-    match base_path with
-    | Some base_path -> base_path
-    | None -> Env_config_core.base_path ()
-  in
+let rules_path ~base_path () =
   Filename.concat (Workspace_utils.masc_dir_from_base_path ~base_path) "approval-rules.json"
 ;;
 
@@ -172,26 +167,26 @@ let backend_of_runtime_context ?backend runtime_contract =
   | None -> backend_of_runtime_contract runtime_contract
 ;;
 
-let load_rules_unlocked ?base_path () =
-  match Safe_ops.read_json_file_safe (rules_path ?base_path ()) with
+let load_rules_unlocked ~base_path () =
+  match Safe_ops.read_json_file_safe (rules_path ~base_path ()) with
   | Ok (`List entries) -> entries |> List.filter_map approval_rule_of_yojson
   | _ -> []
 ;;
 
-let save_rules_unlocked ?base_path rules : (unit, string) result =
-  let path = rules_path ?base_path () in
+let save_rules_unlocked ~base_path rules : (unit, string) result =
+  let path = rules_path ~base_path () in
   Fs_compat.mkdir_p (Filename.dirname path);
   let json = `List (List.map approval_rule_to_yojson rules) in
   Fs_compat.save_file_atomic path (Yojson.Safe.pretty_to_string json)
 ;;
 
-let list_rules ?base_path () =
-  with_rules_lock (fun () -> load_rules_unlocked ?base_path ())
+let list_rules ~base_path () =
+  with_rules_lock (fun () -> load_rules_unlocked ~base_path ())
 ;;
 
-let list_rules_dashboard_json ?base_path () =
+let list_rules_dashboard_json ~base_path () =
   let rules =
-    list_rules ?base_path ()
+    list_rules ~base_path ()
     |> List.sort (fun left right -> Float.compare right.created_at left.created_at)
   in
   `List (List.map approval_rule_to_yojson rules)
@@ -222,7 +217,7 @@ let rule_identity_matches left right =
 ;;
 
 let upsert_rule
-      ?base_path
+      ~base_path
       ~keeper_name
       ~tool_name
       ~input
@@ -235,7 +230,7 @@ let upsert_rule
       ()
   =
   with_rules_lock (fun () ->
-    let rules = load_rules_unlocked ?base_path () in
+    let rules = load_rules_unlocked ~base_path () in
     let request_fingerprint = request_fingerprint input in
     let candidate =
       { id = make_generated_id "rule"
@@ -256,7 +251,7 @@ let upsert_rule
     match List.find_opt (fun rule -> rule_identity_matches rule candidate) rules with
     | Some existing -> existing, false
     | None ->
-      (match save_rules_unlocked ?base_path (candidate :: rules) with
+      (match save_rules_unlocked ~base_path (candidate :: rules) with
        | Ok () -> ()
        | Error msg ->
          Otel_metric_store.inc_counter
@@ -267,20 +262,20 @@ let upsert_rule
       candidate, true)
 ;;
 
-let delete_rule ?base_path ~id () =
+let delete_rule ~base_path ~id () =
   with_rules_lock (fun () ->
-    let rules = load_rules_unlocked ?base_path () in
+    let rules = load_rules_unlocked ~base_path () in
     match List.find_opt (fun rule -> String.equal rule.id id) rules with
     | None -> Error (Printf.sprintf "approval rule %s not found" id)
     | Some deleted ->
       let remaining = List.filter (fun rule -> not (String.equal rule.id id)) rules in
-      (match save_rules_unlocked ?base_path remaining with
+      (match save_rules_unlocked ~base_path remaining with
        | Ok () -> Ok deleted
        | Error msg -> Error msg))
 ;;
 
 let find_matching_rule
-      ?base_path
+      ~base_path
       ~keeper_name
       ~tool_name
       ~input
@@ -291,7 +286,7 @@ let find_matching_rule
       ()
   =
   with_rules_lock (fun () ->
-    let rules = load_rules_unlocked ?base_path () in
+    let rules = load_rules_unlocked ~base_path () in
     let request_fingerprint = request_fingerprint input in
     let sandbox_profile = sandbox_profile_of_runtime_context ?sandbox_profile runtime_contract in
     let backend = backend_of_runtime_context ?backend runtime_contract in
@@ -321,7 +316,7 @@ let find_matching_rule
              else current)
           rules
       in
-      (match save_rules_unlocked ?base_path updated_rules with
+      (match save_rules_unlocked ~base_path updated_rules with
        | Ok () -> ()
        | Error msg ->
          Otel_metric_store.inc_counter

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -31,7 +31,7 @@ type pending_approval =
   ; selected_model : string option
   ; disposition : string option
   ; disposition_reason : string option
-  ; audit_base_path : string option
+  ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
   }

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -26,7 +26,7 @@ type pending_approval =
   ; selected_model : string option
   ; disposition : string option
   ; disposition_reason : string option
-  ; audit_base_path : string option
+  ; audit_base_path : string
   ; resolver : Agent_sdk.Hooks.approval_decision Eio.Promise.u option
   ; on_resolution : (Agent_sdk.Hooks.approval_decision -> unit) option
   }

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -969,6 +969,7 @@ let test_dashboard_exposes_keeper_approval_queue () =
             ~tool_name:"tool_edit_file"
             ~input:(`Assoc [ ("path", `String "/tmp/danger") ])
             ~risk_level:Lib.Keeper_approval_queue.Critical
+            ~base_path:dir
             ~selected_model:"openai:gpt-5.4"
             ()
         in
@@ -1074,6 +1075,7 @@ let test_approval_queue_surfaces_action_key_and_sandbox_target () =
           ~risk_level:Lib.Keeper_approval_queue.Medium
           ~runtime_contract:
             (`Assoc [("backend", `String "docker"); ("sandbox_target", `String "docker")])
+          ~base_path:dir
           ~on_resolution:(fun _ -> ())
           ()
       in

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -271,6 +271,10 @@ let test_enterprise_blocks_high () =
 let test_approval_queue_submit_and_resolve () =
   Eio_main.run @@ fun _env ->
   (* Simulate: agent fiber submits, operator fiber resolves *)
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   Eio.Switch.run @@ fun sw ->
   let result = ref None in
   (* Agent fiber: submit and await (will block until resolved) *)
@@ -281,6 +285,7 @@ let test_approval_queue_submit_and_resolve () =
         ~tool_name:"tool_edit_file"
         ~input:(`Assoc [("path", `String "/dangerous")])
         ~risk_level:AQ.Critical
+        ~base_path
         ()
     in
     result := Some decision
@@ -316,10 +321,14 @@ let test_approval_queue_submit_and_resolve () =
     Alcotest.fail ("expected Approve, got Reject: " ^ r)
   | Some (Agent_sdk.Hooks.Edit _) ->
     Alcotest.fail "expected Approve, got Edit"
-  | None -> Alcotest.fail "agent fiber did not resume"
+  | None -> Alcotest.fail "agent fiber did not resume")
 
 let test_approval_queue_reject () =
   Eio_main.run @@ fun _env ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   Eio.Switch.run @@ fun sw ->
   let result = ref None in
   Eio.Fiber.fork ~sw (fun () ->
@@ -329,6 +338,7 @@ let test_approval_queue_reject () =
         ~tool_name:"masc_force_reset"
         ~input:(`Assoc [])
         ~risk_level:AQ.Critical
+        ~base_path
         ()
     in
     result := Some decision
@@ -350,10 +360,14 @@ let test_approval_queue_reject () =
   | Some (Agent_sdk.Hooks.Reject reason) ->
     Alcotest.(check bool) "reason contains text" true
       (String.length reason > 0)
-  | _ -> Alcotest.fail "expected Reject"
+  | _ -> Alcotest.fail "expected Reject")
 
 let test_approval_queue_expire_stale () =
   Eio_main.run @@ fun _env ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   Eio.Switch.run @@ fun sw ->
   let result = ref None in
   Eio.Fiber.fork ~sw (fun () ->
@@ -363,6 +377,7 @@ let test_approval_queue_expire_stale () =
         ~tool_name:"masc_dangerous_tool"
         ~input:(`Assoc [])
         ~risk_level:AQ.High
+        ~base_path
         ()
     in
     result := Some decision
@@ -376,7 +391,7 @@ let test_approval_queue_expire_stale () =
   | Some (Agent_sdk.Hooks.Reject reason) ->
     Alcotest.(check bool) "timeout reason" true
       (String.starts_with ~prefix:"approval timed out" reason)
-  | _ -> Alcotest.fail "expected Reject from timeout"
+  | _ -> Alcotest.fail "expected Reject from timeout")
 
 let test_approval_queue_expire_skips_critical () =
   (* [Critical] entries originate from indefinite-wait operator gates
@@ -384,12 +399,17 @@ let test_approval_queue_expire_skips_critical () =
      create a 30-min expire / re-enqueue cycle and silently push the
      keeper into a permanent paused state. The janitor must skip them. *)
   Eio_main.run @@ fun _env ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   let resolution = ref None in
   let id =
     AQ.submit_pending
       ~keeper_name:"test-keeper-critical"
       ~tool_name:"keeper_continue_after_reconcile"
       ~input:(`Assoc [])
+      ~base_path
       ~risk_level:AQ.Critical
       ~on_resolution:(fun decision -> resolution := Some decision)
       ()
@@ -406,11 +426,15 @@ let test_approval_queue_expire_skips_critical () =
      | Some _ -> Some "resolved");
   (* Cleanup: manually resolve so subsequent tests don't see stray state. *)
   match AQ.resolve ~id ~decision:(Agent_sdk.Hooks.Reject "test cleanup") with
-  | Ok () | Error _ -> ()
+  | Ok () | Error _ -> ())
 
 let test_submit_and_await_clock_timeout_skips_critical () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   Eio.Switch.run @@ fun sw ->
   let keeper_name = "critical-clock-timeout-test" in
   let result = ref None in
@@ -421,6 +445,7 @@ let test_submit_and_await_clock_timeout_skips_critical () =
         ~tool_name:"keeper_continue_after_reconcile"
         ~input:(`Assoc [])
         ~risk_level:AQ.Critical
+        ~base_path
         ~clock
         ~timeout_s:0.01
         ()
@@ -447,11 +472,15 @@ let test_submit_and_await_clock_timeout_skips_critical () =
   | Some decision ->
       Alcotest.fail
         ("expected Approve, got " ^ AQ.approval_decision_to_string decision)
-  | None -> Alcotest.fail "Critical approval did not resume"
+  | None -> Alcotest.fail "Critical approval did not resume")
 
 let test_submit_and_await_clock_returns_manual_decision () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   Eio.Switch.run @@ fun sw ->
   let keeper_name = "medium-clock-manual-test" in
   let result = ref None in
@@ -462,6 +491,7 @@ let test_submit_and_await_clock_returns_manual_decision () =
         ~tool_name:"tool_search_files"
         ~input:(`Assoc [ ("op", `String "write") ])
         ~risk_level:AQ.Medium
+        ~base_path
         ~clock
         ~timeout_s:1.0
         ()
@@ -483,7 +513,7 @@ let test_submit_and_await_clock_returns_manual_decision () =
   | Some decision ->
       Alcotest.fail
         ("expected Approve, got " ^ AQ.approval_decision_to_string decision)
-  | None -> Alcotest.fail "manual approval did not resume"
+  | None -> Alcotest.fail "manual approval did not resume")
 
 let test_approval_resolve_nonexistent () =
   Eio_main.run @@ fun _env ->
@@ -499,6 +529,10 @@ let test_approval_queue_cancel_cleans_up () =
   Eio_main.run @@ fun _env ->
   (* Simulate: agent fiber is cancelled (Switch closes) while awaiting.
      The pending entry must be cleaned up from the hashtbl. (#5949) *)
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   let initial_count = AQ.pending_count () in
   (try
      Eio.Switch.run @@ fun sw ->
@@ -509,6 +543,7 @@ let test_approval_queue_cancel_cleans_up () =
            ~tool_name:"masc_dangerous"
            ~input:(`Assoc [])
            ~risk_level:AQ.Critical
+           ~base_path
            ()
        in
        ());
@@ -518,7 +553,7 @@ let test_approval_queue_cancel_cleans_up () =
    with Failure _ -> ());
   (* After cancellation, the pending entry should be cleaned up *)
   let final_count = AQ.pending_count () in
-  Alcotest.(check int) "no orphan entries" initial_count final_count
+  Alcotest.(check int) "no orphan entries" initial_count final_count)
 
 let test_approval_queue_cancel_records_terminal_audit () =
   Eio_main.run @@ fun _env ->
@@ -560,6 +595,10 @@ let test_approval_queue_cancel_records_terminal_audit () =
 
 let test_background_pending_callback_and_keeper_lookup () =
   Eio_main.run @@ fun _env ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   let initial_count = AQ.pending_count () in
   let callback_result = ref None in
   let id =
@@ -568,6 +607,7 @@ let test_background_pending_callback_and_keeper_lookup () =
       ~tool_name:"keeper_continue_after_partial_commit"
       ~input:(`Assoc [("kind", `String "continue_gate_required")])
       ~risk_level:AQ.Critical
+      ~base_path
       ~on_resolution:(fun decision -> callback_result := Some decision)
       ()
   in
@@ -585,10 +625,14 @@ let test_background_pending_callback_and_keeper_lookup () =
   match !callback_result with
   | Some Agent_sdk.Hooks.Approve -> ()
   | Some _ -> Alcotest.fail "expected approve callback"
-  | None -> Alcotest.fail "expected callback to fire"
+  | None -> Alcotest.fail "expected callback to fire")
 
 let test_background_pending_reuses_existing_entry () =
   Eio_main.run @@ fun _env ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   let initial_count = AQ.pending_count () in
   let first_callback = ref None in
   let second_callback = ref None in
@@ -598,6 +642,7 @@ let test_background_pending_reuses_existing_entry () =
       ~tool_name:"keeper_continue_after_partial_commit"
       ~input:(`Assoc [("kind", `String "continue_gate_required")])
       ~risk_level:AQ.Critical
+      ~base_path
       ~on_resolution:(fun decision -> first_callback := Some decision)
       ()
   in
@@ -608,6 +653,7 @@ let test_background_pending_reuses_existing_entry () =
       ~tool_name:"keeper_continue_after_partial_commit"
       ~input:(`Assoc [("kind", `String "continue_gate_required")])
       ~risk_level:AQ.Critical
+      ~base_path
       ~on_resolution:(fun decision -> second_callback := Some decision)
       ()
   in
@@ -622,9 +668,14 @@ let test_background_pending_reuses_existing_entry () =
   Alcotest.(check bool) "first callback fired" true
     (match !first_callback with Some Agent_sdk.Hooks.Approve -> true | _ -> false);
   Alcotest.(check bool) "second callback not attached to duplicate submit" true
-    (Option.is_none !second_callback)
+    (Option.is_none !second_callback))
 
 let test_background_pending_distinct_inputs_do_not_reuse_entry () =
+  Eio_main.run @@ fun _env ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   let initial_count = AQ.pending_count () in
   let callback_result = ref [] in
   let id1 =
@@ -637,6 +688,7 @@ let test_background_pending_distinct_inputs_do_not_reuse_entry () =
           ; "argv", `List [ `String "status"; `String "--short" ]
           ])
       ~risk_level:AQ.Medium
+      ~base_path
       ~on_resolution:(fun decision -> callback_result := decision :: !callback_result)
       ()
   in
@@ -650,6 +702,7 @@ let test_background_pending_distinct_inputs_do_not_reuse_entry () =
           ; "argv", `List [ `String "log"; `String "--oneline"; `String "-1" ]
           ])
       ~risk_level:AQ.High
+      ~base_path
       ~on_resolution:(fun decision -> callback_result := decision :: !callback_result)
       ()
   in
@@ -659,10 +712,14 @@ let test_background_pending_distinct_inputs_do_not_reuse_entry () =
   ignore (AQ.resolve ~id:id1 ~decision:Agent_sdk.Hooks.Approve);
   ignore (AQ.resolve ~id:id2 ~decision:(Agent_sdk.Hooks.Reject "cleanup"));
   Alcotest.(check int) "cleanup restores count"
-    initial_count (AQ.pending_count ())
+    initial_count (AQ.pending_count ()))
 
 let test_approval_queue_get_pending_detail () =
   Eio_main.run @@ fun _env ->
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   let initial_count = AQ.pending_count () in
   let callback_result = ref None in
   let input =
@@ -676,6 +733,7 @@ let test_approval_queue_get_pending_detail () =
     AQ.submit_pending
       ~keeper_name:"detail-keeper"
       ~tool_name:"tool_edit_file"
+      ~base_path
       ~input
       ~risk_level:AQ.Critical
       ~turn_id:7
@@ -727,9 +785,13 @@ let test_approval_queue_get_pending_detail () =
   Alcotest.(check bool) "callback fired" true
     (match !callback_result with Some Agent_sdk.Hooks.Approve -> true | _ -> false);
   Alcotest.(check int) "entry removed"
-    initial_count (AQ.pending_count ())
+    initial_count (AQ.pending_count ()))
 
 let test_approval_queue_keeps_sandbox_backend_out_of_runtime_contract () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
   let runtime_contract =
     Masc.Keeper_runtime_contract.runtime_contract_json_from_fields
       ~keeper_name:"redacted-contract-keeper"
@@ -755,6 +817,7 @@ let test_approval_queue_keeps_sandbox_backend_out_of_runtime_contract () =
       ~sandbox_profile:"docker"
       ~backend:"docker"
       ~runtime_contract
+      ~base_path
       ~on_resolution:(fun _ -> ())
       ()
   in
@@ -778,7 +841,7 @@ let test_approval_queue_keeps_sandbox_backend_out_of_runtime_contract () =
       Alcotest.(check bool)
         "detail runtime_contract keeps sandbox_profile redacted"
         false
-        (has_assoc_key "sandbox_profile" detail_contract))
+        (has_assoc_key "sandbox_profile" detail_contract)))
 
 let test_resolve_with_policy_remembers_medium_allow () =
   with_eio_base_path @@ fun base_path ->

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -184,7 +184,7 @@ let with_temp_masc_base f =
        | Some value -> Unix.putenv "MASC_BASE_PATH_INPUT" value
        | None -> Unix.putenv "MASC_BASE_PATH_INPUT" "");
       cleanup_dir base_path)
-    f
+    (fun () -> f base_path)
 
 (* ── 1. Risk classification ──────────────────────────────── *)
 
@@ -1336,20 +1336,20 @@ let test_callback_always_approve_respects_forbidden () =
       | None -> Alcotest.fail "destructive tool callback did not suspend for approval")
 
 let test_read_recent_audit_filters_after_wide_scan () =
-  with_temp_masc_base @@ fun () ->
+  with_temp_masc_base @@ fun base_path ->
   let keeper_name = "audit-target-keeper" in
-  AQ.audit_approval_event ~event_type:"resolved" ~id:"target-audit"
+  AQ.audit_approval_event ~base_path ~event_type:"resolved" ~id:"target-audit"
     ~keeper_name ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
     ~selected_model:"openai:gpt-5.4"
     ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ();
   for i = 1 to 32 do
-    AQ.audit_approval_event ~event_type:"resolved"
+    AQ.audit_approval_event ~base_path ~event_type:"resolved"
       ~id:(Printf.sprintf "other-audit-%02d" i)
       ~keeper_name:(Printf.sprintf "busy-keeper-%02d" i)
       ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
       ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ()
   done;
-  match AQ.read_recent_audit ~keeper_name ~n:1 () with
+  match AQ.read_recent_audit ~base_path ~keeper_name ~n:1 () with
   | [ json ] ->
       Alcotest.(check string) "target approval survives unrelated tail"
         "target-audit"


### PR DESCRIPTION
## RFC-0274 Wave A — Workspace base_path SSOT threading (implementation)

Implements Wave A of [RFC-0274](https://github.com/jeong-sik/masc/blob/feature/p1-1-workspace-env-threading/docs/rfc/RFC-0274-workspace-base-path-ssot-threading.md) (PR #21952): retire `Env_config_core.base_path()` runtime env-read and thread `Workspace.config.base_path` as the single runtime SSOT.

### Leak sites closed (root fix)
- `keeper_approval_queue_rules.ml` `rules_path` — `None -> Env_config_core.base_path ()` removed
- `keeper_approval_queue.ml` `get_audit_store` — same fallback removed

These were the only two runtime env-read leak sites in the approval queue. Production callers already passed `~base_path` explicitly, so the leak lived entirely inside the module fallbacks.

### Threading (Parse-don't-validate)
`?base_path:string` (optional) -> `base_path:string` (required) through:
- rules module (8 fns): `rules_path`, `load_rules_unlocked`, `save_rules_unlocked`, `list_rules`, `list_rules_dashboard_json`, `upsert_rule`, `delete_rule`, `find_matching_rule`
- audit chain (4 fns): `get_audit_store`, `audit_approval_event`, `audit_rule_event`, `read_recent_audit`
- submit/resolve chain: `submit_and_await`, `submit_pending`, `resolve_entry`, `remember_rule_for_entry`, `resolve_with_policy`
- `governance_pipeline.to_oas_approval_callback`: `?config` -> `config` required (all callers already passed `~config`)
- `pending_approval.audit_base_path`: `string option` -> `string` (submit captures the now-required base_path; entry is the authoritative workspace source for the `resolve` convenience wrapper, per RFC-0274 per-entry-snapshot)

The compiler now rejects any base_path-less call, making the leak state unrepresentable. This is the root fix (not a symptom suppressor): no `Option.value ~default:(Env_config_core.base_path ())` shims remain.

### Deferred to Wave A.2
`approval_policy_effective_json` leak (`keeper_runtime_contract.ml:206`) requires threading the `runtime_contract_json` / `goal_progress_json` / `runtime_observability_contract_json` config chain plus their callers — a deeper chain than Wave A's rules+queue scope. `governance_pipeline` calls `runtime_contract_json ?config:(Some config)` to keep that chain on `?config` until its dedicated wave. Tracked by RFC-0274 §6 acceptance.

### Verification
- CI: Build and Test, CI Gate, TLA+ Model Checking, Meta Guards (determinism ratchet)
- Pre-check (scoped slice agent, local worktree): `dune build --root .` exit 0; `test_hitl_approval` (37 tests) + `test_dashboard_governance` (26 tests) pass; `check-determinism-contract.sh` exit 0 (no new NDT debt)

RFC: RFC-0274 (PR #21952). This is the keeper subsystem — RFC discovered and cited per agent_delegation policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
