### PR TITLE
fix(test): query ToolNotAllowed counter with tool_type label (main RED, latent since #21402)

### DIFF
--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -310,9 +310,20 @@ let test_public_read_rejects_offset_with_tutor () =
         (contains_substring result.raw_output {|"tool":"Grep"|}))
 
 let counter_for_tool_not_allowed ~keeper ~tool ~reason =
+  (* Production emits ToolNotAllowed with a "tool_type" label derived from
+     [Tool_telemetry.tool_type_of_name] (RFC-0084), added to the single
+     emission site in keeper_tool_dispatch_runtime.ml. Otel_metric_store keys
+     metrics by the exact label set, so the query must carry tool_type or it
+     never matches the stored counter (reads as a permanent zero). *)
+  let tool_type = Masc.Tool_telemetry.tool_type_of_name tool in
   Masc.Otel_metric_store.metric_value_or_zero
     Keeper_metrics.(to_string ToolNotAllowed)
-    ~labels:[ ("keeper", keeper); ("tool", tool); ("reason", reason) ]
+    ~labels:
+      [ ("keeper", keeper)
+      ; ("tool", tool)
+      ; ("reason", reason)
+      ; ("tool_type", tool_type)
+      ]
     ()
 
 (* #13xxx: tool_not_allowed Otel_metric_store counter *)


### PR DESCRIPTION
## 목표

main에서 **silently 실패 중인 테스트 2개**를 고친다. `test_keeper_tool_dispatch_runtime`의 `tool_not_allowed_counter` 스위트 중 `increments for not_in_candidate_set`/`increments for denied_by_policy`가 origin/main에서 FAIL 상태인데, `Build and Test`가 최근 main 커밋에서 SKIPPED라 노출되지 않고 5일째 잠복했다.

> 방치 worktree 적대 탐색(`tool-orchestration-audit-fix`, detached HEAD·미커밋)에서 발견한 dropped work를 현재 `origin/main`(677889831c) 위에서 재검증·재구성했다.

## 근본 원인

`ToolNotAllowed` 카운터는 `keeper_tool_dispatch_runtime.ml`의 **단일 방출 사이트**에서 증가한다. #21402(2026-06-17)가 이 방출에 `tool_type` 라벨(`Tool_telemetry.tool_type_of_name`, RFC-0084 저-cardinality 분류)을 추가해 라벨셋이 4개가 되었다:

```
[ "keeper"; "tool"; "reason"; "tool_type" ]
```

그러나 테스트 헬퍼 `counter_for_tool_not_allowed`는 3-라벨로 조회를 유지했다:

```
[ ("keeper",..); ("tool",..); ("reason",..) ]
```

`Otel_metric_store`는 메트릭을 **정확한 라벨셋**으로 키잉한다(`Otel_metric_key.metric_key`는 라벨 리스트의 위치 인코딩). 따라서 3-라벨 조회는 저장된 4-라벨 카운터와 **절대 매칭되지 않고 영구 0**을 읽는다 → `before +. 1.0` 단언이 `0.0 + 1.0 == 0.0`으로 실패.

(`reason label is bounded` 케이스는 exact-label 조회 경로가 아니라 영향받지 않아 `[OK]` — 그래서 부분적으로만 깨졌다.)

## 변경 내용

- `counter_for_tool_not_allowed` 헬퍼가 production 방출과 동일하게 `tool_type` 라벨(같은 순서, `Masc.Tool_telemetry.tool_type_of_name tool`)을 조회에 포함하도록 한다. test/test_keeper_tool_dispatch_runtime.ml 1파일, +12/-1.
- 근거를 주석으로 남김(production 방출과 exact-key 매칭 규율).

이건 워크어라운드가 아니라 **테스트를 production 계약에 맞추는 정합 수정**이다. `tool_type` 방출 자체는 의도된 동작(RFC-0084, 다른 3개 방출 사이트도 동일 라벨 부착)이므로 production을 바꿀 게 없고, 갱신 누락된 테스트가 근본 원인이다.

## 검증 (runtime 증거)

현재 `origin/main`(677889831c)에서 격리 worktree(`--root .`) 빌드·실행:

- **fix 전**: `2 failures! in 3.825s. 36 tests run.` (`[FAIL] tool_not_allowed_counter 0/1`)
- **fix 후**: `Test Successful in 0.279s. 36 tests run.` (`[OK] tool_not_allowed_counter 0/1/2`)
- ocamlformat clean(대상 .ml). `test/dune`의 @fmt 차이는 선재 드리프트로 본 PR 범위 밖(미변경).

## 범위 밖

- `Build and Test`가 main 커밋에서 SKIPPED되는 path-filter/conveyor 정책은 별개 이슈(이 테스트가 5일간 잠복한 진짜 배경). 본 PR은 테스트 정확성만 복구한다.

RFC 트리거 subsystem 아님(test 전용, credential/operator/sandbox/hooks 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
