### PR TITLE
fix(config): route GC/snapshot env knobs through validated parser

### DIFF
--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -155,9 +155,13 @@ let () =
   Dashboard_snapshot.register_namespace_truth_snapshot Server_dashboard_http_namespace_truth.namespace_truth_snapshot_from_caches;
   if Option.is_none (Sys.getenv_opt "OCAMLRUNPARAM") then begin
     let open Gc in
+    (* Route through the validated helper: a malformed value (e.g.
+       MASC_GC_SPACE_OVERHEAD=abc) previously raised [Failure] -- the
+       hand-rolled [with Not_found] only caught the unset case, so a typo
+       in this env var crashed server bootstrap. [get_int_nonneg] also
+       maps a negative value to the default. *)
     let gc_space_overhead =
-      try int_of_string (Sys.getenv "MASC_GC_SPACE_OVERHEAD")
-      with Not_found -> 100
+      Env_config_core.get_int_nonneg ~default:100 "MASC_GC_SPACE_OVERHEAD"
     in
     let ctrl = get () in
     set { ctrl with

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -123,8 +123,13 @@ let take = List.take
     while keeping dashboard metrics within 5 seconds of reality.
     Configurable via [MASC_SNAPSHOT_INTERVAL_SEC] env var (default 5.0). *)
 let snapshot_min_interval_sec =
-  try float_of_string (Sys.getenv "MASC_SNAPSHOT_INTERVAL_SEC")
-  with Not_found -> 5.0
+  (* Route through the validated helper (same idiom as [MASC_SSE_*] above):
+     a malformed value (e.g. "abc") previously raised [Failure] -- the
+     hand-rolled [with Not_found] only caught the unset case, so a typo in
+     this env var crashed the module at load. [get_float_nonneg] also maps
+     negative / NaN / +-inf to the default, which is correct for an
+     interval-seconds knob. *)
+  Env_config_core.get_float_nonneg ~default:5.0 "MASC_SNAPSHOT_INTERVAL_SEC"
 
 (** Timestamp of the last completed snapshot.  CAS-guarded so that
     concurrent [broadcast_impl] fibers racing to snapshot after the

--- a/test/test_env_config_nonneg.ml
+++ b/test/test_env_config_nonneg.ml
@@ -111,6 +111,24 @@ let test_float_nonneg_garbage_uses_default () =
     (C.get_float_nonneg
        ~default:8.0 "MASC_TEST_NONNEG_FLOAT_GARBAGE")
 
+(* ── production knob regression anchors ───────────────────────────────
+   Pin the two knobs whose call sites (sse.ml [snapshot_min_interval_sec],
+   server_runtime_bootstrap.ml [gc_space_overhead]) were changed from a
+   hand-rolled [try _of_string (Sys.getenv ..) with Not_found -> default]
+   -- which let [Failure] escape and crash module load on a malformed
+   value -- to these validated helpers.  Garbage must now yield the
+   documented default rather than raise. *)
+
+let test_snapshot_interval_garbage_uses_default () =
+  with_env "MASC_SNAPSHOT_INTERVAL_SEC" "notafloat" @@ fun () ->
+  check_float "MASC_SNAPSHOT_INTERVAL_SEC garbage -> default 5.0" 5.0
+    (C.get_float_nonneg ~default:5.0 "MASC_SNAPSHOT_INTERVAL_SEC")
+
+let test_gc_space_overhead_garbage_uses_default () =
+  with_env "MASC_GC_SPACE_OVERHEAD" "abc" @@ fun () ->
+  check_int "MASC_GC_SPACE_OVERHEAD garbage -> default 100" 100
+    (C.get_int_nonneg ~default:100 "MASC_GC_SPACE_OVERHEAD")
+
 (* ── runner ───────────────────────────────────────────────────────── *)
 
 let () =
@@ -147,5 +165,12 @@ let () =
             test_float_nonneg_unset_uses_default;
           Alcotest.test_case "garbage → default" `Quick
             test_float_nonneg_garbage_uses_default;
+        ] );
+      ( "production_knob_regression",
+        [
+          Alcotest.test_case "MASC_SNAPSHOT_INTERVAL_SEC garbage → default"
+            `Quick test_snapshot_interval_garbage_uses_default;
+          Alcotest.test_case "MASC_GC_SPACE_OVERHEAD garbage → default"
+            `Quick test_gc_space_overhead_garbage_uses_default;
         ] );
     ]


### PR DESCRIPTION
## Problem

Two env-var knobs parse their value with a hand-rolled
`try _of_string (Sys.getenv "X") with Not_found -> default`. The handler
catches only `Not_found` (env var unset). A *malformed* value
(`MASC_GC_SPACE_OVERHEAD=abc`, `MASC_SNAPSHOT_INTERVAL_SEC=notafloat`) makes
`int_of_string` / `float_of_string` raise `Failure`, which escapes the
handler and crashes the module at load:

- `lib/server/server_runtime_bootstrap.ml:159` — `gc_space_overhead`
  (crashes server bootstrap)
- `lib/sse.ml:126` — `snapshot_min_interval_sec`

A typo in an optional perf-tuning env var should not take down the server.

## Fix

Route both sites through the existing validated helpers
`Env_config_core.get_int_nonneg` / `get_float_nonneg`, which:

- catch `Failure` (malformed value → default), fixing the crash;
- reject negative / NaN / ±inf (nonsensical for an interval / GC overhead);
- are the established codebase idiom — `board_types`, `bg_task`,
  `keeper_disk_pressure`, and `sse.ml` itself already use
  `Env_config_core.get_int` at `:76` / `:234`.

This is a root fix that routes to the single shared parser, not a per-site
`| Failure _` hand-patch. The complete set of unguarded
`_of_string (Sys.getenv …)` sites is exactly these two; `process_eio.ml:94`
already catches `Not_found | Failure _`.

## Behavior change

For these two knobs a negative / NaN / ±inf value now yields the default
(previously a negative parsed through as-is; NaN/inf silently broke the
interval comparison). Valid non-negative finite values are unchanged.

Trade-off: a malformed value now falls back to the default instead of
crashing. For optional perf knobs this favors boot resilience over a loud
crash on a minor setting. Uniform warn-on-malformed across all
`Env_config_core` helpers would be a separate cross-cutting change.

## Tests

`test/test_env_config_nonneg.ml` already proves these helpers map
garbage / negative / NaN / inf / unset → default. Added two regression
anchors pinning the production knobs (`MASC_SNAPSHOT_INTERVAL_SEC`,
`MASC_GC_SPACE_OVERHEAD`) to their defaults (5.0, 100) on garbage input.

Found via an adversarial deficiency hunt (parse-nonopt class), verified
refute-by-default.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
