### PR TITLE
fix(ide): close annotations writer fd on exception via Fun.protect

### DIFF
--- a/lib/ide/ide_annotations.ml
+++ b/lib/ide/ide_annotations.ml
@@ -96,12 +96,21 @@ let write_all_partition ~base_dir partition annotations =
   let lines = List.map Yojson.Safe.to_string jsons in
   let tmp_path = path ^ ".tmp" in
   let oc = open_out_bin tmp_path in
-  List.iter
-    (fun line ->
-       output_string oc line;
-       output_char oc '\n')
-    lines;
-  close_out oc;
+  (* [Fun.protect] guarantees the fd is closed even if [output_string] /
+     [output_char] / [flush] raises mid-write (e.g. ENOSPC). Without it the
+     fd leaked on exception, since [close_out] below was unreachable -- the
+     other writers in this codebase (fs_compat, masc_log) already guard this
+     way. [flush] inside the body surfaces write errors so a failed write
+     re-raises before [Sys.rename] promotes a partial file over the good one. *)
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+       List.iter
+         (fun line ->
+            output_string oc line;
+            output_char oc '\n')
+         lines;
+       flush oc);
   Sys.rename tmp_path path
 ;;
 

--- a/test/test_ide_annotations.ml
+++ b/test/test_ide_annotations.ml
@@ -719,10 +719,66 @@ let test_document_highlights_related () =
          check int "two highlights" 2 (List.length highlights))))
 ;;
 
+(* Round-trip through [compact], which calls the internal
+   [write_all_partition].  Guards the [Fun.protect] fd-safe rewrite: the
+   happy path must still write every annotation back so a later [list]
+   sees them all. *)
+let test_compact_preserves_annotations () =
+  with_temp_dir (fun base_dir ->
+    let mk content =
+      match
+        Store.create
+          ~base_dir
+          ~keeper_id:"sangsu"
+          ~file_path:"lib/x.ml"
+          ~line_start:1
+          ~line_end:2
+          ~kind:Types.Comment
+          ~content
+          ~goal_id:"g"
+          ~task_id:"t"
+          ~board_post_id:"p"
+          ~comment_id:"c"
+          ~pr_id:"1"
+          ~git_ref:"r"
+          ~log_id:"l"
+          ~session_id:"s"
+          ~operation_id:"o"
+          ~worker_run_id:"w"
+          ()
+      with
+      | Error msg -> fail msg
+      | Ok created -> created
+    in
+    let a1 = mk "first" in
+    let a2 = mk "second" in
+    Store.compact ~base_dir ();
+    let filter =
+      { Types.file_path = None; keeper_id = None; goal_id = None; task_id = None }
+    in
+    let listed = Store.list ~base_dir ~filter () in
+    check int "compact preserves count" 2 (List.length listed);
+    let ids =
+      List.map (fun (a : Types.annotation) -> a.id) listed
+      |> List.sort String.compare
+    in
+    check
+      (list string)
+      "compact preserves ids"
+      (List.sort String.compare [ a1.id; a2.id ])
+      ids)
+;;
+
 let () =
   run
     "ide_annotations"
-    [ ( "route_context"
+    [ ( "compact"
+      , [ test_case
+            "compact preserves annotations (fd-safe write)"
+            `Quick
+            test_compact_preserves_annotations
+        ] )
+    ; ( "route_context"
       , [ test_case
             "annotation json preserves route context"
             `Quick


### PR DESCRIPTION
## Problem

`Ide_annotations.write_all_partition` (the rewrite behind `compact` and
`delete`) opened the temp file with `open_out_bin` and closed it only via a
`close_out` placed *after* the write loop:

```ocaml
let oc = open_out_bin tmp_path in
List.iter (fun line -> output_string oc line; output_char oc '\n') lines;
close_out oc;
Sys.rename tmp_path path
```

If `output_string` / `output_char` raises mid-write (ENOSPC, I/O error),
the exception propagates past the unreachable `close_out` and the fd leaks.
`compact` (`ide_annotations.ml:213`) has no surrounding handler, so repeated
failing compactions exhaust file descriptors.

This was the only unguarded writer found in `lib/` — `fs_compat`, `masc_log`
and the other writers already wrap their channels.

## Fix

Wrap the write in `Fun.protect ~finally:(fun () -> close_out_noerr oc)`,
matching the sibling idiom. `flush oc` inside the body surfaces write errors
so a failed write re-raises *before* `Sys.rename` could promote a partial
temp file over the good one. The fd is now closed on every path.

## Tests

Added a `compact` round-trip test to `test/test_ide_annotations.ml`: create
two annotations, `compact`, then `list` and assert both survive. This
exercises `write_all_partition` through the public API and guards the
happy-path rewrite. The fd-leak-on-exception path is structural
(`Fun.protect` guarantees closure) and is not unit-reproducible without a
forced I/O failure.

Found via an adversarial deficiency hunt (channel-leak class), verified
refute-by-default.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
