### PR TITLE
[v2] shell — pixel-match left icon-rail (58px collapsed SideRail)

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -237,8 +237,11 @@ describe('App v2 header chrome', () => {
     const rail = container.querySelector('#dashboard-side-rail') as HTMLElement
     expect(rail).not.toBeNull()
     const cls = Array.from(rail.classList).join(' ')
-    // The desktop rail must carry a fixed width (w-14 or w-55), not w-full.
-    expect(cls).toMatch(/\bw-14\b|\bw-55\b/)
+    // The desktop rail must carry a fixed width, not w-full. Collapsed default
+    // renders the keeper-v2 prototype's 58px icon rail (w-[58px], --nav-w
+    // v2.css:232); expanded renders w-55.
+    expect(cls).toMatch(/w-\[58px\]|\bw-55\b/)
+    expect(cls).not.toMatch(/\bw-full\b/)
     expect(cls).not.toMatch(/\bmax-h-75\b/)
   })
 

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -78,9 +78,12 @@ import {
 // Sidebar collapsed state persists across reloads — a user who picks
 // the dense layout keeps it. Namespaced key avoids clashing with any
 // future per-user preference that might use plain \"sidebar-collapsed\".
+// Default = collapsed: a fresh load shows the keeper-v2 prototype's
+// icon-only 58px rail. Returning users keep their stored choice (the
+// persistent signal only falls back to this default when no value is set).
 const sidebarCollapsed = persistentSignal<boolean>({
   key: 'dashboard:sidebar-collapsed',
-  defaultValue: false,
+  defaultValue: true,
 })
 const mobileMenuOpen = signal(false)
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1117,13 +1117,19 @@ export function SideRail({
 
   return html`
     <nav class="v2-shell-surface flex flex-col h-full" aria-label="Dashboard navigation">
-      <div class="nav-brand v2-shell-toolbar flex items-center ${collapsed ? 'justify-center' : 'justify-between'} border-b border-[var(--color-border-default)] px-2 pt-2 pb-2">
-        ${!collapsed ? html`
-          <div class="px-1 leading-none">
-            <div class="nb-title font-mono text-[var(--fs-9)] font-bold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-disabled)]">MASC</div>
-            <div class="nb-sub mt-1 font-mono text-[var(--fs-11)] font-semibold uppercase tracking-[0.14em] text-[var(--color-fg-secondary)]">Cockpit</div>
-          </div>
-        ` : null}
+      <div class="nav-brand v2-shell-toolbar flex ${collapsed ? 'flex-col items-center gap-1.5' : 'items-center justify-between'} border-b border-[var(--color-border-default)] px-2 pt-2 pb-2">
+        ${collapsed
+          ? html`
+            <!-- Collapsed brand = the keeper-v2 prototype's .nav-home logo box
+                 (v2.css:242): 38x38 volt-filled square, "M" monogram, glow. -->
+            <div class="nav-home" aria-hidden="true">M</div>
+          `
+          : html`
+            <div class="px-1 leading-none">
+              <div class="nb-title font-mono text-[var(--fs-9)] font-bold uppercase tracking-[var(--track-brand)] text-[var(--color-fg-disabled)]">MASC</div>
+              <div class="nb-sub mt-1 font-mono text-[var(--fs-11)] font-semibold uppercase tracking-[0.14em] text-[var(--color-fg-secondary)]">Cockpit</div>
+            </div>
+          `}
         <button type="button"
           class=${`v2-shell-action nav-collapse flex size-6 items-center justify-center rounded-[var(--r-0)] border border-transparent text-[var(--color-fg-muted)] cursor-pointer transition-[background-color,border-color,color] duration-[var(--t-med)] hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-fg-secondary)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'surface' })}`}
           aria-label=${collapsed ? 'Expand sidebar' : 'Collapse sidebar'}

--- a/dashboard/src/components/mobile-nav.test.ts
+++ b/dashboard/src/components/mobile-nav.test.ts
@@ -130,8 +130,21 @@ describe('DashboardNavRail', () => {
     expect(container.querySelector('nav[aria-label="Primary mobile navigation"]')).toBeNull()
     const rail = container.querySelector('[data-testid="dashboard-nav-rail"]')
     expect(rail).not.toBeNull()
-    expect(rail?.className).toContain('w-14')
+    // Collapsed rail width matches the keeper-v2 prototype --nav-w: 58px
+    // (v2.css:232) — literal w-[58px], not Tailwind w-14 (56px).
+    expect(rail?.className).toContain('w-[58px]')
     expect(rail?.className).toContain('max-[1100px]:hidden')
+  })
+
+  it('renders the prototype icon-rail brand logo box when collapsed', () => {
+    renderNav({ mobile: false, drawerOpen: false, collapsed: true })
+
+    const rail = container.querySelector('[data-testid="dashboard-nav-rail"]')
+    expect(rail?.getAttribute('data-collapsed')).toBe('true')
+    // Collapsed brand = prototype .nav-home 38x38 monogram box (v2.css:242).
+    const brandHome = container.querySelector('.nav-brand .nav-home')
+    expect(brandHome).not.toBeNull()
+    expect(brandHome?.textContent?.trim()).toBe('M')
   })
 
   it('hides mobile tabs while reading keeper chat', () => {

--- a/dashboard/src/components/mobile-nav.ts
+++ b/dashboard/src/components/mobile-nav.ts
@@ -57,7 +57,10 @@ export function DashboardNavRail({
   onCloseDrawer,
 }: DashboardNavRailProps) {
   const effectiveCollapsed = mobile ? false : collapsed
-  const sideRailWidthClass = mobile ? 'w-72' : (collapsed ? 'w-14' : 'w-55')
+  // Collapsed rail = the keeper-v2 prototype's icon-only app rail.
+  // Width is the prototype's --nav-w: 58px (v2.css:232) — literal px because
+  // Tailwind's w-14 (56px) would shrink it by 2px off the spec.
+  const sideRailWidthClass = mobile ? 'w-72' : (collapsed ? 'w-[58px]' : 'w-55')
   const sideRailResponsiveClass = mobile
     ? drawerOpen
       ? 'block fixed inset-y-0 left-0 z-50 m-0 max-h-none rounded-none border-r'

--- a/dashboard/src/styles/v2-shell.css
+++ b/dashboard/src/styles/v2-shell.css
@@ -74,9 +74,30 @@
 }
 
 #dashboard-side-rail.v2-shell-rail[data-collapsed="true"] .nav-brand {
-  justify-content: center;
-  padding: 8px 6px;
+  /* Stack the logo box over the collapse toggle; prototype rail top is
+     padding:10px 0 (v2.css:239). */
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 6px 8px;
   margin-bottom: 6px;
+}
+
+/* Collapsed brand logo box — pixel-matched to the prototype .nav-home
+   (v2.css:242-249): 38x38 volt-filled square, var(--radius-sm)=4px corners,
+   display font 700 16px monogram on volt-ink, soft glow. */
+#dashboard-side-rail.v2-shell-rail .nav-brand .nav-home {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;             /* v2.css:243 */
+  height: 38px;            /* v2.css:243 */
+  border-radius: 4px;      /* v2.css:243 var(--radius-sm) = 4px */
+  font-family: var(--v2-font-display);
+  font-weight: 700;        /* v2.css:245 */
+  font-size: 16px;         /* v2.css:245 */
+  color: var(--volt-ink, var(--color-bg-page)); /* v2.css:246 --volt-ink */
+  background: var(--v2-accent-brand);           /* v2.css:246 --volt */
+  box-shadow: 0 0 14px var(--accent-glow, var(--ss-brand-tint)); /* v2.css:247 0 0 14px --volt-glow */
 }
 
 #dashboard-side-rail.v2-shell-rail .nav-brand .nb-title {
@@ -252,41 +273,72 @@
   box-shadow: inset 2px 0 0 var(--v2-accent-brand);
 }
 
-/* Collapsed rail: icon-only surface buttons */
+/* Collapsed rail: icon-only surface buttons.
+   Pixel-matched to the keeper-v2 prototype's .nav-item app-rail icon box
+   (v2.css:253-264): 46x46 box, radius var(--radius-sm)=4px, 22x22 svg,
+   text-dim default → text-bright on hover, volt-strong + left-edge bar on
+   active. Literal 46px/22px/4px because the dashboard's 2px-base --sp-*
+   tokens would not land on these exact prototype values. */
 #dashboard-side-rail.v2-shell-rail .nav-link-collapsed {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
-  margin: 2px auto;
-  border-radius: 10px;
+  width: 46px;             /* v2.css:254 .nav-item width */
+  height: 46px;            /* v2.css:254 .nav-item height */
+  margin: 0 auto;          /* vertical rhythm comes from the list gap (3px) */
+  border-radius: 4px;      /* v2.css:254 var(--radius-sm) = 4px (tokens v2.css:67) */
   border: 1px solid transparent;
   color: var(--v2-text-dim);
   cursor: pointer;
-  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+  position: relative;      /* anchors the active left-edge ::before bar */
+  transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
 }
 
-#dashboard-side-rail.v2-shell-rail[data-collapsed="true"] .nav-link-collapsed {
-  width: 38px;
-  height: 38px;
+/* Active = prototype .nav-item.on (v2.css:263): volt-strong glyph on bg-card,
+   with a 3px volt left-edge bar + glow (v2.css:264 ::before). */
+#dashboard-side-rail.v2-shell-rail .nav-link-collapsed.active {
+  background: var(--v2-surface-subtle);   /* prototype --bg-card */
+  color: var(--v2-accent-brand);          /* prototype --volt-strong (via accent) */
+  border-color: transparent;
+}
+
+#dashboard-side-rail.v2-shell-rail .nav-link-collapsed.active::before {
+  content: "";
+  position: absolute;
+  left: -10px;             /* v2.css:264 */
+  top: 10px;
+  bottom: 10px;
+  width: 3px;              /* v2.css:264 left-edge bar width */
+  background: var(--v2-accent-brand);     /* prototype --volt */
+  border-radius: 0 3px 3px 0;
+  box-shadow: 0 0 10px var(--accent-glow, var(--ss-brand-tint)); /* v2.css:264 0 0 10px var(--volt-glow) */
 }
 
 #dashboard-side-rail.v2-shell-rail .nav-link-collapsed:hover {
-  background: var(--v2-surface-subtle);
-  color: var(--v2-accent-brand);
-  border-color: var(--v2-border);
-}
-
-#dashboard-side-rail.v2-shell-rail .nav-link-collapsed.active {
-  background: var(--ss-brand-tint);
-  color: var(--v2-text-bright);
-  border-color: var(--v2-accent-brand);
+  background: var(--v2-surface-subtle);   /* prototype --bg-card (v2.css:262) */
+  color: var(--v2-text-bright);           /* prototype --text-bright (v2.css:262) */
+  border-color: transparent;
 }
 
 #dashboard-side-rail.v2-shell-rail .nav-link-collapsed .nav-icon > svg {
-  width: 18px;
-  height: 18px;
+  width: 22px;             /* v2.css:259 .nav-item svg */
+  height: 22px;
+}
+
+/* Collapsed nav list vertical rhythm — prototype .v2-nav uses gap:3px
+   (v2.css:238). The shared list uses Tailwind gap-1 (4px); tighten to the
+   prototype's 3px and center the icon column when collapsed. */
+#dashboard-side-rail.v2-shell-rail[data-collapsed="true"] .flex-1 > .flex.flex-col {
+  gap: 3px;
+  align-items: center;
+}
+
+/* Drop the list container's horizontal padding when collapsed so the 46px
+   icon box centers inside the 58px rail (prototype .v2-nav padding:10px 0,
+   v2.css:239). Tailwind px-2 (8px) would clip the box against overflow-hidden. */
+#dashboard-side-rail.v2-shell-rail[data-collapsed="true"] .flex-1.overflow-y-auto {
+  padding-left: 0;
+  padding-right: 0;
 }
 
 /* Health indicator footer */


### PR DESCRIPTION
## Approach: SAFE / CONTAINED (not a rewrite)

The dashboard already has a collapsible `SideRail` whose collapsed state renders icon-only `.nav-link-collapsed` links. The icon-rail = the collapsed SideRail. This PR pixel-matches that collapsed state to the keeper-v2 prototype's 58px icon-only app rail (`.v2-nav`) and flips the default to collapsed. No shell rewrite, no icon-system swap.

Ground-truth spec: `keeper-v2/styles/v2.css` `.v2-nav` block + `keeper-v2/shell.jsx` `NavRail`.

## Rail metrics: before -> after (with prototype citations)

| Element | Before | After | Prototype source |
|---|---|---|---|
| Collapsed rail width | `w-14` (56px) | `w-[58px]` | `--nav-w: 58px` (v2.css:232) |
| Brand box (collapsed) | none (chevron only) | `.nav-home` 38x38, radius 4px, volt bg, volt-ink "M", `0 0 14px` glow | `.nav-home` (v2.css:242-249) |
| Icon box `.nav-link-collapsed` | 38-40px, radius 10px | 46x46, radius 4px | `.nav-item` (v2.css:253-264) |
| Icon svg (collapsed) | 18x18 | 22x22 | `.nav-item svg` (v2.css:259) |
| Active state | tinted bg + accent border | bg-card + volt-strong glyph + 3px volt left-edge bar (`left:-10px; top/bottom:10px`) + `0 0 10px` glow | `.nav-item.on` + `::before` (v2.css:263-264) |
| Hover | accent color + border | text-bright on bg-card, transparent border | `.nav-item:hover` (v2.css:262) |
| Vertical rhythm | Tailwind gap-1 (4px) | 3px list gap, icon column centered, list horizontal padding dropped | `.v2-nav gap:3px; padding:10px 0` (v2.css:238-239) |

Colors use the dashboard's existing v2-shell semantic tokens, which alias 1:1 to the prototype's palette under `data-skin=v2` (`--v2-accent-brand`->`--color-accent-fg`->`--volt`, `--v2-surface-subtle`->`--color-bg-elevated`->`--bg-card`, `--accent-glow`->`--volt-glow`). Active/hover therefore track `data-volt` (brass/blood/ice) and paper theme automatically. Literal `46/38/22/4px` and `3px` are used per task spec because the dashboard's 2px-base `--sp-*` tokens would not land on these exact prototype values; each is commented with its v2.css source line.

Icons: the dashboard's existing `SurfaceIcon` glyph system is kept as-is (contained scope; the surfaces are not 1:1 with the prototype's set, and re-mapping every glyph would be out-of-scope churn risking regressions on every surface).

## Default-collapsed change

Flipped the `dashboard:sidebar-collapsed` persistent signal default `false -> true` (app.ts) so a fresh load shows the prototype's icon-only rail. Returning users keep their stored choice — the persistent signal only falls back to the default when no value is stored, so this is opt-out-preserving.

Test impact of the flip: 1 stale assertion in `app.test.ts` ("does not collapse the left rail out of view on desktop") matched `w-14|w-55`; updated to `w-[58px]|w-55` and added a `not w-full` guard to preserve the test's real intent (rail must carry a fixed width, not full-width). No other test assumed expanded-by-default.

## Tests

- Updated `mobile-nav.test.ts`: stale `w-14` -> `w-[58px]` (cited); added a test asserting the collapsed brand `.nav-home` "M" box renders.
- Updated `app.test.ts` width regex as above.
- `dashboard-shell.test.ts` collapsed-rail structural assertions still pass unchanged.
- Full suite: `npx vitest run` -> **582 files / 7610 tests passed**. (Two focus-timing tests — `use-focus-scope`, `connector-action-error` — flaked under parallel execution on intermediate runs but pass in isolation and passed clean on the final run; they share no state with the rail.)
- `tsc --noEmit`: clean (exit 0).

## Files changed
- `dashboard/src/app.ts` — default collapsed `false -> true`
- `dashboard/src/components/mobile-nav.ts` — collapsed width `w-14 -> w-[58px]`
- `dashboard/src/components/dashboard-shell.ts` — collapsed brand `.nav-home` "M" box
- `dashboard/src/styles/v2-shell.css` — collapsed icon box (46/22/4px), active left-edge bar, hover, brand box, 3px rhythm, list padding
- `dashboard/src/app.test.ts`, `dashboard/src/components/mobile-nav.test.ts` — assertion updates

RFC gate N/A — dashboard UI only (no files outside `dashboard/`).
