### PR TITLE
perf(eval_gate): precompile evasion regexes once at module load

### DIFF
--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -185,13 +185,26 @@ let evasion_indicators : evasion_indicator list = [
     callers that render the matched substring. The typed kind is
     available via {!detect_evasion_typed} for callers that need to
     discriminate. *)
+(** Precompile each evasion pattern once at module load.  [detect_evasion_typed]
+    runs in the pre-check gate for every shell tool invocation; the previous
+    code recompiled all {!evasion_indicators} patterns ([Re.Pcre.re |> Re.compile])
+    on every call.  Pairing the compiled regex with its indicator keeps the
+    typed return value unchanged and matches the module-level-compile idiom used
+    by [drift_guard] / [cache_eio]. *)
+let compiled_evasion_indicators : (Re.re * evasion_indicator) list =
+  List.map
+    (fun (indicator : evasion_indicator) ->
+      (Re.Pcre.re indicator.pattern |> Re.compile, indicator))
+    evasion_indicators
+
 let detect_evasion_typed (command : string) : evasion_indicator option =
   let cmd_lower = String.lowercase_ascii command in
-  List.find_opt (fun { pattern; _ } ->
-    Safe_ops.protect ~default:false (fun () ->
-      let re = Re.Pcre.re pattern |> Re.compile in
-      Re.execp re cmd_lower)
-  ) evasion_indicators
+  List.find_map
+    (fun (re, indicator) ->
+      if Safe_ops.protect ~default:false (fun () -> Re.execp re cmd_lower)
+      then Some indicator
+      else None)
+    compiled_evasion_indicators
 
 let detect_evasion (command : string) : (string * string) option =
   match detect_evasion_typed command with

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -363,6 +363,35 @@ let test_post_eval_result_to_yojson () =
     (json |> member "error_message" |> to_string)
 
 (* ================================================================ *)
+(* detect_evasion (guards the precompiled-regex refactor)           *)
+(* ================================================================ *)
+
+let test_detect_evasion_kinds () =
+  let check_kind label cmd expected =
+    match Eval_gate.detect_evasion_typed cmd with
+    | Some { Eval_gate.kind; _ } ->
+      Alcotest.(check string)
+        label
+        (Eval_gate.evasion_kind_to_string expected)
+        (Eval_gate.evasion_kind_to_string kind)
+    | None -> Alcotest.failf "%s: expected an evasion indicator" label
+  in
+  check_kind "variable expansion" "echo ${HOME}" Eval_gate.Variable_expansion;
+  check_kind "hex escape" {|printf \x41|} Eval_gate.Hex_escape;
+  check_kind "base64 decode pipe" "base64 -d payload"
+    Eval_gate.Base64_decode_pipe;
+  check_kind "eval invocation" "eval ls" Eval_gate.Eval_invocation;
+  check_kind "xargs destructive" "find . | xargs rm -f"
+    Eval_gate.Xargs_destructive
+
+let test_detect_evasion_benign () =
+  match Eval_gate.detect_evasion_typed "ls -la /tmp" with
+  | None -> ()
+  | Some { Eval_gate.kind; _ } ->
+    Alcotest.failf "benign command flagged as %s"
+      (Eval_gate.evasion_kind_to_string kind)
+
+(* ================================================================ *)
 (* Runner                                                            *)
 (* ================================================================ *)
 
@@ -371,6 +400,10 @@ let () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   Eio_guard.enable ();
   Alcotest.run "Eval_gate" [
+    ("evasion_detection", [
+      Alcotest.test_case "kinds detected" `Quick test_detect_evasion_kinds;
+      Alcotest.test_case "benign not flagged" `Quick test_detect_evasion_benign;
+    ]);
     ("destructive_detection", [
       Alcotest.test_case "detect rm -rf" `Quick test_detect_rm_rf;
       Alcotest.test_case "detect force push" `Quick test_detect_force_push;


### PR DESCRIPTION
## Problem

`Eval_gate.detect_evasion_typed` runs in the pre-check gate on every shell
tool invocation. On each call it recompiled all six evasion patterns:

```ocaml
List.find_opt (fun { pattern; _ } ->
  Safe_ops.protect ~default:false (fun () ->
    let re = Re.Pcre.re pattern |> Re.compile in  (* per call, per pattern *)
    Re.execp re cmd_lower)) evasion_indicators
```

The patterns are module-level constants, so this compiles six PCRE regexes
from scratch on every gated command — work the codebase already avoids
elsewhere (`drift_guard`, `cache_eio` compile their patterns once at module
load).

## Fix

Precompile the patterns once into a module-level
`compiled_evasion_indicators : (Re.re * evasion_indicator) list`, and have
`detect_evasion_typed` match against the cached regexes. The public type
`evasion_indicator` and the function signature are unchanged — the compiled
regex lives in an internal pairing list, not the public record.
`Safe_ops.protect` still wraps `Re.execp` so the gate cannot raise.

## Tests

`detect_evasion` had no direct coverage. Added `test/test_eval_gate.ml`
cases asserting each evasion kind is detected (variable expansion, hex
escape, base64 decode pipe, eval, xargs-destructive) and that a benign
command is not flagged. These pin detection behavior across the precompile
refactor.

Found via an adversarial deficiency hunt (regex-dynamic class), verified
refute-by-default.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
