### PR TITLE
fix(dashboard): isolate parallel payload sections via Cancel_safe.observe (resurrect task-864)

### DIFF
--- a/lib/server/server_dashboard_http_core.ml
+++ b/lib/server/server_dashboard_http_core.ml
@@ -527,19 +527,44 @@ let dashboard_shell_payload_json
       := measure_json_projection "meta_cognition" (fun () ->
            meta_cognition_summary_cached config)
     else
+      (* Isolate each parallel section: in [Eio.Fiber.all] a single fiber's
+         exception cancels its siblings and fails the whole payload. Route each
+         through [Cancel_safe.observe] (RFC-0106 SSOT) so an unexpected section
+         failure logs and lets the other sections complete; the section's ref
+         keeps its [(`Null, 0)] default, so the payload renders that one section
+         as null instead of returning a 500. [Eio.Cancel.Cancelled] is re-raised
+         by [Cancel_safe.observe] so fiber-tree unwind is preserved. *)
       Eio.Fiber.all
         [ (fun () ->
-            meta_cognition_r
-            := measure_json_projection "meta_cognition" (fun () ->
-                 meta_cognition_summary_cached config))
+            Cancel_safe.observe
+              ~on_exn:(fun exn ->
+                Log.Dashboard.error
+                  "dashboard meta_cognition section failed: %s"
+                  (Printexc.to_string exn))
+              (fun () ->
+                meta_cognition_r
+                := measure_json_projection "meta_cognition" (fun () ->
+                     meta_cognition_summary_cached config)))
         ; (fun () ->
-            config_resolution_r
-            := measure_json_projection "config_resolution" (fun () ->
-                 Config_dir_resolver.(resolve () |> to_json)))
+            Cancel_safe.observe
+              ~on_exn:(fun exn ->
+                Log.Dashboard.error
+                  "dashboard config_resolution section failed: %s"
+                  (Printexc.to_string exn))
+              (fun () ->
+                config_resolution_r
+                := measure_json_projection "config_resolution" (fun () ->
+                     Config_dir_resolver.(resolve () |> to_json))))
         ; (fun () ->
-            runtime_resolution_r
-            := measure_json_projection "runtime_resolution" (fun () ->
-                 Server_dashboard_http_runtime_info.runtime_resolution_json config))
+            Cancel_safe.observe
+              ~on_exn:(fun exn ->
+                Log.Dashboard.error
+                  "dashboard runtime_resolution section failed: %s"
+                  (Printexc.to_string exn))
+              (fun () ->
+                runtime_resolution_r
+                := measure_json_projection "runtime_resolution" (fun () ->
+                     Server_dashboard_http_runtime_info.runtime_resolution_json config)))
         ];
     let meta_cognition_json, meta_cognition_ms = !meta_cognition_r in
     let config_resolution_json, config_resolution_ms = !config_resolution_r in

--- a/test/dune
+++ b/test/dune
@@ -1158,7 +1158,7 @@
 (test
  (name test_cancel_safe)
  (modules test_cancel_safe)
- (libraries alcotest masc_cancel_safe eio))
+ (libraries alcotest masc_cancel_safe eio eio_main))
 
 ; Warn-log dedup table stays bounded under distinct token-hash-prefix churn.
 

--- a/test/test_cancel_safe.ml
+++ b/test/test_cancel_safe.ml
@@ -46,6 +46,33 @@ let test_observe_routes_then_reraises () =
    | Eio.Cancel.Cancelled _ -> reraised := true);
   check bool "observe re-raises Cancelled" true !reraised
 
+let test_observe_isolates_fiber_all_siblings () =
+  (* Regression for the dashboard payload isolation
+     (server_dashboard_http_core.dashboard_shell_payload_json): each parallel
+     section is wrapped in [Cancel_safe.observe] so one section's failure does
+     not cancel its siblings. In a bare [Eio.Fiber.all] a single fiber raising
+     cancels the whole group; [observe] routes the non-Cancelled exception to
+     [on_exn], so the failing fiber returns normally and the sibling fibers
+     run to completion. *)
+  Eio_main.run
+  @@ fun _env ->
+  let a = ref false in
+  let c = ref false in
+  let failures = ref 0 in
+  Eio.Fiber.all
+    [ (fun () ->
+        Cancel_safe.observe ~on_exn:(fun _ -> incr failures) (fun () -> a := true))
+    ; (fun () ->
+        Cancel_safe.observe
+          ~on_exn:(fun _ -> incr failures)
+          (fun () -> raise (Failure "section b")))
+    ; (fun () ->
+        Cancel_safe.observe ~on_exn:(fun _ -> incr failures) (fun () -> c := true))
+    ];
+  check bool "sibling a completed despite section b failing" true !a;
+  check bool "sibling c completed despite section b failing" true !c;
+  check int "exactly one section routed to on_exn" 1 !failures
+
 let () =
   run "cancel_safe"
     [ ( "protect"
@@ -54,5 +81,9 @@ let () =
         ; test_case "passes through success" `Quick test_passes_through_success
         ; test_case "observe routes then re-raises Cancelled" `Quick
             test_observe_routes_then_reraises
+        ] )
+    ; ( "fiber-all isolation"
+      , [ test_case "observe lets Fiber.all siblings complete" `Quick
+            test_observe_isolates_fiber_all_siblings
         ] )
     ]


### PR DESCRIPTION
## 목표

대시보드 페이로드(`dashboard_shell_payload_json`)는 독립적인 3개 projection(meta_cognition / config_resolution / runtime_resolution)을 `Eio.Fiber.all`로 병렬 실행한다. bare `Fiber.all`은 **한 fiber가 raise하면 형제 fiber를 취소**하므로, 한 섹션의 실패가 대시보드 페이로드 전체를 500으로 만든다. 각 섹션을 격리해 한 섹션이 실패해도 나머지가 완성되도록 한다.

> 방치 브랜치 적대 탐색(라운드 4, committed-but-no-PR 결)에서 발견한 dropped work `qa-king/task-864-fiber-all-isolation`(MASC-864, PR 미생성·10일 방치)을 현재 `origin/main` 위에서 **정제 부활**했다.

## 변경 내용

- `server_dashboard_http_core.ml`의 3개 섹션 fiber를 각각 `Cancel_safe.observe`(RFC-0106 SSOT)로 감쌌다. 예기치 못한 섹션 실패는 `Log.Dashboard.error`로 기록되고 형제 fiber는 완성된다. 실패한 섹션의 ref는 초기값 `(`Null, 0)`을 유지 → 해당 섹션만 `null`로 렌더링되고 나머지는 정상.
- `Eio.Cancel.Cancelled`는 `Cancel_safe.observe`가 항상 re-raise → fiber-tree unwind 보존(협조적 취소 정상 동작).
- 회귀 테스트(`test_cancel_safe`, `fiber-all isolation` 그룹): `Fiber.all` 안에서 한 fiber가 `observe`를 통해 raise해도 형제 fiber가 완성됨을 결정론적으로 증명.

### 원본 대비 정제 2가지

1. **SSOT 사용**: task-864 원본은 hand-rolled `try ... | Cancelled -> raise | exn -> log`였다. 같은 디렉토리의 `server_mcp_transport_http_respond.ml`이 이미 쓰는 `Cancel_safe.observe`(RFC-0106 SSOT)로 교체 — Cancelled re-raise 규율을 한 곳에 모은다(수동 arm 누락 위험 제거).
2. **scope 축소(가치 기반)**: 원본은 `operator_control_snapshot.ml`의 Fiber.all도 건드렸으나, 그 사이트는 fiber 2개 중 1개가 trivial(`empty_section`)이고 나머지(keepers+persistent_agents)는 순차 의존이라 한 fiber에 묶여 있다 → **격리해도 보호할 형제가 없는 no-op**. RFC-게이트(`operator_control*`) 표면을 기능 이득 0으로 건드리지 않기 위해 제외했다(N-of-M 회피가 아니라, 그 사이트엔 격리 가치가 없음).

## 설계 트레이드오프 (owner 판단 — Draft 유지 사유)

- **partial vs total 실패**: 이 변경은 "한 섹션 실패 시 500" → "그 섹션만 null + 나머지 정상 + 에러 로그"로 동작을 바꾼다. 관측성 페이로드에는 partial이 낫다고 본다(operator가 무언가는 본다, 어느 섹션이 죽었는지 로그로 드러난다). 다만 "섹션이 왜 실패하는가"라는 근본 원인을 격리가 **가리지 않도록** `Log.Dashboard.error`로 항상 기록한다 — silent 억제가 아니라 가시적 graceful degradation이다.
- 이 동작 변경(payload 경로)이 의도와 맞는지 owner 확인을 위해 Draft + `agent-pr`로 연다.

## 로컬 검증

- `dune build --root . @check` green(server 포함 전체 컴파일).
- `test_cancel_safe` 5 tests run, `Test Successful`(신규 fiber-all isolation 포함).
- ocamlformat clean(대상 `.ml` 2개 + test/dune 라인). repo 전반 dune-fmt 드리프트는 선재이며 본 PR 범위 밖.

## 범위 밖

- `operator_control_snapshot.ml` Fiber.all 격리(위 scope 사유로 제외).
- 섹션 projection을 주입 가능하게 만드는 리팩터(대시보드 payload 통합 테스트용) — 별도 작업. 현재는 격리 동작을 SSOT 콤비네이터 레벨 회귀 테스트로 증명.

RFC-0106(Cancel_safe SSOT) 인용. credential/operator/sandbox/hooks subsystem 무관(server dashboard payload 경로).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
