### PR TITLE
[v2] logs — colhd bottom hairline pixel-fix (follow-up to #22020)

### DIFF
--- a/dashboard/src/styles/v2-logs.css
+++ b/dashboard/src/styles/v2-logs.css
@@ -277,7 +277,10 @@
   padding: 10px 26px;
   border-top: 1px solid var(--border-main);
   color: var(--color-fg-muted);
-  border-bottom: 1px solid var(--color-border-divider);
+  /* --border-main (not --color-border-divider) — prototype logs.css:56 uses
+     --border-main for both top and bottom; the divider alias resolves to the
+     fainter --border-soft under data-skin=v2, a silent hairline regression. */
+  border-bottom: 1px solid var(--border-main);
   background: var(--bg-panel);
 }
 


### PR DESCRIPTION
## Why

Re-audit follow-up to merged PR #22020 (v2 logs pixel-match). PR #22020 was already squash-merged, so a post-merge commit to its branch would not reach main (workflow rule + masc#5303). This is the corrective PR.

## Change

`.v2-logs-table-header` bottom border used `--color-border-divider`, which under `data-skin=v2` (skin-v2.css) resolves to the fainter `--border-soft` (#1e1f29). The prototype (`keeper-v2/styles/logs.css:56`, `.lg-colhd`) uses `--border-main` (#282a36) for BOTH the top and bottom hairline. The wrong alias was a silent color regression — the column-header bottom rule rendered fainter than the prototype.

Fixed to `--border-main` to match the prototype on both edges.

## Audit scope

Full property-by-property re-audit of every shared `.lg-*` <-> `.v2-logs-*` rule (header, stats, toolbar, filter chips, column header, rows, kind badges, time/identity/message, caret, detail). ~70 properties checked. All other values already matched after #22020 (104px kind column, h1 -0.01em letter-spacing, gaps/paddings, sev border-left colors, kind data-attr colors, radial bg). Token aliases verified to resolve to the same hex/px under data-skin=v2 (--volt / --text-mid / --border-main / --radius-pill).

Detail body (`.v2-logs-detail-grid` + StatusChip tags) and toolbar advanced-menu / provider-panel are grounded real-data structures, not 1:1 mock ports — intentionally out of literal-port scope; their shared typographic values (10px uppercase key / 12px bright value) still align to prototype `.lg-kv-k` / `.lg-kv-v`.

## Verify
- `npx tsc --noEmit` clean
- `npx vitest run src/components/logs.test.ts src/config/navigation.test.ts` -> 69 passed
- CSS-only token swap on a line not covered by JS/TS execution; coverage gate unaffected.

RFC-WAIVED: dashboard surface CSS pixel-fix, no credential/identity/operator/hooks/workflow surface touched.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
