### PR TITLE
refactor(keeper): decouple no-progress detector from social-model delivery_surface (RFC-0276 Phase 2a)

### DIFF
--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -73,9 +73,60 @@ let no_work_budget_threshold_override
   else None
 ;;
 
-let apply_loop_detectors ~config ~observation ~social_state updated_meta result =
-  (* RFC-0239 §3 R3: feed the loop detector a semantic no-progress verdict
-     instead of the literal speech_act. A turn makes progress if it produced
+(* RFC-0276 §3.2: runtime-observed delivery classification. Replaces the LLM
+   self-declared [delivery_surface] (the social-model header protocol) as the
+   input to the no-progress loop detector. Derived once from turn facts already
+   in scope — the tool names actually called and whether visible text was
+   emitted — so the anti-thrash verdict no longer trusts a model-authored
+   header.
+
+   Tool-capability classification is delegated to [Keeper_tool_capability_axis],
+   the typed SSOT for tool-name capabilities, rather than matching tool-name
+   string literals here (CLAUDE.md anti-pattern #1: no scattered hardcoded tool
+   names; the social-model [inferred_tool_surface] enumerated the same names and
+   is removed in RFC-0276 Phase 2b). *)
+type turn_delivery =
+  | Peer_only
+    (* peer-surface tool (board/comment/broadcast/keeper-msg), or silent:
+       no peer/claim tool and no visible text *)
+  | User_facing (* non-empty visible reply, no peer/claim tool *)
+  | Task_claim (* task-claim tool *)
+
+(* Classify from observable facts. Order is significant: a turn that calls a
+   peer-surface tool is [Peer_only] even if it also produced text, because the
+   board/broadcast post is the salient delivery; a claim turn is exempt because
+   claiming is itself progress (RFC-0239). *)
+let classify_delivery ~tools ~has_visible_text =
+  if Keeper_tool_capability_axis.(supports_any Board_activity tools)
+  then Peer_only
+  else if Keeper_tool_capability_axis.(supports_any Claim_task tools)
+  then Task_claim
+  else if has_visible_text
+  then User_facing
+  else Peer_only
+;;
+
+let classify_turn_delivery result =
+  classify_delivery
+    ~tools:(Keeper_agent_result.tool_names result)
+    ~has_visible_text:(String.trim result.Keeper_agent_run.response_text <> "")
+;;
+
+(* A peer-only or silent turn must show durable evidence to count as progress; a
+   user-facing reply or a task claim is exempt. Preserves the pre-RFC-0276
+   [delivery_surface] mapping (Board_*/Broadcast/Silent -> true;
+   Visible_reply/Task_claim -> false). Exhaustive, no [_ ->] catch-all
+   (CLAUDE.md anti-pattern #4): a new [turn_delivery] variant must be classified
+   here at compile time. *)
+let delivery_requires_evidence = function
+  | Peer_only -> true
+  | User_facing | Task_claim -> false
+;;
+
+let apply_loop_detectors ~config ~observation updated_meta result =
+  (* RFC-0239 §3 R3 / RFC-0276 §3.2: feed the loop detector a semantic
+     no-progress verdict derived from observed turn facts, not the LLM
+     self-declared delivery_surface. A turn makes progress if it produced
      durable evidence (substantive tool calls or validated output); a turn that
      only posts to peers (board/comment/broadcast) or stays silent without such
      evidence accrues the streak. The old speech_act="stay_silent" check reset
@@ -86,10 +137,7 @@ let apply_loop_detectors ~config ~observation ~social_state updated_meta result 
     || Option.is_some (KUM.visible_run_validation result)
   in
   let surface_requires_evidence =
-    match social_state.Social.delivery_surface with
-    | Social.Board_post | Social.Board_comment | Social.Broadcast_surface
-    | Social.Silent -> true
-    | Social.Visible_reply | Social.Task_claim_surface -> false
+    delivery_requires_evidence (classify_turn_delivery result)
   in
   let made_progress =
     Keeper_no_progress_loop_detector.turn_made_progress
@@ -129,6 +177,14 @@ let apply_loop_detectors ~config ~observation ~social_state updated_meta result 
 
 module For_testing = struct
   let no_work_budget_threshold_override = no_work_budget_threshold_override
+
+  type nonrec turn_delivery = turn_delivery =
+    | Peer_only
+    | User_facing
+    | Task_claim
+
+  let classify_delivery = classify_delivery
+  let delivery_requires_evidence = delivery_requires_evidence
 end
 
 let append_metrics_snapshot
@@ -521,7 +577,7 @@ let handle
       result
   in
   let updated_meta =
-    apply_loop_detectors ~config ~observation ~social_state updated_meta result
+    apply_loop_detectors ~config ~observation updated_meta result
   in
   append_metrics_snapshot
     ~config

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -95,7 +95,19 @@ type turn_delivery =
 (* Classify from observable facts. Order is significant: a turn that calls a
    peer-surface tool is [Peer_only] even if it also produced text, because the
    board/broadcast post is the salient delivery; a claim turn is exempt because
-   claiming is itself progress (RFC-0239). *)
+   claiming is itself progress (RFC-0239). This precedence (peer > claim > text)
+   mirrors the removed social-model [inferred_tool_surface] if/else-if order, so
+   a multi-signal turn cannot flip the anti-thrash verdict to exempt.
+
+   Behavior change (RFC-0276 §2.4): the [Board_activity] capability set is
+   {keeper_board_post, keeper_board_comment, masc_broadcast, masc_keeper_msg} —
+   wider than the old social-model peer set {board_post, board_comment,
+   broadcast} by [masc_keeper_msg] (keeper->keeper message). A turn that only
+   sends a peer message with no durable evidence now accrues the no-progress
+   streak (it previously reset it). This is intentional: a bare peer message is
+   exactly the "posts to peers without evidence" case RFC-0239 targets. The set
+   is pinned in test_no_progress_loop_detector so any axis change forces a
+   conscious no-progress review. *)
 let classify_delivery ~tools ~has_visible_text =
   if Keeper_tool_capability_axis.(supports_any Board_activity tools)
   then Peer_only

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -14,6 +14,20 @@ module For_testing : sig
     -> surface_requires_evidence:bool
     -> observation:Keeper_world_observation.world_observation
     -> int option
+
+  (** RFC-0276 §3.2 runtime-observed delivery classification (replaces the LLM
+      self-declared [delivery_surface] as the no-progress detector input). *)
+  type turn_delivery =
+    | Peer_only
+    | User_facing
+    | Task_claim
+
+  val classify_delivery
+    :  tools:string list
+    -> has_visible_text:bool
+    -> turn_delivery
+
+  val delivery_requires_evidence : turn_delivery -> bool
 end
 
 val handle

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -12,6 +12,7 @@ module D = Masc.Keeper_no_progress_loop_detector
 module Metrics = Masc.Otel_metric_store
 module Success = Masc.Keeper_unified_turn_success.For_testing
 module WO = Masc.Keeper_world_observation
+module Cap = Masc.Keeper_tool_capability_axis
 
 (* Detector now uses Eio.Mutex (was Stdlib.Mutex; the latter raised EDEADLK
    under any fiber contention). Every public entry needs an Eio fiber
@@ -247,6 +248,77 @@ let test_no_progress_board_post_accrues_streak () =
   Alcotest.(check int) "board posts without evidence accrue streak" 4
     (D.current_streak ~keeper_name:k)
 
+(* RFC-0276 §3.2: the no-progress detector input is derived from observed turn
+   facts (tool names + visible text) via [classify_delivery], replacing the LLM
+   self-declared delivery_surface. These tests pin the mapping the detector
+   relies on. *)
+let delivery_label = function
+  | Success.Peer_only -> "peer_only"
+  | Success.User_facing -> "user_facing"
+  | Success.Task_claim -> "task_claim"
+
+let classify ~tools ~has_visible_text =
+  delivery_label (Success.classify_delivery ~tools ~has_visible_text)
+
+let test_classify_delivery_mapping () =
+  let claim_tool = List.hd Cap.claim_task_tool_names in
+  (* Every peer-surface tool (SSOT list) classifies as Peer_only, with or
+     without text — the board/broadcast post is the salient delivery. *)
+  List.iter
+    (fun t ->
+      Alcotest.(check string)
+        (Printf.sprintf "board_activity tool %s -> peer_only" t)
+        "peer_only"
+        (classify ~tools:[ t ] ~has_visible_text:false);
+      Alcotest.(check string)
+        (Printf.sprintf "board_activity tool %s + text -> peer_only" t)
+        "peer_only"
+        (classify ~tools:[ t ] ~has_visible_text:true))
+    Cap.board_activity_tool_names;
+  (* Claim tool is exempt (claiming is progress, RFC-0239). *)
+  Alcotest.(check string) "claim tool -> task_claim" "task_claim"
+    (classify ~tools:[ claim_tool ] ~has_visible_text:false);
+  (* No peer/claim tool + visible text -> user-facing reply (exempt). *)
+  Alcotest.(check string) "no tool + text -> user_facing" "user_facing"
+    (classify ~tools:[] ~has_visible_text:true);
+  (* No peer/claim tool + no text = silent turn -> Peer_only (requires
+     evidence). This is the parse-don't-validate replacement for the old
+     DELIVERY_SURFACE: silent header self-declaration. *)
+  Alcotest.(check string) "no tool + no text (silent) -> peer_only" "peer_only"
+    (classify ~tools:[] ~has_visible_text:false);
+  (* A non-peer, non-claim tool with no visible text is still routed by surface
+     only (Peer_only); strong_evidence (substantive tool calls) is the separate
+     channel that lets such a turn count as progress. *)
+  let exec_tool = List.hd Cap.shell_command_input_tool_names in
+  Alcotest.(check string) "exec-only no text -> peer_only" "peer_only"
+    (classify ~tools:[ exec_tool ] ~has_visible_text:false)
+
+let test_delivery_requires_evidence_mapping () =
+  Alcotest.(check bool) "peer_only requires evidence" true
+    (Success.delivery_requires_evidence Success.Peer_only);
+  Alcotest.(check bool) "user_facing exempt" false
+    (Success.delivery_requires_evidence Success.User_facing);
+  Alcotest.(check bool) "task_claim exempt" false
+    (Success.delivery_requires_evidence Success.Task_claim)
+
+(* End-to-end: silent no-evidence turns (no tools, no visible text) accrue the
+   streak through the decoupled classification path, mirroring the board-post
+   anti-thrash test but via the RFC-0276 fact-derived surface. *)
+let test_silent_turns_accrue_streak () =
+  let k = "decouple_silent_thrash" in
+  for _ = 1 to 4 do
+    let surface_requires_evidence =
+      Success.delivery_requires_evidence
+        (Success.classify_delivery ~tools:[] ~has_visible_text:false)
+    in
+    record_turn ~keeper_name:k
+      ~made_progress:
+        (D.turn_made_progress ~strong_evidence:false ~surface_requires_evidence)
+    |> ignore_outcome
+  done;
+  Alcotest.(check int) "silent no-evidence turns accrue streak" 4
+    (D.current_streak ~keeper_name:k)
+
 let () =
   Alcotest.run "keeper_no_progress_loop_detector"
     [
@@ -275,6 +347,15 @@ let () =
             `Quick (with_eio test_latched_no_repeat_while_streak_grows);
           Alcotest.test_case "latch releases on reset, then re-fires"
             `Quick (with_eio test_latch_releases_on_reset_then_refires);
+        ] );
+      ( "RFC-0276 delivery decouple",
+        [
+          Alcotest.test_case "classify_delivery maps observed facts"
+            `Quick test_classify_delivery_mapping;
+          Alcotest.test_case "delivery_requires_evidence mapping"
+            `Quick test_delivery_requires_evidence_mapping;
+          Alcotest.test_case "silent no-evidence turns accrue streak"
+            `Quick (with_eio test_silent_turns_accrue_streak);
         ] );
       ( "per-keeper isolation",
         [

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -262,22 +262,60 @@ let classify ~tools ~has_visible_text =
 
 let test_classify_delivery_mapping () =
   let claim_tool = List.hd Cap.claim_task_tool_names in
-  (* Every peer-surface tool (SSOT list) classifies as Peer_only, with or
-     without text — the board/broadcast post is the salient delivery. *)
+  (* Pin the EXACT peer-surface set that the no-progress classifier treats as
+     evidence-requiring. Intentionally an explicit literal, NOT
+     [Cap.board_activity_tool_names] iterated: iterating the axis would be
+     tautological (it could never detect the axis growing a 5th tool). If
+     [Keeper_tool_capability_axis] adds a Board_activity tool, this assertion
+     fails and forces a conscious decision about its no-progress impact —
+     converting the policy<->taxonomy coupling from silent to guarded.
+
+     vs the removed social-model [inferred_tool_surface] set
+     {keeper_board_comment, keeper_board_post, keeper_broadcast}: this set adds
+     [masc_keeper_msg] (keeper->keeper message; [masc_broadcast] is the public
+     name of the same [keeper_broadcast] tool). That is an intentional, more
+     complete peer-surface definition (RFC-0276 §2.4 / §3.2 behavior change): a
+     turn that only sends a peer message with no durable evidence now accrues
+     the streak, matching RFC-0239's "only posts to peers without evidence"
+     intent, where the old social model let a bare keeper-msg turn reset it. *)
+  let expected_peer_tools =
+    [ "keeper_board_comment"
+    ; "keeper_board_post"
+    ; "masc_broadcast"
+    ; "masc_keeper_msg"
+    ]
+  in
+  Alcotest.(check (slist string String.compare))
+    "peer-surface set is exactly the pinned list (axis-drift guard)"
+    expected_peer_tools Cap.board_activity_tool_names;
+  (* Every pinned peer tool -> Peer_only, with or without text: a turn that
+     calls a peer-surface tool is Peer_only even when it also produced text,
+     because the peer post is the salient delivery (tools dominate text). *)
   List.iter
     (fun t ->
       Alcotest.(check string)
-        (Printf.sprintf "board_activity tool %s -> peer_only" t)
-        "peer_only"
+        (Printf.sprintf "peer tool %s -> peer_only" t) "peer_only"
         (classify ~tools:[ t ] ~has_visible_text:false);
       Alcotest.(check string)
-        (Printf.sprintf "board_activity tool %s + text -> peer_only" t)
+        (Printf.sprintf "peer tool %s + text -> peer_only (tools dominate text)"
+           t)
         "peer_only"
         (classify ~tools:[ t ] ~has_visible_text:true))
-    Cap.board_activity_tool_names;
-  (* Claim tool is exempt (claiming is progress, RFC-0239). *)
+    expected_peer_tools;
+  (* Multi-signal precedence (RFC-0276 §3.2 total derivation): a turn carrying
+     both a peer tool and a claim tool, plus text, is Peer_only — peer-posting
+     dominates claim, which dominates text. Mirrors the removed
+     inferred_tool_surface if/else-if order so the anti-thrash invariant cannot
+     flip to exempt on a multi-signal turn. *)
+  Alcotest.(check string) "peer + claim + text -> peer_only" "peer_only"
+    (classify ~tools:[ "keeper_board_post"; claim_tool ] ~has_visible_text:true);
+  (* Claim tool is exempt (claiming is progress, RFC-0239); claim dominates
+     text. *)
   Alcotest.(check string) "claim tool -> task_claim" "task_claim"
     (classify ~tools:[ claim_tool ] ~has_visible_text:false);
+  Alcotest.(check string) "claim + text -> task_claim (claim dominates text)"
+    "task_claim"
+    (classify ~tools:[ claim_tool ] ~has_visible_text:true);
   (* No peer/claim tool + visible text -> user-facing reply (exempt). *)
   Alcotest.(check string) "no tool + text -> user_facing" "user_facing"
     (classify ~tools:[] ~has_visible_text:true);


### PR DESCRIPTION
## 목적

no-progress loop detector(RFC-0239)를 social model의 `delivery_surface`(LLM 자기선언 헤더)에서 **떼어내** 런타임 관측 사실 기반으로 재정초한다. RFC-0276(#22035) §3.2의 **Phase 2a**다.

이 PR은 social model을 **삭제하지 않는다** — 여전히 컴파일된다. 삭제(Phase 2b) 전에 안전망(detector)을 먼저 fact 기반으로 옮겨 green 머지하는 순서다(RFC-0276 §4).

## 변경

`keeper_unified_turn_success.ml`의 `surface_requires_evidence`가 `social_state.delivery_surface`를 match하던 것을, 턴 사실에서 유도한 typed `turn_delivery`로 교체:

```ocaml
type turn_delivery =
  | Peer_only    (* board/comment/broadcast/keeper-msg 도구, 또는 도구 없고 가시 텍스트 없는 silent *)
  | User_facing  (* 비어있지 않은 가시 응답 *)
  | Task_claim   (* claim 도구 *)
```

- 도구 분류는 `Keeper_tool_capability_axis`(typed SSOT)에 위임 — board 도구명 리터럴을 여기 박지 않는다(CLAUDE.md 안티패턴 #1; social model `inferred_tool_surface`가 같은 이름을 enumerate했고 Phase 2b에서 제거).
- `apply_loop_detectors`는 더 이상 `~social_state`를 받지 않는다.
- exhaustive match, `_ ->` catch-all 없음(CLAUDE.md 안티패턴 #4).

## Behavior change (의도적, RFC-0276 §3.2 / 적대검증 C1)

이전에 **도구 없이** `DELIVERY_SURFACE: board_post` 헤더를 자기선언한 턴은, 이제 텍스트를 냈으면 `User_facing`, 아니면 `Peer_only`로 분류된다. 보드에 글을 올리려면 keeper가 **보드 도구를 호출**해야 한다(관측 가능) — 헤더를 주장하는 것(검증 불가)이 아니다. 도구를 호출한 턴과 silent 턴은 영향 없고, anti-thrash 불변식은 유지된다.

## 테스트

`test_no_progress_loop_detector`(test/dune 등록된 live 테스트)에 추가:

- `classify_delivery`가 모든 `board_activity` SSOT 도구명 / claim / text / silent / exec-only를 올바로 매핑.
- `delivery_requires_evidence` 매핑(Peer_only→true, User_facing|Task_claim→false).
- silent no-evidence 턴이 decouple된 경로로 streak를 누적하는 end-to-end(기존 board-post anti-thrash 테스트의 fact 기반 대응물).

## 검증

빌드/테스트는 CI(`CI Gate`)에서 확인한다. 로컬 `dune build`는 이 환경에서 SIGURG(144)로 즉사하므로 의존하지 않는다.

RFC-WAIVED: 본 PR은 keeper turn 제어흐름 변경으로 credential/operator/sandbox/dashboard-credential/hooks/workflow subsystem이 아니다. 거버넌스 산출물은 RFC-0276(#22035).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
