### PR TITLE
fix(keeper): retire max-turn watchdog — capped keeper lifetime, not a turn (RFC-0125 P4 / RFC-0250)

### DIFF
--- a/docs/rfc/RFC-0125-bounded-subprocess-discipline.md
+++ b/docs/rfc/RFC-0125-bounded-subprocess-discipline.md
@@ -23,8 +23,33 @@ window before semaphore over-release removal.
 | P1 ratchet | #15958 | **Closed** | `scripts/lint-spawn-bounded.sh` + `.github/workflows/spawn-bounded-check.yml` + 5-site allowlist (~135 LoC) |
 | P2 keeper_docker default audit | — | **Closed — no action** | audit revealed `default_timeout_sec () = 2s` (typed Sandbox caller); both sites already bounded |
 | P3 runtime socket budget | — | **Out of scope** | blocked on `Agent_sdk` upstream + RFC-0107 D.2c (runtime-facing client migration) |
-| P4 supervisor watchdog | #15964 | **Closed** | opt-in `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC`, reuses `In_turn_hung` (no new variant) |
+| P4 supervisor watchdog | #15964 | **Retired (2026-06-22)** | opt-in `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC`, reused `In_turn_hung`. **Removed** — the `Eio.Fiber.first` timer wrapped the whole keepalive loop, capping keeper *lifetime* (not a single turn). See Amendment (2026-06-22) below. |
 | P5 deprecation marker | #15973 | tracking | `force_release_holder_for` marked WORKAROUND; removal blocked on 30-day `metric_keeper_provider_timeout_watchdog_termination` trend -> 0 |
+
+### Amendment (2026-06-22): P4 retired — max-turn watchdog removed
+
+P4's keeper-level max-turn watchdog is **removed** from
+`keeper_supervisor_launch.ml`. Root cause: the
+`Eio.Fiber.first (Eio.Time.sleep clock t) (run_heartbeat_loop)` pattern wrapped
+the *entire* keepalive loop, so the timer measured keeper **lifetime** from
+launch and was never reset per turn. With a positive
+`MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` (e.g. the default-on flip proposed in
+\#21967), every keeper alive past the threshold — healthy multi-turn or idle
+alike — was stamped `In_turn_hung` and force-restarted. Despite the
+`In_turn_hung` name it capped process lifetime, not a single stuck turn.
+
+Per-turn wall-clock timeouts are a deliberately-removed pattern
+(`keeper_unified_turn_attempt_watchdog`: "MASC must not impose a wall-clock
+timeout around the whole provider/tool"; RFC-0250 §"deliberately removed").
+In-turn / idle recovery is already provided, turn-scoped, by:
+
+- `assess_stale_run` → `Idle_turn` (no turn produced; `MASC_KEEPER_STALE_RUN_SEC`, default-on)
+- `assess_in_turn_progress` → `Mid_turn_no_progress` (in-turn no-progress; RFC-0012)
+
+`In_turn_hung` is now a producer-less variant (consumers retained for the closed
+sum). `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` is parsed but ignored (no-op
+stub; remove in a follow-up). Regression guard:
+`test_keeper_supervisor.ml` "tool in flight far past threshold → None".
 
 ### implementation_prs reconciliation
 

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -188,8 +188,10 @@ end
 module Keeper_max_turn_watchdog : sig
   val timeout_sec_opt : unit -> float option
   (** DEPRECATED / no-op. Parses [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC]
-      ([Some t] when positive, else [None]), but the supervisor no longer calls
-      this, so the env var has no effect.
+      ([Some t] when positive, else [None]). The supervisor calls this only to
+      emit a one-time deprecation warning when the knob is set
+      ([Keeper_supervisor_launch.warn_retired_max_turn_watchdog_if_set]); it
+      never acts on the value, so the env var has no effect on behavior.
 
       The keeper-level max-turn wall-clock watchdog was removed from
       [keeper_supervisor_launch.ml] (RFC-0250 alignment). It used

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -183,26 +183,25 @@ module Approval_janitor : sig
   val interval_seconds : float
 end
 
-(** {1 Keeper max-turn watchdog (RFC-0109 P4)} *)
+(** {1 Keeper max-turn watchdog (RFC-0125 P4) — RETIRED} *)
 
 module Keeper_max_turn_watchdog : sig
   val timeout_sec_opt : unit -> float option
-  (** [timeout_sec_opt ()] returns the keeper-level max-turn wall-clock
-      budget when [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC] is set to
-      a positive number, or [None] when the env var is unset / zero /
-      negative.
+  (** DEPRECATED / no-op. Parses [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC]
+      ([Some t] when positive, else [None]), but the supervisor no longer calls
+      this, so the env var has no effect.
 
-      When [Some t] is returned, the supervisor races each keeper's
-      [Keeper_keepalive.run_heartbeat_loop] against
-      [Eio.Time.sleep ctx.clock t] via [Eio.Fiber.first]. Timer expiry
-      cancels the keepalive fiber and stamps [Stale_turn_timeout
-      "max_turn_watchdog"] on the registry so [sweep_and_recover]
-      restarts the keeper instead of treating the cancellation as a
-      clean stop.
-
-      Default: [None] (disabled). Recommended live value: [600.0]
-      (10 minutes). Set lower for aggressive sangsu-style stuck
-      recovery, higher for long-running research keepers. *)
+      The keeper-level max-turn wall-clock watchdog was removed from
+      [keeper_supervisor_launch.ml] (RFC-0250 alignment). It used
+      [Eio.Fiber.first] to race the whole [Keeper_keepalive.run_heartbeat_loop]
+      against [Eio.Time.sleep], which measured keeper {e lifetime} from launch
+      (never reset per turn) and so capped long-lived keepers rather than a
+      single stuck turn. Per-turn wall-clock timeouts are a deliberately-removed
+      pattern ([Keeper_unified_turn_attempt_watchdog]: "MASC must not impose a
+      wall-clock timeout around the whole provider/tool"). Turn-scoped recovery
+      now lives in [Keeper_stale_run] ([Idle_turn]) and
+      [Keeper_mid_turn_progress] ([Mid_turn_no_progress]). Stub retained for
+      env-knob-catalog / in-flight-branch stability; remove in a follow-up. *)
 end
 
 (** {1 Keeper stale-run window (RFC-0250)} *)
@@ -213,7 +212,7 @@ module Keeper_stale_run : sig
       when [MASC_KEEPER_STALE_RUN_SEC] is positive, or [None] when unset /
       zero / negative.
 
-      Distinct from [Keeper_max_turn_watchdog] (opt-in, [In_turn_hung]):
+      Distinct from [Keeper_max_turn_watchdog] (retired; formerly [In_turn_hung]):
       this keys on [last_turn_ts] while [current_turn_observation = None],
       producing [Idle_turn] — the no-turn-produced case. Default-on at
       [1800.0] (30 min). *)
@@ -227,8 +226,8 @@ module Keeper_mid_turn_progress : sig
       when [MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC] is positive, or [None]
       when unset / zero / negative.
 
-      Distinct from [Keeper_max_turn_watchdog] (wall-clock, [In_turn_hung]) and
-      [Keeper_stale_run] (no-turn, [Idle_turn]): keys on
+      Distinct from [Keeper_max_turn_watchdog] (retired; formerly [In_turn_hung])
+      and [Keeper_stale_run] (no-turn, [Idle_turn]): keys on
       [current_turn_observation.last_progress_at] while a turn is running,
       producing [Mid_turn_no_progress] when no progress event has been recorded
       for longer than the threshold.

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -14,6 +14,29 @@ module Startup_helpers = Keeper_supervisor_startup_helpers
 let backoff_delay = Startup_helpers.backoff_delay
 let keep_last_n = Startup_helpers.keep_last_n
 
+(* RFC-0125 P4 / RFC-0250: the max-turn watchdog was retired (it capped keeper
+   lifetime, not a turn — see [launch_supervised_fiber] below). The
+   [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC] knob is no longer consumed by the
+   supervisor, so an operator who still sets it would otherwise get a silent
+   no-op. Emit one process-wide deprecation WARN (on the first set-and-launch)
+   so the dead knob is visible until the env module + auto-generated
+   runtime-tunables catalog are removed in a follow-up. *)
+let warned_retired_max_turn_watchdog = Atomic.make false
+
+let warn_retired_max_turn_watchdog_if_set () =
+  match Env_config_runtime.Keeper_max_turn_watchdog.timeout_sec_opt () with
+  | Some timeout_s
+    when not (Atomic.exchange warned_retired_max_turn_watchdog true) ->
+    Log.Keeper.warn
+      "MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC=%.1fs is set but the max-turn \
+       watchdog was retired (RFC-0125 P4 / RFC-0250: MASC must not impose a \
+       wall-clock timeout on a turn); it has no effect. Turn-scoped recovery \
+       uses MASC_KEEPER_STALE_RUN_SEC (Idle_turn) and \
+       MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC (Mid_turn_no_progress)."
+      timeout_s
+  | _ -> ()
+;;
+
 (** supervision_cohort cluster moved to Keeper_supervisor_types
     (intra-library file split, 2026-05-16). *)
 include Keeper_supervisor_types
@@ -179,7 +202,10 @@ let launch_supervised_fiber
                 따라서 keepalive loop 를 race 없이 직접 실행한다. [In_turn_hung]
                 variant 는 producer 가 사라져 consumer-only (closed sum) 로 남는다;
                 아래 watchdog_triggered 분기는 sweep 이 stamp 한 다른 stale reason
-                ([Idle_turn] / [Mid_turn_no_progress] 등) 으로 계속 작동한다. *)
+                ([Idle_turn] / [Mid_turn_no_progress] 등) 으로 계속 작동한다.
+                set-but-ignored knob 가 silent no-op 가 되지 않도록, retired knob
+                가 설정돼 있으면 1 회 deprecation WARN 을 남긴다. *)
+             warn_retired_max_turn_watchdog_if_set ();
              Keeper_keepalive.run_heartbeat_loop
                ~proactive_warmup_sec
                ctx

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -158,51 +158,34 @@ let launch_supervised_fiber
       Eio_guard.protect
         (fun () ->
            try
-             (* RFC-0125 P4: opt-in keeper-level max-turn watchdog.
-                When [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC] is set
-                to a positive float, race the keepalive loop against
-                [Eio.Time.sleep ctx.clock t] via [Eio.Fiber.first].
-                Timer expiry stamps
-                [Stale_turn_timeout (In_turn_hung ...)] BEFORE the
-                timer fiber returns so the existing watchdog_triggered
-                branch (below) treats the cancellation as a crash and
-                [sweep_and_recover] restarts the keeper. Default
-                disabled — opt-in. *)
-             (match
-                Env_config_runtime.Keeper_max_turn_watchdog.timeout_sec_opt
-                  ()
-              with
-              | None ->
-                Keeper_keepalive.run_heartbeat_loop
-                  ~proactive_warmup_sec
-                  ctx
-                  meta
-                  reg.fiber_stop
-                  ~wakeup:reg.fiber_wakeup
-              | Some timeout_s ->
-                Eio.Fiber.first
-                  (fun () ->
-                    Eio.Time.sleep ctx.clock timeout_s;
-                    Keeper_registry.set_failure_reason
-                      ~base_path
-                      meta.name
-                      (Some
-                         (Keeper_registry.Stale_turn_timeout
-                            (Keeper_registry_types.In_turn_hung
-                               { active_seconds = timeout_s
-                               ; timeout_threshold = timeout_s
-                               })));
-                    Log.Keeper.warn
-                      "%s: max-turn watchdog fired after %.1fs (RFC-0125 P4)"
-                      meta.name
-                      timeout_s)
-                  (fun () ->
-                    Keeper_keepalive.run_heartbeat_loop
-                      ~proactive_warmup_sec
-                      ctx
-                      meta
-                      reg.fiber_stop
-                      ~wakeup:reg.fiber_wakeup));
+             (* RFC-0125 P4 의 keeper-level max-turn watchdog ([In_turn_hung]
+                wall-clock timer) 를 제거한다 (RFC-0250 §"deliberately removed"
+                정렬). 그 타이머는 [Eio.Fiber.first] 로 keepalive loop 전체를 감싸
+                keeper *launch* 이후 wall-clock 을 쟀고 — 턴 경계마다 리셋되지
+                않으므로 — 단일 턴이 아니라 keeper lifetime 을 cap 했다. 결과적으로
+                30 분 넘게 사는 정상 keeper (짧은 턴을 여러 번 처리했든 idle 이든)
+                도 [In_turn_hung] 으로 강제 재시작되었다. [In_turn_hung] 이라는
+                이름과 달리 "현재 턴이 너무 오래" 가 아니라 "프로세스가 너무 오래"
+                를 측정한 것이다.
+
+                per-turn wall-clock timeout 은 의도적으로 금지된 패턴이다:
+                [Keeper_unified_turn_attempt_watchdog] .mli — "MASC must not impose
+                a wall-clock timeout around the whole provider/tool". in-turn-hung /
+                idle 복구는 supervisor sweep 의 [assess_in_turn_progress]
+                ([Mid_turn_no_progress], turn observation 의 last_progress_at 기준)
+                + [assess_stale_run] ([Idle_turn], last_turn_ts 기준) 가 담당하며,
+                둘 다 turn-scoped 라 이 원칙을 준수한다 (각각
+                test_assess_in_turn_progress / test_assess_stale_run 로 커버).
+                따라서 keepalive loop 를 race 없이 직접 실행한다. [In_turn_hung]
+                variant 는 producer 가 사라져 consumer-only (closed sum) 로 남는다;
+                아래 watchdog_triggered 분기는 sweep 이 stamp 한 다른 stale reason
+                ([Idle_turn] / [Mid_turn_no_progress] 등) 으로 계속 작동한다. *)
+             Keeper_keepalive.run_heartbeat_loop
+               ~proactive_warmup_sec
+               ctx
+               meta
+               reg.fiber_stop
+               ~wakeup:reg.fiber_wakeup;
              (* Check if watchdog set a failure reason that should trigger
               crash recovery instead of a clean stop. When the stale
               watchdog sets fiber_stop + Stale_turn_timeout, the heartbeat

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2368,7 +2368,14 @@ let test_assess_in_turn_progress () =
           ~now:1400.0
           ~progress_timeout:300.0));
   (* The suppression is count-gated, not timing: a long silent tool stays
-     excluded no matter how far past the threshold. *)
+     excluded no matter how far past the threshold. This is the exact invariant
+     the removed RFC-0125 P4 max-turn wall-clock watchdog violated: that
+     [Eio.Fiber.first] timer would have force-restarted this long-but-healthy
+     tool turn on keeper *lifetime* (now - launch), not on per-turn stall. After
+     its removal (RFC-0250 alignment), recovery relies only on no-progress
+     ([Mid_turn_no_progress]) + no-turn ([Idle_turn]); a turn making progress is
+     never killed by a wall-clock cap. Treat a regression here as a signal that a
+     lifetime/wall-clock watchdog was re-introduced. *)
   check bool "tool in flight far past threshold → None" true
     (Option.is_none
        (Sup.assess_in_turn_progress


### PR DESCRIPTION
## 목표
keeper-level max-turn watchdog (RFC-0125 P4, `In_turn_hung`) 을 제거한다. 이 watchdog 은 `keeper_supervisor_launch.ml` 에서 `Eio.Fiber.first (Eio.Time.sleep clock t) (run_heartbeat_loop)` 로 keepalive loop **전체** 를 감싸, 타이머가 keeper *launch* 이후 wall-clock 을 쟀고 턴 경계마다 리셋되지 않았다. 결과적으로 단일 턴이 아니라 keeper **lifetime** 을 cap 했다 — 30 분 넘게 사는 정상 keeper (짧은 턴을 여러 번 처리했든 idle 이든) 도 `In_turn_hung` 으로 강제 재시작되었다. 이름과 달리 "현재 턴이 너무 오래" 가 아니라 "프로세스가 너무 오래" 를 측정한 것이다.

## 배경
- #21967 (max-turn watchdog default-on flip) 셀프리뷰에서 이 lifetime-cap 동작을 코드로 확정했다: `Eio.Fiber.first` 가 감싸는 `Keeper_keepalive.run_heartbeat_loop` 는 `.mli` 계약상 "until [stop] becomes true" = 키퍼 전 생애를 도는 long-lived loop 다. 타이머는 launch 부터 1 회만 카운트하고 턴마다 리셋되지 않는다. default-on 이 되면 fleet 전역 keeper 가 30 분마다 강제 재시작된다.
- per-turn wall-clock timeout 은 **의도적으로 제거된 금지 패턴**이다: `Keeper_unified_turn_attempt_watchdog` `.mli` — "MASC must not impose a wall-clock timeout around the whole provider/tool"; RFC-0250 §"deliberately removed". 따라서 타이머를 per-turn 으로 "고치는" 것조차 부활이며, 올바른 해결은 watchdog 자체의 제거다.
- in-turn / idle 복구는 이미 turn-scoped 로 존재한다: `assess_stale_run` → `Idle_turn` (no-turn, `MASC_KEEPER_STALE_RUN_SEC`, default-on), `assess_in_turn_progress` → `Mid_turn_no_progress` (in-turn no-progress, RFC-0012).

## 변경
- `lib/keeper/keeper_supervisor_launch.ml`: `Eio.Fiber.first` watchdog race 제거 → `run_heartbeat_loop` 직접 실행. sweep 기반 `watchdog_triggered` crash-recovery 분기는 유지 (sweep 이 stamp 한 `Idle_turn`/`Mid_turn_no_progress` 등으로 계속 작동).
- **ghost knob 방지**: `warn_retired_max_turn_watchdog_if_set` 추가 — operator 가 retired `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` 를 설정한 채 keeper 가 뜨면 startup 1 회 deprecation WARN. Atomic flag 로 process-wide 1 회. (silent no-op 방지.)
- `lib/config/env_config_runtime.mli`: `Keeper_max_turn_watchdog` 을 RETIRED 로 문서화. supervisor 는 WARN 목적으로만 `timeout_sec_opt` 를 호출하고 값은 무시한다.
- `docs/rfc/RFC-0125-bounded-subprocess-discipline.md`: P4 를 Retired 로 표시 + Amendment (2026-06-22).
- `test/test_keeper_supervisor.ml`: 기존 "tool in flight far past threshold → None" 케이스를 watchdog 제거의 명시적 회귀 가드로 주석 연결.

## 적대 리뷰 대응 (issuecomment-4765015991)
적대 리뷰가 "후속 분리" 가 ghost knob silent no-op 를 남긴다고 정확히 지적했다 (operator 가 retired knob 설정 시 WARN 없이 무시 + `runtime-tunables.md` 가 여전히 "Opt-in/작동" 광고). 대응:
- **silent → visible**: 위 one-time deprecation WARN 추가.
- **완전 제거** (env module 본체 + auto-gen catalog row + `In_turn_hung` variant): **#22038** 로 추적. `runtime-tunables.md` 는 `env_config_*.ml` 에서 기계 생성(catalog)되므로 정리에 `dune exec` (= 로컬 빌드) 가 필요한데, 이번 작업은 로컬 빌드 금지 환경이다. removal target: catalog regen 가능 환경.

## In_turn_hung variant
이 watchdog 이 유일한 producer 였으므로 제거 후 `In_turn_hung` 은 consumer-only dead variant 가 된다 (closed sum 이라 기존 match arm 은 컴파일 호환). variant 제거도 #22038.

## 로컬 검증
- 로컬 빌드 미수행 (지시에 따라 로컬 빌드 금지). CI 검증: 코어 제거 커밋 기준 **Build and Test PASS (28m23s)**, CI Gate PASS, TLA+ Model Checking PASS, ocamlformat PASS. WARN 추가 커밋은 재 push 후 CI 재검증.
- 변경 안전성 근거: `test_assess_stale_run` (Idle_turn 복구), `test_assess_in_turn_progress` ("hung → Mid_turn_no_progress" + "tool in flight far past threshold → None") 가 복구 경로 + 핵심 불변식을 단위 테스트로 커버.

## RFC
RFC-0125 P4 (max-turn watchdog) 을 retire 하고, RFC-0250 §"deliberately removed" 의 "MASC must not impose a wall-clock timeout on a turn" 원칙에 정렬한다. 기존 RFC 원칙을 준수하는 제거이므로 신규 RFC 불필요 (RFC-0125 amendment 로 기록).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
