### PR TITLE
fix(dashboard): remove stray ed read-command breaking logs.test.ts tsc gate

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -472,7 +472,6 @@ describe('LogViewer Code links', () => {
     routeLinks.find(link => link.textContent === 'Telemetry')?.click()
     expect(window.location.hash).toBe('#monitoring?section=fleet-health&view=event-log&session_id=sess-nested&operation_id=op-nested&worker_run_id=wr-nested&q=turn-8')
   })
-.r . /tmp/logs_test_resolved_block.txt
 })
 
 describe('LogViewer kind column', () => {


### PR DESCRIPTION
## 무엇을 / 왜

`main` 의 `dashboard/src/components/logs.test.ts:475` 에 ed/vi `.r` (read-file) 명령 파편이 source 로 누출돼 있었습니다:

```
.r . /tmp/logs_test_resolved_block.txt
```

이로 인해 `tsc --noEmit` 가 `error TS1003: Identifier expected` 로 깨지고, **모든 PR 의 Dashboard 게이트가 red** 였습니다 (`pull_request` 체크는 PR 을 main 과 병합 후 tsc 를 돌리므로, dashboard 를 건드리지 않는 keeper backend PR(#22036)까지 동일 실패). = 단일 깨진 파일이 전 fleet 의 Dashboard 게이트를 차단.

## 근거 (grounding)
- 혼입 커밋: `7a9376379` (`#21999` 머지, 2026-06-22 05:43:20).
- 해당 파일 패치 hunk: `@@ -472,6 +472,7 @@` = **순수 +1 삽입**. 블록 교체가 아니므로 누락된 test content 없음 → stray 1줄 제거가 **정확한 revert**.
- 제거 후 구조: `})`(it) → `})`(describe 'LogViewer Code links') → `describe('LogViewer kind column')` = valid TS.

## 변경
- `logs.test.ts` 에서 stray 라인 1줄 제거 (521 → 520 lines). 그 외 무변경.

## 검증
- 로컬 빌드 금지 환경이라 tsc 는 이 PR 의 Dashboard 체크(CI)로 확인합니다. green 이면 main 의 fleet-wide Dashboard 차단도 해소됩니다.

Fixes #22039
