### PR TITLE
refactor(keeper): remove retired max-turn watchdog surface (In_turn_hung + env knob)

### DIFF
--- a/docs/design/tool-aware-no-progress-watchdog.md
+++ b/docs/design/tool-aware-no-progress-watchdog.md
@@ -61,7 +61,9 @@ read of `pending_tool_count` or a "lag ≤ X + pre-cancel recheck" protocol.
   dropped or out-of-order event cannot wedge the count. The same holds for tool
   errors: `ToolCompleted` carries `output = Error _` and the FSM transition
   decrements the count. The only remaining wedge is a hard crash that emits no
-  terminal event at all; that is covered by the `In_turn_hung` backstop (§6).
+  terminal event at all; that is covered by sweep-based crash recovery
+  (`assess_stale_run` → `Idle_turn`), since the per-turn `In_turn_hung` wall-clock
+  backstop was retired (RFC-0125 P4 amendment, 2026-06-22).
 - The registry's `update_entry_if_registered` (`keeper_registry_setup.ml:80-88`)
   uses an `Atomic.compare_and_set` retry loop, so concurrent
   `record_turn_progress` and `record_turn_tool_inflight` writes to the same
@@ -72,8 +74,10 @@ read of `pending_tool_count` or a "lag ≤ X + pre-cancel recheck" protocol.
   `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` is parsed but deliberately NOT
   forwarded to OAS "until OAS proves active tool execution is excluded from idle
   accounting" (`lib/config/env_config_keeper.ml:419-420`).
-- `In_turn_hung` (wall-clock, `Keeper_max_turn_watchdog`) remains the absolute
-  backstop for a turn that never terminates, independent of progress.
+- A turn that never terminates is caught by the no-turn / no-progress sweeps
+  (`assess_stale_run` → `Idle_turn`, `assess_in_turn_progress` →
+  `Mid_turn_no_progress`); the former per-turn `In_turn_hung` wall-clock watchdog
+  was retired (RFC-0125 P4 amendment, 2026-06-22).
 
 ## 3. Constraint that picks the seam
 

--- a/docs/rfc/RFC-0125-bounded-subprocess-discipline.md
+++ b/docs/rfc/RFC-0125-bounded-subprocess-discipline.md
@@ -46,9 +46,16 @@ In-turn / idle recovery is already provided, turn-scoped, by:
 - `assess_stale_run` → `Idle_turn` (no turn produced; `MASC_KEEPER_STALE_RUN_SEC`, default-on)
 - `assess_in_turn_progress` → `Mid_turn_no_progress` (in-turn no-progress; RFC-0012)
 
-`In_turn_hung` is now a producer-less variant (consumers retained for the closed
-sum). `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` is parsed but ignored (no-op
-stub; remove in a follow-up). Regression guard:
+The watchdog was the sole producer of `In_turn_hung`, so that kill-class variant
+is **removed** from `stale_kill_class` (canonical
+`keeper_registry_types_kill_class.ml` plus its `keeper_registry_types_failure`
+re-exports). The `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` env module
+(`env_config_runtime.ml`) and its auto-generated `docs/runtime-tunables.md` row
+are **removed** as well, so an operator setting the knob gets a no-such-knob
+result rather than a silent no-op. The terminal-code `Stale_turn_timeout_in_turn`
+is a distinct type and is **kept** — it remains the lossy wire-restore canonical
+for a stale turn whose kill-class sub-class was not preserved on the wire
+(`of_wire` / `of_failure_reason_option`). Regression guard:
 `test_keeper_supervisor.ml` "tool in flight far past threshold → None".
 
 ### implementation_prs reconciliation

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 356 unique knobs across 9 modules.
+**Total**: 355 unique knobs across 9 modules.
 
-**Typed getter classification**: 22/209 tagged (`operator`: 22, `algorithm`: 0, `unclassified`: 187).
+**Typed getter classification**: 22/208 tagged (`operator`: 22, `algorithm`: 0, `unclassified`: 186).
 
 ## Env_config_core (29 knobs; typed classification 1/12)
 
@@ -189,121 +189,120 @@ the categorization roadmap. Newly-added typed getters in
 |---|---|---|---|---|---|
 | `MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 99 |  |
 
-## Env_config_runtime (115 knobs; typed classification 5/91)
+## Env_config_runtime (114 knobs; typed classification 5/90)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 617 | Per-agent burst capacity. Default: 50. |
-| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 614 | Per-agent requests per second. Default: 20. |
+| `MASC_AGENT_RATE_BURST` | typed:int | unclassified | unclassified | 587 | Per-agent burst capacity. Default: 50. |
+| `MASC_AGENT_RATE_LIMIT` | typed:float | unclassified | unclassified | 584 | Per-agent requests per second. Default: 20. |
 | `MASC_AGENT_TRANSPORT` | string_literal | n/a | n/a | 312 | Agent transport type variant (e.g. "grpc", "http", "ws"). |
 | `MASC_APPROVAL_JANITOR_ENABLED` | typed:bool | unclassified | unclassified | 385 | Enable the periodic approval_janitor sweep fiber.  Default: true. Set MASC_APPROVAL_JANITOR_ENABLED=false to disable ... |
 | `MASC_APPROVAL_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 393 | Sweep interval in seconds.  Default: 60s (every minute). Operators tolerate up to a minute of "approval still pending... |
-| `MASC_BOARD_BACKEND` | string_literal | n/a | n/a | 504 | Board backend type as a typed selector (e.g. "jsonl", "pg"). |
-| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 500 | Flush interval for board persistence (seconds). Default: 30. |
-| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 848 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
+| `MASC_BOARD_BACKEND` | string_literal | n/a | n/a | 474 | Board backend type as a typed selector (e.g. "jsonl", "pg"). |
+| `MASC_BOARD_FLUSH_INTERVAL_SEC` | typed:float | unclassified | unclassified | 470 | Flush interval for board persistence (seconds). Default: 30. |
+| `MASC_BRIEFING_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 818 | Dashboard mission briefing cache TTL (seconds). Default: 300 (5 min). |
 | `MASC_CACHE_MAX_ENTRIES` | typed:int | unclassified | unclassified | 73 | Maximum total number of cache entries (default 1000) |
 | `MASC_CACHE_MAX_ENTRY_SIZE` | typed:int | unclassified | unclassified | 69 | Maximum size of a single cache entry value in bytes (default 100KB) |
-| `MASC_CANCELLATION_CLEANUP_SEC` | typed:float | unclassified | unclassified | 860 | Cancellation token cleanup interval (seconds). Default: 300 (5 min). |
+| `MASC_CANCELLATION_CLEANUP_SEC` | typed:float | unclassified | unclassified | 830 | Cancellation token cleanup interval (seconds). Default: 300 (5 min). |
 | `MASC_CANCELLATION_TOKEN_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 187 | Token cleanup max age (seconds) |
 | `MASC_CDAL_ENABLED` | feature_flag | n/a | n/a | 335 | Enable contract-driven proof capture. Default: true. |
 | `MASC_CDAL_GATE_ENABLED` | feature_flag | n/a | n/a | 339 | Block task completion when CDAL verdict is Violated/Inconclusive. Default: false. |
 | `MASC_CDAL_VERDICT_LOOKUP_LIMIT` | typed:int | unclassified | unclassified | 346 | Max verdicts to scan when looking up the latest verdict by task_id. Beyond this limit, older entries are silently ski... |
 | `MASC_CLAIM_TTL_SECONDS` | typed:float | unclassified | unclassified | 96 | Maximum time a task can stay Claimed/InProgress without agent heartbeat before being auto-released back to Todo (seco... |
-| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 695 |  |
-| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 691 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
-| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 693 |  |
-| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 734 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
-| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 748 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
-| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 686 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
-| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 758 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
-| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 791 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
-| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 778 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
-| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 723 |  |
-| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 718 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
-| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 767 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
-| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 682 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
-| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 678 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
-| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 674 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
+| `MASC_DASHBOARD_CTX_COMPACTING` | typed:float | unclassified | unclassified | 665 |  |
+| `MASC_DASHBOARD_CTX_HANDOFF_IMMINENT` | typed:float | unclassified | unclassified | 661 | Keeper context-ratio lifecycle thresholds. Higher ratio = closer to context limit = more urgency. |
+| `MASC_DASHBOARD_CTX_PREPARING` | typed:float | unclassified | unclassified | 663 |  |
+| `MASC_DASHBOARD_EXECUTION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 704 | Execution surface compute timeout (light + parameterized). Wraps two [Dashboard_cache.get_or_compute_with_timeout] si... |
+| `MASC_DASHBOARD_EXECUTION_TRUST_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 718 | Execution-trust surface compute timeout. Wraps [Dashboard_cache.get_or_compute_with_timeout] at [server_dashboard_htt... |
+| `MASC_DASHBOARD_KEEPER_ACTION_STALE_SEC` | typed:float | unclassified | unclassified | 656 | Keeper action-age threshold (seconds). Default: 3600 (1 hour). |
+| `MASC_DASHBOARD_MISSION_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 728 | Mission card compute timeout. Wraps three [Dashboard_cache.get_or_compute_with_timeout] sites at [server_dashboard_ht... |
+| `MASC_DASHBOARD_RENDER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 761 | Maximum wall-clock for a single dashboard render ([Dashboard_execution.json_render]). Wraps the entire render pipelin... |
+| `MASC_DASHBOARD_SHELL_LIGHT_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 748 | Shell render compute timeout (light path). Default 8s. Must remain strictly less than [shell_timeout_sec] so the spli... |
+| `MASC_DASHBOARD_SHELL_PREWARM_OUTER_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 693 |  |
+| `MASC_DASHBOARD_SHELL_PREWARM_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 688 | Dashboard shell-cache pre-warm timeouts. The pre-warm fires once on server bootstrap. It is wrapped in two nested tim... |
+| `MASC_DASHBOARD_SHELL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 737 | Shell render compute timeout (full path). Used by [Dashboard_cache.get_or_compute_with_timeout] for the full shell re... |
+| `MASC_DASHBOARD_SIGNAL_LIVE_SEC` | typed:float | unclassified | unclassified | 652 | Duration (seconds) for a signal to count as "live". Default: 300 (5 min). |
+| `MASC_DASHBOARD_SIGNAL_QUIET_SEC` | typed:float | unclassified | unclassified | 648 | Duration (seconds) for borderline "quiet" warning. Default: 600 (10 min). |
+| `MASC_DASHBOARD_SIGNAL_STALE_SEC` | typed:float | unclassified | unclassified | 644 | Duration (seconds) after which a signal is considered stale. Default: 1200 (20 min). |
 | `MASC_EXECUTOR_DOMAIN_COUNT` | typed:int | Concurrency | operator | 85 | Shared executor worker-domain count override. Env: [MASC_EXECUTOR_DOMAIN_COUNT]. Default: unset, use {!Domain_pool}'s... |
-| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 821 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
-| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 809 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
-| `MASC_FULL_SURFACE` | feature_flag | n/a | n/a | 537 | Full tool surface override. Default: false. Re-readable within the process; callers should still document the effecti... |
+| `MASC_FULL_HEALTH_CRITICAL_FAILURE_THRESHOLD` | typed:int | unclassified | unclassified | 791 | Number of consecutive [/health?full=1] cache-refresh failures that must accumulate before [masc_full_health_refresh_c... |
+| `MASC_FULL_HEALTH_REFRESH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 779 | Full-health snapshot proactive refresh timeout (seconds). Caps a single [/health?full=1] cache refresh attempt in [Se... |
+| `MASC_FULL_SURFACE` | feature_flag | n/a | n/a | 507 | Full tool surface override. Default: false. Re-readable within the process; callers should still document the effecti... |
 | `MASC_GRPC_ENABLED` | feature_flag | n/a | n/a | 287 | Whether gRPC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
 | `MASC_GRPC_PORT` | string_literal | n/a | n/a | 283 | gRPC server port. Default: 8936. |
 | `MASC_GRPC_TARGET` | string_literal | n/a | n/a | 291 | gRPC client target address. Derived from grpc_port when unset. |
 | `MASC_HTTP_AUTH_STRICT` | feature_flag | n/a | n/a | 317 |  |
-| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 876 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
-| `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` | typed:float | unclassified | unclassified | 852 | Keeper world observation bootstrap window (seconds). Default: 300 (5 min). |
-| `MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 417 | {1 Keeper Max-Turn Watchdog (RFC-0109 P4)} Opt-in keeper-level wall-clock watchdog. Default disabled — opt-in via [... |
-| `MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC` | typed:float | Timeouts | operator | 465 | In-turn progress-silence threshold in seconds; produces [Mid_turn_no_progress] when a running turn records no progres... |
-| `MASC_KEEPER_STALE_RUN_SEC` | typed:float | unclassified | unclassified | 437 | {1 Keeper Stale-Run Window (RFC-0250)} Default-on wall-clock window for the no-turn-produced case, distinct from the ... |
+| `MASC_JANITOR_INTERVAL_SEC` | typed:float | unclassified | unclassified | 846 | Bootstrap janitor tick interval (seconds). Drives the SSE/session/ rate-limit/webrtc reaper loop in [server_bootstrap... |
+| `MASC_KEEPER_BOOTSTRAP_WINDOW_SEC` | typed:float | unclassified | unclassified | 822 | Keeper world observation bootstrap window (seconds). Default: 300 (5 min). |
+| `MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC` | typed:float | Timeouts | operator | 435 | In-turn progress-silence threshold in seconds; produces [Mid_turn_no_progress] when a running turn records no progres... |
+| `MASC_KEEPER_STALE_RUN_SEC` | typed:float | unclassified | unclassified | 408 | {1 Keeper Stale-Run Window (RFC-0250)} Default-on wall-clock window for the no-turn-produced case. It keys on [last_t... |
 | `MASC_KEEPER_ZOMBIE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 10 | Threshold for keeper agents (longer grace period, default 1 hour) |
-| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 840 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
-| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 844 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
-| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 542 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
+| `MASC_LABEL_QUIET_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 810 | Dashboard label "quiet" threshold (seconds). Default: 300 (5 min). |
+| `MASC_LABEL_STUCK_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 814 | Dashboard label "stuck" threshold (seconds). Default: 900 (15 min). |
+| `MASC_LIST_PAGE_SIZE` | typed:int | unclassified | unclassified | 512 | Tool list page size, clamped to [10, 1024]. Default: 512. Re-readable within the process; not a guarantee of shell-le... |
 | `MASC_LLAMA_MAX_TOKENS` | typed:int | unclassified | unclassified | 160 | Upper bound for local runtime requests. Callers may request less, but never more than this cap. Falls back to MASC_LL... |
 | `MASC_LOCAL_MAX_TOKENS` | typed:int | unclassified | unclassified | 158 | Upper bound for local runtime requests. Callers may request less, but never more than this cap. Falls back to MASC_LL... |
-| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 629 | Local runtime cooldown (seconds). |
-| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 625 | Enable local runtime debug logging. Default: false. |
-| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 635 | Local worker heartbeat interval (seconds). Default: 60. |
-| `MASC_LOCAL_WORKER_MAX_TOKENS` | typed:int | unclassified | unclassified | 632 | Local worker max tokens per request. Default: 1024. |
+| `MASC_LOCAL_RUNTIME_COOLDOWN_SEC` | string_literal | n/a | n/a | 599 | Local runtime cooldown (seconds). |
+| `MASC_LOCAL_RUNTIME_DEBUG` | feature_flag | n/a | n/a | 595 | Enable local runtime debug logging. Default: false. |
+| `MASC_LOCAL_WORKER_HEARTBEAT_SEC` | typed:int | unclassified | unclassified | 605 | Local worker heartbeat interval (seconds). Default: 60. |
+| `MASC_LOCAL_WORKER_MAX_TOKENS` | typed:int | unclassified | unclassified | 602 | Local worker max tokens per request. Default: 1024. |
 | `MASC_LOCK_EXPIRY_WARNING_SEC` | typed:float | unclassified | unclassified | 28 | Lock expiry warning threshold (seconds before expiry) |
 | `MASC_LOCK_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 24 | Default lock timeout (seconds). Reduced from 1800s (30 min) to 120s (2 min) — file locks should fail fast; a 30-min... |
 | `MASC_MESSAGE_MAX_COUNT` | typed:int | unclassified | unclassified | 229 | Maximum number of message files to retain per workspace (default 200). Oldest messages (by filename sort) are deleted... |
-| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 832 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
-| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 643 | SSE drain interval (seconds). Default: 2.0. |
+| `MASC_METRICS_FLUSH_SEC` | typed:float | unclassified | unclassified | 802 | Tool metrics flush interval (seconds). Default: 300 (5 min). |
+| `MASC_OAS_SSE_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 613 | SSE drain interval (seconds). Default: 2.0. |
 | `MASC_ORCHESTRATOR_AGENT` | typed:string | unclassified | unclassified | 108 | Orchestrator agent name |
 | `MASC_ORCHESTRATOR_INTERVAL` | typed:float | unclassified | unclassified | 104 | Orchestrator check interval (seconds) |
 | `MASC_ORCHESTRATOR_MIN_PRIORITY` | typed:int | unclassified | unclassified | 111 |  |
 | `MASC_ORCHESTRATOR_TIMEOUT` | typed:int | unclassified | unclassified | 114 |  |
-| `MASC_PROC_MIN_CONFIDENCE` | typed:float | unclassified | unclassified | 517 | Minimum confidence for crystallization, clamped to [0, 1]. Default: 0.7. |
-| `MASC_PROC_MIN_EVIDENCE` | typed:int | unclassified | unclassified | 513 | Minimum evidence count for crystallization. Default: 3. |
-| `MASC_PROVIDER_RUN_TTL_SEC` | typed:float | unclassified | unclassified | 864 | Provider run finished TTL (seconds). Default: 3600 (1 hour). |
-| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 576 | Extra public tools (comma-separated names). |
-| `MASC_PULSE_MAX_CONSUMER_FAILURES` | typed:int | unclassified | unclassified | 524 | Max consecutive consumer failures before recovery. Default: 3. |
-| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 611 | Burst capacity. Default: 150. |
-| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 608 | Requests per second. Default: 100. |
-| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 890 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
+| `MASC_PROC_MIN_CONFIDENCE` | typed:float | unclassified | unclassified | 487 | Minimum confidence for crystallization, clamped to [0, 1]. Default: 0.7. |
+| `MASC_PROC_MIN_EVIDENCE` | typed:int | unclassified | unclassified | 483 | Minimum evidence count for crystallization. Default: 3. |
+| `MASC_PROVIDER_RUN_TTL_SEC` | typed:float | unclassified | unclassified | 834 | Provider run finished TTL (seconds). Default: 3600 (1 hour). |
+| `MASC_PUBLIC_TOOLS_EXTRA` | string_literal | n/a | n/a | 546 | Extra public tools (comma-separated names). |
+| `MASC_PULSE_MAX_CONSUMER_FAILURES` | typed:int | unclassified | unclassified | 494 | Max consecutive consumer failures before recovery. Default: 3. |
+| `MASC_RATE_BURST` | typed:int | unclassified | unclassified | 581 | Burst capacity. Default: 150. |
+| `MASC_RATE_LIMIT` | typed:float | unclassified | unclassified | 578 | Requests per second. Default: 100. |
+| `MASC_RATE_LIMIT_BUCKET_TTL_SEC` | typed:int | unclassified | unclassified | 860 | Rate-limit bucket staleness TTL (seconds). Buckets with no traffic for this long are reaped by the janitor loop. Defa... |
 | `MASC_RELAY_TARGET_AGENT` | typed:string | unclassified | unclassified | 124 | {1 Relay Configuration} |
-| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 882 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
-| `MASC_SESSION_LIVE_TURN_WINDOW_SEC` | typed:float | unclassified | unclassified | 836 | Team session live turn window (seconds). Default: 300 (5 min). |
+| `MASC_REPO_SYNC_INTERVAL_SEC` | typed:float | unclassified | unclassified | 852 | Repository auto-sync interval (seconds). The repo_sync fiber in [server_bootstrap_loops] wakes at this cadence to fet... |
+| `MASC_SESSION_LIVE_TURN_WINDOW_SEC` | typed:float | unclassified | unclassified | 806 | Team session live turn window (seconds). Default: 300 (5 min). |
 | `MASC_SESSION_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 36 | Maximum session age before cleanup (seconds) |
 | `MASC_SESSION_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 40 | Rate limit window (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 45 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
-| `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` | feature_flag | n/a | n/a | 983 | Enable the Shell IR approval policy gate. Default: true (RFC-0254 — the autonomous policy is a strict safety improv... |
-| `MASC_SHELL_IR_PATH_JAIL_ENABLED` | feature_flag | n/a | n/a | 997 | Apply the workspace path jail [Exec_policy.validate_shell_ir_paths] to keeper Execute commands. Default: true. Re-rea... |
-| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 916 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
-| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 904 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
-| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 932 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
-| `MASC_SLOT_YIELD_ENABLED` | feature_flag | n/a | n/a | 476 | Release LLM slot during tool execution so other agents can use it. Default: false. Set MASC_SLOT_YIELD_ENABLED=true t... |
-| `MASC_SMART_HB_BASE_INTERVAL_SEC` | typed:float | unclassified | unclassified | 652 | Base heartbeat interval (seconds), clamped [5, 300]. Default: 30. |
-| `MASC_SMART_HB_IDLE_MULTIPLIER` | typed:float | unclassified | unclassified | 657 | Idle multiplier for interval, clamped [1, 10]. Default: 3. |
-| `MASC_SMART_HB_IDLE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 662 | Idle threshold (seconds) before multiplier kicks in, clamped [60, 3600]. Default: 300. |
+| `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` | feature_flag | n/a | n/a | 953 | Enable the Shell IR approval policy gate. Default: true (RFC-0254 — the autonomous policy is a strict safety improv... |
+| `MASC_SHELL_IR_PATH_JAIL_ENABLED` | feature_flag | n/a | n/a | 967 | Apply the workspace path jail [Exec_policy.validate_shell_ir_paths] to keeper Execute commands. Default: true. Re-rea... |
+| `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 886 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
+| `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 874 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
+| `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 902 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |
+| `MASC_SLOT_YIELD_ENABLED` | feature_flag | n/a | n/a | 446 | Release LLM slot during tool execution so other agents can use it. Default: false. Set MASC_SLOT_YIELD_ENABLED=true t... |
+| `MASC_SMART_HB_BASE_INTERVAL_SEC` | typed:float | unclassified | unclassified | 622 | Base heartbeat interval (seconds), clamped [5, 300]. Default: 30. |
+| `MASC_SMART_HB_IDLE_MULTIPLIER` | typed:float | unclassified | unclassified | 627 | Idle multiplier for interval, clamped [1, 10]. Default: 3. |
+| `MASC_SMART_HB_IDLE_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 632 | Idle threshold (seconds) before multiplier kicks in, clamped [60, 3600]. Default: 300. |
 | `MASC_SPAWN_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 138 | Grace period before timeout — sends SIGTERM for checkpoint opportunity (seconds). |
 | `MASC_SPAWN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 134 | Default spawn timeout for agent processes (seconds). Used by spawn.ml, spawn_eio.ml, and tool_relay.ml. Higher value ... |
-| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 856 | SSE buffer TTL (seconds). Default: 300 (5 min). |
-| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 868 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
+| `MASC_SSE_BUFFER_TTL_SEC` | typed:float | unclassified | unclassified | 826 | SSE buffer TTL (seconds). Default: 300 (5 min). |
+| `MASC_STALLED_SESSION_THRESHOLD_SEC` | typed:float | unclassified | unclassified | 838 | Operator digest stalled session threshold (seconds). Default: 300 (5 min). |
 | `MASC_STARTUP_WATCHDOG_SEC` | typed:float | unclassified | unclassified | 328 | Startup watchdog timeout, clamped to [30, 600]. Default: 240. Re-readable within the process, but operationally a boo... |
 | `MASC_TEMPO_DEFAULT_INTERVAL_SEC` | typed:float | unclassified | unclassified | 61 | Default polling interval (seconds) |
 | `MASC_TEMPO_MAX_INTERVAL_SEC` | typed:float | unclassified | unclassified | 57 | Maximum polling interval (seconds) - for idle tempo |
 | `MASC_TEMPO_MIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 53 | Minimum polling interval (seconds) - for urgent tempo |
-| `MASC_TOOL_DESCRIPTION_BUDGET` | string_literal | n/a | n/a | 564 | Tool description budget (max chars). None = unlimited. |
-| `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | unclassified | unclassified | 572 | Read-only tool retry limit. Default: 2. |
-| `MASC_TOOL_TIMEOUT_BOARD_SEC` | typed:int | Timeouts | operator | 559 | Board write outer MCP tool-call timeout, clamped to [5, 300] seconds. Default: 90 seconds (#10569). @category Timeout... |
-| `MASC_TOOL_TIMEOUT_DEFAULT_SEC` | typed:int | Timeouts | operator | 551 | Default outer MCP tool-call timeout, clamped to [5, 300] seconds. Board writes have a separate timeout below so opera... |
+| `MASC_TOOL_DESCRIPTION_BUDGET` | string_literal | n/a | n/a | 534 | Tool description budget (max chars). None = unlimited. |
+| `MASC_TOOL_READONLY_RETRY_LIMIT` | typed:int | unclassified | unclassified | 542 | Read-only tool retry limit. Default: 2. |
+| `MASC_TOOL_TIMEOUT_BOARD_SEC` | typed:int | Timeouts | operator | 529 | Board write outer MCP tool-call timeout, clamped to [5, 300] seconds. Default: 90 seconds (#10569). @category Timeout... |
+| `MASC_TOOL_TIMEOUT_DEFAULT_SEC` | typed:int | Timeouts | operator | 521 | Default outer MCP tool-call timeout, clamped to [5, 300] seconds. Board writes have a separate timeout below so opera... |
 | `MASC_USE_H2` | string_literal | n/a | n/a | 306 | HTTP mode: typed variant for "auto", "h2_only", "h1_only". |
 | `MASC_VERIFICATION_FSM_ENABLED` | feature_flag | n/a | n/a | 352 | Enable AwaitingVerification state and cross-agent approval. Default: false. |
 | `MASC_VERIFICATION_TIMEOUT_CHECK_INTERVAL_SEC` | typed:float | unclassified | unclassified | 362 | Interval for verification timeout check fiber (seconds). Default: 60. Issue #7549. |
 | `MASC_VERIFICATION_TIMEOUT_DEADLINE_SEC` | typed:float | unclassified | unclassified | 357 | Maximum time a task may remain AwaitingVerification before surfacing an operator-visible timeout. Default: 24h. |
 | `MASC_WEBRTC_ENABLED` | feature_flag | n/a | n/a | 302 | Whether WebRTC transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at boot. |
-| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 592 |  |
-| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 585 |  |
-| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 579 |  |
-| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 582 |  |
-| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | unclassified | unclassified | 600 |  |
-| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 596 |  |
-| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 588 |  |
-| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 967 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
+| `MASC_WEB_SEARCH_CACHE_TTL_SEC` | typed:float | unclassified | unclassified | 562 |  |
+| `MASC_WEB_SEARCH_FALLBACKS` | string_literal | n/a | n/a | 555 |  |
+| `MASC_WEB_SEARCH_PROVIDER` | string_literal | n/a | n/a | 549 |  |
+| `MASC_WEB_SEARCH_PROVIDER_ORDER` | string_literal | n/a | n/a | 552 |  |
+| `MASC_WEB_SEARCH_RATE_LIMIT_MAX_CALLS` | typed:int | unclassified | unclassified | 570 |  |
+| `MASC_WEB_SEARCH_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 566 |  |
+| `MASC_WEB_SEARCH_TIMEOUT_SEC` | typed:int | unclassified | unclassified | 558 |  |
+| `MASC_WORKSPACE_GIT_LOCAL_OP_TIMEOUT_SEC` | typed:float | Timeouts | operator | 937 | Budget (seconds) for local-only git operations under [Masc_exec.Exec_gate.run_argv*] in {!Workspace_git}: [rev-parse]... |
 | `MASC_WS_ENABLED` | feature_flag | n/a | n/a | 298 | Whether WebSocket transport is enabled. Default: true. Accessor-shaped reader; listener lifecycle is still decided at... |
 | `MASC_WS_PORT` | string_literal | n/a | n/a | 294 | WebSocket server port. Default: 8937. |
 | `MASC_ZOMBIE_CLEANUP_INTERVAL_SEC` | typed:float | unclassified | unclassified | 14 | Cleanup loop interval (seconds) |

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -393,41 +393,12 @@ module Approval_janitor = struct
     get_float ~default:60.0 "MASC_APPROVAL_JANITOR_INTERVAL_SEC"
 end
 
-(** {1 Keeper Max-Turn Watchdog (RFC-0109 P4)}
-
-    Opt-in keeper-level wall-clock watchdog. Default disabled — opt-in
-    via [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC]. Backward-compat
-    until an operator turns it on.
-
-    When enabled, the supervisor races each keeper's keepalive loop
-    against [Eio.Time.sleep clock t] via [Eio.Fiber.first]. Timer
-    expiry cancels the loop fiber and the registry is stamped with
-    [Stale_turn_timeout "max_turn_watchdog"], which the existing
-    [sweep_and_recover] crash-recovery path already understands.
-
-    Closes the sangsu / masc-improver mid_turn_no_progress class of
-    stucks without touching the existing stale_turn_timeout fast path
-    (which only detects in-turn no-progress, not "stuck for too long
-    in a single attempt"). *)
-module Keeper_max_turn_watchdog = struct
-  let timeout_sec_opt () =
-    let v =
-      get_float
-        ~default:0.0
-        "MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC"
-    in
-    if v > 0.0 then Some v else None
-end
-
 (** {1 Keeper Stale-Run Window (RFC-0250)}
 
-    Default-on wall-clock window for the no-turn-produced case, distinct
-    from the opt-in [Keeper_max_turn_watchdog] above. The max-turn watchdog
-    produces [In_turn_hung] (a turn is taking too long); this window produces
-    [Idle_turn] (no turn has completed at all). It keys on [last_turn_ts]
-    while [current_turn_observation = None] — exactly the [Idle_turn]
-    variant's doc contract — so it does not re-introduce the per-turn
-    wall-clock timeout that was deliberately removed
+    Default-on wall-clock window for the no-turn-produced case. It keys on
+    [last_turn_ts] while [current_turn_observation = None] — exactly the
+    [Idle_turn] variant's doc contract — so it does not re-introduce the
+    per-turn wall-clock timeout that was deliberately removed
     ([keeper_unified_turn_attempt_watchdog]).
 
     Default 1800s: a [Running] keeper that has not completed a turn in 30 min
@@ -441,10 +412,9 @@ end
 (** {1 Keeper mid-turn progress watchdog (RFC-0012)}
 
     Opt-in progress-silence window for the in-turn case. Distinct from
-    [Keeper_max_turn_watchdog] (wall-clock "one attempt taking too long",
-    produces [In_turn_hung]) and [Keeper_stale_run] (no turn produced at all,
-    produces [Idle_turn]): this keys on
-    [current_turn_observation.last_progress_at] while a turn IS running,
+    [Keeper_stale_run] (no turn produced at all, produces [Idle_turn]): this
+    keys on [current_turn_observation.last_progress_at] while a turn IS
+    running,
     producing [Mid_turn_no_progress] when no forward-progress event
     (tool_completed / sdk-turn boundary) has been recorded for longer than the
     threshold.

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -183,29 +183,6 @@ module Approval_janitor : sig
   val interval_seconds : float
 end
 
-(** {1 Keeper max-turn watchdog (RFC-0125 P4) — RETIRED} *)
-
-module Keeper_max_turn_watchdog : sig
-  val timeout_sec_opt : unit -> float option
-  (** DEPRECATED / no-op. Parses [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC]
-      ([Some t] when positive, else [None]). The supervisor calls this only to
-      emit a one-time deprecation warning when the knob is set
-      ([Keeper_supervisor_launch.warn_retired_max_turn_watchdog_if_set]); it
-      never acts on the value, so the env var has no effect on behavior.
-
-      The keeper-level max-turn wall-clock watchdog was removed from
-      [keeper_supervisor_launch.ml] (RFC-0250 alignment). It used
-      [Eio.Fiber.first] to race the whole [Keeper_keepalive.run_heartbeat_loop]
-      against [Eio.Time.sleep], which measured keeper {e lifetime} from launch
-      (never reset per turn) and so capped long-lived keepers rather than a
-      single stuck turn. Per-turn wall-clock timeouts are a deliberately-removed
-      pattern ([Keeper_unified_turn_attempt_watchdog]: "MASC must not impose a
-      wall-clock timeout around the whole provider/tool"). Turn-scoped recovery
-      now lives in [Keeper_stale_run] ([Idle_turn]) and
-      [Keeper_mid_turn_progress] ([Mid_turn_no_progress]). Stub retained for
-      env-knob-catalog / in-flight-branch stability; remove in a follow-up. *)
-end
-
 (** {1 Keeper stale-run window (RFC-0250)} *)
 
 module Keeper_stale_run : sig
@@ -214,8 +191,7 @@ module Keeper_stale_run : sig
       when [MASC_KEEPER_STALE_RUN_SEC] is positive, or [None] when unset /
       zero / negative.
 
-      Distinct from [Keeper_max_turn_watchdog] (retired; formerly [In_turn_hung]):
-      this keys on [last_turn_ts] while [current_turn_observation = None],
+      Keys on [last_turn_ts] while [current_turn_observation = None],
       producing [Idle_turn] — the no-turn-produced case. Default-on at
       [1800.0] (30 min). *)
 end
@@ -228,8 +204,7 @@ module Keeper_mid_turn_progress : sig
       when [MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC] is positive, or [None]
       when unset / zero / negative.
 
-      Distinct from [Keeper_max_turn_watchdog] (retired; formerly [In_turn_hung])
-      and [Keeper_stale_run] (no-turn, [Idle_turn]): keys on
+      Distinct from [Keeper_stale_run] (no-turn, [Idle_turn]): keys on
       [current_turn_observation.last_progress_at] while a turn is running,
       producing [Mid_turn_no_progress] when no progress event has been recorded
       for longer than the threshold.

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -760,7 +760,6 @@ let append (config : Workspace.config) (receipt : t) =
    blocked on a long call and would otherwise never produce a receipt. *)
 let stale_kill_class_label = function
   | Keeper_registry.Idle_turn _ -> "idle_turn"
-  | Keeper_registry.In_turn_hung _ -> "in_turn_hung"
   | Keeper_registry.Mid_turn_no_progress _ -> "mid_turn_no_progress"
   | Keeper_registry.Noop_failure_loop _ -> "noop_failure_loop"
 ;;

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -36,12 +36,6 @@ type stale_kill_class =
       (** [last_turn_ts] older than the idle threshold while the keeper
           phase is [Running] but no [current_turn_observation] is
           recorded. *)
-  | In_turn_hung of {
-      active_seconds : float;
-      timeout_threshold : float;
-    }
-      (** A turn started ([current_turn_observation = Some]) and ran past
-          [timeout_threshold] seconds. *)
   | Mid_turn_no_progress of {
       active_seconds : float;
       since_progress_seconds : float;

--- a/lib/keeper/keeper_registry_types_failure.ml
+++ b/lib/keeper/keeper_registry_types_failure.ml
@@ -18,10 +18,6 @@ type ambiguous_partial_commit =
 
 type stale_kill_class = Keeper_registry_types_kill_class.stale_kill_class =
   | Idle_turn of { stall_seconds : float }
-  | In_turn_hung of
-      { active_seconds : float
-      ; timeout_threshold : float
-      }
   | Mid_turn_no_progress of
       { active_seconds : float
       ; since_progress_seconds : float

--- a/lib/keeper/keeper_registry_types_failure.mli
+++ b/lib/keeper/keeper_registry_types_failure.mli
@@ -10,7 +10,6 @@ type ambiguous_partial_commit =
 type stale_kill_class =
   Keeper_registry_types_kill_class.stale_kill_class =
     Idle_turn of { stall_seconds : float; }
-  | In_turn_hung of { active_seconds : float; timeout_threshold : float; }
   | Mid_turn_no_progress of { active_seconds : float;
       since_progress_seconds : float; progress_timeout_threshold : float;
       last_progress_kind : string option;

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -183,12 +183,6 @@ let stale_kill_class_summary (kill_class : Keeper_registry.stale_kill_class) =
       "idle_turn: no completed turn for %.0fs; stale watchdog stopped the keeper before \
        restart."
       stall_seconds
-  | Keeper_registry.In_turn_hung { active_seconds; timeout_threshold } ->
-    Printf.sprintf
-      "in_turn_hung: active turn ran for %.0fs past the %.0fs timeout; stale watchdog \
-       stopped the keeper."
-      active_seconds
-      timeout_threshold
   | Keeper_registry.Mid_turn_no_progress
       { active_seconds
       ; since_progress_seconds

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -64,7 +64,8 @@ let assess_stale_run
     routes the [Stale_turn_timeout _] to crash recovery. Keys on
     [last_progress_at] (tool_completed / sdk-turn boundary events recorded by
     [Keeper_registry.record_turn_progress]), never on raw turn wall-clock, so
-    it is orthogonal to [In_turn_hung] (wall-clock) and [Idle_turn] (no-turn). *)
+    it is distinct from the no-turn [Idle_turn] case (the per-turn wall-clock
+    timeout it would have contrasted with was deliberately removed). *)
 let assess_in_turn_progress
     ~(phase : Keeper_state_machine.phase)
     ~(in_turn : Keeper_registry_types.turn_observation option)
@@ -79,8 +80,8 @@ let assess_in_turn_progress
             execution, not no-progress. [active_tool_count] mirrors the event
             bus [pending_tool_count] (via [record_turn_tool_inflight]). A long
             silent tool call therefore does not produce [Mid_turn_no_progress];
-            a hung tool is bounded by the tool substrate budget and the
-            wall-clock [In_turn_hung] watchdog, not this signal. *)
+            a hung tool is bounded by the tool substrate budget, not this
+            signal. *)
          && obs.active_tool_count = 0
          && now -. obs.last_progress_at > progress_timeout ->
     Some
@@ -357,7 +358,7 @@ let sweep_and_recover (ctx : _ context) =
             producer); when stale, stamp the reason and invoke the
             dead [emit_stale_keeper_broadcast] (its first call site).
             The next sweep's [watchdog_stop_pending] routes it to
-            crash recovery exactly as [In_turn_hung].
+            crash recovery like any other [Stale_turn_timeout].
 
             RFC-0012: the in-turn counterpart. When a turn IS running
             but [last_progress_at] is older than

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -100,7 +100,7 @@ val assess_in_turn_progress :
     with a turn in progress ([in_turn = Some obs]) whose [last_progress_at] is
     older than [progress_timeout]. [None] otherwise (not running, no turn in
     progress, or progress recorded within the window). Keys on recorded progress
-    events, orthogonal to the wall-clock [In_turn_hung] and no-turn [Idle_turn].
+    events, distinct from the no-turn [Idle_turn] case (not raw turn wall-clock).
     Exposed for regression tests. *)
 
 val failure_reason_policy_decision_for_test :

--- a/lib/keeper/keeper_supervisor_launch.ml
+++ b/lib/keeper/keeper_supervisor_launch.ml
@@ -14,29 +14,6 @@ module Startup_helpers = Keeper_supervisor_startup_helpers
 let backoff_delay = Startup_helpers.backoff_delay
 let keep_last_n = Startup_helpers.keep_last_n
 
-(* RFC-0125 P4 / RFC-0250: the max-turn watchdog was retired (it capped keeper
-   lifetime, not a turn — see [launch_supervised_fiber] below). The
-   [MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC] knob is no longer consumed by the
-   supervisor, so an operator who still sets it would otherwise get a silent
-   no-op. Emit one process-wide deprecation WARN (on the first set-and-launch)
-   so the dead knob is visible until the env module + auto-generated
-   runtime-tunables catalog are removed in a follow-up. *)
-let warned_retired_max_turn_watchdog = Atomic.make false
-
-let warn_retired_max_turn_watchdog_if_set () =
-  match Env_config_runtime.Keeper_max_turn_watchdog.timeout_sec_opt () with
-  | Some timeout_s
-    when not (Atomic.exchange warned_retired_max_turn_watchdog true) ->
-    Log.Keeper.warn
-      "MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC=%.1fs is set but the max-turn \
-       watchdog was retired (RFC-0125 P4 / RFC-0250: MASC must not impose a \
-       wall-clock timeout on a turn); it has no effect. Turn-scoped recovery \
-       uses MASC_KEEPER_STALE_RUN_SEC (Idle_turn) and \
-       MASC_KEEPER_MID_TURN_PROGRESS_TIMEOUT_SEC (Mid_turn_no_progress)."
-      timeout_s
-  | _ -> ()
-;;
-
 (** supervision_cohort cluster moved to Keeper_supervisor_types
     (intra-library file split, 2026-05-16). *)
 include Keeper_supervisor_types
@@ -181,31 +158,28 @@ let launch_supervised_fiber
       Eio_guard.protect
         (fun () ->
            try
-             (* RFC-0125 P4 의 keeper-level max-turn watchdog ([In_turn_hung]
+             (* RFC-0125 P4 의 keeper-level max-turn watchdog (구 [In_turn_hung]
                 wall-clock timer) 를 제거한다 (RFC-0250 §"deliberately removed"
                 정렬). 그 타이머는 [Eio.Fiber.first] 로 keepalive loop 전체를 감싸
                 keeper *launch* 이후 wall-clock 을 쟀고 — 턴 경계마다 리셋되지
                 않으므로 — 단일 턴이 아니라 keeper lifetime 을 cap 했다. 결과적으로
                 30 분 넘게 사는 정상 keeper (짧은 턴을 여러 번 처리했든 idle 이든)
-                도 [In_turn_hung] 으로 강제 재시작되었다. [In_turn_hung] 이라는
-                이름과 달리 "현재 턴이 너무 오래" 가 아니라 "프로세스가 너무 오래"
-                를 측정한 것이다.
+                도 강제 재시작되었다. 이름과 달리 "현재 턴이 너무 오래" 가 아니라
+                "프로세스가 너무 오래" 를 측정한 것이다.
 
                 per-turn wall-clock timeout 은 의도적으로 금지된 패턴이다:
                 [Keeper_unified_turn_attempt_watchdog] .mli — "MASC must not impose
-                a wall-clock timeout around the whole provider/tool". in-turn-hung /
+                a wall-clock timeout around the whole provider/tool". in-turn /
                 idle 복구는 supervisor sweep 의 [assess_in_turn_progress]
                 ([Mid_turn_no_progress], turn observation 의 last_progress_at 기준)
                 + [assess_stale_run] ([Idle_turn], last_turn_ts 기준) 가 담당하며,
                 둘 다 turn-scoped 라 이 원칙을 준수한다 (각각
                 test_assess_in_turn_progress / test_assess_stale_run 로 커버).
-                따라서 keepalive loop 를 race 없이 직접 실행한다. [In_turn_hung]
-                variant 는 producer 가 사라져 consumer-only (closed sum) 로 남는다;
+                따라서 keepalive loop 를 race 없이 직접 실행한다. watchdog 의 유일
+                producer 였던 [In_turn_hung] kill-class variant 와 그 opt-in env
+                knob ([MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC]) 도 함께 제거됐다.
                 아래 watchdog_triggered 분기는 sweep 이 stamp 한 다른 stale reason
-                ([Idle_turn] / [Mid_turn_no_progress] 등) 으로 계속 작동한다.
-                set-but-ignored knob 가 silent no-op 가 되지 않도록, retired knob
-                가 설정돼 있으면 1 회 deprecation WARN 을 남긴다. *)
-             warn_retired_max_turn_watchdog_if_set ();
+                ([Idle_turn] / [Mid_turn_no_progress] 등) 으로 계속 작동한다. *)
              Keeper_keepalive.run_heartbeat_loop
                ~proactive_warmup_sec
                ctx

--- a/lib/keeper/keeper_turn_terminal_code.ml
+++ b/lib/keeper/keeper_turn_terminal_code.ml
@@ -51,8 +51,9 @@ let of_wire = function
   | "healthy" -> Some Healthy
   | "stale_turn_timeout" ->
     (* Lossy: the wire string lost the sub-class. Canonicalise to
-         [In_turn_hung] (the most common observed sub-class in
-         production traces). PR-4 removes [of_wire] callers. *)
+         [Stale_turn_timeout_in_turn], the terminal-code canonical for a
+         stale turn whose kill-class sub-class was not preserved on the
+         wire. PR-4 removes [of_wire] callers. *)
     Some Stale_turn_timeout_in_turn
   | "stale_termination_storm" -> Some Stale_termination_storm
   | "stale_fleet_batch" -> Some Stale_fleet_batch
@@ -79,8 +80,6 @@ let of_failure_reason : Keeper_registry.failure_reason -> t = function
   | Keeper_registry.Turn_consecutive_failures _ -> Turn_failures
   | Keeper_registry.Stale_turn_timeout (Keeper_registry.Idle_turn _) ->
     Stale_turn_timeout_idle
-  | Keeper_registry.Stale_turn_timeout (Keeper_registry.In_turn_hung _) ->
-    Stale_turn_timeout_in_turn
   | Keeper_registry.Stale_turn_timeout (Keeper_registry.Mid_turn_no_progress _) ->
     Stale_turn_timeout_no_progress
   | Keeper_registry.Stale_turn_timeout (Keeper_registry.Noop_failure_loop _) ->
@@ -106,8 +105,8 @@ let of_failure_reason_option = function
   | Some fr -> of_failure_reason fr
   | None ->
     (* A stale keeper without a recorded failure reason still emits the
-       stale-turn cohort. Canonicalise to [In_turn_hung], matching the
-       lossy [of_wire] convention for ["stale_turn_timeout"]. *)
+       stale-turn cohort. Canonicalise to [Stale_turn_timeout_in_turn],
+       matching the lossy [of_wire] convention for ["stale_turn_timeout"]. *)
     Stale_turn_timeout_in_turn
 ;;
 

--- a/lib/keeper/keeper_turn_terminal_code.mli
+++ b/lib/keeper/keeper_turn_terminal_code.mli
@@ -21,8 +21,9 @@ type t =
   (** [Keeper_registry.Stale_turn_timeout (Idle_turn _)]: the keeper
           was [Running] but never observed a turn-start. *)
   | Stale_turn_timeout_in_turn
-  (** [Keeper_registry.Stale_turn_timeout (In_turn_hung _)]: a turn
-          began and ran past its timeout threshold. *)
+  (** Terminal code for a stale turn whose kill-class sub-class was not
+          preserved on the wire (formerly the retired [In_turn_hung]); produced
+          by the lossy [of_wire] / [of_failure_reason_option] canonicalisation. *)
   | Stale_turn_timeout_no_progress
   (** [Keeper_registry.Stale_turn_timeout (Mid_turn_no_progress _)]: a live
           turn stayed inside its outer timeout but stopped producing
@@ -90,8 +91,7 @@ val to_wire : t -> string
     for PR-4, which removes the consumer side of [of_wire] entirely).
 
     Some wire strings are lossy ([stale_turn_timeout] cannot distinguish
-    [Idle_turn] / [In_turn_hung] / [Mid_turn_no_progress] /
-    [Noop_failure_loop]).
+    [Idle_turn] / [Mid_turn_no_progress] / [Noop_failure_loop]).
     Such wire strings deserialise to a single canonical sub-class —
     documented in the [.ml] — to avoid silent fallthrough. *)
 val of_wire : string -> t option

--- a/lib/keeper_registry/keeper_registry_types_kill_class.ml
+++ b/lib/keeper_registry/keeper_registry_types_kill_class.ml
@@ -30,10 +30,6 @@ type ambiguous_partial_commit =
     See keeper_registry.mli for rationale. *)
 type stale_kill_class =
   | Idle_turn of { stall_seconds : float }
-  | In_turn_hung of
-      { active_seconds : float
-      ; timeout_threshold : float
-      }
   | Mid_turn_no_progress of
       { active_seconds : float
       ; since_progress_seconds : float
@@ -49,11 +45,6 @@ let progress_kind_label = function
 
 let stale_kill_class_to_string = function
   | Idle_turn { stall_seconds } -> Printf.sprintf "idle_turn(%.0fs)" stall_seconds
-  | In_turn_hung { active_seconds; timeout_threshold } ->
-    Printf.sprintf
-      "in_turn_hung(active=%.0fs threshold=%.0fs)"
-      active_seconds
-      timeout_threshold
   | Mid_turn_no_progress
       { active_seconds
       ; since_progress_seconds

--- a/lib/keeper_registry/keeper_registry_types_kill_class.mli
+++ b/lib/keeper_registry/keeper_registry_types_kill_class.mli
@@ -12,10 +12,6 @@ type ambiguous_partial_commit =
 
 type stale_kill_class =
   | Idle_turn of { stall_seconds : float }
-  | In_turn_hung of
-      { active_seconds : float
-      ; timeout_threshold : float
-      }
   | Mid_turn_no_progress of
       { active_seconds : float
       ; since_progress_seconds : float

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -189,7 +189,14 @@ let test_supervisor_policy_restarts_stale_turn () =
     policy_decision_exn
       (Some
          (Reg.Stale_turn_timeout
-            (Reg.In_turn_hung { active_seconds = 60.0; timeout_threshold = 30.0 })))
+            (* formerly In_turn_hung (retired); any stale_kill_class drives the
+               same keeper-liveness restart decision. *)
+            (Reg.Mid_turn_no_progress
+               { active_seconds = 60.0
+               ; since_progress_seconds = 45.0
+               ; progress_timeout_threshold = 30.0
+               ; last_progress_kind = None
+               })))
   in
   check string "scope" "keeper_liveness"
     (KFP.failure_scope_to_label decision.failure_scope);


### PR DESCRIPTION
## 목표
RFC-0125 P4 max-turn watchdog retirement 의 후속 — watchdog 제거(이전 PR)가 남긴 dead surface 를 완전히 제거한다 (#22038).

## 배경
직전 PR 에서 watchdog 자체(`keeper_supervisor_launch.ml` 의 `Eio.Fiber.first` race)는 제거했으나, production-blocking fix 를 최소 변경으로 머지하기 위해 그 producer 였던 `In_turn_hung` kill-class variant, opt-in env knob (`MASC_KEEPER_MAX_TURN_WATCHDOG_TIMEOUT_SEC`), auto-generated catalog row, 임시 deprecation WARN 을 남겨두고 #22038 로 추적했다. catalog 재생성이 `dune exec`(로컬 빌드)를 요구해 분리한 것이다. 이 PR 이 그 dead surface 를 닫는다.

## 변경
### 제거
- **`stale_kill_class.In_turn_hung`** — watchdog 이 유일 producer 였으므로 제거. canonical `keeper_registry_types_kill_class.ml` + `keeper_registry_types_failure` / `keeper_registry_types` re-export. consumer arm 3 곳(terminal-code `of_failure_reason`, execution-receipt label, status-bridge summary) 동반 제거. OCaml exhaustive match 로 전 사이트 확인 (catch-all `_ ->` 추가 없음).
- **`Keeper_max_turn_watchdog` env module** (`env_config_runtime.ml/.mli`) + 임시 deprecation WARN (`keeper_supervisor_launch.ml`).
- **`docs/runtime-tunables.md` catalog row** — `bin/env_knob_catalog.exe` 로 재생성 (knob 광고 제거 + env module 삭제로 인한 line drift 정정).

### 유지 (의도적)
- **`keeper_turn_terminal_code.Stale_turn_timeout_in_turn`** — kill-class variant 와 **별개 타입**. `of_wire` / `of_failure_reason_option` 의 lossy wire-restore canonical (와이어 문자열이 sub-class 를 잃었을 때 복원값). doc 의 In_turn_hung 참조만 갱신. wire round-trip 은 `test_keeper_turn_disposition` 으로 커버.

## 검증 (로컬)
- `dune build @check` PASS (전체 타입체크).
- `test_keeper_supervisor` 68 tests PASS (turn-scoped 복구: stale_run_window / mid_turn_progress_window).
- `test_keeper_turn_disposition` 10 tests PASS (terminal-code round-trip / projection — `Stale_turn_timeout_in_turn` 유지 정상).
- ocamlformat 0.29.0 (= `.ocamlformat` version) 정규화. 무관한 dune-file 포맷 변경은 revert.
- catalog drift gate: 재생성 후 `git diff --exit-code docs/runtime-tunables.md` 일치.

## Turn-scoped 복구 (무변경)
`assess_stale_run` (Idle_turn, `MASC_KEEPER_STALE_RUN_SEC` default-on) + `assess_in_turn_progress` (Mid_turn_no_progress, RFC-0012) 가 wedge case 를 담당. per-turn wall-clock timeout 은 RFC-0250 §"deliberately removed" 금지 패턴이므로 이를 부활시키지 않는다.

## RFC
RFC-0125 P4 amendment (2026-06-22) 에 variant + env knob + catalog 완전 제거를 반영. 기존 RFC 원칙(RFC-0125 P4 retire + RFC-0250 정렬) 준수 제거이므로 신규 RFC 불필요.

WORKAROUND-WAIVED: 이 PR 은 workaround 의 *제거*(dead variant/ghost knob cleanup)이지 추가가 아니다. "후속 PR 로 완료" 표현은 N-of-M 패치 시그니처와 표면상 닮았으나, 직전 PR 이 production-blocking 이라 최소 변경으로 머지하고 catalog regen(로컬 빌드 필요)을 #22038 로 분리한 합당한 단계적 제거다. abstraction 실패가 아니라 typed variant + env knob + catalog 의 N 면을 한 번에 닫는 cleanup.

Closes #22038.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
