### PR TITLE
perf(admission): skip dead /dev/fd scan when fd-pressure gate disabled

### DIFF
--- a/lib/admission_queue.ml
+++ b/lib/admission_queue.ml
@@ -181,10 +181,29 @@ let check_host_resources_with ~surface ~keeper_name ~fd_count ~threshold =
   else Ok ()
 ;;
 
+(* Resolve the gate from the configured threshold.  [fd_count] is a thunk so
+   the [/dev/fd] scan in [Otel_metric_process.approximate_open_fd_count] runs
+   only when a finite threshold is configured.  When gating is disabled
+   ([None]) the scan is skipped entirely and the call is admitted.
+
+   Behaviour-preserving against the former [max_int] sentinel: that sentinel
+   admitted every call (no real fd count reaches [max_int * 9 / 10]) yet paid
+   the directory scan on every admission.  The admit decision is unchanged;
+   only the dead scan is dropped.  The MASC-side concurrency gate
+   (RFC-0124 admission denial boundary, RFC-0153 backpressure) is unrelated
+   and untouched; host-level fd pressure is handled out-of-process by the
+   RFC-0137 keeper_fd_pressure poller. *)
+let check_host_resources_for_threshold ~surface ~keeper_name ~threshold ~fd_count =
+  match threshold with
+  | None -> Ok ()
+  | Some threshold ->
+    check_host_resources_with ~surface ~keeper_name ~fd_count:(fd_count ()) ~threshold
+;;
+
 let check_host_resources ~surface ~keeper_name =
-  let fd_count = Otel_metric_process.approximate_open_fd_count () in
-  let threshold = Otel_metric_process.fd_warn_threshold in
-  check_host_resources_with ~surface ~keeper_name ~fd_count ~threshold
+  check_host_resources_for_threshold ~surface ~keeper_name
+    ~threshold:Otel_metric_process.fd_warn_threshold
+    ~fd_count:Otel_metric_process.approximate_open_fd_count
 ;;
 
 let with_permit ?wait_timeout_sec:_ ~priority:_ ~keeper_name ~runtime_id f =
@@ -280,4 +299,6 @@ module For_testing = struct
   let check_host_resources ~surface ~keeper_name ~fd_count ~threshold =
     check_host_resources_with ~surface ~keeper_name ~fd_count ~threshold
   ;;
+
+  let check_host_resources_for_threshold = check_host_resources_for_threshold
 end

--- a/lib/admission_queue.mli
+++ b/lib/admission_queue.mli
@@ -43,8 +43,11 @@ val with_permit :
   (unit -> 'a) ->
   ('a, [> `Host_resource_saturated of string ]) result
 (** Run [f] in passthrough mode and record inflight observation for metrics
-    and snapshots. Returns [Error (`Host_resource_saturated msg)] if host FD
-    count exceeds the safety threshold. Otherwise returns [Ok (f ())].
+    and snapshots. When an fd-pressure threshold is configured
+    ([Otel_metric_process.fd_warn_threshold = Some _]) and the host FD count
+    reaches it, returns [Error (`Host_resource_saturated msg)]; otherwise
+    returns [Ok (f ())]. While the threshold is [None] (the default) the fd
+    scan is skipped and every call is admitted.
 
     No MASC-side concurrency gate is applied here; OAS runtime owns provider
     capacity, retry, and timeout behavior. *)
@@ -86,4 +89,14 @@ module For_testing : sig
     threshold:int ->
     (unit, [> `Host_resource_saturated of string ]) result
   (** Deterministic host-resource check for threshold tests. *)
+
+  val check_host_resources_for_threshold :
+    surface:Admission_queue_metrics.rejection_surface ->
+    keeper_name:string ->
+    threshold:int option ->
+    fd_count:(unit -> int) ->
+    (unit, [> `Host_resource_saturated of string ]) result
+  (** The production gate as a pure function: [fd_count] is forced only when
+      [threshold] is [Some _]. Tests pass a counting thunk to assert the
+      [/dev/fd] scan is skipped while gating is disabled ([None]). *)
 end

--- a/lib/otel_metric_store/otel_metric_process.ml
+++ b/lib/otel_metric_store/otel_metric_process.ml
@@ -1,4 +1,15 @@
-let fd_warn_threshold = max_int
+(* fd-pressure admission threshold.
+
+   [None] disables the in-process gate: [Admission_queue.check_host_resources]
+   skips the per-call [/dev/fd] directory scan entirely instead of computing a
+   count that can never reach the threshold.  [Some n] rejects admission once
+   the approximate open-fd count reaches 90% of [n].
+
+   Disabled by default (previously encoded as the sentinel [max_int]).
+   Encoding "disabled" as [None] rather than a sentinel makes the skip total
+   and type-checked, and removes the [n * 9 / 10] overflow that the [max_int]
+   sentinel computed on every admission. *)
+let fd_warn_threshold : int option = None
 
 let approximate_open_fd_count () =
   let candidates = [ "/dev/fd"; "/proc/self/fd" ] in

--- a/lib/otel_metric_store/otel_metric_process.mli
+++ b/lib/otel_metric_store/otel_metric_process.mli
@@ -1,3 +1,5 @@
-val fd_warn_threshold : int
+val fd_warn_threshold : int option
+(** fd-pressure admission threshold. [None] disables the gate (and its
+    per-call [/dev/fd] scan); [Some n] rejects admission at 90% of [n]. *)
 
 val approximate_open_fd_count : unit -> int

--- a/test/dune
+++ b/test/dune
@@ -39,6 +39,7 @@
   test_keeper_lane_mentions
   test_keeper_librarian_retry
   test_surface_ref
+  test_admission_fd_gate
   test_keeper_turn_outcome
   test_keeper_cycle_channel
   test_board_collect_pause_gate
@@ -341,6 +342,7 @@
   test_keeper_lane_mentions
   test_keeper_librarian_retry
   test_surface_ref
+  test_admission_fd_gate
   test_keeper_turn_outcome
   test_keeper_cycle_channel
   test_board_collect_pause_gate

--- a/test/test_admission_fd_gate.ml
+++ b/test/test_admission_fd_gate.ml
@@ -1,0 +1,81 @@
+(* Admission fd-pressure gate (C12 perf fix).
+
+   The gate must skip the per-call [/dev/fd] directory scan when no threshold
+   is configured.  Before this change the threshold was the sentinel [max_int],
+   which admitted every call (no real fd count reaches [max_int * 9 / 10]) yet
+   still ran [Otel_metric_process.approximate_open_fd_count] — a directory
+   scan — on every admission.
+
+   Pinned here:
+   1. Disabled ([None]) admits without ever forcing the fd-count thunk, i.e.
+      the scan is not run on the hot admission path while gating is off.
+   2. Enabled ([Some n]) forces the thunk exactly once and applies the 90%
+      rejection boundary: below 90% admits, at/above 90% rejects.
+
+   The thunk is the dependency-injected stand-in for the real fd scan; a call
+   counter makes the "scan skipped while disabled" guarantee observable. *)
+
+open Alcotest
+
+module A = Masc.Admission_queue
+module M = Masc.Admission_queue_metrics
+
+(* Returns a thunk and the ref recording how many times the gate forced it. *)
+let counting_fd ~returns =
+  let calls = ref 0 in
+  let thunk () =
+    incr calls;
+    returns
+  in
+  (thunk, calls)
+
+(* The rejection path of the underlying [check_host_resources_with] records
+   fd-growth history under an [Eio.Mutex], so the gate must run inside an Eio
+   scheduler (as it always does in production, under [with_permit]). *)
+let gate ~threshold ~fd_count =
+  Eio_main.run @@ fun _env ->
+  A.For_testing.check_host_resources_for_threshold ~surface:M.With_permit
+    ~keeper_name:"test-keeper" ~threshold ~fd_count
+
+let is_ok = function Ok () -> true | Error _ -> false
+let is_saturated = function Error (`Host_resource_saturated _) -> true | Ok () -> false
+
+let test_disabled_skips_scan () =
+  (* A huge fd value would reject if it were ever read; it must not be. *)
+  let fd_count, calls = counting_fd ~returns:999_999 in
+  let r = gate ~threshold:None ~fd_count in
+  check bool "disabled admits" true (is_ok r);
+  check int "disabled never runs the fd scan" 0 !calls
+
+let test_below_threshold_admits () =
+  let fd_count, calls = counting_fd ~returns:50 in
+  let r = gate ~threshold:(Some 100) ~fd_count in
+  check bool "below 90% admits" true (is_ok r);
+  check int "scan forced exactly once" 1 !calls
+
+let test_at_threshold_rejects () =
+  (* 100 * 9 / 10 = 90; an fd count of 90 reaches the boundary. *)
+  let fd_count, calls = counting_fd ~returns:90 in
+  let r = gate ~threshold:(Some 100) ~fd_count in
+  check bool "at 90% rejects" true (is_saturated r);
+  check int "scan forced exactly once" 1 !calls
+
+let test_just_below_threshold_admits () =
+  let fd_count, calls = counting_fd ~returns:89 in
+  let r = gate ~threshold:(Some 100) ~fd_count in
+  check bool "just below 90% admits" true (is_ok r);
+  check int "scan forced exactly once" 1 !calls
+
+let () =
+  run "admission_fd_gate"
+    [
+      ( "scan-skip",
+        [ test_case "disabled skips fd scan" `Quick test_disabled_skips_scan ] );
+      ( "threshold",
+        [
+          test_case "below threshold admits" `Quick test_below_threshold_admits;
+          test_case "at threshold rejects" `Quick test_at_threshold_rejects;
+          test_case "just below threshold admits" `Quick
+            test_just_below_threshold_admits;
+        ] );
+    ]


### PR DESCRIPTION
## 요약

admission 핫패스(`check_host_resources`)가 매 호출마다 `approximate_open_fd_count`(= `Sys.readdir "/dev/fd"` 디렉토리 스캔)를 실행하지만, 그 결과를 `fd_warn_threshold = max_int`(실제 fd 수로 도달 불가)와만 비교합니다. 즉 keeper turn / tool-call admission 경로에서 **거부를 절대 유발할 수 없는 죽은 계산**을 매번 수행하고, `max_int * 9 / 10` overflow도 매번 계산합니다.

`MASC 성능 병목 종합 분석 보고서`의 96개 주장을 적대 검증한 결과, 즉시 적용 가치가 있고 가드레일을 통과한 유일한 항목입니다(상세: `~/me/reports/masc-perf-report-adversarial-review-20260622.md`). 보고서가 제안한 "5초 캐시" 옵션은 CLAUDE.md 워크어라운드 시그니처(N초 캐시 = 증상 억제)라 채택하지 않고, "비활성 시 스캔 스킵" 경로를 타입 안전하게 구현했습니다.

## 변경

- `otel_metric_process.{ml,mli}`: `fd_warn_threshold : int = max_int` → `int option = None`. "비활성"을 매직 센티넬이 아닌 타입으로 표현(Parse, don't validate). `max_int * 9 / 10` overflow 제거.
- `admission_queue.{ml,mli}`: `check_host_resources_for_threshold ~threshold ~fd_count` 도입. `fd_count`를 thunk(`unit -> int`)로 받아 `Some _`일 때만 강제 → `None`이면 스캔 자체를 건너뜀. `check_host_resources_with`(90% 거부 로직)는 무변경.
- `test/test_admission_fd_gate.ml`: 카운팅 thunk로 **"비활성 시 fd 스캔이 호출되지 않음"을 직접 단언**(최적화 증명) + 90% 경계(below/at/just-below) 검증.

## 동작 보존

- 비활성(기본값, `None`)에서는 종전과 동일하게 모든 호출을 admit — 단, 스캔을 안 함.
- 유한 threshold(`Some n`)에서는 종전과 동일하게 fd 수가 `n`의 90%에 도달하면 `Host_resource_saturated` 거부.

## 검증

- `dune build --root . test/test_admission_fd_gate.exe` 성공 (masc + otel_metric_store lib 전체 링크 → 타입 정합).
- `dune exec test/test_admission_fd_gate.exe`: 4/4 통과.

## RFC 영향 범위

behavior-preserving 최적화이며 admission/fd 거버넌스 설계를 변경하지 않습니다.
- RFC-0124 (admission denial boundary) / RFC-0153 (runtime backpressure): MASC-side 동시성 게이트는 무관·무변경.
- RFC-0137 (host fd pressure → keeper pause): 별도 out-of-process `keeper_fd_pressure` poller로, 본 in-process 스캔과 무관.
- RFC-0101/0162 (fd accounting / jsonl write-path fd pressure): 영향 없음.

`fd_warn_threshold` / `approximate_open_fd_count` 소비자는 `admission_queue.ml` + `otel_metric_process` 모듈로 한정됨을 `rg -l`로 확인했습니다.

RFC-WAIVED: behavior-preserving dead-computation 제거 + 타입 안전화. 신규 admission/fd 설계 변경 없음 (위 RFC들과 무관·무변경).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
