### PR TITLE
fix(dashboard): align stale 'WS open' assertion to production '3s polling' (unblocks main Dashboard gate)

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -535,7 +535,7 @@ describe('LogViewer Code links', () => {
     await waitFor(() => expect(container.textContent).toContain('tool event'))
     expect(container.textContent).toContain('turn event')
     expect(container.textContent).toContain('lifecycle event')
-    expect(container.querySelector('.v2-logs-live')?.textContent).toContain('masc-mcp · WS open')
+    expect(container.querySelector('.v2-logs-live')?.textContent).toContain('masc-mcp · 3s polling')
 
     const toolChip = container.querySelector('[data-testid="logs-filter-tool"]') as HTMLButtonElement
     await act(async () => {


### PR DESCRIPTION
Closes #22041

## 문제

`main`의 Dashboard 게이트가 **fleet-wide red** 상태입니다. `dashboard/src/components/logs.test.ts:538`이 production이 절대 렌더하지 않는 stale 라벨 `'masc-mcp · WS open'`을 단언하기 때문입니다.

```
FAIL src/components/logs.test.ts:538 > LogViewer Code links > filters rows by kind chips...
AssertionError: expected 'masc-mcp · 3s polling · 3.0δ/min' to contain 'masc-mcp · WS open'
```

## 근거 (production SSOT)

`dashboard/src/components/logs.ts`의 live indicator:

```js
<span class="v2-logs-live mono">...${autoRefresh.value
  ? `masc-mcp · 3s polling · ${eventRatePerMinute(logEntries)}δ/min`
  : 'masc-mcp · WS paused'}</span>
```

- active → `masc-mcp · 3s polling · Nδ/min`
- paused → `masc-mcp · WS paused`
- **`WS open`은 production 어디에도 없음** (`gh search code` 확인: 테스트 파일 1회·production 0회).

실제 transport는 HTTP 3s polling(`POLL_INTERVAL_MS=3000`, `dashboard_bonsai/README.md`도 "3s polling logs stream"으로 명시). 따라서 `3s polling`이 진실, 테스트의 `WS open`이 stale 라벨(WS-label churn #21999/#22002에서 유입, #22003이 production은 `3s polling`으로 정정했으나 이 테스트 단언은 미갱신).

## 변경

1줄 — 테스트 단언을 truthful polling 라벨로 정렬:

```diff
-    expect(container.querySelector('.v2-logs-live')?.textContent).toContain('masc-mcp · WS open')
+    expect(container.querySelector('.v2-logs-live')?.textContent).toContain('masc-mcp · 3s polling')
```

워크어라운드 아님 — production 라벨이 실제 transport와 일치하는 진실이고, 테스트가 허위 라벨을 고정하던 것을 진실로 정렬합니다.

## 영향 (연계 반경)

main이 red인 동안 모든 dashboard 체크 PR이 base-inheritance로 차단됩니다. 직접 확인된 피해:

- **#22045** (순수 OCaml perf/admission) — dashboard TS를 건드리지 않는데 Dashboard 체크 FAILURE. 이 PR 머지 후 재실행하면 해소될 것.

local build 금지 환경이라 CI의 Dashboard 체크 green이 검증 권위입니다. 단일 실패(`582 passed | 1 failed`)라 이 한 줄이 root.

선례: #22040 (logs.test.ts stray-ed-command로 동일하게 main red → 1줄 Contents API revert).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
