### PR TITLE
fix(dashboard): select tool row by kind in logs.test detail-click (main red)

### DIFF
--- a/dashboard/src/components/logs.test.ts
+++ b/dashboard/src/components/logs.test.ts
@@ -569,8 +569,13 @@ describe('LogViewer Code links', () => {
     expect(container.textContent).toContain('turn event')
     expect(container.textContent).toContain('lifecycle event')
 
-    const row = container.querySelector('[data-testid="logs-row"]') as HTMLDivElement
-    fireEvent.click(row.querySelector('.v2-logs-line') as Element)
+    // Rows render newest-seq-first (sortLogEntries: b.seq - a.seq), so the tool
+    // entry (seq 1) is the last row, not the first. Select it by its kind cell
+    // instead of by position so the assertion tracks the intended row.
+    const toolRow = [...container.querySelectorAll('[data-testid="logs-row"]')].find(
+      r => r.querySelector('.v2-logs-kind')?.getAttribute('data-kind') === 'tool',
+    ) as HTMLDivElement
+    fireEvent.click(toolRow.querySelector('.v2-logs-line') as Element)
     await waitFor(() =>
       expect(container.querySelector('.v2-logs-kind-grid')?.textContent).toContain('tool'),
     )


### PR DESCRIPTION
## 문제

`main`의 Dashboard 게이트가 **여전히 fleet-wide red**입니다. `dashboard/src/components/logs.test.ts`의 `filters rows by kind chips and keeps kind-aware details for toolbar view` 테스트가 실패합니다:

```
FAIL src/components/logs.test.ts > LogViewer Code links > filters rows by kind chips...
AssertionError: expected 'fromidletorunningtriggerwake' to contain 'tool'
```

## 근본 원인 (grounding)

이 테스트는 `1e79d29b4`("event-log visual polish")에서 **+103/-0 순수 추가로 새로 도입된 DOA 테스트**입니다. main CI 이력상 직전 `e319bc813`(06:01)이 마지막 green이고 `1e79d29b4`(06:03)부터 red — 즉 이 새 테스트가 main을 깬 회귀입니다. 같은 커밋의 production diff(`logs.ts` +4/-3)는 순수 시각 변경(KeeperBadge 컴포넌트화, eyebrow 추가, 헤더 `소스`→`keeper`)뿐 — **정렬·라이브 라벨을 건드리지 않았습니다.**

테스트는 두 곳에서 *존재하지 않는 production*을 가정했습니다:

1. live indicator 라벨을 `'masc-mcp · WS open'`으로 단언 → 실제는 `'masc-mcp · 3s polling'` (#22046에서 이미 수정)
2. **detail-click을 첫 번째 행에 수행하며 그 행이 tool 행이라고 가정** → 이 PR이 수정

production `logs.ts`는 `sortLogEntries`로 **newest-seq-first**(`b.seq - a.seq`) 정렬합니다(line 189-190, green baseline에 이미 존재):

```js
function sortLogEntries(entries: LogEntry[]): LogEntry[] {
  return [...entries].sort((a, b) => b.seq - a.seq)
}
```

fixture는 tool=seq 1, turn=seq 2, lifecycle=seq 3이므로 렌더 순서는 **lifecycle(맨 위) → turn → tool(맨 아래)**. 따라서 `querySelector('[data-testid="logs-row"]')` 첫 행은 lifecycle(fsm)이고, 그 kind-grid는 `renderLogKindGrid`에서 `from/to/trigger`만 출력 → `'fromidletorunningtriggerwake'`. 'tool' 없음.

vitest는 첫 실패에서 멈추므로 #22046이 단언 #1을 고치기 전까지 이 단언 #2는 가려져 있었습니다.

## 변경

위치 기반 선택을 **kind 속성 기반 결정론적 선택**으로 교체:

```diff
-    const row = container.querySelector('[data-testid="logs-row"]') as HTMLDivElement
-    fireEvent.click(row.querySelector('.v2-logs-line') as Element)
+    const toolRow = [...container.querySelectorAll('[data-testid="logs-row"]')].find(
+      r => r.querySelector('.v2-logs-kind')?.getAttribute('data-kind') === 'tool',
+    ) as HTMLDivElement
+    fireEvent.click(toolRow.querySelector('.v2-logs-line') as Element)
```

- `data-kind="tool"`은 production이 각 행 kind cell에 노출하는 **구조 속성**(`renderLogRow`, 같은 파일 다른 테스트 line 619에서도 검증) — 스트링-콘텐츠 매치가 아니라 selector.
- 정렬 순서와 무관하게 의도한 tool 행을 선택 → 테스트가 production의 정당한 동작(newest-first)을 추적.
- production은 정상이고 테스트만 stale했습니다. 워크어라운드 아님 — DOA 테스트를 실제 production 계약에 정렬.

## 영향 (연계 반경)

main red 동안 모든 dashboard 체크 PR이 base-inheritance로 차단됩니다. 이미 확인된 피해: #22045(순수 OCaml인데 Dashboard FAILURE). #22046이 라벨 단언을 고쳤으나 같은 테스트의 두 번째 stale 단언이 남아 main이 계속 red였습니다. 이 PR이 마지막 조각입니다(단일 실패 `584 passed | 1 failed`).

local build/test 금지 환경 → CI Dashboard 체크 green이 검증 권위.

선례: #22040(stray-ed-command), #22046(WS-open 라벨) — 동일 테스트 파일의 누적 stale을 1줄씩 정렬.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
