### PR TITLE
fix(docs): regenerate runtime-tunables.md after #22052 social-model knob removal

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,11 +14,11 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 355 unique knobs across 9 modules.
+**Total**: 354 unique knobs across 9 modules.
 
-**Typed getter classification**: 22/208 tagged (`operator`: 22, `algorithm`: 0, `unclassified`: 186).
+**Typed getter classification**: 22/207 tagged (`operator`: 22, `algorithm`: 0, `unclassified`: 185).
 
-## Env_config_core (29 knobs; typed classification 1/12)
+## Env_config_core (28 knobs; typed classification 1/11)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -35,11 +35,10 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 243 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 202 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
-| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 539 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
-| `MASC_KEEPER_DESIRES` | typed:string | unclassified | unclassified | 534 | Default keeper desires (drive statement). Default: "". |
-| `MASC_KEEPER_NEEDS` | typed:string | unclassified | unclassified | 530 | Default keeper needs (operational requirements). Default: "". |
-| `MASC_KEEPER_SOCIAL_MODEL` | typed:string | unclassified | unclassified | 522 | Default social model for keepers. Default: "bdi_speech_v1". |
-| `MASC_KEEPER_WILL` | typed:string | unclassified | unclassified | 526 | Default keeper will (long-term intent). Default: "". |
+| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 535 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
+| `MASC_KEEPER_DESIRES` | typed:string | unclassified | unclassified | 530 | Default keeper desires (drive statement). Default: "". |
+| `MASC_KEEPER_NEEDS` | typed:string | unclassified | unclassified | 526 | Default keeper needs (operational requirements). Default: "". |
+| `MASC_KEEPER_WILL` | typed:string | unclassified | unclassified | 522 | Default keeper will (long-term intent). Default: "". |
 | `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 476 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 477 | SSOT for logging / observability env-var names (issue 8352). |
 | `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 409 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |


### PR DESCRIPTION
## Summary

Regenerate the auto-generated `docs/runtime-tunables.md` to clear the **Env knob
catalog drift gate** that #22052 left red on `main`.

## Why main is red

RFC-0276 Phase 2b (#22052) removed the `MASC_KEEPER_SOCIAL_MODEL` typed getter
from `lib/config/env_config_core.ml`. `docs/runtime-tunables.md` is generated
from `lib/config/env_config_*.ml` by `bin/env_knob_catalog.exe` and verified by
the `Env knob catalog drift gate` step inside **Build and Test**. The #22052
squash-merge did not include the regenerated doc, so on `main` the doc still
lists `MASC_KEEPER_SOCIAL_MODEL` and `Total: 355`, and the gate fails
(`git diff --exit-code docs/runtime-tunables.md` is non-empty after regen).

## Change

`dune exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md`:

- drop the `MASC_KEEPER_SOCIAL_MODEL` row
- `Total` 355 → 354, `Env_config_core` 29 → 28 knobs
- re-anchor the line numbers of the sibling keeper knobs
  (`MASC_KEEPER_{WILL,NEEDS,DESIRES}`, `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE`)
  shifted by the source deletion

Generated-artifact sync only; no source change.

## Verification

- `dune exec ./bin/env_knob_catalog.exe -- docs/runtime-tunables.md` then
  `git diff --exit-code docs/runtime-tunables.md` is clean — idempotent, the same
  check the CI gate runs.
- `grep -c MASC_KEEPER_SOCIAL_MODEL docs/runtime-tunables.md` = 0.

Follow-up to #22052 (RFC-0276 Phase 2b). Docs/generated artifact only — no
RFC-gated subsystem touched.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
