### PR TITLE
refactor(dashboard): de-frame v2 셸 풀블리드 (Phase 1a)

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -127,7 +127,7 @@ describe('App v2 header chrome', () => {
     expect(crumb?.textContent?.trim().endsWith('/')).toBe(false)
   })
 
-  it('renders the main stage as a StyleSeed card (white, rounded-2xl, soft shadow)', () => {
+  it('renders the main stage full-bleed (no card frame — matches keeper-v2 prototype)', () => {
     window.innerWidth = 1280
     renderApp()
 
@@ -135,11 +135,16 @@ describe('App v2 header chrome', () => {
     expect(main).not.toBeNull()
     expect(main?.classList.contains('v2-body')).toBe(true)
 
+    // The v2-body is edge-to-edge full-bleed: the wrapper card chrome (rounded
+    // corners, border, card background, drop shadow) was removed so the shell
+    // matches the prototype's full-bleed .v2-body grid. The page background
+    // shows through; each surface owns its own background.
     const cls = main?.className ?? ''
-    expect(cls).toContain('bg-[var(--ss-card)]')
-    expect(cls).toContain('rounded-[var(--ss-radius-card)]')
-    expect(cls).toContain('shadow-[var(--ss-shadow-card)]')
-    expect(cls).toContain('border-[var(--ss-border)]')
+    expect(cls).not.toContain('bg-[var(--ss-card)]')
+    expect(cls).not.toContain('rounded-[var(--ss-radius-card)]')
+    expect(cls).not.toContain('shadow-[var(--ss-shadow-card)]')
+    // Still clips so the inner .dashboard-main-scroll owns the scrollbar.
+    expect(cls).toContain('overflow-hidden')
   })
 
   it('renders health chips with the shared chip class', () => {

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -434,7 +434,7 @@ export function App() {
         <${DashboardHealthStrip} />
       `}
 
-      <div class=${compactChromeMode ? 'v2-shell-stage flex flex-1 overflow-hidden p-0' : 'v2-shell-stage flex flex-1 gap-2 overflow-hidden p-2 max-[1100px]:flex-col'}>
+      <div class=${compactChromeMode ? 'v2-shell-stage flex flex-1 overflow-hidden p-0' : 'v2-shell-stage flex flex-1 overflow-hidden max-[1100px]:flex-col'}>
         ${compactChromeMode
           ? null
           : html`
@@ -455,7 +455,7 @@ export function App() {
             id="main-content"
             tabindex=${-1}
             data-mpane=${mobileKeeperPane ?? undefined}
-            class=${compactChromeMode ? 'v2-body min-w-0 flex-1 overflow-hidden' : 'v2-body min-w-0 flex-1 overflow-hidden rounded-[var(--ss-radius-card)] border border-[var(--ss-border)] bg-[var(--ss-card)] shadow-[var(--ss-shadow-card)]'}
+            class="v2-body min-w-0 flex-1 overflow-hidden"
           >
             <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : keeperDetailMode ? 'h-full p-0' : focusMode ? 'dashboard-main-scroll h-full overflow-y-auto p-3 max-[520px]:p-2 max-[900px]:pb-16' : 'dashboard-main-scroll h-full overflow-y-auto p-4 max-[900px]:pb-16'}>
               <div class="v2-surface" key=${currentTab}>

--- a/dashboard/src/components/mobile-nav.ts
+++ b/dashboard/src/components/mobile-nav.ts
@@ -84,7 +84,7 @@ export function DashboardNavRail({
         aria-label="Sidebar navigation"
         data-collapsed=${effectiveCollapsed ? 'true' : 'false'}
         data-testid="dashboard-nav-rail"
-        class="v2-shell-rail ${sideRailWidthClass} shrink-0 overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] backdrop-blur-xl transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] ${sideRailResponsiveClass}"
+        class="v2-shell-rail ${sideRailWidthClass} shrink-0 overflow-hidden border-r border-[var(--color-border-default)] bg-[var(--shell-rail-bg)] transition-[width] duration-[var(--t-slow)] ease-[var(--ease)] ${sideRailResponsiveClass}"
       >
         <${SideRail} collapsed=${effectiveCollapsed} onToggle=${onToggleCollapsed} primaryOnly=${!mobile} />
       </aside>

--- a/dashboard/src/styles/app-shell-v2.css
+++ b/dashboard/src/styles/app-shell-v2.css
@@ -304,16 +304,13 @@
 }
 
 .v2-app .v2-body {
-  /* White card stage with rounded-2xl and soft shadow. */
-  background: var(--ss-card);
-  border: 1px solid var(--ss-border);
-  border-radius: var(--ss-radius-card);
-  box-shadow: var(--ss-shadow-card);
+  /* Full-bleed surface — no card frame (matches the keeper-v2 prototype's
+     edge-to-edge .v2-body). The page background shows through; each surface
+     and its inner cards own their own backgrounds and borders. */
 
   /* Smooth transitions for the main surface as rails collapse/expand or the
      viewport changes. */
   transition:
-    border-radius var(--v2-shell-transition),
     flex var(--v2-shell-transition),
     opacity var(--v2-shell-transition),
     transform var(--v2-shell-transition);
@@ -348,15 +345,9 @@
   }
 }
 
-/* Bubble style variants (data-bubble mirrors v2 tweak panel). */
-.v2-app[data-bubble="card"] .v2-body {
-  box-shadow: var(--ss-shadow-card);
-}
-
-.v2-app[data-bubble="flat"] .v2-body {
-  box-shadow: none;
-  border-color: var(--ss-border);
-}
+/* The data-bubble tweak governs chat bubble styling (see craft-v2.css); it no
+   longer toggles a shell-frame shadow because the .v2-body card was removed
+   for the full-bleed shell. */
 
 /* ═══════════════════════════════════════════════════════════════
    FOCUS MODE CHROME

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -1025,8 +1025,9 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 }
 
 @media (max-width: 860px) {
-  [data-keeper-detail-mode="true"] .v2-shell-stage { padding: 6px; }
-  [data-keeper-detail-mode="true"] .v2-body { border-radius: var(--r-2); }
+  /* Edge-to-edge on mobile keeper detail — the wrapper card (with its 6px
+     inset and rounded corners) was removed for the full-bleed shell, so the
+     stage padding and body border-radius that protected the card are gone. */
   [data-keeper-detail-mode="true"] .v2-header-brand { max-width: calc(100vw - 86px); }
 
   .kw-mobile-rail-drawer {


### PR DESCRIPTION
## 배경

Phase 0(#22048)에서 토큰 중복 숙청 + 프로토타입 SSOT 벤더링을 했다. Phase 1은 라이브 대시보드가 keeper-v2 프로토타입과 "한눈에 다른" 진짜 동인 — **셸 프레임** — 을 고친다.

3개 Plan 에이전트 그라운딩 결과: 라이브는 모든 화면을 "둥근 카드 프레임 속 내용"으로 감싸고(`v2-body` rounded/border/shadow + 바깥 gap/padding), 프로토타입은 edge-to-edge 풀블리드다. 이 PR(**Phase 1a**)은 그 프레임 껍데기를 벗긴다.

## 변경 (de-frame only — 시각 외 동작 불변)

- **v2-body**: 카드 chrome 제거 — inline 유틸(rounded/border/bg/shadow) + `.v2-app .v2-body` CSS 규칙 + `data-bubble` shadow 토글. 페이지 배경이 비치고, 각 surface가 자기 배경을 소유.
- **v2-shell-stage**: 바깥 `gap-2`/`p-2` 제거 → nav와 콘텐츠가 flush.
- **nav rail**: rounded 카드 + full border + backdrop-blur 제거, `border-r`로 edge-to-edge 레일.
- **모바일 keeper detail**: 제거된 카드의 둥근 모서리를 보호하던 `padding:6px`/`border-radius`(@860px) 제거.

flex stage·nested `kw-grid`는 불변(프레임 제거 외 시각 동일). keeper 패널을 셸 트랙에 subgrid 정렬하는 것은 후속(Phase 1b).

## 스코프 밖 (의도적)

단일-그리드 subgrid 재구조화·개별 surface 포트는 후속/제외. board/schedule/fleet은 라이브가 이미 동급 이상이라 제외(되돌리면 테스트된 기능 손실 = 퇴행).

## 검증

- 전체 dashboard vitest: **585 파일 / 7665 테스트 green**.
- `tsc --noEmit` pass, `vite build` pass.
- "StyleSeed card" 테스트 → 풀블리드(카드 클래스 부재) 단언으로 재작성.
- (참고) 로컬 `*.solid.test` 7건은 node_modules symlink 아티팩트(`jest-dom/dist/vitest.mjs` 미해석)로 pre-existing — clean base에서 동일 실패 확인. CI는 정상 node_modules로 통과(main Dashboard green).

## 시각 확인 권장

`make build` → `:8935`에서 5개 모드(standard/focus/widget-solo/keeper-detail/code) × 860/900/1180px 대조 권장.

RFC-WAIVED: dashboard CSS/레이아웃 변경. credential/identity/operator/keeper-sandbox/hooks/workflow 등 RFC-gated subsystem 미해당.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
