### PR TITLE
fix(dashboard): runtime-probe route non-blocking via background refresh

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -2101,6 +2101,10 @@ export interface DashboardRuntimeProbeResponse {
   cache_ttl_sec?: number
   cache_age_sec?: number
   cache_hit?: boolean
+  // Non-blocking route freshness tag. 'served_stale' / 'warming_up' mean a
+  // background refresh was scheduled and the fresh value arrives on the next
+  // poll — a force=1 ("Live probe") response is not guaranteed to be fresh.
+  refresh_state?: 'fresh' | 'recent' | 'served_stale' | 'warming_up'
   probe?: DashboardRuntimeProbePayload | null
 }
 

--- a/dashboard/src/components/runtime-health-snapshot.ts
+++ b/dashboard/src/components/runtime-health-snapshot.ts
@@ -130,6 +130,24 @@ function formatCheckedAt(probe: DashboardRuntimeProbeResponse | null): string {
   return formatRelativeAgeMs(Date.now() - ms)
 }
 
+function runtimeProbeFreshnessLabel(probe: DashboardRuntimeProbeResponse | null): string {
+  // Reflect the server's non-blocking refresh_state so a force=1 ("Live probe")
+  // response is not mislabelled "fresh probe" when it is actually a stale value
+  // returned with a background refresh scheduled. Falls back to the cache_hit
+  // flag for older servers that do not emit refresh_state.
+  switch (probe?.refresh_state) {
+    case 'served_stale':
+      return 'refreshing'
+    case 'warming_up':
+      return 'warming up'
+    case 'fresh':
+    case 'recent':
+      return 'cache hit'
+    default:
+      return probe?.cache_hit ? 'cache hit' : 'fresh probe'
+  }
+}
+
 function firstProblem(
   providers: DashboardRuntimeProvidersResponse | null,
   probe: DashboardRuntimeProbeResponse | null,
@@ -266,7 +284,7 @@ export function RuntimeHealthSnapshot() {
           label="checked"
           value=${formatCheckedAt(probe)}
           status=${probeError ? 'crit' : probe ? 'ok' : 'warn'}
-          delta=${{ direction: probeError ? 'down' : 'flat', text: probe?.cache_hit ? 'cache hit' : 'fresh probe' }}
+          delta=${{ direction: probeError ? 'down' : 'flat', text: runtimeProbeFreshnessLabel(probe) }}
         />
         <${StatTile}
           label="assignments"

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1078,6 +1078,36 @@ let dashboard_runtime_probe_degraded_envelope
     ]
 ;;
 
+let dashboard_runtime_probe_failure_envelope_of_exn (exn : exn) =
+  (* Failure envelope persisted to the cache when a background refresh raises,
+     so the dashboard surfaces the cause instead of masking it as a stale or
+     warming-up value (failure-visibility contract). [Printexc.to_string]
+     carries the exception message into the [errors] array; the next refresh
+     after TTL expiry retries the probe. Pure function so the envelope shape is
+     unit-testable independent of the cache/atomic plumbing. *)
+  dashboard_runtime_probe_degraded_envelope
+    ~status:"unreachable"
+    ~error:(Printexc.to_string exn)
+    ~observation:
+      "Runtime probe background refresh failed; the value below is a failure \
+       snapshot cached for the cache TTL window so the dashboard surfaces the \
+       cause. The next refresh after TTL expiry retries the probe."
+    ~limitation:"Cached failure envelope; a successful refresh replaces it."
+    ()
+
+let dashboard_runtime_probe_record_failure exn =
+  (* Write the failure envelope to the cache (so subsequent reads within the
+     TTL window see the cause) and release the single-flight CAS. [Atomic.set]
+     never yields. *)
+  Atomic.set
+    dashboard_runtime_probe_cache
+    (Some
+       { probe = dashboard_runtime_probe_failure_envelope_of_exn exn
+       ; refreshed_at = Time_compat.now ()
+       });
+  Atomic.set dashboard_runtime_probe_refresh_in_flight false
+;;
+
 let maybe_fork_dashboard_runtime_probe_refresh () =
   (* Trigger a background refresh of the runtime probe cache without ever
      blocking the caller. Single-flight via the
@@ -1111,20 +1141,20 @@ let maybe_fork_dashboard_runtime_probe_refresh () =
               (Some { probe = fresh; refreshed_at });
             Atomic.set dashboard_runtime_probe_refresh_in_flight false
           | exception Eio.Cancel.Cancelled _ ->
-            (* Switch cancelled (e.g. server shutdown): release CAS, leave
-               whatever cache value remains in place. *)
+            (* Switch cancelled (e.g. server shutdown): release CAS, do not
+               cache. A shutdown is not a probe failure. *)
             Atomic.set dashboard_runtime_probe_refresh_in_flight false
-          | exception Eio.Mutex.Poisoned cause ->
-            Atomic.set dashboard_runtime_probe_refresh_in_flight false;
-            Log.Dashboard.warn
-              "runtime probe background refresh skipped: HTTP pool mutex \
-               poisoned (%s)"
-              (Printexc.to_string cause)
           | exception exn ->
-            Atomic.set dashboard_runtime_probe_refresh_in_flight false;
+            (* Persist a failure envelope so the dashboard surfaces the cause
+               instead of masking it as a stale or warming-up value
+               (failure-visibility contract). Cached for the TTL window; the
+               next refresh after expiry retries. Covers [Eio.Mutex.Poisoned]
+               and any other exn -- [dashboard_runtime_probe_record_failure]
+               writes the envelope and releases the CAS atomically. *)
             Log.Dashboard.warn
               "runtime probe background refresh failed: %s"
-              (Printexc.to_string exn)
+              (Printexc.to_string exn);
+            dashboard_runtime_probe_record_failure exn
         in
         (try Eio.Fiber.fork ~sw run with
          | exn when eio_switch_fork_unavailable exn ->

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -1051,6 +1051,91 @@ let run_dashboard_runtime_probe () =
     dashboard_runtime_probe_payload_json_of_runtimes ?default_id runtimes
 ;;
 
+let dashboard_runtime_probe_degraded_envelope
+      ~status ~error ~observation ~limitation () =
+  (* Degraded probe envelope shared by the warming-up (cold start, no prior
+     cache value) and unreachable paths. Keeps [probe_ok] false and every
+     summary count zero so the dashboard surfaces a clear "no data yet" state
+     rather than stalling the HTTP response. *)
+  `Assoc
+    [ "source", `String runtime_inventory_source
+    ; "status", `String status
+    ; "probe_ok", `Bool false
+    ; "checked_at", `String (Masc_domain.now_iso ())
+    ; ( "summary"
+      , `Assoc
+          [ "runtimes", `Int 0
+          ; "probed", `Int 0
+          ; "reachable", `Int 0
+          ; "failed", `Int 0
+          ; "skipped", `Int 0
+          ; "default_runtime_id", `Null
+          ] )
+    ; "providers", `List []
+    ; "errors", `List [ `String error ]
+    ; "observations", `List [ `String observation ]
+    ; "limitations", `List [ `String limitation ]
+    ]
+;;
+
+let maybe_fork_dashboard_runtime_probe_refresh () =
+  (* Trigger a background refresh of the runtime probe cache without ever
+     blocking the caller. Single-flight via the
+     [dashboard_runtime_probe_refresh_in_flight] CAS: if a refresh is already
+     running, this is a no-op. On domains where a background [Eio.Fiber.fork]
+     is not permitted (Domain_pool worker domains, or when no server switch is
+     reachable), release the CAS and skip -- a subsequent request on the main
+     domain will pick it up. [Atomic.set] never yields, so the in-flight flag
+     is always cleared even when the forked fiber raises or is cancelled.
+
+     This replaces the previous synchronous wait (up to
+     [dashboard_runtime_probe_timeout_sec], i.e. 15s) that stalled the whole
+     dashboard shell on every cache-miss poll and every force=1 request.
+     Mirrors the git-rev-parse background-refresh pattern
+     ([maybe_refresh_git_rev_parse_short_in_background]) already in this
+     module. *)
+  if Atomic.compare_and_set dashboard_runtime_probe_refresh_in_flight false true
+  then begin
+    if background_refresh_domain_unavailable () then
+      Atomic.set dashboard_runtime_probe_refresh_in_flight false
+    else
+      match Eio_context.get_switch_opt () with
+      | None -> Atomic.set dashboard_runtime_probe_refresh_in_flight false
+      | Some sw ->
+        let run () =
+          match run_dashboard_runtime_probe () with
+          | fresh ->
+            let refreshed_at = Time_compat.now () in
+            Atomic.set
+              dashboard_runtime_probe_cache
+              (Some { probe = fresh; refreshed_at });
+            Atomic.set dashboard_runtime_probe_refresh_in_flight false
+          | exception Eio.Cancel.Cancelled _ ->
+            (* Switch cancelled (e.g. server shutdown): release CAS, leave
+               whatever cache value remains in place. *)
+            Atomic.set dashboard_runtime_probe_refresh_in_flight false
+          | exception Eio.Mutex.Poisoned cause ->
+            Atomic.set dashboard_runtime_probe_refresh_in_flight false;
+            Log.Dashboard.warn
+              "runtime probe background refresh skipped: HTTP pool mutex \
+               poisoned (%s)"
+              (Printexc.to_string cause)
+          | exception exn ->
+            Atomic.set dashboard_runtime_probe_refresh_in_flight false;
+            Log.Dashboard.warn
+              "runtime probe background refresh failed: %s"
+              (Printexc.to_string exn)
+        in
+        (try Eio.Fiber.fork ~sw run with
+         | exn when eio_switch_fork_unavailable exn ->
+           background_refresh_mark_domain_unavailable ();
+           Atomic.set dashboard_runtime_probe_refresh_in_flight false
+         | exn ->
+           Atomic.set dashboard_runtime_probe_refresh_in_flight false;
+           raise exn)
+  end
+;;
+
 let dashboard_runtime_probe_cached_value () =
   match Atomic.get dashboard_runtime_probe_cache with
   | Some entry -> Some (entry.probe, entry.refreshed_at)
@@ -1083,73 +1168,29 @@ let dashboard_runtime_probe_http_json ?(force = false) () =
     with
     | Some (cached, cached_at) -> cached, true, cached_at
     | None ->
-      if Atomic.compare_and_set dashboard_runtime_probe_refresh_in_flight false true
-      then (
-        (* Run the Eio-yielding probe outside any Stdlib mutex/Fun.protect
-             scope.  The CAS guard above serialises refreshes; the [match]
-             below ensures the in-flight flag is always cleared even when
-             the probe raises or is cancelled (Atomic.set never yields). *)
-        match run_dashboard_runtime_probe () with
-        | fresh ->
-          let refreshed_at = Time_compat.now () in
-          Atomic.set dashboard_runtime_probe_cache (Some { probe = fresh; refreshed_at });
-          Atomic.set dashboard_runtime_probe_refresh_in_flight false;
-          fresh, false, refreshed_at
-        | exception Eio.Mutex.Poisoned cause ->
-          Atomic.set dashboard_runtime_probe_refresh_in_flight false;
-          Log.Dashboard.warn
-            "runtime probe skipped: HTTP pool mutex poisoned (%s); \
-             returning degraded envelope"
-            (Printexc.to_string cause);
-          let degraded =
-            `Assoc
-              [ "source", `String runtime_inventory_source
-              ; "status", `String "unreachable"
-              ; "probe_ok", `Bool false
-              ; "checked_at", `String (Masc_domain.now_iso ())
-              ; ( "summary"
-                , `Assoc
-                    [ "runtimes", `Int 0
-                    ; "probed", `Int 0
-                    ; "reachable", `Int 0
-                    ; "failed", `Int 0
-                    ; "skipped", `Int 0
-                    ; "default_runtime_id", `Null
-                    ] )
-              ; "providers", `List []
-              ; "errors", `List [ `String "pool mutex poisoned; restart to recover" ]
-              ; ( "observations"
-                , `List
-                    [ `String
-                        (Printf.sprintf
-                           "Runtime probe failed: HTTP pool mutex poisoned (%s). \
-                            The pool recovers on next successful request; if this \
-                            persists, restart the server."
-                           (Printexc.to_string cause))
-                    ] )
-              ; "limitations"
-              , `List
-                  [ `String "Probe skipped due to poisoned pool mutex."
-                  ]
-              ]
-          in
-          degraded, false, 0.0
-        | exception exn ->
-          let bt = Printexc.get_raw_backtrace () in
-          Atomic.set dashboard_runtime_probe_refresh_in_flight false;
-          Printexc.raise_with_backtrace exn bt)
-      else (
-        let fallback_now = Time_compat.now () in
-        match
-          if not force
-          then dashboard_runtime_probe_fresh_value ~now:fallback_now
-          else None
-        with
-        | Some (cached, cached_at) -> cached, true, cached_at
-        | None ->
-          (match dashboard_runtime_probe_cached_value () with
-           | Some (cached, cached_at) -> cached, false, cached_at
-           | None -> `Null, false, 0.0))
+      (* Cache miss (or forced refresh): trigger a non-blocking background
+         refresh and return the best value available right now (stale cache,
+         or a warming-up envelope on cold start). This removes the synchronous
+         up-to-[dashboard_runtime_probe_timeout_sec] wait that previously
+         stalled the dashboard shell on every cache-miss poll and on every
+         force=1 request. *)
+      maybe_fork_dashboard_runtime_probe_refresh ();
+      (match dashboard_runtime_probe_cached_value () with
+       | Some (stale, stale_at) -> stale, false, stale_at
+       | None ->
+         ( dashboard_runtime_probe_degraded_envelope
+             ~status:"warming_up"
+             ~error:"background probe in progress"
+             ~observation:
+               "Runtime probe is running in the background after a cold \
+                start or cache expiry; the next poll returns the refreshed \
+                value."
+             ~limitation:
+               "First response with no prior cache value returns this \
+                placeholder until the background probe completes."
+             (),
+           false,
+           0.0 ))
   in
   let response_now = Time_compat.now () in
   let refreshed_at_json, cache_age_json =

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -54,6 +54,18 @@ let clear_dashboard_runtime_probe_cache_for_tests () =
   Atomic.set dashboard_runtime_probe_refresh_in_flight false
 ;;
 
+let set_dashboard_runtime_probe_cache_for_tests ~probe ~age_sec () =
+  (* Seed the probe cache with a value [age_sec] seconds old so tests can drive
+     the fresh / recent-window / stale branches of [dashboard_runtime_probe_http_json]
+     deterministically. Unit tests have no Eio switch to fork a real background
+     refresh into, so the cache must be seeded directly. The [age_sec] is
+     translated to an absolute [refreshed_at] here so callers do not depend on
+     [Time_compat]. *)
+  Atomic.set
+    dashboard_runtime_probe_cache
+    (Some { probe; refreshed_at = Time_compat.now () -. age_sec })
+;;
+
 (* Per-path TTL cache for `git rev-parse --short HEAD`.  Each miss forks
    git and can take seconds on large worktrees (~/me etc.), yet HEAD
    changes infrequently, and every dashboard shell refresh calls this
@@ -1188,25 +1200,57 @@ let dashboard_runtime_probe_recent_value ~now =
   | _ -> None
 ;;
 
+(* Why this exists: force=1 callers (the dashboard "Live probe" button) expect an
+   immediate fresh value, but the route is non-blocking — a cache miss schedules
+   a background refresh and returns the best value available now. This tag makes
+   that contract explicit in the response so the client can tell "this is the
+   refreshed value" from "a refresh was scheduled; the next poll carries the new
+   value", instead of inferring it from [cache_hit] alone. Closed sum so adding a
+   freshness branch forces an exhaustive update of the serializer. *)
+type dashboard_runtime_probe_refresh_state =
+  | Refresh_fresh (* TTL-fresh cache hit (non-force); no background refresh triggered. *)
+  | Refresh_recent
+  (* force=1 within [dashboard_runtime_probe_force_min_refresh_sec]: the recent
+     value is served and no new refresh is triggered (force rate limit). *)
+  | Refresh_served_stale
+  (* Cache miss with a stale value: the stale value is returned and a background
+     refresh was scheduled; the next poll carries the fresh value. *)
+  | Refresh_warming_up
+(* Cold start (no cache value): a warming-up placeholder is returned and a
+     background refresh was scheduled; the next poll carries the fresh value. *)
+
+let dashboard_runtime_probe_refresh_state_to_string = function
+  | Refresh_fresh -> "fresh"
+  | Refresh_recent -> "recent"
+  | Refresh_served_stale -> "served_stale"
+  | Refresh_warming_up -> "warming_up"
+;;
+
 let dashboard_runtime_probe_http_json ?(force = false) () =
   let now = Time_compat.now () in
-  let probe, cache_hit, refreshed_at =
+  let probe, cache_hit, refreshed_at, refresh_state =
     match
       if force
       then dashboard_runtime_probe_recent_value ~now
       else dashboard_runtime_probe_fresh_value ~now
     with
-    | Some (cached, cached_at) -> cached, true, cached_at
+    | Some (cached, cached_at) ->
+      (* Cache hit: a force=1 hit inside the recent-value window is rate-limited
+         (no new refresh) and tagged [recent]; a plain TTL-fresh hit is [fresh].
+         Neither schedules a background refresh. *)
+      cached, true, cached_at, (if force then Refresh_recent else Refresh_fresh)
     | None ->
-      (* Cache miss (or forced refresh): trigger a non-blocking background
-         refresh and return the best value available right now (stale cache,
-         or a warming-up envelope on cold start). This removes the synchronous
-         up-to-[dashboard_runtime_probe_timeout_sec] wait that previously
-         stalled the dashboard shell on every cache-miss poll and on every
-         force=1 request. *)
+      (* Cache miss (or forced refresh past the recent window): trigger a
+         non-blocking background refresh and return the best value available
+         right now (stale cache, or a warming-up envelope on cold start). This
+         removes the synchronous up-to-[dashboard_runtime_probe_timeout_sec]
+         wait that previously stalled the dashboard shell on every cache-miss
+         poll and on every force=1 request. [refresh_state] tells the client a
+         refresh was scheduled, so a force=1 caller does not mistake the
+         stale/warming-up value for an immediate fresh probe. *)
       maybe_fork_dashboard_runtime_probe_refresh ();
       (match dashboard_runtime_probe_cached_value () with
-       | Some (stale, stale_at) -> stale, false, stale_at
+       | Some (stale, stale_at) -> stale, false, stale_at, Refresh_served_stale
        | None ->
          ( dashboard_runtime_probe_degraded_envelope
              ~status:"warming_up"
@@ -1220,7 +1264,8 @@ let dashboard_runtime_probe_http_json ?(force = false) () =
                 placeholder until the background probe completes."
              (),
            false,
-           0.0 ))
+           0.0,
+           Refresh_warming_up ))
   in
   let response_now = Time_compat.now () in
   let refreshed_at_json, cache_age_json =
@@ -1234,6 +1279,8 @@ let dashboard_runtime_probe_http_json ?(force = false) () =
     ; "cache_ttl_sec", `Float dashboard_runtime_probe_cache_ttl_sec
     ; "cache_age_sec", cache_age_json
     ; "cache_hit", `Bool cache_hit
+    ; ( "refresh_state"
+      , `String (dashboard_runtime_probe_refresh_state_to_string refresh_state) )
     ; "probe", probe
     ]
 ;;

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -76,6 +76,13 @@ val dashboard_runtime_probe_http_json :
     includes a [cache_hit] flag so dashboards can show
     the freshness state. *)
 
+val dashboard_runtime_probe_failure_envelope_of_exn :
+  exn -> Yojson.Safe.t
+(** Pure builder for the failure envelope persisted to the cache when a
+    background refresh raises ([probe_ok=false], status [unreachable], the
+    exception message in [errors]). Exposed so the failure-visibility contract
+    is unit-testable independent of the cache/atomic plumbing. *)
+
 val dashboard_runtime_probe_payload_json_for_tests :
   ?default_id:string -> Runtime.t list -> Yojson.Safe.t
 (** Test-only pure projection for the production runtime reachability payload.

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -68,13 +68,26 @@ val light_runtime_resolution_json : Workspace.config -> Yojson.Safe.t
 
 val dashboard_runtime_probe_http_json :
   ?force:bool -> unit -> Yojson.Safe.t
-(** Returns the dashboard runtime-probe envelope.  With
-    [?force:true], bypasses the per-call freshness gate
-    and falls back to the recent-value gate; with
-    [?force:false] (default), skips the read entirely
-    when a fresh cache value is available.  Output
-    includes a [cache_hit] flag so dashboards can show
-    the freshness state. *)
+(** Returns the dashboard runtime-probe envelope. The route never blocks: on a
+    cache hit it returns the cached value; on a miss it schedules a non-blocking
+    background refresh and returns the best value available now (a stale cache
+    value, or a cold-start warming-up placeholder).
+
+    [?force:true] (the dashboard "Live probe" button) bypasses the per-call TTL
+    gate and uses the shorter recent-value window
+    ([dashboard_runtime_probe_force_min_refresh_sec]); past that window it still
+    only schedules a background refresh — it does NOT block for an immediate
+    fresh probe. Callers that expect "force = instant fresh value" must instead
+    read [refresh_state] and re-poll.
+
+    Output fields:
+    - [cache_hit]: the returned [probe] came from cache (it was not freshly
+      scheduled this call).
+    - [refresh_state]: one of [fresh] (TTL-fresh hit), [recent] (force=1 inside
+      the recent window), [served_stale] (stale value returned + background
+      refresh scheduled), or [warming_up] (cold-start placeholder + background
+      refresh scheduled). [served_stale]/[warming_up] mean the refreshed value
+      arrives on the next poll. *)
 
 val dashboard_runtime_probe_failure_envelope_of_exn :
   exn -> Yojson.Safe.t
@@ -160,6 +173,14 @@ val clear_dashboard_runtime_probe_cache_for_tests :
 (** Drops the cached runtime-probe value AND clears the
     refresh-in-flight gate so the next call observes a
     fresh state machine. *)
+
+val set_dashboard_runtime_probe_cache_for_tests :
+  probe:Yojson.Safe.t -> age_sec:float -> unit -> unit
+(** Seeds the runtime-probe cache with [probe], aged [age_sec] seconds. Drives
+    the fresh ([age_sec] < TTL, non-force) / recent ([age_sec] < force window,
+    force=1) / stale (older than both) branches of
+    {!dashboard_runtime_probe_http_json} deterministically, since unit tests
+    have no Eio switch for a real background refresh. *)
 
 (** {1 Git rev-parse short test seams + helper} *)
 

--- a/test/dune
+++ b/test/dune
@@ -225,6 +225,7 @@
   test_keeper_toml
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers
+  test_dashboard_runtime_probe_nonblocking
   test_keeper_tool_policy_masc_surface
   test_keeper_tool_visibility_projection
   test_keeper_tool_capability_axis
@@ -528,6 +529,7 @@
   test_keeper_toml
   test_runtime_toml_overrides
   test_runtime_provider_auth_headers
+  test_dashboard_runtime_probe_nonblocking
   test_keeper_tool_policy_masc_surface
   test_keeper_tool_visibility_projection
   test_keeper_tool_capability_axis
@@ -665,6 +667,7 @@
 
 ; Fusion OAS failure-detail tests need Fusion_types constructors from
 ; masc.fusion_core, which is intentionally not re-exported via masc.
+
 (test
  (name test_fusion_oas_error_detail)
  (modules test_fusion_oas_error_detail)
@@ -673,6 +676,7 @@
 ; RFC-0266 Phase 3: masc_fusion_status tool — JSON projection of the run
 ; registry + keeper-LLM visibility (Pass B Default gate). Needs masc.fusion_core
 ; for the Fusion_run_registry module (not re-exported via masc_test_deps).
+
 (test
  (name test_fusion_status_tool)
  (modules test_fusion_status_tool)
@@ -681,6 +685,7 @@
 ; RFC-0252 §8 — judge_meta/panel_meta structured serialization. Needs
 ; masc.fusion_core for Fusion_types constructors (Answer/Recommend/Insufficient,
 ; judge_synthesis record) + Masc.Fusion_sink for the public meta serializers.
+
 (test
  (name test_fusion_sink_meta)
  (modules test_fusion_sink_meta)
@@ -1199,6 +1204,7 @@
  (libraries alcotest masc.json_field yojson))
 
 ; RFC-0264 P2: recall-injection ledger record serialiser unit tests.
+
 (test
  (name test_keeper_recall_injection_ledger)
  (modules test_keeper_recall_injection_ledger)
@@ -1236,17 +1242,41 @@
 (test
  (name test_schedule_store)
  (modules test_schedule_store)
- (libraries alcotest eio eio_main fs_compat masc_workspace masc_schedule unix yojson))
+ (libraries
+  alcotest
+  eio
+  eio_main
+  fs_compat
+  masc_workspace
+  masc_schedule
+  unix
+  yojson))
 
 (test
  (name test_schedule_service)
  (modules test_schedule_service)
- (libraries alcotest eio eio_main fs_compat masc_workspace masc_schedule unix yojson))
+ (libraries
+  alcotest
+  eio
+  eio_main
+  fs_compat
+  masc_workspace
+  masc_schedule
+  unix
+  yojson))
 
 (test
  (name test_schedule_runner)
  (modules test_schedule_runner)
- (libraries alcotest eio eio_main fs_compat masc_workspace masc_schedule unix yojson))
+ (libraries
+  alcotest
+  eio
+  eio_main
+  fs_compat
+  masc_workspace
+  masc_schedule
+  unix
+  yojson))
 
 (test
  (name test_schedule_consumer_dispatch)
@@ -2344,6 +2374,7 @@
  (preprocess
   (pps ppx_safe_shell))
  (libraries alcotest masc.masc_exec masc.exec_policy))
+
 ; Coverage regression tests for keeper/runtime immutable-state refactor (P9-P12).
 
 (test

--- a/test/test_dashboard_runtime_probe_nonblocking.ml
+++ b/test/test_dashboard_runtime_probe_nonblocking.ml
@@ -1,0 +1,65 @@
+open Alcotest
+open Masc
+
+(* Regression test for the runtime-probe route's non-blocking background
+   refresh.
+
+   Before the fix, a cache-miss [dashboard_runtime_probe_http_json] waited
+   synchronously for [run_dashboard_runtime_probe] (up to
+   [dashboard_runtime_probe_timeout_sec] = 15s), stalling the whole dashboard
+   shell on every cache-miss poll and every force=1 request. The fix triggers a
+   background refresh via [maybe_fork_dashboard_runtime_probe_refresh] and
+   returns a stale or warming-up envelope immediately.
+
+   This test pins that contract: a runner hook that would block for seconds if
+   called synchronously must NOT delay the [http_json] response. A unit test has
+   no Eio server switch, so [maybe_fork_dashboard_runtime_probe_refresh] skips
+   the background fork (no switch reachable) and [http_json] returns the
+   warming-up envelope without ever invoking the runner -- the exact behavior
+   that distinguishes the non-blocking route from the old synchronous one. If a
+   future change reintroduces a synchronous [run_dashboard_runtime_probe] call
+   on the request path, [slow_runner_invoked] becomes 1 and the wall-clock
+   budget is blown, failing this test. *)
+
+let slow_runner_invoked = ref 0
+
+let slow_runner () : Yojson.Safe.t =
+  incr slow_runner_invoked;
+  (* Simulate an expensive probe (e.g. cold Ollama model load). If the route
+     ever regresses to calling the runner synchronously, the wall-clock budget
+     below is blown and [slow_runner_invoked] becomes 1. *)
+  Unix.sleepf 3.0;
+  `Null
+
+let probe_ok_of = function
+  | `Assoc fields ->
+    (match List.assoc_opt "probe" fields with
+     | Some (`Assoc inner) ->
+       (match List.assoc_opt "probe_ok" inner with
+        | Some (`Bool b) -> b
+        | _ -> true)
+     | _ -> true)
+  | _ -> true
+
+let test_http_json_does_not_block_on_cold_start () =
+  Server_dashboard_http_runtime_info.clear_dashboard_runtime_probe_cache_for_tests ();
+  Server_dashboard_http_runtime_info.set_dashboard_runtime_probe_runner_for_tests
+    slow_runner;
+  slow_runner_invoked := 0;
+  let t0 = Unix.gettimeofday () in
+  let json =
+    Server_dashboard_http_runtime_info.dashboard_runtime_probe_http_json ()
+  in
+  let elapsed = Unix.gettimeofday () -. t0 in
+  check int "slow runner never invoked (no synchronous probe)" 0 !slow_runner_invoked;
+  check bool "warming-up envelope returned (probe_ok false)" false (probe_ok_of json);
+  check bool "http_json returns within the non-blocking budget" false
+    (elapsed >= 2.0);
+  Server_dashboard_http_runtime_info.clear_dashboard_runtime_probe_runner_for_tests ();
+  Server_dashboard_http_runtime_info.clear_dashboard_runtime_probe_cache_for_tests ()
+
+let () =
+  run "dashboard_runtime_probe_nonblocking"
+    [ "non-blocking",
+        [ test_case "cold start does not block" `Quick
+            test_http_json_does_not_block_on_cold_start ] ]

--- a/test/test_dashboard_runtime_probe_nonblocking.ml
+++ b/test/test_dashboard_runtime_probe_nonblocking.ml
@@ -41,6 +41,38 @@ let probe_ok_of = function
      | _ -> true)
   | _ -> true
 
+(* Inspectors for an envelope value directly (top-level fields), used by the
+   failure-envelope contract test. *)
+
+let envelope_probe_ok = function
+  | `Assoc fields ->
+    (match List.assoc_opt "probe_ok" fields with
+     | Some (`Bool b) -> b
+     | _ -> true)
+  | _ -> true
+
+let envelope_status = function
+  | `Assoc fields ->
+    (match List.assoc_opt "status" fields with
+     | Some (`String s) -> s
+     | _ -> "?")
+  | _ -> "?"
+
+(* P1: failure-visibility contract. When the background refresh raises, the
+   failure envelope persisted to the cache must carry probe_ok=false and a
+   distinct [unreachable] status (not [warming_up]) so the dashboard can tell
+   "probe failed" apart from "probe still warming up". If this regresses to
+   "log only, never cache the cause", the operator loses the failure reason. *)
+
+let test_failure_envelope_carries_unreachable_status () =
+  let envelope =
+    Server_dashboard_http_runtime_info.dashboard_runtime_probe_failure_envelope_of_exn
+      (Failure "simulated ollama timeout")
+  in
+  check bool "failure envelope probe_ok false" false (envelope_probe_ok envelope);
+  check string "failure envelope status unreachable" "unreachable"
+    (envelope_status envelope)
+
 let test_http_json_does_not_block_on_cold_start () =
   Server_dashboard_http_runtime_info.clear_dashboard_runtime_probe_cache_for_tests ();
   Server_dashboard_http_runtime_info.set_dashboard_runtime_probe_runner_for_tests
@@ -62,4 +94,7 @@ let () =
   run "dashboard_runtime_probe_nonblocking"
     [ "non-blocking",
         [ test_case "cold start does not block" `Quick
-            test_http_json_does_not_block_on_cold_start ] ]
+            test_http_json_does_not_block_on_cold_start ]
+    ; "failure visibility",
+        [ test_case "failure envelope carries unreachable status" `Quick
+            test_failure_envelope_carries_unreachable_status ] ]

--- a/test/test_dashboard_runtime_probe_nonblocking.ml
+++ b/test/test_dashboard_runtime_probe_nonblocking.ml
@@ -1,7 +1,7 @@
 open Alcotest
 open Masc
 
-(* Regression test for the runtime-probe route's non-blocking background
+(* Regression tests for the runtime-probe route's non-blocking background
    refresh.
 
    Before the fix, a cache-miss [dashboard_runtime_probe_http_json] waited
@@ -11,25 +11,29 @@ open Masc
    background refresh via [maybe_fork_dashboard_runtime_probe_refresh] and
    returns a stale or warming-up envelope immediately.
 
-   This test pins that contract: a runner hook that would block for seconds if
-   called synchronously must NOT delay the [http_json] response. A unit test has
-   no Eio server switch, so [maybe_fork_dashboard_runtime_probe_refresh] skips
-   the background fork (no switch reachable) and [http_json] returns the
-   warming-up envelope without ever invoking the runner -- the exact behavior
-   that distinguishes the non-blocking route from the old synchronous one. If a
-   future change reintroduces a synchronous [run_dashboard_runtime_probe] call
-   on the request path, [slow_runner_invoked] becomes 1 and the wall-clock
-   budget is blown, failing this test. *)
+   The contract these tests pin is "no synchronous probe on the request path".
+   That is asserted with a deterministic invocation COUNTER ([slow_runner_invoked]),
+   not a wall-clock threshold: a unit test has no Eio server switch, so
+   [maybe_fork_dashboard_runtime_probe_refresh] skips the background fork and the
+   runner is never invoked from the request path. The [refresh_state] field of
+   the response is asserted directly, so every freshness branch (warming_up /
+   served_stale / recent) is verified by state transition rather than by timing.
+   If a future change reintroduces a synchronous [run_dashboard_runtime_probe]
+   call on the request path, [slow_runner_invoked] becomes 1 and these tests
+   fail. *)
 
 let slow_runner_invoked = ref 0
 
 let slow_runner () : Yojson.Safe.t =
   incr slow_runner_invoked;
-  (* Simulate an expensive probe (e.g. cold Ollama model load). If the route
-     ever regresses to calling the runner synchronously, the wall-clock budget
-     below is blown and [slow_runner_invoked] becomes 1. *)
+  (* Simulate an expensive probe (e.g. cold Ollama model load). The tests assert
+     on [slow_runner_invoked], not on elapsed time; the sleep only makes a
+     synchronous-call regression additionally visible as a slow run. *)
   Unix.sleepf 3.0;
   `Null
+
+(* Inspectors for the [http_json] response envelope (top-level fields wrapping
+   the [probe] value). *)
 
 let probe_ok_of = function
   | `Assoc fields ->
@@ -41,7 +45,33 @@ let probe_ok_of = function
      | _ -> true)
   | _ -> true
 
-(* Inspectors for an envelope value directly (top-level fields), used by the
+let cache_hit_of = function
+  | `Assoc fields ->
+    (match List.assoc_opt "cache_hit" fields with
+     | Some (`Bool b) -> b
+     | _ -> false)
+  | _ -> false
+
+let refresh_state_of = function
+  | `Assoc fields ->
+    (match List.assoc_opt "refresh_state" fields with
+     | Some (`String s) -> s
+     | _ -> "?")
+  | _ -> "?"
+
+(* Pull a marker string out of the [probe] field, to prove the cached value was
+   served verbatim (not replaced by a placeholder). *)
+let probe_marker_of = function
+  | `Assoc fields ->
+    (match List.assoc_opt "probe" fields with
+     | Some (`Assoc inner) ->
+       (match List.assoc_opt "marker" inner with
+        | Some (`String s) -> Some s
+        | _ -> None)
+     | _ -> None)
+  | _ -> None
+
+(* Inspectors for a bare envelope value (top-level fields), used by the
    failure-envelope contract test. *)
 
 let envelope_probe_ok = function
@@ -58,6 +88,10 @@ let envelope_status = function
      | _ -> "?")
   | _ -> "?"
 
+let reset_probe_seams () =
+  Server_dashboard_http_runtime_info.clear_dashboard_runtime_probe_runner_for_tests ();
+  Server_dashboard_http_runtime_info.clear_dashboard_runtime_probe_cache_for_tests ()
+
 (* P1: failure-visibility contract. When the background refresh raises, the
    failure envelope persisted to the cache must carry probe_ok=false and a
    distinct [unreachable] status (not [warming_up]) so the dashboard can tell
@@ -73,28 +107,94 @@ let test_failure_envelope_carries_unreachable_status () =
   check string "failure envelope status unreachable" "unreachable"
     (envelope_status envelope)
 
-let test_http_json_does_not_block_on_cold_start () =
-  Server_dashboard_http_runtime_info.clear_dashboard_runtime_probe_cache_for_tests ();
+(* Cold start: no cache value. The route must return a warming-up placeholder
+   without ever invoking the (synchronous) runner. *)
+let test_cold_start_returns_warming_up_without_probe () =
+  reset_probe_seams ();
   Server_dashboard_http_runtime_info.set_dashboard_runtime_probe_runner_for_tests
     slow_runner;
   slow_runner_invoked := 0;
-  let t0 = Unix.gettimeofday () in
   let json =
     Server_dashboard_http_runtime_info.dashboard_runtime_probe_http_json ()
   in
-  let elapsed = Unix.gettimeofday () -. t0 in
-  check int "slow runner never invoked (no synchronous probe)" 0 !slow_runner_invoked;
+  check int "slow runner never invoked on cold start" 0 !slow_runner_invoked;
   check bool "warming-up envelope returned (probe_ok false)" false (probe_ok_of json);
-  check bool "http_json returns within the non-blocking budget" false
-    (elapsed >= 2.0);
-  Server_dashboard_http_runtime_info.clear_dashboard_runtime_probe_runner_for_tests ();
-  Server_dashboard_http_runtime_info.clear_dashboard_runtime_probe_cache_for_tests ()
+  check bool "cache_hit false on cold start" false (cache_hit_of json);
+  check string "refresh_state is warming_up" "warming_up" (refresh_state_of json);
+  reset_probe_seams ()
+
+(* force=1 with a stale cache value: the route must serve the stale value
+   immediately (no synchronous probe) and tag it [served_stale] so the client
+   knows a refresh was scheduled and the fresh value arrives on the next poll. *)
+let test_force_with_stale_cache_serves_stale_without_probe () =
+  reset_probe_seams ();
+  Server_dashboard_http_runtime_info.set_dashboard_runtime_probe_runner_for_tests
+    slow_runner;
+  slow_runner_invoked := 0;
+  let stale_probe =
+    `Assoc
+      [ "probe_ok", `Bool true
+      ; "status", `String "reachable"
+      ; "marker", `String "stale-cache-value"
+      ]
+  in
+  (* Older than both the TTL (30s) and the force window (10s). *)
+  Server_dashboard_http_runtime_info.set_dashboard_runtime_probe_cache_for_tests
+    ~probe:stale_probe ~age_sec:100.0 ();
+  let json =
+    Server_dashboard_http_runtime_info.dashboard_runtime_probe_http_json
+      ~force:true ()
+  in
+  check int "slow runner never invoked on force=1 stale" 0 !slow_runner_invoked;
+  check string "refresh_state is served_stale" "served_stale" (refresh_state_of json);
+  check bool "cache_hit false (value is stale, refresh scheduled)" false
+    (cache_hit_of json);
+  check (option string) "stale value served verbatim" (Some "stale-cache-value")
+    (probe_marker_of json);
+  reset_probe_seams ()
+
+(* force=1 within the recent-value window: the recent value is served as a hit
+   and tagged [recent]; no refresh is scheduled (force rate limit) and the
+   runner is not invoked. *)
+let test_force_within_recent_window_serves_recent () =
+  reset_probe_seams ();
+  Server_dashboard_http_runtime_info.set_dashboard_runtime_probe_runner_for_tests
+    slow_runner;
+  slow_runner_invoked := 0;
+  let recent_probe =
+    `Assoc
+      [ "probe_ok", `Bool true
+      ; "status", `String "reachable"
+      ; "marker", `String "recent-cache-value"
+      ]
+  in
+  (* Within the force window (10s). *)
+  Server_dashboard_http_runtime_info.set_dashboard_runtime_probe_cache_for_tests
+    ~probe:recent_probe ~age_sec:1.0 ();
+  let json =
+    Server_dashboard_http_runtime_info.dashboard_runtime_probe_http_json
+      ~force:true ()
+  in
+  check int "slow runner never invoked on force=1 recent" 0 !slow_runner_invoked;
+  check string "refresh_state is recent" "recent" (refresh_state_of json);
+  check bool "cache_hit true (recent value within force window)" true
+    (cache_hit_of json);
+  check (option string) "recent value served verbatim" (Some "recent-cache-value")
+    (probe_marker_of json);
+  reset_probe_seams ()
 
 let () =
   run "dashboard_runtime_probe_nonblocking"
-    [ "non-blocking",
-        [ test_case "cold start does not block" `Quick
-            test_http_json_does_not_block_on_cold_start ]
-    ; "failure visibility",
+    [ ( "non-blocking",
+        [ test_case "cold start returns warming_up, no probe" `Quick
+            test_cold_start_returns_warming_up_without_probe
+        ; test_case "force=1 stale serves served_stale, no probe" `Quick
+            test_force_with_stale_cache_serves_stale_without_probe
+        ; test_case "force=1 recent serves recent hit, no probe" `Quick
+            test_force_within_recent_window_serves_recent
+        ] )
+    ; ( "failure visibility",
         [ test_case "failure envelope carries unreachable status" `Quick
-            test_failure_envelope_carries_unreachable_status ] ]
+            test_failure_envelope_carries_unreachable_status
+        ] )
+    ]


### PR DESCRIPTION
## Summary

The dashboard `runtime-probe` route blocked the whole dashboard shell for up to **15s** on every cache-miss poll and every `force=1` request ("한 번 잡히면 모든 게 다 느려짐"). Root cause: `dashboard_runtime_probe_http_json` called `run_dashboard_runtime_probe()` **synchronously** on cache miss, and cache TTL (30s) == poll interval (30s), so the hit rate collapsed to near-zero — roughly every poll was a 15s synchronous wait.

## Fix

Replace the synchronous probe with `maybe_fork_dashboard_runtime_probe_refresh`:
- **Single-flight CAS** (`dashboard_runtime_probe_refresh_in_flight`) — at most one background refresh
- **Eio.Fiber.fork** off the request path, mirroring the existing `maybe_refresh_git_rev_parse_short_in_background` pattern in the same module (git probe was already background; runtime-probe was the inconsistent synchronous one)
- Route now **always returns immediately** with the best-available value:
  - fresh cache → hit (unchanged)
  - stale cache → return stale + trigger background refresh
  - cold start → warming-up envelope (`probe_ok=false`) + trigger background refresh

Never blocks. Worker-domain or no-switch fallback skips the fork and still returns immediately (never falls back to synchronous wait).

## Why not polling / SSE / WebSocket changes

This is **not** a polling-frequency or transport change. The bug was the synchronous wait on cache miss, not the polling interval. 30s polling is conservative; cache TTL == poll interval was a separate latent trap but the actual stall came from waiting synchronously. The fix makes each probe non-blocking, so polling stays as-is and every response is ~1ms.

## Changes
- `lib/server/server_dashboard_http_runtime_info.ml`: new `maybe_fork_dashboard_runtime_probe_refresh`; rewrote `dashboard_runtime_probe_http_json` miss path; extracted shared `dashboard_runtime_probe_degraded_envelope` (was inlined in the Mutex.Poisoned arm)
- `test/test_dashboard_runtime_probe_nonblocking.ml`: new regression test — asserts a slow runner hook is **never invoked** on the request path (fails if anyone reintroduces the synchronous wait)
- `test/dune`: register the new test in both build + runtest stanzas

## Verification
- `dune build` ✓
- `dune exec test/test_dashboard_runtime_probe_nonblocking.exe` ✓ (1 test, 0.000s — the 3s slow-runner sleep never ran)

## Tradeoffs
- **Cold start first response** is now a warming-up envelope (`probe_ok=false`) instead of a synchronous probe. Next poll (≤30s) returns the refreshed value. This is the cost of never blocking.
- **`force=1` no longer guarantees an immediate fresh value** — it triggers a background refresh and returns the current cache. The refreshed value appears on the next poll. This removes the 15s blocking that `force=1` previously caused.

## RFC
Mirrors RFC-0138 (dashboard snapshot lock-free architecture) non-blocking principles. **Not a workaround** — removes a blocking wait rather than capping/masking symptoms (no cap/cooldown/dedup/repair signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
