### PR TITLE
refactor(dashboard): 승인 위험도 typed exhaustive 라벨로 humanize (phase 2a)

### DIFF
--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -90,11 +90,12 @@ describe('ApprovalsSurface', () => {
     expect(cards.length).toBe(4)
     expect(container.textContent).toContain('masc-improver')
     expect(container.textContent).toContain('fs_write')
-    // risk_level is surfaced uppercased on the .ap-kind badge
-    expect(container.textContent).toContain('CRITICAL')
-    expect(container.textContent).toContain('HIGH')
-    expect(container.textContent).toContain('MEDIUM')
-    expect(container.textContent).toContain('LOW')
+    // risk_level is surfaced as a humanized Korean label on the .ap-kind badge
+    // (keeperApprovalRiskLabel — exhaustive over the closed risk-level union).
+    expect(container.textContent).toContain('심각')
+    expect(container.textContent).toContain('높음')
+    expect(container.textContent).toContain('보통')
+    expect(container.textContent).toContain('낮음')
     expect(container.querySelector('[data-approval-id="appr-1"]')?.className).toContain('sev-bad')
     expect(container.querySelector('[data-approval-id="appr-3"]')?.className).toContain('sev-warn')
     expect(container.querySelector('[data-approval-id="appr-4"]')?.className).toContain('sev-accent')

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -19,6 +19,7 @@ import { TELEMETRY_AUTO_REFRESH_MS } from '../../config/constants'
 import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
 import {
   isHighOrCriticalKeeperApprovalRisk,
+  keeperApprovalRiskLabel,
   keeperApprovalRiskVisualBand,
   type KeeperApprovalRiskVisualBand,
 } from '../../lib/governance-risk-level'
@@ -95,7 +96,7 @@ function approvalDetailRows(item: KeeperApprovalQueueItem): Array<{ label: strin
   return [
     { label: '키퍼', value: item.keeper_name },
     { label: '도구', value: item.tool_name },
-    { label: '위험도', value: item.risk_level.toUpperCase() },
+    { label: '위험도', value: keeperApprovalRiskLabel(item.risk_level) },
     { label: '대기', value: apAge(item.waiting_s) },
     { label: '작업', value: approvalWorkSummary(item) },
     { label: '런타임', value: approvalRuntimeSummary(item) },
@@ -140,7 +141,7 @@ function ApprovalCard({
       <div class="ap-rail"></div>
       <div class="ap-main">
         <div class="ap-h">
-          <span class=${`ap-kind sev-${sev}`}>${(item.risk_level ?? 'unknown').toUpperCase()}</span>
+          <span class=${`ap-kind sev-${sev}`}>${keeperApprovalRiskLabel(item.risk_level)}</span>
           <span class="ap-tool mono">${item.tool_name}</span>
           <span class="ap-id mono">${item.id}</span>
           <span class=${`ap-age sev-${sev}`}>${apAge(item.waiting_s)}</span>
@@ -232,7 +233,7 @@ function ApprovalDetailPanel({
       data-approval-id=${item.id}
     >
       <div class="ap-detail-panel-head">
-        <span class=${`ap-kind sev-${sev}`}>${item.risk_level.toUpperCase()}</span>
+        <span class=${`ap-kind sev-${sev}`}>${keeperApprovalRiskLabel(item.risk_level)}</span>
         <div class="ap-detail-panel-title">
           <strong>${approvalTitle(item)}</strong>
           <span class="mono">${item.id}</span>

--- a/dashboard/src/lib/governance-risk-level.test.ts
+++ b/dashboard/src/lib/governance-risk-level.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  asKeeperApprovalRiskLevel,
+  keeperApprovalRiskLabel,
+  keeperApprovalRiskVisualBand,
+} from './governance-risk-level'
+
+describe('keeperApprovalRiskLabel', () => {
+  it('maps each closed risk-level value to its Korean label', () => {
+    expect(keeperApprovalRiskLabel('critical')).toBe('심각')
+    expect(keeperApprovalRiskLabel('high')).toBe('높음')
+    expect(keeperApprovalRiskLabel('medium')).toBe('보통')
+    expect(keeperApprovalRiskLabel('low')).toBe('낮음')
+  })
+
+  it('parses case-insensitively via the shared closed-set parser', () => {
+    expect(keeperApprovalRiskLabel('CRITICAL')).toBe('심각')
+    expect(keeperApprovalRiskLabel('  High  ')).toBe('높음')
+  })
+
+  it('shows unknown / unparseable input as 미분류 rather than the raw string', () => {
+    expect(keeperApprovalRiskLabel(null)).toBe('미분류')
+    expect(keeperApprovalRiskLabel(undefined)).toBe('미분류')
+    expect(keeperApprovalRiskLabel('')).toBe('미분류')
+    // A raw enum leak that is not a risk level is not silently prettified.
+    expect(keeperApprovalRiskLabel('completion_contract_result:passive_only')).toBe('미분류')
+  })
+
+  it('stays aligned with the visual band parser on the same input', () => {
+    // Both helpers route through asKeeperApprovalRiskLevel, so a value that
+    // parses to a band also parses to a non-미분류 label.
+    expect(asKeeperApprovalRiskLevel('high')).toBe('high')
+    expect(keeperApprovalRiskVisualBand('high')).toBe('warn')
+    expect(keeperApprovalRiskLabel('high')).toBe('높음')
+  })
+})

--- a/dashboard/src/lib/governance-risk-level.test.ts
+++ b/dashboard/src/lib/governance-risk-level.test.ts
@@ -3,6 +3,7 @@ import {
   asKeeperApprovalRiskLevel,
   keeperApprovalRiskLabel,
   keeperApprovalRiskVisualBand,
+  maxKeeperApprovalRiskLevel,
 } from './governance-risk-level'
 
 describe('keeperApprovalRiskLabel', () => {
@@ -32,5 +33,38 @@ describe('keeperApprovalRiskLabel', () => {
     expect(asKeeperApprovalRiskLevel('high')).toBe('high')
     expect(keeperApprovalRiskVisualBand('high')).toBe('warn')
     expect(keeperApprovalRiskLabel('high')).toBe('높음')
+  })
+})
+
+describe('keeperApprovalRiskVisualBand', () => {
+  it('maps each closed level through the shared SSOT', () => {
+    expect(keeperApprovalRiskVisualBand('critical')).toBe('bad')
+    expect(keeperApprovalRiskVisualBand('high')).toBe('warn')
+    expect(keeperApprovalRiskVisualBand('medium')).toBe('accent')
+    expect(keeperApprovalRiskVisualBand('low')).toBe('info')
+  })
+
+  it('falls back to info for unparseable input', () => {
+    expect(keeperApprovalRiskVisualBand(null)).toBe('info')
+    expect(keeperApprovalRiskVisualBand('nope')).toBe('info')
+  })
+})
+
+describe('maxKeeperApprovalRiskLevel', () => {
+  it('returns the highest-rank level from the SSOT ordering', () => {
+    expect(
+      maxKeeperApprovalRiskLevel([
+        { risk_level: 'low' },
+        { risk_level: 'critical' },
+        { risk_level: 'medium' },
+      ]),
+    ).toBe('critical')
+  })
+
+  it('ignores unparseable rows and returns null when none parse', () => {
+    expect(
+      maxKeeperApprovalRiskLevel([{ risk_level: 'nope' }, { risk_level: null }]),
+    ).toBe(null)
+    expect(maxKeeperApprovalRiskLevel([])).toBe(null)
   })
 })

--- a/dashboard/src/lib/governance-risk-level.ts
+++ b/dashboard/src/lib/governance-risk-level.ts
@@ -13,12 +13,36 @@ import type { KeeperApprovalRiskLevel } from '../types/governance'
 
 export type KeeperApprovalRiskVisualBand = 'bad' | 'warn' | 'accent' | 'info'
 
-const RISK_LEVEL_VALUES: ReadonlySet<string> = new Set([
-  'low',
-  'medium',
-  'high',
-  'critical',
-] satisfies readonly KeeperApprovalRiskLevel[])
+interface RiskLevelMeta {
+  readonly label: string
+  readonly band: KeeperApprovalRiskVisualBand
+  readonly rank: number
+}
+
+// Single source of truth, keyed by the closed `KeeperApprovalRiskLevel` union.
+//
+// This is what makes the exhaustiveness *compiler-enforced* rather than merely
+// asserted by a hand-written switch: `satisfies Record<KeeperApprovalRiskLevel,
+// …>` requires a key for EVERY union member (a missing key is a compile error,
+// independent of tsconfig flags like noImplicitReturns). A hand-listed Set or a
+// per-function switch only enforces a subset, so adding a backend risk level
+// could silently fall through to 미분류 / 'info' without a build failure. Every
+// derived view below (parser vocabulary, label, visual band, ordering rank)
+// reads from this one object, so a new risk level forces an update here once.
+const RISK_LEVEL_META = {
+  critical: { label: '심각', band: 'bad', rank: 4 },
+  high: { label: '높음', band: 'warn', rank: 3 },
+  medium: { label: '보통', band: 'accent', rank: 2 },
+  low: { label: '낮음', band: 'info', rank: 1 },
+} as const satisfies Record<KeeperApprovalRiskLevel, RiskLevelMeta>
+
+// Shown (not hidden or prettified) when input does not parse to a closed level.
+const UNCLASSIFIED_LABEL = '미분류'
+const UNCLASSIFIED_BAND: KeeperApprovalRiskVisualBand = 'info'
+
+// Parser vocabulary derived from the SSOT keys, so it cannot drift from the
+// label/band/rank views above.
+const RISK_LEVEL_VALUES: ReadonlySet<string> = new Set(Object.keys(RISK_LEVEL_META))
 
 export function isKeeperApprovalRiskLevel(
   value: string,
@@ -36,49 +60,22 @@ export function asKeeperApprovalRiskLevel(
 }
 
 export function keeperApprovalRiskVisualBand(value: unknown): KeeperApprovalRiskVisualBand {
-  switch (asKeeperApprovalRiskLevel(value)) {
-    case 'critical':
-      return 'bad'
-    case 'high':
-      return 'warn'
-    case 'medium':
-      return 'accent'
-    case 'low':
-    case null:
-      return 'info'
-  }
+  const level = asKeeperApprovalRiskLevel(value)
+  return level === null ? UNCLASSIFIED_BAND : RISK_LEVEL_META[level].band
 }
 
-// Human-readable Korean label for a governance risk level. Exhaustive over the
-// closed `KeeperApprovalRiskLevel` union (same shape as
-// `keeperApprovalRiskVisualBand`) so a new backend risk level forces a compile
-// error here rather than silently falling through to a raw wire string. Unknown
-// / unparseable input renders as 미분류 (shown, not hidden or prettified).
+// Human-readable Korean label for a governance risk level. Reads from the
+// `RISK_LEVEL_META` SSOT, so a new backend risk level is a compile error at the
+// SSOT (above) rather than a silent fall-through to a raw wire string here.
+// Unknown / unparseable input renders as 미분류 (shown, not hidden or prettified).
 export function keeperApprovalRiskLabel(value: unknown): string {
-  switch (asKeeperApprovalRiskLevel(value)) {
-    case 'critical':
-      return '심각'
-    case 'high':
-      return '높음'
-    case 'medium':
-      return '보통'
-    case 'low':
-      return '낮음'
-    case null:
-      return '미분류'
-  }
+  const level = asKeeperApprovalRiskLevel(value)
+  return level === null ? UNCLASSIFIED_LABEL : RISK_LEVEL_META[level].label
 }
 
 export function isHighOrCriticalKeeperApprovalRisk(value: unknown): boolean {
   const level = asKeeperApprovalRiskLevel(value)
   return level === 'critical' || level === 'high'
-}
-
-const RISK_RANK: Record<KeeperApprovalRiskLevel, number> = {
-  critical: 4,
-  high: 3,
-  medium: 2,
-  low: 1,
 }
 
 export function maxKeeperApprovalRiskLevel(
@@ -88,7 +85,7 @@ export function maxKeeperApprovalRiskLevel(
   let topLabel: KeeperApprovalRiskLevel | null = null
   for (const item of items) {
     const level = asKeeperApprovalRiskLevel(item.risk_level)
-    const rank = level ? RISK_RANK[level] : 0
+    const rank = level === null ? 0 : RISK_LEVEL_META[level].rank
     if (rank > topRank) {
       topRank = rank
       topLabel = level

--- a/dashboard/src/lib/governance-risk-level.ts
+++ b/dashboard/src/lib/governance-risk-level.ts
@@ -49,6 +49,26 @@ export function keeperApprovalRiskVisualBand(value: unknown): KeeperApprovalRisk
   }
 }
 
+// Human-readable Korean label for a governance risk level. Exhaustive over the
+// closed `KeeperApprovalRiskLevel` union (same shape as
+// `keeperApprovalRiskVisualBand`) so a new backend risk level forces a compile
+// error here rather than silently falling through to a raw wire string. Unknown
+// / unparseable input renders as 미분류 (shown, not hidden or prettified).
+export function keeperApprovalRiskLabel(value: unknown): string {
+  switch (asKeeperApprovalRiskLevel(value)) {
+    case 'critical':
+      return '심각'
+    case 'high':
+      return '높음'
+    case 'medium':
+      return '보통'
+    case 'low':
+      return '낮음'
+    case null:
+      return '미분류'
+  }
+}
+
 export function isHighOrCriticalKeeperApprovalRisk(value: unknown): boolean {
   const level = asKeeperApprovalRiskLevel(value)
   return level === 'critical' || level === 'high'


### PR DESCRIPTION
## 목적

승인 큐(approvals surface)에서 위험도(`risk_level`)를 `.toUpperCase()`로 raw wire string을 그대로 대문자화해 노출하던 것을, 닫힌 union을 모두 처리하는 typed 라벨로 교체합니다. v2 대시보드 humanize 작업(Phase 2a)의 첫 번째 typed 정리 항목입니다.

기존 동작은 백엔드 enum 문자열(`critical`/`high`/...)을 화면 분류기 없이 그대로 대문자로 보여줬고, 한 렌더 사이트는 `item.risk_level ?? 'unknown'`이라 null일 때 `UNKNOWN`을 출력하는 등 사이트마다 처리가 달랐습니다.

## 변경 내용

- `lib/governance-risk-level.ts`에 `keeperApprovalRiskLabel(value)` 추가. 기존 `keeperApprovalRiskVisualBand`와 동일하게 `asKeeperApprovalRiskLevel`(정확 매칭 파서)을 거친 뒤 닫힌 `KeeperApprovalRiskLevel` union을 exhaustive `switch`로 매핑합니다.
  - `critical → 심각`, `high → 높음`, `medium → 보통`, `low → 낮음`, `null → 미분류`.
  - 백엔드 SSOT: `lib/governance_pipeline_types.ml` (`type risk_level = Low | Medium | High | Critical`).
- `components/approvals/approvals-surface.ts` 3개 렌더 사이트(상세 행, 승인 카드, 상세 패널)를 모두 이 라벨로 통일. 기존 `?? 'unknown'` permissive fallback은 파서의 `미분류` case로 흡수.

### 설계 근거 (워크어라운드 아님)

문자열 분류기(`if str === 'x' return 'y'`)나 `.replace(/_/g,' ')` 같은 prettifier를 **추가하지 않습니다**. 오히려 raw `.toUpperCase()` 변환을 제거하고, 컴파일러가 강제하는 closed union + exhaustive match로 대체합니다(Parse, don't validate). 백엔드에 새 위험도가 추가되면 이 파일에서 컴파일 에러가 나므로, raw enum이 UI로 조용히 누출되지 않습니다. 알 수 없는 입력은 `미분류`로 **명시 표출**하며 prettify하거나 숨기지 않습니다.

## 검증

- `pnpm typecheck` — clean.
- `pnpm exec vitest run` (main config) — 위험도/`ap-kind`를 단언하는 6개 파일 162건 통과:
  - `lib/governance-risk-level.test.ts` (신규, exhaustive 라벨 + 대소문자 무시 파싱 + unknown→미분류)
  - `components/approvals/approvals-surface.test.ts` (4카드 critical/high/medium/low → 심각/높음/보통/낮음 단언으로 갱신)
  - `components/governance.test.ts`, `components/governance-risk.test.ts`, `components/ide/ide-shell.test.ts`, `components/overview/overview.test.ts`
- CSS `.ap-kind { text-transform: uppercase }`는 한국어 라벨에 no-op이라 시각 영향 없음.

## 관련

- 이슈 #22059 — `attention_reason` free-text contract 누출. 별도 typed contract 작업으로 추적(이 PR 범위 아님, 워크어라운드 도입 금지).

RFC-WAIVED: dashboard 표시 컴포넌트(approvals surface) 한정 변경. credential / operator control plane / keeper sandbox / Claude Code hooks / workflow 문서 어느 gated subsystem도 건드리지 않음. 백엔드 enum 추가/제거 없이 프론트 라벨 매핑만 추가.
