### PR TITLE
fix(test): tools/list internal_keeper_runtime 모순 단언 제거

### DIFF
--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -2088,7 +2088,7 @@ let tool_names_from_list_response response =
       | _ -> Alcotest.fail "result not an object")
   | _ -> Alcotest.fail "response not an object"
 
-let test_handle_request_tools_list_internal_keeper_runtime_includes_keeper_internal_tools
+let test_handle_request_tools_list_internal_keeper_runtime_hides_keeper_internal_tools
     () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -2111,8 +2111,15 @@ let test_handle_request_tools_list_internal_keeper_runtime_includes_keeper_inter
           ~internal_keeper_runtime:true state request
       in
       let names = tool_names_from_list_response response in
-      Alcotest.(check bool) "tool_execute listed" true
-        (List.mem "tool_execute" names);
+      (* internal_keeper_runtime no longer exposes keeper-internal tools to
+         tools/list: the Agent_internal surface was removed and
+         include_agent_internal adds no schema (see
+         mcp_server_eio_tool_profile.ml), so the Full-profile is_public_mcp
+         filter still drops them. Pin that tool_execute and masc_session stay
+         hidden even when the flag is set. A prior half-finished refactor left a
+         contradictory "tool_execute listed = true" assertion here against the
+         identical [List.mem] expression; it could never co-pass with the
+         hidden check below and is removed. *)
       Alcotest.(check bool) "retired tool_execute hidden" false
         (List.mem "tool_execute" names);
       Alcotest.(check bool) "system internal still hidden" false
@@ -2965,8 +2972,8 @@ let eio_tests = [
     test_handle_request_tools_call_records_keeper_usage_for_public_mcp;
   "handle tools/call blocks keeper internal tool", `Quick,
     test_handle_request_tools_call_blocks_keeper_internal_tool;
-  "handle tools/list internal keeper runtime includes keeper tools", `Quick,
-    test_handle_request_tools_list_internal_keeper_runtime_includes_keeper_internal_tools;
+  "handle tools/list internal keeper runtime hides keeper internal tools", `Quick,
+    test_handle_request_tools_list_internal_keeper_runtime_hides_keeper_internal_tools;
   "handle tools/call internal keeper runtime allows keeper tool", `Quick,
     test_handle_request_tools_call_internal_keeper_runtime_allows_keeper_internal_tool;
   "internal keeper runtime cleanup preserves primary exception", `Quick,


### PR DESCRIPTION
## 무엇을

`test/test_mcp_server_eio.ml`의 `tools/list` + `internal_keeper_runtime` 테스트가 **동일한 식** `List.mem "tool_execute" names`에 대해 `true`와 `false`를 동시에 단언해 **둘 다 통과 불가**인 모순을 제거했습니다.

```ocaml
(* before — 같은 expression, 정반대 기대값 *)
Alcotest.(check bool) "tool_execute listed" true   (List.mem "tool_execute" names);
Alcotest.(check bool) "retired tool_execute hidden" false (List.mem "tool_execute" names);
```

## 왜 (근본 원인)

Agent_internal surface 제거 리팩터가 **반쪽만 적용된 잔재**입니다:
- 새 동작에 맞춘 `"retired tool_execute hidden" false` 단언은 추가됐으나,
- 옛 동작 가정의 `"tool_execute listed" true` 단언과 테스트 이름/라벨(`includes`)은 그대로 남았습니다.

현재 `internal_keeper_runtime`는 tools/list에 keeper-internal 도구를 노출하지 않습니다 — `include_agent_internal`가 schema를 추가하지 않고, Full 프로파일의 `is_public_mcp` 필터가 `tool_execute`를 drop합니다(`tool_catalog_surfaces.ml`의 `public_mcp_surface_tools`에 부재).

## 어떻게 가려져 있었나

masc CI는 `dune build`(컴파일만)를 hard-required로 게이트하지만 **테스트 *실행* 실패는 advisory(non-gating)**입니다(`ci.yml`). 두 단언 모두 valid OCaml이라 컴파일은 통과 → 등록된 테스트가 런타임에 조용히 실패해도 머지를 막지 못했습니다.

## 변경

- 모순된 `true` 단언 삭제 + 리팩터 맥락 주석 추가.
- 테스트 이름/라벨 `includes` → `hides`로 실제 동작에 맞춤(거짓 surface 제거).
- 남은 단언: `internal_keeper_runtime:true`에서도 `tool_execute`/`masc_session`이 숨겨짐을 고정(회귀 방지).

## 근거 (3중 그라운딩)

1. **정적**: `rg -nw tool_execute lib/tool_catalog_surfaces/tool_catalog_surfaces.ml` → 0건. public 목록·hidden 목록 어디에도 없어 generic-internal로 떨어져 Hidden.
2. **경험적**: 직전 로컬 실행이 정확히 이 테스트에서 `List.mem "tool_execute" names = false` 관측(= `true` 단언이 깨지는 쪽).
3. **별칭축**: `tool_name_alias_axis.ml` — `public_name="Execute", internal_name="tool_execute"` → "tool_execute"는 내부명.

## 검증

- `ocamlformat 0.29.0 --check` clean.
- 컴파일: PR의 hard-required `dune build`.
- 테스트 실행: PR advisory CI에서 이 테스트가 통과로 전환됨을 확인.

RFC-WAIVED: 테스트 전용 변경(test/test_mcp_server_eio.ml 1파일). credential/identity·operator control·keeper sandbox·dashboard credential·hooks·workflow 등 RFC 게이트 subsystem 미접촉.
