### PR TITLE
fix: filter social state from durable transcript to break BDI speech model loop

### DIFF
--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -94,6 +94,48 @@ let take_last limit items =
   drop (max 0 (len - limit)) items
 ;;
 
+(* RFC-0276 (Phase 2 purge) removed the keeper social-model self-report
+   protocol end to end: no code path emits these headers any more
+   (`rg "SOCIAL_MODEL:|BELIEF_SUMMARY:|SPEECH_ACT:|DELIVERY_SURFACE:|ACTIVE_DESIRE:|CURRENT_INTENTION:" lib/`
+   = 0 producers). They survive only in durable chat-store rows written before
+   the purge, when a keeper was told to "start every response with
+   machine-readable headers" (RFC-0276 §2.1). Re-injecting those stale header
+   lines into the next turn's prompt restored the social state the keeper then
+   re-emitted — a self-reinforcing loop that outlived the code purge (task-1468).
+
+   The set is closed (the producer is gone), so this is a parse-boundary reject
+   of un-migrated data, not a new open-ended classifier. It is scoped to
+   [Assistant] rows only — where the protocol ever wrote headers — so a user who
+   literally types "BLOCKER: …" is never stripped. It strips header *lines*, not
+   whole rows, so a real reply that followed the headers in the same pre-purge
+   turn is preserved.
+
+   Removal target: delete once a chat-store backfill (RFC-0276 follow-up) strips
+   these lines on write/migration and no pre-purge rows remain on disk. Until
+   then, rejecting at this projection boundary keeps the loop broken regardless
+   of how old the on-disk data is. *)
+let legacy_social_state_header_prefixes =
+  [ "SOCIAL_MODEL:"; "BELIEF_SUMMARY:"; "SPEECH_ACT:"; "DELIVERY_SURFACE:"
+  ; "ACTIVE_DESIRE:"; "CURRENT_INTENTION:"; "BLOCKER:"; "NEED:" ]
+;;
+
+let is_legacy_social_state_header line =
+  let line = String.trim line in
+  List.exists
+    (fun prefix -> String.starts_with ~prefix line)
+    legacy_social_state_header_prefixes
+;;
+
+(* Drop the legacy header lines from a pre-purge assistant message, keeping the
+   real reply lines. Operates on line structure (the headers were one-per-line),
+   so it runs before [collapse_line_breaks] flattens the newlines away. *)
+let strip_legacy_social_state_headers content =
+  content
+  |> String.split_on_char '\n'
+  |> List.filter (fun line -> not (is_legacy_social_state_header line))
+  |> String.concat "\n"
+;;
+
 let recent_direct_conversation_of_messages
       ?(limit = default_recent_direct_limit)
       (messages : Keeper_chat_store.chat_message list)
@@ -118,11 +160,21 @@ let recent_direct_conversation_of_messages
            (match m.audio with
             | Some _ -> None
             | None ->
-              Some
-                { role = Assistant
-                ; speaker_label = None
-                ; content
-                }))
+              (* Reject pre-purge social-state header lines at the parse
+                 boundary, then re-normalise: an all-header row collapses to
+                 "" and is dropped here, while a header+reply row keeps the
+                 reply. *)
+              let content =
+                collapse_line_breaks
+                  (strip_legacy_social_state_headers m.content)
+              in
+              if content = "" then None
+              else
+                Some
+                  { role = Assistant
+                  ; speaker_label = None
+                  ; content
+                  }))
       | Keeper_chat_store.Role.Tool ->
         (match m.tool_call_name with
          | None -> None
@@ -165,13 +217,9 @@ let render_recent_direct_conversation_context
       Printf.sprintf "- %s%s: %s"
         (direct_line_role_to_label line.role) speaker line.content
     in
-    let social_state_prefixes =
-      [ "SOCIAL_MODEL:"; "BELIEF_SUMMARY:"; "SPEECH_ACT:"; "DELIVERY_SURFACE:";
-        "ACTIVE_DESIRE:"; "CURRENT_INTENTION:"; "BLOCKER:"; "NEED:" ]
-    in
-    let is_social_state_line s =
-      List.exists (fun prefix -> String.starts_with ~prefix s) social_state_prefixes
-    in
+    (* Pure rendering: legacy social-state headers are already rejected at the
+       parse boundary in [recent_direct_conversation_of_messages], so this
+       function carries no classification logic. *)
     String.concat "\n"
       ([
          "--- Recent direct conversation (durable transcript) ---";
@@ -179,7 +227,7 @@ let render_recent_direct_conversation_context
          "Use them to answer continuity questions about your immediately previous replies.";
          "Do not claim that you checked board, task, file, status, or runtime state unless a listed tool_call supports it or you call the relevant tool in this turn; without tool evidence, say it has not been verified in this turn.";
        ]
-       @ (List.filter (fun line -> not (is_social_state_line line.content)) lines |> List.map render_line))
+       @ List.map render_line lines)
 ;;
 
 (* RFC-0230: the lane is the state. A mention is pending when it arrives after

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -179,7 +179,7 @@ let render_recent_direct_conversation_context
          "Use them to answer continuity questions about your immediately previous replies.";
          "Do not claim that you checked board, task, file, status, or runtime state unless a listed tool_call supports it or you call the relevant tool in this turn; without tool evidence, say it has not been verified in this turn.";
        ]
-       @ (List.map render_line lines |> List.filter (fun s -> not (is_social_state_line s))))
+       @ (List.filter (fun line -> not (is_social_state_line line.content)) lines |> List.map render_line))
 ;;
 
 (* RFC-0230: the lane is the state. A mention is pending when it arrives after

--- a/lib/keeper/keeper_world_observation_message_scope.ml
+++ b/lib/keeper/keeper_world_observation_message_scope.ml
@@ -165,6 +165,13 @@ let render_recent_direct_conversation_context
       Printf.sprintf "- %s%s: %s"
         (direct_line_role_to_label line.role) speaker line.content
     in
+    let social_state_prefixes =
+      [ "SOCIAL_MODEL:"; "BELIEF_SUMMARY:"; "SPEECH_ACT:"; "DELIVERY_SURFACE:";
+        "ACTIVE_DESIRE:"; "CURRENT_INTENTION:"; "BLOCKER:"; "NEED:" ]
+    in
+    let is_social_state_line s =
+      List.exists (fun prefix -> String.starts_with ~prefix s) social_state_prefixes
+    in
     String.concat "\n"
       ([
          "--- Recent direct conversation (durable transcript) ---";
@@ -172,7 +179,7 @@ let render_recent_direct_conversation_context
          "Use them to answer continuity questions about your immediately previous replies.";
          "Do not claim that you checked board, task, file, status, or runtime state unless a listed tool_call supports it or you call the relevant tool in this turn; without tool evidence, say it has not been verified in this turn.";
        ]
-       @ List.map render_line lines)
+       @ (List.map render_line lines |> List.filter (fun s -> not (is_social_state_line s))))
 ;;
 
 (* RFC-0230: the lane is the state. A mention is pending when it arrives after

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -318,6 +318,99 @@ let test_recent_direct_context_omits_transport_failure_as_self_reply () =
       Alcotest.(check bool) "failure text is not a self utterance" false
         (contains_substring rendered "Keeper request failed"))
 
+(* RFC-0276 / task-1468: a pre-purge assistant turn led with social-state
+   headers and then the real reply. The header lines must be stripped at the
+   parse boundary while the reply survives — otherwise the headers re-inject and
+   the BDI loop persists, or (the previous over-strip bug) the whole turn
+   including the reply is dropped. *)
+let test_recent_direct_context_strips_legacy_social_headers_keeps_reply () =
+  let base_dir = temp_base_path "keeper-chat-social-strip" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-social-strip" in
+      K.append_assistant_message ~base_dir ~keeper_name
+        ~content:
+          "SOCIAL_MODEL: cooperative\n\
+           BELIEF_SUMMARY: user is waiting\n\
+           SPEECH_ACT: inform\n\
+           DELIVERY_SURFACE: dashboard\n\
+           ACTIVE_DESIRE: finish task\n\
+           CURRENT_INTENTION: reply now\n\
+           BLOCKER: none\n\
+           NEED: nothing\n\
+           I finished reading the board and posted a summary."
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+        ();
+      let lines =
+        K.load ~base_dir ~keeper_name
+        |> MS.recent_direct_conversation_of_messages
+      in
+      Alcotest.(check (list string)) "row survives as a single assistant line"
+        [ "assistant" ] (recent_roles lines);
+      let rendered = MS.render_recent_direct_conversation_context lines in
+      Alcotest.(check bool) "real reply text is preserved" true
+        (contains_substring rendered
+           "I finished reading the board and posted a summary.");
+      List.iter
+        (fun header ->
+          Alcotest.(check bool)
+            (Printf.sprintf "social header %S is stripped" header)
+            false
+            (contains_substring rendered header))
+        [ "SOCIAL_MODEL:"; "BELIEF_SUMMARY:"; "SPEECH_ACT:"
+        ; "DELIVERY_SURFACE:"; "ACTIVE_DESIRE:"; "CURRENT_INTENTION:" ])
+
+(* An assistant row that is *only* headers carries no reply; after stripping it
+   collapses to empty and must drop out entirely rather than render a blank
+   "- assistant:" line. *)
+let test_recent_direct_context_drops_header_only_assistant_row () =
+  let base_dir = temp_base_path "keeper-chat-social-only" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-social-only" in
+      K.append_assistant_message ~base_dir ~keeper_name
+        ~content:"SOCIAL_MODEL: cooperative\nSPEECH_ACT: inform\nNEED: nothing"
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+        ();
+      K.append_assistant_message ~base_dir ~keeper_name
+        ~content:"A genuine reply with no headers."
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+        ();
+      let lines =
+        K.load ~base_dir ~keeper_name
+        |> MS.recent_direct_conversation_of_messages
+      in
+      Alcotest.(check (list string)) "header-only row dropped, real reply kept"
+        [ "assistant" ] (recent_roles lines);
+      let rendered = MS.render_recent_direct_conversation_context lines in
+      Alcotest.(check bool) "remaining reply is the genuine one" true
+        (contains_substring rendered "A genuine reply with no headers."))
+
+(* The strip is scoped to assistant rows: a user who literally types a line
+   starting with "BLOCKER:" or "NEED:" is conversational input, not a keeper
+   self-report header, and must not be filtered. *)
+let test_recent_direct_context_keeps_user_blocker_line () =
+  let base_dir = temp_base_path "keeper-chat-user-blocker" in
+  Fun.protect
+    ~finally:(fun () -> try remove_tree base_dir with _ -> ())
+    (fun () ->
+      let keeper_name = "keeper-chat-user-blocker" in
+      K.append_user_message ~base_dir ~keeper_name
+        ~content:"BLOCKER: the deploy is stuck, can you check?"
+        ~surface:(Masc.Surface_ref.Dashboard { session_id = None })
+        ();
+      let lines =
+        K.load ~base_dir ~keeper_name
+        |> MS.recent_direct_conversation_of_messages
+      in
+      Alcotest.(check (list string)) "user line survives" [ "user" ]
+        (recent_roles lines);
+      let rendered = MS.render_recent_direct_conversation_context lines in
+      Alcotest.(check bool) "user BLOCKER: text is not stripped" true
+        (contains_substring rendered "the deploy is stuck"))
+
 let test_recent_direct_context_omits_voice_audio_self_echo () =
   let base_dir = temp_base_path "keeper-chat-recent-voice" in
   Fun.protect
@@ -1293,6 +1386,13 @@ let () =
             test_recent_direct_context_renders_prior_reply_and_tool_evidence;
           Alcotest.test_case "recent context omits transport failure as reply" `Quick
             test_recent_direct_context_omits_transport_failure_as_self_reply;
+          Alcotest.test_case "recent context strips legacy social headers, keeps reply"
+            `Quick
+            test_recent_direct_context_strips_legacy_social_headers_keeps_reply;
+          Alcotest.test_case "recent context drops header-only assistant row" `Quick
+            test_recent_direct_context_drops_header_only_assistant_row;
+          Alcotest.test_case "recent context keeps user BLOCKER: line" `Quick
+            test_recent_direct_context_keeps_user_blocker_line;
           Alcotest.test_case "recent context omits voice audio self echo" `Quick
             test_recent_direct_context_omits_voice_audio_self_echo;
           Alcotest.test_case "recent context is owner-direct only" `Quick


### PR DESCRIPTION
SOCIAL_MODEL/BELIEF_SUMMARY/SPEECH_ACT/DELIVERY_SURFACE/ACTIVE_DESIRE/CURRENT_INTENTION/BLOCKER/NEED headers were being captured in continuity snapshots and re-injected into subsequent turn prompts, causing the BDI speech model to restore stale social state and re-emit the same headers — a self-reinforcing loop that survived filesystem purge. Filter these 8 social state header lines from the rendered durable transcript in keeper_world_observation_message_scope.ml. Closes task-1468.