### PR TITLE
perf(dashboard): runtime-probe 4축 가속 (병렬·timeout·SWR·boot prefetch)

### DIFF
--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -548,6 +548,12 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       Dashboard_snapshot.refresh_loop
         ~sw ~clock ~config:(Mcp_server.workspace_config state) ~state
         ~interval_sec:2.0 ());
+  (* Warm the runtime-probe cache before the first dashboard request so the
+     shell does not open on a [warming_up] placeholder (which reads as "runtime
+     down" to an operator). Non-blocking:
+     [maybe_fork_dashboard_runtime_probe_refresh] forks a background fiber under
+     this switch and the single-flight CAS makes a concurrent refresh a no-op. *)
+  Server_dashboard_http_runtime_info.maybe_fork_dashboard_runtime_probe_refresh ();
   let resolved_base = (Mcp_server.workspace_config state).base_path in
   let masc_dir = Workspace.masc_root_dir (Mcp_server.workspace_config state) in
   resolved_base, masc_dir

--- a/lib/server/server_dashboard_http_runtime_info.ml
+++ b/lib/server/server_dashboard_http_runtime_info.ml
@@ -15,7 +15,38 @@ let dashboard_runtime_probe_cache : dashboard_runtime_probe_cache_entry option A
 
 let dashboard_runtime_probe_cache_ttl_sec = 30.0
 let dashboard_runtime_probe_force_min_refresh_sec = 10.0
-let dashboard_runtime_probe_timeout_sec = 15
+(* Metadata-probe timeout. The dashboard probe hits provider metadata endpoints
+   only ([/api/tags] for Ollama, [/models] for messages/chat — see
+   {!dashboard_runtime_probe_url}); it never sends a completion request, so there
+   is no warm-KV inference to wait for. A dead/dropping runtime therefore fails
+   fast (RST) and a slow one is bounded here. 15s matched the completion-probe
+   timeout and let one unreachable runtime stall the whole dashboard for the
+   full window ("runtime-probe 한 번 잡히면 모든 게 다 느려짐"); 5s is a ~10x margin
+   over observed metadata latency (<500ms) while cutting the worst-case stall
+   by 3x. The completion-probe ([tool_local_runtime_probe]) keeps its own
+   longer timeout because it does run inference.
+
+   Caveat: this 5s is a total-request cap that also bounds remote provider
+   [/models] endpoints (Messages/Chat APIs reached over the public internet),
+   not just loopback Ollama. A legitimately-slow-but-alive cloud endpoint that
+   the prior 15s tolerated can now be cut to [network_error]/unreachable;
+   because the probe runs off the hot path and the next poll retries this
+   self-heals, but the <500ms margin is evidenced for the local path only. *)
+let dashboard_runtime_probe_timeout_sec = 5
+(* Soft-TTL for stale-while-revalidate. A cache value is served as fresh for the
+   full [dashboard_runtime_probe_cache_ttl_sec], but once its age crosses this
+   threshold the request path schedules a non-blocking background refresh so the
+   *next* poll (default 30s) sees a fresh value instead of a post-expiry miss.
+   Set to half the TTL so a value refreshed on poll N is pre-warmed before
+   poll N+1 -- this is what closes the TTL==poll-interval hit-rate-0 trap
+   (cache expiry landing right at the next poll). *)
+let dashboard_runtime_probe_soft_refresh_sec = 15.0
+(* Concurrency cap for the parallel runtime-probe fan-out
+   ([dashboard_runtime_probe_payload_json_of_runtimes]). The configured runtime
+   fleet is small (a handful of providers), so this is a safety bound against
+   unbounded fork rather than a tuned throughput knob; it mirrors
+   [Dashboard_execution.dashboard_enrich_max_fibers] (8). *)
+let dashboard_runtime_probe_max_fibers = 8
 let dashboard_runtime_probe_refresh_in_flight = Atomic.make false
 
 let dashboard_runtime_probe_runner_hook : (unit -> Yojson.Safe.t) option Atomic.t =
@@ -223,8 +254,10 @@ let git_rev_parse_short_probe_argv dir =
    The probe runs on a background fiber via
    [maybe_refresh_git_rev_parse_short_in_background], so the extra
    wall-time does not affect the hot dashboard path — cached values
-   keep serving during the refresh. Matches the sibling
-   [dashboard_runtime_probe_timeout_sec = 15] at the top of this module. *)
+   keep serving during the refresh. This git-probe timeout is deliberately
+   independent of (and larger than) the metadata probe
+   [dashboard_runtime_probe_timeout_sec] (now 5s): a git rev-parse on a large
+   repo is slower than an HTTP metadata GET, so the two are tuned separately. *)
 let git_rev_parse_short_probe_timeout_sec = 15.0
 
 let git_rev_parse_short_probe dir =
@@ -993,7 +1026,43 @@ let dashboard_runtime_provider_probe_json
 ;;
 
 let dashboard_runtime_probe_payload_json_of_runtimes ?default_id runtimes =
-  let probes = List.map dashboard_runtime_provider_probe_json runtimes in
+  (* Probe each runtime concurrently when a server switch is reachable (the
+     production background-refresh fiber / boot warm, or a switch-bearing
+     test). Each probe is an independent runtime/URL/HTTP connection with no
+     shared mutable state, so the work is embarrassingly parallel and latency
+     collapses from [sum latencies] to [max latencies] -- a dead runtime no
+     longer serializes the probes after it.
+
+     Concurrency goes through [Eio.Fiber.List.map], the established in-repo
+     idiom for bounded parallel dashboard fan-out (see
+     [Dashboard_execution]'s enrich_keeper_with_diagnostic). It (a) preserves
+     input order, so the count / summary / errors invariants below stay
+     byte-identical to the sequential branch; (b) runs the bodies on its OWN
+     internal switch and re-raises any non-[Cancelled] exception at THIS call
+     site, NOT on the ambient (server root) switch. That distinction matters
+     because the probe body is NOT total: [dashboard_runtime_provider_probe_json]
+     reaches [Masc_http_client]'s pool init ([Pool.create] / [register_pool]),
+     which can raise [Invalid_argument] / [Eio.Mutex.Poisoned]. A bare
+     [Eio.Fiber.fork ~sw] onto the root switch would let such a raise call
+     [Switch.fail sw] and cancel sibling server background fibers; routing
+     through [Fiber.List.map] instead degrades the whole batch to the caller's
+     failure envelope ([maybe_fork_dashboard_runtime_probe_refresh]'s
+     [| exception exn -> record_failure]) -- the same outcome the sequential
+     [List.map] already produces, so the parallel path is no worse than
+     sequential under a rogue exn. [Eio.Cancel.Cancelled] (server shutdown)
+     still propagates. Bounded at [dashboard_runtime_probe_max_fibers].
+
+     Without a switch (unit tests, no Eio scheduler) it falls back to a
+     sequential [List.map] so deterministic ordering and test seams hold. *)
+  let probes =
+    match Eio_context.get_switch_opt () with
+    | None -> List.map dashboard_runtime_provider_probe_json runtimes
+    | Some _sw ->
+      Eio.Fiber.List.map
+        ~max_fibers:dashboard_runtime_probe_max_fibers
+        dashboard_runtime_provider_probe_json
+        runtimes
+  in
   let count pred = probes |> List.filter pred |> List.length in
   let skipped = count (fun p -> p.skipped) in
   let reachable = count (fun p -> Option.equal Bool.equal p.reachable (Some true)) in
@@ -1237,7 +1306,18 @@ let dashboard_runtime_probe_http_json ?(force = false) () =
     | Some (cached, cached_at) ->
       (* Cache hit: a force=1 hit inside the recent-value window is rate-limited
          (no new refresh) and tagged [recent]; a plain TTL-fresh hit is [fresh].
-         Neither schedules a background refresh. *)
+         Stale-while-revalidate: even on a TTL-fresh (non-force) hit, once the
+         cached value's age crosses the soft-TTL
+         [dashboard_runtime_probe_soft_refresh_sec] we schedule a non-blocking
+         background refresh. The single-flight CAS inside
+         {!maybe_fork_dashboard_runtime_probe_refresh} makes this a no-op when a
+         refresh is already running. This pre-warms the cache so the *next* poll
+         sees a fresh value instead of letting cache expiry land on a poll (the
+         TTL==poll-interval hit-rate-0 trap). The current response still serves
+         the fresh value; the refresh is invisible to the client. *)
+      let age = now -. cached_at in
+      if (not force) && age > dashboard_runtime_probe_soft_refresh_sec
+      then maybe_fork_dashboard_runtime_probe_refresh ();
       cached, true, cached_at, (if force then Refresh_recent else Refresh_fresh)
     | None ->
       (* Cache miss (or forced refresh past the recent window): trigger a

--- a/lib/server/server_dashboard_http_runtime_info.mli
+++ b/lib/server/server_dashboard_http_runtime_info.mli
@@ -96,6 +96,15 @@ val dashboard_runtime_probe_failure_envelope_of_exn :
     exception message in [errors]). Exposed so the failure-visibility contract
     is unit-testable independent of the cache/atomic plumbing. *)
 
+val maybe_fork_dashboard_runtime_probe_refresh : unit -> unit
+(** Schedule a non-blocking background refresh of the runtime-probe cache.
+    Single-flight via an internal CAS: a no-op when a refresh is already
+    running, when no server switch is reachable, or on Domain_pool worker
+    domains where a background [Eio.Fiber.fork] is not permitted. Called by
+    {!dashboard_runtime_probe_http_json} on cache miss / soft-TTL expiry, and by
+    the server boot path to warm the cache before the first dashboard request
+    so the first response is not a [warming_up] placeholder. *)
+
 val dashboard_runtime_probe_payload_json_for_tests :
   ?default_id:string -> Runtime.t list -> Yojson.Safe.t
 (** Test-only pure projection for the production runtime reachability payload.

--- a/test/test_dashboard_runtime_probe_nonblocking.ml
+++ b/test/test_dashboard_runtime_probe_nonblocking.ml
@@ -183,6 +183,43 @@ let test_force_within_recent_window_serves_recent () =
     (probe_marker_of json);
   reset_probe_seams ()
 
+(* SWR soft-TTL fresh hit: a non-force value aged past the soft-TTL (15s) but
+   within the cache TTL (30s) must still be served as a [fresh] hit WITHOUT a
+   synchronous probe on the request path. The background refresh the soft-TTL
+   schedules is forked under a server switch in production; a unit test has no
+   switch, so [maybe_fork_dashboard_runtime_probe_refresh] is a no-op here and
+   the runner stays uninvoked. This pins the request-path contract for the SWR
+   branch: if a future change makes the soft-TTL hit refresh synchronously (or
+   downgrade the envelope), [slow_runner_invoked] becomes 1 or [refresh_state]
+   stops being [fresh] and this fails. The switch-bearing assertion that the
+   background refresh actually fires and pre-warms the cache needs an
+   [Eio.Switch] harness and is tracked as a follow-up. *)
+let test_soft_ttl_fresh_hit_serves_fresh_without_sync_probe () =
+  reset_probe_seams ();
+  Server_dashboard_http_runtime_info.set_dashboard_runtime_probe_runner_for_tests
+    slow_runner;
+  slow_runner_invoked := 0;
+  let fresh_probe =
+    `Assoc
+      [ "probe_ok", `Bool true
+      ; "status", `String "reachable"
+      ; "marker", `String "soft-ttl-fresh-value"
+      ]
+  in
+  (* Past the soft-TTL (15s), still within the cache TTL (30s) and outside the
+     force window (10s): the soft-TTL refresh branch is taken. *)
+  Server_dashboard_http_runtime_info.set_dashboard_runtime_probe_cache_for_tests
+    ~probe:fresh_probe ~age_sec:20.0 ();
+  let json =
+    Server_dashboard_http_runtime_info.dashboard_runtime_probe_http_json ()
+  in
+  check int "slow runner never invoked on soft-TTL fresh hit" 0 !slow_runner_invoked;
+  check string "refresh_state is fresh" "fresh" (refresh_state_of json);
+  check bool "cache_hit true (value still within TTL)" true (cache_hit_of json);
+  check (option string) "fresh value served verbatim" (Some "soft-ttl-fresh-value")
+    (probe_marker_of json);
+  reset_probe_seams ()
+
 let () =
   run "dashboard_runtime_probe_nonblocking"
     [ ( "non-blocking",
@@ -192,6 +229,8 @@ let () =
             test_force_with_stale_cache_serves_stale_without_probe
         ; test_case "force=1 recent serves recent hit, no probe" `Quick
             test_force_within_recent_window_serves_recent
+        ; test_case "soft-TTL fresh hit serves fresh, no sync probe" `Quick
+            test_soft_ttl_fresh_hit_serves_fresh_without_sync_probe
         ] )
     ; ( "failure visibility",
         [ test_case "failure envelope carries unreachable status" `Quick


### PR DESCRIPTION
## 목적

runtime-probe를 네 축에서 빠르게 만든다. 앞선 non-blocking fix(#22060, request-path 동기 stall 제거)가 닿지 못한 **probe 자체의 구조적 지연**을 대상으로 한다.

| 축 | 변경 | 효과 |
|----|------|------|
| 1. 병렬화 | server switch 가용 시 per-runtime probe를 `Eio.Fiber.List.map ~max_fibers`로 동시 실행 | latency가 `sum` → `max`. 죽은 runtime이 뒤 probe를 직렬화하지 않음 |
| 2. timeout | metadata-probe timeout 15s → 5s | 도달 불가 runtime 하나가 대시보드 전체를 15s stall시키던 문제 제거 |
| 3. SWR | soft-TTL(=TTL의 절반, 15s) 초과 fresh-hit에서 non-blocking background refresh 예약 | `TTL==poll-interval` hit-rate-0 trap 해소(다음 poll이 fresh를 봄) |
| 4. boot warm | `start_background_maintenance`에서 캐시 prefetch | 첫 대시보드 요청이 `warming_up` placeholder가 아님 |

## 변경 파일

- `lib/server/server_dashboard_http_runtime_info.ml` — 4축 본체
- `lib/server/server_dashboard_http_runtime_info.mli` — `maybe_fork_dashboard_runtime_probe_refresh` 노출(boot warm 호출용)
- `lib/server/server_bootstrap_maintenance.ml` — boot warm 호출
- `test/test_dashboard_runtime_probe_nonblocking.ml` — soft-TTL request-path 핀 추가

## 적대 검증 경위 (병합 전 self-review)

5-에이전트 적대 리뷰가 Axis 1에서 **blocker(M1)**를 찾았고 본 PR에서 수정했다:

- **문제(M1)**: 최초 구현은 per-runtime probe를 손수 짠 `Eio.Promise.create + Eio.Fiber.fork ~sw + Promise.await`로 **server root switch에 직접 fork**했다. background-refresh/boot 경로에서 `Eio_context.get_switch_opt ()`는 root switch를 돌려준다(`server_runtime_bootstrap.ml:245`). probe body는 total이 아니다 — `dashboard_runtime_provider_probe_json → Masc_http_client.get_response_sync → Pool.create / register_pool`이 `Invalid_argument` / `Eio.Mutex.Poisoned`를 raise할 수 있다. fork된 fiber에서 non-Cancel 예외가 raise되면 Eio는 `Switch.fail sw`를 호출 → **서버 전체 background fiber 취소** + 짝이 되는 `await`는 영구 hang.
- **수정**: 손수 짠 fork/await를 `Eio.Fiber.List.map ~max_fibers`로 교체. 이건 같은 dashboard subsystem의 확립된 idiom(`dashboard_execution.ml`의 enrich fan-out)이다 — (a) 입력 순서 보존 → 하위 count/summary 불변식 그대로, (b) **내부 switch**에서 실행 + 호출 지점 re-raise → probe 예외가 root switch가 아니라 `maybe_fork_dashboard_runtime_probe_refresh`의 기존 `| exception exn -> record_failure` 엔벨로프에 잡힌다. 즉 sequential `List.map`과 동일한 degrade(batch가 failure envelope로). `Eio.Cancel.Cancelled`(셧다운)는 그대로 전파.
- 이 수정은 신규 미검증 동시성 코드를 *추가*가 아니라 *제거*한다(신뢰된 Eio primitive에 위임).

## 동작 변화 명시 (Axis 2)

5s는 total-request cap이라 loopback Ollama만이 아니라 **cloud `/models` endpoint(Messages/Chat API)**도 묶는다. 이전 15s가 허용하던 느리지만-살아있는 cloud runtime이 `network_error`/unreachable로 표시될 수 있다. hot path 밖이고 다음 poll이 retry하므로 self-heal하지만, `<500ms` margin 근거는 local path에 한정된다. 코드 주석에도 명시.

## RFC 게이트

대상 아님 — credential/operator/keeper_sandbox/dashboard-credential/hooks/workflow 경로 무관(server dashboard probe 단일 모듈 + boot maintenance). `dashboard_runtime_probe_timeout_sec`는 env knob이 아닌 compile-time literal이라 RFC-0138 timeout-ceiling ratchet 및 `lint-timeout-env-count` 게이트 범위 밖(리뷰어 2 확인).

## 테스트

- 추가: `test_soft_ttl_fresh_hit_serves_fresh_without_sync_probe` — age=20 fresh-hit이 동기 probe 없이 `refresh_state=fresh`로 verbatim 제공됨을 단언(SWR 분기 request-path 계약).
- deferred: 병렬 격리 핀(M1 재발 방지) + SWR background-fire 핀은 **Eio.Switch 하네스 + Runtime.t fixture**가 필요. 정밀 spec과 하네스 선례(`test_dashboard_cache.ml:699`)를 #22067에 기록.
- 빌드/OCaml 테스트 실행은 CI에 위임(로컬 OCaml 빌드 비실행 정책).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
