### PR TITLE
fix(keeper): typed Fusion_completed stimulus classification (RFC-0266 regression)

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -27,6 +27,18 @@ let stimulus_kind_to_string = function
   | Fusion_completed -> "fusion_completed"
 ;;
 
+(* stimulus_kind_to_string의 역. 닫힌 합에 없는 문자열(스키마 드리프트/손상 row)은
+   [None]. 소비자([note_stimulus_kind])가 파싱된 variant를 exhaustive match하므로 새
+   variant 추가 시 컴파일러가 분류 누락을 강제한다 — RFC-0266에서 [Fusion_completed]가
+   문자열 화이트리스트에 누락돼 정상 wake가 unsupported로 오집계된 회귀를 차단한다. *)
+let stimulus_kind_of_string = function
+  | "board_signal" -> Some Board_signal
+  | "bootstrap" -> Some Bootstrap
+  | "no_progress_recovery" -> Some No_progress_recovery
+  | "fusion_completed" -> Some Fusion_completed
+  | _ -> None
+;;
+
 let reaction_kind_to_string = function
   | Turn_started -> "turn_started"
   | Execution_receipt -> "execution_receipt"
@@ -35,6 +47,20 @@ let reaction_kind_to_string = function
   | Operator_escalation -> "operator_escalation"
   | Supervisor_recovery_requested -> "supervisor_recovery_requested"
   | Unknown_reaction value -> value
+;;
+
+(* reaction_kind_to_string의 역(전사). 알려진 문자열은 typed variant로, 그 외에는
+   [Unknown_reaction]으로 — reaction_kind는 [Unknown_reaction of string] escape를 가져
+   항상 전사다. 소비자([note_reaction_kind])가 exhaustive match하므로 새 typed variant
+   추가 시 컴파일러가 분류 누락을 강제한다(stimulus와 동일한 닫힌-합 안티패턴 방지). *)
+let reaction_kind_of_string = function
+  | "turn_started" -> Turn_started
+  | "execution_receipt" -> Execution_receipt
+  | "terminal_reason" -> Terminal_reason
+  | "cursor_ack" -> Cursor_ack
+  | "operator_escalation" -> Operator_escalation
+  | "supervisor_recovery_requested" -> Supervisor_recovery_requested
+  | other -> Unknown_reaction other
 ;;
 
 let option_json f = function
@@ -461,20 +487,26 @@ let summarize_rows ~keeper_name ~limit rows =
     | None -> ()
   in
   let note_reaction_kind = function
-    | Some "turn_started" -> incr turn_started_count
-    | Some "cursor_ack" -> incr cursor_ack_count
-    | Some "execution_receipt" -> incr execution_receipt_count
-    | Some "terminal_reason" -> incr terminal_reason_count
-    | Some "operator_escalation" -> incr operator_escalation_count
-    | Some "supervisor_recovery_requested" -> incr supervisor_recovery_requested_count
-    | Some _ -> incr unknown_reaction_count
     | None -> incr unknown_reaction_count
+    | Some raw ->
+      (match reaction_kind_of_string raw with
+       | Turn_started -> incr turn_started_count
+       | Cursor_ack -> incr cursor_ack_count
+       | Execution_receipt -> incr execution_receipt_count
+       | Terminal_reason -> incr terminal_reason_count
+       | Operator_escalation -> incr operator_escalation_count
+       | Supervisor_recovery_requested -> incr supervisor_recovery_requested_count
+       | Unknown_reaction _ -> incr unknown_reaction_count)
   in
   let note_stimulus_kind = function
-    | Some "board_signal"
-    | Some "bootstrap"
-    | Some "no_progress_recovery" -> ()
-    | Some _ | None -> incr unsupported_stimulus_count
+    | None -> incr unsupported_stimulus_count
+    | Some raw ->
+      (match stimulus_kind_of_string raw with
+       | None -> incr unsupported_stimulus_count
+       (* 닫힌 합의 모든 variant는 인식된 정상 stimulus다(미지원 아님). 새 variant
+          추가 시 이 or-pattern이 non-exhaustive가 되어 컴파일 에러 → 분류 갱신을
+          강제한다 (catch-all 금지). *)
+       | Some (Board_signal | Bootstrap | No_progress_recovery | Fusion_completed) -> ())
   in
   let note_payload_parse_error row =
     match assoc_field "stimulus" row with

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -28,6 +28,16 @@ type reaction_kind =
 val stimulus_kind_to_string : stimulus_kind -> string
 val reaction_kind_to_string : reaction_kind -> string
 
+val stimulus_kind_of_string : string -> stimulus_kind option
+(** Inverse of {!stimulus_kind_to_string}.  Strings outside the closed sum
+    (schema drift / corruption) map to [None].  Summary classification parses
+    through this and matches the variant exhaustively, so adding a stimulus
+    variant forces the classifier to be updated (RFC-0266 regression guard). *)
+
+val reaction_kind_of_string : string -> reaction_kind
+(** Inverse of {!reaction_kind_to_string}.  Total: unknown strings map to
+    [Unknown_reaction], mirroring the open [Unknown_reaction of string] escape. *)
+
 val board_stimulus_id : post_id:string -> string
 (** Stable id for board-originated stimuli. *)
 

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -42,6 +42,18 @@ let no_progress_recovery_stimulus ?(keeper_name = "no-progress-keeper") () :
   }
 ;;
 
+let fusion_completed_stimulus ?(run_id = "fus-ledger-1") () :
+  Keeper_event_queue.stimulus
+  =
+  { post_id = "fusion-run:" ^ run_id
+  ; urgency = Keeper_event_queue.Normal
+  ; arrived_at = 1234.5
+  ; payload =
+      Keeper_event_queue.Fusion_completed
+        { run_id; ok = true; resolved_answer = "use approach B"; board_post_id = "post-fus" }
+  }
+;;
+
 let check_member_string label expected key json =
   check string label expected (json |> member key |> to_string)
 ;;
@@ -351,6 +363,80 @@ let test_unknown_reaction_degrades_summary () =
    payload is unrepresentable — the prior [test_malformed_typed_payload_degrades_summary]
    covered a parse-error path that can no longer occur and was removed. *)
 
+(* RFC-0266 regression: a recorded [Fusion_completed] stimulus is a recognized
+   closed-sum kind and must NOT be miscounted as an unsupported stimulus.  The
+   prior string whitelist ([board_signal]/[bootstrap]/[no_progress_recovery])
+   dropped [fusion_completed] into [unsupported_stimulus_count], degrading the
+   summary on every async fusion wake.  (We assert only the unsupported counter:
+   with no reaction row the stimulus is still legitimately pending.) *)
+let test_fusion_completed_stimulus_is_supported () =
+  with_temp_base @@ fun base_path ->
+  let keeper_name = "fusion-keeper" in
+  Keeper_reaction_ledger.record_event_queue_stimulus
+    ~base_path
+    ~keeper_name
+    (fusion_completed_stimulus ());
+  let summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check int "fusion_completed is not an unsupported stimulus" 0
+    (summary |> member "unsupported_stimulus_count" |> to_int)
+;;
+
+(* Drift guard: [stimulus_kind_of_string] must stay the inverse of
+   [stimulus_kind_to_string] for every closed-sum variant, and reject unknowns.
+   Pairs with the exhaustive match in [note_stimulus_kind] so a new variant
+   cannot silently fall back to [unsupported]. *)
+let test_stimulus_kind_string_roundtrip () =
+  let roundtrips k =
+    match
+      Keeper_reaction_ledger.stimulus_kind_of_string
+        (Keeper_reaction_ledger.stimulus_kind_to_string k)
+    with
+    | Some k' ->
+      String.equal
+        (Keeper_reaction_ledger.stimulus_kind_to_string k')
+        (Keeper_reaction_ledger.stimulus_kind_to_string k)
+    | None -> false
+  in
+  List.iter
+    (fun k ->
+      check bool "stimulus_kind round-trips through string" true (roundtrips k))
+    [ Keeper_reaction_ledger.Board_signal
+    ; Keeper_reaction_ledger.Bootstrap
+    ; Keeper_reaction_ledger.No_progress_recovery
+    ; Keeper_reaction_ledger.Fusion_completed
+    ];
+  check bool "unknown stimulus kind string is None" true
+    (Option.is_none (Keeper_reaction_ledger.stimulus_kind_of_string "totally_unknown"))
+;;
+
+(* Drift guard: [reaction_kind_of_string] is total — known strings round-trip to
+   their typed variant, unknown strings preserve the original via
+   [Unknown_reaction].  Pairs with the exhaustive match in [note_reaction_kind]. *)
+let test_reaction_kind_string_roundtrip () =
+  let roundtrips k =
+    String.equal
+      (Keeper_reaction_ledger.reaction_kind_to_string
+         (Keeper_reaction_ledger.reaction_kind_of_string
+            (Keeper_reaction_ledger.reaction_kind_to_string k)))
+      (Keeper_reaction_ledger.reaction_kind_to_string k)
+  in
+  List.iter
+    (fun k ->
+      check bool "reaction_kind round-trips through string" true (roundtrips k))
+    [ Keeper_reaction_ledger.Turn_started
+    ; Keeper_reaction_ledger.Execution_receipt
+    ; Keeper_reaction_ledger.Terminal_reason
+    ; Keeper_reaction_ledger.Cursor_ack
+    ; Keeper_reaction_ledger.Operator_escalation
+    ; Keeper_reaction_ledger.Supervisor_recovery_requested
+    ];
+  check string "unknown reaction string preserved as Unknown_reaction" "legacy_custom"
+    (Keeper_reaction_ledger.reaction_kind_to_string
+       (Keeper_reaction_ledger.reaction_kind_of_string "legacy_custom"))
+;;
+
 let () =
   run
     "keeper_reaction_ledger"
@@ -391,6 +477,18 @@ let () =
             "unknown reaction degrades summary"
             `Quick
             test_unknown_reaction_degrades_summary
+        ; test_case
+            "fusion_completed stimulus is supported (RFC-0266)"
+            `Quick
+            test_fusion_completed_stimulus_is_supported
+        ; test_case
+            "stimulus_kind string round-trip drift guard"
+            `Quick
+            test_stimulus_kind_string_roundtrip
+        ; test_case
+            "reaction_kind string round-trip drift guard"
+            `Quick
+            test_reaction_kind_string_roundtrip
         ] )
     ]
 ;;


### PR DESCRIPTION
## 무엇을

`keeper_reaction_ledger`의 `note_stimulus_kind`가 닫힌 합 `stimulus_kind`(`Board_signal | Bootstrap | No_progress_recovery | Fusion_completed`)를 **raw string 화이트리스트**로 역분류해, RFC-0266이 추가한 `Fusion_completed`(`"fusion_completed"`)가 `Some _ -> unsupported_stimulus_count`로 흘렀습니다. 결과: 모든 async `masc_fusion` 완료 wake가 `degraded_signal_count`를 키워 reaction-ledger summary status를 `"degraded"`로 오표시합니다.

forward helper(`stimulus_kind_to_string Fusion_completed`)는 `test_fusion_wake.ml`이 단언하고 있었지만, **역방향 분류기는 아무도 단언하지 않아** 회귀가 새어나갔습니다.

## 근본 수정 (워크어라운드 아님)

두 역분류기(`note_stimulus_kind` + 형제 `note_reaction_kind`)를 `stimulus_kind_of_string`/`reaction_kind_of_string` 파서 → **exhaustive variant match**로 교체했습니다. 새 variant 추가 시 그 arm이 non-exhaustive가 되어 컴파일러가 분류 누락을 잡습니다(catch-all 금지). 같은 함수(`summarize_rows`) cluster의 동일 안티패턴 두 사이트를 한 PR에서 닫아 N-of-M 패치를 피했습니다.

- string 분류기를 **추가**가 아니라 **제거**하는 방향(CLAUDE.md 워크어라운드 시그니처 #2의 역).
- 동작 변화는 `"fusion_completed"` 한 케이스뿐(`unsupported` → 인식됨). `note_reaction_kind`는 동작 보존 — `reaction_kind`의 `Unknown_reaction of string` escape로 모든 비-typed 문자열이 그대로 unknown으로 집계됩니다.

## 변경 파일

- `lib/keeper/keeper_reaction_ledger.ml` — `stimulus_kind_of_string`/`reaction_kind_of_string` 역함수 추가, 두 `note_*` 분류기 typed화.
- `lib/keeper/keeper_reaction_ledger.mli` — 두 `of_string` inverse 노출(round-trip drift-guard 테스트용).
- `test/test_keeper_reaction_ledger.ml` — 회귀 테스트(`summary_for_keeper`가 기록된 `Fusion_completed` stimulus를 unsupported로 집계하지 않음) + 두 round-trip drift-guard(미래 variant 추가 시 `of_string` 동기화 강제).

## 로컬 검증

- ocamlformat 0.29.0 `--check`: 3파일 CLEAN
- DET/NDT determinism-contract gate: PASS (새 `| _ -> None` / `Unknown_reaction other`는 fail-closed라 ratchet 무플래그)

## 미검증

- 로컬 OCaml 빌드/테스트 미실행(정책상 CI 위임). exhaustive match 컴파일과 3개 신규 테스트 실행은 CI가 증명합니다.

## 안티패턴 self-check

- telemetry-as-fix: 해당 없음 (카운터를 추가해 가시화한 게 아니라 분류 자체를 수정)
- string/substring 분류기 추가: 해당 없음 (제거)
- N-of-M 패치: 해당 없음 (두 사이트 동시 수정)
- catch-all `_ ->` 추가: 해당 없음 (제거; stimulus or-pattern은 exhaustive)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
