### PR TITLE
fix(transport): drive IDE LSP WebSocket upgrade via SSOT (RFC-0281 Phase 2)

### DIFF
--- a/docs/rfc/RFC-0281-websocket-transport-ssot.md
+++ b/docs/rfc/RFC-0281-websocket-transport-ssot.md
@@ -116,7 +116,11 @@ val mcp_websocket_handler
 - A (same-origin): `respond_and_drive_upgrade ~upgrade ~reqd ~handler:(mcp_websocket_handler ?sw ?clock ~on_message ~origin_label:"same-origin /ws")`.
 - C (standalone): `Ws_eio.Server.create_connection_handler ~sw (mcp_websocket_handler ~sw ~clock ~on_message ~origin_label:"standalone")`.
 
-B (IDE LSP) shares §3.1 attachment but **not** §3.2: it is a different protocol (LSP dispatch, not `dispatch_inbound_message`). Its `wsd -> Websocket_connection.t` builder stays in `server_ide_lsp_proxy.ml`, but routed through `respond_and_drive_upgrade` so it is actually driven (fixing the B liveness/no-read defect). Its `Pong` branch is corrected to record liveness.
+B (IDE LSP) shares §3.1 attachment but **not** §3.2: it is a different protocol (LSP dispatch, not `dispatch_inbound_message`). Its `wsd -> Websocket_connection.t` builder stays in `server_ide_lsp_proxy.ml`, but is routed through `respond_and_drive_upgrade` so it is actually driven (fixing the no-read defect).
+
+B also has no server-side heartbeat (it never pings the client), so its `Pong` branch stays a no-op close — there is no liveness to record. (Adding a heartbeat to the LSP socket for parity with the MCP path is a possible future enhancement, out of scope here.)
+
+Because the Gluten upgrade handler must return promptly (§3.1), B cannot keep its previous per-connection `Eio.Switch.run` + disconnect-promise scaffold (which scoped the spawned language-server processes by switch teardown). Instead, the spawned processes are bound to the server switch and reclaimed **explicitly** in `disconnect`: `Lsp_process_manager.shutdown` closes each process's stdin/stdout/stderr flows, which makes the response-reader and stderr-drain fibers' reads raise so those fibers exit — reclaiming both the processes and their fibers without a switch teardown. `disconnect` is idempotent (guarded by `disconnected`) and runs under `spawn_mutex`; it is invoked from the frame `Connection_close` and `eof` handlers, which httpun-ws delivers sequentially on the connection fiber (so it cannot race in-flight `dispatch_message`, which runs on that same fiber).
 
 ### 3.3 Threading `upgrade` to the route — typed WS route in the Router
 

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -90,7 +90,11 @@ let disconnect cs =
 
 (** Thread-safe send: serializes WebSocket writes across fibers. *)
 let send cs msg =
-  Eio.Mutex.use_rw ~protect:true cs.send_mutex (fun () -> send_text cs.wsd msg)
+  if Atomic.get cs.disconnected
+  then ()
+  else
+    Eio.Mutex.use_rw ~protect:true cs.send_mutex (fun () ->
+      if not (Atomic.get cs.disconnected) then send_text cs.wsd msg)
 ;;
 
 (** JSON-RPC request ID — LSP spec allows integer or string. *)
@@ -263,7 +267,13 @@ let extract_line params =
 (** Ensure LSP process exists for a language.
     Spawns + initializes on first use, blocking until ready. *)
 let ensure_lsp_process cs lang_id =
-  Eio.Mutex.use_rw ~protect:true cs.spawn_mutex (fun () ->
+  if Atomic.get cs.disconnected
+  then Error "connection closed"
+  else
+    Eio.Mutex.use_rw ~protect:true cs.spawn_mutex (fun () ->
+      if Atomic.get cs.disconnected
+      then Error "connection closed"
+      else
     match Hashtbl.find_opt cs.processes lang_id with
     | Some proc -> Ok proc
     | None ->
@@ -721,9 +731,12 @@ let handle_document_highlight cs params id =
 
 (** Dispatch an incoming LSP message to the appropriate handler. *)
 let dispatch_message cs msg =
-  try
-    let json = Yojson.Safe.from_string msg in
-    match json with
+  if Atomic.get cs.disconnected
+  then ()
+  else
+    try
+      let json = Yojson.Safe.from_string msg in
+      match json with
     | `Assoc fields ->
       let method_opt =
         match List.assoc_opt "method" fields with
@@ -789,10 +802,12 @@ let dispatch_message cs msg =
           | None -> send_error cs n Mcp_error_code.(to_wire_code Method_not_found) ("Unhandled method: " ^ m))
        (* Server-initiated notification broadcast *)
        | Some m, None ->
-         Hashtbl.iter
-           (fun _lang_id proc ->
-              Lsp_message_router.send_notification cs.router proc ~method_:m ~params)
-           cs.processes
+         Eio.Mutex.use_rw ~protect:true cs.spawn_mutex (fun () ->
+           if not (Atomic.get cs.disconnected) then
+             Hashtbl.iter
+               (fun _lang_id proc ->
+                  Lsp_message_router.send_notification cs.router proc ~method_:m ~params)
+               cs.processes)
        (* No method field *)
        | None, Some n -> send_error cs n Mcp_error_code.(to_wire_code Invalid_request) "Missing method field"
        | None, None -> ())

--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -13,9 +13,6 @@ open Server_utils
 module Http = Http_server_eio
 module Ws = Httpun_ws
 
-(** SHA1 for httpun-ws handshake. *)
-let sha1 s = Digestif.SHA1.(digest_string s |> to_raw_string)
-
 (** Send text frame via WebSocket. *)
 let send_text wsd s =
   let bytes = Bytes.unsafe_of_string s in
@@ -49,7 +46,14 @@ let read_frame_text ~len ~on_text payload =
     schedule ())
 ;;
 
-(** Per-connection state shared across frame handler and relay fibers. *)
+(** Per-connection state shared across frame handler and relay fibers.
+
+    [sw] is the server-lifetime switch (LSP processes + their reader
+    fibers are spawned on it).  Per-connection reclamation is explicit
+    via {!disconnect} rather than switch teardown, because under the
+    Gluten upgrade model ({!Server_mcp_transport_ws.respond_and_drive_upgrade})
+    the upgrade handler cannot block to hold a per-connection switch
+    open.  RFC-0281 Phase 2. *)
 type conn_state =
   { sw : Eio.Switch.t
   ; router : Lsp_message_router.t
@@ -61,17 +65,27 @@ type conn_state =
   ; send_mutex : Eio.Mutex.t
   ; spawn_mutex : Eio.Mutex.t
   ; clock : float Eio.Time.clock_ty Eio.Resource.t
-  ; on_disconnect : unit Eio.Promise.u
   ; disconnected : bool Atomic.t
   }
 
 let base_path_of_state state = (Mcp_server.workspace_config state).base_path
 
-(** Signal connection end — resolves the disconnect promise so
-    [Eio.Switch.run] exits and cleans up all associated resources. *)
+(** Signal connection end.  Idempotent (guarded by [disconnected]).
+
+    Explicitly shuts down every spawned LSP process.
+    [Lsp_process_manager.shutdown] closes the process stdin/stdout/stderr
+    flows, which makes the response-reader and stderr-drain fibers' reads
+    raise so those fibers exit — so this reclaims the processes AND their
+    fibers without a switch teardown.  Required because [cs.sw] is the
+    server switch: without explicit shutdown the processes would leak
+    until server shutdown (RFC-0261).  Taken under [spawn_mutex] so it
+    cannot race a concurrent {!ensure_lsp_process}.  RFC-0281 Phase 2. *)
 let disconnect cs =
   if Atomic.compare_and_set cs.disconnected false true
-  then Eio.Promise.resolve cs.on_disconnect ()
+  then
+    Eio.Mutex.use_rw ~protect:true cs.spawn_mutex (fun () ->
+      Hashtbl.iter (fun _ proc -> Lsp_process_manager.shutdown proc) cs.processes;
+      Hashtbl.clear cs.processes)
 ;;
 
 (** Thread-safe send: serializes WebSocket writes across fibers. *)
@@ -798,9 +812,9 @@ let dispatch_message cs msg =
 (** Register the /api/v1/ide/lsp WebSocket endpoint. *)
 let add_routes ~sw ~clock router =
   let router =
-    Http.Router.get
+    Http.Router.ws_get
       "/api/v1/ide/lsp"
-      (fun request reqd ->
+      (fun ~upgrade request reqd ->
          with_public_read
            (fun state _req reqd ->
               let origin =
@@ -812,58 +826,62 @@ let add_routes ~sw ~clock router =
                | None ->
                  Log.Server.warn "LSP WebSocket: no proc_mgr available"
                | Some proc_mgr ->
-               Ws.Handshake.respond_with_upgrade ~sha1 reqd (fun () ->
-                 Eio.Switch.run (fun conn_sw ->
-                   let done_promise, done_resolver = Eio.Promise.create () in
-                   let ws_conn =
-                     Ws.Server_connection.create_websocket (fun wsd ->
-                       Log.Server.info "LSP WebSocket connected from %s" origin;
-                       let cs =
-                         { sw = conn_sw
-                         ; router = Lsp_message_router.create ()
-                         ; processes = Hashtbl.create 4
-                         ; wsd
-                         ; base_path = base_path_of_state state
-                         ; proc_mgr
-                         ; workspace_root = ref (base_path_of_state state)
-                         ; send_mutex = Eio.Mutex.create ()
-                         ; spawn_mutex = Eio.Mutex.create ()
-                         ; clock
-                         ; on_disconnect = done_resolver
-                         ; disconnected = Atomic.make false
-                         }
-                      in
-                      { Ws.Websocket_connection.frame =
-                          (fun ~opcode ~is_fin:_ ~len payload ->
-                            match opcode with
-                            | `Text | `Binary ->
-                              read_frame_text
-                                ~len
-                                ~on_text:(fun msg -> dispatch_message cs msg)
-                                payload
-                            | `Ping ->
-                              (try Ws.Wsd.send_pong wsd with
-                               | exn ->
-                                 Log.Server.debug
-                                   "LSP send_pong failed: %s"
-                                   (Printexc.to_string exn));
-                              Ws.Payload.close payload
-                            | `Connection_close ->
-                              Log.Server.info "LSP WebSocket disconnecting";
-                              disconnect cs;
-                              Ws.Payload.close payload
-                            | `Pong | `Continuation | `Other _ -> Ws.Payload.close payload)
-                      ; eof =
-                          (fun ?error:_ () ->
-                            Log.Server.info "LSP WebSocket EOF";
-                            disconnect cs)
-                      })
-                  in
-                  ignore ws_conn;
-                  ignore (Eio.Promise.await done_promise)))
-              |> function
-              | Ok () -> ()
-              | Error e -> Log.Server.warn "WebSocket upgrade failed: %s" e))
+                 (* RFC-0281: drive the upgraded connection via the shared
+                    attachment SSOT.  The previous code built [ws_conn] and
+                    [ignore]d it (never calling Gluten [upgrade]), so frames
+                    were never read; it also blocked on a per-connection
+                    [Eio.Switch.run] + promise, which the Gluten model
+                    forbids.  Subprocesses are now reclaimed explicitly in
+                    {!disconnect} (called from [Connection_close]/[eof]). *)
+                 (match
+                    Server_mcp_transport_ws.respond_and_drive_upgrade
+                      ~upgrade
+                      ~reqd
+                      ~handler:(fun wsd ->
+                        Log.Server.info "LSP WebSocket connected from %s" origin;
+                        let cs =
+                          { sw
+                          ; router = Lsp_message_router.create ()
+                          ; processes = Hashtbl.create 4
+                          ; wsd
+                          ; base_path = base_path_of_state state
+                          ; proc_mgr
+                          ; workspace_root = ref (base_path_of_state state)
+                          ; send_mutex = Eio.Mutex.create ()
+                          ; spawn_mutex = Eio.Mutex.create ()
+                          ; clock
+                          ; disconnected = Atomic.make false
+                          }
+                        in
+                        { Ws.Websocket_connection.frame =
+                            (fun ~opcode ~is_fin:_ ~len payload ->
+                              match opcode with
+                              | `Text | `Binary ->
+                                read_frame_text
+                                  ~len
+                                  ~on_text:(fun msg -> dispatch_message cs msg)
+                                  payload
+                              | `Ping ->
+                                (try Ws.Wsd.send_pong wsd with
+                                 | exn ->
+                                   Log.Server.debug
+                                     "LSP send_pong failed: %s"
+                                     (Printexc.to_string exn));
+                                Ws.Payload.close payload
+                              | `Connection_close ->
+                                Log.Server.info "LSP WebSocket disconnecting";
+                                disconnect cs;
+                                Ws.Payload.close payload
+                              | `Pong | `Continuation | `Other _ ->
+                                Ws.Payload.close payload)
+                        ; eof =
+                            (fun ?error:_ () ->
+                              Log.Server.info "LSP WebSocket EOF";
+                              disconnect cs)
+                        })
+                  with
+                  | Ok () -> ()
+                  | Error e -> Log.Server.warn "WebSocket upgrade failed: %s" e)))
            request
            reqd)
       router

--- a/test/test_server_ide_lsp_proxy.ml
+++ b/test/test_server_ide_lsp_proxy.ml
@@ -1,6 +1,7 @@
 open Alcotest
 
 module Lsp = Server_ide_lsp_proxy.For_testing
+module Http = Masc.Http_server_eio
 
 let member key = function
   | `Assoc fields -> List.assoc_opt key fields
@@ -77,6 +78,30 @@ let test_file_uri_resolution_is_workspace_scoped () =
     (Lsp.resolve_relative ~base "file:///tmp/outside.ml")
 ;;
 
+(* RFC-0281 Phase 2: [/api/v1/ide/lsp] must be a typed WebSocket-upgrade
+   route ([Router.Ws]).  Only a Ws route receives the Gluten [upgrade]
+   capability, so a regression to [Router.Plain] would silently
+   reintroduce the undriven-socket defect (frames never read).  [add_routes]
+   only registers the closure here — no process is spawned — so the
+   [Eio_main.run] just supplies the switch + clock it captures. *)
+let test_lsp_route_is_ws () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      let clock = Eio.Stdenv.clock env in
+      let router =
+        Server_ide_lsp_proxy.add_routes ~sw ~clock (Http.Router.create ())
+      in
+      let request = Httpun.Request.create `GET "/api/v1/ide/lsp" in
+      match Http.Router.resolve router request with
+      | `Matched route ->
+        (match route.Http.Router.handler with
+         | Http.Router.Ws _ -> ()
+         | Http.Router.Plain _ ->
+           fail "/api/v1/ide/lsp must be a Router.Ws route, not Plain")
+      | `Method_not_allowed | `Not_found ->
+        fail "/api/v1/ide/lsp route must resolve"))
+;;
+
 let () =
   run
     "server_ide_lsp_proxy"
@@ -87,6 +112,8 @@ let () =
             test_workspace_root_initialize_stays_in_base
         ; test_case "file uri resolution is workspace scoped" `Quick
             test_file_uri_resolution_is_workspace_scoped
+        ; test_case "/api/v1/ide/lsp is a Ws upgrade route" `Quick
+            test_lsp_route_is_ws
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

RFC-0281 Phase 2 — 마지막 WebSocket 업그레이드 사이트인 IDE LSP `/api/v1/ide/lsp`를 SSOT로 통합해 실제로 연결을 구동하게 만든다. Phase 1(#22072)이 same-origin `/ws`와 standalone `:8937`을 고쳤고, 본 PR이 세 번째이자 마지막 사이트를 정리한다.

## 근본 원인

`server_ide_lsp_proxy.ml`의 `/api/v1/ide/lsp` 핸들러는 `Server_connection`을 만든 뒤 `ignore` 했다 — Gluten `upgrade`를 호출하지 않아 인바운드 frame이 전혀 읽히지 않는다(same-origin `/ws`와 동일한 결함). 게다가 업그레이드 콜백을 per-connection `Eio.Switch.run` + disconnect promise로 블로킹했는데, 이는 Gluten 구동 모델(콜백 즉시 반환 필요)과 비호환이다.

## 변경

- `/api/v1/ide/lsp`를 `Http.Router.get` → `Http.Router.ws_get`으로 등록, `~upgrade` capability를 받아 공유 attachment SSOT `Server_mcp_transport_ws.respond_and_drive_upgrade`로 연결을 **구동**한다.
- subprocess 정리 모델 교체: 기존 switch-teardown(블로킹 핸들러 의존, Gluten과 비호환)을 **`disconnect`에서 명시적 reclamation**으로 변경. `Lsp_process_manager.shutdown`이 프로세스의 stdin/stdout/stderr flow를 닫으면 response-reader·stderr-drain fiber의 read가 raise되어 fiber가 종료 → 프로세스와 fiber를 switch teardown 없이 모두 회수. `disconnect`는 `disconnected` Atomic으로 idempotent, `spawn_mutex` 하에 실행.
- 정리: 더 이상 쓰지 않는 로컬 `sha1`(respond_and_drive_upgrade가 handshake 소유)과 `on_disconnect` conn_state 필드 제거.

이로써 RFC-0281의 "어중이떠중이 숙청"이 완결된다 — 세 업그레이드 사이트(same-origin `/ws`, standalone `:8937`, IDE LSP) 모두 attachment SSOT를 경유한다.

## 동시성 분석 (적대적 자가검증)

- **Deadlock 없음**: `disconnect`의 `spawn_mutex`는 `ensure_lsp_process`가 반환 후 해제하므로 disconnect 시점에 free. `exit`/`Connection_close`/`eof` 어디서 호출돼도 mutex를 잡은 상태가 아니다.
- **Use-after-free 없음**: `dispatch_message`와 `disconnect`는 동일 연결 fiber에서 httpun-ws가 frame/eof를 순차 전달하므로 동시 실행되지 않는다. stdout-reader fiber가 shutdown 도중 `send_client_notification`해도 `send_mutex` + 닫힌 writer 에러 처리로 benign하며, `shutdown`이 stdout_r를 닫는 즉시 그 fiber는 종료한다.
- **Leak 없음**: `shutdown`(flow close)이 reader fiber를 회수하고, `eof`가 항상 fire되어 `disconnect`를 호출한다.

## 검증

- `dune build @check` rc=0 (전체 코드베이스 타입체크). **타입 시스템이 회귀 가드**: `ws_get`은 `ws_handler`(`~upgrade`)를 요구하고 `respond_and_drive_upgrade ~upgrade`는 그 capability가 있어야만 호출되므로, 비구동 Plain route로의 회귀는 컴파일 불가.
- `bin/main_eio.exe` 링크 통과.
- `test_server_ide_lsp_proxy` 3 tests 통과(For_testing 단위, 무영향).
- ocamlformat 0.29.0 clean.

## 남은 미검증

- LSP `/api/v1/ide/lsp` 실제 request/response 왕복(RFC-0281 §5-5)은 서버 재시작 + LSP 클라이언트로 머지 후 확인.
- LSP 소켓 heartbeat(MCP 경로와 parity)는 본 PR 범위 밖(B는 원래 heartbeat 없음, Pong→no-op close 유지). 필요 시 후속.

## 관련

- 선행: #22072 (Phase 1, RFC-0281 본체), #22074 (RFC 번호 충돌 정정).

RFC-0281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
