### PR TITLE
fix(dashboard): type lifecycle event cache patchers via exhaustive variant match (#22071 HIGH)

### DIFF
--- a/lib/keeper_registry/keeper_lifecycle_events.ml
+++ b/lib/keeper_registry/keeper_lifecycle_events.ml
@@ -20,10 +20,12 @@
     phases that fire a wire event ([Stopped] / [Crashed] / [Dead] /
     [Running]).
 
-    The sync test in [test/test_types.ml :: lifecycle_events_ssot]
-    asserts every literal event name still emitted by the supervisor
-    and keepalive lives in [all_event_names], so adding a new event
-    site without updating the SSOT fails CI. *)
+    NOTE (#22071): a previously-cited emit-site coverage test
+    ([test/test_types.ml :: lifecycle_events_ssot]) does not exist —
+    keep this vocabulary aligned with the supervisor/keepalive call
+    sites by hand. The [to_string]/[event_of_string] round-trip is
+    pinned by [test/test_dashboard_http_core.ml ::
+    lifecycle_event_of_string_roundtrip]. *)
 
 (** Custom (non-phase-derived) keeper lifecycle events. Each verb
     captures an action distinct from a phase noun:
@@ -56,6 +58,22 @@ let to_string = function
   | Auto_resumed -> "auto_resumed"
   | Admission_denied -> "admission_denied"
 
+(* Inverse of [to_string] over the closed custom-event sum. Strings outside the
+   vocabulary (phase-derived names, legacy/operator strings, garbage) map to
+   [None] so callers parse-then-exhaustive-match instead of reverse-classifying
+   the variant by raw string literals. The round-trip is pinned by
+   [test/test_dashboard_http_core.ml :: lifecycle_event_of_string_roundtrip]. *)
+let event_of_string = function
+  | "started" -> Some Started
+  | "reconciled" -> Some Reconciled
+  | "restarted" -> Some Restarted
+  | "dead_cleaned" -> Some Dead_cleaned
+  | "self_preservation" -> Some Self_preservation
+  | "paused_pruned" -> Some Paused_pruned
+  | "auto_resumed" -> Some Auto_resumed
+  | "admission_denied" -> Some Admission_denied
+  | _ -> None
+
 let all_custom_events : t list =
   [ Started; Reconciled; Restarted; Dead_cleaned;
     Self_preservation; Paused_pruned; Auto_resumed; Admission_denied ]
@@ -67,9 +85,9 @@ let valid_custom_event_strings : string list =
     {!Keeper_state_machine.phase_to_string} for the four lifecycle
     phases that publish a lifecycle event. The list is hand-rolled
     rather than generated to keep this module dependency-free
-    (Keeper_state_machine pulls in the full FSM module); the sync
-    test in [test/test_types.ml] asserts the strings stay aligned
-    with [Keeper_state_machine.phase_to_string]. *)
+    (Keeper_state_machine pulls in the full FSM module). Keep aligned
+    with [Keeper_state_machine.phase_to_string] by hand — the formerly
+    cited sync test ([test/test_types.ml]) does not exist (#22071). *)
 let phase_derived_event_strings : string list =
   [ "stopped"; "crashed"; "dead"; "running" ]
 
@@ -83,9 +101,9 @@ let all_event_names : string list =
 
     [publish_keeper_lifecycle] previously took [event:string ?phase] --
     a typo at any of the supervisor/keepalive call sites silently
-    landed on the bus as a garbage event name. The runtime SSOT test
-    in [test_types.ml :: lifecycle_events_ssot] caught drift at CI
-    time but not at compile time.
+    landed on the bus as a garbage event name. (A runtime SSOT test in
+    [test_types.ml :: lifecycle_events_ssot] was cited here but does
+    not exist — #22071.)
 
     This sum type unifies the two pre-existing typed vocabularies
     ([t] for the custom verbs, [Keeper_state_machine.phase] for the

--- a/lib/keeper_registry/keeper_lifecycle_events.mli
+++ b/lib/keeper_registry/keeper_lifecycle_events.mli
@@ -13,6 +13,13 @@ type t =
   | Admission_denied
 
 val to_string : t -> string
+
+(** Inverse of {!to_string} over the closed custom-event sum. Strings outside
+    the vocabulary map to [None]. Lets dashboard cache patchers parse a wire
+    event name to the typed verb and match it exhaustively (compile-time
+    coverage) instead of reverse-classifying by raw string literals. *)
+val event_of_string : string -> t option
+
 val all_custom_events : t list
 val valid_custom_event_strings : string list
 

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -380,64 +380,85 @@ let dashboard_transport_health_snapshot_json () =
   Server_dashboard_http_cache.cached_surface_json transport_health_cache
 ;;
 
-(* Issue #8396: cache patchers used to recognise only 7 lifecycle event
-   names while [Keeper_lifecycle_events.all_event_names] now publishes
-   12. The drift left dashboard rows stale until the next full
-   recompute when the supervisor emitted [dead_cleaned],
-   [self_preservation], [paused_pruned], or the phase-derived [running].
+(* Issue #8396 / #22071: cache patchers project a wire lifecycle event name onto
+   dashboard row fields (keepalive_running / phase / pipeline_stage / paused).
+   Cache rows deserialise from JSON, so the input is a [string]; but the closed
+   custom-event vocabulary ([Keeper_lifecycle_events.t]) is parsed to the typed
+   verb and matched EXHAUSTIVELY in [display_of_custom_event]. Adding a custom
+   lifecycle variant now fails to compile here until its projection is defined —
+   replacing the prior raw-string whitelist that silently dropped new variants
+   to [None] (and an in-doc reference to a coverage test that did not exist).
 
-   The 4 patchers below remain string-typed (cache rows deserialise
-   from JSON), but each [match] now covers every name in the SSOT.
-   The sync test in [test/test_types.ml :: lifecycle_event_cache_patcher_coverage]
-   asserts every name in [Keeper_lifecycle_events.all_event_names]
-   returns [Some] from at least one of these patchers. *)
+   Phase-derived names ([running]/[stopped]/[crashed]/[dead]) and legacy operator
+   strings ([paused]/[resumed]) are not custom-event verbs and cross the JSON
+   boundary as raw strings, so they stay string-keyed and fail closed to [None]
+   for unknown input. Coverage over the SSOT vocabulary is pinned by
+   [test/test_dashboard_http_core.ml :: lifecycle_event_cache_patcher_coverage]. *)
 
-let keepalive_running_of_lifecycle_event = function
-  | "started" | "restarted" | "reconciled" | "running" -> Some true
-  | "resumed" | "self_preservation" | "auto_resumed" -> Some true
-  | "paused" -> Some true
-  | "paused_pruned" -> Some false (* prune == removed from supervision *)
-  | "admission_denied" -> Some false (* admission guard refused to launch a fiber *)
-  | "dead_cleaned" -> Some false (* cleanup == no longer alive *)
-  | "stopped" | "crashed" | "dead" -> Some false
+type lifecycle_display =
+  { ld_keepalive_running : bool
+  ; ld_phase : string
+  ; ld_pipeline_stage : string
+  ; ld_paused : bool
+  }
+
+(* Exhaustive over the closed custom-event sum. A new [Keeper_lifecycle_events.t]
+   variant breaks this match (no catch-all) until its dashboard projection is
+   declared. Values are byte-identical to the prior per-field string whitelist. *)
+let display_of_custom_event (verb : Keeper_lifecycle_events.t) : lifecycle_display =
+  let open Keeper_lifecycle_events in
+  match verb with
+  | Started | Restarted | Reconciled | Self_preservation | Auto_resumed ->
+    { ld_keepalive_running = true; ld_phase = "running"; ld_pipeline_stage = "idle"; ld_paused = false }
+  | Paused_pruned ->
+    (* prune == removed from supervision *)
+    { ld_keepalive_running = false; ld_phase = "stopped"; ld_pipeline_stage = "offline"; ld_paused = true }
+  | Admission_denied ->
+    (* admission guard refused to launch a fiber *)
+    { ld_keepalive_running = false; ld_phase = "offline"; ld_pipeline_stage = "offline"; ld_paused = false }
+  | Dead_cleaned ->
+    (* cleanup == no longer alive *)
+    { ld_keepalive_running = false; ld_phase = "dead"; ld_pipeline_stage = "offline"; ld_paused = false }
+;;
+
+(* Phase-derived + legacy operator strings (not custom-event verbs). Raw-string
+   keyed by necessity (JSON boundary); unknown input fails closed to [None]. *)
+let display_of_phase_or_legacy_string = function
+  | "running" ->
+    Some { ld_keepalive_running = true; ld_phase = "running"; ld_pipeline_stage = "idle"; ld_paused = false }
+  | "stopped" ->
+    Some { ld_keepalive_running = false; ld_phase = "stopped"; ld_pipeline_stage = "offline"; ld_paused = true }
+  | "crashed" ->
+    Some { ld_keepalive_running = false; ld_phase = "crashed"; ld_pipeline_stage = "crashed"; ld_paused = false }
+  | "dead" ->
+    Some { ld_keepalive_running = false; ld_phase = "dead"; ld_pipeline_stage = "offline"; ld_paused = false }
+  | "paused" ->
+    Some { ld_keepalive_running = true; ld_phase = "paused"; ld_pipeline_stage = "paused"; ld_paused = true }
+  | "resumed" ->
+    Some { ld_keepalive_running = true; ld_phase = "running"; ld_pipeline_stage = "idle"; ld_paused = false }
   | _ -> None
 ;;
 
-let phase_of_lifecycle_event = function
-  | "started" | "restarted" | "reconciled" | "running" -> Some "running"
-  | "resumed" | "self_preservation" | "auto_resumed" -> Some "running"
-  | "paused" -> Some "paused"
-  | "admission_denied" -> Some "offline"
-  | "paused_pruned" -> Some "stopped"
-  | "stopped" -> Some "stopped"
-  | "crashed" -> Some "crashed"
-  | "dead" | "dead_cleaned" -> Some "dead"
-  | _ -> None
+let lifecycle_display_of_event event =
+  match Keeper_lifecycle_events.event_of_string event with
+  | Some verb -> Some (display_of_custom_event verb)
+  | None -> display_of_phase_or_legacy_string event
 ;;
 
-let pipeline_stage_of_lifecycle_event = function
-  | "started" | "restarted" | "reconciled" | "running" -> Some "idle"
-  | "resumed" | "self_preservation" | "auto_resumed" -> Some "idle"
-  | "paused" -> Some "paused"
-  | "admission_denied" -> Some "offline"
-  | "paused_pruned" -> Some "offline"
-  | "stopped" | "dead" | "dead_cleaned" -> Some "offline"
-  | "crashed" -> Some "crashed"
-  | _ -> None
+let keepalive_running_of_lifecycle_event event =
+  Option.map (fun (d : lifecycle_display) -> d.ld_keepalive_running) (lifecycle_display_of_event event)
 ;;
 
-let paused_of_lifecycle_event = function
-  | "started"
-  | "restarted"
-  | "reconciled"
-  | "resumed"
-  | "running"
-  | "self_preservation"
-  | "auto_resumed" -> Some false
-  | "paused" | "paused_pruned" | "stopped" -> Some true
-  | "admission_denied" -> Some false
-  | "dead" | "dead_cleaned" | "crashed" -> Some false
-  | _ -> None
+let phase_of_lifecycle_event event =
+  Option.map (fun (d : lifecycle_display) -> d.ld_phase) (lifecycle_display_of_event event)
+;;
+
+let pipeline_stage_of_lifecycle_event event =
+  Option.map (fun (d : lifecycle_display) -> d.ld_pipeline_stage) (lifecycle_display_of_event event)
+;;
+
+let paused_of_lifecycle_event event =
+  Option.map (fun (d : lifecycle_display) -> d.ld_paused) (lifecycle_display_of_event event)
 ;;
 
 let keeper_agent_status_opt row =

--- a/lib/server/server_dashboard_http_execution_surfaces.ml
+++ b/lib/server/server_dashboard_http_execution_surfaces.ml
@@ -402,6 +402,14 @@ type lifecycle_display =
   ; ld_paused : bool
   }
 
+type lifecycle_legacy_wire_event =
+  | Legacy_running
+  | Legacy_stopped
+  | Legacy_crashed
+  | Legacy_dead
+  | Legacy_paused
+  | Legacy_resumed
+
 (* Exhaustive over the closed custom-event sum. A new [Keeper_lifecycle_events.t]
    variant breaks this match (no catch-all) until its dashboard projection is
    declared. Values are byte-identical to the prior per-field string whitelist. *)
@@ -423,20 +431,36 @@ let display_of_custom_event (verb : Keeper_lifecycle_events.t) : lifecycle_displ
 
 (* Phase-derived + legacy operator strings (not custom-event verbs). Raw-string
    keyed by necessity (JSON boundary); unknown input fails closed to [None]. *)
-let display_of_phase_or_legacy_string = function
-  | "running" ->
-    Some { ld_keepalive_running = true; ld_phase = "running"; ld_pipeline_stage = "idle"; ld_paused = false }
-  | "stopped" ->
-    Some { ld_keepalive_running = false; ld_phase = "stopped"; ld_pipeline_stage = "offline"; ld_paused = true }
-  | "crashed" ->
-    Some { ld_keepalive_running = false; ld_phase = "crashed"; ld_pipeline_stage = "crashed"; ld_paused = false }
-  | "dead" ->
-    Some { ld_keepalive_running = false; ld_phase = "dead"; ld_pipeline_stage = "offline"; ld_paused = false }
-  | "paused" ->
-    Some { ld_keepalive_running = true; ld_phase = "paused"; ld_pipeline_stage = "paused"; ld_paused = true }
-  | "resumed" ->
-    Some { ld_keepalive_running = true; ld_phase = "running"; ld_pipeline_stage = "idle"; ld_paused = false }
+let lifecycle_legacy_wire_event_of_string = function
+  | "running" -> Some Legacy_running
+  | "stopped" -> Some Legacy_stopped
+  | "crashed" -> Some Legacy_crashed
+  | "dead" -> Some Legacy_dead
+  | "paused" -> Some Legacy_paused
+  | "resumed" -> Some Legacy_resumed
   | _ -> None
+;;
+
+let display_of_phase_or_legacy_event = function
+  | Legacy_running ->
+    Some { ld_keepalive_running = true; ld_phase = "running"; ld_pipeline_stage = "idle"; ld_paused = false }
+  | Legacy_stopped ->
+    Some
+      { ld_keepalive_running = false; ld_phase = "stopped"; ld_pipeline_stage = "offline"; ld_paused = true }
+  | Legacy_crashed ->
+    Some
+      { ld_keepalive_running = false; ld_phase = "crashed"; ld_pipeline_stage = "crashed"; ld_paused = false }
+  | Legacy_dead ->
+    Some { ld_keepalive_running = false; ld_phase = "dead"; ld_pipeline_stage = "offline"; ld_paused = false }
+  | Legacy_paused ->
+    Some { ld_keepalive_running = true; ld_phase = "paused"; ld_pipeline_stage = "paused"; ld_paused = true }
+  | Legacy_resumed ->
+    Some { ld_keepalive_running = true; ld_phase = "running"; ld_pipeline_stage = "idle"; ld_paused = false }
+
+let display_of_phase_or_legacy_string s =
+  match lifecycle_legacy_wire_event_of_string s with
+  | None -> None
+  | Some event -> display_of_phase_or_legacy_event event
 ;;
 
 let lifecycle_display_of_event event =

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1228,7 +1228,14 @@ let test_lifecycle_event_of_string_roundtrip () =
     Keeper_lifecycle_events.all_custom_events;
   check bool "unknown lifecycle event string is None" true
     (Option.is_none
-       (Keeper_lifecycle_events.event_of_string "no_such_lifecycle_event"))
+       (Keeper_lifecycle_events.event_of_string "no_such_lifecycle_event"));
+  List.iter
+    (fun verb ->
+      check bool
+        ("legacy phase/operator event is not a custom verb: " ^ verb)
+        true
+        (Option.is_none (Keeper_lifecycle_events.event_of_string verb)))
+    [ "running"; "stopped"; "crashed"; "dead"; "paused"; "resumed" ]
 
 let test_lifecycle_event_cache_patcher_coverage () =
   (* Every name in the SSOT vocabulary must be classified ([Some]) by all four

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1210,6 +1210,56 @@ let test_telemetry_n_default_is_bounded () =
     "explicit positive n honoured"
     500 (resolve ~has_time_window:true ~n_param:(Some "500"))
 
+(* Issue #22071: lifecycle event classification was reverse-mapped by a raw
+   string whitelist that bypassed compiler exhaustiveness, and the module
+   docstrings cited coverage tests ([lifecycle_events_ssot] /
+   [lifecycle_event_cache_patcher_coverage]) in a test/test_types.ml that does
+   not exist. These are the real guards. *)
+let test_lifecycle_event_of_string_roundtrip () =
+  List.iter
+    (fun verb ->
+      let s = Keeper_lifecycle_events.to_string verb in
+      check bool
+        ("event_of_string round-trips " ^ s)
+        true
+        (match Keeper_lifecycle_events.event_of_string s with
+         | Some v -> String.equal (Keeper_lifecycle_events.to_string v) s
+         | None -> false))
+    Keeper_lifecycle_events.all_custom_events;
+  check bool "unknown lifecycle event string is None" true
+    (Option.is_none
+       (Keeper_lifecycle_events.event_of_string "no_such_lifecycle_event"))
+
+let test_lifecycle_event_cache_patcher_coverage () =
+  (* Every name in the SSOT vocabulary must be classified ([Some]) by all four
+     dashboard cache patchers — the coverage the phantom test only promised. The
+     custom-event subset is also compiler-enforced via [display_of_custom_event]. *)
+  List.iter
+    (fun name ->
+      check bool
+        ("keepalive_running classifies " ^ name)
+        true
+        (Option.is_some
+           (Server_dashboard_http_execution_surfaces.keepalive_running_of_lifecycle_event
+              name));
+      check bool
+        ("phase classifies " ^ name)
+        true
+        (Option.is_some
+           (Server_dashboard_http_execution_surfaces.phase_of_lifecycle_event name));
+      check bool
+        ("pipeline_stage classifies " ^ name)
+        true
+        (Option.is_some
+           (Server_dashboard_http_execution_surfaces.pipeline_stage_of_lifecycle_event
+              name));
+      check bool
+        ("paused classifies " ^ name)
+        true
+        (Option.is_some
+           (Server_dashboard_http_execution_surfaces.paused_of_lifecycle_event name)))
+    Keeper_lifecycle_events.all_event_names
+
 let () =
   run "dashboard_http_core"
     [
@@ -1287,5 +1337,11 @@ let () =
             test_telemetry_n_default_is_bounded;
           test_case "fleet-composite envelope is cached across polls" `Quick
             test_dashboard_fleet_composite_envelope_is_cached;
+        ] );
+      ( "lifecycle event classification (#22071)",
+        [ test_case "event_of_string round-trips to_string" `Quick
+            test_lifecycle_event_of_string_roundtrip;
+          test_case "cache patchers cover the SSOT vocabulary" `Quick
+            test_lifecycle_event_cache_patcher_coverage;
         ] );
     ]

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1267,6 +1267,53 @@ let test_lifecycle_event_cache_patcher_coverage () =
            (Server_dashboard_http_execution_surfaces.paused_of_lifecycle_event name)))
     Keeper_lifecycle_events.all_event_names
 
+let test_lifecycle_event_display_values () =
+  (* Pin the exact (keepalive_running, phase, pipeline_stage, paused) projection
+     for every lifecycle event string — including the legacy operator strings
+     [paused] / [resumed] that are outside [all_event_names]. This locks the
+     byte-identity the refactor preserves: a value drift in
+     [display_of_custom_event] or [display_of_phase_or_legacy_string] now fails
+     here instead of silently changing a dashboard row (the coverage test above
+     only asserts [Some], not the value). *)
+  let cases =
+    [ ("started", true, "running", "idle", false);
+      ("restarted", true, "running", "idle", false);
+      ("reconciled", true, "running", "idle", false);
+      ("self_preservation", true, "running", "idle", false);
+      ("auto_resumed", true, "running", "idle", false);
+      ("running", true, "running", "idle", false);
+      ("resumed", true, "running", "idle", false);
+      ("paused", true, "paused", "paused", true);
+      ("paused_pruned", false, "stopped", "offline", true);
+      ("admission_denied", false, "offline", "offline", false);
+      ("dead_cleaned", false, "dead", "offline", false);
+      ("stopped", false, "stopped", "offline", true);
+      ("crashed", false, "crashed", "crashed", false);
+      ("dead", false, "dead", "offline", false);
+    ]
+  in
+  List.iter
+    (fun (name, keepalive, phase, pipeline, paused) ->
+      check (option bool)
+        ("keepalive_running value for " ^ name)
+        (Some keepalive)
+        (Server_dashboard_http_execution_surfaces.keepalive_running_of_lifecycle_event
+           name);
+      check (option string)
+        ("phase value for " ^ name)
+        (Some phase)
+        (Server_dashboard_http_execution_surfaces.phase_of_lifecycle_event name);
+      check (option string)
+        ("pipeline_stage value for " ^ name)
+        (Some pipeline)
+        (Server_dashboard_http_execution_surfaces.pipeline_stage_of_lifecycle_event
+           name);
+      check (option bool)
+        ("paused value for " ^ name)
+        (Some paused)
+        (Server_dashboard_http_execution_surfaces.paused_of_lifecycle_event name))
+    cases
+
 let () =
   run "dashboard_http_core"
     [
@@ -1350,5 +1397,7 @@ let () =
             test_lifecycle_event_of_string_roundtrip;
           test_case "cache patchers cover the SSOT vocabulary" `Quick
             test_lifecycle_event_cache_patcher_coverage;
+          test_case "cache patchers pin byte-identical values" `Quick
+            test_lifecycle_event_display_values;
         ] );
     ]


### PR DESCRIPTION
## 무엇을 / 왜

Issue #22071 의 HIGH 사이트 수정. 닫힌 합(`Keeper_lifecycle_events.t`)을 대시보드 캐시 patcher 4개가 **raw string 화이트리스트 + catch-all(`| _ -> None`)** 로 역분류하던 안티패턴을 제거한다. PR #22069 가 `keeper_reaction_ledger.ml` 에서 닫은 것과 동일한 closed-sum-string-whitelist 패턴의 형제 사이트다.

기존 구조의 문제:
- `keepalive_running_of_lifecycle_event` / `phase_of_lifecycle_event` / `pipeline_stage_of_lifecycle_event` / `paused_of_lifecycle_event` 4개 함수가 각각 동일한 14개 이벤트 문자열을 독립적으로 string match + `| _ -> None` 로 분류.
- `Keeper_lifecycle_events.t` 에 custom-event variant 를 추가해도 컴파일러가 이 4개 사이트의 누락을 감지하지 못함 → 새 variant 가 조용히 `None` 으로 떨어져 대시보드 row 가 stale.
- 모듈 docstring 들이 `test/test_types.ml :: lifecycle_event_cache_patcher_coverage` / `lifecycle_events_ssot` 라는 coverage 테스트가 보증한다고 인용했으나, **그 테스트는 존재하지 않는다**(phantom). 컴파일러-대체 가드인 척하는 허위 인용.

## 어떻게

`server_dashboard_http_execution_surfaces.ml`:
- 단일 `lifecycle_display` record(`ld_keepalive_running`/`ld_phase`/`ld_pipeline_stage`/`ld_paused`)로 분류 로직을 한 곳에 집중.
- `display_of_custom_event : Keeper_lifecycle_events.t -> lifecycle_display` 는 **closed sum 을 exhaustive match(catch-all 금지)**. 새 custom-event variant 추가 시 여기서 컴파일 에러 → 누락 강제 감지.
- `display_of_phase_or_legacy_string : string -> lifecycle_display option` 는 phase-derived(`running`/`stopped`/`crashed`/`dead`) + legacy operator(`paused`/`resumed`) 문자열만 담당. 이들은 JSON 경계를 raw string 으로 넘어오므로 타입 강제 불가 → 그대로 string-keyed, unknown 은 `None` fail-closed.
- 4개 public accessor 는 `Option.map` 으로 record 필드만 추출. 시그니처(`string -> bool option` / `string -> string option`)는 `.mli` 공개 API 그대로 보존.

`keeper_lifecycle_events.{ml,mli}`:
- `event_of_string : string -> t option` 추가(`to_string` 의 역함수, 닫힌 합 밖은 `None`). dashboard patcher 가 wire event name 을 typed verb 로 parse 한 뒤 exhaustive match 하도록.
- phantom test 를 인용하던 3개 docstring 을 정직하게 교정(존재하지 않는 테스트 → 실제 가드 경로 명시).

## byte-identity

기존 4개 함수의 14개 입력 문자열 × 4개 출력 필드를 신규 구조와 손으로 전수 대조 → **모두 동일**. 동작 변화 없음(순수 리팩터, 분류 결과 불변). unknown 입력은 기존/신규 모두 `None`.

## 테스트

`test/test_dashboard_http_core.ml` 에 실제 coverage 테스트 2개 추가(phantom 대체):
- `lifecycle_event_of_string_roundtrip`: `all_custom_events` 전수 round-trip(`of_string(to_string v) = v`) + unknown → `None`.
- `lifecycle_event_cache_patcher_coverage`: `all_event_names`(SSOT vocabulary) 전 항목이 4개 patcher 모두에서 `Some` 반환.

## 안티패턴 self-check

- 텔레메트리-as-fix: 해당 없음(분류 로직을 typed 화, counter 추가 아님).
- string 분류기 보강: **반대** — string 화이트리스트를 제거하고 closed sum exhaustive match 로 교체.
- N-of-M: 4개 patcher 를 한 PR 에서 동시 전환(단일 `display_of_custom_event` 로 통합).
- catch-all 추가: 없음. `display_of_custom_event` 는 catch-all 무. string 잔여 경로의 `| _ -> None` 은 JSON 경계의 fail-closed(제거가 아닌 유지, unknown→None 보수적).

## 범위 밖(보호)

- patcher public 시그니처(`.mli`) 불변.
- phase-derived/legacy 문자열 경로의 분류 값 불변.
- Issue #22071 의 MEDIUM/LOW 사이트(`keeper_runtime_trust_snapshot.ml`, `dashboard_goals_types_health.ml`, `keeper_hooks_oas.ml`)는 별도 PR.

Closes part of #22071 (HIGH site).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
