### PR TITLE
fix(dashboard): restore v2 font-scale + stop duplicate surface titles

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -49,6 +49,20 @@ describe('App v2 header chrome', () => {
     expect(app?.hasAttribute('data-surface')).toBe(true)
   })
 
+  it('passes the font-scale percentage to --twk-font-scale without double-dividing (regression #21998)', () => {
+    renderApp()
+    const app = container.querySelector('.v2-app') as HTMLElement | null
+    expect(app).not.toBeNull()
+    const dataScale = app?.getAttribute('data-font-scale') ?? ''
+    const cssVar = app?.style.getPropertyValue('--twk-font-scale').trim() ?? ''
+    // craft-v2.css resolves the scale as `calc(var(--twk-font-scale) * 1%)`, so
+    // the CSS variable must carry the same raw percentage integer as
+    // data-font-scale. #21998 divided by 100 (data=100 but var=1), collapsing
+    // .v2-app font-size to 0.16px and hiding every inherited-size glyph/emoji.
+    expect(Number(cssVar)).toBe(Number(dataScale))
+    expect(Number(cssVar)).toBeGreaterThan(1)
+  })
+
   it('defaults to the v2 dark skin (no data-theme on the dashboard root)', () => {
     // Theme ownership lives on <html> (bootstrapped by main.ts, toggled by
     // ThemeSwitch). The app root no longer hard-codes a theme, so the default

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -337,7 +337,12 @@ export function App() {
       data-volt=${tweaksVolt.value}
       data-surface=${currentTab}
       style=${{
-        '--twk-font-scale': String(tweaksFontScale.value / 100),
+        // tweaksFontScale.value is a percentage integer (80..140, default 100).
+        // craft-v2.css resolves it as `calc(var(--twk-font-scale) * 1%)`, so the
+        // raw percentage must be passed through. Dividing by 100 here (regressed
+        // in #21998) double-applies the percentage: 100 -> `1 * 1%` -> 0.16px,
+        // collapsing every inherited-font-size glyph (emoji, icon chars) to ~0px.
+        '--twk-font-scale': String(tweaksFontScale.value),
         '--thread-w': `${tweaksThreadW.value}px`,
       }}
     >

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { ConnectionStatus, DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, SideRail, summarizeAttentionPreview } from './dashboard-shell'
+import { ConnectionStatus, DashboardHealthStrip, DashboardMain, dashboardHealthChips, isKeeperDetailDashboardRoute, shouldRenderSurfaceLead, SideRail, summarizeAttentionPreview } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 import { dashboardWsConnected, dashboardWsLastError, dashboardWsReady, dashboardWsSseFallbackActive } from '../dashboard-ws-state'
@@ -1050,5 +1050,34 @@ describe('DashboardHealthStrip v2 chrome', () => {
     const strip = container.querySelector('[data-testid="dashboard-health-strip"]')
     expect(strip).not.toBeNull()
     expect(strip?.classList.contains('v2-health-strip')).toBe(true)
+  })
+})
+
+describe('shouldRenderSurfaceLead', () => {
+  afterEach(() => {
+    route.value = { tab: 'overview', params: {}, postId: null }
+  })
+
+  // Surfaces that render the shared SurfaceHeader in their own body must NOT
+  // also get the generic SurfaceLead — otherwise the title renders twice.
+  // board regressed in #22021; monitoring/command/lab carried the same gap.
+  it.each(['monitoring', 'command', 'lab', 'board'] as const)(
+    'suppresses the generic SurfaceLead for the %s surface (renders its own SurfaceHeader)',
+    tab => {
+      expect(shouldRenderSurfaceLead({ tab, params: {}, postId: null })).toBe(false)
+    },
+  )
+
+  // code (IDE) has no bespoke header and is not a keeper-detail route, so it
+  // still relies on the generic SurfaceLead — a control that the set was not
+  // broadened to suppress the lead everywhere.
+  it('keeps the generic SurfaceLead for the code surface', () => {
+    expect(shouldRenderSurfaceLead({ tab: 'code', params: {}, postId: null })).toBe(true)
+  })
+
+  // keepers always renders its own keeper UI (keeper-detail guard short-circuits
+  // before the set lookup), so it never gets the generic lead.
+  it('suppresses the generic SurfaceLead for the keepers surface via the keeper-detail guard', () => {
+    expect(shouldRenderSurfaceLead({ tab: 'keepers', params: {}, postId: null })).toBe(false)
   })
 })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1478,8 +1478,16 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
 //   settings   → settings-surface.ts   <header class="set-content-h"> <h1>…</h1>
 //   connectors → connector-status.ts   (prototype surface, own header)
 //
-// Surfaces WITHOUT their own header (monitoring, command, lab, board) keep the
-// generic SurfaceLead, which supplies their title.
+// A second group renders the shared SurfaceHeader component (header.v2-surface-header)
+// at the top of their own body — the documented replacement for the generic lead
+// (see surface-header.test.ts). They must be listed here too, otherwise the shell
+// stacks SurfaceLead above SurfaceHeader and the title renders twice:
+//   monitoring → status.ts           <SurfaceHeader> <h1>Keeper Fleet</h1>
+//   command    → operations-panel.ts <SurfaceHeader> <h1>Actions</h1>
+//   lab        → lab.ts              <SurfaceHeader> <h1>Tools</h1>
+//   board      → board-surface.ts    <SurfaceHeader> <h1>Board</h1> (#22021)
+//
+// Surfaces that still rely on the generic SurfaceLead for their title: keepers, code.
 const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set([
   'overview',
   'approvals',
@@ -1490,6 +1498,13 @@ const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set([
   'cockpit',
   'settings',
   'connectors',
+  // Render the shared SurfaceHeader in their own body; without these the generic
+  // SurfaceLead stacked a duplicate title above each (board regressed in #22021,
+  // monitoring/command/lab carried the same gap from their SurfaceHeader adoption).
+  'monitoring',
+  'command',
+  'lab',
+  'board',
 ])
 
 export function shouldRenderSurfaceLead(routeState: RouteState): boolean {


### PR DESCRIPTION
## 목표

v2 디자인 마이그레이션에서 유입된 대시보드 렌더 회귀 2건을 수정합니다. 증상: (1) 보드 리액션 이모지·인라인 글리프 아이콘이 빈 박스로 표시, (2) 일부 surface 제목이 두 번 렌더.

## 근본 원인

### 1. 폰트 스케일 붕괴 → 아이콘/이모지/글리프 안 보임 (회귀: #21998)

`craft-v2.css`는 폰트 스케일을 `calc(var(--twk-font-scale) * 1%)`로 적용하며 **퍼센트 정수**(`data-font-scale = 80..140`)를 기대합니다. `#21998`이 `app.ts`를 `tweaksFontScale.value / 100`으로 바꾸면서 퍼센트가 이중 적용됐습니다 — 기본값 100에서 변수가 `1`이 되어 `.v2-app` font-size가 `1% × 16px = 0.16px`로 붕괴.

`.v2-app` 전체 서브트리가 0.16px를 상속하므로, **상속 폰트사이즈에 의존하는 모든 콘텐츠**(보드 리액션 이모지, 런타임 에디터 등의 인라인 글리프, 상단바 글리프 버튼)가 ~0px로 렌더돼 빈 박스처럼 보였습니다. lucide SVG 아이콘은 `width`/`height` 속성이 있어 영향받지 않아 일부 아이콘만 보이는 패턴이 나타났습니다.

→ 원본 퍼센트 정수를 그대로 전달하도록 복구. 브라우저 실측으로 `--twk-font-scale: 100` → `.v2-app` font-size 16px 복구 확인.

### 2. surface 제목 중복 렌더

`monitoring`·`command`·`lab`·`board` 네 surface는 자체 body에 공유 `SurfaceHeader`(`header.v2-surface-header`)를 렌더합니다(board는 #22021에서 채택). 그런데 이들이 `SURFACE_OWN_LEAD_IDS`에 누락돼 shell이 generic `SurfaceLead`를 함께 렌더 → 동일한 `<h1>`이 위에 겹쳐 제목이 두 번 표시됐습니다. 라이브 DOM에서 `monitoring`("Keeper Fleet")·`board`("Board") 모두 헤더 2개 확인.

→ 네 surface를 `SURFACE_OWN_LEAD_IDS`에 추가해 자체 `SurfaceHeader`만 남도록 수정. `keepers`(keeper-detail 가드)·`code`(자체 헤더 없음)는 기존 동작 유지.

## 변경 파일

- `dashboard/src/app.ts` — `--twk-font-scale`에 퍼센트 원본값 전달 (`/100` 제거), 컨벤션 주석 추가
- `dashboard/src/components/dashboard-shell.ts` — `SURFACE_OWN_LEAD_IDS`에 `monitoring`·`command`·`lab`·`board` 추가, 주석 갱신
- `dashboard/src/app.test.ts` — `--twk-font-scale`가 `data-font-scale`와 동일 퍼센트를 전달하는지(이중 분할 금지) 회귀 테스트
- `dashboard/src/components/dashboard-shell.test.ts` — 네 SurfaceHeader surface의 `shouldRenderSurfaceLead` = false, `code` = true, `keepers` = false 회귀 테스트

## 검증 (로컬)

- `tsc --noEmit`: 에러 0
- `eslint`: 에러 0 (symlink 경로 "no matching config" 경고만, CI `eslint src`는 정상)
- `vitest run` (app / dashboard-shell / surface-header): 77/77 통과 (신규 테스트 포함)
- 브라우저 실측: 폰트 스케일 100→16px 복구, 깨진 상태에서 헤더 2개 존재 확인

## 미검증

- 전체 vitest 스위트는 미실행(변경 인접 파일만 실행). dashboard-only 변경이라 OCaml `Build and Test`는 비해당.
