### PR TITLE
fix(keeper): 채팅 히스토리 JSON에 구조화된 surface 재emit

### DIFF
--- a/lib/keeper/keeper_chat_store.ml
+++ b/lib/keeper/keeper_chat_store.ml
@@ -985,6 +985,15 @@ let to_json_array ?base_dir (messages : chat_message list) : Yojson.Safe.t =
               @ opt_string_field "tool_call_id" m.tool_call_id
               @ opt_string_field "tool_call_name" m.tool_call_name
               @ opt_string_field "source" m.source
+              (* RFC-0232 P5: re-emit the structured surface so a history
+                 reload restores the connector deep-link, not only the
+                 derived [source] lane label. [encode_line] persists it with
+                 the same [Surface_ref.to_json] and [load] decodes it back
+                 into [m.surface]; this read-serve site had dropped it, so
+                 [surfaceLink] in the dashboard rendered nothing on reload. *)
+              @ (match m.surface with
+                 | None -> []
+                 | Some s -> [ ("surface", Surface_ref.to_json s) ])
               @ opt_string_field "conversation_id" m.conversation_id
               @ opt_string_field "external_message_id" m.external_message_id
               @ speaker_fields m.speaker

--- a/test/test_keeper_chat_store.ml
+++ b/test/test_keeper_chat_store.ml
@@ -552,7 +552,21 @@ let test_append_user_message_roundtrip () =
                   assistant_json |> member "conversation_id" |> to_string);
               Alcotest.(check bool) "json assistant omits inbound message id" true
                 Yojson.Safe.Util.(
-                  assistant_json |> member "external_message_id" = `Null)
+                  assistant_json |> member "external_message_id" = `Null);
+              (* RFC-0232 P5: the structured surface must survive the
+                 read-serve emitter, not only the derived [source] label, so
+                 the dashboard rebuilds the connector deep-link on a history
+                 reload instead of dropping it. *)
+              let user_surface = Yojson.Safe.Util.member "surface" user_json in
+              Alcotest.(check bool) "json user row carries structured surface"
+                true (user_surface <> `Null);
+              (match Masc.Surface_ref.of_json user_surface with
+               | Ok s ->
+                   Alcotest.(check string)
+                     "surface round-trips to the discord gate lane" "discord"
+                     (Masc.Surface_ref.lane_label s)
+               | Error e ->
+                   Alcotest.failf "surface did not round-trip from json: %s" e)
           | rows ->
               Alcotest.failf "expected 2 json rows, got %d"
                 (List.length rows))


### PR DESCRIPTION
## 목표

채팅 히스토리의 connector 딥링크(Discord/Slack/GitHub/gate)가 라이브에서는 보이지만 **새로고침하면 사라지는** 문제를 고친다. 대시보드 "화면이 스펙" 백엔드 필드 충실도 감사에서 드러난 단일 FILL.

## 근본 원인

`surface`(구조화된 `Surface_ref.t`)는 쓰기/읽기 양쪽에서 보존된다:

- 쓰기: `encode_line`이 `Surface_ref.to_json`으로 디스크에 저장 (`keeper_chat_store.ml:313`).
- 읽기: `load`가 디코드해 메모리 레코드 `m.surface`로 복원 (`:554-567`, 레코드 필드 `:168`, RFC-0232 P5).

그런데 히스토리 serve emitter `to_json_array`(`/chat/history` 응답, `:967-1008`)는 파생된 `source` lane 라벨(`:987`)만 내보내고 **구조화된 `surface` clause가 없었다**. 라우트는 `server_dashboard_http_keeper_api.ml:211-222`. FE는 이 필드를 기대한다: 스키마 `surface: optional(SurfaceRefSchema)`, 정규화 `raw.surface`, 렌더 `surfaceLink(entry.surface)`(`primitives.ts:1828`). 결과적으로 서버가 메모리에는 값을 들고 있으면서 재직렬화하지 않아, 새로고침 때마다 딥링크가 비었다.

## 변경

- `to_json_array`에 쓰기 경로와 **동일한 `Surface_ref.to_json`을 재사용**하는 surface clause 1개 추가. 정상이고 테스트된 쓰기 경로는 건드리지 않아 영향 범위를 읽기 emitter로 한정했다.
- 기존 `test_append_user_message_roundtrip`(이미 Gate surface를 설정하고 json 행을 검사하지만 `surface`만 단언하지 않던, 이 갭을 잡았어야 할 테스트)에 `surface` present + `of_json` round-trip 단언을 추가했다.

## 검증

- worktree 로컬 빌드 통과 (`dune build test/test_keeper_chat_store.exe`, exe 40MB 산출 = 컴파일 OK).
- 추가한 surface round-trip 단언 통과 (`speaker_identity` 케이스 `[OK]`).
- 유일하게 실패한 `tool_call_persistence 8 (direct_owner)`은 **이 변경을 stash한 clean 베이스라인에서도 동일하게 실패** → pre-existing 환경성 실패(`No Eio fs context → Memory backend` fallback, raw `dune exec` 한정). `to_json_array`를 거치지 않는 경로(`direct_owner_conversation_context`)임을 grep으로 확인했다.
- ocamlformat 0.29.0 `--check` 통과.

## 범위 밖 (의도적 비변경)

- `turn_transcript_to_json`(`:1061`)은 의도적 최소 투영(role/content/ts/kind)이고 FE도 거기서 surfaceLink를 렌더하지 않으므로 변경하지 않는다 (단일 site fix, N-of-M 아님).
- model/provider identity redaction(RFC-0132)과 무관 — `surface`는 라우팅 참조이고 라이브 경로는 이미 emit한다.
