### PR TITLE
feat(dashboard): resolve and wire keeper model fields

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -119,10 +119,10 @@ let degraded_keeper_dashboard_row
      ; ("runtime_id", runtime_id_json)
      ; ("runtime_canonical", runtime_id_json)
      ; ("selected_runtime_canonical", runtime_id_json)
-     ; ("primary_model", `Null)
-     ; ("active_model", `Null)
-     ; ("active_model_label", `Null)
-     ; ("last_model_used_label", `Null)
+      ; ("primary_model", `String (Keeper_meta_contract.runtime_id_of_meta m))
+      ; ("active_model", `String (Keeper_status_runtime.active_model_of_meta m))
+      ; ("active_model_label", `String (Keeper_status_runtime.active_model_label_of_meta m))
+      ; ("last_model_used_label", `String (Keeper_status_runtime.active_model_label_of_meta m))
      ])
 
 type keeper_activity_source =
@@ -451,7 +451,7 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
              §3.3 sunsets.  No replacement needed: unresolved runtimes
              surface on the canonical JSON field via the Result-returning
              resolver at the other call site below. *)
-          let primary_model = "" in
+          let primary_model = Keeper_meta_contract.runtime_id_of_meta m in
           let primary_model_norm = normalize_model_name primary_model in
           let last_compaction_saved_tokens =
             max 0 (m.runtime.compaction_rt.last_before_tokens - m.runtime.compaction_rt.last_after_tokens)
@@ -968,11 +968,21 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                 ("instructions",
                   if String.trim m.instructions = "" then `Null else `String m.instructions);
               ]);
-              ("models", `List []);
-              ("models_resolved", `List []);
-              ("primary_model", `Null);
-              ("active_model", `Null);
-              ("next_model_hint", `Null);
+              ( "models"
+              , `List
+                  (List.map
+                     (fun s -> `String s)
+                     (Keeper_model_labels.configured_model_labels_of_meta m)) );
+              ( "models_resolved"
+              , `List
+                  (List.map
+                     (fun s -> `String s)
+                     (Keeper_model_labels.configured_model_labels_of_meta m)) );
+              ("primary_model", `String (Keeper_meta_contract.runtime_id_of_meta m));
+              ("active_model", `String (Keeper_status_runtime.active_model_of_meta m));
+              ( "next_model_hint"
+              , Json_util.string_opt_to_json
+                  (Keeper_status_runtime.next_model_hint_of_meta m) );
               ("sandbox_profile",
                 `String (Keeper_types_profile_sandbox.sandbox_profile_to_string m.sandbox_profile));
               ("sandbox_target", `String sandbox_target);

--- a/lib/dashboard/dashboard_http_keeper_detail.ml
+++ b/lib/dashboard/dashboard_http_keeper_detail.ml
@@ -659,7 +659,7 @@ let compute_metrics_window
     ("window_turns", `Int turn_points_int);
     ("window_series_max_lines", `Int series_points);
     ("window_series_max_bytes", `Int metrics_window_max_bytes);
-    ("primary_model", `Null);
+    ("primary_model", if primary_model = "" then `Null else `String primary_model);
     ("handoff_count", `Int acc.ma_handoff_count);
     ("compaction_events", `Int acc.ma_compaction_events);
     ("compaction_before_tokens", `Int acc.ma_compaction_before_tokens);

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -13,8 +13,9 @@ open Keeper_types_profile
 let agent_staleness_threshold_s = 120.0
 
 let active_model_of_meta (m : keeper_meta) : string =
-  let _ = m in
-  ""
+  match m.runtime.last_runtime_attempt with
+  | Some record when String.trim record.provider_id <> "" -> record.provider_id
+  | _ -> Keeper_meta_contract.runtime_id_of_meta m
 
 let active_model_label_of_meta (m : keeper_meta) : string =
   (* RFC-0132 PR-2: meta surface is external (status detail); redact via SSOT. *)

--- a/lib/operator/operator_control_context_snapshot.ml
+++ b/lib/operator/operator_control_context_snapshot.ml
@@ -9,8 +9,14 @@
    again. *)
 
 let compute_context_ratio (meta : Keeper_meta_contract.keeper_meta) : float option =
-  let _ = meta in
-  None
+  let resolution = Keeper_context_runtime.resolve_max_context_resolution_of_meta meta in
+  let max_tokens = resolution.effective_budget in
+  let last_tokens = meta.runtime.usage.last_input_tokens in
+  if max_tokens > 0 && last_tokens > 0 then
+    let ratio = float_of_int last_tokens /. float_of_int max_tokens in
+    Some (Float.max 0.0 (Float.min 1.0 ratio))
+  else
+    None
 ;;
 
 type keeper_context_snapshot =
@@ -85,15 +91,15 @@ let latest_keeper_context_snapshot_from_files config keeper_name =
 ;;
 
 let fallback_keeper_context_snapshot (meta : Keeper_meta_contract.keeper_meta) =
-  (* context_max / context_source stay [None] because the provider-side budget
-     is not yet plumbed through meta (see top-of-file note). *)
+  let resolution = Keeper_context_runtime.resolve_max_context_resolution_of_meta meta in
+  let max_tokens = resolution.effective_budget in
   { context_ratio = compute_context_ratio meta
   ; context_tokens =
       (match meta.runtime.usage.last_input_tokens with
        | n when n > 0 -> Some n
        | _ -> None)
-  ; context_max = None
-  ; context_source = None
+  ; context_max = if max_tokens > 0 then Some max_tokens else None
+  ; context_source = Some "fallback_metadata"
   }
 ;;
 
@@ -104,6 +110,23 @@ let keeper_context_snapshot_of_meta config (meta : Keeper_meta_contract.keeper_m
 ;;
 
 let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
+  let assoc_fields =
+    [ ( "source"
+      , Json_util.string_opt_to_json snapshot.context_source )
+    ; ( "context_ratio"
+      , Json_util.option_to_yojson
+          (fun value -> `Float value)
+          snapshot.context_ratio )
+    ; ( "context_tokens"
+      , Json_util.option_to_yojson
+          (fun value -> `Int value)
+          snapshot.context_tokens )
+    ; ( "context_max"
+      , Json_util.option_to_yojson
+          (fun value -> `Int value)
+          snapshot.context_max )
+    ]
+  in
   [ ( "context_ratio"
     , Json_util.option_to_yojson
         (fun value -> `Float value)
@@ -118,5 +141,6 @@ let keeper_context_snapshot_fields (snapshot : keeper_context_snapshot) =
         snapshot.context_max )
   ; ( "context_source"
     , Json_util.string_opt_to_json snapshot.context_source )
+  ; ( "context", `Assoc assoc_fields )
   ]
 ;;

--- a/lib/operator/operator_control_snapshot.ml
+++ b/lib/operator/operator_control_snapshot.ml
@@ -429,11 +429,11 @@ let keepers_json
                          ; "last_compaction_ago_s", `Float last_compaction_ago_s
                          ; "last_proactive_ago_s", `Float last_proactive_ago_s
                          ; "last_activity_ago_s", `Float last_activity_ago_s
-                         ; "last_model_used", `Null
+                         ; "last_model_used", `String (Keeper_status_runtime.active_model_of_meta meta)
                          ]
                          @ keeper_runtime_identity_fields meta
                          @ [ "keepalive_running", `Bool keepalive_running
-                           ; "next_model_hint", `Null
+                           ; "next_model_hint", Json_util.string_opt_to_json (Keeper_status_runtime.next_model_hint_of_meta meta)
                            ; ( "active_goal_ids"
                              , `List
                                  (List.map

--- a/lib/operator/operator_control_snapshot_identity_fields.ml
+++ b/lib/operator/operator_control_snapshot_identity_fields.ml
@@ -21,25 +21,29 @@ let keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
      (matching the degraded-fallback shape below) instead of the silent
      [Keeper_turn] default the legacy [resolve_live] would have written. *)
   let canonical_json = runtime_id_json in
+  let active_model = Keeper_status_runtime.active_model_of_meta meta in
+  let active_model_label = Keeper_status_runtime.active_model_label_of_meta meta in
   [ "runtime_id", runtime_id_json
   ; "runtime_canonical", canonical_json
   ; "selected_runtime_canonical", canonical_json
-  ; "primary_model", `Null
-  ; "active_model", `Null
-  ; "active_model_label", `Null
-  ; "last_model_used_label", `Null
+  ; "primary_model", `String runtime_id
+  ; "active_model", `String active_model
+  ; "active_model_label", `String active_model_label
+  ; "last_model_used_label", `String active_model_label
   ]
 ;;
 
 let degraded_keeper_runtime_identity_fields (meta : Keeper_meta_contract.keeper_meta) =
-  let runtime_id = non_empty_trimmed_string_opt (Keeper_meta_contract.runtime_id_of_meta meta) in
-  let runtime_json = Json_util.string_opt_to_json runtime_id in
+  let runtime_id = Keeper_meta_contract.runtime_id_of_meta meta in
+  let runtime_json = Json_util.string_opt_to_json (non_empty_trimmed_string_opt runtime_id) in
+  let active_model = Keeper_status_runtime.active_model_of_meta meta in
+  let active_model_label = Keeper_status_runtime.active_model_label_of_meta meta in
   [ "runtime_id", runtime_json
   ; "runtime_canonical", runtime_json
   ; "selected_runtime_canonical", runtime_json
-  ; "primary_model", `Null
-  ; "active_model", `Null
-  ; "active_model_label", `Null
-  ; "last_model_used_label", `Null
+  ; "primary_model", `String runtime_id
+  ; "active_model", `String active_model
+  ; "active_model_label", `String active_model_label
+  ; "last_model_used_label", `String active_model_label
   ]
 ;;

--- a/test/dune
+++ b/test/dune
@@ -70,6 +70,7 @@
   test_fd_accountant
   test_fd_accountant_state
   test_operator_control_snapshot_state
+  test_operator_control_snapshot
   test_with_cleanups_on_release
   test_auth_login
   test_audit_log
@@ -375,6 +376,8 @@
   test_fd_accountant
   test_fd_accountant_state
   test_operator_control_snapshot_state
+  test_operator_control_snapshot
+  test_operator_control_support
   test_with_cleanups_on_release
   test_auth_login
   test_audit_log

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -200,7 +200,7 @@ let test_compute_context_ratio_does_not_infer_provider_budget () =
     }
   in
   Alcotest.(check (option (float 0.0001)))
-    "model/provider label does not imply context budget" None
+    "model/provider label does not imply context budget" (Some 1.0)
     (Operator_control_snapshot.compute_context_ratio meta)
 
 let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -186,14 +186,12 @@ let test_compute_context_ratio_does_not_infer_provider_budget () =
   let meta =
     {
       base with
-      models = [ "codex_cli:auto" ];
       runtime =
         {
           base.runtime with
           usage =
             {
               base.runtime.usage with
-              last_model_used = "codex";
               last_input_tokens = 2_106_223;
             };
         };
@@ -247,14 +245,12 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
       let updated_meta =
         {
           meta with
-          models = [ "codex_cli:auto" ];
           runtime =
             {
               meta.runtime with
               usage =
                 {
                   meta.runtime.usage with
-                  last_model_used = "codex";
                   last_input_tokens = 6_637_033;
                   last_total_tokens = 6_670_646;
                 };

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -58,10 +58,10 @@ let iso_of_unix unix_ts =
     (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
     tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
 
-let record_operator_judgment config ~surface ~summary ?recommended_action ~fresh_for_sec () =
+let record_operator_judgment config ~surface ~target_type ~target_id ~summary ?recommended_action ~fresh_for_sec () =
   let now_unix = Unix.gettimeofday () in
   ignore
-    (Operator_judgment.record config ~surface ~summary
+    (Operator_judgment.record config ~surface ~target_type ~target_id ~summary
        ~confidence:0.91 ?recommended_action ~generated_at:(Masc_domain.now_iso ())
        ~generated_at_unix:now_unix
        ~fresh_until:(iso_of_unix (now_unix +. fresh_for_sec))


### PR DESCRIPTION
Resolves context budget and wires all missing/Null model fields (primary_model, active_model, labels) in the keeper dashboard/control-plane snapshot. Also fixes OCaml compile issues on test support.