### PR TITLE
feat(dashboard): keeper-v2 프로토타입 전면 스킨 (big-bang reskin)

### DIFF
--- a/dashboard/docs/V2-RESKIN-PROGRESS.md
+++ b/dashboard/docs/V2-RESKIN-PROGRESS.md
@@ -1,0 +1,77 @@
+# Dashboard v2 big-bang reskin — progress & plan
+
+Branch: `feat/dashboard-v2-skin-bigbang` (worktree). Goal: 100% match the
+keeper-v2 design prototype (icons, fonts, colors, margins, padding, weight),
+SSOT CSS, production-grade, no stub/hardcode/silent-failure.
+
+## Ground truth (prototype)
+- Source: `/Users/dancer/Downloads/v2 2/project/keeper-v2/` (jsx + styles/).
+- Standalone (rendered target): served at `http://127.0.0.1:8971/Keeper%20Agent%20v2%20(standalone)%20(2).html`
+  (`?surface=<id>` deep-links). Python http.server over ~/Downloads.
+- Maps (workflow output): `/tmp/keeper-v2-maps/*.md`
+  - proto-data-contract, proto-keepers-dom, proto-css-tokens, live-store-mapping, current-shell-inventory.
+
+## Dev
+- Worktree dev server: `pnpm dev` → http://localhost:5174/dashboard/ (proxies API to 8935 live backend).
+- Live backend: 8935.
+
+## Key realization
+The dashboard was already ~80% migrated to keeper-v2 CSS class vocabulary
+(.ov-*, .kp-row, .thread, .bubble, .ctx-*). It looked "far" only because of
+drifted legacy *-v2.css + a cluttered Tailwind shell. Vendoring the prototype
+CSS as SSOT + a clean prototype-DOM shell snapped most surfaces into place.
+=> Strategy: surgical per-surface DOM alignment where close; rebuild where far.
+
+## Done (verified in-browser)
+- [x] Foundation (c480ecabb4): vendored 14 prototype CSS SSOT + new shell + v2 components.
+- [x] Keepers roster (9b025cff2b) + context rail (4aa94fba8e) → prototype .roster/.kp-row/.ctx DOM.
+- [x] Overview (ea93e8fed5): trimmed to prototype (dropped fleet grid + v1 rollup).
+- [x] Schedule SHELL (1366bc3228): .ov.sch-surf header + KPIs. (panel still TODO)
+- [x] v2 constants (ea579f312c): schedule-constants.ts, fusion-constants.ts.
+- [x] 6 near-match surfaces (e69cae4254): approvals/board/connectors/logs/settings/workspace.
+
+## Surface match landscape (audit)
+DONE + verified in-browser (11 surfaces): overview, keepers (roster/rail/chat header),
+approvals, board, connectors, logs, settings, workspace, schedule (shell+panel), code/IDE,
+fusion. Far-surface rebuilds (schedule-panel, ide, fusion) landed cleanly.
+
+REMAINING (reverted — rate-limited mid-rewrite, need careful redo):
+- monitoring/Monitor (agent-roster.ts): fl-* row retarget worked, but the rebuild left a
+  DUPLICATE "Keeper Fleet" header (shell SurfaceLead + a second header) + misplaced foot
+  ticker + skeleton stat bars. Note: monitoring is in dashboard-shell's "no own header"
+  list → SurfaceLead renders the title; a rebuild must NOT add a second top header.
+- runtime-editor (runtime-environment-editor.ts + runtime-toml-editor.ts): structure good
+  (.rt-nav sections switch, .rt-lane/.rt-card), but EMBEDDED in settings narrower than the
+  prototype full surface → .rt-lane flex (label-l flex:1 + wide .rt-select control) squeezes
+  the label to ~50px → vertical text wrap. Fix: full-width embed and/or cap .rt-select and/or
+  stack .rt-lane label-above-control when narrow.
+- mobile bottom tab bar (.v2-nav.is-mnav) in nav-rail-v2.ts (desktop-only so far).
+- keepers chat thread/composer (KeeperConversationPanel, board-shared) still .kw-*.
+
+## Remaining deltas (adversarial, prioritized)
+- [ ] Keepers roster header: current = verbose stat grid (12/9/0/3) + chips;
+      prototype = compact `.roster-filters` (전체/실행/주의 + search icon + sort).
+- [ ] Keepers roster rows: show time + basepath + phase dot (proto) vs "최근 활동"+summary.
+- [ ] Keepers ctx rail: prototype = 처리량/런타임/컨텍스트(window bar + 지금 컴팩트 +
+      컴팩션 스냅샷 + 메모리 보기)/소유 태스크. Current has "운영 상세" link + "윈도우 사용률 미수신"
+      (live ctx window data gap — keeper.context_ratio/tokens/max).
+- [ ] Keepers 4-col `.v2-body` grid (roster|chat|ctx) vs current single-column internal grid.
+- [ ] Keepers chat header actions = FSM_ACTIONS glyphs (⏸◉⇄■⚙).
+- [ ] Per-surface audit: overview (도메인 현황 cards), board, schedule, runtime,
+      monitor, approvals, work, logs, ide, connectors, settings.
+- [ ] Mobile bottom tab bar (.v2-nav.is-mnav) + more-sheet.
+- [ ] Stray focus-mode toggle bottom-left on non-primary surfaces.
+- [ ] Final cleanup PR: remove legacy *-v2.css / v2-shell.css / app-shell-v2.css once surfaces migrated.
+
+## Notes
+- Live data gaps (mark, don't fake): schedule/cron (no signal), context window
+  (keeper.context_*), model (keeper.metrics_window.primary_model).
+- KeeperPhase live enum == prototype FSM_STATES + Zombie.
+
+## Deferred polish (after far surfaces)
+- Keepers chat (keeper-workspace-chat.ts) still uses .kw-chat-* classes (styled by
+  keeper-workspace.css mimic, not SSOT). Retarget header → .chat-head/.name-row/.sub/
+  .chat-actions + Pill, and reduce actions to prototype FSM glyphs + ⚙ (drop
+  search/archive/trash) — needs WorkspaceCommandButtons changes too. Visually ~95% already.
+- Final cleanup PR: remove legacy keeper-workspace.css / *-v2.css / v2-shell.css once all
+  surfaces emit prototype classes; run tsc/lint/tests.

--- a/dashboard/docs/V2-RESKIN-PROGRESS.md
+++ b/dashboard/docs/V2-RESKIN-PROGRESS.md
@@ -5,11 +5,15 @@ keeper-v2 design prototype (icons, fonts, colors, margins, padding, weight),
 SSOT CSS, production-grade, no stub/hardcode/silent-failure.
 
 ## Ground truth (prototype)
-- Source: `/Users/dancer/Downloads/v2 2/project/keeper-v2/` (jsx + styles/).
-- Standalone (rendered target): served at `http://127.0.0.1:8971/Keeper%20Agent%20v2%20(standalone)%20(2).html`
-  (`?surface=<id>` deep-links). Python http.server over ~/Downloads.
-- Maps (workflow output): `/tmp/keeper-v2-maps/*.md`
-  - proto-data-contract, proto-keepers-dom, proto-css-tokens, live-store-mapping, current-shell-inventory.
+- Source: keeper-v2 design prototype (jsx + `styles/`), provided out-of-repo by the
+  designer. Point `$KEEPER_V2_PROTO` at its local checkout; the vendored SSOT copy of
+  its CSS lives in `src/styles/keeper-v2/` (the in-repo source of truth for the skin).
+- Standalone (rendered target): the `Keeper Agent v2 (standalone)` HTML from that
+  prototype, served locally (`?surface=<id>` deep-links) — e.g.
+  `python3 -m http.server` inside `$KEEPER_V2_PROTO`.
+- Maps (transient investigation output, regenerable, not committed):
+  proto-data-contract, proto-keepers-dom, proto-css-tokens, live-store-mapping,
+  current-shell-inventory.
 
 ## Dev
 - Worktree dev server: `pnpm dev` → http://localhost:5174/dashboard/ (proxies API to 8935 live backend).

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>MASC Dashboard</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Noto+Sans+KR:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap" />
 </head>
 <body>
   <div id="app"></div>

--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -4,9 +4,9 @@ import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
 import { App, shouldShowCopilotFab, shouldSuppressFloatingChrome, shouldUseCompactDashboardChrome } from './app'
 import { route } from './router'
-import { serverStatus, shellCounts } from './store'
-import { selectedKeeper } from './components/keeper-detail-state'
-import { keeperMobilePane } from './components/keeper-mobile-pane-state'
+import { keepers } from './store'
+import { activeKeeperName } from './keeper-state'
+import type { Keeper } from './types'
 
 describe('App v2 header chrome', () => {
   let container: HTMLDivElement
@@ -17,10 +17,8 @@ describe('App v2 header chrome', () => {
     document.body.appendChild(container)
     window.location.hash = originalHash
     route.value = { tab: 'overview', params: {}, postId: null }
-    shellCounts.value = null
-    serverStatus.value = null
-    selectedKeeper.value = null
-    keeperMobilePane.value = 'chat'
+    keepers.value = []
+    activeKeeperName.value = ''
   })
 
   afterEach(() => {
@@ -28,10 +26,8 @@ describe('App v2 header chrome', () => {
     container.remove()
     window.location.hash = originalHash
     route.value = { tab: 'overview', params: {}, postId: null }
-    shellCounts.value = null
-    serverStatus.value = null
-    selectedKeeper.value = null
-    keeperMobilePane.value = 'chat'
+    keepers.value = []
+    activeKeeperName.value = ''
   })
 
   function renderApp() {
@@ -74,67 +70,77 @@ describe('App v2 header chrome', () => {
 
   it('renders v2 shell header and health strip scopes', () => {
     renderApp()
-    expect(container.querySelector('header.v2-shell-header')).not.toBeNull()
+    // The shell header is now TopBarV2's `.v2-top` (the old `header.v2-shell-header`
+    // element was replaced by the keeper-v2 prototype top bar). The health strip is
+    // re-mounted under the top bar, so its testid + scope class still hold.
+    expect(container.querySelector('.v2-top')).not.toBeNull()
     expect(container.querySelector('[data-testid="dashboard-health-strip"].v2-health-strip')).not.toBeNull()
   })
 
   it('renders v2 header structural classes', () => {
     renderApp()
-    expect(container.querySelector('.v2-header-brand')).not.toBeNull()
-    expect(container.querySelector('.v2-header-mark')).not.toBeNull()
-    expect(container.querySelector('.v2-header-crumb')).not.toBeNull()
-    // The global chrome no longer renders a page title: surface-level headers
-    // own the title source of truth, so the shell header carries only the crumb.
+    // Brand/mark moved into the nav rail (NavRailV2 `.nav-brand` + `.nav-home`);
+    // the keeper-v2 shell renders the MASC mark there, not in the top bar.
+    expect(container.querySelector('.nav-brand')).not.toBeNull()
+    expect(container.querySelector('.nav-home')).not.toBeNull()
+    // The crumb is now `.v2-top .crumb` (TopBarV2), replacing `.v2-header-crumb`.
+    expect(container.querySelector('.v2-top .crumb')).not.toBeNull()
+    // The global chrome still renders no page title: surface-level headers own the
+    // title source of truth, so the shell header carries only the crumb. (Old
+    // `.v2-header-title` selector is gone; nothing renders a header title.)
     expect(container.querySelector('.v2-header-title')).toBeNull()
-    expect(container.querySelector('.v2-header-actions')).not.toBeNull()
+    // The header still carries an action/status cluster: the re-mounted operational
+    // chrome lives in `.v2-top-ops` (was `.v2-header-actions` / `.v2-app-header-status`).
+    expect(container.querySelector('.v2-top-ops')).not.toBeNull()
+    // The shell no longer renders inline header tabs (`.v2-shell-tabs`); navigation
+    // is the nav rail / bottom tab bar.
     expect(container.querySelector('.v2-shell-tabs')).toBeNull()
-    expect(container.querySelector('.v2-app-header-status')).not.toBeNull()
+    // The live running-count chip still renders in the top bar.
     expect(container.querySelector('.v2-statchip.live')).not.toBeNull()
   })
 
-  it('renders keeper breadcrumb tail and visible Korean desktop status chips', () => {
+  it('renders keeper breadcrumb tail and the live running-count chip', () => {
     window.innerWidth = 1280
     route.value = { tab: 'keepers', params: { keeper: 'albini' }, postId: null }
-    shellCounts.value = {
-      agents: 0,
-      tasks: 0,
-      keepers: 7,
-      total_runtimes: 0,
-      configured_keepers: 7,
-    }
-    serverStatus.value = {} as NonNullable<typeof serverStatus.value>
+    // The live running-count chip counts running keepers from the `keepers` store
+    // (via phaseStatus), not from shellCounts. Seed 7 running keepers so the chip
+    // reads "7 실행 중".
+    keepers.value = Array.from({ length: 7 }, (_, i): Keeper => ({
+      name: `k${i}`,
+      status: 'running',
+      lifecycle_phase: 'Running',
+    }))
     renderApp()
 
-    const crumb = container.querySelector('.v2-header-crumb')
+    // Crumb is now `.v2-top .crumb` (TopBarV2): surface label + keeper tail.
+    const crumb = container.querySelector('.v2-top .crumb')
     expect(crumb?.textContent).toContain('Keepers')
     expect(crumb?.textContent).toContain('albini')
 
-    const status = container.querySelector('.v2-app-header-status') as HTMLElement | null
-    expect(status).not.toBeNull()
-    expect(status?.classList.contains('flex')).toBe(true)
-    expect(status?.classList.contains('hidden')).toBe(false)
-    expect(status?.textContent).toContain('7 실행 중')
-    expect(status?.textContent).toContain('서버')
-    expect(status?.textContent).toContain('응답')
-    const liveChip = status?.querySelector('.v2-statchip.live') as HTMLElement | null
-    expect(liveChip?.getAttribute('title')).toBe('실행 중인 keeper 수 (shell 스냅샷 기준)')
-    const schedulerChip = Array.from(status?.querySelectorAll('.v2-statchip') ?? [])
-      .find(chip => chip !== liveChip) as HTMLElement | undefined
-    expect(schedulerChip?.getAttribute('title')).toBe('dashboard shell이 최근 서버 status를 수신했는지 여부')
-    expect(
-      status?.querySelector('.v2-statchip.live span')?.classList.contains('motion-safe:animate-pulse'),
-    ).toBe(true)
+    // The live running-count chip is `.v2-statchip.live` in the top bar. The old
+    // `.v2-app-header-status` container, the separate server-status "scheduler"
+    // chip ("서버"/"응답" text + its title), and the chip-title attributes were
+    // removed by the v2 reskin — TopBarV2 emits an attention indicator + 예약
+    // button instead. The live-count + pulse coverage is preserved here.
+    const liveChip = container.querySelector('.v2-statchip.live') as HTMLElement | null
+    expect(liveChip).not.toBeNull()
+    expect(liveChip?.textContent).toContain('7 실행 중')
+    // Pulse is now carried by the StatusDot pip (`.dot2.pulse`), replacing the old
+    // `motion-safe:animate-pulse` utility class on an inner span.
+    expect(liveChip?.querySelector('.dot2.pulse')).not.toBeNull()
   })
 
-  it('falls back to selectedKeeper for the breadcrumb tail when no route keeper param', () => {
-    // Mirrors keeper-detail-page resolution tier 2: with no route keeper param
-    // the crumb still tracks the keeper the chat is showing via selectedKeeper.
+  it('falls back to activeKeeperName for the breadcrumb tail when no route keeper param', () => {
+    // With no route keeper param the crumb still tracks the keeper the chat is
+    // showing. TopBarV2's fallback source is now `activeKeeperName` (the old
+    // `selectedKeeper` fallback was removed by the reskin); the fallback intent
+    // is unchanged.
     window.innerWidth = 1280
     route.value = { tab: 'keepers', params: {}, postId: null }
-    selectedKeeper.value = { name: 'grimja' } as NonNullable<typeof selectedKeeper.value>
+    activeKeeperName.value = 'grimja'
     renderApp()
 
-    const crumb = container.querySelector('.v2-header-crumb')
+    const crumb = container.querySelector('.v2-top .crumb')
     expect(crumb?.textContent).toContain('Keepers')
     expect(crumb?.textContent).toContain('grimja')
     // No dangling slash when a tail is present.
@@ -147,18 +153,23 @@ describe('App v2 header chrome', () => {
 
     const main = container.querySelector('#main-content') as HTMLElement | null
     expect(main).not.toBeNull()
-    expect(main?.classList.contains('v2-body')).toBe(true)
+    // The host is `.v2-surface-host` and sits inside the `.v2-body` grid column
+    // (the old shell put `v2-body` directly on #main-content; the v2 grid now
+    // wraps it).
+    expect(main?.classList.contains('v2-surface-host')).toBe(true)
+    expect(main?.closest('.v2-body')).not.toBeNull()
 
-    // The v2-body is edge-to-edge full-bleed: the wrapper card chrome (rounded
-    // corners, border, card background, drop shadow) was removed so the shell
-    // matches the prototype's full-bleed .v2-body grid. The page background
-    // shows through; each surface owns its own background.
+    // Edge-to-edge full-bleed: the wrapper card chrome (rounded corners, border,
+    // card background, drop shadow) was removed so the shell matches the
+    // prototype's full-bleed grid. The page background shows through; each
+    // surface owns its own background.
     const cls = main?.className ?? ''
     expect(cls).not.toContain('bg-[var(--ss-card)]')
     expect(cls).not.toContain('rounded-[var(--ss-radius-card)]')
     expect(cls).not.toContain('shadow-[var(--ss-shadow-card)]')
-    // Still clips so the inner .dashboard-main-scroll owns the scrollbar.
-    expect(cls).toContain('overflow-hidden')
+    // The host owns the scrollbar via an inline style (replacing the old
+    // overflow-hidden class on the host + overflow-y-auto on the inner scroll).
+    expect(main?.style.overflowY).toBe('auto')
   })
 
   it('renders health chips with the shared chip class', () => {
@@ -171,42 +182,36 @@ describe('App v2 header chrome', () => {
     window.innerWidth = 900
     renderApp()
     const app = container.querySelector('.v2-app')
-    expect(app?.getAttribute('data-mobile')).toBe('true')
+    // The v2 shell emits data-mobile="1" (prototype CSS attribute selector),
+    // not "true".
+    expect(app?.getAttribute('data-mobile')).toBe('1')
   })
 
   it('does not set data-mobile above the v2 shell breakpoint', () => {
     window.innerWidth = 901
     renderApp()
     const app = container.querySelector('.v2-app')
-    expect(app?.getAttribute('data-mobile')).toBe('false')
+    // Above the breakpoint the attribute is omitted entirely (was "false").
+    expect(app?.hasAttribute('data-mobile')).toBe(false)
   })
 
-  it('uses a 44x44 mobile menu button touch target', () => {
+  it('renders the always-present mobile bottom tab bar below the breakpoint', () => {
     window.innerWidth = 900
     renderApp()
 
-    const menuButton = container.querySelector('button[aria-controls="dashboard-side-rail"]') as HTMLElement | null
-    expect(menuButton).not.toBeNull()
-    expect(menuButton?.classList.contains('size-11')).toBe(true)
+    // Mobile nav is now NavRailV2's always-present bottom tab bar
+    // (`nav.v2-nav.is-mnav`). The old drawer model (a 44x44 hamburger
+    // `button[aria-controls="dashboard-side-rail"]` toggling a side-rail
+    // drawer + `nav[aria-label="Primary mobile navigation"]`) was removed by
+    // the reskin; the prototype keeps a persistent bottom tab bar instead.
+    expect(container.querySelector('nav.v2-nav.is-mnav')).not.toBeNull()
   })
 
-  it('hides mobile nav tabs when the mobile side-rail drawer is open', async () => {
-    window.innerWidth = 900
-    renderApp()
-
-    const menuButton = container.querySelector('button[aria-controls="dashboard-side-rail"]') as HTMLElement | null
-    expect(menuButton).not.toBeNull()
-    menuButton!.click()
-
-    await waitFor(() => {
-      expect(container.querySelector('nav[aria-label="Primary mobile navigation"]')).toBeNull()
-    })
-
-    menuButton!.click()
-    await waitFor(() => {
-      expect(container.querySelector('nav[aria-label="Primary mobile navigation"]')).not.toBeNull()
-    })
-  })
+  // REMOVED: "hides mobile nav tabs when the mobile side-rail drawer is open" —
+  // the mobile side-rail drawer + hamburger toggle were removed by the v2 reskin.
+  // The bottom tab bar (`nav.v2-nav.is-mnav`) is always present on mobile, so
+  // there is no drawer-open state that hides it. Positive coverage that the
+  // bottom bar renders is kept in the test above.
 
   it('uses the header Copilot control instead of a floating FAB on mobile', () => {
     window.innerWidth = 900
@@ -216,93 +221,64 @@ describe('App v2 header chrome', () => {
     expect(container.querySelector('[data-testid="copilot-dock-fab"]')).toBeNull()
   })
 
-  it('keeps mobile nav available on the keeper roster pane', () => {
-    window.location.hash = '#keepers?keeper=sangsu'
-    route.value = { tab: 'keepers', params: { keeper: 'sangsu' }, postId: null }
-    keeperMobilePane.value = 'roster'
-    window.innerWidth = 900
-    renderApp()
-
-    expect(container.querySelector('#main-content')?.getAttribute('data-mpane')).toBe('roster')
-    expect(container.querySelector('nav[aria-label="Primary mobile navigation"]')).not.toBeNull()
-  })
-
-  it('hides mobile nav while reading the keeper chat pane', () => {
-    window.location.hash = '#keepers?keeper=sangsu'
-    route.value = { tab: 'keepers', params: { keeper: 'sangsu' }, postId: null }
-    keeperMobilePane.value = 'chat'
-    window.innerWidth = 900
-    renderApp()
-
-    expect(container.querySelector('#main-content')?.getAttribute('data-mpane')).toBe('chat')
-    const bottomNav = container.querySelector('nav[aria-label="Primary mobile navigation"]')
-    expect(bottomNav).toBeNull()
-  })
+  // REMOVED: "keeps mobile nav available on the keeper roster pane" and
+  // "hides mobile nav while reading the keeper chat pane" — both asserted the old
+  // per-pane mobile-nav gating driven by `#main-content[data-mpane]` +
+  // `keeperMobilePane`. The reskin dropped `data-mpane` from #main-content and the
+  // `nav[aria-label="Primary mobile navigation"]` element; the mobile bottom tab
+  // bar (`nav.v2-nav.is-mnav`) is now always present regardless of keeper pane.
+  // Positive bottom-bar coverage is kept above.
 
   it('renders the left side rail on desktop', () => {
     window.innerWidth = 1280
     renderApp()
 
-    const rail = container.querySelector('#dashboard-side-rail')
+    // The desktop rail is now NavRailV2's `nav.v2-nav` (no `#dashboard-side-rail`
+    // id, no `.v2-shell-rail`). The mobile-hidden behaviour is no longer a class
+    // on the rail: on desktop the rail variant has no `.is-mnav`.
+    const rail = container.querySelector('nav.v2-nav')
     expect(rail).not.toBeNull()
-    expect(rail?.classList.contains('v2-shell-rail')).toBe(true)
-    expect(rail?.classList.contains('max-[1100px]:hidden')).toBe(true)
+    expect(rail?.classList.contains('is-mnav')).toBe(false)
   })
 
   it('does not collapse the left rail out of view on desktop', () => {
     window.innerWidth = 1280
     renderApp()
 
-    const rail = container.querySelector('#dashboard-side-rail') as HTMLElement
+    const rail = container.querySelector('nav.v2-nav')
     expect(rail).not.toBeNull()
-    const cls = Array.from(rail.classList).join(' ')
-    // The desktop rail must carry a fixed width, not w-full. Collapsed default
-    // renders the keeper-v2 prototype's 58px icon rail (w-[58px], --nav-w
-    // v2.css:232); expanded renders w-55.
-    expect(cls).toMatch(/w-\[58px\]|\bw-55\b/)
-    expect(cls).not.toMatch(/\bw-full\b/)
-    expect(cls).not.toMatch(/\bmax-h-75\b/)
+    // The rail width is no longer a utility class on the rail element; it is the
+    // 58px grid column of the `.v2-body` shell grid (icon rail). Assert that the
+    // grid reserves a fixed 58px column for the rail (not a collapsed 0 / 1fr-only
+    // grid), keeping the "rail stays visible with a real width" intent.
+    const body = container.querySelector('.v2-body') as HTMLElement | null
+    expect(body).not.toBeNull()
+    expect(body?.style.gridTemplateColumns).toContain('58px')
   })
 
   it('keeps main content scrollable', () => {
     window.innerWidth = 1280
     renderApp()
 
-    const main = container.querySelector('#main-content')
+    const main = container.querySelector('#main-content') as HTMLElement | null
     expect(main).not.toBeNull()
-    expect(main?.classList.contains('overflow-hidden')).toBe(true)
+    // The host owns the scrollbar via an inline style (replacing the old
+    // `overflow-hidden` class on the host).
+    expect(main?.style.overflowY).toBe('auto')
 
+    // The inner scroll wrapper is `.dashboard-main-scroll.h-full`. The reskin
+    // moved scroll ownership onto the host inline style, so the inner wrapper no
+    // longer carries `overflow-y-auto` — it just fills height (`h-full`).
     const scroll = main?.querySelector('.dashboard-main-scroll')
     expect(scroll).not.toBeNull()
-    expect(scroll?.classList.contains('overflow-y-auto')).toBe(true)
     expect(scroll?.classList.contains('h-full')).toBe(true)
   })
 
-  it('toggles the mobile side-rail drawer', async () => {
-    window.innerWidth = 900
-    renderApp()
-
-    const rail = container.querySelector('#dashboard-side-rail') as HTMLElement | null
-    expect(rail).not.toBeNull()
-
-    const menuButton = container.querySelector('button[aria-controls="dashboard-side-rail"]') as HTMLElement | null
-    expect(menuButton).not.toBeNull()
-    menuButton!.click()
-
-    // DashboardNavRail owns the mobile drawer contract: opening swaps the rail
-    // from the hidden mobile state into an explicit block drawer.
-    await waitFor(() => {
-      expect(rail?.classList.contains('block')).toBe(true)
-      expect(rail?.classList.contains('hidden')).toBe(false)
-      expect(container.querySelector('[data-testid="dashboard-status-tray"]')).toBeNull()
-      expect(container.querySelector('[data-testid="dashboard-focus-mode-toggle"]')).toBeNull()
-    })
-
-    menuButton!.click()
-    await waitFor(() => {
-      expect(rail?.classList.contains('hidden')).toBe(true)
-    })
-  })
+  // REMOVED: "toggles the mobile side-rail drawer" — the v2 reskin removed the
+  // mobile side-rail drawer (`#dashboard-side-rail` block/hidden toggling) and its
+  // hamburger control (`button[aria-controls="dashboard-side-rail"]`). The mobile
+  // bottom tab bar (`nav.v2-nav.is-mnav`) is always present; there is no
+  // drawer-open/closed state to toggle. Positive bottom-bar coverage is kept above.
 
   it('hides floating status and focus chrome on prototype primary surfaces', () => {
     window.innerWidth = 1280
@@ -330,23 +306,24 @@ describe('App v2 header chrome', () => {
     route.value = { tab: 'monitoring', params: { section: 'agents' }, postId: null }
     renderApp()
 
-    // Rail should be visible initially.
-    expect(container.querySelector('#dashboard-side-rail')).not.toBeNull()
+    // Rail (now `nav.v2-nav`) should be visible initially.
+    expect(container.querySelector('nav.v2-nav')).not.toBeNull()
 
     const focusButton = container.querySelector('[data-testid="dashboard-focus-mode-toggle"]') as HTMLElement | null
     expect(focusButton).not.toBeNull()
     focusButton!.click()
 
-    // Wait for Preact to re-render after the persistent signal update.
+    // Wait for Preact to re-render after the persistent signal update. Focus mode
+    // (compact chrome) omits the rail entirely.
     await waitFor(() => {
-      expect(container.querySelector('#dashboard-side-rail')).toBeNull()
+      expect(container.querySelector('nav.v2-nav')).toBeNull()
     })
     expect(container.querySelector('[data-testid="dashboard-focus-mode-toggle"]')).not.toBeNull()
 
     // Toggling back restores the rail.
     focusButton!.click()
     await waitFor(() => {
-      expect(container.querySelector('#dashboard-side-rail')).not.toBeNull()
+      expect(container.querySelector('nav.v2-nav')).not.toBeNull()
     })
   })
 })

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -1,12 +1,20 @@
-// MASC Dashboard — Root component
-// Sticky app shell with tab routing and live status rail
+// MASC Dashboard — Root component (v2 skin shell)
+//
+// The chrome (top bar, nav rail, body grid) is the keeper-v2 prototype DOM
+// (`.v2-app` → `.v2-top` → `.v2-stage` → `.v2-body`), styled by the vendored
+// keeper-v2 CSS SSOT (src/styles/keeper-v2/*). The body still mounts the
+// existing `DashboardMain` surface dispatcher, so every surface keeps
+// rendering while it is migrated to the prototype DOM in stacked follow-ups.
+//
+// All lifecycle wiring (router, WS, SSE reaction, periodic refresh, dev-token,
+// config thresholds, cleanup, volt/theme sync) is preserved verbatim from the
+// previous shell — only the rendered DOM changed.
 
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { lazy, Suspense } from 'preact/compat'
 import { signal } from '@preact/signals'
 import { persistentSignal } from './lib/persistent-signal'
-import { ringFocusClasses } from './components/common/ring'
 import { route, initRouter } from './router'
 import {
   pauseQueuedOasRuntimeIngress,
@@ -14,28 +22,15 @@ import {
 } from './sse'
 import { requestNamespaceTruthNow, disposeNamespaceTruthScheduler } from './namespace-truth-store'
 import { cancelPendingSSERefreshes, registerMissionRefresh, setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
-import { refreshShell, serverStatus, shellCounts } from './store'
+import { refreshShell } from './store'
 import { connectDashboardWS, disconnectDashboardWS, subscribeDashboardRoute } from './dashboard-ws'
 import { ensureDevToken } from './api/dev-token'
 import { fetchDashboardConfig, parseContextThresholds } from './api/dashboard'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
 import { setContextThresholds } from './config/context-thresholds'
-import {
-  BuildIdentityBadge,
-  ConnectionStatus,
-  DashboardHealthStrip,
-  DashboardMain,
-  ErrorCounterBadge,
-  isKeeperDetailDashboardRoute,
-} from './components/dashboard-shell'
-import { ThemeSwitch } from './components/theme-switch'
-import { EmergencyStopControl } from './components/emergency-stop-control'
-import { AttentionIndicator } from './components/attention-indicator'
-import { TransportBeacon } from './components/transport-beacon'
-import { DashboardNavRail } from './components/mobile-nav'
+import { DashboardMain, isKeeperDetailDashboardRoute } from './components/dashboard-shell'
 import { SkipLink } from './components/skip-link'
 import { selectedAgentName } from './components/agent-detail-selection'
-import { selectedKeeper } from './components/keeper-detail-state'
 import { selectedTask } from './components/goals/task-detail-selection'
 import { ToastContainer } from './components/common/toast'
 import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
@@ -43,13 +38,9 @@ import { BundleStalenessBanner, installBundleStalenessWatch } from './components
 import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification-state'
 import { DashboardStatusTray } from './components/status-tray'
 import { DashboardFocusModeToggle, dashboardFocusMode } from './components/focus-mode-toggle'
-import {
-  DASHBOARD_NAV_ITEMS,
-  currentSectionForRoute,
-  isPrimaryDashboardSurface,
-} from './config/navigation'
+import { isPrimaryDashboardSurface } from './config/navigation'
+import { governanceData } from './components/governance-signals'
 import type { TabId } from './types'
-import { Menu, X } from 'lucide-preact'
 import { useKeyboardShortcutHost } from '../design-system/headless-preact/use-keyboard-shortcut'
 import { globalShortcutManager } from './lib/global-shortcut-manager'
 import { useKeeperPinShortcuts } from './components/ide/use-keeper-pin-shortcuts'
@@ -58,14 +49,11 @@ import { isWidgetSoloRoute } from './components/widget-solo'
 import {
   CopilotDock,
   CopilotDockFab,
-  CopilotDockTopBarButton,
   useCopilotDock,
   useCopilotDockShortcuts,
 } from './components/copilot-dock'
-import { keeperMobilePane } from './components/keeper-mobile-pane-state'
 import {
   TweaksPanel,
-  TweaksPanelToggle,
   tweaksDensity,
   tweaksFontScale,
   tweaksMotion,
@@ -74,13 +62,12 @@ import {
   tweaksVolt,
   tweaksThreadW,
 } from './components/tweaks-panel'
+import { TopBarV2 } from './components/v2/top-bar-v2'
+import { NavRailV2 } from './components/v2/nav-rail-v2'
 
-// Sidebar collapsed state persists across reloads — a user who picks
-// the dense layout keeps it. Namespaced key avoids clashing with any
-// future per-user preference that might use plain \"sidebar-collapsed\".
-// Default = collapsed: a fresh load shows the keeper-v2 prototype's
-// icon-only 58px rail. Returning users keep their stored choice (the
-// persistent signal only falls back to this default when no value is set).
+// Sidebar collapsed state persists across reloads (kept for compatibility with
+// downstream consumers / tests). The v2 rail is a fixed 58px icon rail, so this
+// no longer toggles width, but the signal is retained so the contract holds.
 const sidebarCollapsed = persistentSignal<boolean>({
   key: 'dashboard:sidebar-collapsed',
   defaultValue: true,
@@ -108,24 +95,6 @@ const LazyTaskDetailOverlay = lazy(async () => ({
 const LazyCommandPalette = lazy(async () => ({
   default: (await import('./components/common/command-palette')).CommandPalette,
 }))
-const LazyAuthStatus = lazy(async () => ({
-  default: (await import('./components/auth-status')).AuthStatus,
-}))
-const LazyRemoteWarningBanner = lazy(async () => ({
-  default: (await import('./components/auth-status')).RemoteWarningBanner,
-}))
-
-function authStatusFallback() {
-  return html`
-    <span
-      class="flex h-[22px] w-[4.5rem] items-center gap-1.5 rounded-[var(--r-1)] border border-solid border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2"
-      aria-hidden="true"
-    >
-      <span class="size-[7px] rounded-[var(--r-0)] bg-[var(--color-fg-disabled)]"></span>
-      <span class="h-2.5 w-9 rounded-[var(--r-1)] bg-[var(--color-fg-disabled)]"></span>
-    </span>
-  `
-}
 
 function refreshCurrentRoute(options?: { recordVisit?: boolean }): void {
   const routeState = route.value
@@ -163,28 +132,13 @@ export function shouldShowCopilotFab({
 }
 
 export function App() {
-  // RFC-0012 §3.2: bind a single document-level keydown listener once at
-  // the app root. Registry starts empty; per RFC §8 each ad-hoc keydown
-  // owner (command palette, modal Escape, IDE multi-keeper pin promote /
-  // unpin) migrates onto `globalShortcutManager` in its own PR. The
-  // manager's `dispatch` returns `false` on no-match so the host does not
-  // `preventDefault`, leaving existing element-scoped listeners working.
+  // RFC-0012 §3.2: single document-level keydown host bound once at the root.
   useKeyboardShortcutHost(globalShortcutManager)
-
-  // RFC-0027 PR-γ-2: 5 multi-keeper-pin shortcuts (Mod+Shift+1..4
-  // promote, Mod+Shift+W unpin head). First consumer of the global
-  // shortcut manager (RFC-0012 §8 consumer-migration pattern). Chord
-  // namespace deliberately distinct from RFC-0012 §4 default IDE set
-  // (Mod+1..9 reserved for tab switching, Mod+W for tab close).
+  // RFC-0027 PR-γ-2: multi-keeper-pin shortcuts.
   useKeeperPinShortcuts(globalShortcutManager)
 
   useEffect(() => {
     let cancelled = false
-    // WS/WSS is the sole dashboard transport. The server fans every
-    // broadcast to the WS external-subscriber path, and reconnect re-syncs
-    // via the hello/subscribe snapshot, so the SSE fallback path was
-    // removed (it carried a separate event-id space and caused stale-delta
-    // churn at the WS<->SSE boundary).
 
     // Initialize hash router and compatible deep links
     initRouter()
@@ -194,17 +148,12 @@ export function App() {
         console.warn('[app] dashboard dev-token bootstrap failed', err instanceof Error ? err.message : err)
       })
 
-    // Loopback dashboards can self-provision a dev bearer token. Do that before
-    // the first authenticated projections so the header auth badge and runtime
-    // stores do not briefly settle on an unauthenticated shell snapshot.
     void ensureLoopbackAuth()
       .finally(() => {
         if (cancelled) return
         void refreshShell({ light: true })
         requestNamespaceTruthNow()
 
-        // Fetch runtime thresholds so health-strip and lifecycle state use
-        // server-side config instead of compiled fallback defaults (P-DASH-07).
         void fetchDashboardConfig()
           .then(data => {
             const thresholds = parseContextThresholds(data, {
@@ -236,8 +185,6 @@ export function App() {
           })
       })
 
-    // Register mission refresh for periodic recovery from transient failures.
-    // Uses registration pattern to avoid circular imports.
     registerMissionRefresh(() => {
       void import('./mission-actions')
         .then(({ refreshMissionSnapshot }) => refreshMissionSnapshot())
@@ -246,16 +193,9 @@ export function App() {
         })
     })
 
-    // Setup SSE -> store reaction (debounced refresh on events)
     const unsubSSE = setupSSEReaction()
-
-    // Periodic refresh for keeper heartbeats (no SSE events)
     startPeriodicRefresh()
-
-    // Error notification cleanup (removes old acknowledged errors)
     startErrorCleanup()
-
-    // Detect a newer served bundle when the tab is picked up again
     const uninstallStalenessWatch = installBundleStalenessWatch()
 
     return () => {
@@ -270,12 +210,7 @@ export function App() {
   }, [])
 
   useEffect(() => {
-    // Cancel any pending SSE-triggered refreshes from the previous tab
-    // to prevent stale fetch results arriving after navigation (C-4/M-12).
     cancelPendingSSERefreshes()
-    // Swallow + log subscribe rejections (timeout / closed socket) here so
-    // they do not surface as Uncaught (in promise) noise in DevTools.  The
-    // ws layer owns reconnect on failure (see dashboard-ws.ts onopen path).
     subscribeDashboardRoute(route.value).catch(err => {
       console.warn('[dashboard] subscribeDashboardRoute failed', err)
     })
@@ -288,22 +223,9 @@ export function App() {
   const isMobile = useIsMobile()
 
   const currentTab = route.value.tab
-  const currentView = DASHBOARD_NAV_ITEMS.find(item => item.id === currentTab)
-  const currentSection = currentSectionForRoute(route.value)
-  // Keepers surface is sectionless (navigation `keepers: []`), so its breadcrumb
-  // tail is the keeper the chat is showing. Prefer the explicit route param,
-  // then fall back to the `selectedKeeper` signal (mirrors keeper-detail-page's
-  // tier-2 resolution) so the crumb still tracks the keeper when no route param
-  // is present. Reading `selectedKeeper.value` subscribes App to a single
-  // low-frequency signal — NOT the high-frequency keepers list (P0 perf).
-  // Mirrors the v2 design crumb `<surface> / <keeper.id>`.
-  const breadcrumbKeeper = currentTab === 'keepers'
-    ? (route.value.params.keeper?.trim() || selectedKeeper.value?.name || undefined)
-    : undefined
   const isCodeSurface = currentTab === 'code'
   const widgetSoloMode = isWidgetSoloRoute(route.value)
   const keeperDetailMode = isKeeperDetailDashboardRoute(route.value)
-  const mobileKeeperPane = isMobile && keeperDetailMode ? keeperMobilePane.value : null
   const focusMode = dashboardFocusMode.value
   const mobileDrawerOpen = isMobile && mobileMenuOpen.value
   const suppressFloatingChrome = shouldSuppressFloatingChrome({
@@ -316,26 +238,34 @@ export function App() {
     focusMode,
   })
 
-  // sync volt and theme to document root
+  // sync volt and theme to document root (skin-v2 voltage + paper theme)
   useEffect(() => {
     document.documentElement.setAttribute('data-volt', tweaksVolt.value)
     document.documentElement.setAttribute('data-theme', tweaksTheme.value === 'paper' ? 'paper' : '')
   }, [tweaksVolt.value, tweaksTheme.value])
 
+  const approvalsBadge = governanceData.value?.approval_queue?.length ?? 0
+
+  // Body grid columns. Desktop: nav rail (58px) + single content column. Mobile:
+  // a single 1fr column — the nav becomes a fixed bottom tab bar (.v2-nav.is-mnav),
+  // out of grid flow. (The keepers 4-column roster|chat|ctx grid is provided by
+  // the keeper-workspace layout, not here.)
+  const cols = isMobile ? '1fr' : '58px minmax(0,1fr)'
+
   return html`
     <div
-      class="v2-app flex min-h-screen h-screen flex-col overflow-hidden bg-[var(--color-bg-page)] text-[var(--color-fg-primary)]"
-      data-widget-solo=${widgetSoloMode ? 'true' : 'false'}
-      data-focus-mode=${focusMode ? 'true' : 'false'}
-      data-keeper-detail-mode=${keeperDetailMode ? 'true' : 'false'}
-      data-mobile=${isMobile ? 'true' : 'false'}
+      class="v2-app"
+      data-surface=${currentTab}
       data-density=${tweaksDensity.value}
       data-motion=${tweaksMotion.value}
       data-bubble=${tweaksBubble.value}
+      data-mobile=${isMobile ? '1' : null}
       data-font-scale=${tweaksFontScale.value}
       data-theme=${tweaksTheme.value === 'paper' ? 'paper' : null}
       data-volt=${tweaksVolt.value}
-      data-surface=${currentTab}
+      data-focus-mode=${focusMode ? 'true' : 'false'}
+      data-keeper-detail-mode=${keeperDetailMode ? 'true' : 'false'}
+      data-widget-solo=${widgetSoloMode ? 'true' : 'false'}
       style=${{
         // tweaksFontScale.value is a percentage integer (80..140, default 100).
         // craft-v2.css resolves it as `calc(var(--twk-font-scale) * 1%)`, so the
@@ -347,130 +277,27 @@ export function App() {
       }}
     >
       <${SkipLink} />
-      <header class="${compactChromeMode ? 'hidden' : 'relative v2-shell-header'} z-10 shrink-0 px-4 py-2">
-        <div class="absolute inset-x-0 bottom-0 h-[1px] bg-gradient-to-r from-transparent via-[var(--accent-15)] to-transparent"></div>
-        <div class="flex w-full items-center justify-between gap-3 max-[1080px]:flex-col max-[1080px]:items-stretch">
-          <div class="flex min-w-0 flex-1 items-center gap-3 max-[860px]:flex-wrap">
-            <div class="flex min-w-0 shrink-0 items-center gap-2.5 max-[520px]:w-full">
-              <button type="button"
-                class=${`${isMobile ? 'flex' : 'hidden'} size-11 items-center justify-center rounded-md border border-[var(--ss-border)] bg-[var(--ss-card)] text-[var(--ss-text-primary)] cursor-pointer transition-colors hover:bg-[var(--ss-surface-subtle)] ${ringFocusClasses({ tone: 'accent-medium', width: 2, offset: 2, offsetSurface: 'page' })}`}
-                aria-expanded=${mobileMenuOpen.value}
-                aria-label=${mobileMenuOpen.value ? 'Close navigation' : 'Open navigation'}
-                aria-controls="dashboard-side-rail"
-                onClick=${() => { mobileMenuOpen.value = !mobileMenuOpen.value }}
-              >
-                ${mobileMenuOpen.value ? html`<${X} size=${20} />` : html`<${Menu} size=${20} />`}
-              </button>
-              <div class="v2-header-brand flex min-w-0 items-stretch overflow-hidden rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
-                <div class="v2-header-mark flex w-12 shrink-0 flex-col items-center justify-center border-r border-[var(--color-border-default)] bg-[var(--accent-10)] px-2 py-1 font-display text-2xs font-semibold uppercase leading-none tracking-[0.12em] text-[var(--color-accent-fg)]">
-                  MASC
-                </div>
-                <div class="min-w-0 px-2.5 py-1">
-                  <div class="v2-header-crumb flex items-center gap-1.5 font-ui text-[var(--fs-10)] uppercase leading-none tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
-                    <span>${currentView?.label ?? 'Surface'}</span>
-                    ${breadcrumbKeeper
-                      ? html`
-                          <span class="text-[var(--color-warn)]">/</span>
-                          <span class="truncate">${breadcrumbKeeper}</span>
-                        `
-                      : currentSection && currentSection.label !== currentView?.label
-                      ? html`
-                          <span class="text-[var(--color-warn)]">/</span>
-                          <span class="truncate">${currentSection.label}</span>
-                        `
-                      : null}
-                  </div>
-                  ${/* No title heading here: each surface owns its primary header
-                       (single source of truth), so the global chrome shows only the
-                       crumb — matching the v2 design top bar, which carries a slim
-                       breadcrumb and no page title. A title here duplicated every
-                       surface-level heading/header. */ ''}
-                </div>
-              </div>
-            </div>
+      ${compactChromeMode ? null : html`<${TopBarV2} dock=${dock} />`}
 
-          </div>
-
-          <div class="v2-header-actions flex shrink-0 flex-wrap items-center justify-end gap-2 max-[1080px]:justify-between">
-            <div class="v2-app-header-status v2-desktop-header-only flex items-center gap-2" aria-label="대시보드 요약">
-              <span class="v2-statchip live" title="실행 중인 keeper 수 (shell 스냅샷 기준)">
-                <span class="inline-block size-2 rounded-full bg-[var(--color-status-ok)] shadow-[0_0_7px_rgb(var(--ok-glow)/0.75)] motion-safe:animate-pulse"></span>
-                ${shellCounts.value?.keepers ?? 0} 실행 중
-              </span>
-              <span class="v2-statchip" title="dashboard shell이 최근 서버 status를 수신했는지 여부">
-                서버 <b>${serverStatus.value ? '응답' : '—'}</b>
-              </span>
-            </div>
-            <${AttentionIndicator} />
-            <span class="contents" data-mobile-detail-keep><${EmergencyStopControl} /></span>
-            <${CopilotDockTopBarButton} dock=${dock} />
-            <${Suspense} fallback=${authStatusFallback()}>
-              <${LazyAuthStatus} />
-            <//>
-            <${ConnectionStatus} />
-            <${ErrorCounterBadge} />
-            <div class="v2-desktop-header-only"><${TransportBeacon} /></div>
-            <div class="v2-desktop-header-only"><${ThemeSwitch} /></div>
-            <div class="v2-desktop-header-only"><${TweaksPanelToggle} /></div>
-            <div class="v2-desktop-header-only"><${BuildIdentityBadge} /></div>
-          </div>
-        </div>
-      </header>
-
-      ${widgetSoloMode
-        ? html`
-          <div
-            class="flex shrink-0 flex-wrap items-center justify-end gap-2 border-b border-[var(--ss-border)] bg-[var(--ss-card)] px-3 py-1.5"
-            data-testid="dashboard-widget-solo-auth-strip"
-            aria-label="Solo view auth and runtime status"
-          >
-            <${Suspense} fallback=${authStatusFallback()}>
-              <${LazyAuthStatus} />
-            <//>
-            <${ConnectionStatus} />
-            <${ErrorCounterBadge} />
-          </div>
-        `
-        : null}
-      ${focusMode || keeperDetailMode ? null : html`
-        <${Suspense} fallback=${null}>
-          <${LazyRemoteWarningBanner} />
-        <//>
-        <${DashboardHealthStrip} />
-      `}
-
-      <div class=${compactChromeMode ? 'v2-shell-stage flex flex-1 overflow-hidden p-0' : 'v2-shell-stage flex flex-1 overflow-hidden max-[1100px]:flex-col'}>
-        ${compactChromeMode
-          ? null
-          : html`
-            <${DashboardNavRail}
-              currentTab=${currentTab}
-              mobile=${isMobile}
-              drawerOpen=${mobileMenuOpen.value}
-              hideMobileTabs=${mobileKeeperPane === 'chat'}
-              collapsed=${sidebarCollapsed.value}
-              onToggleCollapsed=${() => { sidebarCollapsed.value = !sidebarCollapsed.value }}
-              onToggleDrawer=${() => { mobileMenuOpen.value = !mobileMenuOpen.value }}
-              onCloseDrawer=${() => { mobileMenuOpen.value = false }}
-            />
-          `}
-
-        <div class="v2-stage min-h-0 flex-1">
+      <div class="v2-stage">
+        <div class="v2-body" style=${{ gridTemplateColumns: cols }}>
+          ${compactChromeMode ? null : html`<${NavRailV2} badges=${{ approvals: approvalsBadge }} mobile=${isMobile} />`}
           <main
             id="main-content"
             tabindex=${-1}
-            data-mpane=${mobileKeeperPane ?? undefined}
-            class="v2-body min-w-0 flex-1 overflow-hidden"
+            class="v2-surface-host"
+            style=${{ minWidth: 0, minHeight: 0, overflowY: 'auto' }}
           >
-            <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : keeperDetailMode ? 'h-full p-0' : focusMode ? 'dashboard-main-scroll h-full overflow-y-auto p-3 max-[520px]:p-2 max-[900px]:pb-16' : 'dashboard-main-scroll h-full overflow-y-auto p-4 max-[900px]:pb-16'}>
+            <div class=${isCodeSurface || widgetSoloMode ? 'h-full overflow-hidden p-0' : keeperDetailMode ? 'h-full p-0' : 'dashboard-main-scroll h-full p-4 max-[900px]:pb-16'}>
               <div class="v2-surface" key=${currentTab}>
                 <${DashboardMain} />
               </div>
             </div>
           </main>
-          ${dock.state.value.open ? html`<${CopilotDock} dock=${dock} />` : null}
         </div>
+        ${dock.state.value.open ? html`<${CopilotDock} dock=${dock} />` : null}
       </div>
+
       ${shouldShowCopilotFab({
         dockOpen: dock.state.value.open,
         compactChromeMode,

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -28,7 +28,8 @@ import { ensureDevToken } from './api/dev-token'
 import { fetchDashboardConfig, parseContextThresholds } from './api/dashboard'
 import { CONTEXT_RATIO_CRITICAL, CONTEXT_RATIO_WARN, CONTEXT_RATIO_COMPACTING } from './config/constants'
 import { setContextThresholds } from './config/context-thresholds'
-import { DashboardMain, isKeeperDetailDashboardRoute } from './components/dashboard-shell'
+import { DashboardMain, DashboardHealthStrip, isKeeperDetailDashboardRoute } from './components/dashboard-shell'
+import { RemoteWarningBanner } from './components/auth-status'
 import { SkipLink } from './components/skip-link'
 import { selectedAgentName } from './components/agent-detail-selection'
 import { selectedTask } from './components/goals/task-detail-selection'
@@ -278,6 +279,11 @@ export function App() {
     >
       <${SkipLink} />
       ${compactChromeMode ? null : html`<${TopBarV2} dock=${dock} />`}
+      ${/* Operational/safety strips re-mounted under the v2 top bar (review P1):
+          remote-auth warning + the runtime health chip bar. Both self-gate
+          (render null when there is no warning / no health signal). */ ''}
+      ${compactChromeMode ? null : html`<${RemoteWarningBanner} />`}
+      ${compactChromeMode ? null : html`<${DashboardHealthStrip} />`}
 
       <div class="v2-stage">
         <div class="v2-body" style=${{ gridTemplateColumns: cols }}>

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -302,6 +302,67 @@ export function rosterBlockerDisplay(
   return { cell, detail, title, kindLabel, rawKind }
 }
 
+// keeper-v2 Fleet skin (fleet.css .fl-*) helpers. The prototype keys every
+// chip / rail / aside-state on a 5-value tone vocabulary
+// (ok/warn/bad/busy/idle). masc's RuntimeBand collapses onto 4 of those via
+// ROSTER_BAND_TONE; the Korean tone label below is the same `FL_TONE_LABEL`
+// the prototype shipped, used for the aside "selected runtime" state line.
+type FleetTone = 'ok' | 'warn' | 'bad' | 'busy' | 'idle'
+
+const FL_TONE_LABEL: Record<FleetTone, string> = {
+  ok: '실행',
+  warn: '대기',
+  bad: '주의',
+  busy: '전이',
+  idle: '정지',
+}
+
+// CTX pressure threshold the prototype paints `hot` at (>=85%). Mirrors the
+// existing live threshold used in the aside CTX meter so both surfaces agree.
+const FLEET_CTX_HOT_PCT = 85
+
+type FleetVital = { k: string; v: string }
+
+// Build the aside `런타임` vitals grid from real keeper runtime fields only.
+// Fields with no live source (e.g. tps) are omitted rather than fabricated —
+// the audit (P1-6) flags `tps` as having no roster-model source.
+function fleetRuntimeVitals(
+  keeper: Keeper | null,
+  contextDetail: string | null,
+): FleetVital[] {
+  if (!keeper) return []
+  const vitals: FleetVital[] = []
+
+  const model = (keeper.active_model ?? keeper.model ?? keeper.last_model_used ?? '')
+    .trim()
+    .replace('claude-', '')
+  if (model) vitals.push({ k: 'model', v: model })
+
+  const runtime = (keeper.runtime_canonical ?? keeper.selected_runtime_canonical ?? '').trim()
+  if (runtime) vitals.push({ k: 'runtime', v: runtime })
+
+  if (typeof keeper.keeper_age_s === 'number' && Number.isFinite(keeper.keeper_age_s)) {
+    vitals.push({ k: 'uptime', v: formatDuration(keeper.keeper_age_s) })
+  }
+
+  const turns = keeper.total_turns ?? keeper.turn_count ?? null
+  if (typeof turns === 'number' && Number.isFinite(turns)) {
+    vitals.push({ k: 'turns', v: String(turns) })
+  }
+
+  const openTasks = keeper.goal_progress?.open_task_count
+  const doneTasks = keeper.goal_progress?.done_task_count
+  if (typeof openTasks === 'number' || typeof doneTasks === 'number') {
+    const open = typeof openTasks === 'number' ? openTasks : 0
+    const done = typeof doneTasks === 'number' ? doneTasks : 0
+    vitals.push({ k: 'tasks', v: `${open} / ${done}` })
+  }
+
+  if (contextDetail) vitals.push({ k: 'context', v: contextDetail })
+
+  return vitals
+}
+
 function registerKeeperLookup<T extends Pick<Keeper, 'keeper_id' | 'name' | 'agent_name'>>(
   lookup: Map<string, T>,
   source: T,
@@ -997,13 +1058,154 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     ? rosterBlockerDisplay(selectedRow.stateNote, selectedRow.keeperRuntime)
     : null
 
+  // keeper-v2 Fleet skin: partition the (already sorted) rows into an
+  // "attention" group and the steady remainder so the roster renders the
+  // prototype's `fl-group attn` / `fl-group` dividers + tone-rail rows.
+  // Sorting already pushes attention band to the top (see `filtered` order),
+  // so partitioning preserves order within each group.
+  const attentionRows = rosterRows.filter(row => row.band.key === 'attention')
+  const steadyRows = rosterRows.filter(row => row.band.key !== 'attention')
+
+  // Health pills (fl-hpill) read from the same band counts the status filter
+  // chips already compute. No title here — the shell's SurfaceLead owns the
+  // "Keeper Fleet" header for this surface (dashboard-shell SURFACE_OWN_LEAD).
+  const healthRun = counts.active
+  const healthPaused = counts.paused
+  const healthOffline = counts.offline
+  const healthAttention = counts.attention
+
+  const selectedTone: FleetTone = selectedRow ? ROSTER_BAND_TONE[selectedRow.band.key] : 'idle'
+  const selectedCtxPct = selectedRow?.contextMeta?.pct ?? null
+  const selectedCtxHot = selectedCtxPct != null && selectedCtxPct >= FLEET_CTX_HOT_PCT
+  const selectedVitals = selectedRow
+    ? fleetRuntimeVitals(selectedRow.keeperRuntime, selectedRow.contextMeta?.detail ?? null)
+    : []
+  const selectedKeeperId = selectedRow?.keeperRuntime?.keeper_id?.trim() || null
+  const selectedKoreanName = selectedRow?.keeperRuntime?.koreanName?.trim()
+    || selectedRow?.agent.koreanName?.trim()
+    || null
+
+  // Render one fleet roster row (.fl-row), layered with the live classes /
+  // test-ids the tests + CSS rely on (v2-monitoring-roster-row, data-tone,
+  // data-testid). The grid track comes from .fl-row (var(--fl-cols)).
+  const renderFleetRow = (row: (typeof rosterRows)[number]) => {
+    const selected = selectedRow?.key === row.key
+    const tone = ROSTER_BAND_TONE[row.band.key]
+    const blockerDisplay = rosterBlockerDisplay(row.stateNote, row.keeperRuntime)
+    const stageLabel =
+      row.fsmStageText
+      ?? row.monitoringEvidence?.phase?.label
+      ?? row.monitoringEvidence?.stage?.label
+      ?? null
+    // chip text: band label (운영판정) so the operational verdict reads first,
+    // matching the legacy column the tests + operators rely on. gloss line:
+    // blocker reason when present, else the stage/phase label. The band action
+    // hint (재개 대기 / 기동 필요 / 감시 중 / 연결 없음) renders as a second
+    // muted line. All fall back to honest copy, never faked.
+    const chipLabel = row.band.label
+    const glossText = row.stateNote
+      ? blockerDisplay.cell
+      : (stageLabel ?? '실행 중')
+    const glossTitle = row.stateNote ? blockerDisplay.title : (stageLabel ?? '')
+    const latestTool = row.recentTools[0] ?? (row.toolCallCount != null && row.toolCallCount > 0 ? `${row.toolCallCount} calls` : '—')
+    const ctxPct = row.contextMeta?.pct ?? null
+    const ctxHot = ctxPct != null && ctxPct >= FLEET_CTX_HOT_PCT
+    // namespace line: keeper id is the closest stable namespace handle the
+    // roster row model carries; agents without a keeper runtime show none.
+    const namespaceLine = row.keeperRuntime?.keeper_id?.trim()
+      || row.keeperRuntime?.agent_name?.trim()
+      || null
+
+    const handleRowKey = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        setSelectedKey(row.key)
+      }
+    }
+
+    return html`
+      <div
+        role="button"
+        tabIndex=${0}
+        key=${row.key}
+        data-testid="keeper-operations-row"
+        data-tone=${tone}
+        aria-label=${`${row.displayName} 선택`}
+        aria-pressed=${selected}
+        onClick=${() => setSelectedKey(row.key)}
+        onKeyDown=${handleRowKey}
+        class="fl-row v2-monitoring-roster-row ${selected ? 'sel' : ''} ${ringFocusClasses({ tone: 'accent-fg', width: 2 })}"
+      >
+        <div class="fl-id">
+          <span class="shrink-0">
+            <${AgentAvatar}
+              name=${row.agent.name}
+              status=${row.presenceDisplay.status}
+              traits=${row.agent.traits}
+              size="md"
+              currentWork=${row.currentWork}
+              activityAge=${row.lastActivityAge}
+            />
+          </span>
+          <div class="fl-id-txt">
+            <div class="fl-name">
+              <b>${row.displayName}</b>
+              ${row.band.key === 'attention' ? html`<span class="fl-att">▲</span>` : null}
+            </div>
+            <div class="mt-0.5 flex flex-wrap items-center gap-1.5 text-2xs text-[var(--color-fg-secondary)]">
+              <${AgentPresence} status=${row.presenceDisplay.status} detail=${row.presenceDisplay.detail} size="sm" />
+            </div>
+            ${namespaceLine ? html`<div class="fl-ns">${namespaceLine}</div>` : null}
+          </div>
+        </div>
+
+        <div class="fl-state">
+          <span class="fl-chip" data-tone=${tone} title=${row.band.description}>
+            <span class="inline-block h-1.5 w-1.5 rounded-full" style="background:currentColor" aria-hidden="true"></span>
+            ${chipLabel}
+          </span>
+          <span class="fl-gloss" title=${glossTitle}>${glossText}</span>
+          <span class="fl-gloss">${row.bandActionHint}</span>
+        </div>
+
+        <div class="fl-ctx">
+          ${ctxPct != null
+            ? html`
+                <div class="fl-ctx-bar"><span class=${ctxHot ? 'hot' : ''} style="width:${ctxPct}%"></span></div>
+                <span class="fl-ctx-val ${ctxHot ? 'hot' : ctxPct === 0 ? 'zero' : ''}">${ctxPct}%</span>
+              `
+            : html`<span class="fl-ctx-val zero" data-stub="no context_ratio">—</span>`}
+        </div>
+
+        <div class="fl-tool ${row.recentTools.length || (row.toolCallCount ?? 0) > 0 ? '' : 'none'}" title=${latestTool}>${latestTool}</div>
+
+        <div class="fl-actcell" onClick=${(e: Event) => e.stopPropagation()}>
+          ${row.keeperRuntime
+            ? html`<${KeeperActionButtons}
+                keeper=${row.keeperRuntime}
+                size="sm"
+                compact
+                stopPropagation
+              />`
+            : html`<span class="text-2xs text-[var(--color-fg-muted)]">—</span>`}
+        </div>
+      </div>
+    `
+  }
+
   return html`
-    <div class="v2-monitoring-surface agent-page flex w-full flex-col gap-5 px-0 py-1">
+    <div class="v2-monitoring-surface fl-shell agent-page">
       <section class="monitor-surface-card monitor-surface-card-strong v2-monitoring-card p-5" aria-label="에이전트 디렉터리">
         <div class="flex flex-col gap-5">
           <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
-            <div class="flex min-w-0 flex-col gap-2">
-              <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]">${resultCountLabel}</span>
+            <div class="flex min-w-0 flex-col gap-2.5">
+              <div class="fl-health">
+                <span class="fl-hpill ok">런타임 가동 <b>${healthRun}</b></span>
+                <span class="fl-hpill warn">일시정지 <b>${healthPaused}</b></span>
+                <span class="fl-hpill">오프라인 <b>${healthOffline}</b></span>
+                ${healthAttention > 0 ? html`<span class="fl-hpill bad">주의 <b>${healthAttention}</b></span>` : null}
+              </div>
+              <span class="inline-flex w-fit items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]">${resultCountLabel}</span>
             </div>
 
             <label class="flex w-full flex-col gap-2 text-2xs font-semibold tracking-[var(--track-caps)] text-[var(--color-fg-muted)] uppercase">
@@ -1054,119 +1256,33 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         </div>
       </section>
 
-      <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
-        <section class="monitor-surface-card monitor-surface-card-medium v2-monitoring-panel overflow-hidden" aria-label="Keeper operations list">
+      <div class="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_372px]">
+        <section class="fl-main monitor-surface-card monitor-surface-card-medium v2-monitoring-panel overflow-hidden" aria-label="Keeper operations list">
           <!--
-            2026-05-27 KEEPER OPERATIONS row redesign:
-            - 현재 단계 column was almost always "-" for stuck keepers (the
-              dominant case the surface exists for) and duplicated the
-              SELECTED RUNTIME phase badge. Removed; the blocker/stage cell
-              now switches: blocker text when blocked, stage/phase label
-              when running.
-            - Row is now div role=button so inline action buttons
-              (재개 / 일시정지 / 깨우기 / 기동 / 종료) can be nested without
-              violating no-button-in-button HTML. Enter/Space keep
-              keyboard selection working.
-            - 차단 근거 셀이 truncate(1줄) 였던 것을 line-clamp-2 로 풀어 잘림을 완화.
+            keeper-v2 Fleet skin (fleet.css .fl-*): roster header + tone-rail
+            rows + attention/steady group dividers. The shell's SurfaceLead
+            owns the "Keeper Fleet" title for this surface, so this body
+            renders NO top-level page header (avoids the prior duplicate-header
+            regression). Live wiring (selection, filters, actions, presence) is
+            unchanged — only the markup/class tree is reskinned.
+
+            Column header labels keep 운영판정 / 차단 · 단계 / 액션 so existing
+            tests + operators read the same axis names; the cells below fold
+            them into the fl-state chip + fl-gloss as the prototype does.
           -->
-          <div class="grid grid-cols-[minmax(180px,1.35fr)_minmax(80px,0.5fr)_minmax(170px,1.1fr)_minmax(110px,0.65fr)_minmax(160px,0.9fr)] gap-3 border-b border-[var(--color-border-divider)] px-4 py-2.5 text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)] max-lg:hidden">
+          <div class="fl-rhead">
             <span>Keeper</span>
-            <span>운영판정</span>
-            <span>차단 · 단계</span>
+            <span>운영판정 · 차단 · 단계</span>
+            <span>컨텍스트</span>
             <span>최근 도구</span>
-            <span>액션</span>
+            <span class="r">액션</span>
           </div>
 
-          <div class="divide-y divide-[var(--color-border-divider)]">
-            ${rosterRows.map(row => {
-              const selected = selectedRow?.key === row.key
-              const blockerDisplay = rosterBlockerDisplay(row.stateNote, row.keeperRuntime)
-              const stageLabel =
-                row.fsmStageText
-                ?? row.monitoringEvidence?.phase?.label
-                ?? row.monitoringEvidence?.stage?.label
-                ?? null
-              // 차단이 있으면 차단 근거가 더 의미 있고, 차단이 없으면 현재 단계 라벨로 fallback.
-              // 둘 다 없으면 '-'.
-              const blockerOrStage = row.stateNote
-                ? blockerDisplay.cell
-                : (stageLabel ?? '-')
-              const blockerOrStageTitle = row.stateNote
-                ? blockerDisplay.title
-                : (stageLabel ?? '')
-              const latestTool = row.recentTools[0] ?? (row.toolCallCount != null && row.toolCallCount > 0 ? `${row.toolCallCount} calls` : '-')
-
-              const handleRowKey = (e: KeyboardEvent) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  setSelectedKey(row.key)
-                }
-              }
-
-              return html`
-                <div
-                  role="button"
-                  tabIndex=${0}
-                  key=${row.key}
-                  data-testid="keeper-operations-row"
-                  data-tone=${ROSTER_BAND_TONE[row.band.key]}
-                  aria-label=${`${row.displayName} 선택`}
-                  aria-pressed=${selected}
-                  onClick=${() => setSelectedKey(row.key)}
-                  onKeyDown=${handleRowKey}
-                  class="v2-monitoring-roster-row grid w-full cursor-pointer grid-cols-1 gap-2 px-4 py-3 text-left transition-colors hover:bg-[var(--color-bg-elevated)] ${ringFocusClasses({ tone: 'accent-fg', width: 2 })} lg:grid-cols-[minmax(180px,1.35fr)_minmax(80px,0.5fr)_minmax(170px,1.1fr)_minmax(110px,0.65fr)_minmax(160px,0.9fr)] lg:items-center lg:gap-3 ${selected ? 'bg-[var(--color-bg-hover)]' : 'bg-transparent'}"
-                >
-                  <span class="flex min-w-0 items-center gap-3">
-                    <span class="shrink-0">
-                      <${AgentAvatar}
-                        name=${row.agent.name}
-                        status=${row.presenceDisplay.status}
-                        traits=${row.agent.traits}
-                        size="md"
-                        currentWork=${row.currentWork}
-                        activityAge=${row.lastActivityAge}
-                      />
-                    </span>
-                    <span class="min-w-0">
-                      <span class="block truncate text-sm font-semibold text-[var(--color-fg-primary)]">${row.displayName}</span>
-                      <span class="mt-0.5 flex flex-wrap items-center gap-1.5 text-2xs text-[var(--color-fg-secondary)]">
-                        <${AgentPresence} status=${row.presenceDisplay.status} detail=${row.presenceDisplay.detail} size="sm" />
-                      </span>
-                    </span>
-                  </span>
-
-                  <span
-                    class="inline-flex w-fit min-w-[4.5rem] flex-col items-start rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1 text-2xs font-medium leading-tight text-[var(--color-fg-primary)] lg:w-auto"
-                    title=${row.band.description}
-                  >
-                    <span>${row.band.label}</span>
-                    <span class="mt-0.5 text-2xs font-normal text-[var(--color-fg-secondary)]">${row.bandActionHint}</span>
-                  </span>
-
-                  <span class="min-w-0 text-xs leading-snug text-[var(--color-fg-primary)]">
-                    <span class="block truncate lg:hidden text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">차단 · 단계</span>
-                    <span class="line-clamp-2 break-words" title=${blockerOrStageTitle}>${blockerOrStage}</span>
-                  </span>
-
-                  <span class="min-w-0 text-xs leading-snug text-[var(--color-fg-primary)]">
-                    <span class="block truncate lg:hidden text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">최근 도구</span>
-                    <span class="block truncate" title=${latestTool}>${latestTool}</span>
-                  </span>
-
-                  <span class="min-w-0">
-                    <span class="block lg:hidden text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">액션</span>
-                    ${row.keeperRuntime
-                      ? html`<${KeeperActionButtons}
-                          keeper=${row.keeperRuntime}
-                          size="sm"
-                          compact
-                          stopPropagation
-                        />`
-                      : html`<span class="text-2xs text-[var(--color-fg-muted)]">—</span>`}
-                  </span>
-                </div>
-              `
-            })}
+          <div class="fl-roster">
+            ${attentionRows.length > 0 ? html`<div class="fl-group attn">주의 필요 · ${attentionRows.length}</div>` : null}
+            ${attentionRows.map(renderFleetRow)}
+            ${steadyRows.length > 0 ? html`<div class="fl-group">정상 · ${steadyRows.length}</div>` : null}
+            ${steadyRows.map(renderFleetRow)}
 
             ${rosterRows.length === 0 ? html`
               <div class="px-6 py-10">
@@ -1183,45 +1299,79 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           </div>
         </section>
 
-        <aside class="monitor-surface-card monitor-surface-card-medium v2-monitoring-panel p-4" aria-label="Selected keeper detail">
+        <aside class="fl-aside monitor-surface-card monitor-surface-card-medium v2-monitoring-panel" aria-label="Selected keeper detail">
           ${selectedRow ? html`
-            <div class="flex h-full flex-col gap-4">
-              <div class="flex items-start justify-between gap-3">
-                <div class="min-w-0">
-                  <span class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">selected runtime</span>
-                  <h3 class="m-0 mt-1 truncate text-xl font-semibold text-[var(--color-fg-primary)]">${selectedRow.displayName}</h3>
+            <div class="fl-as-head">
+              <span class="fl-as-ey">selected runtime</span>
+              <span class="fl-as-state">
+                <span class="inline-block h-1.5 w-1.5 rounded-full" style="background:currentColor" aria-hidden="true"></span>
+                ${FL_TONE_LABEL[selectedTone]}
+              </span>
+            </div>
+
+            <div class="fl-as-id">
+              <span class="shrink-0">
+                <${AgentAvatar}
+                  name=${selectedRow.agent.name}
+                  status=${selectedRow.presenceDisplay.status}
+                  traits=${selectedRow.agent.traits}
+                  size="lg"
+                  currentWork=${selectedRow.currentWork}
+                  activityAge=${selectedRow.lastActivityAge}
+                />
+              </span>
+              <div class="min-w-0">
+                <h3 class="fl-as-name m-0 truncate">${selectedRow.displayName}</h3>
+                ${selectedKoreanName || selectedKeeperId ? html`
+                  <div class="fl-as-kr">
+                    ${selectedKoreanName ?? ''}
+                    ${selectedKoreanName && selectedKeeperId ? ' · ' : ''}
+                    ${selectedKeeperId ? html`<span class="font-mono">${selectedKeeperId}</span>` : null}
+                  </div>
+                ` : null}
+                <div class="mt-1.5 flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-secondary)]">
+                  <${AgentPresence} status=${selectedRow.presenceDisplay.status} detail=${selectedRow.presenceDisplay.detail} size="sm" />
+                  <span class="inline-flex items-center gap-1 text-[var(--color-fg-muted)]">
+                    ${selectedRow.lastActivityLabel}
+                    <span class="text-[var(--color-fg-primary)]">
+                      ${selectedRow.lastActivityAt
+                        ? html`<${TimeAgo} timestamp=${selectedRow.lastActivityAt} />`
+                        : selectedRow.lastActivityAge != null
+                          ? `${formatDuration(selectedRow.lastActivityAge)} 전`
+                          : '기록 없음'}
+                    </span>
+                  </span>
                 </div>
-                <${AgentPresence} status=${selectedRow.presenceDisplay.status} detail=${selectedRow.presenceDisplay.detail} size="sm" />
               </div>
+            </div>
 
-              <p class="m-0 text-sm leading-paragraph text-[var(--color-fg-primary)]" title=${selectedRow.summaryText}>${selectedRow.summaryText}</p>
+            <div class="fl-as-cta">
+              <button
+                type="button"
+                class="fl-open-chat v2-monitoring-action"
+                aria-label=${selectedRow.detailLabel}
+                onClick=${selectedRow.openDetail}
+              >
+                <span>상세 열기</span><span class="arr">▸</span>
+              </button>
+            </div>
 
-              <div class="flex flex-wrap items-center gap-2">
+            <div class="fl-as-sec">
+              <div class="fl-as-phase">
                 ${selectedRow.isKeeper && selectedRow.fsmPhaseKey
                   ? html`<${KeeperPhaseBadge} phase=${selectedRow.fsmPhaseKey} compact />`
-                  : null}
+                  : html`<span class="fl-chip" data-tone=${selectedTone}>${selectedRow.band.label}</span>`}
                 ${selectedRow.fsmStageKey && selectedRow.fsmStageText ? html`
                   <span class="inline-flex items-center rounded-[var(--r-0)] border px-2 py-0.5 text-2xs font-medium ${stageBadgeClass(selectedRow.fsmStageKey)}" title=${selectedRow.monitoringEvidence?.stage?.description ?? '활동 단계 정보가 없습니다.'}>
                     ${selectedRow.fsmStageText}
                   </span>
                 ` : null}
-                <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs text-[var(--color-fg-muted)]" title=${selectedRow.band.description}>
-                  상태 액션
-                  <span class="ml-1 text-[var(--color-fg-primary)]">${selectedRow.bandActionHint}</span>
-                </span>
-                <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs text-[var(--color-fg-muted)]">
-                  ${selectedRow.lastActivityLabel}
-                  <span class="ml-1 text-[var(--color-fg-primary)]">
-                    ${selectedRow.lastActivityAt
-                      ? html`<${TimeAgo} timestamp=${selectedRow.lastActivityAt} />`
-                      : selectedRow.lastActivityAge != null
-                        ? `${formatDuration(selectedRow.lastActivityAge)} 전`
-                        : '기록 없음'}
-                  </span>
-                </span>
               </div>
+              <div class="fl-as-gloss">${selectedRow.summaryText}</div>
+            </div>
 
-              ${selectedRow.stateNote ? html`
+            ${selectedRow.stateNote ? html`
+              <div class="fl-as-sec">
                 <div class="rounded-[var(--r-1)] border border-[var(--warn-20)] bg-[var(--warn-10)] px-3 py-2.5">
                   <div class="flex flex-wrap items-center gap-2">
                     <span class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-status-warn)]">${selectedRow.stateNote.label}</span>
@@ -1234,22 +1384,38 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   </div>
                   <p class="m-0 mt-1 text-xs leading-relaxed text-[var(--color-fg-primary)]">${selectedBlockerDisplay?.detail}</p>
                 </div>
-              ` : null}
+              </div>
+            ` : null}
 
-              ${selectedRow.contextMeta ? html`
-                <div class="flex items-center gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-xs text-[var(--color-fg-muted)]">
-                  <span class="font-semibold uppercase tracking-[var(--track-caps)]">CTX</span>
-                  <span class="font-mono text-[var(--color-fg-secondary)]">${selectedRow.contextMeta.pct}%</span>
-                  ${selectedRow.contextMeta.detail ? html`<span class="font-mono text-2xs">${selectedRow.contextMeta.detail}</span>` : null}
-                  <span class="ml-auto inline-block h-1.5 w-20 overflow-hidden rounded-[var(--r-0)] bg-[var(--color-bg-hover)]">
-                    <span class="block h-full rounded-[var(--r-0)] ${selectedRow.contextMeta.pct > 85 ? 'bg-[var(--color-status-err)]' : selectedRow.contextMeta.pct > 60 ? 'bg-[var(--color-status-warn)]' : 'bg-[var(--color-status-ok)]'}" style="width:${selectedRow.contextMeta.pct}%"></span>
-                  </span>
+            ${selectedCtxPct != null ? html`
+              <div class="fl-as-sec">
+                <h4>컨텍스트 압박</h4>
+                <div class="fl-ctxbig">
+                  <div class="fl-ctxbig-top">
+                    <span class="v ${selectedCtxHot ? 'hot' : ''}">${selectedCtxPct}%</span>
+                    <span class="l">${selectedCtxHot ? 'compact 임계 근접' : 'window 사용량'}</span>
+                  </div>
+                  <div class="bar"><span class=${selectedCtxHot ? 'hot' : ''} style="width:${selectedCtxPct}%"></span></div>
+                  ${selectedRow.contextMeta?.detail ? html`<div class="mt-1.5 font-mono text-2xs text-[var(--color-fg-muted)]">${selectedRow.contextMeta.detail}</div>` : null}
                 </div>
-              ` : null}
+              </div>
+            ` : null}
 
-              ${(selectedRow.recentTools.length > 0 || selectedRow.toolCallCount != null || selectedRow.toolAuditAt) ? html`
+            ${selectedVitals.length > 0 ? html`
+              <div class="fl-as-sec">
+                <h4>런타임</h4>
+                <div class="fl-vitals">
+                  ${selectedVitals.map(vital => html`
+                    <div class="fl-vital"><div class="k">${vital.k}</div><div class="v">${vital.v}</div></div>
+                  `)}
+                </div>
+              </div>
+            ` : null}
+
+            ${(selectedRow.recentTools.length > 0 || selectedRow.toolCallCount != null || selectedRow.toolAuditAt) ? html`
+              <div class="fl-as-sec">
+                <h4>최근 도구</h4>
                 <div class="flex flex-wrap items-center gap-1.5 text-2xs text-[var(--color-fg-muted)]">
-                  <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5">최근 도구</span>
                   <${AgentCapability} tools=${selectedRow.recentTools} maxVisible=${5} />
                   ${selectedRow.toolCallCount != null && selectedRow.toolCallCount > 0 ? html`
                     <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs">${selectedRow.toolCallCount}회 관찰됨</span>
@@ -1258,52 +1424,50 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                     <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5 text-2xs">감사 <${TimeAgo} timestamp=${selectedRow.toolAuditAt} /></span>
                   ` : null}
                 </div>
-              ` : null}
-
-              ${selectedRow.keeperRuntime ? html`
-                <div class="grid gap-2 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3">
-                  <div class="text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">detail lenses</div>
-                  <div class="flex flex-wrap gap-2">
-                    <${RouteLink}
-                      tab="monitoring"
-                      params=${{ section: 'cognition', view: 'keeper', keeper: selectedRow.keeperRuntime.name, focus: 'bdi' }}
-                      class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)]"
-                    >
-                      Cognition
-                    <//>
-                    <${RouteLink}
-                      tab="monitoring"
-                      params=${{ section: 'cognition', view: 'keeper', keeper: selectedRow.keeperRuntime.name, focus: 'tool-access' }}
-                      class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)]"
-                    >
-                      Tool Access
-                    <//>
-                    <${RouteLink}
-                      tab="monitoring"
-                      params=${{ section: 'runtime', view: 'inspector', keeper: selectedRow.keeperRuntime.name }}
-                      class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)]"
-                    >
-                      Runtime Trace
-                    <//>
-                  </div>
-                </div>
-              ` : null}
-
-              <div class="mt-auto flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  class="v2-monitoring-action inline-flex items-center justify-center rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-3 py-2 text-xs font-medium text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--accent-20)]"
-                  aria-label=${selectedRow.detailLabel}
-                  onClick=${selectedRow.openDetail}
-                >
-                  상세 열기
-                </button>
               </div>
-            </div>
+            ` : null}
+
+            ${selectedRow.keeperRuntime ? html`
+              <div class="fl-as-sec">
+                <h4>상세 렌즈</h4>
+                <div class="flex flex-wrap gap-2">
+                  <${RouteLink}
+                    tab="monitoring"
+                    params=${{ section: 'cognition', view: 'keeper', keeper: selectedRow.keeperRuntime.name, focus: 'bdi' }}
+                    class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)]"
+                  >
+                    Cognition
+                  <//>
+                  <${RouteLink}
+                    tab="monitoring"
+                    params=${{ section: 'cognition', view: 'keeper', keeper: selectedRow.keeperRuntime.name, focus: 'tool-access' }}
+                    class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)]"
+                  >
+                    Tool Access
+                  <//>
+                  <${RouteLink}
+                    tab="monitoring"
+                    params=${{ section: 'runtime', view: 'inspector', keeper: selectedRow.keeperRuntime.name }}
+                    class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2.5 py-1.5 text-xs font-medium text-[var(--color-fg-primary)] transition-colors hover:bg-[var(--color-bg-hover)]"
+                  >
+                    Runtime Trace
+                  <//>
+                </div>
+              </div>
+            ` : null}
           ` : html`
-            <${EmptyState} message="선택할 keeper 또는 agent가 없습니다." compact />
+            <div class="fl-as-sec">
+              <${EmptyState} message="선택할 keeper 또는 agent가 없습니다." compact />
+            </div>
           `}
         </aside>
+      </div>
+
+      <div class="fl-foot">
+        <span class="fl-tick"><span class="k">keepers</span><span class="v">fresh ${healthRun}/${rosterRows.length}</span></span>
+        <span class="fl-tick"><span class="k">paused</span><span class="v">${healthPaused}</span></span>
+        <span class="fl-tick"><span class="k">offline</span><span class="v">${healthOffline}</span></span>
+        <span class="fl-tick"><span class="k">attention</span><span class="v ${healthAttention ? 'warn' : 'ok'}">${healthAttention}</span></span>
       </div>
     </div>
   `

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -37,6 +37,24 @@ function apSev(riskLevel: string | null | undefined): KeeperApprovalRiskVisualBa
   return keeperApprovalRiskVisualBand(riskLevel)
 }
 
+// Prototype's .ap-kind chip leads with a glyph (data.jsx APPROVAL_KIND). The live
+// queue item has no `kind` taxonomy field, so we do NOT fabricate a kind glyph;
+// instead the chip leads with a glyph derived from the real risk visual band —
+// the icon affordance the prototype shows, keyed only off data we actually have.
+// Exhaustive over KeeperApprovalRiskVisualBand so a new band is a compile error.
+function apSevGlyph(band: KeeperApprovalRiskVisualBand): string {
+  switch (band) {
+    case 'bad':
+      return '⚠' // ⚠ destructive / irreversible
+    case 'warn':
+      return '▲' // ▲ elevated
+    case 'accent':
+      return '◆' // ◆ moderate
+    case 'info':
+      return '●' // ● low
+  }
+}
+
 // seconds-waited → "N분 N초 대기" (prototype apAge).
 function apAge(sec: number | null | undefined): string {
   const s = Math.max(0, Math.round(sec ?? 0))
@@ -141,7 +159,7 @@ function ApprovalCard({
       <div class="ap-rail"></div>
       <div class="ap-main">
         <div class="ap-h">
-          <span class=${`ap-kind sev-${sev}`}>${keeperApprovalRiskLabel(item.risk_level)}</span>
+          <span class=${`ap-kind sev-${sev}`}>${apSevGlyph(sev)} ${keeperApprovalRiskLabel(item.risk_level)}</span>
           <span class="ap-tool mono">${item.tool_name}</span>
           <span class="ap-id mono">${item.id}</span>
           <span class=${`ap-age sev-${sev}`}>${apAge(item.waiting_s)}</span>
@@ -233,7 +251,7 @@ function ApprovalDetailPanel({
       data-approval-id=${item.id}
     >
       <div class="ap-detail-panel-head">
-        <span class=${`ap-kind sev-${sev}`}>${keeperApprovalRiskLabel(item.risk_level)}</span>
+        <span class=${`ap-kind sev-${sev}`}>${apSevGlyph(sev)} ${keeperApprovalRiskLabel(item.risk_level)}</span>
         <div class="ap-detail-panel-title">
           <strong>${approvalTitle(item)}</strong>
           <span class="mono">${item.id}</span>
@@ -277,6 +295,7 @@ export function ApprovalsSurface() {
       <div class="ov-scroll">
         <header class="ov-head">
           <div>
+            <span class="ov-eyebrow">HITL</span>
             <h1>승인 · HITL 큐</h1>
             <p class="ov-sub">
               keeper가 위험·비가역 행동 전 결재를 청한 항목 ·
@@ -296,7 +315,7 @@ export function ApprovalsSurface() {
             <div class=${`ov-kpi-v ${items.length ? 'warn' : 'ok'}`}>${items.length}</div>
           </div>
           <div class="ov-kpi">
-            <div class="ov-kpi-k">위험 · 높음</div>
+            <div class="ov-kpi-k">비가역 · 위험</div>
             <div class=${`ov-kpi-v ${stats.risky ? 'bad' : ''}`}>${stats.risky}</div>
           </div>
           <div class="ov-kpi">

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -12,7 +12,6 @@ import { Select } from '../common/select'
 import { Checkbox } from '../common/checkbox'
 import { RichContent } from '../common/rich-content'
 import { CursorPagination } from '../common/pagination'
-import { SurfaceHeader } from '../common/surface-header'
 import { stripStateBlocks } from '../../keeper-message'
 import { route } from '../../router'
 import { keepers as dashboardKeepers, messages, refreshExecution } from '../../store'
@@ -526,12 +525,15 @@ function PostCard({ post }: { post: BoardPost }) {
 }
 
 // ── v2 board chrome ────────────────────────────────────────────────
+// Glyph vocabulary mirrors the keeper-v2 prototype (data-surfaces.jsx:7-12):
+// all→◈, incidents→⚠, watercooler→◌, every other hearth→⌗. Live hearth
+// names are data-driven, so the generic ⌗ default matches the prototype's
+// per-hearth glyph while the two named specials keep their prototype glyphs.
 const SUB_BOARD_GLYPHS: Record<string, string> = {
-  all: '＃',
-  ops: '⚙',
-  review: '⚖',
-  notice: '▣',
-  default: '＃',
+  all: '◈',
+  incidents: '⚠',
+  watercooler: '◌',
+  default: '⌗',
 }
 
 function countMentionMessages(): number {
@@ -590,13 +592,17 @@ function BdRail({ activeSub, onSub, onMentions }: {
   `
 }
 
-function BdFeedHead({ activeFilter, onFilter, count }: {
+function BdFeedHead({ activeFilter, onFilter, count, contentQuery, onContentQuery }: {
   activeFilter: 'all' | 'state' | 'mod'
   onFilter: (filter: 'all' | 'state' | 'mod') => void
   count: number
+  contentQuery: string
+  onContentQuery: (value: string) => void
 }) {
   const activeHearth = boardHearthFilter.value
-  const title = activeHearth === '' ? '전체 피드' : `#${activeHearth}`
+  // Prototype board.jsx:158 renders the bare hearth label (e.g. "core/scheduler")
+  // with no "#" prefix; the hearth name already carries its namespace path.
+  const title = activeHearth === '' ? '전체 피드' : activeHearth
   const filters: Array<{ key: 'all' | 'state' | 'mod'; label: string }> = [
     { key: 'all', label: '전체' },
     { key: 'state', label: '상태 블록' },
@@ -607,6 +613,14 @@ function BdFeedHead({ activeFilter, onFilter, count }: {
     <div class="bd-feed-head">
       <h2>${title}</h2>
       <span class="ns">${count}개 포스트</span>
+      <${TextInput}
+        type="search"
+        value=${contentQuery}
+        placeholder="제목/본문에서 검색"
+        ariaLabel="게시글 본문 필터"
+        onInput=${(e: Event) => onContentQuery((e.target as HTMLInputElement).value)}
+        class="min-w-40 max-w-64 !px-2 !py-1 !text-xs"
+      />
       <span class="spacer"></span>
       ${filters.map(f => html`
         <button
@@ -712,7 +726,7 @@ function BdThreadDetail({
         <div class="bd-th">
           <${BdAuthor} name=${authorAvatarKey} size=${26} />
           <div>
-            <div class="bd-th-hd"><span class="who">${authorLabel}</span><span class="ts"><${TimeAgo} timestamp=${post.created_at} /></span></div>
+            <div class="bd-th-hd"><span class="who">${authorLabel}</span><span class="ts mono"><${TimeAgo} timestamp=${post.created_at} /></span></div>
             <div class="bd-th-body">
               <div class="text-sm font-semibold mb-1">${stripInlineMarkdown(post.title)}</div>
               <${RichContent} text=${stripStateBlocks(post.body)} previewLimit=${4} />
@@ -1352,6 +1366,8 @@ function BdFeed({ posts, onMentions }: { posts: BoardPost[]; onMentions: () => v
         activeFilter=${boardFilterMode.value}
         onFilter=${(filter: 'all' | 'state' | 'mod') => { boardFilterMode.value = filter }}
         count=${filteredByMode.length}
+        contentQuery=${contentQuery}
+        onContentQuery=${setContentQuery}
       />
       <${BdMobileQueues}
         activeFilter=${boardFilterMode.value}
@@ -1361,18 +1377,8 @@ function BdFeed({ posts, onMentions }: { posts: BoardPost[]; onMentions: () => v
         onMentions=${onMentions}
       />
       <div class="bd-list">
-        <div class="mb-3 flex items-center gap-2">
-          <${TextInput}
-            type="search"
-            value=${contentQuery}
-            placeholder="제목/본문에서 검색"
-            ariaLabel="게시글 본문 필터"
-            onInput=${(e: Event) => setContentQuery((e.target as HTMLInputElement).value)}
-            class="min-w-45 max-w-80 flex-1 !px-2 !py-1 !text-xs"
-          />
-        </div>
         ${isFiltering && filteredByMode.length === 0 && posts.length > 0
-          ? html`<div class="bd-empty">필터 결과 없음 (${posts.length} items)</div>`
+          ? html`<div class="ov-empty">필터 결과 없음 (${posts.length} items)</div>`
           : filteredByMode.length === 0 && boardLoading.value
             ? html`<${LoadingState} title="게시판 불러오는 중…" />`
             : filteredByMode.length === 0
@@ -1502,7 +1508,6 @@ export function BoardSurface() {
       class="v2-board-surface ss-surface bg-surface-page text-text-primary"
       data-detail-width=${String(detailWidth)}
     >
-      <${SurfaceHeader} />
       <div class="bd-body" style=${`--bd-detail-width: ${detailWidth}px;`}>
         <${BdRail}
           activeSub=${activeSub}

--- a/dashboard/src/components/connector-status.ts
+++ b/dashboard/src/components/connector-status.ts
@@ -1662,19 +1662,25 @@ function ConnectorsSurfaceHeader({
   onRefresh: () => void
 }) {
   return html`
-    <header class="cn-surf-head">
+    <header class="cn-surf-head surf-head">
       <div>
         <div class="eyebrow">Gate</div>
         <h1>${filterId ? CONNECTOR_DISPLAY_NAMES[filterId] ?? '커넥터' : '커넥터'}</h1>
-        <div class="cn-surf-sub">
+        <div class="cn-surf-sub surf-sub">
           외부 게이트 ${connectorCount}개 · <b>${activeCount} active</b> ·
           <span class="mono">GET /api/v1/gate/connectors</span>
         </div>
       </div>
-      <div class="cn-surf-actions">
+      <div class="cn-surf-actions" style=${{ display: 'flex', gap: 8 }}>
         <button
           type="button"
-          class="cn-act"
+          class="cn-act act"
+          aria-label="게이트 설정 열기"
+          onClick=${() => { navigate('settings') }}
+        >게이트 설정 →</button>
+        <button
+          type="button"
+          class="cn-act act"
           aria-label="게이트 새로고침"
           onClick=${onRefresh}
         >게이트 새로고침 ↻</button>
@@ -1743,10 +1749,14 @@ function GateStatusStrip({
   connectors: GateConnectorInfo[]
 }) {
   const healthy = gate !== null && connectors.some(c => c.gate_healthy === true)
-  function statusClass(): string {
-    if (healthy) return 'run'
-    if (gate === null) return 'off'
-    return 'pause'
+  // Prototype gate-strip dot is <StatusDot status pulse/> → window.KV.Dot → `.dot2`
+  // (messages.jsx:8 maps run→ok, pause→warn, off→idle). The vendored CSS styles
+  // `.dot2` / `.dot2.ok` / `.dot2.warn` (v2.css:395); there is no `.status-dot`
+  // rule, so emit the prototype's `.dot2` vocabulary instead.
+  function statusDotClass(): string {
+    if (healthy) return 'dot2 ok pulse'
+    if (gate === null) return 'dot2'
+    return 'dot2 warn'
   }
   function statusLabel(): string {
     if (healthy) return 'healthy'
@@ -1761,9 +1771,9 @@ function GateStatusStrip({
   const generatedAt = resolveGeneratedAt()
 
   return html`
-    <div class="cn-gate-strip" data-testid="connector-gate-strip">
+    <div class="cn-gate-strip gate-strip" data-testid="connector-gate-strip">
       <span>
-        <span class=${`status-dot ${statusClass()}`}></span>
+        <span class=${statusDotClass()}></span>
         gate <b>${statusLabel()}</b>
       </span>
       <span class="sep"></span>
@@ -1895,7 +1905,12 @@ function ConnectorGateCard({
   const pillClass = connectorStatusPillClass(label)
   const bindings = connector?.configured_bindings ?? EMPTY_CONFIGURED_BINDINGS
   const caps = connector?.capabilities?.length ? connector.capabilities : ['bindings']
-  const baseOrGuilds = connector?.gate_base_url || (connector?.guild_count ? `${connector.guild_count} guilds` : '')
+  // Prototype card cell label is exactly `Base URL` (webhook) or `Guilds`
+  // (connectors.jsx:96); value is the base URL or the numeric guild count.
+  // Mirror the existing connectorScopeLabel/connectorScopeValue helpers
+  // (below) so the card and the live panel agree on the same wiring.
+  const scopeLabel = connectorScopeLabel(connector)
+  const scopeValue = connectorScopeValue(connector)
 
   return html`
     <article
@@ -1926,7 +1941,7 @@ function ConnectorGateCard({
       <div class="cn-kv">
         <${ConnectorValueCell} label="Bot" value=${connector?.bot_user_name || connector?.bot_user_id} highlight />
         <${ConnectorValueCell} label="Reply mode" value=${connector?.reply_mode || 'manual'} />
-        <${ConnectorValueCell} label=${connector?.channel === 'webhook' ? 'Base URL' : 'Base URL / Guilds'} value=${baseOrGuilds} />
+        <${ConnectorValueCell} label=${scopeLabel} value=${scopeValue} />
         <${ConnectorValueCell} label="PID" value=${connector?.pid || '-'} />
         <${ConnectorValueCell} label="Last ready" value=${connector?.last_ready_at ? timeAgo(connector.last_ready_at) : '-'} />
         <${ConnectorValueCell} label="Updated" value=${connector?.updated_at ? timeAgo(connector.updated_at) : '-'} />
@@ -2003,9 +2018,9 @@ function ConnectorsAuditLog({ connectors }: { connectors: GateConnectorInfo[] })
 
   return html`
     <section class="cn-audit" data-testid="connector-audit-log">
-      <div class="cn-audit-h">
+      <div class="cn-audit-h ov-card-h">
         <h3>최근 감사 로그</h3>
-        <span class="cn-audit-legend">recent_audit · last 5</span>
+        <span class="cn-audit-legend ov-legend mono">recent_audit · last 5</span>
       </div>
       ${rows.length
         ? html`
@@ -2318,7 +2333,8 @@ export function ConnectorStatusPanel() {
   const activeCount = allConnectors.filter(c => connectorStateLabel(c) === 'connected').length
 
   return html`
-    <div class="contain-content v2-connector-status v2-connectors-surface ss-surface bg-surface-page">
+    <main class="v2-connector-status v2-connectors-surface surf" data-screen-label="커넥터">
+      <div class="surf-scroll">
       <${ConnectorsSurfaceHeader}
         filterId=${filterId as KnownConnectorId | null}
         connectorCount=${connectorCount}
@@ -2412,6 +2428,7 @@ export function ConnectorStatusPanel() {
         : null}
 
       ${filterId ? html`<${GateAnalyticsSection} gate=${d} gateError=${snapshot.gateError} />` : null}
+      </div>
 
       ${configDrawerConnectorId.value
         ? html`
@@ -2422,7 +2439,7 @@ export function ConnectorStatusPanel() {
             />
           `
         : null}
-    </div>
+    </main>
   `
 }
 

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1478,16 +1478,25 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
 //   settings   → settings-surface.ts   <header class="set-content-h"> <h1>…</h1>
 //   connectors → connector-status.ts   (prototype surface, own header)
 //
-// A second group renders the shared SurfaceHeader component (header.v2-surface-header)
-// at the top of their own body — the documented replacement for the generic lead
-// (see surface-header.test.ts). They must be listed here too, otherwise the shell
-// stacks SurfaceLead above SurfaceHeader and the title renders twice:
+// A second group renders their own primary header inside their body — the v2
+// migration moved the header decision into each surface: monitoring/command/lab
+// render the shared SurfaceHeader at their own call site (status.ts,
+// operations-panel.ts, lab.ts), board renders its own header (#22021), and the
+// reskinned prototype surfaces carry a bespoke header. They must be listed here
+// too, otherwise the shell stacks SurfaceLead above that header and the title
+// renders twice (the duplicate "Keeper Fleet" header observed on #monitoring,
+// 2026-06-22):
 //   monitoring → status.ts           <SurfaceHeader> <h1>Keeper Fleet</h1>
 //   command    → operations-panel.ts <SurfaceHeader> <h1>Actions</h1>
 //   lab        → lab.ts              <SurfaceHeader> <h1>Tools</h1>
 //   board      → board-surface.ts    <SurfaceHeader> <h1>Board</h1> (#22021)
 //
 // Surfaces that still rely on the generic SurfaceLead for their title: keepers, code.
+//
+// WORKAROUND: this allow-list is the exact N-of-M pattern surface-header.ts set
+// out to delete (a list the compiler cannot keep in sync with reality). Root fix:
+// drop SurfaceLead/SURFACE_OWN_LEAD_IDS entirely and give every surface its own
+// header. Tracked as a follow-up; corrected here so live surfaces stop double-rendering.
 const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set([
   'overview',
   'approvals',
@@ -1498,8 +1507,8 @@ const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set([
   'cockpit',
   'settings',
   'connectors',
-  // Render the shared SurfaceHeader in their own body; without these the generic
-  // SurfaceLead stacked a duplicate title above each (board regressed in #22021,
+  // Each renders its own header in its body; without these the generic SurfaceLead
+  // stacked a duplicate title above each (board regressed in #22021,
   // monitoring/command/lab carried the same gap from their SurfaceHeader adoption).
   'monitoring',
   'command',

--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -120,10 +120,19 @@ describe('FusionSurface', () => {
     expect(container.textContent).toContain('Which deploy path should we take?')
     expect(container.textContent).toContain('gpt-5')
     expect(container.textContent).toContain('claude-sonnet-4')
-    expect(container.textContent).toContain('Canary has the best rollback evidence.')
+    // The rebuilt detail surfaces the judge verdict as the humanized decision
+    // label ('answer' -> '해결 답안' via fusionDecisionSpec), then renders
+    // `resolved_answer` as the resolved body. The raw `judge.synthesis` string is
+    // only a fallback for `resolved_answer` (FusionRunDetail `resolved = ...`), so
+    // it is not shown when `resolved_answer` is present — assert the verdict the
+    // component actually renders from this judge metadata instead.
+    expect(container.textContent).toContain('해결 답안')
     expect(container.textContent).toContain('Ship canary first, then expand.')
-    expect(container.textContent).toContain('1,300')
-    expect(container.textContent).toContain('360')
+    // Tokens are no longer rendered as separate comma-formatted in/out figures;
+    // the detail KPI strip combines panel+judge into one `Nk` total
+    // (combinedTokenLabel: observed 1300 + 360 = 1660 -> '1.7k').
+    expect(container.textContent).toContain('토큰 (패널+심판)')
+    expect(container.textContent).toContain('1.7k')
     expect(container.querySelector('[data-testid="fusion-pipe"]')).not.toBeNull()
     expect(container.querySelector('.fus-rdot.done')).not.toBeNull()
     expect(container.textContent).toContain('panel ×2')
@@ -194,7 +203,10 @@ describe('FusionSurface', () => {
     expect(evidence?.textContent).toContain('Add the rollback caveat to the operator note.')
     expect(evidence?.textContent).toContain('No cost impact estimate.')
     expect(evidence?.textContent).toContain('staging rollback transcript')
-    expect(evidence?.textContent).toContain('publish operator note')
+    // The recommendation `action` is rendered in the `.fus-resolved` block as
+    // `권고 · <action>` (FusionRunDetail), not inside the structured judge-evidence
+    // panel — assert it against the full surface where it actually appears.
+    expect(container.textContent).toContain('publish operator note')
   })
 
   it('calls ringFocusClasses() for focus rings instead of stringifying the function', () => {

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useMemo } from 'preact/hooks'
+import { useMemo, useState } from 'preact/hooks'
 import type { BoardPost } from '../../types'
 import { navigate, replaceRoute, route } from '../../router'
 import {
@@ -15,6 +15,7 @@ import { ringFocusClasses } from '../common/ring'
 import { AgentAvatar } from '../overview/agent-avatar'
 import { FusionRunsPanel } from './fusion-runs-panel'
 import { asRecord, asString, asStringArray } from '../common/normalize'
+import { fusionDecisionSpec, type FusionDecisionSpec } from '../v2/fusion-constants'
 import {
   firstString,
   firstNumber,
@@ -251,6 +252,22 @@ function toneFor(status: FusionRunStatus, decision: string | null): FusionTone {
   return status === 'running' ? 'muted' : 'ok'
 }
 
+// Wire `decision` is a free-form string (`fusion_sink.render_decision` emits
+// `"answer — …"` / `"recommend — …"` / `"insufficient — missing: …"`), not the
+// clean OCaml variant. Map it to the canonical key the SSOT `fusionDecisionSpec`
+// understands, then defer label/glyph/tone to that shared spec (no inline
+// label/colour drift). Unknown / running / failed decisions fall through to the
+// spec's neutral fallback. This mirrors the existing `toneFor` substring logic —
+// the typed variant lives backend-side and is flattened to a string on the wire.
+function decisionSpecFor(decision: string | null): FusionDecisionSpec | null {
+  if (!decision) return null
+  const lower = decision.toLowerCase()
+  if (lower.includes('answer')) return fusionDecisionSpec('Answer')
+  if (lower.includes('recommend')) return fusionDecisionSpec('Recommend')
+  if (lower.includes('insufficient') || lower.includes('uncertain')) return fusionDecisionSpec('Insufficient')
+  return fusionDecisionSpec(decision)
+}
+
 function keeperNameFor(post: BoardPost): string {
   return post.author_identity?.display_name
     || post.author_identity?.id
@@ -311,14 +328,20 @@ function buildFusionRuns(posts: readonly BoardPost[]): FusionRunView[] {
     .sort((a, b) => timeValue(b.updatedAt) - timeValue(a.updatedAt))
 }
 
-function formatTokens(value: number | null | undefined): string {
-  if (value == null) return 'n/a'
-  return new Intl.NumberFormat().format(value)
-}
-
 function formatCost(value: number | null): string {
   if (value === null) return 'n/a'
   return `$${value.toFixed(4)}`
+}
+
+/** Combined panel+judge token total, in `Nk` form, for the detail KPI strip
+ *  (prototype collapses the in/out split into one figure). Returns `null` when
+ *  there is no token data so the cell renders an honest em-dash. */
+function combinedTokenLabel(usage: FusionUsage): string | null {
+  const input = usage.inputTokens ?? 0
+  const output = usage.outputTokens ?? 0
+  const total = input + output
+  if (total <= 0) return null
+  return total >= 1000 ? `${(total / 1000).toFixed(1)}k` : String(total)
 }
 
 function statusLabel(status: FusionRunStatus): string {
@@ -344,17 +367,50 @@ function compactText(value: string, max = 180): string {
   return `${normalized.slice(0, max - 1)}...`
 }
 
-function FusionMetric({ label, value, tone = 'muted' }: { label: string; value: string | number; tone?: FusionTone }) {
+// Prototype detail KPI cell (`.fus-kpi` with `.k`/`.v`, optional `.v` tone +
+// `<small>` unit). Replaces the dead `.fus-kpi-k`/`.fus-kpi-v` markup.
+function FusionMetric({
+  label,
+  value,
+  unit,
+  tone,
+}: {
+  label: string
+  value: string | number
+  unit?: string
+  tone?: FusionTone
+}) {
   return html`
-    <div class=${`fus-kpi tone-${tone}`}>
-      <div class="fus-kpi-k">${label}</div>
-      <div class="fus-kpi-v">${value}</div>
+    <div class="fus-kpi">
+      <div class="k">${label}</div>
+      <div class=${tone ? `v ${tone}` : 'v'}>
+        ${value}${unit ? html`<small> ${unit}</small>` : null}
+      </div>
     </div>
   `
 }
 
 function FusionStatusGlyph({ status }: { status: FusionRunStatus }) {
   return html`<span class=${`fus-rdot ${statusDotClass(status)}`} aria-hidden="true"></span>`
+}
+
+// Keeper identity link (prototype `.fus-who`/`.nm`). Navigates to the keeper
+// chat lane, preserving the existing `navigate('keepers', …)` wiring.
+function FusionKeeperLink({ keeper, size = 'sm' }: { keeper: string; size?: 'sm' | 'md' }) {
+  return html`
+    <button
+      type="button"
+      class=${`fus-who ${ringFocusClasses()}`}
+      title=${`${keeper} 대화 열기`}
+      onClick=${(event: Event) => {
+        event.stopPropagation()
+        navigate('keepers', { keeper })
+      }}
+    >
+      <${AgentAvatar} name=${keeper} size=${size} />
+      <span class="nm">${keeper}</span>
+    </button>
+  `
 }
 
 function FusionPipelineStrip({ run }: { run: FusionRunView }) {
@@ -370,33 +426,59 @@ function FusionPipelineStrip({ run }: { run: FusionRunView }) {
         keeper turn
       </span>
       <span class="fus-pipe-arr" aria-hidden="true">→</span>
-      <span class=${`fus-pipe-node ${gateClass}`}>gate</span>
+      <span class=${`fus-pipe-node ${gateClass} ${gateClass === 'gate' ? 'ok' : ''}`}>gate</span>
       <span class="fus-pipe-arr" aria-hidden="true">→</span>
-      <span class=${`fus-pipe-node panel ${panelFailures > 0 ? 'warn' : ''}`}>
+      <span class=${`fus-pipe-node panel ${run.status === 'failed' && run.panel.length === 0 ? 'off' : ''}`}>
         ${panelLabel}${panelFailures > 0 ? ` · fail ${panelFailures}` : ''}
       </span>
       <span class="fus-pipe-arr" aria-hidden="true">→</span>
-      <span class=${`fus-pipe-node judge ${run.status === 'failed' ? 'deny' : ''}`}>${judgeLabel}</span>
+      <span class=${`fus-pipe-node judge ${run.status === 'failed' || run.status === 'running' ? 'off' : ''}`}>${judgeLabel}</span>
       <span class="fus-pipe-arr" aria-hidden="true">→</span>
-      <span class="fus-pipe-node sink">board evidence</span>
+      <span class=${`fus-pipe-node sink ${run.status === 'complete' ? '' : 'off'}`}>board evidence</span>
     </section>
   `
 }
 
+// Prototype panel card (`.fus-pcard`). Retains `.fus-panel-card` +
+// `answered`/`failed` modifiers so existing tests keep matching, and adds the
+// vendored `.fus-pcard*` classes that actually style the card. The answer body
+// is collapsible (prototype `.fus-pans`).
 function FusionPanelCard({ entry }: { entry: FusionPanelEntry }) {
   const failed = isPanelFailure(entry.status)
+  const [open, setOpen] = useState(false)
   const body = entry.answer ?? entry.reason ?? 'No panel output captured.'
+  const tokenTotal = (entry.inputTokens ?? 0) + (entry.outputTokens ?? 0)
+  const tokenLabel = tokenTotal > 0
+    ? (tokenTotal >= 1000 ? `${(tokenTotal / 1000).toFixed(1)}k` : String(tokenTotal))
+    : null
+
   return html`
-    <article class=${`fus-panel-card ${failed ? 'failed' : 'answered'}`}>
-      <div class="fus-panel-head">
-        <span class="fus-panel-model">${entry.model}</span>
-        <span class=${`fus-mini-status ${failed ? 'bad' : 'ok'}`}>${entry.status}</span>
+    <article class=${`fus-pcard fus-panel-card ${failed ? 'failed' : 'answered'}`}>
+      <div class="fus-pcard-h">
+        <span class="fus-pmodel mono">${entry.model}</span>
+        ${failed
+          ? html`<span class="fus-pstate fail">${entry.reason ?? entry.status}</span>`
+          : tokenLabel
+            ? html`<span class="fus-ptok mono" title="입력+출력 토큰">${tokenLabel} tok</span>`
+            : null}
       </div>
-      <p class="fus-panel-body">${compactText(body, 360)}</p>
-      <div class="fus-panel-foot">
-        <span>in ${formatTokens(entry.inputTokens)}</span>
-        <span>out ${formatTokens(entry.outputTokens)}</span>
-      </div>
+      ${failed
+        ? null
+        : html`
+            <div
+              class=${`fus-pans ${open ? 'open' : ''}`}
+              role="button"
+              tabIndex=${0}
+              title=${open ? '접기' : '펼치기'}
+              onClick=${() => setOpen(prev => !prev)}
+              onKeyDown=${(event: KeyboardEvent) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  setOpen(prev => !prev)
+                }
+              }}
+            >${body}</div>
+          `}
     </article>
   `
 }
@@ -414,152 +496,139 @@ function hasStructuredJudgeEvidence(judge: FusionJudge): boolean {
 function FusionModelChips({ models }: { models: string[] }) {
   if (models.length === 0) return null
   return html`
-    <span class="fus-model-chips">
-      ${models.map(model => html`<span class="fus-model-chip" key=${model}>${model}</span>`)}
+    <span class="fus-mchips">
+      ${models.map(model => html`<span class="fus-mchip mono" key=${model}>${model}</span>`)}
     </span>
   `
 }
 
+// Structured judge synthesis (prototype `.fus-judge-body` / `.fus-jsec`).
+// Keeps `data-testid="fusion-judge-evidence"` + the "Structured judge evidence"
+// summary head (consumed by tests) and renders the five prototype groups with
+// glyphs + counts.
 function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
   if (!hasStructuredJudgeEvidence(judge)) return null
 
   return html`
-    <div class="fus-judge-evidence" data-testid="fusion-judge-evidence">
-      <div class="fus-judge-evidence-head">
-        <span>Structured judge evidence</span>
-        <span>
-          ${judge.consensus.length} consensus · ${judge.contradictions.length} contradictions ·
-          ${judge.partialCoverage.length} coverage
-        </span>
-      </div>
-
-      ${judge.consensus.length > 0
-        ? html`
-            <div class="fus-jgroup">
-              <h4>Consensus</h4>
-              <div class="fus-jrows">
-                ${judge.consensus.map((claim, index) => html`
-                  <div class="fus-jrow" key=${`consensus-${index}`}>
-                    <p>${claim.text}</p>
-                    <${FusionModelChips} models=${claim.models} />
-                  </div>
-                `)}
-              </div>
+    <div class="fus-judge" data-testid="fusion-judge-evidence">
+      <div class="fus-judge-body">
+        <section class="fus-jsec consensus" hidden=${judge.consensus.length === 0}>
+          <h5>
+            <span class="fus-jglyph">≡</span>합의 <span class="n">${judge.consensus.length}</span>
+            <span class="fus-sub-note">Structured judge evidence</span>
+          </h5>
+          ${judge.consensus.map((claim, index) => html`
+            <div class="fus-claim" key=${`consensus-${index}`}>
+              <p>${claim.text}</p>
+              <${FusionModelChips} models=${claim.models} />
             </div>
-          `
-        : null}
+          `)}
+        </section>
 
-      ${judge.contradictions.length > 0
-        ? html`
-            <div class="fus-jgroup">
-              <h4>Contradictions</h4>
-              <div class="fus-jrows">
+        ${judge.contradictions.length > 0
+          ? html`
+              <section class="fus-jsec contra">
+                <h5><span class="fus-jglyph">⇄</span>상충 <span class="n">${judge.contradictions.length}</span></h5>
                 ${judge.contradictions.map((contradiction, index) => html`
-                  <div class="fus-jrow" key=${`contradiction-${index}`}>
-                    <strong>${contradiction.topic}</strong>
+                  <div class="fus-contra" key=${`contradiction-${index}`}>
+                    <div class="fus-contra-topic">${contradiction.topic}</div>
                     ${contradiction.positions.map(position => html`
-                      <span class="fus-position" key=${`${contradiction.topic}:${position.model}`}>
-                        <span>${position.model}</span>
-                        <span>${position.stance}</span>
-                      </span>
+                      <div class="fus-pos" key=${`${contradiction.topic}:${position.model}`}>
+                        <span class="fus-pos-m mono">${position.model}</span>
+                        <span class="fus-pos-s">${position.stance}</span>
+                      </div>
                     `)}
                   </div>
                 `)}
-              </div>
-            </div>
-          `
-        : null}
+              </section>
+            `
+          : null}
 
-      ${judge.partialCoverage.length > 0
-        ? html`
-            <div class="fus-jgroup">
-              <h4>Partial Coverage</h4>
-              <div class="fus-jrows">
+        ${judge.partialCoverage.length > 0
+          ? html`
+              <section class="fus-jsec coverage">
+                <h5><span class="fus-jglyph">◑</span>부분 커버리지 <span class="n">${judge.partialCoverage.length}</span></h5>
                 ${judge.partialCoverage.map((gap, index) => html`
-                  <div class="fus-jrow" key=${`coverage-${index}`}>
-                    <strong>${gap.topic}</strong>
-                    <${FusionModelChips} models=${gap.addressedBy} />
-                    <p><span class="fus-muted-key">missing</span>${gap.missing}</p>
+                  <div class="fus-gap" key=${`coverage-${index}`}>
+                    <div class="fus-gap-topic">${gap.topic}</div>
+                    <div class="fus-gap-row">
+                      <span class="k">다룸</span>
+                      <${FusionModelChips} models=${gap.addressedBy} />
+                    </div>
+                    <div class="fus-gap-row">
+                      <span class="k">누락</span>
+                      <span class="fus-gap-miss">${gap.missing}</span>
+                    </div>
                   </div>
                 `)}
-              </div>
-            </div>
-          `
-        : null}
+              </section>
+            `
+          : null}
 
-      ${judge.uniqueInsights.length > 0
-        ? html`
-            <div class="fus-jgroup">
-              <h4>Unique Insights</h4>
-              <div class="fus-jrows">
+        ${judge.uniqueInsights.length > 0
+          ? html`
+              <section class="fus-jsec insight">
+                <h5><span class="fus-jglyph">✦</span>고유 통찰 <span class="n">${judge.uniqueInsights.length}</span></h5>
                 ${judge.uniqueInsights.map((insight, index) => html`
-                  <div class="fus-jrow" key=${`insight-${index}`}>
+                  <div class="fus-insight" key=${`insight-${index}`}>
                     <p>${insight.text}</p>
-                    ${insight.model ? html`<${FusionModelChips} models=${[insight.model]} />` : null}
+                    ${insight.model ? html`<span class="fus-mchip mono">${insight.model}</span>` : null}
                   </div>
                 `)}
-              </div>
-            </div>
-          `
-        : null}
+              </section>
+            `
+          : null}
 
-      ${judge.blindSpots.length > 0 || judge.missingInputs.length > 0
-        ? html`
-            <div class="fus-jgroup fus-jgroup-split">
-              ${judge.blindSpots.length > 0
-                ? html`
-                    <div>
-                      <h4>Blind Spots</h4>
-                      <ul>${judge.blindSpots.map(item => html`<li key=${item}>${item}</li>`)}</ul>
-                    </div>
-                  `
-                : null}
-              ${judge.missingInputs.length > 0
-                ? html`
-                    <div>
-                      <h4>Missing Inputs</h4>
-                      <ul>${judge.missingInputs.map(item => html`<li key=${item}>${item}</li>`)}</ul>
-                    </div>
-                  `
-                : null}
-            </div>
-          `
-        : null}
+        ${judge.blindSpots.length > 0
+          ? html`
+              <section class="fus-jsec blind">
+                <h5><span class="fus-jglyph">⚠</span>사각지대 <span class="n">${judge.blindSpots.length}</span></h5>
+                <ul class="fus-blind">${judge.blindSpots.map(item => html`<li key=${item}>${item}</li>`)}</ul>
+              </section>
+            `
+          : null}
 
-      ${judge.recommendation
-        ? html`
-            <div class="fus-jgroup">
-              <h4>Recommendation</h4>
-              <div class="fus-jrow">
-                ${judge.recommendation.action ? html`<strong>${judge.recommendation.action}</strong>` : null}
-                ${judge.recommendation.rationale ? html`<p>${judge.recommendation.rationale}</p>` : null}
-              </div>
-            </div>
-          `
-        : null}
+        ${judge.missingInputs.length > 0
+          ? html`
+              <section class="fus-jsec blind">
+                <h5><span class="fus-jglyph">⚠</span>부족한 입력 <span class="n">${judge.missingInputs.length}</span></h5>
+                <ul class="fus-blind">${judge.missingInputs.map(item => html`<li key=${item}>${item}</li>`)}</ul>
+              </section>
+            `
+          : null}
+      </div>
     </div>
   `
 }
 
 function FusionRunRow({ run, active }: { run: FusionRunView; active: boolean }) {
+  const dec = decisionSpecFor(run.judge.decision)
   return html`
     <button
       type="button"
-      class=${`fus-run-row ${active ? 'active' : ''} ${ringFocusClasses()}`}
+      class=${`fus-run-row fus-row ${active ? 'active sel' : ''} st-${run.status} ${ringFocusClasses()}`}
       aria-current=${active ? 'true' : undefined}
       onClick=${() => replaceRoute('fusion', { run_id: run.runId })}
     >
-      <span class="fus-row-top">
-        <span class="fus-run-mark">
-          <${FusionStatusGlyph} status=${run.status} />
-          <span class="fus-run-id">${run.runId}</span>
-        </span>
-        <span class=${`fus-status tone-${run.tone}`}>${statusLabel(run.status)}</span>
+      <span class="fus-row-h">
+        <${FusionStatusGlyph} status=${run.status} />
+        <span class="fus-run-id mono">${run.runId}</span>
+        <span class="fus-row-ts"><${TimeAgo} timestamp=${run.updatedAt} /></span>
       </span>
-      <span class="fus-row-question">${compactText(run.question, 110)}</span>
-      <span class="fus-row-meta">
-        <span>${run.keeperName}</span>
-        <${TimeAgo} timestamp=${run.updatedAt} />
+      <span class="fus-row-prompt">${compactText(run.question, 110)}</span>
+      <span class="fus-row-f">
+        <span class="fus-who static" title=${run.keeperName}>
+          <${AgentAvatar} name=${run.keeperName} size="sm" />
+          <span class="nm">${run.keeperName}</span>
+        </span>
+        <span class="spacer"></span>
+        ${run.status === 'running'
+          ? html`<span class="fus-dec-badge run">심의 중</span>`
+          : run.status === 'failed'
+            ? html`<span class="fus-dec-badge bad">실패</span>`
+            : dec
+              ? html`<span class=${`fus-dec-badge ${dec.cls}`}>${dec.glyph} ${dec.lbl}</span>`
+              : null}
       </span>
     </button>
   `
@@ -568,81 +637,161 @@ function FusionRunRow({ run, active }: { run: FusionRunView; active: boolean }) 
 function FusionRunDetail({ run }: { run: FusionRunView }) {
   const answered = run.panel.filter(entry => !isPanelFailure(entry.status)).length
   const failed = run.panel.length - answered
-  const synthesis = run.judge.synthesis ?? run.judge.error ?? 'No judge synthesis captured.'
-  const resolved = run.judge.resolvedAnswer ?? 'No resolved answer captured.'
+  const resolved = run.judge.resolvedAnswer ?? run.judge.synthesis ?? run.judge.error ?? 'No resolved answer captured.'
+  const dec = decisionSpecFor(run.judge.decision)
+  const decClass = dec && dec.cls ? `dec-${dec.cls}` : ''
+  const tokenLabel = combinedTokenLabel(run.usage)
 
   return html`
-    <article class="fus-detail" data-testid="fusion-detail">
-      <header class="fus-detail-head">
-        <div class="fus-detail-title">
-          <div class="fus-detail-meta">
-            <${FusionStatusGlyph} status=${run.status} />
-            <span class=${`fus-status tone-${run.tone}`}>${statusLabel(run.status)}</span>
-            <span class="fus-run-id">${run.runId}</span>
-            <${TimeAgo} timestamp=${run.updatedAt} mode="both" />
-          </div>
-          <h2>${run.title}</h2>
+    <div class="fus-run-scroll" data-testid="fusion-detail">
+      <div class="fus-run-head">
+        <div class="fus-run-id-row">
+          <${FusionStatusGlyph} status=${run.status} />
+          <h1 class="mono">${run.runId}</h1>
+          <span class="fus-preset" title="runtime.toml [fusion.presets.*]" data-stub="preset not joined into board-derived run view (registry-only field)">preset · n/a</span>
+          <span class=${`fus-status tone-${run.tone}`}>${statusLabel(run.status)}</span>
         </div>
-        <div class="fus-actions">
+        <div class="fus-run-by">
+          <${FusionKeeperLink} keeper=${run.keeperName} size="md" />
+          <span class="fus-run-meta"><${TimeAgo} timestamp=${run.updatedAt} mode="both" /></span>
+          <span class="spacer"></span>
           <button
             type="button"
-            class=${`fus-action ${ringFocusClasses()}`}
+            class=${`fus-link inline ${ringFocusClasses()}`}
             onClick=${() => navigate('keepers', { keeper: run.keeperName })}
-          >Open keeper</button>
+          >키퍼 열기</button>
           <button
             type="button"
-            class=${`fus-action primary ${ringFocusClasses()}`}
+            class=${`fus-link inline ${ringFocusClasses()}`}
             onClick=${() => navigate('board', { post: run.boardPostId })}
-          >Open board post</button>
+          >보드 포스트 열기</button>
         </div>
-      </header>
+      </div>
 
       <${FusionPipelineStrip} run=${run} />
 
-      <section class="fus-question">
-        <div class="fus-label">Prompt</div>
-        <p>${run.question}</p>
-      </section>
+      <div class="fus-kpis" aria-label="Fusion run metrics">
+        <${FusionMetric}
+          label="패널"
+          value=${`${answered}/${run.panel.length}`}
+          unit="모델"
+          tone=${failed > 0 ? 'warn' : 'ok'}
+        />
+        <${FusionMetric} label="토큰 (패널+심판)" value=${tokenLabel ?? '—'} />
+        <${FusionMetric} label="비용 (관측)" value=${formatCost(run.usage.costUsd)} />
+        <${FusionMetric}
+          label="결정"
+          value=${dec ? dec.lbl : run.status === 'failed' ? '실패' : '대기'}
+          tone=${dec && (dec.cls === 'ok' || dec.cls === 'warn' || dec.cls === 'volt') ? dec.cls : run.status === 'failed' ? 'bad' : undefined}
+        />
+      </div>
 
-      <section class="fus-kpis" aria-label="Fusion run metrics">
-        <${FusionMetric} label="panel" value=${`${answered}/${run.panel.length}`} tone=${failed > 0 ? 'warn' : 'ok'} />
-        <${FusionMetric} label="input tokens" value=${formatTokens(run.usage.inputTokens)} />
-        <${FusionMetric} label="output tokens" value=${formatTokens(run.usage.outputTokens)} tone="volt" />
-        <${FusionMetric} label="cost" value=${formatCost(run.usage.costUsd)} />
-      </section>
+      <div class="fus-block">
+        <div class="fus-block-lbl">심의 프롬프트</div>
+        <div class="fus-prompt">${run.question}</div>
+      </div>
 
-      <section class="fus-section">
-        <div class="fus-section-head">
-          <h3>Panel</h3>
-          <span>${run.panel.length} models</span>
+      <div class="fus-block">
+        <div class="fus-block-lbl">
+          패널 · ${run.panel.length}개 모델 병렬
+          <span class="fus-sub-note">Async_agent.all · 실패 격리</span>
         </div>
         ${run.panel.length === 0
-          ? html`<div class="fus-empty-inline">No panel entries captured for this run.</div>`
+          ? html`<div class="fus-judge-wait">패널 응답이 기록되지 않았습니다.</div>`
           : html`<div class="fus-panel-grid">${run.panel.map(entry => html`<${FusionPanelCard} key=${entry.model} entry=${entry} />`)}</div>`}
-      </section>
+      </div>
 
-      <section class="fus-judge">
-        <div class="fus-section-head">
-          <h3>Judge</h3>
-          <span>${run.judge.decision ?? run.judge.status ?? 'n/a'}</span>
+      ${run.status === 'running'
+        ? html`
+            <div class="fus-block">
+              <div class="fus-block-lbl">심판 종합</div>
+              <div class="fus-judge-wait">
+                <span class="fus-rdot run"></span>패널 응답 대기 중 — 전원 도착 후 심판(Structured.extract)이 1회 호출됩니다.
+              </div>
+            </div>
+          `
+        : html`
+            <div class="fus-block">
+              <div class="fus-block-lbl">
+                심판 종합
+                <span class="fus-judge-model mono">${run.judge.decision ?? run.judge.status ?? 'n/a'}</span>
+                <span class="fus-sub-note">Structured.extract · 닫힌 타입 schema</span>
+              </div>
+              ${hasStructuredJudgeEvidence(run.judge)
+                ? html`<${FusionJudgeEvidence} judge=${run.judge} />`
+                : html`<div class="fus-judge-wait">구조화된 심판 근거가 기록되지 않았습니다.</div>`}
+            </div>
+          `}
+
+      <div class=${`fus-resolved ${decClass}`}>
+        <div class="fus-resolved-h">
+          ${dec
+            ? html`<span class=${`fus-dec-badge big ${dec.cls}`}>${dec.glyph} ${dec.lbl}</span>`
+            : html`<span class="fus-dec-badge big">${run.status === 'failed' ? '실패' : '미결'}</span>`}
+          ${run.judge.recommendation?.action
+            ? html`<span class="fus-rec-action">권고 · ${run.judge.recommendation.action}</span>`
+            : null}
         </div>
-        <pre class="fus-synthesis">${synthesis}</pre>
-        <${FusionJudgeEvidence} judge=${run.judge} />
-      </section>
+        <div class="fus-resolved-lbl">resolved_answer</div>
+        <p class="fus-resolved-body">${resolved}</p>
+        ${run.judge.recommendation?.rationale
+          ? html`<p class="fus-rec-rationale"><span class="k">근거</span>${run.judge.recommendation.rationale}</p>`
+          : null}
+        ${run.judge.missingInputs.length > 0
+          ? html`
+              <div class="fus-missing">
+                <span class="k">부족한 입력</span>
+                <ul>${run.judge.missingInputs.map(item => html`<li key=${item}>${item}</li>`)}</ul>
+              </div>
+            `
+          : null}
+      </div>
 
-      <section class="fus-resolved">
-        <div class="fus-label">Resolved answer</div>
-        <p>${resolved}</p>
-      </section>
-
-      <section class="fus-sink">
-        <div>
-          <div class="fus-label">Sink</div>
-          <p>board evidence · post ${run.boardPostId}</p>
-        </div>
-        <${AgentAvatar} name=${run.keeperName} size="sm" />
-      </section>
-    </article>
+      ${run.status === 'complete'
+        ? html`
+            <div class="fus-block">
+              <div class="fus-block-lbl">
+                결과 도착 · sink
+                <span class="fus-sub-note">judge 결론이 키퍼 흐름에 녹는 경로</span>
+              </div>
+              <div class="fus-sink">
+                <div class="fus-sink-tracks">
+                  <div class="fus-sink-track">
+                    <span class="fus-sink-ico chat">▭</span>
+                    <div class="fus-sink-tx">
+                      <button
+                        type="button"
+                        class=${`fus-sink-to ${ringFocusClasses()}`}
+                        onClick=${() => navigate('keepers', { keeper: run.keeperName })}
+                      >${run.keeperName} chat lane →</button>
+                      <span class="fus-sink-d">resolved_answer 1줄 append → 다음 턴 observation · librarian이 memory-os fact로 추출</span>
+                    </div>
+                  </div>
+                  <div class="fus-sink-track">
+                    <span class="fus-sink-ico board">▦</span>
+                    <div class="fus-sink-tx">
+                      <button
+                        type="button"
+                        class=${`fus-sink-to ${ringFocusClasses()}`}
+                        onClick=${() => navigate('board', { post: run.boardPostId })}
+                      >보드 포스트 #${run.boardPostId} →</button>
+                      <span class="fus-sink-d">패널 N + 심판 종합을 meta_json 증거로 발행 · run_id로 쿼리</span>
+                    </div>
+                  </div>
+                  <div class="fus-sink-track">
+                    <span class="fus-sink-ico wake">◉</span>
+                    <div class="fus-sink-tx">
+                      <span class="fus-sink-to static">키퍼 wake · Fusion_completed</span>
+                      <span class="fus-sink-d">RFC-0266 typed stimulus로 호출 키퍼를 깨워 결론을 actionable 입력으로 전달</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="fus-corr">correlation · <span class="mono">${run.runId}</span></div>
+              </div>
+            </div>
+          `
+        : null}
+    </div>
   `
 }
 
@@ -656,68 +805,78 @@ export function FusionSurface() {
   const registryFailed = registryRuns.filter(run => run.status === 'failed').length
 
   return html`
-    <main class="ov ss-surface bg-surface-page text-text-primary v2-fusion-surface" data-testid="fusion-surface">
-      <div class="ov-scroll fus-scroll">
-        <header class="ov-head fus-head">
-          <div>
-            <h1>Fusion</h1>
-            <p class="ov-sub">
-              Panel deliberations, judge synthesis, and board sink evidence from masc_fusion.
-            </p>
+    <main class="surf fus v2-fusion-surface" data-testid="fusion-surface" data-screen-label="Fusion">
+      <header class="surf-head fus-head">
+        <div>
+          <div class="eyebrow">RFC-0252 · 패널 + 심판</div>
+          <h1>Fusion</h1>
+          <p class="surf-sub ov-sub">
+            masc_fusion 패널 심의 · 심판 종합 · 보드 sink 증거.
+          </p>
+        </div>
+        <button
+          type="button"
+          class=${`fus-link inline fus-refresh ${ringFocusClasses()}`}
+          onClick=${() => { void refreshFusionBoard(); void refreshFusionRuns() }}
+          disabled=${fusionBoardLoading.value || fusionRunsLoading.value}
+        >${fusionBoardLoading.value || fusionRunsLoading.value ? 'Refreshing...' : 'Refresh'}</button>
+      </header>
+
+      <${FusionRunsPanel} />
+
+      <section class="fus-kpis" aria-label="Fusion overview">
+        <${FusionMetric} label="board runs" value=${runs.length} tone=${runs.length ? 'ok' : undefined} />
+        <${FusionMetric}
+          label="registry"
+          value=${registryRuns.length}
+          tone=${registryRunning ? 'warn' : registryRuns.length ? 'ok' : undefined}
+        />
+        <${FusionMetric} label="running" value=${registryRunning} tone=${registryRunning ? 'warn' : undefined} />
+        <${FusionMetric} label="failed" value=${registryFailed} tone=${registryFailed ? 'bad' : undefined} />
+      </section>
+
+      <div class="fus-body">
+        <aside class="fus-list" aria-label="Fusion runs">
+          <div class="fus-list-h">
+            <h4>심의 런</h4>
+            <span class="fus-list-sub">RFC-0252 · 패널+심판</span>
+            ${registryRunning > 0
+              ? html`<span class="fus-list-live"><span class="fus-rdot run"></span>${registryRunning} 진행</span>`
+              : null}
           </div>
-          <button
-            type="button"
-            class=${`fus-refresh ${ringFocusClasses()}`}
-            onClick=${() => { void refreshFusionBoard(); void refreshFusionRuns() }}
-            disabled=${fusionBoardLoading.value || fusionRunsLoading.value}
-          >${fusionBoardLoading.value || fusionRunsLoading.value ? 'Refreshing...' : 'Refresh'}</button>
-        </header>
-
-        <${FusionRunsPanel} />
-
-        <section class="fus-top-kpis" aria-label="Fusion overview">
-          <${FusionMetric} label="board runs" value=${runs.length} tone=${runs.length ? 'ok' : 'muted'} />
-          <${FusionMetric}
-            label="registry"
-            value=${registryRuns.length}
-            tone=${registryRunning ? 'warn' : registryRuns.length ? 'ok' : 'muted'}
-          />
-          <${FusionMetric} label="running" value=${registryRunning} tone=${registryRunning ? 'warn' : 'muted'} />
-          <${FusionMetric} label="failed" value=${registryFailed} tone=${registryFailed ? 'bad' : 'muted'} />
-        </section>
+          ${runs.length === 0
+            ? html`<div class="fus-list-scroll"><div class="ov-empty">보드 sink 심의 런이 없습니다</div></div>`
+            : html`
+                <div class="fus-list-scroll">
+                  ${runs.map(run => html`
+                    <${FusionRunRow}
+                      key=${run.runId}
+                      run=${run}
+                      active=${selected?.runId === run.runId}
+                    />
+                  `)}
+                </div>
+              `}
+        </aside>
 
         ${runs.length === 0
           ? html`
-              <section class="fus-empty" data-testid="fusion-empty">
-                <div class="fus-empty-mark">F</div>
-                <h2>No board-sink fusion posts yet</h2>
-                <p>
-                  Registry status is shown above from <code>/api/v1/dashboard/fusion-runs</code>;
-                  detailed panel and judge review appears after the fusion sink writes a board post
-                  with <code>meta.source = "fusion"</code>.
-                </p>
-              </section>
-            `
-          : html`
-              <div class="fus-layout">
-                <aside class="fus-list" aria-label="Fusion runs">
-                  <div class="fus-list-head">
-                    <span>Runs</span>
-                    <span>${runs.length}</span>
+              <div class="fus-run-scroll" data-testid="fusion-empty">
+                <div class="fus-block">
+                  <div class="fus-block-lbl">보드 sink 대기</div>
+                  <div class="fus-judge-wait">
+                    No board-sink fusion posts yet.
                   </div>
-                  <div class="fus-run-scroll">
-                    ${runs.map(run => html`
-                      <${FusionRunRow}
-                        key=${run.runId}
-                        run=${run}
-                        active=${selected?.runId === run.runId}
-                      />
-                    `)}
-                  </div>
-                </aside>
-                ${selected ? html`<${FusionRunDetail} run=${selected} />` : null}
+                  <p class="fus-rec-rationale">
+                    레지스트리 상태는 위 패널(<code>/api/v1/dashboard/fusion-runs</code>)에 표시됩니다.
+                    상세한 패널·심판 리뷰는 fusion sink가 <code>meta.source = "fusion"</code> 보드 포스트를 기록한 뒤 나타납니다.
+                  </p>
+                </div>
               </div>
-            `}
+            `
+          : selected
+            ? html`<${FusionRunDetail} run=${selected} />`
+            : null}
       </div>
     </main>
   `

--- a/dashboard/src/components/ide/ide-shell.ts
+++ b/dashboard/src/components/ide/ide-shell.ts
@@ -246,6 +246,44 @@ function activeStatusbarRepository(
     ?? repositories[0]
 }
 
+/**
+ * Derive a browsable https web URL from a git clone URL so the repo-origin
+ * block can render the prototype's `↗` external link.
+ *
+ * Total + deterministic: handles the two common clone forms
+ * (`https://host/owner/repo[.git]` and `git@host:owner/repo[.git]`) and
+ * returns `null` for anything else. A `null` result means "no usable web
+ * link" — the caller omits the `<a>` rather than fabricating a destination.
+ */
+function deriveRepoWebUrl(cloneUrl: string | null | undefined): string | null {
+  const raw = cloneUrl?.trim()
+  if (!raw) return null
+  const stripGitSuffix = (path: string): string => path.replace(/\.git$/i, '')
+  if (/^https?:\/\//i.test(raw)) {
+    try {
+      const url = new URL(raw)
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') return null
+      url.pathname = stripGitSuffix(url.pathname)
+      url.username = ''
+      url.password = ''
+      return url.toString()
+    } catch {
+      return null
+    }
+  }
+  // scp-like syntax: git@host:owner/repo(.git)
+  const scpMatch = /^[^@\s]+@([^:\s]+):(.+)$/.exec(raw)
+  if (scpMatch) {
+    const host = scpMatch[1]
+    const rawPath = scpMatch[2]
+    if (!host || !rawPath) return null
+    const path = stripGitSuffix(rawPath.replace(/^\/+/, ''))
+    if (!path) return null
+    return `https://${host}/${path}`
+  }
+  return null
+}
+
 function statusbarWorkspaceLabel(
   repositories: ReadonlyArray<Repository> | undefined,
   activeRepositoryId: string | null | undefined,
@@ -617,6 +655,72 @@ function IdeCursorRailRow({ cursor }: { readonly cursor: KeeperCursor }) {
   `
 }
 
+/**
+ * Repo-origin block for the IDE top bar — prototype `.ide-repo` chrome.
+ *
+ * Renders the active repository's origin clone URL (copy-on-click), an
+ * optional GitHub-style web link, and the default branch using the vendored
+ * keeper-v2 `.ide-repo` / `.ide-remote` / `.ide-web` / `.br` skin classes.
+ *
+ * Data honesty:
+ *  - origin URL + default branch come from the live `Repository`.
+ *  - the web link is only rendered when a usable https URL can be derived.
+ *  - the prototype's "변경 N건" dirty count has no live source on
+ *    `Repository`, so it is surfaced as a `data-stub` placeholder (no number).
+ */
+function IdeRepoOrigin({
+  repositories,
+  activeRepositoryId,
+}: {
+  readonly repositories: ReadonlyArray<Repository> | undefined
+  readonly activeRepositoryId: string | null | undefined
+}) {
+  const [copied, setCopied] = useState(false)
+  const repository = activeStatusbarRepository(repositories, activeRepositoryId)
+  if (!repository) return null
+
+  const origin = repository.url.trim()
+  const branch = repository.default_branch.trim()
+  const webUrl = deriveRepoWebUrl(origin)
+
+  const copyOrigin = () => {
+    if (!origin) return
+    const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined
+    if (!clipboard) return
+    void clipboard.writeText(origin).then(() => {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1100)
+    }).catch(() => {
+      // Clipboard can be blocked by permissions; leave the label unchanged.
+    })
+  }
+
+  return html`
+    <span
+      class="ide-repo"
+      data-testid="ide-repo-origin"
+      title=${`이 keeper 워크트리의 origin (git remote) · ${repository.local_path || repository.name}`}
+    >
+      ${origin
+        ? html`
+          <button
+            type="button"
+            class="ide-remote mono"
+            title="origin 클론 URL 복사"
+            onClick=${copyOrigin}
+          >${copied ? '✓ 복사됨' : origin}</button>
+        `
+        : html`<span class="ide-remote mono" data-stub="repo-origin">origin URL 미수신</span>`}
+      ${webUrl
+        ? html`<a class="ide-web" href=${webUrl} target="_blank" rel="noreferrer" title="웹에서 보기 ↗">↗</a>`
+        : null}
+      ${branch ? html`<span class="br" title="기본 브랜치 (default_branch)">${branch}</span>` : null}
+      ${' · '}
+      <span data-stub="repo-dirty-count" title="변경 파일 수 — 라이브 신호 없음">변경 미수신</span>
+    </span>
+  `
+}
+
 export function IdeShell() {
   const workspaceStore = useMemo(() => createIdeDataWorkspaceStore(), [])
 
@@ -883,6 +987,10 @@ export function IdeShell() {
               ? `base_path: ${statusbar.workspaceBasePath} (set MASC_BASE_PATH to change)`
               : undefined}
           >${statusbar.workspaceLabel}</span>
+          <${IdeRepoOrigin}
+            repositories=${repositories}
+            activeRepositoryId=${activeRepositoryId}
+          />
           <div
             class="ide-plane-statusbar-meta"
             aria-label="IDE operational context"
@@ -969,14 +1077,14 @@ export function IdeShell() {
               class="ide-plane-conversation ide-v2-rail v2-ide-panel"
               data-testid="ide-right-rail"
             >
-              <div class="ide-v2-rail-tabs" role="tablist" aria-label="IDE right rail">
+              <div class="ide-v2-rail-tabs ide-rail-tabs" role="tablist" aria-label="IDE right rail">
                 ${IDE_RIGHT_RAIL_TABS.map(tab => html`
                   <button
                     key=${tab.id}
                     type="button"
                     role="tab"
                     aria-selected=${rightRailTab === tab.id ? 'true' : 'false'}
-                    class=${`ide-v2-rail-tab ${rightRailTab === tab.id ? 'on' : ''}`}
+                    class=${`ide-v2-rail-tab ide-rail-tab ${rightRailTab === tab.id ? 'on' : ''}`}
                     onClick=${() => setRightRailTab(tab.id)}
                   >${tab.label}</button>
                 `)}

--- a/dashboard/src/components/keeper-detail-page.test.ts
+++ b/dashboard/src/components/keeper-detail-page.test.ts
@@ -1,5 +1,6 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
+import { fireEvent } from '@testing-library/preact'
 import { afterEach, describe, expect, it } from 'vitest'
 import { keepers, tasks } from '../store'
 import type { Keeper, Task } from '../types'
@@ -55,11 +56,21 @@ describe('KeeperWorkspaceRoster', () => {
     const container = renderInto(html`<${KeeperWorkspaceRoster} activeName="sangsu" />`)
 
     expect(container.textContent).toContain('전체3')
-    expect(container.textContent).toContain('실행중1')
-    expect(container.textContent).toContain('실행 중')
-    expect(container.textContent).toContain('대기 · 일시정지')
-    expect(container.textContent).toContain('중지 · 종료됨')
-    expect(container.querySelector('.kw-roster-search')).not.toBeNull()
+    // v2 filter chips carry the SHORT label + count ('실행' + '1'), not the old
+    // combined '실행중1' chip label (rails.jsx filter chips).
+    expect(container.textContent).toContain('실행1')
+    // v2 status group headers render the SHORT label + count in the body and the
+    // FULL label in the .roster-group title attribute; query the title to keep the
+    // exact full-label checks.
+    const groupTitles = Array.from(container.querySelectorAll('.roster-group')).map(g => g.getAttribute('title'))
+    expect(groupTitles).toContain('실행 중')
+    expect(groupTitles).toContain('대기 · 일시정지')
+    expect(groupTitles).toContain('중지 · 종료됨')
+    // v2 mounts the search input only after toggling the '⌕' .rfilter-icon
+    // (searchOpen defaults false); the class is now .roster-search.
+    expect(container.querySelector('.roster-search')).toBeNull()
+    fireEvent.click(container.querySelector('.rfilter-icon') as HTMLButtonElement)
+    expect(container.querySelector('.roster-search')).not.toBeNull()
     expect(container.querySelector('[aria-current="true"]')?.textContent).toContain('sangsu')
   })
 })
@@ -69,7 +80,12 @@ describe('KeeperWorkspaceRail', () => {
     tasks.value = [makeTask()]
     const container = renderInto(html`<${KeeperWorkspaceRail} keeper=${makeKeeper()} onToggleDetail=${() => {}} />`)
 
-    expect(container.textContent).toContain('런타임 · 처리량')
+    // v2 rail split the old combined '런타임 · 처리량' card into separate
+    // 런타임 (RuntimeSection / .rtc-card) and 처리량 (ThroughputSection) sections,
+    // each with its own .ctx-sec h4 header.
+    const sectionHeaders = Array.from(container.querySelectorAll('.ctx-sec h4')).map(h => h.textContent)
+    expect(sectionHeaders).toContain('런타임')
+    expect(sectionHeaders).toContain('처리량')
     expect(container.textContent).toContain('claude-sonnet-4')
     expect(container.textContent).toContain('oas-seoul-1')
     expect(container.textContent).toContain('62%')

--- a/dashboard/src/components/keeper-detail.test.ts
+++ b/dashboard/src/components/keeper-detail.test.ts
@@ -335,8 +335,10 @@ describe('KeeperDetailPage', () => {
     // 3-pane workspace renders (roster | conversation | context rail) without
     // tripping the monitoring error boundary.
     expect(container.querySelector('.kw-grid')).toBeTruthy()
-    expect(container.querySelector('.kw-roster')).toBeTruthy()
-    expect(container.querySelector('.kw-rail')).toBeTruthy()
+    // v2 reskin renamed the pane roots: KeeperWorkspaceRoster '.kw-roster' -> '.roster',
+    // KeeperWorkspaceRail '.kw-rail' -> '.ctx'. Same elements, retargeted selectors.
+    expect(container.querySelector('.roster')).toBeTruthy()
+    expect(container.querySelector('.ctx')).toBeTruthy()
     // The grid binds data-mobile-pane to the keeperMobilePane signal — the
     // load-bearing hook the <=860px CSS pane-switch depends on. Entering a
     // keeper resets the signal to 'chat', so the attribute must reflect that

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -150,7 +150,7 @@ describe('KeeperWorkspaceChat', () => {
       `, container)
     })
 
-    const slug = container.querySelector('.kw-chat-slug') as HTMLElement | null
+    const slug = container.querySelector('.chat-head .sub .sub-ns') as HTMLElement | null
     expect(slug).not.toBeNull()
     expect(slug?.textContent).toContain('~/wt/sangsu')
   })
@@ -193,6 +193,8 @@ describe('KeeperWorkspaceChat', () => {
     const { keeperMobilePane } = await import('../keeper-detail-state')
     keeperMobilePane.value = 'chat'
 
+    // The back button is mobile-only in the reskinned ChatHeader (desktop keeps
+    // the roster visible), so render in mobile mode to exercise the same behavior.
     await act(async () => {
       render(html`
         <${KeeperWorkspaceChat}
@@ -200,6 +202,7 @@ describe('KeeperWorkspaceChat', () => {
           detailOpen=${false}
           onToggleDetail=${vi.fn()}
           onClear=${vi.fn()}
+          mobile=${true}
         />
       `, container)
     })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -28,13 +28,12 @@ import { keeperThreads } from '../../keeper-state'
 import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
+import { Pill, type PillTone } from '../v2/primitives-v2'
+import { phaseTone, phasePulse } from '../v2/keeper-fsm'
 import {
   WorkspaceSigil,
-  StatusDot,
   keeperBucket,
-  keeperStatusTone,
   keeperPhaseLabel,
-  statePillTone,
 } from './keeper-workspace-shared'
 
 type WorkspaceUtilityAction = 'turn' | 'clear' | 'artifacts' | 'detail' | 'config'
@@ -243,7 +242,7 @@ function WorkspaceCommandButtons({
           <button
             key=${command.id}
             type="button"
-            class=${`kw-chat-command-icon${command.danger ? ' danger' : ''}${command.active ? ' active' : ''} v2-monitoring-action`}
+            class=${`act icon${command.danger ? ' danger' : ''}${command.active ? ' on' : ''}`}
             aria-label=${command.label}
             aria-pressed=${command.active ? 'true' : undefined}
             title=${command.title}
@@ -285,40 +284,42 @@ function ChatHeader({
   onOpenConfig?: () => void
 }): VNode {
   const bucket = keeperBucket(keeper)
-  const tone = keeperStatusTone(keeper)
-  const pill = statePillTone(tone)
   const live = bucket === 'running'
+  const tone = phaseTone(keeper.lifecycle_phase)
+  const pillTone: PillTone = tone === 'idle' ? 'neutral' : tone === 'busy' ? 'warn' : tone
+  const pulse = phasePulse(keeper.lifecycle_phase)
+  const phase = keeper.lifecycle_phase ?? keeper.phase ?? keeperPhaseLabel(keeper)
+  const basepath = keeper.sandbox_target ?? keeper.skill_primary ?? keeper.active_model ?? keeper.model ?? ''
 
-  // Single-row header: identity + status + actions only. Runtime / model /
-  // throughput / scope live in the context rail (ThroughputSection) — the
-  // canonical home — so the header stays slim and the conversation gets the
-  // vertical space instead of a redundant metadata sub-row.
+  // Prototype ChatHeader (shell.jsx): avatar + identity (name + phase pill) +
+  // basepath sub + action icons. The back button is mobile-only (desktop keeps
+  // the roster visible). Runtime/model/throughput live in the context rail.
   return html`
-    <div class="kw-chat-head v2-monitoring-toolbar">
-      <button
-        type="button"
-        class="kw-chat-back kw-act v2-monitoring-action"
-        title="키퍼 로스터"
-        aria-label="키퍼 로스터로 돌아가기"
-        onClick=${() => {
-          keeperMobilePane.value = 'roster'
-          onBack?.()
-        }}
-        data-testid="kw-chat-back-to-roster"
-      >
-        <${ChevronLeft} size=${16} aria-hidden="true" />
-      </button>
+    <div class=${`chat-head${mobile ? ' is-mobile' : ''}`}>
+      ${mobile
+        ? html`<button
+            type="button"
+            class="chat-back"
+            title="키퍼 로스터"
+            aria-label="키퍼 로스터로 돌아가기"
+            onClick=${() => {
+              keeperMobilePane.value = 'roster'
+              onBack?.()
+            }}
+            data-testid="kw-chat-back-to-roster"
+          ><${ChevronLeft} size=${16} aria-hidden="true" /></button>`
+        : null}
       <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${live} />
-      <div class="kw-chat-id">
-        <div class="kw-chat-name-row">
-          <h2 class="kw-chat-name">${keeper.koreanName ?? keeper.name}</h2>
-          <span class=${`kw-state-pill ${pill}`} title=${keeperDisplayStatus(keeper)}>
-            <${StatusDot} tone=${tone} pulse=${live} />${keeperPhaseLabel(keeper)}
-          </span>
+      <div class="chat-id">
+        <div class="name-row">
+          <h2>${keeper.name}</h2>
+          <${Pill} tone=${pillTone} dot=${pillTone === 'neutral' ? 'idle' : pillTone} dotPulse=${pulse} title=${keeperDisplayStatus(keeper)}>${phase}</${Pill}>
         </div>
-        <div class="kw-chat-slug">${keeper.sandbox_target ?? keeper.skill_primary ?? keeper.active_model ?? keeper.model ?? ''}</div>
+        <div class="sub">
+          <span class="sub-ns" title="basepath — 이 keeper의 격리된 worktree 루트"><span class="mono">${basepath}</span></span>
+        </div>
       </div>
-      <div class="kw-chat-actions">
+      <div class="chat-actions">
         <${WorkspaceCommandButtons}
           keeper=${keeper}
           mobile=${mobile}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -72,7 +72,10 @@ describe('KeeperWorkspaceRail', () => {
 
   it('renders the runtime / throughput vitals', () => {
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
-    expect(container.textContent).toContain('런타임 · 처리량')
+    // v2 rail splits the old combined "런타임 · 처리량" header into separate
+    // "처리량" and "런타임" sections; assert both still render their vitals.
+    expect(container.textContent).toContain('처리량')
+    expect(container.textContent).toContain('런타임')
     expect(container.textContent).toContain('sonnet-4.6')
     expect(container.textContent).toContain('oas·seoul-1')
   })
@@ -80,15 +83,17 @@ describe('KeeperWorkspaceRail', () => {
   it('hides the model cell when no model was reported', () => {
     const k = mkKeeper({ runtime_canonical: 'runpod_gemma' })
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`)
-    expect(container.textContent).toContain('런타임 · 처리량')
+    expect(container.textContent).toContain('런타임')
     expect(container.textContent).toContain('runpod_gemma')
-    expect(container.textContent).not.toContain('모델')
-    expect(container.textContent).not.toContain('—')
+    // The model cell (.rtc-model) is not rendered when no model is reported.
+    expect(container.querySelector('.rtc-model')).toBeNull()
   })
 
   it('renders the context-window occupancy percent', () => {
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
-    expect(container.textContent).toContain('컨텍스트 점유')
+    // v2 renames the "컨텍스트 점유" header to "컨텍스트" with a "윈도우 사용량" usage label.
+    expect(container.textContent).toContain('컨텍스트')
+    expect(container.textContent).toContain('윈도우 사용량')
     expect(container.textContent).toContain('62%')
     expect(container.textContent).toContain('124.0k')
   })
@@ -101,24 +106,30 @@ describe('KeeperWorkspaceRail', () => {
 
   it('renders owned task status in the top row and title on its own line', () => {
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
-    const tag = container.querySelector('.kw-tasktag') as HTMLElement | null
+    // v2 renames .kw-tasktag → .tasktag and .kw-tasktag-row → .tasktag-top.
+    const tag = container.querySelector('.tasktag') as HTMLElement | null
     expect(tag).not.toBeNull()
-    const row = tag?.querySelector('.kw-tasktag-row')
+    const row = tag?.querySelector('.tasktag-top')
     expect(row).not.toBeNull()
     expect(row?.textContent).toContain('T-4412')
     expect(row?.textContent).toContain('in_progress')
-    expect(tag?.textContent).toContain('세그먼트 리텐션 대시보드')
+    // Title lives outside the top row on its own .ttl line.
+    expect(row?.textContent).not.toContain('세그먼트 리텐션 대시보드')
+    expect(tag?.querySelector('.ttl')?.textContent).toContain('세그먼트 리텐션 대시보드')
   })
 
-  it('renders throughput range chips when a sparkline is available', () => {
+  it('renders the throughput sparkline when a series is available', () => {
     const k = mkKeeper({
       metrics_series: [{ wall_tokens_per_second: 10 }, { wall_tokens_per_second: 64 }] as unknown as Keeper['metrics_series'],
     })
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`)
-    const chips = container.querySelector('.kw-range-chips')
-    expect(chips).not.toBeNull()
-    expect(chips?.textContent).toContain('저부하')
-    expect(chips?.textContent).toContain('고부하')
+    // v2 dropped the labeled 저부하/고부하 load-range chips; the throughput
+    // section now renders the series as a .tps-spark sparkline (>= 2 points)
+    // alongside the latest tok/s value. Assert the viz renders from the series.
+    const spark = container.querySelector('.tps-spark')
+    expect(spark).not.toBeNull()
+    expect(spark?.querySelectorAll('span').length).toBeGreaterThanOrEqual(2)
+    expect(container.querySelector('.tps-val')?.textContent).toContain('64')
   })
 
   it('opens the planning task detail when an owned task is clicked', () => {
@@ -155,21 +166,22 @@ describe('KeeperWorkspaceRail', () => {
 
   it('renders the auto-compact threshold label', () => {
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${() => {}} />`)
+    // With meter data the gate renders as the "compact NN%" meter mark.
     expect(container.textContent).toContain('compact 72%')
-    expect(container.textContent).toContain('ratio_gate 72%')
-    expect(container.textContent).toContain('profile balanced')
-    expect(container.textContent).toContain('message_gate 120')
+    // The meter mark also exposes the gate percentage via its label element.
+    expect(container.querySelector('.meter-mark-lbl')?.textContent).toContain('compact 72%')
   })
 
   it('renders context metrics as missing when only a zero default exists', () => {
     const k = mkKeeper({ context_ratio: 0, compaction_count: 0, last_compaction_ago_s: 0 })
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} onToggleDetail=${() => {}} />`)
-    expect(container.textContent).toContain('컨텍스트 사용량 미수신')
-    expect(container.textContent).toContain('컴팩트 기록 없음')
+    // v2 collapses the missing-context state into a single "윈도우 사용률 미수신"
+    // empty card (.ctx-empty); no fake usage meter and no usage percentage.
+    expect(container.textContent).toContain('윈도우 사용률 미수신')
+    expect(container.querySelector('.ctx-empty')).not.toBeNull()
     expect(container.textContent).not.toContain('윈도우 사용량')
-    expect(container.querySelector('.kw-meter')).toBeNull()
-    expect(container.textContent).not.toContain('마지막 컴팩트 0초 전')
-    const button = container.querySelector('.kw-compact-btn') as HTMLButtonElement | null
+    expect(container.querySelector('.meter')).toBeNull()
+    const button = container.querySelector('.cmp-run') as HTMLButtonElement | null
     expect(button).not.toBeNull()
     expect(button?.disabled).toBe(true)
   })
@@ -180,14 +192,15 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('윈도우 사용률 미수신')
     expect(container.textContent).toContain('37.8k')
     expect(container.textContent).not.toContain('윈도우 사용량')
-    expect(container.querySelector('.kw-meter')).toBeNull()
-    expect(container.textContent).toContain('compact ratio_gate는 50%입니다')
+    expect(container.querySelector('.meter')).toBeNull()
+    // The empty card still surfaces the compaction gate (default 50%) as ratio_gate.
+    expect(container.textContent).toContain('ratio_gate 50%')
   })
 
   it('runs overflow compaction without force through the existing MCP tool', async () => {
     shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
     const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, phase: 'Overflowed' })} onToggleDetail=${() => {}} />`)
-    fireEvent.click(getByRole('button', { name: '지금 compact' }))
+    fireEvent.click(getByRole('button', { name: /지금 컴팩트/ }))
 
     await waitFor(() => {
       expect(callMcpTool).toHaveBeenCalledWith('masc_keeper_compact', {
@@ -201,7 +214,7 @@ describe('KeeperWorkspaceRail', () => {
   it('confirms before forcing compaction on running keepers', async () => {
     shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
     const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, phase: 'Running' })} onToggleDetail=${() => {}} />`)
-    fireEvent.click(getByRole('button', { name: '지금 compact' }))
+    fireEvent.click(getByRole('button', { name: /지금 컴팩트/ }))
 
     await waitFor(() => {
       expect(requestConfirm).toHaveBeenCalledWith(expect.objectContaining({
@@ -219,7 +232,7 @@ describe('KeeperWorkspaceRail', () => {
     vi.mocked(requestConfirm).mockResolvedValueOnce(false)
     shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
     const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, phase: 'Running' })} onToggleDetail=${() => {}} />`)
-    fireEvent.click(getByRole('button', { name: '지금 compact' }))
+    fireEvent.click(getByRole('button', { name: /지금 컴팩트/ }))
 
     await waitFor(() => expect(requestConfirm).toHaveBeenCalled())
     expect(callMcpTool).not.toHaveBeenCalled()
@@ -228,10 +241,15 @@ describe('KeeperWorkspaceRail', () => {
   it('fires onToggleDetail from the 운영 상세 button', () => {
     const onToggle = vi.fn()
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} onToggleDetail=${onToggle} />`)
-    const btn = container.querySelector('.kw-detail-btn') as HTMLElement
+    // v2 replaces the single .kw-detail-btn with .cmp-open inspector entries that
+    // route to the operational detail body. The compaction-snapshot entry carries
+    // the "운영 상세에서 보기" label and fires onToggleDetail.
+    const btn = Array.from(container.querySelectorAll('.cmp-open')).find(
+      el => el.textContent?.includes('운영 상세'),
+    ) as HTMLElement | undefined
     expect(btn).toBeTruthy()
-    expect(btn.textContent).toContain('운영 상세')
-    fireEvent.click(btn)
+    expect(btn?.textContent).toContain('운영 상세')
+    fireEvent.click(btn as HTMLElement)
     expect(onToggle).toHaveBeenCalled()
   })
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -1,8 +1,10 @@
-// Keeper Workspace — context rail (right). Runtime/throughput, context-window
-// occupancy, owned tasks, recent tool calls, and the "운영 상세" toggle that
-// surfaces the full KeeperDetailBody. Most data comes from the live Keeper
-// object + the tasks store; the recent-tool-calls section lazy-loads the rich
-// per-call store (see keeper-workspace-tool-calls.ts).
+// Keeper Workspace — context rail (right). Ported to the keeper-v2 prototype DOM
+// (rails.jsx ContextRail): `.ctx` → `.ctx-scroll` → `.ctx-sec` sections (주의 /
+// 런타임 `.rtc-card` / 처리량 `.tps-card` / 컨텍스트 `.ctx-card` / 소유 태스크
+// `.ctx-list`), styled by the vendored SSOT CSS. Live wiring (Keeper object +
+// tasks store + masc_keeper_compact) is unchanged; only the DOM/classes changed.
+// Data gaps (runtime capability flags, effort segments, compaction/memory
+// inspectors) are MARKED, never faked.
 
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
@@ -11,8 +13,7 @@ import { shellAuthSummary, tasks } from '../../store'
 import type { Keeper, Task } from '../../types'
 import { navigate } from '../../router'
 import { keeperModelLabel, keeperRuntimeLabel } from './keeper-workspace-shared'
-import { KeeperWorkspaceRecentTools } from './keeper-workspace-tool-calls'
-import { formatDuration } from '../../lib/format-time'
+import { CountBadge } from '../v2/primitives-v2'
 import { callMcpTool } from '../../api/mcp'
 import { showToast } from '../common/toast'
 import { requestConfirm } from '../common/confirm-dialog'
@@ -79,9 +80,6 @@ function attentionFallback(keeper: Keeper): string | null {
 
 type AttentionItem = { sev: 'bad' | 'warn'; text: string }
 
-/** Attention items from the same live signals the roster badge counts
- *  (blocked tasks + explicit flag). No fabricated severities — the section
- *  is omitted entirely when there is nothing to surface. */
 function attentionItems(keeper: Keeper): AttentionItem[] {
   const items: AttentionItem[] = []
   const blocked = keeper.blocked_task_count ?? 0
@@ -97,13 +95,13 @@ function AttentionSection({ keeper }: { keeper: Keeper }): VNode | null {
   const items = attentionItems(keeper)
   if (items.length === 0) return null
   return html`
-    <div class="kw-sec v2-monitoring-panel">
-      <h4>주의 <span class="kw-kp-att">${items.length}</span></h4>
-      <div class="kw-att-list v2-monitoring-row">
+    <div class="ctx-sec">
+      <h4 style=${{ display: 'flex', alignItems: 'center', gap: '7px' }}>주의 <${CountBadge}>${items.length}</${CountBadge}></h4>
+      <div class="att-list">
         ${items.map((it, i) => html`
-          <div class=${`kw-att-item ${it.sev} v2-monitoring-row`} key=${`${it.text}-${i}`}>
-            <span class="kw-att-dot" aria-hidden="true"></span>
-            <span class="kw-att-text" title=${it.text}>${it.text}</span>
+          <div class=${`att-item ${it.sev}`} key=${`${it.text}-${i}`}>
+            <span class="att-dot" aria-hidden="true"></span>
+            <span class="att-text" title=${it.text}>${it.text}</span>
           </div>
         `)}
       </div>
@@ -111,9 +109,49 @@ function AttentionSection({ keeper }: { keeper: Keeper }): VNode | null {
   `
 }
 
-function formatAgo(seconds: number | null | undefined): string | null {
-  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds < 0) return null
-  return `${formatDuration(seconds)} 전`
+function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
+  const model = keeperModelLabel(keeper)
+  const runtime = keeperRuntimeLabel(keeper)
+  const max = contextMax(keeper)
+  const ctxK = max ? formatK(max) : null
+  return html`
+    <div class="ctx-sec">
+      <h4>런타임</h4>
+      <div class="rtc-card">
+        <div class="rtc-id mono">${runtime ?? '런타임 미수신'}</div>
+        ${model
+          ? html`<div class="rtc-model mono">${model}${ctxK ? ` · ${ctxK} ctx` : ''}</div>`
+          : null}
+        ${/* Live execution snapshot carries no capability flags / effort segments
+             (multimodal/json/tool-choice, low/medium/high). Marked, not faked. */ ''}
+        <div class="rtc-na" data-stub="runtime-capabilities">능력·effort 정보 미수신</div>
+      </div>
+    </div>
+  `
+}
+
+function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
+  const series = tpsSeries(keeper)
+  const peak = Math.max(1, ...series)
+  const latest = series.at(-1) ?? 0
+  const live = keeper.status.toLowerCase() === 'running' || keeper.status.toLowerCase() === 'active'
+  return html`
+    <div class="ctx-sec">
+      <h4>처리량</h4>
+      <div class="tps-card">
+        <div class="tps-now">
+          <span class=${`tps-val${latest > 0 ? '' : ' idle'}`}>${latest > 0 ? latest : '—'}</span>
+          <span class="tps-unit">tok/s</span>
+          ${live && latest > 0 ? html`<span class="tps-flag"><span class="tps-dot"></span>live</span>` : null}
+        </div>
+        ${series.length >= 2
+          ? html`<div class="tps-spark" aria-hidden="true">
+              ${series.map(v => html`<span style=${{ height: `${Math.max(6, (v / peak) * 100)}%`, opacity: 0.35 + 0.65 * (v / peak) }}></span>`)}
+            </div>`
+          : null}
+      </div>
+    </div>
+  `
 }
 
 function compactionGatePct(keeper: Keeper): number {
@@ -132,7 +170,7 @@ function compactRequiresForce(keeper: Keeper): boolean {
   return status === 'running' || status === 'active' || status === 'busy' || status === 'failing'
 }
 
-function ContextSection({ keeper }: { keeper: Keeper }): VNode {
+function ContextSection({ keeper, onToggleDetail }: { keeper: Keeper; onToggleDetail: () => void }): VNode {
   const [compacting, setCompacting] = useState(false)
   const pct = contextPercent(keeper)
   const compactAt = compactionGatePct(keeper)
@@ -141,17 +179,8 @@ function ContextSection({ keeper }: { keeper: Keeper }): VNode {
   const baseTokens = keeper.context_tokens ?? keeper.context?.context_tokens ?? null
   const tokens = formatK(baseTokens)
   const maxLabel = formatK(max)
-  const msgCount = keeper.context?.message_count ?? null
-  const hasCheckpoint = keeper.context?.has_checkpoint ?? null
-  const contextSource = nonEmpty(keeper.context_source ?? keeper.context?.source)
   const compactionCount = keeper.compaction_count ?? null
-  const compactionProfile = nonEmpty(keeper.compaction_profile)
-  const messageGate = keeper.compaction_message_gate
-  const tokenGate = keeper.compaction_token_gate
   const hasCompactionHistory = typeof compactionCount === 'number' && compactionCount > 0
-  const lastCompactionAgo = hasCompactionHistory ? formatAgo(keeper.last_compaction_ago_s) : null
-  const lastCompactionSaved = hasCompactionHistory ? formatK(keeper.last_compaction_saved_tokens) : null
-  const hasUsageBreakdown = baseTokens !== null || max !== null || msgCount !== null || hasCheckpoint !== null || contextSource != null
   const hasMeterData = pct !== null && (pct > 0 || max !== null)
   const compactAccess = dashboardAuthAccess(shellAuthSummary.value, 'worker')
   const canCompact = compactAccess.allowed && !compacting
@@ -174,21 +203,12 @@ function ContextSection({ keeper }: { keeper: Keeper }): VNode {
       }
       setCompacting(true)
       try {
-        const raw = await callMcpTool('masc_keeper_compact', {
-          name: keeper.name,
-          force,
-        })
-        const parsed = JSON.parse(raw) as {
-          before_tokens?: number
-          after_tokens?: number
-          phase_after?: string
-        }
+        const raw = await callMcpTool('masc_keeper_compact', { name: keeper.name, force })
+        const parsed = JSON.parse(raw) as { before_tokens?: number; after_tokens?: number; phase_after?: string }
         const before = formatK(parsed.before_tokens)
         const after = formatK(parsed.after_tokens)
         showToast(
-          before && after
-            ? `${keeper.name} compact 완료: ${before} -> ${after}`
-            : `${keeper.name} compact 완료`,
+          before && after ? `${keeper.name} compact 완료: ${before} -> ${after}` : `${keeper.name} compact 완료`,
           'success',
         )
         await refreshAfterRuntimeAction()
@@ -199,125 +219,54 @@ function ContextSection({ keeper }: { keeper: Keeper }): VNode {
       }
     })()
   }
-  const contextMeta = html`
-    <div class="kw-ctx-meta">
-      ${msgCount !== null ? html`<span>메시지 ${msgCount}개</span>` : null}
-      ${hasCheckpoint === true ? html`<span>체크포인트 보유</span>` : null}
-      ${contextSource ? html`<span>출처 ${contextSource}</span>` : null}
+
+  const usageHeader = html`
+    <div style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+      <span style=${{ fontSize: '12px', color: 'var(--text-mid)' }}>윈도우 사용량</span>
+      <span class="mono" style=${{ fontSize: '14px', color: hot ? 'var(--status-bad)' : 'var(--volt-strong)' }}>${pct ?? 0}%</span>
     </div>
   `
-  let usageBody: VNode
-  if (hasMeterData) {
-    usageBody = html`
-      <div class="flex items-baseline justify-between">
-        <span class="text-xs text-[var(--color-fg-secondary)]">윈도우 사용량</span>
-        <span class=${`font-mono text-sm ${hot ? 'text-[var(--color-status-err)]' : 'text-[var(--color-accent-fg)]'}`}>${pct ?? 0}%</span>
-      </div>
-      <div class="kw-meter-wrap">
-        <div class=${`kw-meter${hot ? ' hot' : ''}`}><span style=${{ width: `${pct ?? 0}%` }}></span></div>
-        <span class="kw-meter-mark" style=${{ left: `${compactAt}%` }} title=${`compact ratio_gate ${compactAt}%`}>
-          <i class="kw-meter-mark-lbl">compact ${compactAt}%</i>
-        </span>
-      </div>
-      ${tokens || maxLabel
-        ? html`<div class="kw-ctx-tok">
-            <span class="mono">${tokens ?? '—'}</span>
-            <span aria-hidden="true">/</span>
-            <span class="mono">${maxLabel ?? '—'}</span>
-            <span class="lbl">사용 / 전체 윈도우</span>
-          </div>`
-        : null}
-      ${contextMeta}
-    `
-  } else if (hasUsageBreakdown) {
-    usageBody = html`
-      <div class="kw-context-empty">
-        <strong>윈도우 사용률 미수신</strong>
-        <span>전체 윈도우 총량이 없어 비율을 숨깁니다. compact ratio_gate는 ${compactAt}%입니다.</span>
-      </div>
-      ${tokens || maxLabel
-        ? html`<div class="kw-ctx-tok">
-            <span class="mono">${tokens ?? '—'}</span>
-            <span aria-hidden="true">/</span>
-            <span class="mono">${maxLabel ?? '—'}</span>
-            <span class="lbl">사용 / 전체 윈도우</span>
-          </div>`
-        : null}
-      ${contextMeta}
-    `
-  } else {
-    usageBody = html`
-      <div class="kw-context-empty">
-        <strong>컨텍스트 사용량 미수신</strong>
-        <span>런타임이 토큰/윈도우 메트릭을 아직 보내지 않았습니다.</span>
-      </div>
-    `
-  }
 
   return html`
-    <div class="kw-sec v2-monitoring-panel">
-      <h4>컨텍스트 점유</h4>
-      <div class="kw-card v2-monitoring-card">
-        ${usageBody}
-        <div class="kw-cmp-readonly">
-          ${hasCompactionHistory
-            ? html`
-                <span>누적 컴팩트 ${compactionCount}회</span>
-                ${lastCompactionAgo ? html`<span>마지막 ${lastCompactionAgo}</span>` : null}
-                ${lastCompactionSaved ? html`<span>절약 ${lastCompactionSaved} tok</span>` : null}
-              `
-            : html`<span>컴팩트 기록 없음</span>`}
-          ${compactionProfile ? html`<span>profile ${compactionProfile}</span>` : null}
-          <span>ratio_gate ${compactAt}%</span>
-          ${typeof messageGate === 'number' && messageGate > 0 ? html`<span>message_gate ${messageGate}</span>` : null}
-          ${typeof tokenGate === 'number' && tokenGate > 0 ? html`<span>token_gate ${formatK(tokenGate) ?? tokenGate}</span>` : null}
+    <div class="ctx-sec">
+      <h4>컨텍스트</h4>
+      <div class="ctx-card">
+        ${hasMeterData
+          ? html`
+              ${usageHeader}
+              <div class="meter-wrap">
+                <div class=${`meter${hot ? ' hot' : ''}`}><span style=${{ width: `${pct ?? 0}%` }}></span></div>
+                <span class=${`meter-mark${hot ? ' hot' : ''}`} style=${{ left: `${compactAt}%` }}>
+                  <i class="meter-mark-lbl">compact ${compactAt}%</i>
+                </span>
+              </div>
+            `
+          : html`<div class="ctx-empty" data-stub="context-window"><strong>윈도우 사용률 미수신</strong><span>런타임이 전체 윈도우 총량을 아직 보내지 않았습니다. ratio_gate ${compactAt}%.</span></div>`}
+        <div class="ctx-tok">
+          <span class="mono">${tokens ?? '—'}</span>
+          <span class="ctx-tok-sep">/</span>
+          <span class="mono ctx-tok-full">${maxLabel ?? '—'}</span>
+          <span class="ctx-tok-lbl">사용 / 전체 윈도우</span>
         </div>
-        <div class="kw-cmp-actions">
+        <div class="cmp-actions">
           <button
             type="button"
-            class="kw-act kw-compact-btn v2-monitoring-action"
+            class=${`cmp-run${compacting ? ' busy' : ''}`}
             disabled=${!canCompact}
-            title=${compactAccess.allowed ? 'masc_keeper_compact force=true 실행' : compactReason}
+            title=${compactAccess.allowed ? 'masc_keeper_compact 실행' : compactReason}
             onClick=${runCompact}
-          >${compacting ? 'compact 중...' : '지금 compact'}</button>
+          >${compacting ? html`<span class="cmp-spin"></span> 컴팩트 실행 중…` : '◉ 지금 컴팩트'}</button>
         </div>
+        ${/* The prototype opens dedicated compaction-snapshot / memory inspectors;
+             those live overlays do not exist yet, so both route to the operational
+             detail body (FSM · 진단 · 정체성 · memory). Marked as a deferred wiring. */ ''}
+        <button type="button" class="cmp-open" data-stub="compaction-inspector" onClick=${onToggleDetail}>
+          ◉ 컴팩션 스냅샷${hasCompactionHistory ? ` · ${compactionCount}` : ''} <span class="cmp-open-sub">운영 상세에서 보기</span>
+        </button>
+        <button type="button" class="cmp-open" data-stub="memory-inspector" onClick=${onToggleDetail}>
+          ◈ 메모리 보기 <span class="cmp-open-sub">FSM · 진단 · 정체성</span>
+        </button>
       </div>
-    </div>
-  `
-}
-
-function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
-  const model = keeperModelLabel(keeper)
-  const runtime = keeperRuntimeLabel(keeper)
-  // scope (skill_primary) used to live in the chat header sub-row; folded here
-  // so the slim single-row header loses no information.
-  const scope = keeper.skill_primary ?? null
-  const series = tpsSeries(keeper)
-  const peak = Math.max(1, ...series)
-  const latest = series.length ? series[series.length - 1] : 0
-  return html`
-    <div class="kw-sec v2-monitoring-panel">
-      <h4>런타임 · 처리량</h4>
-      <div class=${`kw-vitals ${model ? '' : 'single'} v2-monitoring-row`}>
-        <div class=${`kw-vital ${runtime ? '' : 'muted'}`}><div class="vk">런타임</div><div class="vv" title=${runtime ?? ''}>${runtime ?? '런타임 미수신'}</div></div>
-        ${model ? html`<div class="kw-vital"><div class="vk">모델</div><div class="vv" title=${model}>${model}</div></div>` : null}
-        ${scope ? html`<div class="kw-vital" style=${{ gridColumn: '1 / -1' }}><div class="vk">scope</div><div class="vv" title=${scope}>${scope}</div></div>` : null}
-      </div>
-      ${series.length >= 2
-        ? html`<div class="kw-card mt-2 v2-monitoring-card">
-            <div class="flex items-baseline justify-between">
-              <span class="font-mono text-base text-[var(--color-status-ok)]">${latest}</span>
-              <span class="text-2xs text-[var(--color-fg-muted)]">tok/s</span>
-            </div>
-            <div class="mt-2 flex h-7 items-end gap-0.5" aria-hidden="true">
-              ${series.map(v => html`<span class="flex-1 rounded-[1px] bg-[var(--color-status-ok)]" style=${{ height: `${Math.max(6, (v / peak) * 100)}%`, opacity: 0.35 + 0.65 * (v / peak) }}></span>`)}
-            </div>
-          </div>
-          <div class="kw-range-chips">
-            <span class="kw-range-chip">저부하</span>
-            <span class="kw-range-chip">고부하</span>
-          </div>`
-        : null}
     </div>
   `
 }
@@ -328,27 +277,27 @@ function OwnedTasksSection({ keeper }: { keeper: Keeper }): VNode {
     navigate('workspace', { section: 'planning', task: task.id })
   }
   return html`
-    <div class="kw-sec v2-monitoring-panel">
+    <div class="ctx-sec">
       <h4>소유 태스크</h4>
-      <div class="kw-list v2-monitoring-row">
+      <div class="ctx-list">
         ${owned.length
           ? owned.map(t => html`
               <button
                 type="button"
-                class="kw-tasktag v2-monitoring-row"
+                class="tasktag"
                 key=${t.id}
-                title=${`${t.id} · ${t.title}`}
+                title=${`작업으로 이동 · ${t.id} · ${t.title}`}
                 aria-label=${`태스크 열기: ${t.id} ${t.title}`}
                 onClick=${() => openTask(t)}
               >
-                <div class="kw-tasktag-row">
+                <div class="tasktag-top">
                   <span class="tid">${t.id}</span>
-                  ${t.status ? html`<span class=${`tstate ${taskStateClass(t.status)}`}>${t.status}</span>` : null}
+                  ${t.status ? html`<span class=${`tasktag-state ${taskStateClass(t.status)}`}>${t.status}</span>` : null}
                 </div>
                 <span class="ttl">${t.title}</span>
               </button>
             `)
-          : html`<div class="kw-list-empty v2-monitoring-row">할당된 태스크 없음</div>`}
+          : html`<div style=${{ fontSize: '12px', color: 'var(--text-dim)' }}>할당된 태스크 없음</div>`}
       </div>
     </div>
   `
@@ -362,19 +311,13 @@ export function KeeperWorkspaceRail({
   onToggleDetail: () => void
 }): VNode {
   return html`
-    <aside class="kw-rail v2-monitoring-surface" aria-label="키퍼 컨텍스트">
-      <div class="kw-rail-scroll v2-monitoring-panel">
+    <aside class="ctx" aria-label="키퍼 컨텍스트">
+      <div class="ctx-scroll">
         <${AttentionSection} keeper=${keeper} />
         <${ThroughputSection} keeper=${keeper} />
-        <${ContextSection} keeper=${keeper} />
+        <${RuntimeSection} keeper=${keeper} />
+        <${ContextSection} keeper=${keeper} onToggleDetail=${onToggleDetail} />
         <${OwnedTasksSection} keeper=${keeper} />
-        <${KeeperWorkspaceRecentTools} keeperName=${keeper.name} />
-        <div class="kw-sec v2-monitoring-toolbar">
-          <button type="button" class="kw-detail-btn v2-monitoring-action" onClick=${onToggleDetail}>
-            <span>운영 상세</span>
-            <span class="sub">FSM · 진단 · 정체성 · 설정 →</span>
-          </button>
-        </div>
       </div>
     </aside>
   `

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -47,93 +47,45 @@ afterEach(() => {
 describe('KeeperWorkspaceRoster', () => {
   it('renders status groups with keeper rows', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const labels = Array.from(host.querySelectorAll('.kw-roster-group-label')).map(g => g.textContent)
-    expect(labels).toContain('실행 중')
-    expect(labels).toContain('대기 · 일시정지')
-    expect(labels).toContain('중지 · 종료됨')
-    expect(host.querySelectorAll('.kw-kp-row').length).toBe(3)
+    // Prototype group headers (`.roster-group`) carry the SHORT label as text
+    // and the full label in the `title` attribute (rails.jsx groupLabel).
+    const titles = Array.from(host.querySelectorAll('.roster-group')).map(g => g.getAttribute('title'))
+    expect(titles).toContain('실행 중')
+    expect(titles).toContain('대기 · 일시정지')
+    expect(titles).toContain('중지 · 종료됨')
+    expect(host.querySelectorAll('.kp-row').length).toBe(3)
   })
 
   it('marks the active keeper row', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const active = host.querySelector('.kw-kp-row[aria-current="true"]') as HTMLElement
+    const active = host.querySelector('.kp-row[aria-current="true"]') as HTMLElement
     expect(active?.textContent).toContain('masc-improver')
   })
 
   it('shows filter chip counts (all / running / attention)', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const chips = Array.from(host.querySelectorAll('.kw-rfilter')).map(c => c.textContent)
-    // 전체 3, 실행중 1 (only masc-improver), 주의 1 (rama)
+    const chips = Array.from(host.querySelectorAll('.rfilter')).map(c => c.textContent)
+    // 전체 3, 실행 1 (only masc-improver), 주의 1 (rama)
     expect(chips.some(c => c?.includes('전체') && c?.includes('3'))).toBe(true)
-    expect(chips.some(c => c?.includes('실행중') && c?.includes('1'))).toBe(true)
+    expect(chips.some(c => c?.includes('실행') && c?.includes('1'))).toBe(true)
     expect(chips.some(c => c?.includes('주의') && c?.includes('1'))).toBe(true)
   })
 
-  it('renders a Keepers title with the total count above the search box', () => {
+  it('shows the total keeper count on the 전체 filter chip', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const title = host.querySelector('.kw-roster-title') as HTMLElement | null
-    expect(title).not.toBeNull()
-    expect(title?.textContent).toContain('Keepers')
-    expect(title?.textContent).toContain('3')
+    // v2 dropped the standalone "Keepers" title; the total count now lives on
+    // the 전체 filter chip in the .roster-filters band.
+    const allChip = Array.from(host.querySelectorAll('.rfilter')).find(c => c.textContent?.includes('전체'))
+    expect(allChip).not.toBeUndefined()
+    expect(allChip?.textContent).toContain('3')
   })
 
-  it('renders a backed fleet summary band before scanning roster rows', () => {
-    keepers.value = [
-      mk({ name: 'running', status: 'running', lifecycle_phase: 'Running', context_ratio: 0.81 }),
-      mk({ name: 'paused', status: 'running', paused: true, lifecycle_phase: 'Paused' }),
-      mk({ name: 'offline', status: 'stopped', lifecycle_phase: 'Stopped' }),
-      mk({
-        name: 'approval',
-        status: 'running',
-        lifecycle_phase: 'Running',
-        blocked_task_count: 2,
-        current_gate: { kind: 'approval_required', tool: 'fs_write', risk: 'critical' },
-      }),
-    ]
-
-    render(html`<${KeeperWorkspaceRoster} activeName="running" />`, host)
-
-    const summary = host.querySelector('[data-testid="kw-roster-summary"]') as HTMLElement
-    expect(summary).not.toBeNull()
-    expect(summary.textContent).toContain('전체')
-    expect(summary.textContent).toContain('실행')
-    expect(summary.textContent).toContain('대기')
-    expect(summary.textContent).toContain('중지')
-    expect(summary.textContent).toContain('주의 1')
-    expect(summary.textContent).toContain('승인 1')
-    expect(summary.textContent).toContain('CTX 80%+ 1')
-    expect(Array.from(summary.querySelectorAll('.kw-roster-stat b')).map(node => node.textContent)).toEqual([
-      '4',
-      '2',
-      '1',
-      '1',
-    ])
-  })
-
-  it('keeps fleet summary totals independent of search and filter state', () => {
-    keepers.value = [
-      mk({ name: 'alpha', status: 'running', lifecycle_phase: 'Running' }),
-      mk({ name: 'beta', status: 'running', lifecycle_phase: 'Running' }),
-      mk({ name: 'gamma', status: 'stopped', lifecycle_phase: 'Stopped', needs_attention: true }),
-    ]
-
-    render(html`<${KeeperWorkspaceRoster} activeName="alpha" />`, host)
-    fireEvent.input(host.querySelector('.kw-roster-search') as HTMLInputElement, {
-      target: { value: 'gamma' },
-    })
-    fireEvent.click(Array.from(host.querySelectorAll('.kw-rfilter')).find(chip => chip.textContent?.includes('주의')) as HTMLButtonElement)
-
-    const summary = host.querySelector('[data-testid="kw-roster-summary"]') as HTMLElement
-    expect(Array.from(summary.querySelectorAll('.kw-roster-stat b')).map(node => node.textContent)).toEqual([
-      '3',
-      '2',
-      '0',
-      '1',
-    ])
-    const rows = host.querySelectorAll('.kw-kp-row')
-    expect(rows.length).toBe(1)
-    expect(rows[0]?.textContent).toContain('gamma')
-  })
+  // The fleet-summary band ([data-testid="kw-roster-summary"] with total/running/
+  // paused/offline + 주의/승인/CTX aggregates) was removed in the v2 reskin — the
+  // prototype roster opens straight into the .roster-filters band (전체/실행/주의
+  // chips). The two band-rendering tests that lived here are dropped with the
+  // feature. The underlying rosterFleetSummary() logic is still covered by the
+  // unit test below.
 
   it('computes fleet summary from live keeper fields without local-only fleet actions', () => {
     const result = rosterFleetSummary([
@@ -165,7 +117,7 @@ describe('KeeperWorkspaceRoster', () => {
     // switch the single-pane mobile layout over to that keeper's chat.
     keeperMobilePane.value = 'roster'
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" onSelect=${onSelect} />`, host)
-    const rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
+    const rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
     const sangsuRow = rows.find(r => r.textContent?.includes('sangsu'))
     sangsuRow?.click()
     expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'agents', keeper: 'sangsu' })
@@ -229,7 +181,7 @@ describe('KeeperWorkspaceRoster', () => {
   it('opens the command menu on right-click (contextmenu) without selecting the row', () => {
     const onSelect = vi.fn()
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" onSelect=${onSelect} />`, host)
-    const rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
+    const rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
     const sangsuRow = rows.find(r => r.textContent?.includes('sangsu')) as HTMLElement
 
     // fireEvent returns false when the (cancelable) event had preventDefault
@@ -246,7 +198,7 @@ describe('KeeperWorkspaceRoster', () => {
 
   it('opens the command menu on right-click of a mini-roster sigil', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" mini=${true} />`, host)
-    const minis = Array.from(host.querySelectorAll('.kw-kp-mini')) as HTMLElement[]
+    const minis = Array.from(host.querySelectorAll('.kp-row.mini')) as HTMLElement[]
     const ramaMini = minis.find(b => (b.getAttribute('aria-label') ?? '').includes('rama')) as HTMLElement
 
     fireEvent.contextMenu(ramaMini, { clientX: 60, clientY: 200 })
@@ -257,37 +209,48 @@ describe('KeeperWorkspaceRoster', () => {
 
   it('renders a status-toned dot in each group header (rg-dot)', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const groupDotTone = (label: string): string | undefined => {
-      const header = Array.from(host.querySelectorAll('.kw-roster-group')).find(
-        g => g.querySelector('.kw-roster-group-label')?.textContent === label,
+    // The prototype header (`.roster-group`) carries the status tone via its
+    // own bucket class (run/pause/off) and renders an untoned `.rg-dot` pip;
+    // the full status label is in the `title` attribute. Headers are keyed by
+    // the full label.
+    const groupTone = (label: string): { hasDot: boolean; cls: string | undefined } => {
+      const header = Array.from(host.querySelectorAll('.roster-group')).find(
+        g => g.getAttribute('title') === label,
       )
-      return header?.querySelector('.kw-dot')?.className
+      return { hasDot: !!header?.querySelector('.rg-dot'), cls: header?.className }
     }
-    // running → ok (green), paused → warn (amber), offline → idle (no tone class)
-    expect(groupDotTone('실행 중')).toContain('ok')
-    expect(groupDotTone('대기 · 일시정지')).toContain('warn')
-    const offlineDot = groupDotTone('중지 · 종료됨')
-    expect(offlineDot).toBeDefined()
-    expect(offlineDot).not.toContain('ok')
-    expect(offlineDot).not.toContain('warn')
-    expect(offlineDot).not.toContain('bad')
+    // running → run, paused → pause, offline → off (the 3 prototype buckets,
+    // 1:1 with the old ok/warn/idle tones).
+    const running = groupTone('실행 중')
+    expect(running.hasDot).toBe(true)
+    expect(running.cls).toContain('run')
+    const paused = groupTone('대기 · 일시정지')
+    expect(paused.hasDot).toBe(true)
+    expect(paused.cls).toContain('pause')
+    const offline = groupTone('중지 · 종료됨')
+    expect(offline.hasDot).toBe(true)
+    expect(offline.cls).toContain('off')
+    expect(offline.cls).not.toContain('run')
+    expect(offline.cls).not.toContain('pause')
   })
 
   it('filters by search query', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const search = host.querySelector('.kw-roster-search') as HTMLInputElement
+    // Prototype gates the search box behind the `.rfilter-icon` toggle.
+    fireEvent.click(host.querySelector('.rfilter-icon') as HTMLButtonElement)
+    const search = host.querySelector('.roster-search') as HTMLInputElement
     fireEvent.input(search, { target: { value: 'rama' } })
-    const rows = host.querySelectorAll('.kw-kp-row')
+    const rows = host.querySelectorAll('.kp-row')
     expect(rows.length).toBe(1)
     expect(rows[0]?.textContent).toContain('rama')
   })
 
   it('sorts the roster by name and attention count', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const sort = host.querySelector('.kw-roster-sort') as HTMLSelectElement
+    const sort = host.querySelector('.roster-sort') as HTMLSelectElement
 
     fireEvent.change(sort, { target: { value: 'name' } })
-    let rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
+    let rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
     expect(rows.map(r => r.textContent ?? '')).toEqual([
       expect.stringContaining('masc-improver'),
       expect.stringContaining('rama'),
@@ -295,68 +258,31 @@ describe('KeeperWorkspaceRoster', () => {
     ])
 
     fireEvent.change(sort, { target: { value: 'att' } })
-    rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
+    rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
     expect(rows[0]?.textContent).toContain('rama')
   })
 
   it('renders a compact sigil-only roster in mini mode', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" mini=${true} />`, host)
-    expect(host.querySelector('.kw-roster-search')).toBeNull()
-    expect(host.querySelector('.kw-roster-sort')).toBeNull()
-    expect(host.querySelectorAll('.kw-kp-mini').length).toBe(3)
-    expect(host.querySelector('.kw-kp-mini[aria-current="true"]')).not.toBeNull()
+    expect(host.querySelector('.roster-search')).toBeNull()
+    expect(host.querySelector('.roster-sort')).toBeNull()
+    expect(host.querySelectorAll('.kp-row.mini').length).toBe(3)
+    expect(host.querySelector('.kp-row.mini[aria-current="true"]')).not.toBeNull()
   })
 
-  it('shows a work-preview line per row, preferring recent output', () => {
-    keepers.value = [
-      mk({ name: 'with-output', status: 'running', recent_output_preview: '리뷰 코멘트 정리 중' }),
-    ]
-    render(html`<${KeeperWorkspaceRoster} activeName="with-output" />`, host)
-    const work = host.querySelector('.kw-kp-work') as HTMLElement
-    expect(work?.textContent).toBe('리뷰 코멘트 정리 중')
-    // title mirrors the text so truncated previews stay inspectable on hover
-    expect(work?.getAttribute('title')).toBe('리뷰 코멘트 정리 중')
-  })
-
-  it('falls through the work-preview precedence chain', () => {
-    keepers.value = [
-      // recent_output/input absent -> short_goal wins over goal/current_task
-      mk({ name: 'goal-only', status: 'running', short_goal: 'WIP 게이트 수정', goal: '무시됨' }),
-    ]
-    render(html`<${KeeperWorkspaceRoster} activeName="goal-only" />`, host)
-    const work = host.querySelector('.kw-kp-work') as HTMLElement
-    expect(work?.textContent).toBe('WIP 게이트 수정')
-  })
-
-  it('surfaces last_proactive_preview for a proactive-only keeper', () => {
-    // A proactive keeper never broadcasts, so the message-bus previews
-    // (recent_output/input) and goal/current_task stay empty; its work lives
-    // only in last_proactive_preview. The roster must read it rather than
-    // rendering the bare placeholder.
-    keepers.value = [
-      mk({
-        name: 'executor',
-        status: 'running',
-        last_proactive_preview: 'Continuation checkpoint saved; scheduled next cycle.',
-      }),
-    ]
-    render(html`<${KeeperWorkspaceRoster} activeName="executor" />`, host)
-    const work = host.querySelector('.kw-kp-work') as HTMLElement
-    expect(work?.textContent).toBe('Continuation checkpoint saved; scheduled next cycle.')
-  })
-
-  it('renders the empty-work fallback when no preview source exists', () => {
-    keepers.value = [mk({ name: 'bare', status: 'stopped' })]
-    render(html`<${KeeperWorkspaceRoster} activeName="bare" />`, host)
-    const work = host.querySelector('.kw-kp-work') as HTMLElement
-    expect(work?.textContent).toBe('최근 작업 요약 없음')
-    expect(work?.getAttribute('title')).toBe('')
-  })
+  // The per-row work-preview line (.kw-kp-work — recent_output > short_goal >
+  // goal/current_task > last_proactive_preview > empty fallback) was removed in
+  // the v2 reskin: the prototype roster row is a compact picker (name + FSM state
+  // + basepath handle + activity time/attention), and a selected keeper's work
+  // is shown in the chat pane. The 4 work-preview rendering tests are dropped with
+  // the line. The precedence logic itself (keeperWorkPreview) is still rendered +
+  // covered on the Monitor Fleet roster (agent-roster). See PR notes — restore the
+  // workspace-roster preview line if operators want it back.
 
   it('uses content-visibility:auto on plain-list rows below the virtualization threshold', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     expect(host.querySelector('.virtual-list-spacer')).toBeNull()
-    const rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
+    const rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
     expect(rows.length).toBeGreaterThan(0)
     expect(rows.every(r => r.style.contentVisibility === 'auto')).toBe(true)
   })
@@ -368,30 +294,31 @@ describe('KeeperWorkspaceRoster', () => {
     )
     render(html`<${KeeperWorkspaceRoster} activeName="keeper-0" />`, host)
     expect(host.querySelector('.virtual-list-spacer')).not.toBeNull()
-    expect(host.querySelector('.kw-roster-list')).not.toBeNull()
+    expect(host.querySelector('.roster-list')).not.toBeNull()
     // The windowed path renders the group header through the same renderHeader(),
-    // so the status dot must appear here too (all 60 keepers are running → ok).
-    expect(host.querySelector('.kw-roster-group .kw-dot.ok')).not.toBeNull()
+    // so the toned header must appear here too (all 60 keepers are running → the
+    // `.roster-group.run` bucket with its `.rg-dot` pip).
+    expect(host.querySelector('.roster-group.run .rg-dot')).not.toBeNull()
   })
 
   it('renders the sort select defaulting to status order', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const sortSel = host.querySelector('.kw-roster-sort') as HTMLSelectElement
+    const sortSel = host.querySelector('.roster-sort') as HTMLSelectElement
     expect(sortSel).not.toBeNull()
     expect(sortSel.value).toBe('status')
     expect(Array.from(sortSel.options).map(o => o.value)).toEqual(['status', 'name', 'att'])
     // status mode keeps the bucket group headers
-    expect(host.querySelectorAll('.kw-roster-group').length).toBeGreaterThan(0)
+    expect(host.querySelectorAll('.roster-group').length).toBeGreaterThan(0)
   })
 
   it('sorts by name into a flat alphabetical list with no group headers', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    fireEvent.change(host.querySelector('.kw-roster-sort') as HTMLSelectElement, {
+    fireEvent.change(host.querySelector('.roster-sort') as HTMLSelectElement, {
       target: { value: 'name' },
     })
     // flat list → status group headers disappear
-    expect(host.querySelectorAll('.kw-roster-group').length).toBe(0)
-    const order = Array.from(host.querySelectorAll('.kw-kp-row')).map(r =>
+    expect(host.querySelectorAll('.roster-group').length).toBe(0)
+    const order = Array.from(host.querySelectorAll('.kp-row')).map(r =>
       r.textContent?.includes('masc-improver') ? 'masc-improver' : r.textContent?.includes('rama') ? 'rama' : 'sangsu',
     )
     expect(order).toEqual(['masc-improver', 'rama', 'sangsu'])
@@ -404,10 +331,10 @@ describe('KeeperWorkspaceRoster', () => {
       mk({ name: 'flagged', status: 'running', needs_attention: true }),
     ]
     render(html`<${KeeperWorkspaceRoster} activeName="calm" />`, host)
-    fireEvent.change(host.querySelector('.kw-roster-sort') as HTMLSelectElement, {
+    fireEvent.change(host.querySelector('.roster-sort') as HTMLSelectElement, {
       target: { value: 'att' },
     })
-    const order = Array.from(host.querySelectorAll('.kw-kp-row')).map(r =>
+    const order = Array.from(host.querySelectorAll('.kp-row')).map(r =>
       r.textContent?.includes('blocked-3') ? 'blocked-3' : r.textContent?.includes('flagged') ? 'flagged' : 'calm',
     )
     // blocked-3 (score 3) > flagged (flag → score 1) > calm (score 0)
@@ -417,7 +344,7 @@ describe('KeeperWorkspaceRoster', () => {
   it('shows the keeper basepath (sandbox_target) as the row sub-line, shortened with a full-path title', () => {
     keepers.value = [mk({ name: 'miso', status: 'running', sandbox_target: '/workspace/keepers/keeper-miso' })]
     render(html`<${KeeperWorkspaceRoster} activeName="miso" />`, host)
-    const handle = host.querySelector('.kw-kp-handle') as HTMLElement
+    const handle = host.querySelector('.kp-handle') as HTMLElement
     expect(handle?.textContent).toBe('…/keepers/keeper-miso')
     expect(handle?.getAttribute('title')).toBe('/workspace/keepers/keeper-miso')
   })
@@ -425,7 +352,7 @@ describe('KeeperWorkspaceRoster', () => {
   it('falls back to the scope proxy when a keeper has no sandbox_target', () => {
     keepers.value = [mk({ name: 'nobase', status: 'running', model: 'anthropic/claude-x' })]
     render(html`<${KeeperWorkspaceRoster} activeName="nobase" />`, host)
-    const handle = host.querySelector('.kw-kp-handle') as HTMLElement
+    const handle = host.querySelector('.kp-handle') as HTMLElement
     expect(handle?.textContent).toBe('anthropic/claude-x')
   })
 
@@ -435,15 +362,17 @@ describe('KeeperWorkspaceRoster', () => {
       mk({ name: 'beta', status: 'running', sandbox_target: '/srv/worktrees/beta-tree' }),
     ]
     render(html`<${KeeperWorkspaceRoster} activeName="alpha" />`, host)
-    fireEvent.input(host.querySelector('.kw-roster-search') as HTMLInputElement, { target: { value: 'beta-tree' } })
-    const rows = host.querySelectorAll('.kw-kp-row')
+    // Prototype gates the search box behind the `.rfilter-icon` toggle.
+    fireEvent.click(host.querySelector('.rfilter-icon') as HTMLButtonElement)
+    fireEvent.input(host.querySelector('.roster-search') as HTMLInputElement, { target: { value: 'beta-tree' } })
+    const rows = host.querySelectorAll('.kp-row')
     expect(rows.length).toBe(1)
     expect(rows[0]?.textContent).toContain('beta')
   })
 
   it('renders a per-group keeper count in the status group header', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const counts = Array.from(host.querySelectorAll('.kw-roster-group-n')).map(n => n.textContent)
+    const counts = Array.from(host.querySelectorAll('.rg-n')).map(n => n.textContent)
     // FIXTURE: 1 running, 1 paused, 1 stopped
     expect(counts).toEqual(['1', '1', '1'])
   })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -1,8 +1,9 @@
-// Keeper Workspace — roster pane (left). Search + status filter chips +
-// status-grouped keeper rows. Ported from the v2 design (rails.jsx Roster),
-// wired to the live `keepers` store. Selecting a row routes to that keeper,
-// which swaps the conversation + rail panes (same route shape the detail
-// page already used, so deep links keep working).
+// Keeper Workspace — roster pane (left). Ported to the keeper-v2 prototype DOM
+// (rails.jsx Roster): `.roster` → `.roster-filters` (전체/실행/주의 + search
+// toggle + sort) → `.roster-list` of `.roster-group` + `.kp-row`. Styled by the
+// vendored SSOT CSS (keeper-v2/v2.css). All live wiring (the `keepers` store,
+// filtering/sorting, the FSM action menu, route-on-select) is unchanged from the
+// previous `.kw-*` implementation — only the emitted DOM/classes changed.
 
 import { html } from 'htm/preact'
 import {
@@ -20,19 +21,18 @@ import { keepers } from '../../store'
 import { navigate } from '../../router'
 import { selectKeeper } from '../../keeper-runtime'
 import { keeperMobilePane } from '../keeper-detail-state'
-import { keeperActivityDisplay, keeperWorkPreview } from '../../lib/keeper-runtime-display'
+import { keeperActivityDisplay } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import type { Keeper } from '../../types'
 import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
 import { VirtualList } from '../common/virtual-list'
+import { kSlot, kSigil } from '../keeper-badge'
+import { SigilBadge, Dot } from '../v2/primitives-v2'
+import { phaseTone, phasePulse } from '../v2/keeper-fsm'
 import {
-  WorkspaceSigil,
-  StatusDot,
   keeperBucket,
-  keeperStatusTone,
   keeperPhaseLabel,
   type KeeperBucket,
-  type DotTone,
 } from './keeper-workspace-shared'
 
 type RosterFilter = 'all' | 'run' | 'att'
@@ -51,63 +51,30 @@ type RosterFleetSummary = {
 }
 
 const LIFECYCLE_COPY: Record<KeeperActionKey, { label: string; title: string; icon: IconComponent; danger?: boolean }> = {
-  pause: {
-    label: '일시정지',
-    title: '일시정지: 실행 중인 keeper 를 일시 멈춥니다',
-    icon: Pause,
-  },
-  resume: {
-    label: '재개',
-    title: '재개: 일시정지된 keeper 를 다시 실행합니다',
-    icon: Play,
-  },
-  wakeup: {
-    label: '깨우기',
-    title: '깨우기: 다음 turn 을 즉시 시도합니다',
-    icon: RotateCcw,
-  },
-  boot: {
-    label: '기동',
-    title: '기동: offline keeper 를 다시 시작합니다',
-    icon: Play,
-  },
-  shutdown: {
-    label: '종료',
-    title: '종료: keeper 를 완전 종료합니다',
-    icon: Square,
-    danger: true,
-  },
+  pause: { label: '일시정지', title: '일시정지: 실행 중인 keeper 를 일시 멈춥니다', icon: Pause },
+  resume: { label: '재개', title: '재개: 일시정지된 keeper 를 다시 실행합니다', icon: Play },
+  wakeup: { label: '깨우기', title: '깨우기: 다음 turn 을 즉시 시도합니다', icon: RotateCcw },
+  boot: { label: '기동', title: '기동: offline keeper 를 다시 시작합니다', icon: Play },
+  shutdown: { label: '종료', title: '종료: keeper 를 완전 종료합니다', icon: Square, danger: true },
 }
 const MENU_WIDTH = 190
 const MENU_ESTIMATED_HEIGHT = 246
 const MENU_VIEWPORT_MARGIN = 8
 
-const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
-  { bucket: 'running', label: '실행 중' },
-  { bucket: 'paused', label: '대기 · 일시정지' },
-  { bucket: 'offline', label: '중지 · 종료됨' },
+// Prototype group order + the short header label it uses (rails.jsx groupLabel).
+const GROUP_ORDER: { bucket: KeeperBucket; label: string; short: string; cls: string }[] = [
+  { bucket: 'running', label: '실행 중', short: '실행 중', cls: 'run' },
+  { bucket: 'paused', label: '대기 · 일시정지', short: '대기', cls: 'pause' },
+  { bucket: 'offline', label: '중지 · 종료됨', short: '중지', cls: 'off' },
 ]
+const GROUP_BY_BUCKET = Object.fromEntries(GROUP_ORDER.map((g) => [g.bucket, g])) as Record<KeeperBucket, (typeof GROUP_ORDER)[number]>
 
-/** Group-header status dot tone (design rails.jsx `.rg-dot` colored by groupCls).
- *  Reuses the shared StatusDot vocabulary instead of a bespoke dot so the header
- *  marker matches the per-row dots: running→ok, paused→warn, offline→idle. */
-const GROUP_BUCKET_TONE: Record<KeeperBucket, DotTone> = {
-  running: 'ok',
-  paused: 'warn',
-  offline: 'idle',
-}
-
-/** Flattened roster item used by the virtualized render path. */
 type RosterItem =
-  | { type: 'header'; bucket: KeeperBucket; label: string; count: number }
+  | { type: 'header'; bucket: KeeperBucket; count: number }
   | { type: 'row'; keeper: Keeper }
 
-/** Switch to the shared VirtualList once the roster is long enough that DOM
- *  weight matters. Below this we keep the identical grouped DOM structure and
- *  rely on content-visibility:auto for cheap off-screen skipping. */
 const WINDOW_AT = 60
 
-/** Blocked tasks + explicit attention flag → the roster attention badge. */
 function attentionCount(keeper: Keeper): number {
   return keeper.blocked_task_count ?? (keeper.needs_attention === true ? 1 : 0)
 }
@@ -117,15 +84,8 @@ function needsAttention(keeper: Keeper): boolean {
 
 export function rosterFleetSummary(rows: readonly Keeper[]): RosterFleetSummary {
   const summary: RosterFleetSummary = {
-    total: rows.length,
-    running: 0,
-    paused: 0,
-    offline: 0,
-    attention: 0,
-    approvalGate: 0,
-    highContext: 0,
+    total: rows.length, running: 0, paused: 0, offline: 0, attention: 0, approvalGate: 0, highContext: 0,
   }
-
   for (const keeper of rows) {
     const bucket = keeperBucket(keeper)
     if (bucket === 'running') summary.running += 1
@@ -137,47 +97,28 @@ export function rosterFleetSummary(rows: readonly Keeper[]): RosterFleetSummary 
       summary.highContext += 1
     }
   }
-
   return summary
 }
 
-/** Numeric attention weight for the 'att' sort: attention-needing keepers rank
- *  above the rest, ordered by blocked-task count (min 1 when only the flag is
- *  set, so a flagged-but-unblocked keeper still outranks a calm one). Mirrors
- *  the v2 roster's numeric `k.att` sort key. */
 function attentionScore(keeper: Keeper): number {
   return needsAttention(keeper) ? Math.max(1, attentionCount(keeper)) : 0
 }
 
-/** Comparator for the flat sort modes ('name'/'att'). 'status' keeps the bucket
- *  grouping instead and never reaches here. Name ties break alphabetically so
- *  the order is stable. */
 function compareKeepers(a: Keeper, b: Keeper, sort: Exclude<RosterSort, 'status'>): number {
   if (sort === 'name') return a.name.localeCompare(b.name)
   return attentionScore(b) - attentionScore(a) || a.name.localeCompare(b.name)
 }
 
-/** ns proxy: keepers have no namespace field; the skill path is the closest
- *  real scope signal, with the model as fallback. */
 function keeperScope(keeper: Keeper): string | null {
   return keeper.skill_primary ?? keeper.active_model ?? keeper.model ?? null
 }
 
-/** The keeper's sandbox location — the design's roster identity sub-line
- *  (rails.jsx renders `k.basepath` here). The live field is `sandbox_target`
- *  (keeper-detail-alert-strip.ts:252 uses the same field); for a `local`
- *  profile it is the worktree root path, for `docker` the container target.
- *  Unlike the alert strip, this deliberately does NOT fall back to
- *  `sandbox_profile`: a bare 'local'/'docker' literal is not a useful roster
- *  identity, so RosterRow falls through to the scope proxy (skill/model) instead. */
+// The keeper's sandbox location — the prototype roster identity sub-line
+// (rails.jsx renders `k.basepath`). Live field is `sandbox_target`.
 function keeperBasepath(keeper: Keeper): string {
   return keeper.sandbox_target?.trim() ?? ''
 }
 
-/** Local worktree roots are long absolute paths that end-ellipsis to an
- *  unhelpful common prefix in the narrow column, so show the last two segments
- *  (the identifying tail) with the full path in `title`. Non-path targets
- *  (e.g. a docker target) are shown verbatim. */
 function shortBasepath(value: string): string {
   if (!value.startsWith('/')) return value
   const parts = value.split('/').filter(Boolean)
@@ -188,6 +129,11 @@ function matchesQuery(keeper: Keeper, q: string): boolean {
   if (!q) return true
   const hay = `${keeper.name} ${keeper.koreanName ?? ''} ${keeperScope(keeper) ?? ''} ${keeper.model ?? ''} ${keeperBasepath(keeper)}`.toLowerCase()
   return hay.includes(q.toLowerCase())
+}
+
+// Prototype kp-state shows the raw English FSM phase ("Running", "Compacting").
+function phaseText(keeper: Keeper): string {
+  return keeper.lifecycle_phase ?? keeper.phase ?? keeperPhaseLabel(keeper)
 }
 
 function RosterRow({
@@ -204,22 +150,17 @@ function RosterRow({
   style?: string
 }) {
   const bucket = keeperBucket(keeper)
-  const tone = keeperStatusTone(keeper)
   const att = attentionCount(keeper)
-  const scope = keeperScope(keeper)
   const basepath = keeperBasepath(keeper)
-  // Design roster identity sub-line = basepath; fall back to the scope proxy
-  // when a keeper has no sandbox target yet so the row never loses its sub-label.
-  const handle = basepath ? shortBasepath(basepath) : scope
-  const handleTitle = basepath || scope || ''
+  const handle = basepath ? shortBasepath(basepath) : keeperScope(keeper)
+  const handleTitle = basepath || keeperScope(keeper) || ''
   const activity = keeperActivityDisplay(keeper)
-  const work = keeperWorkPreview(keeper)
   const select = () => onSelect(keeper.name)
   return html`
     <div
       role="button"
       tabindex="0"
-      class="kw-kp-row v2-monitoring-row"
+      class=${`kp-row${active ? ' sel' : ''}`}
       style=${style}
       aria-current=${active ? 'true' : 'false'}
       onClick=${select}
@@ -230,24 +171,23 @@ function RosterRow({
         select()
       }}
     >
-      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
-      <div class="kw-kp-meta">
-        <div class="kw-kp-name">${keeper.koreanName ?? keeper.name}</div>
-        <div class="kw-kp-sub">
-          <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${bucket === 'running'} />${keeperPhaseLabel(keeper)}</span>
-          ${handle ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle" title=${handleTitle}>${handle}</span>` : null}
+      <${SigilBadge} slot=${kSlot(keeper.name)} sigil=${kSigil(keeper.name)} size=${38} beat=${bucket === 'running'} title=${keeper.name} />
+      <div class="kp-meta">
+        <div class="kp-name">${keeper.name}</div>
+        <div class="kp-sub">
+          <span class="kp-state"><${Dot} state=${phaseTone(keeper.lifecycle_phase)} pulse=${phasePulse(keeper.lifecycle_phase)} />${phaseText(keeper)}</span>
+          ${handle ? html`<span aria-hidden="true">·</span><span class="kp-handle" title=${handleTitle}>${handle}</span>` : null}
         </div>
-        <div class="kw-kp-work" title=${work ?? ''}>${work ?? '최근 작업 요약 없음'}</div>
       </div>
-      <div class="kw-kp-right">
-        ${activity.source !== 'none' ? html`<span class="kw-kp-time">${activity.label}</span>` : null}
-        ${att > 0 ? html`<span class="kw-kp-att" title=${`주의 ${att}건`}>${att}</span>` : null}
+      <div class="kp-right">
+        ${activity.source !== 'none' ? html`<span class="kp-time">${activity.label}</span>` : null}
+        ${att > 0 ? html`<span class="kp-att" title=${`주의 ${att}건 — 컨텍스트 레일에서 확인`}>${att}</span>` : null}
       </div>
       <button
         type="button"
-        class="kw-kp-more v2-monitoring-action"
+        class="kp-more"
         aria-label=${`${keeper.name} 명령`}
-        title="keeper 명령"
+        title="명령 메뉴"
         onClick=${(event: MouseEvent) => onMenu(keeper, event)}
         data-testid=${`kw-roster-menu-${keeper.name}`}
       >
@@ -269,20 +209,18 @@ function MiniRosterRow({
   onMenu: (keeper: Keeper, event: MouseEvent) => void
 }) {
   const bucket = keeperBucket(keeper)
-  const tone = keeperStatusTone(keeper)
-  const label = `${keeper.name} · ${keeperPhaseLabel(keeper)}`
+  const label = `${keeper.name} · ${phaseText(keeper)}`
   return html`
     <button
       type="button"
-      class="kw-kp-mini v2-monitoring-action"
+      class=${`kp-row mini${active ? ' sel' : ''}`}
       aria-current=${active ? 'true' : 'false'}
       aria-label=${label}
       title=${label}
       onClick=${() => onSelect(keeper.name)}
       onContextMenu=${(event: MouseEvent) => onMenu(keeper, event)}
     >
-      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
-      <${StatusDot} tone=${tone} pulse=${bucket === 'running'} />
+      <${SigilBadge} slot=${kSlot(keeper.name)} sigil=${kSigil(keeper.name)} size=${38} beat=${bucket === 'running'} title=${keeper.name} />
     </button>
   `
 }
@@ -298,34 +236,6 @@ function lifecycleActions(keeper: Keeper): KeeperActionKey[] {
   return actions
 }
 
-function pct(count: number, total: number): string {
-  if (total <= 0 || count <= 0) return '0%'
-  return `${Math.max(4, Math.round((count / total) * 100))}%`
-}
-
-function KeeperFleetSummaryBand({ summary }: { summary: RosterFleetSummary }): VNode {
-  return html`
-    <section class="kw-roster-summary" data-testid="kw-roster-summary" aria-label="키퍼 플릿 요약">
-      <div class="kw-roster-meter" aria-hidden="true">
-        <span class="run" style=${{ width: pct(summary.running, summary.total) }}></span>
-        <span class="pause" style=${{ width: pct(summary.paused, summary.total) }}></span>
-        <span class="off" style=${{ width: pct(summary.offline, summary.total) }}></span>
-      </div>
-      <div class="kw-roster-summary-grid">
-        <div class="kw-roster-stat"><b>${summary.total}</b><span>전체</span></div>
-        <div class="kw-roster-stat ok"><b>${summary.running}</b><span>실행</span></div>
-        <div class="kw-roster-stat warn"><b>${summary.paused}</b><span>대기</span></div>
-        <div class="kw-roster-stat idle"><b>${summary.offline}</b><span>중지</span></div>
-      </div>
-      <div class="kw-roster-flags">
-        <span class=${summary.attention > 0 ? 'hot' : ''}>주의 ${summary.attention}</span>
-        <span class=${summary.approvalGate > 0 ? 'gate' : ''}>승인 ${summary.approvalGate}</span>
-        <span class=${summary.highContext > 0 ? 'ctx' : ''}>CTX 80%+ ${summary.highContext}</span>
-      </div>
-    </section>
-  `
-}
-
 function KeeperRosterMenu({
   state,
   onClose,
@@ -339,31 +249,25 @@ function KeeperRosterMenu({
 }): VNode {
   const keeper = state.keeper
   const actions = lifecycleActions(keeper)
-  const select = () => {
-    onSelect(keeper.name)
-    onClose()
-  }
+  const select = () => { onSelect(keeper.name); onClose() }
   const openConfig = () => {
     onSelect(keeper.name)
-    if (onOpenConfig) {
-      onOpenConfig(keeper.name)
-    }
+    if (onOpenConfig) onOpenConfig(keeper.name)
     onClose()
   }
-
   return html`
     <div
-      class="kw-kp-menu v2-monitoring-surface"
+      class="kp-menu"
       role="menu"
       style=${{ left: `${state.x}px`, top: `${state.y}px` }}
       onClick=${(event: Event) => event.stopPropagation()}
       data-testid="kw-roster-menu"
     >
-      <div class="kw-kp-menu-head v2-monitoring-toolbar">
-        <${WorkspaceSigil} id=${keeper.name} size=${22} beat=${keeperBucket(keeper) === 'running'} />
-        <span>${keeper.name}</span>
+      <div class="kp-menu-h">
+        <${SigilBadge} slot=${kSlot(keeper.name)} sigil=${kSigil(keeper.name)} size=${20} title=${keeper.name} />
+        <span class="mono">${keeper.name}</span>
       </div>
-      <button type="button" role="menuitem" class="kw-kp-menu-item" onClick=${select} data-testid="kw-roster-menu-open-chat">
+      <button type="button" role="menuitem" class="kp-menu-i" onClick=${select} data-testid="kw-roster-menu-open-chat">
         <${MessageSquare} size=${14} aria-hidden="true" />
         <span>대화 열기</span>
       </button>
@@ -375,12 +279,9 @@ function KeeperRosterMenu({
             key=${action}
             type="button"
             role="menuitem"
-            class=${`kw-kp-menu-item${copy.danger ? ' danger' : ''}`}
+            class=${`kp-menu-i${copy.danger ? ' danger' : ''}`}
             title=${copy.title}
-            onClick=${() => {
-              void runKeeperAction(keeper.name, action)
-              onClose()
-            }}
+            onClick=${() => { void runKeeperAction(keeper.name, action); onClose() }}
             data-testid=${`kw-roster-menu-${action}`}
           >
             <${Icon} size=${14} aria-hidden="true" />
@@ -389,10 +290,10 @@ function KeeperRosterMenu({
         `
       })}
       ${actions.length === 0
-        ? html`<div class="kw-kp-menu-note">현재 실행 가능한 명령 없음</div>`
+        ? html`<div class="kp-menu-note">현재 실행 가능한 명령 없음</div>`
         : null}
-      <div class="kw-kp-menu-sep"></div>
-      <button type="button" role="menuitem" class="kw-kp-menu-item" onClick=${openConfig} data-testid="kw-roster-menu-config">
+      <div class="kp-menu-sep"></div>
+      <button type="button" role="menuitem" class="kp-menu-i" onClick=${openConfig} data-testid="kw-roster-menu-config">
         <${Settings} size=${14} aria-hidden="true" />
         <span>keeper 설정</span>
       </button>
@@ -414,6 +315,7 @@ export function KeeperWorkspaceRoster({
   mini?: boolean
 }): VNode {
   const [query, setQuery] = useState('')
+  const [searchOpen, setSearchOpen] = useState(false)
   const [filter, setFilter] = useState<RosterFilter>('all')
   const [sort, setSort] = useState<RosterSort>('status')
   const [menu, setMenu] = useState<RosterMenuState>(null)
@@ -421,9 +323,6 @@ export function KeeperWorkspaceRoster({
   useEffect(() => {
     if (!menu) return
     const close = () => setMenu(null)
-    // Esc closes the menu (was: any key — typing in the search box dismissed it);
-    // scroll closes it too (capture phase) so the row-anchored menu can't drift
-    // away from its row. Mirrors the design roster menu (rails.jsx).
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setMenu(null)
     }
@@ -438,7 +337,6 @@ export function KeeperWorkspaceRoster({
   }, [menu])
 
   const all = keepers.value
-  const summary = rosterFleetSummary(all)
   const counts = {
     all: all.length,
     run: all.filter(k => keeperBucket(k) === 'running').length,
@@ -451,15 +349,12 @@ export function KeeperWorkspaceRoster({
     return matchesQuery(k, query)
   })
 
-  const sortRows = (rows: Keeper[]): Keeper[] => {
-    return sort === 'status' ? rows : [...rows].sort((a, b) => compareKeepers(a, b, sort))
-  }
+  const sortRows = (rows: Keeper[]): Keeper[] =>
+    sort === 'status' ? rows : [...rows].sort((a, b) => compareKeepers(a, b, sort))
 
   const select = (name: string) => {
     setMenu(null)
     selectKeeper(name)
-    // On mobile the roster and conversation share one column; picking a keeper
-    // should reveal that keeper's chat (the roster is the "back" target).
     keeperMobilePane.value = 'chat'
     if (routeSurface === 'keepers') {
       navigate('keepers', { keeper: name })
@@ -470,16 +365,10 @@ export function KeeperWorkspaceRoster({
   }
 
   const openMenu = (keeper: Keeper, event: MouseEvent) => {
-    // Centralized here so both entry points behave: the ⋯ button click and a
-    // right-click on the row. preventDefault suppresses the browser's native
-    // context menu on right-click; stopPropagation keeps a ⋯ click from also
-    // selecting the row (the click would otherwise bubble to the row onClick).
     event.preventDefault()
     event.stopPropagation()
     const target = event.currentTarget as HTMLElement
-    const rosterRect = target.closest('.kw-roster')?.getBoundingClientRect() ?? { left: 0, top: 0 }
-    // Right-click anchors the menu at the cursor (design rails.jsx openMenu); the
-    // ⋯ button right-aligns the menu just below itself.
+    const rosterRect = target.closest('.roster')?.getBoundingClientRect() ?? { left: 0, top: 0 }
     let anchorRight: number
     let anchorTop: number
     if (event.type === 'contextmenu') {
@@ -498,52 +387,38 @@ export function KeeperWorkspaceRoster({
       MENU_VIEWPORT_MARGIN,
       Math.min(anchorTop, window.innerHeight - MENU_ESTIMATED_HEIGHT - MENU_VIEWPORT_MARGIN),
     )
-    setMenu({
-      keeper,
-      x: viewportX - rosterRect.left,
-      y: viewportY - rosterRect.top,
-    })
+    setMenu({ keeper, x: viewportX - rosterRect.left, y: viewportY - rosterRect.top })
   }
 
   const filterChips: { id: RosterFilter; label: string }[] = [
     { id: 'all', label: '전체' },
-    { id: 'run', label: '실행중' },
+    { id: 'run', label: '실행' },
     { id: 'att', label: '주의' },
   ]
 
-  // Flatten to [{ type: 'header'|'row', ... }] for windowing. 'status' keeps the
-  // bucket grouping with headers; 'name'/'att' produce a flat sorted list with no
-  // headers, mirroring the v2 roster sort modes (rails.jsx Roster).
   const items: RosterItem[] = []
   if (sort === 'status') {
     for (const group of GROUP_ORDER) {
       const rows = visible.filter(k => keeperBucket(k) === group.bucket)
       if (rows.length === 0) continue
-      items.push({ type: 'header', bucket: group.bucket, label: group.label, count: rows.length })
-      for (const keeper of rows) {
-        items.push({ type: 'row', keeper })
-      }
+      items.push({ type: 'header', bucket: group.bucket, count: rows.length })
+      for (const keeper of rows) items.push({ type: 'row', keeper })
     }
   } else {
-    for (const keeper of sortRows(visible)) {
-      items.push({ type: 'row', keeper })
-    }
+    for (const keeper of sortRows(visible)) items.push({ type: 'row', keeper })
   }
 
   const useVirtual = items.length > WINDOW_AT
   const rowStyle = 'content-visibility:auto;contain-intrinsic-size:auto 58px'
   const miniRows = sortRows(all)
 
-  // Single source for the group header so the windowed and non-windowed render
-  // paths can't drift (they previously inlined the header markup separately).
   function renderHeader(item: Extract<RosterItem, { type: 'header' }>): VNode {
-    return html`<div class="kw-roster-group v2-monitoring-row" key=${`h:${item.bucket}`}><${StatusDot} tone=${GROUP_BUCKET_TONE[item.bucket]} /><span class="kw-roster-group-label">${item.label}</span><span class="kw-roster-group-n">${item.count}</span></div>`
+    const g = GROUP_BY_BUCKET[item.bucket]
+    return html`<div class=${`roster-group ${g.cls}`} title=${g.label} key=${`h:${item.bucket}`}><span class="rg-dot"></span>${g.short}<span class="rg-n">${item.count}</span></div>`
   }
 
   function renderItem(item: RosterItem): VNode {
-    if (item.type === 'header') {
-      return renderHeader(item)
-    }
+    if (item.type === 'header') return renderHeader(item)
     return html`<${RosterRow} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} />`
   }
 
@@ -552,37 +427,33 @@ export function KeeperWorkspaceRoster({
   }
 
   return html`
-    <aside class=${`kw-roster${mini ? ' mini' : ''} v2-monitoring-surface`} aria-label="키퍼 로스터">
+    <aside class=${`roster${mini ? ' mini' : ''}`} aria-label="키퍼 로스터">
       ${mini
-        ? html`<div class="kw-roster-mini-list">
+        ? html`<div class="roster-list mini-list">
             ${miniRows.map(k => html`<${MiniRosterRow} key=${k.name} keeper=${k} active=${k.name === activeName} onSelect=${select} onMenu=${openMenu} />`)}
           </div>`
         : html`
-          <div class="kw-roster-head v2-monitoring-toolbar">
-            <div class="kw-roster-title"><span>Keepers</span><span class="n">${counts.all}</span></div>
-            <input
-              class="kw-roster-search"
-              type="text"
-              placeholder="이름 · 스코프 검색…"
-              aria-label="키퍼 검색"
-              value=${query}
-              onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-            />
-          </div>
-          <${KeeperFleetSummaryBand} summary=${summary} />
-          <div class="kw-roster-filters v2-monitoring-toolbar" role="group" aria-label="상태 필터">
+          <div class="roster-filters" role="group" aria-label="상태 필터">
             ${filterChips.map(chip => html`
               <button
                 type="button"
-                class="kw-rfilter v2-monitoring-action"
+                class=${`rfilter${filter === chip.id ? ' on' : ''}`}
                 aria-pressed=${filter === chip.id ? 'true' : 'false'}
                 onClick=${() => setFilter(chip.id)}
               >
                 ${chip.label}<span class="n">${counts[chip.id]}</span>
               </button>
             `)}
+            <button
+              type="button"
+              class=${`rfilter-icon${searchOpen ? ' on' : ''}`}
+              title="검색"
+              aria-label="키퍼 검색 토글"
+              aria-pressed=${searchOpen ? 'true' : 'false'}
+              onClick=${() => setSearchOpen(o => !o)}
+            >${'⌕'}</button>
             <select
-              class="kw-roster-sort v2-monitoring-action"
+              class="roster-sort"
               aria-label="키퍼 정렬"
               value=${sort}
               onChange=${(e: Event) => setSort((e.target as HTMLSelectElement).value as RosterSort)}
@@ -592,17 +463,30 @@ export function KeeperWorkspaceRoster({
               <option value="att">주의순</option>
             </select>
           </div>
+          ${searchOpen
+            ? html`<div class="roster-head">
+                <input
+                  class="roster-search"
+                  type="text"
+                  placeholder="이름·basepath 검색…"
+                  aria-label="키퍼 검색"
+                  autofocus
+                  value=${query}
+                  onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
+                />
+              </div>`
+            : null}
           ${visible.length === 0
-            ? html`<div class="kw-roster-list"><div class="kw-roster-empty v2-monitoring-row">일치하는 키퍼가 없습니다</div></div>`
+            ? html`<div class="roster-list"><div class="roster-empty" style="padding:30px 12px;text-align:center;color:var(--text-dim);font-size:12px">일치하는 Keeper가 없습니다</div></div>`
         : useVirtual
           ? html`<${VirtualList}
               items=${items}
               estimatedItemHeight=${58}
-              className="kw-roster-list"
+              className="roster-list"
               renderItem=${renderItem}
               getKey=${getKey}
             />`
-          : html`<div class="kw-roster-list">
+          : html`<div class="roster-list">
               ${items.map(item => item.type === 'header'
                 ? renderHeader(item)
                 : html`<${RosterRow} key=${item.keeper.name} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} style=${rowStyle} />`)}

--- a/dashboard/src/components/logs.ts
+++ b/dashboard/src/components/logs.ts
@@ -16,6 +16,7 @@ import { TextInput } from './common/input'
 import { Select } from './common/select'
 import { Checkbox } from './common/checkbox'
 import { LogFilter } from './common/log-filter'
+import { RouteLink } from './common/route-link'
 import { KeeperBadge } from './keeper-badge'
 import { createAsyncResource, loaded } from '../lib/async-state'
 import { toolCategory } from './tool-call-shared'
@@ -643,11 +644,66 @@ async function loadSelectedProviderLog() {
   )
 }
 
+// Pretty-print a nested details value as a JSON code block body, matching the
+// keeper-v2 prototype (`JSON.stringify(value, null, 1)`). Returns null for empty
+// objects/arrays/strings so absent payloads render no `lg-code` block at all
+// (no fabricated "{}" placeholders). Strings pass through verbatim — the backend
+// already emits some results as pre-rendered strings.
+function formatDetailCode(value: unknown): string | null {
+  if (value == null) return null
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed === '' ? null : trimmed
+  }
+  if (typeof value === 'object') {
+    if (Array.isArray(value) && value.length === 0) return null
+    if (!Array.isArray(value) && Object.keys(value as Record<string, unknown>).length === 0) return null
+    try {
+      return JSON.stringify(value, null, 1)
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+// Read a free-form note/gloss string from the details object. The backend
+// `details` schema is `record(string, unknown)`, so these keys are not
+// guaranteed to be present — callers render the `lg-note` block only when this
+// returns a non-empty value.
+function detailNote(details: Record<string, unknown> | null, ...keys: string[]): string | null {
+  if (!details) return null
+  for (const key of keys) {
+    const value = details[key]
+    if (typeof value === 'string' && value.trim() !== '') return value.trim()
+  }
+  return null
+}
+
+// Read a recipients[] array of human-readable strings from the details object.
+// Not present in the general log stream today (the backend emits scalar detail
+// fields only) — render conditionally so this never shows fabricated chips.
+function detailRecipients(details: Record<string, unknown> | null): string[] {
+  if (!details) return []
+  const value = details.recipients
+  if (!Array.isArray(value)) return []
+  return value
+    .map(item => (typeof item === 'string' ? item.trim() : ''))
+    .filter(item => item !== '')
+}
+
 // Kind-aware key/value grid for the expanded detail panel. Fields are pulled
 // from the backend `details` object via detailLabel; absent fields are dropped
-// so the layout matches the Observatory reference when the data is present and
+// so the layout matches the keeper-v2 prototype when the data is present and
 // degrades gracefully (no row) otherwise. The generic level/module/source/
 // timestamp grid and tag row below it are preserved for every kind.
+//
+// Class vocabulary: each k/v grid carries the prototype `.lg-kv`/`.lg-kv-row`/
+// `.lg-kv-k`/`.lg-kv-v` classes (vendored keeper-v2/logs.css, loaded last) plus
+// the legacy `.v2-logs-detail-grid`/`.v2-logs-kind-grid` classes the tests
+// query. The per-kind payload blocks (args/result code, note, recipients, the
+// HILT jump) use the prototype `.lg-block`/`.lg-code`/`.lg-note`/`.lg-recips`/
+// `.lg-jump` classes and render only when their data is present.
 function renderLogKindGrid(
   kind: LogDisplayKind,
   details: Record<string, unknown> | null,
@@ -655,18 +711,31 @@ function renderLogKindGrid(
   if (!details) return null
   const d = detailLabel
   const row = (k: string, v: string | null): VNode | null =>
-    v && v !== '' ? html`<div><span>${k}</span><b class="mono">${v}</b></div>` : null
+    v && v !== '' ? html`<div class="lg-kv-row"><span class="lg-kv-k mono">${k}</span><b class="lg-kv-v mono">${v}</b></div>` : null
   const grid = (...rows: Array<VNode | null>): VNode | null => {
     const filled = rows.filter((r): r is VNode => r !== null)
-    return filled.length ? html`<div class="v2-logs-detail-grid v2-logs-kind-grid">${filled}</div>` : null
+    return filled.length ? html`<div class="v2-logs-detail-grid v2-logs-kind-grid lg-kv">${filled}</div>` : null
   }
+  const codeBlock = (label: string, value: unknown): VNode | null => {
+    const body = formatDetailCode(value)
+    return body === null
+      ? null
+      : html`<div class="lg-block"><span class="lg-block-h">${label}</span><pre class="lg-code">${body}</pre></div>`
+  }
+  const note = (text: string | null, dim = false): VNode | null =>
+    text ? html`<div class=${`lg-note${dim ? ' dim' : ''}`}>${text}</div>` : null
+
   if (kind === 'tool') {
-    return grid(
-      row('tool', d(details, 'tool_name') ?? d(details, 'tool')),
-      row('outcome', d(details, 'outcome') ?? d(details, 'status')),
-      row('latency', d(details, 'latency_ms') ?? d(details, 'duration_ms') ?? d(details, 'dur')),
-      row('namespace', d(details, 'namespace') ?? d(details, 'ns')),
-    )
+    return html`
+      ${grid(
+        row('tool', d(details, 'tool_name') ?? d(details, 'tool')),
+        row('outcome', d(details, 'outcome') ?? d(details, 'status')),
+        row('latency', d(details, 'latency_ms') ?? d(details, 'duration_ms') ?? d(details, 'dur')),
+        row('namespace', d(details, 'namespace') ?? d(details, 'ns')),
+      )}
+      ${codeBlock('args', details.tool_args ?? details.args ?? details.input)}
+      ${codeBlock('result', details.result ?? details.output)}
+    `
   }
   if (kind === 'turn') {
     const tools = (details as { tools_used?: unknown }).tools_used
@@ -679,27 +748,49 @@ function renderLogKindGrid(
     )
   }
   if (kind === 'lifecycle') {
-    return grid(
-      row('from', d(details, 'from') ?? d(details, 'phase')),
-      row('to', d(details, 'to') ?? d(details, 'next_phase')),
-      row('trigger', d(details, 'trigger')),
-    )
+    return html`
+      ${grid(
+        row('from', d(details, 'from') ?? d(details, 'phase')),
+        row('to', d(details, 'to') ?? d(details, 'next_phase')),
+        row('trigger', d(details, 'trigger')),
+      )}
+      ${note(detailNote(details, 'gloss'))}
+    `
   }
   if (kind === 'approval') {
     const goalJob = [d(details, 'goal_id') ?? d(details, 'goal'), d(details, 'job_id') ?? d(details, 'job')]
       .filter((v): v is string => v !== null)
       .join(' · ')
-    return grid(
-      row('tool', d(details, 'tool')),
-      row('severity', d(details, 'severity')),
-      row('goal · job', goalJob || null),
-    )
+    const request = detailNote(details, 'req', 'request')
+    const extra = detailNote(details, 'detail')
+    return html`
+      ${grid(
+        row('tool', d(details, 'tool')),
+        row('severity', d(details, 'severity')),
+        row('goal · job', goalJob || null),
+      )}
+      ${request ? html`<div class="lg-note">“${request}”</div>` : null}
+      ${note(extra, true)}
+      <${RouteLink}
+        tab="approvals"
+        class="lg-jump"
+        data-testid="logs-approval-jump"
+        aria-label="HILT 승인 큐 열기"
+      >HILT 승인 큐 열기 →<//>
+    `
   }
   if (kind === 'broadcast') {
-    return grid(
-      row('scope', d(details, 'scope') ?? d(details, 'namespace')),
-      row('via', d(details, 'via') ?? d(details, 'channel')),
-    )
+    const recipients = detailRecipients(details)
+    return html`
+      ${grid(
+        row('scope', d(details, 'scope') ?? d(details, 'namespace')),
+        row('via', d(details, 'via') ?? d(details, 'channel')),
+      )}
+      ${note(detailNote(details, 'note'))}
+      ${recipients.length > 0
+        ? html`<div class="lg-recips">${recipients.map((r, i) => html`<span key=${i} class="lg-recip mono">${r}</span>`)}</div>`
+        : html`<div class="lg-recips" data-stub="no-recipients-source"><span class="lg-note dim">수신자 정보 없음 (현재 스트림에 수신자 데이터 없음)</span></div>`}
+    `
   }
   return null
 }
@@ -749,7 +840,7 @@ function renderLogRow(entry: LogEntry) {
   return html`
     <div
       key=${entry.seq}
-      class=${`logs-row v2-logs-row ${isExpanded ? 'is-open' : ''}`}
+      class=${`logs-row v2-logs-row lg-row ${isExpanded ? 'is-open open' : ''}`}
       data-testid="logs-row"
       data-log-seq=${entry.seq}
       data-sev=${severity}
@@ -757,22 +848,22 @@ function renderLogRow(entry: LogEntry) {
     >
       <button
         type="button"
-        class="v2-logs-line"
+        class="v2-logs-line lg-line"
         aria-expanded=${isExpanded}
         onClick=${() => {
           expandedLogSeq.value = isExpanded ? null : entry.seq
         }}
       >
-        <span class="v2-logs-time mono">${formatLogClock(entry.ts)}</span>
-        <span class="v2-logs-who">
+        <span class="v2-logs-time lg-time mono">${formatLogClock(entry.ts)}</span>
+        <span class="v2-logs-who lg-who">
           <${KeeperBadge} id=${identity} variant="sigil" size="md" title=${identity} />
-          <span class="v2-logs-identity" title=${identity}>${identity}</span>
+          <span class="v2-logs-identity lg-kid" title=${identity}>${identity}</span>
         </span>
-        <span class="v2-logs-kind" data-kind=${displayKind}>${LOG_KIND_LABELS[displayKind]}</span>
-        <span class="v2-logs-message" title=${failure ? `${renderedMessage}\n${failure.summary}` : renderedMessage}>
+        <span class="v2-logs-kind lg-kind" data-kind=${displayKind}>${LOG_KIND_LABELS[displayKind]}</span>
+        <span class="v2-logs-message lg-msg" title=${failure ? `${renderedMessage}\n${failure.summary}` : renderedMessage}>
           ${renderedMessage}
         </span>
-        <span class="v2-logs-caret" aria-hidden="true">
+        <span class="v2-logs-caret lg-caret" aria-hidden="true">
           ${isExpanded ? html`<${ChevronDown} size=${14} />` : html`<${ChevronRight} size=${14} />`}
         </span>
       </button>
@@ -781,7 +872,7 @@ function renderLogRow(entry: LogEntry) {
         : null}
       ${isExpanded
         ? html`
-          <div class="v2-logs-detail">
+          <div class="v2-logs-detail lg-detail">
             ${renderLogKindGrid(displayKind, details) ?? ''}
             <div class="v2-logs-detail-grid">
               <div><span>level</span><b style=${{ color: LEVEL_COLORS[level] ?? 'inherit' }}>${level}</b></div>
@@ -1083,29 +1174,29 @@ export function LogViewer() {
   const providerDiagnostics = renderProviderLogPanel()
 
   return html`
-    <div class="logs-viewer v2-logs-surface">
+    <div class="logs-viewer v2-logs-surface lg">
       <section class="v2-logs-panel" aria-label="로그 뷰어">
-        <header class="v2-logs-head">
-          <div class="v2-logs-head-main">
-            <p class="v2-logs-eyebrow">Observatory</p>
+        <header class="v2-logs-head lg-head">
+          <div class="v2-logs-head-main lg-head-l">
+            <span class="v2-logs-eyebrow ov-eyebrow">Observatory</span>
             <h1>이벤트 로그</h1>
-            <p class="v2-logs-sub mono">live trace stream · masc runtime · ${logWindowLabel(logEntries)}</p>
+            <p class="v2-logs-sub lg-sub mono">live trace stream · masc runtime · ${logWindowLabel(logEntries)}</p>
           </div>
-          <div class="v2-logs-stats" aria-label="로그 요약">
-            <div class="v2-logs-stat"><span class="k">이벤트/분</span><span class="v mono">${eventRatePerMinute(logEntries)}</span></div>
-            <div class="v2-logs-stat"><span class="k">오류율</span><span class=${`v mono ${summary.errors > 0 ? 'bad' : ''}`}>${errRate}%</span></div>
-            <div class="v2-logs-stat"><span class="k">tool 호출</span><span class="v mono">${toolCalls}</span></div>
-            <div class="v2-logs-stat"><span class="k">활성 keeper</span><span class="v mono">${logActiveIdentityCount(logEntries)}</span></div>
+          <div class="v2-logs-stats lg-stats" aria-label="로그 요약">
+            <div class="v2-logs-stat lg-stat"><span class="k">이벤트/분</span><span class="v mono">${eventRatePerMinute(logEntries)}</span></div>
+            <div class="v2-logs-stat lg-stat"><span class="k">오류율</span><span class=${`v mono ${summary.errors > 0 ? 'bad' : ''}`}>${errRate}%</span></div>
+            <div class="v2-logs-stat lg-stat"><span class="k">tool 호출</span><span class="v mono">${toolCalls}</span></div>
+            <div class="v2-logs-stat lg-stat"><span class="k">활성 keeper</span><span class="v mono">${logActiveIdentityCount(logEntries)}</span></div>
           </div>
         </header>
 
-        <div class="logs-toolbar v2-logs-toolbar">
-          <div class="logs-filters v2-logs-filters">
+        <div class="logs-toolbar v2-logs-toolbar lg-toolbar">
+          <div class="logs-filters v2-logs-filters lg-filters">
             ${LOG_KIND_FILTERS.map(filter => html`
               <${LogFilter}
                 key=${filter.value || 'all'}
                 active=${kindFilter.value === filter.value}
-                class="v2-logs-filter-chip"
+                class="v2-logs-filter-chip lg-fchip"
                 data-testid=${`logs-filter-${filter.value || 'all'}`}
                 onClick=${() => {
                   kindFilter.value = filter.value
@@ -1114,13 +1205,13 @@ export function LogViewer() {
             `)}
           </div>
 
-          <div class="v2-logs-toolbar-break"></div>
+          <div class="v2-logs-toolbar-break lg-tb-spacer"></div>
 
           <div class="logs-actions v2-logs-actions">
             ${renderLogProvenance(logData)}
             <button
               type="button"
-              class=${`v2-logs-attention ${levelFilter.value === 'WARN' ? 'on' : ''}`}
+              class=${`v2-logs-attention lg-onlyerr ${levelFilter.value === 'WARN' ? 'on' : ''}`}
               aria-pressed=${levelFilter.value === 'WARN'}
               onClick=${() => { levelFilter.value = levelFilter.value === 'WARN' ? 'INFO' : 'WARN' }}
             >
@@ -1206,7 +1297,7 @@ export function LogViewer() {
               />
               자동
             </label>
-            <span class="v2-logs-live mono"><span class="dot" />${autoRefresh.value ? `masc-mcp · 3s polling · ${eventRatePerMinute(logEntries)}δ/min` : 'masc-mcp · WS paused'}</span>
+            <span class="v2-logs-live lg-live mono"><span class="dot" />${autoRefresh.value ? `masc-mcp · 3s polling · ${eventRatePerMinute(logEntries)}δ/min` : 'masc-mcp · WS paused'}</span>
             <button
               type="button"
               class="logs-refresh-btn v2-logs-refresh"
@@ -1246,7 +1337,7 @@ export function LogViewer() {
             : null}
         </div>
 
-        <div class="v2-logs-table-header">
+        <div class="v2-logs-table-header lg-colhd">
           <span>시각</span>
           <span>keeper</span>
           <span>유형</span>
@@ -1256,7 +1347,7 @@ export function LogViewer() {
 
         ${visibleEntries.length === 0
           ? html`
-              <div class="flex flex-1 items-center justify-center px-6 text-sm text-[var(--color-fg-muted)]" role="status">
+              <div class="lg-empty" role="status">
                 ${emptyMessage}
               </div>
             `
@@ -1267,7 +1358,7 @@ export function LogViewer() {
                 overscan=${6}
                 getKey=${(entry: LogEntry) => String(entry.seq)}
                 renderItem=${(entry: LogEntry) => renderLogRow(entry)}
-                className="v2-logs-stream"
+                className="v2-logs-stream lg-stream"
               />
             `}
 

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -705,9 +705,8 @@ describe('Overview v2 marker classes', () => {
     const { container } = render(h(Overview, null))
 
     expect(container.querySelector('.v2-overview-surface')).not.toBeNull()
-    expect(container.querySelector('.v2-overview-rollup')).not.toBeNull()
-    expect(container.querySelector('.v2-overview-rollup .v2-overview-funnel')).not.toBeNull()
-    expect(container.querySelector('.v2-overview-rollup .v2-overview-keepers')).not.toBeNull()
+    expect(container.querySelector('.v2-overview-primary-grid')).not.toBeNull()
+    expect(container.querySelector('.v2-overview-domains')).not.toBeNull()
   })
 
   it('renders keeper-v2 port marker classes', () => {
@@ -717,7 +716,7 @@ describe('Overview v2 marker classes', () => {
     expect(container.querySelector('.v2-overview-kpis')).not.toBeNull()
     expect(container.querySelector('.v2-overview-attention')).not.toBeNull()
     expect(container.querySelector('.v2-overview-telemetry')).not.toBeNull()
-    expect(container.querySelector('.v2-overview-fleet')).not.toBeNull()
+    expect(container.querySelector('.v2-overview-domains')).not.toBeNull()
   })
 })
 
@@ -734,20 +733,19 @@ describe('Overview StyleSeed surfaces', () => {
     expect(root?.classList.contains('text-text-primary')).toBe(true)
   })
 
-  it('renders the prototype primary sequence before the legacy rollup', () => {
+  it('renders the prototype primary sequence (kpis → grid → domains)', () => {
     const { container } = render(h(Overview, null))
     const sequence = [...container.querySelectorAll(
-      '[data-testid="overview-kpis"], [data-testid="overview-primary-grid"], [data-testid="overview-fleet"], [data-testid="overview-rollup"]',
+      '[data-testid="overview-kpis"], [data-testid="overview-primary-grid"], [data-testid="overview-domains"]',
     )].map(el => el.getAttribute('data-testid'))
 
     expect(sequence).toEqual([
       'overview-kpis',
       'overview-primary-grid',
-      'overview-fleet',
-      'overview-rollup',
+      'overview-domains',
     ])
     expect(container.querySelector('.v2-overview-kpis')?.classList.contains('ov-kpis')).toBe(true)
-    expect(container.querySelector('.v2-overview-fleet')?.classList.contains('ov-card')).toBe(true)
+    expect(container.querySelector('.v2-overview-domains')?.classList.contains('ov-domains')).toBe(true)
   })
 
   it('uses the prototype two-column overview grid container', () => {
@@ -918,12 +916,12 @@ describe('Overview prototype surface', () => {
     ])
   })
 
-  it('places the domain section after the fleet grid and before the rollup', () => {
+  it('places the domain section last, after the primary grid', () => {
     const { container } = render(h(Overview, null))
     const order = [...container.querySelectorAll(
-      '[data-testid="overview-fleet"], [data-testid="overview-domains"], [data-testid="overview-rollup"]',
+      '[data-testid="overview-primary-grid"], [data-testid="overview-domains"]',
     )].map(el => el.getAttribute('data-testid'))
-    expect(order).toEqual(['overview-fleet', 'overview-domains', 'overview-rollup'])
+    expect(order).toEqual(['overview-primary-grid', 'overview-domains'])
   })
 
   // Gap 1: KPI grid uses 6-column layout (surfaces.css:88 `repeat(6, 1fr)`)

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -17,15 +17,8 @@
 
 import { html } from 'htm/preact'
 import { useEffect, useMemo } from 'preact/hooks'
-import { SectionCard } from '../common/card'
-import { StatTile } from '../common/stat-tile'
-import { TimeAgo } from '../common/time-ago'
-import { StatusDot } from '../common/status-dot'
-import type { KpiCellKind } from '../kpi-shared'
-import { KpiStripIsland } from '../kpi-strip-island'
 import { AgentAvatar } from './agent-avatar'
-import { missionSnapshot } from '../../mission-store'
-import { agents, tasks, keepers, messages, boardPosts, goals, fusionRuns } from '../../store'
+import { tasks, keepers, boardPosts, goals, fusionRuns } from '../../store'
 import type { Agent, Task, Keeper, Message, BoardPost, Goal, KeeperRuntimeBlockerClass } from '../../types/core'
 import type { FusionRunRecord } from '../../api/dashboard'
 import { SYSTEM_ACTOR_NAME } from '../../types/core'
@@ -33,9 +26,7 @@ import type {
   DashboardMissionResponse,
   DashboardMissionSessionCard,
 } from '../../types/dashboard-mission'
-import { openAgentDetail } from '../agent-detail-state'
-import { openTaskDetail } from '../goals/task-detail-state'
-import { nowSecondsSignal, useNowSecondsTicker } from '../../lib/now-signal'
+import { useNowSecondsTicker } from '../../lib/now-signal'
 import { keeperDisplayStatus, keeperRuntimeBlockerLabel } from '../../lib/keeper-runtime-display'
 import { isKeeperPaused } from '../../lib/keeper-predicates'
 import { isAgentOffline } from '../../lib/agent-status'
@@ -44,17 +35,11 @@ import { createAsyncResource, type AsyncResource, type AsyncState } from '../../
 import { navigate } from '../../router'
 import type { TabId } from '../../types/sse'
 import {
-  normalizeSurfaceReadinessPayload,
-  summarizeSurfaceReadiness,
-  type SurfaceReadinessEntry,
-} from '../surface-readiness-panel'
-import {
   fetchTelemetry,
   fetchTelemetrySummary,
   type TelemetryEntry,
   type TelemetrySourceSummary,
 } from '../../api/dashboard'
-import { get } from '../../api/core'
 
 // ─── Attention / Keeper v2 helpers ───────────────────────────────────────────
 
@@ -477,6 +462,20 @@ function pushTickerEvent(out: FleetTickerEvent[], event: Omit<FleetTickerEvent, 
   out.push({ ...event, timestampMs, text })
 }
 
+// Human-readable keeper status, used in the fleet ticker event text.
+function keeperStatusLabel(status?: string | null): string {
+  switch ((status ?? '').toLowerCase()) {
+    case 'active': case 'live': return 'Active'
+    case 'busy': case 'executing': return 'Busy'
+    case 'paused': return 'Paused'
+    case 'offline': return 'Offline'
+    case 'dead': return 'Dead'
+    case 'stopped': return 'Stopped'
+    case 'unbooted': return 'Unbooted'
+    default: return status ?? 'Unknown'
+  }
+}
+
 export function deriveFleetTickerEvents({
   taskList,
   messageList,
@@ -545,106 +544,6 @@ export function deriveFleetTickerEvents({
     .slice(0, Math.max(0, max))
 }
 
-function tickerToneClass(tone: FleetTickerEvent['tone']): string {
-  switch (tone) {
-    case 'ok':
-      return 'text-success'
-    case 'warn':
-      return 'text-warning'
-    case 'err':
-      return 'text-destructive'
-    case 'info':
-      return 'text-brand'
-    default:
-      return 'text-text-tertiary'
-  }
-}
-
-function FleetTicker({ events }: { events: FleetTickerEvent[] }) {
-  if (events.length === 0) return null
-  return html`
-    <${SectionCard}
-      title="Fleet Ticker"
-      class="v2-overview-ticker ss-card mx-6"
-      variant="standard"
-      right=${html`<span class="text-[12px] text-text-tertiary">latest ${events.length}</span>`}
-      data-testid="overview-fleet-ticker"
-    >
-      <div
-        role="list"
-        aria-label="Recent fleet events"
-        class="flex min-w-0 gap-2 overflow-x-auto pb-1"
-      >
-        ${events.map(event => html`
-          <div
-            key=${event.id}
-            role="listitem"
-            class="v2-overview-ticker-card grid min-w-[15rem] max-w-[22rem] max-[768px]:min-w-[12rem] flex-[0_0_auto] gap-1 rounded-md border border-border bg-card px-3 py-2"
-          >
-            <div class="flex min-w-0 items-center gap-2 font-mono text-[10px] uppercase tracking-wider">
-              <span class=${tickerToneClass(event.tone)}>${event.kind}</span>
-              <span class="truncate text-text-tertiary">${event.actor}</span>
-              <${TimeAgo} timestamp=${event.timestamp} class="ml-auto shrink-0 text-text-disabled" />
-            </div>
-            <div class="truncate text-[13px] font-semibold text-text-primary">${event.text}</div>
-            <div class="truncate font-mono text-[10px] uppercase tracking-wider text-text-disabled">${event.label}</div>
-          </div>
-        `)}
-      </div>
-    <//>
-  `
-}
-
-function AlertPanel({ agentAlerts, taskAlerts }: { agentAlerts: AgentAlert[]; taskAlerts: TaskAlert[] }) {
-  const allAlerts = [...agentAlerts, ...taskAlerts]
-  if (allAlerts.length === 0) return null
-  const hasCritical = allAlerts.some(a => a.severity === 'critical')
-  const criticalCount = allAlerts.filter(a => a.severity === 'critical').length
-  const warnCount = allAlerts.filter(a => a.severity === 'warn').length
-
-  return html`
-    <${SectionCard}
-      title="Alerts"
-      class="v2-overview-alerts ss-card mx-6"
-      variant="standard"
-      tone=${hasCritical ? 'border-destructive' : 'border-warning'}
-      right=${html`<${StatusDot} class=${hasCritical ? 'bg-destructive' : 'bg-warning'} />`}
-      data-testid="overview-alerts"
-    >
-      <div class="mb-4">
-        <${KpiStripIsland}
-          cols=${2}
-          cells=${[
-            { label: 'Critical', value: String(criticalCount), kind: 'err' },
-            { label: 'Warning', value: String(warnCount), kind: 'warn' },
-          ]}
-        />
-      </div>
-      <ul class="space-y-2 border-t border-border pt-4">
-        ${allAlerts.map(
-          a => html`
-            <li
-              class="flex items-start justify-between gap-4 cursor-pointer p-1 -m-1 rounded-md"
-              onClick=${() => {
-                if ('name' in a) openAgentDetail(a.name)
-                else openTaskDetail(a.task)
-              }}
-            >
-              <div class="flex-1 min-w-0">
-                <p class="text-[13px] font-semibold truncate text-text-primary">${'name' in a ? a.display : a.title}</p>
-                <p class="text-[11px] text-text-tertiary truncate">${'reason' in a ? a.reason : a.status}</p>
-              </div>
-              <span class=${`chip sm shrink-0 ${a.severity === 'critical' ? 'is-err' : 'is-warn'}`}>
-                ${a.severity.toUpperCase()}
-              </span>
-            </li>
-          `,
-        )}
-      </ul>
-    <//>
-  `
-}
-
 // ─── Funnel ──────────────────────────────────────────────────────────────────
 
 export interface FunnelCounts {
@@ -704,45 +603,6 @@ export function formatTargetRatio(counts: FunnelCounts): string {
   return `${counts.completed}/${counts.target} (${pct}%)`
 }
 
-function funnelSegStyle(pct: number): string {
-  return pct > 0 ? `width:${pct.toFixed(1)}%` : ''
-}
-
-function FunnelCard({ counts }: { counts: FunnelCounts }) {
-  const awaitingKind: KpiCellKind | undefined = counts.awaiting > 0 ? 'warn' : undefined
-  const total = counts.created + counts.inProgress + counts.awaiting + counts.completed
-  const segPct = (n: number) => total > 0 ? (n / total) * 100 : 0
-  return html`
-    <${SectionCard}
-      label="Today"
-      class="v2-overview-funnel ss-card mx-6"
-      variant="standard"
-      right=${html`<span class="text-[12px] text-text-tertiary">task basis</span>`}
-      data-testid="overview-funnel"
-    >
-      <${KpiStripIsland}
-        ariaLabel="Today funnel"
-        cols=${5}
-        cells=${[
-          { variant: 'stacked', label: 'New', value: String(counts.created), testId: 'funnel-created' },
-          { variant: 'stacked', label: 'Active', value: String(counts.inProgress), testId: 'funnel-in-progress' },
-          { variant: 'stacked', label: 'Verify', value: String(counts.awaiting), kind: awaitingKind, testId: 'funnel-awaiting' },
-          { variant: 'stacked', label: 'Done', value: String(counts.completed), kind: 'ok', testId: 'funnel-completed' },
-          { variant: 'stacked', label: 'Target', value: formatTargetRatio(counts), testId: 'funnel-target' },
-        ]}
-      />
-      ${total > 0 ? html`
-        <div class="bar-seg mt-4" style="height:var(--sp-1)" data-testid="funnel-seg">
-          ${counts.inProgress > 0 ? html`<span class="seg-idle" style=${funnelSegStyle(segPct(counts.inProgress))}></span>` : null}
-          ${counts.awaiting > 0 ? html`<span class="seg-warn" style=${funnelSegStyle(segPct(counts.awaiting))}></span>` : null}
-          ${counts.completed > 0 ? html`<span class="seg-ok" style=${funnelSegStyle(segPct(counts.completed))}></span>` : null}
-          ${counts.created > 0 ? html`<span class="seg-idle" style=${funnelSegStyle(segPct(counts.created))}></span>` : null}
-        </div>
-      ` : null}
-    <//>
-  `
-}
-
 // ─── Mission Party ────────────────────────────────────────────────────────────
 
 export function progressPct(session: DashboardMissionSessionCard | null): number | null {
@@ -753,86 +613,7 @@ export function progressPct(session: DashboardMissionSessionCard | null): number
   return Math.min(100, Math.round((cur / req) * 100))
 }
 
-function MissionPartyCard({ active }: { active: DashboardMissionSessionCard | null }) {
-  if (!active) {
-    return html`
-      <${SectionCard} label="Active mission" class="v2-overview-party ss-card mx-6" variant="standard" data-testid="overview-party-empty">
-        <p class="text-[11px] text-text-tertiary italic">No active mission</p>
-      <//>
-    `
-  }
-
-  const progress = progressPct(active)
-  const status = active.status ?? 'unknown'
-  const members = active.member_names
-
-  return html`
-    <${SectionCard} label="Active Mission" class="v2-overview-party ss-card mx-6" variant="standard" data-testid="overview-party">
-      <div class="space-y-4">
-        <div class="flex items-center justify-between">
-           <p class="text-[13px] font-semibold text-text-primary truncate flex-1 mr-4">
-             ${active.goal}
-           </p>
-           <div class="flex -space-x-1.5">
-             ${members.map(m => html`<${AgentAvatar} key=${m} name=${m} size="xs" class="ring-1 ring-[var(--bg-surface-page)]" />`)}
-           </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-3">
-          <${StatTile}
-            label="Progress"
-            value=${progress === null ? 'n/a' : `${progress}%`}
-            status=${progress !== null && progress > 80 ? 'ok' : progress !== null ? 'brass' : undefined}
-            delta=${progress !== null ? { direction: progress > 50 ? 'up' : 'flat', text: progress > 80 ? 'on track' : `${progress}%` } : undefined}
-          />
-          <${StatTile}
-            label="Status"
-            value=${status.toUpperCase()}
-            status=${status === 'running' || status === 'active' ? 'ok' : status === 'paused' ? 'warn' : 'brass'}
-          />
-        </div>
-        ${progress !== null ? html`
-          <div class="bar ${progress > 80 ? 'is-ok' : progress > 50 ? '' : 'is-warn'}">
-            <span class="fill" style="width: ${progress}%"></span>
-          </div>
-        ` : null}
-      </div>
-    <//>
-  `
-}
-
 // ─── Keeper Strip ────────────────────────────────────────────────────────────
-
-function keeperPillClass(status?: string | null): string {
-  switch ((status ?? '').toLowerCase()) {
-    case 'active':
-    case 'live':
-      return 'pill is-ok'
-    case 'busy':
-    case 'executing':
-      return 'pill is-running'
-    case 'offline':
-    case 'dead':
-    case 'stopped':
-    case 'unbooted':
-      return 'pill is-err'
-    default:
-      return 'pill is-paused'
-  }
-}
-
-function keeperStatusLabel(status?: string | null): string {
-  switch ((status ?? '').toLowerCase()) {
-    case 'active': case 'live': return 'Active'
-    case 'busy': case 'executing': return 'Busy'
-    case 'paused': return 'Paused'
-    case 'offline': return 'Offline'
-    case 'dead': return 'Dead'
-    case 'stopped': return 'Stopped'
-    case 'unbooted': return 'Unbooted'
-    default: return status ?? 'Unknown'
-  }
-}
 
 export function pickActiveKeepers(keeperList: readonly Keeper[], max = 3): Keeper[] {
   return [...keeperList]
@@ -846,41 +627,6 @@ export function pickActiveKeepers(keeperList: readonly Keeper[], max = 3): Keepe
     .slice(0, max)
 }
 
-function KeeperStrip({ keeperList }: { keeperList: readonly Keeper[] }) {
-  const activeKeepers = pickActiveKeepers(keeperList)
-
-  if (activeKeepers.length === 0) {
-    return html`
-      <${SectionCard} label="Active Keepers" class="v2-overview-keepers ss-card mx-6" variant="standard" data-testid="overview-keepers-empty">
-        <p class="text-[11px] text-text-tertiary italic">No active keepers</p>
-      <//>
-    `
-  }
-
-  return html`
-    <${SectionCard} label="Active Keepers" class="v2-overview-keepers ss-card mx-6" variant="standard" data-testid="overview-keepers">
-      <ul class="flex flex-wrap gap-x-6 gap-y-2">
-        ${activeKeepers.map(
-          k => {
-            const displayStatus = keeperDisplayStatus(k)
-            return html`
-            <li key=${k.name} class="flex items-center gap-2">
-              <div class="min-w-0">
-                <p class="text-[13px] font-medium truncate text-text-primary">${k.koreanName && k.koreanName !== '' ? k.koreanName : k.name}</p>
-                ${k.last_heartbeat !== undefined
-                  ? html`<${TimeAgo} timestamp=${k.last_heartbeat} class="text-[10px] text-text-tertiary" />`
-                  : null}
-              </div>
-              <span class="${keeperPillClass(displayStatus)} text-[10px] shrink-0">${keeperStatusLabel(displayStatus)}</span>
-            </li>
-            `
-          },
-        )}
-      </ul>
-    <//>
-  `
-}
-
 export function pickActiveSession(snap: DashboardMissionResponse | null): DashboardMissionSessionCard | null {
   if (snap === null) return null
   const running = snap.sessions.find(s => s.status === 'running' || s.status === 'active' || s.status === 'busy')
@@ -889,16 +635,7 @@ export function pickActiveSession(snap: DashboardMissionResponse | null): Dashbo
 
 // ─── Surface Readiness Summary ───────────────────────────────────────────────
 
-const surfaceReadinessResource: AsyncResource<SurfaceReadinessEntry[]> = createAsyncResource()
 const overviewTelemetryResource: AsyncResource<OverviewTelemetrySnapshot> = createAsyncResource()
-
-function loadSurfaceReadiness(): Promise<void> {
-  return surfaceReadinessResource.load(async () => {
-    const raw = await get<unknown>('/api/v1/dashboard/surface-readiness')
-    const data = normalizeSurfaceReadinessPayload(raw)
-    return data.surfaces
-  })
-}
 
 function loadOverviewTelemetry(nowMs = Date.now()): Promise<void> {
   return overviewTelemetryResource.load(async () => {
@@ -915,33 +652,6 @@ function loadOverviewTelemetry(nowMs = Date.now()): Promise<void> {
       truncated: telemetry.truncated ?? false,
     })
   })
-}
-
-function SurfaceReadinessSummary() {
-  useEffect(() => { void loadSurfaceReadiness() }, [])
-
-  const state = surfaceReadinessResource.state.value
-  if (state.status !== 'loaded') return null
-
-  const summary = summarizeSurfaceReadiness(state.data)
-  return html`
-    <${SectionCard}
-      label="Surface Readiness"
-      class="v2-overview-readiness ss-card mx-6"
-      variant="standard"
-      data-testid="overview-surface-readiness"
-    >
-      <${KpiStripIsland}
-        ariaLabel="Surface readiness summary"
-        cols=${3}
-        cells=${[
-          { variant: 'stacked', label: 'Main', value: String(summary.main), testId: 'sr-main' },
-          { variant: 'stacked', label: 'Total', value: String(summary.total), testId: 'sr-total' },
-          { variant: 'stacked', label: 'Gaps', value: String(summary.gaps), kind: summary.gaps > 0 ? 'warn' : 'ok', testId: 'sr-gaps' },
-        ]}
-      />
-    <//>
-  `
 }
 
 // ─── Keeper-v2 overview surfaces ─────────────────────────────────────────────
@@ -1155,89 +865,6 @@ function OverviewTelemetry({
   `
 }
 
-function keeperNamespaceLabel(keeper: Keeper): string {
-  return keeper.runtime_canonical
-    ?? keeper.selected_runtime_canonical
-    ?? keeper.runtime_id
-    ?? keeper.agent_name
-    ?? 'runtime unavailable'
-}
-
-function OverviewFleetGrid({ keeperList }: { keeperList: readonly Keeper[] }) {
-  if (keeperList.length === 0) {
-    return html`
-      <section class="ov-card ov-fleet v2-overview-fleet" data-testid="overview-fleet">
-        <div class="ov-card-h">
-          <h3>Keeper 전체</h3>
-          <button type="button" class="ov-link" onClick=${() => navigate('monitoring', { section: 'agents' })}>전체 대화 보기 →</button>
-        </div>
-        <div class="ov-empty">No keepers</div>
-      </section>
-    `
-  }
-
-  const sorted = useMemo(
-    () => [...keeperList].sort((a, b) => {
-      const aAtt = pickAttentionKeepers([a]).length > 0 ? 1 : 0
-      const bAtt = pickAttentionKeepers([b]).length > 0 ? 1 : 0
-      if (aAtt !== bAtt) return bAtt - aAtt
-      const tsA = parseIsoMs(a.last_heartbeat) ?? 0
-      const tsB = parseIsoMs(b.last_heartbeat) ?? 0
-      return tsB - tsA
-    }),
-    [keeperList],
-  )
-
-  return html`
-    <section class="ov-card ov-fleet v2-overview-fleet" data-testid="overview-fleet">
-      <div class="ov-card-h">
-        <h3>Keeper 전체</h3>
-        <button type="button" class="ov-link" onClick=${() => navigate('monitoring', { section: 'agents' })}>전체 대화 보기 →</button>
-      </div>
-      <div class="ov-fleet-grid v2-overview-fleet-grid">
-        ${sorted.map(k => {
-          const displayStatus = keeperDisplayStatus(k)
-          const isRunning = keeperRowLooksRunning(k)
-          const ctx = k.context_ratio ?? 0
-          const ctxPct = Math.round(ctx * 100)
-          const displayName = k.koreanName && k.koreanName !== '' ? k.koreanName : k.name
-          return html`
-            <button
-              key=${k.name}
-              type="button"
-              class="ov-keeper v2-overview-keeper"
-              onClick=${() => navigate('monitoring', { section: 'agents', keeper: k.name })}
-              data-testid=${`overview-keeper-${k.name}`}
-            >
-              <div class="ov-keeper-top">
-                <${AgentAvatar} name=${k.name} size="sm" status=${displayStatus} />
-                <div class="ov-keeper-id">
-                  <div class="ov-keeper-name">${displayName}</div>
-                  <div class="ov-keeper-state">
-                    <${StatusDot} class=${isRunning ? 'bg-success' : 'bg-text-disabled'} />
-                    <span class="truncate">${k.phase ?? k.lifecycle_phase ?? displayStatus}</span>
-                  </div>
-                </div>
-                ${pickAttentionKeepers([k]).length > 0
-                  ? html`<span class="ov-keeper-att v2-overview-keeper-att">!</span>`
-                  : null}
-              </div>
-              <div class="ov-keeper-ns mono">${keeperNamespaceLabel(k)}</div>
-              <div class="ov-keeper-foot">
-                <span class="mono">${keeperModelLabel(k) || keeperNamespaceLabel(k)}</span>
-                <div class="ov-mini-meter v2-overview-mini-meter">
-                  <span class=${ctx >= 0.85 ? 'hot' : ''} style=${{ width: `${Math.min(100, ctxPct)}%` }}></span>
-                </div>
-                <span class="mono ov-keeper-ctx">${ctxPct}%</span>
-              </div>
-            </button>
-          `
-        })}
-      </div>
-    </section>
-  `
-}
-
 // ─── Domain status section (overview.jsx:159-261) ────────────────────────────
 //
 // "도메인 현황" header over a 7-card grid: one summary card per surface
@@ -1397,23 +1024,10 @@ export function Overview() {
     }, 60_000)
     return () => window.clearInterval(interval)
   }, [])
-  const snap = missionSnapshot.value
   const taskList = tasks.value
   const keeperList = keepers.value
-  const agentList = agents.value
-  const messageList = messages.value
-  const boardPostList = boardPosts.value
   const goalList = goals.value
   const fusionList = fusionRuns.value
-  const nowMs = nowSecondsSignal.value * 1000
-  const active = useMemo(() => pickActiveSession(snap), [snap])
-  const counts = useMemo(() => computeFunnelCounts(taskList, active, nowMs), [taskList, active, nowMs])
-  const agentAlerts = useMemo(() => deriveAgentAlerts(agentList), [agentList])
-  const taskAlerts = useMemo(() => deriveTaskAlerts(taskList, nowMs), [taskList, nowMs])
-  const tickerEvents = useMemo(
-    () => deriveFleetTickerEvents({ taskList, messageList, boardPostList, keeperList }),
-    [taskList, messageList, boardPostList, keeperList],
-  )
   const stats = useMemo(() => computeOverviewStats(keeperList, taskList), [keeperList, taskList])
   const digest = useMemo(
     () => computeOverviewDigest(keeperList, goalList, fusionList),
@@ -1430,20 +1044,7 @@ export function Overview() {
           <${OverviewAttentionPanel} keeperList=${keeperList} />
           <${OverviewTelemetry} telemetry=${telemetry} />
         </div>
-        <${OverviewFleetGrid} keeperList=${keeperList} />
         <${OverviewDomainSection} stats=${stats} digest=${digest} />
-
-        <details class="v2-overview-rollup" data-testid="overview-rollup">
-          <summary>운영 롤업</summary>
-          <div class="v2-overview-rollup-body">
-            <${AlertPanel} agentAlerts=${agentAlerts} taskAlerts=${taskAlerts} />
-            <${SurfaceReadinessSummary} />
-            <${FleetTicker} events=${tickerEvents} />
-            <${FunnelCard} counts=${counts} />
-            <${MissionPartyCard} active=${active} />
-            <${KeeperStrip} keeperList=${keeperList} />
-          </div>
-        </details>
       </div>
     </main>
   `

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -1,24 +1,36 @@
 import { html } from 'htm/preact'
 import { Save } from 'lucide-preact'
-import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useMemo, useState } from 'preact/hooks'
 import {
+  deleteRuntimeTomlKey,
   parseRuntimeTomlEnvironment,
   setRuntimeTomlBindingField,
   setRuntimeTomlDefault,
-  setRuntimeTomlModelField,
+  setRuntimeTomlKey,
   setRuntimeTomlProviderCredential,
   setRuntimeTomlProviderField,
   type RuntimeTomlBinding,
   type RuntimeTomlCredentialType,
   type RuntimeTomlEnvironment,
-  type RuntimeTomlModel,
   type RuntimeTomlProvider,
-  type RuntimeTomlTransportKind,
 } from '../lib/runtime-toml-config'
+import { keepers } from '../store'
 import { ActionButton } from './common/button'
+import { StatusDot } from './common/status-dot'
+
+// rt-* section ids. Mirrors RUNTIME_SECTIONS in runtime-toml-editor.ts so the
+// nav can drive which prototype body is visible. 'toml' is rendered by the
+// parent, not here.
+export type RuntimeStructuredSection =
+  | 'routing'
+  | 'providers'
+  | 'models'
+  | 'bindings'
+  | 'assignments'
 
 interface RuntimeEnvironmentEditorProps {
   sourceText: string
+  section: RuntimeStructuredSection
   dirty: boolean
   disabled?: boolean
   saving?: boolean
@@ -26,67 +38,13 @@ interface RuntimeEnvironmentEditorProps {
   onSave: (sourceText?: string) => void
 }
 
-const FIELD_CLASS = 'w-full rounded-[var(--r-1)] border border-[var(--input-border)] bg-[var(--input-bg)] px-2 py-1.5 text-xs text-[var(--color-fg-primary)] outline-none focus:border-[var(--color-accent-fg)]'
-const CHECKBOX_CLASS = 'h-4 w-4 rounded-[var(--r-0)] border border-[var(--input-border)] bg-[var(--input-bg)]'
-
 function firstId<T extends { id: string }>(items: T[]): string {
   return items[0]?.id ?? ''
-}
-
-function selectedItem<T extends { id: string }>(items: T[], selectedId: string): T | null {
-  return items.find(item => item.id === selectedId) ?? items[0] ?? null
-}
-
-function numberValue(value: number | null): string {
-  return typeof value === 'number' && Number.isFinite(value) ? String(value) : ''
 }
 
 function parsePositiveInt(value: string): number | null {
   const parsed = Number.parseInt(value, 10)
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null
-}
-
-function FieldShell({
-  label,
-  hint,
-  children,
-}: {
-  label: string
-  hint?: string
-  children: unknown
-}) {
-  return html`
-    <label class="min-w-0">
-      <span class="mb-1 block text-2xs font-semibold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">${label}</span>
-      ${children}
-      ${hint ? html`<span class="mt-1 block text-3xs text-[var(--color-fg-disabled)]">${hint}</span>` : null}
-    </label>
-  `
-}
-
-function ToggleField({
-  label,
-  checked,
-  disabled,
-  onChange,
-}: {
-  label: string
-  checked: boolean
-  disabled?: boolean
-  onChange: (checked: boolean) => void
-}) {
-  return html`
-    <label class="flex min-h-9 items-center justify-between gap-3 rounded-[var(--r-1)] border border-[var(--color-border-subtle)] px-2 py-1.5">
-      <span class="text-xs text-[var(--color-fg-secondary)]">${label}</span>
-      <input
-        type="checkbox"
-        class=${CHECKBOX_CLASS}
-        checked=${checked}
-        disabled=${disabled}
-        onChange=${(event: Event) => onChange((event.currentTarget as HTMLInputElement).checked)}
-      />
-    </label>
-  `
 }
 
 function runtimeOptions(environment: RuntimeTomlEnvironment): string[] {
@@ -100,110 +58,79 @@ function credentialValue(provider: RuntimeTomlProvider): string {
   return ''
 }
 
-function credentialLabel(type: RuntimeTomlCredentialType): string {
-  if (type === 'env') return 'env key'
-  if (type === 'file') return 'file path'
-  if (type === 'inline') return 'inline value'
-  return 'credential'
-}
-
 function transportValue(provider: RuntimeTomlProvider): string {
   if (provider.transportKind === 'command') return provider.command
   return provider.endpoint
 }
 
-function SectionTitle({ children }: { children: unknown }) {
-  return html`
-    <div class="text-2xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-fg-primary)]">
-      ${children}
-    </div>
-  `
+// Prototype rt-model-ctx label — runtime-editor.jsx:176 `(max/1000).toFixed(0)}k ctx`.
+function protoContext(value: number | null | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return '— ctx'
+  return `${(value / 1000).toFixed(0)}k ctx`
 }
 
-interface RuntimeCatalogEntry {
-  id: string
-  binding: RuntimeTomlBinding
-  provider: RuntimeTomlProvider | null
-  model: RuntimeTomlModel | null
-  isDefault: boolean
+// rt-cap chip — runtime-editor.jsx:17 rtCapChip. `on` toggles the ✓/· glyph
+// and the .on tone (runtime.css:64). Read-only capability readout.
+function capChip(on: boolean, label: string) {
+  return html`<span class="rt-cap ${on ? 'on' : ''}">${on ? '✓' : '·'} ${label}</span>`
 }
 
-function runtimeCatalogEntries(environment: RuntimeTomlEnvironment): RuntimeCatalogEntry[] {
-  return environment.bindings.map(binding => ({
-    id: binding.id,
-    binding,
-    provider: environment.providers.find(provider => provider.id === binding.providerId) ?? null,
-    model: environment.models.find(model => model.id === binding.modelId) ?? null,
-    isDefault: binding.id === environment.defaultRuntimeId || binding.isDefault,
-  }))
+// Read a bare [runtime] string value (librarian / cross_verifier) straight from
+// the draft. The parser only surfaces `default`, so the extra routing lanes are
+// read here from the same source text the parser consumes. Matches the
+// parser's [section] header + key = "value" grammar.
+function readRuntimeLaneValue(sourceText: string, key: string): string {
+  const lines = sourceText.split('\n')
+  let inRuntime = false
+  for (const rawLine of lines) {
+    const headerMatch = rawLine.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/)
+    if (headerMatch) {
+      inRuntime = headerMatch[1]?.trim() === 'runtime'
+      continue
+    }
+    if (!inRuntime) continue
+    const keyMatch = rawLine.match(/^\s*([A-Za-z0-9_-]+)\s*=\s*"([^"]*)"\s*(?:#.*)?$/)
+    if (keyMatch && keyMatch[1] === key) return keyMatch[2] ?? ''
+  }
+  return ''
 }
 
-function compactContext(value: number | null | undefined): string {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 'ctx -'
-  if (value >= 1_000_000) return `${Number.parseFloat((value / 1_000_000).toFixed(1))}M ctx`
-  if (value >= 1_000) return `${Math.round(value / 1_000)}K ctx`
-  return `${value} ctx`
+// Read [runtime.assignments] keeper -> runtime id from the draft. Same grammar
+// as the parser; surfaces explicit assignments so each keeper row reflects what
+// runtime.toml actually pins (and falls back to default when absent).
+function readRuntimeAssignments(sourceText: string): Record<string, string> {
+  const lines = sourceText.split('\n')
+  let inSection = false
+  const assignments: Record<string, string> = {}
+  for (const rawLine of lines) {
+    const headerMatch = rawLine.match(/^\s*\[([^\]]+)\]\s*(?:#.*)?$/)
+    if (headerMatch) {
+      inSection = headerMatch[1]?.trim() === 'runtime.assignments'
+      continue
+    }
+    if (!inSection) continue
+    const keyMatch = rawLine.match(/^\s*([A-Za-z0-9_.-]+)\s*=\s*"([^"]*)"\s*(?:#.*)?$/)
+    if (keyMatch?.[1]) assignments[keyMatch[1]] = keyMatch[2] ?? ''
+  }
+  return assignments
 }
 
-function compactTransport(provider: RuntimeTomlProvider | null): string {
-  if (!provider) return 'transport -'
-  if (provider.transportKind === 'command') return 'cli'
-  if (provider.endpoint.startsWith('http://127.0.0.1') || provider.endpoint.startsWith('http://localhost')) return 'local'
-  if (provider.endpoint !== '') return 'cloud'
-  return provider.transportKind
-}
-
-function boolToken(label: string, value: boolean | undefined): string {
-  return `${label}:${value === true ? 'on' : 'off'}`
-}
-
-function RuntimeCatalogStrip({
-  entries,
-  selectedRuntimeId,
-  disabled,
-  onSelect,
-}: {
-  entries: RuntimeCatalogEntry[]
-  selectedRuntimeId: string
-  disabled: boolean
-  onSelect: (entry: RuntimeCatalogEntry) => void
-}) {
-  if (entries.length === 0) return null
-  return html`
-    <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-3" data-testid="runtime-catalog-strip">
-      ${entries.map(entry => {
-        const active = entry.id === selectedRuntimeId
-        const providerLabel = entry.provider?.displayName || entry.provider?.id || entry.binding.providerId
-        const modelLabel = entry.model?.apiName || entry.model?.id || entry.binding.modelId
-        return html`
-          <button
-            type="button"
-            class="v2-monitoring-card min-w-0 rounded-[var(--r-1)] border px-3 py-2 text-left transition-colors ${active ? 'border-[var(--color-accent-fg)] bg-[var(--accent-10)]' : 'border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] hover:border-[var(--color-border-strong)]'}"
-            disabled=${disabled}
-            onClick=${() => onSelect(entry)}
-            aria-pressed=${active}
-          >
-            <div class="flex items-center justify-between gap-2">
-              <span class="truncate font-mono text-xs font-semibold text-[var(--color-fg-primary)]">${entry.id}</span>
-              ${entry.isDefault ? html`<span class="shrink-0 rounded-[var(--r-1)] border border-[var(--accent-30)] px-1.5 py-0.5 text-3xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">default</span>` : null}
-            </div>
-            <div class="mt-1 truncate text-xs text-[var(--color-fg-secondary)]">${providerLabel}</div>
-            <div class="truncate text-2xs text-[var(--color-fg-muted)]">${modelLabel} · ${compactContext(entry.model?.maxContext)} · ${compactTransport(entry.provider)}</div>
-            <div class="mt-1 flex flex-wrap gap-1 text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">
-              <span>${boolToken('tools', entry.model?.toolsSupport)}</span>
-              <span>${boolToken('thinking', entry.model?.thinkingSupport)}</span>
-              <span>${boolToken('stream', entry.model?.streaming)}</span>
-              <span>concurrency:${entry.binding.maxConcurrent ?? '-'}</span>
-            </div>
-          </button>
-        `
-      })}
-    </div>
-  `
+// keeper.status -> StatusDot tone (bg). Mirrors copilot-dock's run/idle/bad
+// split; tone classes are the existing --color-status-* tokens.
+function keeperDotTone(status: string): string {
+  const normalized = status.toLowerCase()
+  if (normalized === 'run' || normalized === 'running' || normalized === 'active') {
+    return 'bg-[var(--color-status-ok)]'
+  }
+  if (normalized === 'pause' || normalized === 'paused' || normalized === 'idle') {
+    return 'bg-[var(--color-status-warn)]'
+  }
+  return 'bg-[var(--color-status-err)]'
 }
 
 export function RuntimeEnvironmentEditor({
   sourceText,
+  section,
   dirty,
   disabled,
   saving,
@@ -211,91 +138,103 @@ export function RuntimeEnvironmentEditor({
   onSave,
 }: RuntimeEnvironmentEditorProps) {
   const environment = useMemo(() => parseRuntimeTomlEnvironment(sourceText), [sourceText])
-  const [selectedRuntimeId, setSelectedRuntimeId] = useState('')
-  const [selectedProviderId, setSelectedProviderId] = useState('')
-  const [selectedModelId, setSelectedModelId] = useState('')
+  const [modelQuery, setModelQuery] = useState('')
 
-  useEffect(() => {
-    const nextRuntimeId = environment.bindings.some(binding => binding.id === selectedRuntimeId)
-      ? selectedRuntimeId
-      : environment.defaultRuntimeId || firstId(environment.bindings)
-    const runtime = environment.bindings.find(binding => binding.id === nextRuntimeId) ?? environment.bindings[0] ?? null
-    const nextProviderId = environment.providers.some(provider => provider.id === selectedProviderId)
-      ? selectedProviderId
-      : runtime?.providerId ?? firstId(environment.providers)
-    const nextModelId = environment.models.some(model => model.id === selectedModelId)
-      ? selectedModelId
-      : runtime?.modelId ?? firstId(environment.models)
-    if (nextRuntimeId !== selectedRuntimeId) setSelectedRuntimeId(nextRuntimeId)
-    if (nextProviderId !== selectedProviderId) setSelectedProviderId(nextProviderId)
-    if (nextModelId !== selectedModelId) setSelectedModelId(nextModelId)
-  }, [environment, selectedModelId, selectedProviderId, selectedRuntimeId])
-
-  const bindings = runtimeOptions(environment)
-  const selectedRuntime = selectedItem<RuntimeTomlBinding>(environment.bindings, selectedRuntimeId)
-  const selectedProvider = selectedItem<RuntimeTomlProvider>(environment.providers, selectedProviderId)
-  const selectedModel = selectedItem<RuntimeTomlModel>(environment.models, selectedModelId)
+  const runtimeIds = runtimeOptions(environment)
   const isDisabled = disabled === true || saving === true
-  const catalogEntries = runtimeCatalogEntries(environment)
 
-  function selectRuntimeEntry(entry: RuntimeCatalogEntry) {
-    setSelectedRuntimeId(entry.id)
-    setSelectedProviderId(entry.binding.providerId)
-    setSelectedModelId(entry.binding.modelId)
-  }
+  const librarianLane = readRuntimeLaneValue(sourceText, 'librarian')
+  const crossVerifierLane = readRuntimeLaneValue(sourceText, 'cross_verifier')
+  const assignments = readRuntimeAssignments(sourceText)
+  const keeperList = keepers.value
+
+  const filteredModels = environment.models.filter(model => {
+    if (modelQuery.trim() === '') return true
+    const query = modelQuery.toLowerCase()
+    return model.id.toLowerCase().includes(query) || model.apiName.toLowerCase().includes(query)
+  })
 
   function updateDefault(runtimeId: string) {
-    setSelectedRuntimeId(runtimeId)
-    const runtime = environment.bindings.find(binding => binding.id === runtimeId)
-    if (runtime) {
-      setSelectedProviderId(runtime.providerId)
-      setSelectedModelId(runtime.modelId)
-    }
     onDraftChange(setRuntimeTomlDefault(sourceText, runtimeId))
   }
 
-  function updateProvider(field: 'display-name' | 'protocol' | 'endpoint' | 'command', value: string) {
-    if (!selectedProvider) return
-    onDraftChange(setRuntimeTomlProviderField(sourceText, selectedProvider.id, field, value))
+  function updateRoutingLane(lane: 'librarian' | 'cross_verifier', runtimeId: string) {
+    onDraftChange(setRuntimeTomlKey(sourceText, 'runtime', lane, runtimeId))
   }
 
-  function updateProviderTransport(kind: RuntimeTomlTransportKind) {
-    if (!selectedProvider || kind === 'missing') return
-    const value = kind === 'command'
-      ? selectedProvider.command || selectedProvider.endpoint
-      : selectedProvider.endpoint || selectedProvider.command
-    onDraftChange(setRuntimeTomlProviderField(sourceText, selectedProvider.id, kind, value))
+  function updateProvider(providerId: string, field: 'endpoint', value: string) {
+    onDraftChange(setRuntimeTomlProviderField(sourceText, providerId, field, value))
   }
 
-  function updateCredential(type: RuntimeTomlCredentialType, value: string) {
-    if (!selectedProvider) return
-    onDraftChange(setRuntimeTomlProviderCredential(sourceText, selectedProvider.id, type, value))
+  function updateCredential(providerId: string, type: RuntimeTomlCredentialType, value: string) {
+    onDraftChange(setRuntimeTomlProviderCredential(sourceText, providerId, type, value))
   }
 
-  function updateModel(
-    field: 'api-name' | 'max-context' | 'tools-support' | 'thinking-support' | 'streaming',
-    value: string | number | boolean,
-  ) {
-    if (!selectedModel) return
-    onDraftChange(setRuntimeTomlModelField(sourceText, selectedModel.id, field, value))
+  function setDefaultBinding(binding: RuntimeTomlBinding) {
+    onDraftChange(setRuntimeTomlDefault(sourceText, binding.id))
   }
 
   function updateBinding(
-    field: 'is-default' | 'max-concurrent' | 'keep-alive' | 'num-ctx',
-    value: string | number | boolean | null,
+    runtimeId: string,
+    field: 'max-concurrent' | 'num-ctx',
+    value: number | null,
   ) {
-    if (!selectedRuntime) return
-    onDraftChange(setRuntimeTomlBindingField(sourceText, selectedRuntime.id, field, value))
+    onDraftChange(setRuntimeTomlBindingField(sourceText, runtimeId, field, value))
+  }
+
+  function updateAssignment(keeperName: string, runtimeId: string) {
+    if (runtimeId === environment.defaultRuntimeId) {
+      // default == fallback; drop the explicit pin so toml stays minimal.
+      onDraftChange(deleteRuntimeTomlKey(sourceText, 'runtime.assignments', keeperName))
+      return
+    }
+    onDraftChange(setRuntimeTomlKey(sourceText, 'runtime.assignments', keeperName, runtimeId))
+  }
+
+  // rt-select — runtime.css:43. Inline width cap so the 248px min-width never
+  // crushes the flex sibling label in the narrow Settings embed (the prototype
+  // ran full-screen). flex-wrap on the row lets the control drop below the
+  // label instead of squeezing it to one-word-per-line.
+  const selectStyle = { minWidth: 0, maxWidth: '248px', flex: '1 1 200px' }
+  const laneStyle = { flexWrap: 'wrap' as const }
+
+  function laneRow(
+    lane: 'default' | 'librarian' | 'cross_verifier',
+    label: string,
+    hint: string,
+    value: string,
+    onChange: (runtimeId: string) => void,
+    needsJson: boolean,
+  ) {
+    return html`
+      <div class="rt-lane" style=${laneStyle}>
+        <div class="rt-lane-l">
+          <div class="rt-lane-lbl">${label}</div>
+          <div class="rt-lane-hint">${hint}</div>
+        </div>
+        <div class="rt-lane-c">
+          <select
+            class="rt-select mono"
+            style=${selectStyle}
+            value=${value}
+            disabled=${isDisabled}
+            aria-label=${lane === 'default' ? 'default runtime' : `${lane} runtime`}
+            onChange=${(event: Event) => onChange((event.currentTarget as HTMLSelectElement).value)}
+          >
+            ${runtimeIds.map(id => html`<option value=${id}>${id}</option>`)}
+          </select>
+          ${needsJson
+            ? html`<span class="rt-ok" data-stub="no-per-model-json-cap">JSON 모드 필요 · 모델 capability 미수집</span>`
+            : null}
+        </div>
+      </div>
+    `
   }
 
   return html`
-    <div class="v2-monitoring-detail border-t border-[var(--color-border-divider)] pt-3" data-testid="runtime-environment-editor">
-      <div class="mb-3 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
-        <div class="min-w-0">
-          <div class="text-2xs font-bold uppercase tracking-[var(--track-caps)] text-[var(--color-accent-fg)]">
-            런타임 환경
-          </div>
-        </div>
+    <div data-testid="runtime-environment-editor">
+      <div class="rt-head-actions" style=${{ justifyContent: 'flex-end', marginBottom: '14px' }}>
+        <span class="rt-nav-sub mono" style=${{ marginRight: 'auto' }}>런타임 환경</span>
         <${ActionButton}
           variant="primary"
           size="sm"
@@ -313,262 +252,239 @@ export function RuntimeEnvironmentEditor({
       </div>
 
       ${environment.warnings.length > 0 ? html`
-        <div class="mb-3 rounded-[var(--r-1)] border border-[var(--color-status-warn)]/35 bg-[var(--warn-10)] px-3 py-2 text-xs text-[var(--color-status-warn)]">
+        <div class="rt-note" data-testid="runtime-environment-warnings">
           ${environment.warnings.join(' · ')}
         </div>
       ` : null}
 
-      ${bindings.length === 0 ? html`
-        <div class="v2-monitoring-panel rounded-[var(--r-1)] border border-[var(--color-border-default)] px-3 py-4 text-xs text-[var(--color-fg-muted)]">
-          구조화해서 편집할 provider.model binding이 없습니다. 아래 raw editor에서 runtime.toml을 먼저 추가하세요.
+      ${runtimeIds.length === 0 ? html`
+        <div class="rt-note" data-testid="runtime-environment-empty">
+          구조화해서 편집할 provider.model binding이 없습니다. runtime.toml 섹션에서 먼저 추가하세요.
         </div>
-      ` : html`
-        <div class="mb-3 grid gap-2">
-          <${SectionTitle}>런타임 카탈로그<//>
-          <${RuntimeCatalogStrip}
-            entries=${catalogEntries}
-            selectedRuntimeId=${selectedRuntime?.id ?? ''}
-            disabled=${isDisabled}
-            onSelect=${selectRuntimeEntry}
-          />
-        </div>
-        <div class="grid gap-3 xl:grid-cols-[minmax(16rem,0.8fr)_minmax(0,1.1fr)_minmax(0,1.1fr)_minmax(0,1fr)]">
-          <div class="grid content-start gap-3 border-b border-[var(--color-border-divider)] pb-3 xl:border-b-0 xl:border-r xl:pb-0 xl:pr-3">
-            <${SectionTitle}>기본 런타임<//>
-            <${FieldShell} label="default runtime" hint="runtime.toml [runtime].default">
-              <select
-                class=${FIELD_CLASS}
-                value=${environment.defaultRuntimeId || selectedRuntimeId}
-                disabled=${isDisabled}
-                aria-label="default runtime"
-                onChange=${(event: Event) => updateDefault((event.currentTarget as HTMLSelectElement).value)}
-              >
-                ${bindings.map(id => html`<option value=${id}>${id}</option>`)}
-              </select>
-            <//>
-            <${FieldShell} label="binding" hint="편집할 provider.model">
-              <select
-                class=${FIELD_CLASS}
-                value=${selectedRuntime?.id ?? ''}
-                disabled=${isDisabled}
-                aria-label="runtime binding"
-                onChange=${(event: Event) => {
-                  const runtimeId = (event.currentTarget as HTMLSelectElement).value
-                  setSelectedRuntimeId(runtimeId)
-                  const runtime = environment.bindings.find(binding => binding.id === runtimeId)
-                  if (runtime) {
-                    setSelectedProviderId(runtime.providerId)
-                    setSelectedModelId(runtime.modelId)
-                  }
-                }}
-              >
-                ${bindings.map(id => html`<option value=${id}>${id}</option>`)}
-              </select>
-            <//>
-          </div>
+      ` : null}
 
-          <div class="grid content-start gap-3 border-b border-[var(--color-border-divider)] pb-3 xl:border-b-0 xl:border-r xl:pb-0 xl:pr-3">
-            <${SectionTitle}>Provider 연결<//>
-            <${FieldShell} label="provider">
-              <select
-                class=${FIELD_CLASS}
-                value=${selectedProvider?.id ?? ''}
-                disabled=${isDisabled}
-                aria-label="provider"
-                onChange=${(event: Event) => setSelectedProviderId((event.currentTarget as HTMLSelectElement).value)}
-              >
-                ${environment.providers.map(provider => html`<option value=${provider.id}>${provider.id}</option>`)}
-              </select>
-            <//>
-            <${FieldShell} label="display-name">
-              <input
-                class=${FIELD_CLASS}
-                value=${selectedProvider?.displayName ?? ''}
-                disabled=${isDisabled || !selectedProvider}
-                aria-label="provider display-name"
-                onInput=${(event: Event) => updateProvider('display-name', (event.currentTarget as HTMLInputElement).value)}
-              />
-            <//>
-            <${FieldShell} label="protocol">
-              <input
-                class=${FIELD_CLASS}
-                value=${selectedProvider?.protocol ?? ''}
-                disabled=${isDisabled || !selectedProvider}
-                aria-label="provider protocol"
-                onInput=${(event: Event) => updateProvider('protocol', (event.currentTarget as HTMLInputElement).value)}
-              />
-            <//>
-            <div class="grid grid-cols-[8rem_minmax(0,1fr)] gap-2">
-              <${FieldShell} label="transport">
-                <select
-                  class=${FIELD_CLASS}
-                  value=${selectedProvider?.transportKind === 'command' ? 'command' : 'endpoint'}
-                  disabled=${isDisabled || !selectedProvider}
-                  aria-label="provider transport"
-                  onChange=${(event: Event) => updateProviderTransport((event.currentTarget as HTMLSelectElement).value as RuntimeTomlTransportKind)}
-                >
-                  <option value="endpoint">endpoint</option>
-                  <option value="command">command</option>
-                </select>
-              <//>
-              <${FieldShell} label=${selectedProvider?.transportKind === 'command' ? 'command' : 'endpoint'}>
+      <!-- routing — runtime-editor.jsx:135-141. default lane is live; librarian /
+           cross_verifier are read from [runtime] and written back. -->
+      <div class=${section === 'routing' ? '' : 'hidden'} data-testid="runtime-section-routing">
+        <div class="rt-note">
+          런타임 id = <span class="mono">provider.model</span> (binding key). 레인은 등록된 바인딩 중에서 고릅니다.
+        </div>
+        ${laneRow(
+          'default',
+          '기본 런타임',
+          '[runtime].default — 배정 없는 keeper가 사용',
+          environment.defaultRuntimeId || firstId(environment.bindings),
+          updateDefault,
+          false,
+        )}
+        ${laneRow(
+          'librarian',
+          'memory-os 라이브러리안',
+          '[runtime].librarian — 턴 후 에피소드 추출, JSON 모드 필요',
+          librarianLane,
+          runtimeId => updateRoutingLane('librarian', runtimeId),
+          true,
+        )}
+        ${laneRow(
+          'cross_verifier',
+          'cross-verifier',
+          '[runtime].cross_verifier — 반-합리화 평가, JSON 모드 필요',
+          crossVerifierLane,
+          runtimeId => updateRoutingLane('cross_verifier', runtimeId),
+          true,
+        )}
+      </div>
+
+      <!-- providers — runtime-editor.jsx:144-165. endpoint + credential editable;
+           protocol shown read-only. provider capability chips
+           (mcp-tools/tool-events/mcp-http-headers) have no live source. -->
+      <div class=${section === 'providers' ? '' : 'hidden'} data-testid="runtime-section-providers">
+        <div class="rt-cards">
+          ${environment.providers.map(provider => html`
+            <div key=${provider.id} class="rt-card">
+              <div class="rt-card-h">
+                <span class="rt-card-id mono">${provider.id}</span>
+                <span class="rt-card-name">${provider.displayName}</span>
+                <span class="rt-proto mono">${provider.protocol || '—'}</span>
+              </div>
+              <div class="rt-field">
+                <span class="sub-k">endpoint</span>
                 <input
-                  class=${FIELD_CLASS}
-                  value=${selectedProvider ? transportValue(selectedProvider) : ''}
-                  disabled=${isDisabled || !selectedProvider}
+                  class="rt-input mono"
+                  value=${transportValue(provider)}
+                  disabled=${isDisabled}
                   aria-label="provider transport value"
-                  onInput=${(event: Event) => {
-                    const kind = selectedProvider?.transportKind === 'command' ? 'command' : 'endpoint'
-                    updateProvider(kind, (event.currentTarget as HTMLInputElement).value)
-                  }}
+                  onInput=${(event: Event) => updateProvider(provider.id, 'endpoint', (event.currentTarget as HTMLInputElement).value)}
                 />
-              <//>
+              </div>
+              <div class="rt-field">
+                <span class="sub-k">credential</span>
+                ${provider.credentialType === 'none'
+                  ? html`<span class="rt-cred-none mono">없음 (로컬)</span>`
+                  : html`
+                    <span class="rt-cred">
+                      <span class="rt-cred-type mono">${provider.credentialType}</span>
+                      <input
+                        class="rt-input mono"
+                        type=${provider.credentialType === 'inline' ? 'password' : 'text'}
+                        value=${credentialValue(provider)}
+                        disabled=${isDisabled}
+                        aria-label="provider credential value"
+                        onInput=${(event: Event) => updateCredential(provider.id, provider.credentialType, (event.currentTarget as HTMLInputElement).value)}
+                      />
+                    </span>
+                  `}
+              </div>
+              <div class="rt-caps" data-stub="no-provider-capability-source">
+                <span class="rt-cap">· mcp-tools</span>
+                <span class="rt-cap">· tool-events</span>
+                <span class="rt-cap">· mcp-http-headers</span>
+              </div>
             </div>
-            <div class="grid grid-cols-[8rem_minmax(0,1fr)] gap-2">
-              <${FieldShell} label="credential">
-                <select
-                  class=${FIELD_CLASS}
-                  value=${selectedProvider?.credentialType ?? 'none'}
-                  disabled=${isDisabled || !selectedProvider}
-                  aria-label="provider credential type"
-                  onChange=${(event: Event) => {
-                    const type = (event.currentTarget as HTMLSelectElement).value as RuntimeTomlCredentialType
-                    updateCredential(type, credentialValue(selectedProvider as RuntimeTomlProvider))
-                  }}
-                >
-                  <option value="none">none</option>
-                  <option value="env">env</option>
-                  <option value="file">file</option>
-                  <option value="inline">inline</option>
-                </select>
-              <//>
-              <${FieldShell} label=${credentialLabel(selectedProvider?.credentialType ?? 'none')}>
-                <input
-                  class=${FIELD_CLASS}
-                  type=${selectedProvider?.credentialType === 'inline' ? 'password' : 'text'}
-                  value=${selectedProvider ? credentialValue(selectedProvider) : ''}
-                  disabled=${isDisabled || !selectedProvider || selectedProvider.credentialType === 'none'}
-                  aria-label="provider credential value"
-                  onInput=${(event: Event) => {
-                    const type = selectedProvider?.credentialType ?? 'none'
-                    updateCredential(type, (event.currentTarget as HTMLInputElement).value)
-                  }}
-                />
-              <//>
-            </div>
-          </div>
-
-          <div class="grid content-start gap-3 border-b border-[var(--color-border-divider)] pb-3 xl:border-b-0 xl:border-r xl:pb-0 xl:pr-3">
-            <${SectionTitle}>Model<//>
-            <${FieldShell} label="model">
-              <select
-                class=${FIELD_CLASS}
-                value=${selectedModel?.id ?? ''}
-                disabled=${isDisabled}
-                aria-label="model"
-                onChange=${(event: Event) => setSelectedModelId((event.currentTarget as HTMLSelectElement).value)}
-              >
-                ${environment.models.map(model => html`<option value=${model.id}>${model.id}</option>`)}
-              </select>
-            <//>
-            <${FieldShell} label="api-name">
-              <input
-                class=${FIELD_CLASS}
-                value=${selectedModel?.apiName ?? ''}
-                disabled=${isDisabled || !selectedModel}
-                aria-label="model api-name"
-                onInput=${(event: Event) => updateModel('api-name', (event.currentTarget as HTMLInputElement).value)}
-              />
-            <//>
-            <${FieldShell} label="max-context">
-              <input
-                class=${FIELD_CLASS}
-                type="number"
-                min="1"
-                step="1024"
-                value=${numberValue(selectedModel?.maxContext ?? null)}
-                disabled=${isDisabled || !selectedModel}
-                aria-label="model max-context"
-                onInput=${(event: Event) => {
-                  const parsed = parsePositiveInt((event.currentTarget as HTMLInputElement).value)
-                  if (parsed !== null) updateModel('max-context', parsed)
-                }}
-              />
-            <//>
-            <${ToggleField}
-              label="tools-support"
-              checked=${selectedModel?.toolsSupport ?? false}
-              disabled=${isDisabled || !selectedModel}
-              onChange=${(checked: boolean) => updateModel('tools-support', checked)}
-            />
-            <${ToggleField}
-              label="thinking-support"
-              checked=${selectedModel?.thinkingSupport ?? false}
-              disabled=${isDisabled || !selectedModel}
-              onChange=${(checked: boolean) => updateModel('thinking-support', checked)}
-            />
-            <${ToggleField}
-              label="streaming"
-              checked=${selectedModel?.streaming ?? false}
-              disabled=${isDisabled || !selectedModel}
-              onChange=${(checked: boolean) => updateModel('streaming', checked)}
-            />
-          </div>
-
-          <div class="grid content-start gap-3">
-            <${SectionTitle}>Binding<//>
-            <${ToggleField}
-              label="is-default"
-              checked=${selectedRuntime?.isDefault ?? false}
-              disabled=${isDisabled || !selectedRuntime}
-              onChange=${(checked: boolean) => updateBinding('is-default', checked)}
-            />
-            <${FieldShell} label="max-concurrent">
-              <input
-                class=${FIELD_CLASS}
-                type="number"
-                min="1"
-                step="1"
-                value=${numberValue(selectedRuntime?.maxConcurrent ?? null)}
-                disabled=${isDisabled || !selectedRuntime}
-                aria-label="binding max-concurrent"
-                onInput=${(event: Event) => {
-                  const parsed = parsePositiveInt((event.currentTarget as HTMLInputElement).value)
-                  if (parsed !== null) updateBinding('max-concurrent', parsed)
-                }}
-              />
-            <//>
-            <${FieldShell} label="keep-alive">
-              <input
-                class=${FIELD_CLASS}
-                value=${selectedRuntime?.keepAlive ?? ''}
-                disabled=${isDisabled || !selectedRuntime}
-                placeholder="예: 10m"
-                aria-label="binding keep-alive"
-                onInput=${(event: Event) => {
-                  const value = (event.currentTarget as HTMLInputElement).value
-                  updateBinding('keep-alive', value.trim() === '' ? null : value)
-                }}
-              />
-            <//>
-            <${FieldShell} label="num-ctx">
-              <input
-                class=${FIELD_CLASS}
-                type="number"
-                min="1"
-                step="1024"
-                value=${numberValue(selectedRuntime?.numCtx ?? null)}
-                disabled=${isDisabled || !selectedRuntime}
-                aria-label="binding num-ctx"
-                onInput=${(event: Event) => {
-                  const value = (event.currentTarget as HTMLInputElement).value
-                  updateBinding('num-ctx', value.trim() === '' ? null : parsePositiveInt(value))
-                }}
-              />
-            <//>
-          </div>
+          `)}
         </div>
-      `}
+      </div>
+
+      <!-- models — runtime-editor.jsx:167-191. search + read-only chips. Live
+           model parse exposes tools/thinking/streaming/maxContext only; the
+           prototype's json/structured/multimodal/tool-choice/effort chips have
+           no live source. -->
+      <div class=${section === 'models' ? '' : 'hidden'} data-testid="runtime-section-models">
+        <input
+          class="rt-search mono"
+          placeholder="모델 검색 — id / api-name"
+          value=${modelQuery}
+          disabled=${isDisabled}
+          aria-label="모델 검색"
+          onInput=${(event: Event) => setModelQuery((event.currentTarget as HTMLInputElement).value)}
+        />
+        <div class="rt-models">
+          ${filteredModels.map(model => html`
+            <div key=${model.id} class="rt-model">
+              <div class="rt-model-h">
+                <span class="rt-model-id mono">${model.id}</span>
+                <span class="rt-model-api mono">${model.apiName}</span>
+                <span class="rt-model-ctx mono">${protoContext(model.maxContext)}</span>
+              </div>
+              <div class="rt-caps">
+                ${capChip(model.toolsSupport, 'tools')}
+                ${capChip(model.thinkingSupport, 'thinking')}
+                ${capChip(model.streaming, 'streaming')}
+                <span class="rt-cap" data-stub="no-json-cap">· json</span>
+                <span class="rt-cap" data-stub="no-structured-cap">· structured</span>
+                <span class="rt-cap" data-stub="no-multimodal-cap">· multimodal</span>
+                <span class="rt-cap tcf mono" data-stub="no-effort-source">effort: 미수집</span>
+              </div>
+            </div>
+          `)}
+          ${filteredModels.length === 0 ? html`
+            <div class="rt-note" data-testid="runtime-models-empty">일치하는 모델이 없습니다.</div>
+          ` : null}
+        </div>
+      </div>
+
+      <!-- bindings — runtime-editor.jsx:193-214. radio sets the default runtime;
+           max-conc / num-ctx editable. price / effort sub-line has no live
+           source. -->
+      <div class=${section === 'bindings' ? '' : 'hidden'} data-testid="runtime-section-bindings">
+        <div class="rt-binds">
+          <div class="rt-note">
+            바인딩 = 런타임 id <span class="mono">provider.model</span>. 라디오로 기본 런타임 지정.
+          </div>
+          ${environment.bindings.map(binding => {
+            const isDefault = binding.id === environment.defaultRuntimeId || binding.isDefault
+            const model = environment.models.find(m => m.id === binding.modelId) ?? null
+            return html`
+              <div key=${binding.id} class="rt-bind ${isDefault ? 'is-default' : ''}">
+                <button
+                  type="button"
+                  class="rt-radio ${isDefault ? 'on' : ''}"
+                  disabled=${isDisabled}
+                  title="기본 런타임으로"
+                  aria-label=${`${binding.id} 기본 런타임으로`}
+                  aria-pressed=${isDefault}
+                  onClick=${() => setDefaultBinding(binding)}
+                >${isDefault ? '◉' : '○'}</button>
+                <div class="rt-bind-main">
+                  <div class="rt-bind-key mono">
+                    ${binding.id}${isDefault ? html`<span class="rt-default-tag">default</span>` : null}
+                  </div>
+                  <div class="rt-bind-sub mono" data-stub="no-price-or-effort-source">
+                    ${protoContext(model?.maxContext ?? null)} · 가격/effort 미수집
+                  </div>
+                </div>
+                <div class="rt-bind-fields">
+                  <label class="rt-mini">
+                    <span>max-conc</span>
+                    <input
+                      class="rt-input-sm mono"
+                      value=${binding.maxConcurrent == null ? '' : String(binding.maxConcurrent)}
+                      placeholder="∞"
+                      disabled=${isDisabled}
+                      aria-label=${`${binding.id} max-concurrent`}
+                      onInput=${(event: Event) => {
+                        const raw = (event.currentTarget as HTMLInputElement).value
+                        updateBinding(binding.id, 'max-concurrent', raw.trim() === '' ? null : parsePositiveInt(raw))
+                      }}
+                    />
+                  </label>
+                  <label class="rt-mini">
+                    <span>num-ctx</span>
+                    <input
+                      class="rt-input-sm mono"
+                      value=${binding.numCtx == null ? '' : String(binding.numCtx)}
+                      placeholder="—"
+                      disabled=${isDisabled}
+                      aria-label=${`${binding.id} num-ctx`}
+                      onInput=${(event: Event) => {
+                        const raw = (event.currentTarget as HTMLInputElement).value
+                        updateBinding(binding.id, 'num-ctx', raw.trim() === '' ? null : parsePositiveInt(raw))
+                      }}
+                    />
+                  </label>
+                </div>
+              </div>
+            `
+          })}
+        </div>
+      </div>
+
+      <!-- assignments — runtime-editor.jsx:216-231. keeper -> runtime id from
+           the live keepers signal + [runtime.assignments]. -->
+      <div class=${section === 'assignments' ? '' : 'hidden'} data-testid="runtime-section-assignments">
+        <div class="rt-assigns">
+          <div class="rt-note">
+            [runtime.assignments] — keeper → 런타임 id. <span class="mono">default</span>와 같으면 toml에서 생략(폴백).
+          </div>
+          ${keeperList.length === 0 ? html`
+            <div class="rt-note" data-testid="runtime-assignments-empty">표시할 keeper가 없습니다.</div>
+          ` : keeperList.map(keeper => {
+            const current = assignments[keeper.name] ?? environment.defaultRuntimeId
+            const isDefault = current === environment.defaultRuntimeId
+            return html`
+              <div key=${keeper.name} class="rt-assign">
+                <span class="rt-assign-k">
+                  <${StatusDot} size="sm" class=${keeperDotTone(keeper.status)} />
+                  <span class="mono">${keeper.name}</span>
+                </span>
+                <select
+                  class="rt-select mono"
+                  style=${selectStyle}
+                  value=${current}
+                  disabled=${isDisabled}
+                  aria-label=${`${keeper.name} 런타임 배정`}
+                  onChange=${(event: Event) => updateAssignment(keeper.name, (event.currentTarget as HTMLSelectElement).value)}
+                >
+                  ${runtimeIds.map(id => html`<option value=${id}>${id}</option>`)}
+                </select>
+                ${isDefault
+                  ? html`<span class="rt-assign-tag mono">↳ default 폴백</span>`
+                  : html`<span class="rt-assign-tag pin mono">고정</span>`}
+              </div>
+            `
+          })}
+        </div>
+      </div>
     </div>
   `
 }

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -335,11 +335,10 @@ export function RuntimeEnvironmentEditor({
                     </span>
                   `}
               </div>
-              <div class="rt-caps" data-stub="no-provider-capability-source">
-                <span class="rt-cap">· mcp-tools</span>
-                <span class="rt-cap">· tool-events</span>
-                <span class="rt-cap">· mcp-http-headers</span>
-              </div>
+              ${/* Provider capability chips (mcp-tools/tool-events/mcp-http-headers)
+                   had no live source and rendered as if confirmed. Removed until a
+                   provider-capability source exists, rather than implying support
+                   with no backing (PR #22081 review P1: no stub). */ ''}
             </div>
           `)}
         </div>
@@ -370,9 +369,11 @@ export function RuntimeEnvironmentEditor({
                 ${capChip(model.toolsSupport, 'tools')}
                 ${capChip(model.thinkingSupport, 'thinking')}
                 ${capChip(model.streaming, 'streaming')}
-                <span class="rt-cap" data-stub="no-json-cap">· json</span>
-                <span class="rt-cap" data-stub="no-structured-cap">· structured</span>
-                <span class="rt-cap" data-stub="no-multimodal-cap">· multimodal</span>
+                ${/* json/structured/multimodal chips had no live source yet rendered
+                     styled identically to the real tools/thinking/streaming capChips,
+                     implying support. Removed until a model-capability source exists
+                     (PR #22081 review P1: no stub). effort stays — it states "미수집"
+                     honestly rather than faking a value. */ ''}
                 <span class="rt-cap tcf mono" data-stub="no-effort-source">effort: 미수집</span>
               </div>
             </div>

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -168,9 +168,13 @@ describe('RuntimeTomlEditor', () => {
 
     await waitFor(() => {
       expect(container.textContent).toContain('런타임 환경')
-      expect(container.textContent).toContain('런타임 카탈로그')
-      expect(container.textContent).toContain('128K ctx')
-      expect(container.textContent).toContain('tools:on')
+      // The prototype models section renders each model read-only: id + context
+      // (protoContext → "128k ctx") + capability chips. It replaced the legacy
+      // editable catalog grid; context length is now edited per-runtime via the
+      // binding num-ctx control (asserted below), not by mutating the model fact.
+      const modelsSection = container.querySelector('[data-testid="runtime-section-models"]')
+      expect(modelsSection?.textContent).toContain('qwen')
+      expect(modelsSection?.textContent).toContain('128k ctx')
       expect((container.querySelector('[aria-label="provider transport value"]') as HTMLInputElement | null)?.value)
         .toBe('https://runpod.example/v1')
     })
@@ -181,7 +185,7 @@ describe('RuntimeTomlEditor', () => {
     await waitFor(() => {
       expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toContain('endpoint = "https://runpod.example/v2"')
     })
-    fireEvent.input(container.querySelector('[aria-label="model max-context"]') as HTMLInputElement, {
+    fireEvent.input(container.querySelector('[aria-label="runpod_mtp.qwen num-ctx"]') as HTMLInputElement, {
       target: { value: '262144' },
     })
     fireEvent.click(container.querySelector('[data-testid="runtime-environment-save"]') as HTMLButtonElement)
@@ -191,7 +195,7 @@ describe('RuntimeTomlEditor', () => {
     })
     const savedSource = apiMocks.saveRuntimeTomlConfig.mock.calls[0]?.[0] as string
     expect(savedSource).toContain('endpoint = "https://runpod.example/v2"')
-    expect(savedSource).toContain('max-context = 262144')
+    expect(savedSource).toContain('num-ctx = 262144')
     expect(savedSource).toContain('[providers.openai]')
   })
 

--- a/dashboard/src/components/runtime-toml-editor.ts
+++ b/dashboard/src/components/runtime-toml-editor.ts
@@ -17,7 +17,7 @@ import { SectionCard } from './common/card'
 import { copyToClipboard } from './common/copyable-code'
 import { ErrorState, LoadingState } from './common/feedback-state'
 import { ringFocusClasses } from './common/ring'
-import { RuntimeEnvironmentEditor } from './runtime-environment-editor'
+import { RuntimeEnvironmentEditor, type RuntimeStructuredSection } from './runtime-environment-editor'
 
 type LoadState = 'idle' | 'loading' | 'loaded'
 
@@ -232,6 +232,16 @@ export function RuntimeTomlEditor() {
     }
   }
 
+  async function handleCopySource() {
+    const ok = await copyToClipboard(draft)
+    if (ok) {
+      setNotice('runtime.toml 복사됨')
+      setError(null)
+    } else {
+      setError('runtime.toml 복사 실패')
+    }
+  }
+
   function handleEditorScroll(event: Event) {
     const gutter = lineGutterRef.current
     if (!gutter) return
@@ -286,6 +296,9 @@ export function RuntimeTomlEditor() {
   // is toggled via the nav, so the editor wiring is never torn down on switch.
   const structuredActive = section !== 'toml'
   const tomlActive = section === 'toml'
+  // When the toml section is active, RuntimeEnvironmentEditor is hidden anyway;
+  // fall back to 'routing' so its `section` prop stays a valid structured id.
+  const structuredSection: RuntimeStructuredSection = section === 'toml' ? 'routing' : section
 
   const toolbar = html`
     <div class="v2-monitoring-toolbar sticky top-0 z-10 -mx-1 bg-[var(--color-bg-surface)]/95 px-1 py-2 backdrop-blur">
@@ -436,6 +449,7 @@ export function RuntimeTomlEditor() {
                 <div class=${structuredActive ? '' : 'hidden'} data-testid="runtime-toml-structured">
                   <${RuntimeEnvironmentEditor}
                     sourceText=${draft}
+                    section=${structuredSection}
                     dirty=${dirty}
                     disabled=${loadState !== 'loaded'}
                     saving=${saving}
@@ -449,36 +463,55 @@ export function RuntimeTomlEditor() {
                   />
                 </div>
 
-                <!-- toml section — read-only raw view with the working textarea +
-                     toolbar (runtime-editor.jsx:233-242). -->
+                <!-- toml section — prototype .rt-toml-wrap chrome
+                     (runtime-editor.jsx:233-242) around the working editable
+                     code-frame. The prototype preview is read-only; the live
+                     editor stays editable (intentional divergence — the toml
+                     section is the raw escape hatch), so the .rt-toml-bar note
+                     reads "직접 편집 가능" instead of "읽기 전용". The inner
+                     v2-monitoring-code-frame + line gutter + textarea are kept
+                     verbatim (data-testids the tests rely on). -->
                 <div class=${tomlActive ? 'flex flex-col gap-3' : 'hidden'} data-testid="runtime-toml-section">
                   ${toolbar}
-                  <div
-                    class="v2-monitoring-code-frame grid min-h-[32rem] max-h-[72vh] grid-cols-[3.5rem_minmax(0,1fr)] overflow-hidden rounded-[var(--r-1)] border border-[var(--input-border)] bg-[var(--input-bg)]"
-                    data-testid="runtime-toml-code-frame"
-                  >
-                    <pre
-                      ref=${lineGutterRef}
-                      class="select-none overflow-hidden border-r border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-3 text-right font-mono text-xs leading-relaxed text-[var(--color-fg-disabled)]"
-                      aria-hidden="true"
-                      data-testid="runtime-toml-line-numbers"
-                    >${lineNumbers}</pre>
-                    <textarea
-                      ref=${textareaRef}
-                      class="min-h-[32rem] w-full resize-y overflow-auto border-0 bg-transparent px-3 py-3 font-mono text-xs leading-relaxed text-[var(--color-fg-primary)] outline-none ${editorFocusClasses}"
-                      aria-label="runtime.toml source"
-                      data-testid="runtime-toml-source"
-                      value=${draft}
-                      rows=${32}
-                      wrap="off"
-                      spellcheck=${false}
-                      autocapitalize="off"
-                      autocorrect="off"
-                      disabled=${saving}
-                      onInput=${handleEditorInput}
-                      onKeyDown=${handleEditorKeyDown}
-                      onScroll=${handleEditorScroll}
-                    ></textarea>
+                  <div class="rt-toml-wrap">
+                    <div class="rt-toml-bar">
+                      <span class="mono">${path}</span>
+                      <span class="rt-toml-ro">직접 편집 가능 · 저장 시 라이브 적용</span>
+                      <button
+                        type="button"
+                        class="rt-copy"
+                        onClick=${handleCopySource}
+                        title="runtime.toml 복사"
+                        data-testid="runtime-toml-copy-source"
+                      >복사</button>
+                    </div>
+                    <div
+                      class="v2-monitoring-code-frame grid min-h-[32rem] max-h-[72vh] grid-cols-[3.5rem_minmax(0,1fr)] overflow-hidden rounded-[var(--r-1)] border border-[var(--input-border)] bg-[var(--input-bg)]"
+                      data-testid="runtime-toml-code-frame"
+                    >
+                      <pre
+                        ref=${lineGutterRef}
+                        class="select-none overflow-hidden border-r border-[var(--color-border-default)] bg-[var(--color-bg-page)] px-2 py-3 text-right font-mono text-xs leading-relaxed text-[var(--color-fg-disabled)]"
+                        aria-hidden="true"
+                        data-testid="runtime-toml-line-numbers"
+                      >${lineNumbers}</pre>
+                      <textarea
+                        ref=${textareaRef}
+                        class="min-h-[32rem] w-full resize-y overflow-auto border-0 bg-transparent px-3 py-3 font-mono text-xs leading-relaxed text-[var(--color-fg-primary)] outline-none ${editorFocusClasses}"
+                        aria-label="runtime.toml source"
+                        data-testid="runtime-toml-source"
+                        value=${draft}
+                        rows=${32}
+                        wrap="off"
+                        spellcheck=${false}
+                        autocapitalize="off"
+                        autocorrect="off"
+                        disabled=${saving}
+                        onInput=${handleEditorInput}
+                        onKeyDown=${handleEditorKeyDown}
+                        onScroll=${handleEditorScroll}
+                      ></textarea>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/dashboard/src/components/schedule/schedule-surface.test.ts
+++ b/dashboard/src/components/schedule/schedule-surface.test.ts
@@ -127,17 +127,27 @@ describe('ScheduleSurface', () => {
     await flush()
 
     expect(mocks.loadTools).not.toHaveBeenCalled()
-    const summary = container.querySelector('[aria-label="Schedule summary"]')
-    expect(summary?.textContent).toContain('pending')
-    expect(summary?.textContent).toContain('due')
-    expect(summary?.textContent).toContain('scheduled')
-    expect(summary?.textContent).toContain('running')
-    expect(summary?.textContent).not.toContain('active')
-    expect(summary?.textContent).not.toContain('due effective')
-    expect(summary?.textContent).not.toContain('blocked approval')
-    expect(container.textContent).toContain('출처 schedule_runner_signals')
-    expect(container.textContent).toContain('masc_schedule_get')
-    expect(container.textContent).toContain('durable wake signal feed')
+    // v2 reskin: the KPI summary strip is now `.ov-kpis` (aria-label '예약 요약')
+    // with Korean labels; pending/scheduled stay distinct and due+running fold
+    // into the single 'due · 실행' KPI (counts unchanged).
+    const summary = container.querySelector('[aria-label="예약 요약"]')
+    expect(summary?.textContent).toContain('승인 대기')
+    expect(summary?.textContent).toContain('due · 실행')
+    expect(summary?.textContent).toContain('예약됨')
+    expect(summary?.textContent).toContain('총 예약')
+    // The folded summary still must not leak the diagnostics-only derived/FSM
+    // vocabulary (활성/유효 도래/승인 차단) as separate KPIs.
+    expect(summary?.textContent).not.toContain('활성')
+    expect(summary?.textContent).not.toContain('유효 도래')
+    expect(summary?.textContent).not.toContain('승인 차단')
+    // The wake-signal feed header is renamed in v2.
+    expect(container.textContent).toContain('wake signal 피드 · schedule_runner.tick')
+    // REMOVED: '출처 <signal_source>' feed attribution line is not rendered on
+    // the v2 surface (it is diagnostics-only); no equivalent element exists to
+    // retarget, so this coverage is dropped rather than weakened.
+    // REMOVED: keeper_next_tool ('masc_schedule_get') is not rendered anywhere
+    // on the v2 surface — neither the card nor the SchDetail overlay use
+    // KeeperActionCell — so this coverage is dropped (genuinely gone from v2).
     expect(container.querySelector('[data-schedule-id="sched-1"]')).not.toBeNull()
     expect(container.querySelectorAll('[data-schedule-mutation]')).toHaveLength(0)
   })
@@ -168,8 +178,11 @@ describe('ScheduleSurface', () => {
     render(html`<${ScheduleSurface} />`, container)
     await flush()
 
+    // v2 reskin: the pending KPI label is Korean ('승인 대기'). The sparse-count
+    // merge still resolves to 2 (counts.pending=1 vs 2 materialized pending-family
+    // requests → max), so the assertion intent is unchanged.
     const pendingKpi = Array.from(container.querySelectorAll('.ov-kpi'))
-      .find(element => element.textContent?.includes('pending'))
+      .find(element => element.textContent?.includes('승인 대기'))
     expect(pendingKpi?.textContent).toContain('2')
   })
 

--- a/dashboard/src/components/schedule/schedule-surface.ts
+++ b/dashboard/src/components/schedule/schedule-surface.ts
@@ -2,12 +2,12 @@
 //
 // The card/detail projection lives in tools/scheduled-automation-panel.ts and
 // is reused here so the route does not fork the backed schedule semantics.
+// Shell (header + KPI strip) ported to the keeper-v2 prototype (schedule.jsx):
+// `.ov.sch-surf` → `.ov-head` (eyebrow + title + sub) → `.ov-kpis` (4 KPIs).
 
 import { html } from 'htm/preact'
-import { RefreshCw } from 'lucide-preact'
 import { useEffect } from 'preact/hooks'
 import type { DashboardScheduledAutomation } from '../../api'
-import { formatDateTimeKo } from '../../lib/format-time'
 import { ErrorState, LoadingState } from '../common/feedback-state'
 import { ScheduledAutomationPanel, normalizedScheduleStatus } from '../tools/scheduled-automation-panel'
 import {
@@ -43,8 +43,8 @@ export function ScheduleSurface() {
   const pendingCount = countByStatus(automation, ['pending', 'pending_approval', 'awaiting_approval'])
   const scheduledCount = countByStatus(automation, ['scheduled'])
   const runningCount = countByStatus(automation, ['running'])
-  const generatedAt = automation?.generated_at ?? data?.generated_at ?? null
-  const signalCount = automation?.signal_count ?? automation?.signals?.length ?? 0
+  const dueRunning = dueEffective + runningCount
+  const totalCount = automation?.requests?.length ?? 0
 
   useEffect(() => {
     if (!toolsData.value && !toolsLoading.value) {
@@ -53,64 +53,40 @@ export function ScheduleSurface() {
   }, [])
 
   return html`
-    <main class="ov ss-surface bg-surface-page text-text-primary" data-testid="schedule-surface">
+    <main class="ov sch-surf" data-screen-label="예약" data-testid="schedule-surface">
       <div class="ov-scroll">
         <header class="ov-head">
-          <div>
-            <h1>예약 자동화</h1>
-            <p class="ov-sub">
-              keeper 예약 요청 · 승인 차단 · 실행 준비 · durable wake signal
-            </p>
-          </div>
-          <button
-            type="button"
-            class="v2-shell-action inline-flex min-h-10 items-center gap-2 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2 text-xs text-[var(--color-fg-secondary)] transition-colors hover:border-[var(--color-accent-fg)] hover:text-[var(--color-fg-primary)] disabled:cursor-not-allowed disabled:opacity-60"
-            onClick=${() => { void loadTools() }}
-            disabled=${loading}
-            aria-busy=${loading ? 'true' : 'false'}
-            data-testid="schedule-refresh"
-          >
-            <${RefreshCw} size=${14} aria-hidden="true" />
-            <span>${loading ? '새로고침 중' : '새로고침'}</span>
-          </button>
+          <div class="ov-eyebrow">Schedule</div>
+          <h1>예약 · 자동화 큐</h1>
+          <p class="ov-sub">
+            keeper가 예약한 미래 작업 · operator가 due 전 승인 · <span class="mono">lib/schedule</span>
+          </p>
         </header>
 
         ${error ? html`<${ErrorState} message=${error} class="mb-4" />` : null}
 
-        <section class="ov-kpis" style=${{ gridTemplateColumns: 'repeat(4, 1fr)' }} aria-label="Schedule summary">
+        <section class="ov-kpis" style=${{ gridTemplateColumns: 'repeat(4, 1fr)' }} aria-label="예약 요약">
           <div class="ov-kpi">
-            <div class="ov-kpi-k">pending</div>
+            <div class="ov-kpi-k">승인 대기</div>
             <div class=${`ov-kpi-v ${pendingCount > 0 ? 'warn' : 'ok'}`}>${countLabel(pendingCount)}</div>
           </div>
           <div class="ov-kpi">
-            <div class="ov-kpi-k">due</div>
-            <div class=${`ov-kpi-v ${dueEffective > 0 ? 'warn' : 'ok'}`}>${countLabel(dueEffective)}</div>
+            <div class="ov-kpi-k">예약됨</div>
+            <div class=${`ov-kpi-v ${scheduledCount > 0 ? 'info' : ''}`}>${countLabel(scheduledCount)}</div>
           </div>
           <div class="ov-kpi">
-            <div class="ov-kpi-k">scheduled</div>
-            <div class=${`ov-kpi-v ${scheduledCount > 0 ? 'volt' : ''}`}>${countLabel(scheduledCount)}</div>
+            <div class="ov-kpi-k">due · 실행</div>
+            <div class=${`ov-kpi-v ${dueRunning > 0 ? 'warn' : 'ok'}`}>${countLabel(dueRunning)}</div>
           </div>
           <div class="ov-kpi">
-            <div class="ov-kpi-k">running</div>
-            <div class=${`ov-kpi-v ${runningCount > 0 ? 'ok' : ''}`}>${countLabel(runningCount)}</div>
+            <div class="ov-kpi-k">총 예약</div>
+            <div class="ov-kpi-v volt">${countLabel(totalCount)}</div>
           </div>
         </section>
 
-        <div class="mb-3 flex flex-wrap gap-x-4 gap-y-1 text-3xs text-[var(--color-fg-muted)]">
-          <span>
-            출처 <span class="font-mono text-[var(--color-fg-secondary)]">${automation?.source ?? 'schedule_store'}</span>
-          </span>
-          <span>
-            signal 행 <span class="font-mono text-[var(--color-fg-secondary)]">${countLabel(signalCount)}</span>
-          </span>
-          <span>
-            생성 <span class="font-mono text-[var(--color-fg-secondary)]">${formatDateTimeKo(generatedAt)}</span>
-          </span>
-        </div>
-
         ${loading && !automation
           ? html`<${LoadingState}>예약 자동화 projection 불러오는 중...<//>`
-          : html`<${ScheduledAutomationPanel} automation=${automation} />`}
+          : html`<${ScheduledAutomationPanel} automation=${automation} variant="v2" />`}
       </div>
     </main>
   `

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -592,8 +592,9 @@ export function SettingsSurface() {
         <nav class="set-nav" aria-label="Settings categories">
           <div class="set-nav-h">
             <div class="eyebrow">Operator</div>
-            <div class="set-nav-title">Settings</div>
-            <div class="set-nav-sub mono">@operator · masc-mcp</div>
+            <!-- keeper-v2 settings.jsx:244-247 — nav header is eyebrow + KO title
+                 only; the prototype does not render a sub-line here. -->
+            <div class="set-nav-title">설정</div>
           </div>
           ${SET_GROUPS.map(([glabel, ids]) => html`
             <div key=${glabel} class="set-nav-group">
@@ -617,7 +618,8 @@ export function SettingsSurface() {
               })}
             </div>
           `)}
-          <div class="set-nav-note">Prototype controls are read-only previews; runtime.toml is live-backed.</div>
+          <!-- keeper-v2 settings.jsx:262 — KO nav-note copy. -->
+          <div class="set-nav-note">프로토타입 — 변경은 로컬에만 적용됩니다.</div>
         </nav>
 
         <div class="set-content">

--- a/dashboard/src/components/tools/scheduled-automation-panel.ts
+++ b/dashboard/src/components/tools/scheduled-automation-panel.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { useState } from 'preact/hooks'
+import { useEffect, useState } from 'preact/hooks'
 import {
   resolveScheduleApproval,
   type DashboardScheduleDecision,
@@ -13,6 +13,14 @@ import { formatDateTimeKo } from '../../lib/format-time'
 import { ActionButton } from '../common/button'
 import { StatusChip, type StatusChipTone } from '../common/status-chip'
 import { showToast } from '../common/toast'
+import { SigilBadge } from '../v2/primitives-v2'
+import { kSigil, kSlot } from '../keeper-badge'
+import {
+  schedPayloadSpec,
+  schedRiskSpec,
+  schedStatusSpec,
+  type SchedStatusSpec,
+} from '../v2/schedule-constants'
 
 type ScheduleFilterKey = 'all' | 'pending' | 'due' | 'ready' | 'scheduled' | 'terminal'
 
@@ -802,12 +810,455 @@ function DurableSignalItem({
   `
 }
 
-export function ScheduledAutomationPanel({
+/* ════════════════════════════════════════════════════════════════════════
+   keeper-v2 prototype surface (schedule.jsx). Emits the vendored `.sch-*` /
+   `.turn-*` DOM so styles/keeper-v2/schedule.css applies. Opt-in via
+   `variant="v2"`; the default `diagnostics` path above is the dense FSM view
+   reused by the Tools surface and must stay byte-stable.
+
+   Live data only — no fabricated operator/timestamps. Live fields absent in the
+   prototype model (relative due text "4h 12m 후", structured decision
+   provenance, payload `body`) are rendered from the real ISO timestamps /
+   marked data-stub rather than invented (audit P2 #11, #12). The live approval
+   API supports approve/reject only (no cancel), so the prototype's cancel
+   action is omitted here rather than wired to a no-op. */
+
+// Live status strings are lower_snake (pending_approval); the vendored
+// SCHED_STATUS map is keyed on Schedule_domain PascalCase. Total function:
+// unknown statuses fall back to schedStatusSpec's dim spec.
+const LIVE_STATUS_TO_SPEC_KEY: Readonly<Record<string, string>> = {
+  pending_approval: 'Pending_approval',
+  awaiting_approval: 'Pending_approval',
+  blocked_approval: 'Pending_approval',
+  scheduled: 'Scheduled',
+  due: 'Due',
+  due_pending_refresh: 'Due',
+  running: 'Running',
+  succeeded: 'Succeeded',
+  failed: 'Failed',
+  rejected: 'Rejected',
+  cancelled: 'Cancelled',
+  canceled: 'Cancelled',
+  expired: 'Expired',
+}
+
+// Live risk_class strings are lower_snake (workspace_write); SCHED_RISK is keyed
+// PascalCase. Same total-function fallback contract.
+const LIVE_RISK_TO_SPEC_KEY: Readonly<Record<string, string>> = {
+  reminder_only: 'Reminder_only',
+  read_only: 'Read_only',
+  workspace_write: 'Workspace_write',
+  external_write: 'External_write',
+  destructive: 'Destructive',
+  cost_bearing: 'Cost_bearing',
+}
+
+function statusSpecForLive(status: string | null | undefined): SchedStatusSpec {
+  const key = LIVE_STATUS_TO_SPEC_KEY[normalized(status)]
+  // Pass the resolved PascalCase key when known, else the raw value so the
+  // fallback renders the original string rather than a generic placeholder.
+  return schedStatusSpec(key ?? status ?? undefined)
+}
+
+function riskSpecForLive(risk: string | null | undefined): { lbl: string; cls: string } {
+  const key = LIVE_RISK_TO_SPEC_KEY[normalized(risk)]
+  return schedRiskSpec(key ?? risk ?? undefined)
+}
+
+// Card rail tone class. SCHED_STATUS specs only ever yield warn/info/ok/bad/dim
+// for statuses; .sch-card.st-volt is not defined, so clamp anything else to dim.
+const CARD_RAIL_TONES: ReadonlySet<string> = new Set(['ok', 'warn', 'bad', 'info', 'dim'])
+function cardRailTone(cls: string): string {
+  return CARD_RAIL_TONES.has(cls) ? cls : 'dim'
+}
+
+// Prototype filter tabs (audit P0 #3): 5 tabs, prototype labels/ordering.
+type SchTabKey = 'pending' | 'scheduled' | 'active' | 'done' | 'all'
+interface SchTabDef {
+  readonly key: SchTabKey
+  readonly label: string
+  // Effective-status values (live, normalized) this tab includes; null = all.
+  readonly statuses: readonly string[] | null
+}
+const SCH_TABS: readonly SchTabDef[] = [
+  { key: 'pending', label: '승인 대기', statuses: ['pending_approval', 'awaiting_approval', 'blocked_approval'] },
+  { key: 'scheduled', label: '예약됨', statuses: ['scheduled'] },
+  { key: 'active', label: 'due · 실행', statuses: ['due', 'due_pending_refresh', 'running'] },
+  { key: 'done', label: '완료 · 종료', statuses: ['succeeded', 'failed', 'rejected', 'cancelled', 'canceled', 'expired'] },
+  { key: 'all', label: '전체', statuses: null },
+]
+
+function schTabMatches(tab: SchTabDef, request: DashboardScheduledAutomationRequest): boolean {
+  if (tab.statuses === null) return true
+  return tab.statuses.includes(normalized(effectiveStatus(request)))
+}
+
+function recurrenceText(request: DashboardScheduledAutomationRequest): string {
+  return recurrenceLabel(request)
+}
+
+/** `.sch-pill` status chip with glyph (audit P0 #2). */
+function SchStatusPill({ status }: { status: string | null | undefined }) {
+  const spec = statusSpecForLive(status)
+  return html`<span class=${`sch-pill ${spec.cls}`}>${spec.glyph} ${spec.lbl}</span>`
+}
+
+/** `.sch-risk` chip (audit P0 #1 head row). */
+function SchRiskChip({ risk }: { risk: string | null | undefined }) {
+  const spec = riskSpecForLive(risk)
+  return html`<span class=${`sch-risk ${spec.cls}`} title=${`risk_class = ${risk ?? '-'}`}>${spec.lbl}</span>`
+}
+
+/** Keeper attribution on `.sch-meta` — sigil + id (audit P0/P1 #8). No live
+ *  keeper-chat nav callback is wired into the schedule route, so the id is
+ *  shown as text rather than a fake nav button. */
+function SchKeeperMeta({ actor }: { actor: DashboardScheduledAutomationActor | null | undefined }) {
+  const id = actor?.id?.trim()
+  if (!id) {
+    return html`<span class="sch-by"><span class="sch-actor-kind mono" data-stub="no scheduled_by actor">예약</span></span>`
+  }
+  return html`
+    <span class="sch-by">
+      <${SigilBadge} slot=${kSlot(id)} sigil=${kSigil(id)} size=${22} title=${id} />
+      <span class="sch-klink" title=${actorLabel(actor)}>${id}</span>
+      <span class="sch-actor-kind mono">예약</span>
+    </span>
+  `
+}
+
+function SchCard({
+  request,
+  onOpen,
+}: {
+  request: DashboardScheduledAutomationRequest
+  onOpen: (request: DashboardScheduledAutomationRequest) => void
+}) {
+  const status = effectiveStatus(request)
+  const spec = statusSpecForLive(status)
+  const payload = schedPayloadSpec(request.payload_kind)
+  const dueIso = request.next_due_at_iso ?? request.due_at_iso ?? null
+  const summary = request.payload_summary?.trim() || null
+  return html`
+    <article class=${`sch-card st-${cardRailTone(spec.cls)}`} data-schedule-id=${request.schedule_id}>
+      <div class="sch-card-rail"></div>
+      <div class="sch-card-main">
+        <button
+          type="button"
+          class="sch-card-head"
+          data-schedule-detail=${request.schedule_id}
+          onClick=${() => { onOpen(request) }}
+        >
+          <span class="sch-kind">${payload.glyph} ${payload.lbl}</span>
+          <span class="sch-id mono">${request.schedule_id}</span>
+          <${SchRiskChip} risk=${request.risk_class} />
+          <span class="sch-rec mono" title="recurrence">↻ ${recurrenceText(request)}</span>
+          <span class="sch-head-sp"></span>
+          <${SchStatusPill} status=${status} />
+        </button>
+        ${summary
+          ? html`<button type="button" class="sch-summary" onClick=${() => { onOpen(request) }}>${summary}</button>`
+          : html`<button type="button" class="sch-summary" data-stub="no payload_summary" onClick=${() => { onOpen(request) }}>요약 없음 · 상세 보기</button>`}
+        <div class="sch-meta">
+          <${SchKeeperMeta} actor=${request.scheduled_by} />
+          <span class="sch-due" title="due_at"><span class="sub-k">due</span> ${formatDateTimeKo(dueIso)}</span>
+          ${request.requires_separate_human_grant
+            ? html`<span class="sch-need mono" title="별도 사람(operator) 승인 필요">⊙ 승인 필요</span>`
+            : null}
+        </div>
+      </div>
+    </article>
+  `
+}
+
+/** Detail overlay `.turn-overlay > .turn-drawer.sch-drawer` (audit P0 #4). */
+function SchDetail({
+  request,
+  onClose,
+  onResolved,
+}: {
+  request: DashboardScheduledAutomationRequest
+  onClose: () => void
+  onResolved?: () => Promise<void> | void
+}) {
+  // External-system sync: Escape-to-close keyboard listener (legitimate effect).
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => { window.removeEventListener('keydown', onKey) }
+  }, [onClose])
+
+  const status = effectiveStatus(request)
+  const payload = schedPayloadSpec(request.payload_kind)
+  const dueIso = request.next_due_at_iso ?? request.due_at_iso ?? null
+  const requestedAtIso = request.requested_at_iso ?? null
+  const expiresAtIso = request.expires_at_iso ?? null
+  const execution = request.last_execution
+  const summary = request.payload_summary?.trim() || null
+  const approval = request.approval_policy ?? (request.approval_required ? 'required' : 'not_required')
+  // Live payload has no `body` — only kind/digest/target/summary. Render what is
+  // available in the envelope and mark the absent body honestly (audit #12).
+  const payloadEnvelope = JSON.stringify(
+    {
+      kind: request.payload_kind ?? null,
+      digest: request.payload_digest ?? null,
+      target: request.payload_target ?? null,
+      summary: summary,
+    },
+    null,
+    2,
+  )
+
+  return html`
+    <div class="turn-overlay" onClick=${onClose}>
+      <div
+        class="turn-drawer sch-drawer"
+        data-schedule-detail-panel=${request.schedule_id}
+        onClick=${(event: MouseEvent) => { event.stopPropagation() }}
+      >
+        <div class="turn-hd">
+          <h3>예약 상세</h3>
+          <span class="tid">${request.schedule_id}</span>
+          <span class="sch-hd-sp" style=${{ marginLeft: 'auto' }}></span>
+          <${SchStatusPill} status=${status} />
+          <button type="button" class="turn-close" onClick=${onClose} title="닫기 (Esc)">✕</button>
+        </div>
+        <div class="turn-body">
+          <div class="turn-sec">
+            <h4>${payload.glyph} ${payload.lbl}</h4>
+            ${summary
+              ? html`<p class="sch-d-summary">${summary}</p>`
+              : html`<p class="sch-d-summary" data-stub="no payload_summary">요약 없음</p>`}
+            <div class="sch-badges">
+              <${SchRiskChip} risk=${request.risk_class} />
+              <span class="sch-rec mono">↻ ${recurrenceText(request)}</span>
+              <span class="sch-src mono">${enumLabel(request.source)}</span>
+            </div>
+          </div>
+
+          <div class="turn-sec">
+            <h4>주체 · 직무분리</h4>
+            <div class="sch-kvs">
+              <div class="sch-kv"><span class="k">requested_by</span><span class="v mono">${actorLabel(request.requested_by)}</span></div>
+              <div class="sch-kv"><span class="k">scheduled_by</span><span class="v mono">${actorLabel(request.scheduled_by)}</span></div>
+              <div class="sch-kv"><span class="k">approval_required</span><span class="v mono">${String(request.approval_required)}</span></div>
+            </div>
+            ${request.scheduled_by?.id
+              ? html`<div class="sch-sod">승인자(operator)는 요청자·예약자와 달라야 실행 grant가 발급됩니다 — 예약 주체는 keeper(<b>${request.scheduled_by.id}</b>), 승인 주체는 operator.</div>`
+              : html`<div class="sch-sod">승인자(operator)는 요청자·예약자와 달라야 실행 grant가 발급됩니다.</div>`}
+          </div>
+
+          <div class="turn-sec">
+            <h4>타이밍</h4>
+            <div class="sch-kvs">
+              <div class="sch-kv"><span class="k">요청</span><span class="v mono">${formatDateTimeKo(requestedAtIso)}</span></div>
+              <div class="sch-kv"><span class="k">due</span><span class="v mono">${formatDateTimeKo(dueIso)}</span></div>
+              <div class="sch-kv"><span class="k">만료</span><span class="v mono">${formatDateTimeKo(expiresAtIso)}</span></div>
+              <div class="sch-kv"><span class="k">recurrence</span><span class="v mono">${recurrenceText(request)}</span></div>
+            </div>
+          </div>
+
+          <div class="turn-sec">
+            <h4>승인 정책</h4>
+            <div class="sch-kvs">
+              <div class="sch-kv"><span class="k">approval_policy</span><span class="v mono">${enumLabel(approval)}</span></div>
+              <div class="sch-kv"><span class="k">운영자 조치</span><span class="v mono">${enumLabel(request.operator_action)}</span></div>
+              <div class="sch-kv"><span class="k">실행 준비</span><span class="v mono">${enumLabel(request.execution_readiness)}</span></div>
+            </div>
+          </div>
+
+          <div class="turn-sec">
+            <h4>payload 봉투</h4>
+            <pre class="turn-pre" data-stub="payload body not in projection">${payloadEnvelope}</pre>
+          </div>
+
+          <div class="turn-sec">
+            <h4>최근 실행 기록</h4>
+            <${SchExecution} execution=${execution} />
+          </div>
+
+          <${SchDetailActions} request=${request} onResolved=${onResolved} onClose=${onClose} />
+        </div>
+      </div>
+    </div>
+  `
+}
+
+function SchExecution({ execution }: { execution: DashboardScheduledAutomationExecution | null | undefined }) {
+  if (!execution) {
+    return html`<div class="sch-kvs"><div class="sch-kv"><span class="k">status</span><span class="v mono" data-stub="no last_execution">실행 기록 없음</span></div></div>`
+  }
+  const detailRows = executionDetailRows(execution.detail)
+  return html`
+    <div class="sch-kvs">
+      <div class="sch-kv"><span class="k">status</span><span class="v mono">${enumLabel(execution.status)}</span></div>
+      <div class="sch-kv"><span class="k">시작</span><span class="v mono">${formatDateTimeKo(execution.started_at_iso ?? null)}</span></div>
+      <div class="sch-kv"><span class="k">종료</span><span class="v mono">${formatDateTimeKo(execution.finished_at_iso ?? null)}</span></div>
+      ${detailRows.map(row => html`
+        <div class="sch-kv" data-execution-detail-row=${row.label}><span class="k">${row.label}</span><span class="v mono">${row.value}</span></div>
+      `)}
+    </div>
+    ${execution.error ? html`<div class="sch-exec bad">${execution.error}</div>` : null}
+  `
+}
+
+/** Detail-overlay actions. Wired to the real approve/reject API only — the
+ *  prototype's cancel action has no live endpoint, so it is omitted. Buttons
+ *  render only when an `onResolved` refresh callback exists (mirrors the
+ *  diagnostics ApprovalCell contract: no callback → read-only). */
+function SchDetailActions({
+  request,
+  onResolved,
+  onClose,
+}: {
+  request: DashboardScheduledAutomationRequest
+  onResolved?: () => Promise<void> | void
+  onClose: () => void
+}) {
+  const [pendingDecision, setPendingDecision] = useState<DashboardScheduleDecision | null>(null)
+  if (!onResolved || !isApprovalActionable(request)) return null
+  const busy = pendingDecision !== null
+
+  async function decide(decision: DashboardScheduleDecision) {
+    setPendingDecision(decision)
+    try {
+      await resolveScheduleApproval(
+        request.schedule_id,
+        decision,
+        decision === 'reject' ? 'rejected from dashboard' : undefined,
+      )
+      showToast(`${request.schedule_id} ${decision === 'approve' ? 'approved' : 'rejected'}`, 'success')
+      await onResolved?.()
+      onClose()
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'schedule approval failed', 'error')
+    } finally {
+      setPendingDecision(null)
+    }
+  }
+
+  return html`
+    <div class="turn-sec sch-detail-actions">
+      <button
+        type="button"
+        class="sch-act approve"
+        data-schedule-mutation="approve"
+        data-testid=${`schedule-approve-${request.schedule_id}`}
+        disabled=${busy}
+        aria-busy=${pendingDecision === 'approve' ? 'true' : 'false'}
+        onClick=${() => { void decide('approve') }}
+      >승인 — grant 발급</button>
+      <button
+        type="button"
+        class="sch-act deny"
+        data-schedule-mutation="reject"
+        data-testid=${`schedule-reject-${request.schedule_id}`}
+        disabled=${busy}
+        aria-busy=${pendingDecision === 'reject' ? 'true' : 'false'}
+        onClick=${() => { void decide('reject') }}
+      >거부</button>
+    </div>
+  `
+}
+
+function SchedulePrototypeSurface({
   automation,
   onResolved,
 }: {
+  automation: DashboardScheduledAutomation
+  onResolved?: () => Promise<void> | void
+}) {
+  const [tab, setTab] = useState<SchTabKey>('pending')
+  const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(null)
+
+  const rows = automation.requests ?? []
+  const tabDef = SCH_TABS.find(definition => definition.key === tab) ?? SCH_TABS[0]!
+  const filtered = rows.filter(request => schTabMatches(tabDef, request))
+  // Durable runner signals (real source). Keep one feed (audit P0/P1 #9).
+  const durableSignals = [...(automation.signals ?? [])].sort((a, b) => signalTimestamp(a) - signalTimestamp(b))
+  const selected = selectedScheduleId
+    ? rows.find(request => request.schedule_id === selectedScheduleId) ?? null
+    : null
+
+  return html`
+    <div class="sch-panel">
+      <div class="sch-tabs" role="tablist" aria-label="예약 필터">
+        ${SCH_TABS.map(definition => {
+          const count = definition.statuses === null
+            ? rows.length
+            : rows.filter(request => schTabMatches(definition, request)).length
+          const active = definition.key === tab
+          return html`
+            <button
+              type="button"
+              role="tab"
+              aria-selected=${active ? 'true' : 'false'}
+              class=${`sch-tab ${active ? 'on' : ''}`}
+              data-schedule-filter=${definition.key}
+              onClick=${() => { setTab(definition.key) }}
+            >${definition.label}<span class="sch-tab-n mono">${count.toLocaleString()}</span></button>
+          `
+        })}
+      </div>
+
+      ${filtered.length === 0
+        ? html`<div class="sch-empty">이 필터에 해당하는 예약이 없습니다.</div>`
+        : html`
+            <div class="sch-list">
+              ${filtered.map(request => html`
+                <${SchCard}
+                  request=${request}
+                  onOpen=${(next: DashboardScheduledAutomationRequest) => { setSelectedScheduleId(next.schedule_id) }}
+                />
+              `)}
+            </div>
+          `}
+
+      <section class="sch-signals">
+        <div class="ov-card-h"><h3>wake signal 피드 · schedule_runner.tick</h3></div>
+        ${durableSignals.length === 0
+          ? html`<div class="sch-empty" data-stub="no durable runner signals">durable wake signal 없음</div>`
+          : html`
+              <div class="sch-sig-list">
+                ${durableSignals.map(signal => {
+                  const spec = statusSpecForLive(signal.kind)
+                  return html`
+                    <div class="sch-sig" data-schedule-signal-id=${signal.signal_id}>
+                      <span class="sch-sig-at mono" data-schedule-signal-at=${signal.signal_id}>${compactTimeLabel(signal.emitted_at_iso ?? signal.due_at_iso ?? null)}</span>
+                      <span class=${`sch-sig-kind ${spec.cls}`} data-schedule-signal-kind=${signal.kind}>${enumLabel(signal.kind || signal.event_type)}</span>
+                      <button
+                        type="button"
+                        class="sch-sig-id mono"
+                        data-schedule-signal-schedule=${signal.schedule_id}
+                        onClick=${() => { setSelectedScheduleId(signal.schedule_id) }}
+                      >${signal.schedule_id}</button>
+                      <span class="sch-sig-risk mono" data-schedule-signal-risk=${signal.signal_id}>${enumLabel(signal.risk_class)}</span>
+                    </div>
+                  `
+                })}
+              </div>
+            `}
+      </section>
+
+      ${selected
+        ? html`<${SchDetail} request=${selected} onClose=${() => { setSelectedScheduleId(null) }} onResolved=${onResolved} />`
+        : null}
+    </div>
+  `
+}
+
+export function ScheduledAutomationPanel({
+  automation,
+  onResolved,
+  variant = 'diagnostics',
+}: {
   automation?: DashboardScheduledAutomation | null
   onResolved?: () => Promise<void> | void
+  variant?: 'diagnostics' | 'v2'
 }) {
   const [activeFilter, setActiveFilter] = useState<ScheduleFilterKey>('all')
   const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(null)
@@ -818,6 +1269,10 @@ export function ScheduledAutomationPanel({
         예약 자동화 projection 없음
       </div>
     `
+  }
+
+  if (variant === 'v2') {
+    return html`<${SchedulePrototypeSurface} automation=${automation} onResolved=${onResolved} />`
   }
 
   const nonzeroCounts = Object.entries(automation.counts ?? {})

--- a/dashboard/src/components/v2/fusion-constants.ts
+++ b/dashboard/src/components/v2/fusion-constants.ts
@@ -1,0 +1,28 @@
+// MASC v2 — fusion decision display constants (ported from prototype
+// fusion-data.jsx). Judge decision → label + tone class + glyph for the
+// `.fus-dec-badge` / `.msg-fusion` prototype markup. Pure data.
+
+export interface FusionDecisionSpec {
+  readonly lbl: string
+  readonly cls: string
+  readonly glyph: string
+}
+
+export const FUSION_DECISION: Readonly<Record<string, FusionDecisionSpec>> = {
+  Answer: { lbl: '해결 답안', cls: 'ok', glyph: '✓' },
+  Recommend: { lbl: '권고 (advisory)', cls: 'volt', glyph: '▸' },
+  Insufficient: { lbl: '심의 무효 · 부족', cls: 'warn', glyph: '⚠' },
+}
+
+export const DENY_REASON: Readonly<Record<string, string>> = {
+  Disabled: 'fusion 비활성 (enabled=false)',
+  Preset_unknown: '알 수 없는 preset',
+  Depth_exceeded: '재귀 깊이 초과 (Nested)',
+  Over_hourly_budget: '시간당 발동 예산 초과',
+}
+
+/** Decision spec lookup with a neutral fallback (unknown decisions render
+ * with the raw key rather than throwing). */
+export function fusionDecisionSpec(decision: string | null | undefined): FusionDecisionSpec {
+  return (decision && FUSION_DECISION[decision]) || { lbl: decision || '미결', cls: '', glyph: '◈' }
+}

--- a/dashboard/src/components/v2/icons-v2.ts
+++ b/dashboard/src/components/v2/icons-v2.ts
@@ -1,0 +1,25 @@
+// MASC v2 — nav icon set (ported 1:1 from prototype shell.jsx ICON map).
+// Custom 24×24 line icons (NOT lucide) so the rail matches the design exactly.
+
+import { html } from 'htm/preact'
+import type { VNode } from 'preact'
+
+type Icon = VNode
+
+export const ICONS: Readonly<Record<string, Icon>> = {
+  grid: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="3" y="3" width="7" height="7" rx="1.4" /><rect x="14" y="3" width="7" height="7" rx="1.4" /><rect x="3" y="14" width="7" height="7" rx="1.4" /><rect x="14" y="14" width="7" height="7" rx="1.4" /></svg>`,
+  users: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.2" /><path d="M3.5 19c0-3 2.6-5 5.5-5s5.5 2 5.5 5" /><path d="M16.5 6.2a3 3 0 0 1 0 5.6" /><path d="M18.5 19c0-2-.8-3.6-2-4.6" /></svg>`,
+  board: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"><rect x="3" y="4" width="5" height="16" rx="1.2" /><rect x="10" y="4" width="5" height="11" rx="1.2" /><rect x="17" y="4" width="4" height="14" rx="1.2" /></svg>`,
+  term: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2.2" /><path d="M7 9l3 3-3 3" /><path d="M13 15h4" /></svg>`,
+  code: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6l-5 6 5 6" /><path d="M16 6l5 6-5 6" /><path d="M13.5 4l-3 16" /></svg>`,
+  plug: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M9 3v5M15 3v5" /><path d="M6 8h12v3a6 6 0 0 1-12 0z" /><path d="M12 17v4" /></svg>`,
+  gear: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3" /><path d="M12 2.5v3M12 18.5v3M2.5 12h3M18.5 12h3M5.1 5.1l2.1 2.1M16.8 16.8l2.1 2.1M18.9 5.1l-2.1 2.1M7.2 16.8l-2.1 2.1" /></svg>`,
+  shield: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5.5c0 4.3-3 7.3-7 8.5-4-1.2-7-4.2-7-8.5V6z" /><path d="M9.2 12l2 2 3.6-3.8" /></svg>`,
+  target: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5" /><circle cx="12" cy="12" r="4" /><circle cx="12" cy="12" r="0.6" fill="currentColor" /></svg>`,
+  monitor: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h3.5l2-6 4 13 2.2-7H21" /></svg>`,
+  logs: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h10M4 10h16M4 14h13M4 18h9" /></svg>`,
+  fusion: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="4.5" cy="5" r="1.7" /><circle cx="4.5" cy="12" r="1.7" /><circle cx="4.5" cy="19" r="1.7" /><path d="M6.2 5.4 11 11M6.2 12H11M6.2 18.6 11 13" /><circle cx="12.9" cy="12" r="2" /><path d="M14.9 12H19.5" /><circle cx="20" cy="12" r="1.6" fill="currentColor" /></svg>`,
+  clock: html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5" /><path d="M12 7.5V12l3 2" /></svg>`,
+}
+
+export const ICON_MORE: Icon = html`<svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="5" cy="12" r="1.7" /><circle cx="12" cy="12" r="1.7" /><circle cx="19" cy="12" r="1.7" /></svg>`

--- a/dashboard/src/components/v2/keeper-fsm.ts
+++ b/dashboard/src/components/v2/keeper-fsm.ts
@@ -1,0 +1,147 @@
+// MASC v2 — Keeper lifecycle FSM tables (ported 1:1 from prototype data.jsx)
+//
+// The prototype's 12-state FSM drives every keeper's status dot tone, the
+// breathing pulse, the hover gloss, and the operator action set. The live
+// dashboard's `KeeperPhase` (types/core.ts) is the same 12 states plus
+// `Zombie`, so these tables map directly onto live keeper data. Unknown /
+// null phases fall back to the idle/off bucket (a total display default —
+// the prototype used the same `?? 'idle'` pattern), never throwing.
+
+export type KeeperTone = 'ok' | 'warn' | 'bad' | 'busy' | 'idle'
+export type KeeperCoarseStatus = 'run' | 'pause' | 'off'
+
+// An operator-issued lifecycle action. `via` shows a transient phase first,
+// then auto-advances to `to` after `ms`. Without `via`, the transition is
+// instant. `danger` marks destructive (drain/stop) actions.
+export interface FsmAction {
+  readonly id: string
+  readonly label: string
+  readonly glyph: string
+  readonly hint: string
+  readonly to: string
+  readonly via?: string
+  readonly ms?: number
+  readonly danger?: boolean
+}
+
+// The 12 canonical FSM phases (prototype FSM_STATES). `Zombie` is a live-only
+// extra handled by the fallbacks below.
+export const FSM_STATES = [
+  'Offline',
+  'Restarting',
+  'Running',
+  'Compacting',
+  'HandingOff',
+  'Failing',
+  'Overflowed',
+  'Draining',
+  'Paused',
+  'Stopped',
+  'Crashed',
+  'Dead',
+] as const
+
+// phase → status-dot tone (12 phases collapse into 5 buckets).
+const PHASE_TONE: Readonly<Record<string, KeeperTone>> = {
+  Running: 'ok',
+  Paused: 'warn',
+  Draining: 'warn',
+  Compacting: 'busy',
+  HandingOff: 'busy',
+  Restarting: 'busy',
+  Failing: 'bad',
+  Overflowed: 'bad',
+  Crashed: 'bad',
+  Dead: 'bad',
+  Zombie: 'bad',
+  Stopped: 'idle',
+  Offline: 'idle',
+}
+
+// phase → whether the dot breathes (active/transient phases only).
+const PHASE_PULSE: Readonly<Record<string, boolean>> = {
+  Running: true,
+  Compacting: true,
+  HandingOff: true,
+  Restarting: true,
+  Failing: true,
+}
+
+// phase → KR hover gloss.
+const PHASE_INFO: Readonly<Record<string, string>> = {
+  Offline: '오프라인 — 실행 중이 아님',
+  Restarting: '재시작 중',
+  Running: '실행 중 — 작업/라운드 순환',
+  Compacting: '컨텍스트 압축 중',
+  HandingOff: '작업을 다른 keeper 에게 인계하는 중',
+  Failing: '실패 처리 중',
+  Overflowed: '컨텍스트 윈도우 초과',
+  Draining: '정상 종료를 위해 작업을 비우는 중',
+  Paused: '슈퍼바이저가 일시정지함',
+  Stopped: '중지됨',
+  Crashed: '비정상 종료',
+  Dead: '복구 불가 — 종료됨',
+  Zombie: '좀비 — 등록됐으나 응답 없음',
+}
+
+// Reusable action literals (shared across phases keeps the table honest).
+const A_STOP: FsmAction = { id: 'stop', label: '중지', glyph: '⏹', via: 'Draining', to: 'Stopped', ms: 1500, danger: true, hint: '작업을 비우고 종료 (Drain → Stopped)' }
+
+// phase → ordered operator actions. Phases absent here (Compacting,
+// HandingOff, Draining, Restarting, Dead, Zombie) expose no action — they are
+// transient or terminal.
+const FSM_ACTIONS: Readonly<Record<string, readonly FsmAction[]>> = {
+  Running: [
+    { id: 'pause', label: '일시정지', glyph: '⏸', to: 'Paused', hint: '슈퍼바이저가 잠시 멈춤 — 컨텍스트·소유 태스크 보존, 즉시 재개 가능' },
+    { id: 'compact', label: '컴팩션', glyph: '◉', via: 'Compacting', to: 'Running', ms: 1700, hint: '컨텍스트를 지금 압축하고 실행 복귀' },
+    { id: 'handoff', label: '핸드오프', glyph: '⇄', via: 'HandingOff', to: 'Stopped', ms: 1700, hint: '소유 태스크를 인계하고 이 세션 정리' },
+    A_STOP,
+  ],
+  Paused: [
+    { id: 'resume', label: '재개', glyph: '▶', to: 'Running', hint: '멈춘 지점부터 다시 실행' },
+    A_STOP,
+  ],
+  Overflowed: [
+    { id: 'compact', label: '컴팩션', glyph: '◉', via: 'Compacting', to: 'Running', ms: 2000, hint: '윈도우 초과 — 압축으로 복구' },
+    { ...A_STOP, hint: '복구 대신 종료' },
+  ],
+  Failing: [
+    { id: 'restart', label: '재시작', glyph: '↻', via: 'Restarting', to: 'Running', ms: 1700, hint: '실패 처리 후 재시작' },
+    { ...A_STOP, hint: '종료' },
+  ],
+  Crashed: [
+    { id: 'restart', label: '재시작', glyph: '↻', via: 'Restarting', to: 'Running', ms: 1800, hint: '비정상 종료 — 재시작 시도' },
+  ],
+  Stopped: [
+    { id: 'start', label: '시작', glyph: '▶', via: 'Restarting', to: 'Running', ms: 1500, hint: '중지된 keeper 새로 시작' },
+  ],
+  Offline: [
+    { id: 'start', label: '시작', glyph: '▶', via: 'Restarting', to: 'Running', ms: 1500, hint: '오프라인 keeper 시작' },
+  ],
+}
+
+const RUN_PHASES = new Set(['Running', 'Compacting', 'HandingOff', 'Restarting', 'Failing'])
+const PAUSE_PHASES = new Set(['Paused', 'Draining'])
+
+/** phase → coarse status bucket (mirrors prototype phaseStatus). */
+export function phaseStatus(phase: string | null | undefined): KeeperCoarseStatus {
+  if (phase && RUN_PHASES.has(phase)) return 'run'
+  if (phase && PAUSE_PHASES.has(phase)) return 'pause'
+  return 'off'
+}
+
+export function phaseTone(phase: string | null | undefined): KeeperTone {
+  return (phase && PHASE_TONE[phase]) || 'idle'
+}
+
+export function phasePulse(phase: string | null | undefined): boolean {
+  return !!(phase && PHASE_PULSE[phase])
+}
+
+export function phaseInfo(phase: string | null | undefined): string {
+  return (phase && PHASE_INFO[phase]) || phase || '알 수 없음'
+}
+
+export function fsmActions(phase: string | null | undefined): readonly FsmAction[] {
+  return (phase && FSM_ACTIONS[phase]) || []
+}

--- a/dashboard/src/components/v2/nav-rail-v2.ts
+++ b/dashboard/src/components/v2/nav-rail-v2.ts
@@ -1,0 +1,156 @@
+// MASC v2 — left surface nav rail (ported from prototype shell.jsx NavRail).
+// Emits the prototype `.v2-nav` DOM (brand · nav-item · nav-div · spacer ·
+// settings) so the vendored v2.css styles it 1:1. Surface ids are mapped to
+// the live dashboard TabIds; clicking drives the real router (navigate()).
+
+import { html } from 'htm/preact'
+import { useState, useEffect } from 'preact/hooks'
+import { navigate, route } from '../../router'
+import type { TabId } from '../../types'
+import { ICONS, ICON_MORE } from './icons-v2'
+
+interface SurfaceEntry {
+  readonly tab: TabId
+  readonly label: string
+  readonly icon: keyof typeof ICONS
+}
+type NavEntry = SurfaceEntry | 'sep'
+
+// Prototype SURFACES order/labels/icons, mapped to live TabIds.
+//   prototype work→workspace, monitor→monitoring, ide→code; rest 1:1.
+const SURFACES: readonly NavEntry[] = [
+  { tab: 'overview', label: '개요', icon: 'grid' },
+  'sep',
+  { tab: 'keepers', label: 'Keepers', icon: 'users' },
+  { tab: 'monitoring', label: 'Monitor', icon: 'monitor' },
+  'sep',
+  { tab: 'workspace', label: '작업', icon: 'target' },
+  { tab: 'approvals', label: '승인', icon: 'shield' },
+  { tab: 'schedule', label: '예약', icon: 'clock' },
+  'sep',
+  { tab: 'board', label: '보드', icon: 'board' },
+  { tab: 'fusion', label: 'Fusion', icon: 'fusion' },
+  { tab: 'logs', label: '로그', icon: 'logs' },
+  'sep',
+  { tab: 'code', label: 'IDE', icon: 'code' },
+  { tab: 'connectors', label: '커넥터', icon: 'plug' },
+]
+
+export interface NavBadges {
+  readonly approvals?: number
+  readonly schedule?: number
+}
+
+const SURFACE_LABEL: Readonly<Record<string, string>> = Object.fromEntries(
+  SURFACES.filter((e): e is SurfaceEntry => e !== 'sep').map((e) => [e.tab, e.label]),
+)
+
+/** Crumb label for a tab (prototype SURFACE_LABEL); settings + unknowns fall back. */
+export function surfaceLabel(tab: TabId): string {
+  return SURFACE_LABEL[tab] ?? (tab === 'settings' ? '설정' : tab)
+}
+
+// On phones the rail collapses to a bottom tab bar: the operator's daily loop
+// (home / agents / work / approvals) gets first-class tabs; the rest live behind
+// a 더보기 sheet so no tab drops below the 44px hit target (prototype shell.jsx).
+const MOBILE_PRIMARY: readonly TabId[] = ['overview', 'keepers', 'workspace', 'approvals']
+const SURFACE_ENTRIES: readonly SurfaceEntry[] = SURFACES.filter((e): e is SurfaceEntry => e !== 'sep')
+
+export function NavRailV2({ badges, mobile = false }: { badges?: NavBadges; mobile?: boolean }) {
+  const active = route.value.tab
+  const badgeFor = (tab: TabId): number | undefined => {
+    if (tab === 'approvals') return badges?.approvals || undefined
+    if (tab === 'schedule') return badges?.schedule || undefined
+    return undefined
+  }
+
+  const [moreOpen, setMoreOpen] = useState(false)
+  useEffect(() => { setMoreOpen(false) }, [active])
+
+  if (mobile) {
+    const byTab = new Map(SURFACE_ENTRIES.map((e) => [e.tab, e]))
+    const primary = MOBILE_PRIMARY.map((t) => byTab.get(t)).filter((e): e is SurfaceEntry => !!e)
+    const hidden = SURFACE_ENTRIES.filter((e) => !MOBILE_PRIMARY.includes(e.tab))
+    const moreActive = !MOBILE_PRIMARY.includes(active)
+    const hiddenBadge = hidden.reduce((n, e) => n + (badgeFor(e.tab) ?? 0), 0)
+    const Tab = (e: SurfaceEntry) => {
+      const badge = badgeFor(e.tab)
+      return html`
+        <button key=${e.tab} class=${`nav-item ${active === e.tab ? 'on' : ''}`} onClick=${() => navigate(e.tab)} title=${e.label}>
+          ${ICONS[e.icon]}<span class="nlbl">${e.label}</span>
+          ${badge ? html`<span class="nav-badge">${badge}</span>` : null}
+        </button>
+      `
+    }
+    return html`
+      <nav class="v2-nav is-mnav">
+        ${primary.map(Tab)}
+        <button class=${`nav-item ${moreActive ? 'on' : ''}`} title="더보기" onClick=${(e: Event) => { e.stopPropagation(); setMoreOpen((o) => !o) }}>
+          ${ICON_MORE}<span class="nlbl">더보기</span>
+          ${hiddenBadge ? html`<span class="nav-badge">${hiddenBadge}</span>` : null}
+        </button>
+      </nav>
+      ${moreOpen
+        ? html`
+            <div class="mnav-back" onClick=${() => setMoreOpen(false)}>
+              <div class="mnav-sheet" onClick=${(e: Event) => e.stopPropagation()}>
+                <div class="mnav-grip"></div>
+                <div class="mnav-sheet-h">더보기</div>
+                <div class="mnav-grid">
+                  ${hidden.map((e) => {
+                    const badge = badgeFor(e.tab)
+                    return html`
+                      <button key=${e.tab} class=${`mnav-tile ${active === e.tab ? 'on' : ''}`} onClick=${() => { navigate(e.tab); setMoreOpen(false) }}>
+                        <span class="mnav-ic">${ICONS[e.icon]}</span>
+                        <span class="mnav-lbl">${e.label}</span>
+                        ${badge ? html`<span class="nav-badge">${badge}</span>` : null}
+                      </button>
+                    `
+                  })}
+                  <button class=${`mnav-tile ${active === 'settings' ? 'on' : ''}`} onClick=${() => { navigate('settings'); setMoreOpen(false) }}>
+                    <span class="mnav-ic">${ICONS.gear}</span>
+                    <span class="mnav-lbl">설정</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          `
+        : null}
+    `
+  }
+
+  return html`
+    <nav class="v2-nav">
+      <div class="nav-brand" role="button" tabindex=${0} title="MASC · 개요(홈)로" style=${{ cursor: 'pointer' }} onClick=${() => navigate('overview')}>
+        <div class="nav-home">M</div>
+        <span class="nlbl">MASC</span>
+      </div>
+      ${SURFACES.map((entry, i) =>
+        entry === 'sep'
+          ? html`<div key=${'sep' + i} class="nav-div"></div>`
+          : (() => {
+              const badge = badgeFor(entry.tab)
+              return html`
+                <button
+                  key=${entry.tab}
+                  class=${`nav-item ${active === entry.tab ? 'on' : ''}`}
+                  onClick=${() => navigate(entry.tab)}
+                  title=${entry.label}
+                >
+                  ${ICONS[entry.icon]}<span class="nlbl">${entry.label}</span>
+                  ${badge ? html`<span class="nav-badge">${badge}</span>` : null}
+                </button>
+              `
+            })(),
+      )}
+      <div class="nav-spacer"></div>
+      <button
+        class=${`nav-item ${active === 'settings' ? 'on' : ''}`}
+        title="설정"
+        onClick=${() => navigate('settings')}
+      >
+        ${ICONS.gear}<span class="nlbl">설정</span>
+      </button>
+    </nav>
+  `
+}

--- a/dashboard/src/components/v2/primitives-v2.ts
+++ b/dashboard/src/components/v2/primitives-v2.ts
@@ -1,0 +1,127 @@
+// MASC v2 — primitive component library (ported from prototype primitives.jsx
+// + messages.jsx identity leaves). These wrap the vendored v2.css classes
+// (.dot2 / .sigil / .chip / .meter) and the converged inline-styled <Pill>.
+// Visual identity is 1:1 with the prototype: tone tints come from the same
+// design tokens (PILL_TONES), the sigil pulls its slot color from --kp{slot}.
+
+import { html } from 'htm/preact'
+import type { JSX } from 'preact'
+
+export type PillTone = 'neutral' | 'ok' | 'warn' | 'bad' | 'volt' | 'info'
+export type DotState = 'ok' | 'warn' | 'bad' | 'busy' | 'idle'
+
+interface ToneSpec {
+  readonly color: string
+  readonly border: string
+  readonly bg: string
+}
+
+// The converged badge palette — one table replaces the prototype's seven
+// forked badge classes. color-mix keeps tints token-derived.
+export const PILL_TONES: Readonly<Record<PillTone, ToneSpec>> = {
+  neutral: { color: 'var(--text-mid)', border: 'var(--border-main)', bg: 'var(--bg-card)' },
+  ok: { color: 'var(--status-ok)', border: 'color-mix(in oklab, var(--status-ok) 45%, transparent)', bg: 'color-mix(in oklab, var(--status-ok) 10%, var(--bg-card))' },
+  warn: { color: 'var(--status-warn)', border: 'color-mix(in oklab, var(--status-warn) 45%, transparent)', bg: 'color-mix(in oklab, var(--status-warn) 9%, var(--bg-card))' },
+  bad: { color: 'var(--status-bad)', border: 'color-mix(in oklab, var(--status-bad) 42%, transparent)', bg: 'color-mix(in oklab, var(--status-bad) 10%, var(--bg-card))' },
+  volt: { color: 'var(--volt-strong)', border: 'var(--volt-dim)', bg: 'var(--volt-wash)' },
+  info: { color: 'var(--info)', border: 'color-mix(in oklab, var(--info) 38%, transparent)', bg: 'color-mix(in oklab, var(--info) 9%, var(--bg-card))' },
+}
+
+/** Status pip — `.dot2` + tone + optional pulse. */
+export function Dot({ state = 'idle', pulse = false }: { state?: DotState; pulse?: boolean }) {
+  const cls = ['dot2']
+  if (state && state !== 'idle') cls.push(state)
+  if (pulse) cls.push('pulse')
+  return html`<span class=${cls.join(' ')}></span>`
+}
+
+export interface PillProps {
+  tone?: PillTone
+  mono?: boolean
+  dot?: boolean | DotState
+  dotPulse?: boolean
+  soft?: boolean
+  count?: boolean
+  title?: string
+  style?: JSX.CSSProperties
+  children?: unknown
+}
+
+/** The converged badge. Inline-styled (the prototype's Pill emits no stable
+ * class) so the tone table is the single source of truth. */
+export function Pill(props: PillProps) {
+  const { tone = 'neutral', mono = false, dot = false, dotPulse = false, soft = false, count = false, title, style, children } = props
+  const t = PILL_TONES[tone] ?? PILL_TONES.neutral
+  const base: JSX.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    fontFamily: mono ? 'var(--font-mono)' : 'var(--font-ui)',
+    fontSize: count ? 10 : 11,
+    fontWeight: count ? 600 : 400,
+    letterSpacing: mono ? '0.04em' : '0.05em',
+    lineHeight: 1.2,
+    padding: count ? '1px 7px' : '4px 10px',
+    borderRadius: 'var(--radius-pill)',
+    border: '1px solid ' + t.border,
+    color: t.color,
+    background: soft ? 'transparent' : t.bg,
+    whiteSpace: 'nowrap',
+    ...style,
+  }
+  const dotState: DotState = dot === true ? (tone === 'neutral' ? 'idle' : (tone as DotState)) : (dot || 'idle')
+  return html`
+    <span style=${base} title=${title}>
+      ${dot ? html`<${Dot} state=${dotState} pulse=${dotPulse} />` : null}
+      ${children}
+    </span>
+  `
+}
+
+/** Count badge — numeric tally pill (former .att-count / .kp-att). */
+export function CountBadge({ tone = 'bad', children }: { tone?: PillTone; children?: unknown }) {
+  return html`<${Pill} tone=${tone} count mono>${children}</${Pill}>`
+}
+
+export interface SigilProps {
+  slot?: number | string
+  size?: number
+  heartbeat?: boolean
+  title?: string
+  fontScale?: number
+  children?: unknown
+}
+
+/** Slot-colored monogram identity — `.sigil` with --kc from --kp{slot}. */
+export function Sigil({ slot = 1, size = 32, heartbeat = false, title, fontScale = 0.4, children }: SigilProps) {
+  const kc = typeof slot === 'number' ? `var(--kp${slot})` : slot
+  const style: JSX.CSSProperties = {
+    // CSS custom property — typed via index escape (preact passes it through).
+    ['--kc' as string]: kc,
+    width: size,
+    height: size,
+    fontSize: Math.round(size * fontScale),
+  }
+  return html`<span class=${'sigil' + (heartbeat ? ' heartbeat' : '')} title=${title} aria-label=${title} style=${style}>${children}</span>`
+}
+
+/** Keeper identity badge: color slot + 2-letter sigil (keeper-badge.ts). */
+export function SigilBadge({ slot, sigil, size = 18, beat = false, title }: { slot: number; sigil: string; size?: number; beat?: boolean; title?: string }) {
+  return html`<${Sigil} slot=${slot} size=${size} heartbeat=${beat} title=${title} fontScale=${0.46}>${sigil}</${Sigil}>`
+}
+
+/** Status dot driven by the coarse run/pause/off status (messages.jsx). */
+export function StatusDot({ status, pulse = false }: { status: string; pulse?: boolean }) {
+  const state: DotState = status === 'run' ? 'ok' : status === 'pause' ? 'warn' : status === 'off' ? 'idle' : (status as DotState)
+  return html`<${Dot} state=${state} pulse=${pulse} />`
+}
+
+/** Keeper's proposed next action chip (`.chip` + leading arrow). */
+export function SuggestionChip({ pre = '→', onClick, children }: { pre?: string; onClick?: () => void; children?: unknown }) {
+  return html`<button class="chip" onClick=${onClick}>${pre ? html`<span class="pre">${pre}</span>` : null}${children}</button>`
+}
+
+/** Linear meter (`.meter` + optional hot). */
+export function Meter({ pct = 0, hot = false }: { pct?: number; hot?: boolean }) {
+  return html`<div class=${'meter' + (hot ? ' hot' : '')}><span style=${{ width: Math.max(0, Math.min(100, pct)) + '%' }}></span></div>`
+}

--- a/dashboard/src/components/v2/schedule-constants.ts
+++ b/dashboard/src/components/v2/schedule-constants.ts
@@ -1,0 +1,59 @@
+// MASC v2 — schedule domain display constants (ported from prototype
+// schedule-data.jsx; mirrors lib/schedule Schedule_domain). Status/risk/payload
+// → label + tone class + glyph for the `.sch-pill` / `.sch-risk` / `.sch-kind`
+// prototype markup. Pure data; the live schedule surface maps its API records
+// onto these keys.
+
+export interface SchedStatusSpec {
+  readonly lbl: string
+  readonly cls: string
+  readonly glyph: string
+}
+
+export const SCHED_STATUS: Readonly<Record<string, SchedStatusSpec>> = {
+  Pending_approval: { lbl: '승인 대기', cls: 'warn', glyph: '◷' },
+  Scheduled: { lbl: '예약됨', cls: 'info', glyph: '◈' },
+  Due: { lbl: 'due', cls: 'warn', glyph: '◉' },
+  Running: { lbl: '실행 중', cls: 'ok', glyph: '▶' },
+  Succeeded: { lbl: '완료', cls: 'ok', glyph: '✓' },
+  Failed: { lbl: '실패', cls: 'bad', glyph: '✕' },
+  Rejected: { lbl: '거부됨', cls: 'bad', glyph: '⊘' },
+  Cancelled: { lbl: '취소됨', cls: 'dim', glyph: '◌' },
+  Expired: { lbl: '만료', cls: 'dim', glyph: '⊗' },
+}
+
+export const SCHED_TERMINAL: readonly string[] = ['Succeeded', 'Failed', 'Rejected', 'Cancelled', 'Expired']
+
+export const SCHED_RISK: Readonly<Record<string, { lbl: string; cls: string }>> = {
+  Reminder_only: { lbl: 'reminder', cls: 'dim' },
+  Read_only: { lbl: 'read-only', cls: 'ok' },
+  Workspace_write: { lbl: 'workspace-write', cls: 'info' },
+  External_write: { lbl: 'external-write', cls: 'warn' },
+  Destructive: { lbl: 'destructive', cls: 'bad' },
+  Cost_bearing: { lbl: 'cost-bearing', cls: 'volt' },
+}
+
+export const SCHED_PAYLOAD: Readonly<Record<string, { glyph: string; lbl: string }>> = {
+  'keeper.start': { glyph: '◇', lbl: 'keeper 기동' },
+  'compact.sweep': { glyph: '◉', lbl: '컴팩션 스윕' },
+  'index.reindex': { glyph: '▤', lbl: '재색인' },
+  'report.generate': { glyph: '▦', lbl: '리포트 생성' },
+  'trace.export': { glyph: '▥', lbl: 'trace 내보내기' },
+  'gate.recheck': { glyph: '◬', lbl: '게이트 재점검' },
+  'broadcast.send': { glyph: '◈', lbl: '브로드캐스트' },
+  'archive.purge': { glyph: '⊗', lbl: '아카이브 정리' },
+}
+
+/** Status spec lookup with a neutral fallback (total function — unknown live
+ * statuses render as a dim chip rather than throwing). */
+export function schedStatusSpec(status: string | null | undefined): SchedStatusSpec {
+  return (status && SCHED_STATUS[status]) || { lbl: status || '알 수 없음', cls: 'dim', glyph: '◌' }
+}
+
+export function schedRiskSpec(risk: string | null | undefined): { lbl: string; cls: string } {
+  return (risk && SCHED_RISK[risk]) || { lbl: risk || '미상', cls: 'dim' }
+}
+
+export function schedPayloadSpec(kind: string | null | undefined): { glyph: string; lbl: string } {
+  return (kind && SCHED_PAYLOAD[kind]) || { glyph: '▢', lbl: kind || '작업' }
+}

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -15,6 +15,15 @@ import { TweaksPanelToggle } from '../tweaks-panel'
 import { StatusDot } from './primitives-v2'
 import { phaseStatus } from './keeper-fsm'
 import { surfaceLabel } from './nav-rail-v2'
+// Operational/safety chrome the v2 prototype omits but operators rely on
+// (connection state, transport telemetry, emergency stop, error inbox, auth,
+// build identity). Re-mounted into the v2 top bar so the reskin does not drop
+// live operational visibility (PR #22081 review P1). These are zero-prop
+// components that read their own signals.
+import { ConnectionStatus, ErrorCounterBadge, BuildIdentityBadge } from '../dashboard-shell'
+import { AuthStatus } from '../auth-status'
+import { EmergencyStopControl } from '../emergency-stop-control'
+import { TransportBeacon } from '../transport-beacon'
 
 const DEAD_PHASES = new Set(['Overflowed', 'Crashed', 'Dead', 'Zombie'])
 
@@ -95,12 +104,22 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
       <div class="v2-top-spacer"></div>
       <span class="v2-statchip live"><${StatusDot} status="run" pulse=${true} />${running} 실행 중</span>
       <${AttentionIndicatorV2} />
-      ${/* 예약(schedule): no live cron/schedule signal yet — see live-store-mapping §4.
-          Rendered as a navigable chip; data-stub marks the absent backend source. */ ''}
-      <button class="v2-statchip attn" data-stub="schedule" onClick=${() => navigate('schedule')} title="예약 자동화 큐 — 라이브 백엔드 신호 없음(표시용)">
-        ${'◷'} 예약 <b>정상</b>
+      ${/* 예약(schedule): no live cron/schedule signal yet. Rendered as a plain
+          navigation affordance only — no fabricated status (PR #22081 review:
+          no stub). Wire to a live schedule signal when the backend exposes one. */ ''}
+      <button class="v2-statchip" onClick=${() => navigate('schedule')} title="예약 자동화 큐">
+        ${'◷'} 예약
       </button>
+      ${/* Operational/safety status cluster (review P1: keep operator chrome). */ ''}
+      <div class="v2-top-ops">
+        <${ConnectionStatus} />
+        <${TransportBeacon} />
+        <${EmergencyStopControl} />
+        <${ErrorCounterBadge} />
+        <${AuthStatus} />
+      </div>
       <${CopilotDockTopBarButton} dock=${dock} />
+      <${BuildIdentityBadge} />
       <${TweaksPanelToggle} />
     </div>
   `

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -1,0 +1,107 @@
+// MASC v2 — top bar (ported from prototype shell.jsx TopBar + AttentionIndicator).
+// Emits the prototype `.v2-top` DOM (crumb · live statchip · attention ·
+// schedule · Copilot). Wired to live signals: running count + attention
+// aggregate (governance approvals, needs-attention keepers, dead/overflowed,
+// stale connectors). The Copilot button reuses the existing dock controller.
+
+import { html } from 'htm/preact'
+import { useState, useEffect } from 'preact/hooks'
+import { navigate, route } from '../../router'
+import { keepers, staleKeepers } from '../../store'
+import { activeKeeperName } from '../../keeper-state'
+import { governanceData } from '../governance-signals'
+import { CopilotDockTopBarButton, type CopilotDockApi } from '../copilot-dock'
+import { TweaksPanelToggle } from '../tweaks-panel'
+import { StatusDot } from './primitives-v2'
+import { phaseStatus } from './keeper-fsm'
+import { surfaceLabel } from './nav-rail-v2'
+
+const DEAD_PHASES = new Set(['Overflowed', 'Crashed', 'Dead', 'Zombie'])
+
+interface AttentionAgg {
+  approvals: number
+  keepers: number
+  dead: number
+  stale: number
+  total: number
+}
+
+function computeAttention(): AttentionAgg {
+  const ks = keepers.value
+  const approvals = governanceData.value?.approval_queue?.length ?? 0
+  const attKeepers = ks.filter((k) => k.needs_attention === true).length
+  const dead = ks.filter((k) => !!k.lifecycle_phase && DEAD_PHASES.has(k.lifecycle_phase)).length
+  const stale = staleKeepers.value.size
+  return { approvals, keepers: attKeepers, dead, stale, total: approvals + attKeepers + dead + stale }
+}
+
+function AttentionIndicatorV2() {
+  const [open, setOpen] = useState(false)
+  useEffect(() => {
+    if (!open) return
+    const close = () => setOpen(false)
+    window.addEventListener('click', close)
+    return () => window.removeEventListener('click', close)
+  }, [open])
+
+  const a = computeAttention()
+  if (!a.total) {
+    return html`<span class="v2-statchip live" title="처리할 항목 없음">${'✓'} 정상</span>`
+  }
+  const rows = [
+    { k: 'approvals', n: a.approvals, lbl: '승인 대기', sev: 'bad', nav: 'approvals' as const },
+    { k: 'keepers', n: a.keepers, lbl: '주의 keeper', sev: 'warn', nav: 'monitoring' as const },
+    { k: 'dead', n: a.dead, lbl: '죽음·넘침', sev: 'bad', nav: 'monitoring' as const },
+    { k: 'stale', n: a.stale, lbl: 'stale 게이트', sev: 'warn', nav: 'connectors' as const },
+  ].filter((r) => r.n > 0)
+  const tone = a.approvals > 0 || a.dead > 0 ? 'bad' : 'warn'
+  return html`
+    <div class="attn-wrap" onClick=${(e: Event) => e.stopPropagation()}>
+      <button class=${`v2-statchip attn ${tone}`} onClick=${() => setOpen((o) => !o)} title="지금 나를 필요로 하는 것">
+        ${'⚑'} 주의 <b>${a.total}</b>
+      </button>
+      ${open
+        ? html`
+            <div class="attn-menu">
+              <div class="attn-menu-h">지금 나를 필요로 하는 것</div>
+              ${rows.map(
+                (r) => html`
+                  <button key=${r.k} class="attn-row" onClick=${() => { setOpen(false); navigate(r.nav) }}>
+                    <span class=${`dot2 ${r.sev}`}></span>
+                    <span class="attn-row-lbl">${r.lbl}</span>
+                    <span class="attn-row-n mono">${r.n}</span>
+                  </button>
+                `,
+              )}
+            </div>
+          `
+        : null}
+    </div>
+  `
+}
+
+export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
+  const tab = route.value.tab
+  const running = keepers.value.filter((k) => phaseStatus(k.lifecycle_phase) === 'run').length
+  const crumbKeeper = tab === 'keepers' ? route.value.params.keeper?.trim() || activeKeeperName.value || '' : ''
+  return html`
+    <div class="v2-top">
+      <div class="crumb">
+        <span class=${tab === 'keepers' && crumbKeeper ? '' : 'on'}>${surfaceLabel(tab)}</span>
+        ${tab === 'keepers' && crumbKeeper
+          ? html`<span>/</span><span class="on">${crumbKeeper}</span>`
+          : null}
+      </div>
+      <div class="v2-top-spacer"></div>
+      <span class="v2-statchip live"><${StatusDot} status="run" pulse=${true} />${running} 실행 중</span>
+      <${AttentionIndicatorV2} />
+      ${/* 예약(schedule): no live cron/schedule signal yet — see live-store-mapping §4.
+          Rendered as a navigable chip; data-stub marks the absent backend source. */ ''}
+      <button class="v2-statchip attn" data-stub="schedule" onClick=${() => navigate('schedule')} title="예약 자동화 큐 — 라이브 백엔드 신호 없음(표시용)">
+        ${'◷'} 예약 <b>정상</b>
+      </button>
+      <${CopilotDockTopBarButton} dock=${dock} />
+      <${TweaksPanelToggle} />
+    </div>
+  `
+}

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -405,7 +405,12 @@ describe('Work', () => {
           horizon: 'short',
           title: 'Goal needing approval',
           priority: 9,
-          status: 'verifying',
+          // 'active' status does not auto-expand on mount (work.ts:403 only
+          // auto-expands priority===1 / at_risk / verifying / blocked). A
+          // 'verifying' goal would start open, so the click below would CLOSE
+          // it and drop the .wk-vchip chips. approval pill is status-independent
+          // (driven by require_completion_approval), so it still renders.
+          status: 'active',
           phase: 'executing',
           require_completion_approval: true,
           verifier_policy: {

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -29,30 +29,31 @@ function isWorkSection(v: string | undefined): v is WorkSection {
 
 // ── Task state mapping ──────────────────────────────────────────────────────
 
-type JobStateKey = 'done' | 'wip' | 'review' | 'blocked' | 'todo'
+// Bucket = progress-aggregation axis (done/wip/verify/blocked/todo).
+// cls    = the prototype's CSS modifier on .wk-task-dot/.wk-task-state.
+// They differ on purpose: the vendored v2.css defines dot/state variants
+// `done|wip|verify|claimed|cancelled|todo` (v2.css:832-850) but NOT
+// `review` or `blocked`, so emitting the prototype's exact class names is
+// what gets the row styled. `claimed` keeps its own (info-blue) color
+// instead of folding into wip; `cancelled` keeps the struck-through grey.
+type JobBucket = 'done' | 'wip' | 'verify' | 'blocked' | 'todo'
+type JobStateCls = 'done' | 'wip' | 'verify' | 'claimed' | 'cancelled' | 'todo'
 
 interface JobState {
   label: string
-  cls: JobStateKey
-}
-
-const JOB_STATE: Record<JobStateKey, JobState> = {
-  done: { label: '완료', cls: 'done' },
-  wip: { label: '진행 중', cls: 'wip' },
-  review: { label: '검증 대기', cls: 'review' },
-  blocked: { label: '막힘', cls: 'blocked' },
-  todo: { label: '대기', cls: 'todo' },
+  bucket: JobBucket
+  cls: JobStateCls
 }
 
 function jobStateForTask(task: Task): JobState {
   switch (task.status) {
-    case 'done': return JOB_STATE.done
-    case 'in_progress':
-    case 'claimed': return JOB_STATE.wip
-    case 'awaiting_verification': return JOB_STATE.review
-    case 'cancelled': return JOB_STATE.blocked
+    case 'done': return { label: '완료', bucket: 'done', cls: 'done' }
+    case 'in_progress': return { label: '진행 중', bucket: 'wip', cls: 'wip' }
+    case 'claimed': return { label: '클레임', bucket: 'wip', cls: 'claimed' }
+    case 'awaiting_verification': return { label: '검증 대기', bucket: 'verify', cls: 'verify' }
+    case 'cancelled': return { label: '취소', bucket: 'blocked', cls: 'cancelled' }
     case 'todo':
-    default: return JOB_STATE.todo
+    default: return { label: '대기', bucket: 'todo', cls: 'todo' }
   }
 }
 
@@ -118,6 +119,15 @@ function goalStatusClass(status: string): 'ok' | 'warn' | 'bad' | 'volt' {
   return GOAL_STATUS_CLASS[status] ?? 'ok'
 }
 
+// Gate evidence outcome → Korean outcome word for the right-aligned
+// .wk-gate-out column. Mirrors the prototype GATE_OUTCOME map
+// (data.jsx:369): satisfied 충족 / missing 누락 / failed 실패.
+const GATE_OUTCOME_LABEL: Record<'satisfied' | 'missing' | 'failed', string> = {
+  satisfied: '충족',
+  missing: '누락',
+  failed: '실패',
+}
+
 // ── Goal horizon mapping ────────────────────────────────────────────────────
 
 interface HorizonMeta {
@@ -133,10 +143,6 @@ const HORIZON_META: HorizonMeta[] = [
   { key: 'mid', label: '중기', sub: '이번 분기' },
   LONG_HORIZON_META,
 ]
-
-function horizonMetaForGoal(goal: Goal): HorizonMeta {
-  return HORIZON_META.find(h => h.key === goal.horizon) ?? LONG_HORIZON_META
-}
 
 function horizonKeyForGoal(goal: Goal): Goal['horizon'] {
   return HORIZON_META.some(h => h.key === goal.horizon) ? goal.horizon : 'long'
@@ -195,11 +201,11 @@ function goalProgressCounts(goalTasks: Task[]): GoalProgressCounts {
   const counts: GoalProgressCounts = { done: 0, wip: 0, verify: 0, blocked: 0, total: goalTasks.length }
   for (const t of goalTasks) {
     if (t.status === 'cancelled') continue
-    const state = jobStateForTask(t).cls
-    if (state === 'done') counts.done++
-    else if (state === 'blocked') counts.blocked++
-    else if (state === 'review') counts.verify++
-    else if (state === 'wip') counts.wip++
+    const bucket = jobStateForTask(t).bucket
+    if (bucket === 'done') counts.done++
+    else if (bucket === 'blocked') counts.blocked++
+    else if (bucket === 'verify') counts.verify++
+    else if (bucket === 'wip') counts.wip++
   }
   return counts
 }
@@ -234,8 +240,8 @@ function TaskGate({ rows }: { rows: ReturnType<typeof taskGateRows> }) {
           <span class="wk-gate-mark">
             ${g.outcome === 'satisfied' ? '✓' : g.outcome === 'failed' ? '✕' : '○'}
           </span>
-          <span class="wk-gate-label mono">${g.label}</span>
-          <span class="wk-gate-detail">${g.detail}</span>
+          <span class="wk-gate-ev"><span class="mono">${g.label}</span> · ${g.detail}</span>
+          <span class="wk-gate-out">${GATE_OUTCOME_LABEL[g.outcome]}</span>
         </div>
       `)}
     </div>
@@ -326,17 +332,22 @@ function GoalCard({
 }) {
   const progress = goalProgressCounts(goalTasks)
   const lead = leadKeeperForGoal(goal)
-  const horizon = horizonMetaForGoal(goal)
-  const hasBlock = progress.blocked > 0
 
+  // Border tint by goal status (prototype .wk-goal.st-warn/.st-bad/.st-volt,
+  // v2.css:812-814): at_risk→amber, blocked→bad, verifying→volt. `st-ok`
+  // has no rule (neutral border) which matches the prototype default.
   return html`
-    <div class=${`wk-goal ss-card ${open ? 'open' : ''} ${hasBlock ? 'has-block' : ''}`} data-testid="goal-card" data-goal-id=${goal.id}>
+    <div class=${`wk-goal ${open ? 'open' : ''} st-${goalStatusClass(goal.status)}`} data-testid="goal-card" data-goal-id=${goal.id}>
       <button type="button" class="wk-goal-h" onClick=${onToggle} aria-expanded=${open}>
         <span class="wk-caret" aria-hidden="true">${open ? '\u25BE' : '\u25B8'}</span>
         <span class="wk-prio mono" title=${`우선순위 ${goal.priority}`}>P${goal.priority}</span>
         <span class=${`wk-gstatus ${goalStatusClass(goal.status)}`}>${goalStatusLabel(goal.status)}</span>
         <span class="wk-goal-title">${goal.title}</span>
-        <span class="wk-goal-ns mono">${horizon.label}</span>
+        <!-- Prototype shows a namespace pill (.wk-goal-ns) here from g.ns.
+             The live Goal type has no namespace/ns field (types/core.ts:603),
+             so rather than fake it with the redundant horizon label (the card
+             already sits under a horizon section header), the pill is dropped
+             until a backend namespace field exists. Audit workspace.md #3. -->
         <span class="wk-spacer"></span>
         ${goal.require_completion_approval || goal.active_verification_request_id
           ? html`<span class="wk-approval" title="완료 승인 필요">✓ 완료 승인</span>`
@@ -353,6 +364,7 @@ function GoalCard({
         <span class="wk-prog-lbl mono">
           ${progress.done}/${progress.total}${progress.verify > 0 ? ` · 검증 ${progress.verify}` : ''}${progress.blocked > 0 ? ` · 막힘 ${progress.blocked}` : ''}
         </span>
+        ${goal.phase ? html`<span class="wk-goal-phase mono" title="goal phase">${goal.phase}</span>` : null}
         ${goal.metric ? html`<span class="wk-metric mono" title="목표 지표">${goal.metric}</span>` : null}
       </div>
       ${open ? html`
@@ -383,7 +395,12 @@ function WorkSurfaceV2() {
       const next = new Set(prev)
       for (const g of goalList) {
         const progress = goalProgressCounts(allTasks.filter(t => t.goal_id === g.id))
-        if (g.priority === 1 || progress.blocked > 0) next.add(g.id)
+        // Prototype auto-expands attention goals (priority >= 7 || at_risk ||
+        // verifying, work.jsx:138). The live priority scale (1=top vs 9=top)
+        // is not confirmed against the backend, so the priority trigger is
+        // left as-is and only the unambiguous status triggers are aligned:
+        // at_risk / verifying / any blocked task. Audit workspace.md #7.
+        if (g.priority === 1 || g.status === 'at_risk' || g.status === 'verifying' || progress.blocked > 0) next.add(g.id)
       }
       return next
     })
@@ -452,14 +469,13 @@ function WorkSurfaceV2() {
   }, [goalList, claimedTasks])
 
   return html`
-    <main class="wk-surface ss-surface bg-surface-page text-text-primary">
-      <div class="wk-scroll">
-        <div class="wk-inner space-y-6">
-          <header class="wk-head">
+    <main class="ov">
+      <div class="ov-scroll">
+        <header class="ov-head">
             <div>
-              <span class="wk-eyebrow">Goal Store</span>
+              <span class="ov-eyebrow">Goal Store</span>
               <h1>작업 · 목표</h1>
-              <p class="wk-sub">Goal → Task → keeper · horizon으로 묶고 게이트 증거로 검증</p>
+              <p class="ov-sub">Goal → Task → keeper · horizon으로 묶고 게이트 증거로 검증</p>
             </div>
             <button
               type="button"
@@ -472,31 +488,31 @@ function WorkSurfaceV2() {
             </button>
           </header>
 
-          <section class="wk-kpis ss-card" data-testid="work-kpis" style=${{ gridTemplateColumns: 'repeat(5, 1fr)' }}>
-            <div class="wk-kpi">
-              <div class="wk-kpi-k">활성 목표</div>
-              <div class="wk-kpi-v volt" data-testid="kpi-goals">${totals.goals}</div>
+          <section class="ov-kpis" data-testid="work-kpis" style=${{ gridTemplateColumns: 'repeat(5, 1fr)' }}>
+            <div class="ov-kpi">
+              <div class="ov-kpi-k">활성 목표</div>
+              <div class="ov-kpi-v volt" data-testid="kpi-goals">${totals.goals}</div>
             </div>
-            <div class="wk-kpi">
-              <div class="wk-kpi-k">전체 Task</div>
-              <div class="wk-kpi-v" data-testid="kpi-tasks">${totals.tasks}</div>
+            <div class="ov-kpi">
+              <div class="ov-kpi-k">전체 Task</div>
+              <div class="ov-kpi-v" data-testid="kpi-tasks">${totals.tasks}</div>
             </div>
-            <div class="wk-kpi">
-              <div class="wk-kpi-k">진행 중</div>
-              <div class=${`wk-kpi-v ${totals.wip > 0 ? 'volt' : ''}`} data-testid="kpi-wip">${totals.wip}</div>
+            <div class="ov-kpi">
+              <div class="ov-kpi-k">진행 중</div>
+              <div class=${`ov-kpi-v ${totals.wip > 0 ? 'volt' : ''}`} data-testid="kpi-wip">${totals.wip}</div>
             </div>
-            <div class="wk-kpi">
-              <div class="wk-kpi-k">검증 대기</div>
-              <div class=${`wk-kpi-v ${totals.verify > 0 ? 'warn' : ''}`} data-testid="kpi-verify">${totals.verify}</div>
+            <div class="ov-kpi">
+              <div class="ov-kpi-k">검증 대기</div>
+              <div class=${`ov-kpi-v ${totals.verify > 0 ? 'volt' : ''}`} data-testid="kpi-verify">${totals.verify}</div>
             </div>
-            <div class="wk-kpi">
-              <div class="wk-kpi-k">백로그</div>
-              <div class=${`wk-kpi-v ${totals.backlog > 0 ? 'warn' : ''}`} data-testid="kpi-backlog">${totals.backlog}</div>
+            <div class="ov-kpi">
+              <div class="ov-kpi-k">백로그</div>
+              <div class=${`ov-kpi-v ${totals.backlog > 0 ? 'warn' : ''}`} data-testid="kpi-backlog">${totals.backlog}</div>
             </div>
           </section>
 
           ${backlogTasks.length > 0 ? html`
-            <section class="wk-backlog ss-card mx-6" data-testid="work-backlog">
+            <section class="wk-backlog" data-testid="work-backlog">
               <div class="wk-backlog-h">
                 <span class="wk-backlog-glyph" aria-hidden="true">⊕</span>
                 클레임 가능 백로그
@@ -520,33 +536,29 @@ function WorkSurfaceV2() {
             </section>
           ` : null}
 
-          <div class="wk-horizons px-6">
-            ${horizonGroups.map(group => html`
-              <section class="wk-horizon" data-testid="work-horizon" data-horizon=${group.key}>
-                <div class="wk-hz-head">
-                  <span class="wk-hz-lbl">${group.label}</span>
-                  <span class="wk-hz-sub">${group.sub}</span>
-                  <span class="wk-spacer"></span>
-                  <span class="wk-hz-n mono">${group.goals.length} goals</span>
-                </div>
-                <div class="wk-list">
-                  ${group.goals.map(g => html`
-                    <${GoalCard}
-                      key=${g.id}
-                      goal=${g}
-                      open=${openSet.has(g.id)}
-                      onToggle=${() => toggleGoal(g.id)}
-                      goalTasks=${tasksByGoalId.get(g.id) ?? []}
-                      onClaim=${claimTask}
-                    />
-                  `)}
-                </div>
-              </section>
-            `)}
-          </div>
+          ${horizonGroups.map(group => html`
+            <div class="wk-horizon" data-testid="work-horizon" data-horizon=${group.key}>
+              <div class="wk-hz-head">
+                <span class="wk-hz-lbl">${group.label}</span>
+                <span class="wk-hz-sub">${group.sub}</span>
+                <span class="wk-hz-n mono">${group.goals.length}</span>
+              </div>
+              <div class="wk-list">
+                ${group.goals.map(g => html`
+                  <${GoalCard}
+                    key=${g.id}
+                    goal=${g}
+                    open=${openSet.has(g.id)}
+                    onToggle=${() => toggleGoal(g.id)}
+                    goalTasks=${tasksByGoalId.get(g.id) ?? []}
+                    onClaim=${claimTask}
+                  />
+                `)}
+              </div>
+            </div>
+          `)}
 
           <div class="wk-foot mono">Goal → Task → keeper · horizon(단기·중기·장기) · 완료는 게이트 증거 충족 후 done · 미배정 task 는 백로그에서 claim</div>
-        </div>
       </div>
     </main>
   `

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -78,6 +78,30 @@ import './styles/ss-keeper-v2-bridge.css'
 // v2 rule overrides its v1 counterpart (.gd-board, .mg-board, .ide-plane-shell).
 import.meta.glob('./styles/*-v2.css', { eager: true })
 
+// ── keeper-v2 prototype CSS — the SSOT skin (big-bang v2 reskin) ──
+// Vendored verbatim from the design prototype (keeper-v2/styles/*), loaded
+// LAST so the prototype's shell/skin classes (.v2-top/.v2-body/.v2-nav/.kp-row
+// /.thread/.bubble/.ctx-*/.ov-*) win over any legacy *-v2.css drift on shared
+// names. Load order is the prototype's <link> order (notes/css-map.md): tokens
+// → v2 (shell+chat) → surfaces → per-surface overrides; craft.css after v2 so
+// density rules win. As surfaces migrate to prototype DOM, the legacy CSS above
+// is removed (final cleanup PR). Fonts: Google Fonts via index.html + the
+// @import at the top of colors_and_type.css (the local 9.9MB ttf is not bundled).
+import './styles/keeper-v2/colors_and_type.css'
+import './styles/keeper-v2/v2.css'
+import './styles/keeper-v2/surfaces.css'
+import './styles/keeper-v2/dock.css'
+import './styles/keeper-v2/craft.css'
+import './styles/keeper-v2/inspector.css'
+import './styles/keeper-v2/perf.css'
+import './styles/keeper-v2/fleet.css'
+import './styles/keeper-v2/logs.css'
+import './styles/keeper-v2/keeper-config.css'
+import './styles/keeper-v2/fusion.css'
+import './styles/keeper-v2/memory.css'
+import './styles/keeper-v2/schedule.css'
+import './styles/keeper-v2/runtime.css'
+
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { App } from './app'

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -102,6 +102,20 @@ import './styles/keeper-v2/memory.css'
 import './styles/keeper-v2/schedule.css'
 import './styles/keeper-v2/runtime.css'
 
+// ── CSS SSOT removal scope (PR #22081 review P1) ──
+// `styles/craft-v2.css` (loaded via the *-v2.css glob above) is NOT yet removable:
+// it is the sole owner of rules the vendored keeper-v2 CSS does not cover, all keyed
+// to LIVE dashboard classes (keeper-v2/craft.css targets design-only .thread/.bubble
+// /.roster-list that the live DOM never renders, so it cannot replace these):
+//   1. `--twk-font-scale` var + `.v2-app[data-font-scale]` font-size calc (app.ts:275)
+//   2. `.v2-app[data-density]` → `.kw-*` workspace density + scrollbar rules
+//   3. `.v2-app[data-bubble='flat'] .chat-bubble` (live class; keeper-v2 targets .bubble)
+//   4. `.twk-panel` / `.twk-*` tweaks-panel UI
+// Removal plan (follow-up): migrate (1)-(4) into keeper-v2/* retargeted to the live
+// classes, verify craft-v2.test.ts + app.test.ts green after each step, then delete
+// craft-v2.css and drop it from the glob. Until then keeper-v2 loads LAST (wins on
+// shared selectors); craft-v2.css supplies only the unique rules above — no
+// live-selector conflict, so single-ownership holds per selector today.
 import { render } from 'preact'
 import { html } from 'htm/preact'
 import { App } from './app'

--- a/dashboard/src/styles/keeper-v2/colors_and_type.css
+++ b/dashboard/src/styles/keeper-v2/colors_and_type.css
@@ -1,0 +1,446 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC — Colors & Type
+   The brand runs across 4 themes (Dark Fantasy / Cyberpunk /
+   Terminal / Parchment) but Dark Fantasy is the canonical voice.
+   This file defines the Dark Fantasy tokens as :root defaults and
+   offers the other three as [data-theme] overrides, plus the
+   Paper/Ink dashboard inversion (used as the docs/light surface).
+   ══════════════════════════════════════════════════════════════ */
+
+/* Fonts — all families fetched from Google Fonts (woff2, subset).
+   The prototype shipped a local 9.9MB NotoSansKR ttf + Cinzel ttf; those are
+   not vendored into the dashboard bundle (binary-in-git + bundle bloat). The
+   default v2 skin uses Space Grotesk (display) + Noto Sans KR (ui/body) +
+   JetBrains Mono; Cinzel/EB Garamond/Share Tech Mono back the non-default
+   dark-fantasy/terminal themes. index.html also <link>s these for early load. */
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Noto+Sans+KR:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;700&family=Cinzel:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,600;1,400&family=Share+Tech+Mono&display=swap');
+
+/* ── Dark Fantasy (default) — Visceral · decay-forward ── */
+:root,
+[data-theme="dark-fantasy"] {
+  /* Base surfaces — wet stone, blood-soaked wood */
+  --bg-deep:        #0a0706;     /* pitch with a red undertone */
+  --bg-panel:       #14100d;     /* rotted wood */
+  --bg-panel-alt:   #1b1612;     /* card base */
+  --bg-card:        #221815;     /* bruised meat */
+  --bg-card-hover:  #2e211c;
+
+  /* Borders — scabbed, stitched leather */
+  --border-main:      #2a1a14;
+  --border-highlight: #5a3028;   /* scab / raw wound */
+
+  /* Text — bone and bandage */
+  --text-bright:  #e8d8b8;       /* clean bone */
+  --text-primary: #b8a488;       /* dirty bandage */
+  --text-dim:     #6a5848;       /* mold dust */
+
+  /* Accents — blood is primary now; brass demoted to warning */
+  --accent-blood:    #a01818;    /* fresh arterial */
+  --accent-blood-dim:#5a0f0f;    /* dried clot */
+  --accent-viscera:  #c94a3a;    /* raw flesh / inflamed */
+  --accent-bile:     #6a7a3a;    /* sickly yellow-green */
+  --accent-mold:     #3a5a48;    /* cold mold */
+  --accent-brass:    #8a6a28;    /* tarnished gold, rare */
+  --accent-brass-dim:#5a4618;
+  --accent-bone:     #d8c8a0;
+  --accent-ink:      #3a2a5a;    /* arcane violet, rarer */
+  --accent-ember:    #c4461a;    /* dying ember */
+  --accent-glow:     rgba(160, 24, 24, 0.28);
+  --accent-blood-glow: rgba(201, 74, 58, 0.32);
+
+  /* Status — blood, bile, mold */
+  --status-ok:    #5a7a3a;       /* bile / queasy green */
+  --status-warn:  #a06a1a;       /* burnt ember */
+  --status-bad:   #a01818;       /* blood */
+  --status-idle:  #4a3a32;       /* dried mold */
+
+  /* Type stacks */
+  --font-display: 'Cinzel', 'Noto Sans KR', 'EB Garamond', serif;
+  --font-body:    'EB Garamond', 'Noto Sans KR', Georgia, serif;
+  --font-ui:      'Noto Sans KR', 'IBM Plex Sans KR', -apple-system, sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, Menlo, Consolas, monospace;
+
+  /* Shape */
+  --radius-xs:   2px;
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:   12px;
+  --radius-pill: 999px;
+
+  /* Shadows */
+  --shadow-panel:  0 2px 12px rgba(0, 0, 0, 0.6);
+  --shadow-card:   0 1px 4px rgba(0, 0, 0, 0.5);
+  --shadow-raised: 0 8px 24px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--border-highlight);
+  --shadow-glow:   0 0 20px var(--accent-glow);
+  --shadow-inset:  inset 0 0 0 1px rgba(196, 162, 101, 0.25);
+
+  /* Spacing (4px grid) */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  24px;
+  --space-6:  32px;
+  --space-7:  48px;
+  --space-8:  64px;
+
+  /* Scrollbar */
+  --scrollbar-thumb:       #2a1f1a;
+  --scrollbar-thumb-hover: #3d2e22;
+}
+
+/* ── Cyberpunk ─────────────────────────────────────────── */
+[data-theme="cyberpunk"] {
+  --bg-deep:      #05000f;
+  --bg-panel:     #0d0821;
+  --bg-panel-alt: #130e2a;
+  --bg-card:      #1a1235;
+  --bg-card-hover:#221a42;
+  --border-main:      #2a1a4a;
+  --border-highlight: #6a2fd6;
+  --text-bright:  #f5f0ff;
+  --text-primary: #e0d4ff;
+  --text-dim:     #6a5d8d;
+  --accent-brass: #00ffcc;
+  --accent-brass-dim: #008866;
+  --accent-blood: #ff2266;
+  --accent-ink:   #6a2fd6;
+  --accent-glow:  rgba(0, 255, 204, 0.12);
+  --status-ok:   #00ffcc;
+  --status-warn: #ffaa00;
+  --status-bad:  #ff2266;
+  --font-display: 'Share Tech Mono', 'Noto Sans KR', monospace;
+  --font-body:    'Noto Sans KR', sans-serif;
+  --font-ui:      'Share Tech Mono', 'Noto Sans KR', monospace;
+  --radius-xs: 0; --radius-sm: 0; --radius-md: 0;
+  --shadow-panel: 0 0 16px rgba(106, 47, 214, 0.3);
+  --shadow-glow:  0 0 24px rgba(0, 255, 204, 0.2), 0 0 48px rgba(0, 255, 204, 0.05);
+}
+
+/* ── Terminal ──────────────────────────────────────────── */
+[data-theme="terminal"] {
+  --bg-deep:      #000800;
+  --bg-panel:     #001200;
+  --bg-panel-alt: #001a00;
+  --bg-card:      #002200;
+  --bg-card-hover:#003000;
+  --border-main:      #0a3a0a;
+  --border-highlight: #00aa00;
+  --text-bright:  #00ff00;
+  --text-primary: #00cc00;
+  --text-dim:     #006600;
+  --accent-brass: #00ff00;
+  --accent-brass-dim: #009900;
+  --accent-blood: #ffcc00;
+  --accent-ink:   #00aaaa;
+  --accent-glow:  rgba(0, 255, 0, 0.08);
+  --status-ok:   #00ff00;
+  --status-warn: #ffcc00;
+  --status-bad:  #ff4400;
+  --font-display: 'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-body:    'JetBrains Mono', 'Noto Sans KR', monospace;
+  --font-ui:      'JetBrains Mono', 'Noto Sans KR', monospace;
+  --radius-xs: 0; --radius-sm: 0; --radius-md: 0;
+  --shadow-panel: 0 0 8px rgba(0, 255, 0, 0.1);
+  --shadow-glow:  0 0 16px rgba(0, 255, 0, 0.15);
+}
+
+/* ── Parchment (in-app warm theme) ─────────────────────── */
+[data-theme="parchment"] {
+  --bg-deep:      #1a1610;
+  --bg-panel:     #241f18;
+  --bg-panel-alt: #2e2820;
+  --bg-card:      #332d24;
+  --bg-card-hover:#3d362c;
+  --border-main:      #4a3f30;
+  --border-highlight: #6a5d48;
+  --text-bright:  #f0e4cc;
+  --text-primary: #d4c4a0;
+  --text-dim:     #8a7d68;
+  --accent-brass: #c4a050;
+  --accent-brass-dim: #8a7035;
+  --accent-blood: #8b4513;
+  --accent-ink:   #556b2f;
+  --accent-glow:  rgba(196, 160, 80, 0.1);
+}
+
+/* ── Paper / Ink (docs + light-surface inversion) ──────── */
+[data-theme="paper"] {
+  color-scheme: light;
+  --paper:   #F5F2EA;
+  --paper-2: #EFEBE0;
+  --paper-3: #E5E0D1;
+  --paper-4: #D8D2BF;
+  --ink:     #151515;
+  --ink-2:   #2E2E2C;
+  --ink-3:   #515049;
+  --ink-4:   #74726A;
+  --ink-5:   #9A978D;
+  --ink-6:   #BCB8AC;
+
+  --forest:  #2D5F4E;  --forest-fill:#CFDFD7;
+  --brass:   #8C6A1E;  --brass-fill: #E9DDB8;
+  --brick:   #8B3A3A;  --brick-fill: #E8CFCB;
+  --ember:   #B35A1F;  --ember-fill: #ECD5BD;
+  --slate:   #3E4A5C;  --slate-fill: #D6DBE2;
+  --plum:    #5C3E56;  --plum-fill:  #E0D4DE;
+  --teal:    #236874;  --teal-fill:  #CEDEE2;
+
+  --bg-deep:      var(--paper);
+  --bg-panel:     var(--paper-2);
+  --bg-panel-alt: var(--paper-3);
+  --bg-card:      var(--paper-2);
+  --bg-card-hover:var(--paper-3);
+  --border-main:      rgba(21,21,21,0.22);
+  --border-highlight: rgba(21,21,21,0.48);
+  --text-bright:  var(--ink);
+  --text-primary: var(--ink-2);
+  --text-dim:     var(--ink-4);
+  --accent-brass: var(--brass);
+  --accent-brass-dim: var(--brass-fill);
+  --accent-blood: var(--brick);
+  --accent-ink:   var(--slate);
+  --accent-glow:  rgba(140,106,30,0.12);
+  --status-ok:   var(--forest);
+  --status-warn: var(--ember);
+  --status-bad:  var(--brick);
+  --status-idle: var(--ink-5);
+  --shadow-panel: 0 1px 2px rgba(0,0,0,0.06), 0 0 0 1px rgba(0,0,0,0.06);
+  --shadow-card:  0 1px 0 rgba(0,0,0,0.04);
+  --shadow-glow:  none;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   SEMANTIC ELEMENT DEFAULTS
+   Opinionated tags so a bare HTML file looks like MASC.
+   ══════════════════════════════════════════════════════════════ */
+
+html, body {
+  background: var(--bg-deep);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2, h3, h4, .display {
+  font-family: var(--font-display);
+  color: var(--text-bright);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 400;
+  margin: 0;
+}
+
+h1 { font-size: 42px; letter-spacing: 0.2em; text-shadow: 0 0 40px var(--accent-glow); }
+h2 { font-size: 24px; letter-spacing: 0.14em; color: var(--accent-brass); }
+h3 { font-size: 16px; letter-spacing: 0.12em; color: var(--accent-brass); }
+h4 { font-size: 13px; letter-spacing: 0.1em;  color: var(--text-primary); }
+
+p, li { font-family: var(--font-body); color: var(--text-primary); }
+
+.overline, .eyebrow {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+code, pre, .mono, .tabular-nums {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+
+a { color: var(--accent-brass); text-decoration: none; border-bottom: 1px dotted var(--accent-brass-dim); }
+a:hover { color: var(--text-bright); border-bottom-color: var(--text-bright); }
+
+hr {
+  border: 0;
+  border-top: 1px solid var(--border-main);
+  margin: var(--space-5) 0;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   UTILITY PRIMITIVES
+   Minimal set used by preview cards & UI kit. Components live in
+   ui_kits/, not here.
+   ══════════════════════════════════════════════════════════════ */
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-card);
+}
+
+.panel {
+  background: var(--bg-panel);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  box-shadow: var(--shadow-panel);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill);
+  background: var(--bg-panel-alt);
+  color: var(--text-dim);
+}
+.pill.ok    { color: var(--status-ok);   border-color: color-mix(in oklab, var(--status-ok)   40%, transparent); }
+.pill.warn  { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); }
+.pill.bad   { color: var(--status-bad);  border-color: color-mix(in oklab, var(--status-bad)  40%, transparent); }
+.pill.brass { color: var(--accent-brass);border-color: color-mix(in oklab, var(--accent-brass)40%, transparent); }
+
+.btn {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  border: 1px solid var(--border-main);
+  background: var(--bg-panel-alt);
+  color: var(--text-primary);
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: border-color 0.18s, color 0.18s, background 0.18s, transform 0.08s;
+}
+.btn:hover { border-color: var(--accent-brass-dim); color: var(--accent-brass); }
+.btn:active { transform: translateY(1px); }
+.btn.primary {
+  border-color: var(--accent-brass);
+  color: var(--accent-brass);
+  box-shadow: var(--shadow-inset);
+}
+.btn.primary:hover { background: var(--accent-glow); color: var(--text-bright); }
+.btn.ghost { background: transparent; }
+
+.input {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  padding: 6px 10px;
+  background: var(--bg-panel-alt);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-xs);
+  color: var(--text-primary);
+}
+.input:focus { outline: none; border-color: var(--accent-brass-dim); }
+
+.dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; background: var(--text-dim); }
+.dot.ok   { background: var(--status-ok);   box-shadow: 0 0 6px var(--status-ok); }
+.dot.warn { background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
+.dot.bad  { background: var(--status-bad);  box-shadow: 0 0 6px var(--status-bad); }
+
+/* ══════════════════════════════════════════════════════════════
+   TEXTURES — parchment grain, blood, wax, scratches
+   Apply via `.tex-parchment`, `.tex-blood`, `.tex-wax`, `.tex-scratch`.
+   They're SVG-data-URI backgrounds that layer on top of any surface.
+   ══════════════════════════════════════════════════════════════ */
+.tex-parchment {
+  background-image:
+    radial-gradient(ellipse at 20% 15%, rgba(255,230,180,0.04), transparent 50%),
+    radial-gradient(ellipse at 80% 85%, rgba(90,40,10,0.08), transparent 55%),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='220' height='220'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' seed='7'/><feColorMatrix values='0 0 0 0 0.1  0 0 0 0 0.08  0 0 0 0 0.06  0 0 0 0.55 0'/></filter><rect width='100%25' height='100%25' filter='url%28%23n%29' opacity='0.35'/></svg>");
+  background-blend-mode: multiply, multiply, normal;
+}
+.tex-blood {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='360' height='360' viewBox='0 0 360 360'><g fill='%23a01818' opacity='0.55'><ellipse cx='48' cy='36' rx='14' ry='5' transform='rotate(-12 48 36)'/><path d='M52 40c2 8-1 18-6 22-4-6-3-16 6-22Z'/><ellipse cx='230' cy='180' rx='22' ry='8'/><path d='M240 188c3 12-1 30-10 34-6-10-5-24 10-34Z'/><circle cx='300' cy='80' r='3'/><circle cx='310' cy='90' r='2'/><circle cx='120' cy='300' r='4'/><circle cx='130' cy='310' r='2'/><ellipse cx='150' cy='260' rx='10' ry='4' transform='rotate(25 150 260)'/></g></svg>");
+  background-size: 360px 360px;
+}
+.tex-wax {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='300' height='300'><g fill='%23e8d8b0' opacity='0.35'><path d='M40 20c6 18-4 30-12 30 4-12 0-22 12-30Z'/><circle cx='28' cy='52' r='4'/><circle cx='36' cy='58' r='3'/><path d='M220 160c8 22-6 40-14 38 2-14 0-28 14-38Z'/><circle cx='208' cy='200' r='5'/></g></svg>");
+  background-size: 300px 300px;
+}
+.tex-scratch {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><g stroke='%23e8d8b0' stroke-opacity='0.07' stroke-width='0.6' fill='none'><path d='M0 80 L400 60'/><path d='M40 0 L80 400'/><path d='M0 240 L400 260'/><path d='M200 0 L240 400'/><path d='M0 340 L400 320'/><path d='M320 0 L340 400'/></g></svg>");
+}
+.tex-mold {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='340' height='340'><g opacity='0.55'><circle cx='40' cy='60' r='18' fill='%233a5a48' opacity='0.4'/><circle cx='50' cy='70' r='10' fill='%236a7a3a' opacity='0.35'/><circle cx='260' cy='120' r='24' fill='%233a5a48' opacity='0.35'/><circle cx='270' cy='130' r='12' fill='%236a7a3a' opacity='0.3'/><circle cx='150' cy='280' r='20' fill='%233a5a48' opacity='0.3'/><circle cx='80' cy='220' r='14' fill='%236a7a3a' opacity='0.3'/><circle cx='310' cy='260' r='16' fill='%233a5a48' opacity='0.35'/></g></svg>");
+  background-size: 340px 340px;
+  filter: blur(1.5px);
+}
+.tex-viscera {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><g fill='none' stroke='%23a01818' stroke-opacity='0.4' stroke-width='1.4'><path d='M40 60c20 0 20 20 10 30s-30 10-20 30 40 5 40 25 -30 15 -40 30'/><path d='M260 140c20 0 25 25 10 35s-40 10-30 35 45 10 45 30'/><path d='M120 300c25-5 40 10 30 25s-30 10-40 30'/></g></svg>");
+  background-size: 400px 400px;
+  opacity: 0.85;
+}
+.tex-noise {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.2' numOctaves='2' seed='3'/><feColorMatrix values='0 0 0 0 0.9  0 0 0 0 0.85  0 0 0 0 0.7  0 0 0 0.05 0'/></filter><rect width='100%25' height='100%25' filter='url%28%23n%29'/></svg>");
+}
+
+/* ══════════════════════════════════════════════════════════════
+   GOTHIC FRAMES — corner tabs, arch, sarcophagus
+   Wrap any element with .frame-gothic to get corner carvings.
+   ══════════════════════════════════════════════════════════════ */
+.frame-gothic {
+  position: relative;
+  border: 1px solid var(--border-highlight);
+  box-shadow: var(--shadow-inset), var(--shadow-panel);
+}
+.frame-gothic::before,
+.frame-gothic::after {
+  content: ""; position: absolute; width: 14px; height: 14px;
+  border: 1px solid var(--accent-brass); pointer-events: none;
+}
+.frame-gothic::before { top: -1px; left: -1px; border-right: 0; border-bottom: 0; }
+.frame-gothic::after  { bottom: -1px; right: -1px; border-left: 0; border-top: 0; }
+
+.frame-arch {
+  position: relative;
+  border: 1px solid var(--accent-brass-dim);
+  border-radius: 120px 120px 2px 2px / 60px 60px 2px 2px;
+  padding: 28px 20px 16px;
+  background: var(--bg-card);
+}
+.frame-arch::before {
+  content: ""; position: absolute; inset: 6px; border: 1px solid var(--border-highlight);
+  border-radius: inherit; pointer-events: none;
+}
+
+.frame-sarc {
+  position: relative;
+  border: 1px solid var(--border-highlight);
+  clip-path: polygon(
+    12px 0, calc(100% - 12px) 0, 100% 12px,
+    100% calc(100% - 12px), calc(100% - 12px) 100%,
+    12px 100%, 0 calc(100% - 12px), 0 12px
+  );
+  background: var(--bg-card);
+}
+
+/* Glyph usage: <svg class="gl"><use href=".../atlas.svg#skull"/></svg> */
+.gl { width: 16px; height: 16px; display: inline-block; vertical-align: -3px; color: currentColor; }
+.gl-lg { width: 24px; height: 24px; vertical-align: -6px; }
+.gl-xl { width: 40px; height: 40px; }
+.gl-brass { color: var(--accent-brass); }
+.gl-blood { color: var(--accent-blood); }
+.gl-bone  { color: var(--accent-bone); }
+
+/* Drop cap for gothic body text */
+.dropcap::first-letter {
+  font-family: var(--font-display);
+  float: left; font-size: 54px; line-height: 0.9;
+  padding: 6px 10px 0 0; color: var(--accent-blood);
+  text-shadow: 0 0 24px var(--accent-blood-glow);
+}
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb, var(--border-main)); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover, var(--border-highlight)); }

--- a/dashboard/src/styles/keeper-v2/craft.css
+++ b/dashboard/src/styles/keeper-v2/craft.css
@@ -1,0 +1,306 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Craft layer
+   Loaded LAST. A polish pass over the existing skin: one breathing
+   rhythm (density), one motion system (press / lift / focus / entrance),
+   and consistency fixes across every surface. Purely additive —
+   nothing here invents new color or type, it only refines spacing,
+   interaction and finish on top of v2.css / surfaces.css.
+
+   Three taste axes are exposed as Tweaks and driven by attributes on
+   .v2-app:  data-density (spacious|regular|compact),
+             data-motion  (lively|subtle|off),
+             data-bubble  (card|flat).
+   ══════════════════════════════════════════════════════════════ */
+
+/* ── Motion + lift tokens ─────────────────────────────────────── */
+[data-skin="v2"] {
+  --ease-out:    cubic-bezier(0.22, 0.61, 0.36, 1);
+  --ease-spring: cubic-bezier(0.34, 1.32, 0.5, 1);
+  --dur-fast: 110ms;
+  --dur:      170ms;
+  --dur-slow: 260ms;
+  --lift:  -2px;   /* card hover rise */
+  --press:  1px;   /* button press sink */
+}
+
+/* ══════════════════════════════════════════════════════════════
+   1 · DENSITY — one breathing rhythm, three steps
+   The semantic spacing tokens already feed most surfaces; override
+   them per density, then top up the spots that still carry literals.
+   ══════════════════════════════════════════════════════════════ */
+.v2-app[data-density="spacious"] {
+  --pad-surface: 32px 42px 60px;
+  --pad-card:    16px 18px;
+  --gap-card:    18px;
+  --gap-row:     11px;
+}
+.v2-app[data-density="regular"] {
+  --pad-surface: 22px 26px 40px;
+  --pad-card:    12px 14px;
+  --gap-card:    14px;
+  --gap-row:     8px;
+}
+.v2-app[data-density="compact"] {
+  --pad-surface: 15px 18px 30px;
+  --pad-card:    9px 11px;
+  --gap-card:    10px;
+  --gap-row:     6px;
+}
+
+/* ── Chat console — spacious (the headline surface) ── */
+.v2-app[data-density="spacious"] .chat-head   { padding: 18px 28px 16px; gap: 16px; }
+.v2-app[data-density="spacious"] .thread      { padding: 34px 0 14px; }
+.v2-app[data-density="spacious"] .thread-inner{ gap: 30px; padding: 0 40px; }
+.v2-app[data-density="spacious"] .msg         { gap: 15px; }
+.v2-app[data-density="spacious"] .bubble      { padding: 17px 21px; line-height: 1.7; }
+.v2-app[data-density="spacious"] .composer    { padding: 16px 30px 22px; }
+.v2-app[data-density="spacious"] .ctx-scroll  { padding: 20px; gap: 22px; }
+.v2-app[data-density="spacious"] .ctx-card,
+.v2-app[data-density="spacious"] .tps-card    { padding: 14px 15px; }
+.v2-app[data-density="spacious"] .roster-head { padding: 15px 14px; }
+.v2-app[data-density="spacious"] .roster-list { padding: 9px 8px; }
+.v2-app[data-density="spacious"] .kp-row      { padding: 11px 11px; }
+.v2-app[data-density="spacious"] .roster-filters { padding: 12px 14px; }
+
+/* ── Board — spacious ── */
+.v2-app[data-density="spacious"] .bd-feed-head    { padding: 15px 24px; }
+.v2-app[data-density="spacious"] .bd-list         { padding: 20px 24px; gap: 14px; }
+.v2-app[data-density="spacious"] .bd-rail         { padding: 18px 12px; }
+.v2-app[data-density="spacious"] .bd-composer     { padding: 14px 24px 18px; }
+.v2-app[data-density="spacious"] .bd-detail-h     { padding: 16px 18px; }
+.v2-app[data-density="spacious"] .bd-detail-scroll{ padding: 18px; gap: 14px; }
+
+/* ── Settings — spacious ── */
+.v2-app[data-density="spacious"] .settings-surf .set-card-b { padding: 12px 40px 56px; }
+.v2-app[data-density="spacious"] .set-content-h { padding: 26px 40px 18px; }
+.v2-app[data-density="spacious"] .set-row       { padding: 16px 0; }
+.v2-app[data-density="spacious"] .set-nav-item  { padding: 11px 13px; }
+
+/* ── Chat console — compact (tighten what regular leaves) ── */
+.v2-app[data-density="compact"] .thread        { padding: 14px 0 6px; }
+.v2-app[data-density="compact"] .thread-inner  { gap: 14px; padding: 0 22px; }
+.v2-app[data-density="compact"] .chat-head     { padding: 10px 16px 9px; }
+.v2-app[data-density="compact"] .composer      { padding: 9px 18px 12px; }
+.v2-app[data-density="compact"] .ctx-scroll    { padding: 11px; gap: 12px; }
+.v2-app[data-density="compact"] .bd-list       { padding: 11px 14px; gap: 8px; }
+.v2-app[data-density="compact"] .set-row       { padding: 10px 0; }
+
+/* ══════════════════════════════════════════════════════════════
+   2 · MOTION — press, hover lift, focus ring, entrance
+   Base rules below are the "subtle" tier. [data-motion="lively"]
+   amplifies; [data-motion="off"] removes all of it (and is implied
+   for reduced-motion users).
+   ══════════════════════════════════════════════════════════════ */
+
+/* Consistent transitions on every interactive control. */
+.v2-app .act, .v2-app .send, .v2-app .rfilter, .v2-app .bd-filter,
+.v2-app .bd-sub, .v2-app .log-f, .v2-app .set-verify, .v2-app .set-seg-b,
+.v2-app .cp-mode, .v2-app .fbk-btn, .v2-app .chip, .v2-app .tps-range,
+.v2-app .set-add, .v2-app .ctool, .v2-app .nav-item, .v2-app .turn-tab,
+.v2-app .bd-react, .v2-app .bd-comp-tab, .v2-app .cn-config,
+.v2-app .set-stepper button, .v2-app .turn-close, .v2-app .rail-toggle,
+.v2-app .topbar-copilot, .v2-app .dock-fab {
+  transition: background var(--dur) var(--ease-out),
+              border-color var(--dur) var(--ease-out),
+              color var(--dur) var(--ease-out),
+              box-shadow var(--dur) var(--ease-out),
+              transform var(--dur-fast) var(--ease-out);
+}
+
+/* Press — every button sinks 1px on active (brand: translateY press). */
+.v2-app[data-motion]:not([data-motion="off"]) .act:active,
+.v2-app[data-motion]:not([data-motion="off"]) .send:not(:disabled):active,
+.v2-app[data-motion]:not([data-motion="off"]) .rfilter:active,
+.v2-app[data-motion]:not([data-motion="off"]) .bd-filter:active,
+.v2-app[data-motion]:not([data-motion="off"]) .bd-sub:active,
+.v2-app[data-motion]:not([data-motion="off"]) .log-f:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-verify:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-seg-b:active,
+.v2-app[data-motion]:not([data-motion="off"]) .cp-mode:active,
+.v2-app[data-motion]:not([data-motion="off"]) .fbk-btn:active,
+.v2-app[data-motion]:not([data-motion="off"]) .chip:active,
+.v2-app[data-motion]:not([data-motion="off"]) .tps-range:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-add:active,
+.v2-app[data-motion]:not([data-motion="off"]) .ctool:active,
+.v2-app[data-motion]:not([data-motion="off"]) .bd-react:active,
+.v2-app[data-motion]:not([data-motion="off"]) .turn-tab:active,
+.v2-app[data-motion]:not([data-motion="off"]) .cn-config:active,
+.v2-app[data-motion]:not([data-motion="off"]) .topbar-copilot:active,
+.v2-app[data-motion]:not([data-motion="off"]) .set-nav-item:active {
+  transform: translateY(var(--press));
+}
+
+/* Hover lift on genuine cards (not list rows). */
+.v2-app .ov-keeper, .v2-app .cp-route, .v2-app .cp-mode,
+.v2-app .cn-card, .v2-app .bd-post {
+  transition: background var(--dur) var(--ease-out),
+              border-color var(--dur) var(--ease-out),
+              box-shadow var(--dur) var(--ease-out),
+              transform var(--dur) var(--ease-out);
+}
+.v2-app[data-motion]:not([data-motion="off"]) .ov-keeper:hover,
+.v2-app[data-motion]:not([data-motion="off"]) .cp-route:hover,
+.v2-app[data-motion]:not([data-motion="off"]) .cn-card:hover {
+  transform: translateY(var(--lift));
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--volt-wash);
+}
+.v2-app[data-motion]:not([data-motion="off"]) .bd-post:hover {
+  transform: translateY(var(--lift));
+  box-shadow: 0 5px 16px rgba(0, 0, 0, 0.38);
+}
+
+/* Avatar / sigil micro-zoom on the keeper rows + board authors. */
+.v2-app .kp-av, .v2-app .roster .sigil { transition: transform var(--dur) var(--ease-out); }
+.v2-app[data-motion="lively"] .kp-row:hover .kp-av,
+.v2-app[data-motion="lively"] .kp-row:hover .sigil { transform: scale(1.06); }
+
+/* Keyboard focus ring — one brass halo everywhere, mouse clicks stay clean. */
+.v2-app a:focus-visible,
+.v2-app button:focus-visible,
+.v2-app [role="button"]:focus-visible,
+.v2-app [tabindex]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-deep), 0 0 0 4px var(--volt-dim);
+  border-radius: var(--radius-sm);
+}
+.v2-app textarea:focus-visible,
+.v2-app input:focus-visible { outline: none; }
+
+/* Message entrance is intentionally omitted: a backgrounded iframe freezes
+   the animation clock on frame 0, so any keyframe that starts at opacity:0
+   would hold content hidden. Content visibility must never depend on an
+   animation running — the press/hover/focus polish below carries the craft. */
+
+/* Trace / tool body reveal a touch smoother (render on click → foreground). */
+.v2-app .reason-detail, .v2-app .tool-body2 {
+  animation: fade-soft var(--dur) var(--ease-out);
+}
+@keyframes fade-soft { from { opacity: 0; } to { opacity: 1; } }
+
+/* ── LIVELY tier — bolder lifts, glow on the primary action, sheen ── */
+.v2-app[data-motion="lively"] { --lift: -3px; }
+.v2-app[data-motion="lively"] .ov-keeper:hover,
+.v2-app[data-motion="lively"] .cp-route:hover,
+.v2-app[data-motion="lively"] .cn-card:hover,
+.v2-app[data-motion="lively"] .bd-post:hover {
+  transition-timing-function: var(--ease-spring);
+}
+.v2-app[data-motion="lively"] .send:not(:disabled):hover {
+  box-shadow: 0 0 22px var(--volt-glow), 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+.v2-app[data-motion="lively"] .nav-item:hover { transform: translateY(-1px); }
+.v2-app[data-motion="lively"] .chip:hover { transform: translateY(-2px); }
+
+/* ── OFF tier — kill every transition & animation (also reduced-motion) ── */
+.v2-app[data-motion="off"] *,
+.v2-app[data-motion="off"] *::before,
+.v2-app[data-motion="off"] *::after {
+  transition: none !important;
+  animation: none !important;
+}
+@media (prefers-reduced-motion: reduce) {
+  .v2-app *, .v2-app *::before, .v2-app *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   3 · MESSAGE STYLE — card (default) vs flat (document-like)
+   Flat strips the assistant bubble chrome so long answers read as
+   a clean document; the user message keeps a quiet brass spine so
+   the conversation still has two clear voices.
+   ══════════════════════════════════════════════════════════════ */
+.v2-app[data-bubble="flat"] .bubble {
+  background: transparent;
+  border-color: transparent;
+  border-radius: 0;
+  padding: 2px 0 0;
+}
+.v2-app[data-bubble="flat"] .bubble.user {
+  background: transparent;
+  border: 0;
+  border-left: 2px solid var(--volt-dim);
+  border-radius: 0;
+  padding: 2px 0 2px 16px;
+}
+.v2-app[data-bubble="flat"] .bubble code,
+.v2-app[data-bubble="flat"] .bubble .md-table,
+.v2-app[data-bubble="flat"] .bubble .callout {
+  /* nested chrome stays — only the outer shell flattens */
+}
+.v2-app[data-bubble="flat"] .msg.from-user .bubble.user {
+  border-left: 0;
+  border-right: 2px solid var(--volt-dim);
+  padding: 2px 16px 2px 0;
+  text-align: left;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   4 · CONSISTENCY — scrollbars, hairlines, small finish fixes
+   ══════════════════════════════════════════════════════════════ */
+
+/* One scrollbar treatment across every scroll region. */
+.v2-app .thread::-webkit-scrollbar,
+.v2-app .ctx-scroll::-webkit-scrollbar,
+.v2-app .roster-list::-webkit-scrollbar,
+.v2-app .set-content::-webkit-scrollbar,
+.v2-app .set-nav::-webkit-scrollbar,
+.v2-app .bd-list::-webkit-scrollbar,
+.v2-app .bd-detail-scroll::-webkit-scrollbar,
+.v2-app .bd-rail::-webkit-scrollbar,
+.v2-app .log-stream::-webkit-scrollbar,
+.v2-app .turn-body::-webkit-scrollbar {
+  width: 10px;
+}
+.v2-app .thread::-webkit-scrollbar-thumb,
+.v2-app .ctx-scroll::-webkit-scrollbar-thumb,
+.v2-app .roster-list::-webkit-scrollbar-thumb,
+.v2-app .set-content::-webkit-scrollbar-thumb,
+.v2-app .set-nav::-webkit-scrollbar-thumb,
+.v2-app .bd-list::-webkit-scrollbar-thumb,
+.v2-app .bd-detail-scroll::-webkit-scrollbar-thumb,
+.v2-app .bd-rail::-webkit-scrollbar-thumb,
+.v2-app .log-stream::-webkit-scrollbar-thumb,
+.v2-app .turn-body::-webkit-scrollbar-thumb {
+  background: var(--border-main);
+  border-radius: var(--radius-md);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  transition: background var(--dur);
+}
+.v2-app .thread::-webkit-scrollbar-thumb:hover,
+.v2-app .ctx-scroll::-webkit-scrollbar-thumb:hover,
+.v2-app .roster-list::-webkit-scrollbar-thumb:hover,
+.v2-app .set-content::-webkit-scrollbar-thumb:hover,
+.v2-app .bd-list::-webkit-scrollbar-thumb:hover,
+.v2-app .bd-detail-scroll::-webkit-scrollbar-thumb:hover {
+  background: var(--border-highlight);
+  background-clip: padding-box;
+}
+.v2-app * { scrollbar-width: thin; scrollbar-color: var(--border-main) transparent; }
+
+/* Composer hairline lifts to brass on focus (matches board composer). */
+.v2-app .composer-box.focus { box-shadow: 0 0 0 3px var(--volt-wash); }
+
+/* Roster search + every text input share the same focus halo. */
+.v2-app .set-input:focus,
+.v2-app .roster-search:focus,
+.v2-app .cn-be-chn:focus,
+.v2-app .kc-text:focus {
+  box-shadow: 0 0 0 2px var(--volt-wash);
+}
+
+/* Section headers keep an even baseline rhythm in the context rail. */
+.v2-app .ctx-sec + .ctx-sec { margin-top: 2px; }
+
+/* Top-bar stat chips: quiet hover so they don't look dead next to live data. */
+.v2-app .v2-statchip { transition: border-color var(--dur), color var(--dur); }
+
+/* Disabled send reads clearly inert. */
+.v2-app .send:disabled { transform: none; }
+
+/* Compaction-snapshot trigger: let the "before/after 보기" sub-label drop to
+   its own right-aligned line instead of crushing the label into a wrap. */
+.v2-app .cmp-open { flex-wrap: wrap; align-items: baseline; row-gap: 3px; }
+.v2-app .cmp-open-sub { margin-left: auto; }

--- a/dashboard/src/styles/keeper-v2/dock.css
+++ b/dashboard/src/styles/keeper-v2/dock.css
@@ -1,0 +1,198 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Copilot Dock
+   A global, co-view conversation panel. Toggleable from anywhere
+   (top-bar button · FAB · ⌘J), dockable to the right OR floating,
+   keeper-pickable, streaming, and bound to each surface's structured
+   context ("we're both looking at this screen"). Uses the v2 token
+   system + type ladder — no new colors.
+   ══════════════════════════════════════════════════════════════ */
+
+/* stage wrapper: lets the docked panel push the body */
+.v2-stage { flex: 1; min-height: 0; display: flex; }
+.v2-stage > .v2-body { flex: 1; min-width: 0; }
+
+/* ── shell ── */
+.dock {
+  display: flex; flex-direction: column; min-height: 0;
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 72%);
+  color: var(--text-primary);
+}
+.dock.docked {
+  width: var(--dock-w, 372px); flex: none;
+  border-left: 1px solid var(--border-main);
+}
+.dock.float {
+  position: fixed; z-index: 60;
+  width: 384px; height: min(78vh, 600px);
+  border: 1px solid var(--border-highlight);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-pop);
+  overflow: hidden;
+}
+
+/* ── header ── */
+.dock-head {
+  flex: none; display: flex; align-items: center; gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  border-bottom: 1px solid var(--border-main); background: var(--bg-panel);
+}
+.dock-head.drag { cursor: grab; user-select: none; }
+.dock-head.drag:active { cursor: grabbing; }
+.dock-title {
+  display: flex; align-items: center; gap: var(--sp-2);
+  font-family: var(--font-display); font-weight: 600; font-size: 13px;
+  letter-spacing: 0.02em; color: var(--text-bright);
+}
+.dock-spark { width: 16px; height: 16px; color: var(--volt-strong); }
+.dock-head .spacer { flex: 1; }
+.dock-iconbtn {
+  width: 28px; height: 28px; display: flex; align-items: center; justify-content: center;
+  border-radius: var(--radius-sm); border: 1px solid transparent; background: transparent;
+  color: var(--text-dim); cursor: pointer; transition: 0.14s; font-size: 13px;
+}
+.dock-iconbtn:hover { color: var(--text-bright); background: var(--bg-card); }
+
+/* ── identity row (keeper picker) ── */
+.dock-idrow { flex: none; display: flex; align-items: center; gap: var(--sp-3); padding: var(--sp-3) var(--sp-4) 0; }
+.dock-picker { position: relative; flex: none; }
+.dock-picker-btn {
+  display: flex; align-items: center; gap: var(--sp-2);
+  padding: 3px 9px 3px 3px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main); background: var(--bg-card); cursor: pointer; transition: 0.14s;
+}
+.dock-picker-btn:hover { border-color: var(--border-highlight); }
+.dock-picker-btn .nm { font-size: 11.5px; color: var(--text-bright); font-weight: 600; white-space: nowrap; }
+.dock-picker-btn .cv { color: var(--text-dim); font-size: 9px; }
+.dock-idrow-hint { font-size: 10.5px; color: var(--text-dim); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dock-idrow-hint .mono { font-family: var(--font-mono); color: var(--text-mid); }
+
+.dock-menu {
+  position: absolute; top: calc(100% + 6px); left: 0; width: 256px; max-height: 318px; overflow-y: auto;
+  background: var(--bg-panel); border: 1px solid var(--border-highlight);
+  border-radius: var(--radius-md); box-shadow: var(--shadow-pop); z-index: 8; padding: 5px;
+}
+.dock-menu-row { display: flex; align-items: center; gap: var(--sp-3); padding: 7px 8px; border-radius: var(--radius-sm); cursor: pointer; transition: 0.12s; }
+.dock-menu-row:hover { background: var(--bg-card); }
+.dock-menu-row.on { background: var(--bg-card); box-shadow: inset 0 0 0 1px var(--volt-wash); }
+.dock-menu-row .minfo { min-width: 0; flex: 1; }
+.dock-menu-row .nm { font-size: 12px; color: var(--text-bright); font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dock-menu-row .nm .h { color: var(--text-dim); font-weight: 400; font-size: 10px; }
+.dock-menu-row .sub { display: flex; align-items: center; gap: 5px; font-size: 10px; color: var(--text-dim); font-family: var(--font-mono); margin-top: 2px; }
+
+/* ── co-view context card ── */
+.dock-coview {
+  flex: none; margin: var(--sp-4) var(--sp-4) 0; padding: var(--sp-3) var(--sp-4);
+  border: 1px solid var(--border-soft); border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--info) 6%, var(--bg-sunken));
+}
+.dock-coview-h { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: var(--sp-2); }
+.dock-coview-h .lbl { font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--info); font-weight: 600; }
+.dock-coview-h .route { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+.dock-coview .scene { font-size: 12.5px; color: var(--text-bright); font-weight: 600; margin-bottom: var(--sp-2); }
+.dock-coview-fields { display: flex; flex-wrap: wrap; gap: 5px; }
+.dock-field {
+  display: inline-flex; align-items: center; gap: 5px; white-space: nowrap;
+  font-family: var(--font-mono); font-size: 10px; padding: 2px 7px;
+  border-radius: var(--radius-pill); border: 1px solid var(--border-main);
+  background: var(--bg-deep); color: var(--text-mid);
+}
+.dock-field .k { color: var(--text-dim); }
+.dock-field.bad .v  { color: var(--status-bad); }
+.dock-field.warn .v { color: var(--status-warn); }
+.dock-field.volt .v { color: var(--volt-strong); }
+.dock-coview .sync { display: flex; align-items: center; gap: 5px; margin-top: var(--sp-2); font-size: 9.5px; color: var(--text-dim); }
+.dock-coview .sync .d { width: 5px; height: 5px; border-radius: 50%; background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); animation: dot-pulse 2s ease-in-out infinite; }
+
+/* ── thread ── */
+.dock-thread { flex: 1; overflow-y: auto; padding: var(--sp-4); display: flex; flex-direction: column; gap: var(--sp-4); }
+.dock-thread::-webkit-scrollbar { width: 8px; }
+.dock-thread::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
+.dock-empty { margin: auto; text-align: center; color: var(--text-dim); padding: var(--sp-5) var(--sp-3); display: flex; flex-direction: column; gap: var(--sp-3); align-items: center; }
+.dock-empty .ico { font-size: 24px; opacity: 0.5; color: var(--info); }
+.dock-empty .t { font-family: var(--font-display); font-size: 12.5px; color: var(--text-mid); letter-spacing: 0.03em; }
+.dock-empty .s { font-size: 11.5px; line-height: 1.6; max-width: 250px; }
+
+.dmsg { display: grid; grid-template-columns: 26px 1fr; gap: var(--sp-3); }
+.dmsg.user { grid-template-columns: 1fr 26px; }
+.dmsg.user .dmsg-col { order: 0; }
+.dmsg.user .dmsg-av { order: 1; }
+.dmsg-av.op { width: 26px; height: 26px; display: flex; align-items: center; justify-content: center; border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: 9px; color: var(--volt-ink); background: var(--volt); }
+.dmsg-col { min-width: 0; }
+.dmsg.user .dmsg-hd { justify-content: flex-end; }
+.dmsg-hd { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
+.dmsg-hd .who { font-family: var(--font-display); font-weight: 600; font-size: 11px; color: var(--text-bright); }
+.dmsg-hd .ts { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); }
+.dbubble {
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  border-radius: 3px var(--radius-md) var(--radius-md) var(--radius-md);
+  padding: var(--sp-3) var(--sp-4); font-size: 12.5px; line-height: 1.6; color: var(--text-primary);
+}
+.dmsg.user .dbubble { background: var(--volt-wash); border-color: var(--volt-dim); border-radius: var(--radius-md) 3px var(--radius-md) var(--radius-md); color: var(--text-bright); }
+.dbubble p { margin: 0 0 7px; }
+.dbubble p:last-child { margin-bottom: 0; }
+.dbubble code { font-family: var(--font-mono); font-size: 11px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 0 4px; border-radius: var(--radius-xs); color: var(--volt-strong); }
+.dbubble strong { color: var(--text-bright); font-weight: 600; }
+.dcaret { display: inline-block; width: 7px; height: 13px; background: var(--volt); margin-left: 2px; vertical-align: -2px; animation: dcaret 1s steps(2) infinite; }
+@keyframes dcaret { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+
+/* ── suggestions (mini) ── */
+.dsug { display: flex; flex-direction: column; gap: 5px; margin-top: var(--sp-3); }
+.dsug button {
+  text-align: left; font-family: var(--font-ui); font-size: 11.5px; line-height: 1.3;
+  padding: 6px 10px; border-radius: var(--radius-sm); border: 1px solid var(--border-main);
+  background: var(--bg-card); color: var(--text-primary); cursor: pointer; transition: 0.14s;
+}
+.dsug button:hover { border-color: var(--volt); color: var(--text-bright); background: var(--bg-card-hover); }
+.dsug button .pre { color: var(--volt); margin-right: 6px; }
+
+/* ── composer ── */
+.dock-composer { flex: none; padding: var(--sp-3) var(--sp-4) var(--sp-4); border-top: 1px solid var(--border-main); background: var(--bg-panel); }
+.dock-comp-box {
+  display: flex; align-items: flex-end; gap: var(--sp-2);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  border-radius: var(--radius-md); padding: 5px 5px 5px var(--sp-4); transition: 0.15s;
+}
+.dock-comp-box.focus { border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); }
+.dock-comp-box textarea { flex: 1; resize: none; border: 0; outline: 0; background: transparent; color: var(--text-bright); font-family: var(--font-ui); font-size: 12.5px; line-height: 1.5; padding: 7px 0; max-height: 120px; min-height: 20px; }
+.dock-comp-box textarea::placeholder { color: var(--text-dim); }
+.dock-send { width: 30px; height: 30px; flex: none; border-radius: var(--radius-sm); border: 1px solid var(--volt); background: var(--volt); color: var(--volt-ink); cursor: pointer; display: flex; align-items: center; justify-content: center; font-size: 14px; transition: 0.14s; }
+.dock-send:hover:not(:disabled) { background: var(--volt-strong); box-shadow: 0 0 14px var(--volt-glow); }
+.dock-send:disabled { opacity: 0.4; cursor: default; }
+.dock-foot { display: flex; align-items: center; gap: var(--sp-3); margin-top: 7px; font-size: 10px; color: var(--text-dim); }
+.dock-foot b { color: var(--volt-strong); font-family: var(--font-mono); font-weight: 600; }
+.dock-foot kbd { font-family: var(--font-mono); font-size: 9px; background: var(--bg-card); border: 1px solid var(--border-main); border-bottom-width: 2px; border-radius: var(--radius-xs); padding: 1px 4px; color: var(--text-mid); }
+
+/* ── triggers: FAB + top-bar button ── */
+.dock-fab {
+  position: fixed; right: 22px; bottom: 22px; z-index: 55;
+  height: 44px; padding: 0 16px; display: flex; align-items: center; gap: var(--sp-2);
+  border-radius: var(--radius-pill); border: 1px solid var(--volt);
+  background: var(--volt); color: var(--volt-ink);
+  font-family: var(--font-ui); font-weight: 600; font-size: 12.5px; cursor: pointer;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.4), 0 0 18px var(--volt-glow); transition: 0.16s;
+}
+.dock-fab:hover { background: var(--volt-strong); transform: translateY(-1px); }
+.dock-fab .spark { width: 17px; height: 17px; }
+.dock-fab kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 5px; border-radius: var(--radius-xs); background: color-mix(in oklab, var(--volt-ink) 16%, transparent); }
+
+.topbar-copilot {
+  display: flex; align-items: center; gap: 7px; height: 30px; padding: 0 10px;
+  border-radius: var(--radius-pill); border: 1px solid var(--border-main);
+  background: var(--bg-panel-alt); color: var(--text-mid); cursor: pointer;
+  font-family: var(--font-ui); font-size: 11px; transition: 0.14s; white-space: nowrap;
+}
+.topbar-copilot:hover { border-color: var(--volt-dim); color: var(--volt-strong); }
+.topbar-copilot.on { border-color: var(--volt); color: var(--volt-strong); background: var(--volt-wash); }
+.topbar-copilot .spark { width: 14px; height: 14px; }
+.topbar-copilot kbd { font-family: var(--font-mono); font-size: 9px; padding: 1px 4px; border-radius: var(--radius-xs); background: var(--bg-card); border: 1px solid var(--border-main); color: var(--text-dim); }
+
+/* The Keepers surface IS a chat — a floating co-view "Chat" FAB there is
+   redundant and overlaps the composer's send button. Hide it on Keepers. */
+.v2-app[data-surface="keepers"] .dock-fab { display: none; }
+
+@media (max-width: 1180px) {
+  .dock.docked { width: 320px; }
+}
+@media (max-width: 860px) {
+  .dock.docked { position: fixed; right: 0; top: 50px; bottom: 0; width: 320px; z-index: 60; box-shadow: var(--shadow-pop); }
+}

--- a/dashboard/src/styles/keeper-v2/fleet.css
+++ b/dashboard/src/styles/keeper-v2/fleet.css
@@ -1,0 +1,243 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Keeper Fleet (monitoring / agents) — improved roster.
+   Tokens from colors_and_type.css + v2.css. Loads after them.
+   Design goal: kill the "every row is identical" wall — make state,
+   identity and pressure scannable down a single column edge.
+   ══════════════════════════════════════════════════════════════ */
+
+/* shell + global nav rail (rail styles come from v2.css .v2-nav) */
+.fl-root { display: flex; flex-direction: row; height: 100%; min-height: 0; }
+
+.fl-shell {
+  height: 100%; box-sizing: border-box;
+  min-width: 0; min-height: 0; flex: 1;
+  display: flex; flex-direction: column;
+  background:
+    radial-gradient(ellipse at 18% 0%, color-mix(in oklab, var(--volt) 5%, transparent), transparent 55%),
+    var(--bg-deep);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  /* shared roster column track — header + rows + group dividers align to this */
+  --fl-cols: minmax(196px, 1.3fr) 184px 140px minmax(108px, 1fr) 128px;
+  --fl-gap: 14px;
+}
+
+/* ── top bar ── */
+.fl-top {
+  flex: none; display: flex; align-items: center; gap: 18px;
+  padding: 0 22px; height: 58px;
+  border-bottom: 1px solid var(--border-main);
+  background: var(--bg-panel);
+}
+.fl-brand { display: flex; flex-direction: column; justify-content: center; gap: 1px; flex: none; }
+.fl-brand .ov-eyebrow { margin-bottom: 0; }
+.fl-crumb { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); white-space: nowrap; }
+.fl-title { font-family: var(--font-display); font-weight: 600; font-size: 18px; letter-spacing: -0.005em; color: var(--text-bright); white-space: nowrap; }
+.fl-health { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.fl-hpill {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-size: 11.5px; color: var(--text-mid);
+  padding: 5px 11px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border-main); background: var(--bg-card);
+  white-space: nowrap;
+}
+.fl-hpill b { font-family: var(--font-mono); font-weight: 600; color: var(--text-bright); }
+.fl-hpill.ok b { color: var(--status-ok); }
+.fl-hpill.warn b { color: var(--status-warn); }
+.fl-hpill.bad { border-color: color-mix(in oklab, var(--status-bad) 38%, transparent); background: color-mix(in oklab, var(--status-bad) 10%, var(--bg-card)); color: var(--status-bad); }
+.fl-hpill.bad b { color: var(--status-bad); }
+.fl-spacer { flex: 1; }
+.fl-meta { display: flex; align-items: center; gap: 14px; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
+.fl-meta .live { color: var(--status-ok); }
+
+/* ── body: roster + aside ── */
+.fl-body { flex: 1; min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) 372px; }
+.fl-main { min-width: 0; display: flex; flex-direction: column; overflow: hidden; }
+
+/* roster header */
+.fl-rhead {
+  flex: none; display: grid; align-items: center;
+  grid-template-columns: var(--fl-cols);
+  gap: var(--fl-gap);
+  padding: 12px 22px 11px calc(22px + 3px);
+  border-bottom: 1px solid var(--border-main);
+}
+.fl-rhead span { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); font-weight: 600; }
+.fl-rhead .r { text-align: right; }
+
+.fl-roster { flex: 1; min-height: 0; overflow-y: auto; padding-bottom: 8px; }
+
+/* group divider (attention vs steady) */
+.fl-group {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 22px 7px;
+  font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim);
+}
+.fl-group::after { content: ""; flex: 1; height: 1px; background: var(--border-soft); }
+.fl-group.attn { color: var(--status-warn); }
+
+/* ── roster row — the core fix ── */
+.fl-row {
+  position: relative; display: grid; align-items: center;
+  grid-template-columns: var(--fl-cols);
+  gap: var(--fl-gap);
+  padding: 11px 22px 11px calc(22px + 3px);
+  border-bottom: 1px solid var(--border-soft);
+  cursor: pointer; transition: background 0.15s;
+  text-align: left; width: 100%; background: transparent; border-left: none; font: inherit; color: inherit;
+}
+.fl-row::before {  /* the scannable tone rail */
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px;
+  background: var(--rail, var(--border-highlight));
+}
+.fl-row[data-tone="ok"]   { --rail: var(--status-ok); }
+.fl-row[data-tone="warn"] { --rail: var(--status-warn); }
+.fl-row[data-tone="bad"]  { --rail: var(--status-bad); }
+.fl-row[data-tone="busy"] { --rail: var(--info); }
+.fl-row[data-tone="idle"] { --rail: color-mix(in oklab, var(--text-dim) 50%, transparent); }
+.fl-row:hover { background: var(--bg-card); }
+.fl-row.sel { background: var(--bg-card-hover); }
+.fl-row.sel::after {
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--volt) 32%, transparent);
+}
+
+/* identity cell */
+.fl-id { display: flex; align-items: center; gap: 11px; min-width: 0; }
+.fl-id-txt { min-width: 0; }
+.fl-name { display: flex; align-items: center; gap: 8px; }
+.fl-name b { font-family: var(--font-display); font-weight: 600; font-size: 14.5px; color: var(--text-bright); white-space: nowrap; }
+.fl-att {
+  display: inline-flex; align-items: center; gap: 4px; flex: none;
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600;
+  color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 13%, transparent);
+  border: 1px solid color-mix(in oklab, var(--status-bad) 34%, transparent);
+  padding: 0 6px; border-radius: var(--radius-pill);
+}
+.fl-ns { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); margin-top: 3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* state cell */
+.fl-state { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.fl-chip {
+  display: inline-flex; align-items: center; gap: 6px; align-self: flex-start;
+  font-size: 11px; letter-spacing: 0.03em; white-space: nowrap;
+  padding: 3px 9px; border-radius: var(--radius-pill);
+  border: 1px solid var(--chip-bd, var(--border-main));
+  color: var(--chip-fg, var(--text-mid)); background: var(--chip-bg, var(--bg-card));
+}
+.fl-chip[data-tone="ok"]   { --chip-fg: var(--status-ok);   --chip-bd: color-mix(in oklab, var(--status-ok) 42%, transparent);   --chip-bg: color-mix(in oklab, var(--status-ok) 11%, var(--bg-card)); }
+.fl-chip[data-tone="warn"] { --chip-fg: var(--status-warn); --chip-bd: color-mix(in oklab, var(--status-warn) 42%, transparent); --chip-bg: color-mix(in oklab, var(--status-warn) 10%, var(--bg-card)); }
+.fl-chip[data-tone="bad"]  { --chip-fg: var(--status-bad);  --chip-bd: color-mix(in oklab, var(--status-bad) 40%, transparent);  --chip-bg: color-mix(in oklab, var(--status-bad) 11%, var(--bg-card)); }
+.fl-chip[data-tone="busy"] { --chip-fg: var(--info);        --chip-bd: color-mix(in oklab, var(--info) 40%, transparent);        --chip-bg: color-mix(in oklab, var(--info) 10%, var(--bg-card)); }
+.fl-chip[data-tone="idle"] { --chip-fg: var(--text-dim);    --chip-bd: var(--border-main); --chip-bg: var(--bg-card); }
+.fl-gloss { font-size: 10.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* context cell */
+.fl-ctx { display: flex; align-items: center; gap: 9px; }
+.fl-ctx-bar { flex: 1; height: 5px; border-radius: var(--radius-pill); background: var(--bg-sunken); border: 1px solid var(--border-soft); overflow: hidden; }
+.fl-ctx-bar > span { display: block; height: 100%; background: linear-gradient(90deg, var(--volt-dim), var(--volt)); }
+.fl-ctx-bar > span.hot { background: linear-gradient(90deg, var(--status-warn), var(--status-bad)); }
+.fl-ctx-val { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); flex: none; width: 34px; text-align: right; }
+.fl-ctx-val.hot { color: var(--status-bad); }
+.fl-ctx-val.zero { color: var(--text-dim); }
+
+/* last tool cell */
+.fl-tool { font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fl-tool.none { color: var(--text-dim); }
+
+/* actions — hidden until row hover/selected, so 30 buttons stop shouting */
+.fl-actcell { display: flex; align-items: center; justify-content: flex-end; gap: 7px; min-width: 0; }
+/* chat entry — always visible: the persistent path into the conversation console */
+.fl-chat {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 26px; flex: none;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in oklab, var(--volt) 34%, var(--border-main));
+  background: var(--volt-wash); color: var(--volt-strong);
+  cursor: pointer; transition: 0.14s; text-decoration: none;
+}
+.fl-chat:hover { border-color: var(--volt); background: color-mix(in oklab, var(--volt) 16%, transparent); color: var(--volt-strong); }
+.fl-actions { display: flex; justify-content: flex-end; gap: 5px; opacity: 0; transition: opacity 0.14s; }
+.fl-row:hover .fl-actions, .fl-row.sel .fl-actions { opacity: 1; }
+.fl-act {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; flex: none;
+  border-radius: var(--radius-sm); border: 1px solid var(--border-main);
+  background: var(--bg-panel-alt); color: var(--text-mid); cursor: pointer;
+  font-size: 12px; line-height: 1; transition: 0.14s;
+}
+.fl-act:hover { border-color: var(--volt-dim); color: var(--volt-strong); background: var(--volt-wash); }
+.fl-act.danger:hover { border-color: color-mix(in oklab, var(--status-bad) 50%, transparent); color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
+.fl-act.none { opacity: 0.3; pointer-events: none; }
+
+/* ── aside: selected runtime detail ── */
+.fl-aside { border-left: 1px solid var(--border-main); background: var(--bg-panel); display: flex; flex-direction: column; min-height: 0; overflow-y: auto; }
+.fl-as-head { display: flex; align-items: center; justify-content: space-between; padding: 16px 20px 0; }
+.fl-as-ey { font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+.fl-as-state { display: inline-flex; align-items: center; gap: 7px; font-size: 11px; color: var(--text-mid); }
+.fl-as-id { display: flex; align-items: center; gap: 13px; padding: 12px 20px 16px; border-bottom: 1px solid var(--border-soft); }
+.fl-as-name { font-family: var(--font-display); font-weight: 600; font-size: 22px; color: var(--text-bright); line-height: 1.1; }
+.fl-as-kr { font-size: 11px; color: var(--text-dim); margin-top: 4px; }
+
+/* primary CTA — the clear path from monitoring into the conversation console */
+.fl-as-cta { padding: 14px 20px; border-bottom: 1px solid var(--border-soft); }
+.fl-open-chat {
+  display: flex; align-items: center; gap: 10px; width: 100%; box-sizing: border-box;
+  font-family: var(--font-ui); font-size: 13px; font-weight: 500; color: var(--volt-strong);
+  padding: 11px 14px; border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in oklab, var(--volt) 40%, var(--border-main));
+  background: var(--volt-wash); cursor: pointer; transition: 0.16s; text-decoration: none;
+}
+.fl-open-chat:hover { border-color: var(--volt); background: color-mix(in oklab, var(--volt) 15%, transparent); }
+.fl-open-chat .arr { margin-left: auto; font-family: var(--font-mono); color: var(--volt); }
+.fl-as-sec { padding: 15px 20px; border-bottom: 1px solid var(--border-soft); }
+.fl-as-sec h4 { margin: 0 0 11px; font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); font-weight: 600; }
+.fl-as-phase { display: flex; align-items: center; gap: 10px; }
+.fl-as-gloss { font-size: 11.5px; color: var(--text-mid); margin-top: 9px; line-height: 1.5; text-wrap: pretty; }
+.fl-ctxbig { margin-top: 4px; }
+.fl-ctxbig-top { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 7px; }
+.fl-ctxbig-top .v { font-family: var(--font-mono); font-size: 18px; color: var(--volt-strong); }
+.fl-ctxbig-top .v.hot { color: var(--status-bad); }
+.fl-ctxbig-top .l { font-size: 10px; color: var(--text-dim); }
+.fl-ctxbig .bar { height: 7px; border-radius: var(--radius-pill); background: var(--bg-sunken); border: 1px solid var(--border-soft); overflow: hidden; }
+.fl-ctxbig .bar > span { display: block; height: 100%; background: linear-gradient(90deg, var(--volt-dim), var(--volt)); }
+.fl-ctxbig .bar > span.hot { background: linear-gradient(90deg, var(--status-warn), var(--status-bad)); }
+
+.fl-vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.fl-vital { background: var(--bg-card); padding: 9px 11px; }
+.fl-vital .k { font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); }
+.fl-vital .v { font-family: var(--font-mono); font-size: 14px; color: var(--text-bright); margin-top: 3px; }
+
+.fl-tools { display: flex; flex-direction: column; gap: 6px; }
+.fl-toolrow { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); }
+.fl-toolrow .tl { font-size: 9px; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-xs); padding: 1px 4px; flex: none; }
+
+.fl-actbar { display: flex; flex-wrap: wrap; gap: 8px; }
+.fl-btn {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-family: var(--font-ui); font-size: 12px; color: var(--text-bright);
+  padding: 8px 14px; border-radius: var(--radius-sm);
+  border: 1px solid var(--border-main); background: var(--bg-card); cursor: pointer; transition: 0.16s;
+}
+.fl-btn:hover { border-color: var(--volt-dim); color: var(--volt-strong); background: var(--volt-wash); }
+.fl-btn .g { font-size: 13px; }
+.fl-btn.danger:hover { border-color: color-mix(in oklab, var(--status-bad) 50%, transparent); color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
+.fl-btn.busy { opacity: 0.6; pointer-events: none; }
+.fl-noact { font-size: 11.5px; color: var(--text-dim); font-style: italic; }
+
+/* ── foot ticker — slim ambient pulse ── */
+.fl-foot {
+  flex: none; display: flex; align-items: center; gap: 22px;
+  padding: 0 22px; height: 36px;
+  border-top: 1px solid var(--border-main); background: var(--bg-panel);
+}
+.fl-tick { display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.fl-tick .k { letter-spacing: 0.1em; text-transform: uppercase; }
+.fl-tick .v { color: var(--text-mid); }
+.fl-tick .v.ok { color: var(--status-ok); }
+.fl-tick .v.warn { color: var(--status-warn); }
+
+@media (max-width: 1100px) {
+  .fl-body { grid-template-columns: 1fr; }
+  .fl-aside { display: none; }
+}

--- a/dashboard/src/styles/keeper-v2/fusion.css
+++ b/dashboard/src/styles/keeper-v2/fusion.css
@@ -1,0 +1,231 @@
+/* ════════════════════════════════════════════════════════════════
+   FUSION — RFC-0252 panel+judge 심의 가시화
+   Master (run list) + detail (deliberation canvas). v2 tokens only.
+   ════════════════════════════════════════════════════════════════ */
+.fus { background: var(--bg-deep); }
+.fus-body { display: grid; grid-template-columns: 312px minmax(0, 1fr); flex: 1; min-height: 0; }
+
+/* ── run dot ── */
+.fus-rdot { flex: none; width: 9px; height: 9px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-size: 7px; color: var(--bg-deep); }
+.fus-rdot.done { background: var(--status-ok); }
+.fus-rdot.deny { background: var(--status-bad); color: #fff; font-size: 8px; }
+.fus-rdot.run  { background: var(--volt); box-shadow: 0 0 0 0 var(--volt-glow); animation: fus-pulse 1.5s ease-out infinite; }
+@keyframes fus-pulse { 0% { box-shadow: 0 0 0 0 var(--volt-glow); } 70% { box-shadow: 0 0 0 6px transparent; } 100% { box-shadow: 0 0 0 0 transparent; } }
+
+/* ════ MASTER LIST ════ */
+.fus-list { display: flex; flex-direction: column; min-height: 0; border-right: 1px solid var(--border-main); background: var(--bg-panel); }
+.fus-list-h { display: flex; align-items: center; gap: 9px; padding: 16px 16px 12px; border-bottom: 1px solid var(--border-soft); }
+.fus-list-h h4 { font-family: var(--font-display); font-weight: 500; font-size: 14px; color: var(--text-bright); margin: 0; }
+.fus-list-sub { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.08em; color: var(--text-dim); text-transform: uppercase; }
+.fus-list-live { margin-left: auto; display: inline-flex; align-items: center; gap: 5px; font-size: 10px; color: var(--volt-strong); }
+.fus-list-scroll { flex: 1; overflow-y: auto; padding: 8px; display: flex; flex-direction: column; gap: 7px; }
+.fus-list-scroll::-webkit-scrollbar { width: 8px; }
+.fus-list-scroll::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
+
+.fus-row { text-align: left; background: var(--bg-card); border: 1px solid var(--border-soft); border-radius: var(--radius-md); padding: 10px 11px; cursor: pointer; transition: border-color 0.14s, background 0.14s; display: flex; flex-direction: column; gap: 7px; }
+.fus-row:hover { border-color: var(--border-highlight); }
+.fus-row.sel { border-color: var(--volt-dim); background: var(--bg-card-hover); box-shadow: inset 2px 0 0 var(--volt); }
+.fus-row.st-running.sel { box-shadow: inset 2px 0 0 var(--volt); }
+.fus-row-h { display: flex; align-items: center; gap: 7px; }
+.fus-run-id { font-size: 11px; color: var(--text-mid); letter-spacing: 0.02em; }
+.fus-row-ts { margin-left: auto; font-size: 10px; color: var(--text-dim); }
+.fus-row-prompt { font-size: 12px; color: var(--text-primary); line-height: 1.45; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.fus-row-f { display: flex; align-items: center; gap: 8px; }
+.fus-trig { font-size: 9.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fus-row-f .spacer { flex: 1; }
+
+/* keeper identity */
+.fus-who { display: inline-flex; align-items: center; gap: 6px; background: none; border: 0; padding: 0; cursor: pointer; color: var(--text-mid); }
+.fus-who .nm { font-family: var(--font-display); font-weight: 500; font-size: 11px; color: var(--text-mid); }
+.fus-who:hover .nm { color: var(--volt-strong); }
+.fus-who.static { cursor: default; }
+
+/* decision badges */
+.fus-dec-badge { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.03em; padding: 2px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); white-space: nowrap; }
+.fus-dec-badge.ok   { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); background: color-mix(in oklab, var(--status-ok) 9%, transparent); }
+.fus-dec-badge.volt { color: var(--volt-strong); border-color: var(--volt-dim); background: var(--volt-wash); }
+.fus-dec-badge.warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 45%, transparent); background: color-mix(in oklab, var(--status-warn) 8%, transparent); }
+.fus-dec-badge.bad  { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); background: color-mix(in oklab, var(--status-bad) 8%, transparent); }
+.fus-dec-badge.run  { color: var(--volt-strong); border-color: var(--volt-dim); }
+.fus-dec-badge.big { font-size: 12.5px; padding: 5px 13px; }
+
+/* ════ DETAIL CANVAS ════ */
+.fus-run-scroll { overflow-y: auto; padding: 22px 28px 48px; min-width: 0; }
+.fus-run-scroll::-webkit-scrollbar { width: 9px; }
+.fus-run-scroll::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
+
+.fus-run-head { margin-bottom: 16px; }
+.fus-run-id-row { display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
+.fus-run-id-row h1 { font-family: var(--font-mono); font-weight: 500; font-size: 21px; letter-spacing: 0.01em; color: var(--text-bright); margin: 0; }
+.fus-preset { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 2px 8px; }
+.fus-trig-chip { font-size: 10.5px; color: var(--volt-strong); border: 1px solid var(--volt-dim); background: var(--volt-wash); border-radius: var(--radius-pill); padding: 2px 9px; }
+.fus-run-by { display: flex; align-items: center; gap: 11px; margin-top: 11px; }
+.fus-run-by .fus-who .nm { font-size: 13px; color: var(--text-primary); }
+.fus-run-meta { font-size: 11px; color: var(--text-dim); }
+
+/* pipeline strip */
+.fus-pipe { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; padding: 11px 14px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-md); margin-bottom: 16px; }
+.fus-pipe-node { font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.04em; padding: 4px 10px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); color: var(--text-mid); background: var(--bg-card); white-space: nowrap; }
+.fus-pipe-node.gate.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); }
+.fus-pipe-node.gate.deny { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); background: color-mix(in oklab, var(--status-bad) 8%, transparent); }
+.fus-pipe-node.panel { color: var(--volt-strong); border-color: var(--volt-dim); }
+.fus-pipe-node.judge { color: var(--text-bright); }
+.fus-pipe-node.off { color: var(--text-dim); opacity: 0.45; }
+.fus-pipe-arr { color: var(--text-dim); font-size: 12px; }
+
+/* kpi strip */
+.fus-kpis { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--border-soft); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; margin-bottom: 20px; }
+.fus-kpi { background: var(--bg-panel); padding: 12px 15px; }
+.fus-kpi .k { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); }
+.fus-kpi .v { font-family: var(--font-mono); font-variant-numeric: tabular-nums; font-size: 21px; color: var(--text-bright); margin-top: 5px; }
+.fus-kpi .v small { font-size: 11px; color: var(--text-dim); }
+.fus-kpi .v.ok { color: var(--status-ok); } .fus-kpi .v.bad { color: var(--status-bad); }
+.fus-kpi .v.warn { color: var(--status-warn); } .fus-kpi .v.volt { color: var(--volt-strong); }
+
+/* generic block */
+.fus-block { margin-bottom: 20px; }
+.fus-block-lbl { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 9px; display: flex; align-items: center; gap: 9px; }
+.fus-sub-note { font-family: var(--font-body); letter-spacing: 0.02em; text-transform: none; color: var(--text-dim); opacity: 0.7; font-size: 10px; }
+.fus-judge-model { color: var(--volt-strong); letter-spacing: 0.01em; }
+
+.fus-prompt { font-size: 14px; color: var(--text-primary); line-height: 1.6; padding: 14px 16px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-left: 2px solid var(--volt-dim); border-radius: var(--radius-sm); text-wrap: pretty; }
+.fus-link { display: inline-block; margin-top: 8px; font-size: 11px; color: var(--text-dim); cursor: pointer; }
+.fus-link:hover { color: var(--volt-strong); }
+.fus-link.inline { display: inline; margin: 0; color: var(--volt-strong); }
+
+/* ── panel grid ── */
+.fus-panel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(248px, 1fr)); gap: 10px; }
+.fus-pcard { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 11px 13px; display: flex; flex-direction: column; gap: 9px; }
+.fus-pcard.failed { opacity: 0.7; border-style: dashed; }
+.fus-pcard.running { border-color: var(--volt-dim); }
+.fus-pcard-h { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.fus-pmodel { font-size: 11.5px; color: var(--text-bright); font-weight: 500; }
+.fus-pstate { font-size: 9.5px; padding: 1px 7px; border-radius: var(--radius-pill); margin-left: auto; }
+.fus-pstate.run { color: var(--volt-strong); border: 1px solid var(--volt-dim); display: inline-flex; align-items: center; gap: 4px; }
+.fus-pstate.fail { color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 40%, transparent); background: color-mix(in oklab, var(--status-bad) 8%, transparent); margin-left: auto; }
+.fus-pstate .dots { display: inline-flex; gap: 2px; }
+.fus-pstate .dots i { width: 3px; height: 3px; border-radius: 50%; background: currentColor; animation: fus-blink 1.2s infinite; }
+.fus-pstate .dots i:nth-child(2) { animation-delay: 0.2s; } .fus-pstate .dots i:nth-child(3) { animation-delay: 0.4s; }
+@keyframes fus-blink { 0%, 60%, 100% { opacity: 0.25; } 30% { opacity: 1; } }
+
+.fus-conf { display: inline-flex; align-items: center; gap: 6px; margin-left: auto; }
+.fus-conf-bar { width: 42px; height: 4px; border-radius: 2px; background: var(--border-main); overflow: hidden; }
+.fus-conf-bar i { display: block; height: 100%; background: var(--volt); border-radius: 2px; }
+.fus-conf .mono { font-size: 9.5px; color: var(--text-dim); }
+.fus-ptok { font-size: 9.5px; color: var(--text-dim); }
+.fus-pcard-h .fus-conf + .fus-ptok { margin-left: 0; }
+
+.fus-pans { font-size: 12px; color: var(--text-mid); line-height: 1.55; cursor: pointer; display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical; overflow: hidden; position: relative; }
+.fus-pans.open { -webkit-line-clamp: unset; }
+.fus-pans:not(.open)::after { content: '… 더보기'; position: absolute; right: 0; bottom: 0; padding-left: 18px; font-size: 10px; color: var(--volt-strong); background: linear-gradient(90deg, transparent, var(--bg-panel) 40%); }
+.fus-pans.skeleton { display: flex; flex-direction: column; gap: 6px; cursor: default; }
+.fus-pans.skeleton span { height: 8px; border-radius: 3px; background: linear-gradient(90deg, var(--border-soft), var(--border-main), var(--border-soft)); background-size: 200% 100%; animation: fus-shim 1.4s infinite; }
+.fus-pans.skeleton span:nth-child(2) { width: 86%; } .fus-pans.skeleton span:nth-child(3) { width: 64%; }
+@keyframes fus-shim { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+
+/* ── judge synthesis ── */
+.fus-judge { border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-panel); overflow: hidden; }
+.fus-judge-body { display: flex; flex-direction: column; }
+.fus-jsec { padding: 13px 16px; border-bottom: 1px solid var(--border-soft); }
+.fus-jsec:last-child { border-bottom: 0; }
+.fus-jsec h5 { font-family: var(--font-display); font-weight: 500; font-size: 12px; letter-spacing: 0.04em; color: var(--text-bright); margin: 0 0 9px; display: flex; align-items: center; gap: 8px; }
+.fus-jsec h5 .n { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); font-weight: 400; }
+.fus-jglyph { width: 18px; height: 18px; display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-xs); font-size: 11px; }
+.fus-jsec.consensus .fus-jglyph { color: var(--status-ok); background: color-mix(in oklab, var(--status-ok) 12%, transparent); }
+.fus-jsec.contra .fus-jglyph { color: var(--status-warn); background: color-mix(in oklab, var(--status-warn) 12%, transparent); }
+.fus-jsec.coverage .fus-jglyph { color: var(--info, #8a6cf0); background: color-mix(in oklab, var(--info, #8a6cf0) 14%, transparent); }
+.fus-jsec.insight .fus-jglyph { color: var(--volt-strong); background: var(--volt-wash); }
+.fus-jsec.blind .fus-jglyph { color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 11%, transparent); }
+
+.fus-claim, .fus-insight { padding: 8px 0; border-top: 1px solid var(--border-soft); }
+.fus-claim:first-of-type, .fus-insight:first-of-type { border-top: 0; padding-top: 0; }
+.fus-claim p, .fus-insight p { margin: 0 0 6px; font-size: 12.5px; color: var(--text-primary); line-height: 1.5; }
+.fus-insight { display: flex; align-items: flex-start; gap: 10px; }
+.fus-insight p { flex: 1; margin: 0; }
+
+.fus-mchips { display: inline-flex; flex-wrap: wrap; gap: 4px; }
+.fus-mchip { font-size: 9px; color: var(--text-dim); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 1px 6px; background: var(--bg-sunken); white-space: nowrap; }
+
+.fus-contra { padding: 8px 0; border-top: 1px solid var(--border-soft); }
+.fus-contra:first-of-type { border-top: 0; padding-top: 0; }
+.fus-contra-topic { font-size: 12px; color: var(--text-mid); margin-bottom: 6px; font-weight: 500; }
+.fus-pos { display: flex; gap: 9px; padding: 3px 0; align-items: baseline; }
+.fus-pos-m { font-size: 9.5px; color: var(--volt-strong); min-width: 110px; flex: none; }
+.fus-pos-s { font-size: 12px; color: var(--text-primary); line-height: 1.45; }
+
+.fus-gap { padding: 8px 0; border-top: 1px solid var(--border-soft); }
+.fus-gap:first-of-type { border-top: 0; padding-top: 0; }
+.fus-gap-topic { font-size: 12px; color: var(--text-mid); font-weight: 500; margin-bottom: 5px; }
+.fus-gap-row { display: flex; gap: 9px; align-items: baseline; padding: 2px 0; }
+.fus-gap-row .k { font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); min-width: 36px; flex: none; }
+.fus-gap-miss { font-size: 12px; color: var(--text-primary); line-height: 1.45; }
+
+.fus-blind { margin: 0; padding-left: 18px; }
+.fus-blind li { font-size: 12px; color: var(--text-primary); line-height: 1.55; margin-bottom: 4px; }
+
+.fus-judge-wait { display: flex; align-items: center; gap: 9px; font-size: 12px; color: var(--text-dim); padding: 14px 16px; background: var(--bg-panel); border: 1px dashed var(--border-main); border-radius: var(--radius-md); }
+
+/* ── resolved + decision ── */
+.fus-resolved { border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 16px 18px; margin-bottom: 20px; background: var(--bg-panel); }
+.fus-resolved.dec-ok   { border-color: color-mix(in oklab, var(--status-ok) 32%, var(--border-main)); background: linear-gradient(120deg, color-mix(in oklab, var(--status-ok) 6%, var(--bg-panel)), var(--bg-panel) 55%); }
+.fus-resolved.dec-volt { border-color: var(--volt-dim); background: linear-gradient(120deg, var(--volt-wash), var(--bg-panel) 55%); }
+.fus-resolved.dec-warn { border-color: color-mix(in oklab, var(--status-warn) 32%, var(--border-main)); background: linear-gradient(120deg, color-mix(in oklab, var(--status-warn) 6%, var(--bg-panel)), var(--bg-panel) 55%); }
+.fus-resolved-h { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+.fus-rec-action { font-size: 12px; color: var(--text-mid); }
+.fus-resolved-lbl { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 6px; }
+.fus-resolved-body { font-size: 14.5px; color: var(--text-bright); line-height: 1.62; margin: 0; text-wrap: pretty; }
+.fus-rec-rationale { font-size: 12.5px; color: var(--text-mid); line-height: 1.55; margin: 11px 0 0; }
+.fus-rec-rationale .k, .fus-missing .k { font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); margin-right: 8px; }
+.fus-missing { margin-top: 12px; }
+.fus-missing ul { margin: 7px 0 0; padding-left: 18px; }
+.fus-missing li { font-size: 12.5px; color: var(--text-primary); line-height: 1.5; margin-bottom: 3px; }
+
+/* ── sink ── */
+.fus-sink { font-size: 12px; color: var(--text-mid); line-height: 1.55; padding: 13px 15px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-left: 2px solid var(--volt-dim); border-radius: var(--radius-sm); }
+.fus-sink b { color: var(--text-bright); font-weight: 600; }
+.fus-sink-h { font-family: var(--font-ui); font-size: 11px; color: var(--text-bright); margin-bottom: 11px; display: flex; align-items: baseline; gap: 9px; }
+.fus-sink-tracks { display: flex; flex-direction: column; gap: 10px; }
+.fus-sink-track { display: flex; gap: 11px; align-items: flex-start; }
+.fus-sink-ico { flex: none; width: 22px; height: 22px; display: inline-flex; align-items: center; justify-content: center; border-radius: var(--radius-xs); border: 1px solid var(--border-main); font-size: 12px; }
+.fus-sink-ico.chat { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 32%, transparent); }
+.fus-sink-ico.board { color: var(--info); border-color: color-mix(in oklab, var(--info) 32%, transparent); }
+.fus-sink-ico.wake { color: var(--volt-strong); border-color: var(--volt-dim); }
+.fus-sink-tx { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.fus-sink-to { align-self: flex-start; background: none; border: 0; padding: 0; cursor: pointer; font-size: 12.5px; color: var(--volt-strong); font-family: var(--font-ui); }
+.fus-sink-to:hover { text-decoration: underline; }
+.fus-sink-to.static { color: var(--text-bright); cursor: default; }
+.fus-sink-d { font-size: 11px; color: var(--text-dim); line-height: 1.5; }
+.fus-sink-glyph { color: var(--volt-strong); flex: none; font-size: 13px; line-height: 1.4; }
+.fus-corr { display: block; margin-top: 11px; padding-top: 9px; border-top: 1px solid var(--border-soft); font-size: 10px; color: var(--text-dim); }
+.fus-corr .mono { color: var(--text-mid); }
+
+/* ── denied ── */
+.fus-deny { border: 1px solid color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); border-radius: var(--radius-md); padding: 16px 18px; margin-bottom: 20px; background: linear-gradient(120deg, color-mix(in oklab, var(--status-bad) 6%, var(--bg-panel)), var(--bg-panel) 55%); }
+.fus-deny-h { display: flex; align-items: center; gap: 9px; font-family: var(--font-display); font-weight: 500; font-size: 15px; color: var(--text-bright); }
+.fus-deny-h .mono { color: var(--status-bad); font-size: 13px; }
+.fus-deny-glyph { width: 22px; height: 22px; display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 45%, transparent); font-size: 12px; }
+.fus-deny-lbl { font-size: 12.5px; color: var(--status-bad); margin: 10px 0 0; }
+.fus-deny-detail { font-size: 12.5px; color: var(--text-primary); line-height: 1.6; margin: 8px 0 12px; text-wrap: pretty; }
+.fus-sink.denied { background: var(--bg-sunken); }
+
+/* mobile */
+@media (max-width: 760px) {
+  .fus-body { grid-template-columns: 1fr; }
+  .fus-list { max-height: 240px; }
+  .fus-kpis { grid-template-columns: repeat(2, 1fr); }
+  .fus-run-scroll { padding: 16px 16px 40px; }
+}
+
+/* ── Fusion conclusion card inside a keeper chat lane (RFC §8.1) ── */
+.msg-fusion { border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 12px 14px; margin: 4px 0; background: var(--bg-sunken); }
+.msg-fusion.dec-ok   { border-color: color-mix(in oklab, var(--status-ok) 30%, var(--border-main)); }
+.msg-fusion.dec-volt { border-color: var(--volt-dim); }
+.msg-fusion.dec-warn { border-color: color-mix(in oklab, var(--status-warn) 30%, var(--border-main)); }
+.msg-fusion-h { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; margin-bottom: 9px; }
+.msg-fusion-tag { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; color: var(--volt-strong); }
+.msg-fusion-run { font-size: 10px; color: var(--text-dim); }
+.msg-fusion-h .fus-dec-badge { margin-left: auto; }
+.msg-fusion-ans { font-size: 13px; color: var(--text-primary); line-height: 1.6; margin: 0; text-wrap: pretty; }
+.msg-fusion-foot { display: flex; align-items: center; gap: 12px; margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--border-soft); font-size: 11px; color: var(--text-dim); }
+.msg-fusion-link { margin-left: auto; background: none; border: 0; padding: 0; cursor: pointer; font-family: var(--font-ui); font-size: 11px; color: var(--volt-strong); }
+.msg-fusion-link:hover { text-decoration: underline; }

--- a/dashboard/src/styles/keeper-v2/inspector.css
+++ b/dashboard/src/styles/keeper-v2/inspector.css
@@ -1,0 +1,127 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Turn Inspector
+   A real agent-trace detail surface: summary stats, token economics,
+   a turn waterfall, a structured transcript with tool cards, and
+   copyable context blocks. Reuses the .turn-overlay / .turn-drawer
+   shell; everything new is namespaced .ti-*.
+   ══════════════════════════════════════════════════════════════ */
+
+.v2-app .ti-drawer { width: min(720px, 96vw); }
+.v2-app .ti-drawer .turn-hd h3 { white-space: nowrap; flex: none; }
+.v2-app .ti-drawer .turn-hd .tid { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* ── Header subline: model · finish ── */
+.ti-sub { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding: 0 16px 12px; border-bottom: 1px solid var(--border-soft); }
+.ti-chip { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-mid); border: 1px solid var(--border-main); background: var(--bg-card); padding: 3px 9px; border-radius: var(--radius-pill); white-space: nowrap; }
+.ti-chip .sub-k { margin: 0; }
+.ti-chip.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 35%, transparent); }
+
+/* ── Summary stat strip ── */
+.ti-summary { display: grid; grid-template-columns: repeat(5, 1fr); gap: 1px; background: var(--border-soft); border-bottom: 1px solid var(--border-main); }
+.ti-stat { background: var(--bg-panel); padding: 11px 14px; min-width: 0; }
+.ti-stat .k { font-size: 8.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); }
+.ti-stat .v { font-family: var(--font-mono); font-size: 16px; color: var(--text-bright); margin-top: 5px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.ti-stat .v small { font-size: 10px; color: var(--text-dim); }
+.ti-stat .v.ok { color: var(--status-ok); }
+.ti-stat .v.volt { color: var(--volt-strong); }
+
+/* ── Token economics bar ── */
+.ti-tok { padding: 13px 16px; }
+.ti-tok-top { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
+.ti-tok-top .lbl { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); }
+.ti-tok-top .ctxpct { font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); }
+.ti-tok-bar { display: flex; height: 10px; border-radius: var(--radius-pill); overflow: hidden; background: var(--bg-sunken); border: 1px solid var(--border-soft); }
+.ti-tok-bar > span { display: block; height: 100%; min-width: 2px; }
+.ti-tok-bar .seg-in { background: var(--info-dim); }
+.ti-tok-bar .seg-out { background: var(--volt); }
+.ti-tok-legend { display: flex; gap: 18px; margin-top: 9px; font-size: 11.5px; color: var(--text-mid); }
+.ti-tok-legend span { display: inline-flex; align-items: center; gap: 6px; }
+.ti-tok-legend i { width: 9px; height: 9px; border-radius: 2px; flex: none; }
+.ti-tok-legend .in i { background: var(--info-dim); }
+.ti-tok-legend .out i { background: var(--volt); }
+.ti-tok-legend b { font-family: var(--font-mono); color: var(--text-bright); font-weight: 600; }
+
+/* ── Waterfall timeline ── */
+.ti-wf { display: flex; flex-direction: column; }
+.ti-wf-row { display: grid; grid-template-columns: 158px 1fr 56px; gap: 12px; align-items: center; padding: 6px 0; border-top: 1px solid var(--border-soft); }
+.ti-wf-row:first-child { border-top: 0; }
+.ti-wf-lbl { display: flex; align-items: center; gap: 8px; min-width: 0; font-size: 12.5px; color: var(--text-primary); }
+.ti-wf-lbl .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ti-wf-lbl .nm.mono { font-family: var(--font-mono); font-size: 11.5px; }
+.ti-wf-ico { width: 8px; height: 8px; border-radius: 2px; flex: none; }
+.ti-wf-track { position: relative; height: 18px; background: var(--bg-sunken); border-radius: var(--radius-xs); overflow: hidden; }
+.ti-wf-bar { position: absolute; top: 3px; height: 12px; border-radius: 3px; min-width: 4px; transition: none; }
+.ti-wf-dur { font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); text-align: right; font-variant-numeric: tabular-nums; }
+.ti-k-ctx { background: var(--text-dim); }
+.ti-k-reason { background: var(--info); }
+.ti-k-tool { background: var(--volt); }
+.ti-k-gen { background: var(--status-ok); }
+.ti-wf-foot { display: flex; align-items: center; justify-content: space-between; margin-top: 12px; padding-top: 11px; border-top: 1px solid var(--border-main); font-size: 11.5px; color: var(--text-dim); }
+.ti-wf-foot b { font-family: var(--font-mono); color: var(--text-bright); font-weight: 600; }
+.ti-wf-legend { display: flex; gap: 14px; }
+.ti-wf-legend span { display: inline-flex; align-items: center; gap: 5px; font-size: 10.5px; color: var(--text-dim); }
+.ti-wf-legend i { width: 8px; height: 8px; border-radius: 2px; }
+
+/* ── Copyable code card ── */
+.ti-code { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-well); margin-top: 6px; }
+.ti-code-h { display: flex; align-items: center; gap: 8px; padding: 6px 10px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.ti-code-h .cap { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); }
+.ti-code-h .sz { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+.ti-code pre { margin: 0; padding: 10px 12px; overflow-x: auto; font-family: var(--font-mono); font-size: 11.5px; line-height: 1.62; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.ti-code pre .jk { color: var(--volt-strong); }
+.ti-code pre .js { color: var(--status-ok); }
+.ti-copy { margin-left: auto; display: inline-flex; align-items: center; gap: 5px; background: none; border: 1px solid var(--border-main); color: var(--text-dim); border-radius: var(--radius-xs); font-family: var(--font-ui); font-size: 10px; padding: 3px 9px; cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.ti-copy:hover { color: var(--volt); border-color: var(--volt-dim); }
+.ti-copy.done { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); }
+
+/* ── Structured tool card (transcript) ── */
+.ti-tool { border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.ti-tool-h { display: flex; align-items: center; gap: 9px; padding: 9px 12px; background: var(--bg-panel-alt); }
+.ti-tool-h .seq { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+.ti-tool-h .tnm { font-family: var(--font-mono); font-size: 12.5px; color: var(--text-bright); }
+.ti-tool-h .pill { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 7px; border-radius: var(--radius-pill); }
+.ti-tool-h .pill.ok { color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 40%, transparent); }
+.ti-tool-h .pill.bad { color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 40%, transparent); }
+.ti-tool-h .lat { margin-left: auto; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
+.ti-tool-b { padding: 10px 12px; }
+
+/* ── Role-tinted transcript message ── */
+.ti-msg { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.ti-msg-h { display: flex; align-items: center; gap: 8px; padding: 7px 11px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.ti-msg-role { font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.1em; padding: 1px 8px; border-radius: var(--radius-xs); }
+.ti-msg-role.system { color: var(--info); border: 1px solid color-mix(in oklab, var(--info) 35%, transparent); }
+.ti-msg-role.user { color: var(--volt-strong); border: 1px solid var(--volt-dim); }
+.ti-msg-role.assistant { color: var(--text-bright); border: 1px solid var(--border-highlight); }
+.ti-msg-h .who { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.ti-msg-h .seq { margin-left: auto; font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+.ti-msg-b { padding: 10px 12px; font-family: var(--font-body); font-size: 12.5px; line-height: 1.62; color: var(--text-primary); white-space: pre-wrap; word-break: break-word; }
+.ti-msg-b.mono { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); }
+
+.ti-seq-rail { display: flex; flex-direction: column; gap: 10px; }
+
+/* ── Meta: parameter chips + kv ── */
+.ti-params { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 4px; }
+.ti-param { font-family: var(--font-mono); font-size: 11px; padding: 4px 11px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-dim); }
+.ti-param b { color: var(--text-bright); font-weight: 600; margin-left: 6px; }
+
+/* ── Context section card ── */
+.ti-ctx-card { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.ti-ctx-h { display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.ti-ctx-h .t { font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-mid); }
+.ti-ctx-h .tok { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.ti-ctx-card pre { margin: 0; padding: 11px 13px; max-height: 340px; overflow: auto; font-family: var(--font-mono); font-size: 11.5px; line-height: 1.62; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+
+/* section title gets a count chip on the right */
+.ti-sec-h { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin: 0 0 9px; }
+.ti-sec-h h4 { margin: 0; }
+.ti-sec-h .n { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+
+/* Drawer entrance: transform-only (no opacity fade). A backgrounded tab
+   freezes the animation clock on frame 0 — fading opacity there would hold
+   the whole drawer invisible. Sliding without fading keeps the resting/paused
+   state fully visible (just 18px offset) while still animating in foreground.
+   Redefines the global @keyframes turn-in used by every .turn-drawer. */
+@keyframes turn-in {
+  from { transform: translateX(18px); }
+  to   { transform: none; }
+}

--- a/dashboard/src/styles/keeper-v2/keeper-config.css
+++ b/dashboard/src/styles/keeper-v2/keeper-config.css
@@ -1,0 +1,159 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Keeper 상세 설정 (풀스크린 surface + 좌측 8탭).
+   Tokens from colors_and_type.css + v2.css. Reuses .set-row /
+   .set-seg / .set-toggle from craft.css for the inline controls.
+   ══════════════════════════════════════════════════════════════ */
+.kcf-overlay {
+  position: fixed; inset: 0; z-index: 95;
+  background: rgba(4, 5, 8, 0.62);
+  display: flex; align-items: center; justify-content: center; padding: 3vh 2vw;
+  animation: kcf-fade .16s ease;
+}
+@keyframes kcf-fade { from { opacity: 0; } to { opacity: 1; } }
+
+.kcf {
+  width: min(1240px, 96vw); height: min(940px, 94vh);
+  display: flex; flex-direction: column; min-height: 0;
+  background: var(--bg-deep); color: var(--text-primary); font-family: var(--font-ui);
+  border: 1px solid var(--border-main); border-radius: 8px; overflow: hidden;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.6);
+}
+
+/* ── top bar ── */
+.kcf-top { flex: none; display: flex; align-items: center; gap: 13px; padding: 14px 20px; border-bottom: 1px solid var(--border-main); background: var(--bg-panel); }
+.kcf-top-id { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.kcf-top-name { font-family: var(--font-display); font-weight: 600; font-size: 17px; letter-spacing: -0.005em; color: var(--text-bright); display: flex; align-items: baseline; gap: 9px; }
+.kcf-top-kr { font-family: var(--font-ui); font-size: 12px; font-weight: 400; color: var(--text-dim); }
+.kcf-top-sub { font-size: 11px; color: var(--text-dim); }
+.kcf-top-phase { display: inline-flex; align-items: center; gap: 7px; font-size: 11.5px; color: var(--text-mid); padding: 5px 11px; border: 1px solid var(--border-main); border-radius: var(--radius-pill); background: var(--bg-card); white-space: nowrap; }
+.kcf-top-spacer { flex: 1; }
+.kcf-top-x { width: 30px; height: 30px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: none; color: var(--text-mid); cursor: pointer; font-size: 13px; transition: .18s; }
+.kcf-top-x:hover { border-color: var(--volt-dim); color: var(--volt); }
+
+/* ── body: tab rail + content ── */
+.kcf-body { flex: 1; min-height: 0; display: flex; }
+.kcf-tabs { flex: none; width: 198px; border-right: 1px solid var(--border-main); background: var(--bg-panel); padding: 12px 10px; display: flex; flex-direction: column; gap: 2px; overflow-y: auto; }
+.kcf-tab {
+  display: flex; align-items: center; gap: 11px; width: 100%; text-align: left;
+  padding: 10px 12px; border: 0; border-radius: var(--radius-sm); background: none; cursor: pointer;
+  color: var(--text-mid); font-family: var(--font-ui); font-size: 13.5px; transition: background .14s ease, color .14s ease;
+}
+.kcf-tab:hover { background: color-mix(in oklab, var(--text-bright) 5%, transparent); color: var(--text-bright); }
+.kcf-tab.on { background: var(--volt-wash, color-mix(in oklab, var(--volt) 12%, transparent)); color: var(--volt-strong, var(--volt)); }
+.kcf-tab-ic { width: 20px; text-align: center; font-size: 15px; opacity: 0.9; }
+.kcf-tab.on .kcf-tab-ic { opacity: 1; }
+.kcf-tab-lbl { white-space: nowrap; }
+
+.kcf-main { flex: 1; min-width: 0; overflow-y: auto; padding: 24px 30px 30px; }
+
+/* ── section ── */
+.kcf-sec { margin-bottom: 30px; max-width: 860px; }
+.kcf-sec-h { display: flex; align-items: center; gap: 12px; }
+.kcf-sec-h h3 { margin: 0; font-family: var(--font-display); font-weight: 600; font-size: 13px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-bright); }
+.kcf-sec-desc { margin: 7px 0 0; font-size: 12.5px; line-height: 1.55; color: var(--text-dim); max-width: 680px; }
+.kcf-sec-body { margin-top: 14px; display: flex; flex-direction: column; gap: 4px; }
+
+/* ── read-only fact grid ── */
+.kcf-facts { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1px; background: var(--border-soft); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.kcf-fact { display: flex; flex-direction: column; gap: 4px; padding: 11px 14px; background: var(--bg-card); }
+.kcf-fact-k { font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); }
+.kcf-fact-v { font-size: 13px; color: var(--text-bright); word-break: break-word; }
+.kcf-fact-v.mono { font-family: var(--font-mono); font-size: 12px; }
+
+/* ── plan / readonly badges ── */
+.kcf-plan { display: inline-flex; align-items: center; gap: 2px; font-size: 9.5px; letter-spacing: 0.06em; font-weight: 400; color: var(--text-dim); background: color-mix(in oklab, var(--info) 12%, transparent); border: 1px solid color-mix(in oklab, var(--info) 30%, transparent); border-radius: var(--radius-xs); padding: 2px 7px; }
+.kcf-plan em { font-style: normal; color: var(--text-dim); font-size: 11px; letter-spacing: 0; margin-left: 4px; }
+.kcf-ro { font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); }
+
+/* ── text fields ── */
+.kcf-textfield { display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px; }
+.kcf-tf-h { display: flex; align-items: baseline; gap: 10px; }
+.kcf-tf-h label { font-size: 12px; font-weight: 600; color: var(--text-mid); }
+.kcf-tf-hint { font-size: 11px; color: var(--text-dim); }
+.kcf-text {
+  width: 100%; box-sizing: border-box; resize: vertical;
+  padding: 10px 12px; border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  background: var(--bg-panel); color: var(--text-primary); font-family: var(--font-ui); font-size: 13px; line-height: 1.6;
+  transition: border-color .16s ease;
+}
+.kcf-text.mono { font-family: var(--font-mono); font-size: 12px; }
+.kcf-text:focus { outline: none; border-color: var(--volt-dim); }
+.kcf-traits { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.kcf-trait { font-size: 10.5px; color: var(--volt); padding: 3px 9px; border: 1px solid color-mix(in oklab, var(--volt) 32%, transparent); border-radius: var(--radius-pill); }
+
+/* ── runtime chain ── */
+.kcf-chain { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.kcf-chain-item { font-size: 11.5px; color: var(--text-mid); padding: 5px 11px; border: 1px solid var(--border-main); border-radius: var(--radius-pill); background: var(--bg-card); }
+.kcf-chain-item + .kcf-chain-item { position: relative; }
+.kcf-chain-item + .kcf-chain-item::before { content: '→'; position: absolute; left: -16px; top: 50%; transform: translateY(-50%); color: var(--text-dim); font-size: 11px; }
+
+/* paths */
+.kcf-paths { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; }
+.kcf-path-eff { font-size: 11px; color: var(--text-dim); }
+
+/* ── tools ── */
+.kcf-tools { display: flex; flex-direction: column; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.kcf-tool { display: grid; grid-template-columns: auto 190px 52px 1fr; align-items: center; gap: 12px; padding: 9px 13px; background: var(--bg-card); }
+.kcf-tool.on { background: color-mix(in oklab, var(--volt) 7%, var(--bg-card)); }
+.kcf-tool-id { font-size: 12px; color: var(--text-bright); }
+.kcf-tool-risk { font-size: 10px; text-align: center; padding: 2px 7px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-dim); }
+.kcf-tool-risk.read { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 34%, transparent); }
+.kcf-tool-risk.write { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 36%, transparent); }
+.kcf-tool-risk.lifecycle { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); }
+.kcf-tool-desc { font-size: 11.5px; color: var(--text-dim); }
+
+/* ── goals picker ── */
+.kcf-goals { display: flex; flex-direction: column; gap: 12px; }
+.kcf-goals-bar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.kcf-search { display: flex; align-items: center; gap: 8px; flex: 1; min-width: 220px; padding: 8px 12px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-panel); }
+.kcf-search-ic { color: var(--text-dim); font-size: 13px; }
+.kcf-search input { flex: 1; border: 0; background: none; color: var(--text-primary); font-family: var(--font-ui); font-size: 13px; outline: none; }
+.kcf-hz { display: flex; gap: 3px; }
+.kcf-hz-b { font-size: 12px; color: var(--text-mid); padding: 6px 12px; border: 1px solid var(--border-main); background: none; border-radius: var(--radius-pill); cursor: pointer; transition: .16s; }
+.kcf-hz-b:hover { color: var(--text-bright); border-color: var(--volt-dim); }
+.kcf-hz-b.on { color: var(--bg-deep); background: var(--volt); border-color: var(--volt); font-weight: 600; }
+.kcf-goals-count { font-size: 11px; color: var(--text-dim); margin-left: auto; }
+.kcf-goals-list { display: flex; flex-direction: column; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; max-height: 460px; overflow-y: auto; }
+.kcf-goal { display: grid; grid-template-columns: 22px 1fr auto; align-items: center; gap: 12px; padding: 10px 14px; background: var(--bg-card); border: 0; text-align: left; cursor: pointer; transition: background .12s ease; }
+.kcf-goal:hover { background: color-mix(in oklab, var(--text-bright) 4%, var(--bg-card)); }
+.kcf-goal.on { background: color-mix(in oklab, var(--volt) 9%, var(--bg-card)); }
+.kcf-goal-check { width: 18px; height: 18px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--border-main); border-radius: var(--radius-xs); font-size: 11px; color: var(--volt); }
+.kcf-goal.on .kcf-goal-check { background: var(--volt); color: var(--bg-deep); border-color: var(--volt); }
+.kcf-goal-body { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.kcf-goal-title { font-size: 13px; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kcf-goal-id { font-size: 10.5px; color: var(--text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kcf-goal-hz { font-size: 10px; letter-spacing: 0.04em; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); white-space: nowrap; }
+.kcf-goal-hz.hz-short { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 30%, transparent); }
+.kcf-goal-hz.hz-mid { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 32%, transparent); }
+.kcf-goal-hz.hz-long { color: var(--info); border-color: color-mix(in oklab, var(--info) 34%, transparent); }
+.kcf-goals-empty, .kcf-goals-empty { padding: 30px; text-align: center; color: var(--text-dim); font-size: 13px; background: var(--bg-card); }
+
+/* ── hooks table ── */
+.kcf-hooks { display: flex; flex-direction: column; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.kcf-hook-hd, .kcf-hook { display: grid; grid-template-columns: 200px 200px 1fr; gap: 14px; align-items: center; padding: 9px 14px; background: var(--bg-card); }
+.kcf-hook-hd { background: var(--bg-panel); }
+.kcf-hook-hd span { font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); font-weight: 600; }
+.kcf-hook.off { opacity: 0.5; }
+.kcf-hook-slot { font-size: 12px; color: var(--text-bright); }
+.kcf-hook-src { font-size: 11.5px; color: var(--text-mid); }
+.kcf-hook-src.na { color: var(--text-dim); font-style: italic; }
+.kcf-hook-gate { font-size: 11px; color: var(--text-dim); }
+
+/* ── footer ── */
+.kcf-foot { flex: none; display: flex; align-items: center; gap: 10px; padding: 13px 20px; border-top: 1px solid var(--border-main); background: var(--bg-panel); }
+.kcf-foot-note { font-size: 11px; color: var(--text-dim); }
+.kcf-foot-spacer { flex: 1; }
+.kcf-btn { font-family: var(--font-ui); font-size: 13px; padding: 9px 18px; border-radius: var(--radius-sm); cursor: pointer; transition: .16s; }
+.kcf-btn.ghost { background: none; border: 1px solid var(--border-main); color: var(--text-mid); }
+.kcf-btn.ghost:hover { border-color: var(--volt-dim); color: var(--text-bright); }
+.kcf-btn.save { background: var(--volt); border: 1px solid var(--volt); color: var(--bg-deep); font-weight: 600; }
+.kcf-btn.save:hover { background: var(--volt-strong, var(--volt)); box-shadow: 0 0 20px rgba(196, 162, 101, 0.18); }
+
+@media (max-width: 760px) {
+  .kcf { width: 100vw; height: 100vh; border-radius: 0; }
+  .kcf-overlay { padding: 0; }
+  .kcf-tabs { width: 56px; padding: 10px 6px; }
+  .kcf-tab-lbl { display: none; }
+  .kcf-facts, .kcf-tool { grid-template-columns: 1fr; }
+  .kcf-tool { grid-template-columns: auto 1fr; }
+}

--- a/dashboard/src/styles/keeper-v2/logs.css
+++ b/dashboard/src/styles/keeper-v2/logs.css
@@ -1,0 +1,118 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — 이벤트 로그 (observe / trace stream) surface.
+   Tokens from colors_and_type.css + v2.css. Loads after them.
+   A dense, scannable, tail-style event stream: monospace clock,
+   keeper identity, kind badge, one-line summary; click to expand
+   the real event payload (args/result, turn meta, lifecycle, …).
+   ══════════════════════════════════════════════════════════════ */
+.lg {
+  height: 100%; min-height: 0; box-sizing: border-box;
+  display: flex; flex-direction: column;
+  background:
+    radial-gradient(ellipse at 14% 0%, color-mix(in oklab, var(--volt) 5%, transparent), transparent 55%),
+    var(--bg-deep);
+  color: var(--text-primary); font-family: var(--font-ui);
+  --lg-cols: 92px minmax(150px, 230px) 104px minmax(0, 1fr) 24px;
+}
+
+/* ── header ── */
+.lg-head { flex: none; display: flex; align-items: flex-start; gap: 24px; padding: 22px 26px 16px; }
+.lg-head-l h1 { margin: 0; font-family: var(--font-display); font-weight: 600; font-size: 22px; letter-spacing: -0.01em; color: var(--text-bright); }
+.lg-sub { margin: 6px 0 0; font-size: 11px; letter-spacing: 0.04em; color: var(--text-dim); }
+.lg-stats { margin-left: auto; display: flex; gap: 10px; }
+.lg-stat {
+  display: flex; flex-direction: column; gap: 3px; min-width: 74px;
+  padding: 8px 13px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-card);
+}
+.lg-stat .k { font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); }
+.lg-stat .v { font-size: 17px; font-weight: 600; color: var(--text-bright); font-variant-numeric: tabular-nums; }
+.lg-stat .v.bad { color: var(--status-bad); }
+
+/* ── toolbar ── */
+.lg-toolbar { flex: none; display: flex; align-items: center; gap: 10px; padding: 0 26px 14px; }
+.lg-filters { display: flex; gap: 4px; }
+.lg-fchip {
+  font-family: var(--font-ui); font-size: 12px; color: var(--text-mid);
+  padding: 6px 12px; border: 1px solid var(--border-main); background: transparent;
+  border-radius: var(--radius-pill); cursor: pointer; transition: color .18s ease, border-color .18s ease, background .18s ease;
+}
+.lg-fchip:hover { color: var(--text-bright); border-color: var(--volt-dim); }
+.lg-fchip.on { color: var(--bg-deep); background: var(--volt); border-color: var(--volt); font-weight: 600; }
+.lg-tb-spacer { flex: 1; }
+.lg-onlyerr {
+  font-family: var(--font-ui); font-size: 12px; color: var(--text-mid);
+  padding: 6px 12px; border: 1px solid var(--border-main); background: transparent;
+  border-radius: var(--radius-pill); cursor: pointer; transition: color .18s ease, border-color .18s ease;
+}
+.lg-onlyerr:hover { color: var(--text-bright); border-color: var(--volt-dim); }
+.lg-onlyerr.on { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 50%, transparent); background: color-mix(in oklab, var(--status-warn) 10%, transparent); }
+.lg-live { display: inline-flex; align-items: center; gap: 7px; font-size: 11px; color: var(--text-dim); }
+.lg-live .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--status-ok); box-shadow: 0 0 0 0 color-mix(in oklab, var(--status-ok) 60%, transparent); animation: lg-pulse 2.4s ease-in-out infinite; }
+@keyframes lg-pulse { 0%, 100% { box-shadow: 0 0 0 0 color-mix(in oklab, var(--status-ok) 55%, transparent); } 50% { box-shadow: 0 0 0 4px transparent; } }
+
+/* ── column header ── */
+.lg-colhd {
+  flex: none; display: grid; grid-template-columns: var(--lg-cols); gap: 14px; align-items: center;
+  padding: 9px 26px; margin: 0 0; border-top: 1px solid var(--border-main); border-bottom: 1px solid var(--border-main);
+  background: var(--bg-panel);
+}
+.lg-colhd span { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); font-weight: 600; }
+
+/* ── stream ── */
+.lg-stream { flex: 1; min-height: 0; overflow-y: auto; }
+.lg-row { border-bottom: 1px solid var(--border-soft); border-left: 2px solid transparent; }
+.lg-row[data-sev="ok"]   { border-left-color: transparent; }
+.lg-row[data-sev="warn"] { border-left-color: color-mix(in oklab, var(--status-warn) 70%, transparent); }
+.lg-row[data-sev="bad"]  { border-left-color: var(--status-bad); }
+.lg-row[data-sev="busy"] { border-left-color: var(--volt); }
+.lg-row[data-sev="info"] { border-left-color: color-mix(in oklab, var(--info) 60%, transparent); }
+.lg-row.open { background: color-mix(in oklab, var(--volt) 4%, transparent); }
+
+.lg-line {
+  width: 100%; display: grid; grid-template-columns: var(--lg-cols); gap: 14px; align-items: center;
+  padding: 9px 26px; background: none; border: 0; cursor: pointer; text-align: left;
+  font-family: var(--font-ui); transition: background .12s ease;
+}
+.lg-line:hover { background: color-mix(in oklab, var(--text-bright) 4%, transparent); }
+.lg-time { font-size: 12px; color: var(--text-mid); font-variant-numeric: tabular-nums; }
+.lg-row[data-sev="bad"] .lg-time { color: var(--status-bad); }
+.lg-who { display: flex; align-items: center; gap: 9px; min-width: 0; }
+.lg-kid { font-size: 13px; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.lg-nosig { width: 18px; height: 18px; border-radius: 4px; background: var(--bg-card); border: 1px solid var(--border-main); flex: none; }
+.lg-kind {
+  justify-self: start; font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; font-weight: 600;
+  padding: 3px 8px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); color: var(--text-dim);
+  white-space: nowrap;
+}
+.lg-kind[data-kind="tool"]      { color: var(--volt); border-color: color-mix(in oklab, var(--volt) 36%, transparent); }
+.lg-kind[data-kind="turn"]      { color: var(--text-mid); }
+.lg-kind[data-kind="lifecycle"] { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 36%, transparent); }
+.lg-kind[data-kind="approval"]  { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); }
+.lg-kind[data-kind="broadcast"] { color: var(--info); border-color: color-mix(in oklab, var(--info) 40%, transparent); }
+.lg-msg { font-size: 13px; color: var(--text-primary); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.lg-caret { justify-self: center; font-size: 11px; color: var(--text-dim); }
+
+/* ── expanded detail ── */
+.lg-detail { padding: 4px 26px 16px calc(26px + 92px + 14px); display: flex; flex-direction: column; gap: 10px; }
+.lg-kv { display: flex; flex-wrap: wrap; gap: 6px 22px; }
+.lg-kv-row { display: flex; gap: 8px; align-items: baseline; }
+.lg-kv-k { font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-dim); }
+.lg-kv-v { font-size: 12px; color: var(--text-bright); }
+.lg-block { display: flex; flex-direction: column; gap: 4px; }
+.lg-block-h { font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); }
+.lg-code {
+  margin: 0; padding: 10px 12px; border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  background: var(--bg-panel); color: var(--text-mid); font-family: var(--font-mono); font-size: 11.5px; line-height: 1.55;
+  white-space: pre-wrap; word-break: break-word; max-width: 760px;
+}
+.lg-note { font-size: 12.5px; line-height: 1.55; color: var(--text-mid); max-width: 720px; }
+.lg-note.dim { color: var(--text-dim); font-size: 11.5px; }
+.lg-recips { display: flex; flex-wrap: wrap; gap: 6px; }
+.lg-recip { font-size: 11px; color: var(--text-mid); padding: 3px 9px; border: 1px solid var(--border-main); border-radius: var(--radius-pill); }
+.lg-jump {
+  align-self: flex-start; font-family: var(--font-ui); font-size: 12px; color: var(--volt);
+  padding: 6px 12px; border: 1px solid color-mix(in oklab, var(--volt) 40%, transparent); background: transparent;
+  border-radius: var(--radius-sm); cursor: pointer; transition: background .18s ease, border-color .18s ease;
+}
+.lg-jump:hover { background: color-mix(in oklab, var(--volt) 12%, transparent); border-color: var(--volt); }
+.lg-empty { padding: 48px; text-align: center; color: var(--text-dim); font-size: 13px; }

--- a/dashboard/src/styles/keeper-v2/memory.css
+++ b/dashboard/src/styles/keeper-v2/memory.css
@@ -1,0 +1,111 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Keeper memory inspector. Reuses the .turn-overlay /
+   .turn-drawer / .turn-sec / .cmp-diff shell; everything new is .mem-*.
+   v2 tokens only.
+   ══════════════════════════════════════════════════════════════ */
+.v2-app .mem-drawer { width: min(680px, 96vw); }
+
+/* header scope toggle */
+.mem-scope { margin-left: auto; display: inline-flex; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.mem-scope button { font-family: var(--font-ui); font-size: 11px; padding: 5px 12px; background: transparent; color: var(--text-dim); border: 0; border-left: 1px solid var(--border-main); cursor: pointer; transition: 0.14s; }
+.mem-scope button:first-child { border-left: 0; }
+.mem-scope button:hover { color: var(--text-mid); background: var(--bg-card); }
+.mem-scope button.on { color: var(--volt-ink); background: var(--volt); }
+.mem-drawer .turn-close { margin-left: 10px; }
+
+.mem-empty { font-size: 12px; color: var(--text-dim); padding: 10px 2px; }
+.mem-sec-head { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.mem-sec-head h4 { margin: 0; }
+.mem-n { font-size: 11px; color: var(--text-dim); }
+.mem-hint { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.02em; text-transform: none; color: var(--text-dim); margin-left: 6px; }
+
+/* ── context composition ── */
+.mem-compo { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 11px 12px; background: var(--bg-card); }
+.mem-compo-head { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
+.mem-compo-tot { font-size: 18px; color: var(--text-bright); }
+.mem-compo-sub { font-size: 11px; color: var(--text-dim); }
+.mem-bar { display: flex; height: 12px; border-radius: 3px; overflow: hidden; background: var(--bg-sunken); }
+.mem-bar > span { display: block; min-width: 2px; }
+.mem-legend { display: grid; grid-template-columns: 1fr 1fr; gap: 4px 16px; margin-top: 11px; }
+.mem-leg { display: flex; align-items: center; gap: 7px; }
+.mem-leg-sw { width: 9px; height: 9px; border-radius: 2px; flex: none; }
+.mem-leg-lbl { font-size: 11.5px; color: var(--text-mid); flex: 1; min-width: 0; }
+.mem-leg-v { font-size: 11px; color: var(--text-dim); }
+
+/* ── pinned facts ── */
+.mem-pins { display: flex; flex-direction: column; gap: 7px; }
+.mem-pin { display: flex; gap: 9px; padding: 9px 11px; border: 1px solid var(--border-soft); border-left: 2px solid var(--volt-dim); border-radius: var(--radius-sm); background: var(--bg-card); }
+.mem-pin-ico { color: var(--volt); font-size: 13px; line-height: 1.5; flex: none; }
+.mem-pin-body { min-width: 0; }
+.mem-pin-text { font-size: 12.5px; line-height: 1.5; color: var(--text-primary); text-wrap: pretty; }
+.mem-pin-meta { display: flex; align-items: center; gap: 9px; margin-top: 6px; font-size: 10.5px; color: var(--text-dim); }
+.mem-by { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 1px 6px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
+.mem-by.operator { color: var(--volt-strong); border-color: var(--volt-dim); }
+.mem-by.auto { color: var(--text-dim); }
+.mem-tag { font-family: var(--font-mono); font-size: 10px; color: var(--info); }
+
+/* ── long-term store ── */
+.mem-filters { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 9px; }
+.mem-filter { font-family: var(--font-ui); font-size: 10.5px; padding: 3px 10px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.mem-filter:hover { color: var(--text-mid); border-color: var(--border-highlight); }
+.mem-filter.on { color: var(--text-bright); border-color: var(--volt-dim); background: var(--volt-wash); }
+.mem-store { display: flex; flex-direction: column; }
+.mem-store-row { display: flex; gap: 10px; padding: 10px 0; border-top: 1px solid var(--border-soft); }
+.mem-store-row:first-child { border-top: 0; }
+.mem-kind { flex: none; align-self: flex-start; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); white-space: nowrap; }
+.mem-kind.fact { color: var(--volt-strong); border-color: var(--volt-dim); }
+.mem-kind.decision { color: var(--info); border-color: color-mix(in oklab, var(--info) 35%, transparent); }
+.mem-kind.pattern { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 35%, transparent); }
+.mem-kind.pref { color: var(--text-mid); }
+.mem-kind.entity { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 35%, transparent); }
+.mem-store-main { min-width: 0; flex: 1; }
+.mem-store-text { font-size: 12.5px; line-height: 1.5; color: var(--text-primary); text-wrap: pretty; }
+.mem-store-meta { display: flex; align-items: center; gap: 12px; margin-top: 6px; font-size: 10.5px; color: var(--text-dim); }
+.mem-src { color: var(--text-dim); }
+.mem-sal { position: relative; width: 54px; height: 5px; border-radius: 3px; background: var(--bg-sunken); overflow: hidden; flex: none; }
+.mem-sal > span { position: absolute; left: 0; top: 0; bottom: 0; background: var(--volt); border-radius: 3px; }
+
+/* ── recall timeline ── */
+.mem-timeline { display: flex; flex-direction: column; }
+.mem-tl-row { display: grid; grid-template-columns: 42px 64px 1fr auto; gap: 10px; align-items: center; padding: 7px 0; border-top: 1px solid var(--border-soft); font-size: 12px; }
+.mem-tl-row:first-child { border-top: 0; }
+.mem-tl-at { font-size: 10.5px; color: var(--text-dim); }
+.mem-op { font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; color: var(--text-mid); white-space: nowrap; }
+.mem-op.recall { color: var(--info); }
+.mem-op.inject { color: var(--status-ok); }
+.mem-op.pin { color: var(--volt-strong); }
+.mem-op.compact { color: var(--status-warn); }
+.mem-op.evict { color: var(--text-dim); }
+.mem-tl-text { color: var(--text-mid); min-width: 0; line-height: 1.45; }
+.mem-tl-tok { font-size: 11px; text-align: right; white-space: nowrap; }
+.mem-tl-tok.neg { color: var(--status-ok); }
+.mem-tl-tok.pos { color: var(--text-dim); }
+
+/* ── aggregate ── */
+.mem-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+.mem-stat { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 11px 10px; background: var(--bg-card); text-align: center; }
+.mem-stat .v { display: block; font-size: 19px; color: var(--text-bright); }
+.mem-stat .k { display: block; margin-top: 3px; font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+
+.mem-kinds-dist { display: flex; flex-direction: column; gap: 7px; }
+.mem-kd-row { display: grid; grid-template-columns: 72px 1fr 28px; gap: 10px; align-items: center; }
+.mem-kd-bar { height: 7px; background: var(--bg-sunken); border-radius: 3px; overflow: hidden; }
+.mem-kd-bar > span { display: block; height: 100%; background: var(--volt); border-radius: 3px; }
+.mem-kd-n { font-size: 11px; color: var(--text-mid); text-align: right; }
+
+.mem-table { display: flex; flex-direction: column; }
+.mem-tr { display: grid; grid-template-columns: 1.7fr 0.6fr 0.5fr 0.7fr 1.1fr; gap: 10px; align-items: center; padding: 8px 6px; border-top: 1px solid var(--border-soft); font-size: 12px; color: var(--text-mid); text-align: left; background: none; border-left: 0; border-right: 0; border-bottom: 0; cursor: pointer; width: 100%; transition: background 0.14s; }
+.mem-tr:hover:not(.mem-th) { background: var(--bg-card); }
+.mem-th { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); cursor: default; border-top: 0; }
+.mem-td-id { display: inline-flex; align-items: center; gap: 7px; min-width: 0; }
+.mem-td-id .mono { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mem-td-bar { position: relative; display: flex; align-items: center; }
+.mem-td-bar i { position: absolute; left: 0; height: 6px; background: color-mix(in oklab, var(--status-ok) 45%, transparent); border-radius: 3px; }
+.mem-td-bar b { position: relative; margin-left: auto; font-weight: 500; font-size: 11px; color: var(--text-mid); }
+
+@media (max-width: 560px) {
+  .mem-legend { grid-template-columns: 1fr; }
+  .mem-stats { grid-template-columns: repeat(2, 1fr); }
+  .mem-tl-row { grid-template-columns: 38px 56px 1fr; }
+  .mem-tl-tok { display: none; }
+}

--- a/dashboard/src/styles/keeper-v2/perf.css
+++ b/dashboard/src/styles/keeper-v2/perf.css
@@ -1,0 +1,8 @@
+/* MASC v2 — performance layer styles (perf.jsx).
+   Windowing scrollers for VirtualList. Tokens from colors_and_type.css + v2.css. */
+
+/* ── VirtualList scrollers ── */
+.vl-scroller { scrollbar-width: thin; }
+.vl-scroller::-webkit-scrollbar { width: 10px; }
+.vl-scroller::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: 6px; border: 2px solid transparent; background-clip: padding-box; }
+.vl-row { box-sizing: border-box; }

--- a/dashboard/src/styles/keeper-v2/runtime.css
+++ b/dashboard/src/styles/keeper-v2/runtime.css
@@ -1,0 +1,142 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Runtime config editor (full-screen overlay). v2 tokens only.
+   ══════════════════════════════════════════════════════════════ */
+.rt-overlay { position: fixed; inset: 0; z-index: 95; background: rgba(4,5,8,0.55); display: flex; align-items: stretch; justify-content: center; padding: 28px; animation: rt-fade 0.16s ease; }
+@keyframes rt-fade { from { opacity: 0; } to { opacity: 1; } }
+.rt-shell { display: grid; grid-template-columns: 218px minmax(0,1fr); width: min(1080px, 100%); height: 100%; background: var(--bg-panel); border: 1px solid var(--border-highlight); border-radius: var(--radius-lg); overflow: hidden; box-shadow: 0 18px 60px rgba(0,0,0,0.55); }
+
+/* nav */
+.rt-nav { display: flex; flex-direction: column; gap: 2px; padding: 16px 12px; background: var(--bg-deep); border-right: 1px solid var(--border-main); }
+.rt-nav-h { padding: 4px 8px 14px; }
+.rt-nav-h .eyebrow { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+.rt-nav-title { font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.1em; font-size: 15px; color: var(--text-bright); margin-top: 4px; }
+.rt-nav-sub { font-size: 10.5px; color: var(--text-dim); margin-top: 3px; }
+.rt-nav-item { display: flex; align-items: center; gap: 10px; padding: 9px 11px; border: 0; background: none; border-radius: var(--radius-sm); color: var(--text-dim); font-size: 13px; cursor: pointer; transition: 0.14s; text-align: left; }
+.rt-nav-item:hover { color: var(--text-mid); background: var(--bg-card); }
+.rt-nav-item.on { color: var(--text-bright); background: var(--volt-wash); box-shadow: inset 0 0 0 1px var(--volt-dim); }
+.rt-nav-gl { width: 18px; flex: none; color: var(--text-dim); font-size: 12px; }
+.rt-nav-item.on .rt-nav-gl { color: var(--volt); }
+.rt-nav-foot { margin-top: auto; padding: 10px 8px 2px; font-size: 10px; color: var(--text-dim); }
+
+/* content */
+.rt-content { display: flex; flex-direction: column; min-width: 0; }
+.rt-head { display: flex; align-items: center; justify-content: space-between; padding: 18px 24px 15px; border-bottom: 1px solid var(--border-soft); }
+.rt-head h1 { font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.1em; font-size: 18px; color: var(--text-bright); margin: 0; }
+.rt-head-actions { display: flex; align-items: center; gap: 10px; }
+.rt-save { font-family: var(--font-ui); font-size: 12px; padding: 7px 15px; border-radius: var(--radius-sm); border: 1px solid var(--volt-dim); background: var(--volt-wash); color: var(--volt); cursor: pointer; transition: 0.14s; }
+.rt-save:hover { background: var(--volt); color: var(--volt-ink); }
+.rt-close { width: 30px; height: 30px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: none; color: var(--text-mid); cursor: pointer; }
+.rt-close:hover { border-color: var(--volt-dim); color: var(--volt); }
+.rt-body { flex: 1; overflow-y: auto; padding: 20px 24px 40px; }
+
+.rt-note { font-size: 11.5px; line-height: 1.55; color: var(--text-dim); margin-bottom: 14px; }
+.rt-input { background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 7px 10px; color: var(--text-bright); font-size: 12px; }
+.rt-input:focus { outline: none; border-color: var(--volt-dim); }
+
+/* routing lanes */
+.rt-lane { display: flex; align-items: center; gap: 16px; padding: 14px 0; border-top: 1px solid var(--border-soft); }
+.rt-lane:first-of-type { border-top: 0; }
+.rt-lane-l { flex: 1; min-width: 0; }
+.rt-lane-lbl { font-size: 13px; color: var(--text-primary); }
+.rt-lane-hint { font-size: 11px; color: var(--text-dim); margin-top: 3px; }
+.rt-lane-c { display: flex; align-items: center; gap: 10px; flex: none; }
+.rt-select { background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 7px 10px; color: var(--text-bright); font-size: 12px; cursor: pointer; min-width: 248px; }
+.rt-select:focus { outline: none; border-color: var(--volt-dim); }
+.rt-warn { font-size: 11px; color: var(--status-bad); white-space: nowrap; }
+.rt-ok { font-size: 11px; color: var(--status-ok); white-space: nowrap; }
+
+/* provider cards */
+.rt-cards { display: flex; flex-direction: column; gap: 12px; }
+.rt-card { border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-card); padding: 13px 15px; }
+.rt-card-h { display: flex; align-items: center; gap: 10px; margin-bottom: 11px; }
+.rt-card-id { font-size: 13px; color: var(--volt-strong); }
+.rt-card-name { font-size: 12.5px; color: var(--text-bright); }
+.rt-proto { margin-left: auto; font-size: 10px; color: var(--text-dim); border: 1px solid var(--border-main); padding: 1px 7px; border-radius: var(--radius-pill); }
+.rt-field { display: flex; align-items: center; gap: 10px; margin-top: 7px; }
+.rt-field .sub-k { min-width: 78px; }
+.rt-field .rt-input { flex: 1; }
+.rt-cred { display: flex; align-items: center; gap: 8px; flex: 1; }
+.rt-cred-type { font-size: 10px; color: var(--info); border: 1px solid color-mix(in oklab, var(--info) 30%, transparent); padding: 2px 7px; border-radius: var(--radius-pill); flex: none; }
+.rt-cred .rt-input { flex: 1; }
+.rt-cred-none { font-size: 11.5px; color: var(--text-dim); }
+.rt-caps { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 11px; }
+.rt-cap { font-family: var(--font-mono); font-size: 10px; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); }
+.rt-cap.on { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 32%, transparent); }
+.rt-cap.tcf { color: var(--info); border-color: color-mix(in oklab, var(--info) 28%, transparent); }
+
+/* models */
+.rt-search { width: 100%; box-sizing: border-box; background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 9px 12px; color: var(--text-bright); font-size: 12px; margin-bottom: 12px; }
+.rt-search:focus { outline: none; border-color: var(--volt-dim); }
+.rt-models { display: flex; flex-direction: column; gap: 9px; }
+.rt-model { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); background: var(--bg-card); padding: 11px 13px; }
+.rt-model-h { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin-bottom: 9px; }
+.rt-model-id { font-size: 12.5px; color: var(--text-bright); }
+.rt-model-api { font-size: 11px; color: var(--text-dim); }
+.rt-model-ctx { margin-left: auto; font-size: 10.5px; color: var(--text-mid); }
+
+/* bindings */
+.rt-binds { display: flex; flex-direction: column; gap: 9px; }
+.rt-bind { display: flex; align-items: center; gap: 12px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-card); padding: 10px 13px; }
+.rt-bind.is-default { border-color: var(--volt-dim); background: var(--volt-wash); }
+.rt-radio { flex: none; background: none; border: 0; color: var(--text-dim); font-size: 15px; cursor: pointer; padding: 0; }
+.rt-radio.on { color: var(--volt); }
+.rt-bind-main { flex: 1; min-width: 0; }
+.rt-bind-key { font-size: 12.5px; color: var(--text-bright); display: flex; align-items: center; gap: 8px; }
+.rt-default-tag { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--volt); border: 1px solid var(--volt-dim); padding: 1px 6px; border-radius: var(--radius-pill); }
+.rt-bind-sub { font-size: 10.5px; color: var(--text-dim); margin-top: 3px; }
+.rt-bind-fields { display: flex; gap: 10px; flex: none; }
+.rt-mini { display: flex; flex-direction: column; gap: 3px; font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-dim); }
+.rt-input-sm { width: 58px; background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 5px 7px; color: var(--text-bright); font-size: 11.5px; }
+.rt-input-sm:focus { outline: none; border-color: var(--volt-dim); }
+
+/* assignments */
+.rt-assigns { display: flex; flex-direction: column; }
+.rt-assign { display: flex; align-items: center; gap: 14px; padding: 9px 0; border-top: 1px solid var(--border-soft); }
+.rt-assign:first-of-type { border-top: 0; }
+.rt-assign-k { display: inline-flex; align-items: center; gap: 8px; width: 150px; flex: none; font-size: 12.5px; color: var(--text-bright); }
+.rt-assign-tag { font-size: 10.5px; color: var(--text-dim); }
+.rt-assign-tag.pin { color: var(--volt-strong); }
+
+/* toml */
+.rt-toml-wrap { border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-well); }
+.rt-toml-bar { display: flex; align-items: center; gap: 10px; padding: 8px 12px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); font-size: 11px; color: var(--text-dim); }
+.rt-toml-bar .mono { color: var(--text-mid); }
+.rt-toml-ro { font-size: 10px; }
+.rt-copy { margin-left: auto; background: none; border: 1px solid var(--border-main); color: var(--text-mid); border-radius: var(--radius-sm); font-size: 11px; padding: 4px 11px; cursor: pointer; }
+.rt-copy:hover { border-color: var(--volt-dim); color: var(--volt); }
+.rt-toml { margin: 0; padding: 14px 16px; overflow-x: auto; max-height: 60vh; }
+.rt-toml code { font-family: var(--font-mono); font-size: 12px; line-height: 1.65; color: var(--text-primary); white-space: pre; }
+
+/* settings launcher card + per-keeper runtime capability card */
+.rtc-card { border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-card); padding: 10px 12px; }
+.rtc-id { font-size: 11.5px; color: var(--volt-strong); word-break: break-all; }
+.rtc-na { font-size: 11px; color: var(--text-dim); margin-top: 5px; }
+.rtc-model { font-size: 10.5px; color: var(--text-dim); margin-top: 4px; }
+.rtc-flags { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 9px; }
+.rtc-flag { font-family: var(--font-mono); font-size: 10px; padding: 1px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); }
+.rtc-flag.on { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 32%, transparent); }
+.rtc-flag.off { color: var(--text-dim); }
+.rtc-effort { display: flex; align-items: center; gap: 9px; margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--border-soft); }
+.rtc-effort-k { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); }
+.rtc-eff-seg { display: inline-flex; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.rtc-eff { font-family: var(--font-mono); font-size: 10px; padding: 3px 9px; background: transparent; color: var(--text-dim); border: 0; border-left: 1px solid var(--border-main); cursor: pointer; transition: 0.14s; }
+.rtc-eff:first-child { border-left: 0; }
+.rtc-eff:hover { color: var(--text-mid); }
+.rtc-eff.on { color: var(--volt-ink); background: var(--volt); }
+.rtc-eff-na { font-size: 10.5px; color: var(--text-dim); }
+
+.set-rt-launch { border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-card); padding: 16px 18px; }
+.set-rt-launch h3 { font-family: var(--font-ui); font-size: 14px; color: var(--text-bright); margin: 0 0 6px; }
+.set-rt-launch p { font-size: 12px; line-height: 1.55; color: var(--text-dim); margin: 0 0 14px; }
+.set-rt-launch-stats { display: flex; gap: 22px; margin-bottom: 16px; }
+.set-rt-launch-stat .v { font-family: var(--font-mono); font-size: 17px; color: var(--text-bright); }
+.set-rt-launch-stat .k { display: block; font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); margin-top: 2px; }
+.set-rt-open { font-family: var(--font-ui); font-size: 13px; padding: 9px 18px; border-radius: var(--radius-sm); border: 1px solid var(--volt-dim); background: var(--volt-wash); color: var(--volt); cursor: pointer; transition: 0.14s; }
+.set-rt-open:hover { background: var(--volt); color: var(--volt-ink); }
+
+@media (max-width: 720px) {
+  .rt-shell { grid-template-columns: 1fr; }
+  .rt-nav { flex-direction: row; overflow-x: auto; }
+  .rt-nav-h, .rt-nav-foot { display: none; }
+  .rt-select { min-width: 160px; }
+}

--- a/dashboard/src/styles/keeper-v2/schedule.css
+++ b/dashboard/src/styles/keeper-v2/schedule.css
@@ -1,0 +1,126 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Scheduler surface (예약 자동화). Reuses .ov-* shell +
+   .turn-* overlay; everything new is .sch-*. v2 tokens only.
+   ══════════════════════════════════════════════════════════════ */
+
+/* status/risk tone helper — map cls → color var */
+.sch-pill, .sch-risk, .sch-decision, .sch-exec, .sch-sig-kind { --tone: var(--text-dim); }
+.ok   { }
+.sch-pill.ok,   .sch-decision.ok,   .sch-exec.ok,   .sch-sig-kind.ok   { --tone: var(--status-ok); }
+.sch-pill.warn, .sch-decision.warn, .sch-sig-kind.warn { --tone: var(--status-warn); }
+.sch-pill.bad,  .sch-decision.bad,  .sch-exec.bad   { --tone: var(--status-bad); }
+.sch-pill.info  { --tone: var(--info); }
+.sch-pill.volt  { --tone: var(--volt-strong); }
+.sch-pill.dim,  .sch-decision.dim   { --tone: var(--text-dim); }
+
+/* ── filter tabs ── */
+.sch-tabs { display: flex; flex-wrap: wrap; gap: 6px; margin: 18px 0 14px; }
+.sch-tab { display: inline-flex; align-items: center; gap: 7px; font-family: var(--font-ui); font-size: 12px; padding: 7px 13px; border: 1px solid var(--border-main); border-radius: var(--radius-pill); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.sch-tab:hover { color: var(--text-mid); border-color: var(--border-highlight); }
+.sch-tab.on { color: var(--text-bright); border-color: var(--volt-dim); background: var(--volt-wash); }
+.sch-tab-n { font-size: 10.5px; color: var(--text-dim); }
+.sch-tab.on .sch-tab-n { color: var(--volt-strong); }
+
+.sch-empty { font-size: 13px; color: var(--text-dim); padding: 28px 4px; text-align: center; border: 1px dashed var(--border-main); border-radius: var(--radius-sm); }
+
+/* ── post-action result banner (어디로 갔는지) ── */
+.sch-banner { display: flex; align-items: center; gap: 11px; margin: 0 0 14px; padding: 11px 14px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-card); font-size: 12.5px; color: var(--text-mid); animation: turn-in 0.18s ease; }
+.sch-banner.approve { border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); background: color-mix(in oklab, var(--status-ok) 8%, transparent); }
+.sch-banner.reject { border-color: color-mix(in oklab, var(--status-bad) 38%, transparent); background: color-mix(in oklab, var(--status-bad) 7%, transparent); }
+.sch-banner.cancel { border-color: var(--border-highlight); }
+.sch-banner-ico { flex: none; font-size: 14px; }
+.sch-banner.approve .sch-banner-ico { color: var(--status-ok); }
+.sch-banner.reject .sch-banner-ico { color: var(--status-bad); }
+.sch-banner.cancel .sch-banner-ico { color: var(--text-dim); }
+.sch-banner-txt { flex: 1; min-width: 0; }
+.sch-banner-txt b { color: var(--text-bright); }
+.sch-banner-go { flex: none; background: none; border: 1px solid var(--border-highlight); color: var(--text-mid); border-radius: var(--radius-pill); font-family: var(--font-ui); font-size: 11.5px; padding: 4px 12px; cursor: pointer; transition: 0.14s; }
+.sch-banner-go:hover { border-color: var(--volt-dim); color: var(--volt); }
+.sch-banner-x { flex: none; background: none; border: 0; color: var(--text-dim); cursor: pointer; font-size: 12px; padding: 2px 4px; }
+.sch-banner-x:hover { color: var(--text-bright); }
+
+/* ── schedule cards ── */
+.sch-list { display: flex; flex-direction: column; gap: 11px; }
+.sch-card { display: flex; border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-card); overflow: hidden; }
+.sch-card-rail { width: 3px; flex: none; background: var(--tone, var(--border-main)); }
+.sch-card.st-ok   { --tone: var(--status-ok); }
+.sch-card.st-warn { --tone: var(--status-warn); }
+.sch-card.st-bad  { --tone: var(--status-bad); }
+.sch-card.st-info { --tone: var(--info); }
+.sch-card.st-dim  { --tone: var(--border-highlight); }
+.sch-card-main { flex: 1; min-width: 0; padding: 12px 14px; }
+
+.sch-card-head { display: flex; align-items: center; gap: 10px; width: 100%; background: none; border: 0; padding: 0; cursor: pointer; text-align: left; flex-wrap: wrap; }
+.sch-kind { font-family: var(--font-ui); font-size: 12.5px; color: var(--text-bright); white-space: nowrap; }
+.sch-id { font-size: 11px; color: var(--text-dim); }
+.sch-head-sp { flex: 1; }
+.sch-rec { font-size: 10.5px; color: var(--text-mid); }
+
+.sch-pill { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-ui); font-size: 10.5px; letter-spacing: 0.02em; padding: 2px 9px; border-radius: var(--radius-pill); color: var(--tone); border: 1px solid color-mix(in oklab, var(--tone) 38%, transparent); background: color-mix(in oklab, var(--tone) 10%, transparent); white-space: nowrap; }
+.sch-risk { font-family: var(--font-mono); font-size: 10px; padding: 1px 7px; border-radius: var(--radius-xs); color: var(--tone); border: 1px solid color-mix(in oklab, var(--tone) 32%, transparent); }
+.sch-risk.dim  { --tone: var(--text-dim); }
+.sch-risk.ok   { --tone: var(--status-ok); }
+.sch-risk.info { --tone: var(--info); }
+.sch-risk.warn { --tone: var(--status-warn); }
+.sch-risk.bad  { --tone: var(--status-bad); }
+.sch-risk.volt { --tone: var(--volt-strong); }
+
+.sch-summary { display: block; width: 100%; text-align: left; background: none; border: 0; padding: 9px 0 0; cursor: pointer; font-size: 13px; line-height: 1.5; color: var(--text-primary); text-wrap: pretty; }
+.sch-summary:hover { color: var(--text-bright); }
+
+.sch-meta { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; margin-top: 10px; font-size: 11.5px; color: var(--text-dim); }
+.sch-by { display: inline-flex; align-items: center; gap: 7px; }
+.sch-klink { background: none; border: 0; padding: 0; cursor: pointer; font-family: var(--font-mono); font-size: 12px; color: var(--text-mid); }
+.sch-klink:hover { color: var(--volt); text-decoration: underline; }
+.sch-actor-kind { font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); border: 1px solid var(--border-main); padding: 1px 5px; border-radius: var(--radius-pill); }
+.sch-due { display: inline-flex; align-items: baseline; gap: 4px; color: var(--text-mid); }
+.sch-need { color: var(--status-warn); }
+.sch-grant { color: var(--status-ok); }
+
+.sch-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 13px; }
+.sch-act { font-family: var(--font-ui); font-size: 12px; padding: 6px 14px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: transparent; color: var(--text-mid); cursor: pointer; transition: 0.16s; }
+.sch-act:hover { border-color: var(--border-highlight); color: var(--text-bright); }
+.sch-act.approve { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); }
+.sch-act.approve:hover { background: var(--status-ok); color: var(--bg-deep); border-color: var(--status-ok); }
+.sch-act.deny { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); }
+.sch-act.deny:hover { background: color-mix(in oklab, var(--status-bad) 16%, transparent); }
+.sch-act.deny:disabled { opacity: 0.45; cursor: not-allowed; }
+.sch-act.ghost { color: var(--text-dim); }
+
+.sch-reject { display: flex; gap: 8px; align-items: center; margin-top: 10px; }
+.sch-reject-in { flex: 1; min-width: 0; background: var(--bg-sunken); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 7px 10px; color: var(--text-bright); font-size: 12px; }
+.sch-reject-in:focus { outline: none; border-color: var(--volt-dim); }
+
+/* ── detail overlay ── */
+.v2-app .sch-drawer { width: min(620px, 96vw); }
+.v2-app .sch-drawer .turn-hd h3 { white-space: nowrap; flex: none; }
+.sch-drawer .turn-hd .tid { white-space: nowrap; }
+.sch-d-summary { font-size: 13.5px; line-height: 1.55; color: var(--text-primary); margin: 0 0 10px; text-wrap: pretty; }
+.sch-badges { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.sch-src { font-size: 10.5px; color: var(--text-dim); border: 1px solid var(--border-main); padding: 1px 7px; border-radius: var(--radius-pill); }
+.sch-kvs { display: flex; flex-direction: column; gap: 6px; }
+.sch-kv { display: flex; align-items: baseline; gap: 12px; }
+.sch-kv .k { flex: none; width: 130px; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+.sch-kv .v { font-size: 12.5px; color: var(--text-bright); word-break: break-word; }
+.sch-sod { margin-top: 10px; padding: 9px 11px; font-size: 11.5px; line-height: 1.55; color: var(--text-mid); background: var(--bg-sunken); border: 1px solid var(--border-soft); border-left: 2px solid var(--volt-dim); border-radius: var(--radius-sm); }
+.sch-sod b { color: var(--volt-strong); }
+.sch-decision { font-size: 12.5px; padding: 9px 11px; border-radius: var(--radius-sm); border: 1px solid color-mix(in oklab, var(--tone) 32%, transparent); background: color-mix(in oklab, var(--tone) 9%, transparent); color: var(--tone); }
+.sch-decision + .sch-decision { margin-top: 7px; }
+.sch-reason { margin-top: 5px; color: var(--text-mid); font-style: italic; }
+.sch-exec { margin-top: 8px; font-family: var(--font-mono); font-size: 11.5px; padding: 8px 10px; border-radius: var(--radius-sm); background: var(--bg-sunken); border: 1px solid color-mix(in oklab, var(--tone) 28%, transparent); color: var(--tone); }
+.sch-detail-actions { display: flex; flex-wrap: wrap; gap: 9px; border-top: 1px solid var(--border-soft); padding-top: 14px; }
+
+/* ── wake signal feed ── */
+.sch-signals { margin-top: 26px; }
+.sch-sig-list { display: flex; flex-direction: column; }
+.sch-sig { display: flex; align-items: center; gap: 12px; padding: 8px 2px; border-top: 1px solid var(--border-soft); font-size: 12px; }
+.sch-sig:first-child { border-top: 0; }
+.sch-sig-at { font-size: 11px; color: var(--text-dim); width: 42px; flex: none; }
+.sch-sig-kind { font-family: var(--font-mono); font-size: 11px; color: var(--tone); padding: 1px 8px; border-radius: var(--radius-pill); border: 1px solid color-mix(in oklab, var(--tone) 30%, transparent); }
+.sch-sig-id { background: none; border: 0; padding: 0; cursor: pointer; font-size: 11.5px; color: var(--text-mid); }
+.sch-sig-id:hover { color: var(--volt); text-decoration: underline; }
+.sch-sig-risk { margin-left: auto; font-size: 10.5px; color: var(--text-dim); }
+
+@media (max-width: 720px) {
+  .sch-kv .k { width: 96px; }
+}

--- a/dashboard/src/styles/keeper-v2/surfaces.css
+++ b/dashboard/src/styles/keeper-v2/surfaces.css
@@ -1,0 +1,894 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — Surface styles: Overview · Board · Cockpit ·
+   Connectors · IDE, plus collapsible rails. Loads after v2.css.
+   ══════════════════════════════════════════════════════════════ */
+
+/* ════ SHARED SURFACE SHELL ════ */
+.surf { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--bg-deep); }
+.surf-scroll { flex: 1; overflow-y: auto; padding: var(--pad-surface); }
+.surf-scroll::-webkit-scrollbar { width: 9px; }
+.surf-scroll::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
+
+.surf-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+.surf-head h1 { font-family: var(--font-display); font-weight: 500; font-size: 22px; letter-spacing: 0.02em; color: var(--text-bright); margin: 0; }
+.surf-head .eyebrow { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 5px; }
+.surf-sub { margin-top: 5px; font-size: 12px; color: var(--text-dim); }
+.surf-sub b { color: var(--volt-strong); font-weight: 600; }
+.surf-sub .mono { color: var(--text-mid); }
+
+/* ════ COLLAPSIBLE RAILS ════ */
+.v2-body { transition: grid-template-columns 0.22s ease; }
+
+/* roster mini mode: sigils only (collapses to icons unless hover-peeking) */
+.roster.mini:not(.peek) .roster-head, .roster.mini:not(.peek) .roster-filters { display: none; }
+.roster.mini:not(.peek) .kp-more { display: none; }
+.roster.mini:not(.peek) .roster-group { padding: 8px 0 6px; margin-top: 5px; border-top: 1px solid var(--border-soft); text-align: center; letter-spacing: 0; font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); overflow: visible; white-space: nowrap; display: flex; align-items: center; justify-content: center; gap: 5px; }
+.roster.mini:not(.peek) .roster-group::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: var(--rg-tone, var(--text-dim)); flex: none; }
+.roster.mini:not(.peek) .roster-group.run { --rg-tone: var(--status-ok); }
+.roster.mini:not(.peek) .roster-group.pause { --rg-tone: var(--status-warn); }
+.roster.mini:not(.peek) .roster-group.off { --rg-tone: var(--text-dim); }
+.roster.mini:not(.peek) .roster-list > div:first-child .roster-group { border-top: 0; margin-top: 0; }
+.roster.mini:not(.peek) .kp-row { grid-template-columns: 38px; justify-content: center; padding: 6px 0; justify-items: center; }
+
+/* mini-roster identity flyout (hover) */
+.kp-flyout { position: fixed; z-index: 75; transform: translateY(-50%); min-width: 192px; padding: 10px 12px; background: var(--bg-panel); border: 1px solid var(--border-highlight); border-radius: var(--radius-sm); box-shadow: 0 8px 26px rgba(0,0,0,0.5); pointer-events: none; }
+.kpf-h { display: flex; align-items: center; gap: 9px; margin-bottom: 9px; }
+.kpf-id { min-width: 0; }
+.kpf-name { font-size: 13px; color: var(--text-bright); }
+.kpf-phase { display: flex; align-items: center; gap: 5px; font-size: 11px; color: var(--text-mid); margin-top: 2px; }
+.kpf-row { display: flex; gap: 8px; align-items: baseline; font-size: 11px; padding: 2px 0; }
+.kpf-k { flex: none; font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); min-width: 54px; }
+.kpf-row .mono { color: var(--text-mid); word-break: break-all; }
+.kpf-att { margin-top: 7px; padding-top: 7px; border-top: 1px solid var(--border-soft); font-size: 11px; color: var(--status-warn); }
+.roster.mini:not(.peek) .kp-meta, .roster.mini:not(.peek) .kp-right { display: none; }
+.roster.mini:not(.peek) .kp-row.sel::before { left: -4px; }
+.roster.mini:not(.peek) .roster-list { padding: 6px 4px; }
+
+/* hover-peek: mini rail expands to full content as an overlay (no layout shift) */
+.roster.mini.peek { position: absolute; left: 58px; top: 0; bottom: 0; width: 286px; z-index: 45; box-shadow: 8px 0 30px rgba(0,0,0,0.55); border-right: 1px solid var(--border-highlight); animation: roster-peek 0.16s ease; }
+@keyframes roster-peek { from { opacity: 0; transform: translateX(-8px); } to { opacity: 1; transform: translateX(0); } }
+
+.rail-toggle {
+  position: absolute; top: 50%; transform: translateY(-50%);
+  width: 17px; height: 52px; z-index: 30; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  color: var(--text-dim); font-size: 10px; padding: 0;
+  transition: 0.15s;
+}
+.rail-toggle:hover { color: var(--volt-strong); border-color: var(--volt-dim); background: var(--bg-card-hover); }
+.rail-toggle.left { left: 0; border-left: 0; border-radius: 0 6px 6px 0; }
+.rail-toggle.right { right: 0; border-right: 0; border-radius: 6px 0 0 6px; }
+
+/* drag-to-resize handles at the rail seams */
+.rail-resizer { position: absolute; top: 0; bottom: 0; width: 7px; z-index: 25; cursor: col-resize; }
+.rail-resizer.left { left: -3px; }
+.rail-resizer.right { right: -3px; }
+.rail-resizer::after { content: ''; position: absolute; top: 0; bottom: 0; left: 50%; width: 1px; background: transparent; transition: background 0.14s; }
+.rail-resizer:hover::after { background: var(--volt-dim); left: 3px; width: 2px; }
+body.rail-resizing { cursor: col-resize; user-select: none; }
+body.rail-resizing .v2-body { transition: none; }
+.chat-wrap { position: relative; display: flex; min-width: 0; min-height: 0; }
+.chat-wrap .chat { flex: 1; }
+
+/* ════ OVERVIEW ════ */
+.ov { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--bg-deep); }
+.ov-scroll { flex: 1; overflow-y: auto; padding: var(--pad-surface); max-width: 1280px; width: 100%; margin: 0 auto; }
+.ov-head { display: flex; align-items: flex-end; justify-content: space-between; margin-bottom: 18px; }
+.ov-head h1 { font-family: var(--font-display); font-weight: 500; font-size: 22px; color: var(--text-bright); margin: 0; }
+.ov-sub { margin-top: 5px; font-size: 12px; color: var(--text-dim); }
+.ov-sub b { color: var(--volt-strong); }
+.ov-sub .mono { color: var(--text-mid); }
+.ov-eyebrow { display: inline-block; font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 7px; }
+.ov-purpose { margin-top: 7px; font-size: 12.5px; color: var(--text-dim); }
+.ov-purpose b { color: var(--text-mid); font-weight: 600; }
+.ov-clock { font-size: 18px; color: var(--text-mid); }
+.ov-clock span { font-size: 10px; color: var(--text-dim); letter-spacing: 0.14em; }
+
+.ov-kpis { display: grid; grid-template-columns: repeat(6, 1fr); gap: 1px; background: var(--border-soft); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; margin-bottom: 16px; }
+.ov-kpi { background: var(--bg-panel); padding: 13px 15px; }
+.ov-kpi-k { font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+.ov-kpi-v { font-family: var(--font-mono); font-variant-numeric: tabular-nums; font-size: 23px; color: var(--text-bright); margin-top: 5px; }
+.ov-kpi-v small { font-size: 11px; color: var(--text-dim); }
+.ov-kpi-v.ok { color: var(--status-ok); } .ov-kpi-v.bad { color: var(--status-bad); }
+.ov-kpi-v.warn { color: var(--status-warn); } .ov-kpi-v.volt { color: var(--volt-strong); }
+
+.ov-grid { display: grid; grid-template-columns: minmax(0, 1.25fr) minmax(0, 1fr); gap: var(--gap-card); margin-bottom: 16px; }
+.ov-card { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: var(--pad-card); min-width: 0; }
+.ov-card-h { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+.ov-card-h h3 { font-family: var(--font-display); font-weight: 500; font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-mid); margin: 0; white-space: nowrap; }
+.ov-count { font-family: var(--font-mono); font-size: 11px; color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 14%, transparent); border: 1px solid color-mix(in oklab, var(--status-bad) 35%, transparent); padding: 1px 8px; border-radius: var(--radius-pill); }
+.ov-legend { font-size: 10px; color: var(--text-dim); }
+.ov-link { font-family: var(--font-ui); font-size: 11px; color: var(--volt-strong); background: none; border: 0; cursor: pointer; padding: 2px 0; }
+.ov-link:hover { text-decoration: underline; }
+
+.ov-attn-list { display: flex; flex-direction: column; gap: 7px; }
+.ov-attn-row { display: flex; align-items: center; gap: 11px; padding: 9px 10px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); cursor: pointer; transition: 0.14s; }
+.ov-attn-row:hover { border-color: var(--border-highlight); background: var(--bg-card-hover); }
+.ov-attn-meta { min-width: 0; flex: 1; }
+.ov-attn-name { font-family: var(--font-display); font-weight: 600; font-size: 13px; color: var(--text-bright); display: flex; gap: 9px; align-items: baseline; }
+.ov-attn-ns { font-size: 10px; color: var(--text-dim); font-weight: 400; }
+.ov-attn-reason { display: flex; align-items: center; gap: 6px; font-size: 11.5px; margin-top: 3px; color: var(--text-mid); }
+.ov-attn-reason.sev-bad { color: var(--status-bad); }
+.ov-attn-reason.sev-warn { color: var(--status-warn); }
+.ov-attn-act { flex: none; font-family: var(--font-ui); font-size: 11px; padding: 6px 11px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-panel-alt); color: var(--text-mid); cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.ov-attn-act:hover { color: var(--volt-strong); border-color: var(--volt-dim); }
+.ov-empty { padding: 26px 0; text-align: center; color: var(--text-dim); font-size: 12px; }
+
+.ov-bars { display: flex; align-items: flex-end; gap: 4px; height: 92px; padding: 4px 2px 0; }
+.ov-bar { flex: 1; min-width: 0; background: linear-gradient(180deg, var(--volt-dim), color-mix(in oklab, var(--volt-dim) 50%, var(--bg-card))); border-radius: 2px 2px 0 0; }
+.ov-bar.hot { background: linear-gradient(180deg, var(--volt), var(--volt-dim)); box-shadow: 0 0 9px var(--volt-glow); }
+.ov-tel-foot { display: flex; gap: 22px; margin-top: 12px; padding-top: 11px; border-top: 1px solid var(--border-soft); }
+.ov-tel-stat .k { font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); display: block; }
+.ov-tel-stat .v { font-size: 13px; color: var(--text-mid); margin-top: 3px; display: block; }
+
+.ov-fleet-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(215px, 1fr)); gap: 9px; }
+.ov-keeper { text-align: left; background: var(--bg-card); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 11px 12px; cursor: pointer; transition: 0.14s; min-width: 0; font-family: var(--font-ui); }
+.ov-keeper:hover { border-color: var(--volt-dim); background: var(--bg-card-hover); box-shadow: 0 0 0 2px var(--volt-wash); }
+.ov-keeper-top { display: flex; align-items: center; gap: 9px; }
+.ov-keeper-id { min-width: 0; flex: 1; }
+.ov-keeper-name { font-family: var(--font-display); font-weight: 600; font-size: 12.5px; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ov-keeper-state { display: flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); margin-top: 2px; }
+.ov-keeper-att { font-family: var(--font-mono); font-size: 9.5px; font-weight: 600; min-width: 16px; text-align: center; padding: 1px 5px; border-radius: var(--radius-pill); color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 16%, transparent); border: 1px solid color-mix(in oklab, var(--status-bad) 35%, transparent); flex: none; }
+.ov-keeper-ns { font-size: 10px; color: var(--text-dim); margin-top: 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ov-keeper-foot { display: flex; align-items: center; gap: 8px; margin-top: 7px; font-size: 10px; color: var(--text-dim); }
+.ov-mini-meter { flex: 1; height: 4px; border-radius: var(--radius-pill); background: var(--bg-sunken); border: 1px solid var(--border-soft); overflow: hidden; }
+.ov-mini-meter span { display: block; height: 100%; background: var(--volt-dim); }
+.ov-mini-meter span.hot { background: var(--status-bad); }
+.ov-keeper-ctx { flex: none; }
+
+/* ════ OVERVIEW — operational home (domain cards) ════ */
+.ov-kpi.link { cursor: pointer; transition: background 0.14s; }
+.ov-kpi.link:hover { background: var(--bg-panel-alt); }
+.ov-section-h { font-family: var(--font-display); font-weight: 500; font-size: 12px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); margin: 4px 0 12px; }
+.ov-domains { display: grid; grid-template-columns: repeat(auto-fill, minmax(290px, 1fr)); gap: var(--gap-card); }
+.ov-dcard { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 13px 15px 14px; display: flex; flex-direction: column; min-width: 0; }
+.ov-dcard-h { display: flex; align-items: center; gap: 9px; margin-bottom: 11px; }
+.ov-dcard-h h3 { font-family: var(--font-display); font-weight: 600; font-size: 13.5px; color: var(--text-bright); margin: 0; white-space: nowrap; }
+.ov-dcount { font-family: var(--font-mono); font-size: 10.5px; padding: 1px 7px; border-radius: var(--radius-pill); color: var(--text-mid); border: 1px solid var(--border-main); background: var(--bg-card); }
+.ov-dcount.bad { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 35%, transparent); background: color-mix(in oklab, var(--status-bad) 11%, transparent); }
+.ov-dcount.warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 35%, transparent); background: color-mix(in oklab, var(--status-warn) 9%, transparent); }
+.ov-dcount.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 35%, transparent); background: color-mix(in oklab, var(--status-ok) 9%, transparent); }
+.ov-dcount.volt { color: var(--volt-strong); border-color: var(--volt-dim); background: var(--volt-wash); }
+.ov-dlink { margin-left: auto; font-family: var(--font-ui); font-size: 11px; color: var(--volt-strong); background: none; border: 0; cursor: pointer; padding: 2px 0; white-space: nowrap; }
+.ov-dlink:hover { text-decoration: underline; }
+.ov-dcard-body { display: flex; flex-direction: column; gap: 9px; flex: 1; }
+
+/* goal mini */
+.ov-goal { display: flex; flex-direction: column; gap: 5px; }
+.ov-goal + .ov-goal { padding-top: 9px; border-top: 1px solid var(--border-soft); }
+.ov-goal-top { display: flex; align-items: center; gap: 7px; }
+.ov-goal-pri { width: 7px; height: 7px; border-radius: 50%; flex: none; background: var(--text-dim); }
+.ov-goal-pri.high { background: var(--status-bad); } .ov-goal-pri.normal { background: var(--volt); } .ov-goal-pri.low { background: var(--text-dim); }
+.ov-goal-title { font-size: 12.5px; color: var(--text-primary); flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ov-goal-due { font-size: 10px; color: var(--text-dim); flex: none; }
+.ov-goal-meter { height: 4px; border-radius: var(--radius-pill); background: var(--bg-sunken); border: 1px solid var(--border-soft); overflow: hidden; }
+.ov-goal-meter span { display: block; height: 100%; background: var(--volt-dim); }
+.ov-goal-sub { font-size: 10px; color: var(--text-dim); }
+
+/* urgent approval */
+.ov-urg { padding: 9px 11px; border-radius: var(--radius-sm); background: var(--bg-sunken); border: 1px solid var(--border-soft); }
+.ov-urg-sev { font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; display: inline-block; padding: 1px 7px; border-radius: var(--radius-xs); margin-bottom: 5px; }
+.ov-urg-sev.sev-bad { color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
+.ov-urg-sev.sev-warn { color: var(--status-warn); background: color-mix(in oklab, var(--status-warn) 11%, transparent); }
+.ov-urg-sev.sev-info { color: var(--volt-strong); background: var(--volt-wash); }
+.ov-urg-title { font-size: 12.5px; color: var(--text-bright); line-height: 1.4; }
+.ov-urg-by { font-size: 10px; color: var(--text-dim); margin-top: 4px; }
+.ov-mini-list { display: flex; flex-direction: column; gap: 5px; }
+.ov-mini-row { display: flex; align-items: center; gap: 8px; }
+.ov-mini-txt { font-size: 11.5px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* fusion mini */
+.ov-fus { padding: 9px 11px; border-radius: var(--radius-sm); background: var(--bg-sunken); border: 1px solid var(--border-soft); }
+.ov-fus-h { display: flex; align-items: center; gap: 9px; }
+.ov-fus-run { font-size: 11px; color: var(--text-mid); }
+.ov-fus-h .fus-dec-badge { margin-left: auto; }
+.ov-fus-by { font-size: 10px; color: var(--text-dim); margin-top: 5px; }
+.ov-fus-foot { font-size: 11px; }
+.ov-fus-live { display: flex; align-items: center; gap: 6px; color: var(--status-warn); }
+.ov-fus-idle { color: var(--text-dim); }
+
+/* generic stat rows */
+.ov-stat-row { display: flex; align-items: center; justify-content: space-between; padding: 5px 0; border-bottom: 1px solid var(--border-soft); }
+.ov-stat-row:last-child { border-bottom: 0; }
+.ov-stat-row .k { font-size: 11.5px; color: var(--text-mid); }
+.ov-stat-row .v { font-family: var(--font-display); font-weight: 600; font-size: 14px; color: var(--text-bright); }
+
+/* connectors pills */
+.ov-conn-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.ov-conn-pill { display: inline-flex; align-items: center; gap: 5px; font-size: 10.5px; padding: 3px 9px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-mid); background: var(--bg-card); }
+.ov-conn-pill .g { font-size: 9px; }
+.ov-conn-pill.ok { border-color: color-mix(in oklab, var(--status-ok) 32%, transparent); color: var(--status-ok); }
+.ov-conn-pill.stale { border-color: color-mix(in oklab, var(--status-warn) 38%, transparent); color: var(--status-warn); background: color-mix(in oklab, var(--status-warn) 7%, var(--bg-card)); }
+.ov-conn-pill.off { opacity: 0.5; }
+.ov-conn-warn { font-size: 11px; color: var(--status-warn); margin-top: 4px; }
+
+/* fleet summary */
+.ov-fleet-sum { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--border-soft); border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.ov-fleet-stat { background: var(--bg-card); padding: 9px 6px; text-align: center; }
+.ov-fleet-stat .v { font-family: var(--font-mono); font-size: 19px; color: var(--text-bright); display: block; }
+.ov-fleet-stat .v.ok { color: var(--status-ok); } .ov-fleet-stat .v.warn { color: var(--status-warn); } .ov-fleet-stat .v.bad { color: var(--status-bad); }
+.ov-fleet-stat .k { font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); margin-top: 2px; display: block; }
+
+/* ════ COCKPIT — Command Map ════ */
+.cp-body { flex: 1; min-height: 0; display: grid; grid-template-columns: minmax(280px, 360px) minmax(0, 1fr); }
+.cp-world { border-right: 1px solid var(--border-main); background: var(--bg-well); position: relative; overflow: hidden; display: flex; flex-direction: column; }
+.cp-world-cv { position: relative; flex: 1; min-height: 300px; }
+.cp-ring { position: absolute; border: 1px solid rgba(224,176,87,0.10); border-radius: 50%; left: 50%; top: 50%; transform: translate(-50%, -50%); }
+.cp-node { position: absolute; transform: translate(-50%, -50%); display: flex; flex-direction: column; align-items: center; gap: 4px; cursor: pointer; transition: 0.15s; z-index: 2; }
+.cp-node:hover { transform: translate(-50%, -50%) scale(1.12); }
+.cp-node .nm { font-family: var(--font-mono); font-size: 8.5px; color: var(--text-dim); white-space: nowrap; }
+.cp-node.off { opacity: 0.4; }
+.cp-world-foot { flex: none; padding: 12px 14px; border-top: 1px solid var(--border-soft); display: flex; flex-direction: column; gap: 6px; background: rgba(8,9,13,0.7); }
+.cp-world-foot .row { display: flex; justify-content: space-between; font-size: 10.5px; color: var(--text-dim); }
+.cp-world-foot .row b { font-family: var(--font-mono); color: var(--text-mid); font-weight: 500; }
+.cp-world-title { position: absolute; top: 14px; left: 16px; z-index: 3; }
+.cp-world-title .t { font-family: var(--font-display); font-size: 11px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--text-mid); }
+.cp-world-title .s { font-size: 10px; color: var(--text-dim); margin-top: 3px; }
+
+.cp-main { min-height: 0; overflow-y: auto; padding: var(--pad-surface); }
+.cp-main::-webkit-scrollbar { width: 9px; }
+.cp-main::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); }
+.cp-inner { max-width: 1080px; margin: 0 auto; display: flex; flex-direction: column; gap: var(--gap-card); }
+
+.cp-modebar { display: flex; align-items: center; gap: 8px; }
+.cp-mode { display: flex; flex-direction: column; gap: 2px; align-items: flex-start; padding: 8px 14px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-panel); color: var(--text-mid); cursor: pointer; font-family: var(--font-ui); transition: 0.15s; }
+.cp-mode .ml { font-size: 12px; font-weight: 600; color: var(--text-mid); }
+.cp-mode .ms { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); }
+.cp-mode:hover { border-color: var(--border-highlight); }
+.cp-mode.on { border-color: var(--volt); background: var(--volt-wash); box-shadow: 0 0 0 2px var(--volt-wash); }
+.cp-mode.on .ml { color: var(--volt-strong); }
+
+.cp-disc { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; }
+.cp-disc-h { display: flex; align-items: center; gap: 10px; padding: 10px 14px; border-bottom: 1px solid var(--border-soft); }
+.cp-disc-h h3 { font-family: var(--font-display); font-weight: 500; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-mid); margin: 0; white-space: nowrap; }
+.cp-disc-rows { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: var(--border-soft); }
+.cp-disc-row { background: var(--bg-panel); padding: 11px 14px; }
+.cp-disc-row .lvl { font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--volt-strong); }
+.cp-disc-row .ttl { font-size: 12.5px; font-weight: 600; color: var(--text-bright); margin-top: 4px; }
+.cp-disc-row .sum { font-size: 11px; color: var(--text-dim); margin-top: 3px; line-height: 1.5; }
+.cp-disc-row .mtr { display: inline-block; font-family: var(--font-mono); font-size: 10px; color: var(--text-mid); background: var(--bg-card); border: 1px solid var(--border-main); padding: 1px 7px; border-radius: var(--radius-pill); margin-top: 7px; }
+
+.cp-plane { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; }
+.cp-plane-h { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 12px 14px; border-bottom: 1px solid var(--border-soft); background: var(--bg-panel-alt); }
+.cp-plane-h .lft { display: flex; gap: 10px; min-width: 0; }
+.cp-plane-ico { width: 30px; height: 30px; flex: none; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-deep); display: flex; align-items: center; justify-content: center; color: var(--volt-strong); }
+.cp-plane-ico svg { width: 15px; height: 15px; }
+.cp-plane-h h2 { font-family: var(--font-display); font-weight: 600; font-size: 14px; color: var(--text-bright); margin: 0; }
+.cp-plane-h .sum { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+.cp-plane-h .chips { display: flex; gap: 6px; flex: none; }
+.cp-cov { font-family: var(--font-mono); font-size: 9.5px; padding: 2px 8px; border-radius: var(--radius-xs); border: 1px solid; white-space: nowrap; }
+.cp-cov.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 35%, transparent); background: color-mix(in oklab, var(--status-ok) 9%, transparent); }
+.cp-cov.blk { color: var(--text-dim); border-color: var(--border-main); background: var(--bg-deep); }
+
+.cp-routes { display: grid; grid-template-columns: repeat(auto-fill, minmax(225px, 1fr)); gap: 8px; padding: 12px 14px; }
+.cp-route { display: flex; flex-direction: column; justify-content: space-between; gap: 12px; min-height: 86px; text-align: left; padding: 10px 12px; border-radius: var(--radius-sm); border: 1px solid var(--border-soft); background: var(--bg-deep); cursor: pointer; font-family: var(--font-ui); transition: 0.15s; min-width: 0; }
+.cp-route:hover { border-color: var(--border-highlight); background: var(--bg-card); }
+.cp-route:hover .arr { color: var(--volt-strong); }
+.cp-route-top { display: flex; justify-content: space-between; gap: 8px; min-width: 0; }
+.cp-route .rl { font-size: 12.5px; font-weight: 600; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cp-route .rc { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); margin-top: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cp-route .arr { color: var(--text-dim); flex: none; transition: 0.15s; font-size: 12px; }
+.cp-route .cp-cov { align-self: flex-start; }
+
+/* ════ BOARD ════ */
+.bd-body { flex: 1; min-height: 0; display: grid; grid-template-columns: 200px minmax(0, 1fr) minmax(290px, 360px); }
+.bd-body.no-detail { grid-template-columns: 200px minmax(0, 1fr); }
+
+.bd-rail { position: relative; border-right: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); padding: 14px 9px; overflow-y: auto; }
+.bd-rail h4 { font-size: 9.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-dim); margin: 0 0 8px 7px; font-weight: 500; }
+.bd-sub { display: flex; align-items: center; gap: 8px; width: 100%; text-align: left; padding: 7px 9px; border-radius: var(--radius-sm); border: 1px solid transparent; background: none; color: var(--text-mid); font-family: var(--font-ui); font-size: 12.5px; cursor: pointer; transition: 0.13s; white-space: nowrap; overflow: hidden; }
+.bd-sub:hover { background: var(--bg-card); color: var(--text-bright); }
+.bd-sub.on { background: var(--bg-card); color: var(--volt-strong); border-color: var(--volt-dim); }
+.bd-sub .glyph { font-size: 11px; color: var(--text-dim); width: 13px; text-align: center; }
+.bd-sub.on .glyph { color: var(--volt-strong); }
+.bd-sub .n { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.bd-sub .unread { margin-left: auto; width: 7px; height: 7px; border-radius: 50%; background: var(--volt); box-shadow: 0 0 7px var(--volt-glow); }
+.bd-rail .div { height: 1px; background: var(--border-soft); margin: 12px 4px; }
+
+.bd-feed { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+.bd-feed-head { flex: none; display: flex; align-items: center; gap: 10px; padding: 11px 18px; border-bottom: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep)); }
+.bd-feed-head h2 { font-family: var(--font-display); font-weight: 600; font-size: 15px; color: var(--text-bright); margin: 0; white-space: nowrap; }
+.bd-feed-head .ns { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.bd-feed-head .spacer { flex: 1; }
+.bd-filter { font-family: var(--font-ui); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 4px 10px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.bd-filter.on { color: var(--volt-ink); background: var(--volt); border-color: var(--volt); font-weight: 600; }
+.bd-filter:not(.on):hover { color: var(--text-mid); border-color: var(--border-highlight); }
+
+.bd-list { flex: 1; overflow-y: auto; padding: 14px 18px; display: flex; flex-direction: column; gap: 10px; }
+.bd-list::-webkit-scrollbar { width: 9px; }
+.bd-list::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); }
+
+.bd-post { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: var(--pad-card); cursor: pointer; transition: 0.14s; }
+.bd-post:hover { border-color: var(--border-highlight); background: var(--bg-card); }
+.bd-post.sel { border-color: var(--volt-dim); box-shadow: inset 0 0 0 1px var(--volt-wash); background: var(--bg-card); }
+.bd-post-h { display: flex; align-items: center; gap: 9px; }
+.bd-post-h .who { font-family: var(--font-display); font-weight: 600; font-size: 12.5px; color: var(--text-bright); }
+/* author identity — clickable path into the keeper's conversation */
+.bd-wholink { display: inline-flex; align-items: center; gap: 9px; background: none; border: 0; padding: 0; margin: 0; font: inherit; color: inherit; cursor: pointer; border-radius: var(--radius-xs); transition: 0.15s; }
+.bd-wholink.static { cursor: default; }
+.bd-wholink:not(.static):hover .who { color: var(--volt-strong); }
+.bd-av-link { display: inline-flex; padding: 0; border: 0; background: none; cursor: pointer; border-radius: 6px; transition: box-shadow 0.15s; }
+.bd-av-link:hover { box-shadow: 0 0 0 2px var(--volt); }
+.bd-post-h .ts { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); margin-left: auto; flex: none; }
+.bd-badge { font-size: 8.5px; letter-spacing: 0.1em; text-transform: uppercase; padding: 2px 6px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-dim); background: var(--bg-deep); white-space: nowrap; }
+.bd-badge.state { color: var(--info); border-color: color-mix(in oklab, var(--info) 35%, transparent); }
+.bd-badge.pin { color: var(--volt-strong); border-color: var(--volt-dim); }
+.bd-badge.mod { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); }
+.bd-post-title { font-size: 13.5px; font-weight: 600; color: var(--text-bright); margin-top: 8px; line-height: 1.4; }
+.bd-post-body { font-size: 12.5px; color: var(--text-mid); line-height: 1.55; margin-top: 5px; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.bd-post-body code, .bd-th-body code { font-family: var(--font-mono); font-size: 11px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 0 4px; border-radius: var(--radius-xs); color: var(--volt-strong); }
+.bd-post-body .mention, .bd-th-body .mention { color: var(--info); font-family: var(--font-mono); font-size: 11.5px; }
+.bd-post-foot { display: flex; align-items: center; gap: 7px; margin-top: 10px; }
+.bd-react { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 10.5px; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-soft); background: var(--bg-deep); color: var(--text-mid); cursor: pointer; transition: 0.13s; }
+.bd-react:hover { border-color: var(--volt-dim); color: var(--volt-strong); }
+.bd-react.mine { border-color: var(--volt-dim); background: var(--volt-wash); color: var(--volt-strong); }
+.bd-post-foot .replies { margin-left: auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.bd-post-foot .karma { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; }
+.bd-post-foot .karma b { color: var(--volt-strong); font-weight: 600; }
+
+/* state-block post */
+.bd-stateblock { display: grid; grid-template-columns: auto 1fr; gap: 4px 14px; margin-top: 9px; padding: 9px 12px; border-radius: var(--radius-sm); background: var(--bg-sunken); border: 1px dashed var(--border-main); font-family: var(--font-mono); font-size: 11px; }
+.bd-stateblock .sk { color: var(--text-dim); }
+.bd-stateblock .sv { color: var(--text-mid); }
+.bd-stateblock .sv.hl { color: var(--info); }
+
+/* board composer */
+.bd-composer { flex: none; border-top: 1px solid var(--border-main); background: linear-gradient(0deg, var(--bg-panel), var(--bg-deep)); padding: 10px 18px 14px; }
+.bd-comp-tabs { display: flex; gap: 4px; margin-bottom: 8px; }
+.bd-comp-tab { font-family: var(--font-ui); font-size: 11px; padding: 4px 11px; border-radius: 4px 4px 0 0; border: 1px solid transparent; background: none; color: var(--text-dim); cursor: pointer; white-space: nowrap; }
+.bd-comp-tab.on { color: var(--volt-strong); border-color: var(--border-main); border-bottom-color: var(--bg-deep); background: var(--bg-card); }
+.bd-comp-box { display: flex; gap: 10px; align-items: flex-end; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 5px 5px 5px 13px; }
+.bd-comp-box:focus-within { border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); }
+.bd-comp-box textarea { flex: 1; resize: none; border: 0; outline: 0; background: transparent; color: var(--text-bright); font-family: var(--font-ui); font-size: 13px; line-height: 1.5; padding: 8px 0; min-height: 21px; max-height: 120px; }
+.bd-comp-box textarea::placeholder { color: var(--text-dim); }
+
+/* board detail rail (thread) */
+.bd-detail { border-left: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; min-height: 0; }
+.bd-detail-h { flex: none; display: flex; align-items: center; gap: 9px; padding: 12px 14px; border-bottom: 1px solid var(--border-soft); }
+.bd-detail-h h3 { font-family: var(--font-display); font-weight: 500; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-mid); margin: 0; flex: 1; }
+.bd-detail-x { background: none; border: 0; color: var(--text-dim); cursor: pointer; font-size: 13px; padding: 3px 6px; border-radius: var(--radius-sm); }
+.bd-detail-x:hover { color: var(--text-bright); background: var(--bg-card); }
+.bd-detail-scroll { flex: 1; overflow-y: auto; padding: 14px; display: flex; flex-direction: column; gap: 11px; }
+.bd-th { display: grid; grid-template-columns: 26px 1fr; gap: 9px; }
+.bd-th-hd { display: flex; align-items: baseline; gap: 7px; }
+.bd-th-hd .who { font-family: var(--font-display); font-weight: 600; font-size: 12px; color: var(--text-bright); }
+.bd-th-hd .ts { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+.bd-th-body { font-size: 12.5px; color: var(--text-primary); line-height: 1.6; margin-top: 3px; }
+.bd-mention-row { display: flex; align-items: flex-start; gap: 9px; padding: 9px 10px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); cursor: pointer; transition: 0.13s; }
+.bd-mention-row:hover { border-color: var(--border-highlight); }
+.bd-mention-row .txt { font-size: 11.5px; color: var(--text-mid); line-height: 1.5; min-width: 0; }
+.bd-mention-row .txt b { color: var(--text-bright); font-weight: 600; }
+.bd-mention-row .ts { margin-left: auto; flex: none; font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); }
+
+/* ════ CONNECTORS ════ */
+.cn-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(330px, 1fr)); gap: var(--gap-card); margin-bottom: 16px; }
+.cn-card { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; display: flex; flex-direction: column; }
+.cn-card.stale { border-color: color-mix(in oklab, var(--status-warn) 35%, var(--border-main)); }
+.cn-card.down { border-color: color-mix(in oklab, var(--status-bad) 30%, var(--border-main)); }
+.cn-h { display: flex; align-items: center; gap: 11px; padding: 13px 15px; border-bottom: 1px solid var(--border-soft); background: var(--bg-panel-alt); }
+.cn-glyph { width: 34px; height: 34px; flex: none; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-deep); display: flex; align-items: center; justify-content: center; font-size: 15px; color: var(--volt-strong); }
+.cn-h .meta { min-width: 0; flex: 1; }
+.cn-h .nm { font-family: var(--font-display); font-weight: 600; font-size: 14px; color: var(--text-bright); }
+.cn-h .ch { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); margin-top: 3px; }
+.cn-kv { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border-soft); border-bottom: 1px solid var(--border-soft); }
+.cn-kv .cell { background: var(--bg-panel); padding: 8px 15px; }
+.cn-kv .k { font-size: 8.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+.cn-kv .v { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); margin-top: 3px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cn-kv .v.hl { color: var(--volt-strong); }
+.cn-caps { display: flex; flex-wrap: wrap; gap: 5px; padding: 10px 15px; border-bottom: 1px solid var(--border-soft); }
+.cn-cap { font-family: var(--font-mono); font-size: 9.5px; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); background: var(--bg-deep); white-space: nowrap; }
+.cn-bind { padding: 10px 15px 13px; flex: 1; }
+.cn-bind h5 { font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); margin: 0 0 9px; font-weight: 600; }
+.cn-bind-row { display: flex; align-items: center; gap: 9px; padding: 7px 0; font-family: var(--font-mono); font-size: 12.5px; border-bottom: 1px dashed var(--border-soft); }
+.cn-bind-row:last-child { border-bottom: 0; }
+/* binding row as a button — routes into the bound keeper's conversation */
+button.cn-bind-row { width: 100%; background: none; border-left: 0; border-right: 0; border-top: 0; text-align: left; cursor: pointer; transition: 0.14s; margin: 0; }
+button.cn-bind-row:hover { background: var(--volt-wash); }
+button.cn-bind-row:hover .cn-bind-go { color: var(--volt-strong); transform: translateX(2px); }
+.cn-bind-go { margin-left: auto; flex: none; color: var(--text-dim); font-family: var(--font-mono); transition: 0.14s; }
+.cn-bind-row .chn { color: var(--text-mid); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cn-bind-row .arr { color: var(--text-dim); flex: none; }
+.cn-bind-none { font-size: 11px; color: var(--text-dim); padding: 4px 0; }
+
+/* binding editor (connector config drawer) */
+.cn-be { border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 9px 11px; margin-bottom: 8px; background: var(--bg-card); transition: opacity 0.14s; }
+.cn-be.off { opacity: 0.5; }
+.cn-be-main { display: flex; align-items: center; gap: 8px; }
+.cn-be-chn { flex: 1; min-width: 0; font-size: 12px; padding: 5px 8px; background: var(--bg-sunken); color: var(--text-bright); border: 1px solid var(--border-main); border-radius: var(--radius-xs); outline: none; }
+.cn-be-chn:focus { border-color: var(--volt-dim); }
+.cn-be-arr { color: var(--text-dim); flex: none; }
+.cn-be-kp { display: flex; align-items: center; gap: 6px; flex: none; }
+.cn-be-sel { font-size: 12px; padding: 5px 8px; background: var(--bg-sunken); color: var(--text-bright); border: 1px solid var(--border-main); border-radius: var(--radius-xs); outline: none; cursor: pointer; }
+.cn-be-sel:focus { border-color: var(--volt-dim); }
+.cn-be-del { flex: none; width: 24px; height: 24px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; font-size: 11px; transition: 0.14s; }
+.cn-be-del:hover { border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); color: var(--status-bad); }
+.cn-be-opts { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 8px; }
+.cn-be-dir { display: inline-flex; border: 1px solid var(--border-main); border-radius: var(--radius-xs); overflow: hidden; }
+.cn-dir-b { font-family: var(--font-ui); font-size: 10.5px; padding: 4px 10px; background: transparent; border: 0; color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.cn-dir-b:not(:last-child) { border-right: 1px solid var(--border-main); }
+.cn-dir-b:hover { color: var(--text-mid); }
+.cn-dir-b.on { background: var(--volt-wash); color: var(--volt); }
+.set-toggle.sm { width: 32px; height: 18px; }
+.set-toggle.sm .knob { width: 13px; height: 13px; }
+.set-toggle.sm.on .knob { left: 16px; }
+
+.cn-audit { background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 14px 16px; }
+.cn-audit table { width: 100%; border-collapse: collapse; font-size: 11.5px; }
+.cn-audit th { text-align: left; font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); font-weight: 500; padding: 4px 10px 8px 0; border-bottom: 1px solid var(--border-main); }
+.cn-audit td { padding: 7px 10px 7px 0; border-bottom: 1px solid var(--border-soft); color: var(--text-mid); font-family: var(--font-mono); font-size: 10.5px; white-space: nowrap; }
+.cn-audit td.act { color: var(--text-bright); font-family: var(--font-ui); font-size: 11.5px; white-space: normal; }
+.cn-audit tr:last-child td { border-bottom: 0; }
+
+.gate-strip { display: flex; align-items: center; gap: 14px; padding: 10px 16px; border: 1px solid var(--border-main); border-radius: var(--radius-md); background: var(--bg-panel); margin-bottom: 16px; font-size: 12px; color: var(--text-mid); flex-wrap: wrap; }
+.gate-strip .sep { width: 1px; height: 16px; background: var(--border-soft); }
+.gate-strip b { color: var(--text-bright); font-weight: 600; }
+.gate-strip .mono { font-size: 11px; }
+
+/* ════ IDE ════ */
+.ide { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--bg-deep); }
+.ide-top { flex: none; display: flex; align-items: center; gap: 12px; height: 42px; padding: 0 14px; border-bottom: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep)); }
+.ide-repo { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); }
+.ide-repo .br { color: var(--volt-strong); }
+.ide-remote { color: var(--text-bright); cursor: pointer; transition: color 0.14s; background: none; border: 0; padding: 0; font: inherit; }
+.ide-remote:hover { color: var(--volt); text-decoration: underline; text-underline-offset: 2px; }
+.ide-remote::before { content: "⎇ "; color: var(--text-dim); }
+.ide-web { color: var(--text-dim); text-decoration: none; margin: 0 6px 0 5px; font-size: 11px; transition: color 0.14s; }
+.ide-web:hover { color: var(--volt); }
+
+/* ════ SETTINGS SURFACE ════ */
+.settings-surf { display: flex; min-width: 0; min-height: 0; }
+.set-shell { display: flex; flex: 1; min-width: 0; min-height: 0; }
+.set-nav { width: 218px; flex: none; border-right: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; overflow-y: auto; padding-bottom: 10px; }
+.set-nav-h { padding: 18px 18px 14px; border-bottom: 1px solid var(--border-soft); margin-bottom: 8px; }
+.set-nav-h .eyebrow { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--volt-strong); }
+.set-nav-title { font-family: var(--font-display); font-weight: 400; text-transform: uppercase; letter-spacing: 0.14em; font-size: 19px; color: var(--text-bright); margin: 4px 0 5px; }
+.set-nav-sub { font-size: 10.5px; color: var(--text-dim); }
+.set-nav-item { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; margin: 1px 8px; padding: 9px 11px; border-radius: var(--radius-sm); background: none; border: 1px solid transparent; cursor: pointer; transition: 0.14s; text-align: left; outline: none; }
+.set-nav-item .ko { font-size: 13px; color: var(--text-mid); }
+.set-nav-item .en { font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); }
+.set-nav-item:hover { background: var(--bg-card); }
+.set-nav-item:hover .ko { color: var(--text-bright); }
+.set-nav-item.on { background: var(--volt-wash); border-color: var(--volt-dim); }
+.set-nav-item.on .ko { color: var(--volt-strong); }
+.set-nav-item.on .en { color: var(--volt); }
+.set-nav-group { display: flex; flex-direction: column; margin-bottom: 5px; }
+.set-nav-glabel { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); padding: 13px 19px 4px; }
+@media (max-width: 900px) {
+  .set-nav-group { display: contents; }
+  .set-nav-glabel { display: none; }
+}
+
+.set-content { flex: 1; min-width: 0; overflow-y: auto; }
+.set-content-h { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 22px 28px 16px; border-bottom: 1px solid var(--border-soft); position: sticky; top: 0; background: var(--bg-deep); z-index: 2; }
+.set-content-h h1 { font-family: var(--font-display); font-weight: 400; text-transform: uppercase; letter-spacing: 0.1em; font-size: 22px; color: var(--text-bright); margin: 0; white-space: nowrap; }
+.settings-surf .set-card-b { padding: 8px 28px 40px; max-width: 760px; }
+
+.set-row { display: flex; align-items: center; gap: 14px; padding: 13px 0; border-top: 1px solid var(--border-soft); }
+.set-row:first-child { border-top: 0; }
+.set-row-l { flex: 1; min-width: 0; }
+.set-label { font-size: 13px; color: var(--text-primary); }
+.set-hint { font-size: 11px; color: var(--text-dim); margin-top: 3px; }
+.set-row-c { flex: none; }
+.set-sub-h { font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); margin: 18px 0 2px; }
+.set-link { background: none; border: 0; color: var(--volt); cursor: pointer; font: inherit; padding: 0; text-decoration: underline; text-underline-offset: 2px; }
+.set-mcp-detail { margin: -4px 0 4px; padding: 8px 11px; background: var(--bg-well); border: 1px solid var(--border-soft); border-radius: var(--radius-xs); font-size: 11px; color: var(--text-dim); overflow-x: auto; white-space: nowrap; }
+.set-nav-note { margin: auto 12px 12px; font-size: 10px; line-height: 1.5; color: var(--text-dim); padding-top: 12px; border-top: 1px solid var(--border-soft); }
+
+.set-verify { font-family: var(--font-ui); font-size: 11px; padding: 6px 11px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid); cursor: pointer; white-space: nowrap; transition: 0.14s; }
+.set-verify:hover { border-color: var(--volt-dim); color: var(--volt); }
+.set-verify.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); }
+.set-verify.checking { color: var(--text-dim); }
+.set-path { display: flex; align-items: center; gap: 7px; }
+.set-path .set-input { width: 260px; }
+
+.set-rolepill { font-family: var(--font-mono); font-size: 11px; color: var(--volt-strong); border: 1px solid var(--volt-dim); background: var(--volt-wash); padding: 3px 10px; border-radius: var(--radius-pill); }
+
+.set-rt { border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 11px 13px; margin-top: 10px; background: var(--bg-card); }
+.set-rt-top { display: flex; align-items: center; gap: 10px; margin-bottom: 9px; }
+.set-rt-name { font-size: 13px; color: var(--text-bright); }
+.set-rt-kind { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); border: 1px solid var(--border-main); padding: 1px 7px; border-radius: var(--radius-pill); }
+.set-rt-keepers { font-size: 11px; color: var(--text-dim); }
+.set-rt-top .set-verify { margin-left: auto; }
+.set-rt-row { display: flex; align-items: center; gap: 9px; margin-top: 6px; }
+.set-rt-row .sub-k { min-width: 62px; }
+.set-rt-row .set-input { flex: 1; }
+
+.set-toml-wrap { margin-top: 8px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-well); }
+.set-toml-bar { display: flex; align-items: center; gap: 10px; padding: 7px 11px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); font-size: 11px; color: var(--text-dim); }
+.set-toml-bar .mono { color: var(--text-mid); }
+.set-toml-ro { font-size: 10px; }
+.set-toml-bar .set-verify { margin-left: auto; }
+.set-toml { margin: 0; padding: 12px 14px; overflow-x: auto; }
+.set-toml code { font-family: var(--font-mono); font-size: 12px; line-height: 1.6; color: var(--text-primary); white-space: pre; }
+
+/* system log viewer */
+.log-view { border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-well); }
+.log-filters { display: flex; align-items: center; gap: 5px; padding: 8px 10px; border-bottom: 1px solid var(--border-soft); background: var(--bg-panel); }
+.log-f { font-family: var(--font-ui); font-size: 11px; padding: 4px 11px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.log-f:hover { color: var(--text-mid); }
+.log-f.on { color: var(--volt-ink); background: var(--volt); border-color: var(--volt); }
+.log-live { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 10.5px; color: var(--status-ok); }
+.log-stream { max-height: 320px; overflow-y: auto; padding: 6px 0; }
+.log-line { display: grid; grid-template-columns: 64px 44px 96px 1fr 16px; gap: 8px; align-items: baseline; padding: 4px 12px; font-size: 11.5px; line-height: 1.4; }
+.log-line:hover { background: var(--bg-panel-alt); }
+.log-line .lt { color: var(--text-dim); }
+.log-line .ll { text-transform: uppercase; font-size: 9px; letter-spacing: 0.06em; }
+.log-line .ll.info { color: var(--text-dim); }
+.log-line .ll.warn { color: var(--status-warn); }
+.log-line .ll.error { color: var(--status-bad); }
+.log-line .lk { color: var(--volt-strong); }
+.log-line .lm { color: var(--text-mid); }
+.log-line .ls.ok { color: var(--status-ok); }
+.log-line .ls.fail { color: var(--status-bad); }
+.log-line .ls.warn { color: var(--status-warn); }
+
+.set-toggle { width: 38px; height: 22px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: var(--bg-sunken); cursor: pointer; padding: 0; position: relative; transition: 0.16s; }
+.set-toggle .knob { position: absolute; top: 2px; left: 2px; width: 16px; height: 16px; border-radius: 50%; background: var(--text-dim); transition: 0.16s; }
+.set-toggle.on { background: var(--volt-wash); border-color: var(--volt-dim); }
+.set-toggle.on .knob { left: 18px; background: var(--volt); }
+
+.set-seg { display: inline-flex; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.set-seg-b { font-family: var(--font-mono); font-size: 11px; padding: 5px 11px; background: transparent; color: var(--text-dim); border: 0; border-left: 1px solid var(--border-main); cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.set-seg-b:first-child { border-left: 0; }
+.set-seg-b:hover { color: var(--text-mid); background: var(--bg-card); }
+.set-seg-b.on { color: var(--volt-ink); background: var(--volt); }
+
+.set-stepper { display: inline-flex; align-items: center; gap: 10px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 3px 8px; }
+.set-stepper button { width: 22px; height: 22px; border: 0; background: var(--bg-card); color: var(--text-mid); border-radius: var(--radius-xs); cursor: pointer; font-size: 14px; }
+.set-stepper button:hover { color: var(--volt); }
+.set-stepper .mono { min-width: 18px; text-align: center; color: var(--text-bright); }
+
+.set-slider { display: inline-flex; align-items: center; gap: 10px; }
+.set-slider input[type=range] { width: 130px; accent-color: var(--volt); }
+.set-slider .mono { color: var(--text-bright); min-width: 36px; }
+
+.set-input { font-family: var(--font-mono); font-size: 12px; padding: 7px 10px; background: var(--bg-sunken); color: var(--text-primary); border: 1px solid var(--border-main); border-radius: var(--radius-sm); outline: none; width: 230px; }
+.set-input:focus { border-color: var(--volt-dim); box-shadow: 0 0 0 2px var(--volt-wash); }
+
+.set-policy-legend { display: flex; flex-wrap: wrap; gap: 14px; padding: 4px 0 10px; font-size: 11px; color: var(--text-dim); }
+.set-policy-legend b { color: var(--text-mid); }
+.set-add { margin-top: 12px; width: 100%; padding: 9px; background: var(--bg-sunken); border: 1px dashed var(--border-highlight); border-radius: var(--radius-sm); color: var(--text-mid); cursor: pointer; font-family: var(--font-ui); font-size: 12px; transition: 0.14s; }
+.set-add:hover { border-color: var(--volt-dim); color: var(--volt); }
+
+/* ── tool-group policy ─────────────────────────────────────── */
+.set-tg-row { display: flex; align-items: flex-start; gap: 14px; padding: 12px 0; border-bottom: 1px solid var(--border-soft); }
+.set-tg-l { flex: 1; min-width: 0; }
+.set-tg-head { display: flex; align-items: center; flex-wrap: wrap; gap: 7px; margin-bottom: 7px; }
+.set-tg-id { font-size: 12.5px; color: var(--text-bright); }
+.set-tg-kind { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase; padding: 2px 6px; border-radius: var(--radius-xs); border: 1px solid var(--border-soft); color: var(--text-dim); }
+.set-tg-kind.masc { color: var(--volt); border-color: var(--volt-dim); background: var(--volt-wash); }
+.set-tg-kind.guard { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 45%, transparent); }
+.set-tg-kind.optin { color: var(--text-mid); }
+.set-tg-tools { display: flex; flex-wrap: wrap; gap: 5px; }
+.set-tg-chip { font-size: 10.5px; padding: 2px 7px; background: var(--bg-well); border: 1px solid var(--border-soft); border-radius: var(--radius-xs); color: var(--text-mid); }
+.set-tg-chip.safe { border-color: color-mix(in oklab, var(--status-ok) 35%, transparent); color: color-mix(in oklab, var(--status-ok) 80%, var(--text-mid)); }
+
+.set-guard { display: flex; align-items: center; flex-wrap: wrap; gap: 9px; padding: 4px 0 4px; }
+.set-guard-step { font-size: 12px; padding: 6px 12px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); color: var(--text-bright); box-shadow: inset 0 0 0 1px var(--volt-wash); }
+.set-guard-arrow { color: var(--text-dim); font-size: 13px; }
+
+/* ── fusion preset ─────────────────────────────────────────── */
+.set-fus-preset { display: grid; grid-template-columns: 1fr; gap: 12px; }
+.set-fus-lane { padding: 11px 13px; background: var(--bg-well); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); }
+.set-fus-lane-h { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); margin-bottom: 8px; }
+.set-fus-model { font-size: 12px; color: var(--text-mid); padding: 5px 9px; background: var(--bg-card); border: 1px solid var(--border-soft); border-radius: var(--radius-xs); margin-bottom: 5px; }
+.set-fus-model:last-child { margin-bottom: 0; }
+.set-fus-model.judge { color: var(--volt); border-color: var(--volt-dim); background: var(--volt-wash); }
+
+/* ── discord trigger radio list ────────────────────────────── */
+.set-trigger { display: flex; align-items: flex-start; gap: 10px; width: 100%; text-align: left; padding: 10px 12px; margin-bottom: 6px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); cursor: pointer; transition: 0.14s; }
+.set-trigger:hover { border-color: var(--volt-dim); }
+.set-trigger.on { border-color: var(--volt-dim); background: var(--volt-wash); }
+.set-trigger-radio { flex: none; width: 15px; height: 15px; margin-top: 2px; border-radius: 50%; border: 1.5px solid var(--border-highlight); transition: 0.14s; }
+.set-trigger.on .set-trigger-radio { border-color: var(--volt); box-shadow: inset 0 0 0 3px var(--volt); }
+.set-trigger-l { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.set-trigger-l .mono { font-size: 12.5px; color: var(--text-bright); }
+.set-trigger-hint { font-size: 11px; color: var(--text-dim); }
+
+.cn-config { margin-left: 8px; width: 26px; height: 26px; flex: none; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-main); color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.cn-config:hover { border-color: var(--volt-dim); color: var(--volt); }
+
+@media (max-width: 900px) {
+  .set-shell { flex-direction: column; }
+  .set-nav { width: auto; flex-direction: row; overflow-x: auto; border-right: 0; border-bottom: 1px solid var(--border-main); padding: 0; }
+  .set-nav-h { display: none; }
+  .set-nav-item { flex: none; margin: 6px 2px; }
+  .set-nav-item .en { display: none; }
+  .settings-surf .set-card-b { padding: 8px 16px 80px; max-width: 100%; }
+  .set-content-h { padding: 16px; }
+  .set-input { width: 100%; }
+}
+.ide-views { display: flex; gap: 3px; margin-left: 8px; }
+.ide-view { font-family: var(--font-ui); font-size: 11px; padding: 5px 12px; border-radius: var(--radius-sm); border: 1px solid transparent; background: none; color: var(--text-dim); cursor: pointer; transition: 0.13s; }
+.ide-view:hover { color: var(--text-mid); background: var(--bg-card); }
+.ide-view.on { color: var(--volt-strong); background: var(--bg-card); border-color: var(--border-main); }
+.ide-top .spacer { flex: 1; }
+.ide-presence { display: flex; align-items: center; gap: 5px; }
+.ide-presence .lbl { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); margin-right: 4px; }
+
+.ide-body { flex: 1; min-height: 0; display: grid; grid-template-columns: 230px minmax(0, 1fr) minmax(270px, 320px); }
+.ide-body.no-tree { grid-template-columns: 0 minmax(0, 1fr) minmax(270px, 320px); }
+.ide-body.no-rail { grid-template-columns: 230px minmax(0, 1fr) 0; }
+.ide-body.no-tree.no-rail { grid-template-columns: 0 minmax(0, 1fr) 0; }
+
+/* file tree */
+.ide-tree { position: relative; border-right: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); overflow-y: auto; padding: 10px 7px; min-width: 0; }
+/* shared draggable column edge (board rail · IDE tree) */
+.col-resizer { position: absolute; top: 0; bottom: 0; right: -3px; width: 7px; z-index: 20; cursor: col-resize; }
+.col-resizer::after { content: ''; position: absolute; top: 0; bottom: 0; left: 3px; width: 1px; background: transparent; transition: background 0.14s; }
+.col-resizer:hover::after { background: var(--volt-dim); width: 2px; }
+.ide-tree h4 { font-size: 9px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-dim); margin: 2px 0 8px 8px; font-weight: 500; }
+.ide-fnode { display: flex; align-items: center; gap: 7px; width: 100%; text-align: left; padding: 4px 8px; border-radius: var(--radius-sm); border: 0; background: none; color: var(--text-mid); font-family: var(--font-mono); font-size: 11.5px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; transition: 0.12s; }
+.ide-fnode:hover { background: var(--bg-card); color: var(--text-bright); }
+.ide-fnode.on { background: var(--bg-card); color: var(--volt-strong); }
+.ide-fnode .tw { color: var(--text-dim); font-size: 9px; width: 10px; flex: none; }
+.ide-fnode .dirty { width: 6px; height: 6px; border-radius: 50%; background: var(--status-warn); margin-left: auto; flex: none; }
+.ide-fnode .kcur { margin-left: auto; flex: none; }
+.ide-fnode .kcur + .dirty { margin-left: 4px; }
+
+/* editor */
+.ide-ed { display: flex; flex-direction: column; min-width: 0; min-height: 0; }
+.ide-crumb { flex: none; display: flex; align-items: center; gap: 7px; padding: 7px 14px; border-bottom: 1px solid var(--border-soft); background: var(--bg-sunken); font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); overflow-x: auto; white-space: nowrap; }
+.ide-crumb .seg { color: var(--text-dim); } .ide-crumb .seg.last { color: var(--text-mid); }
+.ide-crumb .own { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; color: var(--text-dim); flex: none; }
+.ide-code { flex: 1; overflow: auto; font-family: var(--font-mono); font-size: 12px; line-height: 1.75; padding: 10px 0 28px; position: relative; }
+.ide-code::-webkit-scrollbar { width: 9px; height: 9px; }
+.ide-code::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); }
+.cl { display: flex; min-width: max-content; position: relative; padding: 0 18px 0 0; }
+.cl .ln { width: 52px; flex: none; text-align: right; padding-right: 14px; color: #3d3f4e; user-select: none; }
+.cl .lc { white-space: pre; color: var(--text-primary); }
+.cl:hover { background: rgba(255,255,255,0.018); }
+.cl.hl-cursor { background: color-mix(in oklab, var(--kc, var(--kp1)) 7%, transparent); box-shadow: inset 2.5px 0 0 var(--kc, var(--kp1)); }
+.cl.hl-ann { background: color-mix(in oklab, var(--status-warn) 5%, transparent); }
+.cl .ann-pin { position: sticky; right: 10px; margin-left: 18px; align-self: center; }
+/* syntax tints (OCaml-ish) */
+.tk-kw { color: #c792ea; } .tk-fn { color: var(--info); } .tk-str { color: var(--status-ok); }
+.tk-com { color: #586073; font-style: italic; } .tk-num { color: var(--volt-strong); } .tk-mod { color: var(--accent-bone); }
+
+.cursor-tag { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); font-size: 8.5px; padding: 1px 7px 1px 2px; border-radius: var(--radius-pill); color: #0b0c10; background: var(--kc, var(--kp1)); margin-left: 16px; vertical-align: middle; white-space: nowrap; }
+.cursor-tag .fm { opacity: 0.75; }
+
+.ann-pin { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-ui); font-size: 9.5px; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid color-mix(in oklab, var(--status-warn) 45%, transparent); background: color-mix(in oklab, var(--status-warn) 12%, var(--bg-deep)); color: var(--status-warn); cursor: pointer; white-space: nowrap; }
+.ann-pin.risk { border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); background: color-mix(in oklab, var(--status-bad) 10%, var(--bg-deep)); color: var(--status-bad); }
+
+/* diff view */
+.ide-diff { flex: 1; overflow: auto; display: grid; grid-template-columns: 1fr 1fr; font-family: var(--font-mono); font-size: 11.5px; line-height: 1.7; }
+.ide-diff .pane { min-width: 0; border-right: 1px solid var(--border-soft); padding: 8px 0 24px; }
+.ide-diff .pane:last-child { border-right: 0; }
+.ide-diff .pane-h { position: sticky; top: 0; padding: 4px 14px 6px; font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); background: var(--bg-deep); border-bottom: 1px solid var(--border-soft); margin-bottom: 6px; z-index: 2; display: flex; gap: 8px; align-items: center; }
+.ide-diff .pane-h .sha { color: var(--volt-strong); text-transform: none; letter-spacing: 0; }
+.dl { display: flex; padding-right: 14px; }
+.dl .ln { width: 44px; flex: none; text-align: right; padding-right: 12px; color: #3d3f4e; user-select: none; }
+.dl .lc { white-space: pre; color: var(--text-primary); min-width: 0; }
+.dl.add { background: color-mix(in oklab, var(--status-ok) 8%, transparent); box-shadow: inset 2px 0 0 var(--status-ok); }
+.dl.del { background: color-mix(in oklab, var(--status-bad) 8%, transparent); box-shadow: inset 2px 0 0 var(--status-bad); }
+.dl.pad { opacity: 0.35; }
+
+/* activity rail */
+.ide-rail { border-left: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; min-height: 0; min-width: 0; }
+.ide-rail-tabs { flex: none; display: flex; gap: 2px; padding: 9px 10px 0; border-bottom: 1px solid var(--border-soft); }
+.ide-rail-tab { font-family: var(--font-ui); font-size: 11px; padding: 6px 11px; border: 0; background: none; color: var(--text-dim); cursor: pointer; border-bottom: 2px solid transparent; }
+.ide-rail-tab.on { color: var(--volt-strong); border-bottom-color: var(--volt); }
+.ide-rail-scroll { flex: 1; overflow-y: auto; padding: 11px 12px; display: flex; flex-direction: column; gap: 9px; }
+.ide-ev { display: grid; grid-template-columns: 24px 1fr; gap: 8px; padding: 8px 9px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); }
+.ide-ev .ico { width: 22px; height: 22px; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; font-size: 10px; background: var(--bg-deep); border: 1px solid var(--border-main); color: var(--text-dim); }
+.ide-ev.tool .ico { color: var(--info); } .ide-ev.pr .ico { color: var(--volt-strong); } .ide-ev.turn .ico { color: var(--text-mid); }
+.ide-ev .hd { display: flex; align-items: baseline; gap: 7px; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-bright); flex-wrap: wrap; }
+.ide-ev .hd .lat { color: var(--text-dim); font-size: 9.5px; }
+.ide-ev .hd .ts { margin-left: auto; color: var(--text-dim); font-size: 9px; }
+.ide-ev .sum { font-size: 11px; color: var(--text-mid); margin-top: 3px; line-height: 1.5; font-family: var(--font-ui); }
+.ide-ev .fp { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); margin-top: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ide-ev .prstate { font-size: 9px; letter-spacing: 0.08em; text-transform: uppercase; padding: 1px 6px; border-radius: var(--radius-xs); border: 1px solid; }
+.ide-ev .prstate.open { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); }
+.ide-ev .prstate.merged { color: #b48af0; border-color: #4a3f8a; }
+
+.ide-ann-card { padding: 9px 11px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); }
+.ide-ann-card .hd { display: flex; align-items: center; gap: 7px; font-size: 10.5px; color: var(--text-dim); font-family: var(--font-mono); }
+.ide-ann-card .hd .kind { font-size: 8.5px; letter-spacing: 0.1em; text-transform: uppercase; padding: 1px 6px; border-radius: var(--radius-xs); border: 1px solid color-mix(in oklab, var(--status-warn) 40%, transparent); color: var(--status-warn); }
+.ide-ann-card .hd .kind.risk { border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); color: var(--status-bad); }
+.ide-ann-card .bd { font-size: 11.5px; color: var(--text-primary); line-height: 1.55; margin-top: 6px; }
+.ide-ann-card .lk { display: flex; gap: 6px; margin-top: 7px; }
+.ide-ann-card .lk span { font-family: var(--font-mono); font-size: 9.5px; color: var(--volt-strong); background: var(--volt-wash); border: 1px solid var(--volt-dim); padding: 1px 7px; border-radius: var(--radius-pill); }
+
+/* execute output drawer */
+.ide-drawer { flex: none; border-top: 1px solid var(--border-main); background: var(--bg-well); display: flex; flex-direction: column; max-height: 200px; }
+.ide-drawer.closed { max-height: 30px; }
+.ide-drawer-h { flex: none; display: flex; align-items: center; gap: 10px; padding: 5px 14px; cursor: pointer; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); user-select: none; }
+.ide-drawer-h:hover { color: var(--text-mid); }
+.ide-drawer-h .chev { transition: transform 0.18s; font-size: 9px; }
+.ide-drawer.closed .ide-drawer-h .chev { transform: rotate(-90deg); }
+.ide-drawer-h .ok { color: var(--status-ok); }
+.ide-drawer-body { overflow-y: auto; padding: 2px 14px 12px; font-family: var(--font-mono); font-size: 11px; line-height: 1.7; color: var(--text-mid); }
+.ide-drawer.closed .ide-drawer-body { display: none; }
+.ide-drawer-body .out-ok { color: var(--status-ok); }
+.ide-drawer-body .out-dim { color: #586073; }
+
+/* responsive */
+@media (max-width: 1280px) {
+  .ov-kpis { grid-template-columns: repeat(3, 1fr); }
+  .ov-grid { grid-template-columns: 1fr; }
+  .bd-body { grid-template-columns: 170px minmax(0, 1fr); }
+  .bd-detail { display: none; }
+  .cp-body { grid-template-columns: minmax(0, 1fr); }
+  .cp-world { display: none; }
+  .ide-body { grid-template-columns: 200px minmax(0, 1fr); }
+  .ide-rail { display: none; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   TYPE LADDER — authoritative heading normalization
+   One ladder for every surface. Loads last so it wins source order;
+   values come from --fs/--fw/--tr tokens in v2.css. Editing a tier
+   here changes every title of that level at once.
+   ══════════════════════════════════════════════════════════════ */
+
+/* T1 — surface / subject title (개요 · 커넥터 · Command Map · keeper 이름) */
+.ov-head h1,
+.surf-head h1,
+.chat-id h2 {
+  font-family: var(--font-display);
+  font-weight: var(--fw-t1);
+  font-size: var(--fs-t1);
+  letter-spacing: var(--tr-t1);
+  text-transform: none;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+/* T2 — region / panel title (Work·Comms 플레인 · 전체 피드) */
+.cp-plane-h h2,
+.bd-feed-head h2 {
+  font-family: var(--font-display);
+  font-weight: var(--fw-t2);
+  font-size: var(--fs-t2);
+  letter-spacing: var(--tr-t2);
+  text-transform: none;
+  color: var(--text-bright);
+  margin: 0;
+}
+
+/* T3 — card / section header (주의 필요 · 텔레메트리 · Progressive Disclosure
+   · Keepers · 활력 지표 · 최근 감사 로그) */
+.ov-card-h h3,
+.cp-disc-h h3,
+.roster-title h3,
+.ctx-sec h4 {
+  font-family: var(--font-display);
+  font-weight: var(--fw-t3);
+  font-size: var(--fs-t3);
+  letter-spacing: var(--tr-t3);
+  text-transform: uppercase;
+  color: var(--text-mid);
+  margin: 0;
+  white-space: nowrap;
+}
+
+/* T4 — micro label (서브보드 · 바인딩 · 파일트리) */
+.bd-rail h4,
+.cn-bind h5,
+.ide-tree h4 {
+  font-family: var(--font-ui);
+  font-weight: var(--fw-t4);
+  font-size: var(--fs-t4);
+  letter-spacing: var(--tr-t4);
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+
+/* ════════════════════════════════════════════════════════════════
+   APPROVALS — HILT 결재 큐
+   ════════════════════════════════════════════════════════════════ */
+.ap-sla { font-size: 11px; color: var(--status-warn); border: 1px solid color-mix(in oklab, var(--status-warn) 35%, var(--border-main)); background: color-mix(in oklab, var(--status-warn) 8%, transparent); padding: 4px 10px; border-radius: var(--radius-pill); white-space: nowrap; }
+
+.ap-queue { display: flex; flex-direction: column; gap: 10px; margin-bottom: 22px; }
+.ap-card { display: flex; background: var(--bg-panel); border: 1px solid var(--border-main); border-radius: var(--radius-md); overflow: hidden; transition: border-color 0.16s; }
+.ap-card:hover { border-color: var(--border-highlight); }
+.ap-card .ap-rail { flex: none; width: 3px; background: var(--border-main); }
+.ap-card.sev-bad  .ap-rail { background: var(--status-bad); }
+.ap-card.sev-warn .ap-rail { background: var(--status-warn); }
+.ap-card.sev-info .ap-rail { background: var(--volt-dim); }
+.ap-card.sev-bad { border-color: color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); background: linear-gradient(100deg, color-mix(in oklab, var(--status-bad) 6%, var(--bg-panel)), var(--bg-panel) 60%); }
+.ap-main { flex: 1; min-width: 0; padding: 13px 16px 14px; }
+
+.ap-h { display: flex; align-items: center; gap: 9px; }
+.ap-kind { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 7px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-mid); white-space: nowrap; }
+.ap-kind.sev-bad  { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); background: color-mix(in oklab, var(--status-bad) 9%, transparent); }
+.ap-kind.sev-warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 42%, transparent); background: color-mix(in oklab, var(--status-warn) 7%, transparent); }
+.ap-kind.sev-info { color: var(--volt-strong); border-color: var(--volt-dim); background: var(--volt-wash); }
+.ap-tool { font-size: 10px; color: var(--text-dim); }
+.ap-id { font-size: 10px; color: var(--text-dim); margin-left: auto; letter-spacing: 0.06em; }
+.ap-age { font-size: 10px; font-family: var(--font-mono); color: var(--text-dim); white-space: nowrap; }
+.ap-age.sev-bad { color: var(--status-bad); } .ap-age.sev-warn { color: var(--status-warn); }
+
+.ap-title { font-family: var(--font-display); font-weight: 500; font-size: 15px; color: var(--text-bright); margin: 9px 0 4px; line-height: 1.35; }
+.ap-detail { font-size: 12px; color: var(--text-mid); line-height: 1.55; margin: 0 0 11px; }
+
+.ap-req { display: flex; gap: 10px; padding: 10px 12px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); margin-bottom: 12px; }
+.ap-req-body { min-width: 0; flex: 1; }
+.ap-req-who { display: flex; align-items: center; gap: 8px; margin-bottom: 3px; }
+.ap-klink { font-family: var(--font-display); font-weight: 600; font-size: 12px; color: var(--text-bright); background: none; border: 0; padding: 0; cursor: pointer; }
+.ap-klink:hover { color: var(--volt-strong); }
+.ap-req-goal { font-size: 10px; color: var(--text-dim); cursor: pointer; }
+.ap-req-goal:hover { color: var(--volt-strong); }
+.ap-req-quote { font-size: 12.5px; color: var(--text-primary); line-height: 1.5; font-style: italic; }
+
+.ap-actions { display: flex; align-items: center; gap: 7px; }
+.ap-act { font-family: var(--font-ui); font-size: 11.5px; letter-spacing: 0.04em; padding: 7px 16px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid); cursor: pointer; transition: 0.14s; }
+.ap-act.approve { border-color: color-mix(in oklab, var(--status-ok) 50%, transparent); color: var(--status-ok); }
+.ap-act.approve:hover { background: color-mix(in oklab, var(--status-ok) 14%, transparent); color: var(--text-bright); }
+.ap-act.deny { border-color: color-mix(in oklab, var(--status-bad) 50%, transparent); color: var(--status-bad); }
+.ap-act.deny:hover { background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
+.ap-act.defer:hover { border-color: var(--status-warn); color: var(--status-warn); }
+.ap-act.ghost { margin-left: auto; border-color: transparent; color: var(--text-dim); padding: 7px 4px; }
+.ap-act.ghost:hover { color: var(--volt-strong); }
+
+.ap-divider { display: flex; align-items: center; gap: 10px; margin: 6px 2px 2px; font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); }
+.ap-divider::after { content: ''; flex: 1; height: 1px; background: var(--border-soft); }
+
+.ap-clear { text-align: center; padding: 52px 20px; display: flex; flex-direction: column; align-items: center; gap: 7px; color: var(--text-dim); }
+.ap-clear .ico { width: 46px; height: 46px; display: flex; align-items: center; justify-content: center; border-radius: 50%; font-size: 22px; color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 40%, transparent); background: color-mix(in oklab, var(--status-ok) 8%, transparent); }
+.ap-clear h3 { font-family: var(--font-display); font-weight: 500; font-size: 15px; color: var(--text-mid); margin: 4px 0 0; }
+.ap-clear-sub { font-size: 12px; max-width: 360px; line-height: 1.6; }
+
+.ap-log { border-top: 1px solid var(--border-soft); padding-top: 16px; }
+.ap-log-row { display: flex; align-items: center; gap: 10px; padding: 8px 4px; border-bottom: 1px solid var(--border-soft); }
+.ap-log-row:last-child { border-bottom: 0; }
+.ap-log-status { font-size: 10.5px; font-family: var(--font-mono); white-space: nowrap; }
+.ap-log-status.ok { color: var(--status-ok); } .ap-log-status.bad { color: var(--status-bad); } .ap-log-status.warn { color: var(--status-warn); }
+.ap-log-id { font-size: 10px; color: var(--text-dim); }
+.ap-log-title { font-size: 12px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ap-spacer { flex: 1; }
+.ap-log-undo { font-family: var(--font-ui); font-size: 10.5px; color: var(--text-dim); background: none; border: 0; cursor: pointer; padding: 2px 4px; }
+.ap-log-undo:hover { color: var(--volt-strong); }
+
+/* nav badge (열린 승인 수) */
+.nav-item { position: relative; }
+.nav-badge { position: absolute; top: 5px; right: 8px; min-width: 15px; height: 15px; padding: 0 4px; border-radius: var(--radius-pill); background: var(--status-bad); color: #fff; font-family: var(--font-mono); font-size: 9px; font-weight: 600; display: flex; align-items: center; justify-content: center; box-shadow: 0 0 0 2px var(--bg-deep); }
+
+/* topbar 승인 칩 (clickable) */
+.v2-statchip.appr { cursor: pointer; }
+.v2-statchip.appr:hover { border-color: var(--status-warn); color: var(--text-bright); }
+
+/* ════════════════════════════════════════════════════════════════
+   COMMAND PALETTE — ⌘K
+   ════════════════════════════════════════════════════════════════ */
+.cmdk-backdrop { position: fixed; inset: 0; z-index: 60; background: color-mix(in oklab, var(--bg-deep) 72%, transparent); backdrop-filter: blur(3px); display: flex; align-items: flex-start; justify-content: center; padding-top: 12vh; animation: cmdk-fade 0.14s ease-out; }
+@keyframes cmdk-fade { from { opacity: 0; } to { opacity: 1; } }
+.cmdk { width: min(560px, 92vw); max-height: 64vh; display: flex; flex-direction: column; background: var(--bg-panel); border: 1px solid var(--border-highlight); border-radius: var(--radius-lg); box-shadow: var(--shadow-pop); overflow: hidden; animation: cmdk-pop 0.16s cubic-bezier(0.2,0.7,0.3,1); }
+@keyframes cmdk-pop { from { transform: translateY(-8px) scale(0.99); opacity: 0; } to { transform: none; opacity: 1; } }
+.cmdk-input-row { display: flex; align-items: center; gap: 11px; padding: 14px 16px; border-bottom: 1px solid var(--border-soft); }
+.cmdk-glyph { font-family: var(--font-mono); font-size: 11px; color: var(--volt-strong); letter-spacing: 0.06em; flex: none; }
+.cmdk-input { flex: 1; background: none; border: 0; outline: none; color: var(--text-bright); font-family: var(--font-ui); font-size: 15px; }
+.cmdk-input::placeholder { color: var(--text-dim); }
+.cmdk-esc { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 2px 6px; }
+.cmdk-list { flex: 1; overflow-y: auto; padding: 7px; }
+.cmdk-list::-webkit-scrollbar { width: 8px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
+.cmdk-empty { padding: 28px; text-align: center; color: var(--text-dim); font-size: 12.5px; }
+.cmdk-group { font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-dim); padding: 9px 10px 4px; }
+.cmdk-item { display: flex; align-items: center; gap: 11px; padding: 8px 10px; border-radius: var(--radius-sm); cursor: pointer; }
+.cmdk-item.sel { background: var(--bg-card); box-shadow: inset 0 0 0 1px var(--volt-wash); }
+.cmdk-item-glyph { width: 22px; height: 22px; flex: none; display: flex; align-items: center; justify-content: center; border-radius: var(--radius-xs); border: 1px solid var(--border-main); background: var(--bg-deep); color: var(--text-mid); font-size: 12px; }
+.cmdk-item.sel .cmdk-item-glyph { color: var(--volt-strong); border-color: var(--volt-dim); }
+.cmdk-item-body { min-width: 0; flex: 1; }
+.cmdk-item-t { font-size: 12.5px; color: var(--text-bright); font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cmdk-item-sub { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.cmdk-chord { font-family: var(--font-mono); font-size: 12px; color: var(--volt-strong); flex: none; width: 14px; text-align: center; }
+.cmdk-foot { display: flex; gap: 16px; padding: 9px 16px; border-top: 1px solid var(--border-soft); background: var(--bg-deep); }
+.cmdk-foot span { font-size: 10px; color: var(--text-dim); display: inline-flex; align-items: center; gap: 5px; }
+.cmdk-foot kbd { font-family: var(--font-mono); font-size: 9px; color: var(--text-mid); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 1px 5px; }
+
+
+/* ════ KEEPER CONFIG — 도구 권한 (masc_*) 행 ════ */
+.kc-tools { display: flex; flex-direction: column; gap: 4px; margin-top: 4px; }
+.kc-tool { display: flex; align-items: center; gap: 9px; padding: 6px 8px; border: 1px solid var(--border-soft); border-radius: var(--radius-sm); background: var(--bg-sunken); }
+.kc-tool.on { border-color: color-mix(in oklab, var(--volt-strong) 30%, var(--border-main)); background: color-mix(in oklab, var(--volt-strong) 5%, var(--bg-sunken)); }
+.kc-tool-id { font-size: 11.5px; color: var(--text-mid); flex: none; }
+.kc-tool.on .kc-tool-id { color: var(--text-bright); }
+.kc-tool-risk { font-family: var(--font-mono); font-size: 8.5px; letter-spacing: 0.06em; padding: 1px 5px; border-radius: var(--radius-xs); border: 1px solid var(--border-main); color: var(--text-dim); flex: none; }
+.kc-tool-risk.read { color: var(--text-dim); }
+.kc-tool-risk.write { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 38%, transparent); }
+.kc-tool-risk.lifecycle { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 42%, transparent); }
+.kc-tool-desc { font-size: 10.5px; color: var(--text-dim); margin-left: auto; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -1,0 +1,1499 @@
+/* ══════════════════════════════════════════════════════════════
+   MASC v2 — High-contrast skin + Keeper Agent Chat layout
+   A chromatic re-skin over the MASC semantic spine: cooler neutral
+   near-black ground so a single warm voltage (brass / blood / ice)
+   reads vivid and sharp. Body text pushed brighter for readability.
+   Loaded AFTER colors_and_type.css.
+   ══════════════════════════════════════════════════════════════ */
+
+[data-skin="v2"] {
+  /* Surfaces — cool neutral charcoal, clean elevation steps */
+  --bg-deep:        #08090d;
+  --bg-panel:       #0f1015;
+  --bg-panel-alt:   #15161d;
+  --bg-card:        #1b1c25;
+  --bg-card-hover:  #23242f;
+  --bg-sunken:      #0a0b0f;
+  --bg-well:        #06070a;   /* deepest: code/shell/tool wells inside cards */
+
+  /* Borders — crisper, cooler */
+  --border-main:      #282a36;
+  --border-soft:      #1e1f29;
+  --border-highlight: #3b3d4e;
+
+  /* Text — bone, pushed bright for reading (raised contrast on mid/dim
+     so 9–11px labels, eyebrows and captions stay legible on dark ground) */
+  --text-bright:  #f7f1e6;
+  --text-primary: #e3dacb;
+  --text-mid:     #cabfac;
+  --text-dim:     #a59db0;
+
+  /* Accents — vivid */
+  --accent-blood:     #e8472f;
+  --accent-blood-dim: #7a1a12;
+  --accent-viscera:   #ff6a4d;
+  --accent-brass:     #e0b057;
+  --accent-brass-dim: #8a6a28;
+  --accent-bone:      #e6d8b6;
+  --accent-ice:       #46c6f0;
+  --accent-ice-dim:   #1c6b86;
+  --accent-bile:      #8aa83f;
+
+  /* Information / reference accent — distinct from volt (primary action).
+     Used for mentions, state badges, syntax fns, tool events. Volt-aware:
+     under volt=ice it shifts off-cyan so it never collides with primary. */
+  --info:     var(--accent-ice);
+  --info-dim: var(--accent-ice-dim);
+
+  /* Status — saturated but composed */
+  --status-ok:    #46c66a;
+  --status-warn:  #e0a02a;
+  --status-bad:   #e8472f;
+  --status-idle:  #6b6478;
+  --status-busy:  #46c6f0;
+
+  /* Voltage — the single primary accent (default brass/gold) */
+  --volt:        var(--accent-brass);
+  --volt-strong: #f0c373;
+  --volt-dim:    var(--accent-brass-dim);
+  --volt-ink:    #1a1405;
+  --volt-glow:   rgba(224,176,87,0.22);
+  --volt-wash:   rgba(224,176,87,0.10);
+
+  /* Radius scale — engraved, tiny corners (brand: 2/4/6/…). One ladder;
+     literals below recovered into these tokens. */
+  --radius-2xs: 2px;
+  --radius-xs:  3px;
+  --radius-sm:  4px;   /* chips · tabs · inputs · small controls */
+  --radius-md:  6px;   /* cards · panels · composer */
+  --radius-lg:  10px;  /* large panels */
+
+  /* Spacing scale (2px base) + semantic aliases. Surface padding, card
+     padding and inter-card gaps were drifting (12·13·14 / 22·20…) — these
+     give every surface one rhythm. */
+  --sp-1: 4px;  --sp-2: 6px;  --sp-3: 8px;  --sp-4: 10px; --sp-5: 12px;
+  --sp-6: 14px; --sp-7: 16px; --sp-8: 20px; --sp-9: 24px; --sp-10: 32px;
+  --pad-surface: 22px 26px 40px;  /* surface scroll outer padding */
+  --pad-card:    12px 14px;       /* card / panel body padding */
+  --gap-card:    14px;            /* between sibling cards / panels */
+  --gap-row:     8px;             /* between list rows */
+
+  --shadow-card:   0 1px 3px rgba(0,0,0,0.5);
+  --shadow-panel:  0 4px 22px rgba(0,0,0,0.55);
+  --shadow-pop:    0 12px 40px rgba(0,0,0,0.6), 0 0 0 1px var(--border-main);
+  /* Override the base (dark-fantasy) blood-tinted glow so it tracks volt
+     instead — keeps title/primary glow coherent in every voltage. */
+  --accent-glow:   var(--volt-glow);
+  --shadow-glow:   0 0 20px var(--volt-glow);
+
+  /* v2 type — sharp grotesque replaces the gothic Cinzel */
+  --font-display: 'Space Grotesk', 'Noto Sans KR', system-ui, sans-serif;
+  --font-body:    'Noto Sans KR', 'Space Grotesk', system-ui, sans-serif;
+
+  /* ── TYPE LADDER — one heading system across every surface ──
+     T1 surface/subject title · T2 region/panel title ·
+     T3 card/section header (UPPER) · T4 micro label (UPPER).
+     All display = Space Grotesk, all weight 600. The authoritative
+     selector block lives at the end of surfaces.css. */
+  --fs-t1: 22px; --fw-t1: 600; --tr-t1: -0.005em;  /* bright · sentence */
+  --fs-t2: 16px; --fw-t2: 600; --tr-t2: 0;         /* bright · sentence */
+  --fs-t3: 11px; --fw-t3: 600; --tr-t3: 0.14em;    /* mid · UPPER */
+  --fs-t4: 9px;  --fw-t4: 600; --tr-t4: 0.2em;     /* dim · UPPER */
+}
+
+[data-skin="v2"][data-volt="blood"] {
+  --volt: var(--accent-blood); --volt-strong: #ff6a4d; --volt-dim: var(--accent-blood-dim);
+  --volt-ink: #ffffff; --volt-glow: rgba(232,71,47,0.26); --volt-wash: rgba(232,71,47,0.10);
+}
+[data-skin="v2"][data-volt="ice"] {
+  --volt: var(--accent-ice); --volt-strong: #7ad8f6; --volt-dim: var(--accent-ice-dim);
+  --volt-ink: #04121a; --volt-glow: rgba(70,198,240,0.24); --volt-wash: rgba(70,198,240,0.09);
+  /* primary is now cyan → shift the info accent to violet to stay distinct */
+  --info: #8a6cf0; --info-dim: #4a3aa0;
+}
+
+/* ════════════════════════════════════════════════════════════
+   PAPER — light reading theme. The same v2 semantic spine and
+   voltage system, surfaces flipped to warm paper-white so long
+   conversations read like a printed document (high contrast,
+   airy). Toggled via html[data-theme="paper"].
+   ════════════════════════════════════════════════════════════ */
+[data-skin="v2"][data-theme="paper"] {
+  color-scheme: light;
+  --bg-deep:        #f1f2f5;
+  --bg-panel:       #fafbfc;
+  --bg-panel-alt:   #ffffff;
+  --bg-card:        #ffffff;
+  --bg-card-hover:  #eef0f3;
+  --bg-sunken:      #f3f4f7;
+  --bg-well:        #eef0f3;
+
+  --border-main:      rgba(22,24,29,0.12);
+  --border-soft:      rgba(22,24,29,0.07);
+  --border-highlight: rgba(22,24,29,0.22);
+
+  --text-bright:  #16181d;
+  --text-primary: #2f3137;
+  --text-mid:     #565962;
+  --text-dim:     #797d86;
+
+  /* status — darkened for legibility on white */
+  --status-ok:    #17803d;
+  --status-warn:  #b45309;
+  --status-bad:   #b42318;
+  --status-idle:  #9298a2;
+  --status-busy:  #1e6fa8;
+
+  --info:     #2d6cdf;
+  --info-dim: #1e54bc;
+
+  /* soft ink shadows instead of black drop shadows */
+  --shadow-card:   0 1px 2px rgba(22,24,29,0.07);
+  --shadow-panel:  0 4px 18px rgba(22,24,29,0.10);
+  --shadow-pop:    0 12px 32px rgba(22,24,29,0.16), 0 0 0 1px var(--border-main);
+  --shadow-glow:   0 0 0 1px var(--volt-dim);
+
+  /* default voltage (brass) deepened so gold reads on white */
+  --volt:        #b07d1a;
+  --volt-strong: #8c5e0f;
+  --volt-dim:    #e2c987;
+  --volt-ink:    #ffffff;
+  --volt-glow:   rgba(176,125,26,0.16);
+  --volt-wash:   rgba(176,125,26,0.10);
+  --accent-glow: var(--volt-glow);
+}
+[data-skin="v2"][data-theme="paper"][data-volt="blood"] {
+  --volt: #b42318; --volt-strong: #8f1b12; --volt-dim: #f0b4ad;
+  --volt-ink: #ffffff; --volt-glow: rgba(180,35,24,0.16); --volt-wash: rgba(180,35,24,0.09);
+}
+[data-skin="v2"][data-theme="paper"][data-volt="ice"] {
+  --volt: #1e6fa8; --volt-strong: #155888; --volt-dim: #a8d4ea;
+  --volt-ink: #ffffff; --volt-glow: rgba(30,111,168,0.16); --volt-wash: rgba(30,111,168,0.09);
+  --info: #7a4fd0; --info-dim: #5a37a0;
+}
+
+/* ── Reset for the app shell ─────────────────────────────── */
+[data-skin="v2"], [data-skin="v2"] body { height: 100%; }
+.v2-app * { box-sizing: border-box; }
+.v2-app {
+  position: fixed; inset: 0;
+  display: flex; flex-direction: column;
+  background:
+    radial-gradient(1200px 600px at 80% -10%, rgba(224,176,87,0.04), transparent 60%),
+    radial-gradient(900px 500px at -5% 110%, rgba(232,71,47,0.05), transparent 60%),
+    var(--bg-deep);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  overflow: hidden;
+}
+.v2-app .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+
+/* ════ TOP BAR ════ */
+.v2-top {
+  display: flex; align-items: center; gap: 18px;
+  height: 50px; flex: none;
+  padding: 0 16px;
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+  border-bottom: 1px solid var(--border-main);
+  z-index: 20;
+}
+.v2-wordmark { display: flex; align-items: baseline; gap: 9px; }
+.v2-wordmark b {
+  font-family: var(--font-display); font-weight: 400;
+  letter-spacing: 0.26em; font-size: 16px; color: var(--text-bright);
+}
+.v2-wordmark .ver {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em;
+  color: var(--volt-ink); background: var(--volt); padding: 2px 6px; border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+.v2-top .crumb {
+  font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--text-dim); display: flex; gap: 8px; align-items: center;
+}
+.v2-top .crumb .on { color: var(--text-mid); }
+.v2-top-spacer { flex: 1; }
+.v2-statchip {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-size: 11px; letter-spacing: 0.04em;
+  padding: 5px 10px; border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill); color: var(--text-mid);
+  background: var(--bg-panel-alt); white-space: nowrap;
+}
+.v2-statchip b { color: var(--text-bright); font-weight: 600; }
+.v2-statchip.live { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 40%, transparent); }
+.v2-statchip.warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); }
+
+/* ════ BODY GRID ════ */
+.v2-body {
+  flex: 1; min-height: 0;
+  display: grid;
+  grid-template-columns: var(--nav-w, 58px) var(--roster-w, 286px) 1fr var(--ctx-w, 312px);
+}
+.v2-body.no-ctx { grid-template-columns: var(--nav-w, 58px) var(--roster-w, 286px) 1fr 0; }
+
+/* ════ APP NAV RAIL (main menu) ════ */
+.v2-nav {
+  display: flex; flex-direction: column; align-items: center; gap: 3px;
+  padding: 10px 0 12px; border-right: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+}
+.nav-home {
+  width: 38px; height: 38px; border-radius: var(--radius-sm); margin-bottom: 9px;
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 700; font-size: 16px;
+  color: var(--volt-ink); background: var(--volt); cursor: default;
+  box-shadow: 0 0 14px var(--volt-glow); transition: 0.14s;
+}
+.nav-home:hover { filter: none; }
+.nav-brand { display: flex; flex-direction: column; align-items: center; gap: 3px; margin-bottom: 8px; }
+.nav-brand .nav-home { margin-bottom: 0; }
+.nav-brand .nlbl { font-size: 8.5px; letter-spacing: 0.06em; color: var(--text-dim); }
+.nav-item {
+  width: 46px; height: 46px; border-radius: var(--radius-sm); cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 3px;
+  color: var(--text-dim); border: 1px solid transparent; background: transparent;
+  transition: 0.14s; position: relative;
+}
+.nav-item svg { width: 22px; height: 22px; }
+.nav-item .nlbl { display: none; }
+.nav-brand .nlbl { display: none; }
+.nav-item:hover { color: var(--text-bright); background: var(--bg-card); }
+.nav-item.on { color: var(--volt-strong); background: var(--bg-card); }
+.nav-item.on::before { content: ""; position: absolute; left: -10px; top: 10px; bottom: 10px; width: 3px; background: var(--volt); border-radius: 0 3px 3px 0; box-shadow: 0 0 10px var(--volt-glow); }
+.nav-spacer { flex: 1; }
+.nav-div { height: 1px; margin: 8px 10px; background: var(--border-soft); flex: none; }
+
+/* avatar fallback (keeper without a portrait) */
+.is-fallback {
+  display: flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-weight: 600; letter-spacing: 0.02em;
+  color: hsl(var(--ah, 40) 62% 80%);
+  background: linear-gradient(135deg, hsl(var(--ah,40) 34% 18%), hsl(var(--ah,40) 30% 10%));
+  border: 1px solid hsl(var(--ah,40) 40% 33%);
+}
+.kp-av.is-fallback { font-size: 13px; }
+.chat-av.is-fallback { font-size: 17px; }
+.msg-av.is-fallback { font-size: 12px; }
+
+/* ════ KEEPER SIGIL BADGE (canonical identity: slot color + 2-letter monogram) ════ */
+.v2-app {
+  --kp1:#e0b057; --kp2:#d9743f; --kp3:#e0a82e; --kp4:#c64f6d;
+  --kp5:#8a6cf0; --kp6:#46c66a; --kp7:#5fb0c4; --kp8:#9aa83f;
+  --kp9:#5b9cf0; --kp10:#c569d4; --kp11:#8a7bf0; --kp12:#d98a4f;
+}
+.sigil {
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); font-weight: 700; letter-spacing: 0; flex: none;
+  color: #0b0c10; background: var(--kc, var(--kp1));
+  border-radius: var(--radius-sm);
+}
+.sigil.heartbeat { box-shadow: 0 0 8px color-mix(in oklab, var(--kc, var(--kp1)) 70%, transparent); animation: sg-beat 1.5s ease-in-out infinite; }
+@keyframes sg-beat { 0%,100% { box-shadow: 0 0 6px color-mix(in oklab, var(--kc) 55%, transparent); } 50% { box-shadow: 0 0 13px color-mix(in oklab, var(--kc) 85%, transparent); } }
+.sigil-chip {
+  display: inline-flex; align-items: center; gap: 6px; flex: none; white-space: nowrap;
+  font-family: var(--font-mono); font-size: 11px; color: var(--kc, var(--kp1));
+  padding: 2px 8px 2px 3px; border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in oklab, var(--kc, var(--kp1)) 40%, var(--border-main));
+  background: color-mix(in oklab, var(--kc, var(--kp1)) 9%, transparent);
+}
+.sigil-chip .sigil { width: 17px; height: 17px; font-size: 9px; }
+
+/* ════ ROSTER RAIL ════ */
+.roster {
+  border-right: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 60%);
+  display: flex; flex-direction: column; min-height: 0;
+}
+.roster-head { padding: 11px 12px 11px; border-bottom: 1px solid var(--border-soft); }
+.roster-title { display: flex; align-items: center; justify-content: space-between; margin-bottom: 11px; }
+.roster-title h3 {
+  font-family: var(--font-display); font-weight: 400; text-transform: uppercase;
+  letter-spacing: 0.2em; font-size: 13px; color: var(--text-bright); margin: 0;
+}
+.roster-title .count {
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-dim);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  padding: 2px 7px; border-radius: var(--radius-pill);
+}
+.roster-search {
+  width: 100%; font-family: var(--font-ui); font-size: 12.5px;
+  padding: 8px 11px; background: var(--bg-sunken); color: var(--text-primary);
+  border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  outline: none;
+}
+.roster-search:focus { border-color: var(--volt-dim); box-shadow: 0 0 0 2px var(--volt-wash); }
+.roster-search::placeholder { color: var(--text-dim); }
+
+.roster-filters { display: flex; align-items: center; gap: 5px; padding: 9px 12px; flex-wrap: nowrap; border-bottom: 1px solid var(--border-soft); }
+.rfilter-icon { flex: none; margin-left: auto; width: 26px; height: 24px; display: inline-flex; align-items: center; justify-content: center; font-size: 13px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.rfilter-icon:hover { color: var(--text-mid); border-color: var(--border-highlight); }
+.rfilter-icon.on { color: var(--volt); border-color: var(--volt-dim); background: var(--volt-wash); }
+.roster-sort {
+  margin-left: 0; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.02em;
+  padding: 4px 5px; border-radius: var(--radius-pill); cursor: pointer; flex: none; max-width: 74px;
+  border: 1px solid var(--border-main); background: transparent; color: var(--text-dim);
+  transition: 0.15s; outline: none;
+}
+.roster-sort:hover { color: var(--text-mid); border-color: var(--border-highlight); }
+.roster-sort:focus { border-color: var(--volt-dim); }
+.roster-sort option { background: var(--bg-panel); color: var(--text-primary); }
+.rfilter {
+  font-size: 10px; letter-spacing: 0.02em; text-transform: uppercase;
+  padding: 4px 7px; border-radius: var(--radius-pill); cursor: pointer; white-space: nowrap; flex: none;
+  border: 1px solid var(--border-main); background: transparent; color: var(--text-dim);
+  font-family: var(--font-ui); transition: 0.15s; display: inline-flex; gap: 5px; align-items: center;
+}
+.rfilter:hover { color: var(--text-mid); border-color: var(--border-highlight); }
+.rfilter.on { color: var(--volt-ink); background: var(--volt); border-color: var(--volt); font-weight: 600; }
+.rfilter .n { opacity: 0.7; }
+
+.roster-list { flex: 1; overflow-y: auto; padding: 6px; }
+.roster-group {
+  font-size: 9.5px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-dim);
+  padding: 12px 8px 5px; display: flex; align-items: center; gap: 7px;
+}
+.roster-group .rg-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--rg-tone, var(--text-dim)); flex: none; }
+.roster-group .rg-n { margin-left: auto; font-family: var(--font-mono); letter-spacing: 0; font-size: 10px; color: var(--text-dim); }
+.roster-group.run { --rg-tone: var(--status-ok); }
+.roster-group.pause { --rg-tone: var(--status-warn); }
+.roster-group.off { --rg-tone: var(--text-dim); }
+.kp-row {
+  display: grid; grid-template-columns: 38px 1fr auto; gap: 10px; align-items: center;
+  padding: 8px 9px; border-radius: var(--radius-sm); cursor: pointer;
+  border: 1px solid transparent; transition: background 0.14s, border-color 0.14s;
+  position: relative;
+}
+.kp-row:hover { background: var(--bg-card); }
+.kp-row.sel { background: var(--bg-card); border-color: var(--volt-dim); box-shadow: inset 0 0 0 1px var(--volt-wash); }
+.kp-row.sel::before {
+  content: ""; position: absolute; left: -6px; top: 8px; bottom: 8px; width: 3px;
+  background: var(--volt); border-radius: 0 3px 3px 0; box-shadow: 0 0 10px var(--volt-glow);
+}
+.kp-av {
+  width: 38px; height: 38px; border-radius: var(--radius-sm); object-fit: cover;
+  border: 1px solid var(--border-highlight); filter: saturate(0.92) contrast(1.04);
+  background: var(--bg-sunken); font-size: 14px;
+}
+.kp-meta { min-width: 0; }
+.kp-name { font-family: var(--font-display); font-weight: 600; font-size: 14.5px; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kp-handle { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kp-sub { display: flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; min-width: 0; }
+.kp-state { display: inline-flex; align-items: center; gap: 5px; flex: none; }
+.kp-sub > span:not(.kp-handle):not(.kp-state) { flex: none; }
+.kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; transition: opacity 0.14s; }
+.kp-time { font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.kp-att {
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600;
+  min-width: 16px; text-align: center; padding: 1px 5px; border-radius: var(--radius-pill);
+  color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 16%, transparent);
+  border: 1px solid color-mix(in oklab, var(--status-bad) 35%, transparent);
+}
+
+/* status dot */
+.dot2 { width: 7px; height: 7px; border-radius: 50%; display: inline-block; flex: none; background: var(--status-idle); }
+.dot2.ok   { background: var(--status-ok);   box-shadow: 0 0 7px var(--status-ok); }
+.dot2.warn { background: var(--status-warn); box-shadow: 0 0 7px var(--status-warn); }
+.dot2.bad  { background: var(--status-bad);  box-shadow: 0 0 7px var(--status-bad); }
+.dot2.busy { background: var(--status-busy); box-shadow: 0 0 7px var(--status-busy); }
+.dot2.pulse { animation: dot-pulse 1.8s ease-in-out infinite; }
+@keyframes dot-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+/* ════ CHAT MAIN ════ */
+.chat { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--bg-deep); }
+
+.chat-head {
+  flex: none; padding: 9px 20px 9px;
+  border-bottom: 1px solid var(--border-main);
+  background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
+  display: flex; align-items: center; gap: 12px;
+}
+.chat-av {
+  width: 40px; height: 40px; border-radius: var(--radius-md); object-fit: cover;
+  border: 1px solid var(--border-highlight); flex: none;
+  box-shadow: 0 0 0 1px var(--bg-deep), 0 0 18px rgba(0,0,0,0.5);
+  filter: saturate(0.95) contrast(1.05);
+}
+.chat-av[data-sigil] { display: flex; align-items: center; justify-content: center; padding: 0; border: 0; box-shadow: none; filter: none; background: transparent; }
+.chat-av[data-sigil] .sigil { width: 40px; height: 40px; border-radius: var(--radius-md); font-size: 16px; }
+.chat-id { min-width: 0; flex: 1; }
+.chat-id .name-row { display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
+.chat-id h2 {
+  font-family: var(--font-display); font-weight: 400; text-transform: none;
+  letter-spacing: 0.02em; font-size: 20px; color: var(--text-bright); margin: 0; white-space: nowrap;
+}
+.chat-id .slug { font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); }
+.chat-id .sub { display: flex; align-items: center; gap: 10px; margin-top: 5px; font-size: 12.5px; color: var(--text-dim); flex-wrap: wrap; }
+.chat-id .sub > span { white-space: nowrap; }
+.sub-ns { display: inline-flex; align-items: center; gap: 6px; }
+.sub-tag {
+  font-family: var(--font-ui); font-size: 8.5px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--text-dim); background: var(--bg-card); border: 1px solid var(--border-main);
+  padding: 1px 5px; border-radius: var(--radius-sm); line-height: 1.5;
+}
+
+.state-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11px; letter-spacing: 0.04em; padding: 4px 10px; border-radius: var(--radius-pill);
+  background: var(--bg-card); border: 1px solid var(--border-main); color: var(--text-mid);
+}
+.state-pill.run  { color: var(--status-ok);  border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); background: color-mix(in oklab, var(--status-ok) 10%, var(--bg-card)); }
+.state-pill.pause{ color: var(--status-warn);border-color: color-mix(in oklab, var(--status-warn) 45%, transparent); }
+.state-pill.off  { color: var(--text-dim); }
+.fsm-chip {
+  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.04em;
+  padding: 3px 8px; border-radius: var(--radius-sm); color: var(--text-mid);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+}
+
+.chat-actions { display: flex; gap: 7px; align-items: center; flex: none; }
+.act {
+  font-family: var(--font-ui); font-size: 11px; letter-spacing: 0.05em;
+  padding: 7px 12px; border-radius: var(--radius-sm); cursor: pointer;
+  border: 1px solid var(--border-main); background: var(--bg-card); color: var(--text-mid);
+  transition: 0.15s; white-space: nowrap;
+}
+.act:hover { color: var(--text-bright); border-color: var(--border-highlight); background: var(--bg-card-hover); }
+.act.danger:hover { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 50%, transparent); }
+.act.icon { padding: 0; width: 32px; height: 32px; display: inline-flex; align-items: center; justify-content: center; font-size: 15px; line-height: 1; }
+
+/* meta strip */
+.chat-meta {
+  flex: none; display: flex; align-items: center; gap: 0;
+  padding: 0 20px; height: 34px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--bg-sunken);
+  overflow-x: auto;
+}
+.meta-cell { display: flex; align-items: center; gap: 7px; padding-right: 18px; margin-right: 18px; border-right: 1px solid var(--border-soft); white-space: nowrap; }
+.meta-cell:last-child { border-right: 0; }
+.meta-cell .k { font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-dim); }
+.meta-cell .v { font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); }
+.meta-cell .v.volt { color: var(--volt-strong); }
+
+/* thread */
+.thread { flex: 1; overflow-y: auto; padding: 22px 0 8px; }
+.thread-inner { max-width: var(--thread-w, 980px); margin: 0 auto; padding: 0 28px; display: flex; flex-direction: column; gap: 26px; }
+
+.daydiv { display: flex; align-items: center; gap: 12px; color: var(--text-dim); font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; }
+.daydiv::before, .daydiv::after { content: ""; height: 1px; flex: 1; background: var(--border-soft); }
+
+/* message */
+.msg { display: grid; grid-template-columns: 34px 1fr; gap: 13px; }
+.msg-av { width: 34px; height: 34px; border-radius: var(--radius-sm); object-fit: cover; border: 1px solid var(--border-highlight); filter: saturate(0.95) contrast(1.05); }
+.msg-av.op { display: flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 11px; color: var(--volt-ink); background: var(--volt); border-color: var(--volt); }
+.msg-col { min-width: 0; }
+.msg-hd { display: flex; align-items: center; gap: 9px; margin-bottom: 6px; }
+.msg-hd .who { font-family: var(--font-display); font-weight: 600; font-size: 13px; color: var(--text-bright); white-space: nowrap; }
+.msg-hd .whoh { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.msg-hd .ts { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.src-badge {
+  font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 2px 6px; border-radius: var(--radius-xs); color: var(--text-mid);
+  background: var(--bg-card); border: 1px solid var(--border-main);
+}
+.src-badge.dashboard { color: var(--volt-strong); border-color: var(--volt-dim); }
+.src-badge.discord { color: #8a9bf0; border-color: #3a3d6a; }
+.src-badge.slack { color: #5fc7b0; border-color: #2c5a52; }
+.src-badge.imessage { color: #6aa6ef; border-color: #2c4a6a; }
+
+/* assistant bubble */
+.bubble {
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  border-radius: 4px 14px 14px 14px; padding: 16px 19px;
+  color: var(--text-primary); line-height: 1.72; font-family: var(--font-body); font-size: 16.5px;
+  /* subtle emboss: top inner highlight + soft drop so the bubble lifts off the thread */
+  box-shadow: inset 0 1px 0 rgba(247,241,230,0.05), 0 2px 6px rgba(0,0,0,0.34);
+}
+.bubble.user {
+  background: var(--volt-wash); border-color: var(--volt-dim);
+  border-radius: 14px 4px 14px 14px; color: var(--text-bright);
+  box-shadow: inset 0 1px 0 rgba(247,241,230,0.06), 0 2px 6px rgba(0,0,0,0.30);
+}
+/* paper theme: softer ink-shadow emboss on light ground */
+[data-theme="paper"] .bubble { box-shadow: 0 1px 2px rgba(22,24,29,0.07), 0 3px 10px rgba(22,24,29,0.06); border-color: var(--border-soft); }
+[data-theme="paper"] .bubble.user { background: var(--volt-wash); border-color: var(--volt-dim); color: var(--text-bright); box-shadow: 0 1px 2px rgba(22,24,29,0.08), 0 3px 10px rgba(22,24,29,0.07); }
+
+/* paper theme — explicit surface fixes for interactive controls whose
+   dark base value otherwise persisted (selected roster row, ctx-rail
+   buttons, broadcast card). Literal paper tokens so they always flip. */
+[data-skin="v2"][data-theme="paper"] .cmp-open { background: #f3f4f7; color: var(--text-mid); }
+[data-skin="v2"][data-theme="paper"] .cmp-open:hover { background: #eef0f3; }
+[data-skin="v2"][data-theme="paper"] .kp-row.sel { background: var(--volt-wash); }
+[data-skin="v2"][data-theme="paper"] .kp-row:hover { background: #eef0f3; }
+[data-skin="v2"][data-theme="paper"] .cmp-run { color: var(--volt-ink); }
+.msg.from-user { grid-template-columns: 1fr 34px; }
+.msg.from-user .msg-col { order: 0; }
+.msg.from-user .msg-av { order: 1; }
+.msg.from-user .msg-hd { justify-content: flex-end; }
+
+.bubble p { margin: 0 0 10px; color: var(--text-primary); }
+.bubble p:last-child { margin-bottom: 0; }
+.bubble strong { color: var(--text-bright); font-weight: 600; }
+.bubble h4 { font-family: var(--font-ui); text-transform: none; letter-spacing: 0; font-size: 15px; color: var(--text-bright); margin: 4px 0 9px; }
+.bubble ul { margin: 0 0 10px; padding-left: 18px; }
+.bubble li { margin: 3px 0; color: var(--text-primary); }
+.bubble li::marker { color: var(--volt); }
+.bubble code { font-family: var(--font-mono); font-size: 13px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 1px 5px; border-radius: var(--radius-sm); color: var(--volt-strong); }
+.bubble hr { border: 0; border-top: 1px solid var(--border-soft); margin: 13px 0; }
+
+.callout {
+  display: flex; gap: 9px; padding: 10px 12px; margin: 10px 0;
+  border-radius: var(--radius-sm); font-size: 13.5px; line-height: 1.5;
+  background: color-mix(in oklab, var(--status-warn) 9%, var(--bg-sunken));
+  border: 1px solid color-mix(in oklab, var(--status-warn) 36%, transparent);
+  color: var(--text-primary);
+}
+.callout .ico { color: var(--status-warn); flex: none; }
+
+/* markdown table */
+.md-table { width: 100%; border-collapse: collapse; margin: 8px 0 10px; font-family: var(--font-ui); font-size: 13px; }
+.md-table th, .md-table td { text-align: left; padding: 8px 12px; border-bottom: 1px solid var(--border-soft); }
+.md-table thead th { font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); font-weight: 600; border-bottom: 1px solid var(--border-main); }
+.md-table tbody tr:hover { background: var(--bg-panel-alt); }
+.md-table td.num, .md-table th.num { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.md-table .muted { color: var(--text-dim); }
+
+/* feedback row */
+.fbk { display: flex; align-items: center; gap: 4px; margin-top: 9px; }
+.fbk-btn {
+  display: inline-flex; align-items: center; gap: 5px; cursor: pointer;
+  padding: 5px 8px; border-radius: var(--radius-xs); border: 1px solid transparent;
+  background: transparent; color: var(--text-dim); font-family: var(--font-ui); font-size: 11px; transition: 0.14s;
+  white-space: nowrap;
+}
+.fbk-btn:hover { color: var(--text-mid); background: var(--bg-card); }
+.fbk-btn.on { color: var(--volt-strong); }
+.fbk-verify { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; font-size: 11px; color: var(--status-ok); }
+
+/* tool trace */
+.tool {
+  border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  background: var(--bg-sunken); overflow: hidden; margin-top: 2px;
+}
+.tool-hd {
+  display: flex; align-items: center; gap: 10px; padding: 9px 12px; cursor: pointer;
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-mid); transition: 0.14s;
+}
+.tool-hd:hover { background: var(--bg-panel-alt); }
+.tool-hd .chev { transition: transform 0.18s; color: var(--text-dim); }
+.tool.open .tool-hd .chev { transform: rotate(90deg); }
+.tool-hd .tname { color: var(--text-bright); }
+.tool-hd .tdot { margin-left: auto; }
+.tool-hd .tdur { color: var(--text-dim); font-size: 11px; }
+.tool-body { padding: 0 12px 12px; display: none; }
+.tool.open .tool-body { display: block; }
+.tool-kv { display: grid; grid-template-columns: 70px 1fr; gap: 4px 12px; font-family: var(--font-mono); font-size: 11.5px; padding: 9px 0 0; }
+.tool-kv .tk { color: var(--text-dim); }
+.tool-kv .tv { color: var(--text-mid); word-break: break-word; }
+.tool pre {
+  margin: 9px 0 0; padding: 10px; background: var(--bg-well); border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xs); font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid);
+  overflow-x: auto; line-height: 1.55;
+}
+.tool pre .jk { color: var(--volt-strong); }
+.tool pre .js { color: var(--status-ok); }
+
+/* agent trace group — bundles thinking / reasoning / tool steps into one block */
+.trace { border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-sunken); overflow: hidden; }
+.trace-hd {
+  display: flex; align-items: center; gap: 9px; padding: 9px 12px; cursor: pointer;
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-mid); transition: background 0.14s;
+}
+.trace-hd:hover { background: var(--bg-panel-alt); }
+.trace-hd .chev { color: var(--text-dim); transition: transform 0.18s; font-size: 9px; }
+.trace.open > .trace-hd .chev { transform: rotate(90deg); }
+.trace-hd .glyph { color: var(--volt); font-size: 11px; }
+.trace-hd .tlabel { color: var(--text-bright); font-family: var(--font-ui); letter-spacing: 0.13em; text-transform: uppercase; font-size: 11px; }
+.trace-hd .tcount { color: var(--text-dim); }
+.trace-hd .tmeta { margin-left: auto; display: flex; align-items: center; gap: 12px; color: var(--text-dim); font-size: 11px; }
+.trace-hd .tmeta .mono { color: var(--text-mid); }
+
+.trace-steps { display: none; position: relative; padding: 8px 12px 12px 14px; }
+.trace.open > .trace-steps { display: block; }
+.trace-rail { position: absolute; left: 19px; top: 14px; bottom: 18px; width: 1px; background: var(--border-main); }
+
+.tstep { position: relative; padding-left: 18px; }
+.tstep + .tstep { margin-top: 10px; }
+.tnode {
+  position: absolute; left: 0; top: 4px; width: 11px; height: 11px; border-radius: 50%;
+  background: var(--bg-sunken); border: 1.5px solid var(--text-dim); box-sizing: border-box; z-index: 1;
+}
+.tstep.think .tnode { border-style: dotted; }
+.tstep.reason .tnode { border-color: var(--info); }
+.tstep.tool .tnode { border-color: var(--volt); background: var(--volt); box-shadow: 0 0 0 2px var(--bg-sunken); }
+
+.tstep-main { min-width: 0; flex: 1; }
+.tstep-row { display: flex; align-items: center; gap: 8px; }
+.tstep-row.click { cursor: pointer; }
+.tstep-kind {
+  font-family: var(--font-ui); text-transform: uppercase; letter-spacing: 0.1em;
+  font-size: 9.5px; line-height: 1.5; flex: none;
+}
+.tstep.think .tstep-kind { color: var(--text-dim); }
+.tstep.reason .tstep-kind { color: var(--info); }
+.tstep.tool .tstep-kind { color: var(--volt); }
+.tstep-text { font-family: var(--font-body); font-size: 12.5px; color: var(--text-primary); line-height: 1.5; min-width: 0; }
+.tstep.think .tstep-text { color: var(--text-mid); font-style: italic; }
+.tstep .tname { color: var(--text-bright); font-size: 12px; }
+.tstep .tdur { color: var(--text-dim); font-size: 11px; }
+.tstep-row .chev.sm { margin-left: auto; color: var(--text-dim); font-size: 8px; transition: transform 0.18s; flex: none; }
+.tstep.exp .tstep-row .chev.sm { transform: rotate(90deg); }
+.tstep .dot2 { flex: none; }
+
+.reason-detail {
+  margin-top: 7px; padding: 9px 12px; border-left: 2px solid var(--info-dim);
+  background: color-mix(in oklab, var(--info) 7%, transparent);
+  font-family: var(--font-body); font-size: 12.5px; line-height: 1.62; color: var(--text-mid);
+  border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
+}
+.reason-detail code { font-family: var(--font-mono); font-size: 11.5px; color: var(--info); }
+.reason-detail strong { color: var(--text-bright); }
+
+.tool-body2 { margin-top: 8px; }
+.tool-body2 .tk { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.1em; margin-top: 9px; }
+.tool-body2 .tk:first-child { margin-top: 0; }
+.tool-body2 pre {
+  margin: 4px 0 0; padding: 10px; background: var(--bg-well); border: 1px solid var(--border-soft);
+  border-radius: var(--radius-xs); font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid);
+  overflow-x: auto; line-height: 1.55;
+}
+.tool-body2 pre .jk { color: var(--volt-strong); }
+.tool-body2 pre .js { color: var(--status-ok); }
+
+/* attention section (ctx rail) — what needs the operator's attention, and where */
+.att-count {
+  font-family: var(--font-mono); font-size: 10px; color: var(--status-bad);
+  border: 1px solid color-mix(in oklab, var(--status-bad) 40%, transparent);
+  background: color-mix(in oklab, var(--status-bad) 12%, transparent);
+  padding: 0 6px; border-radius: var(--radius-pill); margin-left: 7px; vertical-align: middle;
+}
+.att-list { display: flex; flex-direction: column; gap: 6px; }
+.att-item {
+  display: flex; align-items: flex-start; gap: 8px; padding: 8px 10px;
+  background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm);
+  font-size: 12px; line-height: 1.45; color: var(--text-primary);
+}
+.att-item .att-dot { width: 6px; height: 6px; border-radius: 50%; margin-top: 5px; flex: none; }
+.att-item.warn { border-left: 2px solid var(--status-warn); }
+.att-item.warn .att-dot { background: var(--status-warn); box-shadow: 0 0 6px var(--status-warn); }
+.att-item.bad { border-left: 2px solid var(--status-bad); }
+.att-item.bad .att-dot { background: var(--status-bad); box-shadow: 0 0 6px var(--status-bad); }
+
+/* turn inspector drawer — full injected prompt + context for one turn */
+.fbk-btn.inspect { margin-left: 4px; color: var(--info); border-color: color-mix(in oklab, var(--info) 30%, transparent); }
+.fbk-btn.inspect:hover { color: var(--info); border-color: var(--info); }
+.turn-overlay { position: fixed; inset: 0; background: rgba(4,5,8,0.42); z-index: 90; display: flex; justify-content: flex-end; }
+.turn-drawer {
+  width: min(560px, 94vw); height: 100%; background: var(--bg-panel);
+  border-left: 1px solid var(--border-main); box-shadow: -8px 0 30px rgba(0,0,0,0.5);
+  display: flex; flex-direction: column; animation: turn-in 0.18s ease;
+}
+@keyframes turn-in { from { transform: translateX(24px); opacity: 0; } to { transform: none; opacity: 1; } }
+.turn-hd { display: flex; align-items: center; gap: 10px; padding: 14px 16px; border-bottom: 1px solid var(--border-main); }
+.turn-hd h3 { font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.14em; font-size: 13px; color: var(--text-bright); margin: 0; }
+.turn-hd .tid { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
+.kc-hd .tid { color: var(--text-mid); }
+.kc-hd-phase { display: inline-flex; align-items: center; gap: 6px; margin-left: 4px; font-size: 10.5px; letter-spacing: 0.02em; color: var(--text-mid); font-family: var(--font-ui); }
+.turn-close { margin-left: auto; background: none; border: 1px solid var(--border-main); color: var(--text-mid); width: 26px; height: 26px; border-radius: var(--radius-sm); cursor: pointer; font-size: 12px; transition: 0.14s; }
+.turn-close:hover { border-color: var(--volt-dim); color: var(--volt); }
+.turn-tabs { display: flex; gap: 5px; padding: 9px 14px; border-bottom: 1px solid var(--border-soft); }
+.turn-tab { font-family: var(--font-ui); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; padding: 6px 12px; border: 1px solid transparent; border-radius: var(--radius-sm); color: var(--text-dim); background: none; cursor: pointer; transition: 0.14s; }
+.turn-tab:hover { color: var(--text-mid); }
+.turn-tab.on { color: var(--volt); border-color: var(--volt-dim); background: var(--volt-wash); }
+.turn-body { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 16px; }
+.turn-sec h4 { font-family: var(--font-ui); text-transform: uppercase; letter-spacing: 0.1em; font-size: 10px; color: var(--text-dim); margin: 0 0 8px; }
+.turn-pre { margin: 0; padding: 12px 13px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); font-family: var(--font-mono); font-size: 11.5px; line-height: 1.62; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.turn-thread { display: flex; flex-direction: column; gap: 9px; }
+.turn-msg { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); overflow: hidden; }
+.turn-msg .role { font-family: var(--font-mono); font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.1em; padding: 5px 10px; background: var(--bg-panel-alt); color: var(--text-dim); border-bottom: 1px solid var(--border-soft); }
+.turn-msg .role.system { color: var(--info); }
+.turn-msg .role.user { color: var(--volt); }
+.turn-msg .role.tool { color: var(--status-ok); }
+.turn-msg .role.assistant { color: var(--text-bright); }
+.turn-msg .body { padding: 9px 11px; font-family: var(--font-mono); font-size: 11.5px; line-height: 1.55; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.turn-kv { display: grid; grid-template-columns: 130px 1fr; gap: 8px 12px; font-family: var(--font-mono); font-size: 12px; }
+.turn-kv .k { color: var(--text-dim); }
+.turn-kv .v { color: var(--text-bright); }
+
+/* keeper config drawer */
+.kc-text { width: 100%; font-family: var(--font-body); font-size: 13px; line-height: 1.55; padding: 10px 12px; background: var(--bg-sunken); color: var(--text-primary); border: 1px solid var(--border-main); border-radius: var(--radius-sm); outline: none; resize: vertical; }
+.kc-text:focus { border-color: var(--volt-dim); box-shadow: 0 0 0 2px var(--volt-wash); }
+.kc-traits { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.kc-trait { font-family: var(--font-ui); font-size: 10.5px; color: var(--volt-strong); border: 1px solid var(--volt-dim); background: var(--volt-wash); padding: 2px 9px; border-radius: var(--radius-pill); }
+.kc-save { width: 100%; margin-top: 4px; padding: 11px; background: var(--volt); color: var(--volt-ink); border: 0; border-radius: var(--radius-sm); font-family: var(--font-ui); font-weight: 600; font-size: 13px; cursor: pointer; transition: 0.14s; }
+.kc-save:hover { filter: brightness(1.06); }
+.turn-sec .set-row { padding: 8px 0; }
+.kc-codectx { display: flex; flex-direction: column; gap: 8px; }
+.kc-cc-row { display: flex; align-items: center; gap: 10px; }
+.kc-cc-row .sub-k { min-width: 92px; }
+.kc-cc-row .mono { font-size: 12px; color: var(--text-bright); }
+.kc-cc-row .set-input { flex: 1; }
+.kc-fact-note { font-size: 11px; color: var(--text-dim); margin: -2px 0 9px; }
+.kc-inherit { display: flex; flex-direction: column; gap: 7px; padding: 10px 11px; background: var(--bg-sunken); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); }
+.kc-inh-row { display: flex; align-items: baseline; gap: 9px; min-width: 0; }
+.kc-inh-tag { flex: none; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; color: var(--text-mid); min-width: 64px; }
+.kc-inh-txt { flex: 1; min-width: 0; font-size: 11.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.kc-inh-note { margin-top: 2px; padding-top: 8px; border-top: 1px solid var(--border-soft); font-size: 10.5px; color: var(--text-dim); }
+
+/* web link unfurl card (chat) */
+.linkcard { display: flex; align-items: flex-start; gap: 11px; margin-top: 10px; padding: 11px 13px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); text-decoration: none; transition: border-color 0.18s ease, background 0.18s ease; max-width: 520px; }
+.linkcard:hover { border-color: var(--volt-dim); background: color-mix(in oklab, var(--volt) 5%, var(--bg-card)); }
+.linkcard-fav { flex: none; width: 30px; height: 30px; display: grid; place-items: center; border-radius: var(--radius-xs); background: var(--bg-sunken); border: 1px solid var(--border-soft); color: var(--volt-strong); font-family: var(--font-mono); font-size: 14px; }
+.linkcard.git .linkcard-fav { color: var(--text-bright); }
+.linkcard-body { display: flex; flex-direction: column; gap: 3px; min-width: 0; flex: 1; }
+.linkcard-title { font-family: var(--font-ui); font-size: 13px; font-weight: 600; color: var(--text-bright); line-height: 1.3; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.linkcard-desc { font-size: 12px; color: var(--text-mid); line-height: 1.45; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.linkcard-meta { font-size: 10.5px; color: var(--text-dim); margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.linkcard-go { flex: none; color: var(--text-dim); font-size: 13px; transition: color 0.18s ease; }
+.linkcard:hover .linkcard-go { color: var(--volt-strong); }
+/* inline links inside message bubbles */
+.bubble a, .inline-link { color: var(--volt-strong); text-decoration: underline; text-underline-offset: 2px; text-decoration-color: color-mix(in oklab, var(--volt-strong) 45%, transparent); transition: color 0.15s ease; }
+.bubble a:hover, .inline-link:hover { color: var(--volt); text-decoration-color: var(--volt); }
+
+/* work / goal surface */
+.wk-list { display: flex; flex-direction: column; gap: 12px; margin-top: 4px; }
+.wk-goal { background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.wk-goal.has-block { border-color: color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); }
+.wk-goal-h { display: flex; align-items: center; gap: 10px; width: 100%; padding: 13px 15px 11px; background: none; border: 0; cursor: pointer; text-align: left; color: inherit; }
+.wk-goal-h:hover { background: color-mix(in oklab, var(--volt) 3%, transparent); }
+.wk-caret { flex: none; color: var(--text-dim); font-size: 11px; width: 12px; }
+.wk-pri { flex: none; font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; padding: 2px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-soft); color: var(--text-dim); }
+.wk-pri.high { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); background: color-mix(in oklab, var(--status-bad) 10%, transparent); }
+.wk-pri.normal { color: var(--volt-strong); border-color: color-mix(in oklab, var(--volt) 32%, transparent); }
+.wk-pri.low { color: var(--text-dim); }
+.wk-goal-id { flex: none; font-size: 11.5px; color: var(--text-dim); }
+.wk-goal-title { font-family: var(--font-ui); font-size: 14.5px; font-weight: 600; color: var(--text-bright); }
+.wk-goal-ns { flex: none; font-size: 11px; color: var(--text-mid); background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 1px 7px; border-radius: var(--radius-pill); }
+.wk-spacer { flex: 1; }
+.wk-due { flex: none; font-size: 11px; color: var(--text-dim); }
+.wk-lead { flex: none; display: inline-flex; }
+.wk-goal-sub { display: flex; align-items: center; gap: 11px; padding: 0 15px 13px 37px; }
+.wk-prog { flex: none; width: 300px; max-width: 42%; height: 6px; display: flex; gap: 1.5px; background: var(--bg-sunken); border-radius: var(--radius-pill); overflow: hidden; }
+.wk-seg { height: 100%; }
+.wk-seg.done { background: var(--status-ok); }
+.wk-seg.wip { background: var(--volt); }
+.wk-seg.blocked { background: var(--status-bad); }
+.wk-prog-lbl { flex: none; font-size: 11px; color: var(--text-mid); }
+.wk-metric { margin-left: auto; flex: none; font-size: 11px; color: var(--text-dim); }
+.wk-jobs { border-top: 1px solid var(--border-soft); padding: 10px 15px 13px; display: flex; flex-direction: column; gap: 2px; }
+.wk-note { font-size: 12px; color: var(--text-mid); line-height: 1.5; padding: 2px 0 9px; border-bottom: 1px dashed var(--border-soft); margin-bottom: 7px; }
+.wk-job { display: flex; align-items: center; gap: 10px; padding: 7px 8px; border-radius: var(--radius-xs); }
+.wk-job:hover { background: var(--bg-sunken); }
+.wk-job-dot { flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--text-dim); }
+.wk-job-dot.done { background: var(--status-ok); }
+.wk-job-dot.wip { background: var(--volt); }
+.wk-job-dot.review { background: var(--status-warn); }
+.wk-job-dot.blocked { background: var(--status-bad); }
+.wk-job-id { flex: none; font-size: 11px; color: var(--text-dim); min-width: 52px; }
+.wk-job-title { font-size: 13px; color: var(--text-primary); display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.wk-job.done .wk-job-title { color: var(--text-mid); }
+.wk-job-block { font-size: 11px; color: var(--status-bad); }
+.wk-job-state { flex: none; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; color: var(--text-dim); }
+.wk-job-state.done { color: var(--status-ok); }
+.wk-job-state.wip { color: var(--volt-strong); }
+.wk-job-state.review { color: var(--status-warn); }
+.wk-job-state.blocked { color: var(--status-bad); }
+.wk-job-kp { flex: none; display: inline-flex; align-items: center; justify-content: flex-end; gap: 6px; min-width: 130px; padding: 3px 6px; border-radius: var(--radius-pill); border: 1px solid transparent; background: none; cursor: pointer; color: var(--text-mid); font-size: 11.5px; white-space: nowrap; transition: border-color 0.15s ease, color 0.15s ease; }
+.wk-job-kp:hover { border-color: var(--border-highlight); color: var(--text-bright); }
+.wk-job-kp.none { color: var(--text-dim); cursor: default; }
+.set-add.wk-newgoal { width: auto; margin: 0; flex: none; align-self: center; white-space: nowrap; }
+.wk-blk-n { color: var(--status-bad); }
+.wk-foot { margin: 16px 2px 4px; font-size: 11px; color: var(--text-dim); }
+
+/* ── work v2: horizon groups, real task lifecycle, gate contract, backlog ── */
+.wk-horizon { margin-top: 18px; }
+.wk-hz-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 9px; }
+.wk-hz-lbl { font-family: var(--font-display); font-weight: 600; font-size: 14px; color: var(--text-bright); }
+.wk-hz-sub { font-size: 11px; color: var(--text-dim); }
+.wk-hz-n { margin-left: auto; font-size: 11px; color: var(--text-dim); }
+
+.wk-goal.st-warn { border-color: color-mix(in oklab, var(--status-warn) 30%, var(--border-main)); }
+.wk-goal.st-bad { border-color: color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); }
+.wk-goal.st-volt { border-color: var(--volt-dim); }
+.wk-prio { flex: none; font-size: 10px; color: var(--text-mid); border: 1px solid var(--border-main); border-radius: var(--radius-xs); padding: 1px 6px; }
+.wk-gstatus { flex: none; font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.06em; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); }
+.wk-gstatus.ok { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 38%, transparent); }
+.wk-gstatus.warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 40%, transparent); background: color-mix(in oklab, var(--status-warn) 8%, transparent); }
+.wk-gstatus.bad { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 42%, transparent); background: color-mix(in oklab, var(--status-bad) 8%, transparent); }
+.wk-gstatus.volt { color: var(--volt-strong); border-color: var(--volt-dim); background: var(--volt-wash); }
+.wk-approval { flex: none; font-size: 10px; color: var(--volt-strong); border: 1px solid var(--volt-dim); background: var(--volt-wash); border-radius: var(--radius-pill); padding: 2px 8px; }
+.wk-goal-phase { flex: none; font-size: 10.5px; color: var(--text-dim); }
+.wk-seg.verify { background: var(--volt-strong); }
+
+.wk-tasks { border-top: 1px solid var(--border-soft); padding: 10px 15px 13px; display: flex; flex-direction: column; gap: 3px; }
+.wk-verifier { font-size: 11px; color: var(--text-dim); padding: 4px 0 9px; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.wk-vchip { font-size: 9.5px; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-xs); padding: 1px 6px; background: var(--volt-wash); }
+
+.wk-task { border-radius: var(--radius-xs); }
+.wk-task-main { display: flex; align-items: center; gap: 10px; padding: 7px 8px; border-radius: var(--radius-xs); }
+.wk-task-main:hover { background: var(--bg-sunken); }
+.wk-task-dot { flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--text-dim); }
+.wk-task-dot.done { background: var(--status-ok); }
+.wk-task-dot.wip { background: var(--volt); }
+.wk-task-dot.verify { background: var(--volt-strong); box-shadow: 0 0 7px var(--volt-glow); }
+.wk-task-dot.claimed { background: var(--info); }
+.wk-task-dot.cancelled { background: var(--text-dim); opacity: 0.5; }
+.wk-task-dot.todo { background: transparent; border: 1px solid var(--border-highlight); }
+.wk-task-id { flex: none; font-size: 11px; color: var(--text-dim); min-width: 76px; }
+.wk-task-title { font-size: 13px; color: var(--text-primary); display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.wk-task.done .wk-task-title { color: var(--text-mid); }
+.wk-task.cancelled .wk-task-title { color: var(--text-dim); text-decoration: line-through; }
+.wk-task-block { font-size: 11px; color: var(--status-bad); }
+.wk-task-chev { font-size: 8px; color: var(--text-dim); }
+.wk-task-state { flex: none; font-family: var(--font-ui); font-size: 10px; letter-spacing: 0.04em; color: var(--text-dim); }
+.wk-task-state.done { color: var(--status-ok); }
+.wk-task-state.wip { color: var(--volt-strong); }
+.wk-task-state.verify { color: var(--volt-strong); }
+.wk-task-state.claimed { color: var(--info); }
+.wk-task-state.cancelled { color: var(--text-dim); }
+.wk-task-kp { flex: none; display: inline-flex; align-items: center; justify-content: flex-end; gap: 6px; min-width: 130px; padding: 3px 6px; border-radius: var(--radius-pill); border: 1px solid transparent; background: none; cursor: pointer; color: var(--text-mid); font-size: 11.5px; white-space: nowrap; transition: border-color 0.15s, color 0.15s; }
+.wk-task-kp:hover { border-color: var(--border-highlight); color: var(--text-bright); }
+.wk-task-kp.none { color: var(--text-dim); cursor: default; }
+.wk-task-claim { flex: none; font-family: var(--font-ui); font-size: 11px; padding: 3px 11px; border-radius: var(--radius-pill); border: 1px solid var(--volt-dim); background: var(--volt-wash); color: var(--volt-strong); cursor: pointer; transition: 0.14s; white-space: nowrap; }
+.wk-task-claim:hover { background: color-mix(in oklab, var(--volt) 18%, transparent); color: var(--text-bright); }
+
+.wk-task-detail { padding: 4px 8px 10px 25px; }
+.wk-gate { border: 1px solid var(--border-soft); border-left: 2px solid var(--volt-dim); border-radius: var(--radius-sm); background: var(--bg-sunken); padding: 10px 12px; }
+.wk-gate-h { font-size: 11px; color: var(--text-mid); margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
+.wk-gate-open { font-size: 9.5px; color: var(--status-warn); border: 1px solid color-mix(in oklab, var(--status-warn) 38%, transparent); border-radius: var(--radius-pill); padding: 1px 7px; }
+.wk-gate-ok { font-size: 9.5px; color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 38%, transparent); border-radius: var(--radius-pill); padding: 1px 7px; }
+.wk-gate-row { display: flex; align-items: center; gap: 9px; padding: 4px 0; border-top: 1px solid var(--border-soft); }
+.wk-gate-row:first-of-type { border-top: 0; }
+.wk-gate-mark { flex: none; width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; border-radius: 50%; font-size: 9px; }
+.wk-gate-row.satisfied .wk-gate-mark { color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 40%, transparent); }
+.wk-gate-row.missing .wk-gate-mark { color: var(--text-dim); border: 1px solid var(--border-highlight); }
+.wk-gate-row.failed .wk-gate-mark { color: var(--status-bad); border: 1px solid color-mix(in oklab, var(--status-bad) 45%, transparent); }
+.wk-gate-ev { flex: 1; font-size: 12px; color: var(--text-primary); }
+.wk-gate-row.missing .wk-gate-ev { color: var(--text-mid); }
+.wk-gate-out { flex: none; font-size: 10px; font-family: var(--font-mono); color: var(--text-dim); }
+.wk-gate-row.satisfied .wk-gate-out { color: var(--status-ok); }
+.wk-gate-row.failed .wk-gate-out { color: var(--status-bad); }
+
+.wk-handoff { margin-top: 8px; border: 1px solid var(--border-soft); border-left: 2px solid var(--info); border-radius: var(--radius-sm); background: color-mix(in oklab, var(--info) 5%, var(--bg-sunken)); padding: 10px 12px; }
+.wk-handoff-h { font-size: 11px; color: var(--info); margin-bottom: 7px; }
+.wk-handoff-row { display: flex; gap: 9px; font-size: 12px; color: var(--text-primary); line-height: 1.5; padding: 2px 0; }
+.wk-handoff-row .k { flex: none; font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); min-width: 30px; padding-top: 2px; }
+
+.wk-backlog { margin-top: 16px; border: 1px dashed color-mix(in oklab, var(--status-warn) 30%, var(--border-main)); border-radius: var(--radius-md); background: color-mix(in oklab, var(--status-warn) 4%, var(--bg-panel)); padding: 13px 15px; }
+.wk-backlog-h { display: flex; align-items: center; gap: 9px; font-family: var(--font-display); font-weight: 500; font-size: 13px; color: var(--text-bright); margin-bottom: 10px; }
+.wk-backlog-glyph { color: var(--status-warn); font-size: 14px; }
+.wk-backlog-h .n { font-family: var(--font-mono); font-size: 11px; color: var(--status-warn); }
+.wk-backlog-sub { margin-left: auto; font-size: 10px; color: var(--text-dim); }
+.wk-backlog-list { display: flex; flex-direction: column; gap: 4px; }
+.wk-bl-row { display: flex; align-items: center; gap: 10px; padding: 7px 9px; border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-soft); }
+.wk-bl-title { font-size: 12.5px; color: var(--text-primary); display: flex; align-items: baseline; gap: 8px; min-width: 0; }
+.wk-bl-goal { font-size: 10px; color: var(--text-dim); }
+.wk-bl-prio { flex: none; font-size: 10px; color: var(--text-dim); }
+
+/* small inline label for jargon keys (room / 세션 / …) */
+.sub-k { font-family: var(--font-ui); font-size: 9px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-dim); margin-right: 4px; }
+
+/* suggested chips */
+.suggest { display: flex; flex-direction: column; gap: 7px; margin-top: 4px; }
+.suggest .lbl { font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); }
+.suggest-row { display: flex; flex-wrap: wrap; gap: 8px; }
+.chip {
+  font-family: var(--font-ui); font-size: 13px; cursor: pointer; text-align: left;
+  padding: 8px 13px; border-radius: var(--radius-pill); border: 1px solid var(--border-main);
+  background: var(--bg-card); color: var(--text-primary); transition: 0.15s; line-height: 1.3;
+}
+.chip:hover { border-color: var(--volt); color: var(--text-bright); background: var(--bg-card-hover); box-shadow: 0 0 0 2px var(--volt-wash); }
+.chip .pre { color: var(--volt); margin-right: 7px; }
+
+/* typing */
+.typing { display: inline-flex; gap: 4px; align-items: center; padding: 4px 0; }
+.typing i { width: 6px; height: 6px; border-radius: 50%; background: var(--volt); display: inline-block; animation: tdot 1.2s infinite ease-in-out; }
+.typing i:nth-child(2) { animation-delay: 0.18s; } .typing i:nth-child(3) { animation-delay: 0.36s; }
+@keyframes tdot { 0%,60%,100% { opacity: 0.25; transform: translateY(0); } 30% { opacity: 1; transform: translateY(-3px); } }
+
+/* composer */
+.composer { flex: none; padding: 12px 24px 16px; border-top: 1px solid var(--border-main); background: linear-gradient(0deg, var(--bg-panel), var(--bg-deep)); }
+.composer-inner { max-width: var(--thread-w, 980px); margin: 0 auto; padding: 0 4px; }
+/* slash-command palette */
+.slashmenu { position: absolute; left: 0; right: 0; bottom: calc(100% + 8px); background: var(--bg-panel); border: 1px solid var(--border-highlight); border-radius: var(--radius-md); box-shadow: 0 -8px 28px rgba(0,0,0,0.5); overflow: hidden; z-index: 40; }
+.slashmenu-h { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); padding: 8px 12px 6px; border-bottom: 1px solid var(--border-soft); }
+.slashmenu-i { display: flex; align-items: center; gap: 10px; width: 100%; padding: 8px 12px; background: none; border: 0; cursor: pointer; text-align: left; transition: background 0.12s; }
+.slashmenu-i.on { background: var(--volt-wash); }
+.slashmenu-gl { flex: none; width: 18px; text-align: center; color: var(--text-mid); }
+.slashmenu-i.on .slashmenu-gl { color: var(--volt); }
+.slashmenu-cmd { flex: none; width: 88px; font-size: 12px; color: var(--volt-strong); }
+.slashmenu-lbl { flex: none; font-size: 12.5px; color: var(--text-bright); }
+.slashmenu-hint { flex: 1; min-width: 0; font-size: 11px; color: var(--text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.slashmenu-grp { flex: none; font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-dim); border: 1px solid var(--border-main); padding: 1px 6px; border-radius: var(--radius-pill); }
+.slashmenu-i.danger .slashmenu-cmd, .slashmenu-i.danger .slashmenu-gl { color: var(--status-bad); }
+.composer-box {
+  background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-md);
+  padding: 6px 6px 6px 14px; display: flex; align-items: flex-end; gap: 10px; transition: border-color 0.15s, box-shadow 0.15s;
+  position: relative;
+}
+.composer-box.focus { border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); }
+.composer textarea {
+  flex: 1; resize: none; border: 0; outline: 0; background: transparent;
+  color: var(--text-bright); font-family: var(--font-ui); font-size: 14.5px; line-height: 1.5;
+  padding: 9px 0; max-height: 160px; min-height: 24px;
+}
+.composer textarea::placeholder { color: var(--text-dim); }
+.composer-tools { display: flex; align-items: center; gap: 6px; padding-bottom: 2px; }
+.ctool {
+  width: 34px; height: 34px; display: flex; align-items: center; justify-content: center;
+  border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-panel-alt);
+  color: var(--text-mid); cursor: pointer; transition: 0.14s;
+}
+.ctool:hover { color: var(--text-bright); border-color: var(--border-highlight); }
+.send {
+  height: 34px; padding: 0 16px; border-radius: var(--radius-sm); cursor: pointer;
+  background: var(--volt); color: var(--volt-ink); border: 1px solid var(--volt);
+  font-family: var(--font-ui); font-size: 12.5px; font-weight: 600; letter-spacing: 0.04em;
+  display: inline-flex; align-items: center; gap: 7px; transition: 0.14s;
+  white-space: nowrap; flex: none;
+}
+.send:hover { background: var(--volt-strong); box-shadow: 0 0 18px var(--volt-glow); }
+.send:disabled { opacity: 0.4; cursor: default; box-shadow: none; }
+.composer-foot { display: flex; align-items: center; justify-content: space-between; margin-top: 8px; font-size: 11px; color: var(--text-dim); }
+.composer-foot .as b { color: var(--volt-strong); font-family: var(--font-mono); }
+.composer-foot .hint { font-family: var(--font-mono); white-space: nowrap; }
+.composer-foot .as { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.composer-foot kbd { font-family: var(--font-mono); font-size: 10px; background: var(--bg-card); border: 1px solid var(--border-main); border-bottom-width: 2px; border-radius: var(--radius-xs); padding: 1px 5px; color: var(--text-mid); }
+
+/* composer — drag-over affordance */
+.composer-box.drag { border-color: var(--volt-dim); box-shadow: 0 0 0 3px var(--volt-wash); background: var(--volt-wash); }
+
+/* composer — pending attachment / voice tray */
+.composer-tray { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 9px; }
+.cdraft { display: flex; align-items: center; gap: 9px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 7px 9px; position: relative; }
+.cdraft.att { padding-right: 26px; max-width: 280px; }
+.cdraft-thumb { width: 34px; height: 34px; flex: none; border-radius: var(--radius-xs); overflow: hidden; background: var(--bg-panel-alt); display: flex; align-items: center; justify-content: center; }
+.cdraft-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.cdraft-glyph { color: var(--text-dim); font-size: 17px; }
+.cdraft-meta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.cdraft-name { font-size: 11.5px; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 190px; }
+.cdraft-sub { font-size: 10px; color: var(--text-dim); }
+.cdraft.voice { padding-right: 26px; gap: 8px; flex-wrap: wrap; max-width: 360px; }
+.cdraft-glyph.mic { color: var(--volt); font-size: 14px; }
+.cdraft-wave { display: flex; align-items: center; gap: 1.5px; height: 22px; }
+.cdraft-wave .vbar { width: 2px; border-radius: 1px; background: var(--volt-dim); }
+.cdraft-dur { font-size: 11px; color: var(--text-mid); }
+.cdraft-tx { display: flex; gap: 7px; align-items: baseline; flex-basis: 100%; padding-top: 5px; border-top: 1px solid var(--border-main); }
+.cdraft-tx-k { font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.14em; font-size: 9px; color: var(--volt); flex: none; }
+.cdraft-tx-v { font-size: 11.5px; color: var(--text-mid); line-height: 1.45; }
+.cdraft-x { position: absolute; top: 5px; right: 6px; width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; border: 0; background: transparent; color: var(--text-dim); cursor: pointer; font-size: 10px; border-radius: var(--radius-xs); }
+.cdraft-x:hover { color: var(--status-bad); background: var(--bg-panel-alt); }
+
+/* composer — live recording bar */
+.rec-bar { flex: 1; display: flex; align-items: center; gap: 10px; padding: 5px 4px 5px 10px; min-height: 34px; }
+.rec-dot { width: 9px; height: 9px; border-radius: 50%; background: var(--status-bad); flex: none; animation: recpulse 1.1s ease-in-out infinite; }
+@keyframes recpulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+.rec-lbl { font-family: var(--font-display); text-transform: uppercase; letter-spacing: 0.16em; font-size: 10px; color: var(--status-bad); }
+.rec-clock { font-size: 13px; color: var(--text-bright); }
+.rec-wave { flex: 1; display: flex; align-items: center; gap: 2px; height: 24px; overflow: hidden; }
+.rec-wave .rbar { width: 2.5px; border-radius: 1px; background: var(--volt-dim); flex: none; }
+.rec-btn { height: 30px; padding: 0 12px; border-radius: var(--radius-sm); cursor: pointer; font-family: var(--font-ui); font-size: 12px; transition: 0.14s; flex: none; }
+.rec-btn.cancel { background: transparent; border: 1px solid var(--border-main); color: var(--text-mid); }
+.rec-btn.cancel:hover { color: var(--text-bright); border-color: var(--border-highlight); }
+.rec-btn.stop { background: var(--volt); border: 1px solid var(--volt); color: var(--volt-ink); }
+.rec-btn.stop:hover { background: var(--volt-strong); box-shadow: 0 0 16px var(--volt-glow); }
+
+/* ════ CONTEXT RAIL ════ */
+.ctx { border-left: 1px solid var(--border-main); background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%); display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+.ctx-scroll { overflow-y: auto; padding: 14px; display: flex; flex-direction: column; gap: 16px; }
+.ctx-sec h4 { font-family: var(--font-display); font-weight: 400; text-transform: uppercase; letter-spacing: 0.18em; font-size: 11px; color: var(--text-mid); margin: 0 0 9px; }
+.ctx-card { background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 11px 12px; }
+
+.vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border-soft); border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; }
+.vital { background: var(--bg-card); padding: 9px 11px; }
+.vital .vk { font-size: 9.5px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-mid); font-weight: 600; }
+.vital .vv { font-family: var(--font-mono); font-size: 15px; color: var(--text-bright); margin-top: 3px; }
+.vital .vv.volt { color: var(--volt-strong); }
+.vital .vv small { font-size: 10px; color: var(--text-dim); }
+
+/* context meter */
+.meter { height: 7px; border-radius: var(--radius-pill); background: var(--bg-sunken); border: 1px solid var(--border-soft); overflow: hidden; margin-top: 7px; }
+.meter > span { display: block; height: 100%; background: linear-gradient(90deg, var(--volt-dim), var(--volt)); }
+.meter.hot > span { background: linear-gradient(90deg, var(--status-warn), var(--status-bad)); }
+.meter-wrap { position: relative; margin-top: 7px; }
+.meter-wrap .meter { margin-top: 0; }
+.meter-mark { position: absolute; top: -2px; width: 1px; height: 11px; background: color-mix(in oklab, var(--status-warn) 75%, transparent); transform: translateX(-50%); pointer-events: none; }
+.meter-mark.hot { background: var(--status-bad); }
+.meter-mark-lbl { position: absolute; bottom: 100%; right: 1px; margin-bottom: 3px; font-size: 8.5px; font-style: normal; letter-spacing: 0.04em; text-transform: uppercase; white-space: nowrap; color: color-mix(in oklab, var(--status-warn) 80%, var(--text-dim)); }
+.meter-mark.hot .meter-mark-lbl { color: var(--status-bad); }
+
+/* fsm list */
+.fsm { display: flex; flex-direction: column; gap: 0; }
+.fsm-step { display: flex; align-items: center; gap: 9px; padding: 5px 4px; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim); position: relative; }
+.fsm-step .pip { width: 9px; height: 9px; border-radius: 50%; border: 1px solid var(--border-highlight); background: var(--bg-sunken); flex: none; z-index: 1; }
+.fsm-step.done { color: var(--text-mid); }
+.fsm-step.done .pip { background: var(--text-dim); border-color: var(--text-dim); }
+.fsm-step.cur { color: var(--volt-strong); }
+.fsm-step.cur .pip { background: var(--volt); border-color: var(--volt); box-shadow: 0 0 10px var(--volt-glow); }
+.fsm-step:not(:last-child)::after { content: ""; position: absolute; left: 8.5px; top: 16px; bottom: -5px; width: 1px; background: var(--border-soft); }
+.fsm-step.done:not(:last-child)::after { background: var(--text-dim); }
+
+.ctx-list { display: flex; flex-direction: column; gap: 7px; }
+.ctx-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--text-mid); }
+.ctx-item .ci-name { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-primary); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ctx-item .ci-meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; flex: none; }
+
+.tasktag { display: flex; flex-direction: column; gap: 5px; width: 100%; text-align: left; padding: 8px 10px; border-radius: var(--radius-xs); background: var(--bg-sunken); border: 1px solid var(--border-soft); font-size: 12px; color: var(--text-mid); cursor: pointer; transition: border-color 0.14s, background 0.14s; }
+.tasktag:hover { border-color: var(--border-highlight); background: var(--bg-card); }
+.tasktag-top { display: flex; align-items: center; gap: 8px; }
+.tasktag .ttl { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; color: var(--text-primary); }
+.tasktag .tid { font-family: var(--font-mono); font-size: 10.5px; color: var(--volt-strong); flex: none; }
+.tasktag-state { margin-left: auto; flex: none; font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.04em; text-transform: uppercase; padding: 1px 7px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); }
+.tasktag-state.blocked { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 35%, transparent); }
+.tasktag-state.review { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 35%, transparent); }
+.tasktag-state.active, .tasktag-state.run { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 35%, transparent); }
+
+/* empty state */
+.empty2 { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px; color: var(--text-dim); text-align: center; padding: 40px; }
+.empty2 .ico { font-size: 30px; opacity: 0.5; }
+.empty2 h3 { font-family: var(--font-display); letter-spacing: 0.14em; color: var(--text-mid); font-size: 15px; }
+
+/* density compact */
+.v2-app[data-density="compact"] .thread-inner { gap: 14px; }
+.v2-app[data-density="compact"] .bubble { padding: 11px 13px; font-size: 14px; }
+.v2-app[data-density="compact"] .kp-row { padding: 6px 9px; }
+
+/* ════ TOK/S THROUGHPUT ════ */
+/* header live readout */
+.chat-id .sub .tps-live { display: inline-flex; align-items: center; gap: 5px; color: var(--status-ok); }
+.tps-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--status-ok); box-shadow: 0 0 6px var(--status-ok); animation: tps-pulse 1.1s ease-in-out infinite; }
+@keyframes tps-pulse { 0%,100% { opacity: 0.45; } 50% { opacity: 1; } }
+.chat-id .sub .tps-live .mono { color: var(--status-ok); }
+
+/* context-rail throughput card */
+.tps-card { background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); padding: 9px 11px; }
+.tps-now { display: flex; align-items: baseline; gap: 5px; }
+.tps-val { font-family: var(--font-mono); font-size: 18px; line-height: 1; color: var(--status-ok); font-variant-numeric: tabular-nums; }
+.tps-val.idle { color: var(--text-dim); }
+.tps-unit { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
+.tps-flag { margin-left: auto; display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--status-ok); }
+.tps-spark { position: relative; display: flex; align-items: flex-end; gap: 2px; height: 22px; margin-top: 7px; }
+.tps-spark > span { flex: 1; background: var(--status-ok); border-radius: 1px; min-height: 2px; transition: height 0.5s ease; }
+.tps-ranges { display: flex; align-items: center; gap: 4px; margin-top: 7px; }
+.tps-range { font-family: var(--font-mono); font-size: 10px; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); background: transparent; color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.tps-range:hover { color: var(--text-mid); border-color: var(--border-highlight); }
+.tps-range.on { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); background: color-mix(in oklab, var(--status-ok) 10%, transparent); }
+.tps-avg { margin-left: auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+
+/* compaction full-context before/after toggle */
+.cmp-side-toggle { display: flex; gap: 5px; margin-bottom: 9px; }
+.cmp-side { flex: 1; font-family: var(--font-ui); font-size: 11px; padding: 7px 9px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-sunken); color: var(--text-dim); cursor: pointer; transition: 0.14s; }
+.cmp-side:hover { color: var(--text-mid); }
+.cmp-side.on { color: var(--text-bright); border-color: var(--volt-dim); background: var(--volt-wash); }
+.cmp-ctx-pre { max-height: 280px; overflow-y: auto; }
+
+/* ════ MOBILE-ONLY HEADER CONTROLS (rendered only ≤900px via JS) ════ */
+/* feedback voted state + regen tag */
+.fbk-btn.on.up { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 45%, transparent); }
+.fbk-btn.on.down { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); }
+.fbk-noted { font-family: var(--font-ui); font-size: 11px; color: var(--status-ok); margin-left: 4px; animation: turn-in 0.18s ease; }
+.regen-tag { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.04em; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-pill); padding: 1px 7px; }
+
+/* external-source context provenance (Discord/Slack pulled-in context range) */
+.ctx-from {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 8px; padding: 7px 11px;
+  background: color-mix(in oklab, var(--info) 8%, transparent);
+  border: 1px solid color-mix(in oklab, var(--info) 28%, transparent);
+  border-radius: var(--radius-sm); font-size: 11.5px; color: var(--text-mid);
+}
+.ctx-from .cf-ico { color: var(--info); font-family: var(--font-mono); }
+.ctx-from b { color: var(--text-bright); font-weight: 600; }
+.ctx-from .cf-view { margin-left: auto; flex: none; background: none; border: 1px solid var(--info-dim); color: var(--info); border-radius: var(--radius-pill); font-size: 10.5px; padding: 2px 9px; cursor: pointer; transition: 0.14s; }
+.ctx-from .cf-view:hover { background: color-mix(in oklab, var(--info) 14%, transparent); }
+.cf-detail { margin: -2px 0 8px; padding: 10px 12px; border: 1px solid color-mix(in oklab, var(--info) 24%, transparent); border-top: 0; border-radius: 0 0 var(--radius-sm) var(--radius-sm); background: color-mix(in oklab, var(--info) 5%, transparent); }
+.cf-detail-h { font-size: 10.5px; color: var(--text-dim); margin-bottom: 8px; }
+.cf-msg { display: grid; grid-template-columns: 44px 70px 1fr; gap: 8px; align-items: baseline; padding: 4px 0; font-size: 12px; line-height: 1.45; border-top: 1px solid color-mix(in oklab, var(--info) 12%, transparent); }
+.cf-msg:first-of-type { border-top: 0; }
+.cf-msg .cf-ts { color: var(--text-dim); font-size: 10.5px; }
+.cf-msg .cf-who { color: var(--info); font-weight: 600; }
+.cf-msg .cf-text { color: var(--text-mid); }
+
+/* code block in messages */
+.code-block { margin: 10px 0; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-well); }
+.code-cap { padding: 6px 12px; font-size: 10.5px; color: var(--text-dim); background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.code-block pre { margin: 0; padding: 12px 14px; overflow-x: auto; }
+.code-block code { font-family: var(--font-mono); font-size: 12.5px; line-height: 1.6; color: var(--text-primary); white-space: pre; }
+.code-block .kw { color: var(--volt-strong); opacity: 0.85; }
+.code-block .fn { color: var(--text-bright); }
+.code-block .str { color: color-mix(in oklab, var(--status-ok) 70%, var(--text-mid)); }
+.code-block .cm { color: var(--text-dim); font-style: italic; }
+.code-block .del { color: var(--status-bad); }
+.code-block .add { color: var(--status-ok); }
+
+/* shell / exec output */
+.shell-block { margin: 10px 0; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-well); }
+.shell-bar { display: flex; align-items: center; gap: 6px; padding: 7px 11px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.shell-bar .dot { width: 9px; height: 9px; border-radius: 50%; }
+.shell-bar .dot.r { background: #e0625b; } .shell-bar .dot.y { background: #e0b257; } .shell-bar .dot.g { background: #5ea66a; }
+.shell-bar .shell-title { margin-left: 8px; font-size: 10.5px; color: var(--text-dim); }
+.shell-block pre { margin: 0; padding: 11px 13px; overflow-x: auto; }
+.sh-ln { font-family: var(--font-mono); font-size: 12px; line-height: 1.6; color: var(--text-mid); white-space: pre-wrap; word-break: break-word; }
+.sh-ln.cmd { color: var(--text-bright); }
+.sh-ln .sh-prompt { color: var(--volt-strong); }
+.sh-ln.ok { color: var(--status-ok); }
+.sh-ln.err { color: var(--status-bad); }
+.sh-ln.dim { color: var(--text-dim); }
+.shell-exit { padding: 6px 13px; font-family: var(--font-mono); font-size: 11px; border-top: 1px solid var(--border-soft); }
+.shell-exit.ok { color: var(--status-ok); }
+.shell-exit.fail { color: var(--status-bad); }
+
+/* artifact file card */
+.artifact { display: flex; align-items: center; gap: 11px; margin: 10px 0; padding: 11px 13px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); }
+.af-ico { width: 34px; height: 34px; flex: none; display: flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 15px; color: var(--volt-strong); background: var(--volt-wash); border: 1px solid var(--volt-dim); border-radius: var(--radius-sm); }
+.af-meta { flex: 1; min-width: 0; }
+.af-name { font-size: 13px; color: var(--text-bright); }
+.af-sub { font-size: 10.5px; color: var(--text-dim); margin-top: 2px; text-transform: uppercase; letter-spacing: 0.06em; }
+.af-btn { flex: none; font-family: var(--font-ui); font-size: 11px; padding: 5px 11px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: transparent; color: var(--text-mid); cursor: pointer; transition: 0.14s; }
+.af-btn:hover { border-color: var(--volt-dim); color: var(--volt); }
+
+/* image / svg output */
+.img-out, .svg-out { margin: 10px 0; }
+.img-frame, .svg-frame { border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-sunken); display: flex; align-items: center; justify-content: center; }
+.img-frame img { max-width: 100%; display: block; }
+.img-ph { padding: 40px; color: var(--text-dim); font-size: 12px; font-family: var(--font-ui); }
+.svg-frame { padding: 16px; }
+.svg-frame svg { max-width: 100%; height: auto; display: block; }
+.img-out figcaption, .svg-out figcaption { margin-top: 6px; font-size: 11px; color: var(--text-dim); }
+
+/* ── multimodal: image attachment (vision-modal user input) ── */
+.attach { margin: 10px 0; border: 1px solid var(--border-main); border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-well); }
+.attach-hd { display: flex; align-items: center; gap: 8px; padding: 7px 11px; background: var(--bg-panel-alt); border-bottom: 1px solid var(--border-soft); }
+.attach-clip { color: var(--volt-strong); font-size: 12px; flex: none; }
+.attach-name { font-size: 11px; color: var(--text-mid); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.attach-dims { font-size: 10px; color: var(--text-dim); flex: none; }
+.attach-frame { display: flex; align-items: center; justify-content: center; background: var(--bg-sunken); padding: 0; }
+.attach-frame svg { max-width: 100%; height: auto; display: block; }
+.attach-frame img { width: 100%; max-height: 220px; object-fit: cover; object-position: center 30%; display: block; }
+.attach-cap { display: flex; align-items: center; gap: 8px; padding: 7px 11px; font-size: 10.5px; color: var(--text-dim); border-top: 1px solid var(--border-soft); }
+.attach-tag { font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-pill); padding: 1px 7px; }
+
+/* ── multimodal: voice memo (audio-modal user input) ── */
+.voice { margin: 10px 0; padding: 11px 13px; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-well); }
+.voice-row { display: flex; align-items: center; gap: 12px; }
+.voice-play { flex: none; width: 32px; height: 32px; border-radius: 50%; border: 1px solid var(--volt-dim); background: var(--volt-wash); color: var(--volt-strong); cursor: pointer; font-size: 11px; line-height: 1; display: flex; align-items: center; justify-content: center; padding-left: 2px; transition: 0.14s; }
+.voice-play:hover { border-color: var(--volt); color: var(--volt); }
+.voice-play.on { background: var(--volt); color: var(--volt-ink); border-color: var(--volt); padding-left: 0; }
+.voice-wave { flex: 1; display: flex; align-items: center; gap: 2px; height: 30px; min-width: 0; overflow: hidden; }
+.voice-wave .vbar { flex: 1; min-width: 1px; border-radius: 1px; background: var(--border-highlight); transition: background 0.1s; }
+.voice-wave .vbar.on { background: var(--volt); }
+.voice-dur { flex: none; font-size: 11px; color: var(--text-mid); font-variant-numeric: tabular-nums; }
+.voice-meta { display: flex; align-items: center; gap: 8px; margin-top: 8px; font-size: 10px; color: var(--text-dim); }
+.voice-meta .voice-via { flex: 1; }
+.voice-meta .mono { flex: none; }
+.voice-tx { margin-top: 9px; padding-top: 9px; border-top: 1px dashed var(--border-soft); display: flex; gap: 9px; }
+.voice-tx-k { flex: none; font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); padding-top: 2px; }
+.voice-tx-v { font-size: 12.5px; color: var(--text-primary); line-height: 1.55; }
+
+/* ── keeper-to-keeper broadcast ── */
+.bcast { margin: 10px 0; border: 1px solid var(--volt-dim); border-radius: var(--radius-sm); background: linear-gradient(180deg, var(--volt-wash), var(--bg-well) 80%); overflow: hidden; }
+.bcast-hd { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; padding: 8px 12px; border-bottom: 1px solid var(--border-soft); background: color-mix(in oklab, var(--volt) 6%, transparent); }
+.bcast-tag { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--volt-strong); font-weight: 600; }
+.bcast-scope { font-size: 11px; color: var(--text-bright); }
+.bcast-via { font-size: 10px; color: var(--text-dim); }
+.bcast-count { margin-left: auto; flex: none; font-size: 10px; color: var(--volt-strong); border: 1px solid var(--volt-dim); border-radius: var(--radius-pill); padding: 1px 8px; }
+.bcast-note { padding: 11px 12px; font-size: 13px; color: var(--text-primary); line-height: 1.6; }
+.bcast-note code { font-family: var(--font-mono); font-size: 12px; background: var(--bg-sunken); border: 1px solid var(--border-soft); padding: 0 4px; border-radius: var(--radius-xs); color: var(--volt-strong); }
+.bcast-rcpts { display: flex; flex-direction: column; gap: 1px; background: var(--border-soft); border-top: 1px solid var(--border-soft); }
+.bcast-rcpt { display: flex; align-items: center; gap: 9px; padding: 8px 12px; background: var(--bg-well); }
+.bcast-rcpt-id { font-family: var(--font-mono); font-size: 12px; color: var(--text-bright); flex: 1; min-width: 0; }
+.bcast-ack { flex: none; font-family: var(--font-mono); font-size: 10px; color: var(--text-dim); }
+.bcast-rcpt.acked .bcast-ack { color: var(--status-ok); }
+.bcast-rcpt.read .bcast-ack { color: var(--info); }
+.bcast-rcpt::before { content: ""; flex: none; width: 6px; height: 6px; border-radius: 50%; background: var(--text-dim); order: 3; }
+.bcast-rcpt.acked::before { background: var(--status-ok); box-shadow: 0 0 6px color-mix(in oklab, var(--status-ok) 60%, transparent); }
+.bcast-rcpt.read::before { background: var(--info); }
+
+/* compaction inspector trigger (ctx rail) */
+.cmp-open {
+  width: 100%; margin-top: 10px; display: flex; align-items: center; gap: 7px;
+  font-family: var(--font-ui); font-size: 11.5px; color: var(--text-mid);
+  padding: 8px 10px; background: var(--bg-sunken); border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm); cursor: pointer; transition: 0.14s;
+}
+.cmp-open:hover { border-color: var(--volt-dim); color: var(--volt); }
+.cmp-open-sub { margin-left: auto; font-size: 10px; color: var(--text-dim); }
+
+/* manual compaction trigger (ctx rail) — operator-run compact */
+.cmp-actions { margin-top: 10px; }
+.cmp-run {
+  width: 100%; display: flex; align-items: center; justify-content: center; gap: 7px;
+  font-family: var(--font-ui); font-size: 12px; color: var(--volt-ink);
+  background: var(--volt); border: 1px solid var(--volt); padding: 7px 10px;
+  border-radius: var(--radius-sm); cursor: pointer; transition: 0.14s;
+}
+.cmp-run:hover:not(:disabled) { background: var(--volt-strong); box-shadow: 0 0 16px var(--volt-glow); }
+.cmp-run:disabled { cursor: default; opacity: 0.92; }
+.cmp-run.busy { background: var(--bg-panel-alt); color: var(--text-mid); border-color: var(--border-main); }
+.cmp-spin { width: 11px; height: 11px; border-radius: 50%; border: 2px solid var(--border-highlight); border-top-color: var(--volt); animation: spin 0.7s linear infinite; flex: none; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* roster row command menu */
+.kp-row { position: relative; }
+/* on hover the ⋯ takes the right slot — fade the time/att stack so they
+   don't collide with the absolutely-positioned button */
+.kp-row:hover .kp-right { opacity: 0; pointer-events: none; }
+.kp-more {
+  position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+  width: 24px; height: 24px; border-radius: var(--radius-sm); border: 1px solid var(--border-main);
+  background: var(--bg-panel); color: var(--text-mid); cursor: pointer; font-size: 14px; line-height: 1;
+  opacity: 0; transition: 0.14s; z-index: 2;
+}
+.kp-row:hover .kp-more { opacity: 1; }
+.kp-more:hover { border-color: var(--volt-dim); color: var(--volt); }
+.kp-menu {
+  position: fixed; z-index: 80; min-width: 186px; padding: 5px;
+  background: var(--bg-panel); border: 1px solid var(--border-highlight);
+  border-radius: var(--radius-sm); box-shadow: 0 8px 24px rgba(0,0,0,0.55);
+  animation: turn-in 0.13s ease;
+}
+.kp-menu-h { display: flex; align-items: center; gap: 7px; padding: 7px 9px 8px; border-bottom: 1px solid var(--border-soft); margin-bottom: 4px; font-size: 12px; color: var(--text-bright); }
+.kp-menu-i { display: flex; align-items: center; gap: 9px; width: 100%; padding: 8px 9px; background: none; border: 0; border-radius: var(--radius-xs); color: var(--text-mid); font-family: var(--font-ui); font-size: 12.5px; text-align: left; cursor: pointer; transition: 0.12s; }
+.kp-menu-i:hover { background: var(--bg-card); color: var(--text-bright); }
+.kp-menu-i.danger { color: var(--status-bad); }
+.kp-menu-i.danger:hover { background: color-mix(in oklab, var(--status-bad) 14%, transparent); }
+.kp-menu-sep { height: 1px; background: var(--border-soft); margin: 4px 0; }
+.kp-menu-note { padding: 8px 10px; font-size: 11px; color: var(--text-dim); line-height: 1.4; }
+
+/* header lifecycle: quiet label when no action is legal (transient/Dead) */
+.act-quiet { font-family: var(--font-ui); font-size: 11px; color: var(--text-dim); padding: 0 6px; white-space: nowrap; }
+
+/* mobile chat-header overflow (lifecycle actions live here when chat-actions are hidden) */
+.chat-head-mob { margin-left: auto; display: flex; align-items: center; gap: 8px; position: relative; flex: none; }
+.chat-head-mob .chat-ctx-btn { margin-left: 0; }
+.chat-ovf {
+  flex: none; width: 34px; height: 34px; border-radius: var(--radius-sm);
+  display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--border-main); background: var(--bg-panel-alt);
+  color: var(--text-mid); font-size: 18px; cursor: pointer; transition: 0.14s;
+}
+.chat-ovf:hover { border-color: var(--volt-dim); color: var(--volt); }
+.chat-ovf:active { transform: translateY(1px); }
+.chat-ovf-menu {
+  position: absolute; top: 42px; right: 0; z-index: 80; min-width: 188px; padding: 5px;
+  background: var(--bg-panel); border: 1px solid var(--border-highlight);
+  border-radius: var(--radius-md); box-shadow: var(--shadow-pop);
+  display: flex; flex-direction: column;
+}
+
+/* compaction inspector body */
+.cmp-empty { font-size: 12.5px; line-height: 1.7; color: var(--text-dim); text-align: center; padding: 30px 12px; }
+.cmp-trigger { font-size: 12px; color: var(--text-mid); margin-bottom: 4px; }
+.cmp-trigger .sub-k { margin-right: 6px; }
+.cmp-headline { display: flex; align-items: center; gap: 10px; font-size: 20px; margin-bottom: 12px; }
+.cmp-arrow { color: var(--text-dim); }
+.cmp-reduce { margin-left: auto; font-family: var(--font-mono); font-size: 13px; color: var(--status-ok); border: 1px solid color-mix(in oklab, var(--status-ok) 40%, transparent); background: color-mix(in oklab, var(--status-ok) 10%, transparent); padding: 2px 9px; border-radius: var(--radius-pill); }
+.cmp-stat { display: grid; grid-template-columns: 54px 1fr; gap: 10px; align-items: start; margin-top: 12px; }
+.cmp-stat-k { font-family: var(--font-ui); font-size: 10px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-dim); padding-top: 2px; }
+.cmp-bars { display: flex; flex-direction: column; gap: 3px; }
+.cmp-line { display: flex; align-items: baseline; justify-content: space-between; }
+.cmp-line .t { font-family: var(--font-ui); font-size: 10px; color: var(--text-dim); }
+.cmp-line .v { font-family: var(--font-mono); font-weight: 500; font-size: 12px; color: var(--text-bright); }
+.cmp-line .v.ok { color: var(--status-ok); }
+.cmp-line:nth-of-type(3) { margin-top: 5px; }
+.cmp-bar { position: relative; height: 7px; background: var(--bg-sunken); border-radius: 3px; overflow: hidden; }
+.cmp-bar span { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 3px; }
+.cmp-bar.before span { background: color-mix(in oklab, var(--text-dim) 55%, transparent); }
+.cmp-bar.after span { background: var(--status-ok); }
+
+/* context absolute-token line */
+.ctx-tok { display: flex; align-items: baseline; gap: 5px; margin-top: 8px; }
+.ctx-tok .mono { font-size: 13px; color: var(--text-bright); }
+.ctx-tok-sep { color: var(--text-dim); }
+.ctx-tok-full { color: var(--text-dim) !important; }
+.ctx-tok-lbl { margin-left: auto; font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+
+/* recent tool — expandable detail */
+.ctx-item.click { cursor: pointer; }
+.ctx-item.click:hover { color: var(--text-bright); }
+.ctx-item .ci-chev { margin-left: 6px; flex: none; font-size: 8px; color: var(--text-dim); transition: transform 0.18s; }
+.ctx-item-wrap.open .ci-chev { transform: rotate(90deg); }
+.ci-detail { margin: 4px 0 8px; padding: 8px 10px; background: var(--bg-well); border: 1px solid var(--border-soft); border-radius: var(--radius-xs); }
+.ci-detail .tk { font-family: var(--font-mono); font-size: 9px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.1em; margin-top: 8px; }
+.ci-detail .tk:first-child { margin-top: 0; }
+.ci-detail pre { margin: 3px 0 0; font-family: var(--font-mono); font-size: 11px; color: var(--text-mid); line-height: 1.5; white-space: pre-wrap; word-break: break-word; }
+.cmp-diff { display: grid; grid-template-columns: 1fr; gap: 10px; }
+.cmp-col { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 9px 11px; }
+.cmp-col-h { font-family: var(--font-ui); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 7px; }
+.cmp-col.kept { border-left: 2px solid var(--status-ok); }
+.cmp-col.kept .cmp-col-h { color: var(--status-ok); }
+.cmp-col.summ { border-left: 2px solid var(--info); }
+.cmp-col.summ .cmp-col-h { color: var(--info); }
+.cmp-col.drop { border-left: 2px solid var(--text-dim); }
+.cmp-col.drop .cmp-col-h { color: var(--text-dim); }
+.cmp-li { font-size: 12px; line-height: 1.5; color: var(--text-mid); padding: 3px 0; border-top: 1px solid var(--border-soft); }
+.cmp-li:first-of-type { border-top: 0; }
+
+.chat-back, .chat-ctx-btn {
+  flex: none; width: 34px; height: 34px; border-radius: var(--radius-sm);
+  display: flex; align-items: center; justify-content: center;
+  background: var(--bg-card); border: 1px solid var(--border-main);
+  color: var(--text-mid); font-size: 16px; cursor: pointer; transition: 0.14s;
+}
+.chat-back:active, .chat-ctx-btn:active { transform: translateY(1px); }
+.chat-ctx-btn { margin-left: auto; }
+.chat-back:hover, .chat-ctx-btn:hover { border-color: var(--volt-dim); color: var(--volt); }
+
+/* context drawer (mobile) */
+.ctx-overlay { position: fixed; inset: 0; background: rgba(4,5,8,0.6); z-index: 60; display: flex; justify-content: flex-end; }
+.ctx-drawer { position: relative; width: min(330px, 88vw); height: 100%; animation: turn-in 0.18s ease; box-shadow: -8px 0 30px rgba(0,0,0,0.5); }
+.ctx-drawer .ctx { height: 100%; }
+.ctx-drawer-close {
+  position: absolute; top: 11px; right: 11px; z-index: 3; width: 28px; height: 28px;
+  border-radius: var(--radius-sm); background: var(--bg-card); border: 1px solid var(--border-main);
+  color: var(--text-mid); cursor: pointer; font-size: 12px;
+}
+
+/* scrollbars */
+.roster-list::-webkit-scrollbar, .thread::-webkit-scrollbar, .ctx-scroll::-webkit-scrollbar, .chat-meta::-webkit-scrollbar { width: 9px; height: 7px; }
+.thread::-webkit-scrollbar-thumb, .roster-list::-webkit-scrollbar-thumb, .ctx-scroll::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); border: 2px solid transparent; background-clip: padding-box; }
+.thread::-webkit-scrollbar-thumb:hover { background: var(--border-highlight); background-clip: padding-box; }
+
+/* ════ RESPONSIVE ════ */
+/* tablet-ish: drop the context rail so chat keeps breathing room (desktop ≥901) */
+@media (min-width: 901px) and (max-width: 1120px) {
+  .v2-body { --shrink-ctx: 1; }
+}
+
+/* phones + portrait tablets: single-column master-detail */
+@media (max-width: 900px) {
+  /* top bar: KEEP the attention + schedule chips (the "what needs me" signal
+     is the whole point of a phone glance) — drop only the passive run-count */
+  .v2-top { gap: 8px; padding: 0 12px; height: 46px; }
+  .v2-statchip.live { display: none; }
+  .v2-statchip { padding: 5px 9px; font-size: 10.5px; gap: 5px; }
+  .v2-top .crumb { font-size: 10px; letter-spacing: 0.06em; max-width: 36vw; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .topbar-copilot kbd { display: none; }
+  /* reading a 1:1 thread — the co-view trigger is redundant */
+  .v2-app[data-reading] .topbar-copilot { display: none; }
+
+  /* nav rail → fixed bottom tab bar (5 primary slots + 더보기) */
+  .v2-nav {
+    position: fixed; left: 0; right: 0; bottom: 0; top: auto;
+    flex-direction: row; height: 58px; gap: 0; padding: 0 2px;
+    border-right: none; border-top: 1px solid var(--border-main);
+    justify-content: space-around; z-index: 50;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+  .nav-brand, .nav-spacer, .nav-div { display: none; }
+  .nav-item { flex: 1 1 0; width: auto; height: 56px; border-radius: 0; gap: 3px; }
+  .nav-item svg { width: 21px; height: 21px; }
+  .v2-nav.is-mnav .nav-item .nlbl { display: block; font-size: 9px; letter-spacing: 0.01em; line-height: 1; color: inherit; }
+  .v2-nav.is-mnav .nav-badge { left: 50%; right: auto; margin-left: 5px; top: 5px; }
+  .nav-item:hover, .nav-item.on { background: transparent; }
+  .nav-item.on::before { left: 26%; right: 26%; top: 0; bottom: auto; width: auto; height: 3px; border-radius: 0 0 3px 3px; box-shadow: none; }
+
+  /* hide the bottom bar while reading a thread (full-screen chat) */
+  .v2-body[data-mpane="chat"] .v2-nav { display: none; }
+
+  /* co-view FAB is redundant on a phone — the top-bar Chat button already
+     opens the dock, and a floating FAB collides with the bottom tab bar */
+  .dock-fab { display: none; }
+
+  /* single column; JS already sets gridTemplateColumns:1fr, this is the guard */
+  .v2-body { grid-template-columns: 1fr !important; }
+  /* reserve room so surface content clears the fixed bottom tab bar. Every
+     surface scrolls inside .v2-body; chat hides the bar so it needs no pad. */
+  .v2-body:not([data-mpane="chat"]) { padding-bottom: calc(58px + env(safe-area-inset-bottom, 0px)); }
+
+  /* master-detail: show one pane at a time */
+  .v2-body[data-mpane="chat"] .roster { display: none; }
+  .v2-body[data-mpane="roster"] .chat-wrap { display: none; }
+
+  .roster { border-right: none; }
+  .roster-list { padding-bottom: 16px; }
+
+  .rail-toggle { display: none; }
+  .chat-wrap { min-width: 0; }
+
+  /* chat header compact + mobile controls */
+  .chat-head { padding: 9px 12px; gap: 10px; }
+  .chat-head .chat-actions { display: none; }
+  .chat-id h2 { font-size: 17px; }
+  .chat-id .name-row { gap: 8px; }
+  .chat-id .sub { gap: 8px; margin-top: 4px; }
+
+  .thread { padding-top: 16px; }
+  .thread-inner { padding: 0 14px; gap: 18px; }
+  .composer { padding: 10px 12px 14px; }
+  .composer-inner { padding: 0; }
+
+  /* mobile reading uplift — bump conversation text a touch past desktop so
+     threads stay comfortable on a phone (chrome/roster density unchanged).
+     16px composer input also stops iOS auto-zoom on focus. */
+  .bubble { font-size: 16.5px; line-height: 1.68; padding: 14px 15px; }
+  .bubble code { font-size: 13.5px; }
+  .composer textarea, .composer-input { font-size: 16px; }
+
+  /* turn inspector full-width on phones */
+  .turn-drawer { width: 100vw; }
+}
+
+@media (max-width: 420px) {
+  .chat-id .sub > span:nth-child(2) { display: none; } /* drop model on very narrow, keep room + tok/s */
+  .topbar-copilot span:not(.spark) { display: none; }
+}
+
+/* ════ MOBILE "더보기" SHEET (overflow nav) ════
+   Only rendered on mobile (NavRail mobile branch), so these need no media guard. */
+.mnav-back { position: fixed; inset: 0; background: rgba(4,5,8,0.55); z-index: 70; display: flex; align-items: flex-end; animation: mnav-fade 0.15s ease; }
+.mnav-sheet { width: 100%; background: var(--bg-panel); border-top: 1px solid var(--border-highlight); border-radius: 14px 14px 0 0; padding: 8px 14px calc(18px + env(safe-area-inset-bottom, 0px)); box-shadow: 0 -16px 44px rgba(0,0,0,0.55); animation: mnav-up 0.22s cubic-bezier(0.2,0.7,0.3,1); }
+.mnav-grip { width: 36px; height: 4px; border-radius: 2px; background: var(--border-highlight); margin: 4px auto 12px; }
+.mnav-sheet-h { font-family: var(--font-display); font-weight: 600; font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-dim); padding: 0 2px 12px; }
+.mnav-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+.mnav-tile { position: relative; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; height: 76px; border-radius: var(--radius-md); border: 1px solid var(--border-soft); background: var(--bg-card); color: var(--text-mid); cursor: pointer; transition: 0.14s; }
+.mnav-tile:active { background: var(--bg-card-hover); }
+.mnav-tile.on { border-color: var(--volt-dim); color: var(--volt-strong); background: var(--volt-wash); }
+.mnav-ic { display: flex; }
+.mnav-ic svg { width: 22px; height: 22px; }
+.mnav-lbl { font-size: 11px; font-family: var(--font-ui); }
+.mnav-tile .nav-badge { top: 7px; right: 7px; left: auto; margin: 0; }
+@keyframes mnav-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes mnav-up { from { transform: translateY(14px); opacity: 0; } to { transform: none; opacity: 1; } }
+
+/* ════ TOAST + UNDO (RFC-0007) ════ */
+.toast-host { position: fixed; left: 50%; bottom: 22px; transform: translateX(-50%); z-index: 90; display: flex; flex-direction: column; gap: 8px; align-items: center; pointer-events: none; }
+.toast { pointer-events: auto; display: flex; align-items: center; gap: 11px; min-width: 300px; max-width: 460px; padding: 11px 13px; background: var(--bg-panel); border: 1px solid var(--border-highlight); border-radius: var(--radius-md); box-shadow: var(--shadow-pop); animation: toast-in 0.2s cubic-bezier(0.2,0.7,0.3,1); }
+@keyframes toast-in { from { transform: translateY(10px); opacity: 0; } to { transform: none; opacity: 1; } }
+.toast-glyph { flex: none; width: 22px; height: 22px; display: flex; align-items: center; justify-content: center; border-radius: 50%; font-size: 11px; }
+.toast.tone-ok .toast-glyph { color: var(--status-ok); background: color-mix(in oklab, var(--status-ok) 14%, transparent); }
+.toast.tone-warn .toast-glyph { color: var(--status-warn); background: color-mix(in oklab, var(--status-warn) 14%, transparent); }
+.toast.tone-bad .toast-glyph { color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 14%, transparent); }
+.toast.tone-info .toast-glyph { color: var(--volt-strong); background: var(--volt-wash); }
+.toast.tone-bad { border-color: color-mix(in oklab, var(--status-bad) 38%, var(--border-highlight)); }
+.toast-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.toast-msg { font-size: 13px; color: var(--text-bright); line-height: 1.35; }
+.toast-sub { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
+.toast-undo { flex: none; font-family: var(--font-ui); font-size: 11.5px; color: var(--volt-strong); background: none; border: 1px solid var(--volt-dim); border-radius: var(--radius-sm); padding: 4px 11px; cursor: pointer; transition: 0.14s; }
+.toast-undo:hover { background: var(--volt-wash); color: var(--text-bright); }
+.toast-x { flex: none; width: 22px; height: 22px; border: 0; background: none; color: var(--text-dim); cursor: pointer; font-size: 10px; border-radius: var(--radius-xs); }
+.toast-x:hover { color: var(--text-bright); background: var(--bg-panel-alt); }
+
+/* ════ TOPBAR ATTENTION INDICATOR ════ */
+.attn-wrap { position: relative; }
+.v2-statchip.attn { cursor: pointer; }
+.v2-statchip.attn.warn { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 45%, transparent); background: color-mix(in oklab, var(--status-warn) 8%, transparent); }
+.v2-statchip.attn.bad { color: var(--status-bad); border-color: color-mix(in oklab, var(--status-bad) 48%, transparent); background: color-mix(in oklab, var(--status-bad) 9%, transparent); }
+.v2-statchip.attn b { color: inherit; }
+.v2-statchip.attn:hover { border-color: currentColor; }
+.attn-menu { position: absolute; top: 34px; right: 0; z-index: 80; min-width: 220px; padding: 6px; background: var(--bg-panel); border: 1px solid var(--border-highlight); border-radius: var(--radius-md); box-shadow: var(--shadow-pop); animation: cmdk-pop 0.14s ease; }
+.attn-menu-h { font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); padding: 6px 8px 8px; }
+.attn-row { display: flex; align-items: center; gap: 9px; width: 100%; padding: 8px 9px; background: none; border: 0; border-radius: var(--radius-xs); color: var(--text-mid); font-family: var(--font-ui); font-size: 12.5px; text-align: left; cursor: pointer; transition: 0.12s; }
+.attn-row:hover { background: var(--bg-card); color: var(--text-bright); }
+.attn-row-lbl { flex: 1; }
+.attn-row-n { flex: none; font-size: 12px; color: var(--text-bright); }
+
+/* ════ CHAT BACK-CONTEXT PILL ════ */
+.chat-backctx { align-self: flex-start; margin: 10px 0 -4px 24px; display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-ui); font-size: 11.5px; color: var(--text-mid); background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-pill); padding: 5px 13px; cursor: pointer; transition: 0.14s; }
+.chat-backctx:hover { border-color: var(--volt-dim); color: var(--volt-strong); }
+
+/* ════ GLOBAL FOCUS RING (a11y) ════ */
+.v2-app :focus-visible,
+.cmdk :focus-visible,
+[role="button"]:focus-visible,
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible { outline: 2px solid var(--volt); outline-offset: 2px; border-radius: var(--radius-xs); }
+.v2-app :focus:not(:focus-visible) { outline: none; }


### PR DESCRIPTION
## 목표

대시보드를 `keeper-v2` 디자인 프로토타입에 맞춰 전면 리스킨한다. 프로토타입 CSS를 SSOT로 vendoring하고, 셸과 각 surface DOM을 프로토타입 클래스(`.v2-*` / `.ov-*` / `.fl-*` / `.rt-*` / `.fus-*` / `.sch-*` / `.ctx-*` / `.kp-*`)로 재구성한다.

## 접근

- **기반**: 프로토타입 14개 CSS를 `styles/keeper-v2/`로 vendoring(마지막 로드 = drift된 레거시 `*-v2.css`보다 우선). 폰트는 Google Fonts(9.9MB ttf 제외). 셸을 `.v2-app → .v2-top → .v2-stage → .v2-body → .v2-nav` 프로토타입 DOM으로 재구축(라이프사이클 effect 전부 보존) + 모바일 하단 탭바.
- **Surface 정렬**: 구조가 가까운 곳은 외과적 class-retarget(keepers roster/rail/chat, overview, approvals/board/connectors/logs/settings/workspace), 멀어진 곳은 재구축(schedule panel, IDE, fusion, monitoring Fleet, runtime editor).
- **라이브 데이터 갭**: 가짜 채우지 않고 `data-stub`로 마킹.

## 이 PR에 포함된 핵심 수정

- **중복 "Keeper Fleet" 헤더 해소**: `status.ts`/`operations-panel.ts`/`lab.ts`는 자체 `SurfaceHeader`를 렌더하는데 `monitoring`/`command`/`lab`이 `SURFACE_OWN_LEAD_IDS`에서 누락 → 셸이 `SurfaceLead`를 그 위에 중첩. 목록을 현실에 맞게 교정. (근본 해소 = 셸 `SurfaceLead`/allow-list 전면 제거 + board에 자체 헤더 부여. `dashboard-shell.ts` 주석에 follow-up으로 기록.)
- **CatalogCompatShim 제거**: 재설계로 사라진 catalog UI를 단언하는 stale 테스트를 위해 상시 마운트된 `class="hidden"` DOM 워크어라운드를 제거하고, 테스트를 실제 렌더 DOM(read-only model chip + binding `num-ctx` 편집)에 재조준.
- **tsc 빌드 정상화**: 리스킨이 남긴 타입 에러 해소(overview dead UI ~370줄 삭제 + fusion/ide/rail 가드).

## 로컬 검증

- `tsc --noEmit`: 0 에러.
- `eslint src`: clean.
- 브라우저(`localhost:5174`, 라이브 8935 백엔드): overview/keepers/approvals/board/connectors/logs/settings/workspace/schedule/IDE/fusion/**monitoring**/**runtime**/lab 단일 헤더 + 프로토타입 DOM 렌더 확인. monitoring/runtime/lab/board 헤더 중복 없음 재확인.
- 테스트: 직접 변경한 surface 테스트 green(agent-roster 34/34, runtime-toml-editor 17/17, overview 90/90, dashboard-shell/surface-header/navigation 127/127).

## 미검증 / 진행 중

- 리스킨이 DOM을 바꾸며 stale가 된 keeper-workspace(roster/rail/chat) + fusion 테스트를 프로토타입 DOM에 맞게 갱신 중(make-pass 방지 제약 + diff 적대 검증). 완료 후 커밋·green 확인하고 Ready 전환.
- 모바일 하단 탭바는 브라우저 resize 한계로 데스크톱 미회귀만 확인(프로토타입 1:1 이식).

WORKAROUND-WAIVED: `SURFACE_OWN_LEAD_IDS`에 3개 항목 추가는 symptom 억제가 아니라 "자체 헤더를 렌더하는 surface" 목록을 실제와 일치시키는 데이터 교정이다. 근본 리팩터(allow-list 제거)는 코드 주석에 follow-up으로 명시했다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
