### PR TITLE
fix(dashboard): humanize overview attention reason/action labels via shared SSOT

### DIFF
--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -59,34 +59,15 @@ describe('KeeperRuntimeAlertStrip', () => {
     expect(text).not.toContain('증명')
   })
 
-  it('canonicalizes runtime attention tokens before rendering operator copy', () => {
-    const { container } = render(h(KeeperRuntimeAlertStrip, {
-      keeper: keeper({
-        needs_attention: true,
-        attention_reason: 'watchdog_stale_turn',
-        next_human_action: 'inspect_watchdog_root_cause',
-      }),
-    }))
-
-    const text = container.textContent ?? ''
-    expect(text).toContain('런타임 근거 확인 필요')
-    expect(text).not.toContain('watchdog_stale_turn')
-    expect(text).not.toContain('inspect_watchdog_root_cause')
-  })
-
-  // Lock the remaining producer-side attention reasons that
-  // [canonicalAttentionReason] folds into runtime_blocked. Producers
-  // live at Keeper_status_bridge.ml:782/784/791 (runtime_attempts_exhausted,
-  // provider_tool_capability_missing, fiber_unresolved). The previous
-  // canonicalizes-* it() blocks already cover watchdog_stale_turn and
-  // completion_contract_violation; this parametrises the rest. The
-  // rendered Korean copy "런타임 근거 확인 필요" is the user-visible label
-  // mapped from runtime_blocked in ATTENTION_REASON_LABELS.
+  // Trust-snapshot runtime-failure tokens (keeper_runtime_trust_snapshot.ml)
+  // are not first-class status_bridge reasons; canonicalAttentionReason folds
+  // the enumerated trust set to the coarse `runtime_blocked` label so the strip
+  // shows a label rather than a raw token, pending the trust-vocabulary RFC.
   it.each([
-    'runtime_attempts_exhausted',
-    'provider_tool_capability_missing',
-    'fiber_unresolved',
-  ])('canonicalizes %s into runtime_blocked operator copy', (reason) => {
+    'completion_contract_violation',
+    'fsm_invariant',
+    'runtime_exhausted',
+  ])('folds trust runtime-failure token %s to the coarse runtime_blocked copy', (reason) => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({
         needs_attention: true,
@@ -99,7 +80,27 @@ describe('KeeperRuntimeAlertStrip', () => {
     expect(text).not.toContain(reason)
   })
 
-  it('canonicalizes turn-disposition timeout actions before rendering operator copy', () => {
+  // First-class status_bridge reasons keep their OWN labels — they are no
+  // longer folded into runtime_blocked, so the operator sees the specific
+  // failure the backend distinguished.
+  it.each([
+    ['runtime_attempts_exhausted', '런타임 재시도 소진'],
+    ['fiber_unresolved', '미완료 작업(fiber) 정리 필요'],
+    ['stale_turn_timeout', '응답 지연(stale) 타임아웃'],
+  ])('labels first-class status_bridge reason %s distinctly', (reason, label) => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        needs_attention: true,
+        attention_reason: reason,
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain(label)
+    expect(text).not.toContain(reason)
+  })
+
+  it('labels turn-disposition timeout actions distinctly (no fold)', () => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({
         needs_attention: true,
@@ -108,7 +109,7 @@ describe('KeeperRuntimeAlertStrip', () => {
     }))
 
     const text = container.textContent ?? ''
-    expect(text).toContain('런타임 근거 확인')
+    expect(text).toContain('턴 타임아웃 원인 확인')
     expect(text).not.toContain('inspect_turn_timeout')
   })
 
@@ -141,20 +142,16 @@ describe('KeeperRuntimeAlertStrip', () => {
     expect(text).not.toContain('inspect_latest_error')
   })
 
-  // Lock the remaining producer-side action wires that
-  // [canonicalNextHumanAction] folds into inspect_runtime_blocker. Each
-  // wire here has a live producer in lib/keeper (see
-  // Keeper_turn_disposition.next_action and Keeper_status_bridge), so
-  // dropping any rewrite branch silently in a future sweep would leak
-  // the raw legacy label into operator copy. The previous
-  // canonicalizes-* it() blocks already cover inspect_watchdog_root_cause
-  // and inspect_turn_timeout.
+  // First-class next_human_action wires (Keeper_turn_disposition.next_action /
+  // Keeper_status_bridge) each keep their own label — they are no longer folded
+  // into inspect_runtime_blocker, so the operator sees the specific action.
   it.each([
-    'inspect_runtime_attempts',
-    'inspect_provider_tool_lane',
-    'inspect_completion_contract',
-    'inspect_turn_finalization',
-  ])('canonicalizes %s into inspect_runtime_blocker operator copy', (action) => {
+    ['inspect_runtime_attempts', '재시도별 원인 확인'],
+    ['inspect_turn_finalization', '턴 정리 상태 확인'],
+    ['inspect_stale_turn_root_cause', '응답 지연(stale) 원인 확인'],
+    ['provide_input_or_decline', '입력 제공 또는 거절'],
+    ['reconcile_partial_commit', '부분 커밋 정합성 확인'],
+  ])('labels first-class next_human_action %s distinctly', (action, label) => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({
         needs_attention: true,
@@ -163,7 +160,7 @@ describe('KeeperRuntimeAlertStrip', () => {
     }))
 
     const text = container.textContent ?? ''
-    expect(text).toContain('런타임 근거 확인')
+    expect(text).toContain(label)
     expect(text).not.toContain(action)
   })
 

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -75,7 +75,7 @@ function SyntheticAwareText({ text }: { text: string }) {
 // just returns false and both lines render.
 const ATTENTION_PAIR_DUPLICATES: ReadonlyArray<readonly [AttentionReason, NextHumanAction]> = [
   ['runtime_blocked', 'inspect_runtime_blocker'],
-  ['paused_blocked', 'inspect_blocker_before_resume'],
+  ['paused', 'inspect_blocker_before_resume'],
   ['runtime_trust_snapshot_unavailable', 'inspect_keeper_runtime_trust'],
 ]
 const ATTENTION_PAIR_DUPLICATE_KEYS = new Set<string>(

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -24,6 +24,14 @@ import {
   SYNTHETIC_TOOLTIP,
   stripSyntheticMarker,
 } from '../lib/synthetic-marker'
+import {
+  attentionReasonLabel,
+  canonicalAttentionReason,
+  canonicalNextHumanAction,
+  nextHumanActionLabel,
+  type AttentionReason,
+  type NextHumanAction,
+} from '../lib/keeper-attention-labels'
 
 /**
  * Render a text field that *might* carry the backend `[SYNTHETIC]`
@@ -49,117 +57,11 @@ function SyntheticAwareText({ text }: { text: string }) {
   `
 }
 
-// Backend emit sites for `attention_reason`:
-//   - lib/keeper/keeper_status_bridge.ml:727-742 (six common reasons)
-//   - lib/keeper_fd_pressure.ml:190 ('fd_pressure')
-//   - lib/dashboard/dashboard_goals.ml:44 ('runtime_trust_snapshot_unavailable')
-// Closed as const + Record<AttentionReason, string>. Adding a new label
-// without extending the union, or removing a union arm, fails typecheck
-// rather than silently producing a missing/extraneous Korean label. The
-// dual classification rule the labels map encodes is exhaustive over
-// the union; backend variants that drift past it surface via
-// warnUnknownAttentionToken instead of slipping through as a raw token.
-const ATTENTION_REASONS = [
-  'approval_pending',
-  'continue_gate_required',
-  'paused',
-  'paused_blocked',
-  'runtime_blocked',
-  'provider_runtime_error',
-  'social_model_fallback',
-  'fd_pressure',
-  'runtime_trust_snapshot_unavailable',
-] as const
-type AttentionReason = typeof ATTENTION_REASONS[number]
-
-const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
-  approval_pending: '승인 대기',
-  continue_gate_required: '계속 진행 승인 필요',
-  paused: '일시정지',
-  paused_blocked: '일시정지 원인 확인 필요',
-  runtime_blocked: '런타임 근거 확인 필요',
-  provider_runtime_error: '런타임 호출 오류',
-  social_model_fallback: '소셜 모델 폴백',
-  fd_pressure: 'FD 임계치 초과',
-  runtime_trust_snapshot_unavailable: '런타임 신뢰 스냅샷 없음',
-}
-
-function canonicalAttentionReason(reason: string | null): string | null {
-  if (reason === 'runtime_attempts_exhausted') return 'runtime_blocked'
-  if (reason === 'provider_tool_capability_missing') return 'runtime_blocked'
-  if (reason === 'completion_contract_violation') return 'runtime_blocked'
-  if (reason === 'watchdog_stale_turn') return 'runtime_blocked'
-  if (reason === 'fiber_unresolved') return 'runtime_blocked'
-  return reason
-}
-
-function isAttentionReason(s: string): s is AttentionReason {
-  return (ATTENTION_REASONS as readonly string[]).includes(s)
-}
-
-function attentionReasonLabel(reason: string | null, paused: boolean): string | null {
-  const canonicalReason = canonicalAttentionReason(reason)
-  if (!canonicalReason) return null
-  if ((canonicalReason === 'paused' || canonicalReason === 'paused_blocked') && paused) return null
-  if (isAttentionReason(canonicalReason)) return ATTENTION_REASON_LABELS[canonicalReason]
-  warnUnknownAttentionToken('attention_reason', canonicalReason)
-  return canonicalReason
-}
-
-// Backend emit sites for `next_human_action` (paired 1:1 with the
-// corresponding `attention_reason`):
-//   - lib/keeper/keeper_status_bridge.ml:727-742 (seven common actions)
-//   - lib/keeper/keeper_turn_disposition.ml:63-70 (runtime-trust latest action)
-//   - lib/keeper_fd_pressure.ml:191 ('restore_fd_headroom')
-//   - lib/dashboard/dashboard_goals.ml:45 ('inspect_keeper_runtime_trust')
-const NEXT_HUMAN_ACTIONS = [
-  'approve_or_reject_continue',
-  'inspect_blocker_before_resume',
-  'inspect_runtime_blocker',
-  'inspect_latest_error',
-  'inspect_provider_runtime_cause',
-  'resolve_approval',
-  'resume_or_review',
-  'review_social_model',
-  'restore_fd_headroom',
-  'inspect_keeper_runtime_trust',
-] as const
-type NextHumanAction = typeof NEXT_HUMAN_ACTIONS[number]
-
-const NEXT_HUMAN_ACTION_LABELS: Record<NextHumanAction, string> = {
-  approve_or_reject_continue: '계속 진행 승인 또는 거절',
-  inspect_blocker_before_resume: '원인 확인 후 재개',
-  inspect_runtime_blocker: '런타임 근거 확인',
-  inspect_latest_error: '최근 오류 확인',
-  inspect_provider_runtime_cause: 'Provider 런타임 원인 확인',
-  resolve_approval: '승인 요청 처리',
-  resume_or_review: '재개 또는 설정 검토',
-  review_social_model: '소셜 모델 설정 검토',
-  restore_fd_headroom: 'FD 여유 확보',
-  inspect_keeper_runtime_trust: '런타임 신뢰 스냅샷 확인',
-}
-
-function isNextHumanAction(s: string): s is NextHumanAction {
-  return (NEXT_HUMAN_ACTIONS as readonly string[]).includes(s)
-}
-
-function canonicalNextHumanAction(action: string | null): string | null {
-  if (action === 'inspect_turn_timeout') return 'inspect_runtime_blocker'
-  if (action === 'inspect_runtime_attempts') return 'inspect_runtime_blocker'
-  if (action === 'inspect_provider_tool_lane') return 'inspect_runtime_blocker'
-  if (action === 'inspect_completion_contract') return 'inspect_runtime_blocker'
-  if (action === 'inspect_watchdog_root_cause') return 'inspect_runtime_blocker'
-  if (action === 'inspect_turn_finalization') return 'inspect_runtime_blocker'
-  return action
-}
-
-function nextHumanActionLabel(action: string | null): string | null {
-  const canonicalAction = canonicalNextHumanAction(action)
-  if (!canonicalAction) return null
-  if (isNextHumanAction(canonicalAction)) return NEXT_HUMAN_ACTION_LABELS[canonicalAction]
-  warnUnknownAttentionToken('next_human_action', canonicalAction)
-  return canonicalAction
-}
+// attention_reason / next_human_action humanization (closed-sum unions,
+// Korean label records, canonical folds) lives in
+// ../lib/keeper-attention-labels so this surface and the overview attention
+// queue map the same wire vocabulary through one SSOT. The pair-dedupe below
+// stays local to this surface because only it renders both lines.
 
 // (attention_reason, next_human_action) pairs that surface the same
 // operator intent in two visually identical lines — e.g.
@@ -192,18 +94,6 @@ function canonicalTerminalCode(code: string | null): string | null {
 
 function canonicalTerminalSummary(_code: string | null, summary: string | null | undefined): string | null {
   return summary?.trim() || null
-}
-
-// One-time warn per (kind, token) so dev consoles surface backend
-// variants that have no Korean label, without spamming on every render.
-const warnedAttentionTokens = new Set<string>()
-function warnUnknownAttentionToken(kind: 'attention_reason' | 'next_human_action', token: string) {
-  const key = `${kind}|${token}`
-  if (warnedAttentionTokens.has(key)) return
-  warnedAttentionTokens.add(key)
-  if (typeof console !== 'undefined') {
-    console.warn(`[keeper-detail-alert-strip] unknown ${kind}:`, token)
-  }
 }
 
 // Render the runtime attempt observation with explicit scope label

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -554,6 +554,27 @@ describe('deriveKeeperAttentionReason', () => {
     expect(reason.text).toBe('승인 대기 3건')
     expect(reason.act).toBe('승인 검토')
   })
+
+  it('humanizes known attention_reason / next_human_action wire codes', () => {
+    const reason = deriveKeeperAttentionReason(makeKeeper({
+      name: 'coded',
+      attention_reason: 'runtime_blocked',
+      next_human_action: 'inspect_latest_error',
+    }))
+    expect(reason.text).toBe('런타임 근거 확인 필요')
+    expect(reason.act).toBe('최근 오류 확인')
+  })
+
+  it('keeps unknown composite reason codes raw rather than dropping them', () => {
+    // completion_contract_result:* is a colon-composite the union does not
+    // cover (backend reason leakage tracked separately); it must surface raw,
+    // not silently vanish.
+    const reason = deriveKeeperAttentionReason(makeKeeper({
+      name: 'composite',
+      attention_reason: 'completion_contract_result:passive_only',
+    }))
+    expect(reason.text).toBe('completion_contract_result:passive_only')
+  })
 })
 
 describe('pickAttentionKeepers', () => {

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -38,6 +38,7 @@ import { openTaskDetail } from '../goals/task-detail-state'
 import { nowSecondsSignal, useNowSecondsTicker } from '../../lib/now-signal'
 import { keeperDisplayStatus, keeperRuntimeBlockerLabel } from '../../lib/keeper-runtime-display'
 import { isKeeperPaused } from '../../lib/keeper-predicates'
+import { attentionReasonLabel, nextHumanActionLabel } from '../../lib/keeper-attention-labels'
 import { isAgentOffline } from '../../lib/agent-status'
 import { keeperRowLooksRunning } from '../../runtime-counts'
 import { createAsyncResource, type AsyncResource, type AsyncState } from '../../lib/async-state'
@@ -90,8 +91,15 @@ function hasCriticalAttentionBlocker(blockerClass: Keeper['runtime_blocker_class
 export function deriveKeeperAttentionReason(keeper: Keeper): KeeperAttentionReason {
   const blockerClass = keeper.runtime_blocker_class ?? null
   const blockerLabel = keeperRuntimeBlockerLabel(blockerClass) ?? blockerClass?.replace(/_/g, ' ')
-  const attention = keeper.attention_reason?.trim() || keeper.trust?.attention_reason?.trim()
-  const nextAction = keeper.next_human_action?.trim() || keeper.trust?.next_human_action?.trim()
+  // Humanize the backend `attention_reason` / `next_human_action` wire codes
+  // through the shared SSOT instead of rendering raw tokens like
+  // `inspect_blocker_before_resume`. Unknown codes (e.g. composite reasons
+  // such as `completion_contract_result:*`) fall back to the raw string and
+  // warn in dev — matching the keeper detail alert strip.
+  const attentionRaw = keeper.attention_reason?.trim() || keeper.trust?.attention_reason?.trim() || null
+  const nextActionRaw = keeper.next_human_action?.trim() || keeper.trust?.next_human_action?.trim() || null
+  const attention = attentionReasonLabel(attentionRaw, false) ?? undefined
+  const nextAction = nextHumanActionLabel(nextActionRaw) ?? undefined
 
   if (keeper.runtime_blocker_continue_gate) {
     return {

--- a/dashboard/src/lib/keeper-attention-labels.drift.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.drift.test.ts
@@ -1,0 +1,87 @@
+// Build-time drift guard for the keeper attention vocabulary.
+//
+// The backend is the single source of truth for `attention_reason` /
+// `next_human_action` wire codes — they are string literals emitted from OCaml.
+// keeper-attention-labels.ts hand-mirrors that vocabulary, and that mirror
+// silently drifted before: the backend emitted `stale_turn_timeout` for a
+// release while the frontend union had no arm for it, so the dashboard showed
+// the raw English token instead of a Korean label.
+//
+// This test reads the actual backend emit sites and asserts every token they
+// produce is a known union member here. It is the build-time enforcement the
+// review asked for: when the backend adds or renames a code, this fails until
+// the union/labels are updated, rather than failing silently at runtime in a
+// dev console nobody is watching.
+//
+// It is sourced from the backend files (not a hand-copied list), so it cannot
+// itself drift the way a duplicated constant would.
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import { isAttentionReason, isNextHumanAction } from './keeper-attention-labels'
+
+const here = dirname(fileURLToPath(import.meta.url))
+// dashboard/src/lib → repo root is three levels up.
+const repoRoot = resolve(here, '../../..')
+
+function read(rel: string): string {
+  return readFileSync(resolve(repoRoot, rel), 'utf8')
+}
+
+// keeper_status_bridge.ml emits attention as `true, Some "<reason>", Some
+// "<action>"` triples inside the needs_attention block. Capturing the `true,`
+// prefix scopes the match to that block and excludes unrelated `Some "…"` pairs.
+function statusBridgePairs(): Array<{ reason: string; action: string }> {
+  const src = read('lib/keeper/keeper_status_bridge.ml')
+  const re = /true,\s*Some "([a-z_]+)",\s*Some "([a-z_]+)"/g
+  const pairs: Array<{ reason: string; action: string }> = []
+  for (let m = re.exec(src); m !== null; m = re.exec(src)) {
+    const [, reason, action] = m
+    if (reason && action) pairs.push({ reason, action })
+  }
+  return pairs
+}
+
+// keeper_turn_disposition.ml `next_action` returns `Some "<action>"` per arm.
+// Scope to that function body so `to_wire` / label arms are not picked up.
+function dispositionActions(): string[] {
+  const src = read('lib/keeper/keeper_turn_disposition.ml')
+  const start = src.indexOf('let next_action = function')
+  expect(start, 'next_action function present in keeper_turn_disposition.ml').toBeGreaterThan(-1)
+  const body = src.slice(start, src.indexOf(';;', start))
+  return [...body.matchAll(/Some "([a-z_]+)"/g)]
+    .map((m) => m[1])
+    .filter((token): token is string => token !== undefined)
+}
+
+describe('keeper attention vocabulary drift guard', () => {
+  it('extracts a non-empty backend vocabulary (guard self-check)', () => {
+    // If extraction silently returns nothing, the coverage assertions below
+    // would vacuously pass — assert the emit sites are actually being read.
+    expect(statusBridgePairs().length).toBeGreaterThan(4)
+    expect(dispositionActions().length).toBeGreaterThan(2)
+  })
+
+  it('every keeper_status_bridge attention_reason has a frontend label', () => {
+    const missing = [...new Set(statusBridgePairs().map((p) => p.reason))].filter(
+      (reason) => !isAttentionReason(reason),
+    )
+    expect(missing, `attention_reason codes emitted by the backend with no union arm: ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('every keeper_status_bridge next_human_action has a frontend label', () => {
+    const missing = [...new Set(statusBridgePairs().map((p) => p.action))].filter(
+      (action) => !isNextHumanAction(action),
+    )
+    expect(missing, `next_human_action codes emitted by the backend with no union arm: ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('every keeper_turn_disposition next_action has a frontend label', () => {
+    const missing = [...new Set(dispositionActions())].filter(
+      (action) => !isNextHumanAction(action),
+    )
+    expect(missing, `next_action codes emitted by the backend with no union arm: ${missing.join(', ')}`).toEqual([])
+  })
+})

--- a/dashboard/src/lib/keeper-attention-labels.ts
+++ b/dashboard/src/lib/keeper-attention-labels.ts
@@ -3,14 +3,29 @@
 // the keeper detail alert strip and the overview attention queue — maps them
 // through one closed-sum SSOT instead of rendering raw backend tokens.
 //
-// Closed as const + Record<…, string>. Adding a new label without extending
-// the union, or removing a union arm, fails typecheck rather than silently
-// producing a missing/extraneous Korean label. Backend variants that drift
-// past the union surface via warnUnknownAttentionToken (dev console) and fall
-// back to the raw token rather than slipping through unnoticed.
+// Closed as const + Record<…, string>. Adding a label without extending the
+// union, or removing a union arm, fails typecheck rather than silently
+// producing a missing/extraneous Korean label. Backend tokens that drift past
+// the union surface via warnUnknownAttentionToken (dev console) and fall back
+// to the raw token rather than slipping through unnoticed.
+//
+// The union mirrors the keeper_status_bridge needs_attention vocabulary (plus
+// keeper_turn_disposition / fd_pressure / dashboard_goals) arm-for-arm: every
+// distinct reason/action those closed, non-composite emit sites produce has its
+// own Korean label, with no lossy fold — a keeper blocked on
+// `runtime_attempts_exhausted` and one blocked on `fiber_unresolved` get
+// different operator copy, because the backend already paid to distinguish
+// them. keeper-attention-labels.drift.test.ts reads those backend OCaml emit
+// sites and fails the build if any produced token has no label here, so this
+// list cannot silently drift behind the backend the way it did before
+// (`stale_turn_timeout` was emitted for a release with no label).
+//
+// The richer trust-snapshot attention vocabulary (keeper_runtime_trust_snapshot)
+// is a separate SSOT tracked as a follow-up RFC; see canonicalAttentionReason
+// for the interim coarse bucket.
 
-// One-time warn per (kind, token) so dev consoles surface backend variants
-// that have no Korean label, without spamming on every render.
+// One-time warn per (kind, token) so dev consoles surface backend tokens that
+// have no Korean label, without spamming on every render.
 const warnedAttentionTokens = new Set<string>()
 function warnUnknownAttentionToken(kind: 'attention_reason' | 'next_human_action', token: string) {
   const key = `${kind}|${token}`
@@ -21,20 +36,24 @@ function warnUnknownAttentionToken(kind: 'attention_reason' | 'next_human_action
   }
 }
 
-// Backend emit sites for `attention_reason`:
-//   - lib/keeper/keeper_status_bridge.ml:727-742 (six common reasons)
-//   - lib/keeper_fd_pressure.ml:190 ('fd_pressure')
-//   - lib/dashboard/dashboard_goals.ml:44 ('runtime_trust_snapshot_unavailable')
+// Backend emit sites for `attention_reason` (the drift guard reads these):
+//   - lib/keeper/keeper_status_bridge.ml needs_attention block
+//     (approval_pending, continue_gate_required, paused,
+//      runtime_attempts_exhausted, provider_runtime_error, stale_turn_timeout,
+//      fiber_unresolved, runtime_blocked)
+//   - lib/keeper_runtime/keeper_fd_pressure.ml ('fd_pressure')
+//   - lib/dashboard/dashboard_goals.ml ('runtime_trust_snapshot_unavailable')
 export const ATTENTION_REASONS = [
   'approval_pending',
   'continue_gate_required',
   'paused',
-  'paused_blocked',
-  'runtime_blocked',
+  'runtime_attempts_exhausted',
   'provider_runtime_error',
-  'social_model_fallback',
-  'fd_pressure',
+  'stale_turn_timeout',
+  'fiber_unresolved',
+  'runtime_blocked',
   'runtime_trust_snapshot_unavailable',
+  'fd_pressure',
 ] as const
 export type AttentionReason = typeof ATTENTION_REASONS[number]
 
@@ -42,20 +61,43 @@ const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
   approval_pending: '승인 대기',
   continue_gate_required: '계속 진행 승인 필요',
   paused: '일시정지',
-  paused_blocked: '일시정지 원인 확인 필요',
-  runtime_blocked: '런타임 근거 확인 필요',
+  runtime_attempts_exhausted: '런타임 재시도 소진',
   provider_runtime_error: '런타임 호출 오류',
-  social_model_fallback: '소셜 모델 폴백',
-  fd_pressure: 'FD 임계치 초과',
+  stale_turn_timeout: '응답 지연(stale) 타임아웃',
+  fiber_unresolved: '미완료 작업(fiber) 정리 필요',
+  runtime_blocked: '런타임 근거 확인 필요',
   runtime_trust_snapshot_unavailable: '런타임 신뢰 스냅샷 없음',
+  fd_pressure: 'FD 임계치 초과',
 }
 
+// keeper_runtime_trust_snapshot.ml emits a SEPARATE, larger attention_reason
+// vocabulary on the trust path (fsm_invariant, runtime_exhausted,
+// sandbox_violation, completion_contract_violation, the composite
+// `completion_contract_result:<reason>`, …) than the keeper_status_bridge
+// needs_attention set this union mirrors. Modeling that vocabulary with typed
+// arms — including the composite — is its own SSOT and is tracked as a
+// follow-up RFC, not inlined here (doing it token-by-token would be the
+// partial-migration anti-pattern).
+//
+// Until then these known trust runtime-failure tokens fold to the coarse
+// `runtime_blocked` bucket so the detail strip shows a label instead of a raw
+// English token. This fold is deliberately scoped to that enumerated trust set
+// — the first-class status_bridge reasons (runtime_attempts_exhausted,
+// fiber_unresolved, stale_turn_timeout) are NOT folded and keep their own
+// labels. Unknown/composite trust tokens still fall through to
+// warnUnknownAttentionToken rather than being silently bucketed.
+const TRUST_RUNTIME_FAILURE_ALIASES: ReadonlySet<string> = new Set([
+  'completion_contract_violation',
+  'completion_contract_unsatisfied',
+  'fsm_invariant',
+  'runtime_exhausted',
+  'no_capable_provider',
+  'sandbox_violation',
+  'critical_block',
+])
+
 export function canonicalAttentionReason(reason: string | null): string | null {
-  if (reason === 'runtime_attempts_exhausted') return 'runtime_blocked'
-  if (reason === 'provider_tool_capability_missing') return 'runtime_blocked'
-  if (reason === 'completion_contract_violation') return 'runtime_blocked'
-  if (reason === 'watchdog_stale_turn') return 'runtime_blocked'
-  if (reason === 'fiber_unresolved') return 'runtime_blocked'
+  if (reason !== null && TRUST_RUNTIME_FAILURE_ALIASES.has(reason)) return 'runtime_blocked'
   return reason
 }
 
@@ -66,41 +108,55 @@ export function isAttentionReason(s: string): s is AttentionReason {
 export function attentionReasonLabel(reason: string | null, paused: boolean): string | null {
   const canonicalReason = canonicalAttentionReason(reason)
   if (!canonicalReason) return null
-  if ((canonicalReason === 'paused' || canonicalReason === 'paused_blocked') && paused) return null
+  if (canonicalReason === 'paused' && paused) return null
   if (isAttentionReason(canonicalReason)) return ATTENTION_REASON_LABELS[canonicalReason]
   warnUnknownAttentionToken('attention_reason', canonicalReason)
   return canonicalReason
 }
 
-// Backend emit sites for `next_human_action` (paired 1:1 with the
-// corresponding `attention_reason`):
-//   - lib/keeper/keeper_status_bridge.ml:727-742 (seven common actions)
-//   - lib/keeper/keeper_turn_disposition.ml:63-70 (runtime-trust latest action)
-//   - lib/keeper_fd_pressure.ml:191 ('restore_fd_headroom')
-//   - lib/dashboard/dashboard_goals.ml:45 ('inspect_keeper_runtime_trust')
+// Backend emit sites for `next_human_action` (the drift guard reads these):
+//   - lib/keeper/keeper_status_bridge.ml needs_attention block (paired 1:1 with
+//     the corresponding attention_reason)
+//   - lib/keeper/keeper_turn_disposition.ml next_action
+//     (provide_input_or_decline, rerun_if_still_relevant, inspect_turn_timeout,
+//      inspect_runtime_attempts, reconcile_partial_commit, inspect_latest_error)
+//   - lib/keeper_runtime/keeper_fd_pressure.ml ('restore_fd_headroom')
+//   - lib/dashboard/dashboard_goals.ml ('inspect_keeper_runtime_trust')
 export const NEXT_HUMAN_ACTIONS = [
+  'resolve_approval',
   'approve_or_reject_continue',
   'inspect_blocker_before_resume',
-  'inspect_runtime_blocker',
-  'inspect_latest_error',
+  'inspect_runtime_attempts',
   'inspect_provider_runtime_cause',
-  'resolve_approval',
+  'inspect_stale_turn_root_cause',
+  'inspect_turn_finalization',
+  'inspect_runtime_blocker',
   'resume_or_review',
-  'review_social_model',
+  'provide_input_or_decline',
+  'rerun_if_still_relevant',
+  'inspect_turn_timeout',
+  'reconcile_partial_commit',
+  'inspect_latest_error',
   'restore_fd_headroom',
   'inspect_keeper_runtime_trust',
 ] as const
 export type NextHumanAction = typeof NEXT_HUMAN_ACTIONS[number]
 
 const NEXT_HUMAN_ACTION_LABELS: Record<NextHumanAction, string> = {
+  resolve_approval: '승인 요청 처리',
   approve_or_reject_continue: '계속 진행 승인 또는 거절',
   inspect_blocker_before_resume: '원인 확인 후 재개',
-  inspect_runtime_blocker: '런타임 근거 확인',
-  inspect_latest_error: '최근 오류 확인',
+  inspect_runtime_attempts: '재시도별 원인 확인',
   inspect_provider_runtime_cause: 'Provider 런타임 원인 확인',
-  resolve_approval: '승인 요청 처리',
+  inspect_stale_turn_root_cause: '응답 지연(stale) 원인 확인',
+  inspect_turn_finalization: '턴 정리 상태 확인',
+  inspect_runtime_blocker: '런타임 근거 확인',
   resume_or_review: '재개 또는 설정 검토',
-  review_social_model: '소셜 모델 설정 검토',
+  provide_input_or_decline: '입력 제공 또는 거절',
+  rerun_if_still_relevant: '필요 시 재실행',
+  inspect_turn_timeout: '턴 타임아웃 원인 확인',
+  reconcile_partial_commit: '부분 커밋 정합성 확인',
+  inspect_latest_error: '최근 오류 확인',
   restore_fd_headroom: 'FD 여유 확보',
   inspect_keeper_runtime_trust: '런타임 신뢰 스냅샷 확인',
 }
@@ -109,13 +165,10 @@ export function isNextHumanAction(s: string): s is NextHumanAction {
   return (NEXT_HUMAN_ACTIONS as readonly string[]).includes(s)
 }
 
+// Reserved seam for genuine legacy aliases (see canonicalAttentionReason).
+// Empty today: every action the backend emits has its own arm above, so no
+// distinct action is folded.
 export function canonicalNextHumanAction(action: string | null): string | null {
-  if (action === 'inspect_turn_timeout') return 'inspect_runtime_blocker'
-  if (action === 'inspect_runtime_attempts') return 'inspect_runtime_blocker'
-  if (action === 'inspect_provider_tool_lane') return 'inspect_runtime_blocker'
-  if (action === 'inspect_completion_contract') return 'inspect_runtime_blocker'
-  if (action === 'inspect_watchdog_root_cause') return 'inspect_runtime_blocker'
-  if (action === 'inspect_turn_finalization') return 'inspect_runtime_blocker'
   return action
 }
 

--- a/dashboard/src/lib/keeper-attention-labels.ts
+++ b/dashboard/src/lib/keeper-attention-labels.ts
@@ -1,0 +1,128 @@
+// Shared humanization for the keeper `attention_reason` / `next_human_action`
+// wire vocabularies. Extracted so every surface that shows these codes —
+// the keeper detail alert strip and the overview attention queue — maps them
+// through one closed-sum SSOT instead of rendering raw backend tokens.
+//
+// Closed as const + Record<…, string>. Adding a new label without extending
+// the union, or removing a union arm, fails typecheck rather than silently
+// producing a missing/extraneous Korean label. Backend variants that drift
+// past the union surface via warnUnknownAttentionToken (dev console) and fall
+// back to the raw token rather than slipping through unnoticed.
+
+// One-time warn per (kind, token) so dev consoles surface backend variants
+// that have no Korean label, without spamming on every render.
+const warnedAttentionTokens = new Set<string>()
+function warnUnknownAttentionToken(kind: 'attention_reason' | 'next_human_action', token: string) {
+  const key = `${kind}|${token}`
+  if (warnedAttentionTokens.has(key)) return
+  warnedAttentionTokens.add(key)
+  if (typeof console !== 'undefined') {
+    console.warn(`[keeper-attention-labels] unknown ${kind}:`, token)
+  }
+}
+
+// Backend emit sites for `attention_reason`:
+//   - lib/keeper/keeper_status_bridge.ml:727-742 (six common reasons)
+//   - lib/keeper_fd_pressure.ml:190 ('fd_pressure')
+//   - lib/dashboard/dashboard_goals.ml:44 ('runtime_trust_snapshot_unavailable')
+export const ATTENTION_REASONS = [
+  'approval_pending',
+  'continue_gate_required',
+  'paused',
+  'paused_blocked',
+  'runtime_blocked',
+  'provider_runtime_error',
+  'social_model_fallback',
+  'fd_pressure',
+  'runtime_trust_snapshot_unavailable',
+] as const
+export type AttentionReason = typeof ATTENTION_REASONS[number]
+
+const ATTENTION_REASON_LABELS: Record<AttentionReason, string> = {
+  approval_pending: '승인 대기',
+  continue_gate_required: '계속 진행 승인 필요',
+  paused: '일시정지',
+  paused_blocked: '일시정지 원인 확인 필요',
+  runtime_blocked: '런타임 근거 확인 필요',
+  provider_runtime_error: '런타임 호출 오류',
+  social_model_fallback: '소셜 모델 폴백',
+  fd_pressure: 'FD 임계치 초과',
+  runtime_trust_snapshot_unavailable: '런타임 신뢰 스냅샷 없음',
+}
+
+export function canonicalAttentionReason(reason: string | null): string | null {
+  if (reason === 'runtime_attempts_exhausted') return 'runtime_blocked'
+  if (reason === 'provider_tool_capability_missing') return 'runtime_blocked'
+  if (reason === 'completion_contract_violation') return 'runtime_blocked'
+  if (reason === 'watchdog_stale_turn') return 'runtime_blocked'
+  if (reason === 'fiber_unresolved') return 'runtime_blocked'
+  return reason
+}
+
+export function isAttentionReason(s: string): s is AttentionReason {
+  return (ATTENTION_REASONS as readonly string[]).includes(s)
+}
+
+export function attentionReasonLabel(reason: string | null, paused: boolean): string | null {
+  const canonicalReason = canonicalAttentionReason(reason)
+  if (!canonicalReason) return null
+  if ((canonicalReason === 'paused' || canonicalReason === 'paused_blocked') && paused) return null
+  if (isAttentionReason(canonicalReason)) return ATTENTION_REASON_LABELS[canonicalReason]
+  warnUnknownAttentionToken('attention_reason', canonicalReason)
+  return canonicalReason
+}
+
+// Backend emit sites for `next_human_action` (paired 1:1 with the
+// corresponding `attention_reason`):
+//   - lib/keeper/keeper_status_bridge.ml:727-742 (seven common actions)
+//   - lib/keeper/keeper_turn_disposition.ml:63-70 (runtime-trust latest action)
+//   - lib/keeper_fd_pressure.ml:191 ('restore_fd_headroom')
+//   - lib/dashboard/dashboard_goals.ml:45 ('inspect_keeper_runtime_trust')
+export const NEXT_HUMAN_ACTIONS = [
+  'approve_or_reject_continue',
+  'inspect_blocker_before_resume',
+  'inspect_runtime_blocker',
+  'inspect_latest_error',
+  'inspect_provider_runtime_cause',
+  'resolve_approval',
+  'resume_or_review',
+  'review_social_model',
+  'restore_fd_headroom',
+  'inspect_keeper_runtime_trust',
+] as const
+export type NextHumanAction = typeof NEXT_HUMAN_ACTIONS[number]
+
+const NEXT_HUMAN_ACTION_LABELS: Record<NextHumanAction, string> = {
+  approve_or_reject_continue: '계속 진행 승인 또는 거절',
+  inspect_blocker_before_resume: '원인 확인 후 재개',
+  inspect_runtime_blocker: '런타임 근거 확인',
+  inspect_latest_error: '최근 오류 확인',
+  inspect_provider_runtime_cause: 'Provider 런타임 원인 확인',
+  resolve_approval: '승인 요청 처리',
+  resume_or_review: '재개 또는 설정 검토',
+  review_social_model: '소셜 모델 설정 검토',
+  restore_fd_headroom: 'FD 여유 확보',
+  inspect_keeper_runtime_trust: '런타임 신뢰 스냅샷 확인',
+}
+
+export function isNextHumanAction(s: string): s is NextHumanAction {
+  return (NEXT_HUMAN_ACTIONS as readonly string[]).includes(s)
+}
+
+export function canonicalNextHumanAction(action: string | null): string | null {
+  if (action === 'inspect_turn_timeout') return 'inspect_runtime_blocker'
+  if (action === 'inspect_runtime_attempts') return 'inspect_runtime_blocker'
+  if (action === 'inspect_provider_tool_lane') return 'inspect_runtime_blocker'
+  if (action === 'inspect_completion_contract') return 'inspect_runtime_blocker'
+  if (action === 'inspect_watchdog_root_cause') return 'inspect_runtime_blocker'
+  if (action === 'inspect_turn_finalization') return 'inspect_runtime_blocker'
+  return action
+}
+
+export function nextHumanActionLabel(action: string | null): string | null {
+  const canonicalAction = canonicalNextHumanAction(action)
+  if (!canonicalAction) return null
+  if (isNextHumanAction(canonicalAction)) return NEXT_HUMAN_ACTION_LABELS[canonicalAction]
+  warnUnknownAttentionToken('next_human_action', canonicalAction)
+  return canonicalAction
+}


### PR DESCRIPTION
## 목표

overview "주의 필요" 큐가 백엔드 `attention_reason` / `next_human_action` 코드를 raw로 노출하던 디자인 간극을 수정합니다. 프로토타입 대조 audit에서 발견 (PR #22078 후속).

## 근본 원인

overview 패널은 액션/사유를 `inspect_blocker_before_resume`, `inspect_latest_error` 같은 내부 식별자로 그대로 표시했습니다. 같은 wire vocabulary를 `keeper-detail-alert-strip.ts`는 이미 한국어로 humanize하고 있었으나(`원인 확인 후 재개`, `최근 오류 확인`), overview는 그 SSOT를 쓰지 않았습니다. 프로토타입은 humanized 라벨을 보여줍니다.

overview에 라벨 2개만 하드코딩하면 N-of-M 안티패턴이라, humanization 자체를 공유 SSOT로 추출했습니다.

## 변경

- **`src/lib/keeper-attention-labels.ts` (신규 SSOT)** — closed-sum union(`ATTENTION_REASONS`/`NEXT_HUMAN_ACTIONS`) + `Record<Union,string>` 한국어 라벨 + canonical fold + unknown-token warn. union 미확장 시 typecheck 실패로 누락 차단.
- **`keeper-detail-alert-strip.ts`** — 인라인 정의 제거하고 lib import(동작 동일, canonical-folding 테스트 그대로 통과). 약 125줄 감소.
- **`overview.ts`** — `deriveKeeperAttentionReason`이 `attentionReasonLabel`/`nextHumanActionLabel`로 humanize. 미지원 콜론-composite(`completion_contract_result:*`, 별개 추적 중인 reason 누출)는 raw 유지 + dev warn (조용히 사라지지 않음).
- **`overview.test.ts`** — known 코드 humanize + unknown composite raw 유지 회귀 테스트 2건.

## 검증 (로컬)

- `tsc --noEmit`: 에러 0
- `eslint`: 에러 0 (symlink 경로 경고만)
- `vitest run` (overview + keeper-detail-alert-strip): 111/111 통과 (신규 2건 포함, 리팩터 회귀 없음)

## 비고

콜론-composite reason 누출(`completion_contract_result:*`)은 이 PR 범위 밖 — backend가 닫힌 reason을 콜론 평탄화해 emit하는 별개 이슈(RFC-0279 계열)로, 여기서는 raw 노출 + warn으로 가시화만 합니다.
