### PR TITLE
refactor(transport): share inbound WS frame reassembler across MCP + IDE LSP (RFC-0281 §3.2)

### DIFF
--- a/lib/server/server_ide_lsp_proxy.ml
+++ b/lib/server/server_ide_lsp_proxy.ml
@@ -19,33 +19,6 @@ let send_text wsd s =
   Ws.Wsd.send_bytes ~kind:`Text wsd bytes ~off:0 ~len:(Bytes.length bytes)
 ;;
 
-(** Read a complete frame payload into a string. *)
-let read_frame_text ~len ~on_text payload =
-  if len = 0
-  then on_text ""
-  else (
-    let buffer = Bytes.create len in
-    let offset = ref 0 in
-    let rec schedule () =
-      if !offset >= len
-      then on_text (Bytes.unsafe_to_string buffer)
-      else
-        Ws.Payload.schedule_read
-          payload
-          ~on_eof:(fun () -> on_text (Bytes.sub_string buffer 0 !offset))
-          ~on_read:(fun bs ~off ~len:chunk_len ->
-            Bigstringaf.blit_to_bytes
-              bs
-              ~src_off:off
-              buffer
-              ~dst_off:!offset
-              ~len:chunk_len;
-            offset := !offset + chunk_len;
-            schedule ())
-    in
-    schedule ())
-;;
-
 (** Per-connection state shared across frame handler and relay fibers.
 
     [sw] is the server-lifetime switch (LSP processes + their reader
@@ -66,6 +39,12 @@ type conn_state =
   ; spawn_mutex : Eio.Mutex.t
   ; clock : float Eio.Time.clock_ty Eio.Resource.t
   ; disconnected : bool Atomic.t
+  ; inbound : Server_mcp_transport_ws.Ws_inbound.t
+        (* Shared inbound-frame reassembler (RFC-0281 §3.2): reassembles
+           fragmented LSP messages across [`Continuation] frames and enforces
+           the same frame/message size caps as the MCP session path, replacing
+           B's former single-frame [read_frame_text] which dropped
+           [`Continuation] frames and applied no size cap. *)
   }
 
 let base_path_of_state state = (Mcp_server.workspace_config state).base_path
@@ -866,16 +845,37 @@ let add_routes ~sw ~clock router =
                           ; spawn_mutex = Eio.Mutex.create ()
                           ; clock
                           ; disconnected = Atomic.make false
+                          ; inbound = Server_mcp_transport_ws.Ws_inbound.create ()
                           }
                         in
                         { Ws.Websocket_connection.frame =
-                            (fun ~opcode ~is_fin:_ ~len payload ->
+                            (fun ~opcode ~is_fin ~len payload ->
                               match opcode with
-                              | `Text | `Binary ->
-                                read_frame_text
+                              | `Text | `Binary | `Continuation ->
+                                (* Route data frames through the shared inbound
+                                   reassembler so fragmented LSP messages
+                                   ([`Continuation], [is_fin = false]) survive
+                                   and the frame/message size caps apply
+                                   (RFC-0281 §3.2). *)
+                                Server_mcp_transport_ws.read_data_frame
+                                  cs.inbound
+                                  ~max_frame_bytes:
+                                    (Server_mcp_transport_ws.max_inbound_frame_bytes ())
+                                  ~max_message_bytes:
+                                    (Server_mcp_transport_ws.max_inbound_message_bytes ())
+                                  ~is_fin
                                   ~len
-                                  ~on_text:(fun msg -> dispatch_message cs msg)
                                   payload
+                                  ~on_outcome:(function
+                                    | Server_mcp_transport_ws.Inbound_message msg ->
+                                      dispatch_message cs msg
+                                    | Server_mcp_transport_ws.Inbound_incomplete -> ()
+                                    | Server_mcp_transport_ws.Inbound_rejected rejection
+                                      ->
+                                      Log.Server.warn
+                                        "LSP inbound frame rejected (%s); disconnecting"
+                                        rejection.Server_mcp_transport_ws.reason;
+                                      disconnect cs)
                               | `Ping ->
                                 (try Ws.Wsd.send_pong wsd with
                                  | exn ->
@@ -887,7 +887,7 @@ let add_routes ~sw ~clock router =
                                 Log.Server.info "LSP WebSocket disconnecting";
                                 disconnect cs;
                                 Ws.Payload.close payload
-                              | `Pong | `Continuation | `Other _ ->
+                              | `Pong | `Other _ ->
                                 Ws.Payload.close payload)
                         ; eof =
                             (fun ?error:_ () ->

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -40,6 +40,29 @@ type dashboard_auth_state =
   | Unauthenticated
   | Authenticated of { agent : string option }
 
+(** Inbound WebSocket frame reassembly state.  A single message may arrive
+    across several frames (an initial [`Text]/[`Binary] with [is_fin = false]
+    followed by [`Continuation] frames); this holds the partial buffer until
+    the final fragment.  Shared SSOT for inbound framing across the MCP session
+    handler and the IDE LSP proxy so both reassemble fragments and enforce the
+    same size caps (RFC-0281 §3.2). *)
+module Ws_inbound = struct
+  type t =
+    { mutable partial : Buffer.t option
+    ; mutable partial_bytes : int
+    }
+
+  let create () = { partial = None; partial_bytes = 0 }
+
+  (** Drop any buffered partial message (on reject or close). *)
+  let reset t =
+    t.partial <- None;
+    t.partial_bytes <- 0
+
+  (** Bytes buffered so far for an in-progress fragmented message. *)
+  let buffered_bytes t = t.partial_bytes
+end
+
 (** Active WebSocket session state. *)
 type ws_session = {
   id: string;
@@ -79,8 +102,7 @@ type ws_session = {
       seqs are intentionally excluded because the browser only ACKs deltas. *)
   mutable dashboard_last_delta_seq: int;
   mutable dashboard_last_delta_at: float;
-  mutable inbound_partial_text: Buffer.t option;
-  mutable inbound_partial_text_bytes: int;
+  inbound: Ws_inbound.t;
   inbound_dispatches: int Atomic.t;
 }
 
@@ -232,8 +254,7 @@ let new_session ~id ~wsd =
     dashboard_last_ack_at = now;
     dashboard_last_delta_seq = 0;
     dashboard_last_delta_at = now;
-    inbound_partial_text = None;
-    inbound_partial_text_bytes = 0;
+    inbound = Ws_inbound.create ();
     inbound_dispatches = Atomic.make 0;
   }
 
@@ -1002,58 +1023,100 @@ let close_session_for_inbound_reject session rejection =
       close_detached_session_wsd ~code:`Message_too_big
         ~context:"reject close" detached_session
 
-let handle_inbound_text session ~on_message ~is_fin text =
+(** Outcome of feeding one decoded inbound data frame to
+    {!inbound_accumulate}.  [Inbound_message] carries a fully reassembled
+    application message; [Inbound_incomplete] means the fragment was buffered
+    (or was empty and produced nothing) and more frames are expected;
+    [Inbound_rejected] means a size cap was exceeded and the partial buffer was
+    dropped. *)
+type inbound_read_outcome =
+  | Inbound_message of string
+  | Inbound_incomplete
+  | Inbound_rejected of inbound_size_rejection
+
+(** Reassemble one decoded data-frame chunk into [reader]'s running message,
+    enforcing [max_message_bytes] across fragments.  The only side effect is
+    updating [reader]'s partial buffer, so it is unit testable without a live
+    connection.  Shared SSOT for the MCP session handler and the IDE LSP
+    proxy. *)
+let inbound_accumulate (reader : Ws_inbound.t) ~max_message_bytes ~is_fin text =
   let chunk_len = String.length text in
   let current_bytes =
-    match session.inbound_partial_text with
+    match reader.Ws_inbound.partial with
     | None -> 0
-    | Some _ -> session.inbound_partial_text_bytes
+    | Some _ -> reader.Ws_inbound.partial_bytes
   in
   match
-    classify_inbound_message_size ~current_bytes ~chunk_len
-      ~max_message_bytes:(max_inbound_message_bytes ())
+    classify_inbound_message_size ~current_bytes ~chunk_len ~max_message_bytes
   with
   | Inbound_reject rejection ->
-      session.inbound_partial_text <- None;
-      session.inbound_partial_text_bytes <- 0;
-      close_session_for_inbound_reject session rejection
+      Ws_inbound.reset reader;
+      Inbound_rejected rejection
   | Inbound_accept ->
       let message_bytes = add_bounded_or_max current_bytes chunk_len in
-      match session.inbound_partial_text, is_fin with
-      | None, true ->
-          if chunk_len > 0 then
-            on_message session.id text
-      | None, false ->
-          let initial_size =
-            if chunk_len > max_int / 2 then chunk_len else chunk_len * 2
-          in
-          let buffer = Buffer.create (max 16 initial_size) in
-          Buffer.add_string buffer text;
-          session.inbound_partial_text <- Some buffer;
-          session.inbound_partial_text_bytes <- message_bytes
-      | Some buffer, _ ->
-          Buffer.add_string buffer text;
-          if is_fin then begin
-            session.inbound_partial_text <- None;
-            session.inbound_partial_text_bytes <- 0;
-            let message = Buffer.contents buffer in
-            if String.length message > 0 then
-              on_message session.id message
-          end
-          else
-            session.inbound_partial_text_bytes <- message_bytes
+      (match reader.Ws_inbound.partial, is_fin with
+       | None, true ->
+           if chunk_len > 0 then Inbound_message text else Inbound_incomplete
+       | None, false ->
+           let initial_size =
+             if chunk_len > max_int / 2 then chunk_len else chunk_len * 2
+           in
+           let buffer = Buffer.create (max 16 initial_size) in
+           Buffer.add_string buffer text;
+           reader.Ws_inbound.partial <- Some buffer;
+           reader.Ws_inbound.partial_bytes <- message_bytes;
+           Inbound_incomplete
+       | Some buffer, _ ->
+           Buffer.add_string buffer text;
+           if is_fin
+           then begin
+             Ws_inbound.reset reader;
+             let message = Buffer.contents buffer in
+             if String.length message > 0 then Inbound_message message
+             else Inbound_incomplete
+           end
+           else begin
+             reader.Ws_inbound.partial_bytes <- message_bytes;
+             Inbound_incomplete
+           end)
 
-let read_inbound_message_frame session ~on_message ~is_fin ~len payload =
+(** Drain a WebSocket data-frame payload (frame-size capped) and feed it to
+    {!inbound_accumulate}, delivering the outcome via [on_outcome].  Both the
+    MCP session handler and the IDE LSP proxy route [`Text] / [`Binary] /
+    [`Continuation] frames through this, so both reassemble fragments and apply
+    identical frame/message size caps (RFC-0281 §3.2). *)
+let read_data_frame
+      (reader : Ws_inbound.t)
+      ~max_frame_bytes
+      ~max_message_bytes
+      ~is_fin
+      ~len
+      payload
+      ~on_outcome
+  =
   Transport_metrics.observe_ws_message_bytes_recv len;
-  match classify_inbound_frame_size ~len ~max_frame_bytes:(max_inbound_frame_bytes ()) with
+  match classify_inbound_frame_size ~len ~max_frame_bytes with
   | Inbound_reject rejection ->
       Httpun_ws.Payload.close payload;
-      session.inbound_partial_text <- None;
-      session.inbound_partial_text_bytes <- 0;
-      close_session_for_inbound_reject session rejection
+      Ws_inbound.reset reader;
+      on_outcome (Inbound_rejected rejection)
   | Inbound_accept ->
       read_payload_string payload ~len ~on_complete:(fun text ->
-          handle_inbound_text session ~on_message ~is_fin text)
+          on_outcome (inbound_accumulate reader ~max_message_bytes ~is_fin text))
+
+let read_inbound_message_frame session ~on_message ~is_fin ~len payload =
+  read_data_frame
+    session.inbound
+    ~max_frame_bytes:(max_inbound_frame_bytes ())
+    ~max_message_bytes:(max_inbound_message_bytes ())
+    ~is_fin
+    ~len
+    payload
+    ~on_outcome:(function
+      | Inbound_message msg -> on_message session.id msg
+      | Inbound_incomplete -> ()
+      | Inbound_rejected rejection ->
+          close_session_for_inbound_reject session rejection)
 
 type inbound_dispatch_rejection = {
   reason: string;

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -70,7 +70,7 @@
     [slice_index_enabled_cache] /
     [slice_index_enabled],
     [__test_reset_env_caches],
-    [read_payload_string], [handle_inbound_text],
+    [read_payload_string], [inbound_accumulate], [read_data_frame],
     [send_to_session],
     [broadcast_ws]). *)
 
@@ -83,6 +83,25 @@ type dashboard_auth_state =
     read on the SSE forward hot path and the dashboard RPC auth gates.  Held
     in an [Atomic.t] field so the single write and many reads are tear-free if
     dashboard serving moves off the main Eio domain (RFC-0204 §8.4, Phase 1). *)
+
+(** Inbound WebSocket frame reassembly state.  A single application message may
+    arrive across several frames (an initial [`Text]/[`Binary] with
+    [is_fin = false] followed by [`Continuation] frames); this holds the partial
+    buffer until the final fragment.  Shared SSOT for inbound framing across the
+    MCP session handler and the IDE LSP proxy so both reassemble fragments and
+    enforce identical size caps (RFC-0281 §3.2). *)
+module Ws_inbound : sig
+  type t
+
+  val create : unit -> t
+  (** Fresh reassembly state with no buffered partial message. *)
+
+  val reset : t -> unit
+  (** Drop any buffered partial message (on reject or close). *)
+
+  val buffered_bytes : t -> int
+  (** Bytes buffered so far for an in-progress fragmented message. *)
+end
 
 type ws_session = {
   id : string;
@@ -99,8 +118,7 @@ type ws_session = {
   mutable dashboard_last_ack_at : float;
   mutable dashboard_last_delta_seq : int;
   mutable dashboard_last_delta_at : float;
-  mutable inbound_partial_text : Buffer.t option;
-  mutable inbound_partial_text_bytes : int;
+  inbound : Ws_inbound.t;
   inbound_dispatches : int Atomic.t;
 }
 (** Per-WS session state.  Concrete record because
@@ -232,6 +250,40 @@ type inbound_dispatch_admission =
   | Inbound_dispatch_rejected of inbound_dispatch_rejection
   | Inbound_dispatch_session_gone
 (** Result of attempting to reserve one per-session inbound dispatch slot. *)
+
+type inbound_read_outcome =
+  | Inbound_message of string
+  | Inbound_incomplete
+  | Inbound_rejected of inbound_size_rejection
+(** Outcome of {!inbound_accumulate} / {!read_data_frame}: a fully reassembled
+    application message, a buffered (or empty) fragment awaiting more frames, or
+    a size-cap rejection (the partial buffer is dropped). *)
+
+val inbound_accumulate :
+  Ws_inbound.t ->
+  max_message_bytes:int ->
+  is_fin:bool ->
+  string ->
+  inbound_read_outcome
+(** Reassemble one decoded data-frame chunk into the reader's running message,
+    enforcing [max_message_bytes] across fragments.  Pure state transition over
+    the reader (only its partial buffer is mutated); unit testable without a
+    live connection. *)
+
+val read_data_frame :
+  Ws_inbound.t ->
+  max_frame_bytes:int ->
+  max_message_bytes:int ->
+  is_fin:bool ->
+  len:int ->
+  Httpun_ws.Payload.t ->
+  on_outcome:(inbound_read_outcome -> unit) ->
+  unit
+(** Drain a WebSocket data-frame [payload] (frame-size capped) and feed it to
+    {!inbound_accumulate}, delivering the outcome via [on_outcome].  Both the
+    MCP session handler and the IDE LSP proxy route [`Text] / [`Binary] /
+    [`Continuation] frames through this, so both reassemble fragments and apply
+    identical frame/message size caps (RFC-0281 §3.2). *)
 
 val read_inbound_message_frame :
   ws_session ->

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -664,6 +664,48 @@ let test_inbound_message_size_rejects_accumulated_fragments () =
       Alcotest.(check int) "limit" 1024 r.limit;
       Alcotest.(check int) "actual" 1100 r.actual
 
+(* RFC-0281 §3.2: a single application message may arrive across several WS
+   frames (an initial [`Text]/[`Binary] with [is_fin = false] then
+   [`Continuation] frames).  [inbound_accumulate] is the shared SSOT reassembler
+   used by both the MCP session handler and the IDE LSP proxy.  Before it was
+   shared, the LSP proxy ignored [is_fin] and dropped [`Continuation] frames, so
+   fragmented messages were silently truncated. *)
+let test_inbound_accumulate_single_complete_frame () =
+  let reader = Ws.Ws_inbound.create () in
+  match Ws.inbound_accumulate reader ~max_message_bytes:1024 ~is_fin:true "hello" with
+  | Ws.Inbound_message m -> Alcotest.(check string) "complete frame" "hello" m
+  | Ws.Inbound_incomplete -> Alcotest.fail "single fin frame should yield a message"
+  | Ws.Inbound_rejected _ -> Alcotest.fail "small frame should not be rejected"
+
+let test_inbound_accumulate_reassembles_fragments () =
+  let reader = Ws.Ws_inbound.create () in
+  (match
+     Ws.inbound_accumulate reader ~max_message_bytes:1024 ~is_fin:false {|{"a":|}
+   with
+   | Ws.Inbound_incomplete -> ()
+   | _ -> Alcotest.fail "first fragment must buffer (Incomplete)");
+  (match
+     Ws.inbound_accumulate reader ~max_message_bytes:1024 ~is_fin:false {|1,"b":|}
+   with
+   | Ws.Inbound_incomplete -> ()
+   | _ -> Alcotest.fail "middle fragment must buffer (Incomplete)");
+  match Ws.inbound_accumulate reader ~max_message_bytes:1024 ~is_fin:true "2}" with
+  | Ws.Inbound_message m ->
+      Alcotest.(check string) "reassembled across fragments" {|{"a":1,"b":2}|} m
+  | _ -> Alcotest.fail "final fragment must yield the joined message"
+
+let test_inbound_accumulate_rejects_oversized_message () =
+  let reader = Ws.Ws_inbound.create () in
+  (match Ws.inbound_accumulate reader ~max_message_bytes:8 ~is_fin:false "1234" with
+   | Ws.Inbound_incomplete -> ()
+   | _ -> Alcotest.fail "first fragment within cap must buffer");
+  match Ws.inbound_accumulate reader ~max_message_bytes:8 ~is_fin:false "56789" with
+  | Ws.Inbound_rejected r ->
+      Alcotest.(check string) "reason" "message_too_large" r.reason;
+      Alcotest.(check int) "partial buffer cleared on reject"
+        0 (Ws.Ws_inbound.buffered_bytes reader)
+  | _ -> Alcotest.fail "accumulated overflow must be rejected"
+
 let test_inbound_message_size_rejects_overflow_sum () =
   match
     Ws.classify_inbound_message_size ~current_bytes:(max_int - 10) ~chunk_len:20
@@ -1008,7 +1050,7 @@ let test_new_session_initializes_pong_state () =
     true
     (session.dashboard_last_delta_at <= Unix.gettimeofday ());
   Alcotest.(check int) "partial inbound byte count starts empty"
-    0 session.inbound_partial_text_bytes;
+    0 (Ws.Ws_inbound.buffered_bytes session.inbound);
   Alcotest.(check int) "inbound dispatch count starts empty"
     0 (Atomic.get session.inbound_dispatches)
 
@@ -1144,6 +1186,12 @@ let () =
         test_inbound_frame_size_rejects_negative_length;
       Alcotest.test_case "message cap rejects accumulated fragments" `Quick
         test_inbound_message_size_rejects_accumulated_fragments;
+      Alcotest.test_case "inbound single complete frame delivers message" `Quick
+        test_inbound_accumulate_single_complete_frame;
+      Alcotest.test_case "inbound reassembles fragmented message" `Quick
+        test_inbound_accumulate_reassembles_fragments;
+      Alcotest.test_case "inbound rejects oversized accumulated message" `Quick
+        test_inbound_accumulate_rejects_oversized_message;
       Alcotest.test_case "message cap rejects overflow sums" `Quick
         test_inbound_message_size_rejects_overflow_sum;
       Alcotest.test_case "size cap env defaults" `Quick


### PR DESCRIPTION
## 목적

RFC-0281은 `read_inbound_message_frame`을 "message handling의 공유 SSOT"라고 선언했으나, 실제로는 IDE LSP 프록시(B)가 자체 `read_frame_text`를 사용해 그 선언이 사실이 아니었습니다. B는 `is_fin`을 무시하고 `Continuation` 프레임을 drop했습니다:

- fragmented 인바운드 LSP 메시지(큰 `didOpen`/`didChange` 등)가 첫 조각만 잘린 채 dispatch → JSON 파싱 실패 + 나머지 조각 silent drop
- frame/message 크기 상한 미적용 (무제한 read = DoS 노출)

MCP 세션 핸들러(A/C)는 이미 `read_inbound_message_frame`으로 fragment를 재조립하고 상한을 적용했지만, 그 로직이 session-coupled라 B와 공유되지 않았습니다.

## 변경

인바운드 프레임 재조립 메커니즘을 공유 `Ws_inbound` reader(`Ws_inbound.t` + `inbound_accumulate` + `read_data_frame`)로 추출해 `server_mcp_transport_ws`가 소유합니다. MCP 세션 핸들러와 IDE LSP 프록시 모두 `Text` / `Binary` / `Continuation` 데이터 프레임을 이 reader로 라우팅 → 양쪽이 동일하게 fragment를 재조립하고 동일한 frame/message 크기 상한을 적용합니다.

- MCP 경로: 로직을 reader로 이동, 동작 byte-identical (semantics 불변)
- B 경로: `read_frame_text` 제거, 공유 reader 사용 → Continuation 재조립 + 크기 상한 획득
- control frame(ping/pong/close)은 핸들러별 동작이 달라 각자 유지
- 세션 상태 필드 `inbound_partial_text`/`inbound_partial_text_bytes` → `inbound : Ws_inbound.t`로 캡슐화

## 범위 외 (의도적)

- B의 Pong client-liveness 갭: B는 heartbeat 자체가 없어 별도 범위. RFC-0281이 문서화한 divergence로 유지(별도 후속).

## 검증

- 로컬 `dune build bin/main_eio.exe` (lib + B 링크) EXIT=0
- 신규 fragmentation 단위 테스트(`test_ws_transport`): 단일 완성 프레임 / 다중 fragment 재조립 / oversize 누적 거부 → 68 tests pass
- `test_server_ide_lsp_proxy` 4 / `test_http_server_eio` 41 pass
- 미검증: 라이브 fragmented WS 프레임 왕복은 머지 후 서버 재시작으로 측정 가능

## RFC

RFC-0281 (WebSocket Transport SSOT) §3.2 message-ingestion의 완결입니다. 새 RFC 불필요 — RFC-0281이 이미 이 SSOT를 명시했고(line 71 "read_inbound_message_frame ... the shared SSOT for message handling"), 본 PR이 그 선언을 IDE LSP 경로에도 실재화합니다.

이 변경은 워크어라운드가 아니라 **abstraction 추출(중복 제거의 근본 해결)**입니다: 열등한 복사본(`read_frame_text`)을 삭제하고 단일 SSOT로 수렴시킵니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
