### PR TITLE
fix(test): repair operator-control test build after dune wiring (#22077)

### DIFF
--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -183,17 +183,20 @@ let test_compute_context_ratio_does_not_infer_provider_budget () =
     | Ok meta -> meta
     | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
   in
+  (* Model/provider self-report fields ([models], [last_model_used]) were
+     retired from keeper_meta/usage_metrics (RFC-0275/0276 social-model purge),
+     so no provider label can be expressed here. compute_context_ratio therefore
+     derives the ratio purely from the resolved context budget and recorded
+     token counts — never from a model label. *)
   let meta =
     {
       base with
-      models = [ "codex_cli:auto" ];
       runtime =
         {
           base.runtime with
           usage =
             {
               base.runtime.usage with
-              last_model_used = "codex";
               last_input_tokens = 2_106_223;
             };
         };
@@ -247,14 +250,12 @@ let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =
       let updated_meta =
         {
           meta with
-          models = [ "codex_cli:auto" ];
           runtime =
             {
               meta.runtime with
               usage =
                 {
                   meta.runtime.usage with
-                  last_model_used = "codex";
                   last_input_tokens = 6_637_033;
                   last_total_tokens = 6_670_646;
                 };

--- a/test/test_operator_control_support.ml
+++ b/test/test_operator_control_support.ml
@@ -61,7 +61,8 @@ let iso_of_unix unix_ts =
 let record_operator_judgment config ~surface ~summary ?recommended_action ~fresh_for_sec () =
   let now_unix = Unix.gettimeofday () in
   ignore
-    (Operator_judgment.record config ~surface ~summary
+    (Operator_judgment.record config ~surface
+       ~target_type:Operator_judgment.Workspace ~target_id:None ~summary
        ~confidence:0.91 ?recommended_action ~generated_at:(Masc_domain.now_iso ())
        ~generated_at_unix:now_unix
        ~fresh_until:(iso_of_unix (now_unix +. fresh_for_sec))


### PR DESCRIPTION
## 목적

main HEAD 빌드 복구. `#22077`이 `test_operator_control_snapshot` / `test_operator_control_support`를 처음 `test/dune`에 등록했는데, 이 두 파일은 그 전까지 한 번도 컴파일된 적이 없어 누적된 시그니처 드리프트가 컴파일 타임에 드러나지 않았습니다. 등록되는 순간 빌드가 깨졌습니다.

## 변경

- `test_operator_control_support.ml`: `Operator_judgment.record` 호출에 필수 인자 `~target_type` / `~target_id` 누락 → partial application(warning 5). 프로덕션 경로(`dashboard_operator_judge.ml`)가 넘기는 값에 맞춰 `Workspace` / `None` 추가.
- `test_operator_control_snapshot.ml`: `keeper_meta` / `usage_metrics`에서 제거된 `models`, `last_model_used` 필드(RFC-0275/0276 social-model purge) 참조 3곳 제거. `compute_context_ratio`는 resolved context budget + token count로만 ratio를 산출하고 model label은 쓰지 않으므로 죽은 필드. 의도는 주석으로 보존.

## 검증

- 로컬 `dune build .` 통과 (동일 diff 기준). 런타임 검증은 CI에 위임.

## 후속(이 PR 범위 밖)

- `#22077`이 머지될 때 main이 깨진 채로 들어갔습니다. CI가 이 test 타겟을 실제로 빌드하지 않았을 가능성 — 별도 점검 필요.

RFC-WAIVED: test-only 변경. `lib/operator/operator_control*` 프로덕션 코드 미수정, credential/identity/auth 경로 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
