### PR TITLE
refactor(dashboard): drop board surface title header to match prototype

### DIFF
--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -256,6 +256,14 @@ describe('BoardSurface Component', () => {
     expect(container.querySelector('.v2-board-surface')).not.toBeNull()
   })
 
+  it('renders no title header — board goes straight to the feed (matches prototype)', () => {
+    const { container } = render(h(BoardSurface, null))
+    // The board surface intentionally omits SurfaceHeader; the sub-board rail
+    // and "전체 피드" heading are the only structure above the posts. board is
+    // in SURFACE_OWN_LEAD_IDS so the generic SurfaceLead is also suppressed.
+    expect(container.querySelector('header.v2-surface-header')).toBeNull()
+  })
+
   it('shows the mention inbox detail rail by default', () => {
     const { container } = render(h(BoardSurface, null))
     expect(container.querySelector('[data-testid="bd-mention-detail"]')).not.toBeNull()

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -12,7 +12,6 @@ import { Select } from '../common/select'
 import { Checkbox } from '../common/checkbox'
 import { RichContent } from '../common/rich-content'
 import { CursorPagination } from '../common/pagination'
-import { SurfaceHeader } from '../common/surface-header'
 import { stripStateBlocks } from '../../keeper-message'
 import { route } from '../../router'
 import { keepers as dashboardKeepers, messages, refreshExecution } from '../../store'
@@ -1502,7 +1501,6 @@ export function BoardSurface() {
       class="v2-board-surface ss-surface bg-surface-page text-text-primary"
       data-detail-width=${String(detailWidth)}
     >
-      <${SurfaceHeader} />
       <div class="bd-body" style=${`--bd-detail-width: ${detailWidth}px;`}>
         <${BdRail}
           activeSub=${activeSub}

--- a/dashboard/src/components/common/surface-header.test.ts
+++ b/dashboard/src/components/common/surface-header.test.ts
@@ -19,14 +19,15 @@ describe('SurfaceHeader', () => {
   })
 
   // Each surface that does not render a richer bespoke header (monitoring,
-  // command, lab, board) opts into SurfaceHeader, which surfaces the current
+  // command, lab) opts into SurfaceHeader, which surfaces the current
   // section/view label as the single primary h1. These labels match what the
   // former generic SurfaceLead rendered (same currentSectionForRoute logic).
+  // The board surface renders no title header (matches the prototype), so it
+  // is intentionally absent here.
   it.each([
     ['monitoring', 'Keeper Fleet'],
     ['command', 'Actions'],
     ['lab', 'Tools'],
-    ['board', 'Board'],
   ] as const)('renders the %s surface title as the primary h1', (tab, label) => {
     route.value = { tab, params: {}, postId: null }
     render(h(SurfaceHeader, {}), container)
@@ -35,7 +36,7 @@ describe('SurfaceHeader', () => {
   })
 
   it('carries the shared copy + solo-view affordances', () => {
-    route.value = { tab: 'board', params: {}, postId: null }
+    route.value = { tab: 'monitoring', params: {}, postId: null }
     render(h(SurfaceHeader, {}), container)
     expect(container.querySelector('.v2-surface-header-actions')).not.toBeNull()
     expect(container.querySelector('[data-testid="dashboard-widget-solo-link"]')).not.toBeNull()

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1485,7 +1485,9 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
 //   monitoring → status.ts           <SurfaceHeader> <h1>Keeper Fleet</h1>
 //   command    → operations-panel.ts <SurfaceHeader> <h1>Actions</h1>
 //   lab        → lab.ts              <SurfaceHeader> <h1>Tools</h1>
-//   board      → board-surface.ts    <SurfaceHeader> <h1>Board</h1> (#22021)
+// board is a third case: it renders NO header at all (#22086, prototype is
+// headerless) but must still be in this set so the generic SurfaceLead does not
+// reintroduce a title (board regressed that way in #22021).
 //
 // Surfaces that still rely on the generic SurfaceLead for their title: keepers, code.
 const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set([
@@ -1499,11 +1501,13 @@ const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set([
   'settings',
   'connectors',
   // Render the shared SurfaceHeader in their own body; without these the generic
-  // SurfaceLead stacked a duplicate title above each (board regressed in #22021,
-  // monitoring/command/lab carried the same gap from their SurfaceHeader adoption).
+  // SurfaceLead stacked a duplicate title above each (monitoring/command/lab
+  // carried that gap from their SurfaceHeader adoption).
   'monitoring',
   'command',
   'lab',
+  // board renders no header of its own (#22086); listed here only to suppress
+  // the generic SurfaceLead (which regressed a duplicate Board title in #22021).
   'board',
 ])
 


### PR DESCRIPTION
## 목표

보드 surface가 "Board" 제목 헤더를 렌더하지 않도록 합니다 (디자인 결정: 프로토타입은 제목 헤더 0개, 바로 서브보드 레일 + "전체 피드"로 시작).

## 배경

- #22078이 board를 `SURFACE_OWN_LEAD_IDS`에 추가해 generic `SurfaceLead` 중복을 제거(2개→1개).
- 이 PR은 board의 자체 `<SurfaceHeader/>`까지 제거 → 제목 0개(프로토타입 일치). board가 set에 있으므로 generic lead도 계속 억제됨.

## 변경

- `board-surface.ts` — `<SurfaceHeader/>` 렌더 제거 + 미사용 import 제거
- `surface-header.test.ts` — board를 SurfaceHeader 사용 surface 목록(it.each)에서 제거, affordance 테스트는 monitoring으로 교체, 주석 갱신
- `board-surface.test.ts` — `header.v2-surface-header` 부재 회귀 테스트 추가

## 검증 (로컬)

- `tsc --noEmit`: 에러 0
- `vitest run` (board-surface + surface-header): 64/64 통과
- `eslint`: 에러 0

## 비고

- **base**: main. #22078(board를 SURFACE_OWN_LEAD_IDS에 추가)이 머지돼 main에 반영됨 — 이 PR은 그 위에서 board 자체 헤더까지 제거.
- 보드 2칼럼(멘션 인박스 좌측 이동)은 별도 PR — grid 3→2 + detail 패널 drawer화 + 프로토타입 인터랙션 확인이 필요한 큰 변경이라 분리.
