### PR TITLE
fix(dashboard): clean up #22080 keeper model-field wiring (P2/P3 follow-up)

### DIFF
--- a/lib/dashboard/dashboard_http_keeper.ml
+++ b/lib/dashboard/dashboard_http_keeper.ml
@@ -973,11 +973,6 @@ let keepers_dashboard_json ?(compact = false) (config : Workspace.config) : Yojs
                   (List.map
                      (fun s -> `String s)
                      (Keeper_model_labels.configured_model_labels_of_meta m)) );
-              ( "models_resolved"
-              , `List
-                  (List.map
-                     (fun s -> `String s)
-                     (Keeper_model_labels.configured_model_labels_of_meta m)) );
               ("primary_model", `String (Keeper_meta_contract.runtime_id_of_meta m));
               ("active_model", `String (Keeper_status_runtime.active_model_of_meta m));
               ( "next_model_hint"

--- a/lib/keeper/keeper_status_detail.ml
+++ b/lib/keeper/keeper_status_detail.ml
@@ -372,8 +372,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
            compaction_policy_of_keeper m
          in
 
-         let models_resolved = `List [] in
-
          let metrics_store = Keeper_types_support.keeper_metrics_store config m.name in
          let metrics_path = Keeper_types_support.keeper_metrics_path config m.name in
          let memory_bank_path =
@@ -934,7 +932,6 @@ let handle_keeper_status_config ~(config : Workspace.config) ~(agent_name : stri
              ("turn_budget", `Int max_context_resolution.turn_budget);
              ("effective_budget", `Int max_context_resolution.effective_budget);
            ]);
-           ("models_resolved", models_resolved);
            ("model_observability", model_observability);
            ("runtime_trust", runtime_trust);
            ("chat_queue", chat_queue);

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -18,11 +18,26 @@ let active_model_of_meta (m : keeper_meta) : string =
   | _ -> Keeper_meta_contract.runtime_id_of_meta m
 
 let active_model_label_of_meta (m : keeper_meta) : string =
-  (* RFC-0132 PR-2: meta surface is external (status detail); redact via SSOT. *)
+  (* RFC-0132 PR-2: the meta surface is external (status detail); the model
+     label is redacted via SSOT ([Boundary_redaction.runtime_model_label]).
+     [meta.runtime.usage] carries only [last_input_tokens] — there is no
+     separate last-model-used field — so [last_model_used_label] at the emit
+     sites mirrors this same redacted value. Splitting the two would require
+     adding a model field to [usage_metrics] plus an RFC-0132 carve-out
+     (separate change). Intentionally identical to active by design. *)
   let _ = m in
   Boundary_redaction.to_string Boundary_redaction.runtime_model_label
 
 let next_model_hint_of_meta (m : keeper_meta) : string option =
+  (* NOT-YET-IMPLEMENTED (#22080 follow-up): meta carries no field recording the
+     cascade's next-runtime fallback target, so there is nothing to read here.
+     The real source is [Keeper_unified_turn_cascade_resolution] /
+     [Keeper_error_classify] — the [next_runtime] of a degraded_retry, computed
+     during turn rotation but never persisted back into meta. Producing a real
+     hint requires extending the meta schema to persist next_runtime per keeper
+     (a separate change). Returns [None]; the dashboard already treats null as
+     "no hint" (keeper-store-normalize.ts). The emit sites stay wired so the
+     hint activates automatically once a source exists. *)
   let _ = m in
   None
 

--- a/lib/keeper/keeper_status_runtime.ml
+++ b/lib/keeper/keeper_status_runtime.ml
@@ -37,7 +37,13 @@ let next_model_hint_of_meta (m : keeper_meta) : string option =
      hint requires extending the meta schema to persist next_runtime per keeper
      (a separate change). Returns [None]; the dashboard already treats null as
      "no hint" (keeper-store-normalize.ts). The emit sites stay wired so the
-     hint activates automatically once a source exists. *)
+     hint activates automatically once a source exists.
+
+     Unlike [models_resolved] (removed in this PR as a dead duplicate of the
+     live [models] field), [next_model_hint] is retained as forward-wiring:
+     same emit -> normalize -> unconsumed shape, but [models_resolved] had a
+     live sibling to serve the same data, whereas [next_model_hint] has no
+     source yet and lights up once [next_runtime] is persisted. *)
   let _ = m in
   None
 

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -168,7 +168,12 @@ let test_max_turns_override_source_accepts_raised_ceiling () =
   Alcotest.(check string) "missing override comes from env" "env"
     (Operator_control_snapshot.max_turns_override_source None)
 
-let test_compute_context_ratio_does_not_infer_provider_budget () =
+let test_compute_context_ratio_resolves_budget_and_clamps_at_ceiling () =
+  (* The runtime_id ("primary") resolves to an effective context budget via
+     [Keeper_context_runtime]; [last_input_tokens] here is deliberately above
+     that budget, so the ratio is clamped to the [0,1] ceiling (1.0). The
+     pre-#22080 stub returned [None] (no budget was ever inferred); this test
+     now pins the resolved+clamped behaviour, not the absence of inference. *)
   let base =
     match
       Masc_test_deps.meta_of_json_fixture
@@ -192,13 +197,14 @@ let test_compute_context_ratio_does_not_infer_provider_budget () =
           usage =
             {
               base.runtime.usage with
+              (* over-budget on purpose: ratio clamps to 1.0 *)
               last_input_tokens = 2_106_223;
             };
         };
     }
   in
   Alcotest.(check (option (float 0.0001)))
-    "model/provider label does not imply context budget" (Some 1.0)
+    "resolved budget clamps an over-budget ratio to 1.0" (Some 1.0)
     (Operator_control_snapshot.compute_context_ratio meta)
 
 let test_snapshot_prefers_metrics_context_truth_over_usage_counters () =


### PR DESCRIPTION
## 배경

#22080 이 실수로 머지되어, post-merge 리뷰([issuecomment-4769494004](https://github.com/jeong-sik/masc/pull/22080#issuecomment-4769494004))에서 지적한 P2/P3 follow-up fix.

## 변경

### Fix 1 — test 이름-단언-fixture 삼중 모순 정정 (P2)
`test_compute_context_ratio_does_not_infer_provider_budget` → `test_compute_context_ratio_resolves_budget_and_clamps_at_ceiling`.
- 이름 "does not imply context budget"는 #22080 stub→resolve 전환과 정면 모순(이제 budget을 resolve함).
- 단언 문자열 `"model/provider label does not imply..."` → `"resolved budget clamps an over-budget ratio to 1.0"`.
- fixture에 `last_input_tokens = 2_106_223`이 over-budget(→ clamp 1.0)임을 주석 명시.

### Fix 4 — `models_resolved` dead surface 제거 (P3)
- FE(`dashboard/src`)가 `models_resolved`를 0건 참조, 백엔드 2곳(`keeper_status_detail.ml`, `dashboard_http_keeper.ml`)만 emit.
- `models`와 `models_resolved`가 동일 `configured_model_labels_of_meta` 값이었던 duplicate를 제거. `models`는 authoritative 값 유지, `models_resolved` emit + let binding 제거.

### Fix 2 — `next_model_hint` 정직 마킹 (P2, 근본 제약)
`next_model_hint_of_meta` stub에 정확한 주석: meta에 next_runtime 소스 필드가 없음. 진짜 소스는 `Keeper_unified_turn_cascade_resolution`/`Keeper_error_classify`의 `next_runtime`(degraded_retry)이나 meta에 persist 안 됨. emit은 forward-compatible 유지(resolver 구현 시 자동 활성화). dashboard는 이미 null을 "no hint"로 처리.

### Fix 3 — label 동일 RFC-0132 정합 문서화 (P2, 근본 제약)
`active_model_label_of_meta`에 주석: RFC-0132 redaction + `meta.usage`에 별도 model 필드 없음(`last_input_tokens`만) → `last_model_used_label`이 active와 동일값. 분리는 별도 작업.

## 근본 제약 (별도 작업 필요, 본 PR 범위 밖)

MANIFEST 원칙(근본 해결, 회피 거부)에 따라 솔직히 명시:

- **next_model_hint 실구현**: meta 스키마에 cascade `next_runtime`을 persist하도록 확장 + keeper turn rotation이 기록. 본 PR은 정직한 NOT-YET-IMPLEMENTED 마킹만.
- **label 분리**: `usage_metrics`에 model 필드 추가 + RFC-0132 carve-out 검토. 본 PR은 문서화만.

## 검증

- `dune build @check` EXIT=0 (전체 타입체크)
- `test_operator_control_snapshot` (Fix 1) 실행 통과
- `ocamlformat --check` 4파일 EXIT=0
- `models_resolved` / `next_model_hint` / `active_model_label` / `last_model_used_label` → `test/` 0건 (제거/문서화가 다른 test에 영향 없음 확인)

## 범위 밖

- `operator_control_context_snapshot.ml`의 #22077 P3(top-level + nested 필드 중복)은 본 PR에서 안 건드림(별개 사이트).

Co-Authored-By: Claude <noreply@anthropic.com>