### PR TITLE
refactor(dashboard): move theme switch from top bar to Settings › Display

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -28,7 +28,6 @@ import {
   ErrorCounterBadge,
   isKeeperDetailDashboardRoute,
 } from './components/dashboard-shell'
-import { ThemeSwitch } from './components/theme-switch'
 import { EmergencyStopControl } from './components/emergency-stop-control'
 import { AttentionIndicator } from './components/attention-indicator'
 import { TransportBeacon } from './components/transport-beacon'
@@ -410,7 +409,6 @@ export function App() {
             <${ConnectionStatus} />
             <${ErrorCounterBadge} />
             <div class="v2-desktop-header-only"><${TransportBeacon} /></div>
-            <div class="v2-desktop-header-only"><${ThemeSwitch} /></div>
             <div class="v2-desktop-header-only"><${TweaksPanelToggle} /></div>
             <div class="v2-desktop-header-only"><${BuildIdentityBadge} /></div>
           </div>

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -186,6 +186,17 @@ describe('SettingsSurface', () => {
     expect(container.querySelector('[data-testid="log-viewer"]')).not.toBeNull()
   })
 
+  it('renders the theme switch inside the display section (moved out of the top bar)', () => {
+    route.value = { tab: 'settings', params: { section: 'display' }, postId: null }
+
+    render(html`<${SettingsSurface} />`, container)
+
+    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('표시')
+    const themeButton = [...container.querySelectorAll('button')]
+      .find(b => /DARK|STYLESEED|PAPER/.test(b.textContent ?? ''))
+    expect(themeButton).toBeTruthy()
+  })
+
   it('falls invalid settings sections back to account without a fake subsection', () => {
     expect(normalizeSettingsSection('not-real')).toBe('account')
     route.value = { tab: 'settings', params: { section: 'not-real' }, postId: null }

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -13,6 +13,7 @@ import { navigate, route } from '../router'
 import { fetchDashboardTools, fetchLogs, fetchRuntimeDefaults } from '../api/dashboard.js'
 import type { DashboardToolInventoryItem, LogEntry, RuntimeDefaultsResponse } from '../api/dashboard.js'
 import { RuntimeTomlEditor } from './runtime-toml-editor'
+import { ThemeSwitch } from './theme-switch'
 import type { ComponentChildren } from 'preact'
 
 type SectionId = SettingsRouteSectionId
@@ -1117,6 +1118,9 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'display' && html`
+              <${SetRow} label="Theme" hint="Color palette — Dark / StyleSeed / Paper">
+                <${ThemeSwitch} />
+              <//>
               <${SetRow} label="Density" hint="List/card spacing">
                 <${SetSeg} value=${density} options=${['compact', 'regular']} onChange=${setDensity} />
               <//>


### PR DESCRIPTION
## 목표

상단바 정리(디자인 결정 #1): DARK/StyleSeed/Paper 테마 토글을 **상단바 → 설정 › 표시(Display)**로 이동. 버전 배지·WS 비콘은 상단바에 **유지**.

## 변경

- `app.ts` — 헤더의 `<ThemeSwitch/>`(v2-desktop-header-only) 제거 + 미사용 import 제거. TransportBeacon(WS)·BuildIdentityBadge(버전)·TweaksPanelToggle은 유지.
- `settings-surface.ts` — display 섹션 최상단에 "Theme" 행(`<ThemeSwitch/>`) 추가 + import.
- `settings-surface.test.ts` — display 섹션에 theme switch 렌더 회귀 테스트.

## 검증 (로컬)
- `tsc --noEmit`: 에러 0
- `vitest run` (app + settings-surface + theme-switch): 64/64 통과
- `eslint`: 에러 0

## 비고
ThemeSwitch 컴포넌트 자체(테마 사이클 로직)는 변경 없음 — 렌더 위치만 이동.
