### PR TITLE
feat(fusion): add conditional topology — escalate to refine only when judge is insufficient

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -56,38 +56,50 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
               ~question:req.Fusion_types.prompt ~panel ~web_tools:judge_web_tools
               ~max_tool_calls:judge_max_tool_calls ()
           in
+          (* refine 헬퍼: 1차 종합 (s1,u1)을 2차 심판이 재검토하고 두 usage를 합산한다.
+             2차 실패면 1차 종합으로 graceful degrade(Simple보다 절대 나빠지지 않음 —
+             단 silent 아님: warn 로깅). Refine(무조건)와 Conditional(Insufficient일 때만)이
+             공유한다 — 같은 변환을 두 번 짜지 않는다(N-of-M 회피). *)
+          let refine_over (s1, u1) =
+            match
+              Fusion_judge.run_refine ~sw ~net
+                ~timeout_s:preset.Fusion_policy.judge_timeout_s
+                ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+                ~judge_model:preset.Fusion_policy.judge
+                ~question:req.Fusion_types.prompt ~panel ~prior:s1
+                ~web_tools:judge_web_tools ~max_tool_calls:judge_max_tool_calls ()
+            with
+            | Ok (s2, u2) -> Ok (s2, Fusion_types.add_usage u1 u2)
+            | Error (msg, u2) ->
+              (* 2차 심판이 토큰을 태운 뒤 파싱 실패해도 그 usage(u2)를 버리지 않고
+                 1차와 합산한다 — degrade가 비용을 undercount하지 않도록 (적대 리뷰
+                 #22087 §1). run_refine 이 #22087 에서 Error of (string * usage) 로
+                 바뀌었으므로 conditional 의 refine_over 도 동일하게 usage 를 보존한다. *)
+              Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
+                "fusion run %s refine judge failed, keeping first synthesis: %s"
+                req.Fusion_types.run_id msg;
+              Ok (s1, Fusion_types.add_usage u1 u2)
+          in
           (* 위상별 reduce. Simple은 1차 종합 그대로(현행과 byte-identical — downstream
-             judge/judge_usage/emit 동일). Refine는 1차 종합을 2차 심판이 재검토한다:
-             1차 실패면 refine할 종합이 없어 그대로 전파(Simple과 동일 에러 의미),
-             2차 실패면 1차 종합으로 graceful degrade(REFINE이 Simple보다 절대 나빠지지
-             않음 — 다만 silent 아님: warn 로깅). 두 심판 usage는 [add_usage]로 합산.
-             닫힌 합 exhaustive match라 새 위상 추가 시 컴파일 에러로 누락을 강제한다. *)
+             judge/judge_usage/emit 동일). Refine는 무조건 refine. Conditional은 1차 판정이
+             [Insufficient](애매)일 때만 refine, 그 외엔 1차 종합 그대로(= Simple). 1차 심판
+             실패는 어느 위상이든 그대로 전파(refine할 종합이 없음 = Simple과 동일 에러 의미).
+             topology·decision 둘 다 닫힌 합 exhaustive match라 새 변형 추가 시 컴파일 에러로
+             누락(위상 dispatch / escalate 정책)을 강제한다 — catch-all 없음. *)
           let judge_full =
             match topology with
             | Fusion_types.Simple -> first_judge_full
             | Fusion_types.Refine ->
               (match first_judge_full with
                | Error _ as e -> e
-               | Ok (s1, u1) ->
-                 (match
-                    Fusion_judge.run_refine ~sw ~net
-                      ~timeout_s:preset.Fusion_policy.judge_timeout_s
-                      ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                      ~judge_model:preset.Fusion_policy.judge
-                      ~question:req.Fusion_types.prompt ~panel ~prior:s1
-                      ~web_tools:judge_web_tools
-                      ~max_tool_calls:judge_max_tool_calls ()
-                  with
-                  | Ok (s2, u2) -> Ok (s2, Fusion_types.add_usage u1 u2)
-                  | Error (msg, u2) ->
-                    (* 2차 심판이 토큰을 태운 뒤 파싱 실패해도 그 usage(u2)를 버리지
-                       않고 1차와 합산한다 — degrade가 비용을 undercount하지 않도록
-                       (적대 리뷰 #22087 §1). 종합은 1차로 graceful degrade. *)
-                    Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                      "fusion run %s refine judge failed, keeping first synthesis: \
-                       %s"
-                      req.Fusion_types.run_id msg;
-                    Ok (s1, Fusion_types.add_usage u1 u2)))
+               | Ok pair -> refine_over pair)
+            | Fusion_types.Conditional ->
+              (match first_judge_full with
+               | Error _ as e -> e
+               | Ok ((s1, _) as pair) ->
+                 if Fusion_types.decision_warrants_escalation s1.Fusion_types.decision
+                 then refine_over pair
+                 else Ok pair)
           in
           (* 심판 종합과 토큰 usage를 분리: outcome.judge는 synthesis만(소비자 호환),
              usage는 sink 비용 회계로(RFC §10 패널N+심판M). 심판 실패 시에도 소비한

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -22,9 +22,11 @@ type outcome =
     + [Allow]면 preset의 패널 모델로 [Fusion_panel.run], judge 모델로 [Fusion_judge.run].
       패널/심판 system prompt와 타임아웃은 preset(=config)에서 온다 — 코드 default 없음.
     + [topology]에 따라 reduce 위상을 고른다: [Simple]은 panel→judge→sink(현행),
-      [Refine]은 panel→judge→judge'(1차 종합 재검토)→sink. [Refine]에서 1차 심판이
-      실패하면 [Simple]과 동일하게 에러를 전파하고, 2차 심판이 실패하면 1차 종합으로
-      graceful degrade한다(warn 로깅). 두 심판 usage는 합산해 sink로 보낸다.
+      [Refine]은 panel→judge→judge'(1차 종합 재검토)→sink, [Conditional]은 1차 판정이
+      [Insufficient]일 때만 refine하고 그 외엔 [Simple]처럼 1차 종합 그대로
+      ([Fusion_types.decision_warrants_escalation]). 1차 심판이 실패하면 어느 위상이든
+      [Simple]과 동일하게 에러를 전파하고, refine(2차) 심판이 실패하면 1차 종합으로
+      graceful degrade한다(warn 로깅). refine한 경우 두 심판 usage는 합산해 sink로 보낸다.
     + [Fusion_sink.emit]으로 트랜스크립트를 키퍼 chat lane에 기록. 실패면 [Sink_failed].
     + [Completed]로 패널/심판 결과 반환. *)
 val run

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -154,11 +154,15 @@ type gate_decision =
 type fusion_topology =
   | Simple  (** panel → judge → sink (현행, byte-identical) *)
   | Refine  (** panel → judge → judge'(1차 종합을 재검토) → sink *)
+  | Conditional
+      (** panel → judge → (1차 판정이 [Insufficient]일 때만) judge'(refine) → sink.
+          애매할 때만 한 단계 더 깊이; 그 외엔 1차 종합 그대로. *)
 [@@deriving yojson, show, eq]
 
 let fusion_topology_to_string = function
   | Simple -> "simple"
   | Refine -> "refine"
+  | Conditional -> "conditional"
 
 (* [to_string]의 역함수, 닫힌 합 밖은 [None]=fail-closed (Unknown→permissive 회피).
    keeper 입력 문자열을 typed 위상으로 parse한 뒤 exhaustive match하게 한다. round-trip은
@@ -166,12 +170,28 @@ let fusion_topology_to_string = function
 let fusion_topology_of_string = function
   | "simple" -> Some Simple
   | "refine" -> Some Refine
+  | "conditional" -> Some Conditional
   | _ -> None
 
-let all_fusion_topologies : fusion_topology list = [ Simple; Refine ]
+(* 수동 나열 — 컴파일러 강제가 아니다. [fusion_topology] 에 변형을 추가하면 위쪽
+   match 들(예: [fusion_topology_of_string], [decision_warrants_escalation])은 컴파일
+   에러로 누락을 강제하지만, 이 리스트는 자동 갱신되지 않는다. 드리프트는
+   [test/fusion_core/test_fusion.ml :: topology wire_strings / roundtrip] 가 핀으로
+   잡는다(컴파일러가 아니라 테스트 의존). 더 엄격히 가려면 [ppx_deriving.enumerate]
+   로 컴파일러 생성 — 추적: jeong-sik/masc#22116. *)
+let all_fusion_topologies : fusion_topology list = [ Simple; Refine; Conditional ]
 
 let all_fusion_topology_strings : string list =
   List.map fusion_topology_to_string all_fusion_topologies
+
+(* Conditional 위상의 에스컬레이트 정책: 1차 심판 판정이 더 깊은 심의를 요하는가.
+   [Insufficient](패널이 결정에 부족 = 애매)면 escalate, [Answer]/[Recommend](결론 있음)이면
+   1차 종합 유지. 닫힌 합 exhaustive match(catch-all 없음) — 새 decision 변형 추가 시 여기서
+   컴파일 에러로 escalate 정책을 명시 갱신하게 강제한다. confidence "축"을 새로 만들어 역분류하지
+   않고(reverse-classifier 회피) 기존 닫힌 합을 직접 본다. 순수 — 테스트 가능. *)
+let decision_warrants_escalation = function
+  | Insufficient _ -> true
+  | Answer _ | Recommend _ -> false
 
 (* 1차 심판 종합을 refine 심판 프롬프트에 실어 보낼 lossless 텍스트 렌더. judge_synthesis의
    7필드 + 닫힌 합 decision을 모두 보존한다(CLAUDE.md 워크어라운드 #2 "두 개념을 한 string

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -205,6 +205,9 @@ type gate_decision =
 type fusion_topology =
   | Simple  (** panel → judge → sink (현행, byte-identical) *)
   | Refine  (** panel → judge → judge'(1차 종합을 재검토) → sink *)
+  | Conditional
+      (** panel → judge → (1차 판정이 [Insufficient]일 때만) judge'(refine) → sink.
+          애매할 때만 한 단계 더 깊이; 그 외엔 1차 종합 그대로(= Simple). *)
 [@@deriving yojson, show, eq]
 
 (** 안정적 wire 문자열 ([masc_fusion] 도구 인자·로깅용). *)
@@ -220,6 +223,11 @@ val all_fusion_topologies : fusion_topology list
 
 (** [all_fusion_topologies]의 wire 문자열 (도구 인자 허용값 목록). *)
 val all_fusion_topology_strings : string list
+
+(** [Conditional] 위상의 에스컬레이트 정책. 1차 심판 [decision]이 더 깊은 심의를 요하면
+    [true]. v1: [Insufficient]만 [true]([Answer]/[Recommend]는 [false]). 닫힌 합
+    exhaustive — 새 [judge_decision] 변형 추가 시 컴파일 에러로 정책 갱신을 강제한다. *)
+val decision_warrants_escalation : judge_decision -> bool
 
 (** 1차 심판 종합을 refine 심판 프롬프트에 실을 lossless 텍스트로 렌더한다.
     [judge_synthesis]의 7필드 + 닫힌 합 [decision]을 모두 보존한다(resolved_answer 한 줄로

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -789,8 +789,10 @@ let masc_fusion_schema =
         "How to reduce the panel answers. \"simple\" (default): panel -> one \
          judge -> result. \"refine\": panel -> judge -> a second judge that \
          critically reviews and improves the first synthesis against the panel \
-         evidence -> result (deeper, two judge passes). Unknown values are \
-         rejected."
+         evidence -> result (deeper, two judge passes). \"conditional\": like \
+         simple, but escalates to a second (refine) judge only when the first \
+         judge could not decide (verdict insufficient); otherwise returns the \
+         first synthesis. Unknown values are rejected."
     ]
 ;;
 

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -785,7 +785,18 @@ let test_topology_unknown_is_none () =
 (* wire vocabulary 핀 — 도구 스키마 허용값/에러 메시지가 이 목록에서 파생된다. *)
 let test_topology_strings () =
   Alcotest.(check (list string))
-    "all topology wire strings" [ "simple"; "refine" ] all_fusion_topology_strings
+    "all topology wire strings"
+    [ "simple"; "refine"; "conditional" ]
+    all_fusion_topology_strings
+
+(* Conditional 에스컬레이트 정책 — 닫힌 합 전수 값-핀. Insufficient만 escalate. *)
+let test_escalation_policy () =
+  Alcotest.(check bool) "Insufficient escalates" true
+    (decision_warrants_escalation (Insufficient { missing_for_decision = [ "x" ] }));
+  Alcotest.(check bool) "Answer does not escalate" false
+    (decision_warrants_escalation (Answer "done"));
+  Alcotest.(check bool) "Recommend does not escalate" false
+    (decision_warrants_escalation (Recommend { action = "a"; rationale = "r" }))
 
 (* ---- render_prior_synthesis (refine 프롬프트 입력) --------------------- *)
 
@@ -941,6 +952,7 @@ let () =
       , [ Alcotest.test_case "roundtrip" `Quick test_topology_roundtrip
         ; Alcotest.test_case "unknown_is_none" `Quick test_topology_unknown_is_none
         ; Alcotest.test_case "wire_strings" `Quick test_topology_strings
+        ; Alcotest.test_case "escalation_policy" `Quick test_escalation_policy
         ; Alcotest.test_case "render_lossless_fields" `Quick test_render_lossless_fields
         ; Alcotest.test_case "render_decision_answer" `Quick test_render_decision_answer
         ; Alcotest.test_case "render_decision_recommend" `Quick


### PR DESCRIPTION
## 무엇을 / 왜

Fusion topology에 세 번째 위상 `conditional` 추가 — "애매할 때만 더 깊이". 1차 심판 판정이 `Insufficient`(패널이 결정에 부족)일 때만 2차(refine) 심판으로 에스컬레이트하고, `Answer`/`Recommend`(결론 있음)면 1차 종합 그대로 반환한다.

"Fusion as a Tool" 의 세 합성 원시 중 **분기(branch)**. (슬라이스 1 = `refine` = 순차 합성, 이 슬라이스 = `conditional` = 데이터 의존 분기. 다음 = `judge_of_judges` = 병렬 fan-out.)

> **Stacked PR**: base = `feat/fusion-topology-refine` (#22087). 슬라이스 1의 `fusion_topology`/`run_refine`/`render_prior_synthesis` 를 재사용한다. #22087 머지 후 이 브랜치를 main에 rebase한다.

## 어떻게

- `fusion_core/fusion_types`: `fusion_topology` 에 `Conditional` 추가(of_string/to_string/all 동기). 새 순수 함수 `decision_warrants_escalation : judge_decision -> bool` — 에스컬레이트 정책을 한 곳에 모은 **닫힌 합 exhaustive match**(`Insufficient -> true`, `Answer`/`Recommend -> false`, catch-all 없음). confidence "축"을 새로 만들어 역분류하지 않고 기존 닫힌 합을 직접 본다(reverse-classifier 회피).
- `fusion/fusion_orchestrator`: `refine_over` 헬퍼 추출 — Refine(무조건)와 Conditional(escalate일 때만)이 공유(N-of-M 회피). `Conditional` 분기는 `decision_warrants_escalation` 으로 1차 판정을 보고 escalate 여부 결정.
- `keeper/keeper_tool_descriptor`: `masc_fusion` 스키마 `topology` 설명에 `conditional` 추가.

## 재귀/usage

- 고정 1단계 에스컬레이트(judge1 + refine judge = 최대 2회) — 재귀 아님, depth 카운터 불필요.
- escalate 시 두 심판 usage 합산(`add_usage`), 아니면 1차 usage만. refine 실패 시 1차 종합 fallback(warn, silent 아님) — 슬라이스 1과 동일.

## 테스트

`test/fusion_core/test_fusion.ml`:
- `escalation_policy`: `decision_warrants_escalation` 전수 값-핀(Insufficient→true, Answer/Recommend→false). 에스컬레이트 정책이 닫힌 합 위에서 회귀-보호됨.
- `topology roundtrip`/`wire_strings`: `Conditional` 자동 포함(round-trip은 `all_fusion_topologies` 순회), wire 목록 `["simple"; "refine"; "conditional"]`.

**테스트 못 하는 것(정직)**: orchestrator dispatch(escalate 시 실제 2-judge 실행)는 OAS/creds 필요 → RFC-0252 §11 하네스 영역. 에스컬레이트 *판정*(순수)만 핀했고, *실행*은 통합.

## 안티패턴 self-check

- catch-all 추가: 없음. `decision_warrants_escalation`·orchestrator dispatch 모두 exhaustive.
- string 분류기/텔레메트리-as-fix/cap-cooldown: 해당 없음.
- N-of-M: `refine_over` 공유로 refine 변환을 한 번만 작성.
- 새 confidence 축 역분류: 회피 — 기존 닫힌 합 `judge_decision` 직접 match.

## 범위 밖(보호)

- `simple`/`refine` 경로 동작 불변. `fusion_request` 타입·`Fusion_judge` 시그니처 불변.
- `judge_of_judges`(병렬 judge fan-out, preset judge 목록 = RFC-class)는 후속 슬라이스.

RFC-0252 §13 P2 (Fusion as a Tool — 합성-by-selection, branch 원시).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
