### PR TITLE
fix(dashboard): 메인 surface 중앙 정렬 제거 — full-width 좌측 정렬 통일

### DIFF
--- a/dashboard/src/styles/cockpit-v2.css
+++ b/dashboard/src/styles/cockpit-v2.css
@@ -127,8 +127,9 @@
 }
 
 .cp-inner {
-  max-width: 1080px;
-  margin: 0 auto;
+  /* Full-width, left-aligned — consistency rationale in .ov-scroll
+     (surfaces-v2.css). Prototype centers this in a 1080px column; overridden
+     per design direction. */
   display: flex;
   flex-direction: column;
   gap: var(--gap-card);

--- a/dashboard/src/styles/decenter-surfaces.test.ts
+++ b/dashboard/src/styles/decenter-surfaces.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { declarationsForSelector } from './css-test-utils'
+
+// Regression guard: the main surface containers must not re-introduce a centered
+// max-width column. They fill the content area full-width and align left, to
+// match the other surfaces (board / monitoring / command / lab / ide), which
+// have no centered column. This is an intentional divergence from the v2
+// prototype, which centers .ov-scroll and .cp-inner; per design direction the
+// dashboard overrides that for cross-surface consistency. If a prototype
+// re-sync re-adds `margin: 0 auto` + `max-width`, these tests fail on purpose.
+//
+// Reading-width columns (.thread-inner / .kw-thread-inner / .composer-inner at
+// 980px) are a separate reading-line-length concern and intentionally stay
+// centered — they are not covered here.
+
+const read = (file: string): string => readFileSync(resolve(__dirname, file), 'utf-8')
+
+describe('main surfaces are full-width (no centered max-width column)', () => {
+  it('.ov-scroll (overview) fills width and does not center', () => {
+    const d = declarationsForSelector(read('surfaces-v2.css'), '.ov-scroll')
+    expect(d['max-width']).toBeUndefined()
+    expect(d.margin).toBeUndefined()
+    expect(d.width).toBe('100%')
+  })
+
+  it('.wk-inner (work) fills width and does not center', () => {
+    const d = declarationsForSelector(read('work-v2.css'), '.wk-inner')
+    expect(d['max-width']).toBeUndefined()
+    expect(d.margin).toBeUndefined()
+    expect(d.width).toBe('100%')
+  })
+
+  it('.cp-inner (cockpit) does not center', () => {
+    const d = declarationsForSelector(read('cockpit-v2.css'), '.cp-inner')
+    expect(d['max-width']).toBeUndefined()
+    expect(d.margin).toBeUndefined()
+    expect(d['flex-direction']).toBe('column')
+  })
+
+  it('reading-width columns stay centered (not affected)', () => {
+    const thread = declarationsForSelector(read('keeper-workspace.css'), '.kw-thread-inner')
+    expect(thread['max-width']).toContain('--kw-thread-w')
+    expect(thread.margin).toBe('0 auto')
+  })
+})

--- a/dashboard/src/styles/surfaces-v2.css
+++ b/dashboard/src/styles/surfaces-v2.css
@@ -203,9 +203,12 @@
   flex: 1;
   overflow-y: auto;
   padding: var(--pad-surface);
-  max-width: 1280px;
+  /* Full-width, left-aligned. Main surfaces fill the content area to match
+     board/monitoring/command/lab/ide (which have no centered column). This is
+     an intentional divergence from the v2 prototype, which centers .ov-scroll
+     in a 1280px column; overridden per design direction for cross-surface
+     consistency. Root: see .wk-inner (work-v2.css), .cp-inner (cockpit-v2.css). */
   width: 100%;
-  margin: 0 auto;
 }
 
 .ov-head {

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -35,9 +35,9 @@
 }
 
 .wk-inner {
-  max-width: 1280px;
+  /* Full-width, left-aligned — consistency rationale in .ov-scroll
+     (surfaces-v2.css). Prototype centers this; overridden per design direction. */
   width: 100%;
-  margin: 0 auto;
 }
 
 .wk-head {


### PR DESCRIPTION
## 문제

`디자인 개선` 중 보고: **다른 메뉴 main 레이아웃이 자꾸 다 가운데 정렬인 것도 이상함.**

대시보드 main surface 중 세 곳만 중앙 정렬 컬럼을 씁니다:

| Surface | selector | 기존 |
|---------|----------|------|
| Overview | `.ov-scroll` | `max-width: 1280px; margin: 0 auto` |
| Work | `.wk-inner` | `max-width: 1280px; margin: 0 auto` |
| Cockpit | `.cp-inner` | `max-width: 1080px; margin: 0 auto` |

나머지 surface(board/monitoring/command/lab/ide/connectors/logs/settings)는 **max-width 없이 full-width**입니다. 와이드 디스플레이(M3 Max 등 콘텐츠 영역 > 1280px)에서 위 3개만 좌우 gutter가 크게 생겨, board 등 full-width surface와 **시각적으로 불일치**합니다.

## 변경

- 세 컨테이너에서 `max-width` + `margin: 0 auto` 제거 → full-width 좌측 정렬. 나머지 surface와 동일한 정렬로 통일.
- 채팅 **읽기폭** 컬럼(`.kw-thread-inner`/`.composer-inner`, 980px)은 reading-line-length 목적의 별개 관심사 → **유지**(중앙 정렬 그대로).
- 각 사이트에 의도(프로토타입 divergence + 일관성) 주석 명기. rationale SSOT = `.ov-scroll`(surfaces-v2.css).

## 프로토타입 divergence (의도적)

v2 프로토타입은 `.ov-scroll`(1280px)·`.cp-inner`(1080px)을 **동일하게 중앙 정렬**합니다. 이번 변경은 사용자(디자인 리드)의 명시적 지시에 따라 cross-surface 일관성을 위해 프로토타입 parity를 의도적으로 override합니다. 회귀 테스트가 이 의도를 고정 — 추후 프로토타입 재동기화가 중앙 정렬을 되살리면 테스트가 실패합니다.

## 검증

- `decenter-surfaces.test.ts` 신규: 세 컨테이너에 `max-width`/`margin` 없음 + 읽기폭 컬럼은 중앙 정렬 유지 확인.
- 로컬: `tsc --noEmit` exit 0 · vitest 12/12(신규 4 포함) · eslint 0 errors.

> 로컬 OCaml 빌드 미실행(CSS-only). dashboard-only PR의 `Build and Test`(OCaml) fail은 conveyor 머지 취소 아티팩트일 수 있음 — 권위 게이트는 `Dashboard`(tsc+vitest).

RFC-WAIVED: dashboard CSS 레이아웃 정렬 변경 — credential/operator/keeper sandbox/hooks/workflow subsystem 무관.