### PR TITLE
fix(dashboard): 보드 2칼럼 기본 — detail 칼럼 on-demand 접힘 (#3)

### DIFF
--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -256,9 +256,25 @@ describe('BoardSurface Component', () => {
     expect(container.querySelector('.v2-board-surface')).not.toBeNull()
   })
 
-  it('shows the mention inbox detail rail by default', () => {
+  it('collapses the detail column by default (two-column rail + feed)', () => {
     const { container } = render(h(BoardSurface, null))
+    // No post selected and the mention inbox closed: neither detail rail is
+    // rendered and the grid track collapses to 0, leaving rail + feed. Matches
+    // the v2 prototype, which only expands the detail column on demand.
+    expect(container.querySelector('[data-testid="bd-mention-detail"]')).toBeNull()
+    expect(container.querySelector('[data-testid="bd-thread-detail"]')).toBeNull()
+    const surface = container.querySelector<HTMLElement>('.v2-board-surface')
+    const body = container.querySelector<HTMLElement>('.bd-body')
+    expect(surface?.getAttribute('data-detail-open')).toBe('false')
+    expect(body?.getAttribute('style')).toContain('--bd-detail-width: 0px')
+  })
+
+  it('opens the mention inbox detail rail from the rail queue action', () => {
+    const { container } = render(h(BoardSurface, null))
+    fireEvent.click(screen.getByTestId('bd-queue-mentions'))
     expect(container.querySelector('[data-testid="bd-mention-detail"]')).not.toBeNull()
+    const surface = container.querySelector<HTMLElement>('.v2-board-surface')
+    expect(surface?.getAttribute('data-detail-open')).toBe('true')
   })
 
   it('normalizes persisted Board detail rail widths to the supported range', () => {
@@ -272,6 +288,9 @@ describe('BoardSurface Component', () => {
     setLocalStorageItem(BOARD_DETAIL_WIDTH_STORAGE_KEY, JSON.stringify(430))
 
     const { container } = render(h(BoardSurface, null))
+    // The detail column is collapsed until opened; open the mention inbox so the
+    // persisted width hydrates the grid track and the resize handle renders.
+    fireEvent.click(screen.getByTestId('bd-queue-mentions'))
 
     const surface = container.querySelector<HTMLElement>('.v2-board-surface')
     const body = container.querySelector<HTMLElement>('.bd-body')
@@ -283,6 +302,8 @@ describe('BoardSurface Component', () => {
 
   it('resizes the Board detail rail with pointer drag and keyboard controls', async () => {
     const { container } = render(h(BoardSurface, null))
+    // Open the mention inbox so the detail rail (and its resize handle) renders.
+    fireEvent.click(screen.getByTestId('bd-queue-mentions'))
 
     const surface = container.querySelector<HTMLElement>('.v2-board-surface')
     const handle = screen.getByTestId('bd-detail-resize') as HTMLButtonElement
@@ -316,8 +337,8 @@ describe('BoardSurface Component', () => {
     ]
     render(h(BoardSurface, null))
 
-    const detail = screen.getByTestId('bd-mention-detail')
-    expect(detail).not.toHaveClass('is-mobile-open')
+    // Detail column is collapsed until the mention inbox is opened.
+    expect(screen.queryByTestId('bd-mention-detail')).toBeNull()
 
     const queues = screen.getByTestId('bd-mobile-queues')
     const mentionQueue = within(queues).getByTestId('bd-mobile-queue-mentions')
@@ -325,11 +346,12 @@ describe('BoardSurface Component', () => {
     expect(mentionQueue).toHaveTextContent('1')
 
     fireEvent.click(mentionQueue)
+    const detail = screen.getByTestId('bd-mention-detail')
     expect(detail).toHaveClass('is-mobile-open')
     expect(within(detail).getByText('@dashboard')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('멘션 인박스 닫기'))
-    expect(detail).not.toHaveClass('is-mobile-open')
+    expect(screen.queryByTestId('bd-mention-detail')).toBeNull()
   })
 
   it('keeps v2 workspace panels for category cards', () => {

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -732,14 +732,14 @@ function BdThreadDetail({
 function BdDetail({
   post,
   detailWidth,
-  mentionMobileOpen,
+  mentionsOpen,
   onDetailWidthChange,
   onClose,
   onCloseMentions,
 }: {
   post: BoardPost | null
   detailWidth: number
-  mentionMobileOpen: boolean
+  mentionsOpen: boolean
   onDetailWidthChange: (width: number) => void
   onClose: () => void
   onCloseMentions: () => void
@@ -752,8 +752,13 @@ function BdDetail({
       onClose=${onClose}
     />
   `
+  // No post selected and the mention inbox is closed: render nothing so the
+  // detail grid track collapses to 0 (two-column rail + feed). The mention
+  // inbox is reachable from the rail (bd-queue-mentions). Matches the v2
+  // prototype, which only expands the detail column on demand.
+  if (!mentionsOpen) return null
   return html`
-    <aside class=${`bd-detail is-mentions ${mentionMobileOpen ? 'is-mobile-open' : ''}`} data-testid="bd-mention-detail">
+    <aside class="bd-detail is-mentions is-mobile-open" data-testid="bd-mention-detail">
       <${BdDetailResizeHandle} width=${detailWidth} onWidthChange=${onDetailWidthChange} />
       <div class="bd-detail-h">
         <h3>멘션 인박스</h3>
@@ -1390,7 +1395,11 @@ function BdFeed({ posts, onMentions }: { posts: BoardPost[]; onMentions: () => v
 
 // ── Main Board component (public API) ──────────────────────────────
 export function BoardSurface() {
-  const [mobileMentionInboxOpen, setMobileMentionInboxOpen] = useState(false)
+  // The mention inbox opens on demand (from the rail's bd-queue-mentions button),
+  // on desktop and mobile alike. When neither a post nor the mention inbox is open
+  // the detail column collapses to a two-column rail + feed layout — see the
+  // --bd-detail-width computation below. Matches the standalone v2 prototype.
+  const [mentionInboxOpen, setMentionInboxOpen] = useState(false)
   const [detailWidth, setDetailWidth] = useState<number>(readStoredBoardDetailWidth)
   useEffect(() => () => { selectedPostIds.value = new Set() }, [])
   useEffect(() => registerBoardHearthsRefresh(() => {
@@ -1488,7 +1497,7 @@ export function BoardSurface() {
 
   function openMentionInbox(): void {
     selectedBoardPostId.value = null
-    setMobileMentionInboxOpen(true)
+    setMentionInboxOpen(true)
   }
 
   function setPersistentDetailWidth(width: number): void {
@@ -1497,18 +1506,24 @@ export function BoardSurface() {
     writeStoredBoardDetailWidth(normalized)
   }
 
+  // Detail column is reserved only when a post thread or the mention inbox is
+  // open; otherwise the grid track collapses to 0 (two-column rail + feed).
+  const detailOpen = !!selectedPost || mentionInboxOpen
+
   return html`
     <div
       class="v2-board-surface ss-surface bg-surface-page text-text-primary"
       data-detail-width=${String(detailWidth)}
+      data-detail-open=${String(detailOpen)}
     >
       <${SurfaceHeader} />
-      <div class="bd-body" style=${`--bd-detail-width: ${detailWidth}px;`}>
+      <div class="bd-body" style=${`--bd-detail-width: ${detailOpen ? detailWidth : 0}px;`}>
         <${BdRail}
           activeSub=${activeSub}
           onSub=${(sub: string) => {
             boardHearthFilter.value = sub
             selectedBoardPostId.value = null
+            setMentionInboxOpen(false)
             refreshBoard()
           }}
           onMentions=${openMentionInbox}
@@ -1517,10 +1532,10 @@ export function BoardSurface() {
         <${BdDetail}
           post=${selectedPost}
           detailWidth=${detailWidth}
-          mentionMobileOpen=${mobileMentionInboxOpen}
+          mentionsOpen=${mentionInboxOpen}
           onDetailWidthChange=${setPersistentDetailWidth}
           onClose=${() => { selectedBoardPostId.value = null }}
-          onCloseMentions=${() => setMobileMentionInboxOpen(false)}
+          onCloseMentions=${() => setMentionInboxOpen(false)}
         />
       </div>
     </div>


### PR DESCRIPTION
## 문제 (디자인 간극 #3)

보드가 **항상 3칼럼**(rail + feed + detail 360px)으로, detail 칼럼에 멘션 인박스를 **기본 표시**했습니다. v2 프로토타입은 보드를 **2칼럼**(rail + feed)으로 두고, detail 칼럼은 **on-demand로만** 펼칩니다(no-selection 시 grid track 0px).

브라우저 측정(프로토타입, vw=1604):
- `.bd-body` grid = `200px 1346px 0px` — detail track **0px**(접힘).
- 멘션 = 좌측 레일 채널(`＠멘션 인박스3`), 우측 detail 기본 점유 아님.

## 변경

대시보드 **모바일은 이미** 이 패턴(detail 기본 숨김 + 모바일 큐로 on-demand 오픈)을 구현 중이었음 → **데스크톱에도 동일 모델 적용**:

- `BdDetail`: post 선택 시 thread, 멘션 인박스 명시적 오픈 시 멘션, 그 외 **null**(접힘).
- `.bd-body`의 `--bd-detail-width` grid track: post나 멘션이 열렸을 때만 `detailWidth`, 아니면 **0**(`data-detail-open`으로 상태 노출).
- 멘션은 **레일 버튼**(`bd-queue-mentions`, unread count 유지)으로 접근 → 정보 손실 없음.

내부 상태 `mobileMentionInboxOpen` → `mentionInboxOpen`으로 일반화(데스크톱·모바일 공통 게이트).

## 검증

- `board-surface.test.ts`: 기본 접힘(detail 미렌더 + grid `--bd-detail-width: 0px` + `data-detail-open=false`), 레일/모바일 큐에서 오픈, persisted width + resize handle은 detail 오픈 후 hydrate. **58/58 통과**.
- `tsc --noEmit` exit 0 · eslint clean.

> 프로토타입 SSOT 준수(Vincent 확정). 이 변경은 프로토타입과 **일치** 방향(centering #22092와 달리 override 아님).

RFC-WAIVED: dashboard 보드 레이아웃 상태 변경 — credential/operator/keeper sandbox/hooks/workflow subsystem 무관.