### PR TITLE
fix(dashboard): keeper-v2 메인 surface full-width 좌측정렬 (centering override)

### DIFF
--- a/dashboard/src/styles/keeper-v2/surfaces.css
+++ b/dashboard/src/styles/keeper-v2/surfaces.css
@@ -73,7 +73,12 @@ body.rail-resizing .v2-body { transition: none; }
 
 /* ════ OVERVIEW ════ */
 .ov { display: flex; flex-direction: column; min-width: 0; min-height: 0; background: var(--bg-deep); }
-.ov-scroll { flex: 1; overflow-y: auto; padding: var(--pad-surface); max-width: 1280px; width: 100%; margin: 0 auto; }
+/* OVERRIDE (intentional divergence from prototype): full-width, left-aligned.
+   Overview and Work share .ov-scroll. The prototype centers it in a 1280px
+   column; per design direction the dashboard fills the content area to match
+   the other surfaces (board/monitoring/command/lab/ide). Do not re-add
+   max-width / margin:auto on a prototype re-sync. See .cp-inner below. */
+.ov-scroll { flex: 1; overflow-y: auto; padding: var(--pad-surface); width: 100%; }
 .ov-head { display: flex; align-items: flex-end; justify-content: space-between; margin-bottom: 18px; }
 .ov-head h1 { font-family: var(--font-display); font-weight: 500; font-size: 22px; color: var(--text-bright); margin: 0; }
 .ov-sub { margin-top: 5px; font-size: 12px; color: var(--text-dim); }
@@ -229,7 +234,9 @@ body.rail-resizing .v2-body { transition: none; }
 .cp-main { min-height: 0; overflow-y: auto; padding: var(--pad-surface); }
 .cp-main::-webkit-scrollbar { width: 9px; }
 .cp-main::-webkit-scrollbar-thumb { background: var(--border-main); border-radius: var(--radius-md); }
-.cp-inner { max-width: 1080px; margin: 0 auto; display: flex; flex-direction: column; gap: var(--gap-card); }
+/* OVERRIDE (intentional divergence from prototype): full-width, left-aligned —
+   the prototype centers this in a 1080px column. See .ov-scroll above. */
+.cp-inner { display: flex; flex-direction: column; gap: var(--gap-card); }
 
 .cp-modebar { display: flex; align-items: center; gap: 8px; }
 .cp-mode { display: flex; flex-direction: column; gap: 2px; align-items: flex-start; padding: 8px 14px; border-radius: var(--radius-sm); border: 1px solid var(--border-main); background: var(--bg-panel); color: var(--text-mid); cursor: pointer; font-family: var(--font-ui); transition: 0.15s; }

--- a/dashboard/src/styles/keeper-v2/surfaces.decenter.test.ts
+++ b/dashboard/src/styles/keeper-v2/surfaces.decenter.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { declarationsForSelector } from '../css-test-utils'
+
+// Regression guard: in the keeper-v2 skin (vendored prototype CSS SSOT), the main
+// surface containers fill the content area full-width instead of the prototype's
+// centered max-width column. Overview and Work share .ov-scroll; Cockpit uses
+// .cp-inner. This is an intentional, design-directed divergence from the
+// prototype — if a prototype re-sync re-adds `max-width` + `margin: 0 auto`,
+// these tests fail on purpose.
+
+const css = readFileSync(resolve(__dirname, 'surfaces.css'), 'utf-8')
+
+describe('keeper-v2 main surfaces are full-width (no centered column)', () => {
+  it('.ov-scroll (overview + work) fills width and does not center', () => {
+    const d = declarationsForSelector(css, '.ov-scroll')
+    expect(d['max-width']).toBeUndefined()
+    expect(d.margin).toBeUndefined()
+    expect(d.width).toBe('100%')
+  })
+
+  it('.cp-inner (cockpit) does not center', () => {
+    const d = declarationsForSelector(css, '.cp-inner')
+    expect(d['max-width']).toBeUndefined()
+    expect(d.margin).toBeUndefined()
+    expect(d['flex-direction']).toBe('column')
+  })
+})


### PR DESCRIPTION
keeper-v2 스킨(#22081 머지됨)에서 Overview/Work(.ov-scroll 공유)·Cockpit(.cp-inner)이 max-width 컬럼(1280/1080px)으로 중앙정렬 → 와이드 디스플레이서 board 등 full-width surface와 불일치. max-width+margin:0 auto 제거 → full-width 좌측정렬. 프로토타입과 의도적 divergence(Vincent 확정: '좌측정렬이 맞다'), 인라인 OVERRIDE 주석+회귀테스트(surfaces.decenter.test.ts 2/2)로 재동기화 방지. tsc 0. 이전 origin/main 시도 #22092(closed, 삭제예정 레거시 surfaces-v2.css 수정)의 올바른 재작업. RFC-WAIVED: dashboard CSS 레이아웃.