### PR TITLE
fix(dashboard): actually decenter main surfaces — remove legacy *-v2.css centering that overrides #22098

### DIFF
--- a/dashboard/src/styles/cockpit-v2.css
+++ b/dashboard/src/styles/cockpit-v2.css
@@ -127,8 +127,9 @@
 }
 
 .cp-inner {
-  max-width: 1080px;
-  margin: 0 auto;
+  /* Full-width, left-aligned — consistency rationale in .ov-scroll
+     (surfaces-v2.css). Prototype centers this in a 1080px column; overridden
+     per design direction. */
   display: flex;
   flex-direction: column;
   gap: var(--gap-card);

--- a/dashboard/src/styles/decenter-surfaces.test.ts
+++ b/dashboard/src/styles/decenter-surfaces.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { declarationsForSelector } from './css-test-utils'
+
+// Regression guard: the main surface containers must not re-introduce a centered
+// max-width column. They fill the content area full-width and align left, to
+// match the other surfaces (board / monitoring / command / lab / ide), which
+// have no centered column. This is an intentional divergence from the v2
+// prototype, which centers .ov-scroll and .cp-inner; per design direction the
+// dashboard overrides that for cross-surface consistency. If a prototype
+// re-sync re-adds `margin: 0 auto` + `max-width`, these tests fail on purpose.
+//
+// Reading-width columns (.thread-inner / .kw-thread-inner / .composer-inner at
+// 980px) are a separate reading-line-length concern and intentionally stay
+// centered — they are not covered here.
+
+const read = (file: string): string => readFileSync(resolve(__dirname, file), 'utf-8')
+
+describe('main surfaces are full-width (no centered max-width column)', () => {
+  it('.ov-scroll (overview) fills width and does not center', () => {
+    const d = declarationsForSelector(read('surfaces-v2.css'), '.ov-scroll')
+    expect(d['max-width']).toBeUndefined()
+    expect(d.margin).toBeUndefined()
+    expect(d.width).toBe('100%')
+  })
+
+  it('.wk-inner (work) fills width and does not center', () => {
+    const d = declarationsForSelector(read('work-v2.css'), '.wk-inner')
+    expect(d['max-width']).toBeUndefined()
+    expect(d.margin).toBeUndefined()
+    expect(d.width).toBe('100%')
+  })
+
+  it('.cp-inner (cockpit) does not center', () => {
+    const d = declarationsForSelector(read('cockpit-v2.css'), '.cp-inner')
+    expect(d['max-width']).toBeUndefined()
+    expect(d.margin).toBeUndefined()
+    expect(d['flex-direction']).toBe('column')
+  })
+
+  it('reading-width columns stay centered (not affected)', () => {
+    const thread = declarationsForSelector(read('keeper-workspace.css'), '.kw-thread-inner')
+    expect(thread['max-width']).toContain('--kw-thread-w')
+    expect(thread.margin).toBe('0 auto')
+  })
+})

--- a/dashboard/src/styles/surfaces-v2.css
+++ b/dashboard/src/styles/surfaces-v2.css
@@ -203,9 +203,12 @@
   flex: 1;
   overflow-y: auto;
   padding: var(--pad-surface);
-  max-width: 1280px;
+  /* Full-width, left-aligned. Main surfaces fill the content area to match
+     board/monitoring/command/lab/ide (which have no centered column). This is
+     an intentional divergence from the v2 prototype, which centers .ov-scroll
+     in a 1280px column; overridden per design direction for cross-surface
+     consistency. Root: see .wk-inner (work-v2.css), .cp-inner (cockpit-v2.css). */
   width: 100%;
-  margin: 0 auto;
 }
 
 .ov-head {

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -35,9 +35,9 @@
 }
 
 .wk-inner {
-  max-width: 1280px;
+  /* Full-width, left-aligned — consistency rationale in .ov-scroll
+     (surfaces-v2.css). Prototype centers this; overridden per design direction. */
   width: 100%;
-  margin: 0 auto;
 }
 
 .wk-head {


### PR DESCRIPTION
## 무엇을 / 왜

Overview·Work(`​.ov-scroll`)·Cockpit(`.cp-inner`)·Work(`.wk-inner`) main surface가 wide 디스플레이에서 **중앙정렬(max-width 1280/1080px + margin:0 auto)** 되어 다른 full-width surface와 어긋나는 회귀를 고칩니다. 좌측정렬은 design lead(Vincent)가 명시 지시한 결정입니다(원본 #22092, big-bang reskin #22081 머지로 closed).

## #22098이 이 회귀를 못 고친 이유 (per-property cascade)

#22098이 같은 의도로 머지됐으나 **런타임에 무효**입니다 — 직접 그라운딩:

- #22098은 **신규** `dashboard/src/styles/keeper-v2/surfaces.css`의 `.ov-scroll`에서 max-width/margin을 제거했습니다(`​.ov-scroll { flex; overflow-y; padding; width:100% }` — 둘 다 **선언 생략**).
- 그러나 **legacy** `dashboard/src/styles/surfaces-v2.css:202`의 `.ov-scroll`은 **여전히** `max-width:1280px; margin:0 auto`를 **선언**하고, 이 파일은 main에 그대로 존재하며 `main.ts:79` `import.meta.glob('./styles/*-v2.css',{eager:true})`로 로드됩니다(키퍼-v2는 `main.ts:92`에서 그 *뒤에* 로드).
- CSS cascade는 **속성별**입니다. 나중 규칙(keeper-v2)이 `max-width`/`margin`을 **생략**해도 이전 규칙(legacy)의 그 속성을 **reset하지 않습니다**. `@layer`·`!important` 없음, specificity 동일(`.ov-scroll` 0,1,0). 따라서:
  - `max-width`: legacy만 선언 → **1280px 적용**
  - `margin`: legacy만 선언 → **0 auto 적용** → **여전히 중앙정렬**
- #22098의 가드 `keeper-v2/surfaces.decenter.test.ts`는 keeper-v2 *파일 내용*이 max-width 없음을 단언해 **통과**하지만, 실제 computed style(legacy가 이김)을 반영하지 못합니다 → **test green인데 production 중앙정렬**.

근본 전제 오류: #22098 커밋 메시지의 "the legacy surfaces-v2.css that this reskin removes" — **#22081은 legacy `*-v2.css`를 제거하지 않았습니다**(surfaces-v2/cockpit-v2/work-v2 전부 잔존 + glob 로드). 닫힌 #22092의 closure 사유도 같은 거짓 전제였습니다.

## 어떻게

승리하는 **legacy** 선언을 제거합니다(= 원본 #22092 변경을 현재 main에 cherry-pick, 4개 CSS 타깃이 base와 byte-identical이라 zero-conflict):

- `surfaces-v2.css` `.ov-scroll` / `work-v2.css` `.wk-inner`: `max-width` + `margin:0 auto` 제거, `width:100%` 유지 + 의도 주석.
- `cockpit-v2.css` `.cp-inner`: `max-width:1080px` + `margin:0 auto` 제거.
- 이제 legacy·keeper-v2 양쪽 모두 centering 선언이 없으므로 cascade 결과가 **decentered**가 됩니다(#22098의 keeper-v2 변경도 비로소 유효해짐).
- 신규 `decenter-surfaces.test.ts`: **legacy 파일**의 세 셀렉터에 max-width/margin 없음을 단언(= #22098 test가 비운 사각 — runtime을 결정하는 파일을 가드). 읽기폭 컬럼(`.kw-thread-inner`, keeper-workspace.css)은 reading-line-length 목적이라 **centered 유지**를 함께 핀.

## 범위 밖 / 후속

- legacy `*-v2.css`와 `keeper-v2/*`의 **중복 셀렉터 정의**(split-brain)는 `main.ts:114`의 migration plan으로 정리 예정. 이 PR은 회귀를 즉시 끊고, 두 파일 모두 non-centering으로 만들어 load-order 의존성을 제거합니다.
- 동작 변경은 세 surface 컨테이너의 정렬뿐. 다른 surface·읽기폭 컬럼 불변.

## 검증

- 로컬 빌드 미실행(CSS-only, "로컬 빌드 금지"). 4-file diff + cascade 분석을 fresh clone(main `af959bf`)에서 직접 그라운딩.
- `decenter-surfaces.test.ts`가 회귀 가드(legacy 파일 max-width/margin 없음 + 읽기폭 유지). CI의 `Dashboard`(tsc+vitest)가 권위.

RFC-WAIVED: dashboard CSS 레이아웃 정렬 — credential/operator/keeper sandbox/hooks/workflow subsystem 무관.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
