### PR TITLE
refactor(dashboard): give orphaned ThemeSwitch a home in Settings - Display (re-stack of #22089)

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -186,6 +186,17 @@ describe('SettingsSurface', () => {
     expect(container.querySelector('[data-testid="log-viewer"]')).not.toBeNull()
   })
 
+  it('renders the theme switch inside the display section (moved out of the top bar)', () => {
+    route.value = { tab: 'settings', params: { section: 'display' }, postId: null }
+
+    render(html`<${SettingsSurface} />`, container)
+
+    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('표시')
+    const themeButton = [...container.querySelectorAll('button')]
+      .find(b => /DARK|STYLESEED|PAPER/.test(b.textContent ?? ''))
+    expect(themeButton).toBeTruthy()
+  })
+
   it('falls invalid settings sections back to account without a fake subsection', () => {
     expect(normalizeSettingsSection('not-real')).toBe('account')
     route.value = { tab: 'settings', params: { section: 'not-real' }, postId: null }

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -13,6 +13,7 @@ import { navigate, route } from '../router'
 import { fetchDashboardTools, fetchLogs, fetchRuntimeDefaults } from '../api/dashboard.js'
 import type { DashboardToolInventoryItem, LogEntry, RuntimeDefaultsResponse } from '../api/dashboard.js'
 import { RuntimeTomlEditor } from './runtime-toml-editor'
+import { ThemeSwitch } from './theme-switch'
 import type { ComponentChildren } from 'preact'
 
 type SectionId = SettingsRouteSectionId
@@ -1119,6 +1120,9 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'display' && html`
+              <${SetRow} label="Theme" hint="Color palette — Dark / StyleSeed / Paper">
+                <${ThemeSwitch} />
+              <//>
               <${SetRow} label="Density" hint="List/card spacing">
                 <${SetSeg} value=${density} options=${['compact', 'regular']} onChange=${setDensity} />
               <//>


### PR DESCRIPTION
## 무엇을 / 왜

DARK/StyleSeed/Paper 3-way 테마 토글(`ThemeSwitch`)을 **설정 › 표시(Display)**에 둡니다. 빅뱅 reskin #22081 이후 main에서 `ThemeSwitch`는 **어떤 UI에도 마운트되지 않은 orphan** 상태입니다 — TopBarV2(`top-bar-v2.ts`)는 ThemeSwitch를 안 싣고, settings-surface display 섹션엔 Density/Language/Timezone만 있으며, 3-way 테마 전환은 `?theme=` URL 파라미터/localStorage로만 도달 가능합니다(Tweaks 패널의 paper 토글은 paper만 켜고 끔). 원본 #22089가 reskin과 충돌해 closed됐습니다.

## 어떻게 (re-stack)

- **app.ts 절반은 폐기**: #22089의 "top bar에서 ThemeSwitch 제거"는 **이미 #22081이 달성**(TopBarV2가 ThemeSwitch 미포함, main app.ts에 ThemeSwitch 참조 0건). cherry-pick의 app.ts hunk는 obsolete라 main 버전 유지.
- **settings-surface 절반만 재적용**: `settings-surface.ts`의 `display` 섹션 최상단에 `Theme` 행(`<ThemeSwitch/>`) + import 추가. `settings-surface.test.ts`에 display 섹션 theme 버튼(DARK/STYLESEED/PAPER) 렌더 회귀 테스트.

## 검토 요망 (reconcile)

`ThemeSwitch`(3-way: DARK/StyleSeed/Paper)와 Tweaks 패널의 `tweaksTheme`(paper 토글만) 중복 소지. ThemeSwitch가 canonical 3-way 컨트롤이라 Settings에 두는 게 자연스러우나, Tweaks paper 토글과의 역할 분담(quick-access vs full control)을 확정하면 좋습니다. 이 PR은 orphan된 3-way 컨트롤에 집을 돌려주는 데 집중합니다.

## 검증

로컬 빌드 미실행("로컬 빌드 금지"). fresh clone(main `af959bf`)서 cherry-pick(app.ts obsolete 충돌은 main 버전으로 해소) + ThemeSwitch wiring(settings-surface.ts:16,1122-1124) 직접 그라운딩. CI `Dashboard`(tsc+vitest) 권위.

RFC-WAIVED: dashboard 설정 UI 배치 — credential/operator/keeper sandbox/hooks/workflow subsystem 무관.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
