### PR TITLE
docs: align version truth for 0.19.48 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 ## Unreleased
 
 
+## [0.19.48] - 2026-06-22
+
+### Changed
+- `agent_sdk`: bumped the OAS runtime pin from `v0.207.6` (`fdc35ccc`) to
+  `v0.207.7` (`b84af27e`, OAS `main` HEAD, release 0.207.7 #2166) and raised
+  the dependency floor to `>= 0.207.7` in `dune-project` / `masc.opam`. This
+  release pulls in the Ollama native `/api/chat` multimodal serialization fix
+  (jeong-sik/oas#2165).
+
 ## [0.19.47] - 2026-06-20
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,9 @@
 # masc Roadmap
 
-> Current package version: v0.19.47
-> Latest changelog entry: v0.19.47 (2026-06-20)
+> Current package version: v0.19.48
+> Latest changelog entry: v0.19.48 (2026-06-22)
 > Latest published GitHub release: v0.19.45 (2026-06-17)
-> Updated: 2026-06-20
+> Updated: 2026-06-22
 
 This roadmap is the 6-8 week operating view for `masc`.
 For the product promise and GitHub operating model, see [docs/PRODUCT-OPERATING-PLAN.md](docs/PRODUCT-OPERATING-PLAN.md).

--- a/docs/PRODUCT-OPERATING-PLAN.md
+++ b/docs/PRODUCT-OPERATING-PLAN.md
@@ -9,10 +9,10 @@ code_refs:
 
 # Product Operating Plan
 
-> Current package version: v0.19.47
-> Latest changelog entry: v0.19.47 (2026-06-20)
+> Current package version: v0.19.48
+> Latest changelog entry: v0.19.48 (2026-06-22)
 > Latest published GitHub release: v0.19.45 (2026-06-17)
-> Updated: 2026-06-20
+> Updated: 2026-06-22
 > Release line: pre-1.0 (`0.y.z`); legacy `v2.*` tags are frozen history
 
 Execution companion for capsule-only workspace collaboration hardening:

--- a/docs/spec/SPEC-INDEX.md
+++ b/docs/spec/SPEC-INDEX.md
@@ -11,7 +11,7 @@ code_refs:
 > Supersedes: `docs/SPEC.md`, `docs/MERGED-ARCHITECTURE-SSOT.md`
 > Status: Living draft
 > Last Updated: 2026-05-24
-> Snapshot baseline: `dune-project` version `0.19.47`
+> Snapshot baseline: `dune-project` version `0.19.48`
 
 MASC (Multi-Agent Shared Context)는 OCaml 5.x / Eio 기반 MCP 서버로, 여러 AI 에이전트(Agent-LLM-A, Provider-F, Agent-Code, 로컬 LLM 등)가 동일 코드베이스에서 동시에 작업할 때 발생하는 조율 문제를 해결한다. Workspace 기반 세션 관리, Task 할당, Heartbeat 모니터링, Keeper 자율 에이전트, dashboard/operator read visibility를 제공하며, MCP JSON-RPC 프로토콜을 통해 주요 AI IDE/CLI와 통합된다. Retired orchestration surfaces and internal references remain only as migration context.
 


### PR DESCRIPTION
Aligns front-door docs and CHANGELOG with the 0.19.48 version bump merged in #22101.\n\nChanges:\n- ROADMAP.md: current package version and latest changelog entry → 0.19.48\n- docs/PRODUCT-OPERATING-PLAN.md: same alignment\n- docs/spec/SPEC-INDEX.md: snapshot baseline → 0.19.48\n- CHANGELOG.md: add [0.19.48] release section for the agent_sdk 0.207.7 bump\n\nValidation:\n- `scripts/check-version-truth.sh`: OK\n- `scripts/check-doc-truth.sh`: OK