### PR TITLE
fix(dashboard): board 2-column default, on-demand detail collapse (re-stack of #22094)

### DIFF
--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -256,9 +256,25 @@ describe('BoardSurface Component', () => {
     expect(container.querySelector('.v2-board-surface')).not.toBeNull()
   })
 
-  it('shows the mention inbox detail rail by default', () => {
+  it('collapses the detail column by default (two-column rail + feed)', () => {
     const { container } = render(h(BoardSurface, null))
+    // No post selected and the mention inbox closed: neither detail rail is
+    // rendered and the grid track collapses to 0, leaving rail + feed. Matches
+    // the v2 prototype, which only expands the detail column on demand.
+    expect(container.querySelector('[data-testid="bd-mention-detail"]')).toBeNull()
+    expect(container.querySelector('[data-testid="bd-thread-detail"]')).toBeNull()
+    const surface = container.querySelector<HTMLElement>('.v2-board-surface')
+    const body = container.querySelector<HTMLElement>('.bd-body')
+    expect(surface?.getAttribute('data-detail-open')).toBe('false')
+    expect(body?.getAttribute('style')).toContain('--bd-detail-width: 0px')
+  })
+
+  it('opens the mention inbox detail rail from the rail queue action', () => {
+    const { container } = render(h(BoardSurface, null))
+    fireEvent.click(screen.getByTestId('bd-queue-mentions'))
     expect(container.querySelector('[data-testid="bd-mention-detail"]')).not.toBeNull()
+    const surface = container.querySelector<HTMLElement>('.v2-board-surface')
+    expect(surface?.getAttribute('data-detail-open')).toBe('true')
   })
 
   it('normalizes persisted Board detail rail widths to the supported range', () => {
@@ -272,6 +288,9 @@ describe('BoardSurface Component', () => {
     setLocalStorageItem(BOARD_DETAIL_WIDTH_STORAGE_KEY, JSON.stringify(430))
 
     const { container } = render(h(BoardSurface, null))
+    // The detail column is collapsed until opened; open the mention inbox so the
+    // persisted width hydrates the grid track and the resize handle renders.
+    fireEvent.click(screen.getByTestId('bd-queue-mentions'))
 
     const surface = container.querySelector<HTMLElement>('.v2-board-surface')
     const body = container.querySelector<HTMLElement>('.bd-body')
@@ -283,6 +302,8 @@ describe('BoardSurface Component', () => {
 
   it('resizes the Board detail rail with pointer drag and keyboard controls', async () => {
     const { container } = render(h(BoardSurface, null))
+    // Open the mention inbox so the detail rail (and its resize handle) renders.
+    fireEvent.click(screen.getByTestId('bd-queue-mentions'))
 
     const surface = container.querySelector<HTMLElement>('.v2-board-surface')
     const handle = screen.getByTestId('bd-detail-resize') as HTMLButtonElement
@@ -316,8 +337,8 @@ describe('BoardSurface Component', () => {
     ]
     render(h(BoardSurface, null))
 
-    const detail = screen.getByTestId('bd-mention-detail')
-    expect(detail).not.toHaveClass('is-mobile-open')
+    // Detail column is collapsed until the mention inbox is opened.
+    expect(screen.queryByTestId('bd-mention-detail')).toBeNull()
 
     const queues = screen.getByTestId('bd-mobile-queues')
     const mentionQueue = within(queues).getByTestId('bd-mobile-queue-mentions')
@@ -325,11 +346,12 @@ describe('BoardSurface Component', () => {
     expect(mentionQueue).toHaveTextContent('1')
 
     fireEvent.click(mentionQueue)
+    const detail = screen.getByTestId('bd-mention-detail')
     expect(detail).toHaveClass('is-mobile-open')
     expect(within(detail).getByText('@dashboard')).toBeInTheDocument()
 
     fireEvent.click(screen.getByLabelText('멘션 인박스 닫기'))
-    expect(detail).not.toHaveClass('is-mobile-open')
+    expect(screen.queryByTestId('bd-mention-detail')).toBeNull()
   })
 
   it('keeps v2 workspace panels for category cards', () => {

--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -746,14 +746,14 @@ function BdThreadDetail({
 function BdDetail({
   post,
   detailWidth,
-  mentionMobileOpen,
+  mentionsOpen,
   onDetailWidthChange,
   onClose,
   onCloseMentions,
 }: {
   post: BoardPost | null
   detailWidth: number
-  mentionMobileOpen: boolean
+  mentionsOpen: boolean
   onDetailWidthChange: (width: number) => void
   onClose: () => void
   onCloseMentions: () => void
@@ -766,8 +766,13 @@ function BdDetail({
       onClose=${onClose}
     />
   `
+  // No post selected and the mention inbox is closed: render nothing so the
+  // detail grid track collapses to 0 (two-column rail + feed). The mention
+  // inbox is reachable from the rail (bd-queue-mentions). Matches the v2
+  // prototype, which only expands the detail column on demand.
+  if (!mentionsOpen) return null
   return html`
-    <aside class=${`bd-detail is-mentions ${mentionMobileOpen ? 'is-mobile-open' : ''}`} data-testid="bd-mention-detail">
+    <aside class="bd-detail is-mentions is-mobile-open" data-testid="bd-mention-detail">
       <${BdDetailResizeHandle} width=${detailWidth} onWidthChange=${onDetailWidthChange} />
       <div class="bd-detail-h">
         <h3>멘션 인박스</h3>
@@ -1396,7 +1401,11 @@ function BdFeed({ posts, onMentions }: { posts: BoardPost[]; onMentions: () => v
 
 // ── Main Board component (public API) ──────────────────────────────
 export function BoardSurface() {
-  const [mobileMentionInboxOpen, setMobileMentionInboxOpen] = useState(false)
+  // The mention inbox opens on demand (from the rail's bd-queue-mentions button),
+  // on desktop and mobile alike. When neither a post nor the mention inbox is open
+  // the detail column collapses to a two-column rail + feed layout — see the
+  // --bd-detail-width computation below. Matches the standalone v2 prototype.
+  const [mentionInboxOpen, setMentionInboxOpen] = useState(false)
   const [detailWidth, setDetailWidth] = useState<number>(readStoredBoardDetailWidth)
   useEffect(() => () => { selectedPostIds.value = new Set() }, [])
   useEffect(() => registerBoardHearthsRefresh(() => {
@@ -1494,7 +1503,7 @@ export function BoardSurface() {
 
   function openMentionInbox(): void {
     selectedBoardPostId.value = null
-    setMobileMentionInboxOpen(true)
+    setMentionInboxOpen(true)
   }
 
   function setPersistentDetailWidth(width: number): void {
@@ -1503,17 +1512,24 @@ export function BoardSurface() {
     writeStoredBoardDetailWidth(normalized)
   }
 
+  // Detail column is reserved only when a post thread or the mention inbox is
+  // open; otherwise the grid track collapses to 0 (two-column rail + feed).
+  const detailOpen = !!selectedPost || mentionInboxOpen
+
   return html`
     <div
       class="v2-board-surface ss-surface bg-surface-page text-text-primary"
       data-detail-width=${String(detailWidth)}
+      data-detail-open=${String(detailOpen)}
     >
-      <div class="bd-body" style=${`--bd-detail-width: ${detailWidth}px;`}>
+      <div class="bd-body" style=${`--bd-detail-width: ${detailOpen ? detailWidth : 0}px;`}>
+
         <${BdRail}
           activeSub=${activeSub}
           onSub=${(sub: string) => {
             boardHearthFilter.value = sub
             selectedBoardPostId.value = null
+            setMentionInboxOpen(false)
             refreshBoard()
           }}
           onMentions=${openMentionInbox}
@@ -1522,10 +1538,10 @@ export function BoardSurface() {
         <${BdDetail}
           post=${selectedPost}
           detailWidth=${detailWidth}
-          mentionMobileOpen=${mobileMentionInboxOpen}
+          mentionsOpen=${mentionInboxOpen}
           onDetailWidthChange=${setPersistentDetailWidth}
           onClose=${() => { selectedBoardPostId.value = null }}
-          onCloseMentions=${() => setMobileMentionInboxOpen(false)}
+          onCloseMentions=${() => setMentionInboxOpen(false)}
         />
       </div>
     </div>


### PR DESCRIPTION
## 무엇을 / 왜

보드를 **2칼럼 기본**(rail + feed)으로 두고 detail 칼럼(멘션 인박스/스레드)을 **on-demand로만** 펼칩니다(no-selection 시 grid track 0px). 현재 main은 detail을 **항상 렌더**(`BdDetail`에 collapse 가드 없음, `--bd-detail-width` 무조건 예약)해 3칼럼 고정입니다 — v2 프로토타입의 2칼럼 의도와 어긋남(원본 #22094가 reskin과 충돌해 closed, 회귀 아닌 선재 미개선).

## 어떻게 (re-stack, render hunk rework)

- `BdDetail`: `mentionMobileOpen`→`mentionsOpen` 리네임 + `if (!mentionsOpen) return null`(post도 멘션도 없으면 미렌더 → track 0). 클래스 `is-mentions is-mobile-open`.
- `BoardSurface`: 상태 `mobileMentionInboxOpen`→`mentionInboxOpen` 일반화(데스크톱·모바일 공통), `const detailOpen = !!selectedPost || mentionInboxOpen`, `.v2-board-surface`에 `data-detail-open`, `--bd-detail-width: ${detailOpen ? detailWidth : 0}px`. BdRail `onSub`에 `setMentionInboxOpen(false)`.
- **render hunk 충돌 해소**: #22081이 BoardSurface 렌더에서 `<SurfaceHeader/>`를 제거했으므로(보드는 headerless), #22094의 conditional-width 변경을 **SurfaceHeader 없는 렌더 본문**에 적용(SurfaceHeader 재도입 안 함). 멘션은 rail 버튼(`bd-queue-mentions`)으로 접근 → 정보 손실 없음.

## 검증

로컬 빌드 미실행("로컬 빌드 금지"). fresh clone(main `af959bf`)서 cherry-pick(BdDetail/useState hunk clean, render hunk만 SurfaceHeader-removal에 맞춰 rework) + 충돌마커 0 + BdDetail collapse 가드/리네임/SurfaceHeader 누수 없음 그라운딩. CI `Dashboard`(tsc+vitest) 권위.

RFC-WAIVED: dashboard 보드 레이아웃 상태 — credential/operator/keeper sandbox/hooks/workflow subsystem 무관.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
