### PR TITLE
refactor(dashboard): add board no-header regression guard + drop stale SurfaceHeader test (re-stack of #22086)

### DIFF
--- a/dashboard/src/components/board/board-surface.test.ts
+++ b/dashboard/src/components/board/board-surface.test.ts
@@ -256,6 +256,14 @@ describe('BoardSurface Component', () => {
     expect(container.querySelector('.v2-board-surface')).not.toBeNull()
   })
 
+  it('renders no title header — board goes straight to the feed (matches prototype)', () => {
+    const { container } = render(h(BoardSurface, null))
+    // The board surface intentionally omits SurfaceHeader; the sub-board rail
+    // and "전체 피드" heading are the only structure above the posts. board is
+    // in SURFACE_OWN_LEAD_IDS so the generic SurfaceLead is also suppressed.
+    expect(container.querySelector('header.v2-surface-header')).toBeNull()
+  })
+
   it('shows the mention inbox detail rail by default', () => {
     const { container } = render(h(BoardSurface, null))
     expect(container.querySelector('[data-testid="bd-mention-detail"]')).not.toBeNull()

--- a/dashboard/src/components/common/surface-header.test.ts
+++ b/dashboard/src/components/common/surface-header.test.ts
@@ -19,14 +19,15 @@ describe('SurfaceHeader', () => {
   })
 
   // Each surface that does not render a richer bespoke header (monitoring,
-  // command, lab, board) opts into SurfaceHeader, which surfaces the current
+  // command, lab) opts into SurfaceHeader, which surfaces the current
   // section/view label as the single primary h1. These labels match what the
   // former generic SurfaceLead rendered (same currentSectionForRoute logic).
+  // The board surface renders no title header (matches the prototype), so it
+  // is intentionally absent here.
   it.each([
     ['monitoring', 'Keeper Fleet'],
     ['command', 'Actions'],
     ['lab', 'Tools'],
-    ['board', 'Board'],
   ] as const)('renders the %s surface title as the primary h1', (tab, label) => {
     route.value = { tab, params: {}, postId: null }
     render(h(SurfaceHeader, {}), container)
@@ -35,7 +36,7 @@ describe('SurfaceHeader', () => {
   })
 
   it('carries the shared copy + solo-view affordances', () => {
-    route.value = { tab: 'board', params: {}, postId: null }
+    route.value = { tab: 'monitoring', params: {}, postId: null }
     render(h(SurfaceHeader, {}), container)
     expect(container.querySelector('.v2-surface-header-actions')).not.toBeNull()
     expect(container.querySelector('[data-testid="dashboard-widget-solo-link"]')).not.toBeNull()

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1489,7 +1489,9 @@ export function isKeeperDetailDashboardRoute(routeState: RouteState): boolean {
 //   monitoring → status.ts           <SurfaceHeader> <h1>Keeper Fleet</h1>
 //   command    → operations-panel.ts <SurfaceHeader> <h1>Actions</h1>
 //   lab        → lab.ts              <SurfaceHeader> <h1>Tools</h1>
-//   board      → board-surface.ts    <SurfaceHeader> <h1>Board</h1> (#22021)
+// board is a third case: it renders NO header at all (#22086, prototype is
+// headerless) but must still be in this set so the generic SurfaceLead does not
+// reintroduce a title (board regressed that way in #22021).
 //
 // Surfaces that still rely on the generic SurfaceLead for their title: keepers, code.
 //
@@ -1507,12 +1509,14 @@ const SURFACE_OWN_LEAD_IDS: ReadonlySet<TabId> = new Set([
   'cockpit',
   'settings',
   'connectors',
-  // Each renders its own header in its body; without these the generic SurfaceLead
-  // stacked a duplicate title above each (board regressed in #22021,
-  // monitoring/command/lab carried the same gap from their SurfaceHeader adoption).
+  // Each renders the shared SurfaceHeader in its own body; without these the generic
+  // SurfaceLead stacked a duplicate title above each (monitoring/command/lab
+  // carried that gap from their SurfaceHeader adoption).
   'monitoring',
   'command',
   'lab',
+  // board renders no header of its own (#22086); listed here only to suppress
+  // the generic SurfaceLead (which regressed a duplicate Board title in #22021).
   'board',
 ])
 


### PR DESCRIPTION
## 무엇을 / 왜

보드 surface의 title 헤더 제거를 **회귀 가드 + 테스트/주석 hygiene**으로 마무리합니다. 빅뱅 reskin #22081이 보드를 이미 headerless로 만들었으므로(absorbed) **동작 변경은 없습니다** — 그러나 main에는 (1) 보드가 다시 헤더를 갖는 회귀를 막는 가드 테스트가 없고, (2) `surface-header.test.ts`에 보드가 SurfaceHeader를 쓴다는 **stale 단언**(`['board','Board']` tuple + `tab:'board'` affordance)이 green인 채 남아 오해를 부릅니다. 원본 #22086이 reskin과 충돌해 closed됐습니다.

## 어떻게 (re-stack, hygiene only)

- `board-surface.test.ts`: **회귀 가드** 추가 — `container.querySelector('header.v2-surface-header')`가 null임을 단언(보드가 헤더 없이 곧장 피드로). 프로토타입 재동기화가 헤더를 다시 넣으면 fail.
- `surface-header.test.ts`: stale `['board','Board']` tuple + `tab:'board'` affordance 테스트 제거(보드는 더 이상 SurfaceHeader 미사용 → 단언이 오해 유발, green이지만 misleading).
- `dashboard-shell.ts`: `SURFACE_OWN_LEAD_IDS` 주석 정제 — monitoring/command/lab 설명에서 redundant board 언급 제거(보드는 자체 인라인 주석 "renders no header; listed only to suppress generic SurfaceLead" 보유). 상단/인라인 주석은 main이 이미 대부분 정확(#22081이 흡수).

## 비고

동작 결함이 아니라 **회귀 방지 가드 + stale 단언 제거**입니다. 보드 headerless는 이미 live이나, 가드가 없으면 unguarded edit/프로토타입 re-sync가 헤더를 silent하게 되살릴 수 있습니다.

## 검증

로컬 빌드 미실행("로컬 빌드 금지"). fresh clone(main `af959bf`)서 cherry-pick(dashboard-shell 주석 충돌은 monitoring/command/lab 설명으로 해소, 보드 인라인 주석은 main 기존 유지) + 누적 diff(test 2 + 주석) 그라운딩. CI `Dashboard`(tsc+vitest) 권위.

RFC-WAIVED: dashboard 테스트/주석 hygiene — credential/operator/keeper sandbox/hooks/workflow subsystem 무관.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
