### PR TITLE
fix(dashboard): monitoring 로스터 dev-jargon 카피 정리 (#4)

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -53,7 +53,6 @@ import {
   keeperRowLooksRunning,
   resolveRuntimeCounts,
   runtimeDetailRows,
-  runtimeCountSourceLabel,
   shouldShowExecutionFallbackState,
 } from '../runtime-counts'
 import {
@@ -469,7 +468,7 @@ function expectedCountForKeeperFilter(
 const FILTER_META: Record<StatusFilter, { label: string; description: string }> = {
   all: {
     label: '전체 상세',
-    description: 'execution 상세 행 전체를 보여줍니다. 런타임 가동 총계와는 별도 기준입니다.',
+    description: '모든 키퍼와 에이전트를 표시합니다.',
   },
   active: { label: runtimeBandMeta('active').label, description: runtimeBandMeta('active').description },
   attention: { label: runtimeBandMeta('attention').label, description: runtimeBandMeta('attention').description },
@@ -796,7 +795,6 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
   })
   const expectedScopedCount = expectedCountForKeeperFilter(keeperFilter, runtimeCounts)
-  const countSourceLabel = runtimeCountSourceLabel(runtimeCounts.source)
   const namespaceStatus = namespaceTruth.value?.root.status ?? serverStatus.value
   const namespaceName = namespaceStatus?.project ?? 'default'
 
@@ -887,13 +885,13 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     expectedScopedCount > scopedAgents.length
       ? (
           filtered.length === scopedAgents.length
-            ? `상세 행 ${filtered.length}개 로드됨 · 예상 ${expectedScopedCount}개`
-            : `상세 행 ${filtered.length} / ${scopedAgents.length}개 표시 · 예상 ${expectedScopedCount}개`
+            ? `항목 ${filtered.length}개 표시 · 예상 ${expectedScopedCount}개`
+            : `항목 ${filtered.length} / ${scopedAgents.length}개 표시 · 예상 ${expectedScopedCount}개`
         )
       : (
           filtered.length === scopedAgents.length
-            ? `상세 행 ${filtered.length}개 표시 중`
-            : `상세 행 ${filtered.length} / ${scopedAgents.length}개 표시 중`
+            ? `항목 ${filtered.length}개 표시 중`
+            : `항목 ${filtered.length} / ${scopedAgents.length}개 표시 중`
         )
   const statusChips = (['all', 'attention', 'active', 'paused', 'offline'] as StatusFilter[]).map(key => ({
     key,
@@ -938,16 +936,16 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       : `키퍼 ${keeperStateHints.join(' · ')}`
   const fallbackStateTitle =
     executionError.value
-      ? '상세 상태 불러오기 실패'
+      ? '상태 불러오기 실패'
       : executionLoaded.value
-        ? '상세 상태 부분 동기화'
-        : '상세 상태 동기화 중'
+        ? '일부만 불러옴'
+        : '불러오는 중'
   const fallbackStateMessage =
     executionError.value
-      ? `${countSourceLabel} 기준 ${scopeLabel}입니다. 상세 상태 정보를 아직 가져오지 못했습니다.`
+      ? `${scopeLabel}. 상태 정보를 아직 불러오지 못했습니다.`
       : executionLoaded.value
-        ? `${countSourceLabel} 기준 ${scopeLabel}입니다. 일부만 상세 목록에 반영됐습니다.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''}`
-        : `${countSourceLabel} 기준 ${scopeLabel}입니다.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''} 상세 상태 정보가 올라오면 상태별 분류와 카드가 채워집니다.`
+        ? `${scopeLabel}. 일부만 불러왔습니다.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''}`
+        : `${scopeLabel}.${configuredIdleHint ? ` ${configuredIdleHint}.` : ''} 상태 정보가 올라오면 목록이 채워집니다.`
 
   const rosterRows = useMemo(() => filtered.map((agent: Agent) => {
     const keeperRuntime =
@@ -1241,11 +1239,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   <div class="flex flex-col gap-2">
                     <div class="flex flex-wrap items-center gap-2">
                       <strong class="text-xs font-semibold text-[var(--color-fg-primary)]">${fallbackStateTitle}</strong>
-                      <span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-hover)] px-2 py-0.5 text-2xs font-medium text-[var(--color-fg-muted)]">${countSourceLabel}</span>
                     </div>
                     <p class="m-0 text-xs leading-paragraph text-[var(--color-fg-primary)]">${fallbackStateMessage}</p>
                     <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
-                      <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5">scope ${namespaceName}</span>
+                      <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5">프로젝트 ${namespaceName}</span>
                       ${configuredIdleHint ? html`<span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5">${configuredIdleHint}</span>` : null}
                     </div>
                   </div>
@@ -1290,7 +1287,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   message=${normalizedSearch && scopedAgents.length > 0
                     ? `필터 결과 없음 (${scopedAgents.length} items)`
                     : showExecutionFallbackState && expectedScopedCount > 0
-                      ? `${fallbackStateTitle}: ${countSourceLabel} 기준 ${scopeLabel}가 보이지만, 현재 조건에 맞는 상세 row는 아직 없습니다.`
+                      ? `${fallbackStateTitle}: ${scopeLabel}가 있지만, 현재 조건에 맞는 항목은 아직 없습니다.`
                       : '조건에 맞는 에이전트가 없습니다.'}
                   compact
                 />

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -574,6 +574,11 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
   })
   const configured = runtimeCounts.configured.keepers
   const liveKeepers = runtimeCounts.live.keepers
+  // Scope note (#22110): the agent-roster surface dropped the count-source label
+  // from its always-visible operational copy. Here the same label feeds the
+  // keeper-count-basis chip's `detail` tooltip (hover-only, diagnostic) below —
+  // an on-demand explanation of where the running count comes from, which is the
+  // actionable detail that review kept. Retained intentionally, not an oversight.
   const runningCountSource = input.counts !== null
     ? 'shell'
     : input.keepers.length > 0


### PR DESCRIPTION
## 무엇을

monitoring 로스터(`agent-roster.ts`)가 **내부 데이터 소스 식별자를 화면에 그대로 노출**하던 것을 정리합니다. Vincent 피드백: "안 나와도 되는 정보면 싹 지워도?"

## 왜

`runtimeCountSourceLabel`이 만든 `execution 상세` / `project snapshot` / `shell` / `부분 hydrate` / `미수집`은 카운트가 어느 백엔드 소스에서 왔는지를 나타내는 내부 배관입니다. 운영자는 이 소스 구분으로 행동하지 않으므로 **표시 가치가 없습니다**.

## 변경 (copy-only, 로직 무변경)

- **`countSourceLabel` 완전 제거** — fallback 패널 배지, `"<소스> 기준 …"` 메시지 접두 3곳, empty-state, 그리고 미사용이 된 const·import.
- **남은 visible 카피 평이화**:
  - `상세 행 N개 로드됨` → `항목 N개 표시`
  - `scope me` → `프로젝트 me`
  - fallback 제목: `상세 상태 동기화 중` → `불러오는 중`, `상세 상태 부분 동기화` → `일부만 불러옴`, `상세 상태 불러오기 실패` → `상태 불러오기 실패`
  - 필터 설명: `execution 상세 행 전체를 보여줍니다. 런타임 가동 총계와는 별도 기준입니다.` → `모든 키퍼와 에이전트를 표시합니다.`
- **유지**: `scopeLabel` 카운트 분해(실제 정보), keeper 상태 힌트(일시정지/오프라인/미기동), 부분 로드 힌트(예상 N개).

## 검증

- tsc `--noEmit` exit=0
- `agent-roster.test.ts` + `agents-unified.test.ts` — 41 passed
- eslint clean
- 테스트는 표시 문자열을 단언하지 않아 carry-over 없음

## 범위 메모

`runtime-counts.ts`의 `formatRuntimeRosterCount`(`상세 N / 런타임 가동 N / 키퍼 설정 N`)는 실제 카운트 분해라 유지했습니다. 추가로 평이화를 원하면 후속 PR로 분리 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# ci:skip-test-coverage

copy-only(countSourceLabel 제거 + 표시 카피 평이화). 로직 무변경, 표시 문자열은 brittle coupling 방지로 의도적으로 테스트에서 단언하지 않음. 기존 agent-roster/agents-unified 41건 통과.
