### PR TITLE
feat(keeper): allow git clone via Execute from sandbox root

### DIFF
--- a/config/prompts/keeper.capabilities.md
+++ b/config/prompts/keeper.capabilities.md
@@ -95,10 +95,10 @@ Sandbox layout (NOT `/workspace` — that path does not exist; see <world> WRONG
   - `repos/` — git clones (one per repo, e.g. `repos/REPO_NAME/`) — task work should happen inside `repos/REPO_NAME/`
   - `.` — general sandbox files
 - All paths come from keeper_context_status: use `sandbox_root`, `sandbox_mind`, `sandbox_repos` directly.
-- Clones: use the exact tool listed in your active schema. If no clone path is visible, report the blocker instead of inventing hidden shell tools.
+- Clones: when Execute is visible, use typed `Execute { "executable": "git", "argv": ["clone", "<url>", "repos/<REPO>"] }` from sandbox root. If Execute is not visible or the repo is DENIED, report the blocker instead of inventing hidden shell tools.
 
 Repo setup:
-1. If `repos/REPO` is missing AND the task names a repo under ALLOWED (and not DENIED — see the world block), use the exact allowed tool or Execute path allowed by the active schema. If no such path is allowed, report the missing clone as a blocker.
+1. If `repos/REPO` is missing AND the task names a repo under ALLOWED (and not DENIED — see the world block), clone it with `Execute { "executable": "git", "argv": ["clone", "<url>", "repos/<REPO>"] }` from sandbox root. If Execute is not visible, report the missing clone as a blocker.
 2. Work in your clone `repos/{repo}/` for code/PR changes — this clone is your individual workspace. Create a task branch from the fetched origin default branch (`git fetch origin`, then `git checkout -b {your-name}/{task} origin/main`) before editing; do not edit on the root `main` checkout. A git worktree is optional and is not provisioned for you; if you choose to keep several branches checked out at once, create one rooted under your repo clone (`repos/{repo}/.worktrees/...`) from `origin/main`. If the checkout is dirty before you start, report that blocker instead of layering on another checkout. If multiple clones exist and the task has no clear repo evidence, report the ambiguity instead of guessing.
 3. If setup returns `ok: false`, STOP. Read `detail.hint`, retry once if there's a concrete fix, otherwise report via `keeper_broadcast`.
 

--- a/lib/keeper/keeper_tool_execute_command_semantics.ml
+++ b/lib/keeper/keeper_tool_execute_command_semantics.ml
@@ -37,6 +37,17 @@ let stages_target_repo_commands stages =
   List.exists (fun stage ->
     let bin = normalize_command_name stage.bin in
     bin = "git" || bin = "gh") stages
+;;
+
+let stages_are_git_clone stages =
+  List.exists
+    (fun stage ->
+       normalize_command_name stage.bin = "git"
+       &&
+       match stage.args with
+       | "clone" :: _ -> true
+       | _ -> false)
+    stages
 
 let stages_target_repo_hosting_cli stages =
   List.exists (fun stage -> normalize_command_name stage.bin = "gh") stages
@@ -255,6 +266,11 @@ let resolve_sandbox_root_git_cwd
     cwd_normalized = host_root && stages_target_repo_hosting_cli stages
     && stages_have_repo_hosting_cli_repo_flag stages
   then cwd, None
+  else if cwd_normalized = host_root && stages_are_git_clone stages
+  then (
+    (* git clone is intentionally run from sandbox root to create a new
+       repository under repos/. Do not redirect cwd into an existing clone. *)
+    cwd, None)
   else if cwd_normalized = host_root && stages_target_repo_commands stages
   then (
     let resolve_without_explicit_git_c () =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1453,6 +1453,16 @@ let test_sandbox_root_git_cwd_zero_repo_blocks_before_exec () =
     Alcotest.(check bool) "mentions cwd recovery" true
       (contains_substring msg "cwd=\"repos/<repo>\"")
 
+let test_sandbox_root_git_clone_allowed_from_root () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let cwd, error =
+    resolve_sandbox_root_git_cwd_string ~config ~meta
+      ~cwd:playground ~cmd:"git clone https://github.com/example/repo.git repos/repo"
+  in
+  Alcotest.(check (option string)) "no error for git clone from sandbox root" None error;
+  Alcotest.(check string) "cwd stays sandbox root" playground cwd
+
 let test_sandbox_root_git_cwd_single_repo_auto_chdir () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
@@ -2305,6 +2315,9 @@ let () =
           Alcotest.test_case
             "sandbox-root git with no repo blocks before docker exec"
             `Quick test_sandbox_root_git_cwd_zero_repo_blocks_before_exec;
+          Alcotest.test_case
+            "sandbox-root git clone is allowed from sandbox root"
+            `Quick test_sandbox_root_git_clone_allowed_from_root;
           Alcotest.test_case
             "sandbox-root git with one repo auto-selects cwd"
             `Quick test_sandbox_root_git_cwd_single_repo_auto_chdir;


### PR DESCRIPTION
Removes the artificial restriction that prevented Keeper from cloning a repository via the Execute tool.

Changes:
- lib/keeper/keeper_tool_execute_command_semantics.ml: detect git clone stages and bypass the sandbox-root cwd redirection, so clone can create a new repo under repos/.
- config/prompts/keeper.capabilities.md: tell keepers to use typed Execute with git clone argv when a repo is missing.
- test/test_keeper_sandbox_docker_route.ml: add test_sandbox_root_git_clone_allowed_from_root.

Destructive git operations (push --force, reset --hard, etc.) remain unchanged. The internal Repo_git.clone machinery is left alone; this PR only exposes the natural shell path.

Local validation:
- test_keeper_sandbox_docker_route.exe test docker_route_contract 21,22-31 — 10 git-cwd tests pass.
