### PR TITLE
refactor(keeper): type git clone destination directory and generalize repos-target policy

### DIFF
--- a/bin/gen_shell_ir_walkers.ml
+++ b/bin/gen_shell_ir_walkers.ml
@@ -308,7 +308,7 @@ parse false args|}
     }
   ; { name = "Git_clone"
     ; anon_pattern = "Git_clone _"
-    ; bind_pattern = "Git_clone { repo; branch; depth }"
+    ; bind_pattern = "Git_clone { repo; branch; depth; dest_dir }"
     ; risk = "`Audited"
     ; sandbox = "`Docker"
     ; to_simple_body =
@@ -317,6 +317,7 @@ parse false args|}
         (match depth with Some d -> [ "--depth"; string_of_int d ] | None -> [])
         @ (match branch with None -> [] | Some b -> [ "-b"; b ])
         @ [ repo ]
+        @ (match dest_dir with None -> [] | Some d -> [ d ])
       in
       { Shell_ir.bin = Exec_program.of_known Exec_program.Git
       ; args = List.map (fun s -> Shell_ir.Lit (s, Shell_ir.default_meta)) ("clone" :: args)
@@ -329,34 +330,37 @@ parse false args|}
     ; parse_body =
         Some
           {|
-let rec parse depth branch repo dd = function
+let rec parse depth branch repo dest_dir dd = function
   | [] ->
     (match repo with
-     | Some r -> Some (Shell_ir_typed_types.W (Shell_ir_typed_types.Git_clone { repo = r; branch; depth }))
+     | Some r -> Some (Shell_ir_typed_types.W (Shell_ir_typed_types.Git_clone { repo = r; branch; depth; dest_dir }))
      | None -> None)
   | "--depth" :: n :: rest when not dd ->
     (match int_of_string_opt n with
-     | Some d -> parse (Some d) branch repo dd rest
+     | Some d -> parse (Some d) branch repo dest_dir dd rest
      | None -> None)
-  | "-b" :: b :: rest | "--branch" :: b :: rest when not dd -> parse depth (Some b) repo dd rest
+  | "-b" :: b :: rest | "--branch" :: b :: rest when not dd -> parse depth (Some b) repo dest_dir dd rest
   | arg :: rest when not dd && Shell_ir_typed_types.is_eq_form_flag arg ["--depth"] ->
     let n = Option.get (Shell_ir_typed_types.eq_form_flag_value arg ["--depth"]) in
     (match int_of_string_opt n with
-     | Some d -> parse (Some d) branch repo dd rest
-     | None -> parse depth branch repo dd rest)
+     | Some d -> parse (Some d) branch repo dest_dir dd rest
+     | None -> parse depth branch repo dest_dir dd rest)
   | arg :: rest when not dd && Shell_ir_typed_types.is_eq_form_flag arg ["--branch"] ->
     let b = Option.get (Shell_ir_typed_types.eq_form_flag_value arg ["--branch"]) in
-    parse depth (Some b) repo dd rest
-  | "--" :: rest -> parse depth branch repo true rest
+    parse depth (Some b) repo dest_dir dd rest
+  | "--" :: rest -> parse depth branch repo dest_dir true rest
   | arg :: rest ->
     if not dd && String.length arg > 0 && arg.[0] = '-'
-    then parse depth branch repo dd rest
+    then parse depth branch repo dest_dir dd rest
     else (
       match repo with
-      | None -> parse depth branch (Some arg) dd rest
-      | Some _ -> None)
+      | None -> parse depth branch (Some arg) dest_dir dd rest
+      | Some _ ->
+        (match dest_dir with
+         | None -> parse depth branch repo (Some arg) dd rest
+         | Some _ -> None))
 in
-parse None None None false args|}
+parse None None None None false args|}
     ; no_expand_combined = false
     }
   ; { name = "Curl"

--- a/lib/exec/capability_check_typed.ml
+++ b/lib/exec/capability_check_typed.ml
@@ -50,7 +50,7 @@ let of_command = function
   | Shell_ir_typed.W (Git_status { short }) ->
     let args = arg "status" :: (if short then [ arg "-s" ] else []) in
     [ Capability.Exec_program (Exec_program.of_known Exec_program.Git, args) ]
-  | Shell_ir_typed.W (Git_clone { repo; branch; depth }) ->
+  | Shell_ir_typed.W (Git_clone { repo; branch; depth; dest_dir }) ->
     let args =
       (arg "clone"
        :: (match depth with
@@ -60,6 +60,9 @@ let of_command = function
          | None -> []
          | Some b -> [ arg "-b"; arg b ])
       @ [ arg repo ]
+      @ (match dest_dir with
+         | None -> []
+         | Some d -> [ arg d ])
     in
     [ Capability.Exec_program (Exec_program.of_known Exec_program.Git, args) ]
   | Shell_ir_typed.W (Curl { url; method_; headers; body; output_file; follow_redirects; insecure }) ->

--- a/lib/exec/shell_ir_typed.ml
+++ b/lib/exec/shell_ir_typed.ml
@@ -55,15 +55,17 @@ let pp fmt = function
       path
       case_sensitive
   | W (Git_status { short }) -> Format.fprintf fmt "Git_status(short=%b)" short
-  | W (Git_clone { repo; branch; depth }) ->
+  | W (Git_clone { repo; branch; depth; dest_dir }) ->
     Format.fprintf
       fmt
-      "Git_clone(repo=%s, branch=%a, depth=%a)"
+      "Git_clone(repo=%s, branch=%a, depth=%a, dest_dir=%a)"
       repo
       (Format.pp_print_option Format.pp_print_string)
       branch
       (Format.pp_print_option Format.pp_print_int)
       depth
+      (Format.pp_print_option Format.pp_print_string)
+      dest_dir
   | W (Curl { url; method_; headers; body; output_file; follow_redirects; insecure }) ->
     Format.fprintf
       fmt
@@ -701,8 +703,9 @@ let path_args : wrapped -> string list = function
   | W (Patch { file = None; _ }) -> []
   | W (Make { directory = Some d; _ }) -> [ d ]
   | W (Make { directory = None; _ }) -> []
+  | W (Git_clone { dest_dir = Some d; _ }) -> [ d ]
   (* Remote / URL — not local filesystem paths *)
-  | W (Git_clone _) -> []
+  | W (Git_clone { dest_dir = None; _ }) -> []
   | W (Curl _) -> []
   | W (Wget _) -> []
   | W (Ssh _) -> []

--- a/lib/exec/shell_ir_typed_types.ml
+++ b/lib/exec/shell_ir_typed_types.ml
@@ -38,6 +38,9 @@ and (_, _, _, _) command =
       ; branch : string option
       ; depth : int option
         (** [None] = unlimited (no [--depth] flag); [Some n] = shallow clone. *)
+      ; dest_dir : string option
+        (** Optional local directory to clone into. When [None], git uses the
+            basename of [repo]. *)
       }
       -> (unit, string, [ `Audited ], [ `Host | `Docker ]) command
   | Curl :

--- a/lib/exec/shell_ir_typed_types.mli
+++ b/lib/exec/shell_ir_typed_types.mli
@@ -34,6 +34,9 @@ and (_, _, _, _) command =
       ; branch : string option
       ; depth : int option
         (** [None] = unlimited (no [--depth] flag); [Some n] = shallow clone. *)
+      ; dest_dir : string option
+        (** Optional local directory to clone into. When [None], git uses the
+            basename of [repo]. *)
       }
       -> (unit, string, [ `Audited ], [ `Host | `Docker ]) command
   | Curl :

--- a/lib/exec/test/test_shell_ir_typed_e2e.ml
+++ b/lib/exec/test/test_shell_ir_typed_e2e.ml
@@ -292,6 +292,7 @@ let test_git_commands () =
     ; "git clone https://github.com/x/y.git", "Git_clone"
     ; "git clone --depth 1 https://github.com/x/y.git", "Git_clone"
     ; "git clone -b main https://github.com/x/y.git", "Git_clone"
+    ; "git clone https://github.com/x/y.git repos/z", "Git_clone"
     ]
 ;;
 

--- a/lib/exec/test/test_shell_ir_walkers_gen.ml
+++ b/lib/exec/test/test_shell_ir_walkers_gen.ml
@@ -28,7 +28,7 @@ let all_wrapped : Shell_ir_typed.wrapped list =
   ; W (Cat { path = "/dev/null" })
   ; W (Rg { pattern = "."; path = None; case_sensitive = false })
   ; W (Git_status { short = false })
-  ; W (Git_clone { repo = "x"; branch = None; depth = None })
+  ; W (Git_clone { repo = "x"; branch = None; depth = None; dest_dir = None })
   ; W (Curl { url = "http://x"; method_ = `GET; headers = None; body = None; output_file = None; follow_redirects = false; insecure = false })
   ; W (Rm { paths = [ "/tmp/x" ]; recursive = false; force = false })
   ; W (Sudo { target_argv = [ "sh"; "-c"; "echo hi" ] })
@@ -236,7 +236,7 @@ let test_of_simple_round_trip () =
     ; W (Cat { path = "/etc/passwd" })
     ; W (Rg { pattern = "TODO"; path = Some "."; case_sensitive = true })
     ; W (Git_status { short = true })
-    ; W (Git_clone { repo = "git@github.com:x/y.git"; branch = Some "main"; depth = Some 1 })
+    ; W (Git_clone { repo = "git@github.com:x/y.git"; branch = Some "main"; depth = Some 1; dest_dir = None })
     ; W
         (Curl
            { url = "http://example.com"
@@ -459,6 +459,27 @@ let test_flag_equals_parsing () =
    | W (Git_clone { depth = Some 5; branch = Some "develop"; repo = "repo.git"; _ }) -> ()
    | w ->
      Alcotest.failf "Git_clone --flag=value: expected depth=5 branch=develop, got %a" pp w);
+  (* Git_clone: with destination directory *)
+  let gc2 =
+    of_simple
+      { (base "git") with
+        args = [ lit "clone"; lit "https://github.com/example/repo.git"; lit "repos/myrepo" ]
+      }
+  in
+  (match gc2 with
+   | W
+       (Git_clone
+          { repo = "https://github.com/example/repo.git"
+          ; branch = None
+          ; depth = None
+          ; dest_dir = Some "repos/myrepo"
+          ; _
+          }) -> ()
+   | w ->
+     Alcotest.failf
+       "Git_clone with dest_dir: expected repos/myrepo, got %a"
+       pp
+       w);
   (* Gh: --body=hello --title=world *)
   let gh =
     of_simple

--- a/lib/keeper/keeper_tool_execute_command_semantics.ml
+++ b/lib/keeper/keeper_tool_execute_command_semantics.ml
@@ -37,17 +37,6 @@ let stages_target_repo_commands stages =
   List.exists (fun stage ->
     let bin = normalize_command_name stage.bin in
     bin = "git" || bin = "gh") stages
-;;
-
-let stages_are_git_clone stages =
-  List.exists
-    (fun stage ->
-       normalize_command_name stage.bin = "git"
-       &&
-       match stage.args with
-       | "clone" :: _ -> true
-       | _ -> false)
-    stages
 
 let stages_target_repo_hosting_cli stages =
   List.exists (fun stage -> normalize_command_name stage.bin = "gh") stages
@@ -266,41 +255,39 @@ let resolve_sandbox_root_git_cwd
     cwd_normalized = host_root && stages_target_repo_hosting_cli stages
     && stages_have_repo_hosting_cli_repo_flag stages
   then cwd, None
-  else if cwd_normalized = host_root && stages_are_git_clone stages
-  then (
-    (* git clone is intentionally run from sandbox root to create a new
-       repository under repos/. Do not redirect cwd into an existing clone. *)
-    cwd, None)
   else if cwd_normalized = host_root && stages_target_repo_commands stages
   then (
     let resolve_without_explicit_git_c () =
-      match repos_in_playground () with
-      | [ single_repo ] ->
-        Filename.concat (Filename.concat host_root "repos") single_repo, None
-      | [] ->
-        ( cwd
-        , Some
-            (Printf.sprintf
-                "sandbox root cannot run git/gh: mount point %s is not a git repository and \
-                no sandbox git clones exist under repos/. First clone a repo with \
-                the visible clone tool, then retry with cwd=\"repos/<repo>\"."
-               host_root) )
-      | example_repo :: _ as many ->
-        let suggested_cwd =
-          match repos_path_hint_of_stages ~cmd:(String.trim cmd) stages with
-          | Some (path, _) -> path
-          | None -> "repos/" ^ example_repo
-        in
-        ( cwd
-        , Some
-            (Printf.sprintf
-               "sandbox root cannot run git/gh: mount point %s is not a git repository and \
-                multiple sandbox repos exist. Set cwd explicitly before retrying. Example \
-                next call: Execute { \"executable\": \"git\", \"argv\": [\"status\"], \"cwd\": %S }. Available repos: %s. \
-                Do not retry the same cmd from sandbox root."
-               host_root
-               suggested_cwd
-               (String.concat ", " many)) )
+      (* If the command itself names a target under repos/ (e.g. git clone <url>
+         repos/foo), keep the sandbox-root cwd and let the command operate on
+         that explicit path. This avoids special-casing git clone while still
+         helping plain git status/log calls resolve to the intended repo. *)
+      match repos_path_hint_of_stages ~cmd:(String.trim cmd) stages with
+      | Some (_path, _cmd) -> cwd, None
+      | None -> (
+        match repos_in_playground () with
+        | [ single_repo ] ->
+          Filename.concat (Filename.concat host_root "repos") single_repo, None
+        | [] ->
+          ( cwd
+          , Some
+              (Printf.sprintf
+                  "sandbox root cannot run git/gh: mount point %s is not a git repository and \
+                  no sandbox git clones exist under repos/. First clone a repo with \
+                  the visible clone tool, then retry with cwd=\"repos/<repo>\"."
+                 host_root) )
+        | example_repo :: _ as many ->
+          let suggested_cwd = "repos/" ^ example_repo in
+          ( cwd
+          , Some
+              (Printf.sprintf
+                 "sandbox root cannot run git/gh: mount point %s is not a git repository and \
+                  multiple sandbox repos exist. Set cwd explicitly before retrying. Example \
+                  next call: Execute { \"executable\": \"git\", \"argv\": [\"status\"], \"cwd\": %S }. Available repos: %s. \
+                  Do not retry the same cmd from sandbox root."
+                 host_root
+                 suggested_cwd
+                 (String.concat ", " many)) ))
     in
     let explicit_git_c_path_groups = git_global_c_path_groups_of_stages stages in
     let base_for_git_c_paths = function

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1453,14 +1453,17 @@ let test_sandbox_root_git_cwd_zero_repo_blocks_before_exec () =
     Alcotest.(check bool) "mentions cwd recovery" true
       (contains_substring msg "cwd=\"repos/<repo>\"")
 
-let test_sandbox_root_git_clone_allowed_from_root () =
+let test_sandbox_root_git_explicit_repos_target_keeps_cwd () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
   let cwd, error =
     resolve_sandbox_root_git_cwd_string ~config ~meta
       ~cwd:playground ~cmd:"git clone https://github.com/example/repo.git repos/repo"
   in
-  Alcotest.(check (option string)) "no error for git clone from sandbox root" None error;
+  Alcotest.(check (option string))
+    "no error when git command names explicit repos target"
+    None
+    error;
   Alcotest.(check string) "cwd stays sandbox root" playground cwd
 
 let test_sandbox_root_git_cwd_single_repo_auto_chdir () =
@@ -2316,8 +2319,8 @@ let () =
             "sandbox-root git with no repo blocks before docker exec"
             `Quick test_sandbox_root_git_cwd_zero_repo_blocks_before_exec;
           Alcotest.test_case
-            "sandbox-root git clone is allowed from sandbox root"
-            `Quick test_sandbox_root_git_clone_allowed_from_root;
+            "sandbox-root git with explicit repos target keeps cwd"
+            `Quick test_sandbox_root_git_explicit_repos_target_keeps_cwd;
           Alcotest.test_case
             "sandbox-root git with one repo auto-selects cwd"
             `Quick test_sandbox_root_git_cwd_single_repo_auto_chdir;


### PR DESCRIPTION
Replaces the ad-hoc git clone special case from #22117 with a typed IR field and a general explicit repos/ target policy.