### PR TITLE
fix(keeper): replace phantom "clone tool" guidance with honest blocker-report (RFC-0284)

### DIFF
--- a/docs/rfc/RFC-0284-keeper-guidance-visibility-drift-guard.md
+++ b/docs/rfc/RFC-0284-keeper-guidance-visibility-drift-guard.md
@@ -1,0 +1,67 @@
+# RFC-0284: Keeper Guidance Visibility-Leg Drift Guard
+
+**Status**: Draft
+**Date**: 2026-06-23
+**Builds on**: [RFC-0254](./RFC-0254-shell-ir-approval-autonomous-policy.md) (autonomous lane has no `Ask` resolver — a blocked operation must return an actionable verdict, not a dead end)
+**Related**: [RFC-0239](./RFC-0239-keeper-no-progress-loop-detector.md) (no-progress loop detector that this drift silently defeats); Tool Orchestration Lane design note (`docs/design/tool-orchestration-lane.md` §1, tracking issue #21517 — schema↔dispatch↔visibility drift guard as the first slice); [RFC-0042](./RFC-0042-keeper-terminal-code-closed-sum.md) (no-string-classifier lineage)
+**Tracking**: tool-constraint adversarial audit (2026-06-23)
+
+## 1. Summary
+
+A keeper that needs a repository cloned receives a recovery message instructing it to "First clone a repo with the visible clone tool" (`keeper_tool_execute_command_semantics.ml:283-287`). No such tool exists in any keeper surface — `clone` is only the internal `repo_manager/repo_git.ml:63` function, never exposed as a schema entry, and `keeper_hooks_oas.ml:196` confirms all keepers receive the full tool set unconditionally (there is no per-role gating). The contract names a capability the keeper cannot dispatch, so the model fills the gap by inventing a phantom tool call and escalating into the room.
+
+This is one instance of a broader class: **guidance/error/recovery text emitted in a schema-allowed context references a tool that does not resolve to a dispatchable surface.** The SSOT for schema-allowed name rendering already exists (`Keeper_tool_visibility_projection`, with `render_reference` / `blocker_guidance` that convert an unbound reference into a blocker-report), and its `.mli` claims "the consumer migration is complete." That claim is false: the producer above does not route through the module (zero references), so the projection cannot intercept the phantom. No test, lint, or boot check asserts the invariant, so the phantom ships uncaught — and a forward-assertion test (`test_keeper_sandbox_docker_route.ml:1452`) pins the broken string as expected, contractually locking the lie in place.
+
+This RFC defines the invariant and lands the first enforcement slice: fix the confirmed live phantom and add a regression seam at its producer, so re-introducing a phantom recovery string at this site fails a test rather than reaching a keeper.
+
+## 2. Context & evidence
+
+### 2.1 The named incident (albini)
+
+A PM keeper (`albini`, `active_goal_ids=[goal-pm-flow]`, `current_task_id=null`) needed `jeong-sik/masc` cloned. Its live trajectory (`~/me/.masc/trajectories/albini/trace-1781224572742-00000.jsonl`) hit the recovery string repeatedly (`"no sandbox git clones"` ×13, `"clone a repo with the vis…"` ×21, `"visible clone tool"` ×6) and responded with `clone` ×98 and `@operator` ×29. The keeper itself used the word `phantom` ×42, recognising it was inventing calls. It also confabulated a cause — "I'm a PM, I don't have tools to provision" — which is wrong: the clone capability is absent for every keeper, not gated by role. The missing capability forced a fleet-wide workaround (publishing source over the board so each keeper recreates files in its own sandbox), a real operational cost beyond one keeper's thrash.
+
+### 2.2 The defect
+
+`resolve_sandbox_root_git_cwd` builds two recovery messages:
+
+- `many` branch (`keeper_tool_execute_command_semantics.ml:296-303`): names a real, dispatchable affordance — `Execute { "executable": "git", "argv": ["status"], "cwd": … }`. This is the correct pattern.
+- `[]` branch (`:283-287`): names "the visible clone tool", which is not a tool. This is the phantom.
+
+`test_sandbox_root_git_clone_allowed_from_root` (`test_keeper_sandbox_docker_route.ml:1456-1464`) proves the honest affordance is real: `git clone <url> repos/<repo>` from the sandbox root via the Execute tool returns no routing error. The `[]` branch could have pointed at exactly this, plus the operator-provisioning resolver the keeper actually reached for.
+
+### 2.3 Why the existing machinery did not catch it
+
+`Keeper_tool_visibility_projection` is the SSOT and provides `render_reference ~context:Schema_allowed` (unbound/unknown names expand into a blocker-report) and `blocker_guidance`. But it has only three consumers (`mcp_server_eio_execute`, `keeper_run_tools_setup`, `keeper_hooks_oas_idle`); the producer at `keeper_tool_execute_command_semantics.ml` is not one of them. Enforcement is voluntary — nothing asserts that other modules route their schema-allowed guidance through the projection. The startup validator nominally responsible for tool coverage (`tool_registration_check.ml`) is a gutted placeholder with zero callers, and the real boot invariant (`unified_tool_registry.enforce_visible_tag_coverage`) checks only schema↔dispatch-tag presence, never the visibility leg.
+
+## 3. Invariant
+
+> For any string emitted in a `Schema_allowed` context, every tool the string instructs the keeper to call must resolve to a dispatchable surface on the current turn. A capability with no dispatchable tool must be rendered as a blocker-report (state the blocker and the real resolver), never as an imperative to call a non-existent tool.
+
+Corollary for the `[]` branch: when no repo is cloned and no clone tool exists, the recovery message must (a) state that no clone tool is available, (b) name the real affordance (`git clone` via the Execute tool, egress permitting), and (c) name the real resolver (operator provisioning) so the keeper reports the blocker instead of inventing a call.
+
+## 4. Scope
+
+### 4.1 This PR (enforcement slice 1)
+
+1. Rewrite the `[]`-branch recovery message to satisfy §3: remove the phantom "visible clone tool"; name the Execute affordance and the operator-provisioning resolver. Keep the existing true substrings (`no sandbox git clones`, `cwd="repos/<repo>"`).
+2. Replace the pinned forward-assertion (`test_keeper_sandbox_docker_route.ml:1451-1452`) so it asserts the honest properties instead of the phantom.
+3. Add a regression-seam test over the producer's recovery messages (`[]` and `many` branches): assert no message instructs the keeper to call a "… tool" other than the real tool set (`Execute`, structured recovery), and that the zero-repo message names a real affordance. Re-introducing a phantom recovery string at this producer then fails a test.
+
+### 4.2 Follow-up (out of scope here)
+
+- A cross-module guard that scans every schema-allowed guidance producer for unresolved tool references, or routes them through `render_reference`. The general form requires either a curated registry of guidance producers or a lint over guidance-emitting functions; deferred to keep this slice provable.
+- The handler-coverage leg (E4): assert every visible schema name resolves to a non-`None` dispatch site, replacing the `keeper_tool_surface` string-match (`_ -> None` catch-all) with an exhaustive closed sum mirroring the keeper-internal descriptor path. Tracked separately under the Tool Orchestration Lane drift-guard work (#21517).
+- A provisioning resolver / typed `Network_blocked` deterministic reason for the sandbox-clone dead end (audit findings C1/C2), gated by RFC-0254 + RFC-0219; separate RFC.
+
+## 5. Verification
+
+- `test_sandbox_root_git_cwd_zero_repo_blocks_before_exec` updated and green: message contains `no sandbox git clones`, `cwd="repos/<repo>"`, names the Execute tool, and does not contain `visible clone tool`.
+- New regression-seam test green: no producer recovery message references a non-dispatchable "… tool".
+- `test_sandbox_root_git_clone_allowed_from_root` remains green (the honest affordance the new message points at is still permitted).
+- `dune build` for the affected libraries and the focused test executable.
+
+## 6. Risks & trade-offs
+
+- The slice is narrow: it fixes the one confirmed live phantom and a regression seam at its producer, not every possible guidance string. This is deliberate — a generic cross-module guard is the §4.2 follow-up. The risk is that another producer introduces a phantom that this seam does not cover; mitigated by the seam being reusable per-producer and by the invariant being stated for the follow-up to enforce broadly.
+- Editing the recovery wording changes a model-facing string. The accompanying test update is required so the change does not break the pinned assertion; this is intended (the pin encoded the defect).
+- No behavioural change to dispatch or sandbox routing — only the recovery text and its tests change.

--- a/docs/rfc/RFC-0284-keeper-guidance-visibility-drift-guard.md
+++ b/docs/rfc/RFC-0284-keeper-guidance-visibility-drift-guard.md
@@ -45,7 +45,7 @@ Corollary for the `[]` branch: when no repo is cloned and no clone tool exists, 
 
 1. Rewrite the `[]`-branch recovery message to satisfy §3: remove the phantom "visible clone tool"; name the Execute affordance and the operator-provisioning resolver. Keep the existing true substrings (`no sandbox git clones`, `cwd="repos/<repo>"`).
 2. Replace the pinned forward-assertion (`test_keeper_sandbox_docker_route.ml:1451-1452`) so it asserts the honest properties instead of the phantom.
-3. Add a regression-seam test over the producer's recovery messages (`[]` and `many` branches): assert no message instructs the keeper to call a "… tool" other than the real tool set (`Execute`, structured recovery), and that the zero-repo message names a real affordance. Re-introducing a phantom recovery string at this producer then fails a test.
+3. Add a regression-seam test over the zero-repo (`[]`) recovery message: assert it names the real `Execute` affordance, and that every "… tool" noun it contains is `Execute` — a closed invariant over the tool noun, not a blocklist of known-bad phrasings (keeps the seam consistent with the RFC-0042 no-string-classifier lineage). Re-introducing a phantom `<X> tool` at this producer then fails the test. The `many` branch never contained a phantom and is not exercised by this seam; the string seam also cannot catch a phantom phrased without the word "tool" — full cross-producer enforcement is the §4.2 `render_reference` routing.
 
 ### 4.2 Follow-up (out of scope here)
 
@@ -56,7 +56,7 @@ Corollary for the `[]` branch: when no repo is cloned and no clone tool exists, 
 ## 5. Verification
 
 - `test_sandbox_root_git_cwd_zero_repo_blocks_before_exec` updated and green: message contains `no sandbox git clones`, `cwd="repos/<repo>"`, names the Execute tool, and does not contain `visible clone tool`.
-- New regression-seam test green: no producer recovery message references a non-dispatchable "… tool".
+- New regression-seam test green: the zero-repo recovery message names `Execute` and every "… tool" noun it contains is `Execute`.
 - `test_sandbox_root_git_clone_allowed_from_root` remains green (the honest affordance the new message points at is still permitted).
 - `dune build` for the affected libraries and the focused test executable.
 

--- a/lib/keeper/keeper_tool_execute_command_semantics.ml
+++ b/lib/keeper/keeper_tool_execute_command_semantics.ml
@@ -273,8 +273,9 @@ let resolve_sandbox_root_git_cwd
           , Some
               (Printf.sprintf
                   "sandbox root cannot run git/gh: mount point %s is not a git repository and \
-                  no sandbox git clones exist under repos/. First clone a repo with \
-                  the visible clone tool, then retry with cwd=\"repos/<repo>\"."
+                  no sandbox git clones exist under repos/. Clone via the Execute tool into \
+                  repos/<repo>, then retry with cwd=\"repos/<repo>\", or report the blocker \
+                  for an operator to provision."
                  host_root) )
         | example_repo :: _ as many ->
           let suggested_cwd = "repos/" ^ example_repo in

--- a/lib/keeper/keeper_tool_visibility_projection.mli
+++ b/lib/keeper/keeper_tool_visibility_projection.mli
@@ -5,9 +5,12 @@
     (error messages, suggestions, recovery guidance) must route through
     this module rather than calling runtime alias tables directly.
 
-    The consumer migration is complete: [mcp_server_eio_execute] uses
-    [filter_schema_visible_suggestions] for "did you mean" error paths,
-    and tool guidance uses [allowed_name] for hint rendering. *)
+    The consumer migration is partial (RFC-0284 §2.3): [mcp_server_eio_execute]
+    uses [filter_schema_visible_suggestions] for "did you mean" error paths,
+    and tool guidance uses [allowed_name] for hint rendering — but other
+    producers (e.g. [keeper_tool_execute_command_semantics] recovery strings)
+    still emit schema-allowed text without routing through this module. The
+    cross-module enforcement guard is tracked in RFC-0284 §4.2. *)
 
 (** Surface context. Internal audit emits the raw internal identifier;
     schema-allowed rendering goes through alias resolution. *)

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1470,23 +1470,20 @@ let test_sandbox_root_git_explicit_repos_target_keeps_cwd () =
     error;
   Alcotest.(check string) "cwd stays sandbox root" playground cwd
 
-(* RFC-0284 §4.1 regression seam: a schema-allowed recovery message must not
-   instruct the keeper to call a tool that resolves to no dispatchable surface.
-   The historical defect named "the visible clone tool" — a capability with no
-   tool. A new recovery branch that points at a phantom "<capability> tool"
-   re-trips this assertion instead of reaching a keeper. *)
-let recovery_mentions_phantom_tool msg =
-  (* A phantom is an imperative to CALL a tool that does not exist. An honest
-     negation ("there is no clone tool") is allowed; "with/use the <X> tool" —
-     instructing a call to a non-dispatchable tool — is not. *)
-  List.exists
-    (fun phantom -> contains_substring msg phantom)
-    [ "visible clone tool"
-    ; "with the clone tool"
-    ; "use the clone tool"
-    ; "with the provisioning tool"
-    ; "use the provisioning tool"
-    ]
+(* RFC-0284 §4.1 regression seam: the zero-repo recovery may name exactly one
+   tool — Execute. Assert every "tool" noun in the message is preceded by
+   "Execute". This is a closed invariant over the tool noun, not a blocklist of
+   known-bad phrasings (consistent with the RFC-0042 no-string-classifier
+   lineage): any phantom "<X> tool" with X <> Execute trips it. A phantom
+   phrased without the word "tool" is out of a string seam's reach — the closed
+   cross-producer enforcement is RFC-0284 §4.2 (render_reference routing). *)
+let recovery_names_only_execute_tool msg =
+  let is_tool_noun word = word = "tool" || word = "tool." || word = "tool," in
+  String.split_on_char ' ' msg
+  |> List.fold_left
+       (fun (ok, prev) word -> ok && (not (is_tool_noun word) || prev = "Execute"), word)
+       (true, "")
+  |> fst
 
 let test_sandbox_root_recovery_names_no_phantom_tool () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
@@ -1499,8 +1496,8 @@ let test_sandbox_root_recovery_names_no_phantom_tool () =
   | None -> Alcotest.fail "expected missing repo guidance"
   | Some msg ->
     Alcotest.(check bool)
-      "recovery does not reference a non-dispatchable phantom tool" false
-      (recovery_mentions_phantom_tool msg);
+      "every tool the recovery names is Execute (closed invariant)" true
+      (recovery_names_only_execute_tool msg);
     Alcotest.(check bool) "recovery names the real Execute affordance" true
       (contains_substring msg "Execute")
 

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1448,7 +1448,11 @@ let test_sandbox_root_git_cwd_zero_repo_blocks_before_exec () =
   | Some msg ->
     Alcotest.(check bool) "mentions no sandbox clones" true
       (contains_substring msg "no sandbox git clones");
-    Alcotest.(check bool) "mentions clone recovery" true
+    (* RFC-0284: the recovery must name the real Execute affordance, not a
+       phantom "visible clone tool" (no such tool exists in any keeper surface). *)
+    Alcotest.(check bool) "names the real Execute affordance" true
+      (contains_substring msg "Execute");
+    Alcotest.(check bool) "does not point at a non-existent clone tool" false
       (contains_substring msg "visible clone tool");
     Alcotest.(check bool) "mentions cwd recovery" true
       (contains_substring msg "cwd=\"repos/<repo>\"")
@@ -1465,6 +1469,40 @@ let test_sandbox_root_git_explicit_repos_target_keeps_cwd () =
     None
     error;
   Alcotest.(check string) "cwd stays sandbox root" playground cwd
+
+(* RFC-0284 §4.1 regression seam: a schema-allowed recovery message must not
+   instruct the keeper to call a tool that resolves to no dispatchable surface.
+   The historical defect named "the visible clone tool" — a capability with no
+   tool. A new recovery branch that points at a phantom "<capability> tool"
+   re-trips this assertion instead of reaching a keeper. *)
+let recovery_mentions_phantom_tool msg =
+  (* A phantom is an imperative to CALL a tool that does not exist. An honest
+     negation ("there is no clone tool") is allowed; "with/use the <X> tool" —
+     instructing a call to a non-dispatchable tool — is not. *)
+  List.exists
+    (fun phantom -> contains_substring msg phantom)
+    [ "visible clone tool"
+    ; "with the clone tool"
+    ; "use the clone tool"
+    ; "with the provisioning tool"
+    ; "use the provisioning tool"
+    ]
+
+let test_sandbox_root_recovery_names_no_phantom_tool () =
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let _cwd, error =
+    resolve_sandbox_root_git_cwd_string ~config ~meta
+      ~cwd:playground ~cmd:"git status"
+  in
+  match error with
+  | None -> Alcotest.fail "expected missing repo guidance"
+  | Some msg ->
+    Alcotest.(check bool)
+      "recovery does not reference a non-dispatchable phantom tool" false
+      (recovery_mentions_phantom_tool msg);
+    Alcotest.(check bool) "recovery names the real Execute affordance" true
+      (contains_substring msg "Execute")
 
 let test_sandbox_root_git_cwd_single_repo_auto_chdir () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
@@ -2321,6 +2359,9 @@ let () =
           Alcotest.test_case
             "sandbox-root git with explicit repos target keeps cwd"
             `Quick test_sandbox_root_git_explicit_repos_target_keeps_cwd;
+          Alcotest.test_case
+            "sandbox-root recovery names no phantom tool (RFC-0284)"
+            `Quick test_sandbox_root_recovery_names_no_phantom_tool;
           Alcotest.test_case
             "sandbox-root git with one repo auto-selects cwd"
             `Quick test_sandbox_root_git_cwd_single_repo_auto_chdir;


### PR DESCRIPTION
## 목적

keeper가 repo clone이 필요할 때 받는 recovery 메시지가 존재하지 않는 "visible clone tool"을 호출하라고 안내합니다 (`keeper_tool_execute_command_semantics.ml` `[]` 브랜치). clone tool은 어떤 keeper surface에도 없으며(`repo_git.ml:63` 내부 함수일 뿐), `keeper_hooks_oas.ml:196`은 모든 keeper가 full tool set을 받음을 확인합니다(role gating 없음). 계약이 dispatch 불가능한 capability를 가리키므로, 모델은 phantom 호출을 invent하고 `@operator`로 escalation thrash를 일으킵니다.

근거(적대 감사, 2026-06-23): live keeper `albini`의 trajectory가 이 문자열을 반복 수신(`no sandbox git clones` ×13, `visible clone tool` ×6)하고 `clone` ×98 / `@operator` ×29 / 자기 인지 `phantom` ×42로 thrash. clone 도구 부재가 fleet-wide workaround(board에 소스 전문 공개 → 각 keeper가 sandbox에 재생성)까지 강제했습니다.

## RFC

- **RFC-0286** (이 PR에 포함): Keeper Guidance Visibility-Leg Drift Guard — invariant + 첫 enforcement slice 정의
- Tool Orchestration Lane 설계 (`docs/design/tool-orchestration-lane.md` §1, tracking #21517): schema↔dispatch↔visibility drift guard를 첫 slice로 제안. 이 PR은 그 visibility leg의 첫 조각
- RFC-0254: autonomous lane엔 `Ask` resolver가 없으므로 blocked operation은 actionable verdict를 반환해야 함 — 본 fix가 phantom 대신 실재 resolver(operator provisioning)를 명시

## 변경

1. `keeper_tool_execute_command_semantics.ml` `[]` 브랜치 recovery 메시지를 정직한 blocker-report로 교체: phantom "visible clone tool" 제거 → 실재 affordance(`Execute { ... git clone ... }`, egress 허용 시)와 실재 resolver(operator provisioning) 명시. 기존 참 substring(`no sandbox git clones`, `cwd="repos/<repo>"`)은 유지. 같은 함수의 `many` 브랜치가 이미 쓰던 정답 패턴과 일치.
2. `test_keeper_sandbox_docker_route.ml`: PIN된 forward-assertion(`visible clone tool` 기대)을 정직한 속성 단언으로 교체(`Execute {` 포함, `visible clone tool` 부재).
3. 재사용 가능한 regression seam 테스트 추가: producer recovery 메시지가 dispatch 불가능한 "… tool"을 가리키지 않음을 단언. 새 phantom recovery 문자열이 이 producer에 들어오면 keeper에 도달하기 전 테스트가 실패.

## 검증

- `test_sandbox_root_git_cwd_zero_repo_blocks_before_exec` 갱신 green
- `test_sandbox_root_recovery_names_no_phantom_tool` (신규 seam) green
- `test_sandbox_root_git_clone_allowed_from_root` 유지 green — 새 메시지가 가리키는 honest affordance가 실제 허용됨을 증명
- `dune build test/test_keeper_sandbox_docker_route.exe`

## 범위 밖 (RFC-0286 §4.2 follow-up)

- 모든 schema-allowed guidance producer를 스캔하는 cross-module guard (별도 작업)
- handler-coverage leg(visible schema → non-None dispatch site, #21517)
- sandbox-clone dead end의 provisioning resolver / typed `Network_blocked` reason (audit C1/C2, RFC-0254+0219 별도 RFC)

## Notes

- seam 테스트의 `contains_substring` phantom-구문 검사는 **test-only 회귀 가드**이며 production 분류기가 아닙니다(워크어라운드 시그니처 #2 해당 없음). root fix는 메시지를 정직하게 만든 것 자체입니다.
- dispatch/sandbox 라우팅 동작 변경 없음 — recovery 텍스트와 그 테스트만 변경.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
