### PR TITLE
fix(fusion): sum all failed-judge usage on JOJ all-fail path

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -149,18 +149,24 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
               in
               (match ok_priors with
                | [] ->
-                 (* 전원 실패 — meta할 종합 없음. 첫 에러를 대표로 전파(usage 동반).
-                    관측엔 1차 실패 노드만 남는다(meta 노드 없음, RFC-0284). *)
+                 (* 전원 실패 — meta할 종합 없음. 첫 에러를 대표 메시지로 전파하되, 모든 1차
+                    심판이 태운 토큰을 sum_error_usage로 합산해 usage에 싣는다(undercount
+                    교정, 적대 리뷰 #22093 all-fail; ok_priors=[]이면 firsts는 전부 Error라
+                    fold가 모든 실패 usage를 모은다). 관측엔 1차 실패 노드만 남는다(meta
+                    노드 없음, RFC-0284). observe(#22112)의 (Error err, first_nodes) 관측
+                    구조와 #22122의 usage 회계를 합친 형태 — 두 축은 직교한다. *)
+                 let failed_usage = Fusion_types.sum_error_usage firsts in
                  let err =
                    match
                      List.find_map
-                       (fun (_, r) -> match r with Error e -> Some e | Ok _ -> None)
+                       (fun (_, r) ->
+                         match r with Error (msg, _) -> Some msg | Ok _ -> None)
                        firsts
                    with
-                   | Some e -> e
+                   | Some msg -> (msg, failed_usage)
                    | None ->
-                     ( "judge_of_judges: no judge produced a synthesis"
-                     , Fusion_types.zero_usage )
+                     (* 도달 불가: ok_priors=[]이면 firsts는 전부 Error. fail-closed 방어. *)
+                     ("judge_of_judges: no judge produced a synthesis", failed_usage)
                  in
                  (Error err, first_nodes)
                | (_, first_s, _) :: _ ->

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -14,6 +14,17 @@ let add_usage a b =
   ; output_tokens = a.output_tokens + b.output_tokens
   }
 
+(* [Error] 분기의 usage를 모두 합산한다([Ok]는 무시). 전원 실패 같은 degrade 경로에서
+   첫 에러의 usage만 전파하면 나머지 심판이 태운 토큰을 undercount하므로(적대 리뷰
+   #22093 all-fail), 실패분 usage를 fold해 총 소비를 보존한다. *)
+let sum_error_usage results =
+  List.fold_left
+    (fun acc (_, r) ->
+      match r with
+      | Error (_, u) -> add_usage acc u
+      | Ok _ -> acc)
+    zero_usage results
+
 module Fusion_depth = struct
   type t =
     | Top

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -27,6 +27,11 @@ val zero_usage : usage
 (** 두 사용량의 합 (패널 N + 심판 회계용). *)
 val add_usage : usage -> usage -> usage
 
+(** [sum_error_usage results]는 [results]의 [Error] 원소가 소비한 usage를 모두 합산한다
+    ([Ok]은 무시). 전원 실패 등 degrade 경로에서 첫 에러의 usage만 전파해 나머지 심판이
+    태운 토큰을 잃는 undercount를 막는다(적대 리뷰 #22093 all-fail). *)
+val sum_error_usage : ('id * ('ok, 'msg * usage) result) list -> usage
+
 (** {1 재귀 가드} *)
 
 (** 심의 깊이. OpenRouter의 [x-openrouter-fusion-depth] 헤더에 대응하는 타입드

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -39,11 +39,36 @@ let test_attach_usage_on_parse_failure () =
       usage
   | Ok _ -> fail "expected Error with usage"
 
+let test_sum_error_usage_folds_all_failures () =
+  (* 적대 리뷰 #22093 all-fail: judge-of-judges 전원 실패 시 첫 에러의 usage만 전파하면
+     나머지 심판이 (병렬로) 태운 토큰을 잃어 비용을 undercount한다. sum_error_usage는
+     모든 Error usage를 합산하고 Ok는 무시함을 핀한다. *)
+  let u input_tokens output_tokens : Fusion_types.usage =
+    { Fusion_types.input_tokens; output_tokens }
+  in
+  let results =
+    [ ("j1", Error ("boom1", u 100 10))
+    ; ("j2", Ok (sample_synthesis, u 999 999)) (* Ok 원소는 무시되어야 함 *)
+    ; ("j3", Error ("boom3", u 25 5))
+    ]
+  in
+  check usage_t "sums every failed judge's usage and ignores Ok" (u 125 15)
+    (Fusion_types.sum_error_usage results)
+
+let test_sum_error_usage_empty_is_zero () =
+  check usage_t "no results -> zero usage" Fusion_types.zero_usage
+    (Fusion_types.sum_error_usage [])
+
 let () =
   run "fusion_judge_usage"
     [ ( "attach_usage"
       , [ test_case "success carries usage" `Quick test_attach_usage_on_success
         ; test_case "parse failure carries usage" `Quick
             test_attach_usage_on_parse_failure
+        ] )
+    ; ( "sum_error_usage"
+      , [ test_case "folds all failures, ignores Ok" `Quick
+            test_sum_error_usage_folds_all_failures
+        ; test_case "empty is zero" `Quick test_sum_error_usage_empty_is_zero
         ] )
     ]


### PR DESCRIPTION
## 무엇

judge-of-judges(JOJ) 위상의 **전원 실패(all-fail) 경로에서 usage 미집계**를 고칩니다. 적대 리뷰 #22093 (https://github.com/jeong-sik/masc/pull/22093#issuecomment-4775104494)에서 짚은 🟡 finding의 follow-up (#22093은 이미 머지됨 → main 대상 PR).

## 왜

JOJ는 N개 1차 심판을 `Eio.Fiber.List.map`으로 병렬 실행합니다. 전원 실패 시 기존 코드는:

```ocaml
| Some e -> Error e   (* 첫 실패 심판의 (msg, usage) 하나만 *)
```

로 **첫 실패 심판의 usage만** 전파해, judges 2..N이 (각자 토큰을 태우고) 실패한 비용을 버렸습니다. 성공 경로(`firsts_usage` fold)와 meta-실패 경로(`add_usage firsts_usage meta_u`)는 모든 usage를 합산하는데 all-fail만 비대칭이라, 이 위상 자신의 #22087 §1 원칙("degrade 경로가 태운 토큰을 버리지 않는다")을 스스로 위반했습니다. fusion이 전체 실패해도 운영자는 총 소비 토큰(N심판 합)을 비용/디버깅에 필요로 합니다.

## 변경

- `Fusion_types.sum_error_usage` 추출 — 결과 리스트의 `Error` usage를 모두 fold(`Ok` 무시). 순수 함수, leaf 모듈(fusion_types)에 배치.
- all-fail 분기가 이 헬퍼를 사용해 **모든 실패 심판 usage를 합산**하고, 대표 에러 **메시지는 첫 실패 그대로** 유지.
- `test/test_fusion_judge_usage.ml`에 단위 테스트 2개(다중 실패 합산 + Ok 무시, empty=zero). 이 파일은 #22087 §1 usage 불변식의 canonical 테스트 위치.

## 검증

- 타입: `sum_error_usage : ('id * ('ok, 'msg * usage) result) list -> usage` — orchestrator의 `firsts`(`(panelist_id * (judge_synthesis * usage, string * usage) result) list`)와 단위. 헬퍼를 production 경로(all-fail)가 직접 호출하므로 테스트가 실제 코드를 덮음.
- 로컬 빌드 미수행(레포 정책) → CI의 `Build and Test`로 검증.

## 비고

대표 에러 선택은 여전히 "첫 에러" 메시지입니다(기존 동작 보존). 변경된 것은 usage가 단일→합산뿐이라 동작 회귀 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

RFC-WAIVED: fusion usage 회계 버그 fix, RFC-gated subsystem(credential/sandbox/operator/hooks/workflow) 아님. #22087(RFC-0252 §10) 기존 원칙의 적용 확장.
