### PR TITLE
fix(keeper): reject .. escape in repos/ target path hint (sandbox, #22118 follow-up)

### DIFF
--- a/lib/keeper/keeper_tool_execute_command_semantics.ml
+++ b/lib/keeper/keeper_tool_execute_command_semantics.ml
@@ -207,7 +207,14 @@ let normalize_repos_path_token token =
     else token
   in
   match String.split_on_char '/' token with
-  | "repos" :: repo :: _ when safe_repo_name repo -> Some token
+  | "repos" :: repo :: rest
+    when safe_repo_name repo
+         && not (List.exists (fun seg -> seg = ".." || seg = ".") rest) ->
+    (* repos/<safe-name>/... 만 repos/ 타겟으로 인정한다. 첫 세그먼트는
+       [safe_repo_name]으로, 뒤 세그먼트는 [..]/[.] 부재로 검사한다. 이전 구현은
+       첫 세그먼트만 검사해 [repos/valid/../../escape]가 repos/ 밖으로 빠져나가면서도
+       hint를 통과했다(적대 리뷰 #22118 finding B — repos/-containment 불변식 위반). *)
+    Some token
   | _ -> None
 
 let repos_path_hint_of_stages ~cmd stages =

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -1466,6 +1466,23 @@ let test_sandbox_root_git_explicit_repos_target_keeps_cwd () =
     error;
   Alcotest.(check string) "cwd stays sandbox root" playground cwd
 
+let test_sandbox_root_git_repos_target_rejects_dotdot_escape () =
+  (* 적대 리뷰 #22118 finding B: [repos/<safe>/../../escape]는 repos/ 밖으로
+     빠져나가므로 repos/ 타겟으로 인정하면 안 된다. hint가 거부되어, 빈 playground
+     에서는 "no sandbox git clones" 에러로 떨어진다. 첫 세그먼트만 검사하던 이전
+     구현은 이 토큰을 통과시켜 cwd를 sandbox root로 유지했다(불변식 위반). *)
+  setup ~sandbox:Keeper_types_profile_sandbox.Docker
+  @@ fun ~config ~meta ~playground ->
+  let _cwd, error =
+    resolve_sandbox_root_git_cwd_string ~config ~meta
+      ~cwd:playground
+      ~cmd:"git clone https://github.com/example/repo.git repos/repo/../../escape"
+  in
+  Alcotest.(check bool)
+    "dotdot-escaping repos target is not accepted as a repos/ hint"
+    true
+    (Option.is_some error)
+
 let test_sandbox_root_git_cwd_single_repo_auto_chdir () =
   setup ~sandbox:Keeper_types_profile_sandbox.Docker
   @@ fun ~config ~meta ~playground ->
@@ -2321,6 +2338,9 @@ let () =
           Alcotest.test_case
             "sandbox-root git with explicit repos target keeps cwd"
             `Quick test_sandbox_root_git_explicit_repos_target_keeps_cwd;
+          Alcotest.test_case
+            "sandbox-root git repos target rejects .. escape"
+            `Quick test_sandbox_root_git_repos_target_rejects_dotdot_escape;
           Alcotest.test_case
             "sandbox-root git with one repo auto-selects cwd"
             `Quick test_sandbox_root_git_cwd_single_repo_auto_chdir;


### PR DESCRIPTION
## 무엇

merged #22118의 적대 리뷰 finding B를 고칩니다 (https://github.com/jeong-sik/masc/pull/22118#issuecomment-4775069065). #22118이 이미 머지되어 main 대상 follow-up PR.

## 왜 (보안 — repos/-containment 불변식)

sandbox root에서 git/gh 명령을 라우팅하는 `normalize_repos_path_token`이 `repos/` 다음 **첫 세그먼트만** `safe_repo_name`으로 검사했습니다:

```ocaml
| "repos" :: repo :: _ when safe_repo_name repo -> Some token   (* repo만 검사, 나머지 _ 무검증 *)
```

`safe_repo_name`은 `..`/`.`/`/`를 막지만 두 번째 이후 세그먼트엔 적용되지 않아:
- `repos/../escape` → `repo=".."` → 거부 ✅
- `repos/valid/../../escape` → `repo="valid"`(통과) → **`Some` 반환** → root cwd 유지하고 그 경로로 실행 ❌

정책이 주장하는 "clone/명령이 `repos/` 하위에 머문다"는 불변식이 `..`로 깨졌습니다. Docker가 host FS escape는 막으므로 **host 탈출은 아니나**, 정책 자신의 repos/-containment가 sandbox 내에서 우회됩니다.

## 변경

`repos/<safe>` 뒤 세그먼트 중 `..`/`.`가 하나라도 있으면 거부:

```ocaml
| "repos" :: repo :: rest
  when safe_repo_name repo
       && not (List.exists (fun seg -> seg = ".." || seg = ".") rest) ->
  Some token
```

정상 케이스(`repos/repo`, `repos/repo/sub`, trailing slash)는 보존, traversal만 차단. `test_keeper_sandbox_docker_route.ml`에 회귀 테스트 추가(`repos/repo/../../escape` → hint 거부 → 빈 playground에서 에러).

## 검증

- 로컬 빌드 미수행(레포 정책) → CI `Build and Test`.
- 테스트: `..`-escaping 타겟이 repos/ hint로 인정되지 않음(`Option.is_some error`).

## 남은 finding (이 PR 범위 밖, 추적용)

- **finding C (제약 지옥)**: bare `git clone <url>`(dest 없음) + 빈 playground → "first clone a repo" 메시지가 clone 명령엔 오도. clone 감지 후 "`git clone <url> repos/<name>`" 안내로 교체 필요. capabilities.md prompt가 dest를 안내하므로 compliant keeper는 무영향이라 별 PR로 분리.
- **finding A (SSOT)**: 라우팅이 typed `dest_dir`(#22118에서 도입) 대신 raw args를 string-scan. typed IR로 라우팅을 일원화하는 리팩터는 별도.

## RFC

shell-IR / sandbox 라우팅 인접 변경. 관련 RFC: RFC-0006(keeper-surface-and-sandbox), RFC-0091(execute-typed-argv), RFC-0160(shell-ir-first-class). 신규 정책 도입이 아니라 기존 `normalize_repos_path_token` 검증 강화(하드닝)이므로 신규 RFC 불요.
RFC-WAIVED: 기존 sandbox 라우팅 검증의 traversal 하드닝, 신규 surface/정책 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
