### PR TITLE
docs(keeper): correct manifest helper .mli — effectful, not pure (#22114 follow-up)

### DIFF
--- a/lib/keeper/keeper_unified_turn_manifest.mli
+++ b/lib/keeper/keeper_unified_turn_manifest.mli
@@ -1,13 +1,14 @@
 (** Manifest append helpers for [Keeper_unified_turn].
 
     Extracted from [run_keeper_cycle] so the orchestrator does not own
-    manifest-construction details. These functions are effectful: they read
-    the monotonic clock ([Mtime_clock.now]) for elapsed-time clock refs and
-    perform best-effort manifest append I/O
-    ([Keeper_runtime_manifest.append_best_effort]). The
-    [Keeper_unified_turn_types.turn_state] is threaded immutably — each call
-    returns a new value with an incremented [manifest_seq] rather than mutating
-    in place.
+    manifest-construction details. These functions perform best-effort manifest
+    append I/O ([Keeper_runtime_manifest.append_best_effort]). When
+    [clock_refs] is omitted they also read the monotonic clock
+    ([Mtime_clock.now]) for elapsed-time clock refs and return a new
+    [turn_state] whose [manifest_seq] is incremented; when [clock_refs] is
+    supplied explicitly the provided refs are used and [manifest_seq] is left
+    unchanged. The [Keeper_unified_turn_types.turn_state] is threaded
+    immutably in both cases.
 
     @since God file decomposition *)
 

--- a/lib/keeper/keeper_unified_turn_manifest.mli
+++ b/lib/keeper/keeper_unified_turn_manifest.mli
@@ -1,8 +1,13 @@
 (** Manifest append helpers for [Keeper_unified_turn].
 
     Extracted from [run_keeper_cycle] so the orchestrator does not own
-    manifest-construction details. All functions are pure state transformers
-    on the immutable [Keeper_unified_turn_types.turn_state] accumulator.
+    manifest-construction details. These functions are effectful: they read
+    the monotonic clock ([Mtime_clock.now]) for elapsed-time clock refs and
+    perform best-effort manifest append I/O
+    ([Keeper_runtime_manifest.append_best_effort]). The
+    [Keeper_unified_turn_types.turn_state] is threaded immutably — each call
+    returns a new value with an incremented [manifest_seq] rather than mutating
+    in place.
 
     @since God file decomposition *)
 


### PR DESCRIPTION
merged #22114의 적대 리뷰 doc finding follow-up (https://github.com/jeong-sik/masc/pull/22114#issuecomment-4774988748).

`append_manifest`는 `Mtime_clock.now`(클럭 읽기) + `Keeper_runtime_manifest.append_best_effort`(I/O)를 수행하므로 "pure state transformers"가 아닙니다. effectful임을 명시하고 immutable turn_state threading 설명은 유지. OCaml은 효과를 타입으로 강제하지 않으므로 docstring이 유일 계약 표면 — 정확해야 합니다.

docs-only, RFC 불요.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
