### PR TITLE
fix(keeper): make no-progress detector outcome-aware via typed channel (RFC-0239)

### DIFF
--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -134,6 +134,45 @@ let delivery_requires_evidence = function
   | User_facing | Task_claim -> false
 ;;
 
+(* RFC-0239 / audit D1·D3: the no-progress verdict reads the typed
+   determinism-boundary outcome ([Keeper_tool_outcome]) recorded on each tool
+   call, not just the tool name. A completion/execution call that typed a
+   failure is not evidence; a claim that typed [No_progress] did not bind work,
+   so the [Task_claim] exemption must not apply to it. A [None] typed outcome
+   keeps the legacy name-based behavior: this only DEMOTES on an explicit typed
+   failure / no-progress signal, never promotes, so tools that do not emit a
+   typed outcome are never newly flagged as no-progress. *)
+let typed_outcome_is_nonprogress (outcome : Keeper_tool_outcome.t option) =
+  match outcome with
+  | Some (Keeper_tool_outcome.No_progress _ | Keeper_tool_outcome.Error _) -> true
+  | Some Keeper_tool_outcome.Progress | None -> false
+;;
+
+(* Outcome-aware substantive evidence: an execution/completion tool whose typed
+   outcome is not a failure. Mirrors [Keeper_unified_metrics.has_substantive_tool_calls]
+   (name-only) but drops calls the typed channel marked errored / no-progress. *)
+let has_substantive_tool_calls_with_outcome
+      (calls : (string * Keeper_tool_outcome.t option) list) =
+  List.exists
+    (fun (name, outcome) ->
+       Keeper_tool_progress.is_execution_progress_tool_name name
+       && not (typed_outcome_is_nonprogress outcome))
+    calls
+;;
+
+(* A [Task_claim] turn is exempt from evidence only when a claim actually bound
+   work. A claim that typed [No_progress] (No_eligible_tasks / No_work_available
+   / Resource_conflict) did not bind work and must accrue the no-progress streak
+   (the sangsu claim-idle loop, PR #21065 diagnosis). An untyped claim ([None])
+   stays exempt for back-compat. *)
+let claim_bound_work (calls : (string * Keeper_tool_outcome.t option) list) =
+  List.exists
+    (fun (name, outcome) ->
+       Keeper_tool_progress.is_claim_context_tool_name name
+       && not (typed_outcome_is_nonprogress outcome))
+    calls
+;;
+
 let apply_loop_detectors ~config ~observation updated_meta result =
   (* RFC-0239 §3 R3 / RFC-0276 §3.2: feed the loop detector a semantic
      no-progress verdict derived from observed turn facts, not the LLM
@@ -143,12 +182,23 @@ let apply_loop_detectors ~config ~observation updated_meta result =
      evidence accrues the streak. The retired self-report "stay silent" reset
      the streak whenever a keeper *posted* its "nothing to do" conclusion, so a
      cluster that thrashed by re-posting never tripped the detector. *)
+  let calls_with_outcomes =
+    List.map
+      (fun (d : Keeper_agent_result.tool_call_detail) ->
+         d.tool_name, d.typed_outcome)
+      result.Keeper_agent_run.tool_calls
+  in
   let strong_evidence =
-    KUM.has_substantive_tool_calls (Keeper_agent_result.tool_names result)
+    has_substantive_tool_calls_with_outcome calls_with_outcomes
     || Option.is_some (KUM.visible_run_validation result)
   in
+  (* [Task_claim] is exempt only when a claim bound work; a claim that typed
+     [No_progress] (e.g. No_eligible_tasks) now requires evidence and so accrues
+     the streak. Other surfaces keep the exhaustive name-based mapping. *)
   let surface_requires_evidence =
-    delivery_requires_evidence (classify_turn_delivery result)
+    match classify_turn_delivery result with
+    | Task_claim -> not (claim_bound_work calls_with_outcomes)
+    | (Peer_only | User_facing) as delivery -> delivery_requires_evidence delivery
   in
   let made_progress =
     Keeper_no_progress_loop_detector.turn_made_progress
@@ -196,6 +246,8 @@ module For_testing = struct
 
   let classify_delivery = classify_delivery
   let delivery_requires_evidence = delivery_requires_evidence
+  let has_substantive_tool_calls_with_outcome = has_substantive_tool_calls_with_outcome
+  let claim_bound_work = claim_bound_work
 end
 
 let append_metrics_snapshot

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -28,6 +28,18 @@ module For_testing : sig
     -> turn_delivery
 
   val delivery_requires_evidence : turn_delivery -> bool
+
+  (** Outcome-aware substantive evidence (audit D1): an execution/completion
+      tool whose typed outcome is not a failure. A [None] typed outcome keeps
+      the legacy name-based behavior. *)
+  val has_substantive_tool_calls_with_outcome
+    : (string * Keeper_tool_outcome.t option) list -> bool
+
+  (** Did a claim-context call bind work (audit D3)? [Progress]/[None] => yes;
+      a typed [No_progress]/[Error] claim did not bind work, so a [Task_claim]
+      turn is no longer exempt from the no-progress streak. *)
+  val claim_bound_work
+    : (string * Keeper_tool_outcome.t option) list -> bool
 end
 
 val handle

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -357,6 +357,71 @@ let test_silent_turns_accrue_streak () =
   Alcotest.(check int) "silent no-evidence turns accrue streak" 4
     (D.current_streak ~keeper_name:k)
 
+(* RFC-0239 / audit D1·D3: the no-progress detector reads the typed outcome
+   recorded on each tool call, not just the tool name. *)
+module Outcome = Keeper_tool_outcome
+
+let no_eligible_outcome =
+  Outcome.No_progress
+    { reason =
+        Outcome.No_eligible_tasks
+          { scope_excluded_count = 0
+          ; blocked_count = 0
+          ; verification_blocked_count = 0
+          ; all_goals_excluded = false
+          }
+    }
+
+(* audit D3: a [Task_claim] turn is exempt only when a claim bound work. A claim
+   that typed [No_eligible_tasks] did not bind work (the sangsu claim-idle loop,
+   PR #21065), so it must require evidence and accrue the streak. *)
+let test_claim_outcome_aware_exemption () =
+  let claim = List.hd Cap.claim_task_tool_names in
+  Alcotest.(check bool) "claim No_eligible_tasks did not bind work" false
+    (Success.claim_bound_work [ (claim, Some no_eligible_outcome) ]);
+  Alcotest.(check bool) "claim Progress bound work" true
+    (Success.claim_bound_work [ (claim, Some Outcome.Progress) ]);
+  Alcotest.(check bool) "untyped claim stays exempt (legacy back-compat)" true
+    (Success.claim_bound_work [ (claim, None) ])
+
+(* audit D1: a completion tool that typed a failure is not substantive evidence;
+   an untyped completion keeps the legacy name-based behavior. *)
+let test_strong_evidence_outcome_aware () =
+  let done_tool = List.hd Masc.Keeper_tool_progress.completion_tool_names in
+  let claim = List.hd Cap.claim_task_tool_names in
+  Alcotest.(check bool) "errored completion is not evidence" false
+    (Success.has_substantive_tool_calls_with_outcome
+       [ (done_tool, Some (Outcome.Error { reason = "rejected" })) ]);
+  Alcotest.(check bool) "no-progress completion is not evidence" false
+    (Success.has_substantive_tool_calls_with_outcome
+       [ (done_tool, Some no_eligible_outcome) ]);
+  Alcotest.(check bool) "successful completion is evidence" true
+    (Success.has_substantive_tool_calls_with_outcome
+       [ (done_tool, Some Outcome.Progress) ]);
+  Alcotest.(check bool) "untyped completion keeps legacy evidence" true
+    (Success.has_substantive_tool_calls_with_outcome [ (done_tool, None) ]);
+  Alcotest.(check bool) "a claim is never execution evidence" false
+    (Success.has_substantive_tool_calls_with_outcome
+       [ (claim, Some Outcome.Progress) ])
+
+(* End-to-end: the sangsu claim-idle loop now accrues the streak; a claim that
+   bound work stays exempt. *)
+let test_sangsu_claim_idle_loop_accrues () =
+  let claim = List.hd Cap.claim_task_tool_names in
+  let idle = [ (claim, Some no_eligible_outcome) ] in
+  let strong_evidence = Success.has_substantive_tool_calls_with_outcome idle in
+  let surface_requires_evidence = not (Success.claim_bound_work idle) in
+  Alcotest.(check bool) "no strong evidence from a no-eligible claim" false
+    strong_evidence;
+  Alcotest.(check bool) "no-eligible claim now requires evidence" true
+    surface_requires_evidence;
+  Alcotest.(check bool) "made_progress false => streak accrues" false
+    (D.turn_made_progress ~strong_evidence ~surface_requires_evidence);
+  let bound = [ (claim, Some Outcome.Progress) ] in
+  Alcotest.(check bool) "claim that bound work stays exempt" true
+    (D.turn_made_progress ~strong_evidence:false
+       ~surface_requires_evidence:(not (Success.claim_bound_work bound)))
+
 let () =
   Alcotest.run "keeper_no_progress_loop_detector"
     [
@@ -394,6 +459,12 @@ let () =
             `Quick test_delivery_requires_evidence_mapping;
           Alcotest.test_case "silent no-evidence turns accrue streak"
             `Quick (with_eio test_silent_turns_accrue_streak);
+          Alcotest.test_case "claim exemption is outcome-aware (D3)"
+            `Quick test_claim_outcome_aware_exemption;
+          Alcotest.test_case "strong evidence drops typed-failure completions (D1)"
+            `Quick test_strong_evidence_outcome_aware;
+          Alcotest.test_case "sangsu claim-idle loop accrues streak"
+            `Quick test_sangsu_claim_idle_loop_accrues;
         ] );
       ( "per-keeper isolation",
         [


### PR DESCRIPTION
## 목적

RFC-0239 no-progress loop detector가 turn의 진행 여부를 **tool 이름만으로**(`has_substantive_tool_calls`가 `tool_names`를 받아 `is_execution_progress_tool_name`로 판정) 판정해, 거부된/no-op tool 호출도 progress로 집계합니다. 결과로 anti-thrash streak이 누적되지 않아 detector가 무력화됩니다.

근거(적대 감사, 2026-06-23):
- **D3 (sangsu, PR #21065):** `keeper_task_claim`이 `No_eligible_tasks`를 반환해도 `classify_delivery`가 무조건 `Task_claim`(evidence 면제)으로 분류 → 매 턴 progress 점수 → claim→재claim idle loop가 streak에 안 잡힘.
- **D1:** `tool_names`가 `typed_outcome`를 drop하므로, typed failure를 emit한 completion 도구(`keeper_task_done`/`masc_deliver`)도 이름만으로 evidence로 집계.
- **D2:** task-555가 도입한 typed-outcome 채널(`Keeper_tool_outcome`)이 `tool_call_detail.typed_outcome`에 기록되나 detector가 **읽지 않음**. 정확한 fix primitive가 dead.

## 변경 (root fix: 이름-기반 분류기를 typed 채널로 교체)

`keeper_unified_turn_success.apply_loop_detectors`가 이미 기록된 per-call `typed_outcome`를 읽도록 재배선:
- `strong_evidence`: execution/completion 도구라도 `typed_outcome`가 `Error`/`No_progress`면 evidence에서 제외 (D1).
- `Task_claim` 면제: claim이 실제로 work를 bind(`typed_outcome = Progress`)했을 때만 면제. `No_progress`(No_eligible_tasks 등) claim은 evidence를 요구해 streak 누적 (D3).
- pure helper(`has_substantive_tool_calls_with_outcome`, `claim_bound_work`)로 추출해 `For_testing`에 노출.

**Conservative 설계 (blast radius 한정):** `typed_outcome = None`이면 legacy 이름-기반 동작 유지. 즉 **명시적 typed failure/no-progress 신호일 때만 demote, 절대 promote 안 함**. typed outcome을 emit하지 않는 도구는 새로 no-progress로 오분류되지 않음 → 안전 머신에 대한 false-positive thrash flag 위험 없음.

## 검증

- `test_no_progress_loop_detector`에 3개 케이스 추가, 전부 green:
  - claim `No_eligible_tasks` → not bound work → evidence 요구 (D3)
  - completion `Error`/`No_progress` → not evidence; `Progress`/`None` → evidence (D1)
  - sangsu claim-idle loop → `made_progress=false` → streak 누적; bound-work claim → 면제 유지
- `dune build test/test_no_progress_loop_detector.exe` + 기존 detector 테스트 회귀 없음.

## 범위 밖 (정직한 residual)

- `keeper_task_done` rejection은 현재 `typed_outcome = None`을 emit합니다(`keeper_tool_task_runtime.ml:833 else None`, 그리고 빈 task_id/result rejection은 `workflow_rejection_error_json` 경유로 typed 없음). 따라서 **거부된 done은 아직 demote되지 않습니다**. done/deliver rejection 경로가 typed `Error`를 emit하게 하는 것은 핸들러 측 determinism-boundary fix로 별도 follow-up(audit D1 잔여). 이 PR은 detector(consumer) 측 배선만 다룸 — typed failure를 emit하는 모든 도구(claim 포함)는 즉시 효과.
- `classify_tool_progress_with_outcome`의 `Streak_reset_and_empty_queue_sleep` 효과를 phase gate(EmptyQueueSleep 전이)에 배선하는 것은 별도 기능.

## Notes

- workaround 아님: name-only 분류기를 typed sum(`Keeper_tool_outcome`)로 **교체**하는 root fix (CLAUDE.md 워크어라운드 시그니처 #2 "string 분류기 보강"의 역방향 — 분류기를 제거하고 컴파일러가 강제하는 typed 채널로 이동).
- 안전 머신(RFC-0239) 동작 변경이므로 typed 테스트로 양방향(demote/면제유지) 증명.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>