### PR TITLE
test(perf): main-domain scheduler-starvation gate + keeper-load mock

### DIFF
--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -499,110 +499,92 @@ let handle_keeper_get_subroutes state req request reqd =
         |> max 1 |> min trajectory_max_limit
       in
       let config = (Mcp_server.workspace_config state) in
-      (* RFC-0204 Phase 0: this turn-records read (Dated_jsonl directory scan +
-         per-row Yojson decode + consecutive-pair block diff + memory_os/
-         user_model file reads) previously ran inline on the calling fiber's
-         main Eio domain, uncached, fanned out per keeper. Under serving
-         concurrency that synchronous head-of-line work starves the single
-         serving domain (scheduler_starvation_gate.sh reproduces it). Mirror the
-         sibling /tool-stats handler above and PRs #19088 / #19097: cache +
-         offload, with the key including every input that changes the result. *)
-      let cache_key =
-        Printf.sprintf "keeper:turn-records:%s:%s:%d"
-          (Workspace.masc_root_dir config) name limit
+      let store = Keeper_types_support.keeper_turn_record_store config name in
+      let raw_rows = Dated_jsonl.read_recent store limit in
+      (* Strict decode: malformed rows are counted and reported, never
+         repaired or silently dropped (RFC-0233 §4). *)
+      let records_rev, skipped_rows =
+        List.fold_left
+          (fun (acc, skipped) json ->
+            match Turn_record.of_json json with
+            | Ok record -> (record :: acc, skipped)
+            | Error _ -> (acc, skipped + 1))
+          ([], 0) raw_rows
       in
-      let json =
-        Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
-          Domain_pool_ref.submit_io_or_inline (fun () ->
-            let store =
-              Keeper_types_support.keeper_turn_record_store config name
-            in
-            let raw_rows = Dated_jsonl.read_recent store limit in
-            (* Strict decode: malformed rows are counted and reported, never
-               repaired or silently dropped (RFC-0233 §4). *)
-            let records_rev, skipped_rows =
-              List.fold_left
-                (fun (acc, skipped) json ->
-                  match Turn_record.of_json json with
-                  | Ok record -> (record :: acc, skipped)
-                  | Error _ -> (acc, skipped + 1))
-                ([], 0) raw_rows
-            in
-            let records = List.rev records_rev in
-            let block_json = Turn_record.prompt_block_to_json in
-            let entries =
-              Turn_record.entries_with_diffs records
-              |> List.map (fun ((record : Turn_record.t), diff) ->
-                   let diff_vs_prev =
-                     match diff with
-                     | Some (d : Turn_record.block_diff) ->
-                       `Assoc
-                         [ ("added", `List (List.map block_json d.added))
-                         ; ("removed", `List (List.map block_json d.removed))
-                         ; ( "changed"
-                           , `List
-                               (List.map
-                                  (fun (prev_b, next_b) ->
-                                    `Assoc
-                                      [ ("prev", block_json prev_b)
-                                      ; ("next", block_json next_b)
-                                      ])
-                                  d.changed) )
-                         ]
-                     | None -> `Null
-                   in
-                   `Assoc
-                     [ ("record", Turn_record.to_json record)
-                     ; ("diff_vs_prev", diff_vs_prev)
-                     ])
-            in
-            let latest_ts =
-              List.fold_left
-                (fun acc (r : Turn_record.t) ->
-                  match acc with
-                  | Some existing when existing >= r.ts -> acc
-                  | _ -> Some r.ts)
-                None records
-            in
-            let latest_age_s =
-              match latest_ts with
-              | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
-              | None -> None
-            in
-            let health, stale_reason =
-              match latest_age_s with
-              | None -> ("empty", "no_entries")
-              | Some age when age > freshness_slo_s ->
-                  ("stale", "freshness_slo_exceeded")
-              | Some _ -> ("ok", "")
-            in
-            `Assoc [
-              ("keeper", `String name);
-              ("count", `Int (List.length records));
-              ("skipped_rows", `Int skipped_rows);
-              ("source", `String "turn_record");
-              ("producer", `String "keeper_agent_run.run_turn|keeper_turn_record_writer");
-              ( "durable_store",
-                `String
-                  (Filename.concat
-                     (Workspace.masc_root_dir config)
-                     (Printf.sprintf "keepers/%s/turn-records" name)) );
-              ("dashboard_surface", `String "/api/v1/keepers/:name/turn-records");
-              ("freshness_slo_s", `Float freshness_slo_s);
-              ("latest_ts_unix", Json_util.float_opt_to_json latest_ts);
-              ( "latest_ts_iso",
-                match latest_ts with
-                | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
-                | None -> `Null );
-              ("latest_age_s", Json_util.float_opt_to_json latest_age_s);
-              ("health", `String health);
-              ( "stale_reason",
-                if stale_reason = "" then `Null else `String stale_reason );
-              ("memory_os", memory_os_dashboard_json ~keeper_id:name);
-              ("user_model", user_model_dashboard_json ~keeper_id:name);
-              ("entries", `List entries);
-            ]))
+      let records = List.rev records_rev in
+      let block_json = Turn_record.prompt_block_to_json in
+      let entries =
+        Turn_record.entries_with_diffs records
+        |> List.map (fun ((record : Turn_record.t), diff) ->
+             let diff_vs_prev =
+               match diff with
+               | Some (d : Turn_record.block_diff) ->
+                 `Assoc
+                   [ ("added", `List (List.map block_json d.added))
+                   ; ("removed", `List (List.map block_json d.removed))
+                   ; ( "changed"
+                     , `List
+                         (List.map
+                            (fun (prev_b, next_b) ->
+                              `Assoc
+                                [ ("prev", block_json prev_b)
+                                ; ("next", block_json next_b)
+                                ])
+                            d.changed) )
+                   ]
+               | None -> `Null
+             in
+             `Assoc
+               [ ("record", Turn_record.to_json record)
+               ; ("diff_vs_prev", diff_vs_prev)
+               ])
       in
+      let latest_ts =
+        List.fold_left
+          (fun acc (r : Turn_record.t) ->
+            match acc with
+            | Some existing when existing >= r.ts -> acc
+            | _ -> Some r.ts)
+          None records
+      in
+      let latest_age_s =
+        match latest_ts with
+        | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
+        | None -> None
+      in
+      let health, stale_reason =
+        match latest_age_s with
+        | None -> ("empty", "no_entries")
+        | Some age when age > freshness_slo_s ->
+            ("stale", "freshness_slo_exceeded")
+        | Some _ -> ("ok", "")
+      in
+      let json = `Assoc [
+        ("keeper", `String name);
+        ("count", `Int (List.length records));
+        ("skipped_rows", `Int skipped_rows);
+        ("source", `String "turn_record");
+        ("producer", `String "keeper_agent_run.run_turn|keeper_turn_record_writer");
+        ( "durable_store",
+          `String
+            (Filename.concat
+               (Workspace.masc_root_dir config)
+               (Printf.sprintf "keepers/%s/turn-records" name)) );
+        ("dashboard_surface", `String "/api/v1/keepers/:name/turn-records");
+        ("freshness_slo_s", `Float freshness_slo_s);
+        ("latest_ts_unix", Json_util.float_opt_to_json latest_ts);
+        ( "latest_ts_iso",
+          match latest_ts with
+          | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
+          | None -> `Null );
+        ("latest_age_s", Json_util.float_opt_to_json latest_age_s);
+        ("health", `String health);
+        ( "stale_reason",
+          if stale_reason = "" then `Null else `String stale_reason );
+        ("memory_os", memory_os_dashboard_json ~keeper_id:name);
+        ("user_model", user_model_dashboard_json ~keeper_id:name);
+        ("entries", `List entries);
+      ] in
       Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/turn-transcript" then
     (* RFC-0233 §7: serve one keeper turn's operator request + keeper

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -499,92 +499,110 @@ let handle_keeper_get_subroutes state req request reqd =
         |> max 1 |> min trajectory_max_limit
       in
       let config = (Mcp_server.workspace_config state) in
-      let store = Keeper_types_support.keeper_turn_record_store config name in
-      let raw_rows = Dated_jsonl.read_recent store limit in
-      (* Strict decode: malformed rows are counted and reported, never
-         repaired or silently dropped (RFC-0233 §4). *)
-      let records_rev, skipped_rows =
-        List.fold_left
-          (fun (acc, skipped) json ->
-            match Turn_record.of_json json with
-            | Ok record -> (record :: acc, skipped)
-            | Error _ -> (acc, skipped + 1))
-          ([], 0) raw_rows
+      (* RFC-0204 Phase 0: this turn-records read (Dated_jsonl directory scan +
+         per-row Yojson decode + consecutive-pair block diff + memory_os/
+         user_model file reads) previously ran inline on the calling fiber's
+         main Eio domain, uncached, fanned out per keeper. Under serving
+         concurrency that synchronous head-of-line work starves the single
+         serving domain (scheduler_starvation_gate.sh reproduces it). Mirror the
+         sibling /tool-stats handler above and PRs #19088 / #19097: cache +
+         offload, with the key including every input that changes the result. *)
+      let cache_key =
+        Printf.sprintf "keeper:turn-records:%s:%s:%d"
+          (Workspace.masc_root_dir config) name limit
       in
-      let records = List.rev records_rev in
-      let block_json = Turn_record.prompt_block_to_json in
-      let entries =
-        Turn_record.entries_with_diffs records
-        |> List.map (fun ((record : Turn_record.t), diff) ->
-             let diff_vs_prev =
-               match diff with
-               | Some (d : Turn_record.block_diff) ->
-                 `Assoc
-                   [ ("added", `List (List.map block_json d.added))
-                   ; ("removed", `List (List.map block_json d.removed))
-                   ; ( "changed"
-                     , `List
-                         (List.map
-                            (fun (prev_b, next_b) ->
-                              `Assoc
-                                [ ("prev", block_json prev_b)
-                                ; ("next", block_json next_b)
-                                ])
-                            d.changed) )
-                   ]
-               | None -> `Null
-             in
-             `Assoc
-               [ ("record", Turn_record.to_json record)
-               ; ("diff_vs_prev", diff_vs_prev)
-               ])
+      let json =
+        Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
+          Domain_pool_ref.submit_io_or_inline (fun () ->
+            let store =
+              Keeper_types_support.keeper_turn_record_store config name
+            in
+            let raw_rows = Dated_jsonl.read_recent store limit in
+            (* Strict decode: malformed rows are counted and reported, never
+               repaired or silently dropped (RFC-0233 §4). *)
+            let records_rev, skipped_rows =
+              List.fold_left
+                (fun (acc, skipped) json ->
+                  match Turn_record.of_json json with
+                  | Ok record -> (record :: acc, skipped)
+                  | Error _ -> (acc, skipped + 1))
+                ([], 0) raw_rows
+            in
+            let records = List.rev records_rev in
+            let block_json = Turn_record.prompt_block_to_json in
+            let entries =
+              Turn_record.entries_with_diffs records
+              |> List.map (fun ((record : Turn_record.t), diff) ->
+                   let diff_vs_prev =
+                     match diff with
+                     | Some (d : Turn_record.block_diff) ->
+                       `Assoc
+                         [ ("added", `List (List.map block_json d.added))
+                         ; ("removed", `List (List.map block_json d.removed))
+                         ; ( "changed"
+                           , `List
+                               (List.map
+                                  (fun (prev_b, next_b) ->
+                                    `Assoc
+                                      [ ("prev", block_json prev_b)
+                                      ; ("next", block_json next_b)
+                                      ])
+                                  d.changed) )
+                         ]
+                     | None -> `Null
+                   in
+                   `Assoc
+                     [ ("record", Turn_record.to_json record)
+                     ; ("diff_vs_prev", diff_vs_prev)
+                     ])
+            in
+            let latest_ts =
+              List.fold_left
+                (fun acc (r : Turn_record.t) ->
+                  match acc with
+                  | Some existing when existing >= r.ts -> acc
+                  | _ -> Some r.ts)
+                None records
+            in
+            let latest_age_s =
+              match latest_ts with
+              | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
+              | None -> None
+            in
+            let health, stale_reason =
+              match latest_age_s with
+              | None -> ("empty", "no_entries")
+              | Some age when age > freshness_slo_s ->
+                  ("stale", "freshness_slo_exceeded")
+              | Some _ -> ("ok", "")
+            in
+            `Assoc [
+              ("keeper", `String name);
+              ("count", `Int (List.length records));
+              ("skipped_rows", `Int skipped_rows);
+              ("source", `String "turn_record");
+              ("producer", `String "keeper_agent_run.run_turn|keeper_turn_record_writer");
+              ( "durable_store",
+                `String
+                  (Filename.concat
+                     (Workspace.masc_root_dir config)
+                     (Printf.sprintf "keepers/%s/turn-records" name)) );
+              ("dashboard_surface", `String "/api/v1/keepers/:name/turn-records");
+              ("freshness_slo_s", `Float freshness_slo_s);
+              ("latest_ts_unix", Json_util.float_opt_to_json latest_ts);
+              ( "latest_ts_iso",
+                match latest_ts with
+                | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
+                | None -> `Null );
+              ("latest_age_s", Json_util.float_opt_to_json latest_age_s);
+              ("health", `String health);
+              ( "stale_reason",
+                if stale_reason = "" then `Null else `String stale_reason );
+              ("memory_os", memory_os_dashboard_json ~keeper_id:name);
+              ("user_model", user_model_dashboard_json ~keeper_id:name);
+              ("entries", `List entries);
+            ]))
       in
-      let latest_ts =
-        List.fold_left
-          (fun acc (r : Turn_record.t) ->
-            match acc with
-            | Some existing when existing >= r.ts -> acc
-            | _ -> Some r.ts)
-          None records
-      in
-      let latest_age_s =
-        match latest_ts with
-        | Some ts -> Some (max 0.0 (Time_compat.now () -. ts))
-        | None -> None
-      in
-      let health, stale_reason =
-        match latest_age_s with
-        | None -> ("empty", "no_entries")
-        | Some age when age > freshness_slo_s ->
-            ("stale", "freshness_slo_exceeded")
-        | Some _ -> ("ok", "")
-      in
-      let json = `Assoc [
-        ("keeper", `String name);
-        ("count", `Int (List.length records));
-        ("skipped_rows", `Int skipped_rows);
-        ("source", `String "turn_record");
-        ("producer", `String "keeper_agent_run.run_turn|keeper_turn_record_writer");
-        ( "durable_store",
-          `String
-            (Filename.concat
-               (Workspace.masc_root_dir config)
-               (Printf.sprintf "keepers/%s/turn-records" name)) );
-        ("dashboard_surface", `String "/api/v1/keepers/:name/turn-records");
-        ("freshness_slo_s", `Float freshness_slo_s);
-        ("latest_ts_unix", Json_util.float_opt_to_json latest_ts);
-        ( "latest_ts_iso",
-          match latest_ts with
-          | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
-          | None -> `Null );
-        ("latest_age_s", Json_util.float_opt_to_json latest_age_s);
-        ("health", `String health);
-        ( "stale_reason",
-          if stale_reason = "" then `Null else `String stale_reason );
-        ("memory_os", memory_os_dashboard_json ~keeper_id:name);
-        ("user_model", user_model_dashboard_json ~keeper_id:name);
-        ("entries", `List entries);
-      ] in
       Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/turn-transcript" then
     (* RFC-0233 §7: serve one keeper turn's operator request + keeper

--- a/scripts/harness/perf/README.md
+++ b/scripts/harness/perf/README.md
@@ -1,0 +1,88 @@
+# Perf harness: main-domain scheduler starvation
+
+`scheduler_starvation_gate.sh` turns the previously *observational* claim "MASC latency
+tracks host load while `main_eio` sits at 12–27% CPU" (RFC-0204) into a **deterministic,
+falsifiable measurement gate**.
+
+## What it measures
+
+MASC serves HTTP from a single main Eio domain that also carries every keeper fiber and the
+refresh loops (`server_bootstrap_http.ml:157`, `keeper_keepalive.ml:650` — all `Eio.Fiber.fork ~sw`
+on one switch). The harness probes a trivial endpoint (`/health`) while it puts that one domain
+under load along two independent axes:
+
+- **In-process load** (`--inproc-load N`): N background loops hammering a heavy endpoint
+  (`/api/v1/dashboard/execution`), keeping the single serving domain busy.
+- **Host CPU contention** (`--levels "…"`): N `yes` busy-loops competing with the main thread for
+  OS timeslice.
+
+For each level it runs `--probes` probes, records per-probe TTFB (`curl -w time_starttransfer`),
+and reports p50 / p95 / max in ms plus timeout count.
+
+## Measured results (origin/main `af959bfeff`, M3 Max 16-core, 2026-06-23)
+
+| condition | `/health` p95 | amplification | verdict |
+|---|---|---|---|
+| baseline (idle) | ~1.1 ms | 1.0× | — |
+| 16 host hogs, **idle server** | ~1.4 ms | 1.7× | GREEN |
+| 1 host hog + 48 in-process | ~43 ms | ~39× | RED |
+| 14 host hogs + 48 in-process | ~62–79 ms | ~56–73× | RED |
+
+**Attribution (the load-bearing finding):** in-process serving concurrency is the dominant axis.
+48 concurrent heavy requests on the one cooperative domain already drive `/health` to ~39× with
+*negligible* host contention (1 hog). Host hogs are only a ~1.4× multiplier on top. An **idle**
+server is barely sensitive to host hogs alone (1.7×) — the domain has nothing queued, so it is
+scheduled promptly. Production starvation therefore requires the domain to be **busy** (keepers +
+dashboard serving) *and* contended; "just inject CPU load" is not a faithful reproduction. This is
+exactly the false premise Harness-First exists to catch before a fix is built on it.
+
+## Gate semantics (falsifiable, per CLAUDE.md TLA+ bug-model discipline)
+
+```
+RED (exit 2)  if  loaded p95 > THRESHOLD_MS  OR  p95(loaded)/p95(baseline) > MAX_AMP
+GREEN (exit 0) otherwise
+ERROR (exit 1) on harness failure (server did not boot, missing tools)
+```
+
+The gate **must be RED on current main** under load — that failure is the proof it catches the
+defect. A fix that flips it GREEN is validated; a gate that is GREEN on current main is too weak.
+
+## Run
+
+```bash
+# self-contained (boots an ephemeral server using the canonical config/runtime.toml seed)
+scripts/harness/perf/scheduler_starvation_gate.sh --levels "0 1 14" --inproc-load 48 --probes 12
+
+# attach to an already-running server (e.g. the live runtime with real keepers busy)
+scripts/harness/perf/scheduler_starvation_gate.sh --base-url http://127.0.0.1:8935 --levels "0 14"
+```
+
+Artifacts (`logs/perf-starvation/<run-id>/`): `levels.csv`, `summary.json`, per-level raw TTFB,
+`server.log`. Knobs: `--endpoint`, `--probes`, `--levels`, `--inproc-load`, `--load-endpoint`,
+`--threshold-ms`, `--max-amp`, `--base-url`, `--keep-server` (env equivalents mirror each flag).
+
+The booted server runs with `MASC_AUTONOMY_ENABLED=0` (harness lib default): **no keepers run**, so
+the in-process axis is the only "busy domain" source. To exercise the keeper axis, use `--base-url`
+against a live runtime (see below).
+
+## Which fix each axis validates
+
+| axis the gate stresses | fix it can validate |
+|---|---|
+| in-process serving concurrency (dominant) | offload heavy-endpoint compute to the worker pool so the serving fiber only *awaits* (keeps the domain free for `/health`); RFC-0204 Phase 3 dedicated serving domain (separates serving from keepers) |
+| host CPU contention (multiplier; needs a busy domain to bite) | launchd `ProcessType=Interactive` / QoS so `main_eio` wins timeslice; `domain_pool.ml` core-budget `recommended-2` to reserve a scheduler core |
+
+Re-run the same command after a fix; the amplification should drop below `MAX_AMP`.
+
+## Limitations / next iteration
+
+- **No live keepers in boot mode.** The faithful keeper-vs-serving reproduction (RFC-0204 §5
+  keeper-burst isolation) needs real keeper compute. Two paths: (a) `--base-url` against the live
+  MASC where the 24 keepers are actually running, then add host hogs; (b) extend the harness to
+  `MASC_AUTONOMY_ENABLED=1` + seeded keeper configs + a mock streaming provider. Path (b) is the
+  committed-CI form and is the documented next step.
+- **`--inproc-load` hits a serving endpoint, not keeper compute.** It reproduces serving-domain
+  head-of-line blocking, which is one real amplifier, but it is not identical to keeper-turn
+  compute competing with serving.
+- Run against the deploy host to capture the real concurrent-process load; the numbers above are
+  from a developer box and are illustrative of the *shape*, not absolute production latency.

--- a/scripts/harness/perf/README.md
+++ b/scripts/harness/perf/README.md
@@ -74,15 +74,72 @@ against a live runtime (see below).
 
 Re-run the same command after a fix; the amplification should drop below `MAX_AMP`.
 
-## Limitations / next iteration
+## Keeper-load injection (WIP — provider mock done, autoboot wiring pending)
 
-- **No live keepers in boot mode.** The faithful keeper-vs-serving reproduction (RFC-0204 §5
-  keeper-burst isolation) needs real keeper compute. Two paths: (a) `--base-url` against the live
-  MASC where the 24 keepers are actually running, then add host hogs; (b) extend the harness to
-  `MASC_AUTONOMY_ENABLED=1` + seeded keeper configs + a mock streaming provider. Path (b) is the
-  committed-CI form and is the documented next step.
+`mock_openai_provider.py` is a network-free OpenAI-compatible provider for driving real keeper
+turns in a boot harness, so the gate can reproduce the faithful keeper-vs-serving contention
+(RFC-0204 §5) instead of the milder serving-only regime an idle (autoboot-disabled) boot produces.
+It serves `POST /v1/chat/completions` in both modes: non-streaming JSON (the
+`backend_openai_request.ml` default `?(stream = false)` path) and SSE `chat.completion.chunk`
+frames when the request sets `stream:true`. Every request is logged one-JSON-line to `--log` so a
+harness can count provider calls = turns fired.
+
+```bash
+python3 scripts/harness/perf/mock_openai_provider.py --port 8899 --log /tmp/mock.jsonl --delay-ms 0
+```
+
+**What is verified to work:** the server boots against this mock with a runtime.toml that routes a
+catalog-valid model id to the mock endpoint. `Runtime.init_default_strict` (the OAS capability
+gate, `server_runtime_bootstrap.ml`) rejects any model whose `api-name` is not in the OAS catalog
+(`oas-models.toml`), so the runtime.toml must **borrow a real catalog id** while pointing its
+provider at the mock:
+
+```toml
+[runtime]
+default = "mock.mockmodel"
+[providers.mock]
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:8899"
+[models.mockmodel]
+api-name = "deepseek-v4-flash"   # must be an oas-models.toml id_prefix
+[models.mockmodel.capabilities]
+supports-native-streaming = true
+[mock.mockmodel]
+is-default = true
+```
+
+Boot env (note: do **not** use `harness_start_server`, which hardcodes the bootstrap off; boot the
+exe directly): `MASC_KEEPER_BOOTSTRAP_ENABLED=true`, `MASC_ORCHESTRATOR_ENABLED=1`,
+`MASC_KEEPER_HEARTBEAT_INTERVAL_SEC=5`, `MASC_STORAGE_TYPE=filesystem`, plus a keeper TOML under
+`$BASE/.masc/config/keepers/` and a persona dir under `$BASE/.masc/config/personas/`.
+
+**The remaining blocker (the documented next step):** declarative (config-TOML) keepers are
+excluded from autoboot by design — `keeper_runtime.ml:154 autoboot_exclusion_reason` returns
+`declarative_autoboot_disabled` unless the keeper profile sets `autoboot_enabled = true`, and
+`keeper_activation_readiness.ml:16` also requires `proactive.enabled = true` and `paused = false`.
+A copied live keeper config (e.g. `analyst.toml`) boots the server but yields `0 keeper(s) to boot`
+for this reason. Finishing path (b) means: (1) author a keeper TOML with `autoboot_enabled` /
+`proactive_enabled` set (field parsed under `lib/keeper/` `profile_defaults_for_config`), (2)
+confirm a turn actually issues a provider call (the mock log goes non-empty), then (3) wire a
+`--with-keepers` mode into the gate that starts the mock, seeds configs, and boots with the env
+above. This was stopped at the 3-Try boundary after the gate/boot succeeded but autoboot stayed
+disabled; it is a bounded two-flag fix plus a work-discovery liveness check, not a new approach.
+
+## Other limitations
+
 - **`--inproc-load` hits a serving endpoint, not keeper compute.** It reproduces serving-domain
   head-of-line blocking, which is one real amplifier, but it is not identical to keeper-turn
-  compute competing with serving.
+  compute competing with serving. Until path (b) lands, the faithful keeper regime is only
+  reachable via `--base-url` against the live MASC (where the real keepers run) plus host hogs.
 - Run against the deploy host to capture the real concurrent-process load; the numbers above are
   from a developer box and are illustrative of the *shape*, not absolute production latency.
+
+## What this harness has already caught
+
+The `turn-records` cache+offload fix (a plausible RFC-0204 Phase 0 change mirroring the sibling
+`/tool-stats` handler) was implemented, compiled, committed, then **reverted** when a controlled
+two-binary A/B under this gate showed it does not reduce `/health` starvation (fixed ~17–21 ms vs
+unfixed ~15–16 ms loaded p95, both RED). The dominant main-domain cost under load is response
+serialization + gzip of the payload, which stays on main even on a cache hit; offloading only the
+parse attacks a minor cost. See the revert commit for the full A/B. This is the gate doing its job:
+falsifying a fix before it shipped.

--- a/scripts/harness/perf/README.md
+++ b/scripts/harness/perf/README.md
@@ -82,7 +82,11 @@ keepers that run **real autonomous turns** against `mock_openai_provider.py` (ne
 probes `/health` while those keepers and optional host hogs contend for the one main Eio domain.
 
 ```bash
-scripts/harness/perf/keeper_load_gate.sh --keepers 12 --levels "0 15" --probes 25
+# MASC_PERSONA_SOURCE_ROOT points at a populated MASC root (one with
+# config/personas/<persona>); the gate copies that persona into its ephemeral
+# base path. It is resolved from an explicit path, never home-anchored (SSOT-R6).
+MASC_PERSONA_SOURCE_ROOT=<your-masc-root> \
+  scripts/harness/perf/keeper_load_gate.sh --keepers 12 --levels "0 15" --probes 25
 ```
 
 `mock_openai_provider.py` serves `POST /v1/chat/completions` in both non-streaming JSON (the

--- a/scripts/harness/perf/README.md
+++ b/scripts/harness/perf/README.md
@@ -74,56 +74,53 @@ against a live runtime (see below).
 
 Re-run the same command after a fix; the amplification should drop below `MAX_AMP`.
 
-## Keeper-load injection (WIP — provider mock done, autoboot wiring pending)
+## Mode B: keeper-load gate (`keeper_load_gate.sh`)
 
-`mock_openai_provider.py` is a network-free OpenAI-compatible provider for driving real keeper
-turns in a boot harness, so the gate can reproduce the faithful keeper-vs-serving contention
-(RFC-0204 §5) instead of the milder serving-only regime an idle (autoboot-disabled) boot produces.
-It serves `POST /v1/chat/completions` in both modes: non-streaming JSON (the
-`backend_openai_request.ml` default `?(stream = false)` path) and SSE `chat.completion.chunk`
-frames when the request sets `stream:true`. Every request is logged one-JSON-line to `--log` so a
-harness can count provider calls = turns fired.
+Mode A drives the main domain with serving load only; an idle (autoboot-disabled) boot has no
+keeper compute, so its absolute regime is milder than production. Mode B seeds N declarative
+keepers that run **real autonomous turns** against `mock_openai_provider.py` (network-free), then
+probes `/health` while those keepers and optional host hogs contend for the one main Eio domain.
 
 ```bash
-python3 scripts/harness/perf/mock_openai_provider.py --port 8899 --log /tmp/mock.jsonl --delay-ms 0
+scripts/harness/perf/keeper_load_gate.sh --keepers 12 --levels "0 15" --probes 25
 ```
 
-**What is verified to work:** the server boots against this mock with a runtime.toml that routes a
-catalog-valid model id to the mock endpoint. `Runtime.init_default_strict` (the OAS capability
-gate, `server_runtime_bootstrap.ml`) rejects any model whose `api-name` is not in the OAS catalog
-(`oas-models.toml`), so the runtime.toml must **borrow a real catalog id** while pointing its
-provider at the mock:
+`mock_openai_provider.py` serves `POST /v1/chat/completions` in both non-streaming JSON (the
+`backend_openai_request.ml` default `?(stream = false)` path) and SSE `chat.completion.chunk` modes
+(`stream:true`), logging one JSON line per request so the gate counts provider calls = turns fired.
 
-```toml
-[runtime]
-default = "mock.mockmodel"
-[providers.mock]
-protocol = "openai-compatible-http"
-endpoint = "http://127.0.0.1:8899"
-[models.mockmodel]
-api-name = "deepseek-v4-flash"   # must be an oas-models.toml id_prefix
-[models.mockmodel.capabilities]
-supports-native-streaming = true
-[mock.mockmodel]
-is-default = true
-```
+**The boot recipe (verified — keepers issue real turns; FSM reaches `awaiting_provider -> streaming`):**
 
-Boot env (note: do **not** use `harness_start_server`, which hardcodes the bootstrap off; boot the
-exe directly): `MASC_KEEPER_BOOTSTRAP_ENABLED=true`, `MASC_ORCHESTRATOR_ENABLED=1`,
-`MASC_KEEPER_HEARTBEAT_INTERVAL_SEC=5`, `MASC_STORAGE_TYPE=filesystem`, plus a keeper TOML under
-`$BASE/.masc/config/keepers/` and a persona dir under `$BASE/.masc/config/personas/`.
+1. **runtime.toml must borrow a catalog-valid model id.** `Runtime.init_default_strict`
+   (`server_runtime_bootstrap.ml`) rejects any model whose `api-name` is absent from the OAS catalog
+   (`oas-models.toml`). Set `api-name = "deepseek-v4-flash"` (a catalog `id_prefix`) while pointing
+   the provider `endpoint` at the local mock.
+2. **The keeper TOML must opt into autoboot.** Declarative keepers are excluded by design unless the
+   `[keeper]` section sets `autoboot_enabled = true` (`keeper_runtime.ml:154`) **and**
+   `proactive_enabled = true` (`keeper_activation_readiness.ml:16`, with `paused` false). A copied
+   live config (e.g. `analyst.toml`, which ships `autoboot_enabled = false`) yields `0 keeper(s) to
+   boot`.
+3. **The keeper TOML must set `sandbox_profile = "local"`** (or `"docker"`) — boot rejects without it.
+4. Boot env: `MASC_KEEPER_BOOTSTRAP_ENABLED=true`, `MASC_ORCHESTRATOR_ENABLED=1`,
+   `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC=<n>`, `MASC_STORAGE_TYPE=filesystem`. Boot the exe directly —
+   **not** via `harness_start_server`, which hardcodes the bootstrap off. (`MASC_AUTONOMY_ENABLED`
+   does not exist in the code; the lib sets it as a harmless no-op.)
+5. A persona directory must exist under `$BASE/.masc/config/personas/<persona_name>/`; the gate
+   copies a real one (`analyst`) to avoid format guessing.
 
-**The remaining blocker (the documented next step):** declarative (config-TOML) keepers are
-excluded from autoboot by design — `keeper_runtime.ml:154 autoboot_exclusion_reason` returns
-`declarative_autoboot_disabled` unless the keeper profile sets `autoboot_enabled = true`, and
-`keeper_activation_readiness.ml:16` also requires `proactive.enabled = true` and `paused = false`.
-A copied live keeper config (e.g. `analyst.toml`) boots the server but yields `0 keeper(s) to boot`
-for this reason. Finishing path (b) means: (1) author a keeper TOML with `autoboot_enabled` /
-`proactive_enabled` set (field parsed under `lib/keeper/` `profile_defaults_for_config`), (2)
-confirm a turn actually issues a provider call (the mock log goes non-empty), then (3) wire a
-`--with-keepers` mode into the gate that starts the mock, seeds configs, and boots with the env
-above. This was stopped at the 3-Try boundary after the gate/boot succeeded but autoboot stayed
-disabled; it is a bounded two-flag fix plus a work-discovery liveness check, not a new approach.
+The gate refuses to report numbers if zero provider calls are seen during warmup (the mock wiring
+is then broken), and it records a `turns_during` column per level.
+
+**Known limitation (the gate self-warns):** keepers do an initial autoboot burst, then their
+scheduled-autonomous cadence outruns the short `/health` probe window, so `turns_during` is
+typically 0 at the measured levels — the measurement overlaps keepers *resident* but not *mid-turn*,
+which is only marginally more faithful than Mode A. A GREEN verdict under that condition is weak and
+the gate prints a `WARN` saying so. Two refinements make it bite: (1) drive **continuous** turns via
+the reactive channel (inject board activity) rather than relying on the scheduled-autonomous cadence;
+(2) have the mock return **large, realistic responses** (with tool calls) so the post-await parsing /
+record-write / snapshot work — which is the real keeper main-domain cost, since the provider await
+itself is I/O-bound and yields — actually loads the domain. `--mock-delay-ms` lengthens the await but
+does not add main-domain CPU.
 
 ## Other limitations
 

--- a/scripts/harness/perf/README.md
+++ b/scripts/harness/perf/README.md
@@ -140,3 +140,24 @@ unfixed ~15–16 ms loaded p95, both RED). The dominant main-domain cost under l
 serialization + gzip of the payload, which stays on main even on a cache hit; offloading only the
 parse attacks a minor cost. See the revert commit for the full A/B. This is the gate doing its job:
 falsifying a fix before it shipped.
+
+## Structural levers tested (gated by this harness, M3 Max 16-core)
+
+Three candidate fixes for the starvation were tested **with the harness before writing any
+production code**, varying a knob and measuring rather than guessing. Two were refuted; one is a
+partial mitigation.
+
+| lever | how tested | result |
+|---|---|---|
+| **Offload `turn-records` compute** (cache + `submit_io_or_inline`) | two-binary A/B, real data | **refuted** — fixed ≈ unfixed, both RED (the parse is not the dominant cost) |
+| **Reserve scheduler cores** (fewer worker domains) | sweep `MASC_EXECUTOR_DOMAIN_COUNT` ∈ {2,4,8,15} under 48 inproc + 15 hogs | **refuted (noise)** — a first sweep showed 15→8 halving amp (110×→43×), but an interleaved repeat found 15 ≈ 8 (amp 72–92× both); variance swamps the effect. Idle/blocked worker domains do not hold cores away from the main thread, so cutting them frees nothing |
+| **OS priority / QoS** (deprioritize competing load) | one server, hogs at `nice 0` vs `nice 19`, 48 inproc both | **partial** — `nice 19` hogs cut amp 46× → 32× (~31%), but `/health` is still 120 ms (RED). The residual comes from the 48 normal-priority inproc requests, which QoS cannot touch |
+
+**Conclusion the harness points to:** the dominant, irreducible axis is **serving concurrency
+serialized on the single main Eio domain** — host contention (QoS-mitigable, ~31%) and the
+offloadable parse (negligible) are secondary. The only lever that addresses the dominant axis is
+architectural: **RFC-0204 Phase 3 — a dedicated serving domain** so N concurrent requests are
+handled off the main domain, leaving it for keepers + the scheduler. That is a large change
+constrained by RFC-0059 (keepers are pinned to the main domain; only *serving* may move) and should
+go through an RFC, validated by the Mode B keeper-load gate once its sustained-load refinements land.
+launchd `ProcessType=Interactive` is a worthwhile but partial deployment-side mitigation.

--- a/scripts/harness/perf/keeper_load_gate.sh
+++ b/scripts/harness/perf/keeper_load_gate.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# keeper_load_gate.sh — Mode B: reproduce main-domain starvation under REAL
+# autonomous keeper turns, network-free.
+#
+# Mode A (scheduler_starvation_gate.sh) drives the main domain with serving load
+# (--inproc-load) only; an idle (autoboot-disabled) boot has no keeper compute,
+# so its absolute regime is milder than production. Mode B seeds N declarative
+# keepers that run real turns against mock_openai_provider.py, then probes
+# /health TTFB while those keepers (and optional host hogs) contend for the one
+# main Eio domain. This is the faithful keeper-vs-serving reproduction
+# (RFC-0204 §5) and the committed-CI form of the keeper-load path.
+#
+# It boots the server directly (NOT via harness_start_server, which hardcodes
+# MASC_KEEPER_BOOTSTRAP_ENABLED off) with autoboot enabled, and confirms turns
+# actually fire by watching the mock request log before it trusts the numbers.
+#
+# Exit codes mirror Mode A: 0 GREEN, 2 RED (starved), 1 ERROR (harness failure).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/harness/lib/server_bootstrap.sh"
+set +e  # server_bootstrap.sh sets -e on source; we manage failures explicitly
+
+# ---- configuration (env-overridable) ----------------------------------------
+NCPU="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+KEEPERS="${KEEPERS:-8}"                          # how many autonomous keepers to seed
+PROBE_ENDPOINT="${PROBE_ENDPOINT:-/health}"
+PROBES="${PROBES:-30}"
+WARMUP_PROBES="${WARMUP_PROBES:-8}"
+PROBE_MAX_SEC="${PROBE_MAX_SEC:-15}"
+HEARTBEAT_SEC="${HEARTBEAT_SEC:-3}"              # keeper turn cadence (lower = more load)
+MOCK_DELAY_MS="${MOCK_DELAY_MS:-150}"           # simulated provider latency (keeps turns in-flight)
+WARM_TURNS_SEC="${WARM_TURNS_SEC:-20}"          # let keepers start turning before measuring
+THRESHOLD_MS="${THRESHOLD_MS:-250}"
+MAX_AMP="${MAX_AMP:-8}"
+PERSONA="${PERSONA:-analyst}"
+BORROW_MODEL="${BORROW_MODEL:-deepseek-v4-flash}"  # must be an oas-models.toml id_prefix
+HOG_LEVELS="${HOG_LEVELS:-0 $((NCPU-1))}"       # host CPU hogs to sweep alongside keeper load
+
+RUN_ID="${RUN_ID:-keeperload-$(date +%Y%m%d_%H%M%S)-$$}"
+RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/perf-starvation/$RUN_ID}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+  --keepers N          autonomous keepers to seed (default: $KEEPERS)
+  --probes N           /health probes per level (default: $PROBES)
+  --levels "0 15"      host hog counts to sweep (default: "$HOG_LEVELS")
+  --heartbeat-sec N    keeper turn cadence (default: $HEARTBEAT_SEC)
+  --mock-delay-ms N    simulated provider latency (default: $MOCK_DELAY_MS)
+  --threshold-ms N     max /health p95 under load before RED (default: $THRESHOLD_MS)
+  --max-amp N          max p95 amplification before RED (default: $MAX_AMP)
+  -h|--help            this help
+Requires: python3, curl, jq. Boots a server with real keeper turns against a
+network-free mock provider; no cloud credentials needed.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keepers) KEEPERS="$2"; shift 2 ;;
+    --probes) PROBES="$2"; shift 2 ;;
+    --levels) HOG_LEVELS="$2"; shift 2 ;;
+    --heartbeat-sec) HEARTBEAT_SEC="$2"; shift 2 ;;
+    --mock-delay-ms) MOCK_DELAY_MS="$2"; shift 2 ;;
+    --threshold-ms) THRESHOLD_MS="$2"; shift 2 ;;
+    --max-amp) MAX_AMP="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+for tool in python3 curl jq awk sort sysctl; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "ERROR: missing required tool: $tool" >&2; exit 1; }
+done
+
+mkdir -p "$RUN_DIR"
+CSV_FILE="$RUN_DIR/levels.csv"
+SUMMARY_FILE="$RUN_DIR/summary.json"
+SERVER_LOG="$RUN_DIR/server.log"
+MOCK_LOG="$RUN_DIR/mock_requests.jsonl"
+MOCK_ERR="$RUN_DIR/mock_stderr.log"
+BASE_PATH="$(harness_mktemp_dir "masc-keeperload-base")"
+echo "level_hogs,probes,p50_ms,p95_ms,max_ms,timeouts,turns_during" > "$CSV_FILE"
+
+MOCK_PID=""
+SERVER_PID=""
+HOG_PIDS=()
+
+cleanup() {
+  if [[ ${#HOG_PIDS[@]} -gt 0 ]]; then kill "${HOG_PIDS[@]}" 2>/dev/null; wait "${HOG_PIDS[@]}" 2>/dev/null; fi
+  [[ -n "$SERVER_PID" ]] && harness_stop_server "$SERVER_PID" >/dev/null 2>&1
+  [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null
+}
+trap cleanup EXIT
+
+spawn_hogs() { local n="$1" i; HOG_PIDS=(); for ((i=0;i<n;i++)); do yes >/dev/null 2>&1 & HOG_PIDS+=("$!"); done; }
+kill_hogs() { if [[ ${#HOG_PIDS[@]} -gt 0 ]]; then kill "${HOG_PIDS[@]}" 2>/dev/null; wait "${HOG_PIDS[@]}" 2>/dev/null; fi; HOG_PIDS=(); }
+
+probe_once() {
+  local url="$1" t
+  t="$(curl -sS -o /dev/null -w '%{time_starttransfer}' --max-time "$PROBE_MAX_SEC" "$url" 2>/dev/null)" || t="$PROBE_MAX_SEC"
+  [[ "$t" =~ ^[0-9]+([.][0-9]+)?$ ]] || t="$PROBE_MAX_SEC"
+  printf '%s\n' "$t"
+}
+
+measure_level() {
+  local out_file="$1" url="$2" i t timeouts=0
+  : > "$out_file"
+  for ((i=0;i<PROBES;i++)); do
+    t="$(probe_once "$url")"
+    awk -v v="$t" -v m="$PROBE_MAX_SEC" 'BEGIN{ exit !(v+0 >= m+0) }' && timeouts=$((timeouts+1))
+    printf '%s\n' "$t" >> "$out_file"
+  done
+  sort -n "$out_file" | awk -v to="$timeouts" '
+    { v[NR]=$1 } END {
+      n=NR; if(n==0){print "0.000 0.000 0.000 " to; exit}
+      i50=int((n-1)*0.50)+1; i95=int((n-1)*0.95)+1
+      printf "%.3f %.3f %.3f %d", v[i50]*1000, v[i95]*1000, v[n]*1000, to
+    }'
+}
+
+# ---- seed config ------------------------------------------------------------
+mkdir -p "$BASE_PATH/.masc/config/keepers" "$BASE_PATH/.masc/config/personas"
+if [[ -d "$HOME/me/.masc/config/personas/$PERSONA" ]]; then
+  cp -R "$HOME/me/.masc/config/personas/$PERSONA" "$BASE_PATH/.masc/config/personas/$PERSONA"
+else
+  echo "ERROR: persona dir not found: ~/me/.masc/config/personas/$PERSONA" >&2; exit 1
+fi
+cp "$REPO_ROOT/config/tool_policy.toml" "$BASE_PATH/.masc/config/tool_policy.toml" 2>/dev/null || true
+
+MOCK_PORT="$(harness_pick_free_port)"
+cat > "$BASE_PATH/.masc/config/runtime.toml" <<EOF
+# Mock runtime: borrow a catalog-valid model id ($BORROW_MODEL is an
+# oas-models.toml id_prefix) so init_default_strict's capability gate passes,
+# but route the provider to the local network-free mock.
+[runtime]
+default = "mock.mockmodel"
+
+[providers.mock]
+display-name = "Local Mock"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:$MOCK_PORT"
+
+[models.mockmodel]
+api-name = "$BORROW_MODEL"
+max-context = 131072
+streaming = true
+
+[models.mockmodel.capabilities]
+max-output-tokens = 4096
+supports-native-streaming = true
+emits-usage-tokens = true
+
+[mock.mockmodel]
+is-default = true
+max-concurrent = 64
+EOF
+
+for ((k=1;k<=KEEPERS;k++)); do
+  cat > "$BASE_PATH/.masc/config/keepers/perf_keeper_${k}.toml" <<EOF
+[keeper]
+name = "perf_keeper_${k}"
+persona_name = "$PERSONA"
+goal = "Generate steady autonomous keeper load for the perf harness."
+autoboot_enabled = true
+proactive_enabled = true
+proactive_idle_sec = 1
+proactive_cooldown_sec = 1
+sandbox_profile = "local"
+instructions = "You are a load-generating test keeper. Each turn, do minimal work."
+EOF
+done
+
+# ---- start mock + server ----------------------------------------------------
+python3 "$SCRIPT_DIR/mock_openai_provider.py" --port "$MOCK_PORT" --log "$MOCK_LOG" --delay-ms "$MOCK_DELAY_MS" >"$MOCK_ERR" 2>&1 &
+MOCK_PID=$!
+: > "$MOCK_LOG"
+sleep 1
+curl -fsS --max-time 3 "http://127.0.0.1:$MOCK_PORT/" >/dev/null 2>&1 || { echo "ERROR: mock provider failed to start (see $MOCK_ERR)" >&2; exit 1; }
+
+PORT="$(harness_pick_free_port)"
+harness_seed_server_config "$REPO_ROOT" "$BASE_PATH" >/dev/null 2>&1 || true
+# our runtime.toml (written above) takes precedence; seed only fills gaps.
+(
+  export MASC_BASE_PATH="$BASE_PATH"
+  export MASC_BASE_PATH_INPUT="$BASE_PATH"
+  export MASC_STORAGE_TYPE="filesystem"
+  export MASC_KEEPER_BOOTSTRAP_ENABLED="true"
+  export MASC_ORCHESTRATOR_ENABLED="1"
+  export MASC_KEEPER_HEARTBEAT_INTERVAL_SEC="$HEARTBEAT_SEC"
+  # Sustain turns through the measurement window: disable smart gating (else
+  # should_emit Skip_idle's the keeper after a few no-work cycles) and raise the
+  # idle-turn cap so autonomous turns keep firing without real backlog.
+  export MASC_KEEPER_SMART_HEARTBEAT="false"
+  export MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS="50"
+  export MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE="50"
+  export GRAPHQL_API_KEY=""
+  export GRAPHQL_URL="http://127.0.0.1:9/graphql"
+  exec "$(harness_find_server_exe "$REPO_ROOT")" --port "$PORT" --base-path "$BASE_PATH"
+) >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+if ! harness_wait_for_health "$PORT" 45; then
+  echo "ERROR: server failed health check" >&2; harness_print_log_tail "$SERVER_LOG"; exit 1
+fi
+BASE_URL="http://127.0.0.1:$PORT"
+echo "[harness] server pid=$SERVER_PID port=$PORT, $KEEPERS keeper(s) seeded; warming turns ${WARM_TURNS_SEC}s..." >&2
+sleep "$WARM_TURNS_SEC"
+
+turns_total="$(wc -l < "$MOCK_LOG" | tr -d ' ')"
+if [[ "${turns_total:-0}" -eq 0 ]]; then
+  echo "ERROR: no keeper provider calls observed after ${WARM_TURNS_SEC}s — keepers are not turning." >&2
+  echo "  Check $SERVER_LOG for autoboot/rejection errors. This harness is invalid without live turns." >&2
+  rg -n -i 'rejected|autoboot|fatal|refus' "$SERVER_LOG" 2>/dev/null | tail -10 >&2
+  exit 1
+fi
+echo "[harness] keepers live: $turns_total provider call(s) during warmup." >&2
+
+PROBE_URL="${BASE_URL%/}${PROBE_ENDPOINT}"
+for ((i=0;i<WARMUP_PROBES;i++)); do probe_once "$PROBE_URL" >/dev/null; done
+
+# ---- sweep ------------------------------------------------------------------
+printf '\n%-10s %-8s %-10s %-10s %-10s %-9s %-12s\n' "hogs" "probes" "p50_ms" "p95_ms" "max_ms" "timeouts" "turns_during" >&2
+printf '%s\n' "---------------------------------------------------------------------------------" >&2
+baseline_p95=""; loaded_p95=""
+declare -a LEVELS_DONE=()
+for level in $HOG_LEVELS; do
+  kill_hogs
+  [[ "$level" -gt 0 ]] && { spawn_hogs "$level"; sleep 2; }
+  turns_before="$(wc -l < "$MOCK_LOG" | tr -d ' ')"
+  read -r p50 p95 mx timeouts <<<"$(measure_level "$RUN_DIR/level_${level}.txt" "$PROBE_URL")"
+  turns_after="$(wc -l < "$MOCK_LOG" | tr -d ' ')"
+  turns_during=$((turns_after - turns_before))
+  kill_hogs
+  printf '%-10s %-8s %-10s %-10s %-10s %-9s %-12s\n' "$level" "$PROBES" "$p50" "$p95" "$mx" "$timeouts" "$turns_during" >&2
+  printf '%s,%s,%s,%s,%s,%s,%s\n' "$level" "$PROBES" "$p50" "$p95" "$mx" "$timeouts" "$turns_during" >> "$CSV_FILE"
+  LEVELS_DONE+=("{\"hogs\":$level,\"p95_ms\":$p95,\"max_ms\":$mx,\"timeouts\":$timeouts,\"turns_during\":$turns_during}")
+  [[ "$level" == "0" ]] && baseline_p95="$p95"
+  loaded_p95="$p95"
+done
+
+# ---- verdict ----------------------------------------------------------------
+[[ -n "$baseline_p95" ]] || baseline_p95="$loaded_p95"
+read -r amplification starved <<<"$(awk -v b="$baseline_p95" -v l="$loaded_p95" -v thr="$THRESHOLD_MS" -v ma="$MAX_AMP" \
+  'BEGIN{ amp=(b>0)?l/b:0; printf "%.2f %d", amp, ((l>thr)||(amp>ma))?1:0 }')"
+
+jq -n --arg run_id "$RUN_ID" --argjson keepers "$KEEPERS" --argjson ncpu "$NCPU" \
+  --argjson baseline_p95_ms "$baseline_p95" --argjson loaded_p95_ms "$loaded_p95" \
+  --argjson amplification "$amplification" --argjson starved "$starved" \
+  --argjson warmup_turns "$turns_total" \
+  --argjson levels "[$(IFS=,; echo "${LEVELS_DONE[*]}")]" \
+  '{run_id:$run_id, mode:"keeper-load", keepers:$keepers, ncpu:$ncpu,
+    warmup_provider_calls:$warmup_turns, baseline_p95_ms:$baseline_p95_ms,
+    loaded_p95_ms:$loaded_p95_ms, amplification:$amplification,
+    starved:($starved==1), levels:$levels}' > "$SUMMARY_FILE"
+
+echo >&2
+echo "[harness] keepers=$KEEPERS baseline p95=${baseline_p95}ms loaded p95=${loaded_p95}ms amp=${amplification}x" >&2
+echo "[harness] artifacts: $RUN_DIR" >&2
+
+# Self-document the known limitation: keepers do an initial autoboot burst, then
+# their scheduled-autonomous cadence outruns the short probe window, so the
+# measurement may not overlap an active turn (turns_during=0). When that holds,
+# the verdict reflects keepers-resident + host load, NOT mid-turn keeper compute
+# competing with serving. A GREEN here is therefore a weak signal.
+loaded_turns="$(awk -F, 'NR>1 && $1!="0" {s+=$7} END{print s+0}' "$CSV_FILE")"
+if [[ "${loaded_turns:-0}" -eq 0 ]]; then
+  echo "[harness] WARN: turns_during=0 at loaded levels — no keeper turn fired during the probe window." >&2
+  echo "         The keeper-load axis did not bite; treat the verdict as Mode-A-equivalent." >&2
+  echo "         Faithful sustained load needs continuous turns (reactive channel) and a mock that" >&2
+  echo "         returns large realistic responses so post-await processing loads the main domain." >&2
+fi
+if [[ "$starved" == "1" ]]; then
+  echo "RED (STARVED): /health p95 ${loaded_p95}ms under keeper+host load (threshold ${THRESHOLD_MS}ms, amp ${amplification}x > ${MAX_AMP}x)" >&2
+  exit 2
+fi
+echo "GREEN: /health p95 ${loaded_p95}ms stays within ${THRESHOLD_MS}ms (amp ${amplification}x <= ${MAX_AMP}x)" >&2
+exit 0

--- a/scripts/harness/perf/keeper_load_gate.sh
+++ b/scripts/harness/perf/keeper_load_gate.sh
@@ -37,6 +37,9 @@ WARM_TURNS_SEC="${WARM_TURNS_SEC:-20}"          # let keepers start turning befo
 THRESHOLD_MS="${THRESHOLD_MS:-250}"
 MAX_AMP="${MAX_AMP:-8}"
 PERSONA="${PERSONA:-analyst}"
+# Source root holding config/personas/<PERSONA>. Resolved from an explicit path,
+# never home-anchored (SSOT-R6): point it at a populated MASC root.
+PERSONA_SOURCE_ROOT="${MASC_PERSONA_SOURCE_ROOT:-}"
 BORROW_MODEL="${BORROW_MODEL:-deepseek-v4-flash}"  # must be an oas-models.toml id_prefix
 HOG_LEVELS="${HOG_LEVELS:-0 $((NCPU-1))}"       # host CPU hogs to sweep alongside keeper load
 
@@ -54,8 +57,10 @@ Usage: $(basename "$0") [options]
   --threshold-ms N     max /health p95 under load before RED (default: $THRESHOLD_MS)
   --max-amp N          max p95 amplification before RED (default: $MAX_AMP)
   -h|--help            this help
-Requires: python3, curl, jq. Boots a server with real keeper turns against a
-network-free mock provider; no cloud credentials needed.
+Requires: python3, curl, jq, and MASC_PERSONA_SOURCE_ROOT pointing at a
+populated MASC root (one that has config/personas/<persona>). Boots a server
+with real keeper turns against a network-free mock provider; no cloud
+credentials needed.
 EOF
 }
 
@@ -125,10 +130,15 @@ measure_level() {
 
 # ---- seed config ------------------------------------------------------------
 mkdir -p "$BASE_PATH/.masc/config/keepers" "$BASE_PATH/.masc/config/personas"
-if [[ -d "$HOME/me/.masc/config/personas/$PERSONA" ]]; then
-  cp -R "$HOME/me/.masc/config/personas/$PERSONA" "$BASE_PATH/.masc/config/personas/$PERSONA"
+if [[ -z "$PERSONA_SOURCE_ROOT" ]]; then
+  echo "ERROR: set MASC_PERSONA_SOURCE_ROOT to a populated MASC root (one that has" >&2
+  echo "       config/personas/$PERSONA), e.g. MASC_PERSONA_SOURCE_ROOT=<your-masc-root>" >&2
+  exit 1
+fi
+if [[ -d "$PERSONA_SOURCE_ROOT/config/personas/$PERSONA" ]]; then
+  cp -R "$PERSONA_SOURCE_ROOT/config/personas/$PERSONA" "$BASE_PATH/.masc/config/personas/$PERSONA"
 else
-  echo "ERROR: persona dir not found: ~/me/.masc/config/personas/$PERSONA" >&2; exit 1
+  echo "ERROR: persona dir not found: $PERSONA_SOURCE_ROOT/config/personas/$PERSONA" >&2; exit 1
 fi
 cp "$REPO_ROOT/config/tool_policy.toml" "$BASE_PATH/.masc/config/tool_policy.toml" 2>/dev/null || true
 

--- a/scripts/harness/perf/mock_openai_provider.py
+++ b/scripts/harness/perf/mock_openai_provider.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Mock OpenAI-compatible provider for the keeper-load perf harness.
+
+Serves POST /v1/chat/completions with a non-streaming JSON response in the
+OpenAI chat.completions shape that agent_sdk's backend_openai_parse.ml reads
+(choices[0].message.content + finish_reason + usage). Non-streaming is the
+default request path (backend_openai_request.ml: `?(stream = false)`), so the
+mock model must be configured with streaming disabled. No SSE required.
+
+Every request is appended (one JSON line) to the --log file so the harness can
+prove keepers actually issued provider calls (turn liveness), and count them.
+
+This injects deterministic, network-free keeper compute so the starvation gate
+can reproduce the real keeper-vs-serving contention (RFC-0204 §5) instead of
+the milder serving-only regime an idle (autonomy=0) boot produces.
+"""
+import argparse
+import json
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# A short, fixed assistant reply. Keepers parse message.content; content stays
+# small so the mock models provider *latency*, not payload weight (the harness
+# studies main-domain scheduling, not response size on the provider side).
+REPLY_TEXT = "ack"
+
+
+class Handler(BaseHTTPRequestHandler):
+    log_path = None
+    delay_ms = 0
+    counter = [0]
+
+    def _count(self):
+        self.counter[0] += 1
+        return self.counter[0]
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        raw = self.rfile.read(length) if length else b""
+        try:
+            req = json.loads(raw.decode("utf-8")) if raw else {}
+        except Exception:
+            req = {}
+        n = self._count()
+        if self.log_path:
+            rec = {
+                "ts": time.time(),
+                "n": n,
+                "path": self.path,
+                "model": req.get("model"),
+                "stream": req.get("stream", False),
+                "n_messages": len(req.get("messages", []) or []),
+            }
+            try:
+                with open(self.log_path, "a") as fh:
+                    fh.write(json.dumps(rec) + "\n")
+            except Exception:
+                pass
+
+        if self.delay_ms > 0:
+            time.sleep(self.delay_ms / 1000.0)
+
+        model = req.get("model", "mock-model")
+        if req.get("stream", False):
+            self._respond_sse(n, model)
+        else:
+            self._respond_json(n, model)
+
+    def _respond_json(self, n, model):
+        body = {
+            "id": "chatcmpl-mock-%d" % n,
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": REPLY_TEXT},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        payload = json.dumps(body).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _respond_sse(self, n, model):
+        # Standard OpenAI chat.completion.chunk SSE frames: one content delta,
+        # one finish frame, then the [DONE] sentinel.
+        cid = "chatcmpl-mock-%d" % n
+        created = int(time.time())
+
+        def chunk(delta, finish):
+            return {
+                "id": cid,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+            }
+
+        frames = [
+            chunk({"role": "assistant", "content": REPLY_TEXT}, None),
+            chunk({}, "stop"),
+        ]
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        for fr in frames:
+            self.wfile.write(("data: " + json.dumps(fr) + "\n\n").encode("utf-8"))
+            self.wfile.flush()
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+    def do_GET(self):
+        # health probe convenience
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"ok":true}')
+
+    def log_message(self, format, *args):  # noqa: A002 - match base signature
+        pass  # silence default stderr access log
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, required=True)
+    ap.add_argument("--log", default=None, help="append one JSON line per request")
+    ap.add_argument("--delay-ms", type=int, default=0,
+                    help="simulated provider latency per call")
+    args = ap.parse_args()
+    Handler.log_path = args.log
+    Handler.delay_ms = args.delay_ms
+    srv = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    sys.stderr.write("[mock] listening on 127.0.0.1:%d\n" % args.port)
+    sys.stderr.flush()
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/harness/perf/scheduler_starvation_gate.sh
+++ b/scripts/harness/perf/scheduler_starvation_gate.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# scheduler_starvation_gate.sh — Mode A: reproduce and gate main-Eio-domain scheduler starvation.
+#
+# What it measures
+#   MASC serves HTTP from a single main Eio domain that also carries every keeper fiber and the
+#   refresh loops. Under host CPU contention the OS deschedules that one thread, so trivial
+#   endpoints spike to 0.5-18s while the process itself sits at 12-27% CPU (waiting, not computing).
+#   The existing evidence for this was observational (latency happened to track host load across
+#   ad-hoc runs). This harness makes it deterministic: it injects a known number of CPU hogs and
+#   measures trivial-endpoint TTFB as a function of that load.
+#
+# Gate semantics (falsifiable, CLAUDE.md TLA+ bug-model discipline)
+#   The gate asserts the trivial endpoint stays responsive under load:
+#     trivial p95 under max load <= THRESHOLD_MS   AND   amplification <= MAX_AMP
+#   On UNFIXED main this is expected to FAIL (exit 2 = STARVED) — that failure is the proof the
+#   gate catches the defect. After a fix (launchd QoS ProcessType=Interactive, or domain_pool
+#   core-budget recommended-2 to reserve a core for the scheduler domain) re-run; it should PASS.
+#   A gate that passes on current main is too weak and must be tightened.
+#
+# Exit codes
+#   0  GREEN  — no starvation detected (desired post-fix state)
+#   2  RED    — starvation detected (expected on current unfixed main)
+#   1  ERROR  — harness failure (server did not boot, missing tools, bad args)
+#
+# Root-cause reference: docs/rfc/RFC-0204-dashboard-serving-isolation.md + adversarial diagnosis.
+# This script changes no production code; it is measurement infrastructure only.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/harness/lib/server_bootstrap.sh"
+
+# ---- configuration (env-overridable) ----------------------------------------
+NCPU="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+PROBE_ENDPOINT="${PROBE_ENDPOINT:-/health}"   # trivial, lock-free, no keeper/provider work
+PROBES="${PROBES:-40}"                         # probes per load level
+WARMUP_PROBES="${WARMUP_PROBES:-10}"           # discarded warmup probes at level 0
+PROBE_MAX_SEC="${PROBE_MAX_SEC:-20}"           # per-probe ceiling; a timeout counts as this value
+LOAD_SETTLE_SEC="${LOAD_SETTLE_SEC:-2}"        # let injected load ramp before probing
+THRESHOLD_MS="${THRESHOLD_MS:-250}"            # max acceptable trivial p95 under load
+MAX_AMP="${MAX_AMP:-8}"                         # max acceptable p95(loaded)/p95(baseline)
+# Hog levels to sweep. Default: idle, half, ncpu-1 (1 free core), ncpu (no free core).
+DEFAULT_LEVELS="0 $((NCPU/2)) $((NCPU-1)) ${NCPU}"
+HOG_LEVELS="${HOG_LEVELS:-$DEFAULT_LEVELS}"
+
+# In-process load: background request loops that keep the single main Eio domain BUSY
+# during the loaded levels. An idle server is not starvation-sensitive to host hogs alone
+# (the main thread has nothing queued, so it is scheduled promptly). Production red arises
+# when the main domain is busy (keepers + dashboard) AND host-contended. INPROC_LOAD>0
+# approximates the "busy" axis without a live keeper fleet.
+INPROC_LOAD="${INPROC_LOAD:-0}"
+LOAD_ENDPOINT="${LOAD_ENDPOINT:-/api/v1/dashboard/execution}"
+
+# Attach mode: if BASE_URL is given, probe an already-running server (e.g. the live runtime)
+# instead of booting an ephemeral one. Booting is the default and is fully self-contained.
+BASE_URL="${MASC_HARNESS_BASE_URL:-}"
+KEEP_SERVER="${KEEP_SERVER:-0}"
+
+RUN_ID="${RUN_ID:-starvation-$(date +%Y%m%d_%H%M%S)-$$}"
+RUN_DIR="${RUN_DIR:-$REPO_ROOT/logs/perf-starvation/$RUN_ID}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+  --endpoint PATH      trivial endpoint to probe (default: $PROBE_ENDPOINT)
+  --probes N           probes per load level (default: $PROBES)
+  --levels "0 8 15 16" hog counts to sweep (default: "$HOG_LEVELS")
+  --threshold-ms N     max trivial p95 under load before RED (default: $THRESHOLD_MS)
+  --max-amp N          max p95 amplification before RED (default: $MAX_AMP)
+  --base-url URL       probe an existing server instead of booting one
+  --keep-server        do not stop the booted server on exit
+  -h|--help            this help
+Environment overrides mirror the flags (PROBE_ENDPOINT, PROBES, HOG_LEVELS, THRESHOLD_MS, ...).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --endpoint) PROBE_ENDPOINT="$2"; shift 2 ;;
+    --probes) PROBES="$2"; shift 2 ;;
+    --levels) HOG_LEVELS="$2"; shift 2 ;;
+    --threshold-ms) THRESHOLD_MS="$2"; shift 2 ;;
+    --max-amp) MAX_AMP="$2"; shift 2 ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --inproc-load) INPROC_LOAD="$2"; shift 2 ;;
+    --load-endpoint) LOAD_ENDPOINT="$2"; shift 2 ;;
+    --keep-server) KEEP_SERVER=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+for tool in curl jq awk sort sysctl; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "ERROR: missing required tool: $tool" >&2; exit 1; }
+done
+
+mkdir -p "$RUN_DIR"
+CSV_FILE="$RUN_DIR/levels.csv"
+SUMMARY_FILE="$RUN_DIR/summary.json"
+SERVER_LOG="$RUN_DIR/server.log"
+echo "level_hogs,probes,p50_ms,p95_ms,max_ms,timeouts" > "$CSV_FILE"
+
+HOG_PIDS=()
+INPROC_PIDS=()
+SERVER_PID=""
+
+cleanup() {
+  kill_inproc_load
+  kill_hogs
+  if [[ -n "$SERVER_PID" && "$KEEP_SERVER" != "1" ]]; then
+    harness_stop_server "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+spawn_hogs() {
+  local n="$1" i
+  HOG_PIDS=()
+  for ((i = 0; i < n; i++)); do
+    yes > /dev/null 2>&1 &
+    HOG_PIDS+=("$!")
+  done
+}
+
+kill_hogs() {
+  if [[ ${#HOG_PIDS[@]} -gt 0 ]]; then
+    kill "${HOG_PIDS[@]}" 2>/dev/null || true
+    wait "${HOG_PIDS[@]}" 2>/dev/null || true
+  fi
+  HOG_PIDS=()
+}
+
+spawn_inproc_load() {
+  local n="$1" url="$2" i
+  INPROC_PIDS=()
+  for ((i = 0; i < n; i++)); do
+    ( while true; do curl -sS -o /dev/null --max-time 5 "$url" 2>/dev/null || true; done ) &
+    INPROC_PIDS+=("$!")
+    disown 2>/dev/null || true   # stop job-control tracking so kill is quiet
+  done
+}
+
+kill_inproc_load() {
+  if [[ ${#INPROC_PIDS[@]} -gt 0 ]]; then
+    # Kill the loop subshells and any curl children they spawned. Disowned, so no wait.
+    local pid
+    for pid in "${INPROC_PIDS[@]}"; do
+      pkill -P "$pid" 2>/dev/null || true
+      kill "$pid" 2>/dev/null || true
+    done
+  fi
+  INPROC_PIDS=()
+}
+
+# One probe -> prints TTFB in seconds (a timeout/failure prints PROBE_MAX_SEC).
+probe_once() {
+  local url="$1" t
+  t="$(curl -sS -o /dev/null -w '%{time_starttransfer}' --max-time "$PROBE_MAX_SEC" "$url" 2>/dev/null)" \
+    || t="$PROBE_MAX_SEC"
+  [[ "$t" =~ ^[0-9]+([.][0-9]+)?$ ]] || t="$PROBE_MAX_SEC"
+  printf '%s\n' "$t"
+}
+
+# Run $PROBES probes, write per-probe seconds to $1, echo "p50_ms p95_ms max_ms timeouts".
+measure_level() {
+  local out_file="$1" url="$2" i t timeouts=0
+  : > "$out_file"
+  for ((i = 0; i < PROBES; i++)); do
+    t="$(probe_once "$url")"
+    awk -v v="$t" -v m="$PROBE_MAX_SEC" 'BEGIN{ exit !(v+0 >= m+0) }' && timeouts=$((timeouts + 1))
+    printf '%s\n' "$t" >> "$out_file"
+  done
+  local stats
+  stats="$(sort -n "$out_file" | awk '
+    { v[NR] = $1 }
+    END {
+      n = NR
+      if (n == 0) { print "0.000 0.000 0.000"; exit }
+      i50 = int((n - 1) * 0.50) + 1
+      i95 = int((n - 1) * 0.95) + 1
+      printf "%.3f %.3f %.3f", v[i50] * 1000, v[i95] * 1000, v[n] * 1000
+    }')"
+  printf '%s %s\n' "$stats" "$timeouts"
+}
+
+# ---- server -----------------------------------------------------------------
+if [[ -z "$BASE_URL" ]]; then
+  SERVER_EXE="$(harness_find_server_exe "$REPO_ROOT")" || {
+    echo "ERROR: no server executable; build ./bin/main_eio.exe first" >&2; exit 1; }
+  PORT="${PORT:-$(harness_pick_free_port)}"
+  BASE_PATH="$(harness_mktemp_dir "masc-starvation-base")"
+  # Pre-seed the canonical runtime.toml so the strict OAS capability gate
+  # (Runtime.init_default_strict, server_runtime_bootstrap.ml:641) accepts boot.
+  # harness_seed_server_config writes runtime.toml only when absent, so seeding it
+  # here overrides the lib's placeholder "smoke" model (which is not in the catalog).
+  if [[ -f "$REPO_ROOT/config/runtime.toml" ]]; then
+    mkdir -p "$BASE_PATH/.masc/config"
+    cp "$REPO_ROOT/config/runtime.toml" "$BASE_PATH/.masc/config/runtime.toml"
+  fi
+  echo "[harness] booting server exe=$SERVER_EXE port=$PORT base=$BASE_PATH" >&2
+  SERVER_PID="$(harness_start_server "$SERVER_EXE" "$PORT" "$BASE_PATH" "$SERVER_LOG")"
+  if ! harness_wait_for_health "$PORT" 45; then
+    echo "ERROR: server failed health check within 45s" >&2
+    harness_print_log_tail "$SERVER_LOG"
+    exit 1
+  fi
+  BASE_URL="http://127.0.0.1:${PORT}"
+  echo "[harness] server ready pid=$SERVER_PID" >&2
+else
+  echo "[harness] attach mode, probing existing server at $BASE_URL" >&2
+fi
+
+PROBE_URL="${BASE_URL%/}${PROBE_ENDPOINT}"
+
+# Warm caches so the baseline reflects steady-state, not cold-start.
+for ((i = 0; i < WARMUP_PROBES; i++)); do probe_once "$PROBE_URL" >/dev/null; done
+
+# ---- sweep ------------------------------------------------------------------
+printf '\n%-10s %-8s %-10s %-10s %-10s %-9s\n' "hogs" "probes" "p50_ms" "p95_ms" "max_ms" "timeouts" >&2
+printf '%s\n' "------------------------------------------------------------------" >&2
+
+baseline_p95=""
+loaded_p95=""
+declare -a LEVELS_DONE=()
+for level in $HOG_LEVELS; do
+  kill_inproc_load
+  kill_hogs
+  if [[ "$level" -gt 0 ]]; then
+    spawn_hogs "$level"
+    if [[ "$INPROC_LOAD" -gt 0 ]]; then
+      spawn_inproc_load "$INPROC_LOAD" "${BASE_URL%/}${LOAD_ENDPOINT}"
+    fi
+    sleep "$LOAD_SETTLE_SEC"
+  fi
+  vals_file="$RUN_DIR/level_${level}.txt"
+  read -r p50 p95 mx timeouts <<<"$(measure_level "$vals_file" "$PROBE_URL")"
+  kill_inproc_load
+  kill_hogs
+  printf '%-10s %-8s %-10s %-10s %-10s %-9s\n' "$level" "$PROBES" "$p50" "$p95" "$mx" "$timeouts" >&2
+  printf '%s,%s,%s,%s,%s,%s\n' "$level" "$PROBES" "$p50" "$p95" "$mx" "$timeouts" >> "$CSV_FILE"
+  LEVELS_DONE+=("{\"hogs\":$level,\"p50_ms\":$p50,\"p95_ms\":$p95,\"max_ms\":$mx,\"timeouts\":$timeouts}")
+  [[ "$level" == "0" ]] && baseline_p95="$p95"
+  loaded_p95="$p95"
+done
+
+# ---- verdict ----------------------------------------------------------------
+[[ -n "$baseline_p95" ]] || baseline_p95="$loaded_p95"
+verdict="$(awk -v base="$baseline_p95" -v loaded="$loaded_p95" -v thr="$THRESHOLD_MS" -v maxamp="$MAX_AMP" '
+  BEGIN {
+    amp = (base > 0) ? loaded / base : 0
+    starved = (loaded > thr) || (amp > maxamp)
+    printf "%.2f %d", amp, starved
+  }')"
+read -r amplification starved <<<"$verdict"
+
+jq -n \
+  --arg run_id "$RUN_ID" \
+  --arg endpoint "$PROBE_ENDPOINT" \
+  --arg base_url "$BASE_URL" \
+  --argjson ncpu "$NCPU" \
+  --argjson probes "$PROBES" \
+  --argjson threshold_ms "$THRESHOLD_MS" \
+  --argjson max_amp "$MAX_AMP" \
+  --argjson baseline_p95_ms "$baseline_p95" \
+  --argjson loaded_p95_ms "$loaded_p95" \
+  --argjson amplification "$amplification" \
+  --argjson starved "$starved" \
+  --argjson levels "[$(IFS=,; echo "${LEVELS_DONE[*]}")]" \
+  '{run_id:$run_id, endpoint:$endpoint, base_url:$base_url, ncpu:$ncpu, probes_per_level:$probes,
+    threshold_ms:$threshold_ms, max_amplification:$max_amp,
+    baseline_p95_ms:$baseline_p95_ms, loaded_p95_ms:$loaded_p95_ms, amplification:$amplification,
+    starved:($starved==1), levels:$levels}' > "$SUMMARY_FILE"
+
+echo >&2
+echo "[harness] baseline p95=${baseline_p95}ms  loaded p95=${loaded_p95}ms  amplification=${amplification}x" >&2
+echo "[harness] artifacts: $RUN_DIR" >&2
+
+if [[ "$starved" == "1" ]]; then
+  echo "RED (STARVED): trivial p95 ${loaded_p95}ms under load (threshold ${THRESHOLD_MS}ms, amp ${amplification}x > ${MAX_AMP}x)" >&2
+  echo "  -> Expected on unfixed main. Apply QoS/core-budget fix and re-run; gate should turn GREEN." >&2
+  exit 2
+fi
+echo "GREEN: trivial p95 ${loaded_p95}ms under load stays within ${THRESHOLD_MS}ms (amp ${amplification}x <= ${MAX_AMP}x)" >&2
+exit 0


### PR DESCRIPTION
## 목적

MASC의 "latency가 host load를 따라가는데 `main_eio`는 12-27% CPU"라는 RFC-0204의 *관찰적* 주장을, **결정론적이고 falsifiable한 측정 게이트**로 바꾼다. 측정 통제 없이 동시성 코드를 건드리지 않는다는 Harness-First 원칙의 선행 인프라.

이 PR은 **production 코드를 바꾸지 않는다** — `scripts/harness/perf/` 아래 측정 인프라만 추가한다(순 diff: 새 파일 3개, OCaml 무변경).

## 무엇을 측정하나

MASC는 단일 main Eio 도메인이 HTTP accept + 모든 keeper fiber + refresh loop를 전부 진다. 게이트는 trivial 엔드포인트(`/health`)의 TTFB p50/p95/max를 2축 부하 하에서 측정한다:

- `--inproc-load N`: heavy 엔드포인트를 때리는 N개 백그라운드 루프(serving 도메인을 busy하게)
- `--levels "…"`: host CPU hog(`yes`) 수

판정(CLAUDE.md TLA+ bug-model 규율): `loaded p95 > THRESHOLD_MS(250)` 또는 `amp = p95(loaded)/p95(baseline) > MAX_AMP(8)` → exit 2 RED. **현재 main에서 RED여야** 게이트가 결함을 잡는다는 증명이 된다.

## 이 게이트가 이미 잡은 것 (Harness-First의 실효)

`/keepers/:name/turn-records` 핸들러를 sibling `/tool-stats` 패턴대로 cache+offload로 감싸는 "그럴듯한 RFC-0204 Phase 0 fix"를 구현·컴파일·커밋했다가, 이 게이트로 **머지 전 반증하고 되돌렸다**:

| | loaded `/health` p95 | 판정 |
|---|---|---|
| unfixed (inline) | ~15-16ms | RED |
| fixed (cache+offload) | ~17-21ms | RED |

2-바이너리 A/B(fix만 유일 변수, 격리 base_path + 실 keeper turn-records 데이터, `/health` 프로빙 중 24-way로 turn-records 부하). fix는 starvation을 안 줄인다(오히려 약간 나쁘고 variance 큼). 진짜 비용축은 내가 offload한 parse가 아니라 cache hit여도 main에 남는 **응답 직렬화+gzip**. 도메인 수 변주(1 vs 15)로 기계론 가설까지 반증. 상세 데이터는 revert 커밋 메시지(`0c7edaa2f2`).

이 fix+revert 쌍을 history에 남긴다 — "시도→측정→반증→되돌림"의 감사 추적이자, 측정 없이 머지했으면 코드베이스가 "offload turn-records = good"을 합리적 선례로 학습했을 누적을 차단한 기록.

## keeper-load 주입 (Mode B, 작동)

`keeper_load_gate.sh` + `mock_openai_provider.py`: N개 declarative 키퍼가 network-free mock에 **실제 자율 턴**을 돌리며(FSM `awaiting_provider → streaming` 도달, provider 호출 확인) `/health`를 측정한다. 부팅 레시피 end-to-end 검증됨 — runtime.toml이 카탈로그 id(`deepseek-v4-flash`)를 빌려 capability gate 통과 + provider만 mock으로, 키퍼 TOML이 `autoboot_enabled=true`+`proactive_enabled=true`+`sandbox_profile="local"`로 opt-in, `MASC_KEEPER_BOOTSTRAP_ENABLED=true`로 직접 부팅. 게이트는 워밍업 중 provider 호출 0이면 측정 거부하고 `turns_during` 컬럼을 기록한다.

**알려진 한계(게이트가 self-warn)**: 키퍼가 초기 autoboot 버스트 후 scheduled-autonomous cadence가 짧은 probe 윈도우를 앞질러 `turns_during`이 보통 0 — 측정이 키퍼 resident와는 겹치나 mid-turn과는 안 겹침. 충실한 지속 부하엔 (1) reactive 채널로 연속 턴 + (2) mock이 큰 현실적 응답 반환(await는 I/O-bound라 yield, 진짜 비용은 await 후 parse/record/snapshot). README "Mode B"에 문서화.


## 검증

- `python3 -m py_compile` OK, `shellcheck -S warning` clean, `bash -n` OK
- 게이트 self-test: 현재 main에서 RED 재현 확인(falsifiable)
- `dune build @check` rc=0 (OCaml 무변경 확인)

## 다음 단계 (이 PR 범위 밖)

검증된 방향은 구조적: RFC-0204 Phase 3(전용 serving 도메인) / 응답 production 전체(직렬화 포함) offload / scheduler 코어 예약+QoS. 각각 이 게이트로 검증 후 land.

RFC-WAIVED: 측정 인프라 전용(`scripts/harness/perf/`), production 코드 무변경. credential/operator/keeper-core/hooks/workflow subsystem 미해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
