### PR TITLE
fix(fusion): accumulate partial-fail first-judge usage on JOJ success-meta path

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -170,19 +170,13 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  in
                  (Error err, first_nodes)
                | (_, first_s, _) :: _ ->
-                 (* usage = 성공 1차(ok_priors) + 실패 1차(sum_error_usage firsts). 1차 일부가
-                    실패해도 meta가 성공하면 실패한 1차가 태운 토큰을 잃지 않는다 — all-fail
-                    path(#22122)와 동일 원칙을 성공 meta 경로에도 적용한다(적대 리뷰 #22093
-                    B-1의 부분-실패 경로; all-fail은 부분집합일 뿐 부분-실패가 더 흔하다).
-                    ok_priors는 firsts의 Ok만, sum_error_usage는 Error만 더하므로 둘 합 =
-                    모든 1차 usage(중복/누락 없음). *)
-                 let firsts_usage =
-                   Fusion_types.add_usage
-                     (List.fold_left
-                        (fun acc (_, _, u) -> Fusion_types.add_usage acc u)
-                        Fusion_types.zero_usage ok_priors)
-                     (Fusion_types.sum_error_usage firsts)
-                 in
+                 (* usage = 실행된 모든 1차 심판(성공+실패)이 태운 토큰. 1차 일부가 실패해도
+                    meta가 성공하면 그 실패한 1차의 토큰을 잃지 않는다 — all-fail
+                    path(#22122)와 동일 원칙(적대 리뷰 #22093 B-1; all-fail은 부분집합).
+                    [sum_all_usage]가 firsts의 Ok·Error 양 분기 usage를 모두 합산한다
+                    (이전엔 ok_priors fold + sum_error_usage 두 번에 나눠 더했음 — 적대 리뷰
+                    #22134: 의도는 "모든 1차 비용"이므로 단일 합산이 더 직접적이고 테스트 가능). *)
+                 let firsts_usage = Fusion_types.sum_all_usage firsts in
                  let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
                  (match
                     Fusion_judge.run_meta ~sw ~net

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -170,10 +170,18 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  in
                  (Error err, first_nodes)
                | (_, first_s, _) :: _ ->
+                 (* usage = 성공 1차(ok_priors) + 실패 1차(sum_error_usage firsts). 1차 일부가
+                    실패해도 meta가 성공하면 실패한 1차가 태운 토큰을 잃지 않는다 — all-fail
+                    path(#22122)와 동일 원칙을 성공 meta 경로에도 적용한다(적대 리뷰 #22093
+                    B-1의 부분-실패 경로; all-fail은 부분집합일 뿐 부분-실패가 더 흔하다).
+                    ok_priors는 firsts의 Ok만, sum_error_usage는 Error만 더하므로 둘 합 =
+                    모든 1차 usage(중복/누락 없음). *)
                  let firsts_usage =
-                   List.fold_left
-                     (fun acc (_, _, u) -> Fusion_types.add_usage acc u)
-                     Fusion_types.zero_usage ok_priors
+                   Fusion_types.add_usage
+                     (List.fold_left
+                        (fun acc (_, _, u) -> Fusion_types.add_usage acc u)
+                        Fusion_types.zero_usage ok_priors)
+                     (Fusion_types.sum_error_usage firsts)
                  in
                  let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
                  (match

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -25,6 +25,17 @@ let sum_error_usage results =
       | Ok _ -> acc)
     zero_usage results
 
+(* [Ok]·[Error] 양 분기의 usage를 모두 합산한다. 일부 성공/일부 실패한 fan-out(JOJ
+   1차 심판 등)이 태운 *모든* 토큰을 보존한다. [sum_error_usage](실패분만)와 의도가
+   구분된다 — 이쪽은 "실행된 전부", 저쪽은 "실패한 것만". 부분-실패 경로에서
+   성공분 fold + 실패분 fold를 따로 더하는 대신 한 번에 합산한다(적대 리뷰 #22134). *)
+let sum_all_usage results =
+  List.fold_left
+    (fun acc (_, r) ->
+      match r with
+      | Ok (_, u) | Error (_, u) -> add_usage acc u)
+    zero_usage results
+
 module Fusion_depth = struct
   type t =
     | Top

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -32,6 +32,11 @@ val add_usage : usage -> usage -> usage
     태운 토큰을 잃는 undercount를 막는다(적대 리뷰 #22093 all-fail). *)
 val sum_error_usage : ('id * ('ok, 'msg * usage) result) list -> usage
 
+(** [sum_all_usage results]는 [Ok]·[Error] 양 분기 usage를 모두 합산한다. 일부 성공/일부
+    실패한 fan-out(JOJ 1차 심판 등)이 태운 *모든* 토큰을 보존한다. 성공분 fold와 실패분
+    fold를 따로 더하던 부분-실패 경로를 단일 합산으로 단순화한다(적대 리뷰 #22134). *)
+val sum_all_usage : ('id * ('a * usage, 'b * usage) result) list -> usage
+
 (** {1 재귀 가드} *)
 
 (** 심의 깊이. OpenRouter의 [x-openrouter-fusion-depth] 헤더에 대응하는 타입드

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -59,6 +59,26 @@ let test_sum_error_usage_empty_is_zero () =
   check usage_t "no results -> zero usage" Fusion_types.zero_usage
     (Fusion_types.sum_error_usage [])
 
+let test_sum_all_usage_folds_ok_and_error () =
+  (* 적대 리뷰 #22134 partial-fail: 1차 일부 성공/일부 실패 시 meta가 성공하면 *모든* 1차
+     심판이 태운 토큰(성공분 + 실패분)을 비용에 실어야 한다. sum_all_usage는 Ok와 Error를
+     모두 합산함을 핀한다 — sum_error_usage(실패분만, 위 테스트)와 대비된다. *)
+  let u input_tokens output_tokens : Fusion_types.usage =
+    { Fusion_types.input_tokens; output_tokens }
+  in
+  let results =
+    [ ("j1", Error ("boom1", u 100 10))
+    ; ("j2", Ok (sample_synthesis, u 999 999)) (* Ok도 합산되어야 함 *)
+    ; ("j3", Error ("boom3", u 25 5))
+    ]
+  in
+  check usage_t "sums every judge's usage, Ok and Error alike" (u 1124 1014)
+    (Fusion_types.sum_all_usage results)
+
+let test_sum_all_usage_empty_is_zero () =
+  check usage_t "no results -> zero usage" Fusion_types.zero_usage
+    (Fusion_types.sum_all_usage [])
+
 let () =
   run "fusion_judge_usage"
     [ ( "attach_usage"
@@ -70,5 +90,10 @@ let () =
       , [ test_case "folds all failures, ignores Ok" `Quick
             test_sum_error_usage_folds_all_failures
         ; test_case "empty is zero" `Quick test_sum_error_usage_empty_is_zero
+        ] )
+    ; ( "sum_all_usage"
+      , [ test_case "folds Ok and Error usage alike" `Quick
+            test_sum_all_usage_folds_ok_and_error
+        ; test_case "empty is zero" `Quick test_sum_all_usage_empty_is_zero
         ] )
     ]


### PR DESCRIPTION
## 무엇을 / 왜

judge-of-judges(JOJ)에서 1차 심판이 파싱 실패 등으로 끝나도 토큰은 이미 태웠다. #22122(머지됨)는 **all-fail path**(1차 전원 실패)의 usage만 `sum_error_usage`로 합산했다. 하지만 더 흔한 경로인 **"1차 일부 실패 + meta 성공"**의 `firsts_usage = fold ok_priors`는 성공한 1차만 합산해 실패한 1차가 태운 토큰을 버린다(undercount). 적대 리뷰 #22093 B-1이 지적한 본래 갭이다 — all-fail은 그 부분집합일 뿐이다.

## 어떻게

성공 meta 분기 `firsts_usage`를 `add_usage (ok_priors fold) (sum_error_usage firsts)`로 교정. `ok_priors`는 `firsts`의 `Ok`만, `sum_error_usage`는 `Error`만 더하므로 둘 합 = 모든 1차 usage(중복/누락 없음).

## #22122와의 관계 (N-of-M 안티패턴 아님)

`sum_error_usage`는 #22122가 이미 순수 헬퍼로 추출했다. 이 PR은 **같은 헬퍼를 재활용**하며, 같은 변환을 여러 사이트에서 따로 짜는 N-of-M 안티패턴이 아니다. all-fail과 partial-fail은 *다른 코드 경로*이고, #22122 머지 타이밍 경합(같은 슬라이스를 한 PR로 합치려다 #22122가 먼저 머지됨)으로 분리됐을 뿐 abstraction은 이미 존재한다.

## 영향

usage는 sink 관측 record(대시보드 토큰 회계)에만 영향 — canonical 결정/답변/chat/wake 불변. cost-control 도입이 아니라 usage 정확성 교정이다.

## 테스트

- `dune build lib/fusion lib/fusion_core --root .` 통과(컴파일).
- `ocamlformat --check lib/fusion/fusion_orchestrator.ml` 통과.
- `sum_error_usage` 헬퍼는 #22122의 `test_fusion_judge_usage`(folds-all-failures, empty-is-zero)가 이미 핀했다. 이 PR은 그 헬퍼를 성공 meta 분기에 연결한다.
- **테스트 못 하는 것(정직)**: `Fusion_orchestrator.run`은 live Eio + 심판 HTTP가 필요해 성공 meta 분기 자체는 단위 테스트 불가. usage 회계 end-to-end 검증은 RFC-0252 §11 하네스 트랙.

## 안티패턴 self-check

- telemetry-as-fix 아님: usage를 *정확히 합산*(폐기 교정)이지 counter 추가가 아님.
- string 분류기 / cap-cooldown / repair: 해당 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
