### PR TITLE
feat(dashboard): goal-loop status SSE liveness (RFC-0284)

### DIFF
--- a/dashboard/src/components/goal-loop-panel.test.ts
+++ b/dashboard/src/components/goal-loop-panel.test.ts
@@ -114,6 +114,26 @@ describe('GoalLoopPanel', () => {
     expect(mocks.fetchGoalLoopStatus).not.toHaveBeenCalled()
   })
 
+  it('re-renders when the store signal is written after mount (push reactivity)', async () => {
+    // RFC-0284 §6 FE: the panel reads goalLoopStatusData.value in its render
+    // body, which subscribes it to the signal. A post-mount write (the SSE
+    // push path) must drive a re-render with no fetch and no re-mount. Moving
+    // the read into a useCallback/useMemo closure would break the subscription
+    // and turn this test red — that is the regression this pins.
+    goalLoopStatusData.value = blockedStatus()
+    render(html`<${GoalLoopPanel} />`)
+    expect(screen.getByTestId('goal-loop-next-action').textContent).toContain('D-EMERGENCY-2')
+
+    const pushed = blockedStatus()
+    pushed.nextAction = { ...(pushed.nextAction ?? {}), decision_id: 'D-PUSHED-7' }
+    goalLoopStatusData.value = pushed
+
+    await waitFor(() => {
+      expect(screen.getByTestId('goal-loop-next-action').textContent).toContain('D-PUSHED-7')
+    })
+    expect(mocks.fetchGoalLoopStatus).not.toHaveBeenCalled()
+  })
+
   it('renders phase table, audit, and next action', () => {
     const { container } = render(html`<${GoalLoopPanel} initialStatus=${blockedStatus()} />`)
 

--- a/dashboard/src/components/goal-loop-panel.test.ts
+++ b/dashboard/src/components/goal-loop-panel.test.ts
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/pr
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { GoalLoopPanel } from './goal-loop-panel'
 import { normalizeGoalLoopStatus } from '../goal-loop-status'
+import { goalLoopStatusData } from '../goal-loop-state'
 
 const mocks = vi.hoisted(() => ({
   callMcpTool: vi.fn(),
@@ -96,6 +97,21 @@ describe('GoalLoopPanel', () => {
     mocks.fetchDashboardGoalsTree.mockReset()
     mocks.hydrateGoalTreeSnapshot.mockReset()
     mocks.navigate.mockReset()
+    // RFC-0284: the panel now reads a module-global signal; reset it so a
+    // pushed/refreshed status in one test cannot leak into the next.
+    goalLoopStatusData.value = null
+  })
+
+  it('renders a pushed goal-loop snapshot from the store without a mount fetch', () => {
+    // RFC-0284 §6 FE: a snapshot already in the store renders with no
+    // initialStatus prop and triggers no HTTP fetch (push, not poll).
+    goalLoopStatusData.value = blockedStatus()
+
+    render(html`<${GoalLoopPanel} />`)
+
+    expect(screen.getByTestId('goal-loop-panel')).toBeTruthy()
+    expect(screen.getByTestId('goal-loop-next-action').textContent).toContain('D-EMERGENCY-2')
+    expect(mocks.fetchGoalLoopStatus).not.toHaveBeenCalled()
   })
 
   it('renders phase table, audit, and next action', () => {

--- a/dashboard/src/components/goal-loop-panel.ts
+++ b/dashboard/src/components/goal-loop-panel.ts
@@ -16,6 +16,7 @@ import { asString, isRecord } from './common/normalize'
 import { formatMsCompact } from '../lib/format-number'
 import { errorToString } from '../lib/format-string'
 import { hydrateGoalTreeSnapshot } from '../goal-tree-state'
+import { goalLoopStatusData } from '../goal-loop-state'
 import { navigate } from '../router'
 import {
   GOAL_LOOP_PHASES,
@@ -523,8 +524,14 @@ function GoalLoopDetailDrawer({
 }
 
 export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
-  const [status, setStatus] = useState<GoalLoopStatusResponse | null>(initialStatus ?? null)
-  const [loading, setLoading] = useState(initialStatus === undefined)
+  // RFC-0284: render from the shared pushed store (hydrated by the SSE
+  // goal_loop_status delta / goals snapshot / bootstrap), falling back to the
+  // SSR/prop status until the first push arrives. Reading the signal here makes
+  // the panel re-render on every live update — no mount fetch, no polling.
+  const status = goalLoopStatusData.value ?? initialStatus ?? null
+  const [loading, setLoading] = useState(
+    goalLoopStatusData.value === null && initialStatus === undefined,
+  )
   const [error, setError] = useState<string | null>(null)
   const [selectedPhase, setSelectedPhase] = useState<GoalLoopPhaseName | null>(null)
 
@@ -532,16 +539,22 @@ export function GoalLoopPanel({ initialStatus }: GoalLoopPanelProps) {
     setLoading(true)
     setError(null)
     void fetchGoalLoopStatus()
-      .then(setStatus)
+      .then((next) => {
+        goalLoopStatusData.value = next
+      })
       .catch((err) => {
         setError(errorToString(err))
       })
       .finally(() => setLoading(false))
   }, [])
 
+  // First-paint fallback only: if no snapshot has been pushed (no SSE delta, no
+  // bootstrap hydration) and none was provided, fetch once. This syncs the
+  // empty store with the server — an external-data effect, not state derivation.
   useEffect(() => {
-    if (initialStatus !== undefined) return
-    refresh()
+    if (goalLoopStatusData.value === null && initialStatus === undefined) {
+      refresh()
+    }
   }, [initialStatus, refresh])
 
   if (loading && status === null) {

--- a/dashboard/src/goal-loop-event-type-drift.test.ts
+++ b/dashboard/src/goal-loop-event-type-drift.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+// RFC-0284 review follow-up (parity-gate consistency exception).
+//
+// The `goal_loop_status` event type is a *slice-bridged* event: the frontend
+// handles it in `hydrateDashboardSlice`'s eventType switch (`case 'X'`), NOT as
+// an exact-match `event.type === 'X'` route. The sse-event-type-parity gate only
+// inventories exact-match routes (its regex matches `event.type === 'X'`), so it
+// does NOT track `goal_loop_status`. Its liveness instead depends on three raw
+// string literals staying in sync across the boundary:
+//
+//   1. BE emit       — the event type definition broadcast over SSE
+//   2. BE WS bridge  — the slice-bridge arm mapping it onto the "goals" slice
+//   3. FE switch case — the hydrateDashboardSlice handler
+//
+// Rename one and live goal-loop updates break silently while every other test
+// stays green — exactly the failure mode the parity gate was built to prevent
+// for exact-match routes. This guard binds the three literals (plus the bridge
+// target) so a one-sided rename turns red. RFC §7 rejects widening the
+// exact-match contract surface, so this is a targeted drift guard rather than a
+// parity-gate extension.
+//
+// BE paths are resolved from the dashboard cwd via `../lib/`. The CI Dashboard
+// job runs on a full checkout, so the backend files resolve there too.
+
+const EVENT_TYPE = 'goal_loop_status'
+
+const sites = [
+  [
+    'BE emit (event type def)',
+    '../lib/server/server_dashboard_http_goal_loop_broadcast.ml',
+    `"${EVENT_TYPE}"`,
+  ],
+  [
+    'BE WS slice bridge',
+    '../lib/server/server_mcp_transport_ws.ml',
+    `"${EVENT_TYPE}"`,
+  ],
+  [
+    'FE hydrateDashboardSlice case',
+    'src/sse-store.ts',
+    `'${EVENT_TYPE}'`,
+  ],
+] as const
+
+describe('goal_loop_status event-type cross-boundary drift guard (RFC-0284)', () => {
+  for (const [label, file, literal] of sites) {
+    it(`${label} carries the ${EVENT_TYPE} literal`, () => {
+      const source = readFileSync(resolve(process.cwd(), file), 'utf8')
+      expect(source).toContain(literal)
+    })
+  }
+
+  it('the BE WS bridge maps goal_loop_status onto the existing goals slice', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), '../lib/server/server_mcp_transport_ws.ml'),
+      'utf8',
+    )
+    // The bridge arm (may wrap across lines):
+    //   | "goal_loop_status" ->
+    //       Some "goals"
+    expect(source).toMatch(/"goal_loop_status"\s*->\s*Some\s+"goals"/)
+  })
+})

--- a/dashboard/src/goal-loop-state.ts
+++ b/dashboard/src/goal-loop-state.ts
@@ -1,0 +1,22 @@
+import { signal } from '@preact/signals'
+
+import { normalizeGoalLoopStatus, type GoalLoopStatusResponse } from './goal-loop-status'
+
+// RFC-0284: goal-loop OODA status pushed over SSE — via the `goal_loop_status`
+// live delta and the `goals` snapshot `loop` sub-field — so the panel renders
+// from a shared store instead of polling on mount. Mirrors goal-tree-state.ts.
+export const goalLoopStatusData = signal<GoalLoopStatusResponse | null>(null)
+export const goalLoopStatusError = signal<string | null>(null)
+
+// Hydrate from a raw goal-loop status payload (snake_case JSON as emitted by
+// the server). Returns false — leaving the current value intact — when the
+// payload is not a status object, so a stray empty/garbage delta cannot blank
+// out a good snapshot. The server always stamps `schema_version`, so its
+// presence is the cheap "this is a status" discriminator.
+export function hydrateGoalLoopSnapshot(payload: unknown): boolean {
+  if (!payload || typeof payload !== 'object') return false
+  if (!('schema_version' in payload)) return false
+  goalLoopStatusData.value = normalizeGoalLoopStatus(payload)
+  goalLoopStatusError.value = null
+  return true
+}

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -43,6 +43,7 @@ const replayOasRuntimeTelemetry = vi.fn<() => Promise<void>>(async () => {})
 const compositeTick = signal({ name: '', ts_unix: 0 })
 const hydrateFleetCompositeSnapshot = vi.fn<(payload: unknown) => void>()
 const hydrateGoalTreeSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
+const hydrateGoalLoopSnapshot = vi.fn<(payload: unknown) => boolean>(() => true)
 const noteKeeperChatAppended = vi.fn<(name: string, audio?: unknown, blocks?: unknown) => void>()
 
 async function flushAsyncWork(): Promise<void> {
@@ -95,6 +96,9 @@ async function loadSseStore() {
   vi.doMock('./goal-tree-state', () => ({
     hydrateGoalTreeSnapshot,
   }))
+  vi.doMock('./goal-loop-state', () => ({
+    hydrateGoalLoopSnapshot,
+  }))
   vi.doMock('./keeper-runtime', () => ({
     noteKeeperChatAppended,
   }))
@@ -130,6 +134,8 @@ describe('setupSSEReaction reconnect hydration', () => {
     hydrateFleetCompositeSnapshot.mockClear()
     hydrateGoalTreeSnapshot.mockClear()
     hydrateGoalTreeSnapshot.mockReturnValue(true)
+    hydrateGoalLoopSnapshot.mockClear()
+    hydrateGoalLoopSnapshot.mockReturnValue(true)
     namespaceTruth.value = null
     namespaceTruthError.value = null
     boardPosts.value = []
@@ -705,6 +711,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     sseStore.hydrateDashboardSlice('goals', {
       planning: { goals: [], generated_at: 'now' },
       tree: { tree: [], summary: { total_goals: 0 } },
+      loop: { schema_version: 1, loop_iteration: '3', overall_status: 'ok' },
     })
     sseStore.hydrateDashboardSlice('composite', {
       generated_at: 1,
@@ -715,11 +722,31 @@ describe('setupSSEReaction reconnect hydration', () => {
     expect(hydrateBoardSnapshot).toHaveBeenCalledWith({ posts: [], generated_at: 'now' })
     expect(hydratePlanningSnapshot).toHaveBeenCalledWith({ goals: [], generated_at: 'now' })
     expect(hydrateGoalTreeSnapshot).toHaveBeenCalledWith({ tree: [], summary: { total_goals: 0 } })
+    // RFC-0284: the goals snapshot's loop sub-field hydrates the goal-loop store.
+    expect(hydrateGoalLoopSnapshot).toHaveBeenCalledWith({
+      schema_version: 1,
+      loop_iteration: '3',
+      overall_status: 'ok',
+    })
     expect(hydrateFleetCompositeSnapshot).toHaveBeenCalledWith({
       generated_at: 1,
       count: 0,
       snapshots: [],
     })
+  })
+
+  it('routes the goal_loop_status delta to the goal-loop store, not as a goals snapshot', async () => {
+    const { sseStore } = await loadSseStore()
+
+    // RFC-0284: live goal-loop delta bridged onto the "goals" slice carries the
+    // status directly + the goal_loop_status event type. It must hydrate the
+    // goal-loop store and must NOT be unpacked as a {planning,tree} snapshot.
+    const status = { schema_version: 1, loop_iteration: '8', overall_status: 'warning' }
+    sseStore.hydrateDashboardSlice('goals', status, 'goal_loop_status')
+
+    expect(hydrateGoalLoopSnapshot).toHaveBeenCalledWith(status)
+    expect(hydratePlanningSnapshot).not.toHaveBeenCalled()
+    expect(hydrateGoalTreeSnapshot).not.toHaveBeenCalled()
   })
 
   it('handles every dashboard push slice advertised to route subscriptions', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -56,6 +56,7 @@ import { operatorSnapshot, operatorWorkspaceDigest } from './operator-signals'
 import { compositeTick, hydrateFleetCompositeSnapshot } from './composite-signals'
 import { isRecord } from './lib/type-guards'
 import { hydrateGoalTreeSnapshot } from './goal-tree-state'
+import { hydrateGoalLoopSnapshot } from './goal-loop-state'
 import { showToast } from './components/common/toast'
 import type { ErrorCode } from './types/error'
 import { route } from './router'
@@ -605,6 +606,12 @@ export function hydrateDashboardSlice(slice: string, payload: unknown, eventType
     case 'transport_health_snapshot':
       hydrateServerPushEvent({ type: eventType, payload } as SSEEvent)
       return
+    case 'goal_loop_status':
+      // RFC-0284: live goal-loop delta bridged onto the "goals" slice. The
+      // payload is the goal-loop status itself (not a {planning,tree,loop}
+      // snapshot), so hydrate it directly rather than falling to case 'goals'.
+      hydrateGoalLoopSnapshot(payload)
+      return
   }
   if (eventType) {
     routeServerPushEvent({
@@ -642,12 +649,17 @@ export function hydrateDashboardSlice(slice: string, payload: unknown, eventType
       return
     case 'goals': {
       if (!payload || typeof payload !== 'object') return
-      const record = payload as { planning?: unknown; tree?: unknown }
+      const record = payload as { planning?: unknown; tree?: unknown; loop?: unknown }
       if (record.planning) {
         hydratePlanningSnapshot(record.planning as DashboardPlanningResponse)
       }
       if (record.tree) {
         hydrateGoalTreeSnapshot(record.tree)
+      }
+      if (record.loop) {
+        // RFC-0284: the goals snapshot carries the goal-loop status so the
+        // initial WS snapshot paints the panel without a separate fetch.
+        hydrateGoalLoopSnapshot(record.loop)
       }
       return
     }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -53,6 +53,7 @@ import { timeBoardRequest } from './board-metrics'
 import { namespaceTruth, namespaceTruthError, namespaceTruthInitializing } from './namespace-truth-signals'
 import { normalizeNamespaceTruth } from './namespace-truth-normalizers'
 import { hydrateGoalTreeSnapshot } from './goal-tree-state'
+import { hydrateGoalLoopSnapshot } from './goal-loop-state'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
   normalizeExecutionWorkerSupportBrief,
@@ -720,6 +721,11 @@ function hydrateDashboardBootstrap(data: DashboardBootstrapResponse): void {
   }
   if (data.goals && !bootstrapSliceError(data.goals)) {
     hydrateGoalTreeSnapshot(data.goals)
+  }
+  if (data.goal_loop_status && !bootstrapSliceError(data.goal_loop_status)) {
+    // RFC-0284: seed the goal-loop store on first page load so the panel
+    // renders without its own fetch; live updates then arrive over SSE.
+    hydrateGoalLoopSnapshot(data.goal_loop_status)
   }
 }
 

--- a/docs/rfc/RFC-0284-goal-loop-sse-liveness.md
+++ b/docs/rfc/RFC-0284-goal-loop-sse-liveness.md
@@ -93,6 +93,27 @@ changed** since the last broadcast. This:
 - degrades to today's behavior if detection is unavailable (the HTTP pull stays
   as a fallback for first paint and reconnect hydration).
 
+### §3.3 Implementation note — a `goal_loop_status` event type is required (amended 2026-06-23)
+
+§3.1 assumed the `goals` snapshot is already pushed live and that no new event
+type would be needed. Grounding the live path against the code showed otherwise:
+the dashboard live-update path is the SSE → `dashboard/delta` bridge in
+`server_mcp_transport_ws.ml`, which keys deltas by `dashboard_slice_for_sse_type
+event_type`. The `goals` slice has **no** entry there, so the `case 'goals'`
+handler in `sse-store.ts` only runs on the initial `dashboard/snapshot` burst,
+never on a live delta. Reusing `goals` with no event type therefore cannot
+deliver live updates.
+
+The implementation threads the needle: a dedicated `goal_loop_status` event type
+is broadcast (change-gated) and **bridged onto the existing `goals` slice**
+(`dashboard_slice_for_sse_type "goal_loop_status" -> Some "goals"`). The frontend
+handles it in `hydrateDashboardSlice`'s event-type switch (a `case`, not an
+exact-match `event.type === 'X'` route), so the parity gate (PR #22124) stays
+unaffected — its inventory only tracks exact-match routes. This keeps the §3.1
+goal (reuse the `goals` slice, no new WS slice, parity gate untouched) while
+adding the one event type the live delta bridge actually requires. The `goals`
+snapshot still carries the `loop` sub-field for the initial-burst / HTTP path.
+
 ## §4 Frontend
 
 - `sse-store.ts` `case 'goals'`: when `record.loop` is present, hydrate it into a
@@ -126,10 +147,13 @@ changed** since the last broadcast. This:
 
 ## §7 Alternatives considered
 
-- **A new `goal_loop_status` SSE event** — a dedicated exact-match event +
-  handler. Pro: the parity gate would auto-enforce it. Con: widens the event-type
-  contract surface for a resource that fits the existing `goals` snapshot shape;
-  rejected in favor of §3.1.
+- **A new `goal_loop_status` exact-match SSE event** — a dedicated exact-match
+  `event.type === 'goal_loop_status'` route + handler. Pro: the parity gate would
+  auto-enforce it. Con: widens the parity-gated exact-match contract surface.
+  Rejected in favor of the §3.3 hybrid: a `goal_loop_status` event type is used
+  (the delta bridge requires one) but bridged onto the existing `goals` slice and
+  handled in the slice event-type switch, so it is **not** an exact-match route
+  and the parity gate is unaffected.
 - **Worker → broadcast** — have the Python worker notify the server (HTTP/IPC) to
   broadcast. Rejected (§2): couples the out-of-process worker to the OCaml
   transport; the server already reads the file, so change detection is strictly

--- a/docs/rfc/RFC-0284-goal-loop-sse-liveness.md
+++ b/docs/rfc/RFC-0284-goal-loop-sse-liveness.md
@@ -136,14 +136,22 @@ snapshot still carries the `loop` sub-field for the initial-burst / HTTP path.
 
 ## §6 Verification
 
-- Server: a test that a status change produces exactly one `goals` snapshot with
-  a `loop` field, and an unchanged status produces none (change-detection gate).
-- Frontend: a test that a `goals` snapshot carrying `loop` updates the goal-loop
-  store without an HTTP fetch (mirrors the existing `project_snapshot`
-  no-HTTP-fetch test), and that reconnect re-hydrates.
-- Parity gate (PR #22124): unaffected — `goals` is a snapshot sub-kind routed via
-  the `case 'goals'` switch, not an exact-match `event.type === 'X'` route, so it
-  is outside the gate's exact-match inventory by design.
+- Server: a test that a status change produces exactly one `goal_loop_status`
+  broadcast carrying the status as `payload`, and an unchanged status produces
+  none (`test_goal_loop_broadcast.ml`, change-detection gate). A `generated_at`-
+  only delta also produces none, proving the volatile-key exclusion (§3.2).
+- Frontend: a test that a pushed snapshot updates the goal-loop store and the
+  panel renders it without an HTTP fetch (mirrors the existing no-HTTP-fetch
+  tests), a post-mount signal write re-renders the panel (push reactivity), and
+  reconnect re-hydrates via the existing dashboard refresh.
+- Parity gate (PR #22124): unaffected — `goal_loop_status` is handled in
+  `hydrateDashboardSlice`'s eventType switch (`case 'goal_loop_status'`), bridged
+  onto the `goals` slice (§3.3), not an exact-match `event.type === 'X'` route,
+  so it is outside the gate's exact-match inventory by design. Because the gate
+  does not track it, a dedicated cross-boundary drift guard
+  (`goal-loop-event-type-drift.test.ts`) binds the three `goal_loop_status`
+  literals (BE emit / BE WS bridge / FE case) so a one-sided rename fails instead
+  of silently breaking live updates.
 
 ## §7 Alternatives considered
 

--- a/docs/rfc/RFC-0284-goal-loop-sse-liveness.md
+++ b/docs/rfc/RFC-0284-goal-loop-sse-liveness.md
@@ -8,7 +8,7 @@ author: vincent
 supersedes: []
 superseded_by: null
 related: ["0201", "0022", "0113"]
-implementation_prs: []
+implementation_prs: ["22135"]
 ---
 
 # RFC-0284: Goal-loop status SSE liveness

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -539,9 +539,14 @@ let dashboard_goals_tree_http_json ~(config : Workspace.config) : Yojson.Safe.t 
 ;;
 
 let dashboard_goals_snapshot_json ~(config : Workspace.config) : Yojson.Safe.t =
+  (* RFC-0284: carry the goal-loop OODA status alongside planning/tree so the
+     WS "goals" slice's initial snapshot (and the /goals HTTP pull) paint the
+     goal-loop panel without a separate fetch. Live updates arrive via the
+     [goal_loop_status] delta (Server_dashboard_http_goal_loop_broadcast). *)
   `Assoc
     [ "planning", dashboard_planning_http_json ~config
     ; "tree", dashboard_goals_tree_http_json ~config
+    ; "loop", Dashboard_goal_loop.status_json ~base_path:config.base_path ()
     ]
 
 let dashboard_ide_snapshot_json ~(config : Workspace.config) : Yojson.Safe.t =

--- a/lib/server/server_dashboard_http_goal_loop_broadcast.ml
+++ b/lib/server/server_dashboard_http_goal_loop_broadcast.ml
@@ -1,0 +1,102 @@
+(** RFC-0284: push the goal-loop OODA status to dashboard clients over SSE
+    when its content changes, instead of leaving the panel on HTTP pull.
+
+    The goal-loop worker is an out-of-process Python OODA loop
+    ([scripts/goal_loop_scheduler.py] and friends) that only writes
+    [<masc_dir>/goal-loop/status.json]; it cannot call the in-process
+    [Sse.broadcast]. So the broadcast trigger lives here on the server: a
+    periodic tick reads the (5 s TTL cached) status via
+    [Dashboard_goal_loop.status_json], fingerprints the meaningful content,
+    and broadcasts a [goal_loop_status] event only when it changed since the
+    last broadcast.
+
+    The [goal_loop_status] event bridges to the existing dashboard "goals"
+    WS slice via [Server_mcp_transport_ws.dashboard_slice_for_sse_type], so
+    no new dashboard WS slice is introduced. RFC-0284 §3.1 originally
+    proposed reusing the "goals" snapshot with no new event type at all, but
+    the live-update path runs through the SSE -> dashboard/delta bridge,
+    which keys deltas by event_type; the "goals" slice only paints on the
+    initial dashboard/snapshot burst. A dedicated [goal_loop_status] event
+    type is therefore required for live deltas. See RFC-0284 §3 (amended).
+
+    The change-detection / fingerprint pattern mirrors
+    [Server_dashboard_http_namespace_truth.should_broadcast_namespace_truth_snapshot]. *)
+
+let goal_loop_broadcast_event_type = "goal_loop_status"
+
+(* Default tick interval. Matches the goal-loop status read model's own 5 s
+   TTL cache ([Dashboard_goal_loop.goal_loop_cache_ttl_s]); a shorter tick
+   would only re-read the same cached value. *)
+let goal_loop_broadcast_interval_s = 5.0
+
+(* Per-write volatiles excluded from the change fingerprint. The Python
+   writer stamps a fresh [generated_at] on every write (and the OCaml read
+   model attaches a read-time [dashboard_source]), even when the OODA content
+   is unchanged. Hashing those would broadcast on every no-op rewrite.
+   [loop_iteration] / [overall_status] / [phases] / [next_action] /
+   [system_health_signals] / [known_blockers] remain in the fingerprint, so a
+   real OODA-cycle change still triggers a broadcast. *)
+let goal_loop_fingerprint_volatile_keys = [ "generated_at"; "dashboard_source" ]
+
+let goal_loop_fingerprint (status : Yojson.Safe.t) : Digestif.SHA256.t =
+  let stable =
+    match status with
+    | `Assoc kvs ->
+        `Assoc
+          (List.filter
+             (fun (k, _) -> not (List.mem k goal_loop_fingerprint_volatile_keys))
+             kvs)
+    | other -> other
+  in
+  Digestif.SHA256.digest_string (Yojson.Safe.to_string stable)
+
+let last_goal_loop_snapshot_hash : Digestif.SHA256.t option ref = ref None
+let goal_loop_snapshot_hash_mu = Eio.Mutex.create ()
+
+(* Returns [true] exactly once per distinct fingerprint: the first time a
+   given content is seen, and again only after the content changes. Updates
+   the stored fingerprint as a side effect. *)
+let should_broadcast_goal_loop_snapshot (status : Yojson.Safe.t) : bool =
+  let hash = goal_loop_fingerprint status in
+  Eio.Mutex.use_rw ~protect:true goal_loop_snapshot_hash_mu (fun () ->
+      match !last_goal_loop_snapshot_hash with
+      | Some prev when Digestif.SHA256.equal prev hash -> false
+      | _ ->
+          last_goal_loop_snapshot_hash := Some hash;
+          true)
+
+let goal_loop_snapshot_event (status : Yojson.Safe.t) : Yojson.Safe.t =
+  `Assoc
+    [ "type", `String goal_loop_broadcast_event_type
+    ; "payload", status
+    ; "ts_unix", `Float (Time_compat.now ())
+    ]
+
+(* RFC-0284 §3.2: broadcast a [goal_loop_status] event carrying [status], but
+   only when its fingerprint changed since the last broadcast. Returns [true]
+   when an event was emitted (exposed for tests). *)
+let broadcast_goal_loop_status (status : Yojson.Safe.t) : bool =
+  if should_broadcast_goal_loop_snapshot status then begin
+    Sse.broadcast_to Observers (goal_loop_snapshot_event status);
+    Log.Dashboard.routine "goal-loop status pushed via SSE";
+    true
+  end
+  else begin
+    Log.Dashboard.routine "goal-loop status unchanged, skipping SSE broadcast";
+    false
+  end
+
+let goal_loop_status_for_state (state : Mcp_server.server_state) : Yojson.Safe.t =
+  Dashboard_goal_loop.status_json
+    ~base_path:(Mcp_server.workspace_config state).base_path ()
+
+let start_goal_loop_refresh_loop ~state ~sw ~clock =
+  Proactive_refresh.start
+    ~sw
+    ~clock
+    ~config:
+      (Proactive_refresh.default_config
+         ~label:"goal_loop_status"
+         ~interval_s:goal_loop_broadcast_interval_s)
+    ~compute:(fun () -> goal_loop_status_for_state state)
+    ~on_result:(fun status -> ignore (broadcast_goal_loop_status status))

--- a/lib/server/server_dashboard_http_goal_loop_broadcast.mli
+++ b/lib/server/server_dashboard_http_goal_loop_broadcast.mli
@@ -1,0 +1,43 @@
+(** RFC-0284: server-side change-gated SSE broadcast of the goal-loop OODA
+    status.
+
+    The goal-loop worker is an out-of-process Python OODA loop that only writes
+    [<masc_dir>/goal-loop/status.json]; it cannot call the in-process
+    [Sse.broadcast]. So the broadcast trigger lives here: a periodic tick reads
+    the cached status, fingerprints its meaningful content (per-write volatile
+    fields excluded), and broadcasts only when that content changed. The event
+    bridges to the existing dashboard "goals" WS slice via
+    [Server_mcp_transport_ws.dashboard_slice_for_sse_type], so no new WS slice
+    is introduced. The change-detection pattern mirrors
+    [Server_dashboard_http_namespace_truth]. See the [.ml] and RFC-0284 §3 for
+    the full rationale.
+
+    The change-fingerprint state (last-broadcast hash and its mutex) is
+    intentionally module-private so callers cannot desynchronize it. *)
+
+val goal_loop_broadcast_event_type : string
+(** SSE event type carried by a goal-loop broadcast. Kept in sync with the
+    [dashboard_slice_for_sse_type] bridge entry in [Server_mcp_transport_ws]
+    that maps it onto the "goals" slice. *)
+
+val goal_loop_snapshot_event : Yojson.Safe.t -> Yojson.Safe.t
+(** [goal_loop_snapshot_event status] wraps [status] in the SSE envelope
+    ([type] / [payload] / [ts_unix]) that {!broadcast_goal_loop_status} emits.
+    Exposed for tests asserting the envelope shape. *)
+
+val broadcast_goal_loop_status : Yojson.Safe.t -> bool
+(** [broadcast_goal_loop_status status] broadcasts a
+    {!goal_loop_broadcast_event_type} event carrying [status] to dashboard
+    observers, but only when its meaningful content changed since the last
+    broadcast (per-write volatile fields are excluded from the fingerprint).
+    Returns [true] when an event was emitted, [false] when an unchanged status
+    was skipped. *)
+
+val start_goal_loop_refresh_loop :
+  state:Mcp_server.server_state ->
+  sw:Eio.Switch.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  unit
+(** [start_goal_loop_refresh_loop ~state ~sw ~clock] starts a periodic fiber
+    that reads the cached goal-loop status and calls
+    {!broadcast_goal_loop_status} on each tick (change-gated). *)

--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -395,6 +395,12 @@ let dashboard_slice_for_sse_type = function
       Some "transport"
   | "keeper_composite_changed" ->
       Some "composite"
+  (* RFC-0284: bridge the goal-loop status push into the existing "goals"
+     slice so its live delta reaches dashboard subscribers without adding a
+     new WS slice. Emitted by
+     [Server_dashboard_http_goal_loop_broadcast.broadcast_goal_loop_status]. *)
+  | "goal_loop_status" ->
+      Some "goals"
   | _ -> None
 
 let dashboard_session_result session =

--- a/lib/server/server_runtime_bootstrap.ml
+++ b/lib/server/server_runtime_bootstrap.ml
@@ -1132,6 +1132,11 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
       Server_dashboard_http.start_mission_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_snapshot_refresh_loop ~state ~sw ~clock;
       Server_dashboard_http.start_operator_digest_refresh_loop ~state ~sw ~clock;
+      (* RFC-0284: push goal-loop OODA status over SSE on change so the panel
+         stops polling. The worker is out-of-process (Python), so the trigger
+         is this server-side tick reading the cached status.json. *)
+      Server_dashboard_http_goal_loop_broadcast.start_goal_loop_refresh_loop
+        ~state ~sw ~clock;
       (* Pre-warm shell cache in a separate fiber so it cannot block
          lazy startup tasks or later keeper loop startup
          (#keeper-bootstrap-stuck). *)

--- a/test/dune
+++ b/test/dune
@@ -1182,6 +1182,14 @@
  (modules test_server_auth_warn_log_bound)
  (libraries alcotest masc masc_server eio_main))
 
+; RFC-0284: goal-loop status SSE broadcast is change-gated (new content emits
+; one event; unchanged / generated_at-only change emits none).
+
+(test
+ (name test_goal_loop_broadcast)
+ (modules test_goal_loop_broadcast)
+ (libraries alcotest masc masc_server eio_main))
+
 ; Focused dashboard nudge feed projection.
 
 (test

--- a/test/test_goal_loop_broadcast.ml
+++ b/test/test_goal_loop_broadcast.ml
@@ -1,0 +1,81 @@
+(** RFC-0284 §6 server verification: the goal-loop status broadcast is
+    change-gated.
+
+    A status whose meaningful content changed (loop_iteration / overall_status
+    / phases) broadcasts exactly one [goal_loop_status] event; an unchanged
+    status — or one differing only in the volatile [generated_at] — broadcasts
+    nothing. The gate is exercised through the public [broadcast_goal_loop_status]
+    (bool result + the per-session SSE stream), so the [generated_at]-exclusion
+    is asserted by behavior rather than by inspecting the fingerprint. *)
+
+module Sse = Masc.Sse
+module Broadcast = Server_dashboard_http_goal_loop_broadcast
+
+let status ~iter ~generated_at =
+  `Assoc
+    [ ("schema_version", `Int 1)
+    ; ("generated_at", `String generated_at)
+    ; ("loop_iteration", `String (string_of_int iter))
+    ; ("overall_status", `String "ok")
+    ; ("phases", `Assoc [ ("observe", `Assoc [ ("status", `String "ok") ]) ])
+    ]
+
+let event_type_of = function
+  | `Assoc fields -> (
+      match List.assoc_opt "type" fields with
+      | Some (`String s) -> Some s
+      | _ -> None)
+  | _ -> None
+
+let test_event_shape () =
+  let ev = Broadcast.goal_loop_snapshot_event (status ~iter:1 ~generated_at:"t1") in
+  Alcotest.(check (option string))
+    "event type is goal_loop_status" (Some "goal_loop_status") (event_type_of ev);
+  match ev with
+  | `Assoc fields ->
+      Alcotest.(check bool)
+        "event carries payload" true (List.mem_assoc "payload" fields)
+  | _ -> Alcotest.fail "event must be a JSON object"
+
+let drain session_id =
+  let rec loop n =
+    match Sse.try_pop session_id with Some _ -> loop (n + 1) | None -> n
+  in
+  loop 0
+
+let test_change_gated_broadcast () =
+  Eio_main.run @@ fun _env ->
+  let session_id = Printf.sprintf "goal_loop_test_%d" (Random.int 1_000_000) in
+  let _ = Sse.register ~kind:Sse.Observer session_id ~last_event_id:0 in
+  let (_ : int) = drain session_id in
+  let s1 = status ~iter:1 ~generated_at:"2026-06-23T00:00:00Z" in
+  Alcotest.(check bool)
+    "first status broadcasts" true (Broadcast.broadcast_goal_loop_status s1);
+  Alcotest.(check int) "first status emits one event" 1 (drain session_id);
+  (* identical content -> no rebroadcast *)
+  Alcotest.(check bool)
+    "unchanged status is skipped" false
+    (Broadcast.broadcast_goal_loop_status
+       (status ~iter:1 ~generated_at:"2026-06-23T00:00:00Z"));
+  Alcotest.(check int) "unchanged status emits nothing" 0 (drain session_id);
+  (* only generated_at differs -> still skipped (volatile key excluded) *)
+  Alcotest.(check bool)
+    "generated_at-only change is skipped" false
+    (Broadcast.broadcast_goal_loop_status
+       (status ~iter:1 ~generated_at:"2026-06-23T11:11:11Z"));
+  Alcotest.(check int)
+    "generated_at-only change emits nothing" 0 (drain session_id);
+  (* real OODA change (loop_iteration) -> broadcast *)
+  Alcotest.(check bool)
+    "changed status broadcasts" true
+    (Broadcast.broadcast_goal_loop_status
+       (status ~iter:2 ~generated_at:"2026-06-23T11:11:11Z"));
+  Alcotest.(check int) "changed status emits one event" 1 (drain session_id);
+  Sse.unregister session_id
+
+let () =
+  Alcotest.run "goal_loop_broadcast"
+    [ ("event", [ Alcotest.test_case "shape" `Quick test_event_shape ])
+    ; ( "change_gate"
+      , [ Alcotest.test_case "broadcast" `Quick test_change_gated_broadcast ] )
+    ]


### PR DESCRIPTION
## 목표

goal-loop OODA 상태는 대시보드에서 유일하게 HTTP pull(`goal-loop-panel.ts`의 mount-time `useEffect` fetch + 수동 새로고침)로만 갱신되던 surface였습니다. RFC-0284에 따라 이를 SSE push로 전환해, 운영자가 새로고침하지 않아도 OODA phase가 라이브로 갱신되도록 합니다.

근거 RFC: `docs/rfc/RFC-0284-goal-loop-sse-liveness.md` (이번 PR에서 §3.3 정정 포함).

## 핵심 설계

goal-loop 워커는 **out-of-process Python**(`scripts/goal_loop_scheduler.py` 외)이라 in-process `Sse.broadcast`를 호출할 수 없습니다. 따라서 broadcast 트리거를 서버 측 tick에 둡니다 — 캐시된 status를 읽어 **의미 있는 내용이 바뀌었을 때만**(per-write 변동 필드 `generated_at`/`dashboard_source` 제외 fingerprint) `goal_loop_status` 이벤트를 push.

이 이벤트는 새 WS slice를 만들지 않고 `dashboard_slice_for_sse_type`로 **기존 `goals` slice에 브리지**됩니다. FE는 `hydrateDashboardSlice`의 event-type switch(`case`, exact-match `=== 'X'` 라우트 아님)에서 처리하므로 **parity gate(PR #22124)는 영향 없음**.

### 변경

**Phase 1 — 서버**
- `server_dashboard_http_goal_loop_broadcast.ml`/`.mli` (신규): change-gated broadcast + `Proactive_refresh` tick. 변경 감지는 `namespace_truth` 패턴 미러(SHA256 hash + mutex). `.mli`는 public 표면을 테스트·bootstrap이 쓰는 4개 심볼로 좁히고 change-fingerprint state(last-hash + mutex)를 모듈 private로 캡슐화.
- `server_dashboard_http.ml`: `dashboard_goals_snapshot_json`에 `loop` 필드 추가(초기 WS snapshot/HTTP가 loop 운반).
- `server_mcp_transport_ws.ml`: `goal_loop_status -> "goals"` slice 브리지.
- `server_runtime_bootstrap.ml`: refresh loop 기동.

**Phase 2 — FE**
- `goal-loop-state.ts` (신규): `goalLoopStatusData` signal + `hydrateGoalLoopSnapshot`(`schema_version` 가드로 garbage delta가 정상 스냅샷을 덮어쓰는 것 방지). `goal-tree-state.ts` 미러.
- `sse-store.ts`: goals snapshot의 `loop` 하이드레이트 + `goal_loop_status` delta를 store로 직접 라우팅.
- `store.ts`: bootstrap `goal_loop_status` slice로 첫 로드 시 store seed.
- `goal-loop-panel.ts`: signal 구독으로 전환, mount fetch 제거(수동 새로고침 + store 비었을 때 first-paint fallback fetch만 유지). React 규칙(push, not effect-on-mount) 정렬.

**RFC 정정**: §3.1의 "새 event type 불필요" 전제가 transport 현실(`goals` slice는 live delta 브리지 항목이 없어 초기 burst에서만 도달)과 안 맞아, §3.3에 구현된 hybrid를 기록.

## 로컬 검증

> 최신 `origin/main`(`44b61ca8bc`)으로 rebase 후 재검증. 첫 CI에서 `Lint`(check-ssot R6)와 `OCaml Structure Ratchet`이 실패했으나 — R6는 **stale merge-base 유령**(옛 base `e1e9975065`로 merge-preview 시 다른 RFC-0284 파일이 baseline 9→10을 깸; 내 changeset은 R6-clean, origin/main 전체도 R6=9)이라 rebase로 해소, ratchet은 새 `.mli` 추가로 해소.

- OCaml `dune build @check` (sandbox off): PASS, 무에러.
- `check-ssot.sh` R6(home-masc-root): 9/9 PASS (rebase 후 merge-preview 상태).
- `ocaml-structure-ratchet.sh`: PASS (`lib_other_mli_missing` 0).
- `test_goal_loop_broadcast`(신규): change-gate 검증 — 신규 내용 1 emit / 변경 없음 0 / `generated_at`만 변경 0(volatile 제외 증명) / 실제 변경 1. PASS.
- determinism-contract 게이트: PASS.
- dashboard `tsc --noEmit`: 0 에러.
- dashboard `vitest run`: 7674 중 7673 pass. **유일 실패 `app.test.ts`의 `data-density`('spacious' vs 'regular')는 이 브랜치 base(머지된 main)에서 단독 실행해도 실패하는 pre-existing 이슈**로, 본 변경(goal-loop)과 무관하며 density를 일절 건드리지 않습니다.
- 영향 테스트: `goal-loop-panel.test.ts`/`sse-store.test.ts` 41 pass(신규 2 포함 — panel이 pushed snapshot을 fetch 없이 렌더 / sse-store가 loop 필드·`goal_loop_status` delta 라우팅).
- eslint(변경 파일): 0 errors.
- live 경로 확인: planning route(`workspace`/`planning`, GoalLoopPanel 포함)가 `goals` slice를 구독(`dashboardSlicesForRoute`)하므로 `goal_loop_status` delta가 패널에 도달.

## 남은 항목 / 미검증

- RFC-0284 §5 Phase 3의 reconnect 재하이드레이트는 기존 `hydrateAfterReconnect`의 dashboard refresh로 커버되나 전용 테스트는 추가하지 않음.
- 별건: main에 RFC 번호 `0284` **3중 충돌**(이 RFC + `RFC-0284-keeper-guidance-visibility-drift-guard.md` + `RFC-0284-fusion-judge-observation-record.md`). 번호 재할당이 필요하나 본 PR 범위 아님. keeper-guidance RFC가 check-ssot R6 위반 1줄(`~/me/.masc/...` trajectory 경로 인용)을 main에 들였으므로, 별도 SSOT PR로 그 한 줄을 `<base-path>/.masc/...`로 정정하는 것이 권장됨.

## Best Programmer self-review

- 워크어라운드 아님: change-gated snapshot-delta는 `namespace_truth`/`execution_surfaces`의 기존 패턴 미러(텔레메트리-as-fix/string 분류기/N-of-M 해당 없음).
- 타입: `hydrateGoalLoopSnapshot`은 `schema_version` 유무로 status 판별 후 normalize, garbage 입력은 거부(false 반환, 기존 값 보존).
- 경계: out-of-process worker ↔ in-process transport 경계를 status.json + 서버 tick으로 명시 분리(worker→broadcast 결합 회피).

RFC-0284

🤖 Generated with [Claude Code](https://claude.com/claude-code)
