### PR TITLE
fix(dashboard): 런타임 설정 가로폭 확장 + Chat FAB 아이콘 복원

### DIFF
--- a/dashboard/src/components/copilot-dock.ts
+++ b/dashboard/src/components/copilot-dock.ts
@@ -607,7 +607,7 @@ export function CopilotDockFab({ dock }: { dock: CopilotDockApi }) {
       aria-label="Open Chat Dock"
       title="Chat Dock 열기 (⌘J)"
     >
-      <span class="spark"><${MessageCircle} size=${20} strokeWidth=${2.4} aria-hidden="true" /></span>
+      <span class="spark"><${Sparkles} size=${17} aria-hidden="true" /></span>
       <span class="dock-fab-label">Chat</span>
     </button>
   `
@@ -623,7 +623,7 @@ export function CopilotDockTopBarButton({ dock }: { dock: CopilotDockApi }) {
       data-testid="copilot-dock-topbar-button"
       aria-label="Toggle Chat Dock"
     >
-      <${MessageCircle} class="spark" size=${14} strokeWidth=${2.2} aria-hidden="true" />
+      <${Sparkles} class="spark" size=${14} aria-hidden="true" />
       <span>Chat</span>
       <kbd>⌘J</kbd>
     </button>

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -232,8 +232,13 @@
   max-width: 760px;
 }
 
-.settings-surf .set-card-b-wide {
-  max-width: min(1180px, calc(100% - 56px));
+/* `.set-card-b.set-card-b-wide` (specificity 0,3,0) wins over the vendored
+   keeper-v2/surfaces.css `.settings-surf .set-card-b { max-width: 760px }` (0,2,0),
+   which loads last. With only `.set-card-b-wide` (also 0,2,0) the wide cap lost the
+   load-order tie, so the runtimes surface rendered at 760px (~43% of a 1780px
+   viewport). Widened to fit the two-pane runtime editor. */
+.settings-surf .set-card-b.set-card-b-wide {
+  max-width: min(1480px, calc(100% - 48px));
 }
 
 .settings-runtime-live {
@@ -266,7 +271,7 @@
 }
 
 @media (max-width: 900px) {
-  .settings-surf .set-card-b-wide {
+  .settings-surf .set-card-b.set-card-b-wide {
     max-width: 100%;
   }
   .settings-runtime-live-h {


### PR DESCRIPTION
## 무엇을

대시보드 v2 시각 QA에서 발견한 설정 화면 관련 2건 수정.

### 1. 런타임 설정 화면 가로폭 (`settings-surface.css`)
- 증상: `#settings?section=runtimes` 화면이 760px로 좁아 1780px 뷰포트의 ~43%만 사용, 우측 절반이 공백.
- 원인: CSS load-order split-brain. 런타임 카드는 `set-card-b-wide`(1180px 의도)를 달고 있으나, vendored `keeper-v2/surfaces.css`의 `.settings-surf .set-card-b { max-width: 760px }`가 **맨 뒤 로드** + 명시도 동률(0,2,0)이라 `.set-card-b-wide`를 덮어써 760px로 렌더됨. 즉 wide 클래스가 죽어 있었음.
- 수정: 규칙 셀렉터를 `.set-card-b.set-card-b-wide`(명시도 0,3,0)로 올려 로드 순서와 무관하게 이기게 하고, 2-pane 런타임 편집기에 맞춰 `min(1480px, calc(100% - 48px))`로 확장. 같은 패턴으로 `@media(max-width:900px)` 오버라이드도 함께 올림.

### 2. 우측하단 Chat FAB 아이콘 (`copilot-dock.ts`)
- 증상: Chat FAB(우측하단)에 아이콘이 없어 보임.
- 원인: FAB과 topbar 버튼이 `MessageCircle`을 size=20/14로 17px/14px `.spark` 컨테이너 안에 렌더 → 17×20으로 찌그러져 눈에 잘 안 띔. 또한 keeper-v2 프로토타입은 Chat 어피던스(FAB·topbar·패널 타이틀)를 **전부 sparkle ✦**로 쓰는데, 라이브는 패널 타이틀만 `Sparkles`이고 FAB/topbar는 `MessageCircle`로 갈라져 있었음(미기록 divergence).
- 수정: FAB/topbar를 `Sparkles`로 통일하고 컨테이너 크기(17 / 14)에 맞춰 왜곡 제거 + 프로토타입 일치. `MessageCircle`은 빈-도크 상태(copilot-dock.ts:541)에 여전히 쓰여 import 유효.

## 검증
- `tsc --noEmit` 통과(0), `eslint src/components/copilot-dock.ts` 통과(0)
- `copilot-dock.test.ts` 통과 (아이콘을 단언하는 테스트는 없음)
- 브라우저(5181 dev → 8935 backend): 런타임 카드 `clientWidth 760 → 1432`px, FAB svg = lucide `Sparkles` 17×17, `visibility:visible` 확인
- 참고: `app.test.ts`의 data-density(`'spacious'` vs 기대 `'regular'`) 실패는 **이 변경 이전부터 존재**(clean 브랜치 stash 재현으로 확인) — 본 PR과 무관.

## 스코프 밖 (발견 기록)
- `app.test.ts` data-density 기본값 desync: 앱은 `'spacious'`를 렌더하나 테스트는 `'regular'`를 기대. 본 PR과 무관한 사전 존재 실패 — 별도 처리 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
