### PR TITLE
feat(dashboard): RFC-0284 judge-node 관측 strip 렌더 (PR 2)

### DIFF
--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -11,7 +11,8 @@ import {
   refreshFusionBoard,
   refreshFusionRuns,
 } from '../../store'
-import { FusionSurface } from './fusion-surface'
+import type { FusionJudgeNode } from '../../lib/fusion-meta'
+import { FusionJudgesStrip, FusionSurface } from './fusion-surface'
 
 // Mock only the refresh side effects; keep the real signals (fusionBoardLoading /
 // fusionRunsLoading) via ...actual so the component reads live state. The manual
@@ -138,6 +139,47 @@ describe('FusionSurface', () => {
     expect(container.textContent).toContain('panel ×2')
     expect(container.textContent).toContain('board evidence')
     expect(container.textContent).not.toContain('chat · board')
+  })
+
+  it('renders the RFC-0284 judge-node strip for a judge-of-judges run', () => {
+    // Wiring pin: a board post carrying the `judges` observation array must
+    // surface the per-node topology in the detail view. Before RFC-0284 PR 2
+    // the backend emitted this array but the dashboard dropped it (collapsed to
+    // the singular judge) — this test red-guards that silent regression.
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-joj',
+        title: 'Fusion deliberation (run joj-1): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'joj-1',
+          question: 'Which judge topology?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'a' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'reconciled answer' },
+          judges: [
+            { role: 'first', identity: 'gpt-4o', input_tokens: 100, output_tokens: 10 },
+            { role: 'first', identity: 'gemini', status: 'failed', error: 'timeout', input_tokens: 5, output_tokens: 0 },
+            { role: 'meta', identity: 'o1', input_tokens: 2000, output_tokens: 418 },
+          ],
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const strip = container.querySelector('[data-testid="fusion-judges"]')
+    expect(strip).not.toBeNull()
+    expect(strip?.querySelectorAll('li')).toHaveLength(3)
+    // shape-derived header + role badges (topology is read from the array shape)
+    expect(container.textContent).toContain('심판의 심판')
+    expect(container.textContent).toContain('1차')
+    expect(container.textContent).toContain('메타')
+    // a failed first-judge node is marked, not dropped
+    expect(
+      container.querySelector('[data-testid="fusion-judges"] [data-failed="true"]'),
+    ).not.toBeNull()
+    // the canonical synthesis below the strip is unchanged
+    expect(container.textContent).toContain('reconciled answer')
   })
 
   it('renders structured judge evidence from board metadata without local prototype state', () => {
@@ -362,5 +404,55 @@ describe('FusionSurface', () => {
     expect(cards[0]?.classList.contains('answered')).toBe(true)
     expect(cards[0]?.classList.contains('failed')).toBe(false)
     expect(cards[1]?.classList.contains('failed')).toBe(true)
+  })
+})
+
+describe('FusionJudgesStrip', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  // meta/single/refine echo their role as identity (fusion_sink judge_role_fields);
+  // only `first` carries a real panelist id.
+  const nodes: FusionJudgeNode[] = [
+    { role: 'first', identity: 'gpt-4o', failed: false, inputTokens: 100, outputTokens: 10 },
+    { role: 'first', identity: 'gemini', failed: true, error: 'timeout', inputTokens: 5, outputTokens: 0 },
+    { role: 'meta', identity: 'meta', failed: false, inputTokens: 2000, outputTokens: 418 },
+  ]
+
+  it('renders one row per node with role/failed data attributes and the token label', () => {
+    render(html`<${FusionJudgesStrip} nodes=${nodes} />`, container)
+    const items = container.querySelectorAll('[data-testid="fusion-judges"] li')
+    expect(items).toHaveLength(3)
+    expect(items[0]?.getAttribute('data-role')).toBe('first')
+    expect(items[0]?.getAttribute('data-failed')).toBe('false')
+    expect(items[1]?.getAttribute('data-failed')).toBe('true')
+    expect(items[2]?.getAttribute('data-role')).toBe('meta')
+    // 2000 + 418 = 2418 -> 2.4k tok
+    expect(container.textContent).toContain('2.4k tok')
+    const failed = container.querySelector('[data-failed="true"] .fus-jn-status')
+    expect(failed?.getAttribute('title')).toBe('timeout')
+    expect(failed?.textContent).toContain('실패')
+  })
+
+  it('shows a panelist id for first nodes but suppresses the role-echo identity of a meta node', () => {
+    render(html`<${FusionJudgesStrip} nodes=${nodes} />`, container)
+    const items = container.querySelectorAll('[data-testid="fusion-judges"] li')
+    expect(items[0]?.querySelector('.fus-jn-id')?.textContent?.trim()).toBe('gpt-4o')
+    // meta identity === role ('meta') is redundant with the badge, so it is blank
+    expect(items[2]?.querySelector('.fus-jn-id')?.textContent?.trim()).toBe('')
+  })
+
+  it('renders nothing for a board post that predates the judges array', () => {
+    render(html`<${FusionJudgesStrip} nodes=${[]} />`, container)
+    expect(container.querySelector('[data-testid="fusion-judges"]')).toBeNull()
   })
 })

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -21,7 +21,11 @@ import {
   firstNumber,
   normalizeFusionPanel,
   normalizeFusionUsage,
+  normalizeFusionJudgeNodes,
+  classifyFusionJudgeShape,
   type FusionPanelEntry,
+  type FusionJudgeNode,
+  type FusionJudgeShape,
 } from '../../lib/fusion-meta'
 
 type FusionRunStatus = 'complete' | 'failed' | 'running'
@@ -95,6 +99,7 @@ interface FusionRunView {
   tone: FusionTone
   panel: FusionPanelEntry[]
   judge: FusionJudge
+  judges: FusionJudgeNode[]
   usage: FusionUsage
   createdAt: string
   updatedAt: string
@@ -292,6 +297,7 @@ function fusionRunFromPost(post: BoardPost): FusionRunView | null {
 
   const panel = normalizeFusionPanel(meta.panel)
   const judge = normalizeJudge(meta.judge)
+  const judges = normalizeFusionJudgeNodes(meta.judges)
   const usage = normalizeUsage(meta, panel)
   const runId = firstString(meta, ['run_id', 'runId', 'id']) ?? post.id
   const question = firstString(meta, ['question', 'prompt']) ?? post.body ?? post.content ?? post.title
@@ -308,6 +314,7 @@ function fusionRunFromPost(post: BoardPost): FusionRunView | null {
     tone,
     panel,
     judge,
+    judges,
     usage,
     createdAt: post.created_at,
     updatedAt: post.updated_at || post.created_at,
@@ -410,6 +417,87 @@ function FusionKeeperLink({ keeper, size = 'sm' }: { keeper: string; size?: 'sm'
       <${AgentAvatar} name=${keeper} size=${size} />
       <span class="nm">${keeper}</span>
     </button>
+  `
+}
+
+// Display label for a shape classification (i18n lives in the component layer;
+// `classifyFusionJudgeShape` stays language-free in lib/fusion-meta).
+const JUDGE_SHAPE_LABEL: Record<FusionJudgeShape, string> = {
+  single: '단일 심판',
+  refine: '재검토',
+  'judge-of-judges': '심판의 심판',
+  custom: '심판 위상',
+}
+
+// Korean badge for a backend judge role. Unknown roles fall through to the raw
+// string so a new backend role still renders (the enum is closed on the backend,
+// so this is defensive rather than expected).
+function judgeRoleLabel(role: string): string {
+  switch (role) {
+    case 'first':
+      return '1차'
+    case 'meta':
+      return '메타'
+    case 'refine':
+      return '재검토'
+    case 'single':
+      return '단일'
+    default:
+      return role
+  }
+}
+
+// Per-node combined token figure (`Nk tok` / `N tok`), em-dash when no usage.
+function judgeNodeTokenLabel(node: FusionJudgeNode): string {
+  const total = (node.inputTokens ?? 0) + (node.outputTokens ?? 0)
+  if (total <= 0) return '—'
+  return total >= 1000 ? `${(total / 1000).toFixed(1)}k tok` : `${total} tok`
+}
+
+// A meaningful node identity, or null. The backend only carries a real model id
+// for `first` nodes (the panelist_id); single/refine/meta echo their role string
+// as the identity (fusion_sink.ml judge_role_fields), which is redundant with the
+// role badge, so suppress it rather than print the role twice.
+function judgeNodeIdentity(node: FusionJudgeNode): string | null {
+  return node.identity && node.identity !== node.role ? node.identity : null
+}
+
+// RFC-0284 PR 2: render the observed judge nodes as a structural strip so the
+// execution topology (JoJ = N 1차 + 메타, refine = 2, simple = 1) is visible
+// instead of collapsing into the single canonical judge. Topology is read from
+// the array shape alone; the canonical synthesis below is unchanged. Renders
+// nothing for older board posts that predate the `judges` array.
+export function FusionJudgesStrip({ nodes }: { nodes: readonly FusionJudgeNode[] }) {
+  if (nodes.length === 0) return null
+  const shape = classifyFusionJudgeShape(nodes)
+  return html`
+    <div class="fus-block">
+      <div class="fus-block-lbl">
+        심판 위상 · ${JUDGE_SHAPE_LABEL[shape]}
+        <span class="fus-sub-note">관측된 심판 노드 ${nodes.length}개 · RFC-0284</span>
+      </div>
+      <ul class="fus-judges" data-testid="fusion-judges" role="list">
+        ${nodes.map(
+          (node, index) => html`
+            <li
+              class=${`fus-judge-node ${node.failed ? 'failed' : 'ok'}`}
+              key=${`${node.role}-${node.identity}-${index}`}
+              data-role=${node.role}
+              data-failed=${node.failed ? 'true' : 'false'}
+            >
+              <span class="fus-jn-role">${judgeRoleLabel(node.role)}</span>
+              <span class="fus-jn-id mono" title=${judgeNodeIdentity(node) ?? ''}>
+                ${judgeNodeIdentity(node) ?? ''}
+              </span>
+              <span class="fus-jn-tok">${judgeNodeTokenLabel(node)}</span>
+              ${node.failed
+                ? html`<span class="fus-jn-status deny" title=${node.error ?? 'failed'}>✗ 실패</span>`
+                : html`<span class="fus-jn-status done">✓</span>`}
+            </li>
+          `,
+        )}
+      </ul>
+    </div>
   `
 }
 
@@ -700,6 +788,8 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
           ? html`<div class="fus-judge-wait">패널 응답이 기록되지 않았습니다.</div>`
           : html`<div class="fus-panel-grid">${run.panel.map(entry => html`<${FusionPanelCard} key=${entry.model} entry=${entry} />`)}</div>`}
       </div>
+
+      <${FusionJudgesStrip} nodes=${run.judges} />
 
       ${run.status === 'running'
         ? html`

--- a/dashboard/src/lib/fusion-meta.test.ts
+++ b/dashboard/src/lib/fusion-meta.test.ts
@@ -1,10 +1,12 @@
 // @ts-nocheck
 import { describe, expect, it } from 'vitest'
 import {
+  classifyFusionJudgeShape,
   extractFusionEvidence,
   firstNumber,
   firstString,
   normalizeFusionJudge,
+  normalizeFusionJudgeNodes,
   normalizeFusionPanel,
   normalizeFusionPanelReason,
   normalizeFusionUsage,
@@ -207,5 +209,66 @@ describe('extractFusionEvidence', () => {
     })
     expect(evidence).not.toBeNull()
     expect(evidence?.source).toBe('fusion')
+  })
+})
+
+describe('normalizeFusionJudgeNodes', () => {
+  it('returns [] for a non-array', () => {
+    expect(normalizeFusionJudgeNodes(undefined)).toEqual([])
+    expect(normalizeFusionJudgeNodes({})).toEqual([])
+    expect(normalizeFusionJudgeNodes(null)).toEqual([])
+  })
+
+  it('parses Synthesized and Judge_failed nodes (status:"failed" marks failure)', () => {
+    const nodes = normalizeFusionJudgeNodes([
+      { role: 'first', identity: 'gpt-4o', input_tokens: 100, output_tokens: 10 },
+      { role: 'first', identity: 'gemini', status: 'failed', error: 'timeout', input_tokens: 5, output_tokens: 0 },
+      { role: 'meta', identity: 'o1', input_tokens: 2000, output_tokens: 418 },
+    ])
+    expect(nodes).toEqual([
+      { role: 'first', identity: 'gpt-4o', failed: false, error: undefined, inputTokens: 100, outputTokens: 10 },
+      { role: 'first', identity: 'gemini', failed: true, error: 'timeout', inputTokens: 5, outputTokens: 0 },
+      { role: 'meta', identity: 'o1', failed: false, error: undefined, inputTokens: 2000, outputTokens: 418 },
+    ])
+  })
+
+  it('drops non-record elements and defaults a missing role/identity', () => {
+    const nodes = normalizeFusionJudgeNodes([null, 'x', { input_tokens: 1 }])
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].role).toBe('judge')
+    expect(nodes[0].identity).toBe('judge-3')
+  })
+})
+
+describe('classifyFusionJudgeShape', () => {
+  // role values match fusion_sink.ml judge_role_fields: single | refine | first | meta.
+  const node = role => ({ role, identity: 'm', failed: false })
+
+  it('a lone single node -> single', () => {
+    expect(classifyFusionJudgeShape([node('single')])).toBe('single')
+  })
+
+  it('Single + Refine_pass (refine/conditional 2nd judge) -> refine', () => {
+    expect(classifyFusionJudgeShape([node('single'), node('refine')])).toBe('refine')
+  })
+
+  it('N first-judges + a meta -> judge-of-judges', () => {
+    expect(classifyFusionJudgeShape([node('first'), node('first'), node('meta')])).toBe(
+      'judge-of-judges',
+    )
+  })
+
+  it('all-fail JoJ (first-judges, no meta) -> judge-of-judges, not refine', () => {
+    // `first` is JoJ-exclusive on the backend, so two first-judges with no meta
+    // (every first judge failed → meta never ran) must not be read as refine.
+    expect(classifyFusionJudgeShape([node('first'), node('first')])).toBe('judge-of-judges')
+    expect(classifyFusionJudgeShape([node('first'), node('first'), node('first')])).toBe(
+      'judge-of-judges',
+    )
+  })
+
+  it('an unanticipated shape -> custom (still renders structurally)', () => {
+    expect(classifyFusionJudgeShape([])).toBe('custom')
+    expect(classifyFusionJudgeShape([node('single'), node('single')])).toBe('custom')
   })
 })

--- a/dashboard/src/lib/fusion-meta.ts
+++ b/dashboard/src/lib/fusion-meta.ts
@@ -156,6 +156,80 @@ export function normalizeFusionJudge(value: unknown): FusionJudgeView | null {
   }
 }
 
+// ---------------------------------------------------------------------------
+// RFC-0284 judge-node observation array (`judges`)
+// ---------------------------------------------------------------------------
+
+// One judge execution node from `fusion_sink.ml judge_node_meta`. `role` is the
+// closed backend enum (single | refine | first | meta) but kept as a string so
+// an unanticipated role degrades to a raw badge instead of being dropped. Only
+// structural fields are retained — the dashboard renders topology from the
+// shape of the array, and the per-node synthesis text is carried by the
+// canonical singular `judge`.
+export type FusionJudgeNode = {
+  role: string
+  identity: string
+  failed: boolean
+  error?: string | null
+  inputTokens?: number | null
+  outputTokens?: number | null
+}
+
+// Structural classification of a judges array, derived from shape alone (the
+// array carries no topology field). Language-free so the lib stays i18n-neutral;
+// the component maps it to a display label.
+export type FusionJudgeShape = 'single' | 'refine' | 'judge-of-judges' | 'custom'
+
+/**
+ * Normalize the RFC-0284 `judges` observation array. Each element is a
+ * Synthesized node (role/identity + synthesis sections + per-node usage) or a
+ * Judge_failed node (role/identity + status:"failed" + error + usage); only the
+ * Judge_failed node carries `status`, so absence of `status === 'failed'` marks
+ * a successful node. Non-record elements are dropped (total over loose wire
+ * data); missing role/identity get safe defaults rather than being discarded.
+ */
+export function normalizeFusionJudgeNodes(value: unknown): FusionJudgeNode[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item, index) => {
+    const node = asRecord(item)
+    if (!node) return []
+    const failed = firstString(node, ['status']) === 'failed'
+    return [
+      {
+        role: firstString(node, ['role']) ?? 'judge',
+        identity: firstString(node, ['identity', 'model', 'name']) ?? `judge-${index + 1}`,
+        failed,
+        error: failed ? firstString(node, ['error', 'reason', 'error_text']) ?? undefined : undefined,
+        inputTokens: firstNumber(node, ['input_tokens', 'inputTokens']) ?? undefined,
+        outputTokens: firstNumber(node, ['output_tokens', 'outputTokens']) ?? undefined,
+      },
+    ]
+  })
+}
+
+/**
+ * Classify a judges array by its shape, never by a topology field (RFC-0284
+ * §line 27: the frontend must not hardcode topology-name vocabulary). The
+ * classification reads the per-node `role` — an observed fact carried in each
+ * array element, not a topology label — which is exactly the array shape and is
+ * more robust than a raw node count:
+ *  - any `first` node ⟹ judge-of-judges. `First` is JoJ-exclusive on the
+ *    backend (`fusion_orchestrator.ml run_judge_of_judges`), so this also
+ *    classifies an all-fail JoJ correctly, where the meta node is absent and a
+ *    bare count of two first-judges would otherwise read as refine.
+ *  - any `refine` node ⟹ refine (the `Refine_pass` 2nd judge of refine /
+ *    conditional).
+ *  - a single node ⟹ single (Simple, or a refine/conditional whose 1st judge
+ *    failed before the 2nd ran).
+ *  - anything else ⟹ custom, so an unanticipated topology still renders.
+ */
+export function classifyFusionJudgeShape(nodes: readonly FusionJudgeNode[]): FusionJudgeShape {
+  if (nodes.some(node => node.role === 'first')) return 'judge-of-judges'
+  if (nodes.some(node => node.role === 'refine')) return 'refine'
+  if (nodes.length === 1) return 'single'
+  return 'custom'
+}
+
 export function normalizeFusionUsage(
   meta: Record<string, unknown>,
   panel?: FusionPanelEntry[],

--- a/dashboard/src/styles/keeper-v2/fusion.css
+++ b/dashboard/src/styles/keeper-v2/fusion.css
@@ -165,6 +165,18 @@
 
 .fus-judge-wait { display: flex; align-items: center; gap: 9px; font-size: 12px; color: var(--text-dim); padding: 14px 16px; background: var(--bg-panel); border: 1px dashed var(--border-main); border-radius: var(--radius-md); }
 
+/* ── RFC-0284 PR 2: observed judge-node strip (1차/메타 토폴로지 가시화) ── */
+.fus-judges { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.fus-judge-node { display: flex; align-items: center; gap: 10px; padding: 7px 11px; background: var(--bg-card); border: 1px solid var(--border-main); border-radius: var(--radius-sm); font-size: 11.5px; }
+.fus-judge-node.failed { border-color: color-mix(in oklab, var(--status-bad) 45%, transparent); background: color-mix(in oklab, var(--status-bad) 7%, transparent); }
+.fus-jn-role { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em; padding: 2px 7px; border-radius: var(--radius-sm); border: 1px solid var(--volt-dim); color: var(--volt-strong); white-space: nowrap; }
+.fus-judge-node.failed .fus-jn-role { border-color: color-mix(in oklab, var(--status-bad) 40%, transparent); color: var(--status-bad); }
+.fus-jn-id { color: var(--text-mid); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1 1 auto; min-width: 0; }
+.fus-jn-tok { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; }
+.fus-jn-status { font-size: 11px; white-space: nowrap; }
+.fus-jn-status.done { color: var(--status-ok); }
+.fus-jn-status.deny { color: var(--status-bad); }
+
 /* ── resolved + decision ── */
 .fus-resolved { border: 1px solid var(--border-main); border-radius: var(--radius-md); padding: 16px 18px; margin-bottom: 20px; background: var(--bg-panel); }
 .fus-resolved.dec-ok   { border-color: color-mix(in oklab, var(--status-ok) 32%, var(--border-main)); background: linear-gradient(120deg, color-mix(in oklab, var(--status-ok) 6%, var(--bg-panel)), var(--bg-panel) 55%); }


### PR DESCRIPTION
## 배경 — RFC-0284 PR 2 (deferred frontend)

RFC-0284(`docs/rfc/RFC-0284-fusion-judge-observation-record.md`)는 fusion topology의 실행 구조가 대시보드에 표시되어야 한다고 요구합니다(§line 16, Vincent). backend(PR 1)는 board meta_json에 per-judge-node 관측 배열 `judges`(Synthesized/Judge_failed 노드, role/identity + 노드별 usage)를 emit하지만(`lib/fusion/fusion_sink.ml:328 judge_node_meta`), **프론트 어느 consumer도 이 배열을 읽지 않았습니다** — 전부 단수 canonical `judge`로 collapse → JOJ/refine 위상이 **emit은 되나 표시 안 됨**. RFC는 이 프론트 변경을 §line 79에서 "PR 2"로 명시 deferred 했습니다. 이 PR이 그 PR 2입니다.

진단 근거: `rg 'judges|first_nodes|Synthesized|Judge_failed' dashboard/src` = 0건(main 기준).

## 변경

- **`dashboard/src/lib/fusion-meta.ts`**
  - `normalizeFusionJudgeNodes` — `judges` 배열 정규화(loose wire data에 total, junk drop, role/identity 기본값).
  - `classifyFusionJudgeShape` — 위상을 **배열 shape(노드별 `role`)만으로** 도출(topology 필드 미참조, RFC §line 27 "vocabulary 하드코딩 금지"). `first`는 백엔드에서 JOJ 배타적이므로 `first` 노드 존재 ⟹ judge-of-judges → **all-fail JOJ(meta 부재)도 정확 분류**(단순 노드 카운트는 2-first를 refine으로 오판). language-free enum 반환, i18n은 component.
- **`dashboard/src/components/fusion/fusion-surface.ts`**
  - `FusionJudgesStrip` — 노드당 1행: role 배지(1차/메타/…), panelist id(single/refine/meta는 role 에코라 생략), 노드별 토큰 합계, ok/실패 상태(실패는 error를 hover title). 패널 그리드와 canonical 종합 사이에 배치, **canonical 종합은 불변**. 구 board post(배열 부재)는 렌더 안 함.
- **`dashboard/src/styles/keeper-v2/fusion.css`** — strip 스타일, 기존 디자인 토큰 재사용(신규 selector만, vendored 레이어 override 없음 → CSS split-brain 회피).

표시 깊이는 "구조 strip"(노드 토폴로지 가시화, 노드별 종합 5섹션은 canonical judge가 보유)으로 선택됨.

## 검증

- vitest 45 pass(lib normalize/classify + component unit + E2E 1개)
- `tsc --noEmit` clean
- `eslint src` clean

E2E 핀: board post에 `judges`를 넣으면 detail에 per-node strip이 뜨는지 단언 → "emit됐지만 표시 안 됨" silent regression을 red-guard.

## 미검증

- 시각 레이아웃(vitest는 data/attribute만 단언, computed CSS는 못 봄 — 알려진 한계). 신규 strip은 인접 토큰 스타일을 재사용했으나 브라우저 육안 검증은 미수행.

## RFC

RFC-0284-fusion-judge-observation-record §line 16/27/79.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
