### PR TITLE
test(dashboard): pin goal-loop reconnect re-hydration (RFC-0284 §6)

### DIFF
--- a/dashboard/src/goal-loop-reconnect-rehydration.test.ts
+++ b/dashboard/src/goal-loop-reconnect-rehydration.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+// RFC-0284 §6 — goal-loop reconnect re-hydration.
+//
+// After an SSE reconnect the goal-loop panel must recover via the existing
+// dashboard refresh, NOT a dedicated goal-loop fetch. The load-bearing chain is:
+//
+//   handleReconnect (sse-store.ts)
+//     -> hydrateAfterReconnect          -- calls refreshDashboard({ force: true })
+//       -> refreshDashboard (store.ts)  -- fetches bootstrap
+//         -> hydrateDashboardBootstrap  -- hydrates the goal_loop_status slice
+//           -> hydrateGoalLoopSnapshot  -- updates goalLoopStatusData
+//
+// No single behavioural unit test spans this chain: hydrateDashboardBootstrap is
+// a module-internal function that throws unless given a full shell + execution
+// payload (it hydrates those via same-module functions that cannot be mocked),
+// so exercising it would require mocking the entire bootstrap rather than the
+// goal-loop slice under test. Instead this guard pins the two links that, if
+// removed, silently leave the goal-loop panel stale after a reconnect while
+// every other test stays green. Removing either turns this red.
+
+function functionBody(source: string, name: string): string {
+  const decl = new RegExp(`(?:async\\s+)?function\\s+${name}\\b`).exec(source)
+  if (!decl) throw new Error(`function ${name} not found`)
+  const braceStart = source.indexOf('{', decl.index)
+  if (braceStart < 0) throw new Error(`no body for ${name}`)
+  let depth = 0
+  for (let i = braceStart; i < source.length; i++) {
+    if (source[i] === '{') depth++
+    else if (source[i] === '}') {
+      depth--
+      if (depth === 0) return source.slice(braceStart, i + 1)
+    }
+  }
+  throw new Error(`unbalanced braces in ${name}`)
+}
+
+const sseStore = readFileSync(resolve(process.cwd(), 'src/sse-store.ts'), 'utf8')
+const store = readFileSync(resolve(process.cwd(), 'src/store.ts'), 'utf8')
+
+describe('goal-loop reconnect re-hydration chain (RFC-0284 §6)', () => {
+  it('hydrateAfterReconnect forces a dashboard refresh', () => {
+    const body = functionBody(sseStore, 'hydrateAfterReconnect')
+    expect(body).toMatch(/refreshDashboard\(\s*\{\s*force:\s*true\s*\}\s*\)/)
+  })
+
+  it('hydrateDashboardBootstrap hydrates the goal_loop_status slice', () => {
+    const body = functionBody(store, 'hydrateDashboardBootstrap')
+    expect(body).toContain('data.goal_loop_status')
+    expect(body).toContain('hydrateGoalLoopSnapshot')
+  })
+})


### PR DESCRIPTION
## 목표

RFC-0284 §6은 "goal-loop 패널이 SSE reconnect 후 기존 dashboard refresh로 복구된다"고 기술하지만, 그 체인을 핀하는 테스트가 없었습니다. RFC-0284 §5 Phase 3의 reconnect-rehydration 항목을 닫습니다.

## 체인

```
handleReconnect (sse-store.ts)
  → hydrateAfterReconnect          — refreshDashboard({ force: true }) 호출
    → refreshDashboard (store.ts)  — bootstrap fetch
      → hydrateDashboardBootstrap  — goal_loop_status slice hydrate
        → hydrateGoalLoopSnapshot  — goalLoopStatusData 갱신
```

## 접근

동작 테스트로 이 체인을 싸게 검증할 수 없습니다 — `hydrateDashboardBootstrap`은 full shell+execution payload 없이는 throw하고(같은 모듈 내부 함수로 hydrate되어 mock 불가), goal-loop slice만 검증하려 해도 bootstrap 전체를 mock해야 합니다. 그래서 **구조적 drift-guard**로 두 load-bearing 링크를 핀합니다(RFC-0284가 확립한 패턴):

1. `hydrateAfterReconnect`가 `refreshDashboard({ force: true })`를 호출
2. `hydrateDashboardBootstrap`이 `data.goal_loop_status`를 `hydrateGoalLoopSnapshot`으로 hydrate

함수 본문을 brace-matching으로 추출해 단언하므로, 둘 중 하나라도 제거하면 red가 됩니다(다른 모든 테스트는 green인 채로 reconnect 시 패널이 stale해지는 회귀를 잡음). 동작 테스트가 아닌 이유는 테스트 주석에 명시했습니다.

## 로컬 검증

- `vitest run goal-loop-reconnect-rehydration.test.ts`: 2 pass.
- `tsc --noEmit`: 0 errors. `eslint`(변경 파일): 0 errors.

RFC-0284

🤖 Generated with [Claude Code](https://claude.com/claude-code)
