### PR TITLE
fix(keeper): emit typed Error on rejected keeper_task_done (RFC-0239, audit D1)

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -25,17 +25,30 @@ let keeper_task_result_json ?(typed_outcome = (None : Keeper_tool_outcome.t opti
 let workflow_rejection_error_json
       ?(rule_id = "keeper_task_argument_rejected")
       ?(alternatives = [])
+      ?(typed_outcome : Keeper_tool_outcome.t option)
       message
   =
   (* RFC-0195 P0: [alternatives] is a typed list of tool names the
      LLM can call instead.  Empty list omits the field; non-empty
      surfaces it directly in the JSON payload so the LLM does not
      have to parse prose [hint] strings to discover next-tool
-     candidates. *)
+     candidates.
+
+     RFC-0239 / audit D1: [typed_outcome] carries a top-level
+     [typed_outcome] field (extracted by the PostToolUse hook into
+     [tool_call_detail.typed_outcome]) so a rejected completion is seen
+     as no-progress by the loop detector rather than counted as
+     evidence by tool name alone. *)
+  let extra_fields =
+    match typed_outcome with
+    | Some outcome -> [ "typed_outcome", Keeper_tool_outcome.to_json outcome ]
+    | None -> []
+  in
   Task.Payloads.workflow_rejection_payload_json
     ~rule_id
     ~scope_policy:"observe"
     ~alternatives
+    ~extra_fields
     message
 ;;
 
@@ -784,6 +797,9 @@ let handle_keeper_task_tool
     then
       workflow_rejection_error_json
         ~alternatives:[ "keeper_task_claim"; "keeper_tasks_list" ]
+        ~typed_outcome:
+          (Keeper_tool_outcome.Error
+             { reason = "keeper_task_done rejected: task_id required" })
         "task_id is required. Use the task_id you got from keeper_task_claim."
     else if result_text = ""
     then
@@ -799,6 +815,9 @@ let handle_keeper_task_tool
          error names the field the keeper actually sent. *)
       workflow_rejection_error_json
         ~alternatives:[ "keeper_task_done" ]
+        ~typed_outcome:
+          (Keeper_tool_outcome.Error
+             { reason = "keeper_task_done rejected: result required" })
         "result is required. Audit trail: describe what you completed. \
          Example: result='Refactored module X, all tests green, no flake'."
     else (
@@ -830,7 +849,14 @@ let handle_keeper_task_tool
         ~typed_outcome:
           (if Tool_result.is_success transition_result
            then Some Keeper_tool_outcome.Progress
-           else None)
+           else
+             (* RFC-0239 / audit D1: a rejected completion (wrong owner, stale
+                or invalid transition) is not progress. Emit a typed Error so the
+                no-progress detector demotes it instead of counting the tool name
+                as evidence. *)
+             Some
+               (Keeper_tool_outcome.Error
+                  { reason = Tool_result.message transition_result }))
         ~failure_class:(Tool_result.failure_class transition_result)
         ~ok:(Tool_result.is_success transition_result)
         ~message:(Tool_result.message transition_result)

--- a/test/test_keeper_validation_breaker_exempt.ml
+++ b/test/test_keeper_validation_breaker_exempt.ml
@@ -17,6 +17,9 @@ module U = Yojson.Safe.Util
 (* Tool_result lives in the leaf [masc_tool_types] lib (wrapped false), so
    it is referenced bare — not under [Masc.] — matching existing tests. *)
 module TR = Tool_result
+(* Keeper_tool_outcome lives in the [keeper_metrics] lib (wrapped false), so it
+   is referenced bare — not under [Masc.] — matching the bare [Tool_result]. *)
+module Outcome = Keeper_tool_outcome
 
 let temp_dir () =
   let dir = Filename.temp_file "test_keeper_task_create_" "" in
@@ -146,6 +149,67 @@ let test_keeper_report_state_returns_state_block () =
        check bool "state report returns typed outcome" true
          (json |> U.member "typed_outcome" <> `Null))
 
+(* RFC-0239 / audit D1: a rejected keeper_task_done must carry a typed
+   [Error] outcome so the no-progress loop detector demotes it (PR #22127
+   wired the detector to read typed_outcome; this proves the producer emits
+   it on rejection instead of leaving it [None] and being counted as
+   evidence by tool name alone). *)
+let rejected_done_typed_outcome ~base_path:_ config meta args =
+  let payload =
+    Task.handle_keeper_task_tool ~config ~meta ~name:"keeper_task_done" ~args
+  in
+  let json = Yojson.Safe.from_string payload in
+  check bool "rejected done is not ok" false (json |> U.member "ok" |> U.to_bool);
+  Outcome.of_json (json |> U.member "typed_outcome")
+
+let test_done_missing_task_id_emits_typed_error () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let meta = meta_with_active_goals [] in
+       (* task_id omitted -> early workflow_rejection path. *)
+       match
+         rejected_done_typed_outcome ~base_path config meta
+           (`Assoc [ "result", `String "done" ])
+       with
+       | Some (Outcome.Error _) -> ()
+       | other ->
+         failf "expected typed_outcome = Error, got %s"
+           (match other with
+            | None -> "None"
+            | Some Outcome.Progress -> "Progress"
+            | Some (Outcome.No_progress _) -> "No_progress"
+            | Some (Outcome.Error _) -> "Error"))
+
+let test_done_failed_transition_emits_typed_error () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let meta = meta_with_active_goals [] in
+       (* A done on a task that does not exist fails the transition -> the
+          [else] branch must emit a typed [Error], not [None]. *)
+       match
+         rejected_done_typed_outcome ~base_path config meta
+           (`Assoc
+             [ "task_id", `String "task-does-not-exist"
+             ; "result", `String "completed"
+             ])
+       with
+       | Some (Outcome.Error _) -> ()
+       | other ->
+         failf "expected typed_outcome = Error, got %s"
+           (match other with
+            | None -> "None"
+            | Some Outcome.Progress -> "Progress"
+            | Some (Outcome.No_progress _) -> "No_progress"
+            | Some (Outcome.Error _) -> "Error"))
+
 let () =
   run "keeper validation breaker exemption"
     [ ( "validation_failure_class"
@@ -161,5 +225,9 @@ let () =
             test_task_create_multi_active_goals_without_goal_id_is_unscoped
         ; test_case "keeper_report_state returns state block" `Quick
             test_keeper_report_state_returns_state_block
+        ; test_case "rejected done (missing task_id) emits typed Error (D1)"
+            `Quick test_done_missing_task_id_emits_typed_error
+        ; test_case "rejected done (failed transition) emits typed Error (D1)"
+            `Quick test_done_failed_transition_emits_typed_error
         ] )
     ]


### PR DESCRIPTION
## 목적

PR #22127(RFC-0239)이 no-progress detector를 typed outcome-aware로 만들었으나, **producer-측 잔여 갭(audit D1)**이 남아 있었습니다: 거부된 `keeper_task_done`이 `typed_outcome=None`을 emit해서, completion tool 이름(`Task_done`)만으로 substantive evidence로 집계되고 streak가 누적되지 않았습니다. #22127 적대 리뷰가 정확히 이 갭을 "producer-측 follow-up"으로 지목했습니다.

근거: `keeper_tool_task_runtime.ml`의 done 핸들러 — 성공 시 `Some Progress`, 실패 시 `None`(`else None`), 빈 task_id/result rejection은 `workflow_rejection_error_json` 경유로 typed_outcome 미탑재.

## 변경 (producer가 거부 시 typed Error emit)

`keeper_task_done`의 3개 거부 경로가 typed `Error` outcome을 emit하도록:
- **transition 실패** (`else None` → `Some (Error { reason })`): wrong owner / stale / invalid transition.
- **빈 task_id**, **빈 result**: `workflow_rejection_error_json`에 optional `~typed_outcome` 추가, top-level `typed_outcome` 필드를 payload에 실음.

inbound 경로는 이미 존재: PostToolUse 훅(`keeper_hooks_oas.ml:533`)이 tool output JSON의 top-level `typed_outcome`를 `Keeper_tool_outcome.of_json`으로 추출 → `tool_call_detail.typed_outcome` → #22127 detector가 `Error`/`No_progress`를 demote.

## 검증

- `test_keeper_validation_breaker_exempt`에 2 케이스 추가, 로컬 green:
  - 빈 task_id done → `typed_outcome = Error` (workflow_rejection 경로)
  - 실패 transition(없는 task) done → `typed_outcome = Error` (else 경로)
- producer가 실제 emit하는 payload를 `handle_keeper_task_tool` end-to-end로 검증(hand-built literal 아님).
- 빌드는 CI. (로컬: 기존 `keeper_report_state` 케이스는 이 sandbox의 Memory-backend fallback로 pre-existing fail — 변경 무관, clean origin/main에서도 동일 fail 확인.)

## Notes

- workaround 아님: typed determinism-boundary 채널(`Keeper_tool_outcome`)로 실패를 emit하는 root fix. string 분류기/telemetry-as-fix 아님.
- D-cluster를 닫음: #22127(consumer/detector) + 이 PR(producer/done)로 거부된 completion loop가 streak에 잡힘.
- `~typed_outcome`는 optional(default None)이라 `workflow_rejection_error_json` 기존 동작 불변.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
