### PR TITLE
feat(fusion): emit OTel metrics for RFC-0284 judge observation record

### DIFF
--- a/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
+++ b/infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json
@@ -2845,6 +2845,124 @@
       "title": "Restart Attempts",
       "transparent": true,
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 154
+      },
+      "panels": [],
+      "title": "Fusion Deliberation (RFC-0284)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Judge executions by topology, role, and outcome (RFC-0284).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 155
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (topology, role, outcome) (rate(masc_fusion_judge_executions_total[$__rate_interval])) * 60",
+          "legendFormat": "{{topology}} / {{role}} / {{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Fusion Judge Executions / min",
+      "transparent": true,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Fusion invocations by topology and outcome.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "pointSize": 0,
+            "showPoints": "never"
+          },
+          "unit": "cpm"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 155
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (topology, outcome) (rate(masc_fusion_invocations_total[$__rate_interval])) * 60",
+          "legendFormat": "{{topology}} / {{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Fusion Invocations / min",
+      "transparent": true,
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/lib/fusion/fusion_metrics.ml
+++ b/lib/fusion/fusion_metrics.ml
@@ -1,0 +1,55 @@
+(** Fusion deliberation OTel metrics (RFC-0284).
+
+    Observation records produced by the orchestrator are mirrored as counters
+    so operators can distinguish "no fusion traffic" from "fusion traffic that
+    is not wired to telemetry". *)
+
+open Fusion_types
+
+let metric_fusion_invocations_total =
+  Otel_metric_store_core.declare_counter "masc_fusion_invocations_total"
+
+let metric_fusion_judge_executions_total =
+  Otel_metric_store_core.declare_counter "masc_fusion_judge_executions_total"
+
+let topology_label = function
+  | Simple -> "simple"
+  | Refine -> "refine"
+  | Conditional -> "conditional"
+  | Judge_of_judges -> "judge_of_judges"
+
+let judge_role_of_outcome = function
+  | Synthesized node -> node.role
+  | Judge_failed node -> node.failed_role
+
+let judge_role_label = function
+  | Single -> "single"
+  | Refine_pass -> "refine_pass"
+  | First _ -> "first"
+  | Meta -> "meta"
+
+let judge_outcome_label = function
+  | Synthesized _ -> "synthesized"
+  | Judge_failed _ -> "failed"
+
+let record_judge_execution ~topology node =
+  Otel_metric_store_core.inc_counter
+    metric_fusion_judge_executions_total
+    ~labels:
+      [ "topology", topology_label topology
+      ; "role", judge_role_label (judge_role_of_outcome node)
+      ; "outcome", judge_outcome_label node
+      ]
+    ()
+
+let record_invocation ~topology outcome =
+  let outcome_label =
+    match outcome with
+    | `Denied -> "denied"
+    | `Sink_failed -> "sink_failed"
+    | `Completed -> "completed"
+  in
+  Otel_metric_store_core.inc_counter
+    metric_fusion_invocations_total
+    ~labels:[ "topology", topology_label topology; "outcome", outcome_label ]
+    ()

--- a/lib/fusion/fusion_metrics.mli
+++ b/lib/fusion/fusion_metrics.mli
@@ -1,0 +1,17 @@
+(** Fusion deliberation OTel metrics (RFC-0284). *)
+
+val metric_fusion_invocations_total : string
+val metric_fusion_judge_executions_total : string
+
+val topology_label : Fusion_types.fusion_topology -> string
+val judge_role_label : Fusion_types.judge_role -> string
+val judge_outcome_label : Fusion_types.judge_outcome -> string
+
+val record_judge_execution : topology:Fusion_types.fusion_topology -> Fusion_types.judge_outcome -> unit
+(** Emit a counter increment for one executed judge node.
+    Labels: [topology], [role] \in {single, refine_pass, first, meta},
+    [outcome] \in {synthesized, failed}. *)
+
+val record_invocation : topology:Fusion_types.fusion_topology -> [< `Denied | `Sink_failed | `Completed ] -> unit
+(** Emit a counter increment for one fusion invocation.
+    Labels: [topology], [outcome] \in {denied, sink_failed, completed}. *)

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -11,11 +11,14 @@ type outcome =
 
 let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
   match Fusion_policy.decide ~policy request with
-  | Fusion_types.Deny reason -> Denied reason
+  | Fusion_types.Deny reason ->
+    Fusion_metrics.record_invocation ~topology `Denied;
+    Denied reason
   | Fusion_types.Allow req ->
     (match Fusion_policy.find_preset policy req.Fusion_types.preset with
      | None ->
        (* 게이트가 preset 존재를 이미 검증했으므로 도달 불가. 방어적으로 Denied. *)
+       Fusion_metrics.record_invocation ~topology `Denied;
        Denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
      | Some vp ->
           (* RFC-0280: find_preset가 검증된 preset을 돌려준다 — invariant 재검증 불필요.
@@ -256,10 +259,16 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             | Ok (_, u) -> u
             | Error (_, u) -> u
           in
+          (* RFC-0284 observation record → OTel counters. *)
+          List.iter (Fusion_metrics.record_judge_execution ~topology) judge_nodes;
           (match
              Fusion_sink.emit ~base_dir ~keeper:req.Fusion_types.keeper
                ~run_id:req.Fusion_types.run_id ~question:req.Fusion_types.prompt
                ~panel ~judge ~judges:judge_nodes ~judge_usage
            with
-           | Ok () -> Completed { panel; judge }
-           | Error msg -> Sink_failed msg))
+           | Ok () ->
+             Fusion_metrics.record_invocation ~topology `Completed;
+             Completed { panel; judge }
+           | Error msg ->
+             Fusion_metrics.record_invocation ~topology `Sink_failed;
+             Sink_failed msg))

--- a/test/dune
+++ b/test/dune
@@ -692,6 +692,12 @@
  (modules test_fusion_judge_usage)
  (libraries masc_test_deps masc.fusion_core))
 
+; RFC-0284 — Fusion deliberation OTel metrics: label wiring + counter emission.
+(test
+ (name test_fusion_metrics)
+ (modules test_fusion_metrics)
+ (libraries masc_test_deps masc.fusion_core))
+
 ; RFC-0252 §8 — judge_meta/panel_meta structured serialization. Needs
 ; masc.fusion_core for Fusion_types constructors (Answer/Recommend/Insufficient,
 ; judge_synthesis record) + Masc.Fusion_sink for the public meta serializers.

--- a/test/test_fusion_metrics.ml
+++ b/test/test_fusion_metrics.ml
@@ -1,0 +1,82 @@
+(* RFC-0284 — Fusion deliberation OTel metrics wiring. *)
+
+open Alcotest
+open Masc
+
+let sample_usage : Fusion_types.usage =
+  { Fusion_types.input_tokens = 100; output_tokens = 50 }
+
+let sample_synthesis : Fusion_types.judge_synthesis =
+  { Fusion_types.consensus = []
+  ; contradictions = []
+  ; partial_coverage = []
+  ; unique_insights = []
+  ; blind_spots = []
+  ; resolved_answer = "ok"
+  ; decision = Fusion_types.Answer "ok"
+  }
+
+let test_labels () =
+  check string "topology simple" "simple"
+    (Fusion_metrics.topology_label Fusion_types.Simple);
+  check string "topology judge_of_judges" "judge_of_judges"
+    (Fusion_metrics.topology_label Fusion_types.Judge_of_judges);
+  check string "role single" "single"
+    (Fusion_metrics.judge_role_label Fusion_types.Single);
+  check string "role first" "first"
+    (Fusion_metrics.judge_role_label (Fusion_types.First "p1"));
+  check string "outcome synthesized" "synthesized"
+    (Fusion_metrics.judge_outcome_label
+       (Fusion_types.Synthesized
+          { Fusion_types.role = Single; synthesis = sample_synthesis; usage = sample_usage }));
+  check string "outcome failed" "failed"
+    (Fusion_metrics.judge_outcome_label
+       (Fusion_types.Judge_failed
+          { Fusion_types.failed_role = Meta; error = "boom"; usage = sample_usage }))
+
+let test_record_judge_execution_emits () =
+  let before =
+    Otel_metric_store.metric_value_or_zero
+      Fusion_metrics.metric_fusion_judge_executions_total
+      ~labels:[ "topology", "simple"; "role", "single"; "outcome", "synthesized" ]
+      ()
+  in
+  Fusion_metrics.record_judge_execution
+    ~topology:Fusion_types.Simple
+    (Fusion_types.Synthesized
+       { Fusion_types.role = Single; synthesis = sample_synthesis; usage = sample_usage });
+  let after =
+    Otel_metric_store.metric_value_or_zero
+      Fusion_metrics.metric_fusion_judge_executions_total
+      ~labels:[ "topology", "simple"; "role", "single"; "outcome", "synthesized" ]
+      ()
+  in
+  check (float 0.0) "counter incremented by 1.0" (before +. 1.0) after
+
+let test_record_invocation_emits () =
+  let before =
+    Otel_metric_store.metric_value_or_zero
+      Fusion_metrics.metric_fusion_invocations_total
+      ~labels:[ "topology", "refine"; "outcome", "completed" ]
+      ()
+  in
+  Fusion_metrics.record_invocation ~topology:Fusion_types.Refine `Completed;
+  let after =
+    Otel_metric_store.metric_value_or_zero
+      Fusion_metrics.metric_fusion_invocations_total
+      ~labels:[ "topology", "refine"; "outcome", "completed" ]
+      ()
+  in
+  check (float 0.0) "counter incremented by 1.0" (before +. 1.0) after
+
+let () =
+  run "fusion_metrics"
+    [ ( "labels"
+      , [ test_case "topology/role/outcome labels" `Quick test_labels ] )
+    ; ( "emission"
+      , [ test_case "record_judge_execution increments counter" `Quick
+            test_record_judge_execution_emits
+        ; test_case "record_invocation increments counter" `Quick
+            test_record_invocation_emits
+        ] )
+    ]


### PR DESCRIPTION
## Summary

RFC-0284 added `judge_outcome` observation records to the fusion orchestrator, but the new topology/role/outcome data had no telemetry wiring. This PR adds the missing OTel counters and Grafana panels.

## Changes

- `lib/fusion/fusion_metrics.ml` (+ .mli): new metrics module
  - `masc_fusion_judge_executions_total` (labels: topology, role, outcome)
  - `masc_fusion_invocations_total` (labels: topology, outcome)
- `lib/fusion/fusion_orchestrator.ml`: emit counters on denied/completed/sink-failed invocations and on each executed judge node
- `infrastructure/monitoring/grafana/provisioning/dashboards/masc-keeper-full.json`: add "Fusion Deliberation (RFC-0284)" row with two timeseries panels
- `test/test_fusion_metrics.ml` (+ `test/dune`): unit tests for label mapping and counter emission

## Validation

- `dune build @check` ✅
- `lib/masc.cma` ✅
- `test_fusion_metrics`, `test_fusion_sink_meta`, `fusion_core/test_fusion`, `test_fusion_judge_usage` ✅
- `ocamlformat --check` ✅