### PR TITLE
feat(memory-os): RFC-0285 L1 — self-observation claim_kind + finite horizon

### DIFF
--- a/config/prompts/keeper.librarian.episode_extraction.md
+++ b/config/prompts/keeper.librarian.episode_extraction.md
@@ -30,6 +30,7 @@ Additional rules:
 4. If you are unsure a claim is durable, prefer "ephemeral" over a durable category and state the uncertainty in the claim text. Do not emit a confidence number — the store no longer reads one; spend the words on a precise claim instead.
 5. open_items and constraints are episode-level summary arrays, separate from a claim's category. A claim already categorized as constraint does not need to be repeated in the constraints array.
 6. claim_id (optional): a short lowercase kebab-case slug identifying the CONCLUSION, not the wording — derive it deterministically from the subject and the asserted state (e.g. "pr-21249-verification-complete", "pr-123-open", "pr-123-merged"). Re-stating the same conclusion later MUST reuse the same slug; a changed conclusion (e.g. open -> merged) MUST use a new slug. Omit it if you cannot form a stable slug.
+7. claim_kind (optional): tag the claim's epistemic nature, orthogonal to category. Use "self_observation" for transient first-person agent state — you are idle, looping, blocked, or a tool is timing out (true now, false next turn). Use "external_state" for a claim about the world/PR/issue that is verifiable elsewhere. Use "durable_knowledge" for a timeless rule or lesson. A "lesson" category can still be a self_observation. Omit it when unclear — an omitted tag is treated as durable. Do NOT tag transient self-state as durable knowledge; that is the echo this field exists to stop.
 
 Output schema:
 {
@@ -40,7 +41,8 @@ Output schema:
       "category": "code_change|fact|preference|blocker|goal|constraint|validated_approach|lesson|ephemeral",
       "source_turn": 12,
       "source_tool_call_id": "call_abc",
-      "claim_id": "pr-123-open"
+      "claim_id": "pr-123-open",
+      "claim_kind": "self_observation|external_state|durable_knowledge"
     }
   ],
   "open_items": ["Tasks or questions left unresolved."],

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -215,6 +215,13 @@ let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
          fallback to [normalize_claim] keying); we never derive/hash an id in code,
          which would be the string-classifier workaround the RFC rejects. *)
       let claim_id = optional_string_field "claim_id" fields in
+      (* RFC-0285 §3.1/§3.2(a): the producer-emitted origin tag. Pass-through only —
+         the librarian LLM classifies at the live-context boundary; deriving
+         claim_kind in code would be the read-time string-classifier workaround the
+         RFC rejects. Absent/unrecognized => [None], routing to the durable path. *)
+      let claim_kind =
+        Option.bind (optional_string_field "claim_kind" fields) claim_kind_of_string
+      in
       (* Parse-once at the producer boundary: the LLM's free-text category becomes
          a typed [category] here, so no surface string reaches the store or the
          consolidator (RFC-0244 §2.3 / #21241; RFC-0247 §2.5). The category drives
@@ -230,12 +237,13 @@ let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
         { claim
         ; category
         ; external_ref
+        ; claim_kind
          ; source = claim_source ~trace_id turn tool_call_id
          (* Tier-1 (per-keeper) facts carry no distinct-keeper corroboration set;
             the consolidator populates observed_by only on promotion (RFC-0244). *)
          ; observed_by = []
          ; first_seen = now
-         ; valid_until = fact_valid_until ~now ~external_ref category
+         ; valid_until = fact_valid_until ~now ~external_ref ~claim_kind category
          ; last_verified_at = Some now
          ; schema_version
          ; claim_id

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -298,7 +298,7 @@ let parse_retry_nudge =
    object. Respond with ONLY a single JSON object — no markdown fences, no \
    prose. Required shape:\n\
    {\"episode_summary\": \"string\",\n\
-   \"claims\": [{\"claim\": \"string\", \"category\": \"fact|preference|blocker|goal|constraint|ephemeral|validated_approach|lesson|code_change\", \"source_turn\": 0, \"source_tool_call_id\": \"optional-string\"}],\n\
+   \"claims\": [{\"claim\": \"string\", \"category\": \"fact|preference|blocker|goal|constraint|ephemeral|validated_approach|lesson|code_change\", \"source_turn\": 0, \"source_tool_call_id\": \"optional-string\", \"claim_kind\": \"self_observation|external_state|durable_knowledge\"}],\n\
    \"open_items\": [\"string\"],\n\
    \"constraints\": [\"string\"],\n\
    \"preserved_tool_refs\": [\"string\"]}\n\
@@ -430,6 +430,9 @@ let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason
     { claim = note
     ; category = Keeper_memory_os_types.Ephemeral
     ; external_ref = None
+    ; (* RFC-0285: a parse-retry fallback note is not a librarian-classified claim;
+         leave it untagged ([None]) so it follows the Ephemeral category horizon. *)
+      claim_kind = None
     ; source = { trace_id = inp.trace_id; turn = 0; tool_call_id = None }
     ; observed_by = []
     ; first_seen = now
@@ -437,6 +440,7 @@ let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason
         Keeper_memory_os_types.fact_valid_until
           ~now
           ~external_ref:None
+          ~claim_kind:None
           Keeper_memory_os_types.Ephemeral
     ; last_verified_at = Some now
     ; schema_version = Keeper_memory_os_types.schema_version

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -220,18 +220,27 @@ let max_optional_float values =
     values
 ;;
 
-let valid_until_for_group ~now ~external_ref ~members category =
-  match external_ref with
-  (* RFC-0259 §3.2(b): a referenced claim is volatile regardless of category. *)
-  | Some _ -> Some (now +. volatile_external_ttl_seconds)
-  | None ->
-    (match category with
-     | Ephemeral ->
-       (match min_optional_float (List.map (fun (m : fact) -> m.valid_until) members) with
-        | Some _ as valid_until -> valid_until
-        | None -> category_valid_until ~now category)
-     | Fact | Constraint | Preference | Blocker | Goal | Code_change
-     | Validated_approach | Lesson | Unknown _ -> category_valid_until ~now category)
+let valid_until_for_group ~now ~external_ref ~claim_kind ~members category =
+  match claim_kind with
+  (* RFC-0285 §3.3/§4 re-mint property: a self-observation group inherits the
+     earliest member's horizon so a reworded re-mint does NOT extend it past the
+     first-mint anchor; only when no member carried one does it get a fresh horizon. *)
+  | Some Self_observation ->
+    (match min_optional_float (List.map (fun (m : fact) -> m.valid_until) members) with
+     | Some _ as valid_until -> valid_until
+     | None -> Some (now +. self_observation_ttl_seconds))
+  | Some External_state | Some Durable_knowledge | None ->
+    (match external_ref with
+     (* RFC-0259 §3.2(b): a referenced claim is volatile regardless of category. *)
+     | Some _ -> Some (now +. volatile_external_ttl_seconds)
+     | None ->
+       (match category with
+        | Ephemeral ->
+          (match min_optional_float (List.map (fun (m : fact) -> m.valid_until) members) with
+           | Some _ as valid_until -> valid_until
+           | None -> category_valid_until ~now category)
+        | Fact | Constraint | Preference | Blocker | Goal | Code_change
+        | Validated_approach | Lesson | Unknown _ -> category_valid_until ~now category))
 ;;
 
 let last_verified_for_members members =
@@ -276,10 +285,19 @@ let consolidated_fact ~now ~members (group : merge_group) =
   { claim = group.consolidated_claim
   ; category = group.category
   ; external_ref
+    (* RFC-0285 §3.1: carry the earliest member's tag; a group shares one claim
+       identity, so its members share a claim_kind. *)
+  ; claim_kind = earliest.claim_kind
   ; source = earliest.source
   ; observed_by
   ; first_seen
-  ; valid_until = valid_until_for_group ~now ~external_ref ~members group.category
+  ; valid_until =
+      valid_until_for_group
+        ~now
+        ~external_ref
+        ~claim_kind:earliest.claim_kind
+        ~members
+        group.category
   ; last_verified_at = last_verified_for_members members
   ; schema_version
   ; claim_id = shared_claim_id_for_members members

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -86,6 +86,24 @@ let group_preserves_category ~members (group : merge_group) =
        members
 ;;
 
+(* RFC-0285 §3.1: a merge must not mix [claim_kind]s. [consolidated_fact] takes the
+   earliest member's tag and [valid_until_for_group] inherits the member-min horizon;
+   both are sound ONLY if every member shares one [claim_kind]. Unlike the
+   [claim_identity]-keyed cross-keeper consolidator, an LLM index-group carries no
+   such constraint — and [claim_kind] is orthogonal to [category], so
+   [group_preserves_category] does NOT prevent grouping a [Self_observation] with a
+   durable claim of the same category. Letting [first_seen] order then pick the
+   volatility class would either immortalize the self-observation (earliest durable)
+   or expire the durable claim (earliest self-observation). Refusing the merge keeps
+   the self-observation finite AND the durable claim immortal — strictly safer
+   (RFC-0247 §7 R7: never lose a good fact to a hallucinated plan). *)
+let group_preserves_claim_kind ~members =
+  match members with
+  | [] -> true
+  | (first : fact) :: rest ->
+    List.for_all (fun (m : fact) -> m.claim_kind = first.claim_kind) rest
+;;
+
 (* ---------- JSON parsing (defensive, like the librarian) ---------- *)
 
 let int_list_of_json = function
@@ -285,8 +303,10 @@ let consolidated_fact ~now ~members (group : merge_group) =
   { claim = group.consolidated_claim
   ; category = group.category
   ; external_ref
-    (* RFC-0285 §3.1: carry the earliest member's tag; a group shares one claim
-       identity, so its members share a claim_kind. *)
+    (* RFC-0285 §3.1: carry the earliest member's tag. The merge gate
+       ([group_preserves_claim_kind] in [apply_plan]) guarantees every member shares
+       one claim_kind, so the earliest's tag IS the group's — sound regardless of
+       which member is earliest. *)
   ; claim_kind = earliest.claim_kind
   ; source = earliest.source
   ; observed_by
@@ -330,6 +350,7 @@ let apply_plan ~now ~facts plan =
        then (
          let member_facts = List.map (fun i -> facts_arr.(i)) members in
          if group_preserves_category ~members:member_facts group
+            && group_preserves_claim_kind ~members:member_facts
          then (
            let anchor =
              (* members is guaranteed non-empty by the [>= 2] guard above *)

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -54,7 +54,13 @@ type contribution =
 (* RFC-0259 §3.2(b): a volatile (external-ref) claim is per-keeper status, not
    durable cross-keeper knowledge — exclude it from promotion so it cannot be
    resurrected as an immortal shared fact (the #21363 shape). *)
-let eligible fact = is_promotable fact.category && Option.is_none fact.external_ref
+(* RFC-0285 §3.5: a [Self_observation] is transient keeper-local self-state, never
+   cross-keeper knowledge — gate it here (the single promotion SSOT) rather than
+   widening [is_promotable]'s exhaustive category signature. *)
+let eligible fact =
+  is_promotable fact.category
+  && Option.is_none fact.external_ref
+  && fact.claim_kind <> Some Self_observation
 
 (* Pick the representative fact for a claim group by a structural total order:
    earliest first_seen, then lexically smallest claim, then keeper id — so
@@ -95,6 +101,10 @@ let consolidate_into_shared ~now ~min_keepers contribs =
         { claim = rep.fact.claim
         ; category = rep.fact.category
         ; external_ref = rep.fact.external_ref
+          (* RFC-0285 §3.5: carry the representative's tag (parallel to [claim_id]).
+             [eligible] already drops [Self_observation], so a promoted shared fact is
+             never self-observation; this preserves [External_state]/[None] verbatim. *)
+        ; claim_kind = rep.fact.claim_kind
         ; source = rep.fact.source
         ; observed_by = keepers
         ; first_seen =
@@ -103,7 +113,12 @@ let consolidate_into_shared ~now ~min_keepers contribs =
              backstop — [eligible] already excludes external-ref claims, so this is
              [None] for promotable facts, but a volatile claim could never become an
              immortal shared fact even if that filter regressed. *)
-        ; valid_until = fact_valid_until ~now ~external_ref:rep.fact.external_ref rep.fact.category
+        ; valid_until =
+            fact_valid_until
+              ~now
+              ~external_ref:rep.fact.external_ref
+              ~claim_kind:rep.fact.claim_kind
+              rep.fact.category
           (* The consolidation IS the verification of the shared fact. *)
         ; last_verified_at = Some now
         ; schema_version

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -51,20 +51,22 @@ let retention_rank ~now (f : fact) =
    both fed the deleted composite score and are gone. There is no numeric
    strength to move — re-observation is a binary "seen again now". *)
 let reobserve_fact ~now ~existing ~incoming:(_ : fact) =
-  match existing.external_ref with
-  | Some _ ->
-    (* RFC-0259 §3.7 (P6/F): the librarian re-extracting a volatile (external-ref)
-       claim — possibly reworded — is NOT re-verification; it is the same self-
-       narrative re-emitted from memory. Inherit the prior row entirely so a
-       re-mint cannot reset the volatile TTL or grounding horizon. Only the
-       reconciler ([Stale_open], an external GitHub re-check) advances a volatile
-       claim's [last_verified_at]. This reverses the pre-P6 "re-observing IS
-       re-verification" rule for volatile claims. *)
+  match existing.external_ref, existing.claim_kind with
+  | Some _, _ | _, Some Self_observation ->
+    (* RFC-0259 §3.7 (P6/F) + RFC-0285 §3.3: inherit the prior row entirely for a
+       volatile (external-ref) OR self-observation claim. The librarian re-extracting
+       it — possibly reworded — is NOT re-verification; it is the same self-narrative
+       re-emitted from memory. Inheriting avoids advancing [last_verified_at], which
+       would raise [retention_rank] and make the cap keep a self-observation as
+       "recently verified" — the opposite of the goal. The finite horizon set at first
+       mint (L3) still governs expiry; a re-mint cannot extend it past the anchor.
+       Only the reconciler ([Stale_open], an external re-check) advances a volatile
+       claim's [last_verified_at]. *)
     existing
-  | None ->
-    (* Non-volatile (durable [None] / Ephemeral expiry) re-observe: the librarian
-       re-asserting a durable claim is fresh evidence it still holds, so advance
-       the staleness marker. There is no decay horizon to reset (durable
-       [valid_until] is unchanged), so F does not apply. *)
+  | None, (Some External_state | Some Durable_knowledge | None) ->
+    (* Non-volatile, non-self-observation re-observe: the librarian re-asserting a
+       durable claim is fresh evidence it still holds, so advance the staleness
+       marker. There is no decay horizon to reset (durable [valid_until] is
+       unchanged), so F does not apply. *)
     { existing with last_verified_at = Some now }
 ;;

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -76,6 +76,30 @@ let category_of_string s =
   | _ -> Unknown s
 ;;
 
+(* RFC-0285 §3.1: producer-emitted origin tag, orthogonal to [category] (a [Lesson]
+   can be a self-observation). A closed sum classified ONCE at the librarian write
+   boundary — not a read-time string match (the project's workaround signature #2).
+   An absent/unrecognized tag yields [None] in [claim_kind_of_string], which routes
+   to the durable pre-RFC path (safe), never to wrong-volatile. *)
+type claim_kind =
+  | Self_observation (* transient first-person agent state: idle, looping, tool-timeout *)
+  | External_state (* about the world/PR/issue; verifiable elsewhere *)
+  | Durable_knowledge (* timeless rule / lesson independent of transient state *)
+
+let claim_kind_to_string = function
+  | Self_observation -> "self_observation"
+  | External_state -> "external_state"
+  | Durable_knowledge -> "durable_knowledge"
+;;
+
+let claim_kind_of_string s =
+  match String.lowercase_ascii (String.trim s) with
+  | "self_observation" -> Some Self_observation
+  | "external_state" -> Some External_state
+  | "durable_knowledge" -> Some Durable_knowledge
+  | _ -> None
+;;
+
 (* Exhaustive promotability: only objective, durable claim kinds cross keepers.
    Extends the prior [Fact; Constraint] whitelist with the two outcome-derived
    kinds [Validated_approach] and [Lesson] — a validated approach and a hard-won
@@ -227,15 +251,28 @@ let category_valid_until ~now = function
    not a score); 1 day matches the ephemeral horizon. *)
 let volatile_external_ttl_seconds = 86_400.0
 
-(* RFC-0259 §3.2: the write-side [valid_until] producer. An [external_ref] claim is
-   never durable — it gets the volatile horizon regardless of category, so a
-   PR-status claim mislabeled [Fact] (the #21363 shape) or [Unknown] still decays.
-   [external_ref] is checked first so it takes precedence; otherwise the category
-   decides (only [Ephemeral] is finite). *)
-let fact_valid_until ~now ~external_ref category =
-  match external_ref with
-  | Some _ -> Some (now +. volatile_external_ttl_seconds)
-  | None -> category_valid_until ~now category
+(* RFC-0285 §3.4: transient first-person self-state (idle/looping/tool-timeout) is
+   MORE volatile than external state — a PR's status changes slowly, "am I idle"
+   changes every turn — so it gets a horizon SHORTER than the external one to quiet
+   the self-observation echo faster. Not so short a legitimate short-lived self-state
+   ("waiting on this block") vanishes within the same turn. A TIME, not a score;
+   named, not magic; tune in cycles (RFC §7). *)
+let self_observation_ttl_seconds = 3_600.0
+
+(* RFC-0259 §3.2 / RFC-0285 §3.4: the write-side [valid_until] producer. Precedence:
+   a [Self_observation] claim_kind gets the shortest finite horizon regardless of
+   category or external_ref (it is keeper-local transient state); otherwise an
+   [external_ref] claim gets the volatile horizon (so a PR-status claim mislabeled
+   [Fact] still decays); otherwise the category decides (only [Ephemeral] is finite).
+   [External_state]/[Durable_knowledge] tags carry no horizon of their own — the
+   external_ref / category arms already cover them. *)
+let fact_valid_until ~now ~external_ref ~claim_kind category =
+  match claim_kind with
+  | Some Self_observation -> Some (now +. self_observation_ttl_seconds)
+  | Some External_state | Some Durable_knowledge | None ->
+    (match external_ref with
+     | Some _ -> Some (now +. volatile_external_ttl_seconds)
+     | None -> category_valid_until ~now category)
 ;;
 
 (* RFC-0247 (purge): the fact carries only structure — the claim, its typed
@@ -252,6 +289,12 @@ type fact =
        claim names a PR/issue/task id. Orthogonal to [category] (a [Constraint]
        can reference a PR). Drives [fact_valid_until]: a referenced claim is
        volatile, never durable. Omitted from JSON when [None]. *)
+  ; claim_kind : claim_kind option
+    (* RFC-0285 §3.1: producer ([librarian]) -emitted origin tag, parallel to
+       [external_ref] and orthogonal to [category]. Drives [fact_valid_until]
+       ([Self_observation] gets a short finite horizon) and gates promotion
+       ([Self_observation] never crosses keepers — consolidator [eligible]). Omitted
+       from JSON when [None]; a missing tag degrades to the durable pre-RFC path. *)
   ; source : provenance_event
   ; observed_by : string list
     (* RFC-0244 Tier 2 (shared semantic store) ONLY: the sorted set of distinct
@@ -521,6 +564,12 @@ let fact_to_json f =
     @ (match Option.bind f.claim_id normalize_claim_id with
        | Some id -> [ "claim_id", `String id ]
        | None -> [])
+    (* RFC-0285 §3.1: the producer-emitted origin tag. Omitted when [None] so legacy
+       rows stay byte-identical, appended LAST to keep the prior key order stable for
+       the snapshot fingerprint. *)
+    @ (match f.claim_kind with
+       | Some k -> [ "claim_kind", `String (claim_kind_to_string k) ]
+       | None -> [])
   in
   `Assoc fields
 ;;
@@ -573,12 +622,18 @@ let fact_of_json (json : Yojson.Safe.t) =
           (* RFC-0259 §3.7 (P6): absent on legacy / id-less rows, defaulting to
              [None] so [claim_identity] falls back to [normalize_claim] for them. *)
           let claim_id = Option.bind (json_string_field "claim_id" fields) normalize_claim_id in
+          (* RFC-0285 §3.1: absent on legacy rows -> [None] (durable path). Closed sum,
+             so an unrecognized string also yields [None] (graceful-degrade). The
+             write-side [valid_until] is preserved as-is above; legacy self-observation
+             rows are not retrofitted a horizon (RFC §5 non-goal). *)
+          let claim_kind = Option.bind (json_string_field "claim_kind" fields) claim_kind_of_string in
           Some
             { claim
             ; (* Parse-once at the read boundary; legacy free-string categories
                  on disk map to their arm or [Unknown] (graceful-degrade). *)
               category = category_of_string category_str
             ; external_ref
+            ; claim_kind
             ; source
             ; observed_by
             ; first_seen

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -57,6 +57,23 @@ val category_to_string : category -> string
     anything outside the taxonomy becomes [Unknown] carrying the raw label. *)
 val category_of_string : string -> category
 
+(** RFC-0285 §3.1: producer-emitted origin tag, orthogonal to {!category} (a [Lesson]
+    can be a self-observation). A closed sum classified ONCE at the librarian write
+    boundary — not a read-time string match. Drives {!fact_valid_until}
+    ([Self_observation] gets a short finite horizon) and gates promotion. *)
+type claim_kind =
+  | Self_observation
+  | External_state
+  | Durable_knowledge
+
+(** Canonical lowercase token (round-trips with [claim_kind_of_string]). *)
+val claim_kind_to_string : claim_kind -> string
+
+(** Parse a claim_kind token (trimmed, case-insensitive on known tokens); an
+    absent/unrecognized label yields [None], routing to the durable pre-RFC path
+    (safe), never to wrong-volatile. *)
+val claim_kind_of_string : string -> claim_kind option
+
 (** Whether a category may be promoted into the shared semantic tier. Exhaustive
     over {!category}; only [Fact] and [Constraint] promote (preserving the prior
     ["fact";"constraint"] whitelist), so a new or typo'd category cannot silently
@@ -108,14 +125,21 @@ val category_valid_until : now:float -> category -> float option
     reconciler (P2) lands. *)
 val volatile_external_ttl_seconds : float
 
-(** RFC-0259 §3.2: the write-side [valid_until] producer. An [external_ref] claim
-    is never durable — it gets [volatile_external_ttl_seconds] regardless of
-    category (so a PR-status claim mislabeled [Fact]/[Unknown] still decays);
-    otherwise the category decides (only [Ephemeral] is finite). [external_ref]
-    takes precedence. *)
+(** RFC-0285 §3.4: the self-observation decay horizon (a TIME, not a score). Shorter
+    than [volatile_external_ttl_seconds] — transient first-person self-state changes
+    every turn, so a tighter horizon quiets the echo faster. Tune in cycles. *)
+val self_observation_ttl_seconds : float
+
+(** RFC-0259 §3.2 / RFC-0285 §3.4: the write-side [valid_until] producer. Precedence:
+    [Self_observation] claim_kind gets the shortest finite horizon
+    ([self_observation_ttl_seconds]) regardless of category/external_ref; otherwise an
+    [external_ref] claim gets [volatile_external_ttl_seconds] (so a PR-status claim
+    mislabeled [Fact]/[Unknown] still decays); otherwise the category decides (only
+    [Ephemeral] is finite). *)
 val fact_valid_until
   :  now:float
   -> external_ref:external_ref option
+  -> claim_kind:claim_kind option
   -> category
   -> float option
 
@@ -133,6 +157,11 @@ type fact =
     (** RFC-0259 §3.2(b): set by the producer when the claim names a PR/issue/task
         id. Orthogonal to [category]. Drives [fact_valid_until] (a referenced
         claim is volatile, never durable). Omitted from JSON when [None]. *)
+  ; claim_kind : claim_kind option
+    (** RFC-0285 §3.1: producer-emitted origin tag, parallel to [external_ref] and
+        orthogonal to [category]. Drives [fact_valid_until] ([Self_observation] gets a
+        short horizon) and gates promotion ([Self_observation] never crosses keepers).
+        Omitted from JSON when [None]; a missing tag degrades to the durable path. *)
   ; source : provenance_event
   ; observed_by : string list
     (** RFC-0244 Tier 2 (shared semantic store) only: the sorted set of distinct

--- a/test/memory_os_brain_harness.ml
+++ b/test/memory_os_brain_harness.ml
@@ -81,11 +81,13 @@ let mk_fact
       ?(category = Types.Fact)
       ?(valid_until = None)
       ?(age_seconds = 3600.0)
+      ?(claim_kind = None)
       claim
   =
   { Types.claim
   ; Types.category
   ; Types.external_ref = None
+  ; Types.claim_kind
   ; Types.source = { Types.trace_id = "harness-trace"; Types.turn = 1; Types.tool_call_id = None }
   ; Types.observed_by = []
   ; Types.first_seen = now -. age_seconds

--- a/test/test_keeper_compact_audit.ml
+++ b/test/test_keeper_compact_audit.ml
@@ -74,6 +74,7 @@ let fact_fixture ~now ~claim ?valid_until () =
   { Memory_types.claim = claim
   ; category = Memory_types.Ephemeral
   ; external_ref = None
+  ; claim_kind = None
   ; source =
       { trace_id = "trace-kca-gc"
       ; turn = 1

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -55,6 +55,7 @@ let fact_fixture ~now () =
   { Types.claim = "User prefers concise responses"
   ; Types.category = Types.Preference
   ; Types.external_ref = None
+  ; Types.claim_kind = None
   ; Types.source = { Types.trace_id = "trace-123"; Types.turn = 5; Types.tool_call_id = None }
   ; Types.observed_by = []
   ; Types.first_seen = now -. 86400.0
@@ -2109,7 +2110,8 @@ let suppression_corpus ~now =
     ; Types.category = Types.Blocker
     ; Types.external_ref
     ; Types.first_seen
-    ; Types.valid_until = Types.fact_valid_until ~now:first_seen ~external_ref Types.Blocker
+    ; Types.valid_until =
+        Types.fact_valid_until ~now:first_seen ~external_ref ~claim_kind:None Types.Blocker
     ; Types.last_verified_at = last_verified
     }
   in
@@ -3387,15 +3389,142 @@ let test_fact_valid_until_volatile () =
   Alcotest.(check (option (float 0.001)))
     "external-ref Fact gets the finite volatile horizon"
     (Some (now +. Types.volatile_external_ttl_seconds))
-    (Types.fact_valid_until ~now ~external_ref:pr_ref Types.Fact);
+    (Types.fact_valid_until ~now ~external_ref:pr_ref ~claim_kind:None Types.Fact);
   Alcotest.(check bool)
     "durable Fact with no ref stays durable (None)"
     true
-    (Option.is_none (Types.fact_valid_until ~now ~external_ref:None Types.Fact));
+    (Option.is_none (Types.fact_valid_until ~now ~external_ref:None ~claim_kind:None Types.Fact));
   Alcotest.(check bool)
     "Ephemeral with no ref still finite"
     true
-    (Option.is_some (Types.fact_valid_until ~now ~external_ref:None Types.Ephemeral))
+    (Option.is_some (Types.fact_valid_until ~now ~external_ref:None ~claim_kind:None Types.Ephemeral));
+  (* RFC-0285 §3.4: a Self_observation gets the short finite horizon regardless of
+     category — even an otherwise-durable Fact — and shorter than the external one. *)
+  Alcotest.(check (option (float 0.001)))
+    "Self_observation Fact gets the short self-observation horizon"
+    (Some (now +. Types.self_observation_ttl_seconds))
+    (Types.fact_valid_until
+       ~now
+       ~external_ref:None
+       ~claim_kind:(Some Types.Self_observation)
+       Types.Fact);
+  Alcotest.(check bool)
+    "self-observation horizon is shorter than the external one"
+    true
+    (Types.self_observation_ttl_seconds < Types.volatile_external_ttl_seconds)
+;;
+
+(* RFC-0285 §4: claim_kind tokens round-trip, and an unrecognized token degrades to
+   [None] (the durable pre-RFC path), never to a wrong-volatile guess. *)
+let test_claim_kind_round_trip () =
+  List.iter
+    (fun k ->
+       Alcotest.(check (option string))
+         "claim_kind round-trips to_string -> of_string -> to_string"
+         (Some (Types.claim_kind_to_string k))
+         (Option.map
+            Types.claim_kind_to_string
+            (Types.claim_kind_of_string (Types.claim_kind_to_string k))))
+    [ Types.Self_observation; Types.External_state; Types.Durable_knowledge ];
+  Alcotest.(check bool)
+    "unrecognized claim_kind token -> None (durable path)"
+    true
+    (Option.is_none (Types.claim_kind_of_string "not_a_kind"))
+;;
+
+(* RFC-0285 §4 (load-bearing): a self-observation gets a finite horizon even under a
+   durable category; a re-mint inherits the prior row so the horizon is NOT extended
+   past the first-mint anchor; it expires after its horizon; durable knowledge with no
+   horizon survives indefinitely. *)
+let test_self_observation_horizon_and_remint () =
+  let now = 1_000_000.0 in
+  let mk_self ?(first_seen = now) () =
+    { (fact_fixture ~now ()) with
+      Types.claim = "the agent is idle this turn"
+    ; Types.category = Types.Lesson (* an otherwise-durable category... *)
+    ; Types.claim_kind = Some Types.Self_observation (* ...made finite by the tag *)
+    ; Types.first_seen
+    ; Types.valid_until =
+        Types.fact_valid_until
+          ~now:first_seen
+          ~external_ref:None
+          ~claim_kind:(Some Types.Self_observation)
+          Types.Lesson
+    ; Types.claim_id = Some "self-obs-idle"
+    }
+  in
+  let existing = mk_self () in
+  Alcotest.(check bool)
+    "self-observation is finite despite a durable Lesson category"
+    true
+    (Option.is_some existing.Types.valid_until);
+  (* re-mint property: re-observing the same self-observation later inherits the prior
+     row entirely, so the horizon is not pushed past the original anchor. *)
+  let later = now +. 1_800.0 in
+  let incoming = mk_self ~first_seen:later () in
+  let merged = Policy.reobserve_fact ~now:later ~existing ~incoming in
+  Alcotest.(check (option (float 0.001)))
+    "re-mint does not extend the self-observation horizon past the first anchor"
+    existing.Types.valid_until
+    merged.Types.valid_until;
+  (* it drops from recall once now passes its horizon. *)
+  let past = now +. Types.self_observation_ttl_seconds +. 1.0 in
+  Alcotest.(check bool)
+    "self-observation drops from recall after its horizon"
+    false
+    (Types.fact_is_current ~now:past existing);
+  (* a Durable_knowledge lesson with no horizon survives indefinitely. *)
+  let durable =
+    { (fact_fixture ~now ()) with
+      Types.category = Types.Lesson
+    ; Types.claim_kind = Some Types.Durable_knowledge
+    ; Types.valid_until = None
+    }
+  in
+  Alcotest.(check bool)
+    "durable knowledge survives past the self-observation horizon"
+    true
+    (Types.fact_is_current ~now:past durable)
+;;
+
+(* RFC-0285 §3.5 / §4: a self-observation is never promoted to the shared tier even
+   with a promotable category and enough corroborating keepers; durable knowledge is. *)
+let test_self_observation_not_promoted () =
+  let now = 1_000_000.0 in
+  let self_obs marker =
+    { (fact_fixture ~now ()) with
+      Types.claim = "the agent is looping (" ^ marker ^ ")"
+    ; Types.category = Types.Lesson
+    ; Types.claim_kind = Some Types.Self_observation
+    ; Types.claim_id = Some "self-obs-loop"
+    }
+  in
+  let durable marker =
+    { (fact_fixture ~now ()) with
+      Types.claim = "merging requires two approvals (" ^ marker ^ ")"
+    ; Types.category = Types.Constraint
+    ; Types.claim_kind = Some Types.Durable_knowledge
+    ; Types.claim_id = Some "two-approvals-rule"
+    }
+  in
+  let keeper_facts =
+    [ "k1", [ self_obs "k1"; durable "k1" ]; "k2", [ self_obs "k2"; durable "k2" ] ]
+  in
+  let _considered, shared =
+    Consolidator.promote_facts ~min_keepers:2 ~now ~keeper_facts ()
+  in
+  Alcotest.(check bool)
+    "self-observation is never promoted to the shared tier"
+    false
+    (List.exists
+       (fun (f : Types.fact) -> f.Types.claim_kind = Some Types.Self_observation)
+       shared);
+  Alcotest.(check bool)
+    "durable knowledge with two keepers IS promoted"
+    true
+    (List.exists
+       (fun (f : Types.fact) -> f.Types.claim_id = Some "two-approvals-rule")
+       shared)
 ;;
 
 let test_fact_of_json_rederives_legacy_volatile () =
@@ -4052,6 +4181,18 @@ let () =
             "fact_valid_until: external ref -> finite, durable -> none"
             `Quick
             test_fact_valid_until_volatile
+        ; Alcotest.test_case
+            "claim_kind round-trips; unknown -> None (RFC-0285 §4)"
+            `Quick
+            test_claim_kind_round_trip
+        ; Alcotest.test_case
+            "self-observation: finite horizon, re-mint no extend, expiry (RFC-0285 §4)"
+            `Quick
+            test_self_observation_horizon_and_remint
+        ; Alcotest.test_case
+            "self-observation never promoted; durable is (RFC-0285 §3.5)"
+            `Quick
+            test_self_observation_not_promoted
         ; Alcotest.test_case
             "fact_of_json re-derives a legacy volatile row past horizon"
             `Quick

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -22,6 +22,7 @@ let fact
   { Types.claim
   ; category
   ; external_ref = None
+  ; claim_kind = None
   ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
   ; observed_by
   ; first_seen

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -12,6 +12,7 @@ let fact
       ?last_verified_at
       ?(observed_by = [])
       ?claim_id
+      ?(claim_kind = None)
       claim
   =
   let last_verified_at =
@@ -22,7 +23,7 @@ let fact
   { Types.claim
   ; category
   ; external_ref = None
-  ; claim_kind = None
+  ; claim_kind
   ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
   ; observed_by
   ; first_seen
@@ -201,6 +202,87 @@ let test_apply_rejects_category_upgrade () =
     (claims (Consolidation.apply_plan ~now ~facts plan))
 ;;
 
+(* RFC-0285 §3.1: [group_preserves_category] is orthogonal to [claim_kind], so the
+   LLM can group a Self_observation with a durable claim of the SAME category. The
+   merge must be refused (both kept) — otherwise [earliest.claim_kind] would, by
+   first_seen order, either immortalize the self-observation or expire the durable
+   claim. Earliest here is the durable claim; merging would carry [Durable_knowledge]
+   and re-immortalize the self-observation echo this RFC exists to stop. *)
+let test_apply_rejects_mixed_claim_kind () =
+  let facts =
+    [ fact
+        ~first_seen:100.0
+        ~category:Types.Lesson
+        ~claim_kind:(Some Types.Durable_knowledge)
+        "Bounded retries prevent loop starvation"
+    ; fact
+        ~first_seen:200.0
+        ~category:Types.Lesson
+        ~claim_kind:(Some Types.Self_observation)
+        "the agent is stuck in a retry loop this turn"
+    ]
+  in
+  let plan =
+    { Consolidation.groups =
+        [ { Consolidation.member_indices = [ 0; 1 ]
+          ; consolidated_claim = "retry loops need bounds"
+          ; category = Types.Lesson
+          }
+        ]
+    ; drop_indices = []
+    }
+  in
+  Alcotest.(check (list string))
+    "mixed-claim_kind group is skipped; both facts survive unchanged"
+    [ "Bounded retries prevent loop starvation"
+    ; "the agent is stuck in a retry loop this turn"
+    ]
+    (claims (Consolidation.apply_plan ~now ~facts plan))
+;;
+
+(* RFC-0285 §3.3/§4 re-mint at the consolidation boundary: a homogeneous
+   Self_observation group DOES merge, the consolidated fact stays [Self_observation],
+   and its horizon is the member-min — a reworded re-mint never extends the horizon
+   past the earliest member's anchor. *)
+let test_apply_self_observation_group_inherits_min_horizon () =
+  let facts =
+    [ fact
+        ~first_seen:100.0
+        ~valid_until:1_700_000.0
+        ~category:Types.Lesson
+        ~claim_kind:(Some Types.Self_observation)
+        "the agent is looping"
+    ; fact
+        ~first_seen:200.0
+        ~valid_until:2_000_000.0
+        ~category:Types.Lesson
+        ~claim_kind:(Some Types.Self_observation)
+        "the agent remains in a loop"
+    ]
+  in
+  let plan =
+    { Consolidation.groups =
+        [ { Consolidation.member_indices = [ 0; 1 ]
+          ; consolidated_claim = "the agent is stuck looping"
+          ; category = Types.Lesson
+          }
+        ]
+    ; drop_indices = []
+    }
+  in
+  match Consolidation.apply_plan ~now ~facts plan with
+  | [ merged ] ->
+    Alcotest.(check bool)
+      "consolidated fact stays a self-observation"
+      true
+      (merged.Types.claim_kind = Some Types.Self_observation);
+    Alcotest.(check (option (float 1e-9)))
+      "horizon is the member-min anchor, not extended"
+      (Some 1_700_000.0)
+      merged.Types.valid_until
+  | other -> Alcotest.failf "expected 1 merged fact, got %d" (List.length other)
+;;
+
 let test_apply_preserves_ephemeral_expiry_and_verification_age () =
   let facts =
     [ fact
@@ -373,6 +455,11 @@ let () =
 	        ; Alcotest.test_case "first group wins contested fact" `Quick test_apply_first_group_wins_contested
 	        ; Alcotest.test_case "rejects category downgrade" `Quick test_apply_rejects_category_downgrade
         ; Alcotest.test_case "rejects category upgrade" `Quick test_apply_rejects_category_upgrade
+        ; Alcotest.test_case "rejects mixed claim_kind" `Quick test_apply_rejects_mixed_claim_kind
+        ; Alcotest.test_case
+            "self-observation group inherits min horizon"
+            `Quick
+            test_apply_self_observation_group_inherits_min_horizon
         ; Alcotest.test_case
             "preserves ephemeral expiry and verification age"
             `Quick

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -12,6 +12,7 @@ let fact claim =
   { Types.claim
   ; category = Types.Fact
   ; external_ref = None
+  ; claim_kind = None
   ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
   ; observed_by = []
   ; first_seen = now

--- a/test/test_keeper_user_model.ml
+++ b/test/test_keeper_user_model.ml
@@ -38,6 +38,7 @@ let fact
   { Types.claim
   ; category
   ; external_ref = None
+  ; claim_kind = None
   ; source = { trace_id; turn; tool_call_id = None }
   ; observed_by
   ; first_seen = now -. float_of_int turn

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -113,6 +113,7 @@ let memory_fact ?(category = M.Validated_approach) ?(trace_id = "trace-1") ?(tur
     claim;
     category;
     external_ref = None;
+    claim_kind = None;
     source;
     observed_by = [];
     first_seen = 0.0;

--- a/test/test_rfc0259_reconcile.ml
+++ b/test/test_rfc0259_reconcile.ml
@@ -22,6 +22,7 @@ let fact ?(external_ref = None) ?last_verified_at ~first_seen claim =
   { Types.claim
   ; category = Types.Fact
   ; external_ref
+  ; claim_kind = None
   ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
   ; observed_by = []
   ; first_seen

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -16,6 +16,7 @@ let fact ?(external_ref = None) ?(valid_until = None) ~now claim =
   { Types.claim
   ; Types.category = Types.Fact
   ; Types.external_ref
+  ; Types.claim_kind = None
   ; Types.source = { Types.trace_id = "health-test"; Types.turn = 1; Types.tool_call_id = None }
   ; Types.observed_by = []
   ; Types.first_seen = now

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -93,6 +93,7 @@ let fact ?(category = Types.Preference) ?(trace_id = "trace-user-model")
   { claim
   ; category
   ; external_ref = None
+  ; claim_kind = None
   ; source = { trace_id; turn; tool_call_id = None }
   ; observed_by = []
   ; first_seen


### PR DESCRIPTION
## 목표

RFC-0285 L1 코드 구현 — keeper memory-os의 transient first-person self-state(idle/looping/tool-timeout)가 durable로 저장돼 매 turn 재주입되는 echo를 write-time typed `claim_kind` + finite horizon으로 닫는다.

근거: `memory_quality_eval` harness(PR #22143)가 측정한 baseline echo는 worst **7092×**("no unclaimed tasks exist"), near-dup 213 slots — 대부분 self-observation이 durable로 굳은 것. RFC-0285(문서 머지 #22119)가 이 fix를 명세한다.

## RFC 발견 (RFC-first 게이트)

keeper subsystem(`lib/keeper/keeper_memory_os_*`, `keeper_librarian*`) 변경 → **RFC-0285** (`docs/rfc/RFC-0285-memory-os-self-observation-claim-volatility.md`, merged #22119) §3.1–3.5 + §4 인용. 이 PR은 그 명세의 코드 구현이다.

## 설계 — `external_ref` 미러

`claim_kind`를 **closed sum**(`Self_observation | External_state | Durable_knowledge`)으로, 기존 `external_ref` 필드와 정확히 평행하게 추가. producer 경계에서 **parse-once** — read-time string 분류기(워크어라운드 시그니처 #2)가 아니다. 누락 태그는 default-to-durable(pre-RFC status quo, safe), never wrong-volatile.

## 변경

- **types** (`keeper_memory_os_types.ml`/`.mli`): `claim_kind` type + converters + JSON codec(`None`일 때 생략 → legacy byte-identical); `self_observation_ttl_seconds`(3600s, external 86400s보다 짧게); `fact_valid_until`에 `~claim_kind` arm(Self_observation → category/external_ref 무관 short horizon).
- **producer** (`keeper_librarian.ml`, `keeper_librarian_runtime.ml`, `config/prompts/keeper.librarian.episode_extraction.md`): `fact_of_json`이 `claim_kind`를 `category` 옆에서 파싱; LLM output schema + system prompt가 transient self-state 태깅 지시. **코드 derive 금지**(파생하면 거부된 read-time 분류기).
- **L2** (`keeper_memory_os_policy.ml`): `reobserve_fact`가 self-observation에 대해 prior row inherit(anchor reset 없음, `last_verified_at` 미전진 → retention_rank 부풀림 방지).
- **L3/promotion** (`keeper_memory_os_consolidator.ml`, `keeper_memory_os_consolidation.ml`): consolidator `eligible`가 단일 promotion SSOT에서 Self_observation 제외(`is_promotable` 시그니처 불변); consolidation은 태그 carry-forward + member horizon 상속(re-mint 연장 방지).

## 검증 (CI)

- **unit**: `claim_kind` round-trip + unknown→None; `fact_valid_until`이 Self_observation에 short horizon.
- **property**: self-observation이 durable category에서도 finite; **re-mint property**(같은 claim_id 두 번 mint해도 horizon이 first-mint anchor 너머 연장 안 됨); horizon 경과 후 recall drop; Durable_knowledge(`valid_until=None`) 무기한 생존.
- **promotion-drop**: 2-keeper corroboration에도 Self_observation은 shared tier promote 안 됨; durable knowledge는 promote.

## 범위 밖 (의도적)

- TLA spec-mutation(RFC §4 TLA) — 후속.
- 디스크의 legacy durable self-observation row retrofit — RFC §5 non-goal(코드는 새로 mint되는 claim에만 영향).
- harness로 7092→? **즉시 측정 불가**(라이브 keeper 재실행 + 새 데이터 필요); property test가 메커니즘 증명, harness는 라이브 재측정용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
