### PR TITLE
fix(transport): unify tcp_port_reachable, drop blocking Eio probe (SSOT audit)

### DIFF
--- a/lib/transport_metrics.ml
+++ b/lib/transport_metrics.ml
@@ -461,23 +461,16 @@ let ws_listening () = ws_enabled () && Atomic.get ws_runtime_listening
 let ws_same_origin_ready () =
   ws_enabled () && Atomic.get ws_same_origin_runtime_ready
 
-let tcp_port_reachable port =
-  try
-    let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-    Eio_guard.protect
-      ~finally:(fun () ->
-        try Unix.close sock with
-        | Eio.Cancel.Cancelled _ as e -> raise e
-        | _ -> ())
-      (fun () ->
-         Unix.connect
-           sock
-           (Unix.ADDR_INET
-              (Unix.inet_addr_of_string Masc_network_defaults.masc_http_default_host, port));
-         true)
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> false
+(* [tcp_port_reachable] is intentionally [false], matching the canonical
+   decision in [Transport_read_model.tcp_port_reachable]. A stdlib
+   [Unix.connect] probe here would (a) block the Eio domain on a syscall
+   inside the transport-health refresh path and (b) only ever flip to
+   [true] by racing a foreign listener on the same port, which is not a
+   useful health signal. With this, [grpc_reachable]/[ws_reachable]
+   collapse to their [*_live] (listener-bound) state, the single source
+   of truth shared with the read model. Argument kept for call-site
+   stability. *)
+let tcp_port_reachable (_port : int) : bool = false
 ;;
 
 let hot_session_json (session : hot_queue_session) =


### PR DESCRIPTION
## 배경

`~/me/reports/masc-ssot-audit-2026-06-23.html` SSOT 감사 Transport §의 HIGH finding:
> `tcp_port_reachable`가 두 모듈에서 **반대로** 동작 — `transport_read_model.ml`은 항상 `false`,
> `transport_metrics.ml`은 blocking `Unix.connect` probe. dashboard/health가 같은 사실을 다르게 판단할 수 있고,
> metrics 버전은 Eio domain을 멈출 수 있음.

적대적 검증으로 finding을 확인했습니다:
- `transport_read_model.tcp_port_reachable` (`= false`)에는 근거 주석이 있음: warm-up 중 socket 미bind 리스너는 reachable이 아니며, probe는 같은 포트의 foreign 리스너와 race해야만 `true`가 되어 무의미한 신호.
- `transport_metrics.tcp_port_reachable` (464)는 그 무의미한 blocking probe를 그대로 보유. 호출부 584/587 → JSON `"reachable"` 필드(657/671). 이 빌더는 transport-health refresh 경로(끝 주석이 "proactive refresh가 막히지 않게 PG read 금지"라 명시)라, blocking `Unix.connect`가 Eio를 막는 실제 P1.

## 변경

`transport_metrics.tcp_port_reachable`의 body를 read_model과 동일한 canonical `false`로 교체.
`grpc_reachable`/`ws_reachable`는 `*_live`(listener-bound) 상태로 collapse — read model과 공유되는 단일 진실.
시그니처(`int -> bool`)는 유지하여 호출부 무변경.

## 검증 (적대적, read-only)

- 정의는 metrics에 단 1개(464)뿐 → body 교체로 모든 호출부(584/587) 일괄 적용.
- `.mli`에 `val tcp_port_reachable` 노출 없음(doc 언급뿐) → 외부 caller 0, behavior change는 모듈 내부 JSON에 국한.
- 테스트/대시보드가 `grpc_reachable`/`ws_reachable`를 이름으로 소비하지 않음(grep 0). CI/test에선 리스너 부재로 probe가 어차피 `false` → 골든 무변경.
- orphan 점검: `Unix`는 291/351에서 계속 사용(orphan 아님). `Eio_guard`/`Masc_network_defaults`는 qualified 참조라 per-file 바인딩 없음(unused-open 경고 없음).

## 미검증 (CI 위임)

- 로컬 dune 빌드 미수행(정책). 컴파일·테스트는 CI에서 검증.
- `.ocamlformat`은 `disable = true`(RFC-0010)라 포맷 검사 영향 없음.

RFC: 신규 불필요 — 기존 canonical(read_model) 동작으로의 버그 수정/통일. 관련: RFC-0281(websocket-transport-ssot).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
