### PR TITLE
feat(dashboard): RFC-0284 judge-node 위상을 board 인라인 증거 카드에 렌더

### DIFF
--- a/dashboard/src/components/board/fusion-evidence.test.ts
+++ b/dashboard/src/components/board/fusion-evidence.test.ts
@@ -1,0 +1,105 @@
+import { h } from 'preact'
+import { cleanup, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it } from 'vitest'
+import '@testing-library/jest-dom'
+import { FusionBoardEvidence } from './fusion-evidence'
+
+afterEach(() => cleanup())
+
+// Build a fusion board post whose meta carries the RFC-0284 `judges` observation
+// array. `judges === undefined` models an older post that predates the array.
+function fusionPost(judges: unknown) {
+  return {
+    meta: {
+      source: 'fusion',
+      run_id: 'fus-1',
+      question: 'q?',
+      panel: [{ model: 'gpt-5', status: 'answered', answer: 'panel answer' }],
+      judge: { status: 'synthesized', synthesis: '최종 종합' },
+      judges,
+    },
+  } as Parameters<typeof FusionBoardEvidence>[0]['post']
+}
+
+describe('FusionBoardEvidence judge topology strip (RFC-0284 PR 2)', () => {
+  it('renders the observed judge-node topology for a judge-of-judges run', () => {
+    render(
+      h(FusionBoardEvidence, {
+        post: fusionPost([
+          { role: 'first', identity: 'gpt-5', input_tokens: 400, output_tokens: 1200 },
+          { role: 'first', identity: 'claude', status: 'failed', error: 'timeout' },
+          { role: 'meta', identity: 'meta', input_tokens: 100, output_tokens: 300 },
+        ]),
+      }),
+    )
+    const strip = screen.getByTestId('fusion-board-judges')
+    expect(strip).toBeInTheDocument()
+    // shape classified from array shape alone (any `first` ⟹ judge-of-judges)
+    expect(strip.textContent).toContain('심판의 심판')
+    expect(strip.textContent).toContain('관측된 심판 노드 3개')
+    // role badges
+    expect(strip.textContent).toContain('1차')
+    expect(strip.textContent).toContain('메타')
+    // per-node combined token figures (live arithmetic: 400+1200, 100+300)
+    expect(strip.textContent).toContain('1.6k tok')
+    expect(strip.textContent).toContain('400 tok')
+    // exactly the failed first-judge carries the failed marker
+    expect(strip.querySelectorAll('[data-failed="true"]')).toHaveLength(1)
+    expect(strip.querySelectorAll('[data-fusion-judge-node]')).toHaveLength(3)
+    // identity is suppressed for the meta node (echoes its role) but kept for the
+    // `first` node — assert BOTH directions, else disabling suppression survives:
+    // the role badge renders '메타' (Korean) so the latin role-echo identity 'meta'
+    // must be absent from the meta row's text, while the first node keeps 'gpt-5'.
+    expect(strip.textContent).toContain('gpt-5')
+    const metaNode = strip.querySelector('[data-role="meta"]')
+    expect(metaNode?.textContent).not.toContain('meta')
+    // the canonical singular judge synthesis block is unchanged / still present
+    const root = screen.getByTestId('fusion-board-evidence')
+    expect(root.querySelector('[data-fusion-judge]')).not.toBeNull()
+  })
+
+  it('renders an all-fail judge-of-judges run (N first, no meta) with every row failed', () => {
+    render(
+      h(FusionBoardEvidence, {
+        post: fusionPost([
+          { role: 'first', identity: 'gpt-5', status: 'failed', error: 'timeout' },
+          { role: 'first', identity: 'claude', status: 'failed', error: 'refused' },
+        ]),
+      }),
+    )
+    const strip = screen.getByTestId('fusion-board-judges')
+    // `first` is JoJ-exclusive on the backend, so an all-fail JoJ (no meta node)
+    // still classifies as judge-of-judges, not refine — the exact shape that a
+    // bare node-count classifier would misread.
+    expect(strip.textContent).toContain('심판의 심판')
+    expect(strip.querySelectorAll('[data-fusion-judge-node]')).toHaveLength(2)
+    expect(strip.querySelectorAll('[data-failed="true"]')).toHaveLength(2)
+  })
+
+  it('classifies a refine run from shape', () => {
+    render(
+      h(FusionBoardEvidence, {
+        post: fusionPost([
+          { role: 'single', identity: 'single' },
+          { role: 'refine', identity: 'refine' },
+        ]),
+      }),
+    )
+    expect(screen.getByTestId('fusion-board-judges').textContent).toContain('재검토')
+  })
+
+  it('omits the strip when the meta predates the judges array', () => {
+    render(h(FusionBoardEvidence, { post: fusionPost(undefined) }))
+    expect(screen.queryByTestId('fusion-board-judges')).toBeNull()
+    // the evidence card itself still renders the canonical content
+    expect(screen.getByTestId('fusion-board-evidence')).toBeInTheDocument()
+    expect(screen.getByTestId('fusion-board-evidence').querySelector('[data-fusion-judge]')).not.toBeNull()
+  })
+
+  it('returns null for non-fusion meta', () => {
+    const { container } = render(
+      h(FusionBoardEvidence, { post: { meta: { foo: 'bar' } } as Parameters<typeof FusionBoardEvidence>[0]['post'] }),
+    )
+    expect(container.querySelector('[data-testid="fusion-board-evidence"]')).toBeNull()
+  })
+})

--- a/dashboard/src/components/board/fusion-evidence.ts
+++ b/dashboard/src/components/board/fusion-evidence.ts
@@ -3,9 +3,17 @@ import { RichContent } from '../common/rich-content'
 import type { BoardPost } from '../../types/core'
 import {
   extractFusionEvidence,
+  classifyFusionJudgeShape,
   type FusionJudgeView,
+  type FusionJudgeNode,
   type FusionPanelEntry,
 } from '../../lib/fusion-meta'
+import {
+  judgeShapeLabel,
+  judgeRoleLabel,
+  judgeNodeTokenLabel,
+  judgeNodeIdentity,
+} from '../fusion/fusion-judge-format'
 
 function formatTokens(value: number | null | undefined): string | null {
   return value == null ? null : `${value.toLocaleString()} tok`
@@ -64,6 +72,58 @@ function JudgeBlock({ judge }: { judge: FusionJudgeView }) {
   `
 }
 
+function JudgeNodeRow({ node }: { node: FusionJudgeNode }) {
+  const identity = judgeNodeIdentity(node)
+  return html`
+    <li
+      class=${`flex flex-wrap items-center gap-2 rounded-[var(--r-0)] border px-2 py-1 ${
+        node.failed
+          ? 'border-[var(--bad-30)] bg-[var(--bad-15)]'
+          : 'border-[var(--color-border-divider)] bg-[var(--color-bg-surface)]'
+      }`}
+      data-fusion-judge-node
+      data-role=${node.role}
+      data-failed=${node.failed ? 'true' : 'false'}
+    >
+      <span class="inline-flex rounded-[var(--r-0)] border border-[var(--color-brass-border)] px-1.5 py-0.5 font-mono text-3xs uppercase tracking-wide text-[var(--color-fg-secondary)]">${judgeRoleLabel(node.role)}</span>
+      ${identity
+        ? html`<span class="min-w-0 flex-1 break-all font-mono text-2xs text-[var(--color-fg-muted)]" title=${identity}>${identity}</span>`
+        : html`<span class="flex-1"></span>`}
+      <span class="font-mono text-2xs text-[var(--color-fg-muted)]">${judgeNodeTokenLabel(node)}</span>
+      ${node.failed
+        ? html`<span class="text-2xs font-semibold text-[var(--bad-light)]" title=${node.error ?? 'failed'}>✗ 실패</span>`
+        : html`<span class="text-2xs text-[var(--color-status-ok)]">✓</span>`}
+    </li>
+  `
+}
+
+// RFC-0284 PR 2: observed judge-node topology inline on the board evidence card.
+// Mirrors the standalone fusion surface strip but in the board's token system —
+// the data layer (shape classification, node normalization in lib/fusion-meta)
+// and the i18n labels (fusion/fusion-judge-format) are shared, only the markup is
+// board-native. Renders nothing for older posts whose meta predates the `judges`
+// array, so the canonical singular judge block below stays the sole content there.
+function JudgeTopologyBlock({ nodes }: { nodes: readonly FusionJudgeNode[] }) {
+  if (nodes.length === 0) return null
+  const shape = classifyFusionJudgeShape(nodes)
+  return html`
+    <section
+      class="mb-3 rounded-[var(--r-1)] border border-[var(--color-border-divider)] bg-[var(--color-bg-elevated)] p-3"
+      data-testid="fusion-board-judges"
+    >
+      <div class="mb-2 flex flex-wrap items-center gap-2">
+        <span class="text-xs font-semibold text-[var(--color-fg-secondary)]">심판 위상 · ${judgeShapeLabel(shape)}</span>
+        <span class="font-mono text-3xs uppercase tracking-wide text-[var(--color-fg-muted)]">관측된 심판 노드 ${nodes.length}개 · RFC-0284</span>
+      </div>
+      <ul class="grid gap-2" role="list">
+        ${nodes.map(
+          (node, index) => html`<${JudgeNodeRow} key=${`${node.role}-${node.identity}-${index}`} node=${node} />`,
+        )}
+      </ul>
+    </section>
+  `
+}
+
 export function FusionBoardEvidence({
   post,
   class: className,
@@ -103,6 +163,8 @@ export function FusionBoardEvidence({
           </div>
         `
         : null}
+
+      <${JudgeTopologyBlock} nodes=${evidence.judges} />
 
       ${evidence.judge ? html`<${JudgeBlock} judge=${evidence.judge} />` : null}
 

--- a/dashboard/src/components/fusion/fusion-judge-format.test.ts
+++ b/dashboard/src/components/fusion/fusion-judge-format.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  judgeShapeLabel,
+  judgeRoleLabel,
+  judgeNodeTokenLabel,
+  judgeNodeIdentity,
+} from './fusion-judge-format'
+import type { FusionJudgeNode } from '../../lib/fusion-meta'
+
+function node(partial: Partial<FusionJudgeNode>): FusionJudgeNode {
+  return { role: 'first', identity: 'gpt-5', failed: false, ...partial }
+}
+
+describe('judgeShapeLabel', () => {
+  it('maps every shape to its Korean label', () => {
+    expect(judgeShapeLabel('single')).toBe('단일 심판')
+    expect(judgeShapeLabel('refine')).toBe('재검토')
+    expect(judgeShapeLabel('judge-of-judges')).toBe('심판의 심판')
+    expect(judgeShapeLabel('custom')).toBe('심판 위상')
+  })
+})
+
+describe('judgeRoleLabel', () => {
+  it('maps the known closed backend roles', () => {
+    expect(judgeRoleLabel('first')).toBe('1차')
+    expect(judgeRoleLabel('meta')).toBe('메타')
+    expect(judgeRoleLabel('refine')).toBe('재검토')
+    expect(judgeRoleLabel('single')).toBe('단일')
+  })
+  it('falls through to the raw string for an unanticipated role', () => {
+    expect(judgeRoleLabel('arbiter')).toBe('arbiter')
+  })
+})
+
+describe('judgeNodeTokenLabel', () => {
+  it('renders an em-dash when there is no usage', () => {
+    expect(judgeNodeTokenLabel(node({}))).toBe('—')
+    expect(judgeNodeTokenLabel(node({ inputTokens: 0, outputTokens: 0 }))).toBe('—')
+  })
+  it('sums input + output, plain figure below 1000', () => {
+    expect(judgeNodeTokenLabel(node({ inputTokens: 120, outputTokens: 300 }))).toBe('420 tok')
+  })
+  it('k-formats to one decimal at or above 1000', () => {
+    expect(judgeNodeTokenLabel(node({ inputTokens: 400, outputTokens: 1200 }))).toBe('1.6k tok')
+  })
+})
+
+describe('judgeNodeIdentity', () => {
+  it('keeps an identity that differs from the role (the panelist_id on `first`)', () => {
+    expect(judgeNodeIdentity(node({ role: 'first', identity: 'gpt-5' }))).toBe('gpt-5')
+  })
+  it('suppresses an identity that merely echoes the role', () => {
+    expect(judgeNodeIdentity(node({ role: 'meta', identity: 'meta' }))).toBeNull()
+    expect(judgeNodeIdentity(node({ role: 'single', identity: 'single' }))).toBeNull()
+  })
+  it('suppresses an empty identity', () => {
+    expect(judgeNodeIdentity(node({ role: 'first', identity: '' }))).toBeNull()
+  })
+})

--- a/dashboard/src/components/fusion/fusion-judge-format.ts
+++ b/dashboard/src/components/fusion/fusion-judge-format.ts
@@ -1,0 +1,53 @@
+// RFC-0284 judge-node display formatting (i18n). The data layer
+// (`classifyFusionJudgeShape` / `normalizeFusionJudgeNodes` in lib/fusion-meta)
+// stays language-free; the Korean labels live here in the component layer and
+// are shared by both render surfaces — the standalone fusion surface
+// (`fusion-surface.ts`) and the inline board evidence card
+// (`board/fusion-evidence.ts`) — so the backend role/shape vocabulary has a
+// single mapping and cannot drift between the two views.
+import type { FusionJudgeNode, FusionJudgeShape } from '../../lib/fusion-meta'
+
+// Display label for a shape classification.
+const JUDGE_SHAPE_LABEL: Record<FusionJudgeShape, string> = {
+  single: '단일 심판',
+  refine: '재검토',
+  'judge-of-judges': '심판의 심판',
+  custom: '심판 위상',
+}
+
+export function judgeShapeLabel(shape: FusionJudgeShape): string {
+  return JUDGE_SHAPE_LABEL[shape]
+}
+
+// Korean badge for a backend judge role. Unknown roles fall through to the raw
+// string so a new backend role still renders (the enum is closed on the backend,
+// so this is defensive rather than expected).
+export function judgeRoleLabel(role: string): string {
+  switch (role) {
+    case 'first':
+      return '1차'
+    case 'meta':
+      return '메타'
+    case 'refine':
+      return '재검토'
+    case 'single':
+      return '단일'
+    default:
+      return role
+  }
+}
+
+// Per-node combined token figure (`Nk tok` / `N tok`), em-dash when no usage.
+export function judgeNodeTokenLabel(node: FusionJudgeNode): string {
+  const total = (node.inputTokens ?? 0) + (node.outputTokens ?? 0)
+  if (total <= 0) return '—'
+  return total >= 1000 ? `${(total / 1000).toFixed(1)}k tok` : `${total} tok`
+}
+
+// A meaningful node identity, or null. The backend only carries a real model id
+// for `first` nodes (the panelist_id); single/refine/meta echo their role string
+// as the identity (fusion_sink.ml judge_role_fields), which is redundant with the
+// role badge, so suppress it rather than print the role twice.
+export function judgeNodeIdentity(node: FusionJudgeNode): string | null {
+  return node.identity && node.identity !== node.role ? node.identity : null
+}

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -25,8 +25,13 @@ import {
   classifyFusionJudgeShape,
   type FusionPanelEntry,
   type FusionJudgeNode,
-  type FusionJudgeShape,
 } from '../../lib/fusion-meta'
+import {
+  judgeShapeLabel,
+  judgeRoleLabel,
+  judgeNodeTokenLabel,
+  judgeNodeIdentity,
+} from './fusion-judge-format'
 
 type FusionRunStatus = 'complete' | 'failed' | 'running'
 type FusionTone = 'ok' | 'warn' | 'bad' | 'volt' | 'muted'
@@ -420,48 +425,6 @@ function FusionKeeperLink({ keeper, size = 'sm' }: { keeper: string; size?: 'sm'
   `
 }
 
-// Display label for a shape classification (i18n lives in the component layer;
-// `classifyFusionJudgeShape` stays language-free in lib/fusion-meta).
-const JUDGE_SHAPE_LABEL: Record<FusionJudgeShape, string> = {
-  single: '단일 심판',
-  refine: '재검토',
-  'judge-of-judges': '심판의 심판',
-  custom: '심판 위상',
-}
-
-// Korean badge for a backend judge role. Unknown roles fall through to the raw
-// string so a new backend role still renders (the enum is closed on the backend,
-// so this is defensive rather than expected).
-function judgeRoleLabel(role: string): string {
-  switch (role) {
-    case 'first':
-      return '1차'
-    case 'meta':
-      return '메타'
-    case 'refine':
-      return '재검토'
-    case 'single':
-      return '단일'
-    default:
-      return role
-  }
-}
-
-// Per-node combined token figure (`Nk tok` / `N tok`), em-dash when no usage.
-function judgeNodeTokenLabel(node: FusionJudgeNode): string {
-  const total = (node.inputTokens ?? 0) + (node.outputTokens ?? 0)
-  if (total <= 0) return '—'
-  return total >= 1000 ? `${(total / 1000).toFixed(1)}k tok` : `${total} tok`
-}
-
-// A meaningful node identity, or null. The backend only carries a real model id
-// for `first` nodes (the panelist_id); single/refine/meta echo their role string
-// as the identity (fusion_sink.ml judge_role_fields), which is redundant with the
-// role badge, so suppress it rather than print the role twice.
-function judgeNodeIdentity(node: FusionJudgeNode): string | null {
-  return node.identity && node.identity !== node.role ? node.identity : null
-}
-
 // RFC-0284 PR 2: render the observed judge nodes as a structural strip so the
 // execution topology (JoJ = N 1차 + 메타, refine = 2, simple = 1) is visible
 // instead of collapsing into the single canonical judge. Topology is read from
@@ -473,7 +436,7 @@ export function FusionJudgesStrip({ nodes }: { nodes: readonly FusionJudgeNode[]
   return html`
     <div class="fus-block">
       <div class="fus-block-lbl">
-        심판 위상 · ${JUDGE_SHAPE_LABEL[shape]}
+        심판 위상 · ${judgeShapeLabel(shape)}
         <span class="fus-sub-note">관측된 심판 노드 ${nodes.length}개 · RFC-0284</span>
       </div>
       <ul class="fus-judges" data-testid="fusion-judges" role="list">

--- a/dashboard/src/lib/fusion-meta.test.ts
+++ b/dashboard/src/lib/fusion-meta.test.ts
@@ -210,6 +210,35 @@ describe('extractFusionEvidence', () => {
     expect(evidence).not.toBeNull()
     expect(evidence?.source).toBe('fusion')
   })
+
+  it('carries the RFC-0284 judges observation array (judge-of-judges)', () => {
+    const evidence = extractFusionEvidence({
+      source: 'fusion',
+      run_id: 'fus-joj',
+      panel: [{ model: 'gpt-5', status: 'answered' }],
+      judge: { status: 'synthesized' },
+      judges: [
+        { role: 'first', identity: 'gpt-5', input_tokens: 10, output_tokens: 20 },
+        { role: 'first', identity: 'claude', status: 'failed', error: 'timeout' },
+        { role: 'meta', identity: 'meta' },
+      ],
+    })
+    expect(evidence?.judges).toHaveLength(3)
+    expect(evidence?.judges[0]).toMatchObject({ role: 'first', identity: 'gpt-5', failed: false })
+    // toMatchObject ignores extra keys, so pin that a success node carries no error
+    expect(evidence?.judges[0]?.error).toBeUndefined()
+    expect(evidence?.judges[1]).toMatchObject({ role: 'first', failed: true, error: 'timeout' })
+    expect(evidence?.judges[2]?.role).toBe('meta')
+  })
+
+  it('defaults judges to [] when the meta predates the array', () => {
+    const evidence = extractFusionEvidence({
+      source: 'fusion',
+      panel: [{ model: 'gpt-5', status: 'answered' }],
+      judge: { status: 'synthesized' },
+    })
+    expect(evidence?.judges).toEqual([])
+  })
 })
 
 describe('normalizeFusionJudgeNodes', () => {

--- a/dashboard/src/lib/fusion-meta.ts
+++ b/dashboard/src/lib/fusion-meta.ts
@@ -106,6 +106,10 @@ export type FusionEvidence = {
   question?: string | null
   panel: FusionPanelEntry[]
   judge: FusionJudgeView | null
+  // RFC-0284 per-judge-node observation array. Additive alongside the canonical
+  // singular `judge`; `[]` when the meta predates the `judges` array. Carries the
+  // execution topology (JoJ / refine / simple) for the board evidence card.
+  judges: FusionJudgeNode[]
   usage: FusionUsage | null
 }
 
@@ -275,6 +279,7 @@ export function extractFusionEvidence(meta: unknown): FusionEvidence | null {
     question: firstString(effective, ['question', 'prompt']),
     panel,
     judge,
+    judges: normalizeFusionJudgeNodes(effective.judges),
     usage: normalizeFusionUsage(effective, panel),
   }
 }


### PR DESCRIPTION
## 배경 — RFC-0284를 board 인라인까지 확장

RFC-0284는 fusion topology의 실행 구조가 대시보드에 표시되어야 한다고 요구합니다. backend는 board meta_json에 per-judge-node 관측 배열 `judges`(Synthesized/Judge_failed 노드, role/identity + 노드별 usage)를 emit하지만(`lib/fusion/fusion_sink.ml judge_node_meta`, canonical 단수 `judge`와 ADDITIVE), **PR 2(#22145)는 이를 standalone fusion surface에만 렌더**했습니다.

board 인라인 증거 카드 `FusionBoardEvidence`(`components/board/fusion-evidence.ts`)는 여전히 canonical 단수 judge로 collapse → fusion run이 **실제로 게시되는 board에서는 JoJ/refine 위상이 emit되지만 보이지 않았습니다**. 이 PR이 그 갭을 닫습니다.

## 변경 (7파일, +320/-44)

- **`lib/fusion-meta.ts`** — `FusionEvidence`에 `judges: FusionJudgeNode[]` 추가, `extractFusionEvidence`에서 `normalizeFusionJudgeNodes`로 채움. additive(구 meta는 `[]`)이며 board가 meta를 한 번만 파싱하도록 중앙화. 데이터/분류 로직(`normalizeFusionJudgeNodes`/`classifyFusionJudgeShape`)은 기존 SSOT 재사용.
- **`components/fusion/fusion-judge-format.ts`** (신규) — i18n 라벨 4개(`judgeShapeLabel`/`judgeRoleLabel`/`judgeNodeTokenLabel`/`judgeNodeIdentity`)를 `fusion-surface.ts`에서 추출한 공유 컴포넌트-레이어 모듈. 백엔드 role/shape 어휘의 한국어 매핑을 두 렌더 표면이 **drift 없이 1곳**에서 공유. 데이터 lib(`fusion-meta`)는 language-free 유지.
- **`components/fusion/fusion-surface.ts`** — 로컬 라벨 헬퍼 제거, 공유 모듈 import로 전환(동작 보존 리팩터, 미사용 `FusionJudgeShape` import 정리).
- **`components/board/fusion-evidence.ts`** — board-native 토폴로지 strip(`JudgeTopologyBlock`/`JudgeNodeRow`). board의 Tailwind 토큰 시스템을 사용(surface의 keeper-v2 `.fus-*` 마크업 재사용 아님 — 두 표면의 CSS 시스템이 다름, split-brain 회피). canonical 종합 위에 배치, **canonical 단수 judge 블록은 불변**. 위상은 **배열 shape만으로** 분류(RFC-0284 §27, vocabulary 하드코딩 금지) — `first` 노드 존재 ⟹ judge-of-judges라 all-fail JoJ(meta 부재)도 정확.

## 검증

- vitest **61** pass / `tsc --noEmit` clean / `eslint src` clean (worktree 로컬, node_modules는 main 체크아웃 심볼릭 링크).
- fresh `origin/main`(`78f1c2fcf4`)로 rebase 완료 — diff는 위 7파일만.

### 적대 리뷰(4관점) 반영
- **identity suppression 검증 강화**: board 테스트가 meta 노드의 role-에코 identity 억제를 핀(`[data-role="meta"]` 텍스트에 latin `meta` 부재). **mutation으로 증명** — `judgeNodeIdentity` suppression을 끄면 board 테스트 + format 단위 테스트 둘 다 FAIL.
- **all-fail JoJ board 케이스** 추가(N first·meta 없음 → 여전히 judge-of-judges, 전 row 실패 표시).
- **`fusion-judge-format` 직접 단위 테스트** 신규(라벨 어휘 + 토큰 산술 핀).
- refactor 안전성/RFC 정합/CSS 토큰 관점은 clean.

## 미검증 / 알려진 사항

- 시각 레이아웃(vitest는 data/attribute만 단언, computed CSS 미검증 — 알려진 한계). board-native strip은 인접 카드(`PanelCard`/`JudgeBlock`)와 동일 토큰 재사용.
- **pre-existing(본 PR 도입 아님)**: `--bad-15` 토큰이 dashboard 전역 미정의. 실패 노드 배경은 같은 파일의 기존 `statusClass` 및 `post-detail.ts` 사용과 동일하게 tintless 렌더되나, 실패는 `--bad-30` border + `--bad-light` text + `✗ 실패` 라벨로 표시됨. 멀티테마 토큰 ladder(`--bad-10/-20/-30`이 5개 테마 파일에 정의) 전반을 건드리는 별도 작업이라 분리 추적 → #22154.

## RFC

RFC-0284-fusion-judge-observation-record §16/27/79. 선행: PR 1(backend emit, main), PR 2(#22145, surface render).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
