### PR TITLE
fix(keeper): emit typed Error on rejected keeper_task_done (RFC-0239 D1)

### DIFF
--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -25,6 +25,7 @@ let keeper_task_result_json ?(typed_outcome = (None : Keeper_tool_outcome.t opti
 let workflow_rejection_error_json
       ?(rule_id = "keeper_task_argument_rejected")
       ?(alternatives = [])
+      ?(typed_outcome = (None : Keeper_tool_outcome.t option))
       message
   =
   (* RFC-0195 P0: [alternatives] is a typed list of tool names the
@@ -32,10 +33,21 @@ let workflow_rejection_error_json
      surfaces it directly in the JSON payload so the LLM does not
      have to parse prose [hint] strings to discover next-tool
      candidates. *)
+  (* RFC-0239 / audit D1: a rejected keeper tool call emits its typed
+     determinism-boundary outcome so the no-progress loop detector reads
+     it via [tool_call_detail.typed_outcome] instead of falling back to
+     the name-based evidence path (which counted a rejected
+     [keeper_task_done] as progress). [None] keeps the legacy payload. *)
+  let extra_fields =
+    match typed_outcome with
+    | Some outcome -> Some [ ("typed_outcome", Keeper_tool_outcome.to_json outcome) ]
+    | None -> None
+  in
   Task.Payloads.workflow_rejection_payload_json
     ~rule_id
     ~scope_policy:"observe"
     ~alternatives
+    ?extra_fields
     message
 ;;
 
@@ -784,6 +796,8 @@ let handle_keeper_task_tool
     then
       workflow_rejection_error_json
         ~alternatives:[ "keeper_task_claim"; "keeper_tasks_list" ]
+        ~typed_outcome:
+          (Some (Keeper_tool_outcome.Error { reason = "task_id_required" }))
         "task_id is required. Use the task_id you got from keeper_task_claim."
     else if result_text = ""
     then
@@ -799,6 +813,8 @@ let handle_keeper_task_tool
          error names the field the keeper actually sent. *)
       workflow_rejection_error_json
         ~alternatives:[ "keeper_task_done" ]
+        ~typed_outcome:
+          (Some (Keeper_tool_outcome.Error { reason = "result_required" }))
         "result is required. Audit trail: describe what you completed. \
          Example: result='Refactored module X, all tests green, no flake'."
     else (
@@ -830,9 +846,19 @@ let handle_keeper_task_tool
         ~typed_outcome:
           (if Tool_result.is_success transition_result
            then Some Keeper_tool_outcome.Progress
-           else None)
+           else
+             (* RFC-0239 / audit D1: a failed [keeper_task_done] transition
+                did not bind work, so emit a typed [Error] (reason = the
+                transition's own message) instead of [None]. [None] would
+                leave the detector on the name-based path that counts a
+                rejected completion as evidence. *)
+             Some
+               (Keeper_tool_outcome.Error
+                  { reason = Tool_result.message transition_result }))
         ~failure_class:(Tool_result.failure_class transition_result)
         ~ok:(Tool_result.is_success transition_result)
         ~message:(Tool_result.message transition_result)
         ())
 ;;
+
+

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -422,6 +422,49 @@ let test_sangsu_claim_idle_loop_accrues () =
     (D.turn_made_progress ~strong_evidence:false
        ~surface_requires_evidence:(not (Success.claim_bound_work bound)))
 
+(* audit D1 producer: the handler's rejection branches pass a typed [Error]
+   through [workflow_rejection_error_json ?typed_outcome], which injects it as a
+   top-level [typed_outcome] field via ?extra_fields (see
+   [Workflow_rejection_payload.payload_json], which merges extra_fields into the
+   top-level assoc). Verify the channel round-trips: a typed Error serialized
+   into the payload is restored by [Keeper_tool_outcome.of_json], so the detector
+   reads it as non-progress instead of falling back to the name-based evidence
+   path. The failed-transition branch reuses [keeper_tool_result_json]'s
+   already-tested typed_outcome channel. *)
+let test_done_rejection_emits_typed_error () =
+  let payload ?(alternatives = []) ~reason message =
+    Masc.Task.Payloads.workflow_rejection_payload_json
+      ~scope_policy:"observe"
+      ~alternatives
+      ~extra_fields:[ "typed_outcome", Outcome.to_json (Outcome.Error { reason }) ]
+      message
+  in
+  let typed_outcome_of json =
+    match Yojson.Safe.from_string json with
+    | `Assoc fields -> Option.bind (List.assoc_opt "typed_outcome" fields) Outcome.of_json
+    | _ -> None
+  in
+  let reason_of = function
+    | Some (Outcome.Error { reason }) -> Some reason
+    | _ -> None
+  in
+  Alcotest.(check (option string))
+    "task_id rejection typed Error round-trips" (Some "task_id_required")
+    (reason_of
+       (typed_outcome_of
+          (payload
+             ~alternatives:[ "keeper_task_claim"; "keeper_tasks_list" ]
+             ~reason:"task_id_required"
+             "task_id is required")));
+  Alcotest.(check (option string))
+    "result rejection typed Error round-trips" (Some "result_required")
+    (reason_of
+       (typed_outcome_of
+          (payload
+             ~alternatives:[ "keeper_task_done" ]
+             ~reason:"result_required"
+             "result is required")))
+
 let () =
   Alcotest.run "keeper_no_progress_loop_detector"
     [
@@ -465,6 +508,8 @@ let () =
             `Quick test_strong_evidence_outcome_aware;
           Alcotest.test_case "sangsu claim-idle loop accrues streak"
             `Quick test_sangsu_claim_idle_loop_accrues;
+          Alcotest.test_case "done rejection emits typed Error (D1 producer)"
+            `Quick test_done_rejection_emits_typed_error;
         ] );
       ( "per-keeper isolation",
         [


### PR DESCRIPTION
## Goal (RFC-0239 / audit D1 producer follow-up)

PR #22127 made the no-progress loop detector outcome-aware: it reads
`tool_call_detail.typed_outcome` and demotes a typed `Error`/`No_progress` from
evidence. But `keeper_task_done` still emitted `typed_outcome = None` on
rejection/failure, so a rejected completion stayed on the name-based evidence
path and was counted as progress. PR #22127 documented this as the "honest
residual" (audit D1) and deferred the producer-side fix. This PR closes it.

Follow-up to #22127 (comment 4775408546).

## Changes

`lib/keeper/keeper_tool_task_runtime.ml`:
- **transition failure** (`keeper_task_done` -> `masc_transition` failed): `else
  None` -> `Some (Keeper_tool_outcome.Error { reason = transition message })`.
  The reason reuses the transition's own message.
- **empty task_id / empty result rejections**: `workflow_rejection_error_json`
  now accepts `?typed_outcome` and injects it as a top-level `typed_outcome`
  field via `?extra_fields` (the existing `Workflow_rejection_payload.payload_json`
  extension point), preserving the RFC-0195 payload format (rule_id /
  alternatives / error_class).
- Conservative: `None` keeps the legacy payload; only an explicit typed
  failure/rejection demotes. No tool that does not emit a typed outcome is newly
  flagged (no false-positive thrash risk).

## Verification

- `dune build` clean, including the full test suite (no interface
  inconsistency).
- `test_no_progress_loop_detector`: 20 tests green, including the new
  `done rejection emits typed Error (D1 producer)` case. It proves a typed
  `Error` serialized into the rejection payload round-trips through
  `Keeper_tool_outcome.of_json`, so the detector reads it as non-progress.
- Detector-side consumption of typed `Error` was already covered by PR #22127's
  19 cases; this PR adds only the producer emit + the channel round-trip test.

## Out of scope (honest residual)

- **masc_deliver** rejection/early-return paths: `handle_deliver` returns
  `Tool_result.{make_ok, make_err}` and carries no `typed_outcome` channel at
  all. Enabling deliver needs a `Tool_result` typed_outcome channel - a separate
  follow-up.
- **Test limitation**: the test asserts the typed_outcome channel (payload
  `extra_fields` + `of_json` round-trip), not the handler wiring end-to-end. The
  masc library is `(wrapped true)`, so exposing the cross-library
  `Keeper_tool_outcome.t` in a public `For_testing` module breaks interface
  consistency across other test executables. The wrapper mapping
  (`?typed_outcome` -> `extra_fields:[("typed_outcome", to_json)]`) is a
  one-line injection reviewed in code; a handler-level integration test is a
  future strengthening.

## Notes

- Not a workaround: this routes the name-only evidence path through the typed
  `Keeper_tool_outcome` channel (reverse of the CLAUDE.md workaround signature
  #2 "string classifier"). RFC-0239 cited.
- Not in the agent_delegation RFC-gated subsystems (credential / identity / repo
  / operator / sandbox / hooks / workflow).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
