### PR TITLE
fix(gate): tie Discord gateway reader to the connection switch (RFC-0287 P0)

### DIFF
--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -275,7 +275,12 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
       (match Discord_wss_connection.connect ~sw ~env ~url with
        | conn ->
          conn_ref := Some conn;
-         Eio.Fiber.fork ~sw (fun () -> reader_loop conn)
+         (* Fork the reader on the connection's OWN session switch (not the
+            gateway-wide [sw]) so a per-connection [Close_wss] cancels it. On
+            the gateway-wide [sw] the reader would survive close — blocked in
+            [Stream.take] with nothing left to wake it — and leak one fiber per
+            reconnect cycle (RFC-0287 P0). *)
+         Discord_wss_connection.spawn conn (fun () -> reader_loop conn)
        | exception (Eio.Cancel.Cancelled _ as e) -> raise e
        | exception exn ->
          (* DNS / connect / TLS handshake failure: the socket never came up.
@@ -289,13 +294,13 @@ let run ~sw ~env ~token ~intents ~trigger_policy ~on_event ~on_ambient () =
          Eio.Stream.add input_mailbox
            (Discord_gateway_state.Connect_failed { reason }))
     | Close_wss { code; reason = _ } ->
-      (* Phase 1.4b: explicit close. Discord_wss_connection.close
-         resolves the inner session switch's close-signal promise,
-         which lets that switch return, which cancels reader/writer
-         fibers and releases the socket + TLS flow. The reader's
-         pending read raises Cancelled; reader_loop treats cancellation
-         as terminal so a stale reader cannot enqueue a late Wss_closed
-         for the next connection. *)
+      (* Phase 1.4b: explicit close. Discord_wss_connection.close resolves the
+         inner session switch's close-signal promise, which lets that switch
+         return, turning it off and cancelling every fiber forked on it — the
+         driver, and (because Open_wss forked it via [spawn]) this reader. The
+         reader's pending [Stream.take] therefore raises Cancelled; reader_loop
+         treats cancellation as terminal (the [:211] arm) so a stale reader
+         cannot enqueue a late Wss_closed for the next connection. *)
       Discord_observability.record_gateway_close ~code;
       (match !conn_ref with
        | Some c -> Discord_wss_connection.close c

--- a/lib/gate/discord_wss_connection.ml
+++ b/lib/gate/discord_wss_connection.ml
@@ -66,6 +66,12 @@ type conn =
   { wsd : Ws_wsd.t
   ; events : event Eio.Stream.t
   ; close : unit -> unit
+  ; spawn : (unit -> unit) -> unit
+      (* Fork [f] on this connection's session switch, so it is cancelled when
+         [close] tears the connection down. The gateway runs its reader through
+         this so the reader's lifetime is the connection's, not the gateway's:
+         a per-connection close cancels the reader (its blocking read raises
+         [Cancelled]) instead of leaking it on the outer switch (RFC-0287 P0). *)
   }
 
 (* RFC 6455 §7.4: a Close frame with no body maps to status code 1005
@@ -177,34 +183,63 @@ let build_session ~sw ~env ~url =
   wsd, events
 ;;
 
-let connect ~sw ~env ~url =
-  init_rng ();
+(* Raised inside the session fiber to turn the session switch off on [close].
+   An Eio switch cancels its forked fibers only when it FAILS (or its run-body
+   raises) — a plain return just WAITS for them. So [close] cannot be a normal
+   return: the driver and reader would block forever and the switch would hang
+   waiting for them. Failing the switch with this cancels them, and the fork's
+   handler swallows it (a requested close is not an error). *)
+exception Session_closed
+
+(* Run a connection session on its own switch and expose [spawn] / [close] over
+   it. [setup ~sw] builds the wsd + inbound event stream on the session switch;
+   whatever it forks there (the ws-direct driver) and whatever a consumer later
+   forks via [spawn] is cancelled together when [close] fails the switch.
+   Any exception [setup] raises is re-raised in the caller. *)
+let run_session ~sw ~setup =
   let setup_promise, setup_resolver = Eio.Promise.create () in
   let close_signal, close_trigger = Eio.Promise.create () in
   Eio.Fiber.fork ~sw (fun () ->
-    Eio.Switch.run (fun session_sw ->
-      let result =
-        try Ok (build_session ~sw:session_sw ~env ~url) with
-        | e -> Error e
-      in
-      Eio.Promise.resolve setup_resolver result;
-      match result with
-      | Error _ -> () (* let session_sw exit; socket/flow get released *)
-      | Ok _ -> Eio.Promise.await close_signal));
+    try
+      Eio.Switch.run (fun session_sw ->
+        let result =
+          try Ok (setup ~sw:session_sw) with
+          | e -> Error e
+        in
+        (* Hand the session switch back to the caller alongside the session so
+           consumers (the reader) can fork fibers whose lifetime is this
+           connection's: closing the connection cancels them. *)
+        Eio.Promise.resolve setup_resolver
+          (Result.map (fun (wsd, events) -> (wsd, events, session_sw)) result);
+        match result with
+        | Error _ -> () (* let session_sw exit; socket/flow get released *)
+        | Ok _ ->
+          Eio.Promise.await close_signal;
+          (* Cancel the driver + any spawned reader by failing the switch (a
+             plain return would only wait for them — see [Session_closed]). *)
+          Eio.Switch.fail session_sw Session_closed)
+    with Session_closed -> ());
   match Eio.Promise.await setup_promise with
   | Error e -> raise e
-  | Ok (wsd, events) ->
+  | Ok (wsd, events, session_sw) ->
     let close () =
       match Eio.Promise.peek close_signal with
       | Some () -> () (* idempotent *)
       | None -> Eio.Promise.resolve close_trigger ()
     in
-    { wsd; events; close }
+    let spawn f = Eio.Fiber.fork ~sw:session_sw f in
+    { wsd; events; close; spawn }
+;;
+
+let connect ~sw ~env ~url =
+  init_rng ();
+  run_session ~sw ~setup:(fun ~sw -> build_session ~sw ~env ~url)
 ;;
 
 let read c = read_event (Eio.Stream.take c.events)
 let send_text c s = Ws_wsd.send_text c.wsd s
 let close c = c.close ()
+let spawn c f = c.spawn f
 
 module For_testing = struct
   type nonrec inbound = inbound =
@@ -227,4 +262,14 @@ module For_testing = struct
   let message_to_event = message_to_event
   let close_to_event = close_to_event
   let close_code_no_status = close_code_no_status
+
+  (* A connection with a real session switch + spawn/close but no socket: the
+     wsd is a bare, never-driven endpoint and the event stream stays empty. For
+     testing the reader-lifetime contract (spawn forks on the session switch;
+     close cancels it) independent of WS framing. *)
+  let make_test_conn ~sw =
+    run_session ~sw ~setup:(fun ~sw:_ ->
+      let ep = Ws_endpoint.create Ws_endpoint.Client (fun _ -> Ws_endpoint.handlers ()) in
+      Ws_endpoint.wsd ep, Eio.Stream.create inbound_capacity)
+  ;;
 end

--- a/lib/gate/discord_wss_connection.mli
+++ b/lib/gate/discord_wss_connection.mli
@@ -50,6 +50,14 @@ val close : conn -> unit
     socket. Idempotent — subsequent calls are no-ops. After [close], [read]
     raises and [send_text] acts on a closed descriptor. *)
 
+val spawn : conn -> (unit -> unit) -> unit
+(** [spawn conn f] forks [f] on [conn]'s session switch, so [f] is cancelled
+    when [close conn] tears the connection down. The gateway runs its reader
+    loop through this so the reader's lifetime is the connection's: a
+    per-connection close cancels the reader (its blocking [read] raises
+    [Cancelled]) rather than leaking it on the gateway-wide switch (RFC-0287
+    P0). Call before [close]; forking onto an already-closed connection raises. *)
+
 (** Pure bridge helpers, exposed for unit tests. *)
 module For_testing : sig
   type nonrec inbound = inbound =
@@ -81,4 +89,10 @@ module For_testing : sig
       defaulting a missing code to [close_code_no_status]. *)
 
   val close_code_no_status : int
+
+  val make_test_conn : sw:Eio.Switch.t -> conn
+  (** A connection with a real session switch + [spawn] / [close] but no socket
+      (the wsd is a bare, never-driven endpoint; the event stream stays empty).
+      For testing the reader-lifetime contract — that [spawn] forks on the
+      session switch and [close] cancels it — without a live WS handshake. *)
 end

--- a/test/dune
+++ b/test/dune
@@ -1591,6 +1591,8 @@
 
 (include stanzas/test_discord_wss_bridge.inc)
 
+(include stanzas/test_discord_wss_lifecycle.inc)
+
 (include stanzas/test_keeper_chat_discord.inc)
 
 (test

--- a/test/stanzas/test_discord_wss_lifecycle.inc
+++ b/test/stanzas/test_discord_wss_lifecycle.inc
@@ -1,0 +1,8 @@
+(test
+ (name test_discord_wss_lifecycle)
+ (modules test_discord_wss_lifecycle)
+ (libraries
+  alcotest
+  masc.gate
+  eio
+  eio_main))

--- a/test/test_discord_wss_lifecycle.ml
+++ b/test/test_discord_wss_lifecycle.ml
@@ -1,0 +1,61 @@
+(* RFC-0287 P0 — the gateway reader's lifetime must be the connection's, not
+   the gateway's.
+
+   [Discord_wss_connection.spawn] forks a fiber on the connection's session
+   switch, so [close] cancels it (its blocking [read] raises [Cancelled]).
+   Before the fix the gateway forked the reader on the gateway-wide switch,
+   where a per-connection close left it blocked in [Stream.take] forever — one
+   leaked fiber per reconnect cycle (unbounded on a flaky-network gateway).
+
+   [make_test_conn] gives a connection with the real session switch + spawn +
+   close but no socket, so this pins the lifetime contract without a live WS
+   handshake. The 2s timeout turns a regression (reader not cancelled) into a
+   fast failure instead of a hang. *)
+
+open Alcotest
+module D = Discord_wss_connection
+
+let test_close_cancels_spawned_reader () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let conn = D.For_testing.make_test_conn ~sw in
+  let outcome, set = Eio.Promise.create () in
+  D.spawn conn (fun () ->
+    (* Mirrors reader_loop: block on read; cancellation is the terminal arm. *)
+    match D.read conn with
+    | _ -> Eio.Promise.resolve set `Returned
+    | exception Eio.Cancel.Cancelled _ -> Eio.Promise.resolve set `Cancelled
+    | exception e -> Eio.Promise.resolve set (`Raised e));
+  (* Let the reader reach its blocking [read] before closing, so the test
+     exercises the cancel-a-blocked-reader path the leak was about. *)
+  Eio.Fiber.yield ();
+  D.close conn;
+  match Eio.Time.with_timeout clock 2.0 (fun () -> Ok (Eio.Promise.await outcome)) with
+  | Ok `Cancelled -> ()
+  | Ok `Returned -> fail "reader returned without being cancelled (events stream got an item?)"
+  | Ok (`Raised e) ->
+    fail (Printf.sprintf "reader raised %s; expected Cancelled" (Printexc.to_string e))
+  | Error `Timeout ->
+    fail
+      "spawned reader was not cancelled within 2s of close — it is on the \
+       gateway switch, not the connection's (RFC-0287 P0 fiber leak)"
+;;
+
+let test_double_close_is_idempotent () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun sw ->
+  let conn = D.For_testing.make_test_conn ~sw in
+  D.close conn;
+  D.close conn;
+  check pass "double close does not raise" () ()
+;;
+
+let () =
+  run "discord_wss_lifecycle"
+    [ ( "reader lifetime"
+      , [ test_case "close cancels the spawned reader" `Quick test_close_cancels_spawned_reader
+        ; test_case "double close is idempotent" `Quick test_double_close_is_idempotent
+        ] )
+    ]
+;;


### PR DESCRIPTION
## 목표

Discord 게이트웨이 reader fiber가 연결 종료 시 누출되는 P0를 수정합니다 (RFC-0287, #22132 후속).

## 배경 — 누출 메커니즘

`#22132`(머지됨)에서 reader는 게이트웨이 전역 switch(`~sw`)에 fork됐습니다. per-connection `Close_wss`는 연결의 session switch만 종료시키므로, 전역 switch의 reader는 취소되지 않고 `Eio.Stream.take`에서 영구 block → **reconnect cycle마다 reader fiber 1개씩 누출**(flaky-network long-run gateway에서 unbounded).

추가 근본 원인: Eio switch는 **실패(`Switch.fail`)할 때만** forked fiber를 취소하고, body가 정상 반환하면 *대기*합니다. 따라서 close가 단순히 session switch body를 반환시키는 것만으론 driver/reader를 취소하지 못하고 오히려 switch가 그들을 기다리며 hang합니다 — 로컬 Eio 실험으로 확인(정상 반환 → forked fiber 미취소).

## 변경

- `Discord_wss_connection`에 `spawn : conn -> (unit -> unit) -> unit` 추가 — 연결의 session switch에 fiber를 fork(연결 수명에 묶임).
- 게이트웨이가 reader를 전역 `~sw` 대신 `Discord_wss_connection.spawn`으로 실행 → per-connection close가 reader를 취소.
- `close` 시 session switch를 **`Switch.fail Session_closed`로 종료** → driver + reader를 함께 취소(정상 반환은 대기만 하므로). `Session_closed` sentinel은 session fork가 흡수.
- 이제 참이 된 `Close_wss` 주석을 실제 메커니즘(switch fail → 취소 → reader의 blocking read가 `Cancelled` raise → `:211` 종료 arm)으로 정정.

## 검증

- `test/test_discord_wss_lifecycle.ml` 신규: socket 없는 `For_testing.make_test_conn`으로 "close가 spawn된 reader를 취소"를 단언(2초 bound — 회귀 시 hang 대신 fast-fail).
- **이 테스트는 fix 전 timeout FAIL, fix 후 PASS** — mutation-test 성격으로 실제 회귀를 구분합니다(tautology 아님).
- 로컬(`dune build --root .`, sandbox-off): lifecycle 테스트 2/2, 기존 `test_discord_wss_bridge` 8/8 회귀 없음, 변경 4개 OCaml 파일 ocamlformat clean.

## 범위 / 비고

- RFC: RFC-0287 (ws-direct masc-owned WebSocket stack).
- 워크어라운드 아님 — 구조적 lifetime 수정(cap/cooldown/dedup/telemetry/string 분류기 시그니처 해당 없음).
- `#22132`가 이 fix 없이 머지되어(브랜치 삭제됨) 별도 PR로 main에 올립니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
