### PR TITLE
docs(transport): 서버 upgrade docstring을 ws-direct endpoint로 정정 (RFC-0287 후속)

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -1149,7 +1149,9 @@ let mcp_websocket_handler
 
 (** Perform the HTTP/1.1 -> WebSocket upgrade and drive the resulting
     connection.  Single source of truth for attaching an upgraded
-    socket to a [Httpun_ws.Server_connection.t]: it sends the 101 via
+    socket to a ws-direct [Ws_endpoint] (Server role) packaged as a
+    [Gluten.impl] — drop-in for the former [Httpun_ws.Server_connection.t]
+    (RFC-0287 §4.1): it sends the 101 via
     [respond_with_upgrade], then hands the connection to the Gluten
     runtime via [upgrade].  Omitting the [upgrade] call (the
     pre-RFC-0281 defect) left the connection undriven, so inbound frames


### PR DESCRIPTION
## 목적
RFC-0287 ws-direct 스택 교체(#22132)로 `Httpun_ws.Server_connection.t` 타입이 제거됐는데, `respond_and_drive_upgrade`의 docstring이 여전히 그 타입을 현재 attach 대상으로 서술하고 있었습니다(머지 후 6차원 감사에서 발견). 같은 함수 **본문 주석**(RFC-0287 §4.1)은 이미 정확히 "former Httpun_ws.Server_connection"으로 표기하고 있어 docstring만 불일치였습니다.

## 변경
- `lib/server/server_mcp_transport_ws.ml` docstring 1줄 정정: attach 대상을 ws-direct `[Ws_endpoint]`(Server role) packaged as `[Gluten.impl]`로 서술, 옛 타입은 "former ~ (RFC-0287 §4.1)"로 이력 보존.

## 검증
- 주석 전용 변경 — 빌드/동작 무관.
- `ocamlformat --check` PASS.
- diff: 1 file, +3/-1.

코드/의존성 변경 없음. RFC-0287 후속 doc 정합성 정리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
