### PR TITLE
fix(dashboard): stop board preview body headings inverting title hierarchy

### DIFF
--- a/dashboard/src/components/board/board-surface.ts
+++ b/dashboard/src/components/board/board-surface.ts
@@ -47,6 +47,7 @@ import {
   contributorQualityPercent,
   navigateToAuthor,
   stripInlineMarkdown,
+  dedupeLeadingHeading,
 } from '../../lib/board-utils'
 import {
   firstMentionNameFromMessage,
@@ -363,7 +364,7 @@ function BdStateBlock({ block }: { block: ParsedStateBlock }) {
 // ── Post card (v2 list item) ───────────────────────────────────────
 function PostCard({ post }: { post: BoardPost }) {
   const isDeleting = deletingPostId.value === post.id
-  const previewBody = stripStateBlocks(post.body)
+  const previewBody = dedupeLeadingHeading(post.title, stripStateBlocks(post.body))
   const authorLabel = boardActorDisplayName(post.author, post.author_identity)
   const authorAvatarKey = boardActorAvatarKey(post.author, post.author_identity)
   const authorTitle = boardActorTitle(post.author, post.author_identity)

--- a/dashboard/src/lib/board-utils.test.ts
+++ b/dashboard/src/lib/board-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { stripInlineMarkdown } from './board-utils'
+import { stripInlineMarkdown, dedupeLeadingHeading } from './board-utils'
 
 describe('stripInlineMarkdown', () => {
   it('strips bold markers', () => {
@@ -33,5 +33,43 @@ describe('stripInlineMarkdown', () => {
 
   it('handles empty string', () => {
     expect(stripInlineMarkdown('')).toBe('')
+  })
+})
+
+describe('dedupeLeadingHeading', () => {
+  it('removes leading heading identical to title', () => {
+    const body = '# 주간 리포트\n이번 주 진행 내용입니다.'
+    expect(dedupeLeadingHeading('주간 리포트', body))
+      .toBe('이번 주 진행 내용입니다.')
+  })
+
+  it('keeps leading heading when it differs from title (intentional section)', () => {
+    const body = '# 요약\n세부 내용입니다.'
+    expect(dedupeLeadingHeading('주간 리포트', body))
+      .toBe('# 요약\n세부 내용입니다.')
+  })
+
+  it('normalizes inline markdown in title before comparing', () => {
+    const body = '# 제목\n본문'
+    expect(dedupeLeadingHeading('**제목**', body)).toBe('본문')
+  })
+
+  it('handles h2..h6 the same as h1', () => {
+    const body = '### 같은 제목\n본문'
+    expect(dedupeLeadingHeading('같은 제목', body)).toBe('본문')
+  })
+
+  it('returns body unchanged when no heading present', () => {
+    expect(dedupeLeadingHeading('제목', '본문만 있습니다.'))
+      .toBe('본문만 있습니다.')
+  })
+
+  it('returns body unchanged when title is empty', () => {
+    expect(dedupeLeadingHeading('', '# 제목\n본문')).toBe('# 제목\n본문')
+  })
+
+  it('strips leading heading marker from title when comparing', () => {
+    // title 자체가 '# 제목' 형태여도 정규화하여 body 첫 헤더와 비교한다
+    expect(dedupeLeadingHeading('# 제목', '# 제목\n본문')).toBe('본문')
   })
 })

--- a/dashboard/src/lib/board-utils.ts
+++ b/dashboard/src/lib/board-utils.ts
@@ -66,6 +66,25 @@ export function stripInlineMarkdown(text: string): string {
     .replace(/`(.+?)`/g, '$1')
 }
 
+/**
+ * preview 카드에서 본문 첫 heading이 title과 같은 내용이면 해당 heading 줄을 생략.
+ *
+ * post-detail은 title이 text-2xl(~24px)이라 본문 헤더가 section 역할을 하지만,
+ * preview 카드는 title 타이포가 13.5px라 본문 h1(16px)/h2(14px)가 역전되어
+ * "제목이 두 벌로, 그리고 더 크게" 보이는 현상의 원인이 된다. 미리보기 목적상
+ * title과 중복되는 첫 헤더는 제거한다. title 요약 + body 전개 같은 의도적 구조는
+ * heading 텍스트가 title과 다르면 그대로 유지된다.
+ */
+export function dedupeLeadingHeading(title: string, body: string): string {
+  const normTitle = stripInlineMarkdown(title).trim().replace(/^#+\s*/, '')
+  if (!normTitle) return body
+  const heading = body.match(/^#{1,6}\s+(.+?)\s*$/m)
+  if (heading && stripInlineMarkdown(heading[1] ?? '').trim() === normTitle) {
+    return body.replace(/^#{1,6}\s+.+\n?/m, '')
+  }
+  return body
+}
+
 export function boardActorDisplayName(
   authorName: string,
   identity?: BoardActorIdentity | null,

--- a/dashboard/src/styles/board-v2.css
+++ b/dashboard/src/styles/board-v2.css
@@ -319,6 +319,19 @@
   overflow: hidden;
 }
 
+/* preview 카드 본문 헤더 평탄화: post-detail은 title이 text-2xl이라 본문 헤더가
+   section 역할을 하지만, preview 카드는 title이 13.5px라 본문 h1(16px)/h2(14px)가
+   역전되어 과대 표시된다. 미리보기는 헤딩 위계가 필요 없으므로 body 컨테이너
+   타이포(12.5px)로 귀결시킨다. .markdown-content h1(ui.css)보다 specificity가
+   높아 안전하게 덮어쓴다. */
+.v2-board-surface .bd-post-body :is(h1, h2, h3, h4, h5, h6) {
+  font-size: inherit;
+  font-weight: var(--fw-semi);
+  margin: 0;
+  color: inherit;
+  line-height: inherit;
+}
+
 .v2-board-surface .bd-post-body code,
 .v2-board-surface .bd-th-body code {
   font-family: var(--font-mono);


### PR DESCRIPTION
## Summary

Board preview cards showed the post body's leading markdown heading larger than the card title, and when that heading duplicated the title it read as a second, larger copy ("제목이 두 벌로, 크게 나옴").

## Root cause

`board-surface.ts` renders the preview body through the same `RichContent` markdown renderer as `post-detail.ts`, but the two contexts differ in title typography:

| context | title size | body `h1` (`.markdown-content`, ui.css) |
|---|---|---|
| post-detail | `text-2xl` (~24px) | 16px |
| preview card | 13.5px (board-v2.css) | 16px |

A body `# heading` (16px) or `## heading` (14px) overshadows the 13.5px title — a hierarchy inversion that exists only in the preview context. If the heading text equals the title it reads as a duplicate. (`RichContent`'s `previewLimit` only limits link-preview card count; body text is always full-markdown rendered.)

## Changes

- `board-v2.css` — scope `.bd-post-body :is(h1..h6)` to `inherit` the 12.5px body typography so body headings never exceed the 13.5px title. Out-specifies `.markdown-content h1` (ui.css) via higher specificity. Preview cards are 2-line clamped summaries and don't need heading hierarchy; post-detail keeps full heading styling.
- `board-utils.ts` — `dedupeLeadingHeading(title, body)`: drops a body leading heading whose text equals the title (after inline-markdown normalization). Intentional title-summary + body-section structure is preserved when the heading differs. Applied at `board-surface.ts` (`previewBody`).
- `board-utils.test.ts` — 7 cases.

## Verification

- `pnpm test` (board-utils): 15 passed (8 existing + 7 new)
- `pnpm typecheck` (tsc --noEmit): 0 errors
- `pnpm build` (vite): built in 31s
- `pnpm lint` (eslint src): clean

## Out of scope

This fixes the in-card visual hierarchy (title vs body heading). A keeper re-emitting identical posts (echo loop) would be a separate data-side root (RFC-0283) and is not solved by a read-side render fix.
