### PR TITLE
refactor(events): with_turn_span bracket for worker_oas turn sites

### DIFF
--- a/lib/core/masc_runtime_events.ml
+++ b/lib/core/masc_runtime_events.ml
@@ -7,9 +7,10 @@
 
     The turn event uses [Runtime_events.Type.span] so consumers pair
     [Begin]/[End] bounds natively — no external correlation id is
-    required.  Writers always call [emit_turn_start] and
-    [emit_turn_end] as a pair (see the [Fun.protect] usage at the
-    call sites in [worker_oas] and [keeper_agent_run]). *)
+    required.  Writers bracket the turn body with [with_turn_span] so
+    the [Begin]/[End] pair cannot drift apart; [keeper_agent_run]
+    keeps a manual pair because its finally is a composite (phase
+    event + cancel-ref bookkeeping), not a bare [emit_turn_end]. *)
 
 type Runtime_events.User.tag +=
   | Turn
@@ -23,5 +24,9 @@ let emit_turn_start () =
 
 let emit_turn_end () =
   Runtime_events.User.write ev_turn Runtime_events.Type.End
+
+let with_turn_span f =
+  emit_turn_start ();
+  Eio_guard.protect ~finally:emit_turn_end f
 
 let start_listener () = Runtime_events.start ()

--- a/lib/core/masc_runtime_events.mli
+++ b/lib/core/masc_runtime_events.mli
@@ -23,6 +23,13 @@ val emit_turn_end : unit -> unit
     [emit_turn_start] around the turn body (the consumer pairs them
     by domain+timestamp). *)
 
+val with_turn_span : (unit -> 'a) -> 'a
+(** [with_turn_span f] emits the [Begin] bound, runs [f], and emits the
+    [End] bound even if [f] raises.  Uses {!Eio_guard.protect} so the
+    closing bound runs under [Eio.Switch] when the runtime is active and
+    a body exception is preserved.  Brackets the pair so a caller cannot
+    emit a start without its matching end. *)
+
 val start_listener : unit -> unit
 (** Install the Runtime_events ring buffer listener.
 

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -520,8 +520,7 @@ let rec run_worker_via_oas
           ()
   : (Worker_container_types.run_result, string) result
   =
-  Masc_runtime_events.emit_turn_start ();
-  Eio_guard.protect ~finally:Masc_runtime_events.emit_turn_end
+  Masc_runtime_events.with_turn_span
   @@ fun () ->
   let session_id = meta.mcp_session_id in
   let worker_name = meta.worker_name in
@@ -580,8 +579,7 @@ and resume_worker_via_oas
       ()
   : (Worker_container_types.run_result, string) result
   =
-  Masc_runtime_events.emit_turn_start ();
-  Eio_guard.protect ~finally:Masc_runtime_events.emit_turn_end
+  Masc_runtime_events.with_turn_span
   @@ fun () ->
   let worker_name = meta.worker_name in
   let session_id = meta.mcp_session_id in

--- a/test/test_masc_runtime_events.ml
+++ b/test/test_masc_runtime_events.ml
@@ -39,11 +39,34 @@ let test_turn_span_roundtrip () =
       "expected [Begin; End], got %d event(s)"
       (List.length observed)
 
+(* with_turn_span composes emit_turn_start/emit_turn_end (covered by the
+   round-trip above), so these cases pin only the bracket contract that is
+   new: the body result flows through, and the body exception is re-raised
+   (after the [finally] emits End). They deliberately do not read the
+   process-global ring so they cannot interfere with the round-trip cursor. *)
+
+let test_with_turn_span_returns_body () =
+  let result = Masc_runtime_events.with_turn_span (fun () -> 7) in
+  Alcotest.(check int) "with_turn_span returns the body's result" 7 result
+
+let test_with_turn_span_propagates_exn () =
+  Alcotest.check_raises
+    "with_turn_span re-raises the body exception"
+    (Failure "boom")
+    (fun () ->
+      ignore (Masc_runtime_events.with_turn_span (fun () -> failwith "boom")))
+
 let () =
   Alcotest.run "masc_runtime_events"
     [ ( "span-roundtrip"
       , [ Alcotest.test_case
             "emit_turn_start/emit_turn_end visible to in-process cursor"
             `Quick test_turn_span_roundtrip
+        ] )
+    ; ( "with_turn_span"
+      , [ Alcotest.test_case "returns body result" `Quick
+            test_with_turn_span_returns_body
+        ; Alcotest.test_case "propagates body exception" `Quick
+            test_with_turn_span_propagates_exn
         ] )
     ]


### PR DESCRIPTION
## 배경

`~/me/reports/masc-ssot-audit-2026-06-23.html` SSOT 감사의 `turn-span-manual` finding을 적대적으로 검증한 결과입니다.

`worker_oas.ml`의 `run_worker_via_oas`(523-524)와 `resume_worker_via_oas`(583-584)는 동일한 2단계 관용구로 turn span을 엽니다:

```ocaml
Masc_runtime_events.emit_turn_start ();
Eio_guard.protect ~finally:Masc_runtime_events.emit_turn_end @@ fun () -> ...
```

start/end 페어링이 작성자 책임이라, 이후 편집이 start만 emit하고 end를 빠뜨릴 수 있는 구조입니다.

## 변경

`Masc_runtime_events.with_turn_span : (unit -> 'a) -> 'a`를 추가합니다. body를 bracket하여 `Begin`을 먼저, `End`를 (body가 raise해도) `Eio_guard.protect`로 emit합니다 — 런타임 활성 시 `Eio.Switch` 하에서 cleanup이 돌고 body 예외가 보존됩니다. worker_oas 2개 사이트를 이 helper로 교체했습니다.

`keeper_agent_run`은 manual pair를 유지합니다 — 그쪽 finally는 composite(phase event + cancel-ref 정리)라 `with_turn_span`에 끼우려면 parameterized finally가 필요해 더 나쁜 추상화가 됩니다. 의도적으로 제외했습니다("대강 짠 추상화보단 중복").

## 검증 (적대적, read-only)

- `with_turn_span`는 두 사이트가 byte-identical인 3줄 블록을 정확히 캡처 (`emit_turn_start (); Eio_guard.protect ~finally:emit_turn_end f`).
- `Eio_guard`는 `lib/core/`의 같은 `masc_core` 라이브러리(`wrapped false`)에 있어 `masc_runtime_events.ml`에서 직접 참조 가능 — 신규 cross-lib edge 없음.
- `Eio_guard.protect : finally:(unit -> unit) -> (unit -> 'a) -> 'a` 시그니처 일치 확인.
- worker_oas에서 `Eio_guard`는 675행에서 계속 사용 → orphan 아님.
- 동작 보존: 교체 전후 emit 순서·protect 의미 동일.

## 미검증 (CI 위임)

- 로컬 dune 빌드 미수행(정책). 컴파일·테스트는 CI에서 검증.
- `lib/core`의 `-w +4`(fragile match)는 `with_turn_span`에 패턴 매치가 없어 무관.
- `.ocamlformat`은 `disable = true`(RFC-0010)라 포맷 검사 영향 없음.

RFC-WAIVED: 비-gated subsystem(`lib/core`, `lib/worker_oas`). credential/identity/operator/sandbox/hooks/workflow 무관. 신규 RFC 불필요 — 기존 turn-span 계약을 invariant-enforcing helper로 코드화.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
