### PR TITLE
refactor(keeper): goal-horizon normalizer 이름을 goal로 rename (RFC-0288 §9)

### DIFF
--- a/lib/keeper/keeper_config.mli
+++ b/lib/keeper/keeper_config.mli
@@ -43,7 +43,7 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_goal_horizon_max_chars : int
+val default_goal_max_chars : int
 val default_drift_max_clauses : int
 
 (** Maximum bytes of personality text included in the rendered keeper prompt.
@@ -114,7 +114,7 @@ val utf8_repair_string : string -> string
     on a UTF-8 character boundary. Caller MUST pass [max_bytes] explicitly so
     the unit (bytes, not chars) is visible at every call site. *)
 val normalize_self_model_text : max_bytes:int -> string -> string
-val normalize_goal_horizon_text : ?max_len:int -> string -> string
+val normalize_goal_text : ?max_len:int -> string -> string
 
 val split_semicolon_clauses : string -> string list
 val take_last : int -> 'a list -> 'a list

--- a/lib/keeper/keeper_config_text.ml
+++ b/lib/keeper/keeper_config_text.ml
@@ -53,8 +53,8 @@ let approval_queue_stale_max_wait_sec = 600.0
    because silent truncation in the dashboard made operators think edits were
    not persisting. Operators can lower them via env vars if a deployment needs
    tighter prompt budgets. *)
-let default_goal_horizon_max_chars =
-  match Env_config_core.raw_value_opt "MASC_KEEPER_GOAL_HORIZON_MAX_CHARS" with
+let default_goal_max_chars =
+  match Env_config_core.raw_value_opt "MASC_KEEPER_GOAL_MAX_CHARS" with
   | Some v ->
     (match int_of_string_opt (String.trim v) with
      | Some n when n > 0 -> n
@@ -215,7 +215,7 @@ let normalize_self_model_text ~(max_bytes : int) (raw : string) : string =
     let cut = String_util.utf8_prefix ~max_bytes s in
     String.trim cut
 
-let normalize_goal_horizon_text ?(max_len = default_goal_horizon_max_chars) (raw : string) : string =
+let normalize_goal_text ?(max_len = default_goal_max_chars) (raw : string) : string =
   let s = String.trim raw in
   if s = "" then ""
   else String_util.utf8_prefix ~max_bytes:max_len s

--- a/lib/keeper/keeper_config_text.mli
+++ b/lib/keeper/keeper_config_text.mli
@@ -25,7 +25,7 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_goal_horizon_max_chars : int
+val default_goal_max_chars : int
 val default_drift_max_clauses : int
 val prompt_render_max_bytes : int
 
@@ -51,7 +51,7 @@ val utf8_repair_string : string -> string
 
 val normalize_self_model_text : max_bytes:int -> string -> string
 
-val normalize_goal_horizon_text : ?max_len:int -> string -> string
+val normalize_goal_text : ?max_len:int -> string -> string
 
 val split_semicolon_clauses : string -> string list
 

--- a/lib/keeper/keeper_memory_recall.ml
+++ b/lib/keeper/keeper_memory_recall.ml
@@ -330,7 +330,7 @@ let goal_horizon_candidates (meta : keeper_meta) : string list =
   [meta.goal]
   |> List.filter_map (fun raw ->
        raw
-       |> normalize_goal_horizon_text
+       |> normalize_goal_text
        |> String_util.trim_nonempty)
   |> List.fold_left
        (fun acc goal ->

--- a/lib/keeper/keeper_meta_json_parse.ml
+++ b/lib/keeper/keeper_meta_json_parse.ml
@@ -68,7 +68,7 @@ let parse_keeper_identity (json : Yojson.Safe.t) : (parsed_keeper_identity, stri
       Safe_ops.json_string_list "trace_history" json |> List.filter validate_name
     in
     let pk_goal =
-      Safe_ops.json_string ~default:"" "goal" json |> normalize_goal_horizon_text
+      Safe_ops.json_string ~default:"" "goal" json |> normalize_goal_text
     in
     (* Layer 2 PR-B (commit 5): delegate the surviving personality field
        to [Keeper_personality_io].  parse + coerce yields trim-only

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -179,7 +179,7 @@ let build_keeper_system_prompt
     ~goal
     ~instructions ?(persona_extended = "") ?(keeper_name = "")
     ?(home_ground = "") ?(active_goals = []) () =
-  let goal = normalize_goal_horizon_text goal in
+  let goal = normalize_goal_text goal in
   (* Behavior prompt blocks live under
      [<prompts_dir>/behavior/<name>.md] and are read once per process via
      [Keeper_prompt_external.get]. Missing/unreadable files no longer inject

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -239,7 +239,7 @@ let first_non_empty_goal_candidate candidates =
   |> List.find_map (function
        | None -> None
        | Some raw ->
-         let value = normalize_goal_horizon_text raw in
+         let value = normalize_goal_text raw in
          if value = "" then None else Some value)
 
 let declarative_materialization_goal
@@ -307,8 +307,8 @@ let drift_if label changed =
 
 let goal_horizon_text_equal current target =
   String.equal
-    (normalize_goal_horizon_text current)
-    (normalize_goal_horizon_text target)
+    (normalize_goal_text current)
+    (normalize_goal_text target)
 
 let keeper_meta_persistent_drift_categories
     ~(defaults : Keeper_types_profile.keeper_profile_defaults)
@@ -378,7 +378,7 @@ let ensure_keeper_meta_with_cause config name =
       match defaults.goal with
       | Some goal -> goal
       | None -> (
-          match normalize_goal_horizon_text meta.goal with
+          match normalize_goal_text meta.goal with
           | "" -> (
               match declarative_materialization_goal defaults with
               | Some derived -> derived

--- a/lib/keeper/keeper_status_bridge.ml
+++ b/lib/keeper/keeper_status_bridge.ml
@@ -73,7 +73,7 @@ let live_override_details (meta : keeper_meta) (defaults : keeper_profile_defaul
   []
   |> maybe_string_override
        "prompt.goal"
-       ~normalize:normalize_goal_horizon_text
+       ~normalize:normalize_goal_text
        defaults.goal
        (default_string defaults.goal meta.goal)
   |> maybe_string_override

--- a/lib/keeper/keeper_tool_persona_runtime.ml
+++ b/lib/keeper/keeper_tool_persona_runtime.ml
@@ -326,7 +326,7 @@ let resolved_keeper_args_from_persona args :
           get_string_opt args "goal"
           |> Dashboard_utils.first_some defaults.goal
           |> Option.value ~default:""
-          |> normalize_goal_horizon_text
+          |> normalize_goal_text
         in
         let instructions =
           get_string_opt args "instructions"

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -29,10 +29,10 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
   let now_ts = Time_compat.now () in
   let goal =
     match p.goal_opt with
-    | Some goal -> normalize_goal_horizon_text goal
+    | Some goal -> normalize_goal_text goal
     | None ->
         p.profile_defaults.goal |> Option.value ~default:""
-        |> normalize_goal_horizon_text
+        |> normalize_goal_text
   in
   let autoboot_enabled =
     Dashboard_utils.first_some p.autoboot_enabled_opt p.profile_defaults.autoboot_enabled

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -54,7 +54,7 @@ let update_keeper ?(preserve_prompt_defaults = false)
   in
   let goal =
     match p.goal_opt with
-    | Some g -> normalize_goal_horizon_text g
+    | Some g -> normalize_goal_text g
     | None ->
         if preserve_prompt_defaults then old.goal
         else

--- a/lib/keeper/keeper_types_profile_toml.mli
+++ b/lib/keeper/keeper_types_profile_toml.mli
@@ -11,7 +11,7 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_goal_horizon_max_chars : int
+val default_goal_max_chars : int
 val default_drift_max_clauses : int
 val prompt_render_max_bytes : int
 val bool_default_true_of_env : string -> bool
@@ -33,7 +33,7 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_self_model_text : max_bytes:int -> string -> string
-val normalize_goal_horizon_text : ?max_len:int -> string -> string
+val normalize_goal_text : ?max_len:int -> string -> string
 val split_semicolon_clauses : string -> string list
 val take_last : int -> 'a list -> 'a list
 val compact_self_model_text :

--- a/lib/keeper/keeper_types_profile_toml_io.mli
+++ b/lib/keeper/keeper_types_profile_toml_io.mli
@@ -11,7 +11,7 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_goal_horizon_max_chars : int
+val default_goal_max_chars : int
 val default_drift_max_clauses : int
 val prompt_render_max_bytes : int
 val bool_default_true_of_env : string -> bool
@@ -33,7 +33,7 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_self_model_text : max_bytes:int -> string -> string
-val normalize_goal_horizon_text : ?max_len:int -> string -> string
+val normalize_goal_text : ?max_len:int -> string -> string
 val split_semicolon_clauses : string -> string list
 val take_last : int -> 'a list -> 'a list
 val compact_self_model_text :

--- a/lib/keeper/keeper_types_profile_toml_normalizers.mli
+++ b/lib/keeper/keeper_types_profile_toml_normalizers.mli
@@ -11,7 +11,7 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_goal_horizon_max_chars : int
+val default_goal_max_chars : int
 val default_drift_max_clauses : int
 val prompt_render_max_bytes : int
 val bool_default_true_of_env : string -> bool
@@ -33,7 +33,7 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_self_model_text : max_bytes:int -> string -> string
-val normalize_goal_horizon_text : ?max_len:int -> string -> string
+val normalize_goal_text : ?max_len:int -> string -> string
 val split_semicolon_clauses : string -> string list
 val take_last : int -> 'a list -> 'a list
 val compact_self_model_text :

--- a/lib/keeper/keeper_types_profile_toml_parser.mli
+++ b/lib/keeper/keeper_types_profile_toml_parser.mli
@@ -11,7 +11,7 @@ val default_proactive_enabled : bool
 val default_proactive_idle_sec : int
 val default_proactive_cooldown_sec : int
 val approval_queue_stale_max_wait_sec : float
-val default_goal_horizon_max_chars : int
+val default_goal_max_chars : int
 val default_drift_max_clauses : int
 val prompt_render_max_bytes : int
 val bool_default_true_of_env : string -> bool
@@ -33,7 +33,7 @@ val reject_removed_keeper_msg_input_keys :
   tool_name:string -> Yojson.Safe.t -> (unit, string) result
 val utf8_repair_string : string -> string
 val normalize_self_model_text : max_bytes:int -> string -> string
-val normalize_goal_horizon_text : ?max_len:int -> string -> string
+val normalize_goal_text : ?max_len:int -> string -> string
 val split_semicolon_clauses : string -> string list
 val take_last : int -> 'a list -> 'a list
 val compact_self_model_text :


### PR DESCRIPTION
## 목적

RFC-0288 (#22162)로 goal-horizon 3-필드(`short/mid/long_goal`)를 숙청한 뒤, 살아남은 단일 `goal` 필드를 정규화하는 헬퍼는 그대로 두었습니다. 이름의 `_horizon_`은 이제 **historical wart** — horizon은 사라졌고 이 심볼은 `goal` 하나만 trim + UTF-8 byte-cap합니다. RFC-0288 §9가 의도적으로 미룬 rename을 마무리합니다.

## 변경

순수 rename, 동작 변화 없음:

| Before | After |
|--------|-------|
| `normalize_goal_horizon_text` | `normalize_goal_text` |
| `default_goal_horizon_max_chars` | `default_goal_max_chars` |
| `MASC_KEEPER_GOAL_HORIZON_MAX_CHARS` | `MASC_KEEPER_GOAL_MAX_CHARS` |

15개 파일: 정의 1 + 재노출 `.mli` 6 (include 체인) + 호출부 12. diff는 +27/−27 (1:1 치환).

## operator-compat 노트

env var rename은 **breaking이지만 영향 negligible**: 구 이름 `MASC_KEEPER_GOAL_HORIZON_MAX_CHARS`는 모든 런타임 config·shell에서 **unset** 확인(`rg` + `printenv`). 의존하는 곳 0건. 만약 goal 텍스트 길이 cap 용도로 설정했다면 새 이름으로 교체 필요.

## 검증

- old 심볼 잔여: `rg` 전수 **0건**
- new 심볼 카운트: `normalize_goal_text` 19 / `default_goal_max_chars` 8 / `MASC_KEEPER_GOAL_MAX_CHARS` 1 — 인벤토리와 정확히 일치
- 완전성은 구성적 보장(rg가 qualified 참조 포함 모든 소스 텍스트 검색); 누락 시 CI 컴파일이 fail
- 빌드는 CI Build and Test에 위임

RFC: RFC-0288 §9 (deferred rename follow-up). 워크어라운드 시그니처 해당 없음(pure rename).

## Coverage 게이트 opt-out

`# ci:skip-test-coverage`

pure rename(동작 변화 0)이라 새 test 파일이 불필요합니다. renamed 헬퍼가 감싸는 byte-cap 알고리즘(`String_util.utf8_prefix`)은 sibling `normalize_self_model_text`를 통해 `test_keeper_profile_normalize_10552`에서 이미 커버됩니다 — `normalize_goal_text` 전용 테스트는 같은 알고리즘 재검증(theater)에 그칩니다. rename 완전성은 CI 빌드의 컴파일러가 강제(old-name 잔여 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
