### PR TITLE
refactor(provider): unify http_error_message into Provider_http_error

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -359,25 +359,8 @@ let messages_for_librarian (inp : Keeper_librarian.input) =
          ])
 ;;
 
-let http_error_message (err : Llm_provider.Http_client.http_error) =
-  match err with
-  | Llm_provider.Http_client.NetworkError { message; _ } -> message
-  | Llm_provider.Http_client.TimeoutError { message; phase } ->
-    Printf.sprintf
-      "provider timeout: %s: %s"
-      (Llm_provider.Http_client.timeout_phase_to_label phase)
-      message
-  | Llm_provider.Http_client.AcceptRejected { reason } -> reason
-  | Llm_provider.Http_client.ProviderTerminal { kind = _; message } ->
-    Printf.sprintf "provider terminal: %s" message
-  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
-    Llm_provider.Http_client.provider_failure_to_string ~kind ~message
-  | Llm_provider.Http_client.HttpError { code; body } ->
-    Printf.sprintf
-      "HTTP %d: %s"
-      code
-      (if String.length body > 200 then String.sub body 0 200 ^ "..." else body)
-;;
+(* http_error_message moved to Provider_http_error.to_message (SSOT,
+   2026-06-24): four byte-for-output-identical copies unified. *)
 
 let with_timeout ?clock ~timeout_sec f =
   match clock with
@@ -485,7 +468,7 @@ let extract_with_provider
           complete ~sw ~net ?clock ~config:provider_cfg ~messages ())
       with
       | None -> Transport_failed "librarian provider timed out"
-      | Some (Error err) -> Transport_failed (http_error_message err)
+      | Some (Error err) -> Transport_failed (Provider_http_error.to_message err)
       | Some (Ok response) ->
         let raw = Agent_sdk_response.text_of_response response |> String.trim in
         if String.equal raw ""

--- a/lib/keeper/keeper_memory_llm_summary.ml
+++ b/lib/keeper/keeper_memory_llm_summary.ml
@@ -5,20 +5,8 @@
     the domain prompt, opt-in gate, provider choice, and fallback semantics. *)
 
 
-let http_error_message (err : Llm_provider.Http_client.http_error) =
-  match err with
-  | Llm_provider.Http_client.NetworkError { message; _ } -> message
-  | Llm_provider.Http_client.TimeoutError { message; phase } ->
-      Printf.sprintf "provider timeout: %s: %s"
-        (Llm_provider.Http_client.timeout_phase_to_label phase) message
-  | Llm_provider.Http_client.AcceptRejected { reason } -> reason
-  | Llm_provider.Http_client.ProviderTerminal { kind; message } ->
-      Printf.sprintf "provider terminal: %s" message
-  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
-      Llm_provider.Http_client.provider_failure_to_string ~kind ~message
-  | Llm_provider.Http_client.HttpError { code; body } ->
-      Printf.sprintf "HTTP %d: %s" code
-        (if String.length body > 200 then String.sub body 0 200 ^ "..." else body)
+(* http_error_message moved to Provider_http_error.to_message (SSOT,
+   2026-06-24): four byte-for-output-identical copies unified. *)
 let summary_max_tokens = 512
 
 (* Observability for [summarize_with_provider] outcomes and
@@ -176,7 +164,7 @@ let summarize_with_provider
     | Some (Error err) ->
         Log.Keeper.warn
           "memory LLM summary failed trace_id=%s provider=%s: %s"
-          trace_id provider_cfg.model_id (http_error_message err);
+          trace_id provider_cfg.model_id (Provider_http_error.to_message err);
         None, Keeper_memory_llm_summary_outcome.Http_error
   in
   record_summary_outcome ~runtime_id ~provider_cfg ~outcome;

--- a/lib/provider_http_error.ml
+++ b/lib/provider_http_error.ml
@@ -9,6 +9,9 @@
     field, the others bound it unused). Centralising removes the drift
     surface. *)
 
+let max_body_length = 200
+let body_truncation_suffix = "..."
+
 let to_message (err : Llm_provider.Http_client.http_error) : string =
   match err with
   | Llm_provider.Http_client.NetworkError { message; _ } -> message
@@ -22,4 +25,6 @@ let to_message (err : Llm_provider.Http_client.http_error) : string =
       Llm_provider.Http_client.provider_failure_to_string ~kind ~message
   | Llm_provider.Http_client.HttpError { code; body } ->
       Printf.sprintf "HTTP %d: %s" code
-        (if String.length body > 200 then String.sub body 0 200 ^ "..." else body)
+        (if String.length body > max_body_length
+         then String.sub body 0 max_body_length ^ body_truncation_suffix
+         else body)

--- a/lib/provider_http_error.ml
+++ b/lib/provider_http_error.ml
@@ -1,0 +1,25 @@
+(** Single source of truth for rendering an
+    [Llm_provider.Http_client.http_error] to a one-line human-readable
+    message.
+
+    Four MASC consumers (tool verify/bench runtimes, keeper
+    librarian/memory-summary runtimes) previously each kept a
+    byte-for-output-identical copy of this match; the copies had begun to
+    drift in incidental detail (one discarded the [ProviderTerminal.kind]
+    field, the others bound it unused). Centralising removes the drift
+    surface. *)
+
+let to_message (err : Llm_provider.Http_client.http_error) : string =
+  match err with
+  | Llm_provider.Http_client.NetworkError { message; _ } -> message
+  | Llm_provider.Http_client.TimeoutError { message; phase } ->
+      Printf.sprintf "provider timeout: %s: %s"
+        (Llm_provider.Http_client.timeout_phase_to_label phase) message
+  | Llm_provider.Http_client.AcceptRejected { reason } -> reason
+  | Llm_provider.Http_client.ProviderTerminal { kind = _; message } ->
+      Printf.sprintf "provider terminal: %s" message
+  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
+      Llm_provider.Http_client.provider_failure_to_string ~kind ~message
+  | Llm_provider.Http_client.HttpError { code; body } ->
+      Printf.sprintf "HTTP %d: %s" code
+        (if String.length body > 200 then String.sub body 0 200 ^ "..." else body)

--- a/lib/provider_http_error.mli
+++ b/lib/provider_http_error.mli
@@ -2,6 +2,13 @@
     [Llm_provider.Http_client.http_error] to a human-readable message,
     shared by the tool runtime and keeper runtime consumers. *)
 
+val max_body_length : int
+(** Maximum number of bytes kept from an HTTP error body before truncation. *)
+
+val body_truncation_suffix : string
+(** Suffix appended to an HTTP error body that has been truncated. *)
+
 val to_message : Llm_provider.Http_client.http_error -> string
 (** One-line human-readable message for an HTTP/provider error. HTTP
-    bodies are truncated to 200 bytes with a trailing ellipsis. *)
+    bodies are truncated to {!max_body_length} bytes with a trailing
+    {!body_truncation_suffix}. *)

--- a/lib/provider_http_error.mli
+++ b/lib/provider_http_error.mli
@@ -1,0 +1,7 @@
+(** Single source of truth for rendering an
+    [Llm_provider.Http_client.http_error] to a human-readable message,
+    shared by the tool runtime and keeper runtime consumers. *)
+
+val to_message : Llm_provider.Http_client.http_error -> string
+(** One-line human-readable message for an HTTP/provider error. HTTP
+    bodies are truncated to 200 bytes with a trailing ellipsis. *)

--- a/lib/tool_local_runtime_bench.ml
+++ b/lib/tool_local_runtime_bench.ml
@@ -21,20 +21,8 @@ include Tool_local_runtime_http
 module Oas_types = Agent_sdk.Types
 
 
-let http_error_message (err : Llm_provider.Http_client.http_error) =
-  match err with
-  | Llm_provider.Http_client.NetworkError { message; _ } -> message
-  | Llm_provider.Http_client.TimeoutError { message; phase } ->
-      Printf.sprintf "provider timeout: %s: %s"
-        (Llm_provider.Http_client.timeout_phase_to_label phase) message
-  | Llm_provider.Http_client.AcceptRejected { reason } -> reason
-  | Llm_provider.Http_client.ProviderTerminal { kind; message } ->
-      Printf.sprintf "provider terminal: %s" message
-  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
-      Llm_provider.Http_client.provider_failure_to_string ~kind ~message
-  | Llm_provider.Http_client.HttpError { code; body } ->
-      Printf.sprintf "HTTP %d: %s" code
-        (if String.length body > 200 then String.sub body 0 200 ^ "..." else body)
+(* http_error_message moved to Provider_http_error.to_message (SSOT,
+   2026-06-24): four byte-for-output-identical copies unified. *)
 let pctl percentile values =
   match values with
   | [] -> None
@@ -48,7 +36,7 @@ let pctl percentile values =
       in
       List.nth_opt sorted index
 
-let error_message_of_http_error = http_error_message
+let error_message_of_http_error = Provider_http_error.to_message
 
 let per_runtime_breakdown_to_yojson counts =
   counts

--- a/lib/tool_local_runtime_verify.ml
+++ b/lib/tool_local_runtime_verify.ml
@@ -20,20 +20,8 @@ module Float = Stdlib.Float
 module Oas_types = Agent_sdk.Types
 
 
-let http_error_message (err : Llm_provider.Http_client.http_error) =
-  match err with
-  | Llm_provider.Http_client.NetworkError { message; _ } -> message
-  | Llm_provider.Http_client.TimeoutError { message; phase } ->
-      Printf.sprintf "provider timeout: %s: %s"
-        (Llm_provider.Http_client.timeout_phase_to_label phase) message
-  | Llm_provider.Http_client.AcceptRejected { reason } -> reason
-  | Llm_provider.Http_client.ProviderTerminal { kind; message } ->
-      Printf.sprintf "provider terminal: %s" message
-  | Llm_provider.Http_client.ProviderFailure { kind; message } ->
-      Llm_provider.Http_client.provider_failure_to_string ~kind ~message
-  | Llm_provider.Http_client.HttpError { code; body } ->
-      Printf.sprintf "HTTP %d: %s" code
-        (if String.length body > 200 then String.sub body 0 200 ^ "..." else body)
+(* http_error_message moved to Provider_http_error.to_message (SSOT,
+   2026-06-24): four byte-for-output-identical copies unified. *)
 let safe_discovery_endpoints () =
   try Some (Discovery_cache.get_cached_or_refresh ())
   with
@@ -89,7 +77,7 @@ let first_endpoint_url endpoints =
   | (endpoint : Discovery_cache.endpoint_info) :: _ -> Some endpoint.url
   | [] -> None
 
-let error_message_of_http_error = http_error_message
+let error_message_of_http_error = Provider_http_error.to_message
 
 (** Probe whether an endpoint supports the OpenAI chat-completions protocol.
     This is a protocol-level probe; it explicitly depends on OAS

--- a/test/dune
+++ b/test/dune
@@ -58,6 +58,7 @@
   test_dashboard_oas_bridge
   test_masc_runtime_events
   test_cancel_wall_bucket
+  test_provider_http_error
   test_workspace
   test_workspace_state_recovery
   test_exec_tap
@@ -364,6 +365,7 @@
   test_dashboard_oas_bridge
   test_masc_runtime_events
   test_cancel_wall_bucket
+  test_provider_http_error
   test_workspace
   test_workspace_state_recovery
   test_exec_tap

--- a/test/test_provider_http_error.ml
+++ b/test/test_provider_http_error.ml
@@ -5,6 +5,11 @@
     the nested [network_error_kind] / [timeout_phase] / [provider_*_kind]
     types. *)
 
+(* [masc] is a wrapped library, so reach the new module through its
+   namespace (the same pattern existing tests use, e.g. [Masc.Auth]).
+   [Llm_provider] comes from agent_sdk.llm_provider and is bound directly. *)
+module Provider_http_error = Masc.Provider_http_error
+
 let msg = Alcotest.(check string)
 
 let test_simple_variants () =

--- a/test/test_provider_http_error.ml
+++ b/test/test_provider_http_error.ml
@@ -1,0 +1,34 @@
+(** Drift-guard for [Provider_http_error.to_message] — pins the rendering
+    for the simple variants and the 200-byte HTTP body truncation that the
+    four former copies shared. Uses only the field-only variants
+    ([AcceptRejected], [HttpError]) so the test carries no dependency on
+    the nested [network_error_kind] / [timeout_phase] / [provider_*_kind]
+    types. *)
+
+let msg = Alcotest.(check string)
+
+let test_simple_variants () =
+  msg "AcceptRejected -> reason verbatim" "no transport injected"
+    (Provider_http_error.to_message
+       (Llm_provider.Http_client.AcceptRejected
+          { reason = "no transport injected" }));
+  msg "HttpError short body -> HTTP code: body" "HTTP 503: upstream down"
+    (Provider_http_error.to_message
+       (Llm_provider.Http_client.HttpError
+          { code = 503; body = "upstream down" }))
+
+let test_http_body_truncation () =
+  let body = String.make 250 'x' in
+  let expected = "HTTP 500: " ^ String.make 200 'x' ^ "..." in
+  msg "HTTP body > 200 bytes truncated with ellipsis" expected
+    (Provider_http_error.to_message
+       (Llm_provider.Http_client.HttpError { code = 500; body }))
+
+let () =
+  Alcotest.run "provider_http_error"
+    [ ( "to_message"
+      , [ Alcotest.test_case "simple variants" `Quick test_simple_variants
+        ; Alcotest.test_case "200-byte body truncation" `Quick
+            test_http_body_truncation
+        ] )
+    ]

--- a/test/test_provider_http_error.ml
+++ b/test/test_provider_http_error.ml
@@ -23,9 +23,13 @@ let test_simple_variants () =
           { code = 503; body = "upstream down" }))
 
 let test_http_body_truncation () =
-  let body = String.make 250 'x' in
-  let expected = "HTTP 500: " ^ String.make 200 'x' ^ "..." in
-  msg "HTTP body > 200 bytes truncated with ellipsis" expected
+  let body = String.make (Provider_http_error.max_body_length + 50) 'x' in
+  let expected =
+    "HTTP 500: "
+    ^ String.make Provider_http_error.max_body_length 'x'
+    ^ Provider_http_error.body_truncation_suffix
+  in
+  msg "HTTP body > max_body_length truncated with ellipsis" expected
     (Provider_http_error.to_message
        (Llm_provider.Http_client.HttpError { code = 500; body }))
 


### PR DESCRIPTION
## 배경

`~/me/reports/masc-ssot-audit-2026-06-23.html` 감사의 `http-error-message-4x` finding을 적대적으로 검증했습니다.

`Llm_provider.Http_client.http_error`를 사람이 읽는 문자열로 렌더링하는 `http_error_message`가 4개 파일에 사본으로 존재합니다:
- `lib/tool_local_runtime_verify.ml`
- `lib/tool_local_runtime_bench.ml`
- `lib/keeper/keeper_librarian_runtime.ml`
- `lib/keeper/keeper_memory_llm_summary.ml`

4개 본문은 동일 출력을 내지만 이미 incidental 드리프트가 시작됐습니다: librarian은 `ProviderTerminal { kind = _; message }`로 `kind`를 버리고, 나머지 3개는 `{ kind; message }`로 바인딩(미사용). 한쪽만 고치면 나머지가 조용히 누락됩니다.

> 보고서 정정: `provider_failure_to_string`는 무시되지 않습니다. 중복은 `ProviderFailure` arm을 포함한 **전체 variant wrapper**입니다.

## 변경

`lib/provider_http_error.ml`(+ `.mli`)에 단일 `to_message`를 두고, 4개 소비자를 이를 참조하도록 변경했습니다.
- verify/bench의 `error_message_of_http_error` 별칭 → `Provider_http_error.to_message`로 forward.
- librarian(`:471`)·memory_llm_summary(`:167`) 직접 호출 → `Provider_http_error.to_message err`.
- canonical 본문은 `ProviderTerminal { kind = _; message }`(미사용 필드 명시적 discard) 채택.

## 검증 (적대적, read-only)

- 4개 파일 모두 `masc` 단일 라이브러리 소속 확인: `lib/dune`는 `(include_subdirs unqualified)`, `lib/keeper/`에 dune 없음, `(modules ...)` allowlist 없음 → 새 .ml/.mli가 자동 발견·포함, **신규 cross-lib edge 없음**.
- `masc`는 이미 `llm_provider` 의존(4개 소비자가 `Llm_provider.Http_client` 사용) → 새 모듈 컴파일 가능.
- 4개 본문이 arm·출력 동일함을 직접 대조(차이는 `kind` 바인딩·포매팅뿐, `.ocamlformat disable=true`라 무관).
- 모듈명 `provider_http_error` 충돌 없음. 4개 파일 .mli 어느 것도 `http_error_message`를 노출하지 않음 → 외부 계약 무변경.
- 잔존 `http_error_message`는 breadcrumb 주석뿐, 사용처 4곳 전부 repoint 확인.

## 미검증 (CI 위임)

- 로컬 dune 빌드 미수행(정책). 컴파일·테스트는 CI에서 검증.
- `.ocamlformat`은 `disable = true`(RFC-0010)라 포맷 검사 영향 없음.

RFC-WAIVED: 비-gated subsystem. `keeper_librarian_runtime`/`keeper_memory_llm_summary`는 credential/gh/host_config/sandbox/shell 가 아니며 operator/dashboard/hooks/workflow 무관. SSOT 통일이라 신규 RFC 불필요.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
