### PR TITLE
test(dashboard): run code-blocks tests under jsdom (#22159 regression)

### DIFF
--- a/dashboard/src/components/chat/code-blocks.test.ts
+++ b/dashboard/src/components/chat/code-blocks.test.ts
@@ -1,3 +1,9 @@
+// @vitest-environment jsdom
+// ChatMermaidBlock renders mermaid via DOMPurify + a viewport-gated render
+// (useMermaidInView). Under happy-dom DOMPurify fails its support check and
+// IntersectionObserver never fires, so the diagram stays a placeholder. jsdom
+// (no IntersectionObserver -> immediate render, DOMPurify supported) exercises
+// the real render path, matching markdown-renderer.test.ts / dompurify.test.ts.
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'


### PR DESCRIPTION
## 무엇을 / 왜

main이 현재 RED입니다. 유일한 required check인 `CI Gate`가 `DASHBOARD_RESULT: failure`로 막혀 **모든 PR이 머지 불가** 상태입니다.

근본 원인: #22159(`perf(dashboard): deduplicate mermaid rendering …`)가 `ChatMermaidBlock`(primitives.ts)에 viewport-gated 렌더(`useMermaidInView`)와 명시적 DOMPurify 패스를 추가했지만, 그 동작을 검증하는 `code-blocks.test.ts`(3일 전 #21864 이후 변경 없음)는 **happy-dom 기본 환경**에서 돕니다. happy-dom에서는:

- `IntersectionObserver`가 정의돼 있으나 발화하지 않아 다이어그램이 "다이어그램 (스크롤 시 렌더링)" placeholder로 영구 유지되고,
- DOMPurify가 support check에 실패해 sanitize가 fallback(escape)으로 떨어집니다.

그 결과 2개 테스트가 실패합니다(`renders a mermaid block as SVG`, `falls back to a code block when mermaid rendering errors`).

## 변경

`code-blocks.test.ts`를 `@vitest-environment jsdom`으로 고정. jsdom에서는 `IntersectionObserver`가 `undefined`라 `useMermaidInView`가 즉시 렌더하고, DOMPurify도 정상 동작하여 실제 렌더 경로를 검증합니다. 이는 `markdown-renderer.test.ts`, `dompurify.test.ts`가 이미 쓰는 패턴과 동일합니다.

**테스트 전용, 프로덕션 코드 변경 없음.** 프로덕션(실제 브라우저)에서는 IO가 정상 발화하므로 #22159의 동작 자체는 문제없습니다 — 결함은 테스트 환경 정합성에만 있었습니다.

## 검증

- `pnpm vitest run … code-blocks.test.ts`: 5/5 pass (이전 2 fail → 0)
- `pnpm lint`: pass

## RFC

해당 없음 — `code-blocks.test.ts`(테스트 파일)는 RFC 게이트 대상 subsystem이 아닙니다.

WORKAROUND-WAIVED: workaround-gate가 "fallback" 문구로 SYMPTOM_SUPPRESSION을 매칭했으나 false positive. 이 변경은 증상 억제가 아니라 테스트 환경 정합성 수정으로, 테스트가 happy-dom의 inert IntersectionObserver/미지원 DOMPurify 대신 실제 렌더 경로(jsdom)를 검증하게 만든다. 프로덕션 코드/동작 변경 0, cap/cooldown/telemetry/string-classifier 패턴 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
