### PR TITLE
refactor(worker): name worker top_p/top_k sampling constants

### DIFF
--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -30,6 +30,14 @@ let oas_model_of_effective_model (model_id : string) : string = model_id
 
 let worker_max_turns_cap = 20
 
+(* Worker sampling overrides. The [worker_default] inference profile leaves
+   top_p/top_k unset (None); these are worker_oas's own fixed sampling
+   choice, applied at both the agent_config record and the Builder below.
+   Named here so the two send sites cannot drift (CLAUDE.md magic-number
+   rule). See also the min_p note in [agent_config_of_worker_meta]. *)
+let worker_top_p = 0.95
+let worker_top_k = 40
+
 (** Derive max_turns from worker meta timeout budget.
     Worker runtime no longer stores a separate max_turns contract. *)
 let effective_max_turns (meta : Worker_container_types.worker_container_meta) : int =
@@ -56,8 +64,8 @@ let agent_config_of_worker_meta
   ; max_tokens = Some max_tokens
   ; max_turns = effective_max_turns meta
   ; temperature = Some Runtime_provider_defaults.worker_default_temperature
-  ; top_p = Some 0.95
-  ; top_k = Some 40
+  ; top_p = Some worker_top_p
+  ; top_k = Some worker_top_k
   ; (* min_p intentionally omitted: the constant is 0.0 (no-op) and some
        cloud providers (Groq, GLM) reject the field itself with
        "Invalid request: property 'min_p' is unsupported". OAS capability
@@ -172,8 +180,8 @@ let build_agent
     | None -> b)
     |> Agent_sdk.Builder.with_max_turns config.max_turns
     |> Agent_sdk.Builder.with_temperature Runtime_provider_defaults.worker_default_temperature
-    |> Agent_sdk.Builder.with_top_p 0.95
-    |> Agent_sdk.Builder.with_top_k 40
+    |> Agent_sdk.Builder.with_top_p worker_top_p
+    |> Agent_sdk.Builder.with_top_k worker_top_k
     (* with_min_p intentionally omitted — see agent_config_of_worker_meta
        above for the reason. min_p of 0.0 is a no-op and cloud providers
        (Groq, GLM) reject the field itself. *)


### PR DESCRIPTION
## 배경

`~/me/reports/masc-ssot-audit-2026-06-23.html` 감사 `worker-agent-config-builder-dup` finding의 **안전한 부분만** 적용합니다. (보고서/synthesis의 "두 빌더를 `of_meta` 하나로 병합"은 resume 경로의 checkpoint-model 우선순위를 깨므로 **기각**.)

`worker_oas.ml`은 `top_p = 0.95`, `top_k = 40`을 bare 리터럴로 **각각 2곳**(agent_config 레코드 + Builder 체인)에 박아둡니다. 한쪽만 바꾸면 두 send-site가 드리프트합니다.

## 변경

`worker_top_p` / `worker_top_k` named 상수로 lift, 4개 send-site가 이를 참조. `worker_default_temperature`가 이미 named 값인 것과 일관성.

- **동작 무변경**: 같은 값, 같은 2개 send-site.
- `top_p`/`top_k`는 worker_oas 자체의 샘플링 선택으로 유지 — `Runtime_provider_defaults`(profile 투영)로 옮기지 **않음**(아래 관찰 참고).

## 관찰 (별도 판단 필요, 본 PR 범위 밖)

`Llm_provider.Constants.Inference_profile.worker_default`는 `temperature=0.2`만 정의하고 `top_p=None; top_k=None`(샘플링 미오버라이드)으로 둡니다. `Runtime_provider_defaults.worker_default_temperature`는 이 profile에서 temperature를 투영하지만, worker_oas는 top_p/top_k를 profile 대신 0.95/40으로 **하드코딩 오버라이드**합니다.

이것이 의도된 layering(profile=temperature 소유, worker_oas=sampling 소유)인지, 아니면 profile-None을 따라야 하는 드리프트인지는 **동작 결정**이라 본 PR에서 다루지 않았습니다. 본 리팩터는 어느 해석에서도 옳습니다(리터럴 중복 제거, 값 보존). 의도 확정 시 후속 정리 가능.

## 검증 (적대적, read-only)

- 4개 리터럴 사이트(레코드 67-68, Builder 183-184) 전부 상수 참조로 교체, bare 0.95/40 잔존 0.
- `worker_top_p`/`worker_top_k`는 4곳에서 사용 → `-warn-error +a` 환경에서도 unused 경고 없음.
- 단일 파일, 신규 의존성·cross-lib edge 없음.

## 미검증 (CI 위임)

- 로컬 dune 빌드 미수행(정책). 컴파일은 CI에서 검증.
- `.ocamlformat`은 `disable = true`(RFC-0010)라 포맷 검사 영향 없음.

# ci:skip-test-coverage
커버리지 opt-out 사유: 순수 magic-number 추출(새 로직·동작변경 없음). 의미있는 단위 테스트가 없음(`worker_top_p = 0.95` 검증은 순환적). 중복 제거 자체가 단일 진실을 보장.

RFC-WAIVED: 비-gated subsystem(`lib/worker_oas.ml`). credential/identity/operator/sandbox/hooks/workflow 무관.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
