### PR TITLE
feat(ci): flag the same RFC number claimed by two open PRs

### DIFF
--- a/.github/workflows/pr-axis-check.yml
+++ b/.github/workflows/pr-axis-check.yml
@@ -39,3 +39,14 @@ jobs:
             PR_NUM=${{ inputs.pr_number }}
           fi
           python scripts/pr_axis_check.py --pr "$PR_NUM" --hours 24 --limit 20
+
+      - name: RFC collision detector self-test
+        if: always()
+        run: python scripts/pr_axis_check.py --self-test
+
+      - name: Check RFC number collisions across open PRs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python scripts/pr_axis_check.py --check-rfc-collisions

--- a/scripts/pr_axis_check.py
+++ b/scripts/pr_axis_check.py
@@ -17,6 +17,7 @@ Exit codes:
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -42,6 +43,27 @@ class AxisRisk:
         return (
             f"| #{self.merged_pr} | `{self.risk_type}` | {files_str} | {self.confidence} |"
         )
+
+
+# --- RFC number cross-open-PR collision detection ---------------------------
+# rfc_enforcer.py (--check-numbering) only compares a PR against origin/main and
+# the PR's own diff, so two *open* PRs that each add the same new RFC-NNNN both
+# pass that gate; they only conflict after one side merges (the RFC-0078 ledger
+# race). When stale-green PRs auto-merge without re-validating against the other,
+# a duplicate number can land on main. This sideways check scans concurrent open
+# PRs for the same newly-added RFC number, before either merges.
+_RFC_CLAIM_RE = re.compile(r"(?:^|/)docs/rfc/RFC-(\d{4})-[A-Za-z0-9._-]+\.md$")
+
+
+@dataclass(frozen=True)
+class RfcCollision:
+    rfc_number: str
+    # Sorted ((pr_number, claiming_file_path), ...) for the colliding PRs.
+    prs: Tuple[Tuple[int, str], ...]
+
+    def describe(self) -> str:
+        claimants = ", ".join(f"#{n} ({path})" for n, path in self.prs)
+        return f"RFC-{self.rfc_number}: claimed by {claimants}"
 
 
 def _run_gh(args: List[str]) -> Any:
@@ -356,6 +378,127 @@ query {{
     return results
 
 
+def detect_rfc_collisions(open_prs: List[Dict[str, Any]]) -> List[RfcCollision]:
+    """Find RFC numbers newly claimed by two or more open PRs.
+
+    Pure over its inputs so the self-test can feed synthetic PRs. Each entry in
+    ``open_prs`` is ``{"number": int, "added_rfc_files": [path, ...]}`` where the
+    paths are RFC files ADDED (not modified) by that PR. A number claimed by a
+    single PR — even across multiple files (multi-phase) — is not a collision;
+    only the same new number across distinct PRs is.
+    """
+    by_number: Dict[str, List[Tuple[int, str]]] = {}
+    for pr in open_prs:
+        number_seen: Set[str] = set()
+        for path in pr.get("added_rfc_files", []):
+            match = _RFC_CLAIM_RE.search(path)
+            if match is None:
+                continue
+            number = match.group(1)
+            if number in number_seen:
+                continue  # same PR claiming one number across files — one claim
+            number_seen.add(number)
+            by_number.setdefault(number, []).append((int(pr["number"]), path))
+
+    collisions: List[RfcCollision] = []
+    for number, claims in sorted(by_number.items()):
+        distinct_prs = {pr_num for pr_num, _ in claims}
+        if len(distinct_prs) >= 2:
+            collisions.append(RfcCollision(number, tuple(sorted(claims))))
+    return collisions
+
+
+def get_open_prs_with_added_rfc_files(
+    owner: str, repo: str
+) -> List[Dict[str, Any]]:
+    """Fetch open PRs and the RFC files each one ADDS (GraphQL changeType)."""
+    query = f"""
+query {{
+  repository(owner: "{owner}", name: "{repo}") {{
+    pullRequests(states: OPEN, first: 50) {{
+      nodes {{
+        number
+        title
+        files(first: 100) {{
+          nodes {{ path changeType }}
+        }}
+      }}
+    }}
+  }}
+}}
+"""
+    data = _run_gh_graphql(query)
+    nodes = (
+        data.get("data", {})
+        .get("repository", {})
+        .get("pullRequests", {})
+        .get("nodes", [])
+    )
+    result: List[Dict[str, Any]] = []
+    for pr in nodes:
+        file_nodes = (pr.get("files") or {}).get("nodes") or []
+        added = [
+            f["path"]
+            for f in file_nodes
+            if f.get("changeType") == "ADDED"
+            and _RFC_CLAIM_RE.search(f.get("path", ""))
+        ]
+        if added:
+            result.append(
+                {
+                    "number": pr["number"],
+                    "title": pr.get("title", ""),
+                    "added_rfc_files": added,
+                }
+            )
+    return result
+
+
+def self_test() -> int:
+    """Fixture-based check of detect_rfc_collisions (clean + colliding cases)."""
+    clean = [
+        {"number": 1, "added_rfc_files": ["docs/rfc/RFC-0289-foo.md"]},
+        {"number": 2, "added_rfc_files": ["docs/rfc/RFC-0290-bar.md"]},
+    ]
+    assert detect_rfc_collisions(clean) == [], "distinct numbers must not collide"
+    print("self-test: distinct RFC numbers -> no collision (PASS)")
+
+    buggy = [
+        {
+            "number": 22158,
+            "added_rfc_files": ["docs/rfc/RFC-0289-keeper-progress-lib-split.md"],
+        },
+        {
+            "number": 22144,
+            "added_rfc_files": ["docs/rfc/RFC-0289-closed-sse-event-type-sum.md"],
+        },
+    ]
+    collisions = detect_rfc_collisions(buggy)
+    assert len(collisions) == 1, f"expected 1 collision, got {len(collisions)}"
+    assert collisions[0].rfc_number == "0289"
+    assert {n for n, _ in collisions[0].prs} == {22144, 22158}
+    print(f"self-test: two open PRs claim RFC-0289 -> {collisions[0].describe()} (PASS)")
+
+    multiphase = [
+        {
+            "number": 30,
+            "added_rfc_files": ["docs/rfc/RFC-0300-a.md", "docs/rfc/RFC-0300-b.md"],
+        },
+    ]
+    assert detect_rfc_collisions(multiphase) == [], "single PR multi-file is not a collision"
+    print("self-test: single PR, one number across files -> no collision (PASS)")
+
+    noise = [
+        {"number": 40, "added_rfc_files": ["docs/rfc/README.md", "src/RFC-0289-x.txt"]},
+        {"number": 41, "added_rfc_files": ["docs/rfc/RFC-0289-real.md"]},
+    ]
+    assert detect_rfc_collisions(noise) == [], "non-RFC-claim paths must not collide"
+    print("self-test: non-RFC paths ignored -> no collision (PASS)")
+
+    print("pr_axis_check self-test: all RFC-collision cases passed")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="PR Axis Cross-Check")
     parser.add_argument("--pr", type=int, help="PR number to check")
@@ -363,9 +506,38 @@ def main() -> int:
     parser.add_argument("--hours", type=int, default=24, help="Lookback window in hours")
     parser.add_argument("--limit", type=int, default=20, help="Max recent merged PRs to check")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument(
+        "--check-rfc-collisions",
+        action="store_true",
+        help="Scan all open PRs for the same newly-claimed RFC number",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run fixture-based self-test of RFC collision detection",
+    )
     args = parser.parse_args()
 
+    if args.self_test:
+        return self_test()
+
     owner, repo = get_repo_slug()
+
+    if args.check_rfc_collisions:
+        open_prs = get_open_prs_with_added_rfc_files(owner, repo)
+        collisions = detect_rfc_collisions(open_prs)
+        if collisions:
+            print("RFC number collisions among open PRs:\n")
+            for collision in collisions:
+                print(f"  - {collision.describe()}")
+            print(
+                "\nTwo open PRs cannot both claim the same RFC number. One must "
+                "renumber via scripts/rfc-allocate-next.sh (rewrites the file, "
+                "title, references, and docs/rfc/.next-number). See RFC-0078."
+            )
+            return 1
+        print("No RFC number collisions among open PRs.")
+        return 0
 
     def _block(r: AxisRisk) -> bool:
         return r.confidence != "LOW"


### PR DESCRIPTION
## Problem

`rfc_enforcer.py --check-numbering` compares a PR against `origin/main` and the PR's own diff only. It does **not** look at other open PRs. So two open PRs that each add the same new `RFC-NNNN-*.md` both pass the gate. They only conflict after one side merges — the RFC-0078 ledger race. When a stale-green PR auto-merges (conveyor) without re-validating against the other, a duplicate RFC number lands on `main`.

This happened: `#22158` and `#22144` both claimed `RFC-0289` while open, each passing `--check-numbering` independently.

The existing `.next-number` ledger bump is the intended cross-PR guard, but a squash merge can absorb the duplicate `.next-number` line without conflict, and a stale-green PR can merge before re-validation.

## Change

Add a sideways check in `pr_axis_check.py` (already the repo's cross-PR, API-backed job), covering the open-vs-open gap that `rfc_enforcer` (offline, git-only) cannot see:

- `detect_rfc_collisions()` — pure over its inputs (offline, self-testable). Groups `ADDED` `docs/rfc/RFC-NNNN` files by number; flags a number claimed by **two or more distinct** open PRs. A single PR claiming one number across multiple files (multi-phase) is not a collision.
- `get_open_prs_with_added_rfc_files()` — thin GraphQL adapter using `changeType == ADDED`, so edits to an existing RFC are not treated as new claims.
- `--check-rfc-collisions` (live; exit 1 on collision) and `--self-test` (fixture-based).

Wired into `.github/workflows/pr-axis-check.yml` as two steps (`--self-test`, then the live scan), both `if: always()` so they run independently of the existing axis-stale step.

Boundary: the base-vs-`main` collision case stays with `rfc_enforcer --check-numbering`; this check only covers the complementary open-vs-open gap. No responsibility overlap.

## Why blocking (tradeoff)

The live step exits 1 on a collision, failing the check. A duplicate RFC number is deterministic and the resulting cleanup (renumber + reference rewrites across already-merged files) is costly, so the check blocks rather than warns. Tradeoff: when X and Y collide, **both** go red until one renumbers — including the PR that claimed the number first. The message names both PRs and points to `scripts/rfc-allocate-next.sh`. Can be softened to warn-only if reviewers prefer.

## Verification

- `python3 scripts/pr_axis_check.py --self-test` — passes (clean / colliding `#22158`+`#22144` fixture / multi-phase single-PR / non-RFC-path noise).
- `python3 scripts/pr_axis_check.py --check-rfc-collisions` against the live repo — reports "No RFC number collisions among open PRs" (correct: only `#22144` currently claims `RFC-0289`; `#22158` is gone), exit 0. Confirms the GraphQL query + parsing path.
- `python3 -m py_compile` clean; `yaml.safe_load` of the workflow passes.

## Not a workaround

This is a root-cause detector for a gate gap, not symptom suppression: no telemetry-as-fix (it fails the check, not just counts), no string classifier, no N-of-M patch, no cap/cooldown/dedup/repair. It closes the open-vs-open RFC-numbering hole at the gate level.

## Self-review

- **Goal**: catch two open PRs claiming the same new RFC number before either merges.
- **Files**: `scripts/pr_axis_check.py` (+172, pure fn + GraphQL adapter + self-test + 2 flags), `.github/workflows/pr-axis-check.yml` (+11, 2 steps). Additions only, no deletions.
- **Verified**: self-test (4 cases), live read-only run, compile, yaml.
- **Unverified**: behavior inside GitHub Actions (token-scoped GraphQL); pre-existing Pyright "`_touches_dune_deps` unused" is on `main` already, not introduced here.

See RFC-0078 (RFC number reservation ledger).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
