### PR TITLE
feat(keeper): add Bg_completed stimulus variant — RFC-0290 Phase 1

### DIFF
--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -87,6 +87,16 @@ let consume_single_heartbeat_stimulus
       c.ok
       meta_after_triage.name;
     pending_board_event_of_stimulus ~meta_after_triage stim |> Option.to_list
+  | Keeper_event_queue.Bg_completed c ->
+    (* RFC-0290 Phase 1: the variant exists for compile-time exhaustiveness; no
+       producer emits Bg_completed yet, so returning [] drops nothing today.
+       Surfacing the outcome as a pending_board_event (mirroring
+       Fusion_completed) lands with the executor in Phase 3. *)
+    Log.Keeper.info
+      "turn entry: bg_completed stimulus consumed (Phase 1 no-op) run_id=%s (keeper=%s)"
+      c.bg_run_id
+      meta_after_triage.name;
+    []
   | Keeper_event_queue.Bootstrap ->
     Log.Keeper.info
       "turn entry: bootstrap stimulus consumed (keeper=%s)"

--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -8,6 +8,7 @@ type stimulus_kind =
   | Bootstrap
   | No_progress_recovery
   | Fusion_completed  (* RFC-0266: async masc_fusion completion wake *)
+  | Bg_completed  (* RFC-0290: generic background job completion wake *)
 
 type reaction_kind =
   | Turn_started
@@ -25,6 +26,7 @@ let stimulus_kind_to_string = function
   | Bootstrap -> "bootstrap"
   | No_progress_recovery -> "no_progress_recovery"
   | Fusion_completed -> "fusion_completed"
+  | Bg_completed -> "bg_completed"
 ;;
 
 (* stimulus_kind_to_string의 역. 닫힌 합에 없는 문자열(스키마 드리프트/손상 row)은
@@ -36,6 +38,7 @@ let stimulus_kind_of_string = function
   | "bootstrap" -> Some Bootstrap
   | "no_progress_recovery" -> Some No_progress_recovery
   | "fusion_completed" -> Some Fusion_completed
+  | "bg_completed" -> Some Bg_completed
   | _ -> None
 ;;
 
@@ -79,6 +82,7 @@ let stimulus_kind_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
   | Keeper_event_queue.Bootstrap -> Bootstrap
   | Keeper_event_queue.No_progress_recovery -> No_progress_recovery
   | Keeper_event_queue.Fusion_completed _ -> Fusion_completed
+  | Keeper_event_queue.Bg_completed _ -> Bg_completed
 ;;
 
 let stimulus_id_of_event_queue (stimulus : Keeper_event_queue.stimulus) =
@@ -148,6 +152,11 @@ let stimulus_payload_preview (payload : Keeper_event_queue.stimulus_payload) =
   | Keeper_event_queue.No_progress_recovery -> "no_progress_recovery"
   | Keeper_event_queue.Fusion_completed fc ->
     Printf.sprintf "fusion_completed run_id=%s ok=%b" fc.run_id fc.ok
+  | Keeper_event_queue.Bg_completed c ->
+    Printf.sprintf
+      "bg_completed run_id=%s kind=%s"
+      c.bg_run_id
+      (Keeper_event_queue.bg_job_kind_to_string c.bg_kind)
 ;;
 
 let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
@@ -159,7 +168,8 @@ let stimulus_json ~keeper_name (stimulus : Keeper_event_queue.stimulus) =
     | Keeper_event_queue.Board_signal bs -> bs.updated_at
     | Keeper_event_queue.Bootstrap
     | Keeper_event_queue.No_progress_recovery
-    | Keeper_event_queue.Fusion_completed _ -> None
+    | Keeper_event_queue.Fusion_completed _
+    | Keeper_event_queue.Bg_completed _ -> None
   in
   `Assoc
     (base_fields
@@ -506,7 +516,9 @@ let summarize_rows ~keeper_name ~limit rows =
        (* 닫힌 합의 모든 variant는 인식된 정상 stimulus다(미지원 아님). 새 variant
           추가 시 이 or-pattern이 non-exhaustive가 되어 컴파일 에러 → 분류 갱신을
           강제한다 (catch-all 금지). *)
-       | Some (Board_signal | Bootstrap | No_progress_recovery | Fusion_completed) -> ())
+       | Some
+           (Board_signal | Bootstrap | No_progress_recovery | Fusion_completed | Bg_completed)
+         -> ())
   in
   let note_payload_parse_error row =
     match assoc_field "stimulus" row with

--- a/lib/keeper/keeper_reaction_ledger.mli
+++ b/lib/keeper/keeper_reaction_ledger.mli
@@ -15,6 +15,7 @@ type stimulus_kind =
   | Bootstrap
   | No_progress_recovery
   | Fusion_completed  (** RFC-0266: async masc_fusion completion wake *)
+  | Bg_completed  (** RFC-0290: generic background job completion wake *)
 
 type reaction_kind =
   | Turn_started

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -484,6 +484,10 @@ let pending_board_event_of_stimulus
   | Keeper_event_queue.Fusion_completed fc ->
     Some (pending_board_event_of_fusion_completion ~meta ~arrived_at:stimulus.arrived_at fc)
   | Keeper_event_queue.Bootstrap | Keeper_event_queue.No_progress_recovery -> None
+  | Keeper_event_queue.Bg_completed _ ->
+    (* RFC-0290 Phase 1: no producer emits Bg_completed yet; surfacing the bg
+       outcome as a pending_board_event lands with the executor in Phase 3. *)
+    None
 ;;
 
 (** Collect recent board activity using cursor-based tracking.

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -31,6 +31,11 @@ type stimulus_payload =
       (* RFC-0266: an async [masc_fusion] deliberation finished. Wakes the
          calling keeper so the resolved answer arrives as actionable turn
          input on its next cycle, instead of being discovered passively. *)
+  | Bg_completed of bg_job_completion
+      (* RFC-0290: a generic background job finished. Mirrors [Fusion_completed]
+         — wakes the calling keeper so the outcome arrives as actionable turn
+         input. Phase 1 adds the variant only; no producer emits it yet
+         (executor lands in RFC-0290 Phase 3). *)
 
 and fusion_completion = {
   run_id : string;
@@ -41,9 +46,36 @@ and fusion_completion = {
   (* correlates to the sink's board evidence post; "" if none was created. *)
 }
 
+and bg_job_completion = {
+  bg_run_id : string;
+  bg_kind : bg_job_kind;
+  bg_outcome : bg_job_outcome;
+  bg_board_post_id : string;
+  (* correlates to an optional board evidence post; "" if none was created. *)
+}
+
+and bg_job_kind = Subprocess
+      (* RFC-0290: closed sum of background job kinds (v1 = [Subprocess]); a new
+         kind forces every match to add an arm rather than defaulting. *)
+
+and bg_job_outcome =
+  | Bg_ok of string  (* result payload *)
+  | Bg_failed of string  (* failure label *)
+
 let fusion_completion_post_id (fc : fusion_completion) =
   if String.equal fc.board_post_id "" then "fusion-run:" ^ fc.run_id
   else fc.board_post_id
+
+let bg_job_completion_post_id (c : bg_job_completion) =
+  if String.equal c.bg_board_post_id "" then "bg-run:" ^ c.bg_run_id
+  else c.bg_board_post_id
+
+let bg_job_kind_to_string = function
+  | Subprocess -> "subprocess"
+
+let bg_job_kind_of_string = function
+  | "subprocess" -> Ok Subprocess
+  | other -> Error (Printf.sprintf "unknown bg_job_kind: %s" other)
 
 type stimulus = {
   post_id : post_id;
@@ -120,10 +152,12 @@ let payload_kind_label = function
   | Bootstrap -> "bootstrap"
   | No_progress_recovery -> "no_progress_recovery"
   | Fusion_completed _ -> "fusion_completed"
+  | Bg_completed _ -> "bg_completed"
 
 let is_board_signal = function
   | Board_signal _ -> true
-  | Bootstrap | No_progress_recovery | Fusion_completed _ -> false
+  | Bootstrap | No_progress_recovery | Fusion_completed _ | Bg_completed _ ->
+    false
 
 let drain_board_window ?(window_sec = 2.0) (queue : t) : stimulus list * t =
   let now = Unix.gettimeofday () in
@@ -238,6 +272,18 @@ let payload_to_yojson = function
       ; "resolved_answer", `String fusion.resolved_answer
       ; "board_post_id", `String fusion.board_post_id
       ]
+  | Bg_completed c ->
+    let ok, payload =
+      match c.bg_outcome with Bg_ok s -> (true, s) | Bg_failed s -> (false, s)
+    in
+    `Assoc
+      [ "kind", `String "bg_completed"
+      ; "run_id", `String c.bg_run_id
+      ; "job_kind", `String (bg_job_kind_to_string c.bg_kind)
+      ; "ok", `Bool ok
+      ; "payload", `String payload
+      ; "board_post_id", `String c.bg_board_post_id
+      ]
 
 let payload_of_yojson json =
   let context = "stimulus.payload" in
@@ -261,6 +307,17 @@ let payload_of_yojson json =
     let* resolved_answer = string_field ~context "resolved_answer" fields in
     let* board_post_id = string_field ~context "board_post_id" fields in
     Ok (Fusion_completed { run_id; ok; resolved_answer; board_post_id })
+  | "bg_completed" ->
+    let* run_id = string_field ~context "run_id" fields in
+    let* job_kind_s = string_field ~context "job_kind" fields in
+    let* bg_kind = bg_job_kind_of_string job_kind_s in
+    let* ok = bool_field ~context "ok" fields in
+    let* payload = string_field ~context "payload" fields in
+    let* board_post_id = string_field ~context "board_post_id" fields in
+    let bg_outcome = if ok then Bg_ok payload else Bg_failed payload in
+    Ok
+      (Bg_completed
+         { bg_run_id = run_id; bg_kind; bg_outcome; bg_board_post_id = board_post_id })
   | value -> Error (Printf.sprintf "unknown stimulus payload kind: %s" value)
 
 let stimulus_to_yojson (stimulus : stimulus) =

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -56,6 +56,7 @@ type stimulus_payload =
   | Bootstrap
   | No_progress_recovery
   | Fusion_completed of fusion_completion
+  | Bg_completed of bg_job_completion
 (** Closed set of stimulus kinds. Replaces the prior [payload : string] +
     [classify] JSON-prefix round-trip: producers hold the typed value and
     consumers match it exhaustively, so an unrecognised stimulus is
@@ -75,10 +76,38 @@ and fusion_completion = {
     answer (or a failure label when [ok = false]); [board_post_id] correlates to
     the sink's board evidence post ("" when none was created). *)
 
+and bg_job_completion = {
+  bg_run_id : string;
+  bg_kind : bg_job_kind;
+  bg_outcome : bg_job_outcome;
+  bg_board_post_id : string;
+}
+(** RFC-0290 payload for [Bg_completed]: mirrors [fusion_completion]. [bg_kind]
+    is a closed sum so a new job kind forces exhaustive handling; [bg_outcome]
+    carries the result payload ([Bg_ok]) or a failure label ([Bg_failed]);
+    [bg_board_post_id] correlates to an optional board evidence post ("" if
+    none). *)
+
+and bg_job_kind = Subprocess
+(** RFC-0290: background job kinds. Closed sum (v1 = [Subprocess]); a new kind
+    forces every match to add an arm rather than defaulting. *)
+
+and bg_job_outcome =
+  | Bg_ok of string  (** result payload *)
+  | Bg_failed of string  (** failure label *)
+
 val fusion_completion_post_id : fusion_completion -> post_id
 (** Dedup/correlation id for [Fusion_completed]. Uses [board_post_id] when the
     sink created a board evidence post, otherwise falls back to
     ["fusion-run:<run_id>"]. *)
+
+val bg_job_completion_post_id : bg_job_completion -> post_id
+(** RFC-0290 dedup/correlation id for [Bg_completed]. Uses [bg_board_post_id]
+    when the producer set it, otherwise falls back to ["bg-run:<run_id>"]. *)
+
+val bg_job_kind_to_string : bg_job_kind -> string
+(** RFC-0290: stable label for a background job kind, for logs and correlation
+    (["subprocess"]). *)
 
 type stimulus = {
   post_id : post_id;
@@ -127,7 +156,7 @@ val summary : t -> string
 
 val payload_kind_label : stimulus_payload -> string
 (** Stable short label for logs/metrics: ["board_signal"], ["bootstrap"],
-    ["no_progress_recovery"], or ["fusion_completed"]. *)
+    ["no_progress_recovery"], ["fusion_completed"], or ["bg_completed"]. *)
 
 val is_board_signal : stimulus_payload -> bool
 (** [true] iff the payload is a [Board_signal]. *)

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -54,6 +54,65 @@ let () =
          { run_id = "fus-2"; ok = false; resolved_answer = "sink_failed"; board_post_id = "" })
       "fusion-run:fus-2");
 
+  (* RFC-0290: Bg_completed is a non-board stimulus with its own label; its
+     post_id falls back to "bg-run:<run_id>" when no board post correlates. *)
+  let bg_payload () =
+    Bg_completed
+      { bg_run_id = "bg-1"
+      ; bg_kind = Subprocess
+      ; bg_outcome = Bg_ok "done"
+      ; bg_board_post_id = "post-2"
+      }
+  in
+  assert (not (is_board_signal (bg_payload ())));
+  assert (String.equal (payload_kind_label (bg_payload ())) "bg_completed");
+  assert (
+    String.equal
+      (bg_job_completion_post_id
+         { bg_run_id = "bg-1"
+         ; bg_kind = Subprocess
+         ; bg_outcome = Bg_ok "done"
+         ; bg_board_post_id = "post-2"
+         })
+      "post-2");
+  assert (
+    String.equal
+      (bg_job_completion_post_id
+         { bg_run_id = "bg-2"
+         ; bg_kind = Subprocess
+         ; bg_outcome = Bg_failed "exit 1"
+         ; bg_board_post_id = ""
+         })
+      "bg-run:bg-2");
+
+  (* RFC-0290: Bg_completed survives the stimulus codec round-trip, preserving
+     the outcome variant ([Bg_failed]) and empty board post id. *)
+  (match
+     stimulus_of_yojson
+       (stimulus_to_yojson
+          { post_id = "bgp1"
+          ; urgency = Low
+          ; arrived_at = 3.0
+          ; payload =
+              Bg_completed
+                { bg_run_id = "bg-3"
+                ; bg_kind = Subprocess
+                ; bg_outcome = Bg_failed "boom"
+                ; bg_board_post_id = ""
+                }
+          })
+   with
+   | Ok s ->
+     (match s.payload with
+      | Bg_completed
+          { bg_run_id; bg_kind = Subprocess; bg_outcome = Bg_failed msg; bg_board_post_id }
+        ->
+        assert (String.equal bg_run_id "bg-3");
+        assert (String.equal msg "boom");
+        assert (String.equal bg_board_post_id "")
+      | _ -> Alcotest.fail "Bg_completed codec round-trip changed payload shape")
+   | Error msg -> Alcotest.fail ("Bg_completed stimulus round-trip failed: " ^ msg));
+
   (* --- queue operations preserved --- *)
   let board_stim =
     { post_id = "p1"; urgency = Normal; arrived_at = 0.0; payload = board_payload () }

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -406,6 +406,7 @@ let test_stimulus_kind_string_roundtrip () =
     ; Keeper_reaction_ledger.Bootstrap
     ; Keeper_reaction_ledger.No_progress_recovery
     ; Keeper_reaction_ledger.Fusion_completed
+    ; Keeper_reaction_ledger.Bg_completed
     ];
   check bool "unknown stimulus kind string is None" true
     (Option.is_none (Keeper_reaction_ledger.stimulus_kind_of_string "totally_unknown"))


### PR DESCRIPTION
## 요약

RFC-0290 **Phase 1** — keeper event-queue `stimulus_payload` 닫힌합에 `Bg_completed of bg_job_completion` variant를 추가합니다. fusion(`Fusion_completed`, RFC-0266)이 이미 쓰는 fire-and-forget + wake 골격을 generic background job으로 확장하기 위한 **타입 레벨 토대**입니다.

**런타임 무변화**: 아직 아무도 `Bg_completed`를 emit하지 않습니다. run registry / concurrency cap / subprocess executor는 RFC-0290 Phase 2/3. 이 PR의 가치는 executor가 생기기 *전에* "이 완료 이벤트를 처리하지 않는 consumer가 있으면 컴파일 실패"를 타입 시스템이 보장하는 것입니다.

## 변경

- `keeper_event_queue.ml/.mli`: `Bg_completed` variant + `bg_job_completion` / `bg_job_kind`(closed sum, v1 `Subprocess`) / `bg_job_outcome`(`Bg_ok`/`Bg_failed`) 타입 + post_id/kind helper + 4 match arm(`payload_kind_label` / `is_board_signal` / `payload_to_yojson` / `payload_of_yojson`). unknown deserialized kind는 `Error` 반환(permissive default 아님).
- `keeper_reaction_ledger.ml/.mli`: 자체 mirror `stimulus_kind` enum + 6곳(`to/of_string`, `of_event_queue`, describe, `board_updated_at`, `note_stimulus_kind` or-pattern).
- `keeper_heartbeat_stimulus_intake.ml` / `keeper_world_observation.ml`: no-op arm(`[]` / `None`) + "no producer yet, surface lands Phase 3" 주석(결과 누락 버그로 오해 방지).

## Self-review (Best Programmer 기준)

**목표**: RFC-0290 Phase 1 — stimulus variant + 모든 exhaustive consumer. 런타임 무변화.

**변경 파일** (8): 위 6 + `test_keeper_event_queue.ml` + `test_keeper_reaction_ledger.ml`.

**로컬 검증**:
- `dune build --root .` green (DUNE_EXIT=0, error 0) → exhaustiveness 증명. arm을 하나라도 빼면 non-exhaustive match로 빌드 실패(RFC §6 첫 acceptance).
- `test_keeper_event_queue` all passed / `test_keeper_reaction_ledger` 12 tests Successful — Bg_completed codec round-trip(outcome variant + empty post_id 보존), `payload_kind_label`="bg_completed", `bg_job_completion_post_id` fallback, `stimulus_kind` string round-trip drift guard(Bg_completed 포함).

**미검증 / 후속**:
- producer/executor 없음 → wake/surface 실제 동작은 Phase 2(registry+cap)/Phase 3(executor + FD 격리 + terminal-once). RFC §6의 terminal-once / FD non-leak / cap rejection acceptance는 Phase 2/3 PR.
- 로컬 `@runtest` 전체는 sandbox quirk로 미실행 — CI Build&Test가 authoritative.

## 워크어라운드 self-check (RFC-0290 §9)

typed closed-sum variant 추가입니다(string 분류기 / telemetry-as-fix / N-of-M / cap-cooldown 아님). `bg_kind`는 closed sum이고 unknown kind는 `Error`로 reject. 근거: RFC-0290(main `a9dc2a82`), 선행 RFC-0266(fusion async wake).
