### PR TITLE
fix(ws): make per-session dashboard delivery state cross-domain-safe (RFC-0204 Phase 3 prereq)

### DIFF
--- a/lib/server/server_mcp_transport_ws.ml
+++ b/lib/server/server_mcp_transport_ws.ml
@@ -74,28 +74,40 @@ type ws_session = {
       responsive client could accumulate against (#21509). *)
   last_pong_at: float Atomic.t;
   dashboard_auth: dashboard_auth_state Atomic.t;
-  mutable dashboard_route: string option;
-  dashboard_slices: (string, unit) Hashtbl.t;
-  mutable dashboard_seq: int;
+  dashboard_route: string option Atomic.t;
+  (** Slices this session subscribes to, held as an immutable list inside an
+      [Atomic.t].  Subscribe / unsubscribe (under [sessions_mutex]) publish a
+      fresh list with [Atomic.set]; the SSE fanout reads it lock-free with
+      [Atomic.get].  An immutable snapshot is never mutated in place, so a
+      reader on the serving domain cannot observe a torn list or trip a
+      [Hashtbl] resize on the keeper-loop broadcast path (RFC-0204 Phase 3). *)
+  dashboard_slices: string list Atomic.t;
+  dashboard_seq: int Atomic.t;
   (** Last seq value the client has acknowledged.  0 until the first ack
       arrives.  Paired with {!dashboard_last_buffered_amount} so the server
       can reason about client liveness without touching the wire. *)
-  mutable dashboard_last_ack_seq: int;
+  dashboard_last_ack_seq: int Atomic.t;
   (** Last [WebSocket.bufferedAmount] the client reported in a
       [dashboard/ack] notification.  A growing value is a leading indicator
       that the client cannot drain deltas as fast as the server pushes them;
       sustained growth should eventually gate further sends.  Observability
       lands first — gating is a follow-up once thresholds are established
       from production distributions. *)
-  mutable dashboard_last_buffered_amount: int;
+  dashboard_last_buffered_amount: int Atomic.t;
   (** Last wall-clock time a [dashboard/ack] notification arrived.  A
       subscribed dashboard that stops ACKing can keep a low bufferedAmount
       forever. *)
-  mutable dashboard_last_ack_at: float;
+  dashboard_last_ack_at: float Atomic.t;
   (** Last dashboard/delta seq that expects a browser [dashboard/ack].  Snapshot
       seqs are intentionally excluded because the browser only ACKs deltas. *)
-  mutable dashboard_last_delta_seq: int;
-  mutable dashboard_last_delta_at: float;
+  (** [dashboard_last_delta_seq] / [dashboard_last_delta_at] are written
+      together on the fanout (one delta) and read together by
+      {!session_is_backpressured}.  As independent [Atomic.t]s a cross-domain
+      reader may observe a one-tick-stale pair; that is benign for the stale-ACK
+      backpressure heuristic, which is monotonic and re-evaluates on the next
+      delta (RFC-0204 Phase 3 — deliberate, not an oversight). *)
+  dashboard_last_delta_seq: int Atomic.t;
+  dashboard_last_delta_at: float Atomic.t;
   inbound_dispatches: int Atomic.t;
 }
 
@@ -236,14 +248,14 @@ let new_session ~id ~wsd =
     write_mutex = Eio.Mutex.create ();
     last_pong_at = Atomic.make now;
     dashboard_auth = Atomic.make Unauthenticated;
-    dashboard_route = None;
-    dashboard_slices = Hashtbl.create 8;
-    dashboard_seq = 0;
-    dashboard_last_ack_seq = 0;
-    dashboard_last_buffered_amount = 0;
-    dashboard_last_ack_at = now;
-    dashboard_last_delta_seq = 0;
-    dashboard_last_delta_at = now;
+    dashboard_route = Atomic.make None;
+    dashboard_slices = Atomic.make [];
+    dashboard_seq = Atomic.make 0;
+    dashboard_last_ack_seq = Atomic.make 0;
+    dashboard_last_buffered_amount = Atomic.make 0;
+    dashboard_last_ack_at = Atomic.make now;
+    dashboard_last_delta_seq = Atomic.make 0;
+    dashboard_last_delta_at = Atomic.make now;
     inbound_dispatches = Atomic.make 0;
   }
 
@@ -354,9 +366,18 @@ let jsonrpc_notification method_ params =
       ("params", params);
     ]
 
-let next_dashboard_seq session =
-  session.dashboard_seq <- session.dashboard_seq + 1;
-  session.dashboard_seq
+(* Cross-domain-safe seq allocator: [fetch_and_add] atomically claims a unique
+   slot, so two domains never hand out the same seq.  The old plain
+   read-modify-write lost ~half its updates under true parallelism (RFC-0204
+   Phase 3 gate). *)
+let next_dashboard_seq session = Atomic.fetch_and_add session.dashboard_seq 1 + 1
+
+(* Monotonic-max update for a cross-domain counter: retries until our value
+   lands or a concurrent writer has already raised the field to >= v.  Replaces
+   the old non-atomic "if v > x then x <- v", which lost concurrent acks. *)
+let rec atomic_bump_max a v =
+  let cur = Atomic.get a in
+  if v > cur && not (Atomic.compare_and_set a cur v) then atomic_bump_max a v
 
 let valid_dashboard_slice = function
   | "shell"
@@ -391,9 +412,9 @@ let dashboard_slice_for_sse_type = function
 
 let dashboard_session_result session =
   let slices =
-    Hashtbl.fold (fun slice () acc -> `String slice :: acc)
-      session.dashboard_slices []
+    Atomic.get session.dashboard_slices
     |> List.sort compare
+    |> List.map (fun slice -> `String slice)
   in
   let auth = dashboard_auth session in
   `Assoc
@@ -402,9 +423,9 @@ let dashboard_session_result session =
       ("session_id", `String session.id);
       ("authenticated", `Bool (dashboard_auth_is_authenticated auth));
       ( "agent", Json_util.string_opt_to_json (dashboard_auth_agent auth) );
-      ( "route", Json_util.string_opt_to_json session.dashboard_route );
+      ( "route", Json_util.string_opt_to_json (Atomic.get session.dashboard_route) );
       ("slices", `List slices);
-      ("seq", `Int session.dashboard_seq);
+      ("seq", `Int (Atomic.get session.dashboard_seq));
     ]
 
 let find_session session_id =
@@ -476,19 +497,18 @@ let dashboard_hello ~base_path ~session_id ?token () =
 
 let dashboard_snapshot session =
   let slices =
-    Hashtbl.fold
-      (fun slice () acc ->
-        match !dashboard_snapshot_provider slice with
-        | Some json -> (slice, json) :: acc
-        | None -> acc)
-      session.dashboard_slices []
+    Atomic.get session.dashboard_slices
+    |> List.filter_map (fun slice ->
+           match !dashboard_snapshot_provider slice with
+           | Some json -> Some (slice, json)
+           | None -> None)
     |> List.sort (fun (a, _) (b, _) -> String.compare a b)
   in
   `Assoc
     [
       ("protocol", `String "dashboard-ws.v1");
       ("seq", `Int (next_dashboard_seq session));
-      ( "route", Json_util.string_opt_to_json session.dashboard_route );
+      ( "route", Json_util.string_opt_to_json (Atomic.get session.dashboard_route) );
       ("slices", `Assoc slices);
     ]
 
@@ -508,13 +528,12 @@ let dashboard_subscribe ~session_id ?route ~slices () =
         | [] ->
             with_sessions_rw (fun () ->
                 slice_index_remove_session_locked session_id;
-                Hashtbl.clear session.dashboard_slices;
+                Atomic.set session.dashboard_slices
+                  (List.sort_uniq compare slices);
                 List.iter
-                  (fun slice ->
-                    Hashtbl.replace session.dashboard_slices slice ();
-                    slice_index_add_locked ~session_id ~slice)
+                  (fun slice -> slice_index_add_locked ~session_id ~slice)
                   slices);
-            session.dashboard_route <- route;
+            Atomic.set session.dashboard_route route;
             Ok
               (`Assoc
                 [
@@ -533,13 +552,15 @@ let dashboard_unsubscribe ~session_id ?slices () =
         with_sessions_rw (fun () ->
             match slices with
             | None ->
-                Hashtbl.clear session.dashboard_slices;
+                Atomic.set session.dashboard_slices [];
                 slice_index_remove_session_locked session_id
             | Some slices ->
+                Atomic.set session.dashboard_slices
+                  (List.filter
+                     (fun s -> not (List.mem s slices))
+                     (Atomic.get session.dashboard_slices));
                 List.iter
-                  (fun slice ->
-                    Hashtbl.remove session.dashboard_slices slice;
-                    slice_index_remove_locked ~session_id ~slice)
+                  (fun slice -> slice_index_remove_locked ~session_id ~slice)
                   slices);
         Ok (`Assoc [ ("session", dashboard_session_result session) ])
       end
@@ -556,7 +577,7 @@ let dashboard_ping ~session_id () =
             [
               ("ok", `Bool true);
               ("session_id", `String session.id);
-              ("seq", `Int session.dashboard_seq);
+              ("seq", `Int (Atomic.get session.dashboard_seq));
             ])
 
 let dashboard_ack ~session_id ~seq ?buffered_amount () =
@@ -566,12 +587,11 @@ let dashboard_ack ~session_id ~seq ?buffered_amount () =
       if not (dashboard_auth_is_authenticated (dashboard_auth session)) then
         Error "dashboard/ack requires dashboard/hello first"
       else begin
-        session.dashboard_last_ack_at <- Time_compat.now ();
-        if seq > session.dashboard_last_ack_seq then
-          session.dashboard_last_ack_seq <- seq;
+        Atomic.set session.dashboard_last_ack_at (Time_compat.now ());
+        atomic_bump_max session.dashboard_last_ack_seq seq;
         (match buffered_amount with
          | Some n when n >= 0 ->
-             session.dashboard_last_buffered_amount <- n;
+             Atomic.set session.dashboard_last_buffered_amount n;
              Transport_metrics.observe_ws_client_buffered_bytes n
          | _ -> ());
         Ok
@@ -579,9 +599,10 @@ let dashboard_ack ~session_id ~seq ?buffered_amount () =
             [
               ("session_id", `String session.id);
               ("ack", `Int seq);
-              ("server_last_ack_seq", `Int session.dashboard_last_ack_seq);
+              ("server_last_ack_seq",
+                `Int (Atomic.get session.dashboard_last_ack_seq));
               ("server_last_buffered_amount",
-                `Int session.dashboard_last_buffered_amount);
+                `Int (Atomic.get session.dashboard_last_buffered_amount));
             ])
       end
 
@@ -722,11 +743,11 @@ let parse_sse_dashboard_event sse_event =
 let dashboard_delta_for_parsed session parsed =
   match parsed with
   | Some { event_type; slice = Some slice; payload; broadcast_ts }
-    when Hashtbl.mem session.dashboard_slices slice ->
+    when List.mem slice (Atomic.get session.dashboard_slices) ->
       Transport_metrics.inc_ws_delta_built ();
       let seq = next_dashboard_seq session in
-      session.dashboard_last_delta_seq <- seq;
-      session.dashboard_last_delta_at <- Time_compat.now ();
+      Atomic.set session.dashboard_last_delta_seq seq;
+      Atomic.set session.dashboard_last_delta_at (Time_compat.now ());
       Some
         (jsonrpc_notification "dashboard/delta"
            (`Assoc
@@ -813,14 +834,14 @@ let session_is_backpressured session =
   else
     let limit = client_buffer_limit_bytes () in
     let buffered_limit_exceeded =
-      limit > 0 && session.dashboard_last_buffered_amount >= limit
+      limit > 0 && Atomic.get session.dashboard_last_buffered_amount >= limit
     in
     let ack_stale =
       dashboard_ack_is_stale
         ~now:(Time_compat.now ())
-        ~last_delta_at:session.dashboard_last_delta_at
-        ~last_delta_seq:session.dashboard_last_delta_seq
-        ~last_ack_seq:session.dashboard_last_ack_seq
+        ~last_delta_at:(Atomic.get session.dashboard_last_delta_at)
+        ~last_delta_seq:(Atomic.get session.dashboard_last_delta_seq)
+        ~last_ack_seq:(Atomic.get session.dashboard_last_ack_seq)
         ~threshold_s:(dashboard_ack_stale_threshold_s ())
     in
     buffered_limit_exceeded || ack_stale
@@ -1024,6 +1045,12 @@ let missed_pong_threshold () =
   max 0 (Env_config_core.get_int ~default:3 "MASC_WS_MISSED_PONG_THRESHOLD")
 
 let __test_missed_pong_threshold = missed_pong_threshold
+
+(* Exposed for the cross-domain delivery-state gate (RFC-0204 Phase 3): the gate
+   drives two domains through the seq allocator and asserts the final counter
+   equals the total number of calls (no lost updates). *)
+let __test_next_dashboard_seq = next_dashboard_seq
+let __test_dashboard_seq_value session = Atomic.get session.dashboard_seq
 
 let start_upgrade_heartbeat ?sw ?clock session_id session =
   match sw, clock with

--- a/lib/server/server_mcp_transport_ws.mli
+++ b/lib/server/server_mcp_transport_ws.mli
@@ -97,28 +97,36 @@ type ws_session = {
   write_mutex : Eio.Mutex.t;
   last_pong_at : float Atomic.t;
   dashboard_auth : dashboard_auth_state Atomic.t;
-  mutable dashboard_route : string option;
-  dashboard_slices : (string, unit) Hashtbl.t;
-  mutable dashboard_seq : int;
-  mutable dashboard_last_ack_seq : int;
-  mutable dashboard_last_buffered_amount : int;
-  mutable dashboard_last_ack_at : float;
-  mutable dashboard_last_delta_seq : int;
-  mutable dashboard_last_delta_at : float;
+  dashboard_route : string option Atomic.t;
+  dashboard_slices : string list Atomic.t;
+  dashboard_seq : int Atomic.t;
+  dashboard_last_ack_seq : int Atomic.t;
+  dashboard_last_buffered_amount : int Atomic.t;
+  dashboard_last_ack_at : float Atomic.t;
+  dashboard_last_delta_seq : int Atomic.t;
+  dashboard_last_delta_at : float Atomic.t;
   inbound_dispatches : int Atomic.t;
 }
 (** Per-WS session state.  Concrete record because
     [server_ws_standalone] threads the value through
     {!read_inbound_message_frame} +
     {!send_dashboard_or_raw_sse} and reaches the
-    {!sessions} table directly.  Mutable fields track
-    the dashboard handshake / ack state machine; see the
-    [#10648] / dashboard-ws.v1 protocol notes in the .ml
-    for the field semantics.
+    {!sessions} table directly.  The dashboard handshake /
+    ack state machine is tracked in the [dashboard_*] fields;
+    see the [#10648] / dashboard-ws.v1 protocol notes in the
+    .ml for the field semantics.
 
-    Cross-fiber scalar state ([closed], [last_pong_at]) is
-    held in [Atomic.t] values; all writes to [wsd] are serialized through
-    [write_mutex]. *)
+    All cross-domain state is held in [Atomic.t]: the
+    connection scalars ([closed], [last_pong_at],
+    [inbound_dispatches]); the per-session dashboard delivery
+    counters ([dashboard_seq], the ack / delta / buffered fields)
+    and the subscribed-[dashboard_slices] snapshot, all
+    read / written on the SSE fanout callback that fires from both
+    the main domain (keeper / refresh broadcasts) and serving
+    handlers; and [dashboard_route], written under concurrent
+    per-session dispatch.  Plain mutable fields would race once
+    serving moves to its own domain (RFC-0204 Phase 3).  All writes
+    to [wsd] are serialized through [write_mutex]. *)
 
 val dashboard_auth_is_authenticated : dashboard_auth_state -> bool
 (** [true] once [dashboard_hello] has authenticated the session. *)
@@ -467,3 +475,13 @@ val __test_reset_env_caches : unit -> unit
 val __test_missed_pong_threshold : unit -> int
 (** Test-only seam: exposes the configured missed-pong threshold so tests can
     verify default / env-var / clamping behavior. *)
+
+val __test_next_dashboard_seq : ws_session -> int
+(** Test-only seam: the per-session dashboard seq allocator.  Exposed so the
+    cross-domain delivery-state gate can drive two Eio domains through it
+    (RFC-0204 Phase 3 prerequisite). *)
+
+val __test_dashboard_seq_value : ws_session -> int
+(** Test-only seam: reads the current per-session dashboard seq counter so the
+    cross-domain gate can assert the final value equals the total number of
+    allocations (no lost updates under true parallelism). *)

--- a/test/test_ws_transport.ml
+++ b/test/test_ws_transport.ml
@@ -660,8 +660,8 @@ let test_backpressure_gate_stale_ack_throttles_delivery () =
   with_env_var "MASC_WS_ACK_STALE_THRESHOLD_SEC" "0.001" (fun () ->
     let session = Ws.new_session ~id:"stale-ack" ~wsd:(Obj.magic ()) in
     Atomic.set session.dashboard_auth (Ws.Authenticated { agent = None });
-    session.dashboard_last_delta_seq <- 1;
-    session.dashboard_last_delta_at <- Unix.gettimeofday () -. 10.0;
+    Atomic.set session.dashboard_last_delta_seq 1;
+    Atomic.set session.dashboard_last_delta_at (Unix.gettimeofday () -. 10.0);
     Alcotest.(check bool) "stale ack skips send without closing session"
       true
       (Ws.send_dashboard_or_raw_sse session
@@ -1000,12 +1000,12 @@ let test_new_session_initializes_pong_state () =
     (Atomic.get session.last_pong_at <= Unix.gettimeofday ());
   Alcotest.(check bool) "dashboard ack timestamp is initialized"
     true
-    (session.dashboard_last_ack_at <= Unix.gettimeofday ());
+    (Atomic.get session.dashboard_last_ack_at <= Unix.gettimeofday ());
   Alcotest.(check int) "no delta is pending ack"
-    0 session.dashboard_last_delta_seq;
+    0 (Atomic.get session.dashboard_last_delta_seq);
   Alcotest.(check bool) "delta timestamp is initialized"
     true
-    (session.dashboard_last_delta_at <= Unix.gettimeofday ());
+    (Atomic.get session.dashboard_last_delta_at <= Unix.gettimeofday ());
   Alcotest.(check int) "inbound dispatch count starts empty"
     0 (Atomic.get session.inbound_dispatches)
 
@@ -1059,8 +1059,70 @@ let test_missed_pong_threshold_reads_env () =
   with_env_var "MASC_WS_MISSED_PONG_THRESHOLD" "-2" (fun () ->
     Alcotest.(check int) "negative values clamp to 0" 0 (Ws.__test_missed_pong_threshold ()))
 
+(* ====== Cross-domain delivery-state safety (RFC-0204 Phase 3 gate) ====== *)
+
+(* The per-session dashboard delivery counters are read and written on the SSE
+   fanout callback, which fires from the main domain (keeper keepalive / event
+   bridge / registry / goal-loop refresh broadcasts) AND from serving handlers
+   (HTTP-route broadcasts).  Today that is safe only because a single Eio
+   domain runs cooperative fibers that never preempt mid-update.  RFC-0204
+   Phase 3 moves serving to a second domain; the moment two domains run in
+   parallel, a plain [int] read-modify-write in [next_dashboard_seq] loses
+   updates and hands two callers the same seq, breaking the dashboard-ws.v1
+   seq/ack contract.
+
+   This drives two real domains through [next_dashboard_seq] and asserts the
+   final counter equals the total number of calls — i.e. no increment was lost.
+   It depends only on the public [int] seams, not the field representation, so
+   it compiles against both the plain-int and the Atomic version: RED on the
+   plain field (a tight contended read-modify-write loses ~half its updates on a
+   multicore host), GREEN once the counter is an [int Atomic.t] allocated via
+   [Atomic.fetch_and_add].  The final-count assertion is far more sensitive than
+   a uniqueness check: a single lost update already drops the total below
+   [2 * iters].
+
+   Scope: this proves the [fetch_and_add] seq path — the most severe site (~half
+   the updates lost on a multicore host).  The other delivery fields are simpler
+   conversions verified by inspection and guarded by the rest of the suite:
+   [dashboard_last_ack_seq] uses a CAS-retry monotonic max ([atomic_bump_max]);
+   the buffered / delta / ack_at fields are single [Atomic.set]/[get]. *)
+let test_dashboard_seq_no_lost_updates_across_domains () =
+  (* A single-vCPU host time-slices domains rather than running them in
+     parallel, so the lost-update race cannot manifest there and a pass would be
+     meaningless.  Skip rather than assert a vacuous green. *)
+  if Domain.recommended_domain_count () < 2 then ()
+  else
+  let session = Ws.new_session ~id:"seq-xdomain" ~wsd:(Obj.magic ()) in
+  let iters = 1_000_000 in
+  (* Two-way start barrier: each domain announces arrival and spins until both
+     are present, so the increment loops run in true overlap.  Without it the
+     spawned domain's startup latency can exceed the loop's runtime, the main
+     domain drains its loop before the other starts, and the race never occurs
+     — the test would then pass even on the buggy plain field (a vacuous gate). *)
+  let ready = Atomic.make 0 in
+  let work () =
+    Atomic.incr ready;
+    while Atomic.get ready < 2 do
+      Domain.cpu_relax ()
+    done;
+    for _ = 1 to iters do
+      ignore (Ws.__test_next_dashboard_seq session)
+    done
+  in
+  let other = Domain.spawn work in
+  work ();
+  Domain.join other;
+  Alcotest.(check int)
+    "no dashboard seq increments lost across two domains"
+    (2 * iters)
+    (Ws.__test_dashboard_seq_value session)
+
 let () =
   Alcotest.run "WebSocket Transport" [
+	    ("delivery_xdomain", [
+	      Alcotest.test_case "next_dashboard_seq loses no updates across domains"
+	        `Quick test_dashboard_seq_no_lost_updates_across_domains;
+	    ]);
 	    ("session_registry", [
 	      Alcotest.test_case "initial count" `Quick test_initial_session_count;
 	      Alcotest.test_case "close_all empty" `Quick test_close_all_empty;


### PR DESCRIPTION
## 목적

WebSocket 대시보드 세션의 **per-session delivery state**(seq/ack/delta 카운터 + 구독 슬라이스)를 cross-domain-safe하게 만든다. 이 상태는 오늘 단일 Eio domain의 협조적 스케줄링(fiber가 read-modify-write 중간에 선점되지 않음)에만 의존해 안전하다. 두 번째 domain이 도입되면 즉시 data race가 된다.

RFC-0204(dashboard-serving-isolation) Phase 3 — serving을 전용 domain으로 분리 — 의 **선행 조건**이다. 다만 이 변경 자체는 domain을 분리하지 않으며, 단일 domain에서 동작/동시성 의미가 동일하다(순수 correctness 강화).

## 배경 (전수 audit)

RFC-0204 Phase 3 진입 전 per-handler shared-state 전수 audit 결과, 가장 위험한 cell군이 `lib/server/server_mcp_transport_ws.ml`의 per-session delivery 필드였다. 이들은 SSE fanout 콜백 경로에서 lock 없이 read/write되는데, 그 fanout은 main domain(keeper keepalive / event bridge / registry / goal-loop refresh broadcast)과 serving 핸들러(HTTP-route broadcast) **양쪽에서 발화**한다.

- `next_dashboard_seq`는 plain `mutable int`에 대한 non-atomic `x <- x + 1` — 두 domain이 같은 seq를 발급(client seq/ack 계약 붕괴).
- `dashboard_slices`는 plain `Hashtbl` — fanout이 `Hashtbl.fold`/`mem`로 lock 없이 읽는 동안 subscribe가 `Hashtbl.clear`/`replace`하면 resize-중-iteration으로 corruption/segfault.

## 변경

`lib/server/server_mcp_transport_ws.ml` + `.mli`:

- 6개 scalar delivery 필드를 `Atomic.t`로 전환: `dashboard_seq`, `dashboard_last_ack_seq`, `dashboard_last_buffered_amount`, `dashboard_last_ack_at`, `dashboard_last_delta_seq`, `dashboard_last_delta_at`.
  - `next_dashboard_seq` = `Atomic.fetch_and_add … 1 + 1` (유일 slot 원자 확보).
  - ack 단조 최대 갱신 = `atomic_bump_max`(CAS retry) — 기존 `if v > x then x <- v`의 cross-domain lost-update 제거.
- `dashboard_slices`를 `Hashtbl`에서 **immutable `string list Atomic.t`**로 전환. subscribe/unsubscribe(이미 `sessions_mutex` 하)는 새 리스트를 `Atomic.set`로 publish, fanout은 `Atomic.get`로 lock-free 스냅샷 읽기. 불변 스냅샷은 in-place 변경이 없어 torn read·resize segfault가 원천 불가.
- `dashboard_route`도 `string option Atomic.t`로 전환. inbound-dispatch semaphore가 세션당 최대 32 동시 핸들러를 허용하므로 두 `dashboard/subscribe`가 두 domain에서 동시에 route를 쓸 수 있다(적대 리뷰가 cross-domain 도달성 입증). subscribe write가 `sessions_mutex` 밖에 있던 lock-scope 비대칭도 `Atomic.set`로 해소.

torn-pair 결정: `session_is_backpressured`가 `last_delta_at`+`last_delta_seq`를 함께 읽는다. 독립 Atomic이라 cross-domain reader가 1-tick stale pair를 볼 수 있으나, stale-ACK backpressure는 단조·자기교정 heuristic이라 다음 delta에서 재평가되므로 benign(필드 주석에 명시).

적대 리뷰(4 관점): blocker 0, high 0. NEW race 도입 없음 확인, 게이트 non-vacuous 제3자 반증(revert 시 RED 재현). nit 반영: route Atomic화, 게이트 coverage 코멘트 정직하게 범위 한정(fetch_and_add path 증명, 나머지는 단순 변환), 단일-vCPU 호스트에서 게이트 skip(race 불발 → vacuous green 방지).

## 측정 (RED → GREEN, M3 Max)

`test/test_ws_transport.ml`에 결정론적 게이트 추가: 두 실제 domain이 start-barrier로 동시에 `next_dashboard_seq`를 각 100만 회 호출 후 최종 카운터가 200만인지 단언(증분 손실 0).

| 코드 | 게이트 결과 |
|---|---|
| plain `mutable int` (변경 전) | **RED** — Expected 2000000, Received 1148665 (851,335 손실, **42.6%**) |
| `int Atomic.t` (변경 후) | **GREEN** — 정확히 2000000 |

standalone probe(순수 `int ref` vs `Atomic`)로도 메커니즘 확인: plain 49.5% 손실, Atomic 0.

게이트는 vacuity 비검증을 통과한다 — 변경 소스(Atomic)를 plain으로 revert하면 다시 RED. final-count는 uniqueness보다 민감(단 1개 손실도 `< 2N`).

## 검증

- `dune build` 전체 green(public record 타입 변경이 다른 모듈을 깨지 않음 = 접근자가 ws.ml+test로 한정됨을 컴파일러가 확인).
- `test_ws_transport` 65 tests green(새 게이트 + 기존 stale-ack/pong-init 등 delta 필드 사용 테스트 무회귀).
- production 동작 무변경(단일 domain 의미 동일); domain split 없음.

## RFC

RFC-0204 (dashboard-serving-isolation) §5/§7 — per-session delivery state hardening은 Phase 3 merge gate의 선행. 본 PR은 domain을 옮기지 않고 상태만 cross-domain-safe하게 만든다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
