### PR TITLE
docs(readme): document journey + connector-status routes (fix doc-truth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ make release-evidence
 
 레일 외부에서 접근 가능한 추가 서피스: Monitor (keeper fleet, 도구 모니터, 런타임, observatory), Command (개입·거버넌스·승인), Lab (도구 진단, safety harness, 성능, Memory OS, 키퍼 메모리 상태).
 
-라우트 예시: `dashboard#monitoring?section=agents`, `dashboard#command?section=operations`, `dashboard#lab?section=memory-subsystems`, `dashboard#workspace?section=verification`.
+라우트 예시: `dashboard#monitoring?section=agents`, `dashboard#monitoring?section=journey`, `dashboard#command?section=operations`, `dashboard#connectors?section=connector-status`, `dashboard#lab?section=memory-subsystems`, `dashboard#workspace?section=verification`.
 
-(`journey` 같은 일부 진단 뷰는 `navigation.ts`가 아닌 `dashboard/src/config/status.ts`의 라우트-전용 매핑으로 제공되므로 위 예시에서 제외했다.)
+(`monitoring?section=journey` 같은 일부 진단 뷰는 `navigation.ts` 레일 서피스가 아니라 `dashboard/src/config/status.ts`의 라우트-전용 매핑으로 제공된다 — 레일 라벨 없이 라우트로만 도달한다.)
 
 ---
 


### PR DESCRIPTION
## 문제 — main이 doc-truth로 red (모든 PR이 상속)

`scripts/check-doc-truth.sh:104-107`이 README.md에 4개 라우트 문자열을 `require_contains`로 강제하는데, README surface rewrite 이후 **2개가 누락**되어 있었습니다:

- 누락: `dashboard#monitoring?section=journey`, `dashboard#connectors?section=connector-status`
- README 실제: `monitoring?section=agents`(default), `command?section=operations`✅, `lab?section=memory-subsystems`, `workspace?section=verification`✅

→ main이 doc-truth로 깨져 있었고, 열린 PR 전부(#22189 등)가 이 red를 상속했습니다.

## 근거 (navigation.ts SSOT 교차검증)

- `connectors`: `defaultParams: { section: 'connector-status' }` (navigation.ts:237) — 유효한 default 라우트인데 README에서 누락.
- `journey`: monitoring의 route-only 진단 뷰(`status.ts`, 레일 라벨 없음). README가 의도적으로 제외했었으나(구 line 140) check는 요구 → 불일치.

## 수정

- 라우트 예시에 `monitoring?section=journey`·`connectors?section=connector-status` 추가.
- journey 주석을 "예시에서 제외" → "레일 서피스가 아닌 route-only"로 reword해 **모순 제거**(작성자 의도 보존 + check 만족).

## 검증

- `bash scripts/check-doc-truth.sh` → exit 0 ("Doc truth OK").

이 PR이 머지되면 repo 전역 doc-truth red가 해소됩니다.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
