### PR TITLE
fix(sse): guard SSE connection close against cross-domain double-resolve (RFC-0204 Phase 3 P0)

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -146,16 +146,16 @@ let stream_post_sse_start ~deps ~origin ~session_id ~protocol_version
 let spawn_post_sse_keepalive ~sw ~clock info =
   Eio.Fiber.fork ~sw (fun () ->
       let rec loop () =
-        if not !(info.stop) then (
+        if not (Atomic.get info.stop) then (
           (try
              Eio.Time.sleep clock post_sse_keepalive_interval_s
            with
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn -> Log.Server.warn "SSE keepalive sleep failed for session %s: %s"
                     info.session_id (Printexc.to_string exn));
-          if info.closed then
+          if Atomic.get info.closed then
             close_sse_conn info
-          else if not !(info.stop) then
+          else if not (Atomic.get info.stop) then
             if not (send_raw info ": keepalive\n\n") then
               Log.Server.debug "SSE keepalive send failed for session %s"
                 info.session_id;
@@ -663,7 +663,7 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
                   let rec drain () =
                     let event = Eio.Stream.take event_stream in
                     (try
-                      if not (info.closed || !(info.stop)) then
+                      if not (Atomic.get info.closed || (Atomic.get info.stop)) then
                         if not (send_raw info event) then
                           Log.Server.debug "SSE drain send failed for session %s"
                             info.session_id
@@ -671,7 +671,7 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
                       Log.Server.error "drain write error: %s"
                         (Printexc.to_string exn);
                       stop_sse_session info.session_id);
-                    if not !(info.stop) then drain ()
+                    if not (Atomic.get info.stop) then drain ()
                   in
                   try drain ()
                   with Eio.Cancel.Cancelled _ as e -> raise e
@@ -685,16 +685,16 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
                     | _ -> false
                   in
                   let rec loop () =
-                    if not !(info.stop) then (
+                    if not (Atomic.get info.stop) then (
                       (try Eio.Time.sleep clock sse_ping_interval_s
                        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                          if is_cancelled exn then raise exn;
                          Log.Server.error "ping sleep error: %s"
                            (Printexc.to_string exn));
                       (try
-                         if info.closed then
+                         if Atomic.get info.closed then
                            stop_sse_session info.session_id
-                         else if not !(info.stop) then
+                         else if not (Atomic.get info.stop) then
                            if not (send_raw info ": ping\n\n") then
                              Log.Server.debug "SSE ping send failed for session %s"
                                info.session_id

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -123,7 +123,7 @@ let handle_ag_ui_events ~deps request reqd =
                       let rec drain () =
                         let event = Eio.Stream.take event_stream in
                         (try
-                          if not (info.closed || !(info.stop)) then
+                          if not (Atomic.get info.closed || (Atomic.get info.stop)) then
                             if not (send_raw info event) then
                               Log.Server.debug "ag-ui drain send failed for session %s"
                                 info.session_id
@@ -131,7 +131,7 @@ let handle_ag_ui_events ~deps request reqd =
                           Log.Server.error "ag-ui drain write error: %s"
                             (Printexc.to_string exn);
                           stop_sse_session_preserve_guard info.session_id);
-                        if not !(info.stop) then drain ()
+                        if not (Atomic.get info.stop) then drain ()
                       in
                       try drain ()
                       with Eio.Cancel.Cancelled _ as e -> raise e
@@ -140,14 +140,14 @@ let handle_ag_ui_events ~deps request reqd =
                              (Printexc.to_string exn))
                     ~ping:(fun () ->
                       let rec loop () =
-                        if not !(info.stop) then (
+                        if not (Atomic.get info.stop) then (
                           (try Eio.Time.sleep clock sse_ping_interval_s
                            with Eio.Cancel.Cancelled _ as exn -> raise exn
                               | exn -> Log.Server.debug "SSE ping sleep interrupted: %s" (Printexc.to_string exn));
                           (try
-                             if info.closed then
+                             if Atomic.get info.closed then
                                stop_sse_session_preserve_guard info.session_id
-                             else if not !(info.stop) then
+                             else if not (Atomic.get info.stop) then
                                if not (send_raw info ": ping\n\n") then
                                  Log.Server.debug "ag-ui ping send failed for session %s"
                                    info.session_id
@@ -228,7 +228,7 @@ let handle_presence_events ~deps request reqd =
                   let rec drain () =
                     let event = Eio.Stream.take event_stream in
                     (try
-                       if not (info.closed || !(info.stop)) then
+                       if not (Atomic.get info.closed || (Atomic.get info.stop)) then
                          if not (send_raw info event) then
                            Log.Server.debug
                              "presence drain send failed for session %s"
@@ -239,7 +239,7 @@ let handle_presence_events ~deps request reqd =
                          Log.Server.error "presence drain write error: %s"
                            (Printexc.to_string exn);
                          stop_sse_session_preserve_guard info.session_id);
-                    if not !(info.stop) then drain ()
+                    if not (Atomic.get info.stop) then drain ()
                   in
                   try drain ()
                   with
@@ -249,7 +249,7 @@ let handle_presence_events ~deps request reqd =
                         (Printexc.to_string exn))
                 ~ping:(fun () ->
                   let rec loop () =
-                    if not !(info.stop) then (
+                    if not (Atomic.get info.stop) then (
                       (try Eio.Time.sleep clock sse_ping_interval_s
                        with
                        | Eio.Cancel.Cancelled _ as e -> raise e
@@ -258,9 +258,9 @@ let handle_presence_events ~deps request reqd =
                              "presence ping sleep interrupted: %s"
                              (Printexc.to_string exn));
                       (try
-                         if info.closed then
+                         if Atomic.get info.closed then
                            stop_sse_session_preserve_guard info.session_id
-                         else if not !(info.stop) then
+                         else if not (Atomic.get info.stop) then
                            if not (send_raw info ": ping\n\n") then
                              Log.Server.debug
                                "presence ping send failed for session %s"

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -11,8 +11,9 @@ type sse_conn_info = {
   (* [stop] and [closed] are touched from more than one domain once serving
      runs off the main domain (a disconnect close racing keeper-driven eviction
      / shutdown), so they are [Atomic.t], not a plain [ref] / [mutable].
-     [closed] is the single-close guard: [claim_close] flips it false->true with
-     [compare_and_set] so exactly one caller resolves the one-shot stop promise. *)
+     [closed] is the single-close guard: [run_on_first_close] flips it
+     false->true with [compare_and_set] so exactly one caller runs the close
+     body and resolves the one-shot stop promise. *)
   stop : bool Atomic.t;
   closed : bool Atomic.t;
   (* Resolved exactly once by [close_sse_conn]. [run_sse_pumps] forks the
@@ -103,20 +104,22 @@ let guard_expired ~now ~session_id state =
 let register_sse_conn ~session_id ~info =
   atomic_update sse_conn_by_session (fun map -> SMap.add session_id info map)
 
-(* Claim the single close of [info]: returns [true] for exactly one caller even
-   under concurrent close paths (a disconnect on one domain racing eviction or
-   shutdown on another).  The close body below — including
-   [Eio.Promise.resolve info.resolve_stop] — must run at most once; a second
-   resolve of a one-shot promise raises [Invalid_argument]. *)
-let claim_close info = Atomic.compare_and_set info.closed false true
-
-let __test_claim_close = claim_close
+(* [run_on_first_close closed ~f] runs [f] for exactly the first caller that
+   flips [closed] false->true; later callers are no-ops.  [close_sse_conn]
+   composes its entire close body — including the one-shot
+   [Eio.Promise.resolve info.resolve_stop], whose second call would raise
+   [Invalid_argument] — through this gate, so a disconnect on the serving domain
+   racing eviction or shutdown on the main domain resolves the promise at most
+   once.  Putting the body inside [~f] makes "resolve outside the gate"
+   unrepresentable rather than something a separate drift test has to police. *)
+let run_on_first_close closed ~f =
+  if Atomic.compare_and_set closed false true then f ()
 
 let close_sse_conn info =
-  if claim_close info then (
+  run_on_first_close info.closed ~f:(fun () ->
     Atomic.set info.stop true;
-    (* Release the per-connection pump switch (run_sse_pumps). [claim_close]
-       admits exactly one caller, so the promise is resolved exactly once. *)
+    (* Resolve releases the per-connection pump switch (run_sse_pumps); the gate
+       admits exactly one caller, so this one-shot resolve runs at most once. *)
     Eio.Promise.resolve info.resolve_stop ();
     (try Httpun.Body.Writer.close info.writer
      with
@@ -125,6 +128,10 @@ let close_sse_conn info =
        Log.Misc.debug "close_sse_conn: %s"
          (Printexc.to_string exn));
     Sse.unregister_if_current info.session_id info.client_id)
+
+module For_test = struct
+  let run_on_first_close = run_on_first_close
+end
 
 let stop_sse_session_impl ~clear_guard session_id =
   let info_opt = ref None in

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -8,8 +8,13 @@ type sse_conn_info = {
   client_id : int;
   writer : Httpun.Body.Writer.t;
   mutex : Eio.Mutex.t;
-  stop : bool ref;
-  mutable closed : bool;
+  (* [stop] and [closed] are touched from more than one domain once serving
+     runs off the main domain (a disconnect close racing keeper-driven eviction
+     / shutdown), so they are [Atomic.t], not a plain [ref] / [mutable].
+     [closed] is the single-close guard: [claim_close] flips it false->true with
+     [compare_and_set] so exactly one caller resolves the one-shot stop promise. *)
+  stop : bool Atomic.t;
+  closed : bool Atomic.t;
   (* Resolved exactly once by [close_sse_conn]. [run_sse_pumps] forks the
      drain/ping pumps under a per-connection switch and awaits this promise;
      resolving it releases that switch, cancelling both pumps — including a
@@ -28,8 +33,8 @@ let make_sse_conn ~session_id ~client_id ~writer ~mutex () =
     client_id;
     writer;
     mutex;
-    stop = ref false;
-    closed = false;
+    stop = Atomic.make false;
+    closed = Atomic.make false;
     stop_promise;
     resolve_stop;
   }
@@ -98,13 +103,20 @@ let guard_expired ~now ~session_id state =
 let register_sse_conn ~session_id ~info =
   atomic_update sse_conn_by_session (fun map -> SMap.add session_id info map)
 
+(* Claim the single close of [info]: returns [true] for exactly one caller even
+   under concurrent close paths (a disconnect on one domain racing eviction or
+   shutdown on another).  The close body below — including
+   [Eio.Promise.resolve info.resolve_stop] — must run at most once; a second
+   resolve of a one-shot promise raises [Invalid_argument]. *)
+let claim_close info = Atomic.compare_and_set info.closed false true
+
+let __test_claim_close = claim_close
+
 let close_sse_conn info =
-  if not info.closed then (
-    info.closed <- true;
-    info.stop := true;
-    (* Release the per-connection pump switch (run_sse_pumps). This body runs
-       once per info (guarded by [closed]), so the promise is resolved exactly
-       once. *)
+  if claim_close info then (
+    Atomic.set info.stop true;
+    (* Release the per-connection pump switch (run_sse_pumps). [claim_close]
+       admits exactly one caller, so the promise is resolved exactly once. *)
     Eio.Promise.resolve info.resolve_stop ();
     (try Httpun.Body.Writer.close info.writer
      with
@@ -166,7 +178,7 @@ let stop_sse_session_evict session_id
        let frame = Sse.format_event ~event_type:"evicted" frame_data in
        (try
           Eio.Mutex.use_rw ~protect:true info.mutex (fun () ->
-            if (not info.closed) && not !(info.stop) then
+            if (not (Atomic.get info.closed)) && not (Atomic.get info.stop) then
               Httpun.Body.Writer.write_string info.writer frame)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
@@ -216,7 +228,7 @@ let close_all_sse_connections () =
     (List.length infos)
 
 let send_raw info data =
-  if info.closed || !(info.stop) || Httpun.Body.Writer.is_closed info.writer then (
+  if Atomic.get info.closed || Atomic.get info.stop || Httpun.Body.Writer.is_closed info.writer then (
     close_sse_conn info;
     false)
   else

--- a/lib/server/server_mcp_transport_http_conn.mli
+++ b/lib/server/server_mcp_transport_http_conn.mli
@@ -76,12 +76,15 @@ val close_sse_conn : sse_conn_info -> unit
     Errors during writer close log at {!Log.Misc.debug} but do
     not propagate. *)
 
-val __test_claim_close : sse_conn_info -> bool
-(** Test-only seam: the close-claim used by {!close_sse_conn}.  Returns [true]
-    for the single caller that wins the right to run the close body (resolve the
-    one-shot stop promise).  Exposed so the cross-domain regression test can
-    race two domains on one connection and assert at most one wins — two winners
-    would double-resolve the promise and crash. *)
+(** Test-only seam. *)
+module For_test : sig
+  val run_on_first_close : bool Atomic.t -> f:(unit -> unit) -> unit
+  (** The one-shot close gate used by {!close_sse_conn}: runs [f] for exactly
+      the first caller that flips the flag false->true.  Exposed so the
+      cross-domain regression test can race two domains on one flag and assert
+      [f] runs for at most one — two winners would double-resolve the stop
+      promise and crash. *)
+end
 
 val stop_sse_session : string -> unit
 (** [stop_sse_session session_id] removes the registry entry

--- a/lib/server/server_mcp_transport_http_conn.mli
+++ b/lib/server/server_mcp_transport_http_conn.mli
@@ -17,8 +17,8 @@ type sse_conn_info = {
   client_id : int;
   writer : Httpun.Body.Writer.t;
   mutex : Eio.Mutex.t;
-  stop : bool ref;
-  mutable closed : bool;
+  stop : bool Atomic.t;
+  closed : bool Atomic.t;
   stop_promise : unit Eio.Promise.t;
   resolve_stop : unit Eio.Promise.u;
 }
@@ -27,15 +27,20 @@ type sse_conn_info = {
     via {!make_sse_conn} for the SSE handler.  [client_id = -1]
     indicates an inline response (see {!make_inline_sse_conn}).
 
-    [stop] is a [bool ref] (not [Atomic.t]) because all callers
-    update it from a single fiber under [mutex]; the
-    cross-fiber visibility is established via
-    [Eio.Mutex.use_rw].
+    [closed] and [stop] are [Atomic.t] because the close paths run
+    on different domains once serving moves off the main domain
+    (a client disconnect on the serving domain vs keeper-driven
+    eviction / shutdown on the main domain) — they are not confined
+    to one fiber under [mutex].  [closed] is the single-close guard:
+    {!close_sse_conn} flips it false->true with [compare_and_set] so
+    exactly one caller runs the close body.
 
     [stop_promise]/[resolve_stop] is resolved exactly once by
-    {!close_sse_conn}; {!run_sse_pumps} awaits it to release the
-    per-connection pump switch.  Construct via {!make_sse_conn} so
-    the promise is always paired with the connection. *)
+    {!close_sse_conn} (guaranteed by the [closed] claim above; a
+    second resolve of a one-shot promise raises [Invalid_argument]);
+    {!run_sse_pumps} awaits it to release the per-connection pump
+    switch.  Construct via {!make_sse_conn} so the promise is always
+    paired with the connection. *)
 
 (** {1 Connect-rate guard env knobs} *)
 
@@ -70,6 +75,13 @@ val close_sse_conn : sse_conn_info -> unit
     the SSE client.  Idempotent — safe to call multiple times.
     Errors during writer close log at {!Log.Misc.debug} but do
     not propagate. *)
+
+val __test_claim_close : sse_conn_info -> bool
+(** Test-only seam: the close-claim used by {!close_sse_conn}.  Returns [true]
+    for the single caller that wins the right to run the close body (resolve the
+    one-shot stop promise).  Exposed so the cross-domain regression test can
+    race two domains on one connection and assert at most one wins — two winners
+    would double-resolve the promise and crash. *)
 
 val stop_sse_session : string -> unit
 (** [stop_sse_session session_id] removes the registry entry
@@ -146,7 +158,7 @@ val make_sse_conn :
   unit ->
   sse_conn_info
 (** [make_sse_conn ~session_id ~client_id ~writer ~mutex ()] builds an
-    [sse_conn_info] with [stop = ref false], [closed = false], and a fresh
+    [sse_conn_info] with [stop] and [closed] both [Atomic.make false], and a fresh
     [stop_promise]/[resolve_stop] pair.  All SSE handlers construct connections
     through this so the stop promise is never omitted. *)
 

--- a/test/test_sse_external_sub.ml
+++ b/test/test_sse_external_sub.ml
@@ -181,42 +181,36 @@ let test_external_subscriber_count_linearized_under_domain_contention () =
 (* RFC-0204 Phase 3 prerequisite.  [close_sse_conn] resolves a one-shot stop
    promise; two close paths can race across domains once serving moves off the
    main domain (a client disconnect on the serving domain vs keeper-driven
-   eviction / shutdown on the main domain).  The close body is gated on
-   [claim_close = Atomic.compare_and_set info.closed false true]; if two callers
-   both won, both would [Eio.Promise.resolve] the same promise and raise
-   [Invalid_argument].
+   eviction / shutdown on the main domain).  The close body is gated by
+   [Conn.For_test.run_on_first_close], which runs the body for exactly the first
+   caller that flips the flag false->true; if two callers both won, both would
+   [Eio.Promise.resolve] the same promise and raise [Invalid_argument].
 
-   This drives the [claim_close] PRIMITIVE (via [__test_claim_close]) from two
-   domains over many fresh connections and asserts no connection is claimed by
-   both.  Two winners is exactly the double-resolve precondition.  It proves the
-   primitive, not the wiring — close_sse_conn itself cannot be called in a unit
-   test because it closes a [Httpun.Body.Writer.t], which has no public
-   constructor; [test_close_sse_conn_resolve_is_claim_gated] below pins the
-   wiring at the source level.  RED on the plain check-then-set guard (measured
-   208/50000 double-claims), GREEN on the Atomic compare_and_set. *)
-let test_claim_close_admits_one_winner_across_domains () =
-  if Domain.recommended_domain_count () < 2 then
+   This drives the gate itself — the exact function [close_sse_conn] composes
+   its body through — from two domains over many fresh flags and asserts the
+   gated action runs for at most one domain per flag.  Because the close body
+   (resolve + writer close + unregister) lives inside the gate's [~f] closure,
+   "resolve outside the gate" is not expressible, so no source-level drift guard
+   is needed.  RED on a plain check-then-set gate (measured 208/50000
+   double-runs), GREEN on the Atomic compare_and_set gate. *)
+let test_close_gate_admits_one_winner_across_domains () =
+  if Domain.recommended_domain_count () < 2 then (
     (* On a single-vCPU host the two domains time-slice instead of running in
-       parallel, so the race cannot occur and a green here proves nothing.  Log
-       the skip so a CI run on such a host does not read as real coverage. *)
+       parallel, so the race cannot occur and a green here would prove nothing.
+       Report the skip explicitly so the run is recorded as skipped, not as
+       passing coverage. *)
     Printf.eprintf
-      "[close_race] SKIP test_claim_close_admits_one_winner_across_domains: \
+      "[close_race] SKIP test_close_gate_admits_one_winner_across_domains: \
        recommended_domain_count=%d (<2); cross-domain race cannot manifest\n%!"
-      (Domain.recommended_domain_count ())
+      (Domain.recommended_domain_count ());
+    Alcotest.skip ())
   else begin
     let trials = 50_000 in
-    (* The claim path touches only [info.closed]; [mutex] is a real (free) Eio
-       mutex and [writer] is never dereferenced here, so a stub writer is safe. *)
-    let mutex = Eio.Mutex.create () in
-    let infos =
-      Array.init trials (fun _ ->
-        Conn.make_sse_conn ~session_id:"close-race" ~client_id:0
-          ~writer:(Obj.magic ()) ~mutex ())
-    in
+    let flags = Array.init trials (fun _ -> Atomic.make false) in
     let won = Array.make_matrix 2 trials false in
     (* Two-phase counting barrier across two long-lived domains: at trial [t],
-       both must arrive (2*(t+1) total) before either claims, so the two claims
-       on [infos.(t)] run in true overlap. *)
+       both must arrive (2*(t+1) total) before either closes, so the two close
+       attempts on [flags.(t)] run in true overlap. *)
     let arrived = Atomic.make 0 in
     let worker who =
       for t = 0 to trials - 1 do
@@ -224,7 +218,8 @@ let test_claim_close_admits_one_winner_across_domains () =
         while Atomic.get arrived < 2 * (t + 1) do
           Domain.cpu_relax ()
         done;
-        won.(who).(t) <- Conn.__test_claim_close infos.(t)
+        Conn.For_test.run_on_first_close flags.(t)
+          ~f:(fun () -> won.(who).(t) <- true)
       done
     in
     let other = Domain.spawn (fun () -> worker 1) in
@@ -235,71 +230,15 @@ let test_claim_close_admits_one_winner_across_domains () =
       if won.(0).(t) && won.(1).(t) then incr double
     done;
     Alcotest.(check int)
-      "claim_close never admits two winners (would double-resolve the promise)"
+      "close gate never runs the body for two winners (would double-resolve)"
       0 !double
   end
-
-(* Read a repo source file by walking up from the test's cwd to the directory
-   that contains it. *)
-let read_repo_source rel =
-  let rec find dir hops =
-    if hops > 8 then Alcotest.failf "source root not found from %s" (Sys.getcwd ())
-    else if Sys.file_exists (Filename.concat dir rel) then Filename.concat dir rel
-    else
-      let parent = Filename.dirname dir in
-      if String.equal parent dir then
-        Alcotest.failf "source root not found for %s" rel
-      else find parent (hops + 1)
-  in
-  let path = find (Sys.getcwd ()) 0 in
-  let ic = open_in_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () -> really_input_string ic (in_channel_length ic))
-
-let substring_index hay needle =
-  let hl = String.length hay and nl = String.length needle in
-  let rec loop i =
-    if i + nl > hl then -1
-    else if String.equal (String.sub hay i nl) needle then i
-    else loop (i + 1)
-  in
-  loop 0
-
-let substring_count hay needle =
-  let hl = String.length hay and nl = String.length needle in
-  let rec loop i acc =
-    if i + nl > hl then acc
-    else if String.equal (String.sub hay i nl) needle then loop (i + nl) (acc + 1)
-    else loop (i + 1) acc
-  in
-  loop 0 0
-
-(* Drift guard for the wiring the behavioral test cannot exercise (no
-   constructible Httpun writer): close_sse_conn must resolve the one-shot stop
-   promise at exactly one site, and that site must sit under the [claim_close]
-   CAS guard.  Catches a refactor that resolves outside / before the guard. *)
-let test_close_sse_conn_resolve_is_claim_gated () =
-  let src = read_repo_source "lib/server/server_mcp_transport_http_conn.ml" in
-  (* The applied call form ([... ()]); the doc comment above the function
-     mentions [Eio.Promise.resolve info.resolve_stop] in brackets without the
-     application, so this needle matches only the real call site. *)
-  let resolve = "Eio.Promise.resolve info.resolve_stop ()" in
-  let guard = "if claim_close info then" in
-  Alcotest.(check int) "stop promise resolved at exactly one call site"
-    1 (substring_count src resolve);
-  let gi = substring_index src guard in
-  let ri = substring_index src resolve in
-  Alcotest.(check bool) "the resolve sits under the claim_close CAS guard"
-    true (gi >= 0 && ri > gi)
 
 let () =
   Alcotest.run "SSE External Subscribers" [
     ("close_race", [
-      Alcotest.test_case "claim_close admits one winner across domains"
-        `Quick test_claim_close_admits_one_winner_across_domains;
-      Alcotest.test_case "close_sse_conn resolve is claim_close-gated (source)"
-        `Quick test_close_sse_conn_resolve_is_claim_gated;
+      Alcotest.test_case "close gate admits one winner across domains"
+        `Quick test_close_gate_admits_one_winner_across_domains;
     ]);
     ("lifecycle", [
       Alcotest.test_case "subscribe and unsubscribe" `Quick

--- a/test/test_sse_external_sub.ml
+++ b/test/test_sse_external_sub.ml
@@ -178,25 +178,40 @@ let test_external_subscriber_count_linearized_under_domain_contention () =
         count_before
         (Masc.Sse.external_subscriber_count_with_prefix prefix))
 
-(* RFC-0204 Phase 3 prerequisite: [close_sse_conn] resolves a one-shot stop
-   promise.  Two close paths can race across domains once serving moves off the
+(* RFC-0204 Phase 3 prerequisite.  [close_sse_conn] resolves a one-shot stop
+   promise; two close paths can race across domains once serving moves off the
    main domain (a client disconnect on the serving domain vs keeper-driven
-   eviction / shutdown on the main domain).  The claim guard must admit exactly
-   one closer; two would both [Eio.Promise.resolve] the same promise and raise
-   [Invalid_argument].  This races two domains on the claim for many fresh
-   connections and asserts no connection is ever claimed by both — two winners
-   is exactly the double-resolve crash precondition.  RED on the plain
-   check-then-set guard, GREEN once it is an Atomic compare_and_set.  Skips on
-   single-vCPU hosts where the race cannot manifest. *)
-let test_close_sse_conn_claims_at_most_one_closer () =
-  if Domain.recommended_domain_count () < 2 then ()
+   eviction / shutdown on the main domain).  The close body is gated on
+   [claim_close = Atomic.compare_and_set info.closed false true]; if two callers
+   both won, both would [Eio.Promise.resolve] the same promise and raise
+   [Invalid_argument].
+
+   This drives the [claim_close] PRIMITIVE (via [__test_claim_close]) from two
+   domains over many fresh connections and asserts no connection is claimed by
+   both.  Two winners is exactly the double-resolve precondition.  It proves the
+   primitive, not the wiring — close_sse_conn itself cannot be called in a unit
+   test because it closes a [Httpun.Body.Writer.t], which has no public
+   constructor; [test_close_sse_conn_resolve_is_claim_gated] below pins the
+   wiring at the source level.  RED on the plain check-then-set guard (measured
+   208/50000 double-claims), GREEN on the Atomic compare_and_set. *)
+let test_claim_close_admits_one_winner_across_domains () =
+  if Domain.recommended_domain_count () < 2 then
+    (* On a single-vCPU host the two domains time-slice instead of running in
+       parallel, so the race cannot occur and a green here proves nothing.  Log
+       the skip so a CI run on such a host does not read as real coverage. *)
+    Printf.eprintf
+      "[close_race] SKIP test_claim_close_admits_one_winner_across_domains: \
+       recommended_domain_count=%d (<2); cross-domain race cannot manifest\n%!"
+      (Domain.recommended_domain_count ())
   else begin
     let trials = 50_000 in
-    (* writer / mutex are never touched by the claim path, so a stub is safe. *)
+    (* The claim path touches only [info.closed]; [mutex] is a real (free) Eio
+       mutex and [writer] is never dereferenced here, so a stub writer is safe. *)
+    let mutex = Eio.Mutex.create () in
     let infos =
       Array.init trials (fun _ ->
         Conn.make_sse_conn ~session_id:"close-race" ~client_id:0
-          ~writer:(Obj.magic ()) ~mutex:(Obj.magic ()) ())
+          ~writer:(Obj.magic ()) ~mutex ())
     in
     let won = Array.make_matrix 2 trials false in
     (* Two-phase counting barrier across two long-lived domains: at trial [t],
@@ -220,15 +235,71 @@ let test_close_sse_conn_claims_at_most_one_closer () =
       if won.(0).(t) && won.(1).(t) then incr double
     done;
     Alcotest.(check int)
-      "close claim never admits two closers (would double-resolve the promise)"
+      "claim_close never admits two winners (would double-resolve the promise)"
       0 !double
   end
+
+(* Read a repo source file by walking up from the test's cwd to the directory
+   that contains it. *)
+let read_repo_source rel =
+  let rec find dir hops =
+    if hops > 8 then Alcotest.failf "source root not found from %s" (Sys.getcwd ())
+    else if Sys.file_exists (Filename.concat dir rel) then Filename.concat dir rel
+    else
+      let parent = Filename.dirname dir in
+      if String.equal parent dir then
+        Alcotest.failf "source root not found for %s" rel
+      else find parent (hops + 1)
+  in
+  let path = find (Sys.getcwd ()) 0 in
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let substring_index hay needle =
+  let hl = String.length hay and nl = String.length needle in
+  let rec loop i =
+    if i + nl > hl then -1
+    else if String.equal (String.sub hay i nl) needle then i
+    else loop (i + 1)
+  in
+  loop 0
+
+let substring_count hay needle =
+  let hl = String.length hay and nl = String.length needle in
+  let rec loop i acc =
+    if i + nl > hl then acc
+    else if String.equal (String.sub hay i nl) needle then loop (i + nl) (acc + 1)
+    else loop (i + 1) acc
+  in
+  loop 0 0
+
+(* Drift guard for the wiring the behavioral test cannot exercise (no
+   constructible Httpun writer): close_sse_conn must resolve the one-shot stop
+   promise at exactly one site, and that site must sit under the [claim_close]
+   CAS guard.  Catches a refactor that resolves outside / before the guard. *)
+let test_close_sse_conn_resolve_is_claim_gated () =
+  let src = read_repo_source "lib/server/server_mcp_transport_http_conn.ml" in
+  (* The applied call form ([... ()]); the doc comment above the function
+     mentions [Eio.Promise.resolve info.resolve_stop] in brackets without the
+     application, so this needle matches only the real call site. *)
+  let resolve = "Eio.Promise.resolve info.resolve_stop ()" in
+  let guard = "if claim_close info then" in
+  Alcotest.(check int) "stop promise resolved at exactly one call site"
+    1 (substring_count src resolve);
+  let gi = substring_index src guard in
+  let ri = substring_index src resolve in
+  Alcotest.(check bool) "the resolve sits under the claim_close CAS guard"
+    true (gi >= 0 && ri > gi)
 
 let () =
   Alcotest.run "SSE External Subscribers" [
     ("close_race", [
-      Alcotest.test_case "close_sse_conn claims at most one closer across domains"
-        `Quick test_close_sse_conn_claims_at_most_one_closer;
+      Alcotest.test_case "claim_close admits one winner across domains"
+        `Quick test_claim_close_admits_one_winner_across_domains;
+      Alcotest.test_case "close_sse_conn resolve is claim_close-gated (source)"
+        `Quick test_close_sse_conn_resolve_is_claim_gated;
     ]);
     ("lifecycle", [
       Alcotest.test_case "subscribe and unsubscribe" `Quick

--- a/test/test_sse_external_sub.ml
+++ b/test/test_sse_external_sub.ml
@@ -1,7 +1,13 @@
 (** SSE External Subscriber Tests
 
     Verifies that Sse.subscribe_external / unsubscribe_external
-    correctly hooks into the broadcast fan-out path. *)
+    correctly hooks into the broadcast fan-out path.
+
+    Also hosts the SSE connection close-race regression
+    (Server_mcp_transport_http_conn), which shares this file's domain-contention
+    harness. *)
+
+module Conn = Server_mcp_transport_http_conn
 
 let received_events : string list ref = ref []
 
@@ -172,8 +178,58 @@ let test_external_subscriber_count_linearized_under_domain_contention () =
         count_before
         (Masc.Sse.external_subscriber_count_with_prefix prefix))
 
+(* RFC-0204 Phase 3 prerequisite: [close_sse_conn] resolves a one-shot stop
+   promise.  Two close paths can race across domains once serving moves off the
+   main domain (a client disconnect on the serving domain vs keeper-driven
+   eviction / shutdown on the main domain).  The claim guard must admit exactly
+   one closer; two would both [Eio.Promise.resolve] the same promise and raise
+   [Invalid_argument].  This races two domains on the claim for many fresh
+   connections and asserts no connection is ever claimed by both — two winners
+   is exactly the double-resolve crash precondition.  RED on the plain
+   check-then-set guard, GREEN once it is an Atomic compare_and_set.  Skips on
+   single-vCPU hosts where the race cannot manifest. *)
+let test_close_sse_conn_claims_at_most_one_closer () =
+  if Domain.recommended_domain_count () < 2 then ()
+  else begin
+    let trials = 50_000 in
+    (* writer / mutex are never touched by the claim path, so a stub is safe. *)
+    let infos =
+      Array.init trials (fun _ ->
+        Conn.make_sse_conn ~session_id:"close-race" ~client_id:0
+          ~writer:(Obj.magic ()) ~mutex:(Obj.magic ()) ())
+    in
+    let won = Array.make_matrix 2 trials false in
+    (* Two-phase counting barrier across two long-lived domains: at trial [t],
+       both must arrive (2*(t+1) total) before either claims, so the two claims
+       on [infos.(t)] run in true overlap. *)
+    let arrived = Atomic.make 0 in
+    let worker who =
+      for t = 0 to trials - 1 do
+        ignore (Atomic.fetch_and_add arrived 1);
+        while Atomic.get arrived < 2 * (t + 1) do
+          Domain.cpu_relax ()
+        done;
+        won.(who).(t) <- Conn.__test_claim_close infos.(t)
+      done
+    in
+    let other = Domain.spawn (fun () -> worker 1) in
+    worker 0;
+    Domain.join other;
+    let double = ref 0 in
+    for t = 0 to trials - 1 do
+      if won.(0).(t) && won.(1).(t) then incr double
+    done;
+    Alcotest.(check int)
+      "close claim never admits two closers (would double-resolve the promise)"
+      0 !double
+  end
+
 let () =
   Alcotest.run "SSE External Subscribers" [
+    ("close_race", [
+      Alcotest.test_case "close_sse_conn claims at most one closer across domains"
+        `Quick test_close_sse_conn_claims_at_most_one_closer;
+    ]);
     ("lifecycle", [
       Alcotest.test_case "subscribe and unsubscribe" `Quick
         test_subscribe_and_unsubscribe;


### PR DESCRIPTION
## 목적

SSE 연결 close의 **cross-domain 이중 `Promise.resolve` crash**를 차단한다. `close_sse_conn`은 one-shot stop promise를 resolve하는데, 그 가드가 plain `mutable bool`에 대한 check-then-set(`if not info.closed then ...`)이고 `info.stop`은 `bool ref`였다. serving이 main domain을 벗어나면(RFC-0204 Phase 3) 두 close 경로가 서로 다른 domain에서 경합한다 — serving domain의 클라이언트 disconnect close vs main domain의 keeper-driven eviction/shutdown. 두 closer가 둘 다 `closed = false`를 관측하고 둘 다 close 본문을 실행해 같은 promise를 두 번 resolve → `Invalid_argument` crash.

RFC-0204 Phase 3 per-handler shared-state audit의 **P0 blocker #3**(REFUTED safe verdict: `GET /ag-ui/events`).

## 변경

`lib/server/server_mcp_transport_http_conn.ml` + `.mli` (+ MCP HTTP / AG-UI SSE 핸들러 reader):

- `sse_conn_info.closed`(было `mutable bool`)와 `stop`(было `bool ref`) → `bool Atomic.t`.
- close 가드를 `claim_close = Atomic.compare_and_set info.closed false true`로 추출. `close_sse_conn`은 CAS 승자 1명에 대해서만 본문(resolve + writer close + unregister) 실행 → resolve가 정확히 1회.
- 모든 reader를 `Atomic.get`/`Atomic.set`로 변환(`server_mcp_transport_http.ml`, `server_mcp_transport_http_agui.ml`). 컴파일러가 전 accessor를 강제 검출 — full build green = 누락 0.
- `closed`(CAS)를 `stop`(set) 앞에 둠. 전이 중 reader가 두 flag의 불일치 조합을 관측할 수 있으나(SC라도 reader가 `closed`를 먼저 읽으면 `closed=false, stop=true` 관측 가능) **무해**하다 — 모든 reader(`drain`/`ping`/`keepalive`/`send_raw`/evict)가 `closed`·`stop` 중 *어느 하나라도* true면 terminal로 취급하므로, 어떤 조합이든 닫힘 경로로 수렴한다. 안전 근거는 unobservability가 아니라 "양 flag terminal 취급".

## 범위 (자매 코드 확인)

`lib/server/server_activity_http.ml`의 `stream_info`도 동일 필드명(`closed`/`stop`)을 plain으로 갖지만 **버그 아님 — 손대지 않음**: `close_stream`의 check-then-set은 `Eio.Mutex.use_rw info.mutex` 안에서 실행되고 one-shot promise resolve가 없다. 즉 per-connection mutex(cross-domain-safe)가 직렬화하므로 안전. conn.ml이 버그였던 이유가 정확히 *mutex 없이 resolve*했기 때문 — 이 대비가 fix 범위가 정확함을 보인다.

## 측정 (RED → GREEN, M3 Max)

`test/test_sse_external_sub.ml` `close_race` 그룹: 두 실제 domain이 two-phase barrier로 동시에 같은 연결의 close claim을 경쟁(50,000 fresh 연결). "둘 다 이긴"(=이중 resolve crash 전제) 횟수를 단언.

| 가드 | 게이트 결과 |
|---|---|
| plain check-then-set (변경 전) | **RED** — 50,000 중 **208**건 double-claim |
| CAS (`compare_and_set`, 변경 후) | **GREEN** — 0 |

게이트는 vacuity 비검증 통과 — `claim_close`를 plain으로 revert하면 다시 RED. 단일-vCPU 호스트(race 불발)에선 skip.

## 검증

- `dune build` 전체 green(record 타입 변경의 전 accessor를 컴파일러가 검출, 자매 타입 미영향).
- `test_sse_external_sub` 10 green(close_race 포함), `test_ws_transport` 65 green, `test_transport_integration` 9 green.
- production 동작 무변경(단일 domain 의미 동일); domain split 없음.

## RFC

RFC-0204 (dashboard-serving-isolation) Phase 3 per-handler shared-state audit P0 blocker #3. domain을 옮기지 않고 close 경로를 cross-domain-safe하게 만든다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
