### PR TITLE
test(dashboard): replace fixed-40ms flushUi with waitFor in code-blocks tests

### DIFF
--- a/dashboard/src/components/chat/code-blocks.test.ts
+++ b/dashboard/src/components/chat/code-blocks.test.ts
@@ -6,12 +6,11 @@
 // the real render path, matching markdown-renderer.test.ts / dompurify.test.ts.
 import { html } from 'htm/preact'
 import { render } from 'preact'
+import { waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChatBlock, KeeperConversationEntry } from '../../types'
 import * as shikiHighlighter from '../common/shiki-highlighter'
 import { ChatTranscript } from './primitives'
-
-const flushUi = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 40))
 
 function entry(
   overrides: Partial<KeeperConversationEntry> & Pick<KeeperConversationEntry, 'id' | 'text'>,
@@ -60,8 +59,7 @@ describe('ChatCodeBlock Shiki highlighting', () => {
     expect(code).not.toBeNull()
     expect(code?.textContent).toContain('config.ml')
 
-    await flushUi()
-    expect(code?.textContent).toContain('let x = 1')
+    await waitFor(() => expect(code?.textContent).toContain('let x = 1'))
 
     const copy = code?.querySelector('button[aria-label="코드 복사"]')
     expect(copy).not.toBeNull()
@@ -83,12 +81,13 @@ describe('ChatCodeBlock Shiki highlighting', () => {
       container,
     )
 
-    await flushUi()
-    const copy = container.querySelector('[data-chat-block="code"] button[aria-label="코드 복사"]') as HTMLButtonElement
+    const copy = await waitFor(() => {
+      const btn = container.querySelector('[data-chat-block="code"] button[aria-label="코드 복사"]') as HTMLButtonElement | null
+      expect(btn).not.toBeNull()
+      return btn as HTMLButtonElement
+    })
     copy.click()
-    await flushUi()
-
-    expect(writeText).toHaveBeenCalledWith('<script>alert(1)</script>')
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('<script>alert(1)</script>'))
 
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
@@ -101,9 +100,8 @@ describe('ChatCodeBlock Shiki highlighting', () => {
 
     render(renderBlocks([{ t: 'code', cap: 'weirdlang', html: 'a &lt; b', source: 'a < b' }]), container)
 
-    await flushUi()
     const code = container.querySelector('[data-chat-block="code"]')
-    expect(code?.classList.contains('chat-block-code-fallback')).toBe(true)
+    await waitFor(() => expect(code?.classList.contains('chat-block-code-fallback')).toBe(true))
     expect(code?.textContent).toContain('a < b')
   })
 })
@@ -128,10 +126,9 @@ describe('ChatMermaidBlock diagram rendering', () => {
     expect(block).not.toBeNull()
     expect(block?.textContent).toContain('flow')
 
-    await flushUi()
     // happy-dom + DOMPurify strip the root <svg> tag in tests, but the rendered
     // diagram text survives inside the figure body.
-    expect(block?.textContent).toContain('graph TD')
+    await waitFor(() => expect(block?.textContent).toContain('graph TD'))
   })
 
   it('falls back to a code block when mermaid rendering errors', async () => {
@@ -140,8 +137,7 @@ describe('ChatMermaidBlock diagram rendering', () => {
 
     render(renderBlocks([{ t: 'mermaid', source: 'invalid diagram', caption: 'broken' }]), container)
 
-    await flushUi()
-    expect(container.querySelector('[data-chat-block="mermaid"]')).toBeNull()
+    await waitFor(() => expect(container.querySelector('[data-chat-block="mermaid"]')).toBeNull())
     const code = container.querySelector('[data-chat-block="code"]')
     expect(code).not.toBeNull()
     expect(code?.textContent).toContain('invalid diagram')


### PR DESCRIPTION
## 무엇을 / 왜

`code-blocks.test.ts`의 비동기 단언들이 `flushUi()`(고정 `setTimeout(40ms)`)로 대기 후 검증했습니다. mermaid 렌더 경로는 다단계 비동기(dynamic `import('mermaid')` → serialize → sanitize → parse → `setState` 재렌더)라, 부하 시 40ms 안에 fallback이 렌더되지 않아 `falls back to a code block when mermaid rendering errors` 테스트가 간헐 실패했습니다(`expected <figure> to be null`).

판별 근거: full dashboard suite 592/592 green, 동일 테스트 base 5/5·head 5/5(정상 부하). `pnpm install` 직후 cold-cache 고부하에서만 hit → 로직 회귀가 아닌 **timing flake**.

## 변경

6개 `await flushUi()` + 단언을 `await waitFor(() => 단언)`으로 교체. `waitFor`는 기본 타임아웃까지 폴링하므로 고정 지연 대신 **실제 DOM 상태**를 기다립니다. `flushUi` 헬퍼 제거. 테스트 전용, 프로덕션 변경 없음.

## 검증

- `pnpm typecheck`: pass
- `pnpm lint`: pass
- `code-blocks.test.ts` 5회 연속: 5/5 (간헐 실패 재현 안 됨)

## RFC

해당 없음 — 테스트 파일 변경.

WORKAROUND-WAIVED: 고정 타임아웃이라는 fragile 패턴을 제거하고 결정론적 대기(`waitFor`)로 대체하는 것으로, 증상 억제가 아니라 근본 수정입니다. cap/cooldown/telemetry/string-classifier 패턴 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
