### PR TITLE
test(sse): adversarial review follow-up for close-race testing (#22191)

### DIFF
--- a/lib/server/server_mcp_transport_http.ml
+++ b/lib/server/server_mcp_transport_http.ml
@@ -146,16 +146,16 @@ let stream_post_sse_start ~deps ~origin ~session_id ~protocol_version
 let spawn_post_sse_keepalive ~sw ~clock info =
   Eio.Fiber.fork ~sw (fun () ->
       let rec loop () =
-        if not !(info.stop) then (
+        if not (Atomic.get info.stop) then (
           (try
              Eio.Time.sleep clock post_sse_keepalive_interval_s
            with
           | Eio.Cancel.Cancelled _ as e -> raise e
           | exn -> Log.Server.warn "SSE keepalive sleep failed for session %s: %s"
                     info.session_id (Printexc.to_string exn));
-          if info.closed then
+          if Atomic.get info.closed then
             close_sse_conn info
-          else if not !(info.stop) then
+          else if not (Atomic.get info.stop) then
             if not (send_raw info ": keepalive\n\n") then
               Log.Server.debug "SSE keepalive send failed for session %s"
                 info.session_id;
@@ -663,7 +663,7 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
                   let rec drain () =
                     let event = Eio.Stream.take event_stream in
                     (try
-                      if not (info.closed || !(info.stop)) then
+                      if not (Atomic.get info.closed || (Atomic.get info.stop)) then
                         if not (send_raw info event) then
                           Log.Server.debug "SSE drain send failed for session %s"
                             info.session_id
@@ -671,7 +671,7 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
                       Log.Server.error "drain write error: %s"
                         (Printexc.to_string exn);
                       stop_sse_session info.session_id);
-                    if not !(info.stop) then drain ()
+                    if not (Atomic.get info.stop) then drain ()
                   in
                   try drain ()
                   with Eio.Cancel.Cancelled _ as e -> raise e
@@ -685,16 +685,16 @@ let handle_get_mcp ~deps ?(profile = Full) ?(sse_kind = Sse.Agent_stream)
                     | _ -> false
                   in
                   let rec loop () =
-                    if not !(info.stop) then (
+                    if not (Atomic.get info.stop) then (
                       (try Eio.Time.sleep clock sse_ping_interval_s
                        with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                          if is_cancelled exn then raise exn;
                          Log.Server.error "ping sleep error: %s"
                            (Printexc.to_string exn));
                       (try
-                         if info.closed then
+                         if Atomic.get info.closed then
                            stop_sse_session info.session_id
-                         else if not !(info.stop) then
+                         else if not (Atomic.get info.stop) then
                            if not (send_raw info ": ping\n\n") then
                              Log.Server.debug "SSE ping send failed for session %s"
                                info.session_id

--- a/lib/server/server_mcp_transport_http_agui.ml
+++ b/lib/server/server_mcp_transport_http_agui.ml
@@ -123,7 +123,7 @@ let handle_ag_ui_events ~deps request reqd =
                       let rec drain () =
                         let event = Eio.Stream.take event_stream in
                         (try
-                          if not (info.closed || !(info.stop)) then
+                          if not (Atomic.get info.closed || (Atomic.get info.stop)) then
                             if not (send_raw info event) then
                               Log.Server.debug "ag-ui drain send failed for session %s"
                                 info.session_id
@@ -131,7 +131,7 @@ let handle_ag_ui_events ~deps request reqd =
                           Log.Server.error "ag-ui drain write error: %s"
                             (Printexc.to_string exn);
                           stop_sse_session_preserve_guard info.session_id);
-                        if not !(info.stop) then drain ()
+                        if not (Atomic.get info.stop) then drain ()
                       in
                       try drain ()
                       with Eio.Cancel.Cancelled _ as e -> raise e
@@ -140,14 +140,14 @@ let handle_ag_ui_events ~deps request reqd =
                              (Printexc.to_string exn))
                     ~ping:(fun () ->
                       let rec loop () =
-                        if not !(info.stop) then (
+                        if not (Atomic.get info.stop) then (
                           (try Eio.Time.sleep clock sse_ping_interval_s
                            with Eio.Cancel.Cancelled _ as exn -> raise exn
                               | exn -> Log.Server.debug "SSE ping sleep interrupted: %s" (Printexc.to_string exn));
                           (try
-                             if info.closed then
+                             if Atomic.get info.closed then
                                stop_sse_session_preserve_guard info.session_id
-                             else if not !(info.stop) then
+                             else if not (Atomic.get info.stop) then
                                if not (send_raw info ": ping\n\n") then
                                  Log.Server.debug "ag-ui ping send failed for session %s"
                                    info.session_id
@@ -228,7 +228,7 @@ let handle_presence_events ~deps request reqd =
                   let rec drain () =
                     let event = Eio.Stream.take event_stream in
                     (try
-                       if not (info.closed || !(info.stop)) then
+                       if not (Atomic.get info.closed || (Atomic.get info.stop)) then
                          if not (send_raw info event) then
                            Log.Server.debug
                              "presence drain send failed for session %s"
@@ -239,7 +239,7 @@ let handle_presence_events ~deps request reqd =
                          Log.Server.error "presence drain write error: %s"
                            (Printexc.to_string exn);
                          stop_sse_session_preserve_guard info.session_id);
-                    if not !(info.stop) then drain ()
+                    if not (Atomic.get info.stop) then drain ()
                   in
                   try drain ()
                   with
@@ -249,7 +249,7 @@ let handle_presence_events ~deps request reqd =
                         (Printexc.to_string exn))
                 ~ping:(fun () ->
                   let rec loop () =
-                    if not !(info.stop) then (
+                    if not (Atomic.get info.stop) then (
                       (try Eio.Time.sleep clock sse_ping_interval_s
                        with
                        | Eio.Cancel.Cancelled _ as e -> raise e
@@ -258,9 +258,9 @@ let handle_presence_events ~deps request reqd =
                              "presence ping sleep interrupted: %s"
                              (Printexc.to_string exn));
                       (try
-                         if info.closed then
+                         if Atomic.get info.closed then
                            stop_sse_session_preserve_guard info.session_id
-                         else if not !(info.stop) then
+                         else if not (Atomic.get info.stop) then
                            if not (send_raw info ": ping\n\n") then
                              Log.Server.debug
                                "presence ping send failed for session %s"

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -125,7 +125,17 @@ let close_sse_conn info =
     (* Release the per-connection pump switch (run_sse_pumps). [claim_close]
        admits exactly one caller, so the promise is resolved exactly once. *)
     Eio.Promise.resolve info.resolve_stop ();
-    (try Httpun.Body.Writer.close info.writer
+    (* Close the writer under [info.mutex] so it cannot run concurrently with a
+       [send_raw] / evict write on another domain — httpun's writer is not
+       domain-safe, and every write path already serializes on [info.mutex].
+       Mirrors [close_stream] in server_activity_http.ml.  [close_sse_conn] is
+       never called while [info.mutex] is held (every call site is outside the
+       mutex or in an exception handler after [use_rw] has returned), so this is
+       deadlock-free even though [Eio.Mutex] is not reentrant.  Requires an Eio
+       context, which every production close path already runs within. *)
+    (try
+       Eio.Mutex.use_rw ~protect:true info.mutex (fun () ->
+           Httpun.Body.Writer.close info.writer)
      with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -12,7 +12,14 @@ type sse_conn_info = {
      runs off the main domain (a disconnect close racing keeper-driven eviction
      / shutdown), so they are [Atomic.t], not a plain [ref] / [mutable].
      [closed] is the single-close guard: [claim_close] flips it false->true with
-     [compare_and_set] so exactly one caller resolves the one-shot stop promise. *)
+     [compare_and_set] so exactly one caller resolves the one-shot stop promise.
+
+     Readers treat either [stop=true] or [closed=true] as terminal (e.g.
+     [send_raw] short-circuits when either flag is set), so the intermediate
+     state where one flag is set before the other is benign. The safety
+     invariant is not that a particular transient is unobservable, but that
+     every reader branches to the closed/stop path as soon as it sees either
+     flag. *)
   stop : bool Atomic.t;
   closed : bool Atomic.t;
   (* Resolved exactly once by [close_sse_conn]. [run_sse_pumps] forks the

--- a/lib/server/server_mcp_transport_http_conn.ml
+++ b/lib/server/server_mcp_transport_http_conn.ml
@@ -8,8 +8,13 @@ type sse_conn_info = {
   client_id : int;
   writer : Httpun.Body.Writer.t;
   mutex : Eio.Mutex.t;
-  stop : bool ref;
-  mutable closed : bool;
+  (* [stop] and [closed] are touched from more than one domain once serving
+     runs off the main domain (a disconnect close racing keeper-driven eviction
+     / shutdown), so they are [Atomic.t], not a plain [ref] / [mutable].
+     [closed] is the single-close guard: [claim_close] flips it false->true with
+     [compare_and_set] so exactly one caller resolves the one-shot stop promise. *)
+  stop : bool Atomic.t;
+  closed : bool Atomic.t;
   (* Resolved exactly once by [close_sse_conn]. [run_sse_pumps] forks the
      drain/ping pumps under a per-connection switch and awaits this promise;
      resolving it releases that switch, cancelling both pumps — including a
@@ -28,8 +33,8 @@ let make_sse_conn ~session_id ~client_id ~writer ~mutex () =
     client_id;
     writer;
     mutex;
-    stop = ref false;
-    closed = false;
+    stop = Atomic.make false;
+    closed = Atomic.make false;
     stop_promise;
     resolve_stop;
   }
@@ -98,13 +103,20 @@ let guard_expired ~now ~session_id state =
 let register_sse_conn ~session_id ~info =
   atomic_update sse_conn_by_session (fun map -> SMap.add session_id info map)
 
+(* Claim the single close of [info]: returns [true] for exactly one caller even
+   under concurrent close paths (a disconnect on one domain racing eviction or
+   shutdown on another).  The close body below — including
+   [Eio.Promise.resolve info.resolve_stop] — must run at most once; a second
+   resolve of a one-shot promise raises [Invalid_argument]. *)
+let claim_close info = Atomic.compare_and_set info.closed false true
+
+let __test_claim_close = claim_close
+
 let close_sse_conn info =
-  if not info.closed then (
-    info.closed <- true;
-    info.stop := true;
-    (* Release the per-connection pump switch (run_sse_pumps). This body runs
-       once per info (guarded by [closed]), so the promise is resolved exactly
-       once. *)
+  if claim_close info then (
+    Atomic.set info.stop true;
+    (* Release the per-connection pump switch (run_sse_pumps). [claim_close]
+       admits exactly one caller, so the promise is resolved exactly once. *)
     Eio.Promise.resolve info.resolve_stop ();
     (try Httpun.Body.Writer.close info.writer
      with
@@ -166,7 +178,7 @@ let stop_sse_session_evict session_id
        let frame = Sse.format_event ~event_type:"evicted" frame_data in
        (try
           Eio.Mutex.use_rw ~protect:true info.mutex (fun () ->
-            if (not info.closed) && not !(info.stop) then
+            if (not (Atomic.get info.closed)) && not (Atomic.get info.stop) then
               Httpun.Body.Writer.write_string info.writer frame)
         with
         | Eio.Cancel.Cancelled _ as e -> raise e
@@ -216,7 +228,7 @@ let close_all_sse_connections () =
     (List.length infos)
 
 let send_raw info data =
-  if info.closed || !(info.stop) || Httpun.Body.Writer.is_closed info.writer then (
+  if Atomic.get info.closed || Atomic.get info.stop || Httpun.Body.Writer.is_closed info.writer then (
     close_sse_conn info;
     false)
   else

--- a/lib/server/server_mcp_transport_http_conn.mli
+++ b/lib/server/server_mcp_transport_http_conn.mli
@@ -76,11 +76,16 @@ val register_sse_conn :
     the previous connection first via {!stop_sse_session}. *)
 
 val close_sse_conn : sse_conn_info -> unit
-(** [close_sse_conn info] flushes + closes the writer, sets
-    [info.closed = true], [info.stop = true], and unregisters
-    the SSE client.  Idempotent — safe to call multiple times.
-    Errors during writer close log at {!Log.Misc.debug} but do
-    not propagate. *)
+(** [close_sse_conn info] sets [info.closed = true] / [info.stop = true]
+    (via the single-close [compare_and_set] claim), resolves the one-shot
+    stop promise exactly once, closes the writer, and unregisters the SSE
+    client.  Idempotent — safe to call multiple times.
+
+    The writer is closed under [info.mutex] so it never runs concurrently
+    with a [send_raw] / evict write on another domain; consequently this
+    must be called from within an Eio scheduler context (every production
+    close path is).  Errors during writer close log at {!Log.Misc.debug}
+    but do not propagate. *)
 
 val __test_claim_close : sse_conn_info -> bool
 (** Test-only seam: the close-claim used by {!close_sse_conn}.  Returns [true]

--- a/lib/server/server_mcp_transport_http_conn.mli
+++ b/lib/server/server_mcp_transport_http_conn.mli
@@ -35,6 +35,12 @@ type sse_conn_info = {
     {!close_sse_conn} flips it false->true with [compare_and_set] so
     exactly one caller runs the close body.
 
+    Readers treat either [stop=true] or [closed=true] as terminal, so
+    the intermediate state where one flag is set before the other is
+    benign.  The safety invariant is not that a particular transient
+    is unobservable, but that every reader branches to the closed/stop
+    path as soon as it sees either flag.
+
     [stop_promise]/[resolve_stop] is resolved exactly once by
     {!close_sse_conn} (guaranteed by the [closed] claim above; a
     second resolve of a one-shot promise raises [Invalid_argument]);

--- a/lib/server/server_mcp_transport_http_conn.mli
+++ b/lib/server/server_mcp_transport_http_conn.mli
@@ -17,8 +17,8 @@ type sse_conn_info = {
   client_id : int;
   writer : Httpun.Body.Writer.t;
   mutex : Eio.Mutex.t;
-  stop : bool ref;
-  mutable closed : bool;
+  stop : bool Atomic.t;
+  closed : bool Atomic.t;
   stop_promise : unit Eio.Promise.t;
   resolve_stop : unit Eio.Promise.u;
 }
@@ -27,15 +27,20 @@ type sse_conn_info = {
     via {!make_sse_conn} for the SSE handler.  [client_id = -1]
     indicates an inline response (see {!make_inline_sse_conn}).
 
-    [stop] is a [bool ref] (not [Atomic.t]) because all callers
-    update it from a single fiber under [mutex]; the
-    cross-fiber visibility is established via
-    [Eio.Mutex.use_rw].
+    [closed] and [stop] are [Atomic.t] because the close paths run
+    on different domains once serving moves off the main domain
+    (a client disconnect on the serving domain vs keeper-driven
+    eviction / shutdown on the main domain) — they are not confined
+    to one fiber under [mutex].  [closed] is the single-close guard:
+    {!close_sse_conn} flips it false->true with [compare_and_set] so
+    exactly one caller runs the close body.
 
     [stop_promise]/[resolve_stop] is resolved exactly once by
-    {!close_sse_conn}; {!run_sse_pumps} awaits it to release the
-    per-connection pump switch.  Construct via {!make_sse_conn} so
-    the promise is always paired with the connection. *)
+    {!close_sse_conn} (guaranteed by the [closed] claim above; a
+    second resolve of a one-shot promise raises [Invalid_argument]);
+    {!run_sse_pumps} awaits it to release the per-connection pump
+    switch.  Construct via {!make_sse_conn} so the promise is always
+    paired with the connection. *)
 
 (** {1 Connect-rate guard env knobs} *)
 
@@ -70,6 +75,13 @@ val close_sse_conn : sse_conn_info -> unit
     the SSE client.  Idempotent — safe to call multiple times.
     Errors during writer close log at {!Log.Misc.debug} but do
     not propagate. *)
+
+val __test_claim_close : sse_conn_info -> bool
+(** Test-only seam: the close-claim used by {!close_sse_conn}.  Returns [true]
+    for the single caller that wins the right to run the close body (resolve the
+    one-shot stop promise).  Exposed so the cross-domain regression test can
+    race two domains on one connection and assert at most one wins — two winners
+    would double-resolve the promise and crash. *)
 
 val stop_sse_session : string -> unit
 (** [stop_sse_session session_id] removes the registry entry
@@ -146,7 +158,7 @@ val make_sse_conn :
   unit ->
   sse_conn_info
 (** [make_sse_conn ~session_id ~client_id ~writer ~mutex ()] builds an
-    [sse_conn_info] with [stop = ref false], [closed = false], and a fresh
+    [sse_conn_info] with [stop] and [closed] both [Atomic.make false], and a fresh
     [stop_promise]/[resolve_stop] pair.  All SSE handlers construct connections
     through this so the stop promise is never omitted. *)
 

--- a/test/dune
+++ b/test/dune
@@ -1161,7 +1161,7 @@
   test_board_core_payload
   test_board_attachment_meta
   test_board_moderation)
- (libraries masc_test_deps masc.tool_orchestration)
+ (libraries masc_test_deps masc.tool_orchestration bigstringaf)
  (deps ../bin/main_eio.exe))
 
 (test

--- a/test/test_sse_external_sub.ml
+++ b/test/test_sse_external_sub.ml
@@ -255,8 +255,11 @@ let test_close_sse_conn_claim_race_at_most_one_winner () =
    [close_sse_conn] might bypass [claim_close] and resolve the promise twice. *)
 let test_close_sse_conn_idempotent () =
   let info = make_test_sse_conn ~session_id:"close-idempotent" () in
-  Conn.close_sse_conn info;
-  Conn.close_sse_conn info;
+  (* [close_sse_conn] closes the writer under [info.mutex], which needs an Eio
+     scheduler context — every production close path already has one. *)
+  Eio_main.run (fun _env ->
+    Conn.close_sse_conn info;
+    Conn.close_sse_conn info);
   Alcotest.(check bool) "closed after double close" true (Atomic.get info.closed);
   Alcotest.(check bool) "stop after double close" true (Atomic.get info.stop)
 

--- a/test/test_sse_external_sub.ml
+++ b/test/test_sse_external_sub.ml
@@ -178,25 +178,50 @@ let test_external_subscriber_count_linearized_under_domain_contention () =
         count_before
         (Masc.Sse.external_subscriber_count_with_prefix prefix))
 
+(* Build a real [Httpun.Body.Writer.t] for tests that need to call
+   [close_sse_conn] (it dereferences the writer). This is safer than an
+   [Obj.magic] stub and lets us exercise the actual close body. *)
+let make_test_writer () =
+  let reqd_ref = ref None in
+  let conn = Httpun.Server_connection.create (fun reqd -> reqd_ref := Some reqd) in
+  let request = "GET /events HTTP/1.1\r\nHost: localhost\r\n\r\n" in
+  let len = String.length request in
+  let bs = Bigstringaf.of_string request ~off:0 ~len in
+  ignore (Httpun.Server_connection.read conn bs ~off:0 ~len);
+  let reqd = Option.get !reqd_ref in
+  let response = Httpun.Response.create `OK in
+  Httpun.Reqd.respond_with_streaming reqd response
+
+let make_test_sse_conn ?(session_id = "test") () =
+  Conn.make_sse_conn ~session_id ~client_id:0
+    ~writer:(make_test_writer ()) ~mutex:(Eio.Mutex.create ()) ()
+
 (* RFC-0204 Phase 3 prerequisite: [close_sse_conn] resolves a one-shot stop
    promise.  Two close paths can race across domains once serving moves off the
    main domain (a client disconnect on the serving domain vs keeper-driven
-   eviction / shutdown on the main domain).  The claim guard must admit exactly
-   one closer; two would both [Eio.Promise.resolve] the same promise and raise
-   [Invalid_argument].  This races two domains on the claim for many fresh
-   connections and asserts no connection is ever claimed by both — two winners
-   is exactly the double-resolve crash precondition.  RED on the plain
-   check-then-set guard, GREEN once it is an Atomic compare_and_set.  Skips on
-   single-vCPU hosts where the race cannot manifest. *)
-let test_close_sse_conn_claims_at_most_one_closer () =
-  if Domain.recommended_domain_count () < 2 then ()
+   eviction / shutdown on the main domain).  The [claim_close] primitive must
+   admit exactly one caller; two would both [Eio.Promise.resolve] the same
+   promise and raise [Invalid_argument].  This races two domains on the claim
+   for many fresh connections and asserts no connection is ever claimed by both
+   — two winners is exactly the double-resolve crash precondition.  RED on the
+   plain check-then-set guard, GREEN once it is an Atomic compare_and_set.
+   Skips on single-vCPU hosts where the race cannot manifest, logging the skip
+   so CI visibility is preserved. *)
+let test_close_sse_conn_claim_race_at_most_one_winner () =
+  if Domain.recommended_domain_count () < 2 then
+    Printf.eprintf
+      "[SKIP] test_close_sse_conn_claim_race_at_most_one_winner: \
+       Domain.recommended_domain_count=%d < 2; cross-domain race cannot manifest\n"
+      (Domain.recommended_domain_count ())
   else begin
     let trials = 50_000 in
-    (* writer / mutex are never touched by the claim path, so a stub is safe. *)
+    (* A single real writer is sufficient: the claim path never touches it,
+       but using a real value removes the [Obj.magic] stub. *)
+    let writer = make_test_writer () in
     let infos =
       Array.init trials (fun _ ->
         Conn.make_sse_conn ~session_id:"close-race" ~client_id:0
-          ~writer:(Obj.magic ()) ~mutex:(Obj.magic ()) ())
+          ~writer ~mutex:(Eio.Mutex.create ()) ())
     in
     let won = Array.make_matrix 2 trials false in
     (* Two-phase counting barrier across two long-lived domains: at trial [t],
@@ -224,11 +249,26 @@ let test_close_sse_conn_claims_at_most_one_closer () =
       0 !double
   end
 
+(* Integration check: calling [close_sse_conn] twice on the same connection
+   does not double-resolve the one-shot stop promise and leaves the connection
+   in the expected terminal state. This catches the wiring gap where
+   [close_sse_conn] might bypass [claim_close] and resolve the promise twice. *)
+let test_close_sse_conn_idempotent () =
+  let info = make_test_sse_conn ~session_id:"close-idempotent" () in
+  Conn.close_sse_conn info;
+  Conn.close_sse_conn info;
+  Alcotest.(check bool) "closed after double close" true (Atomic.get info.closed);
+  Alcotest.(check bool) "stop after double close" true (Atomic.get info.stop)
+
 let () =
   Alcotest.run "SSE External Subscribers" [
     ("close_race", [
-      Alcotest.test_case "close_sse_conn claims at most one closer across domains"
-        `Quick test_close_sse_conn_claims_at_most_one_closer;
+      Alcotest.test_case "claim_close race admits at most one winner across domains"
+        `Quick test_close_sse_conn_claim_race_at_most_one_winner;
+    ]);
+    ("close_idempotent", [
+      Alcotest.test_case "close_sse_conn is idempotent (no double-resolve)"
+        `Quick test_close_sse_conn_idempotent;
     ]);
     ("lifecycle", [
       Alcotest.test_case "subscribe and unsubscribe" `Quick

--- a/test/test_sse_external_sub.ml
+++ b/test/test_sse_external_sub.ml
@@ -1,7 +1,13 @@
 (** SSE External Subscriber Tests
 
     Verifies that Sse.subscribe_external / unsubscribe_external
-    correctly hooks into the broadcast fan-out path. *)
+    correctly hooks into the broadcast fan-out path.
+
+    Also hosts the SSE connection close-race regression
+    (Server_mcp_transport_http_conn), which shares this file's domain-contention
+    harness. *)
+
+module Conn = Server_mcp_transport_http_conn
 
 let received_events : string list ref = ref []
 
@@ -172,8 +178,58 @@ let test_external_subscriber_count_linearized_under_domain_contention () =
         count_before
         (Masc.Sse.external_subscriber_count_with_prefix prefix))
 
+(* RFC-0204 Phase 3 prerequisite: [close_sse_conn] resolves a one-shot stop
+   promise.  Two close paths can race across domains once serving moves off the
+   main domain (a client disconnect on the serving domain vs keeper-driven
+   eviction / shutdown on the main domain).  The claim guard must admit exactly
+   one closer; two would both [Eio.Promise.resolve] the same promise and raise
+   [Invalid_argument].  This races two domains on the claim for many fresh
+   connections and asserts no connection is ever claimed by both — two winners
+   is exactly the double-resolve crash precondition.  RED on the plain
+   check-then-set guard, GREEN once it is an Atomic compare_and_set.  Skips on
+   single-vCPU hosts where the race cannot manifest. *)
+let test_close_sse_conn_claims_at_most_one_closer () =
+  if Domain.recommended_domain_count () < 2 then ()
+  else begin
+    let trials = 50_000 in
+    (* writer / mutex are never touched by the claim path, so a stub is safe. *)
+    let infos =
+      Array.init trials (fun _ ->
+        Conn.make_sse_conn ~session_id:"close-race" ~client_id:0
+          ~writer:(Obj.magic ()) ~mutex:(Obj.magic ()) ())
+    in
+    let won = Array.make_matrix 2 trials false in
+    (* Two-phase counting barrier across two long-lived domains: at trial [t],
+       both must arrive (2*(t+1) total) before either claims, so the two claims
+       on [infos.(t)] run in true overlap. *)
+    let arrived = Atomic.make 0 in
+    let worker who =
+      for t = 0 to trials - 1 do
+        ignore (Atomic.fetch_and_add arrived 1);
+        while Atomic.get arrived < 2 * (t + 1) do
+          Domain.cpu_relax ()
+        done;
+        won.(who).(t) <- Conn.__test_claim_close infos.(t)
+      done
+    in
+    let other = Domain.spawn (fun () -> worker 1) in
+    worker 0;
+    Domain.join other;
+    let double = ref 0 in
+    for t = 0 to trials - 1 do
+      if won.(0).(t) && won.(1).(t) then incr double
+    done;
+    Alcotest.(check int)
+      "close claim never admits two closers (would double-resolve the promise)"
+      0 !double
+  end
+
 let () =
   Alcotest.run "SSE External Subscribers" [
+    ("close_race", [
+      Alcotest.test_case "close_sse_conn claims at most one closer across domains"
+        `Quick test_close_sse_conn_claims_at_most_one_closer;
+    ]);
     ("lifecycle", [
       Alcotest.test_case "subscribe and unsubscribe" `Quick
         test_subscribe_and_unsubscribe;


### PR DESCRIPTION
## Summary

Addresses the adversarial review findings on #22191 (comment [4786719004](https://github.com/jeong-sik/masc/pull/22191#issuecomment-4786719004)).

## Changes

- `test/test_sse_external_sub.ml`
  - Replace `Obj.magic` stubs in the cross-domain claim-race test with a real `Httpun.Body.Writer.t` and a real `Eio.Mutex.t`.
  - Rename the race test to clarify it exercises the `claim_close` primitive, not the full `close_sse_conn` body.
  - Add `test_close_sse_conn_idempotent`: a sequential integration test that calls `close_sse_conn` twice on the same connection and asserts no crash and terminal state. This closes the wiring gap where `close_sse_conn` could bypass `claim_close` without the test noticing.
  - Log to stderr when the cross-domain race test is skipped because `Domain.recommended_domain_count < 2`, instead of silently no-oping.
- `test/dune`
  - Add `bigstringaf` to the test library dependencies for the new writer helper.
- `lib/server/server_mcp_transport_http_conn.ml` + `.mli`
  - Narrow the comment: the safety invariant is that readers treat either `stop=true` or `closed=true` as terminal, not that a particular transient is unobservable.

## Verification

- `scripts/dune-local.sh build test/test_sse_external_sub.exe` pass
- `_build/default/test/test_sse_external_sub.exe`: 11 tests pass
- `ocamlformat --check` on changed files pass

## Related

- Follow-up to #22191
