### PR TITLE
feat(cdal_runtime): consume upstream participant_by_name + bump OAS 0.207.8 (adapt tool_output._meta)

### DIFF
--- a/lib/cdal_runtime/sessions_proof.ml
+++ b/lib/cdal_runtime/sessions_proof.ml
@@ -8,12 +8,6 @@ open Sessions_types
 open Sessions_store
 open Result_syntax
 
-let participant_by_name (session : Runtime.session) name =
-  List.find_opt
-    (fun (participant : Runtime.participant) -> String.equal participant.name name)
-    session.participants
-;;
-
 let resolved_provider_of_participant
       (session : Runtime.session)
       (participant : Runtime.participant option)
@@ -88,7 +82,9 @@ let worker_run_of_raw
       (summary : raw_trace_summary)
       (validation : raw_trace_validation)
   =
-  let participant = participant_by_name session summary.run_ref.agent_name in
+  let participant =
+    Agent_sdk.Sessions.participant_by_name session summary.run_ref.agent_name
+  in
   let provider = resolved_provider_of_participant session participant in
   let model = resolved_model_of_participant session participant in
   let final_text =

--- a/lib/cdal_runtime/sessions_proof.mli
+++ b/lib/cdal_runtime/sessions_proof.mli
@@ -9,10 +9,6 @@
 
 open Sessions_types
 
-(** {1 Participant lookup} *)
-
-val participant_by_name : Runtime.session -> string -> Runtime.participant option
-
 (** Resolve the effective provider for a participant,
     falling back to the session provider. *)
 val resolved_provider_of_participant

--- a/lib/keeper/keeper_tool_emission_hook.ml
+++ b/lib/keeper/keeper_tool_emission_hook.ml
@@ -73,7 +73,7 @@ let make_post_tool_use_hook (acc : accumulator) : Agent_sdk.Hooks.hook =
        match event with
        | Agent_sdk.Hooks.PostToolUse { output; _ } -> (
            match output with
-           | Ok { content } -> (
+           | Ok { content; _ } -> (
                match try_parse content with
                | Some json -> push acc json
                | None -> ())

--- a/lib/local/worker_container.ml
+++ b/lib/local/worker_container.ml
@@ -319,7 +319,7 @@ let build_oas_mcp_tools ~sw ~auth_token ~session_id ~worker_name =
                | Ok result when result.is_error ->
                  oas_tool_error result.text
                | Ok result ->
-                 Ok { Agent_sdk.Types.content = result.text }
+                 Ok { Agent_sdk.Types.content = result.text; _meta = None }
                | Error e ->
                  oas_tool_error e
              in

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -280,7 +280,7 @@ let oas_descriptor_of_masc_tool name =
 
 let to_oas_typed_result (tr : Tool_result.result) : Agent_sdk.Types.tool_result =
   if Tool_result.is_success tr
-  then Ok { Agent_sdk.Types.content = maybe_externalize (Tool_result.message tr) }
+  then Ok { Agent_sdk.Types.content = maybe_externalize (Tool_result.message tr); _meta = None }
   else (
     let msg = Tool_result.message tr in
     let json_recoverable, json_error_class =

--- a/lib/typed_tool_masc.ml
+++ b/lib/typed_tool_masc.ml
@@ -28,7 +28,7 @@ let make_dispatch_handler (tool : (_, _) t) : Tool_dispatch.handler =
   fun ~name ~args ->
     let start_time = Time_compat.now () in
     match Agent_sdk.Typed_tool.execute tool.oas_tool args with
-    | Ok { content } -> Some (Tool_result.ok ~tool_name:name ~start_time content)
+    | Ok { content; _ } -> Some (Tool_result.ok ~tool_name:name ~start_time content)
     | Error { message; recoverable; error_class } ->
       (* RFC-0189: source-typed mapping from [Agent_sdk.tool_error]
          to [Tool_result.tool_failure_class].  The SDK's typed

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.207.5"}
+  "agent_sdk" {= "0.207.8"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -217,8 +217,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.207.5"
-  "git+https://github.com/jeong-sik/oas.git#6fe842bf2fdb869b2ed9004029f7cdfd7cd7ca5e"
+  "agent_sdk.0.207.8"
+  "git+https://github.com/jeong-sik/oas.git#e571728cf2d43555987e9ca73b4abc4e55be14a6"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/test/test_keeper_execution_join.ml
+++ b/test/test_keeper_execution_join.ml
@@ -84,7 +84,7 @@ let test_tool_completed_stamps_execution_id () =
       (mk_event ~caused_by:"run-called-1"
          (Agent_sdk.Event_bus.ToolCompleted
             { agent_name = "keeper-x-agent"; tool_name = "Read"
-            ; tool_use_id = "tu-4"; output = Ok { content = "ok" }; turn = 1 }))
+            ; tool_use_id = "tu-4"; output = Ok { content = "ok"; _meta = None }; turn = 1 }))
     |> Option.get
   in
   check (option string) "payload execution_id" (Some "exec-2-0001")
@@ -104,7 +104,7 @@ let test_tool_completed_without_entry_omits_execution_id () =
       (mk_event
          (Agent_sdk.Event_bus.ToolCompleted
             { agent_name = "oas-worker"; tool_name = "Execute"
-            ; tool_use_id = "tu-5"; output = Ok { content = "ok" }; turn = 2 }))
+            ; tool_use_id = "tu-5"; output = Ok { content = "ok"; _meta = None }; turn = 2 }))
     |> Option.get
   in
   check bool "no execution_id field for non-keeper execution" true

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -1303,7 +1303,7 @@ let make_delayed_read_tool clock name delay_ms =
     ~parameters:[]
     (fun _args ->
        Eio.Time.sleep clock (Float.of_int delay_ms /. 1000.0);
-       Ok { Agent_sdk.Types.content = name })
+       Ok { Agent_sdk.Types.content = name; _meta = None })
 ;;
 
 let execute_tools_in_env env ~tools tool_uses =

--- a/test/test_keeper_tool_emission_hook.ml
+++ b/test/test_keeper_tool_emission_hook.ml
@@ -46,7 +46,7 @@ let make_post_tool_use ~content : THooks.hook_event =
     { tool_use_id = "tu-1"
     ; tool_name = "fake_tool"
     ; input = `Assoc []
-    ; output = Ok ({ TT.content } : TT.tool_output)
+    ; output = Ok ({ TT.content; _meta = None } : TT.tool_output)
     ; result_bytes = String.length content
     ; duration_ms = 1.0
     ; schedule = dummy_schedule

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -12,7 +12,7 @@ open Masc
 (** Create a minimal OAS Tool.t from name and description. *)
 let make_tool name description : Agent_sdk.Tool.t =
   Agent_sdk.Tool.create ~name ~description ~parameters:[]
-    (fun _input -> Ok { content = "ok" })
+    (fun _input -> Ok { content = "ok"; _meta = None })
 
 (** A mock rerank_fn that returns the first [k] candidates in order. *)
 let mock_rerank_passthrough ~context:_ ~candidates =

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -34,7 +34,7 @@ let tool_completed name =
        { agent_name = "a"
        ; tool_name = name
        ; tool_use_id = name
-       ; output = Ok { Agent_sdk.Types.content = "done" }
+       ; output = Ok { Agent_sdk.Types.content = "done"; _meta = None }
        ; turn = 0
        })
 ;;

--- a/test/test_masc_context_injector.ml
+++ b/test/test_masc_context_injector.ml
@@ -6,7 +6,7 @@ module MCI = Masc.Masc_context_injector
 (* ── Helpers ──────────────────────────────────────────── *)
 
 let ok_output content : Agent_sdk.Types.tool_result =
-  Ok { Agent_sdk.Types.content }
+  Ok { Agent_sdk.Types.content; _meta = None }
 
 let err_output message : Agent_sdk.Types.tool_result =
   Error { Agent_sdk.Types.message; recoverable = true; error_class = None }

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -876,7 +876,7 @@ let test_runtime_agent_context_leaves_tool_choice_unset_with_tools () =
       ~name:"probe_tool"
       ~description:"probe tool"
       ~parameters:[]
-      (fun _input -> Ok { content = "ok" })
+      (fun _input -> Ok { content = "ok"; _meta = None })
   in
   let config =
     Runtime_agent.default_config

--- a/test/test_tool_bridge_externalize.ml
+++ b/test/test_tool_bridge_externalize.ml
@@ -105,7 +105,7 @@ let test_to_oas_typed_small_inlined () =
   Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
   let small = "small ok" in
   match B.to_oas_typed_result (tool_ok ~tool_name:"test" small) with
-  | Ok { content } ->
+  | Ok { content; _ } ->
       Alcotest.(check string) "inlined verbatim" small content;
       Alcotest.(check bool) "no marker" false (O.is_marker content)
   | Error _ -> Alcotest.fail "expected Ok"
@@ -182,7 +182,7 @@ let test_round_trip_through_oas () =
   Unix.putenv "MASC_TOOL_EXTERNALIZE" "0";
   let payload = String.make 5000 'p' in
   match B.to_oas_typed_result (tool_ok ~tool_name:"test" payload) with
-  | Ok { content } ->
+  | Ok { content; _ } ->
       let decoded = O.decode_from_oas content in
       (match decoded with
        | O.Inline s -> Alcotest.(check string) "inline preserved" payload s

--- a/test/test_typed_tool_masc.ml
+++ b/test/test_typed_tool_masc.ml
@@ -81,7 +81,7 @@ let test_e2e_success () =
   let oas_tool = Typed_tool_masc.to_oas Tool_broadcast_typed.tool in
   let json = `Assoc [("message", `String "typed e2e")] in
   match Agent_sdk.Typed_tool.execute oas_tool json with
-  | Ok { content } ->
+  | Ok { content; _ } ->
     let result = Yojson.Safe.from_string content in
     let open Yojson.Safe.Util in
     Alcotest.(check bool) "delivered" true (result |> member "delivered" |> to_bool)
@@ -96,7 +96,7 @@ let test_e2e_parse_error () =
 let test_e2e_coerced_input () =
   let oas_tool = Typed_tool_masc.to_oas Tool_broadcast_typed.tool in
   match Agent_sdk.Typed_tool.execute oas_tool (`Assoc [("message", `Int 99)]) with
-  | Ok { content } ->
+  | Ok { content; _ } ->
     let result = Yojson.Safe.from_string content in
     let open Yojson.Safe.Util in
     Alcotest.(check bool) "delivered" true (result |> member "delivered" |> to_bool);


### PR DESCRIPTION
## Summary

Step 2 of the cross-repo SSOT consolidation started in jeong-sik/oas#2168.
masc's `lib/cdal_runtime/sessions_proof.ml` carried a byte-identical
reimplementation of `Agent_sdk.Sessions.participant_by_name`; this PR deletes it
and consumes the upstream accessor.

## Changes

- `masc.opam.locked`: bump the agent_sdk OAS pin `6fe842bf` (0.207.5) →
  `e571728cf` (0.207.8). 0.207.8 is the release containing oas#2168
  (`participant_by_name` on the `Sessions` facade; verified `c75324c5` is an
  ancestor of `e571728cf`).
- `lib/cdal_runtime/sessions_proof.ml`: delete the local `participant_by_name`;
  its sole caller (`worker_run_of_raw`) now calls
  `Agent_sdk.Sessions.participant_by_name` (qualified, per the cdal_runtime dune
  convention).
- `lib/cdal_runtime/sessions_proof.mli`: drop the `participant_by_name` export —
  no external caller (verified across lib/bin/test).

## Scope note

The pin bump is 0.207.5 → 0.207.8, so it pulls every OAS change in that range,
not only `participant_by_name`. The only manifest change in `agent_sdk.opam`
across the range is the version string (no external dependency change), but the
upgrade is still a real OAS source bump — masc CI build is authoritative. Local
build skipped per the repo workflow.

Closes #22192.
