### PR TITLE
build(deps): bump ws-direct pin past writer dead-transport busy-spin

### DIFF
--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -242,15 +242,15 @@ pin-depends: [
   ]
   [
   "ws-direct-core.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#c1dc5640d70b86b90dc314f09cb7a9c250e15181"
+  "git+https://github.com/jeong-sik/ws-direct.git#3595406fe28713dbc4638c277e567031da339cd0"
 ]
   [
   "ws-direct-eio.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#c1dc5640d70b86b90dc314f09cb7a9c250e15181"
+  "git+https://github.com/jeong-sik/ws-direct.git#3595406fe28713dbc4638c277e567031da339cd0"
 ]
   [
   "ws-direct-gluten.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#c1dc5640d70b86b90dc314f09cb7a9c250e15181"
+  "git+https://github.com/jeong-sik/ws-direct.git#3595406fe28713dbc4638c277e567031da339cd0"
 ]
 ]
 x-maintenance-intent: ["(latest)"]

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -56,7 +56,7 @@ fi
 # --- Pin SHAs (bump these when upstream changes are needed) ---
 readonly WEBRTC_SHA="1b7993605b293f45169369d488f970ba15132a9f"
 readonly GRPC_DIRECT_SHA="d7269ebebf9e4688486cc6591c66e794607e7b0f"
-readonly WS_DIRECT_SHA="c1dc5640d70b86b90dc314f09cb7a9c250e15181"
+readonly WS_DIRECT_SHA="3595406fe28713dbc4638c277e567031da339cd0"
 readonly NEO4J_BOLT_SHA="a1ca30c1247db5c58934e99306fe330419f7b21a"
 
 include_bisect=false


### PR DESCRIPTION
## 무엇을

ws-direct pin을 `c1dc564` → `3595406` (ws-direct#3)로 bump합니다. 해당 커밋은 wss 전송이 죽었을 때 eio writer fiber가 100% CPU로 busy-spin하던 문제를 고칩니다.

## 왜

`c1dc564`의 writer는 write 실패(`` `Closed ``) 후 무조건 `loop ()` 재진입하는데, `Faraday.close`가 미flush 바이트를 버리지 않아 `next_write_operation`이 영원히 `` `Write `` 를 반환합니다. Eio 단일 domain에서 yield 없는 이 spin이 같은 domain의 모든 fiber(keeper/serving)를 굶겨 **서버 전체를 동결**시켰습니다.

라이브에서 실측됨(main_eio.exe, ~21h 가동): `sample`상 메인 스레드가 `next_write_operation → Eio.Flow.write → report_write_result` + `caml_raise_exn`에 100% on-CPU, 어떤 스레드도 wait에 없음(deadlock 아님 = livelock).

`3595406`은 write 실패 시 루프를 종료하고(faraday async 드라이버 정본 `` `Closed -> close; return``) 회귀 테스트를 추가합니다.

## 변경

- `masc.opam.locked`: ws-direct-core/eio/gluten `c1dc564` → `3595406`
- `scripts/opam-pin-external-deps.sh`: `WS_DIRECT_SHA` `c1dc564` → `3595406`

## 검증

- 로컬 opam 스위치는 이미 `3595406`으로 재설치, 런타임 재기동 후 라이브 확인 완료(CPU idle 정착, `sample`에 ws-direct writer 프레임 0).
- ws-direct 측 회귀 테스트 `test_driver_writer.ml`은 수정 revert 시 실패(non-vacuous).
- 이 bump 전까지는 CI/새 스위치의 `opam install --locked`가 여전히 buggy `c1dc564`를 받습니다.

RFC: 불필요 (gated subsystem credential/operator/dashboard/hooks/workflow 미접촉; lockfile + pin 스크립트 SHA만 변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
