### PR TITLE
chore(cdal): remove verified-dead cdal dune deps + fix stale comments

### DIFF
--- a/lib/cdal/dune
+++ b/lib/cdal/dune
@@ -6,9 +6,12 @@
 ; this is Phase 0 budget G3 / G5 in RFC-0056.
 ;
 ; Pairs with lib/cdal_runtime/ which hosts the producer side.
-; Dependency direction: masc main lib -> masc.cdal -> masc_core
-; (no cycle by construction; Phase 1 will add masc.cdal_runtime once
-; cdal_judge / cdal_eval_v1 / cdal_loader join this sub-library).
+; Dependency direction: masc main lib -> masc.cdal -> masc_core.
+; NOTE (2026-06-24): the masc.cdal_runtime dependency was removed — it was
+; declared in (libraries) but never referenced by adversarial_eval.ml, the
+; sole module in this sub-library (a dead build-graph edge). The RFC-0056
+; "Phase 1" plan to fold cdal_judge / cdal_eval_v1 / cdal_loader here was
+; not carried out; re-add the edge only when a module here actually uses it.
 
 (include_subdirs no)
 
@@ -25,5 +28,4 @@
   masc_core
   masc.config
   masc.masc_exec
-  masc.dated_jsonl
-  masc.cdal_runtime))
+  masc.dated_jsonl))

--- a/lib/cdal_runtime/dune
+++ b/lib/cdal_runtime/dune
@@ -43,11 +43,13 @@
  (libraries
   masc_core
   agent_sdk.base
-  ; agent_sdk (full): originally added for Guardrails_async, referenced by the
-  ; now-purged guardrail_llm (#19469). Also backs the [-open Agent_sdk] flag
-  ; below, so it cannot be dropped without auditing the flag. Whether any
-  ; surviving module still needs the full agent_sdk is unverified (deps audit
-  ; deferred — see header).
+  ; agent_sdk (full): its original user (Guardrails_async in the purged
+  ; guardrail_llm, #19469) is gone, but the full library is still REQUIRED —
+  ; [-open Agent_sdk__] below exposes [Sessions_types], used pervasively by
+  ; sessions_proof / conformance / direct_evidence / runtime_evidence.
+  ; agent_sdk.base does not provide Sessions_types. Verified 2026-06-24: build
+  ; fails if agent_sdk is dropped while -open Agent_sdk__ remains
+  ; ("Unbound module Agent_sdk__").
   agent_sdk
   ; unix: [Unix.gettimeofday] in conformance.ml (surviving module).
   unix
@@ -58,17 +60,13 @@
   eio.unix
   ; eio_main: [Eio_main.run] in autonomy_exec.ml (surviving module).
   eio_main
-  ; agent_sdk.llm_provider: originally for contract_runner ([Llm_provider.*]),
-  ; purged in #19469 — likely dead, removal deferred pending a deps audit.
-  agent_sdk.llm_provider
   yojson
   ppx_deriving_yojson.runtime)
  ; Mirror agent_sdk's flag so migrated modules' `open Types` /
  ; `open Result_syntax` resolve against Agent_sdk_base, matching their
- ; original OAS compilation context.  Also open the wrapped [Agent_sdk]
- ; namespace for unqualified references to agent_sdk submodules.  (The
- ; original example, [Guardrails_async] in guardrail_llm, was purged in
- ; #19469; the flag is kept because [-open Agent_sdk__] below relies on it.)
+ ; original OAS compilation context.  ([-open Agent_sdk] was removed
+ ; 2026-06-24: its only user, [Guardrails_async] in the purged guardrail_llm
+ ; (#19469), is gone and the build passes without it.)
  ; XXX -open Agent_sdk__ accesses agent_sdk's internal wrapper module
  ; (no .mli, so all submodule aliases are visible — including
  ; [Sessions_types], which is referenced by sessions_proof.mli but
@@ -80,7 +78,7 @@
  ; Using [Agent_sdk__] is fragile across dune wrapper-name changes.
  ; RFC-0071 §3.4 Phase 5 ratchet: warning 4 (fragile pattern match) on.
  (flags
-  (:standard -w +4 -open Agent_sdk_base -open Agent_sdk -open Agent_sdk__))
+  (:standard -w +4 -open Agent_sdk_base -open Agent_sdk__))
  (preprocess
   (pps
    ppx_deriving_yojson

--- a/lib/cdal_runtime/dune
+++ b/lib/cdal_runtime/dune
@@ -1,23 +1,32 @@
-; RFC-OAS-011 MM-1 — Skeleton dune sublibrary for OAS CDAL runtime migration.
+; RFC-OAS-011 — masc.cdal_runtime sublibrary: the agent-runtime/producer side
+; of CDAL, migrated out of OAS (agent_sdk) into masc.
 ;
-; This sublibrary will host the agent-runtime side of CDAL (Cdal_proof,
-; Mode_enforcer, Risk_contract, Execution_mode, Proof_capture, Audit, ...)
-; once MM-2 leaf-first migration begins. It is intentionally separated from
-; masc's existing CDAL Phase 1A evaluators (lib/cdal_*.ml + lib/cdal/)
-; because the two layers have different responsibilities:
+; Migration status (2026-06-24): MM-1~MM-4 landed 2026-05-08~11 — #14247
+; (skeleton), #14248~#14264 (B1~B5 batches), #14267 (MM-3-rewire atomic flip
+; Agent_sdk.* -> Masc_cdal_runtime.*), #14285 (MM-4 agent_sdk pin bump). The
+; RFC document itself is still marked Draft (doc-lag); the code is complete.
 ;
-;   masc (本体, lib/cdal_*.ml + lib/cdal/) — CDAL Phase 1A evaluator:
-;     consumer-side judge, verdict_gate, labeling, adversarial_eval.
+; The contract/proof runtime pipeline migrated in B1~B5 was later PURGED in
+; #19469 ("Track B", 2026-05-29, -4987 LoC). Removed modules — do NOT expect
+; them here: cdal_proof, mode_enforcer, mode_resolver, risk_class,
+; risk_contract, execution_mode, effect_evidence, proof_capture, proof_store,
+; contract_runner, cognitive_event, criteria, internal_error_substrate.
 ;
-;   masc.cdal_runtime (this) — CDAL runtime/producer:
-;     proof capture middleware, mode enforcement, risk contract typing.
+; Surviving modules (all in active use):
+;   autonomy_exec    — external execution primitive (used by fd_accountant)
+;   direct_evidence  — proof/evidence materialization (used by worker_container)
+;   sessions_proof   — worker-run + proof_bundle assembly (used by worker_container)
+;   conformance      — session-proof conformance checks
+;   runtime_evidence — telemetry + file evidence bundles
 ;
-; Dependencies are intentionally minimal: only OAS's *core* (agent_sdk.base
-; for Tool/Hooks/Types) plus Yojson for serialization. NO dependency on the
-; masc main library — the producer side must remain reusable independently.
+; Intentionally separated from masc's CDAL Phase 1A evaluator (lib/cdal/,
+; masc.cdal, Adversarial_eval): different responsibility (producer vs
+; consumer-side judge) and different deps (this needs agent_sdk; the evaluator
+; needs none). NO dependency on the masc main library — the producer side must
+; remain reusable independently.
 ;
 ; @rfc RFC-OAS-011 (CDAL Migration to masc)
-; @phase MM-2-leaves — B1 batch (execution_mode, effect_evidence, guardrail_llm)
+; @phase Implemented (post-#19469 maintenance)
 
 ; The parent [lib/dune] uses [(include_subdirs unqualified)] which would
 ; otherwise absorb every .ml under lib/ into the main [masc] library
@@ -34,32 +43,32 @@
  (libraries
   masc_core
   agent_sdk.base
-  ; agent_sdk (full) is needed for Guardrails_async, referenced from
-  ; guardrail_llm.{ml,mli}.  The dune-package places guardrails_async
-  ; in the wrapped [agent_sdk] library, not under agent_sdk.base.
+  ; agent_sdk (full): originally added for Guardrails_async, referenced by the
+  ; now-purged guardrail_llm (#19469). Also backs the [-open Agent_sdk] flag
+  ; below, so it cannot be dropped without auditing the flag. Whether any
+  ; surviving module still needs the full agent_sdk is unverified (deps audit
+  ; deferred — see header).
   agent_sdk
-  ; unix is needed for [Unix.gettimeofday] in conformance.ml (added by
-  ; PR #14255 RFC-OAS-011 MM-2-mid B3).  Listed explicitly so dune
-  ; resolves the [Unix] module without requiring the consumer to open
-  ; it.
+  ; unix: [Unix.gettimeofday] in conformance.ml (surviving module).
   unix
-  ; eio + eio.unix are needed by guardrails_async.mli, guardrail_tripwire.ml,
-  ; autonomy_exec.{ml,mli}, contract_runner.mli (added by PR #14264
-  ; RFC-OAS-011 MM-2-top B5).  These modules have async fiber-based
-  ; signatures (Eio.*) and call Eio_unix.* helpers.
+  ; eio + eio.unix: async fiber signatures in autonomy_exec.{ml,mli} (surviving).
+  ; The other original users (guardrails_async, guardrail_tripwire,
+  ; contract_runner) were purged in #19469.
   eio
   eio.unix
-  ; eio_main needed by autonomy_exec.ml (Eio_main.run for async runtime entry).
+  ; eio_main: [Eio_main.run] in autonomy_exec.ml (surviving module).
   eio_main
-  ; agent_sdk.llm_provider is needed by contract_runner.ml (Llm_provider.*).
+  ; agent_sdk.llm_provider: originally for contract_runner ([Llm_provider.*]),
+  ; purged in #19469 — likely dead, removal deferred pending a deps audit.
   agent_sdk.llm_provider
   yojson
   ppx_deriving_yojson.runtime)
  ; Mirror agent_sdk's flag so migrated modules' `open Types` /
  ; `open Result_syntax` resolve against Agent_sdk_base, matching their
  ; original OAS compilation context.  Also open the wrapped [Agent_sdk]
- ; namespace so unqualified references such as [Guardrails_async] in
- ; [guardrail_llm.{ml,mli}] resolve to [Agent_sdk.Guardrails_async].
+ ; namespace for unqualified references to agent_sdk submodules.  (The
+ ; original example, [Guardrails_async] in guardrail_llm, was purged in
+ ; #19469; the flag is kept because [-open Agent_sdk__] below relies on it.)
  ; XXX -open Agent_sdk__ accesses agent_sdk's internal wrapper module
  ; (no .mli, so all submodule aliases are visible — including
  ; [Sessions_types], which is referenced by sessions_proof.mli but


### PR DESCRIPTION
## 목표
cdal dune 파일의 dead build-graph 의존과 stale 주석 정리. **동작 변경 없음**(주석 + 빌드 그래프만).

## 배경
RFC-OAS-011 CDAL 이주(MM-1~MM-4, 2026-05) 후 #19469 "Track B"에서 contract/proof 런타임 파이프라인 14개 모듈이 purge되었습니다(-4987 LoC). 그 결과 dune의 주석과 의존이 코드와 어긋났습니다.

## 변경 (전부 검증됨)
**`lib/cdal/dune`**
- dead `masc.cdal_runtime` 의존 제거 (`adversarial_eval.ml`이 미참조)

**`lib/cdal_runtime/dune`**
- dead `agent_sdk.llm_provider` 의존 제거 (유일 사용자 `contract_runner` purge됨, `Llm_provider.*` 참조 0)
- dead `-open Agent_sdk` flag 제거 (유일 용도 `Guardrails_async`/`guardrail_llm` purge됨, 참조 0)
- 헤더/의존 주석을 현재 사실로 정정 (생존 5개 모듈, #19469 purge 기록, MM-1~4 완료)

**유지 (제거 불가 — 검증)**: `agent_sdk` (full) + `-open Agent_sdk__` — `Sessions_types`가 `sessions_proof`/`conformance`/`direct_evidence`/`runtime_evidence`에서 대량 사용되며 wrapper 경유로만 접근됨. `agent_sdk` 제거 시 `Unbound module Agent_sdk__`로 빌드 실패함을 확인.

## 로컬 검증 (각 단계 빌드)
| 단계 | 결과 |
|---|---|
| `masc.cdal_runtime` 의존 제거 후 `dune build lib/cdal lib/cdal_runtime` | exit 0 |
| `agent_sdk.llm_provider` 제거 후 빌드 | exit 0 |
| `-open Agent_sdk` 제거 후 빌드 | exit 0 |
| `agent_sdk` (full) 제거 시도 (반증 실험) | exit 1, `Unbound module Agent_sdk__` → 유지 확정 |

## 후속 (별도)
- `RFC-OAS-009 v2` 동일 doc-lag 정정 (oas #2171에서 RFC-OAS-011은 처리)
- `runtime_evidence` masc↔oas 중복 — RFC-OAS-013 위임
- `-open Agent_sdk__` 내부 wrapper 의존 제거(근본): `Sessions_types`를 `agent_sdk.mli`에 re-export 하거나 qualified 참조로 전환 — oas 측 작업

RFC-WAIVED: 변경 대상(`lib/cdal*`, dune 의존/주석)은 credential/identity/operator/keeper_sandbox/dashboard credential/hooks/workflow 등 RFC 게이트 subsystem에 해당하지 않습니다. dead 의존 제거 + 문서 정합성만 수행합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
