### PR TITLE
fix(dashboard): 승인 화면 '비가역·위험' KPI를 bad 밴드(critical)만 카운트

### DIFF
--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -111,6 +111,30 @@ describe('ApprovalsSurface', () => {
     expect(container.querySelector('[data-testid="approvals-queue"]')).not.toBeNull()
   }, 20000)
 
+  it('counts only the bad (critical) visual band in the 비가역·위험 KPI, matching the red card rails', async () => {
+    const { ApprovalsSurface } = await loadSurface([
+      queueItem({ id: 'c1', risk_level: 'critical' }),
+      queueItem({ id: 'h1', risk_level: 'high' }),
+      queueItem({ id: 'm1', risk_level: 'medium' }),
+      queueItem({ id: 'l1', risk_level: 'low' }),
+      queueItem({ id: 'c2', risk_level: 'critical' }),
+    ])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    // Two critical items render the red sev-bad rail; high/medium/low do not.
+    const badCards = container.querySelectorAll('.ap-card.sev-bad')
+    expect(badCards.length).toBe(2)
+
+    // The KPI must equal that bad-band card count (not high+critical), so the
+    // red-styled value never claims irreversible items no card flags red.
+    const kpi = container.querySelector('[data-testid="approvals-kpi-irreversible"]')
+    expect(kpi).not.toBeNull()
+    expect(kpi?.textContent?.trim()).toBe('2')
+    expect(kpi?.className).toContain('bad')
+  }, 20000)
+
   it('renders a selected request dossier from backed approval queue fields', async () => {
     const { ApprovalsSurface } = await loadSurface([
       queueItem({

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -18,7 +18,6 @@ import type { KeeperApprovalQueueItem } from '../../types'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../../config/constants'
 import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
 import {
-  isHighOrCriticalKeeperApprovalRisk,
   keeperApprovalRiskLabel,
   keeperApprovalRiskVisualBand,
   type KeeperApprovalRiskVisualBand,
@@ -284,10 +283,15 @@ export function ApprovalsSurface() {
   const selectedItem = items.find(item => item.id === selectedId) ?? items[0] ?? null
 
   const stats = useMemo(() => {
-    const risky = items.filter(i => isHighOrCriticalKeeperApprovalRisk(i.risk_level)).length
+    // "비가역 · 위험" counts the bad visual band only (critical), matching the red
+    // sev-bad card rail and the prototype's `sev === 'bad'` KPI. The broader
+    // high+critical predicate over-counts: a `high` item renders the warn (amber)
+    // band, so including it made the red-styled KPI claim irreversible items that
+    // no card flags red.
+    const irreversible = items.filter(i => keeperApprovalRiskVisualBand(i.risk_level) === 'bad').length
     const longest = items.reduce((max, i) => Math.max(max, i.waiting_s ?? 0), 0)
     const keepers = new Set(items.map(i => i.keeper_name)).size
-    return { risky, longest, keepers }
+    return { irreversible, longest, keepers }
   }, [items])
 
   return html`
@@ -316,7 +320,7 @@ export function ApprovalsSurface() {
           </div>
           <div class="ov-kpi">
             <div class="ov-kpi-k">비가역 · 위험</div>
-            <div class=${`ov-kpi-v ${stats.risky ? 'bad' : ''}`}>${stats.risky}</div>
+            <div class=${`ov-kpi-v ${stats.irreversible ? 'bad' : ''}`} data-testid="approvals-kpi-irreversible">${stats.irreversible}</div>
           </div>
           <div class="ov-kpi">
             <div class="ov-kpi-k">최장 대기</div>


### PR DESCRIPTION
## 무엇을 / 왜

HITL 승인 화면의 **"비가역 · 위험" KPI가 `high`+`critical`을 세는데**(`isHighOrCriticalKeeperApprovalRisk`), KPI 값은 `bad`(빨강)으로 스타일링되고 시안 KPI는 `sev === 'bad'`(=비가역 밴드)만 셉니다.

live 4-band risk 모델: `critical → bad`(빨간 rail), `high → warn`(amber rail). 따라서 큐에 `high`만 있으면 **빨간 "비가역 N" KPI가 뜨는데 빨간 카드 rail은 0개** — KPI가 어떤 카드도 빨강으로 표시하지 않은 "비가역" 건수를 주장하는 내부 불일치입니다.

## 변경

- KPI 카운트를 `keeperApprovalRiskVisualBand(risk) === 'bad'`(critical)로 교체. 빨간 `sev-bad` 카드 rail 및 시안 KPI 의미와 정렬.
- 공유 헬퍼 `isHighOrCriticalKeeperApprovalRisk`는 **그대로 둠**(`governance.ts:354`가 `isCritical`로 사용). approvals에서 더 이상 안 쓰는 import만 제거.
- 변수명 `risky → irreversible`(이제 "비가역" 라벨 + bad rail과 일치).

## 정당성

KPI 값 div는 이미 `ov-kpi-v ${count ? 'bad' : ''}`로 0 초과 시 빨강 처리됩니다. 즉 의도된 의미는 "빨간(bad) 밴드 건수"였는데 카운트만 high+critical로 어긋나 있었습니다. 이 PR은 카운트를 스타일·카드 rail·시안과 일치시킵니다. 라벨("비가역 · 위험")은 시안 verbatim 유지.

`보류/처리완료` KPI(시안 3·4번)는 defer/resolved 엔드포인트가 없어 `최장 대기/관련 키퍼`로 치환된 상태 그대로 둡니다(별도 정당화된 divergence, 이 PR 범위 밖).

## 검증

- `approvals-surface.test.ts`에 KPI 단언 추가: critical+high+medium+low+critical → KPI = 2 (= `.ap-card.sev-bad` 개수), high 미포함.
- **비-vacuity 증명**: 소스를 구 동작(high+critical)으로 되돌리면 KPI '3' → 테스트 red(`expected '3' to be '2'`).
- 7/7 테스트 · `tsc --noEmit` · `eslint` · `vite build` 전부 pass.

RFC-WAIVED: dashboard 표시 로직/테스트 변경 — credential/identity/operator/sandbox/hooks/workflow 등 RFC-gated subsystem 비해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
