### PR TITLE
build(deps): land ws-direct handshake timeout (#2) — bump to 75e7ce5 + thread ~clock

### DIFF
--- a/lib/gate/discord_wss_connection.ml
+++ b/lib/gate/discord_wss_connection.ml
@@ -179,7 +179,10 @@ let build_session ~sw ~env ~url =
       ~on_eof:(fun () -> Eio.Stream.add events Ev_eof)
       ()
   in
-  let wsd = Ws_direct_eio.Client.connect ~sw ~host ~resource flow builder in
+  let wsd =
+    Ws_direct_eio.Client.connect ~sw ~clock:(Eio.Stdenv.clock env) ~host
+      ~resource flow builder
+  in
   wsd, events
 ;;
 

--- a/lib/server/server_ws_standalone.ml
+++ b/lib/server/server_ws_standalone.ml
@@ -138,6 +138,7 @@ let start
                        Ws_server.handle
                          ~max_message:
                            (Server_mcp_transport_ws.max_inbound_message_bytes ())
+                         ~clock
                          flow
                          (make_websocket_handler ~sw:conn_sw ~clock ~on_message
                             client_addr)

--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -242,15 +242,15 @@ pin-depends: [
   ]
   [
   "ws-direct-core.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#3595406fe28713dbc4638c277e567031da339cd0"
+  "git+https://github.com/jeong-sik/ws-direct.git#75e7ce529a568bc5d98363b7df603ec15d518092"
 ]
   [
   "ws-direct-eio.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#3595406fe28713dbc4638c277e567031da339cd0"
+  "git+https://github.com/jeong-sik/ws-direct.git#75e7ce529a568bc5d98363b7df603ec15d518092"
 ]
   [
   "ws-direct-gluten.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#3595406fe28713dbc4638c277e567031da339cd0"
+  "git+https://github.com/jeong-sik/ws-direct.git#75e7ce529a568bc5d98363b7df603ec15d518092"
 ]
 ]
 x-maintenance-intent: ["(latest)"]

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -56,7 +56,7 @@ fi
 # --- Pin SHAs (bump these when upstream changes are needed) ---
 readonly WEBRTC_SHA="1b7993605b293f45169369d488f970ba15132a9f"
 readonly GRPC_DIRECT_SHA="d7269ebebf9e4688486cc6591c66e794607e7b0f"
-readonly WS_DIRECT_SHA="3595406fe28713dbc4638c277e567031da339cd0"
+readonly WS_DIRECT_SHA="75e7ce529a568bc5d98363b7df603ec15d518092"
 readonly NEO4J_BOLT_SHA="a1ca30c1247db5c58934e99306fe330419f7b21a"
 
 include_bisect=false


### PR DESCRIPTION
## 무엇을

ws-direct pin을 `3595406` → `75e7ce5`로 올려 **ws-direct#2(opening handshake wall-clock deadline)**를 masc에 반영하고, 그것이 요구하는 `~clock`을 두 호출부에 주입합니다.

#22199(이미 머지됨)가 `c1dc564`→`3595406`(ws-direct#3 writer busy-spin fix)을 반영했고, 이 PR은 그 위에 ws-direct#2를 얹는 후속입니다.

## 왜 호출부 수정이 필요한가

ws-direct#2는 `read_head`에 `Eio.Time.with_timeout_exn` 데드라인(slowloris 차단, RFC 6455 §10)을 넣으면서 `Client.connect`·`Server.handle`에 **`~clock`을 필수 labeled arg로 추가**합니다. 따라서 pin을 그 SHA로 올리면 masc 두 호출부가 컴파일에러가 납니다. ws-direct에는 CI가 없어 이 breakage가 업스트림에서 감지되지 않으므로, **pin bump와 호출부 수정을 한 PR로 묶습니다.**

## 변경

- `lib/gate/discord_wss_connection.ml`: `build_session`이 이미 `~env`를 받으므로 `~clock:(Eio.Stdenv.clock env)`을 `Client.connect`에 전달.
- `lib/server/server_ws_standalone.ml`: `clock`이 이미 scope에 있으므로(`make_websocket_handler`에 전달 중) `Ws_server.handle`에 `~clock` 추가.
- `masc.opam.locked`: ws-direct-core/eio/gluten `3595406` → `75e7ce5`.
- `scripts/opam-pin-external-deps.sh`: `WS_DIRECT_SHA` `3595406` → `75e7ce5`.

`handshake_timeout`은 기본값(10s)을 쓰므로 호출부에서 명시하지 않습니다.

## 검증

`dune build --root . bin/main_eio.exe`를 worktree에서 재설치된 ws-direct `75e7ce5`(새 `~clock` API)에 대해 빌드 → 두 호출부 플러밍 컴파일·링크 성공.

RFC: 불필요 (gated subsystem credential/operator/dashboard/hooks/workflow 미접촉; lib/gate·lib/server 호출부 1줄 + lockfile/스크립트 SHA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
