### PR TITLE
fix(dashboard): 승인 화면 data-screen-label + 액션 와이어링 테스트 커버리지

### DIFF
--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -249,6 +249,19 @@ describe('ApprovalsSurface', () => {
     expect(container.querySelector('[data-testid="approvals-queue"]')).toBeNull()
   })
 
+  it('labels the surface with the shared data-screen-label convention', async () => {
+    // Every v2 surface (fusion/schedule/settings/connector/copilot) tags its
+    // <main> with data-screen-label; the prototype names this screen 승인 큐.
+    // Asserting it keeps the approvals surface consistent with that convention.
+    const { ApprovalsSurface } = await loadSurface([])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const main = container.querySelector('[data-testid="approvals-surface"]')
+    expect(main?.getAttribute('data-screen-label')).toBe('승인 큐')
+  })
+
   it('routes the 승인 action through respondToKeeperApproval → resolveGovernanceApproval', async () => {
     const { ApprovalsSurface, resolveGovernanceApproval } = await loadSurface([
       queueItem({ id: 'appr-9', keeper_name: 'masc-improver' }),

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -53,8 +53,15 @@ async function loadSurface(approval_queue: KeeperApprovalQueueItem[]) {
     submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'x' } }),
   }))
   vi.doMock('../../sse-store', () => ({ registerGovernanceRefresh: vi.fn() }))
+  // Preserve the real router (route signal etc.) but capture navigate() so the
+  // "open keeper conversation" wiring can be asserted without a real route change.
+  const navigate = vi.fn()
+  vi.doMock('../../router', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../../router')>()),
+    navigate,
+  }))
   const mod = await import('./approvals-surface')
-  return { ApprovalsSurface: mod.ApprovalsSurface, resolveGovernanceApproval }
+  return { ApprovalsSurface: mod.ApprovalsSurface, resolveGovernanceApproval, navigate }
 }
 
 describe('ApprovalsSurface', () => {
@@ -276,5 +283,77 @@ describe('ApprovalsSurface', () => {
     await flushUi()
 
     expect(resolveGovernanceApproval).toHaveBeenCalledWith('appr-9', 'approve', false)
+  })
+
+  it('routes the 거부 action through resolveGovernanceApproval with the reject decision', async () => {
+    const { ApprovalsSurface, resolveGovernanceApproval } = await loadSurface([
+      queueItem({ id: 'appr-r', keeper_name: 'masc-improver' }),
+    ])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    container.querySelector<HTMLButtonElement>('.ap-card .ap-act.deny')?.click()
+    await flushUi()
+
+    expect(resolveGovernanceApproval).toHaveBeenCalledWith('appr-r', 'reject', false)
+  })
+
+  it('routes the 항상 승인 action through resolveGovernanceApproval with rememberRule=true', async () => {
+    const { ApprovalsSurface, resolveGovernanceApproval } = await loadSurface([
+      queueItem({ id: 'appr-a', keeper_name: 'masc-improver' }),
+    ])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    container.querySelector<HTMLButtonElement>('.ap-card .ap-act.always')?.click()
+    await flushUi()
+
+    expect(resolveGovernanceApproval).toHaveBeenCalledWith('appr-a', 'approve', true)
+  })
+
+  it('surfaces a visible error and re-enables the actions when a decision fails (no silent failure)', async () => {
+    const { ApprovalsSurface, resolveGovernanceApproval } = await loadSurface([
+      queueItem({ id: 'appr-e', keeper_name: 'masc-improver' }),
+    ])
+    // The next decision call rejects: the operator must SEE the failure, because a
+    // silently-failed reject would let the keeper proceed while the queue clears.
+    resolveGovernanceApproval.mockRejectedValueOnce(new Error('승인 서버 연결 실패'))
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    container.querySelector<HTMLButtonElement>('.ap-card .ap-act.deny')?.click()
+    await flushUi()
+
+    // visible error banner with the failure message
+    const errorBanner = container.querySelector('[data-testid="approvals-error"]')
+    expect(errorBanner).not.toBeNull()
+    expect(errorBanner?.textContent).toContain('승인 서버 연결 실패')
+    // actions are re-enabled (finally cleared the busy state) so the operator can retry
+    const denyBtn = container.querySelector<HTMLButtonElement>('.ap-card .ap-act.deny')
+    expect(denyBtn?.disabled).toBe(false)
+  })
+
+  it('opens the keeper conversation from 대화에서 검토', async () => {
+    const { ApprovalsSurface, navigate } = await loadSurface([
+      queueItem({ id: 'appr-k', keeper_name: 'masc-improver' }),
+    ])
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const reviewBtn = container.querySelector<HTMLButtonElement>('.ap-card .ap-act.ghost')
+    expect(reviewBtn?.textContent).toContain('대화에서 검토')
+    reviewBtn?.click()
+    await flushUi()
+
+    // routes to the keeper's detail page (which defaults to the conversation view)
+    expect(navigate).toHaveBeenCalledWith('monitoring', {
+      section: 'agents',
+      view: 'keepers',
+      keeper: 'masc-improver',
+    })
   })
 })

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -291,7 +291,7 @@ export function ApprovalsSurface() {
   }, [items])
 
   return html`
-    <main class="ov ss-surface bg-surface-page text-text-primary" data-testid="approvals-surface">
+    <main class="ov ss-surface bg-surface-page text-text-primary" data-screen-label="승인 큐" data-testid="approvals-surface">
       <div class="ov-scroll">
         <header class="ov-head">
           <div>


### PR DESCRIPTION
## 무엇을 / 왜

HITL 승인 화면의 두 가지를 함께 처리합니다: ①시안/규약 일치 속성 누락 ②액션 와이어링의 안전-임계 경로 테스트 미커버.

### 1. `data-screen-label` 누락

approvals `<main>`만 `data-screen-label`을 선언하지 않았습니다. 다른 모든 v2 surface는 선언합니다: fusion(`Fusion`) / schedule(`예약`) / settings(`설정`) / connector(`커넥터`) / copilot-dock(`Chat 도크`). keeper-v2 시안도 이 화면을 `승인 큐`로 명명. → `data-screen-label="승인 큐"` 추가.

### 2. 액션 와이어링 테스트 커버리지

기존 테스트는 `승인`만 검증했습니다. HITL 결재의 나머지 안전-임계 와이어링을 고정해 회귀를 막습니다:
- `거부` → `resolveGovernanceApproval(id, 'reject', false)`
- `항상 승인` → `resolveGovernanceApproval(id, 'approve', true)`
- **실패 시 `.ap-error` 배너 노출 + 버튼 재활성** (노 Silent Failure: 거부가 조용히 실패하면 큐는 비워지는데 keeper는 진행 → 위험)
- `대화에서 검토 →` → keeper 상세(기본=대화 뷰)로 `navigate`

## 와이어링 감사 결과 (배경)

이 PR 전 라이브 인터랙션을 전수 추적했고 **와이어링은 이미 정확**합니다(`governance-actions.ts:126` respondToKeeperApproval = API + 에러 처리 + busy + refresh; `agents-unified.ts:64` keeper param → KeeperDetailPage, `keeper-detail-page.ts:174` 기본=대화 뷰). 변경은 그 정확성을 **테스트로 고정**하는 것 + 누락 속성. 라이브가 정적 시안보다 견고합니다(실 API·에러·auto-refresh).

## 범위 밖(의도적)

- `ov-2col`/`ov-flush`: live CSS 정의 無 = mockup 전용 → 추가 안 함.
- ApAside Auto승인=governance "Always Rules" 소유 / 최근처리=엔드포인트 無 / 지금상황 pulse=카드+KPI 중복 → 정당한 divergence.

## 검증

- `approvals-surface.test.ts` 11/11 (screen-label 1 + 와이어링 4 추가).
- **비-vacuity 증명**: screen-label 속성 제거 → red; `governanceError` 무력화 → "no silent failure" 테스트 red.
- `tsc --noEmit` · `eslint` · `vite build` 전부 pass.

RFC-WAIVED: dashboard 표시 속성/테스트 변경 — RFC-gated subsystem 비해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
