### PR TITLE
build(deps): bump ws-direct to 88f3259 (connection terminal-event stop #1)

### DIFF
--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -242,15 +242,15 @@ pin-depends: [
   ]
   [
   "ws-direct-core.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#75e7ce529a568bc5d98363b7df603ec15d518092"
+  "git+https://github.com/jeong-sik/ws-direct.git#88f325956e8d03e5d68838145ada08a19e221c42"
 ]
   [
   "ws-direct-eio.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#75e7ce529a568bc5d98363b7df603ec15d518092"
+  "git+https://github.com/jeong-sik/ws-direct.git#88f325956e8d03e5d68838145ada08a19e221c42"
 ]
   [
   "ws-direct-gluten.0.1.0"
-  "git+https://github.com/jeong-sik/ws-direct.git#75e7ce529a568bc5d98363b7df603ec15d518092"
+  "git+https://github.com/jeong-sik/ws-direct.git#88f325956e8d03e5d68838145ada08a19e221c42"
 ]
 ]
 x-maintenance-intent: ["(latest)"]

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -56,7 +56,7 @@ fi
 # --- Pin SHAs (bump these when upstream changes are needed) ---
 readonly WEBRTC_SHA="1b7993605b293f45169369d488f970ba15132a9f"
 readonly GRPC_DIRECT_SHA="d7269ebebf9e4688486cc6591c66e794607e7b0f"
-readonly WS_DIRECT_SHA="75e7ce529a568bc5d98363b7df603ec15d518092"
+readonly WS_DIRECT_SHA="88f325956e8d03e5d68838145ada08a19e221c42"
 readonly NEO4J_BOLT_SHA="a1ca30c1247db5c58934e99306fe330419f7b21a"
 
 include_bisect=false


### PR DESCRIPTION
## 무엇을

ws-direct pin `75e7ce5` → `88f3259`로 올려 **ws-direct#1**(Connection.read_bytes가 첫 terminal event(peer Close/Fail)에서 파싱 중단 → Close 이후 데이터 프레임 미전달, RFC 6455 §5.5.1/§7.1.7)을 반영합니다.

## 왜 호출부 수정이 없는가

#1은 `read_bytes` 내부 제어흐름 변경으로 **시그니처 무변경** → masc 호출부 수정 불필요. 순수 pin bump(#22199과 동일 클래스).

## 변경
- `masc.opam.locked`: ws-direct-core/eio/gluten `75e7ce5` → `88f3259`
- `scripts/opam-pin-external-deps.sh`: `WS_DIRECT_SHA`

## 검증
ws-direct 소비부(`lib/gate` discord, `lib/server` ws_standalone)가 재설치된 ws-direct `88f3259`에 컴파일됨(`dune build --root . lib/gate lib/server`). 전체 빌드는 무관한 로컬 agent_sdk pin skew로만 막힘 — CI는 locked agent_sdk로 빌드.

RFC: 불필요 (gated subsystem 미접촉; lockfile/스크립트 SHA만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)