### PR TITLE
refactor(worker): worker destructive 게이팅을 policy 단일 진실점으로 (CR2, #22195 스택)

### DIFF
--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -321,6 +321,21 @@ let make_tool_tracking_hooks
       ?(destructive_ops_policy = Destructive_ops_policy.default)
       ?context
       () =
+  (* Single source of truth for destructive gating: project the gate's
+     [destructive_check_enabled] flag into the policy once, up front, so the
+     per-tool-call check below consults only [policy.enabled] (via
+     [detect_destructive]). A disabled gate yields
+     [Destructive_ops_policy.disabled]. This mirrors the keeper path
+     ([Keeper_guards]), which gates on the policy alone, and removes the
+     dual-flag where [destructive_check_enabled] and [policy.enabled] could
+     disagree in any future caller that passes a custom policy. *)
+  let destructive_ops_policy =
+    match gate_config with
+    | Some (gate : Eval_gate.gate_config)
+      when not gate.destructive_check_enabled ->
+        Destructive_ops_policy.disabled
+    | _ -> destructive_ops_policy
+  in
   let tool_names_ref = ref [] in
   let tracking =
     { Agent_sdk.Hooks.empty with
@@ -344,9 +359,11 @@ let make_tool_tracking_hooks
                         ~reason_code:"worker_deny"
                         ~reason_text:"tool is on the worker deny list"))
                  else if
-                   (* Gate 1: Destructive pattern detection *)
-                   gate.destructive_check_enabled
-                   && Tool_capability.has Tool_capability.Destructive tool_name
+                   (* Gate 1: Destructive pattern detection. Gated on the policy
+                      alone — [destructive_check_enabled] was projected into
+                      [destructive_ops_policy] above, so a disabled gate makes
+                      [detect_destructive] return [None]. *)
+                   Tool_capability.has Tool_capability.Destructive tool_name
                  then (
                    let cmd = extract_command_from_input input in
                    match Eval_gate.detect_destructive destructive_ops_policy cmd with


### PR DESCRIPTION
## 목적

worker 경로의 destructive 게이팅을 **policy 단일 진실점**으로 통일한다. `make_tool_tracking_hooks`는 `gate.destructive_check_enabled` **그리고** policy(`detect_destructive`가 내부에서 `policy.enabled` 확인)의 **dual-flag**로 게이트했다. flag를 hook 진입 시 policy로 1회 투영(disabled gate → `Destructive_ops_policy.disabled`)하고, per-call 체크는 policy 하나만 보게 한다.

## 배경 (적대 리뷰 후속, #22195 CR2)

#22195 적대 리뷰에서 "single source of truth" 프레이밍이 부분적이라고 지적했다. 추가 조사에서:
- **keeper 경로**(`Keeper_guards`)는 이미 policy 단일 게이트 — flag 없음.
- **worker 경로**만 dual-flag. 단 live 호출부 2곳(`run_worker_via_oas`, `resume_worker_via_oas`)이 policy를 안 넘겨 항상 default(enabled)라 **오늘은 benign**.
- `Eval_gate.guarded_execute`(dual-flag가 가장 날카로웠던 곳)는 **프로덕션 호출자 0 = dead code**.

이 PR은 worker 경로를 keeper 경로와 동일한 단일 진실점으로 맞춰 dual-flag를 제거한다(미래에 커스텀 policy를 넘기는 호출자가 생겨도 불일치 불가능).

## 변경

`lib/worker_oas.ml` `make_tool_tracking_hooks`:
- 진입부에서 `gate.destructive_check_enabled`를 policy로 투영(false → `Destructive_ops_policy.disabled`).
- Gate 1 조건에서 `gate.destructive_check_enabled &&` 제거 → `Tool_capability.has Destructive` 만. policy가 disabled면 `detect_destructive`가 None 반환.

## 동작 (순수 refactor)

네 가지 `(destructive_check_enabled, policy.enabled)` 조합 모두 결과 동일:

| flag | policy.enabled | before | after |
|---|---|---|---|
| T | T | block | block |
| T | F | continue (detect None) | continue (detect None) |
| F | T | continue (short-circuit) | continue (projected disabled) |
| F | F | continue | continue |

기존 `test_destructive_blocks_rm_rf`(flag on)·`test_destructive_disabled`(flag off)가 양 분기를 핀하고 green 유지. revert해도 green이라 새 non-vacuous 테스트는 불가능(순수 구조 변경).

## 스택 / 의존

- `Destructive_ops_policy.disabled`(#22195)에 의존 → 이 PR의 base를 #22195 브랜치로 둔다. #22195 머지 시 main으로 retarget.

## 별도 발견 (이 PR 범위 밖, 기록)

`Eval_gate.guarded_execute`는 dead production code(호출자 0). #22176/#22195가 사실상 미사용 함수 위에서 진행됐다. 제거 또는 wiring을 별도 추적 권고.

RFC-WAIVED: 비-gated subsystem(`lib/worker_oas.ml`). credential/identity/operator/sandbox/hooks/workflow 무관. 순수 refactor, workaround 시그니처 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
