### PR TITLE
fix(dashboard): governanceResource stale-while-revalidate — 승인 큐 깜빡임 제거

### DIFF
--- a/dashboard/src/components/governance-actions.ts
+++ b/dashboard/src/components/governance-actions.ts
@@ -59,8 +59,8 @@ export async function refreshGovernance() {
     return data
   })
   const s = governanceResource.state.value
-  if (s.status === 'error') {
-    governanceError.value = s.message
+  if (s.error) {
+    governanceError.value = s.error
   }
 }
 

--- a/dashboard/src/components/governance-resource-swr.test.ts
+++ b/dashboard/src/components/governance-resource-swr.test.ts
@@ -1,0 +1,110 @@
+// Stale-while-revalidate guard for the governance resource.
+//
+// governanceResource backs both the governance command surface and the HITL
+// approvals surface. It must NOT blank its data while a refresh is in flight:
+// refreshGovernance() runs on mount, on every auto-refresh tick, and after every
+// approve/reject. If a refetch cleared the data, the approvals queue would flash
+// its "열린 승인이 없습니다" empty state every cycle. This pins that the previous
+// data stays visible (loading=true, data=previous) until the new data arrives.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DashboardGovernanceResponse, KeeperApprovalQueueItem } from '../types'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(r => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+function queueItem(id: string): KeeperApprovalQueueItem {
+  return {
+    id,
+    keeper_name: 'keeper-x',
+    tool_name: 'fs_write',
+    risk_level: 'critical',
+    waiting_s: 10,
+    input_preview: 'x',
+    task_id: 'T-1',
+  } as KeeperApprovalQueueItem
+}
+
+function response(queue: KeeperApprovalQueueItem[]): DashboardGovernanceResponse {
+  return {
+    generated_at: '2026-06-24T00:00:00Z',
+    summary: { judge_online: false },
+    items: [],
+    activity: [],
+    judgments: [],
+    pending_actions: [],
+    approval_queue: queue,
+  } as DashboardGovernanceResponse
+}
+
+async function loadGovernance() {
+  vi.resetModules()
+  const fetchDashboardGovernance = vi.fn()
+  vi.doMock('../api', () => ({
+    fetchDashboardGovernance,
+    fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(null),
+    decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
+    resolveGovernanceApproval: vi.fn().mockResolvedValue({ ok: true }),
+    deleteGovernanceApprovalRule: vi.fn().mockResolvedValue({ ok: true }),
+    submitGovernanceCaseBrief: vi.fn().mockResolvedValue(null),
+    submitGovernancePetition: vi.fn().mockResolvedValue({ case: { id: 'x' } }),
+  }))
+  vi.doMock('../sse-store', () => ({ registerGovernanceRefresh: vi.fn() }))
+  const signals = await import('./governance-signals')
+  const actions = await import('./governance-actions')
+  return { fetchDashboardGovernance, signals, actions }
+}
+
+afterEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  vi.doUnmock('../api')
+  vi.doUnmock('../sse-store')
+})
+
+describe('governance resource (stale-while-revalidate)', () => {
+  it('keeps the previously loaded data visible while a refresh is in flight', async () => {
+    const { fetchDashboardGovernance, signals, actions } = await loadGovernance()
+
+    fetchDashboardGovernance.mockResolvedValueOnce(response([queueItem('a1')]))
+    await actions.refreshGovernance()
+    expect(signals.governanceData.value?.approval_queue).toHaveLength(1)
+    expect(signals.governanceLoading.value).toBe(false)
+
+    // Second refresh is in flight (its fetch has not resolved yet).
+    const pending = deferred<DashboardGovernanceResponse>()
+    fetchDashboardGovernance.mockReturnValueOnce(pending.promise)
+    const inflight = actions.refreshGovernance()
+    await Promise.resolve()
+
+    // Loading is true, but the previous queue is STILL visible — not blanked.
+    expect(signals.governanceLoading.value).toBe(true)
+    expect(signals.governanceData.value?.approval_queue).toHaveLength(1)
+
+    // Once the refresh resolves, the new data replaces it.
+    pending.resolve(response([]))
+    await inflight
+    expect(signals.governanceLoading.value).toBe(false)
+    expect(signals.governanceData.value?.approval_queue).toHaveLength(0)
+  })
+
+  it('retains the last good data and surfaces the message when a refresh fails', async () => {
+    const { fetchDashboardGovernance, signals, actions } = await loadGovernance()
+
+    fetchDashboardGovernance.mockResolvedValueOnce(response([queueItem('a1')]))
+    await actions.refreshGovernance()
+
+    fetchDashboardGovernance.mockRejectedValueOnce(new Error('거버넌스 새로고침 실패'))
+    await actions.refreshGovernance()
+
+    // Failure does not wipe the queue, and the error is visible (no silent failure).
+    expect(signals.governanceData.value?.approval_queue).toHaveLength(1)
+    expect(signals.governanceError.value).toContain('거버넌스 새로고침 실패')
+    expect(signals.governanceLoading.value).toBe(false)
+  })
+})

--- a/dashboard/src/components/governance-signals.ts
+++ b/dashboard/src/components/governance-signals.ts
@@ -4,14 +4,19 @@ import type {
   GovernanceCaseBundle,
 } from '../types'
 import type { GovernanceFilter } from './governance-utils'
-import { createAsyncResource, getData } from '../lib/async-state'
+import { createManagedAsyncResource } from '../lib/async-state'
 
 // ── Main governance resource ──
-export const governanceResource = createAsyncResource<DashboardGovernanceResponse>()
+// Managed (stale-while-revalidate): a refetch keeps the previously loaded data
+// visible while `loading` is true, instead of blanking to a dataless state.
+// createAsyncResource cleared data on every load(), so each auto-refresh and
+// each post-action refresh made governanceData null mid-flight — the approvals
+// queue (and the governance surface) flashed its empty state every cycle.
+export const governanceResource = createManagedAsyncResource<DashboardGovernanceResponse>()
 
-export const governanceLoading = computed(() => governanceResource.state.value.status === 'loading')
+export const governanceLoading = computed(() => governanceResource.state.value.loading)
 export const governanceError = signal('')
-export const governanceData = computed(() => getData(governanceResource.state.value) ?? null)
+export const governanceData = computed(() => governanceResource.state.value.data)
 
 // ── Action-specific loading flags (not data-fetch trios) ──
 export const governanceStarting = signal(false)


### PR DESCRIPTION
## 무엇을 / 왜

HITL 승인 화면 와이어링을 추적하다 발견한 **systemic flow 버그**: 승인 큐가 새로고침마다 "열린 승인이 없습니다" 빈 상태로 깜빡입니다.

근본 원인은 approvals가 아니라 공유 `governanceResource`입니다. `createAsyncResource.load()`는 **호출마다 상태를 dataless `loading`으로** 설정합니다(stale-while-revalidate 아님, `async-state.ts:85`). `refreshGovernance()`는 ①마운트 ②매 auto-refresh tick ③매 승인/거부 후 호출되므로, 그때마다 `governanceData`가 mid-flight에 null → approvals 큐(및 governance surface)가 빈 상태로 깜빡입니다. 특히 **승인 직후 큐 전체가 "없음"으로 비었다가 남은 항목으로 다시 채워지는** 깜빡임이 눈에 띕니다.

## 변경 (근본 해결, contained)

`governanceResource`를 이미 존재하는 `createManagedAsyncResource`로 교체. 이건 refetch 중 **이전 data를 유지**(`loading=true`, `data=previous`)하고 에러 시에도 마지막 good data를 보존합니다.

- `governanceData`/`governanceLoading` computed의 **public 타입 불변**(여전히 `T | null` / `boolean`) → 20+ 다운스트림 소비자 무변경 (tsc + 전체 스위트 확인).
- blast radius = 2 파일(`governance-signals.ts` resource+computed 2개, `governance-actions.ts` refreshGovernance error read).
- approvals에 로컬 stale-cache를 두는 workaround 대신 **근본(공유 resource)을 고쳐** governance surface의 동일 깜빡임도 함께 해소.

## 검증

- 새 `governance-resource-swr.test.ts`: refresh in-flight 중 `governanceData` 유지(non-vacuity 증명: createAsyncResource로 되돌리면 red) + 실패 시 last-good 유지 + 에러 visible(no silent failure).
- **전체 대시보드 스위트 594 파일 / 7767 테스트 green** (공유 시그널 변경의 회귀 없음 확인).
- `tsc --noEmit` · `eslint` · `vite build` pass.

## 잔여 (별도)

첫 로드(이전 data 없음) 시 빈 상태가 1회 깜빡이는 건 별개 — approvals가 `governanceLoading && !governanceData`일 때 loading 상태를 렌더하도록 후속 처리 가능. 이 PR은 반복적/post-action 깜빡임(주 결함)을 닫습니다.

RFC-WAIVED: dashboard 데이터-로딩 resource 변경 — credential/identity/operator-control/sandbox/hooks/workflow 등 RFC-gated subsystem 비해당.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
