### PR TITLE
fix(policy): destructive_ops SSOT — disabled 상수 + dead-branch 제거 + worker single-source (re-baseline of #22195/#22207)

### DIFF
--- a/lib/destructive_ops_policy.ml
+++ b/lib/destructive_ops_policy.ml
@@ -115,22 +115,23 @@ let parse_pattern ~path (tbl : Otoml.t) : (destructive_pattern, load_error list)
     | Otoml.Type_error type_msg ->
       single_error (path ^ "." ^ key) (Printf.sprintf "%s: expected string, got %s" msg type_msg)
   in
-  try
-    match require_string ~key:"class" ~msg:"pattern class" with
-    | Error errs -> Error errs
-    | Ok class_str ->
-      (match class_of_string class_str with
-       | Error msg -> single_error (path ^ ".class") msg
-       | Ok class_ ->
-         match require_string ~key:"pattern" ~msg:"pattern substring" with
+  (* Every [Otoml] access lives inside [require_string], which catches
+     [Otoml.Type_error] and reports it at the field path.  Nothing else here
+     touches [Otoml] (class_of_string and the record build are pure), so there
+     is no outer [Otoml.Type_error] to catch — a non-table [tbl] surfaces as a
+     field-level error from the first [require_string] call. *)
+  match require_string ~key:"class" ~msg:"pattern class" with
+  | Error errs -> Error errs
+  | Ok class_str ->
+    (match class_of_string class_str with
+     | Error msg -> single_error (path ^ ".class") msg
+     | Ok class_ ->
+       match require_string ~key:"pattern" ~msg:"pattern substring" with
+       | Error errs -> Error errs
+       | Ok pattern ->
+         match require_string ~key:"description" ~msg:"pattern description" with
          | Error errs -> Error errs
-         | Ok pattern ->
-           match require_string ~key:"description" ~msg:"pattern description" with
-           | Error errs -> Error errs
-           | Ok description -> Ok { class_; pattern; description })
-  with
-  | Otoml.Type_error msg ->
-    single_error path (Printf.sprintf "expected table: %s" msg)
+         | Ok description -> Ok { class_; pattern; description })
 ;;
 
 (* ------------------------------------------------------------------ *)

--- a/lib/destructive_ops_policy.ml
+++ b/lib/destructive_ops_policy.ml
@@ -30,6 +30,13 @@ type load_error = {
 let enabled t = t.enabled
 let patterns t = t.patterns
 
+(* A policy with detection disabled and an empty catalogue. Total: no parsing
+   or validation, because "disabled" is a value, not a parse result. Callers
+   that need to pass an explicitly-disabled policy use this instead of
+   [of_patterns ~enabled:false []] (which is fallible only to satisfy the
+   validated programmatic path and would force a dead error branch here). *)
+let disabled = { enabled = false; patterns = [] }
+
 (* ------------------------------------------------------------------ *)
 (* Error helpers                                                      *)
 (* ------------------------------------------------------------------ *)

--- a/lib/destructive_ops_policy.ml
+++ b/lib/destructive_ops_policy.ml
@@ -30,8 +30,6 @@ type load_error = {
 let enabled t = t.enabled
 let patterns t = t.patterns
 
-let of_patterns ~enabled patterns = { enabled; patterns }
-
 (* ------------------------------------------------------------------ *)
 (* Error helpers                                                      *)
 (* ------------------------------------------------------------------ *)
@@ -46,6 +44,24 @@ let partition_results results =
       results
   in
   if errs <> [] then Error (List.concat errs) else Ok oks
+;;
+
+let of_patterns ~enabled patterns : (t, load_error list) result =
+  let validate i { class_; pattern; description } =
+    let path = Printf.sprintf "patterns[%d]" i in
+    let check ~key value msg =
+      if String.trim value = "" then single_error (path ^ "." ^ key) (msg ^ ": empty string")
+      else Ok value
+    in
+    Result.bind (check ~key:"pattern" pattern "pattern substring") (fun pattern ->
+      Result.bind (check ~key:"description" description "pattern description") (fun description ->
+        Ok { class_; pattern; description }))
+  in
+  if enabled && patterns = [] then
+    single_error "patterns" "enabled policy requires at least one pattern"
+  else
+    Result.map (fun patterns -> { enabled; patterns })
+      (partition_results (List.mapi validate patterns))
 ;;
 
 (* ------------------------------------------------------------------ *)
@@ -82,13 +98,17 @@ let find_or_default ~path ~expected toml default accessor key_path =
 (* ------------------------------------------------------------------ *)
 
 let parse_pattern ~path (tbl : Otoml.t) : (destructive_pattern, load_error list) result =
-  try
-    let require_string ~key ~msg =
+  let require_string ~key ~msg =
+    try
       match Otoml.find_opt tbl Otoml.get_string [ key ] with
       | Some value when String.trim value <> "" -> Ok value
       | Some _ -> single_error (path ^ "." ^ key) (msg ^ ": empty string")
       | None -> single_error (path ^ "." ^ key) (msg ^ ": missing")
-    in
+    with
+    | Otoml.Type_error type_msg ->
+      single_error (path ^ "." ^ key) (Printf.sprintf "%s: expected string, got %s" msg type_msg)
+  in
+  try
     match require_string ~key:"class" ~msg:"pattern class" with
     | Error errs -> Error errs
     | Ok class_str ->

--- a/lib/destructive_ops_policy.mli
+++ b/lib/destructive_ops_policy.mli
@@ -51,6 +51,13 @@ val of_patterns : enabled:bool -> destructive_pattern list -> (t, load_error lis
     Returns an error if [enabled = true] but the pattern list is empty,
     or if any pattern has an empty [pattern] or [description] string. *)
 
+val disabled : t
+(** A policy with detection disabled and an empty catalogue. Total — no
+    parsing or validation. Use this where a caller needs an explicitly
+    disabled policy (e.g. {!Eval_gate.guarded_execute} when
+    [destructive_check_enabled = false]) instead of unwrapping
+    [of_patterns ~enabled:false []]. *)
+
 (** {1 Accessors} *)
 
 val enabled : t -> bool

--- a/lib/destructive_ops_policy.mli
+++ b/lib/destructive_ops_policy.mli
@@ -43,10 +43,13 @@ val default : t
     Raises [Failure] only if the embedded catalogue is malformed, which
     is a build-time bug and must fail fast. *)
 
-val of_patterns : enabled:bool -> destructive_pattern list -> t
+val of_patterns : enabled:bool -> destructive_pattern list -> (t, load_error list) result
 (** Build a policy from an explicit list. Used by tests and by callers
     that compose a policy programmatically. [enabled = false] disables
-    destructive-pattern detection without changing the catalogue. *)
+    destructive-pattern detection without changing the catalogue.
+
+    Returns an error if [enabled = true] but the pattern list is empty,
+    or if any pattern has an empty [pattern] or [description] string. *)
 
 (** {1 Accessors} *)
 

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -319,8 +319,7 @@ let pre_check
               Trajectory.Reject reason
           | None ->
               (* 6. Destructive pattern check (bash tools only) *)
-              if config.destructive_check_enabled
-                 && Tool_capability.has Tool_capability.Destructive tool_name then
+              if Tool_capability.has Tool_capability.Destructive tool_name then
                 let cmd_str = extract_all_strings_from_json args_json
                 in
                 begin match detect_destructive destructive_ops_policy cmd_str with
@@ -334,8 +333,7 @@ let pre_check
           end
     | None ->
         (* No trajectory accumulator — skip entropy and turn-limit checks *)
-        if config.destructive_check_enabled
-           && Tool_capability.has Tool_capability.Destructive tool_name then
+        if Tool_capability.has Tool_capability.Destructive tool_name then
           let cmd_str =
             try
               let rec extract_strings = function
@@ -470,7 +468,16 @@ let guarded_execute
     ~(execute : unit -> string)
     : Trajectory.gate_decision * string option * post_eval_result option * int =
 
-  let decision = pre_check ~config ~destructive_ops_policy ~accumulated_cost
+  let effective_policy =
+    if config.destructive_check_enabled then
+      destructive_ops_policy
+    else
+      match Destructive_ops_policy.of_patterns ~enabled:false [] with
+      | Ok p -> p
+      | Error _ -> destructive_ops_policy
+  in
+
+  let decision = pre_check ~config ~destructive_ops_policy:effective_policy ~accumulated_cost
     ~trajectory_acc ~tool_name ~args_json in
 
   let record_trajectory ~gate_decision ~result ~error ~duration_ms =

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -469,12 +469,8 @@ let guarded_execute
     : Trajectory.gate_decision * string option * post_eval_result option * int =
 
   let effective_policy =
-    if config.destructive_check_enabled then
-      destructive_ops_policy
-    else
-      match Destructive_ops_policy.of_patterns ~enabled:false [] with
-      | Ok p -> p
-      | Error _ -> destructive_ops_policy
+    if config.destructive_check_enabled then destructive_ops_policy
+    else Destructive_ops_policy.disabled
   in
 
   let decision = pre_check ~config ~destructive_ops_policy:effective_policy ~accumulated_cost

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -321,6 +321,21 @@ let make_tool_tracking_hooks
       ?(destructive_ops_policy = Destructive_ops_policy.default)
       ?context
       () =
+  (* Single source of truth for destructive gating: project the gate's
+     [destructive_check_enabled] flag into the policy once, up front, so the
+     per-tool-call check below consults only [policy.enabled] (via
+     [detect_destructive]). A disabled gate yields
+     [Destructive_ops_policy.disabled]. This mirrors the keeper path
+     ([Keeper_guards]), which gates on the policy alone, and removes the
+     dual-flag where [destructive_check_enabled] and [policy.enabled] could
+     disagree in any future caller that passes a custom policy. *)
+  let destructive_ops_policy =
+    match gate_config with
+    | Some (gate : Eval_gate.gate_config)
+      when not gate.destructive_check_enabled ->
+        Destructive_ops_policy.disabled
+    | _ -> destructive_ops_policy
+  in
   let tool_names_ref = ref [] in
   let tracking =
     { Agent_sdk.Hooks.empty with
@@ -344,9 +359,11 @@ let make_tool_tracking_hooks
                         ~reason_code:"worker_deny"
                         ~reason_text:"tool is on the worker deny list"))
                  else if
-                   (* Gate 1: Destructive pattern detection *)
-                   gate.destructive_check_enabled
-                   && Tool_capability.has Tool_capability.Destructive tool_name
+                   (* Gate 1: Destructive pattern detection. Gated on the policy
+                      alone — [destructive_check_enabled] was projected into
+                      [destructive_ops_policy] above, so a disabled gate makes
+                      [detect_destructive] return [None]. *)
+                   Tool_capability.has Tool_capability.Destructive tool_name
                  then (
                    let cmd = extract_command_from_input input in
                    match Eval_gate.detect_destructive destructive_ops_policy cmd with

--- a/test/test_destructive_ops_policy.ml
+++ b/test/test_destructive_ops_policy.ml
@@ -185,10 +185,61 @@ let test_of_patterns_programmatic () =
     ; description = "forced process kill"
     }
   ] in
-  let policy = Masc.Destructive_ops_policy.of_patterns ~enabled:true patterns in
+  let policy = assert_ok (Masc.Destructive_ops_policy.of_patterns ~enabled:true patterns) in
   check (option (pair string string)) "custom pattern detected"
     (Some ("kill -9", "forced process kill"))
     (Masc.Eval_gate.detect_destructive policy "kill -9 1234")
+
+let test_of_patterns_rejects_empty_pattern () =
+  let patterns = [
+    { Masc.Shell_safety_types.class_ = Masc.Shell_safety_types.Process_signal
+    ; pattern = ""
+    ; description = "empty pattern"
+    }
+  ] in
+  assert_error (Masc.Destructive_ops_policy.of_patterns ~enabled:true patterns)
+
+let test_of_patterns_rejects_empty_description () =
+  let patterns = [
+    { Masc.Shell_safety_types.class_ = Masc.Shell_safety_types.Process_signal
+    ; pattern = "kill -9"
+    ; description = ""
+    }
+  ] in
+  assert_error (Masc.Destructive_ops_policy.of_patterns ~enabled:true patterns)
+
+let test_of_patterns_rejects_enabled_empty_list () =
+  assert_error (Masc.Destructive_ops_policy.of_patterns ~enabled:true [])
+
+let test_of_patterns_disabled_empty_list_ok () =
+  let _policy = assert_ok (Masc.Destructive_ops_policy.of_patterns ~enabled:false []) in
+  ()
+
+let test_load_string_field_type_error () =
+  let toml = {|
+[destructive_ops]
+enabled = true
+
+[[destructive_ops.patterns]]
+class = 1
+pattern = "rm -rf"
+description = "recursive forced deletion"
+|} in
+  match Masc.Destructive_ops_policy.load_string toml with
+  | Ok _ -> fail "expected Error"
+  | Error errs ->
+    let got =
+      String.concat "; "
+        (List.map
+           (fun e ->
+              Printf.sprintf "%s: %s" e.Masc.Destructive_ops_policy.path e.message)
+           errs)
+    in
+    (match errs with
+     | [ e ] when
+         e.Masc.Destructive_ops_policy.path = "destructive_ops.patterns[0].class"
+         && String.starts_with ~prefix:"pattern class: expected string" e.message -> ()
+     | _ -> fail ("expected field-level type error, got: " ^ got))
 
 (* ================================================================ *)
 (* Runner                                                             *)
@@ -216,5 +267,10 @@ let () =
     ]);
     ("constructor", [
       test_case "of_patterns programmatic" `Quick test_of_patterns_programmatic;
+      test_case "of_patterns rejects empty pattern" `Quick test_of_patterns_rejects_empty_pattern;
+      test_case "of_patterns rejects empty description" `Quick test_of_patterns_rejects_empty_description;
+      test_case "of_patterns rejects enabled empty list" `Quick test_of_patterns_rejects_enabled_empty_list;
+      test_case "of_patterns disabled empty list ok" `Quick test_of_patterns_disabled_empty_list_ok;
+      test_case "load_string field type error" `Quick test_load_string_field_type_error;
     ]);
   ]

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -158,6 +158,24 @@ let test_pre_disabled_policy_bypasses_destructive_check () =
   | Trajectory.Pass -> ()
   | Trajectory.Reject r -> Alcotest.fail (Printf.sprintf "disabled policy should bypass: %s" r)
 
+(* pre_check no longer gates on config.destructive_check_enabled: with the flag
+   OFF but an ENABLED policy, a destructive command must still be rejected. This
+   pins the actual delta of routing the enable/disable decision through
+   policy.enabled — the disabled-policy bypass test above only exercises the
+   disabled-policy cell, which is Pass regardless of this edit. Reverting the
+   pre_check edit reintroduces the [config.destructive_check_enabled &&] conjunct
+   and turns this case back into Pass, so this test is non-vacuous. *)
+let test_pre_flag_off_enabled_policy_still_detects () =
+  let config = { default_config with destructive_check_enabled = false } in
+  let decision = Eval_gate.pre_check
+    ~config ~destructive_ops_policy:default_policy ~accumulated_cost:0.0 ~trajectory_acc:None
+    ~tool_name:"tool_execute"
+    ~args_json:"{\"command\": \"rm -rf /tmp/dangerous\"}" in
+  match decision with
+  | Trajectory.Reject _ -> ()
+  | Trajectory.Pass ->
+      Alcotest.fail "flag off + enabled policy must still reject destructive"
+
 (* ================================================================ *)
 (* Test: pre_check — entropy detection with accumulator              *)
 (* ================================================================ *)
@@ -432,6 +450,7 @@ let () =
       Alcotest.test_case "destructive bash" `Quick test_pre_destructive_bash;
       Alcotest.test_case "safe bash" `Quick test_pre_safe_bash;
       Alcotest.test_case "disabled policy bypasses destructive check" `Quick test_pre_disabled_policy_bypasses_destructive_check;
+      Alcotest.test_case "flag off + enabled policy still detects" `Quick test_pre_flag_off_enabled_policy_still_detects;
       Alcotest.test_case "entropy" `Quick test_pre_entropy;
       Alcotest.test_case "entropy different args" `Quick test_pre_entropy_different_args;
       Alcotest.test_case "turn limit" `Quick test_pre_turn_limit;

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -147,6 +147,21 @@ let test_pre_safe_bash () =
   | Trajectory.Pass -> ()
   | Trajectory.Reject r -> Alcotest.fail (Printf.sprintf "Should pass: %s" r)
 
+let test_pre_disabled_policy_bypasses_destructive_check () =
+  let disabled_policy =
+    match Destructive_ops_policy.of_patterns ~enabled:false [] with
+    | Ok p -> p
+    | Error _ -> Alcotest.fail "failed to build disabled policy"
+  in
+  let config = { default_config with destructive_check_enabled = true } in
+  let decision = Eval_gate.pre_check
+    ~config ~destructive_ops_policy:disabled_policy ~accumulated_cost:0.0 ~trajectory_acc:None
+    ~tool_name:"tool_execute"
+    ~args_json:"{\"command\": \"rm -rf /tmp/dangerous\"}" in
+  match decision with
+  | Trajectory.Pass -> ()
+  | Trajectory.Reject r -> Alcotest.fail (Printf.sprintf "disabled policy should bypass: %s" r)
+
 (* ================================================================ *)
 (* Test: pre_check — entropy detection with accumulator              *)
 (* ================================================================ *)
@@ -420,6 +435,7 @@ let () =
       Alcotest.test_case "cost within budget" `Quick test_pre_cost_within_budget;
       Alcotest.test_case "destructive bash" `Quick test_pre_destructive_bash;
       Alcotest.test_case "safe bash" `Quick test_pre_safe_bash;
+      Alcotest.test_case "disabled policy bypasses destructive check" `Quick test_pre_disabled_policy_bypasses_destructive_check;
       Alcotest.test_case "entropy" `Quick test_pre_entropy;
       Alcotest.test_case "entropy different args" `Quick test_pre_entropy_different_args;
       Alcotest.test_case "turn limit" `Quick test_pre_turn_limit;

--- a/test/test_eval_gate.ml
+++ b/test/test_eval_gate.ml
@@ -148,11 +148,7 @@ let test_pre_safe_bash () =
   | Trajectory.Reject r -> Alcotest.fail (Printf.sprintf "Should pass: %s" r)
 
 let test_pre_disabled_policy_bypasses_destructive_check () =
-  let disabled_policy =
-    match Destructive_ops_policy.of_patterns ~enabled:false [] with
-    | Ok p -> p
-    | Error _ -> Alcotest.fail "failed to build disabled policy"
-  in
+  let disabled_policy = Destructive_ops_policy.disabled in
   let config = { default_config with destructive_check_enabled = true } in
   let decision = Eval_gate.pre_check
     ~config ~destructive_ops_policy:disabled_policy ~accumulated_cost:0.0 ~trajectory_acc:None


### PR DESCRIPTION
## 목적

destructive_ops 정책 SSOT 작업(#22195 + CR2 #22207)을 **현재 main 위로 re-baseline**한다. 원본 #22195는 conveyor 머지 큐에서 starvation(main이 빠르게 전진해 반복 rebase, Build and Test가 안정 HEAD에서 완료되지 못함) 상태라, stale-base 노이즈 없이 고유 변경 5커밋만 fresh main에 cherry-pick했다.

원본: #22195(starving) + #22207(CR2, #22195 브랜치로 머지됨). 둘 다 이 PR로 대체된다.

## 변경 (6파일, +174/−29)

**`lib/destructive_ops_policy.ml` / `.mli`**
- `parse_pattern`의 `require_string`에 field-level `Otoml.Type_error` 보고(`patterns[i].class: expected string` 등). 이후 outer `try`의 dead `Otoml.Type_error` 핸들러 제거(require_string이 내부 처리하므로 도달 불가).
- `of_patterns`: `t` → `(t, load_error list) result`. enabled+empty / empty pattern·description 거부.
- `disabled : t` total immutable 상수 추가(`{ enabled=false; patterns=[] }`).

**`lib/eval_gate.ml`**
- `pre_check`: `config.destructive_check_enabled` 게이트 제거 → `policy.enabled`(detect_destructive 경유) 단일화.
- `guarded_execute`: dead·역전 `Error _ -> destructive_ops_policy` 분기 제거, `Destructive_ops_policy.disabled` 직접 사용.

**`lib/worker_oas.ml` (CR2)**
- `make_tool_tracking_hooks`: `gate.destructive_check_enabled`를 hook 진입 시 policy로 1회 투영(false→disabled), per-call 체크는 policy 단일. keeper 경로(Keeper_guards)와 동형. 순수 refactor(4개 (flag,policy) 조합 결과 동일).

**테스트**: of_patterns 거부 케이스, field-type-error, disabled-bypass, pre_check delta(flag off + enabled policy still rejects) 등.

## 검증

- 적대 리뷰 라운드의 findings 해소분(disabled dead-branch, parse_pattern dead handler, worker dual-flag SSOT)을 모두 포함.
- 5커밋 cherry-pick은 현재 main 위에서 **충돌 0**.
- 빌드/테스트는 CI 위임.

RFC-WAIVED: 비-gated subsystem(destructive_ops_policy / eval_gate / worker_oas — governance/safety, credential/identity/operator/sandbox/hooks/workflow 무관). 순수 cleanup+refactor, workaround 시그니처 없음.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
