### PR TITLE
feat(dashboard): keeper 메모리 패널 실데이터 백킹 (Phase 1 read-path)

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -579,7 +579,7 @@ describe('parseMemoryOsClaimKind (SSOT mirror of claim_kind_of_string)', () => {
   })
 })
 
-describe('decodeMemoryOsFact via fetchKeeperTurnRecords (RFC-0293 §4a)', () => {
+describe('decodeMemoryOsFact via fetchKeeperTurnRecords (RFC-keeper-memory-panel-real-data §4a)', () => {
   it('decodes fact rows with typed category / provenance / TTL, absorbs Unknown, drops malformed and the deleted score model', async () => {
     const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
       new Response(JSON.stringify({

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -21,6 +21,8 @@ import {
   fetchKeeperToolCalls,
   fetchKeeperToolStats,
   fetchKeeperTurnRecords,
+  parseMemoryOsFactCategory,
+  parseMemoryOsClaimKind,
   fetchKeeperTurnTranscript,
   fetchDashboardMemory,
   fetchDashboardMission,
@@ -540,6 +542,155 @@ describe('keeper tool telemetry fetchers', () => {
     expect(result.entries[0]?.record.finish_reason).toBe('completed')
     expect(result.entries[1]?.record.model).toBeUndefined()
     expect(result.entries[1]?.record.finish_reason).toBeUndefined()
+  })
+})
+
+describe('parseMemoryOsFactCategory (SSOT mirror of category_of_string)', () => {
+  it('maps every known token to its tag and absorbs the rest as a typed Unknown', () => {
+    const known = [
+      'code_change',
+      'fact',
+      'preference',
+      'blocker',
+      'goal',
+      'constraint',
+      'ephemeral',
+      'validated_approach',
+      'lesson',
+    ] as const
+    for (const token of known) {
+      expect(parseMemoryOsFactCategory(token)).toEqual({ tag: token })
+    }
+    // trim + lowercase, like the backend's String.lowercase_ascii (String.trim s)
+    expect(parseMemoryOsFactCategory('  FACT ')).toEqual({ tag: 'fact' })
+    // out-of-vocabulary preserves the raw label so a rising-Unknown rate is visible
+    expect(parseMemoryOsFactCategory('Speculation')).toEqual({ tag: 'unknown', raw: 'Speculation' })
+    expect(parseMemoryOsFactCategory('')).toEqual({ tag: 'unknown', raw: '' })
+  })
+})
+
+describe('parseMemoryOsClaimKind (SSOT mirror of claim_kind_of_string)', () => {
+  it('maps the three kinds and yields undefined for anything else', () => {
+    expect(parseMemoryOsClaimKind('self_observation')).toBe('self_observation')
+    expect(parseMemoryOsClaimKind('external_state')).toBe('external_state')
+    expect(parseMemoryOsClaimKind('durable_knowledge')).toBe('durable_knowledge')
+    expect(parseMemoryOsClaimKind(' DURABLE_KNOWLEDGE ')).toBe('durable_knowledge')
+    expect(parseMemoryOsClaimKind('nonsense')).toBeUndefined()
+  })
+})
+
+describe('decodeMemoryOsFact via fetchKeeperTurnRecords (RFC-0293 §4a)', () => {
+  it('decodes fact rows with typed category / provenance / TTL, absorbs Unknown, drops malformed and the deleted score model', async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify({
+        keeper: 'keeper-alpha',
+        count: 0,
+        source: 'turn_record',
+        entries: [],
+        memory_os: {
+          schema: 'keeper.memory_os.recall_observability.v1',
+          keeper: 'keeper-alpha',
+          source: 'memory_os_files',
+          producer: 'keeper_librarian|keeper_memory_os_recall',
+          facts_store: '.masc/config/keepers/keeper-alpha.facts.jsonl',
+          episodes_store: '.masc/config/keepers/keeper-alpha/episodes',
+          recall_enabled: true,
+          now: 1_790_000_000,
+          now_iso: '2026-09-21T00:00:00Z',
+          read_errors: [],
+          episodes: { tail_limit: 12, shown: 0, current: 0, expired: 0, terminal_markers: 0, items: [] },
+          facts: {
+            tail_limit: 256,
+            shown: 3,
+            current: 2,
+            expired: 1,
+            items: [
+              {
+                claim: 'retention D0 = signup day',
+                category: 'constraint',
+                source: { trace_id: 't-1', turn: 4, tool_call_id: 'call_9' },
+                first_seen: 1_789_000_000,
+                first_seen_iso: '2026-09-09T...Z',
+                reference_time: 1_789_500_000,
+                valid_until: null,
+                valid_until_iso: null,
+                last_verified_at: 1_789_500_000,
+                current: true,
+                claim_kind: 'durable_knowledge',
+                external_ref: { kind: 'pr', id: '22198' },
+                // RFC-0247-deleted score fields: present on the wire here as a
+                // poison payload; the decoder must never copy them through.
+                salience: 0.92,
+                uses: 14,
+                confidence: 0.8,
+              },
+              {
+                claim: 'librarian emitted a category outside the taxonomy',
+                category: 'Speculation', // out-of-vocabulary → Unknown drift absorber
+                source: { trace_id: 't-2', turn: 5 }, // tool_call_id omitted → null
+                first_seen: 1_789_100_000,
+                first_seen_iso: '2026-09-09T...Z',
+                reference_time: 1_789_100_000,
+                valid_until: 1_789_900_000,
+                valid_until_iso: '2026-09-10T...Z',
+                last_verified_at: null,
+                current: false,
+                // claim_kind + external_ref omitted entirely → null
+              },
+              {
+                // malformed: missing required `claim` → dropped, never fabricated
+                category: 'fact',
+                source: { trace_id: 't-3', turn: 6 },
+                first_seen: 1,
+                reference_time: 1,
+                current: true,
+              },
+            ],
+          },
+        },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperTurnRecords('keeper-alpha')
+    const items = result.memory_os?.facts.items ?? []
+
+    // 3 rows in, malformed row dropped, 2 decoded
+    expect(items).toHaveLength(2)
+
+    const [first, second] = items
+    expect(first?.claim).toBe('retention D0 = signup day')
+    expect(first?.category).toEqual({ tag: 'constraint' })
+    expect(first?.source).toEqual({ trace_id: 't-1', turn: 4, tool_call_id: 'call_9' })
+    expect(first?.current).toBe(true)
+    expect(first?.valid_until).toBeNull()
+    expect(first?.reference_time).toBe(1_789_500_000)
+    expect(first?.claim_kind).toBe('durable_knowledge')
+    expect(first?.external_ref).toEqual({ kind: 'pr', id: '22198' })
+
+    // out-of-vocabulary category → typed Unknown arm carrying the raw label
+    expect(second?.category).toEqual({ tag: 'unknown', raw: 'Speculation' })
+    // omitted optionals are null, not fabricated
+    expect(second?.source.tool_call_id).toBeNull()
+    expect(second?.claim_kind).toBeNull()
+    expect(second?.external_ref).toBeNull()
+    expect(second?.current).toBe(false)
+
+    // RFC-0247 drift guard: the deleted composite-score fields never reappear,
+    // even when the wire payload carries them.
+    const deletedScoreKeys = [
+      'salience',
+      'uses',
+      'lastUsed',
+      'confidence',
+      'access_count',
+      'last_accessed',
+      'stale_factor',
+      'expected_lifetime_cycles',
+    ]
+    for (const key of deletedScoreKeys) {
+      expect(first as Record<string, unknown>).not.toHaveProperty(key)
+    }
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3068,7 +3068,7 @@ export type MemoryOsEpisodeSummary = {
   summary: string
 }
 
-// RFC-0293 §4a: the librarian taxonomy as a closed TS union mirroring the OCaml
+// RFC-keeper-memory-panel-real-data §4a: the librarian taxonomy as a closed TS union mirroring the OCaml
 // `category` sum (keeper_memory_os_types.ml — category_to_string is the wire SSOT).
 // The wire carries a string token; it is parsed once at this decode boundary into
 // a tagged value. An out-of-vocabulary token becomes { tag: 'unknown', raw } — the
@@ -3182,7 +3182,7 @@ export type MemoryOsTurnRecordSnapshot = {
     shown: number
     current: number
     expired: number
-    // RFC-0293 §4a: the individual fact rows (bounded by tail_limit; `shown`
+    // RFC-keeper-memory-panel-real-data §4a: the individual fact rows (bounded by tail_limit; `shown`
     // documents the bound so a truncated tail is visible, not silent).
     items: MemoryOsFact[]
   }

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -3068,6 +3068,96 @@ export type MemoryOsEpisodeSummary = {
   summary: string
 }
 
+// RFC-0293 §4a: the librarian taxonomy as a closed TS union mirroring the OCaml
+// `category` sum (keeper_memory_os_types.ml — category_to_string is the wire SSOT).
+// The wire carries a string token; it is parsed once at this decode boundary into
+// a tagged value. An out-of-vocabulary token becomes { tag: 'unknown', raw } — the
+// same drift-absorbing arm the backend's `Unknown of string` defines — so a
+// renamed/typo'd category surfaces as a typed unknown the panel can flag, never a
+// silent miscategorization. This is exact-membership parse-don't-validate, not a
+// substring/prefix classifier.
+export type MemoryOsFactCategoryTag =
+  | 'code_change'
+  | 'fact'
+  | 'preference'
+  | 'blocker'
+  | 'goal'
+  | 'constraint'
+  | 'ephemeral'
+  | 'validated_approach'
+  | 'lesson'
+export type MemoryOsFactCategory =
+  | { readonly tag: MemoryOsFactCategoryTag }
+  | { readonly tag: 'unknown'; readonly raw: string }
+
+// SSOT token list — must stay byte-identical to the known arms of
+// category_of_string/category_to_string. A drift-guard test pins this set.
+const MEMORY_OS_FACT_CATEGORY_TAGS: readonly MemoryOsFactCategoryTag[] = [
+  'code_change',
+  'fact',
+  'preference',
+  'blocker',
+  'goal',
+  'constraint',
+  'ephemeral',
+  'validated_approach',
+  'lesson',
+]
+
+export function parseMemoryOsFactCategory(raw: string): MemoryOsFactCategory {
+  // Mirror category_of_string: trim + lowercase, then exact membership.
+  const token = raw.trim().toLowerCase()
+  const known = MEMORY_OS_FACT_CATEGORY_TAGS.find(tag => tag === token)
+  return known ? { tag: known } : { tag: 'unknown', raw }
+}
+
+// RFC-0285 §3.1 claim_kind — closed vocabulary, no Unknown arm on the backend.
+// Mirrors claim_kind_of_string: an unrecognized/absent token yields undefined,
+// the backend's own None degrade to the durable path.
+export type MemoryOsClaimKind = 'self_observation' | 'external_state' | 'durable_knowledge'
+const MEMORY_OS_CLAIM_KINDS: readonly MemoryOsClaimKind[] = [
+  'self_observation',
+  'external_state',
+  'durable_knowledge',
+]
+export function parseMemoryOsClaimKind(raw: string): MemoryOsClaimKind | undefined {
+  const token = raw.trim().toLowerCase()
+  return MEMORY_OS_CLAIM_KINDS.find(kind => kind === token)
+}
+
+// RFC-0259 §3.2(b) external_ref — closed kind set; mirrors external_ref_kind_of_string.
+export type MemoryOsExternalRefKind = 'pr' | 'issue' | 'task'
+const MEMORY_OS_EXTERNAL_REF_KINDS: readonly MemoryOsExternalRefKind[] = ['pr', 'issue', 'task']
+export type MemoryOsExternalRef = {
+  readonly kind: MemoryOsExternalRefKind
+  readonly id: string
+}
+
+export type MemoryOsFactProvenance = {
+  readonly trace_id: string
+  readonly turn: number
+  readonly tool_call_id: string | null
+}
+
+// One fact row as projected by memory_os_fact_json (server_dashboard_http_keeper_api.ml).
+// Carries only the structure RFC-0247 left on the record — there is no salience /
+// uses / confidence field to decode because the backend has none to emit.
+export type MemoryOsFact = {
+  readonly claim: string
+  readonly category: MemoryOsFactCategory
+  readonly source: MemoryOsFactProvenance
+  readonly first_seen: number
+  readonly first_seen_iso: string | null
+  // last_verified_at else first_seen — the shared staleness anchor (reference_time).
+  readonly reference_time: number
+  readonly valid_until: number | null
+  readonly valid_until_iso: string | null
+  readonly last_verified_at: number | null
+  readonly current: boolean
+  readonly external_ref: MemoryOsExternalRef | null
+  readonly claim_kind: MemoryOsClaimKind | null
+}
+
 export type MemoryOsTurnRecordSnapshot = {
   schema: string
   keeper: string
@@ -3092,6 +3182,9 @@ export type MemoryOsTurnRecordSnapshot = {
     shown: number
     current: number
     expired: number
+    // RFC-0293 §4a: the individual fact rows (bounded by tail_limit; `shown`
+    // documents the bound so a truncated tail is visible, not silent).
+    items: MemoryOsFact[]
   }
 }
 
@@ -3234,6 +3327,65 @@ function decodeMemoryOsEpisode(raw: unknown): MemoryOsEpisodeSummary | null {
   }
 }
 
+function decodeMemoryOsExternalRef(raw: unknown): MemoryOsExternalRef | undefined {
+  if (!isRecord(raw)) return undefined
+  const id = asString(raw.id)
+  const kindToken = asString(raw.kind)?.trim().toLowerCase()
+  if (!id || !kindToken) return undefined
+  // Mirror external_ref_of_json: both fields required and kind in the closed
+  // set, else the whole ref is dropped (the backend's None).
+  const kind = MEMORY_OS_EXTERNAL_REF_KINDS.find(k => k === kindToken)
+  return kind ? { kind, id } : undefined
+}
+
+function decodeMemoryOsFactProvenance(raw: unknown): MemoryOsFactProvenance | null {
+  if (!isRecord(raw)) return null
+  const trace_id = asString(raw.trace_id)
+  const turn = asNumber(raw.turn)
+  if (!trace_id || turn == null) return null
+  return { trace_id, turn, tool_call_id: asNullableString(raw.tool_call_id) }
+}
+
+function decodeMemoryOsFact(raw: unknown): MemoryOsFact | null {
+  if (!isRecord(raw)) return null
+  const claim = asString(raw.claim)
+  const categoryToken = asString(raw.category)
+  const source = decodeMemoryOsFactProvenance(raw.source)
+  const first_seen = asNumber(raw.first_seen)
+  const reference_time = asNumber(raw.reference_time)
+  const current = asBoolean(raw.current)
+  // Required keys are exactly the always-present ones in memory_os_fact_json.
+  // A row missing any of them is a contract violation — dropped here rather
+  // than rendered with a guessed default (no silent fabrication).
+  if (
+    !claim
+    || !categoryToken
+    || !source
+    || first_seen == null
+    || reference_time == null
+    || current == null
+  ) {
+    return null
+  }
+  // external_ref / claim_kind are omitted by the server when None; an
+  // out-of-vocabulary value degrades to null, mirroring the backend contract.
+  const claimKindToken = asString(raw.claim_kind)
+  return {
+    claim,
+    category: parseMemoryOsFactCategory(categoryToken),
+    source,
+    first_seen,
+    first_seen_iso: asNullableString(raw.first_seen_iso),
+    reference_time,
+    valid_until: asNumber(raw.valid_until) ?? null,
+    valid_until_iso: asNullableString(raw.valid_until_iso),
+    last_verified_at: asNumber(raw.last_verified_at) ?? null,
+    current,
+    external_ref: decodeMemoryOsExternalRef(raw.external_ref) ?? null,
+    claim_kind: claimKindToken ? (parseMemoryOsClaimKind(claimKindToken) ?? null) : null,
+  }
+}
+
 function decodeMemoryOsCounts(raw: unknown): {
   tail_limit: number
   shown: number
@@ -3258,8 +3410,9 @@ function decodeMemoryOsSnapshot(raw: unknown): MemoryOsTurnRecordSnapshot | null
   const facts_store = asString(raw.facts_store)
   const episodes_store = asString(raw.episodes_store)
   const episodesRaw = isRecord(raw.episodes) ? raw.episodes : null
+  const factsRaw = isRecord(raw.facts) ? raw.facts : null
   const facts = decodeMemoryOsCounts(raw.facts)
-  if (!schema || !keeper || !source || !producer || !facts_store || !episodes_store || !episodesRaw || !facts) {
+  if (!schema || !keeper || !source || !producer || !facts_store || !episodes_store || !episodesRaw || !factsRaw || !facts) {
     return null
   }
   const episodesCounts = decodeMemoryOsCounts(episodesRaw)
@@ -3288,7 +3441,12 @@ function decodeMemoryOsSnapshot(raw: unknown): MemoryOsTurnRecordSnapshot | null
         .map(decodeMemoryOsEpisode)
         .filter((item): item is MemoryOsEpisodeSummary => item !== null),
     },
-    facts,
+    facts: {
+      ...facts,
+      items: asRecordArray(factsRaw.items)
+        .map(decodeMemoryOsFact)
+        .filter((item): item is MemoryOsFact => item !== null),
+    },
   }
 }
 

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -138,6 +138,7 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
         shown: 9,
         current: 8,
         expired: 1,
+        items: [],
       },
     },
     user_model: {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -425,8 +425,6 @@ export function KeeperWorkspaceRail({
       ? html`<${MemoryInspector}
           keeper=${memoryKeeper}
           keepers=${memoryKeepers}
-          memory=${{}}
-          compactions=${{}}
           onClose=${() => setOverlay(null)}
         />`
       : null}

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -1,168 +1,248 @@
 // @vitest-environment happy-dom
-import { cleanup, fireEvent, render } from '@testing-library/preact'
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/preact'
 import { html } from 'htm/preact'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
-  DEFAULT_COMPACTIONS,
   DEFAULT_MEMORY_KEEPERS,
-  KEEPER_MEMORY,
   MemoryInspector,
-  memAggregate,
-  memComposition,
+  factCategoryMeta,
+  memCompositionFromBlocks,
+  memFmtBytes,
   memFmtTok,
+  promptBlockMeta,
   type MemoryKeeper,
 } from './memory-inspector'
 
-afterEach(() => cleanup())
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
-// masc-improver: ctx 0.86, has pinned facts, store entries, recall timeline,
-// and a compaction record — exercises every section in the one-keeper view.
-const improver: MemoryKeeper = DEFAULT_MEMORY_KEEPERS.find(k => k.id === 'masc-improver')!
+// A turn-records payload exercising the two real-data sections (composition,
+// facts), the episode-backed 압축 section, and read_errors. The unbacked
+// sections (핀 / 회상) render disclosures regardless of payload.
+function turnRecordsPayload() {
+  return {
+    keeper: 'masc-improver',
+    count: 1,
+    source: 'turn_record',
+    memory_os: {
+      schema: 'keeper.memory_os.recall_observability.v1',
+      keeper: 'masc-improver',
+      source: 'memory_os_files',
+      producer: 'keeper_librarian',
+      facts_store: '.masc/config/keepers/masc-improver.facts.jsonl',
+      episodes_store: '.masc/config/keepers/masc-improver/episodes',
+      recall_enabled: true,
+      now: 1_790_000_000,
+      now_iso: '2026-09-21T00:00:00Z',
+      read_errors: [{ scope: 'facts', error: 'one malformed row skipped' }],
+      episodes: {
+        tail_limit: 12,
+        shown: 1,
+        current: 1,
+        expired: 0,
+        terminal_markers: 1,
+        items: [
+          {
+            trace_id: 'trace-ep1',
+            generation: 3,
+            created_at: 1_789_900_000,
+            created_at_iso: '2026-09-20T...Z',
+            valid_until: null,
+            valid_until_iso: null,
+            current: true,
+            terminal_marker: 'handoff_complete',
+            claim_count: 4,
+            summary: '리텐션 코호트 정의를 정리하고 amplitude 쿼리를 표로 캐시함.',
+          },
+        ],
+      },
+      facts: {
+        tail_limit: 256,
+        shown: 2,
+        current: 1,
+        expired: 1,
+        items: [
+          {
+            claim: 'retention D0 = 가입일, 첫 세션 기준',
+            category: 'constraint',
+            source: { trace_id: 'trace-a', turn: 4, tool_call_id: null },
+            first_seen: 1_789_000_000,
+            first_seen_iso: '2026-09-09T...Z',
+            reference_time: 1_789_500_000,
+            valid_until: null,
+            valid_until_iso: null,
+            last_verified_at: 1_789_500_000,
+            current: true,
+            claim_kind: 'durable_knowledge',
+            external_ref: { kind: 'pr', id: '22198' },
+          },
+          {
+            claim: 'amplitude 캐시는 만료됨',
+            category: 'Speculation', // out-of-vocabulary → Unknown chip
+            source: { trace_id: 'trace-b', turn: 5 },
+            first_seen: 1_789_100_000,
+            first_seen_iso: '2026-09-09T...Z',
+            reference_time: 1_789_100_000,
+            valid_until: 1_789_200_000,
+            valid_until_iso: '2026-09-09T...Z',
+            last_verified_at: null,
+            current: false,
+          },
+        ],
+      },
+    },
+    user_model: null,
+    entries: [
+      {
+        record: {
+          keeper: 'masc-improver',
+          trace_id: 'trace-a',
+          absolute_turn: 7,
+          ts: 1_789_999_000,
+          runtime_profile: 'local',
+          blocks: [
+            { block: 'persona', bytes: 1200, digest: 'aaaa1111bbbb' },
+            { block: 'memory_os_recall', bytes: 800, digest: 'cccc2222dddd' },
+            { block: 'dynamic_context', bytes: 400, digest: 'eeee3333ffff' },
+            { block: 'zero_block', bytes: 0, digest: '000000000000' },
+          ],
+          execution_ids: [],
+          input_tokens: 3500,
+          context_window: 200000,
+        },
+        diff_vs_prev: null,
+      },
+    ],
+  }
+}
+
+function stubFetch(payload: unknown = turnRecordsPayload()) {
+  const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
+    new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+  ))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+const improver: MemoryKeeper = { id: 'masc-improver', ctx: 0.86, status: 'run' }
 
 function renderInspector(keeper: MemoryKeeper = improver, onClose = vi.fn()) {
   return render(html`<${MemoryInspector} keeper=${keeper} onClose=${onClose} />`)
 }
 
-describe('MemoryInspector — one-keeper scope', () => {
-  it('renders the drawer shell scoped to the active keeper', () => {
+describe('MemoryInspector — one-keeper scope (real data)', () => {
+  it('fetches turn-records for the keeper and renders the drawer shell', async () => {
+    const fetchMock = stubFetch()
     const { container } = renderInspector()
     expect(container.querySelector('.turn-overlay')).toBeTruthy()
     expect(container.querySelector('.mem-drawer')).toBeTruthy()
-    // header title + the active keeper id
     expect(container.querySelector('.turn-hd h3')?.textContent).toContain('Keeper 메모리')
     expect(container.querySelector('.tid')?.textContent).toBe('masc-improver')
+    await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/masc-improver/turn-records?limit=24')
   })
 
-  it('renders the context-composition bar and a legend derived from live ctx tokens', () => {
+  it('builds the composition bar from real prompt-block bytes (zero blocks dropped)', async () => {
+    stubFetch()
     const { container } = renderInspector()
-    const bar = container.querySelector('.mem-bar')
-    expect(bar).toBeTruthy()
-    // memComposition filters out zero-token parts; masc-improver has 5 parts.
-    const comp = memComposition(improver)
-    expect(comp.parts.length).toBeGreaterThan(0)
-    expect(bar!.querySelectorAll('span').length).toBe(comp.parts.length)
-    // legend rows mirror the parts
-    expect(container.querySelectorAll('.mem-leg').length).toBe(comp.parts.length)
-    // 86% header readout (Math.round(0.86 * 100))
-    expect(container.querySelector('.mem-compo-sub')?.textContent).toContain('86%')
+    const bar = await waitFor(() => {
+      const b = container.querySelector('.mem-bar')
+      expect(b).toBeTruthy()
+      return b!
+    })
+    // 4 blocks in payload, 1 has 0 bytes → 3 segments + 3 legend rows.
+    expect(bar.querySelectorAll('span').length).toBe(3)
+    expect(container.querySelectorAll('.mem-leg').length).toBe(3)
+    // total bytes = 1200+800+400 = 2400, shown as KB; token readout from input_tokens.
+    expect(container.querySelector('.mem-compo-tot')?.textContent).toBe('2.3KB')
+    expect(container.querySelector('.mem-compo-sub')?.textContent).toContain('3.5k tok')
+    // block labels come from the Prompt_block_id mirror, not raw tokens.
+    expect(container.textContent).toContain('메모리 회상')
+    expect(container.textContent).toContain('동적 컨텍스트')
   })
 
-  it('renders pinned facts with their count and operator/auto provenance', () => {
+  it('renders one store row per real fact with typed category chips and Unknown absorption', async () => {
+    stubFetch()
     const { container } = renderInspector()
-    const pinHeads = [...container.querySelectorAll('.turn-sec h4')].map(h => h.textContent ?? '')
-    expect(pinHeads.some(t => t.startsWith('핀 고정 사실'))).toBe(true)
-    const pins = container.querySelectorAll('.mem-pin')
-    expect(pins.length).toBe(KEEPER_MEMORY['masc-improver']!.pinned.length)
-    // first pinned fact text is rendered verbatim
-    expect(container.textContent).toContain('retention 정의: D0 = 가입일, 첫 세션 기준')
+    await waitFor(() => expect(container.querySelectorAll('.mem-store-row').length).toBeGreaterThan(0))
+    // 2 fact items + 1 episode row all use .mem-store-row; assert facts by claim text.
+    expect(container.textContent).toContain('retention D0 = 가입일, 첫 세션 기준')
+    expect(container.textContent).toContain('제약') // constraint chip label
+    // out-of-vocabulary category surfaces its raw label, not a fabricated kind.
+    expect(container.textContent).toContain('Speculation')
+    // external_ref rendered
+    expect(container.textContent).toContain('pr 22198')
+    // NO salience meter — the deleted score model must not reappear.
+    expect(container.querySelector('.mem-sal')).toBeFalsy()
   })
 
-  it('renders the salience store with one row per entry', () => {
+  it('surfaces read_errors and renders honest disclosures for the unbacked sections', async () => {
+    stubFetch()
     const { container } = renderInspector()
-    const rows = container.querySelectorAll('.mem-store-row')
-    expect(rows.length).toBe(KEEPER_MEMORY['masc-improver']!.store.length)
-    // salience meter present on each row
-    expect(container.querySelectorAll('.mem-store-row .mem-sal').length).toBe(rows.length)
+    await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
+    // read_errors visible (no silent failure)
+    expect(container.querySelector('.mem-read-error')?.textContent).toContain('one malformed row skipped')
+    // pins → Phase 2 disclosure, timeline → Phase 3 disclosure (no fabricated rows)
+    const disclosures = [...container.querySelectorAll('.mem-disclosure')].map(d => d.textContent ?? '')
+    expect(disclosures.some(t => t.includes('Phase 2'))).toBe(true)
+    expect(disclosures.some(t => t.includes('Phase 3'))).toBe(true)
+    // no prototype fixture leakage
+    expect(container.querySelector('.mem-pin')).toBeFalsy()
+    expect(container.querySelector('.mem-tl-row')).toBeFalsy()
   })
 
-  it('filters the store by kind when a kind filter is clicked', () => {
+  it('renders the compaction section from real episodes (summary + terminal marker)', async () => {
+    stubFetch()
     const { container } = renderInspector()
-    const allRows = container.querySelectorAll('.mem-store-row').length
-    // masc-improver has 5 distinct kinds, so filter buttons render.
-    const declButtons = [...container.querySelectorAll('.mem-filter')]
-    const decisionBtn = declButtons.find(b => (b.textContent ?? '').includes('결정'))
-    expect(decisionBtn).toBeTruthy()
-    fireEvent.click(decisionBtn!)
-    const afterRows = container.querySelectorAll('.mem-store-row').length
-    expect(afterRows).toBeLessThan(allRows)
-    expect(afterRows).toBe(1) // exactly one 'decision' entry in the fixture
+    await waitFor(() => expect(container.textContent).toContain('리텐션 코호트 정의'))
+    expect(container.textContent).toContain('terminal=handoff_complete')
+    expect(container.textContent).toContain('4 claims')
   })
 
-  it('renders the recall timeline rows', () => {
-    const { container } = renderInspector()
-    const tlRows = container.querySelectorAll('.mem-tl-row')
-    expect(tlRows.length).toBe(KEEPER_MEMORY['masc-improver']!.recall.length)
-    // a compaction op row carries a negative token delta rendered with the minus glyph
-    expect(container.querySelector('.mem-tl-tok.neg')?.textContent).toContain('−')
-  })
-
-  it('renders the compaction diff with kept / summarized / dropped columns', () => {
-    const { container } = renderInspector()
-    expect(container.querySelector('.cmp-diff')).toBeTruthy()
-    expect(container.querySelector('.cmp-col.kept')).toBeTruthy()
-    expect(container.querySelector('.cmp-col.summ')).toBeTruthy()
-    expect(container.querySelector('.cmp-col.drop')).toBeTruthy()
-    const cmp = DEFAULT_COMPACTIONS['masc-improver']![0]!
-    expect(container.querySelector('.cmp-trigger')?.textContent).toContain(cmp.trigger)
-  })
-
-  it('shows the empty-state when a keeper has no compaction history', () => {
-    // sangsu has store/pins but no DEFAULT_COMPACTIONS entry.
-    const sangsu = DEFAULT_MEMORY_KEEPERS.find(k => k.id === 'sangsu')!
-    const { container } = renderInspector(sangsu)
-    expect(container.textContent).toContain('컴팩션 이력 없음')
+  it('shows an explicit empty state when memory_os is absent (no fabrication)', async () => {
+    stubFetch({ keeper: 'ghost', count: 0, source: 'turn_record', memory_os: null, user_model: null, entries: [] })
+    const { container } = renderInspector({ id: 'ghost', ctx: 0, status: 'off' })
+    await waitFor(() => expect(container.textContent).toContain('memory-os 소스 없음'))
+    expect(container.querySelector('.mem-bar')).toBeFalsy()
   })
 })
 
 describe('MemoryInspector — scope toggle', () => {
-  it('switches from one-keeper to the aggregate (전체) view', () => {
+  it('switches to the aggregate (전체) view showing the real roster + a deferral note', async () => {
+    stubFetch()
     const { container } = renderInspector()
-    // one-keeper view first: a single composition bar, no aggregate table.
-    expect(container.querySelector('.mem-table')).toBeFalsy()
-    const allBtn = [...container.querySelectorAll('.mem-scope button')].find(
-      b => b.textContent === '전체',
-    )
+    await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
+    const allBtn = [...container.querySelectorAll('.mem-scope button')].find(b => b.textContent === '전체')
     expect(allBtn).toBeTruthy()
     fireEvent.click(allBtn!)
-    // aggregate view: keeper table + stats + kind distribution appear.
-    expect(container.querySelector('.mem-table')).toBeTruthy()
-    expect(container.querySelectorAll('.mem-stat').length).toBe(4)
     expect(container.querySelector('.tid')?.textContent).toBe('전체 keeper')
-    // one table row per keeper in the roster.
-    expect(container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)').length).toBe(
-      DEFAULT_MEMORY_KEEPERS.length,
-    )
+    // roster table = one row per default keeper (ids + status are real)
+    expect(container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)').length).toBe(DEFAULT_MEMORY_KEEPERS.length)
+    // aggregate memory totals are deferred, disclosed — not fabricated
+    expect([...container.querySelectorAll('.mem-disclosure')].some(d => (d.textContent ?? '').includes('추후 연결'))).toBe(true)
   })
 
-  it('renders a status dot per row mapping run→ok / pause→idle / off→bad', () => {
-    // Mirrors the prototype StatusDot chain (keeper-v2/memory.jsx:196 →
-    // messages.jsx:8): the dot class drives the .dot2 palette in
-    // memory-inspector-v2.css (ok=--status-ok, idle=--status-idle,
-    // bad=--status-bad). A wrong class is a silent colour regression
-    // (e.g. an off keeper showing a brass dot instead of red).
+  it('maps roster status to dot state run→ok / pause→idle / off→bad', async () => {
+    stubFetch()
     const { container } = renderInspector()
-    fireEvent.click(
-      [...container.querySelectorAll('.mem-scope button')].find(b => b.textContent === '전체')!,
-    )
+    await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
+    fireEvent.click([...container.querySelectorAll('.mem-scope button')].find(b => b.textContent === '전체')!)
     const dotClassFor = (id: string): string | undefined => {
       const row = [...container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)')].find(r =>
-        (r.querySelector('.mem-td-id .mono')?.textContent ?? '') === id,
-      )
+        (r.querySelector('.mem-td-id .mono')?.textContent ?? '') === id)
       return row?.querySelector('.mem-dot')?.className
     }
-    expect(dotClassFor('nick0cave')).toContain('ok') // status 'run'
-    expect(dotClassFor('qa-king')).toContain('idle') // status 'pause'
-    expect(dotClassFor('drifter')).toContain('bad') // status 'off'
-  })
-
-  it('drills back into a single keeper when an aggregate row is clicked', () => {
-    const { container } = renderInspector()
-    fireEvent.click(
-      [...container.querySelectorAll('.mem-scope button')].find(b => b.textContent === '전체')!,
-    )
-    const nickRow = [...container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)')].find(
-      r => (r.textContent ?? '').includes('nick0cave'),
-    )
-    expect(nickRow).toBeTruthy()
-    fireEvent.click(nickRow!)
-    // back to one-keeper scope, now showing the picked keeper.
-    expect(container.querySelector('.tid')?.textContent).toBe('nick0cave')
-    expect(container.querySelector('.mem-table')).toBeFalsy()
+    expect(dotClassFor('nick0cave')).toContain('ok')
+    expect(dotClassFor('qa-king')).toContain('idle')
+    expect(dotClassFor('drifter')).toContain('bad')
   })
 })
 
 describe('MemoryInspector — close behaviour', () => {
   it('invokes onClose on overlay click and on the ✕ button', () => {
+    stubFetch()
     const onClose = vi.fn()
     const { container } = renderInspector(improver, onClose)
     fireEvent.click(container.querySelector('.turn-close')!)
@@ -172,6 +252,7 @@ describe('MemoryInspector — close behaviour', () => {
   })
 
   it('does not close when the drawer body itself is clicked (stopPropagation)', () => {
+    stubFetch()
     const onClose = vi.fn()
     const { container } = renderInspector(improver, onClose)
     fireEvent.click(container.querySelector('.mem-drawer')!)
@@ -179,6 +260,7 @@ describe('MemoryInspector — close behaviour', () => {
   })
 
   it('closes on Escape keydown', () => {
+    stubFetch()
     const onClose = vi.fn()
     renderInspector(improver, onClose)
     fireEvent.keyDown(window, { key: 'Escape' })
@@ -186,32 +268,46 @@ describe('MemoryInspector — close behaviour', () => {
   })
 })
 
-describe('memory model helpers', () => {
+describe('memory view-model helpers', () => {
   it('memFmtTok abbreviates thousands and prefixes negatives with the minus glyph', () => {
     expect(memFmtTok(120)).toBe('120')
     expect(memFmtTok(1840)).toBe('1.8k')
     expect(memFmtTok(-110600)).toBe('−110.6k')
   })
 
-  it('memComposition returns no parts for a stopped (ctx 0) keeper', () => {
-    const drifter = DEFAULT_MEMORY_KEEPERS.find(k => k.id === 'drifter')!
-    const comp = memComposition(drifter)
-    expect(comp.total).toBe(0)
-    expect(comp.parts).toEqual([])
+  it('memFmtBytes scales B / KB / MB', () => {
+    expect(memFmtBytes(500)).toBe('500B')
+    expect(memFmtBytes(1536)).toBe('1.5KB')
+    expect(memFmtBytes(2 * 1024 * 1024)).toBe('2.0MB')
   })
 
-  it('memAggregate sums pins/store across keepers and caps topFacts at 6', () => {
-    const agg = memAggregate(DEFAULT_MEMORY_KEEPERS)
-    expect(agg.keeperCount).toBe(DEFAULT_MEMORY_KEEPERS.length)
-    const expectedStore = DEFAULT_MEMORY_KEEPERS.reduce(
-      (n, k) => n + (KEEPER_MEMORY[k.id]?.store.length ?? 0),
-      0,
-    )
-    expect(agg.store).toBe(expectedStore)
-    expect(agg.topFacts.length).toBeLessThanOrEqual(6)
-    // topFacts are sorted by descending salience.
-    for (let i = 1; i < agg.topFacts.length; i++) {
-      expect(agg.topFacts[i - 1]!.salience).toBeGreaterThanOrEqual(agg.topFacts[i]!.salience)
+  it('memCompositionFromBlocks sums real bytes and drops zero-byte blocks', () => {
+    const comp = memCompositionFromBlocks([
+      { block: 'persona', bytes: 1200, digest: 'x' },
+      { block: 'memory_os_recall', bytes: 800, digest: 'y' },
+      { block: 'empty', bytes: 0, digest: 'z' },
+    ])
+    expect(comp.totalBytes).toBe(2000)
+    expect(comp.parts.map(p => p.key)).toEqual(['persona', 'memory_os_recall'])
+    expect(comp.parts[0]?.lbl).toBe('페르소나')
+  })
+
+  it('promptBlockMeta maps known Prompt_block_id tokens and keeps unknown tokens raw', () => {
+    expect(promptBlockMeta('user_model').lbl).toBe('사용자 모델')
+    expect(promptBlockMeta('connected_surface').lbl).toBe('연결 표면')
+    expect(promptBlockMeta('some_future_block').lbl).toBe('some_future_block')
+  })
+
+  it('factCategoryMeta covers every taxonomy arm and carries the raw Unknown label', () => {
+    const tags = [
+      'code_change', 'fact', 'preference', 'blocker', 'goal',
+      'constraint', 'ephemeral', 'validated_approach', 'lesson',
+    ] as const
+    for (const tag of tags) {
+      const meta = factCategoryMeta({ tag })
+      expect(meta.lbl.length).toBeGreaterThan(0)
+      expect(meta.glyph.length).toBeGreaterThan(0)
     }
+    expect(factCategoryMeta({ tag: 'unknown', raw: 'Speculation' }).lbl).toBe('Speculation')
   })
 })

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -6,12 +6,14 @@ import {
   DEFAULT_MEMORY_KEEPERS,
   MemoryInspector,
   factCategoryMeta,
+  latestEntryWithBlocks,
   memCompositionFromBlocks,
   memFmtBytes,
   memFmtTok,
   promptBlockMeta,
   type MemoryKeeper,
 } from './memory-inspector'
+import type { TurnRecordRow } from '../api/dashboard'
 
 afterEach(() => {
   cleanup()
@@ -290,6 +292,23 @@ describe('memory view-model helpers', () => {
     expect(comp.totalBytes).toBe(2000)
     expect(comp.parts.map(p => p.key)).toEqual(['persona', 'memory_os_recall'])
     expect(comp.parts[0]?.lbl).toBe('페르소나')
+  })
+
+  it('latestEntryWithBlocks skips an empty-block tail turn and returns the last assembled prompt', () => {
+    const mkRow = (turn: number, blocks: { block: string; bytes: number; digest: string }[]): TurnRecordRow => ({
+      record: {
+        keeper: 'k', trace_id: 't', absolute_turn: turn, ts: turn, runtime_profile: 'local',
+        blocks, execution_ids: [],
+      },
+      diff_vs_prev: null,
+    })
+    const assembled = mkRow(1, [{ block: 'persona', bytes: 100, digest: 'd' }])
+    const errorTail = mkRow(2, []) // e.g. an error turn with no prompt blocks
+    // last row has no blocks → fall back to the most recent row that does
+    expect(latestEntryWithBlocks([assembled, errorTail])?.record.absolute_turn).toBe(1)
+    // empty input → null, not a fabricated row
+    expect(latestEntryWithBlocks([])).toBeNull()
+    expect(latestEntryWithBlocks([errorTail])).toBeNull()
   })
 
   it('promptBlockMeta maps known Prompt_block_id tokens and keeps unknown tokens raw', () => {

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_MEMORY_KEEPERS,
   MemoryInspector,
   factCategoryMeta,
+  factTtlLabel,
   latestEntryWithBlocks,
   memCompositionFromBlocks,
   memFmtBytes,
@@ -13,7 +14,7 @@ import {
   promptBlockMeta,
   type MemoryKeeper,
 } from './memory-inspector'
-import type { TurnRecordRow } from '../api/dashboard'
+import type { MemoryOsFact, TurnRecordRow } from '../api/dashboard'
 
 afterEach(() => {
   cleanup()
@@ -328,5 +329,34 @@ describe('memory view-model helpers', () => {
       expect(meta.glyph.length).toBeGreaterThan(0)
     }
     expect(factCategoryMeta({ tag: 'unknown', raw: 'Speculation' }).lbl).toBe('Speculation')
+  })
+
+  it('factTtlLabel renders a future expiry as remaining TTL ("…후"), never "지금"', () => {
+    const makeFact = (over: Partial<MemoryOsFact>): MemoryOsFact => ({
+      claim: 'x',
+      category: { tag: 'fact' },
+      source: { trace_id: 't', turn: 0, tool_call_id: null },
+      first_seen: 0,
+      first_seen_iso: null,
+      reference_time: 0,
+      valid_until: null,
+      valid_until_iso: null,
+      last_verified_at: null,
+      current: true,
+      external_ref: null,
+      claim_kind: null,
+      ...over,
+    })
+    const nowSec = Math.floor(Date.now() / 1000)
+    // permanent fact
+    expect(factTtlLabel(makeFact({ valid_until: null, current: true }))).toBe('영구')
+    // current ⟺ valid_until in the future: must show remaining TTL, not collapse
+    // to "지금" (the drift this guards — formatTimeAgo floors the future to 0).
+    const live = factTtlLabel(makeFact({ valid_until: nowSec + 2 * 3600, current: true }))
+    expect(live).not.toContain('지금')
+    expect(live).toContain('후')
+    // an already-expired fact keeps the past form
+    const dead = factTtlLabel(makeFact({ valid_until: nowSec - 2 * 3600, current: false }))
+    expect(dead).toContain('전')
   })
 })

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -1,96 +1,42 @@
 // MASC v2 — Keeper memory inspector (read-only overlay-drawer).
 //
-// Pixel-matched port of the Claude-Design prototype:
-//   keeper-v2/memory.jsx        (rendering + scope toggle)
-//   keeper-v2/memory-data.jsx   (model: pinned facts, long-term store,
-//                                recall timeline, context composition)
-//   keeper-v2/styles/memory.css (.mem-* — see memory-inspector-v2.css)
+// Pixel-matched to the Claude-Design prototype keeper-v2/memory.jsx — same
+// drawer shell, section headers, scope toggle, and `.mem-*` classes
+// (memory-inspector-v2.css) — but every datum is REAL, fetched from
+// `GET /api/v1/keepers/:name/turn-records` (RFC-0293). The prototype's
+// fixture model (fabricated `memComposition` magic + the RFC-0247-deleted
+// salience/uses/lastUsed score fields) is gone.
 //
-// The prototype reads from window.KEEPERS / window.COMPACTIONS globals.
-// Here the data is typed and injectable (props) so the component is
-// decoupled and unit-testable; the ported fixture is the default. The
-// rendering — every section, glyph, Korean/English string, and the
-// context-composition math — mirrors the prototype 1:1.
-//
-// Drawer shell: .turn-overlay / .turn-drawer (ported in
-// memory-inspector-v2.css, which the *-v2.css glob in main.ts eagerly
-// imports). Scope toggle: 이 keeper / 전체 (memory.jsx:233-234).
+// Section data sources (RFC-0293 §4; hybrid treatment confirmed 2026-06-24):
+//   컨텍스트 구성        ← real prompt-assembly block bytes (entries[latest].blocks)
+//   장기 메모리 스토어    ← real memory_os.facts.items (typed category, provenance, TTL)
+//   압축 유지·요약        ← real memory_os.episodes.items (summary + terminal_marker)
+//   핀 고정 사실          ⓘ Phase 2 (operator pins — no backend source yet)
+//   최근 회상·주입        ⓘ Phase 3 (per-op timeline — no event feed yet)
+// The two ⓘ sections render an honest "연결 예정" disclosure, never fabricated
+// rows (no-stub): they DISCLOSE absence rather than fake presence.
 
 import { Fragment } from 'preact'
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
+import { formatTimeAgo } from '../lib/format-time'
+import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+import {
+  fetchKeeperTurnRecords,
+  type TurnRecordsResponse,
+  type MemoryOsTurnRecordSnapshot,
+  type MemoryOsEpisodeSummary,
+  type MemoryOsFact,
+  type MemoryOsFactCategory,
+  type TurnBlock,
+  type TurnRecordRow,
+} from '../api/dashboard'
 
-// WORKAROUND: nested fragments use the Fragment tag, not htm's empty-string-tag
-// form. An empty string tag makes preact call document.createElement('') on
-// nested vnodes, which throws InvalidCharacterError in both jsdom and happy-dom
-// (and real browsers). An empty-string fragment only survives as a render *root*
-// because the test harness wraps it. Root cause: htm represents a fragment via
-// the Fragment export, not an empty tag name. This component is currently
-// imported nowhere, so the crash was never exercised; wiring is a later wave.
-
-// ── Window-window constant (memory-data.jsx:116 → ctx * 200000) ──
-const CONTEXT_WINDOW_TOK = 200000
-
-// ── store-entry kinds → label + glyph + tone class (memory-data.jsx:9-15) ──
-export type MemKind = 'fact' | 'decision' | 'pattern' | 'pref' | 'entity'
-interface MemKindMeta {
-  readonly lbl: string
-  readonly glyph: string
-  readonly cls: string
-}
-export const MEM_KINDS: Readonly<Record<MemKind, MemKindMeta>> = {
-  fact: { lbl: '사실', glyph: '◈', cls: 'fact' },
-  decision: { lbl: '결정', glyph: '◆', cls: 'decision' },
-  pattern: { lbl: '패턴', glyph: '◉', cls: 'pattern' },
-  pref: { lbl: '선호', glyph: '○', cls: 'pref' },
-  entity: { lbl: '개체', glyph: '▢', cls: 'entity' },
-}
-
-// ── recall-timeline operations (memory-data.jsx:18-24) ──
-export type MemOp = 'recall' | 'inject' | 'pin' | 'compact' | 'evict'
-interface MemOpMeta {
-  readonly lbl: string
-  readonly glyph: string
-  readonly cls: string
-}
-export const MEM_OPS: Readonly<Record<MemOp, MemOpMeta>> = {
-  recall: { lbl: '회상', glyph: '↺', cls: 'recall' },
-  inject: { lbl: '주입', glyph: '⤓', cls: 'inject' },
-  pin: { lbl: '핀', glyph: '⊙', cls: 'pin' },
-  compact: { lbl: '압축', glyph: '◉', cls: 'compact' },
-  evict: { lbl: '폐기', glyph: '◌', cls: 'evict' },
-}
-
-export interface MemPin {
-  readonly id: string
-  readonly text: string
-  readonly by: 'operator' | 'auto'
-  readonly at: string
-  readonly tag: string
-}
-export interface MemStoreEntry {
-  readonly id: string
-  readonly kind: MemKind
-  readonly text: string
-  readonly salience: number
-  readonly uses?: number
-  readonly lastUsed?: string
-  readonly src: string
-}
-export interface MemRecall {
-  readonly at: string
-  readonly op: MemOp
-  readonly text: string
-  readonly tok: number
-}
-export interface KeeperMemoryRecord {
-  readonly pinned: readonly MemPin[]
-  readonly store: readonly MemStoreEntry[]
-  readonly recall: readonly MemRecall[]
-}
-
-// Minimal keeper shape the inspector reads (subset of the prototype keeper).
+// Minimal keeper shape the inspector reads. Only `id` (the keeper name used as
+// the API key) and `status` (the header dot) are consumed now; `ctx`/`tasks`/
+// `traces` remain for call-site back-compat (they drove the removed fabricated
+// composition and are no longer read).
 export interface MemoryKeeper {
   readonly id: string
   readonly ctx: number
@@ -99,454 +45,356 @@ export interface MemoryKeeper {
   readonly traces?: number
 }
 
-export interface Compaction {
-  readonly id: string
-  readonly at: string
-  readonly trigger: string
-  readonly kept: readonly string[]
-  readonly summarized: readonly string[]
-  readonly dropped: readonly string[]
-}
-
-// ── fixture (memory-data.jsx:26-112) — ported verbatim ──
-export const KEEPER_MEMORY: Readonly<Record<string, KeeperMemoryRecord>> = {
-  'masc-improver': {
-    pinned: [
-      { id: 'p1', text: 'retention 정의: D0 = 가입일, 첫 세션 기준', by: 'operator', at: '2d', tag: 'definition' },
-      { id: 'p2', text: 'gp:center_type 미정값은 제외하지 말고 "미정" 버킷으로 유지', by: 'operator', at: '1d', tag: 'caveat' },
-      { id: 'p3', text: 'amplitude D0–D3 코호트는 KST 자정 기준으로 끊는다', by: 'auto', at: '5h', tag: 'definition' },
-    ],
-    store: [
-      { id: 's1', kind: 'fact', text: 'trace-store p99 쓰기 지연 목표 < 20ms (현재 19ms)', salience: 0.92, uses: 14, lastUsed: '12분', src: 'T-3902' },
-      { id: 's2', kind: 'decision', text: '리텐션 대시보드 = 코호트 히트맵 + D0/D1/D7 3열로 확정', salience: 0.81, uses: 9, lastUsed: '41분', src: 'goal-retention' },
-      { id: 's3', kind: 'pattern', text: 'amplitude 쿼리 결과는 표로 정규화 후 캐시 — 동일 segment 재질의 빈번', salience: 0.74, uses: 22, lastUsed: '1h', src: 'self' },
-      { id: 's4', kind: 'pref', text: 'operator는 숫자에 천단위 구분 + 단위 명시 선호', salience: 0.55, uses: 6, lastUsed: '3h', src: 'operator' },
-      { id: 's5', kind: 'entity', text: 'gp:center_type — 가맹점 분류 차원 (마트/편의점/기타/미정)', salience: 0.68, uses: 11, lastUsed: '2h', src: 'T-3880' },
-    ],
-    recall: [
-      { at: '14:01', op: 'compact', text: '컨텍스트 86% → 컴팩션, 핵심 사실 5건 유지', tok: -110600 },
-      { at: '13:58', op: 'recall', text: 'retention 정의 + center_type 메모 회상 (턴 시작)', tok: 1840 },
-      { at: '13:52', op: 'inject', text: 'amplitude 표 캐시 주입', tok: 3200 },
-      { at: '13:30', op: 'pin', text: 'operator가 "center_type 미정 버킷 유지" 핀 고정', tok: 120 },
-      { at: '12:10', op: 'evict', text: '만료된 쿼리 캐시 9건 폐기', tok: -4100 },
-    ],
-  },
-  nick0cave: {
-    pinned: [
-      { id: 'p1', text: 'compact()는 lock 보유 중 호출 금지 — p95 380ms 스파이크 원인', by: 'operator', at: '6h', tag: 'risk' },
-      { id: 'p2', text: '임계값 0.38은 seoul-1 기준, tokyo-2는 RTT 보정 필요', by: 'auto', at: '3h', tag: 'caveat' },
-    ],
-    store: [
-      { id: 's1', kind: 'fact', text: 'core/scheduler jitter p95 회귀 가드: 380ms → 19ms', salience: 0.95, uses: 18, lastUsed: '3분', src: 'T-3902' },
-      { id: 's2', kind: 'decision', text: 'unlock 후 압축으로 이동 — compact()를 critical section 밖으로', salience: 0.88, uses: 12, lastUsed: '9분', src: 'T-3902' },
-      { id: 's3', kind: 'pattern', text: 'lock 재진입 가설은 trace_window open_fds 메트릭으로 검증', salience: 0.70, uses: 7, lastUsed: '22분', src: 'self' },
-      { id: 's4', kind: 'entity', text: 'Exec_policy — 실행 정책 통합 표면 (RFC-0254)', salience: 0.60, uses: 5, lastUsed: '1h', src: 'goal-exec-policy' },
-    ],
-    recall: [
-      { at: '14:01', op: 'compact', text: '컨텍스트 91% → 컴팩션, 182k → 58k', tok: -124200 },
-      { at: '13:40', op: 'recall', text: 'jitter 가드 + unlock 결정 회상', tok: 2100 },
-      { at: '13:20', op: 'pin', text: 'auto: tokyo-2 RTT 보정 caveat 핀', tok: 90 },
-    ],
-  },
-  sangsu: {
-    pinned: [
-      { id: 'p1', text: 'round_test.ml 84/84 통과가 머지 게이트 — 깨지면 즉시 중단', by: 'operator', at: '1d', tag: 'gate' },
-    ],
-    store: [
-      { id: 's1', kind: 'fact', text: 'core/runtime dune test 84/84 ok (41.2s)', salience: 0.85, uses: 10, lastUsed: '방금', src: 'self' },
-      { id: 's2', kind: 'pattern', text: 'Eio 리소스는 연 Switch가 닫힐 때 해제 — 라이터는 로컬 Switch.run으로', salience: 0.90, uses: 15, lastUsed: '4분', src: 'T-3902' },
-      { id: 's3', kind: 'pref', text: 'diff는 side-by-side, 탭 너비 2', salience: 0.40, uses: 3, lastUsed: '2h', src: 'operator' },
-    ],
-    recall: [
-      { at: '방금', op: 'recall', text: 'Switch 수명 패턴 회상', tok: 1500 },
-      { at: '12분', op: 'inject', text: 'round_test 결과 주입', tok: 800 },
-    ],
-  },
-  'qa-king': {
-    pinned: [
-      { id: 'p1', text: 'docs/site는 PR마다 프리뷰 배포 — 링크 깨지면 fail', by: 'auto', at: '8h', tag: 'gate' },
-    ],
-    store: [
-      { id: 's1', kind: 'fact', text: 'docs 사이트 빌드 시간 평균 58s', salience: 0.50, uses: 4, lastUsed: '8분', src: 'self' },
-      { id: 's2', kind: 'decision', text: '핸드오프 시 미해결 링크 점검 항목을 다음 keeper에 전달', salience: 0.66, uses: 5, lastUsed: '8분', src: 'self' },
-    ],
-    recall: [
-      { at: '8분', op: 'compact', text: 'HandingOff — 컨텍스트 정리', tok: -42000 },
-    ],
-  },
-  analyst: {
-    pinned: [
-      { id: 'p1', text: 'search/index 재색인은 야간 윈도우(02:00 KST)에만', by: 'operator', at: '12h', tag: 'caveat' },
-    ],
-    store: [
-      { id: 's1', kind: 'fact', text: 'search/index 문서 ~1.2M, 재색인 ~34분', salience: 0.62, uses: 6, lastUsed: '34분', src: 'self' },
-      { id: 's2', kind: 'entity', text: 'gp:center_type 분포 — 분석 코호트 핵심 차원', salience: 0.58, uses: 8, lastUsed: '2h', src: 'T-3880' },
-    ],
-    recall: [
-      { at: '34분', op: 'recall', text: '재색인 윈도우 caveat 회상', tok: 600 },
-    ],
-  },
-  drifter: {
-    pinned: [],
-    store: [
-      { id: 's1', kind: 'fact', text: 'core/runtime overflow 재현: 컨텍스트 100%에서 trace 라이터 fd 누수 누적', salience: 0.70, uses: 3, lastUsed: '3시간', src: 'T-3902' },
-    ],
-    recall: [
-      { at: '3시간', op: 'evict', text: 'Overflowed — 컨텍스트 전체 폐기 직전 스냅샷', tok: -200000 },
-    ],
-  },
-}
-
-// Default keeper roster (subset needed by the inspector) so the
-// 전체 (aggregate) scope renders without external wiring. Status values
-// mirror the prototype keeper roster intent (run / pause / off).
+// Keeper roster fallback for the agent-profile mount (agent-detail-memory.ts)
+// when an agent id is outside the live keepers signal. Identity-only — carries
+// no memory content (that is fetched per keeper).
 export const DEFAULT_MEMORY_KEEPERS: readonly MemoryKeeper[] = [
-  { id: 'masc-improver', ctx: 0.86, status: 'run', tasks: 4, traces: 27 },
-  { id: 'nick0cave', ctx: 0.91, status: 'run', tasks: 4, traces: 38 },
-  { id: 'sangsu', ctx: 0.34, status: 'run', tasks: 2, traces: 11 },
-  { id: 'qa-king', ctx: 0.22, status: 'pause', tasks: 1, traces: 6 },
-  { id: 'analyst', ctx: 0.41, status: 'run', tasks: 1, traces: 9 },
-  { id: 'drifter', ctx: 0, status: 'off', tasks: 0, traces: 4 },
+  { id: 'masc-improver', ctx: 0, status: 'run' },
+  { id: 'nick0cave', ctx: 0, status: 'run' },
+  { id: 'sangsu', ctx: 0, status: 'run' },
+  { id: 'qa-king', ctx: 0, status: 'pause' },
+  { id: 'analyst', ctx: 0, status: 'run' },
+  { id: 'drifter', ctx: 0, status: 'off' },
 ]
 
-export const DEFAULT_COMPACTIONS: Readonly<Record<string, readonly Compaction[]>> = {
-  nick0cave: [
-    {
-      id: 'cmp_7f3a', at: '14:01', trigger: '컨텍스트 91% — 자동 임계치',
-      kept: ['소유 태스크 4건 (T-3902 외)', 'core/scheduler 최근 변경 요약', 'compact lock 재진입 가설'],
-      summarized: ['14:01 이전 라운드 로그 52개 → 6줄 요약', '완료된 trace 29건 → 통계만 보존'],
-      dropped: ['중복 도구 결과 11건', '취소된 분기 탐색 로그'],
-    },
-  ],
-  'masc-improver': [
-    {
-      id: 'cmp_3d90', at: '13:30', trigger: '컨텍스트 86% — 자동 임계치',
-      kept: ['리텐션 정의 (D0=가입일)', 'center_type 분류 미정값 메모'],
-      summarized: ['amplitude 쿼리 결과 14건 → 표 1개'],
-      dropped: ['중복 세그먼트 응답 6건'],
-    },
-  ],
-  'qa-king': [
-    {
-      id: 'cmp_qa01', at: '8분', trigger: 'HandingOff — 핸드오프 정리',
-      kept: ['미해결 링크 점검 항목'],
-      summarized: ['docs 빌드 로그 → 요약'],
-      dropped: ['완료된 프리뷰 배포 로그'],
-    },
-  ],
-  drifter: [
-    {
-      id: 'cmp_dr01', at: '3시간', trigger: 'Overflowed — 컨텍스트 전체 폐기',
-      kept: [],
-      summarized: [],
-      dropped: ['컨텍스트 전체 스냅샷'],
-    },
-  ],
-}
-
-// ── token formatter (memory.jsx:8-12) ──
+// ── byte / token formatters ──
 export function memFmtTok(n: number): string {
   const a = Math.abs(n)
   const s = a >= 1000 ? `${(a / 1000).toFixed(1)}k` : String(a)
   return (n < 0 ? '−' : '') + s
 }
 
-export function getKeeperMemory(
-  k: MemoryKeeper,
-  store: Readonly<Record<string, KeeperMemoryRecord>> = KEEPER_MEMORY,
-): KeeperMemoryRecord {
-  return store[k.id] ?? { pinned: [], store: [], recall: [] }
+export function memFmtBytes(n: number): string {
+  if (n >= 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)}MB`
+  if (n >= 1024) return `${(n / 1024).toFixed(1)}KB`
+  return `${n}B`
+}
+
+// ── prompt-block composition (real, from turn_record blocks) ──
+// PROMPT_BLOCK_META mirrors the OCaml Prompt_block_id closed sum
+// (lib/types/prompt_block_id.ml — to_string is the wire SSOT). A token outside
+// the closed set is an `Other name` block; it keeps its raw label so a new
+// block id surfaces verbatim rather than as a silent miscolour.
+interface BlockMeta {
+  readonly lbl: string
+  readonly color: string
+}
+const PROMPT_BLOCK_META: Readonly<Record<string, BlockMeta>> = {
+  persona: { lbl: '페르소나', color: 'var(--text-dim)' },
+  continuity: { lbl: '연속성', color: 'var(--info)' },
+  dynamic_context: { lbl: '동적 컨텍스트', color: 'var(--volt)' },
+  temporal_summary: { lbl: '시간 요약', color: 'var(--status-warn)' },
+  claimed_task_nudge: { lbl: '태스크 넛지', color: 'var(--status-ok)' },
+  retry_nudge: { lbl: '재시도 넛지', color: 'var(--status-bad)' },
+  memory_os_recall: { lbl: '메모리 회상', color: 'var(--volt-strong)' },
+  user_model: { lbl: '사용자 모델', color: 'var(--info)' },
+  connected_surface: { lbl: '연결 표면', color: 'var(--status-warn)' },
+}
+export function promptBlockMeta(token: string): BlockMeta {
+  return PROMPT_BLOCK_META[token] ?? { lbl: token, color: 'var(--text-dim)' }
 }
 
 export interface CompositionPart {
   readonly key: string
   readonly lbl: string
-  readonly tok: number
+  readonly bytes: number
   readonly color: string
 }
 export interface Composition {
-  readonly total: number
+  readonly totalBytes: number
   readonly parts: readonly CompositionPart[]
 }
 
-// context-window composition for a keeper, derived from live ctx tokens
-// (memory-data.jsx:115-133). Math ported verbatim.
-export function memComposition(
-  k: MemoryKeeper,
-  store: Readonly<Record<string, KeeperMemoryRecord>> = KEEPER_MEMORY,
-): Composition {
-  const total = Math.round((k.ctx || 0) * CONTEXT_WINDOW_TOK)
-  if (total === 0) return { total: 0, parts: [] }
-  const rec = store[k.id] ?? { store: [], pinned: [], recall: [] }
-  const mem = rec.store.length * 900 + rec.pinned.length * 220
-  const system = 6200
-  const tasks = (k.tasks || 0) * 2600
-  const traces = Math.min(Math.round(total * 0.42), (k.traces || 0) * 90)
-  let nsDialog = total - system - tasks - traces - mem
-  if (nsDialog < total * 0.1) nsDialog = Math.round(total * 0.2)
-  const parts: CompositionPart[] = [
-    { key: 'system', lbl: '시스템·월드 프롬프트', tok: system, color: 'var(--text-dim)' },
-    { key: 'ns', lbl: 'namespace · 대화 로그', tok: nsDialog, color: 'var(--volt)' },
-    { key: 'tasks', lbl: '소유 태스크', tok: tasks, color: 'var(--info)' },
-    { key: 'traces', lbl: '최근 trace', tok: traces, color: 'var(--status-warn)' },
-    { key: 'memory', lbl: '메모리 (핀 + 스토어)', tok: mem, color: 'var(--status-ok)' },
-  ].filter(p => p.tok > 0)
-  return { total, parts }
-}
-
-export interface AggregateRow {
-  readonly id: string
-  readonly ctx: number
-  readonly status: string
-  readonly pinned: number
-  readonly store: number
-  readonly memTok: number
-}
-export interface MemAggregate {
-  readonly rows: readonly AggregateRow[]
-  readonly pinned: number
-  readonly store: number
-  readonly memTok: number
-  readonly kindTotals: Readonly<Record<string, number>>
-  readonly topFacts: readonly (MemStoreEntry & { keeper: string })[]
-  readonly keeperCount: number
-}
-
-// aggregate across the passed keepers (memory-data.jsx:140-160).
-export function memAggregate(
-  keepers: readonly MemoryKeeper[],
-  store: Readonly<Record<string, KeeperMemoryRecord>> = KEEPER_MEMORY,
-): MemAggregate {
-  const rows: AggregateRow[] = []
-  let pinned = 0
-  let storeCount = 0
-  let memTok = 0
-  const kindTotals: Record<string, number> = {}
-  const allFacts: (MemStoreEntry & { keeper: string })[] = []
-  keepers.forEach(k => {
-    const m = getKeeperMemory(k, store)
-    const comp = memComposition(k, store)
-    const mt = comp.parts.find(p => p.key === 'memory')?.tok ?? 0
-    pinned += m.pinned.length
-    storeCount += m.store.length
-    memTok += mt
-    m.store.forEach(s => {
-      kindTotals[s.kind] = (kindTotals[s.kind] ?? 0) + 1
-      allFacts.push({ ...s, keeper: k.id })
+// Composition from a turn's assembled prompt blocks. The bar is a BYTES ratio
+// (each block's real byte size); no token magic, no fabricated parts. Zero-byte
+// blocks are dropped so the legend matches the bar.
+export function memCompositionFromBlocks(blocks: readonly TurnBlock[]): Composition {
+  const parts: CompositionPart[] = blocks
+    .filter(b => b.bytes > 0)
+    .map(b => {
+      const meta = promptBlockMeta(b.block)
+      return { key: b.block, lbl: meta.lbl, bytes: b.bytes, color: meta.color }
     })
-    rows.push({ id: k.id, ctx: k.ctx, status: k.status, pinned: m.pinned.length, store: m.store.length, memTok: mt })
-  })
-  const topFacts = [...allFacts].sort((a, b) => b.salience - a.salience).slice(0, 6)
-  return { rows, pinned, store: storeCount, memTok, kindTotals, topFacts, keeperCount: keepers.length }
+  const totalBytes = parts.reduce((sum, p) => sum + p.bytes, 0)
+  return { totalBytes, parts }
+}
+
+// The most recent turn's blocks (entries are append-ordered; last is newest).
+export function latestEntryBlocks(rows: readonly TurnRecordRow[]): readonly TurnBlock[] {
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const blocks = rows[i]?.record.blocks
+    if (blocks && blocks.length > 0) return blocks
+  }
+  return []
+}
+
+function latestEntry(rows: readonly TurnRecordRow[]): TurnRecordRow | null {
+  return rows.length > 0 ? rows[rows.length - 1]! : null
+}
+
+// ── fact category meta (real, exhaustive over the typed union) ──
+export interface FactKindMeta {
+  readonly lbl: string
+  readonly glyph: string
+  readonly color: string
+}
+// Exhaustive switch over MemoryOsFactCategory. A new arm added to the OCaml
+// `category` sum (and its TS mirror) forces a compile error here via the
+// `never` guard — no `_ -> default` swallow, no silent miscolour.
+export function factCategoryMeta(category: MemoryOsFactCategory): FactKindMeta {
+  switch (category.tag) {
+    case 'code_change':
+      return { lbl: '코드 변경', glyph: '◆', color: 'var(--info)' }
+    case 'fact':
+      return { lbl: '사실', glyph: '◈', color: 'var(--status-ok)' }
+    case 'preference':
+      return { lbl: '선호', glyph: '○', color: 'var(--volt-strong)' }
+    case 'blocker':
+      return { lbl: '블로커', glyph: '▲', color: 'var(--status-bad)' }
+    case 'goal':
+      return { lbl: '목표', glyph: '◎', color: 'var(--volt)' }
+    case 'constraint':
+      return { lbl: '제약', glyph: '▢', color: 'var(--status-warn)' }
+    case 'ephemeral':
+      return { lbl: '임시', glyph: '◌', color: 'var(--text-dim)' }
+    case 'validated_approach':
+      return { lbl: '검증된 접근', glyph: '✓', color: 'var(--status-ok)' }
+    case 'lesson':
+      return { lbl: '교훈', glyph: '★', color: 'var(--volt-strong)' }
+    case 'unknown':
+      return { lbl: category.raw || '미분류', glyph: '◇', color: 'var(--text-dim)' }
+    default: {
+      const _exhaustive: never = category
+      return _exhaustive
+    }
+  }
+}
+
+// claim age (staleness anchor = reference_time) and TTL display.
+function factAgeLabel(fact: MemoryOsFact): string {
+  return formatTimeAgo(fact.reference_time)
+}
+function factTtlLabel(fact: MemoryOsFact): string {
+  if (fact.valid_until == null) return '영구'
+  return fact.current
+    ? `만료 ${formatTimeAgo(fact.valid_until)}`
+    : `만료됨 ${formatTimeAgo(fact.valid_until)}`
 }
 
 // ── rendering ──
 
 function MemBar({ parts, total }: { parts: readonly CompositionPart[]; total: number }) {
   return html`
-    <div class="mem-bar" title="컨텍스트 윈도우 구성">
-      ${parts.map(p => html`<span key=${p.key} style=${{ width: `${(p.tok / total) * 100}%`, background: p.color }}></span>`)}
+    <div class="mem-bar" title="프롬프트 구성 (bytes)">
+      ${parts.map(p => html`<span key=${p.key} style=${{ width: `${(p.bytes / total) * 100}%`, background: p.color }}></span>`)}
     </div>`
 }
 
-function MemCompo({ keeper, store }: { keeper: MemoryKeeper; store: Readonly<Record<string, KeeperMemoryRecord>> }) {
-  const { total, parts } = memComposition(keeper, store)
-  if (!total) return html`<div class="mem-empty">중지된 keeper — 활성 컨텍스트 없음.</div>`
+function MemCompoReal({ row }: { row: TurnRecordRow | null }) {
+  const blocks = row?.record.blocks ?? []
+  const { totalBytes, parts } = memCompositionFromBlocks(blocks)
+  if (!row || totalBytes === 0) {
+    return html`<div class="mem-empty">조립된 프롬프트 블록 없음 — 활성 컨텍스트 없음.</div>`
+  }
+  const inputTok = row.record.input_tokens
+  const ctxWin = row.record.context_window
+  const pct = inputTok != null && ctxWin != null && ctxWin > 0
+    ? Math.round((inputTok / ctxWin) * 100)
+    : null
   return html`
     <div class="mem-compo">
       <div class="mem-compo-head">
-        <span class="mono mem-compo-tot">${(total / 1000).toFixed(1)}k</span>
-        <span class="mem-compo-sub">/ 200k 윈도우 · ${Math.round(keeper.ctx * 100)}%</span>
+        <span class="mono mem-compo-tot">${memFmtBytes(totalBytes)}</span>
+        <span class="mem-compo-sub">
+          ${inputTok != null
+            ? html`${memFmtTok(inputTok)} tok${ctxWin != null ? html` / ${memFmtTok(ctxWin)} 윈도우` : null}${pct != null ? html` · ${pct}%` : null}`
+            : html`${parts.length}개 블록`}
+        </span>
       </div>
-      <${MemBar} parts=${parts} total=${total} />
+      <${MemBar} parts=${parts} total=${totalBytes} />
       <div class="mem-legend">
         ${parts.map(p => html`
           <div key=${p.key} class="mem-leg">
             <span class="mem-leg-sw" style=${{ background: p.color }}></span>
             <span class="mem-leg-lbl">${p.lbl}</span>
-            <span class="mem-leg-v mono">${memFmtTok(p.tok)}</span>
+            <span class="mem-leg-v mono">${memFmtBytes(p.bytes)}</span>
           </div>`)}
       </div>
     </div>`
 }
 
-function MemSalience({ v }: { v: number }) {
-  return html`<span class="mem-sal" title=${`salience ${v.toFixed(2)}`}><span style=${{ width: `${v * 100}%` }}></span></span>`
-}
-
-function MemStoreRow({ s, srcOverride }: { s: MemStoreEntry; srcOverride?: string }) {
-  const k = MEM_KINDS[s.kind]
+function FactRow({ fact }: { fact: MemoryOsFact }) {
+  const meta = factCategoryMeta(fact.category)
+  const provenance = `${fact.source.trace_id}#${fact.source.turn}`
   return html`
     <div class="mem-store-row">
-      <span class=${`mem-kind ${k.cls}`}>${k.glyph} ${k.lbl}</span>
+      <span class="mem-kind" style=${{ color: meta.color, borderColor: meta.color }}>${meta.glyph} ${meta.lbl}</span>
       <div class="mem-store-main">
-        <div class="mem-store-text">${s.text}</div>
+        <div class="mem-store-text">${fact.claim}</div>
         <div class="mem-store-meta">
-          <${MemSalience} v=${s.salience} />
-          ${s.uses != null ? html`<span class="mono">${s.uses}회 사용</span>` : null}
-          ${s.lastUsed ? html`<span>최근 ${s.lastUsed}</span>` : null}
-          <span class="mem-src mono">${srcOverride ?? s.src}</span>
+          <span class="mono">${factAgeLabel(fact)}</span>
+          <span class=${`mono ${fact.current ? '' : 'mem-expired'}`}>${factTtlLabel(fact)}</span>
+          ${fact.external_ref
+            ? html`<span class="mem-tag">${fact.external_ref.kind} ${fact.external_ref.id}</span>`
+            : null}
+          <span class="mem-src mono">${provenance}</span>
         </div>
       </div>
     </div>`
 }
 
-// status dot — mirrors prototype StatusDot (memory.jsx:196):
-// run → ok, pause → idle, else → bad.
+// Honest disclosure for a section whose backend source lands in a later RFC
+// phase. NOT a stub: it states the absence and the phase, renders no fabricated
+// data, and is visually distinct from a real-data section.
+function DisclosureNote({ text }: { text: string }) {
+  return html`<div class="mem-empty mem-disclosure">${'ⓘ'} ${text}</div>`
+}
+
+function ReadErrors({ snapshot }: { snapshot: MemoryOsTurnRecordSnapshot }) {
+  if (snapshot.read_errors.length === 0) return null
+  const text = snapshot.read_errors.map(e => `${e.scope}: ${e.error}`).join(' · ')
+  return html`<div class="mem-read-error" role="alert">${'⚠'} 읽기 오류 — ${text}</div>`
+}
+
 function memDotState(status: string): 'ok' | 'idle' | 'bad' {
   return status === 'run' ? 'ok' : status === 'pause' ? 'idle' : 'bad'
 }
 
-function OneKeeperMemory({
-  keeper,
-  store,
-  compactions,
+function CategoryFilters({
+  cats,
+  active,
+  onPick,
 }: {
-  keeper: MemoryKeeper
-  store: Readonly<Record<string, KeeperMemoryRecord>>
-  compactions: Readonly<Record<string, readonly Compaction[]>>
+  cats: readonly MemoryOsFactCategory[]
+  active: string
+  onPick: (tag: string) => void
 }) {
-  const m = getKeeperMemory(keeper, store)
-  const comps = compactions[keeper.id] ?? []
-  const lastCmp = comps[0]
-  const kindFilter = useSignal<'all' | MemKind>('all')
-  const kinds = [...new Set(m.store.map(s => s.kind))]
+  if (cats.length <= 1) return null
+  return html`
+    <div class="mem-filters">
+      <button class=${`mem-filter ${active === 'all' ? 'on' : ''}`} onClick=${() => onPick('all')}>전체</button>
+      ${cats.map(c => {
+        const meta = factCategoryMeta(c)
+        const tag = c.tag === 'unknown' ? `unknown:${c.raw}` : c.tag
+        return html`<button key=${tag} class=${`mem-filter ${active === tag ? 'on' : ''}`} onClick=${() => onPick(tag)}>${meta.glyph} ${meta.lbl}</button>`
+      })}
+    </div>`
+}
+
+function factTag(fact: MemoryOsFact): string {
+  return fact.category.tag === 'unknown' ? `unknown:${fact.category.raw}` : fact.category.tag
+}
+
+function OneKeeperMemoryReal({
+  snapshot,
+  rows,
+}: {
+  snapshot: MemoryOsTurnRecordSnapshot
+  rows: readonly TurnRecordRow[]
+}) {
+  const kindFilter = useSignal<string>('all')
+  const facts = snapshot.facts.items
+  const episodes = [...snapshot.episodes.items].reverse().slice(0, 5)
+  // distinct categories present, in first-seen order, deduped by tag
+  const seen = new Set<string>()
+  const cats: MemoryOsFactCategory[] = []
+  for (const f of facts) {
+    const tag = factTag(f)
+    if (!seen.has(tag)) {
+      seen.add(tag)
+      cats.push(f.category)
+    }
+  }
   const filter = kindFilter.value
-  const storeRows = filter === 'all' ? m.store : m.store.filter(s => s.kind === filter)
+  const storeRows = filter === 'all' ? facts : facts.filter(f => factTag(f) === filter)
+
   return html`
     <${Fragment}>
+      <${ReadErrors} snapshot=${snapshot} />
+
       <div class="turn-sec">
         <h4>컨텍스트 구성</h4>
-        <${MemCompo} keeper=${keeper} store=${store} />
+        <${MemCompoReal} row=${latestEntry(rows)} />
       </div>
 
       <div class="turn-sec">
-        <h4>핀 고정 사실 · ${m.pinned.length}</h4>
-        ${m.pinned.length ? html`
-          <div class="mem-pins">
-            ${m.pinned.map(p => html`
-              <div key=${p.id} class="mem-pin">
-                <span class="mem-pin-ico">${'⊙'}</span>
-                <div class="mem-pin-body">
-                  <div class="mem-pin-text">${p.text}</div>
-                  <div class="mem-pin-meta">
-                    <span class=${`mem-by ${p.by}`}>${p.by}</span>
-                    <span class="mem-tag">${p.tag}</span>
-                    <span class="mono">${p.at} 전</span>
-                  </div>
-                </div>
-              </div>`)}
-          </div>` : html`<div class="mem-empty">핀 고정된 사실 없음.</div>`}
+        <h4>핀 고정 사실</h4>
+        <${DisclosureNote} text="operator 핀은 Phase 2에서 연결 예정 — 현재 백엔드 소스 없음." />
       </div>
 
       <div class="turn-sec">
         <div class="mem-sec-head">
           <h4>장기 메모리 스토어 · memory-os</h4>
-          <span class="mem-n mono">${m.store.length}</span>
+          <span class="mem-n mono">${snapshot.facts.current}/${snapshot.facts.shown}</span>
         </div>
-        ${m.store.length ? html`
-          <${Fragment}>
-            ${kinds.length > 1 ? html`
-              <div class="mem-filters">
-                <button class=${`mem-filter ${filter === 'all' ? 'on' : ''}`} onClick=${() => { kindFilter.value = 'all' }}>전체</button>
-                ${kinds.map(kk => {
-                  const d = MEM_KINDS[kk]
-                  return html`<button key=${kk} class=${`mem-filter ${filter === kk ? 'on' : ''}`} onClick=${() => { kindFilter.value = kk }}>${d.glyph} ${d.lbl}</button>`
-                })}
-              </div>` : null}
-            <div class="mem-store">${storeRows.map(s => html`<${MemStoreRow} key=${s.id} s=${s} />`)}</div>
-          </>` : html`<div class="mem-empty">장기 메모리 항목 없음.</div>`}
+        ${facts.length
+          ? html`
+            <${Fragment}>
+              <${CategoryFilters} cats=${cats} active=${filter} onPick=${(t: string) => { kindFilter.value = t }} />
+              <div class="mem-store">${storeRows.map(f => html`<${FactRow} key=${factTag(f) + f.source.trace_id + f.source.turn + f.claim} fact=${f} />`)}</div>
+            </>`
+          : html`<div class="mem-empty">장기 메모리 항목 없음.</div>`}
       </div>
 
       <div class="turn-sec">
         <h4>최근 회상 · 주입</h4>
-        ${m.recall && m.recall.length ? html`
-          <div class="mem-timeline">
-            ${m.recall.map((r, i) => {
-              const o = MEM_OPS[r.op]
-              return html`
-                <div key=${i} class="mem-tl-row">
-                  <span class="mem-tl-at mono">${r.at}</span>
-                  <span class=${`mem-op ${o.cls}`}>${o.glyph} ${o.lbl}</span>
-                  <span class="mem-tl-text">${r.text}</span>
-                  <span class=${`mem-tl-tok mono ${r.tok < 0 ? 'neg' : 'pos'}`}>${memFmtTok(r.tok)}</span>
-                </div>`
-            })}
-          </div>` : html`<div class="mem-empty">기록된 회상 없음.</div>`}
+        <${DisclosureNote} text="회상·주입 op 타임라인은 Phase 3에서 연결 예정 — 현재 event feed 없음." />
       </div>
 
       <div class="turn-sec">
-        <h4>압축 유지 · 요약 · 폐기</h4>
-        ${lastCmp ? html`
-          <${Fragment}>
-            <div class="cmp-trigger"><span class="sub-k">최근 컴팩션</span>${lastCmp.at} · ${lastCmp.trigger}</div>
-            <div class="cmp-diff">
-              <div class="cmp-col kept"><div class="cmp-col-h">${'◈'} 유지</div>${lastCmp.kept.map((x, i) => html`<div key=${i} class="cmp-li">${x}</div>`)}</div>
-              <div class="cmp-col summ"><div class="cmp-col-h">${'◉'} 요약</div>${lastCmp.summarized.map((x, i) => html`<div key=${i} class="cmp-li">${x}</div>`)}</div>
-              <div class="cmp-col drop"><div class="cmp-col-h">${'◌'} 폐기</div>${lastCmp.dropped.map((x, i) => html`<div key=${i} class="cmp-li">${x}</div>`)}</div>
-            </div>
-          </>` : html`<div class="mem-empty">컴팩션 이력 없음 — 메모리가 압축된 적 없음.</div>`}
+        <h4>압축 유지 · 요약</h4>
+        ${episodes.length
+          ? html`
+            <${Fragment}>
+              <div class="mem-store">
+                ${episodes.map(ep => html`<${EpisodeRow} key=${ep.trace_id + ep.generation} episode=${ep} />`)}
+              </div>
+              <${DisclosureNote} text="유지/요약/폐기 3열 diff는 Phase 3에서 연결 예정 — episode 요약만 표시." />
+            </>`
+          : html`<div class="mem-empty">압축(episode) 이력 없음.</div>`}
       </div>
     </>`
 }
 
-function AllKeepersMemory({
-  keepers,
-  store,
-  onPick,
-}: {
-  keepers: readonly MemoryKeeper[]
-  store: Readonly<Record<string, KeeperMemoryRecord>>
-  onPick: (id: string) => void
-}) {
-  const agg = memAggregate(keepers, store)
-  const maxMem = Math.max(1, ...agg.rows.map(r => r.memTok))
+function EpisodeRow({ episode }: { episode: MemoryOsEpisodeSummary }) {
+  return html`
+    <div class="mem-store-row">
+      <span class="mem-kind" style=${{ color: episode.current ? 'var(--status-ok)' : 'var(--text-dim)', borderColor: episode.current ? 'var(--status-ok)' : 'var(--text-dim)' }}>
+        ${'◉'} g${episode.generation.toString().padStart(4, '0')}
+      </span>
+      <div class="mem-store-main">
+        <div class="mem-store-text">${episode.summary}</div>
+        <div class="mem-store-meta">
+          <span class="mono">${episode.claim_count} claims</span>
+          ${episode.terminal_marker
+            ? html`<span class="mem-tag">terminal=${episode.terminal_marker}</span>`
+            : null}
+          <span class=${`mono ${episode.current ? '' : 'mem-expired'}`}>${episode.current ? '활성' : '만료'}</span>
+          <span class="mem-src mono">${episode.trace_id}</span>
+        </div>
+      </div>
+    </div>`
+}
+
+// Aggregate (전체) scope: real keeper roster (id + status dot are real) with an
+// honest note that per-keeper memory aggregation needs N× turn-records fetches
+// and lands later. No fabricated memory totals.
+function AggregateDeferred({ keepers }: { keepers: readonly MemoryKeeper[] }) {
   return html`
     <${Fragment}>
       <div class="turn-sec">
-        <h4>집계</h4>
-        <div class="mem-stats">
-          <div class="mem-stat"><span class="v mono">${agg.keeperCount}</span><span class="k">keeper</span></div>
-          <div class="mem-stat"><span class="v mono">${agg.pinned}</span><span class="k">핀 고정</span></div>
-          <div class="mem-stat"><span class="v mono">${agg.store}</span><span class="k">스토어 항목</span></div>
-          <div class="mem-stat"><span class="v mono">${(agg.memTok / 1000).toFixed(1)}k</span><span class="k">메모리 토큰</span></div>
-        </div>
+        <h4>전체 keeper</h4>
+        <${DisclosureNote} text="전체 집계는 keeper별 turn-records를 모아야 하므로 추후 연결 — 현재는 단일 keeper 실데이터만." />
       </div>
-
       <div class="turn-sec">
-        <h4>종류별 분포</h4>
-        <div class="mem-kinds-dist">
-          ${Object.entries(agg.kindTotals).sort((a, b) => b[1] - a[1]).map(([kk, n]) => {
-            const d = MEM_KINDS[kk as MemKind] ?? { lbl: kk, glyph: '◈', cls: '' }
-            return html`
-              <div key=${kk} class="mem-kd-row">
-                <span class=${`mem-kind ${d.cls}`}>${d.glyph} ${d.lbl}</span>
-                <div class="mem-kd-bar"><span style=${{ width: `${(n / agg.store) * 100}%` }}></span></div>
-                <span class="mono mem-kd-n">${n}</span>
-              </div>`
-          })}
-        </div>
-      </div>
-
-      <div class="turn-sec">
-        <h4>keeper별 메모리 <span class="mem-hint">행을 누르면 개별 보기</span></h4>
+        <h4>keeper 로스터 · ${keepers.length}</h4>
         <div class="mem-table">
-          <div class="mem-tr mem-th"><span>keeper</span><span>ctx</span><span>핀</span><span>스토어</span><span>mem tok</span></div>
-          ${agg.rows.map(r => html`
-            <button key=${r.id} class="mem-tr" onClick=${() => onPick(r.id)}>
-              <span class="mem-td-id"><span class=${`mem-dot ${memDotState(r.status)}`}></span><span class="mono">${r.id}</span></span>
-              <span class="mono">${Math.round(r.ctx * 100)}%</span>
-              <span class="mono">${r.pinned}</span>
-              <span class="mono">${r.store}</span>
-              <span class="mem-td-bar"><i style=${{ width: `${(r.memTok / maxMem) * 100}%` }}></i><b class="mono">${(r.memTok / 1000).toFixed(1)}k</b></span>
-            </button>`)}
-        </div>
-      </div>
-
-      <div class="turn-sec">
-        <h4>가장 salient한 사실 · 전체</h4>
-        <div class="mem-store">
-          ${agg.topFacts.map(s => html`<${MemStoreRow} key=${s.keeper + s.id} s=${s} srcOverride=${s.keeper} />`)}
+          <div class="mem-tr mem-th"><span>keeper</span><span>상태</span></div>
+          ${keepers.map(k => html`
+            <div key=${k.id} class="mem-tr">
+              <span class="mem-td-id"><span class=${`mem-dot ${memDotState(k.status)}`}></span><span class="mono">${k.id}</span></span>
+              <span class="mono">${k.status}</span>
+            </div>`)}
         </div>
       </div>
     </>`
@@ -556,19 +404,16 @@ export interface MemoryInspectorProps {
   readonly keeper: MemoryKeeper
   readonly onClose: () => void
   readonly keepers?: readonly MemoryKeeper[]
-  readonly memory?: Readonly<Record<string, KeeperMemoryRecord>>
-  readonly compactions?: Readonly<Record<string, readonly Compaction[]>>
 }
 
 export function MemoryInspector({
   keeper,
   onClose,
   keepers = DEFAULT_MEMORY_KEEPERS,
-  memory = KEEPER_MEMORY,
-  compactions = DEFAULT_COMPACTIONS,
 }: MemoryInspectorProps) {
   const scope = useSignal<'one' | 'all'>('one')
-  const pickId = useSignal(keeper.id)
+  const resource = useManagedAsyncResource<TurnRecordsResponse | null>(null)
+  const activeId = keeper.id
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -581,15 +426,23 @@ export function MemoryInspector({
     return () => window.removeEventListener('keydown', onKey)
   }, [onClose])
 
-  const active = keepers.find(k => k.id === pickId.value) ?? keeper
+  useEffect(() => {
+    void resource.load(async (signal) => fetchKeeperTurnRecords(activeId, 24, { signal }))
+    return () => {
+      resource.cancel()
+    }
+  }, [activeId, resource])
+
   const isOne = scope.value === 'one'
+  const state = resource.state.value
+  const response = state.data
 
   return html`
     <div class="turn-overlay" onClick=${onClose}>
       <div class="turn-drawer mem-drawer" onClick=${(e: MouseEvent) => e.stopPropagation()}>
         <div class="turn-hd">
           <h3>Keeper 메모리</h3>
-          <span class="tid">${isOne ? active.id : '전체 keeper'}</span>
+          <span class="tid">${isOne ? activeId : '전체 keeper'}</span>
           <div class="mem-scope">
             <button class=${isOne ? 'on' : ''} onClick=${() => { scope.value = 'one' }}>이 keeper</button>
             <button class=${!isOne ? 'on' : ''} onClick=${() => { scope.value = 'all' }}>전체</button>
@@ -597,9 +450,15 @@ export function MemoryInspector({
           <button class="turn-close" onClick=${onClose} title="닫기 (Esc)">${'✕'}</button>
         </div>
         <div class="turn-body">
-          ${isOne
-            ? html`<${OneKeeperMemory} keeper=${active} store=${memory} compactions=${compactions} />`
-            : html`<${AllKeepersMemory} keepers=${keepers} store=${memory} onPick=${(id: string) => { pickId.value = id; scope.value = 'one' }} />`}
+          ${!isOne
+            ? html`<${AggregateDeferred} keepers=${keepers} />`
+            : state.loading
+              ? html`<div class="mem-empty">메모리 불러오는 중…</div>`
+              : state.error
+                ? html`<div class="mem-read-error" role="alert">${'⚠'} 메모리 불러오기 실패 — ${state.error}</div>`
+                : response?.memory_os
+                  ? html`<${OneKeeperMemoryReal} snapshot=${response.memory_os} rows=${response.entries} />`
+                  : html`<div class="mem-empty">memory-os 소스 없음 — 이 keeper의 turn-records가 비어 있음.</div>`}
         </div>
       </div>
     </div>`

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -131,11 +131,6 @@ export function latestEntryWithBlocks(rows: readonly TurnRecordRow[]): TurnRecor
   return null
 }
 
-// Blocks of that row (thin accessor; same row MemCompoReal renders figures from).
-export function latestEntryBlocks(rows: readonly TurnRecordRow[]): readonly TurnBlock[] {
-  return latestEntryWithBlocks(rows)?.record.blocks ?? []
-}
-
 // ── fact category meta (real, exhaustive over the typed union) ──
 export interface FactKindMeta {
   readonly lbl: string

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -3,11 +3,11 @@
 // Pixel-matched to the Claude-Design prototype keeper-v2/memory.jsx — same
 // drawer shell, section headers, scope toggle, and `.mem-*` classes
 // (memory-inspector-v2.css) — but every datum is REAL, fetched from
-// `GET /api/v1/keepers/:name/turn-records` (RFC-0293). The prototype's
+// `GET /api/v1/keepers/:name/turn-records` (RFC-keeper-memory-panel-real-data). The prototype's
 // fixture model (fabricated `memComposition` magic + the RFC-0247-deleted
 // salience/uses/lastUsed score fields) is gone.
 //
-// Section data sources (RFC-0293 §4; hybrid treatment confirmed 2026-06-24):
+// Section data sources (RFC-keeper-memory-panel-real-data §4; hybrid treatment confirmed 2026-06-24):
 //   컨텍스트 구성        ← real prompt-assembly block bytes (entries[latest].blocks)
 //   장기 메모리 스토어    ← real memory_os.facts.items (typed category, provenance, TTL)
 //   압축 유지·요약        ← real memory_os.episodes.items (summary + terminal_marker)

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -119,17 +119,21 @@ export function memCompositionFromBlocks(blocks: readonly TurnBlock[]): Composit
   return { totalBytes, parts }
 }
 
-// The most recent turn's blocks (entries are append-ordered; last is newest).
-export function latestEntryBlocks(rows: readonly TurnRecordRow[]): readonly TurnBlock[] {
+// The most recent turn that actually assembled a prompt (has blocks). Entries
+// are append-ordered; an error/empty-block turn at the tail is skipped so the
+// composition reflects the last real prompt assembly — and the header token
+// figures are read from this same row, never a blank tail.
+export function latestEntryWithBlocks(rows: readonly TurnRecordRow[]): TurnRecordRow | null {
   for (let i = rows.length - 1; i >= 0; i--) {
-    const blocks = rows[i]?.record.blocks
-    if (blocks && blocks.length > 0) return blocks
+    const row = rows[i]
+    if (row && row.record.blocks.length > 0) return row
   }
-  return []
+  return null
 }
 
-function latestEntry(rows: readonly TurnRecordRow[]): TurnRecordRow | null {
-  return rows.length > 0 ? rows[rows.length - 1]! : null
+// Blocks of that row (thin accessor; same row MemCompoReal renders figures from).
+export function latestEntryBlocks(rows: readonly TurnRecordRow[]): readonly TurnBlock[] {
+  return latestEntryWithBlocks(rows)?.record.blocks ?? []
 }
 
 // ── fact category meta (real, exhaustive over the typed union) ──
@@ -314,7 +318,7 @@ function OneKeeperMemoryReal({
 
       <div class="turn-sec">
         <h4>컨텍스트 구성</h4>
-        <${MemCompoReal} row=${latestEntry(rows)} />
+        <${MemCompoReal} row=${latestEntryWithBlocks(rows)} />
       </div>
 
       <div class="turn-sec">

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -20,7 +20,7 @@ import { Fragment } from 'preact'
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
-import { formatTimeAgo } from '../lib/format-time'
+import { formatTimeAgo, formatTimeUntil } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import {
   fetchKeeperTurnRecords,
@@ -173,10 +173,13 @@ export function factCategoryMeta(category: MemoryOsFactCategory): FactKindMeta {
 function factAgeLabel(fact: MemoryOsFact): string {
   return formatTimeAgo(fact.reference_time)
 }
-function factTtlLabel(fact: MemoryOsFact): string {
+export function factTtlLabel(fact: MemoryOsFact): string {
   if (fact.valid_until == null) return '영구'
+  // current ⟺ valid_until is in the future: show the remaining TTL ("…후").
+  // formatTimeAgo would floor the future delta to 0 and render "만료 지금",
+  // the exact opposite of a not-yet-elapsed deadline. Past expiry keeps "…전".
   return fact.current
-    ? `만료 ${formatTimeAgo(fact.valid_until)}`
+    ? `만료 ${formatTimeUntil(fact.valid_until)}`
     : `만료됨 ${formatTimeAgo(fact.valid_until)}`
 }
 

--- a/dashboard/src/lib/format-time.ts
+++ b/dashboard/src/lib/format-time.ts
@@ -16,6 +16,15 @@ export function formatRelativeSec(deltaSec: number): string {
   return rtf.format(-Math.round(deltaSec / SECONDS_PER_DAY), 'day')
 }
 
+/** Mirror of {@link formatRelativeSec} for a FUTURE instant: a non-negative
+ *  "seconds until" delta formatted with a positive sign — "1시간 후", "3분 후". */
+export function formatRelativeUntilSec(deltaSec: number): string {
+  if (deltaSec < SECONDS_PER_MINUTE) return rtf.format(deltaSec, 'second')
+  if (deltaSec < SECONDS_PER_HOUR) return rtf.format(Math.round(deltaSec / SECONDS_PER_MINUTE), 'minute')
+  if (deltaSec < SECONDS_PER_DAY) return rtf.format(Math.round(deltaSec / SECONDS_PER_HOUR), 'hour')
+  return rtf.format(Math.round(deltaSec / SECONDS_PER_DAY), 'day')
+}
+
 export function normalizeTimestampMs(ts: number): number {
   return ts < UNIX_MS_THRESHOLD ? ts * 1000 : ts
 }
@@ -115,6 +124,19 @@ export function formatTimeAgo(ts: string | number): string {
       ? normalizeTimestampMs(ts)
       : new Date(ts).getTime()
   return formatRelativeSec(Math.max(0, Math.floor((now - then) / 1000)))
+}
+
+/** Relative time until a FUTURE timestamp — "1시간 후", "3분 후". Mirror of
+ *  {@link formatTimeAgo}; an already-past instant clamps to 0 ("지금"). Use this
+ *  (not formatTimeAgo) for future instants — formatTimeAgo floors the future to
+ *  0 and renders "지금", which is wrong for a not-yet-elapsed deadline. */
+export function formatTimeUntil(ts: string | number): string {
+  const now = Date.now()
+  const then =
+    typeof ts === 'number'
+      ? normalizeTimestampMs(ts)
+      : new Date(ts).getTime()
+  return formatRelativeUntilSec(Math.max(0, Math.floor((then - now) / 1000)))
 }
 
 /** Format any date value (ISO string, unix seconds, or null) as Korean localized datetime.

--- a/dashboard/src/styles/memory-inspector-v2.css
+++ b/dashboard/src/styles/memory-inspector-v2.css
@@ -74,7 +74,7 @@
 
 /* keeper-v2/styles/memory.css:16-20 */
 .mem-empty { font-size: 12px; color: var(--text-dim); padding: 10px 2px; }
-/* RFC-0293: honest disclosure for a section whose backend source lands in a
+/* RFC-keeper-memory-panel-real-data: honest disclosure for a section whose backend source lands in a
    later phase — visually distinct from a plain empty state (left accent), but
    not styled as data. */
 .mem-disclosure { border-left: 2px solid var(--border-main); padding-left: 10px; color: var(--text-dim); }

--- a/dashboard/src/styles/memory-inspector-v2.css
+++ b/dashboard/src/styles/memory-inspector-v2.css
@@ -74,6 +74,14 @@
 
 /* keeper-v2/styles/memory.css:16-20 */
 .mem-empty { font-size: 12px; color: var(--text-dim); padding: 10px 2px; }
+/* RFC-0293: honest disclosure for a section whose backend source lands in a
+   later phase — visually distinct from a plain empty state (left accent), but
+   not styled as data. */
+.mem-disclosure { border-left: 2px solid var(--border-main); padding-left: 10px; color: var(--text-dim); }
+/* read errors surfaced (no silent failure) */
+.mem-read-error { font-size: 11.5px; color: var(--status-bad); padding: 8px 10px; margin-bottom: 8px; border: 1px solid color-mix(in oklab, var(--status-bad) 35%, transparent); border-radius: var(--radius-sm); background: color-mix(in oklab, var(--status-bad) 8%, transparent); }
+/* expired-TTL annotation on a fact / episode row */
+.mem-expired { color: var(--status-warn); }
 .mem-sec-head { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
 .mem-sec-head h4 { margin: 0; }
 .mem-n { font-size: 11px; color: var(--text-dim); }

--- a/docs/rfc/RFC-0293-keeper-memory-panel-real-data.md
+++ b/docs/rfc/RFC-0293-keeper-memory-panel-real-data.md
@@ -1,0 +1,247 @@
+---
+rfc: "0293"
+title: "Keeper memory panel: real-data backing (no fabrication, no score resurrection)"
+status: Draft
+created: 2026-06-24
+updated: 2026-06-24
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0233", "0244", "0247", "0259", "0285"]
+implementation_prs: []
+---
+
+# RFC-0293: Keeper memory panel — real-data backing
+
+Status: Draft · The live "Keeper 메모리" panel renders zeros from an empty-prop wiring, and the
+Claude-Design prototype it ports encodes a `score · usage · pin · timeline` model the backend
+deliberately deleted (RFC-0247). This RFC re-derives the panel from what the Memory OS **actually**
+holds — real prompt-block composition, real `fact`/`episode` rows, real recall state — adapts the
+design's visual language to those fields, and adds only the extensions legitimate against the existing
+model. It **does not** revisit RFC-0247: the score-model deletion stands (operator-confirmed
+2026-06-24); `salience` / `uses` / `lastUsed` are not resurrected.
+
+**Surfaces (CLAUDE.md agent_delegation)**: dashboard memory components + a one-key addition to
+`lib/server/server_dashboard_http_keeper_api.ml` serialization. Not credential/operator/sandbox/hooks —
+outside the mandatory-RFC list, but authored as RFC because it amends a serialized data contract and
+rewires a live panel.
+
+## 1. Problem
+
+The "Keeper 메모리" panel (`dashboard/src/components/memory-inspector.ts`, mounted via
+`keeper-workspace-rail.ts:425`) renders **zeros** for pins / store / mem-tok across all 12 live
+keepers (real keeper roster + real CTX% only). Single root cause: `keeper-workspace-rail.ts:428`
+passes `memory=${{}}` / `compactions=${{}}`, overriding the component's bundled fixture defaults
+with empty objects. No real memory data is fetched on this path.
+
+The component is a pixel-accurate port of the Claude-Design prototype (`keeper-v2/memory.jsx`,
+`memory-data.jsx`; CSS parity already complete in `memory-inspector-v2.css`). The naive fix —
+"wire it so it looks like the prototype" — is **not implementable without fabrication**, because the
+prototype encodes a data model the backend deliberately deleted:
+
+- The prototype's `memComposition()` synthesizes a 5-part token breakdown from magic constants
+  (`system=6200`, `store.length*900 + pinned.length*220`, `tasks*2600`, `min(total*0.42, traces*90)`,
+  `if (nsDialog < total*0.1) nsDialog = total*0.2`). The numbers in the design screenshot
+  (6.2k / 78.8k / 28.6k) are this formula's output, **not measured data**.
+- The prototype's store rows carry `salience` (0–1), `uses`, `lastUsed`. These are exactly the fields
+  RFC-0247 removed: `keeper_memory_os_types.ml:278-283` — *"The deleted fields (confidence,
+  access_count, last_accessed, stale_factor, expected_lifetime_cycles) were inputs to the removed
+  composite score; a fact's value is the librarian's judgment, not a number on the row."*
+- The prototype's `kind` taxonomy (`fact/decision/pattern/pref/entity`) is not the backend taxonomy
+  (`category`: `Code_change/Fact/Preference/Blocker/Goal/Constraint/Ephemeral/Validated_approach/
+  Lesson/Unknown`, `keeper_memory_os_types.ml:40-50`).
+- The prototype's recall/inject **op-timeline** with per-event `tok` deltas has no backend producer
+  (recall is a render-time action, `Keeper_memory_os_recall`).
+- The prototype's `pinned` facts have **no backend mechanism** at all.
+
+Porting any of these verbatim violates the stated bar: 노 하드코딩 / 노 휴리스틱 / 노 Stub /
+노 Silent Failure / 노 스트링 매치 / SSOT. So this RFC re-derives the panel from what the backend
+**actually** holds, adapts the design's visual language to real fields, and adds only the extensions
+that are legitimate against the existing memory model.
+
+## 2. Non-goals (adversarial guardrails)
+
+- **No score-model resurrection.** `salience` / `uses` (`access_count`) / `lastUsed` (`last_accessed`)
+  stay deleted. RFC-0247 is upheld, not reversed. Any UI that needs a "0–1 importance bar" is rejected
+  here; a fact's importance is its `category` + the librarian's inclusion judgment, not a row number.
+- **No fabricated token math.** Context composition uses measured `prompt_block.bytes` and turn-level
+  `usage.input_tokens` / `context_window` only. No `ctx * 200000`, no per-part magic multipliers.
+- **No read-side string classifier.** `category` / `claim_kind` / `Prompt_block_id` are already closed
+  sums parsed once at the producer boundary; the dashboard decodes the typed string into a TS
+  discriminated union and handles it exhaustively (an `Unknown of string` / `Other of string` arm
+  carries forward-compatible labels rather than dropping them).
+
+## 3. Field-by-field legitimacy verdict
+
+| Design section / field | Backend reality | Verdict |
+|---|---|---|
+| 컨텍스트 구성 — 5-part **token** breakdown | `turn_record.blocks : prompt_block list` = `{ block: Prompt_block_id.t; bytes; digest }` (real **bytes**, real closed-sum block ids, RFC-0233). Turn-level `usage.input_tokens`, `context_window`. Already served in `/turn-records` `entries[].blocks`. | **Adapt**: render real per-block **bytes** + real block taxonomy + turn `input_tokens`/`context_window`. Drop the fabricated 5-part token split. (P1, **FE-only — no backend change**.) |
+| 장기 메모리 스토어 — claim text | `fact.claim` (`keeper_memory_os_types.ml:285`). `memory_os.facts` currently exposes **counts only**, no `items`. | **Extend**: add `items` to `memory_os_dashboard_json` facts section. (P1, 1 serializer change.) |
+| store — kind | `fact.category` closed sum (10 arms). | **Adapt**: real `category` union, exhaustive. Not the prototype's 5. (P1.) |
+| store — `src` / provenance | `fact.source : provenance_event = { trace_id; turn; tool_call_id }` (line 18-22). | **Adapt**: real provenance, not a single `T-####` tag. (P1.) |
+| store — staleness / age | `reference_time = last_verified_at ∨ first_seen` (line 342-346); `valid_until`; `fact_is_current` (line 317). | **Adapt**: show age (from `reference_time`) + TTL/current state. Replaces `lastUsed`. (P1.) |
+| store — `salience` | Deleted (RFC-0247). | **Drop.** |
+| store — `uses` (`access_count`) | Deleted (RFC-0247). | **Drop.** |
+| store — `lastUsed` (`last_accessed`) | Deleted (RFC-0247). | **Drop** (use `reference_time` age instead). |
+| 핀 고정 사실 (operator pin: by/tag/at) | No mechanism. Pinning = operator judgment annotation; aligns with RFC-0247 ("value is judgment") and is **not** a score. | **New feature, P2** (write path; immutable annotation keyed by `claim_id`). |
+| 회상·주입 타임라인 (op + tok delta) | No per-event log. But episodes ARE real memory-shaping events (`created_at`, `terminal_marker`, `source_turn_range`, `claim_count`); `keeper_compact_audit` holds `before/after_tokens`, `tokens_freed`. | **Adapt/extend, P3**: derive a real timeline from episodes (+ compact audit join). Not a synthetic op log. |
+| 압축 유지/요약/폐기 (3-column items) | `episode.episode_summary` (summarized), `preserved_tool_refs` (kept refs), `open_items`/`constraints` (kept), `source_turn_range`; compact audit token aggregates. Item-level kept/dropped lists do not exist. | **Adapt, P3**: map to real episode fields; "dropped" derived from range − kept. No fabricated item lists. |
+
+Summary: **2 sections fully real after a 1-field serializer add (composition, store), 1 new legitimate
+write feature (pins), 2 sections adaptable from real episode/compaction data.** Zero fabricated fields.
+
+## 4. Phase 1 — read-path: real composition + real store (ship first)
+
+Lowest risk, highest value, no new persistence. Backend touches one function; the rest is FE.
+
+### 4a. Backend — add `items` to the facts section
+
+`memory_os_dashboard_json` (`server_dashboard_http_keeper_api.ml:72`) already reads
+`facts = read_facts_tail ~keeper_id ~n:fact_tail_limit` (line 79) but emits only counts. Add an
+`items` array mirroring the existing `memory_os_episode_json` shape, serializing **only fields that
+exist on `fact`** (no new fields):
+
+```ocaml
+(* RFC-0293 §4a: surface the fact rows the panel renders. Serializes only
+   existing [fact] structure — claim, typed category, provenance, the three
+   timestamps, current-ness — NOT the deleted score fields (RFC-0247). *)
+let memory_os_fact_json ~now (f : Keeper_memory_os_types.fact) =
+  `Assoc
+    ([ "claim", `String f.claim
+     ; "category", `String (Keeper_memory_os_types.category_to_string f.category)
+     ; "source", Keeper_memory_os_types.provenance_event_to_json f.source
+     ; "first_seen", `Float f.first_seen
+     ; "first_seen_iso", `String (Masc_domain.iso8601_of_unix_seconds f.first_seen)
+     ; "reference_time", `Float (Keeper_memory_os_types.reference_time f)
+     ; "valid_until", json_float_opt f.valid_until
+     ; "valid_until_iso", json_time_iso_opt f.valid_until
+     ; "last_verified_at", json_float_opt f.last_verified_at
+     ; "current", `Bool (memory_os_fact_is_current ~now f)
+     ]
+     @ (match f.external_ref with
+        | Some r -> [ "external_ref", Keeper_memory_os_types.external_ref_to_json r ]
+        | None -> [])
+     @ (match f.claim_kind with
+        | Some k -> [ "claim_kind", `String (Keeper_memory_os_types.claim_kind_to_string k) ]
+        | None -> []))
+```
+
+and add `; "items", \`List (List.map (memory_os_fact_json ~now) facts)` to the `facts` `\`Assoc`
+(line 116-122). `category_to_string` is the existing SSOT producer; the FE re-parses it with the
+mirror of `category_of_string`, so the closed sum stays the boundary, not a free string.
+
+Bytes-identical safety: this only **adds** a key to an object; existing consumers
+(`server_dashboard_http_keeper_memory_health.ml`, the FE counts decode) ignore unknown keys. No
+removal, no reordering of the fact JSON on disk (the on-disk `fact_to_json` is untouched).
+
+### 4b. Frontend — typed category + composition view model
+
+Replace the fixture-bound model in `memory-inspector.ts` with decoders over the **already-served**
+`/api/v1/keepers/:name/turn-records` bundle (`memory_os.facts.items`, `entries[latest].blocks`,
+`user_model`). Concretely:
+
+- **Category** as a discriminated union mirroring the OCaml closed sum, decoded once:
+  ```ts
+  type FactCategory =
+    | 'code_change' | 'fact' | 'preference' | 'blocker' | 'goal'
+    | 'constraint' | 'ephemeral' | 'validated_approach' | 'lesson'
+    | { unknown: string }                       // mirrors `Unknown of string`
+  ```
+  A `categoryMeta(c): {lbl; glyph; cls}` is **exhaustive** (TS `never` check on the closed arms);
+  the `{unknown}` arm renders the raw label, never drops it. This is the no-string-match property.
+- **Composition** from real blocks: take the latest `entries` row for the keeper, group its
+  `blocks` by `block` id, sum `bytes`. Parts are the real `Prompt_block_id` arms (Persona,
+  Dynamic_context, Memory_os_recall, User_model, Connected_surface, …), each labeled and colored;
+  the "memory" portion is the real `Memory_os_recall` + `User_model` blocks. Total/secondary line:
+  real `usage.input_tokens` and `context_window`. Units are **bytes** for the bar, **tokens** for the
+  header — both labeled honestly. No `* 200000`.
+- **Store rows**: real `category` + `claim` + provenance + age (`now − reference_time`) + TTL/current
+  badge. The salience bar / "N회 사용" / "최근 X" meta are removed from the row template.
+- **Empty / error states are loud**: the bundle's `memory_os.read_errors` (already produced,
+  `server_dashboard_http_keeper_api.ml:101-106`) is surfaced as a visible error chip — a read failure
+  is shown, not rendered as "0 facts" (no Silent Failure). A stopped keeper with no turn record shows
+  "활성 컨텍스트 없음", distinct from "fetch failed".
+- **Wiring**: `keeper-workspace-rail.ts:428` stops passing `memory=${{}}`; the inspector fetches by
+  keeper name (reusing the existing `decodeMemoryOsSnapshot` path, extended for `items`). The
+  "전체" aggregate view fetches per-keeper snapshots (bounded, with per-keeper error isolation) or a
+  follow-up bulk endpoint; the "이 keeper" view (the primary, design-screenshot view) needs one fetch.
+
+### 4c. Immutability
+
+View models are `readonly`/frozen records built once per fetch; no in-place mutation of decoded rows.
+Matches the existing component's `Readonly<...>` typing and the OCaml `fact` immutability.
+
+## 5. Phase 2 — operator pins (new write feature)
+
+Legitimate: a pin is an **operator judgment annotation**, not a row score — consistent with RFC-0247's
+"value is the librarian's/operator's judgment." To preserve fact immutability, a pin is **not** a
+mutable field on `fact`; it is a separate operator-owned, append-only annotation set keyed by the
+fact's identity:
+
+- Key by `claim_identity` (`keeper_memory_os_types.ml:528`) — the existing dedup SSOT (`claim_id`
+  slug or normalized claim), so a pin survives a reworded re-extraction and never keys on a separate
+  classifier.
+- Store: a per-keeper `pins.jsonl` (append-only, same IO substrate as facts), entries
+  `{ claim_key; by: operator|auto; tag; at }` as a closed-sum-typed record. Last-write-wins per key
+  (pin/unpin) resolved deterministically on read.
+- Write path: an operator action endpoint (auth-gated, mirrors existing operator control handlers).
+  Out of P1 scope; specified here so the panel's pin section is built once with a real producer.
+- Effect (optional, separate decision): a pinned claim may be exempted from TTL expiry / always
+  recalled. That changes retention semantics and would need its own justification + RFC-0247 review;
+  **default P2 is annotation-only (display + operator intent), no retention change.**
+
+## 6. Phase 3 — real memory-shaping timeline
+
+Replace the fabricated op-timeline with a timeline derived from real events:
+
+- **Episodes** (already served, `memory_os.episodes.items`): each is a compaction/summary boundary —
+  `created_at`, `terminal_marker`, `source_turn_range`, `claim_count`, `summary`. Rendered as
+  `compact`/`summarize` events.
+- **Compact audit** (`keeper_compact_audit`: `before_tokens`, `after_tokens`, `tokens_freed`): joined
+  to give the real token delta per compaction (the design's `tok` column, now measured not invented).
+  Requires exposing compact-audit rows in the bundle (currently absent) — a serializer add like §4a.
+- **TTL expiry** (`partition_expired` / GC): expired-fact counts already in `facts.expired`; an
+  `evict` event is the real GC sweep, not a synthetic per-fact line.
+
+The 압축 유지/요약/폐기 columns map to `preserved_tool_refs` (kept), `episode_summary` (summarized),
+and range−kept (dropped). No item list is fabricated; if a field is empty the column is honestly empty.
+
+## 7. OCaml 5.4 / constraints compliance
+
+- **Closed sums + exhaustive match**: `category`, `claim_kind`, `Prompt_block_id`, `external_ref_kind`
+  are existing closed sums parsed once at producer boundaries; new code adds no `_ ->` catch-all and no
+  read-time string match (RFC-0247 §2.5, project workaround-signature #2). `category_to_string` /
+  `category_of_string` remain the only boundary.
+- **No `Obj.magic`, total functions, `Result`/`option` over exceptions** in new decoders; reuse the
+  existing `json_*_field` total accessors and `Result.bind` patterns already in `turn_record.ml`.
+- **Immutability**: facts/episodes/blocks are immutable records; pins are append-only. No in-place
+  mutation introduced.
+- **No Silent Failure**: read errors propagate to `read_errors` and to a visible FE chip; a serializer
+  that can't read a store reports it (existing pattern at `server_dashboard_http_keeper_api.ml:45-55`,
+  which re-raises `Cancelled` and captures other exns as a scoped error string).
+- **SSOT**: composition reuses `Prompt_block_id`; staleness reuses `reference_time`; identity reuses
+  `claim_identity`. No parallel definitions.
+
+## 8. Verification
+
+- **Backend (OCaml)**: a codec round-trip test for `memory_os_fact_json` asserting every `fact` field
+  is present/absent per the optional rules, and that the deleted score keys are **never** emitted
+  (drift guard). Exhaustiveness test that every `category` arm has a `category_to_string` mapping
+  (already covered by `category` tests; extend if a panel-specific mapping is added).
+- **Frontend**: decoder unit tests over a captured real `/turn-records` payload (fixture from a live
+  keeper, not hand-authored) — composition sums match block bytes; category decode covers all 10 arms
+  incl. `{unknown}`; a `read_errors`-bearing payload renders the error chip (not zeros). Revert-guard:
+  removing the `items` decode must turn a populated-store test red (non-vacuous).
+- **Visual**: the "이 keeper" view against a live keeper with real facts; pixel parity holds because
+  the `.mem-*` CSS is unchanged — only the data source and the (now real) row meta change.
+
+## 9. Risks / rollback
+
+- **Risk**: the latest `entries` row may lag the live context (turn records are written post-turn). Mitigation:
+  label the composition with its `latest_ts_iso` / `latest_age_s` (already in the bundle) so staleness
+  is visible, not hidden.
+- **Risk**: `Dynamic_context` is one undifferentiated block (RFC-0233 note) — composition is coarser
+  than the design's 5 parts. This is honest, not a defect; a finer split is a future RFC-0233 producer
+  change, not a dashboard fabrication.
+- **Rollback**: P1 backend is one additive JSON key (drop the key to revert); FE is a single component
+  + the rail wiring line. P2/P3 are independent and unshipped until their own validation passes.

--- a/docs/rfc/RFC-keeper-memory-panel-real-data.md
+++ b/docs/rfc/RFC-keeper-memory-panel-real-data.md
@@ -1,5 +1,5 @@
 ---
-rfc: "0293"
+rfc: "keeper-memory-panel-real-data"
 title: "Keeper memory panel: real-data backing (no fabrication, no score resurrection)"
 status: Draft
 created: 2026-06-24
@@ -11,7 +11,7 @@ related: ["0233", "0244", "0247", "0259", "0285"]
 implementation_prs: []
 ---
 
-# RFC-0293: Keeper memory panel — real-data backing
+# RFC (keeper-memory-panel-real-data): Keeper memory panel — real-data backing
 
 Status: Draft · The live "Keeper 메모리" panel renders zeros from an empty-prop wiring, and the
 Claude-Design prototype it ports encodes a `score · usage · pin · timeline` model the backend
@@ -102,7 +102,7 @@ Lowest risk, highest value, no new persistence. Backend touches one function; th
 exist on `fact`** (no new fields):
 
 ```ocaml
-(* RFC-0293 §4a: surface the fact rows the panel renders. Serializes only
+(* RFC-keeper-memory-panel-real-data §4a: surface the fact rows the panel renders. Serializes only
    existing [fact] structure — claim, typed category, provenance, the three
    timestamps, current-ness — NOT the deleted score fields (RFC-0247). *)
 let memory_os_fact_json ~now (f : Keeper_memory_os_types.fact) =

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -244,7 +244,7 @@ val provenance_event_to_json : provenance_event -> Yojson.Safe.t
 val provenance_event_of_json : Yojson.Safe.t -> provenance_event option
 
 val external_ref_to_json : external_ref -> Yojson.Safe.t
-(** RFC-0293: the on-disk external-ref JSON shape ([{ kind; id }]). Exported so
+(** RFC-keeper-memory-panel-real-data: the on-disk external-ref JSON shape ([{ kind; id }]). Exported so
     the dashboard fact projection ([Server_dashboard_http_keeper_api.memory_os_fact_json])
     surfaces an external_ref byte-identical to storage, instead of re-inlining the
     shape in the server (SSOT). *)

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -243,6 +243,12 @@ val claim_identity : fact -> string
 val provenance_event_to_json : provenance_event -> Yojson.Safe.t
 val provenance_event_of_json : Yojson.Safe.t -> provenance_event option
 
+val external_ref_to_json : external_ref -> Yojson.Safe.t
+(** RFC-0293: the on-disk external-ref JSON shape ([{ kind; id }]). Exported so
+    the dashboard fact projection ([Server_dashboard_http_keeper_api.memory_os_fact_json])
+    surfaces an external_ref byte-identical to storage, instead of re-inlining the
+    shape in the server (SSOT). *)
+
 val fact_to_json : fact -> Yojson.Safe.t
 val fact_of_json : Yojson.Safe.t -> fact option
 

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -69,7 +69,7 @@ let memory_os_episode_json ~now (episode : Keeper_memory_os_types.episode) =
     ]
 ;;
 
-(* RFC-0293 §4a: surface the fact rows the panel renders, mirroring
+(* RFC-keeper-memory-panel-real-data §4a: surface the fact rows the panel renders, mirroring
    [memory_os_episode_json]. Serializes ONLY the existing [fact] structure —
    claim, typed category, provenance, the three timestamps, and current-ness —
    never the deleted score fields (confidence / access_count / last_accessed,
@@ -150,7 +150,7 @@ let memory_os_dashboard_json ~keeper_id =
           ; "shown", `Int (List.length facts)
           ; "current", `Int current_facts
           ; "expired", `Int (List.length facts - current_facts)
-            (* RFC-0293 §4a: the individual fact rows (previously counts-only).
+            (* RFC-keeper-memory-panel-real-data §4a: the individual fact rows (previously counts-only).
                Bounded by [fact_tail_limit]; [shown] documents the bound so a
                truncated tail is visible, not silent. *)
           ; "items", `List (List.map (memory_os_fact_json ~now) facts)

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -69,6 +69,37 @@ let memory_os_episode_json ~now (episode : Keeper_memory_os_types.episode) =
     ]
 ;;
 
+(* RFC-0293 §4a: surface the fact rows the panel renders, mirroring
+   [memory_os_episode_json]. Serializes ONLY the existing [fact] structure —
+   claim, typed category, provenance, the three timestamps, and current-ness —
+   never the deleted score fields (confidence / access_count / last_accessed,
+   RFC-0247): they are absent from the [fact] record, so the type system makes
+   re-emitting them unrepresentable. [reference_time] is the shared staleness
+   anchor (last_verified_at else first_seen), reused rather than re-inlined.
+   [external_ref] / [claim_kind] are omitted when [None] so a claim without them
+   stays a minimal row. The on-disk [fact_to_json] is untouched — this is a
+   read-only dashboard projection, not a storage change. *)
+let memory_os_fact_json ~now (fact : Keeper_memory_os_types.fact) =
+  `Assoc
+    ([ "claim", `String fact.claim
+     ; "category", `String (Keeper_memory_os_types.category_to_string fact.category)
+     ; "source", Keeper_memory_os_types.provenance_event_to_json fact.source
+     ; "first_seen", `Float fact.first_seen
+     ; "first_seen_iso", `String (Masc_domain.iso8601_of_unix_seconds fact.first_seen)
+     ; "reference_time", `Float (Keeper_memory_os_types.reference_time fact)
+     ; "valid_until", json_float_opt fact.valid_until
+     ; "valid_until_iso", json_time_iso_opt fact.valid_until
+     ; "last_verified_at", json_float_opt fact.last_verified_at
+     ; "current", `Bool (memory_os_fact_is_current ~now fact)
+     ]
+    @ (match fact.external_ref with
+       | Some r -> [ "external_ref", Keeper_memory_os_types.external_ref_to_json r ]
+       | None -> [])
+    @ (match fact.claim_kind with
+       | Some k -> [ "claim_kind", `String (Keeper_memory_os_types.claim_kind_to_string k) ]
+       | None -> []))
+;;
+
 let memory_os_dashboard_json ~keeper_id =
   let now = Time_compat.now () in
   let recent_episode_limit = 12 in
@@ -119,6 +150,10 @@ let memory_os_dashboard_json ~keeper_id =
           ; "shown", `Int (List.length facts)
           ; "current", `Int current_facts
           ; "expired", `Int (List.length facts - current_facts)
+            (* RFC-0293 §4a: the individual fact rows (previously counts-only).
+               Bounded by [fact_tail_limit]; [shown] documents the bound so a
+               truncated tail is visible, not silent. *)
+          ; "items", `List (List.map (memory_os_fact_json ~now) facts)
           ] )
     ]
 ;;

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -182,7 +182,7 @@ val handle_keeper_get_subroutes :
 
 val memory_os_fact_json :
   now:float -> Keeper_memory_os_types.fact -> Yojson.Safe.t
-(** RFC-0293 §4a: one fact's read-only dashboard projection — claim, typed
+(** RFC-keeper-memory-panel-real-data §4a: one fact's read-only dashboard projection — claim, typed
     category, provenance, the three timestamps, current-ness, and the optional
     external_ref / claim_kind. Serializes only fields present on [fact]; it
     cannot emit the score fields RFC-0247 deleted (they are not on the record).

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -177,3 +177,14 @@ val handle_keeper_get_subroutes :
   Httpun.Request.t -> Httpun.Request.t -> Httpun.Reqd.t -> unit
 (** Dispatch [GET /api/v1/keepers/<name>/<sub>] sub-routes
     (status / tools / checkpoints listing / etc.). *)
+
+(** {1 Memory-OS dashboard JSON} *)
+
+val memory_os_fact_json :
+  now:float -> Keeper_memory_os_types.fact -> Yojson.Safe.t
+(** RFC-0293 §4a: one fact's read-only dashboard projection — claim, typed
+    category, provenance, the three timestamps, current-ness, and the optional
+    external_ref / claim_kind. Serializes only fields present on [fact]; it
+    cannot emit the score fields RFC-0247 deleted (they are not on the record).
+    Exported so the test suite can assert the JSON shape (and that drift guard)
+    in isolation, per the module's "JSON shapes exported for testing" convention. *)

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -188,3 +188,10 @@ val memory_os_fact_json :
     cannot emit the score fields RFC-0247 deleted (they are not on the record).
     Exported so the test suite can assert the JSON shape (and that drift guard)
     in isolation, per the module's "JSON shapes exported for testing" convention. *)
+
+val memory_os_dashboard_json : keeper_id:string -> Yojson.Safe.t
+(** RFC-keeper-memory-panel-real-data §4a: the full recall-observability payload
+    for one keeper — episode/fact counts plus the per-row [items] arrays read
+    from the keeper's on-disk stores. Exported so the test suite can assert the
+    facts [items] are wired (one row per persisted fact); [memory_os_fact_json],
+    being a pure per-fact projection, cannot guard that wiring on its own. *)

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3857,6 +3857,66 @@ let test_retention_rank_demotes_volatile () =
     (Policy.retention_rank ~now volatile < Policy.retention_rank ~now durable)
 ;;
 
+(* RFC-0293 §4a / §8: the dashboard fact projection serializes the real [fact]
+   structure and never the score fields RFC-0247 deleted. Drift guard sibling of
+   [test_legacy_row_with_dead_score_keys_decodes]: a future edit that re-adds
+   confidence / access_count / last_accessed / salience / uses turns this red. *)
+let test_dashboard_fact_json_omits_score_keys () =
+  let now = 1_000_000.0 in
+  let f =
+    { (fact_fixture ~now ()) with
+      Types.category = Types.Validated_approach
+    ; Types.external_ref = Some { Types.kind = Types.Pr; Types.id = "42" }
+    ; Types.claim_kind = Some Types.Durable_knowledge
+    ; Types.valid_until = Some (now +. 3600.0)
+    }
+  in
+  let fields =
+    match Server_dashboard_http_keeper_api.memory_os_fact_json ~now f with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "memory_os_fact_json must be a JSON object"
+  in
+  let has k = List.mem_assoc k fields in
+  List.iter
+    (fun k -> Alcotest.(check bool) (Printf.sprintf "present: %s" k) true (has k))
+    [ "claim"; "category"; "source"; "first_seen"; "first_seen_iso"
+    ; "reference_time"; "valid_until"; "last_verified_at"; "current"
+    ; "external_ref"; "claim_kind" ];
+  List.iter
+    (fun k -> Alcotest.(check bool) (Printf.sprintf "deleted score key absent: %s" k) false (has k))
+    [ "confidence"; "access_count"; "last_accessed"; "stale_factor"
+    ; "expected_lifetime_cycles"; "salience"; "uses" ];
+  (match List.assoc_opt "category" fields with
+   | Some (`String s) ->
+     Alcotest.(check string) "category is the typed producer string" "validated_approach" s
+   | _ -> Alcotest.fail "category must be a string");
+  match List.assoc_opt "current" fields with
+  | Some (`Bool b) -> Alcotest.(check bool) "current when valid_until is in the future" true b
+  | _ -> Alcotest.fail "current must be a bool"
+;;
+
+(* Optional keys (external_ref / claim_kind) are omitted when [None]; the
+   staleness anchor [reference_time] uses last_verified_at when set. *)
+let test_dashboard_fact_json_omits_optional_when_none () =
+  let now = 1_000_000.0 in
+  let fields =
+    match
+      Server_dashboard_http_keeper_api.memory_os_fact_json ~now (fact_fixture ~now ())
+    with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "memory_os_fact_json must be a JSON object"
+  in
+  Alcotest.(check bool)
+    "external_ref omitted when None" false (List.mem_assoc "external_ref" fields);
+  Alcotest.(check bool)
+    "claim_kind omitted when None" false (List.mem_assoc "claim_kind" fields);
+  match List.assoc_opt "reference_time" fields with
+  | Some (`Float t) ->
+    Alcotest.(check (float 0.001))
+      "reference_time falls back to last_verified_at" (now -. 3600.0) t
+  | _ -> Alcotest.fail "reference_time must be a float"
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_os"
@@ -3919,6 +3979,14 @@ let () =
             "librarian runtime reports fact upsert failure"
             `Quick
             test_librarian_runtime_reports_fact_upsert_failure
+        ; Alcotest.test_case
+            "dashboard fact json omits deleted score keys (RFC-0293 §4a)"
+            `Quick
+            test_dashboard_fact_json_omits_score_keys
+        ; Alcotest.test_case
+            "dashboard fact json omits optional keys when None"
+            `Quick
+            test_dashboard_fact_json_omits_optional_when_none
         ] )
     ; ( "policy"
       , [ Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3857,7 +3857,7 @@ let test_retention_rank_demotes_volatile () =
     (Policy.retention_rank ~now volatile < Policy.retention_rank ~now durable)
 ;;
 
-(* RFC-0293 §4a / §8: the dashboard fact projection serializes the real [fact]
+(* RFC-keeper-memory-panel-real-data §4a / §8: the dashboard fact projection serializes the real [fact]
    structure and never the score fields RFC-0247 deleted. Drift guard sibling of
    [test_legacy_row_with_dead_score_keys_decodes]: a future edit that re-adds
    confidence / access_count / last_accessed / salience / uses turns this red. *)
@@ -3980,7 +3980,7 @@ let () =
             `Quick
             test_librarian_runtime_reports_fact_upsert_failure
         ; Alcotest.test_case
-            "dashboard fact json omits deleted score keys (RFC-0293 §4a)"
+            "dashboard fact json omits deleted score keys (RFC-keeper-memory-panel-real-data §4a)"
             `Quick
             test_dashboard_fact_json_omits_score_keys
         ; Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3861,6 +3861,11 @@ let test_retention_rank_demotes_volatile () =
    structure and never the score fields RFC-0247 deleted. Drift guard sibling of
    [test_legacy_row_with_dead_score_keys_decodes]: a future edit that re-adds
    confidence / access_count / last_accessed / salience / uses turns this red. *)
+(* Honest scope: the score keys are absent by construction today — [type fact]
+   carries no such fields, so [memory_os_fact_json] structurally cannot emit
+   them. This case therefore guards a *re-introduction*: it would go red only if
+   a score field were added back to BOTH the record and the projection. It is
+   not (and cannot be) load-bearing against the current code alone. *)
 let test_dashboard_fact_json_omits_score_keys () =
   let now = 1_000_000.0 in
   let f =
@@ -3915,6 +3920,41 @@ let test_dashboard_fact_json_omits_optional_when_none () =
     Alcotest.(check (float 0.001))
       "reference_time falls back to last_verified_at" (now -. 3600.0) t
   | _ -> Alcotest.fail "reference_time must be a float"
+;;
+
+(* The [items] wiring lives in [memory_os_dashboard_json], not the pure
+   [memory_os_fact_json]; the two fact_json tests above exercise the projection
+   in isolation and would stay green if the dashboard payload stopped emitting
+   the rows (FE then degrades silently to a zero-row panel). This drives the
+   integration path on disk: persist N facts, then assert facts.items carries
+   one row per fact, so reverting the [items] wiring (back to counts-only) is
+   caught here. *)
+let test_dashboard_json_wires_one_fact_item_per_fact () =
+  with_temp_keepers_dir (fun _dir ->
+    let now = 1_000_000.0 in
+    let keeper_id = "memory-panel-test" in
+    let facts =
+      [ { (fact_fixture ~now ()) with Types.claim = "first claim" }
+      ; { (fact_fixture ~now ()) with Types.claim = "second claim" }
+      ; { (fact_fixture ~now ()) with Types.claim = "third claim" }
+      ]
+    in
+    List.iter (Memory_io.append_fact ~keeper_id) facts;
+    let items =
+      match Server_dashboard_http_keeper_api.memory_os_dashboard_json ~keeper_id with
+      | `Assoc top ->
+        (match List.assoc_opt "facts" top with
+         | Some (`Assoc facts_obj) ->
+           (match List.assoc_opt "items" facts_obj with
+            | Some (`List items) -> items
+            | _ -> Alcotest.fail "facts.items must be a JSON list")
+         | _ -> Alcotest.fail "facts must be a JSON object")
+      | _ -> Alcotest.fail "memory_os_dashboard_json must be a JSON object"
+    in
+    Alcotest.(check int)
+      "facts.items emits one row per persisted fact (items wiring)"
+      (List.length facts)
+      (List.length items))
 ;;
 
 let () =
@@ -3987,6 +4027,10 @@ let () =
             "dashboard fact json omits optional keys when None"
             `Quick
             test_dashboard_fact_json_omits_optional_when_none
+        ; Alcotest.test_case
+            "dashboard json wires one facts.items row per persisted fact"
+            `Quick
+            test_dashboard_json_wires_one_fact_item_per_fact
         ] )
     ; ( "policy"
       , [ Alcotest.test_case


### PR DESCRIPTION
## 목표

라이브 "Keeper 메모리" 패널(`127.0.0.1:8935/dashboard#keepers`)이 디자인 대비 정보 반영이 모자라고 0만 렌더하던 문제를 
해결합니다. 원인은 두 가지였습니다.

1. 패널이 `keeper-workspace-rail.ts`에서 `memory={}` 빈 prop으로 마운트됨 (라이브 0의 직접 원인).
2. 포팅된 Claude-Design 프로토타입이 **날조된 composition 산술** + **RFC-0247이 의도적으로 삭제한 점수 
모델**(`salience`/`uses`/`lastUsed`)을 인코딩 — 픽셀퍼펙트 복제 = 날조 = 제약 위반.

이 PR은 패널을 Memory OS가 **실제로** 보유한 데이터(실 prompt-block bytes, 실 `fact`/`episode` 행)로 재유도하고, 
디자인의 시각 언어를 그 필드에 맞춥니다. RFC-0247의 점수 모델 삭제는 유지합니다(operator 확인 2026-06-24).

설계: `docs/rfc/RFC-keeper-memory-panel-real-data.md` (slug-only — 아래 "RFC 번호" 참조).

## 변경 (Phase 1 — read path)

- **백엔드** `lib/server/server_dashboard_http_keeper_api.ml`: `memory_os_fact_json` 추가 + facts 섹션에 `items` 
직렬화. 삭제된 점수 필드는 `fact` 레코드에 없으므로 타입 시스템이 재방출을 unrepresentable로 만듦. 
`keeper_memory_os_types.mli`에 `external_ref_to_json` export(정본 codec 재사용, inline 중복 금지).
- **FE 디코더** `dashboard/src/api/dashboard.ts`: `MemoryOsFact` + `MemoryOsFactCategory`(OCaml `category` 닫힌합 미러, 
Unknown drift-absorber, 정확멤버십 파스 — substring 분류기 아님). malformed-drop + fresh-literal로 삭제 점수키 
round-trip 불가.
- **FE 렌더** `dashboard/src/components/memory-inspector.ts`: 프로토타입 fixture view-model을 실 
`TurnRecordsResponse`로 전면 교체. 하이브리드 섹션(operator 확인):
  - 컨텍스트 구성 → 실 block bytes (`entries[latest].blocks`, 매직 산술 제거)
  - 장기 메모리 스토어 → 실 `facts.items` (exhaustive category switch + `never` 가드)
  - 압축 → 실 `episodes` (summary + terminal_marker)
  - 핀 / 회상·주입 → 정직한 `ⓘ Phase 2/3 연결 예정` disclosure (stub 아님 — 부재 공시)
  - `read_errors` 가시화 (no silent failure)
- `keeper-workspace-rail.ts`: 제거된 `memory`/`compactions` prop 정리. 두 마운트(rail + agent-detail-memory) 모두 
`MemoryKeeper`를 계속 전달.

## 리뷰 대응 (신규 커밋)

- `factTtlLabel` 미래 만료 붕괴 수정: `formatTimeAgo` 대신 `formatTimeUntil` 사용. `current=true` + 미래 
`valid_until` 조합에 대한 회귀 테스트 추가.
- BE `items` wiring revert-guard 추가: `test_dashboard_json_wires_one_fact_item_per_fact`에서 N개 fact를 
영속화한 뒤 `memory_os_dashboard_json`의 `facts.items` 길이가 N인지 assert. 이 테스트는 `memory_os_fact_json` 
고립 테스트로는 잡히지 않던 "한 줄 revert 시 패널 0행" 회귀를 막음.
- `test_dashboard_fact_json_omits_score_keys` docstring 정밀화: 현재 `type fact`에 점수 필드가 없어 
구조적으로 방출 불가하므로, 이 테스트는 "record + projection 둘 다 재도입되면 red"라는 re-introduction guard임을 
명시.

## 로컬 검증

- `npx tsc --noEmit`: clean
- `vitest`: 디코더 + 인스펙터 78/78, 영향 5파일 회귀 128/128
- `eslint` (변경 .ts): clean
- `test/test_keeper_memory_os.exe`: 98 tests pass
- FE revert-guard: composition/items 소스를 비우면 테스트 red
- BE revert-guard: `test_dashboard_json_wires_one_fact_item_per_fact`로 `memory_os_dashboard_json`의 items wiring 
revert 잡음
- `rfc_enforcer.py` (CI invocation): pass

## 남은 미검증 / 후속

- **OCaml 풀빌드**: 로컬 opam switch가 머지된 ws-direct-eio 의존성과 out-of-sync라 masc.server 전체 링크는 로컬에서 
미검증. 내 OCaml 파일은 타입상 정확하며 `test_keeper_memory_os`는 통과 → **CI가 authoritative**.
- **OCaml→TS category cross-lang drift 게이트**: 현재 TS 측은 exact-membership + `unknown` absorb로 정확하지만, 
OCaml arm 추가 시 TS 미갱신을 자동으로 막는 generated-fixture 대조 게이트는 별도 후속 작업.

## RFC 번호 (충돌 해소)

placeholder였던 RFC-0293이 main의 `RFC-0293-keeper-exec-endpoint-backend.md`(#22205)와 충돌. #22198이 RFC 번호 할당을 
제거(forward slug-only)했으므로, slug-only `RFC-keeper-memory-panel-real-data.md`로 재명명하고 모든 코드/문서 인용을 
갱신했습니다. (이전 커밋 메시지의 "RFC-0293 §N"은 이 slug RFC를 가리킵니다.)

## 범위 밖 (후속)

- Phase 2 (operator 핀 write endpoint), Phase 3 (회상·주입 타임라인 + 압축 kept/dropped diff) — 새 백엔드 필요, 별도 
PR. 현재 disclosure로 정직하게 표시.
- 전체(aggregate) scope — keeper별 N-fetch 필요, 단일 keeper 우선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
