### PR TITLE
fix(keeper): drop failed_task from deliberation triage trigger (RFC-0294 PR-2)

### DIFF
--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -216,7 +216,14 @@ let triage (obs : world_observation) : triage_result =
   (* L1 Reactive triggers *)
   if obs.direct_mention then add DirectMention;
   if obs.unclaimed_task_count > 0 then add NewUnclaimedTask;
-  if obs.failed_task_count > 0 then add FailedTask;
+  (* RFC-0294: failed_task (orphan) is NOT an actionable trigger.  Its only
+     affordance, Task_audit, is read-only, so the keeper cannot clear the
+     signal; waking on it produced the executor livelock.  Orphan resolution is
+     the GC/supervisor's job and visibility is the orphan surfacer's — not a
+     proactive wake.  Mirrors [affordance_can_mutate Task_audit = false] in
+     keeper_world_observation.  (The [FailedTask] variant is retained for the
+     Broadcast/ProposeSpawn legality gates below: communicating ABOUT an orphan
+     is a deliberate action, distinct from being woken by it.) *)
   if obs.keeper_fiber_count_changed then add KeeperFiberStartedOrStopped;
 
   (* L2 Proactive triggers — goal-directed *)

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -629,13 +629,14 @@ let autonomous_trigger_lines
                     "- Since last autonomous turn: %ds, effective cooldown: %ds"
                     since_last cooldown)
            | _ -> None);
+          (* RFC-0294: failed_task no longer accelerates the backlog cadence
+             (Task_audit is read-only; the keeper cannot act on an orphan), so
+             only claimable tasks justify the acceleration framing here. *)
           (match decision.task_reactive_cooldown with
-           | Some cooldown
-             when observation.claimable_task_count > 0
-                  || observation.failed_task_count > 0 ->
+           | Some cooldown when observation.claimable_task_count > 0 ->
                Some
                  (Printf.sprintf
-                    "- Backlog acceleration cooldown: %ds for claimable/failed tasks"
+                    "- Backlog acceleration cooldown: %ds for claimable tasks"
                     cooldown)
            | _ -> None);
         ]
@@ -852,7 +853,10 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
         observation.unclaimed_task_count > 0
         || observation.claimable_task_count > 0
         || observation.provider_capacity_blocked_task_count > 0
-        || observation.failed_task_count > 0
+        (* RFC-0294: failed_task does not, by itself, warrant the Namespace
+           State section — an orphan is GC-owned, not keeper-actionable.  It is
+           still shown (as non-actionable telemetry) when the section renders
+           for another reason. *)
         || observation.running_keeper_fiber_count > 0
       then (
         let ubuf = Buffer.create 256 in
@@ -885,9 +889,12 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
             (Printf.sprintf
                "- Provider-capacity blocked claimable tasks: %d\n"
                observation.provider_capacity_blocked_task_count);
+        (* RFC-0294: label orphaned/failed tasks as GC-owned so the model does
+           not try to audit or act on them (the executor no-op livelock). *)
         if observation.failed_task_count > 0 then
           Buffer.add_string ubuf
-            (Printf.sprintf "- Failed tasks: %d\n"
+            (Printf.sprintf
+               "- Failed tasks (orphaned; GC-owned, no keeper action required): %d\n"
                observation.failed_task_count);
         Buffer.add_string ubuf
           (Printf.sprintf

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -95,12 +95,15 @@ let test_triage_unclaimed_task () =
       check bool "contains NewUnclaimedTask" true
         (List.mem D.NewUnclaimedTask triggers)
 
-let test_triage_failed_task () =
+(* RFC-0294: failed_task (orphan) must NOT be an actionable triage trigger —
+   Task_audit is read-only, so waking on it cannot clear it (the executor
+   livelock).  An orphan-only observation yields no trigger. *)
+let test_triage_failed_task_is_not_a_trigger () =
   let obs = { base_obs with failed_task_count = 1 } in
   match D.triage obs with
-  | D.Skip _ -> fail "expected Triggered for failed task"
+  | D.Skip _ -> ()
   | D.Triggered triggers ->
-      check bool "contains FailedTask" true
+      check bool "failed_task must NOT be a trigger" false
         (List.mem D.FailedTask triggers)
 
 let test_triage_keeper_fiber_count_change () =
@@ -1335,8 +1338,8 @@ let () =
             test_triage_direct_mention;
           test_case "unclaimed task triggers" `Quick
             test_triage_unclaimed_task;
-          test_case "failed task triggers" `Quick
-            test_triage_failed_task;
+          test_case "failed task is NOT a trigger (RFC-0294)" `Quick
+            test_triage_failed_task_is_not_a_trigger;
           test_case "keeper fiber count change triggers" `Quick
             test_triage_keeper_fiber_count_change;
           test_case "board mention triggers" `Quick


### PR DESCRIPTION
RFC-0294 PR-2/7. **Stacked on PR #22214 (R1g).**

`keeper_deliberation.triage`가 `failed_task_count>0`에 `FailedTask` 트리거를 추가하던 것을 제거. R1g가 `keeper_world_observation`에서 failed_task를 wake driver에서 뺐는데, deliberation은 여전히 actionable로 취급하는 **dual-definition**이었다. 두 결정 surface가 일치하도록 정렬한다.

- `FailedTask` 변이는 Broadcast/ProposeSpawn legality gate(`has_operational_signal` :429, ProposeSpawn :464)용으로 **유지** — orphan을 broadcast로 surface하는 건 의도적 행동이지 wake-driving이 아니다(다른 의미축).
- `test_triage_failed_task` → `test_triage_failed_task_is_not_a_trigger` (revert-red: orphan-only observation이 이제 trigger 0).

검증: `dune build lib/keeper` green. 풀 테스트는 CI (로컬 agent_sdk 0.207.7 skew).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
