### PR TITLE
fix(keeper): relabel failed_task as GC-owned in prompt surface (RFC-0294 PR-3)

### DIFF
--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -629,13 +629,14 @@ let autonomous_trigger_lines
                     "- Since last autonomous turn: %ds, effective cooldown: %ds"
                     since_last cooldown)
            | _ -> None);
+          (* RFC-0294: failed_task no longer accelerates the backlog cadence
+             (Task_audit is read-only; the keeper cannot act on an orphan), so
+             only claimable tasks justify the acceleration framing here. *)
           (match decision.task_reactive_cooldown with
-           | Some cooldown
-             when observation.claimable_task_count > 0
-                  || observation.failed_task_count > 0 ->
+           | Some cooldown when observation.claimable_task_count > 0 ->
                Some
                  (Printf.sprintf
-                    "- Backlog acceleration cooldown: %ds for claimable/failed tasks"
+                    "- Backlog acceleration cooldown: %ds for claimable tasks"
                     cooldown)
            | _ -> None);
         ]
@@ -852,7 +853,10 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
         observation.unclaimed_task_count > 0
         || observation.claimable_task_count > 0
         || observation.provider_capacity_blocked_task_count > 0
-        || observation.failed_task_count > 0
+        (* RFC-0294: failed_task does not, by itself, warrant the Namespace
+           State section — an orphan is GC-owned, not keeper-actionable.  It is
+           still shown (as non-actionable telemetry) when the section renders
+           for another reason. *)
         || observation.running_keeper_fiber_count > 0
       then (
         let ubuf = Buffer.create 256 in
@@ -885,9 +889,12 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
             (Printf.sprintf
                "- Provider-capacity blocked claimable tasks: %d\n"
                observation.provider_capacity_blocked_task_count);
+        (* RFC-0294: label orphaned/failed tasks as GC-owned so the model does
+           not try to audit or act on them (the executor no-op livelock). *)
         if observation.failed_task_count > 0 then
           Buffer.add_string ubuf
-            (Printf.sprintf "- Failed tasks: %d\n"
+            (Printf.sprintf
+               "- Failed tasks (orphaned; GC-owned, no keeper action required): %d\n"
                observation.failed_task_count);
         Buffer.add_string ubuf
           (Printf.sprintf


### PR DESCRIPTION
RFC-0294 PR-3/7. **Stacked on PR #22215 → #22214 (R1g).**

R1g가 ~100s livelock은 끊었지만, prompt가 여전히 failed_task를 actionable로 주입해 900s housekeeping turn에서 model이 no-op `task_audit`로 빠질 여지가 남아 있었다. 잔여 steering을 닫는다 (`keeper_unified_prompt.ml`):

- Namespace State `"- Failed tasks: %d"` → `"- Failed tasks (orphaned; GC-owned, no keeper action required): %d"`. count는 가시성 위해 유지, 비-actionable로 명시.
- Namespace State render gate에서 failed_task 제거 (orphan 단독으로 섹션 유발 안 함; 다른 사유로 렌더될 때만 telemetry로 표시).
- "Backlog acceleration cooldown" 라인: claimable 전용 (failed는 cadence 가속 안 함).

`observed_affordances`의 task_audit emission은 **의도적으로 유지** — incident 재구성에 쓴 진단 telemetry(`observed_affordances: [task_audit]`)다. prompt relabel이 model-steering surface.

검증: `dune build lib/keeper` green. 풀 테스트는 CI (로컬 agent_sdk 0.207.7 skew).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
