### PR TITLE
fix(test): main Build unblock — purged proof_store dep + stale readiness-gate ts mutation

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -2221,13 +2221,15 @@
  (modules test_rfc_0085_pr6_host_config_from_env)
  (libraries alcotest masc.host_config unix))
 
-; RFC-0085 PR-4 — tool_library + cdal proof_store /tmp fallback purge.
+; RFC-0085 PR-4 — tool_library /tmp fallback purge. The cdal proof_store guard
+; was dropped: proof_store.ml was purged in #19469, so depending on it here made
+; dune fail with "No rule found".
 
 (test
  (name test_rfc_0085_pr4_tool_library_proof_store)
  (modules test_rfc_0085_pr4_tool_library_proof_store)
  (libraries alcotest ast_grep)
- (deps ../lib/tool_library.ml ../lib/cdal_runtime/proof_store.ml))
+ (deps ../lib/tool_library.ml))
 
 ; Verify the shared MCP dispatch finalizer fires typed observers and applies
 ; the result transformer before observers run.

--- a/test/test_keeper_production_readiness_gate.py
+++ b/test/test_keeper_production_readiness_gate.py
@@ -172,9 +172,15 @@ class KeeperProductionReadinessGateTest(unittest.TestCase):
                 / f"{trace}.jsonl"
             )
             text = manifest.read_text(encoding="utf-8")
+            # check_timestamp_order groups rows per (keeper, trace, generation,
+            # turn), so the corruption must be an intra-turn violation. fixture_ts()
+            # spaces turns one minute apart (turn N -> 00:0N:..), so a later-finish
+            # or cross-turn bump stays monotonic within the turn and yields zero
+            # violations. Pull turn 1's turn_finished (offset 7) before its own
+            # turn's first event so the terminal event predates the turn it closes.
             text = text.replace(
                 '"ts": "2026-05-13T00:01:07Z"',
-                '"ts": "2026-05-13T00:01:59Z"',
+                '"ts": "2026-05-13T00:01:00Z"',
                 1,
             )
             manifest.write_text(text, encoding="utf-8")

--- a/test/test_rfc_0085_pr4_tool_library_proof_store.ml
+++ b/test/test_rfc_0085_pr4_tool_library_proof_store.ml
@@ -1,14 +1,16 @@
 open Alcotest
 
-(** RFC-0085 PR-4 — tool_library + cdal proof_store /tmp fallback 박멸.
+(** RFC-0085 PR-4 — tool_library /tmp fallback 박멸.
 
     Verifies:
     - lib/tool_library.ml: ~default:"/tmp" 리터럴 fallback 제거
       (Host_config.host()-based로 변경).
-    - lib/cdal_runtime/proof_store.ml: Not_found -> "/tmp" 리터럴 및
-      home-level [.oas] fallback 제거. cdal_runtime sub-library는
-      masc 본 라이브러리와 격리되어 있으므로 MASC_BASE_PATH /
-      cwd 순서만 직접 사용한다.
+
+    The companion cdal proof_store guards were dropped: lib/cdal_runtime/proof_store.ml
+    was purged in #19469 ("Track B", 2026-05-29), so reading it as a source fixture
+    is unrepresentable — the [(deps ../lib/cdal_runtime/proof_store.ml)] entry made
+    dune fail with "No rule found". The /tmp-fallback invariant it guarded is moot
+    once the module is gone.
 
     AST-based via Ast_grep. *)
 
@@ -26,48 +28,12 @@ let test_tool_library_uses_host_config () =
   then failf "tool_library.ml must call Host_config.host >= 1, got %d" n
 ;;
 
-let test_no_tmp_default_in_proof_store () =
-  let path = "lib/cdal_runtime/proof_store.ml" in
-  let n = Ast_grep.count_string_literals ~module_path:path ~needle:"/tmp" in
-  check int "/tmp literal removed from proof_store fallback" 0 n
-;;
-
-let test_no_home_default_in_proof_store () =
-  let path = "lib/cdal_runtime/proof_store.ml" in
-  let n = Ast_grep.count_string_literals ~module_path:path ~needle:"HOME" in
-  check int "HOME literal removed from proof_store fallback" 0 n
-;;
-
-let test_proof_store_uses_base_path_input_only () =
-  let path = "lib/cdal_runtime/proof_store.ml" in
-  let masc_base =
-    Ast_grep.count_string_literals ~module_path:path ~needle:"MASC_BASE_PATH"
-  in
-  let legacy_me_root =
-    Ast_grep.count_string_literals ~module_path:path ~needle:(String.concat "" [ "ME"; "_ROOT" ])
-  in
-  if masc_base < 1 || legacy_me_root <> 0
-  then
-    failf
-      "proof_store fallback should use MASC_BASE_PATH only, got MASC_BASE_PATH=%d legacy-root=%d"
-      masc_base
-      legacy_me_root
-;;
-
 let () =
   run
-    "rfc-0085-pr-4-tool-library-proof-store"
+    "rfc-0085-pr-4-tool-library"
     [ ( "tool_library"
       , [ test_case "no /tmp literal" `Quick test_no_tmp_default_in_tool_library
         ; test_case "uses Host_config.host" `Quick test_tool_library_uses_host_config
-        ] )
-    ; ( "proof_store"
-      , [ test_case "no /tmp literal" `Quick test_no_tmp_default_in_proof_store
-        ; test_case "no HOME literal" `Quick test_no_home_default_in_proof_store
-        ; test_case
-            "uses base-path input only"
-            `Quick
-            test_proof_store_uses_base_path_input_only
         ] )
     ]
 ;;


### PR DESCRIPTION
## 목표

main의 **Build and Test가 모든 PR에서 RED**인 상태를 푼다. 원인은 두 개의 잠복 breakage가 겹쳐 있던 것이며, 둘 다 **purge/refactor된 source와 어긋난 test fixture**라는 같은 클래스다. 첫 번째가 두 번째를 가리고 있었다.

## breakage 1 — proof_store dune dep (dune 해소 실패)

`lib/cdal_runtime/proof_store.ml`은 #19469("Track B", 2026-05-29)로 purge됐으나, 그 파일을 소스 fixture로 읽던 테스트가 안 따라갔다:

```
; test/dune:2230 (이전)
(deps ../lib/tool_library.ml ../lib/cdal_runtime/proof_store.ml)
```

`test_rfc_0085_pr4_tool_library_proof_store.ml`이 `Ast_grep.count_string_literals`로 proof_store에서 `/tmp`·HOME 리터럴 부재를 검사하던 AST-grep 가드. 검사 대상이 사라져 dune이 dep를 해소 못 해 `Error: No rule found for lib/cdal_runtime/proof_store.ml`로 **전체 빌드가 즉사**(docs-only PR까지 휩쓸림).

**수정**: `test/dune` dep에서 proof_store 제거 + 테스트의 proof_store 3가드(no_tmp/no_home/uses_base_path)+그룹 제거. `tool_library` 2가드는 유지(live + `/tmp`-fallback 회귀가드 유효).

## breakage 2 — readiness gate timestamp 테스트 (breakage 1이 가리고 있던 잠복)

breakage 1이 dune을 즉사시켜 pytest가 한 번도 실행되지 못했다. proof_store dep를 풀자 비로소 Build가 pytest까지 진행했고, `test_keeper_production_readiness_gate.py::test_timestamp_order_violation_fails`가 `AssertionError: 'PASS' != 'FAIL'`로 드러났다.

`check_timestamp_order`는 매니페스트 행을 `(keeper, trace, generation, turn)` 단위로 그룹핑해 **turn별로** 검사한다. fixture(`fixture_ts`)는 turn을 1분 간격으로 배치(turn N → `00:0N:..`). 테스트가 turn 1의 `turn_finished`를 `00:01:07` → `00:01:59`로 바꿔도 (a) turn 내부에선 여전히 offset 1-7 뒤라 monotonic, (b) turn 2(`00:02:01`)보다 앞 → **어느 경로로도 위반 0**. 게이트는 올바르게 PASS를 반환했고, **테스트가 틀린 기대(FAIL)를 단언**하고 있었다. (#20134, 2026-06-04이 fixture 간격을 바꿨으나 그때 build는 이미 breakage 1로 red라 회귀가 안 잡힘.)

**수정**: 변이를 intra-turn 위반으로 이동. turn 1의 `turn_finished`를 자기 turn 첫 이벤트보다 이르게(`00:01:00`) 하여, pairwise 역행 검사와 terminal-ts 가드 양쪽이 검출(order_violations=4 → FAIL). 게이트 로직·fixture는 정상이므로 손대지 않음.

## 검증 (로컬, 결정적 — 순수 Python)

```
$ python3 -m pytest test/test_keeper_production_readiness_gate.py -q
10 passed in 7.90s
```

dune `@runtest`로 도는 나머지 python 테스트 2개도 통과 확인(`test_audit_keeper_fleet_readiness` 31 OK, `test_export_symbol_graph` 1 OK) — 추가 잠복 python 실패 없음.

OCaml 빌드는 로컬 opam이 ws-direct-eio와 out-of-sync라 **CI authoritative**.

## 변경 파일 (test-only, 2 commit)

- `test/dune` + `test/test_rfc_0085_pr4_tool_library_proof_store.ml` (breakage 1)
- `test/test_keeper_production_readiness_gate.py` (breakage 2)

## 남은 main breakage (이 PR 범위 밖)

Lint / Meta Guards / CI Gate 실패는 별개 job이며 이 Build job과 무관. 별도 추적 필요.

RFC-WAIVED: test-only fixture 정합 수정. credential/identity/operator/sandbox/hooks/workflow subsystem 무관.
