### PR TITLE
fix(rfc): RFC-0294 중복 해소 — proactive-wake RFC를 slug-only로

### DIFF
--- a/docs/rfc/RFC-keeper-proactive-wake-actionability-invariant.md
+++ b/docs/rfc/RFC-keeper-proactive-wake-actionability-invariant.md
@@ -1,5 +1,5 @@
 ---
-rfc: "0294"
+rfc: "keeper-proactive-wake-actionability-invariant"
 title: "Keeper Proactive-Wake Actionability Invariant + Self-Cadence Tombstone Gate"
 status: Draft
 created: 2026-06-24
@@ -11,7 +11,7 @@ related: ["0246", "0220", "0233", "0239"]
 implementation_prs: []
 ---
 
-# RFC-0294 — Keeper Proactive-Wake Actionability Invariant + Self-Cadence Tombstone Gate
+# RFC (keeper-proactive-wake-actionability-invariant) — Keeper Proactive-Wake Actionability Invariant + Self-Cadence Tombstone Gate
 
 - Status: Draft
 - Area: `lib/keeper/` (world observation, proactive scheduler, no-progress detector, wake tombstone), `lib/workspace/` (orphan surfacing)

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -82,7 +82,7 @@ let tools_for_affordance = function
     [ "keeper_tasks_list"; "keeper_tasks_audit";
       "keeper_task_done"; "masc_transition" ]
 
-(* RFC-0294: does this affordance grant the keeper a tool that can change
+(* RFC-keeper-proactive-wake-actionability-invariant: does this affordance grant the keeper a tool that can change
    task/world state (and thus clear the signal that surfaced it)?  Exhaustive
    match over the closed [turn_affordance] sum, so adding a new affordance
    forces a decision here at compile time.  [Task_audit] is the sole

--- a/lib/keeper/keeper_agent_tool_surface.mli
+++ b/lib/keeper/keeper_agent_tool_surface.mli
@@ -46,7 +46,7 @@ val tools_for_affordance : turn_affordance -> string list
     change task/world state (and thus clear the signal that surfaced it).
     [Task_audit] is the sole advisory-only ([false]) affordance: a signal whose
     only affordance is [Task_audit] must never drive a proactive wake, or the
-    keeper livelocks on a signal it cannot clear (RFC-0294). Exhaustive over the
+    keeper livelocks on a signal it cannot clear (RFC-keeper-proactive-wake-actionability-invariant). Exhaustive over the
     closed [turn_affordance] sum. *)
 val affordance_can_mutate : turn_affordance -> bool
 

--- a/lib/keeper/keeper_deliberation.ml
+++ b/lib/keeper/keeper_deliberation.ml
@@ -216,7 +216,7 @@ let triage (obs : world_observation) : triage_result =
   (* L1 Reactive triggers *)
   if obs.direct_mention then add DirectMention;
   if obs.unclaimed_task_count > 0 then add NewUnclaimedTask;
-  (* RFC-0294: failed_task (orphan) is NOT an actionable trigger.  Its only
+  (* RFC-keeper-proactive-wake-actionability-invariant: failed_task (orphan) is NOT an actionable trigger.  Its only
      affordance, Task_audit, is read-only, so the keeper cannot clear the
      signal; waking on it produced the executor livelock.  Orphan resolution is
      the GC/supervisor's job and visibility is the orphan surfacer's — not a

--- a/lib/keeper/keeper_unified_prompt.ml
+++ b/lib/keeper/keeper_unified_prompt.ml
@@ -629,7 +629,7 @@ let autonomous_trigger_lines
                     "- Since last autonomous turn: %ds, effective cooldown: %ds"
                     since_last cooldown)
            | _ -> None);
-          (* RFC-0294: failed_task no longer accelerates the backlog cadence
+          (* RFC-keeper-proactive-wake-actionability-invariant: failed_task no longer accelerates the backlog cadence
              (Task_audit is read-only; the keeper cannot act on an orphan), so
              only claimable tasks justify the acceleration framing here. *)
           (match decision.task_reactive_cooldown with
@@ -853,7 +853,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
         observation.unclaimed_task_count > 0
         || observation.claimable_task_count > 0
         || observation.provider_capacity_blocked_task_count > 0
-        (* RFC-0294: failed_task does not, by itself, warrant the Namespace
+        (* RFC-keeper-proactive-wake-actionability-invariant: failed_task does not, by itself, warrant the Namespace
            State section — an orphan is GC-owned, not keeper-actionable.  It is
            still shown (as non-actionable telemetry) when the section renders
            for another reason. *)
@@ -889,7 +889,7 @@ let build_prompt ~(meta : Keeper_meta_contract.keeper_meta) ~(base_path : string
             (Printf.sprintf
                "- Provider-capacity blocked claimable tasks: %d\n"
                observation.provider_capacity_blocked_task_count);
-        (* RFC-0294: label orphaned/failed tasks as GC-owned so the model does
+        (* RFC-keeper-proactive-wake-actionability-invariant: label orphaned/failed tasks as GC-owned so the model does
            not try to audit or act on them (the executor no-op livelock). *)
         if observation.failed_task_count > 0 then
           Buffer.add_string ubuf

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -806,7 +806,7 @@ let observe_direct_keeper_msg ~(config : Workspace.config) ~(meta : keeper_meta)
   }
 ;;
 
-(* RFC-0294: a task-backlog signal drives a proactive turn only if the
+(* RFC-keeper-proactive-wake-actionability-invariant: a task-backlog signal drives a proactive turn only if the
    affordance it grants can mutate task state (and thus clear the signal that
    surfaced it).  [failed_task] grants only [Task_audit], whose tools are
    read-only, so [failed_drives_wake] is structurally [false]: a keeper cannot
@@ -1034,7 +1034,7 @@ let keeper_cycle_decision
         let task_reactive_cooldown =
           max task_cooldown_floor (effective_cooldown / max 1 task_cooldown_divisor)
         in
-        (* RFC-0294: failed_task no longer contributes — Task_audit is
+        (* RFC-keeper-proactive-wake-actionability-invariant: failed_task no longer contributes — Task_audit is
            advisory-only, so an orphan this keeper cannot clear must not drive
            the backlog cadence.  claimable (Task_claim) remains actionable. *)
         let has_actionable_tasks =

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -5,7 +5,7 @@ Edit the generator, not this file. Re-run: scripts/gen-tla-index.sh > specs/INDE
 
 # TLA+ Spec Index
 
-Generated: 2026-06-24T09:20:28Z (HEAD: ff50a6ee04)
+Generated: 2026-06-25T01:58:27Z (HEAD: 5a21bf99c9)
 
 Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to refresh.
 
@@ -128,7 +128,7 @@ Source of truth: `specs/`. Run `scripts/gen-tla-index.sh > specs/INDEX.md` to re
 | KeeperOASAdvanced.tla | KeeperOASAdvanced | manual | 2 | 1 | clean={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicRuntimeFallback, prop:CommittedSideEffectsRequireContinueGate, prop:StrictStopPreemption, prop:EventualTermination} buggy={inv:NoZombieFibers, inv:CancelledNeverAbsorbed, prop:AtomicRuntimeFallback, prop:StrictStopPreemption, prop:EventualTermination} | 6a288b34a171 |
 | KeeperOutcomesConservation.tla | KeeperOutcomesConservation | manual | 2 | 1 | clean={inv:Safety} buggy={inv:ConservationLaw} | 7ac6ec2c5bf3 |
 | KeeperPostTurnOrchestration.tla | KeeperPostTurnOrchestration | manual | 2 | 1 | clean={inv:SafetyInvariant} buggy={inv:SafetyInvariant} | 2b313c94357a |
-| KeeperProactiveWakeGuard.tla | KeeperProactiveWakeGuard | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety} buggy={inv:NeverWakeWithoutMutatingAffordance, inv:NoUnboundedZeroProgressStreak} | 2e5490deb0b2 |
+| KeeperProactiveWakeGuard.tla | KeeperProactiveWakeGuard | manual | 2 | 1 | clean={inv:TypeOK, inv:Safety} buggy={inv:NeverWakeWithoutMutatingAffordance, inv:NoUnboundedZeroProgressStreak} | f12350ddda14 |
 | KeeperReactionLiveness.tla | KeeperReactionLiveness | manual | 2 | 1 | clean={inv:Safety, prop:BoardEnqueueLeadsToReceipt, prop:VerificationLeadsToReaction, prop:GoalVerificationLeadsToResolution, prop:TaskTransitionLeadsToReceipt, prop:CursorAdvancementRequiresAck} buggy={inv:TypeOK, prop:BoardEnqueueLeadsToReceipt} | 04f8e04c4fe0 |
 | KeeperReconcileLiveness.tla | KeeperReconcileLiveness | manual | 2 | 1 | clean={inv:TypeOK, prop:RunningClearsManualReconcile, prop:DeadIsForever, prop:StoppedIsForever, prop:RunningRequiresFiber, prop:ManualReconcileLiveness, prop:FailingRecoveryLiveness, prop:CompactingResolves, prop:HandoffResolves, prop:DrainingResolves} buggy={inv:TypeOK, prop:RunningClearsManualReconcile, prop:DeadIsForever, prop:StoppedIsForever, prop:RunningRequiresFiber, prop:ManualReconcileLiveness, prop:FailingRecoveryLiveness} | 56e340f144a9 |
 | KeeperRolloverDecision.tla | KeeperRolloverDecision | manual | 2 | 1 | clean={inv:SignalGateOverflowOnly} buggy={inv:SignalGateOverflowOnly} | eb2aa357aa35 |

--- a/specs/keeper-state-machine/KeeperProactiveWakeGuard.tla
+++ b/specs/keeper-state-machine/KeeperProactiveWakeGuard.tla
@@ -1,7 +1,7 @@
 ---- MODULE KeeperProactiveWakeGuard ----
 EXTENDS Naturals
 (***************************************************************************)
-(* KeeperProactiveWakeGuard — RFC-0294 actionability invariant.            *)
+(* KeeperProactiveWakeGuard — RFC-keeper-proactive-wake-actionability-invariant actionability invariant.            *)
 (*                                                                         *)
 (* Models the keeper proactive-wake decision for a level-triggered task    *)
 (* signal (failed_task / orphan).  The bug: a signal whose only affordance *)

--- a/test/test_advisory_only_affordance_never_drives_wake.ml
+++ b/test/test_advisory_only_affordance_never_drives_wake.ml
@@ -1,4 +1,4 @@
-(** RFC-0294 T2 — advisory-only affordance never drives a proactive wake.
+(** RFC-keeper-proactive-wake-actionability-invariant T2 — advisory-only affordance never drives a proactive wake.
 
     [affordance_can_mutate] is the single source of truth for "can a keeper
     woken by this signal clear it".  This file pins:

--- a/test/test_keeper_deliberation.ml
+++ b/test/test_keeper_deliberation.ml
@@ -95,7 +95,7 @@ let test_triage_unclaimed_task () =
       check bool "contains NewUnclaimedTask" true
         (List.mem D.NewUnclaimedTask triggers)
 
-(* RFC-0294: failed_task (orphan) must NOT be an actionable triage trigger —
+(* RFC-keeper-proactive-wake-actionability-invariant: failed_task (orphan) must NOT be an actionable triage trigger —
    Task_audit is read-only, so waking on it cannot clear it (the executor
    livelock).  An orphan-only observation yields no trigger. *)
 let test_triage_failed_task_is_not_a_trigger () =
@@ -1338,7 +1338,7 @@ let () =
             test_triage_direct_mention;
           test_case "unclaimed task triggers" `Quick
             test_triage_unclaimed_task;
-          test_case "failed task is NOT a trigger (RFC-0294)" `Quick
+          test_case "failed task is NOT a trigger (RFC-keeper-proactive-wake-actionability-invariant)" `Quick
             test_triage_failed_task_is_not_a_trigger;
           test_case "keeper fiber count change triggers" `Quick
             test_triage_keeper_fiber_count_change;

--- a/test/test_keeper_failed_task_not_proactive_driver.ml
+++ b/test/test_keeper_failed_task_not_proactive_driver.ml
@@ -1,4 +1,4 @@
-(** RFC-0294 T1 — failed_task must not drive a proactive turn.
+(** RFC-keeper-proactive-wake-actionability-invariant T1 — failed_task must not drive a proactive turn.
 
     The [failed_task] signal grants only the read-only [Task_audit] affordance
     (tools keeper_tasks_audit / keeper_tasks_list / masc_tasks), so a keeper

--- a/test/test_keeper_failed_task_orphan_does_not_livelock.ml
+++ b/test/test_keeper_failed_task_orphan_does_not_livelock.ml
@@ -1,4 +1,4 @@
-(** RFC-0294 T3 — a static orphan does not produce a self-cadence livelock.
+(** RFC-keeper-proactive-wake-actionability-invariant T3 — a static orphan does not produce a self-cadence livelock.
 
     Reproduces the executor incident shape (2026-06-21..24): a static
     [failed_task_count > 0] with nothing claimable, re-evaluated on the keeper's


### PR DESCRIPTION
## 목표

main에 **서로 다른 RFC 두 개가 0294 번호를 공유**하는 SSOT 위반을 해소합니다.

- `docs/rfc/RFC-0294-purge-workspace-goal-horizon.md` (#22210, 먼저 머지)
- `docs/rfc/RFC-0294-keeper-proactive-wake-actionability-invariant.md` (#22214, 나중 머지)

## 왜 생겼나 / 왜 CI가 못 잡았나

#22198이 RFC 번호 할당을 제거(forward slug-only)했습니다. `scripts/pr_axis_check.py`의 `detect_rfc_collisions`는 주석(L48–53) 그대로 **concurrent open PR만** 스캔하므로, 한쪽(#22210)이 머지된 뒤 다른쪽(#22214)이 같은 번호로 land하는 merged-vs-open 충돌은 가드 밖입니다. (#22214 리뷰 때 예측했고 그대로 land했습니다.)

## 변경 (반경 포함)

나중 도착한 proactive-wake RFC를 slug-only로 재명명, goal-horizon을 유일한 RFC-0294로 남깁니다.

- `git mv RFC-0294-keeper-proactive-wake-actionability-invariant.md → RFC-keeper-proactive-wake-actionability-invariant.md` (frontmatter `rfc:` slug, title heading).
- proactive-wake를 뜻하는 "RFC-0294" 인용 13건 전부 slug로 갱신: lib/keeper 5파일(.ml/.mli 주석·docstring), test 4파일(docstring·test-case 이름 문자열), TLA spec 1파일. **13건 모두 proactive-wake** — goal-horizon 참조는 손대지 않아 남은 RFC-0294 참조는 모두 비모호.

**코멘트/문자열 전용 — 로직 변경 0.** `rfc_enforcer` 로컬 통과.

## CI 주의

Build는 **#22219(`drop purged proof_store.ml dep`) 머지 전까지 red**입니다 — `test/dune`의 dangling `proof_store.ml` dep가 dune을 깨는 main breakage(이 변경과 무관). #22219 머지 후 rebase하면 green 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
