### PR TITLE
feat(goal): purge workspace-goal horizon — implementation (RFC-0294, recovers #22210)

### DIFF
--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -57,7 +57,6 @@ function makeRawGoalNode(overrides: Record<string, unknown> = {}) {
   return {
     id: 'goal-1',
     title: 'Goal 1',
-    horizon: 'quarterly',
     status: 'active',
     status_color: '#fff',
     phase: 'executing',
@@ -1679,7 +1678,7 @@ describe('fetchKeeperConfig', () => {
         bound_workspace_ids: 'default',
         active_goal_ids: ['goal-runtime'],
         active_goals: [
-          { id: 'goal-runtime', title: 'Ship runtime clarity', horizon: 'mid' },
+          { id: 'goal-runtime', title: 'Ship runtime clarity' },
         ],
         active_goal_count: '1',
         missing_active_goal_ids: [],

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -1615,7 +1615,6 @@ function decodeGoalTreeNode(raw: unknown): GoalTreeNode | null {
   return {
     id,
     title,
-    horizon: asString(raw.horizon, 'unknown'),
     status: asString(raw.status, 'unknown'),
     status_color: asString(raw.status_color, ''),
     phase: asString(raw.phase, 'unknown'),
@@ -2262,9 +2261,8 @@ function normalizeKeeperConfigActiveGoals(raw: unknown): KeeperConfig['workspace
     .map((item) => {
       const id = asNullableString(item.id)
       const title = asNullableString(item.title)
-      const horizon = asNullableString(item.horizon)
-      if (!id || !title || !horizon) return null
-      return { id, title, horizon }
+      if (!id || !title) return null
+      return { id, title }
     })
     .filter((item): item is KeeperConfig['workspace']['active_goals'][number] => item !== null)
 }

--- a/dashboard/src/components/goal-loop-panel.test.ts
+++ b/dashboard/src/components/goal-loop-panel.test.ts
@@ -208,9 +208,6 @@ describe('GoalLoopPanel', () => {
     fireEvent.input(screen.getByLabelText('Goal title'), {
       target: { value: 'Stabilize runtime truth' },
     })
-    fireEvent.change(screen.getByLabelText('Horizon'), {
-      target: { value: 'mid' },
-    })
     fireEvent.change(screen.getByLabelText('Priority'), {
       target: { value: '2' },
     })
@@ -219,7 +216,6 @@ describe('GoalLoopPanel', () => {
     await waitFor(() => {
       expect(mocks.callMcpTool).toHaveBeenCalledWith('masc_goal_upsert', {
         title: 'Stabilize runtime truth',
-        horizon: 'mid',
         priority: 2,
       })
     })

--- a/dashboard/src/components/goal-loop-panel.ts
+++ b/dashboard/src/components/goal-loop-panel.ts
@@ -35,19 +35,11 @@ interface GoalLoopPanelProps {
   initialStatus?: GoalLoopStatusResponse
 }
 
-type GoalHorizon = 'short' | 'mid' | 'long'
-
 interface CreatedGoal {
   title: string
   goalId: string | null
   taskLinkField: string | null
 }
-
-const GOAL_HORIZON_OPTIONS = [
-  { value: 'short', label: 'Short' },
-  { value: 'mid', label: 'Mid' },
-  { value: 'long', label: 'Long' },
-]
 
 const GOAL_PRIORITY_OPTIONS = [
   { value: '1', label: 'P1' },
@@ -272,7 +264,6 @@ function parseGoalUpsertResult(text: string): Omit<CreatedGoal, 'title'> {
 
 function GoalCreateBlock({ onCreated }: { onCreated: () => void }) {
   const [title, setTitle] = useState('')
-  const [horizon, setHorizon] = useState<GoalHorizon>('short')
   const [priority, setPriority] = useState('3')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -290,13 +281,11 @@ function GoalCreateBlock({ onCreated }: { onCreated: () => void }) {
     setCreated(null)
     void callMcpTool('masc_goal_upsert', {
       title: trimmedTitle,
-      horizon,
       priority: Number(priority),
     })
       .then((resultText) => {
         const upsertResult = parseGoalUpsertResult(resultText)
         setTitle('')
-        setHorizon('short')
         setPriority('3')
         setCreated({
           title: trimmedTitle,
@@ -312,11 +301,11 @@ function GoalCreateBlock({ onCreated }: { onCreated: () => void }) {
         setError(errorToString(err))
       })
       .finally(() => setSubmitting(false))
-  }, [horizon, onCreated, priority, title])
+  }, [onCreated, priority, title])
 
   return html`
     <${SectionCard} label="Create Goal" data-testid="goal-loop-create-goal">
-      <form class="grid gap-3 md:grid-cols-[minmax(0,1fr)_8rem_6rem_auto]" onSubmit=${submit}>
+      <form class="grid gap-3 md:grid-cols-[minmax(0,1fr)_6rem_auto]" onSubmit=${submit}>
         <label class="flex min-w-0 flex-col gap-1 text-2xs font-medium text-[var(--color-fg-muted)]">
           Title
           <${TextInput}
@@ -325,15 +314,6 @@ function GoalCreateBlock({ onCreated }: { onCreated: () => void }) {
             ariaLabel="Goal title"
             disabled=${submitting}
             onInput=${(e: Event) => setTitle((e.target as HTMLInputElement).value)}
-          />
-        </label>
-        <label class="flex min-w-0 flex-col gap-1 text-2xs font-medium text-[var(--color-fg-muted)]">
-          Horizon
-          <${Select}
-            value=${horizon}
-            options=${GOAL_HORIZON_OPTIONS}
-            disabled=${submitting}
-            onInput=${(next: string) => setHorizon(next as GoalHorizon)}
           />
         </label>
         <label class="flex min-w-0 flex-col gap-1 text-2xs font-medium text-[var(--color-fg-muted)]">

--- a/dashboard/src/components/goals/goal-helpers.test.ts
+++ b/dashboard/src/components/goals/goal-helpers.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
   priorityStars,
-  horizonLabel,
-  horizonColor,
   priorityLabel,
   phaseFilterLabel,
   matchesGoalPhaseFilter,
@@ -39,50 +37,6 @@ describe('priorityStars', () => {
 
   it('returns 3 filled + 2 empty for 3', () => {
     expect(priorityStars(3)).toBe('\u2605\u2605\u2605\u2606\u2606')
-  })
-})
-
-// ================================================================
-// horizonLabel
-// ================================================================
-
-describe('horizonLabel', () => {
-  it('returns 단기 for short', () => {
-    expect(horizonLabel('short')).toBe('단기')
-  })
-
-  it('returns 중기 for mid', () => {
-    expect(horizonLabel('mid')).toBe('중기')
-  })
-
-  it('returns 장기 for long', () => {
-    expect(horizonLabel('long')).toBe('장기')
-  })
-
-  it('returns raw value for unknown', () => {
-    expect(horizonLabel('custom')).toBe('custom')
-  })
-})
-
-// ================================================================
-// horizonColor
-// ================================================================
-
-describe('horizonColor', () => {
-  it('returns green for short', () => {
-    expect(horizonColor('short')).toBe('var(--color-status-ok)')
-  })
-
-  it('returns amber for mid', () => {
-    expect(horizonColor('mid')).toBe('var(--amber-bright)')
-  })
-
-  it('returns indigo for long', () => {
-    expect(horizonColor('long')).toBe('var(--indigo)')
-  })
-
-  it('returns muted for unknown', () => {
-    expect(horizonColor('unknown')).toBe('var(--color-fg-muted)')
   })
 })
 

--- a/dashboard/src/components/goals/goal-helpers.ts
+++ b/dashboard/src/components/goals/goal-helpers.ts
@@ -10,7 +10,6 @@ import type { Goal, Task } from '../../types'
 
 // -- Filter state ------------------------------------------------
 
-type HorizonFilter = 'all' | 'short' | 'mid' | 'long'
 export type GoalPhaseFilter =
   | 'all'
   | 'executing'
@@ -20,9 +19,6 @@ export type GoalPhaseFilter =
   | 'paused'
   | 'completed'
   | 'dropped'
-
-const horizonFilter = signal<HorizonFilter>('all')
-const phaseFilter = signal<GoalPhaseFilter>('all')
 
 // -- Task-level search (case-insensitive, title + description + assignee) --
 
@@ -58,28 +54,6 @@ export function toggleTaskExpand(id: string) {
   else next.add(id)
   expandedTasks.value = next
 }
-
-// -- Derived data ------------------------------------------------
-
-const filteredGoals = computed(() => {
-  let list = goals.value
-  if (horizonFilter.value !== 'all') {
-    list = list.filter(g => g.horizon === horizonFilter.value)
-  }
-  if (phaseFilter.value !== 'all') {
-    list = list.filter(g => g.phase === phaseFilter.value)
-  }
-  return list
-})
-
-export const groupedByHorizon = computed(() => {
-  const groups: Record<string, Goal[]> = { short: [], mid: [], long: [] }
-  for (const g of filteredGoals.value) {
-    const bucket = groups[g.horizon]
-    if (bucket) bucket.push(g)
-  }
-  return groups
-})
 
 // -- Lookups -----------------------------------------------------
 
@@ -134,39 +108,6 @@ export function goalProgressFor(goalId: string): GoalProgress {
   return goalProgressMap.value.get(goalId) ?? ZERO_PROGRESS
 }
 
-export const horizonProgress = computed<Record<'short' | 'mid' | 'long', GoalProgress>>(() => {
-  const goalsByHorizon: Record<'short' | 'mid' | 'long', Set<string>> = {
-    short: new Set(),
-    mid: new Set(),
-    long: new Set(),
-  }
-  for (const g of goals.value) {
-    const bucket = goalsByHorizon[g.horizon as 'short' | 'mid' | 'long']
-    if (bucket) bucket.add(g.id)
-  }
-  const acc: Record<'short' | 'mid' | 'long', GoalProgress> = {
-    short: { done: 0, total: 0, ratio: 0 },
-    mid: { done: 0, total: 0, ratio: 0 },
-    long: { done: 0, total: 0, ratio: 0 },
-  }
-  for (const t of tasks.value) {
-    const gid = t.goal_id
-    if (!gid || !isCountedTask(t)) continue
-    for (const h of ['short', 'mid', 'long'] as const) {
-      if (goalsByHorizon[h].has(gid)) {
-        acc[h].total += 1
-        if (isDoneTask(t)) acc[h].done += 1
-        break
-      }
-    }
-  }
-  for (const h of ['short', 'mid', 'long'] as const) {
-    const bucket = acc[h]
-    bucket.ratio = bucket.total > 0 ? bucket.done / bucket.total : 0
-  }
-  return acc
-})
-
 export function formatProgressPct(p: GoalProgress): string {
   if (p.total === 0) return '0%'
   return `${Math.round(p.ratio * 100)}%`
@@ -196,24 +137,6 @@ export function TaskProgressBar({ done, total, size = 'md' }: { done: number; to
 
 export function priorityStars(n: number): string {
   return '\u2605'.repeat(Math.min(n, 5)) + '\u2606'.repeat(Math.max(0, 5 - n))
-}
-
-export function horizonLabel(h: string): string {
-  switch (h) {
-    case 'short': return '단기'
-    case 'mid': return '중기'
-    case 'long': return '장기'
-    default: return h
-  }
-}
-
-export function horizonColor(h: string): string {
-  switch (h) {
-    case 'short': return 'var(--color-status-ok)'
-    case 'mid': return 'var(--amber-bright)'
-    case 'long': return 'var(--indigo)'
-    default: return 'var(--color-fg-muted)'
-  }
 }
 
 export function goalPhaseLabel(phase: string): string {

--- a/dashboard/src/components/goals/goal-tree.test.ts
+++ b/dashboard/src/components/goals/goal-tree.test.ts
@@ -72,7 +72,6 @@ function makeGoal(id: string, title: string, children: GoalTreeNode[] = []): Goa
   return {
     id,
     title,
-    horizon: 'short',
     status: 'active',
     status_color: '',
     phase: 'executing',

--- a/dashboard/src/components/goals/goal-tree.ts
+++ b/dashboard/src/components/goals/goal-tree.ts
@@ -42,8 +42,6 @@ import type {
   GoalVerificationSummary,
 } from '../../types'
 import {
-  horizonLabel,
-  horizonColor,
   priorityStars,
   countAwaitingVerificationTasks,
   countAwaitingVerificationInTree,
@@ -1017,12 +1015,6 @@ function TreeNode({ node, depth }: { node: GoalTreeNode; depth: number }) {
 
         <div class="min-w-0 flex-1">
           <div class="mb-1 flex flex-wrap items-center gap-2">
-            <span
-              class="shrink-0 rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-bold uppercase tracking-[var(--track-caps)]"
-              style="color:${horizonColor(node.horizon)}"
-            >
-              ${horizonLabel(node.horizon)}
-            </span>
             <${StatusBadge} status=${goalPhaseStatus(node.phase)} label=${goalPhaseLabel(node.phase)} />
             <${GoalFsmBadge} fsm=${node.goal_fsm} />
             <span class="break-words text-base font-semibold text-text-strong line-clamp-2">${node.title}</span>
@@ -1402,9 +1394,6 @@ function GoalDetailPanel({
             <${StatusBadge} status=${selectedNode.status} />
             <${StatusBadge} status=${goalPhaseStatus(selectedNode.phase)} label=${goalPhaseLabel(selectedNode.phase)} />
             <${GoalFsmBadge} fsm=${selectedNode.goal_fsm} />
-            <span class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 text-3xs font-semibold uppercase tracking-[var(--track-caps)]" style="color:${horizonColor(selectedNode.horizon)}">
-              ${horizonLabel(selectedNode.horizon)}
-            </span>
             ${selectedNode.metric ? html`
               <span
                 class="rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 font-mono text-3xs text-text-secondary"

--- a/dashboard/src/components/goals/planning.ts
+++ b/dashboard/src/components/goals/planning.ts
@@ -15,25 +15,19 @@ import {
 } from '../../store'
 import { navigate } from '../../router'
 import {
-  groupedByHorizon,
-  horizonProgress,
-  formatProgressPct,
   goalProgressFor,
   TaskProgressBar,
-  horizonLabel,
   goalPhaseLabel,
 } from './goal-helpers'
 import { TaskBacklog } from './kanban-components'
 import { TaskStaleAlert } from './task-stale-alert'
 import { TaskWall } from './task-wall'
 import { TaskCreateForm } from '../task-manage/task-create-form'
-import { DECK_CHIP, DECK_LABEL, DECK_META, DECK_PANEL } from './deck-classes'
+import { DECK_CHIP, DECK_LABEL, DECK_PANEL } from './deck-classes'
 
 const QUICK_START_DOC_URL = 'https://github.com/jeong-sik/masc/blob/main/docs/QUICK-START.md'
 const DECK_HEAD = 'flex flex-wrap items-start justify-between gap-3 border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2.5 shadow-[inset_0_2px_0_var(--color-accent-fg)]'
 const DECK_CARD = 'rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3'
-const BRASS_CHIP = 'rounded-[var(--r-0)] border border-[var(--color-brass-border)] bg-[var(--color-brass-soft)] px-1.5 py-0.5 font-mono text-3xs text-[var(--color-accent-fg)]'
-
 function PlanningStat({
   label,
   value,
@@ -208,8 +202,6 @@ export function Planning() {
   const totalTasks = todo.length + inProgress.length + done.length
   const highPriority = [...todo, ...inProgress].filter(t => (t.priority ?? 4) <= 2).length
 
-  const grouped = groupedByHorizon.value
-  const hp = horizonProgress.value
   const hasGoals = goals.value.length > 0
   const onlyBacklogActive = totalTasks > 0 && !hasGoals
   const planStatusHeadline = onlyBacklogActive
@@ -269,7 +261,7 @@ export function Planning() {
               title="장기 목표 파이프라인"
               count=${goals.value.length}
               summary=${hasGoals
-                ? '등록된 목표를 단기/중기/장기로 나눠 추적합니다.'
+                ? '등록된 목표를 우선순위 순으로 추적합니다.'
                 : '등록된 목표가 없습니다. 목표를 등록하면 여기에 표시됩니다.'}
               docHref=${QUICK_START_DOC_URL}
               docLabel="빠른 시작"
@@ -307,112 +299,26 @@ export function Planning() {
         </div>
         ${hasGoals ? html`
           <div class="flex flex-col gap-2 p-3">
-            <div class="flex flex-wrap gap-1.5">
-              ${(grouped.short ?? []).length > 0 ? html`
-                <span class="rounded-[var(--r-0)] border border-ok/25 bg-ok/10 px-1.5 py-0.5 font-mono text-3xs text-ok">
-                  단기 ${(grouped.short ?? []).length}${hp.short.total > 0 ? ` · ${hp.short.done}/${hp.short.total} (${formatProgressPct(hp.short)})` : ''}
-                </span>
-              ` : null}
-              ${(grouped.mid ?? []).length > 0 ? html`
-                <span class="rounded-[var(--r-0)] border border-warn/25 bg-warn/10 px-1.5 py-0.5 font-mono text-3xs text-warn">
-                  중기 ${(grouped.mid ?? []).length}${hp.mid.total > 0 ? ` · ${hp.mid.done}/${hp.mid.total} (${formatProgressPct(hp.mid)})` : ''}
-                </span>
-              ` : null}
-              ${(grouped.long ?? []).length > 0 ? html`
-                <span class="${BRASS_CHIP}">
-                  장기 ${(grouped.long ?? []).length}${hp.long.total > 0 ? ` · ${hp.long.done}/${hp.long.total} (${formatProgressPct(hp.long)})` : ''}
-                </span>
-              ` : null}
-            </div>
-            ${(hp.short.total + hp.mid.total + hp.long.total) > 0 ? html`
-              <div class="flex flex-col gap-1">
-                ${hp.short.total > 0 ? html`
-                  <div class="flex items-center gap-2 text-3xs">
-                    <span class="${DECK_META} w-8 shrink-0">단기</span>
-                    <div
-                      class="relative h-1 grow overflow-hidden rounded-[var(--r-0)] bg-[var(--color-bg-elevated)]"
-                      role="progressbar"
-                      aria-valuenow=${Math.round(hp.short.ratio * 100)}
-                      aria-valuemin="0"
-                      aria-valuemax="100"
-                      aria-label=${`단기 목표 진행 ${hp.short.done}/${hp.short.total}`}
-                    >
-                      <div
-                        class="absolute inset-y-0 left-0 bg-ok"
-                        style=${`width: ${(hp.short.ratio * 100).toFixed(1)}%`}
-                      ></div>
-                    </div>
-                  </div>
-                ` : null}
-                ${hp.mid.total > 0 ? html`
-                  <div class="flex items-center gap-2 text-3xs">
-                    <span class="${DECK_META} w-8 shrink-0">중기</span>
-                    <div
-                      class="relative h-1 grow overflow-hidden rounded-[var(--r-0)] bg-[var(--color-bg-elevated)]"
-                      role="progressbar"
-                      aria-valuenow=${Math.round(hp.mid.ratio * 100)}
-                      aria-valuemin="0"
-                      aria-valuemax="100"
-                      aria-label=${`중기 목표 진행 ${hp.mid.done}/${hp.mid.total}`}
-                    >
-                      <div
-                        class="absolute inset-y-0 left-0 bg-warn"
-                        style=${`width: ${(hp.mid.ratio * 100).toFixed(1)}%`}
-                      ></div>
-                    </div>
-                  </div>
-                ` : null}
-                ${hp.long.total > 0 ? html`
-                  <div class="flex items-center gap-2 text-3xs">
-                    <span class="${DECK_META} w-8 shrink-0">장기</span>
-                    <div
-                      class="relative h-1 grow overflow-hidden rounded-[var(--r-0)] bg-[var(--color-bg-elevated)]"
-                      role="progressbar"
-                      aria-valuenow=${Math.round(hp.long.ratio * 100)}
-                      aria-valuemin="0"
-                      aria-valuemax="100"
-                      aria-label=${`장기 목표 진행 ${hp.long.done}/${hp.long.total}`}
-                    >
-                      <div
-                        class="absolute inset-y-0 left-0 bg-[var(--color-accent-fg)]"
-                        style=${`width: ${(hp.long.ratio * 100).toFixed(1)}%`}
-                      ></div>
-                    </div>
-                  </div>
-                ` : null}
-              </div>
-            ` : null}
-            <div class="mt-3 flex flex-col gap-2">
-              ${(['short', 'mid', 'long'] as const).map(h => {
-                const list = grouped[h] ?? []
-                if (list.length === 0) return null
+            ${/* RFC-0294: flat priority-sorted list replaces horizon grouping */
+            [...goals.value]
+              .sort((a, b) => (a.priority ?? 4) - (b.priority ?? 4) || (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
+              .map(g => {
+                const p = goalProgressFor(g.id)
                 return html`
-                  <div key=${h}>
-                    <div class="${DECK_LABEL} mb-1.5">
-                      ${horizonLabel(h)} 목표
+                  <div key=${g.id} class="flex items-center gap-2 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1.5">
+                    <div class="min-w-0 flex-1">
+                      <div class="flex items-center gap-2">
+                        <span class="truncate text-xs font-medium text-[var(--color-fg-primary)]">${g.title}</span>
+                        <span class="${DECK_CHIP} shrink-0 text-[var(--color-fg-muted)]">${goalPhaseLabel(g.phase)}</span>
+                      </div>
                     </div>
-                    <div class="flex flex-col gap-1.5">
-                      ${list.map(g => {
-                        const p = goalProgressFor(g.id)
-                        return html`
-                          <div key=${g.id} class="flex items-center gap-2 rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-1.5">
-                            <div class="min-w-0 flex-1">
-                              <div class="flex items-center gap-2">
-                                <span class="truncate text-xs font-medium text-[var(--color-fg-primary)]">${g.title}</span>
-                                <span class="${DECK_CHIP} shrink-0 text-[var(--color-fg-muted)]">${goalPhaseLabel(g.phase)}</span>
-                              </div>
-                            </div>
-                            <div class="w-28">
-                              <${TaskProgressBar} done=${p.done} total=${p.total} size="sm" />
-                            </div>
-                          </div>
-                        `
-                      })}
+                    <div class="w-28">
+                      <${TaskProgressBar} done=${p.done} total=${p.total} size="sm" />
                     </div>
                   </div>
                 `
-              })}
-            </div>
+              })
+            }
           </div>
         ` : html`
           <p class="p-3 text-xs text-[var(--color-fg-muted)]">등록된 목표가 없습니다. 목표 트리에서 추가할 수 있습니다.</p>

--- a/dashboard/src/components/goals/task-detail-state.test.ts
+++ b/dashboard/src/components/goals/task-detail-state.test.ts
@@ -103,7 +103,6 @@ describe('filterTaskEvents', () => {
 function makeGoal(overrides: Partial<Goal> = {}): Goal {
   return {
     id: 'g-1',
-    horizon: 'short',
     title: 'default title',
     metric: null,
     target_value: null,

--- a/dashboard/src/components/ide/ide-activity-panel.test.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.test.ts
@@ -572,7 +572,6 @@ describe('IdeActivityPanel', () => {
   it('renders active run goal progress from activity goal and task links', async () => {
     goals.value = [{
       id: 'goal-runtime',
-      horizon: 'short',
       title: 'Runtime goal',
       metric: 'green CI',
       target_value: 'merged',
@@ -846,7 +845,6 @@ describe('IdeActivityPanel', () => {
       'lib/runtime.ml',
       [{
         id: 'goal-runtime',
-        horizon: 'short',
         title: 'Runtime goal',
         priority: 1,
         status: 'active',

--- a/dashboard/src/components/ide/ide-activity-panel.ts
+++ b/dashboard/src/components/ide/ide-activity-panel.ts
@@ -14,7 +14,6 @@ import { goals, tasks } from '../../store'
 import {
   formatProgressPct,
   goalPhaseLabel,
-  horizonLabel,
   type GoalProgress,
 } from '../goals/goal-helpers'
 import { ideConversationThreadSnapshot } from './ide-context-bridge'
@@ -148,7 +147,6 @@ export interface IdeRunProgressGoal {
   readonly goalId: string
   readonly taskId: string | null
   readonly title: string
-  readonly horizon: string
   readonly phase: string
   readonly progress: GoalProgress
   readonly progressLabel: string
@@ -716,7 +714,7 @@ function RunProgressGoalTrack(goal: IdeRunProgressGoal) {
     >
       <div class="ide-run-progress-goal-top">
         <span>GOAL TRACK</span>
-        <span>${goal.horizon} · ${goal.phase}</span>
+        <span>${goal.phase}</span>
       </div>
       <strong title=${goal.title}>${goal.title}</strong>
       <div class="ide-run-progress-goal-bar" aria-hidden="true">
@@ -781,7 +779,6 @@ function activeRunGoal(
     goalId,
     taskId: hit.taskId,
     title: goal?.title ?? goalId,
-    horizon: goal ? horizonLabel(goal.horizon) : 'unknown',
     phase: goal ? goalPhaseLabel(goal.phase) : 'unknown',
     progress,
     progressLabel: formatProgressPct(progress),

--- a/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
@@ -221,7 +221,6 @@ function taskFixture(partial: Partial<Task> = {}): Task {
 function goalFixture(partial: Partial<Goal> = {}): Goal {
   return {
     id: 'goal-runtime',
-    horizon: 'short',
     title: 'Runtime goal',
     metric: 'green CI',
     target_value: '100%',

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -8,7 +8,6 @@ import {
   formatProgressPct,
   goalPhaseLabel,
   goalProgressFor,
-  horizonLabel,
   type GoalProgress,
 } from '../goals/goal-helpers'
 import {
@@ -196,7 +195,7 @@ function GoalProgressCard(
     <div class="ide-keeper-work-goal v2-ide-card" role="status" aria-label=${`Goal ${goal.id} progress ${pctLabel}`}>
       <div class="ide-keeper-work-card-top">
         <span>GOAL PROGRESS</span>
-        <span>${horizonLabel(goal.horizon)} · ${goalPhaseLabel(goal.phase)}</span>
+        <span>${goalPhaseLabel(goal.phase)}</span>
       </div>
       <strong title=${goal.title}>${goal.title}</strong>
       <div class="ide-keeper-work-goal-bar" aria-hidden="true">

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -99,7 +99,7 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
       bound_workspace_ids: ['default'],
       active_goal_ids: ['goal-runtime'],
       active_goals: [
-        { id: 'goal-runtime', title: 'Ship runtime clarity', horizon: 'mid' },
+        { id: 'goal-runtime', title: 'Ship runtime clarity' },
       ],
       active_goal_count: 1,
       missing_active_goal_ids: [],
@@ -440,7 +440,7 @@ describe('buildRuntimePayload — sandbox diffing', () => {
         mention_targets: [],
         bound_workspace_ids: [],
         active_goal_ids: ['goal-a'],
-        active_goals: [{ id: 'goal-a', title: 'Goal A', horizon: 'short' }],
+        active_goals: [{ id: 'goal-a', title: 'Goal A' }],
         active_goal_count: 1,
         missing_active_goal_ids: [],
       },
@@ -514,7 +514,6 @@ const mocks = vi.hoisted(() => ({
       {
         id: 'goal-runtime',
         title: 'Ship runtime clarity',
-        horizon: 'mid',
         status: 'active',
         status_color: '#4ade80',
         phase: 'executing',

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -1060,7 +1060,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     ` : null}
   `
 
-  // prompt ¶ — edit toolbar + horizon goals + instructions + system prompt preview
+  // prompt ¶ — edit toolbar + active goals + instructions + system prompt preview
   const promptTab = html`
     ${toolbar}
     ${promptSection}
@@ -1299,7 +1299,6 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
   `
 
   // goals ◎ — assigned goal-store bindings (active_goal_ids picker)
-  const horizonLabel = (h: string): string => (h === 'short' ? '단기' : h === 'long' ? '장기' : h === 'mid' ? '중기' : h)
   const goalsTab = html`
     <${KcfSec}
       title="배정 목표"
@@ -1328,7 +1327,6 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
                     <span class="kcf-goal-title">${goal.title}</span>
                     <span class="kcf-goal-id mono">${goal.id}</span>
                   </span>
-                  <span class=${`kcf-goal-hz hz-${goal.horizon}`}>${horizonLabel(goal.horizon)}</span>
                 </button>
               `
             })}

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -782,7 +782,6 @@ describe('Overview StyleSeed surfaces', () => {
 function makeGoal(partial: Partial<Goal>): Goal {
   return {
     id: 'g-1',
-    horizon: 'mid',
     title: 'goal',
     priority: 5,
     status: 'active',

--- a/dashboard/src/components/planning-panel.test.ts
+++ b/dashboard/src/components/planning-panel.test.ts
@@ -182,7 +182,6 @@ describe('PlanningPanel', () => {
     goalsSignal.value = [
       {
         id: 'goal-runtime',
-        horizon: 'short',
         title: 'Runtime context goal',
         priority: 1,
         status: 'active',
@@ -289,7 +288,6 @@ describe('PlanningPanel', () => {
     goalsSignal.value = [
       {
         id: 'goal-ledger',
-        horizon: 'short',
         title: 'Verifier readiness',
         priority: 1,
         status: 'active',

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -52,7 +52,6 @@ vi.mock('./repository-management', () => ({
 }))
 
 import { goals, keepers, tasks } from '../store'
-import type { Goal } from '../types'
 import { Work } from './work'
 
 describe('Work', () => {
@@ -142,8 +141,8 @@ describe('Work', () => {
 
     it('renders the reference 5 KPI counts from goals and tasks', () => {
       goals.value = [
-        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
-        { id: 'G-2', horizon: 'mid', title: 'Goal Two', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-2', title: 'Goal Two', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = [
         { id: 'J-1', title: 'Job one', goal_id: 'G-1', status: 'done' },
@@ -161,12 +160,12 @@ describe('Work', () => {
       expect(screen.getByTestId('kpi-verify').textContent).toBe('1')
       expect(screen.getByTestId('kpi-backlog').textContent).toBe('2')
       expect(screen.getByText(/백로그에서 claim/).textContent).toContain('claim')
-      expect(screen.getAllByTestId('work-horizon').map(section => section.getAttribute('data-horizon'))).toEqual(['short', 'mid'])
+      expect(screen.getByTestId('work-goal-list')).toBeTruthy()
     })
 
     it('renders the reference new-goal placeholder button', () => {
       goals.value = [
-        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
 
       render(html`<${Work} />`)
@@ -178,7 +177,7 @@ describe('Work', () => {
 
     it('renders a collapsed goal card per goal and expands on click', () => {
       goals.value = [
-        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = [
         { id: 'J-1', title: 'Job one', goal_id: 'G-1', status: 'in_progress' },
@@ -196,23 +195,21 @@ describe('Work', () => {
       expect(screen.getByText('Job one')).toBeTruthy()
     })
 
-    it('keeps goals with unexpected wire horizons visible in the fallback bucket', () => {
+    it('renders all goals in a flat list regardless of any legacy horizon field', () => {
       goals.value = [
-        { id: 'G-X', horizon: 'quarterly' as unknown as Goal['horizon'], title: 'Unexpected horizon goal', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-X', title: 'Goal visible in flat list', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = []
 
       render(html`<${Work} />`)
 
-      const horizon = screen.getByTestId('work-horizon')
-      expect(horizon.getAttribute('data-horizon')).toBe('long')
-      expect(screen.getByText('Unexpected horizon goal')).toBeTruthy()
-      expect(horizon.textContent).toContain('장기')
+      expect(screen.getByTestId('work-goal-list')).toBeTruthy()
+      expect(screen.getByText('Goal visible in flat list')).toBeTruthy()
     })
 
     it('renders job rows with state, id, title, and blocker note', () => {
       goals.value = [
-        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = [
         { id: 'J-1', title: 'Blocked job', goal_id: 'G-1', status: 'cancelled', handoff_context: { summary: '', reason: 'dependency missing' } },
@@ -235,7 +232,7 @@ describe('Work', () => {
 
     it('navigates to keeper workspace when keeper assignment is clicked', () => {
       goals.value = [
-        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = [
         { id: 'J-1', title: 'Assigned job', goal_id: 'G-1', status: 'in_progress', assignee: 'sangsu' },
@@ -257,7 +254,7 @@ describe('Work', () => {
 
     it('surfaces claimable backlog tasks in a dedicated backlog section', () => {
       goals.value = [
-        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = [
         { id: 'J-1', title: 'Linked job', goal_id: 'G-1', status: 'todo' },
@@ -280,7 +277,7 @@ describe('Work', () => {
 
     it('expands inline task detail for gate evidence and handoff context', () => {
       goals.value = [
-        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = [
         {
@@ -319,7 +316,7 @@ describe('Work', () => {
 
     it('renders all defined gate evaluations including verify_to_review', () => {
       goals.value = [
-        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = [
         {
@@ -349,8 +346,8 @@ describe('Work', () => {
 
     it('maps known goal status IDs to Korean labels', () => {
       goals.value = [
-        { id: 'G-1', horizon: 'short', title: 'Active goal', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
-        { id: 'G-2', horizon: 'mid', title: 'Completed goal', priority: 3, status: 'completed', phase: 'done', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-1', title: 'Active goal', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-2', title: 'Completed goal', priority: 3, status: 'completed', phase: 'done', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = []
 
@@ -365,10 +362,10 @@ describe('Work', () => {
     // prototype's ok/warn/bad/volt color rules (work-v2.css) apply.
     it('applies the semantic status variant class to the goal status chip', () => {
       goals.value = [
-        { id: 'G-ok', horizon: 'short', title: 'Active', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
-        { id: 'G-warn', horizon: 'short', title: 'At risk', priority: 2, status: 'at_risk', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
-        { id: 'G-bad', horizon: 'short', title: 'Blocked', priority: 2, status: 'blocked', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
-        { id: 'G-volt', horizon: 'short', title: 'Verifying', priority: 2, status: 'verifying', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-ok', title: 'Active', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-warn', title: 'At risk', priority: 2, status: 'at_risk', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-bad', title: 'Blocked', priority: 2, status: 'blocked', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-volt', title: 'Verifying', priority: 2, status: 'verifying', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = []
 
@@ -384,7 +381,7 @@ describe('Work', () => {
 
     it('falls back to the ok status variant for unknown goal statuses', () => {
       goals.value = [
-        { id: 'G-x', horizon: 'short', title: 'Mystery', priority: 2, status: 'something_new', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-x', title: 'Mystery', priority: 2, status: 'something_new', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = []
 
@@ -402,7 +399,6 @@ describe('Work', () => {
       goals.value = [
         {
           id: 'G-1',
-          horizon: 'short',
           title: 'Goal needing approval',
           priority: 9,
           // 'active' status does not auto-expand on mount (work.ts:403 only
@@ -443,7 +439,7 @@ describe('Work', () => {
         postId: null,
       }
       goals.value = [
-        { id: 'G-1', horizon: 'short', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
       tasks.value = [
         { id: 'J-1', title: 'Selectable job', goal_id: 'G-1', status: 'todo' },

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1,5 +1,5 @@
 // MASC Dashboard — Work Tab (keeper-v2 goal/task layout)
-// Surface: horizon buckets, Task terminology, inline expandable gate detail,
+// Surface: Goal list (priority-sorted), Task terminology, inline expandable gate detail,
 // claimable backlog, and the 5 KPI strip from the reference design.
 
 import { html } from 'htm/preact'
@@ -126,26 +126,6 @@ const GATE_OUTCOME_LABEL: Record<'satisfied' | 'missing' | 'failed', string> = {
   satisfied: '충족',
   missing: '누락',
   failed: '실패',
-}
-
-// ── Goal horizon mapping ────────────────────────────────────────────────────
-
-interface HorizonMeta {
-  key: Goal['horizon']
-  label: string
-  sub: string
-}
-
-const LONG_HORIZON_META: HorizonMeta = { key: 'long', label: '장기', sub: '방향' }
-
-const HORIZON_META: HorizonMeta[] = [
-  { key: 'short', label: '단기', sub: '매 사이클 · 즉시' },
-  { key: 'mid', label: '중기', sub: '이번 분기' },
-  LONG_HORIZON_META,
-]
-
-function horizonKeyForGoal(goal: Goal): Goal['horizon'] {
-  return HORIZON_META.some(h => h.key === goal.horizon) ? goal.horizon : 'long'
 }
 
 // ── Keeper lookup ───────────────────────────────────────────────────────────
@@ -345,8 +325,7 @@ function GoalCard({
         <span class="wk-goal-title">${goal.title}</span>
         <!-- Prototype shows a namespace pill (.wk-goal-ns) here from g.ns.
              The live Goal type has no namespace/ns field (types/core.ts:603),
-             so rather than fake it with the redundant horizon label (the card
-             already sits under a horizon section header), the pill is dropped
+             the card's goal-status pill is dropped here to avoid duplication
              until a backend namespace field exists. Audit workspace.md #3. -->
         <span class="wk-spacer"></span>
         ${goal.require_completion_approval || goal.active_verification_request_id
@@ -433,11 +412,6 @@ function WorkSurfaceV2() {
     backlog: claimedTasks.filter(t => isClaimableBacklogTask(t)).length,
   }), [goalList, liveTasks, claimedTasks])
 
-  const horizonGroups = useMemo(() => HORIZON_META.map(meta => ({
-    ...meta,
-    goals: goalList.filter(goal => horizonKeyForGoal(goal) === meta.key),
-  })).filter(group => group.goals.length > 0), [goalList])
-
   const backlogTasks = useMemo(() => {
     return claimedTasks
       .filter(t => isClaimableBacklogTask(t))
@@ -475,7 +449,7 @@ function WorkSurfaceV2() {
             <div>
               <span class="ov-eyebrow">Goal Store</span>
               <h1>작업 · 목표</h1>
-              <p class="ov-sub">Goal → Task → keeper · horizon으로 묶고 게이트 증거로 검증</p>
+              <p class="ov-sub">Goal → Task → keeper · 우선순위 순으로 정렬 · 게이트 증거로 검증</p>
             </div>
             <button
               type="button"
@@ -536,29 +510,25 @@ function WorkSurfaceV2() {
             </section>
           ` : null}
 
-          ${horizonGroups.map(group => html`
-            <div class="wk-horizon" data-testid="work-horizon" data-horizon=${group.key}>
-              <div class="wk-hz-head">
-                <span class="wk-hz-lbl">${group.label}</span>
-                <span class="wk-hz-sub">${group.sub}</span>
-                <span class="wk-hz-n mono">${group.goals.length}</span>
-              </div>
-              <div class="wk-list">
-                ${group.goals.map(g => html`
-                  <${GoalCard}
-                    key=${g.id}
-                    goal=${g}
-                    open=${openSet.has(g.id)}
-                    onToggle=${() => toggleGoal(g.id)}
-                    goalTasks=${tasksByGoalId.get(g.id) ?? []}
-                    onClaim=${claimTask}
-                  />
-                `)}
-              </div>
+          ${/* RFC-0294: flat priority-sorted list replaces horizon grouping */
+          goalList.length > 0 ? html`
+            <div class="wk-list" data-testid="work-goal-list">
+              ${[...goalList]
+                .sort((a, b) => (a.priority ?? 4) - (b.priority ?? 4) || (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
+                .map(g => html`
+                <${GoalCard}
+                  key=${g.id}
+                  goal=${g}
+                  open=${openSet.has(g.id)}
+                  onToggle=${() => toggleGoal(g.id)}
+                  goalTasks=${tasksByGoalId.get(g.id) ?? []}
+                  onClaim=${claimTask}
+                />
+              `)}
             </div>
-          `)}
+          ` : null}
 
-          <div class="wk-foot mono">Goal → Task → keeper · horizon(단기·중기·장기) · 완료는 게이트 증거 충족 후 done · 미배정 task 는 백로그에서 claim</div>
+          <div class="wk-foot mono">Goal → Task → keeper · 우선순위 순 정렬 · 완료는 게이트 증거 충족 후 done · 미배정 task 는 백로그에서 claim</div>
       </div>
     </main>
   `

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -881,15 +881,13 @@ function applyPlanningEnvelope(data: DashboardPlanningResponse): void {
       if (!isRecord(row)) return null
       const id = asString(row.id)
       const title = asString(row.title)
-      const horizon = asString(row.horizon)
       const status = asString(row.status)
       const phase = asString(row.phase)
       const createdAt = asString(row.created_at)
       const updatedAt = asString(row.updated_at)
-      if (!id || !title || !horizon || !status || !phase || !createdAt || !updatedAt) return null
+      if (!id || !title || !status || !phase || !createdAt || !updatedAt) return null
       return {
         id,
-        horizon: horizon as Goal['horizon'],
         title,
         metric: asString(row.metric) ?? null,
         target_value: asString(row.target_value) ?? null,

--- a/dashboard/src/styles/keeper-v2/keeper-config.css
+++ b/dashboard/src/styles/keeper-v2/keeper-config.css
@@ -122,10 +122,7 @@
 .kcf-goal-body { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .kcf-goal-title { font-size: 13px; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .kcf-goal-id { font-size: 10.5px; color: var(--text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.kcf-goal-hz { font-size: 10px; letter-spacing: 0.04em; padding: 2px 8px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); color: var(--text-dim); white-space: nowrap; }
-.kcf-goal-hz.hz-short { color: var(--status-ok); border-color: color-mix(in oklab, var(--status-ok) 30%, transparent); }
-.kcf-goal-hz.hz-mid { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 32%, transparent); }
-.kcf-goal-hz.hz-long { color: var(--info); border-color: color-mix(in oklab, var(--info) 34%, transparent); }
+
 .kcf-goals-empty, .kcf-goals-empty { padding: 30px; text-align: center; color: var(--text-dim); font-size: 13px; background: var(--bg-card); }
 
 /* ── hooks table ── */

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -802,12 +802,8 @@
 .wk-blk-n { color: var(--status-bad); }
 .wk-foot { margin: 16px 2px 4px; font-size: 11px; color: var(--text-dim); }
 
-/* ── work v2: horizon groups, real task lifecycle, gate contract, backlog ── */
-.wk-horizon { margin-top: 18px; }
-.wk-hz-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 9px; }
-.wk-hz-lbl { font-family: var(--font-display); font-weight: 600; font-size: 14px; color: var(--text-bright); }
-.wk-hz-sub { font-size: 11px; color: var(--text-dim); }
-.wk-hz-n { margin-left: auto; font-size: 11px; color: var(--text-dim); }
+/* ── work v2: goal list (priority-sorted), task lifecycle, gate contract, backlog ── */
+
 
 .wk-goal.st-warn { border-color: color-mix(in oklab, var(--status-warn) 30%, var(--border-main)); }
 .wk-goal.st-bad { border-color: color-mix(in oklab, var(--status-bad) 32%, var(--border-main)); }

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -110,47 +110,6 @@
 .wk-kpi-v.warn { color: var(--status-warn); }
 .wk-kpi-v.volt { color: var(--volt-strong); }
 
-/* ── Horizon / Goal list ──────────────────────────────────────────────────── */
-.wk-horizons {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  margin-top: 4px;
-}
-
-.wk-horizon {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.wk-hz-head {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  min-height: 22px;
-  padding: 0 2px;
-}
-
-.wk-hz-lbl {
-  font-family: var(--font-ui);
-  font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-bright);
-}
-
-.wk-hz-sub {
-  font-size: 11.5px;
-  color: var(--text-dim);
-}
-
-.wk-hz-n {
-  font-size: 11px;
-  color: var(--text-mid);
-}
-
 .wk-list {
   display: flex;
   flex-direction: column;

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -602,7 +602,6 @@ export type KeeperLifecycleState =
 
 export interface Goal {
   id: string
-  horizon: 'short' | 'mid' | 'long'
   title: string
   metric?: string | null
   target_value?: string | null
@@ -1427,7 +1426,6 @@ interface KeeperConfigHandoff {
 export interface KeeperConfigActiveGoal {
   id: string
   title: string
-  horizon: string
 }
 
 export interface KeeperConfigRuntimeTrust {

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -918,7 +918,6 @@ export interface GoalKeeperTrustSummary {
 export interface GoalTreeNode {
   id: string
   title: string
-  horizon: string
   status: string
   status_color: string
   phase: string

--- a/docs/rfc/RFC-0294-purge-workspace-goal-horizon.md
+++ b/docs/rfc/RFC-0294-purge-workspace-goal-horizon.md
@@ -160,9 +160,10 @@ silent gap). The phases group by file, but P1–P3-OCaml land in one buildable u
 5. **Persistence migration** (§5): legacy goal JSON still has a `"horizon"` key; the
    reader stops reading it (documented intentional drop) and writes omit it.
 
-### Open decision — stagnation threshold re-base (consumer #5)
+### Resolved — stagnation threshold re-base (consumer #5)
 
-`stagnation_threshold_seconds : horizon -> int` must become `horizon`-free. Options:
+Operator selected **(a)**: `stagnation_threshold_seconds` becomes a single constant
+`= Masc_time_constants.day_int` (1 day, the former Mid bucket). Options considered:
 
 - **(a) single named constant** `default_stagnation_threshold_seconds` (no per-goal
   variation). Most surgical; introduces no new axis. Question: which value — the Mid
@@ -172,26 +173,38 @@ silent gap). The phases group by file, but P1–P3-OCaml land in one buildable u
   better "how-urgent" signal). Changes semantics; needs its own justification.
 - **(c) drop stagnation entirely** — rejected: it is a live, surfaced health feature.
 
-This is the only behavior-visible change and is gated on operator input before P1
-lands (it is the spine of the "no heuristic / justification-first" constraint).
+This is the only behavior-visible change in the purge. (a) keeps the value a named
+policy constant — not a magic number and not a priority→time heuristic table —
+which is why it was chosen under the "no heuristic / justification-first"
+constraint. Short goals now alert later (24h vs 6h) and Long goals earlier (24h vs
+72h); priority-derived stagnation (b) remains a possible future refinement.
 
 ## 5. Migration & no-silent-failure
 
-Persisted records at `Goal_store.goals_path` carry `"horizon"`
-(`lib/goal/goal_store.ml:129`, read back at `:173`). After the field is removed from
-`type goal`, the loader must handle the legacy key **explicitly**, not by accident:
+Persisted goal records still carry a `"horizon"` key on disk. After the field is
+removed from `type goal`, removal is handled as **standard schema evolution**, not
+an ad-hoc patch:
 
-- The deserializer ignores a present-but-unknown `"horizon"` member and logs at
-  `info` once per load when it is dropped (visible, not silent). This is a
-  read-time tolerance, not a write-time default.
-- New writes omit the key. A one-pass `update_state` rewrite (already the mechanism
-  at `lib/goal/goal_store.ml:828`'s `update_state`) drops it from every record on
-  the next mutation; no separate migration binary is needed.
-- MCP `masc_goal_upsert` with an explicit `horizon` arg returns a validation error
-  (not a no-op) so callers learn the field is gone rather than having it absorbed.
+- `goal_of_yojson` simply stops reading the `"horizon"` member (it is no longer
+  part of the match). A `(* RFC-0294 *)` comment documents that the legacy key is
+  intentionally ignored, so a future reader does not mistake the omission for a
+  bug. There is no per-load info log: dropping a retired optional field is not a
+  failure, and `read_state` runs often enough that a log line would be pure noise.
+- `goal_to_yojson` no longer emits the key, so it disappears from each record on
+  its next write through the existing `update_state` read-modify-write path. No
+  separate migration binary is needed.
+- MCP rejection of an explicit `horizon` arg is **declarative**: the
+  `masc_goal_list` / `masc_goal_upsert` schemas carry `"additionalProperties":
+  false`, so once `horizon` is no longer an advertised property the validation
+  layer rejects it as an unknown property. A hand-written `if horizon present then
+  error` guard is deliberately avoided — that would be the forbidden string-match
+  pattern and a maintenance wart.
 
-This satisfies "no silent failure": a legacy field is logged when dropped, and a
-caller still sending `horizon` is told, not ignored.
+This satisfies "no silent failure": the on-disk drop is intentional and documented
+(no error to swallow), and a caller still sending `horizon` is rejected by the
+schema, not silently absorbed. The legacy-load path is covered by the existing
+`test_goal_store` fixture whose goal JSON includes a `"horizon"` key and still
+loads.
 
 ## 6. To-Be — the Goal/Task screen without horizon
 

--- a/docs/rfc/RFC-0294-purge-workspace-goal-horizon.md
+++ b/docs/rfc/RFC-0294-purge-workspace-goal-horizon.md
@@ -48,7 +48,10 @@ every layer:
 So "the concept is gone" is an instruction to *make it gone*, not a description of
 the current code. RFC-0288 removed the keeper-meta horizon and explicitly recorded
 that the `Goal_store` horizon "survived as a separate system." This RFC retires that
-survivor, on new evidence (§3) that its single piece of control logic is dead.
+survivor. Its largest control consumer (the refresh cadence) is dead, but — unlike
+RFC-0288's keeper-meta horizon — it is **not entirely dead**: one small live path
+(the dashboard stagnation threshold) re-bases off horizon and must be redesigned,
+not merely deleted (§3).
 
 ## 2. Two different "horizon"s — what this RFC must NOT touch
 
@@ -68,10 +71,21 @@ break them. They stay untouched:
 The purge is therefore scoped by *type identity* (`Goal_store.horizon` and its
 transitive references), not by the word "horizon".
 
-## 3. Justification — horizon's only control logic is dead code
+## 3. Justification — one dead control path, one live one to re-base
 
-`horizon` looks load-bearing because it drives a periodic re-prioritization
-scheduler, but that scheduler is never wired:
+`horizon` has a full census of consumers (origin/main `3086e33d99`):
+
+| # | consumer | role | verdict |
+|---|---|---|---|
+| 1 | `should_refresh_goal`/`reprioritize`/`refresh` (`goal_store.ml:806`–`853`) | re-prioritization cadence | **dead** (delete) |
+| 2 | `sort_goals` `horizon_rank` (`goal_store.ml:531`–`542`) | primary sort key | collapse to `(priority, updated_at desc)` |
+| 3 | `compute_rollup` `short/mid/long_count` (`goal_store.ml:741`–`743`) | count rollup | delete (no external consumer — `rg short_count` hits only `test_keeper_tool_affinity`, an unrelated tool stat) |
+| 4 | `list_goals ?horizon` (`goal_store.ml:551`) + MCP schema | filter | delete (P2) |
+| 5 | `Dashboard_goals_types.stagnation_threshold_seconds` (`dashboard_goals_types_accessor.ml:215`) | **live** stalled-goal threshold (Short 6h / Mid 1d / Long 3d), used at `dashboard_goals_types_builder.ml:396` → `stagnation_status` JSON + health badge | **re-base** (§4) |
+| 6 | keeper prompt context (`keeper_turn_up_create.ml:282`, `keeper_run_context.ml:130`) | injects `horizon_str` into `active_goals` tuple | drop the field from the tuple |
+| 7 | dashboard JSON (`dashboard_goals.ml:204`, `dashboard_http_keeper_snapshot.ml:36`) | serializes horizon | drop the key |
+
+Consumer **#1 is the dead scheduler** — the original premise for the purge:
 
 ```ocaml
 (* lib/goal/goal_store.ml:806 — the cohort selector *)
@@ -97,43 +111,69 @@ Grounding (origin/main `3086e33d99`):
   `compute = goal_loop_status_for_state`, never `Goal_store.refresh`.
 - No test locks `refresh` / `should_refresh_goal` / `reprioritize`.
 
-This mirrors RFC-0288's finding on the keeper-meta horizon ("스케줄러 0"). Once the
-dead cadence is removed, `horizon`'s remaining roles are all non-logic:
+Consumer #1 mirrors RFC-0288's keeper-meta finding ("스케줄러 0"): private, no
+non-test caller, no test lock — deleting it is safe. Consumers #2/#3/#4/#6/#7 only
+sort, count, display, or inject text; none *decide* anything, so they collapse or
+drop cleanly.
 
-1. a persisted field (migration concern, §5);
-2. the primary sort key — `lib/goal/goal_store.ml:531` `horizon_rank` in the
-   `(horizon, priority, updated_at desc)` comparator (`:538`–`:542`);
-3. an optional list filter — `lib/goal/goal_store.ml:551`;
-4. a count rollup — `lib/goal/goal_store.ml:741`–`:743` (`short_count`/`mid_count`/`long_count`);
-5. display (badge/filter/group/progress) on the dashboard.
-
-None of these *decide* anything; they classify, sort, and display. Removing
-`horizon` collapses the sort key to `(priority, updated_at desc)` and deletes the
-dead scheduler outright.
+The one consumer that **does decide** is #5: the dashboard marks a goal `stalled`
+when `stagnation_seconds >= stagnation_threshold_seconds goal.horizon`, and the
+threshold is per-horizon (Short 6h / Mid 1d / Long 3d). Removing `horizon` does not
+remove the need for *a* threshold — stagnation detection is a live, surfaced feature
+(`stagnation_status` is serialized at `dashboard_goals.ml:275` and rendered as a
+health badge at `dashboard_goals_types_health.ml:61`). So #5 must be **re-based onto
+a surviving axis**, not deleted. That choice (single constant vs priority-derived)
+is §4's open decision; it is the only behavior-visible change in this purge and the
+reason the RFC's earlier "only dead logic" framing was wrong.
 
 ## 4. Proposal
 
-Remove `Goal_store.horizon` and everything that exists only to serve it, in four
-phases (§7), each independently compilable and tested:
+`Goal_store.horizon` is the type identity; every consumer in the §3 census is in a
+single OCaml compilation graph (`masc_goal` → `workspace_goals` / `dashboard` /
+`keeper`), so the OCaml side **cannot** be split into independently-green commits —
+removing the field breaks all consumers at once (the compiler enforces totality, no
+silent gap). The phases group by file, but P1–P3-OCaml land in one buildable unit:
 
-1. **Backend type + dead cadence**: delete `type horizon`, `horizon_to_yojson`,
-   `horizon_of_yojson`, `parse_horizon`, the `horizon` record field, `horizon_rank`,
-   `should_refresh_goal`, `reprioritize`, `refresh`, and the `short/mid/long`
-   counts in `rollup`. Collapse the `list_goals` comparator to
-   `(priority, updated_at desc)`. Drop the `?horizon` parameter from `list_goals`
-   and `upsert_goal` and from `goal_store.mli`.
-2. **MCP boundary**: delete `goal_horizon_strings` / `parse_optional_horizon`
-   (`lib/workspace_goals.ml`) and the `horizon` enum + schema fields
-   (`lib/tool_schemas/tool_schemas_workspace_extra.ml`). `masc_goal_list` /
-   `masc_goal_upsert` lose the `horizon` arg; an explicit `horizon` arg now returns
-   an `unknown field` validation error (parse-don't-validate — no silent ignore).
-3. **Dashboard**: delete `HorizonFilter`, the `short/mid/long` grouping
-   (`goal-helpers.ts:76`), `horizonProgress`, `horizonLabel`, `horizonColor`, and
-   the badge spans in `goal-tree.ts`. The Goal screen's primary organization becomes
-   the existing goal tree (parent/child, sorted by priority); the kanban view, KPI
-   strip, claimable-backlog, task drawer, and operator aside are unchanged (§6).
-4. **Persistence migration** (§5): legacy goal JSON on disk still has a `"horizon"`
-   key; the reader drops it explicitly and writes records without it.
+1. **`goal_store.ml(i)`**: delete `type horizon`, `horizon_to/of_yojson`,
+   `parse_horizon`, the `horizon` record field, `horizon_rank`, the dead cadence
+   (`should_refresh_goal`/`reprioritize`/`refresh`) and its now-orphaned scaffolding
+   (`refresh_mode`/`snapshot_mode`/`snapshot`/`refresh_result` types,
+   `parse_refresh_mode`/`parse_snapshot_mode`/`snapshot_mode_of_refresh_mode`,
+   `snapshots_dir`/`scheduler_state_path`/`has_scheduler_state`/`parse_yyyy_mm_dd`/
+   `days_until`), and the `short/mid/long` `rollup` counts. Collapse the comparator
+   to `(priority, updated_at desc)`. Drop `?horizon` from `list_goals`/`upsert_goal`.
+   `ensure_dirs` stops creating `snapshots_dir`.
+2. **OCaml consumers** (same build): drop `horizon_str` from the keeper
+   `active_goals` tuple (`keeper_turn_up_create.ml`, `keeper_run_context.ml`); drop
+   the `"horizon"` key from `dashboard_goals.ml:204` and `dashboard_http_keeper_snapshot.ml`;
+   **re-base stagnation** (see decision below) in `dashboard_goals_types_accessor.ml`
+   + its `.mli`/`dashboard_goals_types.mli` signatures and the `..._builder.ml:396`
+   call site.
+3. **MCP boundary** (same build): delete `goal_horizon_strings` /
+   `parse_optional_horizon` (`lib/workspace_goals.ml`) and the `horizon` enum +
+   schema fields (`lib/tool_schemas/tool_schemas_workspace_extra.ml`). An explicit
+   `horizon` arg to `masc_goal_upsert` returns an `unknown field` validation error
+   (parse-don't-validate — no silent ignore).
+4. **TS dashboard** (separate build): delete `HorizonFilter`, the `short/mid/long`
+   grouping (`goal-helpers.ts:76`), `horizonProgress`, `horizonLabel`, `horizonColor`,
+   and the badge spans in `goal-tree.ts`. Primary view becomes the goal tree (§6).
+5. **Persistence migration** (§5): legacy goal JSON still has a `"horizon"` key; the
+   reader stops reading it (documented intentional drop) and writes omit it.
+
+### Open decision — stagnation threshold re-base (consumer #5)
+
+`stagnation_threshold_seconds : horizon -> int` must become `horizon`-free. Options:
+
+- **(a) single named constant** `default_stagnation_threshold_seconds` (no per-goal
+  variation). Most surgical; introduces no new axis. Question: which value — the Mid
+  bucket (1 day) preserves the median behavior but makes Short goals alert later and
+  Long goals earlier.
+- **(b) priority-derived** `f : priority -> int` (priority survives the purge and is a
+  better "how-urgent" signal). Changes semantics; needs its own justification.
+- **(c) drop stagnation entirely** — rejected: it is a live, surfaced health feature.
+
+This is the only behavior-visible change and is gated on operator input before P1
+lands (it is the spine of the "no heuristic / justification-first" constraint).
 
 ## 5. Migration & no-silent-failure
 

--- a/lib/dashboard/dashboard_goals.ml
+++ b/lib/dashboard/dashboard_goals.ml
@@ -201,7 +201,6 @@ let rec tree_node_to_json ?(effective_policy_for_goal = fun _ -> None)
     [
       ("id", `String goal.id);
       ("title", `String goal.title);
-      ("horizon", Goal_store.horizon_to_yojson goal.horizon);
       ("status", Goal_store.goal_status_to_yojson goal.status);
       ("status_color", `String (goal_status_color goal.status));
       ("phase", Goal_phase.to_yojson goal.phase);

--- a/lib/dashboard/dashboard_goals_types.mli
+++ b/lib/dashboard/dashboard_goals_types.mli
@@ -92,7 +92,10 @@ val receipt_has_runtime_risk : Yojson.Safe.t -> bool
 val iso_max : string -> string -> string
 val latest_iso : ?fallback:string -> string list -> string option
 
-val stagnation_threshold_seconds : Goal_store.horizon -> int
+val stagnation_threshold_seconds : int
+(** RFC-0294: single policy constant (1 day) after the per-horizon table was
+    removed with the workspace-goal horizon. *)
+
 val human_duration : int -> string
 
 (** {1 Metric parsing utilities — pure tokenizer + percent/count inference} *)

--- a/lib/dashboard/dashboard_goals_types_accessor.ml
+++ b/lib/dashboard/dashboard_goals_types_accessor.ml
@@ -212,10 +212,11 @@ let latest_iso ?fallback values =
   | first :: rest ->
       Some (List.fold_left iso_max first rest)
 
-let stagnation_threshold_seconds = function
-  | Goal_store.Short -> 6 * Masc_time_constants.hour_int
-  | Goal_store.Mid -> Masc_time_constants.day_int
-  | Goal_store.Long -> 3 * Masc_time_constants.day_int
+(* RFC-0294: stagnation threshold was per-horizon (Short 6h / Mid 1d / Long 3d).
+   With the workspace-goal horizon removed it collapses to a single policy
+   constant — the former Mid bucket (1 day) — chosen to preserve the median of
+   the old table. *)
+let stagnation_threshold_seconds = Masc_time_constants.day_int
 
 let human_duration seconds =
   if seconds < Masc_time_constants.hour_int

--- a/lib/dashboard/dashboard_goals_types_accessor.mli
+++ b/lib/dashboard/dashboard_goals_types_accessor.mli
@@ -78,5 +78,8 @@ val receipt_has_runtime_risk : Yojson.Safe.t -> bool
 val iso_max : string -> string -> string
 val latest_iso : ?fallback:string -> string list -> string option
 
-val stagnation_threshold_seconds : Goal_store.horizon -> int
+val stagnation_threshold_seconds : int
+(** RFC-0294: single policy constant (1 day) after the per-horizon table was
+    removed with the workspace-goal horizon. *)
+
 val human_duration : int -> string

--- a/lib/dashboard/dashboard_goals_types_builder.ml
+++ b/lib/dashboard/dashboard_goals_types_builder.ml
@@ -393,7 +393,7 @@ let rec build_tree context goals goal =
       "goal_metadata"
   in
   let stale_by_threshold =
-    stagnation_seconds >= stagnation_threshold_seconds goal.Goal_store.horizon
+    stagnation_seconds >= stagnation_threshold_seconds
   in
   let observed_for_stagnation =
     not (String.equal activity_observation "goal_metadata")

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -30,14 +30,9 @@ let keeper_config_json (config : Workspace.config) (name : string)
         List.filter_map
           (fun goal_id ->
              match Goal_store.get_goal config ~goal_id with
-             | Some { Goal_store.id; title; horizon } ->
-                 let horizon_str =
-                   match horizon with
-                   | Goal_store.Short -> "short"
-                   | Goal_store.Mid -> "mid"
-                   | Goal_store.Long -> "long"
-                 in
-                 Some (id, title, horizon_str)
+             (* RFC-0294: active_goals tuple dropped its horizon element. *)
+             | Some { Goal_store.id; title; _ } ->
+                 Some (id, title)
                | None -> None)
           m.active_goal_ids
       in
@@ -56,16 +51,15 @@ let keeper_config_json (config : Workspace.config) (name : string)
       let active_goals_json =
         `List
           (List.map
-             (fun (id, title, horizon) ->
+             (fun (id, title) ->
                 `Assoc [
                   ("id", `String id);
                   ("title", `String title);
-                  ("horizon", `String horizon);
                 ])
              active_goals)
       in
       let resolved_active_goal_ids =
-        List.map (fun (id, _, _) -> id) active_goals
+        List.map (fun (id, _) -> id) active_goals
       in
       let missing_active_goal_ids =
         m.active_goal_ids

--- a/lib/goal/goal_store.ml
+++ b/lib/goal/goal_store.ml
@@ -21,76 +21,17 @@ let goal_status_of_yojson = function
   | `String "dropped" -> Ok Dropped
   | j -> Error ("goal_status_of_yojson: " ^ Yojson.Safe.to_string j)
 
-type horizon =
-  | Short
-  | Mid
-  | Long
-
-let horizon_to_yojson = function
-  | Short -> `String "short"
-  | Mid -> `String "mid"
-  | Long -> `String "long"
-
-let horizon_of_yojson = function
-  | `String "short" -> Ok Short
-  | `String "mid" -> Ok Mid
-  | `String "long" -> Ok Long
-  | j -> Error ("horizon_of_yojson: " ^ Yojson.Safe.to_string j)
-
-type refresh_mode =
-  | Daily
-  | Weekly
-  | Monthly
-
-let refresh_mode_to_yojson = function
-  | Daily -> `String "daily"
-  | Weekly -> `String "weekly"
-  | Monthly -> `String "monthly"
-
-let refresh_mode_of_yojson = function
-  | `String "daily" -> Ok Daily
-  | `String "weekly" -> Ok Weekly
-  | `String "monthly" -> Ok Monthly
-  | j -> Error ("refresh_mode_of_yojson: " ^ Yojson.Safe.to_string j)
-
-type snapshot_mode =
-  | SnapDaily
-  | SnapWeekly
-  | SnapMonthly
-  | SnapManual
-
-let snapshot_mode_to_yojson = function
-  | SnapDaily -> `String "daily"
-  | SnapWeekly -> `String "weekly"
-  | SnapMonthly -> `String "monthly"
-  | SnapManual -> `String "manual"
-
-let snapshot_mode_of_yojson = function
-  | `String "daily" -> Ok SnapDaily
-  | `String "weekly" -> Ok SnapWeekly
-  | `String "monthly" -> Ok SnapMonthly
-  | `String "manual" -> Ok SnapManual
-  | j -> Error ("snapshot_mode_of_yojson: " ^ Yojson.Safe.to_string j)
-
-let snapshot_mode_of_refresh_mode = function
-  | Daily -> SnapDaily
-  | Weekly -> SnapWeekly
-  | Monthly -> SnapMonthly
-
-let parse_snapshot_mode s =
-  match String.trim s |> String.lowercase_ascii with
-  | "daily" -> Some SnapDaily
-  | "weekly" -> Some SnapWeekly
-  | "monthly" -> Some SnapMonthly
-  | "manual" -> Some SnapManual
-  | _ -> None
+(* RFC-0294: the workspace-goal [horizon] (short/mid/long) and its dead
+   refresh/snapshot scheduler ([refresh_mode], [snapshot_mode], and their
+   yojson codecs) were removed. The cadence had no live caller; the only
+   surviving horizon consumer (dashboard stagnation threshold) was re-based
+   onto a single policy constant. *)
 
 let clamp_priority p =
   max 1 (min 5 p)
 
 type goal = {
   id : string;
-  horizon : horizon;
   title : string;
   metric : string option;
   target_value : string option;
@@ -126,7 +67,6 @@ and goal_to_yojson (goal : goal) =
   `Assoc
     [
       ("id", `String goal.id);
-      ("horizon", horizon_to_yojson goal.horizon);
       ("title", `String goal.title);
       ("metric", Json_util.string_opt_to_json goal.metric);
       ("target_value", Json_util.string_opt_to_json goal.target_value);
@@ -170,8 +110,12 @@ and state_of_yojson = function
 and goal_of_yojson = function
   | `Assoc _ as json ->
       begin
-        match Json_util.assoc_member_opt "id" json, horizon_of_yojson (Option.value ~default:`Null (Json_util.assoc_member_opt "horizon" json)), Json_util.assoc_member_opt "title" json with
-        | Some (`String id), Ok horizon, Some (`String title) ->
+        (* RFC-0294: a legacy [horizon] key may still be present on disk; it is
+           intentionally not read here. Goal_to_yojson no longer emits it, so it
+           evaporates on the next write (standard schema evolution, not a drop
+           that needs logging). *)
+        match Json_util.assoc_member_opt "id" json, Json_util.assoc_member_opt "title" json with
+        | Some (`String id), Some (`String title) ->
             let legacy_status =
               match Json_util.assoc_member_opt "status" json with
               | None | Some `Null -> Ok Active
@@ -210,7 +154,6 @@ and goal_of_yojson = function
                     (normalize_goal
                        {
                          id;
-                         horizon;
                          title;
                          metric = Json_util.get_string json "metric" ;
                          target_value = Json_util.get_string json "target_value" ;
@@ -283,9 +226,6 @@ and phase_of_goal_status = function
   | Dropped -> Goal_phase.Dropped
 
 type rollup = {
-  short_count : int;
-  mid_count : int;
-  long_count : int;
   active_count : int;
   paused_count : int;
   done_count : int;
@@ -293,36 +233,10 @@ type rollup = {
 }
 [@@deriving yojson]
 
-type snapshot = {
-  snapshot_id : string;
-  created_at : string;
-  mode : snapshot_mode;
-  goals : goal list;
-  rollup : rollup;
-}
-[@@deriving yojson]
-
 type upsert_kind = [ `created | `updated ]
-
-type refresh_result = {
-  mode : refresh_mode;
-  scanned : int;
-  updated : int;
-  snapshot_id : string;
-}
-[@@deriving yojson]
 
 let normalize_lower s =
   String.trim s |> String.lowercase_ascii
-
-let parse_horizon = function
-  | Some s -> (
-      match normalize_lower s with
-      | "short" -> Some Short
-      | "mid" -> Some Mid
-      | "long" -> Some Long
-      | _ -> None)
-  | None -> None
 
 let parse_goal_status = function
   | Some s -> (
@@ -338,28 +252,14 @@ let parse_goal_phase = function
   | Some s -> Goal_phase.parse s
   | None -> None
 
-let parse_refresh_mode s =
-  match normalize_lower s with
-  | "daily" -> Some Daily
-  | "weekly" -> Some Weekly
-  | "monthly" -> Some Monthly
-  | _ -> None
-
 let goals_path config =
   Filename.concat (Workspace_utils.masc_dir config) "goals.json"
 
 let goals_recovery_path config =
   goals_path config ^ ".last-good"
 
-let snapshots_dir config =
-  Filename.concat (Workspace_utils.masc_dir config) "goals_snapshots"
-
-let scheduler_state_path config =
-  Filename.concat (Workspace_utils.masc_dir config) "goals_scheduler_state.json"
-
 let ensure_dirs config =
-  Workspace_utils.mkdir_p (Workspace_utils.masc_dir config);
-  Workspace_utils.mkdir_p (snapshots_dir config)
+  Workspace_utils.mkdir_p (Workspace_utils.masc_dir config)
 
 let default_state () =
   { version = 1; updated_at = Masc_domain.now_iso (); goals = [] }
@@ -528,33 +428,20 @@ let delete_goal config ~goal_id =
        Ok (Deleted_with_orphaned_links warning))
 
 let sort_goals goals =
-  let horizon_rank = function
-    | Short -> 0
-    | Mid -> 1
-    | Long -> 2
-  in
+  (* RFC-0294: sort key was [(horizon, priority, updated_at desc)]; with horizon
+     removed it collapses to [(priority asc, updated_at desc)]. *)
   List.sort
     (fun left right ->
-      let by_horizon =
-        compare (horizon_rank left.horizon) (horizon_rank right.horizon)
-      in
-      if by_horizon <> 0 then
-        by_horizon
+      let by_priority = compare left.priority right.priority in
+      if by_priority <> 0 then
+        by_priority
       else
-        let by_priority = compare left.priority right.priority in
-        if by_priority <> 0 then
-          by_priority
-        else
-          String.compare right.updated_at left.updated_at)
+        String.compare right.updated_at left.updated_at)
     goals
 
-let list_goals config ?horizon ?status ?phase () =
+let list_goals config ?status ?phase () =
   read_state config
   |> fun state -> state.goals
-  |> List.filter (fun goal ->
-         match horizon with
-         | None -> true
-         | Some horizon -> goal.horizon = horizon)
   |> List.filter (fun goal ->
          match status with
          | None -> true
@@ -595,7 +482,7 @@ let validate_parent_goal_id goals ~goal_id ~parent_goal_id =
       else
         Ok ()
 
-let upsert_goal config ?id ?horizon ?title ?metric ?target_value ?due_date
+let upsert_goal config ?id ?title ?metric ?target_value ?due_date
     ?priority ?status ?phase ?parent_goal_id ?verifier_policy
     ?require_completion_approval () =
   let is_new_goal = id = None in
@@ -658,7 +545,6 @@ let upsert_goal config ?id ?horizon ?title ?metric ?target_value ?due_date
                     normalize_goal
                       {
                         existing with
-                        horizon = Option.value horizon ~default:existing.horizon;
                         title = Option.value title ~default:existing.title;
                         metric = (match metric with Some _ -> metric | None -> existing.metric);
                         target_value =
@@ -701,7 +587,6 @@ let upsert_goal config ?id ?horizon ?title ?metric ?target_value ?due_date
                     normalize_goal
                       {
                         id = resolved_id;
-                        horizon = Option.value horizon ~default:Short;
                         title = Option.value title ~default:"Untitled goal";
                         metric;
                         target_value;
@@ -738,122 +623,16 @@ let compute_rollup goals =
     List_util.count_if predicate goals
   in
   {
-    short_count = count (fun goal -> goal.horizon = Short);
-    mid_count = count (fun goal -> goal.horizon = Mid);
-    long_count = count (fun goal -> goal.horizon = Long);
     active_count = count (fun goal -> goal.status = Active);
     paused_count = count (fun goal -> goal.status = Paused);
     done_count = count (fun goal -> goal.status = Done);
     dropped_count = count (fun goal -> goal.status = Dropped);
   }
 
-let snapshot config ~mode =
-  ensure_dirs config;
-  let state = read_state config in
-  let snapshot_id = Printf.sprintf "gsnap-%d" (now_ms ()) in
-  let snapshot =
-    {
-      snapshot_id;
-      created_at = Masc_domain.now_iso ();
-      mode;
-      goals = state.goals;
-      rollup = compute_rollup state.goals;
-    }
-  in
-  let path =
-    Filename.concat (snapshots_dir config) (snapshot_id ^ ".json")
-  in
-  Workspace_utils.write_json config path (snapshot_to_yojson snapshot);
-  snapshot
-
-let parse_yyyy_mm_dd s =
-  try
-    Scanf.sscanf s "%d-%d-%d" (fun year month day ->
-        let tm =
-          {
-            Unix.tm_sec = 0;
-            tm_min = 0;
-            tm_hour = 0;
-            tm_mday = day;
-            tm_mon = month - 1;
-            tm_year = year - 1900;
-            tm_wday = 0;
-            tm_yday = 0;
-            tm_isdst = false;
-          }
-        in
-        let local_epoch, _ = Unix.mktime tm in
-        let utc_as_local, _ = Unix.mktime (Unix.gmtime local_epoch) in
-        let tz_offset = local_epoch -. utc_as_local in
-        Some (local_epoch +. tz_offset))
-  with Eio.Cancel.Cancelled _ as exn ->
-    raise exn
-  | exn ->
-      Log.Misc.warn "goal_store: parse_yyyy_mm_dd failed: %s"
-        (Printexc.to_string exn);
-      None
-
-let days_until due_date =
-  match due_date with
-  | None -> None
-  | Some due_date -> (
-      match parse_yyyy_mm_dd due_date with
-      | None -> None
-      | Some ts ->
-          let diff = ts -. Unix.time () in
-          Some (int_of_float (diff /. Masc_time_constants.day)))
-
-let should_refresh_goal mode goal =
-  match mode with
-  | Daily -> goal.horizon = Short && goal.phase = Goal_phase.Executing
-  | Weekly -> goal.horizon = Mid && goal.phase = Goal_phase.Executing
-  | Monthly -> goal.horizon = Long && goal.phase = Goal_phase.Executing
-
-let reprioritize mode goal =
-  let next_priority =
-    match days_until goal.due_date with
-    | Some days when days < 0 -> 1
-    | Some days when mode = Daily && days <= 3 -> max 1 (goal.priority - 1)
-    | Some days when mode = Weekly && days <= 14 -> max 1 (goal.priority - 1)
-    | Some days when mode = Monthly && days <= 45 -> max 1 (goal.priority - 1)
-    | _ -> goal.priority
-  in
-  if next_priority = goal.priority then
-    (goal, false)
-  else
-    ( { goal with priority = next_priority; updated_at = Masc_domain.now_iso () }
-      |> normalize_goal,
-      true )
-
-let refresh config ~mode =
-  let scanned = ref 0 in
-  let updated = ref 0 in
-  ignore
-    (update_state config (fun state ->
-         let goals =
-           List.map
-             (fun goal ->
-               if should_refresh_goal mode goal then begin
-                 incr scanned;
-                 let goal, changed = reprioritize mode goal in
-                 if changed then incr updated;
-                 goal
-               end else
-                 goal)
-             state.goals
-         in
-         { version = state.version + 1; updated_at = Masc_domain.now_iso (); goals }))
-  ;
-  let snapshot = snapshot config ~mode:(snapshot_mode_of_refresh_mode mode) in
-  {
-    mode;
-    scanned = !scanned;
-    updated = !updated;
-    snapshot_id = snapshot.snapshot_id;
-  }
+(* RFC-0294: the horizon-driven refresh/snapshot scheduler ([snapshot],
+   [parse_yyyy_mm_dd], [days_until], [should_refresh_goal], [reprioritize],
+   [refresh], [has_scheduler_state]) was removed. It had no live caller and its
+   cohort selector keyed on the now-deleted [horizon]. *)
 
 let active_goals config =
   list_goals config ~status:Active ()
-
-let has_scheduler_state config =
-  Workspace_utils.path_exists config (scheduler_state_path config)

--- a/lib/goal/goal_store.mli
+++ b/lib/goal/goal_store.mli
@@ -12,9 +12,6 @@
       consumers that have not migrated to phases yet
       (derived from phase on write, inferred on read for
       old rows),
-    - a {!horizon} ([Short] / [Mid] / [Long]) used by the
-      refresh / snapshot scheduler to decide which cohort
-      to scan,
     - an optional {!Goal_verification.goal_verifier_policy}
       that gates entry into [Goal_phase.Completed].
 
@@ -25,22 +22,22 @@
     [lib/server/server_dashboard_http]) construct goal records
     by literal, pattern-match on every variant constructor,
     and access record fields ([.id], [.phase],
-    [.updated_at], [.horizon], [.title], …) directly.
+    [.updated_at], [.title], …) directly.
 
-    Internal helpers stay private at this boundary
-    ([refresh_mode], [snapshot_mode], [snapshot] type +
-    function, [refresh_result], [refresh],
-    [parse_refresh_mode], [parse_snapshot_mode],
-    [snapshot_mode_of_refresh_mode], [normalize_lower],
-    [now_ms], [gen_goal_id], [find_goal], [replace_goal],
-    [update_state], [normalize_goal], [sort_goals],
-    [parse_yyyy_mm_dd], [days_until],
-    [should_refresh_goal], [reprioritize], [active_goals],
-    [has_scheduler_state], [scheduler_state_path],
-    [snapshots_dir], [ensure_dirs], [default_state],
-    [clamp_priority]). *)
+    RFC-0294 removed the workspace-goal [horizon] and its dead
+    refresh/snapshot scheduler ([refresh_mode], [snapshot_mode],
+    [snapshot], [refresh_result], [refresh], [parse_refresh_mode],
+    [parse_snapshot_mode], [snapshot_mode_of_refresh_mode],
+    [should_refresh_goal], [reprioritize], [has_scheduler_state],
+    [scheduler_state_path], [snapshots_dir], [parse_yyyy_mm_dd],
+    [days_until]).
 
-(** {1 Status / horizon variants} *)
+    Internal helpers that stay private: [normalize_lower], [now_ms],
+    [gen_goal_id], [find_goal], [replace_goal], [update_state],
+    [normalize_goal], [sort_goals], [active_goals], [ensure_dirs],
+    [default_state], [clamp_priority]. *)
+
+(** {1 Status variants} *)
 
 type goal_status =
   | Active
@@ -57,22 +54,7 @@ val goal_status_to_yojson : goal_status -> Yojson.Safe.t
 val goal_status_of_yojson :
   Yojson.Safe.t -> (goal_status, string) result
 
-type horizon =
-  | Short
-  | Mid
-  | Long
-  (** Time-bucket the goal belongs to.  Used by the
-      refresh scheduler ([Daily] → [Short], [Weekly] →
-      [Mid], [Monthly] → [Long]) to decide which cohort to
-      reprioritise. *)
-
-val horizon_to_yojson : horizon -> Yojson.Safe.t
-
 (** {1 Parsers (string → variant option)} *)
-
-val parse_horizon : string option -> horizon option
-(** Case-insensitive, trim-tolerant.  [None]/empty string
-    pass through as [None]. *)
 
 val parse_goal_status : string option -> goal_status option
 (** Same shape as {!parse_horizon}. *)
@@ -101,7 +83,6 @@ val phase_of_goal_status : goal_status -> Goal_phase.t
 
 type goal = {
   id : string;
-  horizon : horizon;
   title : string;
   metric : string option;
   target_value : string option;
@@ -141,9 +122,6 @@ type state = {
 (** {1 Rollup} *)
 
 type rollup = {
-  short_count : int;
-  mid_count : int;
-  long_count : int;
   active_count : int;
   paused_count : int;
   done_count : int;
@@ -156,9 +134,8 @@ type rollup = {
 val rollup_to_yojson : rollup -> Yojson.Safe.t
 
 val compute_rollup : goal list -> rollup
-(** Field-wise count of goals per horizon and per legacy
-    status.  Single pass; no allocation beyond the result
-    record. *)
+(** Field-wise count of goals per legacy status.  Single
+    pass; no allocation beyond the result record. *)
 
 (** {1 Persistence paths} *)
 
@@ -224,18 +201,16 @@ val delete_goal :
 
 val list_goals :
   Workspace_utils.config ->
-  ?horizon:horizon ->
   ?status:goal_status ->
   ?phase:Goal_phase.t ->
   unit ->
   goal list
 (** Reads the state, applies optional filters, then sorts
-    by [(horizon, priority, updated_at desc)]. *)
+    by [(priority, updated_at desc)]. *)
 
 val upsert_goal :
   Workspace_utils.config ->
   ?id:string ->
-  ?horizon:horizon ->
   ?title:string ->
   ?metric:string ->
   ?target_value:string ->

--- a/lib/keeper/keeper_context_runtime.mli
+++ b/lib/keeper/keeper_context_runtime.mli
@@ -298,7 +298,7 @@ val build_keeper_system_prompt
   -> ?persona_extended:string
   -> ?keeper_name:string
   -> ?home_ground:string
-  -> ?active_goals:(string * string * string) list
+  -> ?active_goals:(string * string) list
   -> unit
   -> string
 

--- a/lib/keeper/keeper_execution.mli
+++ b/lib/keeper/keeper_execution.mli
@@ -60,7 +60,7 @@ val build_keeper_system_prompt :
   ?persona_extended:string ->
   ?keeper_name:string ->
   ?home_ground:string ->
-  ?active_goals:(string * string * string) list ->
+  ?active_goals:(string * string) list ->
   unit ->
   string
 

--- a/lib/keeper/keeper_prompt.ml
+++ b/lib/keeper/keeper_prompt.ml
@@ -211,10 +211,11 @@ let build_keeper_system_prompt
     | goals ->
         let lines =
           List.map
-            (fun (id, title, horizon) ->
-               Printf.sprintf "- %s [%s] %s"
+            (fun (id, title) ->
+               (* RFC-0294: available-goals line was "- <id> [<horizon>] <title>";
+                  horizon removed, so it is now "- <id> <title>". *)
+               Printf.sprintf "- %s %s"
                  (String_util.escape_xml id)
-                 (String_util.escape_xml horizon)
                  (String_util.escape_xml title))
             goals
         in

--- a/lib/keeper/keeper_prompt.mli
+++ b/lib/keeper/keeper_prompt.mli
@@ -35,7 +35,7 @@ val build_keeper_system_prompt :
   ?persona_extended:string ->
   ?keeper_name:string ->
   ?home_ground:string ->
-  ?active_goals:(string * string * string) list ->
+  ?active_goals:(string * string) list ->
   unit ->
   string
 

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -127,14 +127,9 @@ let prepare_run_context
     List.filter_map
       (fun goal_id ->
          match Goal_store.get_goal config ~goal_id with
-         | Some { Goal_store.id; title; horizon } ->
-             let horizon_str =
-               match horizon with
-               | Goal_store.Short -> "short"
-               | Goal_store.Mid -> "mid"
-               | Goal_store.Long -> "long"
-             in
-             Some (id, title, horizon_str)
+         (* RFC-0294: active_goals tuple dropped its horizon element. *)
+         | Some { Goal_store.id; title; _ } ->
+             Some (id, title)
          | None -> None)
       meta.active_goal_ids
   in

--- a/lib/keeper/keeper_turn_up_create.ml
+++ b/lib/keeper/keeper_turn_up_create.ml
@@ -279,14 +279,9 @@ let create_keeper (ctx : _ context) (p : parsed_args) : tool_result =
           List.filter_map
             (fun goal_id ->
                match Goal_store.get_goal ctx.config ~goal_id with
-               | Some { Goal_store.id; title; horizon } ->
-                   let horizon_str =
-                     match horizon with
-                     | Goal_store.Short -> "short"
-                     | Goal_store.Mid -> "mid"
-                     | Goal_store.Long -> "long"
-                   in
-                   Some (id, title, horizon_str)
+               (* RFC-0294: active_goals tuple dropped its horizon element. *)
+               | Some { Goal_store.id; title; _ } ->
+                   Some (id, title)
                | None -> None)
             active_goal_ids
         in

--- a/lib/tool_schemas/tool_schemas_workspace_extra.ml
+++ b/lib/tool_schemas/tool_schemas_workspace_extra.ml
@@ -3,7 +3,10 @@
 
 open Masc_domain
 
-let goal_horizon_enum = [ "short"; "mid"; "long" ]
+(* RFC-0294: goal_horizon_enum removed with the workspace-goal horizon.
+   masc_goal_list/upsert no longer advertise a horizon arg; with the schema's
+   "additionalProperties": false, an explicit horizon key is rejected as an
+   unknown property rather than silently ignored. *)
 (* RFC-0089: the phase/action enums advertised to MCP clients are derived from
    the Goal_phase ADT (the goal lifecycle SSOT), the same source the
    workspace_goals validator uses, so the schema can never advertise a value the
@@ -59,9 +62,9 @@ let schemas : tool_schema list =
     {
       name = "masc_goal_list";
       description =
-        "List shared planning goals from the Goal Store, optionally filtered by horizon or explicit phase. \
+        "List shared planning goals from the Goal Store, optionally filtered by explicit phase. \
 Valid phases: executing, awaiting_verification, awaiting_approval, blocked, paused, completed, dropped. \
-Use when a PM/planner agent needs current long/mid/short goals before creating tasks or reviews. \
+Use when a PM/planner agent needs current goals before creating tasks or reviews. \
 The dashboard Goal Tree reads the same store. Goal-task links are managed externally. \
 The response includes each goal's explicit lifecycle phase and verification policy.";
       input_schema =
@@ -71,7 +74,6 @@ The response includes each goal's explicit lifecycle phase and verification poli
             ( "properties",
               `Assoc
                 [
-                  ("horizon", enum_schema ~description:"Optional horizon filter" goal_horizon_enum);
                   ("phase", enum_schema ~description:"Optional explicit Goal FSM phase filter" goal_phase_enum);
                 ] );
             ("additionalProperties", `Bool false);
@@ -81,7 +83,7 @@ The response includes each goal's explicit lifecycle phase and verification poli
       name = "masc_goal_upsert";
       description =
         "Create or update a shared Goal Store entry used by Planning > Goal Tree. \
-For new goals, provide at least title; omitted horizon defaults to short. \
+For new goals, provide at least title. \
 After creation, goal-task links are registered separately by the keeper orchestrator. \
 Use this tool for goal metadata, parent linkage, and verifier-policy configuration. \
 Lifecycle status/phase fields are intentionally omitted here; use masc_goal_transition / masc_goal_verify for lifecycle moves.";
@@ -93,7 +95,6 @@ Lifecycle status/phase fields are intentionally omitted here; use masc_goal_tran
               `Assoc
                 [
                   ("id", `Assoc [ ("type", `String "string") ]);
-                  ("horizon", enum_schema goal_horizon_enum);
                   ("title", `Assoc [ ("type", `String "string") ]);
                   ("metric", `Assoc [ ("type", `String "string") ]);
                   ("target_value", `Assoc [ ("type", `String "string") ]);

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -54,7 +54,6 @@ let validation_error_result
     (validation_error_response errors)
 ;;
 
-let goal_horizon_strings = [ "short"; "mid"; "long" ]
 let goal_status_strings = [ "active"; "paused"; "done"; "dropped" ]
 
 (* RFC-0089: derive the accepted-value sets from the Goal_phase ADT (the goal
@@ -86,23 +85,10 @@ let make_type_field_error ~field ~constraint_violated ~expected ~received =
   }
 ;;
 
-let parse_optional_horizon args field =
-  match Json_util.assoc_member_opt field args with
-  | None | Some `Null -> Ok None
-  | Some (`String raw) when String.trim raw = "" -> Ok None
-  | Some (`String raw) ->
-    (match Goal_store.parse_horizon (Some raw) with
-     | Some horizon -> Ok (Some horizon)
-     | None ->
-       Error (make_enum_field_error ~field ~allowed:goal_horizon_strings ~received:raw))
-  | Some json ->
-    Error
-      (make_type_field_error
-         ~field
-         ~constraint_violated:Type_string
-         ~expected:"string"
-         ~received:(Yojson.Safe.to_string json))
-;;
+(* RFC-0294: parse_optional_horizon removed with the workspace-goal horizon.
+   The masc_goal_* schemas no longer advertise a horizon arg; rejection of an
+   unexpected horizon key is governed by the schema's additionalProperties
+   policy, not a hand-written substring guard. *)
 
 let parse_optional_goal_status args field =
   match Json_util.assoc_member_opt field args with
@@ -372,13 +358,12 @@ let emit_goal_event = Workspace_goals_verification.emit_goal_event
 let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.result =
   match
     ( reject_retired_goal_list_status args
-    , parse_optional_horizon args "horizon"
     , parse_optional_goal_phase args "phase" )
   with
-  | Error err, _, _ | _, Error err, _ | _, _, Error err ->
+  | Error err, _ | _, Error err ->
     validation_error_result ~tool_name ~start_time [ err ]
-  | Ok (), Ok horizon, Ok phase ->
-    let goals = Goal_store.list_goals ctx.config ?horizon ?phase () in
+  | Ok (), Ok phase ->
+    let goals = Goal_store.list_goals ctx.config ?phase () in
     let rollup = Goal_store.compute_rollup goals in
     ok_result
       ~tool_name
@@ -392,21 +377,18 @@ let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.r
 
 let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result.result =
   match
-    ( parse_optional_horizon args "horizon"
-    , parse_optional_goal_status args "status"
+    ( parse_optional_goal_status args "status"
     , parse_optional_goal_phase args "phase"
     , parse_optional_priority args "priority"
     , parse_optional_policy args "verifier_policy"
     , parse_optional_bool args "require_completion_approval" )
   with
-  | Error err, _, _, _, _, _
-  | _, Error err, _, _, _, _
-  | _, _, Error err, _, _, _
-  | _, _, _, Error err, _, _
-  | _, _, _, _, Error err, _
-  | _, _, _, _, _, Error err -> validation_error_result ~tool_name ~start_time [ err ]
-  | ( Ok horizon
-    , Ok status
+  | Error err, _, _, _, _
+  | _, Error err, _, _, _
+  | _, _, Error err, _, _
+  | _, _, _, Error err, _
+  | _, _, _, _, Error err -> validation_error_result ~tool_name ~start_time [ err ]
+  | ( Ok status
     , Ok phase
     , Ok priority
     , Ok verifier_policy
@@ -425,7 +407,6 @@ let handle_goal_upsert ~tool_name ~start_time (ctx : context) args : Tool_result
           Goal_store.upsert_goal
             ctx.config
             ?id
-            ?horizon
             ?title
             ?metric
             ?target_value

--- a/lib/workspace_goals.mli
+++ b/lib/workspace_goals.mli
@@ -6,14 +6,14 @@
     persisted via {!Goal_store}; this module owns the parsing /
     validation / response-shape contract.
 
-    Internal: ~25 helpers + 6 string lists stay private —
-    \[goal_horizon_strings] / \[goal_status_strings] /
+    Internal: ~25 helpers + 5 string lists stay private —
+    \[goal_status_strings] /
     \[goal_phase_strings] / \[goal_transition_action_strings] /
     \[goal_vote_decision_strings] (allowed-value tables for
     enum field validation), the
     \[make_enum_field_error] / \[make_type_field_error] error
-    formatters, the 11 \[parse_optional_*] field parsers
-    (horizon, goal_status, goal_phase, priority, bool, policy,
+    formatters, the 10 \[parse_optional_*] field parsers
+    (goal_status, goal_phase, priority, bool, policy,
     principal, vote_decision, transition_action, string_list),
     \[goal_upsert_lifecycle_error], \[validate_goal_completion_ready],
     \[goal_policy_nodes], \[verification_summary_json],
@@ -21,7 +21,7 @@
     inside the 4 public {!handle_goal_*} entries. *)
 
 (** [handle_goal_list ctx args] handles [masc_goal_list].
-    Optional filters: [horizon] (short / mid / long), [status]
+    Optional filters: [status]
     (active / paused / done / dropped), [phase] (executing /
     awaiting_verification / etc.).  Returns the goal list with a
     rollup summary.  Validation errors return
@@ -34,7 +34,7 @@ val handle_goal_list
   -> Tool_result.result
 
 (** [handle_goal_upsert ctx args] handles [masc_goal_upsert] —
-    create-or-update a goal record.  Validates horizon /
+    create-or-update a goal record.  Validates
     status / phase / priority / policy / principal /
     string_list fields against the pinned allowed-value tables.
     Lifecycle field errors are reported via the dedicated

--- a/test/test_goal_store.ml
+++ b/test/test_goal_store.ml
@@ -40,7 +40,7 @@ let iso_now () = Masc_domain.now_iso ()
 let make_goal id title =
   let ts = iso_now () in
   {
-    Goal_store.id; horizon = Short; title;
+    Goal_store.id; title;
     metric = None; target_value = None; due_date = None;
     priority = 3; status = Active; phase = Goal_phase.Executing;
     verifier_policy = None; require_completion_approval = false;

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -129,7 +129,6 @@ let test_goal_upsert_and_list () =
       ~args:
         (`Assoc
             [ "title", `String "Ship Goal Surface"
-            ; "horizon", `String "mid"
             ; "priority", `Int 2
             ])
   in
@@ -159,7 +158,7 @@ let test_goal_upsert_and_list () =
     Tool_workspace.dispatch
       (workspace_ctx config)
       ~name:"masc_goal_list"
-      ~args:(`Assoc [ "horizon", `String "mid" ])
+      ~args:(`Assoc [])
   in
   let listed_json =
     match listed with
@@ -222,7 +221,7 @@ let test_goal_list_ignores_blank_optional_filters () =
     Tool_workspace.dispatch
       (workspace_ctx config)
       ~name:"masc_goal_list"
-      ~args:(`Assoc [ "horizon", `String ""; "phase", `String "" ])
+      ~args:(`Assoc [ "phase", `String "" ])
   in
   let listed_json =
     match listed with

--- a/test/test_goal_upsert_fsm_bypass_10247.ml
+++ b/test/test_goal_upsert_fsm_bypass_10247.ml
@@ -181,7 +181,7 @@ let test_no_lifecycle_field_still_round_trips () =
   let body =
     dispatch_upsert_must_succeed
       (workspace_ctx config)
-      [ "title", `String "Default goal"; "horizon", `String "mid"; "priority", `Int 2 ]
+      [ "title", `String "Default goal"; "priority", `Int 2 ]
   in
   check
     bool

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -668,7 +668,6 @@ let field_value fixture ~tool_name field_name schema =
   | "criteria" -> `List []
   | "topic" -> `String (ensure_library_topic fixture)
   | "include_candidates" -> `Bool true
-  | "horizon" -> `String "short"
   | "mode" -> (
       match enum_choice with
       | Some value -> `String value

--- a/test/test_tool_input_validation.ml
+++ b/test/test_tool_input_validation.ml
@@ -1420,7 +1420,6 @@ let test_registered_hook_goal_list_strips_blank_optional_enums () =
   let args =
     `Assoc
       [
-        ("horizon", `String "");
         ("phase", `String " ");
       ]
   in
@@ -1432,8 +1431,6 @@ let test_registered_hook_goal_list_strips_blank_optional_enums () =
       ()
   in
   Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
-  Alcotest.(check bool) "horizon removed" true
-    (Yojson.Safe.Util.member "horizon" forwarded = `Null);
   Alcotest.(check bool) "phase removed" true
     (Yojson.Safe.Util.member "phase" forwarded = `Null)
 
@@ -1449,7 +1446,9 @@ let test_registered_hook_goal_list_rejects_status_filter () =
   Alcotest.(check bool) "blocked" true (Option.is_some blocked)
 
 let test_registered_hook_goal_list_preserves_invalid_enum_for_handler () =
-  let args = `Assoc [("horizon", `String "week")] in
+  (* RFC-0294: horizon removed; phase is the surviving optional enum. An invalid
+     enum value must pass the hook so the handler performs the rejection. *)
+  let args = `Assoc [("phase", `String "notaphase")] in
   let blocked, forwarded =
     run_registered_hook
       ~schema:masc_goal_list_schema
@@ -1458,8 +1457,8 @@ let test_registered_hook_goal_list_preserves_invalid_enum_for_handler () =
       ()
   in
   Alcotest.(check bool) "not blocked" true (Option.is_none blocked);
-  Alcotest.(check string) "invalid value preserved for handler validation" "week"
-    (assoc_string "horizon" forwarded)
+  Alcotest.(check string) "invalid value preserved for handler validation" "notaphase"
+    (assoc_string "phase" forwarded)
 
 let test_registered_hook_required_enum_blank_is_not_stripped () =
   let schema =

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -294,7 +294,7 @@ let test_masc_goal_list_schema () =
   | Some schema ->
       match get_json_assoc "properties" schema.input_schema with
       | Some props ->
-          Alcotest.(check bool) "has horizon" true (List.mem_assoc "horizon" props);
+          Alcotest.(check bool) "horizon filter removed (RFC-0294)" false (List.mem_assoc "horizon" props);
           Alcotest.(check bool) "has phase" true (List.mem_assoc "phase" props);
           Alcotest.(check bool) "no legacy status filter" false (List.mem_assoc "status" props)
       | None -> Alcotest.fail "masc_goal_list missing properties"
@@ -307,7 +307,7 @@ let test_masc_goal_upsert_schema () =
       | Some props ->
           Alcotest.(check bool) "has id" true (List.mem_assoc "id" props);
           Alcotest.(check bool) "has title" true (List.mem_assoc "title" props);
-          Alcotest.(check bool) "has horizon" true (List.mem_assoc "horizon" props);
+          Alcotest.(check bool) "horizon removed (RFC-0294)" false (List.mem_assoc "horizon" props);
           Alcotest.(check bool) "omits status lifecycle field" false
             (List.mem_assoc "status" props);
           Alcotest.(check bool) "omits phase lifecycle field" false


### PR DESCRIPTION
## 왜 새 PR인가 (복구)
PR #22210은 RFC 문서 커밋 1개만 있을 때 squash 머지(`75ac8623`)되어, 이후 같은 브랜치에 올린 **구현 전부가 main에 도달하지 못했습니다**(RFC §3/§4/§5 정정 + OCaml 백엔드 purge + TS 대시보드 purge). 규칙대로(머지된 브랜치 재push 금지) 새 PR로 복구합니다. origin/main에서 분기 후 구현 4커밋 cherry-pick — target 파일이 main에서 0 diff라 무충돌.

RFC: `docs/rfc/RFC-0294-purge-workspace-goal-horizon.md` (이미 main에 존재, 이 PR은 §3/§4/§5만 정정).
⚠️ **RFC 번호 충돌**: main에 `RFC-0294-keeper-proactive-wake-actionability-invariant.md`(#22214 시리즈)도 존재. slug가 식별자라 공존하나(#22198), 혼란 방지를 위해 둘 중 하나 renumber 검토 필요(별개 follow-up).

## 무엇을
workspace-goal `horizon`(단기/중기/장기)을 백엔드 `Goal_store` + MCP + 대시보드(OCaml+TS)에서 완전 제거. **타입 식별자 `Goal_store.horizon` 기준**(문자열 아님): Hebbian decay / runtime deadline / memory-grounding horizon / `horizontal` geometry / cockpit `goal-horizon` URL slug는 보존.

## 정당성 (RFC §3 census)
horizon 소비자 7종: ①refresh/snapshot cadence=**dead**(호출자 0·mli 미노출·lock 0) ②정렬키→`(priority,updated_at desc)` collapse ③rollup count 삭제 ④list 필터 삭제 ⑤**라이브 stagnation 임계값**→단일 상수 1d로 re-base(운영자 선택) ⑥keeper 프롬프트 주입 드롭 ⑦대시보드 JSON 드롭.

## 구현 (P1-P3)
- **OCaml**: goal_store.ml(i) 타입/codec/필드/dead cadence 제거·정렬 collapse·legacy `"horizon"` 키 무시(표준 스키마 진화); workspace_goals + tool_schemas(`additionalProperties:false`로 explicit horizon 거부, hand-guard 아님); dashboard stagnation/JSON·keeper active_goals 3→2튜플(prompt/snapshot/.mli ripple 포함).
- **TS**: types/core(Goal/KeeperConfigActiveGoal/GoalTreeNode), store/api decode, goal-helpers(horizon API 제거), work.ts·planning.ts(horizon 그룹핑→flat priority-sorted), goal-tree 배지, keeper-config/ide 패널, goal-loop-panel, CSS(.wk-horizon/.hz-* 등), 테스트 11파일.

## 검증
- `dune build --root .` green (origin/main rebase 후).
- dashboard `tsc --noEmit` clean; vitest 324 pass(동일 트리, 11 touched files).
- `test_goal_tools`/`test_goal_upsert_fsm` pass; `test_goal_store` 10/11 — 실패 1건(`delete_goal` prune-injection)은 **base에서도 동일 실패**(macOS 파일시스템 quirk, stash로 입증, CI Linux authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
