### PR TITLE
fix(ci): register KeeperProactiveWakeGuard TLA spec as known-unchecked (unblock main)

### DIFF
--- a/scripts/ci/check-tla-harness-coverage.sh
+++ b/scripts/ci/check-tla-harness-coverage.sh
@@ -14,6 +14,11 @@ specs/keeper-state-machine/KeeperRuntimeAttemptFSM.tla
 specs/keeper-state-machine/KeeperRuntimeRouting.tla
 specs/keeper-state-machine/KeeperPostTurnOrchestration.tla
 specs/keeper-state-machine/KeeperRolloverDecision.tla
+# KeeperProactiveWakeGuard.tla was added by #22214 (RFC-0294 proactive-wake) with
+# clean + buggy cfgs but never wired into scripts/tla-check.sh, which reds this gate
+# on main and blocks every PR. Registered as known-unchecked debt to unblock; proper
+# TLC wiring (clean=no-error, buggy=invariant-violated) is a #22214 follow-up.
+specs/keeper-state-machine/KeeperProactiveWakeGuard.tla
 EOF
 }
 


### PR DESCRIPTION
## 무엇을 / 왜
`#22214`(RFC-0294 proactive-wake)가 `specs/keeper-state-machine/KeeperProactiveWakeGuard.tla`를 clean+buggy cfg와 함께 추가했지만 `scripts/tla-check.sh`에 연결하지 않았습니다. 그 결과 `check-tla-harness-coverage.sh`가 **origin/main의 "Meta Guards" 게이트를 red**로 만들어 **열린 모든 PR을 차단**합니다(inherited).

이 PR은 그 spec을 `known_unchecked_specs`에 **audit note와 함께 등록**해 main CI를 green으로 되돌립니다.

## 정직성 (debt 등록이지 real fix 아님)
이건 갭을 가리는 게 아니라 **명시적 debt 등록**입니다. 게이트 메시지가 제공하는 두 경로("wire into tla-check.sh OR add to known_unchecked_specs") 중 후자. KeeperProactiveWakeGuard는 cfg가 있어 TLA bug-model 패턴(clean=no-error / buggy=invariant-violated)으로 **실제 wiring 되어야** 하며, 그건 **#22214 follow-up 소유**입니다. 주석에 이를 명시하고 wiring 시 이 엔트리를 제거하도록 안내했습니다.

## 검증
`bash scripts/ci/check-tla-harness-coverage.sh` → `PASS` (rc=0).

참고: 나머지 inherited red(Lint R6 ratchet)는 #22220이 proactive-wake RFC의 `~/.masc`→`<base-path>/.masc` 변환으로 처리 중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)