### PR TITLE
fix(schedule): gate side-effecting payload kinds at creation (RFC-0234)

### DIFF
--- a/docs/rfc/RFC-0234-scheduled-internal-automation.md
+++ b/docs/rfc/RFC-0234-scheduled-internal-automation.md
@@ -197,6 +197,37 @@ clarification payload such as `kind = "operator.clarification_request"`. The
 schedule core treats that as opaque data too; the consumer decides how to ask
 and what later schedule, if any, to create from the answer.
 
+### Supported payload kind contract (creation gate)
+
+The schedule domain keeps the payload envelope opaque (above), but the
+**creation tool path** rejects **side-effecting** payload kinds the
+production consumer cannot dispatch. Read-only/reminder kinds carry no side
+effect, so they stay opaque and are allowed; the consumer records a visible
+failed execution if it cannot interpret one. The single source of truth for
+dispatchable side-effecting kinds is
+`lib/schedule/schedule_supported_kinds.ml`, referenced by both the creation
+validator (`lib/tool_schedule.ml:validate_known_payload_request`) and the
+consumer (`lib/server/server_schedule_consumers.ml:supported_payload_kinds`).
+Adding a kind to that list is the contract surface; the consumer adapter
+must still implement `accepts`/`dispatch` for it.
+
+This closes the accept-then-die gap. Before this gate, a producer could
+create a schedule with any `kind` string (`orphan_auto_release`,
+`task_goal_generation`, `backlog_depletion_check`, `keeper_surface_post`)
+the consumer could not interpret. The schedule was persisted, became due,
+and the consumer rejected it at dispatch — recorded as a failed execution
+with `error = "unsupported schedule payload kind: ..."` (`fail_due_candidate`
+in `lib/schedule/schedule_store.ml`). The failure was already visible through
+the dashboard (`last_execution.error`), but the schedule was already dead and
+left terminal clutter in the ledger. The creation gate rejects the kind up
+front so the producer learns immediately and cannot fill the queue with work
+that cannot run.
+
+Those keeper-autonomous kinds are intentionally **not** in the supported set:
+they require keeper runtime context (bound surfaces, keeper identity, secret
+redaction) the schedule consumer does not own. They belong in the keeper
+`scheduled_autonomous` path, not the generic schedule queue.
+
 ## §5 Separation-of-duties invariant
 
 The central predicate is:

--- a/lib/schedule/dune
+++ b/lib/schedule/dune
@@ -8,5 +8,10 @@
  (name masc_schedule)
  (public_name masc.masc_schedule)
  (wrapped false)
- (modules schedule_domain schedule_store schedule_service schedule_runner)
+ (modules
+  schedule_domain
+  schedule_supported_kinds
+  schedule_store
+  schedule_service
+  schedule_runner)
  (libraries digestif masc_workspace dated_jsonl unix yojson))

--- a/lib/schedule/schedule_supported_kinds.ml
+++ b/lib/schedule/schedule_supported_kinds.ml
@@ -7,17 +7,17 @@
     dispatch, and neither layer reaches across the [lib/tool] <-> [lib/server]
     boundary (software-development.md boundary-violation antipattern).
 
-    Adding a kind here makes it (a) accepted by the creation validator and
-    (b) declared as supported by the consumer. The consumer adapter must still
-    implement [accepts]/[dispatch] for the kind — this list is the contract,
-    the adapter is the implementation. A supported kind without an adapter
-    branch surfaces at dispatch time as a failed execution with a recorded
-    reason, rather than being silently accepted at creation and dying later:
-    that silent accept-then-die gap is exactly what this module closes. *)
+    Adding a kind here makes it (a) declared as dispatchable by the consumer and
+    (b) listed in {!unsupported_error}'s allow-list. It does NOT by itself make
+    the kind accepted at creation: each side-effecting kind carries its own
+    payload + risk-class contract, enforced by a per-kind branch in
+    [Tool_schedule.validate_known_payload_request]. A kind listed here but
+    without a validator branch stays rejected at creation as an unsupported
+    side-effecting kind — closing the silent accept-then-die gap, just in the
+    safe (reject) direction. So a new side-effecting kind needs BOTH the list
+    entry and a validator branch. *)
 
 let supported = [ "masc.board_post" ]
-
-let is_supported kind = List.mem kind supported
 
 let supported_list_string () = String.concat ", " supported
 

--- a/lib/schedule/schedule_supported_kinds.ml
+++ b/lib/schedule/schedule_supported_kinds.ml
@@ -1,0 +1,29 @@
+(** Supported schedule payload kinds — single source of truth.
+
+    This neutral module is the contract surface between the schedule creation
+    tool layer ({!Tool_schedule}) and the production consumer
+    ({!Server_schedule_consumers}). Both reference this list so that a payload
+    kind accepted at creation time is exactly one the consumer declares it can
+    dispatch, and neither layer reaches across the [lib/tool] <-> [lib/server]
+    boundary (software-development.md boundary-violation antipattern).
+
+    Adding a kind here makes it (a) accepted by the creation validator and
+    (b) declared as supported by the consumer. The consumer adapter must still
+    implement [accepts]/[dispatch] for the kind — this list is the contract,
+    the adapter is the implementation. A supported kind without an adapter
+    branch surfaces at dispatch time as a failed execution with a recorded
+    reason, rather than being silently accepted at creation and dying later:
+    that silent accept-then-die gap is exactly what this module closes. *)
+
+let supported = [ "masc.board_post" ]
+
+let is_supported kind = List.mem kind supported
+
+let supported_list_string () = String.concat ", " supported
+
+let unsupported_error kind =
+  Printf.sprintf
+    "unsupported schedule payload kind: %s; supported: %s"
+    kind
+    (supported_list_string ())
+;;

--- a/lib/schedule/schedule_supported_kinds.mli
+++ b/lib/schedule/schedule_supported_kinds.mli
@@ -1,0 +1,22 @@
+(** Supported schedule payload kinds — single source of truth.
+
+    This neutral module is the contract surface between the schedule creation
+    tool layer ({!Tool_schedule}) and the production consumer
+    ({!Server_schedule_consumers}); see {!Schedule_supported_kinds} for the
+    full design rationale. Both layers reference this list so that a payload
+    kind accepted at creation is exactly one the consumer declares it can
+    dispatch, with neither layer reaching across the [lib/tool] <-> [lib/server]
+    boundary. *)
+
+val supported : string list
+(** Dispatchable side-effecting payload kinds the production consumer can run.
+    Adding a kind here makes it accepted by the creation validator and declared
+    as supported by the consumer; the consumer adapter must still implement
+    [accepts]/[dispatch] for it. *)
+
+val is_supported : string -> bool
+
+val supported_list_string : unit -> string
+
+val unsupported_error : string -> string
+(** Error message for a payload kind outside {!supported}. *)

--- a/lib/schedule/schedule_supported_kinds.mli
+++ b/lib/schedule/schedule_supported_kinds.mli
@@ -3,18 +3,19 @@
     This neutral module is the contract surface between the schedule creation
     tool layer ({!Tool_schedule}) and the production consumer
     ({!Server_schedule_consumers}); see {!Schedule_supported_kinds} for the
-    full design rationale. Both layers reference this list so that a payload
-    kind accepted at creation is exactly one the consumer declares it can
-    dispatch, with neither layer reaching across the [lib/tool] <-> [lib/server]
-    boundary. *)
+    full design rationale. Neither layer reaches across the
+    [lib/tool] <-> [lib/server] boundary. *)
 
 val supported : string list
 (** Dispatchable side-effecting payload kinds the production consumer can run.
-    Adding a kind here makes it accepted by the creation validator and declared
-    as supported by the consumer; the consumer adapter must still implement
-    [accepts]/[dispatch] for it. *)
-
-val is_supported : string -> bool
+    This is the consumer's dispatch set and the allow-list in
+    {!unsupported_error}. Note: the creation validator does NOT grant
+    acceptance from this list alone — each side-effecting kind carries its own
+    payload + risk-class contract enforced by a per-kind branch in
+    [Tool_schedule.validate_known_payload_request]. So adding a side-effecting
+    kind requires BOTH an entry here (consumer dispatch + reject message) AND a
+    validator branch (creation acceptance); the list alone leaves it rejected at
+    creation as an unsupported side-effecting kind. *)
 
 val supported_list_string : unit -> string
 

--- a/lib/server/server_schedule_consumers.ml
+++ b/lib/server/server_schedule_consumers.ml
@@ -2,7 +2,7 @@
    [Schedule_runner] and persisted as execution records; the server maintenance
    loop logs aggregate dispatch counts for runtime telemetry. *)
 
-let supported_payload_kinds = [ "masc.board_post" ]
+let supported_payload_kinds = Schedule_supported_kinds.supported
 
 let ( let* ) = Result.bind
 

--- a/lib/tool_schedule.ml
+++ b/lib/tool_schedule.ml
@@ -270,8 +270,17 @@ let validate_known_payload_request ~payload ~risk_class =
          | None ->
            Error
              "masc.board_post payload requires object body with non-empty content; use board_content for board schedules")
-     | _ -> Ok ())
-  | _ -> Ok ()
+     | Some kind when Schedule_domain.is_side_effecting risk_class ->
+       (* Only side-effecting work needs a consumer adapter that can dispatch
+          it. Reject kinds the consumer cannot run so the queue is not filled
+          with work that dies at dispatch. Read-only/reminder kinds carry no
+          side effect, so their kind stays opaque to the schedule domain — a
+          consumer that does not recognize one records a visible failed
+          execution (fail_due_candidate), not a silent accept-then-die. *)
+       Error (Schedule_supported_kinds.unsupported_error kind)
+     | Some _ -> Ok ()
+     | None -> Error "payload.kind is required")
+  | _ -> Error "payload must be a JSON object"
 ;;
 
 let schedule_request_json ?last_execution (request : Schedule_domain.schedule_request) =

--- a/test/test_schedule_tool_wiring.ml
+++ b/test/test_schedule_tool_wiring.ml
@@ -403,6 +403,41 @@ let test_dispatch_create_rejects_board_payload_without_content () =
   check int "no schedule persisted" 0 (List.length state.schedules)
 ;;
 
+(* A side-effecting payload kind the consumer cannot dispatch must be rejected
+   at creation. The supported set is the SSOT in schedule_supported_kinds.ml;
+   read-only/reminder kinds stay opaque (allowed), only side-effecting work is
+   gated. *)
+let test_dispatch_create_rejects_unsupported_side_effecting_kind () =
+  with_config
+  @@ fun config ->
+  let args =
+    `Assoc
+      [ "schedule_id", `String "sched-unsupported-kind"
+      ; "due_at_unix", `Float 200.0
+      ; "risk_class", `String "workspace_write"
+      ; "payload_kind", `String "orphan_auto_release"
+      ; "payload_body", `Assoc [ "action", `String "orphan_auto_release" ]
+      ; "requested_by_id", `String "operator"
+      ; "scheduled_by_id", `String "scheduler-agent"
+      ]
+  in
+  (match
+     Tool_schedule.dispatch (schedule_ctx config)
+       ~name:(schedule_tool_name Tool_schemas_schedule.Create_request)
+       ~args
+   with
+   | None -> fail "dispatch returned None"
+   | Some result ->
+     check bool "create rejects unsupported side-effecting kind" false
+       (Tool_result.is_success result);
+     check (option string) "failure class" (Some "workflow_rejection")
+       (Option.map Tool_result.tool_failure_class_to_string
+          (Tool_result.failure_class result)));
+  let state = Schedule_store.read_state config in
+  check int "no schedule persisted for unsupported kind" 0
+    (List.length state.schedules)
+;;
+
 let test_dispatch_create_rejects_read_only_board_payload () =
   with_config
   @@ fun config ->
@@ -818,6 +853,8 @@ let () =
             test_dispatch_create_rejects_board_payload_without_content
         ; test_case "dispatch create rejects read-only board payload" `Quick
             test_dispatch_create_rejects_read_only_board_payload
+        ; test_case "dispatch create rejects unsupported side-effecting kind" `Quick
+            test_dispatch_create_rejects_unsupported_side_effecting_kind
         ; test_case "dispatch cancel persists status" `Quick
             test_dispatch_cancel_persists_status
         ; test_case "dashboard projection surfaces schedule FSM" `Quick


### PR DESCRIPTION
## Summary

Closes the silent **accept-then-die** gap in the scheduled automation queue (RFC-0234). `validate_known_payload_request` accepted any payload kind except `masc.board_post` (`| _ -> Ok`), so producers could create schedules whose kind the production consumer cannot dispatch (`orphan_auto_release`, `keeper_surface_post`, ...). The schedule was persisted, became due, and the consumer rejected it at dispatch — recorded as a failed execution with `error = "unsupported schedule payload kind: ..."`, visible only afterward via `last_execution.error`.

## Changes

- Extract the dispatchable **side-effecting** kind set into a neutral SSOT (`lib/schedule/schedule_supported_kinds.ml`), referenced by both the creation validator (`lib/tool_schedule.ml`) and the consumer (`lib/server/server_schedule_consumers.ml`). No `lib/tool` -> `lib/server` boundary violation.
- `validate_known_payload_request` rejects **side-effecting** kinds outside that set at creation. Read-only/reminder kinds stay opaque (no side effect; a consumer that cannot interpret one records a visible failed execution, not a dangerous one).
- RFC-0234 §4 documents the "Supported payload kind contract (creation gate)".
- Regression test for the side-effecting reject path.

## Scope (this PR)

`keeper_surface_post` and the orphan kinds require keeper runtime context (bound surfaces, keeper identity) and belong in the keeper `scheduled_autonomous` path, not this queue — deferred to a follow-up.

## Verification

- `dune build` green.
- New test `dispatch create rejects unsupported side-effecting kind` passes.
- Existing cron/signals tests pass after the read-only relaxation.

## Notes

- `test_dashboard_projection_surfaces_schedule_fsm` (`due keeper next tool hidden visibility`) fails on this branch AND on unmodified origin/main (verified via stash). It is a pre-existing local-environment failure in `masc_schedule_get` tool catalog visibility, unrelated to this change.

RFC: RFC-0234 (scheduled-internal-automation) §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
