### PR TITLE
docs(keeper): stale noop cooldown 주석 정정 (8x→4x) [RFC-0294 PR-7]

### DIFF
--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -915,8 +915,9 @@ let effective_scheduled_autonomous_cooldown
   : int
   =
   (* Noop backoff: consecutive observation-only cycles multiply the base
-     cooldown by 2^min(n, 3), capping at 8x. This prevents token waste when
-     the keeper repeatedly reads board_list without taking action. *)
+     cooldown by 2^min(n, 2), capping at 4x (see [noop_multiplier] below: the
+     shift is [min consecutive_noop_count 2], i.e. 1, 2, 4). This prevents
+     token waste when the keeper repeatedly reads board_list without acting. *)
   let noop_multiplier =
     if consecutive_noop_count <= 0 then 1 else 1 lsl min consecutive_noop_count 2
     (* 1, 2, 4 *)


### PR DESCRIPTION
RFC-0294 PR-7/7 (무빌드, 주석 전용).

`keeper_world_observation.ml`의 noop backoff 블록 주석이 코드와 불일치:
- 주석(구): `2^min(n, 3), capping at 8x`
- 실제 코드: `1 lsl min consecutive_noop_count 2` = `2^min(n, 2)`, 최대 **4x**
- 바로 다음 줄 인라인 주석 `(* 1, 2, 4 *)`은 이미 코드와 일치 → 블록 주석만 stale.

주석을 4x로 정정하고 shift 식을 명시 인용. 코드 변경 없음.

검증: `dune build lib/keeper` exit 0.

Refs RFC-0294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
