### PR TITLE
feat(dashboard): Work surface 시안 fidelity — WorkAside panel + list|kanban toggle

### DIFF
--- a/dashboard/src/components/goals/goal-create-form.ts
+++ b/dashboard/src/components/goals/goal-create-form.ts
@@ -1,0 +1,197 @@
+// Goal creation form — modal overlay pattern.
+// Design reference: prototype NewGoalComposer (work.jsx ~line 437).
+// RFC-0294: no horizon; no lead keeper (live Goal type has no owner field).
+// Fields: title (required), priority (1-5), require_completion_approval (checkbox).
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { TextInput } from '../common/input'
+import { Select } from '../common/select'
+import { ActionButton } from '../common/button'
+import {
+  showGoalCreate,
+  goalCreating,
+  goalCreateError,
+  createGoal,
+  resetGoalCreateForm,
+  GOAL_PRIORITY_MIN,
+  GOAL_PRIORITY_MAX,
+  GOAL_PRIORITY_DEFAULT,
+} from './goal-create-state'
+
+// ── Local form state signals ─────────────────────────────────────────────────
+
+const titleSignal = signal('')
+const prioritySignal = signal(GOAL_PRIORITY_DEFAULT)
+const approvalSignal = signal(false)
+
+export function resetGoalCreateFormLocal(): void {
+  titleSignal.value = ''
+  prioritySignal.value = GOAL_PRIORITY_DEFAULT
+  approvalSignal.value = false
+  resetGoalCreateForm()
+}
+
+function resetLocalForm(): void {
+  resetGoalCreateFormLocal()
+}
+
+// ── Priority options ─────────────────────────────────────────────────────────
+
+const PRIORITY_OPTIONS = Array.from(
+  { length: GOAL_PRIORITY_MAX - GOAL_PRIORITY_MIN + 1 },
+  (_, i) => {
+    const v = GOAL_PRIORITY_MIN + i
+    const label = v === 1 ? `P${v} · 최고` : v === GOAL_PRIORITY_MAX ? `P${v} · 낮음` : `P${v}`
+    return { value: String(v), label }
+  },
+)
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function GoalCreateForm() {
+  if (!showGoalCreate.value) return null
+
+  // Escape key dismisses
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        showGoalCreate.value = false
+        resetLocalForm()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => { window.removeEventListener('keydown', onKey) }
+  }, [])
+
+  const handleSubmit = () => {
+    void createGoal({
+      title: titleSignal.value,
+      priority: prioritySignal.value,
+      require_completion_approval: approvalSignal.value,
+    }).then(ok => {
+      if (ok) resetLocalForm()
+    })
+  }
+
+  const handleClose = () => {
+    showGoalCreate.value = false
+    resetLocalForm()
+  }
+
+  const isTitleEmpty = !titleSignal.value.trim()
+  const isSubmitDisabled = goalCreating.value || isTitleEmpty
+
+  return html`
+    <div
+      class="turn-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="goal-create-title"
+      data-testid="goal-create-overlay"
+      onClick=${handleClose}
+    >
+      <div
+        class="turn-drawer ngc-drawer"
+        data-testid="goal-create-form"
+        onClick=${(e: MouseEvent) => { e.stopPropagation() }}
+      >
+        <div class="turn-hd">
+          <h3 id="goal-create-title">새 목표</h3>
+          <span class="tid mono">masc_goal_upsert</span>
+          <span style=${{ marginLeft: 'auto' }}></span>
+          <button
+            type="button"
+            class="turn-close"
+            data-testid="goal-create-close"
+            onClick=${handleClose}
+            aria-label="닫기 (Esc)"
+          >✕</button>
+        </div>
+
+        <div class="turn-body">
+          <div class="turn-sec">
+            <label
+              for="goal-create-title-input"
+              class="text-2xs font-medium text-text-muted"
+            >
+              제목<span class="ml-0.5 text-[var(--color-status-err)]">*</span>
+            </label>
+            <${TextInput}
+              id="goal-create-title-input"
+              testId="goal-create-title-input"
+              value=${titleSignal.value}
+              placeholder="예) scheduler p99 SLO 400ms 회복"
+              autoFocus=${true}
+              onInput=${(e: Event) => { titleSignal.value = (e.target as HTMLInputElement).value }}
+            />
+            ${isTitleEmpty && goalCreateError.value === '제목을 입력하세요' ? html`
+              <p class="mt-1 text-2xs text-[var(--color-status-err)]" role="alert" data-testid="goal-create-title-error">
+                ${goalCreateError.value}
+              </p>
+            ` : null}
+          </div>
+
+          <div class="turn-sec">
+            <label
+              for="goal-create-priority"
+              class="text-2xs font-medium text-text-muted"
+            >
+              우선순위 · <span class="mono">P${prioritySignal.value}</span>
+            </label>
+            <${Select}
+              id="goal-create-priority"
+              testId="goal-create-priority"
+              value=${String(prioritySignal.value)}
+              options=${PRIORITY_OPTIONS}
+              ariaLabel="우선순위"
+              onInput=${(v: string) => { prioritySignal.value = Number(v) }}
+            />
+            <p class="mt-1 text-2xs text-text-muted">P1이 가장 높습니다.</p>
+          </div>
+
+          <div class="turn-sec">
+            <label class="ngc-check flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                data-testid="goal-create-approval-checkbox"
+                checked=${approvalSignal.value}
+                onChange=${(e: Event) => { approvalSignal.value = (e.target as HTMLInputElement).checked }}
+              />
+              <span>완료 승인 필요 <b>operator 검증 게이트</b></span>
+            </label>
+          </div>
+
+          ${goalCreateError.value && goalCreateError.value !== '제목을 입력하세요' ? html`
+            <div class="turn-sec">
+              <p class="text-2xs text-[var(--color-status-err)]" role="alert" data-testid="goal-create-error">
+                ${goalCreateError.value}
+              </p>
+            </div>
+          ` : null}
+
+          <div class="turn-sec bcc-actions flex flex-wrap gap-2">
+            <${ActionButton}
+              variant="primary"
+              size="md"
+              testId="goal-create-submit"
+              disabled=${isSubmitDisabled}
+              ariaBusy=${goalCreating.value}
+              onClick=${handleSubmit}
+            >
+              ${goalCreating.value ? '생성 중...' : '＋ 목표 생성'}
+            <//>
+            <${ActionButton}
+              variant="ghost"
+              size="md"
+              testId="goal-create-cancel"
+              onClick=${handleClose}
+            >취소<//>
+          </div>
+        </div>
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/goals/goal-create-state.ts
+++ b/dashboard/src/components/goals/goal-create-state.ts
@@ -1,0 +1,57 @@
+// Goal creation state and async action — mirrors task-manage-state.ts idiom.
+// RFC-0294: no horizon field; no status/phase (lifecycle-only via masc_goal_transition).
+
+import { signal } from '@preact/signals'
+import { callMcpTool } from '../../api/mcp'
+import { showToast } from '../common/toast'
+import { refreshGoals } from '../../store'
+import { errorToString } from '../../lib/format-string'
+
+export const GOAL_PRIORITY_MIN = 1
+export const GOAL_PRIORITY_MAX = 5
+export const GOAL_PRIORITY_DEFAULT = 3
+
+export const showGoalCreate = signal(false)
+export const goalCreating = signal(false)
+export const goalCreateError = signal<string | null>(null)
+
+export interface GoalCreateInput {
+  title: string
+  priority: number
+  require_completion_approval: boolean
+}
+
+export async function createGoal(input: GoalCreateInput): Promise<boolean> {
+  const trimmedTitle = input.title.trim()
+  if (!trimmedTitle) {
+    goalCreateError.value = '제목을 입력하세요'
+    return false
+  }
+  goalCreating.value = true
+  goalCreateError.value = null
+  try {
+    const args: Record<string, unknown> = {
+      title: trimmedTitle,
+      priority: input.priority,
+    }
+    if (input.require_completion_approval) {
+      args.require_completion_approval = true
+    }
+    await callMcpTool('masc_goal_upsert', args)
+    showToast('목표 생성 완료', 'success')
+    showGoalCreate.value = false
+    await refreshGoals()
+    return true
+  } catch (err) {
+    const message = errorToString(err)
+    goalCreateError.value = message
+    showToast(`목표 생성 실패: ${message}`, 'error')
+    return false
+  } finally {
+    goalCreating.value = false
+  }
+}
+
+export function resetGoalCreateForm(): void {
+  goalCreateError.value = null
+}

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -59,6 +59,7 @@ describe('Work', () => {
   afterEach(() => {
     cleanup()
     navigateMock.mockClear()
+    selectedTask.value = null
   })
 
   beforeEach(() => {
@@ -840,7 +841,6 @@ describe('Work', () => {
         tasks.value = [
           { id: 'T-todo', title: 'Todo item', goal_id: 'G-1', status: 'todo' },
         ]
-        selectedTask.value = null
 
         render(html`<${Work} />`)
         fireEvent.click(screen.getByTestId('work-view-kanban'))
@@ -853,7 +853,6 @@ describe('Work', () => {
         // openTaskDetail() set the shared selection signal (TaskDetailOverlay is
         // mounted globally in app.ts and renders off this signal).
         expect(selectedTask.value?.id).toBe('T-todo')
-        selectedTask.value = null
       })
     })
   })

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -52,6 +52,7 @@ vi.mock('./repository-management', () => ({
 }))
 
 import { goals, keepers, tasks } from '../store'
+import { selectedTask } from './goals/task-detail-selection'
 import { Work } from './work'
 
 describe('Work', () => {
@@ -830,6 +831,29 @@ describe('Work', () => {
 
         // Backlog strip (.wk-backlog) must NOT be present in kanban view
         expect(screen.queryByTestId('work-backlog')).toBeNull()
+      })
+
+      it('opens the shared task detail overlay when a kanban card is clicked', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = [
+          { id: 'T-todo', title: 'Todo item', goal_id: 'G-1', status: 'todo' },
+        ]
+        selectedTask.value = null
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('work-view-kanban'))
+
+        const card = screen
+          .getByTestId('work-kanban')
+          .querySelector('[data-kanban-task-id="T-todo"]') as HTMLElement
+        expect(selectedTask.value).toBeNull()
+        fireEvent.click(card)
+        // openTaskDetail() set the shared selection signal (TaskDetailOverlay is
+        // mounted globally in app.ts and renders off this signal).
+        expect(selectedTask.value?.id).toBe('T-todo')
+        selectedTask.value = null
       })
     })
   })

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom'
 
@@ -225,7 +225,9 @@ describe('Work', () => {
       const row = screen.getByTestId('job-row')
       expect(row).toBeTruthy()
       expect(row.classList.contains('wk-task')).toBe(true)
-      expect(screen.getByText('Blocked job')).toBeTruthy()
+      // Scope text search to the goal card — the WorkAside also surfaces this
+      // task as a blocker, so screen.getByText() would find multiple matches.
+      expect(within(card! as HTMLElement).getByText('Blocked job')).toBeTruthy()
       expect(screen.getByTestId('job-blocker').textContent).toContain('dependency missing')
       expect(screen.queryByTestId('job-detail')).toBeNull()
     })
@@ -449,6 +451,244 @@ describe('Work', () => {
 
       expect(screen.queryByTestId('work-task-detail')).toBeNull()
       expect(screen.queryByTestId('job-detail')).toBeNull()
+    })
+
+    // ── WorkAside operator triage panel ─────────────────────────────────────
+    describe('WorkAside operator triage panel', () => {
+      // All WorkAside tests use section: 'work' (set in beforeEach above)
+
+      it('renders the aside panel alongside the main goal list', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Active Goal', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = []
+
+        render(html`<${Work} />`)
+
+        // The main goal list and KPI strip should still be present
+        expect(screen.getByTestId('work-kpis')).toBeTruthy()
+        // The aside panel should be present
+        expect(screen.getByTestId('work-aside')).toBeTruthy()
+      })
+
+      it('shows calm empty state when no flagged goals, no todos, and no recent tasks', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Normal Goal', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = []
+
+        render(html`<${Work} />`)
+
+        const aside = screen.getByTestId('work-aside')
+        // "지금 상황" calm state
+        expect(aside.querySelector('[data-testid="wka-flagged-calm"]')?.textContent).toContain('주의 목표 없음')
+        // "해야 할 일" calm state
+        expect(aside.querySelector('[data-testid="wka-todo-calm"]')?.textContent).toContain('대기 중인 작업 없음')
+        // "최근 한 일" calm state
+        expect(aside.querySelector('[data-testid="wka-recent-calm"]')?.textContent).toContain('완료된 task 없음')
+      })
+
+      it('flags goals whose phase is not executing (blocked, paused, awaiting_verification, awaiting_approval)', () => {
+        goals.value = [
+          { id: 'G-ok', title: 'Executing Goal', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+          { id: 'G-bl', title: 'Blocked Goal', priority: 2, status: 'active', phase: 'blocked', created_at: '2026-01-01', updated_at: '2026-01-01' },
+          { id: 'G-pa', title: 'Paused Goal', priority: 3, status: 'active', phase: 'paused', created_at: '2026-01-01', updated_at: '2026-01-01' },
+          { id: 'G-vf', title: 'Verify Goal', priority: 4, status: 'active', phase: 'awaiting_verification', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = []
+
+        render(html`<${Work} />`)
+
+        const aside = screen.getByTestId('work-aside')
+        const flaggedItems = aside.querySelectorAll('[data-testid="wka-flagged-item"]')
+        // G-ok (executing) must NOT appear; the other 3 must appear
+        expect(flaggedItems.length).toBe(3)
+        const titles = Array.from(flaggedItems).map(el => el.textContent ?? '')
+        expect(titles.some(t => t.includes('Blocked Goal'))).toBe(true)
+        expect(titles.some(t => t.includes('Paused Goal'))).toBe(true)
+        expect(titles.some(t => t.includes('Verify Goal'))).toBe(true)
+        expect(titles.some(t => t.includes('Executing Goal'))).toBe(false)
+        // No calm state should be shown
+        expect(aside.querySelector('[data-testid="wka-flagged-calm"]')).toBeNull()
+      })
+
+      it('surfaces approval items for goals with require_completion_approval=true and phase=awaiting_approval', () => {
+        goals.value = [
+          {
+            id: 'G-ap',
+            title: 'Approval Goal',
+            priority: 1,
+            status: 'active',
+            phase: 'awaiting_approval',
+            require_completion_approval: true,
+            verifier_policy: {
+              inherit_mode: 'replace' as const,
+              principals: [{ id: 'lead-keeper' }],
+            },
+            created_at: '2026-01-01',
+            updated_at: '2026-01-01',
+          },
+          // require_completion_approval=true but NOT awaiting_approval phase → no approval item
+          {
+            id: 'G-ex',
+            title: 'Executing With Approval Policy',
+            priority: 2,
+            status: 'active',
+            phase: 'executing',
+            require_completion_approval: true,
+            created_at: '2026-01-01',
+            updated_at: '2026-01-01',
+          },
+        ]
+        tasks.value = []
+
+        render(html`<${Work} />`)
+
+        const aside = screen.getByTestId('work-aside')
+        const approvalItems = aside.querySelectorAll('[data-testid="wka-approval-item"]')
+        expect(approvalItems.length).toBe(1)
+        expect(approvalItems[0]?.textContent).toContain('Approval Goal')
+        expect(approvalItems[0]?.textContent).toContain('lead-keeper')
+      })
+
+      it('surfaces verify tasks (awaiting_verification status) with unsatisfied gate count', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = [
+          {
+            id: 'J-vf',
+            title: 'Verify Me',
+            goal_id: 'G-1',
+            status: 'awaiting_verification',
+            gate: {
+              done: { status: 'blocked', checks: [], reasons: ['ci failing'] },
+              inspect_to_implement: { status: 'ready', checks: [], reasons: [] },
+            },
+          },
+        ]
+
+        render(html`<${Work} />`)
+
+        const aside = screen.getByTestId('work-aside')
+        const verifyItems = aside.querySelectorAll('[data-testid="wka-verify-item"]')
+        expect(verifyItems.length).toBe(1)
+        expect(verifyItems[0]?.textContent).toContain('Verify Me')
+        // 1 unsatisfied gate (done=blocked, inspect=ready → 1 open)
+        expect(verifyItems[0]?.textContent).toContain('1 미충족')
+      })
+
+      it('surfaces tasks with a blocker note (cancelled with handoff_context.reason)', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = [
+          {
+            id: 'J-bl',
+            title: 'Blocked Task',
+            goal_id: 'G-1',
+            status: 'cancelled',
+            handoff_context: { summary: '', reason: 'dependency unavailable' },
+          },
+        ]
+
+        render(html`<${Work} />`)
+
+        const aside = screen.getByTestId('work-aside')
+        const blockerItems = aside.querySelectorAll('[data-testid="wka-blocker-item"]')
+        expect(blockerItems.length).toBe(1)
+        expect(blockerItems[0]?.textContent).toContain('Blocked Task')
+        expect(blockerItems[0]?.textContent).toContain('dependency unavailable')
+      })
+
+      it('surfaces claimable backlog tasks as a single aggregate claim button', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = [
+          { id: 'J-1', title: 'Unassigned A', goal_id: 'G-1', status: 'todo' },
+          { id: 'J-2', title: 'Unassigned B', goal_id: 'G-1', status: 'todo' },
+          { id: 'J-3', title: 'Assigned', goal_id: 'G-1', status: 'todo', assignee: 'sangsu' },
+        ]
+
+        render(html`<${Work} />`)
+
+        const aside = screen.getByTestId('work-aside')
+        const backlogItem = aside.querySelector('[data-testid="wka-backlog-item"]')
+        expect(backlogItem).toBeTruthy()
+        expect(backlogItem?.textContent).toContain('미배정 task 2건')
+      })
+
+      it('surfaces done tasks in the 최근 한 일 section', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = [
+          { id: 'J-done1', title: 'Finished Task', goal_id: 'G-1', status: 'done' },
+          { id: 'J-done2', title: 'Another Done', goal_id: 'G-1', status: 'done' },
+          { id: 'J-wip', title: 'In Progress', goal_id: 'G-1', status: 'in_progress' },
+        ]
+
+        render(html`<${Work} />`)
+
+        const aside = screen.getByTestId('work-aside')
+        const recentItems = aside.querySelectorAll('[data-testid="wka-recent-item"]')
+        expect(recentItems.length).toBe(2)
+        const texts = Array.from(recentItems).map(el => el.textContent ?? '')
+        expect(texts.some(t => t.includes('Finished Task'))).toBe(true)
+        expect(texts.some(t => t.includes('Another Done'))).toBe(true)
+        expect(aside.querySelector('[data-testid="wka-recent-calm"]')).toBeNull()
+      })
+
+      it('toggles to collapsed rail on collapse button click and back on railbtn click', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = []
+
+        // Clear any persisted collapsed state from other tests
+        try { localStorage.removeItem('v2.wkAsideCollapsed') } catch (_) { /* noop */ }
+
+        render(html`<${Work} />`)
+
+        // Expanded state: main aside is visible
+        expect(screen.getByTestId('work-aside')).toBeTruthy()
+        expect(screen.queryByTestId('work-aside-collapsed')).toBeNull()
+
+        // Click collapse button
+        const collapseBtn = screen.getByTestId('work-aside').querySelector('.wka-collapse')
+        expect(collapseBtn).toBeTruthy()
+        fireEvent.click(collapseBtn!)
+
+        // Collapsed rail should now render
+        expect(screen.queryByTestId('work-aside')).toBeNull()
+        expect(screen.getByTestId('work-aside-collapsed')).toBeTruthy()
+
+        // Click expand
+        const railBtn = screen.getByTestId('work-aside-collapsed').querySelector('.wka-railbtn')
+        expect(railBtn).toBeTruthy()
+        fireEvent.click(railBtn!)
+
+        // Back to expanded
+        expect(screen.getByTestId('work-aside')).toBeTruthy()
+        expect(screen.queryByTestId('work-aside-collapsed')).toBeNull()
+      })
+
+      it('does not mix phase classification with string substring matching', () => {
+        // Regression guard: goals in `executing` phase must never appear as flagged,
+        // even if their title/status string contains substrings like 'blocked'.
+        goals.value = [
+          { id: 'G-tricky', title: 'Not blocked — just named oddly', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = []
+
+        render(html`<${Work} />`)
+
+        const aside = screen.getByTestId('work-aside')
+        // No flagged items — executing goals are not flagged
+        expect(aside.querySelectorAll('[data-testid="wka-flagged-item"]').length).toBe(0)
+        expect(aside.querySelector('[data-testid="wka-flagged-calm"]')).toBeTruthy()
+      })
     })
   })
 })

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -690,5 +690,147 @@ describe('Work', () => {
         expect(aside.querySelector('[data-testid="wka-flagged-calm"]')).toBeTruthy()
       })
     })
+
+    // ── Kanban view ─────────────────────────────────────────────────────────
+    describe('kanban view toggle', () => {
+      beforeEach(() => {
+        // Reset persisted view state so tests start from the default 'list' view
+        try { localStorage.removeItem('v2.workView') } catch (_) { /* noop */ }
+      })
+
+      it('renders the view toggle with list active by default', () => {
+        goals.value = []
+        tasks.value = []
+
+        render(html`<${Work} />`)
+
+        const seg = screen.getByTestId('work-viewseg')
+        expect(seg).toBeTruthy()
+        const listBtn = screen.getByTestId('work-view-list')
+        const kanbanBtn = screen.getByTestId('work-view-kanban')
+        expect(listBtn.classList.contains('on')).toBe(true)
+        expect(kanbanBtn.classList.contains('on')).toBe(false)
+        // List view: goal list container present (even if empty)
+        expect(screen.queryByTestId('work-kanban')).toBeNull()
+      })
+
+      it('switches to kanban board on clicking the 칸반 button', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = [
+          { id: 'J-1', title: 'Todo task', goal_id: 'G-1', status: 'todo' },
+          { id: 'J-2', title: 'In progress', goal_id: 'G-1', status: 'in_progress' },
+          { id: 'J-3', title: 'Done task', goal_id: 'G-1', status: 'done' },
+          // Cancelled tasks must not appear in kanban
+          { id: 'J-4', title: 'Cancelled task', goal_id: 'G-1', status: 'cancelled' },
+        ]
+
+        render(html`<${Work} />`)
+
+        // Initially in list view
+        expect(screen.queryByTestId('work-kanban')).toBeNull()
+        expect(screen.getByTestId('work-goal-list')).toBeTruthy()
+
+        // Switch to kanban
+        fireEvent.click(screen.getByTestId('work-view-kanban'))
+
+        // Kanban board present; list view gone
+        const board = screen.getByTestId('work-kanban')
+        expect(board).toBeTruthy()
+        expect(screen.queryByTestId('work-goal-list')).toBeNull()
+
+        // Toggle button state updated
+        expect(screen.getByTestId('work-view-kanban').classList.contains('on')).toBe(true)
+        expect(screen.getByTestId('work-view-list').classList.contains('on')).toBe(false)
+
+        // The 5 KANBAN_COLUMNS are rendered
+        expect(screen.getByTestId('kanban-col-todo')).toBeTruthy()
+        expect(screen.getByTestId('kanban-col-claimed')).toBeTruthy()
+        expect(screen.getByTestId('kanban-col-in_progress')).toBeTruthy()
+        expect(screen.getByTestId('kanban-col-awaiting_verification')).toBeTruthy()
+        expect(screen.getByTestId('kanban-col-done')).toBeTruthy()
+
+        // Tasks appear in the correct columns (by data-testid selector)
+        const todoCol = screen.getByTestId('kanban-col-todo')
+        const wipCol  = screen.getByTestId('kanban-col-in_progress')
+        const doneCol = screen.getByTestId('kanban-col-done')
+        expect(todoCol.textContent).toContain('Todo task')
+        expect(wipCol.textContent).toContain('In progress')
+        expect(doneCol.textContent).toContain('Done task')
+
+        // Cancelled task must be absent from all columns
+        expect(board.textContent).not.toContain('Cancelled task')
+      })
+
+      it('switches back to list view on clicking the 리스트 button', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = []
+
+        render(html`<${Work} />`)
+
+        // Go to kanban
+        fireEvent.click(screen.getByTestId('work-view-kanban'))
+        expect(screen.getByTestId('work-kanban')).toBeTruthy()
+
+        // Back to list
+        fireEvent.click(screen.getByTestId('work-view-list'))
+        expect(screen.queryByTestId('work-kanban')).toBeNull()
+        expect(screen.getByTestId('work-view-list').classList.contains('on')).toBe(true)
+      })
+
+      it('places tasks in the correct column by status using typed KANBAN_COLUMNS (no string-match classification)', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Goal One', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        // One task per non-cancelled status
+        tasks.value = [
+          { id: 'T-todo',   title: 'Todo item',   goal_id: 'G-1', status: 'todo' },
+          { id: 'T-claim',  title: 'Claimed item', goal_id: 'G-1', status: 'claimed', assignee: 'keeper-x' },
+          { id: 'T-wip',    title: 'WIP item',    goal_id: 'G-1', status: 'in_progress', assignee: 'keeper-y' },
+          { id: 'T-verify', title: 'Verify item', goal_id: 'G-1', status: 'awaiting_verification', assignee: 'keeper-z' },
+          { id: 'T-done',   title: 'Done item',   goal_id: 'G-1', status: 'done', assignee: 'keeper-w' },
+        ]
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('work-view-kanban'))
+
+        const board = screen.getByTestId('work-kanban')
+        const cards = board.querySelectorAll('[data-testid="kanban-card"]')
+        // All 5 non-cancelled tasks present
+        expect(cards.length).toBe(5)
+
+        // Each card sits inside the correct column
+        const colFor = (status: string) => board.querySelector(`[data-testid="kanban-col-${status}"]`)
+        expect(colFor('todo')?.querySelector('[data-kanban-task-id="T-todo"]')).toBeTruthy()
+        expect(colFor('claimed')?.querySelector('[data-kanban-task-id="T-claim"]')).toBeTruthy()
+        expect(colFor('in_progress')?.querySelector('[data-kanban-task-id="T-wip"]')).toBeTruthy()
+        expect(colFor('awaiting_verification')?.querySelector('[data-kanban-task-id="T-verify"]')).toBeTruthy()
+        expect(colFor('done')?.querySelector('[data-kanban-task-id="T-done"]')).toBeTruthy()
+      })
+
+      it('shows the goal title on each kanban card and hides the backlog strip in kanban view', () => {
+        goals.value = [
+          { id: 'G-1', title: 'Target Goal', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
+        ]
+        tasks.value = [
+          { id: 'J-1', title: 'Some task', goal_id: 'G-1', status: 'in_progress', assignee: 'keeper-a' },
+          // Claimable todo to verify backlog strip hidden
+          { id: 'J-2', title: 'Claimable', goal_id: 'G-1', status: 'todo' },
+        ]
+
+        render(html`<${Work} />`)
+        fireEvent.click(screen.getByTestId('work-view-kanban'))
+
+        // Goal title appears in card goal link
+        const board = screen.getByTestId('work-kanban')
+        expect(board.textContent).toContain('Target Goal')
+
+        // Backlog strip (.wk-backlog) must NOT be present in kanban view
+        expect(screen.queryByTestId('work-backlog')).toBeNull()
+      })
+    })
   })
 })

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -15,6 +15,11 @@ const routeSignal = signal<{
 })
 
 const navigateMock = vi.hoisted(() => vi.fn())
+const callMcpToolMock = vi.hoisted(() => vi.fn<() => Promise<string>>())
+
+vi.mock('../api/mcp', () => ({
+  callMcpTool: callMcpToolMock,
+}))
 
 vi.mock('../router', () => ({
   get route() { return routeSignal },
@@ -25,6 +30,7 @@ vi.mock('../store', () => ({
   goals: signal([]),
   tasks: signal([]),
   keepers: signal([]),
+  refreshGoals: vi.fn().mockResolvedValue(undefined),
 }))
 
 vi.mock('./board/board-moderation-surface', () => ({
@@ -165,7 +171,7 @@ describe('Work', () => {
       expect(screen.getByTestId('work-goal-list')).toBeTruthy()
     })
 
-    it('renders the reference new-goal placeholder button', () => {
+    it('renders the new-goal button as enabled and opens the form on click', () => {
       goals.value = [
         { id: 'G-1', title: 'Goal One', priority: 2, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
       ]
@@ -174,7 +180,15 @@ describe('Work', () => {
 
       const button = screen.getByTestId('work-new-goal')
       expect(button.textContent).toContain('새 목표')
-      expect(button).toBeDisabled()
+      expect(button).not.toBeDisabled()
+
+      // Form is hidden initially
+      expect(screen.queryByTestId('goal-create-form')).toBeNull()
+
+      fireEvent.click(button)
+
+      // Form appears after click
+      expect(screen.getByTestId('goal-create-form')).toBeTruthy()
     })
 
     it('renders a collapsed goal card per goal and expands on click', () => {
@@ -453,6 +467,71 @@ describe('Work', () => {
 
       expect(screen.queryByTestId('work-task-detail')).toBeNull()
       expect(screen.queryByTestId('job-detail')).toBeNull()
+    })
+
+    // ── Goal-create composer ─────────────────────────────────────────────────
+    describe('goal-create composer', () => {
+      beforeEach(async () => {
+        callMcpToolMock.mockReset()
+        // Reset the goal-create signals and local form state before each test
+        const { showGoalCreate } = await import('./goals/goal-create-state')
+        const { resetGoalCreateFormLocal } = await import('./goals/goal-create-form')
+        showGoalCreate.value = false
+        resetGoalCreateFormLocal()
+      })
+
+      it('calls masc_goal_upsert with title and priority when form is submitted', async () => {
+        callMcpToolMock.mockResolvedValue('ok')
+
+        goals.value = []
+        tasks.value = []
+
+        render(html`<${Work} />`)
+
+        // Open the form
+        fireEvent.click(screen.getByTestId('work-new-goal'))
+        expect(screen.getByTestId('goal-create-form')).toBeTruthy()
+
+        // Fill in the title
+        const titleInput = screen.getByTestId('goal-create-title-input')
+        fireEvent.input(titleInput, { target: { value: 'SLO 400ms 회복' } })
+
+        // Submit
+        fireEvent.click(screen.getByTestId('goal-create-submit'))
+
+        // Wait for async createGoal to resolve
+        await new Promise(resolve => setTimeout(resolve, 0))
+
+        expect(callMcpToolMock).toHaveBeenCalledWith('masc_goal_upsert', expect.objectContaining({
+          title: 'SLO 400ms 회복',
+          priority: expect.any(Number),
+        }))
+        // No horizon field: extract args from the first call via toHaveBeenCalledWith
+        const rawCalls = callMcpToolMock.mock.calls as unknown as [string, Record<string, unknown>][]
+        const callArgs = rawCalls[0]?.[1] ?? {}
+        expect(callArgs).not.toHaveProperty('horizon')
+        expect(callArgs).not.toHaveProperty('status')
+        expect(callArgs).not.toHaveProperty('phase')
+      })
+
+      it('does not call masc_goal_upsert when title is empty or whitespace', async () => {
+        callMcpToolMock.mockResolvedValue('ok')
+
+        goals.value = []
+        tasks.value = []
+
+        render(html`<${Work} />`)
+
+        // Open the form
+        fireEvent.click(screen.getByTestId('work-new-goal'))
+
+        // Leave title empty and click submit
+        fireEvent.click(screen.getByTestId('goal-create-submit'))
+
+        await new Promise(resolve => setTimeout(resolve, 0))
+
+        expect(callMcpToolMock).not.toHaveBeenCalled()
+      })
     })
 
     // ── WorkAside operator triage panel ─────────────────────────────────────

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -15,6 +15,7 @@ import { VerificationRequestsPanel } from './verification-requests-panel'
 import { ErrorBoundary } from './common/error-boundary'
 import { LoadingState } from './common/feedback-state'
 import { KeeperBadge } from './keeper-badge'
+import { openTaskDetail } from './goals/task-detail-state'
 import type { Goal, Task, Keeper } from '../types'
 
 type WorkSection = 'work' | 'board' | 'sub-boards' | 'moderation' | 'planning' | 'repositories' | 'verification'
@@ -586,7 +587,17 @@ function KanbanCard({
       tabIndex=${0}
       data-testid="kanban-card"
       data-kanban-task-id=${task.id}
-      onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') { /* no-op: inline detail not shown in kanban */ } }}
+      aria-label=${`${task.title} 상세 열기`}
+      onClick=${() => openTaskDetail(task)}
+      onKeyDown=${(e: KeyboardEvent) => {
+        // Kanban cards have no inline expansion (unlike TaskRow); Enter/Space
+        // opens the shared TaskDetailOverlay (app.ts-mounted) via openTaskDetail,
+        // which also loads the task's real trace events.
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          openTaskDetail(task)
+        }
+      }}
     >
       <div class="wk-kcard-top">
         <span class="wk-kcard-id mono">${task.id}</span>

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1,10 +1,10 @@
 // MASC Dashboard — Work Tab (keeper-v2 goal/task layout)
 // Surface: Goal list (priority-sorted), Task terminology, inline expandable gate detail,
-// claimable backlog, and the 5 KPI strip from the reference design.
+// claimable backlog, the 5 KPI strip, and WorkAside operator triage panel.
 
 import { html } from 'htm/preact'
 import { lazy, Suspense } from 'preact/compat'
-import { useEffect, useMemo, useState } from 'preact/hooks'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { route, navigate } from '../router'
 import { goals, tasks, keepers } from '../store'
 import { BoardModerationSurface } from './board/board-moderation-surface'
@@ -362,6 +362,430 @@ function GoalCard({
   `
 }
 
+// ── WorkAside — operator triage panel (right column) ──────────────────────
+//
+// Phase → "flagged" mapping rationale:
+//   Prototype uses `status !== 'active'`.  The live Goal type has no `status`
+//   separate from `phase` for the operator triage purpose.  We classify by
+//   `phase` enum — never by substring.
+//
+//   • "flagged" (지금 상황):  phases that need operator attention:
+//       awaiting_verification | awaiting_approval | blocked | paused
+//     `executing` = normal active flow — not flagged.
+//     `completed` | `dropped` = terminal — excluded (already closed out).
+//
+//   • "approvals" (완료 승인): goals with require_completion_approval=true
+//     AND phase=awaiting_approval (final sign-off pending).
+//
+//   • "verifyTasks" (게이트): tasks with status=awaiting_verification.
+//     open-gate count from taskGateRows().
+//
+//   • "blockers": tasks where handoff_context.failure_mode or handoff_context.reason
+//     indicates blockage (status=cancelled OR explicit blocker via blockerNoteForTask).
+//     IMPORTANT: status === 'cancelled' in the live model means "blocked/failed"
+//     (prototype `t.blocker` field does not exist in live Task type; we use
+//     blockerNoteForTask() which reads handoff_context fields).
+//
+//   • "backlog": tasks that isClaimableBacklogTask() returns true for.
+//
+//   • "recent": tasks with status === 'done'.
+
+// Phase semantic class for the .wka-flag border tint.
+// Mirrors prototype goalMeta() / STATUS_COLS cls (data.jsx:340-350).
+// Using the existing GOAL_STATUS_CLASS mapping which covers these phases.
+type WkaFlagCls = 'ok' | 'warn' | 'bad' | 'volt'
+
+const GOAL_PHASE_FLAG_CLS: Record<string, WkaFlagCls> = {
+  executing: 'ok',
+  awaiting_verification: 'volt',
+  awaiting_approval: 'volt',
+  blocked: 'bad',
+  paused: 'warn',
+  completed: 'ok',
+  dropped: 'bad',
+}
+
+const GOAL_PHASE_FLAG_LBL: Record<string, string> = {
+  executing: '진행 중',
+  awaiting_verification: '검증 대기',
+  awaiting_approval: '승인 대기',
+  blocked: '차단',
+  paused: '일시정지',
+  completed: '완료',
+  dropped: '폐기',
+}
+
+function goalPhaseFlagCls(phase: string): WkaFlagCls {
+  return GOAL_PHASE_FLAG_CLS[phase] ?? 'warn'
+}
+
+function goalPhaseFlagLbl(phase: string): string {
+  return GOAL_PHASE_FLAG_LBL[phase] ?? phase
+}
+
+// Goals needing operator attention — positive enumeration of the triage
+// phases only. `executing` (normal active flow) and the terminal phases
+// (`completed` / `dropped`) are deliberately excluded: a closed-out goal is
+// not part of "지금 상황". Exact membership on the phase enum, never a
+// substring match. (Adding a new Goal phase requires deciding here whether it
+// needs triage.)
+const GOAL_ATTENTION_PHASES: ReadonlySet<string> = new Set([
+  'awaiting_verification',
+  'awaiting_approval',
+  'blocked',
+  'paused',
+])
+
+function isGoalFlagged(goal: Goal): boolean {
+  return GOAL_ATTENTION_PHASES.has(goal.phase)
+}
+
+// WorkAside derived data shapes — immutable, computed from signals.
+interface WkaFlaggedGoal {
+  readonly id: string
+  readonly cls: WkaFlagCls
+  readonly lbl: string
+  readonly title: string
+  readonly reason: string | null | undefined
+}
+
+interface WkaApprovalGoal {
+  readonly id: string
+  readonly title: string
+  readonly verifiers: ReadonlyArray<string>
+}
+
+interface WkaVerifyTask {
+  readonly id: string
+  readonly title: string
+  readonly goalId: string
+  readonly open: number // unsatisfied gates
+}
+
+interface WkaBlockerTask {
+  readonly id: string
+  readonly title: string
+  readonly blocker: string
+  readonly goalId: string
+}
+
+interface WkaBacklogTask {
+  readonly id: string
+  readonly title: string
+  readonly goal: string
+  readonly goalId: string
+  readonly priority: number
+}
+
+interface WkaRecentTask {
+  readonly id: string
+  readonly title: string
+  readonly goalId: string
+}
+
+interface WkaCounts {
+  readonly active: number
+  readonly wip: number
+  readonly verify: number
+  readonly backlog: number
+}
+
+interface WorkAsideProps {
+  flagged: ReadonlyArray<WkaFlaggedGoal>
+  approvals: ReadonlyArray<WkaApprovalGoal>
+  verifyTasks: ReadonlyArray<WkaVerifyTask>
+  blockers: ReadonlyArray<WkaBlockerTask>
+  backlog: ReadonlyArray<WkaBacklogTask>
+  recent: ReadonlyArray<WkaRecentTask>
+  counts: WkaCounts
+  onJump: (goalId: string) => void
+  onOpenKeeper?: (name: string) => void
+}
+
+// Aside width persistence — min 312, max 520, default 360.
+const WKA_ASIDE_W_KEY = 'v2.wkAsideW'
+const WKA_ASIDE_COLLAPSED_KEY = 'v2.wkAsideCollapsed'
+const WKA_ASIDE_DEFAULT_W = 360
+const WKA_ASIDE_MIN_W = 312
+const WKA_ASIDE_MAX_W = 520
+
+function readStoredAsideW(): number {
+  try {
+    const v = localStorage.getItem(WKA_ASIDE_W_KEY)
+    if (v) {
+      const n = parseInt(v, 10)
+      if (!isNaN(n)) return Math.max(WKA_ASIDE_MIN_W, Math.min(WKA_ASIDE_MAX_W, n))
+    }
+  } catch (_) { /* storage unavailable */ }
+  return WKA_ASIDE_DEFAULT_W
+}
+
+function readStoredAsideCollapsed(): boolean {
+  try { return localStorage.getItem(WKA_ASIDE_COLLAPSED_KEY) === '1' } catch (_) { return false }
+}
+
+function WorkAside({
+  flagged, approvals, verifyTasks, blockers, backlog, recent, counts, onJump,
+}: WorkAsideProps) {
+  const needTotal = approvals.length + verifyTasks.length + blockers.length + backlog.length
+
+  const [collapsed, setCollapsed] = useState<boolean>(readStoredAsideCollapsed)
+  const [w, setW] = useState<number>(readStoredAsideW)
+  const wRef = useRef(w)
+  wRef.current = w
+
+  const setCol = useCallback((v: boolean) => {
+    setCollapsed(v)
+    try { localStorage.setItem(WKA_ASIDE_COLLAPSED_KEY, v ? '1' : '0') } catch (_) { /* noop */ }
+  }, [])
+
+  const persistW = useCallback((next: number) => {
+    setW(next)
+    try { localStorage.setItem(WKA_ASIDE_W_KEY, String(next)) } catch (_) { /* noop */ }
+  }, [])
+
+  const startResize = useCallback((e: PointerEvent) => {
+    e.preventDefault()
+    const startX = e.clientX
+    const startW = wRef.current
+    document.body.classList.add('rail-resizing')
+    const move = (ev: PointerEvent) => {
+      // Dragging the LEFT edge of the right aside: moving left → wider
+      persistW(Math.max(WKA_ASIDE_MIN_W, Math.min(WKA_ASIDE_MAX_W, startW - (ev.clientX - startX))))
+    }
+    const up = () => {
+      document.body.classList.remove('rail-resizing')
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', up)
+    }
+    window.addEventListener('pointermove', move)
+    window.addEventListener('pointerup', up)
+  }, [persistW])
+
+  if (collapsed) {
+    return html`
+      <aside
+        class="ov-aside wka collapsed"
+        role="button"
+        tabIndex=${0}
+        title="클릭하여 운영 상태 패널 펼치기"
+        aria-expanded=${false}
+        aria-label="운영 상태 패널 펼치기"
+        onClick=${() => setCol(false)}
+        onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setCol(false) } }}
+        data-testid="work-aside-collapsed"
+      >
+        <button
+          type="button"
+          class="wka-railbtn"
+          aria-label="운영 상태 패널 펼치기"
+          onClick=${(e: Event) => { e.stopPropagation(); setCol(false) }}
+        >«</button>
+        <div class="wka-rail-stats" aria-hidden="true">
+          <div class="wka-rail-stat">
+            <b class="mono">${counts.wip}</b>
+            <span>진행</span>
+          </div>
+          <div class=${`wka-rail-stat ${counts.verify ? 'volt' : ''}`}>
+            <b class="mono">${counts.verify}</b>
+            <span>검증</span>
+          </div>
+          <div class=${`wka-rail-stat ${needTotal ? 'volt' : ''}`}>
+            <b class="mono">${needTotal}</b>
+            <span>할일</span>
+          </div>
+          <div class=${`wka-rail-stat ${flagged.length ? 'bad' : ''}`}>
+            <b class="mono">${flagged.length}</b>
+            <span>주의</span>
+          </div>
+        </div>
+        <div class="wka-rail-lbl" aria-hidden="true">운영 상태</div>
+        <div class="wka-rail-hint" aria-hidden="true">펼치기</div>
+      </aside>
+    `
+  }
+
+  return html`
+    <aside
+      class="ov-aside wka"
+      style=${{ width: `${w}px` }}
+      aria-label="운영 상태 패널"
+      data-testid="work-aside"
+    >
+      <div
+        class="wka-resizer"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="패널 폭 조절 — 드래그"
+        tabIndex=${0}
+        onPointerDown=${startResize}
+        onKeyDown=${(e: KeyboardEvent) => {
+          if (e.key === 'ArrowLeft') { e.preventDefault(); persistW(Math.max(WKA_ASIDE_MIN_W, wRef.current + 8)) }
+          if (e.key === 'ArrowRight') { e.preventDefault(); persistW(Math.min(WKA_ASIDE_MAX_W, wRef.current - 8)) }
+        }}
+      ></div>
+
+      <div class="wka-bar">
+        <span class="wka-bar-t">운영 상태</span>
+        <span class="wka-bar-live">
+          <span class="wka-livedot" aria-hidden="true"></span>
+          ${counts.active} active
+        </span>
+        <button
+          type="button"
+          class="wka-collapse"
+          aria-label="운영 상태 패널 접기"
+          aria-expanded=${true}
+          onClick=${() => setCol(true)}
+          title="접기 — Chat 열 때 공간 확보"
+        >»</button>
+      </div>
+
+      <div class="wka-hud" aria-label="작업 현황 요약">
+        <div class="wka-hud-c">
+          <span class="wka-hud-k">진행</span>
+          <span class="wka-hud-v">${counts.wip}</span>
+        </div>
+        <div class="wka-hud-c">
+          <span class="wka-hud-k">검증</span>
+          <span class=${`wka-hud-v ${counts.verify ? 'volt' : ''}`}>${counts.verify}</span>
+        </div>
+        <div class="wka-hud-c">
+          <span class="wka-hud-k">백로그</span>
+          <span class=${`wka-hud-v ${counts.backlog ? 'warn' : ''}`}>${counts.backlog}</span>
+        </div>
+        <div class="wka-hud-c">
+          <span class="wka-hud-k">할 일</span>
+          <span class=${`wka-hud-v ${needTotal ? 'volt' : ''}`}>${needTotal}</span>
+        </div>
+      </div>
+
+      <div class="wka-scroll">
+
+        <section class="wka-sec" aria-labelledby="wka-h-flagged">
+          <div class="wka-h" id="wka-h-flagged" role="heading" aria-level=${3}>
+            지금 상황
+            ${flagged.length > 0 ? html`<span class="wka-h-n bad">${flagged.length}</span>` : null}
+          </div>
+          ${flagged.length === 0
+            ? html`<div class="wka-calm mono" data-testid="wka-flagged-calm">주의 목표 없음 · 정상 순환</div>`
+            : html`
+              <div class="wka-list" data-testid="wka-flagged-list">
+                ${flagged.map(g => html`
+                  <button
+                    key=${g.id}
+                    type="button"
+                    class=${`wka-flag st-${g.cls}`}
+                    onClick=${() => onJump(g.id)}
+                    data-testid="wka-flagged-item"
+                  >
+                    <span class=${`wka-flag-tag ${g.cls}`}>${g.lbl}</span>
+                    <span class="wka-flag-title">${g.title}</span>
+                    ${g.reason ? html`<span class="wka-flag-reason">${g.reason}</span>` : null}
+                  </button>
+                `)}
+              </div>
+            `}
+        </section>
+
+        <section class="wka-sec" aria-labelledby="wka-h-todo">
+          <div class="wka-h" id="wka-h-todo" role="heading" aria-level=${3}>
+            해야 할 일
+            ${needTotal > 0 ? html`<span class="wka-h-n">${needTotal}</span>` : null}
+          </div>
+          <div class="wka-list" data-testid="wka-todo-list">
+            ${approvals.map(g => html`
+              <button
+                key=${g.id}
+                type="button"
+                class="wka-todo approve"
+                onClick=${() => onJump(g.id)}
+                data-testid="wka-approval-item"
+              >
+                <span class="wka-todo-k">완료 승인</span>
+                <span class="wka-todo-t">${g.title}</span>
+                ${g.verifiers.length > 0
+                  ? html`<span class="wka-todo-m mono">${g.verifiers.join(' · ')}</span>`
+                  : null}
+              </button>
+            `)}
+            ${verifyTasks.map(t => html`
+              <button
+                key=${t.id}
+                type="button"
+                class="wka-todo verify"
+                onClick=${() => onJump(t.goalId)}
+                data-testid="wka-verify-item"
+              >
+                <span class="wka-todo-k">게이트</span>
+                <span class="wka-todo-t">${t.title}</span>
+                <span class="wka-todo-m mono">${t.open > 0 ? `${t.open} 미충족` : '검증 대기'}</span>
+              </button>
+            `)}
+            ${blockers.map(t => html`
+              <button
+                key=${t.id}
+                type="button"
+                class="wka-todo block"
+                onClick=${() => onJump(t.goalId)}
+                data-testid="wka-blocker-item"
+              >
+                <span class="wka-todo-k">차단</span>
+                <span class="wka-todo-t">${t.title}</span>
+                <span class="wka-todo-m">${t.blocker}</span>
+              </button>
+            `)}
+            ${backlog.length > 0 ? (() => {
+              // backlog[0] is safe here: length > 0 is checked above, but
+              // TypeScript can't narrow through html`` template literals.
+              const firstGoalId = backlog[0]?.goalId ?? ''
+              return html`
+                <button
+                  type="button"
+                  class="wka-todo claim"
+                  onClick=${() => onJump(firstGoalId)}
+                  data-testid="wka-backlog-item"
+                >
+                  <span class="wka-todo-k">클레임</span>
+                  <span class="wka-todo-t">미배정 task ${backlog.length}건</span>
+                  <span class="wka-todo-m mono">keeper_task_claim</span>
+                </button>
+              `
+            })() : null}
+            ${needTotal === 0
+              ? html`<div class="wka-calm mono" data-testid="wka-todo-calm">대기 중인 작업 없음</div>`
+              : null}
+          </div>
+        </section>
+
+        <section class="wka-sec" aria-labelledby="wka-h-recent">
+          <div class="wka-h" id="wka-h-recent" role="heading" aria-level=${3}>
+            최근 한 일
+            ${recent.length > 0 ? html`<span class="wka-h-n dim">${recent.length}</span>` : null}
+          </div>
+          <div class="wka-list">
+            ${recent.length === 0
+              ? html`<div class="wka-calm mono" data-testid="wka-recent-calm">완료된 task 없음</div>`
+              : recent.map(t => html`
+                <button
+                  key=${t.id}
+                  type="button"
+                  class="wka-done"
+                  onClick=${() => onJump(t.goalId)}
+                  data-testid="wka-recent-item"
+                >
+                  <span class="wka-done-mark">✓</span>
+                  <span class="wka-done-t">${t.title}</span>
+                </button>
+              `)}
+          </div>
+        </section>
+
+      </div>
+    </aside>
+  `
+}
+
 function WorkSurfaceV2() {
   const goalList = goals.value
   const allTasks = tasks.value
@@ -430,6 +854,111 @@ function WorkSurfaceV2() {
     })
   }
 
+  // Expand a goal and scroll its card into view in the left column.
+  // GoalCard renders with data-goal-id so this selector is stable.
+  const jumpToGoal = useCallback((id: string) => {
+    setOpenSet(prev => {
+      const next = new Set(prev)
+      next.add(id)
+      return next
+    })
+    requestAnimationFrame(() => {
+      const scroll = document.querySelector('.ov-2col .ov-scroll')
+      const card = document.querySelector(`[data-goal-id="${id}"]`)
+      if (scroll && card) {
+        const r = card.getBoundingClientRect()
+        const sr = scroll.getBoundingClientRect()
+        scroll.scrollTo({ top: (scroll as HTMLElement).scrollTop + r.top - sr.top - 80, behavior: 'smooth' })
+      } else if (card) {
+        card.scrollIntoView({ block: 'center', behavior: 'smooth' })
+      }
+    })
+  }, [])
+
+  // ── WorkAside derivations (immutable, phase-enum based) ──────────────────
+  // All computed from the same claimedTasks / goalList signals.
+  // See WorkAside phase-mapping comment for rationale.
+
+  const wkaFlagged = useMemo((): ReadonlyArray<WkaFlaggedGoal> =>
+    goalList
+      .filter(isGoalFlagged)
+      .map(g => ({
+        id: g.id,
+        cls: goalPhaseFlagCls(g.phase),
+        lbl: goalPhaseFlagLbl(g.phase),
+        title: g.title,
+        reason: g.last_review_note,
+      })),
+  [goalList])
+
+  const wkaApprovals = useMemo((): ReadonlyArray<WkaApprovalGoal> =>
+    goalList
+      .filter(g => g.require_completion_approval === true && g.phase === 'awaiting_approval')
+      .map(g => ({
+        id: g.id,
+        title: g.title,
+        verifiers: g.verifier_policy?.principals.map(p => p.id) ?? [],
+      })),
+  [goalList])
+
+  const wkaVerifyTasks = useMemo((): ReadonlyArray<WkaVerifyTask> =>
+    claimedTasks
+      .filter(t => t.status === 'awaiting_verification')
+      .map(t => ({
+        id: t.id,
+        title: t.title,
+        goalId: t.goal_id ?? '',
+        open: taskGateRows(t).filter(r => r.outcome !== 'satisfied').length,
+      })),
+  [claimedTasks])
+
+  // Live Task has no freeform `blocker` string field; blockerNoteForTask()
+  // reads handoff_context.failure_mode / reason.  We surface tasks where
+  // that note is non-null (excluding done/awaiting_verification which have
+  // their own sections).
+  const wkaBlockers = useMemo((): ReadonlyArray<WkaBlockerTask> =>
+    claimedTasks
+      .filter(t => {
+        if (t.status === 'done' || t.status === 'awaiting_verification') return false
+        return blockerNoteForTask(t) !== null
+      })
+      .map(t => ({
+        id: t.id,
+        title: t.title,
+        blocker: blockerNoteForTask(t) ?? '',
+        goalId: t.goal_id ?? '',
+      })),
+  [claimedTasks])
+
+  const wkaBacklog = useMemo((): ReadonlyArray<WkaBacklogTask> =>
+    claimedTasks
+      .filter(isClaimableBacklogTask)
+      .map(t => ({
+        id: t.id,
+        title: t.title,
+        goal: t.goal_id ? (goalList.find(g => g.id === t.goal_id)?.title ?? '') : '',
+        goalId: t.goal_id ?? '',
+        priority: t.priority ?? 0,
+      })),
+  [claimedTasks, goalList])
+
+  const wkaRecent = useMemo((): ReadonlyArray<WkaRecentTask> =>
+    claimedTasks
+      .filter(t => t.status === 'done')
+      .map(t => ({
+        id: t.id,
+        title: t.title,
+        goalId: t.goal_id ?? '',
+      })),
+  [claimedTasks])
+
+  const wkaCounts = useMemo((): WkaCounts => ({
+    active: goalList.length,
+    wip: totals.wip,
+    verify: totals.verify,
+    backlog: totals.backlog,
+  }), [goalList, totals])
+
   const tasksByGoalId = useMemo(() => {
     const map = new Map<string, Task[]>()
     for (const g of goalList) map.set(g.id, [])
@@ -443,7 +972,7 @@ function WorkSurfaceV2() {
   }, [goalList, claimedTasks])
 
   return html`
-    <main class="ov">
+    <main class="ov ov-2col">
       <div class="ov-scroll">
         <header class="ov-head">
             <div>
@@ -530,6 +1059,17 @@ function WorkSurfaceV2() {
 
           <div class="wk-foot mono">Goal → Task → keeper · 우선순위 순 정렬 · 완료는 게이트 증거 충족 후 done · 미배정 task 는 백로그에서 claim</div>
       </div>
+      <${WorkAside}
+        flagged=${wkaFlagged}
+        approvals=${wkaApprovals}
+        verifyTasks=${wkaVerifyTasks}
+        blockers=${wkaBlockers}
+        backlog=${wkaBacklog}
+        recent=${wkaRecent}
+        counts=${wkaCounts}
+        onJump=${jumpToGoal}
+        onOpenKeeper=${openKeeperWorkspace}
+      />
     </main>
   `
 }

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -16,6 +16,8 @@ import { ErrorBoundary } from './common/error-boundary'
 import { LoadingState } from './common/feedback-state'
 import { KeeperBadge } from './keeper-badge'
 import { openTaskDetail } from './goals/task-detail-state'
+import { GoalCreateForm } from './goals/goal-create-form'
+import { showGoalCreate } from './goals/goal-create-state'
 import type { Goal, Task, Keeper } from '../types'
 
 type WorkSection = 'work' | 'board' | 'sub-boards' | 'moderation' | 'planning' | 'repositories' | 'verification'
@@ -1175,8 +1177,8 @@ function WorkSurfaceV2() {
                 type="button"
                 class="set-add wk-newgoal"
                 data-testid="work-new-goal"
-                title="새 목표 생성 — 다음 단계에서 설계"
-                disabled=${true}
+                title="새 목표 생성"
+                onClick=${() => { showGoalCreate.value = true }}
               >
                 ＋ 새 목표
               </button>
@@ -1297,6 +1299,7 @@ export function Work() {
           }
         <//>
       </div>
+      <${GoalCreateForm} />
     </div>
   `
 }

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -39,6 +39,22 @@ function isWorkSection(v: string | undefined): v is WorkSection {
 type JobBucket = 'done' | 'wip' | 'verify' | 'blocked' | 'todo'
 type JobStateCls = 'done' | 'wip' | 'verify' | 'claimed' | 'cancelled' | 'todo'
 
+// ── Kanban view columns ─────────────────────────────────────────────────────
+// Closed tuple — cancelled is excluded by design (it has its own aside panel).
+// Each entry: [task.status value, Korean column label, CSS modifier cls].
+// The cls values come directly from JobStateCls so KanbanCard can reuse the
+// same .wk-kcard.<cls> and .wk-kcol-dot.<cls> rules without extra mapping.
+type KanbanStatus = 'todo' | 'claimed' | 'in_progress' | 'awaiting_verification' | 'done'
+type KanbanColumn = readonly [status: KanbanStatus, label: string, cls: JobStateCls]
+
+const KANBAN_COLUMNS: ReadonlyArray<KanbanColumn> = [
+  ['todo',                  '백로그', 'todo'],
+  ['claimed',               '클레임', 'claimed'],
+  ['in_progress',           '진행',   'wip'],
+  ['awaiting_verification', '검증',   'verify'],
+  ['done',                  '완료',   'done'],
+] as const
+
 interface JobState {
   label: string
   bucket: JobBucket
@@ -502,6 +518,22 @@ interface WorkAsideProps {
   onOpenKeeper?: (name: string) => void
 }
 
+// ── View mode persistence ───────────────────────────────────────────────────
+type WorkView = 'list' | 'kanban'
+const WK_VIEW_KEY = 'v2.workView'
+
+function readStoredWorkView(): WorkView {
+  try {
+    const v = localStorage.getItem(WK_VIEW_KEY)
+    if (v === 'kanban') return 'kanban'
+  } catch (_) { /* storage unavailable */ }
+  return 'list'
+}
+
+function writeStoredWorkView(v: WorkView): void {
+  try { localStorage.setItem(WK_VIEW_KEY, v) } catch (_) { /* noop */ }
+}
+
 // Aside width persistence — min 312, max 520, default 360.
 const WKA_ASIDE_W_KEY = 'v2.wkAsideW'
 const WKA_ASIDE_COLLAPSED_KEY = 'v2.wkAsideCollapsed'
@@ -522,6 +554,118 @@ function readStoredAsideW(): number {
 
 function readStoredAsideCollapsed(): boolean {
   try { return localStorage.getItem(WKA_ASIDE_COLLAPSED_KEY) === '1' } catch (_) { return false }
+}
+
+// ── Kanban sub-components ───────────────────────────────────────────────────
+
+// KanbanTask enriches a Task with goal context for the board view.
+// Goal id/title are needed because kanban tasks are flattened across goals.
+interface KanbanTask extends Task {
+  readonly _goalId: string
+  readonly _goalTitle: string
+}
+
+function KanbanCard({
+  task,
+  onClaim,
+  onJumpGoal,
+}: {
+  task: KanbanTask
+  onClaim: (id: string) => void
+  onJumpGoal: (goalId: string) => void
+}) {
+  const state = jobStateForTask(task)
+  const keeper = keeperByName(task.assignee)
+  const blocker = blockerNoteForTask(task)
+  const hasHandoff = !!(task.handoff_context?.summary || task.handoff_context?.next_step)
+
+  return html`
+    <div
+      class=${`wk-kcard ${state.cls}`}
+      role="button"
+      tabIndex=${0}
+      data-testid="kanban-card"
+      data-kanban-task-id=${task.id}
+      onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') { /* no-op: inline detail not shown in kanban */ } }}
+    >
+      <div class="wk-kcard-top">
+        <span class="wk-kcard-id mono">${task.id}</span>
+        <span class="wk-kcard-prio mono">P${task.priority ?? 0}</span>
+      </div>
+      <div class="wk-kcard-title">${task.title}</div>
+      ${blocker ? html`<div class="wk-kcard-block">⚠ ${blocker}</div>` : null}
+      <button
+        class="wk-kcard-goal"
+        type="button"
+        title=${`소속 목표로 이동 · ${task._goalTitle}`}
+        onClick=${(e: Event) => { e.stopPropagation(); onJumpGoal(task._goalId) }}
+      >↳ ${task._goalTitle}</button>
+      <div class="wk-kcard-foot">
+        ${hasHandoff ? html`<span class="wk-kcard-ho" title="핸드오프 이력">⇄</span>` : null}
+        <span class="wk-spacer"></span>
+        ${keeper
+          ? html`
+            <button
+              type="button"
+              class="wk-kcard-kp"
+              title=${`${keeper.name} 대화 열기`}
+              onClick=${(e: Event) => { e.stopPropagation(); openKeeperWorkspace(keeper.name) }}
+            >
+              <${KeeperBadge} id=${keeper.name} size="sm" variant="sigil" />
+            </button>
+          `
+          : task.status === 'todo'
+            ? html`
+              <button
+                type="button"
+                class="wk-kcard-claim"
+                title="keeper_task_claim"
+                onClick=${(e: Event) => { e.stopPropagation(); onClaim(task.id) }}
+              >＋</button>
+            `
+            : html`<span class="wk-kcard-kp none mono">·</span>`}
+      </div>
+    </div>
+  `
+}
+
+function KanbanView({
+  kanbanTasks,
+  onClaim,
+  onJumpGoal,
+}: {
+  kanbanTasks: ReadonlyArray<KanbanTask>
+  onClaim: (id: string) => void
+  onJumpGoal: (goalId: string) => void
+}) {
+  return html`
+    <div class="wk-kanban" data-testid="work-kanban">
+      ${KANBAN_COLUMNS.map(([status, label, cls]) => {
+        const col = kanbanTasks.filter(t => t.status === status)
+        return html`
+          <div key=${status} class=${`wk-kcol ${cls}`} data-testid=${`kanban-col-${status}`}>
+            <div class="wk-kcol-h">
+              <span class=${`wk-kcol-dot ${cls}`} aria-hidden="true"></span>
+              ${label}
+              <span class="wk-kcol-n mono">${col.length}</span>
+            </div>
+            <div class="wk-kcol-body">
+              ${col.length === 0
+                ? html`<div class="wk-kcol-empty mono">—</div>`
+                : col.map(t => html`
+                  <${KanbanCard}
+                    key=${t.id}
+                    task=${t}
+                    onClaim=${onClaim}
+                    onJumpGoal=${onJumpGoal}
+                  />
+                `)}
+            </div>
+          </div>
+        `
+      })}
+    </div>
+  `
 }
 
 function WorkAside({
@@ -790,6 +934,7 @@ function WorkSurfaceV2() {
   const goalList = goals.value
   const allTasks = tasks.value
 
+  const [view, setView] = useState<WorkView>(readStoredWorkView)
   const [openSet, setOpenSet] = useState<Set<string>>(new Set())
   const [claimed, setClaimed] = useState<Set<string>>(new Set())
 
@@ -971,6 +1116,22 @@ function WorkSurfaceV2() {
     return map
   }, [goalList, claimedTasks])
 
+  // Flat list of all non-cancelled tasks with goal context injected.
+  // Used by KanbanView to group by status column.
+  const kanbanTasks = useMemo((): ReadonlyArray<KanbanTask> =>
+    goalList.flatMap(g => {
+      const gTasks = tasksByGoalId.get(g.id) ?? []
+      return gTasks
+        .filter(t => t.status !== 'cancelled')
+        .map(t => ({ ...t, _goalId: g.id, _goalTitle: g.title }))
+    }),
+  [goalList, tasksByGoalId])
+
+  const switchView = useCallback((next: WorkView) => {
+    setView(next)
+    writeStoredWorkView(next)
+  }, [])
+
   return html`
     <main class="ov ov-2col">
       <div class="ov-scroll">
@@ -980,15 +1141,35 @@ function WorkSurfaceV2() {
               <h1>작업 · 목표</h1>
               <p class="ov-sub">Goal → Task → keeper · 우선순위 순으로 정렬 · 게이트 증거로 검증</p>
             </div>
-            <button
-              type="button"
-              class="set-add wk-newgoal"
-              data-testid="work-new-goal"
-              title="새 목표 생성 — 다음 단계에서 설계"
-              disabled=${true}
-            >
-              ＋ 새 목표
-            </button>
+            <div class="wk-head-r">
+              <div class="wk-viewseg" role="tablist" data-testid="work-viewseg">
+                <button
+                  type="button"
+                  class=${view === 'list' ? 'on' : ''}
+                  role="tab"
+                  aria-selected=${view === 'list'}
+                  data-testid="work-view-list"
+                  onClick=${() => switchView('list')}
+                >리스트</button>
+                <button
+                  type="button"
+                  class=${view === 'kanban' ? 'on' : ''}
+                  role="tab"
+                  aria-selected=${view === 'kanban'}
+                  data-testid="work-view-kanban"
+                  onClick=${() => switchView('kanban')}
+                >칸반</button>
+              </div>
+              <button
+                type="button"
+                class="set-add wk-newgoal"
+                data-testid="work-new-goal"
+                title="새 목표 생성 — 다음 단계에서 설계"
+                disabled=${true}
+              >
+                ＋ 새 목표
+              </button>
+            </div>
           </header>
 
           <section class="ov-kpis" data-testid="work-kpis" style=${{ gridTemplateColumns: 'repeat(5, 1fr)' }}>
@@ -1014,7 +1195,7 @@ function WorkSurfaceV2() {
             </div>
           </section>
 
-          ${backlogTasks.length > 0 ? html`
+          ${view === 'list' && backlogTasks.length > 0 ? html`
             <section class="wk-backlog" data-testid="work-backlog">
               <div class="wk-backlog-h">
                 <span class="wk-backlog-glyph" aria-hidden="true">⊕</span>
@@ -1039,23 +1220,31 @@ function WorkSurfaceV2() {
             </section>
           ` : null}
 
-          ${/* RFC-0294: flat priority-sorted list replaces horizon grouping */
-          goalList.length > 0 ? html`
-            <div class="wk-list" data-testid="work-goal-list">
-              ${[...goalList]
-                .sort((a, b) => (a.priority ?? 4) - (b.priority ?? 4) || (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
-                .map(g => html`
-                <${GoalCard}
-                  key=${g.id}
-                  goal=${g}
-                  open=${openSet.has(g.id)}
-                  onToggle=${() => toggleGoal(g.id)}
-                  goalTasks=${tasksByGoalId.get(g.id) ?? []}
-                  onClaim=${claimTask}
-                />
-              `)}
-            </div>
-          ` : null}
+          ${view === 'list'
+            ? /* RFC-0294: flat priority-sorted list replaces horizon grouping */
+              goalList.length > 0 ? html`
+                <div class="wk-list" data-testid="work-goal-list">
+                  ${[...goalList]
+                    .sort((a, b) => (a.priority ?? 4) - (b.priority ?? 4) || (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
+                    .map(g => html`
+                    <${GoalCard}
+                      key=${g.id}
+                      goal=${g}
+                      open=${openSet.has(g.id)}
+                      onToggle=${() => toggleGoal(g.id)}
+                      goalTasks=${tasksByGoalId.get(g.id) ?? []}
+                      onClaim=${claimTask}
+                    />
+                  `)}
+                </div>
+              ` : null
+            : html`
+              <${KanbanView}
+                kanbanTasks=${kanbanTasks}
+                onClaim=${claimTask}
+                onJumpGoal=${jumpToGoal}
+              />
+            `}
 
           <div class="wk-foot mono">Goal → Task → keeper · 우선순위 순 정렬 · 완료는 게이트 증거 충족 후 done · 미배정 task 는 백로그에서 claim</div>
       </div>

--- a/dashboard/src/styles/surfaces-v2.css
+++ b/dashboard/src/styles/surfaces-v2.css
@@ -199,6 +199,22 @@
   background: var(--bg-deep);
 }
 
+/* Two-column layout: main scroll column + WorkAside right rail.
+   Ported from keeper-v2/styles/v2.css:809-810.
+   .ov-2col switches flex-direction to row so the aside sits as a right column.
+   .ov-scroll inside .ov-2col takes remaining width; the aside has its own
+   fixed/draggable width. Hidden below 1180px (aside sets display:none via
+   its own media query in work-v2.css). */
+.ov.ov-2col {
+  flex-direction: row;
+  align-items: stretch;
+}
+
+.ov-2col .ov-scroll {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .ov-scroll {
   flex: 1;
   overflow-y: auto;

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -1256,3 +1256,261 @@
     display: none;
   }
 }
+
+/* ── View toggle (list | kanban) ─────────────────────────────────────────── */
+
+.wk-head-r {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.wk-viewseg {
+  display: inline-flex;
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.wk-viewseg button {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  padding: 6px 14px;
+  background: var(--bg-sunken);
+  color: var(--text-dim);
+  border: 0;
+  cursor: pointer;
+  transition: 0.14s;
+}
+
+.wk-viewseg button + button {
+  border-left: 1px solid var(--border-main);
+}
+
+.wk-viewseg button:hover {
+  color: var(--text-bright);
+}
+
+.wk-viewseg button.on {
+  background: var(--volt-wash);
+  color: var(--volt-strong);
+}
+
+/* ── Kanban board ────────────────────────────────────────────────────────── */
+
+.wk-kanban {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(244px, 1fr);
+  gap: 12px;
+  margin-top: 6px;
+  align-items: start;
+  overflow-x: auto;
+  padding-bottom: 14px;
+}
+
+@media (min-width: 1321px) {
+  .wk-kanban {
+    grid-auto-flow: unset;
+    grid-auto-columns: unset;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+.wk-kcol {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+}
+
+.wk-kcol-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 12px;
+  font-family: var(--font-display);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-mid);
+  border-bottom: 1px solid var(--border-soft);
+  position: sticky;
+  top: 0;
+  background: var(--bg-sunken);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  z-index: 1;
+}
+
+.wk-kcol-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+}
+
+.wk-kcol-dot.todo    { background: var(--text-dim); }
+.wk-kcol-dot.claimed { background: var(--text-mid); }
+.wk-kcol-dot.wip     { background: var(--volt-strong); }
+.wk-kcol-dot.verify  { background: var(--info); }
+.wk-kcol-dot.done    { background: var(--status-ok); }
+
+.wk-kcol-n {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.wk-kcol-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  min-height: 60px;
+}
+
+.wk-kcol-empty {
+  color: var(--text-faint);
+  font-size: 12px;
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* ── Kanban card ─────────────────────────────────────────────────────────── */
+
+.wk-kcard {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 10px 11px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-soft);
+  border-left: 2px solid var(--border-main);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: border-color 0.16s ease, background 0.16s ease, transform 0.12s ease;
+}
+
+.wk-kcard:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--border-highlight);
+  transform: translateY(-1px);
+}
+
+.wk-kcard:focus-visible {
+  outline: 2px solid var(--volt-dim);
+  outline-offset: 1px;
+}
+
+.wk-kcard.wip     { border-left-color: var(--volt-strong); }
+.wk-kcard.verify  { border-left-color: var(--info); }
+.wk-kcard.done    { border-left-color: var(--status-ok); opacity: 0.82; }
+.wk-kcard.claimed { border-left-color: var(--text-mid); }
+
+.wk-kcard-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wk-kcard-id {
+  font-size: 10.5px;
+  color: var(--text-dim);
+}
+
+.wk-kcard-prio {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-dim);
+  border: 1px solid var(--border-main);
+  border-radius: var(--radius-pill);
+  padding: 0 6px;
+}
+
+.wk-kcard-title {
+  font-size: 12.5px;
+  line-height: 1.35;
+  color: var(--text-primary);
+  text-wrap: pretty;
+}
+
+.wk-kcard.done .wk-kcard-title {
+  color: var(--text-mid);
+}
+
+.wk-kcard-block {
+  font-size: 10.5px;
+  color: var(--status-bad);
+}
+
+.wk-kcard-goal {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  text-align: left;
+  font-size: 10.5px;
+  color: var(--text-dim);
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color 0.14s ease;
+}
+
+.wk-kcard-goal:hover {
+  color: var(--volt-strong);
+}
+
+.wk-kcard-ho {
+  color: var(--volt-strong);
+  font-size: 12px;
+}
+
+.wk-kcard-foot {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.wk-kcard-kp {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 50%;
+}
+
+.wk-kcard-kp.none {
+  color: var(--text-faint);
+  cursor: default;
+}
+
+.wk-kcard-claim {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-ui);
+  font-size: 15px;
+  line-height: 1;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1px solid var(--volt-dim);
+  background: var(--volt-wash);
+  color: var(--volt-strong);
+  cursor: pointer;
+  transition: 0.14s;
+}
+
+.wk-kcard-claim:hover {
+  background: color-mix(in oklab, var(--volt) 20%, transparent);
+  color: var(--text-bright);
+}

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -734,3 +734,525 @@
     display: none;
   }
 }
+
+/* ── WorkAside operator triage panel ─────────────────────────────────────────
+ *
+ * Ported from keeper-v2/styles/v2.css lines 809-878, 1047-1182.
+ * Uses dashboard token aliases defined in .wk-surface (above).
+ * The .ov-aside shell is in surfaces-v2.css (.ov.ov-2col layout);
+ * these rules cover the WorkAside-specific internals.
+ *
+ * Token mapping: prototype → dashboard
+ *   var(--bg-panel)      → var(--color-bg-panel-alt)
+ *   var(--bg-deep)       → var(--color-bg-page)
+ *   var(--bg-card)       → var(--color-bg-surface)
+ *   var(--bg-card-hover) → var(--color-bg-surface-hover, var(--color-bg-surface))
+ *   var(--bg-sunken)     → var(--color-bg-sunken, var(--color-bg-page))
+ *   var(--border-main)   → var(--color-border)
+ *   var(--border-soft)   → var(--color-border-subtle)
+ *   var(--border-highlight) → var(--border-strong)
+ *   var(--text-bright)   → var(--color-text-primary)
+ *   var(--text-mid)      → var(--color-text-secondary)
+ *   var(--text-dim)      → var(--text-muted)
+ *   var(--text-faint)    → var(--color-text-disabled, var(--text-muted))
+ *   var(--volt-strong)   → var(--color-volt-strong, var(--color-accent))
+ *   var(--volt-dim)      → var(--color-volt-dim, var(--color-accent-subtle))
+ *   var(--volt-wash)     → var(--color-volt-wash, color-mix(in oklab, var(--color-accent) 10%, transparent))
+ *   var(--volt)          → var(--color-volt, var(--color-accent))
+ *   var(--status-ok)     → var(--color-status-ok)
+ *   var(--status-warn)   → var(--color-status-warn)
+ *   var(--status-bad)    → var(--color-status-bad)
+ *   var(--radius-xs)     → var(--radius-xs, 3px)
+ *   var(--radius-sm)     → var(--radius-sm, 4px)
+ *   var(--radius-pill)   → var(--radius-pill, 999px)
+ *   var(--font-display)  → ui-sans-serif, -apple-system, system-ui, sans-serif
+ *   var(--font-mono)     → ui-monospace, "SF Mono", Menlo, Consolas, monospace
+ *   var(--font-ui)       → ui-sans-serif, -apple-system, system-ui, sans-serif
+ */
+
+/* ── Aside shell ── */
+.ov-aside {
+  flex: none;
+  width: 360px; /* default; overridden inline by resize state */
+  border-left: 1px solid var(--color-border);
+  background: color-mix(in oklab, var(--color-bg-panel-alt) 45%, var(--color-bg-page));
+  overflow-y: auto;
+  padding: 26px 22px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 26px;
+}
+
+/* Collapsed rail mode — narrow fixed width, vertical labels */
+.ov-aside.wka.collapsed {
+  width: 54px;
+  padding: 14px 0 18px;
+  gap: 16px;
+  align-items: center;
+  overflow: visible;
+  cursor: pointer;
+  transition: background 0.16s ease;
+}
+
+.ov-aside.wka.collapsed:hover {
+  background: color-mix(in oklab, var(--color-bg-panel-alt) 62%, var(--color-bg-page));
+}
+
+/* Expanded wka resets .ov-aside defaults to match prototype */
+.ov-aside.wka {
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+/* ── Resizer handle ── */
+.wka-resizer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 6;
+}
+
+.wka-resizer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 1px;
+  background: transparent;
+  transition: background 0.14s ease;
+}
+
+.wka-resizer:hover::after,
+.wka-resizer:focus-visible::after {
+  background: var(--color-volt-strong, var(--color-accent));
+}
+
+/* ── Top bar ── */
+.wka-bar {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 16px 18px 12px;
+  flex: none;
+}
+
+.wka-bar-t {
+  font-family: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-primary);
+}
+
+.wka-bar-live {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.wka-livedot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-status-ok);
+  box-shadow: 0 0 6px var(--color-status-ok);
+}
+
+.wka-collapse,
+.wka-railbtn {
+  display: grid;
+  place-items: center;
+  background: var(--color-bg-sunken, var(--color-bg-page));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xs, 3px);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.14s ease, border-color 0.14s ease;
+}
+
+.wka-collapse {
+  margin-left: auto;
+  width: 24px;
+  height: 24px;
+  font-size: 13px;
+}
+
+.wka-railbtn {
+  width: 28px;
+  height: 28px;
+  font-size: 13px;
+}
+
+.wka-collapse:hover,
+.wka-railbtn:hover,
+.wka-collapse:focus-visible,
+.wka-railbtn:focus-visible {
+  color: var(--color-volt-strong, var(--color-accent));
+  border-color: var(--color-volt-dim, var(--color-accent-subtle));
+}
+
+/* ── HUD counts strip ── */
+.wka-hud {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: color-mix(in oklab, var(--color-bg-surface) 60%, transparent);
+  flex: none;
+}
+
+.wka-hud-c {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 11px 6px 12px 14px;
+  border-left: 1px solid var(--color-border-subtle);
+}
+
+.wka-hud-c:first-child {
+  border-left: 0;
+}
+
+.wka-hud-k {
+  font-size: 8.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.wka-hud-v {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 20px;
+  line-height: 1;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.wka-hud-v.volt {
+  color: var(--color-volt-strong, var(--color-accent));
+}
+
+.wka-hud-v.warn {
+  color: var(--color-status-warn);
+}
+
+/* ── Scrollable section content ── */
+.wka-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 18px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* ── Section header ── */
+.wka-sec {
+  display: flex;
+  flex-direction: column;
+}
+
+.wka-h {
+  font-family: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 11px;
+  white-space: nowrap;
+}
+
+.wka-h .n,
+.wka-h-n {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-muted);
+  letter-spacing: 0;
+}
+
+.wka-h-n.bad {
+  color: var(--color-status-bad);
+}
+
+.wka-h-n.dim {
+  color: var(--text-muted);
+}
+
+.wka-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.wka-calm {
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 5px 2px;
+}
+
+/* ── Flagged goal row ── */
+.wka-flag {
+  text-align: left;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 8px;
+  padding: 9px 11px;
+  border: 1px solid var(--color-border-subtle);
+  border-left-width: 2px;
+  border-radius: var(--radius-sm, 4px);
+  background: var(--color-bg-surface);
+  cursor: pointer;
+  transition: border-color 0.16s ease, background 0.16s ease;
+  width: 100%;
+}
+
+.wka-flag:hover,
+.wka-flag:focus-visible {
+  background: var(--color-bg-surface-hover, var(--color-bg-surface));
+  border-color: var(--border-strong);
+}
+
+.wka-flag.st-warn {
+  border-left-color: var(--color-status-warn);
+}
+
+.wka-flag.st-bad {
+  border-left-color: var(--color-status-bad);
+}
+
+.wka-flag.st-volt {
+  border-left-color: var(--color-volt-strong, var(--color-accent));
+}
+
+.wka-flag-tag {
+  grid-column: 1;
+  align-self: start;
+  font-family: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  padding: 1px 7px;
+  border-radius: var(--radius-pill, 999px);
+  border: 1px solid var(--color-border);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.wka-flag-tag.warn {
+  color: var(--color-status-warn);
+  border-color: color-mix(in oklab, var(--color-status-warn) 40%, transparent);
+}
+
+.wka-flag-tag.bad {
+  color: var(--color-status-bad);
+  border-color: color-mix(in oklab, var(--color-status-bad) 42%, transparent);
+}
+
+.wka-flag-tag.volt {
+  color: var(--color-volt-strong, var(--color-accent));
+  border-color: var(--color-volt-dim, var(--color-accent-subtle));
+}
+
+.wka-flag-title {
+  grid-column: 2;
+  font-size: 12.5px;
+  color: var(--color-text-primary);
+  line-height: 1.3;
+}
+
+.wka-flag-reason {
+  grid-column: 1 / -1;
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ── Todo items (approvals / verify / blockers / backlog) ── */
+.wka-todo {
+  text-align: left;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 3px 9px;
+  padding: 8px 11px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm, 4px);
+  background: var(--color-bg-surface);
+  cursor: pointer;
+  transition: border-color 0.16s ease, background 0.16s ease;
+  width: 100%;
+}
+
+.wka-todo:hover,
+.wka-todo:focus-visible {
+  background: var(--color-bg-surface-hover, var(--color-bg-surface));
+  border-color: var(--border-strong);
+}
+
+.wka-todo-k {
+  grid-column: 1;
+  align-self: start;
+  font-family: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: var(--radius-pill, 999px);
+  white-space: nowrap;
+}
+
+.wka-todo.approve .wka-todo-k {
+  color: var(--color-volt-strong, var(--color-accent));
+  background: var(--color-volt-wash, color-mix(in oklab, var(--color-accent) 10%, transparent));
+  border: 1px solid var(--color-volt-dim, var(--color-accent-subtle));
+}
+
+.wka-todo.verify .wka-todo-k {
+  color: var(--color-volt-strong, var(--color-accent));
+  border: 1px solid var(--color-volt-dim, var(--color-accent-subtle));
+}
+
+.wka-todo.block .wka-todo-k {
+  color: var(--color-status-bad);
+  border: 1px solid color-mix(in oklab, var(--color-status-bad) 42%, transparent);
+}
+
+.wka-todo.claim .wka-todo-k {
+  color: var(--color-status-warn);
+  border: 1px solid color-mix(in oklab, var(--color-status-warn) 40%, transparent);
+}
+
+.wka-todo-t {
+  grid-column: 2;
+  font-size: 12.5px;
+  color: var(--color-text-primary);
+  line-height: 1.3;
+}
+
+.wka-todo-m {
+  grid-column: 2;
+  font-size: 10.5px;
+  color: var(--text-muted);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ── Recent done items ── */
+.wka-done {
+  text-align: left;
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  padding: 6px 10px;
+  border-radius: var(--radius-xs, 3px);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  transition: background 0.16s ease;
+  width: 100%;
+}
+
+.wka-done:hover,
+.wka-done:focus-visible {
+  background: var(--color-bg-sunken, var(--color-bg-page));
+}
+
+.wka-done-mark {
+  flex: none;
+  color: var(--color-status-ok);
+  font-size: 11px;
+}
+
+.wka-done-t {
+  font-size: 12.5px;
+  color: var(--color-text-secondary);
+  line-height: 1.3;
+}
+
+/* ── Collapsed rail stats ── */
+.wka-rail-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 13px;
+  align-items: center;
+}
+
+.wka-rail-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.wka-rail-stat b {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 17px;
+  line-height: 1;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.wka-rail-stat span {
+  font-size: 8px;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.wka-rail-stat.volt b {
+  color: var(--color-volt-strong, var(--color-accent));
+}
+
+.wka-rail-stat.warn b {
+  color: var(--color-status-warn);
+}
+
+.wka-rail-stat.bad b {
+  color: var(--color-status-bad);
+}
+
+.wka-rail-lbl {
+  margin-top: auto;
+  writing-mode: vertical-rl;
+  font-family: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.wka-rail-hint {
+  writing-mode: vertical-rl;
+  font-family: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  color: var(--color-text-disabled, var(--text-muted));
+  text-transform: uppercase;
+  margin-top: 8px;
+}
+
+/* Hide aside at narrow viewports — can't fit 2 columns below 1180px */
+@media (max-width: 1180px) {
+  .ov-aside {
+    display: none;
+  }
+}


### PR DESCRIPTION
horizon purge(#22223, main 반영) 이후 라이브 Work 서피스를 시안(`Downloads/v2 (24)/keeper-v2/work.jsx`)에 맞춰 두 요소 추가. 둘 다 work.ts/CSS의 Work-surface fidelity 변경.

## 1) WorkAside — 우측 운영 triage 패널
`<main class="ov">` 단일컬럼 → `ov-2col`. goals/tasks signals에서 useMemo immutable 도출: flagged goals·승인대기·검증task(open-gate count)·blocker·claimable backlog·최근완료. HUD + collapse(localStorage) + resize handle + a11y. 시안 mock status → **라이브 phase enum exact membership**(`GOAL_ATTENTION_PHASES`={awaiting_verification,awaiting_approval,blocked,paused}; executing·completed·dropped 제외). 적대검증으로 정당성 오류 1건 수정.

## 2) 리스트 | 칸반 뷰 토글
시안의 view 토글(호라이즌|칸반) 복원 — horizon 제거됐으므로 **리스트|칸반**. 리스트=flat priority-sorted goal 리스트, 칸반=전체 task를 status 컬럼 보드로. WorkAside는 양 뷰 유지. **status enum typed closed tuple** `KANBAN_COLUMNS`(todo|claimed|in_progress|awaiting_verification|done; cancelled 의도적 제외)로 immutable per-column 필터. KanbanCard는 기존 헬퍼(jobStateForTask/blockerNoteForTask/keeperByName) 재사용. view는 localStorage `v2.workView` persist.

## 정당성으로 의도적 SKIP한 시안 요소
- **TaskLineage**(시안의 status-합성 actor 체인): 라이브는 이미 **실 `UnifiedTraceEvent[]` trace**(TaskActivityList) 보유 → 시안의 mock 합성 복제는 실데이터 downgrade(노 휴리스틱 위반)라 미복제.

## 검증
dashboard `tsc --noEmit` clean (현재 main 기준). vitest `work.test.ts` **34 pass**(8 WorkAside + 4 kanban + 기존). no stub/hardcoding/string-match, immutable, horizon 미참조.

⚠️ CI는 main-health(#22225: R6/TLA/cdal/harness 4-gate) inherit red — 이 PR diff와 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)