### PR TITLE
fix(server): wire per-keeper Memory OS consolidation and derive hebbian view from shared facts

### DIFF
--- a/lib/keeper/keeper_memory_os_consolidation_runtime.mli
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.mli
@@ -7,6 +7,9 @@
 
 type complete_fn = Keeper_memory_llm_summary.complete_fn
 
+(** Default completion function: routes to [Llm_provider.Complete.complete]. *)
+val default_complete : complete_fn
+
 type outcome =
   | Skipped_too_few of int
   | Transport_failed of string

--- a/lib/server/server_bootstrap_loops.mli
+++ b/lib/server/server_bootstrap_loops.mli
@@ -47,7 +47,7 @@ end
 
 val start_background_maintenance :
   sw:Eio.Switch.t ->
-  clock:[> float Eio.Time.clock_ty ] Eio.Time.clock ->
+  clock:float Eio.Time.clock_ty Eio.Time.clock ->
   env:Eio_unix.Stdenv.base ->
   Mcp_server.server_state -> string * string
 (** Spawn the periodic maintenance fibers (institution episode capping,

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -8,28 +8,30 @@ let log_server_fiber_crash =
 
 (* Resolve the provider config for the Memory OS per-keeper consolidation pass.
    Env var takes precedence; otherwise inherit the librarian runtime so the
-   consolidation LLM uses the same JSON-capable model the librarian uses. *)
+   consolidation LLM uses the same JSON-capable model the librarian uses.
+   An explicit but unknown runtime ID is logged and falls back to the default
+   so typos in operator config are not silently masked. *)
 let provider_cfg_for_memory_os_consolidation () =
+  let default_cfg () =
+    Runtime.get_default_runtime ()
+    |> Option.map (fun rt -> rt.Runtime.provider_config)
+  in
   let runtime_id =
     match Keeper_memory_bank_env.memory_env_opt "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID" with
-    | Some id -> id
-    | None ->
-      (match Runtime.librarian_runtime_id () with
-       | Some id -> id
-       | None ->
-         (match Runtime.get_default_runtime () with
-          | Some rt -> rt.Runtime.id
-          | None -> ""))
+    | Some id -> Some id
+    | None -> Runtime.librarian_runtime_id ()
   in
-  if String.equal runtime_id ""
-  then None
-  else
-    (match Runtime.get_runtime_by_id runtime_id with
+  match runtime_id with
+  | None -> default_cfg ()
+  | Some id ->
+    (match Runtime.get_runtime_by_id id with
      | Some rt -> Some rt.Runtime.provider_config
      | None ->
-       (match Runtime.get_default_runtime () with
-        | Some rt -> Some rt.Runtime.provider_config
-        | None -> None))
+       Log.Server.warn
+         "memory_os_keeper_consolidation: requested runtime %s not found; \
+          falling back to default"
+         id;
+       default_cfg ())
 ;;
 
 (* Run one consolidation pass over every keeper that currently has a fact store.
@@ -59,28 +61,28 @@ let run_memory_os_consolidation_tick
          with
          | Keeper_memory_os_consolidation_runtime.Consolidated { before; after } ->
            Log.Server.info
-             "memory_os_consolidation: keeper=%s before=%d after=%d"
+             "memory_os_keeper_consolidation: keeper=%s before=%d after=%d"
              keeper_id
              before
              after
          | Skipped_too_few n ->
            Log.Server.info
-             "memory_os_consolidation: keeper=%s skipped_too_few=%d"
+             "memory_os_keeper_consolidation: keeper=%s skipped_too_few=%d"
              keeper_id
              n
          | Transport_failed msg ->
            Log.Server.warn
-             "memory_os_consolidation: keeper=%s transport_failed: %s"
+             "memory_os_keeper_consolidation: keeper=%s transport_failed: %s"
              keeper_id
              msg
          | Unparseable msg ->
            Log.Server.warn
-             "memory_os_consolidation: keeper=%s unparseable: %s"
+             "memory_os_keeper_consolidation: keeper=%s unparseable: %s"
              keeper_id
              msg
          | Snapshot_changed { before; current } ->
            Log.Server.info
-             "memory_os_consolidation: keeper=%s snapshot_changed before=%d current=%d"
+             "memory_os_keeper_consolidation: keeper=%s snapshot_changed before=%d current=%d"
              keeper_id
              before
              current
@@ -88,7 +90,7 @@ let run_memory_os_consolidation_tick
        | Eio.Cancel.Cancelled _ as e -> raise e
        | exn ->
          Log.Server.warn
-           "memory_os_consolidation: keeper=%s tick crashed: %s"
+           "memory_os_keeper_consolidation: keeper=%s tick crashed: %s"
            keeper_id
            (Printexc.to_string exn))
     (Keeper_memory_os_io.list_fact_store_keeper_ids ())
@@ -376,7 +378,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
   then
     fork_logged_fiber
       ~sw
-      ~on_error:(log_server_fiber_crash "memory_os_consolidation")
+      ~on_error:(log_server_fiber_crash "memory_os_keeper_consolidation")
       (fun () ->
         (* Coarser than Tier-2 consolidation (300s): this pass calls the LLM,
            so a 10-minute cadence bounds cost while still shrinking stores. *)
@@ -385,7 +387,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
           (match provider_cfg_for_memory_os_consolidation () with
            | None ->
              Log.Server.warn
-               "memory_os_consolidation: no runtime configured; skipping tick"
+               "memory_os_keeper_consolidation: no runtime configured; skipping tick"
            | Some provider_cfg ->
              run_memory_os_consolidation_tick
                ~sw

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -6,6 +6,94 @@ let fork_logged_fiber = Server_bootstrap_loops_fiber.fork_logged_fiber
 let log_server_fiber_crash =
   Server_bootstrap_loops_fiber.log_server_fiber_crash
 
+(* Resolve the provider config for the Memory OS per-keeper consolidation pass.
+   Env var takes precedence; otherwise inherit the librarian runtime so the
+   consolidation LLM uses the same JSON-capable model the librarian uses. *)
+let provider_cfg_for_memory_os_consolidation () =
+  let runtime_id =
+    match Keeper_memory_bank_env.memory_env_opt "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID" with
+    | Some id -> id
+    | None ->
+      (match Runtime.librarian_runtime_id () with
+       | Some id -> id
+       | None ->
+         (match Runtime.get_default_runtime () with
+          | Some rt -> rt.Runtime.id
+          | None -> ""))
+  in
+  if String.equal runtime_id ""
+  then None
+  else
+    (match Runtime.get_runtime_by_id runtime_id with
+     | Some rt -> Some rt.Runtime.provider_config
+     | None ->
+       (match Runtime.get_default_runtime () with
+        | Some rt -> Some rt.Runtime.provider_config
+        | None -> None))
+;;
+
+(* Run one consolidation pass over every keeper that currently has a fact store.
+   The optional [complete] injection lets tests drive the loop with a fake model. *)
+let run_memory_os_consolidation_tick
+      ?(complete = Keeper_memory_os_consolidation_runtime.default_complete)
+      ~sw
+      ~net
+      ?clock
+      ~provider_cfg
+      ~now
+      ()
+  =
+  List.iter
+    (fun keeper_id ->
+       try
+         match
+           Keeper_memory_os_consolidation_runtime.consolidate_keeper
+             ~complete
+             ~sw
+             ~net
+             ?clock
+             ~provider_cfg
+             ~now
+             ~keeper_id
+             ()
+         with
+         | Keeper_memory_os_consolidation_runtime.Consolidated { before; after } ->
+           Log.Server.info
+             "memory_os_consolidation: keeper=%s before=%d after=%d"
+             keeper_id
+             before
+             after
+         | Skipped_too_few n ->
+           Log.Server.info
+             "memory_os_consolidation: keeper=%s skipped_too_few=%d"
+             keeper_id
+             n
+         | Transport_failed msg ->
+           Log.Server.warn
+             "memory_os_consolidation: keeper=%s transport_failed: %s"
+             keeper_id
+             msg
+         | Unparseable msg ->
+           Log.Server.warn
+             "memory_os_consolidation: keeper=%s unparseable: %s"
+             keeper_id
+             msg
+         | Snapshot_changed { before; current } ->
+           Log.Server.info
+             "memory_os_consolidation: keeper=%s snapshot_changed before=%d current=%d"
+             keeper_id
+             before
+             current
+       with
+       | Eio.Cancel.Cancelled _ as e -> raise e
+       | exn ->
+         Log.Server.warn
+           "memory_os_consolidation: keeper=%s tick crashed: %s"
+           keeper_id
+           (Printexc.to_string exn))
+    (Keeper_memory_os_io.list_fact_store_keeper_ids ())
+;;
+
 let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_state) =
   (* Metrics flush fiber: drains write queue every 500ms, batches file appends.
      Replaces the old mutex + synchronous file I/O pattern. *)
@@ -275,11 +363,41 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
          loop ()
        in
        loop ()));
-  (* #9876: Hebbian consolidation fiber. Prior to this, the graph was
-     write-only — strengthen/weaken populated synapses but decay +
-     pruning never ran (zero production callers of [consolidate]).
-     last_consolidation=0.0 on live graphs confirmed the gap in
-     production. *)
+  (* RFC-0247 §2.3: per-keeper Memory OS consolidation. The librarian writes
+     facts every cadence turn; without this pass a keeper's Tier-1 store only
+     grows. Off the hot path: every [interval]s it asks the model to merge
+     duplicate/superseded facts and rewrites the store atomically. Gated by
+     [MASC_KEEPER_MEMORY_OS_CONSOLIDATION] (default false) until a live shadow
+     run validates what the model would prune on the user's data. *)
+  if
+    Keeper_memory_bank_env.memory_env_bool_logged
+      "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
+      ~default:false
+  then
+    fork_logged_fiber
+      ~sw
+      ~on_error:(log_server_fiber_crash "memory_os_consolidation")
+      (fun () ->
+        (* Coarser than Tier-2 consolidation (300s): this pass calls the LLM,
+           so a 10-minute cadence bounds cost while still shrinking stores. *)
+        let interval = 600.0 in
+        let rec loop () =
+          (match provider_cfg_for_memory_os_consolidation () with
+           | None ->
+             Log.Server.warn
+               "memory_os_consolidation: no runtime configured; skipping tick"
+           | Some provider_cfg ->
+             run_memory_os_consolidation_tick
+               ~sw
+               ~net:env#net
+               ~clock
+               ~provider_cfg
+               ~now:(Time_compat.now ())
+               ());
+          Eio.Time.sleep clock interval;
+          loop ()
+        in
+        loop ());
   (* System_internal tool usage log: durable JSONL for pruning evidence (#5120) *)
   Tool_usage_log.init
     ~base_path:(Mcp_server.workspace_config state).base_path

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -1,8 +1,22 @@
 val fork_logged_fiber :
   sw:Eio.Switch.t -> on_error:(exn -> unit) -> (unit -> unit) -> unit
 val log_server_fiber_crash : string -> exn -> unit
+
+val provider_cfg_for_memory_os_consolidation :
+  unit -> Llm_provider.Provider_config.t option
+
+val run_memory_os_consolidation_tick :
+  ?complete:Keeper_memory_os_consolidation_runtime.complete_fn ->
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  provider_cfg:Llm_provider.Provider_config.t ->
+  now:float ->
+  unit ->
+  unit
+
 val start_background_maintenance :
   sw:Eio.Switch.t ->
-  clock:[> float Eio.Time.clock_ty ] Eio.Resource.t ->
+  clock:float Eio.Time.clock_ty Eio.Resource.t ->
   env:Eio_unix.Stdenv.base ->
   Mcp_server.server_state -> string * string

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -123,6 +123,61 @@ let user_model_prompt_json () =
     ]
 ;;
 
+(* RFC-0244 Tier 2: derive the Hebbian synapse view from cross-keeper
+   corroboration. Each shared fact that was observed by multiple keepers
+   becomes one or more synapses; [last_consolidation] is the most recent
+   verification timestamp of any shared fact. Before this, the field was a
+   hardcoded placeholder that always reported an empty graph and
+   last_consolidation=0.0, so recorded memory appeared unviewable. *)
+let compute_hebbian ~base_path ~now () =
+  try
+    let keepers_dir =
+      Config_dir_resolver.keepers_dir_for_base_path ~base_path
+    in
+    let shared_facts =
+      Keeper_memory_os_io.read_facts_all_for_keepers_dir
+        ~keepers_dir
+        ~keeper_id:Keeper_memory_os_types.shared_store_id
+      |> List.filter (Keeper_memory_os_types.fact_is_current ~now)
+    in
+    let last_consolidation =
+      shared_facts
+      |> List.filter_map (fun (f : Keeper_memory_os_types.fact) -> f.last_verified_at)
+      |> List.fold_left Float.max 0.0
+    in
+    let synapse_counts : ((string * string), int) Hashtbl.t = Hashtbl.create 16 in
+    shared_facts
+    |> List.iter (fun (fact : Keeper_memory_os_types.fact) ->
+      let keepers = fact.observed_by in
+      let n = List.length keepers in
+      for i = 0 to n - 1 do
+        for j = i + 1 to n - 1 do
+          let a = List.nth keepers i in
+          let b = List.nth keepers j in
+          let key = if String.compare a b <= 0 then a, b else b, a in
+          let prev = Option.value (Hashtbl.find_opt synapse_counts key) ~default:0 in
+          Hashtbl.replace synapse_counts key (prev + 1)
+        done
+      done);
+    let synapses =
+      Hashtbl.fold
+        (fun (a, b) count acc ->
+           let weight = Float.min 1.0 (float_of_int count *. 0.1) in
+           `Assoc
+             [ "from_agent", `String a
+             ; "to_agent", `String b
+             ; "weight", `Float weight
+             ]
+           :: acc)
+        synapse_counts
+        []
+    in
+    `Assoc [ "synapses", `List synapses; "last_consolidation", `Float last_consolidation ]
+  with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | _ -> `Assoc [ "synapses", `List []; "last_consolidation", `Float 0.0 ]
+;;
+
 let dashboard_memory_subsystems_http_json
       ~(config : Workspace_utils.config)
       ?include_memory_entries
@@ -150,11 +205,8 @@ let dashboard_memory_subsystems_http_json
     |> Option.map (fun s -> String.trim s |> String.lowercase_ascii)
     |> Fun.flip Option.bind (fun s -> if s = "" then None else Some s)
   in
-  let hebbian =
-    try `Null with
-    | Eio.Cancel.Cancelled _ as e -> raise e
-    | _ -> `Assoc [ "synapses", `List []; "last_consolidation", `Float 0.0 ]
-  in
+  let now = Unix.gettimeofday () in
+  let hebbian = compute_hebbian ~base_path:config.base_path ~now () in
   let all_episodes =
     try Institution_eio.load_recent_episodes_jsonl ~limit:max_int with
     | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -123,6 +123,15 @@ let user_model_prompt_json () =
     ]
 ;;
 
+(* The Hebbian synapse weight is a DISPLAY-only saturation scale for the
+   dashboard graph, not a learned or normalized synaptic strength: a keeper pair
+   reaches [max_synapse_weight] once they co-observe [synapse_saturation_facts]
+   shared facts, scaling linearly below that. Named so the scale is explicit and
+   reviewable rather than an unexplained literal (it drives no behavior — purely
+   how thick the dashboard edge renders). *)
+let max_synapse_weight = 1.0
+let synapse_saturation_facts = 10.0
+
 (* RFC-0244 Tier 2: derive the Hebbian synapse view from cross-keeper
    corroboration. Each shared fact that was observed by multiple keepers
    becomes one or more synapses; [last_consolidation] is the most recent
@@ -162,7 +171,9 @@ let compute_hebbian ~base_path ~now () =
     let synapses =
       Hashtbl.fold
         (fun (a, b) count acc ->
-           let weight = Float.min 1.0 (float_of_int count *. 0.1) in
+           let weight =
+             Float.min max_synapse_weight (float_of_int count /. synapse_saturation_facts)
+           in
            `Assoc
              [ "from_agent", `String a
              ; "to_agent", `String b
@@ -175,7 +186,15 @@ let compute_hebbian ~base_path ~now () =
     `Assoc [ "synapses", `List synapses; "last_consolidation", `Float last_consolidation ]
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | _ -> `Assoc [ "synapses", `List []; "last_consolidation", `Float 0.0 ]
+  | exn ->
+    (* Log rather than silently swallow: a persistent fact-store read failure
+       must be distinguishable from a genuinely empty graph, otherwise it
+       presents as the same last_consolidation=0.0 "unviewable" state this
+       function was added to fix. *)
+    Log.Server.warn
+      "compute_hebbian: synapse view derivation failed, returning empty graph: %s"
+      (Printexc.to_string exn);
+    `Assoc [ "synapses", `List []; "last_consolidation", `Float 0.0 ]
 ;;
 
 let dashboard_memory_subsystems_http_json

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -149,6 +149,10 @@ let compute_hebbian ~base_path ~now () =
         ~keeper_id:Keeper_memory_os_types.shared_store_id
       |> List.filter (Keeper_memory_os_types.fact_is_current ~now)
     in
+    (* [last_consolidation] is the most recent [last_verified_at] of any
+       current shared fact, not the timestamp of the last consolidator run.
+       The name matches the dashboard schema; the value is fact-derived because
+       the shared store is the SSOT for cross-keeper corroboration. *)
     let last_consolidation =
       shared_facts
       |> List.filter_map (fun (f : Keeper_memory_os_types.fact) -> f.last_verified_at)
@@ -157,12 +161,18 @@ let compute_hebbian ~base_path ~now () =
     let synapse_counts : ((string * string), int) Hashtbl.t = Hashtbl.create 16 in
     shared_facts
     |> List.iter (fun (fact : Keeper_memory_os_types.fact) ->
-      let keepers = fact.observed_by in
-      let n = List.length keepers in
+      (* Dedupe within a single fact so a duplicate observer cannot inflate the
+         synapse count, and convert to an array for O(1) pairwise indexing. *)
+      let keepers =
+        fact.observed_by
+        |> List.sort_uniq String.compare
+        |> Array.of_list
+      in
+      let n = Array.length keepers in
       for i = 0 to n - 1 do
         for j = i + 1 to n - 1 do
-          let a = List.nth keepers i in
-          let b = List.nth keepers j in
+          let a = keepers.(i) in
+          let b = keepers.(j) in
           let key = if String.compare a b <= 0 then a, b else b, a in
           let prev = Option.value (Hashtbl.find_opt synapse_counts key) ~default:0 in
           Hashtbl.replace synapse_counts key (prev + 1)

--- a/test/dune
+++ b/test/dune
@@ -101,6 +101,7 @@
   test_keeper_user_model
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime
+  test_server_bootstrap_maintenance_memory_os
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state
@@ -414,6 +415,7 @@
   test_keeper_user_model
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime
+  test_server_bootstrap_maintenance_memory_os
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -127,6 +127,27 @@ let test_accumulate_consolidate_recall () =
             (String_util.contains_substring block "deploys via blue-green")))))
 ;;
 
+let test_skips_when_too_few () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+        with_temp_keepers (fun () ->
+          let keeper_id = "keeper-1" in
+          (* A single fact is below the consolidation threshold. *)
+          Io.append_fact ~keeper_id (fact "only one fact");
+          let before_count = List.length (Io.read_facts_all ~keeper_id) in
+          Alcotest.(check int) "single fact accumulated" 1 before_count;
+          Server_bootstrap_maintenance.run_memory_os_consolidation_tick
+            ~complete:(fake_complete "{\"groups\":[],\"drop_indices\":[]}")
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ();
+          let after_count = List.length (Io.read_facts_all ~keeper_id) in
+          Alcotest.(check int) "store unchanged when too few facts" 1 after_count))))
+;;
+
 let () =
   Alcotest.run
     "server_bootstrap_maintenance_memory_os"
@@ -135,6 +156,10 @@ let () =
             "accumulate then consolidate then recall"
             `Quick
             test_accumulate_consolidate_recall
+        ; Alcotest.test_case
+            "skips when too few facts"
+            `Quick
+            test_skips_when_too_few
         ] )
     ]
 ;;

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -1,0 +1,140 @@
+(** Reproduction test for the Memory OS accumulate -> consolidate -> recall flow.
+
+    Before the fix, [Server_bootstrap_maintenance.run_memory_os_consolidation_tick]
+    did not exist and [Keeper_memory_os_consolidation_runtime.consolidate_keeper]
+    had zero production callers, so facts accumulated without consolidation and
+    the recall view only grew. This test drives the new maintenance tick helper
+    with a fake model and asserts the end-to-end flow works. *)
+
+module Types = Masc.Keeper_memory_os_types
+module Io = Masc.Keeper_memory_os_io
+module Recall = Masc.Keeper_memory_os_recall
+module Atypes = Agent_sdk.Types
+
+let now = 1_000_000.0
+
+let fact claim =
+  { Types.claim
+  ; category = Types.Fact
+  ; external_ref = None
+  ; claim_kind = None
+  ; source = { Types.trace_id = "t"; turn = 1; tool_call_id = None }
+  ; observed_by = []
+  ; first_seen = now
+  ; valid_until = None
+  ; last_verified_at = Some now
+  ; schema_version = Types.schema_version
+  ; claim_id = None
+  }
+;;
+
+let fake_response canned =
+  { Llm_provider.Types.id = "fake"
+  ; model = "fake"
+  ; stop_reason = Llm_provider.Types.EndTurn
+  ; content = [ Atypes.Text canned ]
+  ; usage = None
+  ; telemetry = None
+  }
+;;
+
+let fake_complete canned : Masc.Keeper_memory_os_consolidation_runtime.complete_fn =
+  fun ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () -> Ok (fake_response canned)
+;;
+
+let provider_cfg () =
+  Llm_provider.Provider_config.make
+    ~kind:Llm_provider.Provider_config.Anthropic
+    ~model_id:"fake"
+    ~base_url:"http://localhost"
+    ()
+;;
+
+let with_temp_keepers f =
+  let marker = Filename.temp_file "consolidation-tick-" ".tmp" in
+  Sys.remove marker;
+  Io.For_testing.with_keepers_dir marker f
+;;
+
+let with_prompts f =
+  let root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some r -> r
+    | None -> "."
+  in
+  Fun.protect
+    ~finally:Prompt_registry.clear
+    (fun () ->
+       Prompt_registry.clear ();
+       Prompt_registry.set_markdown_dir (Filename.concat root "config/prompts");
+       Masc.Prompt_defaults.init ();
+       f ())
+;;
+
+let test_accumulate_consolidate_recall () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+        with_temp_keepers (fun () ->
+          let keeper_id = "keeper-1" in
+          (* 1. Accumulate: append five redundant facts. *)
+          List.iter
+            (Io.append_fact ~keeper_id)
+            [ fact "deploy uses blue-green"
+            ; fact "deployment is blue-green based"
+            ; fact "build runs on dune 3.x"
+            ; fact "tests live under test/"
+            ; fact "ci runs on github actions"
+            ];
+          let before_count = List.length (Io.read_facts_all ~keeper_id) in
+          Alcotest.(check int) "accumulated facts" 5 before_count;
+          (* 2. Consolidate: the model merges the first two claims. *)
+          let plan =
+            {|{"groups":[{"member_indices":[0,1],"consolidated_claim":"deploys via blue-green","category":"fact"}],"drop_indices":[]}|}
+          in
+          Server_bootstrap_maintenance.run_memory_os_consolidation_tick
+            ~complete:(fake_complete plan)
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ();
+          let after_facts = Io.read_facts_all ~keeper_id in
+          let after_count = List.length after_facts in
+          Alcotest.(check int) "consolidated store size" 4 after_count;
+          let claims = after_facts |> List.map (fun f -> f.Types.claim) |> List.sort String.compare in
+          Alcotest.(check (list string))
+            "consolidated claims"
+            [ "build runs on dune 3.x"
+            ; "ci runs on github actions"
+            ; "deploys via blue-green"
+            ; "tests live under test/"
+            ]
+            claims;
+          (* 3. Recall: the consolidated memory is visible. *)
+          let block =
+            Recall.render_context
+              ~keeper_id
+              ~now
+              ~max_facts:8
+              ~max_episodes:2
+              ()
+          in
+          Alcotest.(check int) "recall sees consolidated store" 4 (List.length (Io.read_facts_all ~keeper_id));
+          Alcotest.(check bool)
+            "recall block includes consolidated claim"
+            true
+            (String_util.contains_substring block "deploys via blue-green")))))
+;;
+
+let () =
+  Alcotest.run
+    "server_bootstrap_maintenance_memory_os"
+    [ ( "memory_os"
+      , [ Alcotest.test_case
+            "accumulate then consolidate then recall"
+            `Quick
+            test_accumulate_consolidate_recall
+        ] )
+    ]
+;;

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -334,6 +334,54 @@ let test_http_json_hebbian_derives_from_shared_facts () =
          check bool "weight is positive" true (Json.(synapse |> member "weight" |> to_number) > 0.0)))
 ;;
 
+let test_http_json_hebbian_empty_without_shared_facts () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       let config = Workspace_utils.default_config dir in
+       let json =
+         Memory_subsystems.dashboard_memory_subsystems_http_json
+           ~config
+           ~include_memory_entries:false
+           (request "/dashboard/memory-subsystems?limit=100")
+       in
+       let hebbian = Json.(json |> member "hebbian") in
+       check int "empty synapses" 0 Json.(hebbian |> member "synapses" |> to_list |> List.length);
+       check
+         (float 0.0001)
+         "last_consolidation zero when no shared facts"
+         0.0
+         Json.(hebbian |> member "last_consolidation" |> to_number))
+;;
+
+let test_http_json_hebbian_dedupes_duplicate_observers () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       let config = Workspace_utils.default_config dir in
+       let keepers_dir =
+         Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.base_path
+       in
+       Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
+         (* A duplicate observer in a single fact must not inflate the edge. *)
+         Memory_io.append_fact
+           ~keeper_id:Types.shared_store_id
+           (shared_fact
+              ~observed_by:[ "keeper-a"; "keeper-a"; "keeper-b" ]
+              ~last_verified_at:10.0
+              "Shared operational fact");
+         let json =
+           Memory_subsystems.dashboard_memory_subsystems_http_json
+             ~config
+             ~include_memory_entries:false
+             (request "/dashboard/memory-subsystems?limit=100")
+         in
+         let synapses = Json.(json |> member "hebbian" |> member "synapses" |> to_list) in
+         check int "one synapse after dedupe" 1 (List.length synapses)))
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   Alcotest.run
@@ -365,6 +413,14 @@ let () =
             "hebbian derives from shared facts"
             `Quick
             test_http_json_hebbian_derives_from_shared_facts
+        ; test_case
+            "hebbian empty without shared facts"
+            `Quick
+            test_http_json_hebbian_empty_without_shared_facts
+        ; test_case
+            "hebbian dedupes duplicate observers"
+            `Quick
+            test_http_json_hebbian_dedupes_duplicate_observers
         ; test_case
             "surfaces draft skill candidates"
             `Quick

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -281,6 +281,59 @@ let test_http_json_surfaces_delegation_requests () =
         (Filename.basename Json.(item |> member "task_seed_md_path" |> to_string)))
 ;;
 
+let shared_fact ?(observed_by = []) ?(last_verified_at = 10.0) claim : Types.fact =
+  { claim
+  ; category = Types.Fact
+  ; external_ref = None
+  ; claim_kind = None
+  ; source = { trace_id = "shared"; turn = 1; tool_call_id = None }
+  ; observed_by
+  ; first_seen = 10.0
+  ; valid_until = None
+  ; last_verified_at = Some last_verified_at
+  ; schema_version = Types.schema_version
+  ; claim_id = None
+  }
+;;
+
+let test_http_json_hebbian_derives_from_shared_facts () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       let config = Workspace_utils.default_config dir in
+       let keepers_dir =
+         Config_dir_resolver.keepers_dir_for_base_path ~base_path:config.base_path
+       in
+       Memory_io.For_testing.with_keepers_dir keepers_dir (fun () ->
+         Memory_io.append_fact
+           ~keeper_id:Types.shared_store_id
+           (shared_fact
+              ~observed_by:[ "keeper-a"; "keeper-b" ]
+              ~last_verified_at:42.0
+              "Shared operational fact");
+         let json =
+           Memory_subsystems.dashboard_memory_subsystems_http_json
+             ~config
+             ~include_memory_entries:false
+             (request "/dashboard/memory-subsystems?limit=100")
+         in
+         let hebbian = Json.(json |> member "hebbian") in
+         check
+           (float 0.0001)
+           "last_consolidation from shared fact"
+           42.0
+           Json.(hebbian |> member "last_consolidation" |> to_number);
+         let synapses = Json.(hebbian |> member "synapses" |> to_list) in
+         check int "one synapse for one shared pair" 1 (List.length synapses);
+         let synapse = List.hd synapses in
+         let from_agent = Json.(synapse |> member "from_agent" |> to_string) in
+         let to_agent = Json.(synapse |> member "to_agent" |> to_string) in
+         let pair = List.sort String.compare [ from_agent; to_agent ] in
+         check (list string) "synapse links the two observers" [ "keeper-a"; "keeper-b" ] pair;
+         check bool "weight is positive" true (Json.(synapse |> member "weight" |> to_number) > 0.0)))
+;;
+
 let () =
   Eio_main.run @@ fun _env ->
   Alcotest.run
@@ -308,6 +361,10 @@ let () =
             "user model projection reads config base path"
             `Quick
             test_http_json_user_model_uses_config_base_path
+        ; test_case
+            "hebbian derives from shared facts"
+            `Quick
+            test_http_json_hebbian_derives_from_shared_facts
         ; test_case
             "surfaces draft skill candidates"
             `Quick


### PR DESCRIPTION
## Summary
- The Memory OS kept appending facts but never ran consolidation in production because `server_bootstrap_maintenance.ml` had only a commented-out Hebbian fiber with no caller for `Keeper_memory_os_consolidation_runtime.consolidate_keeper`.
- The dashboard's `hebbian` field was hardcoded to an empty graph / `last_consolidation=0.0`, so recorded memory was not visible.

## Changes
- Added a per-keeper consolidation tick helper and a 10-minute fiber in `server_bootstrap_maintenance.ml`, gated by `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` (default false) and inheriting the librarian/default runtime config.
- Replaced the placeholder `hebbian` JSON with `compute_hebbian`, which derives synapses and `last_consolidation` from shared facts' `observed_by` lists.
- Added `test_server_bootstrap_maintenance_memory_os.ml` to reproduce accumulate → consolidate → recall.
- Added a dashboard test case asserting `hebbian` derives from shared facts.

## Test Plan
- [x] `dune exec test/test_keeper_memory_os_consolidation_runtime.exe` (6/6 pass)
- [x] `dune exec test/test_server_bootstrap_maintenance_memory_os.exe` (1/1 pass)
- [x] `dune exec test/test_server_dashboard_http_memory_subsystems.exe` (8/8 pass)
- [x] `dune build lib/server/masc_server.a` succeeds
- [x] `ocamlformat --check` on changed files passes

## Scope
- Changes limited to `lib/keeper`, `lib/server`, and `test` memory-related modules.
- No OAS changes.
