### PR TITLE
fix(keeper): autonomous no-tool prose turn requires evidence (RFC-0294 R2a)

### DIFF
--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -88,7 +88,16 @@ type turn_delivery =
   | Peer_only
     (* peer-surface tool (board/comment/broadcast/keeper-msg), or silent:
        no peer/claim tool and no visible text *)
-  | User_facing (* non-empty visible reply, no peer/claim tool *)
+  | User_facing
+    (* RFC-0294 R2a [Reply_to_external] concept: non-empty visible reply on a
+       REACTIVE turn — an external prompt is present (pending mention /
+       board-event / scope-message). Exempt from evidence: replying to an
+       external prompt is itself the work. *)
+  | Autonomous_prose
+    (* RFC-0294 R2a: non-empty visible reply on an AUTONOMOUS (self-cadence, no
+       external prompt) turn. Requires evidence — a keeper that wakes on its own
+       clock and only emits prose ("nothing to do") is not progress, and was the
+       residual no-progress blind spot after R1g. *)
   | Task_claim (* task-claim tool *)
 
 (* Classify from observable facts. Order is significant: a turn that calls a
@@ -107,30 +116,33 @@ type turn_delivery =
    exactly the "posts to peers without evidence" case RFC-0239 targets. The set
    is pinned in test_no_progress_loop_detector so any axis change forces a
    conscious no-progress review. *)
-let classify_delivery ~tools ~has_visible_text =
+let classify_delivery ~is_autonomous ~tools ~has_visible_text =
   if Keeper_tool_capability_axis.(supports_any Board_activity tools)
   then Peer_only
   else if Keeper_tool_capability_axis.(supports_any Claim_task tools)
   then Task_claim
   else if has_visible_text
-  then User_facing
+  then if is_autonomous then Autonomous_prose else User_facing
   else Peer_only
 ;;
 
-let classify_turn_delivery result =
+let classify_turn_delivery ~is_autonomous result =
   classify_delivery
+    ~is_autonomous
     ~tools:(Keeper_agent_result.tool_names result)
     ~has_visible_text:(String.trim result.Keeper_agent_run.response_text <> "")
 ;;
 
-(* A peer-only or silent turn must show durable evidence to count as progress; a
-   user-facing reply or a task claim is exempt. Preserves the pre-RFC-0276
-   surface mapping (peer/broadcast/silent -> true; visible reply/task claim
-   -> false). Exhaustive, no [_ ->] catch-all
-   (CLAUDE.md anti-pattern #4): a new [turn_delivery] variant must be classified
-   here at compile time. *)
+(* A peer-only/silent turn, or an autonomous prose-only turn, must show durable
+   evidence to count as progress; a reactive user-facing reply or a task claim is
+   exempt. Preserves the pre-RFC-0276 surface mapping (peer/broadcast/silent ->
+   true; reactive visible reply/task claim -> false) and adds the RFC-0294 R2a
+   split: an [Autonomous_prose] turn (self-cadence, no external prompt, prose
+   only) now requires evidence. Exhaustive, no [_ ->] catch-all (CLAUDE.md
+   anti-pattern #4): a new [turn_delivery] variant must be classified here at
+   compile time. *)
 let delivery_requires_evidence = function
-  | Peer_only -> true
+  | Peer_only | Autonomous_prose -> true
   | User_facing | Task_claim -> false
 ;;
 
@@ -196,11 +208,20 @@ let apply_loop_detectors ~config ~observation updated_meta result =
   in
   (* [Task_claim] is exempt only when a claim bound work; a claim that typed
      [No_progress] (e.g. No_eligible_tasks) now requires evidence and so accrues
-     the streak. Other surfaces keep the exhaustive name-based mapping. *)
+     the streak. Other surfaces keep the exhaustive name-based mapping.
+     RFC-0294 R2a: the autonomy of the cycle (external prompt absent) splits a
+     prose-only reply into [Autonomous_prose] (requires evidence) vs the reactive
+     [User_facing] reply (exempt). Derived from the same observation channel the
+     budget override already reads. *)
+  let is_autonomous =
+    Keeper_unified_metrics_support.is_scheduled_autonomous_cycle_of_observation
+      observation
+  in
   let surface_requires_evidence =
-    match classify_turn_delivery result with
+    match classify_turn_delivery ~is_autonomous result with
     | Task_claim -> not (claim_bound_work calls_with_outcomes)
-    | (Peer_only | User_facing) as delivery -> delivery_requires_evidence delivery
+    | (Peer_only | User_facing | Autonomous_prose) as delivery ->
+      delivery_requires_evidence delivery
   in
   let made_progress =
     Keeper_no_progress_loop_detector.turn_made_progress
@@ -244,6 +265,7 @@ module For_testing = struct
   type nonrec turn_delivery = turn_delivery =
     | Peer_only
     | User_facing
+    | Autonomous_prose
     | Task_claim
 
   let classify_delivery = classify_delivery

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -19,11 +19,15 @@ module For_testing : sig
       self-declared delivery header as the no-progress detector input). *)
   type turn_delivery =
     | Peer_only
-    | User_facing
+    | User_facing  (** reactive visible reply (external prompt present); exempt *)
+    | Autonomous_prose
+        (** RFC-0294 R2a: self-cadence prose-only turn (no external prompt);
+            requires evidence *)
     | Task_claim
 
   val classify_delivery
-    :  tools:string list
+    :  is_autonomous:bool
+    -> tools:string list
     -> has_visible_text:bool
     -> turn_delivery
 

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -255,10 +255,21 @@ let test_no_progress_board_post_accrues_streak () =
 let delivery_label = function
   | Success.Peer_only -> "peer_only"
   | Success.User_facing -> "user_facing"
+  | Success.Autonomous_prose -> "autonomous_prose"
   | Success.Task_claim -> "task_claim"
 
+(* [classify] is the reactive cycle (external prompt present): a prose-only reply
+   classifies as [User_facing] (exempt), matching the pre-RFC-0294 mapping. The
+   autonomous (self-cadence, no external prompt) cycle is [classify_auto], which
+   routes a prose-only reply to [Autonomous_prose] (requires evidence). The
+   tool-precedence cases (peer/claim dominate text) are autonomy-independent. *)
 let classify ~tools ~has_visible_text =
-  delivery_label (Success.classify_delivery ~tools ~has_visible_text)
+  delivery_label
+    (Success.classify_delivery ~is_autonomous:false ~tools ~has_visible_text)
+
+let classify_auto ~tools ~has_visible_text =
+  delivery_label
+    (Success.classify_delivery ~is_autonomous:true ~tools ~has_visible_text)
 
 let test_classify_delivery_mapping () =
   let claim_tool = List.hd Cap.claim_task_tool_names in
@@ -316,9 +327,20 @@ let test_classify_delivery_mapping () =
   Alcotest.(check string) "claim + text -> task_claim (claim dominates text)"
     "task_claim"
     (classify ~tools:[ claim_tool ] ~has_visible_text:true);
-  (* No peer/claim tool + visible text -> user-facing reply (exempt). *)
-  Alcotest.(check string) "no tool + text -> user_facing" "user_facing"
+  (* No peer/claim tool + visible text, REACTIVE cycle -> user-facing reply
+     (exempt): replying to an external prompt is the work. *)
+  Alcotest.(check string) "no tool + text (reactive) -> user_facing" "user_facing"
     (classify ~tools:[] ~has_visible_text:true);
+  (* RFC-0294 R2a: same surface facts on an AUTONOMOUS cycle (no external prompt)
+     -> autonomous_prose (requires evidence). The autonomy bit is the only
+     difference, so it is the sole discriminator of the split. *)
+  Alcotest.(check string) "no tool + text (autonomous) -> autonomous_prose"
+    "autonomous_prose"
+    (classify_auto ~tools:[] ~has_visible_text:true);
+  (* Tool precedence is autonomy-independent: a peer/claim tool still dominates
+     text even on an autonomous cycle (the split only affects prose-only turns). *)
+  Alcotest.(check string) "peer tool + text (autonomous) -> peer_only" "peer_only"
+    (classify_auto ~tools:[ "keeper_board_post" ] ~has_visible_text:true);
   (* No peer/claim tool + no text = silent turn -> Peer_only (requires
      evidence). This is the parse-don't-validate replacement for the old
      DELIVERY_SURFACE: silent header self-declaration. *)
@@ -336,6 +358,8 @@ let test_delivery_requires_evidence_mapping () =
     (Success.delivery_requires_evidence Success.Peer_only);
   Alcotest.(check bool) "user_facing exempt" false
     (Success.delivery_requires_evidence Success.User_facing);
+  Alcotest.(check bool) "autonomous_prose requires evidence" true
+    (Success.delivery_requires_evidence Success.Autonomous_prose);
   Alcotest.(check bool) "task_claim exempt" false
     (Success.delivery_requires_evidence Success.Task_claim)
 
@@ -347,7 +371,8 @@ let test_silent_turns_accrue_streak () =
   for _ = 1 to 4 do
     let surface_requires_evidence =
       Success.delivery_requires_evidence
-        (Success.classify_delivery ~tools:[] ~has_visible_text:false)
+        (Success.classify_delivery ~is_autonomous:false ~tools:[]
+           ~has_visible_text:false)
     in
     record_turn ~keeper_name:k
       ~made_progress:
@@ -355,6 +380,48 @@ let test_silent_turns_accrue_streak () =
     |> ignore_outcome
   done;
   Alcotest.(check int) "silent no-evidence turns accrue streak" 4
+    (D.current_streak ~keeper_name:k)
+
+(* RFC-0294 R2a: an autonomous (self-cadence, no external prompt) turn that emits
+   only prose and no durable evidence accrues the no-progress streak. This is the
+   residual blind spot after R1g: R1g stops failed_task from *driving* the wake,
+   but a keeper that still wakes (e.g. real cooldown elapse) and only says
+   "nothing to do" previously reset the streak via the [User_facing] exemption.
+   With the [Autonomous_prose] split it now requires evidence. *)
+let test_autonomous_textonly_noop_accrues_streak () =
+  let k = "r2a_autonomous_prose_thrash" in
+  for _ = 1 to 4 do
+    let surface_requires_evidence =
+      Success.delivery_requires_evidence
+        (Success.classify_delivery ~is_autonomous:true ~tools:[]
+           ~has_visible_text:true)
+    in
+    record_turn ~keeper_name:k
+      ~made_progress:
+        (D.turn_made_progress ~strong_evidence:false ~surface_requires_evidence)
+    |> ignore_outcome
+  done;
+  Alcotest.(check int) "autonomous prose-only no-evidence turns accrue streak" 4
+    (D.current_streak ~keeper_name:k)
+
+(* RFC-0294 R2a false-positive guard: a REACTIVE turn (external prompt present)
+   that replies to an operator/peer with prose and no tool is legitimate work and
+   stays exempt — it must NOT accrue the streak. Distinguishes the split from a
+   blanket "no-tool prose is no-progress" cap. *)
+let test_operator_mention_textonly_reply_exempt () =
+  let k = "r2a_reactive_reply_exempt" in
+  for _ = 1 to 4 do
+    let surface_requires_evidence =
+      Success.delivery_requires_evidence
+        (Success.classify_delivery ~is_autonomous:false ~tools:[]
+           ~has_visible_text:true)
+    in
+    record_turn ~keeper_name:k
+      ~made_progress:
+        (D.turn_made_progress ~strong_evidence:false ~surface_requires_evidence)
+    |> ignore_outcome
+  done;
+  Alcotest.(check int) "reactive prose reply does not accrue streak" 0
     (D.current_streak ~keeper_name:k)
 
 (* RFC-0239 / audit D1·D3: the no-progress detector reads the typed outcome
@@ -475,6 +542,12 @@ let () =
             `Quick test_delivery_requires_evidence_mapping;
           Alcotest.test_case "silent no-evidence turns accrue streak"
             `Quick (with_eio test_silent_turns_accrue_streak);
+          Alcotest.test_case
+            "R2a autonomous prose-only turns accrue streak"
+            `Quick (with_eio test_autonomous_textonly_noop_accrues_streak);
+          Alcotest.test_case
+            "R2a reactive prose reply stays exempt (false-positive guard)"
+            `Quick (with_eio test_operator_mention_textonly_reply_exempt);
           Alcotest.test_case "claim exemption is outcome-aware (D3)"
             `Quick test_claim_outcome_aware_exemption;
           Alcotest.test_case "strong evidence drops typed-failure completions (D1)"


### PR DESCRIPTION
RFC-0294 PR-5/7 — R2a (defense-in-depth). R1g(#22214, merged)는 failed_task가 proactive wake를 **구동**하는 것을 source에서 끊었다. R2a는 그 뒤 남는 무진행 blind spot을 닫는 backstop이다.

## 문제 (R1g 이후 잔존)

keeper가 실제 cooldown 경과 등으로 깨어나 도구 없이 prose만("할 일 없음") 내보내면, 기존 `User_facing` 면제 때문에 no-progress streak이 **리셋**돼 loop detector가 영영 안 걸렸다.

## 구조적 수정 (cap 아님)

닫힌 `turn_delivery` sum을 `Autonomous_prose` variant로 확장하고, prose-only 케이스를 **사이클 자율성**으로 분리:

- `classify_delivery`에 `~is_autonomous` 추가. 무도구 prose는 self-cadence(외부 프롬프트 없음)면 `Autonomous_prose`, reactive(pending mention/board-event/scope-message)면 `User_facing` 유지.
- `delivery_requires_evidence`는 exhaustive(`_ ->` catch-all 없음) → 새 variant가 컴파일 타임 분류 강제. `Peer_only | Autonomous_prose -> true`, `User_facing | Task_claim -> false`.
- 자율성 비트는 `apply_loop_detectors`에서 `Keeper_unified_metrics_support.is_scheduled_autonomous_cycle_of_observation`로 도출 — no-work budget override가 이미 읽는 동일 observation 채널. **새 plumbing/순환 의존 0**.

## False-positive 가드

operator/peer mention에 대한 reactive prose 응답은 면제 유지 — 분리는 "도구 없음"이 아니라 **외부 프롬프트 부재**에 게이팅. "모든 무도구 prose를 no-progress"로 over-broaden하는 cap이 아니다.

## 워크어라운드 바 self-check

- counter/telemetry-as-fix ❌ (streak 동작을 실제로 바꿈)
- string-classifier ❌ (typed variant 추가)
- N-of-M ❌ (단일 SSOT 분류기)
- cap/cooldown ❌ (variant + exhaustive match, N개 후 latch 아님)

## 검증

- `dune build lib/` exit 0
- `test_no_progress_loop_detector`: 20→22, 전부 green
- **revert-red 증명**: `Autonomous_prose -> true` arm을 exempt로 되돌리면 매핑 테스트 + streak 테스트 2건 red (로컬 재현). false-positive 가드는 OK 유지 → 분리를 양방향 핀.
- `check-ssot.sh` exit 0

Refs RFC-0294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
