### PR TITLE
feat(keeper): wire wake-tombstone into self-cadence should_run (RFC-0294 R2b)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -74,6 +74,10 @@ val decide_keepalive_scheduling :
   ?runtime_resilience_of_name:(string -> string option) ->
   ?keeper_resilience_of_name:(string -> string option) ->
   ?reactive_wake:bool ->
+  ?wake_tombstone_decide:
+    (origin:Keeper_wake_tombstone.wake_origin ->
+     keeper_name:string ->
+     Keeper_wake_tombstone.wake_decision) ->
   stop:bool Atomic.t ->
   meta:keeper_meta ->
   Keeper_world_observation.world_observation ->

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -29,6 +29,7 @@ let decide_keepalive_scheduling
       ?(runtime_resilience_of_name = fun _ -> None)
       ?(keeper_resilience_of_name = fun _ -> None)
       ?(reactive_wake = false)
+      ?(wake_tombstone_decide = Keeper_wake_tombstone.decide)
       ~stop
       ~meta
       obs
@@ -38,6 +39,26 @@ let decide_keepalive_scheduling
   in
   let requested_should_run_turn =
     (not (Atomic.get stop)) && turn_decision.should_run
+  in
+  (* RFC-0294 R2b: the RFC-0246 wake-tombstone was wired only into the external
+     wake paths (Keeper_registry Heartbeat / Board_reactive); a keeper latched in
+     a no-progress loop kept re-waking on its OWN self-cadence clock. Gate the
+     scheduled-autonomous wake through the same tombstone here. This is an
+     admission gate (like runtime backpressure), so it suppresses [should_run_turn]
+     while leaving [requested_should_run_turn] ("the world wanted a turn") intact.
+     Reactive turns are gated upstream in the registry, so only the autonomous
+     channel is gated here. *)
+  let self_cadence_wake : Keeper_wake_tombstone.wake_decision =
+    if Keeper_world_observation.is_autonomous turn_decision.channel
+    then
+      wake_tombstone_decide ~origin:Keeper_wake_tombstone.Self_cadence
+        ~keeper_name:meta.name
+    else Keeper_wake_tombstone.Wake_allowed
+  in
+  let self_cadence_wake_allowed =
+    match self_cadence_wake with
+    | Keeper_wake_tombstone.Wake_allowed -> true
+    | Keeper_wake_tombstone.Suppressed _ -> false
   in
   let runtime_id = runtime_id_of_meta meta in
   let runtime_backpressure =
@@ -57,11 +78,17 @@ let decide_keepalive_scheduling
   in
   let should_run_turn =
     match runtime_backpressure with
-    | Runtime_admitted -> requested_should_run_turn
+    | Runtime_admitted -> requested_should_run_turn && self_cadence_wake_allowed
     | Runtime_backpressured _ -> false
   in
   let verdict_reasons =
     let base = Keeper_world_observation.verdict_reasons_to_strings turn_decision.verdict in
+    let base =
+      match self_cadence_wake with
+      | Keeper_wake_tombstone.Suppressed reason ->
+        Keeper_wake_tombstone.suppression_label reason :: base
+      | Keeper_wake_tombstone.Wake_allowed -> base
+    in
     match runtime_backpressure with
     | Runtime_backpressured _ -> "runtime_backpressure" :: base
     | Runtime_admitted -> base

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -46,10 +46,15 @@ let decide_keepalive_scheduling
      scheduled-autonomous wake through the same tombstone here. This is an
      admission gate (like runtime backpressure), so it suppresses [should_run_turn]
      while leaving [requested_should_run_turn] ("the world wanted a turn") intact.
+     Only consult the tombstone when a self-cadence turn was actually requested;
+     idle/stop cycles should keep their original skip reason and must not be
+     reported as tombstone suppressions.
      Reactive turns are gated upstream in the registry, so only the autonomous
      channel is gated here. *)
   let self_cadence_wake : Keeper_wake_tombstone.wake_decision =
-    if Keeper_world_observation.is_autonomous turn_decision.channel
+    if
+      requested_should_run_turn
+      && Keeper_world_observation.is_autonomous turn_decision.channel
     then
       wake_tombstone_decide ~origin:Keeper_wake_tombstone.Self_cadence
         ~keeper_name:meta.name

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -14,7 +14,15 @@ val decide_keepalive_scheduling :
   ?runtime_resilience_of_name:(string -> string option) ->
   ?keeper_resilience_of_name:(string -> string option) ->
   ?reactive_wake:bool ->
+  ?wake_tombstone_decide:
+    (origin:Keeper_wake_tombstone.wake_origin ->
+     keeper_name:string ->
+     Keeper_wake_tombstone.wake_decision) ->
   stop:bool Atomic.t ->
   meta:Keeper_meta_contract.keeper_meta ->
   Keeper_world_observation.world_observation ->
   keepalive_scheduling_decision
+(** RFC-0294 R2b: [wake_tombstone_decide] (default {!Keeper_wake_tombstone.decide})
+    gates a scheduled-autonomous (self-cadence) wake through the no-progress
+    tombstone, suppressing [should_run_turn] for a latched keeper while leaving
+    [requested_should_run_turn] intact. Injectable for tests. *)

--- a/lib/keeper/keeper_wake_tombstone.ml
+++ b/lib/keeper/keeper_wake_tombstone.ml
@@ -18,6 +18,11 @@ type wake_origin =
   | Board_reactive
   | Heartbeat
   | Operator_direct
+  | Self_cadence
+    (* RFC-0294 R2b: the keeper's own self-cadence (scheduled-autonomous) clock.
+       An automatic wake like [Heartbeat]/[Board_reactive], so it must NOT bypass
+       the tombstone — a latched keeper kept re-waking on its self-clock was the
+       gap RFC-0246 left open. *)
 [@@deriving show, eq]
 
 (** Why an automatic wake was suppressed. Only the tombstone class today; the
@@ -36,7 +41,7 @@ type wake_decision =
 let bypasses_tombstone (origin : wake_origin) =
   match origin with
   | Operator_direct | Mention -> true
-  | Board_reactive | Heartbeat -> false
+  | Board_reactive | Heartbeat | Self_cadence -> false
 
 (** Gate decision for an automatic wake of [keeper_name]. Reads the
     no-progress loop detector's latched state — the single source of truth —

--- a/lib/keeper/keeper_wake_tombstone.mli
+++ b/lib/keeper/keeper_wake_tombstone.mli
@@ -10,6 +10,9 @@ type wake_origin =
   | Board_reactive
   | Heartbeat
   | Operator_direct
+  | Self_cadence
+      (** RFC-0294 R2b: scheduled-autonomous self-cadence wake; an automatic
+          origin that does NOT bypass the tombstone. *)
 [@@deriving show, eq]
 
 type wake_suppression =

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -33,6 +33,42 @@ let temp_dir prefix =
   Unix.mkdir dir 0o755;
   dir
 
+(* The autonomous keeper_cycle_decision path resolves a runtime id
+   (Keeper_meta_contract.runtime_id_of_meta -> Runtime.get_default_runtime_id),
+   which fails with no silent fallback (RFC-0206 §2.1) unless a default runtime
+   is initialized. Reactive turns return before that point, so only the
+   autonomous R2b test needs this. Tolerant of an already-initialized runtime
+   (Alcotest runs the whole binary in one process). *)
+let ensure_default_runtime () =
+  let runtime_toml =
+    {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+  in
+  let path = Filename.temp_file "heartbeat_integ_runtime_" ".toml" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc runtime_toml);
+  (* Ignore Error: a prior test in the binary may have initialized it already. *)
+  ignore (Runtime.init_default ~config_path:path)
+
 let cleanup_dir dir =
   let rec rm path =
     if Sys.file_exists path then
@@ -872,6 +908,61 @@ let test_keeper_health_backpressure_uses_keeper_name () =
      check string "keeper health reason" "keeper_health_unhealthy" reason
    | Obs.Runtime_admitted -> fail "keeper health should reject turn")
 
+(* RFC-0294 R2b: a scheduled-autonomous (self-cadence) cycle that the world
+   wants to run is suppressed when the keeper is latched in a no-progress loop.
+   The tombstone gate is injected so the test does not depend on global detector
+   state. [requested_should_run_turn] stays true (the world wanted a turn); only
+   [should_run_turn] flips to false (admission gate, like backpressure). *)
+let test_self_cadence_tombstone_suppresses_autonomous_turn () =
+  ensure_default_runtime ();
+  let meta = make_meta "r2b-self-cadence-latched" in
+  let obs = { base_observation with claimable_task_count = 1 } in
+  let suppress_self_cadence ~origin ~keeper_name:_ =
+    match origin with
+    | Masc.Keeper_wake_tombstone.Self_cadence ->
+      Masc.Keeper_wake_tombstone.Suppressed
+        Masc.Keeper_wake_tombstone.Tombstoned_no_progress_loop
+    | _ -> Masc.Keeper_wake_tombstone.Wake_allowed
+  in
+  let decision =
+    KHL.decide_keepalive_scheduling
+      ~runtime_id_of_meta:(fun _ -> "runtime-test")
+      ~wake_tombstone_decide:suppress_self_cadence
+      ~stop:(Atomic.make false)
+      ~meta
+      obs
+  in
+  check bool "autonomous turn was requested" true
+    decision.requested_should_run_turn;
+  check bool "self-cadence tombstone suppresses the run" false
+    decision.should_run_turn;
+  check bool "verdict reasons include the tombstone label" true
+    (List.mem "tombstone_no_progress_loop" decision.verdict_reasons)
+
+(* RFC-0294 R2b false-positive guard: the self-cadence gate applies only to the
+   autonomous channel. A reactive turn (external mention) is gated upstream in
+   the registry, so even a suppressor that would reject every origin must not
+   pause a reactive cycle here — the gate never consults it. *)
+let test_self_cadence_tombstone_does_not_gate_reactive_turn () =
+  let meta = make_meta "r2b-reactive-not-gated" in
+  let obs =
+    { base_observation with pending_mentions = [ "operator", "please run" ] }
+  in
+  let suppress_everything ~origin:_ ~keeper_name:_ =
+    Masc.Keeper_wake_tombstone.Suppressed
+      Masc.Keeper_wake_tombstone.Tombstoned_no_progress_loop
+  in
+  let decision =
+    KHL.decide_keepalive_scheduling
+      ~runtime_id_of_meta:(fun _ -> "runtime-test")
+      ~wake_tombstone_decide:suppress_everything
+      ~stop:(Atomic.make false)
+      ~meta
+      obs
+  in
+  check bool "reactive turn runs despite a self-cadence suppressor" true
+    decision.should_run_turn
+
 let test_crashed_cycle_records_health_failure () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -953,6 +1044,10 @@ let () =
         test_runtime_backpressure_blocks_requested_turn;
       test_case "keeper health blocks by keeper name" `Quick
         test_keeper_health_backpressure_uses_keeper_name;
+      test_case "R2b self-cadence tombstone suppresses autonomous turn" `Quick
+        test_self_cadence_tombstone_suppresses_autonomous_turn;
+      test_case "R2b self-cadence tombstone does not gate reactive turn" `Quick
+        test_self_cadence_tombstone_does_not_gate_reactive_turn;
       test_case "crashed cycles feed agent health breaker" `Quick
         test_crashed_cycle_records_health_failure;
     ];

--- a/test/test_heartbeat_integration.ml
+++ b/test/test_heartbeat_integration.ml
@@ -939,6 +939,30 @@ let test_self_cadence_tombstone_suppresses_autonomous_turn () =
   check bool "verdict reasons include the tombstone label" true
     (List.mem "tombstone_no_progress_loop" decision.verdict_reasons)
 
+(* RFC-0294 R2b observability guard: the tombstone is an admission gate for a
+   requested self-cadence turn, not a replacement for ordinary idle/stop skip
+   reasons. If the world did not request a turn, do not consult/report the
+   tombstone — otherwise idle cycles look tombstoned in metrics. *)
+let test_self_cadence_tombstone_not_reported_when_no_turn_requested () =
+  let meta = make_meta "r2b-self-cadence-idle" in
+  let suppress_everything ~origin:_ ~keeper_name:_ =
+    Masc.Keeper_wake_tombstone.Suppressed
+      Masc.Keeper_wake_tombstone.Tombstoned_no_progress_loop
+  in
+  let decision =
+    KHL.decide_keepalive_scheduling
+      ~runtime_id_of_meta:(fun _ -> "runtime-test")
+      ~wake_tombstone_decide:suppress_everything
+      ~stop:(Atomic.make false)
+      ~meta
+      base_observation
+  in
+  check bool "idle world did not request a turn" false
+    decision.requested_should_run_turn;
+  check bool "idle world still skips" false decision.should_run_turn;
+  check bool "verdict reasons do not include tombstone label" false
+    (List.mem "tombstone_no_progress_loop" decision.verdict_reasons)
+
 (* RFC-0294 R2b false-positive guard: the self-cadence gate applies only to the
    autonomous channel. A reactive turn (external mention) is gated upstream in
    the registry, so even a suppressor that would reject every origin must not
@@ -1046,6 +1070,8 @@ let () =
         test_keeper_health_backpressure_uses_keeper_name;
       test_case "R2b self-cadence tombstone suppresses autonomous turn" `Quick
         test_self_cadence_tombstone_suppresses_autonomous_turn;
+      test_case "R2b self-cadence tombstone is not reported without requested turn" `Quick
+        test_self_cadence_tombstone_not_reported_when_no_turn_requested;
       test_case "R2b self-cadence tombstone does not gate reactive turn" `Quick
         test_self_cadence_tombstone_does_not_gate_reactive_turn;
       test_case "crashed cycles feed agent health breaker" `Quick

--- a/test/test_keeper_wake_tombstone.ml
+++ b/test/test_keeper_wake_tombstone.ml
@@ -66,6 +66,33 @@ let test_per_keeper_isolation () =
   Alcotest.(check bool) "different keeper not affected"
     false (is_suppressed T.Board_reactive "tombstone-f")
 
+(* RFC-0294 R2b: the keeper's own self-cadence (scheduled-autonomous) clock is an
+   automatic origin and must NOT bypass the tombstone — this is the gap RFC-0246
+   left open (only Heartbeat/Board_reactive were gated, never the self-clock). A
+   latched keeper kept re-waking itself indefinitely. *)
+let test_self_cadence_suppressed_when_latched () =
+  D.reset_all_for_test ();
+  latch "tombstone-self-cadence";
+  Alcotest.(check bool)
+    "self-cadence does NOT bypass tombstone when latched"
+    true (is_suppressed T.Self_cadence "tombstone-self-cadence")
+
+(* RFC-0294 R2b false-positive guard (read-heavy-then-write): a keeper that does
+   threshold-1 no-progress turns then makes progress is NOT latched, so its
+   self-cadence wake stays allowed — the gate must not pause a keeper that is
+   still recovering on its own. *)
+let test_self_cadence_not_paused_when_not_latched () =
+  D.reset_all_for_test ();
+  let threshold = D.threshold () in
+  for _ = 1 to threshold - 1 do
+    D.record_turn ~keeper_name:"tombstone-recover" ~made_progress:false ()
+    |> ignore
+  done;
+  D.record_turn ~keeper_name:"tombstone-recover" ~made_progress:true () |> ignore;
+  Alcotest.(check bool)
+    "self-cadence wake allowed for non-latched (recovered) keeper"
+    false (is_suppressed T.Self_cadence "tombstone-recover")
+
 let () =
   Alcotest.run "keeper_wake_tombstone"
     [
@@ -86,5 +113,11 @@ let () =
           ( "per-keeper isolation",
             `Quick,
             with_eio test_per_keeper_isolation );
+          ( "R2b self-cadence suppressed when latched",
+            `Quick,
+            with_eio test_self_cadence_suppressed_when_latched );
+          ( "R2b self-cadence allowed when not latched (recovered)",
+            `Quick,
+            with_eio test_self_cadence_not_paused_when_not_latched );
         ] );
     ]


### PR DESCRIPTION
RFC-0294 PR-6/7 — R2b (defense-in-depth, MANDATORY gap). RFC-0246 wake-tombstone는 외부 wake 두 경로(`keeper_registry.ml:364` Heartbeat, `:438` Board_reactive)에만 배선됐고, keeper 자신의 self-cadence(scheduled-autonomous) clock에는 게이트가 없었다. latched keeper가 자기 시계로 무한 재기동하던 갭을 닫는다.

## 구조적 수정 (terminal tombstone, cap/cooldown 아님)

- **`keeper_wake_tombstone`**: `Self_cadence` wake_origin 추가. `bypasses_tombstone`는 exhaustive(`_ ->` 없음) → 새 variant가 분류 컴파일 강제. `Operator_direct | Mention`만 bypass, `Board_reactive | Heartbeat | Self_cadence`는 bypass 아님.
- **`decide_keepalive_scheduling`**: scheduled-autonomous wake를 `Keeper_wake_tombstone.decide` 경유로 게이팅. **admission 게이트**(runtime backpressure와 동급) — `should_run_turn`만 suppress, `requested_should_run_turn`("world가 턴을 원함")은 보존, suppression label을 verdict_reasons에 추가. reactive 턴은 registry에서 상위 게이팅되므로 autonomous 채널만 여기서 게이팅. tombstone decider는 테스트용 주입 가능(`?wake_tombstone_decide`).

복구는 기존 detector latch: progress 턴이 `is_latched`를 리셋하고 게이트가 그 상태를 읽어 재개. 별도 clear 경로 없음, noop multiplier를 정지 메커니즘으로 쓰지 않음.

## 워크어라운드 바 self-check

- cap/cooldown ❌ (terminal tombstone, N개 후 latch 아님 — detector latch 재사용)
- counter-as-fix ❌ (실제 should_run 억제)
- string-classifier ❌ (typed variant)
- catch-all 추가 ❌ (exhaustive match에 variant 추가)

## 검증

- `dune build lib/` exit 0, `check-ssot.sh` exit 0
- `test_keeper_wake_tombstone`: 5→7 (Self_cadence suppressed when latched + allowed when recovered)
- `test_heartbeat_integration` scheduling: +2 (autonomous suppress: should_run=false·requested=true·verdict label; reactive 미게이팅 가드)
- **revert-red 증명**: (1) Self_cadence를 bypasses_tombstone에 넣으면 unit red; (2) should_run 게이트 제거하면 autonomous integration red. 둘 다 복원 후 green (unit 7/7, integration 30/30).

Refs RFC-0294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
