### PR TITLE
feat(workspace): single-owner orphan surfacer gauge (RFC-0294 PR-4)

### DIFF
--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -141,6 +141,30 @@ let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~workspac
         Error msg
   end)
 
+(** RFC-0294 PR-4: single-owner orphan-task surfacer.
+
+    R1g (RFC-0294) removed [audit_orphan_tasks] from the keeper wake-driver, so an
+    orphaned task — in particular an [AwaitingVerification] one, which
+    [cleanup_zombies] Phase 3 does not release (RFC-0220 §5) and so never returns
+    to 0 — would become silently invisible (broken-but-visible regression). This
+    refreshes [masc_orphan_tasks] (gauge, labeled by status_class) each pulse beat
+    from the same audit, independent of the keeper actor. It is an alertable
+    metric, not an actor wake: if the reaper/pulse itself stalls (the 2026-06-21/22
+    reaper-not-running incident) the gauge goes stale, which is itself alertable.
+    Every class in [Workspace.orphan_status_classes] is emitted (0 when empty) so a
+    cleared class resets rather than leaving a stale value. *)
+let surface_orphan_tasks_gauge workspace_config =
+  let counts =
+    Workspace.orphan_counts_by_status_class
+      (Workspace.audit_orphan_tasks workspace_config)
+  in
+  List.iter
+    (fun (status_class, count) ->
+       Otel_metric_store.set_gauge Otel_metric_store.metric_orphan_tasks
+         ~labels:[ "status_class", status_class ]
+         (Float.of_int count))
+    counts
+
 (** Build the zero-zombie cleanup consumer.
     Runs Workspace.cleanup_zombies and logs if zombies were found. *)
 let make_zero_zombie_consumer ~sw ~workspace_config
@@ -234,7 +258,11 @@ let make_zero_zombie_consumer ~sw ~workspace_config
                         demote of repeated lines. *)
                      Log.Orchestrator.error
                        "[stale-claims] non-benign failure: %s"
-                       reason)
+                       reason);
+                (* RFC-0294 PR-4: refresh the orphan-task gauge each beat, after
+                   cleanup + stale-claim release so it reflects post-GC state. The
+                   surrounding catch (benign filter) covers a surfacer fault. *)
+                surface_orphan_tasks_gauge workspace_config
               with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
                 if not (Workspace_resilience.ZeroZombie.is_benign_error exn) then
                   Log.Orchestrator.warn "[zombie] error: %s" (Printexc.to_string exn)));

--- a/lib/otel_metric_store/otel_core_metric_names.ml
+++ b/lib/otel_metric_store/otel_core_metric_names.ml
@@ -21,6 +21,11 @@ let metric_error_events = Otel_metric_store_core.declare_counter "masc_error_eve
 let metric_workspace_route_failures = Otel_metric_store_core.declare_counter "masc_workspace_route_failures_total"
 let metric_active_agents = "masc_active_agents"
 let metric_pending_tasks = "masc_pending_tasks"
+
+(* RFC-0294 PR-4: gauge of orphaned tasks (claimed/in_progress/awaiting_verification
+   whose assignee is no longer active), labeled by status_class. A gauge (current
+   count), not a counter — no [_total] suffix, matching masc_pending_tasks. *)
+let metric_orphan_tasks = "masc_orphan_tasks"
 let metric_goal_attainment_pct = "masc_goal_attainment_pct"
 let metric_goal_attainment_measured = "masc_goal_attainment_measured"
 let metric_sse_reconnects = Otel_metric_store_core.declare_counter "masc_sse_reconnects_total"

--- a/lib/otel_metric_store/otel_core_metric_names.mli
+++ b/lib/otel_metric_store/otel_core_metric_names.mli
@@ -33,6 +33,9 @@ val metric_workspace_route_failures : string
 val metric_active_agents : string
 val metric_pending_tasks : string
 
+(** RFC-0294 PR-4: gauge of orphaned tasks, labeled by status_class. *)
+val metric_orphan_tasks : string
+
 (** Goal attainment percentage by [goal_id]. Companion
     {!metric_goal_attainment_measured} distinguishes real 0% from
     unmeasured goals. *)

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -161,6 +161,36 @@ let audit_orphan_tasks config : (Masc_domain.task * string) list =
       | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
     ) backlog.tasks
 
+(* RFC-0294 PR-4: the status classes [audit_orphan_tasks] can return — exactly
+   the three "active-assignee" statuses it matches (Claimed / InProgress /
+   AwaitingVerification, see the [task_status] match above). Held as a fixed set
+   so the orphan gauge always reports every class (0 when a class is empty)
+   rather than leaving a stale value behind when a class clears. The string
+   labels mirror [Masc_domain.task_status_to_string]; the surfacer test pins that
+   correspondence (drift guard) so a rename of the canonical strings fails the
+   test instead of silently splitting the metric vocabulary. *)
+let orphan_status_classes = [ "claimed"; "in_progress"; "awaiting_verification" ]
+
+(* Pure: count orphan-audit results per status class over the fixed class set.
+   Separated from the metric I/O (the gauge emitter lives in the orchestrator
+   pulse, which owns the Otel dependency) so the grouping is unit-testable
+   without workspace or metric-store side effects. *)
+let orphan_counts_by_status_class (orphans : (Masc_domain.task * string) list)
+  : (string * int) list =
+  List.map
+    (fun status_class ->
+       let count =
+         List.length
+           (List.filter
+              (fun ((task : Masc_domain.task), _assignee) ->
+                 String.equal
+                   (Masc_domain.task_status_to_string task.task_status)
+                   status_class)
+              orphans)
+       in
+       status_class, count)
+    orphan_status_classes
+
 let is_agent_active_at_path config path =
   match read_json_opt config path with
   | None -> false

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -161,20 +161,34 @@ let audit_orphan_tasks config : (Masc_domain.task * string) list =
       | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
     ) backlog.tasks
 
-(* RFC-0294 PR-4: the status classes [audit_orphan_tasks] can return — exactly
-   the three "active-assignee" statuses it matches (Claimed / InProgress /
-   AwaitingVerification, see the [task_status] match above). Held as a fixed set
-   so the orphan gauge always reports every class (0 when a class is empty)
-   rather than leaving a stale value behind when a class clears. The string
-   labels mirror [Masc_domain.task_status_to_string]; the surfacer test pins that
-   correspondence (drift guard) so a rename of the canonical strings fails the
-   test instead of silently splitting the metric vocabulary. *)
+(* RFC-0294 PR-4: the single typed source of truth for "is this status
+   orphan-eligible, and under which gauge class". EXHAUSTIVE over [task_status]
+   ([@warning "-4"] absent on purpose): adding a new constructor forces a
+   classification decision here at compile time, so a future orphan-eligible
+   status can never be silently dropped from the gauge — the exact failure the
+   old [String.equal (task_status_to_string …)] round-trip allowed. The label
+   strings are the [Masc_domain.task_status_to_string] values for the active
+   statuses, kept here so the metric vocabulary has one owner. Must stay aligned
+   with the orphan-eligibility match in [audit_orphan_tasks] above (both select
+   Claimed / InProgress / AwaitingVerification); the surfacer test pins both the
+   Some-labels and the None-set so a divergence fails the test. *)
+let orphan_status_class_of_status : Masc_domain.task_status -> string option = function
+  | Masc_domain.Claimed _ -> Some "claimed"
+  | Masc_domain.InProgress _ -> Some "in_progress"
+  | Masc_domain.AwaitingVerification _ -> Some "awaiting_verification"
+  | Masc_domain.Todo | Masc_domain.Done _ | Masc_domain.Cancelled _ -> None
+
+(* The fixed class set the gauge reports (0 when a class is empty, so a cleared
+   class resets rather than going stale). Exactly the Some-range of
+   [orphan_status_class_of_status]; the drift-guard test pins that equality. *)
 let orphan_status_classes = [ "claimed"; "in_progress"; "awaiting_verification" ]
 
 (* Pure: count orphan-audit results per status class over the fixed class set.
-   Separated from the metric I/O (the gauge emitter lives in the orchestrator
-   pulse, which owns the Otel dependency) so the grouping is unit-testable
-   without workspace or metric-store side effects. *)
+   Membership is decided by the typed [orphan_status_class_of_status], not a
+   string round-trip, so the grouping shares one exhaustive classifier with the
+   gauge vocabulary. Separated from the metric I/O (the gauge emitter lives in
+   the orchestrator pulse, which owns the Otel dependency) so the grouping is
+   unit-testable without workspace or metric-store side effects. *)
 let orphan_counts_by_status_class (orphans : (Masc_domain.task * string) list)
   : (string * int) list =
   List.map
@@ -183,9 +197,9 @@ let orphan_counts_by_status_class (orphans : (Masc_domain.task * string) list)
          List.length
            (List.filter
               (fun ((task : Masc_domain.task), _assignee) ->
-                 String.equal
-                   (Masc_domain.task_status_to_string task.task_status)
-                   status_class)
+                 match orphan_status_class_of_status task.task_status with
+                 | Some c -> String.equal c status_class
+                 | None -> false)
               orphans)
        in
        status_class, count)

--- a/lib/workspace/workspace_query.mli
+++ b/lib/workspace/workspace_query.mli
@@ -40,6 +40,18 @@ val get_all_agents : config -> Masc_domain.agent list
     Returns [(task, assignee)] pairs for orphaned tasks. *)
 val audit_orphan_tasks : config -> (Masc_domain.task * string) list
 
+(** RFC-0294 PR-4: the fixed set of orphan status classes (claimed /
+    in_progress / awaiting_verification). The orphan gauge reports every class
+    so a cleared class resets to 0 instead of going stale. *)
+val orphan_status_classes : string list
+
+(** RFC-0294 PR-4: count orphan-audit results per status class over
+    {!orphan_status_classes}. Pure (no I/O); the metric emitter is the
+    single-owner orchestrator pulse. Always returns one entry per class. *)
+val orphan_counts_by_status_class
+  :  (Masc_domain.task * string) list
+  -> (string * int) list
+
 (** {1 Agent Membership} *)
 
 (** Check if an agent has an active session the current workspace. *)

--- a/lib/workspace/workspace_query.mli
+++ b/lib/workspace/workspace_query.mli
@@ -40,8 +40,15 @@ val get_all_agents : config -> Masc_domain.agent list
     Returns [(task, assignee)] pairs for orphaned tasks. *)
 val audit_orphan_tasks : config -> (Masc_domain.task * string) list
 
+(** RFC-0294 PR-4: typed source of truth for orphan-status classification.
+    [Some label] for an orphan-eligible status (Claimed / InProgress /
+    AwaitingVerification), [None] otherwise. Exhaustive over [task_status] so a
+    new constructor is a compile error here rather than a silent gauge drop. *)
+val orphan_status_class_of_status : Masc_domain.task_status -> string option
+
 (** RFC-0294 PR-4: the fixed set of orphan status classes (claimed /
-    in_progress / awaiting_verification). The orphan gauge reports every class
+    in_progress / awaiting_verification) — exactly the [Some]-range of
+    {!orphan_status_class_of_status}. The orphan gauge reports every class
     so a cleared class resets to 0 instead of going stale. *)
 val orphan_status_classes : string list
 

--- a/test/dune
+++ b/test/dune
@@ -268,6 +268,7 @@
   test_env_git_noninteractive
   test_no_progress_loop_detector
   test_keeper_wake_tombstone
+  test_orphan_surfacer
   test_cap_blocker_structured_error
   test_context_overflow_action_tracker
   test_keeper_fs_edit_patch
@@ -581,6 +582,7 @@
   test_env_git_noninteractive
   test_no_progress_loop_detector
   test_keeper_wake_tombstone
+  test_orphan_surfacer
   test_cap_blocker_structured_error
   test_context_overflow_action_tracker
   test_keeper_fs_edit_patch

--- a/test/test_orphan_surfacer.ml
+++ b/test/test_orphan_surfacer.ml
@@ -110,6 +110,47 @@ let test_class_labels_match_task_status_to_string () =
     "orphan_status_classes mirror task_status_to_string (drift guard)"
     expected WQ.orphan_status_classes
 
+(* The typed classifier is the membership SSOT: every orphan-eligible status maps
+   to its Some-label, every non-orphan status maps to None, and the Some-range
+   equals orphan_status_classes. A new task_status constructor is a compile error
+   in orphan_status_class_of_status (it cannot reach here as a silent drop); this
+   test additionally pins that the Some-range and the reported class set agree, so
+   adding a class without listing it (or vice versa) fails. *)
+let test_classifier_is_membership_ssot () =
+  let some label = Some label in
+  Alcotest.(check (option string)) "claimed -> Some claimed"
+    (some "claimed")
+    (WQ.orphan_status_class_of_status (MD.Claimed { assignee = "x"; claimed_at = "t" }));
+  Alcotest.(check (option string)) "in_progress -> Some in_progress"
+    (some "in_progress")
+    (WQ.orphan_status_class_of_status (MD.InProgress { assignee = "x"; started_at = "t" }));
+  Alcotest.(check (option string)) "awaiting -> Some awaiting_verification"
+    (some "awaiting_verification")
+    (WQ.orphan_status_class_of_status
+       (MD.AwaitingVerification
+          { assignee = "x"; submitted_at = "t"; verification_id = "v"; phase = MD.Awaiting_verifier }));
+  Alcotest.(check (option string)) "todo -> None" None
+    (WQ.orphan_status_class_of_status MD.Todo);
+  Alcotest.(check (option string)) "done -> None" None
+    (WQ.orphan_status_class_of_status (MD.Done { assignee = "x"; completed_at = "t"; notes = None }));
+  Alcotest.(check (option string)) "cancelled -> None" None
+    (WQ.orphan_status_class_of_status (MD.Cancelled { cancelled_at = "t"; cancelled_by = "x"; reason = None }));
+  (* Some-range over every constructor equals the reported class set. *)
+  let some_range =
+    List.filter_map WQ.orphan_status_class_of_status
+      [ MD.Todo
+      ; MD.Claimed { assignee = "x"; claimed_at = "t" }
+      ; MD.InProgress { assignee = "x"; started_at = "t" }
+      ; MD.AwaitingVerification
+          { assignee = "x"; submitted_at = "t"; verification_id = "v"; phase = MD.Awaiting_verifier }
+      ; MD.Done { assignee = "x"; completed_at = "t"; notes = None }
+      ; MD.Cancelled { cancelled_at = "t"; cancelled_by = "x"; reason = None }
+      ]
+  in
+  Alcotest.(check (list string))
+    "classifier Some-range == orphan_status_classes"
+    WQ.orphan_status_classes some_range
+
 let () =
   Alcotest.run "orphan_surfacer"
     [ ( "orphan_counts_by_status_class"
@@ -120,5 +161,7 @@ let () =
             test_empty_is_all_zero
         ; Alcotest.test_case "class labels match task_status_to_string" `Quick
             test_class_labels_match_task_status_to_string
+        ; Alcotest.test_case "typed classifier is membership SSOT" `Quick
+            test_classifier_is_membership_ssot
         ] )
     ]

--- a/test/test_orphan_surfacer.ml
+++ b/test/test_orphan_surfacer.ml
@@ -1,0 +1,124 @@
+(* test/test_orphan_surfacer.ml
+
+   RFC-0294 PR-4: single-owner orphan-task surfacer. Pins the pure grouping the
+   orchestrator pulse emits as the [masc_orphan_tasks] gauge:
+   - Every status class in [orphan_status_classes] is reported (0 when empty), so
+     a cleared class resets the gauge instead of going stale.
+   - An AwaitingVerification orphan is counted under "awaiting_verification" — the
+     class [cleanup_zombies] Phase 3 never releases (RFC-0220 §5), which R1g made
+     invisible at the keeper wake-driver. T6.
+   - Drift guard: the fixed class labels equal [task_status_to_string] of the
+     orphan-eligible statuses, so a rename of the canonical strings fails here
+     rather than silently splitting the metric vocabulary. *)
+
+module WQ = Masc.Workspace
+module MD = Masc_domain
+
+let make_task ~id ~status : MD.task =
+  { id
+  ; title = "Test Task"
+  ; description = ""
+  ; task_status = status
+  ; priority = 3
+  ; files = []
+  ; created_at = "2024-01-01T00:00:00Z"
+  ; created_by = None
+  ; contract = None
+  ; handoff_context = None
+  ; cycle_count = 0
+  ; reclaim_policy = None
+  ; do_not_reclaim_reason = None
+  }
+
+let count_of cls counts =
+  match List.assoc_opt cls counts with Some n -> n | None -> -1
+
+(* T6: an AwaitingVerification orphan is surfaced under its own class, and the
+   other classes report 0 (fixed-set emission, no stale value). *)
+let test_emits_for_awaiting_verification () =
+  let awaiting =
+    make_task ~id:"t-av"
+      ~status:
+        (MD.AwaitingVerification
+           { assignee = "dead-keeper"
+           ; submitted_at = "2024-01-01T00:00:00Z"
+           ; verification_id = "v-1"
+           ; phase = MD.Awaiting_verifier
+           })
+  in
+  let counts = WQ.orphan_counts_by_status_class [ (awaiting, "dead-keeper") ] in
+  Alcotest.(check int) "awaiting_verification orphan counted" 1
+    (count_of "awaiting_verification" counts);
+  Alcotest.(check int) "claimed class reports 0 (not absent)" 0
+    (count_of "claimed" counts);
+  Alcotest.(check int) "in_progress class reports 0 (not absent)" 0
+    (count_of "in_progress" counts)
+
+(* Mixed input: counts are per-class and the result always covers every class. *)
+let test_counts_per_class () =
+  let claimed1 =
+    make_task ~id:"c1"
+      ~status:(MD.Claimed { assignee = "a"; claimed_at = "2024-01-01T00:00:00Z" })
+  in
+  let claimed2 =
+    make_task ~id:"c2"
+      ~status:(MD.Claimed { assignee = "b"; claimed_at = "2024-01-01T00:00:00Z" })
+  in
+  let inprog =
+    make_task ~id:"i1"
+      ~status:(MD.InProgress { assignee = "c"; started_at = "2024-01-01T00:00:00Z" })
+  in
+  let counts =
+    WQ.orphan_counts_by_status_class
+      [ (claimed1, "a"); (claimed2, "b"); (inprog, "c") ]
+  in
+  Alcotest.(check int) "two claimed orphans" 2 (count_of "claimed" counts);
+  Alcotest.(check int) "one in_progress orphan" 1
+    (count_of "in_progress" counts);
+  Alcotest.(check int) "no awaiting_verification" 0
+    (count_of "awaiting_verification" counts);
+  Alcotest.(check int) "every class present in result"
+    (List.length WQ.orphan_status_classes) (List.length counts)
+
+(* Empty audit -> every class reports 0 (the gauge resets, never goes stale). *)
+let test_empty_is_all_zero () =
+  let counts = WQ.orphan_counts_by_status_class [] in
+  List.iter
+    (fun cls ->
+      Alcotest.(check int)
+        (Printf.sprintf "%s is 0 on empty audit" cls)
+        0 (count_of cls counts))
+    WQ.orphan_status_classes
+
+(* Drift guard: the fixed labels mirror task_status_to_string of the
+   orphan-eligible statuses. A rename of the canonical strings fails here. *)
+let test_class_labels_match_task_status_to_string () =
+  let label status = MD.task_status_to_string status in
+  let expected =
+    [ label (MD.Claimed { assignee = "x"; claimed_at = "t" })
+    ; label (MD.InProgress { assignee = "x"; started_at = "t" })
+    ; label
+        (MD.AwaitingVerification
+           { assignee = "x"
+           ; submitted_at = "t"
+           ; verification_id = "v"
+           ; phase = MD.Awaiting_verifier
+           })
+    ]
+  in
+  Alcotest.(check (list string))
+    "orphan_status_classes mirror task_status_to_string (drift guard)"
+    expected WQ.orphan_status_classes
+
+let () =
+  Alcotest.run "orphan_surfacer"
+    [ ( "orphan_counts_by_status_class"
+      , [ Alcotest.test_case "emits for awaiting_verification (T6)" `Quick
+            test_emits_for_awaiting_verification
+        ; Alcotest.test_case "counts per class" `Quick test_counts_per_class
+        ; Alcotest.test_case "empty audit is all-zero" `Quick
+            test_empty_is_all_zero
+        ; Alcotest.test_case "class labels match task_status_to_string" `Quick
+            test_class_labels_match_task_status_to_string
+        ] )
+    ]


### PR DESCRIPTION
RFC-0294 PR-4/7 — orphan surfacer (필수 보완). R1g(#22214, merged)가 `audit_orphan_tasks`를 keeper wake-driver에서 끊어 unactionable failed_task의 no-op wake를 막았다. 그런데 keeper wake가 orphan을 surface하던 **유일한** 경로였다. 보완 없으면 orphan — 특히 `cleanup_zombies` Phase 3가 release 안 하는(RFC-0220 §5) `AwaitingVerification` (영영 0으로 안 돌아옴) — 이 **silent invisible**(broken-but-visible → blind 회귀)이 된다. R1g가 *제거한* 가시성을 복원하는 single owner.

## telemetry-as-fix 아님

R1g가 구조적 primary fix. 이 PR은 R1g가 *멈춘* surfacing을 **alertable metric으로 복원**하는 것 — fix를 counter로 대신하는 게 아니다. (anti-pattern 바: R1g가 구조적 primary이므로 통과.)

## 변경

- **`otel_core_metric_names`**: `masc_orphan_tasks` gauge (status_class 라벨; gauge라 `_total` 미사용 — `masc_pending_tasks` 컨벤션).
- **`workspace_query`**: `orphan_status_classes`(audit_orphan_tasks가 반환하는 고정 집합 Claimed/InProgress/AwaitingVerification) + **순수** `orphan_counts_by_status_class` — 항상 모든 클래스 보고(빈 클래스 0)해 cleared 클래스가 stale 대신 리셋. I/O 없어 단위 테스트 가능.
- **`orchestrator`**: `surface_orphan_tasks_gauge`가 zombie-pulse 매 beat(cleanup + stale-claim release 후) `audit_orphan_tasks`를 읽어 클래스별 gauge set. keeper actor와 독립 — actor wake가 아닌 alertable metric: reaper/pulse가 멈추면(2026-06-21/22 reaper 미실행 사고) gauge가 stale → 그 자체가 alertable.

## 검증

- `dune build lib/` exit 0, `check-ssot.sh` exit 0
- `test_orphan_surfacer` 4건: T6(awaiting_verification orphan 카운트) + per-class + empty all-zero(gauge reset) + drift guard(`orphan_status_classes` ↔ `task_status_to_string`)
- **revert-red 증명**: `orphan_status_classes`에서 "awaiting_verification" 제거 시 3건 red, 복원 후 green

Refs RFC-0294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
