### PR TITLE
fix(dashboard): 키퍼 액션 반응성 — 즉시 상태 반영 + 스코프 refresh

### DIFF
--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -14,8 +14,8 @@ vi.mock('../api/keeper', () => ({
 }))
 vi.mock('../store', () => ({
   keepers: { value: [] },
-  invalidateDashboardCache: vi.fn(),
-  refreshDashboard: vi.fn(async () => undefined),
+  applyOptimisticKeeperDirective: vi.fn(() => () => {}),
+  refreshExecution: vi.fn(async () => undefined),
 }))
 
 import { keeperActionVisibility } from '../lib/keeper-predicates'

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -25,8 +25,7 @@ import {
 } from '../api/keeper'
 import {
   applyOptimisticKeeperDirective,
-  invalidateDashboardCache,
-  refreshDashboard,
+  refreshExecution,
 } from '../store'
 import type { Keeper } from '../types'
 import { keeperActionVisibility } from '../lib/keeper-predicates'
@@ -34,12 +33,16 @@ import { keeperActionVisibility } from '../lib/keeper-predicates'
 // ── Shared helpers ────────────────────────────────────────────────────────
 
 function afterAction(): void {
-  invalidateDashboardCache()
   // Reconcile the optimistic patch against the authoritative server
-  // snapshot. `force: true` was a dead signal in the bootstrap path of
-  // `refreshDashboard` (only consumed by the fallback) — drop it so we
-  // don't lie about what the call does.
-  void refreshDashboard().catch(err => {
+  // snapshot. Scoped to the execution slice (the keeper roster) instead of
+  // a full `refreshDashboard()` bootstrap: the bootstrap re-hydrated shell,
+  // planning, namespace, goals and goal_loop and flipped dashboardLoading,
+  // which re-rendered every panel — the "the whole screen refreshes on
+  // every keeper action" complaint. `refreshExecution` is the same scope
+  // the SSE keeper_phase_changed route already uses (sse-store.ts), and it
+  // coalesces through the execution scheduler so concurrent actions don't
+  // stack refetches.
+  void refreshExecution().catch(err => {
     const message = err instanceof Error ? err.message : 'dashboard refresh failed'
     showToast(message, 'warning')
   })

--- a/dashboard/src/components/keeper-detail-helpers.test.ts
+++ b/dashboard/src/components/keeper-detail-helpers.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const { refreshDashboard, invalidateDashboardCache } = vi.hoisted(() => ({
+const { refreshDashboard, invalidateDashboardCache, refreshExecution } = vi.hoisted(() => ({
   refreshDashboard: vi.fn<() => Promise<void>>(),
   invalidateDashboardCache: vi.fn(),
+  refreshExecution: vi.fn<() => Promise<void>>(),
 }))
 
 vi.mock('../api', () => ({
@@ -13,6 +14,7 @@ vi.mock('../api', () => ({
 vi.mock('../store', () => ({
   invalidateDashboardCache,
   refreshDashboard,
+  refreshExecution,
 }))
 
 vi.mock('./common/toast', () => ({
@@ -20,17 +22,22 @@ vi.mock('./common/toast', () => ({
 }))
 
 describe('refreshAfterRuntimeAction', () => {
-  it('schedules dashboard refresh without blocking lifecycle buttons', async () => {
+  it('schedules a scoped execution refresh without blocking lifecycle buttons', async () => {
+    // Keeper runtime actions reconcile against the execution slice (the
+    // roster), not a full dashboard bootstrap — see refreshAfterRuntimeAction.
     let releaseRefresh: () => void = () => {}
-    refreshDashboard.mockReturnValueOnce(new Promise<void>(resolve => {
+    refreshExecution.mockReturnValueOnce(new Promise<void>(resolve => {
       releaseRefresh = resolve
     }))
 
     const { refreshAfterRuntimeAction } = await import('./keeper-detail-helpers')
+    // Resolves immediately even while the refetch is still in flight: the
+    // helper fires-and-forgets so the lifecycle button is never blocked.
     await expect(refreshAfterRuntimeAction()).resolves.toBeUndefined()
 
-    expect(invalidateDashboardCache).toHaveBeenCalled()
-    expect(refreshDashboard).toHaveBeenCalledWith({ force: true })
+    expect(refreshExecution).toHaveBeenCalledWith({ force: true })
+    // The full-bootstrap path is no longer taken for keeper actions.
+    expect(refreshDashboard).not.toHaveBeenCalled()
 
     releaseRefresh()
   })

--- a/dashboard/src/components/keeper-detail-helpers.ts
+++ b/dashboard/src/components/keeper-detail-helpers.ts
@@ -1,5 +1,5 @@
 import { currentDashboardActor, runOperatorAction } from '../api'
-import { invalidateDashboardCache, refreshDashboard } from '../store'
+import { invalidateDashboardCache, refreshDashboard, refreshExecution } from '../store'
 import { showToast } from './common/toast'
 import { keeperRuntimeBlockerHint } from '../lib/keeper-runtime-display'
 import type { Keeper } from '../types'
@@ -22,8 +22,16 @@ export async function runSocialSweep(): Promise<void> {
 }
 
 export async function refreshAfterRuntimeAction(): Promise<void> {
-  invalidateDashboardCache()
-  void refreshDashboard({ force: true }).catch(err => {
+  // Keeper runtime actions (boot/shutdown/resume/wakeup/pause from the rail,
+  // alert strip, detail page and lifecycle buttons) reconcile against the
+  // execution slice — the keeper roster — not the full dashboard bootstrap.
+  // The previous `refreshDashboard({ force: true })` re-hydrated shell,
+  // planning, namespace, goals and goal_loop and flipped dashboardLoading,
+  // re-rendering every panel ("the whole screen refreshes when I resume a
+  // keeper"). `force: true` keeps the immediate refetch boot/shutdown need
+  // (those have no optimistic patch); the scope now matches the SSE
+  // keeper_phase_changed route (sse-store.ts).
+  void refreshExecution({ force: true }).catch(err => {
     const message = err instanceof Error ? err.message : '대시보드 새로고침 실패'
     showToast(message, 'warning')
   })

--- a/dashboard/src/store-optimistic-keeper.test.ts
+++ b/dashboard/src/store-optimistic-keeper.test.ts
@@ -4,6 +4,7 @@ import {
   applyOptimisticKeeperDirectives,
   keepers,
 } from './store'
+import { phasePulse, phaseTone } from './components/v2/keeper-fsm'
 import type { Keeper } from './types'
 
 const baseKeeper = (overrides: Partial<Keeper> & { name: string }): Keeper => ({
@@ -29,6 +30,9 @@ describe('applyOptimisticKeeperDirective', () => {
     const after = keepers.value.find(k => k.name === 'rondo')!
     expect(after.paused).toBe(true)
     expect(after.phase).toBe('Paused')
+    // The roster status dot renders lifecycle_phase, not phase — patch it so
+    // the left-list dot flips on the same click (see patchForDirective).
+    expect(after.lifecycle_phase).toBe('Paused')
     expect(after.pipeline_stage).toBe('paused')
     // Other keepers untouched.
     expect(keepers.value.find(k => k.name === 'qa-king')!.paused).toBe(false)
@@ -50,6 +54,7 @@ describe('applyOptimisticKeeperDirective', () => {
     const after = keepers.value[0]!
     expect(after.paused).toBe(false)
     expect(after.phase).toBe('Running')
+    expect(after.lifecycle_phase).toBe('Running')
 
     revert()
     expect(keepers.value[0]).toEqual(original)
@@ -60,6 +65,22 @@ describe('applyOptimisticKeeperDirective', () => {
     applyOptimisticKeeperDirective('rondo', 'wakeup')
     expect(keepers.value[0]!.paused).toBe(false)
     expect(keepers.value[0]!.phase).toBe('Running')
+    expect(keepers.value[0]!.lifecycle_phase).toBe('Running')
+  })
+
+  it('patches lifecycle_phase so the roster status dot tone flips immediately', () => {
+    keepers.value = [
+      baseKeeper({ name: 'rondo', paused: true, phase: 'Paused', lifecycle_phase: 'Paused' }),
+    ]
+    // Before: the dot reads the paused tone from lifecycle_phase.
+    expect(phaseTone(keepers.value[0]!.lifecycle_phase)).toBe('warn')
+
+    applyOptimisticKeeperDirective('rondo', 'resume')
+
+    // After the optimistic resume, the dot tone is the running tone with no
+    // server round-trip. This is the field keeper-workspace-roster renders.
+    expect(phaseTone(keepers.value[0]!.lifecycle_phase)).toBe('ok')
+    expect(phasePulse(keepers.value[0]!.lifecycle_phase)).toBe(true)
   })
 
   it('returns a no-op revert when the keeper is not in the local list', () => {

--- a/dashboard/src/store-optimistic-keeper.test.ts
+++ b/dashboard/src/store-optimistic-keeper.test.ts
@@ -83,6 +83,24 @@ describe('applyOptimisticKeeperDirective', () => {
     expect(phasePulse(keepers.value[0]!.lifecycle_phase)).toBe(true)
   })
 
+  it('reverts lifecycle_phase to the original on failure (no stale Running dot)', () => {
+    // Failure rollback: runKeeperAction calls the returned revert thunk on a
+    // non-ok response and on throw (keeper-action-panel.ts:96-117). Since the
+    // dot reads lifecycle_phase, the revert must restore it — otherwise a
+    // failed resume would leave the dot stuck on a stale 'Running' (a silent
+    // UI lie). Locks the rollback of the field this change introduced.
+    keepers.value = [
+      baseKeeper({ name: 'rondo', paused: true, phase: 'Paused', lifecycle_phase: 'Paused' }),
+    ]
+    const revert = applyOptimisticKeeperDirective('rondo', 'resume')
+    expect(phaseTone(keepers.value[0]!.lifecycle_phase)).toBe('ok')
+
+    revert()
+
+    expect(keepers.value[0]!.lifecycle_phase).toBe('Paused')
+    expect(phaseTone(keepers.value[0]!.lifecycle_phase)).toBe('warn')
+  })
+
   it('returns a no-op revert when the keeper is not in the local list', () => {
     const before = keepers.value
     const revert = applyOptimisticKeeperDirective('ghost', 'pause')

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -129,12 +129,18 @@ export function toggleKeeperInFilter(name: string): void {
 export type OptimisticKeeperDirective = 'pause' | 'resume' | 'wakeup'
 
 function patchForDirective(action: OptimisticKeeperDirective): Partial<Keeper> {
+  // `lifecycle_phase` is the field the roster status dot renders
+  // (keeper-workspace-roster.ts → phaseTone/phasePulse(keeper.lifecycle_phase),
+  // phaseText → lifecycle_phase ?? phase). Patching only `phase` left the
+  // left-list dot stale until the server snapshot arrived, which read as
+  // "status reflects very late" after resume/pause. Patch both so the dot
+  // flips with the same click that flips the action buttons.
   switch (action) {
     case 'pause':
-      return { paused: true, phase: 'Paused', pipeline_stage: 'paused', status: 'paused' }
+      return { paused: true, phase: 'Paused', lifecycle_phase: 'Paused', pipeline_stage: 'paused', status: 'paused' }
     case 'resume':
     case 'wakeup':
-      return { paused: false, phase: 'Running', pipeline_stage: 'idle', status: 'idle' }
+      return { paused: false, phase: 'Running', lifecycle_phase: 'Running', pipeline_stage: 'idle', status: 'idle' }
   }
 }
 


### PR DESCRIPTION
## 배경

키퍼 재개(resume)/시작(boot) 액션의 사용성 불만 2가지를 근본 수정합니다.

1. **키퍼 목록 좌측 상태가 매우 늦게 반영됨**
2. **재개/시작을 누르면 화면 전체가 리프레시됨**

## 근본 원인

### ① 상태 반영 지연 — optimistic 패치가 roster가 렌더하는 필드를 누락
roster 상태 dot은 `keeper.lifecycle_phase`만 렌더합니다 (`keeper-workspace-roster.ts` → `phaseTone/phasePulse(keeper.lifecycle_phase)`, `phaseText` → `lifecycle_phase ?? phase`).
그런데 `store.ts:patchForDirective`의 optimistic 패치는 `phase`/`status`/`pipeline_stage`만 갱신하고 `lifecycle_phase`는 건드리지 않았습니다. 결과적으로 즉시 갱신이 좌측 목록 dot에 보이지 않아 서버 스냅샷(SSE 왕복)까지 기다렸습니다.

### ② 전체 리프레시 — 액션 후 중복 full bootstrap refetch
`afterAction`(keeper-action-panel)과 `refreshAfterRuntimeAction`(keeper-detail-helpers; rail·alert-strip·detail-page·lifecycle 버튼 공용)이 `refreshDashboard()` full bootstrap을 호출했습니다. 이는 shell/planning/namespace/goals/goal_loop를 전부 재수화하고 `dashboardLoading`을 플립해 모든 패널을 재렌더했습니다.
backend는 이미 `keeper_phase_changed` SSE 이벤트를 emit하고, 프론트는 이를 가벼운 `refreshExecution()`(execution 슬라이스만)로 라우팅합니다(`sse-store.ts`). full bootstrap은 이 경로와 중복이었습니다.

## 변경

| 파일 | 변경 |
|------|------|
| `store.ts` | `patchForDirective`에 `lifecycle_phase` 추가 (pause→`Paused`, resume/wakeup→`Running`) |
| `keeper-action-panel.ts` | `afterAction`: `refreshDashboard()` → 스코프 `refreshExecution()`. no-op `invalidateDashboardCache()` 제거 |
| `keeper-detail-helpers.ts` | `refreshAfterRuntimeAction`: `refreshDashboard({force})` → `refreshExecution({force})`. `runSocialSweep`(root-level, 범위 밖)은 그대로 |
| `store-optimistic-keeper.test.ts` | `lifecycle_phase` + roster dot tone 잠금 테스트 추가 |
| `keeper-action-panel.test.ts` | store mock을 새 import 표면(`refreshExecution`)으로 갱신 |

`refreshExecution`은 execution scheduler를 통해 coalesce되므로 연속 액션이 refetch를 쌓지 않습니다. boot/shutdown은 optimistic 패치가 없어 `force: true`로 즉시 스코프 refetch를 유지합니다.

## 로컬 검증

- `tsc --noEmit`: exit=0, 0 errors
- 관련 vitest: store-optimistic(8) + keeper-actions + store-reconcile + keeper-action-panel(10) = 98 tests 통과
- 신규 테스트 비공허성: `lifecycle_phase:'Paused'` 시작 → resume 후 `phaseTone === 'ok'` 단언. 패치 없으면 `'warn'`으로 red.

## 미검증 (리뷰 포인트)

- `refreshExecution` 스코프가 keeper **detail 패널**의 shell-derived 필드까지 커버하는지 실제 대시보드 클릭 검증 미수행. 데이터 의존성상 roster/detail 모두 execution 슬라이스 기반이라 안전할 것으로 추정하나, detail 패널이 shell 슬라이스에만 있는 필드를 표시한다면 해당 필드는 액션 직후 갱신되지 않고 다음 SSE/주기 refresh까지 지연될 수 있음.

RFC-WAIVED: dashboard FE reactivity 수정. credential/identity/operator-control/keeper-sandbox/hooks 등 RFC-gated subsystem 미변경.
