### PR TITLE
perf(dashboard): 키퍼 채팅 composer가 draft를 자체 소유 — 키 입력당 패널 재렌더 제거

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -860,6 +860,31 @@ describe('ChatComposer IME composition guard', () => {
     )
     expect(sent).toBe(0)
   })
+
+  it('keeps its own draft when uncontrolled and surfaces the typed text on send', () => {
+    // The keeper-workspace chat omits onDraftChange so a keystroke updates the
+    // composer's internal draft instead of the host panel — that is what stops
+    // the transcript from re-rendering on every character. The composer must
+    // still capture the text and carry it on the send payload (`text`).
+    let payload: ChatComposerSendPayload | null = null
+    render(
+      html`<${ChatComposer}
+        placeholder="메시지 입력..."
+        disabled=${false}
+        streaming=${false}
+        onSend=${(p: ChatComposerSendPayload) => { payload = p }}
+      />`,
+      container,
+    )
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    expect(textarea).not.toBeNull()
+
+    fireEvent.input(textarea, { target: { value: '소주에 갑오징어' } })
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+
+    expect(payload).not.toBeNull()
+    expect(payload?.text).toBe('소주에 갑오징어')
+  })
 })
 
 describe('Keeper v2 chat blocks', () => {

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -866,13 +866,13 @@ describe('ChatComposer IME composition guard', () => {
     // composer's internal draft instead of the host panel — that is what stops
     // the transcript from re-rendering on every character. The composer must
     // still capture the text and carry it on the send payload (`text`).
-    let payload: ChatComposerSendPayload | null = null
+    const onSend = vi.fn()
     render(
       html`<${ChatComposer}
         placeholder="메시지 입력..."
         disabled=${false}
         streaming=${false}
-        onSend=${(p: ChatComposerSendPayload) => { payload = p }}
+        onSend=${onSend}
       />`,
       container,
     )
@@ -882,8 +882,9 @@ describe('ChatComposer IME composition guard', () => {
     fireEvent.input(textarea, { target: { value: '소주에 갑오징어' } })
     textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
 
-    expect(payload).not.toBeNull()
-    expect(payload?.text).toBe('소주에 갑오징어')
+    expect(onSend).toHaveBeenCalledTimes(1)
+    const sent = onSend.mock.calls[0]?.[0] as ChatComposerSendPayload | undefined
+    expect(sent?.text).toBe('소주에 갑오징어')
   })
 })
 

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -42,6 +42,9 @@ export interface ChatComposerSendPayload {
   blocks: ChatBlock[]
   userBlocks: KeeperUserInputBlock[]
   clientActionId: string
+  /** The trimmed text entered by the operator at send time. Added so hosts can
+      read the message without maintaining a mirrored controlled draft state. */
+  text: string
 }
 
 /** Status dot wrapper — maps keeper-v2 status strings to shared StatusDot tones. */
@@ -2862,7 +2865,7 @@ export function AttachDraftChip({
 }
 
 export function ChatComposer({
-  draft,
+  draft: draftProp,
   placeholder,
   disabled,
   streaming,
@@ -2875,7 +2878,7 @@ export function ChatComposer({
   onAbort,
   layout = 'default',
 }: {
-  draft: string
+  draft?: string
   placeholder: string
   disabled: boolean
   streaming: boolean
@@ -2886,7 +2889,10 @@ export function ChatComposer({
    *  enqueues the message instead of dispatching it immediately. */
   queueEnabled?: boolean
   queueCount?: number
-  onDraftChange: (value: string) => void
+  /** Optional controlled draft handler. When omitted the composer keeps its
+   *  own draft state, which prevents the host from re-rendering on every
+   *  keystroke (see keeper-workspace chat performance). */
+  onDraftChange?: (value: string) => void
   onSend: (payload: ChatComposerSendPayload) => void | Promise<void>
   onAbort?: () => void
   layout?: 'default' | 'primary'
@@ -2895,6 +2901,16 @@ export function ChatComposer({
   const [focus, setFocus] = useState(false)
   const [drag, setDrag] = useState(false)
   const [attachments, setAttachments] = useState<KeeperConversationAttachment[]>([])
+  const [internalDraft, setInternalDraft] = useState('')
+  const isControlled = typeof draftProp === 'string'
+  const draft = isControlled ? draftProp : internalDraft
+  const setDraft = (value: string) => {
+    if (isControlled) {
+      onDraftChange?.(value)
+    } else {
+      setInternalDraft(value)
+    }
+  }
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 
@@ -2903,7 +2919,7 @@ export function ChatComposer({
   // auto-send) so the operator can correct a transcription before it lands.
   const voice = useVoiceInput({
     onTranscribed: (text) => {
-      onDraftChange(draft.trim() === '' ? text : `${draft}\n${text}`)
+      setDraft(draft.trim() === '' ? text : `${draft}\n${text}`)
     },
   })
 
@@ -3000,15 +3016,16 @@ export function ChatComposer({
       blocks,
       userBlocks,
       clientActionId: nextComposerClientActionId(),
+      text,
     })
-    onDraftChange('')
+    setDraft('')
     setAttachments([])
     if (textareaRef.current) textareaRef.current.style.height = 'auto'
   }
 
   const grow = (event: Event) => {
     const target = event.target as HTMLTextAreaElement
-    onDraftChange(target.value)
+    setDraft(target.value)
     target.style.height = 'auto'
     target.style.height = `${Math.min(target.scrollHeight, 160)}px`
   }

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -436,7 +436,6 @@ export function KeeperConversationPanel({
   layout?: 'default' | 'primary' | 'workspace'
   onInspectTurn?: (entry: KeeperConversationEntry) => void
 }) {
-  const [draft, setDraft] = useState('')
   const [showMetadata, setShowMetadata] = useState(readKeeperChatMetadataVisible())
   const [showInternal, setShowInternal] = useState(readKeeperChatInternalVisible())
 
@@ -553,15 +552,14 @@ export function KeeperConversationPanel({
     }
   }
 
-  const submit = async ({ blocks, userBlocks, clientActionId }: ChatComposerSendPayload) => {
-    const prompt = draft.trim()
+  const submit = async ({ blocks, userBlocks, clientActionId, text }: ChatComposerSendPayload) => {
+    const prompt = text
     if (chatAccess.blocked) {
       showToast(chatAccess.message, 'error')
       return
     }
     if (!keeperName || (!prompt && blocks.length === 0)) return
     const attachments = blocksToAttachments(blocks)
-    setDraft('')
     if (keeperSending.value[keeperName]) {
       if (
         isKeeperThreadMessageSendInFlight(keeperName, clientActionId)
@@ -699,7 +697,7 @@ export function KeeperConversationPanel({
                 `
               : null}
             <${ChatComposer}
-              draft=${draft}
+              key=${keeperName}
               placeholder=${chatAccess.blocked
                 ? '현재 actor는 direct keeper chat 권한이 없습니다'
                 : sending
@@ -711,7 +709,6 @@ export function KeeperConversationPanel({
               lastEventAt=${lastSignalAt}
               queueEnabled=${true}
               queueCount=${queueCount}
-              onDraftChange=${setDraft}
               onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
               onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
               layout="primary"
@@ -816,7 +813,7 @@ export function KeeperConversationPanel({
               `
             : null}
           <${ChatComposer}
-            draft=${draft}
+            key=${keeperName}
             placeholder=${chatAccess.blocked
               ? '현재 actor는 direct keeper chat 권한이 없습니다'
               : sending
@@ -828,7 +825,6 @@ export function KeeperConversationPanel({
             lastEventAt=${lastSignalAt}
             queueEnabled=${true}
             queueCount=${queueCount}
-            onDraftChange=${setDraft}
             onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
             onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
             layout="primary"
@@ -931,7 +927,7 @@ export function KeeperConversationPanel({
               `
             : null}
           <${ChatComposer}
-            draft=${draft}
+            key=${keeperName}
             placeholder=${chatAccess.blocked
               ? '현재 actor는 direct keeper chat 권한이 없습니다'
               : sending
@@ -943,7 +939,6 @@ export function KeeperConversationPanel({
             lastEventAt=${lastSignalAt}
             queueEnabled=${true}
             queueCount=${queueCount}
-            onDraftChange=${setDraft}
             onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
             onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
           />


### PR DESCRIPTION
## 배경

키퍼 채팅 화면에서 **채팅 작성(타이핑) 시 느림** 불만. 사용자 확인 결과 ① 한글 입력 끊김 ② 응답 중(스트리밍)일 때 ③ 대화가 길수록 ④ 항상 — 네 증상이 모두 나타남.

## 근본 원인

composer의 draft 상태가 부모 `KeeperConversationPanel`에 hoist되어 있었습니다 (`const [draft, setDraft] = useState('')`), `ChatComposer`에 `draft`/`onDraftChange`로 전달.

→ **매 키 입력 → `setDraft`가 부모를 재렌더 → `ChatTranscript`(모든 메시지 버블) 재렌더.** 대화가 길수록, 스트리밍 중일수록 비용이 커지고, 한글 IME는 무거운 재렌더와 겹쳐 끊깁니다. 이것이 네 증상의 공통 뿌리입니다.

## 변경

`ChatComposer`가 `onDraftChange`가 없을 때 **자체 `internalDraft`로 draft를 소유**(uncontrolled). 호스트는 키 입력당 재렌더하지 않습니다. 전송 텍스트는 `ChatComposerSendPayload.text`로 전달돼 `submit()`이 미러링된 host draft를 읽을 필요가 없습니다. `draft`/`onDraftChange`는 controlled 사용처를 위해 optional로 유지(하위 호환).

| 파일 | 변경 |
|------|------|
| `chat/primitives.ts` | `ChatComposer`: `internalDraft`/`isControlled` 도입, `onDraftChange` optional화, send payload에 `text` 추가 |
| `keeper-shared.ts` | 부모의 `draft` state 제거, `submit`이 payload `text`를 읽음, ChatComposer에 `key=${keeperName}`만 전달(uncontrolled) |
| `chat/primitives.test.ts` | uncontrolled draft + payload.text 잠금 테스트 추가 |

## Provenance

이 PR은 primary worktree(`~/me/workspace/yousleepwhen/masc`)의 working tree에 있던 **uncommitted WIP**(`primitives.ts` + `keeper-shared.ts`)를 캡처해 브랜치로 구제한 것 + 잠금 테스트 추가입니다. 누군가/이전 세션의 미완료 작업을 덮어쓰지 않고 보존했습니다.

## 로컬 검증

- `tsc --noEmit`: 0 errors
- 영향 테스트(primitives, primitives.a11y, keeper-shared, keeper-actions): 175 + 신규 1 통과
- 전체 vitest.config.ts: 595파일 중 593 통과. 실패한 2개(`virtual-list`, `dialog`)는 **병렬 부하 하 flaky** — 격리 실행 시 22/22 통과, 변경과 무관(스크롤/키보드 타이밍). CI single-thread에선 통과 예상.
- 신규 테스트 비공허성: `onDraftChange` 없이 타이핑 → 전송 payload `.text === '소주에 갑오징어'`. internalDraft 없으면 fail.

## 후속(별도 PR 후보)

스트리밍 중 transcript 재렌더는 stream 시그널로 구동되며 `ChatMessageBubble`이 컴포넌트 memo가 아니라 남아 있습니다. 이번 변경은 **키 입력당 경로**만 고칩니다. 버블 memo(완료 메시지 참조 보존은 keeper-state.ts:814에서 확인됨)는 후속.

RFC-WAIVED: dashboard FE 채팅 composer 성능 수정. credential/identity/operator-control/keeper-sandbox/hooks 등 RFC-gated subsystem 미변경.
