### PR TITLE
fix(keeper): 치명적 Eio-context 에러를 substring 아닌 typed 태그로 분류 (노 스트링 매치/Silent Failure)

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_cycle.ml
+++ b/lib/keeper/keeper_heartbeat_loop_cycle.ml
@@ -66,10 +66,12 @@ let run_keeper_cycle_admitted
   | Error err ->
     let e_str = Agent_sdk.Error.to_string err in
     Log.Keeper.debug "%s: keeper cycle failed: %s" meta_after_triage.name e_str;
-    if
-      String_util.contains_substring e_str "Eio switch not available"
-      || String_util.contains_substring e_str "Eio net not available"
-    then (
+    (* Classify on the typed [Config (InvalidConfig { field = "eio_context" })]
+       tag via [Runtime_oas_runner.is_eio_context_error], not by substring-
+       scanning [e_str]: an Eio wording change must not silently drop this
+       fatal-environment promotion. [e_str] is kept for the log/failure-reason
+       message only. *)
+    if Runtime_oas_runner.is_eio_context_error err then (
       Log.Keeper.error
         "%s: fatal environment error — promoting to Keeper_fiber_crash: %s"
         meta_after_triage.name

--- a/lib/runtime/runtime_oas_runner.ml
+++ b/lib/runtime/runtime_oas_runner.ml
@@ -31,8 +31,39 @@ let require_eio ?sw ?net () =
   | None, _ -> Error "Eio switch not available (running outside server context)"
   | _, None -> Error "Eio net not available (running outside server context)"
 
+(* SSOT for the [InvalidConfig.field] tag that marks the MASC-internal
+   "Eio context unavailable" error. Both the producer
+   ([eio_context_error_to_sdk_error]) and the structural classifier
+   ([is_eio_context_error]) reference this single binding, so the two sides
+   cannot drift apart. *)
+let eio_context_field = "eio_context"
+
 let eio_context_error_to_sdk_error detail =
-  Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field = "eio_context"; detail })
+  Agent_sdk.Error.Config
+    (Agent_sdk.Error.InvalidConfig { field = eio_context_field; detail })
+
+(* [true] iff [err] is the "Eio switch/net unavailable" config error this
+   module produces (running outside a server context). Matched structurally
+   on the typed [Config (InvalidConfig { field })] tag — NOT by substring-
+   scanning [Agent_sdk.Error.to_string]: the rendered Eio wording is not a
+   contract and a wording change must not silently drop the fatal-environment
+   promotion in the heartbeat loop. The producer and this predicate live in
+   one module so the [field] tag is the single source of truth. The [when]
+   guard keeps the [Config _] arm reachable regardless of how many
+   constructors the wrapped config-error type carries. *)
+let is_eio_context_error (err : Agent_sdk.Error.sdk_error) : bool =
+  match err with
+  | Agent_sdk.Error.Config (Agent_sdk.Error.InvalidConfig { field; _ })
+    when String.equal field eio_context_field -> true
+  | Agent_sdk.Error.Config _ -> false
+  | Agent_sdk.Error.Provider _ -> false
+  | Agent_sdk.Error.Api _ -> false
+  | Agent_sdk.Error.Agent _ -> false
+  | Agent_sdk.Error.Mcp _ -> false
+  | Agent_sdk.Error.Serialization _ -> false
+  | Agent_sdk.Error.Io _ -> false
+  | Agent_sdk.Error.Orchestration _ -> false
+  | Agent_sdk.Error.Internal _ -> false
 
 let runtime_catalog_error_to_sdk_error detail =
   Agent_sdk.Error.Config

--- a/lib/runtime/runtime_oas_runner.mli
+++ b/lib/runtime/runtime_oas_runner.mli
@@ -28,6 +28,13 @@ val eio_context_error_to_sdk_error : string -> Agent_sdk.Error.sdk_error
 (** Lift a context-missing diagnostic string into an [Agent_sdk.Error.Config]
     error with field ["eio_context"]. *)
 
+val is_eio_context_error : Agent_sdk.Error.sdk_error -> bool
+(** [true] iff the error is the "Eio context unavailable" config error
+    produced by {!eio_context_error_to_sdk_error} (running outside a server
+    context).  Classifies on the typed [Config (InvalidConfig { field })] tag
+    rather than on the rendered message, so an Eio wording change cannot
+    silently break the heartbeat loop's fatal-environment promotion. *)
+
 val runtime_catalog_error_to_sdk_error : string -> Agent_sdk.Error.sdk_error
 (** Lift a runtime-catalog diagnostic into an [Agent_sdk.Error.Config]
     error with field ["runtime_id"]. *)

--- a/test/dune
+++ b/test/dune
@@ -1914,6 +1914,8 @@
 
 (include stanzas/test_masc_error_is_retryable.inc)
 
+(include stanzas/test_runtime_oas_eio_context_classify.inc)
+
 (include stanzas/test_mcp_post_sse_e2e.inc)
 
 (include stanzas/test_mcp_server_eio_tool_profile_capability.inc)

--- a/test/stanzas/test_runtime_oas_eio_context_classify.inc
+++ b/test/stanzas/test_runtime_oas_eio_context_classify.inc
@@ -1,0 +1,8 @@
+; Per-file dune stanza for the typed eio-context error classification
+; suite. Lives here per test/stanzas/README.md to avoid the
+; conflict-runtime hotspot in the legacy grouped (tests ...) stanza.
+
+(test
+ (name test_runtime_oas_eio_context_classify)
+ (modules test_runtime_oas_eio_context_classify)
+ (libraries masc_test_deps))

--- a/test/test_runtime_oas_eio_context_classify.ml
+++ b/test/test_runtime_oas_eio_context_classify.ml
@@ -1,0 +1,63 @@
+(** Pin the typed classification of the MASC-internal "Eio context
+    unavailable" error ([Runtime_oas_runner.is_eio_context_error]).
+
+    Before this suite the heartbeat loop
+    ([keeper_heartbeat_loop_cycle.ml]) decided whether a failed keeper cycle
+    was a fatal-environment error — and therefore whether to promote it to
+    [Keeper_registry.Keeper_fiber_crash] for the supervisor — by
+    substring-scanning [Agent_sdk.Error.to_string]:
+
+      String_util.contains_substring e_str "Eio switch not available"
+
+    That coupled a safety-critical promotion to the exact Eio wording. It
+    would (a) silently MISS the error if the wording changed, and (b)
+    WRONGLY MATCH any unrelated error whose rendered message merely contained
+    the phrase. The classifier is now structural — the typed
+    [Config (InvalidConfig { field = "eio_context" })] tag — and this suite
+    locks both directions so a regression to substring matching fails here. *)
+
+module R = Runtime_oas_runner
+
+(* The error this module produces is classified true, regardless of which of
+   the two context-missing diagnostics it carries. *)
+let test_tagged_error_is_eio_context () =
+  assert (
+    R.is_eio_context_error
+      (R.eio_context_error_to_sdk_error
+         "Eio switch not available (running outside server context)"));
+  assert (
+    R.is_eio_context_error
+      (R.eio_context_error_to_sdk_error
+         "Eio net not available (running outside server context)"))
+
+(* Robustness (the OLD substring matcher would MISS this): a future change to
+   the Eio diagnostic wording must not drop the fatal-environment
+   classification, because the typed [field] tag — not the message — is the
+   discriminator. *)
+let test_wording_independence () =
+  assert (
+    R.is_eio_context_error
+      (R.eio_context_error_to_sdk_error "totally different diagnostic wording"))
+
+(* Precision (the OLD substring matcher would WRONGLY match this): a
+   runtime_id config error whose detail message happens to contain the Eio
+   phrase must NOT be classified as eio-context — its [field] tag is
+   "runtime_id", not "eio_context". *)
+let test_other_config_field_excluded () =
+  assert (
+    not
+      (R.is_eio_context_error
+         (R.runtime_catalog_error_to_sdk_error "Eio switch not available")))
+
+(* Non-Config error families are never eio-context, even when their message
+   contains the phrase. *)
+let test_non_config_errors_excluded () =
+  assert (
+    not (R.is_eio_context_error (Agent_sdk.Error.Internal "Eio switch not available")))
+
+let () =
+  test_tagged_error_is_eio_context ();
+  test_wording_independence ();
+  test_other_config_field_excluded ();
+  test_non_config_errors_excluded ();
+  print_endline "test_runtime_oas_eio_context_classify: OK"


### PR DESCRIPTION
## 무엇을 / 왜

`keeper_heartbeat_loop_cycle`이 실패한 keeper cycle 을 `Keeper_fiber_crash`로 승격(→ supervisor 가 격리 처리)할지를 **에러 메시지 substring 매칭**으로 결정하고 있었습니다:

```ocaml
String_util.contains_substring e_str "Eio switch not available"
|| String_util.contains_substring e_str "Eio net not available"
```

안전에 직결되는 승격을 **Eio 문구에 결합**한 것입니다. 결과:
- 문구가 바뀌면 분류가 조용히 깨져 → 승격 누락(**Silent Failure**), keeper crash 가 supervisor 로 안 감.
- 메시지에 우연히 그 문구를 담은 무관한 에러도 잘못 승격.

사용자 기준 3종 동시 위반: **노 스트링 매치 + 노 Silent Failure + SSOT**.

## 근거 (전파 경로 확인)

이 에러는 **MASC 자체 생산**입니다: `Runtime_oas_runner.require_eio` → 3개 caller 전부(`keeper_turn_driver.ml:93`, `keeper_turn_driver_wrappers.ml:98,239`)가 `eio_context_error_to_sdk_error`로 래핑 → `Agent_sdk.Error.Config (InvalidConfig { field = "eio_context"; detail })`. 즉 **typed discriminator (`field="eio_context"`)가 이미 존재**합니다. 소비자는 rendered string 대신 이 typed 태그를 보면 됩니다.

## 고친 것

- `Runtime_oas_runner.is_eio_context_error : Agent_sdk.Error.sdk_error -> bool` 추가 — `Config (InvalidConfig {field;_})` 태그를 **구조적·exhaustive**(catch-all `_` 없음, 9개 변종 전부 명시)로 매칭. `when` 가드로 `Config _` arm reachable 유지.
- `"eio_context"` 매직 스트링을 `Runtime_oas_runner.eio_context_field` SSOT 상수로 추출 (생산자+분류기 동일 모듈 → field 가 모듈 밖으로 안 샘).
- `keeper_heartbeat_loop_cycle`은 `Runtime_oas_runner.is_eio_context_error err`로 라우팅. `String_util`이 이 파일에서 완전히 빠짐.
- **OAS 경계 존중**: OAS `Agent_sdk.Error` 구조를 바꾸지 않고 기존 typed `Config(InvalidConfig)`만 이용. 분류 술어는 생산자(`runtime_oas_runner`)가 소유.

## 검증 (로컬, 빌드는 CI 확인)

신규 `test_runtime_oas_eio_context_classify`가 **양방향 differential**을 lock — 즉 substring 으로 회귀하면 이 테스트가 red:
- **wording 독립성**: 다른 진단 문구의 eio-context 에러도 `true` (구 substring 은 **놓침**)
- **field 정밀성**: detail 에 "Eio switch not available"를 담은 `runtime_id` 에러는 `false` (구 substring 은 **오탐** → 이 단언이 red 가 됨 = revert-red 논리적 확정)
- non-Config 에러 제외

로컬: `dune exec test/test_runtime_oas_eio_context_classify.exe` → `OK` (lib 컴파일 + 4 단언 통과).

## 반경

- `lib/keeper/keeper_heartbeat_loop_cycle.ml`, `lib/runtime/runtime_oas_runner.ml(.mli)`, 신규 테스트 2 + `test/dune`.
- credential / operator / sandbox / hooks / workflow subsystem 무관 → RFC 불요.
- 같은 군집의 다른 substring 에러분류기(`keeper_tool_filesystem_runtime` `path_not_found_under_allowed_roots:`, `keeper_runtime_trust_timeline` event_type 등)는 RFC-0042 계보의 별도 후속 작업으로 분리.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
