### PR TITLE
fix(dashboard): hit-stable press feedback (keeper button no longer escapes the click)

### DIFF
--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -129,6 +129,7 @@
               border-color var(--dur) var(--ease-out),
               color var(--dur) var(--ease-out),
               box-shadow var(--dur) var(--ease-out),
+              filter var(--dur-fast) var(--ease-out),
               transform var(--dur-fast) var(--ease-out);
 }
 
@@ -144,6 +145,7 @@
               border-color var(--dur) var(--ease-out),
               color var(--dur) var(--ease-out),
               box-shadow var(--dur) var(--ease-out),
+              filter var(--dur-fast) var(--ease-out),
               transform var(--dur-fast) var(--ease-out);
 }
 

--- a/dashboard/src/styles/craft-v2.css
+++ b/dashboard/src/styles/craft-v2.css
@@ -21,7 +21,9 @@
   --dur: 170ms;
   --dur-slow: 260ms;
   --lift: -2px;
-  --press: 1px;
+  /* --press: 1px; removed 2026-06-25 — press feedback은 button:active / @utility
+     pressable 에서 filter:brightness(0.9) 로 전환. translateY(var(--press)) 는
+     클릭 중 hit-target을 이동시켜 가장자리 클릭이 빗나간다(근본 수정). */
 }
 
 /* ── Font scale ───────────────────────────────────────────────── */
@@ -148,7 +150,7 @@
 /* Press sink on active controls. */
 .v2-app[data-motion]:not([data-motion="off"]) button:active,
 .v2-app[data-motion]:not([data-motion="off"]) [role="button"]:active {
-  transform: translateY(var(--press));
+  filter: brightness(0.9);
 }
 
 /* Specific v2 controls — press sink (v2 source). */
@@ -171,7 +173,7 @@
 .v2-app[data-motion]:not([data-motion="off"]) .cn-config:active,
 .v2-app[data-motion]:not([data-motion="off"]) .topbar-copilot:active,
 .v2-app[data-motion]:not([data-motion="off"]) .set-nav-item:active {
-  transform: translateY(var(--press));
+  filter: brightness(0.9);
 }
 
 /* Hover lift on genuine cards. */

--- a/dashboard/src/styles/press-hit-target.test.ts
+++ b/dashboard/src/styles/press-hit-target.test.ts
@@ -1,0 +1,72 @@
+// Press feedback must not move the click hit-target (2026-06-25 fix, PR #22245).
+//
+// CSS `transform` is a single property: translate/scale functions do not
+// compose. When :active applies `transform: translateY/scale(...)`, it
+// overwrites any rest transform on the same element — e.g. .kp-more is
+// centered with `top:50%; transform:translateY(-50%)` (-12px); a press
+// transform replaces that and the button jumps 12px+ DURING the click. An
+// edge click then has its mouseup land off the hit-target and the browser
+// drops the `click` event ("버튼이 도망감 / 눌렀는데 아무 일도 안 일어남").
+//
+// Press feedback must use hit-stable properties (filter / opacity). This
+// test pins that invariant for the two press sites: craft-v2.css (global
+// button / [role="button"] / 18 v2 controls) and @utility pressable
+// (ui.css).
+//
+// Non-vacuous: reintroducing `transform: translateY/scale` on any :active
+// rule in these two files fails this test. Verified by reverting the fix
+// (translateY(var(--press)) / scale(0.97)) — both `it` blocks fail.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'postcss'
+import { describe, expect, it } from 'vitest'
+
+// Read stylesheets as text from disk. Resolve relative to cwd, tolerating
+// either the dashboard package root or the repo root (mirrors
+// approvals-css-ownership.test.ts; import.meta.url is not a file: URL under
+// the vitest module runner and `… ?raw` is stubbed to empty).
+function readStyle(rel: string): string {
+  const candidates = [
+    resolve(process.cwd(), 'src/styles', rel),
+    resolve(process.cwd(), 'dashboard/src/styles', rel),
+  ]
+  const found = candidates.find(existsSync)
+  if (!found) {
+    throw new Error(
+      `press-hit-target.test: cannot locate ${rel} from cwd=${process.cwd()} (tried: ${candidates.join(', ')})`,
+    )
+  }
+  return readFileSync(found, 'utf8')
+}
+
+// transform values that move the box — the hit-target shifters.
+// `transform: none` is the absence of a transform and is allowed.
+const HIT_SHIFTING_TRANSFORM = /(translate|scale|matrix)\(/
+
+/** Return every :active rule declaration whose `transform` shifts the box. */
+function activeHitShiftingTransforms(css: string): string[] {
+  const hits: string[] = []
+  parse(css).walkRules((rule) => {
+    const isActive = rule.selectors.some((s) => s.includes(':active'))
+    if (!isActive) return
+    rule.walkDecls('transform', (decl) => {
+      if (HIT_SHIFTING_TRANSFORM.test(decl.value)) {
+        hits.push(`${rule.selector} → transform: ${decl.value}`)
+      }
+    })
+  })
+  return hits
+}
+
+describe('press feedback never shifts the :active hit-target (PR #22245)', () => {
+  it('craft-v2.css :active rules use no translate/scale/matrix transform', () => {
+    const hits = activeHitShiftingTransforms(readStyle('craft-v2.css'))
+    expect(hits, hits.join('\n')).toEqual([])
+  })
+
+  it('ui.css :active rules (incl. @utility pressable) use no translate/scale/matrix transform', () => {
+    const hits = activeHitShiftingTransforms(readStyle('ui.css'))
+    expect(hits, hits.join('\n')).toEqual([])
+  })
+})

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -141,10 +141,18 @@ button.monitor-row {
 @utility agent-event-badge--default { background: var(--color-border-default); color: var(--color-fg-secondary); font-weight: var(--fw-semi); letter-spacing: .02em; }
 
 /* ── Micro-Interactions (Task 289) ── */
+/* pressable — hit-target을 이동시키지 않는 press (2026-06-25 근본 수정).
+   AS-IS `transform: scale(0.97)` 은 요소의 기존 transform을 통째로 덮어쓴다
+   (CSS transform은 단일 속성이라 translate/scale 함수가 합성되지 않는다).
+   예: .kp-more 는 `top:50%; transform:translateY(-50%)` 로 행 중앙에 배치되어
+   있는데, scale(0.97) 이 활성화되면 translateY(-50%) 가 사라져 12px 낙차 +
+   축소로 hit이 도망간다. filter:brightness 는 transform을 건드리지 않아
+   기존 transform이 보존되고 hit-target이 고정된다. craft-v2.css의 press
+   규칙과 동일한 원리로 통일. */
 @utility pressable {
-  transition: transform var(--t-fast) var(--ease), opacity var(--t-fast) var(--ease-out);
+  transition: filter var(--t-fast) var(--ease-out), opacity var(--t-fast) var(--ease-out);
   &:active:not(:disabled) {
-    transform: scale(0.97);
+    filter: brightness(0.9);
     opacity: 0.9;
   }
 }


### PR DESCRIPTION
## Problem

KEEPERS 탭(keeper 목록)에서 행 좌측 버튼을 누르면 CSS press 효과로 버튼이
아래로 도망가, 위치를 정확히 잡지 않으면 클릭이 빗나가 아무 일도 일어나지
않는다("눌렀는데 아무 일도 안 일어남" / "버튼이 도망감"). 같은 사용성 문제가
대시보드의 다른 버튼에도 공통적으로 나타난다.

## Root cause

Press feedback이 **두 곳에서 `:active` transform**으로 구현되어, 클릭 도중
hit-target을 이동시킨다.

1. `craft-v2.css` — `button:active`, `[role="button"]:active`, 18개 v2 컨트롤:
   `transform: translateY(var(--press))` (1px)
2. `ui.css` `@utility pressable` — `transform: scale(0.97)`

CSS `transform`은 **단일 속성**이라 translate/scale 함수가 합성되지 않는다.
이미 transform을 가진 요소(예: `.kp-more`의 `translateY(-50%)` 수직 중앙 정렬)에서
`:active` transform이 기존 transform을 통째로 덮어쓴다. keeper roster의 ⋯ 버튼은
rest `-12px` → active `+1px`로 **13.8px 점프**, `role=button` 행은 **1px** 이동.
가장자리 클릭 시 mouseup이 hit 밖에서 발생해 브라우저가 `click` 이벤트를 취소한다.

## Fix

Press feedback을 `filter: brightness(0.9)`로 전환 — transform을 건드리지 않아
기존 transform이 보존되고 hit-target이 고정된다. 두 press 사이트에 동일 원리 적용.

- `craft-v2.css`: `translateY(var(--press))` → `filter: brightness(0.9)`
  (button / role=button / 18 컨트롤), dead `--press` 토큰 제거
- `ui.css`: `@utility pressable` `scale(0.97)` → `filter: brightness(0.9)`

## Verification (Playwright, dev dashboard + backend @8935)

| 대상 | before `:active` shift | after |
|------|---:|---:|
| `.kp-row` 행 (role=button) | 0.99px | **0.00px** |
| `.kp-more` 액션 버튼 | 13.85px | **0.00px** |

- roster 클릭 테스트 60개 통과
- ⋯ 메뉴 클릭으로 정상 오픈 (17항목, click 회귀 없음)
- lint + typecheck clean

## Notes

- 잔존 `:active` transform 규칙 3개(`.btn`, `.chat-ovf`, `.chat-back/ctx-btn`)는
  모두 `transform: none`이라 hit 비이동 — 그대로 유지.

RFC-WAIVED: out of scope — CSS press interaction fix (credential/identity/operator/sandbox/hooks/workflow 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
