### PR TITLE
feat(dashboard): pixel-perfect Goal/Task dashboard redesign (keeper-v2)

### DIFF
--- a/dashboard/src/components/goals/goal-create-form.test.ts
+++ b/dashboard/src/components/goals/goal-create-form.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/preact'
 import '@testing-library/jest-dom'
 import { h } from 'preact'
-import { showGoalCreate, resetGoalCreateForm } from './goal-create-state'
+import { showGoalCreate, resetGoalCreateForm, goalCreateError } from './goal-create-state'
 import { GoalCreateForm, resetGoalCreateFormLocal } from './goal-create-form'
 
 describe('GoalCreateForm side panel', () => {
@@ -55,5 +55,19 @@ describe('GoalCreateForm side panel', () => {
     render(h(GoalCreateForm, {}))
     fireEvent.click(screen.getByTestId('goal-create-close'))
     expect(showGoalCreate.value).toBe(false)
+  })
+
+  it('renders a title-empty error by discriminant instead of string matching', () => {
+    goalCreateError.value = { kind: 'title_empty' }
+    render(h(GoalCreateForm, {}))
+    expect(screen.getByTestId('goal-create-title-error')).toHaveTextContent('제목을 입력하세요')
+    expect(screen.queryByTestId('goal-create-error')).toBeNull()
+  })
+
+  it('renders a submit error by discriminant and hides the title-empty error', () => {
+    goalCreateError.value = { kind: 'submit', message: 'backend rejected goal' }
+    render(h(GoalCreateForm, {}))
+    expect(screen.getByTestId('goal-create-error')).toHaveTextContent('backend rejected goal')
+    expect(screen.queryByTestId('goal-create-title-error')).toBeNull()
   })
 })

--- a/dashboard/src/components/goals/goal-create-form.test.ts
+++ b/dashboard/src/components/goals/goal-create-form.test.ts
@@ -1,30 +1,19 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/preact'
 import '@testing-library/jest-dom'
 import { h } from 'preact'
-import { keepers } from '../../store'
 import { showGoalCreate, resetGoalCreateForm } from './goal-create-state'
 import { GoalCreateForm, resetGoalCreateFormLocal } from './goal-create-form'
-
-// Mock KeeperBadge so tests don't depend on avatar internals.
-vi.mock('../keeper-badge', () => ({
-  KeeperBadge: ({ id }: { id: string }) => h('span', { 'data-testid': `keeper-badge-${id}` }, id[0]?.toUpperCase()),
-}))
 
 describe('GoalCreateForm side panel', () => {
   beforeEach(() => {
     showGoalCreate.value = true
     resetGoalCreateForm()
     resetGoalCreateFormLocal()
-    keepers.value = [
-      { name: 'alpha', agent_name: 'alpha-agent', status: 'active' },
-      { name: 'beta', agent_name: 'beta-agent', status: 'active' },
-    ]
   })
 
   afterEach(() => {
     showGoalCreate.value = false
-    keepers.value = []
   })
 
   it('renders the side panel header and eyebrow', () => {
@@ -32,20 +21,6 @@ describe('GoalCreateForm side panel', () => {
     expect(screen.getByTestId('goal-create-panel')).toBeTruthy()
     expect(screen.getByText('goal store · create')).toBeTruthy()
     expect(screen.getByText('새 목표')).toBeTruthy()
-  })
-
-  it('selects 장기 horizon by default', () => {
-    render(h(GoalCreateForm, {}))
-    const longButton = screen.getByRole('radio', { name: '장기' })
-    expect(longButton).toHaveAttribute('aria-checked', 'true')
-  })
-
-  it('switches horizon chips on click', () => {
-    render(h(GoalCreateForm, {}))
-    const shortButton = screen.getByRole('radio', { name: '단기' })
-    fireEvent.click(shortButton)
-    expect(shortButton).toHaveAttribute('aria-checked', 'true')
-    expect(screen.getByRole('radio', { name: '장기' })).toHaveAttribute('aria-checked', 'false')
   })
 
   it('renders a priority slider with default P3', () => {
@@ -70,18 +45,10 @@ describe('GoalCreateForm side panel', () => {
     expect(screen.getByText('가드 통과 · 자율 실행')).toBeTruthy()
   })
 
-  it('renders the lead keeper grid with an unassigned option', () => {
+  it('does not render removed horizon or lead keeper fields', () => {
     render(h(GoalCreateForm, {}))
-    expect(screen.getByRole('button', { name: '미지정' })).toBeTruthy()
-    expect(screen.getByText('alpha')).toBeTruthy()
-    expect(screen.getByText('beta')).toBeTruthy()
-  })
-
-  it('selects a lead keeper on click', () => {
-    render(h(GoalCreateForm, {}))
-    const alphaButton = screen.getByRole('button', { name: 'alpha' })
-    fireEvent.click(alphaButton)
-    expect(alphaButton.className).toContain('on')
+    expect(screen.queryByRole('radiogroup', { name: '호라이즌' })).toBeNull()
+    expect(screen.queryByText('리드 KEEPER')).toBeNull()
   })
 
   it('closes the panel when the close button is clicked', () => {

--- a/dashboard/src/components/goals/goal-create-form.test.ts
+++ b/dashboard/src/components/goals/goal-create-form.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/preact'
+import '@testing-library/jest-dom'
+import { h } from 'preact'
+import { keepers } from '../../store'
+import { showGoalCreate, resetGoalCreateForm } from './goal-create-state'
+import { GoalCreateForm, resetGoalCreateFormLocal } from './goal-create-form'
+
+// Mock KeeperBadge so tests don't depend on avatar internals.
+vi.mock('../keeper-badge', () => ({
+  KeeperBadge: ({ id }: { id: string }) => h('span', { 'data-testid': `keeper-badge-${id}` }, id[0]?.toUpperCase()),
+}))
+
+describe('GoalCreateForm side panel', () => {
+  beforeEach(() => {
+    showGoalCreate.value = true
+    resetGoalCreateForm()
+    resetGoalCreateFormLocal()
+    keepers.value = [
+      { name: 'alpha', agent_name: 'alpha-agent', status: 'active' },
+      { name: 'beta', agent_name: 'beta-agent', status: 'active' },
+    ]
+  })
+
+  afterEach(() => {
+    showGoalCreate.value = false
+    keepers.value = []
+  })
+
+  it('renders the side panel header and eyebrow', () => {
+    render(h(GoalCreateForm, {}))
+    expect(screen.getByTestId('goal-create-panel')).toBeTruthy()
+    expect(screen.getByText('goal store · create')).toBeTruthy()
+    expect(screen.getByText('새 목표')).toBeTruthy()
+  })
+
+  it('selects 장기 horizon by default', () => {
+    render(h(GoalCreateForm, {}))
+    const longButton = screen.getByRole('radio', { name: '장기' })
+    expect(longButton).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('switches horizon chips on click', () => {
+    render(h(GoalCreateForm, {}))
+    const shortButton = screen.getByRole('radio', { name: '단기' })
+    fireEvent.click(shortButton)
+    expect(shortButton).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('radio', { name: '장기' })).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('renders a priority slider with default P3', () => {
+    render(h(GoalCreateForm, {}))
+    const slider = screen.getByTestId('goal-create-priority') as HTMLInputElement
+    expect(slider).toBeTruthy()
+    expect(slider.type).toBe('range')
+    expect(slider.value).toBe('3')
+  })
+
+  it('updates the priority label when the slider moves', () => {
+    render(h(GoalCreateForm, {}))
+    const slider = screen.getByTestId('goal-create-priority') as HTMLInputElement
+    fireEvent.input(slider, { target: { value: '1' } })
+    expect(slider.value).toBe('1')
+    expect(screen.getByText('P1')).toBeTruthy()
+  })
+
+  it('shows the risk readout', () => {
+    render(h(GoalCreateForm, {}))
+    expect(screen.getByText('Safe')).toBeTruthy()
+    expect(screen.getByText('가드 통과 · 자율 실행')).toBeTruthy()
+  })
+
+  it('renders the lead keeper grid with an unassigned option', () => {
+    render(h(GoalCreateForm, {}))
+    expect(screen.getByRole('button', { name: '미지정' })).toBeTruthy()
+    expect(screen.getByText('alpha')).toBeTruthy()
+    expect(screen.getByText('beta')).toBeTruthy()
+  })
+
+  it('selects a lead keeper on click', () => {
+    render(h(GoalCreateForm, {}))
+    const alphaButton = screen.getByRole('button', { name: 'alpha' })
+    fireEvent.click(alphaButton)
+    expect(alphaButton.className).toContain('on')
+  })
+
+  it('closes the panel when the close button is clicked', () => {
+    render(h(GoalCreateForm, {}))
+    fireEvent.click(screen.getByTestId('goal-create-close'))
+    expect(showGoalCreate.value).toBe(false)
+  })
+})

--- a/dashboard/src/components/goals/goal-create-form.ts
+++ b/dashboard/src/components/goals/goal-create-form.ts
@@ -1,4 +1,4 @@
-// Goal creation form — modal overlay pattern.
+// Goal creation form — right-hand side panel in the Work surface.
 // Design reference: prototype NewGoalComposer (work.jsx ~line 437).
 // RFC-0294: no horizon; no lead keeper (live Goal type has no owner field).
 // Fields: title (required), priority (1-5), require_completion_approval (checkbox).
@@ -85,113 +85,106 @@ export function GoalCreateForm() {
   const isSubmitDisabled = goalCreating.value || isTitleEmpty
 
   return html`
-    <div
-      class="turn-overlay"
-      role="dialog"
-      aria-modal="true"
+    <aside
+      class="wk-goal-create-panel"
+      role="form"
       aria-labelledby="goal-create-title"
-      data-testid="goal-create-overlay"
-      onClick=${handleClose}
+      data-testid="goal-create-panel"
     >
-      <div
-        class="turn-drawer ngc-drawer"
-        data-testid="goal-create-form"
-        onClick=${(e: MouseEvent) => { e.stopPropagation() }}
-      >
-        <div class="turn-hd">
+      <div class="wk-goal-create-hd">
+        <div>
+          <div class="wk-goal-create-eyebrow">goal store · create</div>
           <h3 id="goal-create-title">새 목표</h3>
-          <span class="tid mono">masc_goal_upsert</span>
-          <span style=${{ marginLeft: 'auto' }}></span>
-          <button
-            type="button"
-            class="turn-close"
-            data-testid="goal-create-close"
-            onClick=${handleClose}
-            aria-label="닫기 (Esc)"
-          >✕</button>
+        </div>
+        <button
+          type="button"
+          class="wk-goal-create-close"
+          data-testid="goal-create-close"
+          onClick=${handleClose}
+          aria-label="닫기 (Esc)"
+        >✕</button>
+      </div>
+
+      <div class="wk-goal-create-body">
+        <div class="wk-goal-create-sec">
+          <label
+            for="goal-create-title-input"
+            class="wk-goal-create-label"
+          >
+            제목<span class="wk-goal-create-req">*</span>
+          </label>
+          <${TextInput}
+            id="goal-create-title-input"
+            testId="goal-create-title-input"
+            value=${titleSignal.value}
+            placeholder="예) scheduler p99 SLO 400ms 회복"
+            autoFocus=${true}
+            onInput=${(e: Event) => { titleSignal.value = (e.target as HTMLInputElement).value }}
+          />
+          ${isTitleEmpty && goalCreateError.value === '제목을 입력하세요' ? html`
+            <p class="wk-goal-create-err" role="alert" data-testid="goal-create-title-error">
+              ${goalCreateError.value}
+            </p>
+          ` : null}
         </div>
 
-        <div class="turn-body">
-          <div class="turn-sec">
-            <label
-              for="goal-create-title-input"
-              class="text-2xs font-medium text-text-muted"
-            >
-              제목<span class="ml-0.5 text-[var(--color-status-err)]">*</span>
-            </label>
-            <${TextInput}
-              id="goal-create-title-input"
-              testId="goal-create-title-input"
-              value=${titleSignal.value}
-              placeholder="예) scheduler p99 SLO 400ms 회복"
-              autoFocus=${true}
-              onInput=${(e: Event) => { titleSignal.value = (e.target as HTMLInputElement).value }}
+        <div class="wk-goal-create-sec">
+          <label
+            for="goal-create-priority"
+            class="wk-goal-create-label"
+          >
+            우선순위 · <span class="mono">P${prioritySignal.value}</span>
+          </label>
+          <${Select}
+            id="goal-create-priority"
+            testId="goal-create-priority"
+            value=${String(prioritySignal.value)}
+            options=${PRIORITY_OPTIONS}
+            ariaLabel="우선순위"
+            onInput=${(v: string) => { prioritySignal.value = Number(v) }}
+          />
+          <p class="wk-goal-create-hint">P1이 가장 높습니다.</p>
+        </div>
+
+        <div class="wk-goal-create-sec">
+          <label class="wk-goal-create-check">
+            <input
+              type="checkbox"
+              data-testid="goal-create-approval-checkbox"
+              checked=${approvalSignal.value}
+              onChange=${(e: Event) => { approvalSignal.value = (e.target as HTMLInputElement).checked }}
             />
-            ${isTitleEmpty && goalCreateError.value === '제목을 입력하세요' ? html`
-              <p class="mt-1 text-2xs text-[var(--color-status-err)]" role="alert" data-testid="goal-create-title-error">
-                ${goalCreateError.value}
-              </p>
-            ` : null}
-          </div>
+            <span>완료 승인 필요 <b>operator 검증 게이트</b></span>
+          </label>
+        </div>
 
-          <div class="turn-sec">
-            <label
-              for="goal-create-priority"
-              class="text-2xs font-medium text-text-muted"
-            >
-              우선순위 · <span class="mono">P${prioritySignal.value}</span>
-            </label>
-            <${Select}
-              id="goal-create-priority"
-              testId="goal-create-priority"
-              value=${String(prioritySignal.value)}
-              options=${PRIORITY_OPTIONS}
-              ariaLabel="우선순위"
-              onInput=${(v: string) => { prioritySignal.value = Number(v) }}
-            />
-            <p class="mt-1 text-2xs text-text-muted">P1이 가장 높습니다.</p>
+        ${goalCreateError.value && goalCreateError.value !== '제목을 입력하세요' ? html`
+          <div class="wk-goal-create-sec">
+            <p class="wk-goal-create-err" role="alert" data-testid="goal-create-error">
+              ${goalCreateError.value}
+            </p>
           </div>
+        ` : null}
 
-          <div class="turn-sec">
-            <label class="ngc-check flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                data-testid="goal-create-approval-checkbox"
-                checked=${approvalSignal.value}
-                onChange=${(e: Event) => { approvalSignal.value = (e.target as HTMLInputElement).checked }}
-              />
-              <span>완료 승인 필요 <b>operator 검증 게이트</b></span>
-            </label>
-          </div>
-
-          ${goalCreateError.value && goalCreateError.value !== '제목을 입력하세요' ? html`
-            <div class="turn-sec">
-              <p class="text-2xs text-[var(--color-status-err)]" role="alert" data-testid="goal-create-error">
-                ${goalCreateError.value}
-              </p>
-            </div>
-          ` : null}
-
-          <div class="turn-sec bcc-actions flex flex-wrap gap-2">
-            <${ActionButton}
-              variant="primary"
-              size="md"
-              testId="goal-create-submit"
-              disabled=${isSubmitDisabled}
-              ariaBusy=${goalCreating.value}
-              onClick=${handleSubmit}
-            >
-              ${goalCreating.value ? '생성 중...' : '＋ 목표 생성'}
-            <//>
-            <${ActionButton}
-              variant="ghost"
-              size="md"
-              testId="goal-create-cancel"
-              onClick=${handleClose}
-            >취소<//>
-          </div>
+        <div class="wk-goal-create-actions">
+          <${ActionButton}
+            variant="primary"
+            size="md"
+            testId="goal-create-submit"
+            disabled=${isSubmitDisabled}
+            ariaBusy=${goalCreating.value}
+            onClick=${handleSubmit}
+          >
+            ${goalCreating.value ? '생성 중...' : '＋ 목표 생성'}
+          <//>
+          <${ActionButton}
+            variant="ghost"
+            size="md"
+            testId="goal-create-cancel"
+            onClick=${handleClose}
+          >취소<//>
         </div>
       </div>
-    </div>
+    </aside>
   `
 }

--- a/dashboard/src/components/goals/goal-create-form.ts
+++ b/dashboard/src/components/goals/goal-create-form.ts
@@ -7,8 +7,9 @@ import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { TextInput } from '../common/input'
-import { Select } from '../common/select'
 import { ActionButton } from '../common/button'
+import { KeeperBadge } from '../keeper-badge'
+import { keepers } from '../../store'
 import {
   showGoalCreate,
   goalCreating,
@@ -18,35 +19,31 @@ import {
   GOAL_PRIORITY_MIN,
   GOAL_PRIORITY_MAX,
   GOAL_PRIORITY_DEFAULT,
+  GOAL_HORIZONS,
+  GOAL_HORIZON_LABELS,
 } from './goal-create-state'
+import type { GoalHorizon } from './goal-create-state'
 
 // ── Local form state signals ─────────────────────────────────────────────────
 
 const titleSignal = signal('')
 const prioritySignal = signal(GOAL_PRIORITY_DEFAULT)
 const approvalSignal = signal(false)
+const horizonSignal = signal<GoalHorizon>('long')
+const leadKeeperSignal = signal<string | null>(null)
 
 export function resetGoalCreateFormLocal(): void {
   titleSignal.value = ''
   prioritySignal.value = GOAL_PRIORITY_DEFAULT
   approvalSignal.value = false
+  horizonSignal.value = 'long'
+  leadKeeperSignal.value = null
   resetGoalCreateForm()
 }
 
 function resetLocalForm(): void {
   resetGoalCreateFormLocal()
 }
-
-// ── Priority options ─────────────────────────────────────────────────────────
-
-const PRIORITY_OPTIONS = Array.from(
-  { length: GOAL_PRIORITY_MAX - GOAL_PRIORITY_MIN + 1 },
-  (_, i) => {
-    const v = GOAL_PRIORITY_MIN + i
-    const label = v === 1 ? `P${v} · 최고` : v === GOAL_PRIORITY_MAX ? `P${v} · 낮음` : `P${v}`
-    return { value: String(v), label }
-  },
-)
 
 // ── Component ────────────────────────────────────────────────────────────────
 
@@ -71,6 +68,8 @@ export function GoalCreateForm() {
       title: titleSignal.value,
       priority: prioritySignal.value,
       require_completion_approval: approvalSignal.value,
+      horizon: horizonSignal.value,
+      lead_keeper: leadKeeperSignal.value,
     }).then(ok => {
       if (ok) resetLocalForm()
     })
@@ -129,21 +128,73 @@ export function GoalCreateForm() {
         </div>
 
         <div class="wk-goal-create-sec">
+          <label class="wk-goal-create-label">호라이즌 · 계획 주기</label>
+          <div class="wk-goal-create-chips" role="radiogroup" aria-label="호라이즌">
+            ${GOAL_HORIZONS.map(h => html`
+              <button
+                type="button"
+                key=${h}
+                class=${`wk-chip ${horizonSignal.value === h ? 'on' : ''}`}
+                role="radio"
+                aria-checked=${horizonSignal.value === h}
+                onClick=${() => { horizonSignal.value = h }}
+              >${GOAL_HORIZON_LABELS[h]}</button>
+            `)}
+          </div>
+        </div>
+
+        <div class="wk-goal-create-sec">
           <label
             for="goal-create-priority"
             class="wk-goal-create-label"
           >
             우선순위 · <span class="mono">P${prioritySignal.value}</span>
           </label>
-          <${Select}
+          <input
             id="goal-create-priority"
-            testId="goal-create-priority"
-            value=${String(prioritySignal.value)}
-            options=${PRIORITY_OPTIONS}
-            ariaLabel="우선순위"
-            onInput=${(v: string) => { prioritySignal.value = Number(v) }}
+            type="range"
+            class="wk-goal-create-range"
+            data-testid="goal-create-priority"
+            min=${GOAL_PRIORITY_MIN}
+            max=${GOAL_PRIORITY_MAX}
+            value=${prioritySignal.value}
+            onInput=${(e: Event) => { prioritySignal.value = Number((e.target as HTMLInputElement).value) }}
           />
-          <p class="wk-goal-create-hint">P1이 가장 높습니다.</p>
+        </div>
+
+        <div class="wk-goal-create-sec">
+          <label class="wk-goal-create-label">예상 위험도 horizon + priority</label>
+          <div class="wk-goal-create-risk">
+            <span class="wk-goal-create-risk-level">Safe</span>
+            <span class="wk-goal-create-risk-desc">가드 통과 · 자율 실행</span>
+          </div>
+        </div>
+
+        <div class="wk-goal-create-sec">
+          <label class="wk-goal-create-label">리드 KEEPER</label>
+          <div class="wk-goal-create-keepers">
+            <button
+              type="button"
+              class=${`wk-keeper-chip ${leadKeeperSignal.value === null ? 'on' : ''}`}
+              onClick=${() => { leadKeeperSignal.value = null }}
+              title="미지정"
+            >
+              <span class="wk-keeper-avatar-none">?</span>
+              <span>미지정</span>
+            </button>
+            ${keepers.value.map(k => html`
+              <button
+                type="button"
+                key=${k.name}
+                class=${`wk-keeper-chip ${leadKeeperSignal.value === k.name ? 'on' : ''}`}
+                onClick=${() => { leadKeeperSignal.value = k.name }}
+                title=${k.name}
+              >
+                <${KeeperBadge} id=${k.name} size="sm" variant="sigil" />
+                <span>${k.name}</span>
+              </button>
+            `)}
+          </div>
         </div>
 
         <div class="wk-goal-create-sec">

--- a/dashboard/src/components/goals/goal-create-form.ts
+++ b/dashboard/src/components/goals/goal-create-form.ts
@@ -8,8 +8,6 @@ import { signal } from '@preact/signals'
 import { useEffect } from 'preact/hooks'
 import { TextInput } from '../common/input'
 import { ActionButton } from '../common/button'
-import { KeeperBadge } from '../keeper-badge'
-import { keepers } from '../../store'
 import {
   showGoalCreate,
   goalCreating,
@@ -19,25 +17,18 @@ import {
   GOAL_PRIORITY_MIN,
   GOAL_PRIORITY_MAX,
   GOAL_PRIORITY_DEFAULT,
-  GOAL_HORIZONS,
-  GOAL_HORIZON_LABELS,
 } from './goal-create-state'
-import type { GoalHorizon } from './goal-create-state'
 
 // ── Local form state signals ─────────────────────────────────────────────────
 
 const titleSignal = signal('')
 const prioritySignal = signal(GOAL_PRIORITY_DEFAULT)
 const approvalSignal = signal(false)
-const horizonSignal = signal<GoalHorizon>('long')
-const leadKeeperSignal = signal<string | null>(null)
 
 export function resetGoalCreateFormLocal(): void {
   titleSignal.value = ''
   prioritySignal.value = GOAL_PRIORITY_DEFAULT
   approvalSignal.value = false
-  horizonSignal.value = 'long'
-  leadKeeperSignal.value = null
   resetGoalCreateForm()
 }
 
@@ -68,8 +59,6 @@ export function GoalCreateForm() {
       title: titleSignal.value,
       priority: prioritySignal.value,
       require_completion_approval: approvalSignal.value,
-      horizon: horizonSignal.value,
-      lead_keeper: leadKeeperSignal.value,
     }).then(ok => {
       if (ok) resetLocalForm()
     })
@@ -128,22 +117,6 @@ export function GoalCreateForm() {
         </div>
 
         <div class="wk-goal-create-sec">
-          <label class="wk-goal-create-label">호라이즌 · 계획 주기</label>
-          <div class="wk-goal-create-chips" role="radiogroup" aria-label="호라이즌">
-            ${GOAL_HORIZONS.map(h => html`
-              <button
-                type="button"
-                key=${h}
-                class=${`wk-chip ${horizonSignal.value === h ? 'on' : ''}`}
-                role="radio"
-                aria-checked=${horizonSignal.value === h}
-                onClick=${() => { horizonSignal.value = h }}
-              >${GOAL_HORIZON_LABELS[h]}</button>
-            `)}
-          </div>
-        </div>
-
-        <div class="wk-goal-create-sec">
           <label
             for="goal-create-priority"
             class="wk-goal-create-label"
@@ -163,39 +136,10 @@ export function GoalCreateForm() {
         </div>
 
         <div class="wk-goal-create-sec">
-          <label class="wk-goal-create-label">예상 위험도 horizon + priority</label>
+          <label class="wk-goal-create-label">예상 위험도 · priority</label>
           <div class="wk-goal-create-risk">
             <span class="wk-goal-create-risk-level">Safe</span>
             <span class="wk-goal-create-risk-desc">가드 통과 · 자율 실행</span>
-          </div>
-        </div>
-
-        <div class="wk-goal-create-sec">
-          <label class="wk-goal-create-label">리드 KEEPER</label>
-          <div class="wk-goal-create-keepers">
-            <button
-              type="button"
-              class=${`wk-keeper-chip ${leadKeeperSignal.value === null ? 'on' : ''}`}
-              onClick=${() => { leadKeeperSignal.value = null }}
-              title="미지정"
-              aria-label="미지정"
-            >
-              <span class="wk-keeper-avatar-none" aria-hidden="true">?</span>
-              <span>미지정</span>
-            </button>
-            ${keepers.value.map(k => html`
-              <button
-                type="button"
-                key=${k.name}
-                class=${`wk-keeper-chip ${leadKeeperSignal.value === k.name ? 'on' : ''}`}
-                onClick=${() => { leadKeeperSignal.value = k.name }}
-                title=${k.name}
-                aria-label=${k.name}
-              >
-                <${KeeperBadge} id=${k.name} size="sm" variant="sigil" />
-                <span>${k.name}</span>
-              </button>
-            `)}
           </div>
         </div>
 

--- a/dashboard/src/components/goals/goal-create-form.ts
+++ b/dashboard/src/components/goals/goal-create-form.ts
@@ -178,8 +178,9 @@ export function GoalCreateForm() {
               class=${`wk-keeper-chip ${leadKeeperSignal.value === null ? 'on' : ''}`}
               onClick=${() => { leadKeeperSignal.value = null }}
               title="미지정"
+              aria-label="미지정"
             >
-              <span class="wk-keeper-avatar-none">?</span>
+              <span class="wk-keeper-avatar-none" aria-hidden="true">?</span>
               <span>미지정</span>
             </button>
             ${keepers.value.map(k => html`
@@ -189,6 +190,7 @@ export function GoalCreateForm() {
                 class=${`wk-keeper-chip ${leadKeeperSignal.value === k.name ? 'on' : ''}`}
                 onClick=${() => { leadKeeperSignal.value = k.name }}
                 title=${k.name}
+                aria-label=${k.name}
               >
                 <${KeeperBadge} id=${k.name} size="sm" variant="sigil" />
                 <span>${k.name}</span>

--- a/dashboard/src/components/goals/goal-create-form.ts
+++ b/dashboard/src/components/goals/goal-create-form.ts
@@ -14,6 +14,7 @@ import {
   goalCreateError,
   createGoal,
   resetGoalCreateForm,
+  goalCreateErrorMessage,
   GOAL_PRIORITY_MIN,
   GOAL_PRIORITY_MAX,
   GOAL_PRIORITY_DEFAULT,
@@ -109,9 +110,9 @@ export function GoalCreateForm() {
             autoFocus=${true}
             onInput=${(e: Event) => { titleSignal.value = (e.target as HTMLInputElement).value }}
           />
-          ${isTitleEmpty && goalCreateError.value === '제목을 입력하세요' ? html`
+          ${isTitleEmpty && goalCreateError.value?.kind === 'title_empty' ? html`
             <p class="wk-goal-create-err" role="alert" data-testid="goal-create-title-error">
-              ${goalCreateError.value}
+              ${goalCreateErrorMessage(goalCreateError.value)}
             </p>
           ` : null}
         </div>
@@ -155,10 +156,10 @@ export function GoalCreateForm() {
           </label>
         </div>
 
-        ${goalCreateError.value && goalCreateError.value !== '제목을 입력하세요' ? html`
+        ${goalCreateError.value?.kind === 'submit' ? html`
           <div class="wk-goal-create-sec">
             <p class="wk-goal-create-err" role="alert" data-testid="goal-create-error">
-              ${goalCreateError.value}
+              ${goalCreateErrorMessage(goalCreateError.value)}
             </p>
           </div>
         ` : null}

--- a/dashboard/src/components/goals/goal-create-state.ts
+++ b/dashboard/src/components/goals/goal-create-state.ts
@@ -1,5 +1,9 @@
 // Goal creation state and async action — mirrors task-manage-state.ts idiom.
-// RFC-0294: no horizon field; no status/phase (lifecycle-only via masc_goal_transition).
+// RFC-0294: horizon is no longer a top-level view axis, but the prototype
+// keeps it as a creation-time planning attribute. The backend currently
+// rejects unknown keys (additionalProperties: false), so horizon and
+// lead_keeper are collected in the UI but not sent until the backend schema
+// is updated. See docs/superpowers/plans/2026-06-24-masc-goal-task-dashboard-implementation.md.
 
 import { signal } from '@preact/signals'
 import { callMcpTool } from '../../api/mcp'
@@ -11,6 +15,16 @@ export const GOAL_PRIORITY_MIN = 1
 export const GOAL_PRIORITY_MAX = 5
 export const GOAL_PRIORITY_DEFAULT = 3
 
+export type GoalHorizon = 'short' | 'medium' | 'long'
+
+export const GOAL_HORIZONS: GoalHorizon[] = ['short', 'medium', 'long']
+
+export const GOAL_HORIZON_LABELS: Record<GoalHorizon, string> = {
+  short: '단기',
+  medium: '중기',
+  long: '장기',
+}
+
 export const showGoalCreate = signal(false)
 export const goalCreating = signal(false)
 export const goalCreateError = signal<string | null>(null)
@@ -19,6 +33,8 @@ export interface GoalCreateInput {
   title: string
   priority: number
   require_completion_approval: boolean
+  horizon?: GoalHorizon
+  lead_keeper?: string | null
 }
 
 export async function createGoal(input: GoalCreateInput): Promise<boolean> {
@@ -36,6 +52,14 @@ export async function createGoal(input: GoalCreateInput): Promise<boolean> {
     }
     if (input.require_completion_approval) {
       args.require_completion_approval = true
+    }
+    // Backend compatibility gate: masc_goal_upsert currently rejects unknown
+    // keys. Do not send horizon/lead_keeper until the backend schema accepts
+    // them. Set ENABLE_NEW_GOAL_FIELDS to true after verifying the backend.
+    const ENABLE_NEW_GOAL_FIELDS = false
+    if (ENABLE_NEW_GOAL_FIELDS) {
+      if (input.horizon) args.horizon = input.horizon
+      if (input.lead_keeper) args.lead_keeper = input.lead_keeper
     }
     await callMcpTool('masc_goal_upsert', args)
     showToast('목표 생성 완료', 'success')

--- a/dashboard/src/components/goals/goal-create-state.ts
+++ b/dashboard/src/components/goals/goal-create-state.ts
@@ -1,9 +1,7 @@
 // Goal creation state and async action — mirrors task-manage-state.ts idiom.
-// RFC-0294: horizon is no longer a top-level view axis, but the prototype
-// keeps it as a creation-time planning attribute. The backend currently
-// rejects unknown keys (additionalProperties: false), so horizon and
-// lead_keeper are collected in the UI but not sent until the backend schema
-// is updated. See docs/superpowers/plans/2026-06-24-masc-goal-task-dashboard-implementation.md.
+// RFC-0294 removed horizon from the live Goal contract. Keep this payload
+// aligned with masc_goal_upsert's accepted schema; do not collect or stage
+// fields the backend cannot persist.
 
 import { signal } from '@preact/signals'
 import { callMcpTool } from '../../api/mcp'
@@ -15,16 +13,6 @@ export const GOAL_PRIORITY_MIN = 1
 export const GOAL_PRIORITY_MAX = 5
 export const GOAL_PRIORITY_DEFAULT = 3
 
-export type GoalHorizon = 'short' | 'medium' | 'long'
-
-export const GOAL_HORIZONS: GoalHorizon[] = ['short', 'medium', 'long']
-
-export const GOAL_HORIZON_LABELS: Record<GoalHorizon, string> = {
-  short: '단기',
-  medium: '중기',
-  long: '장기',
-}
-
 export const showGoalCreate = signal(false)
 export const goalCreating = signal(false)
 export const goalCreateError = signal<string | null>(null)
@@ -33,8 +21,6 @@ export interface GoalCreateInput {
   title: string
   priority: number
   require_completion_approval: boolean
-  horizon?: GoalHorizon
-  lead_keeper?: string | null
 }
 
 export async function createGoal(input: GoalCreateInput): Promise<boolean> {
@@ -52,14 +38,6 @@ export async function createGoal(input: GoalCreateInput): Promise<boolean> {
     }
     if (input.require_completion_approval) {
       args.require_completion_approval = true
-    }
-    // Backend compatibility gate: masc_goal_upsert currently rejects unknown
-    // keys. Do not send horizon/lead_keeper until the backend schema accepts
-    // them. Set ENABLE_NEW_GOAL_FIELDS to true after verifying the backend.
-    const ENABLE_NEW_GOAL_FIELDS = false
-    if (ENABLE_NEW_GOAL_FIELDS) {
-      if (input.horizon) args.horizon = input.horizon
-      if (input.lead_keeper) args.lead_keeper = input.lead_keeper
     }
     await callMcpTool('masc_goal_upsert', args)
     showToast('목표 생성 완료', 'success')

--- a/dashboard/src/components/goals/goal-create-state.ts
+++ b/dashboard/src/components/goals/goal-create-state.ts
@@ -15,7 +15,12 @@ export const GOAL_PRIORITY_DEFAULT = 3
 
 export const showGoalCreate = signal(false)
 export const goalCreating = signal(false)
-export const goalCreateError = signal<string | null>(null)
+
+export type GoalCreateError =
+  | { kind: 'title_empty' }
+  | { kind: 'submit'; message: string }
+
+export const goalCreateError = signal<GoalCreateError | null>(null)
 
 export interface GoalCreateInput {
   title: string
@@ -23,10 +28,16 @@ export interface GoalCreateInput {
   require_completion_approval: boolean
 }
 
+export function goalCreateErrorMessage(err: GoalCreateError | null): string | null {
+  if (err === null) return null
+  if (err.kind === 'title_empty') return '제목을 입력하세요'
+  return err.message
+}
+
 export async function createGoal(input: GoalCreateInput): Promise<boolean> {
   const trimmedTitle = input.title.trim()
   if (!trimmedTitle) {
-    goalCreateError.value = '제목을 입력하세요'
+    goalCreateError.value = { kind: 'title_empty' }
     return false
   }
   goalCreating.value = true
@@ -46,7 +57,7 @@ export async function createGoal(input: GoalCreateInput): Promise<boolean> {
     return true
   } catch (err) {
     const message = errorToString(err)
-    goalCreateError.value = message
+    goalCreateError.value = { kind: 'submit', message }
     showToast(`목표 생성 실패: ${message}`, 'error')
     return false
   } finally {

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -59,6 +59,7 @@ vi.mock('./repository-management', () => ({
 
 import { goals, keepers, tasks } from '../store'
 import { selectedTask } from './goals/task-detail-selection'
+import { showGoalCreate } from './goals/goal-create-state'
 import { Work } from './work'
 
 describe('Work', () => {
@@ -66,12 +67,14 @@ describe('Work', () => {
     cleanup()
     navigateMock.mockClear()
     selectedTask.value = null
+    showGoalCreate.value = false
   })
 
   beforeEach(() => {
     goals.value = []
     tasks.value = []
     keepers.value = []
+    showGoalCreate.value = false
   })
 
   it('renders the SubBoard surface for the workspace sub-boards section', () => {
@@ -167,6 +170,8 @@ describe('Work', () => {
       expect(screen.getByTestId('kpi-wip').textContent).toBe('1')
       expect(screen.getByTestId('kpi-verify').textContent).toBe('1')
       expect(screen.getByTestId('kpi-backlog').textContent).toBe('2')
+      // Five elevated KPI cards
+      expect(screen.getByTestId('work-kpis').children.length).toBe(5)
       expect(screen.getByText(/백로그에서 claim/).textContent).toContain('claim')
       expect(screen.getByTestId('work-goal-list')).toBeTruthy()
     })
@@ -187,8 +192,9 @@ describe('Work', () => {
 
       fireEvent.click(button)
 
-      // Side panel appears after click
+      // Side panel appears after click and WorkAside is hidden
       expect(screen.getByTestId('goal-create-panel')).toBeTruthy()
+      expect(screen.queryByTestId('work-aside')).toBeNull()
     })
 
     it('renders a collapsed goal card per goal and expands on click', () => {

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -892,7 +892,7 @@ describe('Work', () => {
         expect(colFor('done')?.querySelector('[data-kanban-task-id="T-done"]')).toBeTruthy()
       })
 
-      it('shows the goal title on each kanban card and hides the backlog strip in kanban view', () => {
+      it('shows task titles on kanban cards and hides the backlog strip in kanban view', () => {
         goals.value = [
           { id: 'G-1', title: 'Target Goal', priority: 1, status: 'active', phase: 'executing', created_at: '2026-01-01', updated_at: '2026-01-01' },
         ]
@@ -905,9 +905,10 @@ describe('Work', () => {
         render(html`<${Work} />`)
         fireEvent.click(screen.getByTestId('work-view-kanban'))
 
-        // Goal title appears in card goal link
+        // Task titles appear on cards
         const board = screen.getByTestId('work-kanban')
-        expect(board.textContent).toContain('Target Goal')
+        expect(board.textContent).toContain('Some task')
+        expect(board.textContent).toContain('Claimable')
 
         // Backlog strip (.wk-backlog) must NOT be present in kanban view
         expect(screen.queryByTestId('work-backlog')).toBeNull()

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -516,6 +516,7 @@ describe('Work', () => {
         const rawCalls = callMcpToolMock.mock.calls as unknown as [string, Record<string, unknown>][]
         const callArgs = rawCalls[0]?.[1] ?? {}
         expect(callArgs).not.toHaveProperty('horizon')
+        expect(callArgs).not.toHaveProperty('lead_keeper')
         expect(callArgs).not.toHaveProperty('status')
         expect(callArgs).not.toHaveProperty('phase')
       })

--- a/dashboard/src/components/work.test.ts
+++ b/dashboard/src/components/work.test.ts
@@ -183,12 +183,12 @@ describe('Work', () => {
       expect(button).not.toBeDisabled()
 
       // Form is hidden initially
-      expect(screen.queryByTestId('goal-create-form')).toBeNull()
+      expect(screen.queryByTestId('goal-create-panel')).toBeNull()
 
       fireEvent.click(button)
 
-      // Form appears after click
-      expect(screen.getByTestId('goal-create-form')).toBeTruthy()
+      // Side panel appears after click
+      expect(screen.getByTestId('goal-create-panel')).toBeTruthy()
     })
 
     it('renders a collapsed goal card per goal and expands on click', () => {
@@ -490,7 +490,7 @@ describe('Work', () => {
 
         // Open the form
         fireEvent.click(screen.getByTestId('work-new-goal'))
-        expect(screen.getByTestId('goal-create-form')).toBeTruthy()
+        expect(screen.getByTestId('goal-create-panel')).toBeTruthy()
 
         // Fill in the title
         const titleInput = screen.getByTestId('goal-create-title-input')

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1185,26 +1185,26 @@ function WorkSurfaceV2() {
           </div>
         </header>
 
-          <section class="ov-kpis" data-testid="work-kpis" style=${{ gridTemplateColumns: 'repeat(5, 1fr)' }}>
-            <div class="ov-kpi">
-              <div class="ov-kpi-k">활성 목표</div>
-              <div class="ov-kpi-v volt" data-testid="kpi-goals">${totals.goals}</div>
+          <section class="wk-kpis" data-testid="work-kpis">
+            <div class="wk-kpi">
+              <div class="wk-kpi-k">활성 목표</div>
+              <div class="wk-kpi-v brass" data-testid="kpi-goals">${totals.goals}</div>
             </div>
-            <div class="ov-kpi">
-              <div class="ov-kpi-k">전체 Task</div>
-              <div class="ov-kpi-v" data-testid="kpi-tasks">${totals.tasks}</div>
+            <div class="wk-kpi">
+              <div class="wk-kpi-k">전체 TASK</div>
+              <div class="wk-kpi-v" data-testid="kpi-tasks">${totals.tasks}</div>
             </div>
-            <div class="ov-kpi">
-              <div class="ov-kpi-k">진행 중</div>
-              <div class=${`ov-kpi-v ${totals.wip > 0 ? 'volt' : ''}`} data-testid="kpi-wip">${totals.wip}</div>
+            <div class="wk-kpi">
+              <div class="wk-kpi-k">진행 중</div>
+              <div class=${`wk-kpi-v ${totals.wip > 0 ? 'volt' : ''}`} data-testid="kpi-wip">${totals.wip}</div>
             </div>
-            <div class="ov-kpi">
-              <div class="ov-kpi-k">검증 대기</div>
-              <div class=${`ov-kpi-v ${totals.verify > 0 ? 'volt' : ''}`} data-testid="kpi-verify">${totals.verify}</div>
+            <div class="wk-kpi">
+              <div class="wk-kpi-k">검증 대기</div>
+              <div class=${`wk-kpi-v ${totals.verify > 0 ? 'volt' : ''}`} data-testid="kpi-verify">${totals.verify}</div>
             </div>
-            <div class="ov-kpi">
-              <div class="ov-kpi-k">백로그</div>
-              <div class=${`ov-kpi-v ${totals.backlog > 0 ? 'warn' : ''}`} data-testid="kpi-backlog">${totals.backlog}</div>
+            <div class="wk-kpi">
+              <div class="wk-kpi-k">백로그</div>
+              <div class=${`wk-kpi-v ${totals.backlog > 0 ? 'warn' : ''}`} data-testid="kpi-backlog">${totals.backlog}</div>
             </div>
           </section>
 

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1145,7 +1145,7 @@ function WorkSurfaceV2() {
           <div>
             <span class="ov-eyebrow">GOAL STORE</span>
             <h1>작업 · 목표</h1>
-            <p class="ov-sub">Goal → Task → keeper · horizon으로 묶고 게이트 증거로 검증</p>
+            <p class="ov-sub">Goal → Task → keeper · 우선순위 순 정렬과 게이트 증거로 검증</p>
           </div>
           <div class="wk-head-r">
             <div class="wk-viewseg" role="tablist" data-testid="work-viewseg">

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1136,7 +1136,7 @@ function WorkSurfaceV2() {
   }, [])
 
   return html`
-    <main class="ov ov-2col">
+    <main class=${`ov ov-2col ${showGoalCreate.value ? 'ov-with-panel' : ''}`}>
       <div class="ov-scroll">
         <header class="ov-head wk-head">
           <div>
@@ -1250,6 +1250,7 @@ function WorkSurfaceV2() {
 
           <div class="wk-foot mono">Goal → Task → keeper · 우선순위 순 정렬 · 완료는 게이트 증거 충족 후 done · 미배정 task 는 백로그에서 claim</div>
       </div>
+      ${showGoalCreate.value ? html`<${GoalCreateForm} />` : null}
       <${WorkAside}
         flagged=${wkaFlagged}
         approvals=${wkaApprovals}
@@ -1272,23 +1273,20 @@ export function Work() {
 
   return html`
     <div class="v2-workspace-surface flex min-w-0 flex-col gap-3">
-      <div class="min-w-0 transition-opacity duration-[var(--t-slow)]">
-        <${ErrorBoundary} label=${current}>
-          ${current === 'work' ? html`<${WorkSurfaceV2} />`
-            : current === 'board' ? html`<${BoardSurface} />`
-            : current === 'sub-boards' ? html`<${SubBoardSurface} />`
-            : current === 'moderation' ? html`<${BoardModerationSurface} />`
-            : current === 'planning' ? html`<${PlanningPanel} />`
-            : current === 'repositories' ? html`
-              <${Suspense} fallback=${html`<${LoadingState}>저장소 화면 불러오는 중...<//>`}>
-                <${LazyRepositoryManagement} />
-              <//>
-            `
-            : html`<${VerificationRequestsPanel} />`
-          }
-        <//>
-      </div>
-      <${GoalCreateForm} />
+      <${ErrorBoundary} label=${current}>
+        ${current === 'work' ? html`<${WorkSurfaceV2} />`
+          : current === 'board' ? html`<${BoardSurface} />`
+          : current === 'sub-boards' ? html`<${SubBoardSurface} />`
+          : current === 'moderation' ? html`<${BoardModerationSurface} />`
+          : current === 'planning' ? html`<${PlanningPanel} />`
+          : current === 'repositories' ? html`
+            <${Suspense} fallback=${html`<${LoadingState}>저장소 화면 불러오는 중...<//>`}>
+              <${LazyRepositoryManagement} />
+            <//>
+          `
+          : html`<${VerificationRequestsPanel} />`
+        }
+      <//>
     </div>
   `
 }

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -17,7 +17,7 @@ import { LoadingState } from './common/feedback-state'
 import { KeeperBadge } from './keeper-badge'
 import { openTaskDetail } from './goals/task-detail-state'
 import { GoalCreateForm } from './goals/goal-create-form'
-import { showGoalCreate } from './goals/goal-create-state'
+import { showGoalCreate, GOAL_PRIORITY_MAX } from './goals/goal-create-state'
 import type { Goal, Task, Keeper } from '../types'
 
 type WorkSection = 'work' | 'board' | 'sub-boards' | 'moderation' | 'planning' | 'repositories' | 'verification'
@@ -568,6 +568,12 @@ interface KanbanTask extends Task {
   readonly _goalTitle: string
 }
 
+// Task priorities share the goal 1–5 scale (1 = highest). The prototype only
+// accents P1–P3 in the kanban card chip; P4+ render with the muted base style.
+const TASK_PRIORITY_DEFAULT = GOAL_PRIORITY_MAX
+const KANBAN_ACCENT_PRIORITY_MAX = 3
+const KANBAN_MUTED_PRIORITY_BUCKET = 4
+
 function KanbanCard({
   task,
   onClaim,
@@ -578,8 +584,8 @@ function KanbanCard({
   const state = jobStateForTask(task)
   const keeper = keeperByName(task.assignee)
   const blocker = blockerNoteForTask(task)
-  const p = task.priority ?? 4
-  const normalizedPrio = p <= 3 ? p : 4
+  const p = task.priority ?? TASK_PRIORITY_DEFAULT
+  const normalizedPrio = p <= KANBAN_ACCENT_PRIORITY_MAX ? p : KANBAN_MUTED_PRIORITY_BUCKET
   const description = task.description ?? ''
   const hasDescription = description.length > 0
 
@@ -1231,7 +1237,7 @@ function WorkSurfaceV2() {
               goalList.length > 0 ? html`
                 <div class="wk-list" data-testid="work-goal-list">
                   ${[...goalList]
-                    .sort((a, b) => (a.priority ?? 4) - (b.priority ?? 4) || (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
+                    .sort((a, b) => (a.priority ?? GOAL_PRIORITY_MAX) - (b.priority ?? GOAL_PRIORITY_MAX) || (b.updated_at ?? b.created_at ?? '').localeCompare(a.updated_at ?? a.created_at ?? ''))
                     .map(g => html`
                     <${GoalCard}
                       key=${g.id}

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -934,6 +934,9 @@ function WorkAside({
 }
 
 function WorkSurfaceV2() {
+  // Read showGoalCreate at the top so this component re-renders when the
+  // side-panel toggle changes.
+  const goalCreateOpen = showGoalCreate.value
   const goalList = goals.value
   const allTasks = tasks.value
 
@@ -1136,7 +1139,7 @@ function WorkSurfaceV2() {
   }, [])
 
   return html`
-    <main class=${`ov ov-2col ${showGoalCreate.value ? 'ov-with-panel' : ''}`}>
+    <main class=${`ov ov-2col ${goalCreateOpen ? 'ov-with-panel' : ''}`}>
       <div class="ov-scroll">
         <header class="ov-head wk-head">
           <div>
@@ -1250,18 +1253,19 @@ function WorkSurfaceV2() {
 
           <div class="wk-foot mono">Goal → Task → keeper · 우선순위 순 정렬 · 완료는 게이트 증거 충족 후 done · 미배정 task 는 백로그에서 claim</div>
       </div>
-      ${showGoalCreate.value ? html`<${GoalCreateForm} />` : null}
-      <${WorkAside}
-        flagged=${wkaFlagged}
-        approvals=${wkaApprovals}
-        verifyTasks=${wkaVerifyTasks}
-        blockers=${wkaBlockers}
-        backlog=${wkaBacklog}
-        recent=${wkaRecent}
-        counts=${wkaCounts}
-        onJump=${jumpToGoal}
-        onOpenKeeper=${openKeeperWorkspace}
-      />
+      ${goalCreateOpen ? html`<${GoalCreateForm} />` : html`
+        <${WorkAside}
+          flagged=${wkaFlagged}
+          approvals=${wkaApprovals}
+          verifyTasks=${wkaVerifyTasks}
+          blockers=${wkaBlockers}
+          backlog=${wkaBacklog}
+          recent=${wkaRecent}
+          counts=${wkaCounts}
+          onJump=${jumpToGoal}
+          onOpenKeeper=${openKeeperWorkspace}
+        />
+      `}
     </main>
   `
 }

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1148,42 +1148,42 @@ function WorkSurfaceV2() {
   return html`
     <main class="ov ov-2col">
       <div class="ov-scroll">
-        <header class="ov-head">
-            <div>
-              <span class="ov-eyebrow">Goal Store</span>
-              <h1>작업 · 목표</h1>
-              <p class="ov-sub">Goal → Task → keeper · 우선순위 순으로 정렬 · 게이트 증거로 검증</p>
-            </div>
-            <div class="wk-head-r">
-              <div class="wk-viewseg" role="tablist" data-testid="work-viewseg">
-                <button
-                  type="button"
-                  class=${view === 'list' ? 'on' : ''}
-                  role="tab"
-                  aria-selected=${view === 'list'}
-                  data-testid="work-view-list"
-                  onClick=${() => switchView('list')}
-                >리스트</button>
-                <button
-                  type="button"
-                  class=${view === 'kanban' ? 'on' : ''}
-                  role="tab"
-                  aria-selected=${view === 'kanban'}
-                  data-testid="work-view-kanban"
-                  onClick=${() => switchView('kanban')}
-                >칸반</button>
-              </div>
+        <header class="ov-head wk-head">
+          <div>
+            <span class="ov-eyebrow">GOAL STORE</span>
+            <h1>작업 · 목표</h1>
+            <p class="ov-sub">Goal → Task → keeper · horizon으로 묶고 게이트 증거로 검증</p>
+          </div>
+          <div class="wk-head-r">
+            <div class="wk-viewseg" role="tablist" data-testid="work-viewseg">
               <button
                 type="button"
-                class="set-add wk-newgoal"
-                data-testid="work-new-goal"
-                title="새 목표 생성"
-                onClick=${() => { showGoalCreate.value = true }}
-              >
-                ＋ 새 목표
-              </button>
+                class=${view === 'list' ? 'on' : ''}
+                role="tab"
+                aria-selected=${view === 'list'}
+                data-testid="work-view-list"
+                onClick=${() => switchView('list')}
+              >리스트</button>
+              <button
+                type="button"
+                class=${view === 'kanban' ? 'on' : ''}
+                role="tab"
+                aria-selected=${view === 'kanban'}
+                data-testid="work-view-kanban"
+                onClick=${() => switchView('kanban')}
+              >칸반</button>
             </div>
-          </header>
+            <button
+              type="button"
+              class="wk-newgoal"
+              data-testid="work-new-goal"
+              title="새 목표 생성"
+              onClick=${() => { showGoalCreate.value = true }}
+            >
+              ＋ 새 목표
+            </button>
+          </div>
+        </header>
 
           <section class="ov-kpis" data-testid="work-kpis" style=${{ gridTemplateColumns: 'repeat(5, 1fr)' }}>
             <div class="ov-kpi">

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -571,19 +571,20 @@ interface KanbanTask extends Task {
 function KanbanCard({
   task,
   onClaim,
-  onJumpGoal,
 }: {
   task: KanbanTask
   onClaim: (id: string) => void
-  onJumpGoal: (goalId: string) => void
 }) {
   const state = jobStateForTask(task)
   const keeper = keeperByName(task.assignee)
   const blocker = blockerNoteForTask(task)
-  const hasHandoff = !!(task.handoff_context?.summary || task.handoff_context?.next_step)
+  const p = task.priority ?? 4
+  const normalizedPrio = p <= 3 ? p : 4
+  const description = task.description ?? ''
+  const hasDescription = description.length > 0
 
   return html`
-    <div
+    <article
       class=${`wk-kcard ${state.cls}`}
       role="button"
       tabIndex=${0}
@@ -603,19 +604,12 @@ function KanbanCard({
     >
       <div class="wk-kcard-top">
         <span class="wk-kcard-id mono">${task.id}</span>
-        <span class="wk-kcard-prio mono">P${task.priority ?? 0}</span>
+        <span class=${`wk-kcard-prio prio-${normalizedPrio}`}>P${p}</span>
       </div>
       <div class="wk-kcard-title">${task.title}</div>
       ${blocker ? html`<div class="wk-kcard-block">⚠ ${blocker}</div>` : null}
-      <button
-        class="wk-kcard-goal"
-        type="button"
-        title=${`소속 목표로 이동 · ${task._goalTitle}`}
-        onClick=${(e: Event) => { e.stopPropagation(); onJumpGoal(task._goalId) }}
-      >↳ ${task._goalTitle}</button>
+      ${hasDescription ? html`<p class="wk-kcard-desc">${description}</p>` : null}
       <div class="wk-kcard-foot">
-        ${hasHandoff ? html`<span class="wk-kcard-ho" title="핸드오프 이력">⇄</span>` : null}
-        <span class="wk-spacer"></span>
         ${keeper
           ? html`
             <button
@@ -636,20 +630,18 @@ function KanbanCard({
                 onClick=${(e: Event) => { e.stopPropagation(); onClaim(task.id) }}
               >＋</button>
             `
-            : html`<span class="wk-kcard-kp none mono">·</span>`}
+            : html`<span class="wk-kcard-kp none mono">미배정</span>`}
       </div>
-    </div>
+    </article>
   `
 }
 
 function KanbanView({
   kanbanTasks,
   onClaim,
-  onJumpGoal,
 }: {
   kanbanTasks: ReadonlyArray<KanbanTask>
   onClaim: (id: string) => void
-  onJumpGoal: (goalId: string) => void
 }) {
   return html`
     <div class="wk-kanban" data-testid="work-kanban">
@@ -658,9 +650,8 @@ function KanbanView({
         return html`
           <div key=${status} class=${`wk-kcol ${cls}`} data-testid=${`kanban-col-${status}`}>
             <div class="wk-kcol-h">
-              <span class=${`wk-kcol-dot ${cls}`} aria-hidden="true"></span>
-              ${label}
-              <span class="wk-kcol-n mono">${col.length}</span>
+              <span class="wk-kcol-title">${label}</span>
+              <span class="wk-kcol-count">${col.length}</span>
             </div>
             <div class="wk-kcol-body">
               ${col.length === 0
@@ -670,7 +661,6 @@ function KanbanView({
                     key=${t.id}
                     task=${t}
                     onClaim=${onClaim}
-                    onJumpGoal=${onJumpGoal}
                   />
                 `)}
             </div>
@@ -1255,7 +1245,6 @@ function WorkSurfaceV2() {
               <${KanbanView}
                 kanbanTasks=${kanbanTasks}
                 onClaim=${claimTask}
-                onJumpGoal=${jumpToGoal}
               />
             `}
 

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -1256,6 +1256,48 @@
   color: var(--color-bg-page);
 }
 
+/* ── KPI cards ───────────────────────────────────────────────────────────── */
+
+.wk-kpis {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0.75rem;
+}
+
+.wk-kpi {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0.875rem 1rem;
+  border-radius: var(--r-1);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.wk-kpi-k {
+  font-size: var(--text-2xs);
+  color: var(--color-fg-muted);
+}
+
+.wk-kpi-v {
+  margin-top: 0.5rem;
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--color-fg-primary);
+  line-height: 1;
+}
+
+.wk-kpi-v.brass { color: var(--color-accent-fg); }
+.wk-kpi-v.volt { color: var(--color-status-volt); }
+.wk-kpi-v.warn { color: var(--color-status-warn); }
+
+@media (max-width: 700px) {
+  .wk-kpis {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 /* ── Kanban board ────────────────────────────────────────────────────────── */
 
 .wk-kanban {

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -1302,82 +1302,73 @@
 
 .wk-kanban {
   display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(244px, 1fr);
-  gap: 12px;
-  margin-top: 6px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.75rem;
   align-items: start;
-  overflow-x: auto;
-  padding-bottom: 14px;
 }
 
-@media (min-width: 1321px) {
+@media (max-width: 1100px) {
   .wk-kanban {
-    grid-auto-flow: unset;
-    grid-auto-columns: unset;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(244px, 1fr);
+    grid-template-columns: unset;
+    overflow-x: auto;
+    padding-bottom: 0.75rem;
   }
 }
 
 .wk-kcol {
   display: flex;
   flex-direction: column;
+  min-height: 12rem;
   min-width: 0;
-  background: var(--bg-sunken);
-  border: 1px solid var(--border-soft);
-  border-radius: var(--radius-md);
+  border-radius: var(--r-1);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-page);
 }
 
 .wk-kcol-h {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 11px 12px;
-  font-family: var(--font-display);
-  font-size: 11px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--text-mid);
-  border-bottom: 1px solid var(--border-soft);
-  position: sticky;
-  top: 0;
-  background: var(--bg-sunken);
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
-  z-index: 1;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  border-bottom: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  border-radius: var(--r-1) var(--r-1) 0 0;
 }
 
-.wk-kcol-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  flex: none;
+.wk-kcol-title {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-fg-primary);
 }
 
-.wk-kcol-dot.todo    { background: var(--text-dim); }
-.wk-kcol-dot.claimed { background: var(--text-mid); }
-.wk-kcol-dot.wip     { background: var(--volt-strong); }
-.wk-kcol-dot.verify  { background: var(--info); }
-.wk-kcol-dot.done    { background: var(--status-ok); }
-
-.wk-kcol-n {
-  margin-left: auto;
-  font-size: 11px;
-  color: var(--text-dim);
+.wk-kcol-count {
+  font-size: var(--text-3xs);
+  font-weight: 700;
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--r-0);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-muted);
+  border: 1px solid var(--color-border-default);
 }
 
 .wk-kcol-body {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 10px;
+  gap: 0.5rem;
+  padding: 0.5rem;
   min-height: 60px;
+  overflow-y: auto;
+  max-height: 42rem;
 }
 
 .wk-kcol-empty {
-  color: var(--text-faint);
-  font-size: 12px;
+  color: var(--color-fg-disabled);
+  font-size: var(--text-xs);
   text-align: center;
-  padding: 14px 0;
+  padding: 1rem 0;
 }
 
 /* ── Kanban card ─────────────────────────────────────────────────────────── */
@@ -1385,98 +1376,84 @@
 .wk-kcard {
   display: flex;
   flex-direction: column;
-  gap: 7px;
-  padding: 10px 11px;
-  background: var(--bg-card);
-  border: 1px solid var(--border-soft);
-  border-left: 2px solid var(--border-main);
-  border-radius: var(--radius-sm);
+  gap: 0.375rem;
+  padding: 0.625rem;
+  border-radius: var(--r-0);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
   cursor: pointer;
-  transition: border-color 0.16s ease, background 0.16s ease, transform 0.12s ease;
+  transition: border-color 120ms ease, background-color 120ms ease, transform 120ms ease;
 }
 
 .wk-kcard:hover {
-  background: var(--bg-card-hover);
-  border-color: var(--border-highlight);
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-panel-alt);
   transform: translateY(-1px);
 }
 
 .wk-kcard:focus-visible {
-  outline: 2px solid var(--volt-dim);
+  outline: 2px solid var(--color-accent-fg);
   outline-offset: 1px;
 }
-
-.wk-kcard.wip     { border-left-color: var(--volt-strong); }
-.wk-kcard.verify  { border-left-color: var(--info); }
-.wk-kcard.done    { border-left-color: var(--status-ok); opacity: 0.82; }
-.wk-kcard.claimed { border-left-color: var(--text-mid); }
 
 .wk-kcard-top {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: space-between;
+  gap: 0.5rem;
 }
 
 .wk-kcard-id {
-  font-size: 10.5px;
-  color: var(--text-dim);
+  font-size: var(--text-3xs);
+  color: var(--color-fg-muted);
 }
 
 .wk-kcard-prio {
-  margin-left: auto;
-  font-size: 10px;
-  color: var(--text-dim);
-  border: 1px solid var(--border-main);
-  border-radius: var(--radius-pill);
-  padding: 0 6px;
+  font-size: var(--text-3xs);
+  font-weight: 700;
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--r-0);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-muted);
 }
 
+.wk-kcard-prio.prio-1 { border-color: var(--color-err-border); background: var(--color-err-soft); color: var(--color-err-fg); }
+.wk-kcard-prio.prio-2 { border-color: var(--color-warn-border); background: var(--color-warn-soft); color: var(--color-warn-fg); }
+.wk-kcard-prio.prio-3 { border-color: var(--color-info-border); background: var(--color-info-soft); color: var(--color-info-fg); }
+
 .wk-kcard-title {
-  font-size: 12.5px;
+  font-size: var(--text-sm);
+  font-weight: 600;
   line-height: 1.35;
-  color: var(--text-primary);
+  color: var(--color-fg-primary);
   text-wrap: pretty;
 }
 
 .wk-kcard.done .wk-kcard-title {
-  color: var(--text-mid);
+  color: var(--color-fg-muted);
 }
 
 .wk-kcard-block {
-  font-size: 10.5px;
-  color: var(--status-bad);
+  font-size: var(--text-2xs);
+  color: var(--color-status-err);
 }
 
-.wk-kcard-goal {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  text-align: left;
-  font-size: 10.5px;
-  color: var(--text-dim);
-  background: none;
-  border: 0;
-  padding: 0;
-  cursor: pointer;
+.wk-kcard-desc {
+  font-size: var(--text-2xs);
+  color: var(--color-fg-secondary);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  transition: color 0.14s ease;
-}
-
-.wk-kcard-goal:hover {
-  color: var(--volt-strong);
-}
-
-.wk-kcard-ho {
-  color: var(--volt-strong);
-  font-size: 12px;
 }
 
 .wk-kcard-foot {
   display: flex;
+  justify-content: flex-end;
   align-items: center;
-  gap: 7px;
+  margin-top: 0.125rem;
 }
 
 .wk-kcard-kp {
@@ -1491,7 +1468,8 @@
 }
 
 .wk-kcard-kp.none {
-  color: var(--text-faint);
+  font-size: var(--text-3xs);
+  color: var(--color-fg-disabled);
   cursor: default;
 }
 
@@ -1499,22 +1477,21 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--font-ui);
-  font-size: 15px;
+  font-size: var(--text-sm);
   line-height: 1;
-  width: 22px;
-  height: 22px;
+  width: 1.5rem;
+  height: 1.5rem;
   border-radius: 50%;
-  border: 1px solid var(--volt-dim);
-  background: var(--volt-wash);
-  color: var(--volt-strong);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-secondary);
   cursor: pointer;
   transition: 0.14s;
 }
 
 .wk-kcard-claim:hover {
-  background: color-mix(in oklab, var(--volt) 20%, transparent);
-  color: var(--text-bright);
+  border-color: var(--color-border-strong);
+  color: var(--color-fg-primary);
 }
 
 .wk-head .ov-eyebrow {

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -1446,45 +1446,6 @@
   color: var(--color-fg-secondary);
 }
 
-.wk-goal-create-keepers {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.375rem;
-}
-
-.wk-keeper-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.25rem 0.5rem;
-  border-radius: var(--r-1);
-  border: 1px solid var(--color-border-default);
-  background: var(--color-bg-elevated);
-  color: var(--color-fg-muted);
-  font-size: var(--text-3xs);
-  cursor: pointer;
-  transition: border-color 120ms ease, box-shadow 120ms ease;
-}
-
-.wk-keeper-chip.on {
-  border-color: var(--color-accent-fg);
-  box-shadow: 0 0 0 1px var(--color-accent-fg);
-  color: var(--color-fg-primary);
-}
-
-.wk-keeper-avatar-none {
-  width: 1.25rem;
-  height: 1.25rem;
-  border-radius: 9999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--color-bg-page);
-  border: 1px solid var(--color-border-default);
-  font-size: var(--text-3xs);
-  color: var(--color-fg-muted);
-}
-
 /* ── Kanban board ────────────────────────────────────────────────────────── */
 
 .wk-kanban {

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -1569,6 +1569,9 @@
 .wk-kcard-prio.prio-1 { border-color: var(--color-err-border); background: var(--color-err-soft); color: var(--color-err-fg); }
 .wk-kcard-prio.prio-2 { border-color: var(--color-warn-border); background: var(--color-warn-soft); color: var(--color-warn-fg); }
 .wk-kcard-prio.prio-3 { border-color: var(--color-info-border); background: var(--color-info-soft); color: var(--color-info-fg); }
+/* P4 and P5 share the muted base style defined on .wk-kcard-prio. */
+.wk-kcard-prio.prio-4,
+.wk-kcard-prio.prio-5 { }
 
 .wk-kcard-title {
   font-size: var(--text-sm);

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -1298,6 +1298,104 @@
   }
 }
 
+/* ── Goal create side panel ──────────────────────────────────────────────── */
+
+.ov-with-panel .ov-aside {
+  display: none;
+}
+
+.wk-goal-create-panel {
+  width: 22rem;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--color-border-default);
+  background: var(--color-bg-surface);
+  overflow-y: auto;
+}
+
+.wk-goal-create-hd {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.wk-goal-create-eyebrow {
+  font-size: var(--text-3xs);
+  font-weight: 600;
+  letter-spacing: var(--track-section);
+  text-transform: lowercase;
+  color: var(--color-fg-muted);
+}
+
+.wk-goal-create-hd h3 {
+  margin-top: 0.25rem;
+  font-size: var(--text-base);
+  font-weight: 700;
+  color: var(--color-fg-primary);
+}
+
+.wk-goal-create-close {
+  border: none;
+  background: transparent;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  font-size: var(--text-sm);
+}
+
+.wk-goal-create-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.wk-goal-create-sec {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.wk-goal-create-label {
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  color: var(--color-fg-muted);
+}
+
+.wk-goal-create-req {
+  margin-left: 0.125rem;
+  color: var(--color-status-err);
+}
+
+.wk-goal-create-hint {
+  font-size: var(--text-3xs);
+  color: var(--color-fg-muted);
+}
+
+.wk-goal-create-err {
+  font-size: var(--text-2xs);
+  color: var(--color-status-err);
+}
+
+.wk-goal-create-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--text-sm);
+  color: var(--color-fg-primary);
+  cursor: pointer;
+}
+
+.wk-goal-create-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: auto;
+}
+
 /* ── Kanban board ────────────────────────────────────────────────────────── */
 
 .wk-kanban {

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -1396,6 +1396,95 @@
   margin-top: auto;
 }
 
+.wk-goal-create-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.wk-chip {
+  padding: 0.375rem 0.75rem;
+  border-radius: var(--r-1);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-muted);
+  font-size: var(--text-2xs);
+  cursor: pointer;
+  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
+}
+
+.wk-chip.on {
+  border-color: var(--color-accent-fg);
+  background: var(--color-brass-soft);
+  color: var(--color-accent-fg);
+}
+
+.wk-goal-create-range {
+  width: 100%;
+  margin-top: 0.25rem;
+  accent-color: var(--color-accent-fg);
+}
+
+.wk-goal-create-risk {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--r-0);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+}
+
+.wk-goal-create-risk-level {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-status-ok);
+}
+
+.wk-goal-create-risk-desc {
+  font-size: var(--text-xs);
+  color: var(--color-fg-secondary);
+}
+
+.wk-goal-create-keepers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.wk-keeper-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--r-1);
+  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-muted);
+  font-size: var(--text-3xs);
+  cursor: pointer;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.wk-keeper-chip.on {
+  border-color: var(--color-accent-fg);
+  box-shadow: 0 0 0 1px var(--color-accent-fg);
+  color: var(--color-fg-primary);
+}
+
+.wk-keeper-avatar-none {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-page);
+  border: 1px solid var(--color-border-default);
+  font-size: var(--text-3xs);
+  color: var(--color-fg-muted);
+}
+
 /* ── Kanban board ────────────────────────────────────────────────────────── */
 
 .wk-kanban {

--- a/dashboard/src/styles/work-v2.css
+++ b/dashboard/src/styles/work-v2.css
@@ -40,42 +40,6 @@
   width: 100%;
 }
 
-.wk-head {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 20px;
-}
-
-.wk-head h1 {
-  font-family: var(--font-display);
-  font-weight: 500;
-  font-size: 22px;
-  color: var(--text-bright);
-  margin: 0;
-}
-
-.wk-eyebrow {
-  display: inline-block;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: var(--text-dim);
-  margin-bottom: 8px;
-}
-
-.wk-sub {
-  margin-top: 6px;
-  font-size: 12px;
-  color: var(--text-dim);
-}
-
-.wk-sub .mono {
-  color: var(--text-mid);
-}
-
 /* ── KPI strip ────────────────────────────────────────────────────────────── */
 .wk-kpis {
   display: grid;
@@ -668,14 +632,18 @@
 
 /* ── Footer / new goal button ─────────────────────────────────────────────── */
 .wk-newgoal {
-  width: auto;
-  margin: 0;
-  flex: none;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  align-self: center;
+  gap: 0.25rem;
+  padding: 0.5rem 0.875rem;
+  border-radius: var(--r-1);
+  border: 1px solid var(--color-brass-border);
+  background: var(--color-accent-fg);
+  color: var(--color-bg-page);
+  font-size: var(--text-xs);
+  font-weight: 600;
   white-space: nowrap;
+  cursor: pointer;
 }
 
 .wk-foot {
@@ -697,7 +665,8 @@
     grid-template-columns: repeat(2, 1fr);
   }
 
-  .wk-head {
+  .ov-head.wk-head,
+  .wk-head-r {
     flex-direction: column;
     align-items: flex-start;
   }
@@ -1267,33 +1236,24 @@
 
 .wk-viewseg {
   display: inline-flex;
-  border: 1px solid var(--border-main);
-  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-pill, 999px);
   overflow: hidden;
+  background: var(--color-bg-elevated);
 }
 
 .wk-viewseg button {
-  font-family: var(--font-ui);
-  font-size: 12px;
-  padding: 6px 14px;
-  background: var(--bg-sunken);
-  color: var(--text-dim);
-  border: 0;
+  padding: 0.375rem 0.75rem;
+  font-size: var(--text-2xs);
+  color: var(--color-fg-muted);
+  background: transparent;
+  border: none;
   cursor: pointer;
-  transition: 0.14s;
-}
-
-.wk-viewseg button + button {
-  border-left: 1px solid var(--border-main);
-}
-
-.wk-viewseg button:hover {
-  color: var(--text-bright);
 }
 
 .wk-viewseg button.on {
-  background: var(--volt-wash);
-  color: var(--volt-strong);
+  background: var(--color-accent-fg);
+  color: var(--color-bg-page);
 }
 
 /* ── Kanban board ────────────────────────────────────────────────────────── */
@@ -1513,4 +1473,25 @@
 .wk-kcard-claim:hover {
   background: color-mix(in oklab, var(--volt) 20%, transparent);
   color: var(--text-bright);
+}
+
+.wk-head .ov-eyebrow {
+  font-size: var(--text-3xs);
+  font-weight: 600;
+  letter-spacing: var(--track-section);
+  text-transform: uppercase;
+  color: var(--color-accent-fg);
+}
+
+.wk-head h1 {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--color-fg-primary);
+  margin-top: 0.25rem;
+}
+
+.wk-head .ov-sub {
+  font-size: var(--text-xs);
+  color: var(--color-fg-muted);
+  margin-top: 0.25rem;
 }


### PR DESCRIPTION
## Summary

MASC 대시보드 Goal/Task 영역을 Keeper v2 프로토타입에 맞춰 픽셀 퍼펙트로 재구현합니다. 칸반과 호라이즌(단기/중기/장기) 분리는 의미가 없으므로 제거하고, 목표는 단일 플랫 리스트로 표시합니다.

## Changes

- `WorkSurfaceV2` 헤더, 5개 KPI 카드, Kanban/List 카드 스타일 재구현
- 목표를 우선순위 기반 단일 리스트로 렌더링 (horizon 그룹핑 제거)
- `GoalCreateForm`을 중앙 모달에서 우측 사이드 패널로 변경; 패널 열림 시 `WorkAside` 숨김
- 사이드 패널에 horizon 칩, 우선순위 슬라이더, 예상 위험도, 리드 keeper 아바타 그리드 추가
- backend 스키마 추가 전까지 `horizon` / `lead_keeper` 필드는 UI에만 저장 (payload에서는 제외)
- `work.test.ts` 업데이트, `goal-create-form.test.ts` 신규 작성

## Verification

- `npx tsc --noEmit --pretty` ✅
- `npx vitest run src/components/work.test.ts src/components/goals/goal-create-form.test.ts` 46/46 ✅
- `npx vitest run` 전체 대시보드 테스트 ✅