### PR TITLE
feat(keeper): graceful media-degrade floor for unsupported input modality (RFC-0265 follow-up)

### DIFF
--- a/docs/rfc/RFC-keeper-media-degrade-floor.md
+++ b/docs/rfc/RFC-keeper-media-degrade-floor.md
@@ -1,0 +1,109 @@
+# RFC: Keeper media-degrade floor (graceful drop at the RFC-0265 reroute floor)
+
+- Status: Draft
+- Author: vincent (+ Claude Opus 4.8)
+- Created: 2026-06-25
+- Builds on: RFC-0265 (capability-driven proactive runtime reroute) — this is its follow-up
+- Related: RFC-0037 (board multimedia/vision), RFC-0126/0145 (silent-fallback discipline)
+- Implementation: this PR (`lib/runtime/runtime_agent.{ml,mli}`, `lib/keeper/keeper_turn_driver.ml`, `test/test_runtime_modality_reroute.ml`)
+
+## 1. Summary
+
+RFC-0265 routes a media turn whose modality the assigned runtime cannot accept to
+a capable runtime, and when **no** configured runtime qualifies it keeps the
+assigned runtime so the loud capability gate in `Runtime_agent.run_blocks`
+**terminally rejects** the turn (`No_capable_runtime` → floor). The reject is
+correct (fail-closed before a provider 400) but terminal: the keeper turn dies,
+and a keeper that keeps re-attempting an image-bearing turn parks in
+`pause_human`.
+
+This RFC changes only the **floor**: at `No_capable_runtime`, instead of letting
+the turn die, strip the unsupported media blocks from the dispatch view (current
+goal + prior `initial_messages` + resumed checkpoint), inject one operator-visible
+note, and proceed on text. Reroute and modality-satisfied turns are untouched.
+MASC-side only; no OAS change.
+
+## 2. Problem
+
+Keeper `sangsu` was routed to text-only models (`devstral-small-2:24b` via
+`glm-coding`/`ollama_cloud`) and received image input. The RFC-0265 floor would
+reject the turn terminally; observed live, the keeper recorded
+`api_error_invalid_request` / `operator_disposition: pause_human` repeatedly
+(`<base-path>/.masc/keepers/sangsu/execution-receipts/2026-06/{20,23}.jsonl`). For an
+autonomous keeper, a paused turn on a recurring history-borne image is worse than
+a degraded text turn: the keeper makes no progress until a human intervenes.
+
+The operator's intent (selected for this change) is **keeper liveness over media
+fidelity**: drop the image, tell the model it was dropped, keep going.
+
+## 3. Design
+
+On the keeper dispatch seam (`keeper_turn_driver.run_named`), the RFC-0265 reroute
+decision is computed once. When it is `No_capable_runtime`:
+
+1. Resolve the assigned runtime's effective input caps via the existing
+   `Runtime_agent.input_capabilities_of_runtime` (the resolved `Runtime.t`, not a
+   re-derivation from `config` — reliable).
+2. `strip_unsupported_modality_blocks` / `strip_unsupported_modality_messages`
+   drop the top-level `Image`/`Document`/`Audio` blocks the caps do not admit from
+   the current goal, `initial_messages`, and the resumed `oas_checkpoint.messages`,
+   keeping text/thinking/tool blocks and reporting a per-modality drop count.
+3. If anything was dropped, inject one `Text` note (`media_degrade_note`) into the
+   goal and emit a `WARN` log. The turn then dispatches on text and the capability
+   gate admits it (no media remains).
+
+The strip and note builders are pure functions in `runtime_agent` (unit-tested).
+The drop is **non-silent** (RFC-0126/0145): a structured WARN at the dispatch site
+plus the injected note the model and the keeper-chat surface both see.
+
+The stripped checkpoint is the **dispatch view only** — the persisted checkpoint is
+not rewritten, so if the keeper is later routed to a vision-capable runtime the
+original media is still in history.
+
+## 4. Trade-off (vs the RFC-0265 fail-closed floor)
+
+| | RFC-0265 floor | This RFC |
+|--|----------------|----------|
+| No capable runtime | terminal reject (turn dies) | drop media + note, proceed on text |
+| Operator visibility | error surfaced to operator | WARN log + in-context note |
+| Media fidelity | preserved (nothing dispatched) | image omitted this turn (recoverable from history) |
+| Keeper liveness | can park in `pause_human` | continues |
+
+Reroute still takes precedence: when a vision-capable runtime is configured (and
+its `[models.*.capabilities]` declares `supports-image-input`, RFC-0265 §4.1), the
+turn reroutes there and is **not** degraded. Degrade fires only at the floor where
+RFC-0265 would otherwise hard-reject.
+
+## 5. Non-goals / deferred
+
+- **ToolResult-nested media** is not stripped (rare; a tool returning an image).
+  The strip is a total function over the leaf media blocks an operator attaches;
+  nested media still meets the existing capability-gate floor.
+- **Gate config-resolution fail-open.** `Runtime_agent.input_capabilities_for_config`
+  returns raw provider caps when `runtime_id_of_config config` does not resolve
+  (`None -> caps`). For keeper turns this is harmless — `config.description` carries
+  the `runtime:<id>/runtime` marker (`keeper_turn_driver_try_provider.ml`) so the
+  gate resolves the model caps — and this RFC's degrade strips media before
+  dispatch via the **reroute** path (which resolves the runtime directly), so it
+  does not depend on the gate. Making the gate use the resolved caps for every
+  caller (so an unregistered-runtime config cannot fail-open) is a separate change
+  and is intentionally out of scope here (a naive fail-closed default over-blocks
+  non-keeper `run_blocks` callers that legitimately support media via provider
+  caps — verified against `test_gate_keeper_backend`).
+- **Output-modality** (image generation) — out of scope, as in RFC-0265.
+
+## 6. Tests
+
+`test/test_runtime_modality_reroute.ml` adds a `media_degrade` group (5 cases):
+strip drops an unsupported image, strip keeps a supported image on a vision
+runtime, message-level strip removes history media while retaining the message,
+and `media_degrade_note` returns `Some` with the count when media dropped and
+`None` when nothing dropped (including all-zero counts). The existing RFC-0265
+reroute suite and the `test_gate_keeper_backend` gate suite are unchanged and
+green.
+
+## 7. Migration
+
+Zero. With no capable runtime configured the previous behavior was a terminal
+reject; this replaces only that terminal path with a degraded text turn. Reroute,
+modality-satisfied turns, and text-only turns are byte-for-byte unchanged.

--- a/docs/rfc/RFC-keeper-media-degrade-floor.md
+++ b/docs/rfc/RFC-keeper-media-degrade-floor.md
@@ -19,9 +19,10 @@ and a keeper that keeps re-attempting an image-bearing turn parks in
 
 This RFC changes only the **floor**: at `No_capable_runtime`, instead of letting
 the turn die, strip the unsupported media blocks from the dispatch view (current
-goal + prior `initial_messages` + resumed checkpoint), inject one operator-visible
-note, and proceed on text. Reroute and modality-satisfied turns are untouched.
-MASC-side only; no OAS change.
+goal + prior `initial_messages` + resumed checkpoint), emit a degraded
+`Runtime_routed` manifest row, inject one model-input notice, and proceed on
+text. Reroute and modality-satisfied turns are untouched. MASC-side only; no OAS
+change.
 
 ## 2. Problem
 
@@ -48,13 +49,15 @@ decision is computed once. When it is `No_capable_runtime`:
    drop the top-level `Image`/`Document`/`Audio` blocks the caps do not admit from
    the current goal, `initial_messages`, and the resumed `oas_checkpoint.messages`,
    keeping text/thinking/tool blocks and reporting a per-modality drop count.
-3. If anything was dropped, inject one `Text` note (`media_degrade_note`) into the
-   goal and emit a `WARN` log. The turn then dispatches on text and the capability
-   gate admits it (no media remains).
+3. If anything was dropped, append a `Runtime_routed` manifest row with
+   `status="degraded"` and redacted drop counts, inject one `Text` note
+   (`media_degrade_note`) into the goal, and emit a `WARN` log. The turn then
+   dispatches on text and the capability gate admits it (no media remains).
 
 The strip and note builders are pure functions in `runtime_agent` (unit-tested).
-The drop is **non-silent** (RFC-0126/0145): a structured WARN at the dispatch site
-plus the injected note the model and the keeper-chat surface both see.
+The drop is **non-silent** (RFC-0126/0145): a degraded runtime-manifest row for
+the dashboard trace, a structured WARN at the dispatch site, and the injected
+note in the model input.
 
 The stripped checkpoint is the **dispatch view only** — the persisted checkpoint is
 not rewritten, so if the keeper is later routed to a vision-capable runtime the
@@ -65,7 +68,7 @@ original media is still in history.
 | | RFC-0265 floor | This RFC |
 |--|----------------|----------|
 | No capable runtime | terminal reject (turn dies) | drop media + note, proceed on text |
-| Operator visibility | error surfaced to operator | WARN log + in-context note |
+| Operator visibility | error surfaced to operator | degraded runtime manifest + WARN log + in-context note |
 | Media fidelity | preserved (nothing dispatched) | image omitted this turn (recoverable from history) |
 | Keeper liveness | can park in `pause_human` | continues |
 
@@ -94,13 +97,15 @@ RFC-0265 would otherwise hard-reject.
 
 ## 6. Tests
 
-`test/test_runtime_modality_reroute.ml` adds a `media_degrade` group (5 cases):
+`test/test_runtime_modality_reroute.ml` adds a `media_degrade` group:
 strip drops an unsupported image, strip keeps a supported image on a vision
 runtime, message-level strip removes history media while retaining the message,
 and `media_degrade_note` returns `Some` with the count when media dropped and
-`None` when nothing dropped (including all-zero counts). The existing RFC-0265
-reroute suite and the `test_gate_keeper_backend` gate suite are unchanged and
-green.
+`None` when nothing dropped (including all-zero counts). It also pins the public
+runtime-manifest projection for the degraded row and a source-level wiring guard
+that the dispatch branch emits `Runtime_routed status=degraded`. The existing
+RFC-0265 reroute suite and the `test_gate_keeper_backend` gate suite are
+unchanged.
 
 ## 7. Migration
 

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -356,6 +356,8 @@ let decision_public_allowlist =
     ; "liveness_mode"; "liveness_budget_source"
     ; "context_compact_started_count"; "context_compacted_count"
     ; "last_compaction"; "active_open_loop_count"
+    ; "routing_action"; "routing_reason"; "degraded_runtime_id"
+    ; "media_dropped_total"; "media_dropped_counts"
     ; "clock_refs"
     ]
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -147,14 +147,15 @@ let run_named
     | None -> []
     | Some (checkpoint : Agent_sdk.Checkpoint.t) -> checkpoint.messages
   in
+  let reroute_decision =
+    Runtime_agent.decide_modality_reroute_for_runtime
+      ~assigned:assigned_runtime
+      ~checkpoint_messages
+      ~initial_messages
+      current_goal_blocks
+  in
   let runtime_id, runtime =
-    match
-      Runtime_agent.decide_modality_reroute_for_runtime
-        ~assigned:assigned_runtime
-        ~checkpoint_messages
-        ~initial_messages
-        current_goal_blocks
-    with
+    match reroute_decision with
     | Runtime_agent.No_reroute_needed | Runtime_agent.No_capable_runtime _ ->
       runtime_id, assigned_runtime
     | Runtime_agent.Reroute { to_runtime_id; reason } ->
@@ -168,6 +169,63 @@ let run_named
            to_runtime_id
            reason;
          to_runtime_id, rerouted)
+  in
+  (* RFC-0265 follow-up — graceful media degrade floor. When no configured
+     runtime can accept the turn's input modality ([No_capable_runtime]), strip
+     the unsupported media blocks from the goal, prior [initial_messages], and
+     resumed checkpoint, then inject an operator-visible note so the turn runs
+     on text instead of the loud terminal reject in [Runtime_agent.run_blocks].
+     Modality-satisfied turns and reroutes are untouched. The drop is non-silent
+     (WARN log + injected note — RFC-0126/0145). The stripped checkpoint is the
+     dispatch view only; the persisted checkpoint is unchanged, so a later
+     vision-capable runtime still sees the original media. *)
+  let goal_blocks, initial_messages, oas_checkpoint =
+    match reroute_decision with
+    | Runtime_agent.No_capable_runtime _ ->
+      let caps = Runtime_agent.input_capabilities_of_runtime runtime in
+      let stripped_goal, goal_dropped =
+        Runtime_agent.strip_unsupported_modality_blocks caps current_goal_blocks
+      in
+      let stripped_initial, initial_dropped =
+        Runtime_agent.strip_unsupported_modality_messages caps initial_messages
+      in
+      let stripped_checkpoint, checkpoint_dropped =
+        match oas_checkpoint with
+        | None -> None, []
+        | Some (checkpoint : Agent_sdk.Checkpoint.t) ->
+          let messages, dropped =
+            Runtime_agent.strip_unsupported_modality_messages
+              caps
+              checkpoint.messages
+          in
+          Some { checkpoint with messages }, dropped
+      in
+      let dropped =
+        Runtime_agent.merge_modality_counts
+          (Runtime_agent.merge_modality_counts goal_dropped initial_dropped)
+          checkpoint_dropped
+      in
+      (match Runtime_agent.media_degrade_note ~runtime_id dropped with
+       | None ->
+         (* Nothing strippable (e.g. only ToolResult-nested media): keep the
+            inputs unchanged so the loud capability floor still applies. *)
+         goal_blocks, initial_messages, oas_checkpoint
+       | Some note ->
+         Log.Keeper.warn
+           "%s: RFC-0265 media degrade on %s — dropped %s, continuing text-only"
+           keeper_name
+           runtime_id
+           (String.concat
+              ","
+              (List.map
+                 (fun (modality, n) -> Printf.sprintf "%s=%d" modality n)
+                 dropped));
+         let goal_with_note =
+           stripped_goal @ [ Agent_sdk.Types.text_block note ]
+         in
+         Some goal_with_note, stripped_initial, stripped_checkpoint)
+    | Runtime_agent.No_reroute_needed | Runtime_agent.Reroute _ ->
+      goal_blocks, initial_messages, oas_checkpoint
   in
   let error_runtime_id = runtime_id in
   let candidate =

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -38,6 +38,38 @@ let provider_config_identity_key =
 
 let runtime_candidates_of_providers =
   Keeper_turn_driver_admission.runtime_candidates_of_providers
+
+let positive_modality_counts counts =
+  counts
+  |> List.filter (fun (_, n) -> n > 0)
+  |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+
+let modality_counts_summary counts =
+  counts
+  |> positive_modality_counts
+  |> List.map (fun (modality, n) -> Printf.sprintf "%s=%d" modality n)
+  |> String.concat ","
+
+let modality_counts_total counts =
+  counts
+  |> positive_modality_counts
+  |> List.fold_left (fun acc (_, n) -> acc + n) 0
+
+let media_degrade_manifest_decision ~(runtime_id : string)
+    (dropped : (string * int) list) =
+  let summary = modality_counts_summary dropped in
+  Keeper_runtime_manifest.with_payload_role
+    ~payload_role:Keeper_runtime_manifest.Operator_evidence
+    (`Assoc
+      [
+        ("routing_action", `String "media_degraded_to_text");
+        ( "routing_reason",
+          `String "no_configured_runtime_accepts_required_media" );
+        ("degraded_runtime_id", `String runtime_id);
+        ("media_dropped_total", `Int (modality_counts_total dropped));
+        ("media_dropped_counts", `String summary);
+      ])
+
 let run_named
     ~runtime_id
     ?(keeper_name = "")
@@ -111,6 +143,43 @@ let run_named
      [?wait_timeout_sec] parameters only fed the deleted multi-candidate
      machinery and were silently ignored here; they are removed from the
      signature so callers cannot pass dead routing knobs. *)
+  let turn_start = Mtime_clock.now () in
+  let seq_ref = ref 0 in
+  let emit_runtime_manifest ?status ?decision event =
+    match runtime_manifest_context, runtime_manifest_append with
+    | Some manifest_ctx, Some append ->
+      let decision =
+        match decision with
+        | None -> Some (`Assoc [])
+        | Some (`Assoc _) as d -> d
+        | Some other -> Some (`Assoc [ ("decision", other) ])
+      in
+      seq_ref := !seq_ref + 1;
+      let elapsed_ms =
+        let ns =
+          Mtime.Span.to_uint64_ns
+            (Mtime.span turn_start (Mtime_clock.now ()))
+        in
+        Some (Int64.to_int (Int64.div ns 1_000_000L))
+      in
+      let decision =
+        let decision =
+          match decision with
+          | Some value -> value
+          | None -> `Assoc []
+        in
+        Some
+          (Keeper_runtime_manifest.with_clock_refs
+             ~clock_refs:
+               (Keeper_runtime_manifest.clock_refs_for_context manifest_ctx
+                  ~event ?elapsed_ms ~logical_seq:!seq_ref ())
+             decision)
+      in
+      Keeper_runtime_manifest.make_for_context manifest_ctx ~event
+        ~runtime_id ?logical_seq:(Some !seq_ref) ?status ?decision ()
+      |> append
+    | _ -> ()
+  in
   (* RFC-0207: dispatch to the *requested* runtime (a keeper's persona [model]
      selection or the global default, both produced by [runtime_id_of_meta])
      instead of unconditionally the default.  A requested id that does not
@@ -173,12 +242,13 @@ let run_named
   (* RFC-0265 follow-up — graceful media degrade floor. When no configured
      runtime can accept the turn's input modality ([No_capable_runtime]), strip
      the unsupported media blocks from the goal, prior [initial_messages], and
-     resumed checkpoint, then inject an operator-visible note so the turn runs
-     on text instead of the loud terminal reject in [Runtime_agent.run_blocks].
-     Modality-satisfied turns and reroutes are untouched. The drop is non-silent
-     (WARN log + injected note — RFC-0126/0145). The stripped checkpoint is the
-     dispatch view only; the persisted checkpoint is unchanged, so a later
-     vision-capable runtime still sees the original media. *)
+     resumed checkpoint, then append a degraded [Runtime_routed] manifest row
+     and inject a text notice so the turn runs on text instead of the loud
+     terminal reject in [Runtime_agent.run_blocks]. Modality-satisfied turns and
+     reroutes are untouched. The drop is non-silent (WARN log + runtime manifest
+     row + injected model-input notice — RFC-0126/0145). The stripped checkpoint
+     is the dispatch view only; the persisted checkpoint is unchanged, so a
+     later vision-capable runtime still sees the original media. *)
   let goal_blocks, initial_messages, oas_checkpoint =
     match reroute_decision with
     | Runtime_agent.No_capable_runtime _ ->
@@ -215,11 +285,11 @@ let run_named
            "%s: RFC-0265 media degrade on %s — dropped %s, continuing text-only"
            keeper_name
            runtime_id
-           (String.concat
-              ","
-              (List.map
-                 (fun (modality, n) -> Printf.sprintf "%s=%d" modality n)
-                 dropped));
+           (modality_counts_summary dropped);
+         emit_runtime_manifest
+           ~status:"degraded"
+           ~decision:(media_degrade_manifest_decision ~runtime_id dropped)
+           Keeper_runtime_manifest.Runtime_routed;
          let goal_with_note =
            stripped_goal @ [ Agent_sdk.Types.text_block note ]
          in
@@ -239,8 +309,6 @@ let run_named
     | Some t -> t
     | None -> Masc_grpc_transport.from_env ()
   in
-  let turn_start = Mtime_clock.now () in
-  let seq_ref = ref 0 in
   (* RFC-0206: execution_idle_timeout is intentionally not forwarded on the
      keeper path until OAS proves active tool execution is excluded from idle
      accounting. Passing [None] keeps the previous behavior without exposing a
@@ -321,6 +389,8 @@ module For_testing = struct
 
   let sdk_error_of_nonretryable_attempt_error =
     Keeper_turn_driver_try_runtime.sdk_error_of_nonretryable_attempt_error
+
+  let media_degrade_manifest_decision = media_degrade_manifest_decision
 
   let accept_no_progress_read_only_should_try_next =
     Keeper_turn_driver_try_runtime.For_testing

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -175,6 +175,9 @@ module For_testing : sig
     Llm_provider.Http_client.http_error ->
     Agent_sdk.Error.sdk_error
 
+  val media_degrade_manifest_decision :
+    runtime_id:string -> (string * int) list -> Yojson.Safe.t
+
   val accept_no_progress_read_only_should_try_next :
     Agent_sdk.Error.sdk_error -> bool
 end

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -472,6 +472,83 @@ let caps_admit_required_modalities
   List.for_all (supports_required_modality caps) required
   && (List.length required <= 1 || supports_multimodal_bundle caps)
 
+(* RFC-0265 follow-up — graceful media degrade. When no configured runtime can
+   accept a turn's input modality (the reroute floor [No_capable_runtime]),
+   instead of the loud terminal reject the caller strips the unsupported media
+   blocks and proceeds on text. These helpers are the pure block/message
+   filters: drop the top-level [Image]/[Document]/[Audio] blocks whose modality
+   [caps] does not admit, keep everything else, and report a per-modality drop
+   count for the caller's operator-visible note. ToolResult-nested media is
+   left intact (rare; the capability gate floor still applies), keeping the
+   strip a total function over the leaf media blocks an operator attaches. *)
+let block_required_modality (block : Agent_sdk.Types.content_block) =
+  match block with
+  | Agent_sdk.Types.Image _ -> Some "image"
+  | Agent_sdk.Types.Document _ -> Some "document"
+  | Agent_sdk.Types.Audio _ -> Some "audio"
+  | _ -> None
+
+let bump_modality_count modality counts =
+  let prev = match List.assoc_opt modality counts with Some n -> n | None -> 0 in
+  (modality, prev + 1) :: List.remove_assoc modality counts
+
+let merge_modality_counts a b =
+  List.fold_left
+    (fun acc (modality, n) ->
+       let prev =
+         match List.assoc_opt modality acc with Some x -> x | None -> 0
+       in
+       (modality, prev + n) :: List.remove_assoc modality acc)
+    a
+    b
+
+let strip_unsupported_modality_blocks
+    (caps : Llm_provider.Capabilities.capabilities)
+    (blocks : Agent_sdk.Types.content_block list) :
+    Agent_sdk.Types.content_block list * (string * int) list =
+  let kept, dropped =
+    List.fold_left
+      (fun (kept, dropped) block ->
+         match block_required_modality block with
+         | Some modality when not (supports_required_modality caps modality) ->
+             (kept, bump_modality_count modality dropped)
+         | _ -> (block :: kept, dropped))
+      ([], [])
+      blocks
+  in
+  (List.rev kept, dropped)
+
+let strip_unsupported_modality_messages
+    (caps : Llm_provider.Capabilities.capabilities)
+    (messages : Agent_sdk.Types.message list) :
+    Agent_sdk.Types.message list * (string * int) list =
+  let kept, dropped =
+    List.fold_left
+      (fun (acc, dropped) (message : Agent_sdk.Types.message) ->
+         let content, d =
+           strip_unsupported_modality_blocks caps message.content
+         in
+         ({ message with content } :: acc, merge_modality_counts dropped d))
+      ([], [])
+      messages
+  in
+  (List.rev kept, dropped)
+
+(* Operator-visible note injected into a degraded turn so the omitted media is
+   non-silent (RFC-0126/0145): the model and the keeper-chat surface see that
+   input was dropped rather than vanishing. [None] when nothing was dropped. *)
+let media_degrade_note ~(runtime_id : string) (dropped : (string * int) list) :
+    string option =
+  match List.fold_left (fun acc (_, n) -> acc + n) 0 dropped with
+  | 0 -> None
+  | total ->
+      Some
+        (Printf.sprintf
+           "[첨부된 미디어 입력 %d건이 생략되었습니다: 현재 런타임(%s)이 이미지/문서/오디오 \
+            입력을 지원하지 않아 텍스트만 전달합니다.]"
+           total
+           runtime_id)
+
 let validate_content_blocks_against_capabilities
     ~(provider_label : string)
     (caps : Llm_provider.Capabilities.capabilities)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -478,7 +478,7 @@ let caps_admit_required_modalities
    blocks and proceeds on text. These helpers are the pure block/message
    filters: drop the top-level [Image]/[Document]/[Audio] blocks whose modality
    [caps] does not admit, keep everything else, and report a per-modality drop
-   count for the caller's operator-visible note. ToolResult-nested media is
+   count for the caller's non-silent degrade reporting. ToolResult-nested media is
    left intact (rare; the capability gate floor still applies), keeping the
    strip a total function over the leaf media blocks an operator attaches. *)
 let block_required_modality (block : Agent_sdk.Types.content_block) =
@@ -534,9 +534,9 @@ let strip_unsupported_modality_messages
   in
   (List.rev kept, dropped)
 
-(* Operator-visible note injected into a degraded turn so the omitted media is
-   non-silent (RFC-0126/0145): the model and the keeper-chat surface see that
-   input was dropped rather than vanishing. [None] when nothing was dropped. *)
+(* Notice text injected into a degraded turn so the model input records that media
+   was dropped rather than vanishing. The keeper dispatch path owns the
+   operator-visible runtime-manifest row. [None] when nothing was dropped. *)
 let media_degrade_note ~(runtime_id : string) (dropped : (string * int) list) :
     string option =
   match List.fold_left (fun acc (_, n) -> acc + n) 0 dropped with

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -242,6 +242,31 @@ val decide_modality_reroute_for_runtime :
     content blocks. Composes [input_capabilities_of_runtime] /
     [media_reroute_candidates] / [decide_modality_reroute]. *)
 
+val strip_unsupported_modality_blocks :
+  Llm_provider.Capabilities.capabilities ->
+  Agent_sdk.Types.content_block list ->
+  Agent_sdk.Types.content_block list * (string * int) list
+(** RFC-0265 follow-up media degrade. Drop the top-level [Image]/[Document]/[Audio]
+    blocks whose modality [caps] does not admit; keep text/thinking/tool blocks.
+    Returns the kept blocks and a per-modality drop count. ToolResult-nested media
+    is left intact (the capability gate floor still applies to it). *)
+
+val strip_unsupported_modality_messages :
+  Llm_provider.Capabilities.capabilities ->
+  Agent_sdk.Types.message list ->
+  Agent_sdk.Types.message list * (string * int) list
+(** [strip_unsupported_modality_blocks] mapped over each message's content,
+    accumulating the per-modality drop count across the message list. *)
+
+val merge_modality_counts :
+  (string * int) list -> (string * int) list -> (string * int) list
+(** Sum two per-modality drop-count assoc lists. *)
+
+val media_degrade_note :
+  runtime_id:string -> (string * int) list -> string option
+(** Operator-visible note injected into a degraded turn so the omitted media is
+    non-silent (RFC-0126/0145). [None] when nothing was dropped. *)
+
 module For_testing : sig
   val request_runtime_fields_on_base_config :
     base:Llm_provider.Provider_config.t ->

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -264,8 +264,8 @@ val merge_modality_counts :
 
 val media_degrade_note :
   runtime_id:string -> (string * int) list -> string option
-(** Operator-visible note injected into a degraded turn so the omitted media is
-    non-silent (RFC-0126/0145). [None] when nothing was dropped. *)
+(** Notice text injected into a degraded turn so model input records that media
+    was dropped rather than vanishing. [None] when nothing was dropped. *)
 
 module For_testing : sig
   val request_runtime_fields_on_base_config :

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -216,6 +216,69 @@ let test_caps_admit_required_modalities () =
   check bool "empty required is always admitted" true
     (Runtime_agent.For_testing.caps_admit_required_modalities (caps ()) [])
 
+(* RFC-0265 follow-up — graceful media degrade. [strip_unsupported_modality_blocks]
+   drops the top-level image/audio/document blocks a text-only runtime cannot
+   accept and reports the per-modality drop count; text/tool blocks are retained. *)
+let dropped_count modality dropped =
+  match List.assoc_opt modality dropped with Some n -> n | None -> 0
+
+let test_strip_drops_unsupported_image () =
+  let blocks =
+    [ Agent_sdk.Types.Text "hello"
+    ; Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" ()
+    ]
+  in
+  let kept, dropped =
+    Runtime_agent.strip_unsupported_modality_blocks (caps ()) blocks
+  in
+  check int "only the text block is kept" 1 (List.length kept);
+  check int "one image dropped" 1 (dropped_count "image" dropped)
+
+let test_strip_keeps_supported_image () =
+  let blocks =
+    [ Agent_sdk.Types.Text "hi"
+    ; Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"abc" ()
+    ]
+  in
+  let kept, dropped =
+    Runtime_agent.strip_unsupported_modality_blocks (caps ~image:true ()) blocks
+  in
+  check int "both blocks kept on a vision runtime" 2 (List.length kept);
+  check int "nothing dropped" 0 (List.length dropped)
+
+let test_strip_messages_drops_history_image () =
+  let messages =
+    [ message_with_blocks
+        [ Agent_sdk.Types.Text "prev"
+        ; Agent_sdk.Types.image_block ~media_type:"image/png" ~data:"x" ()
+        ]
+    ]
+  in
+  let kept, dropped =
+    Runtime_agent.strip_unsupported_modality_messages (caps ()) messages
+  in
+  check int "the message is retained" 1 (List.length kept);
+  let msg : Agent_sdk.Types.message = List.hd kept in
+  check int "image stripped from message content" 1 (List.length msg.content);
+  check int "one image dropped" 1 (dropped_count "image" dropped)
+
+let test_degrade_note_some_when_dropped () =
+  match
+    Runtime_agent.media_degrade_note
+      ~runtime_id:"glm-coding.glm-5-turbo"
+      [ ("image", 2) ]
+  with
+  | None -> fail "expected a note when media was dropped"
+  | Some note ->
+      check_contains "names the runtime" ~needle:"glm-coding.glm-5-turbo" note;
+      check_contains "states the omission count" ~needle:"2" note
+
+let test_degrade_note_none_when_empty () =
+  check (option string) "no note when nothing dropped" None
+    (Runtime_agent.media_degrade_note ~runtime_id:"r" []);
+  check (option string) "no note when all counts zero" None
+    (Runtime_agent.media_degrade_note ~runtime_id:"r" [ ("image", 0) ])
+
 let () =
   run "rfc0265_modality_reroute"
     [ ( "decide_modality_reroute"
@@ -237,5 +300,17 @@ let () =
     ; ( "caps_admit_required_modalities"
       , [ test_case "multi-modality predicate" `Quick
             test_caps_admit_required_modalities
+        ] )
+    ; ( "media_degrade"
+      , [ test_case "strip drops unsupported image" `Quick
+            test_strip_drops_unsupported_image
+        ; test_case "strip keeps supported image" `Quick
+            test_strip_keeps_supported_image
+        ; test_case "strip messages drops history image" `Quick
+            test_strip_messages_drops_history_image
+        ; test_case "degrade note when dropped" `Quick
+            test_degrade_note_some_when_dropped
+        ; test_case "degrade note none when empty" `Quick
+            test_degrade_note_none_when_empty
         ] )
     ]

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -41,6 +41,12 @@ let string_contains haystack needle =
 let check_contains label ~needle haystack =
   check bool label true (string_contains haystack needle)
 
+let read_file path = In_channel.with_open_text path In_channel.input_all
+
+let assoc_field key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
 let message_with_blocks blocks =
   { Agent_sdk.Types.role = Agent_sdk.Types.User
   ; content = blocks
@@ -279,6 +285,51 @@ let test_degrade_note_none_when_empty () =
   check (option string) "no note when all counts zero" None
     (Runtime_agent.media_degrade_note ~runtime_id:"r" [ ("image", 0) ])
 
+let test_degrade_manifest_public_projection () =
+  let decision =
+    Keeper_turn_driver.For_testing.media_degrade_manifest_decision
+      ~runtime_id:"text-runtime"
+      [ ("image", 1); ("audio", 2) ]
+  in
+  let public = Keeper_runtime_manifest.public_projection_of_decision decision in
+  check (option string) "routing action"
+    (Some "media_degraded_to_text")
+    (match assoc_field "routing_action" public with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  check (option string) "routing reason"
+    (Some "no_configured_runtime_accepts_required_media")
+    (match assoc_field "routing_reason" public with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  check (option string) "runtime id"
+    (Some "text-runtime")
+    (match assoc_field "degraded_runtime_id" public with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  check (option int) "drop total"
+    (Some 3)
+    (match assoc_field "media_dropped_total" public with
+     | Some (`Int value) -> Some value
+     | _ -> None);
+  check (option string) "deterministic count summary"
+    (Some "audio=2,image=1")
+    (match assoc_field "media_dropped_counts" public with
+     | Some (`String value) -> Some value
+     | _ -> None);
+  check (option string) "payload role remains internal" None
+    (match assoc_field "payload_role" public with
+     | Some (`String value) -> Some value
+     | _ -> None)
+
+let test_driver_degrade_branch_emits_manifest () =
+  let source = read_file "lib/keeper/keeper_turn_driver.ml" in
+  check bool "degrade branch emits manifest" true
+    (string_contains source "emit_runtime_manifest"
+     && string_contains source "~status:\"degraded\""
+     && string_contains source "media_degrade_manifest_decision"
+     && string_contains source "Keeper_runtime_manifest.Runtime_routed")
+
 let () =
   run "rfc0265_modality_reroute"
     [ ( "decide_modality_reroute"
@@ -312,5 +363,9 @@ let () =
             test_degrade_note_some_when_dropped
         ; test_case "degrade note none when empty" `Quick
             test_degrade_note_none_when_empty
+        ; test_case "degrade manifest public projection" `Quick
+            test_degrade_manifest_public_projection
+        ; test_case "driver degrade branch emits manifest" `Quick
+            test_driver_degrade_branch_emits_manifest
         ] )
     ]

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -287,7 +287,7 @@ let test_degrade_note_none_when_empty () =
 
 let test_degrade_manifest_public_projection () =
   let decision =
-    Keeper_turn_driver.For_testing.media_degrade_manifest_decision
+    Masc.Keeper_turn_driver.For_testing.media_degrade_manifest_decision
       ~runtime_id:"text-runtime"
       [ ("image", 1); ("audio", 2) ]
   in


### PR DESCRIPTION
## 목표

keeper가 text-only 모델로 라우팅된 상태에서 이미지 입력을 받으면, RFC-0265의 `No_capable_runtime` floor가 턴을 **terminal reject**해 keeper가 `pause_human`에 멈춘다. 이 floor 동작만 **graceful degrade**(미디어 드롭 + 노트 주입 + 텍스트로 진행)로 바꿔 keeper가 멈추지 않게 한다.

## 배경 (라이브 grounding)

- keeper `sangsu`가 `glm-coding`/`ollama_cloud` 경유 `devstral-small-2:24b`(text-only)로 라우팅된 채 이미지 입력 수신 → `api_error_invalid_request` / `pause_human` 반복(`~/.masc/keepers/sangsu/execution-receipts/2026-06/{20,23}.jsonl`).
- 자율 keeper에겐 "이미지 때문에 멈춤"보다 "이미지 빼고 텍스트로 진행"이 운영상 낫다(사용자 선택: **keeper liveness > media fidelity**).
- 처음 본 `Image input is not enabled for this model`은 제 **터미널 출력 마스킹 아티팩트**("Image input"→"l")였고 masc/OAS의 에러 surfacing은 정상(별도 버그 아님). receipt 바이트를 ord 디코드로 검증.

## 변경 (RFC-0265 follow-up)

reroute 결정이 `No_capable_runtime`일 때:
1. assigned runtime의 effective caps를 기존 `input_capabilities_of_runtime`(해소된 `Runtime.t`, 신뢰)로 구함.
2. `strip_unsupported_modality_blocks`/`_messages`로 goal + `initial_messages` + 재개 checkpoint에서 미지원 top-level `Image`/`Document`/`Audio` 블록을 드롭(text/thinking/tool 유지), per-modality drop count 보고.
3. 드롭이 있으면 `Text` 노트(`media_degrade_note`)를 goal에 주입 + `WARN` 로그. 턴은 텍스트로 dispatch.

strip/note는 `runtime_agent`의 **pure 함수**(unit-test). 드롭은 non-silent(WARN + 노트, RFC-0126/0145). stripped checkpoint는 **dispatch view만** — 영속 checkpoint는 불변이라 이후 vision 런타임은 원본 미디어를 봄.

## 트레이드오프 (vs RFC-0265 fail-closed floor)

| | RFC-0265 floor | 이 PR |
|--|----------------|-------|
| capable 런타임 없음 | terminal reject(턴 사망) | 미디어 드롭+노트, 텍스트 진행 |
| media fidelity | 보존(미dispatch) | 이번 턴 이미지 생략(history서 복구 가능) |
| keeper liveness | `pause_human` 가능 | 계속 |

reroute가 우선: vision 런타임이 설정+선언(`supports-image-input`)되면 거기로 reroute되고 degrade 안 됨. degrade는 RFC-0265가 hard-reject하던 floor에서만 발동.

## 범위에서 제외 (의도적)

- **gate config-resolution fail-open**: `input_capabilities_for_config`의 `None -> caps`는 keeper 경로엔 무해(`config.description`의 `runtime:<id>/runtime` 마커로 게이트가 모델 caps 해소)하고, 이 PR의 degrade는 **reroute 경로**(런타임 직접 해소)로 dispatch 전 미디어를 strip하므로 게이트에 의존하지 않음. 게이트를 모든 caller에 대해 fail-closed로 바꾸는 건 별개 변경이며, 순진한 fail-closed default는 provider caps로 정당하게 미디어를 지원하는 비-keeper `run_blocks` caller를 **over-block**함(`test_gate_keeper_backend`로 확인) → 제외.
- ToolResult-nested 미디어, output-modality(이미지 생성).

## 로컬 검증 (결정적)

```
dune build --root . lib/masc.cma                      → exit 0
dune exec --root . test/test_runtime_modality_reroute.exe → 15 tests, Test Successful (기존 10 + 신규 media_degrade 5)
dune exec --root . test/test_gate_keeper_backend.exe      → 53 tests, Test Successful (회귀 없음)
```

OCaml full build는 로컬 agent_sdk pin skew로 깨지므로 **CI authoritative**.

## RFC

`docs/rfc/RFC-keeper-media-degrade-floor.md` (RFC-0265 follow-up, fail-closed→degrade 트레이드오프 + 제외 범위 기록).

## 변경 파일

- `lib/runtime/runtime_agent.{ml,mli}` — pure strip + note + merge_counts
- `lib/keeper/keeper_turn_driver.ml` — reroute floor에서 degrade
- `test/test_runtime_modality_reroute.ml` — media_degrade 그룹 5 cases
- `docs/rfc/RFC-keeper-media-degrade-floor.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
