### PR TITLE
fix(harness): use catalog model for contract smoke runtime

### DIFF
--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -143,7 +143,11 @@ protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:9/v1"
 
 [models.smoke]
-api-name = "smoke"
+# Borrow a real repo catalog id for strict capability lookup. The transport
+# harness never reaches the provider endpoint, but Runtime.init_default_strict
+# must still see model capability metadata instead of falling back to provider
+# defaults.
+api-name = "deepseek-v4-flash"
 max-context = 32768
 tools-support = true
 streaming = true


### PR DESCRIPTION
## Summary
- point the contract harness smoke runtime at the repo OAS model catalog via api-name=deepseek-v4-flash
- keep the local harness runtime id/provider shape unchanged
- avoid weakening Runtime.init_default_strict or adding provider-default fallback

## Evidence
- CI failure observed on open PRs #22244/#22227: contract harness server boot rejected transport_harness.smoke because model=smoke was absent from oas-models.toml
- bash -n scripts/harness/lib/server_bootstrap.sh
- rg confirmed oas-models.toml contains id_prefix=deepseek-v4-flash
- git diff --check

## Local build
- Not run. Per review objective, build proof should come from CI.