### PR TITLE
perf(dashboard): 채팅 스트리밍 버블 재렌더 차단 + per-keeper draft 영속성 (후속)

### DIFF
--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
 import { html } from 'htm/preact'
-import { render } from 'preact'
+import { render, options } from 'preact'
 import { fireEvent } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry } from '../../types'
 import type { ToolCallEntry } from '../../api/dashboard'
 import { ChatComposer, ChatTranscript, type ChatComposerSendPayload } from './primitives'
+import { _resetChatStoreForTests, readKeeperDraft } from '../../keeper-chat-store'
 import { collectAttachments } from './attachments'
 import { recordToolCallOutputs, resetToolCallOutputs } from '../../tool-call-output-store'
 import { fetchBoardPost } from '../../api/board'
@@ -885,6 +886,117 @@ describe('ChatComposer IME composition guard', () => {
     expect(onSend).toHaveBeenCalledTimes(1)
     const sent = onSend.mock.calls[0]?.[0] as ChatComposerSendPayload | undefined
     expect(sent?.text).toBe('소주에 갑오징어')
+  })
+})
+
+describe('ChatComposer draft persistence (uncontrolled, per-keeper)', () => {
+  let container: HTMLDivElement
+  beforeEach(() => {
+    _resetChatStoreForTests()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+    _resetChatStoreForTests()
+  })
+
+  function mountComposer(draftPersistKey: string, onSend: () => void = () => {}) {
+    render(
+      html`<${ChatComposer}
+        placeholder="메시지 입력..."
+        disabled=${false}
+        streaming=${false}
+        draftPersistKey=${draftPersistKey}
+        onSend=${onSend}
+      />`,
+      container,
+    )
+    return container.querySelector('textarea') as HTMLTextAreaElement
+  }
+
+  it('restores a keeper draft across remount and never leaks across keepers', () => {
+    // Type for keeper 'rondo', then switch away (unmount — the key=keeperName
+    // remount in the app).
+    let textarea = mountComposer('rondo')
+    fireEvent.input(textarea, { target: { value: '소주에 갑오징어' } })
+    render(null, container)
+
+    // Switch to a different keeper → fresh, empty composer (no cross-keeper leak).
+    textarea = mountComposer('qa-king')
+    expect(textarea.value).toBe('')
+
+    // Switch back to 'rondo' → the half-typed draft is restored.
+    render(null, container)
+    textarea = mountComposer('rondo')
+    expect(textarea.value).toBe('소주에 갑오징어')
+  })
+
+  it('clears the persisted draft after a send', () => {
+    const onSend = vi.fn()
+    const textarea = mountComposer('rondo', onSend)
+    fireEvent.input(textarea, { target: { value: 'send me' } })
+    textarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+
+    expect(onSend).toHaveBeenCalledTimes(1)
+    expect(readKeeperDraft('rondo')).toBe('')
+  })
+})
+
+describe('ChatMessageBubble memoization', () => {
+  let container: HTMLDivElement
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+  afterEach(() => {
+    render(null, container)
+    container.remove()
+  })
+
+  // Simulates a stream chunk: render a 2-message transcript, then re-render with
+  // the SAME settled entry reference but a fresh streaming entry (new array), the
+  // way a reconcile preserves settled refs. Returns how many message-bubble
+  // bodies re-ran on the second render. `action` reference stability is the
+  // variable under test (the inline `{ ...onClick }` literal in
+  // KeeperConversationPanel is hoisted to a useMemo so it stays referentially
+  // stable across stream re-renders).
+  function bubbleRerendersOnStream(actionFor: () => unknown): number {
+    type RenderHook = { __r?: (v: unknown) => void }
+    let renders = 0
+    const prev = (options as unknown as RenderHook).__r
+    ;(options as unknown as RenderHook).__r = (vnode) => {
+      const t = (vnode as { type?: { displayName?: string; name?: string } })?.type
+      const label = t?.displayName ?? t?.name ?? ''
+      // Count the inner component body, not the memo wrapper ('Memo(...)').
+      if (label.includes('ChatMessageBubble') && !label.startsWith('Memo(')) renders++
+      prev?.(vnode)
+    }
+    try {
+      const settled = entry({ id: 'a', role: 'assistant', source: 'direct_assistant', text: 'settled reply' })
+      const s1 = entry({ id: 'b', role: 'assistant', source: 'direct_assistant', text: 'partial' })
+      render(html`<${ChatTranscript} entries=${[settled, s1]} emptyText="x" action=${actionFor()} />`, container)
+      const initial = renders
+      expect(initial).toBe(2) // both bubbles paint on first render
+      const s2 = entry({ id: 'b', role: 'assistant', source: 'direct_assistant', text: 'partial reply' })
+      render(html`<${ChatTranscript} entries=${[settled, s2]} emptyText="x" action=${actionFor()} />`, container)
+      return renders - initial
+    } finally {
+      ;(options as unknown as RenderHook).__r = prev
+    }
+  }
+
+  it('skips the settled bubble on a stream update when the action prop is referentially stable', () => {
+    const stable = { label: '턴 상세', title: 't', onClick: () => {} }
+    // Only the streaming bubble re-runs; the settled one is skipped.
+    expect(bubbleRerendersOnStream(() => stable)).toBe(1)
+  })
+
+  it('re-renders the settled bubble when action is a new object each render (why the useMemo matters)', () => {
+    // A fresh action object every render — the pre-fix behaviour — defeats the
+    // shallow-equal skip, so the settled bubble re-runs on every stream chunk.
+    expect(bubbleRerendersOnStream(() => ({ label: '턴 상세', title: 't', onClick: () => {} }))).toBe(2)
   })
 })
 

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -933,6 +933,24 @@ describe('ChatComposer draft persistence (uncontrolled, per-keeper)', () => {
     expect(textarea.value).toBe('소주에 갑오징어')
   })
 
+  it('resyncs immediately when the draft key changes without a remount', () => {
+    let textarea = mountComposer('rondo')
+    fireEvent.input(textarea, { target: { value: 'rondo draft' } })
+
+    // Defensive path for future callers: even without key=${keeperName}
+    // remounting the composer, the new keeper must not briefly inherit the old
+    // keeper's visible buffer or write subsequent input under the wrong key.
+    textarea = mountComposer('qa-king')
+    expect(textarea.value).toBe('')
+
+    fireEvent.input(textarea, { target: { value: 'qa draft' } })
+    expect(readKeeperDraft('rondo')).toBe('rondo draft')
+    expect(readKeeperDraft('qa-king')).toBe('qa draft')
+
+    textarea = mountComposer('rondo')
+    expect(textarea.value).toBe('rondo draft')
+  })
+
   it('clears the persisted draft after a send', () => {
     const onSend = vi.fn()
     const textarea = mountComposer('rondo', onSend)

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2930,29 +2930,51 @@ export function ChatComposer({
   const [drag, setDrag] = useState(false)
   const [attachments, setAttachments] = useState<KeeperConversationAttachment[]>([])
   const isControlled = typeof draftProp === 'string'
+  const draftPersistStoreKey = draftPersistKey?.trim() ?? ''
   // Lazy initializer: on (re)mount restore this keeper's persisted draft so a
   // keeper switch (key=${keeperName} remount) does not drop a half-typed
   // message. Controlled callers manage their own draft, so skip persistence.
-  const [internalDraft, setInternalDraft] = useState(
-    () => (!isControlled && draftPersistKey ? readKeeperDraft(draftPersistKey) : ''),
+  const [internalDraftState, setInternalDraftState] = useState<{ key: string | null; value: string }>(() =>
+    isControlled
+      ? { key: null, value: '' }
+      : {
+          key: draftPersistStoreKey,
+          value: draftPersistStoreKey ? readKeeperDraft(draftPersistStoreKey) : '',
+        },
   )
+  const internalDraft =
+    !isControlled && draftPersistStoreKey !== internalDraftState.key
+      ? draftPersistStoreKey
+        ? readKeeperDraft(draftPersistStoreKey)
+        : ''
+      : internalDraftState.value
   const draft = isControlled ? draftProp : internalDraft
   const setDraft = (value: string) => {
     if (isControlled) {
       onDraftChange?.(value)
     } else {
-      setInternalDraft(value)
-      if (draftPersistKey) writeKeeperDraft(draftPersistKey, value)
+      setInternalDraftState({ key: draftPersistStoreKey, value })
+      if (draftPersistStoreKey) writeKeeperDraft(draftPersistStoreKey, value)
     }
   }
   // External-store sync: a normal keeper switch remounts (key=${keeperName}) and
-  // the lazy initializer above already restored the draft. This effect covers
-  // the one case the initializer cannot — `draftPersistKey` changing without a
-  // remount — by reloading that key's draft, so the write key and the buffer
-  // never diverge into the cross-keeper leak this feature exists to prevent.
-  useEffect(() => {
-    if (!isControlled && draftPersistKey) setInternalDraft(readKeeperDraft(draftPersistKey))
-  }, [draftPersistKey, isControlled])
+  // the lazy initializer above already restored the draft. This layout effect
+  // covers the one case the initializer cannot — `draftPersistKey` changing
+  // without a remount. The render-time fallback above prevents a stale buffer
+  // from being shown for the new key; this effect aligns the internal state for
+  // the next edit.
+  useLayoutEffect(() => {
+    if (isControlled) {
+      if (internalDraftState.key !== null) setInternalDraftState({ key: null, value: '' })
+      return
+    }
+    if (draftPersistStoreKey !== internalDraftState.key) {
+      setInternalDraftState({
+        key: draftPersistStoreKey,
+        value: draftPersistStoreKey ? readKeeperDraft(draftPersistStoreKey) : '',
+      })
+    }
+  }, [draftPersistStoreKey, internalDraftState.key, isControlled])
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -19,6 +19,8 @@ const CHAT_FOCUS_RING = ringFocusClasses({ tone: 'accent-medium', width: 2 })
 import { formatTimeHms } from '../../lib/format-time'
 import { formatCost, formatMsCompact } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
+import { memo } from 'preact/compat'
+import { readKeeperDraft, writeKeeperDraft } from '../../keeper-chat-store'
 import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatChartBlock, ChatIssueBlock, ChatLinkBlock, ChatMermaidBlock, ChatShellBlock, ChatSuggestionsBlock, ChatTableBlock, ChatTraceStep, ChatVoiceBlock, KeeperUserInputBlock } from '../../types'
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, KeeperConversationSource, SurfaceRef } from '../../types'
 import type { ToolCallEntry, ToolCallOutputBlob } from '../../api/dashboard'
@@ -1781,7 +1783,22 @@ const CARD_BLOCK_TYPES: ReadonlySet<ChatBlock['t']> = new Set([
   'shell',
 ])
 
-function ChatMessageBubble({
+// Memoized message bubble. A streaming reply re-renders the conversation panel
+// on every SSE event; the transcript reconcile preserves the entry reference of
+// every settled message (keeper-state.ts), and KeeperConversationPanel hoists
+// the `action` object to a useMemo, so a settled bubble's props are all
+// referentially stable across a stream chunk and its body is skipped.
+//
+// The `action` stabilization is the load-bearing half: without it the inline
+// `{ ...onClick }` literal is a new reference each render and the bubble re-runs
+// regardless of memo (the test 're-renders the settled bubble when action is a
+// new object…' locks this).
+//
+// KNOWN GAP: tool/thinking turns render through the un-memoized TurnWorkBundle,
+// whose `tools` array is rebuilt every render (buildChatRenderUnits), so its
+// trace cards are NOT yet skipped on a stream chunk. Closing that needs the
+// unit arrays stabilized first — a separate follow-up.
+const ChatMessageBubble = memo(function ChatMessageBubble({
   entry,
   showMetadata = true,
   variant = 'default',
@@ -2131,7 +2148,7 @@ function ChatMessageBubble({
         : null}
     </article>
   `
-}
+})
 
 // Pretty-print a JSON-looking string; leave anything else untouched. Shared by
 // the argument and output renderers so both read consistently.
@@ -2877,6 +2894,7 @@ export function ChatComposer({
   onSend,
   onAbort,
   layout = 'default',
+  draftPersistKey,
 }: {
   draft?: string
   placeholder: string
@@ -2896,21 +2914,45 @@ export function ChatComposer({
   onSend: (payload: ChatComposerSendPayload) => void | Promise<void>
   onAbort?: () => void
   layout?: 'default' | 'primary'
+  /** When set (and uncontrolled), the composer persists its unsent draft
+   *  per key across remounts via keeper-chat-store, so switching keepers
+   *  keeps each keeper's own half-typed message without leaking it to
+   *  another keeper. Ignored in controlled mode (the host owns the draft).
+   *
+   *  Callers pass `key=${draftPersistKey}` too, so a keeper switch remounts
+   *  the composer. The effect below additionally re-syncs the buffer if the
+   *  key changes in place, so the write key and the editing buffer can never
+   *  diverge into a cross-keeper leak even without the remount. */
+  draftPersistKey?: string
 }) {
   const [elapsed, setElapsed] = useState(0)
   const [focus, setFocus] = useState(false)
   const [drag, setDrag] = useState(false)
   const [attachments, setAttachments] = useState<KeeperConversationAttachment[]>([])
-  const [internalDraft, setInternalDraft] = useState('')
   const isControlled = typeof draftProp === 'string'
+  // Lazy initializer: on (re)mount restore this keeper's persisted draft so a
+  // keeper switch (key=${keeperName} remount) does not drop a half-typed
+  // message. Controlled callers manage their own draft, so skip persistence.
+  const [internalDraft, setInternalDraft] = useState(
+    () => (!isControlled && draftPersistKey ? readKeeperDraft(draftPersistKey) : ''),
+  )
   const draft = isControlled ? draftProp : internalDraft
   const setDraft = (value: string) => {
     if (isControlled) {
       onDraftChange?.(value)
     } else {
       setInternalDraft(value)
+      if (draftPersistKey) writeKeeperDraft(draftPersistKey, value)
     }
   }
+  // External-store sync: a normal keeper switch remounts (key=${keeperName}) and
+  // the lazy initializer above already restored the draft. This effect covers
+  // the one case the initializer cannot — `draftPersistKey` changing without a
+  // remount — by reloading that key's draft, so the write key and the buffer
+  // never diverge into the cross-keeper leak this feature exists to prevent.
+  useEffect(() => {
+    if (!isControlled && draftPersistKey) setInternalDraft(readKeeperDraft(draftPersistKey))
+  }, [draftPersistKey, isControlled])
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -493,6 +493,16 @@ export function KeeperConversationPanel({
     () => filterConversationEntries(visibleThread, searchQuery),
     [visibleThread, searchQuery],
   )
+  // Stable action object so the memoized ChatMessageBubble's shallow prop
+  // compare can skip unchanged messages — an inline `{ ...onClick }` literal
+  // would be a new reference each render and defeat the memo.
+  const inspectAction = useMemo(
+    () =>
+      onInspectTurn
+        ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn }
+        : undefined,
+    [onInspectTurn],
+  )
   const transcriptEmptyText =
     hasQuery && visibleThread.length > 0
       ? '검색어와 일치하는 메시지가 없습니다.'
@@ -663,7 +673,7 @@ export function KeeperConversationPanel({
               showSourceBadge=${true}
               toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
               toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
-              action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
+              action=${inspectAction}
             />
           </div>
         </div>
@@ -698,6 +708,7 @@ export function KeeperConversationPanel({
               : null}
             <${ChatComposer}
               key=${keeperName}
+              draftPersistKey=${keeperName}
               placeholder=${chatAccess.blocked
                 ? '현재 actor는 direct keeper chat 권한이 없습니다'
                 : sending
@@ -792,7 +803,7 @@ export function KeeperConversationPanel({
           groupToolCalls=${true}
           toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
           toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
-          action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
+          action=${inspectAction}
         />
 
         ${!showInternal && hiddenCount > 0
@@ -814,6 +825,7 @@ export function KeeperConversationPanel({
             : null}
           <${ChatComposer}
             key=${keeperName}
+            draftPersistKey=${keeperName}
             placeholder=${chatAccess.blocked
               ? '현재 actor는 direct keeper chat 권한이 없습니다'
               : sending
@@ -905,7 +917,7 @@ export function KeeperConversationPanel({
             groupToolCalls=${true}
             toolOutputsCoveredSinceMs=${toolCallOutputsCoveredSinceMs(keeperName)}
             toolOutputsCoveredThroughMs=${toolCallOutputsCoveredThroughMs(keeperName)}
-            action=${onInspectTurn ? { label: '턴 상세', title: '이 메시지 턴 상세 열기', onClick: onInspectTurn } : undefined}
+            action=${inspectAction}
           />
         </div>
 
@@ -928,6 +940,7 @@ export function KeeperConversationPanel({
             : null}
           <${ChatComposer}
             key=${keeperName}
+            draftPersistKey=${keeperName}
             placeholder=${chatAccess.blocked
               ? '현재 actor는 direct keeper chat 권한이 없습니다'
               : sending

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -5,7 +5,7 @@
 
 import { html } from 'htm/preact'
 import { ChevronLeft } from 'lucide-preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useCallback, useEffect, useState } from 'preact/hooks'
 import type { VNode } from 'preact'
 import type { Keeper, KeeperConversationEntry } from '../../types'
 import { KeeperConversationPanel } from '../keeper-shared'
@@ -374,10 +374,10 @@ export function KeeperWorkspaceChat({
 }): VNode {
   const [turnInspectorOpen, setTurnInspectorOpen] = useState(false)
   const [turnInspectorEntry, setTurnInspectorEntry] = useState<KeeperConversationEntry | null>(null)
-  const openTurnInspector = (entry?: KeeperConversationEntry) => {
+  const openTurnInspector = useCallback((entry?: KeeperConversationEntry) => {
     setTurnInspectorEntry(entry ?? null)
     setTurnInspectorOpen(true)
-  }
+  }, [])
 
   return html`
     <section class="kw-chat v2-monitoring-surface" role="region" aria-label=${`${keeper.name} 대화`}>

--- a/dashboard/src/keeper-chat-store.test.ts
+++ b/dashboard/src/keeper-chat-store.test.ts
@@ -9,6 +9,10 @@ import {
   getQueueLength,
   getQueueTotal,
   updateQueuedMessage,
+  readKeeperDraft,
+  writeKeeperDraft,
+  clearKeeperDraft,
+  _draftCountForTests,
 } from './keeper-chat-store'
 
 describe('keeper-chat-store input queue', () => {
@@ -120,5 +124,49 @@ describe('keeper-chat-store input queue', () => {
     expect(hasQueuedInputClientAction('keeper-q', 'click-1')).toBe(false)
     enqueueInput('keeper-q', 'original', undefined, 'click-1')
     expect(getQueueLength('keeper-q')).toBe(2)
+  })
+})
+
+describe('keeper-chat-store draft persistence', () => {
+  beforeEach(() => { _resetChatStoreForTests() })
+  afterEach(() => { _resetChatStoreForTests() })
+
+  it('reads empty for an unknown keeper', () => {
+    expect(readKeeperDraft('ghost')).toBe('')
+  })
+
+  it('round-trips a draft per keeper without leaking across keepers', () => {
+    writeKeeperDraft('rondo', '소주에 갑오징어')
+    writeKeeperDraft('qa-king', '리뷰 부탁')
+    // Each keeper keeps its own draft — no cross-keeper leak (the old single
+    // shared draft would have shown one keeper's text in another's composer).
+    expect(readKeeperDraft('rondo')).toBe('소주에 갑오징어')
+    expect(readKeeperDraft('qa-king')).toBe('리뷰 부탁')
+  })
+
+  it('deletes the entry when written empty (no blank accumulation after send)', () => {
+    writeKeeperDraft('rondo', 'half typed')
+    expect(_draftCountForTests()).toBe(1)
+    writeKeeperDraft('rondo', '')
+    expect(readKeeperDraft('rondo')).toBe('')
+    // The entry is removed, not stored as '' — readKeeperDraft alone cannot
+    // distinguish the two, so assert the map actually shrank.
+    expect(_draftCountForTests()).toBe(0)
+  })
+
+  it('clearKeeperDraft drops a keeper draft', () => {
+    writeKeeperDraft('rondo', 'pending')
+    clearKeeperDraft('rondo')
+    expect(readKeeperDraft('rondo')).toBe('')
+  })
+
+  it('trims the key so whitespace variants address the same draft', () => {
+    writeKeeperDraft('rondo', 'x')
+    expect(readKeeperDraft('  rondo  ')).toBe('x')
+  })
+
+  it('ignores a blank-key write', () => {
+    writeKeeperDraft('   ', 'nope')
+    expect(readKeeperDraft('')).toBe('')
   })
 })

--- a/dashboard/src/keeper-chat-store.ts
+++ b/dashboard/src/keeper-chat-store.ts
@@ -35,6 +35,43 @@ function _ensureQueue(keeperName: string): InputQueue {
   return q
 }
 
+// ── Per-keeper composer draft persistence ──────────────────────────────
+//
+// Holds the unsent composer text per keeper. ChatComposer is keyed by
+// keeper name (key=${keeperName}) and therefore remounts on a keeper
+// switch; reading from this map on mount preserves a half-typed message,
+// and — unlike the old single shared `draft` state on the panel — one
+// keeper's text never leaks into another's composer (which previously
+// risked sending to the wrong recipient). Plain Map, not a signal, so the
+// per-keystroke write does not re-render the conversation panel.
+const _drafts = new Map<string, string>()
+
+/** Read the persisted unsent draft for a keeper ('' when none). */
+export function readKeeperDraft(keeperName: string): string {
+  return _drafts.get(keeperName.trim()) ?? ''
+}
+
+/** Persist the unsent draft for a keeper. An empty value deletes the entry
+ *  so the map does not accumulate blank drafts after a send. */
+export function writeKeeperDraft(keeperName: string, value: string): void {
+  const key = keeperName.trim()
+  if (!key) return
+  if (value === '') _drafts.delete(key)
+  else _drafts.set(key, value)
+}
+
+/** Drop a keeper's persisted draft. */
+export function clearKeeperDraft(keeperName: string): void {
+  _drafts.delete(keeperName.trim())
+}
+
+/** Test-only: number of persisted drafts. Lets a test observe that an empty
+ *  write deletes the entry rather than storing a blank string (which
+ *  readKeeperDraft cannot distinguish, since both read back as ''). */
+export function _draftCountForTests(): number {
+  return _drafts.size
+}
+
 /** Enqueue a message typed while the keeper is streaming. Attachments
  *  selected at enqueue time ride along so draining does not drop them. */
 export function enqueueInput(
@@ -146,4 +183,5 @@ export function getQueueTotal(keeperName: string): number {
 
 export function _resetChatStoreForTests(): void {
   _queues.clear()
+  _drafts.clear()
 }


### PR DESCRIPTION
## 배경

`/loop` 대시보드 반응성 작업의 후속 2건 (앞선 #22239/#22243 머지 후, 적대 리뷰가 짚은 잔여 항목). 본 PR도 적대적 리뷰(14-agent fan-out, 10건 제기 → 3건 확정) 후 수정 반영.

## Part A — 스트리밍 중 메시지 버블 재렌더 차단 (action 안정화)

`KeeperConversationPanel`은 키퍼 응답 스트리밍 중 stream 시그널마다 재렌더되고, 그때 `ChatTranscript` → 메시지 버블들이 재평가됩니다. 완료된 메시지 버블은 다시 그릴 필요가 없습니다.

- **load-bearing fix**: 기존 인라인 `action={ label, title, onClick: onInspectTurn }` 리터럴은 매 렌더 새 객체였습니다 → `inspectAction = useMemo(…, [onInspectTurn])`로 hoist하고 `openTurnInspector`를 `useCallback`으로 안정화. 이로써 완료 버블의 모든 prop(entry는 reconcile이 참조 보존, action은 이제 안정)이 참조-안정 → 변경된 버블만 재렌더.
- `ChatMessageBubble`을 `memo()`로 래핑 — codebase의 list-row memo 관습(`ActivityRow`/`KeeperDetailContent`)과 일치하는 명시적·방어적 가드. (실측상 htm가 참조-안정 prop vnode를 이미 캐싱해 memo 없이도 skip되지만, memo는 그 보장을 명시화.)

검증(render-hook 카운트, non-vacuous): action 참조 안정 → 변경 버블 1개만 재렌더(settled skip); action이 매 렌더 새 객체 → settled도 재렌더(2개). 즉 **action 안정화가 skip의 결정 요인**임을 증명.

**알려진 gap (defer)**: tool/thinking 턴은 미-memo `TurnWorkBundle`로 렌더되고 그 `tools` 배열이 매 렌더 재생성(`buildChatRenderUnits`)되어 trace card가 아직 skip되지 않습니다. 닫으려면 unit 배열 참조 안정화가 선행돼야 하는 별도 후속입니다 (코드 주석에 명시). 본 PR은 일반 메시지 버블 경로를 최적화합니다.

## Part B — per-keeper 미전송 draft 영속성

#22243이 composer draft를 `internalDraft`로 격리하며 `key=${keeperName}` remount → keeper 전환 시 미전송 draft가 사라졌습니다. 적대 리뷰가 정확성↔영속성 trade로 지적한 부분을 **둘 다** 충족하도록 해소합니다.

- `keeper-chat-store.ts`에 비반응성 `Map<keeper, draft>` + `readKeeperDraft`/`writeKeeperDraft`/`clearKeeperDraft` (queue store와 동일 패턴, `_resetChatStoreForTests` 확장). 빈 값 write는 entry 삭제(전송 후 blank 누적 방지, `_draftCountForTests`로 검증).
- `ChatComposer`에 `draftPersistKey?` prop: uncontrolled일 때 마운트 시 store에서 lazy-init, 키 입력마다 persist, 전송 시 `setDraft('')`가 store entry 삭제. signal이 아니라 패널 재렌더 미유발.
- **leak 불변식 강화**: key↔draftPersistKey 결합을 JSDoc에 명시 + key가 in-place로 바뀌어도 buffer를 재동기하는 external-store useEffect 추가 → write key와 buffer가 절대 어긋나지 않음(caller 규약에만 의존하지 않음).
- keeper-shared 3 사이트에 `draftPersistKey=${keeperName}`.
- 결과: keeper 전환 시 각 keeper의 미전송 draft 복원 + 다른 keeper로 **누출 없음**(구 단일 draft의 wrong-recipient 리스크 제거).

## 로컬 검증

- `tsc --noEmit`: 0 errors. eslint(변경 파일): clean.
- 신규 테스트: keeper-chat-store draft(6, delete-on-empty는 `_draftCountForTests`로 non-vacuous) + ChatComposer 영속성·no-leak·clear-on-send(2) + bubble action-stability(2, revert-red로 비공허 확인).
- 전체 vitest.config.ts: **595파일 / 7804 tests green**.

## 적대적 리뷰 처리 (3 confirmed)

- **P2** (draftPersistKey/key 결합이 caller 규약 의존) → JSDoc + external-store sync useEffect로 불변식 컴포넌트가 보장.
- **P1** (TurnWorkBundle 미-memo로 streaming win 부분적) → 코드 주석+본문에 defer 명시 (배열 안정화 필요한 후속).
- **nit** (delete-on-empty 테스트 tautology) → `_draftCountForTests` probe로 map 축소 검증.

RFC-WAIVED: dashboard FE 채팅 성능/UX 수정. credential/identity/operator-control/keeper-sandbox/hooks 미변경.
