### PR TITLE
fix(harness): cover remaining strict smoke fixtures

### DIFF
--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -191,6 +191,7 @@ harness_start_server() {
     export MASC_STORAGE_TYPE="filesystem"
     export MASC_AUTONOMY_ENABLED="0"
     export MASC_ORCHESTRATOR_ENABLED="0"
+    export MASC_OTEL_ENABLED="0"
     export MASC_TOOL_TIMEOUT_DEFAULT_SEC="${MASC_TOOL_TIMEOUT_DEFAULT_SEC:-90}"
     export GRAPHQL_API_KEY=""
     export GRAPHQL_URL="http://127.0.0.1:9/graphql"

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -306,7 +306,9 @@ protocol = "openai-compatible-http"
 endpoint = "http://127.0.0.1:9/v1"
 
 [models.smoke]
-api-name = "smoke"
+# The SSE storm harness never reaches this provider endpoint, but strict
+# runtime bootstrap still requires catalog-backed capability metadata.
+api-name = "deepseek-v4-flash"
 max-context = 32768
 tools-support = true
 streaming = true


### PR DESCRIPTION
Follow-up after #22251 merged. Covers the remaining strict-catalog smoke fixture in test_sse_storm_e2e and disables OTLP export for harness-started servers so CI readiness checks do not wait on an absent collector. Local checks: ocamlformat --check test/test_sse_storm_e2e.ml; bash -n scripts/harness/lib/server_bootstrap.sh; git diff --check origin/main...HEAD; rg confirmed no api-name=smoke/model=smoke fixtures remain. Full Dune intentionally not run locally for this sweep; CI is authoritative.