### PR TITLE
feat(multimodal): durable input image store + analyze_image pure contract (RFC vision-delegation Phase 0b/1)

### DIFF
--- a/lib/multimodal/dune
+++ b/lib/multimodal/dune
@@ -6,6 +6,6 @@
  ; RFC-0071 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries shared_types unix yojson)
+ (libraries shared_types unix yojson fs_compat digestif)
  (preprocess
   (pps ppx_tla)))

--- a/lib/multimodal/vision_analyze.ml
+++ b/lib/multimodal/vision_analyze.ml
@@ -1,0 +1,40 @@
+type request =
+  { query : string
+  ; image_media_type : string
+  ; image_bytes : string
+  }
+
+let make_request ~query ~image_media_type ~image_bytes =
+  if String.length (String.trim query) = 0 then Error "analyze_image: empty query"
+  else if String.length image_bytes = 0 then
+    Error "analyze_image: empty image bytes"
+  else if String.length (String.trim image_media_type) = 0 then
+    Error "analyze_image: empty image media type"
+  else Ok { query; image_media_type; image_bytes }
+
+type extraction_error =
+  | Empty_extraction
+  | Truncated_extraction
+
+let string_of_error = function
+  | Empty_extraction -> "empty_extraction"
+  | Truncated_extraction -> "truncated_extraction"
+
+type done_reason =
+  | Stop
+  | Length
+  | Other of string
+
+let done_reason_of_string raw =
+  match String.lowercase_ascii (String.trim raw) with
+  | "stop" | "end_turn" -> Stop
+  | "length" | "max_tokens" -> Length
+  | other -> Other other
+
+let classify ~done_reason ~content =
+  let trimmed = String.trim content in
+  if String.length trimmed > 0 then Ok trimmed
+  else (
+    match done_reason with
+    | Length -> Error Truncated_extraction
+    | Stop | Other _ -> Error Empty_extraction)

--- a/lib/multimodal/vision_analyze.mli
+++ b/lib/multimodal/vision_analyze.mli
@@ -1,0 +1,56 @@
+(** Pure core of the [analyze_image] delegation tool.
+    RFC-keeper-vision-delegation-tool §2.2.
+
+    Encodes the input/output contract of a vision sub-call independent of the
+    provider transport (the mid-turn provider round-trip of §2.6 is the impure
+    shell, deferred). The load-bearing guarantee: an empty or truncated vision
+    reply is a typed error, never [Ok ""] — so delegation cannot reproduce the
+    2026-06-25 empty-reply failure class one layer inward. *)
+
+type request =
+  { query : string
+  ; image_media_type : string
+  ; image_bytes : string
+  }
+(** A validated one-shot vision request: a [query] plus the image bytes loaded
+    from {!Vision_artifact_store}. *)
+
+val make_request
+  :  query:string
+  -> image_media_type:string
+  -> image_bytes:string
+  -> (request, string) result
+(** Validate the inputs at the boundary (fail closed): [query] must be non-blank,
+    [image_bytes] non-empty, [image_media_type] non-blank. [Error msg] otherwise. *)
+
+type extraction_error =
+  | Empty_extraction
+      (** A normal stop with no usable text — the model produced nothing. *)
+  | Truncated_extraction
+      (** The reply hit the token budget ([done_reason = length]) before emitting
+          post-thinking text. The measured cause of the 2026-06-25 gemma4 empty
+          reply (thinking consumed the whole budget). Retry with a larger budget
+          or a runtime that is not thinking-token-starved. *)
+
+val string_of_error : extraction_error -> string
+
+type done_reason =
+  | Stop
+  | Length
+  | Other of string
+      (** Unknown terminal reason, kept verbatim (no Unknown->Permissive
+          collapse). *)
+
+val done_reason_of_string : string -> done_reason
+(** Normalize a provider's terminal-reason string. "stop"/"end_turn" -> [Stop];
+    "length"/"max_tokens" -> [Length]; anything else -> [Other raw]. Case- and
+    surrounding-whitespace-insensitive. *)
+
+val classify
+  :  done_reason:done_reason
+  -> content:string
+  -> (string, extraction_error) result
+(** The analyze_image result contract:
+    - trimmed-non-empty [content] -> [Ok trimmed] (usable even if truncated);
+    - empty [content] with [Length] -> [Error Truncated_extraction];
+    - empty [content] otherwise -> [Error Empty_extraction]. *)

--- a/lib/multimodal/vision_artifact_store.ml
+++ b/lib/multimodal/vision_artifact_store.ml
@@ -1,0 +1,33 @@
+type handle = string
+
+let to_string h = h
+let of_string s = s
+
+(* Content hash = SHA-256 hex of the raw bytes. Same construction as
+   [Review_artifact_store.component_hash] (which truncates to 16 chars); the
+   full digest is kept here because this is an identity, not a display label. *)
+let hash (raw : string) : handle = Digestif.SHA256.(digest_string raw |> to_hex)
+
+let path_of ~dir (h : handle) = Filename.concat dir h
+
+let store ~dir (raw : string) : (handle, string) result =
+  let h = hash raw in
+  Fs_compat.mkdir_p dir;
+  match Fs_compat.save_file_atomic (path_of ~dir h) raw with
+  | Ok () -> Ok h
+  | Error msg -> Error (Printf.sprintf "Vision_artifact_store.store: %s" msg)
+
+let load ~dir (h : handle) : (string, string) result =
+  let path = path_of ~dir h in
+  match Fs_compat.load_file_opt path with
+  | None -> Error (Printf.sprintf "Vision_artifact_store.load: not found: %s" path)
+  | Some bytes ->
+    (* Verify content-addressing on read: stored bytes must hash back to the
+       handle. Catches corruption and forged/wrong handles — fail closed rather
+       than return mismatched bytes. *)
+    if String.equal (hash bytes) h then Ok bytes
+    else
+      Error
+        (Printf.sprintf
+           "Vision_artifact_store.load: content hash mismatch for %s"
+           path)

--- a/lib/multimodal/vision_artifact_store.ml
+++ b/lib/multimodal/vision_artifact_store.ml
@@ -8,6 +8,19 @@ let of_string s = s
    full digest is kept here because this is an identity, not a display label. *)
 let hash (raw : string) : handle = Digestif.SHA256.(digest_string raw |> to_hex)
 
+(* A handle is the lowercase-hex SHA-256 of stored bytes: exactly 64 hex chars.
+   [store] only ever produces such strings, but [of_string] re-wraps arbitrary
+   persisted strings, so a corrupted/forged checkpoint could carry a handle like
+   "../../etc/passwd". Validate the shape before using a handle as a path segment
+   so [load] cannot read outside [dir] (path-traversal fail-closed). *)
+let is_canonical (h : handle) : bool =
+  String.length h = 64
+  && String.for_all
+       (function
+         | '0' .. '9' | 'a' .. 'f' -> true
+         | _ -> false)
+       h
+
 let path_of ~dir (h : handle) = Filename.concat dir h
 
 let store ~dir (raw : string) : (handle, string) result =
@@ -18,6 +31,13 @@ let store ~dir (raw : string) : (handle, string) result =
   | Error msg -> Error (Printf.sprintf "Vision_artifact_store.store: %s" msg)
 
 let load ~dir (h : handle) : (string, string) result =
+  if not (is_canonical h) then
+    Error
+      (Printf.sprintf
+         "Vision_artifact_store.load: malformed handle (expected 64-char \
+          lowercase hex): %S"
+         h)
+  else
   let path = path_of ~dir h in
   match Fs_compat.load_file_opt path with
   | None -> Error (Printf.sprintf "Vision_artifact_store.load: not found: %s" path)

--- a/lib/multimodal/vision_artifact_store.mli
+++ b/lib/multimodal/vision_artifact_store.mli
@@ -26,6 +26,7 @@ val store : dir:string -> string -> (handle, string) result
     file, so a re-store overwrites identical content. [Error msg] on I/O failure. *)
 
 val load : dir:string -> handle -> (string, string) result
-(** [load ~dir h] reads the bytes for [h]. [Error] if the file is absent, or if
-    the stored bytes do not hash back to [h] (corruption or a forged handle) —
-    never a silent empty success. *)
+(** [load ~dir h] reads the bytes for [h]. [Error] (never a silent empty success)
+    if: [h] is not a canonical 64-char lowercase-hex handle (rejected before any
+    filesystem access, so a forged "../" handle cannot read outside [dir]); the
+    file is absent; or the stored bytes do not hash back to [h] (corruption). *)

--- a/lib/multimodal/vision_artifact_store.mli
+++ b/lib/multimodal/vision_artifact_store.mli
@@ -1,0 +1,31 @@
+(** Content-addressed durable store for input images.
+    RFC-keeper-vision-delegation-tool §2.5.
+
+    Image bytes are written to a content-addressed file under a store directory;
+    the handle is the content hash — a plain string that survives JSON and
+    checkpoint round-trips. This keeps the bytes off the lossy {!Payload}
+    [Lazy_payload] path ([Payload.of_json] rebuilds an empty closure): a
+    checkpoint persists only the handle and the bytes are reloaded on demand.
+    Mirrors the content-addressed atomic-write pattern of [Review_artifact_store]
+    (SHA-256 hashing + [Fs_compat.save_file_atomic]). *)
+
+type handle = private string
+(** Opaque content hash (SHA-256 hex). Produced by {!store}; reconstruct a
+    persisted handle string with {!of_string}. *)
+
+val to_string : handle -> string
+(** The on-disk / on-checkpoint string form of a handle. *)
+
+val of_string : string -> handle
+(** Re-wrap a handle string read back from a checkpoint. No I/O; integrity is
+    verified later by {!load} (a wrong string fails closed there). *)
+
+val store : dir:string -> string -> (handle, string) result
+(** [store ~dir bytes] writes [bytes] to a content-addressed file under [dir] and
+    returns its handle. Idempotent: identical bytes map to the same handle and
+    file, so a re-store overwrites identical content. [Error msg] on I/O failure. *)
+
+val load : dir:string -> handle -> (string, string) result
+(** [load ~dir h] reads the bytes for [h]. [Error] if the file is absent, or if
+    the stored bytes do not hash back to [h] (corruption or a forged handle) —
+    never a silent empty success. *)

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -12,5 +12,6 @@
   test_tool_emission
   test_payload
   test_provenance_stub
-  test_vision_artifact_store)
+  test_vision_artifact_store
+  test_vision_analyze)
  (libraries multimodal shared_types astring yojson str unix))

--- a/test/multimodal/dune
+++ b/test/multimodal/dune
@@ -11,5 +11,6 @@
   test_keeper_emitter
   test_tool_emission
   test_payload
-  test_provenance_stub)
+  test_provenance_stub
+  test_vision_artifact_store)
  (libraries multimodal shared_types astring yojson str unix))

--- a/test/multimodal/test_vision_analyze.ml
+++ b/test/multimodal/test_vision_analyze.ml
@@ -1,0 +1,104 @@
+(* Vision_analyze tests — the analyze_image pure contract.
+   RFC-keeper-vision-delegation-tool §2.2.
+
+   Locks the failure contract: an empty or truncated vision reply is a typed
+   error, never Ok "". The truncated case encodes the measured 2026-06-25 gemma4
+   cause (done_reason=length with empty content). *)
+
+module V = Multimodal.Vision_analyze
+
+let is_error = function
+  | Error _ -> true
+  | Ok _ -> false
+
+(* ── make_request: boundary validation, fail closed ── *)
+
+let test_make_request_ok () =
+  match
+    V.make_request ~query:"what is this?" ~image_media_type:"image/png"
+      ~image_bytes:"\x89PNG"
+  with
+  | Ok r ->
+    assert (String.equal r.V.query "what is this?");
+    assert (String.equal r.V.image_media_type "image/png");
+    assert (String.equal r.V.image_bytes "\x89PNG")
+  | Error e -> failwith e
+
+let test_make_request_rejects_blank_query () =
+  assert (is_error (V.make_request ~query:"   " ~image_media_type:"image/png" ~image_bytes:"x"))
+
+let test_make_request_rejects_empty_bytes () =
+  assert (is_error (V.make_request ~query:"q" ~image_media_type:"image/png" ~image_bytes:""))
+
+let test_make_request_rejects_blank_media_type () =
+  assert (is_error (V.make_request ~query:"q" ~image_media_type:"" ~image_bytes:"x"))
+
+(* ── done_reason normalization ── *)
+
+let test_done_reason_of_string () =
+  assert (V.done_reason_of_string "stop" = V.Stop);
+  assert (V.done_reason_of_string "end_turn" = V.Stop);
+  assert (V.done_reason_of_string "  STOP " = V.Stop);
+  assert (V.done_reason_of_string "length" = V.Length);
+  assert (V.done_reason_of_string "max_tokens" = V.Length);
+  match V.done_reason_of_string "content_filter" with
+  | V.Other s -> assert (String.equal s "content_filter")
+  | _ -> assert false
+
+(* ── classify: the contract ── *)
+
+let test_classify_non_empty_is_ok () =
+  match V.classify ~done_reason:V.Stop ~content:"  Crimson  " with
+  | Ok t -> assert (String.equal t "Crimson")
+  | Error _ -> assert false
+
+(* partial-but-present text under a length cap is still usable -> Ok, not error. *)
+let test_classify_non_empty_under_length_is_ok () =
+  match V.classify ~done_reason:V.Length ~content:"a red square, partially" with
+  | Ok t -> assert (String.equal t "a red square, partially")
+  | Error _ -> assert false
+
+(* the gemma4 case: empty content + length -> truncated, not empty. *)
+let test_classify_empty_length_is_truncated () =
+  assert (V.classify ~done_reason:V.Length ~content:"" = Error V.Truncated_extraction)
+
+let test_classify_whitespace_length_is_truncated () =
+  assert (V.classify ~done_reason:V.Length ~content:"  \n " = Error V.Truncated_extraction)
+
+(* empty content with a normal stop -> empty_extraction (model produced nothing). *)
+let test_classify_empty_stop_is_empty () =
+  assert (V.classify ~done_reason:V.Stop ~content:"" = Error V.Empty_extraction)
+
+let test_classify_empty_other_is_empty () =
+  assert (
+    V.classify ~done_reason:(V.Other "content_filter") ~content:""
+    = Error V.Empty_extraction)
+
+(* never Ok "" — the failure class this RFC targets. *)
+let test_classify_never_ok_empty () =
+  List.iter
+    (fun dr ->
+      match V.classify ~done_reason:dr ~content:"" with
+      | Ok s -> assert (String.length s > 0)
+      | Error _ -> ())
+    [ V.Stop; V.Length; V.Other "x" ]
+
+let test_string_of_error () =
+  assert (String.equal (V.string_of_error V.Empty_extraction) "empty_extraction");
+  assert (String.equal (V.string_of_error V.Truncated_extraction) "truncated_extraction")
+
+let () =
+  test_make_request_ok ();
+  test_make_request_rejects_blank_query ();
+  test_make_request_rejects_empty_bytes ();
+  test_make_request_rejects_blank_media_type ();
+  test_done_reason_of_string ();
+  test_classify_non_empty_is_ok ();
+  test_classify_non_empty_under_length_is_ok ();
+  test_classify_empty_length_is_truncated ();
+  test_classify_whitespace_length_is_truncated ();
+  test_classify_empty_stop_is_empty ();
+  test_classify_empty_other_is_empty ();
+  test_classify_never_ok_empty ();
+  test_string_of_error ();
+  print_endline "test_vision_analyze: all assertions passed"

--- a/test/multimodal/test_vision_artifact_store.ml
+++ b/test/multimodal/test_vision_artifact_store.ml
@@ -1,0 +1,81 @@
+(* Vision_artifact_store tests — content-addressed durable input store.
+   RFC-keeper-vision-delegation-tool §2.5.
+
+   The load-bearing property is round-trip durability: store -> load returns the
+   exact bytes. This is precisely what Payload.of_json (Lazy_payload) fails — it
+   rebuilds an empty closure — so this store is the durable alternative. *)
+
+module S = Multimodal.Vision_artifact_store
+
+(* Deterministic per-run unique dir (no Random; pid + counter isolates runs). *)
+let counter = ref 0
+
+let temp_dir () =
+  incr counter;
+  Filename.concat
+    (Filename.get_temp_dir_name ())
+    (Printf.sprintf "vas_test_%d_%d" (Unix.getpid ()) !counter)
+
+let ok = function
+  | Ok v -> v
+  | Error e -> failwith e
+
+(* store -> load round-trips arbitrary binary bytes losslessly. *)
+let test_round_trip () =
+  let dir = temp_dir () in
+  let bytes = "\x89PNG\r\n\x1a\n\x00\xffbinary\x00\x00bytes\xfe" in
+  let h = ok (S.store ~dir bytes) in
+  assert (String.equal (ok (S.load ~dir h)) bytes)
+
+(* content-addressed: identical bytes -> identical handle. *)
+let test_content_addressed () =
+  let dir = temp_dir () in
+  let h1 = ok (S.store ~dir "abc") in
+  let h2 = ok (S.store ~dir "abc") in
+  assert (String.equal (S.to_string h1) (S.to_string h2))
+
+(* distinct bytes -> distinct handles. *)
+let test_distinct () =
+  let dir = temp_dir () in
+  let h1 = ok (S.store ~dir "abc") in
+  let h2 = ok (S.store ~dir "abd") in
+  assert (not (String.equal (S.to_string h1) (S.to_string h2)))
+
+(* the handle survives a string round-trip (what a checkpoint persists) and the
+   reconstructed handle still loads the original bytes. *)
+let test_persisted_handle_reload () =
+  let dir = temp_dir () in
+  let bytes = "durable-across-checkpoint" in
+  let h = ok (S.store ~dir bytes) in
+  let persisted = S.to_string h in
+  let rewrapped = S.of_string persisted in
+  assert (String.equal (ok (S.load ~dir rewrapped)) bytes)
+
+(* an unknown handle is a typed Error, not a crash or empty success. *)
+let test_missing_is_error () =
+  let dir = temp_dir () in
+  let bogus = S.of_string (String.make 64 'a') in
+  match S.load ~dir bogus with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+(* a tampered file (bytes no longer hash to the handle) is rejected on read. *)
+let test_corruption_detected () =
+  let dir = temp_dir () in
+  let h = ok (S.store ~dir "original") in
+  let path = Filename.concat dir (S.to_string h) in
+  let oc = open_out_bin path in
+  output_string oc "tampered-content";
+  close_out oc;
+  match S.load ~dir h with
+  | Error _ -> ()
+  | Ok _ -> assert false
+
+let () =
+  test_round_trip ();
+  test_content_addressed ();
+  test_distinct ();
+  test_persisted_handle_reload ();
+  test_missing_is_error ();
+  test_corruption_detected ();
+  print_endline "test_vision_artifact_store: all assertions passed"

--- a/test/multimodal/test_vision_artifact_store.ml
+++ b/test/multimodal/test_vision_artifact_store.ml
@@ -71,6 +71,26 @@ let test_corruption_detected () =
   | Error _ -> ()
   | Ok _ -> assert false
 
+(* a malformed handle (path-traversal, non-hex, wrong length, uppercase) is
+   rejected before any filesystem access — fail closed, no read outside [dir]. *)
+let test_malformed_handle_rejected () =
+  let dir = temp_dir () in
+  List.iter
+    (fun bad ->
+      match S.load ~dir (S.of_string bad) with
+      | Error _ -> ()
+      | Ok _ -> assert false)
+    [ "../../etc/passwd";
+      "/etc/passwd";
+      "a/b";
+      "not-hex-string";
+      "";
+      String.make 63 'a';
+      (* one short *)
+      String.make 65 'a';
+      (* one long *)
+      String.make 64 'A' (* uppercase: not canonical *) ]
+
 let () =
   test_round_trip ();
   test_content_addressed ();
@@ -78,4 +98,5 @@ let () =
   test_persisted_handle_reload ();
   test_missing_is_error ();
   test_corruption_detected ();
+  test_malformed_handle_rejected ();
   print_endline "test_vision_artifact_store: all assertions passed"


### PR DESCRIPTION
## 무엇을

RFC-keeper-vision-delegation-tool(#22241) §2.5의 **durable content-addressed 입력 이미지 store** 첫 구현 (Phase 0b-A).

## 왜

적대 리뷰가 잡은 #1 결함: 기존 `Multimodal.Workspace`/`Payload`는 (a) output-side, (b) `MASC_MULTIMODAL` off, (c) `Payload.of_json`이 lossy(`Lazy_payload (fun () -> "")`, `payload.mli:35-42`) — checkpoint/재시작 후 빈 바이트. 위임 도구의 multi-turn 재질의가 영속 경계에서 깨집니다. 이 PR이 그 durable 대안을 제공합니다.

## 변경

- `lib/multimodal/vision_artifact_store.ml/.mli`: `store ~dir bytes -> handle`(content-addressed SHA-256 파일), `load ~dir handle -> bytes`. handle은 평문 string(content hash)이라 JSON/checkpoint round-trip 안전 — 바이트를 파일로 빼서 lossy `Payload.of_json` 경로를 우회.
- load 시 content-addressing 재검증: 파일이 handle로 다시 hash되지 않으면 **typed Error**(손상/위조 handle), 절대 silent empty success 없음 — 이 RFC가 겨냥하는 실패 클래스를 도구 내부에서 재현하지 않음.
- `Review_artifact_store` 패턴 미러링(`Digestif.SHA256` + `Fs_compat.save_file_atomic`). multimodal deps에 `fs_compat digestif` 추가(cycle 없음 확인).

## 검증

- `test_vision_artifact_store`: round-trip durability(lossy `Payload.of_json`가 실패하는 그 속성), content-addressing, distinct handles, persisted-handle reload(checkpoint shape), missing→Error, corruption→Error. revert-red 가능.
- `dune build --root . @test/multimodal/runtest` green (형제 테스트 회귀 없음).

## 추가: store path-traversal 하드닝 (자기 리뷰)

`of_string`이 임의 영속 string을 handle로 재포장 → `load`의 `Filename.concat dir h`로 `"../../etc/passwd"` 같은 위조 handle이 **임의 파일 읽기** 유발(content-addressing은 byte mismatch만 막음). `load`가 fs 접근 *전에* canonical 64자 lowercase hex가 아니면 거부(fail closed). `store`는 항상 canonical hex 생성이라 정상 load 무영향. malformed-handle 거부 테스트 추가.

## 추가: `analyze_image` 순수 계약 (`Vision_analyze`)

§2.2 도구의 입력/출력 순수 코어 (provider transport 비의존; §2.6 mid-turn sub-call은 impure shell, 다음 청크):
- `make_request`: 경계 입력 검증(non-blank query/media-type, non-empty bytes), fail closed.
- `classify`: 실패 계약 강제 — trimmed-non-empty → `Ok`; empty + `done_reason=length` → `Truncated_extraction`(#4 gemma4 측정 원인); empty 그 외 → `Empty_extraction`. **절대 `Ok ""` 없음.**
- `done_reason_of_string`: provider terminal reason 정규화(unknown은 `Other` 보존, Unknown→Permissive 금지).
- `test_vision_analyze`: 계약 lock("never Ok empty" 포함).

## 범위 / 다음

후속(미구현, 별도 청크): `analyze_image`의 **impure shell** — mid-turn provider sub-call(§2.6, Eio 컨텍스트 배선) + 도구 등록/dispatch, ingestion interception 양 사이트(§2.3), `multimodal_policy` 축(§2.4). RFC가 Draft이므로 이 PR도 Draft 유지.

RFC-WAIVED: 설계 RFC #22241 동반. lib/multimodal은 RFC-gated subsystem(credential/operator/sandbox/hooks) 미해당.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
