### PR TITLE
feat(dashboard): wire Fusion surface to latest metadata, render rich text, expose params

### DIFF
--- a/dashboard/src/components/fusion/fusion-surface.test.ts
+++ b/dashboard/src/components/fusion/fusion-surface.test.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import { render } from 'preact'
+import { h, render } from 'preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { BoardPost } from '../../types'
 import { route } from '../../router'
@@ -22,6 +22,15 @@ vi.mock('../../store', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../store')>()
   return { ...actual, refreshFusionBoard: vi.fn(), refreshFusionRuns: vi.fn() }
 })
+
+// The Markdown renderer is lazy-loaded, which makes synchronous assertions
+// flaky inside the Fusion surface tests. Mock it to a synchronous renderer so
+// we can assert that RichContent is used without waiting for the async chunk.
+vi.mock('../common/markdown', () => ({
+  Markdown: function Markdown(props: { text: string; class?: string }) {
+    return h('div', { className: `markdown-content ${props.class ?? ''}`.trim() }, props.text)
+  },
+}))
 
 function boardPost(overrides: Partial<BoardPost> & { id: string; meta: BoardPost['meta'] }): BoardPost {
   const { id, meta, ...rest } = overrides
@@ -354,6 +363,37 @@ describe('FusionSurface', () => {
     expect(container.textContent).not.toContain('No fusion runs found')
   })
 
+  it('renders preset from registry when board meta does not carry it', () => {
+    fusionRuns.value = [
+      {
+        runId: 'fus-1',
+        keeper: 'sangsu',
+        preset: 'balanced',
+        startedAt: 1_780_000_000,
+        status: 'running',
+      },
+    ]
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-fus-1',
+        title: 'Fusion deliberation (run fus-1): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-1',
+          question: 'Which path?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const detail = container.querySelector('[data-testid="fusion-detail"]')
+    expect(detail?.textContent).toContain('preset · balanced')
+    expect(detail?.textContent).not.toContain('preset · n/a')
+  })
+
   it('manual Refresh fans out to both the board-meta detail and the run-status registry', () => {
     render(html`<${FusionSurface} />`, container)
     const refresh = container.querySelector<HTMLButtonElement>('.fus-refresh')
@@ -404,6 +444,171 @@ describe('FusionSurface', () => {
     expect(cards[0]?.classList.contains('answered')).toBe(true)
     expect(cards[0]?.classList.contains('failed')).toBe(false)
     expect(cards[1]?.classList.contains('failed')).toBe(true)
+  })
+
+  it('renders generation parameters when present in board meta', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-params',
+        title: 'Fusion deliberation (run fus-params): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-params',
+          question: 'Which path?',
+          temperature: 0.7,
+          top_p: 0.95,
+          top_k: 40,
+          max_tokens: 2048,
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const detail = container.querySelector('[data-testid="fusion-detail"]')
+    expect(detail?.textContent).toContain('temperature')
+    expect(detail?.textContent).toContain('0.7')
+    expect(detail?.textContent).toContain('top_p')
+    expect(detail?.textContent).toContain('0.95')
+    expect(detail?.textContent).toContain('top_k')
+    expect(detail?.textContent).toContain('40')
+    expect(detail?.textContent).toContain('max_tokens')
+    expect(detail?.textContent).toContain('2048')
+  })
+
+  it('hides the generation parameters block when no params are present', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-no-params',
+        title: 'Fusion deliberation (run fus-no-params): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-no-params',
+          question: 'Which path?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const detail = container.querySelector('[data-testid="fusion-detail"]')
+    expect(detail?.textContent).not.toContain('생성 파라미터')
+  })
+
+  it('renders the deliberation prompt as rich content', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-rich-prompt',
+        title: 'Fusion deliberation (run fus-rich-prompt): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-rich-prompt',
+          question: 'Check **this** [link](https://example.com).',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'OK.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Done.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const prompt = container.querySelector('[data-testid="fusion-detail"] .fus-prompt')
+    expect(prompt?.querySelector('.markdown-content')).not.toBeNull()
+    expect(prompt?.textContent).toContain('this')
+    expect(prompt?.textContent).toContain('link')
+  })
+
+  it('renders panel answers as rich content', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-rich-panel',
+        title: 'Fusion deliberation (run fus-rich-panel): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-rich-panel',
+          question: 'Which path?',
+          panel: [
+            {
+              model: 'gpt-5',
+              status: 'answered',
+              answer: 'Use **canary** first.',
+            },
+          ],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const panel = container.querySelector('.fus-panel-card')
+    expect(panel?.querySelector('.markdown-content')).not.toBeNull()
+    expect(panel?.textContent).toContain('canary')
+  })
+
+  it('renders judge evidence text as rich content', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-rich-judge',
+        title: 'Fusion deliberation (run fus-rich-judge): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-rich-judge',
+          question: 'Which path?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
+          judge: {
+            status: 'synthesized',
+            decision: 'answer',
+            resolved_answer: 'Ship canary.',
+            consensus: [{ text: '**Canary** is safer.', models: ['gpt-5'] }],
+          },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const evidence = container.querySelector('[data-testid="fusion-judge-evidence"]')
+    expect(evidence?.querySelector('.markdown-content')).not.toBeNull()
+    expect(evidence?.textContent).toContain('Canary')
+  })
+
+  it('renders resolved answer and recommendation rationale as rich content', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-rich-resolved',
+        title: 'Fusion deliberation (run fus-rich-resolved): recommend',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-rich-resolved',
+          question: 'Which path?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
+          judge: {
+            status: 'synthesized',
+            decision: 'recommend',
+            resolved_answer: 'Ship **canary**.',
+            recommend: {
+              action: 'publish note',
+              rationale: 'Because **rollback** is covered.',
+            },
+          },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const resolved = container.querySelector('.fus-resolved-body')
+    expect(resolved?.querySelector('.markdown-content')).not.toBeNull()
+    expect(resolved?.textContent).toContain('canary')
+
+    const rationale = container.querySelector('.fus-rec-rationale')
+    expect(rationale?.querySelector('.markdown-content')).not.toBeNull()
+    expect(rationale?.textContent).toContain('rollback')
   })
 })
 

--- a/dashboard/src/components/fusion/fusion-surface.ts
+++ b/dashboard/src/components/fusion/fusion-surface.ts
@@ -12,6 +12,7 @@ import {
 } from '../../store'
 import { TimeAgo } from '../common/time-ago'
 import { ringFocusClasses } from '../common/ring'
+import { RichContent } from '../common/rich-content'
 import { AgentAvatar } from '../overview/agent-avatar'
 import { FusionRunsPanel } from './fusion-runs-panel'
 import { asRecord, asString, asStringArray } from '../common/normalize'
@@ -94,6 +95,13 @@ interface FusionUsage {
   costUsd: number | null
 }
 
+interface FusionRunParams {
+  temperature: number | null
+  topP: number | null
+  topK: number | null
+  maxTokens: number | null
+}
+
 interface FusionRunView {
   runId: string
   boardPostId: string
@@ -106,6 +114,8 @@ interface FusionRunView {
   judge: FusionJudge
   judges: FusionJudgeNode[]
   usage: FusionUsage
+  preset: string | null
+  params: FusionRunParams
   createdAt: string
   updatedAt: string
 }
@@ -244,6 +254,15 @@ function normalizeUsage(meta: Record<string, unknown>, panel: FusionPanelEntry[]
   }
 }
 
+function normalizeParams(meta: Record<string, unknown>): FusionRunParams {
+  return {
+    temperature: firstNumber(meta, ['temperature']),
+    topP: firstNumber(meta, ['top_p', 'topP']),
+    topK: firstNumber(meta, ['top_k', 'topK']),
+    maxTokens: firstNumber(meta, ['max_tokens', 'maxTokens']),
+  }
+}
+
 function statusFor(judge: FusionJudge, panel: FusionPanelEntry[]): FusionRunStatus {
   const status = judge.status?.toLowerCase() ?? ''
   if (status.includes('fail')) return 'failed'
@@ -304,6 +323,7 @@ function fusionRunFromPost(post: BoardPost): FusionRunView | null {
   const judge = normalizeJudge(meta.judge)
   const judges = normalizeFusionJudgeNodes(meta.judges)
   const usage = normalizeUsage(meta, panel)
+  const params = normalizeParams(meta)
   const runId = firstString(meta, ['run_id', 'runId', 'id']) ?? post.id
   const question = firstString(meta, ['question', 'prompt']) ?? post.body ?? post.content ?? post.title
   const status = statusFor(judge, panel)
@@ -321,6 +341,8 @@ function fusionRunFromPost(post: BoardPost): FusionRunView | null {
     judge,
     judges,
     usage,
+    preset: null,
+    params,
     createdAt: post.created_at,
     updatedAt: post.updated_at || post.created_at,
   }
@@ -514,7 +536,7 @@ function FusionPanelCard({ entry }: { entry: FusionPanelEntry }) {
             : null}
       </div>
       ${failed
-        ? null
+        ? html`<div class="fus-pans failed">${body}</div>`
         : html`
             <div
               class=${`fus-pans ${open ? 'open' : ''}`}
@@ -528,7 +550,7 @@ function FusionPanelCard({ entry }: { entry: FusionPanelEntry }) {
                   setOpen(prev => !prev)
                 }
               }}
-            >${body}</div>
+            ><${RichContent} text=${body} previewLimit=${0} /></div>
           `}
     </article>
   `
@@ -570,7 +592,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
           </h5>
           ${judge.consensus.map((claim, index) => html`
             <div class="fus-claim" key=${`consensus-${index}`}>
-              <p>${claim.text}</p>
+              <p><${RichContent} text=${claim.text} previewLimit=${0} /></p>
               <${FusionModelChips} models=${claim.models} />
             </div>
           `)}
@@ -586,7 +608,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
                     ${contradiction.positions.map(position => html`
                       <div class="fus-pos" key=${`${contradiction.topic}:${position.model}`}>
                         <span class="fus-pos-m mono">${position.model}</span>
-                        <span class="fus-pos-s">${position.stance}</span>
+                        <span class="fus-pos-s"><${RichContent} text=${position.stance} previewLimit=${0} /></span>
                       </div>
                     `)}
                   </div>
@@ -608,7 +630,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
                     </div>
                     <div class="fus-gap-row">
                       <span class="k">누락</span>
-                      <span class="fus-gap-miss">${gap.missing}</span>
+                      <span class="fus-gap-miss"><${RichContent} text=${gap.missing} previewLimit=${0} /></span>
                     </div>
                   </div>
                 `)}
@@ -622,7 +644,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
                 <h5><span class="fus-jglyph">✦</span>고유 통찰 <span class="n">${judge.uniqueInsights.length}</span></h5>
                 ${judge.uniqueInsights.map((insight, index) => html`
                   <div class="fus-insight" key=${`insight-${index}`}>
-                    <p>${insight.text}</p>
+                    <p><${RichContent} text=${insight.text} previewLimit=${0} /></p>
                     ${insight.model ? html`<span class="fus-mchip mono">${insight.model}</span>` : null}
                   </div>
                 `)}
@@ -634,7 +656,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
           ? html`
               <section class="fus-jsec blind">
                 <h5><span class="fus-jglyph">⚠</span>사각지대 <span class="n">${judge.blindSpots.length}</span></h5>
-                <ul class="fus-blind">${judge.blindSpots.map(item => html`<li key=${item}>${item}</li>`)}</ul>
+                <ul class="fus-blind">${judge.blindSpots.map(item => html`<li key=${item}><${RichContent} text=${item} previewLimit=${0} /></li>`)}</ul>
               </section>
             `
           : null}
@@ -643,7 +665,7 @@ function FusionJudgeEvidence({ judge }: { judge: FusionJudge }) {
           ? html`
               <section class="fus-jsec blind">
                 <h5><span class="fus-jglyph">⚠</span>부족한 입력 <span class="n">${judge.missingInputs.length}</span></h5>
-                <ul class="fus-blind">${judge.missingInputs.map(item => html`<li key=${item}>${item}</li>`)}</ul>
+                <ul class="fus-blind">${judge.missingInputs.map(item => html`<li key=${item}><${RichContent} text=${item} previewLimit=${0} /></li>`)}</ul>
               </section>
             `
           : null}
@@ -685,6 +707,22 @@ function FusionRunRow({ run, active }: { run: FusionRunView; active: boolean }) 
   `
 }
 
+function findPreset(runId: string): string | null {
+  return fusionRuns.value.find(run => run.runId === runId)?.preset ?? null
+}
+
+function paramChip(label: string, value: number | null): ReturnType<typeof html> | null {
+  if (value === null) return null
+  return html`<span class="fus-param"><span class="k">${label}</span><span class="v">${value}</span></span>`
+}
+
+function hasParams(params: FusionRunParams): boolean {
+  return params.temperature !== null
+    || params.topP !== null
+    || params.topK !== null
+    || params.maxTokens !== null
+}
+
 function FusionRunDetail({ run }: { run: FusionRunView }) {
   const answered = run.panel.filter(entry => !isPanelFailure(entry.status)).length
   const failed = run.panel.length - answered
@@ -692,6 +730,7 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
   const dec = decisionSpecFor(run.judge.decision)
   const decClass = dec && dec.cls ? `dec-${dec.cls}` : ''
   const tokenLabel = combinedTokenLabel(run.usage)
+  const preset = run.preset ?? findPreset(run.runId)
 
   return html`
     <div class="fus-run-scroll" data-testid="fusion-detail">
@@ -699,7 +738,7 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
         <div class="fus-run-id-row">
           <${FusionStatusGlyph} status=${run.status} />
           <h1 class="mono">${run.runId}</h1>
-          <span class="fus-preset" title="runtime.toml [fusion.presets.*]" data-stub="preset not joined into board-derived run view (registry-only field)">preset · n/a</span>
+          ${preset ? html`<span class="fus-preset" title="runtime.toml [fusion.presets.*]">preset · ${preset}</span>` : null}
           <span class=${`fus-status tone-${run.tone}`}>${statusLabel(run.status)}</span>
         </div>
         <div class="fus-run-by">
@@ -721,6 +760,20 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
 
       <${FusionPipelineStrip} run=${run} />
 
+      ${hasParams(run.params)
+        ? html`
+            <div class="fus-block">
+              <div class="fus-block-lbl">생성 파라미터</div>
+              <div class="fus-params">
+                ${paramChip('temperature', run.params.temperature)}
+                ${paramChip('top_p', run.params.topP)}
+                ${paramChip('top_k', run.params.topK)}
+                ${paramChip('max_tokens', run.params.maxTokens)}
+              </div>
+            </div>
+          `
+        : null}
+
       <div class="fus-kpis" aria-label="Fusion run metrics">
         <${FusionMetric}
           label="패널"
@@ -739,7 +792,7 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
 
       <div class="fus-block">
         <div class="fus-block-lbl">심의 프롬프트</div>
-        <div class="fus-prompt">${run.question}</div>
+        <div class="fus-prompt"><${RichContent} text=${run.question} previewLimit=${0} /></div>
       </div>
 
       <div class="fus-block">
@@ -786,9 +839,9 @@ function FusionRunDetail({ run }: { run: FusionRunView }) {
             : null}
         </div>
         <div class="fus-resolved-lbl">resolved_answer</div>
-        <p class="fus-resolved-body">${resolved}</p>
+        <p class="fus-resolved-body"><${RichContent} text=${resolved} previewLimit=${0} /></p>
         ${run.judge.recommendation?.rationale
-          ? html`<p class="fus-rec-rationale"><span class="k">근거</span>${run.judge.recommendation.rationale}</p>`
+          ? html`<p class="fus-rec-rationale"><span class="k">근거</span><${RichContent} text=${run.judge.recommendation.rationale} previewLimit=${0} /></p>`
           : null}
         ${run.judge.missingInputs.length > 0
           ? html`

--- a/dashboard/src/styles/fusion-v2.css
+++ b/dashboard/src/styles/fusion-v2.css
@@ -79,6 +79,7 @@
   font-weight: 760;
   line-height: 1.05;
   overflow-wrap: anywhere;
+  text-wrap: pretty;
 }
 
 .v2-fusion-surface .fus-kpi.tone-ok .fus-kpi-v {
@@ -1007,4 +1008,55 @@ button.fus-reconcile-row:hover {
   .v2-fusion-surface .fus-runs-pipe-node:not(:last-child)::after {
     display: none;
   }
+}
+
+.v2-fusion-surface .fus-params {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.v2-fusion-surface .fus-param {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-1);
+  background: var(--fus-panel-strong);
+  padding: 4px 8px;
+  font-size: 11px;
+}
+
+.v2-fusion-surface .fus-param .k {
+  color: var(--fus-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-transform: uppercase;
+  font-size: 9.5px;
+}
+
+.v2-fusion-surface .fus-param .v {
+  color: var(--fus-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.v2-fusion-surface .fus-pans.failed {
+  color: var(--bad-light);
+  cursor: default;
+}
+
+/* Unified long-text wrapping for the standalone Fusion surface.
+   Keep CJK readability while allowing arbitrary identifiers/URLs to break. */
+.v2-fusion-surface .fus-prompt,
+.v2-fusion-surface .fus-resolved-body,
+.v2-fusion-surface .fus-panel-body,
+.v2-fusion-surface .fus-jrow,
+.v2-fusion-surface .fus-gap-miss,
+.v2-fusion-surface .fus-pos-s,
+.v2-fusion-surface .fus-claim p,
+.v2-fusion-surface .fus-insight p,
+.v2-fusion-surface .fus-blind li,
+.v2-fusion-surface .fus-missing li,
+.v2-fusion-surface .fus-rec-rationale .markdown-content {
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
 }

--- a/docs/design/2026-06-24-fusion-dashboard-wiring-rich-text-design.md
+++ b/docs/design/2026-06-24-fusion-dashboard-wiring-rich-text-design.md
@@ -1,0 +1,186 @@
+# Fusion Dashboard Wiring & Rich-Text Rendering Update
+
+- Date: 2026-06-24
+- Author: kimi-code
+- Scope: `~/me/workspace/yousleepwhen/masc/dashboard` (runtime `<MASC_BASE_PATH>/.masc`)
+- Status: Approved for implementation
+
+## Goal
+
+Update the standalone Fusion Dashboard surface so that it keeps up with the latest Fusion backend metadata, renders deliberation prompts and panel/judge answers as rich text, exposes generation parameters, and remains consistent on mobile with predictable word-breaking.
+
+## Out of scope
+
+- Backend timeout / panel failure root-cause analysis (separate issue).
+- Full unification of the standalone Fusion surface and the inline board evidence card.
+- Prototype-v2 design-system parity sweep.
+
+## Background
+
+Recent Fusion backend work (RFC-0284 judge observation record, judge-of-judges topology, etc.) added new fields to board posts. The inline board evidence card (`dashboard/src/components/board/fusion-evidence.ts`) already consumes `judges`, uses `RichContent`, and has a compact Tailwind-like markup. The standalone Fusion surface (`dashboard/src/components/fusion/fusion-surface.ts`) lags behind: it still renders prompts/answers as plain text, carries a `preset · n/a` stub, and does not expose generation parameters. Its styles are split between `fusion-v2.css` and `keeper-v2/fusion.css`, causing word-break and mobile inconsistencies.
+
+## Design
+
+### 1. Data model
+
+Extend `FusionRunView` and add a parameter type in `dashboard/src/components/fusion/fusion-surface.ts`:
+
+```ts
+interface FusionRunParams {
+  temperature: number | null
+  topP: number | null
+  topK: number | null
+  maxTokens: number | null
+}
+
+interface FusionRunView {
+  // ...existing fields
+  preset: string | null
+  params: FusionRunParams
+}
+```
+
+Add a normalizer:
+
+```ts
+function normalizeParams(meta: Record<string, unknown>): FusionRunParams {
+  return {
+    temperature: firstNumber(meta, ['temperature']),
+    topP: firstNumber(meta, ['top_p', 'topP']),
+    topK: firstNumber(meta, ['top_k', 'topK']),
+    maxTokens: firstNumber(meta, ['max_tokens', 'maxTokens']),
+  }
+}
+```
+
+`preset` is currently registry-only. Derive it by looking up the same `runId` in `fusionRuns.value`; if absent, hide the preset chip instead of rendering a stub.
+
+### 2. Rich-text rendering
+
+Import `RichContent` from `../common/rich-content` and replace plain text in:
+
+| Location | Current | Change |
+|----------|---------|--------|
+| Deliberation prompt (`fusion-surface.ts:741-742`) | `<div class="fus-prompt">${run.question}</div>` | `<div class="fus-prompt"><${RichContent} text=${run.question} previewLimit=${0} /></div>` |
+| Panel answer (`FusionPanelCard`) | `<div class="fus-pans">${body}</div>` | Use `RichContent` when `entry.answer` is present; keep `entry.reason` plain. |
+| Judge synthesis / consensus / contradictions / coverage / insights (`FusionJudgeEvidence`) | `<p>${text}</p>` | Wrap long text with `RichContent`. Short chips/labels stay plain. |
+| Resolved answer (`fusion-surface.ts:789`) | `<p class="fus-resolved-body">${resolved}</p>` | `<p class="fus-resolved-body"><${RichContent} text=${resolved} previewLimit=${0} /></p>` |
+| Recommendation rationale (`fusion-surface.ts:791`) | Plain text span | `RichContent` |
+
+`RichContent` already handles markdown and link previews. `previewLimit=${0}` disables link previews inside dense panels to avoid performance overhead.
+
+### 3. Generation parameters UI
+
+Add a new block in `FusionRunDetail`, placed after the pipeline strip:
+
+```ts
+<div class="fus-block">
+  <div class="fus-block-lbl">생성 파라미터</div>
+  <div class="fus-params">
+    ${paramChip('temperature', run.params.temperature)}
+    ${paramChip('top_p', run.params.topP)}
+    ${paramChip('top_k', run.params.topK)}
+    ${paramChip('max_tokens', run.params.maxTokens)}
+  </div>
+</div>
+```
+
+`paramChip` returns `null` when the value is `null`. If all values are `null`, the entire block is hidden.
+
+### 4. CSS / word-break consistency
+
+Treat `dashboard/src/styles/fusion-v2.css` as the SSOT for the standalone surface. Make no changes to `keeper-v2/fusion.css`.
+
+Add a single shared rule for long text containers:
+
+```css
+.v2-fusion-surface .fus-prompt,
+.v2-fusion-surface .fus-resolved-body,
+.v2-fusion-surface .fus-panel-body,
+.v2-fusion-surface .fus-jrow,
+.v2-fusion-surface .fus-gap-miss,
+.v2-fusion-surface .fus-pos-s,
+.v2-fusion-surface .fus-claim p,
+.v2-fusion-surface .fus-insight p,
+.v2-fusion-surface .fus-blind li,
+.v2-fusion-surface .fus-missing li {
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+```
+
+Also align `.fus-kpi-v` with the same rule (it already uses `overflow-wrap: anywhere`).
+
+Add parameter chip styling:
+
+```css
+.v2-fusion-surface .fus-params {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.v2-fusion-surface .fus-param {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-1);
+  background: var(--fus-panel-strong);
+  padding: 4px 8px;
+  font-size: 11px;
+}
+
+.v2-fusion-surface .fus-param .k {
+  color: var(--fus-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-transform: uppercase;
+  font-size: 9.5px;
+}
+
+.v2-fusion-surface .fus-param .v {
+  color: var(--fus-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+```
+
+### 5. Mobile refinements
+
+Existing media queries handle most collapse. Verify and tighten:
+
+- `.fus-params` wraps via `flex-wrap: wrap`.
+- `.fus-pipe` already uses `flex-wrap: wrap`.
+- `.fus-panel-grid` already collapses via `repeat(auto-fit, minmax(248px, 1fr))`.
+- No additional breakpoint needed.
+
+### 6. Error / empty states
+
+- If all params are `null`, omit the parameters block.
+- If `preset` lookup fails, omit the preset chip.
+- `RichContent` returns `null` for empty strings, so guard clauses around `body`/`resolved` remain valid.
+
+### 7. Testing
+
+Update `dashboard/src/components/fusion/fusion-surface.test.ts`:
+
+- Assert that the deliberation prompt container contains a `.markdown-body` child.
+- Assert that a panel answer renders inside `RichContent` (`.markdown-body`) when `entry.answer` is present.
+- Assert that parameter chips render for `temperature`, `top_p`, `top_k`, `max_tokens`.
+- Assert that the `preset` stub is gone and the preset chip renders only when data is present.
+- Run `npx tsc --noEmit --pretty` from the dashboard root and the affected unit tests.
+
+## Files to change
+
+1. `dashboard/src/components/fusion/fusion-surface.ts`
+2. `dashboard/src/styles/fusion-v2.css`
+3. `dashboard/src/components/fusion/fusion-surface.test.ts`
+
+## Acceptance criteria
+
+- [ ] `preset · n/a` stub is removed; preset renders only when available.
+- [ ] Deliberation prompt, panel answers, judge evidence, and resolved answer render with `RichContent`.
+- [ ] `temperature`, `top_p`, `top_k`, `max_tokens` are displayed as chips when present.
+- [ ] Long text wraps consistently via `overflow-wrap: anywhere; text-wrap: pretty;`.
+- [ ] Mobile layout remains usable (parameters wrap, panels collapse, pipeline wraps).
+- [ ] Existing tests pass and new assertions are added.
+- [ ] Type check passes (`npx tsc --noEmit --pretty`).

--- a/docs/design/2026-06-24-fusion-dashboard-wiring-rich-text-plan.md
+++ b/docs/design/2026-06-24-fusion-dashboard-wiring-rich-text-plan.md
@@ -1,0 +1,834 @@
+# Fusion Dashboard Wiring & Rich-Text Rendering Update — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-_SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the standalone Fusion Dashboard surface to expose backend metadata (preset, generation params), render prompts/answers with `RichContent`, and fix word-break/mobile consistency.
+
+**Architecture:** Keep all changes inside the standalone Fusion surface (`dashboard/src/components/fusion/fusion-surface.ts` and its CSS) without touching the inline board evidence card. Extend the existing view model, add defensive normalizers, swap plain text for `RichContent`, and add a parameter chip block plus CSS word-break rules.
+
+**Tech Stack:** Preact + htm, TypeScript, Vite/Vitest, CSS modules in `dashboard/src/styles/fusion-v2.css`.
+
+---
+
+## Scope check
+
+This plan covers a single subsystem: the standalone Fusion surface. The inline board evidence card already uses `RichContent` and is out of scope. Backend timeout investigation is out of scope per the design doc.
+
+## File structure
+
+| File | Responsibility |
+|------|----------------|
+| `dashboard/src/components/fusion/fusion-surface.ts` | View model, normalizers, components, rendering. All runtime changes live here. |
+| `dashboard/src/styles/fusion-v2.css` | SSOT styles for the standalone surface: parameter chips, word-break rules, mobile helpers. |
+| `dashboard/src/components/fusion/fusion-surface.test.ts` | Unit tests for the new behavior. |
+
+---
+
+## Task 1: Extend view model and add parameter normalizer
+
+**Files:**
+- Modify: `dashboard/src/components/fusion/fusion-surface.ts`
+
+### Step 1.1: Add `FusionRunParams` interface and update `FusionRunView`
+
+Insert after the `FusionUsage` interface (around line 95):
+
+```ts
+interface FusionRunParams {
+  temperature: number | null
+  topP: number | null
+  topK: number | null
+  maxTokens: number | null
+}
+```
+
+Update `FusionRunView` (around line 97):
+
+```ts
+interface FusionRunView {
+  runId: string
+  boardPostId: string
+  keeperName: string
+  title: string
+  question: string
+  status: FusionRunStatus
+  tone: FusionTone
+  panel: FusionPanelEntry[]
+  judge: FusionJudge
+  judges: FusionJudgeNode[]
+  usage: FusionUsage
+  preset: string | null
+  params: FusionRunParams
+  createdAt: string
+  updatedAt: string
+}
+```
+
+### Step 1.2: Add `normalizeParams` helper
+
+Insert after `normalizeUsage` (around line 245):
+
+```ts
+function normalizeParams(meta: Record<string, unknown>): FusionRunParams {
+  return {
+    temperature: firstNumber(meta, ['temperature']),
+    topP: firstNumber(meta, ['top_p', 'topP']),
+    topK: firstNumber(meta, ['top_k', 'topK']),
+    maxTokens: firstNumber(meta, ['max_tokens', 'maxTokens']),
+  }
+}
+```
+
+### Step 1.3: Update `fusionRunFromPost` to populate `preset` and `params`
+
+Inside `fusionRunFromPost`, after `const usage = normalizeUsage(meta, panel)` add:
+
+```ts
+  const params = normalizeParams(meta)
+```
+
+And add `preset: null` and `params` to the returned object:
+
+```ts
+  return {
+    runId,
+    boardPostId: post.id,
+    keeperName: keeperNameFor(post),
+    title: post.title || `Fusion run ${runId}`,
+    question,
+    status,
+    tone,
+    panel,
+    judge,
+    judges,
+    usage,
+    preset: null,
+    params,
+    createdAt: post.created_at,
+    updatedAt: post.updated_at || post.created_at,
+  }
+```
+
+### Step 1.4: Type check
+
+Run:
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npx tsc --noEmit --pretty
+```
+
+Expected: no type errors.
+
+---
+
+## Task 2: Wire preset from the registry
+
+**Files:**
+- Modify: `dashboard/src/components/fusion/fusion-surface.ts`
+
+### Step 2.1: Add `findPreset` helper
+
+Insert before `FusionRunDetail` (around line 688):
+
+```ts
+function findPreset(runId: string): string | null {
+  return fusionRuns.value.find(run => run.runId === runId)?.preset ?? null
+}
+```
+
+### Step 2.2: Compute preset inside `FusionRunDetail`
+
+Inside `FusionRunDetail`, after the existing destructurings add:
+
+```ts
+  const preset = run.preset ?? findPreset(run.runId)
+```
+
+### Step 2.3: Replace the stub preset chip
+
+Replace lines 700-702:
+
+```ts
+          <span class="fus-preset" title="runtime.toml [fusion.presets.*]" data-stub="preset not joined into board-derived run view (registry-only field)">preset · n/a</span>
+```
+
+with:
+
+```ts
+          ${preset ? html`<span class="fus-preset" title="runtime.toml [fusion.presets.*]">preset · ${preset}</span>` : null}
+```
+
+### Step 2.4: Add a test for preset wiring
+
+In `dashboard/src/components/fusion/fusion-surface.test.ts`, add inside the `FusionSurface` describe block:
+
+```ts
+  it('renders preset from registry when board meta does not carry it', () => {
+    fusionRuns.value = [
+      {
+        runId: 'fus-1',
+        keeper: 'sangsu',
+        preset: 'balanced',
+        startedAt: 1_780_000_000,
+        status: 'running',
+      },
+    ]
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-fus-1',
+        title: 'Fusion deliberation (run fus-1): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-1',
+          question: 'Which path?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const detail = container.querySelector('[data-testid="fusion-detail"]')
+    expect(detail?.textContent).toContain('preset · balanced')
+    expect(detail?.textContent).not.toContain('preset · n/a')
+  })
+```
+
+### Step 2.5: Run the new test
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npx vitest run src/components/fusion/fusion-surface.test.ts -t "renders preset from registry"
+```
+
+Expected: PASS.
+
+---
+
+## Task 3: Add generation parameter UI
+
+**Files:**
+- Modify: `dashboard/src/components/fusion/fusion-surface.ts`
+- Modify: `dashboard/src/styles/fusion-v2.css`
+
+### Step 3.1: Add `paramChip` helper
+
+Insert before `FusionRunDetail`:
+
+```ts
+function paramChip(label: string, value: number | null): ReturnType<typeof html> | null {
+  if (value === null) return null
+  return html`<span class="fus-param"><span class="k">${label}</span><span class="v">${value}</span></span>`
+}
+
+function hasParams(params: FusionRunParams): boolean {
+  return params.temperature !== null
+    || params.topP !== null
+    || params.topK !== null
+    || params.maxTokens !== null
+}
+```
+
+### Step 3.2: Add the parameters block to `FusionRunDetail`
+
+Insert after `<${FusionPipelineStrip} run=${run} />` (around line 722):
+
+```ts
+      ${hasParams(run.params)
+        ? html`
+            <div class="fus-block">
+              <div class="fus-block-lbl">생성 파라미터</div>
+              <div class="fus-params">
+                ${paramChip('temperature', run.params.temperature)}
+                ${paramChip('top_p', run.params.topP)}
+                ${paramChip('top_k', run.params.topK)}
+                ${paramChip('max_tokens', run.params.maxTokens)}
+              </div>
+            </div>
+          `
+        : null}
+```
+
+### Step 3.3: Add CSS for parameter chips
+
+Append to `dashboard/src/styles/fusion-v2.css`:
+
+```css
+.v2-fusion-surface .fus-params {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.v2-fusion-surface .fus-param {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--fus-line);
+  border-radius: var(--r-1);
+  background: var(--fus-panel-strong);
+  padding: 4px 8px;
+  font-size: 11px;
+}
+
+.v2-fusion-surface .fus-param .k {
+  color: var(--fus-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  text-transform: uppercase;
+  font-size: 9.5px;
+}
+
+.v2-fusion-surface .fus-param .v {
+  color: var(--fus-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+```
+
+### Step 3.4: Add a test for parameter rendering
+
+In `dashboard/src/components/fusion/fusion-surface.test.ts`:
+
+```ts
+  it('renders generation parameters when present in board meta', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-params',
+        title: 'Fusion deliberation (run fus-params): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-params',
+          question: 'Which path?',
+          temperature: 0.7,
+          top_p: 0.95,
+          top_k: 40,
+          max_tokens: 2048,
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const detail = container.querySelector('[data-testid="fusion-detail"]')
+    expect(detail?.textContent).toContain('temperature')
+    expect(detail?.textContent).toContain('0.7')
+    expect(detail?.textContent).toContain('top_p')
+    expect(detail?.textContent).toContain('0.95')
+    expect(detail?.textContent).toContain('top_k')
+    expect(detail?.textContent).toContain('40')
+    expect(detail?.textContent).toContain('max_tokens')
+    expect(detail?.textContent).toContain('2048')
+  })
+
+  it('hides the generation parameters block when no params are present', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-no-params',
+        title: 'Fusion deliberation (run fus-no-params): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-no-params',
+          question: 'Which path?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const detail = container.querySelector('[data-testid="fusion-detail"]')
+    expect(detail?.textContent).not.toContain('생성 파라미터')
+  })
+```
+
+### Step 3.5: Run tests
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npx vitest run src/components/fusion/fusion-surface.test.ts -t "generation parameters"
+```
+
+Expected: both tests PASS.
+
+---
+
+## Task 4: Render deliberation prompt with RichContent
+
+**Files:**
+- Modify: `dashboard/src/components/fusion/fusion-surface.ts`
+
+### Step 4.1: Import `RichContent`
+
+Add to the imports at the top:
+
+```ts
+import { RichContent } from '../common/rich-content'
+```
+
+### Step 4.2: Replace prompt plain text
+
+Replace:
+
+```ts
+      <div class="fus-block">
+        <div class="fus-block-lbl">심의 프롬프트</div>
+        <div class="fus-prompt">${run.question}</div>
+      </div>
+```
+
+with:
+
+```ts
+      <div class="fus-block">
+        <div class="fus-block-lbl">심의 프롬프트</div>
+        <div class="fus-prompt"><${RichContent} text=${run.question} previewLimit=${0} /></div>
+      </div>
+```
+
+### Step 4.3: Add a test
+
+```ts
+  it('renders the deliberation prompt as rich content', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-rich-prompt',
+        title: 'Fusion deliberation (run fus-rich-prompt): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-rich-prompt',
+          question: 'Check **this** [link](https://example.com).',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'OK.' }],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Done.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const prompt = container.querySelector('[data-testid="fusion-detail"] .fus-prompt')
+    expect(prompt?.querySelector('.markdown-body')).not.toBeNull()
+    expect(prompt?.textContent).toContain('this')
+    expect(prompt?.textContent).toContain('link')
+  })
+```
+
+### Step 4.4: Run test
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npx vitest run src/components/fusion/fusion-surface.test.ts -t "deliberation prompt as rich content"
+```
+
+Expected: PASS.
+
+---
+
+## Task 5: Render panel answers with RichContent
+
+**Files:**
+- Modify: `dashboard/src/components/fusion/fusion-surface.ts`
+
+### Step 5.1: Update `FusionPanelCard`
+
+Inside `FusionPanelCard`, change the body rendering section (around line 519-531) from:
+
+```ts
+      ${failed
+        ? null
+        : html`
+            <div
+              class=${`fus-pans ${open ? 'open' : ''}`}
+              role="button"
+              tabIndex=${0}
+              title=${open ? '접기' : '펼치기'}
+              onClick=${() => setOpen(prev => !prev)}
+              onKeyDown=${(event: KeyboardEvent) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  setOpen(prev => !prev)
+                }
+              }}
+            >${body}</div>
+          `}
+```
+
+to:
+
+```ts
+      ${failed
+        ? html`<div class="fus-pans failed">${body}</div>`
+        : html`
+            <div
+              class=${`fus-pans ${open ? 'open' : ''}`}
+              role="button"
+              tabIndex=${0}
+              title=${open ? '접기' : '펼치기'}
+              onClick=${() => setOpen(prev => !prev)}
+              onKeyDown=${(event: KeyboardEvent) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault()
+                  setOpen(prev => !prev)
+                }
+              }}
+            ><${RichContent} text=${body} previewLimit=${0} /></div>
+          `}
+```
+
+### Step 5.2: Add CSS for failed panel body
+
+Add to `dashboard/src/styles/fusion-v2.css`:
+
+```css
+.v2-fusion-surface .fus-pans.failed {
+  color: var(--bad-light);
+  cursor: default;
+}
+```
+
+### Step 5.3: Add a test
+
+```ts
+  it('renders panel answers as rich content', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-rich-panel',
+        title: 'Fusion deliberation (run fus-rich-panel): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-rich-panel',
+          question: 'Which path?',
+          panel: [
+            {
+              model: 'gpt-5',
+              status: 'answered',
+              answer: 'Use **canary** first.',
+            },
+          ],
+          judge: { status: 'synthesized', decision: 'answer', resolved_answer: 'Ship canary.' },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const panel = container.querySelector('.fus-panel-card')
+    expect(panel?.querySelector('.markdown-body')).not.toBeNull()
+    expect(panel?.textContent).toContain('canary')
+  })
+```
+
+### Step 5.4: Run test
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npx vitest run src/components/fusion/fusion-surface.test.ts -t "panel answers as rich content"
+```
+
+Expected: PASS.
+
+---
+
+## Task 6: Render judge evidence with RichContent
+
+**Files:**
+- Modify: `dashboard/src/components/fusion/fusion-surface.ts`
+
+### Step 6.1: Update `FusionJudgeEvidence`
+
+Replace all occurrences where long text is rendered directly inside `FusionJudgeEvidence`.
+
+For consensus claims (around line 571-575):
+
+```ts
+            <div class="fus-claim" key=${`consensus-${index}`}>
+              <p><${RichContent} text=${claim.text} previewLimit=${0} /></p>
+              <${FusionModelChips} models=${claim.models} />
+            </div>
+```
+
+For contradiction stances (around line 588-589):
+
+```ts
+                      <span class="fus-pos-s"><${RichContent} text=${position.stance} previewLimit=${0} /></span>
+```
+
+For coverage missing text (around line 611):
+
+```ts
+                      <span class="fus-gap-miss"><${RichContent} text=${gap.missing} previewLimit=${0} /></span>
+```
+
+For unique insights (around line 624-626):
+
+```ts
+                  <div class="fus-insight" key=${`insight-${index}`}>
+                    <p><${RichContent} text=${insight.text} previewLimit=${0} /></p>
+                    ${insight.model ? html`<span class="fus-mchip mono">${insight.model}</span>` : null}
+                  </div>
+```
+
+For blind spots and missing inputs (around lines 637 and 646):
+
+```ts
+<ul class="fus-blind">${judge.blindSpots.map(item => html`<li key=${item}><${RichContent} text=${item} previewLimit=${0} /></li>`)}</ul>
+```
+
+and:
+
+```ts
+<ul class="fus-blind">${judge.missingInputs.map(item => html`<li key=${item}><${RichContent} text=${item} previewLimit=${0} /></li>`)}</ul>
+```
+
+### Step 6.2: Add a test
+
+```ts
+  it('renders judge evidence text as rich content', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-rich-judge',
+        title: 'Fusion deliberation (run fus-rich-judge): answer',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-rich-judge',
+          question: 'Which path?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
+          judge: {
+            status: 'synthesized',
+            decision: 'answer',
+            resolved_answer: 'Ship canary.',
+            consensus: [{ text: '**Canary** is safer.', models: ['gpt-5'] }],
+          },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const evidence = container.querySelector('[data-testid="fusion-judge-evidence"]')
+    expect(evidence?.querySelector('.markdown-body')).not.toBeNull()
+    expect(evidence?.textContent).toContain('Canary')
+  })
+```
+
+### Step 6.3: Run test
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npx vitest run src/components/fusion/fusion-surface.test.ts -t "judge evidence text as rich content"
+```
+
+Expected: PASS.
+
+---
+
+## Task 7: Render resolved answer and recommendation rationale with RichContent
+
+**Files:**
+- Modify: `dashboard/src/components/fusion/fusion-surface.ts`
+
+### Step 7.1: Update resolved answer
+
+Replace (around line 789):
+
+```ts
+        <p class="fus-resolved-body">${resolved}</p>
+```
+
+with:
+
+```ts
+        <p class="fus-resolved-body"><${RichContent} text=${resolved} previewLimit=${0} /></p>
+```
+
+### Step 7.2: Update recommendation rationale
+
+Replace (around line 791):
+
+```ts
+        ${run.judge.recommendation?.rationale
+          ? html`<p class="fus-rec-rationale"><span class="k">근거</span>${run.judge.recommendation.rationale}</p>`
+          : null}
+```
+
+with:
+
+```ts
+        ${run.judge.recommendation?.rationale
+          ? html`<p class="fus-rec-rationale"><span class="k">근거</span><${RichContent} text=${run.judge.recommendation.rationale} previewLimit=${0} /></p>`
+          : null}
+```
+
+### Step 7.3: Add a test
+
+```ts
+  it('renders resolved answer and recommendation rationale as rich content', () => {
+    fusionBoardPosts.value = [
+      boardPost({
+        id: 'post-rich-resolved',
+        title: 'Fusion deliberation (run fus-rich-resolved): recommend',
+        meta: {
+          source: 'fusion',
+          run_id: 'fus-rich-resolved',
+          question: 'Which path?',
+          panel: [{ model: 'gpt-5', status: 'answered', answer: 'Canary.' }],
+          judge: {
+            status: 'synthesized',
+            decision: 'recommend',
+            resolved_answer: 'Ship **canary**.',
+            recommend: {
+              action: 'publish note',
+              rationale: 'Because **rollback** is covered.',
+            },
+          },
+        },
+      }),
+    ]
+
+    render(html`<${FusionSurface} />`, container)
+
+    const resolved = container.querySelector('.fus-resolved-body')
+    expect(resolved?.querySelector('.markdown-body')).not.toBeNull()
+    expect(resolved?.textContent).toContain('canary')
+
+    const rationale = container.querySelector('.fus-rec-rationale')
+    expect(rationale?.querySelector('.markdown-body')).not.toBeNull()
+    expect(rationale?.textContent).toContain('rollback')
+  })
+```
+
+### Step 7.4: Run test
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npx vitest run src/components/fusion/fusion-surface.test.ts -t "resolved answer and recommendation rationale"
+```
+
+Expected: PASS.
+
+---
+
+## Task 8: Unify word-break rules
+
+**Files:**
+- Modify: `dashboard/src/styles/fusion-v2.css`
+
+### Step 8.1: Add shared word-break rule
+
+Append to `dashboard/src/styles/fusion-v2.css`:
+
+```css
+/* Unified long-text wrapping for the standalone Fusion surface.
+   Keep CJK readability while allowing arbitrary identifiers/URLs to break. */
+.v2-fusion-surface .fus-prompt,
+.v2-fusion-surface .fus-resolved-body,
+.v2-fusion-surface .fus-panel-body,
+.v2-fusion-surface .fus-jrow,
+.v2-fusion-surface .fus-gap-miss,
+.v2-fusion-surface .fus-pos-s,
+.v2-fusion-surface .fus-claim p,
+.v2-fusion-surface .fus-insight p,
+.v2-fusion-surface .fus-blind li,
+.v2-fusion-surface .fus-missing li,
+.v2-fusion-surface .fus-rec-rationale .markdown-body {
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+```
+
+### Step 8.2: Align KPI value
+
+`.fus-kpi-v` already has `overflow-wrap: anywhere;`. Add `text-wrap: pretty;` to keep it consistent:
+
+```css
+.v2-fusion-surface .fus-kpi-v {
+  margin-top: 4px;
+  color: var(--fus-text);
+  font-size: 22px;
+  font-weight: 760;
+  line-height: 1.05;
+  overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+```
+
+### Step 8.3: Verify visually (manual)
+
+Run the dashboard locally:
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npm run dev
+```
+
+Open the Fusion surface with a run that contains long unbroken strings (e.g., URLs, file paths). Confirm text wraps without horizontal overflow on both desktop and mobile viewport (use browser DevTools).
+
+---
+
+## Task 9: Run full test suite and type check
+
+**Files:**
+- Modify: none (verification only)
+
+### Step 9.1: Type check
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npx tsc --noEmit --pretty
+```
+
+Expected: no errors.
+
+### Step 9.2: Fusion surface tests
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npx vitest run src/components/fusion/fusion-surface.test.ts
+```
+
+Expected: all tests PASS.
+
+### Step 9.3: Optional broader test run
+
+```bash
+cd ~/me/workspace/yousleepwhen/masc/dashboard && npx vitest run src/components/fusion/
+```
+
+Expected: all tests PASS.
+
+---
+
+## Self-review
+
+### Spec coverage
+
+| Spec requirement | Task |
+|------------------|------|
+| Extend `FusionRunView` with params and preset | Task 1 |
+| Wire preset from registry, remove stub | Task 2 |
+| Render generation params as chips | Task 3 |
+| Render deliberation prompt as rich text | Task 4 |
+| Render panel answers as rich text | Task 5 |
+| Render judge evidence as rich text | Task 6 |
+| Render resolved answer / rationale as rich text | Task 7 |
+| Unify word-break rules | Task 8 |
+| Mobile remains usable | Tasks 3, 8 (flex-wrap, existing media queries) |
+| Tests + type check | Task 9 |
+
+### Placeholder scan
+
+No TBD/TODO, no vague "add appropriate" steps. Each step includes exact file paths, code, commands, and expected output.
+
+### Type consistency
+
+- `FusionRunView.preset` is `string | null` everywhere.
+- `FusionRunParams` fields are `number | null`.
+- `paramChip` accepts `number | null`.
+- `RichContent` `text` prop is always `string` (fallback strings provided).
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/design/2026-06-24-fusion-dashboard-wiring-rich-text-plan.md`.
+
+Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Which approach?


### PR DESCRIPTION
## Summary

- Extend `FusionRunView` with `preset` + generation params (`temperature`, `top_p`, `top_k`, `max_tokens`) and normalize them from board post meta.
- Wire `preset` from the registry when the board-derived view lacks it; remove the `preset · n/a` stub.
- Render deliberation prompt, panel answers, judge evidence, resolved answer, and recommendation rationale with `RichContent` (markdown).
- Add a generation parameter chip UI to the run detail.
- Unify `word-break` / `overflow-wrap` rules across the standalone Fusion surface.

## Test Plan

- [x] `npx tsc --noEmit --pretty` passes
- [x] `npx vitest run src/components/fusion/` passes (39 tests)
- [x] `npx vitest run src/components/board/fusion-evidence.test.ts` passes (5 tests)

## Design / Plan

- `docs/design/2026-06-24-fusion-dashboard-wiring-rich-text-design.md`
- `docs/design/2026-06-24-fusion-dashboard-wiring-rich-text-plan.md`
