### PR TITLE
fix(keeper): #9 응답피드백 dedup을 recorded_at 권위로 통일 (#22250 리뷰 CR 대응)

### DIFF
--- a/lib/keeper/keeper_response_feedback.ml
+++ b/lib/keeper/keeper_response_feedback.ml
@@ -94,12 +94,26 @@ let empty_tally =
   { helpful = 0; not_helpful = 0; cleared = 0; net = 0; malformed = 0; last_at = None }
 
 let tally_of_records (records : record list) : tally =
-  (* Deduplicate by turn_id, last-occurrence-wins. The log is append-only and
-     chronological, so a re-vote or [Cleared] appended later supersedes the
-     earlier record for the same turn. [Turn_map.add] overwrites, so folding
-     left keeps the last occurrence. *)
+  (* Deduplicate by turn_id, keeping the record with the greatest [recorded_at]
+     — the latest vote for that turn (a re-vote or [Cleared] supersedes an
+     earlier one). [recorded_at] is the SINGLE authority for "latest", the same
+     one [last_at] uses below, so the winner is independent of the input list
+     order: a non-append read, a merge, or out-of-order input cannot change it.
+     (Earlier this dedup used [Turn_map.add] = list-position-last, which
+     disagreed with the [recorded_at]-based [last_at] — review CR.) On an exact
+     [recorded_at] tie the later list element wins, deterministic for a fixed
+     list. *)
   let latest =
-    List.fold_left (fun m (r : record) -> Turn_map.add r.turn_id r m) Turn_map.empty records
+    List.fold_left
+      (fun m (r : record) ->
+        Turn_map.update r.turn_id
+          (function
+            | None -> Some r
+            | Some existing ->
+              Some (if r.recorded_at >= existing.recorded_at then r else existing))
+          m)
+      Turn_map.empty
+      records
   in
   let counted =
     Turn_map.fold
@@ -112,10 +126,8 @@ let tally_of_records (records : record list) : tally =
         in
         let last_at =
           match acc.last_at with
-          | Some t when t >= r.recorded_at -> Some t
-          (* DET-OK: [recorded_at] is parsed input; the max fold is deterministic
-             for a fixed append-order record list. *)
-          | _ -> Some r.recorded_at
+          | None -> Some r.recorded_at
+          | Some t -> Some (Float.max t r.recorded_at)
         in
         { acc with last_at })
       latest

--- a/lib/keeper/keeper_response_feedback.mli
+++ b/lib/keeper/keeper_response_feedback.mli
@@ -70,14 +70,13 @@ val empty_tally : tally
 
 val tally_of_records : record list -> tally
 (** Pure, deterministic: same record list ⇒ same tally. Votes are deduplicated
-    by [turn_id] with last-occurrence-wins (the log is append-only and
-    chronological, so the last record for a turn is the current vote — a
-    re-vote or a [Cleared] supersedes earlier ones). [Cleared] is counted but
-    excluded from [net] (a retraction is "no opinion", not a negative). No
-    magic multipliers, no time-decay, no fabricated 0..1 score.
-
-    NB: the input list must be in append/chronological order (oldest first) for
-    last-wins to mean most-recent; {!read_tally} guarantees this. *)
+    by [turn_id], keeping the record with the greatest [recorded_at] — a re-vote
+    or a [Cleared] supersedes an earlier vote for the same turn. [recorded_at]
+    is the single authority for "latest" (the same one [last_at] uses), so the
+    tally is independent of the input list order: a non-append read, a merge, or
+    out-of-order input cannot change the winner. [Cleared] is counted but
+    excluded from [net] (a retraction is "no opinion", not a negative). No magic
+    multipliers, no time-decay, no fabricated 0..1 score. *)
 
 (** {2 Durable sink + log aggregation — Stdlib I/O via the sibling-log family} *)
 

--- a/test/test_keeper_response_feedback.ml
+++ b/test/test_keeper_response_feedback.ml
@@ -82,6 +82,24 @@ let test_tally_dedup_last_wins () =
   check "dedup net=-1" (t.F.net = -1);
   check "dedup last_at=2.0" (t.F.last_at = Some 2.0)
 
+let test_tally_dedup_by_recorded_at_not_list_order () =
+  (* Review CR: out-of-order input pins [recorded_at] as the dedup authority.
+     The same turn's NEWER vote (recorded_at 2.0) appears FIRST in the list and
+     the OLDER (1.0) LAST. Dedup must pick the 2.0 record (max recorded_at), not
+     the list-last 1.0 — a list-position dedup would pick Not_helpful(1.0) and
+     fail here, so this is non-vacuous (unlike the happy-path test above where
+     list order and recorded_at coincide). *)
+  let t =
+    F.tally_of_records
+      [ mk ~turn_id:"t1" ~signal:F.Helpful ~recorded_at:2.0 ()
+      ; mk ~turn_id:"t1" ~signal:F.Not_helpful ~recorded_at:1.0 ()
+      ]
+  in
+  check "out-of-order dedup: helpful=1 (recorded_at 2.0 wins)" (t.F.helpful = 1);
+  check "out-of-order dedup: not_helpful=0" (t.F.not_helpful = 0);
+  check "out-of-order dedup: net=1" (t.F.net = 1);
+  check "out-of-order last_at=2.0" (t.F.last_at = Some 2.0)
+
 let test_tally_cleared_excluded_from_net () =
   let t =
     F.tally_of_records
@@ -213,6 +231,7 @@ let () =
   test_json_strict ();
   test_tally_basic ();
   test_tally_dedup_last_wins ();
+  test_tally_dedup_by_recorded_at_not_list_order ();
   test_tally_cleared_excluded_from_net ();
   test_tally_retraction_supersedes ();
   test_tally_deterministic ();


### PR DESCRIPTION
## 무엇을 / 왜 (#22250 적대 리뷰 CR 대응)

#22250(머지됨, `ba950e5ff5`)의 적대 리뷰가 `Keeper_response_feedback.tally_of_records`의 **dedup 권위 불일치**를 지적했습니다 (Change Request). 머지가 그 fix 전에 일어나 main에 미반영 → 이 후속 PR로 수정합니다.

### 결함 (리뷰 CR)
`tally_of_records`가 "turn별 최신 vote"를 **두 권위**로 판정:
- **dedup**: `Turn_map.add r.turn_id r` left-fold → **list-위치-마지막** 승(시간 무관).
- **last_at**: `match acc.last_at with Some t when t >= r.recorded_at` → **recorded_at max**(순서 무관).

어긋나는 입력(같은 turn, 더 새로운 vote가 list 앞·오래된 게 뒤)에서 dedup이 **오래된 vote를 승자**로 뽑아 `.mli`의 "재투표/Cleared supersede" 계약을 위반. "append-only chronological"은 타입이 강제 못 하는 **caller-ordering 결합**이라, Phase 1b `read_tally`가 순서 외로 읽거나 `recorded_at`가 비단조(clock skew)면 틀린 승자.

또한 기존 `test_tally_dedup_last_wins`는 list 순서와 recorded_at이 우연히 일치(1.0→2.0)해 **공허**(list-position이든 recorded_at이든 통과).

### 고친 것
- dedup을 **`recorded_at` 최대값**으로(`Turn_map.update`) — `last_at`과 **동일 단일 권위**, 입력 순서 독립(비-append read·merge·out-of-order 무관).
- 겸사겸사 `last_at` fold의 catch-all `| _ -> Some`(+DET-OK 주석)을 exhaustive `None | Some t -> Float.max`로 제거.
- **non-vacuous 테스트 추가**(`test_tally_dedup_by_recorded_at_not_list_order`): 더 새로운 vote(recorded_at 2.0)를 list **앞**, 오래된(1.0)을 **뒤**에 → recorded_at 2.0이 이김을 단언. list-position dedup이면 fail = 권위를 pin.

### 검증
`dune exec test/test_keeper_response_feedback.exe` → OK (15 케이스). DET/NDT gate PASS. 빌드는 CI.

### 반경
- `lib/keeper/keeper_response_feedback.ml/.mli` + test 1파일. #22250 후속(머지된 PR에 push 금지 규칙상 새 PR). credential/operator/sandbox/hooks/workflow 무관 → RFC 불요.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
