### PR TITLE
fix(test): qualify Masc.Keeper_runtime_manifest (main red build break)

### DIFF
--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -291,7 +291,7 @@ let test_degrade_manifest_public_projection () =
       ~runtime_id:"text-runtime"
       [ ("image", 1); ("audio", 2) ]
   in
-  let public = Keeper_runtime_manifest.public_projection_of_decision decision in
+  let public = Masc.Keeper_runtime_manifest.public_projection_of_decision decision in
   check (option string) "routing action"
     (Some "media_degraded_to_text")
     (match assoc_field "routing_action" public with


### PR DESCRIPTION
## main이 red입니다 (build break hotfix)

`dune build .` on main 실패:
```
File "test/test_runtime_modality_reroute.ml", line 294:
Error: Unbound module Keeper_runtime_manifest
```

## 원인
#22249(media-degrade floor)가 `test_runtime_modality_reroute.ml`에서 keeper 모듈을 cross-reference하면서, line 290 `Masc.Keeper_turn_driver`는 qualify했지만 **같은 파일 line 294의 `Keeper_runtime_manifest`를 놓쳤습니다**. 머지된 빌드가 컴파일 안 됨. (제가 #22249 리뷰에서 이 layering cross-ref를 플래그했고, 후속 "qualify keeper driver test helper"가 한 심볼만 고치고 머지된 N-of-M 케이스입니다.)

## Change
line 294를 `Masc.Keeper_runtime_manifest.public_projection_of_decision`로 qualify (line 290과 동일 방식, test는 `masc_test_deps`→`Masc` 접근).

## Verify
`dune build test/test_runtime_modality_reroute.exe` → exit 0 (로컬). main-red 핫픽스라 로컬 빌드로 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
