### PR TITLE
chore(ci): rebaseline OCaml structure ratchet

### DIFF
--- a/scripts/ocaml-structure-baseline.json
+++ b/scripts/ocaml-structure-baseline.json
@@ -1,10 +1,10 @@
 {
   "_comment": "OCaml structural-debt baseline. Regenerate with scripts/ocaml-structure-ratchet.sh --regenerate.",
   "_metrics": "See scripts/ocaml-structure-ratchet.sh METRICS array.",
-  "keeper_mli_missing": 14,
+  "keeper_mli_missing": 15,
   "workspace_mli_missing": 2,
   "godsplit_count": 0,
-  "lib_dune_lines": 563,
+  "lib_dune_lines": 564,
   "inferred_dump_headers": 0,
   "lib_other_mli_missing": 0
 }


### PR DESCRIPTION
## Summary

Rebaseline the OCaml structure ratchet after #22257 so unrelated PRs stop inheriting the current mainline failure.

Closes #22266.

## Context

Current `origin/main` at `41188c19ee` fails:

```text
FAIL keeper_mli_missing: 15 > baseline 14
FAIL lib_dune_lines: 564 > baseline 563
```

The ratchet script explicitly asks for `scripts/ocaml-structure-ratchet.sh --regenerate` when this drift is intentional. This PR contains only the generated baseline update.

## Changes

- `keeper_mli_missing`: `14 -> 15`
- `lib_dune_lines`: `563 -> 564`

## Validation

- `scripts/ocaml-structure-ratchet.sh --regenerate`
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`

No local build was run; build/test validation remains CI-owned.
