### PR TITLE
[codex] Improve keeper v2 mobile dashboard parity

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2,7 +2,7 @@
 <html lang="ko" data-skin="v2" data-volt="brass">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>MASC Dashboard</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -249,6 +249,8 @@ export function App() {
   const isCodeSurface = currentTab === 'code'
   const widgetSoloMode = isWidgetSoloRoute(route.value)
   const keeperDetailMode = isKeeperDetailDashboardRoute(route.value)
+  const mobileKeeperPane = isMobile && keeperDetailMode ? keeperMobilePane.value : null
+  const mobileKeeperReadingMode = mobileKeeperPane === 'chat'
   const focusMode = dashboardFocusMode.value
   const mobileDrawerOpen = isMobile && mobileMenuOpen.value
   const suppressFloatingChrome = shouldSuppressFloatingChrome({
@@ -288,6 +290,7 @@ export function App() {
       data-volt=${tweaksVolt.value}
       data-focus-mode=${focusMode ? 'true' : 'false'}
       data-keeper-detail-mode=${keeperDetailMode ? 'true' : 'false'}
+      data-reading=${mobileKeeperReadingMode ? 'true' : 'false'}
       data-widget-solo=${widgetSoloMode ? 'true' : 'false'}
       style=${{
         // tweaksFontScale.value is a percentage integer (80..140, default 100).
@@ -296,6 +299,7 @@ export function App() {
         // in #21998) double-applies the percentage: 100 -> `1 * 1%` -> 0.16px,
         // collapsing every inherited-font-size glyph (emoji, icon chars) to ~0px.
         '--twk-font-scale': String(tweaksFontScale.value),
+        '--kw-thread-w': `${tweaksThreadW.value}px`,
         '--thread-w': `${tweaksThreadW.value}px`,
       }}
     >

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -49,6 +49,18 @@ export interface ChatComposerSendPayload {
   text: string
 }
 
+export interface ChatComposerCommand {
+  id: string
+  group: string
+  label: string
+  hint?: string
+  glyph?: string
+  danger?: boolean
+  disabled?: boolean
+  disabledReason?: string
+  run: () => void | Promise<void>
+}
+
 /** Status dot wrapper — maps keeper-v2 status strings to shared StatusDot tones. */
 export function ChatStatusDot({ status, pulse }: { status: string; pulse?: boolean }): VNode {
   const state = status === 'run' ? 'ok' : status === 'pause' ? 'warn' : status === 'off' ? 'idle' : status
@@ -324,6 +336,15 @@ let composerActionSeq = 0
 function nextComposerClientActionId(): string {
   composerActionSeq += 1
   return `composer-send-${Date.now()}-${composerActionSeq}`
+}
+
+const VOICE_WAVE_BARS = [0.32, 0.58, 0.44, 0.82, 0.38, 0.66, 0.92, 0.5, 0.72, 0.4, 0.86, 0.56, 0.7, 0.46, 0.78, 0.36]
+
+function formatVoiceClock(seconds: number): string {
+  const whole = Math.max(0, Math.floor(seconds))
+  const minutes = Math.floor(whole / 60)
+  const secs = whole % 60
+  return `${minutes}:${String(secs).padStart(2, '0')}`
 }
 
 function dataUriToText(data: string): string | null {
@@ -2890,6 +2911,7 @@ export function ChatComposer({
   lastEventAt,
   queueEnabled = false,
   queueCount = 0,
+  commands = [],
   onDraftChange,
   onSend,
   onAbort,
@@ -2907,6 +2929,7 @@ export function ChatComposer({
    *  enqueues the message instead of dispatching it immediately. */
   queueEnabled?: boolean
   queueCount?: number
+  commands?: ChatComposerCommand[]
   /** Optional controlled draft handler. When omitted the composer keeps its
    *  own draft state, which prevents the host from re-rendering on every
    *  keystroke (see keeper-workspace chat performance). */
@@ -2926,8 +2949,10 @@ export function ChatComposer({
   draftPersistKey?: string
 }) {
   const [elapsed, setElapsed] = useState(0)
+  const [voiceElapsed, setVoiceElapsed] = useState(0)
   const [focus, setFocus] = useState(false)
   const [drag, setDrag] = useState(false)
+  const [slashIdx, setSlashIdx] = useState(0)
   const [attachments, setAttachments] = useState<KeeperConversationAttachment[]>([])
   const isControlled = typeof draftProp === 'string'
   const draftPersistStoreKey = draftPersistKey?.trim() ?? ''
@@ -2985,7 +3010,20 @@ export function ChatComposer({
     onTranscribed: (text) => {
       setDraft(draft.trim() === '' ? text : `${draft}\n${text}`)
     },
+    onError: (message) => showToast(message, 'error'),
   })
+
+  useEffect(() => {
+    if (voice.state !== 'recording') {
+      setVoiceElapsed(0)
+      return
+    }
+    const startedAt = Date.now()
+    const tick = () => setVoiceElapsed(Math.round((Date.now() - startedAt) / 1000))
+    tick()
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [voice.state])
 
   useEffect(() => {
     if (!streaming || !streamStartedAt) {
@@ -3014,6 +3052,20 @@ export function ChatComposer({
   const isStreamWarning = streaming && elapsed > 60
   const hasContent = draft.trim() !== '' || attachments.length > 0
   const sendDisabled = disabled || !hasContent || (streaming && !queueEnabled)
+  const slashMatch = /^\/([^\s]*)$/.exec(draft)
+  const slashQuery = slashMatch ? slashMatch[1].toLowerCase() : null
+  const slashMatches = useMemo(
+    () => slashQuery === null
+      ? []
+      : commands.filter(command => {
+        const id = command.id.toLowerCase()
+        const label = command.label.toLowerCase()
+        return id.startsWith(slashQuery) || label.startsWith(slashQuery)
+      }),
+    [commands, slashQuery],
+  )
+  const slashOpen = voice.state === 'idle' && slashMatches.length > 0
+  const activeSlashIdx = slashOpen ? Math.min(slashIdx, slashMatches.length - 1) : 0
 
   const isPrimary = layout === 'primary'
 
@@ -3083,18 +3135,54 @@ export function ChatComposer({
       text,
     })
     setDraft('')
+    setSlashIdx(0)
     setAttachments([])
     if (textareaRef.current) textareaRef.current.style.height = 'auto'
+  }
+
+  const runSlashCommand = (command?: ChatComposerCommand) => {
+    if (!command || command.disabled) return
+    setDraft('')
+    setSlashIdx(0)
+    if (textareaRef.current) textareaRef.current.style.height = 'auto'
+    void Promise.resolve(command.run()).catch((err) => {
+      const message = err instanceof Error ? err.message : `${command.label} 실행 실패`
+      showToast(message, 'error')
+    })
   }
 
   const grow = (event: Event) => {
     const target = event.target as HTMLTextAreaElement
     setDraft(target.value)
+    setSlashIdx(0)
     target.style.height = 'auto'
     target.style.height = `${Math.min(target.scrollHeight, 160)}px`
   }
 
   const onKeyDown = (event: KeyboardEvent) => {
+    if (slashOpen) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setSlashIdx((activeSlashIdx + 1) % slashMatches.length)
+        return
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setSlashIdx((activeSlashIdx - 1 + slashMatches.length) % slashMatches.length)
+        return
+      }
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        event.preventDefault()
+        runSlashCommand(slashMatches[activeSlashIdx])
+        return
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setDraft('')
+        setSlashIdx(0)
+        return
+      }
+    }
     if (isSubmitEnter(event) && !event.shiftKey) {
       event.preventDefault()
       if (!sendDisabled) {
@@ -3150,84 +3238,137 @@ export function ChatComposer({
             `
           : null}
         <div class=${boxClass}>
+          ${slashOpen
+            ? html`
+                <div class="slashmenu" role="listbox" aria-label="keeper slash commands">
+                  <div class="slashmenu-h">keeper · 명령</div>
+                  ${slashMatches.map((command, index) => html`
+                    <button
+                      key=${`${command.group}:${command.id}`}
+                      type="button"
+                      role="option"
+                      aria-selected=${index === activeSlashIdx ? 'true' : 'false'}
+                      class=${`slashmenu-i ${index === activeSlashIdx ? 'on' : ''}${command.danger ? ' danger' : ''}`}
+                      disabled=${command.disabled}
+                      title=${command.disabledReason ?? command.hint ?? command.label}
+                      onMouseEnter=${() => setSlashIdx(index)}
+                      onMouseDown=${(event: MouseEvent) => event.preventDefault()}
+                      onClick=${() => runSlashCommand(command)}
+                    >
+                      <span class="slashmenu-gl">${command.glyph ?? '⌁'}</span>
+                      <span class="slashmenu-cmd mono">/${command.id}</span>
+                      <span class="slashmenu-lbl">${command.label}</span>
+                      <span class="slashmenu-hint">${command.disabledReason ?? command.hint ?? ''}</span>
+                      <span class="slashmenu-grp">${command.group}</span>
+                    </button>
+                  `)}
+                </div>
+              `
+            : null}
           <!-- Flush borderless textarea: prototype composer.jsx <textarea> has
                no inline styling; all box styling (border:0, outline:0,
                transparent bg, padding:9px 0) comes from .composer textarea in
                chat.css (mirrors styles/v2.css:932-936). Removing the prior
                inline Tailwind (control-textarea + border + rounded + px/py +
                bg + focus ring) drops the nested box the prototype lacks. -->
-          <textarea
-            ref=${textareaRef}
-            class="composer-textarea"
-            placeholder=${placeholder}
-            aria-label="메시지 입력"
-            value=${draft}
-            onInput=${grow}
-            onKeyDown=${onKeyDown}
-            onFocus=${() => setFocus(true)}
-            onBlur=${() => setFocus(false)}
-            disabled=${disabled}
-          ></textarea>
-          <div class="composer-tools">
-            <input
-              ref=${fileInputRef}
-              type="file"
-              accept="image/png,image/jpeg,image/gif,image/webp,audio/mpeg,audio/mp4,audio/wav,audio/webm,audio/ogg,text/plain,text/markdown,application/json,text/csv"
-              multiple
-              class="hidden"
-              aria-label="파일 첨부"
-              onChange=${(event: Event) => {
-                const target = event.target as HTMLInputElement
-                void ingestFiles(target.files)
-                target.value = ''
-              }}
-            />
-            <button
-              type="button"
-              class="ctool"
-              title="이미지·파일 첨부"
-              aria-label="이미지·파일 첨부"
-              disabled=${disabled}
-              onClick=${() => fileInputRef.current?.click()}
-            >
-              ⊕
-            </button>
-            ${voice.supported ? html`
-              <button
-                type="button"
-                class="ctool ${voice.state === 'recording' ? 'recording' : ''}"
-                title=${voice.state === 'recording' ? '녹음 중지' : voice.state === 'transcribing' ? '음성 인식 중' : '음성으로 입력'}
-                aria-label=${voice.state === 'recording' ? '녹음 중지' : '음성으로 입력'}
-                disabled=${voice.state === 'transcribing' || disabled}
-                onClick=${() => (voice.state === 'recording' ? voice.stop() : voice.start())}
-              >
-                ${voice.state === 'recording'
-                  ? html`<${Square} size=${15} aria-hidden="true" />`
-                  : html`<${Mic} size=${15} aria-hidden="true" />`}
-              </button>
-            ` : null}
-            <button
-              type="button"
-              class="send ${isStreamWarning && !canQueue ? 'warn' : ''}"
-              disabled=${sendDisabled}
-              onClick=${handleSend}
-            >
-              ${streamLabel}
-            </button>
-            ${streaming && onAbort
-              ? html`
+          ${voice.state === 'recording' || voice.state === 'transcribing'
+            ? html`
+                <div class=${`rec-bar ${voice.state === 'transcribing' ? 'transcribing' : ''}`}>
+                  <span class="rec-dot"></span>
+                  <span class="rec-lbl">${voice.state === 'recording' ? '녹음 중' : '전사 중'}</span>
+                  <span class="rec-clock mono">${formatVoiceClock(voiceElapsed)}</span>
+                  <div class="rec-wave" aria-hidden="true">
+                    ${VOICE_WAVE_BARS.map((height, index) => html`
+                      <span
+                        key=${index}
+                        class="rbar"
+                        style=${`height: ${Math.round(4 + height * 18)}px; animation-delay: ${index * 34}ms`}
+                      ></span>
+                    `)}
+                  </div>
                   <button
                     type="button"
-                    class="ctool abort"
-                    title="응답 중지"
-                    aria-label="응답 중지"
-                    onClick=${onAbort}
+                    class="rec-btn stop"
+                    title=${voice.state === 'recording' ? '녹음 종료 — 받아쓰기' : '음성 전사 중'}
+                    disabled=${voice.state !== 'recording'}
+                    onClick=${voice.stop}
                   >
-                    중지${elapsed > 0 ? ` (${elapsed}s)` : ''}
+                    <${Square} size=${13} aria-hidden="true" /> 완료
                   </button>
-                `
-              : null}
-          </div>
+                </div>
+              `
+            : html`
+                <textarea
+                  ref=${textareaRef}
+                  class="composer-textarea"
+                  placeholder=${placeholder}
+                  aria-label="메시지 입력"
+                  value=${draft}
+                  onInput=${grow}
+                  onKeyDown=${onKeyDown}
+                  onFocus=${() => setFocus(true)}
+                  onBlur=${() => setFocus(false)}
+                  disabled=${disabled}
+                ></textarea>
+                <div class="composer-tools">
+                  <input
+                    ref=${fileInputRef}
+                    type="file"
+                    accept="image/png,image/jpeg,image/gif,image/webp,audio/mpeg,audio/mp4,audio/wav,audio/webm,audio/ogg,text/plain,text/markdown,application/json,text/csv"
+                    multiple
+                    class="hidden"
+                    aria-label="파일 첨부"
+                    onChange=${(event: Event) => {
+                      const target = event.target as HTMLInputElement
+                      void ingestFiles(target.files)
+                      target.value = ''
+                    }}
+                  />
+                  <button
+                    type="button"
+                    class="ctool"
+                    title="이미지·파일 첨부"
+                    aria-label="이미지·파일 첨부"
+                    disabled=${disabled}
+                    onClick=${() => fileInputRef.current?.click()}
+                  >
+                    ⊕
+                  </button>
+                  ${voice.supported ? html`
+                    <button
+                      type="button"
+                      class="ctool"
+                      title="음성으로 입력"
+                      aria-label="음성으로 입력"
+                      disabled=${disabled}
+                      onClick=${() => { void voice.start() }}
+                    >
+                      <${Mic} size=${15} aria-hidden="true" />
+                    </button>
+                  ` : null}
+                  <button
+                    type="button"
+                    class="send ${isStreamWarning && !canQueue ? 'warn' : ''}"
+                    disabled=${sendDisabled}
+                    onClick=${handleSend}
+                  >
+                    ${streamLabel}
+                  </button>
+                  ${streaming && onAbort
+                    ? html`
+                        <button
+                          type="button"
+                          class="ctool abort"
+                          title="응답 중지"
+                          aria-label="응답 중지"
+                          onClick=${onAbort}
+                        >
+                          중지${elapsed > 0 ? ` (${elapsed}s)` : ''}
+                        </button>
+                      `
+                    : null}
+                </div>
+              `}
         </div>
         <div class="composer-foot">
           <span class="hint">

--- a/dashboard/src/components/keeper-detail-body.ts
+++ b/dashboard/src/components/keeper-detail-body.ts
@@ -102,7 +102,7 @@ export function KeeperDetailBody({
   onSocialSweep,
 }: KeeperDetailBodyProps) {
   return html`
-    <div class="mx-auto flex w-full max-w-[1180px] flex-col gap-5 v2-monitoring-surface">
+    <div class="kw-detail-body mx-auto flex w-full max-w-[1180px] flex-col gap-5 v2-monitoring-surface">
         <${KeeperRuntimeAlertStrip} keeper=${keeper} />
         <${KeeperDetailSectionRail} />
 

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -187,12 +187,14 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
   // <=1180px drops the rail column entirely (keeper-workspace.css), so the right
   // resizer must not render there even when railOpen is still toggled on.
   const isNarrow = useMatchMedia(KW_NARROW_QUERY)
-  const routeKeeperParam = route.value.tab === 'keepers'
-    ? route.value.params.keeper?.trim()
-    : route.value.tab === 'monitoring' && route.value.params.section === 'agents'
-      ? route.value.params.keeper?.trim()
-      : ''
-  const [mobileRailOpen, setMobileRailOpen] = useState(false)
+  const [mobileRailState, setMobileRailState] = useState<{ keeperName: string; open: boolean }>(() => ({
+    keeperName: keeper.name,
+    open: false,
+  }))
+  const mobileRailOpen = mobileRailState.keeperName === keeper.name && mobileRailState.open
+  const setMobileRailOpenForKeeper = (open: boolean) => {
+    setMobileRailState({ keeperName: keeper.name, open })
+  }
   // Latest transition's wall_clock_at_decision, in unix seconds.  Used by
   // the header KeeperPhaseAndStage to render "현재 phase에 머문 시간" without
   // requiring a new backend field — derivation is plan-approved trade-off.
@@ -221,12 +223,6 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
     setDetailOpen(false)
     setConfigOverlayKeeper(shouldOpenPendingConfig ? keeper.name : null)
   }
-  useEffect(() => {
-    setMobileRailOpen(false)
-    if (routeKeeperParam) {
-      keeperMobilePane.value = 'chat'
-    }
-  }, [keeper.name, routeKeeperParam])
   useEffect(() => {
     selectedKeeper.value = keeper
     selectKeeper(keeper.name)
@@ -390,7 +386,7 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
   `
   const openKeeperConfig = (name = keeper.name) => {
     activeKeeperDetailSection.value = 'keeper-config'
-    setMobileRailOpen(false)
+    setMobileRailOpenForKeeper(false)
     if (name !== keeper.name) {
       pendingConfigKeeperRef.current = name
     }
@@ -485,7 +481,7 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
               onBack=${() => {
                 keeperMobilePane.value = 'roster'
               }}
-              onOpenRail=${() => setMobileRailOpen(true)}
+              onOpenRail=${() => setMobileRailOpenForKeeper(true)}
               onOpenConfig=${() => {
                 openKeeperConfig()
               }}
@@ -512,7 +508,7 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
                     aria-modal="true"
                     aria-label="키퍼 컨텍스트"
                     data-testid="kw-mobile-rail-overlay"
-                    onClick=${() => setMobileRailOpen(false)}
+                    onClick=${() => setMobileRailOpenForKeeper(false)}
                   >
                     <div class="kw-mobile-rail-drawer v2-monitoring-surface" onClick=${(e: Event) => e.stopPropagation()}>
                       <div class="kw-mobile-rail-head v2-monitoring-toolbar">
@@ -520,7 +516,7 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
                         <button
                           type="button"
                           class="kw-act v2-monitoring-action"
-                          onClick=${() => setMobileRailOpen(false)}
+                          onClick=${() => setMobileRailOpenForKeeper(false)}
                         >닫기</button>
                       </div>
                       <${KeeperWorkspaceRail} keeper=${keeper} />

--- a/dashboard/src/components/keeper-detail-page.ts
+++ b/dashboard/src/components/keeper-detail-page.ts
@@ -330,8 +330,8 @@ const KeeperDetailContent = memo(function KeeperDetailContent({
   // Full tabbed detail (FSM / 진단 / 정체성 / 설정 / 디버그) — the original
   // detail-page layout, preserved verbatim and surfaced behind "운영 상세".
   const detailContent = html`
-    <div class="mx-auto flex w-full max-w-[1380px] flex-col gap-5 pb-8 v2-monitoring-surface" data-route-focused-keeper=${keeper.name}>
-      <div class="sm:sticky sm:top-0 z-20 mx-auto w-full max-w-[1180px] overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] shadow-none backdrop-blur-xl v2-monitoring-toolbar">
+    <div class="kw-detail-content mx-auto flex w-full max-w-[1380px] flex-col gap-5 pb-8 v2-monitoring-surface" data-route-focused-keeper=${keeper.name}>
+      <div class="kw-detail-full-head sm:sticky sm:top-0 z-20 mx-auto w-full max-w-[1180px] overflow-hidden rounded-[var(--r-2)] border border-[var(--color-border-default)] bg-[var(--color-bg-page)] shadow-none backdrop-blur-xl v2-monitoring-toolbar">
         <div class="flex flex-col items-stretch justify-between gap-3 px-4 py-2.5 sm:flex-row sm:items-center sm:px-5">
           <${KeeperDetailHeaderInfo}
             keeper=${keeper}

--- a/dashboard/src/components/keeper-detail-shell.ts
+++ b/dashboard/src/components/keeper-detail-shell.ts
@@ -160,10 +160,10 @@ export function KeeperDetailSectionRail() {
   const active = activeKeeperDetailSection.value
   return html`
     <nav
-      class="sm:sticky sm:top-[var(--header-h)] z-10 overflow-x-auto border-b border-[var(--color-border-default)] bg-[var(--color-bg-page)] py-1.5 v2-monitoring-toolbar"
+      class="kw-detail-section-rail sm:sticky sm:top-[var(--header-h)] z-10 overflow-x-auto border-b border-[var(--color-border-default)] bg-[var(--color-bg-page)] py-1.5 v2-monitoring-toolbar"
       aria-label="키퍼 상세 섹션"
     >
-      <div class="flex min-w-max items-center gap-1.5 px-1" role="tablist" aria-label="키퍼 상세 탭">
+      <div class="kw-detail-section-tabs flex min-w-max items-center gap-1.5 px-1" role="tablist" aria-label="키퍼 상세 탭">
         ${KEEPER_DETAIL_SECTIONS.map((section) => html`
           <button
             id=${`${section.id}-tab`}
@@ -172,8 +172,8 @@ export function KeeperDetailSectionRail() {
             aria-selected=${active === section.id}
             aria-controls=${section.id}
             class=${active === section.id
-              ? 'h-8 shrink-0 rounded-[var(--r-1)] border border-[var(--accent-30)] bg-[var(--accent-12)] px-3 text-2xs font-semibold text-[var(--color-accent-fg)] transition-colors'
-              : 'h-8 shrink-0 rounded-[var(--r-1)] border border-transparent px-3 text-2xs font-semibold text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-fg-primary)]'}
+              ? 'kw-detail-section-tab h-8 shrink-0 rounded-[var(--r-1)] border border-[var(--accent-30)] bg-[var(--accent-12)] px-3 text-2xs font-semibold text-[var(--color-accent-fg)] transition-colors'
+              : 'kw-detail-section-tab h-8 shrink-0 rounded-[var(--r-1)] border border-transparent px-3 text-2xs font-semibold text-[var(--color-fg-muted)] transition-colors hover:border-[var(--color-border-default)] hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-fg-primary)]'}
             onClick=${() => selectKeeperDetailSection(section.id)}
           >
             ${section.label}

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -44,7 +44,7 @@ import {
   removeQueuedMessage,
   type QueuedMessage,
 } from '../keeper-chat-store'
-import { AttachDraftChip, ChatComposer, ChatTranscript, STREAM_STALL_THRESHOLD_S, formatAttachmentSize, type ChatComposerSendPayload } from './chat/primitives'
+import { AttachDraftChip, ChatComposer, ChatTranscript, STREAM_STALL_THRESHOLD_S, formatAttachmentSize, type ChatComposerCommand, type ChatComposerSendPayload } from './chat/primitives'
 import { showToast } from './common/toast'
 import { TextInput } from './common/input'
 import { shellAuthSummary } from '../store'
@@ -429,11 +429,13 @@ export function KeeperConversationPanel({
   keeperName,
   placeholder,
   layout = 'default',
+  composerCommands = [],
   onInspectTurn,
 }: {
   keeperName: string
   placeholder: string
   layout?: 'default' | 'primary' | 'workspace'
+  composerCommands?: ChatComposerCommand[]
   onInspectTurn?: (entry: KeeperConversationEntry) => void
 }) {
   const [showMetadata, setShowMetadata] = useState(readKeeperChatMetadataVisible())
@@ -720,6 +722,7 @@ export function KeeperConversationPanel({
               lastEventAt=${lastSignalAt}
               queueEnabled=${true}
               queueCount=${queueCount}
+              commands=${composerCommands}
               onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
               onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
               layout="primary"
@@ -837,6 +840,7 @@ export function KeeperConversationPanel({
             lastEventAt=${lastSignalAt}
             queueEnabled=${true}
             queueCount=${queueCount}
+            commands=${composerCommands}
             onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
             onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
             layout="primary"
@@ -952,6 +956,7 @@ export function KeeperConversationPanel({
             lastEventAt=${lastSignalAt}
             queueEnabled=${true}
             queueCount=${queueCount}
+            commands=${composerCommands}
             onSend=${(payload: ChatComposerSendPayload) => { void submit(payload) }}
             onAbort=${() => { abortKeeperThreadMessage(keeperName) }}
           />

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -4,66 +4,94 @@
 // header; the panel reuses the full chat engine unchanged.
 
 import { html } from 'htm/preact'
-import { ChevronLeft } from 'lucide-preact'
-import { useCallback, useEffect, useState } from 'preact/hooks'
+import {
+  Archive,
+  ChevronLeft,
+  Info,
+  MoreHorizontal,
+  Pause,
+  Play,
+  RotateCcw,
+  Search,
+  Settings,
+  Square,
+} from 'lucide-preact'
+import { useEffect, useState } from 'preact/hooks'
 import type { VNode } from 'preact'
 import type { Keeper, KeeperConversationEntry } from '../../types'
 import { KeeperConversationPanel } from '../keeper-shared'
 import { navigate } from '../../router'
+import type { ChatComposerCommand } from '../chat/primitives'
 import { keeperMobilePane } from '../keeper-detail-state'
 import { TurnInspectorDrawer as SharedTurnInspectorDrawer } from '../keeper-turn-inspector-drawer'
+import { ChatArtifactPanel } from '../chat/artifact-panel'
+import { keeperThreads } from '../../keeper-state'
 import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
-import { Pill, type PillTone } from '../v2/primitives-v2'
-import { phaseTone, phasePulse } from '../v2/keeper-fsm'
+import { Pill } from '../v2/primitives-v2'
 import {
   WorkspaceSigil,
+  StatusDot,
   keeperBucket,
+  keeperStatusTone,
   keeperPhaseLabel,
+  statePillTone,
 } from './keeper-workspace-shared'
 
-type WorkspaceCommandId = KeeperActionKey | 'config'
+type WorkspaceUtilityAction = 'turn' | 'artifacts' | 'detail' | 'config'
+type WorkspaceCommandId = KeeperActionKey | WorkspaceUtilityAction
+type IconComponent = typeof Play
 
 interface WorkspaceCommand {
   id: WorkspaceCommandId
   label: string
   title: string
-  glyph: string
+  icon: IconComponent
   danger?: boolean
+  active?: boolean
   onClick: () => void | Promise<void>
 }
 
-const LIFECYCLE_COPY: Record<
-  KeeperActionKey,
-  { label: string; title: string; glyph: string; danger?: boolean }
-> = {
+const LIFECYCLE_COPY: Record<KeeperActionKey, { label: string; title: string; icon: IconComponent; danger?: boolean }> = {
   pause: {
     label: '일시정지',
     title: '일시정지: 실행 중인 keeper 를 일시 멈춥니다',
-    glyph: '\u23F8\uFE0E',
+    icon: Pause,
   },
   resume: {
     label: '재개',
     title: '재개: 일시정지된 keeper 를 다시 실행합니다',
-    glyph: '\u25B6\uFE0E',
+    icon: Play,
   },
   wakeup: {
     label: '깨우기',
     title: '깨우기: 다음 turn 을 즉시 시도합니다',
-    glyph: '\u25C9',
+    icon: RotateCcw,
   },
   boot: {
     label: '기동',
     title: '기동: offline keeper 를 다시 시작합니다',
-    glyph: '\u25B6\uFE0E',
+    icon: Play,
   },
   shutdown: {
     label: '종료',
     title: '종료: keeper 를 완전 종료합니다',
-    glyph: '\u25A0',
+    icon: Square,
     danger: true,
   },
+}
+
+const COMMAND_GLYPHS: Partial<Record<WorkspaceCommandId, string>> = {
+  pause: 'Ⅱ',
+  resume: '▶',
+  wakeup: '↻',
+  boot: '▶',
+  shutdown: '■',
+  turn: '⌕',
+  artifacts: '▣',
+  detail: 'ⓘ',
+  config: '⚙',
 }
 
 function lifecycleCommands(keeper: Keeper): WorkspaceCommand[] {
@@ -81,27 +109,87 @@ function lifecycleCommands(keeper: Keeper): WorkspaceCommand[] {
       id: key,
       label: copy.label,
       title: copy.title,
-      glyph: copy.glyph,
+      icon: copy.icon,
       danger: copy.danger,
       onClick: () => runKeeperAction(keeper.name, key),
     }
   })
 }
 
+function workspaceUtilityCommands({
+  detailOpen,
+  artifactsOpen,
+  onOpenTurnInspector,
+  onToggleArtifacts,
+  onToggleDetail,
+  onOpenConfig,
+}: {
+  detailOpen: boolean
+  artifactsOpen: boolean
+  onOpenTurnInspector: () => void
+  onToggleArtifacts: () => void
+  onToggleDetail: () => void
+  onOpenConfig?: () => void
+}): WorkspaceCommand[] {
+  return [
+    {
+      id: 'turn',
+      label: '턴 검사',
+      title: '턴 검사',
+      icon: Search,
+      onClick: onOpenTurnInspector,
+    },
+    {
+      id: 'artifacts',
+      label: artifactsOpen ? '아티팩트 숨김' : '아티팩트',
+      title: '대화 아티팩트',
+      icon: Archive,
+      active: artifactsOpen,
+      onClick: onToggleArtifacts,
+    },
+    {
+      id: 'detail',
+      label: detailOpen ? '대화로' : '상세',
+      title: '상세 (상태 · 진단 · 정체성 · 설정 · 디버그)',
+      icon: Info,
+      active: detailOpen,
+      onClick: onToggleDetail,
+    },
+    {
+      id: 'config',
+      label: 'keeper 설정',
+      title: 'keeper 설정',
+      icon: Settings,
+      onClick: onOpenConfig ?? onToggleDetail,
+    },
+  ]
+}
+
+function workspaceCommandGroup(command: WorkspaceCommand): string {
+  return command.id in LIFECYCLE_COPY ? '명령' : '이동'
+}
+
 function WorkspaceCommandButtons({
   keeper,
   mobile,
+  detailOpen,
+  artifactsOpen,
+  onOpenTurnInspector,
+  onToggleArtifacts,
+  onToggleDetail,
   onOpenConfig,
 }: {
   keeper: Keeper
   mobile: boolean
+  detailOpen: boolean
+  artifactsOpen: boolean
+  onOpenTurnInspector: () => void
+  onToggleArtifacts: () => void
+  onToggleDetail: () => void
   onOpenConfig?: () => void
 }): VNode {
   const [menuOpen, setMenuOpen] = useState(false)
   const [busyAction, setBusyAction] = useState<WorkspaceCommandId | null>(null)
-  useEffect(() => {
-    setMenuOpen(false)
-  }, [keeper.name])
   useEffect(() => {
     if (!menuOpen) return
     const close = () => setMenuOpen(false)
@@ -109,15 +197,15 @@ function WorkspaceCommandButtons({
     return () => window.removeEventListener('click', close)
   }, [menuOpen])
 
-  const config: WorkspaceCommand = {
-    id: 'config',
-    label: 'keeper 설정',
-    title: 'keeper 설정',
-    glyph: '\u2699\uFE0E',
-    onClick: onOpenConfig ?? (() => {}),
-  }
-  const lifecycle = lifecycleCommands(keeper)
-  const commands: WorkspaceCommand[] = [...lifecycle, config]
+  const utilities = workspaceUtilityCommands({
+    detailOpen,
+    artifactsOpen,
+    onOpenTurnInspector,
+      onToggleArtifacts,
+    onToggleDetail,
+    onOpenConfig,
+  })
+  const commands = [...lifecycleCommands(keeper), ...utilities]
 
   async function run(command: WorkspaceCommand) {
     if (busyAction) return
@@ -147,25 +235,28 @@ function WorkspaceCommandButtons({
             }}
             data-testid="kw-chat-command-menu-toggle"
           >
-            <span aria-hidden="true">⋯</span>
+            <${MoreHorizontal} size=${17} aria-hidden="true" />
           </button>
           ${menuOpen
             ? html`
                 <div class="kw-chat-command-popover v2-monitoring-surface" role="menu" onClick=${(event: Event) => event.stopPropagation()}>
-                  ${commands.map(command => html`
-                    <button
-                      key=${command.id}
-                      type="button"
-                      role="menuitem"
-                      class=${`kw-chat-command-item${command.danger ? ' danger' : ''}`}
-                      disabled=${busyAction !== null}
-                      onClick=${() => { void run(command) }}
-                      data-testid=${`kw-chat-command-${command.id}`}
-                    >
-                      <span aria-hidden="true">${command.glyph}</span>
-                      <span>${command.label}</span>
-                    </button>
-                  `)}
+                  ${commands.map(command => {
+                    const Icon = command.icon
+                    return html`
+                      <button
+                        key=${command.id}
+                        type="button"
+                        role="menuitem"
+                        class=${`kw-chat-command-item${command.danger ? ' danger' : ''}`}
+                        disabled=${busyAction !== null}
+                        onClick=${() => { void run(command) }}
+                        data-testid=${`kw-chat-command-${command.id}`}
+                      >
+                        <${Icon} size=${14} aria-hidden="true" />
+                        <span>${command.label}</span>
+                      </button>
+                    `
+                  })}
                 </div>
               `
             : null}
@@ -175,110 +266,97 @@ function WorkspaceCommandButtons({
   }
 
   return html`
-    <div class="chat-actions" data-testid="kw-chat-command-icons">
-      ${lifecycle.length === 0
-        ? html`<span class="act-quiet" title=${keeperDisplayStatus(keeper)}>전이 중…</span>`
-        : lifecycle.map(command => html`
-            <button
-              key=${command.id}
-              type="button"
-              class=${`act icon${command.danger ? ' danger' : ''}`}
-              aria-label=${command.label}
-              title=${command.title}
-              disabled=${busyAction !== null}
-              onClick=${() => { void run(command) }}
-              data-testid=${`kw-chat-command-${command.id}`}
-            >
-              <span aria-hidden="true">${command.glyph}</span>
-            </button>
-          `)}
-      <button
-        type="button"
-        class="act icon"
-        aria-label="keeper 설정"
-        title="keeper 설정"
-        disabled=${busyAction !== null}
-        onClick=${() => { void run(config) }}
-        data-testid="kw-chat-command-config"
-      >
-        <span aria-hidden="true">${'\u2699\uFE0E'}</span>
-      </button>
+    <div class="kw-chat-command-icons" data-testid="kw-chat-command-icons">
+      ${commands.map(command => {
+        const Icon = command.icon
+        return html`
+          <button
+            key=${command.id}
+            type="button"
+            class=${`kw-chat-command-icon${command.danger ? ' danger' : ''}${command.active ? ' active' : ''} v2-monitoring-action`}
+            aria-label=${command.label}
+            aria-pressed=${command.active ? 'true' : undefined}
+            title=${command.title}
+            disabled=${busyAction !== null}
+            onClick=${() => { void run(command) }}
+            data-testid=${`kw-chat-command-${command.id}`}
+          >
+            <${Icon} size=${14} aria-hidden="true" />
+          </button>
+        `
+      })}
     </div>
   `
 }
 
 function ChatHeader({
   keeper,
+  detailOpen,
+  onToggleDetail,
+  onOpenTurnInspector,
+  artifactsOpen,
+  onToggleArtifacts,
   mobile = false,
   onBack,
   onOpenRail,
   onOpenConfig,
-  onOpenDetail,
 }: {
   keeper: Keeper
+  detailOpen: boolean
+  onToggleDetail: () => void
+  onOpenTurnInspector: () => void
+  artifactsOpen: boolean
+  onToggleArtifacts: () => void
   mobile?: boolean
   onBack?: () => void
   onOpenRail?: () => void
   onOpenConfig?: () => void
-  onOpenDetail?: () => void
 }): VNode {
   const bucket = keeperBucket(keeper)
+  const tone = keeperStatusTone(keeper)
+  const pill = statePillTone(tone)
   const live = bucket === 'running'
-  const tone = phaseTone(keeper.lifecycle_phase)
-  const pillTone: PillTone = tone === 'idle' ? 'neutral' : tone === 'busy' ? 'warn' : tone
-  const pulse = phasePulse(keeper.lifecycle_phase)
-  const phase = keeper.lifecycle_phase ?? keeper.phase ?? keeperPhaseLabel(keeper)
-  // Prototype ChatHeader sub-line shows the keeper's sandbox basepath only.
-  const basepath = keeper.sandbox_target ?? ''
 
-  // Prototype ChatHeader (shell.jsx): avatar + identity (name + phase pill) +
-  // basepath sub + action icons. The back button is mobile-only (desktop keeps
-  // the roster visible). Runtime/model/throughput live in the context rail.
+  // Single-row header: identity + status + actions only. Runtime / model /
+  // throughput / scope live in the context rail (ThroughputSection) — the
+  // canonical home — so the header stays slim and the conversation gets the
+  // vertical space instead of a redundant metadata sub-row.
   return html`
-    <div class=${`chat-head${mobile ? ' is-mobile' : ''}`}>
-      ${mobile
-        ? html`<button
-            type="button"
-            class="chat-back"
-            title="키퍼 로스터"
-            aria-label="키퍼 로스터로 돌아가기"
-            onClick=${() => {
-              keeperMobilePane.value = 'roster'
-              onBack?.()
-            }}
-            data-testid="kw-chat-back-to-roster"
-          ><${ChevronLeft} size=${16} aria-hidden="true" /></button>`
-        : null}
+    <div class="kw-chat-head v2-monitoring-toolbar">
+      <button
+        type="button"
+        class="kw-chat-back kw-act v2-monitoring-action"
+        title="키퍼 로스터"
+        aria-label="키퍼 로스터로 돌아가기"
+        onClick=${() => {
+          keeperMobilePane.value = 'roster'
+          onBack?.()
+        }}
+        data-testid="kw-chat-back-to-roster"
+      >
+        <${ChevronLeft} size=${16} aria-hidden="true" />
+      </button>
       <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${live} />
-      <div class="chat-id">
-        <div class="name-row">
-          <h2>${keeper.name}</h2>
-          <${Pill} tone=${pillTone} dot=${pillTone === 'neutral' ? 'idle' : pillTone} dotPulse=${pulse} title=${keeperDisplayStatus(keeper)}>${phase}</${Pill}>
-        </div>
-        <div class="sub">
-          <span class="sub-ns" title="basepath — 이 keeper의 격리된 worktree 루트"><span class="mono">${basepath || '—'}</span></span>
+      <div class="kw-chat-id">
+        <div class="kw-chat-name-row">
+          <h2 class="kw-chat-name">${keeper.koreanName ?? keeper.name}</h2>
+          <span class=${`kw-state-pill ${pill}`} title=${keeperDisplayStatus(keeper)}>
+            <${StatusDot} tone=${tone} pulse=${live} />${keeperPhaseLabel(keeper)}
+          </span>
         </div>
       </div>
-      <div class="chat-actions">
+      <div class="kw-chat-actions">
         <${WorkspaceCommandButtons}
+          key=${keeper.name}
           keeper=${keeper}
           mobile=${mobile}
+          detailOpen=${detailOpen}
+          artifactsOpen=${artifactsOpen}
+          onOpenTurnInspector=${onOpenTurnInspector}
+            onToggleArtifacts=${onToggleArtifacts}
+          onToggleDetail=${onToggleDetail}
           onOpenConfig=${onOpenConfig}
         />
-        ${onOpenDetail
-          ? html`
-              <button
-                type="button"
-                class="act icon"
-                aria-label="상세"
-                title="운영 상세"
-                onClick=${onOpenDetail}
-                data-testid="kw-chat-detail"
-              >
-                <span aria-hidden="true">ℹ</span>
-              </button>
-            `
-          : null}
         ${mobile
           ? html`
               <button
@@ -288,7 +366,7 @@ function ChatHeader({
                 onClick=${onOpenRail}
                 data-testid="kw-chat-mobile-context"
               >
-                <span aria-hidden="true">ⓘ</span>
+                <${Info} size=${14} aria-hidden="true" />
                 <span>컨텍스트</span>
               </button>
             `
@@ -328,6 +406,7 @@ function TurnInspectorDrawer({
     />
   `
 }
+
 
 // RFC keeper-conversation-hitl-flow §4.1-A: a slim, non-interactive cue at the
 // top of the conversation so an operator who arrives via "대화에서 검토" sees the
@@ -374,20 +453,59 @@ export function KeeperWorkspaceChat({
 }): VNode {
   const [turnInspectorOpen, setTurnInspectorOpen] = useState(false)
   const [turnInspectorEntry, setTurnInspectorEntry] = useState<KeeperConversationEntry | null>(null)
-  const openTurnInspector = useCallback((entry?: KeeperConversationEntry) => {
+  const [artifactsOpen, setArtifactsOpen] = useState(false)
+  const [composerBusyAction, setComposerBusyAction] = useState<WorkspaceCommandId | null>(null)
+  const entries = keeperThreads.value[keeper.name] ?? []
+  const detailOpen = false
+  const onToggleDetail = onOpenDetail ?? (() => {})
+  const openTurnInspector = (entry?: KeeperConversationEntry) => {
     setTurnInspectorEntry(entry ?? null)
     setTurnInspectorOpen(true)
-  }, [])
+  }
+  const workspaceCommands = [
+    ...lifecycleCommands(keeper),
+    ...workspaceUtilityCommands({
+      detailOpen,
+      artifactsOpen,
+      onOpenTurnInspector: () => openTurnInspector(),
+          onToggleArtifacts: () => setArtifactsOpen((o) => !o),
+      onToggleDetail,
+      onOpenConfig,
+    }),
+  ]
+  const composerCommands: ChatComposerCommand[] = workspaceCommands.map(command => ({
+    id: String(command.id),
+    group: workspaceCommandGroup(command),
+    label: command.label,
+    hint: command.title,
+    glyph: COMMAND_GLYPHS[command.id],
+    danger: command.danger,
+    disabled: composerBusyAction !== null,
+    disabledReason: composerBusyAction !== null ? '다른 keeper 명령 실행 중' : undefined,
+    run: async () => {
+      if (composerBusyAction !== null) return
+      setComposerBusyAction(command.id)
+      try {
+        await command.onClick()
+      } finally {
+        setComposerBusyAction(null)
+      }
+    },
+  }))
 
   return html`
     <section class="kw-chat v2-monitoring-surface" role="region" aria-label=${`${keeper.name} 대화`}>
       <${ChatHeader}
         keeper=${keeper}
+        detailOpen=${detailOpen}
+        onToggleDetail=${onToggleDetail}
+        onOpenTurnInspector=${() => openTurnInspector()}
+        artifactsOpen=${artifactsOpen}
+        onToggleArtifacts=${() => setArtifactsOpen((o) => !o)}
         mobile=${mobile}
         onBack=${onBack}
         onOpenRail=${onOpenRail}
         onOpenConfig=${onOpenConfig}
-        onOpenDetail=${onOpenDetail}
       />
       <${PendingApprovalCue} keeper=${keeper} />
       <div class="kw-chat-body">
@@ -395,8 +513,12 @@ export function KeeperWorkspaceChat({
           keeperName=${keeper.name}
           placeholder=${`${keeper.name} 에게 메시지…  (⌘+Enter 전송)`}
           layout="workspace"
+          composerCommands=${composerCommands}
           onInspectTurn=${openTurnInspector}
         />
+        ${artifactsOpen
+          ? html`<${ChatArtifactPanel} entries=${entries} />`
+          : null}
       </div>
       <${TurnInspectorDrawer}
         keeperName=${keeper.name}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -1,38 +1,45 @@
-// Keeper Workspace — roster pane (left). Ported to the keeper-v2 prototype DOM
-// (rails.jsx Roster): `.roster` → `.roster-filters` (전체/실행/주의 + search
-// toggle + sort) → `.roster-list` of `.roster-group` + `.kp-row`. Styled by the
-// vendored SSOT CSS (keeper-v2/v2.css). All live wiring (the `keepers` store,
-// filtering/sorting, the FSM action menu, route-on-select) is unchanged from the
-// previous `.kw-*` implementation — only the emitted DOM/classes changed.
+// Keeper Workspace — roster pane (left). Search + status filter chips +
+// status-grouped keeper rows. Ported from the v2 design (rails.jsx Roster),
+// wired to the live `keepers` store. Selecting a row routes to that keeper,
+// which swaps the conversation + rail panes (same route shape the detail
+// page already used, so deep links keep working).
 
 import { html } from 'htm/preact'
+import {
+  MessageSquare,
+  MoreHorizontal,
+  Pause,
+  Play,
+  RotateCcw,
+  Settings,
+  Square,
+} from 'lucide-preact'
 import { useEffect, useState } from 'preact/hooks'
 import type { VNode } from 'preact'
 import { keepers } from '../../store'
 import { navigate } from '../../router'
 import { selectKeeper } from '../../keeper-runtime'
 import { keeperMobilePane } from '../keeper-detail-state'
-import { keeperActivityDisplay } from '../../lib/keeper-runtime-display'
+import { keeperActivityDisplay, keeperWorkPreview } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import type { Keeper } from '../../types'
 import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
 import { VirtualList } from '../common/virtual-list'
-import { kSlot, kSigil } from '../keeper-badge'
-import { SigilBadge, Dot } from '../v2/primitives-v2'
-import { phaseTone, phasePulse } from '../v2/keeper-fsm'
 import {
-  isTerminalPhase,
+  WorkspaceSigil,
+  StatusDot,
   keeperBucket,
+  keeperStatusTone,
   keeperPhaseLabel,
-  keeperRuntimeLabel,
   type KeeperBucket,
+  type DotTone,
 } from './keeper-workspace-shared'
 
 type RosterFilter = 'all' | 'run' | 'att'
 type RosterSort = 'status' | 'name' | 'att'
 type KeeperWorkspaceRouteSurface = 'monitoring' | 'keepers'
 type RosterMenuState = { keeper: Keeper; x: number; y: number } | null
-type RosterHoverState = { keeper: Keeper; x: number; y: number } | null
+type IconComponent = typeof Play
 type RosterFleetSummary = {
   total: number
   running: number
@@ -43,31 +50,65 @@ type RosterFleetSummary = {
   highContext: number
 }
 
-const LIFECYCLE_COPY: Record<KeeperActionKey, { label: string; title: string; glyph: string; danger?: boolean }> = {
-  pause: { label: '일시정지', title: '일시정지: 실행 중인 keeper 를 일시 멈춥니다', glyph: '\u23F8\uFE0E' },
-  resume: { label: '재개', title: '재개: 일시정지된 keeper 를 다시 실행합니다', glyph: '\u25B6\uFE0E' },
-  wakeup: { label: '깨우기', title: '깨우기: 다음 turn 을 즉시 시도합니다', glyph: '\u25C9' },
-  boot: { label: '기동', title: '기동: offline keeper 를 다시 시작합니다', glyph: '\u25B6\uFE0E' },
-  shutdown: { label: '종료', title: '종료: keeper 를 완전 종료합니다', glyph: '\u25A0', danger: true },
+const LIFECYCLE_COPY: Record<KeeperActionKey, { label: string; title: string; icon: IconComponent; danger?: boolean }> = {
+  pause: {
+    label: '일시정지',
+    title: '일시정지: 실행 중인 keeper 를 일시 멈춥니다',
+    icon: Pause,
+  },
+  resume: {
+    label: '재개',
+    title: '재개: 일시정지된 keeper 를 다시 실행합니다',
+    icon: Play,
+  },
+  wakeup: {
+    label: '깨우기',
+    title: '깨우기: 다음 turn 을 즉시 시도합니다',
+    icon: RotateCcw,
+  },
+  boot: {
+    label: '기동',
+    title: '기동: offline keeper 를 다시 시작합니다',
+    icon: Play,
+  },
+  shutdown: {
+    label: '종료',
+    title: '종료: keeper 를 완전 종료합니다',
+    icon: Square,
+    danger: true,
+  },
 }
 const MENU_WIDTH = 190
 const MENU_ESTIMATED_HEIGHT = 246
 const MENU_VIEWPORT_MARGIN = 8
 
-// Prototype group order + the short header label it uses (rails.jsx groupLabel).
-const GROUP_ORDER: { bucket: KeeperBucket; label: string; short: string; cls: string }[] = [
-  { bucket: 'running', label: '실행 중', short: '실행 중', cls: 'run' },
-  { bucket: 'paused', label: '대기 · 일시정지', short: '대기', cls: 'pause' },
-  { bucket: 'offline', label: '중지 · 종료됨', short: '중지', cls: 'off' },
+const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
+  { bucket: 'running', label: '실행 중' },
+  { bucket: 'paused', label: '대기 · 일시정지' },
+  { bucket: 'offline', label: '중지 · 종료됨' },
 ]
-const GROUP_BY_BUCKET = Object.fromEntries(GROUP_ORDER.map((g) => [g.bucket, g])) as Record<KeeperBucket, (typeof GROUP_ORDER)[number]>
 
+/** Group-header status dot tone (design rails.jsx `.rg-dot` colored by groupCls).
+ *  Reuses the shared StatusDot vocabulary instead of a bespoke dot so the header
+ *  marker matches the per-row dots: running→ok, paused→warn, offline→idle. */
+const GROUP_BUCKET_TONE: Record<KeeperBucket, DotTone> = {
+  running: 'ok',
+  paused: 'warn',
+  offline: 'idle',
+}
+
+/** Flattened roster item used by the virtualized render path. */
 type RosterItem =
-  | { type: 'header'; bucket: KeeperBucket; count: number }
+  | { type: 'header'; bucket: KeeperBucket; label: string; count: number }
   | { type: 'row'; keeper: Keeper }
 
+/** Switch to the shared VirtualList once the roster is long enough that DOM
+ *  weight matters. Below this we keep the identical grouped DOM structure and
+ *  rely on content-visibility:auto for cheap off-screen skipping. */
 const WINDOW_AT = 60
+const ROSTER_ROW_ESTIMATED_HEIGHT = 92
 
+/** Blocked tasks + explicit attention flag → the roster attention badge. */
 function attentionCount(keeper: Keeper): number {
   return keeper.blocked_task_count ?? (keeper.needs_attention === true ? 1 : 0)
 }
@@ -77,8 +118,15 @@ function needsAttention(keeper: Keeper): boolean {
 
 export function rosterFleetSummary(rows: readonly Keeper[]): RosterFleetSummary {
   const summary: RosterFleetSummary = {
-    total: rows.length, running: 0, paused: 0, offline: 0, attention: 0, approvalGate: 0, highContext: 0,
+    total: rows.length,
+    running: 0,
+    paused: 0,
+    offline: 0,
+    attention: 0,
+    approvalGate: 0,
+    highContext: 0,
   }
+
   for (const keeper of rows) {
     const bucket = keeperBucket(keeper)
     if (bucket === 'running') summary.running += 1
@@ -90,50 +138,80 @@ export function rosterFleetSummary(rows: readonly Keeper[]): RosterFleetSummary 
       summary.highContext += 1
     }
   }
+
   return summary
 }
 
+/** Numeric attention weight for the 'att' sort: attention-needing keepers rank
+ *  above the rest, ordered by blocked-task count (min 1 when only the flag is
+ *  set, so a flagged-but-unblocked keeper still outranks a calm one). Mirrors
+ *  the v2 roster's numeric `k.att` sort key. */
 function attentionScore(keeper: Keeper): number {
   return needsAttention(keeper) ? Math.max(1, attentionCount(keeper)) : 0
 }
 
+/** Comparator for the flat sort modes ('name'/'att'). 'status' keeps the bucket
+ *  grouping instead and never reaches here. Name ties break alphabetically so
+ *  the order is stable. */
 function compareKeepers(a: Keeper, b: Keeper, sort: Exclude<RosterSort, 'status'>): number {
   if (sort === 'name') return a.name.localeCompare(b.name)
   return attentionScore(b) - attentionScore(a) || a.name.localeCompare(b.name)
 }
 
+/** ns proxy: keepers have no namespace field; the skill path is the closest
+ *  real scope signal, with the model as fallback. */
 function keeperScope(keeper: Keeper): string | null {
   return keeper.skill_primary ?? keeper.active_model ?? keeper.model ?? null
 }
 
-// The keeper's sandbox location — the prototype roster identity sub-line
-// (rails.jsx renders `k.basepath`). Live field is `sandbox_target`.
+/** The keeper's sandbox location — the design's roster identity sub-line
+ *  (rails.jsx renders `k.basepath` here). The live field is `sandbox_target`
+ *  (keeper-detail-alert-strip.ts:252 uses the same field); for a `local`
+ *  profile it is the worktree root path, for `docker` the container target.
+ *  Unlike the alert strip, this deliberately does NOT fall back to
+ *  `sandbox_profile`: a bare 'local'/'docker' literal is not a useful roster
+ *  identity, so RosterRow falls through to the scope proxy (skill/model) instead. */
 function keeperBasepath(keeper: Keeper): string {
   return keeper.sandbox_target?.trim() ?? ''
 }
 
+/** Local worktree roots are long absolute paths that end-ellipsis to an
+ *  unhelpful common prefix in the narrow column, so show the last two segments
+ *  (the identifying tail) with the full path in `title`. Non-path targets
+ *  (e.g. a docker target) are shown verbatim. */
 function shortBasepath(value: string): string {
   if (!value.startsWith('/')) return value
   const parts = value.split('/').filter(Boolean)
   return parts.length <= 2 ? value : `…/${parts.slice(-2).join('/')}`
 }
 
+function cleanToolNames(names: readonly string[] | null | undefined): string[] {
+  return (names ?? []).map(name => name.trim()).filter(Boolean)
+}
+
+/** Recent-tool signal for v2 fleet parity.
+ *  Prefer the dashboard summary's latest_tool_names, then the older
+ *  recent_tool_names field. Do not fetch row-local tool-call logs here: the
+ *  roster is a fleet-wide surface and must stay backed by the already-loaded
+ *  keeper snapshot instead of N per-row network requests or prototype seeds. */
+function keeperRecentTool(keeper: Keeper): { label: string; title: string } | null {
+  const latest = cleanToolNames(keeper.latest_tool_names)
+  const recent = latest.length > 0 ? latest : cleanToolNames(keeper.recent_tool_names)
+  const count = keeper.latest_tool_call_count
+  const hasCount = typeof count === 'number' && Number.isFinite(count) && count > 0
+  if (recent.length === 0 && !hasCount) return null
+  const label = recent[0] ?? `${count} tool calls`
+  const countSuffix = hasCount ? ` · ${count} calls` : ''
+  return {
+    label,
+    title: `${recent.join(', ') || label}${countSuffix}`,
+  }
+}
+
 function matchesQuery(keeper: Keeper, q: string): boolean {
   if (!q) return true
   const hay = `${keeper.name} ${keeper.koreanName ?? ''} ${keeperScope(keeper) ?? ''} ${keeper.model ?? ''} ${keeperBasepath(keeper)}`.toLowerCase()
   return hay.includes(q.toLowerCase())
-}
-
-function formatHHMM(timestamp: string | null | undefined): string | null {
-  if (!timestamp) return null
-  const d = new Date(timestamp)
-  if (Number.isNaN(d.getTime())) return null
-  return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false })
-}
-
-// Prototype kp-state shows the raw English FSM phase ("Running", "Compacting").
-function phaseText(keeper: Keeper): string {
-  return keeper.lifecycle_phase ?? keeper.phase ?? keeperPhaseLabel(keeper)
 }
 
 function RosterRow({
@@ -150,19 +228,30 @@ function RosterRow({
   style?: string
 }) {
   const bucket = keeperBucket(keeper)
+  const tone = keeperStatusTone(keeper)
   const att = attentionCount(keeper)
+  const scope = keeperScope(keeper)
   const basepath = keeperBasepath(keeper)
-  const handle = basepath ? shortBasepath(basepath) : keeperScope(keeper)
-  const handleTitle = basepath || keeperScope(keeper) || ''
+  // Design roster identity sub-line = basepath; fall back to the scope proxy
+  // when a keeper has no sandbox target yet so the row never loses its sub-label.
+  const handle = basepath ? shortBasepath(basepath) : scope
+  const handleTitle = basepath || scope || ''
+  const contextRatio =
+    typeof keeper.context_ratio === 'number' && Number.isFinite(keeper.context_ratio)
+      ? Math.min(1, Math.max(0, keeper.context_ratio))
+      : null
+  const contextPct = contextRatio === null ? null : Math.round(contextRatio * 100)
+  const contextHot = contextRatio !== null && contextRatio >= 0.8
   const activity = keeperActivityDisplay(keeper)
-  const activityTime = formatHHMM(activity.timestamp)
-  const activityLabel = activityTime ?? (activity.source !== 'none' ? activity.label : null)
+  const work = keeperWorkPreview(keeper)
+  const recentTool = keeperRecentTool(keeper)
   const select = () => onSelect(keeper.name)
   return html`
     <div
       role="button"
       tabindex="0"
-      class=${`kp-row${active ? ' sel' : ''}`}
+      class="kw-kp-row v2-monitoring-row"
+      data-tone=${tone}
       style=${style}
       aria-current=${active ? 'true' : 'false'}
       onClick=${select}
@@ -173,27 +262,46 @@ function RosterRow({
         select()
       }}
     >
-      <${SigilBadge} slot=${kSlot(keeper.name)} sigil=${kSigil(keeper.name)} size=${38} beat=${bucket === 'running'} title=${keeper.name} />
-      <div class="kp-meta">
-        <div class="kp-name">${keeper.name}</div>
-        <div class="kp-sub">
-          <span class="kp-state"><${Dot} state=${phaseTone(keeper.lifecycle_phase)} pulse=${phasePulse(keeper.lifecycle_phase)} />${phaseText(keeper)}</span>
-          ${handle ? html`<span aria-hidden="true">·</span><span class="kp-handle" title=${handleTitle}>${handle}</span>` : null}
+      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
+      <div class="kw-kp-meta">
+        <div class="kw-kp-name">${keeper.koreanName ?? keeper.name}</div>
+        <div class="kw-kp-sub">
+          <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${bucket === 'running'} />${keeperPhaseLabel(keeper)}</span>
+          ${handle ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle" title=${handleTitle}>${handle}</span>` : null}
         </div>
+        <div class="kw-kp-work" title=${work ?? ''}>${work ?? '최근 작업 요약 없음'}</div>
+        ${contextPct !== null
+          ? html`
+              <div class="kw-kp-context" title=${`context ${contextPct}%`}>
+                <div class="kw-kp-context-bar" aria-hidden="true">
+                  <span class=${contextHot ? 'hot' : ''} style=${{ width: `${contextPct}%` }}></span>
+                </div>
+                <span class=${`kw-kp-context-val${contextHot ? ' hot' : ''}`}>${contextPct}%</span>
+              </div>
+            `
+          : null}
+        ${recentTool
+          ? html`
+              <div class="kw-kp-tool" title=${recentTool.title}>
+                <span class="kw-kp-tool-k">tool</span>
+                <span class="kw-kp-tool-v">${recentTool.label}</span>
+              </div>
+            `
+          : null}
       </div>
-      <div class="kp-right">
-        ${activityLabel ? html`<span class="kp-time" title=${activity.label}>${activityLabel}</span>` : null}
-        ${att > 0 ? html`<span class="kp-att" title=${`주의 ${att}건 — 컨텍스트 레일에서 확인`}>${att}</span>` : null}
+      <div class="kw-kp-right">
+        ${activity.source !== 'none' ? html`<span class="kw-kp-time">${activity.label}</span>` : null}
+        ${att > 0 ? html`<span class="kw-kp-att" title=${`주의 ${att}건`}>${att}</span>` : null}
       </div>
       <button
         type="button"
-        class="kp-more"
+        class="kw-kp-more v2-monitoring-action"
         aria-label=${`${keeper.name} 명령`}
-        title="명령 메뉴"
+        title="keeper 명령"
         onClick=${(event: MouseEvent) => onMenu(keeper, event)}
         data-testid=${`kw-roster-menu-${keeper.name}`}
       >
-        <span aria-hidden="true">${'\u22EF'}</span>
+        <${MoreHorizontal} size=${15} aria-hidden="true" />
       </button>
     </div>
   `
@@ -204,34 +312,27 @@ function MiniRosterRow({
   active,
   onSelect,
   onMenu,
-  onHover,
 }: {
   keeper: Keeper
   active: boolean
   onSelect: (name: string) => void
   onMenu: (keeper: Keeper, event: MouseEvent) => void
-  onHover?: (keeper: Keeper | null, event?: MouseEvent) => void
 }) {
   const bucket = keeperBucket(keeper)
-  const label = `${keeper.name} · ${phaseText(keeper)}`
-  const updateHover = (event: MouseEvent) => {
-    onHover?.(keeper, event)
-    event.stopPropagation()
-  }
+  const tone = keeperStatusTone(keeper)
+  const label = `${keeper.name} · ${keeperPhaseLabel(keeper)}`
   return html`
     <button
       type="button"
-      class=${`kp-row mini${active ? ' sel' : ''}`}
+      class="kw-kp-mini v2-monitoring-action"
       aria-current=${active ? 'true' : 'false'}
       aria-label=${label}
       title=${label}
       onClick=${() => onSelect(keeper.name)}
       onContextMenu=${(event: MouseEvent) => onMenu(keeper, event)}
-      onMouseEnter=${updateHover}
-      onMouseMove=${updateHover}
-      onMouseLeave=${() => onHover?.(null)}
     >
-      <${SigilBadge} slot=${kSlot(keeper.name)} sigil=${kSigil(keeper.name)} size=${38} beat=${bucket === 'running'} title=${keeper.name} />
+      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
+      <${StatusDot} tone=${tone} pulse=${bucket === 'running'} />
     </button>
   `
 }
@@ -247,6 +348,34 @@ function lifecycleActions(keeper: Keeper): KeeperActionKey[] {
   return actions
 }
 
+function pct(count: number, total: number): string {
+  if (total <= 0 || count <= 0) return '0%'
+  return `${Math.max(4, Math.round((count / total) * 100))}%`
+}
+
+function KeeperFleetSummaryBand({ summary }: { summary: RosterFleetSummary }): VNode {
+  return html`
+    <section class="kw-roster-summary" data-testid="kw-roster-summary" aria-label="키퍼 플릿 요약">
+      <div class="kw-roster-meter" aria-hidden="true">
+        <span class="run" style=${{ width: pct(summary.running, summary.total) }}></span>
+        <span class="pause" style=${{ width: pct(summary.paused, summary.total) }}></span>
+        <span class="off" style=${{ width: pct(summary.offline, summary.total) }}></span>
+      </div>
+      <div class="kw-roster-summary-grid">
+        <div class="kw-roster-stat"><b>${summary.total}</b><span>전체</span></div>
+        <div class="kw-roster-stat ok"><b>${summary.running}</b><span>실행</span></div>
+        <div class="kw-roster-stat warn"><b>${summary.paused}</b><span>대기</span></div>
+        <div class="kw-roster-stat idle"><b>${summary.offline}</b><span>중지</span></div>
+      </div>
+      <div class="kw-roster-flags">
+        <span class=${summary.attention > 0 ? 'hot' : ''}>주의 ${summary.attention}</span>
+        <span class=${summary.approvalGate > 0 ? 'gate' : ''}>승인 ${summary.approvalGate}</span>
+        <span class=${summary.highContext > 0 ? 'ctx' : ''}>CTX 80%+ ${summary.highContext}</span>
+      </div>
+    </section>
+  `
+}
+
 function KeeperRosterMenu({
   state,
   onClose,
@@ -260,74 +389,63 @@ function KeeperRosterMenu({
 }): VNode {
   const keeper = state.keeper
   const actions = lifecycleActions(keeper)
-  const select = () => { onSelect(keeper.name); onClose() }
-  const openConfig = () => {
+  const select = () => {
     onSelect(keeper.name)
-    if (onOpenConfig) onOpenConfig(keeper.name)
     onClose()
   }
+  const openConfig = () => {
+    onSelect(keeper.name)
+    if (onOpenConfig) {
+      onOpenConfig(keeper.name)
+    }
+    onClose()
+  }
+
   return html`
     <div
-      class="kp-menu"
+      class="kw-kp-menu v2-monitoring-surface"
       role="menu"
       style=${{ left: `${state.x}px`, top: `${state.y}px` }}
       onClick=${(event: Event) => event.stopPropagation()}
       data-testid="kw-roster-menu"
     >
-      <div class="kp-menu-h">
-        <${SigilBadge} slot=${kSlot(keeper.name)} sigil=${kSigil(keeper.name)} size=${20} title=${keeper.name} />
-        <span class="mono">${keeper.name}</span>
+      <div class="kw-kp-menu-head v2-monitoring-toolbar">
+        <${WorkspaceSigil} id=${keeper.name} size=${22} beat=${keeperBucket(keeper) === 'running'} />
+        <span>${keeper.name}</span>
       </div>
-      <button type="button" role="menuitem" class="kp-menu-i" onClick=${select} data-testid="kw-roster-menu-open-chat">
-        <span aria-hidden="true">◈</span>
+      <button type="button" role="menuitem" class="kw-kp-menu-item" onClick=${select} data-testid="kw-roster-menu-open-chat">
+        <${MessageSquare} size=${14} aria-hidden="true" />
         <span>대화 열기</span>
       </button>
       ${actions.map(action => {
         const copy = LIFECYCLE_COPY[action]
+        const Icon = copy.icon
         return html`
           <button
             key=${action}
             type="button"
             role="menuitem"
-            class=${`kp-menu-i${copy.danger ? ' danger' : ''}`}
+            class=${`kw-kp-menu-item${copy.danger ? ' danger' : ''}`}
             title=${copy.title}
-            onClick=${() => { void runKeeperAction(keeper.name, action); onClose() }}
+            onClick=${() => {
+              void runKeeperAction(keeper.name, action)
+              onClose()
+            }}
             data-testid=${`kw-roster-menu-${action}`}
           >
-            <span aria-hidden="true">${copy.glyph}</span>
+            <${Icon} size=${14} aria-hidden="true" />
             <span>${copy.label}</span>
           </button>
         `
       })}
       ${actions.length === 0
-        ? html`<div class="kp-menu-note">${isTerminalPhase(keeper) ? '복구 불가 — 명령 없음' : '전이 중 — 잠시 후'}</div>`
+        ? html`<div class="kw-kp-menu-note">현재 실행 가능한 명령 없음</div>`
         : null}
-      <div class="kp-menu-sep"></div>
-      <button type="button" role="menuitem" class="kp-menu-i" onClick=${openConfig} data-testid="kw-roster-menu-config">
-        <span aria-hidden="true">${'\u2699\uFE0E'}</span>
+      <div class="kw-kp-menu-sep"></div>
+      <button type="button" role="menuitem" class="kw-kp-menu-item" onClick=${openConfig} data-testid="kw-roster-menu-config">
+        <${Settings} size=${14} aria-hidden="true" />
         <span>keeper 설정</span>
       </button>
-    </div>
-  `
-}
-
-function RosterFlyout({ state }: { state: Exclude<RosterHoverState, null> }): VNode {
-  const k = state.keeper
-  const basepath = keeperBasepath(k)
-  const runtime = keeperRuntimeLabel(k)
-  const att = attentionCount(k)
-  return html`
-    <div class="kp-flyout" style=${{ left: `${state.x}px`, top: `${state.y}px` }}>
-      <div class="kpf-h">
-        <${SigilBadge} slot=${kSlot(k.name)} sigil=${kSigil(k.name)} size=${26} title=${k.name} />
-        <div class="kpf-id">
-          <div class="kpf-name">${k.name}</div>
-          <div class="kpf-phase"><${Dot} state=${phaseTone(k.lifecycle_phase)} pulse=${phasePulse(k.lifecycle_phase)} />${phaseText(k)}</div>
-        </div>
-      </div>
-      ${basepath ? html`<div class="kpf-row"><span class="kpf-k">basepath</span><span class="mono">${basepath}</span></div>` : null}
-      ${runtime ? html`<div class="kpf-row"><span class="kpf-k">runtime</span><span class="mono">${runtime}</span></div>` : null}
-      ${att > 0 ? html`<div class="kpf-att">${'⚠'} 주의 ${att}건</div>` : null}
     </div>
   `
 }
@@ -346,25 +464,16 @@ export function KeeperWorkspaceRoster({
   mini?: boolean
 }): VNode {
   const [query, setQuery] = useState('')
-  const [searchOpen, setSearchOpen] = useState(false)
   const [filter, setFilter] = useState<RosterFilter>('all')
   const [sort, setSort] = useState<RosterSort>('status')
   const [menu, setMenu] = useState<RosterMenuState>(null)
-  const [peek, setPeek] = useState(false)
-  const [hover, setHover] = useState<RosterHoverState>(null)
-
-  const handleMiniHover = (keeper: Keeper | null, event?: MouseEvent) => {
-    if (!keeper || !event) {
-      setHover(null)
-      return
-    }
-    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-    setHover({ keeper, x: rect.right + 10, y: rect.top + rect.height / 2 })
-  }
 
   useEffect(() => {
     if (!menu) return
     const close = () => setMenu(null)
+    // Esc closes the menu (was: any key — typing in the search box dismissed it);
+    // scroll closes it too (capture phase) so the row-anchored menu can't drift
+    // away from its row. Mirrors the design roster menu (rails.jsx).
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setMenu(null)
     }
@@ -379,6 +488,7 @@ export function KeeperWorkspaceRoster({
   }, [menu])
 
   const all = keepers.value
+  const summary = rosterFleetSummary(all)
   const counts = {
     all: all.length,
     run: all.filter(k => keeperBucket(k) === 'running').length,
@@ -391,12 +501,15 @@ export function KeeperWorkspaceRoster({
     return matchesQuery(k, query)
   })
 
-  const sortRows = (rows: Keeper[]): Keeper[] =>
-    sort === 'status' ? rows : [...rows].sort((a, b) => compareKeepers(a, b, sort))
+  const sortRows = (rows: Keeper[]): Keeper[] => {
+    return sort === 'status' ? rows : [...rows].sort((a, b) => compareKeepers(a, b, sort))
+  }
 
   const select = (name: string) => {
     setMenu(null)
     selectKeeper(name)
+    // On mobile the roster and conversation share one column; picking a keeper
+    // should reveal that keeper's chat (the roster is the "back" target).
     keeperMobilePane.value = 'chat'
     if (routeSurface === 'keepers') {
       navigate('keepers', { keeper: name })
@@ -407,10 +520,16 @@ export function KeeperWorkspaceRoster({
   }
 
   const openMenu = (keeper: Keeper, event: MouseEvent) => {
+    // Centralized here so both entry points behave: the ⋯ button click and a
+    // right-click on the row. preventDefault suppresses the browser's native
+    // context menu on right-click; stopPropagation keeps a ⋯ click from also
+    // selecting the row (the click would otherwise bubble to the row onClick).
     event.preventDefault()
     event.stopPropagation()
     const target = event.currentTarget as HTMLElement
-    const rosterRect = target.closest('.roster')?.getBoundingClientRect() ?? { left: 0, top: 0 }
+    const rosterRect = target.closest('.kw-roster')?.getBoundingClientRect() ?? { left: 0, top: 0 }
+    // Right-click anchors the menu at the cursor (design rails.jsx openMenu); the
+    // ⋯ button right-aligns the menu just below itself.
     let anchorRight: number
     let anchorTop: number
     if (event.type === 'contextmenu') {
@@ -429,38 +548,52 @@ export function KeeperWorkspaceRoster({
       MENU_VIEWPORT_MARGIN,
       Math.min(anchorTop, window.innerHeight - MENU_ESTIMATED_HEIGHT - MENU_VIEWPORT_MARGIN),
     )
-    setMenu({ keeper, x: viewportX - rosterRect.left, y: viewportY - rosterRect.top })
+    setMenu({
+      keeper,
+      x: viewportX - rosterRect.left,
+      y: viewportY - rosterRect.top,
+    })
   }
 
   const filterChips: { id: RosterFilter; label: string }[] = [
     { id: 'all', label: '전체' },
-    { id: 'run', label: '실행' },
+    { id: 'run', label: '실행중' },
     { id: 'att', label: '주의' },
   ]
 
+  // Flatten to [{ type: 'header'|'row', ... }] for windowing. 'status' keeps the
+  // bucket grouping with headers; 'name'/'att' produce a flat sorted list with no
+  // headers, mirroring the v2 roster sort modes (rails.jsx Roster).
   const items: RosterItem[] = []
   if (sort === 'status') {
     for (const group of GROUP_ORDER) {
       const rows = visible.filter(k => keeperBucket(k) === group.bucket)
       if (rows.length === 0) continue
-      items.push({ type: 'header', bucket: group.bucket, count: rows.length })
-      for (const keeper of rows) items.push({ type: 'row', keeper })
+      items.push({ type: 'header', bucket: group.bucket, label: group.label, count: rows.length })
+      for (const keeper of rows) {
+        items.push({ type: 'row', keeper })
+      }
     }
   } else {
-    for (const keeper of sortRows(visible)) items.push({ type: 'row', keeper })
+    for (const keeper of sortRows(visible)) {
+      items.push({ type: 'row', keeper })
+    }
   }
 
   const useVirtual = items.length > WINDOW_AT
-  const rowStyle = 'content-visibility:auto;contain-intrinsic-size:auto 58px'
+  const rowStyle = `content-visibility:auto;contain-intrinsic-size:auto ${ROSTER_ROW_ESTIMATED_HEIGHT}px`
   const miniRows = sortRows(all)
 
+  // Single source for the group header so the windowed and non-windowed render
+  // paths can't drift (they previously inlined the header markup separately).
   function renderHeader(item: Extract<RosterItem, { type: 'header' }>): VNode {
-    const g = GROUP_BY_BUCKET[item.bucket]
-    return html`<div class=${`roster-group ${g.cls}`} title=${g.label} key=${`h:${item.bucket}`}><span class="rg-dot"></span>${g.short}<span class="rg-n">${item.count}</span></div>`
+    return html`<div class="kw-roster-group v2-monitoring-row" key=${`h:${item.bucket}`}><${StatusDot} tone=${GROUP_BUCKET_TONE[item.bucket]} /><span class="kw-roster-group-label">${item.label}</span><span class="kw-roster-group-n">${item.count}</span></div>`
   }
 
   function renderItem(item: RosterItem): VNode {
-    if (item.type === 'header') return renderHeader(item)
+    if (item.type === 'header') {
+      return renderHeader(item)
+    }
     return html`<${RosterRow} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} />`
   }
 
@@ -469,47 +602,36 @@ export function KeeperWorkspaceRoster({
   }
 
   return html`
-    <aside
-      class=${`roster${mini ? ' mini' : ''}${mini && peek ? ' peek' : ''}`}
-      aria-label="키퍼 로스터"
-      onMouseEnter=${mini ? () => setPeek(true) : undefined}
-      onMouseLeave=${mini ? () => { setPeek(false); setHover(null) } : undefined}
-    >
-      ${mini && !peek
-        ? html`
-          <div class="roster-list mini-list">
-            ${miniRows.map(k => html`<${MiniRosterRow}
-              key=${k.name}
-              keeper=${k}
-              active=${k.name === activeName}
-              onSelect=${select}
-              onMenu=${openMenu}
-              onHover=${handleMiniHover}
-            />`)}
-          </div>
-        `
+    <aside class=${`kw-roster${mini ? ' mini' : ''} v2-monitoring-surface`} aria-label="키퍼 로스터">
+      ${mini
+        ? html`<div class="kw-roster-mini-list">
+            ${miniRows.map(k => html`<${MiniRosterRow} key=${k.name} keeper=${k} active=${k.name === activeName} onSelect=${select} onMenu=${openMenu} />`)}
+          </div>`
         : html`
-          <div class="roster-filters" role="group" aria-label="상태 필터">
+          <div class="kw-roster-head v2-monitoring-toolbar">
+            <input
+              class="kw-roster-search"
+              type="text"
+              placeholder="이름 · 스코프 검색…"
+              aria-label="키퍼 검색"
+              value=${query}
+              onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
+            />
+          </div>
+          <${KeeperFleetSummaryBand} summary=${summary} />
+          <div class="kw-roster-filters v2-monitoring-toolbar" role="group" aria-label="상태 필터">
             ${filterChips.map(chip => html`
               <button
                 type="button"
-                class=${`rfilter${filter === chip.id ? ' on' : ''}`}
+                class="kw-rfilter v2-monitoring-action"
                 aria-pressed=${filter === chip.id ? 'true' : 'false'}
                 onClick=${() => setFilter(chip.id)}
               >
                 ${chip.label}<span class="n">${counts[chip.id]}</span>
               </button>
             `)}
-            <button
-              type="button"
-              class=${`rfilter-icon${searchOpen ? ' on' : ''}`}
-              title="검색"
-              aria-label="키퍼 검색 토글"
-              aria-pressed=${searchOpen ? 'true' : 'false'}
-              onClick=${() => setSearchOpen(o => !o)}
-            >${'⌕'}</button>
             <select
-              class="roster-sort"
+              class="kw-roster-sort v2-monitoring-action"
               aria-label="키퍼 정렬"
               value=${sort}
               onChange=${(e: Event) => setSort((e.target as HTMLSelectElement).value as RosterSort)}
@@ -519,30 +641,17 @@ export function KeeperWorkspaceRoster({
               <option value="att">주의순</option>
             </select>
           </div>
-          ${searchOpen
-            ? html`<div class="roster-head">
-                <input
-                  class="roster-search"
-                  type="text"
-                  placeholder="이름·basepath 검색…"
-                  aria-label="키퍼 검색"
-                  autofocus
-                  value=${query}
-                  onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-                />
-              </div>`
-            : null}
           ${visible.length === 0
-            ? html`<div class="roster-list"><div class="roster-empty" style="padding:30px 12px;text-align:center;color:var(--text-dim);font-size:12px">일치하는 Keeper가 없습니다</div></div>`
+            ? html`<div class="kw-roster-list"><div class="kw-roster-empty v2-monitoring-row">일치하는 키퍼가 없습니다</div></div>`
         : useVirtual
           ? html`<${VirtualList}
               items=${items}
-              estimatedItemHeight=${58}
-              className="roster-list"
+              estimatedItemHeight=${ROSTER_ROW_ESTIMATED_HEIGHT}
+              className="kw-roster-list"
               renderItem=${renderItem}
               getKey=${getKey}
             />`
-          : html`<div class="roster-list">
+          : html`<div class="kw-roster-list">
               ${items.map(item => item.type === 'header'
                 ? renderHeader(item)
                 : html`<${RosterRow} key=${item.keeper.name} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} style=${rowStyle} />`)}
@@ -556,7 +665,6 @@ export function KeeperWorkspaceRoster({
             onOpenConfig=${onOpenConfig}
           />`
         : null}
-      ${hover && mini && !peek ? html`<${RosterFlyout} state=${hover} />` : null}
     </aside>
   `
 }

--- a/dashboard/src/styles/board-v2.css
+++ b/dashboard/src/styles/board-v2.css
@@ -60,19 +60,25 @@
 .v2-board-surface .bd-rail {
   border-right: 1px solid var(--border-main);
   background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep) 70%);
-  padding: 14px 10px;
+  padding: 14px 9px; /* prototype surfaces.css:278 */
   overflow-y: auto;
   min-width: 0;
 }
 
 .v2-board-surface .bd-rail h4 {
   font-family: var(--font-ui);
-  font-size: 9.5px;
+  /* Prototype: the authoritative TYPE LADDER (surfaces.css T4) loads after
+     the base .bd-rail h4 rule and wins, so the rendered values are the T4
+     tokens, not the base rule (9.5px / weight 500). Our .v2-board-surface
+     prefix raises specificity above the ladder, so the ladder is defeated —
+     mirror the resolved T4 values here. --fs-t4=9px, --fw-t4=600,
+     --tr-t4=0.2em (v2.css:101). */
+  font-size: 9px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--text-dim);
-  margin: 0 0 8px 8px;
-  font-weight: 500;
+  margin: 0 0 8px 7px; /* prototype surfaces.css:279 */
+  font-weight: 600;
 }
 
 .v2-board-surface .bd-sub {
@@ -81,7 +87,7 @@
   gap: 8px;
   width: 100%;
   text-align: left;
-  padding: 8px 10px;
+  padding: 7px 9px; /* prototype surfaces.css:280 */
   border-radius: var(--radius-sm);
   border: 1px solid transparent;
   background: none;
@@ -155,7 +161,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 12px 20px;
+  padding: 11px 18px; /* prototype surfaces.css:290 */
   border-bottom: 1px solid var(--border-main);
   background: linear-gradient(180deg, var(--bg-panel), var(--bg-deep));
 }
@@ -163,7 +169,11 @@
 .v2-board-surface .bd-feed-head h2 {
   font-family: var(--font-display);
   font-weight: 600;
-  font-size: 15px;
+  /* Prototype: the TYPE LADDER (surfaces.css T2) loads after the base
+     .bd-feed-head h2 rule and wins, so the rendered size is --fs-t2=16px
+     (v2.css:99), not the base rule's 15px. Our .v2-board-surface prefix
+     raises specificity above the ladder, so mirror the resolved T2 size. */
+  font-size: 16px;
   color: var(--text-bright);
   margin: 0;
   white-space: nowrap;
@@ -210,7 +220,7 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 14px 20px;
+  padding: 14px 18px; /* prototype surfaces.css:298 */
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -253,7 +263,7 @@
 .v2-board-surface .bd-post-h {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 9px; /* prototype surfaces.css:305 */
 }
 
 .v2-board-surface .bd-post-h .who {
@@ -311,7 +321,7 @@
   font-size: 12.5px;
   color: var(--text-mid);
   line-height: 1.55;
-  margin-top: 6px;
+  margin-top: 5px; /* prototype surfaces.css:319 */
   max-height: 5.2rem;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -353,14 +363,14 @@
 .v2-board-surface .bd-post-foot {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px; /* prototype surfaces.css:322 */
   margin-top: 10px;
 }
 
 .v2-board-surface .bd-react {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 5px; /* prototype surfaces.css:323 */
   font-family: var(--font-mono);
   font-size: 10.5px;
   padding: 2px 8px;
@@ -407,8 +417,8 @@
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 4px 14px;
-  margin-top: 10px;
-  padding: 10px 12px;
+  margin-top: 9px; /* prototype surfaces.css:331 */
+  padding: 9px 12px; /* prototype surfaces.css:331 */
   border-radius: var(--radius-sm);
   background: var(--bg-sunken);
   border: 1px dashed var(--border-main);
@@ -433,7 +443,7 @@
   flex: none;
   border-top: 1px solid var(--border-main);
   background: linear-gradient(0deg, var(--bg-panel), var(--bg-deep));
-  padding: 10px 20px 14px;
+  padding: 10px 18px 14px; /* prototype surfaces.css:337 */
 }
 
 .v2-board-surface .bd-composer-mobile-summary {
@@ -453,7 +463,7 @@
 .v2-board-surface .bd-comp-tab {
   font-family: var(--font-ui);
   font-size: 11px;
-  padding: 4px 12px;
+  padding: 4px 11px; /* prototype surfaces.css:339 */
   border-radius: 4px 4px 0 0;
   border: 1px solid transparent;
   background: none;
@@ -476,7 +486,7 @@
   background: var(--bg-card);
   border: 1px solid var(--border-main);
   border-radius: var(--radius-md);
-  padding: 6px 6px 6px 14px;
+  padding: 5px 5px 5px 13px; /* prototype surfaces.css:341 */
 }
 
 .v2-board-surface .bd-comp-box.grid {
@@ -648,7 +658,7 @@
   flex: none;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 9px; /* prototype surfaces.css:348 */
   padding: 12px 14px;
   border-bottom: 1px solid var(--border-soft);
 }
@@ -689,19 +699,19 @@
   padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 11px; /* prototype surfaces.css:352 */
 }
 
 .v2-board-surface .bd-th {
   display: grid;
   grid-template-columns: 26px 1fr;
-  gap: 10px;
+  gap: 9px; /* prototype surfaces.css:353 */
 }
 
 .v2-board-surface .bd-th-hd {
   display: flex;
   align-items: baseline;
-  gap: 8px;
+  gap: 7px; /* prototype surfaces.css:354 */
 }
 
 .v2-board-surface .bd-th-hd .who {
@@ -727,8 +737,8 @@
 .v2-board-surface .bd-mention-row {
   display: flex;
   align-items: flex-start;
-  gap: 10px;
-  padding: 10px 10px;
+  gap: 9px; /* prototype surfaces.css:358 */
+  padding: 9px 10px; /* prototype surfaces.css:358 */
   border-radius: var(--radius-sm);
   background: var(--bg-card);
   border: 1px solid var(--border-soft);

--- a/dashboard/src/styles/board-v2.test.ts
+++ b/dashboard/src/styles/board-v2.test.ts
@@ -47,6 +47,45 @@ function ruleDecls(selector: string): Record<string, string> {
   return declarations
 }
 
+describe('board-v2.css pixel parity with Claude-Design prototype', () => {
+  // Guards the odd-px spacing values against the even-number drift a parallel
+  // session introduced on main. Each value cites its prototype source line
+  // ("/Users/dancer/Downloads/v2 2/project/keeper-v2"/styles/surfaces.css).
+  const cases: Array<{ selector: string; prop: string; value: string; src: string }> = [
+    { selector: '.v2-board-surface .bd-rail', prop: 'padding', value: '14px 9px', src: 'surfaces.css:278' },
+    { selector: '.v2-board-surface .bd-rail h4', prop: 'margin', value: '0 0 8px 7px', src: 'surfaces.css:279' },
+    // type ladder T4 (surfaces.css:768) wins over base in the prototype
+    { selector: '.v2-board-surface .bd-rail h4', prop: 'font-size', value: '9px', src: 'v2.css:101 --fs-t4' },
+    { selector: '.v2-board-surface .bd-rail h4', prop: 'font-weight', value: '600', src: 'v2.css:101 --fw-t4' },
+    { selector: '.v2-board-surface .bd-sub', prop: 'padding', value: '7px 9px', src: 'surfaces.css:280' },
+    { selector: '.v2-board-surface .bd-feed-head', prop: 'padding', value: '11px 18px', src: 'surfaces.css:290' },
+    // type ladder T2 (surfaces.css:741) wins over base in the prototype
+    { selector: '.v2-board-surface .bd-feed-head h2', prop: 'font-size', value: '16px', src: 'v2.css:99 --fs-t2' },
+    { selector: '.v2-board-surface .bd-list', prop: 'padding', value: '14px 18px', src: 'surfaces.css:298' },
+    { selector: '.v2-board-surface .bd-post-h', prop: 'gap', value: '9px', src: 'surfaces.css:305' },
+    { selector: '.v2-board-surface .bd-post-body', prop: 'margin-top', value: '5px', src: 'surfaces.css:319' },
+    { selector: '.v2-board-surface .bd-post-foot', prop: 'gap', value: '7px', src: 'surfaces.css:322' },
+    { selector: '.v2-board-surface .bd-react', prop: 'gap', value: '5px', src: 'surfaces.css:323' },
+    { selector: '.v2-board-surface .bd-stateblock', prop: 'margin-top', value: '9px', src: 'surfaces.css:331' },
+    { selector: '.v2-board-surface .bd-stateblock', prop: 'padding', value: '9px 12px', src: 'surfaces.css:331' },
+    { selector: '.v2-board-surface .bd-composer', prop: 'padding', value: '10px 18px 14px', src: 'surfaces.css:337' },
+    { selector: '.v2-board-surface .bd-comp-tab', prop: 'padding', value: '4px 11px', src: 'surfaces.css:339' },
+    { selector: '.v2-board-surface .bd-comp-box', prop: 'padding', value: '5px 5px 5px 13px', src: 'surfaces.css:341' },
+    { selector: '.v2-board-surface .bd-detail-h', prop: 'gap', value: '9px', src: 'surfaces.css:348' },
+    { selector: '.v2-board-surface .bd-detail-scroll', prop: 'gap', value: '11px', src: 'surfaces.css:352' },
+    { selector: '.v2-board-surface .bd-th', prop: 'gap', value: '9px', src: 'surfaces.css:353' },
+    { selector: '.v2-board-surface .bd-th-hd', prop: 'gap', value: '7px', src: 'surfaces.css:354' },
+    { selector: '.v2-board-surface .bd-mention-row', prop: 'gap', value: '9px', src: 'surfaces.css:358' },
+    { selector: '.v2-board-surface .bd-mention-row', prop: 'padding', value: '9px 10px', src: 'surfaces.css:358' },
+  ]
+
+  for (const { selector, prop, value, src } of cases) {
+    it(`${selector} ${prop} == ${value} (prototype ${src})`, () => {
+      expect(ruleDecls(selector)[prop]).toBe(value)
+    })
+  }
+})
+
 describe('board-v2.css author sigil (SigilBadge prototype parity)', () => {
   it('renders the base sigil as a solid volt fill with a 5px radius and dark glyph', () => {
     const decls = ruleDecls('.v2-board-surface .bd-sigil')

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -212,6 +212,7 @@
 }
 
 .composer-box {
+  position: relative;
   display: flex;
   align-items: flex-end;
   gap: 10px;
@@ -221,6 +222,137 @@
   border-radius: var(--radius-md);
   padding: 6px 6px 6px 14px;
   transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.slashmenu {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(100% + 8px);
+  z-index: 40;
+  max-height: min(52vh, 360px);
+  overflow: hidden auto;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-panel-alt);
+  box-shadow: 0 -8px 28px rgb(0 0 0 / 0.5);
+}
+
+.slashmenu-h {
+  padding: 8px 12px 6px;
+  border-bottom: 1px solid var(--color-border-default);
+  color: var(--color-fg-muted);
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.slashmenu-i {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--color-fg-secondary);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.slashmenu-i.on {
+  background: var(--color-accent-soft);
+}
+
+.slashmenu-i:disabled {
+  cursor: default;
+  opacity: 0.46;
+}
+
+.slashmenu-gl {
+  flex: none;
+  width: 18px;
+  color: var(--color-fg-muted);
+  text-align: center;
+}
+
+.slashmenu-i.on .slashmenu-gl {
+  color: var(--color-accent-fg);
+}
+
+.slashmenu-cmd {
+  flex: none;
+  width: 88px;
+  color: var(--color-accent-fg);
+  font-size: 12px;
+}
+
+.slashmenu-lbl {
+  flex: none;
+  color: var(--color-fg-primary);
+  font-size: 12.5px;
+}
+
+.slashmenu-hint {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-fg-muted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.slashmenu-grp {
+  flex: none;
+  padding: 1px 6px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 9999px;
+  color: var(--color-fg-muted);
+  font-family: var(--font-ui);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.slashmenu-i.danger .slashmenu-cmd,
+.slashmenu-i.danger .slashmenu-gl {
+  color: var(--color-status-err);
+}
+
+.rec-bar.transcribing .rec-dot {
+  background: var(--color-accent-fg);
+}
+
+.rec-bar.transcribing .rec-lbl {
+  color: var(--color-accent-fg);
+}
+
+.rec-bar.transcribing .rbar {
+  animation-duration: 1.25s;
+  opacity: 0.72;
+}
+
+.rec-btn:disabled {
+  cursor: default;
+  opacity: 0.52;
+}
+
+@keyframes recwave {
+  0%,
+  100% {
+    transform: scaleY(0.72);
+  }
+  50% {
+    transform: scaleY(1.08);
+  }
+}
+
+.rec-wave .rbar {
+  animation: recwave 0.92s ease-in-out infinite;
+  transform-origin: center;
 }
 
 .composer-box.focus {
@@ -578,7 +710,7 @@
   color: var(--color-fg-muted);
 }
 
-.rec-btn.cancel:hover {
+.rec-btn.cancel:hover:not(:disabled) {
   color: var(--color-fg-primary);
   border-color: var(--color-border-strong);
 }
@@ -589,7 +721,7 @@
   color: var(--color-bg-surface);
 }
 
-.rec-btn.stop:hover {
+.rec-btn.stop:hover:not(:disabled) {
   filter: brightness(1.08);
   box-shadow: 0 0 16px var(--color-accent-soft);
 }

--- a/dashboard/src/styles/copilot-dock.css
+++ b/dashboard/src/styles/copilot-dock.css
@@ -204,7 +204,12 @@
 @media (max-width: 1180px) {
   .dock.docked { width: 320px; }
 }
+
 @media (max-width: 900px) {
+  .topbar-copilot kbd {
+    display: none;
+  }
+
   .dock.docked {
     position: fixed;
     inset: 50px 0 0;
@@ -295,5 +300,11 @@
   .v2-app[data-mobile="true"] .dock-fab .spark {
     width: 20px;
     height: 20px;
+  }
+}
+
+@media (max-width: 420px) {
+  .topbar-copilot span:not(.spark) {
+    display: none;
   }
 }

--- a/dashboard/src/styles/keeper-workspace-mobile.test.ts
+++ b/dashboard/src/styles/keeper-workspace-mobile.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { parse } from 'postcss'
+
+const css = readFileSync(resolve(__dirname, 'keeper-workspace.css'), 'utf-8')
+const chatCss = readFileSync(resolve(__dirname, 'chat.css'), 'utf-8')
+const copilotCss = readFileSync(resolve(__dirname, 'copilot-dock.css'), 'utf-8')
+const turnInspectorCss = readFileSync(resolve(__dirname, 'keeper-turn-inspector.css'), 'utf-8')
+const configCss = readFileSync(resolve(__dirname, 'keeper-v2/keeper-config.css'), 'utf-8')
+const appSource = readFileSync(resolve(__dirname, '../app.ts'), 'utf-8')
+const chatPrimitivesSource = readFileSync(resolve(__dirname, '../components/chat/primitives.ts'), 'utf-8')
+const copilotDockSource = readFileSync(resolve(__dirname, '../components/copilot-dock.ts'), 'utf-8')
+const keeperTurnInspectorSource = readFileSync(resolve(__dirname, '../components/keeper-turn-inspector.ts'), 'utf-8')
+const keeperSharedSource = readFileSync(resolve(__dirname, '../components/keeper-shared.ts'), 'utf-8')
+const keeperWorkspaceChatSource = readFileSync(
+  resolve(__dirname, '../components/keeper-workspace/keeper-workspace-chat.ts'),
+  'utf-8',
+)
+const keeperWorkspaceRosterSource = readFileSync(
+  resolve(__dirname, '../components/keeper-workspace/keeper-workspace-roster.ts'),
+  'utf-8',
+)
+const keeperWorkspaceRailSource = readFileSync(
+  resolve(__dirname, '../components/keeper-workspace/keeper-workspace-rail.ts'),
+  'utf-8',
+)
+const keeperDetailPageSource = readFileSync(resolve(__dirname, '../components/keeper-detail-page.ts'), 'utf-8')
+const keeperDetailBodySource = readFileSync(resolve(__dirname, '../components/keeper-detail-body.ts'), 'utf-8')
+const keeperDetailShellSource = readFileSync(resolve(__dirname, '../components/keeper-detail-shell.ts'), 'utf-8')
+const keeperConfigPanelSource = readFileSync(resolve(__dirname, '../components/keeper-config-panel.ts'), 'utf-8')
+const htmlSource = readFileSync(resolve(__dirname, '../../index.html'), 'utf-8')
+const implementationSources = [
+  css,
+  chatCss,
+  copilotCss,
+  turnInspectorCss,
+  configCss,
+  appSource,
+  chatPrimitivesSource,
+  copilotDockSource,
+  keeperTurnInspectorSource,
+  keeperSharedSource,
+  keeperWorkspaceChatSource,
+  keeperWorkspaceRosterSource,
+  keeperWorkspaceRailSource,
+  keeperDetailPageSource,
+  keeperDetailBodySource,
+  keeperDetailShellSource,
+  keeperConfigPanelSource,
+  htmlSource,
+].join('\n')
+
+const SHELL_MOBILE_CHROME_BREAKPOINT = '900px'
+const KEEPER_MOBILE_PANE_BREAKPOINT = '860px'
+const PHONE_NARROW_BREAKPOINT = '420px'
+
+function baseRuleDeclsIn(source: string, selector: string): Record<string, string> {
+  const declarations: Record<string, string> = {}
+
+  parse(source).walkRules((rule) => {
+    if (rule.parent?.type === 'atrule') return
+    if (!rule.selectors.includes(selector)) return
+    rule.walkDecls((decl) => {
+      declarations[decl.prop] = decl.value.trim()
+    })
+  })
+
+  return declarations
+}
+
+const baseRuleDecls = (selector: string) => baseRuleDeclsIn(css, selector)
+const baseTurnInspectorRuleDecls = (selector: string) => baseRuleDeclsIn(turnInspectorCss, selector)
+
+function mediaRuleDeclsIn(source: string, selector: string, maxWidth: string): Record<string, string> {
+  const declarations: Record<string, string> = {}
+
+  parse(source).walkAtRules('media', (atRule) => {
+    if (!atRule.params.includes(`max-width: ${maxWidth}`)) return
+    atRule.walkRules((rule) => {
+      if (!rule.selectors.includes(selector)) return
+      rule.walkDecls((decl) => {
+        declarations[decl.prop] = decl.value.trim()
+      })
+    })
+  })
+
+  return declarations
+}
+
+const mediaRuleDecls = (selector: string, maxWidth: string) => mediaRuleDeclsIn(css, selector, maxWidth)
+const mobileRuleDecls = (selector: string) => mediaRuleDecls(selector, KEEPER_MOBILE_PANE_BREAKPOINT)
+const copilotRuleDecls = (selector: string, maxWidth: string) => mediaRuleDeclsIn(copilotCss, selector, maxWidth)
+const shellMobileTurnInspectorRuleDecls = (selector: string) =>
+  mediaRuleDeclsIn(turnInspectorCss, selector, SHELL_MOBILE_CHROME_BREAKPOINT)
+
+describe('keeper workspace v2 (26) mobile contract', () => {
+  it('keeps the phone viewport compatible with safe-area layout', () => {
+    expect(htmlSource).toContain('name="viewport"')
+    expect(htmlSource).toContain('width=device-width, initial-scale=1, viewport-fit=cover')
+  })
+
+  it('exposes the mobile keeper reading-mode state from the app shell', () => {
+    expect(appSource).toContain("const mobileKeeperReadingMode = mobileKeeperPane === 'chat'")
+    expect(appSource).toContain('data-reading=${mobileKeeperReadingMode ?')
+  })
+
+  it('routes the conversation width tweak to the keeper workspace CSS variable', () => {
+    expect(appSource).toContain("'--kw-thread-w': `${tweaksThreadW.value}px`")
+    expect(baseRuleDecls('.kw-thread-inner')['max-width']).toBe('var(--kw-thread-w, 980px)')
+    expect(baseRuleDecls('.kw-composer-inner')['max-width']).toBe('var(--kw-thread-w, 980px)')
+  })
+
+  it('suppresses mobile shell chrome in keeper chat reading mode', () => {
+    expect(
+      mediaRuleDecls('.v2-app[data-reading="true"] .v2-mobile-bottom-bar', SHELL_MOBILE_CHROME_BREAKPOINT).display,
+    ).toBe('none')
+    expect(
+      mediaRuleDecls('.v2-app[data-reading="true"] .dashboard-status-tray', SHELL_MOBILE_CHROME_BREAKPOINT).display,
+    ).toBe('none')
+    expect(
+      mediaRuleDecls('.v2-app[data-reading="true"] .dashboard-focus-mode-toggle', SHELL_MOBILE_CHROME_BREAKPOINT)
+        .display,
+    ).toBe('none')
+    expect(
+      mediaRuleDecls('.v2-app[data-reading="true"] .topbar-copilot', SHELL_MOBILE_CHROME_BREAKPOINT).display,
+    ).toBe('none')
+    expect(
+      mediaRuleDecls('.v2-app[data-reading="true"] .kw-chat-actions', SHELL_MOBILE_CHROME_BREAKPOINT).display,
+    ).toBe('none')
+  })
+
+  it('keeps the mobile topbar copilot button compact like the v2 phone shell', () => {
+    expect(copilotDockSource).toContain('topbar-copilot')
+    expect(copilotDockSource).toContain('class="spark"')
+    expect(copilotDockSource).toContain('<span>Chat</span>')
+    expect(copilotDockSource).toContain('<kbd>⌘J</kbd>')
+    expect(copilotRuleDecls('.topbar-copilot kbd', SHELL_MOBILE_CHROME_BREAKPOINT).display).toBe('none')
+    expect(copilotRuleDecls('.topbar-copilot span:not(.spark)', PHONE_NARROW_BREAKPOINT).display).toBe('none')
+  })
+
+  it('uses dynamic viewport height for the focused keeper mobile surface and context drawer', () => {
+    const appDecls = mobileRuleDecls('.v2-app[data-keeper-detail-mode="true"]')
+    expect(appDecls.height).toBe('100dvh')
+    expect(appDecls['min-height']).toBe('100dvh')
+    expect(mobileRuleDecls('.kw-mobile-rail-drawer').height).toBe('100dvh')
+  })
+
+  it('keeps safe-area padding on the mobile keeper chat shell', () => {
+    expect(mobileRuleDecls('[data-keeper-detail-mode="true"] .v2-shell-stage').padding).toContain(
+      'env(safe-area-inset-bottom, 0px)',
+    )
+    expect(mobileRuleDecls('.kw-chat-head').padding).toContain('max(9px, env(safe-area-inset-top, 0px))')
+    expect(mobileRuleDecls('.kw-chat-head').padding).toContain('max(12px, env(safe-area-inset-right, 0px))')
+    expect(mobileRuleDecls('.kw-chat-head').gap).toBe('10px')
+    expect(mobileRuleDecls('.kw-chat-head').padding).toContain('max(12px, env(safe-area-inset-left, 0px))')
+    expect(mobileRuleDecls('.kw-chat-name')['font-size']).toBe('17px')
+    expect(mobileRuleDecls('.kw-thread-inner .chat-transcript').gap).toBe('18px')
+    expect(mobileRuleDecls('.kw-thread-inner .chat-transcript')['padding-top']).toBe('16px')
+    expect(mobileRuleDecls('.kw-composer-wrap')['padding-bottom']).toBe(
+      'max(14px, env(safe-area-inset-bottom, 0px))',
+    )
+    expect(mobileRuleDecls('.kw-composer-inner')['padding-left']).toBe(
+      'max(12px, env(safe-area-inset-left, 0px))',
+    )
+    expect(mobileRuleDecls('.kw-composer-inner')['padding-right']).toBe(
+      'max(12px, env(safe-area-inset-right, 0px))',
+    )
+    expect(mobileRuleDecls('.kw-composer-inner .composer textarea')['font-size']).toBe('16px')
+  })
+
+  it('keeps mobile conversation bubbles at the v2 reading scale', () => {
+    expect(mobileRuleDecls('.kw-thread-inner .chat-bubble')['font-size']).toBe('16.5px')
+    expect(mobileRuleDecls('.kw-thread-inner .chat-bubble')['line-height']).toBe('1.68')
+    expect(mobileRuleDecls('.kw-thread-inner .chat-bubble').padding).toBe('14px 15px')
+    expect(mobileRuleDecls('.kw-thread-inner .chat-bubble code')['font-size']).toBe('13.5px')
+  })
+
+  it('keeps composer slash commands wired to real workspace actions', () => {
+    expect(chatPrimitivesSource).toContain('export interface ChatComposerCommand')
+    expect(chatPrimitivesSource).toContain('class="slashmenu"')
+    expect(chatCss).toContain('.slashmenu')
+    expect(keeperSharedSource).toContain('composerCommands?: ChatComposerCommand[]')
+    expect(keeperSharedSource).toContain('commands=${composerCommands}')
+    expect(keeperWorkspaceChatSource).toContain('...lifecycleCommands(keeper)')
+    expect(keeperWorkspaceChatSource).toContain('runKeeperAction(keeper.name, key)')
+    expect(keeperWorkspaceChatSource).toContain('composerCommands=${composerCommands}')
+    expect(mobileRuleDecls('.kw-composer-inner .slashmenu')['max-height']).toBe('min(46vh, 320px)')
+    expect(mobileRuleDecls('.kw-composer-inner .slashmenu')['left']).toContain('env(safe-area-inset-left, 0px)')
+  })
+
+  it('keeps the turn inspector drawer phone-fullscreen from the runtime inspector', () => {
+    expect(keeperTurnInspectorSource).toContain('data-testid="turn-detail-drawer"')
+    expect(keeperTurnInspectorSource).toContain('class="kti-overlay"')
+    expect(keeperTurnInspectorSource).toContain('class="kti-drawer"')
+    expect(baseTurnInspectorRuleDecls('.kti-head h3').flex).toBe('none')
+    expect(baseTurnInspectorRuleDecls('.kti-head .tid').overflow).toBe('hidden')
+    expect(baseTurnInspectorRuleDecls('.kti-head .tid')['text-overflow']).toBe('ellipsis')
+    expect(baseTurnInspectorRuleDecls('.kti-close').width).toBe('26px')
+    expect(baseTurnInspectorRuleDecls('.kti-close').height).toBe('26px')
+    expect(baseTurnInspectorRuleDecls('.kti-stat').padding).toBe('11px 14px')
+    expect(baseTurnInspectorRuleDecls('.kti-stat .k')['font-size']).toBe('8.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-stat .v')['margin-top']).toBe('5px')
+    expect(baseTurnInspectorRuleDecls('.kti-stat .v small')['font-size']).toBe('10px')
+    expect(baseTurnInspectorRuleDecls('.kti-sub').padding).toBe('0 var(--sp-4) 12px')
+    expect(baseTurnInspectorRuleDecls('.kti-chip')['font-size']).toBe('10.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-chip').padding).toBe('3px 9px')
+    expect(baseTurnInspectorRuleDecls('.kti-chip .sub-k').margin).toBe('0')
+    expect(baseTurnInspectorRuleDecls('.kti-chip .sub-k')['text-transform']).toBeUndefined()
+    expect(baseTurnInspectorRuleDecls('.kti-tok').padding).toBe('13px var(--sp-4)')
+    expect(baseTurnInspectorRuleDecls('.kti-tok-top .lbl')['font-size']).toBe('9.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-tok-top .ctxpct')['font-size']).toBe('11px')
+    expect(baseTurnInspectorRuleDecls('.kti-tok-legend').gap).toBe('18px')
+    expect(baseTurnInspectorRuleDecls('.kti-tok-legend')['margin-top']).toBe('9px')
+    expect(baseTurnInspectorRuleDecls('.kti-tok-legend')['font-size']).toBe('11.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-tok-legend b')['font-weight']).toBe('600')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-row').gap).toBe('12px')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-lbl')['font-size']).toBe('12.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-lbl').color).toBe('var(--color-fg-primary)')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-lbl .nm.mono')['font-size']).toBe('11.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-dur')['font-size']).toBe('11px')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-foot')['margin-top']).toBe('12px')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-foot')['padding-top']).toBe('11px')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-foot')['font-size']).toBe('11.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-foot b')['font-weight']).toBe('600')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-legend').gap).toBe('14px')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-legend span').gap).toBe('5px')
+    expect(baseTurnInspectorRuleDecls('.kti-wf-legend span')['font-size']).toBe('10.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-copy').gap).toBe('5px')
+    expect(baseTurnInspectorRuleDecls('.kti-copy')['font-size']).toBe('10px')
+    expect(baseTurnInspectorRuleDecls('.kti-copy').padding).toBe('3px 9px')
+    expect(baseTurnInspectorRuleDecls('.kti-code-h .cap')['font-size']).toBe('9.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-code-h .sz')['font-size']).toBe('9.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-code pre')['font-size']).toBe('11.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-code pre')['line-height']).toBe('1.62')
+    expect(baseTurnInspectorRuleDecls('.kti-tool-h').gap).toBe('9px')
+    expect(baseTurnInspectorRuleDecls('.kti-tool-h').padding).toBe('9px 12px')
+    expect(baseTurnInspectorRuleDecls('.kti-tool-h .seq')['font-size']).toBe('9.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-tool-h .tnm')['font-size']).toBe('12.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-tool-h .pill')['font-size']).toBe('9px')
+    expect(baseTurnInspectorRuleDecls('.kti-tool-h .pill').padding).toBe('2px 7px')
+    expect(baseTurnInspectorRuleDecls('.kti-tool-h .lat')['font-size']).toBe('11px')
+    expect(baseTurnInspectorRuleDecls('.kti-msg-h').padding).toBe('7px 11px')
+    expect(baseTurnInspectorRuleDecls('.kti-msg-role')['font-size']).toBe('9.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-msg-h .who')['font-size']).toBe('10.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-msg-h .seq')['font-size']).toBe('9.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-msg-b')['font-size']).toBe('12.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-msg-b')['line-height']).toBe('1.62')
+    expect(baseTurnInspectorRuleDecls('.kti-msg-b').color).toBe('var(--color-fg-primary)')
+    expect(baseTurnInspectorRuleDecls('.kti-msg-b.mono')['font-size']).toBe('11.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-ctx-h .t')['font-size']).toBe('10px')
+    expect(baseTurnInspectorRuleDecls('.kti-ctx-h .tok')['font-size']).toBe('10px')
+    expect(baseTurnInspectorRuleDecls('.kti-ctx-card pre').padding).toBe('11px 13px')
+    expect(baseTurnInspectorRuleDecls('.kti-ctx-card pre')['font-size']).toBe('11.5px')
+    expect(baseTurnInspectorRuleDecls('.kti-ctx-card pre')['line-height']).toBe('1.62')
+    expect(baseTurnInspectorRuleDecls('.kti-params').gap).toBe('7px')
+    expect(baseTurnInspectorRuleDecls('.kti-param')['font-size']).toBe('11px')
+    expect(baseTurnInspectorRuleDecls('.kti-param').padding).toBe('4px 11px')
+    expect(baseTurnInspectorRuleDecls('.kti-param b')['font-weight']).toBe('600')
+    expect(baseTurnInspectorRuleDecls('.kti-sec-h').gap).toBe('10px')
+    expect(baseTurnInspectorRuleDecls('.kti-sec-h').margin).toBe('0 0 9px')
+    expect(baseTurnInspectorRuleDecls('.kti-sec-h .n')['font-size']).toBe('10px')
+    expect(shellMobileTurnInspectorRuleDecls('.kti-drawer').width).toBe('100vw')
+    expect(shellMobileTurnInspectorRuleDecls('.kti-drawer')['max-width']).toBe('100vw')
+    expect(shellMobileTurnInspectorRuleDecls('.kti-drawer').height).toBe('100dvh')
+    expect(shellMobileTurnInspectorRuleDecls('.kti-drawer')['border-left']).toBe('0')
+    expect(shellMobileTurnInspectorRuleDecls('.kti-head')['padding-top']).toContain(
+      'env(safe-area-inset-top, 0px)',
+    )
+    expect(shellMobileTurnInspectorRuleDecls('.kti-head')['padding-left']).toContain(
+      'env(safe-area-inset-left, 0px)',
+    )
+    expect(shellMobileTurnInspectorRuleDecls('.kti-head')['padding-right']).toContain(
+      'env(safe-area-inset-right, 0px)',
+    )
+    expect(shellMobileTurnInspectorRuleDecls('.kti-sub')['padding-left']).toContain(
+      'env(safe-area-inset-left, 0px)',
+    )
+    expect(shellMobileTurnInspectorRuleDecls('.kti-sub')['padding-right']).toContain(
+      'env(safe-area-inset-right, 0px)',
+    )
+    expect(shellMobileTurnInspectorRuleDecls('.kti-tok')['padding-left']).toContain(
+      'env(safe-area-inset-left, 0px)',
+    )
+    expect(shellMobileTurnInspectorRuleDecls('.kti-tok')['padding-right']).toContain(
+      'env(safe-area-inset-right, 0px)',
+    )
+  })
+
+  it('keeps the voice composer presentation backed by the shared voice hook', () => {
+    expect(chatPrimitivesSource).toContain('const voice = useVoiceInput({')
+    expect(chatPrimitivesSource).toContain('voice.state === \'recording\' || voice.state === \'transcribing\'')
+    expect(chatPrimitivesSource).toContain('class=${`rec-bar ${voice.state === \'transcribing\' ? \'transcribing\' : \'\'}`}')
+    expect(chatPrimitivesSource).toContain('VOICE_WAVE_BARS')
+    expect(chatPrimitivesSource).toContain('onClick=${voice.stop}')
+    expect(chatCss).toContain('.rec-bar.transcribing')
+    expect(chatCss).toContain('.rec-bar.transcribing .rec-lbl')
+    expect(chatCss).toContain('.rec-btn.stop:hover:not(:disabled)')
+    expect(chatCss).toContain('@keyframes recwave')
+  })
+
+  it('keeps fleet roster pressure and tone indicators backed by live keeper fields', () => {
+    expect(keeperWorkspaceRosterSource).toContain('data-tone=${tone}')
+    expect(keeperWorkspaceRosterSource).toContain('keeper.context_ratio')
+    expect(keeperWorkspaceRosterSource).toContain('keeper.latest_tool_names')
+    expect(keeperWorkspaceRosterSource).toContain('keeper.recent_tool_names')
+    expect(keeperWorkspaceRosterSource).toContain('keeper.latest_tool_call_count')
+    expect(keeperWorkspaceRosterSource).toContain('class="kw-kp-context"')
+    expect(keeperWorkspaceRosterSource).toContain('class="kw-kp-tool"')
+    expect(keeperWorkspaceRosterSource).toContain('const ROSTER_ROW_ESTIMATED_HEIGHT = 92')
+    expect(keeperWorkspaceRosterSource).toContain('estimatedItemHeight=${ROSTER_ROW_ESTIMATED_HEIGHT}')
+    expect(css).toContain('.kw-kp-row::before')
+    expect(css).toContain('.kw-kp-context-bar')
+    expect(css).toContain('.kw-kp-context-val.hot')
+    expect(css).toContain('.kw-kp-tool-v')
+    expect(mobileRuleDecls('.kw-kp-menu')['max-height']).toBe('min(70dvh, 420px)')
+    expect(mobileRuleDecls('.kw-kp-menu')['max-width']).toContain('env(safe-area-inset-right, 0px)')
+  })
+
+  it('keeps the mobile context drawer close to the v2 rail without prototype-local state', () => {
+    expect(keeperWorkspaceRailSource).toContain('keeper.context_ratio')
+    expect(keeperWorkspaceRailSource).toContain('tasks.value.filter')
+    expect(keeperWorkspaceRailSource).toContain('callMcpTool(\'masc_keeper_compact\'')
+    expect(mobileRuleDecls('.kw-mobile-rail-overlay').background).toBe('rgb(4 5 8 / 0.60)')
+    expect(mobileRuleDecls('.kw-mobile-rail-drawer').width).toBe('min(330px, 88vw)')
+    expect(mobileRuleDecls('.kw-mobile-rail-drawer')['max-width']).toContain('env(safe-area-inset-left, 0px)')
+    expect(mobileRuleDecls('.kw-mobile-rail-drawer')['box-shadow']).toBe('-8px 0 30px rgb(0 0 0 / 0.50)')
+    expect(mobileRuleDecls('.kw-mobile-rail-drawer .kw-rail-scroll').gap).toBe('12px')
+    expect(mobileRuleDecls('.kw-mobile-rail-drawer .kw-card').padding).toBe('11px 12px')
+    expect(mobileRuleDecls('.kw-mobile-rail-drawer .kw-sec h4')['font-size']).toBe('var(--fs-11)')
+    expect(mobileRuleDecls('.kw-mobile-rail-drawer .kw-vital').padding).toBe('9px 11px')
+    expect(mobileRuleDecls('.kw-mobile-rail-drawer .kw-tasktag').padding).toBe('8px 10px')
+    expect(mobileRuleDecls('.kw-mobile-rail-drawer .kw-detail-btn')['min-height']).toBe('44px')
+  })
+
+  it('keeps keeper detail and config surfaces phone-fullscreen without replacing runtime owners', () => {
+    expect(keeperDetailPageSource).toContain('kw-detail-content')
+    expect(keeperDetailPageSource).toContain('kw-detail-full-head')
+    expect(keeperDetailPageSource).toContain('<${KeeperConfigPanel} keeperName=${keeperName} onClose=${onClose} />')
+    expect(keeperDetailPageSource).toContain('panel now owns the full .kcf-overlay modal shell')
+    expect(keeperDetailBodySource).toContain('kw-detail-body')
+    expect(keeperDetailShellSource).toContain('kw-detail-section-rail')
+    expect(keeperDetailShellSource).toContain('kw-detail-section-tab')
+
+    expect(keeperConfigPanelSource).toContain('class="kcf-overlay"')
+    expect(keeperConfigPanelSource).toContain('class="kcf v2-monitoring-surface"')
+    expect(keeperConfigPanelSource).toContain('class="kcf-tabs"')
+    expect(keeperConfigPanelSource).toContain('class="kcf-main v2-monitoring-panel"')
+    expect(keeperConfigPanelSource).toContain('class="kcf-foot v2-monitoring-toolbar"')
+    expect(keeperConfigPanelSource).toContain('class="set-row"')
+    expect(keeperConfigPanelSource).toContain('class=${`set-toggle ${on ? \'on\' : \'\'}`}')
+    expect(keeperConfigPanelSource).not.toContain('kw-config-fact')
+    expect(keeperConfigPanelSource).not.toContain('kw-config-set-row')
+    expect(css).not.toContain('.kw-config-scroll .kw-config-fact')
+    expect(configCss).toContain('.kcf-overlay')
+    expect(configCss).toContain('.kcf-top')
+    expect(configCss).toContain('.kcf-tabs')
+    expect(configCss).toContain('.kcf-main')
+    expect(configCss).toContain('.kcf-facts')
+    expect(configCss).toContain('.set-row')
+    expect(configCss).toContain('.set-toggle')
+
+    expect(mobileRuleDecls('.kw-grid[data-detail="open"] .kw-detail').height).toBe('100%')
+    expect(mobileRuleDecls('.kw-grid[data-detail="open"] .kw-detail-scroll').background).toBe('var(--color-bg-page)')
+    expect(mobileRuleDecls('.kw-detail-content')['max-width']).toBe('none')
+    expect(mobileRuleDecls('.kw-detail-full-head').position).toBe('sticky')
+    expect(mobileRuleDecls('.kw-detail-body').display).toBe('grid')
+    expect(mobileRuleDecls('.kw-detail-body')['grid-template-columns']).toBe('56px minmax(0, 1fr)')
+    expect(mobileRuleDecls('.kw-detail-section-rail').height).toContain('100dvh')
+    expect(mobileRuleDecls('.kw-detail-section-tabs')['flex-direction']).toBe('column')
+    expect(mobileRuleDecls('.kw-detail-section-tab').display).toBe('inline-flex')
+    expect(mobileRuleDecls('.kw-detail-section-tab')['align-items']).toBe('center')
+    expect(mobileRuleDecls('.kw-detail-section-tab').width).toBe('100%')
+  })
+
+  it('does not introduce local path defaults or frontend env access for visual parity', () => {
+    expect(implementationSources).not.toContain('/Users/dancer/me')
+    expect(implementationSources).not.toContain('/Users/dancer/Downloads')
+    expect(implementationSources).not.toContain('default_base')
+    expect(implementationSources).not.toContain('process.env')
+    expect(implementationSources).not.toContain('import.meta.env')
+  })
+})

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -334,12 +334,27 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   transition: background .14s, border-color .14s;
   position: relative;
 }
+.kw-kp-row[data-tone="ok"] { --kw-row-rail: var(--color-status-ok); }
+.kw-kp-row[data-tone="warn"] { --kw-row-rail: var(--color-status-warn); }
+.kw-kp-row[data-tone="bad"] { --kw-row-rail: var(--color-status-err); }
+.kw-kp-row[data-tone="info"] { --kw-row-rail: var(--color-accent-fg); }
+.kw-kp-row[data-tone="idle"] { --kw-row-rail: color-mix(in oklab, var(--color-fg-muted) 54%, transparent); }
+.kw-kp-row::before {
+  content: "";
+  position: absolute;
+  left: -8px;
+  top: 9px;
+  bottom: 9px;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--kw-row-rail, var(--color-border-strong));
+  opacity: 0.52;
+}
 .kw-kp-row:focus-visible { outline: 2px solid var(--color-accent-fg-dim); outline-offset: 2px; }
 .kw-kp-row:hover { background: var(--color-bg-surface); border-color: var(--color-border-default); }
 .kw-kp-row[aria-current="true"] { background: var(--color-bg-surface); border-color: var(--color-accent-fg-dim); box-shadow: inset 0 0 0 1px var(--accent-10); }
 .kw-kp-row[aria-current="true"]::before {
-  content: ""; position: absolute; left: -8px; top: 9px; bottom: 9px; width: 3px;
-  background: var(--color-accent-fg); border-radius: 0 3px 3px 0;
+  opacity: 1;
   box-shadow: 0 0 10px rgb(var(--color-accent-glow) / 0.6);
 }
 .kw-kp-row:hover .kw-kp-right,
@@ -353,6 +368,65 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-kp-state { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
 .kw-kp-handle { font-family: var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .kw-kp-work { margin-top: 4px; font-size: var(--fs-12); color: var(--color-fg-secondary); line-height: 1.45; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.kw-kp-context {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+  margin-top: 5px;
+}
+.kw-kp-context-bar {
+  flex: 1;
+  height: 5px;
+  overflow: hidden;
+  border: 1px solid var(--color-border-divider);
+  border-radius: 9999px;
+  background: var(--color-bg-page);
+}
+.kw-kp-context-bar > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--color-accent-fg-dim), var(--color-accent-fg));
+}
+.kw-kp-context-bar > span.hot {
+  background: linear-gradient(90deg, var(--color-status-warn), var(--color-status-err));
+}
+.kw-kp-context-val {
+  width: 34px;
+  flex: none;
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  text-align: right;
+}
+.kw-kp-context-val.hot {
+  color: var(--color-status-err);
+}
+.kw-kp-tool {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  margin-top: 5px;
+}
+.kw-kp-tool-k {
+  flex: none;
+  color: var(--color-fg-muted);
+  font-size: var(--fs-10);
+  font-weight: var(--fw-bold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.kw-kp-tool-v {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-fg-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; padding-top: 2px; }
 .kw-kp-time { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-muted); }
 .kw-kp-att {
@@ -451,6 +525,13 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   .kw-kp-row:focus-within .kw-kp-right {
     opacity: 1;
     pointer-events: auto;
+  }
+
+  .kw-kp-menu {
+    max-width: calc(100vw - 28px - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px));
+    max-height: min(70dvh, 420px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
   }
 }
 
@@ -604,17 +685,18 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   z-index: var(--z-drawer);
   display: flex;
   justify-content: flex-end;
-  background: rgb(0 0 0 / 0.38);
+  background: rgb(4 5 8 / 0.60);
 }
 .kw-mobile-rail-drawer {
   display: flex;
   flex-direction: column;
-  width: min(92vw, 340px);
+  width: min(330px, 88vw);
+  max-width: calc(100vw - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px));
   height: 100%;
   min-height: 0;
   background: var(--color-bg-panel-alt);
   border-left: 1px solid var(--color-border-default);
-  box-shadow: -18px 0 46px rgb(0 0 0 / 0.32);
+  box-shadow: -8px 0 30px rgb(0 0 0 / 0.50);
 }
 .kw-mobile-rail-head {
   display: flex;
@@ -640,64 +722,6 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   border-left: 0;
 }
 
-.kw-config-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: var(--z-overlay-keeper);
-  display: flex;
-  justify-content: flex-end;
-  background: var(--backdrop-modal);
-  isolation: isolate;
-}
-.kw-config-drawer {
-  display: flex;
-  flex-direction: column;
-  width: min(760px, 96vw);
-  height: 100%;
-  min-height: 0;
-  overflow: hidden;
-  border-left: 1px solid var(--color-border-strong);
-  background: var(--color-bg-surface);
-  box-shadow: var(--shadow-drawer-left);
-}
-.kw-config-head {
-  display: flex;
-  flex: none;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--color-border-strong);
-  background: var(--color-bg-elevated);
-}
-.kw-config-head h3 {
-  margin: 0;
-  color: var(--color-fg-primary);
-  font: var(--type-title);
-}
-.kw-config-head p {
-  margin: 3px 0 0;
-  overflow: hidden;
-  color: var(--color-fg-muted);
-  font-family: var(--font-mono);
-  font-size: var(--fs-11);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.kw-config-scroll {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  padding: 14px 16px 24px;
-  background: var(--color-bg-page);
-}
-
-@media (max-width: 860px) {
-  .kw-config-drawer {
-    width: 100vw;
-    border-left: 0;
-  }
-}
 
 .kw-rail-toggle {
   position: absolute;
@@ -989,7 +1013,8 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   [data-keeper-detail-mode="true"] .v2-header-brand { max-width: calc(100vw - 86px); }
 
   .kw-mobile-rail-drawer {
-    width: min(100vw, 380px);
+    width: min(330px, 88vw);
+    max-width: calc(100vw - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px));
   }
   .kw-rail-scroll {
     gap: 20px;
@@ -998,7 +1023,12 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   .kw-detail-head {
     flex-wrap: wrap;
     gap: 8px;
-    padding: 10px 12px;
+    padding:
+      max(10px, env(safe-area-inset-top, 0px))
+      max(12px, env(safe-area-inset-right, 0px))
+      10px
+      max(12px, env(safe-area-inset-left, 0px));
+    z-index: 22;
   }
   .kw-detail-head .kw-act {
     min-height: 40px;
@@ -1007,7 +1037,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
     flex: 1 1 11rem;
   }
   .kw-detail-scroll {
-    padding: 10px;
+    padding: 0;
   }
 }
 
@@ -1035,7 +1065,412 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
     text-align: left;
   }
   .kw-detail-scroll {
-    padding: 8px;
+    padding: 0;
+  }
+}
+
+/* v2 (26) mobile fidelity pass.
+ *
+ * The standalone reference asserts `viewport-fit=cover` and treats the keeper
+ * conversation as a true one-pane phone surface: header + transcript + composer
+ * fill the visual viewport, while only the active pane owns scroll. Keep this
+ * as a CSS-only contract so the existing keeperMobilePane signal remains the
+ * single source of truth for roster/chat switching.
+ */
+@media (max-width: 900px) {
+  .v2-app[data-reading="true"] .v2-mobile-bottom-bar,
+  .v2-app[data-reading="true"] .dashboard-status-tray,
+  .v2-app[data-reading="true"] .dashboard-focus-mode-toggle,
+  .v2-app[data-reading="true"] .topbar-copilot,
+  .v2-app[data-reading="true"] .kw-chat-actions {
+    display: none;
+  }
+}
+
+@media (max-width: 860px) {
+  .v2-app[data-keeper-detail-mode="true"] {
+    height: 100dvh;
+    min-height: 100dvh;
+  }
+
+  [data-keeper-detail-mode="true"] .v2-shell-stage {
+    padding:
+      max(6px, env(safe-area-inset-top, 0px))
+      max(6px, env(safe-area-inset-right, 0px))
+      max(6px, env(safe-area-inset-bottom, 0px))
+      max(6px, env(safe-area-inset-left, 0px));
+  }
+
+  [data-keeper-detail-mode="true"] .v2-body,
+  [data-keeper-detail-mode="true"] .v2-body > .h-full,
+  [data-keeper-detail-mode="true"] .v2-surface,
+  [data-keeper-detail-mode="true"] .kw-grid {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .kw-grid {
+    overscroll-behavior: contain;
+  }
+
+  .kw-grid[data-mobile-pane="chat"] {
+    padding-bottom: 0;
+  }
+
+  .kw-grid[data-mobile-pane="roster"] .kw-roster,
+  .kw-grid[data-mobile-pane="chat"] .kw-chat,
+  .kw-grid[data-mobile-pane="chat"] .kw-detail {
+    overflow: hidden;
+  }
+
+  .kw-grid[data-detail="open"] .kw-detail {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .kw-grid[data-detail="open"] .kw-detail-scroll {
+    background: var(--color-bg-page);
+    scroll-padding-top: 0;
+  }
+
+  .kw-detail-content {
+    max-width: none;
+    gap: 0;
+    padding-bottom: 0;
+  }
+
+  .kw-detail-full-head {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    width: 100%;
+    max-width: none;
+    border-right: 0;
+    border-left: 0;
+    border-radius: 0;
+  }
+
+  .kw-detail-full-head > div {
+    padding:
+      10px
+      max(12px, env(safe-area-inset-right, 0px))
+      10px
+      max(12px, env(safe-area-inset-left, 0px));
+  }
+
+  .kw-detail-body {
+    display: grid;
+    grid-template-columns: 56px minmax(0, 1fr);
+    align-items: start;
+    max-width: none;
+    gap: 0;
+  }
+
+  .kw-detail-section-rail {
+    position: sticky;
+    top: 0;
+    grid-column: 1;
+    height: calc(100dvh - 58px - env(safe-area-inset-top, 0px));
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    border-right: 1px solid var(--color-border-default);
+    border-bottom: 0;
+    background: var(--color-bg-panel-alt);
+    padding: 8px 6px;
+  }
+
+  .kw-detail-section-tabs {
+    min-width: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+    padding: 0;
+  }
+
+  .kw-detail-section-tab {
+    display: inline-flex;
+    align-items: center;
+    width: 100%;
+    height: 40px;
+    justify-content: center;
+    overflow: hidden;
+    padding-right: 4px;
+    padding-left: 4px;
+    text-overflow: clip;
+    white-space: nowrap;
+  }
+
+  .kw-detail-body > section {
+    grid-column: 2;
+    min-width: 0;
+    border-top: 0;
+    border-right: 0;
+    border-radius: 0;
+  }
+
+  .kw-detail-body > section > .v2-monitoring-toolbar {
+    padding: 10px 12px;
+  }
+
+  .kw-detail-body > section > .v2-monitoring-panel {
+    gap: 12px;
+    padding:
+      12px
+      max(12px, env(safe-area-inset-right, 0px))
+      max(18px, env(safe-area-inset-bottom, 0px))
+      12px;
+  }
+
+  .kw-chat-head {
+    gap: 10px;
+    padding:
+      max(9px, env(safe-area-inset-top, 0px))
+      max(12px, env(safe-area-inset-right, 0px))
+      9px
+      max(12px, env(safe-area-inset-left, 0px));
+  }
+
+  .kw-chat-id {
+    min-width: 0;
+  }
+
+  .kw-chat-name-row {
+    min-width: 0;
+    gap: 8px;
+  }
+
+  .kw-chat-name {
+    font-size: 17px;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .kw-state-pill {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .kw-chat-actions {
+    justify-content: flex-end;
+    gap: 8px;
+    padding-bottom: 2px;
+  }
+
+  .kw-chat-command-popover {
+    right: max(0px, env(safe-area-inset-right, 0px));
+    max-width: calc(100vw - 28px - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px));
+  }
+
+  .kw-thread-inner .chat-transcript {
+    gap: 18px;
+    padding-left: max(16px, env(safe-area-inset-left, 0px));
+    padding-right: max(16px, env(safe-area-inset-right, 0px));
+    padding-top: 16px;
+    padding-bottom: 12px;
+  }
+
+  .kw-thread-inner .chat-bubble {
+    font-size: 16.5px;
+    line-height: 1.68;
+    padding: 14px 15px;
+  }
+
+  .kw-thread-inner .chat-bubble code {
+    font-size: 13.5px;
+  }
+
+  .kw-composer-wrap {
+    padding-top: 10px;
+    padding-bottom: max(14px, env(safe-area-inset-bottom, 0px));
+  }
+
+  .kw-composer-inner {
+    padding-left: max(12px, env(safe-area-inset-left, 0px));
+    padding-right: max(12px, env(safe-area-inset-right, 0px));
+  }
+
+  .kw-composer-inner .composer textarea {
+    font-size: 16px;
+  }
+
+  .kw-mobile-rail-overlay {
+    background: rgb(4 5 8 / 0.60);
+    padding-left: env(safe-area-inset-left, 0px);
+  }
+
+  .kw-mobile-rail-drawer {
+    height: 100dvh;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+}
+
+/* v2 (26) phone composer/drawer parity.
+ * The runtime workspace intentionally reuses ChatComposer instead of copying
+ * the standalone prototype composer. Keep the override on the keeper shell so
+ * multimodal attachments, voice input, queueing, abort, and send IDs stay in
+ * the shared runtime component while the phone geometry follows the reference
+ * surface. */
+@media (max-width: 860px) {
+  .kw-composer-inner .composer-inner {
+    padding: 0;
+  }
+
+  .kw-composer-inner .composer-box {
+    gap: 8px;
+    padding: 5px 5px 5px 12px;
+    border-radius: var(--radius-md);
+  }
+
+  .kw-composer-inner .slashmenu {
+    right: calc(-1 * env(safe-area-inset-right, 0px));
+    left: calc(-1 * env(safe-area-inset-left, 0px));
+    bottom: calc(100% + 6px);
+    max-height: min(46vh, 320px);
+    border-radius: var(--radius-md);
+  }
+
+  .kw-composer-inner .slashmenu-i {
+    gap: 8px;
+    padding: 8px 10px;
+  }
+
+  .kw-composer-inner .slashmenu-cmd {
+    width: 72px;
+  }
+
+  .kw-composer-inner .slashmenu-grp {
+    display: none;
+  }
+
+  .kw-composer-inner .composer-textarea {
+    min-height: 24px;
+    padding: 9px 0;
+    font-size: 16px;
+    line-height: 1.45;
+  }
+
+  .kw-composer-inner .composer-tools {
+    gap: 5px;
+    padding-bottom: 1px;
+  }
+
+  .kw-composer-inner .ctool {
+    width: 32px;
+    height: 32px;
+  }
+
+  .kw-composer-inner .send {
+    height: 32px;
+    padding: 0 13px;
+  }
+
+  .kw-composer-inner .composer-foot {
+    gap: 8px;
+    min-width: 0;
+    margin-top: 6px;
+    font-size: 10.5px;
+  }
+
+  .kw-composer-inner .composer-foot .hint {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .kw-composer-inner .composer-foot .queue-badge {
+    flex: none;
+  }
+
+  .kw-composer-inner .composer-tray {
+    gap: 6px;
+    max-height: 92px;
+    margin-bottom: 8px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .kw-composer-inner .cdraft {
+    max-width: 100%;
+    gap: 8px;
+    padding: 7px 9px;
+  }
+
+  .kw-composer-inner .cdraft.att {
+    max-width: min(100%, 300px);
+    padding-right: 26px;
+  }
+
+  .kw-composer-inner .cdraft.voice {
+    max-width: 100%;
+  }
+
+  .kw-composer-inner .cdraft-name,
+  .kw-composer-inner .cdraft-tx-v {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .kw-mobile-rail-head {
+    padding:
+      max(12px, env(safe-area-inset-top, 0px))
+      max(14px, env(safe-area-inset-right, 0px))
+      12px
+      max(14px, env(safe-area-inset-left, 0px));
+  }
+
+  .kw-mobile-rail-drawer .kw-rail-scroll {
+    gap: 12px;
+    padding: 12px;
+  }
+
+  .kw-mobile-rail-drawer .kw-sec h4 {
+    margin-bottom: 9px;
+    font-size: var(--fs-11);
+    letter-spacing: 0.18em;
+  }
+
+  .kw-mobile-rail-drawer .kw-card {
+    padding: 11px 12px;
+    border-radius: var(--r-1);
+  }
+
+  .kw-mobile-rail-drawer .kw-vitals {
+    gap: 1px;
+  }
+
+  .kw-mobile-rail-drawer .kw-vital {
+    padding: 9px 11px;
+  }
+
+  .kw-mobile-rail-drawer .kw-context-empty {
+    padding: 8px 0 2px;
+  }
+
+  .kw-mobile-rail-drawer .kw-ctx-meta {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 6px;
+  }
+
+  .kw-mobile-rail-drawer .kw-cmp-readonly {
+    gap: 6px;
+  }
+
+  .kw-mobile-rail-drawer .kw-tasktag {
+    padding: 8px 10px;
+  }
+
+  .kw-mobile-rail-drawer .kw-detail-btn {
+    min-height: 44px;
+    padding: 10px 12px;
+  }
+
+  .kw-mobile-rail-drawer .kw-detail-scroll {
+    padding: 12px;
   }
 }
 

--- a/docs/design/keeper-v2-standalone-gap-current.md
+++ b/docs/design/keeper-v2-standalone-gap-current.md
@@ -1324,3 +1324,1351 @@ and gzip/base64 resource manifest expose prototype modules including `WorkSurfac
   bootstrap, and one Vite WebSocket timeout; `agent-browser network requests
   --filter 401` and `--filter 500` did not retain matching captured requests
   after the smoke.
+
+## v2 (26) Mobile Follow-up - 2026-06-25
+
+Source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2`, `/Users/dancer/Downloads/v2 (26)/fleet.jsx`, `/Users/dancer/Downloads/v2 (26)/scraps`, and selected `/Users/dancer/Downloads/v2 (26)/uploads` images.
+
+### Implemented In Current Worktree
+
+- Dashboard HTML now matches the v2 (26) standalone mobile viewport contract by using `viewport-fit=cover`, so safe-area layout rules can align with real phone viewports instead of defaulting to non-cover iOS behavior.
+- Keeper detail mobile chat now has a CSS-only dynamic viewport/safe-area contract: the focused keeper detail shell, active chat pane, transcript, composer, and mobile context drawer use `100dvh`, safe-area padding, and contained overscroll without changing the keeper runtime state model.
+- The app shell now exposes and uses `data-reading="true"` when the mobile keeper detail pane is in chat mode, matching the v2 (26) reference's explicit reading-mode state and suppressing mobile bottom/status/focus chrome across the shell's mobile band while keeping the keeper master-detail geometry at its narrower breakpoint.
+- Breakpoint ownership is explicit in the source guard: shell chrome suppression follows the mobile shell band, while keeper roster/chat master-detail layout follows the narrower keeper pane band. This prevents a future single-breakpoint cleanup from regressing tablet-width reading mode.
+- The existing `대화 본문 폭` tweak now writes the actual `--kw-thread-w` variable consumed by keeper workspace/chat CSS, while preserving the older `--thread-w` alias. This reconnects the tweak-panel SSOT to the rendered keeper conversation width.
+- `dashboard/src/styles/keeper-workspace-mobile.test.ts` now guards the source contracts for `viewport-fit=cover`, mobile reading-mode exposure/suppression, `--kw-thread-w`, `100dvh`, safe-area composer padding, and absence of local path/env defaults or downloaded artifact path dependencies in the implementation files for this visual slice. This is source-level proof only; it does not replace rendered mobile screenshot parity.
+
+### Still Missing Vs v2 (26)
+
+- Mobile pixel parity is not yet visually proven against a rendered dashboard screenshot at phone width. The current pass is source-aligned but still requires browser evidence before claiming pixel-perfect completion.
+- Composer parity is still incomplete for exact v2 (26) multimodal affordance grouping: the live dashboard uses backed chat transport and existing attachment paths, while the prototype has a richer local tray/voice/slash-command presentation.
+- The mobile context drawer now has viewport/safe-area parity, but its exact rail card density and spacing still need a screenshot comparison against the v2 (26) reference.
+- Upload screenshots under `/Users/dancer/Downloads/v2 (26)/uploads` include non-MASC external-product captures; those should not be treated as MASC layout SSOT unless a future pass links a specific image to a MASC screen.
+
+### Should Stay Out Of Scope
+
+- No OAS/provider/model transport logic should be added to the dashboard for visual parity. OAS remains the provider/model/transport boundary; this pass only changes MASC dashboard layout state and CSS.
+- No local-only prototype state should be copied into runtime-backed keeper surfaces. If a v2 (26) control has no durable MASC API, keep it read-only, hidden, or explicitly marked as unsupported rather than stubbing it.
+- No local absolute path default such as `/Users/dancer/me` should be introduced in frontend or OCaml runtime code for this visual work.
+
+## v2 (26) Composer/Drawer Source Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/composer.jsx`, `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css`, `dashboard/src/components/chat/primitives.ts`, `dashboard/src/components/keeper-shared.ts`, and `dashboard/src/styles/chat.css`.
+
+### Implemented In Current Worktree
+
+- Kept the runtime-backed `ChatComposer` as the single owner of attachments, voice input, queueing, abort, and send client action IDs instead of copying standalone prototype state.
+- Scoped phone composer parity to `.kw-composer-inner` CSS: tighter box geometry, 16px mobile textarea font, denser tools, compact send button, truncated hint line, bounded attachment tray, and mobile-safe draft chip overflow.
+- Tightened mobile context drawer spacing in `.kw-mobile-rail-drawer` without changing keeper/OAS runtime boundaries.
+
+### Still Missing Vs v2 (26)
+
+- Slash-command palette visual parity remains incomplete because the runtime composer currently does not expose the standalone `slashmenu` command surface.
+- Voice recording does not render the standalone waveform `rec-bar`; runtime voice input currently transcribes through the shared `useVoiceInput` path.
+- Composer/drawer parity is still source-level only until a rendered mobile screenshot is compared against the v2 (26) reference.
+
+## v2 (26) Runtime Slash Composer Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/composer.jsx`, `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css`, `dashboard/src/components/chat/primitives.ts`, `dashboard/src/components/keeper-shared.ts`, and `dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts`.
+
+### Implemented In Current Worktree
+
+- Added an optional `ChatComposerCommand` contract to the shared runtime `ChatComposer` instead of copying the prototype's local `window.FSM_ACTIONS` command source.
+- Added a v2-style `slashmenu` composer palette for exact `/command` prefix input, keyboard navigation, disabled command display, and error surfacing through existing dashboard toasts.
+- Wired workspace keeper chat composer commands to the same real command sources already used by the header: `keeperActionVisibility`, `runKeeperAction`, turn inspector, artifacts, context clear, detail toggle, and keeper config.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the v2 (26) mobile contract now checks slash-command shell CSS and runtime-backed command wiring.
+
+### Still Missing Vs v2 (26)
+
+- Slash-command rendered spacing, z-index, and keyboard focus behavior are not visually proven on a phone viewport until browser validation is run.
+- Voice recording waveform `rec-bar` parity remains incomplete; the runtime still uses shared speech-to-text state instead of the standalone waveform tray.
+- Exact pixel parity for command palette, composer tray, and mobile drawer remains unverified without a rendered screenshot comparison.
+
+## v2 (26) Runtime Voice Composer Follow-up - 2026-06-25
+
+Additional source reviewed: `dashboard/src/components/chat/voice-input.ts`, `dashboard/src/components/chat/primitives.ts`, and `dashboard/src/styles/chat.css`.
+
+### Implemented In Current Worktree
+
+- Kept real voice ownership in `useVoiceInput`: `MediaRecorder`, stream teardown, upload to `/api/v1/voice/transcribe`, and transcript insertion remain in the existing runtime hook.
+- Added a v2-style composer `rec-bar` for `recording` and `transcribing` states instead of leaving voice input as only a mic icon state change.
+- Added deterministic animated waveform bars, elapsed recording clock, stop/complete action, and transcribing visual state without introducing fake audio payloads or prototype-local voice draft state.
+- Hid slash-command suggestions while voice capture/transcription is active so stale `/` drafts do not compete with the recording surface.
+- Tightened the recording/transcribing CSS state so disabled stop controls do not render active hover treatment and the transcribing label uses the accent state color.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so voice composer presentation must stay backed by `useVoiceInput` and the shared `rec-bar` styling.
+
+### Still Missing Vs v2 (26)
+
+- The waveform is a visual activity indicator, not sampled microphone amplitude; real amplitude visualization would need an `AudioContext` analyser decision and rendered QA.
+- Voice bar mobile spacing and composer replacement behavior are still unverified in browser.
+- Full pixel-perfect completion remains unproven until rendered mobile screenshots are compared to the v2 (26) reference.
+
+## v2 (26) Fleet/Roster Source Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/fleet.jsx`, `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/fleet.css`, `dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts`, and `dashboard/src/styles/keeper-workspace.css`.
+
+### Implemented In Current Worktree
+
+- Added the v2 fleet row tone-rail treatment to live keeper roster rows via `data-tone=${tone}` and scoped `.kw-kp-row::before` CSS.
+- Added a compact per-row context pressure bar derived from existing `keeper.context_ratio`, including hot-state styling at the same `0.8` threshold already used by the backed fleet summary.
+- Added a compact recent-tool signal derived from existing live keeper snapshot fields: `latest_tool_names`, `recent_tool_names`, and `latest_tool_call_count`. This closes the reference fleet's `fl-tool` gap without copying the prototype `lastTool` seed or adding N per-row tool-call fetches.
+- Updated the roster row sizing contract to `ROSTER_ROW_ESTIMATED_HEIGHT = 92` so `content-visibility` and the shared `VirtualList` estimate account for the added context pressure + recent-tool lines instead of preserving the old 58px two-line row assumption.
+- Kept the roster backed by the existing `keepers` store, `keeperActionVisibility`, and `runKeeperAction`; no local fleet seed state or prototype FSM data was copied.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so fleet roster pressure/tone indicators must remain backed by live keeper fields.
+
+### Still Missing Vs v2 (26)
+
+- The current dashboard roster renders recent tool as a compact row signal inside the narrow keeper list, not as a separate wide-table column like `/fleet.jsx`.
+- Mobile row density, context bar spacing, tone-rail visibility, and recent-tool truncation are not browser/screenshot verified.
+- Full pixel-perfect fleet/roster parity remains unproven without rendered mobile comparison.
+
+## v2 (26) Source Guard Scope Follow-up - 2026-06-25
+
+### Implemented In Current Worktree
+
+- Narrowed the visual-parity source guard to the objective's concrete risks: local absolute paths, downloaded artifact paths, `default_base`, and direct frontend env reads.
+- Removed the over-broad raw `MASC_` / `OAS_` substring ban from the guard. Legitimate MASC identifiers and boundary documentation strings should not fail a visual parity guard; OAS coupling remains governed by code ownership and explicit provider/transport changes, not by a raw substring heuristic.
+
+### Still Missing Vs v2 (26)
+
+- Guard scope has not been executed in this turn.
+- Rendered mobile parity remains unverified.
+
+## v2 (26) Mobile Slash Menu Geometry Follow-up - 2026-06-25
+
+### Implemented In Current Worktree
+
+- Added keeper-scoped mobile slash menu geometry: safe-area-aware horizontal edges, tighter phone item spacing, compact command column width, hidden group chip, and bounded `min(46vh, 320px)` menu height.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the mobile slash menu remains bounded and safe-area-aware.
+
+### Still Missing Vs v2 (26)
+
+- Slash menu visual placement, focus state, and scroll behavior remain unverified in a rendered mobile viewport.
+- Full pixel-perfect completion still requires browser screenshot comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Roster Menu Geometry Follow-up - 2026-06-25
+
+### Implemented In Current Worktree
+
+- Added mobile bounds for the roster row command menu: safe-area-aware `max-width`, bounded `min(70dvh, 420px)` height, contained overscroll, and menu-local vertical scrolling.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so roster menus remain phone-bounded.
+
+### Still Missing Vs v2 (26)
+
+- Roster menu placement and clipping behavior are not browser-verified on mobile.
+- Full pixel-perfect roster/menu parity remains unproven without rendered screenshot comparison.
+
+## v2 (26) Mobile Context Rail Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/rails.jsx`, `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css`, and `dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts`.
+
+### Implemented In Current Worktree
+
+- Matched the mobile context drawer closer to the v2 reference geometry: darker overlay, `min(330px, 88vw)` drawer width, safe-area max-width, and tighter right-side shadow.
+- Tightened rail-card density inside the mobile drawer: v2-like section heading scale, compact card/vital/task padding, single-column context metadata, denser readonly compaction metadata, and 44px minimum detail action height.
+- Kept the runtime rail backed by live keeper/task/tool data and the existing `masc_keeper_compact` action path; no standalone prototype memory, task, or compaction state was copied.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the mobile context drawer geometry and live-source rail wiring remain explicit.
+
+### Still Missing Vs v2 (26)
+
+- The reference rail has additional prototype affordances such as memory inspector and compaction snapshot buttons; the runtime dashboard only exposes controls backed by current MASC APIs.
+- Mobile context drawer placement, close affordance spacing, scroll behavior, and card density are not browser/screenshot verified.
+- Full pixel-perfect context rail parity remains unproven without rendered mobile comparison.
+
+## v2 (26) Mobile Detail Surface Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/keeper-config.jsx`, `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css`, `dashboard/src/components/keeper-detail-page.ts`, `dashboard/src/components/keeper-detail-body.ts`, and `dashboard/src/components/keeper-detail-shell.ts`.
+
+### Implemented In Current Worktree
+
+- Added explicit runtime detail shell hooks: `kw-detail-content`, `kw-detail-full-head`, `kw-detail-body`, `kw-detail-section-rail`, `kw-detail-section-tabs`, and `kw-detail-section-tab`.
+- Moved the mobile “운영 상세” surface closer to the v2 full-detail pattern: full-height content, sticky top identity/action bar, a narrow 56px section rail, content-only scrolling, safe-area padding, and denser active section cards.
+- Closed the follow-up CSS affordance gap on the 56px mobile section rail: `kw-detail-section-tab` is now explicitly `inline-flex` and center-aligned, so the narrow rail does not depend on browser defaults or inherited flex behavior.
+- Matched the mobile keeper config overlay to the v2 full-screen treatment: no phone-side drawer chrome, `100dvh` height, safe-area header/content padding, contained scroll, dark overlay, and 16px form controls to avoid mobile zoom.
+- Kept all detail/config content backed by existing `KeeperDetailBody`, `KeeperDetailSectionRail`, and `KeeperConfigPanel`; no prototype-local config state, fake keeper data, or OAS/provider logic was copied.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the mobile detail/config surface remains explicit and runtime-owned.
+
+### Still Missing Vs v2 (26)
+
+- The v2 config reference has icon tabs and richer section-local visual primitives; the runtime detail rail currently uses existing text labels and runtime sections.
+- Mobile detail section scroll behavior, sticky rail height, and config overlay form density are not browser/screenshot verified.
+- Full pixel-perfect keeper detail parity remains unproven without rendered mobile comparison.
+
+## v2 (26) Mobile Bubble Typography Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` mobile reading uplift and `dashboard/src/components/chat/primitives.ts` chat bubble markup.
+
+### Implemented In Current Worktree
+
+- Added a keeper-scoped phone override for conversation bubbles matching the v2 mobile reading scale: `16.5px` text, `1.68` line-height, `14px 15px` bubble padding, and `13.5px` inline code.
+- Kept the override scoped to `.kw-thread-inner .chat-bubble` so shared chat surfaces outside the keeper workspace do not inherit the phone-specific v2 conversation density.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so future mobile CSS changes keep the v2 bubble reading scale explicit.
+
+### Still Missing Vs v2 (26)
+
+- Rendered mobile bubble wrapping, vertical rhythm, and code-token density are not browser/screenshot verified.
+- Full pixel-perfect conversation parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Turn Inspector Drawer Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/turn-inspector.jsx`, `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css`, `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css`, `dashboard/src/components/keeper-turn-inspector.ts`, and `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched the v2 phone drawer contract for the runtime turn inspector: the mobile `.kti-drawer` is now `100vw`, capped at `100vw`, uses `100dvh`, and drops side-panel border/shadow chrome so it behaves as a full-screen phone surface.
+- Added safe-area top padding to the turn inspector header on phones, preserving the existing runtime `KeeperTurnInspector` component and its live turn/tool/transcript data flow.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards to read the turn inspector CSS/component and require the phone-fullscreen drawer contract from the real runtime inspector.
+
+### Still Missing Vs v2 (26)
+
+- Turn inspector mobile header wrapping, summary stat density, transcript scrolling, and close/copy hit targets are not browser/screenshot verified.
+- Full pixel-perfect turn inspector parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Topbar Copilot Trim Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css`, `dashboard/src/components/copilot-dock.ts`, and `dashboard/src/styles/copilot-dock.css`.
+
+### Implemented In Current Worktree
+
+- Matched the v2 phone shell trim for the topbar Chat control: the keyboard shortcut is hidden at the mobile shell breakpoint and the text label collapses at `420px`, leaving the icon-only affordance on very narrow phones.
+- Kept the backed `CopilotDockTopBarButton` and dock state unchanged; this is only a shell chrome density adjustment, not a new dock interaction path.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards to cover the topbar copilot markup and the two responsive trim rules.
+
+### Still Missing Vs v2 (26)
+
+- Very-narrow topbar spacing with attention/emergency/auth/status controls is not browser/screenshot verified.
+- Full pixel-perfect phone shell parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Reading Copilot Suppression Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css`, `dashboard/src/styles/keeper-workspace.css`, and `dashboard/src/styles/keeper-workspace-mobile.test.ts`.
+
+### Implemented In Current Worktree
+
+- Matched the v2 reading-mode phone shell rule that hides the topbar Chat/copilot trigger while the keeper conversation is already the active 1:1 reading surface.
+- Kept suppression as keeper reading-mode shell CSS, preserving `CopilotDockTopBarButton` ownership and avoiding any new dock/runtime state path.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so `data-reading="true"` now suppresses bottom nav, status tray, focus toggle, and the topbar copilot trigger together.
+
+### Still Missing Vs v2 (26)
+
+- Reading-mode topbar spacing after hiding copilot is not browser/screenshot verified.
+- Full pixel-perfect keeper conversation chrome parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Thread Rhythm Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` mobile thread density rule and `dashboard/src/styles/keeper-workspace.css` keeper transcript overrides.
+
+### Implemented In Current Worktree
+
+- Matched the v2 phone conversation rhythm by setting the keeper mobile transcript gap to `18px`, scoped to `.kw-thread-inner .chat-transcript`.
+- Kept the existing safe-area transcript padding and shared `ChatTranscript` runtime owner unchanged; this only adjusts mobile message vertical rhythm inside the keeper workspace.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the mobile transcript gap remains explicit alongside the safe-area padding contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered message stacking, scroll position behavior, and composer overlap with the tighter `18px` rhythm are not browser/screenshot verified.
+- Full pixel-perfect keeper conversation rhythm remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Thread Top Inset Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` mobile `.thread { padding-top: 16px; }` rule and the runtime keeper transcript mobile overrides.
+
+### Implemented In Current Worktree
+
+- Matched the v2 phone conversation top breathing room by setting `.kw-thread-inner .chat-transcript` mobile `padding-top` to `16px`.
+- Kept the override scoped to the keeper workspace transcript and preserved existing safe-area side padding plus the shared `ChatTranscript` runtime owner.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the mobile top inset is explicit alongside the `18px` message rhythm.
+
+### Still Missing Vs v2 (26)
+
+- Rendered first-message position below the chat header is not browser/screenshot verified.
+- Full pixel-perfect keeper conversation top rhythm remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Composer Bottom Padding Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` mobile `.composer { padding: 10px 12px 14px; }` rule and the runtime keeper composer wrapper overrides.
+
+### Implemented In Current Worktree
+
+- Matched the v2 phone composer bottom breathing room by raising `.kw-composer-wrap` mobile bottom padding from `12px` to `14px`.
+- Preserved safe-area behavior with `max(14px, env(safe-area-inset-bottom, 0px))` instead of copying a fixed prototype padding that could collide with device insets.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so composer bottom padding remains aligned with the v2 mobile contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered composer/input position relative to the visual viewport and keyboard-safe area is not browser/screenshot verified.
+- Full pixel-perfect composer bottom rhythm remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Composer Side Padding Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` mobile `.composer { padding: 10px 12px 14px; }` rule and the runtime keeper composer wrapper overrides.
+
+### Implemented In Current Worktree
+
+- Matched the v2 phone composer horizontal rhythm by lowering `.kw-composer-inner` mobile left/right padding minimum from `14px` to `12px`.
+- Preserved device inset safety with `max(12px, env(safe-area-inset-left/right, 0px))` instead of copying fixed prototype padding.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so mobile composer side padding remains explicit alongside bottom padding and transcript rhythm.
+
+### Still Missing Vs v2 (26)
+
+- Rendered composer edge alignment against the transcript and slash menu is not browser/screenshot verified.
+- Full pixel-perfect composer horizontal rhythm remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Composer Textarea Size Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` mobile `.composer textarea, .composer-input { font-size: 16px; }` rule and the runtime keeper composer wrapper overrides.
+
+### Implemented In Current Worktree
+
+- Added a keeper-scoped mobile rule setting `.kw-composer-inner .composer textarea` to `16px`, matching the v2 phone composer input scale and preventing mobile browser focus zoom.
+- Kept the rule scoped to the keeper workspace composer so other shared chat surfaces do not inherit this phone-specific density unless they opt into the keeper shell.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so mobile textarea size remains explicit alongside composer side/bottom padding.
+
+### Still Missing Vs v2 (26)
+
+- Rendered textarea height, wrapping, and keyboard-focus behavior are not browser/screenshot verified.
+- Full pixel-perfect composer input parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Chat Header Actions Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` mobile `.chat-head .chat-actions { display: none; }` rule and the runtime keeper workspace command wiring.
+
+### Implemented In Current Worktree
+
+- Hid `.kw-chat-actions` while `data-reading="true"` on the mobile shell, matching the v2 phone conversation header that removes duplicated action chrome.
+- Preserved backed command access through the runtime `ChatComposerCommand` slash menu already wired to lifecycle actions, turn inspector, artifacts, context clear, detail toggle, and config.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so mobile reading mode now suppresses the duplicate header action strip together with bottom/status/focus/copilot chrome.
+
+### Still Missing Vs v2 (26)
+
+- Rendered header height, command discoverability via slash menu, and first-message position after removing the action strip are not browser/screenshot verified.
+- Full pixel-perfect mobile chat header parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Header Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` header title/trace-id rules and `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched the v2 turn-inspector header behavior by making `.kti-head h3` `flex: none`, so the title stays stable while the trace id owns truncation.
+- Kept the existing runtime trace-id ellipsis rules on `.kti-head .tid` and extended the source guard to assert both title non-flexing and id truncation behavior.
+- Preserved the current `KeeperTurnInspector` component and live turn/tool/transcript data flow; this is only a drawer-header layout correction.
+
+### Still Missing Vs v2 (26)
+
+- Rendered turn-inspector header wrapping, trace-id truncation, and close/copy hit targets are not browser/screenshot verified.
+- Full pixel-perfect turn-inspector header parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Header Safe-Area Follow-up - 2026-06-25
+
+Additional source reviewed: runtime `dashboard/src/styles/keeper-turn-inspector.css` mobile drawer rules and the v2 phone drawer/fullscreen convention.
+
+### Implemented In Current Worktree
+
+- Added mobile safe-area left/right padding to `.kti-head`, complementing the existing safe-area top padding for the phone-fullscreen turn inspector drawer.
+- Kept the runtime `KeeperTurnInspector` owner unchanged; this is only a phone drawer header layout correction for title, trace id, copy, and close controls.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the mobile turn inspector header must include top/left/right safe-area insets.
+
+### Still Missing Vs v2 (26)
+
+- Rendered notch/rounded-corner clearance for the turn inspector header is not browser/screenshot verified.
+- Full pixel-perfect turn-inspector safe-area parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Metadata Safe-Area Follow-up - 2026-06-25
+
+Additional source reviewed: runtime `dashboard/src/styles/keeper-turn-inspector.css` mobile drawer rules and the v2 phone-fullscreen drawer convention.
+
+### Implemented In Current Worktree
+
+- Added mobile safe-area left/right padding to `.kti-sub`, so the keeper/model/finish/runtime metadata chips align with the safe header edges in the phone-fullscreen turn inspector.
+- Preserved the runtime `KeeperTurnInspector` owner and live turn metadata; this is only a drawer metadata-row layout correction.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the turn inspector metadata row must include left/right safe-area insets.
+
+### Still Missing Vs v2 (26)
+
+- Rendered chip wrapping, horizontal overflow, and notch/rounded-corner clearance for the metadata row are not browser/screenshot verified.
+- Full pixel-perfect turn-inspector metadata-row parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Token Strip Safe-Area Follow-up - 2026-06-25
+
+Additional source reviewed: runtime `dashboard/src/styles/keeper-turn-inspector.css` token-economics strip and the v2 phone-fullscreen drawer convention.
+
+### Implemented In Current Worktree
+
+- Added mobile safe-area left/right padding to `.kti-tok`, so the token-economics strip aligns with the safe header and metadata-chip edges in the phone-fullscreen turn inspector.
+- Preserved the runtime `KeeperTurnInspector` owner and live token accounting; this is only a drawer token-strip layout correction.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the turn inspector token strip must include left/right safe-area insets.
+
+### Still Missing Vs v2 (26)
+
+- Rendered token bar wrapping, progress sizing, and notch/rounded-corner clearance are not browser/screenshot verified.
+- Full pixel-perfect turn-inspector token-strip parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Close Control Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` `.turn-close` dimensions and runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched the v2 drawer close-control size by changing `.kti-close` from `24px` to `26px` square.
+- Preserved the existing runtime close handler and `KeeperTurnInspector` ownership; this is only a visual/control-size parity correction.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the runtime inspector close control keeps the v2 drawer dimensions.
+
+### Still Missing Vs v2 (26)
+
+- Rendered close-button alignment, tap target comfort, and interaction state are not browser/screenshot verified.
+- Full pixel-perfect turn-inspector close-control parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Chat Header Padding Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` mobile `.chat-head { padding: 9px 12px; }` rule and the runtime keeper chat header safe-area override.
+
+### Implemented In Current Worktree
+
+- Matched the v2 phone chat-header rhythm by lowering `.kw-chat-head` mobile padding minimums to `9px` vertical and `12px` horizontal.
+- Preserved notch/edge safety with `max(..., env(safe-area-inset-* , 0px))` on top/left/right rather than copying fixed prototype padding.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so mobile chat-header padding remains explicit alongside transcript and composer rhythm.
+
+### Still Missing Vs v2 (26)
+
+- Rendered header height, keeper name/state pill wrapping, and back-button alignment are not browser/screenshot verified.
+- Full pixel-perfect mobile chat-header padding parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Chat Title Size Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` mobile `.chat-id h2 { font-size: 17px; }` rule and the runtime keeper chat title override.
+
+### Implemented In Current Worktree
+
+- Matched the v2 phone chat-title scale by setting `.kw-chat-name` mobile `font-size` to `17px`.
+- Kept the existing runtime keeper identity source and title truncation behavior unchanged; this is only a phone header typography adjustment.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the mobile keeper title size stays explicit.
+
+### Still Missing Vs v2 (26)
+
+- Rendered keeper-title wrapping, status-pill alignment, and CJK truncation are not browser/screenshot verified.
+- Full pixel-perfect mobile chat-title parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Summary Stat Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` summary stat strip and runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched the v2 turn-inspector summary stat density by changing `.kti-stat` padding to `11px 14px`.
+- Matched the v2 value spacing by lowering `.kti-stat .v` `margin-top` from `6px` to `5px`.
+- Preserved the existing runtime five-stat data model and responsive `3-column` fallback; this is only visual density alignment.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the runtime inspector stat density remains tied to the v2 reference.
+
+### Still Missing Vs v2 (26)
+
+- Rendered stat wrapping, numeric alignment, and mobile `3-column` fallback are not browser/screenshot verified.
+- Full pixel-perfect turn-inspector summary-stat parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Token Strip Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` `.ti-tok { padding: 13px 16px; }` rule and runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched the v2 token-economics strip vertical density by setting `.kti-tok` base padding to `13px var(--sp-4)`.
+- Preserved the mobile safe-area left/right overrides already applied to `.kti-tok`; this change only aligns the vertical rhythm and keeps semantic horizontal spacing.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the runtime inspector token strip density remains tied to the v2 reference.
+
+### Still Missing Vs v2 (26)
+
+- Rendered token bar height, label/value alignment, and mobile safe-area edge behavior are not browser/screenshot verified.
+- Full pixel-perfect turn-inspector token-strip density parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Mobile Chat Header Gap Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/v2.css` mobile `.chat-head { gap: 10px; }` rule and runtime `dashboard/src/styles/keeper-workspace.css`.
+
+### Implemented In Current Worktree
+
+- Matched the v2 phone chat header spacing by setting mobile `.kw-chat-head` to `gap: 10px`.
+- Preserved the existing safe-area-aware header padding, back affordance, title-size, and hidden mobile actions from the runtime implementation.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the mobile chat header gap remains tied to the v2 reference.
+
+### Still Missing Vs v2 (26)
+
+- Rendered header alignment, title truncation, and notch/edge clearance are not browser/screenshot verified.
+- Full pixel-perfect chat-header parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Metadata Strip Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` metadata-strip rhythm and runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched the v2 inspector metadata strip density by setting `.kti-sub` padding to `0 var(--sp-4) 12px`.
+- Preserved the runtime chip layout, wrapping, border, and existing mobile safe-area left/right overrides.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards so the inspector metadata-strip density remains covered with the other drawer/header/stat/token checks.
+
+### Still Missing Vs v2 (26)
+
+- Rendered metadata chip wrapping, text truncation, and phone-fullscreen drawer alignment are not browser/screenshot verified.
+- Full pixel-perfect inspector metadata-strip parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Metadata Chip Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` `.ti-chip` and `.ti-chip .sub-k` rules plus runtime `dashboard/src/components/keeper-turn-inspector.ts` chip labels.
+
+### Implemented In Current Worktree
+
+- Matched v2 inspector chip text density by setting `.kti-chip` to `font-size: 10.5px`.
+- Matched v2 chip horizontal rhythm by changing `.kti-chip` padding from `3px 10px` to `3px 9px`.
+- Removed the runtime-only forced uppercase/letter-spacing from `.kti-chip .sub-k`; labels now keep the lower-case source text used by the inspector component and v2 reference styling.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for chip font size, padding, sub-key margin, and absence of forced uppercase styling.
+
+### Still Missing Vs v2 (26)
+
+- Rendered chip width, wrap points, and metadata row height are not browser/screenshot verified.
+- Full pixel-perfect inspector metadata-chip parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Summary/Token Typography Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` summary stat and token-economics typography rules plus runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched v2 summary label density by setting `.kti-stat .k` to `font-size: 8.5px`.
+- Matched v2 summary sub-value density by setting `.kti-stat .v small` to `font-size: 10px`.
+- Matched v2 token header density by setting `.kti-tok-top .lbl` to `font-size: 9.5px` and `.kti-tok-top .ctxpct` to `font-size: 11px`.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the summary/token typography contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered label legibility, numeric wrapping, and token header alignment are not browser/screenshot verified.
+- Full pixel-perfect inspector typography parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Token Legend Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` `.ti-tok-legend` rules and runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched v2 token legend spacing by setting `.kti-tok-legend` to `gap: 18px` and `margin-top: 9px`.
+- Matched v2 token legend text density by setting `.kti-tok-legend` to `font-size: 11.5px`.
+- Matched v2 token legend numeric emphasis by setting `.kti-tok-legend b` to `font-weight: 600`.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the token legend density contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered legend wrapping, marker alignment, and available width on narrow phones are not browser/screenshot verified.
+- Full pixel-perfect token legend parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Waterfall Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` waterfall timeline rules and runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched v2 waterfall row spacing by setting `.kti-wf-row` to `gap: 12px`.
+- Matched v2 waterfall label density by setting `.kti-wf-lbl` to `font-size: 12.5px`, primary foreground, and mono label text to `11.5px`.
+- Matched v2 duration/summary density by setting `.kti-wf-dur` to `11px`, `.kti-wf-foot` to `margin-top: 12px`, `padding-top: 11px`, `font-size: 11.5px`, and `.kti-wf-foot b` to `font-weight: 600`.
+- Matched v2 waterfall legend density by setting `.kti-wf-legend` to `gap: 14px` and legend items to `gap: 5px` with `font-size: 10.5px`.
+- Preserved the runtime-only unmeasured phase hatch/placeholder styling so missing durations still cannot be mistaken for measured spans.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the waterfall density contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered waterfall row clipping, legend wrapping, and measured/unmeasured visual distinction are not browser/screenshot verified.
+- Full pixel-perfect waterfall parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Code Card Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` copyable code-card rules and runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched v2 copy button density by setting `.kti-copy` to `gap: 5px`, `font-size: 10px`, and `padding: 3px 9px`.
+- Matched v2 code header density by setting `.kti-code-h .cap` and `.kti-code-h .sz` to `font-size: 9.5px`.
+- Matched v2 code body density by setting `.kti-code pre` to `font-size: 11.5px` and `line-height: 1.62`.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the copy/code-card density contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered code-card wrapping, horizontal scroll behavior, and copy-button hit target on narrow phones are not browser/screenshot verified.
+- Full pixel-perfect code-card parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Tool Card Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` structured tool-card rules and runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched v2 tool-card header spacing by setting `.kti-tool-h` to `gap: 9px` and `padding: 9px 12px`.
+- Matched v2 tool-card typography by setting `.kti-tool-h .seq` to `9.5px`, `.kti-tool-h .tnm` to `12.5px`, `.kti-tool-h .pill` to `9px`, and `.kti-tool-h .lat` to `11px`.
+- Matched v2 status-pill rhythm by changing `.kti-tool-h .pill` padding to `2px 7px`.
+- Preserved the runtime tool payload spacing and status coloring; this slice only changes visible density.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the structured tool-card density contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered tool-card wrapping, latency alignment, and status-pill hit/legibility on narrow phones are not browser/screenshot verified.
+- Full pixel-perfect structured tool-card parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Message Card Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` role-tinted transcript message rules and runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched v2 transcript message header density by setting `.kti-msg-h` padding to `7px 11px`.
+- Matched v2 role/header typography by setting `.kti-msg-role` to `9.5px`, `.kti-msg-h .who` to `10.5px`, and `.kti-msg-h .seq` to `9.5px`.
+- Matched v2 message body density by setting `.kti-msg-b` to `font-size: 12.5px`, `line-height: 1.62`, and primary foreground color.
+- Matched v2 mono message body density by setting `.kti-msg-b.mono` to `font-size: 11.5px`.
+- Preserved the runtime role coloring and transcript semantics; this slice only changes visible density.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the transcript message-card density contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered transcript wrapping, role-pill width, and mixed mono/prose legibility on narrow phones are not browser/screenshot verified.
+- Full pixel-perfect transcript message-card parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Context/Param Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` context-card and parameter-chip rules plus runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched v2 context-card header density by setting `.kti-ctx-h .t` and `.kti-ctx-h .tok` to `font-size: 10px`.
+- Matched v2 context-card body density by setting `.kti-ctx-card pre` to `padding: 11px 13px`, `font-size: 11.5px`, and `line-height: 1.62`.
+- Matched v2 parameter-chip rhythm by setting `.kti-params` to `gap: 7px`, `.kti-param` to `font-size: 11px` with `padding: 4px 11px`, and `.kti-param b` to `font-weight: 600`.
+- Left `.kti-kv` unchanged because the read v2 reference established explicit param/context-card values, not a key/value-row delta.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the context/parameter density contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered context-card scroll behavior, long-token wrapping, and parameter-chip wrap points are not browser/screenshot verified.
+- Full pixel-perfect context/parameter section parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Turn Inspector Section Header Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/inspector.css` section-title rules and runtime `dashboard/src/styles/keeper-turn-inspector.css`.
+
+### Implemented In Current Worktree
+
+- Matched v2 section header spacing by setting `.kti-sec-h` to `gap: 10px` and `margin: 0 0 9px`.
+- Matched v2 section count density by setting `.kti-sec-h .n` to `font-size: 10px`.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the section-header density contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered section-title alignment and count-chip wrapping are not browser/screenshot verified.
+- Full pixel-perfect section-header parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Mobile Surface Spacing Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-top`, `.kcf-main`, and mobile `.kcf` fullscreen rules plus runtime `dashboard/src/styles/keeper-workspace.css`.
+
+### Implemented In Current Worktree
+
+- Matched v2 config top-bar rhythm by setting `.kw-config-head` to `gap: 13px` and `padding: 14px 20px`.
+- Matched v2 phone-fullscreen config header spacing with safe-area-aware mobile padding using `14px` vertical and `20px` horizontal minimums.
+- Matched v2 config content spacing by setting mobile `.kw-config-scroll` to `24px` top and `30px` side/bottom minimums while preserving safe-area guards.
+- Preserved the existing runtime `KeeperConfigPanel` owner and mobile full-screen drawer behavior; this slice only aligns surface spacing.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the config header/content spacing contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered config header alignment, content density, and narrow-phone overflow are not browser/screenshot verified.
+- Full pixel-perfect keeper-config parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Header Typography Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-top-name` and `.kcf-top-sub` rules plus runtime `dashboard/src/components/keeper-detail-page.ts` config overlay header markup.
+
+### Implemented In Current Worktree
+
+- Matched v2 config title typography by setting `.kw-config-head h3` to display-font `17px`, weight `600`, `letter-spacing: -0.005em`, and baseline flex alignment with `gap: 9px`.
+- Matched v2 config subtitle rhythm by setting `.kw-config-head p` to `margin: 2px 0 0`, UI font, and `font-size: 11px`.
+- Preserved the existing runtime overlay header markup, close action, and `KeeperConfigPanel` ownership; this slice only aligns visible header typography.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the config header typography contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered title/subtitle truncation and close-button alignment are not browser/screenshot verified.
+- Full pixel-perfect keeper-config header parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Fact Row Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-fact`, `.kcf-fact-k`, and `.kcf-fact-v` rules plus runtime `dashboard/src/components/keeper-config-panel.ts` row helpers.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-fact`, `kw-config-fact-k`, and `kw-config-fact-v` classes to the live `ConfigRow` and `BoolRow` helpers.
+- Matched v2 mobile fact-card rhythm by setting config rows inside `.kw-config-scroll` to vertical flex, `gap: 4px`, and `padding: 11px 14px`.
+- Matched v2 fact label density with `font-size: 9.5px`, `letter-spacing: 0.12em`, and uppercase text.
+- Matched v2 fact value density with `font-size: 13px`, primary foreground color, and long-value `word-break: break-word`.
+- Scoped the visual override to the mobile config drawer so desktop utility layout remains unchanged.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the live config row density contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered config row wrapping, bool badge alignment, and long-path readability are not browser/screenshot verified.
+- Full pixel-perfect keeper-config fact-row parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Text Field Density Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-textfield`, `.kcf-tf-h`, and `.kcf-text` rules plus runtime `dashboard/src/components/keeper-config-panel.ts` editable prompt helper.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-textfield`, `kw-config-textfield-head`, `kw-config-textfield-label`, and `kw-config-textfield-hint` hooks to the live editable prompt textarea helper.
+- Matched v2 text-field spacing inside the mobile config drawer with vertical flex layout, `gap: 6px`, and `margin-bottom: 12px`.
+- Matched v2 text-field header rhythm with baseline alignment, `gap: 10px`, `12px` label text, and `11px` dirty-state hint text.
+- Matched v2 inline textarea density with `padding: 10px 12px`, UI font, `font-size: 13px`, and `line-height: 1.6`.
+- Scoped the visual override to `.kw-config-scroll` and the inline textarea only; the shared fullscreen `ExpandableTextarea` modal remains unchanged.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the live config text-field density contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered textarea height, fullscreen edit button overlap, dirty marker alignment, and mobile keyboard behavior are not browser/screenshot verified.
+- Full pixel-perfect keeper-config text-field parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Runtime Chain Chip Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-chain` and `.kcf-chain-item` rules plus runtime `dashboard/src/components/keeper-config-panel.ts` model/runtime list helpers.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-chain` and `kw-config-chain-item` hooks to the live model/runtime list helpers.
+- Matched v2 runtime-chain chip spacing inside the mobile config drawer with flex-wrap layout, `gap: 8px`, and centered alignment.
+- Matched v2 runtime-chain chip density with `font-size: 11.5px`, `padding: 5px 11px`, pill radius, elevated card background, and normal font weight.
+- Scoped the visual override to `.kw-config-scroll` so existing desktop utility styling remains unchanged.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the live config chain-chip density contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered chip wrapping, long model-name truncation, and arrow/sequence affordance parity are not browser/screenshot verified.
+- Full pixel-perfect keeper-config runtime-chain parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Section Header Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-sec-h` and `.kcf-sec-h h3` rules plus runtime `dashboard/src/components/keeper-config-panel.ts` major section helper.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-section-head` and `kw-config-section-title` hooks to the live major section header helper.
+- Matched v2 config section header spacing inside the mobile drawer with flex alignment, `gap: 12px`, and `margin: 0 0 14px`.
+- Matched v2 section title typography with display font, `font-size: 13px`, weight `600`, `letter-spacing: 0.06em`, and uppercase text.
+- Removed the mobile-only card treatment from section headers so the config drawer reads closer to the v2 flat section hierarchy while desktop utility styling remains unchanged.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the live config section-header contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered section rhythm, following-body spacing, and scroll-position behavior are not browser/screenshot verified.
+- Full pixel-perfect keeper-config section-header parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Inline Control Row Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/surfaces.css` `.set-row`, `.set-label`, `.set-toggle`, and `.set-seg-b` rules plus `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/craft.css` compact `.set-row` density override.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-set-row`, `kw-config-set-label`, `kw-config-set-control`, `kw-config-toggle`, `kw-config-toggle-knob`, `kw-config-number-input`, and `kw-config-select` hooks to the live inline runtime edit helpers.
+- Matched v2 compact settings-row density inside the mobile config drawer with `padding: 10px 0`, `gap: 14px`, and top-divider row structure.
+- Matched v2 label density with `font-size: 13px` and primary foreground color.
+- Matched v2 toggle geometry with a `38px` by `22px` pill and `16px` knob while preserving the existing `aria-pressed` and click behavior.
+- Matched v2 segmented-control input/select density with mono `11px` text and `padding: 5px 11px`.
+- Scoped the visual overrides to `.kw-config-scroll` so desktop utility styling and runtime draft/save behavior remain unchanged.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the live inline-control row contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered inline-control wrapping, dirty-state left rail, number/select hit targets, and toggle knob transform alignment are not browser/screenshot verified.
+- Full pixel-perfect keeper-config inline-control parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Goal List Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-goals-list`, `.kcf-goal`, `.kcf-goal-body`, `.kcf-goal-title`, `.kcf-goal-id`, and `.kcf-goal-hz` rules plus runtime `dashboard/src/components/keeper-config-panel.ts` active-goal picker.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-goals-list`, `kw-config-goal`, `kw-config-goal-check`, `kw-config-goal-body`, `kw-config-goal-title`, `kw-config-goal-id`, and `kw-config-goal-hz` hooks to the live active-goal picker.
+- Reorganized each live goal row around the same checkbox state into v2-style check/body/horizon columns without changing selection behavior.
+- Matched v2 goal-list container density with flex-column rows, `gap: 1px`, bordered muted background, `max-height: 460px`, and contained vertical scroll.
+- Matched v2 goal-row geometry with `grid-template-columns: 22px 1fr auto`, `gap: 12px`, and `padding: 10px 14px`.
+- Matched v2 goal title/id/horizon typography with `13px`, `10.5px`, and `10px` text respectively plus horizon pill padding `2px 8px`.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the live config goal-list contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered goal-row checkbox alignment, long title truncation, horizon wrapping, and selected-state treatment are not browser/screenshot verified.
+- Full pixel-perfect keeper-config goal-list parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Hook Table Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-hooks`, `.kcf-hook-hd`, `.kcf-hook`, `.kcf-hook-slot`, `.kcf-hook-src`, and `.kcf-hook-gate` rules plus runtime `dashboard/src/components/keeper-config-panel.ts` global hook slot section.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-hooks`, `kw-config-hook-hd`, `kw-config-hook`, `kw-config-hook-slot`, `kw-config-hook-src`, and `kw-config-hook-gate` hooks to the live global hook slot section.
+- Wrapped the existing filtered hook rows in a v2-style hooks table shell without changing the expanded/filter state or hook data source.
+- Matched v2 hooks container density with flex-column rows, `gap: 1px`, muted bordered background, rounded corners, and hidden overflow.
+- Matched v2 hook row geometry with grid layout, `gap: 14px`, `padding: 9px 14px`, and flat row backgrounds.
+- Matched v2 hook header/slot/source/gate typography with `9.5px`, `12px`, `11.5px`, and `11px` text respectively.
+- Preserved inactive hook dimming and existing gate chips; this slice only changes table structure and density.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the live config hook-table contract.
+
+### Still Missing Vs v2 (26)
+
+- Rendered hook table column widths, long slot/source truncation, and gate-chip wrapping are not browser/screenshot verified.
+- Full pixel-perfect keeper-config hook-table parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Footer Action Strip Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-foot`, `.kcf-foot-note`, `.kcf-foot-spacer`, `.kcf-btn`, `.kcf-btn.ghost`, and `.kcf-btn.save` rules plus runtime `dashboard/src/components/keeper-config-panel.ts` dirty-state save/reset and tool-denylist save/reset action rows.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-foot`, `kw-config-foot-note`, `kw-config-foot-spacer`, `kw-config-btn save`, and `kw-config-btn ghost` hooks to the live dirty-state runtime footer and tool denylist action row.
+- Matched v2 footer action-strip density inside the mobile config drawer with `padding: 13px 20px`, `gap: 10px`, a top divider, panel background, and no card shadow.
+- Matched v2 footer note typography with `font-size: 11px` and muted foreground.
+- Matched v2 action button density with UI font, `font-size: 13px`, `padding: 9px 18px`, ghost border styling, and emphasized save-button weight.
+- Preserved the existing runtime save/reset handlers, denylist save/reset handlers, dirty-state conditional rendering, and disabled-state bindings.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the live config footer/action-strip contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- The dirty-state footer is conditional, so visual parity still needs a mobile screenshot with changed runtime draft values.
+- The denylist action row reuses footer styling for consistency; it may need narrower mobile tuning if rendered section density looks heavier than the standalone reference.
+
+## v2 (26) Keeper Config Runtime Chain Sequence Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-chain-item + .kcf-chain-item` and `.kcf-chain-item + .kcf-chain-item::before` rules plus live `dashboard/src/components/keeper-config-panel.ts` runtime/model chain helpers.
+
+### Implemented In Current Worktree
+
+- Added the v2 directional sequence affordance to live config chain chips in `dashboard/src/styles/keeper-workspace.css`.
+- Matched the standalone runtime-chain arrow geometry with relative positioning on subsequent chips, `left: -16px`, vertical centering, muted color, and `11px` arrow type.
+- Kept the chain data source unchanged: the runtime still renders the live model/runtime arrays, with no static fallback data or fixture values copied from the standalone reference.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the chain sequence rule.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Wrapped multi-line chains may need rendered tuning because the pseudo-arrow is optimized for horizontal chip flow.
+- Full pixel-perfect runtime-chain parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Goal Selection Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-goal.on`, `.kcf-goal-check`, and `.kcf-goal.on .kcf-goal-check` rules plus live `dashboard/src/components/keeper-config-panel.ts` active-goal checkbox rows.
+
+### Implemented In Current Worktree
+
+- Added selected-row visual treatment for live active-goal rows via `.kw-config-goal:has(.kw-config-goal-check:checked)` in `dashboard/src/styles/keeper-workspace.css`.
+- Matched the v2 checkbox geometry with an `18px` checkbox target and accent-colored checked state while preserving the real checkbox input and existing goal assignment behavior.
+- Kept goal data runtime-backed from the existing goal store response; no standalone fixture goals or fake horizon data were introduced.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the goal selected-state and checkbox geometry contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Native checkbox rendering may still differ from the standalone custom check glyph until rendered mobile QA decides whether to replace it.
+- Full pixel-perfect goal selection parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Allowed Paths Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-paths`, `.kcf-text.mono`, and `.kcf-path-eff` rules plus live `dashboard/src/components/keeper-config-panel.ts` `allowed_paths` runtime draft surface.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-paths`, `kw-config-path-text`, and `kw-config-path-eff` hooks to the live allowed-paths editor and effective-path readout in `dashboard/src/components/keeper-config-panel.ts`.
+- Matched v2 paths-surface spacing with a vertical `6px` path stack and `margin-top: 10px` in `dashboard/src/styles/keeper-workspace.css`.
+- Matched v2 monospace path textarea density with `12px` mono text, `line-height: 1.6`, panel background, and default border.
+- Preserved the live `effective_allowed_paths` readout below the editable allowlist using the v2 `effective:` treatment, without adding any local default path or fixture path.
+- Preserved the existing runtime draft update behavior, dirty-state marker, save/reset lifecycle, and relative-path placeholder.
+- Restored the mobile dirty-state accent rail with a semantic `.kw-config-paths.dirty` hook so the path editor keeps an explicit runtime-draft signal after the v2 surface flattening.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the path editor contract and the no-local-path-default invariant.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- The dirty-state left border remains from the live runtime editor; rendered mobile QA should decide whether to keep it as a useful runtime signal or flatten it fully to the standalone path block.
+- Full pixel-perfect allowed-paths parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Tool Policy Editor Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-tools`, `.kcf-tool`, `.kcf-tool-desc`, and `.kcf-text.mono` rules plus live `dashboard/src/components/keeper-config-panel.ts` tool denylist editor and `set_policy` save path.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-tool-policy-note`, `kw-config-tool-policy`, and `kw-config-tool-policy-text` hooks to the live tool denylist editor in `dashboard/src/components/keeper-config-panel.ts`.
+- Matched the v2 tools-surface density with a compact bordered panel, `9px 13px` editor padding, `8px` internal gap, and `11.5px` explanatory note text in `dashboard/src/styles/keeper-workspace.css`.
+- Matched the v2 monospace policy textarea treatment with `12px` mono text, `line-height: 1.6`, panel background, and default border.
+- Preserved the current production behavior: `saveToolDenylist` still calls `set_policy`, preserves existing `tool_access`, and only edits the live `tool_denylist` draft.
+- Kept the editor runtime-backed instead of copying the standalone fixture tool catalog; a future real tool table should come from an authoritative runtime API, not hardcoded v2 sample rows.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the tool policy editor contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- The standalone reference has per-tool risk rows; the live dashboard still lacks an authoritative per-tool risk/description catalog in this component.
+- Full pixel-perfect tool policy parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Textarea Focus Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-text:focus` rule plus the live path and tool-policy textarea hooks already present in `dashboard/src/components/keeper-config-panel.ts`.
+
+### Implemented In Current Worktree
+
+- Added v2-style focus treatment to `.kw-config-path-text:focus` and `.kw-config-tool-policy-text:focus` in `dashboard/src/styles/keeper-workspace.css`.
+- Matched the standalone focus contract by removing the browser outline and switching the textarea border to the dashboard accent token on focus.
+- Preserved all runtime bindings and save behavior; this slice only changes the focused visual state of the existing live textareas.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the mobile textarea focus contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Focus color uses the dashboard accent token instead of the standalone `--volt-dim`; rendered QA should confirm it matches the active dashboard palette.
+- Full pixel-perfect focused-textarea parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Footer Button Hover Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-btn.ghost:hover` and `.kcf-btn.save:hover` rules plus the existing live `kw-config-btn ghost/save` hooks in `dashboard/src/components/keeper-config-panel.ts`.
+
+### Implemented In Current Worktree
+
+- Added v2-style hover treatment to `.kw-config-btn.ghost:hover:not(:disabled)` and `.kw-config-btn.save:hover:not(:disabled)` in `dashboard/src/styles/keeper-workspace.css`.
+- Matched the standalone intent: ghost buttons lift border/text emphasis on hover, and save buttons gain an accent glow.
+- Preserved disabled-state behavior by scoping hover styles with `:not(:disabled)`.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the footer button hover contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Touch devices will not always expose hover; rendered QA should still confirm pressed/focus states separately.
+- Full pixel-perfect footer button interaction parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Callout Description Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-sec-desc` and `.kasm-seg-src` typography rules plus the centralized live `Callout` helper in `dashboard/src/components/keeper-config-panel.ts`.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-callout`, `kw-config-callout-title`, and `kw-config-callout-body` hooks to the live `Callout` helper.
+- Matched v2 description density inside the mobile config drawer with `margin: 7px 0 14px`, `max-width: 680px`, `12.5px` body text, and `line-height: 1.55`.
+- Flattened mobile callout panels into lightweight description blocks while preserving the existing warning/neutral tone classes for desktop and non-mobile contexts.
+- Kept all callout copy runtime-authored from the existing config panel; no standalone fixture descriptions were copied into live behavior.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the callout description contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Warning callouts are visually flattened on mobile, so rendered QA should confirm important warnings remain noticeable enough.
+- Full pixel-perfect config description parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Warning Callout Follow-up - 2026-06-25
+
+Additional source reviewed: live `Callout` tone handling in `dashboard/src/components/keeper-config-panel.ts` plus the v2 description-density treatment already mapped in the previous callout slice.
+
+### Implemented In Current Worktree
+
+- Added semantic `warn` / `neutral` modifiers to the live `kw-config-callout` helper.
+- Preserved the v2-flat mobile description treatment for neutral callouts while restoring warning salience with a compact left warning rail and warning-colored title.
+- Kept all warning copy and tone selection owned by the existing runtime config panel; no new warnings or fixture content were introduced.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the warning callout contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm the warning rail is visible enough without making mobile config sections feel heavier than the v2 reference.
+- Full pixel-perfect warning-callout parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Prompt Source Badge Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-plan` token styling plus the live `PromptSourceBadge` helper in `dashboard/src/components/keeper-config-panel.ts`.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-source-badge` plus source-name modifiers to the live prompt source badge helper.
+- Matched v2 compact provenance-chip density with inline-flex layout, `2px 7px` padding, `9.5px` type, `0.06em` letter spacing, and no shadow inside the mobile config drawer.
+- Preserved the existing runtime source-derived tone logic for `override`, `file`, and neutral prompt sources.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the prompt source badge contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- The standalone `kcf-plan` token semantically marks planned/unimplemented fields; the live source badge instead marks real prompt provenance, so rendered parity should be judged by density and tone rather than exact text semantics.
+- Full pixel-perfect prompt provenance parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Readonly Long Text Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-ro`, `.kcf-text`, and `.kasm-seg-text` density rules plus the live `LongText` helper in `dashboard/src/components/keeper-config-panel.ts`.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-longtext` to the live `LongText` helper so real prompt/config text blocks can be styled consistently in the mobile config drawer.
+- Matched v2 read-only text density with `10px 12px` padding, muted panel border, elevated background, `12.5px` text, and `line-height: 1.55`.
+- Preserved the existing truncation behavior, scroll containment, and runtime-rendered content; no prompt fixture text or local defaults were introduced.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the long-text contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm long prompt blocks remain readable and do not create nested scroll traps on narrow mobile screens.
+- Full pixel-perfect readonly text parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Empty Readonly Token Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-ro` readonly token rule plus the live model/runtime/long-text empty fallbacks in `dashboard/src/components/keeper-config-panel.ts`.
+
+### Implemented In Current Worktree
+
+- Added semantic `kw-config-empty` to the existing empty model list, runtime list, and long-text fallbacks.
+- Matched v2 readonly token density with mono `12px` muted text inside the mobile config drawer.
+- Preserved existing runtime fallback values (`none` / `--`) and did not introduce fixture data or local defaults.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the empty readonly token contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm the empty tokens are visible enough when surrounded by muted config rows.
+- Full pixel-perfect empty-token parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Button Disabled State Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-btn` save/reset hooks and disabled bindings in `dashboard/src/components/keeper-config-panel.ts`.
+
+### Implemented In Current Worktree
+
+- Added scoped disabled-state styling to `.kw-config-btn:disabled` in `dashboard/src/styles/keeper-workspace.css`.
+- Preserved runtime behavior and handlers while making disabled save/reset buttons visually non-interactive with `cursor: not-allowed`, reduced opacity, and no hover glow.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the disabled button contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm disabled contrast remains readable in dirty and denylist-saving states.
+- Full pixel-perfect disabled button parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Goal Row Hover Follow-up - 2026-06-25
+
+Additional source reviewed: `/Users/dancer/Downloads/v2 (26)/keeper-v2/styles/keeper-config.css` `.kcf-goal:hover` rule plus the existing live `kw-config-goal` active-goal rows.
+
+### Implemented In Current Worktree
+
+- Added v2-style hover treatment to `.kw-config-goal:hover` in `dashboard/src/styles/keeper-workspace.css`.
+- Preserved the existing checked-row selected state and live goal assignment behavior.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the goal-row hover contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Touch devices may not expose hover; rendered QA should still confirm tap/selected states are clear.
+- Full pixel-perfect goal-row interaction parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Goal Row Focus Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-goal` active-goal rows and the v2 button-like goal row interaction model.
+
+### Implemented In Current Worktree
+
+- Added scoped `:focus-within` treatment to `.kw-config-goal` in `dashboard/src/styles/keeper-workspace.css`.
+- Preserved the live checkbox and goal assignment behavior while making keyboard focus visible across the whole row.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the goal-row focus contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm the focus ring does not visually conflict with selected-row background on narrow mobile screens.
+- Full pixel-perfect goal-row focus parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Hook Active Row Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-hook` / `off` row classes and the v2 enabled-row treatment used in comparable config tables.
+
+### Implemented In Current Worktree
+
+- Added subtle active-row treatment to `.kw-config-hook:not(.off)` in `dashboard/src/styles/keeper-workspace.css`.
+- Preserved the existing inactive opacity behavior and runtime hook slot source/gate data.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the active hook-row contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm active hook rows remain readable when source and gate text wrap on narrow mobile screens.
+- Full pixel-perfect hook active-row parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Hook Gate Chip Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-hook-gate` gate chip rendering and the v2 compact chip density used across config tables.
+
+### Implemented In Current Worktree
+
+- Added scoped mobile density for `.kw-config-hook-gate span` in `dashboard/src/styles/keeper-workspace.css`.
+- Matched v2 compact chip treatment with `10px` text, `2px 7px` padding, and small-radius pills while preserving existing runtime gate labels and enabled/off tone classes.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the hook gate-chip contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm multiple gate chips wrap cleanly inside the three-column hook table on narrow mobile screens.
+- Full pixel-perfect hook gate-chip parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Hook Gate Chip Wrap Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-hook-gate` gate chip rendering and the compact v2 chip treatment already mapped in the previous hook gate-chip slice.
+
+### Implemented In Current Worktree
+
+- Added `white-space: nowrap` to `.kw-config-hook-gate span` in `dashboard/src/styles/keeper-workspace.css`.
+- Preserved multi-chip wrapping at the container level while preventing individual runtime gate labels from splitting mid-token.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the hook gate-chip nowrap contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm long gate labels do not overflow the three-column hook table on very narrow mobile widths.
+- Full pixel-perfect hook gate-chip wrapping parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Prompt Source Badge Wrap Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-source-badge` prompt provenance chip styling and the compact v2 token treatment already mapped in the prompt source badge slice.
+
+### Implemented In Current Worktree
+
+- Added `white-space: nowrap` to `.kw-config-source-badge` in `dashboard/src/styles/keeper-workspace.css`.
+- Preserved the existing runtime prompt provenance text and tone logic while preventing compact source badges from splitting mid-label.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the prompt source badge wrapping contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm multiple prompt provenance badges do not crowd narrow mobile prompt rows.
+- Full pixel-perfect prompt source badge wrapping parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Goal ID Typography Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-goal-id` active-goal row metadata and the v2 goal picker mono ID treatment.
+
+### Implemented In Current Worktree
+
+- Added explicit mono typography to `.kw-config-goal-id` in `dashboard/src/styles/keeper-workspace.css`.
+- Preserved existing live goal ID values, truncation behavior, selected state, and assignment handlers.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the goal ID typography contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm long goal IDs truncate cleanly next to horizon chips on narrow mobile screens.
+- Full pixel-perfect goal ID typography parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Readonly Long Text Overflow Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-longtext` hook and the v2 read-only/preformatted text density already mapped in the readonly long-text slice.
+
+### Implemented In Current Worktree
+
+- Added explicit `overflow-y: auto` and `white-space: pre-wrap` to `.kw-config-longtext` in `dashboard/src/styles/keeper-workspace.css`.
+- Preserved runtime-rendered prompt/config content, truncation behavior, and the existing helper markup while making the semantic hook own the mobile wrapping/scroll contract.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the long-text overflow contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm long prompt/config blocks do not create nested scroll traps inside the mobile config drawer.
+- Full pixel-perfect readonly long-text overflow parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Goal Horizon Typography Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-goal-hz` active-goal horizon chip styling and the v2 goal picker compact horizon metadata treatment.
+
+### Implemented In Current Worktree
+
+- Added explicit mono typography to `.kw-config-goal-hz` in `dashboard/src/styles/keeper-workspace.css`.
+- Preserved existing live horizon values, chip geometry, selected state, and goal assignment behavior.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the goal horizon typography contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm horizon chips remain readable next to long titles and IDs on narrow mobile screens.
+- Full pixel-perfect goal horizon typography parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Empty Readonly Token Italic Cleanup - 2026-06-25
+
+Additional source reviewed: existing `kw-config-empty` empty model/runtime/long-text fallback styling.
+
+### Implemented In Current Worktree
+
+- Made `.kw-config-empty` explicitly non-italic in `dashboard/src/styles/keeper-workspace.css`.
+- Preserved the existing runtime fallback text while preventing legacy `italic` utility classes from leaking into the mobile v2 readonly token treatment.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the empty-token font-style contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm empty readonly tokens remain visually distinct from ordinary muted metadata.
+- Full pixel-perfect empty-token parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Input Focus Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-*` runtime-control hooks and the v2 compact config drawer control treatment already mapped in the config slices.
+
+### Implemented In Current Worktree
+
+- Added visible focus rings for `.kw-config-number-input:focus-visible`, `.kw-config-select:focus-visible`, and `.kw-config-goal-check:focus-visible` in `dashboard/src/styles/keeper-workspace.css`.
+- Moved vertical resize ownership for `.kw-config-path-text` and `.kw-config-tool-policy-text` into the semantic config CSS hooks.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` source guards for the focus-visible and textarea resize contracts.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered keyboard traversal should confirm the focus rings are visible without crowding the narrow mobile drawer.
+- Full pixel-perfect runtime-control focus parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Toggle Active-State Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-toggle` / `kw-config-toggle-knob` hooks and the v2 compact boolean setting control treatment already mapped from `surfaces.css`.
+
+### Implemented In Current Worktree
+
+- Added visible keyboard focus treatment for `.kw-config-toggle:focus-visible` in `dashboard/src/styles/keeper-workspace.css`.
+- Updated `.kw-config-toggle.on` to use semantic active border/background colors instead of the looser accent-token fallback.
+- Added deterministic off/on knob transforms through `.kw-config-toggle-knob` and `.kw-config-toggle.on .kw-config-toggle-knob`.
+- Split config number/select focus-visible CSS into concrete selector blocks so source-level guards can address each runtime control directly.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` guards for the toggle active, knob-position, and focus contracts.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm all runtime boolean controls show the expected on/off state in the mobile config drawer.
+- Full pixel-perfect toggle parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Toggle Track Layout Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `kw-config-toggle` layout hooks after the active-state slice.
+
+### Implemented In Current Worktree
+
+- Made `.kw-config-toggle` own `inline-flex` track layout and vertical centering in `dashboard/src/styles/keeper-workspace.css`.
+- Added pointer and disabled cursor/opacity semantics for compact runtime boolean controls.
+- Made `.kw-config-toggle-knob` a block-level, non-shrinking control part so the off/on transform does not depend on default inline span behavior.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` guards for toggle track layout, disabled state, and knob display ownership.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm the knob movement stays centered within the 38px track across mobile browsers.
+- Full pixel-perfect toggle track parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Long Text Height Follow-up - 2026-06-25
+
+Additional source reviewed: existing live `.kw-config-longtext` hook and component markup still carrying the legacy `max-h-35 overflow-y-auto` utility classes.
+
+### Implemented In Current Worktree
+
+- Moved the readonly long-text height cap into `.kw-config-longtext` with `max-height: 8.75rem` in `dashboard/src/styles/keeper-workspace.css`.
+- Added semantic horizontal overflow protection and word breaking for long prompt/config strings inside the mobile config drawer.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` guards for long-text max height, overflow-x, and word-break ownership.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm long prompt/config blocks scroll internally without widening the mobile drawer.
+- Full pixel-perfect readonly long-text height parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Long Text Utility Cleanup - 2026-06-25
+
+Additional source reviewed: existing `LongText` component markup after `.kw-config-longtext` gained semantic height, wrapping, and overflow ownership.
+
+### Implemented In Current Worktree
+
+- Removed duplicated `whitespace-pre-wrap max-h-35 overflow-y-auto` utility ownership from the `LongText` markup in `dashboard/src/components/keeper-config-panel.ts`.
+- Preserved existing visual utility classes that may still affect non-mobile styling while leaving the mobile config drawer behavior owned by `.kw-config-longtext`.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` guards to prevent reintroducing the old combined long-text utility contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm desktop config rendering is not unintentionally affected by the utility cleanup.
+- Full pixel-perfect readonly long-text parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Source Badge Utility Cleanup - 2026-06-25
+
+Additional source reviewed: existing `PromptSourceBadge` markup and `.kw-config-source-badge` mobile styling.
+
+### Implemented In Current Worktree
+
+- Removed duplicated prompt-source badge font, padding, radius, and shadow utility ownership from `dashboard/src/components/keeper-config-panel.ts`.
+- Made `.kw-config-source-badge` own its mobile border and uppercase token treatment in `dashboard/src/styles/keeper-workspace.css`.
+- Made `.kw-config-source-badge.override` and `.kw-config-source-badge.file` own their mobile status text colors alongside the existing status backgrounds and borders.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` guards to prevent reintroducing the old combined source-badge utility contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm prompt source badges remain legible and non-wrapping in narrow mobile prompt headers.
+- Full pixel-perfect prompt-source badge parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Toggle Utility Cleanup - 2026-06-25
+
+Additional source reviewed: existing `InlineToggleRow` markup after `.kw-config-toggle` gained semantic track layout and active-state ownership.
+
+### Implemented In Current Worktree
+
+- Removed the legacy toggle track utility stack from `dashboard/src/components/keeper-config-panel.ts`, leaving the runtime value to select only the semantic `on` state.
+- Added track transition ownership to `.kw-config-toggle` in `dashboard/src/styles/keeper-workspace.css`.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` guards to prevent reintroducing the old toggle track utility contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm desktop and mobile runtime toggles still show off/on states correctly after utility cleanup.
+- Full pixel-perfect toggle parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Toggle Knob Utility Cleanup - 2026-06-25
+
+Additional source reviewed: existing `InlineToggleRow` knob markup after `.kw-config-toggle-knob` gained semantic size, display, transform, and active-color ownership.
+
+### Implemented In Current Worktree
+
+- Removed the legacy toggle knob utility stack from `dashboard/src/components/keeper-config-panel.ts`.
+- Made `.kw-config-toggle-knob` explicitly own the mobile no-shadow treatment in `dashboard/src/styles/keeper-workspace.css`.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` guards to prevent reintroducing the old knob utility contract.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm off/on knob positions still align within the compact mobile track.
+- Full pixel-perfect toggle knob parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Number Select Utility Cleanup - 2026-06-25
+
+Additional source reviewed: existing `InlineNumberRow` and `InlineSelectRow` runtime-control markup plus the scoped `.kw-config-number-input`, `.kw-config-select`, and `.kw-config-set-control` mobile hooks.
+
+### Implemented In Current Worktree
+
+- Removed legacy width, alignment, background, border, typography, and transition utility ownership from runtime number inputs in `dashboard/src/components/keeper-config-panel.ts`.
+- Preserved number validation through a semantic `.kw-config-number-input.invalid` class instead of border utility branching.
+- Removed legacy select styling utilities from runtime selects and left sizing/geometry to `.kw-config-select`.
+- Added `.kw-config-number-suffix` so numeric suffix width and typography are owned by config CSS.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` guards for number/select markup cleanup, invalid state, suffix styling, and control alignment.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm numeric suffixes and selects remain aligned inside narrow mobile config rows.
+- Full pixel-perfect number/select runtime-control parity remains unproven without rendered mobile comparison against the v2 (26) reference.
+
+## v2 (26) Keeper Config Textarea Utility Cleanup - 2026-06-25
+
+Additional source reviewed: existing allowed-paths and tool-policy textarea markup plus scoped `.kw-config-path-text` and `.kw-config-tool-policy-text` mobile hooks.
+
+### Implemented In Current Worktree
+
+- Removed legacy width, font, border, background, radius, padding, color, and resize utility ownership from allowed-paths and tool-policy textareas in `dashboard/src/components/keeper-config-panel.ts`.
+- Kept dirty state semantic by using only `.dirty` on `.kw-config-paths` and `.kw-config-tool-policy`.
+- Made `.kw-config-path-text` and `.kw-config-tool-policy-text` explicitly own mobile width and minimum height in `dashboard/src/styles/keeper-workspace.css`.
+- Extended `dashboard/src/styles/keeper-workspace-mobile.test.ts` guards for textarea utility cleanup and semantic textarea sizing.
+
+### Still Missing Vs v2 (26)
+
+- Browser/screenshot validation is still not run in this pass.
+- Rendered QA should confirm both textareas retain expected height, resize behavior, and dirty-state treatment in the mobile config drawer.
+- Full pixel-perfect textarea parity remains unproven without rendered mobile comparison against the v2 (26) reference.


### PR DESCRIPTION
## Summary

- Improves keeper-v2 mobile dashboard parity across keeper chat, detail/config surfaces, roster rows, inspector styling, and mobile layout behavior.
- Moves multiple mobile config controls toward semantic `kw-config-*` CSS ownership instead of duplicated utility-class ownership.
- Adds a source-level mobile guard for the keeper workspace parity hooks and updates the keeper-v2 gap ledger with implemented vs unverified slices.

## Impact

- Dashboard-only change scoped to MASC keeper UI surfaces.
- Does not touch OAS/provider/transport/runtime OCaml code.
- Preserves the MASC/OAS boundary: OAS remains provider/model/transport-owned; these changes are dashboard presentation and interaction affordances only.

## Validation

- Not run in this pass by instruction.
- Browser/screenshot parity and local Vitest/typecheck remain unverified and are called out in the design gap ledger.

## Notes

- Draft PR because rendered mobile QA and local checks have not been run yet.