### PR TITLE
fix(multimodal): land orphaned review fixes for vision store (total store + non-vacuous traversal test)

### DIFF
--- a/lib/multimodal/dune
+++ b/lib/multimodal/dune
@@ -6,6 +6,6 @@
  ; RFC-0071 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries shared_types unix yojson fs_compat digestif)
+ (libraries shared_types unix yojson fs_compat digestif eio)
  (preprocess
   (pps ppx_tla)))

--- a/lib/multimodal/vision_artifact_store.ml
+++ b/lib/multimodal/vision_artifact_store.ml
@@ -25,10 +25,29 @@ let path_of ~dir (h : handle) = Filename.concat dir h
 
 let store ~dir (raw : string) : (handle, string) result =
   let h = hash raw in
-  Fs_compat.mkdir_p dir;
-  match Fs_compat.save_file_atomic (path_of ~dir h) raw with
-  | Ok () -> Ok h
-  | Error msg -> Error (Printf.sprintf "Vision_artifact_store.store: %s" msg)
+  (* [Fs_compat.mkdir_p] returns unit and raises on failure (EACCES, ENOSPC, a
+     parent path component that is a regular file, test-isolation breach). Honor
+     the [.mli]'s "Error on I/O failure" contract by converting those to [Error]
+     — a total function. Eio cancellation is not an I/O error: re-raise it so the
+     fiber unwinds. *)
+  match
+    (try
+       Fs_compat.mkdir_p dir;
+       Ok ()
+     with
+     | Eio.Cancel.Cancelled _ as exn -> raise exn
+     | exn ->
+       Error
+         (Printf.sprintf
+            "Vision_artifact_store.store: mkdir %s: %s"
+            dir
+            (Printexc.to_string exn)))
+  with
+  | Error _ as e -> e
+  | Ok () ->
+    (match Fs_compat.save_file_atomic (path_of ~dir h) raw with
+     | Ok () -> Ok h
+     | Error msg -> Error (Printf.sprintf "Vision_artifact_store.store: %s" msg))
 
 let load ~dir (h : handle) : (string, string) result =
   if not (is_canonical h) then

--- a/test/multimodal/test_vision_artifact_store.ml
+++ b/test/multimodal/test_vision_artifact_store.ml
@@ -20,6 +20,14 @@ let ok = function
   | Ok v -> v
   | Error e -> failwith e
 
+(* substring check (no extra deps) — pins error identity, not just Error/Ok. *)
+let mentions ~needle s =
+  let nl = String.length needle and sl = String.length s in
+  let rec go i =
+    i + nl <= sl && (String.equal (String.sub s i nl) needle || go (i + 1))
+  in
+  go 0
+
 (* store -> load round-trips arbitrary binary bytes losslessly. *)
 let test_round_trip () =
   let dir = temp_dir () in
@@ -72,13 +80,19 @@ let test_corruption_detected () =
   | Ok _ -> assert false
 
 (* a malformed handle (path-traversal, non-hex, wrong length, uppercase) is
-   rejected before any filesystem access — fail closed, no read outside [dir]. *)
+   rejected by the SHAPE guard before any filesystem access — fail closed, no
+   read outside [dir]. Asserting the error is specifically "malformed handle"
+   (not just any Error) pins the guard: with [is_canonical] removed, a traversal
+   handle falls through to a not-found / hash-mismatch error instead, and this
+   test goes red. The dir is seeded so a non-guarded load would actually reach
+   the filesystem. *)
 let test_malformed_handle_rejected () =
   let dir = temp_dir () in
+  ignore (ok (S.store ~dir "seed so dir exists"));
   List.iter
     (fun bad ->
       match S.load ~dir (S.of_string bad) with
-      | Error _ -> ()
+      | Error msg -> assert (mentions ~needle:"malformed handle" msg)
       | Ok _ -> assert false)
     [ "../../etc/passwd";
       "/etc/passwd";


### PR DESCRIPTION
## 무엇을 / 왜

#22257이 적대 코드 리뷰의 수정사항(commit `7140c9a0c4`)이 land하기 **직전 커밋(`29ab154e47`)에서 squash-merge**됐습니다. GitHub PR head가 stale(`29ab`)인 상태로 머지가 트리거돼, 마지막 push가 squash 범위 밖으로 빠졌습니다 (masc#5303 post-merge-push-loss 패턴). 이 PR이 그 orphan된 리뷰 수정을 현재 main 위에 다시 land합니다.

## 변경 (3 files)

1. **`store` total화** — `Fs_compat.mkdir_p`은 실패 시 raise하는데 `.mli`는 "Error on I/O failure"를 약속 → mkdir 실패(EACCES/ENOSPC/path-component/test-isolation)가 예외로 탈출하던 계약 위반을 수정. mkdir 예외를 `Error`로 변환(total function), `Eio.Cancel.Cancelled`는 re-raise(삼키지 않음). multimodal deps에 `eio` 추가.
2. **non-vacuous traversal 테스트** — `test_malformed_handle_rejected`가 `Error _`만 보던 것을 **"malformed handle" shape-guard 에러를 명시 검증**하도록 강화 + dir seed. mutation으로 검증: `is_canonical` 무력화 시 test red(traversal handle이 not-found/hash 백스톱으로 빠짐). forged `../` handle이 fs 접근 *전에* 거부됨을 pin.

## 검증

- `test_vision_artifact_store` green, `@test/multimodal/runtest` green (회귀 없음).
- non-vacuity: guard 무력화 mutation → line 95 Assertion failed(red) 확인 후 revert.

## 근거

적대 리뷰(fresh-context) verdict FIX-FIRST: store 계약 거짓 + 테스트 부분 vacuous. 둘 다 본 PR에서 해소. RFC-keeper-vision-delegation-tool (#22241) §2.5 building block.

RFC-WAIVED: lib/multimodal은 RFC-gated subsystem 미해당. 설계 RFC #22241 동반.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
