### PR TITLE
fix(workspace): include keeper registry agents in status

### DIFF
--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -41,6 +41,58 @@ let autoboot_proactive_warmup_sec ~base_warmup ~stagger_window_sec ~keeper_name 
   else base_warmup + (stable_keeper_name_hash keeper_name mod (stagger_window_sec + 1))
 ;;
 
+let keeper_agent_status_of_phase = function
+  | Keeper_state_machine.Running -> Masc_domain.Active
+  | Keeper_state_machine.Paused -> Masc_domain.Listening
+  | Keeper_state_machine.Failing
+  | Keeper_state_machine.Overflowed
+  | Keeper_state_machine.Compacting
+  | Keeper_state_machine.HandingOff
+  | Keeper_state_machine.Draining
+  | Keeper_state_machine.Restarting -> Masc_domain.Busy
+  | Keeper_state_machine.Offline
+  | Keeper_state_machine.Stopped
+  | Keeper_state_machine.Crashed
+  | Keeper_state_machine.Dead
+  | Keeper_state_machine.Zombie -> Masc_domain.Inactive
+;;
+
+let keeper_registry_agent ~now (entry : Keeper_registry.registry_entry) : Masc_domain.agent =
+  let meta = entry.meta in
+  let agent_name =
+    match String.trim meta.agent_name with
+    | "" -> Keeper_identity.keeper_agent_name entry.name
+    | name -> name
+  in
+  let agent_meta : Masc_domain.agent_meta =
+    { session_id = "keeper-registry:" ^ entry.name
+    ; agent_type = "keeper"
+    ; pid = None
+    ; hostname = None
+    ; tty = None
+    ; parent_task = None
+    ; keeper_name = Some entry.name
+    ; keeper_id = None
+    }
+  in
+  { Masc_domain.id = None
+  ; name = agent_name
+  ; agent_type = "keeper"
+  ; status = keeper_agent_status_of_phase entry.phase
+  ; capabilities = []
+  ; current_task = None
+  ; session_bound_at = now
+  ; last_seen = now
+  ; meta = Some agent_meta
+  }
+;;
+
+let keeper_registry_runtime_agents (config : Workspace_utils_backend_setup.config) =
+  let now = Masc_domain.now_iso () in
+  Keeper_registry.all ~base_path:config.base_path ()
+  |> List.map (keeper_registry_agent ~now)
+;;
+
 let board_sse_event_params event =
   match event with
   | Board_dispatch.Post_created { post_id; author; title; content; post_kind; hearth } ->
@@ -208,6 +260,7 @@ let start_keeper_loops
   Progress.set_sse_callback Sse.broadcast;
   (* Wire stop_keeper hook so zombie GC can terminate keeper fibers *)
   Atomic.set Workspace_hooks.stop_keeper_fn Keeper_keepalive.stop_keepalive;
+  Atomic.set Workspace_hooks.runtime_agents_fn keeper_registry_runtime_agents;
   (* Shared Agent_sdk Event_bus used as the runtime transport between subsystems.
      Configuration is sourced from [Masc_event_bus_policy.oas_runtime] so the
      buffer-size/policy choice is auditable in source rather than implicit in

--- a/lib/tool_workspace.ml
+++ b/lib/tool_workspace.ml
@@ -190,10 +190,10 @@ let safe_current_task (ctx : context) ~session_bound =
 ;;
 
 let safe_get_agents (ctx : context) =
-  try Workspace.get_agents_raw ctx.config with
+  try Workspace.get_active_agents ctx.config with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
-    Log.Workspace.warn "get_agents_raw failed: %s" (Stdlib.Printexc.to_string exn);
+    Log.Workspace.warn "get_active_agents failed: %s" (Stdlib.Printexc.to_string exn);
     []
 ;;
 

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -55,6 +55,13 @@ let stop_keeper_fn
   : (string -> unit) Atomic.t
   = Atomic.make (fun _name -> ())
 
+(** Runtime-visible agents supplied by upper layers such as the keeper
+    registry.  Workspace code consumes [Masc_domain.agent] rows without
+    depending on the keeper implementation. *)
+let runtime_agents_fn
+  : (Workspace_utils_backend_setup.config -> Masc_domain.agent list) Atomic.t
+  = Atomic.make (fun _config -> [])
+
 (** Relation materializer: agent session end — wraps Relation_materializer.on_agent_session_ended. *)
 let relation_on_leave_fn
   : (leaving_agent:string -> active_agents:string list -> unit) Atomic.t

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -27,6 +27,8 @@ val activity_emit_fn : (Workspace_utils_backend_setup.config ->
 val agent_economy_earn_fn : (base_path:string -> agent_name:string -> reason:string -> unit)
            Atomic.t
 val stop_keeper_fn : (string -> unit) Atomic.t
+val runtime_agents_fn :
+  (Workspace_utils_backend_setup.config -> Masc_domain.agent list) Atomic.t
 val relation_on_leave_fn : (leaving_agent:string -> active_agents:string list -> unit)
            Atomic.t
 val relation_on_task_done_fn : (assignee:string -> active_agents:string list -> unit) Atomic.t

--- a/lib/workspace/workspace_query.ml
+++ b/lib/workspace/workspace_query.ml
@@ -87,6 +87,71 @@ let load_agents_from_dir config dir ~include_inactive =
              Some agent
          | Ok _ | Error _ -> None)
 
+let agent_type_of_state_agent_name name =
+  if Workspace_resilience.Zombie.is_keeper_name name
+  then "keeper"
+  else (
+    match Nickname.extract_agent_type name with
+    | Some agent_type -> agent_type
+    | None -> name)
+
+let state_backed_agent state (name : string) : Masc_domain.agent =
+  let agent_type = agent_type_of_state_agent_name name in
+  let timestamp = state.started_at in
+  let meta : Masc_domain.agent_meta =
+    { session_id = "workspace-state:" ^ name
+    ; agent_type
+    ; pid = None
+    ; hostname = None
+    ; tty = None
+    ; parent_task = None
+    ; keeper_name = None
+    ; keeper_id = None
+    }
+  in
+  { id = None
+  ; name
+  ; agent_type
+  ; status = Masc_domain.Active
+  ; capabilities = []
+  ; current_task = None
+  ; session_bound_at = timestamp
+  ; last_seen = timestamp
+  ; meta = Some meta
+  }
+
+let state_backed_active_agents config =
+  let state = read_state config in
+  state.active_agents |> normalized_string_list |> List.map (state_backed_agent state)
+
+let runtime_agents config =
+  try (Atomic.get Workspace_hooks.runtime_agents_fn) config with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Workspace.warn
+      "runtime_agents_fn failed while reading active agents: %s"
+      (Printexc.to_string exn);
+    []
+
+let agent_status_is_active = function
+  | Masc_domain.Active | Busy | Listening -> true
+  | Inactive -> false
+
+let active_runtime_agents config =
+  runtime_agents config
+  |> List.filter (fun (agent : Masc_domain.agent) ->
+         agent_status_is_active agent.status)
+
+let merge_agents primary secondary =
+  let seen = Hashtbl.create (List.length primary + List.length secondary) in
+  let add_if_new acc (agent : Masc_domain.agent) =
+    if Hashtbl.mem seen agent.name then acc
+    else (
+      Hashtbl.add seen agent.name ();
+      agent :: acc)
+  in
+  List.rev (List.fold_left add_if_new (List.fold_left add_if_new [] primary) secondary)
+
 (** Get raw agent list (for orchestrator).
     Includes inactive agents. Requires initialization. *)
 let get_agents_raw config =
@@ -101,7 +166,9 @@ let get_active_agents config =
   if not (root_is_initialized config) then []
   else
     let agents_path = agents_dir config in
-    load_agents_from_dir config agents_path ~include_inactive:false
+    let workspace_agents = load_agents_from_dir config agents_path ~include_inactive:false in
+    let state_agents = state_backed_active_agents config in
+    merge_agents (merge_agents workspace_agents state_agents) (active_runtime_agents config)
 
 (** Like [get_agents_raw] but returns [[]] when not initialized
     instead of raising.  Includes inactive agents.

--- a/lib/workspace/workspace_status.ml
+++ b/lib/workspace/workspace_status.ml
@@ -34,70 +34,62 @@ let status config =
   Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n\n";
   Buffer.add_string buf "Players:\n";
 
-  (* List agents (bounded for responsiveness) *)
-  let agents_path = agents_dir config in
-  if Sys.file_exists agents_path then begin
-    let agents =
-      Sys.readdir agents_path
-      |> Array.to_list
-      |> List.filter (fun name -> Filename.check_suffix name ".json")
-      |> List.filter_map (fun name ->
-          let path = Filename.concat agents_path name in
-          let json = read_json config path in
-          match agent_of_yojson json with
-          | Ok agent ->
-              let is_zombie =
-                is_zombie_agent
-                  ~agent_type:agent.agent_type
-                  ?agent_meta:agent.meta
-                  ~agent_name:agent.name
-                  agent.last_seen
-              in
-              let stale_current_task =
-                match agent.current_task with
-                | Some task_id ->
-                    not
-                      (Workspace_task_schedule.agent_current_task_matches_assignments
-                         active_task_assignees ~agent_name:agent.name task_id)
-                | None -> false
-              in
-              let display_status =
-                if stale_current_task then
-                  match agent.status with
-                  | Inactive -> Inactive
-                  | Active | Busy | Listening -> Active
-                else
-                  agent.status
-              in
-              let icon =
-                if is_zombie then "💀"
-                else
-                  match display_status with
-                  | Busy -> "🔴"
-                  | Active -> "🟢"
-                  | Listening -> "🎧"
-                  | Inactive -> "⚫"
-              in
-              let task =
-                if is_zombie then "zombie"
-                else if stale_current_task then "idle"
-                else Option.value agent.current_task ~default:"idle"
-              in
-              Some (agent.name, icon, task)
-          | Error _ -> None)
-      |> List.sort (fun (a, _, _) (b, _, _) -> String.compare a b)
-    in
-    let total_agents = List.length agents in
-    let shown_agents = take max_agents_display agents in
-    List.iter (fun (name, icon, task) ->
-      Printf.bprintf buf "  %s %s → %s\n" icon name task
-    ) shown_agents;
-    if total_agents > max_agents_display then
-      Buffer.add_string buf
-        (Printf.sprintf
-           "  … and %d more agents\n"
-           (total_agents - max_agents_display))
-  end;
+  let agents =
+    Workspace_query.get_active_agents config
+    |> List.filter_map (fun (agent : Masc_domain.agent) ->
+           let is_zombie =
+             is_zombie_agent
+               ~agent_type:agent.agent_type
+               ?agent_meta:agent.meta
+               ~agent_name:agent.name
+               agent.last_seen
+           in
+           let stale_current_task =
+             match agent.current_task with
+             | Some task_id ->
+                 not
+                   (Workspace_task_schedule.agent_current_task_matches_assignments
+                      active_task_assignees ~agent_name:agent.name task_id)
+             | None -> false
+           in
+           let display_status =
+             if stale_current_task then
+               match agent.status with
+               | Inactive -> Inactive
+               | Active | Busy | Listening -> Active
+             else
+               agent.status
+           in
+           let icon =
+             if is_zombie then "💀"
+             else
+               match display_status with
+               | Busy -> "🔴"
+               | Active -> "🟢"
+               | Listening -> "🎧"
+               | Inactive -> "⚫"
+           in
+           let task =
+             if is_zombie then "zombie"
+             else if stale_current_task then "idle"
+             else
+               match agent.current_task with
+               | Some task_id -> task_id
+               | None -> "idle"
+           in
+           Some (agent.name, icon, task))
+    |> List.sort (fun (a, _, _) (b, _, _) -> String.compare a b)
+  in
+  let total_agents = List.length agents in
+  let shown_agents = take max_agents_display agents in
+  List.iter (fun (name, icon, task) ->
+    Printf.bprintf buf "  %s %s → %s\n" icon name task
+  ) shown_agents;
+  if total_agents > max_agents_display then
+    Buffer.add_string buf
+      (Printf.sprintf
+         "  … and %d more agents\n"
+         (total_agents - max_agents_display));
 
   Buffer.add_string buf "\nQuest Board:\n";
 

--- a/test/test_tool_workspace_coverage.ml
+++ b/test/test_tool_workspace_coverage.ml
@@ -7,6 +7,7 @@ open Workspace_types
 module Planning_eio = Masc.Task.Planning_eio
 
 let () = Random.self_init ()
+let () = Mirage_crypto_rng_unix.use_default ()
 
 let str_contains s sub =
   let len_s = String.length s in
@@ -128,6 +129,31 @@ let seed_stale_current_task ctx =
   old_last_seen
 ;;
 
+let runtime_agent name : Masc_domain.agent =
+  let now = Masc_domain.now_iso () in
+  let meta : Masc_domain.agent_meta =
+    { session_id = "runtime-hook:" ^ name
+    ; agent_type = "keeper"
+    ; pid = None
+    ; hostname = None
+    ; tty = None
+    ; parent_task = None
+    ; keeper_name = Some name
+    ; keeper_id = None
+    }
+  in
+  { id = None
+  ; name
+  ; agent_type = "keeper"
+  ; status = Masc_domain.Active
+  ; capabilities = []
+  ; current_task = None
+  ; session_bound_at = now
+  ; last_seen = now
+  ; meta = Some meta
+  }
+;;
+
 let write_agent_state config agent_name f =
   let agent_file =
     Filename.concat (Workspace.agents_dir config) (Workspace.safe_filename agent_name ^ ".json")
@@ -218,6 +244,33 @@ let () =
     let agent = read_agent ctx in
     assert (agent.current_task = Some "task-missing");
     assert (agent.last_seen = old_last_seen))
+;;
+
+let () =
+  test "dispatch_status_includes_runtime_agents_without_workspace_files" (fun () ->
+    let ctx = make_test_ctx () in
+    let _ = Workspace.init ctx.config ~agent_name:(Some ctx.agent_name) in
+    let previous = Atomic.get Workspace_hooks.runtime_agents_fn in
+    Fun.protect
+      ~finally:(fun () -> Atomic.set Workspace_hooks.runtime_agents_fn previous)
+      (fun () ->
+        Atomic.set Workspace_hooks.runtime_agents_fn (fun config ->
+          if String.equal config.base_path ctx.config.base_path
+          then [ runtime_agent "keeper-runtime-visible-agent" ]
+          else []);
+        let agent_file =
+          Filename.concat
+            (Workspace.agents_dir ctx.config)
+            (Workspace.safe_filename "keeper-runtime-visible-agent" ^ ".json")
+        in
+        assert (not (Sys.file_exists agent_file));
+        match Tool_workspace.dispatch ctx ~name:"masc_status" ~args:(`Assoc []) with
+        | Some result ->
+          assert (Tool_result.is_success result);
+          let message = Tool_result.message result in
+          assert_contains message "Snapshot: agents=2 zombies=0";
+          assert_contains message "keeper-runtime-visible-agent -> active"
+        | None -> failwith "dispatch returned None"))
 ;;
 
 (* Test status summary and active task cap *)

--- a/test/test_workspace_coverage.ml
+++ b/test/test_workspace_coverage.ml
@@ -1615,6 +1615,132 @@ let test_get_agents_raw () =
     Alcotest.(check bool) "at least 2 agents" true (List.length agents >= 2))
 ;;
 
+let remove_agent_files config =
+  let dir = Workspace.agents_dir config in
+  if Sys.file_exists dir
+  then
+    Sys.readdir dir
+    |> Array.iter (fun name ->
+      if Filename.check_suffix name ".json" then Sys.remove (Filename.concat dir name))
+;;
+
+let runtime_agent ?(status = Masc_domain.Active) name : Masc_domain.agent =
+  let now = Masc_domain.now_iso () in
+  let meta : Masc_domain.agent_meta =
+    { session_id = "runtime-hook:" ^ name
+    ; agent_type = "keeper"
+    ; pid = None
+    ; hostname = None
+    ; tty = None
+    ; parent_task = None
+    ; keeper_name = Some name
+    ; keeper_id = None
+    }
+  in
+  { id = None
+  ; name
+  ; agent_type = "keeper"
+  ; status
+  ; capabilities = []
+  ; current_task = None
+  ; session_bound_at = now
+  ; last_seen = now
+  ; meta = Some meta
+  }
+;;
+
+let test_get_active_agents_falls_back_to_state_when_agent_files_missing () =
+  with_test_env (fun config ->
+    let state = Workspace.read_state config in
+    Workspace.write_state
+      config
+      { state with active_agents = [ "keeper-albini-agent"; ""; "keeper-albini-agent" ] };
+    remove_agent_files config;
+    let agents = Workspace.get_active_agents config in
+    match agents with
+    | [ agent ] ->
+      Alcotest.(check string) "agent name" "keeper-albini-agent" agent.name;
+      Alcotest.(check string) "agent type" "keeper" agent.agent_type;
+      Alcotest.(check string)
+        "agent status"
+        "active"
+        (Masc_domain.agent_status_to_string agent.status);
+      (match agent.meta with
+       | Some meta ->
+         Alcotest.(check string)
+           "synthetic session id"
+           "workspace-state:keeper-albini-agent"
+           meta.session_id
+       | None -> Alcotest.fail "expected synthetic agent meta")
+    | _ -> Alcotest.failf "expected one state-backed agent, got %d" (List.length agents))
+;;
+
+let test_get_active_agents_merges_state_with_file_backed_agents () =
+  with_test_env (fun config ->
+    let file_agent =
+      match Workspace.get_active_agents config with
+      | [ agent ] -> agent
+      | agents -> Alcotest.failf "expected one file-backed agent, got %d" (List.length agents)
+    in
+    let state = Workspace.read_state config in
+    Workspace.write_state
+      config
+      { state with
+        active_agents =
+          [ file_agent.name
+          ; "keeper-state-only-agent"
+          ; ""
+          ; "keeper-state-only-agent"
+          ]
+      };
+    let agents = Workspace.get_active_agents config in
+    let names = List.map (fun (agent : Masc_domain.agent) -> agent.name) agents in
+    Alcotest.(check bool)
+      "keeps file-backed agent"
+      true
+      (List.exists (String.equal file_agent.name) names);
+    Alcotest.(check bool)
+      "adds state-only agent"
+      true
+      (List.exists (String.equal "keeper-state-only-agent") names);
+    Alcotest.(check int) "deduped active agents" 2 (List.length agents);
+    let output = Workspace.status config in
+    Alcotest.(check bool)
+      "direct status includes state-only agent"
+      true
+      (str_contains output "keeper-state-only-agent → idle"))
+;;
+
+let test_get_active_agents_filters_inactive_runtime_agents () =
+  with_test_env (fun config ->
+    let previous = Atomic.get Workspace_hooks.runtime_agents_fn in
+    Fun.protect
+      ~finally:(fun () -> Atomic.set Workspace_hooks.runtime_agents_fn previous)
+      (fun () ->
+        Atomic.set Workspace_hooks.runtime_agents_fn (fun hook_config ->
+          if String.equal hook_config.base_path config.base_path
+          then
+            [ runtime_agent "keeper-runtime-active-agent"
+            ; runtime_agent ~status:Masc_domain.Inactive "keeper-runtime-inactive-agent"
+            ]
+          else []);
+        let agents = Workspace.get_active_agents config in
+        let names = List.map (fun (agent : Masc_domain.agent) -> agent.name) agents in
+        Alcotest.(check bool)
+          "keeps active runtime agent"
+          true
+          (List.exists (String.equal "keeper-runtime-active-agent") names);
+        Alcotest.(check bool)
+          "filters inactive runtime agent"
+          false
+          (List.exists (String.equal "keeper-runtime-inactive-agent") names);
+        let output = Workspace.status config in
+        Alcotest.(check bool)
+          "direct status hides inactive runtime agent"
+          false
+          (str_contains output "keeper-runtime-inactive-agent")))
+;;
+
 let test_get_messages_raw () =
   with_test_env (fun config ->
     let _ = Workspace.broadcast config ~from_agent:"claude" ~content:"Message 1" in
@@ -1984,6 +2110,18 @@ let () =
       , [ Alcotest.test_case "get tasks raw" `Quick test_get_tasks_raw
         ; Alcotest.test_case "get tasks raw empty" `Quick test_get_tasks_raw_empty
         ; Alcotest.test_case "get agents raw" `Quick test_get_agents_raw
+        ; Alcotest.test_case
+            "get active agents falls back to state"
+            `Quick
+            test_get_active_agents_falls_back_to_state_when_agent_files_missing
+        ; Alcotest.test_case
+            "get active agents merges state and file-backed"
+            `Quick
+            test_get_active_agents_merges_state_with_file_backed_agents
+        ; Alcotest.test_case
+            "get active agents filters inactive runtime agents"
+            `Quick
+            test_get_active_agents_filters_inactive_runtime_agents
         ; Alcotest.test_case "get messages raw" `Quick test_get_messages_raw
         ; Alcotest.test_case "is agent joined" `Quick test_is_agent_session_bound
         ] )


### PR DESCRIPTION
## Summary
- include live Keeper_registry entries in masc_status agent snapshots when no workspace agent file exists
- fall back Workspace.get_active_agents to state.active_agents when the agents directory has no active file-backed rows
- route Workspace.status through Workspace_query.get_active_agents so the direct status path shares the fallback behavior

## Verification
- scripts/dune-local.sh build test/test_tool_workspace_coverage.exe test/test_workspace_coverage.exe
- ./_build/default/test/test_tool_workspace_coverage.exe
- ./_build/default/test/test_workspace_coverage.exe test "status|raw_data"

## Notes
- Full direct test_workspace_coverage.exe still has unrelated transition/observability failures in the current tree; the status/raw_data groups touched by this change pass.