### PR TITLE
fix(dashboard): repair keeper v2 mobile checks

### DIFF
--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -47,6 +47,7 @@ import { globalShortcutManager } from './lib/global-shortcut-manager'
 import { useKeeperPinShortcuts } from './components/ide/use-keeper-pin-shortcuts'
 import { useIsMobile } from './hooks/use-is-mobile'
 import { isWidgetSoloRoute } from './components/widget-solo'
+import { keeperMobilePane } from './components/keeper-detail-state'
 import {
   CopilotDock,
   CopilotDockFab,

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -2661,4 +2661,33 @@ describe('ChatComposer v2 prototype surface', () => {
     send.click()
     expect(onSend).toHaveBeenCalledTimes(1)
   })
+
+  it('runs the active slash command from the strict-index-safe menu selection', () => {
+    const run = vi.fn()
+    render(
+      html`<${ChatComposer}
+        draft="/res"
+        placeholder="메시지 입력..."
+        disabled=${false}
+        streaming=${false}
+        commands=${[
+          {
+            id: 'restart',
+            group: 'lifecycle',
+            label: 'Restart keeper',
+            run,
+          },
+        ]}
+        onDraftChange=${() => {}}
+        onSend=${() => {}}
+      />`,
+      container,
+    )
+
+    expect(container.querySelector('.slashmenu')).not.toBeNull()
+    const textarea = container.querySelector('.composer-box textarea') as HTMLTextAreaElement
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(run).toHaveBeenCalledTimes(1)
+  })
 })

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -3053,19 +3053,21 @@ export function ChatComposer({
   const hasContent = draft.trim() !== '' || attachments.length > 0
   const sendDisabled = disabled || !hasContent || (streaming && !queueEnabled)
   const slashMatch = /^\/([^\s]*)$/.exec(draft)
-  const slashQuery = slashMatch ? slashMatch[1].toLowerCase() : null
+  const slashQuery = slashMatch?.[1]?.toLowerCase() ?? null
   const slashMatches = useMemo(
-    () => slashQuery === null
-      ? []
-      : commands.filter(command => {
-        const id = command.id.toLowerCase()
-        const label = command.label.toLowerCase()
-        return id.startsWith(slashQuery) || label.startsWith(slashQuery)
-      }),
+    () =>
+      slashQuery === null
+        ? []
+        : commands.filter((command) => {
+            const id = command.id.toLowerCase()
+            const label = command.label.toLowerCase()
+            return id.startsWith(slashQuery) || label.startsWith(slashQuery)
+          }),
     [commands, slashQuery],
   )
   const slashOpen = voice.state === 'idle' && slashMatches.length > 0
   const activeSlashIdx = slashOpen ? Math.min(slashIdx, slashMatches.length - 1) : 0
+  const activeSlashCommand = slashOpen ? slashMatches[activeSlashIdx] : undefined
 
   const isPrimary = layout === 'primary'
 
@@ -3173,7 +3175,7 @@ export function ChatComposer({
       }
       if (event.key === 'Enter' || event.key === 'Tab') {
         event.preventDefault()
-        runSlashCommand(slashMatches[activeSlashIdx])
+        runSlashCommand(activeSlashCommand)
         return
       }
       if (event.key === 'Escape') {

--- a/dashboard/src/styles/keeper-turn-inspector.css
+++ b/dashboard/src/styles/keeper-turn-inspector.css
@@ -67,6 +67,7 @@
   /* --color-fg-primary maps to --text-bright under [data-skin=v2]
      (skin-v2.css:247), matching the prototype heading's --text-bright. */
   color: var(--color-fg-primary);
+  flex: none;
   white-space: nowrap;
 }
 
@@ -119,12 +120,11 @@
 .kti-sub {
   display: flex;
   align-items: center;
-  /* prototype .ti-sub (keeper-v2/styles/inspector.css:14): gap 8px, padding
-     0 16px 12px. --sp-2/--sp-4 are 6px/10px on the 2px-base v2 scale and would
-     shrink the subline gutters; pin the prototype literals. */
+  /* Keep the integrated drawer gutters on the dashboard v2 spacing token while
+     preserving the prototype row gap and bottom pad. */
   gap: 8px;
   flex-wrap: wrap;
-  padding: 0 16px 12px;
+  padding: 0 var(--sp-4) 12px;
   border-bottom: 1px solid var(--color-border-subtle);
 }
 
@@ -208,10 +208,9 @@
 
 /* ── Token economics bar ── */
 .kti-tok {
-  /* prototype .ti-tok (keeper-v2/styles/inspector.css:29): literal 13px 16px,
-     no border. --sp-3/--sp-4 are 8px/10px on the 2px-base v2 scale and would
-     shrink the token-economics band; pin the prototype literals. */
-  padding: 13px 16px;
+  /* Dashboard v2 uses the shared horizontal spacing token here while preserving
+     the prototype's 13px vertical pad and no-border economics band. */
+  padding: 13px var(--sp-4);
 }
 
 .kti-tok-top {
@@ -302,7 +301,7 @@
 .kti-tok-legend b {
   font-family: var(--font-mono);
   color: var(--color-fg-primary);
-  font-weight: var(--fw-semi);
+  font-weight: 600;
 }
 
 /* ── Tabs — pill rail (prototype .turn-tabs / .turn-tab, keeper-v2/styles/v2.css:701-704) ── */
@@ -432,7 +431,7 @@
   /* prototype .ti-wf-lbl (inspector.css:48): 12.5px. --fs-12 is bumped to 14px
      at desktop :root (variables.css:723); pin the literal. */
   font-size: 12.5px;
-  color: var(--color-fg-secondary);
+  color: var(--color-fg-primary);
 }
 
 .kti-wf-lbl .nm {
@@ -515,7 +514,7 @@
 .kti-wf-foot b {
   font-family: var(--font-mono);
   color: var(--color-fg-primary);
-  font-weight: var(--fw-semi);
+  font-weight: 600;
 }
 
 .kti-wf-legend {
@@ -792,7 +791,7 @@
   font-family: var(--font-body);
   font-size: 12.5px;
   line-height: 1.62;
-  color: var(--color-fg-secondary);
+  color: var(--color-fg-primary);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -889,7 +888,7 @@
 
 .kti-param b {
   color: var(--color-fg-primary);
-  font-weight: var(--fw-semi);
+  font-weight: 600;
   margin-left: 6px;
 }
 
@@ -937,6 +936,31 @@
 
 .kti-turn-summary:hover .open-hint {
   opacity: 1;
+}
+
+@media (max-width: 900px) {
+  .kti-drawer {
+    width: 100vw;
+    max-width: 100vw;
+    height: 100dvh;
+    border-left: 0;
+  }
+
+  .kti-head {
+    padding-top: max(14px, env(safe-area-inset-top, 0px));
+    padding-right: max(16px, env(safe-area-inset-right, 0px));
+    padding-left: max(16px, env(safe-area-inset-left, 0px));
+  }
+
+  .kti-sub {
+    padding-right: max(var(--sp-4), env(safe-area-inset-right, 0px));
+    padding-left: max(var(--sp-4), env(safe-area-inset-left, 0px));
+  }
+
+  .kti-tok {
+    padding-right: max(var(--sp-4), env(safe-area-inset-right, 0px));
+    padding-left: max(var(--sp-4), env(safe-area-inset-left, 0px));
+  }
 }
 
 /* Responsive summary strip */

--- a/dashboard/src/styles/keeper-workspace-mobile.test.ts
+++ b/dashboard/src/styles/keeper-workspace-mobile.test.ts
@@ -101,6 +101,7 @@ describe('keeper workspace v2 (26) mobile contract', () => {
   })
 
   it('exposes the mobile keeper reading-mode state from the app shell', () => {
+    expect(appSource).toContain("import { keeperMobilePane } from './components/keeper-detail-state'")
     expect(appSource).toContain("const mobileKeeperReadingMode = mobileKeeperPane === 'chat'")
     expect(appSource).toContain('data-reading=${mobileKeeperReadingMode ?')
   })

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -1015,6 +1015,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   .kw-mobile-rail-drawer {
     width: min(330px, 88vw);
     max-width: calc(100vw - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px));
+    box-shadow: -8px 0 30px rgb(0 0 0 / 0.50);
   }
   .kw-rail-scroll {
     gap: 20px;


### PR DESCRIPTION
## Summary

- Repairs the dashboard typecheck regression merged by #22268 by importing `keeperMobilePane` where `app.ts` reads it.
- Makes slash command lookup strict-index-safe and restores the keeper mobile/inspector CSS declarations guarded by the mobile parity tests.
- Adds regression assertions for the keeper pane import and slash command execution path so the coverage gate has a real test-file delta.

## Validation

- `pnpm run typecheck` in `dashboard/`
- `pnpm exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/app.test.ts src/styles/keeper-workspace-mobile.test.ts src/styles/board-v2.test.ts src/components/chat/primitives.test.ts` (176 tests)
- `python3 scripts/check_test_coverage.py`
- `bash scripts/lint/no-hardcoded-colors-dashboard.sh`
- `git diff --check -- dashboard/src/app.ts dashboard/src/components/chat/primitives.ts dashboard/src/components/chat/primitives.test.ts dashboard/src/styles/keeper-turn-inspector.css dashboard/src/styles/keeper-workspace.css dashboard/src/styles/keeper-workspace-mobile.test.ts`

## Notes

- Follow-up to #22268 merge commit `5d574cac5d42d499b375eb9cf65e80f628da07eb`; main CI failed in the Dashboard job at TypeScript typecheck.
- Draft until GitHub CI completes.