### PR TITLE
[codex] Improve keeper v2.3 fleet surface

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -185,7 +185,9 @@ describe('KeeperWorkspaceChat', () => {
 
     const slug = container.querySelector('.chat-head .sub .sub-ns') as HTMLElement | null
     expect(slug).toBeNull()
-    expect(container.querySelector('.kw-chat-name')?.textContent).toContain('sangsu')
+    expect(container.querySelector('.kw-chat-name')?.textContent).toContain('상수')
+    expect(container.querySelector('.kw-chat-name')?.textContent).not.toContain('~/wt/sangsu')
+    expect(container.querySelector('.kw-chat-name')?.textContent).not.toContain('skill-primary')
   })
 
   it('switches the mobile pane to roster when the back button is clicked', async () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.test.ts
@@ -166,13 +166,12 @@ describe('KeeperWorkspaceChat', () => {
     expect(container.querySelector('[data-testid="kw-sigil"]')?.textContent).toBe('sangsu')
     expect(container.querySelector('[data-testid="kw-conversation-panel"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="kw-chat-command-icons"]')).not.toBeNull()
-    // Prototype desktop header: only FSM glyphs + settings (⚙).
-    expect(container.querySelector('[data-testid="kw-chat-command-turn"]')).toBeNull()
-    expect(container.querySelector('[data-testid="kw-chat-command-artifacts"]')).toBeNull()
+    expect(container.querySelector('[data-testid="kw-chat-command-turn"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="kw-chat-command-artifacts"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="kw-chat-command-config"]')).not.toBeNull()
   })
 
-  it('renders the keeper scope/path slug under the chat name', async () => {
+  it('keeps runtime scope/path out of the slim chat header', async () => {
     const { KeeperWorkspaceChat } = await loadChat()
     const keeperWithSlug = { ...mockKeeper, sandbox_target: '~/wt/sangsu', skill_primary: 'skill-primary' }
 
@@ -185,8 +184,8 @@ describe('KeeperWorkspaceChat', () => {
     })
 
     const slug = container.querySelector('.chat-head .sub .sub-ns') as HTMLElement | null
-    expect(slug).not.toBeNull()
-    expect(slug?.textContent).toContain('~/wt/sangsu')
+    expect(slug).toBeNull()
+    expect(container.querySelector('.kw-chat-name')?.textContent).toContain('sangsu')
   })
 
   it('switches the mobile pane to roster when the back button is clicked', async () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -13,6 +13,7 @@ import { shellAuthSummary, tasks } from '../../store'
 import type { Keeper, Task } from '../../types'
 import { navigate } from '../../router'
 import { keeperActivityDisplay } from '../../lib/keeper-runtime-display'
+import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import {
   WorkspaceSigil,
   keeperBucket,
@@ -22,6 +23,7 @@ import {
   keeperRuntimeLabel,
   keeperStatusTone,
 } from './keeper-workspace-shared'
+import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
 import { CountBadge } from '../v2/primitives-v2'
 import { callMcpTool } from '../../api/mcp'
 import { showToast } from '../common/toast'
@@ -128,6 +130,25 @@ function formatCtxK(n: number | null | undefined): string | null {
   return `${Math.round(n / 1000)}k ctx`
 }
 
+const FLEET_ACTION_LABELS: Record<KeeperActionKey, string> = {
+  pause: '일시정지',
+  resume: '재개',
+  wakeup: '깨우기',
+  boot: '기동',
+  shutdown: '종료',
+}
+
+function fleetLifecycleActions(keeper: Keeper): KeeperActionKey[] {
+  const visibility = keeperActionVisibility(keeper)
+  const actions: KeeperActionKey[] = []
+  if (visibility.canBoot) actions.push('boot')
+  if (visibility.canResume) actions.push('resume')
+  if (visibility.canWake && !visibility.canBoot) actions.push('wakeup')
+  if (visibility.canPause) actions.push('pause')
+  if (visibility.canShutdown) actions.push('shutdown')
+  return actions
+}
+
 function keeperRecentTools(keeper: Keeper): string[] {
   const names = [
     ...(keeper.latest_tool_names ?? []),
@@ -148,6 +169,7 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
   const model = keeperModelLabel(keeper)
   const runtime = keeperRuntimeLabel(keeper)
   const lifecycle = keeper.phase || keeper.lifecycle_phase || keeper.status
+  const actions = fleetLifecycleActions(keeper).slice(0, 3)
   const openChat = () => {
     navigate('monitoring', { section: 'agents', keeper: keeper.name })
   }
@@ -185,6 +207,20 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
       </div>
       ${tools.length > 0
         ? html`<div class="kw-fleet-tools">${tools.map(tool => html`<span key=${tool} title=${tool}>${tool}</span>`)}</div>`
+        : null}
+      ${actions.length > 0
+        ? html`
+            <div class="kw-fleet-actions">
+              ${actions.map(action => html`
+                <button
+                  key=${action}
+                  type="button"
+                  class=${`kw-fleet-action${action === 'shutdown' ? ' danger' : ''}`}
+                  onClick=${() => void runKeeperAction(keeper.name, action)}
+                >${FLEET_ACTION_LABELS[action]}</button>
+              `)}
+            </div>
+          `
         : null}
     </div>
   `

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -185,7 +185,7 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
   const model = keeperModelLabel(keeper)
   const runtime = keeperRuntimeLabel(keeper)
   const lifecycle = keeper.phase || keeper.lifecycle_phase || keeper.status
-  const actions = fleetLifecycleActions(keeper).slice(0, 3)
+  const actions = fleetLifecycleActions(keeper).filter(action => action !== 'shutdown').slice(0, 3)
   const [pendingAction, setPendingAction] = useState<KeeperActionKey | null>(null)
   const openChat = () => {
     selectKeeper(keeper.name)
@@ -234,7 +234,7 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
                 <button
                   key=${action}
                   type="button"
-                  class=${`kw-fleet-action${action === 'shutdown' ? ' danger' : ''}${pendingAction === action ? ' busy' : ''}`}
+                  class=${`kw-fleet-action${pendingAction === action ? ' busy' : ''}`}
                   title=${`${keeper.name} ${FLEET_ACTION_LABELS[action]}`}
                   aria-label=${`${keeper.name} ${FLEET_ACTION_LABELS[action]}`}
                   aria-busy=${pendingAction === action ? 'true' : 'false'}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -235,6 +235,8 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
                   key=${action}
                   type="button"
                   class=${`kw-fleet-action${action === 'shutdown' ? ' danger' : ''}${pendingAction === action ? ' busy' : ''}`}
+                  title=${`${keeper.name} ${FLEET_ACTION_LABELS[action]}`}
+                  aria-label=${`${keeper.name} ${FLEET_ACTION_LABELS[action]}`}
                   aria-busy=${pendingAction === action ? 'true' : 'false'}
                   disabled=${pendingAction !== null}
                   onClick=${() => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -12,7 +12,16 @@ import type { VNode } from 'preact'
 import { shellAuthSummary, tasks } from '../../store'
 import type { Keeper, Task } from '../../types'
 import { navigate } from '../../router'
-import { keeperBucket, keeperModelLabel, keeperPhaseToken, keeperRuntimeLabel } from './keeper-workspace-shared'
+import { keeperActivityDisplay } from '../../lib/keeper-runtime-display'
+import {
+  WorkspaceSigil,
+  keeperBucket,
+  keeperModelLabel,
+  keeperPhaseLabel,
+  keeperPhaseToken,
+  keeperRuntimeLabel,
+  keeperStatusTone,
+} from './keeper-workspace-shared'
 import { CountBadge } from '../v2/primitives-v2'
 import { callMcpTool } from '../../api/mcp'
 import { showToast } from '../common/toast'
@@ -117,6 +126,68 @@ function AttentionSection({ keeper }: { keeper: Keeper }): VNode | null {
 function formatCtxK(n: number | null | undefined): string | null {
   if (typeof n !== 'number' || !Number.isFinite(n) || n <= 0) return null
   return `${Math.round(n / 1000)}k ctx`
+}
+
+function keeperRecentTools(keeper: Keeper): string[] {
+  const names = [
+    ...(keeper.latest_tool_names ?? []),
+    ...(keeper.recent_tool_names ?? []),
+  ].map(name => name.trim()).filter(Boolean)
+  if (names.length > 0) return Array.from(new Set(names)).slice(0, 4)
+  const count = keeper.latest_tool_call_count
+  return typeof count === 'number' && Number.isFinite(count) && count > 0 ? [`${count} tool calls`] : []
+}
+
+function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
+  const pressure = contextPercent(keeper) ?? 0
+  const tools = keeperRecentTools(keeper)
+  const taskCount = ownedTasks(keeper).length
+  const latestTps = keeper.metrics_series?.at(-1)?.wall_tokens_per_second
+  const activity = keeperActivityDisplay(keeper)
+  const phase = keeperPhaseLabel(keeper)
+  const model = keeperModelLabel(keeper)
+  const runtime = keeperRuntimeLabel(keeper)
+  const lifecycle = keeper.phase || keeper.lifecycle_phase || keeper.status
+  const openChat = () => {
+    navigate('monitoring', { section: 'agents', keeper: keeper.name })
+  }
+
+  return html`
+    <div class="kw-fleet-aside" data-tone=${keeperStatusTone(keeper)}>
+      <div class="kw-fleet-aside-head">
+        <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${keeperBucket(keeper) === 'running'} />
+        <div class="kw-fleet-aside-title">
+          <span class="kw-fleet-aside-kicker">Selected runtime</span>
+          <strong title=${keeper.agent_name || keeper.name}>${keeper.koreanName || keeper.agent_name || keeper.name}</strong>
+          <span title=${keeper.name}>${keeper.name}</span>
+        </div>
+        <span class="kw-fleet-aside-state">${keeper.status}</span>
+      </div>
+      <button type="button" class="kw-fleet-chat" onClick=${openChat}>대화 콘솔 열기</button>
+      <div class="kw-fleet-phase" title=${activity.source !== 'none' ? activity.label : phase}>
+        <b>${phase}</b>
+        <span>${activity.source !== 'none' ? activity.label : '최근 활동 미수신'}</span>
+      </div>
+      <div class="kw-fleet-pressure">
+        <div>
+          <span>Context pressure</span>
+          <strong>${pressure}%</strong>
+        </div>
+        <div class="kw-fleet-pressure-bar" aria-hidden="true"><i style=${{ width: `${pressure}%` }}></i></div>
+      </div>
+      <div class="kw-fleet-vitals">
+        <div><span>model</span><b title=${model ?? ''}>${model ?? '—'}</b></div>
+        <div><span>runtime</span><b title=${runtime ?? ''}>${runtime ?? '—'}</b></div>
+        <div><span>phase</span><b title=${lifecycle}>${lifecycle}</b></div>
+        <div><span>tps</span><b>${typeof latestTps === 'number' ? latestTps.toFixed(1) : '—'}</b></div>
+        <div><span>tools</span><b>${keeper.latest_tool_call_count ?? tools.length}</b></div>
+        <div><span>tasks</span><b>${taskCount}</b></div>
+      </div>
+      ${tools.length > 0
+        ? html`<div class="kw-fleet-tools">${tools.map(tool => html`<span key=${tool} title=${tool}>${tool}</span>`)}</div>`
+        : null}
+    </div>
+  `
 }
 
 function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
@@ -406,6 +477,7 @@ export function KeeperWorkspaceRail({
   return html`
     <aside class="ctx" aria-label="키퍼 컨텍스트">
       <div class="ctx-scroll">
+        <${FleetSelectedSection} keeper=${keeper} />
         <${AttentionSection} keeper=${keeper} />
         <${ThroughputSection} keeper=${keeper} />
         <${RuntimeSection} keeper=${keeper} />

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -12,6 +12,8 @@ import type { VNode } from 'preact'
 import { shellAuthSummary, tasks } from '../../store'
 import type { Keeper, Task } from '../../types'
 import { navigate } from '../../router'
+import { selectKeeper } from '../../keeper-runtime'
+import { keeperMobilePane } from '../keeper-detail-state'
 import { keeperActivityDisplay } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import {
@@ -171,6 +173,8 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
   const lifecycle = keeper.phase || keeper.lifecycle_phase || keeper.status
   const actions = fleetLifecycleActions(keeper).slice(0, 3)
   const openChat = () => {
+    selectKeeper(keeper.name)
+    keeperMobilePane.value = 'chat'
     navigate('monitoring', { section: 'agents', keeper: keeper.name })
   }
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -132,6 +132,15 @@ function formatCtxK(n: number | null | undefined): string | null {
   return `${Math.round(n / 1000)}k ctx`
 }
 
+function keeperFleetTone(keeper: Keeper) {
+  if (
+    keeper.needs_attention === true
+    || (keeper.blocked_task_count ?? 0) > 0
+    || keeper.current_gate?.kind === 'approval_required'
+  ) return 'bad'
+  return keeperStatusTone(keeper)
+}
+
 const FLEET_ACTION_LABELS: Record<KeeperActionKey, string> = {
   pause: '일시정지',
   resume: '재개',
@@ -179,7 +188,7 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
   }
 
   return html`
-    <div class="kw-fleet-aside" data-tone=${keeperStatusTone(keeper)}>
+    <div class="kw-fleet-aside" data-tone=${keeperFleetTone(keeper)}>
       <div class="kw-fleet-aside-head">
         <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${keeperBucket(keeper) === 'running'} />
         <div class="kw-fleet-aside-title">

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -19,11 +19,11 @@ import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import {
   WorkspaceSigil,
   keeperBucket,
+  keeperFleetTone,
   keeperModelLabel,
   keeperPhaseLabel,
   keeperPhaseToken,
   keeperRuntimeLabel,
-  keeperStatusTone,
 } from './keeper-workspace-shared'
 import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
 import { CountBadge } from '../v2/primitives-v2'
@@ -132,15 +132,6 @@ function formatCtxK(n: number | null | undefined): string | null {
   return `${Math.round(n / 1000)}k ctx`
 }
 
-function keeperFleetTone(keeper: Keeper) {
-  if (
-    keeper.needs_attention === true
-    || (keeper.blocked_task_count ?? 0) > 0
-    || keeper.current_gate?.kind === 'approval_required'
-  ) return 'bad'
-  return keeperStatusTone(keeper)
-}
-
 const FLEET_ACTION_LABELS: Record<KeeperActionKey, string> = {
   pause: '일시정지',
   resume: '재개',
@@ -176,7 +167,7 @@ function keeperRecentTools(keeper: Keeper): string[] {
 }
 
 function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
-  const pressure = contextPercent(keeper) ?? 0
+  const pressure = contextPercent(keeper)
   const tools = keeperRecentTools(keeper)
   const taskCount = ownedTasks(keeper).length
   const latestTps = keeper.metrics_series?.at(-1)?.wall_tokens_per_second
@@ -212,9 +203,9 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
       <div class="kw-fleet-pressure">
         <div>
           <span>Context pressure</span>
-          <strong>${pressure}%</strong>
+          <strong>${pressure === null ? '—' : `${pressure}%`}</strong>
         </div>
-        <div class="kw-fleet-pressure-bar" aria-hidden="true"><i style=${{ width: `${pressure}%` }}></i></div>
+        <div class="kw-fleet-pressure-bar" aria-hidden="true"><i style=${{ width: `${pressure ?? 0}%` }}></i></div>
       </div>
       <div class="kw-fleet-vitals">
         <div><span>model</span><b title=${model ?? ''}>${model ?? '—'}</b></div>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -186,6 +186,7 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
   const runtime = keeperRuntimeLabel(keeper)
   const lifecycle = keeper.phase || keeper.lifecycle_phase || keeper.status
   const actions = fleetLifecycleActions(keeper).slice(0, 3)
+  const [pendingAction, setPendingAction] = useState<KeeperActionKey | null>(null)
   const openChat = () => {
     selectKeeper(keeper.name)
     keeperMobilePane.value = 'chat'
@@ -233,9 +234,15 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
                 <button
                   key=${action}
                   type="button"
-                  class=${`kw-fleet-action${action === 'shutdown' ? ' danger' : ''}`}
-                  onClick=${() => void runFleetKeeperAction(keeper.name, action)}
-                >${FLEET_ACTION_LABELS[action]}</button>
+                  class=${`kw-fleet-action${action === 'shutdown' ? ' danger' : ''}${pendingAction === action ? ' busy' : ''}`}
+                  aria-busy=${pendingAction === action ? 'true' : 'false'}
+                  disabled=${pendingAction !== null}
+                  onClick=${() => {
+                    if (pendingAction !== null) return
+                    setPendingAction(action)
+                    void runFleetKeeperAction(keeper.name, action).finally(() => setPendingAction(null))
+                  }}
+                >${pendingAction === action ? '실행중' : FLEET_ACTION_LABELS[action]}</button>
               `)}
             </div>
           `

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -160,6 +160,11 @@ function fleetLifecycleActions(keeper: Keeper): KeeperActionKey[] {
   return actions
 }
 
+async function runFleetKeeperAction(name: string, action: KeeperActionKey): Promise<void> {
+  await runKeeperAction(name, action)
+  await refreshAfterRuntimeAction()
+}
+
 function keeperRecentTools(keeper: Keeper): string[] {
   const names = [
     ...(keeper.latest_tool_names ?? []),
@@ -229,7 +234,7 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
                   key=${action}
                   type="button"
                   class=${`kw-fleet-action${action === 'shutdown' ? ' danger' : ''}`}
-                  onClick=${() => void runKeeperAction(keeper.name, action)}
+                  onClick=${() => void runFleetKeeperAction(keeper.name, action)}
                 >${FLEET_ACTION_LABELS[action]}</button>
               `)}
             </div>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -48,10 +48,10 @@ afterEach(() => {
 })
 
 describe('KeeperWorkspaceRoster', () => {
-  it('renders attention-first groups with keeper rows', () => {
+  it('renders attention first while preserving status groups', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     const labels = Array.from(host.querySelectorAll('.kw-roster-group-label')).map(g => g.textContent)
-    expect(labels).toEqual(['주의 필요', '정상'])
+    expect(labels).toEqual(['주의 필요', '실행 중', '대기 · 일시정지'])
     expect(host.querySelectorAll('.kw-kp-row').length).toBe(3)
   })
 
@@ -211,9 +211,10 @@ describe('KeeperWorkspaceRoster', () => {
     const headers = Array.from(host.querySelectorAll('.kw-roster-group'))
     expect(headers.map(h => h.textContent)).toEqual([
       expect.stringContaining('주의 필요'),
-      expect.stringContaining('정상'),
+      expect.stringContaining('실행 중'),
+      expect.stringContaining('대기 · 일시정지'),
     ])
-    expect(Array.from(host.querySelectorAll('.kw-roster-group-n')).map(n => n.textContent)).toEqual(['1', '2'])
+    expect(Array.from(host.querySelectorAll('.kw-roster-group-n')).map(n => n.textContent)).toEqual(['1', '1', '1'])
   })
 
   it('filters by search query', () => {
@@ -276,7 +277,7 @@ describe('KeeperWorkspaceRoster', () => {
     expect(host.querySelector('.virtual-list-spacer')).not.toBeNull()
     expect(host.querySelector('.kw-roster-list')).not.toBeNull()
     // The windowed path renders the group header through the same renderHeader().
-    expect(host.querySelector('.kw-roster-group .kw-roster-group-label')?.textContent).toBe('정상')
+    expect(host.querySelector('.kw-roster-group .kw-roster-group-label')?.textContent).toBe('실행 중')
   })
 
   it('renders the sort select defaulting to status order', () => {
@@ -349,8 +350,19 @@ describe('KeeperWorkspaceRoster', () => {
   it('renders a per-group keeper count in the status group header', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     const counts = Array.from(host.querySelectorAll('.kw-roster-group-n')).map(n => n.textContent)
-    // FIXTURE: 1 attention row (rama), 2 calm rows (masc-improver, sangsu)
-    expect(counts).toEqual(['1', '2'])
+    // FIXTURE: 1 attention row (rama), then running and paused status buckets.
+    expect(counts).toEqual(['1', '1', '1'])
+  })
+
+  it('does not label calm offline keepers as normal', () => {
+    keepers.value = [
+      mk({ name: 'run', status: 'running', lifecycle_phase: 'Running' }),
+      mk({ name: 'off', status: 'stopped', lifecycle_phase: 'Stopped' }),
+    ]
+    render(html`<${KeeperWorkspaceRoster} activeName="run" />`, host)
+
+    const labels = Array.from(host.querySelectorAll('.kw-roster-group-label')).map(g => g.textContent)
+    expect(labels).toEqual(['실행 중', '중지 · 종료됨'])
   })
 
   it('closes the row command menu on Escape only (not on any keypress) and on scroll', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -10,6 +10,9 @@ vi.mock('../../router', async (orig) => ({
 vi.mock('../keeper-action-panel', () => ({
   runKeeperAction: vi.fn(async () => undefined),
 }))
+vi.mock('../keeper-detail-helpers', () => ({
+  refreshAfterRuntimeAction: vi.fn(async () => undefined),
+}))
 
 import { navigate } from '../../router'
 import { keepers } from '../../store'
@@ -45,26 +48,22 @@ afterEach(() => {
 })
 
 describe('KeeperWorkspaceRoster', () => {
-  it('renders status groups with keeper rows', () => {
+  it('renders attention-first groups with keeper rows', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    // Prototype group headers (`.roster-group`) carry the SHORT label as text
-    // and the full label in the `title` attribute (rails.jsx groupLabel).
-    const titles = Array.from(host.querySelectorAll('.roster-group')).map(g => g.getAttribute('title'))
-    expect(titles).toContain('실행 중')
-    expect(titles).toContain('대기 · 일시정지')
-    expect(titles).toContain('중지 · 종료됨')
-    expect(host.querySelectorAll('.kp-row').length).toBe(3)
+    const labels = Array.from(host.querySelectorAll('.kw-roster-group-label')).map(g => g.textContent)
+    expect(labels).toEqual(['주의 필요', '정상'])
+    expect(host.querySelectorAll('.kw-kp-row').length).toBe(3)
   })
 
   it('marks the active keeper row', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const active = host.querySelector('.kp-row[aria-current="true"]') as HTMLElement
+    const active = host.querySelector('.kw-kp-row[aria-current="true"]') as HTMLElement
     expect(active?.textContent).toContain('masc-improver')
   })
 
   it('shows filter chip counts (all / running / attention)', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const chips = Array.from(host.querySelectorAll('.rfilter')).map(c => c.textContent)
+    const chips = Array.from(host.querySelectorAll('.kw-rfilter')).map(c => c.textContent)
     // 전체 3, 실행 1 (only masc-improver), 주의 1 (rama)
     expect(chips.some(c => c?.includes('전체') && c?.includes('3'))).toBe(true)
     expect(chips.some(c => c?.includes('실행') && c?.includes('1'))).toBe(true)
@@ -75,7 +74,7 @@ describe('KeeperWorkspaceRoster', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     // v2 dropped the standalone "Keepers" title; the total count now lives on
     // the 전체 filter chip in the .roster-filters band.
-    const allChip = Array.from(host.querySelectorAll('.rfilter')).find(c => c.textContent?.includes('전체'))
+    const allChip = Array.from(host.querySelectorAll('.kw-rfilter')).find(c => c.textContent?.includes('전체'))
     expect(allChip).not.toBeUndefined()
     expect(allChip?.textContent).toContain('3')
   })
@@ -117,7 +116,7 @@ describe('KeeperWorkspaceRoster', () => {
     // switch the single-pane mobile layout over to that keeper's chat.
     keeperMobilePane.value = 'roster'
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" onSelect=${onSelect} />`, host)
-    const rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
+    const rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
     const sangsuRow = rows.find(r => r.textContent?.includes('sangsu'))
     sangsuRow?.click()
     expect(navigate).toHaveBeenCalledWith('monitoring', { section: 'agents', keeper: 'sangsu' })
@@ -181,7 +180,7 @@ describe('KeeperWorkspaceRoster', () => {
   it('opens the command menu on right-click (contextmenu) without selecting the row', () => {
     const onSelect = vi.fn()
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" onSelect=${onSelect} />`, host)
-    const rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
+    const rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
     const sangsuRow = rows.find(r => r.textContent?.includes('sangsu')) as HTMLElement
 
     // fireEvent returns false when the (cancelable) event had preventDefault
@@ -198,7 +197,7 @@ describe('KeeperWorkspaceRoster', () => {
 
   it('opens the command menu on right-click of a mini-roster sigil', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" mini=${true} />`, host)
-    const minis = Array.from(host.querySelectorAll('.kp-row.mini')) as HTMLElement[]
+    const minis = Array.from(host.querySelectorAll('.kw-kp-mini')) as HTMLElement[]
     const ramaMini = minis.find(b => (b.getAttribute('aria-label') ?? '').includes('rama')) as HTMLElement
 
     fireEvent.contextMenu(ramaMini, { clientX: 60, clientY: 200 })
@@ -207,50 +206,31 @@ describe('KeeperWorkspaceRoster', () => {
     expect(host.querySelector('[data-testid="kw-roster-menu"]')?.textContent).toContain('rama')
   })
 
-  it('renders a status-toned dot in each group header (rg-dot)', () => {
+  it('renders the v2.3 attention-first group headers with counts', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    // The prototype header (`.roster-group`) carries the status tone via its
-    // own bucket class (run/pause/off) and renders an untoned `.rg-dot` pip;
-    // the full status label is in the `title` attribute. Headers are keyed by
-    // the full label.
-    const groupTone = (label: string): { hasDot: boolean; cls: string | undefined } => {
-      const header = Array.from(host.querySelectorAll('.roster-group')).find(
-        g => g.getAttribute('title') === label,
-      )
-      return { hasDot: !!header?.querySelector('.rg-dot'), cls: header?.className }
-    }
-    // running → run, paused → pause, offline → off (the 3 prototype buckets,
-    // 1:1 with the old ok/warn/idle tones).
-    const running = groupTone('실행 중')
-    expect(running.hasDot).toBe(true)
-    expect(running.cls).toContain('run')
-    const paused = groupTone('대기 · 일시정지')
-    expect(paused.hasDot).toBe(true)
-    expect(paused.cls).toContain('pause')
-    const offline = groupTone('중지 · 종료됨')
-    expect(offline.hasDot).toBe(true)
-    expect(offline.cls).toContain('off')
-    expect(offline.cls).not.toContain('run')
-    expect(offline.cls).not.toContain('pause')
+    const headers = Array.from(host.querySelectorAll('.kw-roster-group'))
+    expect(headers.map(h => h.textContent)).toEqual([
+      expect.stringContaining('주의 필요'),
+      expect.stringContaining('정상'),
+    ])
+    expect(Array.from(host.querySelectorAll('.kw-roster-group-n')).map(n => n.textContent)).toEqual(['1', '2'])
   })
 
   it('filters by search query', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    // Prototype gates the search box behind the `.rfilter-icon` toggle.
-    fireEvent.click(host.querySelector('.rfilter-icon') as HTMLButtonElement)
-    const search = host.querySelector('.roster-search') as HTMLInputElement
+    const search = host.querySelector('.kw-roster-search') as HTMLInputElement
     fireEvent.input(search, { target: { value: 'rama' } })
-    const rows = host.querySelectorAll('.kp-row')
+    const rows = host.querySelectorAll('.kw-kp-row')
     expect(rows.length).toBe(1)
     expect(rows[0]?.textContent).toContain('rama')
   })
 
   it('sorts the roster by name and attention count', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const sort = host.querySelector('.roster-sort') as HTMLSelectElement
+    const sort = host.querySelector('.kw-roster-sort') as HTMLSelectElement
 
     fireEvent.change(sort, { target: { value: 'name' } })
-    let rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
+    let rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
     expect(rows.map(r => r.textContent ?? '')).toEqual([
       expect.stringContaining('masc-improver'),
       expect.stringContaining('rama'),
@@ -258,16 +238,16 @@ describe('KeeperWorkspaceRoster', () => {
     ])
 
     fireEvent.change(sort, { target: { value: 'att' } })
-    rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
+    rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
     expect(rows[0]?.textContent).toContain('rama')
   })
 
   it('renders a compact sigil-only roster in mini mode', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" mini=${true} />`, host)
-    expect(host.querySelector('.roster-search')).toBeNull()
-    expect(host.querySelector('.roster-sort')).toBeNull()
-    expect(host.querySelectorAll('.kp-row.mini').length).toBe(3)
-    expect(host.querySelector('.kp-row.mini[aria-current="true"]')).not.toBeNull()
+    expect(host.querySelector('.kw-roster-search')).toBeNull()
+    expect(host.querySelector('.kw-roster-sort')).toBeNull()
+    expect(host.querySelectorAll('.kw-kp-mini').length).toBe(3)
+    expect(host.querySelector('.kw-kp-mini[aria-current="true"]')).not.toBeNull()
   })
 
   // The per-row work-preview line (.kw-kp-work — recent_output >
@@ -282,7 +262,7 @@ describe('KeeperWorkspaceRoster', () => {
   it('uses content-visibility:auto on plain-list rows below the virtualization threshold', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     expect(host.querySelector('.virtual-list-spacer')).toBeNull()
-    const rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
+    const rows = Array.from(host.querySelectorAll('.kw-kp-row')) as HTMLElement[]
     expect(rows.length).toBeGreaterThan(0)
     expect(rows.every(r => r.style.contentVisibility === 'auto')).toBe(true)
   })
@@ -294,31 +274,29 @@ describe('KeeperWorkspaceRoster', () => {
     )
     render(html`<${KeeperWorkspaceRoster} activeName="keeper-0" />`, host)
     expect(host.querySelector('.virtual-list-spacer')).not.toBeNull()
-    expect(host.querySelector('.roster-list')).not.toBeNull()
-    // The windowed path renders the group header through the same renderHeader(),
-    // so the toned header must appear here too (all 60 keepers are running → the
-    // `.roster-group.run` bucket with its `.rg-dot` pip).
-    expect(host.querySelector('.roster-group.run .rg-dot')).not.toBeNull()
+    expect(host.querySelector('.kw-roster-list')).not.toBeNull()
+    // The windowed path renders the group header through the same renderHeader().
+    expect(host.querySelector('.kw-roster-group .kw-roster-group-label')?.textContent).toBe('정상')
   })
 
   it('renders the sort select defaulting to status order', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const sortSel = host.querySelector('.roster-sort') as HTMLSelectElement
+    const sortSel = host.querySelector('.kw-roster-sort') as HTMLSelectElement
     expect(sortSel).not.toBeNull()
     expect(sortSel.value).toBe('status')
     expect(Array.from(sortSel.options).map(o => o.value)).toEqual(['status', 'name', 'att'])
     // status mode keeps the bucket group headers
-    expect(host.querySelectorAll('.roster-group').length).toBeGreaterThan(0)
+    expect(host.querySelectorAll('.kw-roster-group').length).toBeGreaterThan(0)
   })
 
   it('sorts by name into a flat alphabetical list with no group headers', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    fireEvent.change(host.querySelector('.roster-sort') as HTMLSelectElement, {
+    fireEvent.change(host.querySelector('.kw-roster-sort') as HTMLSelectElement, {
       target: { value: 'name' },
     })
     // flat list → status group headers disappear
-    expect(host.querySelectorAll('.roster-group').length).toBe(0)
-    const order = Array.from(host.querySelectorAll('.kp-row')).map(r =>
+    expect(host.querySelectorAll('.kw-roster-group').length).toBe(0)
+    const order = Array.from(host.querySelectorAll('.kw-kp-row')).map(r =>
       r.textContent?.includes('masc-improver') ? 'masc-improver' : r.textContent?.includes('rama') ? 'rama' : 'sangsu',
     )
     expect(order).toEqual(['masc-improver', 'rama', 'sangsu'])
@@ -331,10 +309,10 @@ describe('KeeperWorkspaceRoster', () => {
       mk({ name: 'flagged', status: 'running', needs_attention: true }),
     ]
     render(html`<${KeeperWorkspaceRoster} activeName="calm" />`, host)
-    fireEvent.change(host.querySelector('.roster-sort') as HTMLSelectElement, {
+    fireEvent.change(host.querySelector('.kw-roster-sort') as HTMLSelectElement, {
       target: { value: 'att' },
     })
-    const order = Array.from(host.querySelectorAll('.kp-row')).map(r =>
+    const order = Array.from(host.querySelectorAll('.kw-kp-row')).map(r =>
       r.textContent?.includes('blocked-3') ? 'blocked-3' : r.textContent?.includes('flagged') ? 'flagged' : 'calm',
     )
     // blocked-3 (score 3) > flagged (flag → score 1) > calm (score 0)
@@ -344,7 +322,7 @@ describe('KeeperWorkspaceRoster', () => {
   it('shows the keeper basepath (sandbox_target) as the row sub-line, shortened with a full-path title', () => {
     keepers.value = [mk({ name: 'miso', status: 'running', sandbox_target: '/workspace/keepers/keeper-miso' })]
     render(html`<${KeeperWorkspaceRoster} activeName="miso" />`, host)
-    const handle = host.querySelector('.kp-handle') as HTMLElement
+    const handle = host.querySelector('.kw-kp-handle') as HTMLElement
     expect(handle?.textContent).toBe('…/keepers/keeper-miso')
     expect(handle?.getAttribute('title')).toBe('/workspace/keepers/keeper-miso')
   })
@@ -352,7 +330,7 @@ describe('KeeperWorkspaceRoster', () => {
   it('falls back to the scope proxy when a keeper has no sandbox_target', () => {
     keepers.value = [mk({ name: 'nobase', status: 'running', model: 'anthropic/claude-x' })]
     render(html`<${KeeperWorkspaceRoster} activeName="nobase" />`, host)
-    const handle = host.querySelector('.kp-handle') as HTMLElement
+    const handle = host.querySelector('.kw-kp-handle') as HTMLElement
     expect(handle?.textContent).toBe('anthropic/claude-x')
   })
 
@@ -362,19 +340,17 @@ describe('KeeperWorkspaceRoster', () => {
       mk({ name: 'beta', status: 'running', sandbox_target: '/srv/worktrees/beta-tree' }),
     ]
     render(html`<${KeeperWorkspaceRoster} activeName="alpha" />`, host)
-    // Prototype gates the search box behind the `.rfilter-icon` toggle.
-    fireEvent.click(host.querySelector('.rfilter-icon') as HTMLButtonElement)
-    fireEvent.input(host.querySelector('.roster-search') as HTMLInputElement, { target: { value: 'beta-tree' } })
-    const rows = host.querySelectorAll('.kp-row')
+    fireEvent.input(host.querySelector('.kw-roster-search') as HTMLInputElement, { target: { value: 'beta-tree' } })
+    const rows = host.querySelectorAll('.kw-kp-row')
     expect(rows.length).toBe(1)
     expect(rows[0]?.textContent).toContain('beta')
   })
 
   it('renders a per-group keeper count in the status group header', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
-    const counts = Array.from(host.querySelectorAll('.rg-n')).map(n => n.textContent)
-    // FIXTURE: 1 running, 1 paused, 1 stopped
-    expect(counts).toEqual(['1', '1', '1'])
+    const counts = Array.from(host.querySelectorAll('.kw-roster-group-n')).map(n => n.textContent)
+    // FIXTURE: 1 attention row (rama), 2 calm rows (masc-improver, sangsu)
+    expect(counts).toEqual(['1', '2'])
   })
 
   it('closes the row command menu on Escape only (not on any keypress) and on scroll', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -40,6 +40,7 @@ type RosterSort = 'status' | 'name' | 'att'
 type KeeperWorkspaceRouteSurface = 'monitoring' | 'keepers'
 type RosterMenuState = { keeper: Keeper; x: number; y: number } | null
 type IconComponent = typeof Play
+type RosterHeaderBucket = KeeperBucket | 'attention' | 'normal'
 type RosterFleetSummary = {
   total: number
   running: number
@@ -82,16 +83,12 @@ const MENU_WIDTH = 190
 const MENU_ESTIMATED_HEIGHT = 246
 const MENU_VIEWPORT_MARGIN = 8
 
-const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
-  { bucket: 'running', label: '실행 중' },
-  { bucket: 'paused', label: '대기 · 일시정지' },
-  { bucket: 'offline', label: '중지 · 종료됨' },
-]
-
 /** Group-header status dot tone (design rails.jsx `.rg-dot` colored by groupCls).
  *  Reuses the shared StatusDot vocabulary instead of a bespoke dot so the header
  *  marker matches the per-row dots: running→ok, paused→warn, offline→idle. */
-const GROUP_BUCKET_TONE: Record<KeeperBucket, DotTone> = {
+const GROUP_BUCKET_TONE: Record<RosterHeaderBucket, DotTone> = {
+  attention: 'bad',
+  normal: 'ok',
   running: 'ok',
   paused: 'warn',
   offline: 'idle',
@@ -99,7 +96,7 @@ const GROUP_BUCKET_TONE: Record<KeeperBucket, DotTone> = {
 
 /** Flattened roster item used by the virtualized render path. */
 type RosterItem =
-  | { type: 'header'; bucket: KeeperBucket; label: string; count: number }
+  | { type: 'header'; bucket: RosterHeaderBucket; label: string; count: number }
   | { type: 'row'; keeper: Keeper }
 
 /** Switch to the shared VirtualList once the roster is long enough that DOM
@@ -114,6 +111,43 @@ function attentionCount(keeper: Keeper): number {
 }
 function needsAttention(keeper: Keeper): boolean {
   return keeper.needs_attention === true || attentionCount(keeper) > 0
+}
+
+function keeperContextRatio(keeper: Keeper): number {
+  if (typeof keeper.context_ratio === 'number' && Number.isFinite(keeper.context_ratio)) {
+    return Math.max(0, Math.min(1, keeper.context_ratio))
+  }
+  const current = keeper.context_tokens ?? keeper.context?.context_tokens ?? 0
+  const max = keeper.context_max ?? keeper.context?.context_max ?? 0
+  return max > 0 ? Math.max(0, Math.min(1, current / max)) : 0
+}
+
+function keeperAttentionGloss(keeper: Keeper): string {
+  const bits: string[] = []
+  const blocked = keeper.blocked_task_count ?? 0
+  if (blocked > 0) bits.push(`차단 ${blocked}건`)
+  if (keeper.current_gate?.kind === 'approval_required') bits.push('승인 대기')
+  const blocker = keeper.runtime_blocker_summary?.trim()
+  const reason = keeper.attention_reason?.trim()
+  const action = keeper.next_human_action?.trim()
+  if (blocker) bits.push(blocker)
+  if (reason) bits.push(reason)
+  if (action) bits.push(action)
+  if (bits.length > 0) return bits.slice(0, 2).join(' · ')
+  return keeperPhaseLabel(keeper) || keeperWorkPreview(keeper) || '최근 상태 미수신'
+}
+
+function keeperStatusRank(keeper: Keeper): number {
+  const bucket = keeperBucket(keeper)
+  if (bucket === 'running') return 0
+  if (bucket === 'paused') return 1
+  return 2
+}
+
+function compareFleetRows(a: Keeper, b: Keeper): number {
+  return keeperStatusRank(a) - keeperStatusRank(b)
+    || keeperContextRatio(b) - keeperContextRatio(a)
+    || a.name.localeCompare(b.name)
 }
 
 export function rosterFleetSummary(rows: readonly Keeper[]): RosterFleetSummary {
@@ -134,7 +168,7 @@ export function rosterFleetSummary(rows: readonly Keeper[]): RosterFleetSummary 
     if (bucket === 'offline') summary.offline += 1
     if (needsAttention(keeper)) summary.attention += 1
     if (keeper.current_gate?.kind === 'approval_required') summary.approvalGate += 1
-    if (typeof keeper.context_ratio === 'number' && Number.isFinite(keeper.context_ratio) && keeper.context_ratio >= 0.8) {
+    if (keeperContextRatio(keeper) >= 0.8) {
       summary.highContext += 1
     }
   }
@@ -155,7 +189,7 @@ function attentionScore(keeper: Keeper): number {
  *  the order is stable. */
 function compareKeepers(a: Keeper, b: Keeper, sort: Exclude<RosterSort, 'status'>): number {
   if (sort === 'name') return a.name.localeCompare(b.name)
-  return attentionScore(b) - attentionScore(a) || a.name.localeCompare(b.name)
+  return attentionScore(b) - attentionScore(a) || keeperContextRatio(b) - keeperContextRatio(a) || a.name.localeCompare(b.name)
 }
 
 /** ns proxy: keepers have no namespace field; the skill path is the closest
@@ -245,6 +279,7 @@ function RosterRow({
   const activity = keeperActivityDisplay(keeper)
   const work = keeperWorkPreview(keeper)
   const recentTool = keeperRecentTool(keeper)
+  const gloss = keeperAttentionGloss(keeper)
   const select = () => onSelect(keeper.name)
   return html`
     <div
@@ -269,6 +304,7 @@ function RosterRow({
           <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${bucket === 'running'} />${keeperPhaseLabel(keeper)}</span>
           ${handle ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle" title=${handleTitle}>${handle}</span>` : null}
         </div>
+        <div class="kw-kp-gloss" title=${gloss}>${gloss}</div>
         <div class="kw-kp-work" title=${work ?? ''}>${work ?? '최근 작업 요약 없음'}</div>
         ${contextPct !== null
           ? html`
@@ -293,6 +329,19 @@ function RosterRow({
         ${activity.source !== 'none' ? html`<span class="kw-kp-time">${activity.label}</span>` : null}
         ${att > 0 ? html`<span class="kw-kp-att" title=${`주의 ${att}건`}>${att}</span>` : null}
       </div>
+      <button
+        type="button"
+        class="kw-kp-chat v2-monitoring-action"
+        aria-label=${`${keeper.name} 대화 열기`}
+        title="대화 열기"
+        onClick=${(event: MouseEvent) => {
+          event.preventDefault()
+          event.stopPropagation()
+          select()
+        }}
+      >
+        <${MessageSquare} size=${14} aria-hidden="true" />
+      </button>
       <button
         type="button"
         class="kw-kp-more v2-monitoring-action"
@@ -566,13 +615,19 @@ export function KeeperWorkspaceRoster({
   // headers, mirroring the v2 roster sort modes (rails.jsx Roster).
   const items: RosterItem[] = []
   if (sort === 'status') {
-    for (const group of GROUP_ORDER) {
-      const rows = visible.filter(k => keeperBucket(k) === group.bucket)
-      if (rows.length === 0) continue
-      items.push({ type: 'header', bucket: group.bucket, label: group.label, count: rows.length })
-      for (const keeper of rows) {
-        items.push({ type: 'row', keeper })
-      }
+    const attentionRows = visible.filter(needsAttention).sort((a, b) =>
+      attentionScore(b) - attentionScore(a)
+      || keeperContextRatio(b) - keeperContextRatio(a)
+      || a.name.localeCompare(b.name),
+    )
+    const normalRows = visible.filter(k => !needsAttention(k)).sort(compareFleetRows)
+    if (attentionRows.length > 0) {
+      items.push({ type: 'header', bucket: 'attention', label: '주의 필요', count: attentionRows.length })
+      for (const keeper of attentionRows) items.push({ type: 'row', keeper })
+    }
+    if (normalRows.length > 0) {
+      items.push({ type: 'header', bucket: 'normal', label: '정상', count: normalRows.length })
+      for (const keeper of normalRows) items.push({ type: 'row', keeper })
     }
   } else {
     for (const keeper of sortRows(visible)) {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -30,6 +30,7 @@ import {
   WorkspaceSigil,
   StatusDot,
   keeperBucket,
+  keeperFleetTone,
   keeperStatusTone,
   keeperPhaseLabel,
   type KeeperBucket,
@@ -117,11 +118,6 @@ function attentionCount(keeper: Keeper): number {
 }
 function needsAttention(keeper: Keeper): boolean {
   return keeper.needs_attention === true || attentionCount(keeper) > 0
-}
-
-function keeperFleetTone(keeper: Keeper): DotTone {
-  if (needsAttention(keeper) || keeper.current_gate?.kind === 'approval_required') return 'bad'
-  return keeperStatusTone(keeper)
 }
 
 function keeperContextRatio(keeper: Keeper): number {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -103,7 +103,7 @@ type RosterItem =
  *  weight matters. Below this we keep the identical grouped DOM structure and
  *  rely on content-visibility:auto for cheap off-screen skipping. */
 const WINDOW_AT = 60
-const ROSTER_ROW_ESTIMATED_HEIGHT = 92
+const ROSTER_ROW_ESTIMATED_HEIGHT = 108
 
 /** Blocked tasks + explicit attention flag → the roster attention badge. */
 function attentionCount(keeper: Keeper): number {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -287,6 +287,7 @@ function RosterRow({
   const recentTool = keeperRecentTool(keeper)
   const gloss = keeperAttentionGloss(keeper)
   const inlineActions = lifecycleActions(keeper).filter(action => action !== 'shutdown').slice(0, 2)
+  const [pendingAction, setPendingAction] = useState<KeeperActionKey | null>(null)
   const select = () => onSelect(keeper.name)
   return html`
     <div
@@ -359,17 +360,21 @@ function RosterRow({
                   <button
                     key=${action}
                     type="button"
-                    class="kw-kp-inline-action v2-monitoring-action"
+                    class=${`kw-kp-inline-action v2-monitoring-action${pendingAction === action ? ' busy' : ''}`}
                     title=${copy.title}
                     aria-label=${`${keeper.name} ${copy.label}`}
+                    aria-busy=${pendingAction === action ? 'true' : 'false'}
+                    disabled=${pendingAction !== null}
                     onClick=${(event: MouseEvent) => {
                       event.preventDefault()
                       event.stopPropagation()
-                      void runRosterKeeperAction(keeper.name, action)
+                      if (pendingAction !== null) return
+                      setPendingAction(action)
+                      void runRosterKeeperAction(keeper.name, action).finally(() => setPendingAction(null))
                     }}
                   >
                     <${Icon} size=${13} aria-hidden="true" />
-                    <span>${copy.label}</span>
+                    <span>${pendingAction === action ? '실행중' : copy.label}</span>
                   </button>
                 `
               })}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -24,6 +24,7 @@ import { keeperActivityDisplay, keeperWorkPreview } from '../../lib/keeper-runti
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import type { Keeper } from '../../types'
 import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
+import { refreshAfterRuntimeAction } from '../keeper-detail-helpers'
 import { VirtualList } from '../common/virtual-list'
 import {
   WorkspaceSigil,
@@ -364,7 +365,7 @@ function RosterRow({
                     onClick=${(event: MouseEvent) => {
                       event.preventDefault()
                       event.stopPropagation()
-                      void runKeeperAction(keeper.name, action)
+                      void runRosterKeeperAction(keeper.name, action)
                     }}
                   >
                     <${Icon} size=${13} aria-hidden="true" />
@@ -428,6 +429,11 @@ function lifecycleActions(keeper: Keeper): KeeperActionKey[] {
   if (visibility.canPause) actions.push('pause')
   if (visibility.canShutdown) actions.push('shutdown')
   return actions
+}
+
+async function runRosterKeeperAction(name: string, action: KeeperActionKey): Promise<void> {
+  await runKeeperAction(name, action)
+  await refreshAfterRuntimeAction()
 }
 
 function pct(count: number, total: number): string {
@@ -510,7 +516,7 @@ function KeeperRosterMenu({
             class=${`kw-kp-menu-item${copy.danger ? ' danger' : ''}`}
             title=${copy.title}
             onClick=${() => {
-              void runKeeperAction(keeper.name, action)
+              void runRosterKeeperAction(keeper.name, action)
               onClose()
             }}
             data-testid=${`kw-roster-menu-${action}`}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -41,7 +41,7 @@ type RosterSort = 'status' | 'name' | 'att'
 type KeeperWorkspaceRouteSurface = 'monitoring' | 'keepers'
 type RosterMenuState = { keeper: Keeper; x: number; y: number } | null
 type IconComponent = typeof Play
-type RosterHeaderBucket = KeeperBucket | 'attention' | 'normal'
+type RosterHeaderBucket = KeeperBucket | 'attention'
 type RosterFleetSummary = {
   total: number
   running: number
@@ -84,12 +84,17 @@ const MENU_WIDTH = 190
 const MENU_ESTIMATED_HEIGHT = 246
 const MENU_VIEWPORT_MARGIN = 8
 
+const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
+  { bucket: 'running', label: '실행 중' },
+  { bucket: 'paused', label: '대기 · 일시정지' },
+  { bucket: 'offline', label: '중지 · 종료됨' },
+]
+
 /** Group-header status dot tone (design rails.jsx `.rg-dot` colored by groupCls).
  *  Reuses the shared StatusDot vocabulary instead of a bespoke dot so the header
  *  marker matches the per-row dots: running→ok, paused→warn, offline→idle. */
 const GROUP_BUCKET_TONE: Record<RosterHeaderBucket, DotTone> = {
   attention: 'bad',
-  normal: 'ok',
   running: 'ok',
   paused: 'warn',
   offline: 'idle',
@@ -664,14 +669,17 @@ export function KeeperWorkspaceRoster({
       || keeperContextRatio(b) - keeperContextRatio(a)
       || a.name.localeCompare(b.name),
     )
-    const normalRows = visible.filter(k => !needsAttention(k)).sort(compareFleetRows)
     if (attentionRows.length > 0) {
       items.push({ type: 'header', bucket: 'attention', label: '주의 필요', count: attentionRows.length })
       for (const keeper of attentionRows) items.push({ type: 'row', keeper })
     }
-    if (normalRows.length > 0) {
-      items.push({ type: 'header', bucket: 'normal', label: '정상', count: normalRows.length })
-      for (const keeper of normalRows) items.push({ type: 'row', keeper })
+    for (const group of GROUP_ORDER) {
+      const rows = visible
+        .filter(k => !needsAttention(k) && keeperBucket(k) === group.bucket)
+        .sort(compareFleetRows)
+      if (rows.length === 0) continue
+      items.push({ type: 'header', bucket: group.bucket, label: group.label, count: rows.length })
+      for (const keeper of rows) items.push({ type: 'row', keeper })
     }
   } else {
     for (const keeper of sortRows(visible)) {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -285,6 +285,7 @@ function RosterRow({
   const work = keeperWorkPreview(keeper)
   const recentTool = keeperRecentTool(keeper)
   const gloss = keeperAttentionGloss(keeper)
+  const inlineActions = lifecycleActions(keeper).filter(action => action !== 'shutdown').slice(0, 2)
   const select = () => onSelect(keeper.name)
   return html`
     <div
@@ -347,6 +348,33 @@ function RosterRow({
       >
         <${MessageSquare} size=${14} aria-hidden="true" />
       </button>
+      ${inlineActions.length > 0
+        ? html`
+            <div class="kw-kp-inline-actions">
+              ${inlineActions.map(action => {
+                const copy = LIFECYCLE_COPY[action]
+                const Icon = copy.icon
+                return html`
+                  <button
+                    key=${action}
+                    type="button"
+                    class="kw-kp-inline-action v2-monitoring-action"
+                    title=${copy.title}
+                    aria-label=${`${keeper.name} ${copy.label}`}
+                    onClick=${(event: MouseEvent) => {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      void runKeeperAction(keeper.name, action)
+                    }}
+                  >
+                    <${Icon} size=${13} aria-hidden="true" />
+                    <span>${copy.label}</span>
+                  </button>
+                `
+              })}
+            </div>
+          `
+        : null}
       <button
         type="button"
         class="kw-kp-more v2-monitoring-action"

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -113,6 +113,11 @@ function needsAttention(keeper: Keeper): boolean {
   return keeper.needs_attention === true || attentionCount(keeper) > 0
 }
 
+function keeperFleetTone(keeper: Keeper): DotTone {
+  if (needsAttention(keeper) || keeper.current_gate?.kind === 'approval_required') return 'bad'
+  return keeperStatusTone(keeper)
+}
+
 function keeperContextRatio(keeper: Keeper): number {
   if (typeof keeper.context_ratio === 'number' && Number.isFinite(keeper.context_ratio)) {
     return Math.max(0, Math.min(1, keeper.context_ratio))
@@ -262,7 +267,7 @@ function RosterRow({
   style?: string
 }) {
   const bucket = keeperBucket(keeper)
-  const tone = keeperStatusTone(keeper)
+  const tone = keeperFleetTone(keeper)
   const att = attentionCount(keeper)
   const scope = keeperScope(keeper)
   const basepath = keeperBasepath(keeper)

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
@@ -2,6 +2,7 @@ import { render } from 'preact'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   keeperBucket,
+  keeperFleetTone,
   keeperStatusTone,
   statePillTone,
   keeperModelLabel,
@@ -104,5 +105,18 @@ describe('WorkspaceSigil', () => {
     expect(el.textContent).toBe('MS') // canonical sigil for masc-improver
     expect(el.style.background).toContain('--color-keeper-6') // canonical slot 6
     expect(el.style.width).toBe('46px')
+  })
+})
+
+describe('keeperFleetTone', () => {
+  it('surfaces attention and approval gates as bad even when the keeper is running', () => {
+    expect(keeperFleetTone(mk({ needs_attention: true }))).toBe('bad')
+    expect(keeperFleetTone(mk({ blocked_task_count: 2 }))).toBe('bad')
+    expect(keeperFleetTone(mk({ current_gate: { kind: 'approval_required', tool: 'shell', risk: 'high' } }))).toBe('bad')
+  })
+
+  it('falls back to the canonical status tone when no fleet attention is present', () => {
+    expect(keeperFleetTone(mk({ status: 'running', lifecycle_phase: 'Running' }))).toBe('ok')
+    expect(keeperFleetTone(mk({ status: 'running', lifecycle_phase: 'Paused', paused: true }))).toBe('warn')
   })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -125,6 +125,19 @@ export function keeperStatusTone(keeper: Keeper): DotTone {
   return 'idle'
 }
 
+/** Fleet surfaces are attention-first: a keeper with blocked work or an
+ *  approval gate should not look healthy just because its runtime is still
+ *  technically running. Kept here so roster rows and the selected-runtime rail
+ *  cannot silently diverge. */
+export function keeperFleetTone(keeper: Keeper): DotTone {
+  if (
+    keeper.needs_attention === true
+    || (keeper.blocked_task_count ?? 0) > 0
+    || keeper.current_gate?.kind === 'approval_required'
+  ) return 'bad'
+  return keeperStatusTone(keeper)
+}
+
 /** The state-pill modifier class for the chat header, derived from the health
  *  tone so error phases get the `bad` pill rather than collapsing to `off`. */
 export function statePillTone(tone: DotTone): 'run' | 'warn' | 'bad' | 'off' {

--- a/dashboard/src/styles/keeper-workspace-v23.test.ts
+++ b/dashboard/src/styles/keeper-workspace-v23.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { declarationsForSelector } from './css-test-utils'
+
+const cssPath = resolve(__dirname, 'keeper-workspace.css')
+const css = readFileSync(cssPath, 'utf-8')
+
+describe('keeper-workspace v2.3 fleet surface CSS', () => {
+  it('keeps new roster text surfaces from overflowing the row', () => {
+    const gloss = declarationsForSelector(css, '.kw-kp-gloss')
+    expect(gloss.overflow).toBe('hidden')
+    expect(gloss['text-overflow']).toBe('ellipsis')
+    expect(gloss['white-space']).toBe('nowrap')
+
+    const inlineActionLabel = declarationsForSelector(css, '.kw-kp-inline-action span')
+    expect(inlineActionLabel.overflow).toBe('hidden')
+    expect(inlineActionLabel['text-overflow']).toBe('ellipsis')
+    expect(inlineActionLabel['white-space']).toBe('nowrap')
+  })
+
+  it('keeps selected runtime details ellipsized inside the rail card', () => {
+    const titleText = declarationsForSelector(css, '.kw-fleet-aside-title strong')
+    expect(titleText.overflow).toBe('hidden')
+    expect(titleText['text-overflow']).toBe('ellipsis')
+    expect(titleText['white-space']).toBe('nowrap')
+
+    const vitalValue = declarationsForSelector(css, '.kw-fleet-vitals b')
+    expect(vitalValue.overflow).toBe('hidden')
+    expect(vitalValue['text-overflow']).toBe('ellipsis')
+    expect(vitalValue['white-space']).toBe('nowrap')
+
+    const toolPill = declarationsForSelector(css, '.kw-fleet-tools span')
+    expect(toolPill.overflow).toBe('hidden')
+    expect(toolPill['text-overflow']).toBe('ellipsis')
+    expect(toolPill['white-space']).toBe('nowrap')
+  })
+
+  it('visibly guards fleet lifecycle actions while they are in flight', () => {
+    const inlineBusy = declarationsForSelector(css, '.kw-kp-inline-action.busy')
+    expect(inlineBusy['border-color']).toContain('34, 211, 238')
+    expect(inlineBusy.color).toBe('#cffafe')
+
+    const railDisabled = declarationsForSelector(css, '.kw-fleet-action:disabled')
+    expect(railDisabled.cursor).toBe('wait')
+    expect(railDisabled.opacity).toBe('0.68')
+  })
+})

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -2080,3 +2080,59 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+.kw-kp-inline-actions {
+  position: absolute;
+  right: 77px;
+  top: 50%;
+  z-index: 2;
+  display: flex;
+  max-width: min(46%, 180px);
+  gap: 5px;
+  min-width: 0;
+  opacity: 0;
+  transform: translateY(-50%) translateX(6px);
+  transition: opacity 150ms ease, transform 150ms ease;
+}
+
+.kw-kp-row:hover .kw-kp-inline-actions,
+.kw-kp-row:focus-within .kw-kp-inline-actions {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+.kw-kp-inline-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  max-width: 88px;
+  height: 28px;
+  gap: 4px;
+  padding: 0 8px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.9);
+  color: rgba(226, 232, 240, 0.86);
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.kw-kp-inline-action span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kw-kp-inline-action:hover {
+  border-color: rgba(96, 165, 250, 0.62);
+  color: #dbeafe;
+}
+
+@media (max-width: 760px) {
+  .kw-kp-inline-actions {
+    display: none;
+  }
+}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -1793,3 +1793,249 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   opacity: 0.45;
   cursor: not-allowed;
 }
+
+/* v2.3 fleet follow-up: expose attention cause, selected runtime, and robust overflow. */
+.kw-kp-row {
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+}
+
+.kw-kp-meta,
+.kw-kp-name,
+.kw-kp-sub,
+.kw-kp-work,
+.kw-kp-gloss,
+.kw-kp-tool,
+.kw-kp-tool-v,
+.kw-kp-handle {
+  min-width: 0;
+}
+
+.kw-kp-gloss {
+  margin-top: 3px;
+  color: rgba(238, 246, 255, 0.72);
+  font-size: 11px;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kw-kp-chat {
+  position: absolute;
+  right: 43px;
+  top: 50%;
+  z-index: 2;
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.88);
+  color: rgba(226, 232, 240, 0.86);
+  opacity: 0;
+  transform: translateY(-50%) translateX(5px);
+  transition: opacity 150ms ease, transform 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+
+.kw-kp-row:hover .kw-kp-chat,
+.kw-kp-row:focus-within .kw-kp-chat {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+.kw-kp-chat:hover {
+  border-color: rgba(96, 165, 250, 0.72);
+  color: #dbeafe;
+}
+
+.kw-fleet-aside {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(56, 189, 248, 0.16), transparent 32%),
+    linear-gradient(160deg, rgba(15, 23, 42, 0.94), rgba(2, 6, 23, 0.84));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+}
+
+.kw-fleet-aside[data-tone="bad"] {
+  border-color: rgba(248, 113, 113, 0.34);
+  background:
+    radial-gradient(circle at 12% 0%, rgba(248, 113, 113, 0.18), transparent 32%),
+    linear-gradient(160deg, rgba(30, 18, 24, 0.94), rgba(2, 6, 23, 0.84));
+}
+
+.kw-fleet-aside-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+}
+
+.kw-fleet-aside-title {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.kw-fleet-aside-title strong,
+.kw-fleet-aside-title span,
+.kw-fleet-aside-kicker,
+.kw-fleet-phase b,
+.kw-fleet-phase span,
+.kw-fleet-vitals b,
+.kw-fleet-tools span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kw-fleet-aside-kicker,
+.kw-fleet-aside-title span,
+.kw-fleet-pressure span,
+.kw-fleet-vitals span {
+  color: rgba(148, 163, 184, 0.82);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.kw-fleet-aside-title strong {
+  color: #f8fafc;
+  font-size: 14px;
+}
+
+.kw-fleet-aside-state {
+  max-width: 84px;
+  padding: 5px 8px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 999px;
+  color: rgba(226, 232, 240, 0.78);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kw-fleet-chat {
+  width: 100%;
+  border: 1px solid rgba(96, 165, 250, 0.38);
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.22), rgba(14, 165, 233, 0.12));
+  color: #dbeafe;
+  font-weight: 800;
+  min-height: 38px;
+}
+
+.kw-fleet-phase {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.kw-fleet-phase b {
+  color: rgba(248, 250, 252, 0.92);
+  font-size: 12px;
+}
+
+.kw-fleet-phase span {
+  color: rgba(203, 213, 225, 0.78);
+  font-size: 11px;
+}
+
+.kw-fleet-pressure {
+  display: grid;
+  gap: 8px;
+}
+
+.kw-fleet-pressure > div:first-child {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.kw-fleet-pressure strong {
+  color: #e0f2fe;
+  font-size: 18px;
+}
+
+.kw-fleet-pressure-bar {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.92);
+}
+
+.kw-fleet-pressure-bar i {
+  display: block;
+  height: 100%;
+  max-width: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #22d3ee, #60a5fa, #f59e0b);
+}
+
+.kw-fleet-vitals {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.kw-fleet-vitals div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+  padding: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 13px;
+  background: rgba(15, 23, 42, 0.54);
+}
+
+.kw-fleet-vitals b {
+  color: rgba(248, 250, 252, 0.9);
+  font-size: 12px;
+}
+
+.kw-fleet-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.kw-fleet-tools span {
+  max-width: 100%;
+  padding: 5px 7px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.64);
+  color: rgba(203, 213, 225, 0.82);
+  font-size: 10px;
+}
+
+.att-text,
+.rtc-id,
+.rtc-model,
+.tasktag .ttl {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .kw-kp-chat {
+    right: 39px;
+    opacity: 1;
+    transform: translateY(-50%);
+  }
+
+  .kw-fleet-vitals {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -2136,3 +2136,15 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
     display: none;
   }
 }
+
+.kw-kp-inline-action:disabled,
+.kw-fleet-action:disabled {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.kw-kp-inline-action.busy,
+.kw-fleet-action.busy {
+  border-color: rgba(34, 211, 238, 0.42);
+  color: #cffafe;
+}

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -2039,3 +2039,44 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+.kw-kp-row {
+  position: relative;
+}
+
+.kw-fleet-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+  min-width: 0;
+}
+
+.kw-fleet-action {
+  min-width: 0;
+  min-height: 32px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.68);
+  color: rgba(226, 232, 240, 0.86);
+  font-size: 11px;
+  font-weight: 800;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kw-fleet-action:hover {
+  border-color: rgba(96, 165, 250, 0.48);
+  color: #eff6ff;
+}
+
+.kw-fleet-action.danger {
+  border-color: rgba(248, 113, 113, 0.28);
+  color: #fecaca;
+}
+
+@media (max-width: 760px) {
+  .kw-fleet-actions {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- regroup the keeper roster into attention-first `주의 필요` and calm `정상` sections for the v2.3 fleet view
- expose a row-level attention/phase gloss plus direct chat affordance wired to the existing keeper selection route
- wire row hover lifecycle actions to existing keeper predicates/actions, excluding shutdown from the row affordance to reduce accidental destructive clicks
- guard row/rail action buttons with pending/disabled state to avoid repeat lifecycle calls while a request is in flight
- refresh the dashboard runtime snapshot after row/menu/rail keeper lifecycle actions so state feedback is not stale
- add a selected-runtime rail card backed by live keeper/task snapshot data: context pressure, model/runtime, phase, TPS, tools, tasks
- wire the selected-runtime action bar to the existing keeper lifecycle predicates/actions (`pause`, `resume`, `wakeup`, `boot`, `shutdown`)
- align the rail `대화 콘솔 열기` CTA with roster selection state (`selectKeeper`, mobile chat pane, route)
- surface attention tone in fleet rows/cards even when the keeper is technically running
- tighten overflow handling for long keeper IDs, runtime names, attention text, tool names, action labels, and task titles
- add focused CSS coverage for v2.3 fleet overflow and in-flight action states

## Validation
- Added `dashboard/src/styles/keeper-workspace-v23.test.ts` for CSS guard coverage.
- Not run locally in this pass.
- Browser/rendered parity validation is intentionally not claimed yet.
