### PR TITLE
docs(rfc): per-runtime note field & dashboard surfacing

### DIFF
--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -103,7 +103,7 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0079 | Log row typed encoder + silent-drop removal | Implemented | 2eed0aa224 2026-06-21 | - |
 | 0080 | Tool registry SSOT — collapse multi-source membership into typed Keeper resol... | Implemented | 2eed0aa224 2026-06-21 | - |
 | 0081 | OAS Telemetry Envelope Context & Keeper/Goal Pivot Timeline | Implemented | 2eed0aa224 2026-06-21 | - |
-| 0082 | Keeper `last_blocker` auto-clear + runtime recovery escalation | Implemented | 2eed0aa224 2026-06-21 | - |
+| 0082 | Keeper `last_blocker` auto-clear + runtime recovery escalation | Implemented | 9bd13686d3 2026-06-25 | - |
 | 0083 | Dashboard system-actor convention typed unification | Implemented | 2eed0aa224 2026-06-21 | - |
 | 0084 | Keeper→Tool Dispatch Unification + 100% Trace/Telemetry | Implemented | 2eed0aa224 2026-06-21 | - |
 | 0086 | Keeper namespace bulk promotion to sub-library | Implemented | 2eed0aa224 2026-06-21 | - |
@@ -222,9 +222,9 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0217 | Telemetry Backend Otel 단일화 (Retired Backend Purge) | Draft | 2eed0aa224 2026-06-21 | - |
 | 0218 | Keeper tool-surface coherence + web-tooling roadmap — phases and per-phase gates | Draft | 2eed0aa224 2026-06-21 | - |
 | 0219 | Remove Sandbox Repo Patrol Gates | Draft | 2eed0aa224 2026-06-21 | - |
-| 0220 | Decouple keeper liveness from verification state + guaranteed satisfier for e... | Draft | 2eed0aa224 2026-06-21 | - |
+| 0220 | Decouple keeper liveness from verification state + guaranteed satisfier for e... | Draft | 6c9029bcbf 2026-06-25 | - |
 | 0221 | Atomic verification submission — task_status as the sole outcome authority | Implemented (steps 1-3 merged #20613/#20617; steps 4-5 measured then dropped, §3.3/§3.4) | 2eed0aa224 2026-06-21 | - |
-| 0222 | Typed acceptance criterion + harness-driven completion for checkable tasks | Draft | 2eed0aa224 2026-06-21 | - |
+| 0222 | Typed acceptance criterion + harness-driven completion for checkable tasks | Draft | 6c9029bcbf 2026-06-25 | - |
 | 0223 | Typed connector surfaces: presence in world prompt, pull-based lane context, ... | Draft | 2eed0aa224 2026-06-21 | - |
 | 0224 | Structured completion report for free-text contract items | Draft | 2eed0aa224 2026-06-21 | - |
 | 0225 | Per-keeper turn single-flight admission | Draft | 2eed0aa224 2026-06-21 | - |
@@ -235,7 +235,7 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0230 | Keeper mention/scope reactivity: cursor-free salience to complement pull-base... | Draft | 2eed0aa224 2026-06-21 | - |
 | 0232 | Typed lane event model: parse at the write boundary, never re-derive by strin... | Draft | 2eed0aa224 2026-06-21 | - |
 | 0233 | Typed turn observability: TurnRecord prompt-block provenance + canonical tool... | Draft | addd7b3668 2026-06-22 | - |
-| 0234 | Scheduled internal automation with separate execution approval | Draft | 4e52542f29 2026-06-21 | - |
+| 0234 | Scheduled internal automation with separate execution approval | Draft | b179664d43 2026-06-25 | - |
 | 0235 | Voice output transport: browser-addressed audio delivery with device-routed p... | Draft | 2eed0aa224 2026-06-21 | - |
 | 0236 | Voice input transport: browser-captured speech-to-text for the dashboard comp... | Draft | 2eed0aa224 2026-06-21 | - |
 | 0237 | Eliminate the write_meta ~force escape hatch (route snapshot writes through C... | Draft | 2eed0aa224 2026-06-21 | - |
@@ -265,9 +265,9 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0262 | Completion authority typing — closing the force-bypass and framing completion... | Draft | 2eed0aa224 2026-06-21 | - |
 | 0263 | Owner-priority cooperative preemption of in-flight autonomous turns | Draft | 2eed0aa224 2026-06-21 | - |
 | 0264 | Memory OS recall outcome-anchored eval harness | Draft | 2eed0aa224 2026-06-21 | - |
-| 0265 | Capability-driven proactive runtime reroute (modality-gated) | Draft | 2eed0aa224 2026-06-21 | - |
+| 0265 | Capability-driven proactive runtime reroute (modality-gated) | Draft | 55bab0404b 2026-06-25 | - |
 | 0266 | Fusion async-completion wake + in-progress 가시성 | Draft | 2eed0aa224 2026-06-21 | - |
-| 0267 | Make task↔goal links visible and explicitly assignable | Draft | 2eed0aa224 2026-06-21 | - |
+| 0267 | Make task↔goal links visible and explicitly assignable | Draft | 6c9029bcbf 2026-06-25 | - |
 | 0268 | Prompt ↔ Closed-sum Variant Sync Gate | Draft | 2eed0aa224 2026-06-21 | - |
 | 0269 | Process Critic Loop for Keeper Work Traces | Draft | 2eed0aa224 2026-06-21 | - |
 | 0270 | CI Gate merge guard: block merges on a non-success CI Gate and trip on red main | Draft | 2eed0aa224 2026-06-21 | - |
@@ -284,7 +284,7 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0281 | WebSocket transport SSOT — separate upgrade-attachment from session-protocol,... | Draft | 7eaba002d2 2026-06-22 | - |
 | 0282 | De-structure keeper self_model (will/needs/desires) into general persona desc... | Draft | 0c540dd87d 2026-06-23 | - |
 | 0283 | Fusion: judge-of-judges 위상 (N개 1차 심판 + meta 심판) | Draft | 2579358d90 2026-06-23 | - |
-| 0284 | Keeper Guidance Visibility-Leg Drift Guard | Draft | fcf92d3386 2026-06-23 | - |
+| 0284 | Keeper Guidance Visibility-Leg Drift Guard | Draft | 6c9029bcbf 2026-06-25 | - |
 | 0285 | Memory OS — Self-Observation Claim Volatility (closing RFC-0259's internal-st... | Draft | d643c403bb 2026-06-23 | - |
 | 0286 | exec/keeper 스택: redirect & turn-termination 경계 소유권 | Draft | f765863658 2026-06-23 | - |
 | 0287 | ws-direct — a single masc-owned WebSocket stack for server and client | Draft | 78f1c2fcf4 2026-06-23 | - |
@@ -294,8 +294,18 @@ implementation_prs: []             # [14181, 14550] 형식 (정수). RFC body �
 | 0291 | Closed SSE event-type sum + typed broadcast — RFC-0004 Phase A0 Wave 2 increment | Draft | db3cea7b4d 2026-06-24 | - |
 | 0292 | Complete lib/auth de-duplication — remove drifted Masc.Auth* test copies | Draft | 92f93e11de 2026-06-24 | - |
 | 0293 | Keeper execution-endpoint backend (host / ephemeral-docker / persistent-docke... | Draft | 0ba556bf42 2026-06-24 | - |
-| 0294 | Purge the workspace-goal horizon (short/mid/long) — dead cadence cohort + a s... | Draft | 75ac8623e6 2026-06-24 | - |
-| elim | Eliminate Substring Destructive Classifier in Favor of Typed Shell IR | Draft | (untracked) | - |
+| 0294 | Purge the workspace-goal horizon (short/mid/long) — dead cadence cohort + a s... | Draft | d7d30816c2 2026-06-24 | - |
+| elim | Eliminate Substring Destructive Classifier in Favor of Typed Shell IR | Draft | 664f8aafe3 2026-06-25 | - |
+| keep | Vision-as-a-tool delegation (decouple multimodal input from conversation runt... | Draft | 55bab0404b 2026-06-25 | - |
+| runt | Per-runtime note field & dashboard surfacing | Draft | 8e1998934b 2026-06-25 | - |
+
+
+
+
+
+
+
+
 
 
 

--- a/docs/rfc/RFC-runtime-note-field-and-dashboard-surfacing.md
+++ b/docs/rfc/RFC-runtime-note-field-and-dashboard-surfacing.md
@@ -1,21 +1,28 @@
-# RFC: Per-runtime `note` field & dashboard surfacing
+---
+rfc: "runtime-note-field-and-dashboard-surfacing"
+title: "Per-runtime note field & dashboard surfacing"
+status: Draft
+created: 2026-06-25
+updated: 2026-06-25
+author: vincent
+supersedes: []
+superseded_by: null
+related: ["0206", "0211", "0273"]
+implementation_prs: []
+---
 
-> **Status**: Draft
-> **Authors**: vincent (with Claude Opus 4.8)
-> **Created**: 2026-06-25
-> **Related RFCs**: RFC-0211-persona-runtime-decouple-opaque-id-runtime-toml-ssot (runtime.toml is the SSOT; this RFC extends its schema with one optional metadata field), RFC-0206-runtime-concept-runtime-rebirth (the `Runtime_toml` parser that must keep ignoring non-dispatch fields), RFC-0273-dashboard-driven-keeper-config-and-runtime-persistence (the dashboard write path `POST /api/v1/runtime/config/raw` and the Settings/runtime panels this RFC surfaces into)
-> **Anchor commit**: `6c9029bcbf` (#22222 — current main at draft time)
+# Per-runtime note field & dashboard surfacing
 
 ## 1. Problem
 
 The rationale for *why* a runtime is configured a certain way lives **only** as free-form TOML comments in `runtime.toml`, and those comments are surfaced in **no structured view**.
 
-Grounded against the live config (`<base-path>/.masc/config/runtime.toml`, 2026-06-25):
+Grounded against a live config snapshot (2026-06-25):
 
-- The global default is `ollama_cloud.minimax-m3`. The reason is a 11-line comment block above `[runtime].default`: RunPod 404 outage on 2026-06-19 forced all keepers to Ollama Cloud, then `deepseek-v4-flash` could not emit structured JSON so the anti-rationalization evaluator returned empty 10/20 times and auto-approved by liveness (#8688), so the default was swapped to the JSON-capable `minimax-m3`.
-- That reasoning is **invisible** anywhere except by reading the raw TOML. A operator looking at the dashboard sees the *effect* (minimax is default) but not the *why*.
+- The global default is `provider_a.model_x`. The reason is an 11-line comment block above `[runtime].default`: a provider outage and a structured-JSON capability failure forced a fleet-wide fallback, so the default was swapped to a JSON-capable model.
+- That reasoning is **invisible** anywhere except by reading the raw TOML. A operator looking at the dashboard sees the *effect* (model_x is default) but not the *why*.
 
-Observed symptom (this session): the operator asked "왜 default가 minimax가 됐지?" — the answer existed, but only buried in a comment. Then: "설정에서 잘 안보임" (it is not visible in Settings).
+Observed symptom (this session): the operator asked "왜 default가 model_x가 됐지?" — the answer existed, but only buried in a comment. Then: "설정에서 잘 안보임" (it is not visible in Settings).
 
 > **Premise correction (2026-06-25, post-verification).** An earlier draft of this RFC claimed a third cause — "comments are lost on dashboard save because the write path re-serializes the TOML." **That claim was falsified by direct verification (§6).** The entire read→edit→write pipeline is comment-preserving (raw textarea editor + line-surgical field edits + verbatim backend write + text-transform assignment edits). So this RFC is **not** a data-loss fix. Its justification is narrower and softer: rationale is preserved but surfaced in **no structured view**. Weigh the (smaller) benefit against the schema+UI cost accordingly.
 
@@ -23,8 +30,8 @@ Two structural causes, grounded:
 
 | Cause | Evidence |
 |---|---|
-| No typed rationale field exists | `dashboard/src/lib/runtime-toml-config.ts` parses `RuntimeTomlProvider`/`Model`/`Binding`; `rg note` → 0 hits. The only optional string is `displayName` (`runtime-toml-config.ts:194`). |
-| Dashboard runtime detail surfaces no rationale | `dashboard/src/components/runtime-panel.ts:20,160-167`: the `런타임` tab = "OAS health chip + runtime monitor only" (operational); the `runtime.toml` tab = a **raw textarea** (`runtime-toml-editor.ts:511-526`). The rationale exists only as raw-text comments visible in that textarea — there is no structured per-runtime rationale surface in the `런타임`/`전체` views, so an operator scanning the structured runtime list cannot see "why this default" without dropping into raw text. |
+| No typed rationale field exists | `dashboard/src/lib/runtime-toml-config.ts` parses `RuntimeTomlProvider`/`Model`/`Binding`; `rg note` → 0 hits. The only optional string is `displayName` (parsed by the same helper in `runtime-toml-config.ts` at anchor commit `6c9029bcbf`). |
+| Dashboard runtime detail surfaces no rationale | `RuntimePanel` (`런타임` tab) = "OAS health chip + runtime monitor only" (operational); the `runtime.toml` tab = a **raw textarea** in `RuntimeTomlEditor`. The rationale exists only as raw-text comments visible in that textarea — there is no structured per-runtime rationale surface in the `런타임`/`전체` views, so an operator scanning the structured runtime list cannot see "why this default" without dropping into raw text. |
 
 ## 2. Boundary & invariants
 
@@ -37,7 +44,7 @@ Two structural causes, grounded:
 | OCaml `Runtime_toml` | **only** Layer 1-3 (`[providers.*]`, `[models.*]`, `[<p>.<m>]` bindings) + `[runtime].default` | `lib/runtime/runtime_toml.mli` (docstring: routing layers 4/5 and strategy tables are "intentionally NOT parsed"; dropped) |
 | Dashboard `runtime-toml-config.ts` | the structured editor model incl. `display-name`, `keeper-assignable`, etc. | RFC-0273 surfaces |
 
-`note` is **purely a dashboard/operator field**. It MUST NOT influence inference dispatch. **Verified (§6 V1):** the OCaml `Runtime_toml` parser reads only specific known keys via `Otoml.find_opt tbl getter [key]` / `find_or ~default` (`runtime_toml.ml:107-108,164,182,244-258`); it does **not** enumerate keys or reject unknowns. The only `unknown_*` errors are for an *invalid value* of a known key (`protocol`, credential `type`) — never for an unexpected key. So an extra `note` key is simply never read → dispatch-invisible by construction, the same already-tolerated class as `display-name` / `[providers.*.healthcheck]` / `[voice.*]`. The invariant is additionally locked by test (§5).
+`note` is **purely a dashboard/operator field**. It MUST NOT influence inference dispatch. **Verified (§6 V1):** the OCaml `Runtime_toml` parser reads only specific known keys via `Otoml.find_opt tbl getter [key]` / `find_or ~default`; it does **not** enumerate keys or reject unknowns. The only `unknown_*` errors are for an *invalid value* of a known key (`protocol`, credential `type`) — never for an unexpected key. So an extra `note` key is simply never read → dispatch-invisible by construction, the same already-tolerated class as `display-name` / `[providers.*.healthcheck]` / `[voice.*]`. The invariant is additionally locked by test (§5).
 
 ### 2.2 Precedent: this is metadata, not a new concept
 
@@ -51,6 +58,8 @@ Untouched. OAS owns provider/model/transport/turn-lifecycle. `note` never crosse
 
 `note` lives **inside** `runtime.toml` (the existing SSOT, RFC-0211). This RFC explicitly rejects a sidecar note store (separate JSON/DB keyed by runtime id) because that creates a second source of truth that drifts from the config it annotates. See §4 Rejected alternatives.
 
+Because comments remain valid (§7), a table could contain both a rationale comment block and a `note` field. To avoid divergent rationales, the dashboard/TOML lint **MUST warn** when a table contains both; comments are **not** deprecated.
+
 ## 3. Design
 
 ### 3.1 Schema (extends RFC-0211)
@@ -60,41 +69,44 @@ Add an **optional** `note` key (TOML string; may be a multi-line triple-quoted s
 - `[providers.<id>]` — why this provider/endpoint exists, auth quirks, outage history.
 - `[models.<id>]` — model provenance, quant, verified capabilities.
 - `[<provider>.<model>]` binding tables — why this binding's concurrency/params are set as they are.
-- `[runtime]` — `default-note` (string): **why the current `default` was chosen.** This is the field that directly answers "왜 default가 minimax가 됐지?".
+- `[runtime]` — `default-note` (string): **why the current `default` was chosen.** This is the field that directly answers "왜 default가 model_x가 됐지?".
 
 ```toml
 [runtime]
-default = "ollama_cloud.minimax-m3"
+default = "provider_a.model_x"
 default-note = """
-2026-06-19: RunPod 404 outage forced all keepers to Ollama Cloud. flash could not
-emit structured JSON (anti-rationalization evaluator empty 10/20, auto-approved by
-liveness #8688) → swapped to JSON-capable minimax-m3. Revert when RunPod returns.
+A prior provider outage and a structured-JSON failure forced a fallback
+to this JSON-capable model. Revert when the original provider returns.
 """
 
-[providers.runpod_fable5]
-note = "Added 2026-06-25. RunPod pod l427t1tmzge86g:19123, llama.cpp. Probe-verified tools+thinking."
+[providers.example_provider]
+note = "Added for redundancy. Endpoint probe-verified tools+thinking."
 ```
 
 Multi-line strings preserve the existing dated-changelog comment style **as a typed value**, so no separate `note : string list` array is needed for v1 (kept as a documented future option, §7).
+
+`default-note` is **not** auto-derived from the currently-selected default binding's `note`; it is operator prose that explains the cross-binding choice. To mitigate staleness, the dashboard write path **SHOULD emit a lint warning** when `[runtime].default` is changed while `default-note` still describes the previous default.
 
 ### 3.2 OCaml `Runtime_toml` — explicit ignore + test
 
 No behavioral change. `note`/`default-note` are not added to `Runtime_schema.config`. A regression test asserts:
 
 - a config carrying `note` on every table kind + `default-note` parses `Ok`, and
-- the resulting `Runtime_schema.config` is byte-identical to the same config with the `note` keys removed (i.e. `note` is provably dispatch-invisible).
+- the resulting `Runtime_schema.config` is semantically equivalent (parsed AST equality) to the same config with the `note` keys removed (i.e. `note` is provably dispatch-invisible).
 
 ### 3.3 Dashboard `runtime-toml-config.ts` — parse + round-trip preserve
 
 - Add `note?: string` to `RuntimeTomlProvider`, `RuntimeTomlModel`, `RuntimeTomlBinding`; add `defaultNote?: string` to the document/runtime model.
-- Parse it exactly like `displayName` (`runtime-toml-config.ts:194` pattern: `asString(values['note'], undefined)`).
-- **Serialize it back** on write so a dashboard-driven save (RFC-0273 `/api/v1/runtime/config/raw`) does not drop it.
+- Parse it exactly like `displayName` (`runtime-toml-config.ts` `asString(values['note'], undefined)` pattern at anchor commit `6c9029bcbf`).
+- **Serialize it back** on write so a dashboard-driven save (RFC-0273 `POST /api/v1/runtime/config/raw`) does not drop it.
+- **Normalize on parse:** trim leading/trailing ASCII whitespace; treat a whitespace-only string as absent; round-trip an absent key as absent (do not write the key when the normalized value is missing).
 
 ### 3.4 Dashboard surfacing — the "설정에서 잘 안보임" fix
 
-- **Default rationale callout** (highest priority): in `runtime-panel.ts` `전체`/`런타임` view, render `[runtime].default` with its `default-note` as a prominent banner at the top. This is the single most-asked question ("why this default") and must be answerable at a glance.
-- **Per-runtime note**: in the `런타임` (providers) view, render each provider/model/binding's `note` inline (e.g. an `ⓘ` affordance expanding to the note). Inert/unassigned runtimes (like a freshly-added `runpod_fable5`) are listed too, so an added-but-not-routed runtime is discoverable — addressing the "added it but can't see it" half of the complaint.
-- **Editor**: in `runtime-toml-editor.ts`, `note` is a labeled field, not a comment, so it round-trips and is editable structurally.
+- **Default rationale callout** (highest priority): in `RuntimePanel` `전체`/`런타임` view, render `[runtime].default` with its `default-note` as a prominent banner at the top. This is the single most-asked question ("why this default") and must be answerable at a glance.
+- **Per-runtime note**: in the structured providers/models view, render each provider/model/binding's `note` inline (e.g. an `ⓘ` affordance expanding to the note).
+- **Editor**: in `RuntimeTomlEditor`, `note` is a labeled field, not a comment, so it round-trips and is editable structurally.
+- **Security requirements:** `note`/`default-note` are operator-editable strings that the dashboard renders as a banner and inline affordance. They **MUST** be treated as plain text: no inline HTML/Markdown rendering, HTML-escaped output, rejection of control characters (ASCII `0x00-0x1F` except `\t`, `\n`, `\r`), and a maximum length of **2,048 Unicode code points**. The write path **MUST reject** values that exceed the limit or contain disallowed control characters.
 
 ### 3.5 Write path
 
@@ -110,26 +122,28 @@ Reuse RFC-0273's existing `POST /api/v1/runtime/config/raw` (`Runtime.save_confi
 
 ## 5. Test plan
 
-- **OCaml** `test/test_runtime_toml*.ml`: §3.2 dispatch-invisibility test (parse Ok + config identical with/without `note`); round-trip via `save_config_text` preserves `note`/`default-note`.
-- **Dashboard** `runtime-toml-config.test.ts`: parse `note` from each table kind + `default-note`; serialize preserves them.
-- **Dashboard component** `runtime-panel`/`runtime-toml-editor` test: default-note banner renders; per-runtime note renders; inert runtime appears in list.
+- **OCaml** `test/test_runtime_toml*.ml`: §3.2 dispatch-invisibility test (parse Ok + config semantically equivalent with/without `note`); round-trip via `save_config_text` preserves `note`/`default-note`.
+- **Dashboard** `runtime-toml-config.test.ts`: parse `note` from each table kind + `default-note`; serialize preserves them; whitespace-only normalized to absent.
+- **Dashboard component** `runtime-panel`/`runtime-toml-editor` test: default-note banner renders; per-runtime note renders.
 
 ## 6. Verification (closed) & open questions
 
-Direct grounding against `main` (worktree `6c9029bcbf`, 2026-06-25):
+Direct grounding against `main` (worktree at anchor commit `6c9029bcbf`, 2026-06-25):
 
-- **V1 — parser tolerates `note` (CONFIRMED).** `runtime_toml.ml` picks known keys with `Otoml.find_opt`/`find_or`; no unknown-key rejection path. Extra `note` is never read. See §2.1.
+- **V1 — parser tolerates `note` (CONFIRMED).** `Runtime_toml` picks known keys with `Otoml.find_opt`/`find_or`; no unknown-key rejection path. Extra `note` is never read. See §2.1.
 - **O1 — comment survival (CLOSED, was the falsified premise).** The full pipeline preserves comments; there is **no** re-serialization that drops them:
-  - Backend write `Runtime.save_config_text` (`runtime.ml:673-678`) = `validate` then `Fs_compat.save_file_atomic path content` — **verbatim raw write**.
-  - Keeper-assignment write `set_runtime_id_for_keeper` → `update_runtime_assignment_text` (`runtime.ml:619-627`) = `split_lines`-based **text transform**, not AST re-serialize.
-  - Dashboard editor `runtime-toml-editor.ts:511-526` = **raw `<textarea>`** on the source text; structured field edits `setRuntimeTomlKey` (`runtime-toml-config.ts:319-333`) replace only the matched line's value. Comments untouched.
+  - Backend write `Runtime.save_config_text` = `validate` then `Fs_compat.save_file_atomic path content` — **verbatim raw write**.
+  - Keeper-assignment write `set_runtime_id_for_keeper` → `update_runtime_assignment_text` = `split_lines`-based **text transform**, not AST re-serialize.
+  - Dashboard editor `RuntimeTomlEditor` = **raw `<textarea>`** on the source text; structured field edits `setRuntimeTomlKey` replace only the matched line's value. Comments untouched.
   - **Consequence:** the "typed field survives serialization" argument is *moot* (comments already survive). The only real gap is **structured surfacing** — see §1 premise correction.
-- **O2 (open)**: Should `default-note` live on `[runtime]` or be auto-derived from the `note` of whichever binding is currently `default`? Proposed: separate `default-note` ("why this is the default" ≠ "what this runtime is"), but see §8 staleness risk.
+- **O2 (closed):** `default-note` remains a separate field on `[runtime]`. Staleness is mitigated by rendering it directly next to the live `default` value and by a write-time lint warning when `default` changes while `default-note` still describes the old default.
 
 ## 7. Non-goals / future
 
 - No change to dispatch/routing semantics, no new endpoint, no comment migration mandate (comments stay valid for non-surfaced detail).
+- Runtime discovery / directory listing for inert/unassigned runtimes is out of scope; surfacing is limited to notes on the existing structured runtime list. A separate RFC may add a runtime directory.
 - Future: `note : string list` dated-entry array with per-entry author/timestamp, if a structured changelog is wanted over a multi-line string.
+- Promotion: status moves to `Active` when the first implementation PR is opened; to `Implemented` when all `implementation_prs` are merged.
 
 ## 8. Workaround self-check (CLAUDE.md bar)
 
@@ -137,5 +151,5 @@ Direct grounding against `main` (worktree `6c9029bcbf`, 2026-06-25):
 - String/substring classifier? No — `note` is a typed `string` value; this RFC *rejects* comment-string-parsing (§4).
 - N-of-M? No.
 - Cap/cooldown/dedup/repair? No.
-- Second SSOT? Explicitly avoided (§2.4).
-- **Staleness honesty (acknowledged risk).** `note`/`default-note` is free-form prose, so it *can* go stale when the value it explains changes (e.g. default flips but the note still describes the old reason). This is inherent to any human rationale and is **not** the "two concepts in one typed value" anti-pattern (note is explicitly metadata, not an overloaded typed field). Nothing enforces freshness. Mitigation, not enforcement: the dashboard renders `default-note` **directly next to the live `default` value**, so a stale note is visible to the operator at the point of reading. No write-time validation is proposed (validating prose against intent is not mechanizable).
+- Second SSOT? Explicitly avoided (§2.4); comment/note divergence is warned by lint.
+- **Staleness honesty (acknowledged risk).** `note`/`default-note` is free-form prose, so it *can* go stale when the value it explains changes (e.g. default flips but the note still describes the old reason). This is inherent to any human rationale and is **not** the "two concepts in one typed value" anti-pattern (note is explicitly metadata, not an overloaded typed field). Nothing enforces freshness. Mitigation, not enforcement: the dashboard renders `default-note` **directly next to the live `default` value** and emits a **write-time lint warning** when `default` changes while `default-note` still describes the old default. No prose-validation is proposed (validating prose against intent is not mechanizable).

--- a/docs/rfc/RFC-runtime-note-field-and-dashboard-surfacing.md
+++ b/docs/rfc/RFC-runtime-note-field-and-dashboard-surfacing.md
@@ -1,0 +1,141 @@
+# RFC: Per-runtime `note` field & dashboard surfacing
+
+> **Status**: Draft
+> **Authors**: vincent (with Claude Opus 4.8)
+> **Created**: 2026-06-25
+> **Related RFCs**: RFC-0211-persona-runtime-decouple-opaque-id-runtime-toml-ssot (runtime.toml is the SSOT; this RFC extends its schema with one optional metadata field), RFC-0206-runtime-concept-runtime-rebirth (the `Runtime_toml` parser that must keep ignoring non-dispatch fields), RFC-0273-dashboard-driven-keeper-config-and-runtime-persistence (the dashboard write path `POST /api/v1/runtime/config/raw` and the Settings/runtime panels this RFC surfaces into)
+> **Anchor commit**: `6c9029bcbf` (#22222 — current main at draft time)
+
+## 1. Problem
+
+The rationale for *why* a runtime is configured a certain way lives **only** as free-form TOML comments in `runtime.toml`, and those comments are surfaced in **no structured view**.
+
+Grounded against the live config (`<base-path>/.masc/config/runtime.toml`, 2026-06-25):
+
+- The global default is `ollama_cloud.minimax-m3`. The reason is a 11-line comment block above `[runtime].default`: RunPod 404 outage on 2026-06-19 forced all keepers to Ollama Cloud, then `deepseek-v4-flash` could not emit structured JSON so the anti-rationalization evaluator returned empty 10/20 times and auto-approved by liveness (#8688), so the default was swapped to the JSON-capable `minimax-m3`.
+- That reasoning is **invisible** anywhere except by reading the raw TOML. A operator looking at the dashboard sees the *effect* (minimax is default) but not the *why*.
+
+Observed symptom (this session): the operator asked "왜 default가 minimax가 됐지?" — the answer existed, but only buried in a comment. Then: "설정에서 잘 안보임" (it is not visible in Settings).
+
+> **Premise correction (2026-06-25, post-verification).** An earlier draft of this RFC claimed a third cause — "comments are lost on dashboard save because the write path re-serializes the TOML." **That claim was falsified by direct verification (§6).** The entire read→edit→write pipeline is comment-preserving (raw textarea editor + line-surgical field edits + verbatim backend write + text-transform assignment edits). So this RFC is **not** a data-loss fix. Its justification is narrower and softer: rationale is preserved but surfaced in **no structured view**. Weigh the (smaller) benefit against the schema+UI cost accordingly.
+
+Two structural causes, grounded:
+
+| Cause | Evidence |
+|---|---|
+| No typed rationale field exists | `dashboard/src/lib/runtime-toml-config.ts` parses `RuntimeTomlProvider`/`Model`/`Binding`; `rg note` → 0 hits. The only optional string is `displayName` (`runtime-toml-config.ts:194`). |
+| Dashboard runtime detail surfaces no rationale | `dashboard/src/components/runtime-panel.ts:20,160-167`: the `런타임` tab = "OAS health chip + runtime monitor only" (operational); the `runtime.toml` tab = a **raw textarea** (`runtime-toml-editor.ts:511-526`). The rationale exists only as raw-text comments visible in that textarea — there is no structured per-runtime rationale surface in the `런타임`/`전체` views, so an operator scanning the structured runtime list cannot see "why this default" without dropping into raw text. |
+
+## 2. Boundary & invariants
+
+### 2.1 `note` is a non-dispatch field — the load-bearing invariant
+
+`runtime.toml` has **two independent consumers**:
+
+| Consumer | Reads | Source |
+|---|---|---|
+| OCaml `Runtime_toml` | **only** Layer 1-3 (`[providers.*]`, `[models.*]`, `[<p>.<m>]` bindings) + `[runtime].default` | `lib/runtime/runtime_toml.mli` (docstring: routing layers 4/5 and strategy tables are "intentionally NOT parsed"; dropped) |
+| Dashboard `runtime-toml-config.ts` | the structured editor model incl. `display-name`, `keeper-assignable`, etc. | RFC-0273 surfaces |
+
+`note` is **purely a dashboard/operator field**. It MUST NOT influence inference dispatch. **Verified (§6 V1):** the OCaml `Runtime_toml` parser reads only specific known keys via `Otoml.find_opt tbl getter [key]` / `find_or ~default` (`runtime_toml.ml:107-108,164,182,244-258`); it does **not** enumerate keys or reject unknowns. The only `unknown_*` errors are for an *invalid value* of a known key (`protocol`, credential `type`) — never for an unexpected key. So an extra `note` key is simply never read → dispatch-invisible by construction, the same already-tolerated class as `display-name` / `[providers.*.healthcheck]` / `[voice.*]`. The invariant is additionally locked by test (§5).
+
+### 2.2 Precedent: this is metadata, not a new concept
+
+Spec §7.3.1 (`masc-mcp/docs/spec/14-configuration.md`) already defines `keeper-assignable` — a typed `bool` metadata field on `tier`/`runtime` consumed by the dashboard/runtime manager, ignored by the dispatch parser. `note` follows the identical pattern: typed, optional, dashboard-consumed, dispatch-ignored. We are extending an established metadata lane, not inventing one.
+
+### 2.3 OAS boundary
+
+Untouched. OAS owns provider/model/transport/turn-lifecycle. `note` never crosses into OAS — it is not in `Runtime_schema.config`.
+
+### 2.4 No second SSOT
+
+`note` lives **inside** `runtime.toml` (the existing SSOT, RFC-0211). This RFC explicitly rejects a sidecar note store (separate JSON/DB keyed by runtime id) because that creates a second source of truth that drifts from the config it annotates. See §4 Rejected alternatives.
+
+## 3. Design
+
+### 3.1 Schema (extends RFC-0211)
+
+Add an **optional** `note` key (TOML string; may be a multi-line triple-quoted string to hold a dated changelog) to:
+
+- `[providers.<id>]` — why this provider/endpoint exists, auth quirks, outage history.
+- `[models.<id>]` — model provenance, quant, verified capabilities.
+- `[<provider>.<model>]` binding tables — why this binding's concurrency/params are set as they are.
+- `[runtime]` — `default-note` (string): **why the current `default` was chosen.** This is the field that directly answers "왜 default가 minimax가 됐지?".
+
+```toml
+[runtime]
+default = "ollama_cloud.minimax-m3"
+default-note = """
+2026-06-19: RunPod 404 outage forced all keepers to Ollama Cloud. flash could not
+emit structured JSON (anti-rationalization evaluator empty 10/20, auto-approved by
+liveness #8688) → swapped to JSON-capable minimax-m3. Revert when RunPod returns.
+"""
+
+[providers.runpod_fable5]
+note = "Added 2026-06-25. RunPod pod l427t1tmzge86g:19123, llama.cpp. Probe-verified tools+thinking."
+```
+
+Multi-line strings preserve the existing dated-changelog comment style **as a typed value**, so no separate `note : string list` array is needed for v1 (kept as a documented future option, §7).
+
+### 3.2 OCaml `Runtime_toml` — explicit ignore + test
+
+No behavioral change. `note`/`default-note` are not added to `Runtime_schema.config`. A regression test asserts:
+
+- a config carrying `note` on every table kind + `default-note` parses `Ok`, and
+- the resulting `Runtime_schema.config` is byte-identical to the same config with the `note` keys removed (i.e. `note` is provably dispatch-invisible).
+
+### 3.3 Dashboard `runtime-toml-config.ts` — parse + round-trip preserve
+
+- Add `note?: string` to `RuntimeTomlProvider`, `RuntimeTomlModel`, `RuntimeTomlBinding`; add `defaultNote?: string` to the document/runtime model.
+- Parse it exactly like `displayName` (`runtime-toml-config.ts:194` pattern: `asString(values['note'], undefined)`).
+- **Serialize it back** on write so a dashboard-driven save (RFC-0273 `/api/v1/runtime/config/raw`) does not drop it.
+
+### 3.4 Dashboard surfacing — the "설정에서 잘 안보임" fix
+
+- **Default rationale callout** (highest priority): in `runtime-panel.ts` `전체`/`런타임` view, render `[runtime].default` with its `default-note` as a prominent banner at the top. This is the single most-asked question ("why this default") and must be answerable at a glance.
+- **Per-runtime note**: in the `런타임` (providers) view, render each provider/model/binding's `note` inline (e.g. an `ⓘ` affordance expanding to the note). Inert/unassigned runtimes (like a freshly-added `runpod_fable5`) are listed too, so an added-but-not-routed runtime is discoverable — addressing the "added it but can't see it" half of the complaint.
+- **Editor**: in `runtime-toml-editor.ts`, `note` is a labeled field, not a comment, so it round-trips and is editable structurally.
+
+### 3.5 Write path
+
+Reuse RFC-0273's existing `POST /api/v1/runtime/config/raw` (`Runtime.save_config_text` + reload) under the same operator-auth gate. **No new endpoint.**
+
+## 4. Rejected alternatives
+
+| Alternative | Why rejected |
+|---|---|
+| Parse TOML comments → notes | String/positional heuristic over comments is fragile and is exactly the "string classifier" anti-pattern (CLAUDE.md workaround bar §2). Comments also aren't addressable per-table. |
+| Sidecar note store (JSON/DB by runtime id) | Second SSOT; drifts from the config it annotates (§2.4). |
+| `note : string list` (dated array) | More schema for v1 with no proven need; multi-line string already captures dated history. Deferred to §7. |
+
+## 5. Test plan
+
+- **OCaml** `test/test_runtime_toml*.ml`: §3.2 dispatch-invisibility test (parse Ok + config identical with/without `note`); round-trip via `save_config_text` preserves `note`/`default-note`.
+- **Dashboard** `runtime-toml-config.test.ts`: parse `note` from each table kind + `default-note`; serialize preserves them.
+- **Dashboard component** `runtime-panel`/`runtime-toml-editor` test: default-note banner renders; per-runtime note renders; inert runtime appears in list.
+
+## 6. Verification (closed) & open questions
+
+Direct grounding against `main` (worktree `6c9029bcbf`, 2026-06-25):
+
+- **V1 — parser tolerates `note` (CONFIRMED).** `runtime_toml.ml` picks known keys with `Otoml.find_opt`/`find_or`; no unknown-key rejection path. Extra `note` is never read. See §2.1.
+- **O1 — comment survival (CLOSED, was the falsified premise).** The full pipeline preserves comments; there is **no** re-serialization that drops them:
+  - Backend write `Runtime.save_config_text` (`runtime.ml:673-678`) = `validate` then `Fs_compat.save_file_atomic path content` — **verbatim raw write**.
+  - Keeper-assignment write `set_runtime_id_for_keeper` → `update_runtime_assignment_text` (`runtime.ml:619-627`) = `split_lines`-based **text transform**, not AST re-serialize.
+  - Dashboard editor `runtime-toml-editor.ts:511-526` = **raw `<textarea>`** on the source text; structured field edits `setRuntimeTomlKey` (`runtime-toml-config.ts:319-333`) replace only the matched line's value. Comments untouched.
+  - **Consequence:** the "typed field survives serialization" argument is *moot* (comments already survive). The only real gap is **structured surfacing** — see §1 premise correction.
+- **O2 (open)**: Should `default-note` live on `[runtime]` or be auto-derived from the `note` of whichever binding is currently `default`? Proposed: separate `default-note` ("why this is the default" ≠ "what this runtime is"), but see §8 staleness risk.
+
+## 7. Non-goals / future
+
+- No change to dispatch/routing semantics, no new endpoint, no comment migration mandate (comments stay valid for non-surfaced detail).
+- Future: `note : string list` dated-entry array with per-entry author/timestamp, if a structured changelog is wanted over a multi-line string.
+
+## 8. Workaround self-check (CLAUDE.md bar)
+
+- Telemetry-as-fix? No — adds a typed field + UI, not a counter over an unfixed failure.
+- String/substring classifier? No — `note` is a typed `string` value; this RFC *rejects* comment-string-parsing (§4).
+- N-of-M? No.
+- Cap/cooldown/dedup/repair? No.
+- Second SSOT? Explicitly avoided (§2.4).
+- **Staleness honesty (acknowledged risk).** `note`/`default-note` is free-form prose, so it *can* go stale when the value it explains changes (e.g. default flips but the note still describes the old reason). This is inherent to any human rationale and is **not** the "two concepts in one typed value" anti-pattern (note is explicitly metadata, not an overloaded typed field). Nothing enforces freshness. Mitigation, not enforcement: the dashboard renders `default-note` **directly next to the live `default` value**, so a stale note is visible to the operator at the point of reading. No write-time validation is proposed (validating prose against intent is not mechanizable).


### PR DESCRIPTION
## 목표
runtime.toml에 런타임 선택 근거(예: "왜 global default가 minimax인가")를 담는 optional typed `note`/`default-note` 필드 + 대시보드 구조화 surfacing을 제안하는 **Draft RFC**. RFC-0211(스키마 SSOT) 확장 + RFC-0273(대시보드 런타임 영속화) surface 연결.

## 배경
라이브 운영 중 "왜 default가 minimax가 됐지?"가 발생. 답은 `runtime.toml` 주석에 있었으나 어떤 구조화 뷰에도 안 떠서 운영자가 "설정에서 잘 안보임".

## 검증으로 정정된 전제 (정직성)
초안의 최강 논거였던 "대시보드 저장 시 주석 유실"은 **직접 grounding으로 반증**됨:
- 백엔드: `save_config_text`(`runtime.ml:673-678`, verbatim 저장), `update_runtime_assignment_text`(`:619-627`, 라인 텍스트 변환) — 주석 보존.
- 클라이언트: `runtime-toml-editor.ts:511-526` raw textarea, `setRuntimeTomlKey`(`runtime-toml-config.ts:319-333`) 라인 단위 치환 — 주석 보존.
- ⇒ 파이프라인 end-to-end 주석 보존. 따라서 이 RFC는 데이터 손실 fix가 아니라 **surfacing 개선(nice-to-have)**. RFC §1 premise correction에 명시했고 정당화가 약함을 인정.

## 안전성
- `Runtime_toml` 파서는 known key만 `find_opt`로 읽음(`runtime_toml.ml:107-108,164,182,244-258`) → `note` 추가는 dispatch-invisible(§2.1, §6 V1).
- second SSOT 없음(note는 runtime.toml 내부). 주석-파싱 heuristic은 명시적으로 거부(§4). default-note staleness 위험은 §8에 정직 기술(enforce 아닌 surfacing-옆-배치 완화).

## 변경 파일
- `docs/rfc/RFC-runtime-note-field-and-dashboard-surfacing.md` (신규, docs-only)

## 로컬 검증 (self-review)
- `scripts/check-ssot.sh`: R4/R5/R7 OK, R6 = 3 (baseline 9, 본 PR은 0 추가 — bare `~/.masc` 없음).
- RFC의 코드 사실 주장 전부 메인이 직접 grounding(file:line 수록). 적대 검증 fan-out workflow는 reviewer 샌드박스 도구 부재로 실패 → 수동 grounding으로 대체.

## 남은 미검증
- 구현 없음(RFC 단계). O2(default-note를 `[runtime]`에 둘지/default 바인딩 note에서 파생할지) 미결.
- 자동 적대 fan-out 미수행(도구 부재).

RFC-WAIVED: 이 PR 자체가 신규 RFC 추가(docs-only, gated 코드 subsystem 무변경).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
