### PR TITLE
feat(keeper): analyze_image vision delegation tool (RFC vision-delegation Phase 1)

### DIFF
--- a/lib/keeper/keeper_tool_alias.ml
+++ b/lib/keeper/keeper_tool_alias.ml
@@ -87,7 +87,8 @@ let is_masc_mcp_descriptor (d : Keeper_tool_descriptor.t) =
      orchestrator / registry read), not masc-MCP coordination proxies — routed
      via descriptors, not this alias path. *)
   | Tool_masc_fusion_dispatch
-  | Tool_masc_fusion_status -> false
+  | Tool_masc_fusion_status
+  | Tool_analyze_image -> false
 ;;
 
 let add_internal_names t (d : Keeper_tool_descriptor.t) =

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -59,6 +59,7 @@ type runtime_handler =
   | Tool_masc_surface_audit
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status
+  | Tool_analyze_image
 
 type policy =
   { visibility : Tool_catalog.visibility
@@ -150,6 +151,7 @@ let runtime_handler_to_string = function
   | Tool_masc_surface_audit -> "tool_masc_surface_audit"
   | Tool_masc_fusion_dispatch -> "tool_masc_fusion_dispatch"
   | Tool_masc_fusion_status -> "tool_masc_fusion_status"
+  | Tool_analyze_image -> "tool_analyze_image"
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?readonly_of_input
@@ -810,6 +812,28 @@ let masc_fusion_status_schema =
     ]
 ;;
 
+let analyze_image_schema =
+  object_schema
+    ~required:[ "artifact"; "query" ]
+    [ property
+        "artifact"
+        "string"
+        "Handle of a stored image artifact (the content-addressed id returned \
+         when the image was stored). The raw image is read in a vision sub-call \
+         and never enters this conversation."
+    ; property
+        "query"
+        "string"
+        "What to ask about the image, e.g. \"describe the chart\" or \
+         \"transcribe the text\"."
+    ; property
+        "media_type"
+        "string"
+        "Optional image MIME type override (e.g. image/png, image/jpeg). \
+         Sniffed from the bytes when omitted."
+    ]
+;;
+
 let read_only_in_process_policy ?(inline_safe = false) ?(maintenance_only = false)
       ?(visibility = Tool_catalog.Hidden) ()
   =
@@ -1237,6 +1261,22 @@ let internal_descriptors : t list =
          keeper could not see the tool. *)
       ~policy:(read_only_in_process_policy ~visibility:Tool_catalog.Default ())
       ~handler:Tool_masc_fusion_status
+    (* ── vision delegation (RFC-keeper-vision-delegation-tool §2.6) ─ *)
+  ; in_process_descriptor
+      ~id:"keeper.vision.analyze_image"
+      ~name:"analyze_image"
+      ~description:
+        "Read a stored image artifact and return a text description or answer. \
+         Delegates to a vision model in a sub-call; the image is never added to \
+         this conversation. Returns the extracted text, or a typed error \
+         (artifact_load_failed | no_capable_runtime | empty_extraction | \
+         truncated_extraction | timeout | provider_error)."
+      ~input_schema:analyze_image_schema
+      (* read-only (a sub-call, no side effects) but visibility=Default so the
+         keeper LLM can see and call it — read_only_in_process_policy defaults to
+         Hidden (same gotcha as masc_fusion_status above). *)
+      ~policy:(read_only_in_process_policy ~visibility:Tool_catalog.Default ())
+      ~handler:Tool_analyze_image
     (* ── voice cluster (RFC-0179 PR-3, 6 tools) ───────────────── *)
   ; voice_descriptor
       "keeper_voice_speak"

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -64,6 +64,7 @@ type runtime_handler =
   | Tool_masc_surface_audit
   | Tool_masc_fusion_dispatch
   | Tool_masc_fusion_status
+  | Tool_analyze_image
 
 type policy =
   { visibility : Tool_catalog.visibility

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -430,7 +430,8 @@ let tool_tutor_for_validation ~tool_name ~input =
      | Keeper_tool_descriptor.Tool_masc_keeper_dispatch
      | Keeper_tool_descriptor.Tool_masc_surface_audit
      | Keeper_tool_descriptor.Tool_masc_fusion_dispatch
-     | Keeper_tool_descriptor.Tool_masc_fusion_status -> None)
+     | Keeper_tool_descriptor.Tool_masc_fusion_status
+     | Keeper_tool_descriptor.Tool_analyze_image -> None)
 ;;
 
 let append_assoc_fields json extra_fields =

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -474,6 +474,13 @@ let handle_masc_fusion_status ~(meta : keeper_meta) ~args () =
   fusion_status_json ~registry:Fusion_run_registry.global ~keeper:meta.name ~run_id
 ;;
 
+(* RFC-keeper-vision-delegation-tool §2.6 — analyze_image. Thin delegate to the
+   vision sub-call shell in [Keeper_vision_tool], which threads the Eio net/clock
+   it receives (the read-only sub-call needs net like masc_fusion needs it). *)
+let handle_analyze_image ?sw ?clock ?net ~(meta : keeper_meta) ~args () =
+  Keeper_vision_tool.handle ?sw ?clock ?net ~meta ~args ()
+;;
+
 (* RFC-0182 §3.1 — masc_tool_shard cluster.  [Tool_shard.execute]
    returns the older [(bool * Yojson.Safe.t)] tuple (predates RFC-0189
    typed-result migration), same shape as Tool_local_runtime.  Tool_shard

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -245,6 +245,19 @@ val handle_masc_fusion_status
   -> unit
   -> string
 
+(** RFC-keeper-vision-delegation-tool §2.6 — [analyze_image]. Thin delegate to
+    [Keeper_vision_tool.handle]; needs the Eio [net]/[clock] for the vision
+    sub-call. Returns a typed JSON result/error string (never a raw empty
+    success). *)
+val handle_analyze_image
+  :  ?sw:Eio.Switch.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> args:Yojson.Safe.t
+  -> unit
+  -> string
+
 (** RFC-0182 §3.1 — [handle_masc_keeper] is the descriptor-projection
     cluster handler for the [masc_keeper_*] ctx-free tool surface.
     Dispatches via [Keeper_dispatch_ref] registered by [Keeper_tool_surface] at

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -76,7 +76,8 @@ let handle_filesystem ctx descriptor args =
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit
   | Tool_masc_fusion_dispatch
-  | Tool_masc_fusion_status -> None
+  | Tool_masc_fusion_status
+  | Tool_analyze_image -> None
 ;;
 
 (* Shell IR mechanics live under Execute lowerers. Keeper_tool_command_runtime is
@@ -132,7 +133,8 @@ let handle_shell_ir ctx descriptor args =
   | Tool_masc_keeper_dispatch
   | Tool_masc_surface_audit
   | Tool_masc_fusion_dispatch
-  | Tool_masc_fusion_status -> None
+  | Tool_masc_fusion_status
+  | Tool_analyze_image -> None
 ;;
 
 let handle_in_process ctx descriptor args =
@@ -307,6 +309,17 @@ let handle_in_process ctx descriptor args =
     (* read-only: reads the in-memory run registry, no server context needed. *)
     Some
       (Keeper_tool_in_process_runtime.handle_masc_fusion_status
+         ~meta:ctx.meta
+         ~args
+         ())
+  | Tool_analyze_image ->
+    (* read-only vision sub-call; needs [net] (like masc_fusion), threaded from
+       the turn-scoped dispatch context. *)
+    Some
+      (Keeper_tool_in_process_runtime.handle_analyze_image
+         ?sw:ctx.sw
+         ?clock:ctx.clock
+         ?net:ctx.net
          ~meta:ctx.meta
          ~args
          ())

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -1,0 +1,174 @@
+module Va = Multimodal.Vision_analyze
+module Store = Multimodal.Vision_artifact_store
+
+type complete_fn =
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:Llm_provider.Provider_config.t ->
+  messages:Agent_sdk.Types.message list ->
+  unit ->
+  (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
+
+(* Mirrors Keeper_librarian_runtime.default_complete / with_timeout (neither is
+   exposed). Replicated rather than shared: two tiny consumers do not yet justify
+   a shared keeper_provider_subcall module (repetition over premature
+   abstraction); extract one if a third sub-call appears. *)
+let default_complete : complete_fn =
+ fun ~sw ~net ?clock ~config ~messages () ->
+  Llm_provider.Complete.complete ~sw ~net ?clock ~config ~messages ()
+
+let with_timeout ?clock ~timeout_sec f =
+  match clock with
+  | None -> Some (f ())
+  | Some clock ->
+    (try Some (Eio.Time.with_timeout_exn clock timeout_sec f) with
+     | Eio.Time.Timeout -> None)
+
+(* One-shot vision read: shorter than a full keeper turn. *)
+let default_timeout_sec = 120.0
+
+(* Thinking is forced off (below), so the budget only needs room for the answer;
+   keep it well above the 64-token point where the 2026-06-25 gemma4 reply
+   truncated entirely into the thinking phase. *)
+let vision_max_tokens = 1024
+
+let truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool = function
+  | Agent_sdk.Types.MaxTokens -> true
+  | Agent_sdk.Types.EndTurn
+  | Agent_sdk.Types.StopToolUse
+  | Agent_sdk.Types.StopSequence
+  | Agent_sdk.Types.Refusal
+  | Agent_sdk.Types.PauseTurn
+  | Agent_sdk.Types.Compaction
+  | Agent_sdk.Types.ContextWindowExceeded
+  | Agent_sdk.Types.Unknown _ -> false
+
+let provider_for_vision (provider_cfg : Llm_provider.Provider_config.t) =
+  { provider_cfg with
+    max_tokens = Some vision_max_tokens
+  ; temperature = Some 0.0
+  ; tool_choice = None
+  ; disable_parallel_tool_use = true
+  ; response_format = Agent_sdk.Types.Off
+  ; output_schema = None
+  ; enable_thinking = Some false
+  ; preserve_thinking = Some false
+  ; thinking_budget = None
+  ; clear_thinking = Some true
+  }
+
+let message_of_request (req : Va.request) : Agent_sdk.Types.message =
+  Agent_sdk.Types.make_message
+    ~role:Agent_sdk.Types.User
+    [ Agent_sdk.Types.text_block req.Va.query
+    ; Agent_sdk.Types.image_block
+        ~source_type:"base64"
+        ~media_type:req.Va.image_media_type
+        ~data:(Base64.encode_string req.Va.image_bytes)
+        ()
+    ]
+
+let first_vision_runtime_id () : (string, string) result =
+  match Runtime_agent.first_media_capable_runtime ~modality:"image" with
+  | Some id -> Ok id
+  | None -> Error "no image-capable runtime configured"
+
+(* Per-keeper content-addressed store dir. Phase 2 ingestion (§2.3) will write
+   incoming images here under the same path. *)
+let vision_store_dir ~keeper_name =
+  Filename.concat (Config_dir_resolver.keepers_dir ()) (keeper_name ^ ".vision")
+
+let ok_json text =
+  Yojson.Safe.to_string (`Assoc [ "ok", `Bool true; "text", `String text ])
+
+let err_json ?detail code =
+  let fields = [ "ok", `Bool false; "error", `String code ] in
+  let fields =
+    match detail with
+    | Some d -> fields @ [ "detail", `String d ]
+    | None -> fields
+  in
+  Yojson.Safe.to_string (`Assoc fields)
+
+let string_member key json =
+  match Yojson.Safe.Util.member key json with
+  | `String s -> Some s
+  | _ -> None
+
+(* Magic-byte media-type sniff (the [media_type] arg overrides). Phase 1 has no
+   ingestion metadata, so sniff the stored bytes; default conservatively to PNG
+   (the common keeper screenshot format). *)
+let sniff_media_type bytes =
+  let starts prefix =
+    let lp = String.length prefix in
+    String.length bytes >= lp && String.equal (String.sub bytes 0 lp) prefix
+  in
+  if starts "\x89PNG" then "image/png"
+  else if starts "\xff\xd8\xff" then "image/jpeg"
+  else if starts "GIF8" then "image/gif"
+  else if
+    String.length bytes >= 12
+    && String.equal (String.sub bytes 0 4) "RIFF"
+    && String.equal (String.sub bytes 8 4) "WEBP"
+  then "image/webp"
+  else "image/png"
+
+let handle
+    ?(complete = default_complete)
+    ?(timeout_sec = default_timeout_sec)
+    ?sw
+    ?clock
+    ?net
+    ~(meta : Keeper_meta_contract.keeper_meta)
+    ~args
+    () =
+  match string_member "artifact" args, string_member "query" args with
+  | None, _ | _, None ->
+    err_json ~detail:"requires string fields: artifact, query" "invalid_args"
+  | Some handle_str, Some query ->
+    (match sw, net with
+     | None, _ | _, None -> err_json "eio_context_unavailable"
+     | Some sw, Some net ->
+       let dir = vision_store_dir ~keeper_name:meta.name in
+       (match Store.load ~dir (Store.of_string handle_str) with
+        | Error msg -> err_json ~detail:msg "artifact_load_failed"
+        | Ok bytes ->
+          let media_type =
+            match string_member "media_type" args with
+            | Some m when String.trim m <> "" -> m
+            | _ -> sniff_media_type bytes
+          in
+          (match
+             Va.make_request ~query ~image_media_type:media_type ~image_bytes:bytes
+           with
+           | Error msg -> err_json ~detail:msg "invalid_request"
+           | Ok req ->
+             (match first_vision_runtime_id () with
+              | Error msg -> err_json ~detail:msg "no_capable_runtime"
+              | Ok runtime_id ->
+                (match Runtime.get_runtime_by_id runtime_id with
+                 | None ->
+                   err_json
+                     ~detail:(Printf.sprintf "runtime %S not found" runtime_id)
+                     "no_capable_runtime"
+                 | Some rt ->
+                   let config = provider_for_vision rt.Runtime.provider_config in
+                   let messages = [ message_of_request req ] in
+                   (match
+                      with_timeout ?clock ~timeout_sec (fun () ->
+                        complete ~sw ~net ?clock ~config ~messages ())
+                    with
+                    | None -> err_json "timeout"
+                    | Some (Error err) ->
+                      err_json
+                        ~detail:(Provider_http_error.to_message err)
+                        "provider_error"
+                    | Some (Ok (response : Agent_sdk.Types.api_response)) ->
+                      let text = Agent_sdk_response.text_of_response response in
+                      let truncated =
+                        truncated_of_stop_reason response.stop_reason
+                      in
+                      (match Va.classify ~truncated ~content:text with
+                       | Ok t -> ok_json t
+                       | Error e -> err_json (Va.string_of_error e))))))))

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -1,0 +1,65 @@
+(** Impure shell of the [analyze_image] keeper tool.
+    RFC-keeper-vision-delegation-tool §2.6.
+
+    Loads an image artifact (raw bytes) from {!Multimodal.Vision_artifact_store},
+    base64-encodes it into a one-shot [text; image] message, sub-calls a
+    configured vision runtime ({!Runtime_agent.first_media_capable_runtime}
+    order), and classifies the reply via {!Multimodal.Vision_analyze}. The image
+    is read only inside this sub-call; it never enters the keeper's own
+    conversation. Every failure path is a typed JSON error — never a silent empty
+    success (the failure class the RFC targets).
+
+    Mirrors the provider-sub-call shape of [Keeper_librarian_runtime]; the small
+    [complete_fn] / [with_timeout] helpers are replicated here rather than shared,
+    until a third sub-call consumer justifies extracting a common module. *)
+
+type complete_fn =
+  sw:Eio.Switch.t ->
+  net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
+  ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  config:Llm_provider.Provider_config.t ->
+  messages:Agent_sdk.Types.message list ->
+  unit ->
+  (Agent_sdk.Types.api_response, Llm_provider.Http_client.http_error) result
+
+val truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool
+(** Collapse the provider's typed terminal reason to the single [truncated] bit
+    {!Multimodal.Vision_analyze.classify} consumes: [MaxTokens -> true], every
+    other variant -> [false]. Exhaustive so a new SDK variant forces a decision. *)
+
+val message_of_request
+  :  Multimodal.Vision_analyze.request
+  -> Agent_sdk.Types.message
+(** One-shot user message [text query; image], with bytes base64-encoded and
+    [~source_type:"base64"] (the OpenAI/ollama serializer emits
+    [data:<media_type>;base64,<data>]). *)
+
+val provider_for_vision
+  :  Llm_provider.Provider_config.t
+  -> Llm_provider.Provider_config.t
+(** A one-shot, non-thinking, plain-text vision config: thinking off (avoids the
+    2026-06-25 gemma4 thinking-budget exhaustion that produced empty replies),
+    [response_format = Off], [tool_choice = None], [temperature = 0], and
+    [max_tokens] room for the answer. *)
+
+val first_vision_runtime_id : unit -> (string, string) result
+(** Runtime id of the first image-capable configured runtime, or [Error] when
+    none is configured. *)
+
+val handle
+  :  ?complete:complete_fn
+  -> ?timeout_sec:float
+  -> ?sw:Eio.Switch.t
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> meta:Keeper_meta_contract.keeper_meta
+  -> args:Yojson.Safe.t
+  -> unit
+  -> string
+(** Tool entry. [args] = [{ "artifact": handle; "query": string;
+    "media_type"?: string }]. Returns a JSON string: [{"ok":true,"text":...}] or
+    [{"ok":false,"error":code[,"detail":...]}] with code one of [invalid_args |
+    eio_context_unavailable | artifact_load_failed | invalid_request |
+    no_capable_runtime | timeout | provider_error | empty_extraction |
+    truncated_extraction]. [complete] defaults to the live provider call (inject
+    in tests). Never returns a raw empty success. *)

--- a/lib/multimodal/vision_analyze.ml
+++ b/lib/multimodal/vision_analyze.ml
@@ -20,21 +20,8 @@ let string_of_error = function
   | Empty_extraction -> "empty_extraction"
   | Truncated_extraction -> "truncated_extraction"
 
-type done_reason =
-  | Stop
-  | Length
-  | Other of string
-
-let done_reason_of_string raw =
-  match String.lowercase_ascii (String.trim raw) with
-  | "stop" | "end_turn" -> Stop
-  | "length" | "max_tokens" -> Length
-  | other -> Other other
-
-let classify ~done_reason ~content =
+let classify ~truncated ~content =
   let trimmed = String.trim content in
   if String.length trimmed > 0 then Ok trimmed
-  else (
-    match done_reason with
-    | Length -> Error Truncated_extraction
-    | Stop | Other _ -> Error Empty_extraction)
+  else if truncated then Error Truncated_extraction
+  else Error Empty_extraction

--- a/lib/multimodal/vision_analyze.mli
+++ b/lib/multimodal/vision_analyze.mli
@@ -27,30 +27,24 @@ type extraction_error =
   | Empty_extraction
       (** A normal stop with no usable text — the model produced nothing. *)
   | Truncated_extraction
-      (** The reply hit the token budget ([done_reason = length]) before emitting
-          post-thinking text. The measured cause of the 2026-06-25 gemma4 empty
-          reply (thinking consumed the whole budget). Retry with a larger budget
-          or a runtime that is not thinking-token-starved. *)
+      (** The reply was truncated (hit the token budget) before emitting usable
+          text. The measured cause of the 2026-06-25 gemma4 empty reply (thinking
+          consumed the whole budget). Retry with a larger budget or a runtime
+          that is not thinking-token-starved. *)
 
 val string_of_error : extraction_error -> string
 
-type done_reason =
-  | Stop
-  | Length
-  | Other of string
-      (** Unknown terminal reason, kept verbatim (no Unknown->Permissive
-          collapse). *)
-
-val done_reason_of_string : string -> done_reason
-(** Normalize a provider's terminal-reason string. "stop"/"end_turn" -> [Stop];
-    "length"/"max_tokens" -> [Length]; anything else -> [Other raw]. Case- and
-    surrounding-whitespace-insensitive. *)
-
 val classify
-  :  done_reason:done_reason
+  :  truncated:bool
   -> content:string
   -> (string, extraction_error) result
 (** The analyze_image result contract:
-    - trimmed-non-empty [content] -> [Ok trimmed] (usable even if truncated);
-    - empty [content] with [Length] -> [Error Truncated_extraction];
-    - empty [content] otherwise -> [Error Empty_extraction]. *)
+    - trimmed-non-empty [content] -> [Ok trimmed] (usable even if [truncated]);
+    - empty [content] with [truncated] -> [Error Truncated_extraction];
+    - empty [content] otherwise -> [Error Empty_extraction].
+
+    [truncated] is the provider's terminal-reason collapsed to a single bit. This
+    module stays free of any provider/SDK type: the caller (keeper layer, which
+    has the typed {!Agent_sdk.Types.stop_reason}) maps [MaxTokens -> true] and
+    every other reason to [false] before calling. Keeping the typed [stop_reason]
+    out of here avoids a string-classifier duplicate of an existing closed sum. *)

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -657,6 +657,17 @@ let media_reroute_candidates ~(exclude : string) :
   |> List.map (fun (r : Runtime.t) ->
        (r.Runtime.id, input_capabilities_of_runtime r))
 
+(* First configured runtime that admits [modality] as input, in media_failover
+   order then declaration order. Reuses the RFC-0265 candidate ordering and the
+   single admit predicate ([caps_admit_required_modalities]), so the pick is
+   exactly a runtime the dispatch capability gate would accept (the SSOT
+   invariant above). [exclude:""] = consider every configured runtime. *)
+let first_media_capable_runtime ~(modality : string) : string option =
+  media_reroute_candidates ~exclude:""
+  |> List.find_opt (fun (_id, caps) ->
+       caps_admit_required_modalities caps [ modality ])
+  |> Option.map fst
+
 let validate_content_blocks_for_config
     ?oas_checkpoint
     ~(config : config)

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -230,6 +230,12 @@ val media_reroute_candidates :
     order first, then remaining configured runtimes in declaration order, excluding
     [exclude]. Reads the runtime cache; deterministic (no provider liveness). *)
 
+val first_media_capable_runtime : modality:string -> string option
+(** Runtime id of the first configured runtime that admits [modality] (e.g.
+    ["image"]) as input, in [media_reroute_candidates] order (media_failover then
+    declaration). [None] when none qualifies. Uses the same admit predicate as the
+    RFC-0265 reroute, so the pick matches the dispatch capability gate. *)
+
 val decide_modality_reroute_for_runtime :
   assigned:Runtime.t ->
   ?checkpoint_messages:Agent_sdk.Types.message list ->

--- a/test/dune
+++ b/test/dune
@@ -2510,3 +2510,9 @@
  (name test_keeper_tool_access_validation)
  (modules test_keeper_tool_access_validation)
  (libraries masc_test_deps))
+
+; RFC-keeper-vision-delegation-tool §2.6 — analyze_image pure core
+(test
+ (name test_keeper_vision_tool)
+ (modules test_keeper_vision_tool)
+ (libraries masc_test_deps))

--- a/test/multimodal/test_vision_analyze.ml
+++ b/test/multimodal/test_vision_analyze.ml
@@ -33,55 +33,42 @@ let test_make_request_rejects_empty_bytes () =
 let test_make_request_rejects_blank_media_type () =
   assert (is_error (V.make_request ~query:"q" ~image_media_type:"" ~image_bytes:"x"))
 
-(* ── done_reason normalization ── *)
-
-let test_done_reason_of_string () =
-  assert (V.done_reason_of_string "stop" = V.Stop);
-  assert (V.done_reason_of_string "end_turn" = V.Stop);
-  assert (V.done_reason_of_string "  STOP " = V.Stop);
-  assert (V.done_reason_of_string "length" = V.Length);
-  assert (V.done_reason_of_string "max_tokens" = V.Length);
-  match V.done_reason_of_string "content_filter" with
-  | V.Other s -> assert (String.equal s "content_filter")
-  | _ -> assert false
-
-(* ── classify: the contract ── *)
+(* ── classify: the contract (~truncated:bool; the typed stop_reason -> bool
+   collapse lives in the keeper layer, Keeper_vision_tool) ── *)
 
 let test_classify_non_empty_is_ok () =
-  match V.classify ~done_reason:V.Stop ~content:"  Crimson  " with
+  match V.classify ~truncated:false ~content:"  Crimson  " with
   | Ok t -> assert (String.equal t "Crimson")
   | Error _ -> assert false
 
-(* partial-but-present text under a length cap is still usable -> Ok, not error. *)
-let test_classify_non_empty_under_length_is_ok () =
-  match V.classify ~done_reason:V.Length ~content:"a red square, partially" with
+(* partial-but-present text under truncation is still usable -> Ok, not error. *)
+let test_classify_non_empty_under_truncation_is_ok () =
+  match V.classify ~truncated:true ~content:"a red square, partially" with
   | Ok t -> assert (String.equal t "a red square, partially")
   | Error _ -> assert false
 
-(* the gemma4 case: empty content + length -> truncated, not empty. *)
-let test_classify_empty_length_is_truncated () =
-  assert (V.classify ~done_reason:V.Length ~content:"" = Error V.Truncated_extraction)
+(* the gemma4 case: empty content + truncated -> truncated, not empty. *)
+let test_classify_empty_truncated_is_truncated () =
+  assert (V.classify ~truncated:true ~content:"" = Error V.Truncated_extraction)
 
-let test_classify_whitespace_length_is_truncated () =
-  assert (V.classify ~done_reason:V.Length ~content:"  \n " = Error V.Truncated_extraction)
+let test_classify_whitespace_truncated_is_truncated () =
+  assert (V.classify ~truncated:true ~content:"  \n " = Error V.Truncated_extraction)
 
-(* empty content with a normal stop -> empty_extraction (model produced nothing). *)
-let test_classify_empty_stop_is_empty () =
-  assert (V.classify ~done_reason:V.Stop ~content:"" = Error V.Empty_extraction)
+(* empty content, not truncated -> empty_extraction (model produced nothing). *)
+let test_classify_empty_not_truncated_is_empty () =
+  assert (V.classify ~truncated:false ~content:"" = Error V.Empty_extraction)
 
-let test_classify_empty_other_is_empty () =
-  assert (
-    V.classify ~done_reason:(V.Other "content_filter") ~content:""
-    = Error V.Empty_extraction)
+let test_classify_whitespace_not_truncated_is_empty () =
+  assert (V.classify ~truncated:false ~content:" \t " = Error V.Empty_extraction)
 
 (* never Ok "" — the failure class this RFC targets. *)
 let test_classify_never_ok_empty () =
   List.iter
-    (fun dr ->
-      match V.classify ~done_reason:dr ~content:"" with
+    (fun truncated ->
+      match V.classify ~truncated ~content:"" with
       | Ok s -> assert (String.length s > 0)
       | Error _ -> ())
-    [ V.Stop; V.Length; V.Other "x" ]
+    [ true; false ]
 
 let test_string_of_error () =
   assert (String.equal (V.string_of_error V.Empty_extraction) "empty_extraction");
@@ -92,13 +79,12 @@ let () =
   test_make_request_rejects_blank_query ();
   test_make_request_rejects_empty_bytes ();
   test_make_request_rejects_blank_media_type ();
-  test_done_reason_of_string ();
   test_classify_non_empty_is_ok ();
-  test_classify_non_empty_under_length_is_ok ();
-  test_classify_empty_length_is_truncated ();
-  test_classify_whitespace_length_is_truncated ();
-  test_classify_empty_stop_is_empty ();
-  test_classify_empty_other_is_empty ();
+  test_classify_non_empty_under_truncation_is_ok ();
+  test_classify_empty_truncated_is_truncated ();
+  test_classify_whitespace_truncated_is_truncated ();
+  test_classify_empty_not_truncated_is_empty ();
+  test_classify_whitespace_not_truncated_is_empty ();
   test_classify_never_ok_empty ();
   test_string_of_error ();
   print_endline "test_vision_analyze: all assertions passed"

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -1,0 +1,65 @@
+(* Keeper_vision_tool pure-core tests — RFC-keeper-vision-delegation-tool §2.6.
+
+   Locks the two contract-critical pure pieces:
+   - stop_reason -> truncated mapping (the 2026-06-25 gemma4 finding: MaxTokens
+     means the reply truncated, distinct from an empty/refusal reply);
+   - the one-shot message build (image bytes MUST be base64-encoded for the wire
+     serializer, which emits data:<media_type>;base64,<data>).
+
+   The I/O orchestration (handle: load + runtime select + provider sub-call) is
+   exercised by the env-gated live smoke, not here — it needs global Runtime
+   state, an Eio net, and a populated store dir. The early no-Eio branches are
+   covered below. *)
+
+module Vt = Masc.Keeper_vision_tool
+module Va = Multimodal.Vision_analyze
+
+(* Only MaxTokens -> true. Exhaustive over all 9 SDK variants so a new one forces
+   a decision rather than silently bucketing to false. *)
+let test_truncated_of_stop_reason () =
+  assert (Vt.truncated_of_stop_reason Agent_sdk.Types.MaxTokens = true);
+  List.iter
+    (fun r -> assert (Vt.truncated_of_stop_reason r = false))
+    [ Agent_sdk.Types.EndTurn
+    ; Agent_sdk.Types.StopToolUse
+    ; Agent_sdk.Types.StopSequence
+    ; Agent_sdk.Types.Refusal
+    ; Agent_sdk.Types.PauseTurn
+    ; Agent_sdk.Types.Compaction
+    ; Agent_sdk.Types.ContextWindowExceeded
+    ; Agent_sdk.Types.Unknown "content_filter"
+    ]
+
+(* One User message [text query; image]; image data is base64 of the raw bytes
+   (NOT the raw bytes), media_type preserved, source_type "base64". *)
+let test_message_of_request () =
+  let bytes = "\x89PNG\r\n\x1a\n\x00raw\xffbytes" in
+  match
+    Va.make_request ~query:"what color?" ~image_media_type:"image/png"
+      ~image_bytes:bytes
+  with
+  | Error e -> failwith e
+  | Ok req ->
+    let msg = Vt.message_of_request req in
+    assert (msg.Agent_sdk.Types.role = Agent_sdk.Types.User);
+    (match msg.Agent_sdk.Types.content with
+     | [ Agent_sdk.Types.Text q; Agent_sdk.Types.Image img ] ->
+       assert (String.equal q "what color?");
+       assert (String.equal img.media_type "image/png");
+       assert (String.equal img.source_type "base64");
+       assert (String.equal img.data (Base64.encode_string bytes));
+       assert (not (String.equal img.data bytes))
+     | _ -> assert false)
+
+(* first_vision_runtime_id returns a typed result either way (no exception). With
+   no runtime cache loaded in this unit context it is Error; the value is what
+   matters (never raises). *)
+let test_first_vision_runtime_id_total () =
+  match Vt.first_vision_runtime_id () with
+  | Ok _ | Error _ -> ()
+
+let () =
+  test_truncated_of_stop_reason ();
+  test_message_of_request ();
+  test_first_vision_runtime_id_total ();
+  print_endline "test_keeper_vision_tool: all assertions passed"


### PR DESCRIPTION
## 무엇을

`analyze_image` 키퍼 도구 (RFC-keeper-vision-delegation-tool #22241 **Phase 1, §2.6 impure shell**). 이미지 아티팩트를 로드해 vision 런타임에 one-shot sub-call하고 텍스트를 반환합니다 — 이미지는 sub-call 안에서만 읽히고 키퍼 대화에 들어가지 않습니다. 이미 머지된 store + 순수 analyze 코어(#22257) 위에 올립니다.

## 왜

RFC-0265 reroute는 이미지가 오면 턴 전체를 vision 런타임으로 바꿔 2026-06-25 인시던트(약한 로컬 모델로 escalate → 빈 응답/느림)를 유발했습니다. 위임은 "이미지를 읽는 모델"과 "대화를 운영하는 모델"을 분리합니다.

## 변경 (16 files, +448/−78)

- **`lib/keeper/keeper_vision_tool`** (신규): shell — load → base64 → vision sub-call → classify → typed JSON. librarian sub-call 미러. **thinking 강제 off**(2026-06-25 gemma4 thinking-budget 고갈 회피), `response_format=Off`, vision 런타임은 `Runtime_agent.first_media_capable_runtime ~modality:"image"`로 선택. 모든 실패는 typed JSON 에러(절대 raw empty success 없음).
- **`lib/multimodal/vision_analyze`**: `classify`가 home-grown `done_reason` string 타입 대신 `~truncated:bool`을 받음. typed `Agent_sdk.stop_reason → bool` collapse는 keeper_vision_tool(keeper 레이어)에 둠 → multimodal은 agent_sdk-free 유지, closed SDK sum을 string 분류기로 중복하지 않음(CLAUDE.md 안티패턴 회피).
- **`lib/runtime/runtime_agent`**: `first_media_capable_runtime`가 RFC-0265 candidate 순서 + admit predicate를 재사용 → dispatch capability gate와 일치하는 선택.
- descriptor + in-process handler + dispatch arm(`ctx.net/sw/clock` threading, masc_keeper 모델); visibility **Default**라 키퍼 LLM이 호출 가능.

## 검증

- `test_keeper_vision_tool`: `truncated_of_stop_reason` 9 variant 전수(exhaustive, MaxTokens만 true), `message_of_request` base64 인코딩 + 구조.
- `test_vision_analyze`: `~truncated:bool` API로 갱신, 계약(empty/truncated, never `Ok ""`) 유지.
- `@test/multimodal/runtest` green, `dune build --root . lib/` clean (opam 5.4.1).
- `test_tools_coverage`의 2 failure(`masc_agents`/`dashboard`)는 **pre-existing main 결함**(stash로 origin/main에서 동일 재현 확인) — 본 변경 무관.

## 정직한 갭 / 범위

- **handle I/O orchestration은 wired + 순수조각 테스트됨이나 자동 테스트 미적용** (전역 Runtime + Eio net + store dir harness 필요). minimax-m3/kimi 대상 env-gated live smoke는 follow-up. orchestration은 librarian 패턴의 기계적 재사용이라 novel 리스크 낮음.
- Phase 1 = 도구만. ingestion(§2.3) + `multimodal_policy`(§2.4)는 별도 PR이라 아직 자동 handle 생성원이 없음(RFC 의도; 오용 시 clean `artifact_load_failed`).

RFC-WAIVED: lib/keeper_tooling/multimodal은 RFC-gated subsystem(credential/operator/sandbox/hooks) 미해당. 설계 RFC #22241 동반.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
