### PR TITLE
fix(dashboard): keeper roster icon alignment and hide empty recent activity

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -359,11 +359,11 @@ export function AgentDetailOverlay() {
             ${renderOwnedTasks(ownedTasks, visibleOwnedTasks, isFilteringTasks)}
           <//>
 
-          <${SectionCard} label="최근 활동">
-            ${lines.length === 0
-              ? html`<div class="h-full min-h-30"><${EmptyState} message="최근 활동 메시지가 없습니다" compact /></div>`
-              : html`<div role="log" aria-label="최근 활동 로그" class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="v2-monitoring-row border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2.5 font-mono text-xs text-[var(--color-fg-primary)] leading-relaxed rounded-[var(--r-1)] hover:bg-[var(--color-bg-hover)] hover:border-[var(--color-border-strong)] transition-colors">${line}</div>`)}</div>`}
-          <//>
+          ${lines.length > 0
+            ? html`<${SectionCard} label="최근 활동">
+              <div role="log" aria-label="최근 활동 로그" class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="v2-monitoring-row border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2.5 font-mono text-xs text-[var(--color-fg-primary)] leading-relaxed rounded-[var(--r-1)] hover:bg-[var(--color-bg-hover)] hover:border-[var(--color-border-strong)] transition-colors">${line}</div>`)}</div>
+            <//>`
+            : null}
         </div>
 
         <div class="flex flex-col gap-5">

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -7,7 +7,7 @@
 import { html } from 'htm/preact'
 import {
   MessageSquare,
-  MoreHorizontal,
+  MoreVertical,
   Pause,
   Play,
   RotateCcw,
@@ -301,7 +301,7 @@ function RosterRow({
         onClick=${(event: MouseEvent) => onMenu(keeper, event)}
         data-testid=${`kw-roster-menu-${keeper.name}`}
       >
-        <${MoreHorizontal} size=${15} aria-hidden="true" />
+        <${MoreVertical} size=${16} focusable="false" aria-hidden="true" />
       </button>
     </div>
   `

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -1233,7 +1233,8 @@
 .kp-more {
   position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
   width: 24px; height: 24px; border-radius: var(--radius-sm); border: 1px solid var(--border-main);
-  background: var(--bg-panel); color: var(--text-mid); cursor: pointer; font-size: 14px; line-height: 1;
+  background: var(--bg-panel); color: var(--text-mid); cursor: pointer;
+  display: flex; align-items: center; justify-content: center; padding: 0;
   opacity: 0; transition: 0.14s; z-index: 2;
 }
 .kp-row:hover .kp-more { opacity: 1; }

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -1227,7 +1227,7 @@
 
 /* roster row command menu */
 .kp-row { position: relative; }
-/* on hover the ⋯ takes the right slot — fade the time/att stack so they
+/* on hover the command menu button takes the right slot — fade the time/att stack so they
    don't collide with the absolutely-positioned button */
 .kp-row:hover .kp-right { opacity: 0; pointer-events: none; }
 .kp-more {

--- a/docs/superpowers/plans/2026-06-24-dashboard-ui-polish-plan.md
+++ b/docs/superpowers/plans/2026-06-24-dashboard-ui-polish-plan.md
@@ -1,0 +1,220 @@
+# Dashboard UI Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the crooked hover ellipsis on keeper roster rows and hide the empty “최근 활동” card in the agent detail overlay.
+
+**Architecture:** Two independent, small UI changes in existing files: replace a text glyph with a centered SVG icon in the keeper roster, and conditionally render a SectionCard in the agent detail overlay. No new components or data-flow changes.
+
+**Tech Stack:** Preact + TypeScript, `htm/preact`, `lucide-preact`, Tailwind-like utility classes + custom CSS in `dashboard/src/styles/keeper-v2/v2.css`, Vitest.
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts` | Renders keeper rows; contains the `⋯` button markup. |
+| `dashboard/src/styles/keeper-v2/v2.css` | `.kp-more` styles. |
+| `dashboard/src/components/agent-detail.ts` | Agent detail overlay; renders the “최근 활동” SectionCard. |
+
+---
+
+## Task 1: Replace roster ellipsis text with `MoreVertical` icon
+
+**Files:**
+- Modify: `dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts:188-197`
+- Modify: `dashboard/src/styles/keeper-v2/v2.css:1237-1244`
+- Test: `dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts`
+
+- [ ] **Step 1: Add the `MoreVertical` import**
+
+In `dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts`, add to the existing `lucide-preact` import list (or create a new import line if no lucide import exists):
+
+```ts
+import { MoreVertical } from 'lucide-preact'
+```
+
+- [ ] **Step 2: Replace the button contents**
+
+Change:
+
+```ts
+<button
+  type="button"
+  class="kp-more"
+  aria-label=${`${keeper.name} 명령`}
+  title="명령 메뉴"
+  onClick=${(event: MouseEvent) => onMenu(keeper, event)}
+  data-testid=${`kw-roster-menu-${keeper.name}`}
+>
+  <span aria-hidden="true">${'\u22EF'}</span>
+</button>
+```
+
+To:
+
+```ts
+<button
+  type="button"
+  class="kp-more"
+  aria-label=${`${keeper.name} 명령`}
+  title="명령 메뉴"
+  onClick=${(event: MouseEvent) => onMenu(keeper, event)}
+  data-testid=${`kw-roster-menu-${keeper.name}`}
+>
+  <${MoreVertical} size=${16} focusable="false" aria-hidden="true" />
+</button>
+```
+
+- [ ] **Step 3: Center the icon via CSS**
+
+In `dashboard/src/styles/keeper-v2/v2.css`, replace the `.kp-more` block:
+
+```css
+.kp-more {
+  position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+  width: 24px; height: 24px; border-radius: var(--radius-sm); border: 1px solid var(--border-main);
+  background: var(--bg-panel); color: var(--text-mid); cursor: pointer; font-size: 14px; line-height: 1;
+  opacity: 0; transition: 0.14s; z-index: 2;
+}
+```
+
+With:
+
+```css
+.kp-more {
+  position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+  width: 24px; height: 24px; border-radius: var(--radius-sm); border: 1px solid var(--border-main);
+  background: var(--bg-panel); color: var(--text-mid); cursor: pointer;
+  display: flex; align-items: center; justify-content: center; padding: 0;
+  opacity: 0; transition: 0.14s; z-index: 2;
+}
+```
+
+Keep the existing `.kp-row:hover .kp-more` and `.kp-more:hover` rules unchanged.
+
+- [ ] **Step 4: Verify roster tests still pass**
+
+Run:
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-memory-consolidation-wire/dashboard
+pnpm test -- keeper-workspace-roster.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Handle lucide-preact test mock if needed**
+
+If the test run fails with an error loading `lucide-preact`, add a mock to `keeper-workspace-roster.test.ts` before the component import:
+
+```ts
+vi.mock('lucide-preact', () => ({
+  MoreVertical: () => null,
+}))
+```
+
+Then re-run the test from Step 4.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-memory-consolidation-wire
+git add dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts dashboard/src/styles/keeper-v2/v2.css
+git commit -m "fix(dashboard): center keeper roster hover menu icon with MoreVertical"
+```
+
+---
+
+## Task 2: Hide empty “최근 활동” card in agent detail overlay
+
+**Files:**
+- Modify: `dashboard/src/components/agent-detail.ts:362-366`
+- Test: `dashboard/src/components/agent-detail-state.test.ts` (no direct UI tests exist, but run to ensure imports still resolve)
+
+- [ ] **Step 1: Make the SectionCard conditional**
+
+In `dashboard/src/components/agent-detail.ts`, replace:
+
+```ts
+<${SectionCard} label="최근 활동">
+  ${lines.length === 0
+    ? html`<div class="h-full min-h-30"><${EmptyState} message="최근 활동 메시지가 없습니다" compact /></div>`
+    : html`<div role="log" aria-label="최근 활동 로그" class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">${lines.map((line: string, idx: number) => html`<div key=${idx} class="v2-monitoring-row border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2.5 font-mono text-xs text-[var(--color-fg-primary)] leading-relaxed rounded-[var(--r-1)] hover:bg-[var(--color-bg-hover)] hover:border-[var(--color-border-strong)] transition-colors">${line}</div>`)}</div>`}
+<//>
+```
+
+With:
+
+```ts
+${lines.length > 0
+  ? html`
+      <${SectionCard} label="최근 활동">
+        <div role="log" aria-label="최근 활동 로그" class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">
+          ${lines.map((line: string, idx: number) => html`<div key=${idx} class="v2-monitoring-row border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2.5 font-mono text-xs text-[var(--color-fg-primary)] leading-relaxed rounded-[var(--r-1)] hover:bg-[var(--color-bg-hover)] hover:border-[var(--color-border-strong)] transition-colors">${line}</div>`)}
+        </div>
+      <//>
+    `
+  : null}
+```
+
+- [ ] **Step 2: Verify agent-detail tests still pass**
+
+Run:
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-memory-consolidation-wire/dashboard
+pnpm test -- agent-detail-state.test.ts
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit Task 2**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-memory-consolidation-wire
+git add dashboard/src/components/agent-detail.ts
+git commit -m "fix(dashboard): hide empty recent activity card in agent detail overlay"
+```
+
+---
+
+## Task 3: Final verification
+
+- [ ] **Step 1: Run type check**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-memory-consolidation-wire/dashboard
+npx tsc --noEmit --pretty
+```
+
+Expected: no TypeScript errors.
+
+- [ ] **Step 2: Run full dashboard test suite**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-memory-consolidation-wire/dashboard
+pnpm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Push branch**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-memory-consolidation-wire
+git push
+```
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Task |
+|------------------|------|
+| Keeper roster hover ellipsis replaced with `MoreVertical` and centered | Task 1 |
+| Existing menu behavior preserved | Task 1 (only button content + CSS changed) |
+| “최근 활동” hidden when `lines.length === 0` | Task 2 |
+| Data source unchanged | Not modified |
+| agent-profile.ts untouched | Not modified |

--- a/docs/superpowers/specs/2026-06-24-dashboard-ui-polish-design.md
+++ b/docs/superpowers/specs/2026-06-24-dashboard-ui-polish-design.md
@@ -1,0 +1,99 @@
+# Dashboard UI Polish: keeper roster ellipsis & agent detail recent activity
+
+## Context
+
+MASC 대시보드의 두 가지 시각적/UX 문제를 수정합니다.
+
+1. **Keeper roster 호버 메뉴 버튼** (`dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts`):
+   마우스를 keeper 행 위에 올리면 우측에 `⋯`(U+22EF) 텍스트 버튼이 나타나는데, 폰트 기반 문자 + `line-height: 1` 조합 때문에 시각적으로 삐딱하게 보입니다.
+
+2. **Agent detail “최근 활동”** (`dashboard/src/components/agent-detail.ts`):
+   `namespaceActivity`가 비어 있을 때 `EmptyState`를 계속 노출해서 “아무것도 안 나온다”는 인상을 줍니다.
+
+## Goals
+
+- 키퍼 행의 호버 메뉴 버튼을 SVG 아이콘으로 교체하고 정중앙 정렬합니다.
+- Agent detail 모달의 “최근 활동” 카드는 데이터가 없을 때 아예 보여주지 않습니다.
+- 기존 동작(메뉴 열기, ESC/스크롤 닫기, 접근성 라벨 등)은 그대로 유지합니다.
+
+## Non-goals
+
+- agent-profile.ts의 “프로젝트 활동”은 수정하지 않습니다.
+- 최근 활동의 데이터 소스(`namespaceActivity`, `fetchWorkspaceMessages`)는 변경하지 않습니다.
+- 새로운 공통 IconButton 컴포넌트를 만들지 않습니다.
+
+## Design
+
+### 1. Keeper roster 호버 메뉴 버튼
+
+**File:** `dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts`
+
+- Import `MoreVertical` from `lucide-preact`.
+- Replace the existing text span:
+  ```ts
+  <span aria-hidden="true">${'\u22EF'}</span>
+  ```
+  with:
+  ```ts
+  <${MoreVertical} size=${16} focusable="false" aria-hidden="true" />
+  ```
+- Keep the surrounding `<button>` attributes: `type="button"`, `class="kp-more"`, `aria-label`, `title`, `onClick`, `data-testid`.
+
+**File:** `dashboard/src/styles/keeper-v2/v2.css`
+
+- Update `.kp-more`:
+  ```css
+  .kp-more {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-main);
+    background: var(--bg-panel);
+    color: var(--text-mid);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    opacity: 0;
+    transition: 0.14s;
+    z-index: 2;
+  }
+  ```
+- Remove `font-size: 14px; line-height: 1;`.
+- Keep `.kp-row:hover .kp-more` and `.kp-more:hover` rules.
+
+### 2. Agent detail “최근 활동” 조걸 표시
+
+**File:** `dashboard/src/components/agent-detail.ts`
+
+- Wrap the existing `<${SectionCard} label="최근 활동">…<//>` block so it renders only when `lines.length > 0`:
+  ```ts
+  ${lines.length > 0
+    ? html`
+        <${SectionCard} label="최근 활동">
+          <div role="log" aria-label="최근 활동 로그" class="max-h-60 overflow-y-auto flex flex-col gap-2 pr-1 custom-scrollbar">
+            ${lines.map((line: string, idx: number) => html`
+              <div key=${idx} class="v2-monitoring-row border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2.5 font-mono text-xs text-[var(--color-fg-primary)] leading-relaxed rounded-[var(--r-1)] hover:bg-[var(--color-bg-hover)] hover:border-[var(--color-border-strong)] transition-colors">${line}</div>
+            `)}
+          </div>
+        <//>
+      `
+    : null}
+  ```
+- Remove the `EmptyState` branch for this card.
+
+## Verification
+
+- `cd dashboard && pnpm test -- keeper-workspace-roster.test.ts` — roster tests pass.
+- `cd dashboard && pnpm test` — full dashboard test suite passes.
+- `cd dashboard && npx tsc --noEmit --pretty` — type check passes.
+
+## Risks
+
+- `lucide-preact` icon을 추가하면 일부 테스트 환경에서 아이콘 모듈 로딩 문제가 발생할 수 있습니다. `keeper-workspace-roster.test.ts`에 lucide mock이 없으면 필요 시 추가합니다.
+- “최근 활동” 카드를 숨기면 두 칸짜리 그리드가 한 칸만 남아 시각적 균형이 달라질 수 있습니다. 이는 기존 grid의 자동 배치로 처리되며 별도 수정은 하지 않습니다.


### PR DESCRIPTION
## What changed

- Keeper roster hover command menu button now uses `MoreVertical` icon from `lucide-preact` and is centered via flexbox, fixing the visually crooked `⋯` text glyph.
- The "최근 활동" card in the agent detail overlay is now rendered only when activity messages exist; the empty-state placeholder is removed.

## Verification

- `pnpm typecheck` — clean
- Targeted tests:
  - `keeper-workspace-roster.test.ts` — 26/26 passed
  - `agent-detail-state.test.ts` — 6/6 passed
- `pnpm lint` — clean (CSS file ignored by ESLint config as expected)
- Full `pnpm test` timed out before completing; no failures were observed in the partial run.

## Design references

- Spec: `docs/superpowers/specs/2026-06-24-dashboard-ui-polish-design.md`
- Plan: `docs/superpowers/plans/2026-06-24-dashboard-ui-polish-plan.md`
