### PR TITLE
fix(dashboard): clarify keeper roster activity and turn timeline

### DIFF
--- a/dashboard/src/components/chat/primitives-interleave.test.ts
+++ b/dashboard/src/components/chat/primitives-interleave.test.ts
@@ -21,6 +21,7 @@ describe('interleaveTraceAndTools', () => {
   const labels = (items: ReturnType<typeof interleaveTraceAndTools>) =>
     items.map((i) => {
       if (i.kind === 'tool') return `tool:${i.entry.id}`
+      if (i.kind === 'chat') return `chat:${i.entry.id}`
       // think/reason carry `text`; the tool variant of ChatTraceStep does not.
       return `think:${'text' in i.step ? i.step.text : i.step.name}`
     })

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1784,7 +1784,7 @@ describe('ChatTranscript — workspace day dividers (C1)', () => {
   })
 })
 
-describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
+describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
   let container: HTMLDivElement
   beforeEach(() => {
     container = document.createElement('div')
@@ -1796,7 +1796,7 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     resetToolCallOutputs()
   })
 
-  it('folds consecutive tool calls into one 작업 과정 card when grouping is on', () => {
+  it('folds consecutive tool calls into one turn timeline card when grouping is on', () => {
     recordToolCallOutputs([
       toolCallOutput({ tool_use_id: 't1', output: 'r1' }),
       toolCallOutput({ tool_use_id: 't2', output: 'r2' }),
@@ -1815,11 +1815,13 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     )
     const cards = container.querySelectorAll('[data-chat-tool-trace]')
     expect(cards.length).toBe(1)
-    expect(cards[0]?.textContent).toContain('작업 과정')
-    expect(cards[0]?.textContent).toContain('2단계')
+    expect(cards[0]?.textContent).toContain('턴 타임라인')
+    expect(cards[0]?.textContent).toContain('3단계')
     expect(cards[0]?.textContent).toContain('도구 2')
+    expect(cards[0]?.textContent).toContain('Chat 1')
     expect(cards[0]?.textContent).toContain('keeper_board_list')
     expect(cards[0]?.textContent).toContain('keeper_tasks_list')
+    expect(cards[0]?.querySelector('[data-chat-trace-step="chat"]')?.textContent).toContain('답변')
     // Grouped surface keeps no standalone per-row tool bubbles.
     expect(container.querySelectorAll('[data-chat-variant="tool-call"]').length).toBe(0)
   })
@@ -1881,7 +1883,7 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
     expect(trace?.textContent).not.toContain('다른 턴 답변')
   })
 
-  it('renders assistant thinking as 작업 과정 even without tool calls', () => {
+  it('renders assistant thinking as a turn timeline even without tool calls', () => {
     render(
       html`<${ChatTranscript}
         entries=${[
@@ -1902,11 +1904,14 @@ describe('ChatTranscript — tool-call grouping (작업 과정)', () => {
 
     const bundle = container.querySelector('[data-chat-turn-bundle]')
     expect(bundle).not.toBeNull()
-    expect(bundle?.textContent).toContain('작업 과정')
-    expect(bundle?.textContent).toContain('1단계')
+    expect(bundle?.textContent).toContain('턴 타임라인')
+    expect(bundle?.textContent).toContain('2단계')
+    expect(bundle?.textContent).toContain('Think 1')
+    expect(bundle?.textContent).toContain('Chat 1')
     expect(bundle?.textContent).toContain('Thinking')
     expect(bundle?.textContent).toContain('checking context')
     expect(bundle?.textContent).toContain('곧 답합니다')
+    expect(bundle?.querySelector('[data-chat-trace-step="chat"]')?.textContent).toContain('곧 답합니다')
   })
 
   it('renders thinking text as sanitized markdown with newlines preserved', () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -2416,8 +2416,10 @@ function ToolTraceStep({ entry, output, canMarkMissing = false }: { entry: Keepe
 type TraceOrderItem =
   | { kind: 'trace'; step: ChatTraceStep }
   | { kind: 'tool'; entry: KeeperConversationEntry; output: ToolCallEntry | null }
+  | { kind: 'chat'; entry: KeeperConversationEntry }
 
 function traceOrderTs(item: TraceOrderItem): string {
+  if (item.kind === 'chat') return item.entry.timestamp ?? '\uffff'
   // ISO-8601 strings sort lexicographically within one clock domain. This merge
   // spans two: think/reason `ts` is stamped on the client when the delta
   // arrives, tool `entry.timestamp` comes from the server (ts_unix). Live
@@ -2447,15 +2449,40 @@ export function interleaveTraceAndTools(
   })
 }
 
+function chatResponsePreview(entry: KeeperConversationEntry): string {
+  const liveLabel = liveMessageLabel(entry)
+  if (liveLabel) return liveLabel
+  const text = entry.text.trim().replace(/\s+/g, ' ')
+  if (!text) return '응답 본문 없음'
+  return text.length > 96 ? `${text.slice(0, 96)}…` : text
+}
+
+function ChatResponseTraceStep({ entry }: { entry: KeeperConversationEntry }) {
+  return html`
+    <div class="chat-block-tstep chat" data-chat-trace-step="chat">
+      <span class="chat-block-tnode"></span>
+      <div class="min-w-0 flex-1">
+        <div class="chat-block-tstep-row">
+          <span class="chat-block-tstep-kind">Chat</span>
+          <span class="chat-block-tstep-name">응답</span>
+          <span class="chat-block-tstep-text">${chatResponsePreview(entry)}</span>
+        </div>
+      </div>
+    </div>
+  `
+}
+
 function ToolTraceCard({
   tools,
   traceSteps = [],
+  assistant = null,
   turnComplete = false,
   toolOutputsCoveredSinceMs = null,
   toolOutputsCoveredThroughMs = null,
 }: {
   tools: KeeperConversationEntry[]
   traceSteps?: ChatTraceStep[]
+  assistant?: KeeperConversationEntry | null
   turnComplete?: boolean
   toolOutputsCoveredSinceMs?: number | null
   toolOutputsCoveredThroughMs?: number | null
@@ -2467,7 +2494,10 @@ function ToolTraceCard({
   // Merge think/reason steps and tool entries into a single occurrence-ordered
   // sequence. Aggregates below (failN/missingN/totalMs/stepN) stay entry-based,
   // so #21892 missing detection and the status taxonomy are unaffected.
-  const ordered = interleaveTraceAndTools(traceSteps, steps)
+  const ordered = assistant
+    ? [...interleaveTraceAndTools(traceSteps, steps), { kind: 'chat' as const, entry: assistant }]
+    : interleaveTraceAndTools(traceSteps, steps)
+  const thinkN = traceSteps.filter((step) => step.kind === 'think' || step.kind === 'reason').length
   const failN = steps.filter(
     (s) => s.output !== null && (s.output.success === false || s.output.semantic_success === false),
   ).length
@@ -2476,7 +2506,8 @@ function ToolTraceCard({
   const missingN = steps.filter((s) => s.output === null && canMarkMissingForEntry(s.entry)).length
   const totalMs = steps.reduce((sum, s) => sum + (s.output?.duration_ms ?? 0), 0)
   const durLabel = totalMs > 0 ? formatMsCompact(totalMs) : null
-  const stepN = traceSteps.length + tools.length
+  const chatN = assistant ? 1 : 0
+  const stepN = traceSteps.length + tools.length + chatN
 
   return html`
     <div class="chat-block-trace ${open ? 'open' : ''}" data-chat-block="trace" data-chat-work-trace data-chat-tool-trace>
@@ -2488,10 +2519,12 @@ function ToolTraceCard({
       >
         <span class="chat-block-trace-chev">${open ? '▾' : '▸'}</span>
         <span>◈</span>
-        <span class="chat-block-trace-label">작업 과정</span>
+        <span class="chat-block-trace-label">턴 타임라인</span>
         <span class="chat-block-trace-count">${stepN}단계</span>
         <span class="chat-block-trace-meta">
+          ${thinkN > 0 ? html`<span>Think ${thinkN}</span>` : null}
           ${tools.length > 0 ? html`<span>도구 ${tools.length}</span>` : null}
+          ${chatN > 0 ? html`<span>Chat ${chatN}</span>` : null}
           ${failN > 0 ? html`<span class="text-[var(--color-status-err)]">실패 ${failN}</span>` : null}
           ${missingN > 0 ? html`<span class="text-[var(--color-status-warn)]">결과 누락 ${missingN}</span>` : null}
           ${durLabel ? html`<span class="tnum">${durLabel}</span>` : null}
@@ -2504,12 +2537,14 @@ function ToolTraceCard({
               ${ordered.map((item, index) =>
                 item.kind === 'trace'
                   ? html`<${ChatTraceStep} key=${`trace-${index}`} step=${item.step} />`
-                  : html`<${ToolTraceStep}
+                  : item.kind === 'tool'
+                    ? html`<${ToolTraceStep}
                       key=${`tool-${item.entry.id}`}
                       entry=${item.entry}
                       output=${item.output}
                       canMarkMissing=${canMarkMissingForEntry(item.entry)}
-                    />`)}
+                    />`
+                    : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} />`)}
             </div>
           `
         : null}
@@ -2545,6 +2580,7 @@ function TurnWorkBundle({
       <${ToolTraceCard}
         tools=${tools}
         traceSteps=${traceSteps}
+        assistant=${assistant}
         turnComplete=${turnComplete}
         toolOutputsCoveredSinceMs=${toolOutputsCoveredSinceMs}
         toolOutputsCoveredThroughMs=${toolOutputsCoveredThroughMs}

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -201,7 +201,7 @@ function WorkspaceCommandButtons({
     detailOpen,
     artifactsOpen,
     onOpenTurnInspector,
-      onToggleArtifacts,
+    onToggleArtifacts,
     onToggleDetail,
     onOpenConfig,
   })
@@ -322,7 +322,7 @@ function ChatHeader({
   // canonical home — so the header stays slim and the conversation gets the
   // vertical space instead of a redundant metadata sub-row.
   return html`
-    <div class="kw-chat-head v2-monitoring-toolbar">
+    <div class="kw-chat-head chat-head v2-monitoring-toolbar">
       <button
         type="button"
         class="kw-chat-back kw-act v2-monitoring-action"
@@ -353,7 +353,7 @@ function ChatHeader({
           detailOpen=${detailOpen}
           artifactsOpen=${artifactsOpen}
           onOpenTurnInspector=${onOpenTurnInspector}
-            onToggleArtifacts=${onToggleArtifacts}
+          onToggleArtifacts=${onToggleArtifacts}
           onToggleDetail=${onToggleDetail}
           onOpenConfig=${onOpenConfig}
         />

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -96,6 +96,44 @@ describe('KeeperWorkspaceRoster', () => {
     expect(allChip?.textContent).toContain('3')
   })
 
+  it('shows explicit recent activity age instead of a creation-date fallback', () => {
+    keepers.value = [
+      mk({
+        name: 'recent-turn',
+        status: 'running',
+        lifecycle_phase: 'Running',
+        last_turn_ago_s: 180,
+      }),
+      mk({
+        name: 'created-only',
+        status: 'running',
+        lifecycle_phase: 'Running',
+        created_at: '2026-03-28T18:00:00Z',
+      }),
+    ]
+
+    render(html`<${KeeperWorkspaceRoster} activeName="recent-turn" />`, host)
+
+    const rows = Array.from(host.querySelectorAll('.kp-row')) as HTMLElement[]
+    const recent = rows.find(row => row.textContent?.includes('recent-turn')) as HTMLElement
+    const createdOnly = rows.find(row => row.textContent?.includes('created-only')) as HTMLElement
+    expect(recent.textContent).toContain('마지막 턴')
+    expect(recent.textContent).toContain('3분 전')
+    expect(createdOnly.textContent).not.toContain('생성')
+  })
+
+  it('labels attention as an attention signal rather than a bare count', () => {
+    keepers.value = [
+      mk({ name: 'blocked', status: 'running', lifecycle_phase: 'Running', blocked_task_count: 1 }),
+    ]
+
+    render(html`<${KeeperWorkspaceRoster} activeName="blocked" />`, host)
+
+    const attention = host.querySelector('.kp-att') as HTMLElement
+    expect(attention?.textContent).toBe('주의 1')
+    expect(attention?.getAttribute('title')).toContain('메시지 수가 아니라')
+  })
+
   // The fleet-summary band ([data-testid="kw-roster-summary"] with total/running/
   // paused/offline + 주의/승인/CTX aggregates) was removed in the v2 reskin — the
   // prototype roster opens straight into the .roster-filters band (전체/실행/주의
@@ -236,6 +274,7 @@ describe('KeeperWorkspaceRoster', () => {
 
   it('filters by search query', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    fireEvent.click(host.querySelector('.kw-rfilter-icon') as HTMLButtonElement)
     const search = host.querySelector('.kw-roster-search') as HTMLInputElement
     fireEvent.input(search, { target: { value: 'rama' } })
     const rows = host.querySelectorAll('.kw-kp-row')
@@ -358,6 +397,7 @@ describe('KeeperWorkspaceRoster', () => {
       mk({ name: 'beta', status: 'running', sandbox_target: '/srv/worktrees/beta-tree' }),
     ]
     render(html`<${KeeperWorkspaceRoster} activeName="alpha" />`, host)
+    fireEvent.click(host.querySelector('.kw-rfilter-icon') as HTMLButtonElement)
     fireEvent.input(host.querySelector('.kw-roster-search') as HTMLInputElement, { target: { value: 'beta-tree' } })
     const rows = host.querySelectorAll('.kw-kp-row')
     expect(rows.length).toBe(1)

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -11,6 +11,7 @@ import {
   Pause,
   Play,
   RotateCcw,
+  Search,
   Settings,
   Square,
 } from 'lucide-preact'
@@ -20,7 +21,9 @@ import { keepers } from '../../store'
 import { navigate } from '../../router'
 import { selectKeeper } from '../../keeper-runtime'
 import { keeperMobilePane } from '../keeper-detail-state'
-import { keeperActivityDisplay, keeperWorkPreview } from '../../lib/keeper-runtime-display'
+import { formatRelativeSec } from '../../lib/format-time'
+import { keeperActivityDisplay } from '../../lib/keeper-runtime-display'
+import type { KeeperActivityDisplay } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import type { Keeper } from '../../types'
 import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
@@ -34,7 +37,6 @@ import {
   keeperStatusTone,
   keeperPhaseLabel,
   type KeeperBucket,
-  type DotTone,
 } from './keeper-workspace-shared'
 
 type RosterFilter = 'all' | 'run' | 'att'
@@ -91,16 +93,6 @@ const GROUP_ORDER: { bucket: KeeperBucket; label: string }[] = [
   { bucket: 'offline', label: '중지 · 종료됨' },
 ]
 
-/** Group-header status dot tone (design rails.jsx `.rg-dot` colored by groupCls).
- *  Reuses the shared StatusDot vocabulary instead of a bespoke dot so the header
- *  marker matches the per-row dots: running→ok, paused→warn, offline→idle. */
-const GROUP_BUCKET_TONE: Record<RosterHeaderBucket, DotTone> = {
-  attention: 'bad',
-  running: 'ok',
-  paused: 'warn',
-  offline: 'idle',
-}
-
 /** Flattened roster item used by the virtualized render path. */
 type RosterItem =
   | { type: 'header'; bucket: RosterHeaderBucket; label: string; count: number }
@@ -127,21 +119,6 @@ function keeperContextRatio(keeper: Keeper): number {
   const current = keeper.context_tokens ?? keeper.context?.context_tokens ?? 0
   const max = keeper.context_max ?? keeper.context?.context_max ?? 0
   return max > 0 ? Math.max(0, Math.min(1, current / max)) : 0
-}
-
-function keeperAttentionGloss(keeper: Keeper): string {
-  const bits: string[] = []
-  const blocked = keeper.blocked_task_count ?? 0
-  if (blocked > 0) bits.push(`차단 ${blocked}건`)
-  if (keeper.current_gate?.kind === 'approval_required') bits.push('승인 대기')
-  const blocker = keeper.runtime_blocker_summary?.trim()
-  const reason = keeper.attention_reason?.trim()
-  const action = keeper.next_human_action?.trim()
-  if (blocker) bits.push(blocker)
-  if (reason) bits.push(reason)
-  if (action) bits.push(action)
-  if (bits.length > 0) return bits.slice(0, 2).join(' · ')
-  return keeperPhaseLabel(keeper) || keeperWorkPreview(keeper) || '최근 상태 미수신'
 }
 
 function keeperStatusRank(keeper: Keeper): number {
@@ -283,10 +260,9 @@ function RosterRow({
       : null
   const contextPct = contextRatio === null ? null : Math.round(contextRatio * 100)
   const contextHot = contextRatio !== null && contextRatio >= 0.8
-  const activity = keeperActivityDisplay(keeper)
-  const work = keeperWorkPreview(keeper)
+  const activity = keeperActivityDisplay(keeper, undefined, { includeCreated: false })
+  const activityText = rosterActivityText(activity)
   const recentTool = keeperRecentTool(keeper)
-  const gloss = keeperAttentionGloss(keeper)
   const inlineActions = lifecycleActions(keeper).filter(action => action !== 'shutdown').slice(0, 2)
   const [pendingAction, setPendingAction] = useState<KeeperActionKey | null>(null)
   const select = () => onSelect(keeper.name)
@@ -294,7 +270,7 @@ function RosterRow({
     <div
       role="button"
       tabindex="0"
-      class="kw-kp-row v2-monitoring-row"
+      class="kw-kp-row kp-row v2-monitoring-row"
       data-tone=${tone}
       style=${style}
       aria-current=${active ? 'true' : 'false'}
@@ -311,10 +287,8 @@ function RosterRow({
         <div class="kw-kp-name">${keeper.koreanName ?? keeper.name}</div>
         <div class="kw-kp-sub">
           <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${bucket === 'running'} />${keeperPhaseLabel(keeper)}</span>
-          ${handle ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle" title=${handleTitle}>${handle}</span>` : null}
+          ${handle ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle kp-handle" title=${handleTitle}>${handle}</span>` : null}
         </div>
-        <div class="kw-kp-gloss" title=${gloss}>${gloss}</div>
-        <div class="kw-kp-work" title=${work ?? ''}>${work ?? '최근 작업 요약 없음'}</div>
         ${contextPct !== null
           ? html`
               <div class="kw-kp-context" title=${`context ${contextPct}%`}>
@@ -335,8 +309,10 @@ function RosterRow({
           : null}
       </div>
       <div class="kw-kp-right">
-        ${activity.source !== 'none' ? html`<span class="kw-kp-time">${activity.label}</span>` : null}
-        ${att > 0 ? html`<span class="kw-kp-att" title=${`주의 ${att}건`}>${att}</span>` : null}
+        ${activityText ? html`<span class="kw-kp-time" title=${activity.timestamp ?? activityText}>${activityText}</span>` : null}
+        ${att > 0
+          ? html`<span class="kw-kp-att kp-att" title=${`주의 신호 ${att}건 · 메시지 수가 아니라 blocked/attention 상태입니다`}>주의 ${att}</span>`
+          : null}
       </div>
       <button
         type="button"
@@ -413,7 +389,7 @@ function MiniRosterRow({
   return html`
     <button
       type="button"
-      class="kw-kp-mini v2-monitoring-action"
+      class="kw-kp-mini kp-row mini v2-monitoring-action"
       aria-current=${active ? 'true' : 'false'}
       aria-label=${label}
       title=${label}
@@ -442,32 +418,16 @@ async function runRosterKeeperAction(name: string, action: KeeperActionKey): Pro
   await refreshAfterRuntimeAction()
 }
 
-function pct(count: number, total: number): string {
-  if (total <= 0 || count <= 0) return '0%'
-  return `${Math.max(4, Math.round((count / total) * 100))}%`
+function rosterActivityText(activity: KeeperActivityDisplay): string | null {
+  if (activity.source === 'none' || activity.ageSeconds === null) return null
+  return `${activity.label} ${formatRelativeSec(activity.ageSeconds)}`
 }
 
-function KeeperFleetSummaryBand({ summary }: { summary: RosterFleetSummary }): VNode {
-  return html`
-    <section class="kw-roster-summary" data-testid="kw-roster-summary" aria-label="키퍼 플릿 요약">
-      <div class="kw-roster-meter" aria-hidden="true">
-        <span class="run" style=${{ width: pct(summary.running, summary.total) }}></span>
-        <span class="pause" style=${{ width: pct(summary.paused, summary.total) }}></span>
-        <span class="off" style=${{ width: pct(summary.offline, summary.total) }}></span>
-      </div>
-      <div class="kw-roster-summary-grid">
-        <div class="kw-roster-stat"><b>${summary.total}</b><span>전체</span></div>
-        <div class="kw-roster-stat ok"><b>${summary.running}</b><span>실행</span></div>
-        <div class="kw-roster-stat warn"><b>${summary.paused}</b><span>대기</span></div>
-        <div class="kw-roster-stat idle"><b>${summary.offline}</b><span>중지</span></div>
-      </div>
-      <div class="kw-roster-flags">
-        <span class=${summary.attention > 0 ? 'hot' : ''}>주의 ${summary.attention}</span>
-        <span class=${summary.approvalGate > 0 ? 'gate' : ''}>승인 ${summary.approvalGate}</span>
-        <span class=${summary.highContext > 0 ? 'ctx' : ''}>CTX 80%+ ${summary.highContext}</span>
-      </div>
-    </section>
-  `
+function groupBucketClass(bucket: RosterHeaderBucket): string {
+  if (bucket === 'attention') return 'att'
+  if (bucket === 'running') return 'run'
+  if (bucket === 'paused') return 'pause'
+  return 'off'
 }
 
 function KeeperRosterMenu({
@@ -583,7 +543,6 @@ export function KeeperWorkspaceRoster({
   }, [menu])
 
   const all = keepers.value
-  const summary = rosterFleetSummary(all)
   const counts = {
     all: all.length,
     run: all.filter(k => keeperBucket(k) === 'running').length,
@@ -652,7 +611,7 @@ export function KeeperWorkspaceRoster({
 
   const filterChips: { id: RosterFilter; label: string }[] = [
     { id: 'all', label: '전체' },
-    { id: 'run', label: '실행중' },
+    { id: 'run', label: '실행' },
     { id: 'att', label: '주의' },
   ]
 
@@ -691,7 +650,18 @@ export function KeeperWorkspaceRoster({
   // Single source for the group header so the windowed and non-windowed render
   // paths can't drift (they previously inlined the header markup separately).
   function renderHeader(item: Extract<RosterItem, { type: 'header' }>): VNode {
-    return html`<div class="kw-roster-group roster-group v2-monitoring-row" title=${item.label} key=${`h:${item.bucket}`}><${StatusDot} tone=${GROUP_BUCKET_TONE[item.bucket]} /><span class="kw-roster-group-label">${item.label}</span><span class="kw-roster-group-n">${item.count}</span></div>`
+    const bucketClass = groupBucketClass(item.bucket)
+    return html`
+      <div
+        class=${`kw-roster-group roster-group ${bucketClass} v2-monitoring-row`}
+        key=${`h:${item.bucket}`}
+        title=${item.label}
+      >
+        <span class="rg-dot" aria-hidden="true"></span>
+        <span class="kw-roster-group-label">${item.label}</span>
+        <span class="kw-roster-group-n rg-n">${item.count}</span>
+      </div>
+    `
   }
 
   function renderItem(item: RosterItem): VNode {
@@ -713,58 +683,63 @@ export function KeeperWorkspaceRoster({
           </div>`
         : html`
           <div class="kw-roster-head v2-monitoring-toolbar">
-            <button
-              type="button"
-              class="rfilter-icon v2-monitoring-action"
-              aria-label="키퍼 검색"
-              aria-expanded=${searchOpen ? 'true' : 'false'}
-              onClick=${() => setSearchOpen(open => !open)}
-            >
-              ⌕
-            </button>
-            <input
-              class=${`kw-roster-search${searchOpen ? ' roster-search' : ''}`}
-              type="text"
-              placeholder="이름 · 스코프 검색…"
-              aria-label="키퍼 검색"
-              value=${query}
-              onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
-            />
-          </div>
-          <${KeeperFleetSummaryBand} summary=${summary} />
-          <div class="kw-roster-filters v2-monitoring-toolbar" role="group" aria-label="상태 필터">
-            ${filterChips.map(chip => html`
+            <div class="kw-roster-filters roster-filters" role="group" aria-label="상태 필터">
+              ${filterChips.map(chip => html`
+                <button
+                  type="button"
+                  class="kw-rfilter rfilter v2-monitoring-action"
+                  aria-pressed=${filter === chip.id ? 'true' : 'false'}
+                  onClick=${() => setFilter(chip.id)}
+                >
+                  ${chip.label}<span class="n">${counts[chip.id]}</span>
+                </button>
+              `)}
               <button
                 type="button"
-                class="kw-rfilter v2-monitoring-action"
-                aria-pressed=${filter === chip.id ? 'true' : 'false'}
-                onClick=${() => setFilter(chip.id)}
+                class="kw-rfilter-icon rfilter-icon v2-monitoring-action"
+                aria-label="키퍼 검색"
+                title="키퍼 검색"
+                aria-pressed=${searchOpen ? 'true' : 'false'}
+                aria-expanded=${searchOpen ? 'true' : 'false'}
+                onClick=${() => setSearchOpen(open => !open)}
               >
-                ${chip.label}<span class="n">${counts[chip.id]}</span>
+                <${Search} size=${14} aria-hidden="true" />
               </button>
-            `)}
-            <select
-              class="kw-roster-sort v2-monitoring-action"
-              aria-label="키퍼 정렬"
-              value=${sort}
-              onChange=${(e: Event) => setSort((e.target as HTMLSelectElement).value as RosterSort)}
-            >
-              <option value="status">상태순</option>
-              <option value="name">이름순</option>
-              <option value="att">주의순</option>
-            </select>
+              <select
+                class="kw-roster-sort roster-sort v2-monitoring-action"
+                aria-label="키퍼 정렬"
+                value=${sort}
+                onChange=${(e: Event) => setSort((e.target as HTMLSelectElement).value as RosterSort)}
+              >
+                <option value="status">상태순</option>
+                <option value="name">이름순</option>
+                <option value="att">주의순</option>
+              </select>
+            </div>
+            ${searchOpen || query
+              ? html`
+                  <input
+                    class="kw-roster-search roster-search"
+                    type="text"
+                    placeholder="이름 · 스코프 검색…"
+                    aria-label="키퍼 검색"
+                    value=${query}
+                    onInput=${(e: Event) => setQuery((e.target as HTMLInputElement).value)}
+                  />
+                `
+              : null}
           </div>
           ${visible.length === 0
-            ? html`<div class="kw-roster-list"><div class="kw-roster-empty v2-monitoring-row">일치하는 키퍼가 없습니다</div></div>`
+            ? html`<div class="kw-roster-list roster-list"><div class="kw-roster-empty v2-monitoring-row">일치하는 키퍼가 없습니다</div></div>`
         : useVirtual
           ? html`<${VirtualList}
               items=${items}
               estimatedItemHeight=${ROSTER_ROW_ESTIMATED_HEIGHT}
-              className="kw-roster-list"
+              className="kw-roster-list roster-list"
               renderItem=${renderItem}
               getKey=${getKey}
             />`
-          : html`<div class="kw-roster-list">
+          : html`<div class="kw-roster-list roster-list">
               ${items.map(item => item.type === 'header'
                 ? renderHeader(item)
                 : html`<${RosterRow} key=${item.keeper.name} keeper=${item.keeper} active=${item.keeper.name === activeName} onSelect=${select} onMenu=${openMenu} style=${rowStyle} />`)}

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -436,6 +436,18 @@ describe('keeperActivityDisplay', () => {
     expect(result.source).toBe('created')
     expect(result.label).toBe('생성')
   })
+
+  it('can suppress created_at when a surface only wants operational activity', () => {
+    const result = keeperActivityDisplay(
+      {
+        created_at: '2026-03-28T18:00:00Z',
+      },
+      undefined,
+      { includeCreated: false },
+    )
+    expect(result.source).toBe('none')
+    expect(result.ageSeconds).toBeNull()
+  })
 })
 
 describe('keeperWorkPreview', () => {

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -25,6 +25,10 @@ export interface KeeperActivityDisplay {
   ageSeconds: number | null
 }
 
+interface KeeperActivityDisplayOptions {
+  includeCreated?: boolean
+}
+
 interface KeeperModelDisplay {
   label: string
   value: string
@@ -138,7 +142,9 @@ function activityDisplaySource(source: Keeper['last_activity_source'] | null | u
 export function keeperActivityDisplay(
   keeper: KeeperActivityDisplaySource | null | undefined,
   fallbackAgentLastSeen?: string | null,
+  options: KeeperActivityDisplayOptions = {},
 ): KeeperActivityDisplay {
+  const includeCreated = options.includeCreated !== false
   const candidates = [
     timestampCandidate(
       activityDisplaySource(keeper?.last_activity_source),
@@ -158,8 +164,10 @@ export function keeperActivityDisplay(
   const agentSeen = timestampCandidate('agent_seen', '에이전트 신호', fallbackAgentLastSeen)
   if (agentSeen) return agentSeen
 
-  const created = timestampCandidate('created', '생성', keeper?.created_at)
-  if (created) return created
+  if (includeCreated) {
+    const created = timestampCandidate('created', '생성', keeper?.created_at)
+    if (created) return created
+  }
 
   return {
     source: 'none',

--- a/dashboard/src/styles/chat-blocks-v2.css
+++ b/dashboard/src/styles/chat-blocks-v2.css
@@ -142,6 +142,17 @@
   background: var(--color-border-strong);
   flex-shrink: 0;
 }
+.chat-block-tstep.think .chat-block-tnode,
+.chat-block-tstep.reason .chat-block-tnode {
+  background: var(--color-accent-fg);
+}
+.chat-block-tstep.tool .chat-block-tnode {
+  background: var(--chat-tool-fg, var(--color-fg-secondary));
+}
+.chat-block-tstep.chat .chat-block-tnode {
+  background: var(--color-status-ok);
+  box-shadow: 0 0 0 3px rgb(var(--color-status-ok-glow) / 0.14);
+}
 
 .chat-block-tstep-row {
   display: flex;
@@ -215,6 +226,14 @@
      reasoning that single-line flow folded into one run-on line). */
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+.chat-block-tstep.chat .chat-block-tstep-text {
+  flex: 1 1 160px;
+  color: var(--color-fg-secondary);
+  font-size: var(--fs-xs);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .chat-block-reason-detail {

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -177,7 +177,13 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   border-right: 1px solid var(--color-border-default);
   background: var(--color-bg-panel-alt);
 }
-.kw-roster-head { padding: 14px; border-bottom: 1px solid var(--color-border-divider); }
+.kw-roster-head {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--color-border-divider);
+}
 .kw-roster-title {
   display: flex; align-items: center; gap: 8px;
   font-family: var(--font-display); font-size: var(--fs-14); text-transform: uppercase; letter-spacing: 0.12em;
@@ -201,75 +207,13 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-roster-search:focus { border-color: var(--color-accent-fg-dim); box-shadow: 0 0 0 2px var(--accent-10); }
 .kw-roster-search::placeholder { color: var(--color-fg-muted); }
 
-.kw-roster-summary {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px 14px 12px;
-  border-bottom: 1px solid var(--color-border-divider);
-  background: color-mix(in oklab, var(--color-bg-surface) 38%, transparent);
-}
-.kw-roster-meter {
-  display: flex;
-  height: 4px;
-  overflow: hidden;
-  border-radius: 9999px;
-  background: var(--color-bg-page);
-}
-.kw-roster-meter span { min-width: 0; height: 100%; }
-.kw-roster-meter .run { background: var(--color-status-ok); }
-.kw-roster-meter .pause { background: var(--color-status-warn); }
-.kw-roster-meter .off { background: var(--color-fg-muted); }
-.kw-roster-summary-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 6px;
-}
-.kw-roster-stat {
-  min-width: 0;
-  padding: 6px 8px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--r-1);
-  background: var(--color-bg-page);
-}
-.kw-roster-stat b {
-  display: block;
-  color: var(--color-fg-primary);
-  font-family: var(--font-mono);
-  font-size: var(--fs-14);
-  line-height: 1.1;
-}
-.kw-roster-stat span {
-  display: block;
-  margin-top: 2px;
-  color: var(--color-fg-muted);
-  font-size: var(--fs-10);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-.kw-roster-stat.ok { border-color: rgb(var(--color-status-ok-glow) / 0.36); }
-.kw-roster-stat.warn { border-color: rgb(var(--color-status-warn-glow) / 0.36); }
-.kw-roster-stat.idle { border-color: color-mix(in oklab, var(--color-fg-muted) 32%, var(--color-border-default)); }
-.kw-roster-flags {
+.kw-roster-filters {
   display: flex;
   min-width: 0;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 6px;
+  flex-wrap: nowrap;
 }
-.kw-roster-flags span {
-  color: var(--color-fg-muted);
-  border: 1px solid var(--color-border-default);
-  border-radius: 9999px;
-  padding: 2px 8px;
-  font-family: var(--font-mono);
-  font-size: var(--fs-10);
-  white-space: nowrap;
-}
-.kw-roster-flags .hot { color: var(--color-status-err); border-color: rgb(var(--color-status-err-glow) / 0.4); background: rgb(var(--color-status-err-glow) / 0.10); }
-.kw-roster-flags .gate { color: var(--color-status-warn); border-color: rgb(var(--color-status-warn-glow) / 0.38); background: rgb(var(--color-status-warn-glow) / 0.09); }
-.kw-roster-flags .ctx { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); background: var(--accent-10); }
-
-.kw-roster-filters { display: flex; gap: 6px; padding: 10px 14px; flex-wrap: wrap; border-bottom: 1px solid var(--color-border-divider); }
 .kw-rfilter {
   font-size: var(--fs-11); letter-spacing: 0.06em; text-transform: uppercase;
   padding: 4px 10px; border-radius: 9999px; cursor: pointer;
@@ -280,6 +224,27 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-rfilter:hover { color: var(--color-fg-primary); border-color: var(--color-border-strong); }
 .kw-rfilter[aria-pressed="true"] { background: var(--color-accent-fg); border-color: var(--color-accent-fg); color: var(--bg-deep); font-weight: var(--fw-semi); }
 .kw-rfilter .n { opacity: 0.8; }
+.kw-rfilter-icon {
+  display: inline-flex;
+  flex: none;
+  width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--r-1);
+  background: transparent;
+  color: var(--color-fg-secondary);
+  cursor: pointer;
+  transition: color .15s, border-color .15s, background .15s;
+}
+.kw-rfilter-icon:hover,
+.kw-rfilter-icon[aria-pressed="true"] {
+  color: var(--color-accent-fg);
+  border-color: var(--color-accent-fg-dim);
+  background: var(--accent-10);
+}
 /* Roster sort <select> — ported from keeper-v2 v2.css .roster-sort. Pushed to
    the right of the filter chips; pill control with the same resting/hover/focus
    treatment as the search field and filter chips. */
@@ -302,6 +267,17 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   font-size: var(--fs-9-5); font-weight: var(--fw-bold); letter-spacing: 0.18em; text-transform: uppercase; color: var(--color-fg-secondary);
   padding: 12px 8px 6px;
 }
+.kw-roster-group .rg-dot {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--color-fg-muted);
+}
+.kw-roster-group.att .rg-dot { background: var(--color-status-err); }
+.kw-roster-group.run .rg-dot { background: var(--color-status-ok); }
+.kw-roster-group.pause .rg-dot { background: var(--color-status-warn); }
+.kw-roster-group.off .rg-dot { background: var(--color-fg-muted); }
 /* Per-group keeper count, right-aligned — mirrors the design roster's rg-n. */
 .kw-roster-group-n { margin-left: auto; letter-spacing: 0; color: var(--color-fg-muted); font-variant-numeric: tabular-nums; }
 .kw-roster-empty { padding: 30px 12px; text-align: center; color: var(--color-fg-secondary); font-size: var(--fs-13); }
@@ -323,12 +299,11 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-kp-mini .kw-dot { position: absolute; right: 5px; bottom: 5px; }
 
 .kw-kp-row {
-  display: grid; grid-template-columns: 40px 1fr auto; gap: 10px; align-items: start;
+  display: grid; grid-template-columns: 40px minmax(0, 1fr) auto; gap: 10px; align-items: start;
   width: 100%; text-align: left;
   /* B5: tighter vertical rhythm (standalone roster density) — row padding 11→8
-     so more keepers fit on screen. align-items stays `start` (not the
-     standalone's `center`) because the live row carries a 3rd work-preview
-     line the standalone's 2-line row does not. */
+     so more keepers fit on screen while the live context/tool signals still
+     have room to wrap cleanly. */
   padding: 8px 10px; border-radius: var(--r-2); cursor: pointer;
   border: 1px solid transparent; background: transparent;
   transition: background .14s, border-color .14s;
@@ -367,7 +342,6 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-kp-sub { display: flex; align-items: center; gap: 6px; font-size: var(--fs-12); color: var(--color-fg-secondary); margin-top: 3px; min-width: 0; }
 .kw-kp-state { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
 .kw-kp-handle { font-family: var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.kw-kp-work { margin-top: 4px; font-size: var(--fs-12); color: var(--color-fg-secondary); line-height: 1.45; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .kw-kp-context {
   display: flex;
   min-width: 0;
@@ -428,13 +402,21 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   white-space: nowrap;
 }
 .kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; padding-top: 2px; }
-.kw-kp-time { font-family: var(--font-mono); font-size: var(--fs-11); color: var(--color-fg-muted); }
+.kw-kp-time {
+  max-width: 96px;
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  line-height: 1.25;
+  color: var(--color-fg-muted);
+  text-align: right;
+}
 .kw-kp-att {
   font-family: var(--font-mono); font-size: var(--fs-10); font-weight: var(--fw-semi);
-  min-width: 16px; text-align: center; padding: 2px 6px; border-radius: 9999px;
+  min-width: 0; text-align: center; padding: 2px 7px; border-radius: 9999px;
   color: var(--color-status-err);
   background: rgb(var(--color-status-err-glow) / 0.16);
   border: 1px solid rgb(var(--color-status-err-glow) / 0.35);
+  white-space: nowrap;
 }
 .kw-kp-more {
   position: absolute;
@@ -577,7 +559,20 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
  * actions wrap to their own row instead (see .kw-chat-head flex-wrap). */
 .kw-chat-id { min-width: 9rem; flex: 1; }
 .kw-chat-name-row { display: flex; align-items: center; gap: 11px; flex-wrap: wrap; }
-.kw-chat-slug { font-size: var(--fs-12); color: var(--color-fg-muted); margin-top: 2px; }
+.kw-chat-sub {
+  min-width: 0;
+  margin-top: 3px;
+  color: var(--color-fg-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-11);
+  line-height: 1.25;
+}
+.kw-chat-sub .sub-ns {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 /* Back-to-roster affordance: only meaningful on the single-pane mobile layout
  * (shown at ≤860px in the conversation media block). On desktop the roster is
  * always visible, so the button is hidden. */


### PR DESCRIPTION
## Summary
- Compact the Keeper workspace roster to match the v2 reference direction: filters first, search behind an icon, no fleet-summary band, no per-row work-preview line.
- Replace ambiguous roster activity/badge labels with operational activity age and explicit attention wording.
- Rename the tool/think card to a turn timeline and add a Chat boundary row so tool steps and the assistant answer are visually connected.

## Validation
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/lib/keeper-runtime-display.test.ts src/components/keeper-workspace/keeper-workspace-roster.test.ts src/components/chat/primitives-interleave.test.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard typecheck
- pnpm --dir dashboard lint
- Rendered QA via Vite + Playwright at http://localhost:5173/dashboard/#keepers?keeper=sangsu
  - Desktop roster: /tmp/keeper-workspace-after-keepers-desktop.png
  - Search interaction: /tmp/keeper-workspace-after-search.png
  - Timeline card: /tmp/keeper-workspace-after-timeline.png
  - Mobile roster pane: /tmp/keeper-workspace-after-mobile-roster-pane.png

## Notes
- Browser plugin unavailable in this session; used regular Playwright.
- Live backend returned 404 for /api/v1/keepers/sangsu/composite during rendered QA; existing page still rendered history/roster and the 404 is unrelated to this dashboard patch.