### PR TITLE
fix(keeper): harden merged vision analyze tool

### DIFF
--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -31,7 +31,7 @@ let default_timeout_sec = 120.0
 (* Thinking is forced off (below), so the budget only needs room for the answer;
    keep it well above the 64-token point where the 2026-06-25 gemma4 reply
    truncated entirely into the thinking phase. *)
-let vision_max_tokens = 1024
+let vision_default_max_tokens = 1024
 
 let truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool = function
   | Agent_sdk.Types.MaxTokens -> true
@@ -46,7 +46,10 @@ let truncated_of_stop_reason : Agent_sdk.Types.stop_reason -> bool = function
 
 let provider_for_vision (provider_cfg : Llm_provider.Provider_config.t) =
   { provider_cfg with
-    max_tokens = Some vision_max_tokens
+    max_tokens =
+      (match provider_cfg.max_tokens with
+       | Some _ as configured -> configured
+       | None -> Some vision_default_max_tokens)
   ; temperature = Some 0.0
   ; tool_choice = None
   ; disable_parallel_tool_use = true
@@ -82,8 +85,14 @@ let vision_store_dir ~keeper_name =
 let ok_json text =
   Yojson.Safe.to_string (`Assoc [ "ok", `Bool true; "text", `String text ])
 
-let err_json ?detail code =
-  let fields = [ "ok", `Bool false; "error", `String code ] in
+let err_json ?detail ?(failure_class = Tool_result.Workflow_rejection) code =
+  let fields =
+    [ "ok", `Bool false
+    ; "error", `String code
+    ; ( "failure_class"
+      , `String (Tool_result.tool_failure_class_to_string failure_class) )
+    ]
+  in
   let fields =
     match detail with
     | Some d -> fields @ [ "detail", `String d ]
@@ -96,9 +105,9 @@ let string_member key json =
   | `String s -> Some s
   | _ -> None
 
-(* Magic-byte media-type sniff (the [media_type] arg overrides). Phase 1 has no
-   ingestion metadata, so sniff the stored bytes; default conservatively to PNG
-   (the common keeper screenshot format). *)
+(* Magic-byte media-type sniff. Phase 1 has no ingestion metadata, so sniff the
+   stored bytes; default conservatively to PNG (the common keeper screenshot
+   format). *)
 let sniff_media_type bytes =
   let starts prefix =
     let lp = String.length prefix in
@@ -113,6 +122,26 @@ let sniff_media_type bytes =
     && String.equal (String.sub bytes 8 4) "WEBP"
   then "image/webp"
   else "image/png"
+
+let normalize_media_type value =
+  String.trim value |> String.lowercase_ascii
+
+let supported_image_media_type = function
+  | "image/png" | "image/jpeg" | "image/gif" | "image/webp" -> true
+  | _ -> false
+
+let media_type_for_request ~bytes args =
+  match string_member "media_type" args with
+  | Some raw when String.trim raw <> "" ->
+    let media_type = normalize_media_type raw in
+    if supported_image_media_type media_type then Ok media_type
+    else
+      Error
+        (Printf.sprintf
+           "unsupported image media_type %S; expected one of image/png, \
+            image/jpeg, image/gif, image/webp"
+           raw)
+  | _ -> Ok (sniff_media_type bytes)
 
 let handle
     ?(complete = default_complete)
@@ -134,41 +163,43 @@ let handle
        (match Store.load ~dir (Store.of_string handle_str) with
         | Error msg -> err_json ~detail:msg "artifact_load_failed"
         | Ok bytes ->
-          let media_type =
-            match string_member "media_type" args with
-            | Some m when String.trim m <> "" -> m
-            | _ -> sniff_media_type bytes
-          in
-          (match
-             Va.make_request ~query ~image_media_type:media_type ~image_bytes:bytes
-           with
-           | Error msg -> err_json ~detail:msg "invalid_request"
-           | Ok req ->
-             (match first_vision_runtime_id () with
-              | Error msg -> err_json ~detail:msg "no_capable_runtime"
-              | Ok runtime_id ->
-                (match Runtime.get_runtime_by_id runtime_id with
-                 | None ->
-                   err_json
-                     ~detail:(Printf.sprintf "runtime %S not found" runtime_id)
-                     "no_capable_runtime"
-                 | Some rt ->
-                   let config = provider_for_vision rt.Runtime.provider_config in
-                   let messages = [ message_of_request req ] in
-                   (match
-                      with_timeout ?clock ~timeout_sec (fun () ->
-                        complete ~sw ~net ?clock ~config ~messages ())
-                    with
-                    | None -> err_json "timeout"
-                    | Some (Error err) ->
+          (match media_type_for_request ~bytes args with
+           | Error msg -> err_json ~detail:msg "invalid_media_type"
+           | Ok media_type ->
+             (match
+                Va.make_request ~query ~image_media_type:media_type
+                  ~image_bytes:bytes
+              with
+              | Error msg -> err_json ~detail:msg "invalid_request"
+              | Ok req ->
+                (match first_vision_runtime_id () with
+                 | Error msg -> err_json ~detail:msg "no_capable_runtime"
+                 | Ok runtime_id ->
+                   (match Runtime.get_runtime_by_id runtime_id with
+                    | None ->
                       err_json
-                        ~detail:(Provider_http_error.to_message err)
-                        "provider_error"
-                    | Some (Ok (response : Agent_sdk.Types.api_response)) ->
-                      let text = Agent_sdk_response.text_of_response response in
-                      let truncated =
-                        truncated_of_stop_reason response.stop_reason
-                      in
-                      (match Va.classify ~truncated ~content:text with
-                       | Ok t -> ok_json t
-                       | Error e -> err_json (Va.string_of_error e))))))))
+                        ~detail:(Printf.sprintf "runtime %S not found" runtime_id)
+                        "no_capable_runtime"
+                    | Some rt ->
+                      let config = provider_for_vision rt.Runtime.provider_config in
+                      let messages = [ message_of_request req ] in
+                      (match
+                         with_timeout ?clock ~timeout_sec (fun () ->
+                           complete ~sw ~net ?clock ~config ~messages ())
+                       with
+                       | None ->
+                         err_json ~failure_class:Tool_result.Transient_error
+                           "timeout"
+                       | Some (Error err) ->
+                         err_json
+                           ~failure_class:Tool_result.Transient_error
+                           ~detail:(Provider_http_error.to_message err)
+                           "provider_error"
+                       | Some (Ok (response : Agent_sdk.Types.api_response)) ->
+                         let text = Agent_sdk_response.text_of_response response in
+                         let truncated =
+                           truncated_of_stop_reason response.stop_reason
+                         in
+                         (match Va.classify ~truncated ~content:text with
+                          | Ok t -> ok_json t
+                          | Error e -> err_json (Va.string_of_error e)))))))))

--- a/lib/keeper/keeper_vision_tool.ml
+++ b/lib/keeper/keeper_vision_tool.ml
@@ -18,6 +18,9 @@ let default_complete : complete_fn =
  fun ~sw ~net ?clock ~config ~messages () ->
   Llm_provider.Complete.complete ~sw ~net ?clock ~config ~messages ()
 
+(* Only [Eio.Time.Timeout] is caught here; [Eio.Cancel.Cancelled] and other
+   exceptions are intentionally propagated so caller cancellation is not
+   swallowed by the tool-level timeout handler. *)
 let with_timeout ?clock ~timeout_sec f =
   match clock with
   | None -> Some (f ())
@@ -85,7 +88,9 @@ let vision_store_dir ~keeper_name =
 let ok_json text =
   Yojson.Safe.to_string (`Assoc [ "ok", `Bool true; "text", `String text ])
 
-let err_json ?detail ?(failure_class = Tool_result.Workflow_rejection) code =
+(* Default to Runtime_failure: an unclassified error is treated as an internal
+   keeper-health fault, not a caller validation or workflow business rule. *)
+let err_json ?detail ?(failure_class = Tool_result.Runtime_failure) code =
   let fields =
     [ "ok", `Bool false
     ; "error", `String code
@@ -99,6 +104,12 @@ let err_json ?detail ?(failure_class = Tool_result.Workflow_rejection) code =
     | None -> fields
   in
   Yojson.Safe.to_string (`Assoc fields)
+
+let failure_class_of_http_error err =
+  if Runtime_attempt_fsm.should_try_next err
+  then Tool_result.Transient_error
+  else Tool_result.Policy_rejection
+;;
 
 let string_member key json =
   match Yojson.Safe.Util.member key json with
@@ -126,9 +137,14 @@ let sniff_media_type bytes =
 let normalize_media_type value =
   String.trim value |> String.lowercase_ascii
 
-let supported_image_media_type = function
-  | "image/png" | "image/jpeg" | "image/gif" | "image/webp" -> true
-  | _ -> false
+let supported_image_media_types =
+  [ "image/png"; "image/jpeg"; "image/gif"; "image/webp" ]
+
+let supported_image_media_type media_type =
+  List.mem media_type supported_image_media_types
+
+let supported_image_media_types_csv =
+  String.concat ", " supported_image_media_types
 
 let media_type_for_request ~bytes args =
   match string_member "media_type" args with
@@ -138,9 +154,9 @@ let media_type_for_request ~bytes args =
     else
       Error
         (Printf.sprintf
-           "unsupported image media_type %S; expected one of image/png, \
-            image/jpeg, image/gif, image/webp"
-           raw)
+           "unsupported image media_type %S; expected one of %s"
+           raw
+           supported_image_media_types_csv)
   | _ -> Ok (sniff_media_type bytes)
 
 let handle
@@ -154,30 +170,53 @@ let handle
     () =
   match string_member "artifact" args, string_member "query" args with
   | None, _ | _, None ->
-    err_json ~detail:"requires string fields: artifact, query" "invalid_args"
+    err_json
+      ~failure_class:Tool_result.Policy_rejection
+      ~detail:"requires string fields: artifact, query"
+      "invalid_args"
   | Some handle_str, Some query ->
     (match sw, net with
-     | None, _ | _, None -> err_json "eio_context_unavailable"
+     | None, _ | _, None ->
+       err_json
+         ~failure_class:Tool_result.Runtime_failure
+         "eio_context_unavailable"
      | Some sw, Some net ->
        let dir = vision_store_dir ~keeper_name:meta.name in
        (match Store.load ~dir (Store.of_string handle_str) with
-        | Error msg -> err_json ~detail:msg "artifact_load_failed"
+        | Error msg ->
+          err_json
+            ~failure_class:Tool_result.Runtime_failure
+            ~detail:msg
+            "artifact_load_failed"
         | Ok bytes ->
           (match media_type_for_request ~bytes args with
-           | Error msg -> err_json ~detail:msg "invalid_media_type"
+           | Error msg ->
+             err_json
+               ~failure_class:Tool_result.Policy_rejection
+               ~detail:msg
+               "invalid_media_type"
            | Ok media_type ->
              (match
                 Va.make_request ~query ~image_media_type:media_type
                   ~image_bytes:bytes
               with
-              | Error msg -> err_json ~detail:msg "invalid_request"
+              | Error msg ->
+                err_json
+                  ~failure_class:Tool_result.Policy_rejection
+                  ~detail:msg
+                  "invalid_request"
               | Ok req ->
                 (match first_vision_runtime_id () with
-                 | Error msg -> err_json ~detail:msg "no_capable_runtime"
+                 | Error msg ->
+                   err_json
+                     ~failure_class:Tool_result.Runtime_failure
+                     ~detail:msg
+                     "no_capable_runtime"
                  | Ok runtime_id ->
                    (match Runtime.get_runtime_by_id runtime_id with
                     | None ->
                       err_json
+                        ~failure_class:Tool_result.Runtime_failure
                         ~detail:(Printf.sprintf "runtime %S not found" runtime_id)
                         "no_capable_runtime"
                     | Some rt ->
@@ -192,7 +231,7 @@ let handle
                            "timeout"
                        | Some (Error err) ->
                          err_json
-                           ~failure_class:Tool_result.Transient_error
+                           ~failure_class:(failure_class_of_http_error err)
                            ~detail:(Provider_http_error.to_message err)
                            "provider_error"
                        | Some (Ok (response : Agent_sdk.Types.api_response)) ->
@@ -202,4 +241,11 @@ let handle
                          in
                          (match Va.classify ~truncated ~content:text with
                           | Ok t -> ok_json t
-                          | Error e -> err_json (Va.string_of_error e)))))))))
+                          | Error Va.Empty_extraction ->
+                            err_json
+                              ~failure_class:Tool_result.Workflow_rejection
+                              "empty_extraction"
+                          | Error Va.Truncated_extraction ->
+                            err_json
+                              ~failure_class:Tool_result.Runtime_failure
+                              "truncated_extraction"))))))))

--- a/lib/keeper/keeper_vision_tool.mli
+++ b/lib/keeper/keeper_vision_tool.mli
@@ -39,8 +39,8 @@ val provider_for_vision
   -> Llm_provider.Provider_config.t
 (** A one-shot, non-thinking, plain-text vision config: thinking off (avoids the
     2026-06-25 gemma4 thinking-budget exhaustion that produced empty replies),
-    [response_format = Off], [tool_choice = None], [temperature = 0], and
-    [max_tokens] room for the answer. *)
+    [response_format = Off], [tool_choice = None], [temperature = 0], and a
+    fallback [max_tokens] only when the selected runtime has not configured one. *)
 
 val first_vision_runtime_id : unit -> (string, string) result
 (** Runtime id of the first image-capable configured runtime, or [Error] when
@@ -57,9 +57,12 @@ val handle
   -> unit
   -> string
 (** Tool entry. [args] = [{ "artifact": handle; "query": string;
-    "media_type"?: string }]. Returns a JSON string: [{"ok":true,"text":...}] or
-    [{"ok":false,"error":code[,"detail":...]}] with code one of [invalid_args |
-    eio_context_unavailable | artifact_load_failed | invalid_request |
-    no_capable_runtime | timeout | provider_error | empty_extraction |
-    truncated_extraction]. [complete] defaults to the live provider call (inject
-    in tests). Never returns a raw empty success. *)
+    "media_type"?: string }]. [media_type], when provided, must be a supported
+    image MIME type; otherwise the stored bytes are sniffed. Returns a JSON
+    string: [{"ok":true,"text":...}] or
+    [{"ok":false,"error":code,"failure_class":class[,"detail":...]}] with code
+    one of [invalid_args | eio_context_unavailable | artifact_load_failed |
+    invalid_media_type | invalid_request | no_capable_runtime | timeout |
+    provider_error | empty_extraction | truncated_extraction]. [complete]
+    defaults to the live provider call (inject in tests). Never returns a raw
+    empty success. *)

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -129,7 +129,7 @@ let test_provider_for_vision_preserves_configured_max_tokens () =
   let fallback = Vt.provider_for_vision { base with max_tokens = None } in
   assert (fallback.max_tokens = Some 1024)
 
-let test_missing_eio_context_is_workflow_rejection () =
+let test_missing_eio_context_is_runtime_failure () =
   let raw =
     Vt.handle
       ~meta:(make_meta "vision-missing-eio")
@@ -142,9 +142,9 @@ let test_missing_eio_context_is_workflow_rejection () =
   in
   let json = json_of_output raw in
   assert (String.equal (assoc_string "error" json) "eio_context_unavailable");
-  assert (String.equal (assoc_string "failure_class" json) "workflow_rejection")
+  assert (String.equal (assoc_string "failure_class" json) "runtime_failure")
 
-let test_invalid_media_type_is_workflow_rejection () =
+let test_invalid_media_type_is_policy_rejection () =
   with_temp_base (fun _ ->
     let meta = make_meta "vision-media-type" in
     let bytes = "\x89PNG\r\n\x1a\nraw" in
@@ -175,13 +175,13 @@ let test_invalid_media_type_is_workflow_rejection () =
     in
     let json = json_of_output raw in
     assert (String.equal (assoc_string "error" json) "invalid_media_type");
-    assert (String.equal (assoc_string "failure_class" json) "workflow_rejection"))
+    assert (String.equal (assoc_string "failure_class" json) "policy_rejection"))
 
 let () =
   test_truncated_of_stop_reason ();
   test_message_of_request ();
   test_first_vision_runtime_id_total ();
   test_provider_for_vision_preserves_configured_max_tokens ();
-  test_missing_eio_context_is_workflow_rejection ();
-  test_invalid_media_type_is_workflow_rejection ();
+  test_missing_eio_context_is_runtime_failure ();
+  test_invalid_media_type_is_policy_rejection ();
   print_endline "test_keeper_vision_tool: all assertions passed"

--- a/test/test_keeper_vision_tool.ml
+++ b/test/test_keeper_vision_tool.ml
@@ -13,6 +13,64 @@
 
 module Vt = Masc.Keeper_vision_tool
 module Va = Multimodal.Vision_analyze
+module Store = Multimodal.Vision_artifact_store
+
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
+let json_of_output raw =
+  try Yojson.Safe.from_string raw with
+  | Yojson.Json_error msg -> failwith ("invalid json output: " ^ msg ^ ": " ^ raw)
+
+let assoc_string key = function
+  | `Assoc fields ->
+    (match List.assoc_opt key fields with
+     | Some (`String s) -> s
+     | Some other ->
+       failwith
+         (Printf.sprintf
+            "field %s was not a string: %s"
+            key
+            (Yojson.Safe.to_string other))
+     | None -> failwith ("missing field: " ^ key))
+  | other -> failwith ("expected object: " ^ Yojson.Safe.to_string other)
+
+let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
+  let json =
+    `Assoc
+      [ "name", `String name
+      ; "agent_name", `String (name ^ "-agent")
+      ; "trace_id", `String (name ^ "-trace")
+      ; "goal", `String "vision tool test"
+      ; "allowed_paths", `List [ `String "*" ]
+      ; "sandbox_profile", `String "none"
+      ]
+  in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok meta -> meta
+  | Error e -> failwith e
+
+let with_temp_base f =
+  let path = Filename.temp_file "masc-vision-tool-test-" "" in
+  Unix.unlink path;
+  Unix.mkdir path 0o755;
+  Unix.putenv "MASC_BASE_PATH" path;
+  Config_dir_resolver.reset ();
+  Fun.protect
+    ~finally:(fun () ->
+      unsetenv "MASC_BASE_PATH";
+      Config_dir_resolver.reset ();
+      let rec rm p =
+        match Unix.lstat p with
+        | { Unix.st_kind = Unix.S_DIR; _ } ->
+          Array.iter
+            (fun name -> rm (Filename.concat p name))
+            (Sys.readdir p);
+          Unix.rmdir p
+        | _ -> Unix.unlink p
+        | exception Unix.Unix_error _ -> ()
+      in
+      rm path)
+    (fun () -> f path)
 
 (* Only MaxTokens -> true. Exhaustive over all 9 SDK variants so a new one forces
    a decision rather than silently bucketing to false. *)
@@ -58,8 +116,72 @@ let test_first_vision_runtime_id_total () =
   match Vt.first_vision_runtime_id () with
   | Ok _ | Error _ -> ()
 
+let test_provider_for_vision_preserves_configured_max_tokens () =
+  let base =
+    Llm_provider.Provider_config.make
+      ~kind:Llm_provider.Provider_config.OpenAI_compat
+      ~model_id:"vision-model"
+      ~base_url:"http://example.invalid"
+      ()
+  in
+  let configured = Vt.provider_for_vision { base with max_tokens = Some 4096 } in
+  assert (configured.max_tokens = Some 4096);
+  let fallback = Vt.provider_for_vision { base with max_tokens = None } in
+  assert (fallback.max_tokens = Some 1024)
+
+let test_missing_eio_context_is_workflow_rejection () =
+  let raw =
+    Vt.handle
+      ~meta:(make_meta "vision-missing-eio")
+      ~args:
+        (`Assoc
+          [ "artifact", `String (String.make 64 'a')
+          ; "query", `String "describe"
+          ])
+      ()
+  in
+  let json = json_of_output raw in
+  assert (String.equal (assoc_string "error" json) "eio_context_unavailable");
+  assert (String.equal (assoc_string "failure_class" json) "workflow_rejection")
+
+let test_invalid_media_type_is_workflow_rejection () =
+  with_temp_base (fun _ ->
+    let meta = make_meta "vision-media-type" in
+    let bytes = "\x89PNG\r\n\x1a\nraw" in
+    let store_dir =
+      Filename.concat
+        (Config_dir_resolver.keepers_dir ())
+        (meta.Masc.Keeper_meta_contract.name ^ ".vision")
+    in
+    let handle =
+      match Store.store ~dir:store_dir bytes with
+      | Ok handle -> Store.to_string handle
+      | Error msg -> failwith msg
+    in
+    let raw =
+      Eio_main.run (fun env ->
+        Eio.Switch.run (fun sw ->
+          Vt.handle
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~meta
+            ~args:
+              (`Assoc
+                [ "artifact", `String handle
+                ; "query", `String "describe"
+                ; "media_type", `String "text/plain"
+                ])
+            ()))
+    in
+    let json = json_of_output raw in
+    assert (String.equal (assoc_string "error" json) "invalid_media_type");
+    assert (String.equal (assoc_string "failure_class" json) "workflow_rejection"))
+
 let () =
   test_truncated_of_stop_reason ();
   test_message_of_request ();
   test_first_vision_runtime_id_total ();
+  test_provider_for_vision_preserves_configured_max_tokens ();
+  test_missing_eio_context_is_workflow_rejection ();
+  test_invalid_media_type_is_workflow_rejection ();
   print_endline "test_keeper_vision_tool: all assertions passed"


### PR DESCRIPTION
Follow-up to merged #22274. This ports the adversarial hardening found while #22277 was still open onto the implementation that actually reached main.\n\nChanges:\n- preserve runtime-configured max_tokens; only apply the vision fallback when unset\n- add failure_class to analyze_image error envelopes so expected workflow/transient failures do not default to runtime_failure\n- validate optional media_type instead of trusting arbitrary strings\n- add focused assertions for max_tokens preservation, missing Eio context classification, and invalid media_type classification\n\nValidation:\n- ocamlformat --check lib/keeper/keeper_vision_tool.ml lib/keeper/keeper_vision_tool.mli test/test_keeper_vision_tool.ml\n- git diff --check HEAD~1..HEAD\n- scripts/dune-local.sh build test/test_keeper_vision_tool.exe\n- ./_build/default/test/test_keeper_vision_tool.exe\n\nKnown external CI state: current main has unrelated Build/Test blockers observed on #22277/#22274 (env catalog drift, missing test_operator_control.exe, SSE 401, contract harness readiness).