### PR TITLE
[codex] Clarify keeper empty reply fallback

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -199,6 +199,27 @@ describe('fetchQueuedKeeperMessageResult', () => {
     expect(queuedKeeperMessageError(result)).toBe('요청이 취소되었습니다.')
     expect(queuedKeeperMessageToReply(result).text).toBe('요청이 취소되었습니다.')
   })
+
+  it('suppresses queued continuation checkpoints as non-visible replies', () => {
+    const result = {
+      requestId: 'kmsg_sangsu_3',
+      keeperName: 'sangsu',
+      status: 'done' as const,
+      ok: true,
+      result: {
+        reply: 'Continuation checkpoint saved; keeper remains scheduled for the next cycle.',
+        turn_outcome: 'continuation_checkpoint',
+      },
+    }
+
+    const reply = queuedKeeperMessageToReply(result)
+
+    expect(reply.text).toBe('')
+    expect(reply.details?.turnOutcome).toBe('continuation_checkpoint')
+    expect(reply.details?.replyText).toBe(
+      'Continuation checkpoint saved; keeper remains scheduled for the next cycle.',
+    )
+  })
 })
 
 describe('streamKeeperMessage', () => {

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -380,6 +380,12 @@ export function queuedKeeperMessageToReply(result: QueuedKeeperMessageResult): K
   const payload = isRecord(result.result) ? result.result : null
   const rawReply = asString(payload?.reply, '').trim()
   const details = normalizeKeeperConversationDetails(payload ?? result.result)
+  if (result.status === 'done' && details?.turnOutcome === 'continuation_checkpoint') {
+    return {
+      text: '',
+      details,
+    }
+  }
   const fallback = rawReply || queuedKeeperMessageError(result)
   return {
     text: formatKeeperVisibleReply(fallback || '(empty reply)'),

--- a/dashboard/src/keeper-actions.test.ts
+++ b/dashboard/src/keeper-actions.test.ts
@@ -537,6 +537,22 @@ describe('sendKeeperThreadMessage stream outcome', () => {
     expect(fetchKeeperToolCalls).toHaveBeenCalledWith('echo', 200)
   })
 
+  it('does not render generic empty-reply text after a tool-only terminal turn', async () => {
+    streamKeeperMessage.mockImplementation(emitting([
+      { type: 'RUN_STARTED' },
+      { type: 'TOOL_CALL_START', toolCallId: 'tc-1', toolCallName: 'keeper_board_list' },
+      { type: 'TOOL_CALL_END', toolCallId: 'tc-1' },
+      { type: 'RUN_FINISHED' },
+    ], true))
+
+    await sendKeeperThreadMessage('echo', '진행 상황?')
+
+    const reply = (keeperThreads.value.echo ?? []).find(entry => entry.role === 'assistant')
+    expect(reply?.delivery).toBe('delivered')
+    expect(reply?.text).toBe('Tool-only turn ended without a final reply.')
+    expect(fetchKeeperToolCalls).toHaveBeenCalledWith('echo', 200)
+  })
+
   it('derives text and media user blocks when only attachments are supplied', async () => {
     streamKeeperMessage.mockImplementation(emitting([
       { type: 'RUN_STARTED' },

--- a/dashboard/src/keeper-actions.ts
+++ b/dashboard/src/keeper-actions.ts
@@ -70,6 +70,8 @@ import {
 
 type KeeperInterjectActionKind = 'send' | 'approve' | 'pause' | 'drain'
 
+const TOOL_ONLY_EMPTY_REPLY_TEXT = 'Tool-only turn ended without a final reply.'
+
 interface KeeperInterjectCommand {
   readonly kind: KeeperInterjectActionKind
   readonly keeperName: string
@@ -769,9 +771,15 @@ export async function sendKeeperThreadMessage(
       !finalText && finalEntry?.delivery === 'queued'
         ? 'queued' as KeeperConversationDelivery
         : 'delivered' as KeeperConversationDelivery
+    let emptyTerminalText = '(empty reply)'
+    if (finalDelivery === 'queued') {
+      emptyTerminalText = ''
+    } else if (toolCallEnded) {
+      emptyTerminalText = TOOL_ONLY_EMPTY_REPLY_TEXT
+    }
 
     finalizeAssistantEntry(keeperName, assistantId, {
-      text: finalText || (finalDelivery === 'queued' ? '' : '(empty reply)'),
+      text: finalText || emptyTerminalText,
       delivery: finalDelivery,
       streamState: null,
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- suppress visible queued replies when the queued keeper result is a typed `continuation_checkpoint`
- replace the generic `(empty reply)` fallback with a tool-only diagnostic when a live terminal stream ran tools but produced no final assistant text
- add regression coverage for both the queued checkpoint path and the tool-only terminal path

## Root Cause

Keeper turns can legitimately finish with a continuation checkpoint or with only tool activity and no final assistant text. The dashboard already handled typed checkpoint details on the SSE detail path, but the queued result converter and terminal fallback still collapsed these cases into a generic `(empty reply)` bubble. That made a real checkpoint/tool-failure turn look like a blank model response.

## Impact

Operators now see a clearer state boundary: continuation checkpoints remain queued/non-visible, and tool-only terminal turns say `Tool-only turn ended without a final reply.` instead of implying the assistant returned an empty answer.

## Validation

- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts src/api/keeper.test.ts src/keeper-actions.test.ts src/keeper-stream.test.ts --no-file-parallelism --maxWorkers=1` — 3 files, 97 tests passed
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit` — passed
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/eslint src/keeper-actions.ts` — passed
- `git diff --check` — passed