### PR TITLE
fix(dashboard): align keeper mobile chat spacing

### DIFF
--- a/dashboard/src/styles/keeper-v2/craft.css
+++ b/dashboard/src/styles/keeper-v2/craft.css
@@ -85,6 +85,55 @@
 .v2-app[data-density="compact"] .bd-list       { padding: 11px 14px; gap: 8px; }
 .v2-app[data-density="compact"] .set-row       { padding: 10px 0; }
 
+/* Mobile keeper workspace: the live chat reuses `.composer` / `.chat-bubble`
+   names from the standalone v2 skin, so this last-loaded craft layer must
+   release desktop density padding on phones. Without this, the 390px chat body
+   loses 40px transcript gutters plus nested 30px composer gutters. */
+@media (max-width: 860px) {
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .chat-transcript {
+    padding:
+      16px
+      max(16px, env(safe-area-inset-right, 0px))
+      12px
+      max(16px, env(safe-area-inset-left, 0px));
+  }
+
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .chat-turn-bundle {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .chat-bubble {
+    width: 100%;
+    max-width: 100%;
+    padding: 14px 15px;
+    line-height: 1.68;
+  }
+
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .kw-composer-wrap {
+    padding:
+      10px
+      max(12px, env(safe-area-inset-right, 0px))
+      max(14px, env(safe-area-inset-bottom, 0px))
+      max(12px, env(safe-area-inset-left, 0px));
+  }
+
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .kw-composer-inner,
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .composer.primary,
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .composer-inner,
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .composer-box {
+    width: 100%;
+    max-width: none;
+    box-sizing: border-box;
+  }
+
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .kw-composer-inner,
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .composer.primary,
+  .v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"] .composer-inner {
+    padding: 0;
+  }
+}
+
 /* ══════════════════════════════════════════════════════════════
    2 · MOTION — press, hover lift, focus ring, entrance
    Base rules below are the "subtle" tier. [data-motion="lively"]

--- a/dashboard/src/styles/keeper-workspace-mobile.test.ts
+++ b/dashboard/src/styles/keeper-workspace-mobile.test.ts
@@ -8,6 +8,7 @@ const chatCss = readFileSync(resolve(__dirname, 'chat.css'), 'utf-8')
 const copilotCss = readFileSync(resolve(__dirname, 'copilot-dock.css'), 'utf-8')
 const turnInspectorCss = readFileSync(resolve(__dirname, 'keeper-turn-inspector.css'), 'utf-8')
 const configCss = readFileSync(resolve(__dirname, 'keeper-v2/keeper-config.css'), 'utf-8')
+const keeperV2CraftCss = readFileSync(resolve(__dirname, 'keeper-v2/craft.css'), 'utf-8')
 const appSource = readFileSync(resolve(__dirname, '../app.ts'), 'utf-8')
 const chatPrimitivesSource = readFileSync(resolve(__dirname, '../components/chat/primitives.ts'), 'utf-8')
 const copilotDockSource = readFileSync(resolve(__dirname, '../components/copilot-dock.ts'), 'utf-8')
@@ -91,6 +92,8 @@ function mediaRuleDeclsIn(source: string, selector: string, maxWidth: string): R
 const mediaRuleDecls = (selector: string, maxWidth: string) => mediaRuleDeclsIn(css, selector, maxWidth)
 const mobileRuleDecls = (selector: string) => mediaRuleDecls(selector, KEEPER_MOBILE_PANE_BREAKPOINT)
 const copilotRuleDecls = (selector: string, maxWidth: string) => mediaRuleDeclsIn(copilotCss, selector, maxWidth)
+const keeperV2CraftMobileRuleDecls = (selector: string) =>
+  mediaRuleDeclsIn(keeperV2CraftCss, selector, KEEPER_MOBILE_PANE_BREAKPOINT)
 const shellMobileTurnInspectorRuleDecls = (selector: string) =>
   mediaRuleDeclsIn(turnInspectorCss, selector, SHELL_MOBILE_CHROME_BREAKPOINT)
 
@@ -193,7 +196,53 @@ describe('keeper workspace v2 (26) mobile contract', () => {
     expect(mobileRuleDecls('.kw-composer-inner .composer textarea')['font-size']).toBe('16px')
   })
 
+  it('uses full-width mobile chat columns instead of desktop reading-width insets', () => {
+    expect(mobileRuleDecls('.kw-chat-body > [data-keeper-chat-layout="workspace"]').width).toBe('100%')
+    expect(mobileRuleDecls('.kw-chat-body > [data-keeper-chat-layout="workspace"]')['max-width']).toBe('100%')
+    expect(mobileRuleDecls('.kw-chat-body > [data-keeper-chat-layout="workspace"]')['min-width']).toBe('0')
+
+    expect(mobileRuleDecls('.v2-app[data-keeper-detail-mode="true"] .kw-rail-toggle').display).toBe('none')
+    expect(mobileRuleDecls('.v2-app[data-keeper-detail-mode="true"] .kw-pane-resizer').display).toBe('none')
+
+    expect(mobileRuleDecls('.kw-chat-toolbar').padding).toContain('max(12px, env(safe-area-inset-right, 0px))')
+    expect(mobileRuleDecls('.kw-chat-toolbar').padding).toContain('max(12px, env(safe-area-inset-left, 0px))')
+    expect(mobileRuleDecls('.kw-chat-toolbar').gap).toBe('8px')
+    expect(mobileRuleDecls('.kw-chat-toolbar [name="keeper_chat_search"]').flex).toBe('1 1 180px')
+    expect(mobileRuleDecls('.kw-chat-toolbar [name="keeper_chat_search"]')['max-width']).toBe('none')
+
+    expect(mobileRuleDecls('[data-keeper-chat-layout="workspace"] .kw-thread-inner').width).toBe('100%')
+    expect(mobileRuleDecls('[data-keeper-chat-layout="workspace"] .kw-thread-inner')['max-width']).toBe('none')
+    expect(mobileRuleDecls('[data-keeper-chat-layout="workspace"] .kw-composer-inner').width).toBe('100%')
+    expect(mobileRuleDecls('[data-keeper-chat-layout="workspace"] .kw-composer-inner')['max-width']).toBe('none')
+    expect(mobileRuleDecls('[data-keeper-chat-layout="workspace"] .composer-inner').width).toBe('100%')
+    expect(mobileRuleDecls('[data-keeper-chat-layout="workspace"] .composer-box').width).toBe('100%')
+  })
+
+  it('overrides the last-loaded v2 craft density gutters for mobile keeper chat', () => {
+    const scope = '.v2-app[data-keeper-detail-mode="true"] [data-keeper-chat-layout="workspace"]'
+
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .chat-transcript`).padding).toContain(
+      'max(16px, env(safe-area-inset-left, 0px))',
+    )
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .chat-turn-bundle`).width).toBe('100%')
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .chat-turn-bundle`)['max-width']).toBe('100%')
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .chat-bubble`).width).toBe('100%')
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .chat-bubble`)['max-width']).toBe('100%')
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .chat-bubble`).padding).toBe('14px 15px')
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .kw-composer-wrap`).padding).toContain(
+      'max(12px, env(safe-area-inset-left, 0px))',
+    )
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .kw-composer-inner`).padding).toBe('0')
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .composer.primary`).padding).toBe('0')
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .composer-inner`).padding).toBe('0')
+    expect(keeperV2CraftMobileRuleDecls(`${scope} .composer-box`).width).toBe('100%')
+  })
+
   it('keeps mobile conversation bubbles at the v2 reading scale', () => {
+    expect(mobileRuleDecls('.kw-thread-inner .chat-turn-bundle').width).toBe('100%')
+    expect(mobileRuleDecls('.kw-thread-inner .chat-turn-bundle')['max-width']).toBe('100%')
+    expect(mobileRuleDecls('.kw-thread-inner .chat-bubble').width).toBe('100%')
+    expect(mobileRuleDecls('.kw-thread-inner .chat-bubble')['max-width']).toBe('100%')
     expect(mobileRuleDecls('.kw-thread-inner .chat-bubble')['font-size']).toBe('16.5px')
     expect(mobileRuleDecls('.kw-thread-inner .chat-bubble')['line-height']).toBe('1.68')
     expect(mobileRuleDecls('.kw-thread-inner .chat-bubble').padding).toBe('14px 15px')

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -1275,6 +1275,43 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
     max-width: calc(100vw - 28px - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px));
   }
 
+  .v2-app[data-keeper-detail-mode="true"] .kw-rail-toggle,
+  .v2-app[data-keeper-detail-mode="true"] .kw-pane-resizer {
+    display: none;
+  }
+
+  .kw-chat-body > [data-keeper-chat-layout="workspace"] {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .kw-chat-toolbar {
+    gap: 8px;
+    padding:
+      8px
+      max(12px, env(safe-area-inset-right, 0px))
+      8px
+      max(12px, env(safe-area-inset-left, 0px));
+  }
+
+  .kw-chat-toolbar [name="keeper_chat_search"] {
+    flex: 1 1 180px;
+    min-width: 0;
+    max-width: none;
+  }
+
+  [data-keeper-chat-layout="workspace"] .kw-thread,
+  [data-keeper-chat-layout="workspace"] .kw-thread-inner,
+  [data-keeper-chat-layout="workspace"] .kw-composer-wrap,
+  [data-keeper-chat-layout="workspace"] .kw-composer-inner,
+  [data-keeper-chat-layout="workspace"] .composer-inner,
+  [data-keeper-chat-layout="workspace"] .composer-box {
+    width: 100%;
+    max-width: none;
+    box-sizing: border-box;
+  }
+
   .kw-thread-inner .chat-transcript {
     gap: 18px;
     padding-left: max(16px, env(safe-area-inset-left, 0px));
@@ -1283,7 +1320,14 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
     padding-bottom: 12px;
   }
 
+  .kw-thread-inner .chat-turn-bundle {
+    width: 100%;
+    max-width: 100%;
+  }
+
   .kw-thread-inner .chat-bubble {
+    width: 100%;
+    max-width: 100%;
     font-size: 16.5px;
     line-height: 1.68;
     padding: 14px 15px;


### PR DESCRIPTION
## Summary
- Fixes the actual mobile spacing regression in keeper chat, not just shell chrome.
- Mobile keeper chat now releases desktop density gutters from the last-loaded v2 craft layer:
  - transcript padding 40px -> 16px
  - nested composer gutters 30px -> 0
  - composer box expands to the mobile column
  - chat turn bundle/bubble expands to the transcript column
- Keeps rail/resizer toggles suppressed in mobile keeper detail mode so they do not occupy visual space.

## Evidence
- Before: /tmp/keeper-spacing-current-15s.png
- Reference: /tmp/keeper-spacing-reference.png
- After: /tmp/keeper-spacing-after-4.png
- CDP computed check after patch:
  - .chat-transcript padding: 16px 16px 12px
  - .chat-bubble width: 332px
  - .kw-composer-inner width: 342px, padding: 0
  - .composer-box width: 342px
  - .kw-rail-toggle left/right display: none

## Verification
- git diff --check
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/styles/keeper-workspace-mobile.test.ts
- pnpm --dir dashboard typecheck
- pnpm --dir dashboard lint
- pnpm --dir dashboard build

Known existing build warnings:
- font assets remain runtime-resolved
- dynamic/static import chunk warnings
- large chunk warnings
