### PR TITLE
fix(dashboard): prevent mobile topbar overflow

### DIFF
--- a/dashboard/src/styles/keeper-v2/ops-cluster.css
+++ b/dashboard/src/styles/keeper-v2/ops-cluster.css
@@ -52,3 +52,22 @@
   letter-spacing: 0.04em;
   white-space: nowrap;
 }
+
+/* The re-mounted operational cluster is wider than the prototype mobile shell.
+   Keep phone/tablet topbars to the prototype-owned status chips so the page does
+   not start with off-canvas actions before the primary surface content. */
+@media (max-width: 900px) {
+  .v2-app[data-mobile="1"] .v2-top-ops,
+  .v2-app[data-mobile="1"] .v2-top > .v2-shell-panel,
+  .v2-app[data-mobile="1"] .v2-top > [data-testid="tweaks-panel-toggle"] {
+    display: none;
+  }
+}
+
+@media (min-width: 901px) and (max-width: 1120px) {
+  .v2-app[data-keeper-detail-mode="true"] .v2-top-ops,
+  .v2-app[data-keeper-detail-mode="true"] .v2-top > .v2-shell-panel,
+  .v2-app[data-keeper-detail-mode="true"] .v2-top > [data-testid="tweaks-panel-toggle"] {
+    display: none;
+  }
+}

--- a/dashboard/src/styles/keeper-workspace-mobile.test.ts
+++ b/dashboard/src/styles/keeper-workspace-mobile.test.ts
@@ -9,6 +9,7 @@ const copilotCss = readFileSync(resolve(__dirname, 'copilot-dock.css'), 'utf-8')
 const turnInspectorCss = readFileSync(resolve(__dirname, 'keeper-turn-inspector.css'), 'utf-8')
 const configCss = readFileSync(resolve(__dirname, 'keeper-v2/keeper-config.css'), 'utf-8')
 const keeperV2CraftCss = readFileSync(resolve(__dirname, 'keeper-v2/craft.css'), 'utf-8')
+const opsClusterCss = readFileSync(resolve(__dirname, 'keeper-v2/ops-cluster.css'), 'utf-8')
 const appSource = readFileSync(resolve(__dirname, '../app.ts'), 'utf-8')
 const chatPrimitivesSource = readFileSync(resolve(__dirname, '../components/chat/primitives.ts'), 'utf-8')
 const copilotDockSource = readFileSync(resolve(__dirname, '../components/copilot-dock.ts'), 'utf-8')
@@ -53,6 +54,7 @@ const implementationSources = [
 ].join('\n')
 
 const SHELL_MOBILE_CHROME_BREAKPOINT = '900px'
+const SHELL_TABLET_EDGE_BREAKPOINT = '1120px'
 const KEEPER_MOBILE_PANE_BREAKPOINT = '860px'
 const PHONE_NARROW_BREAKPOINT = '420px'
 
@@ -92,6 +94,7 @@ function mediaRuleDeclsIn(source: string, selector: string, maxWidth: string): R
 const mediaRuleDecls = (selector: string, maxWidth: string) => mediaRuleDeclsIn(css, selector, maxWidth)
 const mobileRuleDecls = (selector: string) => mediaRuleDecls(selector, KEEPER_MOBILE_PANE_BREAKPOINT)
 const copilotRuleDecls = (selector: string, maxWidth: string) => mediaRuleDeclsIn(copilotCss, selector, maxWidth)
+const opsClusterRuleDecls = (selector: string, maxWidth: string) => mediaRuleDeclsIn(opsClusterCss, selector, maxWidth)
 const keeperV2CraftMobileRuleDecls = (selector: string) =>
   mediaRuleDeclsIn(keeperV2CraftCss, selector, KEEPER_MOBILE_PANE_BREAKPOINT)
 const shellMobileTurnInspectorRuleDecls = (selector: string) =>
@@ -164,6 +167,39 @@ describe('keeper workspace v2 (26) mobile contract', () => {
     expect(copilotDockSource).toContain('<kbd>⌘J</kbd>')
     expect(copilotRuleDecls('.topbar-copilot kbd', SHELL_MOBILE_CHROME_BREAKPOINT).display).toBe('none')
     expect(copilotRuleDecls('.topbar-copilot span:not(.spark)', PHONE_NARROW_BREAKPOINT).display).toBe('none')
+  })
+
+  it('keeps remounted operational topbar chrome out of mobile and keeper tablet edges', () => {
+    expect(opsClusterRuleDecls('.v2-app[data-mobile="1"] .v2-top-ops', SHELL_MOBILE_CHROME_BREAKPOINT).display)
+      .toBe('none')
+    expect(
+      opsClusterRuleDecls('.v2-app[data-mobile="1"] .v2-top > .v2-shell-panel', SHELL_MOBILE_CHROME_BREAKPOINT)
+        .display,
+    ).toBe('none')
+    expect(
+      opsClusterRuleDecls(
+        '.v2-app[data-mobile="1"] .v2-top > [data-testid="tweaks-panel-toggle"]',
+        SHELL_MOBILE_CHROME_BREAKPOINT,
+      ).display,
+    ).toBe('none')
+    expect(
+      opsClusterRuleDecls(
+        '.v2-app[data-keeper-detail-mode="true"] .v2-top-ops',
+        SHELL_TABLET_EDGE_BREAKPOINT,
+      ).display,
+    ).toBe('none')
+    expect(
+      opsClusterRuleDecls(
+        '.v2-app[data-keeper-detail-mode="true"] .v2-top > .v2-shell-panel',
+        SHELL_TABLET_EDGE_BREAKPOINT,
+      ).display,
+    ).toBe('none')
+    expect(
+      opsClusterRuleDecls(
+        '.v2-app[data-keeper-detail-mode="true"] .v2-top > [data-testid="tweaks-panel-toggle"]',
+        SHELL_TABLET_EDGE_BREAKPOINT,
+      ).display,
+    ).toBe('none')
   })
 
   it('uses dynamic viewport height for the focused keeper mobile surface and context drawer', () => {


### PR DESCRIPTION
## Summary
- hide the remounted operational topbar cluster on mobile shell widths
- hide the same low-priority topbar chrome on keeper detail tablet-edge widths
- add a CSS contract test for the mobile/tablet topbar overflow guard

## Verification
- pnpm --dir dashboard exec vitest run --config vitest.config.ts src/styles/keeper-workspace-mobile.test.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard run typecheck
- pnpm --dir dashboard run lint
- python3 /tmp/masc_ui_hunt_cdp.py; all scanned 390px/860px/900px/901px cases reported overflow count 0