### PR TITLE
fix(harness): authenticate contract MCP probes

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -92,7 +92,8 @@ let masc_dashboard_spec : tool_spec =
        to choose the current task-focused view or the full workspace view."
   ; parameters =
       [ { p_name = "scope"
-        ; p_type = T_string { enum = Some dashboard_scope_enum_strings; default = Some "current" }
+        ; p_type =
+            T_string { enum = Some dashboard_scope_enum_strings; default = Some "current" }
         ; p_description = "Dashboard scope: current or all"
         ; p_required = false
         }

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -336,7 +336,8 @@ let handle_add_task ~tool_name ~start_time ctx args =
                   ])
              ()
          | Error err ->
-           Tool_result.ok
+           Tool_result.error
+             ~failure_class:(Some Tool_result.Workflow_rejection)
              ~tool_name
              ~start_time
              (Workspace.add_task_error_to_string err))
@@ -472,7 +473,8 @@ let handle_batch_add_tasks ~tool_name ~start_time ctx args =
               ])
          ()
      | Error err ->
-       Tool_result.ok
+       Tool_result.error
+         ~failure_class:(Some Tool_result.Workflow_rejection)
          ~tool_name
          ~start_time
          (Workspace.batch_add_tasks_error_to_string err))

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -107,16 +107,6 @@ let result_to_response ~tool_name ~start_time = function
         ~tool_name ~start_time
         (Masc_domain.masc_error_to_string e)
 
-let task_id_of_add_task_summary summary =
-  let prefix = "Added " in
-  if not (String.starts_with ~prefix summary)
-  then None
-  else
-    let start = String.length prefix in
-    match String.index_from_opt summary start ':' with
-    | Some stop when stop > start -> Some (String.sub summary start (stop - start))
-    | _ -> None
-
 let log_task_transition_failed ~agent_name err =
   let message = Masc_domain.masc_error_to_string err in
   match err with
@@ -319,8 +309,8 @@ let handle_add_task ~tool_name ~start_time ctx args =
           ~failure_class:(Some Tool_result.Workflow_rejection)
           ~tool_name ~start_time error
     | Ok contract ->
-        let summary =
-          Workspace.add_task ?contract
+        let add_result =
+          Workspace.add_task_with_result ?contract
             ?goal_id
             ~reject_if:
               (Workspace_task_capacity.rejection_for_add_task_for_config
@@ -329,24 +319,27 @@ let handle_add_task ~tool_name ~start_time ctx args =
             ~created_by:ctx.agent_name ctx.config ~title:trimmed_title
             ~priority ~description
         in
-        (match task_id_of_add_task_summary summary with
-         | Some task_id ->
+        (match add_result with
+         | Ok created ->
            Tool_result.make_ok
              ~tool_name
              ~start_time
              ~data:
                (`Assoc
                   [ "ok", `Bool true
-                  ; "task_id", `String task_id
-                  ; "summary", `String summary
+                  ; "task_id", `String created.task_id
+                  ; "summary", `String created.summary
                   ; "title", `String trimmed_title
                   ; "priority", `Int priority
                   ; "description", `String description
                   ; "goal_id", Json_util.string_opt_to_json goal_id
                   ])
              ()
-         | None ->
-           Tool_result.ok ~tool_name ~start_time summary)
+         | Error err ->
+           Tool_result.ok
+             ~tool_name
+             ~start_time
+             (Workspace.add_task_error_to_string err))
 
 (* RFC-0267 Phase 2: assign an existing goalless task to a goal. Thin adapter
    over [Task_goal_assignment.set_task_goal] — the single validated backend
@@ -461,8 +454,28 @@ let handle_batch_add_tasks ~tool_name ~start_time ctx args =
     let tasks =
       List.filter_map (function Ok t -> Some t | Error _ -> None) validated
     in
-    Tool_result.ok ~tool_name ~start_time (Workspace.batch_add_tasks_with_contracts
-      ~created_by:ctx.agent_name ctx.config tasks)
+    let batch_result =
+      Workspace.batch_add_tasks_with_contracts_result
+        ~created_by:ctx.agent_name ctx.config tasks
+    in
+    (match batch_result with
+     | Ok created ->
+       Tool_result.make_ok
+         ~tool_name
+         ~start_time
+         ~data:
+           (`Assoc
+              [ "ok", `Bool true
+              ; "task_ids", `List (List.map (fun task_id -> `String task_id) created.task_ids)
+              ; "summary", `String created.summary
+              ; "count", `Int created.count
+              ])
+         ()
+     | Error err ->
+       Tool_result.ok
+         ~tool_name
+         ~start_time
+         (Workspace.batch_add_tasks_error_to_string err))
 
 let handle_claim ~tool_name ~start_time ctx args =
   (* #18965 — removed [is_agent_session_bound] hard gate.  Agent-internal tag

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -346,11 +346,7 @@ let handle_add_task ~tool_name ~start_time ctx args =
                   ])
              ()
          | None ->
-           Tool_result.error
-             ~failure_class:(Some Tool_result.Workflow_rejection)
-             ~tool_name
-             ~start_time
-             summary)
+           Tool_result.ok ~tool_name ~start_time summary)
 
 (* RFC-0267 Phase 2: assign an existing goalless task to a goal. Thin adapter
    over [Task_goal_assignment.set_task_goal] — the single validated backend

--- a/lib/task/tool_task_handlers.ml
+++ b/lib/task/tool_task_handlers.ml
@@ -107,6 +107,16 @@ let result_to_response ~tool_name ~start_time = function
         ~tool_name ~start_time
         (Masc_domain.masc_error_to_string e)
 
+let task_id_of_add_task_summary summary =
+  let prefix = "Added " in
+  if not (String.starts_with ~prefix summary)
+  then None
+  else
+    let start = String.length prefix in
+    match String.index_from_opt summary start ':' with
+    | Some stop when stop > start -> Some (String.sub summary start (stop - start))
+    | _ -> None
+
 let log_task_transition_failed ~agent_name err =
   let message = Masc_domain.masc_error_to_string err in
   match err with
@@ -309,15 +319,38 @@ let handle_add_task ~tool_name ~start_time ctx args =
           ~failure_class:(Some Tool_result.Workflow_rejection)
           ~tool_name ~start_time error
     | Ok contract ->
-        Tool_result.ok ~tool_name ~start_time
-          (Workspace.add_task ?contract
+        let summary =
+          Workspace.add_task ?contract
             ?goal_id
             ~reject_if:
               (Workspace_task_capacity.rejection_for_add_task_for_config
                  ctx.config
                  ?goal_id)
             ~created_by:ctx.agent_name ctx.config ~title:trimmed_title
-            ~priority ~description)
+            ~priority ~description
+        in
+        (match task_id_of_add_task_summary summary with
+         | Some task_id ->
+           Tool_result.make_ok
+             ~tool_name
+             ~start_time
+             ~data:
+               (`Assoc
+                  [ "ok", `Bool true
+                  ; "task_id", `String task_id
+                  ; "summary", `String summary
+                  ; "title", `String trimmed_title
+                  ; "priority", `Int priority
+                  ; "description", `String description
+                  ; "goal_id", Json_util.string_opt_to_json goal_id
+                  ])
+             ()
+         | None ->
+           Tool_result.error
+             ~failure_class:(Some Tool_result.Workflow_rejection)
+             ~tool_name
+             ~start_time
+             summary)
 
 (* RFC-0267 Phase 2: assign an existing goalless task to a goal. Thin adapter
    over [Task_goal_assignment.set_task_goal] — the single validated backend

--- a/lib/workspace/workspace_task_create.ml
+++ b/lib/workspace/workspace_task_create.ml
@@ -45,10 +45,51 @@ let find_duplicate_task (backlog : backlog) ~(title : string)
     |> Option.map (fun (t : task) -> t.id)
 ;;
 
+type add_task_success =
+  { task_id : string
+  ; summary : string
+  ; title : string
+  ; priority : int
+  ; description : string
+  ; goal_id : string option
+  }
+
+type add_task_error =
+  | Backlog_read_failed of string
+  | Rejected of string
+  | Duplicate of { title : string; existing_id : string }
+  | Unexpected_error of string
+
+type batch_add_tasks_success =
+  { task_ids : string list
+  ; summary : string
+  ; count : int
+  }
+
+type batch_add_tasks_error =
+  | Batch_backlog_read_failed of string
+  | Batch_unexpected_error of string
+
+let add_task_error_to_string = function
+  | Backlog_read_failed msg -> Printf.sprintf "Error: %s" msg
+  | Rejected msg -> Printf.sprintf "Error: %s" msg
+  | Duplicate { title; existing_id } ->
+    Printf.sprintf
+      "Duplicate rejected: '%s' matches existing %s. Use that task instead."
+      title
+      existing_id
+  | Unexpected_error msg -> Printf.sprintf "Error: %s" msg
+;;
+
+let batch_add_tasks_error_to_string = function
+  | Batch_backlog_read_failed msg -> Printf.sprintf "Error adding batch tasks: %s" msg
+  | Batch_unexpected_error msg -> Printf.sprintf "Error adding batch tasks: %s" msg
+;;
+
 (** Add task — file-locked to prevent task ID collision under concurrency.
     Rejects tasks with duplicate titles (exact match after normalization)
     to prevent the same work from being created multiple times. *)
-let add_task
+let add_task_with_result
       ?contract
       ?goal_id
       ?created_by
@@ -65,21 +106,18 @@ let add_task
   try
     with_file_lock config backlog_path (fun () ->
       match read_backlog_r config with
-      | Error msg -> Printf.sprintf "Error: %s" msg
+      | Error msg -> Error (Backlog_read_failed msg)
       | Ok backlog ->
         (match reject_if with
          | Some reject_if -> reject_if backlog
          | None -> None)
         |> (function
-          | Some msg -> Printf.sprintf "Error: %s" msg
+          | Some msg -> Error (Rejected msg)
           | None ->
         (* Dedup guard: reject if an active task with the same normalized title exists *)
         (match find_duplicate_task backlog ~title with
          | Some existing_id ->
-           Printf.sprintf
-             "Duplicate rejected: '%s' matches existing %s. Use that task instead."
-             title
-             existing_id
+           Error (Duplicate { title; existing_id })
          | None ->
            let task_id = Printf.sprintf "task-%03d" (next_task_number config backlog) in
            let contract =
@@ -143,20 +181,38 @@ let add_task
                ~from_agent:actor
                ~content:(Printf.sprintf "New quest: %s" title)
            in
-           Printf.sprintf "Added %s: %s" task_id title)))
+           let summary = Printf.sprintf "Added %s: %s" task_id title in
+           Ok { task_id; summary; title; priority; description; goal_id })))
   with
   | Eio.Cancel.Cancelled _ as e -> raise e
-  | e -> Printf.sprintf "Error: %s" (Printexc.to_string e)
+  | e -> Error (Unexpected_error (Printexc.to_string e))
+;;
+
+let add_task ?contract ?goal_id ?created_by ?reject_if config ~title ~priority
+    ~description =
+  match
+    add_task_with_result
+      ?contract
+      ?goal_id
+      ?created_by
+      ?reject_if
+      config
+      ~title
+      ~priority
+      ~description
+  with
+  | Ok created -> created.summary
+  | Error err -> add_task_error_to_string err
 ;;
 
 (** Add multiple tasks in a batch *)
-let batch_add_tasks_internal ?created_by config tasks =
+let batch_add_tasks_internal_with_result ?created_by config tasks =
   ensure_initialized config;
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
   let actor = Option.value ~default:"system" created_by in
   with_file_lock config backlog_path (fun () ->
     match read_backlog_r config with
-    | Error msg -> Printf.sprintf "Error adding batch tasks: %s" msg
+    | Error msg -> Error (Batch_backlog_read_failed msg)
     | Ok backlog ->
       (try
          let next_num = ref (next_task_number config backlog) in
@@ -238,10 +294,19 @@ let batch_add_tasks_internal ?created_by config tasks =
              summary
          in
          let _ = broadcast config ~from_agent:actor ~content:msg in
-         Printf.sprintf "Added %d tasks: %s" (List.length added_tasks) summary
+         let count = List.length added_tasks in
+         let task_ids = List.map (fun (task : Masc_domain.task) -> task.id) added_tasks in
+         let summary = Printf.sprintf "Added %d tasks: %s" count summary in
+         Ok { task_ids; summary; count }
        with
        | Eio.Cancel.Cancelled _ as e -> raise e
-       | e -> Printf.sprintf "Error adding batch tasks: %s" (Printexc.to_string e)))
+       | e -> Error (Batch_unexpected_error (Printexc.to_string e))))
+;;
+
+let batch_add_tasks_internal ?created_by config tasks =
+  match batch_add_tasks_internal_with_result ?created_by config tasks with
+  | Ok created -> created.summary
+  | Error err -> batch_add_tasks_error_to_string err
 ;;
 
 let batch_add_tasks ?created_by config tasks =
@@ -256,4 +321,8 @@ let batch_add_tasks ?created_by config tasks =
 
 let batch_add_tasks_with_contracts ?created_by config tasks =
   batch_add_tasks_internal ?created_by config tasks
+;;
+
+let batch_add_tasks_with_contracts_result ?created_by config tasks =
+  batch_add_tasks_internal_with_result ?created_by config tasks
 ;;

--- a/lib/workspace/workspace_task_create.mli
+++ b/lib/workspace/workspace_task_create.mli
@@ -19,6 +19,46 @@ val find_duplicate_task :
 
 (** {1 Task creation} *)
 
+type add_task_success =
+  { task_id : string
+  ; summary : string
+  ; title : string
+  ; priority : int
+  ; description : string
+  ; goal_id : string option
+  }
+
+type add_task_error =
+  | Backlog_read_failed of string
+  | Rejected of string
+  | Duplicate of { title : string; existing_id : string }
+  | Unexpected_error of string
+
+type batch_add_tasks_success =
+  { task_ids : string list
+  ; summary : string
+  ; count : int
+  }
+
+type batch_add_tasks_error =
+  | Batch_backlog_read_failed of string
+  | Batch_unexpected_error of string
+
+val add_task_error_to_string : add_task_error -> string
+
+val batch_add_tasks_error_to_string : batch_add_tasks_error -> string
+
+val add_task_with_result :
+  ?contract:Masc_domain.task_contract ->
+  ?goal_id:string ->
+  ?created_by:string ->
+  ?reject_if:(Masc_domain.backlog -> string option) ->
+  config ->
+  title:string ->
+  priority:int ->
+  description:string ->
+  (add_task_success, add_task_error) result
+
 val add_task :
   ?contract:Masc_domain.task_contract ->
   ?goal_id:string ->
@@ -35,6 +75,12 @@ val batch_add_tasks_with_contracts :
   config ->
   (string * int * string * Masc_domain.task_contract option * string option) list ->
   string
+
+val batch_add_tasks_with_contracts_result :
+  ?created_by:string ->
+  config ->
+  (string * int * string * Masc_domain.task_contract option * string option) list ->
+  (batch_add_tasks_success, batch_add_tasks_error) result
 
 val batch_add_tasks_internal :
   ?created_by:string ->

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -61,6 +61,10 @@ else
   echo "$r1"
   exit 1
 fi
+if [ -z "${MCP_SESSION_ID:-}" ]; then
+  step_fail "empty MCP_SESSION_ID after masc_start"
+  exit 1
+fi
 
 # ── Step 2/8: add_task ──
 echo "[2/8] masc_add_task"

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -35,6 +35,15 @@ cleanup_contract_task() {
 }
 trap 'cleanup_contract_task' EXIT
 
+initialize_mcp_session || {
+  echo "FAIL: failed to initialize MCP session" >&2
+  exit 1
+}
+if [ -z "${MCP_SESSION_ID:-}" ]; then
+  echo "FAIL: empty MCP_SESSION_ID after initialize" >&2
+  exit 1
+fi
+
 ensure_contract_goal() {
   local goal_payload
   local goal_json

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -12,22 +12,28 @@
 #   MCP_URL=http://127.0.0.1:9935/mcp ./golden_path_1_contract.sh  # dev instance
 set -euo pipefail
 
-AGENT_NAME="${AGENT_NAME:-admin}"
+AGENT_NAME="${AGENT_NAME:-golden-path-1-harness}"
 MCP_SESSION_ID="${MCP_SESSION_ID:-}"
 export MCP_SESSION_ID
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-START_PATH="${BASE_PATH:-$ROOT_DIR}"
 source "${SCRIPT_DIR}/../lib/test_framework.sh"
-
-extract_text() {
-  jq -r 'if ._harness_error? then empty else try (.result.content[0].text) catch empty end'
-}
 
 PASS=0
 FAIL=0
 GOAL_ID=""
+CLEANUP_TASK_FINALIZED=0
+START_PATH="${BASE_PATH:-$PWD}"
+
+# shellcheck disable=SC2329 # invoked by EXIT trap
+cleanup_contract_task() {
+  local exit_status=$?
+  if [ "$CLEANUP_TASK_FINALIZED" -ne 1 ] && [ -n "${task_id:-}" ]; then
+    call_tool 1999 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"cancel",notes:"GP1 contract cleanup after unsuccessful run"}')" >/dev/null 2>&1 || true
+  fi
+  exit "$exit_status"
+}
+trap 'cleanup_contract_task' EXIT
 
 ensure_contract_goal() {
   local goal_payload
@@ -41,15 +47,8 @@ ensure_contract_goal() {
   fi
 }
 
-ensure_contract_goal
-
 step_pass() { PASS=$((PASS + 1)); echo "  PASS"; }
 step_fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
-
-cleanup() {
-  :
-}
-trap cleanup EXIT
 
 # ── Step 1/8: start ──
 echo "[1/8] masc_start"
@@ -66,6 +65,8 @@ if [ -z "${MCP_SESSION_ID:-}" ]; then
   exit 1
 fi
 
+ensure_contract_goal
+
 # ── Step 2/8: add_task ──
 echo "[2/8] masc_add_task"
 r2="$(call_tool 1002 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" --arg task_title "GP1 contract task $(date +%s)" '{title: $task_title, goal_id: $goal_id, priority: 2, description: "Automated golden path 1 contract verification"}')")"
@@ -76,9 +77,8 @@ else
   echo "$r2"
   exit 1
 fi
-# Extract task_id from response
-task_text="$(printf "%s" "$r2" | extract_text)"
-task_id="$(printf "%s\n" "$task_text" | grep -oE 'task-[0-9]+(-[0-9]+)?' | head -n1 || true)"
+task_json="$(printf '%s' "$r2" | extract_result)"
+task_id="$(printf '%s' "$task_json" | jq -r '.task_id // .id // empty')"
 if [ -z "$task_id" ]; then
   step_fail "could not extract task_id from add_task response"
   echo "$r2"
@@ -141,6 +141,7 @@ fi
 echo "[8/8] masc_transition (done)"
 r8="$(call_tool 1008 "masc_transition" "{\"task_id\":\"$task_id\",\"agent_name\":\"$AGENT_NAME\",\"action\":\"done\",\"notes\":\"Completed GP1 contract flow: bound workspace, created and claimed task, set current task, sent heartbeat, broadcast progress, and verified masc_status returned success.\"}")"
 if require_ok "$r8"; then
+  CLEANUP_TASK_FINALIZED=1
   step_pass
 else
   step_fail "done transition failed"

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -132,7 +132,7 @@ expect_ok "masc_goal_list" "$r_goal_list"
 echo "[11/36] masc_add_task"
 r_add_task="$(call_tool 5015 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" '{title:"Public Tool Sweep Task",goal_id:$goal_id,priority:2,description:"live public surface verification"}')")"
 expect_ok "masc_add_task" "$r_add_task"
-task_id="$( 
+task_id="$(
   printf '%s' "$r_add_task" \
     | jq -r 'try (.result.structuredContent.task_id // .result.structuredContent.id) catch empty | strings' \
     | head -n1

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -53,13 +53,52 @@ call_method() {
   jsonrpc_normalize_response "$raw" "$id"
 }
 
-CLEANUP_TASK_FINALIZED=0
+CLEANUP_TASK_IDS=()
+CLEANUP_TASK_FINALIZED_IDS=()
+
+remember_cleanup_task_id() {
+  local new_task_id="$1"
+  local existing_task_id
+  for existing_task_id in "${CLEANUP_TASK_IDS[@]}"; do
+    if [[ "$existing_task_id" == "$new_task_id" ]]; then
+      return 0
+    fi
+  done
+  CLEANUP_TASK_IDS+=("$new_task_id")
+}
+
+cleanup_task_is_finalized() {
+  local task_id_to_check="$1"
+  local finalized_task_id
+  for finalized_task_id in "${CLEANUP_TASK_FINALIZED_IDS[@]}"; do
+    if [[ "$finalized_task_id" == "$task_id_to_check" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+mark_cleanup_task_finalized() {
+  local finalized_task_id="$1"
+  remember_cleanup_task_id "$finalized_task_id"
+  if cleanup_task_is_finalized "$finalized_task_id"; then
+    return 0
+  fi
+  CLEANUP_TASK_FINALIZED_IDS+=("$finalized_task_id")
+}
+
 # shellcheck disable=SC2329 # invoked by EXIT trap
 cleanup_contract_task() {
   local exit_status=$?
-  if [ "$CLEANUP_TASK_FINALIZED" -ne 1 ] && [ -n "${task_id:-}" ]; then
-    call_tool 5999 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"cancel",notes:"public tool sweep cleanup after unsuccessful run"}')" >/dev/null 2>&1 || true
-  fi
+  local cleanup_call_id=5999
+  local cleanup_task_id
+  for cleanup_task_id in "${CLEANUP_TASK_IDS[@]}"; do
+    if cleanup_task_is_finalized "$cleanup_task_id"; then
+      continue
+    fi
+    call_tool "$cleanup_call_id" "masc_transition" "$(jq -cn --arg task_id "$cleanup_task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"cancel",notes:"public tool sweep cleanup after unsuccessful run"}')" >/dev/null 2>&1 || true
+    cleanup_call_id=$((cleanup_call_id + 1))
+  done
   exit "$exit_status"
 }
 trap 'cleanup_contract_task' EXIT
@@ -140,10 +179,25 @@ task_id="$(
 if [[ -z "$task_id" ]]; then
   mcp_fail_with_context "masc_add_task: could not extract task_id" "$r_add_task"
 fi
+remember_cleanup_task_id "$task_id"
 
 echo "[12/36] masc_batch_add_tasks"
 r_batch_add="$(call_tool 5016 "masc_batch_add_tasks" "$(jq -cn --arg goal_id "$GOAL_ID" '{tasks:[{title:"Public Sweep Batch A",goal_id:$goal_id,priority:3,description:"batch-a"},{title:"Public Sweep Batch B",goal_id:$goal_id,priority:4,description:"batch-b"}]}')")"
 expect_ok "masc_batch_add_tasks" "$r_batch_add"
+batch_task_ids=()
+while IFS= read -r batch_task_id; do
+  if [[ -z "$batch_task_id" ]]; then
+    continue
+  fi
+  batch_task_ids+=("$batch_task_id")
+  remember_cleanup_task_id "$batch_task_id"
+done < <(
+  printf '%s' "$r_batch_add" \
+    | jq -r 'try (.result.structuredContent.task_ids[]?) catch empty | strings'
+)
+if [[ "${#batch_task_ids[@]}" -ne 2 ]]; then
+  mcp_fail_with_context "masc_batch_add_tasks: expected two structured task_ids" "$r_batch_add"
+fi
 
 echo "[13/36] masc_tasks"
 r_tasks="$(call_tool 5017 "masc_tasks" '{}')"
@@ -245,17 +299,26 @@ echo "[33/36] masc_persona_list"
 r_persona_list="$(call_tool 5037 "masc_persona_list" '{"detailed":false}')"
 expect_ok "masc_persona_list" "$r_persona_list"
 
-echo "[34/36] masc_goal_transition"
-r_goal_transition="$(call_tool 5038 "masc_goal_transition" "$(jq -cn --arg goal_id "$GOAL_ID" --arg actor "$AGENT_NAME" '{goal_id:$goal_id,action:"request_complete",actor:{id:$actor},note:"public sweep verification request"}')")"
-expect_ok "masc_goal_transition" "$r_goal_transition"
-
-echo "[35/36] masc_goal_verify"
-r_goal_verify="$(call_tool 5039 "masc_goal_verify" "$(jq -cn --arg goal_id "$GOAL_ID" --arg principal "${AGENT_NAME}-verifier" '{goal_id:$goal_id,principal:{id:$principal},decision:"approve",note:"public sweep verifier approval"}')")"
-expect_ok "masc_goal_verify" "$r_goal_verify"
-
-echo "[36/36] masc_transition (done)"
-r_done="$(call_tool 5040 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"done",notes:"public tool sweep done"}')")"
+echo "[34/36] masc_transition (finish linked tasks)"
+finish_call_id=5038
+for batch_task_id in "${batch_task_ids[@]}"; do
+  r_cancel_batch="$(call_tool "$finish_call_id" "masc_transition" "$(jq -cn --arg task_id "$batch_task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"cancel",notes:"public tool sweep batch cleanup before goal completion"}')")"
+  expect_ok "masc_transition cancel ${batch_task_id}" "$r_cancel_batch"
+  mark_cleanup_task_finalized "$batch_task_id"
+  finish_call_id=$((finish_call_id + 1))
+done
+r_done="$(call_tool "$finish_call_id" "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"done",notes:"public tool sweep done"}')")"
 expect_ok "masc_transition done" "$r_done"
-CLEANUP_TASK_FINALIZED=1
+mark_cleanup_task_finalized "$task_id"
+finish_call_id=$((finish_call_id + 1))
+
+echo "[35/36] masc_goal_transition"
+r_goal_transition="$(call_tool "$finish_call_id" "masc_goal_transition" "$(jq -cn --arg goal_id "$GOAL_ID" --arg actor "$AGENT_NAME" '{goal_id:$goal_id,action:"request_complete",actor:{id:$actor},note:"public sweep verification request"}')")"
+expect_ok "masc_goal_transition" "$r_goal_transition"
+finish_call_id=$((finish_call_id + 1))
+
+echo "[36/36] masc_goal_verify"
+r_goal_verify="$(call_tool "$finish_call_id" "masc_goal_verify" "$(jq -cn --arg goal_id "$GOAL_ID" --arg principal "${AGENT_NAME}-verifier" '{goal_id:$goal_id,principal:{id:$principal},decision:"approve",note:"public sweep verifier approval"}')")"
+expect_ok "masc_goal_verify" "$r_goal_verify"
 
 echo "PASS: public MCP tool live sweep"

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -118,7 +118,7 @@ r_tool_help="$(call_tool 5012 "masc_tool_help" '{"tool_name":"masc_status"}')"
 expect_ok "masc_tool_help" "$r_tool_help"
 
 echo "[9/36] masc_goal_upsert"
-GOAL_SEED_PAYLOAD="$(call_tool 5014 "masc_goal_upsert" "$(jq -cn --arg verifier "$AGENT_NAME" '{title:"Public Tool Sweep Goal",priority:1,verifier_policy:{inherit_mode:"replace",principals:[{id:$verifier}],required_verdicts:1}}')")"
+GOAL_SEED_PAYLOAD="$(call_tool 5014 "masc_goal_upsert" "$(jq -cn --arg verifier "${AGENT_NAME}-verifier" '{title:"Public Tool Sweep Goal",priority:1,verifier_policy:{inherit_mode:"replace",principals:[{id:$verifier}],required_verdicts:1}}')")"
 GOAL_ID="$(printf '%s' "$GOAL_SEED_PAYLOAD" | extract_result | jq -r '.goal_id // empty')"
 if [ -z "$GOAL_ID" ]; then
   mcp_fail_with_context "could not create goal for public tool live sweep" "$GOAL_SEED_PAYLOAD"
@@ -250,7 +250,7 @@ r_goal_transition="$(call_tool 5038 "masc_goal_transition" "$(jq -cn --arg goal_
 expect_ok "masc_goal_transition" "$r_goal_transition"
 
 echo "[35/36] masc_goal_verify"
-r_goal_verify="$(call_tool 5039 "masc_goal_verify" "$(jq -cn --arg goal_id "$GOAL_ID" --arg principal "$AGENT_NAME" '{goal_id:$goal_id,principal:{id:$principal},decision:"approve",note:"public sweep verifier guard"}')")"
+r_goal_verify="$(call_tool 5039 "masc_goal_verify" "$(jq -cn --arg goal_id "$GOAL_ID" --arg principal "${AGENT_NAME}-verifier" '{goal_id:$goal_id,principal:{id:$principal},decision:"approve",note:"public sweep verifier approval"}')")"
 expect_ok "masc_goal_verify" "$r_goal_verify"
 
 echo "[36/36] masc_transition (done)"

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 : "${MCP_URL:=http://127.0.0.1:8935/mcp}"
 : "${BASE_PATH:?BASE_PATH must be set by run_all.sh}"
-: "${AGENT_NAME:=public-tool-sweep-harness}"
+: "${AGENT_NAME:=admin}"
 : "${MCP_SESSION_ID:=}"
 export MCP_SESSION_ID
 
@@ -44,6 +44,26 @@ expect_ok() {
   mcp_fail_with_context "${label}: expected success" "$(response_text_or_error "$payload")"
 }
 
+expect_ok_or_guard() {
+  local label="$1"
+  local payload="$2"
+  local guard_regex="$3"
+  if response_tool_ok "$payload"; then
+    echo "  PASS: ${label}"
+    return 0
+  fi
+  if response_transport_ok "$payload"; then
+    local text
+    text="$(response_text_or_error "$payload")"
+    if [[ -n "$text" ]] && printf '%s' "$text" | grep -Eiq "$guard_regex"; then
+      echo "  PASS: ${label} (guard)"
+      return 0
+    fi
+    mcp_fail_with_context "${label}: expected success or guard /${guard_regex}/" "$text"
+  fi
+  mcp_fail_with_context "${label}: transport/jsonrpc failure" "$payload"
+}
+
 call_method() {
   local id="$1"
   local method="$2"
@@ -53,52 +73,13 @@ call_method() {
   jsonrpc_normalize_response "$raw" "$id"
 }
 
-CLEANUP_TASK_IDS=()
-CLEANUP_TASK_FINALIZED_IDS=()
-
-remember_cleanup_task_id() {
-  local new_task_id="$1"
-  local existing_task_id
-  for existing_task_id in "${CLEANUP_TASK_IDS[@]}"; do
-    if [[ "$existing_task_id" == "$new_task_id" ]]; then
-      return 0
-    fi
-  done
-  CLEANUP_TASK_IDS+=("$new_task_id")
-}
-
-cleanup_task_is_finalized() {
-  local task_id_to_check="$1"
-  local finalized_task_id
-  for finalized_task_id in "${CLEANUP_TASK_FINALIZED_IDS[@]}"; do
-    if [[ "$finalized_task_id" == "$task_id_to_check" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
-mark_cleanup_task_finalized() {
-  local finalized_task_id="$1"
-  remember_cleanup_task_id "$finalized_task_id"
-  if cleanup_task_is_finalized "$finalized_task_id"; then
-    return 0
-  fi
-  CLEANUP_TASK_FINALIZED_IDS+=("$finalized_task_id")
-}
-
+CLEANUP_TASK_FINALIZED=0
 # shellcheck disable=SC2329 # invoked by EXIT trap
 cleanup_contract_task() {
   local exit_status=$?
-  local cleanup_call_id=5999
-  local cleanup_task_id
-  for cleanup_task_id in "${CLEANUP_TASK_IDS[@]}"; do
-    if cleanup_task_is_finalized "$cleanup_task_id"; then
-      continue
-    fi
-    call_tool "$cleanup_call_id" "masc_transition" "$(jq -cn --arg task_id "$cleanup_task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"cancel",notes:"public tool sweep cleanup after unsuccessful run"}')" >/dev/null 2>&1 || true
-    cleanup_call_id=$((cleanup_call_id + 1))
-  done
+  if [ "$CLEANUP_TASK_FINALIZED" -ne 1 ] && [ -n "${task_id:-}" ]; then
+    call_tool 5999 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"cancel",notes:"public tool sweep cleanup after unsuccessful run"}')" >/dev/null 2>&1 || true
+  fi
   exit "$exit_status"
 }
 trap 'cleanup_contract_task' EXIT
@@ -110,7 +91,7 @@ manifest_json="$(
 )"
 expected_public_tools="$(printf '%s\n' "$manifest_json" | jq -c '.public_tool_names | sort')"
 
-echo "[1/36] initialize MCP session"
+echo "[1/31] initialize MCP session"
 initialize_mcp_session || {
   echo "FAIL: failed to initialize MCP session" >&2
   exit 1
@@ -120,7 +101,7 @@ if [[ -z "${MCP_SESSION_ID:-}" ]]; then
   exit 1
 fi
 
-echo "[2/36] tools/list matches expected public surface"
+echo "[2/31] tools/list matches expected public surface"
 tools_list_payload="$(call_method 5001 "tools/list" '{}')"
 if ! response_transport_ok "$tools_list_payload"; then
   mcp_fail_with_context "tools/list failed" "$tools_list_payload"
@@ -132,44 +113,44 @@ if [[ "$actual_public_tools" != "$expected_public_tools" ]]; then
 fi
 echo "  PASS: tools/list public surface"
 
-echo "[3/36] masc_start"
+echo "[3/31] masc_start"
 r_start="$(call_tool 5003 "masc_start" "$(jq -cn --arg path "$BASE_PATH" '{path:$path}')")"
 expect_ok "masc_start" "$r_start"
 
-echo "[4/36] masc_status"
+echo "[4/31] masc_status"
 r_status="$(call_tool 5005 "masc_status" '{}')"
 expect_ok "masc_status" "$r_status"
 
-echo "[5/36] masc_dashboard"
+echo "[5/31] masc_dashboard"
 r_dashboard="$(call_tool 5008 "masc_dashboard" '{}')"
 expect_ok "masc_dashboard" "$r_dashboard"
 
-echo "[6/36] masc_agent_card"
+echo "[6/31] masc_agent_card"
 r_agent_card="$(call_tool 5009 "masc_agent_card" '{}')"
 expect_ok "masc_agent_card" "$r_agent_card"
 
-echo "[7/36] masc_agent_timeline"
-r_agent_timeline="$(call_tool 5010 "masc_agent_timeline" "$(jq -cn --arg agent_name "$AGENT_NAME" '{agent_name:$agent_name,limit:5}')")"
-expect_ok "masc_agent_timeline" "$r_agent_timeline"
-
-echo "[8/36] masc_tool_help"
+echo "[7/31] masc_tool_help"
 r_tool_help="$(call_tool 5012 "masc_tool_help" '{"tool_name":"masc_status"}')"
 expect_ok "masc_tool_help" "$r_tool_help"
 
-echo "[9/36] masc_goal_upsert"
-GOAL_SEED_PAYLOAD="$(call_tool 5014 "masc_goal_upsert" "$(jq -cn --arg verifier "${AGENT_NAME}-verifier" '{title:"Public Tool Sweep Goal",priority:1,verifier_policy:{inherit_mode:"replace",principals:[{id:$verifier}],required_verdicts:1}}')")"
+echo "[8/31] masc_check"
+r_check="$(call_tool 5013 "masc_check" '{"assertions":["joined"]}')"
+expect_ok "masc_check" "$r_check"
+
+echo "[9/31] masc_goal_list"
+r_goal_list="$(call_tool 5014 "masc_goal_list" '{}')"
+expect_ok "masc_goal_list" "$r_goal_list"
+
+echo "[10/31] masc_goal_upsert"
+GOAL_SEED_PAYLOAD="$(call_tool 5015 "masc_goal_upsert" '{"title":"Public Tool Sweep Goal","priority":1}')"
 GOAL_ID="$(printf '%s' "$GOAL_SEED_PAYLOAD" | extract_result | jq -r '.goal_id // empty')"
 if [ -z "$GOAL_ID" ]; then
   mcp_fail_with_context "could not create goal for public tool live sweep" "$GOAL_SEED_PAYLOAD"
 fi
 echo "  PASS: masc_goal_upsert"
 
-echo "[10/36] masc_goal_list"
-r_goal_list="$(call_tool 5013 "masc_goal_list" '{}')"
-expect_ok "masc_goal_list" "$r_goal_list"
-
-echo "[11/36] masc_add_task"
-r_add_task="$(call_tool 5015 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" '{title:"Public Tool Sweep Task",goal_id:$goal_id,priority:2,description:"live public surface verification"}')")"
+echo "[11/31] masc_add_task"
+r_add_task="$(call_tool 5016 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" '{title:"Public Tool Sweep Task",goal_id:$goal_id,priority:2,description:"live public surface verification"}')")"
 expect_ok "masc_add_task" "$r_add_task"
 task_id="$(
   printf '%s' "$r_add_task" \
@@ -179,71 +160,52 @@ task_id="$(
 if [[ -z "$task_id" ]]; then
   mcp_fail_with_context "masc_add_task: could not extract task_id" "$r_add_task"
 fi
-remember_cleanup_task_id "$task_id"
 
-echo "[12/36] masc_batch_add_tasks"
-r_batch_add="$(call_tool 5016 "masc_batch_add_tasks" "$(jq -cn --arg goal_id "$GOAL_ID" '{tasks:[{title:"Public Sweep Batch A",goal_id:$goal_id,priority:3,description:"batch-a"},{title:"Public Sweep Batch B",goal_id:$goal_id,priority:4,description:"batch-b"}]}')")"
+echo "[12/31] masc_batch_add_tasks"
+r_batch_add="$(call_tool 5017 "masc_batch_add_tasks" "$(jq -cn --arg goal_id "$GOAL_ID" '{tasks:[{title:"Public Sweep Batch A",goal_id:$goal_id,priority:3,description:"batch-a"},{title:"Public Sweep Batch B",goal_id:$goal_id,priority:4,description:"batch-b"}]}')")"
 expect_ok "masc_batch_add_tasks" "$r_batch_add"
-batch_task_ids=()
-while IFS= read -r batch_task_id; do
-  if [[ -z "$batch_task_id" ]]; then
-    continue
-  fi
-  batch_task_ids+=("$batch_task_id")
-  remember_cleanup_task_id "$batch_task_id"
-done < <(
-  printf '%s' "$r_batch_add" \
-    | jq -r 'try (.result.structuredContent.task_ids[]?) catch empty | strings'
-)
-if [[ "${#batch_task_ids[@]}" -ne 2 ]]; then
-  mcp_fail_with_context "masc_batch_add_tasks: expected two structured task_ids" "$r_batch_add"
-fi
 
-echo "[13/36] masc_tasks"
-r_tasks="$(call_tool 5017 "masc_tasks" '{}')"
+echo "[13/31] masc_tasks"
+r_tasks="$(call_tool 5018 "masc_tasks" '{}')"
 expect_ok "masc_tasks" "$r_tasks"
 
-echo "[14/36] masc_plan_init"
-r_plan_init="$(call_tool 5018 "masc_plan_init" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
+echo "[14/31] masc_transition claim"
+r_claim="$(call_tool 5019 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"claim",notes:"public tool sweep claim"}')")"
+expect_ok_or_guard "masc_transition claim" "$r_claim" 'already claimed'
+
+echo "[15/31] masc_plan_init"
+r_plan_init="$(call_tool 5020 "masc_plan_init" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
 expect_ok "masc_plan_init" "$r_plan_init"
 
-echo "[15/36] masc_plan_set_task"
-r_plan_set="$(call_tool 5019 "masc_plan_set_task" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
+echo "[16/31] masc_plan_set_task"
+r_plan_set="$(call_tool 5021 "masc_plan_set_task" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
 expect_ok "masc_plan_set_task" "$r_plan_set"
 
-echo "[16/36] masc_plan_update"
-r_plan_update="$(call_tool 5020 "masc_plan_update" "$(jq -cn --arg task_id "$task_id" --arg content "public tool sweep plan" '{task_id:$task_id,content:$content}')")"
+echo "[17/31] masc_plan_update"
+r_plan_update="$(call_tool 5022 "masc_plan_update" "$(jq -cn --arg task_id "$task_id" --arg content "public tool sweep plan" '{task_id:$task_id,content:$content}')")"
 expect_ok "masc_plan_update" "$r_plan_update"
 
-echo "[17/36] masc_plan_get"
-r_plan_get="$(call_tool 5021 "masc_plan_get" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
+echo "[18/31] masc_plan_get"
+r_plan_get="$(call_tool 5023 "masc_plan_get" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
 expect_ok "masc_plan_get" "$r_plan_get"
 
-echo "[18/36] masc_transition (claim)"
-r_claim="$(call_tool 5022 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"claim",notes:"public tool sweep claim"}')")"
-expect_ok "masc_transition claim" "$r_claim"
+echo "[19/31] masc_transition start"
+r_transition="$(call_tool 5024 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"start",notes:"public tool sweep start"}')")"
+expect_ok "masc_transition" "$r_transition"
 
-echo "[19/36] masc_transition (start)"
-r_transition="$(call_tool 5023 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"start",notes:"public tool sweep start"}')")"
-expect_ok "masc_transition start" "$r_transition"
-
-echo "[20/36] masc_check"
-r_check="$(call_tool 5024 "masc_check" '{"assertions":["task_claimed","current_task_set"]}')"
-expect_ok "masc_check" "$r_check"
-
-echo "[21/36] masc_heartbeat"
+echo "[20/31] masc_heartbeat"
 r_heartbeat="$(call_tool 5025 "masc_heartbeat" '{}')"
 expect_ok "masc_heartbeat" "$r_heartbeat"
 
-echo "[22/36] masc_broadcast"
+echo "[21/31] masc_broadcast"
 r_broadcast="$(call_tool 5026 "masc_broadcast" "$(jq -cn --arg agent_name "$AGENT_NAME" --arg message "public tool sweep broadcast" '{agent_name:$agent_name,message:$message}')")"
 expect_ok "masc_broadcast" "$r_broadcast"
 
-echo "[23/36] masc_messages"
+echo "[22/31] masc_messages"
 r_messages="$(call_tool 5027 "masc_messages" '{}')"
 expect_ok "masc_messages" "$r_messages"
 
-echo "[24/36] masc_board_post"
+echo "[23/31] masc_board_post"
 r_board_post="$(call_tool 5028 "masc_board_post" "$(jq -cn --arg author "$AGENT_NAME" --arg title "Public Tool Sweep Post" --arg content "public tool sweep board post" '{author:$author,title:$title,content:$content,visibility:"internal"}')")"
 expect_ok "masc_board_post" "$r_board_post"
 post_id="$(
@@ -255,70 +217,49 @@ if [[ -z "$post_id" ]]; then
   mcp_fail_with_context "masc_board_post: could not extract post_id" "$r_board_post"
 fi
 
-echo "[25/36] masc_board_list"
+echo "[24/31] masc_board_list"
 r_board_list="$(call_tool 5029 "masc_board_list" '{"limit":5}')"
 expect_ok "masc_board_list" "$r_board_list"
 
-echo "[26/36] masc_board_post_get"
+echo "[25/31] masc_board_post_get"
 r_board_get="$(call_tool 5030 "masc_board_post_get" "$(jq -cn --arg post_id "$post_id" '{post_id:$post_id}')")"
 expect_ok "masc_board_post_get" "$r_board_get"
 
-echo "[27/36] masc_board_comment"
+echo "[26/31] masc_board_comment"
 r_board_comment="$(call_tool 5031 "masc_board_comment" "$(jq -cn --arg post_id "$post_id" --arg author "$AGENT_NAME" --arg content "public tool sweep comment" '{post_id:$post_id,author:$author,content:$content}')")"
 expect_ok "masc_board_comment" "$r_board_comment"
 comment_id="$(
   printf '%s' "$r_board_comment" \
-    | jq -r 'try (.result.structuredContent.comment_id // .result.structuredContent.id) catch empty | strings' \
+    | jq -r 'try (.result.structuredContent.comment_id // .result.structuredContent.id // .result.structuredContent.comment.id) catch empty | strings' \
     | head -n1
 )"
 if [[ -z "$comment_id" ]]; then
   mcp_fail_with_context "masc_board_comment: could not extract comment_id" "$r_board_comment"
 fi
 
-echo "[28/36] masc_board_vote"
-r_board_vote="$(call_tool 5032 "masc_board_vote" "$(jq -cn --arg post_id "$post_id" --arg voter "$AGENT_NAME" '{post_id:$post_id,voter:$voter,direction:"up"}')")"
+echo "[27/31] masc_board_vote"
+r_board_vote="$(call_tool 5032 "masc_board_vote" "$(jq -cn --arg post_id "$post_id" --arg voter "$AGENT_NAME" '{post_id:$post_id,voter:$voter}')")"
 expect_ok "masc_board_vote" "$r_board_vote"
 
-echo "[29/36] masc_board_comment_vote"
-r_comment_vote="$(call_tool 5033 "masc_board_comment_vote" "$(jq -cn --arg comment_id "$comment_id" --arg voter "$AGENT_NAME" '{comment_id:$comment_id,voter:$voter,direction:"up"}')")"
-expect_ok "masc_board_comment_vote" "$r_comment_vote"
+echo "[28/31] masc_board_comment_vote"
+if [[ -n "$comment_id" ]]; then
+  r_comment_vote="$(call_tool 5033 "masc_board_comment_vote" "$(jq -cn --arg comment_id "$comment_id" --arg voter "$AGENT_NAME" '{comment_id:$comment_id,voter:$voter,direction:"up"}')")"
+  expect_ok "masc_board_comment_vote" "$r_comment_vote"
+else
+  echo "  PASS: masc_board_comment_vote (skipped: comment id not present in comment response)"
+fi
 
-echo "[30/36] masc_board_reaction"
-r_reaction="$(call_tool 5034 "masc_board_reaction" "$(jq -cn --arg target_id "$post_id" --arg user_id "$AGENT_NAME" '{target_type:"post",target_id:$target_id,user_id:$user_id,emoji:"\uD83D\uDC4D"}')")"
+echo "[29/31] masc_board_reaction"
+r_reaction="$(call_tool 5034 "masc_board_reaction" "$(jq -cn --arg post_id "$post_id" --arg user_id "$AGENT_NAME" '{target_type:"post",target_id:$post_id,user_id:$user_id,emoji:"👍"}')")"
 expect_ok "masc_board_reaction" "$r_reaction"
 
-echo "[31/36] masc_board_curation_read"
-r_curation_read="$(call_tool 5035 "masc_board_curation_read" '{}')"
-expect_ok "masc_board_curation_read" "$r_curation_read"
-
-echo "[32/36] masc_board_curation_submit"
-r_curation_submit="$(call_tool 5036 "masc_board_curation_submit" "$(jq -cn --arg submitted_by "$AGENT_NAME" --arg post_id "$post_id" '{submitted_by:$submitted_by,summary:"public sweep curation",ordering:[$post_id],highlights:[$post_id],health_score:1.0,rationale:"public tool sweep curation"}')")"
-expect_ok "masc_board_curation_submit" "$r_curation_submit"
-
-echo "[33/36] masc_persona_list"
-r_persona_list="$(call_tool 5037 "masc_persona_list" '{"detailed":false}')"
+echo "[30/31] masc_persona_list"
+r_persona_list="$(call_tool 5035 "masc_persona_list" '{}')"
 expect_ok "masc_persona_list" "$r_persona_list"
 
-echo "[34/36] masc_transition (finish linked tasks)"
-finish_call_id=5038
-for batch_task_id in "${batch_task_ids[@]}"; do
-  r_cancel_batch="$(call_tool "$finish_call_id" "masc_transition" "$(jq -cn --arg task_id "$batch_task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"cancel",notes:"public tool sweep batch cleanup before goal completion"}')")"
-  expect_ok "masc_transition cancel ${batch_task_id}" "$r_cancel_batch"
-  mark_cleanup_task_finalized "$batch_task_id"
-  finish_call_id=$((finish_call_id + 1))
-done
-r_done="$(call_tool "$finish_call_id" "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"done",notes:"public tool sweep done"}')")"
-expect_ok "masc_transition done" "$r_done"
-mark_cleanup_task_finalized "$task_id"
-finish_call_id=$((finish_call_id + 1))
-
-echo "[35/36] masc_goal_transition"
-r_goal_transition="$(call_tool "$finish_call_id" "masc_goal_transition" "$(jq -cn --arg goal_id "$GOAL_ID" --arg actor "$AGENT_NAME" '{goal_id:$goal_id,action:"request_complete",actor:{id:$actor},note:"public sweep verification request"}')")"
-expect_ok "masc_goal_transition" "$r_goal_transition"
-finish_call_id=$((finish_call_id + 1))
-
-echo "[36/36] masc_goal_verify"
-r_goal_verify="$(call_tool "$finish_call_id" "masc_goal_verify" "$(jq -cn --arg goal_id "$GOAL_ID" --arg principal "${AGENT_NAME}-verifier" '{goal_id:$goal_id,principal:{id:$principal},decision:"approve",note:"public sweep verifier approval"}')")"
-expect_ok "masc_goal_verify" "$r_goal_verify"
+echo "[31/31] masc_agent_timeline"
+r_agent_timeline="$(call_tool 5036 "masc_agent_timeline" "$(jq -cn --arg agent_name "$AGENT_NAME" '{agent_name:$agent_name,limit:5}')")"
+expect_ok "masc_agent_timeline" "$r_agent_timeline"
+CLEANUP_TASK_FINALIZED=1
 
 echo "PASS: public MCP tool live sweep"

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 : "${MCP_URL:=http://127.0.0.1:8935/mcp}"
 : "${BASE_PATH:?BASE_PATH must be set by run_all.sh}"
-: "${AGENT_NAME:=admin}"
+: "${AGENT_NAME:=public-tool-sweep-harness}"
 : "${MCP_SESSION_ID:=}"
 export MCP_SESSION_ID
 
@@ -44,26 +44,6 @@ expect_ok() {
   mcp_fail_with_context "${label}: expected success" "$(response_text_or_error "$payload")"
 }
 
-expect_ok_or_guard() {
-  local label="$1"
-  local payload="$2"
-  local guard_regex="$3"
-  if response_tool_ok "$payload"; then
-    echo "  PASS: ${label}"
-    return 0
-  fi
-  if response_transport_ok "$payload"; then
-    local text
-    text="$(response_text_or_error "$payload")"
-    if [[ -n "$text" ]] && printf '%s' "$text" | grep -Eiq "$guard_regex"; then
-      echo "  PASS: ${label} (guard)"
-      return 0
-    fi
-    mcp_fail_with_context "${label}: expected success or guard /${guard_regex}/" "$text"
-  fi
-  mcp_fail_with_context "${label}: transport/jsonrpc failure" "$payload"
-}
-
 call_method() {
   local id="$1"
   local method="$2"
@@ -73,6 +53,17 @@ call_method() {
   jsonrpc_normalize_response "$raw" "$id"
 }
 
+CLEANUP_TASK_FINALIZED=0
+# shellcheck disable=SC2329 # invoked by EXIT trap
+cleanup_contract_task() {
+  local exit_status=$?
+  if [ "$CLEANUP_TASK_FINALIZED" -ne 1 ] && [ -n "${task_id:-}" ]; then
+    call_tool 5999 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"cancel",notes:"public tool sweep cleanup after unsuccessful run"}')" >/dev/null 2>&1 || true
+  fi
+  exit "$exit_status"
+}
+trap 'cleanup_contract_task' EXIT
+
 manifest_json="$(
   env -u DUNE_RPC MASC_STORAGE_TYPE=filesystem \
     opam exec -- dune exec --root "$ROOT_DIR" bin/public_tool_manifest.exe \
@@ -80,7 +71,7 @@ manifest_json="$(
 )"
 expected_public_tools="$(printf '%s\n' "$manifest_json" | jq -c '.public_tool_names | sort')"
 
-echo "[1/31] initialize MCP session"
+echo "[1/36] initialize MCP session"
 initialize_mcp_session || {
   echo "FAIL: failed to initialize MCP session" >&2
   exit 1
@@ -90,7 +81,7 @@ if [[ -z "${MCP_SESSION_ID:-}" ]]; then
   exit 1
 fi
 
-echo "[2/31] tools/list matches expected public surface"
+echo "[2/36] tools/list matches expected public surface"
 tools_list_payload="$(call_method 5001 "tools/list" '{}')"
 if ! response_transport_ok "$tools_list_payload"; then
   mcp_fail_with_context "tools/list failed" "$tools_list_payload"
@@ -102,44 +93,44 @@ if [[ "$actual_public_tools" != "$expected_public_tools" ]]; then
 fi
 echo "  PASS: tools/list public surface"
 
-echo "[3/31] masc_start"
+echo "[3/36] masc_start"
 r_start="$(call_tool 5003 "masc_start" "$(jq -cn --arg path "$BASE_PATH" '{path:$path}')")"
 expect_ok "masc_start" "$r_start"
 
-echo "[4/31] masc_status"
+echo "[4/36] masc_status"
 r_status="$(call_tool 5005 "masc_status" '{}')"
 expect_ok "masc_status" "$r_status"
 
-echo "[5/31] masc_dashboard"
+echo "[5/36] masc_dashboard"
 r_dashboard="$(call_tool 5008 "masc_dashboard" '{}')"
 expect_ok "masc_dashboard" "$r_dashboard"
 
-echo "[6/31] masc_agent_card"
+echo "[6/36] masc_agent_card"
 r_agent_card="$(call_tool 5009 "masc_agent_card" '{}')"
 expect_ok "masc_agent_card" "$r_agent_card"
 
-echo "[7/31] masc_tool_help"
+echo "[7/36] masc_agent_timeline"
+r_agent_timeline="$(call_tool 5010 "masc_agent_timeline" "$(jq -cn --arg agent_name "$AGENT_NAME" '{agent_name:$agent_name,limit:5}')")"
+expect_ok "masc_agent_timeline" "$r_agent_timeline"
+
+echo "[8/36] masc_tool_help"
 r_tool_help="$(call_tool 5012 "masc_tool_help" '{"tool_name":"masc_status"}')"
 expect_ok "masc_tool_help" "$r_tool_help"
 
-echo "[8/31] masc_check"
-r_check="$(call_tool 5013 "masc_check" '{"assertions":["joined"]}')"
-expect_ok "masc_check" "$r_check"
-
-echo "[9/31] masc_goal_list"
-r_goal_list="$(call_tool 5014 "masc_goal_list" '{}')"
-expect_ok "masc_goal_list" "$r_goal_list"
-
-echo "[10/31] masc_goal_upsert"
-GOAL_SEED_PAYLOAD="$(call_tool 5015 "masc_goal_upsert" '{"title":"Public Tool Sweep Goal","priority":1}')"
+echo "[9/36] masc_goal_upsert"
+GOAL_SEED_PAYLOAD="$(call_tool 5014 "masc_goal_upsert" "$(jq -cn --arg verifier "$AGENT_NAME" '{title:"Public Tool Sweep Goal",priority:1,verifier_policy:{inherit_mode:"replace",principals:[{id:$verifier}],required_verdicts:1}}')")"
 GOAL_ID="$(printf '%s' "$GOAL_SEED_PAYLOAD" | extract_result | jq -r '.goal_id // empty')"
 if [ -z "$GOAL_ID" ]; then
   mcp_fail_with_context "could not create goal for public tool live sweep" "$GOAL_SEED_PAYLOAD"
 fi
 echo "  PASS: masc_goal_upsert"
 
-echo "[11/31] masc_add_task"
-r_add_task="$(call_tool 5016 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" '{title:"Public Tool Sweep Task",goal_id:$goal_id,priority:2,description:"live public surface verification"}')")"
+echo "[10/36] masc_goal_list"
+r_goal_list="$(call_tool 5013 "masc_goal_list" '{}')"
+expect_ok "masc_goal_list" "$r_goal_list"
+
+echo "[11/36] masc_add_task"
+r_add_task="$(call_tool 5014 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" '{title:"Public Tool Sweep Task",goal_id:$goal_id,priority:2,description:"live public surface verification"}')")"
 expect_ok "masc_add_task" "$r_add_task"
 task_id="$(
   printf '%s' "$r_add_task" \
@@ -150,51 +141,55 @@ if [[ -z "$task_id" ]]; then
   mcp_fail_with_context "masc_add_task: could not extract task_id" "$r_add_task"
 fi
 
-echo "[12/31] masc_batch_add_tasks"
-r_batch_add="$(call_tool 5017 "masc_batch_add_tasks" "$(jq -cn --arg goal_id "$GOAL_ID" '{tasks:[{title:"Public Sweep Batch A",goal_id:$goal_id,priority:3,description:"batch-a"},{title:"Public Sweep Batch B",goal_id:$goal_id,priority:4,description:"batch-b"}]}')")"
+echo "[12/36] masc_batch_add_tasks"
+r_batch_add="$(call_tool 5015 "masc_batch_add_tasks" "$(jq -cn --arg goal_id "$GOAL_ID" '{tasks:[{title:"Public Sweep Batch A",goal_id:$goal_id,priority:3,description:"batch-a"},{title:"Public Sweep Batch B",goal_id:$goal_id,priority:4,description:"batch-b"}]}')")"
 expect_ok "masc_batch_add_tasks" "$r_batch_add"
 
-echo "[13/31] masc_tasks"
-r_tasks="$(call_tool 5018 "masc_tasks" '{}')"
+echo "[13/36] masc_tasks"
+r_tasks="$(call_tool 5016 "masc_tasks" '{}')"
 expect_ok "masc_tasks" "$r_tasks"
 
-echo "[14/31] masc_transition claim"
-r_claim="$(call_tool 5019 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"claim",notes:"public tool sweep claim"}')")"
-expect_ok_or_guard "masc_transition claim" "$r_claim" 'already claimed'
-
-echo "[15/31] masc_plan_init"
-r_plan_init="$(call_tool 5020 "masc_plan_init" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
+echo "[14/36] masc_plan_init"
+r_plan_init="$(call_tool 5018 "masc_plan_init" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
 expect_ok "masc_plan_init" "$r_plan_init"
 
-echo "[16/31] masc_plan_set_task"
-r_plan_set="$(call_tool 5021 "masc_plan_set_task" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
+echo "[15/36] masc_plan_set_task"
+r_plan_set="$(call_tool 5019 "masc_plan_set_task" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
 expect_ok "masc_plan_set_task" "$r_plan_set"
 
-echo "[17/31] masc_plan_update"
-r_plan_update="$(call_tool 5022 "masc_plan_update" "$(jq -cn --arg task_id "$task_id" --arg content "public tool sweep plan" '{task_id:$task_id,content:$content}')")"
+echo "[16/36] masc_plan_update"
+r_plan_update="$(call_tool 5020 "masc_plan_update" "$(jq -cn --arg task_id "$task_id" --arg content "public tool sweep plan" '{task_id:$task_id,content:$content}')")"
 expect_ok "masc_plan_update" "$r_plan_update"
 
-echo "[18/31] masc_plan_get"
-r_plan_get="$(call_tool 5023 "masc_plan_get" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
+echo "[17/36] masc_plan_get"
+r_plan_get="$(call_tool 5021 "masc_plan_get" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
 expect_ok "masc_plan_get" "$r_plan_get"
 
-echo "[19/31] masc_transition start"
-r_transition="$(call_tool 5024 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"start",notes:"public tool sweep start"}')")"
-expect_ok "masc_transition" "$r_transition"
+echo "[18/36] masc_transition (claim)"
+r_claim="$(call_tool 5022 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"claim",notes:"public tool sweep claim"}')")"
+expect_ok "masc_transition claim" "$r_claim"
 
-echo "[20/31] masc_heartbeat"
+echo "[19/36] masc_transition (start)"
+r_transition="$(call_tool 5023 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"start",notes:"public tool sweep start"}')")"
+expect_ok "masc_transition start" "$r_transition"
+
+echo "[20/36] masc_check"
+r_check="$(call_tool 5024 "masc_check" '{"assertions":["task_claimed","current_task_set"]}')"
+expect_ok "masc_check" "$r_check"
+
+echo "[21/36] masc_heartbeat"
 r_heartbeat="$(call_tool 5025 "masc_heartbeat" '{}')"
 expect_ok "masc_heartbeat" "$r_heartbeat"
 
-echo "[21/31] masc_broadcast"
+echo "[22/36] masc_broadcast"
 r_broadcast="$(call_tool 5026 "masc_broadcast" "$(jq -cn --arg agent_name "$AGENT_NAME" --arg message "public tool sweep broadcast" '{agent_name:$agent_name,message:$message}')")"
 expect_ok "masc_broadcast" "$r_broadcast"
 
-echo "[22/31] masc_messages"
+echo "[23/36] masc_messages"
 r_messages="$(call_tool 5027 "masc_messages" '{}')"
 expect_ok "masc_messages" "$r_messages"
 
-echo "[23/31] masc_board_post"
+echo "[24/36] masc_board_post"
 r_board_post="$(call_tool 5028 "masc_board_post" "$(jq -cn --arg author "$AGENT_NAME" --arg title "Public Tool Sweep Post" --arg content "public tool sweep board post" '{author:$author,title:$title,content:$content,visibility:"internal"}')")"
 expect_ok "masc_board_post" "$r_board_post"
 post_id="$(
@@ -206,48 +201,61 @@ if [[ -z "$post_id" ]]; then
   mcp_fail_with_context "masc_board_post: could not extract post_id" "$r_board_post"
 fi
 
-echo "[24/31] masc_board_list"
+echo "[25/36] masc_board_list"
 r_board_list="$(call_tool 5029 "masc_board_list" '{"limit":5}')"
 expect_ok "masc_board_list" "$r_board_list"
 
-echo "[25/31] masc_board_post_get"
+echo "[26/36] masc_board_post_get"
 r_board_get="$(call_tool 5030 "masc_board_post_get" "$(jq -cn --arg post_id "$post_id" '{post_id:$post_id}')")"
 expect_ok "masc_board_post_get" "$r_board_get"
 
-echo "[26/31] masc_board_comment"
+echo "[27/36] masc_board_comment"
 r_board_comment="$(call_tool 5031 "masc_board_comment" "$(jq -cn --arg post_id "$post_id" --arg author "$AGENT_NAME" --arg content "public tool sweep comment" '{post_id:$post_id,author:$author,content:$content}')")"
 expect_ok "masc_board_comment" "$r_board_comment"
 comment_id="$(
   printf '%s' "$r_board_comment" \
-    | jq -r 'try (.result.structuredContent.comment_id // .result.structuredContent.id // .result.structuredContent.comment.id) catch empty | strings' \
+    | jq -r 'try (.result.structuredContent.comment_id // .result.structuredContent.id) catch empty | strings' \
     | head -n1
 )"
 if [[ -z "$comment_id" ]]; then
   mcp_fail_with_context "masc_board_comment: could not extract comment_id" "$r_board_comment"
 fi
 
-echo "[27/31] masc_board_vote"
-r_board_vote="$(call_tool 5032 "masc_board_vote" "$(jq -cn --arg post_id "$post_id" --arg voter "$AGENT_NAME" '{post_id:$post_id,voter:$voter}')")"
+echo "[28/36] masc_board_vote"
+r_board_vote="$(call_tool 5032 "masc_board_vote" "$(jq -cn --arg post_id "$post_id" --arg voter "$AGENT_NAME" '{post_id:$post_id,voter:$voter,direction:"up"}')")"
 expect_ok "masc_board_vote" "$r_board_vote"
 
-echo "[28/31] masc_board_comment_vote"
-if [[ -n "$comment_id" ]]; then
-  r_comment_vote="$(call_tool 5033 "masc_board_comment_vote" "$(jq -cn --arg comment_id "$comment_id" --arg voter "$AGENT_NAME" '{comment_id:$comment_id,voter:$voter,direction:"up"}')")"
-  expect_ok "masc_board_comment_vote" "$r_comment_vote"
-else
-  echo "  PASS: masc_board_comment_vote (skipped: comment id not present in comment response)"
-fi
+echo "[29/36] masc_board_comment_vote"
+r_comment_vote="$(call_tool 5033 "masc_board_comment_vote" "$(jq -cn --arg comment_id "$comment_id" --arg voter "$AGENT_NAME" '{comment_id:$comment_id,voter:$voter,direction:"up"}')")"
+expect_ok "masc_board_comment_vote" "$r_comment_vote"
 
-echo "[29/31] masc_board_reaction"
-r_reaction="$(call_tool 5034 "masc_board_reaction" "$(jq -cn --arg post_id "$post_id" --arg user_id "$AGENT_NAME" '{target_type:"post",target_id:$post_id,user_id:$user_id,emoji:"👍"}')")"
+echo "[30/36] masc_board_reaction"
+r_reaction="$(call_tool 5034 "masc_board_reaction" "$(jq -cn --arg target_id "$post_id" --arg user_id "$AGENT_NAME" '{target_type:"post",target_id:$target_id,user_id:$user_id,emoji:"\uD83D\uDC4D"}')")"
 expect_ok "masc_board_reaction" "$r_reaction"
 
-echo "[30/31] masc_persona_list"
-r_persona_list="$(call_tool 5035 "masc_persona_list" '{}')"
+echo "[31/36] masc_board_curation_read"
+r_curation_read="$(call_tool 5035 "masc_board_curation_read" '{}')"
+expect_ok "masc_board_curation_read" "$r_curation_read"
+
+echo "[32/36] masc_board_curation_submit"
+r_curation_submit="$(call_tool 5036 "masc_board_curation_submit" "$(jq -cn --arg submitted_by "$AGENT_NAME" --arg post_id "$post_id" '{submitted_by:$submitted_by,summary:"public sweep curation",ordering:[$post_id],highlights:[$post_id],health_score:1.0,rationale:"public tool sweep curation"}')")"
+expect_ok "masc_board_curation_submit" "$r_curation_submit"
+
+echo "[33/36] masc_persona_list"
+r_persona_list="$(call_tool 5037 "masc_persona_list" '{"detailed":false}')"
 expect_ok "masc_persona_list" "$r_persona_list"
 
-echo "[31/31] masc_agent_timeline"
-r_agent_timeline="$(call_tool 5036 "masc_agent_timeline" "$(jq -cn --arg agent_name "$AGENT_NAME" '{agent_name:$agent_name,limit:5}')")"
-expect_ok "masc_agent_timeline" "$r_agent_timeline"
+echo "[34/36] masc_goal_transition"
+r_goal_transition="$(call_tool 5038 "masc_goal_transition" "$(jq -cn --arg goal_id "$GOAL_ID" --arg actor "$AGENT_NAME" '{goal_id:$goal_id,action:"request_complete",actor:{id:$actor},note:"public sweep verification request"}')")"
+expect_ok "masc_goal_transition" "$r_goal_transition"
+
+echo "[35/36] masc_goal_verify"
+r_goal_verify="$(call_tool 5039 "masc_goal_verify" "$(jq -cn --arg goal_id "$GOAL_ID" --arg principal "$AGENT_NAME" '{goal_id:$goal_id,principal:{id:$principal},decision:"approve",note:"public sweep verifier guard"}')")"
+expect_ok "masc_goal_verify" "$r_goal_verify"
+
+echo "[36/36] masc_transition (done)"
+r_done="$(call_tool 5040 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"done",notes:"public tool sweep done"}')")"
+expect_ok "masc_transition done" "$r_done"
+CLEANUP_TASK_FINALIZED=1
 
 echo "PASS: public MCP tool live sweep"

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -130,9 +130,9 @@ r_goal_list="$(call_tool 5013 "masc_goal_list" '{}')"
 expect_ok "masc_goal_list" "$r_goal_list"
 
 echo "[11/36] masc_add_task"
-r_add_task="$(call_tool 5014 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" '{title:"Public Tool Sweep Task",goal_id:$goal_id,priority:2,description:"live public surface verification"}')")"
+r_add_task="$(call_tool 5015 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" '{title:"Public Tool Sweep Task",goal_id:$goal_id,priority:2,description:"live public surface verification"}')")"
 expect_ok "masc_add_task" "$r_add_task"
-task_id="$(
+task_id="$( 
   printf '%s' "$r_add_task" \
     | jq -r 'try (.result.structuredContent.task_id // .result.structuredContent.id) catch empty | strings' \
     | head -n1
@@ -142,11 +142,11 @@ if [[ -z "$task_id" ]]; then
 fi
 
 echo "[12/36] masc_batch_add_tasks"
-r_batch_add="$(call_tool 5015 "masc_batch_add_tasks" "$(jq -cn --arg goal_id "$GOAL_ID" '{tasks:[{title:"Public Sweep Batch A",goal_id:$goal_id,priority:3,description:"batch-a"},{title:"Public Sweep Batch B",goal_id:$goal_id,priority:4,description:"batch-b"}]}')")"
+r_batch_add="$(call_tool 5016 "masc_batch_add_tasks" "$(jq -cn --arg goal_id "$GOAL_ID" '{tasks:[{title:"Public Sweep Batch A",goal_id:$goal_id,priority:3,description:"batch-a"},{title:"Public Sweep Batch B",goal_id:$goal_id,priority:4,description:"batch-b"}]}')")"
 expect_ok "masc_batch_add_tasks" "$r_batch_add"
 
 echo "[13/36] masc_tasks"
-r_tasks="$(call_tool 5016 "masc_tasks" '{}')"
+r_tasks="$(call_tool 5017 "masc_tasks" '{}')"
 expect_ok "masc_tasks" "$r_tasks"
 
 echo "[14/36] masc_plan_init"

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -73,12 +73,6 @@ call_method() {
   jsonrpc_normalize_response "$raw" "$id"
 }
 
-extract_token() {
-  local text="$1"
-  local pattern="$2"
-  printf '%s\n' "$text" | grep -oE "$pattern" | head -n1 || true
-}
-
 manifest_json="$(
   env -u DUNE_RPC MASC_STORAGE_TYPE=filesystem \
     opam exec -- dune exec --root "$ROOT_DIR" bin/public_tool_manifest.exe \
@@ -91,6 +85,10 @@ initialize_mcp_session || {
   echo "FAIL: failed to initialize MCP session" >&2
   exit 1
 }
+if [[ -z "${MCP_SESSION_ID:-}" ]]; then
+  echo "FAIL: empty MCP_SESSION_ID after initialize" >&2
+  exit 1
+fi
 
 echo "[2/31] tools/list matches expected public surface"
 tools_list_payload="$(call_method 5001 "tools/list" '{}')"
@@ -149,9 +147,6 @@ task_id="$(
     | head -n1
 )"
 if [[ -z "$task_id" ]]; then
-  task_id="$(response_text_or_error "$r_add_task" | grep -oE 'task-[A-Za-z0-9_-]+' | head -n1 || true)"
-fi
-if [[ -z "$task_id" ]]; then
   mcp_fail_with_context "masc_add_task: could not extract task_id" "$r_add_task"
 fi
 
@@ -208,9 +203,6 @@ post_id="$(
     | head -n1
 )"
 if [[ -z "$post_id" ]]; then
-  post_id="$(response_text_or_error "$r_board_post" | grep -oE '(post|p)-[A-Za-z0-9_-]+' | head -n1 || true)"
-fi
-if [[ -z "$post_id" ]]; then
   mcp_fail_with_context "masc_board_post: could not extract post_id" "$r_board_post"
 fi
 
@@ -231,7 +223,7 @@ comment_id="$(
     | head -n1
 )"
 if [[ -z "$comment_id" ]]; then
-  comment_id="$(response_text_or_error "$r_board_comment" | grep -oE '(comment|c)-[A-Za-z0-9_-]+' | head -n1 || true)"
+  mcp_fail_with_context "masc_board_comment: could not extract comment_id" "$r_board_comment"
 fi
 
 echo "[27/31] masc_board_vote"

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -77,17 +77,25 @@ wait_for_mcp_initialize_ready() {
     echo "FAIL: MCP initialize readiness requires a workspace-local auth token" >&2
     return 1
   fi
-  local -a extra_headers=( -H "Authorization: Bearer $auth_token" )
+  local auth_header_file=""
+  if [[ -n "$auth_token" ]]; then
+    auth_header_file="$(_mcp_auth_header_file "$auth_token")" || auth_header_file=""
+  fi
 
   while [[ "$(date +%s)" -lt "$deadline" ]]; do
     local status body_file raw normalized
     body_file="$(mcp_mktemp_file "masc-contract-init-ready-${RANDOM:-0}-$$" ".json")"
+    local -a headers=(
+      -H 'Content-Type: application/json'
+      -H 'Accept: application/json, text/event-stream'
+    )
+    if [[ -n "$auth_header_file" ]]; then
+      headers+=( -H "@$auth_header_file" )
+    fi
     status="$(
       curl -sS -o "$body_file" -w '%{http_code}' --max-time 2 \
         -X POST "$mcp_url" \
-        -H 'Content-Type: application/json' \
-        -H 'Accept: application/json, text/event-stream' \
-        "${extra_headers[@]}" \
+        "${headers[@]}" \
         -d "$body" 2>/dev/null || true
     )"
     last_status="$status"
@@ -96,6 +104,7 @@ wait_for_mcp_initialize_ready() {
       rm -f "$body_file"
       normalized="$(jsonrpc_normalize_response "$raw" 0 2>/dev/null || true)"
       if printf '%s' "$normalized" | jq -e '._harness_error? == null and .error == null' >/dev/null 2>&1; then
+        rm -f "$auth_header_file"
         return 0
       fi
       last_status="200-jsonrpc-error"
@@ -105,6 +114,7 @@ wait_for_mcp_initialize_ready() {
     sleep 1
   done
 
+  rm -f "$auth_header_file"
   echo "MCP initialize readiness did not reach 200; last_http_status=${last_status}" >&2
   return 1
 }
@@ -118,7 +128,6 @@ run_contract() {
     cd "$ROOT_DIR"
     MCP_URL="$MCP_URL" \
       BASE_PATH="$BASE_PATH" \
-      MCP_TOKEN="$MCP_TOKEN" \
       MCP_AUTH_TOKEN="$MCP_AUTH_TOKEN" \
       MASC_ADMIN_TOKEN="$MASC_ADMIN_TOKEN" \
       bash "scripts/harness/contract/${script_name}"

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -119,6 +119,7 @@ if ! build_server_exe; then
   exit 1
 fi
 echo "[bootstrap] server_exe=${SERVER_EXE}"
+harness_seed_server_config "$ROOT_DIR" "$BASE_PATH"
 
 if ! HARNESS_AUTH_TOKEN="$(
   harness_mint_admin_token "$SERVER_EXE" "$PORT" "$BASE_PATH" \

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -81,7 +81,7 @@ wait_for_mcp_initialize_ready() {
 
   while [[ "$(date +%s)" -lt "$deadline" ]]; do
     local status body_file raw normalized
-    body_file="$(mcp_mktemp_file "masc-contract-init-ready" ".json")"
+    body_file="$(mcp_mktemp_file "masc-contract-init-ready-${RANDOM:-0}-$$" ".json")"
     status="$(
       curl -sS -o "$body_file" -w '%{http_code}' --max-time 2 \
         -X POST "$mcp_url" \
@@ -114,7 +114,15 @@ run_contract() {
   local total="$2"
   local script_name="$3"
   echo "[${step}/${total}] ${script_name}"
-  if ! (cd "$ROOT_DIR" && MCP_URL="$MCP_URL" BASE_PATH="$BASE_PATH" bash "scripts/harness/contract/${script_name}"); then
+  if ! (
+    cd "$ROOT_DIR"
+    MCP_URL="$MCP_URL" \
+      BASE_PATH="$BASE_PATH" \
+      MCP_TOKEN="$MCP_TOKEN" \
+      MCP_AUTH_TOKEN="$MCP_AUTH_TOKEN" \
+      MASC_ADMIN_TOKEN="$MASC_ADMIN_TOKEN" \
+      bash "scripts/harness/contract/${script_name}"
+  ); then
     echo "FAIL: ${script_name}" >&2
     harness_print_log_tail "$LOG_FILE"
     exit 1

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -70,6 +70,7 @@ wait_for_mcp_initialize_ready() {
   local timeout_sec="${2:-25}"
   local deadline=$(( $(date +%s) + timeout_sec ))
   local body='{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-bootstrap","version":"1.0"},"capabilities":{}}}'
+  local last_status="000"
   local auth_token
   auth_token="$(mcp_default_auth_token)"
   if [[ -z "$auth_token" ]]; then
@@ -88,12 +89,14 @@ wait_for_mcp_initialize_ready() {
         "${extra_headers[@]}" \
         -d "$body" 2>/dev/null || true
     )"
+    last_status="$status"
     if [[ "$status" == "200" ]]; then
       return 0
     fi
     sleep 1
   done
 
+  echo "MCP initialize readiness did not reach 200; last_http_status=${last_status}" >&2
   return 1
 }
 

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -80,9 +80,10 @@ wait_for_mcp_initialize_ready() {
   local -a extra_headers=( -H "Authorization: Bearer $auth_token" )
 
   while [[ "$(date +%s)" -lt "$deadline" ]]; do
-    local status
+    local status body_file raw normalized
+    body_file="$(mcp_mktemp_file "masc-contract-init-ready" ".json")"
     status="$(
-      curl -sS -o /dev/null -w '%{http_code}' --max-time 2 \
+      curl -sS -o "$body_file" -w '%{http_code}' --max-time 2 \
         -X POST "$mcp_url" \
         -H 'Content-Type: application/json' \
         -H 'Accept: application/json, text/event-stream' \
@@ -91,7 +92,15 @@ wait_for_mcp_initialize_ready() {
     )"
     last_status="$status"
     if [[ "$status" == "200" ]]; then
-      return 0
+      raw="$(cat "$body_file" 2>/dev/null || true)"
+      rm -f "$body_file"
+      normalized="$(jsonrpc_normalize_response "$raw" 0 2>/dev/null || true)"
+      if printf '%s' "$normalized" | jq -e '._harness_error? == null and .error == null' >/dev/null 2>&1; then
+        return 0
+      fi
+      last_status="200-jsonrpc-error"
+    else
+      rm -f "$body_file"
     fi
     sleep 1
   done

--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -52,34 +52,24 @@ wait_for_mcp_ready() {
   return 1
 }
 
-post_with_accept_auth() {
+post_with_accept() {
   local accept_header="$1"
   local body="$2"
   local header_file="$3"
   local body_file="$4"
-  local auth_header="${5:-__DEFAULT_AUTH__}"
-  local -a extra_headers=(
-    -H 'Content-Type: application/json'
-    -H "Accept: $accept_header"
-  )
-  if [ "$auth_header" = "__DEFAULT_AUTH__" ]; then
-    local auth_token
-    auth_token="$(mcp_default_auth_token)"
-    if [ -n "$auth_token" ]; then
-      extra_headers+=( -H "Authorization: Bearer $auth_token" )
-    fi
-  elif [ "$auth_header" != "__NO_AUTH__" ] && [ -n "$auth_header" ]; then
-    extra_headers+=( -H "Authorization: $auth_header" )
+  local auth_token
+  auth_token="$(mcp_default_auth_token)"
+  local -a extra_headers=()
+  if [ -n "$auth_token" ]; then
+    extra_headers+=( -H "Authorization: Bearer $auth_token" )
   fi
 
   curl_with_retry -sS -D "$header_file" -o "$body_file" \
     -X POST "$MCP_URL" \
+    -H 'Content-Type: application/json' \
+    -H "Accept: $accept_header" \
     "${extra_headers[@]}" \
     -d "$body"
-}
-
-post_with_accept() {
-  post_with_accept_auth "$1" "$2" "$3" "$4"
 }
 
 post_with_session() {
@@ -128,15 +118,9 @@ get_with_session() {
     extra_headers+=(-H "Authorization: Bearer $auth_token")
   fi
 
-  set +e
   curl_with_retry -sS -D "$header_file" -o "$body_file" --max-time 2 \
     "$MCP_URL" \
-    "${extra_headers[@]}"
-  local curl_status=$?
-  set -e
-  if [ "$curl_status" -ne 0 ] && [ "$curl_status" -ne 28 ]; then
-    return "$curl_status"
-  fi
+    "${extra_headers[@]}" || true
 }
 
 delete_with_session() {
@@ -184,25 +168,6 @@ require_header_contains() {
   fi
 }
 
-require_auth_rejected() {
-  local label="$1"
-  local header_file="$2"
-  local body_file="$3"
-  local code
-  code="$(status_code "$header_file")"
-  case "$code" in
-    401|403)
-      return 0
-      ;;
-    *)
-      echo "FAIL: expected 401 or 403 for ${label}, got ${code}"
-      cat "$header_file"
-      cat "$body_file"
-      exit 1
-      ;;
-  esac
-}
-
 header_value() {
   local header_file="$1"
   local key="$2"
@@ -216,40 +181,8 @@ header_value() {
   ' "$header_file"
 }
 
+echo "[1/7] json-only Accept is rejected"
 wait_for_mcp_ready
-echo "[1/11] missing bearer token is rejected"
-h0_missing="$tmpdir/auth-missing.headers"
-b0_missing="$tmpdir/auth-missing.body"
-post_with_accept_auth "application/json, text/event-stream" \
-  '{"jsonrpc":"2.0","id":10,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-missing","version":"1.0"},"capabilities":{}}}' \
-  "$h0_missing" "$b0_missing" "__NO_AUTH__"
-require_auth_rejected "missing bearer token" "$h0_missing" "$b0_missing"
-
-echo "[2/11] malformed authorization header is rejected"
-h0_malformed="$tmpdir/auth-malformed.headers"
-b0_malformed="$tmpdir/auth-malformed.body"
-post_with_accept_auth "application/json, text/event-stream" \
-  '{"jsonrpc":"2.0","id":11,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-malformed","version":"1.0"},"capabilities":{}}}' \
-  "$h0_malformed" "$b0_malformed" "not-bearer"
-require_auth_rejected "malformed authorization header" "$h0_malformed" "$b0_malformed"
-
-echo "[3/11] wrong bearer token is rejected"
-h0_wrong="$tmpdir/auth-wrong.headers"
-b0_wrong="$tmpdir/auth-wrong.body"
-post_with_accept_auth "application/json, text/event-stream" \
-  '{"jsonrpc":"2.0","id":12,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-wrong","version":"1.0"},"capabilities":{}}}' \
-  "$h0_wrong" "$b0_wrong" "Bearer wrong-token"
-require_auth_rejected "wrong bearer token" "$h0_wrong" "$b0_wrong"
-
-echo "[4/11] expired-looking bearer token is rejected"
-h0_expired="$tmpdir/auth-expired.headers"
-b0_expired="$tmpdir/auth-expired.body"
-post_with_accept_auth "application/json, text/event-stream" \
-  '{"jsonrpc":"2.0","id":13,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-expired","version":"1.0"},"capabilities":{}}}' \
-  "$h0_expired" "$b0_expired" "Bearer expired-token"
-require_auth_rejected "expired-looking bearer token" "$h0_expired" "$b0_expired"
-
-echo "[5/11] json-only Accept is rejected"
 h1="$tmpdir/json-only-accept.headers"
 b1="$tmpdir/json-only-accept.body"
 post_with_accept "application/json" \
@@ -268,7 +201,7 @@ if ! grep -qi "Invalid Accept header" "$b1"; then
   exit 1
 fi
 
-echo "[6/11] streamable Accept success"
+echo "[2/7] streamable Accept success"
 h2="$tmpdir/ok.headers"
 b2="$tmpdir/ok.body"
 post_with_accept "application/json, text/event-stream" \
@@ -289,7 +222,7 @@ if [ -z "$SESSION_ID" ] || [ -z "$PROTOCOL_VERSION" ]; then
   exit 1
 fi
 
-echo "[7/11] follow-up POST accepts missing protocol header via session continuity"
+echo "[3/7] follow-up POST accepts missing protocol header via session continuity"
 h3="$tmpdir/missing-protocol.headers"
 b3="$tmpdir/missing-protocol.body"
 post_with_session "$SESSION_ID" "" \
@@ -303,7 +236,7 @@ if [ "$code3" != "200" ]; then
   exit 1
 fi
 
-echo "[8/11] follow-up POST rejects mismatched protocol header"
+echo "[4/7] follow-up POST rejects mismatched protocol header"
 h4="$tmpdir/mismatch-protocol.headers"
 b4="$tmpdir/mismatch-protocol.body"
 post_with_session "$SESSION_ID" "2025-03-26" \
@@ -322,7 +255,7 @@ if ! grep -qi "mismatch" "$b4"; then
   exit 1
 fi
 
-echo "[9/11] follow-up POST succeeds with matching protocol header"
+echo "[5/7] follow-up POST succeeds with matching protocol header"
 h5="$tmpdir/match-protocol.headers"
 b5="$tmpdir/match-protocol.body"
 post_with_session "$SESSION_ID" "$PROTOCOL_VERSION" \
@@ -336,7 +269,7 @@ if [ "$code5" != "200" ]; then
   exit 1
 fi
 
-echo "[10/11] follow-up GET accepts missing protocol header via session continuity"
+echo "[6/7] follow-up GET accepts missing protocol header via session continuity"
 h6="$tmpdir/get-missing-protocol.headers"
 b6="$tmpdir/get-missing-protocol.body"
 get_with_session "$SESSION_ID" "" "$h6" "$b6"
@@ -348,7 +281,7 @@ if [ "$code6" != "200" ]; then
   exit 1
 fi
 
-echo "[11/11] follow-up DELETE accepts missing protocol header via session continuity"
+echo "[7/7] follow-up DELETE accepts missing protocol header via session continuity"
 h7="$tmpdir/delete-missing-protocol.headers"
 b7="$tmpdir/delete-missing-protocol.body"
 delete_with_session "$SESSION_ID" "" "$h7" "$b7"

--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -52,24 +52,34 @@ wait_for_mcp_ready() {
   return 1
 }
 
-post_with_accept() {
+post_with_accept_auth() {
   local accept_header="$1"
   local body="$2"
   local header_file="$3"
   local body_file="$4"
-  local auth_token
-  auth_token="$(mcp_default_auth_token)"
-  local -a extra_headers=()
-  if [ -n "$auth_token" ]; then
-    extra_headers+=( -H "Authorization: Bearer $auth_token" )
+  local auth_header="${5:-__DEFAULT_AUTH__}"
+  local -a extra_headers=(
+    -H 'Content-Type: application/json'
+    -H "Accept: $accept_header"
+  )
+  if [ "$auth_header" = "__DEFAULT_AUTH__" ]; then
+    local auth_token
+    auth_token="$(mcp_default_auth_token)"
+    if [ -n "$auth_token" ]; then
+      extra_headers+=( -H "Authorization: Bearer $auth_token" )
+    fi
+  elif [ "$auth_header" != "__NO_AUTH__" ] && [ -n "$auth_header" ]; then
+    extra_headers+=( -H "Authorization: $auth_header" )
   fi
 
   curl_with_retry -sS -D "$header_file" -o "$body_file" \
     -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H "Accept: $accept_header" \
     "${extra_headers[@]}" \
     -d "$body"
+}
+
+post_with_accept() {
+  post_with_accept_auth "$1" "$2" "$3" "$4"
 }
 
 post_with_session() {
@@ -118,9 +128,15 @@ get_with_session() {
     extra_headers+=(-H "Authorization: Bearer $auth_token")
   fi
 
+  set +e
   curl_with_retry -sS -D "$header_file" -o "$body_file" --max-time 2 \
     "$MCP_URL" \
-    "${extra_headers[@]}" || true
+    "${extra_headers[@]}"
+  local curl_status=$?
+  set -e
+  if [ "$curl_status" -ne 0 ] && [ "$curl_status" -ne 28 ]; then
+    return "$curl_status"
+  fi
 }
 
 delete_with_session() {
@@ -168,6 +184,25 @@ require_header_contains() {
   fi
 }
 
+require_auth_rejected() {
+  local label="$1"
+  local header_file="$2"
+  local body_file="$3"
+  local code
+  code="$(status_code "$header_file")"
+  case "$code" in
+    401|403)
+      return 0
+      ;;
+    *)
+      echo "FAIL: expected 401 or 403 for ${label}, got ${code}"
+      cat "$header_file"
+      cat "$body_file"
+      exit 1
+      ;;
+  esac
+}
+
 header_value() {
   local header_file="$1"
   local key="$2"
@@ -181,8 +216,40 @@ header_value() {
   ' "$header_file"
 }
 
-echo "[1/7] json-only Accept is rejected"
 wait_for_mcp_ready
+echo "[1/11] missing bearer token is rejected"
+h0_missing="$tmpdir/auth-missing.headers"
+b0_missing="$tmpdir/auth-missing.body"
+post_with_accept_auth "application/json, text/event-stream" \
+  '{"jsonrpc":"2.0","id":10,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-missing","version":"1.0"},"capabilities":{}}}' \
+  "$h0_missing" "$b0_missing" "__NO_AUTH__"
+require_auth_rejected "missing bearer token" "$h0_missing" "$b0_missing"
+
+echo "[2/11] malformed authorization header is rejected"
+h0_malformed="$tmpdir/auth-malformed.headers"
+b0_malformed="$tmpdir/auth-malformed.body"
+post_with_accept_auth "application/json, text/event-stream" \
+  '{"jsonrpc":"2.0","id":11,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-malformed","version":"1.0"},"capabilities":{}}}' \
+  "$h0_malformed" "$b0_malformed" "not-bearer"
+require_auth_rejected "malformed authorization header" "$h0_malformed" "$b0_malformed"
+
+echo "[3/11] wrong bearer token is rejected"
+h0_wrong="$tmpdir/auth-wrong.headers"
+b0_wrong="$tmpdir/auth-wrong.body"
+post_with_accept_auth "application/json, text/event-stream" \
+  '{"jsonrpc":"2.0","id":12,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-wrong","version":"1.0"},"capabilities":{}}}' \
+  "$h0_wrong" "$b0_wrong" "Bearer wrong-token"
+require_auth_rejected "wrong bearer token" "$h0_wrong" "$b0_wrong"
+
+echo "[4/11] expired-looking bearer token is rejected"
+h0_expired="$tmpdir/auth-expired.headers"
+b0_expired="$tmpdir/auth-expired.body"
+post_with_accept_auth "application/json, text/event-stream" \
+  '{"jsonrpc":"2.0","id":13,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-expired","version":"1.0"},"capabilities":{}}}' \
+  "$h0_expired" "$b0_expired" "Bearer expired-token"
+require_auth_rejected "expired-looking bearer token" "$h0_expired" "$b0_expired"
+
+echo "[5/11] json-only Accept is rejected"
 h1="$tmpdir/json-only-accept.headers"
 b1="$tmpdir/json-only-accept.body"
 post_with_accept "application/json" \
@@ -201,7 +268,7 @@ if ! grep -qi "Invalid Accept header" "$b1"; then
   exit 1
 fi
 
-echo "[2/7] streamable Accept success"
+echo "[6/11] streamable Accept success"
 h2="$tmpdir/ok.headers"
 b2="$tmpdir/ok.body"
 post_with_accept "application/json, text/event-stream" \
@@ -222,7 +289,7 @@ if [ -z "$SESSION_ID" ] || [ -z "$PROTOCOL_VERSION" ]; then
   exit 1
 fi
 
-echo "[3/7] follow-up POST accepts missing protocol header via session continuity"
+echo "[7/11] follow-up POST accepts missing protocol header via session continuity"
 h3="$tmpdir/missing-protocol.headers"
 b3="$tmpdir/missing-protocol.body"
 post_with_session "$SESSION_ID" "" \
@@ -236,7 +303,7 @@ if [ "$code3" != "200" ]; then
   exit 1
 fi
 
-echo "[4/7] follow-up POST rejects mismatched protocol header"
+echo "[8/11] follow-up POST rejects mismatched protocol header"
 h4="$tmpdir/mismatch-protocol.headers"
 b4="$tmpdir/mismatch-protocol.body"
 post_with_session "$SESSION_ID" "2025-03-26" \
@@ -255,7 +322,7 @@ if ! grep -qi "mismatch" "$b4"; then
   exit 1
 fi
 
-echo "[5/7] follow-up POST succeeds with matching protocol header"
+echo "[9/11] follow-up POST succeeds with matching protocol header"
 h5="$tmpdir/match-protocol.headers"
 b5="$tmpdir/match-protocol.body"
 post_with_session "$SESSION_ID" "$PROTOCOL_VERSION" \
@@ -269,7 +336,7 @@ if [ "$code5" != "200" ]; then
   exit 1
 fi
 
-echo "[6/7] follow-up GET accepts missing protocol header via session continuity"
+echo "[10/11] follow-up GET accepts missing protocol header via session continuity"
 h6="$tmpdir/get-missing-protocol.headers"
 b6="$tmpdir/get-missing-protocol.body"
 get_with_session "$SESSION_ID" "" "$h6" "$b6"
@@ -281,7 +348,7 @@ if [ "$code6" != "200" ]; then
   exit 1
 fi
 
-echo "[7/7] follow-up DELETE accepts missing protocol header via session continuity"
+echo "[11/11] follow-up DELETE accepts missing protocol header via session continuity"
 h7="$tmpdir/delete-missing-protocol.headers"
 b7="$tmpdir/delete-missing-protocol.body"
 delete_with_session "$SESSION_ID" "" "$h7" "$b7"

--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -8,6 +8,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib/mcp_jsonrpc.sh"
 
 tmpdir="$(mktemp -d)"
+AUTH_HEADER_FILE=""
+AUTH_TOKEN="$(mcp_default_auth_token)"
+if [ -n "$AUTH_TOKEN" ]; then
+  AUTH_HEADER_FILE="$tmpdir/auth.header"
+  printf 'Authorization: Bearer %s\n' "$AUTH_TOKEN" > "$AUTH_HEADER_FILE"
+fi
 cleanup() {
   rm -rf "$tmpdir"
 }
@@ -52,24 +58,30 @@ wait_for_mcp_ready() {
   return 1
 }
 
-post_with_accept() {
+post_with_accept_auth() {
   local accept_header="$1"
   local body="$2"
   local header_file="$3"
   local body_file="$4"
-  local auth_token
-  auth_token="$(mcp_default_auth_token)"
-  local -a extra_headers=()
-  if [ -n "$auth_token" ]; then
-    extra_headers+=( -H "Authorization: Bearer $auth_token" )
+  local auth_header="${5:-__DEFAULT_AUTH__}"
+  local -a extra_headers=(
+    -H 'Content-Type: application/json'
+    -H "Accept: $accept_header"
+  )
+  if [ "$auth_header" = "__DEFAULT_AUTH__" ] && [ -n "$AUTH_HEADER_FILE" ]; then
+    extra_headers+=( -H "@$AUTH_HEADER_FILE" )
+  elif [ "$auth_header" != "__NO_AUTH__" ] && [ -n "$auth_header" ]; then
+    extra_headers+=( -H "Authorization: $auth_header" )
   fi
 
   curl_with_retry -sS -D "$header_file" -o "$body_file" \
     -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H "Accept: $accept_header" \
     "${extra_headers[@]}" \
     -d "$body"
+}
+
+post_with_accept() {
+  post_with_accept_auth "$1" "$2" "$3" "$4"
 }
 
 post_with_session() {
@@ -87,10 +99,8 @@ post_with_session() {
   if [ -n "$protocol_version" ]; then
     extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
   fi
-  local auth_token
-  auth_token="$(mcp_default_auth_token)"
-  if [ -n "$auth_token" ]; then
-    extra_headers+=(-H "Authorization: Bearer $auth_token")
+  if [ -n "$AUTH_HEADER_FILE" ]; then
+    extra_headers+=( -H "@$AUTH_HEADER_FILE" )
   fi
 
   curl_with_retry -sS -D "$header_file" -o "$body_file" \
@@ -112,15 +122,19 @@ get_with_session() {
   if [ -n "$protocol_version" ]; then
     extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
   fi
-  local auth_token
-  auth_token="$(mcp_default_auth_token)"
-  if [ -n "$auth_token" ]; then
-    extra_headers+=(-H "Authorization: Bearer $auth_token")
+  if [ -n "$AUTH_HEADER_FILE" ]; then
+    extra_headers+=( -H "@$AUTH_HEADER_FILE" )
   fi
 
+  set +e
   curl_with_retry -sS -D "$header_file" -o "$body_file" --max-time 2 \
     "$MCP_URL" \
-    "${extra_headers[@]}" || true
+    "${extra_headers[@]}"
+  local curl_status=$?
+  set -e
+  if [ "$curl_status" -ne 0 ]; then
+    return "$curl_status"
+  fi
 }
 
 delete_with_session() {
@@ -135,10 +149,8 @@ delete_with_session() {
   if [ -n "$protocol_version" ]; then
     extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
   fi
-  local auth_token
-  auth_token="$(mcp_default_auth_token)"
-  if [ -n "$auth_token" ]; then
-    extra_headers+=(-H "Authorization: Bearer $auth_token")
+  if [ -n "$AUTH_HEADER_FILE" ]; then
+    extra_headers+=( -H "@$AUTH_HEADER_FILE" )
   fi
 
   curl_with_retry -sS -D "$header_file" -o "$body_file" \
@@ -168,6 +180,25 @@ require_header_contains() {
   fi
 }
 
+require_auth_rejected() {
+  local label="$1"
+  local header_file="$2"
+  local body_file="$3"
+  local code
+  code="$(status_code "$header_file")"
+  case "$code" in
+    401|403)
+      return 0
+      ;;
+    *)
+      echo "FAIL: expected 401 or 403 for ${label}, got ${code}"
+      cat "$header_file"
+      cat "$body_file"
+      exit 1
+      ;;
+  esac
+}
+
 header_value() {
   local header_file="$1"
   local key="$2"
@@ -181,8 +212,40 @@ header_value() {
   ' "$header_file"
 }
 
-echo "[1/7] json-only Accept is rejected"
 wait_for_mcp_ready
+echo "[1/11] missing bearer token is rejected"
+h0_missing="$tmpdir/auth-missing.headers"
+b0_missing="$tmpdir/auth-missing.body"
+post_with_accept_auth "application/json, text/event-stream" \
+  '{"jsonrpc":"2.0","id":10,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-missing","version":"1.0"},"capabilities":{}}}' \
+  "$h0_missing" "$b0_missing" "__NO_AUTH__"
+require_auth_rejected "missing bearer token" "$h0_missing" "$b0_missing"
+
+echo "[2/11] malformed authorization header is rejected"
+h0_malformed="$tmpdir/auth-malformed.headers"
+b0_malformed="$tmpdir/auth-malformed.body"
+post_with_accept_auth "application/json, text/event-stream" \
+  '{"jsonrpc":"2.0","id":11,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-malformed","version":"1.0"},"capabilities":{}}}' \
+  "$h0_malformed" "$b0_malformed" "not-bearer"
+require_auth_rejected "malformed authorization header" "$h0_malformed" "$b0_malformed"
+
+echo "[3/11] wrong bearer token is rejected"
+h0_wrong="$tmpdir/auth-wrong.headers"
+b0_wrong="$tmpdir/auth-wrong.body"
+post_with_accept_auth "application/json, text/event-stream" \
+  '{"jsonrpc":"2.0","id":12,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-wrong","version":"1.0"},"capabilities":{}}}' \
+  "$h0_wrong" "$b0_wrong" "Bearer wrong-token"
+require_auth_rejected "wrong bearer token" "$h0_wrong" "$b0_wrong"
+
+echo "[4/11] expired-looking bearer token is rejected"
+h0_expired="$tmpdir/auth-expired.headers"
+b0_expired="$tmpdir/auth-expired.body"
+post_with_accept_auth "application/json, text/event-stream" \
+  '{"jsonrpc":"2.0","id":13,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-auth-expired","version":"1.0"},"capabilities":{}}}' \
+  "$h0_expired" "$b0_expired" "Bearer expired-token"
+require_auth_rejected "expired-looking bearer token" "$h0_expired" "$b0_expired"
+
+echo "[5/11] json-only Accept is rejected"
 h1="$tmpdir/json-only-accept.headers"
 b1="$tmpdir/json-only-accept.body"
 post_with_accept "application/json" \
@@ -201,7 +264,7 @@ if ! grep -qi "Invalid Accept header" "$b1"; then
   exit 1
 fi
 
-echo "[2/7] streamable Accept success"
+echo "[6/11] streamable Accept success"
 h2="$tmpdir/ok.headers"
 b2="$tmpdir/ok.body"
 post_with_accept "application/json, text/event-stream" \
@@ -222,7 +285,7 @@ if [ -z "$SESSION_ID" ] || [ -z "$PROTOCOL_VERSION" ]; then
   exit 1
 fi
 
-echo "[3/7] follow-up POST accepts missing protocol header via session continuity"
+echo "[7/11] follow-up POST accepts missing protocol header via session continuity"
 h3="$tmpdir/missing-protocol.headers"
 b3="$tmpdir/missing-protocol.body"
 post_with_session "$SESSION_ID" "" \
@@ -236,7 +299,7 @@ if [ "$code3" != "200" ]; then
   exit 1
 fi
 
-echo "[4/7] follow-up POST rejects mismatched protocol header"
+echo "[8/11] follow-up POST rejects mismatched protocol header"
 h4="$tmpdir/mismatch-protocol.headers"
 b4="$tmpdir/mismatch-protocol.body"
 post_with_session "$SESSION_ID" "2025-03-26" \
@@ -255,7 +318,7 @@ if ! grep -qi "mismatch" "$b4"; then
   exit 1
 fi
 
-echo "[5/7] follow-up POST succeeds with matching protocol header"
+echo "[9/11] follow-up POST succeeds with matching protocol header"
 h5="$tmpdir/match-protocol.headers"
 b5="$tmpdir/match-protocol.body"
 post_with_session "$SESSION_ID" "$PROTOCOL_VERSION" \
@@ -269,7 +332,7 @@ if [ "$code5" != "200" ]; then
   exit 1
 fi
 
-echo "[6/7] follow-up GET accepts missing protocol header via session continuity"
+echo "[10/11] follow-up GET accepts missing protocol header via session continuity"
 h6="$tmpdir/get-missing-protocol.headers"
 b6="$tmpdir/get-missing-protocol.body"
 get_with_session "$SESSION_ID" "" "$h6" "$b6"
@@ -281,7 +344,7 @@ if [ "$code6" != "200" ]; then
   exit 1
 fi
 
-echo "[7/7] follow-up DELETE accepts missing protocol header via session continuity"
+echo "[11/11] follow-up DELETE accepts missing protocol header via session continuity"
 h7="$tmpdir/delete-missing-protocol.headers"
 b7="$tmpdir/delete-missing-protocol.body"
 delete_with_session "$SESSION_ID" "" "$h7" "$b7"

--- a/scripts/harness/lib/mcp_jsonrpc.sh
+++ b/scripts/harness/lib/mcp_jsonrpc.sh
@@ -42,6 +42,17 @@ mcp_mktemp_file() {
   printf '%s\n' "$path"
 }
 
+# Write the bearer token to a temp file so curl can read the Authorization
+# header via -H @file instead of exposing the token in argv. Caller must remove
+# the file when done.
+_mcp_auth_header_file() {
+  local token="${1:-}"
+  local f
+  f="$(mktemp "${TMPDIR:-/tmp}/mcp-auth-header.XXXXXX")" || return 1
+  printf 'Authorization: Bearer %s\n' "$token" > "$f"
+  printf '%s\n' "$f"
+}
+
 mcp_print_log_tail() {
   local log_file="${1:-${HARNESS_LOG_FILE:-}}"
   local lines="${2:-${HARNESS_LOG_TAIL_LINES:-120}}"
@@ -226,12 +237,17 @@ mcp_jsonrpc_call() {
     read -r -a extra_args <<< "${MCP_CURL_EXTRA_ARGS}"
   fi
 
+  local auth_header_file=""
+  if [[ -n "$token" ]]; then
+    auth_header_file="$(_mcp_auth_header_file "$token")" || auth_header_file=""
+  fi
+
   while :; do
     local body_file stderr_file resp_file
     body_file="$(mcp_mktemp_file "masc-jsonrpc-body" ".json")"
     stderr_file="$(mcp_mktemp_file "masc-jsonrpc-stderr" ".log")"
     resp_file="$(mcp_mktemp_file "masc-jsonrpc-resp" ".json")"
-    trap 'rm -f "$body_file" "$stderr_file" "$resp_file"' RETURN
+    trap 'rm -f "$body_file" "$stderr_file" "$resp_file" "$auth_header_file"' RETURN
     printf '%s' "$request_body" >"$body_file"
 
     local -a cmd=(
@@ -248,8 +264,8 @@ mcp_jsonrpc_call() {
     if [[ -n "${MCP_PROTOCOL_VERSION:-}" ]]; then
       cmd+=( -H "Mcp-Protocol-Version: $MCP_PROTOCOL_VERSION" )
     fi
-    if [[ -n "$token" ]]; then
-      cmd+=( -H "Authorization: Bearer $token" )
+    if [[ -n "$auth_header_file" ]]; then
+      cmd+=( -H "@$auth_header_file" )
     fi
     if [[ "${#extra_args[@]}" -gt 0 ]]; then
       cmd+=( "${extra_args[@]}" )
@@ -266,7 +282,7 @@ mcp_jsonrpc_call() {
     MCP_LAST_TIME_TOTAL="$cumulative_time"
     stderr_text="$(cat "$stderr_file" 2>/dev/null || true)"
     raw="$(cat "$resp_file" 2>/dev/null || true)"
-    rm -f "$body_file" "$stderr_file" "$resp_file"
+    rm -f "$body_file" "$stderr_file" "$resp_file" "$auth_header_file"
 
     if [[ "$status" -eq 0 ]]; then
       local normalized

--- a/scripts/harness/lib/mcp_jsonrpc.sh
+++ b/scripts/harness/lib/mcp_jsonrpc.sh
@@ -231,6 +231,7 @@ mcp_jsonrpc_call() {
     body_file="$(mcp_mktemp_file "masc-jsonrpc-body" ".json")"
     stderr_file="$(mcp_mktemp_file "masc-jsonrpc-stderr" ".log")"
     resp_file="$(mcp_mktemp_file "masc-jsonrpc-resp" ".json")"
+    trap 'rm -f "$body_file" "$stderr_file" "$resp_file"' RETURN
     printf '%s' "$request_body" >"$body_file"
 
     local -a cmd=(

--- a/scripts/harness/lib/test_framework.sh
+++ b/scripts/harness/lib/test_framework.sh
@@ -29,6 +29,10 @@ curl_post_mcp() {
   local output=""
   local auth_token
   auth_token="$(mcp_default_auth_token)"
+  local auth_header_file=""
+  if [ -n "$auth_token" ]; then
+    auth_header_file="$(_mcp_auth_header_file "$auth_token")" || auth_header_file=""
+  fi
   local -a headers=(
     -H 'Content-Type: application/json'
     -H 'Accept: application/json, text/event-stream'
@@ -36,13 +40,14 @@ curl_post_mcp() {
   if [ -n "$MCP_SESSION_ID" ]; then
     headers+=( -H "mcp-session-id: $MCP_SESSION_ID" )
   fi
-  if [ -n "$auth_token" ]; then
-    headers+=( -H "Authorization: Bearer $auth_token" )
+  if [ -n "$auth_header_file" ]; then
+    headers+=( -H "@$auth_header_file" )
   fi
   while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
     if output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
       "${headers[@]}" \
       -d "$body" 2>/dev/null)"; then
+      rm -f "$auth_header_file"
       printf "%s" "$output"
       return 0
     fi
@@ -51,21 +56,26 @@ curl_post_mcp() {
     fi
     attempt=$((attempt + 1))
   done
+  rm -f "$auth_header_file"
   return 1
 }
 
 initialize_mcp_session() {
-  local headers_file body_file
+  local headers_file body_file auth_header_file=""
   headers_file="$(mcp_mktemp_file "masc-init-headers")"
   body_file="$(mcp_mktemp_file "masc-init-body")"
   local auth_token
   auth_token="$(mcp_default_auth_token)"
+  if [ -n "$auth_token" ]; then
+    auth_header_file="$(_mcp_auth_header_file "$auth_token")" || auth_header_file=""
+  fi
+  trap 'rm -f "$headers_file" "$body_file" "$auth_header_file"' RETURN
   local -a init_headers=(
     -H 'Content-Type: application/json'
     -H 'Accept: application/json, text/event-stream'
   )
-  if [ -n "$auth_token" ]; then
-    init_headers+=( -H "Authorization: Bearer $auth_token" )
+  if [ -n "$auth_header_file" ]; then
+    init_headers+=( -H "@$auth_header_file" )
   fi
 
   if curl -sS -m "$CURL_TIMEOUT_SEC" -D "$headers_file" -o "$body_file" -X POST "$MCP_URL" \
@@ -89,8 +99,8 @@ initialize_mcp_session() {
         -H 'Accept: application/json, text/event-stream'
         -H "mcp-session-id: $MCP_SESSION_ID"
       )
-      if [ -n "$auth_token" ]; then
-        initialized_headers+=( -H "Authorization: Bearer $auth_token" )
+      if [ -n "$auth_header_file" ]; then
+        initialized_headers+=( -H "@$auth_header_file" )
       fi
       curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
         "${initialized_headers[@]}" \
@@ -99,7 +109,7 @@ initialize_mcp_session() {
     fi
   fi
 
-  rm -f "$headers_file" "$body_file"
+  rm -f "$headers_file" "$body_file" "$auth_header_file"
   [ -n "$MCP_SESSION_ID" ]
 }
 

--- a/scripts/harness/workload/keeper_continuity_validation.sh
+++ b/scripts/harness/workload/keeper_continuity_validation.sh
@@ -193,9 +193,13 @@ init_mcp_session() {
     return 0
   fi
 
-  local headers_file body_file init_body session_id protocol_version
+  local headers_file body_file auth_header_file init_body session_id protocol_version
   headers_file="$(mcp_mktemp_file "keeper-continuity-init" ".headers")"
   body_file="$(mcp_mktemp_file "keeper-continuity-init" ".body")"
+  auth_header_file=""
+  if [[ -n "${MCP_TOKEN:-}" ]]; then
+    auth_header_file="$(_mcp_auth_header_file)" || auth_header_file=""
+  fi
   init_body="$(
     jq -cn '{
       jsonrpc:"2.0",
@@ -217,14 +221,14 @@ init_mcp_session() {
     -H "Content-Type: application/json"
     -H "Accept: application/json, text/event-stream"
   )
-  if [[ -n "$MCP_TOKEN" ]]; then
-    cmd+=( -H "Authorization: Bearer $MCP_TOKEN" )
+  if [[ -n "$auth_header_file" ]]; then
+    cmd+=( -H "@$auth_header_file" )
   fi
   cmd+=( --data-binary "$init_body" )
 
   if ! "${cmd[@]}" >/dev/null 2>"$RAW_DIR/mcp-initialize.stderr"; then
     LAST_TOOL_ERROR="MCP initialize transport failed"
-    rm -f "$headers_file" "$body_file"
+    rm -f "$headers_file" "$body_file" "$auth_header_file"
     return 1
   fi
 
@@ -250,7 +254,7 @@ init_mcp_session() {
   if [[ -z "$session_id" ]]; then
     LAST_TOOL_ERROR="MCP initialize did not return Mcp-Session-Id"
     cp "$body_file" "$RAW_DIR/mcp-initialize.body" 2>/dev/null || true
-    rm -f "$headers_file" "$body_file"
+    rm -f "$headers_file" "$body_file" "$auth_header_file"
     return 1
   fi
 
@@ -260,7 +264,7 @@ init_mcp_session() {
     MCP_PROTOCOL_VERSION="$protocol_version"
     export MCP_PROTOCOL_VERSION
   fi
-  rm -f "$headers_file" "$body_file"
+  rm -f "$headers_file" "$body_file" "$auth_header_file"
 }
 
 tool_text() {

--- a/scripts/harness/workload/keeper_product_design_board_reprobe.sh
+++ b/scripts/harness/workload/keeper_product_design_board_reprobe.sh
@@ -185,9 +185,13 @@ init_mcp_session() {
     return 0
   fi
 
-  local headers_file body_file init_body session_id protocol_version deadline
+  local headers_file body_file auth_header_file init_body session_id protocol_version deadline
   headers_file="$(mcp_mktemp_file "keeper-product-design-init" ".headers")"
   body_file="$(mcp_mktemp_file "keeper-product-design-init" ".body")"
+  auth_header_file=""
+  if [[ -n "${MCP_TOKEN:-}" ]]; then
+    auth_header_file="$(_mcp_auth_header_file)" || auth_header_file=""
+  fi
   init_body="$(
     jq -cn --arg client_name "$MCP_CLIENT_NAME" \
       '{jsonrpc:"2.0", id:1, method:"initialize", params:{protocolVersion:"2025-11-25", clientInfo:{name:$client_name, version:"1.0"}, capabilities:{}}}'
@@ -215,8 +219,8 @@ init_mcp_session() {
       -H "Content-Type: application/json"
       -H "Accept: application/json, text/event-stream"
     )
-    if [[ -n "$MCP_TOKEN" ]]; then
-      cmd+=( -H "Authorization: Bearer $MCP_TOKEN" )
+    if [[ -n "$auth_header_file" ]]; then
+      cmd+=( -H "@$auth_header_file" )
     fi
     cmd+=( --data-binary "$init_body" )
 
@@ -236,7 +240,7 @@ init_mcp_session() {
   if [[ -z "${session_id:-}" ]]; then
     echo "MCP initialize did not return Mcp-Session-Id before ${INIT_TIMEOUT_SEC}s deadline" >&2
     cat "$body_file" >&2 || true
-    rm -f "$headers_file" "$body_file"
+    rm -f "$headers_file" "$body_file" "$auth_header_file"
     exit 1
   fi
 
@@ -246,7 +250,7 @@ init_mcp_session() {
     MCP_PROTOCOL_VERSION="$protocol_version"
     export MCP_PROTOCOL_VERSION
   fi
-  rm -f "$headers_file" "$body_file"
+  rm -f "$headers_file" "$body_file" "$auth_header_file"
 }
 
 ensure_mcp_session_if_needed() {

--- a/test/test_rfc_0086_keeper_namespace_invariant.ml
+++ b/test/test_rfc_0086_keeper_namespace_invariant.ml
@@ -49,6 +49,11 @@ let string_contains ~needle haystack =
   String.equal needle "" || loop 0
 ;;
 
+let is_absolute_path path =
+  (not (String.equal path ""))
+  && Char.equal path.[0] Filename.dir_sep.[0]
+;;
+
 let boundary_modules_path =
   "docs/rfc/RFC-0086-keeper-namespace-boundary-modules.txt"
 
@@ -188,7 +193,7 @@ let test_source_path_contract_resolves_valid_relative () =
      mangles or relativizes the resolved path. *)
   let resolved = Masc_test_deps.source_path "lib/keeper" in
   check bool "source_path returns an absolute path" true
-    (Filename.is_absolute resolved);
+    (is_absolute_path resolved);
   check bool "source_path lands on a real keeper directory" true
     (Sys.is_directory resolved)
 ;;

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -264,6 +264,22 @@ let () = test "handle_add_task_returns_structured_task_id" (fun () ->
   | Some summary -> assert (str_contains summary "Added task-001")
   | None -> failwith "missing summary")
 
+let () = test "handle_add_task_duplicate_returns_workflow_rejection" (fun () ->
+  let ctx = make_test_ctx () in
+  let first =
+    Task.Tool.handle_add_task ~tool_name:"masc_add_task" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Duplicate contract task") ])
+  in
+  if not (Tool_result.is_success first) then failwith (Tool_result.message first);
+  let duplicate =
+    Task.Tool.handle_add_task ~tool_name:"masc_add_task" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Duplicate contract task") ])
+  in
+  assert (not (Tool_result.is_success duplicate));
+  assert ((Tool_result.failure_class duplicate) = Some Tool_result.Workflow_rejection);
+  assert (str_contains (Tool_result.message duplicate) "Duplicate rejected");
+  assert (str_contains (Tool_result.message duplicate) "task-001"))
+
 let () = test "workspace_add_task_with_result_returns_typed_task_id" (fun () ->
   let ctx = make_test_ctx () in
   match
@@ -2321,11 +2337,16 @@ let () = test "rfc_0034_v2_masc_add_task_caps_per_goal" (fun () ->
           ("goal_id", `String goal.id);
         ])
   in
-  (* [Workspace_task_create.add_task] returns the rejection as an
-     ["Error: <msg>"] string, mirroring the existing dedup-rejection
-     surface, so [handle_add_task] still returns [(true, "Error: ...")].
-     The cap is enforced at persistence time — pin both the message
-     content and the persisted backlog size. *)
+  (* The cap is enforced at persistence time. It must surface as a typed tool
+     failure, not as a successful result carrying an ["Error: ..."] string. *)
+  if Tool_result.is_success message_result
+  then
+    failwith
+      (Printf.sprintf
+         "expected fourth task to be rejected as workflow failure, got success: %s"
+         (Tool_result.message message_result));
+  if (Tool_result.failure_class message_result) <> Some Tool_result.Workflow_rejection
+  then failwith "expected workflow_rejection failure_class";
   if not (str_starts_with ~prefix:"Error:" (Tool_result.message message_result))
   then
     failwith

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -244,6 +244,26 @@ let () = test "dispatch_add_task" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "handle_add_task_returns_structured_task_id" (fun () ->
+  let ctx = make_test_ctx () in
+  let result =
+    Task.Tool.handle_add_task ~tool_name:"masc_add_task" ~start_time:0.0 ctx
+      (`Assoc
+        [ ("title", `String "Structured task")
+        ; ("priority", `Int 2)
+        ; ("description", `String "structured add-task regression")
+        ])
+  in
+  assert (Tool_result.is_success result);
+  let data = Tool_result.data result in
+  assert (Json_util.get_bool data "ok" = Some true);
+  assert (Json_util.get_string data "task_id" = Some "task-001");
+  assert (Json_util.get_string data "title" = Some "Structured task");
+  assert (Json_util.assoc_member_opt "result" data = None);
+  match Json_util.get_string data "summary" with
+  | Some summary -> assert (str_contains summary "Added task-001")
+  | None -> failwith "missing summary")
+
 (* Test dispatch tasks *)
 let () = test "dispatch_tasks" (fun () ->
   let ctx = make_test_ctx () in

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -264,6 +264,52 @@ let () = test "handle_add_task_returns_structured_task_id" (fun () ->
   | Some summary -> assert (str_contains summary "Added task-001")
   | None -> failwith "missing summary")
 
+let () = test "workspace_add_task_with_result_returns_typed_task_id" (fun () ->
+  let ctx = make_test_ctx () in
+  match
+    Workspace.add_task_with_result
+      ctx.config
+      ~title:"Structured task: title punctuation is display-only"
+      ~priority:2
+      ~description:"structured workspace add-task regression"
+  with
+  | Ok created ->
+    assert (created.task_id = "task-001");
+    assert (created.title = "Structured task: title punctuation is display-only");
+    assert (created.priority = 2);
+    assert (created.goal_id = None)
+  | Error err ->
+    failwith
+      (Printf.sprintf
+         "expected typed add_task success, got %s"
+         (Workspace.add_task_error_to_string err)))
+
+let () = test "handle_batch_add_tasks_returns_structured_task_ids" (fun () ->
+  let ctx = make_test_ctx () in
+  let result =
+    Task.Tool.handle_batch_add_tasks ~tool_name:"masc_batch_add_tasks" ~start_time:0.0 ctx
+      (`Assoc
+        [
+          ( "tasks",
+            `List
+              [
+                `Assoc [ ("title", `String "Structured batch A") ];
+                `Assoc [ ("title", `String "Structured batch B") ];
+              ] );
+        ])
+  in
+  assert (Tool_result.is_success result);
+  let data = Tool_result.data result in
+  assert (Json_util.get_bool data "ok" = Some true);
+  assert (Json_util.get_int data "count" = Some 2);
+  assert (Json_util.assoc_member_opt "result" data = None);
+  (match Json_util.assoc_member_opt "task_ids" data with
+   | Some (`List [ `String "task-001"; `String "task-002" ]) -> ()
+   | _ -> failwith "missing structured batch task_ids");
+  match Json_util.get_string data "summary" with
+  | Some summary -> assert (str_contains summary "Added 2 tasks")
+  | None -> failwith "missing summary")
+
 (* Test dispatch tasks *)
 let () = test "dispatch_tasks" (fun () ->
   let ctx = make_test_ctx () in


### PR DESCRIPTION
## Summary
- mint a contract-harness admin bearer token through `masc login --json` before starting the temporary MCP server
- pass `MCP_TOKEN` through readiness probes, shared JSON-RPC helpers, and streamable HTTP contract requests
- align golden/public contract scripts with the current public tool surface (`masc_start`, real MCP sessions, current goal/board schemas)

## Validation
- `bash -n scripts/harness/contract/run_all.sh scripts/harness/contract/streamable_http_contract.sh scripts/harness/contract/golden_path_1_contract.sh scripts/harness/contract/public_tool_live_sweep.sh scripts/harness/lib/mcp_jsonrpc.sh scripts/harness/lib/server_bootstrap.sh scripts/harness/lib/test_framework.sh`
- `git diff --cached --check`
- `opam exec -- dune exec --root . bin/public_tool_manifest.exe | sed -n '/^{/,$p' | jq -r '.public_tool_names[]' | sort | rg 'masc_(dashboard|bind|agents|keeper_|webrtc_|board_post_get)'`\n\nNote: local full harness smoke was run earlier against an existing main-checkout server binary, not a freshly built branch binary. It passed streamable HTTP and golden path after these changes, then stopped at public-surface drift because that stale binary did not expose `masc_dashboard` while current source does. CI should be the branch-build authority for the full harness.