### PR TITLE
fix(fusion): skip judge when no panel answered instead of fabricating a result

### DIFF
--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -211,6 +211,14 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
              강제할 때까지 defer). 단일-심판 노드는 [Single], 1차 심판 실패는 단일-심판
              위상에선 그대로 전파(Simple과 동일 에러 의미)하고 실패 노드 한 건만 남긴다. *)
           let judge_full, judge_nodes =
+            match Fusion_types.judge_skip_reason panel with
+            | Some reason ->
+              (* 패널 전원 실패 — 종합할 답이 없다. judge를 빈 패널로 호출하면 빈
+                 <panel_answers>로 환각 종합을 만들어 0-패널 결과를 정상처럼 표출한다.
+                 judge 미실행 + 명시적 실패로 완료한다(기존 judge-error 표시 경로 재사용,
+                 JOJ all-fail과 동일 의미). judge_nodes=[] — 실행된 심판 없음(RFC-0284). *)
+              (Error (reason, Fusion_types.zero_usage), [])
+            | None ->
             match topology with
             | Fusion_types.Simple ->
               (match run_single_judge () with

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -90,6 +90,20 @@ let answered_of outcomes =
     (function Answered a -> Some a | Failed _ -> None)
     outcomes
 
+let no_panel_answers_error = "all panels failed: no answered panel to synthesize"
+
+(* RFC-0252 left the all-panel-fail case unspecified. The judge prompt is built
+   from [answered_of] only, so when every panel [Failed] the judge is handed an
+   empty <panel_answers> block and fabricates a synthesis from no evidence — the
+   run then surfaces a confident result backed by zero panels (observed: a
+   0-success panel still produced a fusion result). This pure decision lets the
+   orchestrator skip the judge in that case: [Some reason] => complete with
+   [judge = Error reason]; [None] => >= 1 panel answered, run the judge. *)
+let judge_skip_reason outcomes =
+  match answered_of outcomes with
+  | [] -> Some no_panel_answers_error
+  | _ :: _ -> None
+
 type claim =
   { text : string
   ; supporting_models : string list

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -98,6 +98,16 @@ type panel_outcome =
 (** 성공한 답만 추출 (심판 입력 구성용). 입력 순서 보존. *)
 val answered_of : panel_outcome list -> panel_answer list
 
+val no_panel_answers_error : string
+(** Canonical error surfaced when the judge is skipped because no panel answered. *)
+
+val judge_skip_reason : panel_outcome list -> string option
+(** [Some reason] when no panel member answered (every outcome is [Failed]) — the
+    orchestrator then skips the judge and completes with [judge = Error reason]
+    instead of running it. [None] when >= 1 panel [Answered]. Guards against the
+    judge fabricating a synthesis from an empty [<panel_answers>] block when all
+    panels failed (RFC-0252 left all-panel-fail unspecified). *)
+
 (** {1 심판 구조화 출력}
 
     [Structured.extract]의 provider-native JSON schema로 강제 파싱되는 닫힌 타입.

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1055,6 +1055,22 @@ let test_judge_outcome_roundtrip () =
       | Error e -> Alcotest.failf "judge_outcome roundtrip failed: %s" e)
     nodes
 
+(* RFC-0252 all-panel-fail guard: 0 answered panels => judge skipped with the
+   canonical error; >= 1 answered => judge runs. Reverting [judge_skip_reason]
+   to always-[None] turns the first two checks red (non-vacuous). *)
+let test_judge_skip_reason () =
+  let answered m a : panel_outcome = Answered { model = m; answer = a; usage = zero_usage } in
+  let failed m : panel_outcome = Failed { failed_model = m; reason = Provider_error "x" } in
+  let opt = Alcotest.(option string) in
+  Alcotest.(check opt) "all failed => skip" (Some no_panel_answers_error)
+    (judge_skip_reason [ failed "a"; failed "b" ]);
+  Alcotest.(check opt) "empty panel => skip" (Some no_panel_answers_error)
+    (judge_skip_reason []);
+  Alcotest.(check opt) "one answered => run" None
+    (judge_skip_reason [ failed "a"; answered "b" "hi" ]);
+  Alcotest.(check opt) "all answered => run" None
+    (judge_skip_reason [ answered "a" "x"; answered "b" "y" ])
+
 let () =
   Alcotest.run "fusion_core"
     [ ( "gate"
@@ -1139,4 +1155,6 @@ let () =
         ] )
     ; ( "judge_outcome"
       , [ Alcotest.test_case "roundtrip" `Quick test_judge_outcome_roundtrip ] )
+    ; ( "panel_guard"
+      , [ Alcotest.test_case "judge_skip_reason" `Quick test_judge_skip_reason ] )
     ]


### PR DESCRIPTION
## 문제
퓨전 run에서 **패널 0명 성공인데 결과(종합)가 나옴**(대시보드 관측, run `fus-b656c1b8...`).

근본 원인: judge 프롬프트는 `answered_of panel`(성공 패널만)로 구성되는데, 전원 실패 시 `answered_of = []` → judge에게 빈 `<panel_answers></panel_answers>` 전송 → judge LLM이 무에서 종합을 날조. judge 호출 전 "성공 패널 ≥ 1" 가드가 없음.

비대칭이 증거: orchestrator는 "심판 전원 실패"(JOJ `ok_priors = []`)는 `Error`로 막는데, "패널 전원 실패"는 안 막음. RFC-0252는 all-panel-fail을 미규정 → unspecified gap.

## 수정
`Fusion_types.judge_skip_reason`(순수): `answered_of panel = []`면 `Some no_panel_answers_error`, 아니면 `None`. orchestrator는 topology dispatch 전에 이를 검사해, skip 시 judge 미실행 + `judge = Error` 로 완료. 기존 judge-error sink 경로(JOJ all-fail이 이미 쓰는 것)를 재사용 → 대시보드/챗은 "judge failed" 표시(날조 종합 없음).

≥ 1 floor만 적용(0 → 실패). ≥ 2 / 과반 같은 품질 임계는 별도 enhancement.

## 변경 파일
- `lib/fusion_core/fusion_types.{ml,mli}`: 순수 `judge_skip_reason` + named error
- `lib/fusion/fusion_orchestrator.ml`: topology dispatch 앞 가드 (단일 choke point — 모든 위상 커버)
- `test/fusion_core/test_fusion.ml`: 결정 잠금(revert → red)

## 로컬 검증 (self-review)
- fusion_core 테스트 green: `panel_guard/judge_skip_reason [OK]`, 60 tests run.
- 메인 lib 컴파일 OK (`dune build --root . lib/masc.cma` rc=0) — orchestrator 가드 타입체크.
- sink read-verify: `judge_meta` `Error → {status: failed}`, `judges: []` 안전(List.map over []), chat lane `Error → "judge failed"` — crash 없음.

## 남은 미검증
- orchestrator `run` 전체 통합(mock net all-fail → sink)은 unit-test 없음(기존에 orchestrator mock 하네스 부재). read + compile + 기존 Error-judge 경로(JOJ all-fail이 사용 중) 재사용으로 대체.

## 워크어라운드 self-check (CLAUDE.md)
근본 수정임. 증상 카운트가 아니라 날조를 차단(telemetry-as-fix 아님); `answered_of`=closed sum filter(substring 분류기 아님); 리스트 `[]`/`_::_` exhaustive(catch-all 아님); N-of-M/cap/cooldown/dedup/repair 해당 없음.

설계 SSOT: RFC-0252 §4 (fusion orchestrator).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
