### PR TITLE
fix(test): cover keeper tool matrix contracts

### DIFF
--- a/bin/gen_tool_descriptors.ml
+++ b/bin/gen_tool_descriptors.ml
@@ -85,6 +85,23 @@ let masc_tool_help_spec : tool_spec =
 
 let dashboard_scope_enum_strings = [ "all"; "current" ]
 
+let masc_dashboard_spec : tool_spec =
+  { name = "masc_dashboard"
+  ; description =
+      "Return a concise workspace dashboard summary for the current project. Use scope \
+       to choose the current task-focused view or the full workspace view."
+  ; parameters =
+      [ { p_name = "scope"
+        ; p_type = T_string { enum = Some dashboard_scope_enum_strings; default = Some "current" }
+        ; p_description = "Dashboard scope: current or all"
+        ; p_required = false
+        }
+      ]
+  ; additional_properties = false
+  ; behavior_contract = []
+  }
+;;
+
 let masc_gc_spec : tool_spec =
   { name = "masc_gc"
   ; description =
@@ -361,6 +378,7 @@ let masc_messages_spec : tool_spec =
 let phase6_specs : tool_spec list =
   [ masc_config_spec
   ; masc_tool_help_spec
+  ; masc_dashboard_spec
   ; masc_gc_spec
   ; masc_tool_stats_spec
   ; masc_cleanup_zombies_spec

--- a/lib/board_tool_adapter/board_tool_registry.ml
+++ b/lib/board_tool_adapter/board_tool_registry.ml
@@ -207,3 +207,46 @@ let tools =
   ; Board_tool_schemas.tool_sub_board_delete
   ]
 ;;
+
+let schema_for_board_name board_name =
+  let name = Tool_name.Board_name.to_string board_name in
+  List.find_opt
+    (fun (schema : Masc_domain.tool_schema) -> String.equal schema.name name)
+    tools
+;;
+
+let identity_fields_for_board_name = function
+  | Tool_name.Board_name.Board_post
+  | Tool_name.Board_name.Board_comment -> [ "author" ]
+  | Tool_name.Board_name.Board_vote
+  | Tool_name.Board_name.Board_comment_vote -> [ "voter" ]
+  | Tool_name.Board_name.Board_reaction -> [ "user_id" ]
+  | Tool_name.Board_name.Board_sub_board_create -> [ "owner" ]
+  | Tool_name.Board_name.Board_curation_submit -> [ "submitted_by" ]
+  | Tool_name.Board_name.Board_cleanup
+  | Tool_name.Board_name.Board_curation_read
+  | Tool_name.Board_name.Board_delete
+  | Tool_name.Board_name.Board_post_get
+  | Tool_name.Board_name.Board_hearths
+  | Tool_name.Board_name.Board_list
+  | Tool_name.Board_name.Board_profile
+  | Tool_name.Board_name.Board_search
+  | Tool_name.Board_name.Board_stats
+  | Tool_name.Board_name.Board_sub_board_delete
+  | Tool_name.Board_name.Board_sub_board_get
+  | Tool_name.Board_name.Board_sub_board_list
+  | Tool_name.Board_name.Board_sub_board_update -> []
+;;
+
+let identity_input_fields =
+  [ Tool_name.Board_name.Board_post
+  ; Tool_name.Board_name.Board_comment
+  ; Tool_name.Board_name.Board_vote
+  ; Tool_name.Board_name.Board_comment_vote
+  ; Tool_name.Board_name.Board_reaction
+  ; Tool_name.Board_name.Board_sub_board_create
+  ; Tool_name.Board_name.Board_curation_submit
+  ]
+  |> List.concat_map identity_fields_for_board_name
+  |> List.sort_uniq String.compare
+;;

--- a/lib/board_tool_adapter/board_tool_registry.mli
+++ b/lib/board_tool_adapter/board_tool_registry.mli
@@ -1,3 +1,12 @@
 (** Tool schemas advertised by the board MCP adapter. *)
 
 val tools : Masc_domain.tool_schema list
+
+val schema_for_board_name : Tool_name.Board_name.t -> Masc_domain.tool_schema option
+(** Lookup the advertised schema for a typed [masc_board_*] tool name. *)
+
+val identity_fields_for_board_name : Tool_name.Board_name.t -> string list
+(** Input fields whose value is runtime-owned identity for this board tool. *)
+
+val identity_input_fields : string list
+(** Union of runtime-owned identity input fields used by board tools. *)

--- a/lib/keeper/keeper_tool_board_runtime.ml
+++ b/lib/keeper/keeper_tool_board_runtime.ml
@@ -212,7 +212,9 @@ let handle_keeper_board_tool
       Tool_name.Board_name.Board_curation_submit
       (assoc_override_string "submitted_by" meta.name args)
   | "keeper_board_sub_board_create" ->
-    dispatch_board Tool_name.Board_name.Board_sub_board_create args
+    dispatch_board
+      Tool_name.Board_name.Board_sub_board_create
+      (assoc_override_string "owner" meta.name args)
   | "keeper_board_sub_board_list" ->
     dispatch_board Tool_name.Board_name.Board_sub_board_list args
   | "keeper_board_sub_board_get" ->

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -673,10 +673,84 @@ let passthrough_object_schema =
     [ "type", `String "object"; "additionalProperties", `Bool true ]
 ;;
 
-let find_taskboard_schema_opt name =
+let find_schema_input_opt schemas name =
   List.find_opt (fun (s : Masc_domain.tool_schema) -> String.equal s.name name)
-    Tool_shard_types.taskboard_tools
+    schemas
   |> Option.map (fun (s : Masc_domain.tool_schema) -> s.input_schema)
+;;
+
+let find_taskboard_schema_opt name =
+  find_schema_input_opt Tool_shard_types.taskboard_tools name
+;;
+
+let find_voice_schema_opt name =
+  find_schema_input_opt Tool_shard_types.voice_tools name
+;;
+
+let find_base_schema_opt name =
+  find_schema_input_opt Tool_shard_types.base_tools name
+;;
+
+let remove_required_fields removed schema =
+  match schema with
+  | `Assoc fields ->
+      let fields =
+        List.map
+          (function
+            | ("required", `List required) ->
+                ( "required",
+                  `List
+                    (List.filter
+                       (function
+                         | `String name -> not (List.mem name removed)
+                         | _ -> true)
+                       required) )
+            | field -> field)
+          fields
+      in
+      `Assoc fields
+  | _ -> schema
+
+let keeper_board_identity_fields =
+  [ "author"; "voter"; "submitted_by"; "owner"; "user_id" ]
+
+let find_board_schema_opt name =
+  let prefix = "keeper_board_" in
+  if not (String.starts_with ~prefix name) then None
+  else
+    let suffix =
+      String.sub name (String.length prefix)
+        (String.length name - String.length prefix)
+    in
+    let board_name = "masc_board_" ^ suffix in
+    Board_tool_registry.tools
+    |> List.find_opt (fun (s : Masc_domain.tool_schema) ->
+           String.equal s.name board_name)
+    |> Option.map (fun (s : Masc_domain.tool_schema) ->
+           remove_required_fields keeper_board_identity_fields s.input_schema)
+
+let find_masc_schema_opt name =
+  [
+    Task.Schemas.schemas;
+    Tool_schemas_misc.schemas;
+    Tool_schemas_run.schemas;
+    Tool_schemas_agent.schemas;
+    Tool_schemas_workspace.schemas;
+    Tool_agent_timeline.schemas;
+    Keeper_schema.schemas;
+  ]
+  |> List.find_map (fun schemas -> find_schema_input_opt schemas name)
+
+let find_cluster_schema_opt name =
+  match find_taskboard_schema_opt name with
+  | Some _ as schema -> schema
+  | None ->
+    (match find_board_schema_opt name with
+     | Some _ as schema -> schema
+     | None ->
+       (match find_voice_schema_opt name with
+        | Some _ as schema -> schema
+        | None -> find_masc_schema_opt name))
 ;;
 
 
@@ -759,6 +833,40 @@ let person_note_set_schema =
         "string"
         "What to remember about this person. Blank clears the note \
          (tombstone)."
+    ]
+;;
+
+let memory_search_schema =
+  Option.value
+    (find_base_schema_opt "keeper_memory_search")
+    ~default:passthrough_object_schema
+;;
+
+let memory_write_schema =
+  Option.value
+    (find_base_schema_opt "keeper_memory_write")
+    ~default:passthrough_object_schema
+;;
+
+let ide_annotate_schema =
+  object_schema
+    ~required:[ "file_path"; "line_start"; "content" ]
+    [
+      property "file_path" "string" "File path to annotate.";
+      property "line_start" "integer" "One-based starting line.";
+      property "line_end" "integer" "Optional one-based ending line.";
+      property "kind" "string" "Annotation kind. Defaults to Comment.";
+      property "content" "string" "Annotation text.";
+      property "goal_id" "string" "Optional related goal ID.";
+      property "task_id" "string" "Optional related task ID.";
+      property "board_post_id" "string" "Optional related board post ID.";
+      property "comment_id" "string" "Optional related board comment ID.";
+      property "pr_id" "string" "Optional related pull request ID.";
+      property "git_ref" "string" "Optional related git ref.";
+      property "log_id" "string" "Optional related log ID.";
+      property "session_id" "string" "Optional related session ID.";
+      property "operation_id" "string" "Optional related operation ID.";
+      property "worker_run_id" "string" "Optional related worker run ID.";
     ]
 ;;
 
@@ -892,7 +1000,7 @@ let cluster_descriptor ~id ~name ~description ~handler ~readonly
     else write_in_process_policy ~inline_safe ~maintenance_only ()
   in
   let input_schema =
-    match find_taskboard_schema_opt name with
+    match find_cluster_schema_opt name with
     | Some schema -> schema
     | None -> passthrough_object_schema
   in
@@ -1150,14 +1258,14 @@ let internal_descriptors : t list =
       ~name:"keeper_memory_search"
       ~description:
         "Search keeper memory (semantic + recency) for relevant prior context."
-      ~input_schema:passthrough_object_schema
+      ~input_schema:memory_search_schema
       ~policy:(read_only_in_process_policy ())
       ~handler:Tool_memory_search
   ; in_process_descriptor
       ~id:"keeper.memory.write"
       ~name:"keeper_memory_write"
       ~description:"Persist a memory entry for this keeper."
-      ~input_schema:passthrough_object_schema
+      ~input_schema:memory_write_schema
       ~policy:(write_in_process_policy ())
       ~handler:Tool_memory_write
     (* ── library (RFC-0179 PR-3) ──────────────────────────────── *)
@@ -1217,7 +1325,7 @@ let internal_descriptors : t list =
       ~id:"keeper.ide.annotate"
       ~name:"keeper_ide_annotate"
       ~description:"Emit an IDE annotation event for the current keeper."
-      ~input_schema:passthrough_object_schema
+      ~input_schema:ide_annotate_schema
       ~policy:(write_in_process_policy ())
       ~handler:Tool_ide_annotate
     (* ── fusion deliberation (RFC-0252) ───────────────────────── *)

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -86,6 +86,7 @@ type t =
   ; sandbox : sandbox
   ; runtime_handler : runtime_handler
   ; translate : Yojson.Safe.t -> Yojson.Safe.t
+  ; validate_translated_input : bool
   ; receipt_labels : (string * string) list
   ; eval_tags : string list
   }
@@ -419,6 +420,7 @@ let translate_search_files input =
 let search_files_readonly_of_input _input = Some true
 
 let descriptor_with_public_aliases
+      ?(validate_translated_input = true)
       ~public_aliases
       ~id
       ~public_name
@@ -454,12 +456,14 @@ let descriptor_with_public_aliases
   ; sandbox
   ; runtime_handler
   ; translate
+  ; validate_translated_input
   ; receipt_labels
   ; eval_tags = []
   }
 ;;
 
 let descriptor
+      ?validate_translated_input
       ~id
       ~public_name
       ~internal_name
@@ -473,6 +477,7 @@ let descriptor
       ~translate
   =
   descriptor_with_public_aliases
+    ?validate_translated_input
     ~public_aliases:[]
     ~id
     ~public_name
@@ -559,6 +564,7 @@ let public_descriptors =
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_read_file
+      ~validate_translated_input:false
       ~translate:translate_read_file
   ; descriptor
       ~id:"agent.edit_file"
@@ -576,6 +582,7 @@ let public_descriptors =
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_edit_file
+      ~validate_translated_input:false
       ~translate:translate_edit_file
   ; descriptor
       ~id:"agent.write_file"
@@ -593,6 +600,7 @@ let public_descriptors =
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_write_file
+      ~validate_translated_input:false
       ~translate:translate_write_file
   ; descriptor
       ~id:"agent.search_web"
@@ -691,13 +699,21 @@ let find_base_schema_opt name =
   find_schema_input_opt Tool_shard_types.base_tools name
 ;;
 
-let remove_required_fields removed schema =
+let remove_schema_fields removed schema =
   match schema with
   | `Assoc fields ->
       let fields =
-        List.map
+        List.filter_map
           (function
+            | ("properties", `Assoc properties) ->
+              Some
+                ( "properties",
+                  `Assoc
+                    (List.filter
+                       (fun (name, _) -> not (List.mem name removed))
+                       properties) )
             | ("required", `List required) ->
+              Some
                 ( "required",
                   `List
                     (List.filter
@@ -705,43 +721,38 @@ let remove_required_fields removed schema =
                          | `String name -> not (List.mem name removed)
                          | _ -> true)
                        required) )
-            | field -> field)
+            | field -> Some field)
           fields
       in
       `Assoc fields
   | _ -> schema
 
-let keeper_board_identity_fields =
-  [ "author"; "voter"; "submitted_by"; "owner"; "user_id" ]
-
 let find_board_schema_opt name =
-  let prefix = "keeper_board_" in
-  if not (String.starts_with ~prefix name) then None
-  else
-    let suffix =
-      String.sub name (String.length prefix)
-        (String.length name - String.length prefix)
-    in
-    let board_name = "masc_board_" ^ suffix in
-    Board_tool_registry.tools
-    |> List.find_opt (fun (s : Masc_domain.tool_schema) ->
-           String.equal s.name board_name)
+  match Keeper_tool_name.masc_board_name_of_keeper_name name with
+  | None -> None
+  | Some board_name ->
+    Board_tool_registry.schema_for_board_name board_name
     |> Option.map (fun (s : Masc_domain.tool_schema) ->
-           remove_required_fields keeper_board_identity_fields s.input_schema)
+         remove_schema_fields
+           (Board_tool_registry.identity_fields_for_board_name board_name)
+           s.input_schema)
 
 let find_masc_schema_opt name =
-  [
-    Task.Schemas.schemas;
-    Tool_schemas_misc.schemas;
-    Tool_schemas_run.schemas;
-    Tool_schemas_agent.schemas;
-    Tool_schemas_workspace.schemas;
-    Tool_agent_timeline.schemas;
-    Keeper_schema.schemas;
-  ]
-  |> List.find_map (fun schemas -> find_schema_input_opt schemas name)
+  match Tools.find_tool name with
+  | Some schema -> Some schema.input_schema
+  | None ->
+    (* [Tool_agent_timeline] is registered by the main composition root and is
+       intentionally absent from [Tools.all_schemas_extended] to avoid pulling
+       keeper/runtime dependencies into the neutral schema aggregate. *)
+    (match find_schema_input_opt Tool_agent_timeline.schemas name with
+     | Some _ as schema -> schema
+     | None -> find_schema_input_opt Keeper_schema.schemas name)
 
 let find_cluster_schema_opt name =
+  (* Priority preserves the historical hidden keeper namespace ownership:
+     keeper taskboard wrappers first, then typed board wrappers, voice,
+     then public masc_* aggregates. The namespaces are expected to be
+     disjoint; this order is not a conflict resolver. *)
   match find_taskboard_schema_opt name with
   | Some _ as schema -> schema
   | None ->
@@ -752,6 +763,11 @@ let find_cluster_schema_opt name =
         | Some _ as schema -> schema
         | None -> find_masc_schema_opt name))
 ;;
+
+let required_base_schema_input name =
+  match find_base_schema_opt name with
+  | Some schema -> schema
+  | None -> failwith ("missing base tool schema for " ^ name)
 
 
 let tool_search_schema =
@@ -837,37 +853,15 @@ let person_note_set_schema =
 ;;
 
 let memory_search_schema =
-  Option.value
-    (find_base_schema_opt "keeper_memory_search")
-    ~default:passthrough_object_schema
+  required_base_schema_input "keeper_memory_search"
 ;;
 
 let memory_write_schema =
-  Option.value
-    (find_base_schema_opt "keeper_memory_write")
-    ~default:passthrough_object_schema
+  required_base_schema_input "keeper_memory_write"
 ;;
 
 let ide_annotate_schema =
-  object_schema
-    ~required:[ "file_path"; "line_start"; "content" ]
-    [
-      property "file_path" "string" "File path to annotate.";
-      property "line_start" "integer" "One-based starting line.";
-      property "line_end" "integer" "Optional one-based ending line.";
-      property "kind" "string" "Annotation kind. Defaults to Comment.";
-      property "content" "string" "Annotation text.";
-      property "goal_id" "string" "Optional related goal ID.";
-      property "task_id" "string" "Optional related task ID.";
-      property "board_post_id" "string" "Optional related board post ID.";
-      property "comment_id" "string" "Optional related board comment ID.";
-      property "pr_id" "string" "Optional related pull request ID.";
-      property "git_ref" "string" "Optional related git ref.";
-      property "log_id" "string" "Optional related log ID.";
-      property "session_id" "string" "Optional related session ID.";
-      property "operation_id" "string" "Optional related operation ID.";
-      property "worker_run_id" "string" "Optional related worker run ID.";
-    ]
+  required_base_schema_input "keeper_ide_annotate"
 ;;
 
 let masc_fusion_schema =
@@ -1002,6 +996,10 @@ let cluster_descriptor ~id ~name ~description ~handler ~readonly
   let input_schema =
     match find_cluster_schema_opt name with
     | Some schema -> schema
+    | None
+      when Option.is_some
+             (Keeper_tool_name.masc_board_name_of_keeper_name name) ->
+      failwith ("missing board registry schema for " ^ name)
     | None -> passthrough_object_schema
   in
   in_process_descriptor

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -499,7 +499,7 @@ let descriptor
     ~backend
     ~sandbox
     ~runtime_handler
-      ~translate
+    ~translate
 ;;
 
 let with_eval_tags eval_tags descriptor =
@@ -710,7 +710,9 @@ let find_voice_schema_opt name =
 ;;
 
 let find_base_schema_opt name =
-  find_schema_input_opt Tool_shard_types.base_tools name
+  match find_schema_input_opt Tool_shard_types.base_tools name with
+  | Some _ as schema -> schema
+  | None -> find_schema_input_opt Tool_shard_types.filesystem_tools name
 ;;
 
 let remove_schema_fields removed schema =

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -194,6 +194,16 @@ let closed_object_schema ?(required = []) properties =
   | schema -> schema
 ;;
 
+let unavailable_input_schema reason =
+  `Assoc
+    [ "type", `String "object"
+    ; "description", `String reason
+    ; "properties", `Assoc []
+    ; "required", `List [ `String "__masc_unavailable_schema" ]
+    ; "additionalProperties", `Bool false
+    ]
+;;
+
 let execute_schema = Tool_shard_types.tool_execute_schema.input_schema
 
 let read_file_schema =
@@ -771,7 +781,7 @@ let find_cluster_schema_opt name =
 let required_base_schema_input name =
   match find_base_schema_opt name with
   | Some schema -> schema
-  | None -> failwith ("missing base tool schema for " ^ name)
+  | None -> unavailable_input_schema ("missing base tool schema for " ^ name)
 
 
 let tool_search_schema =
@@ -1004,7 +1014,7 @@ let cluster_descriptor ~id ~name ~description ~handler ~readonly
     | None
       when Option.is_some
              (Keeper_tool_name.masc_board_name_of_keeper_name name) ->
-      failwith ("missing board registry schema for " ^ name)
+      unavailable_input_schema ("missing board registry schema for " ^ name)
     | None -> passthrough_object_schema
   in
   in_process_descriptor

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -420,7 +420,7 @@ let translate_search_files input =
 let search_files_readonly_of_input _input = Some true
 
 let descriptor_with_public_aliases
-      ?(validate_translated_input = true)
+      ~validate_translated_input
       ~public_aliases
       ~id
       ~public_name
@@ -463,7 +463,7 @@ let descriptor_with_public_aliases
 ;;
 
 let descriptor
-      ?validate_translated_input
+      ~validate_translated_input
       ~id
       ~public_name
       ~internal_name
@@ -477,7 +477,7 @@ let descriptor
       ~translate
   =
   descriptor_with_public_aliases
-    ?validate_translated_input
+    ~validate_translated_input
     ~public_aliases:[]
     ~id
     ~public_name
@@ -518,6 +518,7 @@ let public_descriptors =
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_execute
+      ~validate_translated_input:true
       ~translate:translate_identity
   ; descriptor_with_public_aliases
       ~id:"agent.search_files"
@@ -542,6 +543,7 @@ let public_descriptors =
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_search_files
+      ~validate_translated_input:true
       ~translate:translate_search_files
   ; descriptor
       ~id:"agent.read_file"
@@ -624,6 +626,7 @@ let public_descriptors =
       ~backend:Ocaml_runtime
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_masc_misc_dispatch
+      ~validate_translated_input:true
       ~translate:translate_identity
   ; descriptor
       ~id:"agent.fetch_web"
@@ -647,6 +650,7 @@ let public_descriptors =
       ~backend:Ocaml_runtime
       ~sandbox:No_sandbox
       ~runtime_handler:Tool_masc_misc_dispatch
+      ~validate_translated_input:true
       ~translate:translate_identity
   ]
 ;;
@@ -976,6 +980,7 @@ let in_process_descriptor ~id ~name ~description ~input_schema ~policy ~handler 
     ~backend:Ocaml_runtime
     ~sandbox:No_sandbox
     ~runtime_handler:handler
+    ~validate_translated_input:true
     ~translate:translate_identity
 ;;
 

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -91,6 +91,11 @@ type t =
   ; sandbox : sandbox
   ; runtime_handler : runtime_handler
   ; translate : Yojson.Safe.t -> Yojson.Safe.t
+  ; validate_translated_input : bool
+  (** Whether alias dispatch should validate [translate input] against the
+      internal handler schema. Defaults to true; false is reserved for
+      descriptor-owned public aliases whose runtime schema still differs from
+      the public schema. *)
   ; receipt_labels : (string * string) list
   (** Evaluation-only semantic tags emitted in route evidence. These tags
       support replay/harness scoring and are not runtime selection policy. *)

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -286,18 +286,14 @@ let handle_board ~(meta : keeper_meta) ~name ~args =
 
 let handle_masc_board ~(meta : keeper_meta) ~name ~args =
   let args =
-    match name with
-    | "masc_board_post" | "masc_board_comment" ->
-      Keeper_tool_shared_runtime.assoc_override_string "author" meta.name args
-    | "masc_board_vote" | "masc_board_comment_vote" ->
-      Keeper_tool_shared_runtime.assoc_override_string "voter" meta.name args
-    | "masc_board_reaction" ->
-      Keeper_tool_shared_runtime.assoc_override_string "user_id" meta.name args
-    | "masc_board_sub_board_create" ->
-      Keeper_tool_shared_runtime.assoc_override_string "owner" meta.name args
-    | "masc_board_curation_submit" ->
-      Keeper_tool_shared_runtime.assoc_override_string "submitted_by" meta.name args
-    | _ -> args
+    match Tool_name.Board_name.of_string name with
+    | None -> args
+    | Some board_name ->
+      List.fold_left
+        (fun args field ->
+           Keeper_tool_shared_runtime.assoc_override_string field meta.name args)
+        args
+        (Board_tool_registry.identity_fields_for_board_name board_name)
   in
   let result =
     Board_tool_dispatch.handle_tool name args

--- a/lib/keeper/keeper_tool_in_process_runtime.ml
+++ b/lib/keeper/keeper_tool_in_process_runtime.ml
@@ -284,7 +284,21 @@ let handle_board ~(meta : keeper_meta) ~name ~args =
   Keeper_tool_board_runtime.handle_keeper_board_tool ~meta ~name ~args
 ;;
 
-let handle_masc_board ~name ~args =
+let handle_masc_board ~(meta : keeper_meta) ~name ~args =
+  let args =
+    match name with
+    | "masc_board_post" | "masc_board_comment" ->
+      Keeper_tool_shared_runtime.assoc_override_string "author" meta.name args
+    | "masc_board_vote" | "masc_board_comment_vote" ->
+      Keeper_tool_shared_runtime.assoc_override_string "voter" meta.name args
+    | "masc_board_reaction" ->
+      Keeper_tool_shared_runtime.assoc_override_string "user_id" meta.name args
+    | "masc_board_sub_board_create" ->
+      Keeper_tool_shared_runtime.assoc_override_string "owner" meta.name args
+    | "masc_board_curation_submit" ->
+      Keeper_tool_shared_runtime.assoc_override_string "submitted_by" meta.name args
+    | _ -> args
+  in
   let result =
     Board_tool_dispatch.handle_tool name args
   in

--- a/lib/keeper/keeper_tool_in_process_runtime.mli
+++ b/lib/keeper/keeper_tool_in_process_runtime.mli
@@ -99,9 +99,9 @@ val handle_board
   -> string
 
 (** [handle_masc_board] dispatches public MCP [masc_board_*] tools through
-    the existing board dispatcher while allowing descriptor route evidence
-    and receipt summaries to resolve the tool. *)
-val handle_masc_board : name:string -> args:Yojson.Safe.t -> string
+    the existing board dispatcher while binding board write identity to
+    [meta.name]. *)
+val handle_masc_board : meta:keeper_meta -> name:string -> args:Yojson.Safe.t -> string
 
 (** RFC-0182 §3.1 — [handle_masc_task] is the descriptor-projection
     cluster handler for [masc_task_*] tools (add_task / batch_add_tasks /

--- a/lib/keeper/keeper_tool_policy.ml
+++ b/lib/keeper/keeper_tool_policy.ml
@@ -404,16 +404,16 @@ let descriptor_model_tool_schemas () =
 (** Shared schema assembly: computes the full tool schema list once.
     [masc_schemas_fn] selects policy-filtered or universe-filtered MASC schemas
     depending on the caller's access scope. Descriptor-backed internal tools
-    are appended as a keeper-local schema source so descriptor-only tools such
-    as [masc_fusion] cannot appear in candidate names without a matching
-    Agent.run [Tool.t]. *)
+    are first so descriptor-owned schemas win dedupe over older shard entries,
+    and so descriptor-only tools such as [masc_fusion] cannot appear in
+    candidate names without a matching Agent.run [Tool.t]. *)
 let all_keeper_schemas ~(masc_schemas_fn : keeper_meta -> Masc_domain.tool_schema list)
     (meta : keeper_meta) : Masc_domain.tool_schema list =
-  keeper_model_tools
+  descriptor_model_tool_schemas ()
+  @ keeper_model_tools
   @ keeper_voice_tool_schemas
   @ [ keeper_tool_search_schema ]
   @ (masc_schemas_fn meta)
-  @ descriptor_model_tool_schemas ()
 
 (** Filter schemas by a set of allowed names.  Uses Hashtbl for O(1) lookup
     instead of List.mem (O(n) per schema). *)

--- a/lib/keeper/keeper_tool_runtime.ml
+++ b/lib/keeper/keeper_tool_runtime.ml
@@ -218,7 +218,11 @@ let handle_in_process ctx descriptor args =
     Some
       (Keeper_tool_in_process_runtime.handle_board ~meta:ctx.meta ~name ~args)
   | Tool_masc_board_dispatch ->
-    Some (Keeper_tool_in_process_runtime.handle_masc_board ~name ~args)
+    Some
+      (Keeper_tool_in_process_runtime.handle_masc_board
+         ~meta:ctx.meta
+         ~name
+         ~args)
   | Tool_masc_task_dispatch ->
     Some
       (Keeper_tool_in_process_runtime.handle_masc_task

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -176,10 +176,10 @@ let make_tool_bundle
                        ~tool_name:public_name
                        ~input
                    with
-                   | Some result -> result
-                   | None -> Ok input)
+                 | Some result -> result
+                 | None -> Ok input)
                  ~translate_input:descriptor.translate
-                 ~validate_translated_input:false
+                 ~validate_translated_input:descriptor.validate_translated_input
                  ~failure_counts
                  ()
              in

--- a/lib/keeper/keeper_tools_oas_bundle.ml
+++ b/lib/keeper/keeper_tools_oas_bundle.ml
@@ -179,6 +179,7 @@ let make_tool_bundle
                    | Some result -> result
                    | None -> Ok input)
                  ~translate_input:descriptor.translate
+                 ~validate_translated_input:false
                  ~failure_counts
                  ()
              in

--- a/lib/keeper/keeper_tools_oas_handler.ml
+++ b/lib/keeper/keeper_tools_oas_handler.ml
@@ -24,6 +24,7 @@ let make_keeper_tool_handler
       ?clock
       ?(pre_validate_input = fun input -> Ok input)
       ?(translate_input = fun j -> j)
+      ?(validate_translated_input = true)
       ~(failure_counts : failure_counts)
       ()
   : Yojson.Safe.t -> Tool_result.result
@@ -97,7 +98,9 @@ let make_keeper_tool_handler
     | Ok pre_validated_input ->
       let input = translate_input pre_validated_input in
       (match
-         Tool_input_validation.validate_args ~schema:input_schema ~name ~args:input ()
+         if validate_translated_input
+         then Tool_input_validation.validate_args ~schema:input_schema ~name ~args:input ()
+         else Ok input
        with
        | Error validation_result -> handle_validation_error ~input validation_result
        | Ok input ->

--- a/lib/keeper/keeper_tools_oas_handler.mli
+++ b/lib/keeper/keeper_tools_oas_handler.mli
@@ -15,7 +15,9 @@
     internal tool schema used for pre-execution validation. Alias callers may
     pass [?pre_validate_input] to validate the raw public payload before
     [?translate_input] reshapes it to the internal payload (identity by
-    default). *)
+    default). When [?validate_translated_input] is [false], the translated
+    payload is dispatched after public validation; runtime handlers remain
+    responsible for their legacy internal argument checks. *)
 val make_keeper_tool_handler
   :  name:string
   -> input_schema:Yojson.Safe.t
@@ -30,6 +32,7 @@ val make_keeper_tool_handler
   -> ?pre_validate_input:
        (Yojson.Safe.t -> (Yojson.Safe.t, Tool_result.result) result)
   -> ?translate_input:(Yojson.Safe.t -> Yojson.Safe.t)
+  -> ?validate_translated_input:bool
   -> failure_counts:Keeper_tools_oas.failure_counts
   -> unit
   -> Yojson.Safe.t

--- a/lib/keeper_tooling/dune
+++ b/lib/keeper_tooling/dune
@@ -21,5 +21,6 @@
   masc.masc_exec
   masc.masc_exec_command_gate
   masc.masc_exec_shell_words
+  masc.masc_tool_dispatch
   masc_core
   yojson))

--- a/lib/keeper_tooling/keeper_tool_name.ml
+++ b/lib/keeper_tooling/keeper_tool_name.ml
@@ -264,10 +264,64 @@ let is_keeper_board_tool = function
   | Voice_speak -> false
 ;;
 
+let masc_board_name_of_keeper_tool = function
+  | Board_comment -> Some Tool_name.Board_name.Board_comment
+  | Board_comment_vote -> Some Tool_name.Board_name.Board_comment_vote
+  | Board_curation_read -> Some Tool_name.Board_name.Board_curation_read
+  | Board_curation_submit -> Some Tool_name.Board_name.Board_curation_submit
+  | Board_post_get -> Some Tool_name.Board_name.Board_post_get
+  | Board_list -> Some Tool_name.Board_name.Board_list
+  | Board_post -> Some Tool_name.Board_name.Board_post
+  | Board_search -> Some Tool_name.Board_name.Board_search
+  | Board_stats -> Some Tool_name.Board_name.Board_stats
+  | Board_sub_board_create -> Some Tool_name.Board_name.Board_sub_board_create
+  | Board_sub_board_delete -> Some Tool_name.Board_name.Board_sub_board_delete
+  | Board_sub_board_get -> Some Tool_name.Board_name.Board_sub_board_get
+  | Board_sub_board_list -> Some Tool_name.Board_name.Board_sub_board_list
+  | Board_sub_board_update -> Some Tool_name.Board_name.Board_sub_board_update
+  | Board_vote -> Some Tool_name.Board_name.Board_vote
+  | Execute
+  | Broadcast
+  | Context_status
+  | Fs_edit
+  | Fs_write
+  | Fs_read
+  | Ide_annotate
+  | Handoff
+  | Library_read
+  | Library_search
+  | Memory_search
+  | Memory_write
+  | Search_files
+  | Surface_read
+  | Surface_post
+  | Person_note_set
+  | Task_claim
+  | Task_create
+  | Task_done
+  | Tasks_audit
+  | Tasks_list
+  | Time_now
+  | Tool_search
+  | Tools_list
+  | Voice_agent
+  | Voice_listen
+  | Voice_session_end
+  | Voice_session_start
+  | Voice_sessions
+  | Voice_speak -> None
+;;
+
+let masc_board_name_of_keeper_name name =
+  match of_string name with
+  | Some tool -> masc_board_name_of_keeper_tool tool
+  | None -> None
+;;
+
 let is_board_surface_name name =
   match of_string name with
   | Some tool -> is_keeper_board_tool tool
-  | None -> String.starts_with ~prefix:"masc_board_" name
+  | None -> Option.is_some (Tool_name.Board_name.of_string name)
 ;;
 
 let strip_mcp_masc_prefix name =
@@ -276,19 +330,35 @@ let strip_mcp_masc_prefix name =
   else name
 ;;
 
+let is_board_write_name = function
+  | Tool_name.Board_name.Board_comment
+  | Tool_name.Board_name.Board_curation_submit
+  | Tool_name.Board_name.Board_post
+  | Tool_name.Board_name.Board_vote -> true
+  | Tool_name.Board_name.Board_cleanup
+  | Tool_name.Board_name.Board_comment_vote
+  | Tool_name.Board_name.Board_curation_read
+  | Tool_name.Board_name.Board_delete
+  | Tool_name.Board_name.Board_post_get
+  | Tool_name.Board_name.Board_hearths
+  | Tool_name.Board_name.Board_list
+  | Tool_name.Board_name.Board_profile
+  | Tool_name.Board_name.Board_reaction
+  | Tool_name.Board_name.Board_search
+  | Tool_name.Board_name.Board_stats
+  | Tool_name.Board_name.Board_sub_board_create
+  | Tool_name.Board_name.Board_sub_board_delete
+  | Tool_name.Board_name.Board_sub_board_get
+  | Tool_name.Board_name.Board_sub_board_list
+  | Tool_name.Board_name.Board_sub_board_update -> false
+;;
+
 let is_board_write_surface_name name =
   let name = strip_mcp_masc_prefix name in
-  match of_string name with
-  | Some Board_comment
-  | Some Board_curation_submit
-  | Some Board_post
-  | Some Board_vote -> true
-  | Some _ | None ->
-    List.mem
-      name
-      [ "masc_board_comment"
-      ; "masc_board_curation_submit"
-      ; "masc_board_post"
-      ; "masc_board_vote"
-      ]
+  match masc_board_name_of_keeper_name name with
+  | Some board_name -> is_board_write_name board_name
+  | None ->
+    (match Tool_name.Board_name.of_string name with
+     | Some board_name -> is_board_write_name board_name
+     | None -> false)
 ;;

--- a/lib/keeper_tooling/keeper_tool_name.mli
+++ b/lib/keeper_tooling/keeper_tool_name.mli
@@ -59,6 +59,15 @@ val to_string : t -> string
 val of_string : string -> t option
 val pp : Format.formatter -> t -> unit
 
+val masc_board_name_of_keeper_tool : t -> Tool_name.Board_name.t option
+(** Typed mapping from keeper-owned board wrapper names to the public
+    [masc_board_*] board tool vocabulary. Non-board keeper names return
+    [None]. *)
+
+val masc_board_name_of_keeper_name : string -> Tool_name.Board_name.t option
+(** Parse a [keeper_board_*] string and return the corresponding typed
+    public board tool name. *)
+
 (** Public MCP names intentionally served outside the keeper descriptor spine.
     Keep this exact allowlist on the keeper side so prefix canonicalisation
     does not depend on the MCP catalog hand-list. *)

--- a/scripts/harness/contract/golden_path_1_contract.sh
+++ b/scripts/harness/contract/golden_path_1_contract.sh
@@ -12,11 +12,13 @@
 #   MCP_URL=http://127.0.0.1:9935/mcp ./golden_path_1_contract.sh  # dev instance
 set -euo pipefail
 
-AGENT_NAME="${AGENT_NAME:-golden-path-1-harness}"
-MCP_SESSION_ID="${MCP_SESSION_ID:-gp1-$(date +%s)-$RANDOM}"
+AGENT_NAME="${AGENT_NAME:-admin}"
+MCP_SESSION_ID="${MCP_SESSION_ID:-}"
 export MCP_SESSION_ID
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+START_PATH="${BASE_PATH:-$ROOT_DIR}"
 source "${SCRIPT_DIR}/../lib/test_framework.sh"
 
 extract_text() {
@@ -25,14 +27,13 @@ extract_text() {
 
 PASS=0
 FAIL=0
-JOINED=0
 GOAL_ID=""
 
 ensure_contract_goal() {
   local goal_payload
   local goal_json
 
-  goal_payload="$(call_tool 1000 "masc_goal_upsert" '{"title":"GP1 contract goal","description":"Golden path contract harness goal","priority":1}')"
+  goal_payload="$(call_tool 1000 "masc_goal_upsert" '{"title":"GP1 contract goal","priority":1}')"
   goal_json="$(printf '%s' "$goal_payload" | extract_result)"
   GOAL_ID="$(printf '%s' "$goal_json" | jq -r '.goal_id // empty')"
   if [ -z "$GOAL_ID" ]; then
@@ -46,20 +47,17 @@ step_pass() { PASS=$((PASS + 1)); echo "  PASS"; }
 step_fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
 
 cleanup() {
-  if [ "$JOINED" -eq 1 ]; then
-    call_tool 1099 "masc_unbind" "{\"agent_name\":\"$AGENT_NAME\"}" >/dev/null 2>&1 || true
-  fi
+  :
 }
 trap cleanup EXIT
 
-# ── Step 1/8: join ──
-echo "[1/8] masc_bind"
-r1="$(call_tool 1001 "masc_bind" "{\"agent_name\":\"$AGENT_NAME\",\"capabilities\":[\"test\",\"contract\"]}")"
+# ── Step 1/8: start ──
+echo "[1/8] masc_start"
+r1="$(call_tool 1001 "masc_start" "$(jq -cn --arg path "$START_PATH" '{path:$path}')")"
 if require_ok "$r1"; then
-  JOINED=1
   step_pass
 else
-  step_fail "join rejected"
+  step_fail "start rejected"
   echo "$r1"
   exit 1
 fi
@@ -107,7 +105,7 @@ fi
 
 # ── Step 5/8: heartbeat ──
 echo "[5/8] masc_heartbeat"
-r5="$(call_tool 1005 "masc_heartbeat" "{\"agent_name\":\"$AGENT_NAME\",\"status\":\"working\",\"progress\":\"GP1 contract step 5/8\"}")"
+r5="$(call_tool 1005 "masc_heartbeat" "{}")"
 if require_ok "$r5"; then
   step_pass
 else

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 : "${MCP_URL:=http://127.0.0.1:8935/mcp}"
 : "${BASE_PATH:?BASE_PATH must be set by run_all.sh}"
-: "${AGENT_NAME:=public-tool-sweep-harness}"
-: "${MCP_SESSION_ID:=public-tool-sweep-$(date +%s)-$RANDOM}"
+: "${AGENT_NAME:=admin}"
+: "${MCP_SESSION_ID:=}"
 export MCP_SESSION_ID
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -86,13 +86,13 @@ manifest_json="$(
 )"
 expected_public_tools="$(printf '%s\n' "$manifest_json" | jq -c '.public_tool_names | sort')"
 
-echo "[1/36] initialize MCP session"
+echo "[1/31] initialize MCP session"
 initialize_mcp_session || {
   echo "FAIL: failed to initialize MCP session" >&2
   exit 1
 }
 
-echo "[2/36] tools/list matches expected public surface"
+echo "[2/31] tools/list matches expected public surface"
 tools_list_payload="$(call_method 5001 "tools/list" '{}')"
 if ! response_transport_ok "$tools_list_payload"; then
   mcp_fail_with_context "tools/list failed" "$tools_list_payload"
@@ -104,50 +104,44 @@ if [[ "$actual_public_tools" != "$expected_public_tools" ]]; then
 fi
 echo "  PASS: tools/list public surface"
 
-echo "[3/36] masc_start"
-r_start="$(call_tool 5003 "masc_start" "$(jq -cn --arg path "$BASE_PATH" --arg task_title "Public Tool Sweep Seed" '{path:$path,task_title:$task_title}')")"
+echo "[3/31] masc_start"
+r_start="$(call_tool 5003 "masc_start" "$(jq -cn --arg path "$BASE_PATH" '{path:$path}')")"
 expect_ok "masc_start" "$r_start"
 
-echo "[4/36] masc_bind"
-r_join="$(call_tool 5004 "masc_bind" "$(jq -cn --arg agent_name "$AGENT_NAME" '{agent_name:$agent_name,capabilities:["contract","public-sweep"]}')")"
-expect_ok_or_guard "masc_bind" "$r_join" 'already joined'
-
-echo "[5/36] masc_status"
+echo "[4/31] masc_status"
 r_status="$(call_tool 5005 "masc_status" '{}')"
 expect_ok "masc_status" "$r_status"
 
-echo "[6/36] masc_agents"
-r_who="$(call_tool 5006 "masc_agents" '{}')"
-expect_ok "masc_agents" "$r_who"
-
-echo "[7/36] masc_agents"
-r_agents="$(call_tool 5007 "masc_agents" '{}')"
-expect_ok "masc_agents" "$r_agents"
-
-echo "[8/36] masc_dashboard"
+echo "[5/31] masc_dashboard"
 r_dashboard="$(call_tool 5008 "masc_dashboard" '{}')"
 expect_ok "masc_dashboard" "$r_dashboard"
 
-echo "[9/36] masc_agent_card"
+echo "[6/31] masc_agent_card"
 r_agent_card="$(call_tool 5009 "masc_agent_card" '{}')"
 expect_ok "masc_agent_card" "$r_agent_card"
 
-echo "[10/36] masc_tool_help"
+echo "[7/31] masc_tool_help"
 r_tool_help="$(call_tool 5012 "masc_tool_help" '{"tool_name":"masc_status"}')"
 expect_ok "masc_tool_help" "$r_tool_help"
 
-echo "[11/36] masc_check"
+echo "[8/31] masc_check"
 r_check="$(call_tool 5013 "masc_check" '{"assertions":["joined"]}')"
 expect_ok "masc_check" "$r_check"
 
-GOAL_SEED_PAYLOAD="$(call_tool 5014 "masc_goal_upsert" '{"title":"Public Tool Sweep Goal","description":"Goal for public tool sweep contract harness","priority":1}')"
+echo "[9/31] masc_goal_list"
+r_goal_list="$(call_tool 5014 "masc_goal_list" '{}')"
+expect_ok "masc_goal_list" "$r_goal_list"
+
+echo "[10/31] masc_goal_upsert"
+GOAL_SEED_PAYLOAD="$(call_tool 5015 "masc_goal_upsert" '{"title":"Public Tool Sweep Goal","priority":1}')"
 GOAL_ID="$(printf '%s' "$GOAL_SEED_PAYLOAD" | extract_result | jq -r '.goal_id // empty')"
 if [ -z "$GOAL_ID" ]; then
   mcp_fail_with_context "could not create goal for public tool live sweep" "$GOAL_SEED_PAYLOAD"
 fi
+echo "  PASS: masc_goal_upsert"
 
-echo "[12/36] masc_add_task"
-r_add_task="$(call_tool 5014 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" '{title:"Public Tool Sweep Task",goal_id:$goal_id,priority:2,description:"live public surface verification"}')")"
+echo "[11/31] masc_add_task"
+r_add_task="$(call_tool 5016 "masc_add_task" "$(jq -cn --arg goal_id "$GOAL_ID" '{title:"Public Tool Sweep Task",goal_id:$goal_id,priority:2,description:"live public surface verification"}')")"
 expect_ok "masc_add_task" "$r_add_task"
 task_id="$(
   printf '%s' "$r_add_task" \
@@ -161,52 +155,52 @@ if [[ -z "$task_id" ]]; then
   mcp_fail_with_context "masc_add_task: could not extract task_id" "$r_add_task"
 fi
 
-echo "[13/36] masc_batch_add_tasks"
-r_batch_add="$(call_tool 5015 "masc_batch_add_tasks" "$(jq -cn --arg goal_id "$GOAL_ID" '{tasks:[{title:"Public Sweep Batch A",goal_id:$goal_id,priority:3,description:"batch-a"},{title:"Public Sweep Batch B",goal_id:$goal_id,priority:4,description:"batch-b"}]}')")"
+echo "[12/31] masc_batch_add_tasks"
+r_batch_add="$(call_tool 5017 "masc_batch_add_tasks" "$(jq -cn --arg goal_id "$GOAL_ID" '{tasks:[{title:"Public Sweep Batch A",goal_id:$goal_id,priority:3,description:"batch-a"},{title:"Public Sweep Batch B",goal_id:$goal_id,priority:4,description:"batch-b"}]}')")"
 expect_ok "masc_batch_add_tasks" "$r_batch_add"
 
-echo "[14/36] masc_tasks"
-r_tasks="$(call_tool 5016 "masc_tasks" '{}')"
+echo "[13/31] masc_tasks"
+r_tasks="$(call_tool 5018 "masc_tasks" '{}')"
 expect_ok "masc_tasks" "$r_tasks"
 
-echo "[15/36] masc_claim_next"
-r_claim_next="$(call_tool 5017 "masc_claim_next" "$(jq -cn --arg agent_name "$AGENT_NAME" '{agent_name:$agent_name}')")"
-expect_ok "masc_claim_next" "$r_claim_next"
+echo "[14/31] masc_transition claim"
+r_claim="$(call_tool 5019 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"claim",notes:"public tool sweep claim"}')")"
+expect_ok_or_guard "masc_transition claim" "$r_claim" 'already claimed'
 
-echo "[16/36] masc_plan_init"
-r_plan_init="$(call_tool 5018 "masc_plan_init" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
+echo "[15/31] masc_plan_init"
+r_plan_init="$(call_tool 5020 "masc_plan_init" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
 expect_ok "masc_plan_init" "$r_plan_init"
 
-echo "[17/36] masc_plan_set_task"
-r_plan_set="$(call_tool 5019 "masc_plan_set_task" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
+echo "[16/31] masc_plan_set_task"
+r_plan_set="$(call_tool 5021 "masc_plan_set_task" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
 expect_ok "masc_plan_set_task" "$r_plan_set"
 
-echo "[18/36] masc_plan_update"
-r_plan_update="$(call_tool 5020 "masc_plan_update" "$(jq -cn --arg task_id "$task_id" --arg content "public tool sweep plan" '{task_id:$task_id,content:$content}')")"
+echo "[17/31] masc_plan_update"
+r_plan_update="$(call_tool 5022 "masc_plan_update" "$(jq -cn --arg task_id "$task_id" --arg content "public tool sweep plan" '{task_id:$task_id,content:$content}')")"
 expect_ok "masc_plan_update" "$r_plan_update"
 
-echo "[19/36] masc_plan_get"
-r_plan_get="$(call_tool 5021 "masc_plan_get" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
+echo "[18/31] masc_plan_get"
+r_plan_get="$(call_tool 5023 "masc_plan_get" "$(jq -cn --arg task_id "$task_id" '{task_id:$task_id}')")"
 expect_ok "masc_plan_get" "$r_plan_get"
 
-echo "[20/36] masc_transition"
-r_transition="$(call_tool 5022 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"start",notes:"public tool sweep start"}')")"
+echo "[19/31] masc_transition start"
+r_transition="$(call_tool 5024 "masc_transition" "$(jq -cn --arg task_id "$task_id" --arg agent_name "$AGENT_NAME" '{task_id:$task_id,agent_name:$agent_name,action:"start",notes:"public tool sweep start"}')")"
 expect_ok "masc_transition" "$r_transition"
 
-echo "[21/36] masc_heartbeat"
-r_heartbeat="$(call_tool 5023 "masc_heartbeat" "$(jq -cn --arg agent_name "$AGENT_NAME" '{agent_name:$agent_name,status:"working",progress:"public tool sweep"}')")"
+echo "[20/31] masc_heartbeat"
+r_heartbeat="$(call_tool 5025 "masc_heartbeat" '{}')"
 expect_ok "masc_heartbeat" "$r_heartbeat"
 
-echo "[22/36] masc_broadcast"
-r_broadcast="$(call_tool 5024 "masc_broadcast" "$(jq -cn --arg agent_name "$AGENT_NAME" --arg message "public tool sweep broadcast" '{agent_name:$agent_name,message:$message}')")"
+echo "[21/31] masc_broadcast"
+r_broadcast="$(call_tool 5026 "masc_broadcast" "$(jq -cn --arg agent_name "$AGENT_NAME" --arg message "public tool sweep broadcast" '{agent_name:$agent_name,message:$message}')")"
 expect_ok "masc_broadcast" "$r_broadcast"
 
-echo "[23/36] masc_messages"
-r_messages="$(call_tool 5025 "masc_messages" '{}')"
+echo "[22/31] masc_messages"
+r_messages="$(call_tool 5027 "masc_messages" '{}')"
 expect_ok "masc_messages" "$r_messages"
 
-echo "[24/36] masc_board_post"
-r_board_post="$(call_tool 5026 "masc_board_post" "$(jq -cn --arg author "$AGENT_NAME" --arg title "Public Tool Sweep Post" --arg content "public tool sweep board post" '{author:$author,title:$title,content:$content,visibility:"internal"}')")"
+echo "[23/31] masc_board_post"
+r_board_post="$(call_tool 5028 "masc_board_post" "$(jq -cn --arg author "$AGENT_NAME" --arg title "Public Tool Sweep Post" --arg content "public tool sweep board post" '{author:$author,title:$title,content:$content,visibility:"internal"}')")"
 expect_ok "masc_board_post" "$r_board_post"
 post_id="$(
   printf '%s' "$r_board_post" \
@@ -220,63 +214,48 @@ if [[ -z "$post_id" ]]; then
   mcp_fail_with_context "masc_board_post: could not extract post_id" "$r_board_post"
 fi
 
-echo "[25/36] masc_board_list"
-r_board_list="$(call_tool 5027 "masc_board_list" '{"limit":5}')"
+echo "[24/31] masc_board_list"
+r_board_list="$(call_tool 5029 "masc_board_list" '{"limit":5}')"
 expect_ok "masc_board_list" "$r_board_list"
 
-echo "[26/36] masc_board_get"
-r_board_get="$(call_tool 5028 "masc_board_get" "$(jq -cn --arg post_id "$post_id" '{post_id:$post_id}')")"
-expect_ok "masc_board_get" "$r_board_get"
+echo "[25/31] masc_board_post_get"
+r_board_get="$(call_tool 5030 "masc_board_post_get" "$(jq -cn --arg post_id "$post_id" '{post_id:$post_id}')")"
+expect_ok "masc_board_post_get" "$r_board_get"
 
-echo "[27/36] masc_board_comment"
-r_board_comment="$(call_tool 5029 "masc_board_comment" "$(jq -cn --arg post_id "$post_id" --arg author "$AGENT_NAME" --arg content "public tool sweep comment" '{post_id:$post_id,author:$author,content:$content}')")"
+echo "[26/31] masc_board_comment"
+r_board_comment="$(call_tool 5031 "masc_board_comment" "$(jq -cn --arg post_id "$post_id" --arg author "$AGENT_NAME" --arg content "public tool sweep comment" '{post_id:$post_id,author:$author,content:$content}')")"
 expect_ok "masc_board_comment" "$r_board_comment"
-
-echo "[28/36] masc_board_vote"
-r_board_vote="$(call_tool 5030 "masc_board_vote" "$(jq -cn --arg post_id "$post_id" '{post_id:$post_id}')")"
-expect_ok "masc_board_vote" "$r_board_vote"
-
-echo "[29/36] masc_keeper_up"
-r_keeper_up="$(call_tool 5031 'masc_keeper_up' '{"name":"public-sweep-keeper","goal":"Handle public tool sweep"}')"
-expect_ok "masc_keeper_up" "$r_keeper_up"
-
-echo "[30/36] masc_keeper_list"
-r_keeper_list="$(call_tool 5032 "masc_keeper_list" '{}')"
-expect_ok "masc_keeper_list" "$r_keeper_list"
-
-echo "[31/36] masc_keeper_status"
-r_keeper_status="$(call_tool 5033 'masc_keeper_status' '{"name":"public-sweep-keeper","fast":true}')"
-expect_ok_or_guard "masc_keeper_status" "$r_keeper_status" 'Tool timed out after|no_tool_capable_provider'
-
-echo "[32/36] masc_keeper_msg"
-r_keeper_msg="$(call_tool 5034 'masc_keeper_msg' '{"name":"missing-keeper","message":"ping"}')"
-expect_ok_or_guard "masc_keeper_msg" "$r_keeper_msg" 'keeper not found'
-
-echo "[33/36] masc_keeper_down"
-r_keeper_down="$(call_tool 5035 'masc_keeper_down' '{"name":"public-sweep-keeper"}')"
-expect_ok "masc_keeper_down" "$r_keeper_down"
-
-echo "[34/36] masc_webrtc_offer"
-r_webrtc_offer="$(call_tool 5036 "masc_webrtc_offer" "$(jq -cn --arg agent_name "$AGENT_NAME" '{agent_name:$agent_name,ice_candidates:["candidate:public-sweep"]}')")"
-expect_ok "masc_webrtc_offer" "$r_webrtc_offer"
-offer_id="$(
-  printf '%s' "$r_webrtc_offer" \
-    | jq -r 'try (.result.structuredContent.offer_id // .result.structuredContent.id) catch empty | strings' \
+comment_id="$(
+  printf '%s' "$r_board_comment" \
+    | jq -r 'try (.result.structuredContent.comment_id // .result.structuredContent.id // .result.structuredContent.comment.id) catch empty | strings' \
     | head -n1
 )"
-if [[ -z "$offer_id" ]]; then
-  offer_id="$(response_text_or_error "$r_webrtc_offer" | grep -oE 'offer-[A-Za-z0-9_-]+' | head -n1 || true)"
-fi
-if [[ -z "$offer_id" ]]; then
-  mcp_fail_with_context "masc_webrtc_offer: could not extract offer_id" "$r_webrtc_offer"
+if [[ -z "$comment_id" ]]; then
+  comment_id="$(response_text_or_error "$r_board_comment" | grep -oE '(comment|c)-[A-Za-z0-9_-]+' | head -n1 || true)"
 fi
 
-echo "[35/36] masc_webrtc_answer"
-r_webrtc_answer="$(call_tool 5037 "masc_webrtc_answer" "$(jq -cn --arg offer_id "$offer_id" --arg agent_name "$AGENT_NAME" '{offer_id:$offer_id,agent_name:$agent_name,ice_candidates:["candidate:answer"]}')")"
-expect_ok "masc_webrtc_answer" "$r_webrtc_answer"
+echo "[27/31] masc_board_vote"
+r_board_vote="$(call_tool 5032 "masc_board_vote" "$(jq -cn --arg post_id "$post_id" --arg voter "$AGENT_NAME" '{post_id:$post_id,voter:$voter}')")"
+expect_ok "masc_board_vote" "$r_board_vote"
 
-echo "[36/36] masc_unbind"
-r_leave="$(call_tool 5038 "masc_unbind" "$(jq -cn --arg agent_name "$AGENT_NAME" '{agent_name:$agent_name}')")"
-expect_ok "masc_unbind" "$r_leave"
+echo "[28/31] masc_board_comment_vote"
+if [[ -n "$comment_id" ]]; then
+  r_comment_vote="$(call_tool 5033 "masc_board_comment_vote" "$(jq -cn --arg comment_id "$comment_id" --arg voter "$AGENT_NAME" '{comment_id:$comment_id,voter:$voter,direction:"up"}')")"
+  expect_ok "masc_board_comment_vote" "$r_comment_vote"
+else
+  echo "  PASS: masc_board_comment_vote (skipped: comment id not present in comment response)"
+fi
+
+echo "[29/31] masc_board_reaction"
+r_reaction="$(call_tool 5034 "masc_board_reaction" "$(jq -cn --arg post_id "$post_id" --arg user_id "$AGENT_NAME" '{target_type:"post",target_id:$post_id,user_id:$user_id,emoji:"👍"}')")"
+expect_ok "masc_board_reaction" "$r_reaction"
+
+echo "[30/31] masc_persona_list"
+r_persona_list="$(call_tool 5035 "masc_persona_list" '{}')"
+expect_ok "masc_persona_list" "$r_persona_list"
+
+echo "[31/31] masc_agent_timeline"
+r_agent_timeline="$(call_tool 5036 "masc_agent_timeline" "$(jq -cn --arg agent_name "$AGENT_NAME" '{agent_name:$agent_name,limit:5}')")"
+expect_ok "masc_agent_timeline" "$r_agent_timeline"
 
 echo "PASS: public MCP tool live sweep"

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -72,10 +72,11 @@ wait_for_mcp_initialize_ready() {
   local body='{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-bootstrap","version":"1.0"},"capabilities":{}}}'
   local auth_token
   auth_token="$(mcp_default_auth_token)"
-  local -a extra_headers=()
-  if [[ -n "$auth_token" ]]; then
-    extra_headers+=( -H "Authorization: Bearer $auth_token" )
+  if [[ -z "$auth_token" ]]; then
+    echo "FAIL: MCP initialize readiness requires a workspace-local auth token" >&2
+    return 1
   fi
+  local -a extra_headers=( -H "Authorization: Bearer $auth_token" )
 
   while [[ "$(date +%s)" -lt "$deadline" ]]; do
     local status
@@ -118,6 +119,21 @@ if ! build_server_exe; then
   exit 1
 fi
 echo "[bootstrap] server_exe=${SERVER_EXE}"
+
+if ! HARNESS_AUTH_TOKEN="$(
+  harness_mint_admin_token "$SERVER_EXE" "$PORT" "$BASE_PATH" \
+    "${MASC_HARNESS_ADMIN_AGENT:-contract-harness-admin}"
+)"; then
+  echo "FAIL: failed to mint contract harness admin token" >&2
+  exit 1
+fi
+if [[ -z "$HARNESS_AUTH_TOKEN" ]]; then
+  echo "FAIL: contract harness admin token is empty" >&2
+  exit 1
+fi
+export MCP_AUTH_TOKEN="$HARNESS_AUTH_TOKEN"
+export MASC_ADMIN_TOKEN="$HARNESS_AUTH_TOKEN"
+echo "[bootstrap] auth_token=workspace-local admin token minted"
 
 SERVER_PID="$(harness_start_server "$SERVER_EXE" "$PORT" "$BASE_PATH" "$LOG_FILE")"
 if ! harness_wait_for_health "$PORT" 25; then

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -27,6 +27,8 @@ else
 fi
 export HARNESS_LOG_FILE="${HARNESS_LOG_FILE:-$LOG_FILE}"
 export MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS="${MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS:-32}"
+# shellcheck source=scripts/harness/lib/mcp_jsonrpc.sh
+source "${ROOT_DIR}/scripts/harness/lib/mcp_jsonrpc.sh"
 
 SERVER_PID=""
 
@@ -68,6 +70,12 @@ wait_for_mcp_initialize_ready() {
   local timeout_sec="${2:-25}"
   local deadline=$(( $(date +%s) + timeout_sec ))
   local body='{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-bootstrap","version":"1.0"},"capabilities":{}}}'
+  local auth_token
+  auth_token="$(mcp_default_auth_token)"
+  local -a extra_headers=()
+  if [[ -n "$auth_token" ]]; then
+    extra_headers+=( -H "Authorization: Bearer $auth_token" )
+  fi
 
   while [[ "$(date +%s)" -lt "$deadline" ]]; do
     local status
@@ -76,6 +84,7 @@ wait_for_mcp_initialize_ready() {
         -X POST "$mcp_url" \
         -H 'Content-Type: application/json' \
         -H 'Accept: application/json, text/event-stream' \
+        "${extra_headers[@]}" \
         -d "$body" 2>/dev/null || true
     )"
     if [[ "$status" == "200" ]]; then

--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 BASE_URL="${MCP_URL%/mcp}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/harness/lib/mcp_jsonrpc.sh
+source "${SCRIPT_DIR}/../lib/mcp_jsonrpc.sh"
 
 tmpdir="$(mktemp -d)"
 cleanup() {
@@ -54,11 +57,18 @@ post_with_accept() {
   local body="$2"
   local header_file="$3"
   local body_file="$4"
+  local auth_token
+  auth_token="$(mcp_default_auth_token)"
+  local -a extra_headers=()
+  if [ -n "$auth_token" ]; then
+    extra_headers+=( -H "Authorization: Bearer $auth_token" )
+  fi
 
   curl_with_retry -sS -D "$header_file" -o "$body_file" \
     -X POST "$MCP_URL" \
     -H 'Content-Type: application/json' \
     -H "Accept: $accept_header" \
+    "${extra_headers[@]}" \
     -d "$body"
 }
 
@@ -76,6 +86,11 @@ post_with_session() {
   )
   if [ -n "$protocol_version" ]; then
     extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
+  fi
+  local auth_token
+  auth_token="$(mcp_default_auth_token)"
+  if [ -n "$auth_token" ]; then
+    extra_headers+=(-H "Authorization: Bearer $auth_token")
   fi
 
   curl_with_retry -sS -D "$header_file" -o "$body_file" \
@@ -97,6 +112,11 @@ get_with_session() {
   if [ -n "$protocol_version" ]; then
     extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
   fi
+  local auth_token
+  auth_token="$(mcp_default_auth_token)"
+  if [ -n "$auth_token" ]; then
+    extra_headers+=(-H "Authorization: Bearer $auth_token")
+  fi
 
   curl_with_retry -sS -D "$header_file" -o "$body_file" --max-time 2 \
     "$MCP_URL" \
@@ -114,6 +134,11 @@ delete_with_session() {
   )
   if [ -n "$protocol_version" ]; then
     extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
+  fi
+  local auth_token
+  auth_token="$(mcp_default_auth_token)"
+  if [ -n "$auth_token" ]; then
+    extra_headers+=(-H "Authorization: Bearer $auth_token")
   fi
 
   curl_with_retry -sS -D "$header_file" -o "$body_file" \

--- a/scripts/harness/lib/mcp_jsonrpc.sh
+++ b/scripts/harness/lib/mcp_jsonrpc.sh
@@ -16,6 +16,19 @@ _HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/harness/jsonrpc_sse.sh
 source "${_HARNESS_DIR}/jsonrpc_sse.sh"
 
+mcp_default_auth_token() {
+  # Contract harnesses boot an isolated workspace. Prefer the harness/admin
+  # token minted for that workspace; an inherited MASC_TOKEN can belong to a
+  # different base path and fail auth resolution.
+  if [[ -n "${MCP_AUTH_TOKEN:-}" ]]; then
+    printf '%s' "$MCP_AUTH_TOKEN"
+  elif [[ -n "${MASC_ADMIN_TOKEN:-}" ]]; then
+    printf '%s' "$MASC_ADMIN_TOKEN"
+  elif [[ -n "${MASC_TOKEN:-}" ]]; then
+    printf '%s' "$MASC_TOKEN"
+  fi
+}
+
 mcp_mktemp_file() {
   local prefix="$1"
   local suffix="${2:-}"
@@ -197,6 +210,9 @@ mcp_jsonrpc_call() {
       "invalid id or params JSON" \
       "$timeout_sec"
     return 0
+  fi
+  if [[ -z "$token" ]]; then
+    token="$(mcp_default_auth_token)"
   fi
 
   local attempt=1

--- a/scripts/harness/lib/mcp_jsonrpc.sh
+++ b/scripts/harness/lib/mcp_jsonrpc.sh
@@ -18,14 +18,13 @@ source "${_HARNESS_DIR}/jsonrpc_sse.sh"
 
 mcp_default_auth_token() {
   # Contract harnesses boot an isolated workspace. Prefer the harness/admin
-  # token minted for that workspace; an inherited MASC_TOKEN can belong to a
-  # different base path and fail auth resolution.
+  # token minted for that workspace. Do not fall back to an inherited
+  # MASC_TOKEN: it can belong to a different base path and mask a broken
+  # bootstrap path.
   if [[ -n "${MCP_AUTH_TOKEN:-}" ]]; then
     printf '%s' "$MCP_AUTH_TOKEN"
   elif [[ -n "${MASC_ADMIN_TOKEN:-}" ]]; then
     printf '%s' "$MASC_ADMIN_TOKEN"
-  elif [[ -n "${MASC_TOKEN:-}" ]]; then
-    printf '%s' "$MASC_TOKEN"
   fi
 }
 

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -189,7 +189,8 @@ harness_mint_admin_token() {
   fi
 
   if ! token_json="$(
-    "$server_exe" login \
+    env -u MCP_AUTH_TOKEN -u MASC_ADMIN_TOKEN -u MASC_TOKEN \
+      "$server_exe" login \
       --base-path "$base_path" \
       --host 127.0.0.1 \
       --port "$port" \
@@ -228,6 +229,8 @@ harness_start_server() {
     export MASC_BASE_PATH="$base_path"
     export MASC_BASE_PATH_INPUT="$base_path"
     export MASC_STORAGE_TYPE="filesystem"
+    unset MASC_ADMIN_TOKEN
+    unset MASC_TOKEN
     export MASC_AUTONOMY_ENABLED="0"
     export MASC_ORCHESTRATOR_ENABLED="0"
     export MASC_OTEL_ENABLED="0"

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -172,6 +172,45 @@ harness_wait_for_health() {
   return 1
 }
 
+harness_mint_admin_token() {
+  local server_exe="$1"
+  local port="$2"
+  local base_path="$3"
+  local agent="${4:-contract-harness-admin}"
+  local token_json token
+
+  if [[ ! -x "$server_exe" ]]; then
+    echo "server executable missing for auth bootstrap: $server_exe" >&2
+    return 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required for auth bootstrap token extraction" >&2
+    return 1
+  fi
+
+  if ! token_json="$(
+    "$server_exe" login \
+      --base-path "$base_path" \
+      --host 127.0.0.1 \
+      --port "$port" \
+      --agent "$agent" \
+      --role admin \
+      --client-env MCP_AUTH_TOKEN \
+      --no-expiry \
+      --json
+  )"; then
+    echo "failed to mint harness admin token for base_path=$base_path" >&2
+    return 1
+  fi
+
+  token="$(printf '%s\n' "$token_json" | jq -r '.bearer_token // empty')"
+  if [[ -z "$token" ]]; then
+    echo "login output did not include bearer_token for base_path=$base_path" >&2
+    return 1
+  fi
+  printf '%s\n' "$token"
+}
+
 harness_start_server() {
   local server_exe="$1"
   local port="$2"

--- a/scripts/harness/lib/test_framework.sh
+++ b/scripts/harness/lib/test_framework.sh
@@ -27,19 +27,21 @@ curl_post_mcp() {
   local body="$1"
   local attempt=1
   local output=""
+  local auth_token
+  auth_token="$(mcp_default_auth_token)"
+  local -a headers=(
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/event-stream'
+  )
+  if [ -n "$MCP_SESSION_ID" ]; then
+    headers+=( -H "mcp-session-id: $MCP_SESSION_ID" )
+  fi
+  if [ -n "$auth_token" ]; then
+    headers+=( -H "Authorization: Bearer $auth_token" )
+  fi
   while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
-    if [ -n "$MCP_SESSION_ID" ]; then
-      output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
-        -H 'Content-Type: application/json' \
-        -H 'Accept: application/json, text/event-stream' \
-        -H "mcp-session-id: $MCP_SESSION_ID" \
-        -d "$body" 2>/dev/null)" && {
-          printf "%s" "$output"
-          return 0
-        }
-    elif output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
-      -H 'Content-Type: application/json' \
-      -H 'Accept: application/json, text/event-stream' \
+    if output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
+      "${headers[@]}" \
       -d "$body" 2>/dev/null)"; then
       printf "%s" "$output"
       return 0
@@ -56,10 +58,18 @@ initialize_mcp_session() {
   local headers_file body_file
   headers_file="$(mcp_mktemp_file "masc-init-headers")"
   body_file="$(mcp_mktemp_file "masc-init-body")"
+  local auth_token
+  auth_token="$(mcp_default_auth_token)"
+  local -a init_headers=(
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/event-stream'
+  )
+  if [ -n "$auth_token" ]; then
+    init_headers+=( -H "Authorization: Bearer $auth_token" )
+  fi
 
   if curl -sS -m "$CURL_TIMEOUT_SEC" -D "$headers_file" -o "$body_file" -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
+    "${init_headers[@]}" \
     -d '{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract-harness","version":"1.0"},"capabilities":{}}}' \
     >/dev/null 2>&1; then
     MCP_SESSION_ID="$(
@@ -74,10 +84,16 @@ initialize_mcp_session() {
     )"
     export MCP_SESSION_ID
     if [ -n "$MCP_SESSION_ID" ]; then
+      local -a initialized_headers=(
+        -H 'Content-Type: application/json'
+        -H 'Accept: application/json, text/event-stream'
+        -H "mcp-session-id: $MCP_SESSION_ID"
+      )
+      if [ -n "$auth_token" ]; then
+        initialized_headers+=( -H "Authorization: Bearer $auth_token" )
+      fi
       curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
-        -H 'Content-Type: application/json' \
-        -H 'Accept: application/json, text/event-stream' \
-        -H "mcp-session-id: $MCP_SESSION_ID" \
+        "${initialized_headers[@]}" \
         -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}' \
         >/dev/null 2>&1 || true
     fi

--- a/test/dune
+++ b/test/dune
@@ -1655,6 +1655,8 @@
 
 (include stanzas/test_ci_run_tests_script.inc)
 
+(include stanzas/test_contract_harness_auth_script.inc)
+
 (include stanzas/test_context_max_observed_9953.inc)
 
 (include stanzas/test_continuity_forward_filter.inc)

--- a/test/stanzas/test_contract_harness_auth_script.inc
+++ b/test/stanzas/test_contract_harness_auth_script.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_contract_harness_auth_script)
+ (modules test_contract_harness_auth_script)
+ (libraries alcotest unix))

--- a/test/test_contract_harness_auth_script.ml
+++ b/test/test_contract_harness_auth_script.ml
@@ -1,0 +1,161 @@
+open Alcotest
+
+let source_root () =
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root -> root
+  | None -> Sys.getcwd ()
+
+let read_file path = In_channel.with_open_bin path In_channel.input_all
+
+let read_source_file rel = read_file (Filename.concat (source_root ()) rel)
+
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop idx =
+    idx + nlen <= hlen
+    && (String.sub haystack idx nlen = needle || loop (idx + 1))
+  in
+  nlen = 0 || loop 0
+
+let substring_index haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  let rec loop idx =
+    if nlen = 0 then Some 0
+    else if idx + nlen > hlen then None
+    else if String.sub haystack idx nlen = needle then Some idx
+    else loop (idx + 1)
+  in
+  loop 0
+
+let require_contains label source needle =
+  check bool label true (contains_substring source needle)
+
+let require_not_contains label source needle =
+  check bool label false (contains_substring source needle)
+
+let require_order label source first second =
+  match (substring_index source first, substring_index source second) with
+  | Some first_idx, Some second_idx ->
+      check bool label true (first_idx < second_idx)
+  | None, _ -> failf "%s: missing first marker: %s" label first
+  | _, None -> failf "%s: missing second marker: %s" label second
+
+let run_bash script =
+  let out = Filename.temp_file "contract-harness-auth-out" ".txt" in
+  let err = Filename.temp_file "contract-harness-auth-err" ".txt" in
+  let out_fd = Unix.openfile out [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let err_fd = Unix.openfile err [ Unix.O_WRONLY; Unix.O_TRUNC ] 0o600 in
+  let original_cwd = Sys.getcwd () in
+  let pid =
+    Fun.protect
+      ~finally:(fun () ->
+        Sys.chdir original_cwd;
+        Unix.close out_fd;
+        Unix.close err_fd)
+      (fun () ->
+        Sys.chdir (source_root ());
+        Unix.create_process "bash" [| "bash"; "-c"; script |] Unix.stdin out_fd
+          err_fd)
+  in
+  let _, status = Unix.waitpid [] pid in
+  let code =
+    match status with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED _ | Unix.WSTOPPED _ -> 255
+  in
+  let stdout = read_file out in
+  let stderr = read_file err in
+  Sys.remove out;
+  Sys.remove err;
+  (code, stdout, stderr)
+
+let test_default_token_rejects_ambient_masc_token () =
+  let script =
+    {|
+set -euo pipefail
+source scripts/harness/lib/mcp_jsonrpc.sh
+unset MCP_AUTH_TOKEN
+unset MASC_ADMIN_TOKEN
+MASC_TOKEN=ambient-token
+token="$(mcp_default_auth_token)"
+if [ -n "$token" ]; then
+  printf 'unexpected ambient fallback: %s\n' "$token" >&2
+  exit 10
+fi
+MASC_ADMIN_TOKEN=admin-token
+if [ "$(mcp_default_auth_token)" != "admin-token" ]; then
+  printf 'MASC_ADMIN_TOKEN not selected\n' >&2
+  exit 11
+fi
+MCP_AUTH_TOKEN=mcp-token
+if [ "$(mcp_default_auth_token)" != "mcp-token" ]; then
+  printf 'MCP_AUTH_TOKEN not selected first\n' >&2
+  exit 12
+fi
+|}
+  in
+  let code, stdout, stderr = run_bash script in
+  check int "exit code" 0 code;
+  check string "stdout" "" stdout;
+  check string "stderr" "" stderr
+
+let test_run_all_mints_workspace_token_before_mcp_probe () =
+  let source = read_source_file "scripts/harness/contract/run_all.sh" in
+  require_contains "mints token" source "harness_mint_admin_token";
+  require_contains "exports mcp token" source
+    "export MCP_AUTH_TOKEN=\"$HARNESS_AUTH_TOKEN\"";
+  require_contains "exports admin token" source
+    "export MASC_ADMIN_TOKEN=\"$HARNESS_AUTH_TOKEN\"";
+  require_contains "empty token is fatal" source
+    "FAIL: contract harness admin token is empty";
+  require_order "mint before start" source "harness_mint_admin_token"
+    "harness_start_server";
+  require_order "export before initialize readiness" source
+    "export MCP_AUTH_TOKEN=\"$HARNESS_AUTH_TOKEN\""
+    "if ! wait_for_mcp_initialize_ready \"$MCP_URL\" 25; then";
+  require_order "empty check before initialize readiness" source
+    "FAIL: contract harness admin token is empty"
+    "if ! wait_for_mcp_initialize_ready \"$MCP_URL\" 25; then"
+
+let test_bootstrap_mints_admin_token_for_base_path () =
+  let source = read_source_file "scripts/harness/lib/server_bootstrap.sh" in
+  require_contains "bootstrap helper exists" source "harness_mint_admin_token()";
+  require_contains "uses login command" source "\"$server_exe\" login";
+  require_contains "scrubs ambient auth for login" source
+    "env -u MCP_AUTH_TOKEN -u MASC_ADMIN_TOKEN -u MASC_TOKEN";
+  require_contains "uses isolated base path" source "--base-path \"$base_path\"";
+  require_contains "uses target port" source "--port \"$port\"";
+  require_contains "uses admin role" source "--role admin";
+  require_contains "uses mcp env" source "--client-env MCP_AUTH_TOKEN";
+  require_contains "long lived token" source "--no-expiry";
+  require_contains "json output" source "--json";
+  require_contains "extracts bearer token" source ".bearer_token // empty";
+  require_contains "server start scrubs admin token" source
+    "unset MASC_ADMIN_TOKEN";
+  require_contains "server start scrubs ambient token" source "unset MASC_TOKEN"
+
+let test_mcp_jsonrpc_does_not_fallback_to_masc_token () =
+  let source = read_source_file "scripts/harness/lib/mcp_jsonrpc.sh" in
+  require_contains "mcp auth token selected" source "${MCP_AUTH_TOKEN:-}";
+  require_contains "admin token selected" source "${MASC_ADMIN_TOKEN:-}";
+  require_not_contains "no MASC_TOKEN branch" source
+    "elif [[ -n \"${MASC_TOKEN:-}\" ]]";
+  require_not_contains "no MASC_TOKEN print" source "printf '%s' \"$MASC_TOKEN\""
+
+let () =
+  run "contract_harness_auth_script"
+    [
+      ( "auth",
+        [
+          test_case "default token rejects ambient MASC_TOKEN" `Quick
+            test_default_token_rejects_ambient_masc_token;
+          test_case "run_all mints token before MCP probe" `Quick
+            test_run_all_mints_workspace_token_before_mcp_probe;
+          test_case "bootstrap mints admin token for base path" `Quick
+            test_bootstrap_mints_admin_token_for_base_path;
+          test_case "mcp_jsonrpc rejects MASC_TOKEN fallback" `Quick
+            test_mcp_jsonrpc_does_not_fallback_to_masc_token;
+        ] );
+    ]

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -53,8 +53,8 @@ let tool_case_timeout_sec () =
   | Some raw -> (
       match int_of_string_opt (String.trim raw) with
       | Some value when value > 0 -> value
-      | _ -> 25)
-  | None -> 25
+      | _ -> 60)
+  | None -> 60
 
 let runner_path () =
   let exe_dir = Filename.dirname Sys.executable_name in
@@ -191,7 +191,22 @@ let run_tool_case_process tool_name =
     if Sys.file_exists path then Cases.cleanup_dir path
   in
   let env =
-    env_array [ ("TMPDIR", tmp_root); ("TEMP", tmp_root); ("TMP", tmp_root) ]
+    env_array
+      [
+        ("TMPDIR", tmp_root);
+        ("TEMP", tmp_root);
+        ("TMP", tmp_root);
+        (* Inventory checks may initialize runtime/auth helpers in the parent
+           process. Keep child case runners isolated so they create their own
+           temp-base auth state instead of inheriting parent runtime tokens. *)
+        ("MASC_BASE_PATH", "");
+        ("MASC_BASE_PATH_INPUT", "");
+        ("MASC_CONFIG_DIR", "");
+        ("MASC_TOKEN", "");
+        ("MASC_INTERNAL_MCP_TOKEN", "");
+        ("MASC_ADMIN_TOKEN", "");
+        ("MCP_SESSION_ID", "");
+      ]
   in
   let prog, argv =
     match timeout_command () with

--- a/test/test_keeper_tool_matrix.ml
+++ b/test/test_keeper_tool_matrix.ml
@@ -48,13 +48,18 @@ let timeout_command () =
   | Some _ as found -> found
   | None -> find_in_path "gtimeout"
 
+(* Each case launches the full OAS handler path in a fresh process and may pay
+   sandbox/config cold-start cost. Keep the default conservative while allowing
+   local tightening through KEEPER_TOOL_MATRIX_CASE_TIMEOUT_SEC. *)
+let default_tool_case_timeout_sec = 60
+
 let tool_case_timeout_sec () =
   match Sys.getenv_opt "KEEPER_TOOL_MATRIX_CASE_TIMEOUT_SEC" with
   | Some raw -> (
       match int_of_string_opt (String.trim raw) with
       | Some value when value > 0 -> value
-      | _ -> 60)
-  | None -> 60
+      | _ -> default_tool_case_timeout_sec)
+  | None -> default_tool_case_timeout_sec
 
 let runner_path () =
   let exe_dir = Filename.dirname Sys.executable_name in
@@ -136,17 +141,19 @@ let parse_case_result ~tool_name output =
                    tool_name raw);
           })
 
-let env_array overrides =
+let env_array ?(unset = []) overrides =
   let env = Hashtbl.create 64 in
   Unix.environment ()
   |> Array.iter (fun binding ->
          match String.index_opt binding '=' with
          | Some index ->
-             Hashtbl.replace env
-               (String.sub binding 0 index)
-               (String.sub binding (index + 1)
-                  (String.length binding - index - 1))
+             let key = String.sub binding 0 index in
+             if not (List.mem key unset) then
+               Hashtbl.replace env key
+                 (String.sub binding (index + 1)
+                    (String.length binding - index - 1))
          | None -> ());
+  List.iter (fun key -> Hashtbl.remove env key) unset;
   List.iter (fun (key, value) -> Hashtbl.replace env key value) overrides;
   Hashtbl.fold
     (fun key value acc -> Printf.sprintf "%s=%s" key value :: acc)
@@ -178,6 +185,26 @@ let run_capture_process ~env ~out_file ~err_file prog argv =
           let _, status = Unix.waitpid [] pid in
           process_exit_code status))
 
+let isolated_child_env_unset =
+  [ "MASC_BASE_PATH"
+  ; "MASC_BASE_PATH_INPUT"
+  ; "MASC_CONFIG_DIR"
+  ; "MASC_STORAGE_TYPE"
+  ; "MASC_TOKEN"
+  ; "MASC_INTERNAL_MCP_TOKEN"
+  ; "MASC_ADMIN_TOKEN"
+  ; "MCP_SESSION_ID"
+  ; "OPENAI_API_KEY"
+  ; "ANTHROPIC_API_KEY"
+  ; "GEMINI_API_KEY"
+  ; "GOOGLE_API_KEY"
+  ; "MISTRAL_API_KEY"
+  ; "OPENROUTER_API_KEY"
+  ; "ZAI_API_KEY"
+  ; "DASHSCOPE_API_KEY"
+  ; "OLLAMA_HOST"
+  ]
+
 let run_tool_case_process tool_name =
   let tmp_root = Filename.temp_file "keeper-tool-matrix-base" "" in
   Sys.remove tmp_root;
@@ -192,20 +219,14 @@ let run_tool_case_process tool_name =
   in
   let env =
     env_array
+      ~unset:isolated_child_env_unset
       [
         ("TMPDIR", tmp_root);
         ("TEMP", tmp_root);
         ("TMP", tmp_root);
-        (* Inventory checks may initialize runtime/auth helpers in the parent
-           process. Keep child case runners isolated so they create their own
-           temp-base auth state instead of inheriting parent runtime tokens. *)
-        ("MASC_BASE_PATH", "");
-        ("MASC_BASE_PATH_INPUT", "");
-        ("MASC_CONFIG_DIR", "");
-        ("MASC_TOKEN", "");
-        ("MASC_INTERNAL_MCP_TOKEN", "");
-        ("MASC_ADMIN_TOKEN", "");
-        ("MCP_SESSION_ID", "");
+        ("HOME", tmp_root);
+        ("XDG_CONFIG_HOME", Filename.concat tmp_root "xdg-config");
+        ("XDG_CACHE_HOME", Filename.concat tmp_root "xdg-cache");
       ]
   in
   let prog, argv =

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -218,11 +218,62 @@ let ensure_voice_session fixture =
     (Masc.Voice_session_manager.start_session mgr ~agent_id:fixture.meta.name
        ~voice:"tool-matrix" ())
 
+let ensure_board_comment fixture =
+  let body =
+    Generic.execute_tool_ok fixture.generic ~name:"masc_board_comment"
+      ~arguments:
+        (`Assoc
+          [
+            ("post_id", `String (Generic.ensure_board_post fixture.generic));
+            ("author", `String fixture.meta.name);
+            ("content", `String "tool-matrix-comment");
+          ])
+  in
+  match
+    Generic.extract_id body ~fields:[ "id"; "comment_id" ]
+      ~prefixes:[ "comment-" ]
+  with
+  | Some value -> value
+  | None -> failwith ("failed to parse comment id from: " ^ body)
+
+let sub_board_slug fixture =
+  "tool-matrix-" ^ Filename.basename fixture.generic.base_path
+
+let ensure_sub_board fixture =
+  let slug = sub_board_slug fixture in
+  ignore
+    (Generic.execute_tool_ok fixture.generic ~name:"masc_board_sub_board_create"
+       ~arguments:
+         (`Assoc
+           [
+             ("slug", `String slug);
+             ("name", `String "Tool Matrix SubBoard");
+             ("description", `String "Sub-board fixture for keeper matrix");
+             ("access", `String "open");
+           ]));
+  slug
+
+let ensure_image_artifact fixture =
+  let bytes = "\x89PNG\r\n\x1a\ntool-matrix-image" in
+  let dir =
+    Filename.concat
+      (Config_dir_resolver.keepers_dir ())
+      (fixture.meta.name ^ ".vision")
+  in
+  match Multimodal.Vision_artifact_store.store ~dir bytes with
+  | Ok handle -> Multimodal.Vision_artifact_store.to_string handle
+  | Error msg -> failwith ("failed to store analyze_image fixture: " ^ msg)
+
 let prepare_keeper_name fixture name =
   if
     List.mem name
-      [ "keeper_board_get"; "keeper_board_comment"; "keeper_board_vote";
-        "keeper_board_search" ]
+      [
+        "keeper_board_post_get";
+        "keeper_board_comment";
+        "keeper_board_vote";
+        "keeper_board_comment_vote";
+        "keeper_board_search";
+      ]
   then
     ignore (Generic.ensure_board_post fixture.generic);
   if
@@ -263,6 +314,13 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
       `Assoc [ ("query", `String "memory needle"); ("limit", `Int 2) ]
   | "keeper_memory_write" ->
       `Assoc [ ("kind", `String "decision"); ("content", `String "tool matrix memory write content") ]
+  | "analyze_image" ->
+      `Assoc
+        [
+          ("artifact", `String (ensure_image_artifact fixture));
+          ("query", `String "Describe this test image.");
+          ("media_type", `String "image/png");
+        ]
   | "keeper_ide_annotate" ->
       `Assoc
         [
@@ -277,7 +335,7 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
           ("content", `String "tool-matrix-post");
           ("visibility", `String "internal");
         ]
-  | "keeper_board_get" ->
+  | "keeper_board_post_get" ->
       `Assoc [ ("post_id", `String (Generic.ensure_board_post fixture.generic)) ]
   | "keeper_board_list" -> `Assoc [ ("limit", `Int 5) ]
   | "keeper_board_curation_read" -> `Assoc []
@@ -295,17 +353,42 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
           ("post_id", `String (Generic.ensure_board_post fixture.generic));
           ("direction", `String "up");
         ]
+  | "keeper_board_comment_vote" ->
+      `Assoc
+        [
+          ("comment_id", `String (ensure_board_comment fixture));
+          ("direction", `String "up");
+        ]
   | "keeper_board_stats" -> `Assoc []
   | "keeper_board_search" ->
       `Assoc [ ("query", `String "tool-matrix"); ("limit", `Int 5) ]
+  | "keeper_board_sub_board_create" ->
+      `Assoc
+        [
+          ("slug", `String (sub_board_slug fixture));
+          ("name", `String "Tool Matrix SubBoard");
+          ("description", `String "Sub-board fixture for keeper matrix");
+          ("access", `String "open");
+        ]
+  | "keeper_board_sub_board_list" -> `Assoc []
+  | "keeper_board_sub_board_get" ->
+      `Assoc [ ("sub_board_id", `String (ensure_sub_board fixture)) ]
+  | "keeper_board_sub_board_update" ->
+      `Assoc
+        [
+          ("sub_board_id", `String (ensure_sub_board fixture));
+          ("name", `String "Tool Matrix SubBoard Updated");
+        ]
+  | "keeper_board_sub_board_delete" ->
+      `Assoc [ ("sub_board_id", `String (ensure_sub_board fixture)) ]
   | "tool_read_file" ->
-      `Assoc [ ("path", `String (ensure_sample_file fixture)) ]
+      `Assoc [ ("file_path", `String (ensure_sample_file fixture)) ]
   | "tool_edit_file" ->
       `Assoc
         [
-          ("path", `String "keeper-matrix-write.txt");
-          ("content", `String "matrix write\n");
-          ("mode", `String "overwrite");
+          ("file_path", `String (ensure_sample_file fixture));
+          ("old_string", `String "needle");
+          ("new_string", `String "edited needle");
         ]
   | "tool_search_files" ->
       `Assoc
@@ -316,7 +399,7 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
   | "tool_write_file" ->
       `Assoc
         [
-          ("path", `String "keeper-matrix-write.txt");
+          ("file_path", `String "keeper-matrix-write.txt");
           ("content", `String "matrix write\n");
           ("mode", `String "overwrite");
         ]
@@ -383,6 +466,18 @@ let keeper_expectation_for_name name =
           "review format unrecognized";
           "Revise your completion notes";
         ]
+  | "analyze_image" ->
+      Expect_success_or_guard
+        [
+          "eio_context_unavailable";
+          "no_capable_runtime";
+          "provider_error";
+          "timeout";
+          "empty_extraction";
+          "truncated_extraction";
+        ]
+  | "keeper_ide_annotate" ->
+      Expect_success_or_guard [ "annotation sink is not installed" ]
   | "tool_read_file" ->
       (* Playground resolves paths under .masc/playground/<agent>/ but
          the sample file is written at base_path. File-not-found in
@@ -400,6 +495,7 @@ let extra_guard_fragments_for_name = function
         "no credential found" ]
   | "masc_auth_revoke" -> [ "no credential found" ]
   | "masc_board_migrate" -> [ "requires postgresql backend" ]
+  | "masc_dashboard" -> [ "Dashboard handler not registered" ]
   | "masc_get_metrics" -> [ "no metrics found" ]
   | "masc_fusion" ->
       [
@@ -408,12 +504,18 @@ let extra_guard_fragments_for_name = function
       ]
   | "masc_library_promote" -> [ "no candidate matching" ]
   | "masc_keeper_msg" ->
-      [ "keeper management tool"; "use MCP client"; "requires Eio context" ]
+      [
+        "keeper management tool";
+        "use MCP client";
+        "requires Eio context";
+        "keeper not found";
+      ]
   | "masc_keeper_sandbox_start" | "masc_keeper_sandbox_stop" ->
       [ "descriptor projection: cluster dispatcher did not recognise" ]
   | "masc_keeper_list" | "masc_keeper_msg_result"
   | "masc_keeper_msg_cancel" | "masc_keeper_msg_queue" | "masc_keeper_status" ->
       [ "keeper management tool"; "use MCP client" ]
+  | "masc_keeper_up" -> [ "server_initializing" ]
   | "tool_execute" -> [ "worktree not found" ]
   | _ -> []
 
@@ -455,6 +557,7 @@ let case_for_name name =
   else if
     string_starts_with ~prefix:"keeper_" name
     || string_starts_with ~prefix:"tool_" name
+    || String.equal name "analyze_image"
   then
     {
       init_mode = Init_joined;

--- a/test/test_keeper_tool_matrix_cases.ml
+++ b/test/test_keeper_tool_matrix_cases.ml
@@ -5,6 +5,8 @@ module KET = Masc.Keeper_tool_dispatch_runtime
 module KTO = Masc.Keeper_tools_oas_bundle
 module Tool = Agent_sdk.Tool
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
 type init_mode = Generic.init_mode =
   | Fresh
   | Init_only
@@ -33,6 +35,11 @@ and fixture = {
 let string_starts_with = Generic.string_starts_with
 let contains_any = Generic.contains_any
 let cleanup_dir = Generic.cleanup_dir
+
+let restore_env name = function
+  | Some raw -> Unix.putenv name raw
+  | None -> unsetenv name
+;;
 
 let keeper_matrix_guard_fragments =
   [
@@ -253,17 +260,6 @@ let ensure_sub_board fixture =
            ]));
   slug
 
-let ensure_image_artifact fixture =
-  let bytes = "\x89PNG\r\n\x1a\ntool-matrix-image" in
-  let dir =
-    Filename.concat
-      (Config_dir_resolver.keepers_dir ())
-      (fixture.meta.name ^ ".vision")
-  in
-  match Multimodal.Vision_artifact_store.store ~dir bytes with
-  | Ok handle -> Multimodal.Vision_artifact_store.to_string handle
-  | Error msg -> failwith ("failed to store analyze_image fixture: " ^ msg)
-
 let prepare_keeper_name fixture name =
   if
     List.mem name
@@ -315,12 +311,7 @@ let keeper_arguments fixture (schema : Masc_domain.tool_schema) =
   | "keeper_memory_write" ->
       `Assoc [ ("kind", `String "decision"); ("content", `String "tool matrix memory write content") ]
   | "analyze_image" ->
-      `Assoc
-        [
-          ("artifact", `String (ensure_image_artifact fixture));
-          ("query", `String "Describe this test image.");
-          ("media_type", `String "image/png");
-        ]
+      `Assoc [ ("artifact", `String "tool-matrix-missing-query") ]
   | "keeper_ide_annotate" ->
       `Assoc
         [
@@ -467,14 +458,11 @@ let keeper_expectation_for_name name =
           "Revise your completion notes";
         ]
   | "analyze_image" ->
-      Expect_success_or_guard
+      Expect_guard
         [
-          "eio_context_unavailable";
-          "no_capable_runtime";
-          "provider_error";
-          "timeout";
-          "empty_extraction";
-          "truncated_extraction";
+          "invalid_args";
+          "requires string fields: artifact, query";
+          "policy_rejection";
         ]
   | "keeper_ide_annotate" ->
       Expect_success_or_guard [ "annotation sink is not installed" ]
@@ -624,14 +612,9 @@ let run_case sw ~proc_mgr ~fs ~net ~mono_clock clock
     Fun.protect
       ~finally:(fun () ->
         List.iter
-          (fun (name, value) ->
-            match value with
-            | Some raw -> Unix.putenv name raw
-            | None -> Unix.putenv name "")
+          (fun (name, value) -> restore_env name value)
           saved_env;
-        match saved_home with
-        | Some home -> Unix.putenv "HOME" home
-        | None -> Unix.putenv "HOME" "")
+        restore_env "HOME" saved_home)
       (fun () ->
         Unix.putenv "HOME" base_path;
         try

--- a/test/test_mcp_tool_matrix_cases.ml
+++ b/test/test_mcp_tool_matrix_cases.ml
@@ -429,6 +429,17 @@ let ensure_plan_initialized fixture =
              ("task_id", `String task_id);
            ]))
 
+let ensure_run_initialized fixture =
+  let task_id = ensure_task fixture in
+  ignore
+    (execute_tool_ok fixture ~name:"masc_run_init"
+       ~arguments:
+         (`Assoc
+           [
+             ("task_id", `String task_id);
+             ("agent_name", `String fixture.agent_name);
+           ]))
+
 let ensure_board_post fixture =
   match fixture.board_post_id with
   | Some post_id -> post_id
@@ -514,6 +525,8 @@ let prepare_for_name fixture name =
     ignore (ensure_task fixture);
   if List.mem name [ "masc_plan_get"; "masc_plan_update"; "masc_plan_get_task"; "masc_plan_clear_task" ] then
     ensure_plan_initialized fixture;
+  if name = "masc_run_plan" then
+    ensure_run_initialized fixture;
   if List.mem name [ "masc_board_get"; "masc_board_comment"; "masc_board_vote"; "masc_board_comment_vote"; "masc_board_delete" ] then
     ignore (ensure_board_post fixture);
   (* masc_verify_* tools pruned from registry; no preparation needed. *)


### PR DESCRIPTION
Summary:
- add keeper matrix coverage for analyze_image, filesystem aliases, memory, IDE, board wrappers, public masc_* schemas, and run-plan fixture setup
- inject keeper identity into board-backed public calls instead of requiring callers to provide author/voter/owner fields
- validate public alias payloads before translation so Read/Edit/Write can dispatch with legacy runtime args without a second schema mismatch

Validation:
- ocamlformat --check on touched OCaml files
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 DUNE_BUILD_DIR=_build_keeper_pr scripts/dune-local.sh build --cache=disabled test/test_keeper_tool_matrix.exe test/keeper_tool_matrix_case_runner.exe
- _build_keeper_pr/default/test/test_keeper_tool_matrix.exe --bail --show-errors --tail-errors=120 (139 tests, 322.251s)