### PR TITLE
[codex] Repair Memory OS audit CI harness fallout

### DIFF
--- a/docs/rfc/RFC-0086-keeper-namespace-boundary-modules.txt
+++ b/docs/rfc/RFC-0086-keeper-namespace-boundary-modules.txt
@@ -1,0 +1,3 @@
+# Approved lib/keeper module basenames that intentionally omit the keeper_
+# prefix. Format: <module-basename> | <reason>.
+surface_ref | Shared typed surface vocabulary used by keeper lanes, external attention, and gate recording.

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -73,15 +73,46 @@ let find_project_root () =
   in
   walk start_dir
 
-let source_path rel = Filename.concat (find_project_root ()) rel
+let validate_source_relpath rel =
+  let fail reason =
+    failwith
+      (Printf.sprintf
+         "Masc_test_deps.source_path requires a clean repo-relative path: %S (%s)"
+         rel
+         reason)
+  in
+  if String.equal rel "" then fail "empty path";
+  if not (Filename.is_relative rel) then fail "absolute path";
+  if String.starts_with ~prefix:"./" rel then fail "leading ./";
+  let parts = String.split_on_char '/' rel in
+  List.iter
+    (function
+      | "" -> fail "empty path segment"
+      | "." -> fail "current-directory path segment"
+      | ".." -> fail "parent-directory path segment"
+      | _ -> ())
+    parts
+
+let source_path rel =
+  validate_source_relpath rel;
+  Filename.concat (find_project_root ()) rel
 
 let read_file path =
-  let ic = open_in path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () ->
-      let n = in_channel_length ic in
-      really_input_string ic n)
+  try
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let n = in_channel_length ic in
+        really_input_string ic n)
+  with exn ->
+    failwith
+      (Printf.sprintf
+         "Masc_test_deps.read_file failed for %S: %s"
+         path
+         (Printexc.to_string exn))
+
+let read_source_file rel = read_file (source_path rel)
 
 let tla_quoted_strings content =
   let re = Str.regexp "\"\\([^\"]*\\)\"" in

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -105,12 +105,14 @@ let read_file path =
       (fun () ->
         let n = in_channel_length ic in
         really_input_string ic n)
-  with exn ->
+  (* Catch only [Sys_error] so OOM/Stack_overflow/Sys.Break and other fatal or
+     async exceptions propagate instead of being folded into a [Failure]. *)
+  with Sys_error msg ->
     failwith
       (Printf.sprintf
          "Masc_test_deps.read_file failed for %S: %s"
          path
-         (Printexc.to_string exn))
+         msg)
 
 let read_source_file rel = read_file (source_path rel)
 

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -73,6 +73,8 @@ let find_project_root () =
   in
   walk start_dir
 
+let source_path rel = Filename.concat (find_project_root ()) rel
+
 let read_file path =
   let ic = open_in path in
   Fun.protect
@@ -140,7 +142,7 @@ let tla_quoted_set_exn ?(source = "<tla>") ~symbol content =
            symbol source)
 
 let tla_quoted_set_from_repo_file_exn ~relpath ~symbol =
-  let path = Filename.concat (find_project_root ()) relpath in
+  let path = source_path relpath in
   tla_quoted_set_exn ~source:relpath ~symbol (read_file path)
 
 let sorted_strings = List.sort String.compare

--- a/test/dune
+++ b/test/dune
@@ -2217,7 +2217,7 @@
 (test
  (name test_server_bootstrap_loop_fork_helper)
  (modules test_server_bootstrap_loop_fork_helper)
- (libraries alcotest))
+ (libraries alcotest masc_test_deps))
 
 ; RFC-0085 PR-3 — server runtime PID lock absorbed into Host_config.run_dir,
 ; and server bootstrap kept free of provider-specific OAS policy wiring.
@@ -2306,7 +2306,7 @@
 (test
  (name test_rfc_0086_keeper_namespace_invariant)
  (modules test_rfc_0086_keeper_namespace_invariant)
- (libraries alcotest))
+ (libraries alcotest masc_test_deps))
 
 ; Eval_tool_selector is an observational harness/benchmark matcher.  It
 ; must not become a live keeper/runtime routing gate or tool policy surface.

--- a/test/test_dune_local_script.ml
+++ b/test/test_dune_local_script.ml
@@ -553,7 +553,9 @@ let test_bare_dune_bypass_aborts_before_dune () =
       in
       write_bare_dune_ps bin_dir;
       let code, _stdout, stderr =
-        run_dune_local dir bin_dir ~unset_env:[ "GITHUB_ACTIONS" ] "build"
+        run_dune_local dir bin_dir
+          ~unset_env:[ "GITHUB_ACTIONS"; "MASC_DUNE_ALLOW_BARE_DUNE" ]
+          "build"
       in
       check int "exits tempfail on bare dune bypass" 75 code;
       check bool "reports unwrapped Dune" true

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -57,7 +57,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 210
+  check int "Keeper_metrics.all covers every constructor" 221
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"

--- a/test/test_rfc_0086_keeper_namespace_invariant.ml
+++ b/test/test_rfc_0086_keeper_namespace_invariant.ml
@@ -15,7 +15,22 @@ open Alcotest
     of any individual .ml AST, so an AST-grep would be the wrong axis
     here. *)
 
-let keeper_root = "lib/keeper"
+let rec find_up dir rel =
+  let candidate = Filename.concat dir rel in
+  if Sys.file_exists candidate then Some candidate
+  else (
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None else find_up parent rel)
+;;
+
+let source_path rel =
+  match find_up (Sys.getcwd ()) rel with
+  | Some path -> path
+  | None ->
+    failf "could not locate source path %S from cwd %S" rel (Sys.getcwd ())
+;;
+
+let keeper_root () = source_path "lib/keeper"
 
 let rec collect_ml_files dir acc =
   let entries = try Sys.readdir dir with Sys_error _ -> [||] in
@@ -36,13 +51,25 @@ let basename_no_ext path =
   try Filename.chop_extension b with Invalid_argument _ -> b
 ;;
 
+let intentional_boundary_module = function
+  | "surface_ref" ->
+    (* Shared typed surface vocabulary extracted for keeper lanes,
+       external attention, and gate recording.  It intentionally has a
+       domain name rather than a keeper_ prefix; renaming it is a broad
+       module-boundary migration, not an accidental file-add regression. *)
+    true
+  | _ -> false
+;;
+
 let test_all_files_have_keeper_prefix () =
-  let files = collect_ml_files keeper_root [] in
+  let files = collect_ml_files (keeper_root ()) [] in
   let offenders =
     List.filter
       (fun path ->
         let base = basename_no_ext path in
-        not (String.length base >= 7 && String.sub base 0 7 = "keeper_"))
+        not
+          (String.length base >= 7 && String.sub base 0 7 = "keeper_"
+           || intentional_boundary_module base))
       files
   in
   match offenders with
@@ -55,7 +82,7 @@ let test_all_files_have_keeper_prefix () =
 ;;
 
 let test_population_sanity () =
-  let files = collect_ml_files keeper_root [] in
+  let files = collect_ml_files (keeper_root ()) [] in
   (* Population sanity: a sudden drop to near-zero or jump beyond
      historical range would indicate a directory move / restructure
      worth re-validating.  Range chosen with margin around the

--- a/test/test_rfc_0086_keeper_namespace_invariant.ml
+++ b/test/test_rfc_0086_keeper_namespace_invariant.ml
@@ -1,4 +1,5 @@
 open Alcotest
+module String_set = Set.Make (String)
 
 (** RFC-0086 — keeper namespace bulk promotion invariant.
 
@@ -15,6 +16,7 @@ open Alcotest
     of any individual .ml AST, so an AST-grep would be the wrong axis
     here. *)
 
+let keeper_prefix = "keeper_"
 let keeper_root () = Masc_test_deps.source_path "lib/keeper"
 
 let rec collect_ml_files dir acc =
@@ -36,37 +38,86 @@ let basename_no_ext path =
   try Filename.chop_extension b with Invalid_argument _ -> b
 ;;
 
+let string_contains ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    idx + needle_len <= haystack_len
+    &&
+    (String.equal (String.sub haystack idx needle_len) needle || loop (idx + 1))
+  in
+  String.equal needle "" || loop 0
+;;
+
 let boundary_modules_path =
   "docs/rfc/RFC-0086-keeper-namespace-boundary-modules.txt"
 
-let intentional_boundary_modules () =
-  let path = Masc_test_deps.source_path boundary_modules_path in
-  let lines =
-    In_channel.with_open_text path (fun ic ->
-      In_channel.input_all ic |> String.split_on_char '\n')
-  in
-  List.filter_map
-    (fun line ->
-      let line = String.trim line in
-      if String.equal line "" || line.[0] = '#'
-      then None
-      else (
-        match String.split_on_char '|' line with
-        | name :: _ -> Some (String.trim name)
-        | [] -> None))
-    lines
+let valid_boundary_basename name =
+  (not (String.equal name ""))
+  && (not (String.starts_with ~prefix:keeper_prefix name))
+  && not
+       (String.exists
+          (function
+            | '/' | '\\' | '.' -> true
+            | _ -> false)
+          name)
+;;
+
+let parse_boundary_module_line ~line_no raw_line =
+  let line = String.trim raw_line in
+  if String.equal line "" || line.[0] = '#'
+  then None
+  else (
+    match String.split_on_char '|' line with
+    | [ raw_name; raw_reason ] ->
+      let name = String.trim raw_name in
+      let reason = String.trim raw_reason in
+      if not (valid_boundary_basename name)
+      then
+        failf
+          "%s:%d invalid boundary basename %S"
+          boundary_modules_path
+          line_no
+          name;
+      if String.equal reason ""
+      then
+        failf
+          "%s:%d boundary module %S is missing a reason"
+          boundary_modules_path
+          line_no
+          name;
+      Some name
+    | _ ->
+      failf
+        "%s:%d malformed line; expected '<module-basename> | <reason>'"
+        boundary_modules_path
+        line_no)
+;;
+
+let load_intentional_boundary_modules () =
+  Masc_test_deps.read_source_file boundary_modules_path
+  |> String.split_on_char '\n'
+  |> List.mapi (fun idx line -> parse_boundary_module_line ~line_no:(idx + 1) line)
+  |> List.filter_map Fun.id
+;;
+
+let intentional_boundary_modules = lazy (load_intentional_boundary_modules ())
+
+let intentional_boundary_module_set () =
+  Lazy.force intentional_boundary_modules
+  |> List.fold_left (fun acc name -> String_set.add name acc) String_set.empty
 ;;
 
 let test_all_files_have_keeper_prefix () =
   let files = collect_ml_files (keeper_root ()) [] in
-  let boundary_modules = intentional_boundary_modules () in
+  let boundary_modules = intentional_boundary_module_set () in
   let offenders =
     List.filter
       (fun path ->
         let base = basename_no_ext path in
         not
-          (String.starts_with ~prefix:"keeper_" base
-           || List.mem base boundary_modules))
+          (String.starts_with ~prefix:keeper_prefix base
+           || String_set.mem base boundary_modules))
       files
   in
   match offenders with
@@ -76,6 +127,58 @@ let test_all_files_have_keeper_prefix () =
       "lib/keeper/ files missing [keeper_] prefix (%d): %s"
       (List.length xs)
       (String.concat ", " xs)
+;;
+
+let sorted_unique xs = List.sort_uniq String.compare xs
+
+let test_boundary_registry_is_sorted_unique_and_necessary () =
+  let registered = Lazy.force intentional_boundary_modules in
+  let sorted_registered = sorted_unique registered in
+  if registered <> sorted_registered
+  then
+    failf
+      "%s must be sorted and unique; got [%s], expected [%s]"
+      boundary_modules_path
+      (String.concat "; " registered)
+      (String.concat "; " sorted_registered);
+  let files = collect_ml_files (keeper_root ()) [] in
+  let required =
+    files
+    |> List.map basename_no_ext
+    |> List.filter (fun base -> not (String.starts_with ~prefix:keeper_prefix base))
+    |> sorted_unique
+  in
+  if registered <> required
+  then
+    failf
+      "%s must list exactly the necessary non-%s lib/keeper basenames; got [%s], \
+       expected [%s]"
+      boundary_modules_path
+      keeper_prefix
+      (String.concat "; " registered)
+      (String.concat "; " required)
+;;
+
+let test_source_path_contract_rejects_unsafe_relatives () =
+  let unsafe_relatives =
+    [ ""
+    ; "/lib/keeper"
+    ; "./lib/keeper"
+    ; "lib/../keeper"
+    ; "lib//keeper"
+    ; "lib/keeper/"
+    ]
+  in
+  List.iter
+    (fun rel ->
+      match Masc_test_deps.source_path rel with
+      | _ -> failf "source_path unexpectedly accepted unsafe relative path %S" rel
+      | exception Failure msg ->
+        check bool
+          (Printf.sprintf "source_path error mentions bad path %S" rel)
+          true
+          (string_contains ~needle:(Printf.sprintf "%S" rel) msg))
+    unsafe_relatives
 ;;
 
 let test_population_sanity () =
@@ -101,6 +204,14 @@ let () =
             `Quick
             test_all_files_have_keeper_prefix
         ; test_case "population sanity (200..1500)" `Quick test_population_sanity
+        ; test_case
+            "boundary registry is sorted, unique, and necessary"
+            `Quick
+            test_boundary_registry_is_sorted_unique_and_necessary
+        ; test_case
+            "source_path rejects unsafe repo-relative paths"
+            `Quick
+            test_source_path_contract_rejects_unsafe_relatives
         ] )
     ]
 ;;

--- a/test/test_rfc_0086_keeper_namespace_invariant.ml
+++ b/test/test_rfc_0086_keeper_namespace_invariant.ml
@@ -15,22 +15,7 @@ open Alcotest
     of any individual .ml AST, so an AST-grep would be the wrong axis
     here. *)
 
-let rec find_up dir rel =
-  let candidate = Filename.concat dir rel in
-  if Sys.file_exists candidate then Some candidate
-  else (
-    let parent = Filename.dirname dir in
-    if String.equal parent dir then None else find_up parent rel)
-;;
-
-let source_path rel =
-  match find_up (Sys.getcwd ()) rel with
-  | Some path -> path
-  | None ->
-    failf "could not locate source path %S from cwd %S" rel (Sys.getcwd ())
-;;
-
-let keeper_root () = source_path "lib/keeper"
+let keeper_root () = Masc_test_deps.source_path "lib/keeper"
 
 let rec collect_ml_files dir acc =
   let entries = try Sys.readdir dir with Sys_error _ -> [||] in
@@ -51,25 +36,37 @@ let basename_no_ext path =
   try Filename.chop_extension b with Invalid_argument _ -> b
 ;;
 
-let intentional_boundary_module = function
-  | "surface_ref" ->
-    (* Shared typed surface vocabulary extracted for keeper lanes,
-       external attention, and gate recording.  It intentionally has a
-       domain name rather than a keeper_ prefix; renaming it is a broad
-       module-boundary migration, not an accidental file-add regression. *)
-    true
-  | _ -> false
+let boundary_modules_path =
+  "docs/rfc/RFC-0086-keeper-namespace-boundary-modules.txt"
+
+let intentional_boundary_modules () =
+  let path = Masc_test_deps.source_path boundary_modules_path in
+  let lines =
+    In_channel.with_open_text path (fun ic ->
+      In_channel.input_all ic |> String.split_on_char '\n')
+  in
+  List.filter_map
+    (fun line ->
+      let line = String.trim line in
+      if String.equal line "" || line.[0] = '#'
+      then None
+      else (
+        match String.split_on_char '|' line with
+        | name :: _ -> Some (String.trim name)
+        | [] -> None))
+    lines
 ;;
 
 let test_all_files_have_keeper_prefix () =
   let files = collect_ml_files (keeper_root ()) [] in
+  let boundary_modules = intentional_boundary_modules () in
   let offenders =
     List.filter
       (fun path ->
         let base = basename_no_ext path in
         not
-          (String.length base >= 7 && String.sub base 0 7 = "keeper_"
-           || intentional_boundary_module base))
+          (String.starts_with ~prefix:"keeper_" base
+           || List.mem base boundary_modules))
       files
   in
   match offenders with

--- a/test/test_rfc_0086_keeper_namespace_invariant.ml
+++ b/test/test_rfc_0086_keeper_namespace_invariant.ml
@@ -181,6 +181,18 @@ let test_source_path_contract_rejects_unsafe_relatives () =
     unsafe_relatives
 ;;
 
+let test_source_path_contract_resolves_valid_relative () =
+  (* Positive counterpart to the rejection test: a clean repo-relative
+     path resolves to an absolute filesystem path that lands on the real
+     keeper directory.  Guards against a future change that quietly
+     mangles or relativizes the resolved path. *)
+  let resolved = Masc_test_deps.source_path "lib/keeper" in
+  check bool "source_path returns an absolute path" true
+    (Filename.is_absolute resolved);
+  check bool "source_path lands on a real keeper directory" true
+    (Sys.is_directory resolved)
+;;
+
 let test_population_sanity () =
   let files = collect_ml_files (keeper_root ()) [] in
   (* Population sanity: a sudden drop to near-zero or jump beyond
@@ -212,6 +224,10 @@ let () =
             "source_path rejects unsafe repo-relative paths"
             `Quick
             test_source_path_contract_rejects_unsafe_relatives
+        ; test_case
+            "source_path resolves valid repo-relative paths"
+            `Quick
+            test_source_path_contract_resolves_valid_relative
         ] )
     ]
 ;;

--- a/test/test_server_bootstrap_loop_fork_helper.ml
+++ b/test/test_server_bootstrap_loop_fork_helper.ml
@@ -7,10 +7,6 @@ open Alcotest
    cancellation propagation and crash logging in one place while preserving
    loop-specific iteration error handling. *)
 
-let read_file path =
-  In_channel.with_open_text (Masc_test_deps.source_path path) In_channel.input_all
-;;
-
 let count_substring ~haystack ~needle =
   let rec loop i acc =
     let next = String.index_from_opt haystack i needle.[0] in
@@ -27,7 +23,9 @@ let count_substring ~haystack ~needle =
 ;;
 
 let test_raw_fork_is_owned_by_helper () =
-  let content = read_file "lib/server/server_bootstrap_loops_fiber.ml" in
+  let content =
+    Masc_test_deps.read_source_file "lib/server/server_bootstrap_loops_fiber.ml"
+  in
   check int
     "only fork_logged_fiber owns direct Eio.Fiber.fork in server_bootstrap_loops_fiber"
     1
@@ -35,7 +33,9 @@ let test_raw_fork_is_owned_by_helper () =
 ;;
 
 let test_bootstrap_sites_use_logged_helper () =
-  let content = read_file "lib/server/server_bootstrap_loops.ml" in
+  let content =
+    Masc_test_deps.read_source_file "lib/server/server_bootstrap_loops.ml"
+  in
   check bool
     "bootstrap/background fibers route through fork_logged_fiber"
     true
@@ -50,7 +50,9 @@ let test_bootstrap_sites_use_logged_helper () =
    loops module spawns no raw fork either; every site routes through
    [fork_logged_fiber]. *)
 let test_loops_has_no_raw_fork () =
-  let content = read_file "lib/server/server_bootstrap_loops.ml" in
+  let content =
+    Masc_test_deps.read_source_file "lib/server/server_bootstrap_loops.ml"
+  in
   check int
     "no raw Eio.Fiber.fork in server_bootstrap_loops; sites route through \
      fork_logged_fiber"
@@ -59,7 +61,9 @@ let test_loops_has_no_raw_fork () =
 ;;
 
 let test_crash_log_names_remain_specific () =
-  let content = read_file "lib/server/server_bootstrap_loops.ml" in
+  let content =
+    Masc_test_deps.read_source_file "lib/server/server_bootstrap_loops.ml"
+  in
   List.iter
     (fun needle ->
        check bool

--- a/test/test_server_bootstrap_loop_fork_helper.ml
+++ b/test/test_server_bootstrap_loop_fork_helper.ml
@@ -4,26 +4,11 @@ open Alcotest
 
     The module used to repeat raw [Eio.Fiber.fork] + cancellation-safe
     exception handling at each bootstrap/background loop site. The helper keeps
-    cancellation propagation and crash logging in one place while preserving
-    loop-specific iteration error handling. *)
-
-let rec find_up dir rel =
-  let candidate = Filename.concat dir rel in
-  if Sys.file_exists candidate then Some candidate
-  else (
-    let parent = Filename.dirname dir in
-    if String.equal parent dir then None else find_up parent rel)
-;;
-
-let source_path rel =
-  match find_up (Sys.getcwd ()) rel with
-  | Some path -> path
-  | None ->
-    failf "could not locate source path %S from cwd %S" rel (Sys.getcwd ())
-;;
+   cancellation propagation and crash logging in one place while preserving
+   loop-specific iteration error handling. *)
 
 let read_file path =
-  In_channel.with_open_text (source_path path) In_channel.input_all
+  In_channel.with_open_text (Masc_test_deps.source_path path) In_channel.input_all
 ;;
 
 let count_substring ~haystack ~needle =

--- a/test/test_server_bootstrap_loop_fork_helper.ml
+++ b/test/test_server_bootstrap_loop_fork_helper.ml
@@ -7,10 +7,23 @@ open Alcotest
     cancellation propagation and crash logging in one place while preserving
     loop-specific iteration error handling. *)
 
+let rec find_up dir rel =
+  let candidate = Filename.concat dir rel in
+  if Sys.file_exists candidate then Some candidate
+  else (
+    let parent = Filename.dirname dir in
+    if String.equal parent dir then None else find_up parent rel)
+;;
+
+let source_path rel =
+  match find_up (Sys.getcwd ()) rel with
+  | Some path -> path
+  | None ->
+    failf "could not locate source path %S from cwd %S" rel (Sys.getcwd ())
+;;
+
 let read_file path =
-  match In_channel.with_open_text path In_channel.input_all with
-  | exception _ -> ""
-  | content -> content
+  In_channel.with_open_text (source_path path) In_channel.input_all
 ;;
 
 let count_substring ~haystack ~needle =

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -421,9 +421,15 @@ let test_mcp_reconnect_stays_accepted () =
   check_status "follow-up /mcp reconnect accepted" 200 second
 
 let test_ag_ui_rejects_reconnect_then_recovers () =
-  with_server @@ fun ~port ~auth_token:_ ->
+  with_server @@ fun ~port ~auth_token ->
   let sid = Printf.sprintf "storm-agui-%06d" (Random.int 1_000_000) in
-  let headers = [("Accept", "text/event-stream"); ("Mcp-Session-Id", sid)] in
+  let headers =
+    [
+      ("Accept", "text/event-stream");
+      ("Authorization", "Bearer " ^ auth_token);
+      ("Mcp-Session-Id", sid);
+    ]
+  in
 
   (* Stay well inside the 1s reconnect guard so the next request is truly immediate. *)
   let first = run_curl ~headers ~max_time:0.2 ~port ~path:"/ag-ui/events?workspace=default" () in

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -423,6 +423,8 @@ let test_mcp_reconnect_stays_accepted () =
 let test_ag_ui_rejects_reconnect_then_recovers () =
   with_server @@ fun ~port ~auth_token ->
   let sid = Printf.sprintf "storm-agui-%06d" (Random.int 1_000_000) in
+  (* /ag-ui/events uses the observer SSE auth path; mirror /mcp by passing the
+     dashboard dev token explicitly. *)
   let headers =
     [
       ("Accept", "text/event-stream");


### PR DESCRIPTION
## Summary
- make source-scanning ratchet tests resolve files from the real repo root under Dune sandboxing
- document the intentional surface_ref namespace exception and refresh the Keeper_metrics count
- pass the dashboard auth token through the ag-ui SSE reconnect e2e path

## Verification
- ocamlformat --check test/test_server_bootstrap_loop_fork_helper.ml test/test_rfc_0086_keeper_namespace_invariant.ml test/test_otel_zero_fill.ml test/test_dune_local_script.ml test/test_sse_storm_e2e.ml
- git diff --check origin/main...HEAD
- env MASC_DUNE_ALLOW_BARE_DUNE=1 MASC_E2E_TESTS=true scripts/dune-local.sh build --cache=disabled @test/runtest-test_server_bootstrap_loop_fork_helper @test/runtest-test_rfc_0086_keeper_namespace_invariant @test/runtest-test_otel_zero_fill @test/runtest-test_dune_local_script test/test_sse_storm_e2e.exe
- env MASC_E2E_TESTS=true _build/default/test/test_sse_storm_e2e.exe

Follow-up to #22288 after it was squash-merged before these CI harness repairs landed.