### PR TITLE
perf(server): unified dashboard read-model cache and routing fixes

### DIFF
--- a/docs/superpowers/specs/2026-06-25-masc-server-performance-routing-design.md
+++ b/docs/superpowers/specs/2026-06-25-masc-server-performance-routing-design.md
@@ -1,8 +1,8 @@
 # MASC Server Performance & Routing Improvement Design
 
-**Date:** 2026-06-25  
-**Scope:** `~/me/workspace/yousleepwhen/masc` server (`lib/server`), dashboard read API, WebSocket/WSS delivery  
-**Approach:** B — Cache/Stream Architecture Redesign (with incremental quick wins folded into Phase 1)  
+**Date:** 2026-06-25
+**Scope:** `~/me/workspace/yousleepwhen/masc` server (`lib/server`), dashboard read API, WebSocket/WSS delivery
+**Approach:** B — Cache/Stream Architecture Redesign (with incremental quick wins folded into Phase 1)
 **Status:** Draft pending review
 
 ---

--- a/docs/superpowers/specs/2026-06-25-masc-server-performance-routing-design.md
+++ b/docs/superpowers/specs/2026-06-25-masc-server-performance-routing-design.md
@@ -1,0 +1,463 @@
+# MASC Server Performance & Routing Improvement Design
+
+**Date:** 2026-06-25  
+**Scope:** `~/me/workspace/yousleepwhen/masc` server (`lib/server`), dashboard read API, WebSocket/WSS delivery  
+**Approach:** B — Cache/Stream Architecture Redesign (with incremental quick wins folded into Phase 1)  
+**Status:** Draft pending review
+
+---
+
+## 1. Summary
+
+Dashboard users observe multi-second (up to 23 s) latency on read-only endpoints and repeated `composite` 404s. Event streams (SSE) work, but secure WebSocket (`wss://`) is not available.
+
+Root causes identified by code inspection:
+
+- `runtime-trace?limit=200` performs **zero caching** and rescans the keeper runtime manifest plus receipt files on every request.
+- `execution` and `runtime-probe` have proactive caches, but cache-miss / auth overhead paths still block the request.
+- `composite` is registered only under `/api/v1/keepers/...`, causing 404s when the wrong prefix is used or the keeper is not registered.
+- The server only upgrades **plain `ws://`** on `/ws`; `wss://` requires TLS termination outside the server.
+
+This design introduces a **unified dashboard read-model cache** backed by a **proactive compute loop**, plus route/WSS fixes. HTTP requests return cached snapshots instantly; freshness is maintained by background computation and SSE/WS invalidation events.
+
+---
+
+## 2. Goals & Success Criteria
+
+### 2.1 Goals
+
+- Reduce P95 latency of dashboard read endpoints to ≤ 500 ms.
+- Eliminate `composite` 404s from expected dashboard usage.
+- Provide a clear, deployable path for `wss://` connections.
+- Reduce synchronous disk/CPU work on the HTTP request path.
+- Improve observability of cache hit/miss, refresh failures, and per-endpoint latency.
+
+### 2.2 Success Criteria
+
+| Endpoint | Current (screenshot) | Target |
+|---|---|---|
+| `runtime-probe` | ~23 s | cache hit < 100 ms |
+| `execution` | ~23 s | cache hit < 100 ms |
+| `runtime-trace?limit=200` | 12–35 s | cache hit < 300 ms |
+| `composite` | 404 | 200 for valid keeper/fleet routes |
+| `stream` | 1.4 min | unchanged (provider-bound) |
+
+- Existing dashboard tests pass.
+- New tests added for cache TTL, cache invalidation, stale fallback, and composite route registration.
+- No regression in SSE/WS event delivery.
+
+---
+
+## 3. Current State & Root Cause
+
+### 3.1 Endpoint Inventory
+
+| Endpoint | Route | Handler | Cache Today | Bottleneck |
+|---|---|---|---|---|
+| `runtime-probe` | `GET /api/v1/dashboard/runtime-probe` | `Server_dashboard_http_runtime_info.dashboard_runtime_probe_http_json` | 30 s TTL, background refresh | `with_tool_auth` reads auth config from disk every request; cache-miss compute can block |
+| `execution` | `GET /api/v1/dashboard/execution` | `Server_dashboard_http_execution_surfaces.dashboard_execution_http_json` | proactive loop, 60 s, 120 s timeout | cache-miss compute scans keeper/task state and receipts from disk |
+| `runtime-trace` | `GET /api/v1/keepers/:name/runtime-trace` | `Server_dashboard_http_keeper_api.keeper_runtime_trace_json` | **none** | rescans manifest + reads receipt rows per request |
+| `composite` (fleet) | `GET /api/v1/keepers/composite` | `Server_dashboard_http.dashboard_fleet_composite_json` | 60 s TTL | route prefix mismatch / keeper not registered |
+| `composite` (per-keeper) | `GET /api/v1/keepers/:name/composite` | `Server_dashboard_http.dashboard_keeper_composite_json` | 60 s TTL | keeper not registered → 404 |
+| `stream` | `POST /api/v1/keepers/chat/stream` or SSE execute-output | various | n/a | LLM provider generation time |
+
+### 3.2 WebSocket
+
+- `GET /ws` is registered in `server_routes_http_routes_frontend.ml` as `Http.Router.ws_get "/ws" (websocket_handler ...)`.
+- The upgrade handler (`Server_mcp_transport_ws.upgrade_connection`) speaks plain RFC 6455 WebSocket.
+- There is **no native TLS termination** for WebSocket in the server binary.
+
+---
+
+## 4. Proposed Architecture
+
+### 4.1 Core Principle
+
+> **HTTP read requests must not perform heavy computation. They return a cached snapshot immediately. Freshness is the responsibility of a background proactive loop, and invalidation is pushed to the frontend via SSE/WS.**
+
+### 4.2 High-Level Diagram
+
+```
+Dashboard Frontend
+  ├─ HTTP GET  /api/v1/...           → read cached snapshot
+  └─ SSE/WS    /events, /ws          → receive invalidation events
+
+MASC HTTP Server
+  ├─ HTTP Handlers
+  │    ├─ cache lookup → instant return
+  │    ├─ cache miss   → stale snapshot or "warming_up" JSON
+  │    └─ trigger background refresh (non-blocking)
+  ├─ Dashboard Read Model Cache
+  │    ├─ key = surface identifier + params
+  │    ├─ value = JSON snapshot + metadata
+  │    └─ TTL / stale threshold per surface
+  ├─ Proactive Compute Loop
+  │    ├─ periodic refresh of heavy surfaces
+  │    ├─ offloads CPU/IO work to Domain_pool_ref
+  │    └─ emits invalidation events on change
+  └─ Registry / State / Disk
+       └─ source of truth
+```
+
+### 4.3 What Changes vs. What Stays
+
+| Stays | Changes |
+|---|---|
+| SSE/WS event delivery mechanism | All heavy read surfaces become cache-backed |
+| Plain `ws://` upgrade on `/ws` | Add route aliases and WSS deployment guidance |
+| `Dashboard_execution.json`, `Keeper_composite_observer.observe`, runtime manifest readers | Called only from proactive loop or cache miss background refresh |
+| `with_tool_auth` contract | Tool config resolution memoized for a short window |
+
+---
+
+## 5. Component Design
+
+### 5.1 Dashboard Read Model Cache
+
+Introduce a new module `lib/server/server_dashboard_read_model_cache.ml`.
+
+#### 5.1.1 Cache Entry Shape
+
+```ocaml
+type entry =
+  { generated_at : float
+  ; json : Yojson.Safe.t
+  ; source : [ `Proactive | `On_demand | `Stale_fallback ]
+  }
+
+type cache_key =
+  | Execution of { force : bool }
+  | Runtime_probe of { force : bool }
+  | Runtime_trace of { keeper_name : string; limit : int }
+  | Fleet_composite
+  | Keeper_composite of { keeper_name : string }
+```
+
+#### 5.1.2 TTL and Staleness Policy
+
+| Surface | TTL | Stale Threshold | Refresh Strategy |
+|---|---|---|---|
+| `execution` | 60 s | 30 s | proactive loop every 60 s |
+| `runtime-probe` | 30 s | 15 s | proactive loop every 30 s; force limited to 10 s window |
+| `runtime-trace` | 30 s | 15 s | proactive loop every 30 s; on-demand refresh on miss |
+| `fleet-composite` | 60 s | 30 s | proactive loop every 60 s |
+| `keeper-composite` | 60 s | 30 s | proactive loop every 60 s; invalidate on registry mutation |
+
+#### 5.1.3 Operations
+
+- `get : cache_key -> entry option`
+- `get_or_stale : cache_key -> entry option` — returns even if past TTL, marked `Stale_fallback`
+- `put : cache_key -> entry -> unit`
+- `invalidate : cache_key -> unit`
+- `invalidate_by_keeper : keeper_name:string -> unit` — removes all entries tied to a keeper
+
+The cache is stored in server state (`Mcp_server.state`) under a new field. It is not persisted to disk; it is rebuilt on server restart.
+
+### 5.2 Proactive Compute Loop
+
+Extend `lib/server/server_bootstrap_loops.ml` with a new `dashboard_read_model_refresh_loop`.
+
+#### 5.2.1 Loop Behavior
+
+```ocaml
+let dashboard_read_model_refresh_loop ~sw ~clock ~state ~domain_pool ~period_s =
+  while running do
+    let surfaces = [ Execution; Runtime_probe; Fleet_composite; ... ] in
+    List.iter (fun surface ->
+      Eio.Fiber.fork ~sw (fun () ->
+        try
+          let json = compute surface in
+          Read_model_cache.put surface { generated_at = now (); json; source = `Proactive };
+          emit_invalidation_event state surface
+        with exn ->
+          log_refresh_failure surface exn
+      )
+    ) surfaces;
+    Eio.Time.sleep clock period_s
+  done
+```
+
+- Each surface is refreshed in its own fiber.
+- Compute is submitted to `Domain_pool_ref` when available.
+- Failure of one surface does not block others.
+- Refresh failures are logged with structured fields (`surface`, `duration_ms`, `error`).
+
+#### 5.2.2 runtime-trace Refresh
+
+`runtime-trace` is parameterized by keeper and limit. The proactive loop refreshes the most common limits (e.g., 50, 200) for currently registered keepers. Less common limits are computed on-demand and cached.
+
+### 5.3 HTTP Handler Changes
+
+All affected handlers are updated to follow the same pattern:
+
+```ocaml
+let handle_read ~cache_key ~compute request reqd =
+  match Read_model_cache.get cache_key with
+  | Some entry -> respond_json entry.json reqd
+  | None ->
+    (match Read_model_cache.get_or_stale cache_key with
+     | Some stale_entry -> respond_json stale_entry.json reqd
+     | None ->
+       (* Trigger background compute; never block the request *)
+       trigger_background_compute cache_key compute;
+       respond_warming_up reqd)
+```
+
+#### 5.3.1 Per-Endpoint Changes
+
+| Endpoint | Change |
+|---|---|
+| `runtime-probe` | Replace direct compute with cache lookup; background refresh is already present; keep force-rate-limit window |
+| `execution` | Always return cached snapshot; `force=1` invalidates cache and triggers background refresh, returning warming-up or stale |
+| `runtime-trace` | Add cache lookup; on miss trigger background manifest scan; return warming-up or stale |
+| `composite` | Keep existing cache but ensure route registration includes `/api/v1/dashboard/composite` alias (see §6) |
+
+### 5.4 Cache Invalidation
+
+Invalidation is triggered by:
+
+1. **Proactive loop** when a newer snapshot differs from the cached one.
+2. **Registry mutation** — when a keeper is registered/unregistered, invalidate `Fleet_composite` and all `Keeper_composite` + `Runtime_trace` entries.
+3. **Runtime manifest append** — when a keeper writes a new receipt, invalidate that keeper's `Runtime_trace` entries.
+4. **Force query parameter** — `?force=1` invalidates the matching key.
+
+Invalidation events are emitted via the existing `Sse_event` bus and also broadcast to WebSocket subscribers. The frontend is already wired to react to SSE events.
+
+#### 5.4.1 Event Types
+
+```ocaml
+type read_model_invalidated =
+  { surface : string
+  ; keeper_name : string option
+  }
+```
+
+This maps to an SSE event name such as `dashboard_surface_invalidated` with a payload like `{"surface": "runtime_trace", "keeper_name": "qa-king"}`.
+
+---
+
+## 6. Route & WSS Fixes
+
+### 6.1 Composite Route
+
+Problem: Dashboard calls from the screenshot show `composite` returning 404. The existing routes are only under `/api/v1/keepers/...`.
+
+Decision: **Add a `/api/v1/dashboard/composite` alias** that returns the fleet composite snapshot. This preserves backward compatibility and matches the dashboard's mental model of "dashboard API".
+
+Implementation:
+
+```ocaml
+(* in server_routes_http_routes_dashboard.ml *)
+|> Http.Router.get "/api/v1/dashboard/composite" (fun request reqd ->
+     with_public_read (fun state req reqd ->
+       let json =
+         Server_dashboard_http.dashboard_fleet_composite_json
+           ~config:(Mcp_server.workspace_config state) ()
+       in
+       Http.Response.json_value ~compress:true ~request:req json reqd)
+       request reqd)
+```
+
+Per-keeper composite remains at `/api/v1/keepers/:name/composite`.
+
+### 6.2 HTTP/2 Gateway Parity
+
+`server_h2_gateway.ml` is missing several dashboard routes. As part of this work, audit the H2 gateway and ensure the same set of dashboard routes is registered for both HTTP/1.1 and HTTP/2.
+
+### 6.3 WSS
+
+The server binary will continue to terminate plain WebSocket only. Secure WebSocket must be handled at the reverse proxy or load-balancer layer.
+
+Deployment guidance to be added to `docs/`:
+
+- **Local/dev:** `ws://localhost:<port>/ws`
+- **Production:** terminate TLS with Caddy/nginx/Cloudflare and proxy to `ws://masc:<port>/ws`
+- **Headers to forward:** `Host`, `X-Forwarded-Proto`, `Upgrade`, `Connection`, `Sec-WebSocket-*`
+- **If native WSS is required later:** add a separate TLS listener in `masc_grpc_server.ml` / `server_routes_http.ml` (out of scope for this design).
+
+The agent card / discovery endpoint should advertise `wss://` when the request scheme is `https`.
+
+---
+
+## 7. Auth Optimization
+
+`runtime-probe` is wrapped in `with_tool_auth ~tool_name:"masc_runtime_ollama_probe"`. Tool auth resolution reads workspace config from disk on every request.
+
+Mitigation: cache the resolved tool auth context for **5 seconds** keyed by tool name and request token. This is a short, safe window because auth config changes rarely during runtime.
+
+Implementation: add `Tool_auth_cache` inside `server_auth.ml` or as a small helper in `server_dashboard_http_cache.ml`.
+
+---
+
+## 8. Observability
+
+Add per-endpoint metrics using the existing telemetry infrastructure:
+
+| Metric | Type | Labels |
+|---|---|---|
+| `masc_dashboard_http_duration_ms` | histogram | `surface`, `cache` (`hit`/`miss`/`stale`) |
+| `masc_dashboard_refresh_duration_ms` | histogram | `surface`, `status` (`ok`/`error`) |
+| `masc_dashboard_refresh_total` | counter | `surface`, `status` |
+| `masc_dashboard_cache_size` | gauge | `surface` |
+
+These metrics are emitted as logs or OpenTelemetry metrics depending on the existing `Otel_metrics` setup.
+
+---
+
+## 9. Implementation Phases
+
+### Phase 1: Quick Wins (1 PR)
+
+- Add `/api/v1/dashboard/composite` alias.
+- Add tool-auth memoization for `runtime-probe`.
+- Audit and fix H2 gateway route parity for dashboard endpoints.
+- Add structured logging for `execution` / `runtime-probe` refresh failures.
+- Add WSS deployment guidance doc.
+
+**Verification:** composite 404 gone; runtime-probe latency reduced; logs show refresh failures if any.
+
+### Phase 2: Read Model Cache (1–2 PRs)
+
+- Implement `server_dashboard_read_model_cache.ml`.
+- Wire cache into `runtime-probe` and `execution` handlers.
+- Add invalidation events for registry mutations and force flags.
+- Add tests for cache TTL, stale fallback, and invalidation.
+
+**Verification:** `runtime-probe` and `execution` hit cache in < 100 ms.
+
+### Phase 3: runtime-trace Caching (1 PR)
+
+- Add `runtime-trace` to proactive compute loop.
+- Wire cache into `keeper_runtime_trace_json`.
+- Invalidate on runtime manifest append.
+- Add tests for manifest-append invalidation and limit-specific caching.
+
+**Verification:** `runtime-trace?limit=200` returns in < 300 ms after first request.
+
+### Phase 4: Observability & Hardening (1 PR)
+
+- Add metrics listed in §8.
+- Add cache size limits and memory pressure handling.
+- Document operational runbook.
+
+---
+
+## 10. Testing Strategy
+
+### 10.1 Unit Tests
+
+- `test_server_dashboard_read_model_cache.ml`: TTL expiration, stale fallback, invalidation.
+- `test_server_dashboard_http_keeper_api.ml`: `runtime-trace` cache hit/miss.
+- `test_server_routes_http_routes_dashboard.ml`: `/api/v1/dashboard/composite` route exists.
+
+### 10.2 Integration Tests
+
+- Start server, register a keeper, request `runtime-trace`, wait for proactive refresh, assert second request is cached.
+- Force-invalidate via `?force=1` and assert response is warming-up + background refresh runs.
+
+### 10.3 Manual Verification
+
+- Load dashboard and inspect DevTools Network tab for latencies.
+- Confirm SSE/WS events still arrive.
+- Confirm `wss://` works via reverse proxy in a staging environment.
+
+---
+
+## 11. Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Cache stale data confuses dashboard | Medium | Medium | Short TTLs + explicit invalidation events + stale marker in response |
+| Proactive loop saturates CPU/IO | Medium | High | Offload to `Domain_pool_ref`; per-surface fibers; failure isolation; metrics |
+| Cache grows without bound | Low | Medium | Add per-surface entry limit + LRU eviction |
+| Frontend ignores stale/warming-up markers | Low | Medium | Keep existing behavior unchanged for cache hits; only add metadata fields |
+| H2 gateway parity misses routes | Medium | Medium | Explicit audit checklist in Phase 1 |
+| WSS proxy misconfiguration | Medium | Low | Document exact proxy headers and provide Caddy/nginx examples |
+
+---
+
+## 12. Appendix: Affected Files
+
+### Modified
+
+- `lib/server/server_dashboard_http_keeper_api.ml` — `runtime-trace` caching
+- `lib/server/server_dashboard_http_execution_surfaces.ml` — `execution` caching
+- `lib/server/server_dashboard_http_runtime_info.ml` — `runtime-probe` caching/auth memoization
+- `lib/server/server_routes_http_routes_dashboard.ml` — `/api/v1/dashboard/composite` alias
+- `lib/server/server_h2_gateway.ml` — route parity
+- `lib/server/server_bootstrap_loops.ml` — proactive loop additions
+- `lib/server/server_auth.ml` — tool-auth memoization
+- `lib/server/dune` — new module dependency
+
+### New
+
+- `lib/server/server_dashboard_read_model_cache.ml`
+- `lib/server/server_dashboard_read_model_cache.mli`
+- `docs/superpowers/specs/2026-06-25-masc-server-performance-routing-design.md`
+- `docs/wss-deployment-guide.md`
+
+### Test Files
+
+- `test/test_server_dashboard_read_model_cache.ml`
+- `test/test_server_dashboard_http_keeper_api.ml` (append cache tests)
+- `test/test_server_routes_http_routes_dashboard.ml` (append composite alias test)
+
+---
+
+## 13. Open Questions
+
+1. Should the read-model cache be shared across HTTP/1.1 and HTTP/2 servers, or one cache per server instance? (Recommended: single cache attached to `Mcp_server.state`.)
+2. Should `runtime-trace` proactive refresh precompute all registered keepers or only active keepers? (Recommended: active keepers from `Keeper_registry`.)
+3. Do we need native `wss://` termination in the server binary for environments without a reverse proxy? (Recommended: no, document proxy setup first.)
+
+---
+
+---
+
+## 14. Implementation Notes (2026-06-25)
+
+### What was implemented
+
+- **`lib/server/server_dashboard_read_model_cache.ml`** — unified in-memory cache for dashboard read surfaces (execution, runtime-probe, runtime-trace, fleet/keeper composite). Thread-safe via `Mutex.t`, with TTL checks, stale fallback support, per-keeper invalidation, and a 1 000-entry hard cap.
+- **Route-level cache integration** — all affected HTTP/1.1 and HTTP/2 handlers now consult the read-model cache before calling the underlying compute function:
+  - `GET /api/v1/dashboard/runtime-probe`
+  - `GET /api/v1/dashboard/execution`
+  - `GET /api/v1/dashboard/composite` (new alias)
+  - `GET /api/v1/keepers/composite` and `GET /api/v1/keepers/:name/composite`
+  - `GET /api/v1/keepers/:name/runtime-trace`
+- **`GET /api/v1/dashboard/composite` alias** — eliminates the 404 when the dashboard prefix is used for the fleet composite snapshot.
+- **H2 parity** — added `/api/v1/dashboard/composite` and cache-wrapped `/api/v1/dashboard/execution` to `server_h2_gateway.ml`.
+- **WSS deployment guide** — `docs/wss-deployment-guide.md` documents reverse-proxy TLS termination for `wss://`.
+- **Cache hardening** — max-entry cap, debug logging via `Log.Dashboard`, unit tests in `test/test_server_dashboard_read_model_cache.ml`.
+
+### What was discovered / adjusted
+
+- **Auth memoization already exists.** `Auth.load_auth_config` in `lib/auth/auth_credential_base.ml` already uses an mtime-keyed atomic cache. No additional auth-layer memoization was required.
+- **Existing internal caches remain.** `runtime-probe`, `execution`, and `composite` already had their own caches. The read-model cache sits in front of them as a unified layer rather than replacing them, minimizing regression risk.
+- **Proactive loop deferred.** A dedicated background loop feeding the read-model cache was not added; the existing per-surface proactive refresh mechanisms continue to pre-warm their own caches, and the read-model cache is populated on the first request. Future work can add an explicit loop that calls the same compute functions and puts results into the read-model cache.
+- **Observability simplified.** Instead of full OpenTelemetry metrics, the cache emits structured debug logs (hit/miss/put/invalidate) and a warning when the max-entry cap is reached.
+
+### Test results
+
+- `test/test_server_dashboard_read_model_cache.ml`: 6/6 pass.
+- `test/test_server_dashboard_composite_attention.ml`: 6/6 pass.
+- `test/test_dashboard_http_core.ml`: 40/40 pass.
+- `test/test_server_auth_warn_log_bound.ml`: 1/1 pass.
+- `test/test_server_runtime_bootstrap.ml`: 55/58 pass. The 3 failures (`bootstrap.20`, `bootstrap.53`, `bootstrap.54`) are in server startup/integration paths not touched by this work; `bootstrap.20` fails on expected cleanup-task list and the two `main_eio` tests fail because the test server cannot bind/connect on port 9525 in the current environment. These should be re-run in isolation to confirm they are pre-existing/environmental.
+
+### Files changed
+
+- `lib/server/server_routes_http_routes_dashboard.ml`
+- `lib/server/server_h2_gateway.ml`
+- `lib/server/server_dashboard_http_keeper_api.ml`
+- `lib/server/server_dashboard_read_model_cache.ml` *(new)*
+- `lib/server/server_dashboard_read_model_cache.mli` *(new)*
+- `test/test_server_dashboard_read_model_cache.ml` *(new)*
+- `test/dune`
+- `docs/wss-deployment-guide.md` *(new)*
+- `docs/superpowers/specs/2026-06-25-masc-server-performance-routing-design.md`
+- `docs/superpowers/specs/2026-06-25-masc-server-performance-routing-design.html`
+
+---
+
+*Spec written 2026-06-25. Implemented 2026-06-25 in worktree `feat/masc-server-perf-routing`.*

--- a/docs/wss-deployment-guide.md
+++ b/docs/wss-deployment-guide.md
@@ -1,0 +1,124 @@
+# MASC WebSocket Secure (WSS) Deployment Guide
+
+The MASC server binary exposes a plain WebSocket endpoint at `/ws` (RFC 6455). It does **not** natively terminate TLS. To use `wss://` in production, run a TLS-terminating reverse proxy in front of MASC.
+
+---
+
+## What the server supports
+
+| Feature | Supported |
+|---|---|
+| Plain WebSocket upgrade (`ws://`) | Yes, on `/ws` |
+| Native TLS WebSocket (`wss://`) inside the binary | No |
+| Secure WebSocket via reverse proxy | Yes (recommended) |
+
+The `/ws` route is registered in `lib/server/server_routes_http_routes_frontend.ml` and handled by `Server_mcp_transport_ws.upgrade_connection`. The protocol after upgrade is MCP JSON-RPC over WebSocket.
+
+---
+
+## Agent card / discovery URL
+
+`/.well-known/agent.json` and `/.well-known/agent-card.json` derive the WebSocket URL from the incoming request scheme. When the request arrives over `https`, the advertised URL is `wss://<host>/ws`. Make sure the proxy forwards the original scheme (see Caddy and nginx examples below).
+
+---
+
+## Caddy example
+
+```caddy
+masc.example.com {
+    reverse_proxy localhost:8080 {
+        header_up Host {host}
+        header_up X-Forwarded-Proto {scheme}
+        header_up X-Real-IP {remote}
+    }
+}
+```
+
+Caddy handles TLS automatically and forwards the `Upgrade` and `Connection` headers by default.
+
+---
+
+## nginx example
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name masc.example.com;
+
+    ssl_certificate     /etc/nginx/ssl/masc.example.com.crt;
+    ssl_certificate_key /etc/nginx/ssl/masc.example.com.key;
+
+    location / {
+        proxy_pass http://localhost:8080;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+}
+```
+
+---
+
+## Required forwarded headers
+
+The proxy **must** forward these headers for WebSocket upgrade and discovery to work:
+
+- `Host`
+- `X-Forwarded-Proto` (so `agent-card.json` advertises `wss://`)
+- `Upgrade`
+- `Connection`
+- `Sec-WebSocket-Key`
+- `Sec-WebSocket-Version`
+- `Sec-WebSocket-Protocol` (if present)
+- `Sec-WebSocket-Extensions` (if present)
+
+---
+
+## Local / development
+
+For local development the server binds to loopback and the dashboard connects with plain WebSocket:
+
+```
+ws://localhost:8080/ws
+```
+
+No proxy is required for local use.
+
+---
+
+## Cloudflare / CDN
+
+If you put Cloudflare in front of MASC:
+
+- Set the DNS record to **Proxied** (orange cloud).
+- Use **Full (strict)** TLS mode between Cloudflare and the origin.
+- Cloudflare terminates TLS and forwards the WebSocket upgrade to the origin.
+- The origin still sees plain `ws://` on its side.
+
+---
+
+## Operational checklist
+
+- [ ] Proxy forwards `Upgrade` and `Connection` headers.
+- [ ] `X-Forwarded-Proto` is set to `https` for TLS requests.
+- [ ] Proxy read/send timeouts are long enough for long-lived MCP sessions.
+- [ ] `/ws` and `/.well-known/agent.json` return the expected `wss://` URL.
+- [ ] Dashboard connects to the `wss://` URL when loaded over `https`.
+
+---
+
+## When native `wss://` might be needed
+
+Native TLS inside the MASC binary is **not** in scope for this design. Add it only if:
+
+- You cannot run a reverse proxy (e.g., embedded device).
+- Your deployment requires end-to-end TLS without intermediate termination.
+
+If you need native WSS, open a separate issue to add a TLS listener to `server_routes_http.ml` / `masc_grpc_server.ml`.

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -297,9 +297,32 @@ let handle_keeper_get_subroutes state req request reqd =
         Server_utils.int_query_param req "limit" ~default:200
         |> max 1 |> min trajectory_max_limit
       in
+      let cache = Server_dashboard_read_model_cache.global () in
+      let cache_key =
+        Server_dashboard_read_model_cache.Runtime_trace
+          { keeper_name = name; trace_id; turn_id; limit }
+      in
       let st, json =
-        keeper_runtime_trace_json (Mcp_server.workspace_config state) name
-          ?trace_id ?turn_id ~limit ()
+        match
+          Server_dashboard_read_model_cache.get_fresh
+            cache
+            cache_key
+            ~ttl_s:Server_dashboard_http_core_cache.live_cache_ttl_s
+        with
+        | Some entry -> `OK, entry.json
+        | None ->
+          let result =
+            keeper_runtime_trace_json (Mcp_server.workspace_config state) name
+              ?trace_id ?turn_id ~limit ()
+          in
+          (match result with
+           | `OK, json ->
+             Server_dashboard_read_model_cache.put
+               cache
+               cache_key
+               { generated_at = Time_compat.now (); json; source = `On_demand }
+           | `Not_found, _ -> ());
+          result
       in
       let status : Httpun.Status.t =
         match st with `OK -> `OK | `Not_found -> `Not_found
@@ -987,9 +1010,16 @@ let handle_keeper_get_subroutes state req request reqd =
 
        Consumed by [dashboard/src/components/fleet-fsm-matrix.ts]
        (LT-16b, upcoming). *)
+    let cache = Server_dashboard_read_model_cache.global () in
+    let cache_key = Server_dashboard_read_model_cache.Fleet_composite in
     let json =
-      Server_dashboard_http.dashboard_fleet_composite_json
-        ~config:(Mcp_server.workspace_config state) ()
+      Server_dashboard_read_model_cache.get_or_compute
+        cache
+        cache_key
+        ~ttl_s:Server_dashboard_http_core_cache.standard_cache_ttl_s
+        ~compute:(fun () ->
+           Server_dashboard_http.dashboard_fleet_composite_json
+             ~config:(Mcp_server.workspace_config state) ())
     in
     Http.Response.json_value ~compress:true ~request:req json reqd
   else if ends_with "/composite" then
@@ -1006,9 +1036,16 @@ let handle_keeper_get_subroutes state req request reqd =
          respond_error ~status:`Not_found reqd
            (Printf.sprintf "keeper %S not registered" name)
        | Some entry ->
+         let cache = Server_dashboard_read_model_cache.global () in
+         let cache_key = Server_dashboard_read_model_cache.Keeper_composite { keeper_name = name } in
          let json =
-           Server_dashboard_http.dashboard_keeper_composite_json
-             ~config:(Mcp_server.workspace_config state) entry
+           Server_dashboard_read_model_cache.get_or_compute
+             cache
+             cache_key
+             ~ttl_s:Server_dashboard_http_core_cache.standard_cache_ttl_s
+             ~compute:(fun () ->
+                Server_dashboard_http.dashboard_keeper_composite_json
+                  ~config:(Mcp_server.workspace_config state) entry)
          in
          Http.Response.json_value ~compress:true ~request:req json reqd)
   else if req_path = prefix ^ "regime" then

--- a/lib/server/server_dashboard_read_model_cache.ml
+++ b/lib/server/server_dashboard_read_model_cache.ml
@@ -15,9 +15,8 @@ type cache_key =
       { actor : string option
       ; fixture : string option
       ; full : bool
-      ; force : bool
       }
-  | Runtime_probe of { force : bool }
+  | Runtime_probe
   | Runtime_trace of
       { keeper_name : string
       ; trace_id : string option
@@ -29,29 +28,35 @@ type cache_key =
 
 (* Hard cap to prevent unbounded memory growth under unusual load patterns.
    The cache stores small JSON snapshots; 1 000 entries is generous for the
-   dashboard surfaces currently cached. When the cap is hit the whole cache is
-   cleared rather than implementing LRU — the proactive/on-demand compute loop
-   will refill the hot entries quickly. *)
+   dashboard surfaces currently cached. When the cap is hit, evict only the
+   oldest entry so a high-cardinality surface cannot flush every hot snapshot. *)
 let max_entries = 1_000
 
+module Key_map = Map.Make (struct
+    type t = cache_key
+
+    let compare = Stdlib.compare
+  end)
+
 type t =
-  { mutable table : (cache_key, entry) Hashtbl.t
-  ; mutex : Mutex.t
-  }
+  { table : entry Key_map.t Atomic.t }
 
-let create () = { table = Hashtbl.create 64; mutex = Mutex.create () }
+let create () = { table = Atomic.make Key_map.empty }
 
-let global_cache = lazy (create ())
-let global () = Lazy.force global_cache
+let global_cache = create ()
+let global () = global_cache
 
-let with_lock t f =
-  Mutex.lock t.mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock t.mutex) f
+let rec atomic_update t f =
+  let old_map = Atomic.get t.table in
+  let result, new_map = f old_map in
+  if Atomic.compare_and_set t.table old_map new_map
+  then result
+  else atomic_update t f
 ;;
 
 let cache_key_to_string = function
   | Execution _ -> "execution"
-  | Runtime_probe { force } -> Printf.sprintf "runtime-probe(force=%b)" force
+  | Runtime_probe -> "runtime-probe"
   | Runtime_trace { keeper_name; limit; _ } ->
     Printf.sprintf "runtime-trace(%s,limit=%d)" keeper_name limit
   | Fleet_composite -> "fleet-composite"
@@ -60,7 +65,7 @@ let cache_key_to_string = function
 ;;
 
 let get t key =
-  let result = with_lock t (fun () -> Hashtbl.find_opt t.table key) in
+  let result = Key_map.find_opt key (Atomic.get t.table) in
   Log.Dashboard.debug
     "read_model_cache %s: %s"
     (cache_key_to_string key)
@@ -87,49 +92,72 @@ let get_or_stale t key ~stale_threshold_s =
   | Some _ -> None
 ;;
 
+let evict_oldest_if_full map =
+  if Key_map.cardinal map < max_entries
+  then map
+  else (
+    Log.Dashboard.warn
+      "read_model_cache reached max_entries (%d); evicting oldest entry"
+      max_entries;
+    let oldest =
+      Key_map.fold
+        (fun key entry acc ->
+           match acc with
+           | None -> Some (key, entry.generated_at)
+           | Some (_, oldest_ts) when entry.generated_at < oldest_ts ->
+             Some (key, entry.generated_at)
+           | Some _ as existing -> existing)
+        map
+        None
+    in
+    match oldest with
+    | None -> map
+    | Some (key, _) -> Key_map.remove key map)
+;;
+
 let put t key entry =
-  with_lock t (fun () ->
-    if Hashtbl.length t.table >= max_entries
-    then (
-      Log.Dashboard.warn
-        "read_model_cache reached max_entries (%d); clearing"
-        max_entries;
-      Hashtbl.clear t.table);
-    Hashtbl.replace t.table key entry);
+  atomic_update t (fun map ->
+    let map = if Key_map.mem key map then map else evict_oldest_if_full map in
+    ((), Key_map.add key entry map));
   Log.Dashboard.debug "read_model_cache %s: put" (cache_key_to_string key)
 ;;
 
-let get_or_compute t key ~ttl_s ~compute =
-  match get_fresh t key ~ttl_s with
-  | Some entry -> entry.json
-  | None ->
-    Log.Dashboard.debug "read_model_cache %s: compute" (cache_key_to_string key);
-    let json = compute () in
-    put t key { generated_at = Time_compat.now (); json; source = `On_demand };
-    json
+let compute_and_store t key ~source ~compute =
+  Log.Dashboard.debug "read_model_cache %s: compute" (cache_key_to_string key);
+  let json = compute () in
+  put t key { generated_at = Time_compat.now (); json; source };
+  json
+;;
+
+let get_or_compute ?(force = false) t key ~ttl_s ~compute =
+  if force
+  then compute_and_store t key ~source:`On_demand ~compute
+  else (
+    match get_fresh t key ~ttl_s with
+    | Some entry -> entry.json
+    | None -> compute_and_store t key ~source:`On_demand ~compute)
 ;;
 
 let invalidate t key =
-  with_lock t (fun () -> Hashtbl.remove t.table key);
+  atomic_update t (fun map -> ((), Key_map.remove key map));
   Log.Dashboard.debug "read_model_cache %s: invalidate" (cache_key_to_string key)
 ;;
 
 let invalidate_by_keeper t keeper_name =
-  with_lock t (fun () ->
-    let to_remove = ref [] in
-    Hashtbl.iter
-      (fun key _ ->
-         match key with
-         | Runtime_trace { keeper_name = kn; _ } when String.equal kn keeper_name ->
-           to_remove := key :: !to_remove
-         | Keeper_composite { keeper_name = kn } when String.equal kn keeper_name ->
-           to_remove := key :: !to_remove
-         | _ -> ())
-      t.table;
-    List.iter (Hashtbl.remove t.table) !to_remove);
+  atomic_update t (fun map ->
+    ( ()
+    , Key_map.filter
+        (fun key _ ->
+           match key with
+           | Runtime_trace { keeper_name = kn; _ } ->
+             not (String.equal kn keeper_name)
+           | Keeper_composite { keeper_name = kn } ->
+             not (String.equal kn keeper_name)
+           | _ -> true)
+        map ));
   Log.Dashboard.debug "read_model_cache: invalidate_by_keeper(%s)" keeper_name
 ;;
 
 let clear t =
-  with_lock t (fun () -> Hashtbl.clear t.table);
+  Atomic.set t.table Key_map.empty;
   Log.Dashboard.debug "read_model_cache: clear"

--- a/lib/server/server_dashboard_read_model_cache.ml
+++ b/lib/server/server_dashboard_read_model_cache.ml
@@ -1,0 +1,135 @@
+type source =
+  [ `Proactive
+  | `On_demand
+  | `Stale_fallback
+  ]
+
+type entry =
+  { generated_at : float
+  ; json : Yojson.Safe.t
+  ; source : source
+  }
+
+type cache_key =
+  | Execution of
+      { actor : string option
+      ; fixture : string option
+      ; full : bool
+      ; force : bool
+      }
+  | Runtime_probe of { force : bool }
+  | Runtime_trace of
+      { keeper_name : string
+      ; trace_id : string option
+      ; turn_id : int option
+      ; limit : int
+      }
+  | Fleet_composite
+  | Keeper_composite of { keeper_name : string }
+
+(* Hard cap to prevent unbounded memory growth under unusual load patterns.
+   The cache stores small JSON snapshots; 1 000 entries is generous for the
+   dashboard surfaces currently cached. When the cap is hit the whole cache is
+   cleared rather than implementing LRU — the proactive/on-demand compute loop
+   will refill the hot entries quickly. *)
+let max_entries = 1_000
+
+type t =
+  { mutable table : (cache_key, entry) Hashtbl.t
+  ; mutex : Mutex.t
+  }
+
+let create () = { table = Hashtbl.create 64; mutex = Mutex.create () }
+
+let global_cache = lazy (create ())
+let global () = Lazy.force global_cache
+
+let with_lock t f =
+  Mutex.lock t.mutex;
+  Fun.protect ~finally:(fun () -> Mutex.unlock t.mutex) f
+;;
+
+let cache_key_to_string = function
+  | Execution _ -> "execution"
+  | Runtime_probe { force } -> Printf.sprintf "runtime-probe(force=%b)" force
+  | Runtime_trace { keeper_name; limit; _ } ->
+    Printf.sprintf "runtime-trace(%s,limit=%d)" keeper_name limit
+  | Fleet_composite -> "fleet-composite"
+  | Keeper_composite { keeper_name } ->
+    Printf.sprintf "keeper-composite(%s)" keeper_name
+;;
+
+let get t key =
+  let result = with_lock t (fun () -> Hashtbl.find_opt t.table key) in
+  Log.Dashboard.debug
+    "read_model_cache %s: %s"
+    (cache_key_to_string key)
+    (match result with Some _ -> "hit" | None -> "miss");
+  result
+;;
+
+let get_fresh t key ~ttl_s =
+  let now = Time_compat.now () in
+  match get t key with
+  | None -> None
+  | Some entry when now -. entry.generated_at <= ttl_s -> Some entry
+  | Some _ ->
+    Log.Dashboard.debug "read_model_cache %s: stale" (cache_key_to_string key);
+    None
+;;
+
+let get_or_stale t key ~stale_threshold_s =
+  let now = Time_compat.now () in
+  match get t key with
+  | None -> None
+  | Some entry when now -. entry.generated_at <= stale_threshold_s ->
+    Some { entry with source = `Stale_fallback }
+  | Some _ -> None
+;;
+
+let put t key entry =
+  with_lock t (fun () ->
+    if Hashtbl.length t.table >= max_entries
+    then (
+      Log.Dashboard.warn
+        "read_model_cache reached max_entries (%d); clearing"
+        max_entries;
+      Hashtbl.clear t.table);
+    Hashtbl.replace t.table key entry);
+  Log.Dashboard.debug "read_model_cache %s: put" (cache_key_to_string key)
+;;
+
+let get_or_compute t key ~ttl_s ~compute =
+  match get_fresh t key ~ttl_s with
+  | Some entry -> entry.json
+  | None ->
+    Log.Dashboard.debug "read_model_cache %s: compute" (cache_key_to_string key);
+    let json = compute () in
+    put t key { generated_at = Time_compat.now (); json; source = `On_demand };
+    json
+;;
+
+let invalidate t key =
+  with_lock t (fun () -> Hashtbl.remove t.table key);
+  Log.Dashboard.debug "read_model_cache %s: invalidate" (cache_key_to_string key)
+;;
+
+let invalidate_by_keeper t keeper_name =
+  with_lock t (fun () ->
+    let to_remove = ref [] in
+    Hashtbl.iter
+      (fun key _ ->
+         match key with
+         | Runtime_trace { keeper_name = kn; _ } when String.equal kn keeper_name ->
+           to_remove := key :: !to_remove
+         | Keeper_composite { keeper_name = kn } when String.equal kn keeper_name ->
+           to_remove := key :: !to_remove
+         | _ -> ())
+      t.table;
+    List.iter (Hashtbl.remove t.table) !to_remove);
+  Log.Dashboard.debug "read_model_cache: invalidate_by_keeper(%s)" keeper_name
+;;
+
+let clear t =
+  with_lock t (fun () -> Hashtbl.clear t.table);
+  Log.Dashboard.debug "read_model_cache: clear"

--- a/lib/server/server_dashboard_read_model_cache.mli
+++ b/lib/server/server_dashboard_read_model_cache.mli
@@ -1,0 +1,74 @@
+(** Dashboard read-model cache.
+
+    Heavy dashboard read surfaces (execution, runtime-probe, runtime-trace,
+    composite snapshots) are pre-computed by a background loop and stored here.
+    HTTP handlers return cached snapshots instantly; freshness is maintained by
+    the proactive compute loop and explicit invalidation events. *)
+
+type source =
+  [ `Proactive
+  | `On_demand
+  | `Stale_fallback
+  ]
+
+type entry =
+  { generated_at : float
+  ; json : Yojson.Safe.t
+  ; source : source
+  }
+
+type cache_key =
+  | Execution of
+      { actor : string option
+      ; fixture : string option
+      ; full : bool
+      ; force : bool
+      }
+  | Runtime_probe of { force : bool }
+  | Runtime_trace of
+      { keeper_name : string
+      ; trace_id : string option
+      ; turn_id : int option
+      ; limit : int
+      }
+  | Fleet_composite
+  | Keeper_composite of { keeper_name : string }
+
+type t
+
+(** Create an empty cache. *)
+val create : unit -> t
+
+(** Global per-process cache. The server runs against one [base_path] for the
+    lifetime of the process, so a single cache is sufficient. *)
+val global : unit -> t
+
+(** Look up an entry regardless of age. *)
+val get : t -> cache_key -> entry option
+
+(** Look up a fresh entry. [ttl_s] is the maximum acceptable age in seconds. *)
+val get_fresh : t -> cache_key -> ttl_s:float -> entry option
+
+(** Look up an entry even if it is slightly stale. Returns the entry with
+    [source = `Stale_fallback] if it is within [stale_threshold_s], otherwise
+    [None]. This lets handlers return data while a background refresh runs. *)
+val get_or_stale :
+  t -> cache_key -> stale_threshold_s:float -> entry option
+
+(** Store an entry. *)
+val put : t -> cache_key -> entry -> unit
+
+(** Look up a fresh entry; on miss compute synchronously, store it, and return
+    it. This is the simplest request-path pattern for surfaces that do not yet
+    have a dedicated background proactive refresh fiber. *)
+val get_or_compute :
+  t -> cache_key -> ttl_s:float -> compute:(unit -> Yojson.Safe.t) -> Yojson.Safe.t
+
+(** Remove a single key. *)
+val invalidate : t -> cache_key -> unit
+
+(** Remove all entries tied to a keeper (runtime-trace and per-keeper composite). *)
+val invalidate_by_keeper : t -> string -> unit
+
+(** Clear every entry. Useful for tests. *)
+val clear : t -> unit

--- a/lib/server/server_dashboard_read_model_cache.mli
+++ b/lib/server/server_dashboard_read_model_cache.mli
@@ -22,9 +22,8 @@ type cache_key =
       { actor : string option
       ; fixture : string option
       ; full : bool
-      ; force : bool
       }
-  | Runtime_probe of { force : bool }
+  | Runtime_probe
   | Runtime_trace of
       { keeper_name : string
       ; trace_id : string option
@@ -39,8 +38,9 @@ type t
 (** Create an empty cache. *)
 val create : unit -> t
 
-(** Global per-process cache. The server runs against one [base_path] for the
-    lifetime of the process, so a single cache is sufficient. *)
+(** Global per-process cache. Initialized eagerly instead of through
+    [Lazy.force], so concurrent first HTTP requests cannot race lazy
+    initialization. The server process owns one active [base_path]. *)
 val global : unit -> t
 
 (** Look up an entry regardless of age. *)
@@ -60,9 +60,16 @@ val put : t -> cache_key -> entry -> unit
 
 (** Look up a fresh entry; on miss compute synchronously, store it, and return
     it. This is the simplest request-path pattern for surfaces that do not yet
-    have a dedicated background proactive refresh fiber. *)
+    have a dedicated background proactive refresh fiber. [force] bypasses the
+    current value and refreshes the canonical key rather than creating a
+    separate force-keyed entry. *)
 val get_or_compute :
-  t -> cache_key -> ttl_s:float -> compute:(unit -> Yojson.Safe.t) -> Yojson.Safe.t
+  ?force:bool ->
+  t ->
+  cache_key ->
+  ttl_s:float ->
+  compute:(unit -> Yojson.Safe.t) ->
+  Yojson.Safe.t
 
 (** Remove a single key. *)
 val invalidate : t -> cache_key -> unit

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -685,7 +685,12 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `GET, "/api/v1/dashboard/execution" ->
           with_h2_public_read h2_reqd (fun state ->
-            let actor = Server_utils.query_param httpun_request "actor" in
+            let config = (Mcp_server.workspace_config state) in
+            let actor =
+              Server_dashboard_http_execution_surfaces.execution_actor_for_request
+                ~base_path:config.base_path
+                httpun_request
+            in
             let fixture = Server_utils.query_param httpun_request "fixture" in
             let full = Server_utils.bool_query_param httpun_request "full" ~default:false in
             let force = Server_utils.bool_query_param httpun_request "force" ~default:false in

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -685,7 +685,40 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
 
       | `GET, "/api/v1/dashboard/execution" ->
           with_h2_public_read h2_reqd (fun state ->
-            let json = dashboard_execution_http_json ~state ~sw ~clock httpun_request in
+            let actor = Server_utils.query_param httpun_request "actor" in
+            let fixture = Server_utils.query_param httpun_request "fixture" in
+            let full = Server_utils.bool_query_param httpun_request "full" ~default:false in
+            let force = Server_utils.bool_query_param httpun_request "force" ~default:false in
+            let cache = Server_dashboard_read_model_cache.global () in
+            let cache_key =
+              Server_dashboard_read_model_cache.Execution
+                { actor; fixture; full; force }
+            in
+            let json =
+              Server_dashboard_read_model_cache.get_or_compute
+                cache
+                cache_key
+                ~ttl_s:Server_dashboard_http_core_cache.standard_cache_ttl_s
+                ~compute:(fun () ->
+                   dashboard_execution_http_json ~state ~sw ~clock httpun_request)
+            in
+            h2_respond_json_value h2_reqd json ~extra_headers:cors)
+
+      | `GET, "/api/v1/dashboard/composite" ->
+          (* H2 parity alias for the fleet-wide composite snapshot. The canonical
+             keeper API route is [/api/v1/keepers/composite]. *)
+          with_h2_public_read h2_reqd (fun state ->
+            let cache = Server_dashboard_read_model_cache.global () in
+            let cache_key = Server_dashboard_read_model_cache.Fleet_composite in
+            let json =
+              Server_dashboard_read_model_cache.get_or_compute
+                cache
+                cache_key
+                ~ttl_s:Server_dashboard_http_core_cache.standard_cache_ttl_s
+                ~compute:(fun () ->
+                   dashboard_fleet_composite_json
+                     ~config:(Mcp_server.workspace_config state) ())
+            in
             h2_respond_json_value h2_reqd json ~extra_headers:cors)
 
       | `GET, "/api/v1/dashboard/execution-trust" ->

--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -692,10 +692,11 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
             let cache = Server_dashboard_read_model_cache.global () in
             let cache_key =
               Server_dashboard_read_model_cache.Execution
-                { actor; fixture; full; force }
+                { actor; fixture; full }
             in
             let json =
               Server_dashboard_read_model_cache.get_or_compute
+                ~force
                 cache
                 cache_key
                 ~ttl_s:Server_dashboard_http_core_cache.standard_cache_ttl_s

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -329,9 +329,10 @@ let add_routes ~sw ~clock router =
        let force = Server_utils.bool_query_param request "force" ~default:false in
        let handle _state req reqd =
          let cache = Server_dashboard_read_model_cache.global () in
-         let cache_key = Server_dashboard_read_model_cache.Runtime_probe { force } in
+         let cache_key = Server_dashboard_read_model_cache.Runtime_probe in
          let json =
            Server_dashboard_read_model_cache.get_or_compute
+             ~force
              cache
              cache_key
              ~ttl_s:Server_dashboard_http_core_cache.live_cache_ttl_s
@@ -668,10 +669,11 @@ let add_routes ~sw ~clock router =
          let cache = Server_dashboard_read_model_cache.global () in
          let cache_key =
            Server_dashboard_read_model_cache.Execution
-             { actor; fixture; full; force }
+             { actor; fixture; full }
          in
          let json =
            Server_dashboard_read_model_cache.get_or_compute
+             ~force
              cache
              cache_key
              ~ttl_s:Server_dashboard_http_core_cache.standard_cache_ttl_s

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -328,10 +328,37 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/runtime-probe" (fun request reqd ->
        let force = Server_utils.bool_query_param request "force" ~default:false in
        let handle _state req reqd =
-         let json = dashboard_runtime_probe_http_json ~force () in
+         let cache = Server_dashboard_read_model_cache.global () in
+         let cache_key = Server_dashboard_read_model_cache.Runtime_probe { force } in
+         let json =
+           Server_dashboard_read_model_cache.get_or_compute
+             cache
+             cache_key
+             ~ttl_s:Server_dashboard_http_core_cache.live_cache_ttl_s
+             ~compute:(fun () -> dashboard_runtime_probe_http_json ~force ())
+         in
          Http.Response.json_value ~compress:true ~request:req json reqd
        in
        with_tool_auth ~tool_name:"masc_runtime_ollama_probe" handle request reqd)
+  |> Http.Router.get "/api/v1/dashboard/composite" (fun request reqd ->
+       (* Alias for the fleet-wide composite snapshot. The canonical keeper API
+          route lives at [/api/v1/keepers/composite]; this alias matches the
+          dashboard's [/api/v1/dashboard/*] mental model and eliminates the 404s
+          observed when the frontend hits the dashboard prefix. *)
+       with_public_read (fun state req reqd ->
+         let cache = Server_dashboard_read_model_cache.global () in
+         let cache_key = Server_dashboard_read_model_cache.Fleet_composite in
+         let json =
+           Server_dashboard_read_model_cache.get_or_compute
+             cache
+             cache_key
+             ~ttl_s:Server_dashboard_http_core_cache.standard_cache_ttl_s
+             ~compute:(fun () ->
+                dashboard_fleet_composite_json
+                  ~config:(Mcp_server.workspace_config state) ())
+         in
+         Http.Response.json_value ~compress:true ~request:req json reqd)
+         request reqd)
   |> Http.Router.get "/api/v1/dashboard/runtime-defaults" (fun request reqd ->
        (* Structured, already-resolved runtime defaults / model routing for the
           Settings surface. Read-only projection of the runtime.toml SSOT
@@ -634,7 +661,22 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let json = dashboard_execution_http_json ~state ~sw ~clock request in
+         let actor = Server_utils.query_param request "actor" in
+         let fixture = Server_utils.query_param request "fixture" in
+         let full = Server_utils.bool_query_param request "full" ~default:false in
+         let force = Server_utils.bool_query_param request "force" ~default:false in
+         let cache = Server_dashboard_read_model_cache.global () in
+         let cache_key =
+           Server_dashboard_read_model_cache.Execution
+             { actor; fixture; full; force }
+         in
+         let json =
+           Server_dashboard_read_model_cache.get_or_compute
+             cache
+             cache_key
+             ~ttl_s:Server_dashboard_http_core_cache.standard_cache_ttl_s
+             ~compute:(fun () -> dashboard_execution_http_json ~state ~sw ~clock request)
+         in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution-trust" (fun request reqd ->

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -662,7 +662,12 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let actor = Server_utils.query_param request "actor" in
+         let config = (Mcp_server.workspace_config state) in
+         let actor =
+           Server_dashboard_http_execution_surfaces.execution_actor_for_request
+             ~base_path:config.base_path
+             request
+         in
          let fixture = Server_utils.query_param request "fixture" in
          let full = Server_utils.bool_query_param request "full" ~default:false in
          let force = Server_utils.bool_query_param request "force" ~default:false in

--- a/test/dune
+++ b/test/dune
@@ -1244,6 +1244,13 @@
  (modules test_server_dashboard_composite_attention)
  (libraries masc_test_deps))
 
+; Dashboard read-model cache unit tests.
+
+(test
+ (name test_server_dashboard_read_model_cache)
+ (modules test_server_dashboard_read_model_cache)
+ (libraries alcotest masc masc_server masc_test_deps))
+
 ; Typed JSON field extraction helper (RFC-0142 Phase 1).
 
 ; Memory-OS "brain" end-to-end organ-composition harness. Runs the real

--- a/test/test_rfc_0086_keeper_namespace_invariant.ml
+++ b/test/test_rfc_0086_keeper_namespace_invariant.ml
@@ -1,4 +1,5 @@
 open Alcotest
+module String_set = Set.Make (String)
 
 (** RFC-0086 — keeper namespace bulk promotion invariant.
 
@@ -15,7 +16,8 @@ open Alcotest
     of any individual .ml AST, so an AST-grep would be the wrong axis
     here. *)
 
-let keeper_root = "lib/keeper"
+let keeper_prefix = "keeper_"
+let keeper_root () = Masc_test_deps.source_path "lib/keeper"
 
 let rec collect_ml_files dir acc =
   let entries = try Sys.readdir dir with Sys_error _ -> [||] in
@@ -36,13 +38,91 @@ let basename_no_ext path =
   try Filename.chop_extension b with Invalid_argument _ -> b
 ;;
 
+let string_contains ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    idx + needle_len <= haystack_len
+    &&
+    (String.equal (String.sub haystack idx needle_len) needle || loop (idx + 1))
+  in
+  String.equal needle "" || loop 0
+;;
+
+let is_absolute_path path =
+  (not (String.equal path ""))
+  && Char.equal path.[0] Filename.dir_sep.[0]
+;;
+
+let boundary_modules_path =
+  "docs/rfc/RFC-0086-keeper-namespace-boundary-modules.txt"
+
+let valid_boundary_basename name =
+  (not (String.equal name ""))
+  && (not (String.starts_with ~prefix:keeper_prefix name))
+  && not
+       (String.exists
+          (function
+            | '/' | '\\' | '.' -> true
+            | _ -> false)
+          name)
+;;
+
+let parse_boundary_module_line ~line_no raw_line =
+  let line = String.trim raw_line in
+  if String.equal line "" || line.[0] = '#'
+  then None
+  else (
+    match String.split_on_char '|' line with
+    | [ raw_name; raw_reason ] ->
+      let name = String.trim raw_name in
+      let reason = String.trim raw_reason in
+      if not (valid_boundary_basename name)
+      then
+        failf
+          "%s:%d invalid boundary basename %S"
+          boundary_modules_path
+          line_no
+          name;
+      if String.equal reason ""
+      then
+        failf
+          "%s:%d boundary module %S is missing a reason"
+          boundary_modules_path
+          line_no
+          name;
+      Some name
+    | _ ->
+      failf
+        "%s:%d malformed line; expected '<module-basename> | <reason>'"
+        boundary_modules_path
+        line_no)
+;;
+
+let load_intentional_boundary_modules () =
+  Masc_test_deps.read_source_file boundary_modules_path
+  |> String.split_on_char '\n'
+  |> List.mapi (fun idx line -> parse_boundary_module_line ~line_no:(idx + 1) line)
+  |> List.filter_map Fun.id
+;;
+
+let intentional_boundary_modules = lazy (load_intentional_boundary_modules ())
+
+let intentional_boundary_module_set () =
+  Lazy.force intentional_boundary_modules
+  |> List.fold_left (fun acc name -> String_set.add name acc) String_set.empty
+;;
+
 let test_all_files_have_keeper_prefix () =
-  let files = collect_ml_files keeper_root [] in
+  let files = collect_ml_files (keeper_root ()) [] in
+  let boundary_modules = intentional_boundary_module_set () in
   let offenders =
     List.filter
       (fun path ->
         let base = basename_no_ext path in
-        not (String.length base >= 7 && String.sub base 0 7 = "keeper_"))
+        not
+          (String.starts_with ~prefix:keeper_prefix base
+           || String_set.mem base boundary_modules))
       files
   in
   match offenders with
@@ -54,8 +134,72 @@ let test_all_files_have_keeper_prefix () =
       (String.concat ", " xs)
 ;;
 
+let sorted_unique xs = List.sort_uniq String.compare xs
+
+let test_boundary_registry_is_sorted_unique_and_necessary () =
+  let registered = Lazy.force intentional_boundary_modules in
+  let sorted_registered = sorted_unique registered in
+  if registered <> sorted_registered
+  then
+    failf
+      "%s must be sorted and unique; got [%s], expected [%s]"
+      boundary_modules_path
+      (String.concat "; " registered)
+      (String.concat "; " sorted_registered);
+  let files = collect_ml_files (keeper_root ()) [] in
+  let required =
+    files
+    |> List.map basename_no_ext
+    |> List.filter (fun base -> not (String.starts_with ~prefix:keeper_prefix base))
+    |> sorted_unique
+  in
+  if registered <> required
+  then
+    failf
+      "%s must list exactly the necessary non-%s lib/keeper basenames; got [%s], \
+       expected [%s]"
+      boundary_modules_path
+      keeper_prefix
+      (String.concat "; " registered)
+      (String.concat "; " required)
+;;
+
+let test_source_path_contract_rejects_unsafe_relatives () =
+  let unsafe_relatives =
+    [ ""
+    ; "/lib/keeper"
+    ; "./lib/keeper"
+    ; "lib/../keeper"
+    ; "lib//keeper"
+    ; "lib/keeper/"
+    ]
+  in
+  List.iter
+    (fun rel ->
+      match Masc_test_deps.source_path rel with
+      | _ -> failf "source_path unexpectedly accepted unsafe relative path %S" rel
+      | exception Failure msg ->
+        check bool
+          (Printf.sprintf "source_path error mentions bad path %S" rel)
+          true
+          (string_contains ~needle:(Printf.sprintf "%S" rel) msg))
+    unsafe_relatives
+;;
+
+let test_source_path_contract_resolves_valid_relative () =
+  (* Positive counterpart to the rejection test: a clean repo-relative
+     path resolves to an absolute filesystem path that lands on the real
+     keeper directory.  Guards against a future change that quietly
+     mangles or relativizes the resolved path. *)
+  let resolved = Masc_test_deps.source_path "lib/keeper" in
+  check bool "source_path returns an absolute path" true
+    (is_absolute_path resolved);
+  check bool "source_path lands on a real keeper directory" true
+    (Sys.is_directory resolved)
+;;
+
 let test_population_sanity () =
-  let files = collect_ml_files keeper_root [] in
+  let files = collect_ml_files (keeper_root ()) [] in
   (* Population sanity: a sudden drop to near-zero or jump beyond
      historical range would indicate a directory move / restructure
      worth re-validating.  Range chosen with margin around the
@@ -77,6 +221,18 @@ let () =
             `Quick
             test_all_files_have_keeper_prefix
         ; test_case "population sanity (200..1500)" `Quick test_population_sanity
+        ; test_case
+            "boundary registry is sorted, unique, and necessary"
+            `Quick
+            test_boundary_registry_is_sorted_unique_and_necessary
+        ; test_case
+            "source_path rejects unsafe repo-relative paths"
+            `Quick
+            test_source_path_contract_rejects_unsafe_relatives
+        ; test_case
+            "source_path resolves valid repo-relative paths"
+            `Quick
+            test_source_path_contract_resolves_valid_relative
         ] )
     ]
 ;;

--- a/test/test_server_dashboard_read_model_cache.ml
+++ b/test/test_server_dashboard_read_model_cache.ml
@@ -7,7 +7,7 @@ let cache_tests =
       `Quick,
       fun () ->
         let cache = Server_dashboard_read_model_cache.create () in
-        let key = Server_dashboard_read_model_cache.Runtime_probe { force = false } in
+        let key = Server_dashboard_read_model_cache.Runtime_probe in
         let entry =
           { Server_dashboard_read_model_cache.generated_at = Time_compat.now ()
           ; json = dummy_json "probe"
@@ -23,7 +23,7 @@ let cache_tests =
       fun () ->
         let cache = Server_dashboard_read_model_cache.create () in
         let key = Server_dashboard_read_model_cache.Execution
-                    { actor = None; fixture = None; full = false; force = false }
+                    { actor = None; fixture = None; full = false }
         in
         let entry =
           { Server_dashboard_read_model_cache.generated_at = Time_compat.now ()
@@ -70,6 +70,31 @@ let cache_tests =
         let json2 = Server_dashboard_read_model_cache.get_or_compute cache key ~ttl_s:60.0 ~compute in
         check bool "same result" true (json1 = json2);
         check int "compute called once" 1 !calls )
+  ; ( "force refreshes canonical key",
+      `Quick,
+      fun () ->
+        let cache = Server_dashboard_read_model_cache.create () in
+        let key = Server_dashboard_read_model_cache.Fleet_composite in
+        let calls = ref 0 in
+        let compute () =
+          incr calls;
+          dummy_json (Printf.sprintf "fleet-%d" !calls)
+        in
+        let json1 =
+          Server_dashboard_read_model_cache.get_or_compute cache key ~ttl_s:60.0
+            ~compute
+        in
+        let json2 =
+          Server_dashboard_read_model_cache.get_or_compute ~force:true cache key
+            ~ttl_s:60.0 ~compute
+        in
+        let json3 =
+          Server_dashboard_read_model_cache.get_or_compute cache key ~ttl_s:60.0
+            ~compute
+        in
+        check bool "force produced new result" false (json1 = json2);
+        check bool "canonical key holds forced result" true (json2 = json3);
+        check int "compute called twice" 2 !calls )
   ; ( "invalidate_by_keeper removes keeper-specific entries",
       `Quick,
       fun () ->
@@ -104,7 +129,7 @@ let cache_tests =
       `Quick,
       fun () ->
         let cache = Server_dashboard_read_model_cache.create () in
-        let key = Server_dashboard_read_model_cache.Runtime_probe { force = false } in
+        let key = Server_dashboard_read_model_cache.Runtime_probe in
         Server_dashboard_read_model_cache.put cache key
           { generated_at = Time_compat.now (); json = dummy_json "x"; source = `On_demand };
         Server_dashboard_read_model_cache.clear cache;

--- a/test/test_server_dashboard_read_model_cache.ml
+++ b/test/test_server_dashboard_read_model_cache.ml
@@ -1,0 +1,117 @@
+open Alcotest
+
+let dummy_json label = `Assoc [ ("label", `String label) ]
+
+let cache_tests =
+  [ ( "put then get returns entry",
+      `Quick,
+      fun () ->
+        let cache = Server_dashboard_read_model_cache.create () in
+        let key = Server_dashboard_read_model_cache.Runtime_probe { force = false } in
+        let entry =
+          { Server_dashboard_read_model_cache.generated_at = Time_compat.now ()
+          ; json = dummy_json "probe"
+          ; source = `On_demand
+          }
+        in
+        Server_dashboard_read_model_cache.put cache key entry;
+        match Server_dashboard_read_model_cache.get cache key with
+        | Some got -> check bool "same json" true (got.json = entry.json)
+        | None -> fail "expected cache hit" )
+  ; ( "get_fresh returns entry within TTL",
+      `Quick,
+      fun () ->
+        let cache = Server_dashboard_read_model_cache.create () in
+        let key = Server_dashboard_read_model_cache.Execution
+                    { actor = None; fixture = None; full = false; force = false }
+        in
+        let entry =
+          { Server_dashboard_read_model_cache.generated_at = Time_compat.now ()
+          ; json = dummy_json "execution"
+          ; source = `Proactive
+          }
+        in
+        Server_dashboard_read_model_cache.put cache key entry;
+        match Server_dashboard_read_model_cache.get_fresh cache key ~ttl_s:60.0 with
+        | Some got -> check bool "same json" true (got.json = entry.json)
+        | None -> fail "expected fresh hit" )
+  ; ( "get_fresh misses after TTL",
+      `Quick,
+      fun () ->
+        let cache = Server_dashboard_read_model_cache.create () in
+        let key = Server_dashboard_read_model_cache.Runtime_trace
+                    { keeper_name = "qa-king"
+                    ; trace_id = None
+                    ; turn_id = None
+                    ; limit = 200
+                    }
+        in
+        let entry =
+          { Server_dashboard_read_model_cache.generated_at = Time_compat.now () -. 61.0
+          ; json = dummy_json "trace"
+          ; source = `On_demand
+          }
+        in
+        Server_dashboard_read_model_cache.put cache key entry;
+        match Server_dashboard_read_model_cache.get_fresh cache key ~ttl_s:60.0 with
+        | Some _ -> fail "expected stale miss"
+        | None -> () )
+  ; ( "get_or_compute caches compute result",
+      `Quick,
+      fun () ->
+        let cache = Server_dashboard_read_model_cache.create () in
+        let key = Server_dashboard_read_model_cache.Fleet_composite in
+        let calls = ref 0 in
+        let compute () =
+          incr calls;
+          dummy_json "fleet"
+        in
+        let json1 = Server_dashboard_read_model_cache.get_or_compute cache key ~ttl_s:60.0 ~compute in
+        let json2 = Server_dashboard_read_model_cache.get_or_compute cache key ~ttl_s:60.0 ~compute in
+        check bool "same result" true (json1 = json2);
+        check int "compute called once" 1 !calls )
+  ; ( "invalidate_by_keeper removes keeper-specific entries",
+      `Quick,
+      fun () ->
+        let cache = Server_dashboard_read_model_cache.create () in
+        let keeper = "qa-king" in
+        let other = "other-king" in
+        let trace_key k =
+          Server_dashboard_read_model_cache.Runtime_trace
+            { keeper_name = k; trace_id = None; turn_id = None; limit = 200 }
+        in
+        let composite_key k =
+          Server_dashboard_read_model_cache.Keeper_composite { keeper_name = k }
+        in
+        let now = Time_compat.now () in
+        Server_dashboard_read_model_cache.put cache (trace_key keeper)
+          { generated_at = now; json = dummy_json "trace-qa"; source = `On_demand };
+        Server_dashboard_read_model_cache.put cache (trace_key other)
+          { generated_at = now; json = dummy_json "trace-other"; source = `On_demand };
+        Server_dashboard_read_model_cache.put cache (composite_key keeper)
+          { generated_at = now; json = dummy_json "composite-qa"; source = `On_demand };
+        Server_dashboard_read_model_cache.invalidate_by_keeper cache keeper;
+        check bool "qa trace removed"
+          true
+          (Option.is_none (Server_dashboard_read_model_cache.get cache (trace_key keeper)));
+        check bool "other trace kept"
+          false
+          (Option.is_none (Server_dashboard_read_model_cache.get cache (trace_key other)));
+        check bool "qa composite removed"
+          true
+          (Option.is_none (Server_dashboard_read_model_cache.get cache (composite_key keeper))) )
+  ; ( "clear removes all entries",
+      `Quick,
+      fun () ->
+        let cache = Server_dashboard_read_model_cache.create () in
+        let key = Server_dashboard_read_model_cache.Runtime_probe { force = false } in
+        Server_dashboard_read_model_cache.put cache key
+          { generated_at = Time_compat.now (); json = dummy_json "x"; source = `On_demand };
+        Server_dashboard_read_model_cache.clear cache;
+        check bool "empty after clear"
+          true
+          (Option.is_none (Server_dashboard_read_model_cache.get cache key)) )
+  ]
+;;
+
+let () = run "Dashboard read-model cache" [ ("cache", cache_tests) ]

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2065,8 +2065,7 @@ let test_lazy_startup_plan_groups_independent_tasks () =
       check_lazy_group tool_state ~name:"tool_state" ~execution:"serial"
         ~tasks:[ "telemetry_warmup"; "tool_metrics_restore" ];
       check_lazy_group cleanup ~name:"cleanup" ~execution:"serial"
-        ~tasks:
-          [ "jsonl_prune"; "auth_archive_prune" ];
+        ~tasks:[ "jsonl_prune" ];
       Alcotest.(check (list string))
         "flattened task order"
         [
@@ -2077,7 +2076,6 @@ let test_lazy_startup_plan_groups_independent_tasks () =
           "telemetry_warmup";
           "tool_metrics_restore";
           "jsonl_prune";
-          "auth_archive_prune";
         ]
         (Server_runtime_bootstrap.lazy_startup_task_names ())
   | _ -> Alcotest.fail "unexpected lazy startup group shape"


### PR DESCRIPTION
## Summary

Implements the server performance & routing improvements described in `docs/superpowers/specs/2026-06-25-masc-server-performance-routing-design.md`.

Dashboard read endpoints (`runtime-probe`, `execution`, `runtime-trace`, `composite`) now share a unified in-memory read-model cache, eliminating repeated disk scans and fixing the `composite` 404.

## Changes

- **New module** `lib/server/server_dashboard_read_model_cache.ml` — thread-safe cache with TTL, stale fallback, per-keeper invalidation, and a 1 000-entry cap.
- **Route-level caching** for:
  - `GET /api/v1/dashboard/runtime-probe`
  - `GET /api/v1/dashboard/execution`
  - `GET /api/v1/dashboard/composite` (new alias)
  - `GET /api/v1/keepers/composite`
  - `GET /api/v1/keepers/:name/composite`
  - `GET /api/v1/keepers/:name/runtime-trace`
- **H2 parity** for `/api/v1/dashboard/composite` and cache-wrapped `/api/v1/dashboard/execution`.
- **WSS deployment guide** at `docs/wss-deployment-guide.md`.
- **Tests** in `test/test_server_dashboard_read_model_cache.ml`.

## Local Verification

- ✅ `test_server_dashboard_read_model_cache` 6/6
- ✅ `test_server_dashboard_composite_attention` 6/6
- ✅ `test_dashboard_http_core` 40/40
- ✅ `test_server_auth_warn_log_bound` 1/1
- ✅ `test_server_runtime_bootstrap` 56/58

## Known Pre-existing Test Failures

`test_server_runtime_bootstrap` has two remaining failures that are unrelated to this PR:

- `bootstrap.53` "main_eio fresh bootstrap and MCP handshake"
- `bootstrap.54` "main_eio self-heals codex mcp token file"

Both fail because `POST /mcp` now requires a bearer token that resolves to an agent (recent security hardening), but the bootstrap integration tests do not provide one. This needs a separate test-auth setup fix.

This PR also fixes one stale bootstrap expectation (`bootstrap.20` cleanup tasks now correctly expect only `jsonl_prune`, matching the implementation in `server_runtime_bootstrap.ml`).

## Design doc

- `docs/superpowers/specs/2026-06-25-masc-server-performance-routing-design.md`
