### PR TITLE
feat(memory): expose dashboard memory lineage policy

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -182,15 +182,19 @@ export type MemoryOsFact = {
 
 export type MemoryOsSelectionPolicy = {
   readonly keeper_scope: string
+  readonly shared_scope: string | null
   readonly facts_source: string
+  readonly shared_facts_source: string | null
   readonly episodes_source: string
-  readonly fact_tail_limit: number
-  readonly episode_tail_limit: number
+  readonly dashboard_fact_tail_limit: number
+  readonly dashboard_episode_tail_limit: number
+  readonly recall_private_fact_limit: number
+  readonly recall_shared_fact_limit: number
+  readonly recall_episode_limit: number
   readonly category_source: string
   readonly claim_kind_source: string
   readonly recall_block: string
   readonly prompt_record: string
-  readonly persona_weighting: boolean
 }
 
 export type MemoryOsTurnRecordSnapshot = {
@@ -425,40 +429,54 @@ function decodeMemoryOsFact(raw: unknown): MemoryOsFact | null {
 function decodeMemoryOsSelectionPolicy(raw: unknown): MemoryOsSelectionPolicy | null {
   if (!isRecord(raw)) return null
   const keeper_scope = asString(raw.keeper_scope)
+  const shared_scope = raw.shared_scope == null ? null : (asString(raw.shared_scope) ?? null)
   const facts_source = asString(raw.facts_source)
+  const shared_facts_source = raw.shared_facts_source == null
+    ? null
+    : (asString(raw.shared_facts_source) ?? null)
   const episodes_source = asString(raw.episodes_source)
-  const fact_tail_limit = asNumber(raw.fact_tail_limit)
-  const episode_tail_limit = asNumber(raw.episode_tail_limit)
+  const dashboard_fact_tail_limit = asNumber(raw.dashboard_fact_tail_limit)
+  const dashboard_episode_tail_limit = asNumber(raw.dashboard_episode_tail_limit)
+  const recall_private_fact_limit = asNumber(raw.recall_private_fact_limit)
+  const recall_shared_fact_limit = asNumber(raw.recall_shared_fact_limit)
+  const recall_episode_limit = asNumber(raw.recall_episode_limit)
   const category_source = asString(raw.category_source)
   const claim_kind_source = asString(raw.claim_kind_source)
   const recall_block = asString(raw.recall_block)
   const prompt_record = asString(raw.prompt_record)
-  const persona_weighting = asBoolean(raw.persona_weighting)
   if (
     !keeper_scope
+    || (raw.shared_scope != null && !shared_scope)
     || !facts_source
+    || (raw.shared_facts_source != null && !shared_facts_source)
     || !episodes_source
-    || fact_tail_limit == null
-    || episode_tail_limit == null
+    || dashboard_fact_tail_limit == null
+    || dashboard_episode_tail_limit == null
+    || recall_private_fact_limit == null
+    || recall_shared_fact_limit == null
+    || recall_episode_limit == null
     || !category_source
     || !claim_kind_source
     || !recall_block
     || !prompt_record
-    || persona_weighting == null
   ) {
     return null
   }
   return {
     keeper_scope,
+    shared_scope,
     facts_source,
+    shared_facts_source,
     episodes_source,
-    fact_tail_limit,
-    episode_tail_limit,
+    dashboard_fact_tail_limit,
+    dashboard_episode_tail_limit,
+    recall_private_fact_limit,
+    recall_shared_fact_limit,
+    recall_episode_limit,
     category_source,
     claim_kind_source,
     recall_block,
     prompt_record,
-    persona_weighting,
   }
 }
 

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -180,11 +180,25 @@ export type MemoryOsFact = {
   readonly claim_kind: MemoryOsClaimKind | null
 }
 
+export type MemoryOsSelectionPolicy = {
+  readonly keeper_scope: string
+  readonly facts_source: string
+  readonly episodes_source: string
+  readonly fact_tail_limit: number
+  readonly episode_tail_limit: number
+  readonly category_source: string
+  readonly claim_kind_source: string
+  readonly recall_block: string
+  readonly prompt_record: string
+  readonly persona_weighting: boolean
+}
+
 export type MemoryOsTurnRecordSnapshot = {
   schema: string
   keeper: string
   source: string
   producer: string
+  selection_policy: MemoryOsSelectionPolicy | null
   facts_store: string
   episodes_store: string
   recall_enabled: boolean
@@ -408,6 +422,46 @@ function decodeMemoryOsFact(raw: unknown): MemoryOsFact | null {
   }
 }
 
+function decodeMemoryOsSelectionPolicy(raw: unknown): MemoryOsSelectionPolicy | null {
+  if (!isRecord(raw)) return null
+  const keeper_scope = asString(raw.keeper_scope)
+  const facts_source = asString(raw.facts_source)
+  const episodes_source = asString(raw.episodes_source)
+  const fact_tail_limit = asNumber(raw.fact_tail_limit)
+  const episode_tail_limit = asNumber(raw.episode_tail_limit)
+  const category_source = asString(raw.category_source)
+  const claim_kind_source = asString(raw.claim_kind_source)
+  const recall_block = asString(raw.recall_block)
+  const prompt_record = asString(raw.prompt_record)
+  const persona_weighting = asBoolean(raw.persona_weighting)
+  if (
+    !keeper_scope
+    || !facts_source
+    || !episodes_source
+    || fact_tail_limit == null
+    || episode_tail_limit == null
+    || !category_source
+    || !claim_kind_source
+    || !recall_block
+    || !prompt_record
+    || persona_weighting == null
+  ) {
+    return null
+  }
+  return {
+    keeper_scope,
+    facts_source,
+    episodes_source,
+    fact_tail_limit,
+    episode_tail_limit,
+    category_source,
+    claim_kind_source,
+    recall_block,
+    prompt_record,
+    persona_weighting,
+  }
+}
+
 function decodeMemoryOsCounts(raw: unknown): {
   tail_limit: number
   shown: number
@@ -444,6 +498,7 @@ function decodeMemoryOsSnapshot(raw: unknown): MemoryOsTurnRecordSnapshot | null
     keeper,
     source,
     producer,
+    selection_policy: decodeMemoryOsSelectionPolicy(raw.selection_policy),
     facts_store,
     episodes_store,
     recall_enabled: asBoolean(raw.recall_enabled, true) ?? true,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -251,6 +251,7 @@ export type {
   MemoryOsExternalRef,
   MemoryOsFactProvenance,
   MemoryOsFact,
+  MemoryOsSelectionPolicy,
   MemoryOsTurnRecordSnapshot,
   KeeperUserModelItem,
   KeeperUserModelSnapshot,
@@ -319,4 +320,3 @@ export {
   fetchTlcResults,
   fetchAuditLedger,
 } from './dashboard-misc'
-

--- a/dashboard/src/components/keeper-turn-inspector.test.ts
+++ b/dashboard/src/components/keeper-turn-inspector.test.ts
@@ -94,6 +94,7 @@ function turnRecordsWithMemoryOs(): TurnRecordsResponse {
       keeper: 'albini',
       source: 'memory_os',
       producer: 'keeper_memory_os.recall',
+      selection_policy: null,
       facts_store: '.masc/config/keepers/albini.facts.jsonl',
       episodes_store: '.masc/config/keepers/albini/episodes',
       recall_enabled: true,

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -38,15 +38,19 @@ function turnRecordsPayload() {
       producer: 'keeper_librarian',
       selection_policy: {
         keeper_scope: 'masc-improver',
+        shared_scope: '_shared',
         facts_source: 'Keeper_memory_os_io.read_facts_tail',
+        shared_facts_source: 'Keeper_memory_os_io.read_facts_all',
         episodes_source: 'Keeper_memory_os_io.read_episodes_tail',
-        fact_tail_limit: 256,
-        episode_tail_limit: 12,
-        category_source: 'keeper_librarian.category',
-        claim_kind_source: 'keeper_librarian.claim_kind',
-        recall_block: 'keeper_memory_os_recall.render_if_enabled',
-        prompt_record: 'turn_record.blocks_digest_only',
-        persona_weighting: false,
+        dashboard_fact_tail_limit: 384,
+        dashboard_episode_tail_limit: 12,
+        recall_private_fact_limit: 8,
+        recall_shared_fact_limit: 4,
+        recall_episode_limit: 2,
+        category_source: 'Keeper_memory_os_types.category_to_string',
+        claim_kind_source: 'Keeper_memory_os_types.claim_kind_to_string',
+        recall_block: 'Keeper_memory_os_recall.render_if_enabled',
+        prompt_record: 'Keeper_run_tools_hooks.record_block Prompt_block_id.Memory_os_recall',
       },
       facts_store: '.masc/config/keepers/masc-improver.facts.jsonl',
       episodes_store: '.masc/config/keepers/masc-improver/episodes',
@@ -76,7 +80,7 @@ function turnRecordsPayload() {
         ],
       },
       facts: {
-        tail_limit: 256,
+        tail_limit: 384,
         shown: 2,
         current: 1,
         expired: 1,
@@ -213,10 +217,15 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     stubFetch()
     const { container } = renderInspector()
     await waitFor(() => expect(container.querySelector('.mem-trust')).toBeTruthy())
-    expect(container.textContent).toContain('keeper-local, no persona weight')
+    expect(container.textContent).toContain('masc-improver + _shared')
+    expect(container.textContent).toContain('private + shared recall tiers')
     expect(container.textContent).toContain('800B memory_os_recall')
     expect(container.textContent).toContain('Keeper_memory_os_io.read_facts_tail')
-    expect(container.textContent).toContain('keeper_memory_os_recall.render_if_enabled')
+    expect(container.textContent).toContain('Keeper_memory_os_io.read_facts_all')
+    expect(container.textContent).toContain('dashboard 384 · prompt 8')
+    expect(container.textContent).toContain('_shared · prompt 4')
+    expect(container.textContent).toContain('dashboard 12 · prompt 2')
+    expect(container.textContent).toContain('Keeper_memory_os_recall.render_if_enabled')
     expect(container.textContent).toContain('Full Prompt')
     expect(container.textContent).toContain('raw text not persisted here')
     expect(container.textContent).toContain('cccc2222dddd')

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -6,12 +6,14 @@ import {
   DEFAULT_MEMORY_KEEPERS,
   MemoryInspector,
   factCategoryMeta,
+  factSelectionReason,
   factTtlLabel,
   latestEntryWithBlocks,
   memCompositionFromBlocks,
   memFmtBytes,
   memFmtTok,
   promptBlockMeta,
+  sortMemoryFactsForReview,
   type MemoryKeeper,
 } from './memory-inspector'
 import type { MemoryOsFact, TurnRecordRow } from '../api/dashboard'
@@ -34,6 +36,18 @@ function turnRecordsPayload() {
       keeper: 'masc-improver',
       source: 'memory_os_files',
       producer: 'keeper_librarian',
+      selection_policy: {
+        keeper_scope: 'masc-improver',
+        facts_source: 'Keeper_memory_os_io.read_facts_tail',
+        episodes_source: 'Keeper_memory_os_io.read_episodes_tail',
+        fact_tail_limit: 256,
+        episode_tail_limit: 12,
+        category_source: 'keeper_librarian.category',
+        claim_kind_source: 'keeper_librarian.claim_kind',
+        recall_block: 'keeper_memory_os_recall.render_if_enabled',
+        prompt_record: 'turn_record.blocks_digest_only',
+        persona_weighting: false,
+      },
       facts_store: '.masc/config/keepers/masc-improver.facts.jsonl',
       episodes_store: '.masc/config/keepers/masc-improver/episodes',
       recall_enabled: true,
@@ -166,19 +180,46 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     expect(container.textContent).toContain('동적 컨텍스트')
   })
 
-  it('renders one store row per real fact with typed category chips and Unknown absorption', async () => {
+  it('renders active/latest facts first, with stored time and selection reason', async () => {
     stubFetch()
     const { container } = renderInspector()
     await waitFor(() => expect(container.querySelectorAll('.mem-store-row').length).toBeGreaterThan(0))
-    // 2 fact items + 1 episode row all use .mem-store-row; assert facts by claim text.
+    // Default view is active/current only so expired rows do not dominate the drawer.
     expect(container.textContent).toContain('retention D0 = 가입일, 첫 세션 기준')
     expect(container.textContent).toContain('제약') // constraint chip label
+    expect(container.textContent).toContain('저장')
+    expect(container.textContent).toContain('검증')
+    expect(container.textContent).toContain('active recall candidate')
+    expect(container.textContent).not.toContain('amplitude 캐시는 만료됨')
+  })
+
+  it('can expand to all rows and still surfaces unknown taxonomy explicitly', async () => {
+    stubFetch()
+    const { container } = renderInspector()
+    await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
+    const allBtn = [...container.querySelectorAll('.mem-filter')].find(b => b.textContent === '전체 2')
+    expect(allBtn).toBeTruthy()
+    fireEvent.click(allBtn!)
     // out-of-vocabulary category surfaces its raw label, not a fabricated kind.
     expect(container.textContent).toContain('Speculation')
+    expect(container.textContent).toContain('expired evidence row')
     // external_ref rendered
     expect(container.textContent).toContain('pr 22198')
     // NO salience meter — the deleted score model must not reappear.
     expect(container.querySelector('.mem-sal')).toBeFalsy()
+  })
+
+  it('surfaces selection policy and prompt digest lineage without claiming raw full-prompt storage', async () => {
+    stubFetch()
+    const { container } = renderInspector()
+    await waitFor(() => expect(container.querySelector('.mem-trust')).toBeTruthy())
+    expect(container.textContent).toContain('keeper-local, no persona weight')
+    expect(container.textContent).toContain('800B memory_os_recall')
+    expect(container.textContent).toContain('Keeper_memory_os_io.read_facts_tail')
+    expect(container.textContent).toContain('keeper_memory_os_recall.render_if_enabled')
+    expect(container.textContent).toContain('Full Prompt')
+    expect(container.textContent).toContain('raw text not persisted here')
+    expect(container.textContent).toContain('cccc2222dddd')
   })
 
   it('surfaces read_errors and renders honest disclosures for the unbacked sections', async () => {
@@ -358,5 +399,45 @@ describe('memory view-model helpers', () => {
     // an already-expired fact keeps the past form
     const dead = factTtlLabel(makeFact({ valid_until: nowSec - 2 * 3600, current: false }))
     expect(dead).toContain('전')
+  })
+
+  it('sortMemoryFactsForReview puts current, most-recent evidence first', () => {
+    const mkFact = (claim: string, current: boolean, reference_time: number): MemoryOsFact => ({
+      claim,
+      category: { tag: 'fact' },
+      source: { trace_id: 't', turn: 1, tool_call_id: null },
+      first_seen: reference_time,
+      first_seen_iso: null,
+      reference_time,
+      valid_until: null,
+      valid_until_iso: null,
+      last_verified_at: null,
+      current,
+      external_ref: null,
+      claim_kind: null,
+    })
+    expect(sortMemoryFactsForReview([
+      mkFact('expired-new', false, 30),
+      mkFact('current-old', true, 10),
+      mkFact('current-new', true, 20),
+    ]).map(f => f.claim)).toEqual(['current-new', 'current-old', 'expired-new'])
+  })
+
+  it('factSelectionReason explains currentness, category, and claim kind', () => {
+    const fact: MemoryOsFact = {
+      claim: 'x',
+      category: { tag: 'constraint' },
+      source: { trace_id: 't', turn: 1, tool_call_id: null },
+      first_seen: 0,
+      first_seen_iso: null,
+      reference_time: 0,
+      valid_until: null,
+      valid_until_iso: null,
+      last_verified_at: null,
+      current: true,
+      external_ref: null,
+      claim_kind: 'durable_knowledge',
+    }
+    expect(factSelectionReason(fact)).toBe('active recall candidate · 제약 · durable')
   })
 })

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -279,6 +279,9 @@ function MemoryTrustStrip({
   const promptTurn = latestPromptRow
     ? `${latestPromptRow.record.trace_id}#${latestPromptRow.record.absolute_turn}`
     : 'none'
+  const scopeLabel = policy?.shared_scope
+    ? `${policy.keeper_scope} + ${policy.shared_scope}`
+    : (policy?.keeper_scope ?? snapshot.keeper)
   return html`
     <div class="mem-trust">
       <div class="mem-trust-card">
@@ -288,8 +291,8 @@ function MemoryTrustStrip({
       </div>
       <div class="mem-trust-card">
         <span class="mem-trust-k">scope</span>
-        <span class="mem-trust-v mono">${policy?.keeper_scope ?? snapshot.keeper}</span>
-        <span class="mem-trust-sub">${policy?.persona_weighting === true ? 'persona weighted' : 'keeper-local, no persona weight'}</span>
+        <span class="mem-trust-v mono">${scopeLabel}</span>
+        <span class="mem-trust-sub">${policy?.shared_scope ? 'private + shared recall tiers' : 'keeper-local recall tier'}</span>
       </div>
       <div class="mem-trust-card">
         <span class="mem-trust-k">prompt link</span>
@@ -306,9 +309,12 @@ function MemoryPolicyDisclosure({ policy }: { policy: MemoryOsSelectionPolicy | 
   }
   return html`
     <div class="mem-policy">
-      <div class="mem-policy-row"><span>facts</span><code>${policy.facts_source}</code><b>${policy.fact_tail_limit}</b></div>
-      <div class="mem-policy-row"><span>episodes</span><code>${policy.episodes_source}</code><b>${policy.episode_tail_limit}</b></div>
-      <div class="mem-policy-row"><span>librarian</span><code>${policy.category_source} + ${policy.claim_kind_source}</code><b>${policy.persona_weighting ? 'persona' : 'no persona'}</b></div>
+      <div class="mem-policy-row"><span>private facts</span><code>${policy.facts_source}</code><b>dashboard ${policy.dashboard_fact_tail_limit} · prompt ${policy.recall_private_fact_limit}</b></div>
+      ${policy.shared_scope && policy.shared_facts_source
+        ? html`<div class="mem-policy-row"><span>shared facts</span><code>${policy.shared_facts_source}</code><b>${policy.shared_scope} · prompt ${policy.recall_shared_fact_limit}</b></div>`
+        : null}
+      <div class="mem-policy-row"><span>episodes</span><code>${policy.episodes_source}</code><b>dashboard ${policy.dashboard_episode_tail_limit} · prompt ${policy.recall_episode_limit}</b></div>
+      <div class="mem-policy-row"><span>librarian</span><code>${policy.category_source} + ${policy.claim_kind_source}</code><b>typed labels</b></div>
       <div class="mem-policy-row"><span>prompt</span><code>${policy.recall_block}</code><b>${policy.prompt_record}</b></div>
     </div>
   `

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -20,7 +20,7 @@ import { Fragment } from 'preact'
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
-import { formatTimeAgo, formatTimeUntil } from '../lib/format-time'
+import { formatDateTimeKo, formatTimeAgo, formatTimeUntil } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import {
   fetchKeeperTurnRecords,
@@ -29,6 +29,7 @@ import {
   type MemoryOsEpisodeSummary,
   type MemoryOsFact,
   type MemoryOsFactCategory,
+  type MemoryOsSelectionPolicy,
   type TurnBlock,
   type TurnRecordRow,
 } from '../api/dashboard'
@@ -183,6 +184,47 @@ export function factTtlLabel(fact: MemoryOsFact): string {
     : `만료됨 ${formatTimeAgo(fact.valid_until)}`
 }
 
+const DEFAULT_FACT_ROW_LIMIT = 12
+type FactVisibilityFilter = 'current' | 'all'
+
+export function sortMemoryFactsForReview(facts: readonly MemoryOsFact[]): MemoryOsFact[] {
+  return [...facts].sort((a, b) => {
+    if (a.current !== b.current) return a.current ? -1 : 1
+    return b.reference_time - a.reference_time
+  })
+}
+
+function formatFactInstant(ts: number, iso: string | null): string {
+  return formatDateTimeKo(iso ?? ts)
+}
+
+function factClaimKindLabel(fact: MemoryOsFact): string {
+  switch (fact.claim_kind) {
+    case 'durable_knowledge':
+      return 'durable'
+    case 'external_state':
+      return 'external'
+    case 'self_observation':
+      return 'self'
+    case null:
+      return 'untyped'
+    default: {
+      const _exhaustive: never = fact.claim_kind
+      return _exhaustive
+    }
+  }
+}
+
+export function factSelectionReason(fact: MemoryOsFact): string {
+  const meta = factCategoryMeta(fact.category)
+  const state = fact.current ? 'active recall candidate' : 'expired evidence row'
+  return `${state} · ${meta.lbl} · ${factClaimKindLabel(fact)}`
+}
+
+function latestMemoryRecallBlock(row: TurnRecordRow | null): TurnBlock | null {
+  return row?.record.blocks.find(block => block.block === 'memory_os_recall') ?? null
+}
+
 // ── rendering ──
 
 function MemBar({ parts, total }: { parts: readonly CompositionPart[]; total: number }) {
@@ -225,6 +267,88 @@ function MemCompoReal({ row }: { row: TurnRecordRow | null }) {
     </div>`
 }
 
+function MemoryTrustStrip({
+  snapshot,
+  latestPromptRow,
+}: {
+  snapshot: MemoryOsTurnRecordSnapshot
+  latestPromptRow: TurnRecordRow | null
+}) {
+  const policy = snapshot.selection_policy
+  const memoryBlock = latestMemoryRecallBlock(latestPromptRow)
+  const promptTurn = latestPromptRow
+    ? `${latestPromptRow.record.trace_id}#${latestPromptRow.record.absolute_turn}`
+    : 'none'
+  return html`
+    <div class="mem-trust">
+      <div class="mem-trust-card">
+        <span class="mem-trust-k">store</span>
+        <span class="mem-trust-v mono">${snapshot.facts.current}/${snapshot.facts.shown} current</span>
+        <span class="mem-trust-sub mono">${snapshot.source}</span>
+      </div>
+      <div class="mem-trust-card">
+        <span class="mem-trust-k">scope</span>
+        <span class="mem-trust-v mono">${policy?.keeper_scope ?? snapshot.keeper}</span>
+        <span class="mem-trust-sub">${policy?.persona_weighting === true ? 'persona weighted' : 'keeper-local, no persona weight'}</span>
+      </div>
+      <div class="mem-trust-card">
+        <span class="mem-trust-k">prompt link</span>
+        <span class="mem-trust-v mono">${memoryBlock ? `${memFmtBytes(memoryBlock.bytes)} memory_os_recall` : 'no memory block'}</span>
+        <span class="mem-trust-sub mono">${promptTurn}</span>
+      </div>
+    </div>
+  `
+}
+
+function MemoryPolicyDisclosure({ policy }: { policy: MemoryOsSelectionPolicy | null }) {
+  if (!policy) {
+    return html`<${DisclosureNote} text="selection_policy 없음 — 대시보드는 fact timestamps/provenance만 표시." />`
+  }
+  return html`
+    <div class="mem-policy">
+      <div class="mem-policy-row"><span>facts</span><code>${policy.facts_source}</code><b>${policy.fact_tail_limit}</b></div>
+      <div class="mem-policy-row"><span>episodes</span><code>${policy.episodes_source}</code><b>${policy.episode_tail_limit}</b></div>
+      <div class="mem-policy-row"><span>librarian</span><code>${policy.category_source} + ${policy.claim_kind_source}</code><b>${policy.persona_weighting ? 'persona' : 'no persona'}</b></div>
+      <div class="mem-policy-row"><span>prompt</span><code>${policy.recall_block}</code><b>${policy.prompt_record}</b></div>
+    </div>
+  `
+}
+
+function MemoryPromptEvidence({
+  snapshot,
+  row,
+}: {
+  snapshot: MemoryOsTurnRecordSnapshot
+  row: TurnRecordRow | null
+}) {
+  const memoryBlock = latestMemoryRecallBlock(row)
+  return html`
+    <div class="mem-prompt-evidence">
+      <div class="mem-prompt-step">
+        <span class="mem-prompt-n">1</span>
+        <div><b>librarian</b><span>${snapshot.producer}</span></div>
+      </div>
+      <div class="mem-prompt-step">
+        <span class="mem-prompt-n">2</span>
+        <div><b>store</b><span class="mono">${snapshot.facts_store}</span></div>
+      </div>
+      <div class="mem-prompt-step">
+        <span class="mem-prompt-n">3</span>
+        <div><b>recall block</b><span class="mono">${memoryBlock ? `${memoryBlock.digest.slice(0, 12)} · ${memFmtBytes(memoryBlock.bytes)}` : 'not present in latest prompt record'}</span></div>
+      </div>
+      <div class="mem-prompt-step">
+        <span class="mem-prompt-n">4</span>
+        <div><b>Full Prompt</b><span>raw text not persisted here; turn-record keeps ordered block digests and byte sizes.</span></div>
+      </div>
+      ${row ? html`
+        <div class="mem-prompt-foot mono">
+          latest assembly ${row.record.trace_id}#${row.record.absolute_turn} · ${formatFactInstant(row.record.ts, null)}
+        </div>
+      ` : null}
+    </div>
+  `
+}
+
 function FactRow({ fact }: { fact: MemoryOsFact }) {
   const meta = factCategoryMeta(fact.category)
   const provenance = `${fact.source.trace_id}#${fact.source.turn}`
@@ -234,13 +358,18 @@ function FactRow({ fact }: { fact: MemoryOsFact }) {
       <div class="mem-store-main">
         <div class="mem-store-text">${fact.claim}</div>
         <div class="mem-store-meta">
-          <span class="mono">${factAgeLabel(fact)}</span>
+          <span class="mono">저장 ${formatFactInstant(fact.first_seen, fact.first_seen_iso)}</span>
+          <span class="mono">기준 ${factAgeLabel(fact)}</span>
+          ${fact.last_verified_at != null
+            ? html`<span class="mono">검증 ${formatFactInstant(fact.last_verified_at, null)}</span>`
+            : null}
           <span class=${`mono ${fact.current ? '' : 'mem-expired'}`}>${factTtlLabel(fact)}</span>
           ${fact.external_ref
             ? html`<span class="mem-tag">${fact.external_ref.kind} ${fact.external_ref.id}</span>`
             : null}
           <span class="mem-src mono">${provenance}</span>
         </div>
+        <div class="mem-store-why">${factSelectionReason(fact)}</div>
       </div>
     </div>`
 }
@@ -295,7 +424,10 @@ function OneKeeperMemoryReal({
   rows: readonly TurnRecordRow[]
 }) {
   const kindFilter = useSignal<string>('all')
-  const facts = snapshot.facts.items
+  const visibilityFilter = useSignal<FactVisibilityFilter>('current')
+  const factRowLimit = useSignal(DEFAULT_FACT_ROW_LIMIT)
+  const latestPromptRow = latestEntryWithBlocks(rows)
+  const facts = sortMemoryFactsForReview(snapshot.facts.items)
   const episodes = [...snapshot.episodes.items].reverse().slice(0, 5)
   // distinct categories present, in first-seen order, deduped by tag
   const seen = new Set<string>()
@@ -308,15 +440,31 @@ function OneKeeperMemoryReal({
     }
   }
   const filter = kindFilter.value
-  const storeRows = filter === 'all' ? facts : facts.filter(f => factTag(f) === filter)
+  const visibilityRows =
+    visibilityFilter.value === 'current' ? facts.filter(f => f.current) : facts
+  const storeRows =
+    filter === 'all' ? visibilityRows : visibilityRows.filter(f => factTag(f) === filter)
+  const visibleStoreRows = storeRows.slice(0, factRowLimit.value)
+  const hiddenStoreRows = Math.max(0, storeRows.length - visibleStoreRows.length)
 
   return html`
     <${Fragment}>
       <${ReadErrors} snapshot=${snapshot} />
+      <${MemoryTrustStrip} snapshot=${snapshot} latestPromptRow=${latestPromptRow} />
 
       <div class="turn-sec">
         <h4>컨텍스트 구성</h4>
-        <${MemCompoReal} row=${latestEntryWithBlocks(rows)} />
+        <${MemCompoReal} row=${latestPromptRow} />
+      </div>
+
+      <div class="turn-sec">
+        <h4>회상 연결 · Full Prompt</h4>
+        <${MemoryPromptEvidence} snapshot=${snapshot} row=${latestPromptRow} />
+      </div>
+
+      <div class="turn-sec">
+        <h4>수집 기준 · librarian</h4>
+        <${MemoryPolicyDisclosure} policy=${snapshot.selection_policy} />
       </div>
 
       <div class="turn-sec">
@@ -332,8 +480,29 @@ function OneKeeperMemoryReal({
         ${facts.length
           ? html`
             <${Fragment}>
+              <div class="mem-filters">
+                <button
+                  class=${`mem-filter ${visibilityFilter.value === 'current' ? 'on' : ''}`}
+                  onClick=${() => { visibilityFilter.value = 'current'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
+                >활성 ${snapshot.facts.current}</button>
+                <button
+                  class=${`mem-filter ${visibilityFilter.value === 'all' ? 'on' : ''}`}
+                  onClick=${() => { visibilityFilter.value = 'all'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
+                >전체 ${facts.length}</button>
+              </div>
               <${CategoryFilters} cats=${cats} active=${filter} onPick=${(t: string) => { kindFilter.value = t }} />
-              <div class="mem-store">${storeRows.map(f => html`<${FactRow} key=${factTag(f) + f.source.trace_id + f.source.turn + f.claim} fact=${f} />`)}</div>
+              <div class="mem-store">${visibleStoreRows.map(f => html`<${FactRow} key=${factTag(f) + f.source.trace_id + f.source.turn + f.claim} fact=${f} />`)}</div>
+              ${hiddenStoreRows > 0
+                ? html`
+                  <button
+                    type="button"
+                    class="mem-more"
+                    onClick=${() => { factRowLimit.value += DEFAULT_FACT_ROW_LIMIT }}
+                  >
+                    ${hiddenStoreRows}개 더 보기
+                  </button>
+                `
+                : null}
             </>`
           : html`<div class="mem-empty">장기 메모리 항목 없음.</div>`}
       </div>

--- a/dashboard/src/styles/memory-inspector-v2.css
+++ b/dashboard/src/styles/memory-inspector-v2.css
@@ -86,6 +86,24 @@
 .mem-sec-head h4 { margin: 0; }
 .mem-n { font-size: 11px; color: var(--text-dim); }
 .mem-hint { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.02em; text-transform: none; color: var(--text-dim); margin-left: 6px; }
+.mem-trust { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+.mem-trust-card { min-width: 0; border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 9px 10px; background: var(--bg-card); }
+.mem-trust-k { display: block; font-family: var(--font-ui); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-dim); }
+.mem-trust-v { display: block; margin-top: 4px; font-size: 12px; color: var(--text-bright); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mem-trust-sub { display: block; margin-top: 3px; font-size: 10.5px; color: var(--text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mem-policy { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); background: var(--bg-card); overflow: hidden; }
+.mem-policy-row { display: grid; grid-template-columns: 72px minmax(0, 1fr) auto; gap: 9px; align-items: center; padding: 8px 10px; border-top: 1px solid var(--border-soft); font-size: 11px; color: var(--text-mid); }
+.mem-policy-row:first-child { border-top: 0; }
+.mem-policy-row span { font-family: var(--font-ui); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-dim); }
+.mem-policy-row code { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 10.5px; color: var(--text-mid); }
+.mem-policy-row b { font-weight: 500; font-size: 10px; color: var(--text-dim); white-space: nowrap; }
+.mem-prompt-evidence { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); background: var(--bg-card); padding: 3px 10px 9px; }
+.mem-prompt-step { display: grid; grid-template-columns: 22px minmax(0, 1fr); gap: 8px; align-items: start; padding: 8px 0; border-top: 1px solid var(--border-soft); }
+.mem-prompt-step:first-child { border-top: 0; }
+.mem-prompt-n { width: 20px; height: 20px; border-radius: var(--radius-pill); border: 1px solid var(--border-main); display: inline-flex; align-items: center; justify-content: center; color: var(--text-dim); font-size: 10px; font-family: var(--font-mono); }
+.mem-prompt-step b { display: block; color: var(--text-bright); font-size: 11.5px; font-weight: 600; }
+.mem-prompt-step span:last-child { display: block; margin-top: 2px; color: var(--text-dim); font-size: 10.5px; line-height: 1.45; overflow-wrap: anywhere; }
+.mem-prompt-foot { margin-top: 3px; padding-top: 8px; border-top: 1px solid var(--border-soft); color: var(--text-dim); font-size: 10px; }
 
 /* ── context composition — keeper-v2/styles/memory.css:23-33 ── */
 .mem-compo { border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 11px 12px; background: var(--bg-card); }
@@ -128,8 +146,11 @@
 .mem-kind.entity { color: var(--status-warn); border-color: color-mix(in oklab, var(--status-warn) 35%, transparent); }
 .mem-store-main { min-width: 0; flex: 1; }
 .mem-store-text { font-size: 12.5px; line-height: 1.5; color: var(--text-primary); text-wrap: pretty; }
-.mem-store-meta { display: flex; align-items: center; gap: 12px; margin-top: 6px; font-size: 10.5px; color: var(--text-dim); }
+.mem-store-meta { display: flex; align-items: center; flex-wrap: wrap; gap: 6px 12px; margin-top: 6px; font-size: 10.5px; color: var(--text-dim); }
 .mem-src { color: var(--text-dim); }
+.mem-store-why { margin-top: 5px; font-size: 10.5px; color: var(--text-dim); line-height: 1.4; }
+.mem-more { margin-top: 9px; width: 100%; border: 1px solid var(--border-main); border-radius: var(--radius-sm); background: var(--bg-sunken); color: var(--text-mid); font-family: var(--font-ui); font-size: 11px; padding: 7px 10px; cursor: pointer; transition: 0.14s; }
+.mem-more:hover { border-color: var(--volt-dim); color: var(--volt); }
 .mem-sal { position: relative; width: 54px; height: 5px; border-radius: 3px; background: var(--bg-sunken); overflow: hidden; flex: none; }
 .mem-sal > span { position: absolute; left: 0; top: 0; bottom: 0; background: var(--volt); border-radius: 3px; }
 
@@ -185,6 +206,7 @@
 /* keeper-v2/styles/memory.css:106-111 */
 @media (max-width: 560px) {
   .mem-legend { grid-template-columns: 1fr; }
+  .mem-trust { grid-template-columns: 1fr; }
   .mem-stats { grid-template-columns: repeat(2, 1fr); }
   .mem-tl-row { grid-template-columns: 38px 56px 1fr; }
   .mem-tl-tok { display: none; }

--- a/docs/rfc/RFC-keeper-memory-panel-real-data.md
+++ b/docs/rfc/RFC-keeper-memory-panel-real-data.md
@@ -3,12 +3,12 @@ rfc: "keeper-memory-panel-real-data"
 title: "Keeper memory panel: real-data backing (no fabrication, no score resurrection)"
 status: Draft
 created: 2026-06-24
-updated: 2026-06-24
+updated: 2026-06-25
 author: vincent
 supersedes: []
 superseded_by: null
 related: ["0233", "0244", "0247", "0259", "0285"]
-implementation_prs: []
+implementation_prs: [22307]
 ---
 
 # RFC (keeper-memory-panel-real-data): Keeper memory panel — real-data backing
@@ -21,10 +21,10 @@ design's visual language to those fields, and adds only the extensions legitimat
 model. It **does not** revisit RFC-0247: the score-model deletion stands (operator-confirmed
 2026-06-24); `salience` / `uses` / `lastUsed` are not resurrected.
 
-**Surfaces (CLAUDE.md agent_delegation)**: dashboard memory components + a one-key addition to
-`lib/server/server_dashboard_http_keeper_api.ml` serialization. Not credential/operator/sandbox/hooks —
-outside the mandatory-RFC list, but authored as RFC because it amends a serialized data contract and
-rewires a live panel.
+**Surfaces (CLAUDE.md agent_delegation)**: dashboard memory components + bounded additions to
+`lib/server/server_dashboard_http_keeper_api.ml` serialization (`facts.items`, `selection_policy`).
+Not credential/operator/sandbox/hooks — outside the mandatory-RFC list, but authored as RFC because
+it amends a serialized data contract and rewires a live panel.
 
 ## 1. Problem
 
@@ -130,6 +130,37 @@ mirror of `category_of_string`, so the closed sum stays the boundary, not a free
 Bytes-identical safety: this only **adds** a key to an object; existing consumers
 (`server_dashboard_http_keeper_memory_health.ml`, the FE counts decode) ignore unknown keys. No
 removal, no reordering of the fact JSON on disk (the on-disk `fact_to_json` is untouched).
+
+### 4a.1 Backend — expose selection_policy lineage without hiding shared recall
+
+`selection_policy` is a dashboard contract field, not a classifier. It must describe what the
+panel is showing and what the prompt recall path can inject. The shape is serialized from an OCaml
+record (`memory_os_selection_policy`) so the JSON object is not an untyped inline literal:
+
+```json
+{
+  "keeper_scope": "masc-improver",
+  "shared_scope": "_shared",
+  "facts_source": "Keeper_memory_os_io.read_facts_tail",
+  "shared_facts_source": "Keeper_memory_os_io.read_facts_all",
+  "episodes_source": "Keeper_memory_os_io.read_episodes_tail",
+  "dashboard_fact_tail_limit": 384,
+  "dashboard_episode_tail_limit": 12,
+  "recall_private_fact_limit": 8,
+  "recall_shared_fact_limit": 4,
+  "recall_episode_limit": 2,
+  "category_source": "Keeper_memory_os_types.category_to_string",
+  "claim_kind_source": "Keeper_memory_os_types.claim_kind_to_string",
+  "recall_block": "Keeper_memory_os_recall.render_if_enabled",
+  "prompt_record": "Keeper_run_tools_hooks.record_block Prompt_block_id.Memory_os_recall"
+}
+```
+
+The `dashboard_*` bounds describe read-panel payload bounds. The `recall_*` bounds describe prompt
+injection defaults from `Keeper_memory_os_recall` and are intentionally separate: the dashboard scans
+more rows than the prompt injects. `persona_weighting` is not emitted because no such runtime feature
+exists. For non-`_shared` keepers, the policy must include the shared tier: actual recall reads the
+keeper-local bounded store and then appends private-precedence facts from `_shared`.
 
 ### 4b. Frontend — typed category + composition view model
 

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -4,6 +4,15 @@
     and episodes, sanitizes them, and returns an advisory block suitable for
     OAS [extra_system_context]. *)
 
+val default_max_facts : int
+(** Default number of keeper-local facts injected into the recall prompt block. *)
+
+val default_max_shared_facts : int
+(** Default number of shared-tier facts appended after keeper-local recall facts. *)
+
+val default_max_episodes : int
+(** Default number of memory episodes injected into the recall prompt block. *)
+
 val render_context
   :  keeper_id:string
   -> now:float

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -92,9 +92,69 @@ let memory_os_fact_json ~now (fact : Keeper_memory_os_types.fact) =
      ; "last_verified_at", json_float_opt fact.last_verified_at
      ; "current", `Bool (memory_os_fact_is_current ~now fact)
      ]
-    @ (match fact.claim_kind with
-       | Some k -> [ "claim_kind", `String (Keeper_memory_os_types.claim_kind_to_string k) ]
-       | None -> []))
+     @ (match fact.claim_kind with
+        | Some k -> [ "claim_kind", `String (Keeper_memory_os_types.claim_kind_to_string k) ]
+        | None -> []))
+;;
+
+type memory_os_selection_policy =
+  { keeper_scope : string
+  ; shared_scope : string option
+  ; facts_source : string
+  ; shared_facts_source : string option
+  ; episodes_source : string
+  ; dashboard_fact_tail_limit : int
+  ; dashboard_episode_tail_limit : int
+  ; recall_private_fact_limit : int
+  ; recall_shared_fact_limit : int
+  ; recall_episode_limit : int
+  ; category_source : string
+  ; claim_kind_source : string
+  ; recall_block : string
+  ; prompt_record : string
+  }
+
+let memory_os_selection_policy_json (policy : memory_os_selection_policy) =
+  `Assoc
+    [ "keeper_scope", `String policy.keeper_scope
+    ; "shared_scope", json_string_opt policy.shared_scope
+    ; "facts_source", `String policy.facts_source
+    ; "shared_facts_source", json_string_opt policy.shared_facts_source
+    ; "episodes_source", `String policy.episodes_source
+    ; "dashboard_fact_tail_limit", `Int policy.dashboard_fact_tail_limit
+    ; "dashboard_episode_tail_limit", `Int policy.dashboard_episode_tail_limit
+    ; "recall_private_fact_limit", `Int policy.recall_private_fact_limit
+    ; "recall_shared_fact_limit", `Int policy.recall_shared_fact_limit
+    ; "recall_episode_limit", `Int policy.recall_episode_limit
+    ; "category_source", `String policy.category_source
+    ; "claim_kind_source", `String policy.claim_kind_source
+    ; "recall_block", `String policy.recall_block
+    ; "prompt_record", `String policy.prompt_record
+    ]
+;;
+
+let memory_os_selection_policy ~keeper_id ~fact_tail_limit ~recent_episode_limit =
+  let has_shared_tier =
+    not (String.equal keeper_id Keeper_memory_os_types.shared_store_id)
+  in
+  { keeper_scope = keeper_id
+  ; shared_scope =
+      (if has_shared_tier then Some Keeper_memory_os_types.shared_store_id else None)
+  ; facts_source = "Keeper_memory_os_io.read_facts_tail"
+  ; shared_facts_source =
+      (if has_shared_tier then Some "Keeper_memory_os_io.read_facts_all" else None)
+  ; episodes_source = "Keeper_memory_os_io.read_episodes_tail"
+  ; dashboard_fact_tail_limit = fact_tail_limit
+  ; dashboard_episode_tail_limit = recent_episode_limit
+  ; recall_private_fact_limit = Keeper_memory_os_recall.default_max_facts
+  ; recall_shared_fact_limit =
+      (if has_shared_tier then Keeper_memory_os_recall.default_max_shared_facts else 0)
+  ; recall_episode_limit = Keeper_memory_os_recall.default_max_episodes
+  ; category_source = "Keeper_memory_os_types.category_to_string"
+  ; claim_kind_source = "Keeper_memory_os_types.claim_kind_to_string"
+  ; recall_block = "Keeper_memory_os_recall.render_if_enabled"
+  ; prompt_record = "Keeper_run_tools_hooks.record_block Prompt_block_id.Memory_os_recall"
+  }
 ;;
 
 let memory_os_dashboard_json ~keeper_id =
@@ -122,18 +182,11 @@ let memory_os_dashboard_json ~keeper_id =
     ; "source", `String "memory_os_files"
     ; "producer", `String "keeper_librarian|keeper_memory_os_recall"
     ; ( "selection_policy"
-      , `Assoc
-          [ "keeper_scope", `String keeper_id
-          ; "facts_source", `String "Keeper_memory_os_io.read_facts_tail"
-          ; "episodes_source", `String "Keeper_memory_os_io.read_episodes_tail"
-          ; "fact_tail_limit", `Int fact_tail_limit
-          ; "episode_tail_limit", `Int recent_episode_limit
-          ; "category_source", `String "keeper_librarian.category"
-          ; "claim_kind_source", `String "keeper_librarian.claim_kind"
-          ; "recall_block", `String "keeper_memory_os_recall.render_if_enabled"
-          ; "prompt_record", `String "turn_record.blocks_digest_only"
-          ; "persona_weighting", `Bool false
-          ] )
+      , memory_os_selection_policy
+          ~keeper_id
+          ~fact_tail_limit
+          ~recent_episode_limit
+        |> memory_os_selection_policy_json )
     ; "facts_store", `String facts_path
     ; "episodes_store", `String episodes_store
     ; "recall_enabled", `Bool (Keeper_memory_os_recall.enabled ())

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -121,6 +121,19 @@ let memory_os_dashboard_json ~keeper_id =
     ; "keeper", `String keeper_id
     ; "source", `String "memory_os_files"
     ; "producer", `String "keeper_librarian|keeper_memory_os_recall"
+    ; ( "selection_policy"
+      , `Assoc
+          [ "keeper_scope", `String keeper_id
+          ; "facts_source", `String "Keeper_memory_os_io.read_facts_tail"
+          ; "episodes_source", `String "Keeper_memory_os_io.read_episodes_tail"
+          ; "fact_tail_limit", `Int fact_tail_limit
+          ; "episode_tail_limit", `Int recent_episode_limit
+          ; "category_source", `String "keeper_librarian.category"
+          ; "claim_kind_source", `String "keeper_librarian.claim_kind"
+          ; "recall_block", `String "keeper_memory_os_recall.render_if_enabled"
+          ; "prompt_record", `String "turn_record.blocks_digest_only"
+          ; "persona_weighting", `Bool false
+          ] )
     ; "facts_store", `String facts_path
     ; "episodes_store", `String episodes_store
     ; "recall_enabled", `Bool (Keeper_memory_os_recall.enabled ())

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3596,6 +3596,100 @@ let test_dashboard_json_wires_one_fact_item_per_fact () =
       (List.length items))
 ;;
 
+let test_dashboard_json_selection_policy_contract () =
+  let assoc_field label fields key =
+    match List.assoc_opt key fields with
+    | Some (`Assoc v) -> v
+    | Some _ -> Alcotest.failf "%s.%s must be an object" label key
+    | None -> Alcotest.failf "%s.%s missing" label key
+  in
+  let string_field label fields key =
+    match List.assoc_opt key fields with
+    | Some (`String v) -> v
+    | Some _ -> Alcotest.failf "%s.%s must be a string" label key
+    | None -> Alcotest.failf "%s.%s missing" label key
+  in
+  let int_field label fields key =
+    match List.assoc_opt key fields with
+    | Some (`Int v) -> v
+    | Some _ -> Alcotest.failf "%s.%s must be an int" label key
+    | None -> Alcotest.failf "%s.%s missing" label key
+  in
+  with_temp_keepers_dir (fun _dir ->
+    let keeper_id = "memory-panel-test" in
+    let top =
+      match Server_dashboard_http_keeper_api.memory_os_dashboard_json ~keeper_id with
+      | `Assoc top -> top
+      | _ -> Alcotest.fail "memory_os_dashboard_json must be a JSON object"
+    in
+    let policy = assoc_field "memory_os" top "selection_policy" in
+    Alcotest.(check string) "keeper_scope" keeper_id (string_field "policy" policy "keeper_scope");
+    Alcotest.(check string)
+      "shared_scope"
+      Types.shared_store_id
+      (string_field "policy" policy "shared_scope");
+    Alcotest.(check string)
+      "private facts source"
+      "Keeper_memory_os_io.read_facts_tail"
+      (string_field "policy" policy "facts_source");
+    Alcotest.(check string)
+      "shared facts source"
+      "Keeper_memory_os_io.read_facts_all"
+      (string_field "policy" policy "shared_facts_source");
+    Alcotest.(check string)
+      "episodes source"
+      "Keeper_memory_os_io.read_episodes_tail"
+      (string_field "policy" policy "episodes_source");
+    Alcotest.(check int)
+      "dashboard fact bound"
+      Memory_io.fact_store_max
+      (int_field "policy" policy "dashboard_fact_tail_limit");
+    Alcotest.(check int)
+      "dashboard episode bound"
+      12
+      (int_field "policy" policy "dashboard_episode_tail_limit");
+    Alcotest.(check int)
+      "prompt private fact bound"
+      Recall.default_max_facts
+      (int_field "policy" policy "recall_private_fact_limit");
+    Alcotest.(check int)
+      "prompt shared fact bound"
+      Recall.default_max_shared_facts
+      (int_field "policy" policy "recall_shared_fact_limit");
+    Alcotest.(check int)
+      "prompt episode bound"
+      Recall.default_max_episodes
+      (int_field "policy" policy "recall_episode_limit");
+    Alcotest.(check string)
+      "category source"
+      "Keeper_memory_os_types.category_to_string"
+      (string_field "policy" policy "category_source");
+    Alcotest.(check string)
+      "claim-kind source"
+      "Keeper_memory_os_types.claim_kind_to_string"
+      (string_field "policy" policy "claim_kind_source");
+    Alcotest.(check string)
+      "recall block source"
+      "Keeper_memory_os_recall.render_if_enabled"
+      (string_field "policy" policy "recall_block");
+    Alcotest.(check string)
+      "prompt record source"
+      "Keeper_run_tools_hooks.record_block Prompt_block_id.Memory_os_recall"
+      (string_field "policy" policy "prompt_record");
+    Alcotest.(check bool)
+      "persona_weighting is not emitted without a real feature"
+      false
+      (List.mem_assoc "persona_weighting" policy);
+    Alcotest.(check bool)
+      "old misleading fact_tail_limit key absent"
+      false
+      (List.mem_assoc "fact_tail_limit" policy);
+    Alcotest.(check bool)
+      "old misleading episode_tail_limit key absent"
+      false
+      (List.mem_assoc "episode_tail_limit" policy))
+;;
+
 let () =
   maybe_run_lock_holder_child ();
   Alcotest.run
@@ -3671,6 +3765,10 @@ let () =
             "dashboard json wires one facts.items row per persisted fact"
             `Quick
             test_dashboard_json_wires_one_fact_item_per_fact
+        ; Alcotest.test_case
+            "dashboard json selection_policy pins recall lineage"
+            `Quick
+            test_dashboard_json_selection_policy_contract
         ] )
     ; ( "policy"
       , [ Alcotest.test_case


### PR DESCRIPTION
## Summary

- expose `selection_policy` as a typed backend contract instead of an inline JSON literal
- include both keeper-local and `_shared` recall tiers so the dashboard does not claim keeper-local-only lineage when prompt recall can inject shared facts
- split dashboard read bounds from prompt injection bounds (`dashboard_*` vs `recall_*`)
- remove the non-existent `persona_weighting` field and replace stale labels with real greppable OCaml paths
- update the Memory OS drawer decoder/UI/test fixture and RFC to match the backend contract
- add an OCaml backend contract test for `selection_policy`

## Verification

- `ocamlformat --check lib/server/server_dashboard_http_keeper_api.ml lib/keeper/keeper_memory_os_recall.mli test/test_keeper_memory_os.ml`
- `pnpm --dir dashboard install --offline`
- `pnpm --dir dashboard typecheck`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/memory-inspector.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm exec eslint src/api/dashboard-turn-records.ts src/components/memory-inspector.ts src/components/memory-inspector.test.ts` from `dashboard/` (0 errors; API/test files are ignored by current ESLint config with warnings)
- `scripts/ocaml-structure-ratchet.sh`
- `git diff --check`
- `git diff --cached --check`

Full Dune build/test is intentionally left to CI.
