### PR TITLE
fix dashboard runtime status source

### DIFF
--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -169,6 +169,9 @@ describe('App v2 header chrome', () => {
     expect(liveChip).not.toBeNull()
     expect(liveChip?.textContent).toContain('1 실행 중')
     expect(liveChip?.title).toContain('runtime health')
+    expect(liveChip?.title).toContain('paused=3')
+    expect(liveChip?.title).toContain('offline=0 (not derived from execution rows)')
+    expect(liveChip?.title).toContain('configured=13 (shell)')
   })
 
   it('falls back to activeKeeperName for the breadcrumb tail when no route keeper param', () => {

--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -4,7 +4,7 @@ import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
 import { App, shouldShowCopilotFab, shouldSuppressFloatingChrome, shouldUseCompactDashboardChrome } from './app'
 import { route } from './router'
-import { keepers } from './store'
+import { executionLoaded, keepers, shellCounts, shellRuntimeResolution } from './store'
 import { activeKeeperName } from './keeper-state'
 import type { Keeper } from './types'
 
@@ -18,6 +18,9 @@ describe('App v2 header chrome', () => {
     window.location.hash = originalHash
     route.value = { tab: 'overview', params: {}, postId: null }
     keepers.value = []
+    executionLoaded.value = false
+    shellCounts.value = null
+    shellRuntimeResolution.value = null
     activeKeeperName.value = ''
   })
 
@@ -27,6 +30,9 @@ describe('App v2 header chrome', () => {
     window.location.hash = originalHash
     route.value = { tab: 'overview', params: {}, postId: null }
     keepers.value = []
+    executionLoaded.value = false
+    shellCounts.value = null
+    shellRuntimeResolution.value = null
     activeKeeperName.value = ''
   })
 
@@ -105,9 +111,9 @@ describe('App v2 header chrome', () => {
   it('renders keeper breadcrumb tail and the live running-count chip', () => {
     window.innerWidth = 1280
     route.value = { tab: 'keepers', params: { keeper: 'albini' }, postId: null }
-    // The live running-count chip counts running keepers from the `keepers` store
-    // (via phaseStatus), not from shellCounts. Seed 7 running keepers so the chip
-    // reads "7 실행 중".
+    // Before runtime health hydrates, the shared runtime-count resolver falls
+    // back to the execution rows. Seed 7 running keepers so the chip reads
+    // "7 실행 중".
     keepers.value = Array.from({ length: 7 }, (_, i): Keeper => ({
       name: `k${i}`,
       status: 'running',
@@ -131,6 +137,38 @@ describe('App v2 header chrome', () => {
     // Pulse is now carried by the StatusDot pip (`.dot2.pulse`), replacing the old
     // `motion-safe:animate-pulse` utility class on an inner span.
     expect(liveChip?.querySelector('.dot2.pulse')).not.toBeNull()
+  })
+
+  it('uses runtime health for the live running-count chip when rows are stale', () => {
+    window.innerWidth = 1280
+    route.value = { tab: 'keepers', params: { keeper: 'albini' }, postId: null }
+    keepers.value = Array.from({ length: 7 }, (_, i): Keeper => ({
+      name: `stale-${i}`,
+      status: 'running',
+      lifecycle_phase: 'Running',
+    }))
+    shellCounts.value = { agents: 0, tasks: 0, keepers: 7, total_runtimes: 7, configured_keepers: 13 }
+    shellRuntimeResolution.value = {
+      fleet_safety: {
+        keeper_fibers: 7,
+        paused_keepers: 3,
+        paused_keepers_health: { count: 3 },
+        keeper_fleet_no_fibers: false,
+        keeper_fd_pressure: null,
+        keeper_fleet_safety: {
+          running_keeper_fiber_count: 1,
+          paused_keeper_count: 3,
+        },
+        keeper_reaction_ledger: null,
+      },
+    } as any
+
+    renderApp()
+
+    const liveChip = container.querySelector('.v2-statchip.live') as HTMLElement | null
+    expect(liveChip).not.toBeNull()
+    expect(liveChip?.textContent).toContain('1 실행 중')
+    expect(liveChip?.title).toContain('runtime health')
   })
 
   it('falls back to activeKeeperName for the breadcrumb tail when no route keeper param', () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -13,6 +13,7 @@ import {
   executionLoading,
   executionError,
   shellCounts,
+  shellRuntimeResolution,
 } from '../store'
 import { FilterChips } from './common/filter-chips'
 import { TextInput } from './common/input'
@@ -792,6 +793,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
     shellCounts: shellCounts.value,
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
+    runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
   })
   const expectedScopedCount = expectedCountForKeeperFilter(keeperFilter, runtimeCounts)
   const namespaceStatus = namespaceTruth.value?.root.status ?? serverStatus.value

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -794,6 +794,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     shellCounts: shellCounts.value,
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
     runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
+    runtimeHealthGeneratedAt: serverStatus.value?.generated_at ?? null,
   })
   const expectedScopedCount = expectedCountForKeeperFilter(keeperFilter, runtimeCounts)
   const namespaceStatus = namespaceTruth.value?.root.status ?? serverStatus.value

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -794,7 +794,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     shellCounts: shellCounts.value,
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
     runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
-    runtimeHealthGeneratedAt: serverStatus.value?.generated_at ?? null,
+    runtimeHealthGeneratedAt: shellRuntimeResolution.value?.generated_at ?? null,
   })
   const expectedScopedCount = expectedCountForKeeperFilter(keeperFilter, runtimeCounts)
   const namespaceStatus = namespaceTruth.value?.root.status ?? serverStatus.value

--- a/dashboard/src/components/agents-unified.test.ts
+++ b/dashboard/src/components/agents-unified.test.ts
@@ -66,6 +66,7 @@ vi.mock('../store', () => ({
   keepers: { value: [] },
   executionLoaded: { value: false },
   shellCounts: { value: null },
+  shellRuntimeResolution: { value: null },
 }))
 vi.mock('../namespace-truth-store', () => ({
   namespaceTruth: { value: null },

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -7,7 +7,7 @@ import { useMemo, useState } from 'preact/hooks'
 import { computed } from '@preact/signals'
 import { FilterChips } from './common/filter-chips'
 import { navigate, route } from '../router'
-import { agents, keepers, executionLoaded, shellCounts, shellRuntimeResolution } from '../store'
+import { agents, keepers, serverStatus, executionLoaded, shellCounts, shellRuntimeResolution } from '../store'
 import { AgentRoster, countRuntimeKinds } from './agent-roster'
 import { AgentProfile } from './agent-profile'
 import { KeeperDetailPage } from './keeper-detail-page'
@@ -82,6 +82,7 @@ export function AgentsUnified() {
     shellCounts: shellCounts.value,
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
     runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
+    runtimeHealthGeneratedAt: serverStatus.value?.generated_at ?? null,
   })
   function chipCount(id: AgentsView): number | string | null {
     if (id === 'all') return formatRuntimeRosterCount(runtimeCounts)

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -7,7 +7,7 @@ import { useMemo, useState } from 'preact/hooks'
 import { computed } from '@preact/signals'
 import { FilterChips } from './common/filter-chips'
 import { navigate, route } from '../router'
-import { agents, keepers, serverStatus, executionLoaded, shellCounts, shellRuntimeResolution } from '../store'
+import { agents, keepers, executionLoaded, shellCounts, shellRuntimeResolution } from '../store'
 import { AgentRoster, countRuntimeKinds } from './agent-roster'
 import { AgentProfile } from './agent-profile'
 import { KeeperDetailPage } from './keeper-detail-page'
@@ -82,7 +82,7 @@ export function AgentsUnified() {
     shellCounts: shellCounts.value,
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
     runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
-    runtimeHealthGeneratedAt: serverStatus.value?.generated_at ?? null,
+    runtimeHealthGeneratedAt: shellRuntimeResolution.value?.generated_at ?? null,
   })
   function chipCount(id: AgentsView): number | string | null {
     if (id === 'all') return formatRuntimeRosterCount(runtimeCounts)

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -7,7 +7,7 @@ import { useMemo, useState } from 'preact/hooks'
 import { computed } from '@preact/signals'
 import { FilterChips } from './common/filter-chips'
 import { navigate, route } from '../router'
-import { agents, keepers, executionLoaded, shellCounts } from '../store'
+import { agents, keepers, executionLoaded, shellCounts, shellRuntimeResolution } from '../store'
 import { AgentRoster, countRuntimeKinds } from './agent-roster'
 import { AgentProfile } from './agent-profile'
 import { KeeperDetailPage } from './keeper-detail-page'
@@ -81,6 +81,7 @@ export function AgentsUnified() {
     namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
     shellCounts: shellCounts.value,
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
+    runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
   })
   function chipCount(id: AgentsView): number | string | null {
     if (id === 'all') return formatRuntimeRosterCount(runtimeCounts)

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -355,7 +355,7 @@ describe('dashboardHealthChips', () => {
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
       .toBe('키퍼 런타임 가동 0 / 일시정지 3 / 설정 13')
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
-      .toBe('런타임 가동=runtime health; 일시정지=재개 대기 lifecycle row; 오프라인=프로세스/하트비트 없음으로 기동 필요 row; 설정=shell keeper 설정.')
+      .toBe('런타임 가동=runtime health; 일시정지=runtime health; 오프라인=runtime health only; execution offline rows not mixed; 설정=shell keeper 설정.')
     expect(chips.find(chip => chip.key === 'paused-keepers')?.label)
       .toBe('일시정지 keeper 3')
     expect(chips.find(chip => chip.key === 'no-keeper-rows')).toBeUndefined()

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -326,6 +326,41 @@ describe('dashboardHealthChips', () => {
       .toBe('런타임 가동=shell; 일시정지=재개 대기 lifecycle row; 오프라인=프로세스/하트비트 없음으로 기동 필요 row; 설정=project snapshot keeper 설정.')
   })
 
+  it('uses runtime health as the paused keeper count authority when detail rows are absent', () => {
+    const chips = dashboardHealthChips({
+      connected: true,
+      counts: { agents: 0, keepers: 9, configured_keepers: 13, total_runtimes: 13 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        source_mismatch: false,
+        server_workspace_mismatch: false,
+        fleet_safety: {
+          keeper_fibers: 9,
+          paused_keepers: 2,
+          paused_keepers_health: { count: 3 },
+          keeper_fleet_no_fibers: false,
+          keeper_fd_pressure: null,
+          keeper_fleet_safety: {
+            running_keeper_fiber_count: 0,
+            paused_keeper_count: 4,
+          },
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+
+    expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
+      .toBe('키퍼 런타임 가동 0 / 일시정지 3 / 설정 13')
+    expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
+      .toBe('런타임 가동=runtime health; 일시정지=재개 대기 lifecycle row; 오프라인=프로세스/하트비트 없음으로 기동 필요 row; 설정=shell keeper 설정.')
+    expect(chips.find(chip => chip.key === 'paused-keepers')?.label)
+      .toBe('일시정지 keeper 3')
+    expect(chips.find(chip => chip.key === 'no-keeper-rows')).toBeUndefined()
+  })
+
   it('returns a healthy chip when no runtime risk is visible', () => {
     const chips = dashboardHealthChips({
       connected: true,
@@ -362,12 +397,12 @@ describe('dashboardHealthChips', () => {
       loading: false,
     })
 
-    expect(chips).toEqual([expect.objectContaining({
-      key: 'fleet-liveness-risk',
+    const chip = chips.find(c => c.key === 'fleet-liveness-risk')
+    expect(chip).toEqual(expect.objectContaining({
       label: 'Fleet liveness risk',
       tone: 'bad',
-    })])
-    expect(chips[0]?.detail).toContain('keeper_fibers=1')
+    }))
+    expect(chip?.detail).toContain('keeper_fibers=1')
   })
 
   it('surfaces a P0 blocked fleet when health reports zero running keeper fibers', () => {
@@ -418,16 +453,16 @@ describe('dashboardHealthChips', () => {
       loading: false,
     })
 
-    expect(chips).toEqual([expect.objectContaining({
-      key: 'fleet-liveness-risk',
+    const chip = chips.find(c => c.key === 'fleet-liveness-risk')
+    expect(chip).toEqual(expect.objectContaining({
       label: 'P0 fleet blocked',
       tone: 'bad',
-    })])
-    expect(chips[0]?.detail).toContain('status=blocked')
-    expect(chips[0]?.detail).toContain('running_keeper_fiber_count=0')
-    expect(chips[0]?.detail).toContain('paused_keeper_count=13')
-    expect(chips[0]?.detail).toContain('target_reaction_capacity_count=14')
-    expect(chips[0]?.detail).toContain('resume selected paused keepers')
+    }))
+    expect(chip?.detail).toContain('status=blocked')
+    expect(chip?.detail).toContain('running_keeper_fiber_count=0')
+    expect(chip?.detail).toContain('paused_keeper_count=13')
+    expect(chip?.detail).toContain('target_reaction_capacity_count=14')
+    expect(chip?.detail).toContain('resume selected paused keepers')
   })
 
   it('labels an all-paused fleet as paused instead of blocked', () => {
@@ -478,14 +513,14 @@ describe('dashboardHealthChips', () => {
       loading: false,
     })
 
-    expect(chips).toEqual([expect.objectContaining({
-      key: 'fleet-liveness-risk',
+    const chip = chips.find(c => c.key === 'fleet-liveness-risk')
+    expect(chip).toEqual(expect.objectContaining({
       label: 'Fleet paused',
       tone: 'warn',
-    })])
-    expect(chips[0]?.detail).toContain('paused_keeper_count=3')
-    expect(chips[0]?.detail).toContain('paused is lifecycle state')
-    expect(chips[0]?.detail).not.toContain('resume selected paused keepers')
+    }))
+    expect(chip?.detail).toContain('paused_keeper_count=3')
+    expect(chip?.detail).toContain('paused is lifecycle state')
+    expect(chip?.detail).not.toContain('resume selected paused keepers')
   })
 
   it('keeps mixed paused fleets blocked when autoboot keepers are still below target', () => {
@@ -536,13 +571,13 @@ describe('dashboardHealthChips', () => {
       loading: false,
     })
 
-    expect(chips).toEqual([expect.objectContaining({
-      key: 'fleet-liveness-risk',
+    const chip = chips.find(c => c.key === 'fleet-liveness-risk')
+    expect(chip).toEqual(expect.objectContaining({
       label: 'P0 fleet blocked',
       tone: 'bad',
-    })])
-    expect(chips[0]?.detail).toContain('paused_autoboot_enabled_keeper_count=13')
-    expect(chips[0]?.detail).toContain('resume selected paused keepers')
+    }))
+    expect(chip?.detail).toContain('paused_autoboot_enabled_keeper_count=13')
+    expect(chip?.detail).toContain('resume selected paused keepers')
   })
 
   it('surfaces fleet capacity degradation when running fibers are below target', () => {
@@ -593,18 +628,18 @@ describe('dashboardHealthChips', () => {
       loading: false,
     })
 
-    expect(chips).toEqual([expect.objectContaining({
-      key: 'fleet-liveness-risk',
+    const chip = chips.find(c => c.key === 'fleet-liveness-risk')
+    expect(chip).toEqual(expect.objectContaining({
       label: 'Fleet capacity degraded',
       tone: 'warn',
-    })])
-    expect(chips[0]?.detail).toContain('status=degraded')
-    expect(chips[0]?.detail).toContain('healthy_running_keeper_fiber_count=3')
-    expect(chips[0]?.detail).toContain('executable_keeper_fiber_count=11')
-    expect(chips[0]?.detail).toContain('failing_keeper_fiber_count=8')
-    expect(chips[0]?.detail).toContain('target_reaction_capacity_count=13')
-    expect(chips[0]?.detail).toContain('reaction_capacity_shortfall_count=10')
-    expect(chips[0]?.detail).toContain('blocker=reaction_capacity_below_target')
+    }))
+    expect(chip?.detail).toContain('status=degraded')
+    expect(chip?.detail).toContain('healthy_running_keeper_fiber_count=3')
+    expect(chip?.detail).toContain('executable_keeper_fiber_count=11')
+    expect(chip?.detail).toContain('failing_keeper_fiber_count=8')
+    expect(chip?.detail).toContain('target_reaction_capacity_count=13')
+    expect(chip?.detail).toContain('reaction_capacity_shortfall_count=10')
+    expect(chip?.detail).toContain('blocker=reaction_capacity_below_target')
   })
 
   it('does not treat non-FD fleet blocked counts as FD pressure', () => {
@@ -655,12 +690,12 @@ describe('dashboardHealthChips', () => {
       loading: false,
     })
 
-    expect(chips).toEqual([expect.objectContaining({
-      key: 'fleet-liveness-risk',
+    const chip = chips.find(c => c.key === 'fleet-liveness-risk')
+    expect(chip).toEqual(expect.objectContaining({
       label: 'Fleet capacity degraded',
       tone: 'warn',
-    })])
-    expect(chips[0]?.detail).not.toContain('FD pressure')
+    }))
+    expect(chip?.detail).not.toContain('FD pressure')
   })
 
   it('surfaces fleet liveness risk when FD pressure blocks 24 keepers', () => {
@@ -690,12 +725,12 @@ describe('dashboardHealthChips', () => {
       loading: false,
     })
 
-    expect(chips).toEqual([expect.objectContaining({
-      key: 'fleet-liveness-risk',
+    const chip = chips.find(c => c.key === 'fleet-liveness-risk')
+    expect(chip).toEqual(expect.objectContaining({
       label: 'Fleet liveness risk',
       tone: 'bad',
-    })])
-    expect(chips[0]?.detail).toContain('blocking 24 keepers')
+    }))
+    expect(chip?.detail).toContain('blocking 24 keepers')
   })
 
   it('prioritizes FD pressure over degraded capacity when both are present', () => {
@@ -753,12 +788,12 @@ describe('dashboardHealthChips', () => {
       loading: false,
     })
 
-    expect(chips).toEqual([expect.objectContaining({
-      key: 'fleet-liveness-risk',
+    const chip = chips.find(c => c.key === 'fleet-liveness-risk')
+    expect(chip).toEqual(expect.objectContaining({
       label: 'Fleet liveness risk',
       tone: 'bad',
-    })])
-    expect(chips[0]?.detail).toContain('blocking 24 keepers')
+    }))
+    expect(chip?.detail).toContain('blocking 24 keepers')
   })
 
   it('surfaces reaction ledger cursor sweeps even when pending backlog is clear', () => {
@@ -790,13 +825,13 @@ describe('dashboardHealthChips', () => {
       loading: false,
     })
 
-    expect(chips).toEqual([expect.objectContaining({
-      key: 'reaction-ledger',
+    const chip = chips.find(c => c.key === 'reaction-ledger')
+    expect(chip).toEqual(expect.objectContaining({
       label: 'Reaction ledger swept 4',
       tone: 'ok',
-    })])
-    expect(chips[0]?.detail).toContain('cursor_swept=3')
-    expect(chips[0]?.detail).toContain('legacy_swept=1')
+    }))
+    expect(chip?.detail).toContain('cursor_swept=3')
+    expect(chip?.detail).toContain('legacy_swept=1')
   })
 
   it('warns on real reaction ledger pending backlog', () => {
@@ -828,28 +863,32 @@ describe('dashboardHealthChips', () => {
       loading: false,
     })
 
-    expect(chips).toEqual([expect.objectContaining({
-      key: 'reaction-ledger',
+    const chip = chips.find(c => c.key === 'reaction-ledger')
+    expect(chip).toEqual(expect.objectContaining({
       label: 'Reaction ledger pending 2',
       tone: 'warn',
-    })])
-    expect(chips[0]?.detail).toContain('pending=2')
+    }))
+    expect(chip?.detail).toContain('pending=2')
   })
 
   it('attaches drill-down routes so HEALTH chips deep-link operators to the right view', () => {
     const chips = dashboardHealthChips({
       connected: true,
       counts: { keepers: 0, configured_keepers: 3 },
-      keepers: [{
-        name: 'keeper-a',
-        status: 'paused',
-        paused: true,
-      } as any],
+      keepers: [],
       runtimeResolution: {
         status: 'warn',
         warnings: [],
         source_mismatch: true,
         server_workspace_mismatch: false,
+        fleet_safety: {
+          keeper_fibers: 0,
+          paused_keepers: 0,
+          paused_keepers_health: null,
+          keeper_fleet_no_fibers: false,
+          keeper_fd_pressure: null,
+          keeper_fleet_safety: null,
+        },
       } as any,
       executionError: null,
       loading: false,
@@ -862,13 +901,33 @@ describe('dashboardHealthChips', () => {
       tab: 'monitoring',
       params: { section: 'runtime' },
     })
-    // paused-keepers → fleet-health (operator drills into the keeper list)
-    expect(byKey['paused-keepers']?.route).toEqual({
+    // no-keeper-rows → same fleet-health section (configured vs live diff)
+    expect(byKey['no-keeper-rows']?.route).toEqual({
       tab: 'monitoring',
       params: { section: 'fleet-health' },
     })
-    // no-keeper-rows → same fleet-health section (configured vs live diff)
-    expect(byKey['no-keeper-rows']?.route).toEqual({
+
+    const pausedChips = dashboardHealthChips({
+      connected: true,
+      counts: { keepers: 0, configured_keepers: 3 },
+      keepers: [],
+      runtimeResolution: {
+        status: 'ready',
+        warnings: [],
+        fleet_safety: {
+          keeper_fibers: 0,
+          paused_keepers: 1,
+          keeper_fleet_no_fibers: false,
+          keeper_fd_pressure: null,
+          keeper_fleet_safety: null,
+        },
+      } as any,
+      executionError: null,
+      loading: false,
+    })
+    const pausedByKey = Object.fromEntries(pausedChips.map(c => [c.key, c]))
+    // paused-keepers → fleet-health (operator drills into the keeper list)
+    expect(pausedByKey['paused-keepers']?.route).toEqual({
       tab: 'monitoring',
       params: { section: 'fleet-health' },
     })

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -18,7 +18,6 @@ import {
   configuredCountSourceLabel,
   formatKeeperCountBreakdown,
   keeperRowLooksRunning,
-  resolveRuntimeFleetSafetyCounts,
   resolveRuntimeCounts,
   runtimeCountSourceLabel,
 } from '../runtime-counts'
@@ -233,6 +232,7 @@ interface DashboardHealthInput {
   namespaceTruthConfiguredKeepers?: number
   keepers: Keeper[]
   runtimeResolution: DashboardRuntimeResolution | null
+  runtimeGeneratedAt?: string | null
   runtimeProviderProbe?: DashboardRuntimeProbePayload | null
   runtimeProviderProbeError?: string | null
   executionError: string | null
@@ -560,7 +560,6 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
 
   const rowPausedKeepers = input.keepers.filter(isKeeperPaused).length
   const fallbackRunningKeepers = input.keepers.filter(keeperRowLooksRunning).length
-  const runtimeHealthCounts = resolveRuntimeFleetSafetyCounts(runtime?.fleet_safety ?? null)
   const runtimeCounts = resolveRuntimeCounts({
     executionLoaded: input.keepers.length > 0,
     agentsCount: input.counts?.agents ?? 0,
@@ -572,6 +571,7 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
     shellCounts: input.counts,
     shellConfiguredKeepers: input.counts?.configured_keepers,
     runtimeFleetSafety: runtime?.fleet_safety ?? null,
+    runtimeHealthGeneratedAt: input.runtimeGeneratedAt,
   })
   const configured = runtimeCounts.configured.keepers
   const liveKeepers = runtimeCounts.live.keepers
@@ -581,13 +581,19 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
   // keeper-count-basis chip's `detail` tooltip (hover-only, diagnostic) below —
   // an on-demand explanation of where the running count comes from, which is the
   // actionable detail that review kept. Retained intentionally, not an oversight.
-  const runningCountSource = runtimeHealthCounts?.hasRunningKeepers === true
+  const runningCountSource = runtimeCounts.source === 'runtime-health'
     ? 'runtime health'
     : input.counts !== null
     ? 'shell'
     : input.keepers.length > 0
       ? '상세 행'
       : runtimeCountSourceLabel(runtimeCounts.source)
+  const pausedCountSource = runtimeCounts.source === 'runtime-health'
+    ? 'runtime health'
+    : '재개 대기 lifecycle row'
+  const offlineCountSource = runtimeCounts.source === 'runtime-health'
+    ? 'runtime health only; execution offline rows not mixed'
+    : '프로세스/하트비트 없음으로 기동 필요 row'
   if (configured > 0 && (configured !== liveKeepers || pausedKeepers > 0 || runtimeCounts.live.offlineKeepers > 0)) {
     chips.push({
       key: 'keeper-count-basis',
@@ -597,7 +603,7 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
         offlineKeepers: runtimeCounts.live.offlineKeepers,
         configuredKeepers: configured,
       }),
-      detail: `런타임 가동=${runningCountSource}; 일시정지=재개 대기 lifecycle row; 오프라인=프로세스/하트비트 없음으로 기동 필요 row; 설정=${configuredCountSourceLabel(runtimeCounts.configured.source)} keeper 설정.`,
+      detail: `런타임 가동=${runningCountSource}; 일시정지=${pausedCountSource}; 오프라인=${offlineCountSource}; 설정=${configuredCountSourceLabel(runtimeCounts.configured.source)} keeper 설정.`,
       tone: 'muted',
     })
   }
@@ -750,6 +756,7 @@ export function DashboardHealthStrip() {
       namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
       keepers: keepers.value,
       runtimeResolution: shellRuntimeResolution.value,
+      runtimeGeneratedAt: serverStatus.value?.generated_at ?? null,
       runtimeProviderProbe: shellRuntimeProviderProbe.value,
       runtimeProviderProbeError: shellRuntimeProviderProbeError.value,
       executionError: executionError.value,

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -571,7 +571,7 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
     shellCounts: input.counts,
     shellConfiguredKeepers: input.counts?.configured_keepers,
     runtimeFleetSafety: runtime?.fleet_safety ?? null,
-    runtimeHealthGeneratedAt: input.runtimeGeneratedAt,
+    runtimeHealthGeneratedAt: input.runtimeGeneratedAt ?? runtime?.generated_at ?? null,
   })
   const configured = runtimeCounts.configured.keepers
   const liveKeepers = runtimeCounts.live.keepers
@@ -756,7 +756,7 @@ export function DashboardHealthStrip() {
       namespaceTruthConfiguredKeepers: namespaceTruth.value?.root.configured_keepers,
       keepers: keepers.value,
       runtimeResolution: shellRuntimeResolution.value,
-      runtimeGeneratedAt: serverStatus.value?.generated_at ?? null,
+      runtimeGeneratedAt: shellRuntimeResolution.value?.generated_at ?? null,
       runtimeProviderProbe: shellRuntimeProviderProbe.value,
       runtimeProviderProbeError: shellRuntimeProviderProbeError.value,
       executionError: executionError.value,

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -18,6 +18,7 @@ import {
   configuredCountSourceLabel,
   formatKeeperCountBreakdown,
   keeperRowLooksRunning,
+  resolveRuntimeFleetSafetyCounts,
   resolveRuntimeCounts,
   runtimeCountSourceLabel,
 } from '../runtime-counts'
@@ -557,29 +558,32 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
     })
   }
 
-  const pausedKeepers = input.keepers.filter(isKeeperPaused).length
+  const rowPausedKeepers = input.keepers.filter(isKeeperPaused).length
   const fallbackRunningKeepers = input.keepers.filter(keeperRowLooksRunning).length
-  const fallbackOfflineKeepers = Math.max(0, input.keepers.length - fallbackRunningKeepers - pausedKeepers)
+  const runtimeHealthCounts = resolveRuntimeFleetSafetyCounts(runtime?.fleet_safety ?? null)
   const runtimeCounts = resolveRuntimeCounts({
-    executionLoaded: input.counts !== null || input.keepers.length > 0,
+    executionLoaded: input.keepers.length > 0,
     agentsCount: input.counts?.agents ?? 0,
     keepersCount: input.counts?.keepers ?? fallbackRunningKeepers,
-    pausedKeepersCount: pausedKeepers,
-    offlineKeepersCount: input.counts !== null ? 0 : fallbackOfflineKeepers,
+    pausedKeepersCount: rowPausedKeepers,
     keeperRowsCount: input.keepers.length,
     namespaceTruthCounts: input.namespaceTruthCounts,
     namespaceTruthConfiguredKeepers: input.namespaceTruthConfiguredKeepers,
     shellCounts: input.counts,
     shellConfiguredKeepers: input.counts?.configured_keepers,
+    runtimeFleetSafety: runtime?.fleet_safety ?? null,
   })
   const configured = runtimeCounts.configured.keepers
   const liveKeepers = runtimeCounts.live.keepers
+  const pausedKeepers = runtimeCounts.live.pausedKeepers
   // Scope note (#22110): the agent-roster surface dropped the count-source label
   // from its always-visible operational copy. Here the same label feeds the
   // keeper-count-basis chip's `detail` tooltip (hover-only, diagnostic) below —
   // an on-demand explanation of where the running count comes from, which is the
   // actionable detail that review kept. Retained intentionally, not an oversight.
-  const runningCountSource = input.counts !== null
+  const runningCountSource = runtimeHealthCounts?.hasRunningKeepers === true
+    ? 'runtime health'
+    : input.counts !== null
     ? 'shell'
     : input.keepers.length > 0
       ? '상세 행'
@@ -632,7 +636,7 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
     chips.push(cdalChip)
   }
 
-  if (configured > 0 && liveKeepers === 0) {
+  if (configured > 0 && input.keepers.length === 0 && liveKeepers === 0 && pausedKeepers === 0) {
     chips.push({
       key: 'no-keeper-rows',
       label: 'No keeper rows',

--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -15,10 +15,13 @@ vi.mock('../api/keeper', () => ({
 vi.mock('../store', () => ({
   keepers: { value: [] },
   applyOptimisticKeeperDirective: vi.fn(() => () => {}),
-  refreshExecution: vi.fn(async () => undefined),
+  refreshKeeperRuntimeStatus: vi.fn(async () => undefined),
 }))
 
+import { pauseKeeper } from '../api/keeper'
 import { keeperActionVisibility } from '../lib/keeper-predicates'
+import { applyOptimisticKeeperDirective, refreshKeeperRuntimeStatus } from '../store'
+import { runKeeperAction } from './keeper-action-panel'
 import type { Keeper } from '../types'
 
 function makeKeeper(overrides: Partial<Keeper>): Keeper {
@@ -138,5 +141,16 @@ describe('keeperActionVisibility', () => {
       const v = keeperActionVisibility(k)
       expect(v.canWake).toBe(true)
     })
+  })
+})
+
+describe('runKeeperAction', () => {
+  it('refreshes the shared runtime status source after a successful directive', async () => {
+    vi.mocked(pauseKeeper).mockResolvedValueOnce({ ok: true })
+
+    await runKeeperAction('rondo', 'pause')
+
+    expect(applyOptimisticKeeperDirective).toHaveBeenCalledWith('rondo', 'pause')
+    expect(refreshKeeperRuntimeStatus).toHaveBeenCalledWith({ force: true })
   })
 })

--- a/dashboard/src/components/keeper-action-panel.test.ts
+++ b/dashboard/src/components/keeper-action-panel.test.ts
@@ -151,6 +151,6 @@ describe('runKeeperAction', () => {
     await runKeeperAction('rondo', 'pause')
 
     expect(applyOptimisticKeeperDirective).toHaveBeenCalledWith('rondo', 'pause')
-    expect(refreshKeeperRuntimeStatus).toHaveBeenCalledWith({ force: true })
+    expect(refreshKeeperRuntimeStatus).toHaveBeenCalledWith()
   })
 })

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -38,7 +38,7 @@ function afterAction(): void {
   // shell runtime-health for top-strip / roster aggregate counts. This avoids
   // the old full `refreshDashboard()` bootstrap while keeping every status
   // surface on the same post-action truth source.
-  void refreshKeeperRuntimeStatus({ force: true }).catch(err => {
+  void refreshKeeperRuntimeStatus().catch(err => {
     const message = err instanceof Error ? err.message : 'dashboard refresh failed'
     showToast(message, 'warning')
   })

--- a/dashboard/src/components/keeper-action-panel.ts
+++ b/dashboard/src/components/keeper-action-panel.ts
@@ -25,7 +25,7 @@ import {
 } from '../api/keeper'
 import {
   applyOptimisticKeeperDirective,
-  refreshExecution,
+  refreshKeeperRuntimeStatus,
 } from '../store'
 import type { Keeper } from '../types'
 import { keeperActionVisibility } from '../lib/keeper-predicates'
@@ -34,15 +34,11 @@ import { keeperActionVisibility } from '../lib/keeper-predicates'
 
 function afterAction(): void {
   // Reconcile the optimistic patch against the authoritative server
-  // snapshot. Scoped to the execution slice (the keeper roster) instead of
-  // a full `refreshDashboard()` bootstrap: the bootstrap re-hydrated shell,
-  // planning, namespace, goals and goal_loop and flipped dashboardLoading,
-  // which re-rendered every panel — the "the whole screen refreshes on
-  // every keeper action" complaint. `refreshExecution` is the same scope
-  // the SSE keeper_phase_changed route already uses (sse-store.ts), and it
-  // coalesces through the execution scheduler so concurrent actions don't
-  // stack refetches.
-  void refreshExecution().catch(err => {
+  // snapshots that drive status UI: execution rows for the roster and light
+  // shell runtime-health for top-strip / roster aggregate counts. This avoids
+  // the old full `refreshDashboard()` bootstrap while keeping every status
+  // surface on the same post-action truth source.
+  void refreshKeeperRuntimeStatus({ force: true }).catch(err => {
     const message = err instanceof Error ? err.message : 'dashboard refresh failed'
     showToast(message, 'warning')
   })
@@ -225,4 +221,3 @@ export function KeeperActionButtons({
     </div>
   `
 }
-

--- a/dashboard/src/components/keeper-detail-helpers.test.ts
+++ b/dashboard/src/components/keeper-detail-helpers.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const { refreshDashboard, invalidateDashboardCache, refreshExecution } = vi.hoisted(() => ({
+const { refreshDashboard, invalidateDashboardCache, refreshKeeperRuntimeStatus } = vi.hoisted(() => ({
   refreshDashboard: vi.fn<() => Promise<void>>(),
   invalidateDashboardCache: vi.fn(),
-  refreshExecution: vi.fn<() => Promise<void>>(),
+  refreshKeeperRuntimeStatus: vi.fn<() => Promise<void>>(),
 }))
 
 vi.mock('../api', () => ({
@@ -14,7 +14,7 @@ vi.mock('../api', () => ({
 vi.mock('../store', () => ({
   invalidateDashboardCache,
   refreshDashboard,
-  refreshExecution,
+  refreshKeeperRuntimeStatus,
 }))
 
 vi.mock('./common/toast', () => ({
@@ -22,11 +22,11 @@ vi.mock('./common/toast', () => ({
 }))
 
 describe('refreshAfterRuntimeAction', () => {
-  it('schedules a scoped execution refresh without blocking lifecycle buttons', async () => {
-    // Keeper runtime actions reconcile against the execution slice (the
-    // roster), not a full dashboard bootstrap — see refreshAfterRuntimeAction.
+  it('schedules scoped execution + light shell refresh without blocking lifecycle buttons', async () => {
+    // Keeper runtime actions reconcile against execution rows plus shell
+    // runtime-health, not a full dashboard bootstrap — see refreshAfterRuntimeAction.
     let releaseRefresh: () => void = () => {}
-    refreshExecution.mockReturnValueOnce(new Promise<void>(resolve => {
+    refreshKeeperRuntimeStatus.mockReturnValueOnce(new Promise<void>(resolve => {
       releaseRefresh = resolve
     }))
 
@@ -35,7 +35,7 @@ describe('refreshAfterRuntimeAction', () => {
     // helper fires-and-forgets so the lifecycle button is never blocked.
     await expect(refreshAfterRuntimeAction()).resolves.toBeUndefined()
 
-    expect(refreshExecution).toHaveBeenCalledWith({ force: true })
+    expect(refreshKeeperRuntimeStatus).toHaveBeenCalledWith({ force: true })
     // The full-bootstrap path is no longer taken for keeper actions.
     expect(refreshDashboard).not.toHaveBeenCalled()
 

--- a/dashboard/src/components/keeper-detail-helpers.test.ts
+++ b/dashboard/src/components/keeper-detail-helpers.test.ts
@@ -35,7 +35,7 @@ describe('refreshAfterRuntimeAction', () => {
     // helper fires-and-forgets so the lifecycle button is never blocked.
     await expect(refreshAfterRuntimeAction()).resolves.toBeUndefined()
 
-    expect(refreshKeeperRuntimeStatus).toHaveBeenCalledWith({ force: true })
+    expect(refreshKeeperRuntimeStatus).toHaveBeenCalledWith()
     // The full-bootstrap path is no longer taken for keeper actions.
     expect(refreshDashboard).not.toHaveBeenCalled()
 

--- a/dashboard/src/components/keeper-detail-helpers.ts
+++ b/dashboard/src/components/keeper-detail-helpers.ts
@@ -1,5 +1,5 @@
 import { currentDashboardActor, runOperatorAction } from '../api'
-import { invalidateDashboardCache, refreshDashboard, refreshExecution } from '../store'
+import { invalidateDashboardCache, refreshDashboard, refreshKeeperRuntimeStatus } from '../store'
 import { showToast } from './common/toast'
 import { keeperRuntimeBlockerHint } from '../lib/keeper-runtime-display'
 import type { Keeper } from '../types'
@@ -24,14 +24,15 @@ export async function runSocialSweep(): Promise<void> {
 export async function refreshAfterRuntimeAction(): Promise<void> {
   // Keeper runtime actions (boot/shutdown/resume/wakeup/pause from the rail,
   // alert strip, detail page and lifecycle buttons) reconcile against the
-  // execution slice — the keeper roster — not the full dashboard bootstrap.
+  // execution slice and the light shell runtime-health slice — not the full
+  // dashboard bootstrap.
   // The previous `refreshDashboard({ force: true })` re-hydrated shell,
   // planning, namespace, goals and goal_loop and flipped dashboardLoading,
   // re-rendering every panel ("the whole screen refreshes when I resume a
-  // keeper"). `force: true` keeps the immediate refetch boot/shutdown need
-  // (those have no optimistic patch); the scope now matches the SSE
-  // keeper_phase_changed route (sse-store.ts).
-  void refreshExecution({ force: true }).catch(err => {
+  // keeper"). `force: true` keeps the immediate refetch boot/shutdown need,
+  // while the shell light refresh updates the global runtime-health chips that
+  // now share the same status source as the roster counts.
+  void refreshKeeperRuntimeStatus({ force: true }).catch(err => {
     const message = err instanceof Error ? err.message : '대시보드 새로고침 실패'
     showToast(message, 'warning')
   })

--- a/dashboard/src/components/keeper-detail-helpers.ts
+++ b/dashboard/src/components/keeper-detail-helpers.ts
@@ -29,10 +29,10 @@ export async function refreshAfterRuntimeAction(): Promise<void> {
   // The previous `refreshDashboard({ force: true })` re-hydrated shell,
   // planning, namespace, goals and goal_loop and flipped dashboardLoading,
   // re-rendering every panel ("the whole screen refreshes when I resume a
-  // keeper"). `force: true` keeps the immediate refetch boot/shutdown need,
-  // while the shell light refresh updates the global runtime-health chips that
-  // now share the same status source as the roster counts.
-  void refreshKeeperRuntimeStatus({ force: true }).catch(err => {
+  // keeper"). The shared refresh stays on the store scheduler so rapid
+  // post-action clicks coalesce while shell runtime-health updates before the
+  // execution projection is read.
+  void refreshKeeperRuntimeStatus().catch(err => {
     const message = err instanceof Error ? err.message : '대시보드 새로고침 실패'
     showToast(message, 'warning')
   })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -83,6 +83,15 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('oas·seoul-1')
   })
 
+  it('renders the selected runtime state from the canonical phase label', () => {
+    const k = mkKeeper({ status: 'offline', lifecycle_phase: 'Paused' })
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} />`)
+    const state = container.querySelector('.kw-fleet-aside-state') as HTMLElement | null
+    expect(state).not.toBeNull()
+    expect(state?.textContent).toBe('일시정지')
+    expect(state?.getAttribute('title')).toBe('offline')
+  })
+
   it('shows the model line as missing when no model was reported', () => {
     const k = mkKeeper({ runtime_canonical: 'runpod_gemma' })
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} />`)

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -153,7 +153,6 @@ function fleetLifecycleActions(keeper: Keeper): KeeperActionKey[] {
 
 async function runFleetKeeperAction(name: string, action: KeeperActionKey): Promise<void> {
   await runKeeperAction(name, action)
-  await refreshAfterRuntimeAction()
 }
 
 function keeperRecentTools(keeper: Keeper): string[] {
@@ -175,6 +174,8 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
   const phase = keeperPhaseLabel(keeper)
   const model = keeperModelLabel(keeper)
   const runtime = keeperRuntimeLabel(keeper)
+  const bucket = keeperBucket(keeper)
+  const tone = keeperFleetTone(keeper)
   const lifecycle = keeper.phase || keeper.lifecycle_phase || keeper.status
   const actions = fleetLifecycleActions(keeper).filter(action => action !== 'shutdown').slice(0, 3)
   const [pendingAction, setPendingAction] = useState<KeeperActionKey | null>(null)
@@ -185,15 +186,15 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
   }
 
   return html`
-    <div class="kw-fleet-aside" data-tone=${keeperFleetTone(keeper)}>
+    <div class="kw-fleet-aside" data-tone=${tone}>
       <div class="kw-fleet-aside-head">
-        <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${keeperBucket(keeper) === 'running'} />
+        <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${bucket === 'running'} />
         <div class="kw-fleet-aside-title">
           <span class="kw-fleet-aside-kicker">Selected runtime</span>
           <strong title=${keeper.agent_name || keeper.name}>${keeper.koreanName || keeper.agent_name || keeper.name}</strong>
           <span title=${keeper.name}>${keeper.name}</span>
         </div>
-        <span class="kw-fleet-aside-state">${keeper.status}</span>
+        <span class="kw-fleet-aside-state" title=${keeper.status}>${phase}</span>
       </div>
       <button type="button" class="kw-fleet-chat" onClick=${openChat}>대화 콘솔 열기</button>
       <div class="kw-fleet-phase" title=${activity.source !== 'none' ? activity.label : phase}>
@@ -304,7 +305,7 @@ function ThroughputSection({ keeper }: { keeper: Keeper }): VNode {
   const peak = Math.max(1, ...series)
   const latest = allSeries.at(-1) ?? 0
   const avg = series.length ? Math.round(series.reduce((a, b) => a + b, 0) / series.length) : 0
-  const live = keeper.status.toLowerCase() === 'running' || keeper.status.toLowerCase() === 'active'
+  const live = keeperBucket(keeper) === 'running'
   return html`
     <div class="ctx-sec">
       <h4

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -27,7 +27,6 @@ import type { KeeperActivityDisplay } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import type { Keeper } from '../../types'
 import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
-import { refreshAfterRuntimeAction } from '../keeper-detail-helpers'
 import { VirtualList } from '../common/virtual-list'
 import {
   WorkspaceSigil,
@@ -415,7 +414,6 @@ function lifecycleActions(keeper: Keeper): KeeperActionKey[] {
 
 async function runRosterKeeperAction(name: string, action: KeeperActionKey): Promise<void> {
   await runKeeperAction(name, action)
-  await refreshAfterRuntimeAction()
 }
 
 function rosterActivityText(activity: KeeperActivityDisplay): string | null {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
@@ -24,6 +24,10 @@ describe('keeperBucket', () => {
   it('classifies a paused keeper from the paused flag', () => {
     expect(keeperBucket(mk({ status: 'running', paused: true }))).toBe('paused')
   })
+  it('keeps an explicit pause state ahead of stale offline status', () => {
+    expect(keeperBucket(mk({ status: 'stopped', paused: true }))).toBe('paused')
+    expect(keeperBucket(mk({ status: 'offline', lifecycle_phase: 'Paused' }))).toBe('paused')
+  })
   it('classifies a stopped keeper as offline', () => {
     expect(keeperBucket(mk({ status: 'stopped' }))).toBe('offline')
   })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -13,8 +13,8 @@ import type { Keeper } from '../../types'
 export type KeeperBucket = 'running' | 'paused' | 'offline'
 
 export function keeperBucket(keeper: Keeper): KeeperBucket {
-  if (isKeeperOffline(keeper)) return 'offline'
   if (isKeeperPaused(keeper)) return 'paused'
+  if (isKeeperOffline(keeper)) return 'offline'
   return 'running'
 }
 

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -7,14 +7,14 @@
 import { html } from 'htm/preact'
 import { useState, useEffect } from 'preact/hooks'
 import { navigate, route } from '../../router'
-import { executionLoaded, keepers, shellCounts, shellRuntimeResolution, staleKeepers } from '../../store'
+import { executionLoaded, keepers, serverStatus, shellCounts, shellRuntimeResolution, staleKeepers } from '../../store'
 import { activeKeeperName } from '../../keeper-state'
 import { governanceData } from '../governance-signals'
 import { CopilotDockTopBarButton, type CopilotDockApi } from '../copilot-dock'
 import { TweaksPanelToggle } from '../tweaks-panel'
 import { StatusDot } from './primitives-v2'
 import { surfaceLabel } from './nav-rail-v2'
-import { keeperRowLooksRunning, resolveRuntimeCounts, runtimeCountSourceLabel } from '../../runtime-counts'
+import { configuredCountSourceLabel, keeperRowLooksRunning, resolveRuntimeCounts, runtimeCountSourceLabel } from '../../runtime-counts'
 // Operational/safety chrome the v2 prototype omits but operators rely on
 // (connection state, transport telemetry, emergency stop, error inbox, auth,
 // build identity). Re-mounted into the v2 top bar so the reskin does not drop
@@ -106,8 +106,18 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
     shellCounts: shellCounts.value,
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
     runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
+    runtimeHealthGeneratedAt: serverStatus.value?.generated_at ?? null,
   })
   const running = runtimeCounts.live.keepers
+  const countTitle = [
+    `runtime count: ${runtimeCountSourceLabel(runtimeCounts.source)}`,
+    `running=${runtimeCounts.live.keepers}`,
+    `paused=${runtimeCounts.live.pausedKeepers}`,
+    runtimeCounts.source === 'runtime-health'
+      ? 'offline=0 (not derived from execution rows)'
+      : `offline=${runtimeCounts.live.offlineKeepers}`,
+    `configured=${runtimeCounts.configured.keepers} (${configuredCountSourceLabel(runtimeCounts.configured.source)})`,
+  ].join('; ')
   const crumbKeeper = tab === 'keepers' ? route.value.params.keeper?.trim() || activeKeeperName.value || '' : ''
   return html`
     <div class="v2-top">
@@ -118,7 +128,7 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
           : null}
       </div>
       <div class="v2-top-spacer"></div>
-      <span class="v2-statchip live" title=${`runtime count: ${runtimeCountSourceLabel(runtimeCounts.source)}`}>
+      <span class="v2-statchip live" title=${countTitle}>
         <${StatusDot} status="run" pulse=${true} />${running} 실행 중
       </span>
       <${AttentionIndicatorV2} />

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -7,7 +7,7 @@
 import { html } from 'htm/preact'
 import { useState, useEffect } from 'preact/hooks'
 import { navigate, route } from '../../router'
-import { executionLoaded, keepers, serverStatus, shellCounts, shellRuntimeResolution, staleKeepers } from '../../store'
+import { executionLoaded, keepers, shellCounts, shellRuntimeResolution, staleKeepers } from '../../store'
 import { activeKeeperName } from '../../keeper-state'
 import { governanceData } from '../governance-signals'
 import { CopilotDockTopBarButton, type CopilotDockApi } from '../copilot-dock'
@@ -106,7 +106,7 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
     shellCounts: shellCounts.value,
     shellConfiguredKeepers: shellCounts.value?.configured_keepers,
     runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
-    runtimeHealthGeneratedAt: serverStatus.value?.generated_at ?? null,
+    runtimeHealthGeneratedAt: shellRuntimeResolution.value?.generated_at ?? null,
   })
   const running = runtimeCounts.live.keepers
   const countTitle = [

--- a/dashboard/src/components/v2/top-bar-v2.ts
+++ b/dashboard/src/components/v2/top-bar-v2.ts
@@ -7,14 +7,14 @@
 import { html } from 'htm/preact'
 import { useState, useEffect } from 'preact/hooks'
 import { navigate, route } from '../../router'
-import { keepers, staleKeepers } from '../../store'
+import { executionLoaded, keepers, shellCounts, shellRuntimeResolution, staleKeepers } from '../../store'
 import { activeKeeperName } from '../../keeper-state'
 import { governanceData } from '../governance-signals'
 import { CopilotDockTopBarButton, type CopilotDockApi } from '../copilot-dock'
 import { TweaksPanelToggle } from '../tweaks-panel'
 import { StatusDot } from './primitives-v2'
-import { phaseStatus } from './keeper-fsm'
 import { surfaceLabel } from './nav-rail-v2'
+import { keeperRowLooksRunning, resolveRuntimeCounts, runtimeCountSourceLabel } from '../../runtime-counts'
 // Operational/safety chrome the v2 prototype omits but operators rely on
 // (connection state, transport telemetry, emergency stop, error inbox, auth,
 // build identity). Re-mounted into the v2 top bar so the reskin does not drop
@@ -91,7 +91,23 @@ function AttentionIndicatorV2() {
 
 export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
   const tab = route.value.tab
-  const running = keepers.value.filter((k) => phaseStatus(k.lifecycle_phase) === 'run').length
+  const fallbackRunningKeepers = keepers.value.filter((keeper) => keeperRowLooksRunning({
+    status: keeper.status,
+    phase: keeper.lifecycle_phase ?? keeper.phase,
+    pipeline_stage: keeper.pipeline_stage,
+    paused: keeper.paused,
+    keepalive_running: keeper.keepalive_running,
+  })).length
+  const runtimeCounts = resolveRuntimeCounts({
+    executionLoaded: executionLoaded.value,
+    agentsCount: shellCounts.value?.agents ?? 0,
+    keepersCount: shellCounts.value?.keepers ?? fallbackRunningKeepers,
+    keeperRowsCount: keepers.value.length,
+    shellCounts: shellCounts.value,
+    shellConfiguredKeepers: shellCounts.value?.configured_keepers,
+    runtimeFleetSafety: shellRuntimeResolution.value?.fleet_safety ?? null,
+  })
+  const running = runtimeCounts.live.keepers
   const crumbKeeper = tab === 'keepers' ? route.value.params.keeper?.trim() || activeKeeperName.value || '' : ''
   return html`
     <div class="v2-top">
@@ -102,7 +118,9 @@ export function TopBarV2({ dock }: { dock: CopilotDockApi }) {
           : null}
       </div>
       <div class="v2-top-spacer"></div>
-      <span class="v2-statchip live"><${StatusDot} status="run" pulse=${true} />${running} 실행 중</span>
+      <span class="v2-statchip live" title=${`runtime count: ${runtimeCountSourceLabel(runtimeCounts.source)}`}>
+        <${StatusDot} status="run" pulse=${true} />${running} 실행 중
+      </span>
       <${AttentionIndicatorV2} />
       ${/* 예약(schedule): no live cron/schedule signal yet. Rendered as a plain
           navigation affordance only — no fabricated status (PR #22081 review:

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -11,6 +11,7 @@ import {
   formatRuntimeRosterCount,
   keeperRowLooksRunning,
   keeperDetailRows,
+  runtimeHealthIsFresh,
   resolveRuntimeFleetSafetyCounts,
   resolveRuntimeCounts,
   runtimeDetailRows,
@@ -225,6 +226,133 @@ describe('resolveRuntimeCounts', () => {
       configured: { keepers: 13, totalRuntimes: 13, source: 'shell' },
       source: 'runtime-health',
     })
+  })
+
+  it('does not fall back to keeper_fibers when running_keeper_fiber_count is absent', () => {
+    const runtimeFleetSafety = {
+      keeper_fibers: 9,
+      keeper_fleet_safety: {},
+    } as any
+
+    expect(resolveRuntimeFleetSafetyCounts(runtimeFleetSafety)).toBeNull()
+  })
+
+  it('does not derive offline keepers from execution rows when runtime health is authoritative', () => {
+    const runtimeFleetSafety = {
+      keeper_fleet_safety: {
+        running_keeper_fiber_count: 2,
+        paused_keeper_count: 1,
+      },
+    } as any
+
+    expect(resolveRuntimeCounts({
+      executionLoaded: true,
+      agentsCount: 0,
+      keepersCount: 2,
+      pausedKeepersCount: 1,
+      offlineKeepersCount: 5,
+      keeperRowsCount: 8,
+      namespaceTruthCounts: { agents: 0, keepers: 8, tasks: 0 },
+      namespaceTruthConfiguredKeepers: 8,
+      runtimeFleetSafety,
+    })).toEqual({
+      live: { agents: 0, keepers: 2, pausedKeepers: 1, offlineKeepers: 0, keeperRows: 3, tasks: 0, totalRuntimes: 2, available: true },
+      configured: { keepers: 8, totalRuntimes: 8, source: 'namespace-truth' },
+      source: 'runtime-health',
+    })
+  })
+
+  it('does not treat total keeper_fibers as the running runtime count', () => {
+    const runtimeFleetSafety = {
+      keeper_fibers: 9,
+      paused_keepers: 2,
+      paused_keepers_health: null,
+      keeper_fleet_safety: {},
+    } as any
+
+    expect(resolveRuntimeFleetSafetyCounts(runtimeFleetSafety)).toEqual({
+      runningKeepers: 0,
+      pausedKeepers: 2,
+      hasRunningKeepers: false,
+      hasPausedKeepers: true,
+    })
+
+    expect(resolveRuntimeCounts({
+      executionLoaded: true,
+      agentsCount: 0,
+      keepersCount: 9,
+      pausedKeepersCount: 0,
+      offlineKeepersCount: 6,
+      keeperRowsCount: 9,
+      shellCounts: { agents: 0, keepers: 9, tasks: 0, total_runtimes: 9 },
+      shellConfiguredKeepers: 13,
+      runtimeFleetSafety,
+    })).toEqual({
+      live: { agents: 0, keepers: 0, pausedKeepers: 2, offlineKeepers: 0, keeperRows: 2, tasks: 0, totalRuntimes: 0, available: true },
+      configured: { keepers: 13, totalRuntimes: 9, source: 'shell' },
+      source: 'runtime-health',
+    })
+  })
+
+  it('does not synthesize runtime-health offline counts from execution rows', () => {
+    expect(resolveRuntimeCounts({
+      executionLoaded: true,
+      agentsCount: 0,
+      keepersCount: 9,
+      pausedKeepersCount: 1,
+      offlineKeepersCount: 6,
+      keeperRowsCount: 9,
+      namespaceTruthCounts: { agents: 0, keepers: 13, tasks: 0, total_runtimes: 13 },
+      runtimeFleetSafety: {
+        keeper_fibers: 9,
+        paused_keepers: 1,
+        paused_keepers_health: { count: 1 },
+        keeper_fleet_safety: {
+          running_keeper_fiber_count: 2,
+          paused_keeper_count: 1,
+        },
+      } as any,
+    })).toEqual({
+      live: { agents: 0, keepers: 2, pausedKeepers: 1, offlineKeepers: 0, keeperRows: 3, tasks: 0, totalRuntimes: 2, available: true },
+      configured: { keepers: 13, totalRuntimes: 13, source: 'namespace-truth' },
+      source: 'runtime-health',
+    })
+  })
+
+  it('ignores stale runtime health and falls back to execution row counts', () => {
+    expect(resolveRuntimeCounts({
+      executionLoaded: true,
+      agentsCount: 0,
+      keepersCount: 4,
+      pausedKeepersCount: 1,
+      offlineKeepersCount: 2,
+      keeperRowsCount: 7,
+      runtimeHealthGeneratedAt: '2026-06-25T12:00:00Z',
+      nowMs: Date.parse('2026-06-25T12:02:01Z'),
+      runtimeFleetSafety: {
+        keeper_fibers: 9,
+        paused_keepers: 3,
+        paused_keepers_health: { count: 3 },
+        keeper_fleet_safety: {
+          running_keeper_fiber_count: 0,
+          paused_keeper_count: 3,
+        },
+      } as any,
+    })).toEqual({
+      live: { agents: 0, keepers: 4, pausedKeepers: 1, offlineKeepers: 2, keeperRows: 7, tasks: 0, totalRuntimes: 4, available: true },
+      configured: { keepers: 0, totalRuntimes: 0, source: 'none' },
+      source: 'execution',
+    })
+  })
+})
+
+describe('runtimeHealthIsFresh', () => {
+  it('rejects malformed or stale runtime health timestamps', () => {
+    const now = Date.parse('2026-06-25T12:02:00Z')
+    expect(runtimeHealthIsFresh(null, now)).toBe(true)
+    expect(runtimeHealthIsFresh('not-a-date', now)).toBe(false)
+    expect(runtimeHealthIsFresh('2026-06-25T12:00:00Z', now)).toBe(true)
+    expect(runtimeHealthIsFresh('2026-06-25T11:59:59Z', now)).toBe(false)
   })
 })
 

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -11,6 +11,7 @@ import {
   formatRuntimeRosterCount,
   keeperRowLooksRunning,
   keeperDetailRows,
+  resolveRuntimeFleetSafetyCounts,
   resolveRuntimeCounts,
   runtimeDetailRows,
   runtimeCountSourceLabel,
@@ -192,11 +193,45 @@ describe('resolveRuntimeCounts', () => {
       source: 'execution',
     })
   })
+
+  it('uses structured runtime health as the live keeper count source', () => {
+    const runtimeFleetSafety = {
+      keeper_fibers: 9,
+      paused_keepers: 2,
+      paused_keepers_health: { count: 3 },
+      keeper_fleet_safety: {
+        running_keeper_fiber_count: 0,
+        paused_keeper_count: 4,
+      },
+    } as any
+
+    expect(resolveRuntimeFleetSafetyCounts(runtimeFleetSafety)).toEqual({
+      runningKeepers: 0,
+      pausedKeepers: 3,
+      hasRunningKeepers: true,
+      hasPausedKeepers: true,
+    })
+
+    expect(resolveRuntimeCounts({
+      executionLoaded: false,
+      agentsCount: 0,
+      keepersCount: 9,
+      pausedKeepersCount: 0,
+      shellCounts: { agents: 0, keepers: 9, tasks: 0, total_runtimes: 13 },
+      shellConfiguredKeepers: 13,
+      runtimeFleetSafety,
+    })).toEqual({
+      live: { agents: 0, keepers: 0, pausedKeepers: 3, offlineKeepers: 0, keeperRows: 3, tasks: 0, totalRuntimes: 0, available: true },
+      configured: { keepers: 13, totalRuntimes: 13, source: 'shell' },
+      source: 'runtime-health',
+    })
+  })
 })
 
 describe('runtimeCountSourceLabel', () => {
   it('maps count source ids to user-facing labels', () => {
     expect(runtimeCountSourceLabel('execution')).toBe('execution 상세')
+    expect(runtimeCountSourceLabel('runtime-health')).toBe('runtime health')
     expect(runtimeCountSourceLabel('project-snapshot')).toBe('project snapshot')
     expect(runtimeCountSourceLabel('shell')).toBe('shell')
     expect(runtimeCountSourceLabel('partial')).toBe('부분 hydrate')

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -55,6 +55,8 @@ interface ResolveRuntimeCountsOptions {
   shellCounts?: DashboardShellResponse['counts'] | null
   shellConfiguredKeepers?: number
   runtimeFleetSafety?: DashboardFleetSafetyHealth | null
+  runtimeHealthGeneratedAt?: string | null
+  nowMs?: number
 }
 
 function finiteCount(value: unknown): number | null {
@@ -117,6 +119,8 @@ export interface RuntimeFleetSafetyCounts {
   hasPausedKeepers: boolean
 }
 
+export const RUNTIME_HEALTH_FRESH_MS = 120_000
+
 function firstFiniteCount(...values: unknown[]): number | null {
   for (const value of values) {
     const count = finiteCount(value)
@@ -130,10 +134,7 @@ export function resolveRuntimeFleetSafetyCounts(
 ): RuntimeFleetSafetyCounts | null {
   if (!fleetSafety) return null
   const fleet = fleetSafety.keeper_fleet_safety
-  const runningKeepers = firstFiniteCount(
-    fleet?.running_keeper_fiber_count,
-    fleetSafety.keeper_fibers,
-  )
+  const runningKeepers = firstFiniteCount(fleet?.running_keeper_fiber_count)
   const pausedKeepers = firstFiniteCount(
     fleetSafety.paused_keepers_health?.count,
     fleet?.paused_keeper_count,
@@ -146,6 +147,16 @@ export function resolveRuntimeFleetSafetyCounts(
     hasRunningKeepers: runningKeepers !== null,
     hasPausedKeepers: pausedKeepers !== null,
   }
+}
+
+export function runtimeHealthIsFresh(
+  generatedAt: string | null | undefined,
+  nowMs = Date.now(),
+): boolean {
+  if (!generatedAt) return true
+  const timestampMs = Date.parse(generatedAt)
+  if (!Number.isFinite(timestampMs)) return false
+  return Math.max(0, nowMs - timestampMs) <= RUNTIME_HEALTH_FRESH_MS
 }
 
 function normalizeCounts(
@@ -237,30 +248,39 @@ export function resolveRuntimeCounts({
   shellCounts,
   shellConfiguredKeepers,
   runtimeFleetSafety,
+  runtimeHealthGeneratedAt,
+  nowMs,
 }: ResolveRuntimeCountsOptions): RuntimeCounts {
-  const runtimeHealthCounts = resolveRuntimeFleetSafetyCounts(runtimeFleetSafety)
+  const runtimeHealthCounts = runtimeHealthIsFresh(runtimeHealthGeneratedAt, nowMs)
+    ? resolveRuntimeFleetSafetyCounts(runtimeFleetSafety)
+    : null
   const liveAgents = normalizeCount(agentsCount)
-  const liveKeepers = runtimeHealthCounts?.hasRunningKeepers === true
+  const runtimeHealthAvailable = runtimeHealthCounts !== null
+  const liveKeepers = runtimeHealthAvailable
     ? runtimeHealthCounts.runningKeepers
     : normalizeCount(keepersCount)
-  const livePausedKeepers = runtimeHealthCounts?.hasPausedKeepers === true
+  const livePausedKeepers = runtimeHealthAvailable
     ? runtimeHealthCounts.pausedKeepers
     : normalizeCount(pausedKeepersCount)
-  const liveOfflineKeepers = normalizeCount(offlineKeepersCount)
-  const liveKeeperRows = Math.max(
-    normalizeCount(keeperRowsCount),
-    liveKeepers + livePausedKeepers + liveOfflineKeepers,
-  )
+  const liveOfflineKeepers = runtimeHealthAvailable ? 0 : normalizeCount(offlineKeepersCount)
+  const liveKeeperRows = runtimeHealthAvailable
+    ? liveKeepers + livePausedKeepers
+    : Math.max(
+        normalizeCount(keeperRowsCount),
+        liveKeepers + livePausedKeepers + liveOfflineKeepers,
+      )
   const liveTasks = normalizeCount(tasksCount)
   const live: LiveRuntimeView = {
     agents: liveAgents,
     keepers: liveKeepers,
     pausedKeepers: livePausedKeepers,
-    offlineKeepers: Math.max(0, liveKeeperRows - liveKeepers - livePausedKeepers),
+    offlineKeepers: runtimeHealthAvailable
+      ? 0
+      : Math.max(0, liveKeeperRows - liveKeepers - livePausedKeepers),
     keeperRows: liveKeeperRows,
     tasks: liveTasks,
     totalRuntimes: liveAgents + liveKeepers,
-    available: executionLoaded || runtimeHealthCounts !== null,
+    available: executionLoaded || runtimeHealthAvailable,
   }
 
   const namespace = normalizeCounts(namespaceTruthCounts)
@@ -283,7 +303,7 @@ export function resolveRuntimeCounts({
     executionLoaded,
     live,
     configured,
-    runtimeHealthAvailable: runtimeHealthCounts !== null,
+    runtimeHealthAvailable,
   })
   return { live, configured, source }
 }

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -1,7 +1,8 @@
-import type { DashboardNamespaceTruthResponse, DashboardShellResponse } from './types'
+import type { DashboardFleetSafetyHealth, DashboardNamespaceTruthResponse, DashboardShellResponse } from './types'
 
 export type RuntimeCountSource =
   | 'execution'
+  | 'runtime-health'
   | 'project-snapshot'
   | 'shell'
   | 'partial'
@@ -53,12 +54,16 @@ interface ResolveRuntimeCountsOptions {
   namespaceTruthConfiguredKeepers?: number
   shellCounts?: DashboardShellResponse['counts'] | null
   shellConfiguredKeepers?: number
+  runtimeFleetSafety?: DashboardFleetSafetyHealth | null
+}
+
+function finiteCount(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  return Math.max(0, Math.floor(value))
 }
 
 function normalizeCount(value: unknown): number {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
-    : 0
+  return finiteCount(value) ?? 0
 }
 
 function normalizeRuntimeToken(value: unknown): string {
@@ -103,6 +108,44 @@ export function keeperRowLooksRunning(row: KeeperRuntimeCountRow | null | undefi
     || RUNNING_KEEPER_RUNTIME_TOKENS.has(phase)
     || RUNNING_KEEPER_RUNTIME_TOKENS.has(stage)
   )
+}
+
+export interface RuntimeFleetSafetyCounts {
+  runningKeepers: number
+  pausedKeepers: number
+  hasRunningKeepers: boolean
+  hasPausedKeepers: boolean
+}
+
+function firstFiniteCount(...values: unknown[]): number | null {
+  for (const value of values) {
+    const count = finiteCount(value)
+    if (count !== null) return count
+  }
+  return null
+}
+
+export function resolveRuntimeFleetSafetyCounts(
+  fleetSafety: DashboardFleetSafetyHealth | null | undefined,
+): RuntimeFleetSafetyCounts | null {
+  if (!fleetSafety) return null
+  const fleet = fleetSafety.keeper_fleet_safety
+  const runningKeepers = firstFiniteCount(
+    fleet?.running_keeper_fiber_count,
+    fleetSafety.keeper_fibers,
+  )
+  const pausedKeepers = firstFiniteCount(
+    fleetSafety.paused_keepers_health?.count,
+    fleet?.paused_keeper_count,
+    fleetSafety.paused_keepers,
+  )
+  if (runningKeepers === null && pausedKeepers === null) return null
+  return {
+    runningKeepers: runningKeepers ?? 0,
+    pausedKeepers: pausedKeepers ?? 0,
+    hasRunningKeepers: runningKeepers !== null,
+    hasPausedKeepers: pausedKeepers !== null,
+  }
 }
 
 function normalizeCounts(
@@ -163,12 +206,15 @@ function deriveStatusSource({
   executionLoaded,
   live,
   configured,
+  runtimeHealthAvailable,
 }: {
   executionLoaded: boolean
   live: LiveRuntimeView
   configured: ConfiguredRuntimeView
+  runtimeHealthAvailable: boolean
 }): RuntimeCountSource {
   const liveDetailRows = live.agents + live.keeperRows
+  if (runtimeHealthAvailable) return 'runtime-health'
   if (executionLoaded && (liveDetailRows > 0 || configured.totalRuntimes === 0)) {
     return 'execution'
   }
@@ -190,10 +236,16 @@ export function resolveRuntimeCounts({
   namespaceTruthConfiguredKeepers,
   shellCounts,
   shellConfiguredKeepers,
+  runtimeFleetSafety,
 }: ResolveRuntimeCountsOptions): RuntimeCounts {
+  const runtimeHealthCounts = resolveRuntimeFleetSafetyCounts(runtimeFleetSafety)
   const liveAgents = normalizeCount(agentsCount)
-  const liveKeepers = normalizeCount(keepersCount)
-  const livePausedKeepers = normalizeCount(pausedKeepersCount)
+  const liveKeepers = runtimeHealthCounts?.hasRunningKeepers === true
+    ? runtimeHealthCounts.runningKeepers
+    : normalizeCount(keepersCount)
+  const livePausedKeepers = runtimeHealthCounts?.hasPausedKeepers === true
+    ? runtimeHealthCounts.pausedKeepers
+    : normalizeCount(pausedKeepersCount)
   const liveOfflineKeepers = normalizeCount(offlineKeepersCount)
   const liveKeeperRows = Math.max(
     normalizeCount(keeperRowsCount),
@@ -208,7 +260,7 @@ export function resolveRuntimeCounts({
     keeperRows: liveKeeperRows,
     tasks: liveTasks,
     totalRuntimes: liveAgents + liveKeepers,
-    available: executionLoaded,
+    available: executionLoaded || runtimeHealthCounts !== null,
   }
 
   const namespace = normalizeCounts(namespaceTruthCounts)
@@ -227,7 +279,12 @@ export function resolveRuntimeCounts({
     shellConfiguredKeepers: shellConfiguredKeeperCount,
   })
 
-  const source = deriveStatusSource({ executionLoaded, live, configured })
+  const source = deriveStatusSource({
+    executionLoaded,
+    live,
+    configured,
+    runtimeHealthAvailable: runtimeHealthCounts !== null,
+  })
   return { live, configured, source }
 }
 
@@ -235,6 +292,8 @@ export function runtimeCountSourceLabel(source: RuntimeCountSource): string {
   switch (source) {
     case 'execution':
       return 'execution 상세'
+    case 'runtime-health':
+      return 'runtime health'
     case 'project-snapshot':
       return 'project snapshot'
     case 'shell':

--- a/dashboard/src/store-dashboard-bootstrap.test.ts
+++ b/dashboard/src/store-dashboard-bootstrap.test.ts
@@ -326,6 +326,8 @@ describe('refreshKeeperRuntimeStatus', () => {
     expect(apiMocks.fetchDashboardBootstrap).not.toHaveBeenCalled()
     expect(apiMocks.fetchDashboardExecution).toHaveBeenCalledWith({ force: true })
     expect(apiMocks.fetchDashboardShell).toHaveBeenCalledWith({ light: true })
+    expect(apiMocks.fetchDashboardShell.mock.invocationCallOrder[0]!)
+      .toBeLessThan(apiMocks.fetchDashboardExecution.mock.invocationCallOrder[0]!)
     expect(store.shellCounts.value).toEqual({
       agents: 0,
       tasks: 7,

--- a/dashboard/src/store-dashboard-bootstrap.test.ts
+++ b/dashboard/src/store-dashboard-bootstrap.test.ts
@@ -277,3 +277,63 @@ describe('refreshDashboard bootstrap', () => {
     expect(store.executionLoaded.value).toBe(true)
   })
 })
+
+describe('refreshKeeperRuntimeStatus', () => {
+  it('refreshes execution and light shell runtime status without full bootstrap', async () => {
+    apiMocks.fetchDashboardShell.mockResolvedValue({
+      generated_at: '2026-06-25T12:00:00Z',
+      status: { project: 'me' },
+      counts: { agents: 0, tasks: 7, keepers: 1, total_runtimes: 1 },
+      configured_keepers: 13,
+      auth: null,
+      config_resolution: null,
+      runtime_resolution: {
+        status: 'ready',
+        warnings: [],
+        base_path: { path: '/tmp/me', exists: true, source: 'input' },
+        workspace_path: { path: '/tmp/me', exists: true, source: 'workspace' },
+        resolved_base_path: { path: '/tmp/me', exists: true, source: 'resolved_base' },
+        data_root: { path: '/tmp/me/.masc', exists: true, source: 'runtime_data' },
+        prompt_markdown_dir: { path: '/tmp/me/.masc/config/prompts', exists: true, source: 'prompt_registry' },
+        build: {
+          release_version: '0.19.48',
+          commit: 'abcdef1',
+          started_at: '2026-06-25T11:59:00Z',
+          uptime_seconds: 60,
+        },
+        keeper_fibers: 1,
+        paused_keepers: 3,
+        paused_keepers_health: { count: 3, names: ['a', 'b', 'c'] },
+        keeper_fleet_safety: { running_keeper_fiber_count: 1, paused_keeper_count: 3 },
+      },
+    })
+    apiMocks.fetchDashboardExecution.mockResolvedValue({
+      generated_at: '2026-06-25T12:00:00Z',
+      status: { project: 'me' },
+      agents: [],
+      tasks: [],
+      messages: [],
+      keepers: [{ name: 'verifier', status: 'running' }],
+      execution_queue: [],
+      worker_support_briefs: [],
+      continuity_briefs: [],
+    })
+
+    const store = await import('./store')
+
+    await store.refreshKeeperRuntimeStatus({ force: true })
+
+    expect(apiMocks.fetchDashboardBootstrap).not.toHaveBeenCalled()
+    expect(apiMocks.fetchDashboardExecution).toHaveBeenCalledWith({ force: true })
+    expect(apiMocks.fetchDashboardShell).toHaveBeenCalledWith({ light: true })
+    expect(store.shellCounts.value).toEqual({
+      agents: 0,
+      tasks: 7,
+      keepers: 1,
+      total_runtimes: 1,
+      configured_keepers: 13,
+    })
+    expect(store.shellRuntimeResolution.value?.fleet_safety?.paused_keepers).toBe(3)
+    expect(store.keepers.value).toHaveLength(1)
+  })
+})

--- a/dashboard/src/store-normalizers.ts
+++ b/dashboard/src/store-normalizers.ts
@@ -548,6 +548,7 @@ function normalizeKeeperRuntimeResolved(raw: unknown): KeeperRuntimeResolved | n
 
 export function normalizeDashboardRuntimeResolution(
   raw: unknown,
+  generatedAt?: string,
 ): DashboardRuntimeResolution | null {
   if (!isRecord(raw)) return null
   const status = asString(raw.status)
@@ -561,6 +562,7 @@ export function normalizeDashboardRuntimeResolution(
     return null
   }
   return {
+    generated_at: generatedAt ?? toIsoTimestamp(raw.generated_at) ?? null,
     status,
     warnings: asStringArray(raw.warnings),
     base_path: basePath,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -979,7 +979,7 @@ export function hydrateShellSnapshot(
     shellAuthSummary.value = normalizedAuth
   }
   const normalizedConfigResolution = normalizeDashboardConfigResolution(data.config_resolution)
-  const normalizedRuntimeResolution = normalizeDashboardRuntimeResolution(data.runtime_resolution)
+  const normalizedRuntimeResolution = normalizeDashboardRuntimeResolution(data.runtime_resolution, data.generated_at)
   if (!wantsLight || normalizedConfigResolution) {
     shellConfigResolution.value = normalizedConfigResolution
   }
@@ -1088,11 +1088,9 @@ export async function refreshExecution(opts?: RefreshOptions): Promise<void> {
 }
 
 export async function refreshKeeperRuntimeStatus(opts?: RefreshOptions): Promise<void> {
-  const force = opts?.force ?? true
-  await Promise.all([
-    refreshExecution({ force }),
-    refreshShell({ light: true, force }),
-  ])
+  const force = opts?.force ?? false
+  await refreshShell({ light: true, force })
+  await refreshExecution({ force })
 }
 
 /** Reconcile board posts by id+updated_at so unchanged items keep

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -1087,6 +1087,14 @@ export async function refreshExecution(opts?: RefreshOptions): Promise<void> {
   }
 }
 
+export async function refreshKeeperRuntimeStatus(opts?: RefreshOptions): Promise<void> {
+  const force = opts?.force ?? true
+  await Promise.all([
+    refreshExecution({ force }),
+    refreshShell({ light: true, force }),
+  ])
+}
+
 /** Reconcile board posts by id+updated_at so unchanged items keep
  *  the same object reference.  Preact skips re-rendering subtrees
  *  whose props haven't changed, preserving scroll position. */

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -113,6 +113,7 @@ export interface KeeperRuntimeResolved {
 }
 
 export interface DashboardRuntimeResolution {
+  generated_at?: string | null
   status: 'ready' | 'warn' | string
   warnings: string[]
   base_path: DashboardConfigResolutionItem


### PR DESCRIPTION
## Summary

Fixes the dashboard status indicators so the top bar, health strip, roster aggregates, and post-action refresh path use the same runtime-health source for keeper running/paused/offline counts.

## Root Cause

The dashboard had multiple status-count paths:

- the top bar counted keeper rows through local phase status
- health chips used shell/runtime data plus row fallbacks
- roster aggregates had their own execution-row counts
- keeper actions refreshed execution rows but did not force-refresh the light shell runtime-health slice

Those paths could disagree after pause/resume/stop or when execution rows lagged the runtime health snapshot.

## What Changed

- Added `runtime-health` as a first-class `RuntimeCountSource`.
- Centralized runtime-health count precedence in `resolveRuntimeCounts`, using structured `keeper_fleet_safety` and `paused_keepers_health`.
- Updated the top bar live chip to use the shared resolver instead of a separate row-only phase count.
- Threaded `shellRuntimeResolution.value?.fleet_safety` into agent/keeper aggregate surfaces.
- Added `refreshKeeperRuntimeStatus({ force: true })` to refresh execution rows and light shell runtime health after keeper actions without full dashboard bootstrap.
- Removed duplicate lifecycle refresh calls where `runKeeperAction` now owns the post-action refresh.
- Aligned selected keeper display with the canonical phase/bucket so paused state wins over stale offline/stopped status.

## Validation

- `vitest run --config vitest.config.ts src/app.test.ts src/runtime-counts.test.ts src/components/dashboard-shell.test.ts src/components/keeper-workspace/keeper-workspace-shared.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts src/components/keeper-action-panel.test.ts src/components/keeper-detail-helpers.test.ts src/store-dashboard-bootstrap.test.ts --no-file-parallelism --maxWorkers=1`
  - 8 files passed, 150 tests passed
- `tsc --noEmit --pretty`
  - passed
- `eslint` on touched dashboard files
  - exit 0; repo config ignored 6 test/store files with warnings
- `git diff --check`
  - passed
- Browser render against live backend via Vite on `127.0.0.1:5177`
  - screenshot: `/private/tmp/masc-dashboard-status-5177.png`
  - DOM: top chip `0 실행 중`, title `runtime count: runtime health`
  - DOM: health strip `키퍼 런타임 가동 0 / 일시정지 5 / 오프라인 5 / 설정 13`

## Notes

No OCaml backend files were changed. Focused OCaml wrapper build remained blocked by an existing live bare Dune process:

```text
scripts/dune-local.sh build test/test_dashboard_http_core.exe
[dune-local] live Dune process outside scripts/dune-local.sh detected:
[dune-local]   84602 1 dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc ./bin/main_eio.exe --
```
