### PR TITLE
[codex] Improve keeper tool/chat interleaving

### DIFF
--- a/dashboard/src/components/chat/artifact-panel.test.ts
+++ b/dashboard/src/components/chat/artifact-panel.test.ts
@@ -53,7 +53,7 @@ describe('extractArtifactGroups', () => {
             t: 'trace',
             trace: [
               { kind: 'think', text: 'plan' },
-              { kind: 'tool', name: 'keeper_context_status', status: 'ok', dur: '0.2s', args: { path: 'a' }, result: '{"ok":true}' },
+              { kind: 'tool', name: 'keeper_context_status', status: 'ok', dur: '0.2s', args: '{"path":"a"}', result: '{"ok":true}' },
             ],
           },
           { t: 'link', url: 'https://example.com', title: 'Example', meta: 'example.com' },

--- a/dashboard/src/components/chat/primitives-interleave.test.ts
+++ b/dashboard/src/components/chat/primitives-interleave.test.ts
@@ -21,6 +21,7 @@ describe('interleaveTraceAndTools', () => {
   const labels = (items: ReturnType<typeof interleaveTraceAndTools>) =>
     items.map((i) => {
       if (i.kind === 'tool') return `tool:${i.entry?.id ?? i.step?.toolCallId ?? i.step?.name}`
+      if (i.kind === 'tool-entry') return `tool:${i.entry.id}`
       if (i.kind === 'chat') return `chat:${i.entry.id}`
       return `think:${i.step.text}`
     })
@@ -66,6 +67,14 @@ describe('interleaveTraceAndTools', () => {
       [],
     )
     expect(labels(out)).toEqual(['think:A', 'tool:X'])
+  })
+
+  it('prefers authoritative tool rows over unjoinable trace-only tool steps', () => {
+    const out = interleaveTraceAndTools(
+      [think('A'), { kind: 'tool', name: 'legacy-tool' }],
+      [tool('X')],
+    )
+    expect(labels(out)).toEqual(['think:A', 'tool:tool-X'])
   })
 
   it('handles empty inputs without error', () => {

--- a/dashboard/src/components/chat/primitives-interleave.test.ts
+++ b/dashboard/src/components/chat/primitives-interleave.test.ts
@@ -2,9 +2,9 @@
 
 // Unit tests for the render-time think<->tool interleaving in ToolTraceCard.
 // Pure-function level so the ordering contract is asserted without the jsdom
-// render harness: the merge must preserve occurrence order (think -> tool ->
-// think -> tool) and fall back to the legacy two-section order when a step has
-// no timestamp.
+// render harness: live streams carry tool calls in traceSteps, so the merge
+// must preserve that structural order and use sibling tool entries only for
+// details/result hydration.
 import { describe, expect, it } from 'vitest'
 import type { ChatTraceStep, KeeperConversationEntry } from '../../types'
 import { interleaveTraceAndTools } from './primitives'
@@ -12,57 +12,58 @@ import { interleaveTraceAndTools } from './primitives'
 describe('interleaveTraceAndTools', () => {
   const think = (text: string, ts?: string): ChatTraceStep =>
     ts === undefined ? { kind: 'think', text } : { kind: 'think', text, ts }
-  // Tool entries only need `id` and `timestamp` for ordering; interleave reads
-  // nothing else off them.
-  const tool = (id: string, ts: string) => ({
-    entry: { id, role: 'tool', timestamp: ts } as unknown as KeeperConversationEntry,
+  const traceTool = (name: string, toolCallId: string, ts?: string): ChatTraceStep =>
+    ts === undefined ? { kind: 'tool', name, toolCallId } : { kind: 'tool', name, toolCallId, ts }
+  const tool = (toolCallId: string) => ({
+    entry: { id: `tool-${toolCallId}`, role: 'tool' } as unknown as KeeperConversationEntry,
     output: null,
   })
   const labels = (items: ReturnType<typeof interleaveTraceAndTools>) =>
     items.map((i) => {
-      if (i.kind === 'tool') return `tool:${i.entry.id}`
+      if (i.kind === 'tool') return `tool:${i.entry?.id ?? i.step?.toolCallId ?? i.step?.name}`
       if (i.kind === 'chat') return `chat:${i.entry.id}`
-      // think/reason carry `text`; the tool variant of ChatTraceStep does not.
-      return `think:${'text' in i.step ? i.step.text : i.step.name}`
+      return `think:${i.step.text}`
     })
 
-  it('interleaves think and tool by occurrence time (think -> tool -> think -> tool)', () => {
+  it('preserves structural trace order for think -> tool -> think -> tool', () => {
     const out = interleaveTraceAndTools(
       [
         think('A', '2026-06-21T00:00:01.000Z'),
+        traceTool('status', 'X', '2026-06-21T00:00:04.000Z'),
         think('B', '2026-06-21T00:00:03.000Z'),
+        traceTool('board', 'Y', '2026-06-21T00:00:02.000Z'),
       ],
       [
-        tool('X', '2026-06-21T00:00:02.000Z'),
-        tool('Y', '2026-06-21T00:00:04.000Z'),
+        tool('X'),
+        tool('Y'),
       ],
     )
-    expect(labels(out)).toEqual(['think:A', 'tool:X', 'think:B', 'tool:Y'])
+    expect(labels(out)).toEqual(['think:A', 'tool:tool-X', 'think:B', 'tool:tool-Y'])
   })
 
-  it('keeps the legacy two-section order when think steps carry no timestamp', () => {
-    // Absent ts (backend-normalized steps) sorts as '' and precedes any tool,
-    // so thinks stay grouped above tools — matching the pre-change render.
+  it('keeps the legacy two-section order when trace carries no tool steps', () => {
     const out = interleaveTraceAndTools(
       [think('A'), think('B')],
-      [tool('X', '2026-06-21T00:00:02.000Z')],
+      [tool('X')],
     )
-    expect(labels(out)).toEqual(['think:A', 'think:B', 'tool:X'])
+    expect(labels(out)).toEqual(['think:A', 'think:B', 'tool:tool-X'])
   })
 
-  it('places an earlier tool before a later think', () => {
+  it('uses trace order even when timestamps would imply a different order', () => {
     const out = interleaveTraceAndTools(
-      [think('A', '2026-06-21T00:00:05.000Z')],
-      [tool('X', '2026-06-21T00:00:01.000Z')],
+      [
+        think('A', '2026-06-21T00:00:05.000Z'),
+        traceTool('status', 'X', '2026-06-21T00:00:01.000Z'),
+      ],
+      [tool('X')],
     )
-    expect(labels(out)).toEqual(['tool:X', 'think:A'])
+    expect(labels(out)).toEqual(['think:A', 'tool:tool-X'])
   })
 
-  it('preserves stable trace-then-tool order on equal timestamps', () => {
-    // Stable sort keeps the input order (trace before tool) when timestamps tie.
+  it('can render a trace-only tool step before the sibling entry exists', () => {
     const out = interleaveTraceAndTools(
-      [think('A', '2026-06-21T00:00:01.000Z')],
-      [tool('X', '2026-06-21T00:00:01.000Z')],
+      [think('A'), traceTool('status', 'X')],
+      [],
     )
     expect(labels(out)).toEqual(['think:A', 'tool:X'])
   })
@@ -73,7 +74,7 @@ describe('interleaveTraceAndTools', () => {
       labels(interleaveTraceAndTools([think('A', '2026-06-21T00:00:01.000Z')], [])),
     ).toEqual(['think:A'])
     expect(
-      labels(interleaveTraceAndTools([], [tool('X', '2026-06-21T00:00:01.000Z')])),
-    ).toEqual(['tool:X'])
+      labels(interleaveTraceAndTools([], [tool('X')])),
+    ).toEqual(['tool:tool-X'])
   })
 })

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1276,7 +1276,7 @@ describe('Keeper v2 chat blocks', () => {
         t: 'trace',
         trace: [
           { kind: 'think', text: 'planning' },
-          { kind: 'tool', name: 'keeper_context_status', status: 'ok', dur: '0.2s', args: { path: 'a' }, result: '{"ok":true}' },
+          { kind: 'tool', name: 'keeper_context_status', status: 'ok', dur: '0.2s', args: '{"path":"a"}', result: '{"ok":true}' },
         ],
       },
     ])

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -25,7 +25,7 @@ import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatChartBlock, C
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, KeeperConversationSource, SurfaceRef } from '../../types'
 import type { ToolCallEntry, ToolCallOutputBlob } from '../../api/dashboard'
 import { fetchBoardPost } from '../../api/board'
-import { lookupToolCallOutput, toolCallOutputsById } from '../../tool-call-output-store'
+import { lookupToolCallOutput, toolCallIdFromToolEntryId, toolCallOutputsById, toolEntryIdFromCallId } from '../../tool-call-output-store'
 import { Sigil } from '../common/sigil-chip'
 import { SuggestionChip } from '../common/suggestion-chip'
 import { StatusDot } from '../common/status-dot'
@@ -59,6 +59,18 @@ export interface ChatComposerCommand {
   disabled?: boolean
   disabledReason?: string
   run: () => void | Promise<void>
+}
+
+type TraceToolStatus = NonNullable<ChatTraceToolStep['status']>
+
+const TRACE_TOOL_STATUS_UI: Record<TraceToolStatus, { className: 'ok' | 'bad' | 'pending'; title: string }> = {
+  pending: { className: 'pending', title: '출력 대기 중' },
+  ok: { className: 'ok', title: '성공' },
+  err: { className: 'bad', title: '실패' },
+}
+
+function traceToolStatusUi(status: ChatTraceToolStep['status']): { className: 'ok' | 'bad' | 'pending'; title: string } {
+  return TRACE_TOOL_STATUS_UI[status ?? 'pending']
 }
 
 /** Status dot wrapper — maps keeper-v2 status strings to shared StatusDot tones. */
@@ -1187,18 +1199,7 @@ function ChatTraceStep({ step }: { step: ChatTraceStep }) {
     `
   }
 
-  const statusClass =
-    step.status === 'ok'
-      ? 'ok'
-      : step.status === 'err'
-        ? 'bad'
-        : 'pending'
-  const statusTitle =
-    step.status === 'ok'
-      ? '성공'
-      : step.status === 'err'
-        ? '실패'
-        : '출력 대기 중'
+  const statusUi = traceToolStatusUi(step.status)
 
   return html`
     <div class="chat-block-tstep tool ${open ? 'exp' : ''}" data-chat-trace-step="tool">
@@ -1208,9 +1209,9 @@ function ChatTraceStep({ step }: { step: ChatTraceStep }) {
           <span class="chat-block-tstep-kind">Tool</span>
           <span class="chat-block-tstep-name">${step.name}</span>
           <span
-            class="chat-block-tstep-status ${statusClass}"
-            title=${statusTitle}
-            aria-label=${statusTitle}
+            class="chat-block-tstep-status ${statusUi.className}"
+            title=${statusUi.title}
+            aria-label=${statusUi.title}
           ></span>
           <span class="chat-block-tstep-dur">${step.dur}</span>
           <span class="chat-block-tstep-chev">▶</span>
@@ -2366,7 +2367,7 @@ function isToolOutputCoveredByHydration(
 // still-null output is "missing" (unknown outcome).
 function toolEntryFromTraceStep(step: ChatTraceToolStep): KeeperConversationEntry {
   return {
-    id: step.toolCallId ? `${TOOL_ENTRY_PREFIX}${step.toolCallId}` : `trace-tool-${step.name}-${step.ts ?? 'unknown'}`,
+    id: step.toolCallId ? toolEntryIdFromCallId(step.toolCallId) : `trace-tool-${step.name}-${step.ts ?? 'unknown'}`,
     role: 'tool',
     source: 'tool_result',
     label: step.name,
@@ -2459,15 +2460,25 @@ function ToolTraceStep({
 
 type TraceOrderItem =
   | { kind: 'trace'; step: Exclude<ChatTraceStep, ChatTraceToolStep> }
-  | { kind: 'tool'; step?: ChatTraceToolStep; entry?: KeeperConversationEntry; output: ToolCallEntry | null }
+  | { kind: 'tool'; step: ChatTraceToolStep; entry: KeeperConversationEntry | null; output: ToolCallEntry | null }
+  | { kind: 'tool-entry'; entry: KeeperConversationEntry; output: ToolCallEntry | null }
   | { kind: 'chat'; entry: KeeperConversationEntry }
 
-const TOOL_ENTRY_PREFIX = 'tool-'
+function isToolOrderItem(item: TraceOrderItem): item is Extract<TraceOrderItem, { kind: 'tool' | 'tool-entry' }> {
+  return item.kind === 'tool' || item.kind === 'tool-entry'
+}
 
-function toolCallIdFromEntry(entry: KeeperConversationEntry): string | null {
-  return entry.id.startsWith(TOOL_ENTRY_PREFIX)
-    ? entry.id.slice(TOOL_ENTRY_PREFIX.length)
-    : null
+function traceStepDurationMs(dur: string | undefined): number {
+  const trimmed = dur?.trim()
+  if (!trimmed) return 0
+  const match = /^(\d+(?:\.\d+)?)\s*(ms|s|m)?$/i.exec(trimmed)
+  if (!match) return 0
+  const value = Number(match[1])
+  if (!Number.isFinite(value)) return 0
+  const unit = match[2]?.toLowerCase() ?? 'ms'
+  if (unit === 'm') return value * 60_000
+  if (unit === 's') return value * 1_000
+  return value
 }
 
 // Groups a turn's explicit progress/tool entries into one "작업 과정" trace
@@ -2483,7 +2494,7 @@ export function interleaveTraceAndTools(
 ): TraceOrderItem[] {
   const toolsByCallId = new Map<string, { entry: KeeperConversationEntry; output: ToolCallEntry | null }>()
   for (const item of toolSteps) {
-    const callId = toolCallIdFromEntry(item.entry)
+    const callId = toolCallIdFromToolEntryId(item.entry.id)
     if (callId) toolsByCallId.set(callId, item)
   }
   const usedToolIds = new Set<string>()
@@ -2494,19 +2505,20 @@ export function interleaveTraceAndTools(
       continue
     }
     const callId = step.toolCallId?.trim()
+    if (!callId && toolSteps.length > 0) continue
     const matched = callId ? toolsByCallId.get(callId) : undefined
     if (callId) usedToolIds.add(callId)
     ordered.push({
       kind: 'tool',
       step,
-      entry: matched?.entry,
+      entry: matched?.entry ?? null,
       output: matched?.output ?? null,
     })
   }
   for (const item of toolSteps) {
-    const callId = toolCallIdFromEntry(item.entry)
+    const callId = toolCallIdFromToolEntryId(item.entry.id)
     if (callId && usedToolIds.has(callId)) continue
-    ordered.push({ kind: 'tool', entry: item.entry, output: item.output })
+    ordered.push({ kind: 'tool-entry', entry: item.entry, output: item.output })
   }
   return ordered
 }
@@ -2556,19 +2568,22 @@ function ToolTraceCard({
   const ordered = assistant
     ? [...interleaveTraceAndTools(traceSteps, steps), { kind: 'chat' as const, entry: assistant }]
     : interleaveTraceAndTools(traceSteps, steps)
-  const orderedToolSteps = ordered.filter((item): item is Extract<TraceOrderItem, { kind: 'tool' }> => item.kind === 'tool')
+  const orderedToolSteps = ordered.filter(isToolOrderItem)
   const thinkN = traceSteps.filter((step) => step.kind === 'think' || step.kind === 'reason').length
   const failN = orderedToolSteps.filter(
     (s) =>
       (s.output !== null && (s.output.success === false || s.output.semantic_success === false))
-      || s.step?.status === 'err',
+      || (s.kind === 'tool' && s.step.status === 'err'),
   ).length
   // Surface unjoined outputs as "missing" only once the turn and output
   // hydration have both settled.
   const missingN = orderedToolSteps.filter(
-    (s) => s.output === null && s.entry !== undefined && canMarkMissingForEntry(s.entry),
+    (s) => s.output === null && s.entry !== null && canMarkMissingForEntry(s.entry),
   ).length
-  const totalMs = orderedToolSteps.reduce((sum, s) => sum + (s.output?.duration_ms ?? 0), 0)
+  const totalMs = orderedToolSteps.reduce(
+    (sum, s) => sum + (s.output?.duration_ms ?? (s.kind === 'tool' ? traceStepDurationMs(s.step.dur) : 0)),
+    0,
+  )
   const durLabel = totalMs > 0 ? formatMsCompact(totalMs) : null
   const chatN = assistant ? 1 : 0
   const stepN = ordered.length
@@ -2603,16 +2618,22 @@ function ToolTraceCard({
                   ? html`<${ChatTraceStep} key=${`trace-${index}`} step=${item.step} />`
                   : item.kind === 'tool'
                     ? (() => {
-                        const entry = item.entry ?? (item.step ? toolEntryFromTraceStep(item.step) : null)
-                        if (!entry) return null
+                        const entry = item.entry ?? toolEntryFromTraceStep(item.step)
                         return html`<${ToolTraceStep}
-                          key=${`tool-${item.entry?.id ?? item.step?.toolCallId ?? item.step?.name ?? index}`}
+                          key=${`tool-trace-${item.entry?.id ?? item.step.toolCallId ?? item.step.name}-${index}`}
                           entry=${entry}
                           output=${item.output}
-                          canMarkMissing=${item.entry !== undefined && canMarkMissingForEntry(item.entry)}
+                          canMarkMissing=${item.entry !== null && canMarkMissingForEntry(item.entry)}
                           traceStep=${item.step}
                         />`
                       })()
+                    : item.kind === 'tool-entry'
+                      ? html`<${ToolTraceStep}
+                          key=${`tool-entry-${item.entry.id}`}
+                          entry=${item.entry}
+                          output=${item.output}
+                          canMarkMissing=${canMarkMissingForEntry(item.entry)}
+                        />`
                     : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} />`)}
             </div>
           `

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -508,7 +508,15 @@ function traceStepMarkdown(raw: string): { __html: string } {
 }
 
 function highlightJson(obj: unknown): string {
-  const s = JSON.stringify(obj, null, 2)
+  let value = obj
+  if (typeof obj === 'string') {
+    try {
+      value = JSON.parse(obj)
+    } catch {
+      value = obj
+    }
+  }
+  const s = typeof value === 'string' ? value : JSON.stringify(value, null, 2)
   return sanitizeHtml(
     s
       .replace(/("[^"]+"):/g, '<span class="chat-json-key">$1</span>:')

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -21,7 +21,7 @@ import { formatCost, formatMsCompact } from '../../lib/format-number'
 import { isSubmitEnter } from '../../lib/keyboard'
 import { memo } from 'preact/compat'
 import { readKeeperDraft, writeKeeperDraft } from '../../keeper-chat-store'
-import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatChartBlock, ChatIssueBlock, ChatLinkBlock, ChatMermaidBlock, ChatShellBlock, ChatSuggestionsBlock, ChatTableBlock, ChatTraceStep, ChatVoiceBlock, KeeperUserInputBlock } from '../../types'
+import type { ChatBlock, ChatBroadcastBlock, ChatCalloutBlock, ChatChartBlock, ChatIssueBlock, ChatLinkBlock, ChatMermaidBlock, ChatShellBlock, ChatSuggestionsBlock, ChatTableBlock, ChatTraceStep, ChatTraceToolStep, ChatVoiceBlock, KeeperUserInputBlock } from '../../types'
 import type { KeeperConversationAttachment, KeeperConversationAudioClip, KeeperConversationDetails, KeeperConversationEntry, KeeperConversationSource, SurfaceRef } from '../../types'
 import type { ToolCallEntry, ToolCallOutputBlob } from '../../api/dashboard'
 import { fetchBoardPost } from '../../api/board'
@@ -1179,6 +1179,19 @@ function ChatTraceStep({ step }: { step: ChatTraceStep }) {
     `
   }
 
+  const statusClass =
+    step.status === 'ok'
+      ? 'ok'
+      : step.status === 'err'
+        ? 'bad'
+        : 'pending'
+  const statusTitle =
+    step.status === 'ok'
+      ? '성공'
+      : step.status === 'err'
+        ? '실패'
+        : '출력 대기 중'
+
   return html`
     <div class="chat-block-tstep tool ${open ? 'exp' : ''}" data-chat-trace-step="tool">
       <span class="chat-block-tnode"></span>
@@ -1186,7 +1199,11 @@ function ChatTraceStep({ step }: { step: ChatTraceStep }) {
         <div class="chat-block-tstep-row click" onClick=${() => setOpen((o) => !o)}>
           <span class="chat-block-tstep-kind">Tool</span>
           <span class="chat-block-tstep-name">${step.name}</span>
-          <span class="chat-block-tstep-status ${step.status === 'ok' ? 'ok' : 'bad'}"></span>
+          <span
+            class="chat-block-tstep-status ${statusClass}"
+            title=${statusTitle}
+            aria-label=${statusTitle}
+          ></span>
           <span class="chat-block-tstep-dur">${step.dur}</span>
           <span class="chat-block-tstep-chev">▶</span>
         </div>
@@ -2339,21 +2356,51 @@ function isToolOutputCoveredByHydration(
 // result are joined from the tool-call output store. A null output is "pending"
 // until the owning turn and output hydration have both settled; after that, a
 // still-null output is "missing" (unknown outcome).
-function ToolTraceStep({ entry, output, canMarkMissing = false }: { entry: KeeperConversationEntry; output: ToolCallEntry | null; canMarkMissing?: boolean }) {
+function toolEntryFromTraceStep(step: ChatTraceToolStep): KeeperConversationEntry {
+  return {
+    id: step.toolCallId ? `${TOOL_ENTRY_PREFIX}${step.toolCallId}` : `trace-tool-${step.name}-${step.ts ?? 'unknown'}`,
+    role: 'tool',
+    source: 'tool_result',
+    label: step.name,
+    text: step.args ?? '',
+    rawText: step.args ?? '',
+    timestamp: step.ts ?? null,
+    delivery: step.status === 'err' ? 'error' : step.status === 'ok' ? 'delivered' : 'streaming',
+    streamState: step.status === 'pending' || step.status === undefined ? 'streaming' : null,
+    details: null,
+  }
+}
+
+function ToolTraceStep({
+  entry,
+  output,
+  canMarkMissing = false,
+  traceStep,
+}: {
+  entry: KeeperConversationEntry
+  output: ToolCallEntry | null
+  canMarkMissing?: boolean
+  traceStep?: ChatTraceToolStep
+}) {
   const [open, setOpen] = useState(false)
-  const name = entry.label || 'tool'
-  const displayArgs = prettyJsonish(entry.text || '')
+  const name = traceStep?.name || entry.label || 'tool'
+  const displayArgs = prettyJsonish(entry.text || traceStep?.args || '')
   const isEmptyArgs = EMPTY_ARG_TEXTS.has(displayArgs.trim())
   const status: 'pending' | 'missing' | 'ok' | 'bad' =
     output === null
-      ? canMarkMissing
-        ? 'missing'
-        : 'pending'
+      ? traceStep?.status === 'err'
+        ? 'bad'
+        : traceStep?.status === 'ok'
+          ? 'ok'
+          : (canMarkMissing ? 'missing' : 'pending')
       : output.success === false || output.semantic_success === false
         ? 'bad'
         : 'ok'
-  const durLabel = output?.duration_ms != null && output.duration_ms > 0 ? formatMsCompact(output.duration_ms) : ''
-  const resultView = output ? toolOutputDisplay(output.output) : null
+  const durLabel =
+    output?.duration_ms != null && output.duration_ms > 0
+      ? formatMsCompact(output.duration_ms)
+      : traceStep?.dur ?? ''
+  const resultView = output ? toolOutputDisplay(output.output) : (traceStep?.result ? { text: traceStep.result, truncated: false } : null)
   const hasResult = resultView !== null && resultView.text.trim() !== ''
   // Expandable when there is anything to show: args, a result, or a still-pending
   // call (so the operator can open it and see "출력 대기 중…").
@@ -2402,51 +2449,58 @@ function ToolTraceStep({ entry, output, canMarkMissing = false }: { entry: Keepe
   `
 }
 
-// Groups a turn's explicit progress/tool entries into one "작업 과정" trace
-// card placed above the answer bubble. The step list is visible by default so
-// operators can see thinking progress, tool names, and status without opening
-// each raw args/result body.
-// Interleave think/reason trace steps with tool entries by occurrence time so
-// the card shows the real think -> tool -> think order instead of two separate
-// blocks. This is a render-time merge only: tool entries keep their
-// entry-based output join (lookupToolCallOutput) and trace steps keep their
-// markdown render path. No data-structure change, so #21892 missing/aggregate
-// counts and the ToolTraceStep status taxonomy (pending/missing/ok/bad) are
-// preserved.
 type TraceOrderItem =
-  | { kind: 'trace'; step: ChatTraceStep }
-  | { kind: 'tool'; entry: KeeperConversationEntry; output: ToolCallEntry | null }
+  | { kind: 'trace'; step: Exclude<ChatTraceStep, ChatTraceToolStep> }
+  | { kind: 'tool'; step?: ChatTraceToolStep; entry?: KeeperConversationEntry; output: ToolCallEntry | null }
   | { kind: 'chat'; entry: KeeperConversationEntry }
 
-function traceOrderTs(item: TraceOrderItem): string {
-  if (item.kind === 'chat') return item.entry.timestamp ?? '\uffff'
-  // ISO-8601 strings sort lexicographically within one clock domain. This merge
-  // spans two: think/reason `ts` is stamped on the client when the delta
-  // arrives, tool `entry.timestamp` comes from the server (ts_unix). Live
-  // ordering is best-effort chronological and can cross within ~1 RTT; a step
-  // without `ts` (backend-normalized, no timestamp from the wire) sorts first.
-  if (item.kind === 'tool') return item.entry.timestamp ?? ''
-  // Only think/reason carry `ts`; the tool variant of ChatTraceStep does not
-  // (and is never a 'trace' item here, but narrow for type safety).
-  const step = item.step
-  return step.kind === 'tool' ? '' : step.ts ?? ''
+const TOOL_ENTRY_PREFIX = 'tool-'
+
+function toolCallIdFromEntry(entry: KeeperConversationEntry): string | null {
+  return entry.id.startsWith(TOOL_ENTRY_PREFIX)
+    ? entry.id.slice(TOOL_ENTRY_PREFIX.length)
+    : null
 }
 
+// Groups a turn's explicit progress/tool entries into one "작업 과정" trace
+// card placed above the answer bubble. Live streams append tool calls directly
+// into traceSteps, so this function renders that structural sequence verbatim.
+// Legacy history that has only think/reason steps still falls back to the old
+// honest shape: trace rows first, then sibling tool entries. It deliberately
+// does not sort by timestamps because thinking deltas and tool rows come from
+// different clocks and cannot prove causal order after the fact.
 export function interleaveTraceAndTools(
   traceSteps: ChatTraceStep[],
   toolSteps: { entry: KeeperConversationEntry; output: ToolCallEntry | null }[],
 ): TraceOrderItem[] {
-  const traceItems: TraceOrderItem[] = traceSteps.map((step) => ({ kind: 'trace', step }))
-  const toolItems: TraceOrderItem[] = toolSteps.map(({ entry, output }) => ({ kind: 'tool', entry, output }))
-  // trace-then-tool concat is the stable fallback order: Array.prototype.sort
-  // is stable, so equal (or absent) timestamps preserve this input order,
-  // matching the legacy two-section render as a baseline.
-  return [...traceItems, ...toolItems].sort((a, b) => {
-    const ta = traceOrderTs(a)
-    const tb = traceOrderTs(b)
-    if (ta === tb) return 0
-    return ta < tb ? -1 : 1
-  })
+  const toolsByCallId = new Map<string, { entry: KeeperConversationEntry; output: ToolCallEntry | null }>()
+  for (const item of toolSteps) {
+    const callId = toolCallIdFromEntry(item.entry)
+    if (callId) toolsByCallId.set(callId, item)
+  }
+  const usedToolIds = new Set<string>()
+  const ordered: TraceOrderItem[] = []
+  for (const step of traceSteps) {
+    if (step.kind !== 'tool') {
+      ordered.push({ kind: 'trace', step })
+      continue
+    }
+    const callId = step.toolCallId?.trim()
+    const matched = callId ? toolsByCallId.get(callId) : undefined
+    if (callId) usedToolIds.add(callId)
+    ordered.push({
+      kind: 'tool',
+      step,
+      entry: matched?.entry,
+      output: matched?.output ?? null,
+    })
+  }
+  for (const item of toolSteps) {
+    const callId = toolCallIdFromEntry(item.entry)
+    if (callId && usedToolIds.has(callId)) continue
+    ordered.push({ kind: 'tool', entry: item.entry, output: item.output })
+  }
+  return ordered
 }
 
 function chatResponsePreview(entry: KeeperConversationEntry): string {
@@ -2491,23 +2545,25 @@ function ToolTraceCard({
   const steps = tools.map((entry) => ({ entry, output: lookupToolCallOutput(entry.id) }))
   const canMarkMissingForEntry = (entry: KeeperConversationEntry): boolean =>
     turnComplete && isToolOutputCoveredByHydration(entry, toolOutputsCoveredSinceMs, toolOutputsCoveredThroughMs)
-  // Merge think/reason steps and tool entries into a single occurrence-ordered
-  // sequence. Aggregates below (failN/missingN/totalMs/stepN) stay entry-based,
-  // so #21892 missing detection and the status taxonomy are unaffected.
   const ordered = assistant
     ? [...interleaveTraceAndTools(traceSteps, steps), { kind: 'chat' as const, entry: assistant }]
     : interleaveTraceAndTools(traceSteps, steps)
+  const orderedToolSteps = ordered.filter((item): item is Extract<TraceOrderItem, { kind: 'tool' }> => item.kind === 'tool')
   const thinkN = traceSteps.filter((step) => step.kind === 'think' || step.kind === 'reason').length
-  const failN = steps.filter(
-    (s) => s.output !== null && (s.output.success === false || s.output.semantic_success === false),
+  const failN = orderedToolSteps.filter(
+    (s) =>
+      (s.output !== null && (s.output.success === false || s.output.semantic_success === false))
+      || s.step?.status === 'err',
   ).length
   // Surface unjoined outputs as "missing" only once the turn and output
   // hydration have both settled.
-  const missingN = steps.filter((s) => s.output === null && canMarkMissingForEntry(s.entry)).length
-  const totalMs = steps.reduce((sum, s) => sum + (s.output?.duration_ms ?? 0), 0)
+  const missingN = orderedToolSteps.filter(
+    (s) => s.output === null && s.entry !== undefined && canMarkMissingForEntry(s.entry),
+  ).length
+  const totalMs = orderedToolSteps.reduce((sum, s) => sum + (s.output?.duration_ms ?? 0), 0)
   const durLabel = totalMs > 0 ? formatMsCompact(totalMs) : null
   const chatN = assistant ? 1 : 0
-  const stepN = traceSteps.length + tools.length + chatN
+  const stepN = ordered.length
 
   return html`
     <div class="chat-block-trace ${open ? 'open' : ''}" data-chat-block="trace" data-chat-work-trace data-chat-tool-trace>
@@ -2523,7 +2579,7 @@ function ToolTraceCard({
         <span class="chat-block-trace-count">${stepN}단계</span>
         <span class="chat-block-trace-meta">
           ${thinkN > 0 ? html`<span>Think ${thinkN}</span>` : null}
-          ${tools.length > 0 ? html`<span>도구 ${tools.length}</span>` : null}
+          ${orderedToolSteps.length > 0 ? html`<span>도구 ${orderedToolSteps.length}</span>` : null}
           ${chatN > 0 ? html`<span>Chat ${chatN}</span>` : null}
           ${failN > 0 ? html`<span class="text-[var(--color-status-err)]">실패 ${failN}</span>` : null}
           ${missingN > 0 ? html`<span class="text-[var(--color-status-warn)]">결과 누락 ${missingN}</span>` : null}
@@ -2538,12 +2594,17 @@ function ToolTraceCard({
                 item.kind === 'trace'
                   ? html`<${ChatTraceStep} key=${`trace-${index}`} step=${item.step} />`
                   : item.kind === 'tool'
-                    ? html`<${ToolTraceStep}
-                      key=${`tool-${item.entry.id}`}
-                      entry=${item.entry}
-                      output=${item.output}
-                      canMarkMissing=${canMarkMissingForEntry(item.entry)}
-                    />`
+                    ? (() => {
+                        const entry = item.entry ?? (item.step ? toolEntryFromTraceStep(item.step) : null)
+                        if (!entry) return null
+                        return html`<${ToolTraceStep}
+                          key=${`tool-${item.entry?.id ?? item.step?.toolCallId ?? item.step?.name ?? index}`}
+                          entry=${entry}
+                          output=${item.output}
+                          canMarkMissing=${item.entry !== undefined && canMarkMissingForEntry(item.entry)}
+                          traceStep=${item.step}
+                        />`
+                      })()
                     : html`<${ChatResponseTraceStep} key=${`chat-${item.entry.id}`} entry=${item.entry} />`)}
             </div>
           `

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -412,7 +412,21 @@ describe('KeeperConversationPanel', () => {
     expect(getQueueLength('sangsu')).toBe(2)
   })
 
-  it('keeps queued client action ids attached when draining the queue', async () => {
+  it('renders queued drafts inside the transcript while the keeper is busy', async () => {
+    keeperSending.value = { sangsu: true }
+    enqueueInput('sangsu', 'queued transcript draft', undefined, 'queued-action-1')
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    expect(container.textContent).toContain('queued transcript draft')
+    expect(container.querySelector('[data-chat-delivery="queued"]')).not.toBeNull()
+  })
+
+  it('keeps queued client action ids attached when draining the queue as independent turns', async () => {
     enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
     enqueueInput('sangsu', 'queued two', undefined, 'queued-click-2')
 
@@ -429,10 +443,14 @@ describe('KeeperConversationPanel', () => {
     const sendButton = container.querySelector('.send') as HTMLButtonElement
     fireEvent.click(sendButton)
 
-    await waitFor(() => expect(sendKeeperThreadMessage).toHaveBeenCalledTimes(2))
-    expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[1]).toBe('queued one\n\n---\n\nqueued two')
+    await waitFor(() => expect(sendKeeperThreadMessage).toHaveBeenCalledTimes(3))
+    expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[1]).toBe('queued one')
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[2]).toEqual(expect.objectContaining({
-      clientActionIds: ['queued-click-1', 'queued-click-2'],
+      clientActionId: 'queued-click-1',
+    }))
+    expect(vi.mocked(sendKeeperThreadMessage).mock.calls[2]?.[1]).toBe('queued two')
+    expect(vi.mocked(sendKeeperThreadMessage).mock.calls[2]?.[2]).toEqual(expect.objectContaining({
+      clientActionId: 'queued-click-2',
     }))
   })
 
@@ -461,7 +479,7 @@ describe('KeeperConversationPanel', () => {
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[1]).toBe('queued one')
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[2]?.[1]).toBe('queued during drain')
     expect(vi.mocked(sendKeeperThreadMessage).mock.calls[2]?.[2]).toEqual(expect.objectContaining({
-      clientActionIds: ['queued-click-3'],
+      clientActionId: 'queued-click-3',
     }))
     expect(getQueueLength('sangsu')).toBe(0)
   })

--- a/dashboard/src/components/keeper-shared.test.ts
+++ b/dashboard/src/components/keeper-shared.test.ts
@@ -64,7 +64,7 @@ import {
   isKeeperThreadMessageSendInFlight,
   sendKeeperThreadMessage,
 } from '../keeper-runtime'
-import { _resetChatStoreForTests, enqueueInput, getQueueLength } from '../keeper-chat-store'
+import { _resetChatStoreForTests, enqueueInput, getQueuedMessages, getQueueLength } from '../keeper-chat-store'
 import { shellAuthSummary } from '../store'
 import type { KeeperConversationEntry } from '../types'
 import {
@@ -426,6 +426,21 @@ describe('KeeperConversationPanel', () => {
     expect(container.querySelector('[data-chat-delivery="queued"]')).not.toBeNull()
   })
 
+  it('renders queued drafts with invalid timestamps without throwing', async () => {
+    keeperSending.value = { sangsu: true }
+    const msg = enqueueInput('sangsu', 'queued invalid timestamp', undefined, 'queued-action-1')
+    msg.timestamp = Number.NaN
+
+    expect(() => render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )).not.toThrow()
+    await Promise.resolve()
+
+    expect(container.textContent).toContain('queued invalid timestamp')
+    expect(container.querySelector('[data-chat-delivery="queued"]')).not.toBeNull()
+  })
+
   it('keeps queued client action ids attached when draining the queue as independent turns', async () => {
     enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
     enqueueInput('sangsu', 'queued two', undefined, 'queued-click-2')
@@ -482,6 +497,31 @@ describe('KeeperConversationPanel', () => {
       clientActionId: 'queued-click-3',
     }))
     expect(getQueueLength('sangsu')).toBe(0)
+  })
+
+  it('drops an aborted queued send instead of requeueing it', async () => {
+    vi.mocked(sendKeeperThreadMessage).mockImplementation(async (_keeperName, message) => {
+      if (message === 'queued one') throw new DOMException('cancelled', 'AbortError')
+    })
+    enqueueInput('sangsu', 'queued one', undefined, 'queued-click-1')
+    enqueueInput('sangsu', 'queued two', undefined, 'queued-click-2')
+
+    render(
+      html`<${KeeperConversationPanel} keeperName="sangsu" placeholder="메시지 입력..." />`,
+      container,
+    )
+    await Promise.resolve()
+
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement
+    fireEvent.input(textarea, { target: { value: 'trigger drain' } })
+    await Promise.resolve()
+
+    const sendButton = container.querySelector('.send') as HTMLButtonElement
+    fireEvent.click(sendButton)
+
+    await waitFor(() => expect(sendKeeperThreadMessage).toHaveBeenCalledTimes(2))
+    expect(vi.mocked(sendKeeperThreadMessage).mock.calls[1]?.[1]).toBe('queued one')
+    expect(getQueuedMessages('sangsu').map(msg => msg.content)).toEqual(['queued two'])
   })
 
   it('forwards the message-level turn inspector action to the transcript', async () => {

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -37,8 +37,10 @@ import { isDefaultVisibleConversationEntry } from '../keeper-state'
 import {
   enqueueInput,
   clearInputQueue,
-  getQueueLength,
   getQueuedMessages,
+  dequeueInput,
+  markInputSent,
+  requeueInputFront,
   hasQueuedInputClientAction,
   updateQueuedMessage,
   removeQueuedMessage,
@@ -231,6 +233,26 @@ function liveAssistantPlaceholder(keeperName: string): KeeperConversationEntry {
     timestamp: null,
     delivery: 'streaming',
     streamState: 'streaming',
+    details: null,
+    error: null,
+  }
+}
+
+function queuedInputToConversationEntry(msg: QueuedMessage): KeeperConversationEntry {
+  const hasText = msg.content.trim().length > 0
+  const attachmentCount = msg.attachments?.length ?? 0
+  const attachmentText = attachmentCount > 0 ? `첨부 ${attachmentCount}개 대기 중` : ''
+  return {
+    id: `queued-user-${msg.id}`,
+    role: 'user',
+    source: 'direct_user',
+    label: 'You',
+    text: hasText ? msg.content : attachmentText,
+    rawText: msg.content,
+    timestamp: new Date(msg.timestamp).toISOString(),
+    delivery: 'queued',
+    streamState: undefined,
+    attachments: msg.attachments,
     details: null,
     error: null,
   }
@@ -475,7 +497,7 @@ export function KeeperConversationPanel({
   const [searchQuery, setSearchQuery] = useState('')
   // Bumped whenever the input queue mutates — the queue lives outside
   // the signal graph (keeper-chat-store), so re-renders must be forced.
-  const [, setQueueVersion] = useState(0)
+  const [queueVersion, setQueueVersion] = useState(0)
   const bumpQueue = () => setQueueVersion(v => v + 1)
 
   // External-system sync: merge the server-persisted transcript
@@ -505,10 +527,22 @@ export function KeeperConversationPanel({
         : thread,
     [thread, sending, keeperName],
   )
+  const queuedMessages = useMemo(
+    () => getQueuedMessages(keeperName),
+    [keeperName, queueVersion],
+  )
+  const queueCount = queuedMessages.length
+  const visibleThreadWithQueue = useMemo(
+    () =>
+      queuedMessages.length > 0
+        ? [...visibleThread, ...queuedMessages.map(queuedInputToConversationEntry)]
+        : visibleThread,
+    [visibleThread, queuedMessages],
+  )
   const hasQuery = searchQuery.trim().length > 0
   const transcriptEntries = useMemo(
-    () => filterConversationEntries(visibleThread, searchQuery),
-    [visibleThread, searchQuery],
+    () => filterConversationEntries(visibleThreadWithQueue, searchQuery),
+    [visibleThreadWithQueue, searchQuery],
   )
   // Stable action object so the memoized ChatMessageBubble's shallow prop
   // compare can skip unchanged messages — an inline `{ ...onClick }` literal
@@ -521,14 +555,13 @@ export function KeeperConversationPanel({
     [onInspectTurn],
   )
   const transcriptEmptyText =
-    hasQuery && visibleThread.length > 0
+    hasQuery && visibleThreadWithQueue.length > 0
       ? '검색어와 일치하는 메시지가 없습니다.'
       : '아직 표시할 대화가 없습니다. 내부 메시지는 토글로 볼 수 있습니다.'
   const hydrating = keeperHydrating.value[keeperName] ?? false
   const error = keeperActionErrors.value[keeperName]
   const chatAccess = keeperDirectChatAccess(shellAuthSummary.value)
   const composerDisabled = !keeperName || chatAccess.blocked
-  const queueCount = getQueueLength(keeperName)
 
   // 1 s ticker while a stream is active so the stall badge can compare
   // against wall-clock time. External-system sync (timer), not data init.
@@ -553,24 +586,28 @@ export function KeeperConversationPanel({
 
   const drainQueue = async () => {
     for (;;) {
-      const queued = getQueuedMessages(keeperName)
-      if (queued.length === 0) return
-      clearInputQueue(keeperName)
+      const queued = dequeueInput(keeperName)
+      if (!queued) return
       bumpQueue()
 
-      const batchedContent = queued.map(q => q.content.trim()).filter(Boolean).join('\n\n---\n\n')
-      const batchedAttachments = queued.flatMap(q => q.attachments ?? [])
-      const batchedClientActionIds = queued
-        .map(q => q.clientActionId?.trim())
-        .filter((clientActionId): clientActionId is string => Boolean(clientActionId))
-      if (!batchedContent && batchedAttachments.length === 0) continue
+      const content = queued.content.trim()
+      const attachments = queued.attachments && queued.attachments.length > 0 ? queued.attachments : undefined
+      if (!content && !attachments) {
+        markInputSent(keeperName)
+        bumpQueue()
+        continue
+      }
 
       try {
-        await sendKeeperThreadMessage(keeperName, batchedContent, {
-          attachments: batchedAttachments.length > 0 ? batchedAttachments : undefined,
-          clientActionIds: batchedClientActionIds,
+        await sendKeeperThreadMessage(keeperName, content, {
+          attachments,
+          clientActionId: queued.clientActionId,
         })
+        markInputSent(keeperName)
+        bumpQueue()
       } catch (err) {
+        requeueInputFront(keeperName, queued)
+        bumpQueue()
         if (isAbortError(err)) return
         const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
         showToast(message, 'error')
@@ -642,7 +679,7 @@ export function KeeperConversationPanel({
           />
           ${hasQuery
             ? html`<span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2 py-0.5 text-2xs font-medium text-[var(--color-fg-secondary)] v2-monitoring-row" data-chat-search-count>
-                ${transcriptEntries.length} / ${visibleThread.length}
+                ${transcriptEntries.length} / ${visibleThreadWithQueue.length}
               </span>`
             : null}
           <span class="spacer"></span>
@@ -712,7 +749,7 @@ export function KeeperConversationPanel({
                       <span>${queueCount}개 메시지 대기 중</span>
                       <button type="button" class="underline hover:text-[var(--color-fg-secondary)]" onClick=${cancelQueue}>모두 취소</button>
                     </div>
-                    ${getQueuedMessages(keeperName).map(msg => html`
+                    ${queuedMessages.map(msg => html`
                       <${QueueItemCard}
                         key=${msg.id}
                         keeperName=${keeperName}
@@ -777,7 +814,7 @@ export function KeeperConversationPanel({
             />
             ${hasQuery
               ? html`<span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]" data-chat-search-count>
-                  ${transcriptEntries.length} / ${visibleThread.length}
+                  ${transcriptEntries.length} / ${visibleThreadWithQueue.length}
                 </span>`
               : null}
             <${GhostButton} onClick=${toggleMetadata} ariaExpanded=${showMetadata}>
@@ -892,7 +929,7 @@ export function KeeperConversationPanel({
             />
             ${hasQuery
               ? html`<span class="inline-flex items-center rounded-[var(--r-0)] border border-[var(--accent-20)] bg-[var(--accent-10)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]" data-chat-search-count>
-                  ${transcriptEntries.length} / ${visibleThread.length}
+                  ${transcriptEntries.length} / ${visibleThreadWithQueue.length}
                 </span>`
               : null}
             <${GhostButton} onClick=${toggleMetadata} ariaExpanded=${showMetadata}>

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -249,12 +249,21 @@ function queuedInputToConversationEntry(msg: QueuedMessage): KeeperConversationE
     label: 'You',
     text: hasText ? msg.content : attachmentText,
     rawText: msg.content,
-    timestamp: new Date(msg.timestamp).toISOString(),
+    timestamp: queuedTimestampIso(msg.timestamp),
     delivery: 'queued',
     streamState: undefined,
     attachments: msg.attachments,
     details: null,
     error: null,
+  }
+}
+
+function queuedTimestampIso(timestampMs: number): string | null {
+  if (!Number.isFinite(timestampMs)) return null
+  try {
+    return new Date(timestampMs).toISOString()
+  } catch {
+    return null
   }
 }
 
@@ -606,9 +615,13 @@ export function KeeperConversationPanel({
         markInputSent(keeperName)
         bumpQueue()
       } catch (err) {
+        if (isAbortError(err)) {
+          markInputSent(keeperName)
+          bumpQueue()
+          return
+        }
         requeueInputFront(keeperName, queued)
         bumpQueue()
-        if (isAbortError(err)) return
         const message = err instanceof Error ? err.message : `${keeperName} 메시지 전송 실패`
         showToast(message, 'error')
         return

--- a/dashboard/src/keeper-chat-store.test.ts
+++ b/dashboard/src/keeper-chat-store.test.ts
@@ -4,6 +4,7 @@ import {
   enqueueInput,
   dequeueInput,
   markInputSent,
+  requeueInputFront,
   clearInputQueue,
   hasQueuedInputClientAction,
   getQueueLength,
@@ -66,6 +67,21 @@ describe('keeper-chat-store input queue', () => {
     markInputSent('keeper-q')
     const next = dequeueInput('keeper-q')
     expect(next!.content).toBe('b')
+  })
+
+  it('requeues a deferred sending item at the front', () => {
+    enqueueInput('keeper-q', 'first')
+    enqueueInput('keeper-q', 'second')
+    const msg = dequeueInput('keeper-q')
+    expect(msg!.content).toBe('first')
+
+    requeueInputFront('keeper-q', msg!)
+
+    const replay = dequeueInput('keeper-q')
+    expect(replay!.content).toBe('first')
+    markInputSent('keeper-q')
+    const next = dequeueInput('keeper-q')
+    expect(next!.content).toBe('second')
   })
 
   it('clearInputQueue removes all items', () => {

--- a/dashboard/src/keeper-chat-store.ts
+++ b/dashboard/src/keeper-chat-store.ts
@@ -157,6 +157,14 @@ export function dequeueInput(keeperName: string): QueuedMessage | null {
   return msg
 }
 
+/** Put an unsent/deferred message back at the front of the queue. */
+export function requeueInputFront(keeperName: string, msg: QueuedMessage): void {
+  const q = _ensureQueue(keeperName)
+  q.sending = false
+  if (q.items.some(item => item.id === msg.id)) return
+  q.items.unshift({ ...msg, sent: false })
+}
+
 /** Mark the current sending item as done and clear the sending flag. */
 export function markInputSent(keeperName: string): void {
   const q = _queues.get(keeperName)

--- a/dashboard/src/keeper-state.test.ts
+++ b/dashboard/src/keeper-state.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { beforeEach } from 'vitest'
 import {
   THREAD_ENTRY_CAP,
+  appendAssistantToolTraceArgsDelta,
+  appendAssistantToolTraceStep,
   appendAssistantThinkingDelta,
   appendThreadEntry,
   attachKeeperAudioClip,
@@ -12,13 +14,14 @@ import {
   isToolConversationEntry,
   isVisibleDirectConversationEntry,
   keeperThreads,
+  markAssistantToolTraceEnded,
   mergeServerHistoryEntries,
   normalizeAudioClip,
   normalizeStatusDetail,
   removeThreadEntries,
   setStatusDetail,
 } from './keeper-state'
-import type { KeeperConversationEntry } from './types'
+import type { ChatBlock, KeeperConversationEntry } from './types'
 
 describe('normalizeStatusDetail', () => {
   it('infers and hides internal keeper history from direct comms', () => {
@@ -334,6 +337,41 @@ describe('thread history merge & persistence', () => {
     expect(entries[1]?.timestamp).toBeTruthy()
   })
 
+  it('preserves object payloads in persisted tool trace blocks', () => {
+    const entries = chatHistoryEntriesFromRest('echo', [
+      {
+        role: 'assistant',
+        content: 'done',
+        ts: 1_780_000_000,
+        blocks: [
+          {
+            t: 'trace',
+            trace: [
+              {
+                kind: 'tool',
+                name: 'lookup',
+                toolCallId: 'tc-object',
+                args: { query: 'masc', limit: 2 },
+                result: { ok: true },
+              },
+            ],
+          },
+        ] as unknown as ChatBlock[],
+      },
+    ])
+
+    const traceBlock = entries[0]?.blocks?.find((block): block is Extract<ChatBlock, { t: 'trace' }> => block.t === 'trace')
+    expect(traceBlock?.trace).toEqual([
+      {
+        kind: 'tool',
+        name: 'lookup',
+        toolCallId: 'tc-object',
+        args: '{\n  "query": "masc",\n  "limit": 2\n}',
+        result: '{\n  "ok": true\n}',
+      },
+    ])
+  })
+
   it('maps persisted tool rows to the live tool-entry convention', () => {
     const entries = chatHistoryEntriesFromRest('echo', [
       { role: 'user', content: 'run checks', ts: 1_780_000_000 },
@@ -631,6 +669,36 @@ describe('thread history merge & persistence', () => {
 
     const ids = (keeperThreads.value.echo ?? []).map(e => e.id)
     expect(ids).toEqual(['tool-1', 'reply-1', 'tail-1'])
+  })
+
+  it('does not duplicate an existing tool row when a start event repeats', () => {
+    appendThreadEntry('echo', entry({ id: 'reply-1', role: 'assistant', source: 'direct_assistant' }))
+    insertThreadEntryBefore('echo', 'reply-1', entry({ id: 'tool-1', role: 'tool', source: 'tool_result', text: '{"a":1}' }))
+    insertThreadEntryBefore('echo', 'reply-1', entry({ id: 'tool-1', role: 'tool', source: 'tool_result', text: '{"a":2}' }))
+
+    const tools = (keeperThreads.value.echo ?? []).filter(e => e.id === 'tool-1')
+    expect(tools).toHaveLength(1)
+    expect(tools[0]?.text).toBe('{"a":1}')
+  })
+
+  it('preserves accumulated tool trace state when TOOL_CALL_START repeats', () => {
+    appendThreadEntry('echo', entry({ id: 'reply-1', role: 'assistant', source: 'direct_assistant' }))
+    appendAssistantToolTraceStep('echo', 'reply-1', { toolCallId: 'tc-1', name: 'lookup', ts: '2026-06-25T00:00:00.000Z' })
+    appendAssistantToolTraceArgsDelta('echo', 'reply-1', 'tc-1', '{"a":1}')
+    markAssistantToolTraceEnded('echo', 'reply-1', 'tc-1')
+    appendAssistantToolTraceStep('echo', 'reply-1', { toolCallId: 'tc-1', name: 'lookup-again', ts: '2026-06-25T00:00:01.000Z' })
+
+    const reply = keeperThreads.value.echo?.find(e => e.id === 'reply-1')
+    expect(reply?.traceSteps).toEqual([
+      {
+        kind: 'tool',
+        name: 'lookup',
+        toolCallId: 'tc-1',
+        status: 'ok',
+        args: '{"a":1}',
+        ts: '2026-06-25T00:00:00.000Z',
+      },
+    ])
   })
 
   it('removes only the requested local thread entries', () => {

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -285,15 +285,17 @@ function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
     const name = asString(raw.name)
     if (name === undefined) return null
     const status = asString(raw.status)
-    const toolStatus: 'ok' | 'err' | undefined =
-      status === 'ok' || status === 'err' ? status : undefined
+    const toolStatus: 'pending' | 'ok' | 'err' | undefined =
+      status === 'pending' || status === 'ok' || status === 'err' ? status : undefined
     return withoutUndefined({
       kind: 'tool',
       name,
+      toolCallId: asString(raw.toolCallId) ?? asString(raw.tool_call_id) ?? undefined,
       status: toolStatus,
       dur: asString(raw.dur) ?? undefined,
-      args: raw.args,
+      args: asString(raw.args) ?? undefined,
       result: asString(raw.result) ?? undefined,
+      ts: asString(raw.ts) ?? undefined,
     })
   }
   return null
@@ -866,6 +868,105 @@ export function appendAssistantThinkingDelta(name: string, entryId: string, delt
       delivery: 'streaming',
     }
   })
+}
+
+function warnMissingToolTrace(
+  op: string,
+  keeperName: string,
+  entryId: string,
+  toolCallId: string,
+): void {
+  console.warn(
+    `[keeper-trace] ${op} ignored: missing tool trace step keeper=${keeperName} entry=${entryId} toolCallId=${toolCallId}`,
+  )
+}
+
+export function appendAssistantToolTraceStep(
+  name: string,
+  entryId: string,
+  step: { toolCallId: string; name: string; ts?: string },
+): void {
+  const toolCallId = step.toolCallId.trim()
+  const toolName = step.name.trim()
+  if (!toolCallId || !toolName) {
+    console.warn(
+      `[keeper-trace] start ignored: invalid tool trace step keeper=${name} entry=${entryId}`,
+    )
+    return
+  }
+  updateThreadEntry(name, entryId, entry => {
+    const existing = entry.traceSteps ?? []
+    const index = existing.findIndex(
+      trace => trace.kind === 'tool' && trace.toolCallId === toolCallId,
+    )
+    const nextStep: ChatTraceStep = {
+      kind: 'tool',
+      toolCallId,
+      name: toolName,
+      status: 'pending',
+      ts: step.ts ?? new Date().toISOString(),
+    }
+    const traceSteps =
+      index === -1
+        ? [...existing, nextStep]
+        : existing.map((trace, i) => i === index ? { ...trace, ...nextStep } : trace)
+    return {
+      ...entry,
+      traceSteps,
+      streamState: 'streaming',
+      delivery: 'streaming',
+    }
+  })
+}
+
+export function appendAssistantToolTraceArgsDelta(
+  name: string,
+  entryId: string,
+  toolCallId: string,
+  delta: string,
+): void {
+  const id = toolCallId.trim()
+  if (!id || !delta) return
+  let found = false
+  updateThreadEntry(name, entryId, entry => {
+    const existing = entry.traceSteps ?? []
+    const traceSteps = existing.map((trace) => {
+      if (trace.kind !== 'tool' || trace.toolCallId !== id) return trace
+      found = true
+      return {
+        ...trace,
+        args: `${trace.args ?? ''}${delta}`,
+      }
+    })
+    return {
+      ...entry,
+      traceSteps,
+    }
+  })
+  if (!found) warnMissingToolTrace('args patch', name, entryId, id)
+}
+
+export function markAssistantToolTraceEnded(
+  name: string,
+  entryId: string,
+  toolCallId: string,
+): void {
+  const id = toolCallId.trim()
+  if (!id) return
+  let found = false
+  updateThreadEntry(name, entryId, entry => {
+    const existing = entry.traceSteps ?? []
+    const traceSteps = existing.map((trace) => {
+      if (trace.kind !== 'tool' || trace.toolCallId !== id) return trace
+      found = true
+      return trace
+    })
+    return {
+      ...entry,
+      traceSteps,
+    }
+  })
+  if (!found) warnMissingToolTrace('end patch', name, entryId, id)
 }
 
 export function finalizeAssistantEntry(

--- a/dashboard/src/keeper-state.ts
+++ b/dashboard/src/keeper-state.ts
@@ -2,6 +2,7 @@ import { signal } from '@preact/signals'
 import { formatKeeperVisibleReply } from './keeper-message'
 import { parseTextToChatBlocks } from './lib/chat-blocks'
 import { isRecord, asString, asNumber, asBoolean, toIsoTimestamp } from './components/common/normalize'
+import { toolEntryIdFromCallId } from './tool-call-output-store'
 import type {
   KeeperConversationAttachment,
   KeeperConversationAudioClip,
@@ -268,6 +269,17 @@ function normalizeNumberArray(raw: unknown): number[] | null {
   return values as number[]
 }
 
+function normalizeTracePayload(raw: unknown): string | undefined {
+  if (raw === undefined || raw === null) return undefined
+  if (typeof raw === 'string') return raw
+  try {
+    const encoded = JSON.stringify(raw, null, 2)
+    return encoded === undefined ? String(raw) : encoded
+  } catch {
+    return String(raw)
+  }
+}
+
 function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
   if (!isRecord(raw)) return null
   const kind = asString(raw.kind)
@@ -293,8 +305,8 @@ function normalizeTraceStep(raw: unknown): ChatTraceStep | null {
       toolCallId: asString(raw.toolCallId) ?? asString(raw.tool_call_id) ?? undefined,
       status: toolStatus,
       dur: asString(raw.dur) ?? undefined,
-      args: asString(raw.args) ?? undefined,
-      result: asString(raw.result) ?? undefined,
+      args: normalizeTracePayload(raw.args),
+      result: normalizeTracePayload(raw.result),
       ts: asString(raw.ts) ?? undefined,
     })
   }
@@ -796,6 +808,7 @@ export function insertThreadEntryBefore(
   entry: KeeperConversationEntry,
 ): void {
   const existing = keeperThreads.value[name] ?? []
+  if (existing.some(e => e.id === entry.id)) return
   const index = existing.findIndex(e => e.id === beforeId)
   const next =
     index === -1
@@ -876,9 +889,7 @@ function warnMissingToolTrace(
   entryId: string,
   toolCallId: string,
 ): void {
-  console.warn(
-    `[keeper-trace] ${op} ignored: missing tool trace step keeper=${keeperName} entry=${entryId} toolCallId=${toolCallId}`,
-  )
+  console.warn('[keeper-trace] missing tool trace step', { op, keeperName, entryId, toolCallId })
 }
 
 export function appendAssistantToolTraceStep(
@@ -889,9 +900,7 @@ export function appendAssistantToolTraceStep(
   const toolCallId = step.toolCallId.trim()
   const toolName = step.name.trim()
   if (!toolCallId || !toolName) {
-    console.warn(
-      `[keeper-trace] start ignored: invalid tool trace step keeper=${name} entry=${entryId}`,
-    )
+    console.warn('[keeper-trace] invalid tool trace step', { op: 'start', keeperName: name, entryId })
     return
   }
   updateThreadEntry(name, entryId, entry => {
@@ -909,7 +918,17 @@ export function appendAssistantToolTraceStep(
     const traceSteps =
       index === -1
         ? [...existing, nextStep]
-        : existing.map((trace, i) => i === index ? { ...trace, ...nextStep } : trace)
+        : existing.map((trace, i) =>
+            i === index && trace.kind === 'tool'
+              ? {
+                  ...trace,
+                  name: trace.name || toolName,
+                  toolCallId,
+                  status: trace.status ?? 'pending',
+                  ts: trace.ts ?? nextStep.ts,
+                }
+              : trace,
+          )
     return {
       ...entry,
       traceSteps,
@@ -959,7 +978,10 @@ export function markAssistantToolTraceEnded(
     const traceSteps = existing.map((trace) => {
       if (trace.kind !== 'tool' || trace.toolCallId !== id) return trace
       found = true
-      return trace
+      return {
+        ...trace,
+        status: trace.status === 'err' ? ('err' as const) : ('ok' as const),
+      }
     })
     return {
       ...entry,
@@ -1142,7 +1164,7 @@ interface RestChatHistoryMessage {
 function toolHistoryEntry(message: RestChatHistoryMessage): KeeperConversationEntry | null {
   if (!message.tool_call_id || !message.tool_call_name) return null
   return {
-    id: `tool-${message.tool_call_id}`,
+    id: toolEntryIdFromCallId(message.tool_call_id),
     role: 'tool',
     source: 'tool_result',
     label: message.tool_call_name,

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -353,7 +353,7 @@ describe('applyKeeperStreamEvent tool calls', () => {
         kind: 'tool',
         name: 'keeper_board_list',
         toolCallId: 'tc-ordered',
-        status: 'pending',
+        status: 'ok',
         args: '{"limit":1}',
         ts: expect.any(String),
       },
@@ -374,5 +374,35 @@ describe('applyKeeperStreamEvent tool calls', () => {
     const tool = keeperThreads.value.sangsu?.find(entry => entry.id === 'tool-tc-fallback')
     expect(tool?.text).toBe('{"post_id":"p-1"}')
     expect(tool?.delivery).toBe('delivered')
+  })
+
+  it('keeps duplicate TOOL_CALL_START events idempotent', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_START',
+      toolCallId: 'tc-repeat',
+      toolCallName: 'keeper_board_post',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TOOL_CALL_ARGS', toolCallId: 'tc-repeat', delta: '{"post_id":"p-1"}' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TOOL_CALL_END', toolCallId: 'tc-repeat' })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_START',
+      toolCallId: 'tc-repeat',
+      toolCallName: 'keeper_board_post',
+    })
+
+    const thread = keeperThreads.value.sangsu ?? []
+    expect(thread.filter(entry => entry.id === 'tool-tc-repeat')).toHaveLength(1)
+    const reply = thread.find(entry => entry.id === 'reply-1')
+    expect(reply?.traceSteps).toEqual([
+      {
+        kind: 'tool',
+        name: 'keeper_board_post',
+        toolCallId: 'tc-repeat',
+        status: 'ok',
+        args: '{"post_id":"p-1"}',
+        ts: expect.any(String),
+      },
+    ])
   })
 })

--- a/dashboard/src/keeper-stream.test.ts
+++ b/dashboard/src/keeper-stream.test.ts
@@ -301,11 +301,64 @@ describe('applyKeeperStreamEvent tool calls', () => {
     expect(tool.label).toBe('masc_status')
     expect(tool.text).toBe('{"fast":true}')
     expect(tool.delivery).toBe('streaming')
+    const reply = thread[replyIndex]!
+    expect(reply.traceSteps).toEqual([
+      {
+        kind: 'tool',
+        name: 'masc_status',
+        toolCallId: 'tc-1',
+        status: 'pending',
+        args: '{"fast":true}',
+        ts: expect.any(String),
+      },
+    ])
 
     applyKeeperStreamEvent('sangsu', 'reply-1', { type: 'TOOL_CALL_END', toolCallId: 'tc-1' })
     const finished = keeperThreads.value.sangsu?.find(entry => entry.id === 'tool-tc-1')
     expect(finished?.delivery).toBe('delivered')
     expect(finished?.streamState).toBeNull()
+  })
+
+  it('records tool calls in the assistant trace between thinking deltas', () => {
+    assistantEntry()
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { delta: 'think A' },
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_START',
+      toolCallId: 'tc-ordered',
+      toolCallName: 'keeper_board_list',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_ARGS',
+      toolCallId: 'tc-ordered',
+      delta: '{"limit":1}',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'TOOL_CALL_END',
+      toolCallId: 'tc-ordered',
+    })
+    applyKeeperStreamEvent('sangsu', 'reply-1', {
+      type: 'CUSTOM',
+      name: 'KEEPER_THINKING_DELTA',
+      value: { delta: 'think B' },
+    })
+
+    const reply = keeperThreads.value.sangsu?.find(entry => entry.id === 'reply-1')
+    expect(reply?.traceSteps).toEqual([
+      { kind: 'think', text: 'think A', ts: expect.any(String) },
+      {
+        kind: 'tool',
+        name: 'keeper_board_list',
+        toolCallId: 'tc-ordered',
+        status: 'pending',
+        args: '{"limit":1}',
+        ts: expect.any(String),
+      },
+      { kind: 'think', text: 'think B', ts: expect.any(String) },
+    ])
   })
 
   it('routes args to the last started tool call when toolCallId is missing', () => {

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -22,6 +22,7 @@ import {
   setRecordValue,
 } from './keeper-state'
 import { isRecord, asString } from './components/common/normalize'
+import { toolEntryIdFromCallId } from './tool-call-output-store'
 
 const KEEPER_MESSAGE_CANCELLED_TEXT = '요청이 취소되었습니다.'
 export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'cancelled'])
@@ -29,10 +30,6 @@ export const TERMINAL_REQUEST_STATUSES = new Set(['done', 'error', 'lost', 'canc
 // Most recent TOOL_CALL_START id per keeper — fallback target for
 // TOOL_CALL_ARGS / TOOL_CALL_END events that omit toolCallId.
 const lastToolCallIds = new Map<string, string>()
-
-function toolEntryId(toolCallId: string): string {
-  return `tool-${toolCallId}`
-}
 
 export interface KeeperThreadAbortResult {
   readonly keeperName: string
@@ -105,7 +102,7 @@ export function applyKeeperStreamEvent(
       // Insert above the live assistant bubble so the final reply text
       // stays the last entry in the transcript.
       insertThreadEntryBefore(keeperName, assistantEntryId, {
-        id: toolEntryId(toolCallId),
+        id: toolEntryIdFromCallId(toolCallId),
         role: 'tool',
         source: 'tool_result',
         label: toolName,
@@ -122,7 +119,7 @@ export function applyKeeperStreamEvent(
       const toolCallId = event.toolCallId ?? lastToolCallIds.get(keeperName)
       if (toolCallId && typeof event.delta === 'string' && event.delta) {
         appendAssistantToolTraceArgsDelta(keeperName, assistantEntryId, toolCallId, event.delta)
-        updateThreadEntry(keeperName, toolEntryId(toolCallId), entry => ({
+        updateThreadEntry(keeperName, toolEntryIdFromCallId(toolCallId), entry => ({
           ...entry,
           text: `${entry.text}${event.delta}`,
           rawText: `${entry.rawText ?? entry.text}${event.delta}`,
@@ -134,7 +131,7 @@ export function applyKeeperStreamEvent(
       const toolCallId = event.toolCallId ?? lastToolCallIds.get(keeperName)
       if (toolCallId) {
         markAssistantToolTraceEnded(keeperName, assistantEntryId, toolCallId)
-        updateThreadEntry(keeperName, toolEntryId(toolCallId), entry => ({
+        updateThreadEntry(keeperName, toolEntryIdFromCallId(toolCallId), entry => ({
           ...entry,
           delivery: 'delivered',
           streamState: null,

--- a/dashboard/src/keeper-stream.ts
+++ b/dashboard/src/keeper-stream.ts
@@ -4,10 +4,13 @@ import type { KeeperChatStreamEvent } from './api'
 import {
   appendAssistantDelta,
   appendAssistantThinkingDelta,
+  appendAssistantToolTraceArgsDelta,
+  appendAssistantToolTraceStep,
   setAssistantStreamState,
   updateThreadEntry,
   insertThreadEntryBefore,
   finalizeAssistantEntry,
+  markAssistantToolTraceEnded,
   clearActiveStream,
   clearActiveStreamRequestId,
   releaseActiveStreamRequestId,
@@ -94,13 +97,18 @@ export function applyKeeperStreamEvent(
     case 'TOOL_CALL_START': {
       const toolCallId = event.toolCallId ?? `tc-${keeperName}-${Date.now()}`
       lastToolCallIds.set(keeperName, toolCallId)
+      const toolName = event.toolCallName ?? event.name ?? 'tool'
+      appendAssistantToolTraceStep(keeperName, assistantEntryId, {
+        toolCallId,
+        name: toolName,
+      })
       // Insert above the live assistant bubble so the final reply text
       // stays the last entry in the transcript.
       insertThreadEntryBefore(keeperName, assistantEntryId, {
         id: toolEntryId(toolCallId),
         role: 'tool',
         source: 'tool_result',
-        label: event.toolCallName ?? event.name ?? 'tool',
+        label: toolName,
         text: '',
         rawText: '',
         timestamp: new Date().toISOString(),
@@ -113,6 +121,7 @@ export function applyKeeperStreamEvent(
     case 'TOOL_CALL_ARGS': {
       const toolCallId = event.toolCallId ?? lastToolCallIds.get(keeperName)
       if (toolCallId && typeof event.delta === 'string' && event.delta) {
+        appendAssistantToolTraceArgsDelta(keeperName, assistantEntryId, toolCallId, event.delta)
         updateThreadEntry(keeperName, toolEntryId(toolCallId), entry => ({
           ...entry,
           text: `${entry.text}${event.delta}`,
@@ -124,6 +133,7 @@ export function applyKeeperStreamEvent(
     case 'TOOL_CALL_END': {
       const toolCallId = event.toolCallId ?? lastToolCallIds.get(keeperName)
       if (toolCallId) {
+        markAssistantToolTraceEnded(keeperName, assistantEntryId, toolCallId)
         updateThreadEntry(keeperName, toolEntryId(toolCallId), entry => ({
           ...entry,
           delivery: 'delivered',

--- a/dashboard/src/tool-call-output-store.test.ts
+++ b/dashboard/src/tool-call-output-store.test.ts
@@ -6,9 +6,11 @@ import {
   markToolCallOutputsHydrating,
   recordToolCallOutputs,
   resetToolCallOutputs,
+  toolCallIdFromToolEntryId,
   toolCallOutputsById,
   toolCallOutputsCoveredSinceMs,
   toolCallOutputsCoveredThroughMs,
+  toolEntryIdFromCallId,
 } from './tool-call-output-store'
 
 function toolCall(overrides: Partial<ToolCallEntry> = {}): ToolCallEntry {
@@ -37,6 +39,12 @@ describe('tool-call-output-store', () => {
   it('looks up by the chat entry id, stripping the tool- prefix', () => {
     recordToolCallOutputs([toolCall({ tool_use_id: 'toolu_abc', output: 'hello' })])
     expect(lookupToolCallOutput('tool-toolu_abc')?.output).toBe('hello')
+  })
+
+  it('exports the shared chat-entry id convention', () => {
+    expect(toolEntryIdFromCallId('toolu_abc')).toBe('tool-toolu_abc')
+    expect(toolCallIdFromToolEntryId('tool-toolu_abc')).toBe('toolu_abc')
+    expect(toolCallIdFromToolEntryId('chat-toolu_abc')).toBeNull()
   })
 
   it('looks up by a bare tool_use_id (no prefix) as well', () => {

--- a/dashboard/src/tool-call-output-store.ts
+++ b/dashboard/src/tool-call-output-store.ts
@@ -16,7 +16,17 @@ import type { ToolCallEntry } from './api/dashboard'
 
 // Chat tool entries id their rows `tool-<tool_call_id>` on both the live
 // stream and history paths (keeper-stream.ts / keeper-state.ts).
-const TOOL_ENTRY_ID_PREFIX = 'tool-'
+export const TOOL_ENTRY_ID_PREFIX = 'tool-'
+
+export function toolEntryIdFromCallId(toolCallId: string): string {
+  return `${TOOL_ENTRY_ID_PREFIX}${toolCallId}`
+}
+
+export function toolCallIdFromToolEntryId(entryId: string): string | null {
+  return entryId.startsWith(TOOL_ENTRY_ID_PREFIX)
+    ? entryId.slice(TOOL_ENTRY_ID_PREFIX.length)
+    : null
+}
 
 // Global join table: tool_use_id → the tool-call IO entry (input + output).
 // Replaced (not mutated) on each merge so signal subscribers re-render.
@@ -137,9 +147,7 @@ export function recordToolCallOutputs(entries: readonly ToolCallEntry[]): void {
  *  or for rows whose call carried no provider id. Reads the signal value, so
  *  a component calling this during render subscribes to store updates. */
 export function lookupToolCallOutput(toolEntryId: string): ToolCallEntry | null {
-  const toolUseId = toolEntryId.startsWith(TOOL_ENTRY_ID_PREFIX)
-    ? toolEntryId.slice(TOOL_ENTRY_ID_PREFIX.length)
-    : toolEntryId
+  const toolUseId = toolCallIdFromToolEntryId(toolEntryId) ?? toolEntryId
   return toolCallOutputsById.value.get(toolUseId) ?? null
 }
 

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -826,12 +826,21 @@ export type ChatImageBlock = { t: 'image'; src?: string; ph?: string; cap?: stri
 export type ChatSvgBlock = { t: 'svg'; svg: string; cap?: string }
 export type ChatMermaidBlock = { t: 'mermaid'; source: string; caption?: string }
 
-// `ts` (ISO-8601) lets ToolTraceCard interleave think/reason steps with tool
-// entries by occurrence time. Absent on backend-normalized steps (no timestamp
-// surfaced from the wire), which then sort first as a legacy fallback.
+// `ts` (ISO-8601) records when the trace event arrived. Live streams preserve
+// think/tool order structurally in this array; persisted legacy rows may omit
+// timestamps and still render in stored order.
 export type ChatTraceThinkStep = { kind: 'think'; text: string; ts?: string }
 export type ChatTraceReasonStep = { kind: 'reason'; text: string; detail?: string; ts?: string }
-export type ChatTraceToolStep = { kind: 'tool'; name: string; status?: 'ok' | 'err'; dur?: string; args?: unknown; result?: string }
+export type ChatTraceToolStep = {
+  kind: 'tool'
+  name: string
+  toolCallId?: string
+  status?: 'pending' | 'ok' | 'err'
+  dur?: string
+  args?: string
+  result?: string
+  ts?: string
+}
 export type ChatTraceStep = ChatTraceThinkStep | ChatTraceReasonStep | ChatTraceToolStep
 export type ChatTraceBlock = { t: 'trace'; trace: ChatTraceStep[] }
 


### PR DESCRIPTION
## Summary

- Preserve live Think -> Tool -> Think ordering by recording tool calls into assistant traceSteps at stream ingestion time and rendering the structural sequence directly.
- Join timeline tool rows by exact toolCallId instead of timestamp sorting, while keeping legacy history fallback behavior.
- Render queued user drafts in the conversation transcript immediately and drain queued inputs FIFO as independent sends, preserving each clientActionId.
- Normalize stringified trace tool args so typed trace payloads render as structured JSON instead of escaped string literals.

## Why

The previous UI grouped thinking and tool rows in a way that obscured the actual turn flow. It also batched queued messages into one prompt, which lost user turn boundaries and per-message client action ids.

## Validation

- pnpm -C dashboard typecheck
- pnpm -C dashboard lint
- pnpm -C dashboard exec vitest run --config vitest.config.ts src/keeper-stream.test.ts src/keeper-chat-store.test.ts src/components/chat/primitives-interleave.test.ts src/components/keeper-shared.test.ts src/components/chat/artifact-panel.test.ts src/components/chat/primitives.test.ts --no-file-parallelism --maxWorkers=1
- git diff --check
- Playwright screenshots for desktop and mobile keeper chat route: http://127.0.0.1:5174/dashboard/#keepers?keeper=sangsu
