### PR TITLE
ci: install grpcurl from pinned release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,18 +588,26 @@ jobs:
           install-flags: --with-test
           os-packages: jq ripgrep
 
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.22'
-          # This workflow only uses Go to install grpcurl and does not
-          # carry a repo go.mod/go.sum for module cache restoration.
-          cache: false
-
       - name: Install grpcurl
+        env:
+          GRPCURL_VERSION: "1.9.3"
+          GRPCURL_SHA256: "a926b62a85787ccf73ef8736b3ae554f1242e39d92bb8767a79d6dd23b11d1d5"
         run: |
-          GOBIN="$HOME/go/bin" go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
-          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+
+          asset="grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz"
+          url="https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/${asset}"
+          archive="${RUNNER_TEMP}/${asset}"
+          bin_dir="${RUNNER_TEMP}/grpcurl-bin"
+
+          curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "${url}" -o "${archive}"
+          (cd "${RUNNER_TEMP}" && printf '%s  %s\n' "${GRPCURL_SHA256}" "${asset}" | sha256sum -c -)
+
+          mkdir -p "${bin_dir}"
+          tar -xzf "${archive}" -C "${bin_dir}" grpcurl
+          chmod +x "${bin_dir}/grpcurl"
+          echo "${bin_dir}" >> "$GITHUB_PATH"
+          "${bin_dir}/grpcurl" -version
 
       - name: Build
         id: build_step


### PR DESCRIPTION
## Summary

- Remove the Build and Test job's Go toolchain setup that was only used to compile `grpcurl`.
- Install `grpcurl` from the pinned upstream v1.9.3 Linux x86_64 release tarball instead.
- Verify the release archive with the upstream SHA256 before adding it to `PATH`.

## Why

Multiple open PRs are failing `Build and Test` before any useful Dune failure is emitted. The logs repeatedly stop at:

```text
Install grpcurl
GOBIN="$HOME/go/bin" go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
```

Affected examples checked today:

- #22301: Build and Test failed at job `83453882415`
- #22302: Build and Test failed at job `83449663279`
- #22300: Build and Test failed at job `83445735988`
- #22306: Build and Test failed at job `83447512911`

This keeps review-response PRs red without reaching the actual Dune build/test surface.

## Verification

- `git diff --check`
- YAML parse:
  - `python3 -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".github/workflows/ci.yml").read_text()); print("yaml-ok")'`
- Upstream release asset check:
  - `gh api repos/fullstorydev/grpcurl/releases/tags/v1.9.3 --jq '.assets[].name'`
  - confirmed `grpcurl_1.9.3_linux_x86_64.tar.gz`
- Checksum/tar check:
  - SHA256 matched `a926b62a85787ccf73ef8736b3ae554f1242e39d92bb8767a79d6dd23b11d1d5`
  - archive contains `grpcurl`

No local Dune build/test was run.
