### PR TITLE
fix(dashboard): force post-action runtime refresh

### DIFF
--- a/dashboard/src/store-dashboard-bootstrap.test.ts
+++ b/dashboard/src/store-dashboard-bootstrap.test.ts
@@ -279,6 +279,35 @@ describe('refreshDashboard bootstrap', () => {
 })
 
 describe('refreshKeeperRuntimeStatus', () => {
+  it('force-refreshes post-action runtime status by default', async () => {
+    apiMocks.fetchDashboardShell.mockResolvedValue({
+      generated_at: '2026-06-25T12:00:00Z',
+      status: { project: 'me' },
+      counts: { agents: 0, tasks: 0, keepers: 1, total_runtimes: 1 },
+      configured_keepers: 1,
+      auth: null,
+      config_resolution: null,
+      runtime_resolution: null,
+    })
+    apiMocks.fetchDashboardExecution.mockResolvedValue({
+      generated_at: '2026-06-25T12:00:00Z',
+      status: { project: 'me' },
+      agents: [],
+      tasks: [],
+      messages: [],
+      keepers: [],
+      execution_queue: [],
+      worker_support_briefs: [],
+      continuity_briefs: [],
+    })
+
+    const store = await import('./store')
+
+    await store.refreshKeeperRuntimeStatus()
+
+    expect(apiMocks.fetchDashboardExecution).toHaveBeenCalledWith({ force: true })
+  })
+
   it('refreshes execution and light shell runtime status without full bootstrap', async () => {
     apiMocks.fetchDashboardShell.mockResolvedValue({
       generated_at: '2026-06-25T12:00:00Z',

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -1088,7 +1088,7 @@ export async function refreshExecution(opts?: RefreshOptions): Promise<void> {
 }
 
 export async function refreshKeeperRuntimeStatus(opts?: RefreshOptions): Promise<void> {
-  const force = opts?.force ?? false
+  const force = opts?.force ?? true
   await refreshShell({ light: true, force })
   await refreshExecution({ force })
 }

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -322,6 +322,14 @@ let init_default_strict ~config_path =
        Ok ())
 
 let runtime_state () = Atomic.get loaded_state_ref
+
+module For_testing = struct
+  type snapshot = loaded_state
+
+  let snapshot () = runtime_state ()
+  let restore snapshot = Atomic.set loaded_state_ref snapshot
+end
+
 let get_default_runtime () = (runtime_state ()).default_runtime
 let get_runtimes () = (runtime_state ()).runtimes
 let get_runtime_ids () = runtime_ids (runtime_state ()).runtimes


### PR DESCRIPTION
## Summary

- Restore `refreshKeeperRuntimeStatus()` default `force: true` after #22308.
- Keep the lighter shell-before-execution refresh path, but avoid stale post-action runtime health under the shell TTL.
- Add regression coverage for no-argument post-action refresh calls.

## Why

Keeper action surfaces call `refreshKeeperRuntimeStatus()` without arguments after pause/resume/boot/shutdown. With #22308's `force` default changed to `false`, those paths could skip the light shell refresh inside `SHELL_TTL_MS` and leave runtime-health counts stale after an operator action.

## Verification

- `pnpm exec vitest run --config vitest.config.ts src/store-dashboard-bootstrap.test.ts --no-file-parallelism --maxWorkers=1`
- `pnpm run typecheck`
- `pnpm exec eslint src/store.ts src/store-dashboard-bootstrap.test.ts` exited 0, but both files are outside the current ESLint allowlist and were reported as ignored.
