### PR TITLE
fix(runtime): implement testing snapshot

### DIFF
--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -288,6 +288,13 @@ let empty_loaded_state =
 
 let loaded_state_ref : loaded_state Atomic.t = Atomic.make empty_loaded_state
 
+module For_testing = struct
+  type snapshot = loaded_state
+
+  let snapshot () = Atomic.get loaded_state_ref
+  let restore snapshot = Atomic.set loaded_state_ref snapshot
+end
+
 let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
 let set_loaded


### PR DESCRIPTION
## Summary
- implement Runtime.For_testing.snapshot/restore declared in runtime.mli
- preserve atomic loaded-state semantics by snapshotting the immutable loaded_state record

## Evidence
- CI failure source: main Health/Lint/Build failed with runtime.mli requiring For_testing while runtime.ml did not provide it
- Local: scripts/dune-local.sh build @lib/runtime/all (pass, after rebase)
- Local: scripts/dune-local.sh build ./bin/main_eio.exe (pass before rebase; post-rebase rerun blocked by external bare dune build @check)
- Local: git diff --check (pass)

## Notes
- Scoped to lib/runtime/runtime.ml only.
- No runtime behavior change outside the testing-only module implementation.