### PR TITLE
fix(test): use supported absolute path check

### DIFF
--- a/test/test_rfc_0086_keeper_namespace_invariant.ml
+++ b/test/test_rfc_0086_keeper_namespace_invariant.ml
@@ -188,7 +188,7 @@ let test_source_path_contract_resolves_valid_relative () =
      mangles or relativizes the resolved path. *)
   let resolved = Masc_test_deps.source_path "lib/keeper" in
   check bool "source_path returns an absolute path" true
-    (Filename.is_absolute resolved);
+    (not (Filename.is_relative resolved));
   check bool "source_path lands on a real keeper directory" true
     (Sys.is_directory resolved)
 ;;


### PR DESCRIPTION
## Summary
- replace the unsupported OCaml stdlib call Filename.is_absolute with the repo-standard not (Filename.is_relative ...) check
- unblocks Health target test/test_rfc_0086_keeper_namespace_invariant.ml on OCaml 5.4.1

## Evidence
- CI Health failure from #22316: test/test_rfc_0086_keeper_namespace_invariant.ml line 191, Error: Unbound value Filename.is_absolute
- Local: git diff --check (pass)
- Local targeted dune test was attempted, but scripts/dune-local.sh refused because external bare dune processes were running outside the repo lock.