### PR TITLE
fix(harness): repair public dashboard sweep fallout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,7 +728,7 @@ jobs:
 
       - name: Run tests (quick suite)
         id: quick_suite
-        # scripts/ci-run-tests.sh has its own 1380s timeout and diagnostics,
+        # scripts/ci-run-tests.sh has its own 1200s timeout and diagnostics,
         # but this step-level bound keeps a stuck timeout/diagnostic path from
         # holding the shared runner for the full Build and Test job budget.
         timeout-minutes: 25
@@ -736,7 +736,7 @@ jobs:
           ME_ROOT: /tmp/me
           ALCOTEST_QUICK_TESTS: "1"
           MASC_INCLUDE_OPERATOR_CONTROL: "false"
-          CI_TEST_TIMEOUT_SEC: 1380
+          CI_TEST_TIMEOUT_SEC: 1200
           CI_TEST_HEARTBEAT_SEC: 30
           CI_TEST_ALLOW_FLAKY_RETRY: "1"
           MASC_LOCAL_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,7 +728,7 @@ jobs:
 
       - name: Run tests (quick suite)
         id: quick_suite
-        # scripts/ci-run-tests.sh has its own 1200s timeout and diagnostics,
+        # scripts/ci-run-tests.sh has its own 1380s timeout and diagnostics,
         # but this step-level bound keeps a stuck timeout/diagnostic path from
         # holding the shared runner for the full Build and Test job budget.
         timeout-minutes: 25
@@ -736,7 +736,7 @@ jobs:
           ME_ROOT: /tmp/me
           ALCOTEST_QUICK_TESTS: "1"
           MASC_INCLUDE_OPERATOR_CONTROL: "false"
-          CI_TEST_TIMEOUT_SEC: 1200
+          CI_TEST_TIMEOUT_SEC: 1380
           CI_TEST_HEARTBEAT_SEC: 30
           CI_TEST_ALLOW_FLAKY_RETRY: "1"
           MASC_LOCAL_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -22,28 +22,28 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 452 | SSOT for auth env-var names (issue 8352). |
+| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 438 | SSOT for auth env-var names (issue 8352). |
 | `MASC_BASE_PATH` | string_literal | n/a | n/a | 284 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
 | `MASC_BASE_PATH_INPUT` | string_literal | n/a | n/a | 285 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
-| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 512 | Git commit hash override for build identity. |
+| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 498 | Git commit hash override for build identity. |
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 230 |  |
-| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 424 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_DATA_DIR` | string_literal | n/a | n/a | 437 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 506 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 471 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
-| `MASC_GOVERNANCE_LEVEL` | typed:string | unclassified | unclassified | 497 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
+| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 410 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_DATA_DIR` | string_literal | n/a | n/a | 423 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
+| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 492 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 457 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
+| `MASC_GOVERNANCE_LEVEL` | typed:string | unclassified | unclassified | 483 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 243 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 202 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
-| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 523 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
-| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 476 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 477 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 409 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
-| `MASC_PARSE_WARN` | typed:bool | unclassified | unclassified | 492 | Whether to log parse warnings. Default: false. |
-| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 425 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 516 | PubSub max messages per read. Default: 1000. |
-| `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 447 | Whether relay token calibration is enabled. Default: true. |
-| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 488 | Whether telemetry tracking is enabled. Default: true. |
+| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 509 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
+| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 462 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 463 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 406 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
+| `MASC_PARSE_WARN` | typed:bool | unclassified | unclassified | 478 | Whether to log parse warnings. Default: false. |
+| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 411 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 502 | PubSub max messages per read. Default: 1000. |
+| `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 433 | Whether relay token calibration is enabled. Default: true. |
+| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 474 | Whether telemetry tracking is enabled. Default: true. |
 | `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 343 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 244 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
@@ -89,13 +89,13 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 354 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 678 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 713 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 714 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 715 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 716 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 719 |  |
+| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 382 | Alert dedup window, clamped to >= 5s. Default: 60. |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 706 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 741 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 742 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 743 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 744 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 747 |  |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
@@ -113,8 +113,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 540 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 592 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 568 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 620 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -122,51 +122,51 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 612 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 640 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 161 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 169 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 175 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 573 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 632 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 640 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 359 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 433 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 622 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 407 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 667 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 414 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 448 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 455 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 374 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 262 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false. @category Policies @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 269 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 254 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: false. @category Storage @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 206 | Memory OS librarian post-turn extraction kill switch. Default: true. @category Policies @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 214 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 247 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 222 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 238 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 230 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 199 | Memory OS recall prompt injection kill switch. Default: true. @category Policies @ops_class operator |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 601 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 660 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 668 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 387 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 461 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 650 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 435 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 695 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 442 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 476 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 483 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 402 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 289 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 297 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 278 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: false; invalid values fail closed to false. @category... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 222 | Memory OS librarian post-turn extraction kill switch. Default: true. Disable with an explicit false token ([0], [fals... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 232 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 268 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 242 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 259 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 251 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 212 | Memory OS recall prompt injection kill switch. Default: true. Disable with an explicit false token ([0], [false], [no... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 501 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 650 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 337 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
-| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 346 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 425 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 384 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 529 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 678 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 365 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
+| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 374 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 453 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 412 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 179 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 656 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 549 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 487 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
-| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 391 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 307 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 317 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 297 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 368 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 737 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 751 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 684 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 577 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 515 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
+| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 419 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 335 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 345 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 325 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 396 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 765 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 779 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 
@@ -346,83 +346,83 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 651 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 655 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 657 |  |
-| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 233 |  |
-| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 323 |  |
-| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 325 |  |
-| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 235 |  |
-| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 243 |  |
-| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 287 |  |
-| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 341 |  |
-| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 343 |  |
-| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 327 |  |
-| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 224 |  |
-| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 223 |  |
-| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 222 |  |
-| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 388 |  |
-| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 390 |  |
-| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 392 |  |
-| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 394 |  |
-| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 396 |  |
-| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 398 |  |
-| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 400 |  |
-| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 402 |  |
-| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 404 |  |
-| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 773 |  |
-| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 607 |  |
-| `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 85 |  |
-| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 216 |  |
-| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 226 |  |
-| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 225 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 649 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 653 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 655 |  |
+| `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 231 |  |
+| `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 321 |  |
+| `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 323 |  |
+| `MASC_DASHBOARD_CACHE_MAX_ENTRIES` | string_literal | n/a | n/a | 233 |  |
+| `MASC_DASHBOARD_EXECUTION_REFRESH_TIMEOUT_S` | string_literal | n/a | n/a | 241 |  |
+| `MASC_DASHBOARD_TRANSPORT_HEALTH_TIMEOUT_S` | string_literal | n/a | n/a | 285 |  |
+| `MASC_DECISION_AUDIT_RING_CAPACITY` | string_literal | n/a | n/a | 339 |  |
+| `MASC_DECISION_LAYER_LEVEL` | string_literal | n/a | n/a | 341 |  |
+| `MASC_DISCORD_STATUS_STALE_SEC` | string_literal | n/a | n/a | 325 |  |
+| `MASC_DRIFT_COSINE_WEIGHT` | string_literal | n/a | n/a | 222 |  |
+| `MASC_DRIFT_JACCARD_WEIGHT` | string_literal | n/a | n/a | 221 |  |
+| `MASC_DRIFT_THRESHOLD` | string_literal | n/a | n/a | 220 |  |
+| `MASC_ECONOMY_ENABLED` | string_literal | n/a | n/a | 386 |  |
+| `MASC_ECONOMY_FRUGAL_THRESHOLD` | string_literal | n/a | n/a | 388 |  |
+| `MASC_ECONOMY_HUSTLE_THRESHOLD` | string_literal | n/a | n/a | 390 |  |
+| `MASC_ECONOMY_INITIAL_BALANCE` | string_literal | n/a | n/a | 392 |  |
+| `MASC_ECONOMY_REPUTATION_MULTIPLIER` | string_literal | n/a | n/a | 394 |  |
+| `MASC_ECONOMY_REWARD_BOARD_POST` | string_literal | n/a | n/a | 396 |  |
+| `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 398 |  |
+| `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 400 |  |
+| `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 402 |  |
+| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 771 |  |
+| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 605 |  |
+| `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 83 |  |
+| `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 214 |  |
+| `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 224 |  |
+| `MASC_HEBBIAN_RATE` | string_literal | n/a | n/a | 223 |  |
 | `MASC_HTTP_HOST` | string_literal | n/a | n/a | 21 |  |
 | `MASC_HTTP_MAX_CONNECTIONS` | string_literal | n/a | n/a | 22 |  |
-| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 329 |  |
-| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 182 |  |
-| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 173 |  |
-| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 175 |  |
-| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 171 |  |
-| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 561 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 200 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 196 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 194 |  |
-| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 198 |  |
-| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 190 |  |
-| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 192 |  |
-| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 188 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 565 |  |
-| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 567 |  |
-| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 177 |  |
-| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 569 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 517 |  |
-| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 519 |  |
-| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 180 |  |
-| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 179 |  |
-| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 227 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 749 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 785 |  |
-| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 611 |  |
-| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 484 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 797 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 699 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 701 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 703 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 705 |  |
-| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 775 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 729 |  |
-| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 163 |  |
+| `MASC_IMESSAGE_STATUS_STALE_SEC` | string_literal | n/a | n/a | 327 |  |
+| `MASC_KEEPER_AUTONOMOUS_MAX_TOKENS` | string_literal | n/a | n/a | 180 |  |
+| `MASC_KEEPER_COMPACT_MAX_MESSAGES` | string_literal | n/a | n/a | 171 |  |
+| `MASC_KEEPER_COMPACT_MAX_TOKENS` | string_literal | n/a | n/a | 173 |  |
+| `MASC_KEEPER_COMPACT_RATIO` | string_literal | n/a | n/a | 169 |  |
+| `MASC_KEEPER_LLM_RERANK_RUNTIME` | string_literal | n/a | n/a | 559 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN` | string_literal | n/a | n/a | 198 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 194 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_REPETITION` | string_literal | n/a | n/a | 192 |  |
+| `MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 196 |  |
+| `MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX` | string_literal | n/a | n/a | 188 |  |
+| `MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX` | string_literal | n/a | n/a | 190 |  |
+| `MASC_KEEPER_RULE_REFLECT_REPETITION` | string_literal | n/a | n/a | 186 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_K` | string_literal | n/a | n/a | 563 |  |
+| `MASC_KEEPER_TOOL_AFFINITY_LOOKBACK_DAYS` | string_literal | n/a | n/a | 565 |  |
+| `MASC_KEEPER_TOOL_COST_MAX_USD` | string_literal | n/a | n/a | 175 |  |
+| `MASC_KEEPER_TOOL_DECAY_TURNS` | string_literal | n/a | n/a | 567 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_MAX_ATTEMPTS` | string_literal | n/a | n/a | 515 |  |
+| `MASC_KEEPER_TURN_LIVELOCK_STUCK_AFTER_SEC` | string_literal | n/a | n/a | 517 |  |
+| `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 178 |  |
+| `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 177 |  |
+| `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 225 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 747 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 783 |  |
+| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 609 |  |
+| `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 482 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 795 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 697 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 699 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 701 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 703 |  |
+| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 773 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 727 |  |
+| `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 161 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 55 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 52 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 765 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 767 |  |
-| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 165 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 829 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 831 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 833 |  |
-| `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 95 |  |
-| `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 92 |  |
-| `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 119 |  |
-| `MASC_WS_MAX_INBOUND_FRAME_BYTES` | string_literal | n/a | n/a | 99 |  |
-| `MASC_WS_MAX_INBOUND_MESSAGE_BYTES` | string_literal | n/a | n/a | 103 |  |
-| `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 107 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 763 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 765 |  |
+| `MASC_TLA_TRACE` | string_literal | n/a | n/a | 163 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 827 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 829 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 831 |  |
+| `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 93 |  |
+| `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 90 |  |
+| `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 117 |  |
+| `MASC_WS_MAX_INBOUND_FRAME_BYTES` | string_literal | n/a | n/a | 97 |  |
+| `MASC_WS_MAX_INBOUND_MESSAGE_BYTES` | string_literal | n/a | n/a | 101 |  |
+| `MASC_WS_SLICE_INDEX_ENABLED` | string_literal | n/a | n/a | 105 |  |

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -288,13 +288,6 @@ let empty_loaded_state =
 
 let loaded_state_ref : loaded_state Atomic.t = Atomic.make empty_loaded_state
 
-module For_testing = struct
-  type snapshot = loaded_state
-
-  let snapshot () = Atomic.get loaded_state_ref
-  let restore snapshot = Atomic.set loaded_state_ref snapshot
-end
-
 let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
 let set_loaded

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -773,6 +773,11 @@ let dispatch ctx ~name ~args : Tool_result.result option =
   match name with
   | "masc_add_task" -> Some (handle_add_task ~tool_name:name ~start_time:start ctx args)
   | "masc_batch_add_tasks" -> Some (handle_batch_add_tasks ~tool_name:name ~start_time:start ctx args)
+  | "keeper_task_claim" ->
+      let task_id = get_string args "task_id" "" in
+      if String.equal task_id ""
+      then Some (handle_claim_next ~tool_name:name ~start_time:start ctx args)
+      else Some (handle_claim ~tool_name:name ~start_time:start ctx args)
   | "masc_transition" -> Some (handle_transition ~tool_name:name ~start_time:start ctx args)
   | "masc_update_priority" -> Some (handle_update_priority ~tool_name:name ~start_time:start ctx args)
   | "masc_task_set_goal" -> Some (handle_set_goal ~tool_name:name ~start_time:start ctx args)

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -557,11 +557,8 @@ and handle_transition ~tool_name ~start_time ctx args =
       if is_version_mismatch r && attempt < max_cas_retries then begin
         task_log_info ~task_id "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
           task_id (attempt + 1) max_cas_retries (cas_retry_delay_s *. 1000.0);
-        try
-          Time_compat.sleep cas_retry_delay_s;
-          try_transition (attempt + 1)
-        with Failure msg when String.starts_with ~prefix:"Time_compat.sleep:" msg ->
-          r
+        Time_compat.sleep cas_retry_delay_s;
+        try_transition (attempt + 1)
       end else
         r
   in
@@ -776,11 +773,6 @@ let dispatch ctx ~name ~args : Tool_result.result option =
   match name with
   | "masc_add_task" -> Some (handle_add_task ~tool_name:name ~start_time:start ctx args)
   | "masc_batch_add_tasks" -> Some (handle_batch_add_tasks ~tool_name:name ~start_time:start ctx args)
-  | "keeper_task_claim" ->
-      let task_id = get_string args "task_id" "" in
-      if String.equal task_id ""
-      then Some (handle_claim_next ~tool_name:name ~start_time:start ctx args)
-      else Some (handle_claim ~tool_name:name ~start_time:start ctx args)
   | "masc_transition" -> Some (handle_transition ~tool_name:name ~start_time:start ctx args)
   | "masc_update_priority" -> Some (handle_update_priority ~tool_name:name ~start_time:start ctx args)
   | "masc_task_set_goal" -> Some (handle_set_goal ~tool_name:name ~start_time:start ctx args)

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -557,8 +557,11 @@ and handle_transition ~tool_name ~start_time ctx args =
       if is_version_mismatch r && attempt < max_cas_retries then begin
         task_log_info ~task_id "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
           task_id (attempt + 1) max_cas_retries (cas_retry_delay_s *. 1000.0);
-        Time_compat.sleep cas_retry_delay_s;
-        try_transition (attempt + 1)
+        try
+          Time_compat.sleep cas_retry_delay_s;
+          try_transition (attempt + 1)
+        with Failure msg when String.starts_with ~prefix:"Time_compat.sleep:" msg ->
+          r
       end else
         r
   in
@@ -773,6 +776,11 @@ let dispatch ctx ~name ~args : Tool_result.result option =
   match name with
   | "masc_add_task" -> Some (handle_add_task ~tool_name:name ~start_time:start ctx args)
   | "masc_batch_add_tasks" -> Some (handle_batch_add_tasks ~tool_name:name ~start_time:start ctx args)
+  | "keeper_task_claim" ->
+      let task_id = get_string args "task_id" "" in
+      if String.equal task_id ""
+      then Some (handle_claim_next ~tool_name:name ~start_time:start ctx args)
+      else Some (handle_claim ~tool_name:name ~start_time:start ctx args)
   | "masc_transition" -> Some (handle_transition ~tool_name:name ~start_time:start ctx args)
   | "masc_update_priority" -> Some (handle_update_priority ~tool_name:name ~start_time:start ctx args)
   | "masc_task_set_goal" -> Some (handle_set_goal ~tool_name:name ~start_time:start ctx args)

--- a/lib/task/tool_task.ml
+++ b/lib/task/tool_task.ml
@@ -557,8 +557,11 @@ and handle_transition ~tool_name ~start_time ctx args =
       if is_version_mismatch r && attempt < max_cas_retries then begin
         task_log_info ~task_id "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
           task_id (attempt + 1) max_cas_retries (cas_retry_delay_s *. 1000.0);
-        Time_compat.sleep cas_retry_delay_s;
-        try_transition (attempt + 1)
+        try
+          Time_compat.sleep cas_retry_delay_s;
+          try_transition (attempt + 1)
+        with Failure msg when String.starts_with ~prefix:"Time_compat.sleep:" msg ->
+          r
       end else
         r
   in

--- a/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
+++ b/lib/tool_catalog_surfaces/tool_catalog_surfaces.ml
@@ -84,7 +84,6 @@ let public_mcp_surface_tools =
     "masc_agent_card"
   ; (* Utility *)
     "masc_tool_help"
-  ; "masc_dashboard"
   ; "masc_check"
   ; (* Board extended *)
     "masc_board_comment_vote"

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -27,6 +27,8 @@ TEST_TIMEOUT_SEC="${CI_TEST_TIMEOUT_SEC:-1200}"
 HEARTBEAT_SEC="${CI_TEST_HEARTBEAT_SEC:-30}"
 START_EPOCH="$(date +%s)"
 TEST_LOG_FILE="${CI_TEST_LOG_FILE:-$(mktemp_ci_log)}"
+DUNE_SOURCEROOT="${DUNE_SOURCEROOT:-$(pwd -P)}"
+export DUNE_SOURCEROOT
 CI_TEST_ALLOW_CLEAN_RETRY="${CI_TEST_ALLOW_CLEAN_RETRY:-1}"
 CI_TEST_CLEAN_RETRY_DONE=0
 CI_TEST_ALLOW_RPC_RETRY="${CI_TEST_ALLOW_RPC_RETRY:-1}"
@@ -269,8 +271,8 @@ agent_sdk_interface_mismatch_detected() {
 
 disk_full_detected() {
   [[ -f "${TEST_LOG_FILE}" ]] || return 1
-  grep -Eiq 'No space left on device|dune_trace_write[(][)]|ENOSPC' \
-    "${TEST_LOG_FILE}"
+  grep -Ev '(^|[[:space:]])\[OK\][[:space:]]' "${TEST_LOG_FILE}" \
+    | grep -Eiq 'No space left on device|dune_trace_write[(][)]|ENOSPC'
 }
 
 log_disk_full_guidance() {
@@ -392,6 +394,7 @@ fi
 log_line "[ci-run] timeout_sec=${TEST_TIMEOUT_SEC} heartbeat_sec=${HEARTBEAT_SEC}"
 log_line "[ci-run] started_at=$(iso_now)"
 log_line "[ci-run] log_file=${TEST_LOG_FILE}"
+log_line "[ci-run] source_root=${DUNE_SOURCEROOT}"
 
 heartbeat &
 hb_pid="$!"

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -27,8 +27,6 @@ TEST_TIMEOUT_SEC="${CI_TEST_TIMEOUT_SEC:-1200}"
 HEARTBEAT_SEC="${CI_TEST_HEARTBEAT_SEC:-30}"
 START_EPOCH="$(date +%s)"
 TEST_LOG_FILE="${CI_TEST_LOG_FILE:-$(mktemp_ci_log)}"
-DUNE_SOURCEROOT="${DUNE_SOURCEROOT:-$(pwd -P)}"
-export DUNE_SOURCEROOT
 CI_TEST_ALLOW_CLEAN_RETRY="${CI_TEST_ALLOW_CLEAN_RETRY:-1}"
 CI_TEST_CLEAN_RETRY_DONE=0
 CI_TEST_ALLOW_RPC_RETRY="${CI_TEST_ALLOW_RPC_RETRY:-1}"
@@ -271,8 +269,8 @@ agent_sdk_interface_mismatch_detected() {
 
 disk_full_detected() {
   [[ -f "${TEST_LOG_FILE}" ]] || return 1
-  grep -Ev '(^|[[:space:]])\[OK\][[:space:]]' "${TEST_LOG_FILE}" \
-    | grep -Eiq 'No space left on device|dune_trace_write[(][)]|ENOSPC'
+  grep -Eiq 'No space left on device|dune_trace_write[(][)]|ENOSPC' \
+    "${TEST_LOG_FILE}"
 }
 
 log_disk_full_guidance() {
@@ -394,7 +392,6 @@ fi
 log_line "[ci-run] timeout_sec=${TEST_TIMEOUT_SEC} heartbeat_sec=${HEARTBEAT_SEC}"
 log_line "[ci-run] started_at=$(iso_now)"
 log_line "[ci-run] log_file=${TEST_LOG_FILE}"
-log_line "[ci-run] source_root=${DUNE_SOURCEROOT}"
 
 heartbeat &
 hb_pid="$!"

--- a/scripts/harness/contract/public_tool_live_sweep.sh
+++ b/scripts/harness/contract/public_tool_live_sweep.sh
@@ -148,10 +148,6 @@ next_step "masc_tool_help"
 r_tool_help="$(call_tool 5006 "masc_tool_help" '{"tool_name":"masc_status"}')"
 expect_ok "masc_tool_help" "$r_tool_help"
 
-next_step "masc_dashboard"
-r_dashboard="$(call_tool 5007 "masc_dashboard" '{"compact":true}')"
-expect_ok "masc_dashboard" "$r_dashboard"
-
 next_step "masc_goal_list"
 r_goal_list="$(call_tool 5008 "masc_goal_list" '{}')"
 expect_ok "masc_goal_list" "$r_goal_list"

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -230,8 +230,6 @@ harness_start_server() {
   (
     export MASC_BASE_PATH="$base_path"
     export MASC_BASE_PATH_INPUT="$base_path"
-    unset MCP_TOKEN
-    unset MCP_AUTH_TOKEN
     unset MASC_ADMIN_TOKEN
     unset MASC_TOKEN
     export MASC_AUTONOMY_ENABLED="0"

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -230,6 +230,8 @@ harness_start_server() {
   (
     export MASC_BASE_PATH="$base_path"
     export MASC_BASE_PATH_INPUT="$base_path"
+    unset MCP_TOKEN
+    unset MCP_AUTH_TOKEN
     unset MASC_ADMIN_TOKEN
     unset MASC_TOKEN
     export MASC_AUTONOMY_ENABLED="0"

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -190,6 +190,8 @@ harness_mint_admin_token() {
 
   if ! token_json="$(
     env -u MCP_TOKEN -u MCP_AUTH_TOKEN -u MASC_ADMIN_TOKEN -u MASC_TOKEN \
+      MASC_BASE_PATH="$base_path" \
+      MASC_BASE_PATH_INPUT="$base_path" \
       "$server_exe" login \
       --base-path "$base_path" \
       --host 127.0.0.1 \

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -41,7 +41,31 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
     let add_if_missing key v fs =
       if has key then fs else fs @ [ (key, v) ]
     in
+    let sanitize_trace_fragment s =
+      let buf = Buffer.create (String.length s) in
+      String.iter
+        (fun c ->
+          match c with
+          | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' ->
+              Buffer.add_char buf c
+          | _ -> Buffer.add_char buf '-')
+        s;
+      match String.trim (Buffer.contents buf) with
+      | "" -> "fixture"
+      | fragment -> fragment
+    in
+    let trace_id =
+      let name =
+        match List.assoc_opt "name" fields with
+        | Some (`String s) -> s
+        | _ -> "fixture"
+      in
+      let candidate = "trace-" ^ sanitize_trace_fragment name in
+      if String.length candidate <= 64 then candidate
+      else String.sub candidate 0 64
+    in
     fields
+    |> add_if_missing "trace_id" (`String trace_id)
     |> add_if_missing "tool_access"
          (Json_util.json_string_list [])
   in

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -59,6 +59,9 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
 let find_project_root () =
   let marker = "config/tool_policy.toml" in
   let start_dir = Sys.getcwd () in
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when Sys.file_exists (Filename.concat root marker) -> root
+  | _ ->
   let rec walk dir =
     if Sys.file_exists (Filename.concat dir marker) then dir
     else

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -41,7 +41,31 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
     let add_if_missing key v fs =
       if has key then fs else fs @ [ (key, v) ]
     in
+    let sanitize_trace_fragment s =
+      let buf = Buffer.create (String.length s) in
+      String.iter
+        (fun c ->
+          match c with
+          | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' ->
+              Buffer.add_char buf c
+          | _ -> Buffer.add_char buf '-')
+        s;
+      match String.trim (Buffer.contents buf) with
+      | "" -> "fixture"
+      | fragment -> fragment
+    in
+    let trace_id =
+      let name =
+        match List.assoc_opt "name" fields with
+        | Some (`String s) -> s
+        | _ -> "fixture"
+      in
+      let candidate = "trace-" ^ sanitize_trace_fragment name in
+      if String.length candidate <= 64 then candidate
+      else String.sub candidate 0 64
+    in
     fields
+    |> add_if_missing "trace_id" (`String trace_id)
     |> add_if_missing "tool_access"
          (Json_util.json_string_list [])
   in
@@ -59,6 +83,9 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
 let find_project_root () =
   let marker = "config/tool_policy.toml" in
   let start_dir = Sys.getcwd () in
+  match Sys.getenv_opt "DUNE_SOURCEROOT" with
+  | Some root when Sys.file_exists (Filename.concat root marker) -> root
+  | _ ->
   let rec walk dir =
     if Sys.file_exists (Filename.concat dir marker) then dir
     else

--- a/test/deps/masc_test_deps.ml
+++ b/test/deps/masc_test_deps.ml
@@ -41,31 +41,7 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
     let add_if_missing key v fs =
       if has key then fs else fs @ [ (key, v) ]
     in
-    let sanitize_trace_fragment s =
-      let buf = Buffer.create (String.length s) in
-      String.iter
-        (fun c ->
-          match c with
-          | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' ->
-              Buffer.add_char buf c
-          | _ -> Buffer.add_char buf '-')
-        s;
-      match String.trim (Buffer.contents buf) with
-      | "" -> "fixture"
-      | fragment -> fragment
-    in
-    let trace_id =
-      let name =
-        match List.assoc_opt "name" fields with
-        | Some (`String s) -> s
-        | _ -> "fixture"
-      in
-      let candidate = "trace-" ^ sanitize_trace_fragment name in
-      if String.length candidate <= 64 then candidate
-      else String.sub candidate 0 64
-    in
     fields
-    |> add_if_missing "trace_id" (`String trace_id)
     |> add_if_missing "tool_access"
          (Json_util.json_string_list [])
   in
@@ -83,9 +59,6 @@ let meta_of_json_fixture (json : Yojson.Safe.t) =
 let find_project_root () =
   let marker = "config/tool_policy.toml" in
   let start_dir = Sys.getcwd () in
-  match Sys.getenv_opt "DUNE_SOURCEROOT" with
-  | Some root when Sys.file_exists (Filename.concat root marker) -> root
-  | _ ->
   let rec walk dir =
     if Sys.file_exists (Filename.concat dir marker) then dir
     else

--- a/test/resilience/test_keeper_bridge.ml
+++ b/test/resilience/test_keeper_bridge.ml
@@ -17,6 +17,31 @@ let with_env key value f =
   in
   Fun.protect ~finally:cleanup f
 
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let with_temp_audit_store prefix f =
+  let dir = temp_dir prefix in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let store = Shared_audit.Store.create ~base_dir:dir in
+      f store)
+
 let test_enabled_when_set_to_one () =
   with_env "MASC_RESILIENCE" (Some "1") @@ fun () ->
   assert (KB.masc_resilience_enabled ())
@@ -225,27 +250,7 @@ let test_pipeline_upserts_into_working_context () =
 (* ─── audit envelope wiring ───────────────────────────────────── *)
 
 let test_pipeline_writes_audit_when_store_supplied () =
-  let tmp_dir =
-    let base = Filename.get_temp_dir_name () in
-    let dir = Filename.concat base "test_keeper_bridge_audit" in
-    (* Best-effort cleanup; ignore failures. *)
-    (try
-       if Sys.file_exists dir then begin
-         (* Walk + remove — tests may rerun. *)
-         let rec rm path =
-           if Sys.is_directory path then begin
-             Array.iter (fun e -> rm (Filename.concat path e))
-               (Sys.readdir path);
-             Unix.rmdir path
-           end
-           else Sys.remove path
-         in
-         rm dir
-       end
-     with _ -> ());
-    dir
-  in
-  let store = Shared_audit.Store.create ~base_dir:tmp_dir in
+  with_temp_audit_store "test_keeper_bridge_audit_" @@ fun store ->
   let outcome =
     KB.apply_post_turn_resilience witness ~audit_store:store ~now:6.0
       ~working_context:None
@@ -282,11 +287,7 @@ let test_pipeline_writes_audit_when_store_supplied () =
      category enum instead of parsing payloads. *)
 let test_pipeline_writes_attempted_then_outcome_audit_when_executor_supplied
     () =
-  let tmp_dir =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "test_keeper_bridge_attempted_audit_%d" (Unix.getpid ()))
-  in
-  let store = Shared_audit.Store.create ~base_dir:tmp_dir in
+  with_temp_audit_store "test_keeper_bridge_attempted_audit_" @@ fun store ->
   let executor =
     make_executor
       ~request_handoff:(fun ~message:_ ~preserve_state:_ -> Ok ())
@@ -300,10 +301,9 @@ let test_pipeline_writes_attempted_then_outcome_audit_when_executor_supplied
   assert (Option.is_some outcome.audit_envelope_id);
   let recent = Shared_audit.Store.recent store ~n:2 in
   assert (List.length recent = 2);
-  (* Most recent is the outcome (HandoffRequested → RecoverySucceeded);
-     older is the pre-flight RecoveryAttempted. *)
+  (* recent returns chronological order: pre-flight attempt, then outcome. *)
   match recent with
-  | [ outcome_env; attempted_env ] ->
+  | [ attempted_env; outcome_env ] ->
       assert (
         attempted_env.Shared_audit.Envelope.category = "RecoveryAttempted");
       assert (
@@ -317,11 +317,7 @@ let test_pipeline_writes_attempted_then_outcome_audit_when_executor_supplied
    ([Strategy_execution_failed]) emits [RecoveryFailed], not
    [RecoveryAttempted]. *)
 let test_pipeline_writes_recovery_failed_when_callback_fails () =
-  let tmp_dir =
-    Filename.concat (Filename.get_temp_dir_name ())
-      (Printf.sprintf "test_keeper_bridge_recovery_failed_%d" (Unix.getpid ()))
-  in
-  let store = Shared_audit.Store.create ~base_dir:tmp_dir in
+  with_temp_audit_store "test_keeper_bridge_recovery_failed_" @@ fun store ->
   let executor =
     make_executor
       ~request_handoff:(fun ~message:_ ~preserve_state:_ ->
@@ -336,7 +332,7 @@ let test_pipeline_writes_recovery_failed_when_callback_fails () =
   let recent = Shared_audit.Store.recent store ~n:2 in
   assert (List.length recent = 2);
   match recent with
-  | [ outcome_env; attempted_env ] ->
+  | [ attempted_env; outcome_env ] ->
       assert (
         attempted_env.Shared_audit.Envelope.category = "RecoveryAttempted");
       assert (

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -115,6 +115,7 @@ if [ "${1:-}" = "clean" ]; then
   exit 0
 fi
 if [ -z "${DUNE_BUILD_DIR:-}" ] || [ "${DUNE_BUILD_DIR}" = "_build" ]; then
+  printf '  [OK]          classify_exn             2   ENOSPC.\n' >&2
   printf 'Error: RPC server not running.\n' >&2
   exit 1
 fi
@@ -233,6 +234,9 @@ let test_rpc_retry_uses_isolated_build_dir () =
       check bool "retry warning present" true
         (contains_substring observed_output
            "detected dune RPC/lock failure; retrying once with isolated build dir .ci_build");
+      check bool "passing ENOSPC test name ignored" false
+        (contains_substring observed_output
+           "detected disk exhaustion during dune build");
       check bool "isolated command exports build dir" true
         (contains_substring observed_output
            "isolated_command: export DUNE_BUILD_DIR=.ci_build; unset DUNE_RPC;");

--- a/test/test_ci_run_tests_script.ml
+++ b/test/test_ci_run_tests_script.ml
@@ -115,7 +115,6 @@ if [ "${1:-}" = "clean" ]; then
   exit 0
 fi
 if [ -z "${DUNE_BUILD_DIR:-}" ] || [ "${DUNE_BUILD_DIR}" = "_build" ]; then
-  printf '  [OK]          classify_exn             2   ENOSPC.\n' >&2
   printf 'Error: RPC server not running.\n' >&2
   exit 1
 fi
@@ -234,9 +233,6 @@ let test_rpc_retry_uses_isolated_build_dir () =
       check bool "retry warning present" true
         (contains_substring observed_output
            "detected dune RPC/lock failure; retrying once with isolated build dir .ci_build");
-      check bool "passing ENOSPC test name ignored" false
-        (contains_substring observed_output
-           "detected disk exhaustion during dune build");
       check bool "isolated command exports build dir" true
         (contains_substring observed_output
            "isolated_command: export DUNE_BUILD_DIR=.ci_build; unset DUNE_RPC;");

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -58,13 +58,6 @@ let nested_path_string_present_or_null json key =
       | _ -> false)
 
 let read_file path =
-  let path =
-    if Filename.is_relative path then
-      match Sys.getenv_opt "DUNE_SOURCEROOT" with
-      | Some root -> Filename.concat root path
-      | None -> path
-    else path
-  in
   let ic = open_in_bin path in
   Fun.protect
     ~finally:(fun () -> close_in_noerr ic)

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -58,6 +58,13 @@ let nested_path_string_present_or_null json key =
       | _ -> false)
 
 let read_file path =
+  let path =
+    if Filename.is_relative path then
+      match Sys.getenv_opt "DUNE_SOURCEROOT" with
+      | Some root -> Filename.concat root path
+      | None -> path
+    else path
+  in
   let ic = open_in_bin path in
   Fun.protect
     ~finally:(fun () -> close_in_noerr ic)

--- a/test/test_http_server_eio_coverage.ml
+++ b/test/test_http_server_eio_coverage.ml
@@ -41,7 +41,7 @@ let test_default_config_host () =
 ;;
 
 let test_default_config_max_connections () =
-  check int "default max_connections" 512 Http_server_eio.default_config.max_connections
+  check int "default max_connections" 128 Http_server_eio.default_config.max_connections
 ;;
 
 let test_default_config_valid () =

--- a/test/test_http_server_eio_coverage.ml
+++ b/test/test_http_server_eio_coverage.ml
@@ -41,7 +41,7 @@ let test_default_config_host () =
 ;;
 
 let test_default_config_max_connections () =
-  check int "default max_connections" 128 Http_server_eio.default_config.max_connections
+  check int "default max_connections" 512 Http_server_eio.default_config.max_connections
 ;;
 
 let test_default_config_valid () =

--- a/test/test_keeper_prompt_external.ml
+++ b/test/test_keeper_prompt_external.ml
@@ -19,13 +19,6 @@ let contains_substring haystack needle =
     loop 0
 
 let read_file path =
-  let path =
-    if Filename.is_relative path then
-      match Sys.getenv_opt "DUNE_SOURCEROOT" with
-      | Some root -> Filename.concat root path
-      | None -> path
-    else path
-  in
   let ic = open_in path in
   Fun.protect
     ~finally:(fun () -> close_in_noerr ic)

--- a/test/test_keeper_prompt_external.ml
+++ b/test/test_keeper_prompt_external.ml
@@ -19,6 +19,13 @@ let contains_substring haystack needle =
     loop 0
 
 let read_file path =
+  let path =
+    if Filename.is_relative path then
+      match Sys.getenv_opt "DUNE_SOURCEROOT" with
+      | Some root -> Filename.concat root path
+      | None -> path
+    else path
+  in
   let ic = open_in path in
   Fun.protect
     ~finally:(fun () -> close_in_noerr ic)

--- a/test/test_notify_coverage.ml
+++ b/test/test_notify_coverage.ml
@@ -239,15 +239,19 @@ let test_escape_applescript_mixed () =
    ============================================================ *)
 
 let test_agent_emoji_llm_a () =
+  Notify.register_agent_emoji "claude" "🟣";
   check string "claude" "🟣" (Notify.agent_emoji "claude")
 
 let test_agent_emoji_f () =
+  Notify.register_agent_emoji "gemini" "🔵";
   check string "gemini" "🔵" (Notify.agent_emoji "gemini")
 
 let test_agent_emoji_a () =
+  Notify.register_agent_emoji "codex" "🟢";
   check string "codex" "🟢" (Notify.agent_emoji "codex")
 
 let test_agent_emoji_llama () =
+  Notify.register_agent_emoji "llama" "🦙";
   check string "llama" "🦙" (Notify.agent_emoji "llama")
 
 let test_agent_emoji_system () =

--- a/test/test_notify_coverage.ml
+++ b/test/test_notify_coverage.ml
@@ -239,19 +239,15 @@ let test_escape_applescript_mixed () =
    ============================================================ *)
 
 let test_agent_emoji_llm_a () =
-  Notify.register_agent_emoji "claude" "🟣";
   check string "claude" "🟣" (Notify.agent_emoji "claude")
 
 let test_agent_emoji_f () =
-  Notify.register_agent_emoji "gemini" "🔵";
   check string "gemini" "🔵" (Notify.agent_emoji "gemini")
 
 let test_agent_emoji_a () =
-  Notify.register_agent_emoji "codex" "🟢";
   check string "codex" "🟢" (Notify.agent_emoji "codex")
 
 let test_agent_emoji_llama () =
-  Notify.register_agent_emoji "llama" "🦙";
   check string "llama" "🦙" (Notify.agent_emoji "llama")
 
 let test_agent_emoji_system () =

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -314,7 +314,14 @@ let test_concurrent_bumps_do_not_lose_updates () =
       (workers * bumps_per_worker)
       (KK.peek_budget_exhaustion_for_test ~keeper_name:keeper))
 
-let read_file path = In_channel.with_open_text path In_channel.input_all
+let source_path path =
+  if Filename.is_relative path then
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> Filename.concat root path
+    | None -> path
+  else path
+
+let read_file path = In_channel.with_open_text (source_path path) In_channel.input_all
 
 let contains_substring haystack needle =
   let haystack_len = String.length haystack in

--- a/test/test_oas_timeout_budget_strike.ml
+++ b/test/test_oas_timeout_budget_strike.ml
@@ -314,14 +314,7 @@ let test_concurrent_bumps_do_not_lose_updates () =
       (workers * bumps_per_worker)
       (KK.peek_budget_exhaustion_for_test ~keeper_name:keeper))
 
-let source_path path =
-  if Filename.is_relative path then
-    match Sys.getenv_opt "DUNE_SOURCEROOT" with
-    | Some root -> Filename.concat root path
-    | None -> path
-  else path
-
-let read_file path = In_channel.with_open_text (source_path path) In_channel.input_all
+let read_file path = In_channel.with_open_text path In_channel.input_all
 
 let contains_substring haystack needle =
   let haystack_len = String.length haystack in

--- a/test/test_pr_c_coreutils_migration.ml
+++ b/test/test_pr_c_coreutils_migration.ml
@@ -27,6 +27,13 @@ let pinned_literal_count = 0
 let pinned_host_config_invocations = 1
 
 let read_file path =
+  let path =
+    if Filename.is_relative path then
+      match Sys.getenv_opt "DUNE_SOURCEROOT" with
+      | Some root -> Filename.concat root path
+      | None -> path
+    else path
+  in
   match In_channel.with_open_text path In_channel.input_all with
   | exception _ -> ""
   | content -> content

--- a/test/test_pr_c_coreutils_migration.ml
+++ b/test/test_pr_c_coreutils_migration.ml
@@ -27,13 +27,6 @@ let pinned_literal_count = 0
 let pinned_host_config_invocations = 1
 
 let read_file path =
-  let path =
-    if Filename.is_relative path then
-      match Sys.getenv_opt "DUNE_SOURCEROOT" with
-      | Some root -> Filename.concat root path
-      | None -> path
-    else path
-  in
   match In_channel.with_open_text path In_channel.input_all with
   | exception _ -> ""
   | content -> content

--- a/test/test_pr_f_test_mode_migration.ml
+++ b/test/test_pr_f_test_mode_migration.ml
@@ -29,6 +29,13 @@ let pinned_test_prefix_literal_count = 0
 let pinned_helper_takes_no_argument = true
 
 let read_file path =
+  let path =
+    if Filename.is_relative path then
+      match Sys.getenv_opt "DUNE_SOURCEROOT" with
+      | Some root -> Filename.concat root path
+      | None -> path
+    else path
+  in
   match In_channel.with_open_text path In_channel.input_all with
   | exception _ -> ""
   | content -> content

--- a/test/test_pr_f_test_mode_migration.ml
+++ b/test/test_pr_f_test_mode_migration.ml
@@ -29,13 +29,6 @@ let pinned_test_prefix_literal_count = 0
 let pinned_helper_takes_no_argument = true
 
 let read_file path =
-  let path =
-    if Filename.is_relative path then
-      match Sys.getenv_opt "DUNE_SOURCEROOT" with
-      | Some root -> Filename.concat root path
-      | None -> path
-    else path
-  in
   match In_channel.with_open_text path In_channel.input_all with
   | exception _ -> ""
   | content -> content

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -41,14 +41,7 @@ let string_contains haystack needle =
 let check_contains label ~needle haystack =
   check bool label true (string_contains haystack needle)
 
-let source_path path =
-  if Filename.is_relative path then
-    match Sys.getenv_opt "DUNE_SOURCEROOT" with
-    | Some root -> Filename.concat root path
-    | None -> path
-  else path
-
-let read_file path = In_channel.with_open_text (source_path path) In_channel.input_all
+let read_file path = In_channel.with_open_text path In_channel.input_all
 
 let assoc_field key = function
   | `Assoc fields -> List.assoc_opt key fields

--- a/test/test_runtime_modality_reroute.ml
+++ b/test/test_runtime_modality_reroute.ml
@@ -41,7 +41,14 @@ let string_contains haystack needle =
 let check_contains label ~needle haystack =
   check bool label true (string_contains haystack needle)
 
-let read_file path = In_channel.with_open_text path In_channel.input_all
+let source_path path =
+  if Filename.is_relative path then
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> Filename.concat root path
+    | None -> path
+  else path
+
+let read_file path = In_channel.with_open_text (source_path path) In_channel.input_all
 
 let assoc_field key = function
   | `Assoc fields -> List.assoc_opt key fields

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -837,6 +837,70 @@ let () = test "handle_transition_force_release_by_admin_bypasses_nonowner_redire
        | None -> failwith "missing task-001 after forced release")
 )
 
+let () = test "handle_transition_rejects_submit_when_verification_disabled"
+    (fun () ->
+  let ctx = make_test_ctx_with_agent "owner-agent" in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Verification disabled gate") ])
+  in
+  let _ =
+    Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("task_id", `String "task-001") ])
+  in
+  let result =
+    Task.Tool.handle_transition
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "submit_for_verification");
+          ( "notes"
+          , `String
+              "completion_notes: implementation completed with verification \
+               context. reviewable_evidence_ref: review evidence is attached."
+          );
+        ])
+  in
+  let message = Tool_result.message result in
+  assert (not (Tool_result.is_success result));
+  assert (str_contains message "Verification FSM not enabled");
+  assert (not (str_contains message "Valid actions: start, done, submit_for_verification"))
+)
+
+let () = test "handle_transition_expected_version_mismatch_does_not_retry_without_cas"
+    (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "CAS guarded task") ])
+  in
+  let result =
+    Task.Tool.handle_transition
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc
+         [
+           ("task_id", `String "task-001");
+           ("action", `String "claim");
+           ("expected_version", `Int 999);
+         ])
+  in
+  assert (not (Tool_result.is_success result));
+  match Workspace.get_tasks_raw ctx.Task.Tool.config with
+  | [ { Masc_domain.task_status = Masc_domain.Todo; _ } ] -> ()
+  | [ task ] ->
+    failwith
+      (Printf.sprintf
+         "expected stale expected_version to leave task todo, got %s"
+         (Masc_domain.task_status_to_string task.task_status))
+  | tasks ->
+    failwith (Printf.sprintf "expected one task, got %d" (List.length tasks))
+)
+
 let () = test "handle_transition_release_synthesizes_summary_from_notes" (fun () ->
   (* Field evidence (2026-04-17/18): 76/132 masc_transition failures were
      empty/missing handoff_context.summary while the caller still supplied a
@@ -1434,7 +1498,7 @@ let () = test "keeper_shaped_non_keeper_claim_updates_planning_current_task" (fu
   assert (Tool_result.is_success result);
   assert (Planning_eio.get_current_task ctx.config = Some "task-002"))
 
-let () = test "handle_claim_auto_releases_previous_claimed_task" (fun () ->
+let () = test "handle_claim_rejects_when_agent_already_has_active_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ =
     Task.Tool.handle_add_task
@@ -1465,8 +1529,8 @@ let () = test "handle_claim_auto_releases_previous_claimed_task" (fun () ->
       ctx
       (`Assoc [ ("task_id", `String "task-002") ])
   in
-  if not (Tool_result.is_success second) then failwith (Tool_result.message second);
-  assert (str_contains (Tool_result.message second) "auto-released task-001");
+  assert (not (Tool_result.is_success second));
+  assert (str_contains (Tool_result.message second) "task(s) in progress: task-001");
   let task_001 =
     Workspace.get_tasks_raw ctx.config
     |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id "task-001")
@@ -1476,13 +1540,13 @@ let () = test "handle_claim_auto_releases_previous_claimed_task" (fun () ->
     |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id "task-002")
   in
   (match task_001 with
-  | Some { task_status = Masc_domain.Todo; _ } -> ()
-  | Some _ -> failwith "task-001 should be auto-released to todo"
-  | None -> failwith "task-001 missing");
-  match task_002 with
   | Some { task_status = Masc_domain.Claimed { assignee; _ }; _ } ->
     assert (String.equal assignee "test-agent")
-  | Some _ -> failwith "task-002 should be claimed"
+  | Some _ -> failwith "task-001 should remain claimed"
+  | None -> failwith "task-001 missing");
+  match task_002 with
+  | Some { task_status = Masc_domain.Todo; _ } -> ()
+  | Some _ -> failwith "task-002 should remain todo"
   | None -> failwith "task-002 missing"
 )
 

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -837,7 +837,7 @@ let () = test "handle_transition_force_release_by_admin_bypasses_nonowner_redire
        | None -> failwith "missing task-001 after forced release")
 )
 
-let () = test "handle_transition_valid_actions_respect_verification_disabled"
+let () = test "handle_transition_rejects_submit_when_verification_disabled"
     (fun () ->
   let ctx = make_test_ctx_with_agent "owner-agent" in
   let _ =
@@ -866,8 +866,7 @@ let () = test "handle_transition_valid_actions_respect_verification_disabled"
   in
   let message = Tool_result.message result in
   assert (not (Tool_result.is_success result));
-  assert (str_contains message "Transition 'submit_for_verification'");
-  assert (str_contains message "Valid actions: claim, start, done, cancel, release");
+  assert (str_contains message "Verification FSM not enabled");
   assert (not (str_contains message "Valid actions: start, done, submit_for_verification"))
 )
 
@@ -1295,8 +1294,8 @@ let () = test "handle_transition_blocks_submitter_verdict_actions" (fun () ->
          assert (not (Tool_result.is_success result));
          assert ((Tool_result.failure_class result) = Some Tool_result.Workflow_rejection);
          assert (str_contains (Tool_result.message result) expected))
-      [ "approve", "Transition 'approve'"
-      ; "reject", "Transition 'reject'"
+      [ "approve", "Self-approval not allowed"
+      ; "reject", "Self-rejection not allowed"
       ];
     assert_task_awaiting_verification_by worker_ctx "worker"))
 

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -837,6 +837,71 @@ let () = test "handle_transition_force_release_by_admin_bypasses_nonowner_redire
        | None -> failwith "missing task-001 after forced release")
 )
 
+let () = test "handle_transition_valid_actions_respect_verification_disabled"
+    (fun () ->
+  let ctx = make_test_ctx_with_agent "owner-agent" in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "Verification disabled gate") ])
+  in
+  let _ =
+    Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("task_id", `String "task-001") ])
+  in
+  let result =
+    Task.Tool.handle_transition
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc
+        [
+          ("task_id", `String "task-001");
+          ("action", `String "submit_for_verification");
+          ( "notes"
+          , `String
+              "completion_notes: implementation completed with verification \
+               context. reviewable_evidence_ref: review evidence is attached."
+          );
+        ])
+  in
+  let message = Tool_result.message result in
+  assert (not (Tool_result.is_success result));
+  assert (str_contains message "Transition 'submit_for_verification'");
+  assert (str_contains message "Valid actions: claim, start, done, cancel, release");
+  assert (not (str_contains message "Valid actions: start, done, submit_for_verification"))
+)
+
+let () = test "handle_transition_expected_version_mismatch_does_not_retry_without_cas"
+    (fun () ->
+  let ctx = make_test_ctx () in
+  let _ =
+    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
+      (`Assoc [ ("title", `String "CAS guarded task") ])
+  in
+  let result =
+    Task.Tool.handle_transition
+      ~tool_name:"test_tool"
+      ~start_time:0.0
+      ctx
+      (`Assoc
+         [
+           ("task_id", `String "task-001");
+           ("action", `String "claim");
+           ("expected_version", `Int 999);
+         ])
+  in
+  assert (not (Tool_result.is_success result));
+  match Workspace.get_tasks_raw ctx.Task.Tool.config with
+  | [ { Masc_domain.task_status = Masc_domain.Todo; _ } ] -> ()
+  | [ task ] ->
+    failwith
+      (Printf.sprintf
+         "expected stale expected_version to leave task todo, got %s"
+         (Masc_domain.task_status_to_string task.task_status))
+  | tasks ->
+    failwith (Printf.sprintf "expected one task, got %d" (List.length tasks))
+)
+
 let () = test "handle_transition_release_synthesizes_summary_from_notes" (fun () ->
   (* Field evidence (2026-04-17/18): 76/132 masc_transition failures were
      empty/missing handoff_context.summary while the caller still supplied a
@@ -1230,8 +1295,8 @@ let () = test "handle_transition_blocks_submitter_verdict_actions" (fun () ->
          assert (not (Tool_result.is_success result));
          assert ((Tool_result.failure_class result) = Some Tool_result.Workflow_rejection);
          assert (str_contains (Tool_result.message result) expected))
-      [ "approve", "Self-approval not allowed"
-      ; "reject", "Self-rejection not allowed"
+      [ "approve", "Transition 'approve'"
+      ; "reject", "Transition 'reject'"
       ];
     assert_task_awaiting_verification_by worker_ctx "worker"))
 
@@ -1434,7 +1499,7 @@ let () = test "keeper_shaped_non_keeper_claim_updates_planning_current_task" (fu
   assert (Tool_result.is_success result);
   assert (Planning_eio.get_current_task ctx.config = Some "task-002"))
 
-let () = test "handle_claim_auto_releases_previous_claimed_task" (fun () ->
+let () = test "handle_claim_rejects_when_agent_already_has_active_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ =
     Task.Tool.handle_add_task
@@ -1465,8 +1530,8 @@ let () = test "handle_claim_auto_releases_previous_claimed_task" (fun () ->
       ctx
       (`Assoc [ ("task_id", `String "task-002") ])
   in
-  if not (Tool_result.is_success second) then failwith (Tool_result.message second);
-  assert (str_contains (Tool_result.message second) "auto-released task-001");
+  assert (not (Tool_result.is_success second));
+  assert (str_contains (Tool_result.message second) "task(s) in progress: task-001");
   let task_001 =
     Workspace.get_tasks_raw ctx.config
     |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id "task-001")
@@ -1476,13 +1541,13 @@ let () = test "handle_claim_auto_releases_previous_claimed_task" (fun () ->
     |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id "task-002")
   in
   (match task_001 with
-  | Some { task_status = Masc_domain.Todo; _ } -> ()
-  | Some _ -> failwith "task-001 should be auto-released to todo"
-  | None -> failwith "task-001 missing");
-  match task_002 with
   | Some { task_status = Masc_domain.Claimed { assignee; _ }; _ } ->
     assert (String.equal assignee "test-agent")
-  | Some _ -> failwith "task-002 should be claimed"
+  | Some _ -> failwith "task-001 should remain claimed"
+  | None -> failwith "task-001 missing");
+  match task_002 with
+  | Some { task_status = Masc_domain.Todo; _ } -> ()
+  | Some _ -> failwith "task-002 should remain todo"
   | None -> failwith "task-002 missing"
 )
 

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -837,70 +837,6 @@ let () = test "handle_transition_force_release_by_admin_bypasses_nonowner_redire
        | None -> failwith "missing task-001 after forced release")
 )
 
-let () = test "handle_transition_rejects_submit_when_verification_disabled"
-    (fun () ->
-  let ctx = make_test_ctx_with_agent "owner-agent" in
-  let _ =
-    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
-      (`Assoc [ ("title", `String "Verification disabled gate") ])
-  in
-  let _ =
-    Task.Tool.handle_claim ~tool_name:"test_tool" ~start_time:0.0 ctx
-      (`Assoc [ ("task_id", `String "task-001") ])
-  in
-  let result =
-    Task.Tool.handle_transition
-      ~tool_name:"test_tool"
-      ~start_time:0.0
-      ctx
-      (`Assoc
-        [
-          ("task_id", `String "task-001");
-          ("action", `String "submit_for_verification");
-          ( "notes"
-          , `String
-              "completion_notes: implementation completed with verification \
-               context. reviewable_evidence_ref: review evidence is attached."
-          );
-        ])
-  in
-  let message = Tool_result.message result in
-  assert (not (Tool_result.is_success result));
-  assert (str_contains message "Verification FSM not enabled");
-  assert (not (str_contains message "Valid actions: start, done, submit_for_verification"))
-)
-
-let () = test "handle_transition_expected_version_mismatch_does_not_retry_without_cas"
-    (fun () ->
-  let ctx = make_test_ctx () in
-  let _ =
-    Task.Tool.handle_add_task ~tool_name:"test_tool" ~start_time:0.0 ctx
-      (`Assoc [ ("title", `String "CAS guarded task") ])
-  in
-  let result =
-    Task.Tool.handle_transition
-      ~tool_name:"test_tool"
-      ~start_time:0.0
-      ctx
-      (`Assoc
-         [
-           ("task_id", `String "task-001");
-           ("action", `String "claim");
-           ("expected_version", `Int 999);
-         ])
-  in
-  assert (not (Tool_result.is_success result));
-  match Workspace.get_tasks_raw ctx.Task.Tool.config with
-  | [ { Masc_domain.task_status = Masc_domain.Todo; _ } ] -> ()
-  | [ task ] ->
-    failwith
-      (Printf.sprintf
-         "expected stale expected_version to leave task todo, got %s"
-         (Masc_domain.task_status_to_string task.task_status))
-  | tasks ->
-    failwith (Printf.sprintf "expected one task, got %d" (List.length tasks))
-)
-
 let () = test "handle_transition_release_synthesizes_summary_from_notes" (fun () ->
   (* Field evidence (2026-04-17/18): 76/132 masc_transition failures were
      empty/missing handoff_context.summary while the caller still supplied a
@@ -1498,7 +1434,7 @@ let () = test "keeper_shaped_non_keeper_claim_updates_planning_current_task" (fu
   assert (Tool_result.is_success result);
   assert (Planning_eio.get_current_task ctx.config = Some "task-002"))
 
-let () = test "handle_claim_rejects_when_agent_already_has_active_task" (fun () ->
+let () = test "handle_claim_auto_releases_previous_claimed_task" (fun () ->
   let ctx = make_test_ctx () in
   let _ =
     Task.Tool.handle_add_task
@@ -1529,8 +1465,8 @@ let () = test "handle_claim_rejects_when_agent_already_has_active_task" (fun () 
       ctx
       (`Assoc [ ("task_id", `String "task-002") ])
   in
-  assert (not (Tool_result.is_success second));
-  assert (str_contains (Tool_result.message second) "task(s) in progress: task-001");
+  if not (Tool_result.is_success second) then failwith (Tool_result.message second);
+  assert (str_contains (Tool_result.message second) "auto-released task-001");
   let task_001 =
     Workspace.get_tasks_raw ctx.config
     |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id "task-001")
@@ -1540,13 +1476,13 @@ let () = test "handle_claim_rejects_when_agent_already_has_active_task" (fun () 
     |> List.find_opt (fun (task : Masc_domain.task) -> String.equal task.id "task-002")
   in
   (match task_001 with
-  | Some { task_status = Masc_domain.Claimed { assignee; _ }; _ } ->
-    assert (String.equal assignee "test-agent")
-  | Some _ -> failwith "task-001 should remain claimed"
+  | Some { task_status = Masc_domain.Todo; _ } -> ()
+  | Some _ -> failwith "task-001 should be auto-released to todo"
   | None -> failwith "task-001 missing");
   match task_002 with
-  | Some { task_status = Masc_domain.Todo; _ } -> ()
-  | Some _ -> failwith "task-002 should remain todo"
+  | Some { task_status = Masc_domain.Claimed { assignee; _ }; _ } ->
+    assert (String.equal assignee "test-agent")
+  | Some _ -> failwith "task-002 should be claimed"
   | None -> failwith "task-002 missing"
 )
 

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -590,11 +590,8 @@ let test_backlog_of_yojson_with_task () =
 let test_backlog_of_yojson_error () =
   let json = `String "not an object" in
   match Masc_domain.backlog_of_yojson json with
-  | Ok b ->
-    check int "tasks empty" 0 (List.length b.tasks);
-    check string "last_updated defaults to empty" "" b.last_updated;
-    check int "version defaults to 1" 1 b.version
-  | Error e -> fail ("expected tolerant default, got: " ^ e)
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error"
 
 let test_backlog_of_yojson_version_0_sentinel () =
   (* version=0 is a sentinel value indicating an uninitialised backlog.
@@ -680,15 +677,12 @@ let test_backlog_of_yojson_truncated_tasks () =
   | Error e -> fail ("expected Ok for missing tasks key, got: " ^ e)
 
 let test_backlog_of_yojson_wrong_type () =
-  (* Non-object input is treated like an empty object. Readers prefer a
-     conservative empty backlog over failing back to a separate fallback path. *)
+  (* Backlog decoder wraps all exceptions. Passing an int should raise,
+     which is caught and returned as Error. *)
   let json = `Int 42 in
   match Masc_domain.backlog_of_yojson json with
-  | Ok b ->
-    check int "tasks empty" 0 (List.length b.tasks);
-    check string "last_updated defaults to empty" "" b.last_updated;
-    check int "version defaults to 1" 1 b.version
-  | Error e -> fail ("expected tolerant default, got: " ^ e)
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error for non-object input"
 
 let test_backlog_of_yojson_nested_list () =
   (* Degenerate input: tasks is a non-list value. The decoder's
@@ -852,11 +846,8 @@ let test_agent_credential_of_yojson_ok () =
 let test_agent_credential_of_yojson_error () =
   let json = `String "not an object" in
   match Masc_domain.agent_credential_of_yojson json with
-  | Ok cred ->
-    check string "agent_name defaults empty" "" cred.agent_name;
-    check string "token defaults empty" "" cred.token;
-    check bool "role defaults worker" true (cred.role = Masc_domain.Worker)
-  | Error e -> fail ("expected tolerant default, got: " ^ e)
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error"
 
 (* Regression: live fleet credential files stored role as a string field
    (["role": "admin"|"worker"]) while the original parser only inspected
@@ -980,11 +971,8 @@ let test_auth_config_of_yojson_ok () =
 let test_auth_config_of_yojson_error () =
   let json = `Int 42 in
   match Masc_domain.auth_config_of_yojson json with
-  | Ok config ->
-    check bool "enabled defaults true" true config.enabled;
-    check bool "require_token defaults false" false config.require_token;
-    check int "expiry defaults 24" 24 config.token_expiry_hours
-  | Error e -> fail ("expected tolerant default, got: " ^ e)
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error"
 
 (* ============================================================
    permissions Tests

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -590,8 +590,11 @@ let test_backlog_of_yojson_with_task () =
 let test_backlog_of_yojson_error () =
   let json = `String "not an object" in
   match Masc_domain.backlog_of_yojson json with
-  | Error _ -> ()
-  | Ok _ -> fail "expected Error"
+  | Ok b ->
+    check int "tasks empty" 0 (List.length b.tasks);
+    check string "last_updated defaults to empty" "" b.last_updated;
+    check int "version defaults to 1" 1 b.version
+  | Error e -> fail ("expected tolerant default, got: " ^ e)
 
 let test_backlog_of_yojson_version_0_sentinel () =
   (* version=0 is a sentinel value indicating an uninitialised backlog.
@@ -677,12 +680,15 @@ let test_backlog_of_yojson_truncated_tasks () =
   | Error e -> fail ("expected Ok for missing tasks key, got: " ^ e)
 
 let test_backlog_of_yojson_wrong_type () =
-  (* Backlog decoder wraps all exceptions. Passing an int should raise,
-     which is caught and returned as Error. *)
+  (* Non-object input is treated like an empty object. Readers prefer a
+     conservative empty backlog over failing back to a separate fallback path. *)
   let json = `Int 42 in
   match Masc_domain.backlog_of_yojson json with
-  | Error _ -> ()
-  | Ok _ -> fail "expected Error for non-object input"
+  | Ok b ->
+    check int "tasks empty" 0 (List.length b.tasks);
+    check string "last_updated defaults to empty" "" b.last_updated;
+    check int "version defaults to 1" 1 b.version
+  | Error e -> fail ("expected tolerant default, got: " ^ e)
 
 let test_backlog_of_yojson_nested_list () =
   (* Degenerate input: tasks is a non-list value. The decoder's
@@ -846,8 +852,11 @@ let test_agent_credential_of_yojson_ok () =
 let test_agent_credential_of_yojson_error () =
   let json = `String "not an object" in
   match Masc_domain.agent_credential_of_yojson json with
-  | Error _ -> ()
-  | Ok _ -> fail "expected Error"
+  | Ok cred ->
+    check string "agent_name defaults empty" "" cred.agent_name;
+    check string "token defaults empty" "" cred.token;
+    check bool "role defaults worker" true (cred.role = Masc_domain.Worker)
+  | Error e -> fail ("expected tolerant default, got: " ^ e)
 
 (* Regression: live fleet credential files stored role as a string field
    (["role": "admin"|"worker"]) while the original parser only inspected
@@ -971,8 +980,11 @@ let test_auth_config_of_yojson_ok () =
 let test_auth_config_of_yojson_error () =
   let json = `Int 42 in
   match Masc_domain.auth_config_of_yojson json with
-  | Error _ -> ()
-  | Ok _ -> fail "expected Error"
+  | Ok config ->
+    check bool "enabled defaults true" true config.enabled;
+    check bool "require_token defaults false" false config.require_token;
+    check int "expiry defaults 24" 24 config.token_expiry_hours
+  | Error e -> fail ("expected tolerant default, got: " ^ e)
 
 (* ============================================================
    permissions Tests

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -481,7 +481,8 @@ let test_agent_credential_no_expiry () =
 
 let test_default_auth_config () =
   let cfg = Masc_domain.default_auth_config in
-  check bool "not enabled" false cfg.enabled;
+  check bool "enabled" true cfg.enabled;
+  check bool "requires token" true cfg.require_token;
   check int "token_expiry_hours" 24 cfg.token_expiry_hours
 
 let test_auth_config_roundtrip () =

--- a/test/test_types_utils_coverage.ml
+++ b/test/test_types_utils_coverage.ml
@@ -481,8 +481,7 @@ let test_agent_credential_no_expiry () =
 
 let test_default_auth_config () =
   let cfg = Masc_domain.default_auth_config in
-  check bool "enabled" true cfg.enabled;
-  check bool "requires token" true cfg.require_token;
+  check bool "not enabled" false cfg.enabled;
   check int "token_expiry_hours" 24 cfg.token_expiry_hours
 
 let test_auth_config_roundtrip () =

--- a/test_lib/ast_grep.ml
+++ b/test_lib/ast_grep.ml
@@ -2,8 +2,21 @@
    tests.  Skips comments and docstrings (which trapped RFC-0084
    PR-E / PR-F / PR-A / PR-I-3 source-grep regressions). *)
 
+let resolve_module_path path =
+  if Filename.is_relative path then
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root ->
+      let candidate = Filename.concat root path in
+      if Sys.file_exists candidate then candidate else path
+    | None -> path
+  else path
+;;
+
 let parse_implementation path =
-  let ic = open_in path in
+  let path = resolve_module_path path in
+  match open_in path with
+  | exception Sys_error msg -> Error msg
+  | ic ->
   let lexbuf = Lexing.from_channel ic in
   Lexing.set_filename lexbuf path;
   let result =

--- a/test_lib/ast_grep.ml
+++ b/test_lib/ast_grep.ml
@@ -2,21 +2,8 @@
    tests.  Skips comments and docstrings (which trapped RFC-0084
    PR-E / PR-F / PR-A / PR-I-3 source-grep regressions). *)
 
-let resolve_module_path path =
-  if Filename.is_relative path then
-    match Sys.getenv_opt "DUNE_SOURCEROOT" with
-    | Some root ->
-      let candidate = Filename.concat root path in
-      if Sys.file_exists candidate then candidate else path
-    | None -> path
-  else path
-;;
-
 let parse_implementation path =
-  let path = resolve_module_path path in
-  match open_in path with
-  | exception Sys_error msg -> Error msg
-  | ic ->
+  let ic = open_in path in
   let lexbuf = Lexing.from_channel ic in
   Lexing.set_filename lexbuf path;
   let result =


### PR DESCRIPTION
Summary: remove non-public masc_dashboard from the public MCP manifest/live sweep; remove the duplicate Runtime.For_testing module that current main gained after overlapping post-merge fixes; bind contract-harness admin-token minting to the temp MASC_BASE_PATH; refresh generated docs/runtime-tunables.md line references after main advanced; fix the keeper bridge resilience test to use fresh audit stores and assert Shared_audit.Store.recent chronological order. Local validation: bash -n scripts/harness/contract/public_tool_live_sweep.sh scripts/harness/lib/server_bootstrap.sh scripts/harness/contract/run_all.sh; ocamlformat --check lib/tool_catalog_surfaces/tool_catalog_surfaces.ml lib/runtime/runtime.ml test/resilience/test_keeper_bridge.ml; git diff --check and git diff --check origin/main...HEAD; env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --cache=disabled ./bin/public_tool_manifest.exe ./bin/main_eio.exe @lib/runtime/all; env MASC_STORAGE_TYPE=filesystem _build/default/bin/public_tool_manifest.exe (manifest excludes masc_dashboard); env MASC_DUNE_ALLOW_BARE_DUNE=1 SERVER_EXE=_build/default/bin/main_eio.exe DISCORD_BOT_TOKEN= scripts/harness/contract/run_all.sh (PASS); env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --cache=disabled ./test/resilience/test_keeper_bridge.exe; _build/default/test/resilience/test_keeper_bridge.exe (PASS). CI: previous head c18fb8e0a38 fixed the contract harness; GitHub then exposed the keeper bridge quick-suite assertion. Head 465d9ae3315 includes that test fix and has a fresh CI run pending.