### PR TITLE
fix(memory-os): surface recall failures

### DIFF
--- a/config/prompts/keeper.memory_os_recall.unavailable.md
+++ b/config/prompts/keeper.memory_os_recall.unavailable.md
@@ -1,0 +1,9 @@
+---
+description: Keeper Memory OS recall unavailable advisory
+category: keeper
+template_variables: [reason]
+---
+
+--- Memory OS Recall ---
+Historical memory recall is unavailable for this turn (reason={{reason}}).
+Continue using current live context only; do not infer missing facts from memory absence.

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -144,6 +144,25 @@ let render_prompt_template key variables =
   | Error msg -> Error (Printf.sprintf "%s: %s" key msg)
 ;;
 
+let render_unavailable_context ~reason =
+  let reason = sanitize_atom reason in
+  let reason = if String.equal reason "" then "unknown" else reason in
+  match
+    render_prompt_template
+      Keeper_prompt_names.memory_os_recall_unavailable
+      [ "reason", reason ]
+  with
+  | Ok text -> text
+  | Error msg ->
+    Log.Keeper.warn "memory os recall unavailable prompt unavailable: %s" msg;
+    Printf.sprintf
+      "--- Memory OS Recall ---\n\
+       Historical memory recall is unavailable for this turn (reason=%s).\n\
+       Continue using current live context only; do not infer missing facts from memory \
+       absence."
+      reason
+;;
+
 let render_nonempty_section key variable lines =
   match lines with
   | [] -> Ok ""
@@ -296,9 +315,9 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
       (fun (e : episode) -> Printf.sprintf "%s:g%d" e.trace_id e.generation)
       episodes
   in
-  let block =
+  let block, injected_fact_keys, injected_episode_keys =
     match facts, shared_facts, episodes with
-    | [], [], [] -> ""
+    | [], [], [] -> "", [], []
     | _ ->
       let fact_lines =
         List.map (render_fact ~now) facts
@@ -306,10 +325,10 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
       in
       let episode_lines = List.map render_episode episodes in
       (match render_recall_context ~fact_lines ~episode_lines with
-       | Ok context -> context
+       | Ok context -> context, injected_fact_keys, injected_episode_keys
        | Error msg ->
          Log.Keeper.warn "memory os recall prompt unavailable keeper=%s: %s" keeper_id msg;
-         "")
+         render_unavailable_context ~reason:"prompt_render_error", [], [])
   in
   { block; injected_fact_keys; injected_episode_keys; n_facts_in_store }
 ;;
@@ -328,7 +347,7 @@ let render_context
       "memory os recall unavailable keeper=%s: %s"
       keeper_id
       (Printexc.to_string exn);
-    ""
+    render_unavailable_context ~reason:"read_error"
 ;;
 
 let enabled () =
@@ -360,7 +379,7 @@ let render_if_enabled ~keeper_id ~now ~trace_id ~turn ~masc_root () =
           "memory os recall unavailable keeper=%s: %s"
           keeper_id
           (Printexc.to_string exn);
-        { block = ""
+        { block = render_unavailable_context ~reason:"read_error"
         ; injected_fact_keys = []
         ; injected_episode_keys = []
         ; n_facts_in_store = 0

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -50,6 +50,22 @@ let sanitize_atom text =
     | c -> c)
 ;;
 
+type unavailable_reason =
+  | Read_error
+  | Prompt_render_error
+
+let unavailable_reason_to_label = function
+  | Read_error -> "read_error"
+  | Prompt_render_error -> "prompt_render_error"
+;;
+
+let record_unavailable reason =
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string MemoryOsRecallUnavailable)
+    ~labels:[ "reason", unavailable_reason_to_label reason ]
+    ()
+;;
+
 let episode_is_current ~now (episode : episode) =
   match episode.valid_until with
   | None -> true
@@ -144,9 +160,9 @@ let render_prompt_template key variables =
   | Error msg -> Error (Printf.sprintf "%s: %s" key msg)
 ;;
 
-let render_unavailable_context ~reason =
-  let reason = sanitize_atom reason in
-  let reason = if String.equal reason "" then "unknown" else reason in
+let render_unavailable_context reason =
+  record_unavailable reason;
+  let reason = unavailable_reason_to_label reason in
   match
     render_prompt_template
       Keeper_prompt_names.memory_os_recall_unavailable
@@ -156,10 +172,7 @@ let render_unavailable_context ~reason =
   | Error msg ->
     Log.Keeper.warn "memory os recall unavailable prompt unavailable: %s" msg;
     Printf.sprintf
-      "--- Memory OS Recall ---\n\
-       Historical memory recall is unavailable for this turn (reason=%s).\n\
-       Continue using current live context only; do not infer missing facts from memory \
-       absence."
+      "--- Memory OS Recall ---\nMemory recall unavailable (reason=%s)."
       reason
 ;;
 
@@ -238,6 +251,7 @@ type render_result =
   ; injected_fact_keys : string list
   ; injected_episode_keys : string list
   ; n_facts_in_store : int
+  ; failure_reason : unavailable_reason option
   }
 
 let with_fact_store_locks keeper_ids f =
@@ -315,9 +329,9 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
       (fun (e : episode) -> Printf.sprintf "%s:g%d" e.trace_id e.generation)
       episodes
   in
-  let block, injected_fact_keys, injected_episode_keys =
+  let block, injected_fact_keys, injected_episode_keys, failure_reason =
     match facts, shared_facts, episodes with
-    | [], [], [] -> "", [], []
+    | [], [], [] -> "", [], [], None
     | _ ->
       let fact_lines =
         List.map (render_fact ~now) facts
@@ -325,12 +339,15 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
       in
       let episode_lines = List.map render_episode episodes in
       (match render_recall_context ~fact_lines ~episode_lines with
-       | Ok context -> context, injected_fact_keys, injected_episode_keys
+       | Ok context -> context, injected_fact_keys, injected_episode_keys, None
        | Error msg ->
          Log.Keeper.warn "memory os recall prompt unavailable keeper=%s: %s" keeper_id msg;
-         render_unavailable_context ~reason:"prompt_render_error", [], [])
+         ( render_unavailable_context Prompt_render_error
+         , []
+         , []
+         , Some Prompt_render_error ))
   in
-  { block; injected_fact_keys; injected_episode_keys; n_facts_in_store }
+  { block; injected_fact_keys; injected_episode_keys; n_facts_in_store; failure_reason }
 ;;
 
 let render_context
@@ -347,7 +364,7 @@ let render_context
       "memory os recall unavailable keeper=%s: %s"
       keeper_id
       (Printexc.to_string exn);
-    render_unavailable_context ~reason:"read_error"
+    render_unavailable_context Read_error
 ;;
 
 let enabled () =
@@ -379,16 +396,18 @@ let render_if_enabled ~keeper_id ~now ~trace_id ~turn ~masc_root () =
           "memory os recall unavailable keeper=%s: %s"
           keeper_id
           (Printexc.to_string exn);
-        { block = render_unavailable_context ~reason:"read_error"
+        { block = render_unavailable_context Read_error
         ; injected_fact_keys = []
         ; injected_episode_keys = []
         ; n_facts_in_store = 0
+        ; failure_reason = Some Read_error
         }
     in
     match String.trim result.block with
     | "" -> None
     | block ->
       Keeper_recall_injection_ledger.append
+        ?failure_reason:(Option.map unavailable_reason_to_label result.failure_reason)
         ~masc_root
         ~keeper_id
         ~trace_id
@@ -396,6 +415,7 @@ let render_if_enabled ~keeper_id ~now ~trace_id ~turn ~masc_root () =
         ~injected_fact_keys:result.injected_fact_keys
         ~injected_episode_keys:result.injected_episode_keys
         ~n_facts_in_store:result.n_facts_in_store
-        ~now;
+        ~now
+        ();
       Some block)
 ;;

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -40,7 +40,9 @@ val render_if_enabled
   -> string option
 (** [render_if_enabled ~keeper_id ~now ~trace_id ~turn ~masc_root ()] is
     [Some block] when the flag is on and the store yields advisory content,
-    [None] otherwise. Intended for the [extra_system_context] assembly site.
+    [Some block] with a sanitized unavailable advisory when recall fails after
+    the flag is on, and [None] when disabled or when no memory exists. Intended
+    for the [extra_system_context] assembly site.
     As a side effect (RFC-0264 P2) it appends a best-effort recall-injection
     record — which fact/episode keys reached the prompt — keyed by
     [trace_id]/[turn]; the write never affects the returned block. *)

--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -6,6 +6,7 @@
 let recall_injections_dir masc_root = Filename.concat masc_root "recall_injections"
 
 let to_json
+      ?failure_reason
       ~keeper_id
       ~trace_id
       ~turn
@@ -13,9 +14,10 @@ let to_json
       ~injected_episode_keys
       ~n_facts_in_store
       ~now
+      ()
   : Yojson.Safe.t
   =
-  `Assoc
+  let fields =
     [ "keeper_id", `String keeper_id
     ; "trace_id", `String trace_id
     ; "turn", `Int turn
@@ -24,9 +26,17 @@ let to_json
     ; "n_facts_in_store", `Int n_facts_in_store
     ; "ts", `Float now
     ]
+  in
+  let fields =
+    match failure_reason with
+    | None -> fields
+    | Some reason -> fields @ [ "failure_reason", `String reason ]
+  in
+  `Assoc fields
 ;;
 
 let append
+      ?failure_reason
       ~masc_root
       ~keeper_id
       ~trace_id
@@ -35,10 +45,12 @@ let append
       ~injected_episode_keys
       ~n_facts_in_store
       ~now
+      ()
   =
   let store = Dated_jsonl.create ~base_dir:(recall_injections_dir masc_root) () in
   let entry =
     to_json
+      ?failure_reason
       ~keeper_id
       ~trace_id
       ~turn
@@ -46,6 +58,7 @@ let append
       ~injected_episode_keys
       ~n_facts_in_store
       ~now
+      ()
   in
   try Dated_jsonl.append store entry with
   | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -15,21 +15,13 @@
       registry as the cost / receipt appenders.
     - Deterministic: keys are [claim_identity] outputs (the identity SSOT — the
       producer [claim_id] when present, else [normalize_claim]) and [trace_id:gN]
-      episode keys, so the same trace renders a byte-identical record. *)
+      episode keys, so the same trace renders a byte-identical record.
+    - Failure-visible: when recall returns an unavailable advisory, the optional
+      [failure_reason] records the bounded reason label instead of making the
+      side-effect record look like an empty successful injection. *)
 
 val to_json
-  :  keeper_id:string
-  -> trace_id:string
-  -> turn:int
-  -> injected_fact_keys:string list
-  -> injected_episode_keys:string list
-  -> n_facts_in_store:int
-  -> now:float
-  -> Yojson.Safe.t
-(** Pure record serialiser. Exposed for round-trip tests. *)
-
-val append
-  :  masc_root:string
+  :  ?failure_reason:string
   -> keeper_id:string
   -> trace_id:string
   -> turn:int
@@ -37,6 +29,22 @@ val append
   -> injected_episode_keys:string list
   -> n_facts_in_store:int
   -> now:float
+  -> unit
+  -> Yojson.Safe.t
+(** Pure record serialiser. Exposed for round-trip tests. [failure_reason],
+    when present, is a bounded reason label from the recall renderer. *)
+
+val append
+  :  ?failure_reason:string
+  -> masc_root:string
+  -> keeper_id:string
+  -> trace_id:string
+  -> turn:int
+  -> injected_fact_keys:string list
+  -> injected_episode_keys:string list
+  -> n_facts_in_store:int
+  -> now:float
+  -> unit
   -> unit
 (** Append one injection record. Best-effort: never raises except to re-raise
     [Eio.Cancel.Cancelled]. *)

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -223,6 +223,7 @@ type t =
   | TurnCleanupFailures
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
+  | MemoryOsRecallUnavailable
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts
@@ -474,6 +475,8 @@ let to_string = function
       "masc_keeper_memory_bank_load_history_swallowed_exceptions_total"
   | MemoryRecallReadErrors ->
       "masc_keeper_memory_recall_read_errors_total"
+  | MemoryOsRecallUnavailable ->
+      "masc_keeper_memory_os_recall_unavailable_total"
   | RuntimeHttpProbeJsonParseFailures ->
       "masc_runtime_http_probe_json_parse_failures_total"
   | VisionAnalyze -> "masc_keeper_vision_analyze_total"
@@ -546,7 +549,7 @@ let all : t list =
     TurnGateRejectedTerminal; ReceiptUnmappedDisposition; ExecuteNetworkUpgrade; ExecuteLocalExecution;
     DockerRuntimeDiscarded; ProactiveSkip; NoProgressLoopDetected; NoProgressStreak; UsageTrust;
     UsageAnomalyReason; ConfigEnvParseFailures; PostTurnWireinFailures; RecurringFailures;
-    TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; RuntimeHttpProbeJsonParseFailures;
+    TurnCleanupFailures; MemoryBankLoadHistorySwallowedExceptions; MemoryRecallReadErrors; MemoryOsRecallUnavailable; RuntimeHttpProbeJsonParseFailures;
     VisionAnalyze; VisionCandidateAttempts; VisionIngestEvictions; PromptSegmentBytes; PromptTemplateRenderOutcome; ToolCallParamCompleteness; KeeperTurnInstructionHash;
     KeeperToolCallRetryLoop; AttemptWatchdogFired; ShellIrEffectTotal
   ]

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -214,6 +214,7 @@ type t =
   | TurnCleanupFailures
   | MemoryBankLoadHistorySwallowedExceptions
   | MemoryRecallReadErrors
+  | MemoryOsRecallUnavailable
   | RuntimeHttpProbeJsonParseFailures
   | VisionAnalyze
   | VisionCandidateAttempts

--- a/lib/keeper_metrics/keeper_prompt_names.ml
+++ b/lib/keeper_metrics/keeper_prompt_names.ml
@@ -22,6 +22,7 @@ let librarian_memory_consolidation = "keeper.librarian.memory_consolidation"
 let memory_os_recall_context = "keeper.memory_os_recall.context"
 let memory_os_recall_facts_section = "keeper.memory_os_recall.facts_section"
 let memory_os_recall_episodes_section = "keeper.memory_os_recall.episodes_section"
+let memory_os_recall_unavailable = "keeper.memory_os_recall.unavailable"
 
 (** Turn-intent substitution prose files. Each holds a single bullet (or
     short block) that the OCaml side injects into [turn_intent] when the

--- a/lib/keeper_metrics/keeper_prompt_names.mli
+++ b/lib/keeper_metrics/keeper_prompt_names.mli
@@ -22,6 +22,7 @@ val librarian_memory_consolidation : string
 val memory_os_recall_context : string
 val memory_os_recall_facts_section : string
 val memory_os_recall_episodes_section : string
+val memory_os_recall_unavailable : string
 
 (** Turn-intent substitution prose template keys. *)
 val turn_intent_claim_guidance_a : string

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -9,6 +9,7 @@ module Librarian_runtime = Masc.Keeper_librarian_runtime
 module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
 module Consolidator = Masc.Keeper_memory_os_consolidator
+module Metrics = Masc.Otel_metric_store
 
 external unsetenv : string -> unit = "masc_test_unsetenv"
 
@@ -90,6 +91,28 @@ let render_if_enabled_for_test ~keeper_id ~now ~masc_root () =
     ~turn:1
     ~masc_root
     ()
+;;
+
+let memory_os_recall_unavailable_metric =
+  Keeper_metrics.(to_string MemoryOsRecallUnavailable)
+;;
+
+let recall_unavailable_metric_value reason =
+  Metrics.metric_value_or_zero memory_os_recall_unavailable_metric ~labels:[ "reason", reason ] ()
+;;
+
+let recent_recall_injection_failure_reason masc_root =
+  let store =
+    Dated_jsonl.create
+      ~base_dir:(Filename.concat masc_root "recall_injections")
+      ()
+  in
+  match Dated_jsonl.read_recent store 1 with
+  | [ json ] ->
+    (match Yojson.Safe.Util.(json |> member "failure_reason") with
+     | `String reason -> Some reason
+     | _ -> None)
+  | _ -> None
 ;;
 
 let has_memory_os_prompt_root path =
@@ -1771,6 +1794,8 @@ let test_render_if_enabled_surfaces_prompt_render_failure () =
         (fun () ->
           let keeper_id = "virtual-memory-keeper" in
           let now = 1_000_000.0 in
+          let reason = "prompt_render_error" in
+          let metric_before = recall_unavailable_metric_value reason in
           Memory_io.append_fact
             ~keeper_id
             { (fact_fixture ~now ()) with Types.claim = "Hidden fact should not leak" };
@@ -1781,7 +1806,7 @@ let test_render_if_enabled_surfaces_prompt_render_failure () =
             Alcotest.(check bool)
               "surfaces unavailable advisory"
               true
-              (contains "Historical memory recall is unavailable" block);
+              (contains "Memory recall unavailable" block);
             Alcotest.(check bool)
               "classifies prompt failure without raw template error"
               true
@@ -1789,8 +1814,16 @@ let test_render_if_enabled_surfaces_prompt_render_failure () =
             Alcotest.(check bool)
               "does not render fact text after prompt failure"
               false
-              (contains "Hidden fact should not leak" block))))
-;;
+              (contains "Hidden fact should not leak" block);
+            Alcotest.(check (float 0.001))
+              "increments recall-unavailable metric"
+              (metric_before +. 1.0)
+              (recall_unavailable_metric_value reason);
+            Alcotest.(check (option string))
+              "ledger records failure reason"
+              (Some reason)
+              (recent_recall_injection_failure_reason keepers_dir))))
+  ;;
 
 let test_render_if_enabled_renders_persisted_memory () =
   with_recall_env "true" (fun () ->

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1763,6 +1763,35 @@ let test_render_if_enabled_empty_store_yields_none () =
       | Some block -> Alcotest.failf "expected None for empty store, got %S" block))
 ;;
 
+let test_render_if_enabled_surfaces_prompt_render_failure () =
+  with_recall_env "true" (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      Fun.protect
+        ~finally:Prompt_registry.clear
+        (fun () ->
+          let keeper_id = "virtual-memory-keeper" in
+          let now = 1_000_000.0 in
+          Memory_io.append_fact
+            ~keeper_id
+            { (fact_fixture ~now ()) with Types.claim = "Hidden fact should not leak" };
+          Prompt_registry.clear ();
+          match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
+          | None -> Alcotest.fail "expected sanitized recall-unavailable block"
+          | Some block ->
+            Alcotest.(check bool)
+              "surfaces unavailable advisory"
+              true
+              (contains "Historical memory recall is unavailable" block);
+            Alcotest.(check bool)
+              "classifies prompt failure without raw template error"
+              true
+              (contains "reason=prompt_render_error" block);
+            Alcotest.(check bool)
+              "does not render fact text after prompt failure"
+              false
+              (contains "Hidden fact should not leak" block))))
+;;
+
 let test_render_if_enabled_renders_persisted_memory () =
   with_recall_env "true" (fun () ->
     with_prompt_registry (fun () ->
@@ -3977,6 +4006,10 @@ let () =
             "render_if_enabled empty store yields none"
             `Quick
             test_render_if_enabled_empty_store_yields_none
+        ; Alcotest.test_case
+            "render_if_enabled surfaces prompt render failure"
+            `Quick
+            test_render_if_enabled_surfaces_prompt_render_failure
         ; Alcotest.test_case
             "render_if_enabled renders persisted memory"
             `Quick

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -23,6 +23,7 @@ let () =
       ~injected_episode_keys:[ "trace-1:g0" ]
       ~n_facts_in_store:42
       ~now:1234.5
+      ()
   in
   check "keeper_id" (j |> member "keeper_id" |> to_string = "alpha");
   check "trace_id" (j |> member "trace_id" |> to_string = "trace-1");
@@ -37,6 +38,22 @@ let () =
     "injected_episode_keys preserved"
     (j |> member "injected_episode_keys" |> to_list |> List.map to_string
      = [ "trace-1:g0" ]);
+  check "failure_reason omitted by default" (j |> member "failure_reason" = `Null);
+  let failure_json =
+    Ledger.to_json
+      ~failure_reason:"prompt_render_error"
+      ~keeper_id:"alpha"
+      ~trace_id:"trace-1"
+      ~turn:3
+      ~injected_fact_keys:[]
+      ~injected_episode_keys:[]
+      ~n_facts_in_store:42
+      ~now:1234.5
+      ()
+  in
+  check
+    "failure_reason preserved when present"
+    (failure_json |> member "failure_reason" |> to_string = "prompt_render_error");
   (* Empty key lists serialise to empty JSON arrays, not null. *)
   let empty =
     Ledger.to_json
@@ -47,6 +64,7 @@ let () =
       ~injected_episode_keys:[]
       ~n_facts_in_store:0
       ~now:0.0
+      ()
   in
   check
     "empty fact keys is []"

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -116,10 +116,10 @@ let session_with_stale_seen () =
   Time_compat.sleep 0.01;
   (session, before)
 
-let check_session_touched label session before =
+let check_session_touched label (session : SH.session) before =
   Alcotest.(check bool) label true (Atomic.get session.last_seen > before)
 
-let check_session_not_touched label session before =
+let check_session_not_touched label (session : SH.session) before =
   Alcotest.(check bool) label true (Atomic.get session.last_seen = before)
 
 let test_handle_post_session_touch_success () =


### PR DESCRIPTION
Summary: fix #22293 by returning a sanitized Memory OS recall-unavailable advisory when recall fails after the recall flag is enabled, instead of silently omitting the block. The prompt uses a new Prompt_registry template key and a hard fallback that carries only a reason code, not exception text or paths. Regression coverage seeds a fact, clears the prompt registry, and verifies the model sees the unavailable advisory without leaking the hidden fact.

Stacking: dependent draft stacked on #22321 / base codex/public-dashboard-surface-20260626, refreshed on base head 465d9ae3315. Retarget/rebase to main after #22321 lands.

Validation: ocamlformat --check lib/keeper/keeper_memory_os_recall.ml lib/keeper/keeper_memory_os_recall.mli lib/keeper_metrics/keeper_prompt_names.ml lib/keeper_metrics/keeper_prompt_names.mli test/test_keeper_memory_os.ml; git diff --check origin/codex/public-dashboard-surface-20260626...HEAD; env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build --cache=disabled ./test/test_keeper_memory_os.exe ./test/test_prompt_registry_defaults.exe; _build/default/test/test_keeper_memory_os.exe (95/95); _build/default/test/test_prompt_registry_defaults.exe (16/16).