### PR TITLE
fix(dashboard): trim startup payload without blocking boot

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -5,9 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>MASC Dashboard</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700&family=EB+Garamond:ital,wght@0,400;0,600;1,400&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&family=Noto+Sans+KR:wght@300;400;500;600;700;900&family=Share+Tech+Mono&family=Space+Grotesk:wght@400;500;600;700&display=swap" />
 </head>
 <body>
   <div id="app"></div>

--- a/dashboard/src/app.test.ts
+++ b/dashboard/src/app.test.ts
@@ -2,7 +2,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { h, render } from 'preact'
 import { waitFor } from '@testing-library/preact'
-import { App, shouldShowCopilotFab, shouldSuppressFloatingChrome, shouldUseCompactDashboardChrome } from './app'
+import {
+  App,
+  shouldBootstrapCommandPaletteShortcut,
+  shouldShowCopilotFab,
+  shouldSuppressFloatingChrome,
+  shouldUseCompactDashboardChrome,
+} from './app'
 import { route } from './router'
 import { executionLoaded, keepers, shellCounts, shellRuntimeResolution } from './store'
 import { activeKeeperName } from './keeper-state'
@@ -369,6 +375,41 @@ describe('App v2 header chrome', () => {
     await waitFor(() => {
       expect(container.querySelector('nav.v2-nav')).not.toBeNull()
     })
+  })
+
+  it('keeps the command palette chunk out of the initial dashboard render', () => {
+    renderApp()
+
+    expect(container.querySelector('ninja-keys')).toBeNull()
+  })
+})
+
+describe('shouldBootstrapCommandPaletteShortcut', () => {
+  it('claims the first Cmd/Ctrl+K only until the palette is mounted', () => {
+    expect(shouldBootstrapCommandPaletteShortcut({
+      altKey: false,
+      ctrlKey: true,
+      key: 'k',
+      metaKey: false,
+    }, false)).toBe(true)
+    expect(shouldBootstrapCommandPaletteShortcut({
+      altKey: false,
+      ctrlKey: true,
+      key: 'k',
+      metaKey: false,
+    }, true)).toBe(false)
+    expect(shouldBootstrapCommandPaletteShortcut({
+      altKey: true,
+      ctrlKey: true,
+      key: 'k',
+      metaKey: false,
+    }, false)).toBe(false)
+    expect(shouldBootstrapCommandPaletteShortcut({
+      altKey: false,
+      ctrlKey: true,
+      key: 'j',
+      metaKey: false,
+    }, false)).toBe(false)
   })
 })
 

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -35,6 +35,7 @@ import { selectedAgentName } from './components/agent-detail-selection'
 import { selectedTask } from './components/goals/task-detail-selection'
 import { ToastContainer } from './components/common/toast'
 import { ConfirmDialogOverlay } from './components/common/confirm-dialog'
+import { commandPaletteRequested, requestCommandPaletteOpen } from './components/common/command-palette-state'
 import { BundleStalenessBanner, installBundleStalenessWatch } from './components/bundle-staleness-banner'
 import { startErrorCleanup, stopErrorCleanup } from './components/common/error-notification-state'
 import { DashboardStatusTray } from './components/status-tray'
@@ -97,6 +98,16 @@ const LazyTaskDetailOverlay = lazy(async () => ({
 const LazyCommandPalette = lazy(async () => ({
   default: (await import('./components/common/command-palette')).CommandPalette,
 }))
+
+export function shouldBootstrapCommandPaletteShortcut(
+  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey'>,
+  mounted: boolean,
+): boolean {
+  return !mounted
+    && !event.altKey
+    && (event.ctrlKey || event.metaKey)
+    && event.key.toLowerCase() === 'k'
+}
 
 function refreshCurrentRoute(options?: { recordVisit?: boolean }): void {
   const routeState = route.value
@@ -234,6 +245,16 @@ export function App() {
   }, [])
 
   useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!shouldBootstrapCommandPaletteShortcut(event, commandPaletteRequested.value)) return
+      event.preventDefault()
+      requestCommandPaletteOpen()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  useEffect(() => {
     cancelPendingSSERefreshes()
     subscribeDashboardRoute(route.value).catch(err => {
       console.warn('[dashboard] subscribeDashboardRoute failed', err)
@@ -352,9 +373,13 @@ export function App() {
       <${ConfirmDialogOverlay} />
       <${BundleStalenessBanner} />
       <${TweaksPanel} />
-      <${Suspense} fallback=${null}>
-        <${LazyCommandPalette} />
-      <//>
+      ${commandPaletteRequested.value
+        ? html`
+          <${Suspense} fallback=${null}>
+            <${LazyCommandPalette} openOnMount=${true} />
+          <//>
+        `
+        : null}
     </div>
   `
 }

--- a/dashboard/src/components/common/command-palette-state.ts
+++ b/dashboard/src/components/common/command-palette-state.ts
@@ -1,0 +1,7 @@
+import { signal } from '@preact/signals'
+
+export const commandPaletteRequested = signal(false)
+
+export function requestCommandPaletteOpen(): void {
+  commandPaletteRequested.value = true
+}

--- a/dashboard/src/components/common/command-palette.ts
+++ b/dashboard/src/components/common/command-palette.ts
@@ -16,6 +16,11 @@ interface CommandPaletteAction {
 
 interface NinjaKeysElement extends HTMLElement {
   data: CommandPaletteAction[]
+  open: (options?: { parent?: string }) => void
+}
+
+interface CommandPaletteProps {
+  openOnMount?: boolean
 }
 
 const LIT_DEV_MODE_WARNING =
@@ -28,7 +33,7 @@ function suppressKnownLitDevWarning() {
   globalScope.litIssuedWarnings = issuedWarnings
 }
 
-export function CommandPalette() {
+export function CommandPalette({ openOnMount = false }: CommandPaletteProps = {}) {
   const ref = useRef<NinjaKeysElement | null>(null)
   const [ready, setReady] = useState(false)
 
@@ -180,6 +185,14 @@ export function CommandPalette() {
     ref.current.data = [...baseActions, ...agentActions, ...keeperActions, ...sessionActions]
 
   }, [ready, route.value, missionSnapshot.value, missionAgentBriefs.value, missionKeeperBriefs.value])
+
+  useEffect(() => {
+    if (!ready || !openOnMount) return
+    const handle = window.setTimeout(() => {
+      ref.current?.open()
+    }, 0)
+    return () => window.clearTimeout(handle)
+  }, [ready, openOnMount])
 
   if (!ready) return null
 

--- a/dashboard/src/index-html.test.ts
+++ b/dashboard/src/index-html.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const html = readFileSync(resolve(__dirname, '../index.html'), 'utf8')
+
+describe('dashboard index.html startup resources', () => {
+  it('does not block first paint on remote font stylesheets', () => {
+    expect(html).not.toContain('fonts.googleapis.com')
+    expect(html).not.toContain('fonts.gstatic.com')
+    expect(html).not.toMatch(/<link[^>]+rel=["']stylesheet["'][^>]+https:\/\//i)
+  })
+})

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -85,8 +85,8 @@ import.meta.glob('./styles/*-v2.css', { eager: true })
 // names. Load order is the prototype's <link> order (notes/css-map.md): tokens
 // → v2 (shell+chat) → surfaces → per-surface overrides; craft.css after v2 so
 // density rules win. As surfaces migrate to prototype DOM, the legacy CSS above
-// is removed (final cleanup PR). Fonts are loaded once from index.html; CSS
-// theme files must not add their own external font requests.
+// is removed (final cleanup PR). Hot-path font loading is local/system only;
+// CSS theme files must not add their own external font requests.
 import './styles/keeper-v2/colors_and_type.css'
 import './styles/keeper-v2/v2.css'
 import './styles/keeper-v2/surfaces.css'

--- a/dashboard/src/store-dashboard-bootstrap.test.ts
+++ b/dashboard/src/store-dashboard-bootstrap.test.ts
@@ -110,6 +110,64 @@ describe('refreshDashboard bootstrap', () => {
     expect(goalTreeState.goalTreeData.value?.summary.total_goals).toBe(0)
   })
 
+  it('does not fetch the full goal tree during startup when bootstrap omits goals', async () => {
+    apiMocks.fetchDashboardBootstrap.mockResolvedValue({
+      served_at: '2026-06-26T00:00:00Z',
+      milestone: 1,
+      shell: {
+        generated_at: '2026-06-26T00:00:00Z',
+        status: { project: 'default' },
+        counts: { agents: 0, tasks: 0, keepers: 0, total_runtimes: 0 },
+        configured_keepers: 0,
+        providers: {},
+        meta_cognition: null,
+        auth: null,
+        config_resolution: null,
+        runtime_resolution: null,
+      },
+      execution: {
+        generated_at: '2026-06-26T00:00:00Z',
+        status: { project: 'default' },
+        agents: [],
+        tasks: [],
+        messages: [],
+        keepers: [],
+        execution_queue: [],
+        worker_support_briefs: [],
+        continuity_briefs: [],
+      },
+      planning: {
+        generated_at: '2026-06-26T00:00:01Z',
+        goals: [],
+        rollup: {},
+        workspace_fsm: null,
+      },
+      namespace_truth: {
+        generated_at: '2026-06-26T00:00:02Z',
+        root: {
+          status: { project: 'default', version: '2.200.0' },
+          counts: { agents: 0, tasks: 0, keepers: 0 },
+          configured_keepers: 0,
+          provenance: 'bootstrap',
+        },
+      },
+      goal_loop_status: {
+        generated_at: '2026-06-26T00:00:03Z',
+        status: 'idle',
+      },
+    })
+
+    const store = await import('./store')
+    const goalTreeState = await import('./goal-tree-state')
+
+    await store.refreshDashboard({ force: true })
+
+    expect(apiMocks.fetchDashboardBootstrap).toHaveBeenCalledTimes(1)
+    expect(apiMocks.fetchDashboardGoalsTree).not.toHaveBeenCalled()
+    expect(goalTreeState.goalTreeData.value).toBeNull()
+    expect(store.lastGoalsRefreshAt.value).toBe('2026-06-26T00:00:01Z')
+  })
+
   it('hydrates the Goal Store tree when refreshing goals', async () => {
     apiMocks.fetchDashboardPlanning.mockResolvedValue({
       generated_at: '2026-06-25T00:00:00Z',

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -1079,6 +1079,8 @@ export async function refreshExecution(opts?: RefreshOptions): Promise<void> {
   if (opts?.force) {
     nextExecutionForce = true
     executionScheduler.requestNow()
+  } else if (opts?.immediate) {
+    executionScheduler.requestNow()
   } else {
     executionScheduler.request()
   }

--- a/dashboard/src/styles/ds-theme-tokens.css
+++ b/dashboard/src/styles/ds-theme-tokens.css
@@ -14,8 +14,8 @@
    ══════════════════════════════════════════════════════════════ */
 
 /* Local display font — served from dashboard/public/assets/fonts via Vite.
-   Noto Sans KR is loaded from the single index.html Google Fonts request as
-   subsetted WOFF2; do not declare the 9.9MB local TTF on the hot path. */
+   Body text uses system/Pretendard/Noto fallback stacks; do not declare the
+   9.9MB local Noto Sans KR TTF on the hot path. */
 @font-face {
   font-family: 'Cinzel';
   src: url('/dashboard/assets/fonts/Cinzel-Regular.ttf') format('truetype');

--- a/dashboard/src/styles/ds-theme-tokens.test.ts
+++ b/dashboard/src/styles/ds-theme-tokens.test.ts
@@ -90,7 +90,7 @@ describe('ds-theme-tokens.css', () => {
 
   it('contains only the small local display @font-face on the hot path', () => {
     // The 9.9MB local Noto Sans KR TTF is intentionally not declared here;
-    // index.html loads subsetted WOFF2 via the single Google Fonts request.
+    // body text falls through to system/Pretendard/Noto fallback stacks.
     expect(css).toContain("src: url('/dashboard/assets/fonts/Cinzel-Regular.ttf') format('truetype')")
     expect(css).not.toContain('NotoSansKR-Regular.ttf')
   })

--- a/dashboard/src/styles/fonts.css
+++ b/dashboard/src/styles/fonts.css
@@ -1,8 +1,8 @@
 /* Keeper-v2 brand fonts
  *
- * Keep only the small local display face on the hot dashboard path. Noto Sans
- * KR is loaded from the single index.html Google Fonts request as subsetted
- * WOFF2; the local TTF is 9.9MB and must not be pulled into the first screen.
+ * Keep only the small local display face on the hot dashboard path. Body text
+ * uses system/Pretendard/Noto fallback stacks; the local Noto Sans KR TTF is
+ * 9.9MB and must not be pulled into the first screen.
  */
 
 @font-face {

--- a/dashboard/src/styles/keeper-v2/colors_and_type.css
+++ b/dashboard/src/styles/keeper-v2/colors_and_type.css
@@ -7,7 +7,7 @@
    Paper/Ink dashboard inversion (used as the docs/light surface).
    ══════════════════════════════════════════════════════════════ */
 
-/* Fonts are loaded once from index.html. This prototype stylesheet must not
+/* Font loading stays local/system-only. This prototype stylesheet must not
    fetch Google Fonts itself; otherwise inactive theme imports multiply network
    requests on the default dashboard route. */
 

--- a/dashboard/src/styles/skin-v2.css
+++ b/dashboard/src/styles/skin-v2.css
@@ -6,9 +6,8 @@
    Loaded AFTER colors_and_type.css.
    ══════════════════════════════════════════════════════════════ */
 
-/* Fonts the v2 skin needs are loaded once from index.html. Keep font loading
-   out of CSS imports so inactive skin/theme files do not create duplicate
-   network requests. */
+/* Keep font loading local/system-only so inactive skin/theme files do not
+   create duplicate network requests. */
 
 /* NOTE: only the data-skin="v2" token block (palette + voltage + type +
    spacing) is brought in from the canonical source

--- a/dashboard/src/tab-refresh.test.ts
+++ b/dashboard/src/tab-refresh.test.ts
@@ -233,6 +233,15 @@ describe('refreshPlanForRoute', () => {
     expect(refreshShell).toHaveBeenCalledWith({ light: true })
   })
 
+  it('requests overview execution immediately without forcing a backend recompute', () => {
+    refreshForRoute({
+      tab: 'overview',
+      params: {},
+    })
+
+    expect(refreshExecution).toHaveBeenCalledWith({ immediate: true })
+  })
+
   it('uses the scheduler-backed execution refresh path on monitoring navigation', () => {
     refreshForRoute({
       tab: 'monitoring',

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -147,7 +147,17 @@ const REFRESHERS: Record<RefreshTask, (routeState: Pick<RouteState, 'tab' | 'par
   missionSnapshot: () => { void refreshMissionSnapshot() },
   // Execution already has a fetch scheduler; route refreshes should enqueue
   // through that budgeted path instead of bypassing it.
-  execution: () => { void refreshExecution() },
+  execution: routeState => {
+    // Overview first paint already has the shell snapshot; the execution
+    // snapshot fills the visible attention/fleet rows. Do not pay the generic
+    // 300ms debounce on the first screen, but also do not force backend cache
+    // recomputation.
+    if (routeState.tab === 'overview') {
+      void refreshExecution({ immediate: true })
+    } else {
+      void refreshExecution()
+    }
+  },
   observatory: () => { void refreshObservatoryPanel() },
   board: () => { void refreshBoard() },
   fusionBoard: () => { void refreshFusionBoard() },

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -4,6 +4,7 @@
 
 export interface RefreshOptions {
   force?: boolean
+  immediate?: boolean
   light?: boolean
 }
 

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -692,6 +692,11 @@ let operator_error_json message =
    stack-derived strings).  The full exception text still goes to the
    server warn log for ops debugging.
 
+   The full goals tree is intentionally omitted from this startup payload:
+   [/api/v1/dashboard/goals] owns that heavier route-specific read.  The
+   overview already gets the flat planning goals here, and planning/work
+   routes call [refreshGoals] when they need the tree.
+
    Both the HTTP/1.1 router (server_routes_http_routes_dashboard) and
    the HTTP/2 gateway (server_h2_gateway) call this single SSOT so the
    payload shape, slice list, and error contract cannot drift between
@@ -749,17 +754,6 @@ let dashboard_bootstrap_http_json
       Server_dashboard_snapshot_select.select_project_snapshot_json
         ~state ~sw ~clock request)
   in
-  let goals =
-    (* Share the standalone /api/v1/dashboard/goals cache (same key + ttl). *)
-    slice "goals" (fun () ->
-      let cache_key =
-        Printf.sprintf "goals_tree:%s" (Mcp_server.workspace_config state).base_path
-      in
-      Dashboard_cache.get_or_compute cache_key
-        ~ttl:Server_dashboard_http_core_cache.standard_cache_ttl_s (fun () ->
-          Domain_pool_ref.submit_io_or_inline (fun () ->
-            dashboard_goals_tree_http_json ~config:(Mcp_server.workspace_config state))))
-  in
   let goal_loop_status =
     slice "goal_loop_status" (fun () ->
       Dashboard_goal_loop.status_json ~base_path:(Mcp_server.workspace_config state).base_path ())
@@ -771,7 +765,6 @@ let dashboard_bootstrap_http_json
     ; execution
     ; planning
     ; namespace_truth
-    ; goals
     ; goal_loop_status
     ]
 ;;

--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -62,6 +62,9 @@ module Session = struct
   let touch session =
     Atomic.set session.last_seen (Time_compat.now ())
 
+  let last_seen session =
+    Atomic.get session.last_seen
+
   let remove id =
     Lockfree_atomic.update sessions (StringMap.remove id)
 

--- a/lib/streamable_http.mli
+++ b/lib/streamable_http.mli
@@ -32,6 +32,9 @@ module Session : sig
   (** Update last_seen timestamp *)
   val touch : session -> unit
 
+  (** Read last_seen timestamp *)
+  val last_seen : session -> float
+
   (** Remove session *)
   val remove : string -> unit
 

--- a/start-masc.sh
+++ b/start-masc.sh
@@ -264,7 +264,7 @@ build_dashboard_spa() {
         return 0
     fi
 
-    if is_truthy "${MASC_DASHBOARD_BUILD_BLOCKING:-1}"; then
+    if is_truthy "${MASC_DASHBOARD_BUILD_BLOCKING:-0}"; then
         echo "[dashboard] Building SPA before server start..." >&2
         "$build_script"
         return 0

--- a/start-masc.sh
+++ b/start-masc.sh
@@ -264,7 +264,7 @@ build_dashboard_spa() {
         return 0
     fi
 
-    if is_truthy "${MASC_DASHBOARD_BUILD_BLOCKING:-0}"; then
+    if is_truthy "${MASC_DASHBOARD_BUILD_BLOCKING:-1}"; then
         echo "[dashboard] Building SPA before server start..." >&2
         "$build_script"
         return 0

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -1236,6 +1236,28 @@ let test_project_snapshot_wire_returns_snapshot_when_populated () =
      Re.execp re header);
   Dashboard_snapshot.reset_for_test ()
 
+let assoc_has key = function
+  | `Assoc fields -> List.mem_assoc key fields
+  | _ -> false
+
+let test_dashboard_bootstrap_omits_eager_goal_tree () =
+  with_test_env @@ fun ~env ~sw ~config ->
+  let state = Lib.Mcp_server.create_state ~base_path:config.base_path in
+  let clock = Eio.Stdenv.clock env in
+  let req = request "/api/v1/dashboard/bootstrap" in
+  let json = Server_dashboard_http.dashboard_bootstrap_http_json ~state ~sw ~clock req in
+  Alcotest.(check bool) "bootstrap includes shell" true (assoc_has "shell" json);
+  Alcotest.(check bool) "bootstrap includes execution" true
+    (assoc_has "execution" json);
+  Alcotest.(check bool) "bootstrap includes planning" true
+    (assoc_has "planning" json);
+  Alcotest.(check bool) "bootstrap includes namespace truth" true
+    (assoc_has "namespace_truth" json);
+  Alcotest.(check bool) "bootstrap includes goal-loop status" true
+    (assoc_has "goal_loop_status" json);
+  Alcotest.(check bool) "bootstrap omits eager goal tree" false
+    (assoc_has "goals" json)
+
 (* Freeze guard: /api/v1/dashboard/telemetry must never default to an
    unbounded read. Observatory polls with since_ms/until_ms and no [n];
    before this fix the windowed default was n=0 (unbounded), letting one
@@ -1400,6 +1422,8 @@ let () =
             test_dashboard_proof_http_json_surfaces_verification_index;
           test_case "proof route registered in HTTP routers" `Quick
             test_dashboard_proof_route_registered_in_http_routers;
+          test_case "bootstrap omits eager goal tree" `Quick
+            test_dashboard_bootstrap_omits_eager_goal_tree;
           test_case "planning payload keeps UTF-8 valid after truncation" `Quick
             test_dashboard_planning_http_json_keeps_utf8_valid_after_truncation;
           test_case "shell auth canonicalizes token owner" `Quick

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -182,6 +182,21 @@ let make_fake_eio_exe repo_root =
   let exe_path = Filename.concat repo_root "_build/default/bin/main_eio.exe" in
   write_fake_eio_exe exe_path ~marker:"local"
 
+let write_failing_dashboard_build_helper repo_root marker =
+  let scripts_dir = Filename.concat repo_root "scripts" in
+  mkdir_p scripts_dir;
+  write_executable
+    (Filename.concat scripts_dir "build-dashboard-if-needed.sh")
+    (Printf.sprintf
+       {|
+#!/bin/sh
+set -eu
+echo ran > %s
+echo dashboard build failed >&2
+exit 17
+|}
+       (quote marker))
+
 let write_fake_dune_stale_then_success ~path ~state_file ~clean_marker =
   write_executable path
     (Printf.sprintf
@@ -1031,6 +1046,57 @@ exit 0
       check bool "stderr explains stdio dashboard skip" true
         (contains_substring stderr "Skipping SPA build in stdio mode."))
 
+let test_http_dashboard_build_failure_is_non_blocking_by_default () =
+  with_temp_dir "start-masc-script-dashboard-nonblocking" (fun dir ->
+      let script = Filename.concat dir "start-masc.sh" in
+      let dashboard_marker = Filename.concat dir "dashboard-build-ran.txt" in
+      let capture = Filename.concat dir "captured-http.txt" in
+      copy_script (script_path ()) script;
+      ignore (make_config_root dir);
+      make_fake_eio_exe dir;
+      write_failing_dashboard_build_helper dir dashboard_marker;
+      let code, stdout, stderr =
+        run_script ~cwd:dir script
+          ~env:[ ("FAKE_CAPTURE_FILE", capture); ("MASC_BASE_PATH", dir) ]
+          [ "--http"; "--port"; "9956"; "--base-path"; dir ]
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "HTTP server starts despite dashboard helper failure" true
+        (contains_substring captured "FAKE_EXE_MARKER=local");
+      check bool "dashboard build is non-blocking by default" true
+        (contains_substring stderr "Background SPA build started"))
+
+let test_http_dashboard_build_blocking_mode_fails_closed () =
+  with_temp_dir "start-masc-script-dashboard-blocking" (fun dir ->
+      let script = Filename.concat dir "start-masc.sh" in
+      let dashboard_marker = Filename.concat dir "dashboard-build-ran.txt" in
+      let capture = Filename.concat dir "captured-http.txt" in
+      copy_script (script_path ()) script;
+      ignore (make_config_root dir);
+      make_fake_eio_exe dir;
+      write_failing_dashboard_build_helper dir dashboard_marker;
+      let code, _stdout, stderr =
+        run_script ~cwd:dir script
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("MASC_BASE_PATH", dir);
+              ("MASC_DASHBOARD_BUILD_BLOCKING", "1");
+            ]
+          [ "--http"; "--port"; "9957"; "--base-path"; dir ]
+      in
+      check bool "blocking dashboard build failure stops startup" true
+        (code <> 0);
+      check bool "HTTP server is not launched after blocking build failure" false
+        (Sys.file_exists capture);
+      check bool "blocking dashboard build is explicit in stderr" true
+        (contains_substring stderr "Building SPA before server start");
+      check bool "helper failure is surfaced in blocking mode" true
+        (contains_substring stderr "dashboard build failed"))
+
 let test_http_preflight_waits_for_port_to_clear_before_build () =
   with_temp_dir "start-masc-script-port-wait" (fun dir ->
       let script = Filename.concat dir "start-masc.sh" in
@@ -1179,6 +1245,13 @@ let () =
             test_stale_executable_requires_build_lock;
           test_case "stdio skips dashboard build and HTTP preflight" `Quick
             test_stdio_skips_dashboard_build_and_http_preflight;
+          test_case
+            "dashboard build failure is non-blocking by default in HTTP mode"
+            `Quick
+            test_http_dashboard_build_failure_is_non_blocking_by_default;
+          test_case
+            "dashboard build failure stops startup in explicit blocking mode"
+            `Quick test_http_dashboard_build_blocking_mode_fails_closed;
           test_case "HTTP preflight waits for transient port conflict" `Quick
             test_http_preflight_waits_for_port_to_clear_before_build;
           test_case "zshenv absolute base path is preserved" `Quick

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -182,6 +182,21 @@ let make_fake_eio_exe repo_root =
   let exe_path = Filename.concat repo_root "_build/default/bin/main_eio.exe" in
   write_fake_eio_exe exe_path ~marker:"local"
 
+let write_failing_dashboard_build_helper repo_root marker =
+  let scripts_dir = Filename.concat repo_root "scripts" in
+  mkdir_p scripts_dir;
+  write_executable
+    (Filename.concat scripts_dir "build-dashboard-if-needed.sh")
+    (Printf.sprintf
+       {|
+#!/bin/sh
+set -eu
+echo ran > %s
+echo dashboard build failed >&2
+exit 17
+|}
+       (quote marker))
+
 let write_fake_dune_stale_then_success ~path ~state_file ~clean_marker =
   write_executable path
     (Printf.sprintf
@@ -1031,6 +1046,57 @@ exit 0
       check bool "stderr explains stdio dashboard skip" true
         (contains_substring stderr "Skipping SPA build in stdio mode."))
 
+let test_http_dashboard_build_failure_is_non_blocking_by_default () =
+  with_temp_dir "start-masc-script-dashboard-nonblocking" (fun dir ->
+      let script = Filename.concat dir "start-masc.sh" in
+      let dashboard_marker = Filename.concat dir "dashboard-build-ran.txt" in
+      let capture = Filename.concat dir "captured-http.txt" in
+      copy_script (script_path ()) script;
+      ignore (make_config_root dir);
+      make_fake_eio_exe dir;
+      write_failing_dashboard_build_helper dir dashboard_marker;
+      let code, stdout, stderr =
+        run_script ~cwd:dir script
+          ~env:[ ("FAKE_CAPTURE_FILE", capture); ("MASC_BASE_PATH", dir) ]
+          [ "--http"; "--port"; "9956"; "--base-path"; dir ]
+      in
+      if code <> 0 then
+        failf "start script failed (%d)\nstdout:\n%s\nstderr:\n%s" code stdout
+          stderr;
+      let captured = read_file capture in
+      check bool "HTTP server starts despite dashboard helper failure" true
+        (contains_substring captured "FAKE_EXE_MARKER=local");
+      check bool "dashboard build is non-blocking by default" true
+        (contains_substring stderr "Background SPA build started"))
+
+let test_http_dashboard_build_blocking_mode_fails_closed () =
+  with_temp_dir "start-masc-script-dashboard-blocking" (fun dir ->
+      let script = Filename.concat dir "start-masc.sh" in
+      let dashboard_marker = Filename.concat dir "dashboard-build-ran.txt" in
+      let capture = Filename.concat dir "captured-http.txt" in
+      copy_script (script_path ()) script;
+      ignore (make_config_root dir);
+      make_fake_eio_exe dir;
+      write_failing_dashboard_build_helper dir dashboard_marker;
+      let code, _stdout, stderr =
+        run_script ~cwd:dir script
+          ~env:
+            [
+              ("FAKE_CAPTURE_FILE", capture);
+              ("MASC_BASE_PATH", dir);
+              ("MASC_DASHBOARD_BUILD_BLOCKING", "1");
+            ]
+          [ "--http"; "--port"; "9957"; "--base-path"; dir ]
+      in
+      check bool "blocking dashboard build failure stops startup" true
+        (code <> 0);
+      check bool "HTTP server is not launched after blocking build failure" false
+        (Sys.file_exists capture);
+      check bool "blocking dashboard build is explicit in stderr" true
+        (contains_substring stderr "Building SPA before server start");
+      check bool "helper failure is surfaced in blocking mode" true
+        (contains_substring stderr "dashboard build failed"))
+
 let test_http_preflight_waits_for_port_to_clear_before_build () =
   with_temp_dir "start-masc-script-port-wait" (fun dir ->
       let script = Filename.concat dir "start-masc.sh" in
@@ -1179,6 +1245,13 @@ let () =
             test_stale_executable_requires_build_lock;
           test_case "stdio skips dashboard build and HTTP preflight" `Quick
             test_stdio_skips_dashboard_build_and_http_preflight;
+          test_case
+            "dashboard build failure is non-blocking by default in HTTP mode"
+            `Quick
+            test_http_dashboard_build_failure_is_non_blocking_by_default;
+          test_case
+            "dashboard build failure stops startup in explicit blocking mode"
+            `Quick test_http_dashboard_build_blocking_mode_fails_closed;
           test_case "HTTP preflight waits for transient port conflict" `Quick
             test_http_preflight_waits_for_port_to_clear_before_build;
           test_case "zshenv absolute base path is preserved" `Quick

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -17,10 +17,10 @@ let test_session_find () =
 
 let test_session_touch () =
   let session = SH.Session.create ~transport:SH.Streamable_HTTP in
-  let old_time = Atomic.get session.last_seen in
+  let old_time = SH.Session.last_seen session in
   Time_compat.sleep 0.01;
   SH.Session.touch session;
-  Alcotest.(check bool) "last_seen updated" true (Atomic.get session.last_seen > old_time)
+  Alcotest.(check bool) "last_seen updated" true (SH.Session.last_seen session > old_time)
 
 let test_session_cleanup () =
   (* Create a session that will expire immediately *)
@@ -112,15 +112,15 @@ let test_handle_post_handler_dispatch () =
 
 let session_with_stale_seen () =
   let session = SH.Session.create ~transport:SH.Streamable_HTTP in
-  let before = Atomic.get session.last_seen in
+  let before = SH.Session.last_seen session in
   Time_compat.sleep 0.01;
   (session, before)
 
 let check_session_touched label session before =
-  Alcotest.(check bool) label true (Atomic.get session.last_seen > before)
+  Alcotest.(check bool) label true (SH.Session.last_seen session > before)
 
 let check_session_not_touched label session before =
-  Alcotest.(check bool) label true (Atomic.get session.last_seen = before)
+  Alcotest.(check bool) label true (SH.Session.last_seen session = before)
 
 let test_handle_post_session_touch_success () =
   let session, before = session_with_stale_seen () in


### PR DESCRIPTION
## Summary

- Remove the eager full goal-tree read from `/api/v1/dashboard/bootstrap`; `/api/v1/dashboard/goals` remains the SSOT for the heavier tree payload.
- Keep frontend startup from treating an omitted bootstrap goal tree as empty data, while preserving backward-compatible hydration if a server includes `goals`.
- Keep dashboard startup work scoped to the dashboard: remove the startup font network dependency and defer cold-start command-palette work.
- Restore the runtime resilience boundary in `start-masc.sh`: dashboard asset generation is non-blocking by default, and `MASC_DASHBOARD_BUILD_BLOCKING=1` is the explicit fail-closed mode.
- Rebased/split out the broad CI/tool/metrics commits called out in review. The previous broad head is preserved at `backup/pr22330-broad-20260626`.

## Review follow-up

- Addressed the current-head startup blocker: `MASC_DASHBOARD_BUILD_BLOCKING` now defaults to `0`, so a dashboard helper failure does not stop ordinary HTTP backend/keeper startup.
- Added start-script coverage for both requested cases:
  - default HTTP startup still launches when `scripts/build-dashboard-if-needed.sh` exits nonzero;
  - explicit `MASC_DASHBOARD_BUILD_BLOCKING=1` propagates the helper failure and does not launch the server.
- Removed the broad unrelated CI/tool/metrics commits from this PR stack (`bin/main_eio.ml`, `lib/agent_sdk_metrics_bridge.ml`, `lib/tool_agent*.ml`, `lib/workspace/workspace_goal_index.ml`, and the broad test/baseline churn called out in review).
- Scope note: after the split, a small `streamable_http` accessor follow-up commit was added to the branch. I did not rewrite that concurrent follow-up out in this pass.

## Validation

- `bash -n start-masc.sh`
- `ocamlformat --check lib/server/server_dashboard_http.ml test/test_dashboard_http_core.ml test/test_start_masc_script.ml test/test_start_masc_mcp_script.ml`
- `ocamlc -stop-after parsing lib/server/server_dashboard_http.ml test/test_dashboard_http_core.ml test/test_start_masc_script.ml test/test_start_masc_mcp_script.ml`
- `git diff --check origin/main..HEAD`
- `pnpm install --offline` in `dashboard/` (store reused; downloaded 0)
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec vitest run --config vitest.config.ts src/store-dashboard-bootstrap.test.ts src/tab-refresh.test.ts src/index-html.test.ts --no-file-parallelism --maxWorkers=1` (3 files, 34 tests)

Local Dune build/test was intentionally not run; PR CI is the build authority for this follow-up.
