### PR TITLE
fix(health): surface dormant active task owners

### DIFF
--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -708,7 +708,7 @@ let blocked_keeper_detail_json
      @ last_failure_fields)
 
 type active_task_owner_without_executable_fiber = {
-  keeper_name : string;
+  keeper_name : string option;
   agent_name : string;
   task_id : string;
   task_status : string;
@@ -727,7 +727,14 @@ let empty_active_task_owner_fiber_scan =
   }
 
 let compare_active_task_owner_without_executable_fiber left right =
-  let cmp = String.compare left.keeper_name right.keeper_name in
+  let compare_string_opt left right =
+    match (left, right) with
+    | None, None -> 0
+    | None, Some _ -> -1
+    | Some _, None -> 1
+    | Some left, Some right -> String.compare left right
+  in
+  let cmp = compare_string_opt left.keeper_name right.keeper_name in
   if cmp <> 0 then cmp
   else
     let cmp = String.compare left.agent_name right.agent_name in
@@ -747,15 +754,20 @@ let active_task_assignment (task : Masc_domain.task) =
   | Masc_domain.Cancelled _ -> None
 
 let active_task_owner_without_executable_fiber_json row =
+  let action =
+    match row.keeper_name with
+    | Some _ -> "start_or_recover_keeper_or_reassign_task"
+    | None -> "create_keeper_or_reassign_task"
+  in
   `Assoc
     [
-      ("keeper", `String row.keeper_name);
-      ("name", `String row.keeper_name);
+      ("keeper", Json_util.string_opt_to_json row.keeper_name);
+      ("name", Json_util.string_opt_to_json row.keeper_name);
       ("agent_name", `String row.agent_name);
       ("task_id", `String row.task_id);
       ("task_status", `String row.task_status);
       ("executable", `Bool false);
-      ("action", `String "start_or_recover_keeper_or_reassign_task");
+      ("action", `String action);
     ]
 
 let keeper_agent_bindings config =
@@ -795,21 +807,32 @@ let active_task_owner_fiber_scan config ~executable_names =
                    keeper_names_for_agent agent_bindings assignee
                  in
                  if
-                   keeper_names = []
-                   || List.exists
-                        (fun keeper_name ->
-                          String_set.mem keeper_name executable_set)
-                        keeper_names
+                   List.exists
+                     (fun keeper_name ->
+                       String_set.mem keeper_name executable_set)
+                     keeper_names
                  then []
                  else
-                   keeper_names
-                   |> List.map (fun keeper_name ->
-                        {
-                          keeper_name;
-                          agent_name = assignee;
-                          task_id = task.id;
-                          task_status;
-                        }))
+                   (match keeper_names with
+                    | [] ->
+                        [
+                          {
+                            keeper_name = None;
+                            agent_name = assignee;
+                            task_id = task.id;
+                            task_status;
+                          };
+                        ]
+                    | keeper_names ->
+                        keeper_names
+                        |> List.map (fun keeper_name ->
+                             {
+                               keeper_name = Some keeper_name;
+                               agent_name = assignee;
+                               task_id = task.id;
+                               task_status;
+                             }))
+                   )
         |> List.concat
         |> List.sort_uniq compare_active_task_owner_without_executable_fiber
       in
@@ -889,11 +912,11 @@ let keeper_fleet_safety_health_json
   in
   let active_task_owner_without_executable_fiber_names =
     active_task_owner_scan.active_task_owner_without_executable_fibers
-    |> List.map (fun row -> row.keeper_name)
+    |> List.filter_map (fun row -> row.keeper_name)
     |> sorted_unique_strings
   in
   let active_task_owner_without_executable_fiber_count =
-    List.length active_task_owner_without_executable_fiber_names
+    List.length active_task_owner_scan.active_task_owner_without_executable_fibers
   in
   let active_task_owner_without_executable_fiber =
     active_task_owner_without_executable_fiber_count > 0

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -707,6 +707,111 @@ let blocked_keeper_detail_json
      ]
      @ last_failure_fields)
 
+type active_task_owner_without_executable_fiber = {
+  keeper_name : string;
+  agent_name : string;
+  task_id : string;
+  task_status : string;
+}
+
+type active_task_owner_fiber_scan = {
+  active_task_owner_without_executable_fibers :
+    active_task_owner_without_executable_fiber list;
+  active_task_owner_scan_errors : (string * string) list;
+}
+
+let empty_active_task_owner_fiber_scan =
+  {
+    active_task_owner_without_executable_fibers = [];
+    active_task_owner_scan_errors = [];
+  }
+
+let compare_active_task_owner_without_executable_fiber left right =
+  let cmp = String.compare left.keeper_name right.keeper_name in
+  if cmp <> 0 then cmp
+  else
+    let cmp = String.compare left.agent_name right.agent_name in
+    if cmp <> 0 then cmp
+    else String.compare left.task_id right.task_id
+
+let active_task_assignment (task : Masc_domain.task) =
+  match task.task_status with
+  | Masc_domain.Claimed { assignee; _ }
+  | Masc_domain.InProgress { assignee; _ } ->
+      Some
+        ( assignee,
+          Workspace_task_schedule.task_status_label task.task_status )
+  | Masc_domain.Todo
+  | Masc_domain.AwaitingVerification _
+  | Masc_domain.Done _
+  | Masc_domain.Cancelled _ -> None
+
+let active_task_owner_without_executable_fiber_json row =
+  `Assoc
+    [
+      ("keeper", `String row.keeper_name);
+      ("name", `String row.keeper_name);
+      ("agent_name", `String row.agent_name);
+      ("task_id", `String row.task_id);
+      ("task_status", `String row.task_status);
+      ("executable", `Bool false);
+      ("action", `String "start_or_recover_keeper_or_reassign_task");
+    ]
+
+let keeper_agent_bindings config =
+  Keeper_meta_store.keeper_names config
+  |> List.fold_left
+       (fun (bindings, read_errors) name ->
+         match Keeper_meta_store.read_meta config name with
+         | Ok (Some meta) -> ((meta.agent_name, meta.name) :: bindings, read_errors)
+         | Ok None -> (bindings, read_errors)
+         | Error err -> (bindings, (name, err) :: read_errors))
+       ([], [])
+
+let active_task_owner_fiber_scan config ~executable_names =
+  let executable_set = string_set_of_list executable_names in
+  let agent_bindings, meta_read_errors = keeper_agent_bindings config in
+  match Workspace.read_backlog_r config with
+  | Error err ->
+      {
+        active_task_owner_without_executable_fibers = [];
+        active_task_owner_scan_errors =
+          ("backlog", err) :: meta_read_errors;
+      }
+  | Ok backlog ->
+      let rows =
+        backlog.tasks
+        |> List.map (fun task ->
+             match active_task_assignment task with
+             | None -> []
+             | Some (assignee, task_status) ->
+                 agent_bindings
+                 |> List.filter_map (fun (agent_name, keeper_name) ->
+                      if
+                        String.equal agent_name assignee
+                        && not (String_set.mem keeper_name executable_set)
+                      then
+                        Some
+                          {
+                            keeper_name;
+                            agent_name;
+                            task_id = task.id;
+                            task_status;
+                          }
+                      else None))
+        |> List.concat
+        |> List.sort_uniq compare_active_task_owner_without_executable_fiber
+      in
+      {
+        active_task_owner_without_executable_fibers = rows;
+        active_task_owner_scan_errors =
+          List.sort_uniq
+            (fun (left_name, left_err) (right_name, right_err) ->
+              let cmp = String.compare left_name right_name in
+              if cmp <> 0 then cmp else String.compare left_err right_err)
+            meta_read_errors;
+      }
+
 let keeper_fleet_safety_health_json
     ?bootable_names:bootable_names_override
     ?autoboot_scan:autoboot_scan_override
@@ -763,6 +868,28 @@ let keeper_fleet_safety_health_json
     | Some snapshot -> snapshot.executable_names
     | None -> fallback_running_names
   in
+  let active_task_owner_scan =
+    match current_server_state_opt () with
+    | Some state ->
+        active_task_owner_fiber_scan
+          (Mcp_server.workspace_config state)
+          ~executable_names
+    | None -> empty_active_task_owner_fiber_scan
+  in
+  let active_task_owner_without_executable_fiber_names =
+    active_task_owner_scan.active_task_owner_without_executable_fibers
+    |> List.map (fun row -> row.keeper_name)
+    |> sorted_unique_strings
+  in
+  let active_task_owner_without_executable_fiber_count =
+    List.length active_task_owner_without_executable_fiber_names
+  in
+  let active_task_owner_without_executable_fiber =
+    active_task_owner_without_executable_fiber_count > 0
+  in
+  let active_task_owner_scan_failed =
+    active_task_owner_scan.active_task_owner_scan_errors <> []
+  in
   let phase_names =
     match phase_snapshot with
     | Some snapshot -> snapshot.phase_names
@@ -813,6 +940,8 @@ let keeper_fleet_safety_health_json
   in
   let status =
     if no_executable_keeper_fibers then "blocked"
+    else if active_task_owner_without_executable_fiber then "degraded"
+    else if active_task_owner_scan_failed then "degraded"
     else if no_running_fibers then "degraded"
     else if low_running_fiber_margin then "degraded"
     else if reaction_capacity_below_target then "degraded"
@@ -861,6 +990,9 @@ let keeper_fleet_safety_health_json
   in
   let blocker =
     if no_executable_keeper_fibers then Some "no_executable_keeper_fibers"
+    else if active_task_owner_without_executable_fiber then
+      Some "active_task_owner_without_executable_fiber"
+    else if active_task_owner_scan_failed then Some "active_task_owner_scan_failed"
     else if no_running_fibers then Some "no_healthy_running_keeper_fibers"
     else if low_running_fiber_margin then Some "low_running_fiber_margin"
     else if reaction_capacity_below_target then Some "reaction_capacity_below_target"
@@ -899,6 +1031,28 @@ let keeper_fleet_safety_health_json
     ; "minimum_running_fibers", `Int minimum_running_fibers
     ; "no_running_fibers", `Bool no_running_fibers
     ; "no_executable_keeper_fibers", `Bool no_executable_keeper_fibers
+    ; ( "active_task_owner_without_executable_fiber"
+      , `Bool active_task_owner_without_executable_fiber )
+    ; ( "active_task_owner_without_executable_fiber_count"
+      , `Int active_task_owner_without_executable_fiber_count )
+    ; ( "active_task_owner_without_executable_fiber_names"
+      , `List
+          (List.map
+             (fun name -> `String name)
+             active_task_owner_without_executable_fiber_names) )
+    ; ( "active_task_owner_without_executable_fiber_tasks"
+      , `List
+          (List.map
+             active_task_owner_without_executable_fiber_json
+             active_task_owner_scan.active_task_owner_without_executable_fibers) )
+    ; ( "active_task_owner_scan_error_count"
+      , `Int (List.length active_task_owner_scan.active_task_owner_scan_errors) )
+    ; ( "active_task_owner_scan_errors"
+      , `List
+          (List.map
+             (fun (source, error) ->
+               `Assoc [ ("source", `String source); ("error", `String error) ])
+             active_task_owner_scan.active_task_owner_scan_errors) )
     ; "low_running_fiber_margin", `Bool low_running_fiber_margin
     ; "reaction_capacity_below_target", `Bool reaction_capacity_below_target
     ; "reaction_capacity_shortfall_count", `Int reaction_capacity_shortfall_count
@@ -918,5 +1072,7 @@ let keeper_fleet_safety_health_json
           (no_executable_keeper_fibers
            || no_running_fibers
            || low_running_fiber_margin
-           || reaction_capacity_below_target) )
+           || reaction_capacity_below_target
+           || active_task_owner_without_executable_fiber
+           || active_task_owner_scan_failed) )
     ]

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -768,6 +768,12 @@ let keeper_agent_bindings config =
          | Error err -> (bindings, (name, err) :: read_errors))
        ([], [])
 
+let keeper_names_for_agent agent_bindings assignee =
+  agent_bindings
+  |> List.filter_map (fun (agent_name, keeper_name) ->
+       if String.equal agent_name assignee then Some keeper_name else None)
+  |> sorted_unique_strings
+
 let active_task_owner_fiber_scan config ~executable_names =
   let executable_set = string_set_of_list executable_names in
   let agent_bindings, meta_read_errors = keeper_agent_bindings config in
@@ -785,20 +791,25 @@ let active_task_owner_fiber_scan config ~executable_names =
              match active_task_assignment task with
              | None -> []
              | Some (assignee, task_status) ->
-                 agent_bindings
-                 |> List.filter_map (fun (agent_name, keeper_name) ->
-                      if
-                        String.equal agent_name assignee
-                        && not (String_set.mem keeper_name executable_set)
-                      then
-                        Some
-                          {
-                            keeper_name;
-                            agent_name;
-                            task_id = task.id;
-                            task_status;
-                          }
-                      else None))
+                 let keeper_names =
+                   keeper_names_for_agent agent_bindings assignee
+                 in
+                 if
+                   keeper_names = []
+                   || List.exists
+                        (fun keeper_name ->
+                          String_set.mem keeper_name executable_set)
+                        keeper_names
+                 then []
+                 else
+                   keeper_names
+                   |> List.map (fun keeper_name ->
+                        {
+                          keeper_name;
+                          agent_name = assignee;
+                          task_id = task.id;
+                          task_status;
+                        }))
         |> List.concat
         |> List.sort_uniq compare_active_task_owner_without_executable_fiber
       in

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1448,6 +1448,91 @@ let test_health_json_degrades_on_active_task_owner_without_executable_fiber () =
         Alcotest.(check bool) "health asks operator action" true
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
+let test_health_json_ignores_stale_active_task_alias_when_agent_executable () =
+  with_temp_dir "health-active-task-owner-executable-alias" (fun dir ->
+    let config_root = make_config_root dir in
+    Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
+    write_file
+      (Filename.concat (Filename.concat config_root "keepers") "executor.toml")
+      "[keeper]\ngoal = \"goal-executor\"\nautoboot_enabled = false\n";
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        let executor =
+          make_keeper_meta ~name:"executor" ~trace_id:"trace-executor" ()
+        in
+        let stale_executor =
+          {
+            (make_keeper_meta
+               ~name:"executor-stale"
+               ~trace_id:"trace-executor-stale"
+               ())
+            with
+            Keeper_meta_contract.agent_name = executor.agent_name;
+          }
+        in
+        write_keeper_meta_exn config executor;
+        write_keeper_meta_exn config stale_executor;
+        let task =
+          make_task
+            ~id:"task-active-owner"
+            ~title:"Active keeper task"
+            ~status:
+              (Types.InProgress
+                 {
+                   assignee = executor.Keeper_meta_contract.agent_name;
+                   started_at = "2026-06-26T00:00:01Z";
+                 })
+            ()
+        in
+        Workspace.write_backlog config
+          { Types.tasks = [ task ]; last_updated = "2026-06-26T00:00:02Z"; version = 2 };
+        let phase_counts :
+            Server_routes_http_runtime_fleet_scan.keeper_phase_counts =
+          { running = 1; failing = 0; recovering = 0; executable = 1 }
+        in
+        let phase_snapshot :
+            Server_routes_http_runtime_fleet_scan.keeper_phase_snapshot =
+          {
+            counts = phase_counts;
+            running_names = [ executor.name ];
+            recovering_names = [];
+            executable_names = [ executor.name ];
+            phase_names = [ (executor.name, "running") ];
+          }
+        in
+        let fleet_safety =
+          Server_routes_http_runtime_fleet_scan.keeper_fleet_safety_health_json
+            ~bootable_names:[]
+            ~autoboot_scan:
+              Server_routes_http_runtime_fleet_scan.empty_autoboot_keeper_scan
+            ~phase_snapshot
+            ~phase_counts
+            ~paused_keepers_json:(`Assoc [ ("count", `Int 0) ])
+            ()
+        in
+        let open Yojson.Safe.Util in
+        Alcotest.(check string) "health remains ok" "ok"
+          (fleet_safety |> member "status" |> to_string);
+        Alcotest.(check bool) "health does not flag stale alias" false
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber"
+           |> to_bool);
+        Alcotest.(check int) "health reports no dormant owner rows" 0
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_count"
+           |> to_int);
+        Alcotest.(check bool) "health does not require operator action" false
+          (fleet_safety |> member "operator_action_required" |> to_bool)))
+
 let test_health_json_degrades_when_reaction_capacity_below_target () =
   with_temp_dir "health-reaction-capacity-below-target" (fun dir ->
     let config_root = make_config_root dir in
@@ -3260,6 +3345,10 @@ let () =
             "health json degrades on active task owner without executable fiber"
             `Quick
             test_health_json_degrades_on_active_task_owner_without_executable_fiber;
+          Alcotest.test_case
+            "health json ignores stale active task alias when agent executable"
+            `Quick
+            test_health_json_ignores_stale_active_task_alias_when_agent_executable;
           Alcotest.test_case
             "health json degrades when reaction capacity is below target"
             `Quick test_health_json_degrades_when_reaction_capacity_below_target;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1533,6 +1533,78 @@ let test_health_json_ignores_stale_active_task_alias_when_agent_executable () =
         Alcotest.(check bool) "health does not require operator action" false
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
+let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
+  with_temp_dir "health-active-task-owner-without-binding" (fun dir ->
+    let config_root = make_config_root dir in
+    Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        let assignee = "missing-keeper-agent" in
+        let task =
+          make_task
+            ~id:"task-active-owner-without-binding"
+            ~title:"Active keeper task without binding"
+            ~status:
+              (Types.InProgress
+                 { assignee; started_at = "2026-06-26T00:00:01Z" })
+            ()
+        in
+        Workspace.write_backlog config
+          { Types.tasks = [ task ]; last_updated = "2026-06-26T00:00:02Z"; version = 2 };
+        let request = Httpun.Request.create `GET "/health" in
+        let json = Server_routes_http_runtime.make_health_json request in
+        let open Yojson.Safe.Util in
+        let fleet_safety = json |> member "keeper_fleet_safety" in
+        Alcotest.(check string) "health marks missing binding degraded"
+          "degraded"
+          (fleet_safety |> member "status" |> to_string);
+        Alcotest.(check string) "health marks missing binding blocker"
+          "active_task_owner_without_executable_fiber"
+          (fleet_safety |> member "blocker" |> to_string);
+        Alcotest.(check bool) "health exposes missing binding flag" true
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber"
+           |> to_bool);
+        Alcotest.(check int) "health exposes missing binding row count" 1
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_count"
+           |> to_int);
+        Alcotest.(check (list string)) "health has no keeper names"
+          []
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_names"
+           |> to_list
+           |> List.map to_string);
+        let dormant_tasks =
+          fleet_safety
+          |> member "active_task_owner_without_executable_fiber_tasks"
+          |> to_list
+        in
+        Alcotest.(check int) "health exposes missing binding task row" 1
+          (List.length dormant_tasks);
+        let dormant_task = List.hd dormant_tasks in
+        Alcotest.(check bool) "missing binding row keeper null" true
+          (dormant_task |> member "keeper" = `Null);
+        Alcotest.(check string) "missing binding row agent" assignee
+          (dormant_task |> member "agent_name" |> to_string);
+        Alcotest.(check string) "missing binding row task id"
+          "task-active-owner-without-binding"
+          (dormant_task |> member "task_id" |> to_string);
+        Alcotest.(check string) "missing binding action"
+          "create_keeper_or_reassign_task"
+          (dormant_task |> member "action" |> to_string);
+        Alcotest.(check bool) "health asks operator action" true
+          (fleet_safety |> member "operator_action_required" |> to_bool)))
+
 let test_health_json_degrades_when_reaction_capacity_below_target () =
   with_temp_dir "health-reaction-capacity-below-target" (fun dir ->
     let config_root = make_config_root dir in
@@ -3349,6 +3421,10 @@ let () =
             "health json ignores stale active task alias when agent executable"
             `Quick
             test_health_json_ignores_stale_active_task_alias_when_agent_executable;
+          Alcotest.test_case
+            "health json degrades on active task owner without keeper binding"
+            `Quick
+            test_health_json_degrades_on_active_task_owner_without_keeper_binding;
           Alcotest.test_case
             "health json degrades when reaction capacity is below target"
             `Quick test_health_json_degrades_when_reaction_capacity_below_target;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1012,6 +1012,23 @@ let make_keeper_meta ?(paused = false) ?(name = "sangsu")
       }
   | Error err -> Alcotest.fail ("meta_of_json failed: " ^ err)
 
+let make_task ?(title = "Task") ?(description = "") ~id ~status () : Types.task =
+  {
+    id;
+    title;
+    description;
+    task_status = status;
+    priority = 3;
+    files = [];
+    created_at = "2026-06-26T00:00:00Z";
+    created_by = Some "test";
+    contract = None;
+    handoff_context = None;
+    cycle_count = 0;
+    reclaim_policy = None;
+    do_not_reclaim_reason = None;
+  }
+
 let write_keeper_meta_exn config meta =
   match Keeper_meta_store.write_meta config meta with
   | Ok () -> ()
@@ -1344,6 +1361,92 @@ let test_health_json_keeps_timeout_pause_without_policy_manual () =
           (detail |> member "auto_resume_source" |> to_string);
         Alcotest.(check string) "last blocker class" "turn_timeout"
           (detail |> member "last_blocker" |> member "klass" |> to_string)))
+
+let test_health_json_degrades_on_active_task_owner_without_executable_fiber () =
+  with_temp_dir "health-active-task-owner-without-fiber" (fun dir ->
+    let config_root = make_config_root dir in
+    Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
+    write_file
+      (Filename.concat (Filename.concat config_root "keepers") "executor.toml")
+      "[keeper]\ngoal = \"goal-executor\"\nautoboot_enabled = false\n";
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        let executor =
+          make_keeper_meta ~name:"executor" ~trace_id:"trace-executor" ()
+        in
+        write_keeper_meta_exn config executor;
+        let task =
+          make_task
+            ~id:"task-active-owner"
+            ~title:"Active keeper task"
+            ~status:
+              (Types.InProgress
+                 {
+                   assignee = executor.Keeper_meta_contract.agent_name;
+                   started_at = "2026-06-26T00:00:01Z";
+                 })
+            ()
+        in
+        Workspace.write_backlog config
+          { Types.tasks = [ task ]; last_updated = "2026-06-26T00:00:02Z"; version = 2 };
+        let request = Httpun.Request.create `GET "/health" in
+        let json = Server_routes_http_runtime.make_health_json request in
+        let open Yojson.Safe.Util in
+        let fleet_safety = json |> member "keeper_fleet_safety" in
+        Alcotest.(check int) "health keeps autoboot target empty" 0
+          (fleet_safety |> member "target_reaction_capacity_count" |> to_int);
+        Alcotest.(check bool) "health does not report target no-executable" false
+          (fleet_safety |> member "no_executable_keeper_fibers" |> to_bool);
+        Alcotest.(check string) "health marks dormant task owner degraded"
+          "degraded"
+          (fleet_safety |> member "status" |> to_string);
+        Alcotest.(check string) "health marks dormant task owner blocker"
+          "active_task_owner_without_executable_fiber"
+          (fleet_safety |> member "blocker" |> to_string);
+        Alcotest.(check bool) "health exposes dormant task owner flag" true
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber"
+           |> to_bool);
+        Alcotest.(check int) "health exposes dormant owner count" 1
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_count"
+           |> to_int);
+        Alcotest.(check (list string)) "health exposes dormant owner name"
+          [ "executor" ]
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_names"
+           |> to_list
+           |> List.map to_string);
+        let dormant_tasks =
+          fleet_safety
+          |> member "active_task_owner_without_executable_fiber_tasks"
+          |> to_list
+        in
+        Alcotest.(check int) "health exposes dormant owner task row" 1
+          (List.length dormant_tasks);
+        let dormant_task = List.hd dormant_tasks in
+        Alcotest.(check string) "dormant row keeper" "executor"
+          (dormant_task |> member "keeper" |> to_string);
+        Alcotest.(check string) "dormant row agent"
+          executor.Keeper_meta_contract.agent_name
+          (dormant_task |> member "agent_name" |> to_string);
+        Alcotest.(check string) "dormant row task id" "task-active-owner"
+          (dormant_task |> member "task_id" |> to_string);
+        Alcotest.(check string) "dormant row status" "in_progress"
+          (dormant_task |> member "task_status" |> to_string);
+        Alcotest.(check int) "health has no scan errors" 0
+          (fleet_safety |> member "active_task_owner_scan_error_count" |> to_int);
+        Alcotest.(check bool) "health asks operator action" true
+          (fleet_safety |> member "operator_action_required" |> to_bool)))
 
 let test_health_json_degrades_when_reaction_capacity_below_target () =
   with_temp_dir "health-reaction-capacity-below-target" (fun dir ->
@@ -3153,6 +3256,10 @@ let () =
           Alcotest.test_case
             "health json keeps timeout pause without policy manual"
             `Quick test_health_json_keeps_timeout_pause_without_policy_manual;
+          Alcotest.test_case
+            "health json degrades on active task owner without executable fiber"
+            `Quick
+            test_health_json_degrades_on_active_task_owner_without_executable_fiber;
           Alcotest.test_case
             "health json degrades when reaction capacity is below target"
             `Quick test_health_json_degrades_when_reaction_capacity_below_target;


### PR DESCRIPTION
## Summary
- add a fleet health scan for active claimed/in-progress tasks whose persisted keeper owner has no executable fiber
- surface typed health fields for dormant active-task owners and scan errors
- add a regression covering zero autoboot target, zero executable fibers, and an in-progress keeper-owned task

## Live evidence
- On 2026-06-26, /health?full=1 reported keeper_fleet_safety.status=ok with executable_keeper_fiber_count=0, target_reaction_capacity_count=0, and operator_action_required=false.
- The live backlog simultaneously had three in_progress tasks assigned to keeper agents: task-1521 keeper-sangsu-agent, task-1528 keeper-executor-agent, task-1529 keeper-rondo-agent.
- Persisted keeper meta maps those agent names to sangsu, executor, and rondo.

## Verification
- ocamlformat --check lib/server/server_routes_http_runtime_fleet_scan.ml test/test_server_runtime_bootstrap.ml
- git diff --check
- scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe
- ./_build/default/test/test_server_runtime_bootstrap.exe test --color=never bootstrap 25