### PR TITLE
fix(memory): upsert librarian fallback notes

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -378,10 +378,6 @@ let collapse_for_unstructured_note raw =
     raw;
   Buffer.contents buf |> String.trim
 
-let unstructured_fallback_claim_id ~trace_id ~reason =
-  Keeper_memory_os_types.normalize_claim_id
-    (Printf.sprintf "librarian-unstructured-fallback-%s-%s" trace_id reason)
-
 let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason ~raw =
   let raw_excerpt, _ =
     Keeper_text_processing.truncate_utf8_prefix
@@ -416,11 +412,10 @@ let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason
           Keeper_memory_os_types.Ephemeral
     ; last_verified_at = Some now
     ; schema_version = Keeper_memory_os_types.schema_version
-    ; (* MASC authors this diagnostic fallback, not the LLM librarian. Use a
-         stable producer id so repeated unparseable responses for the same trace
-         and parse-failure class upsert instead of accumulating fresh raw-note
-         claims. The trace scope prevents cross-trace over-merge. *)
-      claim_id = unstructured_fallback_claim_id ~trace_id:inp.trace_id ~reason
+    ; (* MASC authors this diagnostic fallback, not the LLM librarian. Do not
+         overload the librarian [claim_id] producer-identity field; diagnostic
+         fallback rows degrade to exact-text identity via [claim_id = None]. *)
+      claim_id = None
     }
   in
   { Keeper_memory_os_types.trace_id = inp.trace_id

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -378,6 +378,10 @@ let collapse_for_unstructured_note raw =
     raw;
   Buffer.contents buf |> String.trim
 
+let unstructured_fallback_claim_id ~trace_id ~reason =
+  Keeper_memory_os_types.normalize_claim_id
+    (Printf.sprintf "librarian-unstructured-fallback-%s-%s" trace_id reason)
+
 let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason ~raw =
   let raw_excerpt, _ =
     Keeper_text_processing.truncate_utf8_prefix
@@ -412,7 +416,11 @@ let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason
           Keeper_memory_os_types.Ephemeral
     ; last_verified_at = Some now
     ; schema_version = Keeper_memory_os_types.schema_version
-    ; claim_id = None
+    ; (* MASC authors this diagnostic fallback, not the LLM librarian. Use a
+         stable producer id so repeated unparseable responses for the same trace
+         and parse-failure class upsert instead of accumulating fresh raw-note
+         claims. The trace scope prevents cross-trace over-merge. *)
+      claim_id = unstructured_fallback_claim_id ~trace_id:inp.trace_id ~reason
     }
   in
   { Keeper_memory_os_types.trace_id = inp.trace_id

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1172,9 +1172,76 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
             (contains "unstructured_note" fact.Types.claim);
           Alcotest.(check (float 0.001))
             "persisted fact first_seen uses injected clock"
-            fallback_created_at
-            fact.Types.first_seen
+          fallback_created_at
+          fact.Types.first_seen
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
+;;
+
+let test_librarian_unstructured_fallback_upserts_by_claim_id () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      with_eio (fun ~sw ~net ~clock ->
+        let keeper_id = "runtime-librarian-fallback-upsert-keeper" in
+        let response_text = ref "first invalid librarian payload" in
+        let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+          Ok (fake_response !response_text)
+        in
+        let inp : Librarian.input =
+          { Librarian.trace_id = "trace-runtime-fallback-upsert"
+          ; generation = 12
+          ; messages = [ text_message "Please remember repeated fallback shape." ]
+          }
+        in
+        let run_once () =
+          match
+            Librarian_runtime.extract_and_append_with_provider
+              ~complete
+              ~clock
+              ~timeout_sec:1.0
+              ~sw
+              ~net
+              ~keeper_id
+              ~provider_cfg:(test_provider_cfg ())
+              inp
+          with
+          | Error msg -> Alcotest.fail msg
+          | Ok episode -> episode
+        in
+        let first = run_once () in
+        Eio.Time.sleep clock 0.01;
+        response_text := "second invalid librarian payload with different text";
+        let second = run_once () in
+        Alcotest.(check int)
+          "both fallback episodes are still evented"
+          2
+          (List.length (Memory_io.read_events_tail ~keeper_id ~n:10));
+        match Memory_io.read_facts_all ~keeper_id with
+        | [ fact ] ->
+          Alcotest.(check bool)
+            "fallback claim_id is producer-stable"
+            true
+            (match fact.Types.claim_id with
+             | Some id ->
+               contains "librarian-unstructured-fallback" id
+               && contains "trace-runtime-fallback-upsert" id
+             | None -> false);
+          Alcotest.(check bool)
+            "first raw note is preserved on merge"
+            true
+            (contains "first invalid librarian payload" fact.Types.claim);
+          Alcotest.(check bool)
+            "second raw note did not append a fresh fact"
+            false
+            (contains "second invalid librarian payload" fact.Types.claim);
+          Alcotest.(check (float 0.001))
+            "first_seen anchor is inherited"
+            first.Types.created_at
+            fact.Types.first_seen;
+          Alcotest.(check (option (float 0.001)))
+            "last_verified_at advances on reobserve"
+            (Some second.Types.created_at)
+            fact.Types.last_verified_at
+        | facts -> Alcotest.failf "expected one upserted fact, got %d" (List.length facts))))
 ;;
 
 let test_librarian_runtime_reports_fact_upsert_failure () =
@@ -4135,6 +4202,10 @@ let () =
             "unparseable output is preserved as unstructured fallback"
             `Quick
             test_librarian_runtime_preserves_unstructured_fallback
+        ; Alcotest.test_case
+            "unstructured fallback upserts by producer claim_id"
+            `Quick
+            test_librarian_unstructured_fallback_upserts_by_claim_id
         ; Alcotest.test_case
             "provider slot gate caps concurrency at capacity (#21376/#21230)"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1135,6 +1135,10 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
                 "fallback is ephemeral"
                 true
                 (fact.Types.category = Types.Ephemeral);
+              Alcotest.(check (option string))
+                "fallback diagnostic does not author claim_id"
+                None
+                fact.Types.claim_id;
               Alcotest.(check (float 0.001))
                 "fallback fact first_seen uses episode timestamp"
                 episode.Types.created_at
@@ -1177,22 +1181,24 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
 ;;
 
-let test_librarian_unstructured_fallback_upserts_by_claim_id () =
+let test_librarian_unstructured_fallback_uses_exact_text_identity () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
       with_eio (fun ~sw ~net ~clock ->
         let keeper_id = "runtime-librarian-fallback-upsert-keeper" in
-        let response_text = ref "first invalid librarian payload" in
-        let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
-          Ok (fake_response !response_text)
-        in
         let inp : Librarian.input =
           { Librarian.trace_id = "trace-runtime-fallback-upsert"
           ; generation = 12
           ; messages = [ text_message "Please remember repeated fallback shape." ]
           }
         in
-        let run_once () =
+        let first_complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+          Ok (fake_response "first invalid librarian payload")
+        in
+        let second_complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+          Ok (fake_response "second invalid librarian payload with different text")
+        in
+        let run_once complete =
           match
             Librarian_runtime.extract_and_append_with_provider
               ~complete
@@ -1207,41 +1213,45 @@ let test_librarian_unstructured_fallback_upserts_by_claim_id () =
           | Error msg -> Alcotest.fail msg
           | Ok episode -> episode
         in
-        let first = run_once () in
-        Eio.Time.sleep clock 0.01;
-        response_text := "second invalid librarian payload with different text";
-        let second = run_once () in
+        let first = run_once first_complete in
+        let second = run_once second_complete in
         Alcotest.(check int)
           "both fallback episodes are still evented"
           2
           (List.length (Memory_io.read_events_tail ~keeper_id ~n:10));
-        match Memory_io.read_facts_all ~keeper_id with
-        | [ fact ] ->
+        let facts = Memory_io.read_facts_all ~keeper_id in
+        Alcotest.(check int) "distinct diagnostics remain distinct facts" 2 (List.length facts);
+        Alcotest.(check bool)
+          "fallback diagnostics do not author claim_id"
+          true
+          (List.for_all (fun fact -> Option.is_none fact.Types.claim_id) facts);
+        Alcotest.(check bool)
+          "first raw note is preserved"
+          true
+          (List.exists
+             (fun fact -> contains "first invalid librarian payload" fact.Types.claim)
+             facts);
+        Alcotest.(check bool)
+          "second raw note is preserved"
+          true
+          (List.exists
+             (fun fact -> contains "second invalid librarian payload" fact.Types.claim)
+             facts);
+        (match first.Types.claims, second.Types.claims with
+         | [ first_fact ], [ second_fact ] ->
           Alcotest.(check bool)
-            "fallback claim_id is producer-stable"
+            "first result has no claim_id"
             true
-            (match fact.Types.claim_id with
-             | Some id ->
-               contains "librarian-unstructured-fallback" id
-               && contains "trace-runtime-fallback-upsert" id
-             | None -> false);
+            (Option.is_none first_fact.Types.claim_id);
           Alcotest.(check bool)
-            "first raw note is preserved on merge"
+            "second result has no claim_id"
             true
-            (contains "first invalid librarian payload" fact.Types.claim);
-          Alcotest.(check bool)
-            "second raw note did not append a fresh fact"
-            false
-            (contains "second invalid librarian payload" fact.Types.claim);
-          Alcotest.(check (float 0.001))
-            "first_seen anchor is inherited"
-            first.Types.created_at
-            fact.Types.first_seen;
-          Alcotest.(check (option (float 0.001)))
-            "last_verified_at advances on reobserve"
-            (Some second.Types.created_at)
-            fact.Types.last_verified_at
-        | facts -> Alcotest.failf "expected one upserted fact, got %d" (List.length facts))))
+            (Option.is_none second_fact.Types.claim_id)
+         | first_claims, second_claims ->
+           Alcotest.failf
+             "expected one fallback fact in each result, got %d/%d"
+             (List.length first_claims)
+             (List.length second_claims)))))
 ;;
 
 let test_librarian_runtime_reports_fact_upsert_failure () =
@@ -4203,9 +4213,9 @@ let () =
             `Quick
             test_librarian_runtime_preserves_unstructured_fallback
         ; Alcotest.test_case
-            "unstructured fallback upserts by producer claim_id"
+            "unstructured fallback uses exact-text identity"
             `Quick
-            test_librarian_unstructured_fallback_upserts_by_claim_id
+            test_librarian_unstructured_fallback_uses_exact_text_identity
         ; Alcotest.test_case
             "provider slot gate caps concurrency at capacity (#21376/#21230)"
             `Quick

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -116,10 +116,10 @@ let session_with_stale_seen () =
   Time_compat.sleep 0.01;
   (session, before)
 
-let check_session_touched label session before =
+let check_session_touched label (session : SH.session) before =
   Alcotest.(check bool) label true (Atomic.get session.last_seen > before)
 
-let check_session_not_touched label session before =
+let check_session_not_touched label (session : SH.session) before =
   Alcotest.(check bool) label true (Atomic.get session.last_seen = before)
 
 let test_handle_post_session_touch_success () =


### PR DESCRIPTION
## Summary
- assign MASC-authored unstructured librarian fallback facts a stable trace-scoped claim_id
- repeated invalid-JSON fallback episodes still append events, but their diagnostic facts upsert instead of accumulating fresh raw-note rows
- add a regression covering two different invalid provider responses for the same trace collapsing to one fact row

## Validation
- ocamlformat --check lib/keeper/keeper_librarian_runtime.ml test/test_keeper_memory_os.ml
- git diff --check
- scripts/dune-local.sh build test/test_keeper_memory_os.exe
- ./_build/default/test/test_keeper_memory_os.exe test --color=never "librarian runtime"