### PR TITLE
feat(keeper): integrate multimodal policy ingestion branch

### DIFF
--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -30,7 +30,13 @@ let config_field_names =
   ; "tool_heavy_msg_threshold"; "tool_heavy_ratio_floor"
   ; "auto_handoff"; "handoff_threshold"; "handoff_cooldown_sec"
   ; "per_provider_timeout_s"; "always_approve"
-  ; "multimodal_policy"
+    (* NOTE: multimodal_policy is a PERSISTED runtime field: meta_to_json emits
+       it (keeper_meta_json.ml) and it is a canonical key. It must NOT be in this
+       config-only scrub list: keeper_meta_store drops these keys on read before
+       meta_of_json, so listing it here deleted "delegate" on every read (parse
+       fell back to Mm_inherit -> gate never delegated -> next write re-emitted
+       "inherit"). The test/test_config_runtime_split invariant (no meta_to_json
+       key may be in config_field_names) guards this. *)
   ; "autoboot_enabled"; "max_context_override"
   ; "telemetry_feedback_enabled"; "telemetry_feedback_window_hours"
   ]

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -1,7 +1,8 @@
 (** Keeper meta JSON scrub helpers.
 
-    Kept below the codec/parser facade so persisted runtime JSON can be
-    normalized before [keeper_meta] decoding. *)
+    Kept below the codec/parser facade so persisted runtime JSON cleanup code
+    can share the same TOML-owned field names without introducing a module
+    cycle. *)
 
 
 (* Config/policy fields owned by TOML only.  Never written to JSON; scrubbed
@@ -32,11 +33,11 @@ let config_field_names =
   ; "per_provider_timeout_s"; "always_approve"
     (* NOTE: multimodal_policy is a PERSISTED runtime field: meta_to_json emits
        it (keeper_meta_json.ml) and it is a canonical key. It must NOT be in this
-       config-only scrub list: keeper_meta_store drops these keys on read before
-       meta_of_json, so listing it here deleted "delegate" on every read (parse
-       fell back to Mm_inherit -> gate never delegated -> next write re-emitted
-       "inherit"). The test/test_config_runtime_split invariant (no meta_to_json
-       key may be in config_field_names) guards this. *)
+       config-only scrub list: any call-site that rewrites persisted JSON with
+       this list would delete "delegate", after which parsing falls back to
+       Mm_inherit and the next write re-emits "inherit". The
+       test/test_config_runtime_split invariant (no meta_to_json key may be in
+       config_field_names) guards this. *)
   ; "autoboot_enabled"; "max_context_override"
   ; "telemetry_feedback_enabled"; "telemetry_feedback_window_hours"
   ]

--- a/lib/keeper/keeper_meta_json_scrub.ml
+++ b/lib/keeper/keeper_meta_json_scrub.ml
@@ -30,6 +30,7 @@ let config_field_names =
   ; "tool_heavy_msg_threshold"; "tool_heavy_ratio_floor"
   ; "auto_handoff"; "handoff_threshold"; "handoff_cooldown_sec"
   ; "per_provider_timeout_s"; "always_approve"
+  ; "multimodal_policy"
   ; "autoboot_enabled"; "max_context_override"
   ; "telemetry_feedback_enabled"; "telemetry_feedback_window_hours"
   ]

--- a/lib/keeper/keeper_meta_json_scrub.mli
+++ b/lib/keeper/keeper_meta_json_scrub.mli
@@ -1,7 +1,8 @@
 (** Keeper meta JSON scrub helpers.
 
-    Lives below the codec/parser facade so persisted runtime JSON can
-    be normalized before [keeper_meta] decoding. *)
+    Lives below the codec/parser facade so persisted runtime JSON cleanup code
+    can share the same TOML-owned field names without introducing a module
+    cycle. *)
 
 (** Config field names owned by TOML only — never written to JSON.
     Defined here to avoid module cycles; re-exported by

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -30,6 +30,7 @@ let read_meta_file_path path : (Keeper_meta_contract.keeper_meta option, string)
     match Safe_ops.read_json_file_safe path with
     | Error e -> Error e
     | Ok json ->
+      let json = drop_assoc_keys config_field_names json in
       warn_unknown_keeper_meta_keys ~path json;
       (match meta_of_json json with
        | Ok meta -> Ok (Some meta)

--- a/lib/keeper/keeper_meta_store.ml
+++ b/lib/keeper/keeper_meta_store.ml
@@ -30,7 +30,6 @@ let read_meta_file_path path : (Keeper_meta_contract.keeper_meta option, string)
     match Safe_ops.read_json_file_safe path with
     | Error e -> Error e
     | Ok json ->
-      let json = drop_assoc_keys config_field_names json in
       warn_unknown_keeper_meta_keys ~path json;
       (match meta_of_json json with
        | Ok meta -> Ok (Some meta)

--- a/test/dune
+++ b/test/dune
@@ -2455,7 +2455,11 @@
  (modules test_keeper_visible_path_projection)
  (libraries masc_test_deps))
 
-(executable
+; (test) not (executable): this guards the "no meta_to_json key may live in
+; config_field_names" invariant (config/runtime split). As (executable) it was
+; never run by `dune runtest`, so the multimodal_policy scrub regression shipped
+; uncaught. (test) runs it under @runtest; it exits 1 on a leaked key.
+(test
  (name test_config_runtime_split)
  (modules test_config_runtime_split)
  (libraries masc_test_deps))

--- a/test/stanzas/test_keeper_meta_unknown_keys_warn.inc
+++ b/test/stanzas/test_keeper_meta_unknown_keys_warn.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_meta_unknown_keys_warn)
  (modules test_keeper_meta_unknown_keys_warn)
- (libraries masc keeper_metrics fs_compat alcotest))
+ (libraries masc keeper_metrics fs_compat alcotest yojson))

--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -19,25 +19,10 @@ open Masc
 let counter_total () =
   Otel_metric_store.metric_total Keeper_metrics.(to_string MetaJsonFailures)
 
-let read_file path =
-  let ic = open_in path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () ->
-       let len = in_channel_length ic in
-       really_input_string ic len)
-
-let contains_substring haystack needle =
-  let haystack_len = String.length haystack in
-  let needle_len = String.length needle in
-  if needle_len = 0
-  then true
-  else (
-    let rec loop idx =
-      idx + needle_len <= haystack_len
-      && (String.sub haystack idx needle_len = needle || loop (idx + 1))
-    in
-    loop 0)
+let top_level_json_key_present path key =
+  match Yojson.Safe.from_file path with
+  | `Assoc fields -> List.mem_assoc key fields
+  | _ -> Alcotest.fail "keeper meta must remain a JSON object"
 
 let canonical_only_meta_json () =
   (* Build an `Assoc whose every key is in [canonical_keeper_meta_key_names].
@@ -121,7 +106,27 @@ let test_persisted_multimodal_policy_is_canonical_before_warn () =
       Alcotest.(check bool)
         "read path keeps persisted multimodal_policy key"
         true
-        (contains_substring (read_file path) "\"multimodal_policy\""))
+        (top_level_json_key_present path "multimodal_policy"))
+
+let test_config_keys_are_warned_before_parse () =
+  let path = Filename.temp_file "masc-config-key-keeper-meta-" ".json" in
+  Fun.protect
+    ~finally:(fun () ->
+      if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+      Fs_compat.save_file
+        path
+        {|{"name":"config-key","agent_name":"config-key","trace_id":"trace-config-key","tool_access":[],"goal":"legacy profile goal"}|};
+      let before = counter_total () in
+      (match Keeper_meta_store.read_meta_file_path path with
+       | Ok (Some meta) -> Alcotest.(check string) "keeper name" "config-key" meta.name
+       | Ok None -> Alcotest.fail "expected keeper meta"
+       | Error err -> Alcotest.fail ("read_meta_file_path failed: " ^ err));
+      let after = counter_total () in
+      Alcotest.(check bool)
+        "TOML-owned config keys are warned before parse, not silently dropped"
+        true
+        (after > before))
 
 let fresh_tmpdir () =
   let path = Filename.temp_file "masc-progress-refresh-" ".tmp" in
@@ -175,6 +180,10 @@ let () =
             "persisted multimodal policy is canonical before warning"
             `Quick
             test_persisted_multimodal_policy_is_canonical_before_warn
+        ; Alcotest.test_case
+            "config keys are warned before parse"
+            `Quick
+            test_config_keys_are_warned_before_parse
         ; Alcotest.test_case
             "progress Updated-line refresh failure is observable"
             `Quick

--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -19,6 +19,26 @@ open Masc
 let counter_total () =
   Otel_metric_store.metric_total Keeper_metrics.(to_string MetaJsonFailures)
 
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let len = in_channel_length ic in
+       really_input_string ic len)
+
+let contains_substring haystack needle =
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  if needle_len = 0
+  then true
+  else (
+    let rec loop idx =
+      idx + needle_len <= haystack_len
+      && (String.sub haystack idx needle_len = needle || loop (idx + 1))
+    in
+    loop 0)
+
 let canonical_only_meta_json () =
   (* Build an `Assoc whose every key is in [canonical_keeper_meta_key_names].
      Values are placeholders — [warn_unknown_keeper_meta_keys] inspects keys
@@ -74,7 +94,7 @@ let test_counter_ticks_on_genuine_unknown_key () =
     true
     (after > before)
 
-let test_legacy_toml_owned_meta_keys_are_ignored_before_warn () =
+let test_persisted_multimodal_policy_is_canonical_before_warn () =
   let path = Filename.temp_file "masc-legacy-keeper-meta-" ".json" in
   Fun.protect
     ~finally:(fun () ->
@@ -86,22 +106,22 @@ let test_legacy_toml_owned_meta_keys_are_ignored_before_warn () =
       let before = counter_total () in
       (match Keeper_meta_store.read_meta_file_path path with
        | Ok (Some meta) ->
-         Alcotest.(check string) "keeper name" "legacy-mm" meta.name
+         Alcotest.(check string) "keeper name" "legacy-mm" meta.name;
+         Alcotest.(check string)
+           "multimodal policy"
+           "delegate"
+           (Keeper_types_profile.multimodal_policy_to_string meta.multimodal_policy)
        | Ok None -> Alcotest.fail "expected keeper meta"
        | Error err -> Alcotest.fail ("read_meta_file_path failed: " ^ err));
       let after = counter_total () in
       Alcotest.(check (float 0.0001))
-        "legacy TOML-owned keys are scrubbed before unknown-key warning"
+        "persisted multimodal policy is canonical before unknown-key warning"
         before
         after;
-      match Safe_ops.read_json_file_safe path with
-      | Error err -> Alcotest.fail ("failed to reload keeper meta: " ^ err)
-      | Ok (`Assoc fields) ->
-        Alcotest.(check bool)
-          "read path does not rewrite persisted legacy meta"
-          true
-          (List.mem_assoc "multimodal_policy" fields)
-      | Ok _ -> Alcotest.fail "keeper meta must remain a JSON object")
+      Alcotest.(check bool)
+        "read path keeps persisted multimodal_policy key"
+        true
+        (contains_substring (read_file path) "\"multimodal_policy\""))
 
 let fresh_tmpdir () =
   let path = Filename.temp_file "masc-progress-refresh-" ".tmp" in
@@ -152,9 +172,9 @@ let () =
             `Quick
             test_counter_ticks_on_genuine_unknown_key
         ; Alcotest.test_case
-            "legacy TOML-owned keys are ignored before warning"
+            "persisted multimodal policy is canonical before warning"
             `Quick
-            test_legacy_toml_owned_meta_keys_are_ignored_before_warn
+            test_persisted_multimodal_policy_is_canonical_before_warn
         ; Alcotest.test_case
             "progress Updated-line refresh failure is observable"
             `Quick

--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -82,14 +82,7 @@ let test_legacy_toml_owned_meta_keys_are_ignored_before_warn () =
     (fun () ->
       Fs_compat.save_file
         path
-        (Yojson.Safe.to_string
-           (`Assoc
-             [ "name", `String "legacy-mm"
-             ; "agent_name", `String "legacy-mm"
-             ; "trace_id", `String "trace-legacy-mm"
-             ; "tool_access", `List []
-             ; "multimodal_policy", `String "Delegate"
-             ]));
+        {|{"name":"legacy-mm","agent_name":"legacy-mm","trace_id":"trace-legacy-mm","tool_access":[],"multimodal_policy":"Delegate"}|};
       let before = counter_total () in
       (match Keeper_meta_store.read_meta_file_path path with
        | Ok (Some meta) ->

--- a/test/test_keeper_meta_unknown_keys_warn.ml
+++ b/test/test_keeper_meta_unknown_keys_warn.ml
@@ -74,6 +74,42 @@ let test_counter_ticks_on_genuine_unknown_key () =
     true
     (after > before)
 
+let test_legacy_toml_owned_meta_keys_are_ignored_before_warn () =
+  let path = Filename.temp_file "masc-legacy-keeper-meta-" ".json" in
+  Fun.protect
+    ~finally:(fun () ->
+      if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+      Fs_compat.save_file
+        path
+        (Yojson.Safe.to_string
+           (`Assoc
+             [ "name", `String "legacy-mm"
+             ; "agent_name", `String "legacy-mm"
+             ; "trace_id", `String "trace-legacy-mm"
+             ; "tool_access", `List []
+             ; "multimodal_policy", `String "Delegate"
+             ]));
+      let before = counter_total () in
+      (match Keeper_meta_store.read_meta_file_path path with
+       | Ok (Some meta) ->
+         Alcotest.(check string) "keeper name" "legacy-mm" meta.name
+       | Ok None -> Alcotest.fail "expected keeper meta"
+       | Error err -> Alcotest.fail ("read_meta_file_path failed: " ^ err));
+      let after = counter_total () in
+      Alcotest.(check (float 0.0001))
+        "legacy TOML-owned keys are scrubbed before unknown-key warning"
+        before
+        after;
+      match Safe_ops.read_json_file_safe path with
+      | Error err -> Alcotest.fail ("failed to reload keeper meta: " ^ err)
+      | Ok (`Assoc fields) ->
+        Alcotest.(check bool)
+          "read path does not rewrite persisted legacy meta"
+          true
+          (List.mem_assoc "multimodal_policy" fields)
+      | Ok _ -> Alcotest.fail "keeper meta must remain a JSON object")
+
 let fresh_tmpdir () =
   let path = Filename.temp_file "masc-progress-refresh-" ".tmp" in
   Sys.remove path;
@@ -122,6 +158,10 @@ let () =
             "counter still ticks on genuine unknown"
             `Quick
             test_counter_ticks_on_genuine_unknown_key
+        ; Alcotest.test_case
+            "legacy TOML-owned keys are ignored before warning"
+            `Quick
+            test_legacy_toml_owned_meta_keys_are_ignored_before_warn
         ; Alcotest.test_case
             "progress Updated-line refresh failure is observable"
             `Quick


### PR DESCRIPTION
## What

Rebases the multimodal policy ingestion branch onto latest main and scopes this PR to the remaining unique keeper-meta gap: persisted runtime snapshot keys such as `multimodal_policy` must stay parseable and canonical, while TOML-owned legacy config keys must not be silently stripped before warning/parsing.

Main already contains:
- `multimodal_policy` type and profile/TOML parsing
- `keeper_vision_ingest` image eviction (RFC vision-delegation 2.3)
- `keeper_meta_json_parse` round-trip parsing of `multimodal_policy`

This branch keeps `multimodal_policy` out of the config-only scrub list because `meta_to_json` emits it as canonical persisted runtime state. Dropping it before parse would silently downgrade persisted `Delegate` back to `Mm_inherit`. The read path now warns on and parses the original JSON instead of applying the config-field drop list first.

## Changes

- `lib/keeper/keeper_meta_json_scrub.ml`: documents why persisted runtime keys must not be added to `config_field_names`
- `lib/keeper/keeper_meta_store.ml`: removes pre-parse `drop_assoc_keys config_field_names`, so unknown-key warning and `meta_of_json` see the same source JSON
- `test/dune`: makes `test_config_runtime_split` run as a Dune test
- `test/test_keeper_meta_unknown_keys_warn.ml`: pins persisted `multimodal_policy = Delegate` readback, structural JSON key preservation, and warning behavior for TOML-owned config keys

## Related

- Supersedes / incorporates #22323
- Closes the gap between TOML-owned keeper defaults and JSON persisted runtime state
