### PR TITLE
fix(keeper): require visible no-work proactive replies

### DIFF
--- a/config/keepers/verifier.toml
+++ b/config/keepers/verifier.toml
@@ -38,7 +38,7 @@ actionable signal 처리:
 - 신호 수신 -> keeper_tasks_list/masc_tasks 또는 keeper_tasks_audit 1회 호출 -> approve/reject, orphan force_release, 또는 blocker/no-work 기록 순서로 처리한다.
 - passive read만 하고 끝내지 마라. 단, 검증 불가 blocker 기록은 유효한 active action이다.
 - awaiting_verification task가 0개면 free-text로 끝내지 마라. board/broadcast 신호가 있으면 keeper_board_curation_submit으로 "no awaiting verification tasks"를 기록한다.
-- 순수 idle/no-work 턴에서는 SPEECH_ACT: stay_silent와 DELIVERY_SURFACE: silent를 사용한다.
+- 순수 idle/no-work 턴에서는 활동을 조작하지 말고, 짧은 no-work 보고와 필수 상태 블록으로 종료한다.
 """
 
 tool_access = [

--- a/config/prompts/keeper.core_behavior.md
+++ b/config/prompts/keeper.core_behavior.md
@@ -1,7 +1,7 @@
 Autonomous behavior:
 - Use tools when they are the direct way to inspect the current state or make progress. If the correct result is a direct answer, a blocker report, or no-op, do not fabricate a tool call just to satisfy a policy.
 - On proactive turns: act directly on your current goal. Only call keeper_board_list if you expect actionable content. If board_list returned no actionable items last turn, do not call it again.
-- The scheduler should open proactive turns only when structured work exists (claimed task, backlog, repo delta, or external signal). If a proactive turn still arrives without a real signal, do not fabricate activity; report no work and end the turn without a visible reply or tool call.
+- The scheduler should open proactive turns only when structured work exists (claimed task, backlog, repo delta, or external signal). If a proactive turn still arrives without a real signal, do not fabricate activity; give a short no-work report and end with the required state block.
 - Heartbeat is server-managed. Do not plan or request heartbeat tool calls.
 - ACTION TOOLS: Use only the exact tool schemas currently shown to you by the runtime. Common action tools, when present in your active schema list, include keeper_task_claim (claim work), Read/Edit/Write (read and modify files), Execute (run typed `executable`/`argv` inside your sandbox), and keeper_board_post (share findings). Do not call hidden implementation names unless the active schema literally lists that exact name. Read/list/search calls are evidence gathering; follow them with a real next step only when the evidence justifies it.
 

--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -144,7 +144,7 @@ A PR you opened is open work assigned to you. It is not done when you push; it i
 - Heartbeat is server-managed. You do not need to call any heartbeat tool.
 - Do not spend a turn on maintenance-only tools when actionable work exists.
 - If blocked, report the concrete blocker and what you need to proceed
-- If nothing meaningful to do, end the turn without a visible reply or tool call
+- If nothing meaningful remains after inspection, give a short no-work report and end with the required state block
 
 Board tools are optional. Do not post just to satisfy the loop.
 When making claims or decisions, search the library or run a shell query first if relevant facts may exist.

--- a/test/dune
+++ b/test/dune
@@ -976,6 +976,7 @@
   test_keeper_wip_admission
   test_eval_gate_evasion
   test_prompt_registry_defaults
+  test_prompt_no_silent_reply_contract
   test_keeper_prompt_external
   test_keeper_recurring
   test_evidence_claim_schema
@@ -1163,6 +1164,7 @@
   test_keeper_wip_admission
   test_eval_gate_evasion
   test_prompt_registry_defaults
+  test_prompt_no_silent_reply_contract
   test_keeper_prompt_external
   test_keeper_recurring
   test_evidence_claim_schema

--- a/test/test_keeper_no_signal_silence.ml
+++ b/test/test_keeper_no_signal_silence.ml
@@ -1,10 +1,10 @@
-(** No-signal silence invariant for [keeper_cycle_decision].
+(** No-signal scheduler invariant for [keeper_cycle_decision].
 
     PR #21685 removed the [Entropic_oscillation] turn-trigger: a 600s / 5%
     random probe that, per the runtime decision log (96 entropic turns over
     ~19h on the analyst keeper), produced visible action 88.5% of the time —
-    contradicting the prompt policy ([config/prompts/keeper.core_behavior.md:4]:
-    a structured-work-less proactive turn reports [SPEECH_ACT: stay_silent]).
+    contradicting the scheduler policy: a structured-work-less proactive turn
+    should not be opened.
 
     After the removal, a warm keeper (past bootstrap, [min_interval] not yet
     elapsed, no provider cooldown) with NO per-keeper signal (no mention, board
@@ -14,7 +14,8 @@
     It is the structural dual of the thundering-herd backlog test
     ([test_keeper_reactive_wake_backlog_gate]): that file shows global backlog
     drives a run ([backlog=1] -> [should_run=true]); this file shows the
-    absence of all signals drives silence ([backlog=0] -> [should_run=false]).
+    absence of all signals suppresses scheduling ([backlog=0] ->
+    [should_run=false]).
 
     The assertion is sensitive to [should_run]: a [|| true] mutation of the
     intent flag is killed by this test. The removed [Entropic_oscillation]

--- a/test/test_prompt_no_silent_reply_contract.ml
+++ b/test/test_prompt_no_silent_reply_contract.ml
@@ -30,6 +30,10 @@ let prompt_path name =
   Filename.concat (find_repo_root (Sys.getcwd ())) ("config/prompts/" ^ name)
 ;;
 
+let keeper_config_path name =
+  Filename.concat (find_repo_root (Sys.getcwd ())) ("config/keepers/" ^ name)
+;;
+
 let contains text needle =
   String_util.contains_substring text needle
 ;;
@@ -64,6 +68,21 @@ let test_no_work_prompts_do_not_request_silent_finish () =
     [ "keeper.core_behavior.md"; "keeper.unified.system.md" ]
 ;;
 
+let test_keeper_toml_does_not_request_silent_finish () =
+  let root = find_repo_root (Sys.getcwd ()) in
+  let keepers_dir = Filename.concat root "config/keepers" in
+  Sys.readdir keepers_dir
+  |> Array.to_list
+  |> List.filter (fun file -> Filename.check_suffix file ".toml")
+  |> List.sort String.compare
+  |> List.iter (fun file ->
+    let prompt = "config/keepers/" ^ file in
+    let text = read_file (keeper_config_path file) in
+    assert_not_contains ~prompt text "SPEECH_ACT: stay_silent";
+    assert_not_contains ~prompt text "DELIVERY_SURFACE: silent";
+    assert_not_contains ~prompt text "stay_silent")
+;;
+
 let () =
   run
     "prompt no silent reply contract"
@@ -72,6 +91,10 @@ let () =
             "no-work prompts require visible no-work report"
             `Quick
             test_no_work_prompts_do_not_request_silent_finish
+        ; test_case
+            "keeper TOML must not request silent no-work finish"
+            `Quick
+            test_keeper_toml_does_not_request_silent_finish
         ] )
     ]
 ;;

--- a/test/test_prompt_no_silent_reply_contract.ml
+++ b/test/test_prompt_no_silent_reply_contract.ml
@@ -1,0 +1,77 @@
+(** Prompt asset guard for the keeper no-work contract.
+
+    Keeper finalization requires visible response text or executed tool
+    progress. Prompt assets must not tell keepers to finish a proactive turn
+    with no visible reply and no tool call; that produces a fatal
+    ["keeper turn completed with no textual reply"] runtime error. *)
+
+open Alcotest
+
+let rec find_repo_root dir =
+  let marker = Filename.concat dir "config/prompts/keeper.core_behavior.md" in
+  if Sys.file_exists marker then dir
+  else
+    let parent = Filename.dirname dir in
+    if String.equal parent dir
+    then fail "could not locate repo root from prompt contract test"
+    else find_repo_root parent
+;;
+
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let len = in_channel_length ic in
+       really_input_string ic len)
+;;
+
+let prompt_path name =
+  Filename.concat (find_repo_root (Sys.getcwd ())) ("config/prompts/" ^ name)
+;;
+
+let contains text needle =
+  String_util.contains_substring text needle
+;;
+
+let assert_not_contains ~prompt text needle =
+  check
+    bool
+    (Printf.sprintf "%s must not contain %S" prompt needle)
+    false
+    (contains text needle)
+;;
+
+let assert_contains ~prompt text needle =
+  check
+    bool
+    (Printf.sprintf "%s must contain %S" prompt needle)
+    true
+    (contains text needle)
+;;
+
+let test_no_work_prompts_do_not_request_silent_finish () =
+  List.iter
+    (fun prompt ->
+       let text = read_file (prompt_path prompt) in
+       assert_not_contains
+         ~prompt
+         text
+         "without a visible reply or tool call";
+       assert_not_contains ~prompt text "stay_silent";
+       assert_contains ~prompt text "short no-work report";
+       assert_contains ~prompt text "state block")
+    [ "keeper.core_behavior.md"; "keeper.unified.system.md" ]
+;;
+
+let () =
+  run
+    "prompt no silent reply contract"
+    [ ( "prompt assets"
+      , [ test_case
+            "no-work prompts require visible no-work report"
+            `Quick
+            test_no_work_prompts_do_not_request_silent_finish
+        ] )
+    ]
+;;


### PR DESCRIPTION
## Summary
- update keeper prompt assets so no-work proactive turns produce a short visible report plus the required state block instead of ending silently
- add a prompt asset guard that rejects the fatal silent-finish phrasing
- update the older no-signal scheduler test comments so they no longer imply prompt-level stay_silent behavior

## Live evidence
- observed nick0cave keepalive turns returning thinking-only output and no tool progress, followed by "keeper turn completed with no textual reply" runtime failures
- active OAS turn_ready events showed a normal tool schema, so the immediate mismatch was the prompt contract telling keepers to end with no visible reply/tool while finalization requires visible text or tool progress

## Validation
- ocamlformat --check test/test_prompt_no_silent_reply_contract.ml test/test_keeper_no_signal_silence.ml
- git diff --check origin/main
- scripts/dune-local.sh build test/test_prompt_no_silent_reply_contract.exe (passed before rebase)
- ./_build/default/test/test_prompt_no_silent_reply_contract.exe --color=never (passed before and after rebase)

Note: a post-rebase wrapper build retry was blocked by another bare Dune process outside scripts/dune-local.sh; CI is the compile authority for the rebased commit.