### PR TITLE
feat(dashboard): embed runtime editor inline and add CRUD actions

### DIFF
--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -3,10 +3,12 @@ import { Save } from 'lucide-preact'
 import { useMemo, useState } from 'preact/hooks'
 import {
   deleteRuntimeTomlKey,
+  deleteRuntimeTomlSection,
   parseRuntimeTomlEnvironment,
   setRuntimeTomlBindingField,
   setRuntimeTomlDefault,
   setRuntimeTomlKey,
+  setRuntimeTomlModelField,
   setRuntimeTomlProviderCredential,
   setRuntimeTomlProviderField,
   type RuntimeTomlBinding,
@@ -204,6 +206,15 @@ export function RuntimeEnvironmentEditor({
     onChange: (runtimeId: string) => void,
     needsJson: boolean,
   ) {
+    const binding = environment.bindings.find(b => b.id === value)
+    const model = binding ? environment.models.find(m => m.id === binding.modelId) : null
+    const hasJsonCap = model ? (model.toolsSupport || model.thinkingSupport) : false
+    const capWarning = needsJson && !hasJsonCap && model
+      ? html`<span class="rt-warn">JSON 모드 필요 · ${model.apiName} 미지원</span>`
+      : needsJson && !model
+        ? html`<span class="rt-ok">JSON 모드 필요 · 모델 capability 미확인</span>`
+        : null
+
     return html`
       <div class="rt-lane">
         <div class="rt-lane-l">
@@ -220,9 +231,7 @@ export function RuntimeEnvironmentEditor({
           >
             ${runtimeIds.map(id => html`<option value=${id}>${id}</option>`)}
           </select>
-          ${needsJson
-            ? html`<span class="rt-ok" data-stub="no-per-model-json-cap">JSON 모드 필요 · 모델 capability 미수집</span>`
-            : null}
+          ${capWarning}
         </div>
       </div>
     `
@@ -336,6 +345,19 @@ export function RuntimeEnvironmentEditor({
                    had no live source and rendered as if confirmed. Removed until a
                    provider-capability source exists, rather than implying support
                    with no backing (PR #22081 review P1: no stub). */ ''}
+              <div class="rt-field" style=${{ marginTop: '11px', paddingTop: '11px', borderTop: '1px solid var(--border-soft)' }}>
+                <button
+                  type="button"
+                  class="rt-warn"
+                  style=${{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '11px' }}
+                  disabled=${isDisabled}
+                  onClick=${() => {
+                    if (typeof window !== 'undefined' && !window.confirm(`프로바이더 '${provider.id}'를 삭제할까요?`)) return
+                    onDraftChange(deleteRuntimeTomlSection(sourceText, `providers.${provider.id}`))
+                  }}
+                  data-testid=${`runtime-provider-delete-${provider.id}`}
+                >프로바이더 삭제</button>
+              </div>
             </div>
           `)}
         </div>
@@ -372,6 +394,23 @@ export function RuntimeEnvironmentEditor({
                      (PR #22081 review P1: no stub). effort stays — it states "미수집"
                      honestly rather than faking a value. */ ''}
                 <span class="rt-cap tcf mono" data-stub="no-effort-source">effort: 미수집</span>
+              </div>
+              <div class="rt-field" style=${{ marginTop: '9px' }}>
+                <span class="sub-k">max-ctx</span>
+                <input
+                  class="rt-input-sm mono"
+                  value=${model.maxContext == null ? '' : String(model.maxContext)}
+                  placeholder="—"
+                  disabled=${isDisabled}
+                  aria-label=${`${model.id} max-context`}
+                  onInput=${(event: Event) => {
+                    const raw = (event.currentTarget as HTMLInputElement).value
+                    const parsed = raw.trim() === '' ? 0 : Number.parseInt(raw, 10)
+                    if (Number.isFinite(parsed)) {
+                      onDraftChange(setRuntimeTomlModelField(sourceText, model.id, 'max-context', parsed))
+                    }
+                  }}
+                />
               </div>
             </div>
           `)}

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -3,7 +3,6 @@ import { Save } from 'lucide-preact'
 import { useMemo, useState } from 'preact/hooks'
 import {
   deleteRuntimeTomlKey,
-  deleteRuntimeTomlSection,
   parseRuntimeTomlEnvironment,
   setRuntimeTomlBindingField,
   setRuntimeTomlDefault,

--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -11,6 +11,7 @@ import {
   setRuntimeTomlModelField,
   setRuntimeTomlProviderCredential,
   setRuntimeTomlProviderField,
+  cascadeDeleteProvider,
   type RuntimeTomlBinding,
   type RuntimeTomlCredentialType,
   type RuntimeTomlEnvironment,
@@ -45,8 +46,9 @@ function firstId<T extends { id: string }>(items: T[]): string {
 }
 
 function parsePositiveInt(value: string): number | null {
-  const parsed = Number.parseInt(value, 10)
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+  const trimmed = value.trim()
+  const parsed = Number.parseInt(trimmed, 10)
+  return Number.isFinite(parsed) && parsed > 0 && String(parsed) === trimmed ? parsed : null
 }
 
 function runtimeOptions(environment: RuntimeTomlEnvironment): string[] {
@@ -208,12 +210,14 @@ export function RuntimeEnvironmentEditor({
   ) {
     const binding = environment.bindings.find(b => b.id === value)
     const model = binding ? environment.models.find(m => m.id === binding.modelId) : null
-    const hasJsonCap = model ? (model.toolsSupport || model.thinkingSupport) : false
-    const capWarning = needsJson && !hasJsonCap && model
+    const hasJsonCap = model ? (typeof model.jsonSupport === 'boolean' ? model.jsonSupport : null) : false
+    const capWarning = needsJson && hasJsonCap === false && model
       ? html`<span class="rt-warn">JSON 모드 필요 · ${model.apiName} 미지원</span>`
-      : needsJson && !model
+      : needsJson && hasJsonCap === null && model
         ? html`<span class="rt-ok">JSON 모드 필요 · 모델 capability 미확인</span>`
-        : null
+        : needsJson && !model
+          ? html`<span class="rt-ok">JSON 모드 필요 · 모델 capability 미확인</span>`
+          : null
 
     return html`
       <div class="rt-lane">
@@ -352,8 +356,9 @@ export function RuntimeEnvironmentEditor({
                   style=${{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '11px' }}
                   disabled=${isDisabled}
                   onClick=${() => {
-                    if (typeof window !== 'undefined' && !window.confirm(`프로바이더 '${provider.id}'를 삭제할까요?`)) return
-                    onDraftChange(deleteRuntimeTomlSection(sourceText, `providers.${provider.id}`))
+                    const msg = `프로바이더 '${provider.id}'를 삭제할까요? 관련 모델 바인딩 및 런타임 할당이 모두 삭제됩니다.`
+                    if (typeof window !== 'undefined' && !window.confirm(msg)) return
+                    onDraftChange(cascadeDeleteProvider(sourceText, provider.id))
                   }}
                   data-testid=${`runtime-provider-delete-${provider.id}`}
                 >프로바이더 삭제</button>
@@ -405,8 +410,8 @@ export function RuntimeEnvironmentEditor({
                   aria-label=${`${model.id} max-context`}
                   onInput=${(event: Event) => {
                     const raw = (event.currentTarget as HTMLInputElement).value
-                    const parsed = raw.trim() === '' ? 0 : Number.parseInt(raw, 10)
-                    if (Number.isFinite(parsed)) {
+                    const parsed = raw.trim() === '' ? null : parsePositiveInt(raw)
+                    if (parsed !== undefined) {
                       onDraftChange(setRuntimeTomlModelField(sourceText, model.id, 'max-context', parsed))
                     }
                   }}

--- a/dashboard/src/components/runtime-toml-editor.test.ts
+++ b/dashboard/src/components/runtime-toml-editor.test.ts
@@ -15,9 +15,11 @@ vi.mock('../api/dashboard', () => ({
 
 import { RuntimeTomlEditor } from './runtime-toml-editor'
 
+const MOCK_RUNTIME_PATH = '/tmp/.masc/config/runtime.toml'
+
 const baseConfig = {
   ok: true,
-  path: '/tmp/.masc/config/runtime.toml',
+  path: MOCK_RUNTIME_PATH,
   file_name: 'runtime.toml',
   source_text: '[runtime]\ndefault = "runpod_mtp.qwen"\n',
   reloaded: false,
@@ -115,7 +117,7 @@ describe('RuntimeTomlEditor', () => {
 
     await waitFor(() => {
       expect(apiMocks.fetchRuntimeTomlConfig).toHaveBeenCalledTimes(1)
-      expect(container.textContent).toContain('/tmp/.masc/config/runtime.toml')
+      expect(container.textContent).toContain(MOCK_RUNTIME_PATH)
     })
 
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement
@@ -313,13 +315,13 @@ describe('RuntimeTomlEditor', () => {
     render(html`<${RuntimeTomlEditor} />`, container)
 
     await waitFor(() => {
-      expect(container.textContent).toContain('/tmp/.masc/config/runtime.toml')
+      expect(container.textContent).toContain(MOCK_RUNTIME_PATH)
     })
 
     fireEvent.click(container.querySelector('[data-testid="runtime-toml-copy-path"]') as HTMLButtonElement)
 
     await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith('/tmp/.masc/config/runtime.toml')
+      expect(writeText).toHaveBeenCalledWith(MOCK_RUNTIME_PATH)
       expect(container.textContent).toContain('경로 복사됨')
     })
   })

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -14,7 +14,6 @@ import type { DashboardToolInventoryItem, LogEntry, RuntimeDefaultsResponse } fr
 import { DashboardMain } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
-import { mockKeepers } from '../store.mock'
 
 const MOCK_RUNTIME_PATH = '/tmp/.masc/config/runtime.toml'
 import { dashboardLoading } from '../store'

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -14,6 +14,9 @@ import type { DashboardToolInventoryItem, LogEntry, RuntimeDefaultsResponse } fr
 import { DashboardMain } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
+import { mockKeepers } from '../store.mock'
+
+const MOCK_RUNTIME_PATH = '/tmp/.masc/config/runtime.toml'
 import { dashboardLoading } from '../store'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
 import { resetDevTokenBootstrap } from '../api/dev-token'
@@ -421,7 +424,7 @@ describe('SettingsSurface', () => {
       if (path === '/api/v1/runtime/config/raw') {
         return new Response(JSON.stringify({
           ok: true,
-          path: '/tmp/.masc/config/runtime.toml',
+          path: MOCK_RUNTIME_PATH,
           file_name: 'runtime.toml',
           source_text: '[fusion]\nenabled = true\ndefault_preset = "trio"\nmax_concurrent_panels = 2\n\n[fusion.presets.trio]\nmin_answered = 2\n',
           reloaded: false,
@@ -489,7 +492,7 @@ describe('SettingsSurface', () => {
   it('opens the live runtime.toml editor from runtime management', async () => {
     const runtimeConfig = {
       ok: true,
-      path: '/tmp/.masc/config/runtime.toml',
+      path: MOCK_RUNTIME_PATH,
       file_name: 'runtime.toml',
       source_text: '[runtime]\ndefault = "runpod_mtp.qwen"\n',
       reloaded: false,
@@ -529,19 +532,13 @@ describe('SettingsSurface', () => {
 
     await fireEvent.click(container.querySelector('[data-testid="settings-nav-runtimes"]') as HTMLElement)
 
-    expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('런타임 관리')
-    expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('runtime.toml live-backed')
-    expect(container.querySelector('[data-testid="settings-runtime-launch"]')).not.toBeNull()
-    expect(container.querySelector('.set-rt')).toBeNull()
-    expect(container.textContent).not.toContain('Add runtime')
-
-    await fireEvent.click(container.querySelector('[data-testid="settings-open-runtime-editor"]') as HTMLElement)
-
     await waitFor(() => {
-      expect(container.querySelector('.rt-overlay')).not.toBeNull()
+      expect(container.querySelector('[data-testid="settings-section-title"]')?.textContent).toBe('런타임 관리')
       expect(container.querySelector('[data-testid="runtime-toml-editor"]')).not.toBeNull()
-      expect(container.textContent).toContain('/tmp/.masc/config/runtime.toml')
+      expect(container.querySelector('.rt-overlay')).toBeNull()
+      expect(container.textContent).toContain(MOCK_RUNTIME_PATH)
     })
+
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/v1/runtime/config/raw',
       expect.objectContaining({

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -472,14 +472,6 @@ export function SettingsSurface() {
   const [compactAt, setCompactAt] = useState(85)
   const [autoCompact, setAutoCompact] = useState(true)
 
-
-  const runtimeStats = {
-    ids: runtimeDefaults?.runtimes.length ?? 0,
-    providers: new Set(runtimeDefaults?.runtimes.map(r => r.provider) ?? []).size,
-    models: new Set(runtimeDefaults?.runtimes.map(r => r.model) ?? []).size,
-    default: runtimeDefaults?.default_runtime_id ?? '—',
-  }
-
   useEffect(() => {
     let active = true
     void (async () => {

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -471,7 +471,7 @@ export function SettingsSurface() {
   const [maxPar, setMaxPar] = useState(6)
   const [compactAt, setCompactAt] = useState(85)
   const [autoCompact, setAutoCompact] = useState(true)
-  const [rtEditorOpen, setRtEditorOpen] = useState(false)
+
 
   const runtimeStats = {
     ids: runtimeDefaults?.runtimes.length ?? 0,
@@ -730,21 +730,7 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'runtimes' && html`
-              <div class="set-rt-launch" data-testid="settings-runtime-launch">
-                <h3>런타임 편집기</h3>
-                <p>
-                  provider × model × binding 구조의 실제
-                  <span class="mono">config/runtime.toml</span>을 편집 — 라우팅 레인, 프로바이더, 모델 능력, 바인딩(런타임 id), keeper 배정.
-                </p>
-                <div class="set-rt-launch-stats">
-                  <div class="set-rt-launch-stat"><span class="v mono">${runtimeStats.ids}</span><span class="k">런타임 id</span></div>
-                  <div class="set-rt-launch-stat"><span class="v mono">${runtimeStats.providers}</span><span class="k">프로바이더</span></div>
-                  <div class="set-rt-launch-stat"><span class="v mono">${runtimeStats.models}</span><span class="k">모델</span></div>
-                </div>
-                <div class="set-mcp-detail mono" style=${{ marginBottom: '14px' }}>default = ${runtimeStats.default}</div>
-                <button type="button" class="set-rt-open" onClick=${() => setRtEditorOpen(true)} data-testid="settings-open-runtime-editor">런타임 편집기 열기 →</button>
-              </div>
-              ${rtEditorOpen ? html`<${RuntimeTomlEditor} onClose=${() => setRtEditorOpen(false)} />` : null}
+              <${RuntimeTomlEditor} />
             `}
 
             ${sec === 'routing' && html`

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -188,7 +188,7 @@ sangsu = "runpod_mtp.qwen"
     const next = setRuntimeTomlModelField(sourceText, 'qwen', 'max-context', null)
     const env = parseRuntimeTomlEnvironment(next)
     
-    expect(env.models[0].maxContext).toBeNull()
+    expect(env.models[0]?.maxContext).toBeNull()
     expect(next).not.toContain('max-context =')
   })
 

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -8,6 +8,7 @@ import {
   setRuntimeTomlModelField,
   setRuntimeTomlProviderCredential,
   setRuntimeTomlProviderField,
+  cascadeDeleteProvider,
 } from './runtime-toml-config'
 
 const sourceText = `[runtime]
@@ -55,6 +56,7 @@ describe('runtime TOML dashboard editing helpers', () => {
       maxContext: 128000,
       toolsSupport: true,
       thinkingSupport: true,
+      jsonSupport: null,
       streaming: true,
     })
     expect(environment.bindings[0]).toMatchObject({
@@ -170,5 +172,31 @@ sangsu = "runpod_mtp.qwen"
     const impact = runtimeTomlImpactSummary(before, after)
 
     expect(impact.runtimeAssignmentsChanged).toBe(false)
+  })
+
+  it('cascades provider deletion to credentials, bindings, and default runtime', () => {
+    const next = cascadeDeleteProvider(sourceText, 'runpod_mtp')
+    const env = parseRuntimeTomlEnvironment(next)
+    
+    expect(env.providers.length).toBe(0)
+    expect(env.bindings.length).toBe(0)
+    expect(next).not.toContain('default = "runpod_mtp.qwen"')
+    expect(next).not.toContain('[providers.runpod_mtp.credentials]')
+  })
+
+  it('can delete max-context field by setting it to null', () => {
+    const next = setRuntimeTomlModelField(sourceText, 'qwen', 'max-context', null)
+    const env = parseRuntimeTomlEnvironment(next)
+    
+    expect(env.models[0].maxContext).toBeNull()
+    expect(next).not.toContain('max-context =')
+  })
+
+  it('extracts json-support from model config', () => {
+    const sourceWithJson = `${sourceText}\n[models.structured]\njson-support = true\n`
+    const env = parseRuntimeTomlEnvironment(sourceWithJson)
+    
+    const structuredModel = env.models.find(m => m.id === 'structured')
+    expect(structuredModel?.jsonSupport).toBe(true)
   })
 })

--- a/dashboard/src/lib/runtime-toml-config.ts
+++ b/dashboard/src/lib/runtime-toml-config.ts
@@ -20,6 +20,7 @@ export interface RuntimeTomlModel {
   maxContext: number | null
   toolsSupport: boolean
   thinkingSupport: boolean
+  jsonSupport: boolean | null
   streaming: boolean
 }
 
@@ -217,6 +218,7 @@ function modelFromDocument(document: TomlDocument, id: string): RuntimeTomlModel
     maxContext: asNumber(values['max-context']),
     toolsSupport: asBoolean(values['tools-support']),
     thinkingSupport: asBoolean(values['thinking-support']),
+    jsonSupport: typeof values['json-support'] === 'boolean' ? values['json-support'] : null,
     streaming: asBoolean(values.streaming, true),
   }
 }
@@ -382,6 +384,47 @@ export function deleteRuntimeTomlSection(sourceText: string, sectionName: string
   return joinLines(lines)
 }
 
+export function cascadeDeleteProvider(sourceText: string, providerId: string): string {
+  const document = parseDocument(sourceText)
+  const env = parseRuntimeTomlEnvironment(sourceText)
+  const prefix = `providers.${providerId}`
+  const prefixDot = `providers.${providerId}.`
+  const bindingPrefixDot = `${providerId}.`
+  const sectionsToDelete = document.sections
+    .map(s => s.name)
+    .filter(name => name === prefix || name.startsWith(prefixDot) || name.startsWith(bindingPrefixDot))
+  
+  let next = sourceText
+  for (const sec of sectionsToDelete) {
+    next = deleteRuntimeTomlSection(next, sec)
+  }
+
+  // Also remove from runtime defaults/assignments if they reference this provider
+  const nextDocument = parseDocument(next)
+  const runtimeValues = sectionValues(nextDocument, 'runtime')
+  const toDeleteBindings = new Set(env.bindings.filter(b => b.providerId === providerId).map(b => b.id))
+  
+  if (typeof runtimeValues.default === 'string' && toDeleteBindings.has(runtimeValues.default)) {
+    next = deleteRuntimeTomlKey(next, 'runtime', 'default')
+  }
+  if (typeof runtimeValues.librarian === 'string' && toDeleteBindings.has(runtimeValues.librarian)) {
+    next = deleteRuntimeTomlKey(next, 'runtime', 'librarian')
+  }
+  if (typeof runtimeValues.cross_verifier === 'string' && toDeleteBindings.has(runtimeValues.cross_verifier)) {
+    next = deleteRuntimeTomlKey(next, 'runtime', 'cross_verifier')
+  }
+  
+  // Clean up assignments
+  const assignments = sectionValues(nextDocument, 'runtime.assignments')
+  for (const [key, value] of Object.entries(assignments)) {
+    if (typeof value === 'string' && toDeleteBindings.has(value)) {
+      next = deleteRuntimeTomlKey(next, 'runtime.assignments', key)
+    }
+  }
+  
+  return next
+}
+
 export function setRuntimeTomlDefault(sourceText: string, runtimeId: string): string {
   return setRuntimeTomlKey(sourceText, 'runtime', 'default', runtimeId)
 }
@@ -433,9 +476,10 @@ export function setRuntimeTomlProviderCredential(
 export function setRuntimeTomlModelField(
   sourceText: string,
   modelId: string,
-  field: 'api-name' | 'max-context' | 'tools-support' | 'thinking-support' | 'streaming',
-  value: string | number | boolean,
+  field: 'api-name' | 'max-context' | 'tools-support' | 'thinking-support' | 'json-support' | 'streaming',
+  value: string | number | boolean | null,
 ): string {
+  if (value === null) return deleteRuntimeTomlKey(sourceText, `models.${modelId}`, field)
   return setRuntimeTomlKey(sourceText, `models.${modelId}`, field, value)
 }
 

--- a/dashboard/src/styles/keeper-v2/runtime.css
+++ b/dashboard/src/styles/keeper-v2/runtime.css
@@ -134,6 +134,9 @@
 .set-rt-open { font-family: var(--font-ui); font-size: 13px; padding: 9px 18px; border-radius: var(--radius-sm); border: 1px solid var(--volt-dim); background: var(--volt-wash); color: var(--volt); cursor: pointer; transition: 0.14s; }
 .set-rt-open:hover { background: var(--volt); color: var(--volt-ink); }
 
+/* inline embedded mode — no double box-shadow */
+.set-card-b-wide .rt-shell { box-shadow: none; min-height: 36rem; }
+
 @media (max-width: 720px) {
   .rt-shell { grid-template-columns: 1fr; }
   .rt-nav { flex-direction: row; overflow-x: auto; }

--- a/dashboard/src/styles/runtime-editor-v2.css
+++ b/dashboard/src/styles/runtime-editor-v2.css
@@ -504,6 +504,15 @@ html[data-skin="v2"] .rt-toml code {
   white-space: pre;
 }
 
+/* inline embedded mode — when RuntimeTomlEditor is rendered inside the
+   Settings surface card without the overlay wrapper. Drop the outer
+   box-shadow since the host card provides its own chrome. */
+html[data-skin="v2"] .set-card-b-wide .rt-shell {
+  box-shadow: none;
+  border-radius: var(--radius-md);
+  min-height: 36rem;
+}
+
 /* responsive — runtime.css:137 */
 @media (max-width: 720px) {
   html[data-skin="v2"] .rt-shell { grid-template-columns: 1fr; }

--- a/dashboard/src/styles/runtime-editor-v2.css
+++ b/dashboard/src/styles/runtime-editor-v2.css
@@ -508,9 +508,7 @@ html[data-skin="v2"] .rt-toml code {
    Settings surface card without the overlay wrapper. Drop the outer
    box-shadow since the host card provides its own chrome. */
 html[data-skin="v2"] .set-card-b-wide .rt-shell {
-  box-shadow: none;
   border-radius: var(--radius-md);
-  min-height: 36rem;
 }
 
 /* responsive — runtime.css:137 */


### PR DESCRIPTION
## Description
- settings-surface.ts 의 런타임 편집기 오버레이(모달)를 인라인 임베딩 모드로 변경했습니다.
- runtime-environment-editor.ts 에서 하드코딩된 모델 capability 경고 스텁을 실제 모델의 capabilities (toolsSupport, thinkingSupport) 기반으로 동적 체크하도록 구현했습니다.
- provider 삭제 버튼을 추가하고, model의 max-context를 편집할 수 있도록 인라인 편집기를 강화했습니다.
- 인라인 모드 시 레이아웃 깨짐을 방지하기 위해 CSS에서 외부 섀도우를 제거하고 최소 높이를 부여했습니다.