### PR TITLE
Fix Shell IR privileged dispatch floor

### DIFF
--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -73,6 +73,17 @@ type dispatch_error =
   | Approval_required of { summary : string; bin : string }
   | Policy_denied of { reason : string }
 
+let rec first_privileged_program = function
+  | [] -> None
+  | Masc_exec.Capability.Exec_program (bin, _) :: _
+    when Masc_exec.Exec_program.risk_class bin = `Privileged -> Some bin
+  | Masc_exec.Capability.Pipeline_fold inner :: rest ->
+    (match first_privileged_program inner with
+     | Some _ as found -> found
+     | None -> first_privileged_program rest)
+  | _ :: rest -> first_privileged_program rest
+;;
+
 let validate_paths ?keeper_id ?base_path ~workdir ir =
   (* RFC-0255 section 4.6: path-jail kill-switch. When disabled, skip the
      workspace path whitelist entirely. This also removes the only positional
@@ -111,41 +122,53 @@ let dispatch_classified
       envelope
   =
   let ir = envelope.Masc_exec.Shell_ir_risk.ir in
-  (* Trust- AND flag-independent catastrophic floor (RFC-0254 §4 lesson (c),
-     §5.4).  [dispatch_classified] is the single chokepoint every executed
-     command passes through — the [MASC_SHELL_IR_APPROVAL_GATE_ENABLED]=off
-     keeper path (keeper_tool_execute_runtime.ml) and the read-ops/evidence
-     paths reach it directly — so enforcing the floor here makes it
-     unconditional: destructive git, redirect write-escape, and [mkfs] are
-     denied even with the approval flag off.  The [_with_approval] wrapper runs
-     the same [catastrophic_floor] first via [Approval_policy.decide] (single
-     source of truth); on its allow path this re-scan returns [None], so there
-     is no double-deny, only one cheap pure scan.  Destructive git has no path
-     argument for [validate_paths] to jail, so this floor is its only enforcer
-     (RFC-0254 §5.4). *)
-  match
-    Masc_exec.Approval_policy.catastrophic_floor (Masc_exec.Capability_check.of_ir ir)
-  with
+  let caps = Masc_exec.Capability_check.of_ir ir in
+  (* Trust- and flag-independent safety floors.  [dispatch_classified] is the
+     single chokepoint every executed command passes through, including the
+     [MASC_SHELL_IR_APPROVAL_GATE_ENABLED]=off route.  The catastrophic floor is
+     never approvable; the privileged-program floor is fail-closed until a real
+     Shell IR approval resolver is wired.  This prevents autonomous/flag-off
+     paths from treating [sudo]/[chmod]/[rm]/[dd] as executable merely because
+     no HITL channel exists. *)
+  match Masc_exec.Approval_policy.catastrophic_floor caps with
   | Some reason ->
     Error (Policy_denied { reason = Masc_exec.Verdict.deny_reason_to_string reason })
   | None ->
-    let gate_verdict =
-      Shell_gate.gate_typed
-        ~ir
-        ~syntax_policy:{ allow_pipes; redirect_allowed }
-        ~path_policy:Shell_gate.forbid_masc_internal_state_paths
-        ~sandbox:{ target = sandbox }
-        ()
-    in
-    gate_verdict_map
-      gate_verdict
-      ~f_reject:(fun diagnostic -> Error (Gate_reject diagnostic))
-      ~f_cannot_parse:(Error Cannot_parse)
-      ~f_too_complex:(Error Too_complex)
-      ~f_allow:(fun _context ->
-        match validate_paths ?keeper_id ?base_path ~workdir ir with
-        | Error e -> Error (Path_reject e)
-        | Ok () -> Ok (Masc_exec.Exec_dispatch.dispatch_decided ?base_host_env ?on_output_chunk envelope))
+    (match first_privileged_program caps with
+     | Some bin ->
+       let bin = Masc_exec.Exec_program.to_string bin in
+       Error
+         (Approval_required
+            { summary =
+                Printf.sprintf
+                  "privileged command '%s' requires explicit approval; no \
+                   Shell IR approval resolver is configured, so it is blocked"
+                  bin
+            ; bin
+            })
+     | None ->
+       let gate_verdict =
+         Shell_gate.gate_typed
+           ~ir
+           ~syntax_policy:{ allow_pipes; redirect_allowed }
+           ~path_policy:Shell_gate.forbid_masc_internal_state_paths
+           ~sandbox:{ target = sandbox }
+           ()
+       in
+       gate_verdict_map
+         gate_verdict
+         ~f_reject:(fun diagnostic -> Error (Gate_reject diagnostic))
+         ~f_cannot_parse:(Error Cannot_parse)
+         ~f_too_complex:(Error Too_complex)
+         ~f_allow:(fun _context ->
+           match validate_paths ?keeper_id ?base_path ~workdir ir with
+           | Error e -> Error (Path_reject e)
+           | Ok () ->
+             Ok
+               (Masc_exec.Exec_dispatch.dispatch_decided
+                  ?base_host_env
+                  ?on_output_chunk
+                  envelope)))
 ;;
 
 (* TEL-OK: wrapper only classifies before delegating to dispatch_classified. *)
@@ -190,7 +213,9 @@ let last_simple_of_ir ir =
     (the approval decision is made first, then [dispatch_classified] applies
     [Shell_gate.gate_typed] followed by [validate_paths]).
     [Ask] and [Deny] are surfaced as typed errors so the keeper runtime
-    can log them and return a structured failure to the model. *)
+    can log them and return a structured failure to the model.  Even when the
+    policy overlay allows, [dispatch_classified] still applies the privileged
+    fail-closed floor before dispatch. *)
 let dispatch_classified_with_approval
       ?allow_pipes
       ?redirect_allowed

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -75,13 +75,21 @@ type dispatch_error =
 
 let rec first_privileged_program = function
   | [] -> None
-  | Masc_exec.Capability.Exec_program (bin, _) :: _
-    when Masc_exec.Exec_program.risk_class bin = `Privileged -> Some bin
-  | Masc_exec.Capability.Pipeline_fold inner :: rest ->
-    (match first_privileged_program inner with
-     | Some _ as found -> found
+  | cap :: rest ->
+    let found =
+      match cap with
+      | Masc_exec.Capability.Exec_program (bin, _)
+        when Masc_exec.Exec_program.risk_class bin = `Privileged -> Some bin
+      | Masc_exec.Capability.Exec_program _ -> None
+      | Masc_exec.Capability.Read_path _ -> None
+      | Masc_exec.Capability.Write_path _ -> None
+      | Masc_exec.Capability.Git _ -> None
+      | Masc_exec.Capability.Env_set _ -> None
+      | Masc_exec.Capability.Pipeline_fold inner -> first_privileged_program inner
+    in
+    (match found with
+     | Some _ -> found
      | None -> first_privileged_program rest)
-  | _ :: rest -> first_privileged_program rest
 ;;
 
 let validate_paths ?keeper_id ?base_path ~workdir ir =
@@ -127,9 +135,11 @@ let dispatch_classified
      single chokepoint every executed command passes through, including the
      [MASC_SHELL_IR_APPROVAL_GATE_ENABLED]=off route.  The catastrophic floor is
      never approvable; the privileged-program floor is fail-closed until a real
-     Shell IR approval resolver is wired.  This prevents autonomous/flag-off
-     paths from treating [sudo]/[chmod]/[rm]/[dd] as executable merely because
-     no HITL channel exists. *)
+     Shell IR approval resolver is wired.  [Exec_program.risk_class] is derived
+     from the closed [Exec_program.known] metadata registry, and unknown
+     binaries are classified as [`Privileged] in [Exec_program.of_string].  The
+     capability scan above enumerates every [Capability.t] arm so new
+     execution-bearing capabilities cannot silently bypass this floor. *)
   match Masc_exec.Approval_policy.catastrophic_floor caps with
   | Some reason ->
     Error (Policy_denied { reason = Masc_exec.Verdict.deny_reason_to_string reason })

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
@@ -71,8 +71,11 @@ val dispatch_classified :
 (** Run the canonical keeper Shell IR pipeline for an already-classified IR:
     typed gate -> path validation -> dispatch_decided. [redirect_allowed]
     defaults to [true] for the historical tool execute path; legacy code-shell
-    callers pass [false].  [?on_output_chunk] is forwarded to the host
-    dispatch path for live output streaming. *)
+    callers pass [false].  Catastrophic operations are policy-denied, and
+    privileged programs are [Approval_required] until a Shell IR approval
+    resolver is wired; this also applies to the approval-gate kill-switch path.
+    [?on_output_chunk] is forwarded to the host dispatch path for live output
+    streaming. *)
 
 val dispatch_classified_with_approval :
   ?allow_pipes:bool ->
@@ -92,7 +95,8 @@ val dispatch_classified_with_approval :
     [Ask] produces [Approval_required] carrying the blocked binary (the
     summary notes the audited/privileged risk class); [Deny] produces
     [Policy_denied] carrying the rendered typed [Verdict.deny_reason].
-    [Allow] and [Suggest_confirm] proceed to dispatch.
+    [Allow] and [Suggest_confirm] proceed to {!dispatch_classified}, which
+    still applies the privileged fail-closed floor before process dispatch.
     A nested pipeline whose last stage is itself a pipeline yields
     [Too_complex], matching {!dispatch_classified}. *)
 

--- a/test/test_destructive_floor_differential.ml
+++ b/test/test_destructive_floor_differential.ml
@@ -7,7 +7,7 @@
 
     {1 What this harness measures — and what it deliberately excludes}
 
-    An autonomous keeper has THREE unconditional block gates on an executed
+    An autonomous keeper has FOUR unconditional block gates on an executed
     command:
 
       1. [Shell_ir_risk.is_destructive] (risk = [Destructive_protected]) —
@@ -15,12 +15,15 @@
       2. [Approval_policy.catastrophic_floor] (destructive-git / redirect
          write-escape / catastrophic-by-identity program, e.g. mkfs) —
          approval_policy.ml:107; and
-      3. the path jail [Exec_policy.validate_shell_ir_paths]
+      3. privileged/unknown executable fail-closed in
+         [Keeper_tool_execute_shell_ir.dispatch_classified] while no Shell IR
+         approval resolver exists; and
+      4. the path jail [Exec_policy.validate_shell_ir_paths]
          (keeper_tool_execute_shell_ir.ml:82) — jails command ARGUMENT paths
          to the workspace whitelist.
 
-    This harness models (1) and (2): the COMMAND-SHAPE classifiers (command
-    identity / git op / redirect). It deliberately EXCLUDES the path jail (3),
+    This harness models (1), (2), and (3): the COMMAND-SHAPE classifiers (command
+    identity / git op / redirect). It deliberately EXCLUDES the path jail (4),
     because the path jail is a SEPARATE, PERMANENT policy axis — not because it
     is temporary:
 
@@ -47,33 +50,25 @@
         resolved: shutdown/reboot lifted into the catastrophic floor (#22234);
         destructive SQL lifted into the typed DB-capability floor ([Db_op] +
         [Approval_policy.find_destructive_db], inside catastrophic_floor); and
-        kill/pkill DELIBERATELY ALLOWED (a keeper legitimately signals processes
-        it spawned, with no safe ownership boundary at the syntax layer — user
-        decision). The residual path-independent gap is therefore only the
-        deliberately-allowed set (kill/pkill). Literal destructive SQL on
-        psql/mysql/mariadb/cockroach is covered by the typed DB floor; non-literal
-        SQL ([Var]/[Concat]) is documented in the RFC because this all-literal
-        corpus cannot express it.
+        kill/pkill are unknown executables, therefore privileged and
+        fail-closed until a Shell IR approval resolver exists. Literal
+        destructive SQL on psql/mysql/mariadb/cockroach is covered by the typed
+        DB floor; non-literal SQL ([Var]/[Concat]) is documented in the RFC
+        because this all-literal corpus cannot express it.
       - path-BEARING: the command targets a path. The PERMANENT path jail covers
-        an OUT-OF-WORKSPACE target. The IN-WORKSPACE representative used here
-        (e.g. [rm -r ./build], [chmod 777 ./script.sh]) is a LEGITIMATE keeper
-        operation that the path jail allows by design — see
-        [test_rm_root_allowed_at_policy_layer_jailed_downstream] in
-        lib/exec/test/test_approval_policy.ml, which pins that argv paths stay
-        OUT of the command-shape floor. The substring catalogue blocks these
-        in-workspace forms over-broadly; Phase 3 deletion deliberately drops
-        that over-broad block. So path-bearing entries are resolved by the
-        permanent jail (out-of-workspace) + a documented policy refinement
-        (in-workspace), NOT by lifting them into the command-shape floor.
+        an OUT-OF-WORKSPACE target. In-workspace privileged examples (e.g.
+        [rm -r ./build], [chmod 777 ./script.sh], [dd of=./out.img]) are now
+        blocked by the privileged-program floor until a Shell IR approval
+        resolver exists. Non-privileged path-bearing coverage remains the path
+        jail's job.
 
     Retirement (Phase 3) safety invariant: deleting the substring layer must not
     newly ALLOW anything dangerous. For each substring-blocked command the typed
     system must then either (a) command-shape-block it [path-independent
-    catastrophic], (b) permanent-path-jail-block it [path-bearing,
-    out-of-workspace], or (c) deliberately allow it because substring was
-    over-broad [path-bearing in-workspace, or a path-independent op explicitly
-    decided to allow]. The two baselines below pin (a)'s remaining work-list and
-    (b)'s stable set so neither grows silently. *)
+    catastrophic or privileged-without-resolver], (b) permanent-path-jail-block
+    it [path-bearing, out-of-workspace], or (c) deliberately allow it because
+    substring was over-broad. The baselines below are now empty and pin that no
+    substring-blocked corpus entry escapes the typed command-shape floors. *)
 
 open Masc
 module Exec = Masc_exec
@@ -100,7 +95,8 @@ let simple_ir bin_str args =
 (* An entry binds the substring view (the command string) to the typed view
    (the IR) from one (bin, args) pair, so both verdicts see identical tokens.
    [path_independent] marks commands with no path argument: the permanent path
-   jail can NEVER cover them, so they are the irreducible command-shape gap. *)
+   jail can NEVER cover them, so any gap there must be closed or explicitly
+   accepted by command-shape policy. *)
 type entry =
   { cls : string
   ; bin_ : string
@@ -115,24 +111,33 @@ let label e = Printf.sprintf "[%s] %s" e.cls (cmd_string e)
 let substring_blocks e = Option.is_some (Eval_gate.detect_destructive policy (cmd_string e))
 let classify e = Risk.classify (Risk.undecided (ir_of e))
 
-(* Command-shape typed verdict: the two UNCONDITIONAL command-shape blocks an
-   autonomous keeper applies (path jail excluded by design — see header). Under
-   the autonomous overlay every non-catastrophic risk class is Observe => Allow,
-   so these two are the whole command-shape block set. *)
+(* Command-shape typed verdict: the UNCONDITIONAL command-shape blocks an
+   autonomous keeper applies before path jail: destructive risk, catastrophic
+   floor, and privileged/unknown executable fail-closed while no Shell IR
+   approval resolver exists. *)
+let rec has_privileged_program = function
+  | [] -> false
+  | Exec.Capability.Exec_program (bin, _) :: _
+    when Exec.Exec_program.risk_class bin = `Privileged -> true
+  | Exec.Capability.Pipeline_fold inner :: rest ->
+    has_privileged_program inner || has_privileged_program rest
+  | _ :: rest -> has_privileged_program rest
+;;
+
 let typed_blocks e =
+  let caps = Exec.Capability_check.of_ir (ir_of e) in
   Risk.is_destructive (classify e)
-  || Option.is_some
-       (Exec.Approval_policy.catastrophic_floor (Exec.Capability_check.of_ir (ir_of e)))
+  || Option.is_some (Exec.Approval_policy.catastrophic_floor caps)
+  || has_privileged_program caps
 ;;
 
 (* One representative command per pattern in config/destructive_ops.toml.
    Path-bearing patterns target an IN-WORKSPACE relative path (./…): that is the
-   case the permanent path jail allows (a legitimate keeper op), so a gap here
-   is a genuine command-shape observation, not an artifact of omitting the path
-   jail. The redirect-shaped device_write pattern "> /dev/" is not represented
-   (it needs a Redirect_scope value and is covered by catastrophic_floor
-   write-escape on a separate path); [dd] represents the device_write class.
-   Logged in the report (no silent cap). *)
+   case where path jail alone would not help, so the privileged floor must catch
+   privileged binaries and unknown executables. The redirect-shaped device_write
+   pattern "> /dev/" is not represented (it needs a Redirect_scope value and is
+   covered by catastrophic_floor write-escape on a separate path); [dd]
+   represents the device_write class. Logged in the report (no silent cap). *)
 let destructive_corpus =
   [ mk "recursive_delete" "rm" [ "-rf"; "./build" ]
   ; mk "recursive_delete" "rm" [ "-r"; "./build" ]
@@ -173,7 +178,8 @@ let bearing_gap () = List.filter (fun e -> not e.path_independent) (gap ())
 
 (* Baseline ratchet 1 — the path-INDEPENDENT residual. No path argument, so the
    permanent path jail can never cover these. Two RFC §6 decisions emptied the
-   command-shape WORK-LIST here, leaving only the deliberately-allowed set:
+   command-shape WORK-LIST here, and the privileged fail-closed floor covers the
+   remaining unknown/privileged executables:
 
    - system_control (shutdown/reboot): lifted into
      [Approval_policy.find_catastrophic_program] — now COVERED (Phase 2,
@@ -182,39 +188,23 @@ let bearing_gap () = List.filter (fun e -> not e.path_independent) (gap ())
      lifted into the typed DB-capability floor ([Db_op] +
      [Approval_policy.find_destructive_db]) — now COVERED (this PR). It is
      therefore NOT in the gap anymore.
-   - process_signal (kill/pkill): DELIBERATELY ALLOWED. A keeper legitimately
-     signals processes it spawned, and there is no safe ownership boundary at
-     the syntax layer; flooring it would be a constraint with no principled cut
-     (user decision: "no bizarre constraints"). So it stays substring-blocked
-     until Phase 3, then drops as over-broad — like the path-bearing set, it is
-     resolved by deliberate allowance, NOT by a floor lift.
+   - process_signal (kill/pkill): unknown binaries are privileged per
+     [Exec_program.of_string], therefore they now hit the privileged fail-closed
+     floor until a Shell IR approval resolver exists.
 
-   The remaining entries are deliberately allowed, not must-floor work. A NEW
-   path-independent destructive pattern appearing here is a red that demands a
-   classify-or-decide — the ratchet's purpose. Already covered (NOT in the gap):
-   rm -rf, git push --force/-f, git reset --hard, git clean -f, filesystem
-   format, shutdown, reboot, destructive SQL on psql/mysql/mariadb/cockroach. *)
-let expected_independent_gap =
-  [ "[process_signal] kill -9 1234"
-  ; "[process_signal] pkill -f node"
-  ]
-;;
+   A NEW path-independent destructive pattern appearing here is a red that
+   demands a classify-or-decide — the ratchet's purpose. Already covered (NOT in
+   the gap): rm -rf, git push --force/-f, git reset --hard, git clean -f,
+   filesystem format, shutdown, reboot, destructive SQL on
+   psql/mysql/mariadb/cockroach, and unknown privileged process-signal tools. *)
+let expected_independent_gap = []
 
 (* Baseline ratchet 2 — the path-BEARING gap. Each targets an in-workspace path.
    The PERMANENT path jail (validate_shell_ir_paths, default-on, graduated to
-   the only path at RFC-0255 P5) covers the out-of-workspace variant; the
-   in-workspace form shown is a legitimate keeper operation that the design
-   keeps OUT of the command-shape floor
-   ([test_rm_root_allowed_at_policy_layer_jailed_downstream]). These are
-   resolved by the permanent jail + a documented drop of substring
-   over-broadness, NOT lifted into the floor. Pinned so the set cannot grow. *)
-let expected_bearing_gap =
-  [ "[device_write] dd if=/dev/zero of=./out.img"
-  ; "[privilege_escalation] chmod 777 ./script.sh"
-  ; "[recursive_delete] rm -r ./build"
-  ; "[recursive_delete] rmdir ./build"
-  ]
-;;
+   the only path at RFC-0255 P5) covers the out-of-workspace variant. The
+   in-workspace privileged forms shown here now hit the privileged fail-closed
+   floor before path validation. Pinned so the set cannot grow. *)
+let expected_bearing_gap = []
 
 let test_safe_controls_not_blocked () =
   List.iter
@@ -248,10 +238,10 @@ let test_report () =
       entries
   in
   print_group
-    "  path-INDEPENDENT residual (deliberately-allowed; work-list now empty — see header)"
+    "  path-INDEPENDENT residual (should stay empty — see header)"
     independent;
   print_group
-    "  path-BEARING (in-workspace legit; out-of-workspace covered by the PERMANENT path jail)"
+    "  path-BEARING residual (should stay empty; path jail remains separate)"
     bearing;
   Printf.printf
     "NOTE: path jail (validate_shell_ir_paths, default-on, graduated to the only \
@@ -261,8 +251,7 @@ let test_report () =
 ;;
 
 (* Ratchet: each partition of the gap must equal its recorded baseline. Fails on
-   growth (new uncovered pattern = regression) or unrecorded shrink (Phase-2
-   progress to capture). *)
+   growth (new uncovered pattern = regression). *)
 let test_gap_baseline () =
   let actual_independent = List.sort compare (List.map label (independent_gap ())) in
   let actual_bearing = List.sort compare (List.map label (bearing_gap ())) in
@@ -271,7 +260,7 @@ let test_gap_baseline () =
     (List.sort compare expected_independent_gap)
     actual_independent;
   Alcotest.(check (list string))
-    "path-bearing gap matches jail-covered baseline"
+    "path-bearing gap matches command-shape baseline"
     (List.sort compare expected_bearing_gap)
     actual_bearing
 ;;

--- a/test/test_destructive_floor_differential.ml
+++ b/test/test_destructive_floor_differential.ml
@@ -117,11 +117,18 @@ let classify e = Risk.classify (Risk.undecided (ir_of e))
    approval resolver exists. *)
 let rec has_privileged_program = function
   | [] -> false
-  | Exec.Capability.Exec_program (bin, _) :: _
-    when Exec.Exec_program.risk_class bin = `Privileged -> true
-  | Exec.Capability.Pipeline_fold inner :: rest ->
-    has_privileged_program inner || has_privileged_program rest
-  | _ :: rest -> has_privileged_program rest
+  | cap :: rest ->
+    let current =
+      match cap with
+      | Exec.Capability.Exec_program (bin, _) ->
+        Exec.Exec_program.risk_class bin = `Privileged
+      | Exec.Capability.Read_path _ -> false
+      | Exec.Capability.Write_path _ -> false
+      | Exec.Capability.Git _ -> false
+      | Exec.Capability.Env_set _ -> false
+      | Exec.Capability.Pipeline_fold inner -> has_privileged_program inner
+    in
+    current || has_privileged_program rest
 ;;
 
 let typed_blocks e =

--- a/test/test_exec_dispatch.ml
+++ b/test/test_exec_dispatch.ml
@@ -1007,6 +1007,38 @@ let () =
   | Error (Keeper_tool_execute_shell_ir.Approval_required _) -> ()
   | Error _ -> assert false
 
+let () =
+  with_eio @@ fun () ->
+  let open Masc_exec.Shell_ir in
+  let bin = Masc_exec.Exec_program.of_string "chmod" |> Result.get_ok in
+  let ir =
+    { bin
+    ; args =
+        [ Lit ("600", default_meta)
+        ; Lit ("./__nonexistent_privileged_guard", default_meta)
+        ]
+    ; env = []
+    ; cwd = None
+    ; redirects = []
+    ; sandbox = Masc_exec.Sandbox_target.host ()
+    }
+  in
+  let envelope =
+    Masc_exec.Shell_ir_risk.classify
+      (Masc_exec.Shell_ir_risk.undecided (Masc_exec.Shell_ir.Simple ir))
+  in
+  match
+    Keeper_tool_execute_shell_ir.dispatch_classified
+      ~workdir:"/tmp"
+      ~sandbox:(Masc_exec.Sandbox_target.host ())
+      envelope
+  with
+  | Ok _ -> assert false
+  | Error
+      (Keeper_tool_execute_shell_ir.Approval_required { summary = _; bin }) ->
+    assert (String.equal bin "chmod")
+  | Error _ -> assert false
+
 (* --- Keeper_tool_execute_shell_ir.dispatch_classified: catastrophic floor is
    flag-independent (RFC-0254 §5.3.1) --- *)
 


### PR DESCRIPTION
Split from #22314 into a focused audit slice.

Scope:
- enforce a fail-closed privileged-program floor in `Keeper_tool_execute_shell_ir.dispatch_classified`, including the approval-gate kill-switch/direct dispatch path
- keep catastrophic denial as policy-denied and surface privileged commands as `Approval_required` until a Shell IR approval resolver exists
- update the destructive-floor differential ratchet so substring-blocked privileged/unknown commands no longer remain as accepted residuals

Out of scope:
- board persistence/moderation changes
- goal approval persistence changes
- task CAS retry changes (#22345)
- goal actor binding changes (#22343)

Local verification without Dune, per current workflow:
- `ocamlformat --check lib/keeper_tooling/keeper_tool_execute_shell_ir.ml lib/keeper_tooling/keeper_tool_execute_shell_ir.mli test/test_exec_dispatch.ml test/test_destructive_floor_differential.ml`
- conflict-marker scan on touched files
- `git diff --cached --check`

Dune build/test proof is intentionally left to GitHub CI. Main quick-suite fallout is tracked separately in #22341.