### PR TITLE
Fix evidence gate token boundaries

### DIFF
--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -24,125 +24,16 @@ let reason_evidence_incomplete ~required_evidence =
      reference supplied"
     (List.length required_evidence)
 
-let starts_with ~prefix value =
-  let prefix_len = String.length prefix in
-  String.length value >= prefix_len && String.sub value 0 prefix_len = prefix
-
-let payload_after_prefix ~prefix value =
-  let prefix_len = String.length prefix in
-  String.sub value prefix_len (String.length value - prefix_len)
-
-let is_hex_char = function
-  | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
-  | _ -> false
-
-let min_short_commit_hex_len = 7
-let max_commit_hex_len = 64
-let max_file_extension_len = 12
-
-let is_commit_ref value =
-  let len = String.length value in
-  len >= min_short_commit_hex_len
-  && len <= max_commit_hex_len
-  && String.for_all is_hex_char value
-
-let contains_path_separator value = String.contains value '/'
-
-let is_file_ref_char = function
-  | '0' .. '9'
-  | 'a' .. 'z'
-  | 'A' .. 'Z'
-  | '/'
-  | '.'
-  | '_'
-  | '-'
-  | '~'
-  | '@'
-  | ':' -> true
-  | _ -> false
-
-let is_extension_char = function
-  | '0' .. '9' | 'a' .. 'z' | 'A' .. 'Z' -> true
-  | _ -> false
-
-let has_plausible_extension value =
-  match String.rindex_opt value '.' with
-  | None -> false
-  | Some idx ->
-    let len = String.length value in
-    let ext_len = len - idx - 1 in
-    idx > 0
-    && ext_len >= 1
-    && ext_len <= max_file_extension_len
-    && String.for_all is_file_ref_char value
-    && String.for_all is_extension_char (String.sub value (idx + 1) ext_len)
-
-let has_file_payload_char value =
-  String.exists
-    (function
-      | '/' | '.' -> false
-      | _ -> true)
-    value
-
-let has_concrete_prefix_payload ~prefix value =
-  let payload = payload_after_prefix ~prefix value |> String.trim in
-  (not (String.equal payload "")) && has_file_payload_char payload
-
-let looks_like_file_path value =
-  String.for_all is_file_ref_char value
-  && has_file_payload_char value
-  && (contains_path_separator value || has_plausible_extension value)
-
-let is_pr_ref value =
-  let len = String.length value in
-  (len > 3
-   && (starts_with ~prefix:"PR#" value || starts_with ~prefix:"pr#" value)
-   && String.for_all
-        (function
-          | '0' .. '9' -> true
-          | _ -> false)
-        (String.sub value 3 (len - 3)))
-  || (len > 1
-      && value.[0] = '#'
-      && String.for_all
-           (function
-             | '0' .. '9' -> true
-             | _ -> false)
-           (String.sub value 1 (len - 1)))
-
-let is_trace_ref value =
-  (starts_with ~prefix:"trace:" value
-   && has_concrete_prefix_payload ~prefix:"trace:" value)
-  || (starts_with ~prefix:"turn:" value
-      && has_concrete_prefix_payload ~prefix:"turn:" value)
-  || (starts_with ~prefix:"receipt:" value
-      && has_concrete_prefix_payload ~prefix:"receipt:" value)
-
-let is_url_ref value =
-  (starts_with ~prefix:"http://" value
-   && has_concrete_prefix_payload ~prefix:"http://" value)
-  || (starts_with ~prefix:"https://" value
-      && has_concrete_prefix_payload ~prefix:"https://" value)
-
-let is_file_uri_ref value =
-  starts_with ~prefix:"file://" value
-  && has_concrete_prefix_payload ~prefix:"file://" value
-
 let evidence_ref_is_concrete ref_ =
-  let value = String.trim ref_ in
-  if String.equal value "" then false
-  else if starts_with ~prefix:"http://" value || starts_with ~prefix:"https://" value
-  then is_url_ref value
-  else if starts_with ~prefix:"file://" value then is_file_uri_ref value
-  else if
-    starts_with ~prefix:"trace:" value
-    || starts_with ~prefix:"turn:" value
-    || starts_with ~prefix:"receipt:" value
-  then is_trace_ref value
-  else
-    is_pr_ref value
-    || is_commit_ref value
-    || looks_like_file_path value
+  match Evidence_ref.of_string ref_ with
+  | Some
+      ( Evidence_ref.Url _
+      | Evidence_ref.File_uri _
+      | Evidence_ref.Pr _
+      | Evidence_ref.Commit _
+      | Evidence_ref.Trace_ref _
+      | Evidence_ref.File_path _ ) -> true
+  | None -> false
 
 let is_reference_token_char = function
   | '0' .. '9'

--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -35,29 +35,6 @@ let evidence_ref_is_concrete ref_ =
       | Evidence_ref.File_path _ ) -> true
   | None -> false
 
-let is_reference_token_char = function
-  | '0' .. '9'
-  | 'a' .. 'z'
-  | 'A' .. 'Z'
-  | '/'
-  | '_'
-  | '-'
-  | '~'
-  | '@' -> true
-  | _ -> false
-
-let reference_boundary_match haystack needle start =
-  let needle_len = String.length needle in
-  let before =
-    start = 0 || not (is_reference_token_char haystack.[start - 1])
-  in
-  let after_idx = start + needle_len in
-  let after =
-    after_idx >= String.length haystack
-    || not (is_reference_token_char haystack.[after_idx])
-  in
-  before && after
-
 let notes_mention_required_entry ~notes entry =
   let needle = String.lowercase_ascii entry in
   let haystack = String.lowercase_ascii notes in
@@ -70,7 +47,7 @@ let notes_mention_required_entry ~notes entry =
       if i > limit then false
       else if
         String.sub haystack i needle_len = needle
-        && reference_boundary_match haystack needle i
+        && Evidence_ref.boundary_match ~haystack ~needle ~start:i
       then true
       else loop (i + 1)
     in

--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -24,34 +24,144 @@ let reason_evidence_incomplete ~required_evidence =
      reference supplied"
     (List.length required_evidence)
 
+let starts_with ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len && String.sub value 0 prefix_len = prefix
+
+let is_hex_char = function
+  | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
+  | _ -> false
+
+let is_commit_ref value =
+  let len = String.length value in
+  len >= 7 && len <= 40 && String.for_all is_hex_char value
+
+let contains_path_separator value =
+  String.contains value '/' || String.contains value '\\'
+
+let is_file_ref_char = function
+  | '0' .. '9'
+  | 'a' .. 'z'
+  | 'A' .. 'Z'
+  | '/'
+  | '\\'
+  | '.'
+  | '_'
+  | '-'
+  | '~'
+  | '@'
+  | ':' -> true
+  | _ -> false
+
+let is_extension_char = function
+  | '0' .. '9' | 'a' .. 'z' | 'A' .. 'Z' -> true
+  | _ -> false
+
+let has_plausible_extension value =
+  match String.rindex_opt value '.' with
+  | None -> false
+  | Some idx ->
+    let len = String.length value in
+    let ext_len = len - idx - 1 in
+    idx > 0
+    && ext_len >= 1
+    && ext_len <= 12
+    && String.for_all is_file_ref_char value
+    && String.for_all is_extension_char (String.sub value (idx + 1) ext_len)
+
+let looks_like_file_path value =
+  String.for_all is_file_ref_char value
+  && (contains_path_separator value || has_plausible_extension value)
+
+let is_pr_ref value =
+  let len = String.length value in
+  (len > 3
+   && (starts_with ~prefix:"PR#" value || starts_with ~prefix:"pr#" value)
+   && String.for_all
+        (function
+          | '0' .. '9' -> true
+          | _ -> false)
+        (String.sub value 3 (len - 3)))
+  || (len > 1
+      && value.[0] = '#'
+      && String.for_all
+           (function
+             | '0' .. '9' -> true
+             | _ -> false)
+           (String.sub value 1 (len - 1)))
+
+let is_trace_ref value =
+  starts_with ~prefix:"trace:" value
+  || starts_with ~prefix:"turn:" value
+  || starts_with ~prefix:"receipt:" value
+
+let evidence_ref_is_concrete ref_ =
+  let value = String.trim ref_ in
+  if String.equal value "" then false
+  else
+    starts_with ~prefix:"http://" value
+    || starts_with ~prefix:"https://" value
+    || starts_with ~prefix:"file://" value
+    || is_pr_ref value
+    || is_commit_ref value
+    || is_trace_ref value
+    || looks_like_file_path value
+
+let is_reference_token_char = function
+  | '0' .. '9'
+  | 'a' .. 'z'
+  | 'A' .. 'Z'
+  | '/'
+  | '\\'
+  | '_'
+  | '-'
+  | '~'
+  | '@' -> true
+  | _ -> false
+
+let reference_boundary_match haystack needle start =
+  let needle_len = String.length needle in
+  let before =
+    start = 0 || not (is_reference_token_char haystack.[start - 1])
+  in
+  let after_idx = start + needle_len in
+  let after =
+    after_idx >= String.length haystack
+    || not (is_reference_token_char haystack.[after_idx])
+  in
+  before && after
+
+let notes_mention_required_entry ~notes entry =
+  let needle = String.lowercase_ascii entry in
+  let haystack = String.lowercase_ascii notes in
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  if needle_len = 0 || needle_len > haystack_len then false
+  else
+    let limit = haystack_len - needle_len in
+    let rec loop i =
+      if i > limit then false
+      else if
+        String.sub haystack i needle_len = needle
+        && reference_boundary_match haystack needle i
+      then true
+      else loop (i + 1)
+    in
+    loop 0
+
 (* Heuristic: an "evidence entry" is satisfied when the notes or
-   handoff_context.evidence_refs mention a non-placeholder string that
-   names it. *)
+   concrete handoff_context.evidence_refs mention a non-placeholder string that
+   names it. Blank required entries are never evidence. *)
 let evidence_entry_satisfied
     ~notes
     ~(handoff_context : Masc_domain.task_handoff_context option)
     (entry : string)
   =
   let entry_trimmed = String.trim entry in
-  if String.equal entry_trimmed "" then true
+  if String.equal entry_trimmed "" then false
   else
     let entry_lower = String.lowercase_ascii entry_trimmed in
-    let notes_lower = String.lowercase_ascii notes in
-    let mentions s =
-      let needle = String.lowercase_ascii s in
-      let nlen = String.length needle in
-      let hlen = String.length notes_lower in
-      if nlen = 0 || nlen > hlen then false
-      else
-        let limit = hlen - nlen in
-        let rec loop i =
-          if i > limit then false
-          else if String.sub notes_lower i nlen = needle then true
-          else loop (i + 1)
-        in
-        loop 0
-    in
-    let in_notes = mentions entry_lower in
+    let in_notes = notes_mention_required_entry ~notes entry_lower in
     let in_handoff =
       match handoff_context with
       | None -> false
@@ -59,7 +169,7 @@ let evidence_entry_satisfied
         List.exists
           (fun ref_ ->
             let r = String.lowercase_ascii (String.trim ref_) in
-            r <> "" && r = entry_lower)
+            evidence_ref_is_concrete ref_ && r = entry_lower)
           hc.evidence_refs
     in
     in_notes || in_handoff
@@ -111,7 +221,7 @@ let handoff_supplies_evidence
   | None -> false
   | Some hc ->
     List.exists
-      (fun ref_ -> String.trim ref_ |> String.length > 0)
+      evidence_ref_is_concrete
       hc.evidence_refs
 
 (* Evidence-substantiveness gate for explicit verification submissions. Normal

--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -28,23 +28,31 @@ let starts_with ~prefix value =
   let prefix_len = String.length prefix in
   String.length value >= prefix_len && String.sub value 0 prefix_len = prefix
 
+let payload_after_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  String.sub value prefix_len (String.length value - prefix_len)
+
 let is_hex_char = function
   | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
   | _ -> false
 
+let min_short_commit_hex_len = 7
+let max_commit_hex_len = 64
+let max_file_extension_len = 12
+
 let is_commit_ref value =
   let len = String.length value in
-  len >= 7 && len <= 40 && String.for_all is_hex_char value
+  len >= min_short_commit_hex_len
+  && len <= max_commit_hex_len
+  && String.for_all is_hex_char value
 
-let contains_path_separator value =
-  String.contains value '/' || String.contains value '\\'
+let contains_path_separator value = String.contains value '/'
 
 let is_file_ref_char = function
   | '0' .. '9'
   | 'a' .. 'z'
   | 'A' .. 'Z'
   | '/'
-  | '\\'
   | '.'
   | '_'
   | '-'
@@ -65,12 +73,24 @@ let has_plausible_extension value =
     let ext_len = len - idx - 1 in
     idx > 0
     && ext_len >= 1
-    && ext_len <= 12
+    && ext_len <= max_file_extension_len
     && String.for_all is_file_ref_char value
     && String.for_all is_extension_char (String.sub value (idx + 1) ext_len)
 
+let has_file_payload_char value =
+  String.exists
+    (function
+      | '/' | '.' -> false
+      | _ -> true)
+    value
+
+let has_concrete_prefix_payload ~prefix value =
+  let payload = payload_after_prefix ~prefix value |> String.trim in
+  (not (String.equal payload "")) && has_file_payload_char payload
+
 let looks_like_file_path value =
   String.for_all is_file_ref_char value
+  && has_file_payload_char value
   && (contains_path_separator value || has_plausible_extension value)
 
 let is_pr_ref value =
@@ -91,20 +111,37 @@ let is_pr_ref value =
            (String.sub value 1 (len - 1)))
 
 let is_trace_ref value =
-  starts_with ~prefix:"trace:" value
-  || starts_with ~prefix:"turn:" value
-  || starts_with ~prefix:"receipt:" value
+  (starts_with ~prefix:"trace:" value
+   && has_concrete_prefix_payload ~prefix:"trace:" value)
+  || (starts_with ~prefix:"turn:" value
+      && has_concrete_prefix_payload ~prefix:"turn:" value)
+  || (starts_with ~prefix:"receipt:" value
+      && has_concrete_prefix_payload ~prefix:"receipt:" value)
+
+let is_url_ref value =
+  (starts_with ~prefix:"http://" value
+   && has_concrete_prefix_payload ~prefix:"http://" value)
+  || (starts_with ~prefix:"https://" value
+      && has_concrete_prefix_payload ~prefix:"https://" value)
+
+let is_file_uri_ref value =
+  starts_with ~prefix:"file://" value
+  && has_concrete_prefix_payload ~prefix:"file://" value
 
 let evidence_ref_is_concrete ref_ =
   let value = String.trim ref_ in
   if String.equal value "" then false
+  else if starts_with ~prefix:"http://" value || starts_with ~prefix:"https://" value
+  then is_url_ref value
+  else if starts_with ~prefix:"file://" value then is_file_uri_ref value
+  else if
+    starts_with ~prefix:"trace:" value
+    || starts_with ~prefix:"turn:" value
+    || starts_with ~prefix:"receipt:" value
+  then is_trace_ref value
   else
-    starts_with ~prefix:"http://" value
-    || starts_with ~prefix:"https://" value
-    || starts_with ~prefix:"file://" value
-    || is_pr_ref value
+    is_pr_ref value
     || is_commit_ref value
-    || is_trace_ref value
     || looks_like_file_path value
 
 let is_reference_token_char = function
@@ -112,7 +149,6 @@ let is_reference_token_char = function
   | 'a' .. 'z'
   | 'A' .. 'Z'
   | '/'
-  | '\\'
   | '_'
   | '-'
   | '~'

--- a/lib/cdal_evidence_gate.ml
+++ b/lib/cdal_evidence_gate.ml
@@ -12,8 +12,8 @@ let rule_id_evidence_incomplete = "cdal_evidence_incomplete"
 let hint_evidence_incomplete =
   "Supply task-completion evidence: notes >= 20 chars summarising what \
    changed AND every contract.required_evidence entry mentioned verbatim, \
-   OR at least one handoff_context.evidence_refs reference (file path, PR \
-   number, commit hash, trace id, or any reference URL). Pure-placeholder \
+   OR at least one handoff_context.evidence_refs reference (PR number, commit \
+   hash, trace id, or reviewer-inspectable URL). Pure-placeholder \
    notes ('done', 'ok', etc.) with no required_evidence mention and no \
    handoff evidence_refs keep this gate closed."
 
@@ -24,15 +24,15 @@ let reason_evidence_incomplete ~required_evidence =
      reference supplied"
     (List.length required_evidence)
 
-let evidence_ref_is_concrete ref_ =
+let evidence_ref_is_gate_trusted ref_ =
   match Evidence_ref.of_string ref_ with
-  | Some
-      ( Evidence_ref.Url _
-      | Evidence_ref.File_uri _
-      | Evidence_ref.Pr _
-      | Evidence_ref.Commit _
-      | Evidence_ref.Trace_ref _
-      | Evidence_ref.File_path _ ) -> true
+  | Some (Evidence_ref.Url _ | Evidence_ref.Pr _ | Evidence_ref.Commit _ | Evidence_ref.Trace_ref _) -> true
+  | Some (Evidence_ref.File_uri _ | Evidence_ref.File_path _) ->
+    (* File-shaped refs are only shape-recognized by [Evidence_ref]. Without a
+       base-path/artifact-store resolution step they are candidates, not proof a
+       reviewer can inspect. Fail closed until a validated file evidence type is
+       available. *)
+    false
   | None -> false
 
 let notes_mention_required_entry ~notes entry =
@@ -73,7 +73,7 @@ let evidence_entry_satisfied
         List.exists
           (fun ref_ ->
             let r = String.lowercase_ascii (String.trim ref_) in
-            evidence_ref_is_concrete ref_ && r = entry_lower)
+            evidence_ref_is_gate_trusted ref_ && r = entry_lower)
           hc.evidence_refs
     in
     in_notes || in_handoff
@@ -125,7 +125,7 @@ let handoff_supplies_evidence
   | None -> false
   | Some hc ->
     List.exists
-      evidence_ref_is_concrete
+      evidence_ref_is_gate_trusted
       hc.evidence_refs
 
 (* Evidence-substantiveness gate for explicit verification submissions. Normal
@@ -134,7 +134,7 @@ let handoff_supplies_evidence
    evidence a reviewer can inspect downstream. A contracted task passes when
    *every* required_evidence entry is mentioned in notes/handoff AND the caller
    supplied at least one of: substantive notes, or a handoff evidence reference
-   (file path, PR number, commit hash, trace id, or any reference URL). Empty
+   (PR number, commit hash, trace id, or reviewer-inspectable URL). Empty
    notes with empty required_evidence still rejects, since that carries no
    evidence at all. *)
 let evidence_is_substantive

--- a/lib/cdal_evidence_gate.mli
+++ b/lib/cdal_evidence_gate.mli
@@ -7,10 +7,11 @@
     Explicit verification submission is checked for the presence of evidence
     the reviewer can inspect downstream — substantive
     notes plus the contract's [required_evidence] entries mentioned as
-    standalone reference tokens, or a concrete handoff reference (file path,
-    PR number, commit hash, trace id, or any reference URL). Blank required
-    evidence entries are treated as unsatisfied. There is no internal
-    proof/verdict pipeline.
+    standalone reference tokens, or a trusted handoff reference (PR number,
+    commit hash, trace id, or reviewer-inspectable URL). File-shaped refs are
+    only shape-recognized until an artifact/base-path validation layer can prove
+    they exist inside the allowed workspace. Blank required evidence entries are
+    treated as unsatisfied. There is no internal proof/verdict pipeline.
 
     Decision matrix:
 

--- a/lib/cdal_evidence_gate.mli
+++ b/lib/cdal_evidence_gate.mli
@@ -6,9 +6,11 @@
 
     Explicit verification submission is checked for the presence of evidence
     the reviewer can inspect downstream — substantive
-    notes plus the contract's [required_evidence] entries, or a handoff
-    reference (file path, PR number, commit hash, trace id, or any
-    reference URL). There is no internal proof/verdict pipeline.
+    notes plus the contract's [required_evidence] entries mentioned as
+    standalone reference tokens, or a concrete handoff reference (file path,
+    PR number, commit hash, trace id, or any reference URL). Blank required
+    evidence entries are treated as unsatisfied. There is no internal
+    proof/verdict pipeline.
 
     Decision matrix:
 

--- a/lib/evidence_ref.ml
+++ b/lib/evidence_ref.ml
@@ -96,6 +96,43 @@ let is_file_ref_char = function
   | ':' -> true
   | _ -> false
 
+let is_reference_body_char = function
+  | '0' .. '9'
+  | 'a' .. 'z'
+  | 'A' .. 'Z'
+  | '/'
+  | '_'
+  | '-'
+  | '~'
+  | '@' -> true
+  | _ -> false
+
+let is_reference_connector_char = function
+  | '.' | ':' | '?' | '&' | '=' | '%' | '#' | '+' -> true
+  | _ -> false
+
+let reference_char_extends_right haystack idx =
+  if idx >= String.length haystack then false
+  else if is_reference_body_char haystack.[idx] then true
+  else if is_reference_connector_char haystack.[idx]
+  then (
+    let next = idx + 1 in
+    next < String.length haystack && is_reference_body_char haystack.[next])
+  else false
+
+let reference_char_extends_left haystack idx =
+  idx >= 0
+  && idx < String.length haystack
+  &&
+  (is_reference_body_char haystack.[idx]
+   || is_reference_connector_char haystack.[idx])
+
+let boundary_match ~haystack ~needle ~start =
+  let before = start = 0 || not (reference_char_extends_left haystack (start - 1)) in
+  let after_idx = start + String.length needle in
+  let after = not (reference_char_extends_right haystack after_idx) in
+  before && after
+
 let is_extension_char = function
   | '0' .. '9' | 'a' .. 'z' | 'A' .. 'Z' -> true
   | _ -> false

--- a/lib/evidence_ref.ml
+++ b/lib/evidence_ref.ml
@@ -34,6 +34,10 @@ let is_hex_char = function
   | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
   | _ -> false
 
+let is_decimal_digit = function
+  | '0' .. '9' -> true
+  | _ -> false
+
 let parse_commit value =
   let len = String.length value in
   if
@@ -43,20 +47,26 @@ let parse_commit value =
   then Some (Commit value)
   else None
 
-let parse_positive_int value =
-  match int_of_string_opt value with
-  | Some n when n > 0 -> Some n
-  | Some _ | None -> None
+let parse_positive_decimal value =
+  if String.equal value "" || not (String.for_all is_decimal_digit value)
+  then None
+  else (
+    match int_of_string_opt value with
+    | Some n when n > 0 -> Some n
+    | Some _ | None -> None)
 
 let parse_pr value =
-  let len = String.length value in
-  if
-    len > 3
-    && (starts_with ~prefix:"PR#" value || starts_with ~prefix:"pr#" value)
-  then Option.map (fun n -> Pr n) (parse_positive_int (String.sub value 3 (len - 3)))
-  else if len > 1 && Char.equal value.[0] '#'
-  then Option.map (fun n -> Pr n) (parse_positive_int (String.sub value 1 (len - 1)))
-  else None
+  let parse_prefixed ~prefix value =
+    if starts_with ~prefix value
+    then Option.map (fun n -> Pr n) (parse_positive_decimal (payload_after_prefix ~prefix value))
+    else None
+  in
+  match parse_prefixed ~prefix:"PR#" value with
+  | Some _ as parsed -> parsed
+  | None ->
+    (match parse_prefixed ~prefix:"pr#" value with
+     | Some _ as parsed -> parsed
+     | None -> parse_prefixed ~prefix:"#" value)
 
 let has_payload_char value =
   String.exists

--- a/lib/evidence_ref.ml
+++ b/lib/evidence_ref.ml
@@ -1,0 +1,165 @@
+type trace_kind =
+  | Trace
+  | Turn
+  | Receipt
+
+type t =
+  | Url of string
+  | File_uri of string
+  | Pr of int
+  | Commit of string
+  | Trace_ref of trace_kind * string
+  | File_path of string
+
+let min_short_commit_hex_len = 7
+let max_commit_hex_len = 64
+let max_file_extension_len = 12
+
+let starts_with ~prefix value =
+  let prefix_len = String.length prefix in
+  String.length value >= prefix_len && String.sub value 0 prefix_len = prefix
+
+let payload_after_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  String.sub value prefix_len (String.length value - prefix_len)
+
+let is_hex_char = function
+  | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
+  | _ -> false
+
+let parse_commit value =
+  let len = String.length value in
+  if
+    len >= min_short_commit_hex_len
+    && len <= max_commit_hex_len
+    && String.for_all is_hex_char value
+  then Some (Commit value)
+  else None
+
+let parse_positive_int value =
+  match int_of_string_opt value with
+  | Some n when n > 0 -> Some n
+  | Some _ | None -> None
+
+let parse_pr value =
+  let len = String.length value in
+  if
+    len > 3
+    && (starts_with ~prefix:"PR#" value || starts_with ~prefix:"pr#" value)
+  then Option.map (fun n -> Pr n) (parse_positive_int (String.sub value 3 (len - 3)))
+  else if len > 1 && Char.equal value.[0] '#'
+  then Option.map (fun n -> Pr n) (parse_positive_int (String.sub value 1 (len - 1)))
+  else None
+
+let has_payload_char value =
+  String.exists
+    (function
+      | '/' | '.' -> false
+      | _ -> true)
+    value
+
+let has_concrete_prefix_payload ~prefix value =
+  let payload = payload_after_prefix ~prefix value |> String.trim in
+  if String.equal payload "" || not (has_payload_char payload) then None else Some payload
+
+let parse_url value =
+  if starts_with ~prefix:"http://" value
+  then Option.map (fun payload -> Url ("http://" ^ payload)) (has_concrete_prefix_payload ~prefix:"http://" value)
+  else if starts_with ~prefix:"https://" value
+  then Option.map (fun payload -> Url ("https://" ^ payload)) (has_concrete_prefix_payload ~prefix:"https://" value)
+  else None
+
+let parse_file_uri value =
+  if starts_with ~prefix:"file://" value
+  then Option.map (fun payload -> File_uri payload) (has_concrete_prefix_payload ~prefix:"file://" value)
+  else None
+
+let parse_trace value =
+  if starts_with ~prefix:"trace:" value
+  then Option.map (fun payload -> Trace_ref (Trace, payload)) (has_concrete_prefix_payload ~prefix:"trace:" value)
+  else if starts_with ~prefix:"turn:" value
+  then Option.map (fun payload -> Trace_ref (Turn, payload)) (has_concrete_prefix_payload ~prefix:"turn:" value)
+  else if starts_with ~prefix:"receipt:" value
+  then Option.map (fun payload -> Trace_ref (Receipt, payload)) (has_concrete_prefix_payload ~prefix:"receipt:" value)
+  else None
+
+let is_file_ref_char = function
+  | '0' .. '9'
+  | 'a' .. 'z'
+  | 'A' .. 'Z'
+  | '/'
+  | '.'
+  | '_'
+  | '-'
+  | '~'
+  | '@'
+  | ':' -> true
+  | _ -> false
+
+let is_extension_char = function
+  | '0' .. '9' | 'a' .. 'z' | 'A' .. 'Z' -> true
+  | _ -> false
+
+let contains_path_separator value = String.contains value '/'
+
+let has_plausible_extension value =
+  match String.rindex_opt value '.' with
+  | None -> false
+  | Some idx ->
+    let len = String.length value in
+    let ext_len = len - idx - 1 in
+    idx > 0
+    && ext_len >= 1
+    && ext_len <= max_file_extension_len
+    && String.for_all is_file_ref_char value
+    && String.for_all is_extension_char (String.sub value (idx + 1) ext_len)
+
+let parse_file_path value =
+  if
+    String.for_all is_file_ref_char value
+    && has_payload_char value
+    && (contains_path_separator value || has_plausible_extension value)
+  then Some (File_path value)
+  else None
+
+let has_known_prefix value =
+  starts_with ~prefix:"http://" value
+  || starts_with ~prefix:"https://" value
+  || starts_with ~prefix:"file://" value
+  || starts_with ~prefix:"trace:" value
+  || starts_with ~prefix:"turn:" value
+  || starts_with ~prefix:"receipt:" value
+
+let of_string raw =
+  let value = String.trim raw in
+  if String.equal value "" then None
+  else if has_known_prefix value
+  then (
+    match parse_url value with
+    | Some _ as parsed -> parsed
+    | None ->
+      (match parse_file_uri value with
+       | Some _ as parsed -> parsed
+       | None -> parse_trace value))
+  else (
+    match parse_pr value with
+    | Some _ as parsed -> parsed
+    | None ->
+      (match parse_commit value with
+       | Some _ as parsed -> parsed
+       | None -> parse_file_path value))
+
+let trace_kind_to_string = function
+  | Trace -> "trace"
+  | Turn -> "turn"
+  | Receipt -> "receipt"
+
+let to_string = function
+  | Url value -> value
+  | File_uri path -> "file://" ^ path
+  | Pr n -> "PR#" ^ string_of_int n
+  | Commit value -> value
+  | Trace_ref (kind, payload) -> trace_kind_to_string kind ^ ":" ^ payload
+  | File_path value -> value
+
+let is_concrete_string value = Option.is_some (of_string value)

--- a/lib/evidence_ref.ml
+++ b/lib/evidence_ref.ml
@@ -11,8 +11,15 @@ type t =
   | Trace_ref of trace_kind * string
   | File_path of string
 
+(* Minimum length of a git "short" commit id (git's default abbrev). Hex
+   strings shorter than this are not treated as commit refs. *)
 let min_short_commit_hex_len = 7
+(* Maximum length of a commit hex id. 64 = SHA-256 hex; git SHA-1 is 40.
+   Accept the longer form so SHA-256 repos are covered. *)
 let max_commit_hex_len = 64
+(* Upper bound on a plausible file extension (e.g. final segment of
+   ".tar.gz"). Bounds the plausible-extension check in
+   [has_plausible_extension]. *)
 let max_file_extension_len = 12
 
 let starts_with ~prefix value =
@@ -151,9 +158,39 @@ let has_plausible_extension value =
     && String.for_all is_file_ref_char value
     && String.for_all is_extension_char (String.sub value (idx + 1) ext_len)
 
+let is_absolute_path value =
+  String.length value > 0 && Char.equal value.[0] '/'
+
+let contains_parent_segment value =
+  (* Reject ".." as a path segment (parent-dir traversal). Matched only at
+     a segment boundary so a literal ".." inside a file name (e.g. "v1..0")
+     is not falsely rejected. *)
+  let len = String.length value in
+  let rec scan i =
+    if i + 2 > len then false
+    else if
+      Char.equal value.[i] '.'
+      && (i + 1 < len)
+      && Char.equal value.[i + 1] '.'
+      && (i = 0 || Char.equal value.[i - 1] '/')
+      && (i + 2 = len || Char.equal value.[i + 2] '/')
+    then true
+    else scan (i + 1)
+  in
+  scan 0
+
 let parse_file_path value =
+  (* P0 (#22348 review): a concrete artifact reference must not be an
+     absolute path or contain a parent-dir ("..") segment — both are
+     gate-bypass shapes, not legitimate relative artifact refs. NOTE: this
+     is shape validation only; the deeper "candidate vs validated"
+     separation the review asks for (so even a/b and x.txt require a
+     base-path-resolved validated variant before the gate accepts them) is
+     deferred as a follow-up. *)
   if
-    String.for_all is_file_ref_char value
+    not (is_absolute_path value)
+    && not (contains_parent_segment value)
+    && String.for_all is_file_ref_char value
     && has_payload_char value
     && (contains_path_separator value || has_plausible_extension value)
   then Some (File_path value)
@@ -199,4 +236,9 @@ let to_string = function
   | Trace_ref (kind, payload) -> trace_kind_to_string kind ^ ":" ^ payload
   | File_path value -> value
 
-let is_concrete_string value = Option.is_some (of_string value)
+(* Formerly [is_concrete_string]. Renamed (#22348 review P1): the typed
+   variant only recognizes a *shape* (url / commit / pr / file_path / …)
+   — it does NOT semantically validate that the value is a real, existing,
+   base-path-resolved artifact. Callers must not read "true" as "this is a
+   concrete, trusted evidence reference". *)
+let recognizes_evidence_shape value = Option.is_some (of_string value)

--- a/lib/evidence_ref.mli
+++ b/lib/evidence_ref.mli
@@ -20,7 +20,14 @@ type t =
 
 val of_string : string -> t option
 val to_string : t -> string
-val is_concrete_string : string -> bool
+val recognizes_evidence_shape : string -> bool
+(** [recognizes_evidence_shape value] is true when [value] matches a known
+    evidence-reference SHAPE (url / file_uri / pr / commit / trace_ref /
+    file_path). It is a SHAPE HEURISTIC ONLY — it does NOT semantically
+    validate that the value is a real, existing, base-path-resolved
+    artifact. Callers must not read [true] as "this is concrete, trusted
+    evidence"; resolve and validate against the artifact store / base path
+    before gating on it. (Renamed from [is_concrete_string], #22348 review.) *)
 
 val boundary_match : haystack:string -> needle:string -> start:int -> bool
 (** [boundary_match ~haystack ~needle ~start] is true when [needle] appears

--- a/lib/evidence_ref.mli
+++ b/lib/evidence_ref.mli
@@ -21,3 +21,10 @@ type t =
 val of_string : string -> t option
 val to_string : t -> string
 val is_concrete_string : string -> bool
+
+val boundary_match : haystack:string -> needle:string -> start:int -> bool
+(** [boundary_match ~haystack ~needle ~start] is true when [needle] appears
+    as a standalone evidence-reference token at [start]. The policy treats
+    path/URL/trace punctuation as extending the token only when more reference
+    characters follow, so ["src/main.ml."] can end a sentence while
+    ["src/main.ml.bak"] remains a longer reference. *)

--- a/lib/evidence_ref.mli
+++ b/lib/evidence_ref.mli
@@ -1,0 +1,23 @@
+(** Evidence_ref — typed SSOT for reviewer-inspectable evidence references.
+
+    Raw evidence references still enter the system as strings for wire
+    compatibility, but recognition of supported shapes lives here. Gates should
+    consume {!of_string} and match the typed value instead of rediscovering ref
+    kinds locally. *)
+
+type trace_kind =
+  | Trace
+  | Turn
+  | Receipt
+
+type t =
+  | Url of string
+  | File_uri of string
+  | Pr of int
+  | Commit of string
+  | Trace_ref of trace_kind * string
+  | File_path of string
+
+val of_string : string -> t option
+val to_string : t -> string
+val is_concrete_string : string -> bool

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -595,16 +595,62 @@ let default_evaluator_runtime () =
 (* Contract verification (#3071)                                     *)
 (* ================================================================ *)
 
+(** Tokenize legacy contract text for local Gate 2.5 matching.
+    ASCII punctuation separates tokens; UTF-8 bytes remain token
+    characters so non-English contract items still compare literally
+    across ASCII whitespace/punctuation. *)
+let contract_tokens text =
+  let buf = Buffer.create 16 in
+  let out = ref [] in
+  let is_token_char = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> true
+    | c -> Char.code c >= 128
+  in
+  let flush () =
+    if Buffer.length buf > 0
+    then (
+      out := Buffer.contents buf :: !out;
+      Buffer.clear buf)
+  in
+  String.iter
+    (fun c ->
+       if is_token_char c
+       then Buffer.add_char buf (Char.lowercase_ascii c)
+       else flush ())
+    text;
+  flush ();
+  List.rev !out
+;;
+
+let contains_token_sequence ~haystack ~needle =
+  let rec starts_with needle haystack =
+    match needle, haystack with
+    | [], _ -> true
+    | n :: ns, h :: hs when String.equal n h -> starts_with ns hs
+    | _ -> false
+  in
+  match needle with
+  | [] -> false
+  | _ ->
+    let rec loop = function
+      | [] -> false
+      | _ :: rest as tokens -> starts_with needle tokens || loop rest
+    in
+    loop haystack
+;;
+
 (** Check completion notes against a pre-declared contract.
-    Returns unmet contract items. A contract item is "met" if the
-    notes contain a case-insensitive substring match.
+    Returns unmet contract items. A contract item is "met" if its
+    normalized token sequence appears in the notes with token boundaries.
 
     This is deliberately simple — the contract is a lightweight
     pre-declaration, not a formal specification language. *)
 let check_contract ~(notes : string) ~(contract : string list) : string list =
-  let lower_notes = String.lowercase_ascii notes in
+  let notes_tokens = contract_tokens notes in
   List.filter
-    (fun item -> not (String_util.contains_substring_ci lower_notes item))
+    (fun item ->
+       let item_tokens = contract_tokens item in
+       not (contains_token_sequence ~haystack:notes_tokens ~needle:item_tokens))
     contract
 ;;
 
@@ -709,8 +755,7 @@ let review
       (* Gate 2.5: legacy local contract check. When the verification FSM is
      enabled, contract judgment is deferred to the Gate 3 LLM prompt instead
      of routing normal completion through a verifier agent. When FSM is
-     disabled, the historical substring check remains as a minimal local
-     safety net. *)
+     disabled, a token-boundary check remains as a minimal local safety net. *)
       let contract_rejection =
         if Env_config_runtime.Verification.fsm_enabled ()
         then None

--- a/test/test_anti_rationalization_gate2_advisory_10113.ml
+++ b/test/test_anti_rationalization_gate2_advisory_10113.ml
@@ -126,6 +126,30 @@ let test_build_prompt_includes_verification_contract () =
     true
     (contains "Reject if the notes do not provide concrete evidence")
 
+let test_check_contract_rejects_embedded_substrings () =
+  let unmet =
+    AR.check_contract
+      ~notes:
+        "The parser is errorless; the contest coverage marker exists in the \
+         fixture."
+      ~contract:[ "error"; "test coverage" ]
+  in
+  Alcotest.(check (list string))
+    "embedded substrings do not satisfy contract items"
+    [ "error"; "test coverage" ]
+    unmet
+
+let test_check_contract_matches_token_sequence_through_punctuation () =
+  let unmet =
+    AR.check_contract
+      ~notes:"Tests: passed. Coverage-report attached to the completion notes."
+      ~contract:[ "tests passed"; "coverage report" ]
+  in
+  Alcotest.(check (list string))
+    "punctuation-separated token sequences satisfy contract items"
+    []
+    unmet
+
 (* Counter label vocabulary contract — pin each decision string
    so dashboards keyed on these labels do not silently break.
    These three strings are the only valid values; adding a new
@@ -188,6 +212,13 @@ let () =
             `Quick test_build_prompt_no_advisory_section_without_input;
           Alcotest.test_case "verification contract included"
             `Quick test_build_prompt_includes_verification_contract;
+        ] );
+      ( "contract_check",
+        [
+          Alcotest.test_case "embedded substrings remain unmet"
+            `Quick test_check_contract_rejects_embedded_substrings;
+          Alcotest.test_case "punctuation token sequence is accepted"
+            `Quick test_check_contract_matches_token_sequence_through_punctuation;
         ] );
       ( "counter_labels",
         [

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -138,6 +138,45 @@ let test_handoff_reference_passes () =
   | Gate.Reject { rule_id; _ } ->
     failf "handoff reference should Pass, got Reject rule_id=%s" rule_id
 
+let test_plain_handoff_reference_rejects () =
+  let task = make_task ~contract:(Some (make_contract ())) () in
+  List.iter
+    (fun ref_ ->
+       match
+         Gate.decide
+           ~task_id:"task-weak-handoff"
+           ~task_opt:(Some task)
+           ~notes:""
+           ~handoff_context:(Some (handoff_with_refs [ ref_ ]))
+           ()
+       with
+       | Gate.Pass ->
+         failf "plain handoff text %S must not count as concrete evidence" ref_
+       | Gate.Reject { rule_id; _ } ->
+         check string "rule_id" Gate.rule_id_evidence_incomplete rule_id)
+    [ "see retro"; "see retro." ]
+
+let test_blank_required_evidence_rejects () =
+  let contract = make_contract ~required_evidence:[ "  " ] () in
+  let task = make_task ~contract:(Some contract) () in
+  match
+    Gate.decide
+      ~task_id:"task-blank-required"
+      ~task_opt:(Some task)
+      ~notes:"substantive completion notes are present here"
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> fail "blank required_evidence entry must not auto-satisfy"
+  | Gate.Reject { rule_id; payload_json; _ } ->
+    check string "rule_id" Gate.rule_id_evidence_incomplete rule_id;
+    (match payload_json with
+     | `Assoc fields ->
+       (match List.assoc_opt "required_evidence_unsatisfied" fields with
+        | Some (`List xs) -> check int "blank unsatisfied count" 1 (List.length xs)
+        | _ -> fail "payload missing required_evidence_unsatisfied")
+     | _ -> fail "payload is not Assoc")
+
 (* Contract + required_evidence unsatisfied → Reject *)
 let test_required_evidence_unsatisfied_rejects () =
   let contract =
@@ -164,6 +203,57 @@ let test_required_evidence_unsatisfied_rejects () =
         | Some (`Assoc _) -> ()
         | _ -> fail "payload missing evidence_summary")
      | _ -> fail "payload is not Assoc")
+
+let test_required_evidence_embedded_substring_rejects () =
+  let contract = make_contract ~required_evidence:[ "error" ] () in
+  let task = make_task ~contract:(Some contract) () in
+  match
+    Gate.decide
+      ~task_id:"task-embedded-substring"
+      ~task_opt:(Some task)
+      ~notes:"completed an errorless run with enough context"
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> fail "embedded substring must not satisfy required_evidence"
+  | Gate.Reject { rule_id; payload_json; _ } ->
+    check string "rule_id" Gate.rule_id_evidence_incomplete rule_id;
+    (match payload_json with
+     | `Assoc fields ->
+       (match List.assoc_opt "required_evidence_unsatisfied" fields with
+        | Some (`List [ `String "error" ]) -> ()
+        | _ -> fail "payload did not preserve unsatisfied evidence entry")
+     | _ -> fail "payload is not Assoc")
+
+let test_required_evidence_path_with_punctuation_passes () =
+  let contract = make_contract ~required_evidence:[ "src/main.ml" ] () in
+  let task = make_task ~contract:(Some contract) () in
+  match
+    Gate.decide
+      ~task_id:"task-path-boundary"
+      ~task_opt:(Some task)
+      ~notes:"implemented the fix in src/main.ml. review notes attached"
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> ()
+  | Gate.Reject { rule_id; _ } ->
+    failf "path mention followed by punctuation should Pass, got %s" rule_id
+
+let test_required_evidence_word_with_colon_passes () =
+  let contract = make_contract ~required_evidence:[ "error" ] () in
+  let task = make_task ~contract:(Some contract) () in
+  match
+    Gate.decide
+      ~task_id:"task-word-colon-boundary"
+      ~task_opt:(Some task)
+      ~notes:"Error: reproduced and fixed with detailed validation notes"
+      ~handoff_context:None
+      ()
+  with
+  | Gate.Pass -> ()
+  | Gate.Reject { rule_id; _ } ->
+    failf "word mention followed by colon should Pass, got %s" rule_id
 
 (* Contract (no required_evidence) + placeholder notes, no handoff → Reject *)
 let test_placeholder_notes_reject () =
@@ -198,8 +288,18 @@ let () =
             test_required_evidence_satisfied_passes
         ; test_case "substantive notes → Pass" `Quick test_substantive_notes_pass
         ; test_case "handoff reference → Pass" `Quick test_handoff_reference_passes
+        ; test_case "plain handoff text → Reject" `Quick
+            test_plain_handoff_reference_rejects
+        ; test_case "blank required_evidence → Reject" `Quick
+            test_blank_required_evidence_rejects
         ; test_case "required_evidence unsatisfied → Reject" `Quick
             test_required_evidence_unsatisfied_rejects
+        ; test_case "embedded required_evidence substring → Reject" `Quick
+            test_required_evidence_embedded_substring_rejects
+        ; test_case "required_evidence path punctuation → Pass" `Quick
+            test_required_evidence_path_with_punctuation_passes
+        ; test_case "required_evidence word colon → Pass" `Quick
+            test_required_evidence_word_with_colon_passes
         ; test_case "placeholder notes → Reject" `Quick
             test_placeholder_notes_reject
         ] )

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -156,6 +156,46 @@ let test_plain_handoff_reference_rejects () =
          check string "rule_id" Gate.rule_id_evidence_incomplete rule_id)
     [ "see retro"; "see retro." ]
 
+let test_placeholder_handoff_reference_rejects () =
+  let task = make_task ~contract:(Some (make_contract ())) () in
+  List.iter
+    (fun ref_ ->
+       match
+         Gate.decide
+           ~task_id:"task-placeholder-handoff"
+           ~task_opt:(Some task)
+           ~notes:""
+           ~handoff_context:(Some (handoff_with_refs [ ref_ ]))
+           ()
+       with
+       | Gate.Pass ->
+         failf "placeholder handoff ref %S must not count as evidence" ref_
+       | Gate.Reject { rule_id; _ } ->
+         check string "rule_id" Gate.rule_id_evidence_incomplete rule_id)
+    [ "http://"; "https://"; "file://"; "trace:"; "turn:"; "receipt:"; "/"; "//"; "./" ]
+
+let test_placeholder_required_evidence_reference_rejects () =
+  let contract = make_contract ~required_evidence:[ "trace:" ] () in
+  let task = make_task ~contract:(Some contract) () in
+  match
+    Gate.decide
+      ~task_id:"task-placeholder-required-ref"
+      ~task_opt:(Some task)
+      ~notes:"substantive completion notes are present here"
+      ~handoff_context:(Some (handoff_with_refs [ "trace:" ]))
+      ()
+  with
+  | Gate.Pass ->
+    fail "placeholder required_evidence reference must remain unsatisfied"
+  | Gate.Reject { rule_id; payload_json; _ } ->
+    check string "rule_id" Gate.rule_id_evidence_incomplete rule_id;
+    (match payload_json with
+     | `Assoc fields ->
+       (match List.assoc_opt "required_evidence_unsatisfied" fields with
+        | Some (`List [ `String "trace:" ]) -> ()
+        | _ -> fail "payload did not preserve placeholder evidence entry")
+     | _ -> fail "payload is not Assoc")
+
 let test_blank_required_evidence_rejects () =
   let contract = make_contract ~required_evidence:[ "  " ] () in
   let task = make_task ~contract:(Some contract) () in
@@ -290,6 +330,10 @@ let () =
         ; test_case "handoff reference → Pass" `Quick test_handoff_reference_passes
         ; test_case "plain handoff text → Reject" `Quick
             test_plain_handoff_reference_rejects
+        ; test_case "placeholder handoff ref → Reject" `Quick
+            test_placeholder_handoff_reference_rejects
+        ; test_case "placeholder required ref → Reject" `Quick
+            test_placeholder_required_evidence_reference_rejects
         ; test_case "blank required_evidence → Reject" `Quick
             test_blank_required_evidence_rejects
         ; test_case "required_evidence unsatisfied → Reject" `Quick

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -196,6 +196,46 @@ let test_placeholder_required_evidence_reference_rejects () =
         | _ -> fail "payload did not preserve placeholder evidence entry")
      | _ -> fail "payload is not Assoc")
 
+let test_evidence_ref_parser_ssot () =
+  let parses_as label expected = function
+    | Some actual -> check string label expected actual
+    | None -> failf "%s did not parse" label
+  in
+  let rejects label raw =
+    match Evidence_ref.of_string raw with
+    | None -> ()
+    | Some ref_ ->
+      failf "%s should reject, parsed %S" label (Evidence_ref.to_string ref_)
+  in
+  Evidence_ref.of_string "https://example.test/pr/42"
+  |> Option.map (function
+    | Evidence_ref.Url value -> value
+    | other -> Evidence_ref.to_string other)
+  |> parses_as "url ref" "https://example.test/pr/42";
+  Evidence_ref.of_string "PR#42"
+  |> Option.map (function
+    | Evidence_ref.Pr value -> string_of_int value
+    | other -> Evidence_ref.to_string other)
+  |> parses_as "PR ref" "42";
+  Evidence_ref.of_string "trace:run-123"
+  |> Option.map (function
+    | Evidence_ref.Trace_ref (Evidence_ref.Trace, value) -> value
+    | other -> Evidence_ref.to_string other)
+  |> parses_as "trace ref" "run-123";
+  Evidence_ref.of_string "logs/output.json"
+  |> Option.map (function
+    | Evidence_ref.File_path value -> value
+    | other -> Evidence_ref.to_string other)
+  |> parses_as "file path ref" "logs/output.json";
+  List.iter
+    (fun (label, raw) -> rejects label raw)
+    [ "bare http", "http://"
+    ; "bare https", "https://"
+    ; "bare file URI", "file://"
+    ; "bare trace", "trace:"
+    ; "bare path separator", "/"
+    ]
+
 let test_blank_required_evidence_rejects () =
   let contract = make_contract ~required_evidence:[ "  " ] () in
   let task = make_task ~contract:(Some contract) () in
@@ -334,6 +374,7 @@ let () =
             test_placeholder_handoff_reference_rejects
         ; test_case "placeholder required ref → Reject" `Quick
             test_placeholder_required_evidence_reference_rejects
+        ; test_case "evidence ref parser SSOT" `Quick test_evidence_ref_parser_ssot
         ; test_case "blank required_evidence → Reject" `Quick
             test_blank_required_evidence_rejects
         ; test_case "required_evidence unsatisfied → Reject" `Quick

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -174,6 +174,53 @@ let test_placeholder_handoff_reference_rejects () =
          check string "rule_id" Gate.rule_id_evidence_incomplete rule_id)
     [ "http://"; "https://"; "file://"; "trace:"; "turn:"; "receipt:"; "/"; "//"; "./" ]
 
+let test_unvalidated_file_handoff_reference_rejects () =
+  let task = make_task ~contract:(Some (make_contract ())) () in
+  List.iter
+    (fun ref_ ->
+       match
+         Gate.decide
+           ~task_id:"task-file-handoff"
+           ~task_opt:(Some task)
+           ~notes:""
+           ~handoff_context:(Some (handoff_with_refs [ ref_ ]))
+           ()
+       with
+       | Gate.Pass ->
+         failf
+           "unvalidated file-shaped handoff ref %S must not count as trusted evidence"
+           ref_
+       | Gate.Reject { rule_id; _ } ->
+         check string "rule_id" Gate.rule_id_evidence_incomplete rule_id)
+    [ "logs/output.json"; "a/b"; "x.txt"; "file://logs/output.json"; "file:///tmp/proof.log" ]
+
+let test_unvalidated_file_required_evidence_rejects () =
+  List.iter
+    (fun ref_ ->
+       let contract = make_contract ~required_evidence:[ ref_ ] () in
+       let task = make_task ~contract:(Some contract) () in
+       match
+         Gate.decide
+           ~task_id:"task-file-required"
+           ~task_opt:(Some task)
+           ~notes:"substantive completion notes without the file-shaped reference"
+           ~handoff_context:(Some (handoff_with_refs [ ref_ ]))
+           ()
+       with
+       | Gate.Pass ->
+         failf
+           "unvalidated file-shaped handoff ref %S must not satisfy required_evidence"
+           ref_
+       | Gate.Reject { rule_id; payload_json; _ } ->
+         check string "rule_id" Gate.rule_id_evidence_incomplete rule_id;
+         (match payload_json with
+          | `Assoc fields ->
+            (match List.assoc_opt "required_evidence_unsatisfied" fields with
+             | Some (`List [ `String actual ]) -> check string "unsatisfied" ref_ actual
+             | _ -> fail "payload did not preserve unsatisfied file evidence")
+          | _ -> fail "payload is not Assoc"))
+    [ "logs/output.json"; "a/b"; "x.txt"; "file://logs/output.json" ]
+
 let test_placeholder_required_evidence_reference_rejects () =
   let contract = make_contract ~required_evidence:[ "trace:" ] () in
   let task = make_task ~contract:(Some contract) () in
@@ -410,6 +457,10 @@ let () =
             test_plain_handoff_reference_rejects
         ; test_case "placeholder handoff ref → Reject" `Quick
             test_placeholder_handoff_reference_rejects
+        ; test_case "unvalidated file handoff ref → Reject" `Quick
+            test_unvalidated_file_handoff_reference_rejects
+        ; test_case "unvalidated file required ref → Reject" `Quick
+            test_unvalidated_file_required_evidence_rejects
         ; test_case "placeholder required ref → Reject" `Quick
             test_placeholder_required_evidence_reference_rejects
         ; test_case "evidence ref parser SSOT" `Quick test_evidence_ref_parser_ssot

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -284,6 +284,9 @@ let test_evidence_ref_parser_ssot () =
     ; "absolute path", "/etc/passwd"
     ; "parent-dir traversal", "../../etc/passwd"
     ; "parent-dir mid-segment", "logs/../../etc/passwd"
+    ; "hex PR number", "PR#0x2A"
+    ; "octal PR number", "#0o10"
+    ; "signed PR number", "PR#+42"
     ]
 
 let test_blank_required_evidence_rejects () =

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -234,6 +234,9 @@ let test_evidence_ref_parser_ssot () =
     ; "bare file URI", "file://"
     ; "bare trace", "trace:"
     ; "bare path separator", "/"
+    ; "absolute path", "/etc/passwd"
+    ; "parent-dir traversal", "../../etc/passwd"
+    ; "parent-dir mid-segment", "logs/../../etc/passwd"
     ]
 
 let test_blank_required_evidence_rejects () =

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -305,6 +305,41 @@ let test_required_evidence_embedded_substring_rejects () =
         | _ -> fail "payload did not preserve unsatisfied evidence entry")
      | _ -> fail "payload is not Assoc")
 
+let test_required_evidence_extended_reference_rejects () =
+  let cases =
+    [ "src/main.ml", "completed work in src/main.ml.bak with enough notes"
+    ; "file.tar", "completed work in file.tar.gz with enough notes"
+    ; ( "https://example.test/pr/42"
+      , "completed work in https://example.test/pr/42.extra with enough notes" )
+    ; "trace:run-123", "completed work in trace:run-123:retry with enough notes"
+    ]
+  in
+  List.iter
+    (fun (required, notes) ->
+       let contract = make_contract ~required_evidence:[ required ] () in
+       let task = make_task ~contract:(Some contract) () in
+       match
+         Gate.decide
+           ~task_id:"task-extended-reference"
+           ~task_opt:(Some task)
+           ~notes
+           ~handoff_context:None
+           ()
+       with
+       | Gate.Pass ->
+         failf
+           "longer reference in notes must not satisfy required_evidence %S"
+           required
+       | Gate.Reject { rule_id; payload_json; _ } ->
+         check string "rule_id" Gate.rule_id_evidence_incomplete rule_id;
+         (match payload_json with
+          | `Assoc fields ->
+            (match List.assoc_opt "required_evidence_unsatisfied" fields with
+             | Some (`List [ `String actual ]) -> check string "unsatisfied" required actual
+             | _ -> fail "payload did not preserve unsatisfied evidence entry")
+          | _ -> fail "payload is not Assoc"))
+    cases
+
 let test_required_evidence_path_with_punctuation_passes () =
   let contract = make_contract ~required_evidence:[ "src/main.ml" ] () in
   let task = make_task ~contract:(Some contract) () in
@@ -381,6 +416,8 @@ let () =
             test_required_evidence_unsatisfied_rejects
         ; test_case "embedded required_evidence substring → Reject" `Quick
             test_required_evidence_embedded_substring_rejects
+        ; test_case "extended required_evidence reference → Reject" `Quick
+            test_required_evidence_extended_reference_rejects
         ; test_case "required_evidence path punctuation → Pass" `Quick
             test_required_evidence_path_with_punctuation_passes
         ; test_case "required_evidence word colon → Pass" `Quick


### PR DESCRIPTION
Split from #22314 into a focused audit slice.

Scope:
- require concrete handoff references instead of accepting arbitrary non-empty handoff text
- stop blank `required_evidence` entries from auto-satisfying verification
- match required evidence and legacy Gate 2.5 contracts on token/reference boundaries instead of embedded substrings
- centralize notes-side reference boundary matching in `Evidence_ref.boundary_match`
- add tests for embedded substring rejection, punctuation/path boundary acceptance, and longer-reference rejection (`src/main.ml.bak`, `file.tar.gz`, URL suffixes, trace suffixes)

Review response:
- The CDAL gate no longer owns a separate `is_reference_token_char` set.
- `Evidence_ref` now owns the boundary policy used by notes-side required evidence matching.
- Sentence punctuation after a ref still passes (`src/main.ml.`), while punctuation that extends a ref rejects (`src/main.ml.bak`, `trace:run-123:retry`).

Out of scope:
- goal actor binding changes (#22343)
- task CAS retry changes (#22345)
- Shell IR privileged dispatch floor (#22347)
- board persistence/moderation changes
- goal approval persistence changes

Local verification without Dune, per current workflow:
- `ocamlformat --check lib/evidence_ref.ml lib/evidence_ref.mli lib/cdal_evidence_gate.ml test/test_cdal_evidence_gate.ml`
- `ocamlc -stop-after parsing lib/evidence_ref.ml lib/evidence_ref.mli lib/cdal_evidence_gate.ml test/test_cdal_evidence_gate.ml`
- `git diff --check`
- source scan: `lib/cdal_evidence_gate.ml` no longer defines local reference-token/boundary helpers and calls `Evidence_ref.boundary_match`
- anchored conflict-marker scan on touched files

Dune build/test proof is intentionally left to GitHub CI. Main quick-suite fallout is tracked separately in #22341.