### PR TITLE
fix(keeper): retry empty no-progress responses

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -257,13 +257,6 @@ let is_accept_no_usable_progress_error (err : Agent_sdk.Error.sdk_error) : bool 
   | None ->
     false
 
-let is_recoverable_no_progress_accept_rejection
-    (err : Agent_sdk.Error.sdk_error) : bool =
-  match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some err ->
-    Keeper_turn_driver.accept_rejection_has_no_progress_retry_hint err
-  | None -> false
-
 (* Classification of why a degraded retry is being attempted.  Closed set
    covering both producer paths: [phase_recovery_retry] (7 narrow reasons)
    and [recoverable_runtime_failure_reason] (broader set including raw
@@ -301,36 +294,18 @@ let degraded_retry_reason_to_string = function
 
 let accept_rejection_degraded_retry_reason err =
   match Keeper_turn_driver.classify_masc_internal_error err with
-  | Some
-      (Keeper_turn_driver.Accept_rejected
-         {
-           reason_kind = Some Keeper_turn_driver.Accept_no_usable_progress;
-           response_shape = Some Keeper_turn_driver.Accept_response_empty;
-           last_tool_effect = None;
-           any_mutating_tool = None;
-           tool_effects_seen = [];
-           _;
-         }) ->
-    Some Empty_no_progress
-  | Some (Keeper_turn_driver.Accept_rejected _)
-    when is_recoverable_no_progress_accept_rejection err ->
-    Some Read_only_no_progress
-  | Some
-      ( Keeper_turn_driver.Accept_rejected _
-      | Keeper_turn_driver.Runtime_exhausted _
-      | Keeper_turn_driver.Capacity_backpressure _
-      | Keeper_turn_driver.Resumable_cli_session _
-      | Keeper_turn_driver.Admission_queue_timeout _
-      | Keeper_turn_driver.Admission_queue_rejected _
-      | Keeper_turn_driver.Turn_timeout _
-      | Keeper_turn_driver.Provider_timeout _
-      | Keeper_turn_driver.Max_tokens_ceiling_violation _
-      | Keeper_turn_driver.Ambiguous_post_commit _
-      | Keeper_turn_driver.Internal_unhandled_exception _
-      | Keeper_turn_driver.Internal_bridge_exception _
-      | Keeper_turn_driver.Internal_contract_rejected _ )
-  | None ->
-    None
+  | Some internal_error ->
+    (match Keeper_turn_driver.accept_no_progress_retry_kind internal_error with
+     | Some `Empty_no_progress -> Some Empty_no_progress
+     | Some `Read_only_no_progress -> Some Read_only_no_progress
+     | None -> None)
+  | None -> None
+
+let is_recoverable_no_progress_accept_rejection
+    (err : Agent_sdk.Error.sdk_error) : bool =
+  match accept_rejection_degraded_retry_reason err with
+  | Some (Empty_no_progress | Read_only_no_progress) -> true
+  | Some _ | None -> false
 
 type degraded_retry =
   { next_runtime : string

--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -257,11 +257,11 @@ let is_accept_no_usable_progress_error (err : Agent_sdk.Error.sdk_error) : bool 
   | None ->
     false
 
-let is_thinking_only_read_only_accept_rejection
+let is_recoverable_no_progress_accept_rejection
     (err : Agent_sdk.Error.sdk_error) : bool =
   match Keeper_turn_driver.classify_masc_internal_error err with
   | Some err ->
-    Keeper_turn_driver.accept_rejection_has_read_only_no_progress_retry_hint err
+    Keeper_turn_driver.accept_rejection_has_no_progress_retry_hint err
   | None -> false
 
 (* Classification of why a degraded retry is being attempted.  Closed set
@@ -282,6 +282,7 @@ type degraded_retry_reason =
   | Server_error
   | Auth_error
   | Read_only_no_progress
+  | Empty_no_progress
 
 let degraded_retry_reason_to_string = function
   | Hard_quota -> "hard_quota"
@@ -296,6 +297,40 @@ let degraded_retry_reason_to_string = function
   | Server_error -> "server_error"
   | Auth_error -> "auth_error"
   | Read_only_no_progress -> "read_only_no_progress"
+  | Empty_no_progress -> "empty_no_progress"
+
+let accept_rejection_degraded_retry_reason err =
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some
+      (Keeper_turn_driver.Accept_rejected
+         {
+           reason_kind = Some Keeper_turn_driver.Accept_no_usable_progress;
+           response_shape = Some Keeper_turn_driver.Accept_response_empty;
+           last_tool_effect = None;
+           any_mutating_tool = None;
+           tool_effects_seen = [];
+           _;
+         }) ->
+    Some Empty_no_progress
+  | Some (Keeper_turn_driver.Accept_rejected _)
+    when is_recoverable_no_progress_accept_rejection err ->
+    Some Read_only_no_progress
+  | Some
+      ( Keeper_turn_driver.Accept_rejected _
+      | Keeper_turn_driver.Runtime_exhausted _
+      | Keeper_turn_driver.Capacity_backpressure _
+      | Keeper_turn_driver.Resumable_cli_session _
+      | Keeper_turn_driver.Admission_queue_timeout _
+      | Keeper_turn_driver.Admission_queue_rejected _
+      | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Provider_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
+      | Keeper_turn_driver.Ambiguous_post_commit _
+      | Keeper_turn_driver.Internal_unhandled_exception _
+      | Keeper_turn_driver.Internal_bridge_exception _
+      | Keeper_turn_driver.Internal_contract_rejected _ )
+  | None ->
+    None
 
 type degraded_retry =
   { next_runtime : string
@@ -370,12 +405,12 @@ let degraded_retry_after_recoverable_error
         (Keeper_turn_driver.Runtime_exhausted
            { reason = Keeper_turn_driver.Candidates_filtered_after_cycles; _ }) ->
         phase_recovery_retry Runtime_candidates_filtered
-    | Some (Keeper_turn_driver.Accept_rejected _)
-      when is_thinking_only_read_only_accept_rejection err ->
-        phase_recovery_retry Read_only_no_progress
+    | Some (Keeper_turn_driver.Accept_rejected _) ->
+        (match accept_rejection_degraded_retry_reason err with
+         | Some reason -> phase_recovery_retry reason
+         | None -> None)
     | Some
         (Keeper_turn_driver.Runtime_exhausted _)
-    | Some (Keeper_turn_driver.Accept_rejected _)
     | Some (Keeper_turn_driver.Admission_queue_rejected _)
     | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
     | Some (Keeper_turn_driver.Ambiguous_post_commit _)
@@ -420,10 +455,8 @@ let recoverable_runtime_failure_reason (err : Agent_sdk.Error.sdk_error) =
            arm previously returned [None]. Other arms below remain
            non-recoverable to keep the surface conservative. *)
         Some Runtime_exhausted
-    | Some (Keeper_turn_driver.Accept_rejected _)
-      when is_thinking_only_read_only_accept_rejection err ->
-        Some Read_only_no_progress
-    | Some (Keeper_turn_driver.Accept_rejected _)
+    | Some (Keeper_turn_driver.Accept_rejected _) ->
+        accept_rejection_degraded_retry_reason err
     | Some (Keeper_turn_driver.Admission_queue_rejected _)
     | Some (Keeper_turn_driver.Max_tokens_ceiling_violation _)
     | Some (Keeper_turn_driver.Ambiguous_post_commit _)
@@ -545,7 +578,7 @@ let default_degraded_rotation_candidates
   in
   let default_candidates = [ normalized_base; default_runtime; phase_recovery_runtime ] in
   match fallback_reason with
-  | Some Read_only_no_progress ->
+  | Some (Read_only_no_progress | Empty_no_progress) ->
     let tool_capable =
       Runtime.get_runtimes ()
       |> List.filter (fun (runtime : Runtime.t) -> runtime.model.tools_support)
@@ -632,7 +665,7 @@ let is_completion_contract_violation (_ : Agent_sdk.Error.sdk_error) : bool =
   false
 
 let degraded_reason_allows_candidate_cycle = function
-  | Hard_quota | Rate_limit | Read_only_no_progress -> false
+  | Hard_quota | Rate_limit | Read_only_no_progress | Empty_no_progress -> false
   | Resumable_cli_session
   | Admission_queue_timeout
   | Provider_timeout
@@ -678,6 +711,7 @@ let degraded_rotation_after_recoverable_error
             candidates
         | Hard_quota
         | Read_only_no_progress
+        | Empty_no_progress
         | Resumable_cli_session
         | Admission_queue_timeout
         | Provider_timeout

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -107,6 +107,7 @@ type degraded_retry_reason =
   | Server_error
   | Auth_error
   | Read_only_no_progress
+  | Empty_no_progress
 
 val degraded_retry_reason_to_string : degraded_retry_reason -> string
 

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -392,6 +392,9 @@ module For_testing = struct
 
   let media_degrade_manifest_decision = media_degrade_manifest_decision
 
+  let accept_no_progress_should_try_next =
+    Keeper_turn_driver_try_runtime.For_testing.accept_no_progress_should_try_next
+
   let accept_no_progress_read_only_should_try_next =
     Keeper_turn_driver_try_runtime.For_testing
     .accept_no_progress_read_only_should_try_next

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -178,6 +178,8 @@ module For_testing : sig
   val media_degrade_manifest_decision :
     runtime_id:string -> (string * int) list -> Yojson.Safe.t
 
+  val accept_no_progress_should_try_next : Agent_sdk.Error.sdk_error -> bool
+
   val accept_no_progress_read_only_should_try_next :
     Agent_sdk.Error.sdk_error -> bool
 end

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -66,6 +66,12 @@ let is_accept_rejected_sdk_error err =
   | None ->
     false
 
+let accept_no_progress_should_try_next err =
+  match Keeper_internal_error.classify_masc_internal_error err with
+  | Some err ->
+    Keeper_internal_error.accept_rejection_has_no_progress_retry_hint err
+  | None -> false
+
 let accept_no_progress_read_only_should_try_next err =
   match Keeper_internal_error.classify_masc_internal_error err with
   | Some err ->
@@ -237,7 +243,7 @@ let run
          | Some http_err
            when (not is_last)
                 && (Runtime_attempt_fsm.should_try_next http_err
-                    || accept_no_progress_read_only_should_try_next original_error)
+                    || accept_no_progress_should_try_next original_error)
            ->
            loop checkpoint_after (Some http_err) rest
          | Some http_err ->
@@ -249,6 +255,8 @@ let run
   loop resume_checkpoint last_err candidates
 
 module For_testing = struct
+  let accept_no_progress_should_try_next = accept_no_progress_should_try_next
+
   let accept_no_progress_read_only_should_try_next =
     accept_no_progress_read_only_should_try_next
 end

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -619,6 +619,19 @@ let accept_rejection_has_read_only_no_progress_retry_hint = function
   | Internal_contract_rejected _ ->
     false
 
+let accept_rejection_has_no_progress_retry_hint = function
+  | Accept_rejected
+      {
+        reason_kind = Some Accept_no_usable_progress;
+        response_shape = Some Accept_response_empty;
+        last_tool_effect = None;
+        any_mutating_tool = None;
+        tool_effects_seen = [];
+        _;
+      } ->
+    true
+  | err -> accept_rejection_has_read_only_no_progress_retry_hint err
+
 let sdk_error_of_masc_internal_error err =
   Agent_sdk.Error.Internal
     (masc_internal_error_prefix ^ Yojson.Safe.to_string (masc_internal_error_to_json err))

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -593,7 +593,17 @@ let runtime_id_of_masc_internal_error = function
   | Internal_bridge_exception _
   | Internal_contract_rejected _ -> "unknown"
 
-let accept_rejection_has_read_only_no_progress_retry_hint = function
+let accept_no_progress_retry_kind = function
+  | Accept_rejected
+      {
+        reason_kind = Some Accept_no_usable_progress;
+        response_shape = Some Accept_response_empty;
+        last_tool_effect = None;
+        any_mutating_tool = None;
+        tool_effects_seen = [];
+        _;
+      } ->
+    Some `Empty_no_progress
   | Accept_rejected
       {
         reason_kind = Some Accept_no_usable_progress;
@@ -603,7 +613,7 @@ let accept_rejection_has_read_only_no_progress_retry_hint = function
         tool_effects_seen;
         _;
       } ->
-    tool_effects_seen <> []
+    if tool_effects_seen = [] then None else Some `Read_only_no_progress
   | Accept_rejected _
   | Runtime_exhausted _
   | Capacity_backpressure _
@@ -617,20 +627,20 @@ let accept_rejection_has_read_only_no_progress_retry_hint = function
   | Internal_unhandled_exception _
   | Internal_bridge_exception _
   | Internal_contract_rejected _ ->
+    None
+
+let accept_rejection_has_read_only_no_progress_retry_hint err =
+  match accept_no_progress_retry_kind err with
+  | Some `Read_only_no_progress -> true
+  | Some `Empty_no_progress
+  | None ->
     false
 
-let accept_rejection_has_no_progress_retry_hint = function
-  | Accept_rejected
-      {
-        reason_kind = Some Accept_no_usable_progress;
-        response_shape = Some Accept_response_empty;
-        last_tool_effect = None;
-        any_mutating_tool = None;
-        tool_effects_seen = [];
-        _;
-      } ->
+let accept_rejection_has_no_progress_retry_hint err =
+  match accept_no_progress_retry_kind err with
+  | Some (`Empty_no_progress | `Read_only_no_progress) ->
     true
-  | err -> accept_rejection_has_read_only_no_progress_retry_hint err
+  | None -> false
 
 let sdk_error_of_masc_internal_error err =
   Agent_sdk.Error.Internal

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -152,6 +152,8 @@ val kind_of_masc_internal_error : masc_internal_error -> string
 
 val runtime_id_of_masc_internal_error : masc_internal_error -> string
 
+val accept_rejection_has_no_progress_retry_hint : masc_internal_error -> bool
+
 val accept_rejection_has_read_only_no_progress_retry_hint :
   masc_internal_error -> bool
 

--- a/lib/keeper_runtime/keeper_internal_error.mli
+++ b/lib/keeper_runtime/keeper_internal_error.mli
@@ -152,6 +152,10 @@ val kind_of_masc_internal_error : masc_internal_error -> string
 
 val runtime_id_of_masc_internal_error : masc_internal_error -> string
 
+val accept_no_progress_retry_kind :
+  masc_internal_error ->
+  [ `Empty_no_progress | `Read_only_no_progress ] option
+
 val accept_rejection_has_no_progress_retry_hint : masc_internal_error -> bool
 
 val accept_rejection_has_read_only_no_progress_retry_hint :

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -820,7 +820,61 @@ let test_empty_non_end_turn_response_is_rejected () =
   Alcotest.(check bool)
     "no-progress accept rejection is typed"
     true
-    (Masc.Keeper_error_classify.is_accept_no_usable_progress_error err)
+    (Masc.Keeper_error_classify.is_accept_no_usable_progress_error err);
+  Alcotest.(check bool)
+    "empty no-progress can try next candidate"
+    true
+    (Masc.Keeper_turn_driver.For_testing.accept_no_progress_should_try_next err);
+  Alcotest.(check bool)
+    "empty no-progress is not a read-only retry"
+    false
+    (Masc.Keeper_turn_driver.For_testing
+     .accept_no_progress_read_only_should_try_next
+       err);
+  Alcotest.(check (option string))
+    "empty no-progress is runtime-recoverable"
+    (Some "empty_no_progress")
+    (Option.map
+       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
+
+let test_empty_after_workspace_mutation_stays_terminal () =
+  let checkpoint =
+    checkpoint_with_messages
+      [
+        message
+          [
+            tool_use
+              ~input:(`Assoc [ "title", `String "t"; "body", `String "b" ])
+              "keeper_board_post";
+          ];
+      ]
+  in
+  let result =
+    Masc.Keeper_turn_driver.For_testing.apply_accept
+      ~runtime_id:"runtime.empty-after-mutation"
+      ~accept:Keeper_tool_response.response_has_text_or_tool_progress
+      (run_result ~checkpoint ())
+  in
+  let err, reason_kind, reason = expect_accept_rejected result in
+  Alcotest.(check bool)
+    "reason kind is no usable progress"
+    true
+    (reason_kind = Some Keeper_internal_error.Accept_no_usable_progress);
+  Alcotest.(check bool)
+    "reason includes mutating tool context"
+    true
+    (contains ~needle:"last_tool_effect=mutating" reason);
+  Alcotest.(check bool)
+    "empty response after mutation does not try next candidate"
+    false
+    (Masc.Keeper_turn_driver.For_testing.accept_no_progress_should_try_next err);
+  Alcotest.(check (option string))
+    "empty response after mutation is not runtime-recoverable"
+    None
+    (Option.map
+       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
 
 let test_blank_text_non_end_turn_response_is_rejected () =
   let result =
@@ -993,6 +1047,10 @@ let () =
             test_thinking_only_non_end_turn_response_is_rejected;
           Alcotest.test_case "empty non-end-turn response is rejected" `Quick
             test_empty_non_end_turn_response_is_rejected;
+          Alcotest.test_case
+            "empty response after workspace mutation stays terminal"
+            `Quick
+            test_empty_after_workspace_mutation_stays_terminal;
           Alcotest.test_case "blank text non-end-turn response is rejected" `Quick
             test_blank_text_non_end_turn_response_is_rejected;
           Alcotest.test_case "custom predicate rejection stays distinct" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -64,6 +64,19 @@ let run_result ?content ?stop_reason ?checkpoint () : Runtime_agent.run_result =
     stop_reason = Runtime_agent.Completed;
   }
 
+let accept_no_progress_retry_kind_string err =
+  let kind =
+    match Masc.Keeper_turn_driver.classify_masc_internal_error err with
+    | Some internal_error ->
+      Masc.Keeper_turn_driver.accept_no_progress_retry_kind internal_error
+    | None -> None
+  in
+  Option.map
+    (function
+      | `Empty_no_progress -> "empty_no_progress"
+      | `Read_only_no_progress -> "read_only_no_progress")
+    kind
+
 let test_keeper_hook_relaxes_strict_tool_choice () =
   let open Agent_sdk.Types in
   let relax = Masc.Keeper_run_tools_hooks.relax_strict_tool_choice_for_keeper in
@@ -514,6 +527,10 @@ let test_historical_mutation_does_not_block_current_read_only_retry () =
      .accept_no_progress_read_only_should_try_next
        err);
   Alcotest.(check (option string))
+    "current read-only no-progress classified by internal-error SSOT"
+    (Some "read_only_no_progress")
+    (accept_no_progress_retry_kind_string err);
+  Alcotest.(check (option string))
     "current read-only no-progress is runtime-recoverable"
     (Some "read_only_no_progress")
     (Option.map
@@ -831,6 +848,10 @@ let test_empty_non_end_turn_response_is_rejected () =
     (Masc.Keeper_turn_driver.For_testing
      .accept_no_progress_read_only_should_try_next
        err);
+  Alcotest.(check (option string))
+    "empty no-progress classified by internal-error SSOT"
+    (Some "empty_no_progress")
+    (accept_no_progress_retry_kind_string err);
   Alcotest.(check (option string))
     "empty no-progress is runtime-recoverable"
     (Some "empty_no_progress")

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -116,10 +116,10 @@ let session_with_stale_seen () =
   Time_compat.sleep 0.01;
   (session, before)
 
-let check_session_touched label session before =
+let check_session_touched label (session : SH.session) before =
   Alcotest.(check bool) label true (Atomic.get session.last_seen > before)
 
-let check_session_not_touched label session before =
+let check_session_not_touched label (session : SH.session) before =
   Alcotest.(check bool) label true (Atomic.get session.last_seen = before)
 
 let test_handle_post_session_touch_success () =


### PR DESCRIPTION
## Summary
- treat typed empty/no-tool/no-progress accept rejections as runtime-rotation candidates
- classify the retry kind from the `Keeper_internal_error` SSOT via `accept_no_progress_retry_kind`
- keep the older bool helpers as compatibility wrappers over that SSOT classification
- map `Keeper_error_classify` degraded retry reasons from the SSOT result instead of reopening the raw `Accept_rejected` record
- add accept-driver assertions for both `read_only_no_progress` and `empty_no_progress` SSOT classifications

## Review comment response
- Latest blocker at `863f188e` asked for `Keeper_internal_error.accept_no_progress_retry_kind : masc_internal_error -> [ `Empty_no_progress | `Read_only_no_progress ] option`.
- The branch already had the code consolidation in `9a0542e`; this follow-up adds direct test coverage so the classifier contract is visible in tests too.
- `keeper_error_classify.ml` no longer contains the empty-response record predicate (`Accept_response_empty`, `last_tool_effect = None`, `any_mutating_tool = None`, `tool_effects_seen = []`).

## Evidence
- User-facing failure: `runpod_fable5.gemma4-coder-fable5` returned `accept_rejected` with `reason_kind=no_usable_progress`, `response_shape=empty`, and no tool effects.
- Earlier live health probe on 2026-06-26 02:54 UTC could not connect to `127.0.0.1:8935`; later probe on 2026-06-26 03:26 UTC showed MASC back up on `main` at `e882945c06d`, so this PR is source-level/runtime-retry repair, not a live deployed fix.
- `.masc/trajectories/ramarama/trace-1781691370928-00000.jsonl` contains repeated empty no-progress terminal attempts for the same runtime.

## Validation
- `ocamlc -stop-after parsing lib/keeper_runtime/keeper_internal_error.ml lib/keeper_runtime/keeper_internal_error.mli lib/keeper/keeper_error_classify.ml lib/keeper/keeper_error_classify.mli test/test_keeper_turn_driver_accept.ml`
- `ocamlformat --check lib/keeper_runtime/keeper_internal_error.ml lib/keeper_runtime/keeper_internal_error.mli lib/keeper/keeper_error_classify.ml lib/keeper/keeper_error_classify.mli test/test_keeper_turn_driver_accept.ml`
- `git diff --check`
- source scan: no duplicated empty no-progress record predicate remains in `lib/keeper/keeper_error_classify.ml`
- conflict-marker scan over touched files

## Notes
- Dune/local build was intentionally not run in this follow-up; PR CI remains the build authority.