### PR TITLE
Fix goal principal test helper on main

### DIFF
--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -51,15 +51,10 @@ let parse_json_result (result : Tool_result.result) =
   else Alcotest.fail ((Tool_result.message result))
 ;;
 
-let principal_json ?display_name ~id =
-  let fields =
-    ("id", `String id)
-    ::
-    (match display_name with
-     | None -> []
-     | Some display_name -> [ "display_name", `String display_name ])
-  in
-  `Assoc fields
+let principal_json ~id = `Assoc [ "id", `String id ]
+
+let principal_json_with_display_name ~id ~display_name =
+  `Assoc [ "id", `String id; "display_name", `String display_name ]
 ;;
 
 let get_string_field json field =
@@ -820,7 +815,9 @@ let test_goal_principal_display_name_canonicalized () =
             [ "goal_id", `String goal.id
             ; "action", `String "request_complete"
             ; ( "actor"
-              , principal_json ~id:"planner" ~display_name:forged_actor_label )
+              , principal_json_with_display_name
+                  ~id:"planner"
+                  ~display_name:forged_actor_label )
             ])
   in
   let transitioned_json =
@@ -857,7 +854,9 @@ let test_goal_principal_display_name_canonicalized () =
             [ "goal_id", `String goal.id
             ; "request_id", `String request_id
             ; ( "principal"
-              , principal_json ~id:"agent-alpha" ~display_name:forged_vote_label )
+              , principal_json_with_display_name
+                  ~id:"agent-alpha"
+                  ~display_name:forged_vote_label )
             ; "decision", `String "approve"
             ])
   in


### PR DESCRIPTION
Hotfix for the main CI regression introduced by #22343.

Problem:
- `test/test_goal_tools.ml` changed `principal_json` to `let principal_json ?display_name ~id = ...` without a final non-optional argument.
- Existing calls like `principal_json ~id:"planner"` became partial applications under `-warn-error +16`, causing CI Health/Build/Lint to fail while compiling `test_goal_tools.ml`.

Fix:
- Restore `principal_json ~id` as the simple helper used by existing tests.
- Add `principal_json_with_display_name ~id ~display_name` only for the forged-display-name regression test.

Local non-Dune verification:
- `ocamlformat --check test/test_goal_tools.ml`
- `git diff --check`
- anchored conflict-marker scan on touched file

Dune build/test proof is intentionally left to GitHub CI.