### PR TITLE
fix(test): align reqd-invalid-state guard with ws-direct stack (RFC-0287)

### DIFF
--- a/test/test_reqd_invalid_state_swallow.ml
+++ b/test/test_reqd_invalid_state_swallow.ml
@@ -36,8 +36,13 @@
       direct [respond_with_string] calls in the critical POST/GET/DELETE
       handlers (especially the OAS-executing forked fiber at [Eio.Fiber.fork
       ~sw:(runtime.sw)]).
-   5. [lib/server/server_ws_standalone.ml]: [Ws.Wsd.send_pong] wrapped so the
-      "cannot write to closed writer" race is explicit.
+   5. [lib/server/server_ws_standalone.ml]: the WebSocket write path was
+      guarded against the "cannot write to closed writer" race. After the
+      RFC-0287 ws-direct swap (#22132, 2026-06-23) the write path moved into
+      the ws-direct Endpoint and [Ws.Wsd.send_pong] is no longer called here;
+      the equivalent safety is now enforced by ws-direct Server delegation +
+      missed-pong threshold + write-failure classifier + per-connection flow
+      release (see the W1/W2 anchors below).
 
    This test asserts the presence of these defensive patterns in the source so
    a future refactor that silently removes them fails CI before it can re-arm
@@ -265,23 +270,46 @@ let () =
     |> read_file
   in
 
-  (* Anchor W1: send_pong is still guarded by the write-failure classifier. *)
+  (* RFC-0287 ws-direct update: the ws-direct Endpoint now owns the WebSocket
+     write path, so [Ws.Wsd.send_pong] is no longer called directly from this
+     module. The cycle9 closed-writer safety is preserved equivalently by:
+       - delegating the connection to the ws-direct Server ([Ws_server.handle])
+       - the ws-direct heartbeat/pong protocol ([missed_pong_threshold])
+       - classifying write failures on handler exit ([classify_write_failure])
+       - releasing the per-connection flow on cancel ([Eio.Switch.on_release])
+     These anchors lock the ws-direct equivalents so a future refactor that
+     silently drops any of them fails CI before re-arming the 2026-05-05
+     cycle9 FATAL restart loop. *)
+
+  (* Anchor W1a-i: the connection is delegated to the ws-direct Server, not
+     driven by raw [Ws.Wsd.send_pong] calls from this module. *)
   assert_contains
-    ~label:"W1a: send_pong call still present"
+    ~label:"W1a-i: ws-direct Server.handle delegation"
     ws_src
-    "Ws.Wsd.send_pong session.wsd";
+    "Ws_server.handle";
+
+  (* Anchor W1a-ii: the ws-direct heartbeat/pong protocol is armed (closes
+     sessions that stop responding), the equivalent of the old manual
+     send_pong health-check path. *)
   assert_contains
-    ~label:"W1b: send_pong write failure classifier"
+    ~label:"W1a-ii: ws-direct missed-pong threshold"
+    ws_src
+    "missed_pong_threshold";
+
+  (* Anchor W1b: the write-failure classifier is still present on the
+     handler-error path, so a closed writer is explicit instead of fatal. *)
+  assert_contains
+    ~label:"W1b: write-failure classifier on handler error"
     ws_src
     "classify_write_failure exn";
 
-  (* Anchor W2: writer-closed-during-cancel race comment is present
-     (the wsd-race incident reference travels with the [send_pong]
-     wrapper, so a future refactor that drops the comment is forced
-     to update this anchor). *)
+  (* Anchor W2: the per-connection flow is released via the connection switch
+     on cancel, so a cancel-during-write race closes the flow safely instead
+     of escaping to the server switch — equivalent to the old "writer closed
+     during cancel race" guard. *)
   assert_contains
-    ~label:"W2: writer closed during cancel race comment"
+    ~label:"W2: per-connection flow release on cancel"
     ws_src
-    "writer closed during cancel race";
+    "Eio.Switch.on_release conn_sw";
 
   print_endline "test_reqd_invalid_state_swallow: OK"


### PR DESCRIPTION
## Summary

Fixes the main-branch `test_reqd_invalid_state_swallow` regression guard that has been silently red on `main` since PR #22132 (RFC-0287 ws-direct full swap, 2026-06-23), unblocking every base=`main` build-required PR.

## Root cause

The 2026-05-05 cycle9 FATAL regression guard asserted the presence of
`Ws.Wsd.send_pong session.wsd` in `lib/server/server_ws_standalone.ml`.

PR #22132 (RFC-0287) moved the WebSocket write path into the ws-direct
Endpoint (`Ws_direct_eio.Server`), so the direct `Ws.Wsd.send_pong` call
became obsolete and was removed from this module. The guard kept looking
for the old literal, turning into a **stale false positive**.

Because the CI skip gate folds this quick-suite check into `run_heavy=true`
for `main` pushes but executes it on PRs, `main` looked green while every
base=`main` PR failed the build with a byte-identical error:

```
Fatal error: exception Failure("[W1a: send_pong call still present]
  expected source to contain \"Ws.Wsd.send_pong session.wsd\" ...")
```

Evidence of inheritance: #22182 (README docs-only) and #22318 (memory fix)
fail with the exact same stack trace — a README PR cannot have a real
build defect, so the failure is inherited from `main`.

## Fix: equivalent ws-direct invariants

The cycle9 closed-writer safety is preserved equivalently in the ws-direct
stack by four invariants. The guard now locks all four instead of the
removed `send_pong` literal (anchor count goes 3 → 4, not weaker):

| Anchor | Locks |
|--------|-------|
| `Ws_server.handle` | connection delegated to the ws-direct Server (no raw send_pong here) |
| `missed_pong_threshold` | ws-direct heartbeat/pong protocol (old manual health-check equivalent) |
| `classify_write_failure exn` | closed-writer is explicit on handler-error path (unchanged) |
| `Eio.Switch.on_release conn_sw` | per-connection flow released safely on cancel (old "writer closed during cancel race" equivalent) |

Each anchor points at code that actually exists in
`lib/server/server_ws_standalone.ml` and each closes one axis of the
original cycle9 FATAL in the ws-direct way.

## Verification

Local build + run (runner-constrained environment, so verified locally first):

```
dune build --root . test/test_reqd_invalid_state_swallow.exe
./_build/default/test/test_reqd_invalid_state_swallow.exe
# test_reqd_invalid_state_swallow: OK   (exit 0)
```

## Impact

Resolves the main red inherited by base=`main` build-required PRs
(#22182, #22318, and others once CI settles).

Refs: RFC-0287, #22132

Co-Authored-By: Claude <noreply@anthropic.com>
