### PR TITLE
fix(config): unify TOML/env precedence and tool schema SSOT

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -43,7 +43,16 @@ let descriptor_owned_internal_tool_schemas : Masc_domain.tool_schema list =
 
 let raw_all_tool_schemas : Masc_domain.tool_schema list =
   dedupe_schemas
-    (Tools.raw_schemas
+    (* #9912 / #10101: [Tool_shard.all_keeper_tool_schemas] is the SSOT
+       for every keeper-facing shard tool. It is placed first so that,
+       on the unlikely event of a duplicate name with another aggregate
+       source, the keeper shard definition wins and help lookup /
+       dispatch metadata stay coherent. The earlier #9912 patch only
+       registered [Tool_shard.base_tools] (5 always-present tools); #10101
+       observed 11 other shard categories still missing
+       (keeper_task_claim, tool_edit_file, keeper_board_*, ...). *)
+    (Tool_shard.all_keeper_tool_schemas
+     @ Tools.raw_schemas
      @ Tool_schemas_misc.schemas
      @ descriptor_owned_internal_tool_schemas
      (* Board MCP adapter schemas live outside neutral Tool substrate and
@@ -51,20 +60,7 @@ let raw_all_tool_schemas : Masc_domain.tool_schema list =
      @ Board_tool.tools
      @ Keeper_types_profile.schemas
      @ Tool_local_runtime.schemas
-     @ Tool_agent_timeline.schemas
-     @ Tool_shard.schemas
-     (* #9912 / #10101: every keeper-facing shard tool must reach the
-        authoritative registry consumed by
-        [Tool_help_registry.find_entry], or keepers that request
-        help on the tool receive "unknown tool" despite the
-        dispatcher handling it correctly.  #9912 plugged only
-        [Tool_shard.base_tools] (5 always-present tools); #10101
-        observed 11 other shard categories still missing
-        (keeper_task_claim, tool_edit_file, keeper_board_*, ...).
-        [Tool_shard.all_keeper_tool_schemas] is the SSOT that
-        pulls from [all_shards] plus unsharded default schemas, so future
-        tool categories flow through without another patch-local fix. *)
-     @ Tool_shard.all_keeper_tool_schemas)
+     @ Tool_agent_timeline.schemas)
 
 let front_door_tool_schemas : Masc_domain.tool_schema list = raw_all_tool_schemas
 

--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -134,6 +134,26 @@ let value_to_string = function
   | Keeper_toml_loader.Toml_bool b -> Some (if b then "true" else "false")
   | Keeper_toml_loader.Toml_string_array _ -> None
 
+(** Resolve a single TOML key to its boot-override value. Returns
+    [Some (env_name, value)] when the key is present in the doc and the
+    corresponding env var is unset (so the TOML value would apply).
+    Returns [None] when the env var is already set (caller override wins)
+    or the key is absent / unsupported.
+
+    This is the single precedence rule shared by the pure preview
+    ([resolve_overrides]) and the effectful apply path ([apply_one]):
+    env var > TOML > hardcoded default. *)
+let resolve_one
+    ?(env_lookup = Env_config_core.raw_value_opt)
+    (doc : Keeper_toml_loader.toml_doc) (toml_key, env_name) =
+  if env_is_set env_lookup env_name then
+    (* Caller env override — leave alone. *)
+    None
+  else
+    match List.assoc_opt toml_key doc with
+    | None -> None
+    | Some v -> Option.map (fun s -> (env_name, s)) (value_to_string v)
+
 (** Apply one TOML key to the corresponding env var, unless the env var
     is already set (caller override wins). Returns [true] iff a boot
     override was actually recorded.
@@ -144,19 +164,12 @@ let value_to_string = function
 let apply_one
     ?(env_lookup = Env_config_core.raw_value_opt)
     ?(env_set = Config_boot_overrides.set)
-    (doc : Keeper_toml_loader.toml_doc) (toml_key, env_name) =
-  if env_is_set env_lookup env_name then
-    (* Caller env override — leave alone. *)
-    false
-  else
-    match List.assoc_opt toml_key doc with
-    | None -> false
-    | Some v ->
-      match value_to_string v with
-      | None -> false
-      | Some s ->
-        env_set env_name s;
-        true
+    (doc : Keeper_toml_loader.toml_doc) pair =
+  match resolve_one ~env_lookup doc pair with
+  | None -> false
+  | Some (env_name, s) ->
+    env_set env_name s;
+    true
 
 (** Pure version of the load+apply pipeline. Parses TOML and returns
     the number of overrides that would be applied, plus a list of
@@ -164,22 +177,8 @@ let apply_one
 let resolve_overrides
     ?(env_lookup = Env_config_core.raw_value_opt)
     (doc : Keeper_toml_loader.toml_doc) =
-  let count, applied =
-    List.fold_left
-      (fun (count, applied) (toml_key, env_name) ->
-        if env_is_set env_lookup env_name then (count, applied)
-        else
-          match List.assoc_opt toml_key doc with
-          | None -> (count, applied)
-          | Some v ->
-            match value_to_string v with
-            | None -> (count, applied)
-            | Some s ->
-              (count + 1, (env_name, s) :: applied))
-      (0, [])
-      key_to_env
-  in
-  (count, List.rev applied)
+  let applied = List.filter_map (resolve_one ~env_lookup doc) key_to_env in
+  (List.length applied, applied)
 
 (* Shadow registry: stores every TOML value keyed by env name, even when
    the env var is already set.  This lets operator surfaces compare the


### PR DESCRIPTION
## Changes
- lib/keeper_runtime/keeper_runtime_config.ml: introduce resolve_one helper so env > TOML > default precedence is applied consistently instead of duplicated in preview vs apply paths.
- lib/config.ml: put Tool_shard.all_keeper_tool_schemas first in raw_all_tool_schemas so the declared keeper shard SSOT wins on duplicate names.

## Motivation
Part of the adversarial review cleanup: eliminate SSOT duality and split-brain schema merging.

## Verification
- dune build ✅
- test_runtime_toml_overrides.exe 25/25 ✅
- test_keeper_runtime_config_leaf.exe 2/2 ✅
- test_tool_registry_consistency.exe 6/6 ✅