### PR TITLE
fix(env,event_bus): replace module-level Atomic globals with Domain.DLS

### DIFF
--- a/lib/keeper_event_bus/keeper_event_bus.ml
+++ b/lib/keeper_event_bus/keeper_event_bus.ml
@@ -1,19 +1,26 @@
-(** Keeper_event_bus — Per-domain OAS Event_bus reference.
+(** Keeper_event_bus — OAS Event_bus reference with domain-local override.
 
-    Holds the shared Event_bus instance set once per OCaml domain at
-    server bootstrap.  Separate module to avoid dependency cycles:
+    Holds the shared Event_bus instance set at server bootstrap. Separate
+    module to avoid dependency cycles:
     Keeper_keepalive and Keeper_agent_run both depend on keeper
     modules that form cycles if they reference each other.
 
-    Stored in [Domain.DLS] so access is domain-local.  Keeper
-    supervision runs on the owning Eio domain, so this is equivalent
-    to the previous process-scoped Atomic semantics while removing
-    the module-level global.
+    [Domain.DLS] stores a per-domain override. A process-wide fallback
+    preserves the previous lookup contract for domains that have not been
+    explicitly initialized.
 
     @since 2.255.0 *)
 
 let bus_key : Agent_sdk.Event_bus.t option Domain.DLS.key =
   Domain.DLS.new_key (fun () -> None)
 
-let set bus = Domain.DLS.set bus_key (Some bus)
-let get () = Domain.DLS.get bus_key
+let process_bus : Agent_sdk.Event_bus.t option Atomic.t = Atomic.make None
+
+let set bus =
+  Domain.DLS.set bus_key (Some bus);
+  Atomic.set process_bus (Some bus)
+
+let get () =
+  match Domain.DLS.get bus_key with
+  | Some _ as bus -> bus
+  | None -> Atomic.get process_bus

--- a/lib/keeper_event_bus/keeper_event_bus.ml
+++ b/lib/keeper_event_bus/keeper_event_bus.ml
@@ -1,13 +1,19 @@
-(** Keeper_event_bus — Process-scoped OAS Event_bus reference.
+(** Keeper_event_bus — Per-domain OAS Event_bus reference.
 
-    Holds the shared Event_bus instance set once at server bootstrap.
-    Separate module to avoid dependency cycles: Keeper_keepalive and
-    Keeper_agent_run both depend on keeper modules that form cycles
-    if they reference each other.
+    Holds the shared Event_bus instance set once per OCaml domain at
+    server bootstrap.  Separate module to avoid dependency cycles:
+    Keeper_keepalive and Keeper_agent_run both depend on keeper
+    modules that form cycles if they reference each other.
+
+    Stored in [Domain.DLS] so access is domain-local.  Keeper
+    supervision runs on the owning Eio domain, so this is equivalent
+    to the previous process-scoped Atomic semantics while removing
+    the module-level global.
 
     @since 2.255.0 *)
 
-let bus_ref : Agent_sdk.Event_bus.t option Atomic.t = Atomic.make None
+let bus_key : Agent_sdk.Event_bus.t option Domain.DLS.key =
+  Domain.DLS.new_key (fun () -> None)
 
-let set bus = Atomic.set bus_ref (Some bus)
-let get () = Atomic.get bus_ref
+let set bus = Domain.DLS.set bus_key (Some bus)
+let get () = Domain.DLS.get bus_key

--- a/lib/keeper_event_bus/keeper_event_bus.mli
+++ b/lib/keeper_event_bus/keeper_event_bus.mli
@@ -1,13 +1,17 @@
-(** Keeper_event_bus — Process-scoped OAS Event_bus reference.
+(** Keeper_event_bus — Per-domain OAS Event_bus reference.
 
-    Holds the shared Event_bus instance set once at server bootstrap.
-    Separate module to avoid dependency cycles between Keeper_keepalive
-    and Keeper_agent_run.
+    Holds the shared Event_bus instance set once per OCaml domain at
+    server bootstrap.  Separate module to avoid dependency cycles
+    between Keeper_keepalive and Keeper_agent_run.
+
+    Stored in [Domain.DLS] to remove the previous module-level
+    Atomic global; keeper supervision runs on the owning Eio domain,
+    so the observable semantics remain process-scoped.
 
     @since 2.255.0 *)
 
-(** Install the process-wide event bus. Call once at bootstrap. *)
+(** Install the event bus for the current domain. Call once at bootstrap. *)
 val set : Agent_sdk.Event_bus.t -> unit
 
-(** Read the installed event bus, if any. *)
+(** Read the installed event bus for the current domain, if any. *)
 val get : unit -> Agent_sdk.Event_bus.t option

--- a/lib/keeper_event_bus/keeper_event_bus.mli
+++ b/lib/keeper_event_bus/keeper_event_bus.mli
@@ -1,17 +1,19 @@
-(** Keeper_event_bus — Per-domain OAS Event_bus reference.
+(** Keeper_event_bus — OAS Event_bus reference with domain-local override.
 
-    Holds the shared Event_bus instance set once per OCaml domain at
-    server bootstrap.  Separate module to avoid dependency cycles
-    between Keeper_keepalive and Keeper_agent_run.
+    Holds the shared Event_bus instance set at server bootstrap. Separate
+    module to avoid dependency cycles between Keeper_keepalive and
+    Keeper_agent_run.
 
-    Stored in [Domain.DLS] to remove the previous module-level
-    Atomic global; keeper supervision runs on the owning Eio domain,
-    so the observable semantics remain process-scoped.
+    The current domain's [Domain.DLS] value is preferred. A process-wide
+    fallback preserves legacy lookup semantics for domains that have not
+    installed their own bus yet.
 
     @since 2.255.0 *)
 
-(** Install the event bus for the current domain. Call once at bootstrap. *)
+(** Install the event bus for the current domain and process fallback. Call
+    once at bootstrap; re-install in a domain that owns a separate bus. *)
 val set : Agent_sdk.Event_bus.t -> unit
 
-(** Read the installed event bus for the current domain, if any. *)
+(** Read the installed event bus for the current domain, falling back to the
+    process-level bus when the domain has no override. *)
 val get : unit -> Agent_sdk.Event_bus.t option

--- a/lib/masc_eio_env.ml
+++ b/lib/masc_eio_env.ml
@@ -1,8 +1,11 @@
-(** Module-level Eio environment for OAS HTTP calls.
-    Set once at server startup via {!init}.
+(** Per-domain Eio environment for OAS HTTP calls.
+    Set once per OCaml domain via {!init}.
 
     The switch and net handle are needed by OAS provider completions
-    which use cohttp-eio for HTTP transport.
+    which use cohttp-eio for HTTP transport.  They are stored in
+    [Domain.DLS] so each domain holds its own handles; this removes the
+    module-level Atomic global and avoids cross-domain [Eio.Switch]
+    access errors.
 
     @since 2.130.0 *)
 
@@ -12,15 +15,15 @@ type t = {
   clock : float Eio.Time.clock_ty Eio.Resource.t option;
 }
 
-let env : t option Atomic.t = Atomic.make None
+let env_key : t option Domain.DLS.key = Domain.DLS.new_key (fun () -> None)
 
-let init ~sw ~net ?clock () = Atomic.set env (Some { sw; net; clock })
+let init ~sw ~net ?clock () = Domain.DLS.set env_key (Some { sw; net; clock })
 
-let reset_for_test () = Atomic.set env None
+let reset_for_test () = Domain.DLS.set env_key None
 
 let get () =
-  match Atomic.get env with
+  match Domain.DLS.get env_key with
   | Some e -> e
   | None -> invalid_arg "Masc_eio_env.get: not initialized. Call init at server startup."
 
-let get_opt () = Atomic.get env
+let get_opt () = Domain.DLS.get env_key

--- a/lib/masc_eio_env.ml
+++ b/lib/masc_eio_env.ml
@@ -3,9 +3,9 @@
 
     The switch and net handle are needed by OAS provider completions
     which use cohttp-eio for HTTP transport.  They are stored in
-    [Domain.DLS] so each domain holds its own handles; this removes the
-    module-level Atomic global and avoids cross-domain [Eio.Switch]
-    access errors.
+    [Domain.DLS] so each domain can hold its own handles, with a process-wide
+    compatibility fallback for domains that have not been explicitly
+    initialized yet.
 
     @since 2.130.0 *)
 
@@ -16,14 +16,23 @@ type t = {
 }
 
 let env_key : t option Domain.DLS.key = Domain.DLS.new_key (fun () -> None)
+let process_env : t option Atomic.t = Atomic.make None
 
-let init ~sw ~net ?clock () = Domain.DLS.set env_key (Some { sw; net; clock })
+let init ~sw ~net ?clock () =
+  let env = { sw; net; clock } in
+  Domain.DLS.set env_key (Some env);
+  Atomic.set process_env (Some env)
 
-let reset_for_test () = Domain.DLS.set env_key None
+let reset_for_test () =
+  Domain.DLS.set env_key None;
+  Atomic.set process_env None
+
+let get_opt () =
+  match Domain.DLS.get env_key with
+  | Some _ as env -> env
+  | None -> Atomic.get process_env
 
 let get () =
-  match Domain.DLS.get env_key with
+  match get_opt () with
   | Some e -> e
   | None -> invalid_arg "Masc_eio_env.get: not initialized. Call init at server startup."
-
-let get_opt () = Domain.DLS.get env_key

--- a/lib/masc_eio_env.mli
+++ b/lib/masc_eio_env.mli
@@ -3,15 +3,16 @@
 
     The OAS provider completions use [cohttp-eio] for HTTP
     transport, which needs an Eio switch and net handle.
-    {!init} is called once per OCaml domain (in
-    [server_runtime_bootstrap] and in each standalone executable);
-    every consumer that needs to issue an HTTP call later reaches
+    {!init} is called at server bootstrap and may be called again
+    by additional OCaml domains that own their own Eio handles.
+    Every consumer that needs to issue an HTTP call later reaches
     the captured handles via {!get} or {!get_opt}.
 
-    Internal storage (the [Domain.DLS] slot) is hidden — callers
-    consume only the {!type-t} record and the accessors.  Using
-    domain-local storage removes the previous module-level Atomic
-    global and matches the domain-local nature of [Eio.Switch]. *)
+    Internal storage is hidden. The current domain's [Domain.DLS]
+    value is preferred. A process-wide fallback preserves legacy
+    lookup semantics for domains that have not been explicitly
+    initialised yet; callers that use the returned [Eio.Switch] or net
+    handle across domains still need an ownership audit. *)
 
 type t = {
   sw : Eio.Switch.t;
@@ -31,9 +32,9 @@ val init :
   unit ->
   unit
 (** Capture the runtime handles for the current OCaml domain.
-    Last-writer-wins on [Domain.DLS.set]; intended to be called
-    exactly once per domain at startup but a re-init is permitted
-    (used by the harness test suite). *)
+    Last-writer-wins for both the domain-local slot and the process-wide
+    compatibility fallback. Intended to be called at startup; re-init is
+    permitted by harness tests and standalone executables. *)
 
 val reset_for_test : unit -> unit
 (** Clear the captured environment for direct test executable runs. *)
@@ -47,7 +48,7 @@ val get : unit -> t
 
 val get_opt : unit -> t option
 (** Read the captured environment without raising. Returns
-    [None] when {!init} has not run — used by tests and by
-    code paths that must degrade gracefully (runtime catalog
-    runtime, masc_oas_bridge fallback, local-runtime probes,
-    oas_worker_named scheduler). *)
+    [None] only when {!init} has not run in the process. Used by tests and
+    by code paths that must degrade gracefully (runtime catalog runtime,
+    masc_oas_bridge fallback, local-runtime probes, oas_worker_named
+    scheduler). *)

--- a/lib/masc_eio_env.mli
+++ b/lib/masc_eio_env.mli
@@ -1,16 +1,17 @@
-(** Masc_eio_env — module-level Eio environment for OAS HTTP
+(** Masc_eio_env — per-domain Eio environment for OAS HTTP
     calls.
 
     The OAS provider completions use [cohttp-eio] for HTTP
     transport, which needs an Eio switch and net handle.
-    {!init} is called once at server startup (in
-    [server_runtime_bootstrap]); every consumer that needs to
-    issue an HTTP call later reaches the captured handles via
-    {!get} or {!get_opt}.
+    {!init} is called once per OCaml domain (in
+    [server_runtime_bootstrap] and in each standalone executable);
+    every consumer that needs to issue an HTTP call later reaches
+    the captured handles via {!get} or {!get_opt}.
 
-    Internal storage (the [Atomic.t t option] slot) is hidden —
-    callers consume only the {!type-t} record and the three
-    accessors. *)
+    Internal storage (the [Domain.DLS] slot) is hidden — callers
+    consume only the {!type-t} record and the accessors.  Using
+    domain-local storage removes the previous module-level Atomic
+    global and matches the domain-local nature of [Eio.Switch]. *)
 
 type t = {
   sw : Eio.Switch.t;
@@ -29,10 +30,10 @@ val init :
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->
   unit ->
   unit
-(** Capture the runtime handles. Last-writer-wins on
-    [Atomic.set]; intended to be called exactly once at server
-    startup but a re-init is permitted (used by the harness
-    test suite). *)
+(** Capture the runtime handles for the current OCaml domain.
+    Last-writer-wins on [Domain.DLS.set]; intended to be called
+    exactly once per domain at startup but a re-init is permitted
+    (used by the harness test suite). *)
 
 val reset_for_test : unit -> unit
 (** Clear the captured environment for direct test executable runs. *)

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -100,6 +100,19 @@ let test_clocked_env_runs_function () =
         | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err))))
 ;;
 
+let test_env_process_fallback_visible_from_uninitialized_domain () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Masc_eio_env.reset_for_test ();
+      Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
+        Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ~clock:(Eio.Stdenv.clock env) ();
+        let worker = Domain.spawn (fun () -> Option.is_some (Masc_eio_env.get_opt ())) in
+        Alcotest.(check bool)
+          "process fallback is visible from another domain"
+          true
+          (Domain.join worker))))
+;;
+
 let test_timeout_log_carries_failure_envelope () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
@@ -268,6 +281,10 @@ let () =
             `Quick
             test_clockless_env_fails_closed_without_calling_fn
         ; Alcotest.test_case "clocked env runs" `Quick test_clocked_env_runs_function
+        ; Alcotest.test_case
+            "process fallback is visible cross-domain"
+            `Quick
+            test_env_process_fallback_visible_from_uninitialized_domain
         ; Alcotest.test_case
             "timeout log carries failure envelope"
             `Quick

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -153,6 +153,17 @@ let test_state_pending_count_integrity_under_concurrent_updates () =
   check int "concurrent pure computation leaves count at zero" 0 state.pending_tool_count
 ;;
 
+let test_keeper_event_bus_process_fallback_visible_from_uninitialized_domain () =
+  let bus = Agent_sdk.Event_bus.create () in
+  Keeper_event_bus.set bus;
+  let worker = Domain.spawn (fun () -> Option.is_some (Keeper_event_bus.get ())) in
+  check
+    bool
+    "process fallback is visible from another domain"
+    true
+    (Domain.join worker)
+;;
+
 let test_take_drain_cancel_clears_active_without_spin () =
   let open EB.For_testing in
   let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
@@ -226,6 +237,8 @@ let () =
     ; ( "concurrency"
       , [ test_case "pure transitions under concurrent domains" `Quick
             test_state_pending_count_integrity_under_concurrent_updates
+        ; test_case "event bus fallback is visible cross-domain" `Quick
+            test_keeper_event_bus_process_fallback_visible_from_uninitialized_domain
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick


### PR DESCRIPTION
## Changes

- `lib/masc_eio_env.ml/mli`: prefer a per-domain `Domain.DLS` environment, but keep a process-wide compatibility fallback so uninitialized domains do not silently lose the server bootstrap environment.
- `lib/keeper_event_bus.ml/mli`: prefer a per-domain `Domain.DLS` event-bus override, but keep a process-wide compatibility fallback so uninitialized domains preserve the old lookup contract.
- `test/test_keeper_llm_bridge.ml`: documents that `Masc_eio_env.get_opt` remains visible from another OCaml domain after process bootstrap init.
- `test/test_keeper_unified_turn_event_bus.ml`: documents that `Keeper_event_bus.get` remains visible from another OCaml domain after process bootstrap set.

## Motivation

Raw `Domain.DLS` changed the previous process-wide lookup semantics: a value initialized during server bootstrap disappeared for later callers on another OCaml domain. This follow-up keeps the DLS override path for domains that own their own handles, while preserving the legacy process fallback until all cross-domain callers are explicitly audited/threaded.

## Verification

Comment-response light checks only; no local Dune build/test and no CI/build status checked.

- `ocamlformat --check lib/masc_eio_env.ml lib/masc_eio_env.mli lib/keeper_event_bus/keeper_event_bus.ml lib/keeper_event_bus/keeper_event_bus.mli test/test_keeper_llm_bridge.ml test/test_keeper_unified_turn_event_bus.ml`
- `git diff --check`
- conflict marker scan
- `ocamlc -stop-after parsing` on touched `.ml` files
