### PR TITLE
fix(streaming): session consistency, accept_fork, and O(N) buffer fix

### DIFF
--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -307,19 +307,14 @@ let run ~sw ~net ~clock config request_handler =
 
   let rec accept_loop () =
     try
-      (try
-        let flow, client_addr = Eio.Net.accept ~sw socket in
-        disable_nagle flow;
-        reset_backoff ();
-        Eio.Fiber.fork ~sw (fun () ->
+      Eio.Net.accept_fork ~sw socket
+        ~on_error:(fun exn ->
+          if not (is_cancelled exn) then
+            Log.Http.error "[%s] connection handler error: %s"
+              listener_tag (Printexc.to_string exn))
+        (fun flow client_addr ->
           Eio.Switch.run (fun conn_sw ->
-            Eio.Switch.on_release conn_sw (fun () ->
-              try Eio.Flow.close flow with
-              | Eio.Cancel.Cancelled _ as e -> raise e
-              | exn ->
-                Log.Misc.error "[%s] flow close failed: %s"
-                  listener_tag (Printexc.to_string exn)
-            );
+            disable_nagle flow;
             try
               H2_eio.Server.create_connection_handler
                 ~sw:conn_sw
@@ -333,24 +328,16 @@ let run ~sw ~net ~clock config request_handler =
               Log.Http.error "[%s] connection error: %s"
                 listener_tag (Printexc.to_string exn)
           )
-        )
-      with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-        if is_cancelled exn then raise exn;
-        let delay = !backoff_s in
-        Log.Http.error "[%s] accept error: %s (backoff %.2fs)"
-          listener_tag (Printexc.to_string exn) delay;
-        Eio.Time.sleep clock delay;
-        bump_backoff ());
+        );
+      reset_backoff ();
       accept_loop ()
     with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-      if is_cancelled exn then ()
-      else begin
-        let delay = !backoff_s in
-        Log.Http.error "[%s] accept loop error: %s (backoff %.2fs)"
-          listener_tag (Printexc.to_string exn) delay;
-        Eio.Time.sleep clock delay;
-        bump_backoff ();
-        accept_loop ()
-      end
+      if is_cancelled exn then raise exn;
+      let delay = !backoff_s in
+      Log.Http.error "[%s] accept error: %s (backoff %.2fs)"
+        listener_tag (Printexc.to_string exn) delay;
+      Eio.Time.sleep clock delay;
+      bump_backoff ();
+      accept_loop ()
   in
   accept_loop ()

--- a/lib/http_server_h2.mli
+++ b/lib/http_server_h2.mli
@@ -287,9 +287,11 @@ val run :
 (** [run ~sw ~net ~clock config request_handler] binds to
     [config.host:config.port] with [Eio.Net.listen
     ~backlog:config.max_connections], then accepts in a loop.
-    Each accepted connection is handled in a forked fiber under
-    its own switch; flow close is registered via
-    [Eio.Switch.on_release].
+    Each accepted connection is handled in a new fiber via
+    [Eio.Net.accept_fork], which closes the flow when the handler
+    returns; the per-connection handler runs under its own switch
+    so internal H2 reader/writer fibers are released with the
+    connection.
 
     Backoff: per-iteration accept errors trigger exponential
     backoff (50 ms initial, 1 s ceiling) via [Eio.Time.sleep

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -281,7 +281,8 @@ let buffer_event event_id event_str =
     let timestamp = Time_compat.now () in
     let next = (event_id, event_str, timestamp) :: lst in
     let trimmed =
-      if List.length next > max_buffer_size then take max_buffer_size next
+      if List.compare_length_with next max_buffer_size > 0 then
+        take max_buffer_size next
       else next
     in
     { next_state = trimmed; result = () })

--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -5,7 +5,7 @@
     Architecture:
     - Stateless by default (no session required for simple request/response)
     - Optional session for: SSE streaming, server-initiated messages
-    - Thread-safe session storage using Mutex
+    - Lock-free session storage using atomic CAS
 *)
 
 type transport = Streamable_HTTP
@@ -28,10 +28,11 @@ type request_handler =
 
 module StringMap = Set_util.StringMap
 
-(** Session storage with mutex protection *)
+(** Session storage using lock-free atomic updates.
+    A single [Atomic.t] holds the immutable session map so reads never block
+    and writers retry via CAS instead of taking a mutex. *)
 module Session = struct
-  let sessions : session StringMap.t ref = ref StringMap.empty
-  let mutex = Eio.Mutex.create ()
+  let sessions : session StringMap.t Atomic.t = Atomic.make StringMap.empty
 
   let generate_id () =
     let hex = Random_id.hex ~bytes:16 in
@@ -43,46 +44,47 @@ module Session = struct
       (String.sub hex 16 4)
       (String.sub hex 20 12)
 
-  let with_lock f =
-    Eio.Mutex.use_rw ~protect:true mutex (fun () -> f ())
-
   let create ~transport =
-    with_lock (fun () ->
-      let session = {
-        id = generate_id ();
-        created_at = Time_compat.now ();
-        last_seen = Atomic.make (Time_compat.now ());
-        transport;
-        subscriptions = [];
-      } in
-      sessions := StringMap.add session.id session !sessions;
-      session)
+    let now = Time_compat.now () in
+    let session = {
+      id = generate_id ();
+      created_at = now;
+      last_seen = Atomic.make now;
+      transport;
+      subscriptions = [];
+    } in
+    Lockfree_atomic.update sessions (StringMap.add session.id session);
+    session
 
   let find id =
-    with_lock (fun () -> StringMap.find_opt id !sessions)
+    StringMap.find_opt id (Atomic.get sessions)
 
   let touch session =
     Atomic.set session.last_seen (Time_compat.now ())
 
   let remove id =
-    with_lock (fun () -> sessions := StringMap.remove id !sessions)
+    Lockfree_atomic.update sessions (StringMap.remove id)
 
   let list_all () =
-    with_lock (fun () ->
-      !sessions
-      |> StringMap.bindings
-      |> List.map (fun (_, v) -> v)
-    )
+    Atomic.get sessions
+    |> StringMap.bindings
+    |> List.map (fun (_, v) -> v)
 
   let cleanup ~ttl_seconds =
     let now = Time_compat.now () in
     let cutoff = now -. ttl_seconds in
-    with_lock (fun () ->
-      let to_remove = StringMap.fold (fun id session acc ->
-        if Atomic.get session.last_seen < cutoff then id :: acc else acc
-      ) !sessions [] in
-      List.iter (fun id -> sessions := StringMap.remove id !sessions) to_remove;
-      List.length to_remove)
+    Lockfree_atomic.update_with_commit sessions (fun map ->
+      let expired = ref [] in
+      let next =
+        StringMap.fold
+          (fun id session acc ->
+             if Atomic.get session.last_seen < cutoff then begin
+               expired := id :: !expired;
+               StringMap.remove id acc
+             end else acc)
+          map map
+      in
+      { next_state = next; result = List.length !expired })
 end
 
 (** JSON-RPC low-level helpers (raw Yojson, pre-parse validation). *)
@@ -114,12 +116,13 @@ let jsonrpc_extract_id = function
 
 let jsonrpc_dispatch_request (handler : request_handler) request =
   try
-    handler request
+    (handler request, false)
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    jsonrpc_error_response
-      ~id:(jsonrpc_extract_id request)
-      ~code:Mcp_error_code.Internal_error
-      ~message:(Log.Server.error "streamable_http dispatch: %s" (Printexc.to_string exn); "Internal error")
+    (jsonrpc_error_response
+       ~id:(jsonrpc_extract_id request)
+       ~code:Mcp_error_code.Internal_error
+       ~message:(Log.Server.error "streamable_http dispatch: %s" (Printexc.to_string exn); "Internal error"),
+     true)
 
 (** Handle POST /mcp - JSON-RPC request processing *)
 let handle_post ?session_id ~body ?request_handler () =
@@ -151,21 +154,23 @@ let handle_post ?session_id ~body ?request_handler () =
         None )
 
   | Ok json ->
-      (* Find or create session if session_id provided *)
+      (* Find session if session_id provided. Do not touch it yet: a malformed
+         or crashing request should not refresh the activity window. *)
       let session = match session_id with
         | Some id -> Session.find id
         | None -> None
       in
-
-      (* Touch session if found *)
-      Option.iter Session.touch session;
 
       (* Streamable HTTP transport no longer accepts JSON-RPC batches. *)
       if jsonrpc_is_batch json then
         (Error_response (400, "JSON-RPC batch requests are not supported"), session)
       else if jsonrpc_is_valid_request json then
         (* Single request - delegate to MCP handler *)
-        let response = jsonrpc_dispatch_request request_handler json in
+        let response, handler_raised = jsonrpc_dispatch_request request_handler json in
+        (* Only refresh last_seen when the handler returned normally. A handler
+           exception produces an internal-error response but must not keep the
+           session alive. *)
+        if not handler_raised then Option.iter Session.touch session;
         (Json_response response, session)
       else
         (Error_response (400, "Invalid JSON-RPC request"), session)

--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -115,14 +115,12 @@ let jsonrpc_extract_id = function
   | _ -> `Null
 
 let jsonrpc_dispatch_request (handler : request_handler) request =
-  try
-    (handler request, false)
+  try handler request
   with Eio.Cancel.Cancelled _ as e -> raise e | exn ->
-    (jsonrpc_error_response
+    jsonrpc_error_response
        ~id:(jsonrpc_extract_id request)
        ~code:Mcp_error_code.Internal_error
-       ~message:(Log.Server.error "streamable_http dispatch: %s" (Printexc.to_string exn); "Internal error"),
-     true)
+       ~message:(Log.Server.error "streamable_http dispatch: %s" (Printexc.to_string exn); "Internal error")
 
 (** Handle POST /mcp - JSON-RPC request processing *)
 let handle_post ?session_id ~body ?request_handler () =
@@ -154,23 +152,22 @@ let handle_post ?session_id ~body ?request_handler () =
         None )
 
   | Ok json ->
-      (* Find session if session_id provided. Do not touch it yet: a malformed
-         or crashing request should not refresh the activity window. *)
+      (* A syntactically valid request body on an existing streamable session
+         proves client activity even if JSON-RPC validation or handler dispatch
+         later returns an error response. Malformed JSON does not reach here and
+         therefore does not refresh the activity window. *)
       let session = match session_id with
         | Some id -> Session.find id
         | None -> None
       in
+      Option.iter Session.touch session;
 
       (* Streamable HTTP transport no longer accepts JSON-RPC batches. *)
       if jsonrpc_is_batch json then
         (Error_response (400, "JSON-RPC batch requests are not supported"), session)
       else if jsonrpc_is_valid_request json then
         (* Single request - delegate to MCP handler *)
-        let response, handler_raised = jsonrpc_dispatch_request request_handler json in
-        (* Only refresh last_seen when the handler returned normally. A handler
-           exception produces an internal-error response but must not keep the
-           session alive. *)
-        if not handler_raised then Option.iter Session.touch session;
+        let response = jsonrpc_dispatch_request request_handler json in
         (Json_response response, session)
       else
         (Error_response (400, "Invalid JSON-RPC request"), session)

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -110,6 +110,96 @@ let test_handle_post_handler_dispatch () =
   | _ ->
       Alcotest.fail "expected Json_response"
 
+let session_with_stale_seen () =
+  let session = SH.Session.create ~transport:SH.Streamable_HTTP in
+  let before = Atomic.get session.last_seen in
+  Time_compat.sleep 0.01;
+  (session, before)
+
+let check_session_touched label session before =
+  Alcotest.(check bool) label true (Atomic.get session.last_seen > before)
+
+let check_session_not_touched label session before =
+  Alcotest.(check bool) label true (Atomic.get session.last_seen = before)
+
+let test_handle_post_session_touch_success () =
+  let session, before = session_with_stale_seen () in
+  let handler _ =
+    `Assoc
+      [
+        ("jsonrpc", `String "2.0");
+        ("id", `Int 7);
+        ("result", `Assoc [("ok", `Bool true)]);
+      ]
+  in
+  let response, returned_session =
+    SH.handle_post ~session_id:session.id
+      ~body:{|{"jsonrpc":"2.0","method":"ping","id":7}|}
+      ~request_handler:handler
+      ()
+  in
+  (match response with
+   | SH.Json_response _ -> ()
+   | _ -> Alcotest.fail "expected Json_response");
+  Alcotest.(check bool) "session returned" true (Option.is_some returned_session);
+  check_session_touched "valid dispatch touches session" session before
+
+let test_handle_post_session_touch_handler_exception () =
+  let session, before = session_with_stale_seen () in
+  let handler _ = failwith "boom" in
+  let response, returned_session =
+    SH.handle_post ~session_id:session.id
+      ~body:{|{"jsonrpc":"2.0","method":"explode","id":8}|}
+      ~request_handler:handler
+      ()
+  in
+  (match response with
+   | SH.Json_response json ->
+       (match json with
+        | `Assoc fields ->
+            Alcotest.(check bool) "internal error returned" true
+              (List.mem_assoc "error" fields)
+        | _ -> Alcotest.fail "expected JSON-RPC error object")
+   | _ -> Alcotest.fail "expected Json_response");
+  Alcotest.(check bool) "session returned" true (Option.is_some returned_session);
+  check_session_touched "handler exception still touches session" session before
+
+let test_handle_post_session_touch_batch () =
+  let session, before = session_with_stale_seen () in
+  let response, returned_session =
+    SH.handle_post ~session_id:session.id
+      ~body:{|[{"jsonrpc":"2.0","method":"a","id":1}]|}
+      ()
+  in
+  (match response with
+   | SH.Error_response (400, _) -> ()
+   | _ -> Alcotest.fail "expected batch 400");
+  Alcotest.(check bool) "session returned" true (Option.is_some returned_session);
+  check_session_touched "valid JSON batch touches session" session before
+
+let test_handle_post_session_touch_invalid_request () =
+  let session, before = session_with_stale_seen () in
+  let response, returned_session =
+    SH.handle_post ~session_id:session.id ~body:{|{"jsonrpc":"2.0","id":9}|} ()
+  in
+  (match response with
+   | SH.Error_response (400, _) -> ()
+   | _ -> Alcotest.fail "expected invalid request 400");
+  Alcotest.(check bool) "session returned" true (Option.is_some returned_session);
+  check_session_touched "valid JSON invalid request touches session" session before
+
+let test_handle_post_session_touch_malformed_json () =
+  let session, before = session_with_stale_seen () in
+  let response, returned_session =
+    SH.handle_post ~session_id:session.id ~body:"not valid json" ()
+  in
+  (match response with
+   | SH.Error_response (400, _) -> ()
+   | _ -> Alcotest.fail "expected malformed JSON 400");
+  Alcotest.(check bool) "session not returned before parse" true
+    (Option.is_none returned_session);
+  check_session_not_touched "malformed JSON does not touch session" session before
+
 let test_handle_get () =
   match SH.handle_get () with
   | Ok session ->
@@ -143,6 +233,16 @@ let () =
       Alcotest.test_case "invalid json" `Quick test_handle_post_invalid_json;
       Alcotest.test_case "batch" `Quick test_handle_post_batch;
       Alcotest.test_case "handler dispatch" `Quick test_handle_post_handler_dispatch;
+      Alcotest.test_case "session touch success" `Quick
+        test_handle_post_session_touch_success;
+      Alcotest.test_case "session touch handler exception" `Quick
+        test_handle_post_session_touch_handler_exception;
+      Alcotest.test_case "session touch batch" `Quick
+        test_handle_post_session_touch_batch;
+      Alcotest.test_case "session touch invalid request" `Quick
+        test_handle_post_session_touch_invalid_request;
+      Alcotest.test_case "session touch malformed json" `Quick
+        test_handle_post_session_touch_malformed_json;
     ];
     "Handle GET", [
       Alcotest.test_case "create session" `Quick test_handle_get;


### PR DESCRIPTION
## Summary
- keep streamable HTTP session `last_seen` refreshed for any syntactically valid session-bound POST body, including handler exceptions converted to JSON-RPC internal errors
- keep malformed JSON as the boundary that does not refresh session activity
- preserve the H2 connection-handler call-shape fixes already on this branch
- add `handle_post ~session_id` coverage for successful dispatch, handler exception, batch rejection, invalid JSON-RPC request, and malformed JSON

## Verification
- ocamlc -stop-after parsing lib/streamable_http.ml test/test_streamable_http.ml
- ocamlformat --check lib/streamable_http.ml test/test_streamable_http.ml
- git diff --check
- rg -n '<<<<<<<|=======|>>>>>>>' lib/streamable_http.ml test/test_streamable_http.ml (no matches)
- rg -n 'handler_raised|Only refresh last_seen|must not keep the session alive|crashing request should not refresh|when JSON-RPC handler raises' lib/streamable_http.ml test/test_streamable_http.ml (no matches)

No local Dune build/test per operator instruction; CI remains the build authority.