### PR TITLE
fix(dashboard): reconnect on failed notification and restore worker parse offload

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -85,16 +85,23 @@ class MockWebSocket {
 
 class MockParseWorker {
   static holdResponses = false
+  static instances: MockParseWorker[] = []
 
   onmessage: ((event: MessageEvent) => void) | null = null
   onerror: ((event: ErrorEvent) => void) | null = null
   onmessageerror: ((event: MessageEvent) => void) | null = null
   terminated = false
+  heldMessages: Array<{ id: number; data: string }> = []
 
-  constructor(readonly url: URL) {}
+  constructor(readonly url: URL) {
+    MockParseWorker.instances.push(this)
+  }
 
   postMessage(message: { id: number; data: string }): void {
-    if (MockParseWorker.holdResponses) return
+    if (MockParseWorker.holdResponses) {
+      this.heldMessages.push(message)
+      return
+    }
     this.onmessage?.({
       data: {
         id: message.id,
@@ -103,8 +110,25 @@ class MockParseWorker {
     } as MessageEvent)
   }
 
+  releaseHeldResponses(): void {
+    const messages = this.heldMessages.splice(0)
+    for (const message of messages) {
+      this.onmessage?.({
+        data: {
+          id: message.id,
+          payloads: [JSON.parse(message.data) as unknown],
+        },
+      } as MessageEvent)
+    }
+  }
+
   terminate(): void {
     this.terminated = true
+  }
+
+  static reset(): void {
+    MockParseWorker.holdResponses = false
+    MockParseWorker.instances = []
   }
 }
 
@@ -188,7 +212,7 @@ beforeEach(() => {
 
 afterEach(() => {
   disconnectDashboardWS()
-  MockParseWorker.holdResponses = false
+  MockParseWorker.reset()
   clearDashboardWsDiscoveryCacheForTests()
   dashboardWsConnected.value = false
   dashboardWsLastError.value = null
@@ -1072,6 +1096,49 @@ describe('dashboard websocket route subscriptions', () => {
       { agents: [] },
       undefined,
     )
+  })
+
+  it('drops held parse worker replies after socket teardown', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+    vi.stubGlobal('Worker', MockParseWorker)
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: subscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+    dashboardWsLastSeq.value = 0
+    sseStoreMocks.hydrateDashboardSlice.mockClear()
+
+    MockParseWorker.holdResponses = true
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: { seq: 43, slice: 'execution', payload: { agents: [] } },
+    })
+    expect(sseStoreMocks.hydrateDashboardSlice).not.toHaveBeenCalled()
+    const sentBeforeTeardown = socket.sent.length
+    const worker = MockParseWorker.instances[0]!
+
+    disconnectDashboardWS()
+    worker.releaseHeldResponses()
+    await vi.advanceTimersByTimeAsync(5_000)
+    flushPendingInbound()
+
+    expect(worker.terminated).toBe(true)
+    expect(dashboardWsLastSeq.value).toBe(0)
+    expect(sseStoreMocks.hydrateDashboardSlice).not.toHaveBeenCalled()
+    expect(socket.sent).toHaveLength(sentBeforeTeardown)
   })
 
   it('reconnects when sending a delta ack notification throws', async () => {

--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -83,6 +83,31 @@ class MockWebSocket {
   }
 }
 
+class MockParseWorker {
+  static holdResponses = false
+
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: ErrorEvent) => void) | null = null
+  onmessageerror: ((event: MessageEvent) => void) | null = null
+  terminated = false
+
+  constructor(readonly url: URL) {}
+
+  postMessage(message: { id: number; data: string }): void {
+    if (MockParseWorker.holdResponses) return
+    this.onmessage?.({
+      data: {
+        id: message.id,
+        payloads: [JSON.parse(message.data) as unknown],
+      },
+    } as MessageEvent)
+  }
+
+  terminate(): void {
+    this.terminated = true
+  }
+}
+
 function installWebSocketMocks(): void {
   mockSockets.length = 0
   vi.stubGlobal('WebSocket', MockWebSocket)
@@ -163,6 +188,7 @@ beforeEach(() => {
 
 afterEach(() => {
   disconnectDashboardWS()
+  MockParseWorker.holdResponses = false
   clearDashboardWsDiscoveryCacheForTests()
   dashboardWsConnected.value = false
   dashboardWsLastError.value = null
@@ -972,6 +998,120 @@ describe('dashboard websocket route subscriptions', () => {
       { agents: [] },
       undefined,
     )
+  })
+
+  it('offloads inbound frame parsing to a Web Worker when available', async () => {
+    installWebSocketMocks()
+    vi.stubGlobal('Worker', MockParseWorker)
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: subscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+    sseStoreMocks.hydrateDashboardSlice.mockClear()
+
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: { seq: 43, slice: 'execution', payload: { agents: [] } },
+    })
+
+    expect(dashboardWsLastSeq.value).toBe(43)
+    expect(sseStoreMocks.hydrateDashboardSlice).toHaveBeenCalledWith(
+      'execution',
+      { agents: [] },
+      undefined,
+    )
+  })
+
+  it('falls back to main-thread parsing when the parse worker stops responding', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+    vi.stubGlobal('Worker', MockParseWorker)
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: subscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+    sseStoreMocks.hydrateDashboardSlice.mockClear()
+
+    MockParseWorker.holdResponses = true
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: { seq: 43, slice: 'execution', payload: { agents: [] } },
+    })
+    expect(sseStoreMocks.hydrateDashboardSlice).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    flushPendingInbound()
+
+    expect(dashboardWsLastSeq.value).toBe(43)
+    expect(sseStoreMocks.hydrateDashboardSlice).toHaveBeenCalledWith(
+      'execution',
+      { agents: [] },
+      undefined,
+    )
+  })
+
+  it('reconnects when sending a delta ack notification throws', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+
+    await connectDashboardWS({ tab: 'overview', params: {} })
+    const socket = mockSockets[0]!
+    socket.open()
+    const hello = parseRpc(socket, 0)
+    socket.receive({ jsonrpc: '2.0', id: hello.id, result: {} })
+    await flushPromises()
+
+    const subscribe = parseRpc(socket, 1)
+    socket.receive({
+      jsonrpc: '2.0',
+      id: subscribe.id,
+      result: { snapshot: { seq: 1, slices: {} } },
+    })
+    await flushPromises()
+
+    socket.send = () => {
+      throw new Error('send exploded')
+    }
+
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: { seq: 44, slice: 'execution', payload: { agents: [] } },
+    })
+
+    expect(dashboardWsConnected.value).toBe(false)
+    expect(dashboardWsReady.value).toBe(false)
+    expect(dashboardWsLastError.value).toContain('send exploded')
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await flushPromises()
+
+    expect(mockSockets).toHaveLength(2)
+    expect(mockSockets[1]!.readyState).toBe(MockWebSocket.CONNECTING)
   })
 
   it('ignores stale subscribe snapshots that arrive after a newer route subscription', async () => {

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -35,6 +35,7 @@ type PendingRpc = {
 }
 type ParseWorkerJob = {
   data: string
+  generation: number
   timeout: ReturnType<typeof setTimeout>
 }
 type DashboardRouteState = Pick<RouteState, 'tab' | 'params'>
@@ -322,6 +323,7 @@ function fallbackParseWorkerJob(id: number): void {
   if (!job) return
   workerJobs.delete(id)
   clearTimeout(job.timeout)
+  if (job.generation !== connectGeneration || !socket) return
   pendingInbound.push(job.data)
   scheduleFlush()
 }
@@ -330,6 +332,15 @@ function fallbackAllParseWorkerJobs(): void {
   for (const id of Array.from(workerJobs.keys())) {
     fallbackParseWorkerJob(id)
   }
+  parseWorker?.terminate()
+  parseWorker = null
+}
+
+function cancelParseWorkerJobs(): void {
+  for (const job of workerJobs.values()) {
+    clearTimeout(job.timeout)
+  }
+  workerJobs.clear()
   parseWorker?.terminate()
   parseWorker = null
 }
@@ -350,6 +361,7 @@ function initParseWorker(): Worker | null {
       if (!job) return
       workerJobs.delete(id)
       clearTimeout(job.timeout)
+      if (job.generation !== connectGeneration || !socket) return
       deliverParsedPayloads(Array.isArray(payloads) ? payloads : [])
     }
     parseWorker.onerror = fallbackAllParseWorkerJobs
@@ -508,6 +520,7 @@ function closeSocket(): void {
     socket = null
   }
   clearPendingInbound()
+  cancelParseWorkerJobs()
   rejectPendingRpcs(new Error('dashboard websocket closed'))
 }
 
@@ -721,6 +734,7 @@ function handleMessage(data: unknown): void {
     const id = ++workerJobId
     workerJobs.set(id, {
       data,
+      generation: connectGeneration,
       timeout: setTimeout(() => {
         fallbackParseWorkerJob(id)
       }, DASHBOARD_WS_PARSE_TIMEOUT_MS),
@@ -925,6 +939,7 @@ export async function connectDashboardWS(routeState?: DashboardRouteState): Prom
     }
     lastSubscribeKey = ''
     socket = null
+    cancelParseWorkerJobs()
     rejectPendingRpcs(closeError)
     if (fatal) {
       shouldReconnect = false

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -33,6 +33,10 @@ type PendingRpc = {
   reject: (err: Error) => void
   timeout: ReturnType<typeof setTimeout>
 }
+type ParseWorkerJob = {
+  data: string
+  timeout: ReturnType<typeof setTimeout>
+}
 type DashboardRouteState = Pick<RouteState, 'tab' | 'params'>
 
 interface DashboardWsDiscovery {
@@ -55,6 +59,7 @@ interface DashboardWsDiscoveryResult {
 }
 
 const DASHBOARD_WS_DISCOVERY_CACHE_KEY = 'masc.dashboard.ws.discovery.v1'
+const DASHBOARD_WS_PARSE_TIMEOUT_MS = 5_000
 
 let socket: WebSocket | null = null
 let rpcId = 0
@@ -299,6 +304,62 @@ export function flushPendingInbound(): void {
   flushPending()
 }
 
+// Phase 2 (PR-4.5): Offload JSON/SSE parsing to a Web Worker so the
+// main thread never blocks on large payloads.
+let parseWorker: Worker | null = null
+let workerJobId = 0
+const workerJobs = new Map<number, ParseWorkerJob>()
+
+function deliverParsedPayloads(payloads: unknown[]): void {
+  for (const payload of payloads) {
+    pendingInbound.push(payload)
+  }
+  scheduleFlush()
+}
+
+function fallbackParseWorkerJob(id: number): void {
+  const job = workerJobs.get(id)
+  if (!job) return
+  workerJobs.delete(id)
+  clearTimeout(job.timeout)
+  pendingInbound.push(job.data)
+  scheduleFlush()
+}
+
+function fallbackAllParseWorkerJobs(): void {
+  for (const id of Array.from(workerJobs.keys())) {
+    fallbackParseWorkerJob(id)
+  }
+  parseWorker?.terminate()
+  parseWorker = null
+}
+
+function initParseWorker(): Worker | null {
+  if (parseWorker) return parseWorker
+  if (typeof Worker === 'undefined') return null
+  try {
+    parseWorker = new Worker(
+      new URL('./workers/dashboard-ws.worker.ts', import.meta.url),
+    )
+    parseWorker.onmessage = (event) => {
+      const { id, payloads } = event.data as {
+        id: number
+        payloads: unknown[]
+      }
+      const job = workerJobs.get(id)
+      if (!job) return
+      workerJobs.delete(id)
+      clearTimeout(job.timeout)
+      deliverParsedPayloads(Array.isArray(payloads) ? payloads : [])
+    }
+    parseWorker.onerror = fallbackAllParseWorkerJobs
+    parseWorker.onmessageerror = fallbackAllParseWorkerJobs
+    return parseWorker
+  } catch {
+    return null
+  }
+}
+
 function rememberRouteState(routeState: DashboardRouteState): DashboardRouteState {
   desiredRouteState = {
     tab: routeState.tab,
@@ -520,6 +581,10 @@ function sendNotification(method: string, params: JsonObject): void {
     // surface to the console so operators can see the drop pattern in
     // DevTools when investigating "server keeps re-sending stale deltas."
     console.warn('[dashboard-ws] sendNotification failed', { method, err })
+    // A thrown send on a socket whose readyState claimed OPEN signals a
+    // half-open connection. Treat it like any other transport failure and
+    // reconnect rather than letting subsequent deltas stack up un-acked.
+    reconnectAfterCurrentSocketFailure(currentSocket, err)
   }
 }
 
@@ -651,10 +716,23 @@ function processInboundMessage(data: string): void {
 
 function handleMessage(data: unknown): void {
   if (typeof data !== 'string') return
-  // Inbound frames are parsed inline on the main thread. The PR-4.5 worker
-  // parse-offload path was retired when its source module
-  // (workers/dashboard-ws.worker.ts) was removed in dead-store sweep #18352;
-  // the worker had been failing to load and falling back here ever since.
+  const worker = initParseWorker()
+  if (worker) {
+    const id = ++workerJobId
+    workerJobs.set(id, {
+      data,
+      timeout: setTimeout(() => {
+        fallbackParseWorkerJob(id)
+      }, DASHBOARD_WS_PARSE_TIMEOUT_MS),
+    })
+    try {
+      worker.postMessage({ id, data })
+    } catch {
+      fallbackParseWorkerJob(id)
+      parseWorker = null
+    }
+    return
+  }
   pendingInbound.push(data)
   scheduleFlush()
 }

--- a/dashboard/src/workers/dashboard-ws.worker.ts
+++ b/dashboard/src/workers/dashboard-ws.worker.ts
@@ -1,0 +1,7 @@
+import { parseIncomingPayloads } from '../dashboard-ws-parse'
+
+self.onmessage = (event: MessageEvent<{ id: number; data: string }>) => {
+  const { id, data } = event.data
+  const payloads = parseIncomingPayloads(data)
+  self.postMessage({ id, payloads })
+}


### PR DESCRIPTION
## Summary
- reconnect when dashboard delta ack notification send fails
- restore Web Worker parsing for inbound dashboard WS frames
- bind parse-worker jobs to the current connection generation and cancel/terminate outstanding worker jobs on socket teardown
- add a regression where a held worker reply is released after disconnect and must not hydrate dashboard state, advance `dashboardWsLastSeq`, or send a stale ack

## Verification
- pnpm exec vitest run --config vitest.config.ts src/dashboard-ws.test.ts --no-file-parallelism --maxWorkers=1 (44 passed)
- pnpm exec eslint src/dashboard-ws.ts src/dashboard-ws.test.ts
- pnpm exec tsc --noEmit --pretty false
- git diff --check
- rg -n '<<<<<<<|=======|>>>>>>>' dashboard/src/dashboard-ws.ts dashboard/src/dashboard-ws.test.ts (no matches)

No local Dune build/test per operator instruction; CI remains the build authority.