### PR TITLE
fix(board): enforce delete lock order

### DIFF
--- a/lib/board/board_core.ml
+++ b/lib/board/board_core.ml
@@ -825,45 +825,45 @@ let list_sub_boards store : sub_board list =
 ;;
 
 let delete_sub_board store ~sub_board_id : (unit, board_error) Result.t =
-  with_persist_lock store (fun () ->
-    let snapshot =
-      with_lock store (fun () ->
-        let resolved_opt =
-          match Hashtbl.find_opt store.sub_boards sub_board_id with
-          | Some sb -> Some (sub_board_id, sb.slug)
-          | None ->
-            (match Hashtbl.find_opt store.sub_boards_by_slug sub_board_id with
-             | None -> None
-             | Some id ->
-               (match Hashtbl.find_opt store.sub_boards id with
-                | Some sb -> Some (id, sb.slug)
-                | None -> None))
-        in
-        match resolved_opt with
-        | None ->
-          Error (Invalid_id (Printf.sprintf "Sub-board not found: %s" sub_board_id))
-        | Some (id, slug) ->
-          Hashtbl.remove store.sub_boards id;
-          Hashtbl.remove store.sub_boards_by_slug slug;
-          (* Orphan policy: clear hearth on posts that belonged to this sub-board *)
-          Hashtbl.iter
-            (fun _ (post : post) ->
-               match post.hearth with
-               | Some h when String.equal h slug ->
-                 let updated = { post with hearth = None } in
-                 Hashtbl.replace store.posts (Post_id.to_string post.id) updated;
-                 store.dirty_posts <- true;
-                 Hashtbl.replace store.dirty_post_ids (Post_id.to_string post.id) ()
-               | _ -> ())
-            store.posts;
-          invalidate_post_caches store;
-          Ok (sub_boards_jsonl_unlocked store))
+  let snapshot =
+    with_lock store (fun () ->
+    let resolved_opt =
+      match Hashtbl.find_opt store.sub_boards sub_board_id with
+      | Some sb -> Some (sub_board_id, sb.slug)
+      | None ->
+        (match Hashtbl.find_opt store.sub_boards_by_slug sub_board_id with
+         | None -> None
+         | Some id ->
+           (match Hashtbl.find_opt store.sub_boards id with
+            | Some sb -> Some (id, sb.slug)
+            | None -> None))
     in
-    match snapshot with
-    | Error _ as e -> e
-    | Ok content ->
-      save_sub_boards_jsonl content;
-      Ok ())
+    match resolved_opt with
+    | None ->
+      Error (Invalid_id (Printf.sprintf "Sub-board not found: %s" sub_board_id))
+    | Some (id, slug) ->
+      Hashtbl.remove store.sub_boards id;
+      Hashtbl.remove store.sub_boards_by_slug slug;
+      (* Orphan policy: clear hearth on posts that belonged to this sub-board *)
+      Hashtbl.iter
+        (fun _ (post : post) ->
+           match post.hearth with
+           | Some h when String.equal h slug ->
+             let updated = { post with hearth = None } in
+             Hashtbl.replace store.posts (Post_id.to_string post.id) updated;
+             store.dirty_posts <- true;
+             Hashtbl.replace store.dirty_post_ids (Post_id.to_string post.id) ()
+           | _ -> ())
+        store.posts;
+      invalidate_post_caches store;
+      let content = sub_boards_jsonl_unlocked store in
+      Ok content)
+  in
+  match snapshot with
+  | Error _ as e -> e
+  | Ok content ->
+    with_persist_lock store (fun () -> save_sub_boards_jsonl content);
+    Ok ()
 ;;
 
 (** {1 Voting - Deduplicated} *)

--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -93,8 +93,9 @@ val record_comment_timestamp : author:string -> now:float -> unit
     every other reader / writer. *)
 val with_lock : store -> (unit -> 'a) -> 'a
 
-(** [with_persist_lock store f] serializes JSONL writes that must run
-    after the state mutation lock has been released. *)
+(** [with_persist_lock store f] serializes JSONL writes. Callers must not hold
+    [with_lock] while acquiring it; compute any state snapshot under
+    [with_lock], release it, then acquire [with_persist_lock]. *)
 val with_persist_lock : store -> (unit -> 'a) -> 'a
 
 (** Clears [karma_cache] and [sorted_posts_cache].  Called

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -114,7 +114,9 @@ let mark_dirty_comment store comment_id =
 
 let with_lock store f = Eio.Mutex.use_rw ~protect:true store.mutex (fun () -> f ())
 
-(** Serialize JSONL writes without holding the state mutex. *)
+(** Serialize JSONL writes. Callers must never hold the state mutex while
+    acquiring [persist_mutex]; compute snapshots under [with_lock], release it,
+    then call [with_persist_lock]. *)
 let with_persist_lock store f =
   let started = Time_compat.now () in
   Eio.Mutex.use_rw ~protect:true store.persist_mutex (fun () ->

--- a/lib/board/board_votes.ml
+++ b/lib/board/board_votes.ml
@@ -638,71 +638,82 @@ let delete_post store ~post_id : (unit, board_error) Result.t =
   match Post_id.of_string post_id with
   | Error e -> Error e
   | Ok pid ->
-      with_persist_lock store (fun () ->
-        let snapshot =
-          with_lock store (fun () ->
-            let post_key = Post_id.to_string pid in
-            match Hashtbl.find_opt store.posts post_key with
-            | None -> Error (Post_not_found post_id)
-            | Some _ ->
-                let comment_ids =
-                  Hashtbl.fold
-                    (fun key (c : comment) acc ->
-                      if String.equal (Post_id.to_string c.post_id) post_key then key :: acc else acc)
-                    store.comments []
-                in
-                Hashtbl.remove store.posts post_key;
-                Hashtbl.remove store.comments_by_post post_key;
-                List.iter (fun comment_key -> Hashtbl.remove store.comments comment_key) comment_ids;
-                let vote_keys =
-                  Hashtbl.fold
-                    (fun key _ acc ->
-                      if String.starts_with ~prefix:("post:" ^ post_key ^ ":") key
-                         || List.exists
-                              (fun comment_key ->
-                                String.starts_with ~prefix:("comment:" ^ comment_key ^ ":") key)
-                              comment_ids
-                      then key :: acc
-                      else acc)
-                    store.vote_log []
-                in
-                let reaction_keys =
-                  Hashtbl.fold
-                    (fun key (reaction : reaction) acc ->
-                      if
-                        ((=) reaction.target_type Reaction_post
-                         && String.equal reaction.target_id post_key)
-                        || ((=) reaction.target_type Reaction_comment
-                            && List.exists (String.equal reaction.target_id)
-                                 comment_ids)
-                      then key :: acc
-                      else acc)
-                    store.reactions []
-                in
-                List.iter (fun key -> Hashtbl.remove store.vote_log key) vote_keys;
-                List.iter (fun key -> Hashtbl.remove store.reactions key) reaction_keys;
-                store.post_count := max 0 (!(store.post_count) - 1);
-                invalidate_post_caches store;
-                invalidate_comment_caches store;
-                store.dirty_posts <- false;
-                store.dirty_comments <- false;
-                Hashtbl.clear store.dirty_post_ids;
-                Hashtbl.clear store.dirty_comment_ids;
-                store.last_flush <- Time_compat.now ();
-                Ok
-                  ( posts_jsonl_snapshot store
-                  , comments_jsonl_snapshot store
-                  , vote_log_jsonl store
-                  , reactions_jsonl_snapshot store ))
+    let snapshot =
+      with_lock store (fun () ->
+      let post_key = Post_id.to_string pid in
+      match Hashtbl.find_opt store.posts post_key with
+      | None -> Error (Post_not_found post_id)
+      | Some _ ->
+        let comment_ids =
+          Hashtbl.fold
+            (fun key (c : comment) acc ->
+               if String.equal (Post_id.to_string c.post_id) post_key then key :: acc else acc)
+            store.comments
+            []
         in
-        match snapshot with
-        | Error _ as e -> e
-        | Ok (posts_jsonl, comments_jsonl, votes_jsonl, reactions_jsonl) ->
-            save_jsonl_snapshot ~where:"rewrite_posts" ~path:(persist_path ()) posts_jsonl;
-            save_jsonl_snapshot ~where:"rewrite_comments" ~path:(comments_path ()) comments_jsonl;
-            save_vote_log_jsonl votes_jsonl;
-            save_jsonl_snapshot ~where:"rewrite_reactions" ~path:(reactions_path ()) reactions_jsonl;
-            Ok ())
+        Hashtbl.remove store.posts post_key;
+        Hashtbl.remove store.comments_by_post post_key;
+        List.iter (fun comment_key -> Hashtbl.remove store.comments comment_key) comment_ids;
+        let vote_keys =
+          Hashtbl.fold
+            (fun key _ acc ->
+               if
+                 String.starts_with ~prefix:("post:" ^ post_key ^ ":") key
+                 || List.exists
+                      (fun comment_key ->
+                         String.starts_with
+                           ~prefix:("comment:" ^ comment_key ^ ":")
+                           key)
+                      comment_ids
+               then key :: acc
+               else acc)
+            store.vote_log
+            []
+        in
+        let reaction_keys =
+          Hashtbl.fold
+            (fun key (reaction : reaction) acc ->
+               if
+                 ((=) reaction.target_type Reaction_post
+                  && String.equal reaction.target_id post_key)
+                 || ((=) reaction.target_type Reaction_comment
+                     && List.exists (String.equal reaction.target_id) comment_ids)
+               then key :: acc
+               else acc)
+            store.reactions
+            []
+        in
+        List.iter (fun key -> Hashtbl.remove store.vote_log key) vote_keys;
+        List.iter (fun key -> Hashtbl.remove store.reactions key) reaction_keys;
+        store.post_count := max 0 (!(store.post_count) - 1);
+        invalidate_post_caches store;
+        invalidate_comment_caches store;
+        store.dirty_posts <- false;
+        store.dirty_comments <- false;
+        Hashtbl.clear store.dirty_post_ids;
+        Hashtbl.clear store.dirty_comment_ids;
+        store.last_flush <- Time_compat.now ();
+        let posts_jsonl = posts_jsonl_snapshot store in
+        let comments_jsonl = comments_jsonl_snapshot store in
+        let votes_jsonl = vote_log_jsonl store in
+        let reactions_jsonl = reactions_jsonl_snapshot store in
+        Ok (posts_jsonl, comments_jsonl, votes_jsonl, reactions_jsonl))
+    in
+    (match snapshot with
+     | Error _ as e -> e
+     | Ok (posts_jsonl, comments_jsonl, votes_jsonl, reactions_jsonl) ->
+       with_persist_lock store (fun () ->
+         save_jsonl_snapshot ~where:"rewrite_posts" ~path:(persist_path ()) posts_jsonl;
+         save_jsonl_snapshot
+           ~where:"rewrite_comments"
+           ~path:(comments_path ())
+           comments_jsonl;
+         save_vote_log_jsonl votes_jsonl;
+         save_jsonl_snapshot
+           ~where:"rewrite_reactions"
+           ~path:(reactions_path ())
+           reactions_jsonl);
+       Ok ())
 
 (** {1 Global Store}
 
@@ -757,31 +768,29 @@ let reset_global_for_test () =
     flush-write path makes [board_posts.jsonl] a true snapshot file with
     one line per id and atomic rewrite semantics. *)
 let flush_dirty store =
-  let had_dirty, vote_log =
+  let posts_jsonl, comments_jsonl, vote_log =
     with_lock store (fun () ->
       let had_dirty = store.dirty_posts || store.dirty_comments in
+      let posts_jsonl = if had_dirty then Some (posts_jsonl_snapshot store) else None in
+      let comments_jsonl =
+        if had_dirty then Some (comments_jsonl_snapshot store) else None
+      in
+      let vote_log = if had_dirty then Some (vote_log_jsonl store) else None in
       Hashtbl.clear store.dirty_post_ids;
       Hashtbl.clear store.dirty_comment_ids;
       store.dirty_posts <- false;
       store.dirty_comments <- false;
       store.last_flush <- Time_compat.now ();
-      let vote_log =
-        if had_dirty then Some (vote_log_jsonl store) else None
-      in
-      (had_dirty, vote_log))
+      (posts_jsonl, comments_jsonl, vote_log))
   in
   with_persist_lock store (fun () ->
-      if had_dirty then begin
-        let posts_jsonl = with_lock store (fun () -> posts_jsonl_snapshot store) in
-        let comments_jsonl =
-          with_lock store (fun () -> comments_jsonl_snapshot store)
-        in
-        save_jsonl_snapshot ~where:"flush_posts"
-          ~path:(persist_path ()) posts_jsonl;
-        save_jsonl_snapshot ~where:"flush_comments"
-          ~path:(comments_path ()) comments_jsonl
-      end;
-      Option.iter save_vote_log_jsonl vote_log)
+    Option.iter
+      (save_jsonl_snapshot ~where:"flush_posts" ~path:(persist_path ()))
+      posts_jsonl;
+    Option.iter
+      (save_jsonl_snapshot ~where:"flush_comments" ~path:(comments_path ()))
+      comments_jsonl;
+    Option.iter save_vote_log_jsonl vote_log)
 
 
 (** {1 Karma & Flair - Reddit-style} *)

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -1260,7 +1260,16 @@ let test_sub_board_delete_clears_orphan_hearth () =
    | Error e -> Alcotest.fail (Board.show_board_error e)
    | Ok post ->
        Alcotest.(check (option string)) "post hearth cleared after sub-board delete"
-         None post.Board.hearth)
+         None post.Board.hearth);
+  Board_dispatch.flush ();
+  Board.reset_global_for_test ();
+  Board_dispatch.reset_for_test ();
+  Board_dispatch.init_jsonl ();
+  (match Board_dispatch.get_post ~post_id with
+   | Error e -> Alcotest.fail (Board.show_board_error e)
+   | Ok post ->
+       Alcotest.(check (option string)) "cleared hearth survives restart" None
+         post.Board.hearth)
 
 let test_sub_board_post_count_projection () =
   ignore

--- a/test/test_board_karma_ledger.ml
+++ b/test/test_board_karma_ledger.ml
@@ -269,6 +269,94 @@ let file_contains path needle =
         in
         loop ())
 
+let find_substring_from text needle start =
+  let needle_len = String.length needle in
+  let text_len = String.length text in
+  let rec loop i =
+    if needle_len = 0 then Some i
+    else if i + needle_len > text_len then None
+    else if String.sub text i needle_len = needle then Some i
+    else loop (i + 1)
+  in
+  loop start
+
+let source_slice ~rel ~start_marker ~end_marker =
+  let text = Masc_test_deps.read_file (Masc_test_deps.source_path rel) in
+  match find_substring_from text start_marker 0 with
+  | None -> Alcotest.failf "missing start marker %S in %s" start_marker rel
+  | Some start ->
+    (match find_substring_from text end_marker start with
+     | None -> Alcotest.failf "missing end marker %S in %s" end_marker rel
+     | Some stop -> String.sub text start (stop - start))
+
+let call_extent text ~call_marker ~from =
+  match find_substring_from text call_marker from with
+  | None -> None
+  | Some call_start ->
+    (match find_substring_from text "(" call_start with
+     | None -> None
+     | Some open_pos ->
+       let len = String.length text in
+       let rec scan i depth =
+         if i >= len
+         then len
+         else (
+           match text.[i] with
+           | '(' -> scan (i + 1) (depth + 1)
+           | ')' ->
+             let depth = depth - 1 in
+             if depth = 0 then i + 1 else scan (i + 1) depth
+           | _ -> scan (i + 1) depth)
+       in
+       Some (call_start, scan open_pos 0))
+
+let has_nested_call text ~outer ~inner =
+  let rec loop from =
+    match call_extent text ~call_marker:outer ~from with
+    | None -> false
+    | Some (start, stop) ->
+      let call_text = String.sub text start (stop - start) in
+      (match find_substring_from call_text inner (String.length outer) with
+       | Some _ -> true
+       | None -> loop (start + 1))
+  in
+  loop 0
+
+let assert_no_nested_call label text ~outer ~inner =
+  Alcotest.(check bool) label false (has_nested_call text ~outer ~inner)
+
+let test_delete_lock_order_source_pin () =
+  let delete_sub_board =
+    source_slice ~rel:"lib/board/board_core.ml"
+      ~start_marker:"let delete_sub_board"
+      ~end_marker:"(** {1 Voting"
+  in
+  let delete_post =
+    source_slice ~rel:"lib/board/board_votes.ml"
+      ~start_marker:"let delete_post"
+      ~end_marker:"(** {1 Global Store}"
+  in
+  let flush_dirty =
+    source_slice ~rel:"lib/board/board_votes.ml"
+      ~start_marker:"let flush_dirty"
+      ~end_marker:"(** {1 Karma"
+  in
+  let check label body =
+    assert_no_nested_call
+      (label ^ ": no persist lock inside state lock")
+      body
+      ~outer:"with_lock store"
+      ~inner:"with_persist_lock store";
+    assert_no_nested_call
+      (label ^ ": no state lock inside persist lock")
+      body
+      ~outer:"with_persist_lock store"
+      ~inner:"with_lock store"
+  in
+  check "delete_sub_board" delete_sub_board;
+  check "delete_post" delete_post;
+  check "flush_dirty" flush_dirty
+
 let test_delete_post_rewrites_persisted_snapshots () =
   let post = create_post_exn ~author:"alice" ~content:"delete me" in
   let pid = Board.Post_id.to_string post.id in
@@ -282,9 +370,16 @@ let test_delete_post_rewrites_persisted_snapshots () =
   in
   let cid = Board.Comment_id.to_string comment.id in
   vote_exn ~voter:"carol" ~post_id:pid ~direction:Board.Up;
+  vote_comment_exn ~voter:"erin" ~comment_id:cid ~direction:Board.Up;
   (match
      Board_dispatch.toggle_reaction ~target_type:Board.Reaction_post
        ~target_id:pid ~user_id:"dave" ~emoji:"👍"
+   with
+   | Ok _ -> ()
+   | Error e -> Alcotest.fail (Board.show_board_error e));
+  (match
+     Board_dispatch.toggle_reaction ~target_type:Board.Reaction_comment
+       ~target_id:cid ~user_id:"frank" ~emoji:"👍"
    with
    | Ok _ -> ()
    | Error e -> Alcotest.fail (Board.show_board_error e));
@@ -300,7 +395,32 @@ let test_delete_post_rewrites_persisted_snapshots () =
   check_absent "posts snapshot removes deleted post" (Board.persist_path ()) pid;
   check_absent "comments snapshot removes deleted comment" (Board.comments_path ()) cid;
   check_absent "vote snapshot removes deleted post vote" (Board_votes.vote_log_path ()) pid;
-  check_absent "reaction snapshot removes deleted post reaction" (Board.reactions_path ()) pid
+  check_absent
+    "vote snapshot removes deleted comment vote"
+    (Board_votes.vote_log_path ())
+    cid;
+  check_absent "reaction snapshot removes deleted post reaction" (Board.reactions_path ()) pid;
+  check_absent
+    "reaction snapshot removes deleted comment reaction"
+    (Board.reactions_path ())
+    cid;
+  let store =
+    match Board_dispatch.backend () with
+    | Board_dispatch.Jsonl store -> store
+  in
+  Alcotest.(check bool) "dirty posts cleared after delete" false store.dirty_posts;
+  Alcotest.(check bool)
+    "dirty comments cleared after delete"
+    false
+    store.dirty_comments;
+  Alcotest.(check int)
+    "dirty post ids cleared after delete"
+    0
+    (Hashtbl.length store.dirty_post_ids);
+  Alcotest.(check int)
+    "dirty comment ids cleared after delete"
+    0
+    (Hashtbl.length store.dirty_comment_ids)
 
 (** {1 JSON serialisation} *)
 
@@ -446,6 +566,8 @@ let () =
         (with_eio test_replay_invariant);
       Alcotest.test_case "delete post rewrites persisted snapshots" `Quick
         (with_eio test_delete_post_rewrites_persisted_snapshots);
+      Alcotest.test_case "delete paths never nest state and persist locks" `Quick
+        test_delete_lock_order_source_pin;
     ];
     "serialisation", [
       Alcotest.test_case "json fields" `Quick


### PR DESCRIPTION
## Summary
- change `delete_sub_board`, `delete_post`, and `flush_dirty` to compute state snapshots under `with_lock`, release the state mutex, then acquire `with_persist_lock` for JSONL writes
- clarify the persistence lock contract so callers do not hold both state and persist locks simultaneously
- add regression coverage for delete persistence cleanup, sub-board hearth persistence, and a source-level guard that the three critical paths do not nest state/persist locks in either direction

## Verification
- ocamlc -stop-after parsing lib/board/board_core.ml lib/board/board_core.mli lib/board/board_core_persist.ml lib/board/board_votes.ml test/test_board_karma_ledger.ml test/test_board_dispatch.ml
- ocamlformat --check lib/board/board_core.ml lib/board/board_core.mli lib/board/board_core_persist.ml lib/board/board_votes.ml test/test_board_karma_ledger.ml test/test_board_dispatch.ml
- git diff --check
- rg -n '<<<<<<<|=======|>>>>>>>' lib/board/board_core.ml lib/board/board_core.mli lib/board/board_core_persist.ml lib/board/board_votes.ml test/test_board_karma_ledger.ml test/test_board_dispatch.ml (no matches)
- python3 source scan: no nested state/persist locks in delete_sub_board/delete_post/flush_dirty

No local Dune build/test per operator instruction; CI remains the build authority.