### PR TITLE
fix(dashboard): simplify keeper workspace actions

### DIFF
--- a/dashboard/src/components/emergency-stop-control.test.ts
+++ b/dashboard/src/components/emergency-stop-control.test.ts
@@ -72,6 +72,7 @@ describe('EmergencyStopControl', () => {
 
     expect(container.textContent).toContain('Emergency Stop')
     expect(container.querySelector('[data-testid="emergency-stop-control"]')).toBeTruthy()
+    expect(container.querySelector('.emergency-stop-control')).toBeTruthy()
   })
 
   it('pauses the namespace after the confirmation is accepted', async () => {
@@ -115,6 +116,7 @@ describe('EmergencyStopControl', () => {
 
     expect(container.textContent).toContain('Paused')
     expect(container.textContent).toContain('Resume')
+    expect(container.querySelector('.emergency-stop-control')).toBeTruthy()
   })
 
   it('resumes the namespace when Resume is clicked', async () => {

--- a/dashboard/src/components/emergency-stop-control.ts
+++ b/dashboard/src/components/emergency-stop-control.ts
@@ -35,7 +35,7 @@ export function EmergencyStopControl() {
 
   if (state === 'paused') {
     return html`
-      <div class="v2-shell-panel flex items-center gap-1.5" data-testid="emergency-stop-control">
+      <div class="emergency-stop-control v2-shell-panel flex items-center gap-1.5" data-testid="emergency-stop-control">
         <${CountBadge} tone="warn">Paused<//>
         ${access.allowed ? html`
           <${ActionButton} variant="ghost" size="sm" disabled=${loading}
@@ -49,7 +49,7 @@ export function EmergencyStopControl() {
 
   if (state === 'running' && access.allowed) {
     return html`
-      <${ActionButton} variant="danger" size="sm" disabled=${loading}
+      <${ActionButton} variant="danger" size="sm" class="emergency-stop-control" disabled=${loading}
         testId="emergency-stop-control"
         onClick=${async () => {
           const confirmed = await requestConfirm({

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -92,6 +92,14 @@ describe('KeeperWorkspaceRail', () => {
     expect(state?.getAttribute('title')).toBe('offline')
   })
 
+  it('keeps the selected runtime card informational without a duplicate chat CTA', () => {
+    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} />`)
+
+    expect(container.querySelector('.kw-fleet-aside')).not.toBeNull()
+    expect(container.querySelector('.kw-fleet-chat')).toBeNull()
+    expect(container.textContent).not.toContain('대화 콘솔 열기')
+  })
+
   it('shows the model line as missing when no model was reported', () => {
     const k = mkKeeper({ runtime_canonical: 'runpod_gemma' })
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${k} />`)
@@ -105,11 +113,16 @@ describe('KeeperWorkspaceRail', () => {
 
   it('renders the context-window occupancy percent', () => {
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} />`)
-    // v2 renames the "컨텍스트 점유" header to "컨텍스트" with a "윈도우 사용량" usage label.
+    const meter = container.querySelector('.meter') as HTMLElement | null
+
     expect(container.textContent).toContain('컨텍스트')
-    expect(container.textContent).toContain('윈도우 사용량')
+    expect(container.textContent).not.toContain('윈도우 사용량')
     expect(container.textContent).toContain('62%')
     expect(container.textContent).toContain('124.0k')
+    expect(meter).not.toBeNull()
+    expect(meter?.getAttribute('role')).toBe('meter')
+    expect(meter?.getAttribute('aria-label')).toBe('컨텍스트 윈도우 사용률')
+    expect(meter?.getAttribute('aria-valuenow')).toBe('62')
   })
 
   it('lists only the keeper-owned tasks', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -116,7 +116,7 @@ describe('KeeperWorkspaceRail', () => {
     const meter = container.querySelector('.meter') as HTMLElement | null
 
     expect(container.textContent).toContain('컨텍스트')
-    expect(container.textContent).not.toContain('윈도우 사용량')
+    expect(container.textContent).toContain('윈도우 사용량')
     expect(container.textContent).toContain('62%')
     expect(container.textContent).toContain('124.0k')
     expect(meter).not.toBeNull()

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -12,8 +12,6 @@ import type { VNode } from 'preact'
 import { shellAuthSummary, tasks } from '../../store'
 import type { Keeper, Task } from '../../types'
 import { navigate } from '../../router'
-import { selectKeeper } from '../../keeper-runtime'
-import { keeperMobilePane } from '../keeper-detail-state'
 import { keeperActivityDisplay } from '../../lib/keeper-runtime-display'
 import { keeperActionVisibility } from '../../lib/keeper-predicates'
 import {
@@ -179,11 +177,6 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
   const lifecycle = keeper.phase || keeper.lifecycle_phase || keeper.status
   const actions = fleetLifecycleActions(keeper).filter(action => action !== 'shutdown').slice(0, 3)
   const [pendingAction, setPendingAction] = useState<KeeperActionKey | null>(null)
-  const openChat = () => {
-    selectKeeper(keeper.name)
-    keeperMobilePane.value = 'chat'
-    navigate('monitoring', { section: 'agents', keeper: keeper.name })
-  }
 
   return html`
     <div class="kw-fleet-aside" data-tone=${tone}>
@@ -196,7 +189,6 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
         </div>
         <span class="kw-fleet-aside-state" title=${keeper.status}>${phase}</span>
       </div>
-      <button type="button" class="kw-fleet-chat" onClick=${openChat}>대화 콘솔 열기</button>
       <div class="kw-fleet-phase" title=${activity.source !== 'none' ? activity.label : phase}>
         <b>${phase}</b>
         <span>${activity.source !== 'none' ? activity.label : '최근 활동 미수신'}</span>
@@ -278,10 +270,10 @@ function RuntimeSection({ keeper }: { keeper: Keeper }): VNode {
                 </span>
               </div>
             `
-          : html`<div class="rtc-na" data-stub="runtime-capabilities">capabilities — n/a</div>`}
+          : html`<div class="rtc-na" data-missing="runtime-capabilities">능력 정보 미수신</div>`}
         <div class="rtc-effort">
           <span class="rtc-effort-k">effort</span>
-          <span class="rtc-eff-na" data-stub="runtime-effort">조정 불가 · 미수집</span>
+          <span class="rtc-eff-na" data-missing="runtime-effort">조정 정보 미수신</span>
         </div>
       </div>
     </div>
@@ -431,9 +423,8 @@ function ContextSection({
   }
 
   const usageHeader = html`
-    <div style=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
-      <span style=${{ fontSize: '12px', color: 'var(--text-mid)' }}>윈도우 사용량</span>
-      <span class="mono" style=${{ fontSize: '14px', color: hot ? 'var(--status-bad)' : 'var(--volt-strong)' }}>${pct ?? 0}%</span>
+    <div class="ctx-meter-head" aria-label=${`윈도우 사용률 ${pct ?? 0}%`}>
+      <span class=${`ctx-meter-pct mono${hot ? ' hot' : ''}`}>${pct ?? 0}%</span>
     </div>
   `
 
@@ -445,13 +436,20 @@ function ContextSection({
           ? html`
               ${usageHeader}
               <div class="meter-wrap">
-                <div class=${`meter${hot ? ' hot' : ''}`}><span style=${{ width: `${pct ?? 0}%` }}></span></div>
+                <div
+                  class=${`meter${hot ? ' hot' : ''}`}
+                  role="meter"
+                  aria-label="컨텍스트 윈도우 사용률"
+                  aria-valuenow=${pct ?? 0}
+                  aria-valuemin="0"
+                  aria-valuemax="100"
+                ><span style=${{ width: `${pct ?? 0}%` }}></span></div>
                 <span class=${`meter-mark${hot ? ' hot' : ''}`} style=${{ left: `${compactAt}%` }}>
                   <i class="meter-mark-lbl">compact ${compactAt}%</i>
                 </span>
               </div>
             `
-          : html`<div class="ctx-empty" data-stub="context-window"><strong>윈도우 사용률 미수신</strong><span>런타임이 전체 윈도우 총량을 아직 보내지 않았습니다.</span></div>`}
+          : html`<div class="ctx-empty" data-missing="context-window"><strong>윈도우 사용률 미수신</strong><span>런타임이 전체 윈도우 총량을 아직 보내지 않았습니다.</span></div>`}
         <div class="ctx-tok">
           <span class="mono">${tokens ?? '—'}</span>
           <span class="ctx-tok-sep">/</span>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -423,7 +423,8 @@ function ContextSection({
   }
 
   const usageHeader = html`
-    <div class="ctx-meter-head" aria-label=${`윈도우 사용률 ${pct ?? 0}%`}>
+    <div class="ctx-meter-head">
+      <span class="ctx-meter-label">윈도우 사용량</span>
       <span class=${`ctx-meter-pct mono${hot ? ' hot' : ''}`}>${pct ?? 0}%</span>
     </div>
   `

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -78,12 +78,13 @@ describe('KeeperWorkspaceRoster', () => {
     expect(active?.textContent).toContain('masc-improver')
   })
 
-  it('exposes selectable rows with a descriptive accessible label', () => {
+  it('uses visible row content for the selectable row name', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     const active = host.querySelector('.kw-kp-row[aria-current="true"]') as HTMLElement
 
-    expect(active?.getAttribute('aria-label')).toContain('masc-improver 선택')
-    expect(active?.getAttribute('aria-label')).toContain('실행 중')
+    expect(active?.getAttribute('aria-label')).toBeNull()
+    expect(active?.textContent).toContain('masc-improver')
+    expect(active?.textContent).toContain('실행 중')
   })
 
   it('keeps row actions behind one explicit command menu target', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -78,6 +78,22 @@ describe('KeeperWorkspaceRoster', () => {
     expect(active?.textContent).toContain('masc-improver')
   })
 
+  it('exposes selectable rows with a descriptive accessible label', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+    const active = host.querySelector('.kw-kp-row[aria-current="true"]') as HTMLElement
+
+    expect(active?.getAttribute('aria-label')).toContain('masc-improver 선택')
+    expect(active?.getAttribute('aria-label')).toContain('실행 중')
+  })
+
+  it('keeps row actions behind one explicit command menu target', () => {
+    render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
+
+    expect(host.querySelector('.kw-kp-chat')).toBeNull()
+    expect(host.querySelector('.kw-kp-inline-actions')).toBeNull()
+    expect(host.querySelectorAll('.kw-kp-more').length).toBe(host.querySelectorAll('.kw-kp-row').length)
+  })
+
   it('shows filter chip counts (all / running / attention)', () => {
     render(html`<${KeeperWorkspaceRoster} activeName="masc-improver" />`, host)
     const chips = Array.from(host.querySelectorAll('.kw-rfilter')).map(c => c.textContent)

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -262,8 +262,10 @@ function RosterRow({
   const activity = keeperActivityDisplay(keeper, undefined, { includeCreated: false })
   const activityText = rosterActivityText(activity)
   const recentTool = keeperRecentTool(keeper)
-  const inlineActions = lifecycleActions(keeper).filter(action => action !== 'shutdown').slice(0, 2)
-  const [pendingAction, setPendingAction] = useState<KeeperActionKey | null>(null)
+  const phaseLabel = keeperPhaseLabel(keeper)
+  const contextLabel = contextPct === null ? '' : ` · context ${contextPct}%`
+  const attentionLabel = att > 0 ? ` · 주의 ${att}` : ''
+  const rowLabel = `${keeper.name} 선택 · ${phaseLabel}${contextLabel}${attentionLabel}`
   const select = () => onSelect(keeper.name)
   return html`
     <div
@@ -273,6 +275,7 @@ function RosterRow({
       data-tone=${tone}
       style=${style}
       aria-current=${active ? 'true' : 'false'}
+      aria-label=${rowLabel}
       onClick=${select}
       onContextMenu=${(event: MouseEvent) => onMenu(keeper, event)}
       onKeyDown=${(event: KeyboardEvent) => {
@@ -285,7 +288,7 @@ function RosterRow({
       <div class="kw-kp-meta">
         <div class="kw-kp-name">${keeper.koreanName ?? keeper.name}</div>
         <div class="kw-kp-sub">
-          <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${bucket === 'running'} />${keeperPhaseLabel(keeper)}</span>
+          <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${bucket === 'running'} />${phaseLabel}</span>
           ${handle ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle kp-handle" title=${handleTitle}>${handle}</span>` : null}
         </div>
         ${contextPct !== null
@@ -315,53 +318,9 @@ function RosterRow({
       </div>
       <button
         type="button"
-        class="kw-kp-chat v2-monitoring-action"
-        aria-label=${`${keeper.name} 대화 열기`}
-        title="대화 열기"
-        onClick=${(event: MouseEvent) => {
-          event.preventDefault()
-          event.stopPropagation()
-          select()
-        }}
-      >
-        <${MessageSquare} size=${14} aria-hidden="true" />
-      </button>
-      ${inlineActions.length > 0
-        ? html`
-            <div class="kw-kp-inline-actions">
-              ${inlineActions.map(action => {
-                const copy = LIFECYCLE_COPY[action]
-                const Icon = copy.icon
-                return html`
-                  <button
-                    key=${action}
-                    type="button"
-                    class=${`kw-kp-inline-action v2-monitoring-action${pendingAction === action ? ' busy' : ''}`}
-                    title=${copy.title}
-                    aria-label=${`${keeper.name} ${copy.label}`}
-                    aria-busy=${pendingAction === action ? 'true' : 'false'}
-                    disabled=${pendingAction !== null}
-                    onClick=${(event: MouseEvent) => {
-                      event.preventDefault()
-                      event.stopPropagation()
-                      if (pendingAction !== null) return
-                      setPendingAction(action)
-                      void runRosterKeeperAction(keeper.name, action).finally(() => setPendingAction(null))
-                    }}
-                  >
-                    <${Icon} size=${13} aria-hidden="true" />
-                    <span>${pendingAction === action ? '실행중' : copy.label}</span>
-                  </button>
-                `
-              })}
-            </div>
-          `
-        : null}
-      <button
-        type="button"
         class="kw-kp-more v2-monitoring-action"
-        aria-label=${`${keeper.name} 명령`}
-        title="keeper 명령"
+        aria-label=${`${keeper.name} 명령 메뉴`}
+        title="keeper 명령 메뉴"
         onClick=${(event: MouseEvent) => onMenu(keeper, event)}
         data-testid=${`kw-roster-menu-${keeper.name}`}
       >

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -263,9 +263,6 @@ function RosterRow({
   const activityText = rosterActivityText(activity)
   const recentTool = keeperRecentTool(keeper)
   const phaseLabel = keeperPhaseLabel(keeper)
-  const contextLabel = contextPct === null ? '' : ` · context ${contextPct}%`
-  const attentionLabel = att > 0 ? ` · 주의 ${att}` : ''
-  const rowLabel = `${keeper.name} 선택 · ${phaseLabel}${contextLabel}${attentionLabel}`
   const select = () => onSelect(keeper.name)
   return html`
     <div
@@ -275,7 +272,6 @@ function RosterRow({
       data-tone=${tone}
       style=${style}
       aria-current=${active ? 'true' : 'false'}
-      aria-label=${rowLabel}
       onClick=${select}
       onContextMenu=${(event: MouseEvent) => onMenu(keeper, event)}
       onKeyDown=${(event: KeyboardEvent) => {

--- a/dashboard/src/styles/keeper-v2/ops-cluster.css
+++ b/dashboard/src/styles/keeper-v2/ops-cluster.css
@@ -53,7 +53,7 @@
   white-space: nowrap;
 }
 
-.v2-top-ops > [data-testid="emergency-stop-control"] {
+.v2-top-ops > .emergency-stop-control {
   display: inline-flex;
   flex: none;
   align-items: center;
@@ -64,7 +64,7 @@
   white-space: nowrap;
 }
 
-.v2-top-ops > [data-testid="emergency-stop-control"] > span {
+.v2-top-ops > .emergency-stop-control > span {
   flex-wrap: nowrap;
   white-space: nowrap;
 }

--- a/dashboard/src/styles/keeper-v2/ops-cluster.css
+++ b/dashboard/src/styles/keeper-v2/ops-cluster.css
@@ -53,6 +53,22 @@
   white-space: nowrap;
 }
 
+.v2-top-ops > [data-testid="emergency-stop-control"] {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  max-height: 30px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.v2-top-ops > [data-testid="emergency-stop-control"] > span {
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
 /* The re-mounted operational cluster is wider than the prototype mobile shell.
    Keep phone/tablet topbars to the prototype-owned status chips so the page does
    not start with off-canvas actions before the primary surface content. */

--- a/dashboard/src/styles/keeper-workspace-mobile.test.ts
+++ b/dashboard/src/styles/keeper-workspace-mobile.test.ts
@@ -94,6 +94,7 @@ function mediaRuleDeclsIn(source: string, selector: string, maxWidth: string): R
 const mediaRuleDecls = (selector: string, maxWidth: string) => mediaRuleDeclsIn(css, selector, maxWidth)
 const mobileRuleDecls = (selector: string) => mediaRuleDecls(selector, KEEPER_MOBILE_PANE_BREAKPOINT)
 const copilotRuleDecls = (selector: string, maxWidth: string) => mediaRuleDeclsIn(copilotCss, selector, maxWidth)
+const opsClusterBaseRuleDecls = (selector: string) => baseRuleDeclsIn(opsClusterCss, selector)
 const opsClusterRuleDecls = (selector: string, maxWidth: string) => mediaRuleDeclsIn(opsClusterCss, selector, maxWidth)
 const keeperV2CraftMobileRuleDecls = (selector: string) =>
   mediaRuleDeclsIn(keeperV2CraftCss, selector, KEEPER_MOBILE_PANE_BREAKPOINT)
@@ -170,6 +171,13 @@ describe('keeper workspace v2 (26) mobile contract', () => {
   })
 
   it('keeps remounted operational topbar chrome out of mobile and keeper tablet edges', () => {
+    expect(opsClusterBaseRuleDecls('.v2-top-ops > [data-testid="emergency-stop-control"]')['white-space'])
+      .toBe('nowrap')
+    expect(opsClusterBaseRuleDecls('.v2-top-ops > [data-testid="emergency-stop-control"]')['min-height'])
+      .toBe('28px')
+    expect(opsClusterBaseRuleDecls('.v2-top-ops > [data-testid="emergency-stop-control"] > span')['white-space'])
+      .toBe('nowrap')
+
     expect(opsClusterRuleDecls('.v2-app[data-mobile="1"] .v2-top-ops', SHELL_MOBILE_CHROME_BREAKPOINT).display)
       .toBe('none')
     expect(
@@ -416,6 +424,10 @@ describe('keeper workspace v2 (26) mobile contract', () => {
     expect(keeperWorkspaceRosterSource).toContain('keeper.latest_tool_call_count')
     expect(keeperWorkspaceRosterSource).toContain('class="kw-kp-context"')
     expect(keeperWorkspaceRosterSource).toContain('class="kw-kp-tool"')
+    expect(keeperWorkspaceRosterSource).not.toContain('class="kw-kp-chat')
+    expect(keeperWorkspaceRosterSource).not.toContain('class="kw-kp-inline-actions')
+    expect(keeperWorkspaceRailSource).not.toContain('kw-fleet-chat')
+    expect(keeperWorkspaceRailSource).not.toContain('data-stub')
     expect(keeperWorkspaceRosterSource).toContain('const ROSTER_ROW_ESTIMATED_HEIGHT = 92')
     expect(keeperWorkspaceRosterSource).toContain('estimatedItemHeight=${ROSTER_ROW_ESTIMATED_HEIGHT}')
     expect(css).toContain('.kw-kp-row::before')

--- a/dashboard/src/styles/keeper-workspace-mobile.test.ts
+++ b/dashboard/src/styles/keeper-workspace-mobile.test.ts
@@ -171,11 +171,9 @@ describe('keeper workspace v2 (26) mobile contract', () => {
   })
 
   it('keeps remounted operational topbar chrome out of mobile and keeper tablet edges', () => {
-    expect(opsClusterBaseRuleDecls('.v2-top-ops > [data-testid="emergency-stop-control"]')['white-space'])
-      .toBe('nowrap')
-    expect(opsClusterBaseRuleDecls('.v2-top-ops > [data-testid="emergency-stop-control"]')['min-height'])
-      .toBe('28px')
-    expect(opsClusterBaseRuleDecls('.v2-top-ops > [data-testid="emergency-stop-control"] > span')['white-space'])
+    expect(opsClusterBaseRuleDecls('.v2-top-ops > .emergency-stop-control')['white-space']).toBe('nowrap')
+    expect(opsClusterBaseRuleDecls('.v2-top-ops > .emergency-stop-control')['min-height']).toBe('28px')
+    expect(opsClusterBaseRuleDecls('.v2-top-ops > .emergency-stop-control > span')['white-space'])
       .toBe('nowrap')
 
     expect(opsClusterRuleDecls('.v2-app[data-mobile="1"] .v2-top-ops', SHELL_MOBILE_CHROME_BREAKPOINT).display)
@@ -424,10 +422,6 @@ describe('keeper workspace v2 (26) mobile contract', () => {
     expect(keeperWorkspaceRosterSource).toContain('keeper.latest_tool_call_count')
     expect(keeperWorkspaceRosterSource).toContain('class="kw-kp-context"')
     expect(keeperWorkspaceRosterSource).toContain('class="kw-kp-tool"')
-    expect(keeperWorkspaceRosterSource).not.toContain('class="kw-kp-chat')
-    expect(keeperWorkspaceRosterSource).not.toContain('class="kw-kp-inline-actions')
-    expect(keeperWorkspaceRailSource).not.toContain('kw-fleet-chat')
-    expect(keeperWorkspaceRailSource).not.toContain('data-stub')
     expect(keeperWorkspaceRosterSource).toContain('const ROSTER_ROW_ESTIMATED_HEIGHT = 92')
     expect(keeperWorkspaceRosterSource).toContain('estimatedItemHeight=${ROSTER_ROW_ESTIMATED_HEIGHT}')
     expect(css).toContain('.kw-kp-row::before')

--- a/dashboard/src/styles/keeper-workspace-v23.test.ts
+++ b/dashboard/src/styles/keeper-workspace-v23.test.ts
@@ -1,10 +1,28 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { parse } from 'postcss'
 import { declarationsForSelector } from './css-test-utils'
 
 const cssPath = resolve(__dirname, 'keeper-workspace.css')
 const css = readFileSync(cssPath, 'utf-8')
+
+function baseDeclarationsForSelector(selector: string): Record<string, string> {
+  const declarations: Record<string, string> = {}
+  let found = false
+
+  parse(css).walkRules((rule) => {
+    if (rule.parent?.type === 'atrule') return
+    if (!rule.selectors.includes(selector)) return
+    found = true
+    rule.walkDecls((decl) => {
+      declarations[decl.prop] = decl.value.trim()
+    })
+  })
+
+  if (!found) throw new Error(`Selector not found: ${selector}`)
+  return declarations
+}
 
 describe('keeper-workspace v2.3 fleet surface CSS', () => {
   it('keeps new roster text surfaces from overflowing the row', () => {
@@ -13,10 +31,21 @@ describe('keeper-workspace v2.3 fleet surface CSS', () => {
     expect(gloss['text-overflow']).toBe('ellipsis')
     expect(gloss['white-space']).toBe('nowrap')
 
-    const inlineActionLabel = declarationsForSelector(css, '.kw-kp-inline-action span')
-    expect(inlineActionLabel.overflow).toBe('hidden')
-    expect(inlineActionLabel['text-overflow']).toBe('ellipsis')
-    expect(inlineActionLabel['white-space']).toBe('nowrap')
+    const rightRail = declarationsForSelector(css, '.kw-kp-right')
+    expect(rightRail['padding-right']).toBe('34px')
+    expect(rightRail['align-items']).toBe('flex-end')
+  })
+
+  it('keeps roster rows to one always discoverable command target', () => {
+    const menuButton = baseDeclarationsForSelector('.kw-kp-more')
+
+    expect(menuButton.position).toBe('absolute')
+    expect(menuButton.opacity).toBe('0.72')
+    expect(menuButton.width).toBe('26px')
+    expect(css).not.toContain('.kw-kp-chat')
+    expect(css).not.toContain('.kw-kp-inline-actions')
+    expect(css).not.toContain('.kw-kp-inline-action')
+    expect(css).not.toContain('.kw-fleet-chat')
   })
 
   it('keeps selected runtime details ellipsized inside the rail card', () => {
@@ -37,12 +66,12 @@ describe('keeper-workspace v2.3 fleet surface CSS', () => {
   })
 
   it('visibly guards fleet lifecycle actions while they are in flight', () => {
-    const inlineBusy = declarationsForSelector(css, '.kw-kp-inline-action.busy')
-    expect(inlineBusy['border-color']).toContain('34, 211, 238')
-    expect(inlineBusy.color).toBe('#cffafe')
-
     const railDisabled = declarationsForSelector(css, '.kw-fleet-action:disabled')
     expect(railDisabled.cursor).toBe('wait')
     expect(railDisabled.opacity).toBe('0.68')
+
+    const railBusy = declarationsForSelector(css, '.kw-fleet-action.busy')
+    expect(railBusy['border-color']).toContain('34, 211, 238')
+    expect(railBusy.color).toBe('#cffafe')
   })
 })

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -1996,9 +1996,15 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 
 .ctx-meter-head {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: baseline;
+  gap: 8px;
   min-width: 0;
+}
+
+.ctx-meter-label {
+  color: var(--text-mid);
+  font-size: 12px;
 }
 
 .ctx-meter-pct {

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -339,8 +339,8 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 }
 .kw-kp-row:hover .kw-kp-right,
 .kw-kp-row:focus-within .kw-kp-right {
-  opacity: 0;
-  pointer-events: none;
+  opacity: 1;
+  pointer-events: auto;
 }
 .kw-kp-meta { min-width: 0; }
 .kw-kp-name { font-weight: var(--fw-bold); font-size: var(--fs-15); color: var(--color-fg-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -406,7 +406,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; padding-top: 2px; }
+.kw-kp-right { display: flex; flex-direction: column; align-items: flex-end; gap: 4px; flex: none; padding-top: 2px; padding-right: 34px; }
 .kw-kp-time {
   max-width: 96px;
   font-family: var(--font-mono);
@@ -435,7 +435,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   justify-content: center;
   padding: 0;
   transform: translateY(-50%);
-  opacity: 0;
+  opacity: 0.72;
   border: 1px solid var(--color-border-default);
   border-radius: var(--r-1);
   background: var(--color-bg-panel-alt);
@@ -1873,35 +1873,6 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   white-space: nowrap;
 }
 
-.kw-kp-chat {
-  position: absolute;
-  right: 43px;
-  top: 50%;
-  z-index: 2;
-  display: grid;
-  width: 28px;
-  height: 28px;
-  place-items: center;
-  border: 1px solid rgba(148, 163, 184, 0.26);
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.88);
-  color: rgba(226, 232, 240, 0.86);
-  opacity: 0;
-  transform: translateY(-50%) translateX(5px);
-  transition: opacity 150ms ease, transform 150ms ease, border-color 150ms ease, color 150ms ease;
-}
-
-.kw-kp-row:hover .kw-kp-chat,
-.kw-kp-row:focus-within .kw-kp-chat {
-  opacity: 1;
-  transform: translateY(-50%) translateX(0);
-}
-
-.kw-kp-chat:hover {
-  border-color: rgba(96, 165, 250, 0.72);
-  color: #dbeafe;
-}
-
 .kw-fleet-aside {
   display: grid;
   gap: 12px;
@@ -1976,16 +1947,6 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   white-space: nowrap;
 }
 
-.kw-fleet-chat {
-  width: 100%;
-  border: 1px solid rgba(96, 165, 250, 0.38);
-  border-radius: 14px;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.22), rgba(14, 165, 233, 0.12));
-  color: #dbeafe;
-  font-weight: 800;
-  min-height: 38px;
-}
-
 .kw-fleet-phase {
   display: grid;
   gap: 4px;
@@ -2031,6 +1992,22 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   max-width: 100%;
   border-radius: inherit;
   background: linear-gradient(90deg, #22d3ee, #60a5fa, #f59e0b);
+}
+
+.ctx-meter-head {
+  display: flex;
+  justify-content: flex-end;
+  align-items: baseline;
+  min-width: 0;
+}
+
+.ctx-meter-pct {
+  color: var(--volt-strong);
+  font-size: 14px;
+}
+
+.ctx-meter-pct.hot {
+  color: var(--status-bad);
 }
 
 .kw-fleet-vitals {
@@ -2082,12 +2059,6 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 }
 
 @media (max-width: 760px) {
-  .kw-kp-chat {
-    right: 39px;
-    opacity: 1;
-    transform: translateY(-50%);
-  }
-
   .kw-fleet-vitals {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -2134,69 +2105,11 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   }
 }
 
-.kw-kp-inline-actions {
-  position: absolute;
-  right: 77px;
-  top: 50%;
-  z-index: 2;
-  display: flex;
-  max-width: min(46%, 180px);
-  gap: 5px;
-  min-width: 0;
-  opacity: 0;
-  transform: translateY(-50%) translateX(6px);
-  transition: opacity 150ms ease, transform 150ms ease;
-}
-
-.kw-kp-row:hover .kw-kp-inline-actions,
-.kw-kp-row:focus-within .kw-kp-inline-actions {
-  opacity: 1;
-  transform: translateY(-50%) translateX(0);
-}
-
-.kw-kp-inline-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 0;
-  max-width: 88px;
-  height: 28px;
-  gap: 4px;
-  padding: 0 8px;
-  overflow: hidden;
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.9);
-  color: rgba(226, 232, 240, 0.86);
-  font-size: 10px;
-  font-weight: 800;
-}
-
-.kw-kp-inline-action span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.kw-kp-inline-action:hover {
-  border-color: rgba(96, 165, 250, 0.62);
-  color: #dbeafe;
-}
-
-@media (max-width: 760px) {
-  .kw-kp-inline-actions {
-    display: none;
-  }
-}
-
-.kw-kp-inline-action:disabled,
 .kw-fleet-action:disabled {
   cursor: wait;
   opacity: 0.68;
 }
 
-.kw-kp-inline-action.busy,
 .kw-fleet-action.busy {
   border-color: rgba(34, 211, 238, 0.42);
   color: #cffafe;


### PR DESCRIPTION
## Summary
- remove hover-only roster chat and inline lifecycle buttons; keep one stable command menu per keeper row
- remove duplicate selected-runtime chat CTA from the right rail while keeping context usage visible to sighted users
- compact the Emergency Stop control with a semantic `.emergency-stop-control` styling hook instead of CSS selectors on `data-testid`
- replace keeper-workspace rail data-stub markers with explicit data-missing markers

## Review comment response
- P1: production CSS now selects `.emergency-stop-control`; `data-testid` remains only as a test hook.
- P2: removed source-string negative assertions from `keeper-workspace-mobile.test.ts`; DOM-level component tests cover removed chat and inline action surfaces.
- P2: removed the generated roster row `aria-label` so visible row contents provide the selectable row name.
- P2: restored the visible `윈도우 사용량` context meter label and moved the layout styling into CSS.
- P3: centralizing `data-missing` placeholders is left as follow-up scope; this PR only removes the touched `data-stub` marker usage.

## Validation
- `pnpm exec vitest run --config vitest.config.ts src/components/emergency-stop-control.test.ts src/styles/keeper-workspace-mobile.test.ts src/components/keeper-workspace/keeper-workspace-roster.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts --no-file-parallelism --maxWorkers=1` (79 tests)
- `pnpm exec eslint src/components/emergency-stop-control.ts src/components/emergency-stop-control.test.ts src/styles/keeper-workspace-mobile.test.ts src/components/keeper-workspace/keeper-workspace-roster.ts src/components/keeper-workspace/keeper-workspace-roster.test.ts src/components/keeper-workspace/keeper-workspace-rail.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts` (0 errors; two test files are ignored by project config with warnings)
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
- conflict-marker scan over touched dashboard files

## Notes
- Dune/local build was intentionally not run; PR CI remains the build authority.
- The existing `data-testid="emergency-stop-control"` remains in component tests only; production CSS no longer selects on it.