### PR TITLE
fix(board): bind moderation actor to auth

### DIFF
--- a/lib/server/server_dashboard_http_delete_actions.ml
+++ b/lib/server/server_dashboard_http_delete_actions.ml
@@ -502,7 +502,7 @@ let add_delete_action_routes router =
 
   |> Http.Router.post "/api/v1/dashboard/board/moderation/flag" (fun request reqd ->
        with_token_permission_auth ~permission:Masc_domain.CanAdmin
-         (fun _state _agent_name req reqd ->
+         (fun _state agent_name req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
            try
              let json = Yojson.Safe.from_string body_str in
@@ -526,10 +526,7 @@ let add_delete_action_routes router =
              | None ->
                   respond_error ~request:req reqd (invalid_request "target_id")
              | Some target_id ->
-                  let reporter =
-                    Safe_ops.json_string_opt "reporter" json
-                    |> Option.value ~default:"operator"
-                  in
+                  let reporter = agent_name in
                    (match Board_moderation.flag ~target_kind ~target_id ~reporter ~reason with
                     | Error msg ->
                        Http.Response.json_value ~status:`Conflict ~request:req
@@ -607,11 +604,7 @@ let add_delete_action_routes router =
                            Board_moderation.flag_reason_of_string
                        in
                        let note = Safe_ops.json_string_opt "note" json in
-                       let actor =
-                         match Safe_ops.json_string_opt "actor" json with
-                         | Some a -> (match String_util.trim_to_option a with Some trimmed -> trimmed | None -> agent_name)
-                         | _ -> agent_name
-                       in
+                       let actor = agent_name in
                        (match Board_moderation.record_action ~target_kind ~target_id
                                 ~actor ~action ?reason ?note () with
                         | Error msg ->

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -82,6 +82,44 @@ let contains_substring haystack needle =
     true
   with Not_found -> false
 
+let source_text rel = Masc_test_deps.read_file (Masc_test_deps.source_path rel)
+
+let slice_between text ~start_marker ~end_marker =
+  try
+    let start = Str.search_forward (Str.regexp_string start_marker) text 0 in
+    let stop = Str.search_forward (Str.regexp_string end_marker) text start in
+    String.sub text start (stop - start)
+  with Not_found ->
+    Alcotest.failf "missing source marker between %S and %S" start_marker end_marker
+
+let slice_from text ~start_marker =
+  try
+    let start = Str.search_forward (Str.regexp_string start_marker) text 0 in
+    String.sub text start (String.length text - start)
+  with Not_found -> Alcotest.failf "missing source marker %S" start_marker
+
+let test_moderation_http_identity_bound_to_auth_source () =
+  let src = source_text "lib/server/server_dashboard_http_delete_actions.ml" in
+  let flag_route =
+    slice_between src
+      ~start_marker:{|Http.Router.post "/api/v1/dashboard/board/moderation/flag"|}
+      ~end_marker:{|Http.Router.get "/api/v1/dashboard/board/moderation/queue"|}
+  in
+  let action_route =
+    slice_from src
+      ~start_marker:{|Http.Router.post "/api/v1/dashboard/board/moderation/action"|}
+  in
+  Alcotest.(check bool) "flag route binds authenticated agent" true
+    (contains_substring flag_route "(fun _state agent_name req reqd ->");
+  Alcotest.(check bool) "flag reporter uses authenticated agent" true
+    (contains_substring flag_route "let reporter = agent_name");
+  Alcotest.(check bool) "flag route ignores body reporter" false
+    (contains_substring flag_route {|json_string_opt "reporter"|});
+  Alcotest.(check bool) "action actor uses authenticated agent" true
+    (contains_substring action_route "let actor = agent_name");
+  Alcotest.(check bool) "action route ignores body actor" false
+    (contains_substring action_route {|json_string_opt "actor"|})
+
 (** {2 Group 1: Helper / Formatting Functions} *)
 
 let test_visibility_of_string () =
@@ -1885,6 +1923,8 @@ let () =
             `Quick test_inline_board_post_author_rewrites_caller_claim;
           Alcotest.test_case "MCP runtime board post author accepts matching alias"
             `Quick test_inline_board_post_author_accepts_matching_alias;
+          Alcotest.test_case "moderation http identity binds to auth source"
+            `Quick test_moderation_http_identity_bound_to_auth_source;
         ] );
       ( "json_helpers",
         [


### PR DESCRIPTION
## Summary
- bind board moderation flag reporter to the authenticated admin principal
- bind board moderation action actor to the authenticated admin principal
- remove request-body actor/reporter overrides that could spoof moderation audit identity
- breaking API contract change: clients can no longer submit `actor` or `reporter`; moderation identity is always the authenticated caller
- add a source-level regression pin for the moderation HTTP routes so body `actor`/`reporter` reads do not return

## Verification
- ocamlc -stop-after parsing lib/server/server_dashboard_http_delete_actions.ml test/test_tool_board_coverage.ml
- ocamlformat --check lib/server/server_dashboard_http_delete_actions.ml test/test_tool_board_coverage.ml
- git diff --check
- rg -n '<<<<<<<|=======|>>>>>>>' lib/server/server_dashboard_http_delete_actions.ml test/test_tool_board_coverage.ml (no matches)
- python3 source scan: moderation reporter/actor bound to authenticated agent

No local Dune build/test per operator instruction; CI remains the build authority.