### PR TITLE
fix(memory): keep fallback extraction cadence due

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -300,6 +300,20 @@ type parse_retry_error =
   | Retry_exhausted_unparseable of string
   | Retry_transport_failed of string
 
+type extraction_kind =
+  | Structured_episode
+  | Unstructured_fallback
+
+type extraction_result =
+  { episode : Keeper_memory_os_types.episode
+  ; kind : extraction_kind
+  }
+
+let should_record_cadence_success = function
+  | Structured_episode -> true
+  | Unstructured_fallback -> false
+;;
+
 let rec run_with_parse_retries ~max_retries ~attempt messages =
   match attempt messages with
   | Parsed episode -> Ok episode
@@ -435,7 +449,7 @@ let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason
   ; schema_version = Keeper_memory_os_types.schema_version
   }
 
-let extract_with_provider
+let extract_with_provider_classified
     ?(complete = default_complete)
     ?clock
     ?(timeout_sec = librarian_default_timeout_sec)
@@ -476,7 +490,7 @@ let extract_with_provider
          ~attempt
          messages
      with
-     | Ok episode -> Ok episode
+     | Ok episode -> Ok { episode; kind = Structured_episode }
      | Error (Retry_transport_failed msg) -> Error msg
      | Error (Retry_exhausted_unparseable msg) ->
        let raw =
@@ -490,10 +504,29 @@ let extract_with_provider
          inp.trace_id
          generation
          msg;
-       Ok (unstructured_episode ~now ~generation inp ~reason:msg ~raw))
+       Ok
+         { episode = unstructured_episode ~now ~generation inp ~reason:msg ~raw
+         ; kind = Unstructured_fallback
+         })
 ;;
 
-let extract_and_append_with_provider
+let extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~generation inp =
+  match
+    extract_with_provider_classified
+      ?complete
+      ?clock
+      ?timeout_sec
+      ~sw
+      ~net
+      ~provider_cfg
+      ~generation
+      inp
+  with
+  | Error _ as e -> e
+  | Ok { episode; kind = _ } -> Ok episode
+;;
+
+let extract_and_append_with_provider_classified
     ?complete
     ?clock
     ?timeout_sec
@@ -509,9 +542,19 @@ let extract_and_append_with_provider
       ~keeper_id
       ~trace_id:inp.Keeper_librarian.trace_id
   in
-  match extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~generation inp with
+  match
+    extract_with_provider_classified
+      ?complete
+      ?clock
+      ?timeout_sec
+      ~sw
+      ~net
+      ~provider_cfg
+      ~generation
+      inp
+  with
   | Error _ as e -> e
-  | Ok episode ->
+  | Ok ({ episode; kind = _ } as extraction) ->
     let now = episode.Keeper_memory_os_types.created_at in
     (* RFC-0243: UPSERT claims into the fact store instead of blind-appending. A claim
        re-extracted across turns is folded into the existing row
@@ -566,8 +609,33 @@ let extract_and_append_with_provider
         (* RFC-0251: the co-occurrence edge / spreading-activation organ was removed
            (dark-by-default, no recall consumer), so the fact upsert above is the only
            post-merge work. *)
-        Ok episode
+        Ok extraction
       | Error message -> Error ("memory os fact upsert failed: " ^ message))
+;;
+
+let extract_and_append_with_provider
+    ?complete
+    ?clock
+    ?timeout_sec
+    ~sw
+    ~net
+    ~keeper_id
+    ~provider_cfg
+    inp
+  =
+  match
+    extract_and_append_with_provider_classified
+      ?complete
+      ?clock
+      ?timeout_sec
+      ~sw
+      ~net
+      ~keeper_id
+      ~provider_cfg
+      inp
+  with
+  | Error _ as e -> e
+  | Ok { episode; kind = _ } -> Ok episode
 ;;
 
 let provider_for_runtime ~runtime_id =
@@ -611,7 +679,7 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
              in
              match
                with_provider_slot ?clock (fun () ->
-                 extract_and_append_with_provider
+                 extract_and_append_with_provider_classified
                    ?complete
                    ?clock
                    ~timeout_sec
@@ -631,15 +699,24 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                  "memory os librarian skipped runtime=%s: global provider slot busy (capacity=%d)"
                  runtime_id
                  (global_slot_capacity ())
-             | Some (Ok episode) ->
-               (* Only a successful write resets the cadence. Skipped or failed
-                  attempts leave the keeper due on the next turn. *)
-               cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
-               Log.Keeper.info ~keeper_name:keeper_id
-                 "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
-                 episode.Keeper_memory_os_types.trace_id
-                 episode.generation
-                 (List.length episode.claims)
+             | Some (Ok { episode; kind }) ->
+               if should_record_cadence_success kind
+               then (
+                 (* Only structured extraction resets the cadence. Skipped,
+                    failed, or unstructured fallback attempts leave the keeper
+                    due on the next turn. *)
+                 cadence_record_success ~keeper_id ~trace_id:inp.trace_id;
+                 Log.Keeper.info ~keeper_name:keeper_id
+                   "memory os librarian wrote episode trace_id=%s generation=%d claims=%d"
+                   episode.Keeper_memory_os_types.trace_id
+                   episode.generation
+                   (List.length episode.claims))
+               else
+                 Log.Keeper.warn ~keeper_name:keeper_id
+                   "memory os librarian wrote unstructured fallback trace_id=%s generation=%d claims=%d; cadence remains due"
+                   episode.Keeper_memory_os_types.trace_id
+                   episode.generation
+                   (List.length episode.claims)
              | Some (Error err) ->
                Otel_metric_store.inc_counter
                  Keeper_metrics.(to_string EpisodeCreateFailures)

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -51,10 +51,10 @@ val cadence_due : keeper_id:string -> trace_id:string -> bool
     unseen keeper, or the first call after a rollover, is due immediately. *)
 
 val cadence_record_success : keeper_id:string -> trace_id:string -> unit
-(** Record a successful extraction for [keeper_id] on [trace_id] so the cadence
-    counter resets and the next cycle can begin. Must only be called after a
-    due turn actually produced an episode; skipped or failed attempts must not
-    call this. *)
+(** Record a successful structured extraction for [keeper_id] on [trace_id] so
+    the cadence counter resets and the next cycle can begin. Must only be called
+    after a due turn actually produced a structured episode; skipped, failed, or
+    unstructured-fallback attempts must not call this. *)
 
 val cadence_counter_entries : unit -> int
 (** Number of live per-keeper cadence rows. Bounded by the number of keepers
@@ -105,6 +105,20 @@ type parse_retry_error =
   | Retry_exhausted_unparseable of string
   | Retry_transport_failed of string
 
+type extraction_kind =
+  | Structured_episode
+  | Unstructured_fallback
+
+type extraction_result =
+  { episode : Keeper_memory_os_types.episode
+  ; kind : extraction_kind
+  }
+
+val should_record_cadence_success : extraction_kind -> bool
+(** Whether this extraction kind is allowed to reset the librarian cadence.
+    Unstructured fallback episodes are durable diagnostics, but they mean the
+    provider still failed to produce structured memory. *)
+
 val run_with_parse_retries
   :  max_retries:int
   -> attempt:(Agent_sdk.Types.message list -> attempt_outcome)
@@ -144,6 +158,17 @@ val extract_with_provider
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, string) result
 
+val extract_with_provider_classified
+  :  ?complete:complete_fn
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?timeout_sec:float
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> provider_cfg:Llm_provider.Provider_config.t
+  -> generation:int
+  -> Keeper_librarian.input
+  -> (extraction_result, string) result
+
 val extract_and_append_with_provider
   :  ?complete:complete_fn
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
@@ -154,6 +179,17 @@ val extract_and_append_with_provider
   -> provider_cfg:Llm_provider.Provider_config.t
   -> Keeper_librarian.input
   -> (Keeper_memory_os_types.episode, string) result
+
+val extract_and_append_with_provider_classified
+  :  ?complete:complete_fn
+  -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  -> ?timeout_sec:float
+  -> sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> keeper_id:string
+  -> provider_cfg:Llm_provider.Provider_config.t
+  -> Keeper_librarian.input
+  -> (extraction_result, string) result
 
 val run_best_effort
   :  ?complete:complete_fn

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -158,6 +158,12 @@ let test_cadence_record_success_resets () =
   check bool "after success the next turn is not due" false
     (R.cadence_due ~keeper_id:kid ~trace_id:tid)
 
+let test_cadence_success_policy () =
+  check bool "structured extraction resets cadence" true
+    (R.should_record_cadence_success R.Structured_episode);
+  check bool "unstructured fallback stays due" false
+    (R.should_record_cadence_success R.Unstructured_fallback)
+
 (* [cadence_due] drives the real per-(keeper, trace) counter table (the gate
    [run_best_effort] uses). A fresh pair is due immediately, and failures are
    left due until [cadence_record_success] is called. Asserted as
@@ -365,6 +371,7 @@ let () =
           test_case "cadence 1 always due" `Quick test_cadence_one_always_due;
           test_case "step transitions" `Quick test_cadence_step_transitions;
           test_case "record success resets" `Quick test_cadence_record_success_resets;
+          test_case "success policy excludes fallback" `Quick test_cadence_success_policy;
           test_case "cadence_due fires once per period" `Quick test_cadence_due_periodic;
           test_case "cadence_due is per-keeper" `Quick test_cadence_due_independent_keepers;
           test_case "cadence_due resets on trace rollover" `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1111,7 +1111,7 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
         in
         let fallback_started_at = Eio.Time.now clock in
         let fallback_result =
-          Librarian_runtime.extract_and_append_with_provider
+          Librarian_runtime.extract_and_append_with_provider_classified
             ~complete
             ~clock
             ~timeout_sec:1.0
@@ -1131,7 +1131,17 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
         in
         (match fallback_result with
          | Error msg -> Alcotest.fail msg
-         | Ok episode ->
+         | Ok extraction ->
+           let episode = extraction.Librarian_runtime.episode in
+           let kind = extraction.Librarian_runtime.kind in
+           (match kind with
+            | Librarian_runtime.Unstructured_fallback -> ()
+            | Librarian_runtime.Structured_episode ->
+              Alcotest.fail "expected unstructured fallback extraction");
+           Alcotest.(check bool)
+             "fallback does not count as cadence success"
+             false
+             (Librarian_runtime.should_record_cadence_success kind);
            fallback_created_at := Some episode.Types.created_at;
            check_in_clock_window
              "fallback created_at derives from injected clock"


### PR DESCRIPTION
## Summary
- classify librarian extraction results as structured vs unstructured fallback without relying on terminal-marker string matching
- keep existing episode-only extraction APIs as wrappers while adding classified APIs for the runtime control path
- stop resetting librarian cadence when the provider only produced an unstructured fallback episode

## Evidence
- Live runtime log showed repeated `memory os librarian preserving unstructured fallback` for `trace-1781513619204-00000`, latest observed at 2026-06-26T05:07:11Z generation 378.
- Current code returned fallback episodes as `Ok episode`, so `run_best_effort` recorded cadence success for lossy extraction.

## Local checks
- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_librarian_runtime.mli lib/keeper/keeper_librarian_runtime.ml test/test_keeper_librarian_retry.ml test/test_keeper_memory_os.ml`

## Not run locally
- focused Dune build/tests: shared `/tmp/me-dune-local.lock` was held by PID 7601 running `pr22330-scope-clean/scripts/dune-local.sh exec test/test_streamable_http.exe`; CI is the build authority for this branch.
