### PR TITLE
fix(dashboard): remove unused runtimeStats (#22346 follow-up)

### DIFF
--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -472,14 +472,6 @@ export function SettingsSurface() {
   const [compactAt, setCompactAt] = useState(85)
   const [autoCompact, setAutoCompact] = useState(true)
 
-
-  const runtimeStats = {
-    ids: runtimeDefaults?.runtimes.length ?? 0,
-    providers: new Set(runtimeDefaults?.runtimes.map(r => r.provider) ?? []).size,
-    models: new Set(runtimeDefaults?.runtimes.map(r => r.model) ?? []).size,
-    default: runtimeDefaults?.default_runtime_id ?? '—',
-  }
-
   useEffect(() => {
     let active = true
     void (async () => {


### PR DESCRIPTION
본인 #22346에서 런치 패널 제거 후 runtimeStats(settings-surface.ts:476)가 unused로 잔류해 TS noUnusedLocals / Test Coverage Check 실패. 사용처 없으므로 정의 제거. 본인 브랜치 base stacked fix — 본인 merge 결정.