### PR TITLE
fix(masc): adversarial review follow-up (#22364)

### DIFF
--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -77,9 +77,11 @@ let helloFailed = false
 const pending = new Map<number, PendingRpc>()
 
 // WebSocket close codes that indicate a persistent failure and should stop
-// reconnection attempts: 1002 protocol error, 1003 unsupported data, 1008
-// policy violation, and 1011 internal server error per RFC 6455.
-const FATAL_CLOSE_CODES = new Set([1002, 1003, 1008, 1011])
+// reconnection attempts: 1002 protocol error, 1003 unsupported data, and 1008
+// policy violation per RFC 6455.  1011 (internal server error) is kept
+// reconnectable because it is usually a transient server-side condition
+// (restart/crash/redeploy) rather than a protocol-level rejection.
+const FATAL_CLOSE_CODES = new Set([1002, 1003, 1008])
 
 function sessionStorageOrNull(): Storage | null {
   if (typeof sessionStorage === 'undefined') return null

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -16,7 +16,7 @@ type config = {
 let default_config = {
   port = Env_config_core.masc_http_port_int ();
   host = Env_config_core.masc_host ();
-  max_connections = Env_config_core.get_int ~default:512 "MASC_HTTP_MAX_CONNECTIONS";
+  max_connections = Env_config_core.get_int ~default:128 "MASC_HTTP_MAX_CONNECTIONS";
 }
 
 (** HTTP/2 request handler type - receives H2.Reqd.t directly *)

--- a/lib/keeper_event_bus/keeper_event_bus.ml
+++ b/lib/keeper_event_bus/keeper_event_bus.ml
@@ -1,13 +1,14 @@
-(** Keeper_event_bus — OAS Event_bus reference with domain-local override.
+(** Keeper_event_bus — shared OAS Event_bus reference.
 
     Holds the shared Event_bus instance set at server bootstrap. Separate
     module to avoid dependency cycles:
     Keeper_keepalive and Keeper_agent_run both depend on keeper
     modules that form cycles if they reference each other.
 
-    [Domain.DLS] stores a per-domain override. A process-wide fallback
-    preserves the previous lookup contract for domains that have not been
-    explicitly initialized.
+    The event bus itself is a process-safe message channel and is stored
+    in a process-wide [Atomic.t] intentionally.  This is NOT a precedent for
+    Eio resources ([Eio.Switch.t], [Eio.Net.t], clocks); those remain
+    per-domain via {!Masc_eio_env}.
 
     @since 2.255.0 *)
 

--- a/lib/masc_eio_env.ml
+++ b/lib/masc_eio_env.ml
@@ -3,9 +3,10 @@
 
     The switch and net handle are needed by OAS provider completions
     which use cohttp-eio for HTTP transport.  They are stored in
-    [Domain.DLS] so each domain can hold its own handles, with a process-wide
-    compatibility fallback for domains that have not been explicitly
-    initialized yet.
+    [Domain.DLS] only; an uninitialized domain must call {!init} itself
+    or fail closed.  Falling back to another domain's [Eio.Switch.t] or
+    [Eio.Net.t] would let a worker domain borrow handles whose lifetime is
+    tied to the originating domain's switch, which is unsafe.
 
     @since 2.130.0 *)
 
@@ -16,21 +17,14 @@ type t = {
 }
 
 let env_key : t option Domain.DLS.key = Domain.DLS.new_key (fun () -> None)
-let process_env : t option Atomic.t = Atomic.make None
 
 let init ~sw ~net ?clock () =
-  let env = { sw; net; clock } in
-  Domain.DLS.set env_key (Some env);
-  Atomic.set process_env (Some env)
+  Domain.DLS.set env_key (Some { sw; net; clock })
 
 let reset_for_test () =
-  Domain.DLS.set env_key None;
-  Atomic.set process_env None
+  Domain.DLS.set env_key None
 
-let get_opt () =
-  match Domain.DLS.get env_key with
-  | Some _ as env -> env
-  | None -> Atomic.get process_env
+let get_opt () = Domain.DLS.get env_key
 
 let get () =
   match get_opt () with

--- a/test/test_backend.ml
+++ b/test/test_backend.ml
@@ -29,7 +29,7 @@ let with_eio_env f =
   Eio_main.run @@ fun env ->
   let fs = Eio.Stdenv.fs env in
   let tmp_dir = make_test_dir () in
-  let config = { Backend.default_config with
+  let config = { (Backend.default_config ()) with
     base_path = tmp_dir;
     node_id = "test_node";
     cluster_name = "test";
@@ -211,7 +211,7 @@ let test_unified_backend () =
   Eio_main.run @@ fun env ->
   let fs = Eio.Stdenv.fs env in
   let tmp_dir = make_test_dir () in
-  let config = { Backend.default_config with
+  let config = { (Backend.default_config ()) with
     base_path = tmp_dir;
     node_id = "unified_test";
     cluster_name = "test";

--- a/test/test_backend_coverage.ml
+++ b/test/test_backend_coverage.ml
@@ -159,7 +159,7 @@ let with_eio_backend_and_dir f =
   let fs = Eio.Stdenv.fs env in
   let clock = Eio.Stdenv.clock env in
   let tmp_dir = make_test_dir "masc_eio" in
-  let config = { Backend.default_config with base_path = tmp_dir; node_id = "test"; cluster_name = "test" } in
+  let config = { (Backend.default_config ()) with base_path = tmp_dir; node_id = "test"; cluster_name = "test" } in
   Fun.protect
     ~finally:(fun () -> try rm_rf tmp_dir with _ -> ())
     (fun () ->

--- a/test/test_distributed_lock_backlog_namespace.ml
+++ b/test/test_distributed_lock_backlog_namespace.ml
@@ -34,7 +34,7 @@ let with_eio_backend f =
   let clock = Eio.Stdenv.clock env in
   let tmp_dir = make_test_dir "masc_lock_backlog" in
   let config =
-    { Backend.default_config with
+    { (Backend.default_config ()) with
       base_path = tmp_dir
     ; node_id = "test-node"
     ; cluster_name = "test-cluster"

--- a/test/test_keeper_llm_bridge.ml
+++ b/test/test_keeper_llm_bridge.ml
@@ -100,16 +100,16 @@ let test_clocked_env_runs_function () =
         | Error err -> Alcotest.fail (Agent_sdk.Error.to_string err))))
 ;;
 
-let test_env_process_fallback_visible_from_uninitialized_domain () =
+let test_env_uninitialized_domain_returns_none () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       Masc_eio_env.reset_for_test ();
       Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
         Masc_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ~clock:(Eio.Stdenv.clock env) ();
-        let worker = Domain.spawn (fun () -> Option.is_some (Masc_eio_env.get_opt ())) in
-        Alcotest.(check bool)
-          "process fallback is visible from another domain"
-          true
+        let worker = Domain.spawn (fun () -> Masc_eio_env.get_opt ()) in
+        Alcotest.(check (option pass))
+          "uninitialized domain returns None"
+          None
           (Domain.join worker))))
 ;;
 
@@ -282,9 +282,9 @@ let () =
             test_clockless_env_fails_closed_without_calling_fn
         ; Alcotest.test_case "clocked env runs" `Quick test_clocked_env_runs_function
         ; Alcotest.test_case
-            "process fallback is visible cross-domain"
+            "uninitialized domain returns None"
             `Quick
-            test_env_process_fallback_visible_from_uninitialized_domain
+            test_env_uninitialized_domain_returns_none
         ; Alcotest.test_case
             "timeout log carries failure envelope"
             `Quick

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -153,14 +153,14 @@ let test_state_pending_count_integrity_under_concurrent_updates () =
   check int "concurrent pure computation leaves count at zero" 0 state.pending_tool_count
 ;;
 
-let test_keeper_event_bus_process_fallback_visible_from_uninitialized_domain () =
+let test_keeper_event_bus_is_intentionally_process_wide () =
   let bus = Agent_sdk.Event_bus.create () in
   Keeper_event_bus.set bus;
-  let worker = Domain.spawn (fun () -> Option.is_some (Keeper_event_bus.get ())) in
+  let worker = Domain.spawn (fun () -> Keeper_event_bus.get ()) in
   check
-    bool
-    "process fallback is visible from another domain"
-    true
+    (option pass)
+    "event bus is intentionally process-wide and visible from another domain"
+    (Some bus)
     (Domain.join worker)
 ;;
 
@@ -237,8 +237,8 @@ let () =
     ; ( "concurrency"
       , [ test_case "pure transitions under concurrent domains" `Quick
             test_state_pending_count_integrity_under_concurrent_updates
-        ; test_case "event bus fallback is visible cross-domain" `Quick
-            test_keeper_event_bus_process_fallback_visible_from_uninitialized_domain
+        ; test_case "event bus is intentionally process-wide" `Quick
+            test_keeper_event_bus_is_intentionally_process_wide
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick


### PR DESCRIPTION
Follow-up to #22364 addressing the blocking review comments from the latest round.

- Remove process_env fallback from Masc_eio_env; uninitialized domains fail closed.
- Document Keeper_event_bus process-wide Atomic as intentionally process-safe.
- Remove 1011 from FATAL_CLOSE_CODES so transient server errors reconnect.
- Revert MASC_HTTP_MAX_CONNECTIONS default to 128 (env override remains).
- Fix Backend.default_config () call sites and SH.session annotations.

CI validation requested per review bar.