### PR TITLE
fix(keeper): fail closed non-rg tool_search_files op (#22334 boundary)

### DIFF
--- a/lib/keeper/keeper_workspace_ops.ml
+++ b/lib/keeper/keeper_workspace_ops.ml
@@ -22,21 +22,43 @@ let handle_tool_search_files
       ~(args : Yojson.Safe.t)
   =
   let raw_path = Safe_ops.json_string ~default:"" "path" args |> String.trim in
-  match
-    Keeper_workspace_read_ops.try_handle ~turn_sandbox_factory ~config ~meta ~args
-      ~op:"rg" ~raw_path
-  with
-  | Some response -> response
-  | None ->
-    (* Unreachable: search_files is rg-only and try_handle always handles
-       rg. Kept as a typed guard rather than an assert so a future routing
-       change degrades to a clear message instead of a crash. *)
+  (* tool_search_files is rg-only. A present non-rg op must fail closed
+     BEFORE rg-specific argument validation, so the requested operation is
+     preserved in the error instead of being silently reclassified as rg
+     (boundary contract: #22334 review). *)
+  let requested_op = Safe_ops.json_string_opt "op" args in
+  match requested_op with
+  | None | Some "" | Some "rg" ->
+    (match
+       Keeper_workspace_read_ops.try_handle ~turn_sandbox_factory ~config ~meta
+         ~args ~op:"rg" ~raw_path
+     with
+    | Some response -> response
+    | None ->
+      (* Unreachable: search_files is rg-only and try_handle always handles
+         rg. Kept as a typed guard rather than an assert so a future routing
+         change degrades to a clear message instead of a crash. *)
+      Yojson.Safe.to_string
+        (`Assoc
+            [ "ok", `Bool false
+            ; ( "error"
+              , `String
+                  "search_files supports only rg (pattern search); use \
+                   Execute for directory listing, file reads, find, or git" )
+            ]))
+  | Some other ->
+    (* Fail closed: preserve the caller-requested op in both the echoed
+       [op] field and the error message so policy/audit see the real
+       request, never a silent rewrite to rg. *)
     Yojson.Safe.to_string
       (`Assoc
           [ "ok", `Bool false
+          ; "op", `String other
           ; ( "error"
             , `String
-                "search_files supports only rg (pattern search); use Execute \
-                 for directory listing, file reads, find, or git" )
+                (Printf.sprintf
+                   "tool_search_files does not support op %S; this tool is rg \
+                    (pattern search) only. Use Execute for other operations."
+                   other) )
           ])
 ;;

--- a/test/test_keeper_sandbox_docker_route.ml
+++ b/test/test_keeper_sandbox_docker_route.ml
@@ -555,10 +555,12 @@ let test_unknown_workspace_op_is_unsupported_before_docker () =
    | Some true -> Alcotest.failf "unknown op unexpectedly succeeded: %s" raw
    | Some false | None -> ());
   Alcotest.(check bool)
-    "rg-only handler requires a search pattern"
+    "non-rg op fails closed with unsupported-op error"
     true
-    (response_mentions raw "error" "pattern is required for rg");
-  Alcotest.(check (option string)) "handler op is rg-only" (Some "rg")
+    (response_mentions raw "error" "does not support op");
+  Alcotest.(check (option string))
+    "handler preserves requested op, not rewritten to rg"
+    (Some "future_repo_op")
     (parse_string_field raw "op")
 
 let test_turn_sandbox_file_write_uses_host_bind_mount () =
@@ -1188,10 +1190,12 @@ let test_tool_search_files_repo_review_is_unsupported () =
    | Some true -> Alcotest.failf "repo action unexpectedly succeeded: %s" raw
    | Some false | None -> ());
   Alcotest.(check bool)
-    "repo action payload cannot bypass rg pattern contract"
+    "repo action op fails closed with unsupported-op error"
     true
-    (response_mentions raw "error" "pattern is required for rg");
-  Alcotest.(check (option string)) "handler op is rg-only" (Some "rg")
+    (response_mentions raw "error" "does not support op");
+  Alcotest.(check (option string))
+    "handler preserves requested op, not rewritten to rg"
+    (Some "gh")
     (parse_string_field raw "op")
 
 let docker_run_line log_path =


### PR DESCRIPTION
본인 #22334 review(코멘트 4806733742/4806729296)가 지적한 boundary 위반 fix: handle_tool_search_files가 caller op를 무시하고 항상 ~op:"rg"로 dispatch → non-rg op(future_repo_op, gh)가 rg로 silent 재분류. fix: Safe_ops.json_string_opt로 op 읽고, present && non-rg면 ok:false + unsupported-op error + op 보존(fail closed, rg 검증 전). 테스트 future_repo_op/gh가 ok:false + unsupported + op 보존 assert. 로컬 test_keeper_sandbox_docker_route 61 테스트 통과. 본인 브랜치 base stacked fix — 본인 merge 결정.