### PR TITLE
fix(keeper): remove prompt wildcard tool token

### DIFF
--- a/config/prompts/keeper.unified.system.md
+++ b/config/prompts/keeper.unified.system.md
@@ -94,7 +94,7 @@ Decide what to do based on the current world state below.
 ### Research evidence
 - Ground novel technical, policy, library, model, pricing, API, or industry-pattern claims with evidence before presenting them as fact.
 - Use code evidence for repo-local claims: search/read the relevant files and cite stable `path:line` references in the post or reply.
-- Use web evidence for external or current claims: call `WebSearch` with `includeContent: true` to get current sources plus keeper-readable `content_text` and raw per-result `page_content`; call `WebFetch` for a selected URL when you need deeper reading or a citation-ready page. These MASC-owned names (`WebSearch`, `WebFetch`) are the exact tool names to use; do not use snake_case variants such as `web_search` or the internal `masc_web_*` identifiers.
+- Use web evidence for external or current claims: call `WebSearch` with `includeContent: true` to get current sources plus keeper-readable `content_text` and raw per-result `page_content`; call `WebFetch` for a selected URL when you need deeper reading or a citation-ready page. These MASC-owned names (`WebSearch`, `WebFetch`) are the exact tool names to use; do not use snake_case variants such as `web_search` or internal web backend identifiers.
 - If no source is found or the available tools cannot verify the claim, mark the claim with `[uncited]` instead of presenting it as verified.
 
 #### WebSearch / WebFetch concrete usage

--- a/scripts/lint/no-tool-substrate-adapter-surface.sh
+++ b/scripts/lint/no-tool-substrate-adapter-surface.sh
@@ -77,7 +77,7 @@ LEGACY_REPO_HELPER_PATTERN='(keeper|github)_pr_[A-Za-z0-9_]*'
 GH_COMMIT_PATTERN='gh_'"commit"
 GITHUB_COMMENT_PATTERN='github_'"comment"
 MICRO_TOOL_PATTERN="\b(${PR_VERB_PATTERN}|${GH_COMMIT_PATTERN}|${GITHUB_COMMENT_PATTERN}|${REPO_PR_PATTERN}|${LEGACY_REPO_HELPER_PATTERN})\b"
-INTERNAL_WEB_TOOL_PATTERN='\b(masc_web_search|masc_web_fetch)\b'
+INTERNAL_WEB_TOOL_PATTERN='(\b(masc_web_search|masc_web_fetch)\b|\bmasc_web_\*)'
 
 current_tmp="$(mktemp -t tool-substrate-adapter-surface.current.XXXXXX)"
 allow_tmp="$(mktemp -t tool-substrate-adapter-surface.allow.XXXXXX)"

--- a/test/test_keeper_prompt_token_integrity.ml
+++ b/test/test_keeper_prompt_token_integrity.ml
@@ -14,6 +14,12 @@ let keeper = "test-keeper-p0-3"
 let total_unknown () = Metrics.metric_total metric_name
 let total_stripped () = Metrics.metric_total stripped_metric_name
 
+let read_file path =
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
 let test_known_tokens_are_not_reported () =
   let prompt =
     String.concat " "
@@ -146,6 +152,16 @@ let test_case_insensitive_resolution () =
   Alcotest.(check (list string))
     "mixed-case known tokens resolve" [] unknowns
 
+let test_unified_system_prompt_has_no_unresolved_tokens () =
+  let path = "config/prompts/keeper.unified.system.md" in
+  let prompt = read_file path in
+  let unknowns =
+    Scanner.scan_text ~keeper_name:keeper ~source:System_prompt prompt
+  in
+  Alcotest.(check (list string))
+    "unified system prompt has no unresolved keeper/masc tokens"
+    [] unknowns
+
 (* ── strip_unresolved_tool_tokens (registry-driven sanitization) ── *)
 
 let test_strip_removes_unresolved_lowercase_token () =
@@ -212,6 +228,8 @@ let () =
             test_rendered_prompt_scans_all_surfaces;
           Alcotest.test_case "case insensitive resolution" `Quick
             test_case_insensitive_resolution;
+          Alcotest.test_case "unified system prompt has no unresolved tokens"
+            `Quick test_unified_system_prompt_has_no_unresolved_tokens;
         ] );
       ( "sanitization",
         [


### PR DESCRIPTION
## Summary

- removes the literal `masc_web_*` wildcard from the keeper-facing unified system prompt
- extends `no-tool-substrate-adapter-surface` so wildcard internal web-token prose is forbidden with `masc_web_search` / `masc_web_fetch`
- adds a focused regression that scans the checked-in unified system prompt for unresolved `keeper_*` / `masc_*` tokens

## Evidence

Live root cause from `/Users/dancer/me/.masc/logs/system_log_2026-06-26.jsonl`:

- `keeper_prompt_token_integrity: unknown masc token "masc_web_*" in system_prompt for keeper idealist`
- `keeper_prompt_token_integrity: stripped masc token "masc_web_*" from prompt for keeper idealist`
- grouped count before fix: 237 unknown + 237 stripped warnings for idealist on 2026-06-26 logs

The prompt text was a negative example: it told keepers not to use internal `masc_web_*` names. The registry-driven scanner correctly treats lower-case `masc_*` tokens as tool candidates, so the prompt itself violated the scanner contract.

## Verification

- `git diff --check origin/main...HEAD`
- `bash scripts/lint/no-tool-substrate-adapter-surface.sh --fail`
- `ocamlformat --check test/test_keeper_prompt_token_integrity.ml`
- `scripts/dune-local.sh exec test/test_keeper_prompt_token_integrity.exe` -> 15 tests passed

## Notes

This does not hardcode a runtime path, add an env knob, or add a fallback. It removes a model-facing stale-token source and pins the existing ratchet to prevent reintroduction.