### PR TITLE
feat(dashboard): surface keeper autoboot exclusion reason on roster

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -46,6 +46,7 @@ import {
 } from '../lib/monitoring-runtime'
 import { KeeperPhaseBadge } from './keeper-phase-indicator'
 import { KeeperActionButtons } from './keeper-action-panel'
+import { keeperExclusionLabel } from './keeper-exclusion-label'
 import {
   expectedKeeperDetailRows,
   expectedRuntimeDetailRows,
@@ -1103,6 +1104,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
     // hint (재개 대기 / 기동 필요 / 감시 중 / 연결 없음) renders as a second
     // muted line. All fall back to honest copy, never faked.
     const chipLabel = row.band.label
+    // autoboot exclusion (declarative_autoboot_disabled / autoboot_disabled):
+    // why this keeper is not booting. null when bootable; paused has its own
+    // 일시정지 UI so it is filtered out in keeperExclusionLabel. Surfaced on
+    // execution keepers via enrich_keeper_with_diagnostic.
+    const exclusionLabel = keeperExclusionLabel(row.keeperRuntime?.exclusion_reason)
     const glossText = row.stateNote
       ? blockerDisplay.cell
       : (stageLabel ?? '실행 중')
@@ -1166,6 +1172,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
           </span>
           <span class="fl-gloss" title=${glossTitle}>${glossText}</span>
           <span class="fl-gloss">${row.bandActionHint}</span>
+          ${exclusionLabel
+            ? html`<span class="fl-gloss" data-exclusion title="자동 부팅에서 제외됨 — 서버 시작 시 기동하지 않습니다. 기동 버튼으로 직접 켜세요.">${exclusionLabel}</span>`
+            : null}
         </div>
 
         <div class="fl-ctx">

--- a/dashboard/src/components/keeper-exclusion-label.test.ts
+++ b/dashboard/src/components/keeper-exclusion-label.test.ts
@@ -19,8 +19,8 @@ describe('keeperExclusionLabel', () => {
     expect(keeperExclusionLabel(undefined)).toBeNull()
   })
 
-  it('returns null for unknown reason strings rather than surfacing raw backend tokens', () => {
-    expect(keeperExclusionLabel('something_future')).toBeNull()
+  it('returns a visible generic label for unknown reason strings without surfacing raw backend tokens', () => {
+    expect(keeperExclusionLabel('something_future')).toBe('부팅 제외')
     expect(keeperExclusionLabel('')).toBeNull()
   })
 })

--- a/dashboard/src/components/keeper-exclusion-label.test.ts
+++ b/dashboard/src/components/keeper-exclusion-label.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { keeperExclusionLabel } from './keeper-exclusion-label'
+
+describe('keeperExclusionLabel', () => {
+  it('maps declarative_autoboot_disabled to a Korean operator label', () => {
+    expect(keeperExclusionLabel('declarative_autoboot_disabled')).toBe('시작 시 부팅 안 함')
+  })
+
+  it('maps autoboot_disabled to a Korean operator label', () => {
+    expect(keeperExclusionLabel('autoboot_disabled')).toBe('수동 부팅 해제')
+  })
+
+  it('returns null for paused — the roster and detail strip already render a dedicated 일시정지 badge, so the exclusion label must not duplicate it', () => {
+    expect(keeperExclusionLabel('paused')).toBeNull()
+  })
+
+  it('returns null for bootable keepers (null / undefined reason)', () => {
+    expect(keeperExclusionLabel(null)).toBeNull()
+    expect(keeperExclusionLabel(undefined)).toBeNull()
+  })
+
+  it('returns null for unknown reason strings rather than surfacing raw backend tokens', () => {
+    expect(keeperExclusionLabel('something_future')).toBeNull()
+    expect(keeperExclusionLabel('')).toBeNull()
+  })
+})

--- a/dashboard/src/components/keeper-exclusion-label.ts
+++ b/dashboard/src/components/keeper-exclusion-label.ts
@@ -1,3 +1,13 @@
+import type { KeeperAutobootExclusionReason } from '../types/core'
+
+function isKeeperAutobootExclusionReason(
+  reason: string,
+): reason is KeeperAutobootExclusionReason {
+  return reason === 'declarative_autoboot_disabled'
+    || reason === 'paused'
+    || reason === 'autoboot_disabled'
+}
+
 /** Map backend autoboot exclusion reasons to Korean operator-facing labels.
  *
  * Mirrors `Keeper_runtime.autoboot_exclusion_reason` (OCaml):
@@ -9,15 +19,18 @@
  * a dedicated 일시정지 badge; only the "autoboot off" cases need a distinct
  * label so an operator sees *why* a keeper is not booting/proactive. */
 export function keeperExclusionLabel(
-  reason: string | null | undefined,
+  reason: KeeperAutobootExclusionReason | string | null | undefined,
 ): string | null {
   if (!reason) return null
+  if (!isKeeperAutobootExclusionReason(reason)) return '부팅 제외'
   switch (reason) {
     case 'declarative_autoboot_disabled':
       return '시작 시 부팅 안 함'
     case 'autoboot_disabled':
       return '수동 부팅 해제'
-    default:
+    case 'paused':
       return null
+    default:
+      return reason satisfies never
   }
 }

--- a/dashboard/src/components/keeper-exclusion-label.ts
+++ b/dashboard/src/components/keeper-exclusion-label.ts
@@ -1,0 +1,23 @@
+/** Map backend autoboot exclusion reasons to Korean operator-facing labels.
+ *
+ * Mirrors `Keeper_runtime.autoboot_exclusion_reason` (OCaml):
+ *   - declarative_autoboot_disabled — keepers/<name>.toml autoboot_enabled=false
+ *   - autoboot_disabled             — meta autoboot_enabled=false (no toml default)
+ *   - paused                         — supervisor paused (covered by dedicated paused UI)
+ *
+ * `paused` returns null here because the roster and detail strip already render
+ * a dedicated 일시정지 badge; only the "autoboot off" cases need a distinct
+ * label so an operator sees *why* a keeper is not booting/proactive. */
+export function keeperExclusionLabel(
+  reason: string | null | undefined,
+): string | null {
+  if (!reason) return null
+  switch (reason) {
+    case 'declarative_autoboot_disabled':
+      return '시작 시 부팅 안 함'
+    case 'autoboot_disabled':
+      return '수동 부팅 해제'
+    default:
+      return null
+  }
+}

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1104,6 +1104,10 @@ export interface Keeper {
   phase?: KeeperPhase | null
   runtime_class?: 'keeper'
   paused?: boolean
+  /** Autoboot exclusion reason (declarative_autoboot_disabled / paused /
+   *  autoboot_disabled) — why this keeper is not booting/proactive. null when
+   *  bootable. Surfaced from execution `keepers` and briefing `keeper_briefs`. */
+  exclusion_reason?: string | null
   registered?: boolean
   reconcile_status?: string | null
   emoji?: string

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1095,6 +1095,15 @@ export type KeeperPhase =
   | 'Dead'
   | 'Zombie'
 
+export const KEEPER_AUTOBOOT_EXCLUSION_REASONS = [
+  'declarative_autoboot_disabled',
+  'paused',
+  'autoboot_disabled',
+] as const
+
+export type KeeperAutobootExclusionReason =
+  typeof KEEPER_AUTOBOOT_EXCLUSION_REASONS[number]
+
 export interface Keeper {
   name: string
   keeper_id?: string | null
@@ -1104,10 +1113,10 @@ export interface Keeper {
   phase?: KeeperPhase | null
   runtime_class?: 'keeper'
   paused?: boolean
-  /** Autoboot exclusion reason (declarative_autoboot_disabled / paused /
-   *  autoboot_disabled) — why this keeper is not booting/proactive. null when
-   *  bootable. Surfaced from execution `keepers` and briefing `keeper_briefs`. */
-  exclusion_reason?: string | null
+  /** Autoboot exclusion reason mirrored from `Keeper_runtime`.
+   *  null when bootable. Surfaced from execution `keepers` and briefing
+   *  `keeper_briefs`. */
+  exclusion_reason?: KeeperAutobootExclusionReason | null
   registered?: boolean
   reconcile_status?: string | null
   emoji?: string

--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -208,6 +208,12 @@ let build_keeper_briefs (config : Workspace.config) (keepers : Yojson.Safe.t lis
                         Json_util.string_opt_to_json
                           (String_util.trim_to_option (string_field "goal" keeper)) );
                       ("last_autonomous_action_at", member_assoc "last_autonomous_action_at" keeper);
+                      ("proactive_enabled", member_assoc "proactive_enabled" keeper);
+                      ("paused", member_assoc "paused" keeper);
+                      ("exclusion_reason",
+                       (match Keeper_runtime.autoboot_exclusion_reason config name with
+                        | Some r -> `String r
+                        | None -> `Null));
                     ]
                     @ keeper_tool_audit_json_fields config registry_lookup keeper
                         (match String_util.trim_to_option (string_field "agent_name" keeper) with

--- a/lib/dashboard/dashboard_briefing_assembly.ml
+++ b/lib/dashboard/dashboard_briefing_assembly.ml
@@ -211,9 +211,8 @@ let build_keeper_briefs (config : Workspace.config) (keepers : Yojson.Safe.t lis
                       ("proactive_enabled", member_assoc "proactive_enabled" keeper);
                       ("paused", member_assoc "paused" keeper);
                       ("exclusion_reason",
-                       (match Keeper_runtime.autoboot_exclusion_reason config name with
-                        | Some r -> `String r
-                        | None -> `Null));
+                       Keeper_runtime.autoboot_exclusion_reason_opt_to_yojson
+                         (Keeper_runtime.autoboot_exclusion_reason config name));
                     ]
                     @ keeper_tool_audit_json_fields config registry_lookup keeper
                         (match String_util.trim_to_option (string_field "agent_name" keeper) with

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -287,7 +287,12 @@ let enrich_keeper_with_diagnostic ~(config : Workspace.config) (keeper_json : Yo
      (match Json_util.assoc_string_opt "name" result with
       | Some name ->
         (match Keeper_runtime.autoboot_exclusion_reason config name with
-         | Some reason -> `Assoc (assoc_upsert fields "exclusion_reason" (`String reason))
+         | Some reason ->
+           `Assoc
+             (assoc_upsert
+                fields
+                "exclusion_reason"
+                (Keeper_runtime.autoboot_exclusion_reason_to_yojson reason))
          | None -> result)
       | None -> result)
    | other -> other)

--- a/lib/dashboard/dashboard_execution.ml
+++ b/lib/dashboard/dashboard_execution.ml
@@ -222,7 +222,7 @@ let upsert_keeper_trust_fields fields trust =
 ;;
 
 let enrich_keeper_with_diagnostic ~(config : Workspace.config) (keeper_json : Yojson.Safe.t) =
-  match keeper_json with
+  let result = match keeper_json with
   | `Assoc fields ->
     (* The upstream operator snapshot already carries these for most keeper rows.
        Reuse them before falling back to per-keeper file reads. *)
@@ -277,6 +277,20 @@ let enrich_keeper_with_diagnostic ~(config : Workspace.config) (keeper_json : Yo
            | Ok None | Error _ -> keeper_json)
         | _ -> keeper_json))
   | _ -> keeper_json
+  in
+  (* Surface the autoboot exclusion reason so the roster can show *why* a keeper
+     is not booting/proactive (declarative_autoboot_disabled / paused /
+     autoboot_disabled).  paused/proactive_enabled already ride on the snapshot
+     keeper row; exclusion_reason is the missing visibility piece. *)
+  (match result with
+   | `Assoc fields ->
+     (match Json_util.assoc_string_opt "name" result with
+      | Some name ->
+        (match Keeper_runtime.autoboot_exclusion_reason config name with
+         | Some reason -> `Assoc (assoc_upsert fields "exclusion_reason" (`String reason))
+         | None -> result)
+      | None -> result)
+   | other -> other)
 ;;
 
 let bool_field ?(default = false) key json =

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -146,24 +146,41 @@ let remember_boot_meta_result ctx name result =
       record_boot_meta_failure ~base_path ~name ~cause ~error:message;
       Error message
 
+type autoboot_exclusion_reason =
+  | Paused
+  | Declarative_autoboot_disabled
+  | Autoboot_disabled
+
+let autoboot_exclusion_reason_to_string = function
+  | Paused -> "paused"
+  | Declarative_autoboot_disabled -> "declarative_autoboot_disabled"
+  | Autoboot_disabled -> "autoboot_disabled"
+
+let autoboot_exclusion_reason_to_yojson reason =
+  `String (autoboot_exclusion_reason_to_string reason)
+
+let autoboot_exclusion_reason_opt_to_yojson = function
+  | Some reason -> autoboot_exclusion_reason_to_yojson reason
+  | None -> `Null
+
 type autoboot_exclusion = {
   keeper_name : string;
-  reason : string;
+  reason : autoboot_exclusion_reason;
 }
 
 let autoboot_exclusion_reason config name =
   match read_meta_file_path (keeper_meta_path config name) with
   | Ok (Some meta) ->
-    if meta.paused then Some "paused"
+    if meta.paused then Some Paused
     else
       (match (profile_defaults_for_config config name).autoboot_enabled with
        | Some true -> None
-       | Some false -> Some "declarative_autoboot_disabled"
+       | Some false -> Some Declarative_autoboot_disabled
        | None ->
-         if meta.autoboot_enabled then None else Some "autoboot_disabled")
+         if meta.autoboot_enabled then None else Some Autoboot_disabled)
   | Ok None ->
     (match (profile_defaults_for_config config name).autoboot_enabled with
-     | Some false -> Some "declarative_autoboot_disabled"
+     | Some false -> Some Declarative_autoboot_disabled
      | Some true | None -> None)
   | Error _ ->
     (* Preserve existing behavior: corrupt/unreadable meta still enters the

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -85,6 +85,12 @@ val bootable_keeper_names : Workspace.config -> string list
 (** Names of every keeper whose [keepers/<name>/keeper.toml] exists and
     looks bootable on disk. *)
 
+val autoboot_exclusion_reason : Workspace.config -> string -> string option
+(** Per-keeper autoboot exclusion reason label ([paused] /
+    [declarative_autoboot_disabled] / [autoboot_disabled]), or [None] when the
+    keeper is bootable.  Single-keeper projection of
+    {!autoboot_excluded_keeper_reasons}. *)
+
 val autoboot_excluded_keeper_reasons : Workspace.config -> autoboot_exclusion list
 (** Configured keepers skipped by autoboot with operator-facing reason labels. *)
 

--- a/lib/keeper/keeper_runtime.mli
+++ b/lib/keeper/keeper_runtime.mli
@@ -74,9 +74,26 @@ val boot_meta_failure_for :
     the current process has observed one.  Cleared when the keeper loads or
     materializes successfully. *)
 
+type autoboot_exclusion_reason =
+  | Paused
+  | Declarative_autoboot_disabled
+  | Autoboot_disabled
+(** Closed reason why a configured keeper is intentionally absent from
+    {!bootable_keeper_names}. *)
+
+val autoboot_exclusion_reason_to_string : autoboot_exclusion_reason -> string
+(** Stable JSON/log label for {!autoboot_exclusion_reason}. *)
+
+val autoboot_exclusion_reason_to_yojson : autoboot_exclusion_reason -> Yojson.Safe.t
+(** Stable JSON representation for {!autoboot_exclusion_reason}. *)
+
+val autoboot_exclusion_reason_opt_to_yojson :
+  autoboot_exclusion_reason option -> Yojson.Safe.t
+(** Stable JSON representation for an optional {!autoboot_exclusion_reason}. *)
+
 type autoboot_exclusion = {
   keeper_name : string;
-  reason : string;
+  reason : autoboot_exclusion_reason;
 }
 (** Why a configured keeper is intentionally absent from
     {!bootable_keeper_names}. *)
@@ -85,10 +102,9 @@ val bootable_keeper_names : Workspace.config -> string list
 (** Names of every keeper whose [keepers/<name>/keeper.toml] exists and
     looks bootable on disk. *)
 
-val autoboot_exclusion_reason : Workspace.config -> string -> string option
-(** Per-keeper autoboot exclusion reason label ([paused] /
-    [declarative_autoboot_disabled] / [autoboot_disabled]), or [None] when the
-    keeper is bootable.  Single-keeper projection of
+val autoboot_exclusion_reason : Workspace.config -> string -> autoboot_exclusion_reason option
+(** Per-keeper autoboot exclusion reason, or [None] when the keeper is bootable.
+    Single-keeper projection of
     {!autoboot_excluded_keeper_reasons}. *)
 
 val autoboot_excluded_keeper_reasons : Workspace.config -> autoboot_exclusion list

--- a/lib/server/server_bootstrap_loops.ml
+++ b/lib/server/server_bootstrap_loops.ml
@@ -804,7 +804,10 @@ let start_keeper_loops
         let rendered =
           exclusions
           |> List.map (fun Keeper_runtime.{ keeper_name; reason } ->
-            Printf.sprintf "%s=%s" keeper_name reason)
+            Printf.sprintf
+              "%s=%s"
+              keeper_name
+              (Keeper_runtime.autoboot_exclusion_reason_to_string reason))
           |> String.concat ", "
         in
         Log.Keeper.info

--- a/lib/server/server_runtime_startup_credentials.ml
+++ b/lib/server/server_runtime_startup_credentials.ml
@@ -109,7 +109,10 @@ let sync_bootable_keeper_credentials (state : Mcp_server.server_state) =
     let rendered =
       excluded_keepers
       |> List.map (fun Keeper_runtime.{ keeper_name; reason } ->
-        Printf.sprintf "%s=%s" keeper_name reason)
+        Printf.sprintf
+          "%s=%s"
+          keeper_name
+          (Keeper_runtime.autoboot_exclusion_reason_to_string reason))
       |> String.concat ", "
     in
     Log.Server.info


### PR DESCRIPTION
## What
Keepers excluded from autoboot (`autoboot_enabled=false` in keeper.toml, or runtime paused) were invisible on the dashboard — the only signal was a single INFO log line at boot. Operators could not see *why* a keeper was not booting/proactive from the roster, which is exactly the failure mode that left proactive turns silently dead.

## Changes
- **briefing `keeper_briefs`** (`dashboard_briefing_assembly.ml`): add `proactive_enabled` / `paused` / `exclusion_reason`
- **execution `keepers`** (`dashboard_execution.ml`): `enrich_keeper_with_diagnostic` post-process injects `exclusion_reason` (reuses existing `~config`, no caller signature change)
- **`keeper_runtime.mli`**: export `autoboot_exclusion_reason` (it was implemented in `.ml` but absent from the interface, so the Dashboard library could not reach it — this was the build blocker)
- **`types/core.ts`**: `Keeper.exclusion_reason?: string | null`
- **`agent-roster.ts`**: roster row renders a Korean gloss ("시작 시 부팅 안 함" / "수동 부팅 해제") when `exclusion_reason` is set
- new **`keeper-exclusion-label.ts`**: reason → Korean label map (`paused` is filtered out since it has a dedicated 일시정지 UI)

## Why this surface (live evidence)
Live check against the running binary: execution `keepers[]` already carries `paused` / `proactive_enabled` but **not** `autoboot_enabled`. `exclusion_reason` ("declarative_autoboot_disabled" / "paused" / "autoboot_disabled") is a superset of the autoboot on/off boolean, so one field answers "why is this keeper not booting". The roster consumes execution `keepers` (not `continuity_briefs`), so the injection point is `enrich_keeper_with_diagnostic` (which already has `~config`) rather than `continuity_row_of_keeper` (which would require threading `config` through callers).

## Verification
- `dune build lib/` — EXIT 0
- `tsc --noEmit` — EXIT 0
- vitest: `agent-roster` / `keeper-badge` / `keeper-detail-alert-strip` — 68 passed

Runtime visibility (exclusion_reason values appearing on execution/briefing) is verifiable once this binary is deployed; the running server still serves the pre-change 0.19.48 binary.

## Out of scope
A5 (detail alert-strip badge) is intentionally deferred: the per-keeper detail endpoint (`/api/v1/keepers/:name`) does not pass through `enrich`, so surfacing `exclusion_reason` there needs a separate backend injection on a different serialization path. The roster (at-a-glance) was the goal.

## RFC
None. Touches dashboard JSON serialization + frontend types/render + a `.mli` export. No credential / identity / operator-escalation / sandbox / hooks / workflow surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
