### PR TITLE
fix(dashboard): rebuild stale generated startup assets

### DIFF
--- a/scripts/build-dashboard-if-needed.sh
+++ b/scripts/build-dashboard-if-needed.sh
@@ -28,11 +28,33 @@ else
 fi
 dashboard_pm_label="${dashboard_pm[*]}"
 
-# Check if rebuild is needed: any source file newer than stamp
+generated_index_has_remote_startup_resources() {
+  local index="$OUTPUT_DIR/index.html"
+  [ -f "$index" ] || return 1
+
+  # The dashboard source index intentionally avoids network-blocking startup
+  # resources. Treat stale generated output that still contains them as invalid
+  # even when the timestamp stamp says "fresh".
+  if grep -Eiq 'https://fonts\.(googleapis|gstatic)\.com' "$index"; then
+    return 0
+  fi
+  if grep -Eiq '<link[^>]+rel=["'\'']stylesheet["'\''][^>]+href=["'\'']https://' "$index"; then
+    return 0
+  fi
+
+  return 1
+}
+
+# Check if rebuild is needed: source mtimes, missing output, or invalid output.
 needs_rebuild() {
   # No stamp or no output → must build
   [ ! -f "$STAMP" ] && return 0
   [ ! -f "$OUTPUT_DIR/index.html" ] && return 0
+
+  if generated_index_has_remote_startup_resources; then
+    echo "[dashboard] Generated index contains remote startup resources; rebuilding." >&2
+    return 0
+  fi
 
   # Any .ts/.tsx/.css/.html source newer than stamp → rebuild
   if find "$DASHBOARD_DIR/src" \
@@ -55,7 +77,7 @@ needs_rebuild() {
 }
 
 if needs_rebuild; then
-  echo "[dashboard] Sources changed, rebuilding SPA..." >&2
+  echo "[dashboard] Build output stale, rebuilding SPA..." >&2
   temp_root="${TMPDIR:-/tmp}"
   temp_root="${temp_root%/}"
   if [ ! -d "$temp_root" ] || [ ! -w "$temp_root" ]; then

--- a/test/test_run_local_script.ml
+++ b/test/test_run_local_script.ml
@@ -8,6 +8,11 @@ let source_root () =
 let run_local_script_path () =
   Filename.concat (Filename.concat (source_root ()) "scripts") "run-local.sh"
 
+let build_dashboard_if_needed_script_path () =
+  Filename.concat
+    (Filename.concat (source_root ()) "scripts")
+    "build-dashboard-if-needed.sh"
+
 let read_file path =
   In_channel.with_open_bin path In_channel.input_all
 
@@ -270,6 +275,60 @@ let test_build_dashboard_flag_is_opt_in () =
           code_flag stdout_flag stderr_flag;
       check bool "helper invoked with flag" true (Sys.file_exists marker))
 
+let test_dashboard_build_helper_rebuilds_remote_startup_resource_output () =
+  with_temp_dir "run-local-script" (fun dir ->
+      let repo_root = Filename.concat dir "repo" in
+      let scripts_dir = Filename.concat repo_root "scripts" in
+      let dashboard_dir = Filename.concat repo_root "dashboard" in
+      let output_dir = Filename.concat repo_root "assets/dashboard" in
+      let fake_bin = Filename.concat dir "fake-bin" in
+      let pnpm_capture = Filename.concat dir "pnpm-calls.txt" in
+      mkdir_p scripts_dir;
+      mkdir_p (Filename.concat dashboard_dir "src");
+      mkdir_p (Filename.concat dashboard_dir "node_modules");
+      mkdir_p output_dir;
+      mkdir_p fake_bin;
+      copy_script
+        (build_dashboard_if_needed_script_path ())
+        (Filename.concat scripts_dir "build-dashboard-if-needed.sh");
+      write_file (Filename.concat dashboard_dir "package.json") {|{"scripts":{"build":"vite build"}}|};
+      write_file (Filename.concat dashboard_dir "index.html")
+        {|<!doctype html><html><head></head><body><div id="app"></div></body></html>|};
+      write_file (Filename.concat dashboard_dir "src/main.ts") "export {}\n";
+      write_file (Filename.concat output_dir "index.html")
+        {|<!doctype html><html><head><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR"></head><body></body></html>|};
+      write_file (Filename.concat output_dir ".build-stamp") "fresh\n";
+      write_executable (Filename.concat fake_bin "pnpm")
+        (Printf.sprintf
+           {|
+#!/bin/sh
+set -eu
+printf '%%s\n' "$*" >> %s
+case "$*" in
+  "run build")
+    mkdir -p ../assets/dashboard
+    printf 'fresh generated dashboard\n' > ../assets/dashboard/index.html
+    ;;
+esac
+|}
+           (Filename.quote pnpm_capture));
+      let script = Filename.concat scripts_dir "build-dashboard-if-needed.sh" in
+      let path =
+        fake_bin ^ ":" ^ Option.value ~default:"" (Sys.getenv_opt "PATH")
+      in
+      let code, stdout, stderr =
+        run_process ~cwd:repo_root script
+          ~env:[ ("PATH", path) ]
+          [| script |]
+      in
+      if code <> 0 then
+        failf "dashboard build helper failed (%d)\nstdout:\n%s\nstderr:\n%s"
+          code stdout stderr;
+      check bool "stale generated index forced rebuild" true
+        (contains_substring (read_file pnpm_capture) "run build");
+      check bool "stale reason was explicit" true
+        (contains_substring stderr "remote startup resources"))
+
 let test_existing_target_config_is_not_overwritten () =
   with_temp_dir "run-local-script" (fun dir ->
       let repo_root = setup_fake_repo dir in
@@ -393,6 +452,9 @@ let () =
             test_print_port_is_stable_for_target_dir;
           test_case "build-dashboard flag is opt-in" `Quick
             test_build_dashboard_flag_is_opt_in;
+          test_case "dashboard helper rebuilds stale remote startup resources"
+            `Quick
+            test_dashboard_build_helper_rebuilds_remote_startup_resource_output;
           test_case "bootstrap-keepers flag is opt-in" `Quick
             test_bootstrap_keepers_flag_is_opt_in;
           test_case "existing target config is not overwritten" `Quick


### PR DESCRIPTION
## Summary
- Treat generated assets/dashboard/index.html as stale when it still contains remote startup font/style resources, even if .build-stamp is fresh.
- Add a run-local script regression test that proves a stale generated Google Fonts index forces the dashboard build helper to run.

## Validation
- bash -n scripts/build-dashboard-if-needed.sh
- shellcheck scripts/build-dashboard-if-needed.sh
- ocamlformat --check test/test_run_local_script.ml
- bash /private/tmp/verify_dashboard_stale_asset_guard.sh /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-dashboard-stale-asset-guard-20260626
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-dashboard-stale-asset-guard-20260626/dashboard/vitest.config.ts /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/fix-dashboard-stale-asset-guard-20260626/dashboard/src/index-html.test.ts --no-file-parallelism --maxWorkers=1
- git diff --check

Local Dune intentionally not run; CI is the build authority for OCaml per repo workflow.