### PR TITLE
fix(dashboard): partition query-dependent route caches

### DIFF
--- a/lib/server/server_dashboard_http_core_cache.ml
+++ b/lib/server/server_dashboard_http_core_cache.ml
@@ -102,12 +102,21 @@ let dashboard_query_cache_segment = function
   | None -> "missing"
 ;;
 
+let dashboard_query_cache_value_json = function
+  | Some raw ->
+    let value = String.trim raw in
+    if value = "" then `Null else `String value
+  | None -> `Null
+;;
+
 let dashboard_query_cache_key config prefix fields =
   let suffix =
-    fields
-    |> List.map (fun (key, value) ->
-      Printf.sprintf "%s=%s" key (dashboard_query_cache_segment value))
-    |> String.concat ":"
+    `List
+      (List.map
+         (fun (key, value) ->
+           `List [ `String key; dashboard_query_cache_value_json value ])
+         fields)
+    |> Yojson.Safe.to_string
   in
   dashboard_cache_key config prefix suffix
 ;;

--- a/lib/server/server_dashboard_http_core_cache.ml
+++ b/lib/server/server_dashboard_http_core_cache.ml
@@ -95,6 +95,23 @@ let dashboard_cache_key (config : Workspace.config) prefix suffix =
     suffix
 ;;
 
+let dashboard_query_cache_segment = function
+  | Some raw ->
+    let value = String.trim raw in
+    if value = "" then "missing" else value
+  | None -> "missing"
+;;
+
+let dashboard_query_cache_key config prefix fields =
+  let suffix =
+    fields
+    |> List.map (fun (key, value) ->
+      Printf.sprintf "%s=%s" key (dashboard_query_cache_segment value))
+    |> String.concat ":"
+  in
+  dashboard_cache_key config prefix suffix
+;;
+
 let dashboard_briefing_timeout_s = Env_config_runtime.Dashboard.briefing_timeout_sec
 
 let attach_projection_diagnostics json diagnostics =

--- a/lib/server/server_dashboard_http_core_cache.mli
+++ b/lib/server/server_dashboard_http_core_cache.mli
@@ -24,6 +24,9 @@ val with_dashboard_timeout :
 
 val cache_partition_segment : Workspace.config -> string
 val dashboard_cache_key : Workspace.config -> string -> string -> string
+val dashboard_query_cache_segment : string option -> string
+val dashboard_query_cache_key :
+  Workspace.config -> string -> (string * string option) list -> string
 val dashboard_briefing_timeout_s : float
 
 val attach_projection_diagnostics :

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -19,6 +19,16 @@ let live_cache_ttl_s = Server_dashboard_http_core_cache.live_cache_ttl_s
 let realtime_cache_ttl_s = Server_dashboard_http_core_cache.realtime_cache_ttl_s
 let feature_health_cache_ttl_s = Server_dashboard_http_core_cache.feature_health_cache_ttl_s
 
+let dashboard_actor_cache_segment state req =
+  match
+    dashboard_actor_for_request
+      ~base_path:(Mcp_server.workspace_config state).base_path
+      req
+  with
+  | Some actor -> Some actor
+  | None -> Some "default"
+;;
+
 let dashboard_error_json ?ok message =
   let fields = [ ("error", `String message) ] in
   let fields =
@@ -887,7 +897,10 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/briefing" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let cache_key =
-           Printf.sprintf "briefing:%s" (Mcp_server.workspace_config state).base_path
+           Server_dashboard_http_core_cache.dashboard_query_cache_key
+             (Mcp_server.workspace_config state)
+             "briefing"
+             [ ("actor", dashboard_actor_cache_segment state req) ]
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:live_cache_ttl_s (fun () ->
@@ -899,7 +912,12 @@ let add_routes ~sw ~clock router =
   |> Http.Router.get "/api/v1/dashboard/session" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let cache_key =
-           Printf.sprintf "session:%s" (Mcp_server.workspace_config state).base_path
+           Server_dashboard_http_core_cache.dashboard_query_cache_key
+             (Mcp_server.workspace_config state)
+             "session"
+             [ ("actor", dashboard_actor_cache_segment state req)
+             ; ("session", Server_utils.query_param req "session_id")
+             ]
          in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:live_cache_ttl_s (fun () ->
@@ -928,14 +946,20 @@ let add_routes ~sw ~clock router =
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/briefing/sections" (fun request reqd ->
        with_public_read (fun state req reqd ->
-         let cache_key =
-           Printf.sprintf "mission_briefing:%s"
-             (Mcp_server.workspace_config state).base_path
-         in
          let json =
-           Dashboard_cache.get_or_compute cache_key ~ttl:live_cache_ttl_s (fun () ->
+           if Server_utils.bool_query_param req "force" ~default:false then
              Domain_pool_ref.submit_io_or_inline (fun () ->
-               dashboard_briefing_sections_http_json ~state ~sw ~clock req))
+               dashboard_briefing_sections_http_json ~state ~sw ~clock req)
+           else
+             let cache_key =
+               Server_dashboard_http_core_cache.dashboard_query_cache_key
+                 (Mcp_server.workspace_config state)
+                 "mission_briefing"
+                 [ ("actor", dashboard_actor_cache_segment state req) ]
+             in
+             Dashboard_cache.get_or_compute cache_key ~ttl:live_cache_ttl_s (fun () ->
+               Domain_pool_ref.submit_io_or_inline (fun () ->
+                 dashboard_briefing_sections_http_json ~state ~sw ~clock req))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -20,13 +20,9 @@ let realtime_cache_ttl_s = Server_dashboard_http_core_cache.realtime_cache_ttl_s
 let feature_health_cache_ttl_s = Server_dashboard_http_core_cache.feature_health_cache_ttl_s
 
 let dashboard_actor_cache_segment state req =
-  match
-    dashboard_actor_for_request
-      ~base_path:(Mcp_server.workspace_config state).base_path
-      req
-  with
-  | Some actor -> Some actor
-  | None -> Some "default"
+  dashboard_actor_for_request
+    ~base_path:(Mcp_server.workspace_config state).base_path
+    req
 ;;
 
 let dashboard_error_json ?ok message =

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -492,9 +492,40 @@ let test_dashboard_query_cache_key_partitions_route_params () =
         (not (String.equal session_a actor_b));
       check string "deterministic key shape"
         (Printf.sprintf
-           "session:%s:default:actor=default:session=session-a"
+           "session:%s:default:[[\"actor\",\"default\"],[\"session\",\"session-a\"]]"
            config.base_path)
         session_a)
+
+let test_dashboard_query_cache_key_encodes_delimiter_values () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Workspace_utils.default_config dir in
+      let actor_delimiter =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key config "session"
+          [ ("actor", Some "default:session=session-a")
+          ; ("session", Some "session-b")
+          ]
+      in
+      let session_delimiter =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key config "session"
+          [ ("actor", Some "default")
+          ; ("session", Some "session-a:session=session-b")
+          ]
+      in
+      let missing_session =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key config "session"
+          [ ("actor", Some "default"); ("session", None) ]
+      in
+      let literal_missing_session =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key config "session"
+          [ ("actor", Some "default"); ("session", Some "missing") ]
+      in
+      check bool "delimiter-bearing values do not collide" true
+        (not (String.equal actor_delimiter session_delimiter));
+      check bool "literal missing does not collide with absent value" true
+        (not (String.equal missing_session literal_missing_session)))
 
 let test_operator_snapshot_default_route_exposes_provenance () =
   with_test_env @@ fun ~env ~sw ~config ->
@@ -1452,6 +1483,8 @@ let () =
             test_dashboard_query_cache_segment_normalizes_missing_values;
           test_case "dashboard query cache key partitions route params" `Quick
             test_dashboard_query_cache_key_partitions_route_params;
+          test_case "dashboard query cache key encodes delimiter values" `Quick
+            test_dashboard_query_cache_key_encodes_delimiter_values;
           test_case "operator snapshot default route exposes provenance" `Quick
             test_operator_snapshot_default_route_exposes_provenance;
           test_case "operator digest default route exposes provenance" `Quick

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -460,6 +460,42 @@ let test_operator_snapshot_default_route_hydrates_first_success () =
        (contains_substring source
           "then cached_surface_json operator_snapshot_cache"))
 
+let test_dashboard_query_cache_segment_normalizes_missing_values () =
+  check string "missing none" "missing"
+    (Server_dashboard_http_core_cache.dashboard_query_cache_segment None);
+  check string "missing blank" "missing"
+    (Server_dashboard_http_core_cache.dashboard_query_cache_segment (Some "  "));
+  check string "trimmed value" "keeper-a"
+    (Server_dashboard_http_core_cache.dashboard_query_cache_segment (Some " keeper-a "))
+
+let test_dashboard_query_cache_key_partitions_route_params () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Workspace_utils.default_config dir in
+      let session_a =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key config "session"
+          [ ("actor", Some "default"); ("session", Some "session-a") ]
+      in
+      let session_b =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key config "session"
+          [ ("actor", Some "default"); ("session", Some "session-b") ]
+      in
+      let actor_b =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key config "session"
+          [ ("actor", Some "keeper-b"); ("session", Some "session-a") ]
+      in
+      check bool "session_id partitions route cache" true
+        (not (String.equal session_a session_b));
+      check bool "actor partitions route cache" true
+        (not (String.equal session_a actor_b));
+      check string "deterministic key shape"
+        (Printf.sprintf
+           "session:%s:default:actor=default:session=session-a"
+           config.base_path)
+        session_a)
+
 let test_operator_snapshot_default_route_exposes_provenance () =
   with_test_env @@ fun ~env ~sw ~config ->
   let state =
@@ -1412,6 +1448,10 @@ let () =
             test_dashboard_shell_http_json_prefers_light_last_good_while_prewarming;
           test_case "operator snapshot hydrates on first default request" `Quick
             test_operator_snapshot_default_route_hydrates_first_success;
+          test_case "dashboard query cache segment normalizes missing values" `Quick
+            test_dashboard_query_cache_segment_normalizes_missing_values;
+          test_case "dashboard query cache key partitions route params" `Quick
+            test_dashboard_query_cache_key_partitions_route_params;
           test_case "operator snapshot default route exposes provenance" `Quick
             test_operator_snapshot_default_route_exposes_provenance;
           test_case "operator digest default route exposes provenance" `Quick

--- a/test/test_dashboard_http_core.ml
+++ b/test/test_dashboard_http_core.ml
@@ -522,10 +522,20 @@ let test_dashboard_query_cache_key_encodes_delimiter_values () =
         Server_dashboard_http_core_cache.dashboard_query_cache_key config "session"
           [ ("actor", Some "default"); ("session", Some "missing") ]
       in
+      let missing_actor =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key config "session"
+          [ ("actor", None); ("session", Some "session-a") ]
+      in
+      let explicit_default_actor =
+        Server_dashboard_http_core_cache.dashboard_query_cache_key config "session"
+          [ ("actor", Some "default"); ("session", Some "session-a") ]
+      in
       check bool "delimiter-bearing values do not collide" true
         (not (String.equal actor_delimiter session_delimiter));
       check bool "literal missing does not collide with absent value" true
-        (not (String.equal missing_session literal_missing_session)))
+        (not (String.equal missing_session literal_missing_session));
+      check bool "missing actor does not collide with explicit default actor" true
+        (not (String.equal missing_actor explicit_default_actor)))
 
 let test_operator_snapshot_default_route_exposes_provenance () =
   with_test_env @@ fun ~env ~sw ~config ->


### PR DESCRIPTION
## Summary
- partition dashboard route caches by actor for briefing surfaces
- partition session cache by session_id and actor
- bypass the route cache for forced briefing-section refreshes so force remains a real recompute signal
- add unit coverage for query cache segment normalization and route-param partitioning

## Validation
- ocamlformat --check lib/server/server_routes_http_routes_dashboard.ml lib/server/server_dashboard_http_core_cache.ml lib/server/server_dashboard_http_core_cache.mli test/test_dashboard_http_core.ml
- git diff --check

Local Dune build intentionally not run; Dune/build/test verification is delegated to GitHub CI per operator instruction.