### PR TITLE
fix(dashboard): resolve 4 TypeScript typecheck blockers (#22346)

### DIFF
--- a/dashboard/src/components/runtime-environment-editor.ts
+++ b/dashboard/src/components/runtime-environment-editor.ts
@@ -3,7 +3,6 @@ import { Save } from 'lucide-preact'
 import { useMemo, useState } from 'preact/hooks'
 import {
   deleteRuntimeTomlKey,
-  deleteRuntimeTomlSection,
   parseRuntimeTomlEnvironment,
   setRuntimeTomlBindingField,
   setRuntimeTomlDefault,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -14,7 +14,6 @@ import type { DashboardToolInventoryItem, LogEntry, RuntimeDefaultsResponse } fr
 import { DashboardMain } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
-import { mockKeepers } from '../store.mock'
 
 const MOCK_RUNTIME_PATH = '/tmp/.masc/config/runtime.toml'
 import { dashboardLoading } from '../store'

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -472,14 +472,6 @@ export function SettingsSurface() {
   const [compactAt, setCompactAt] = useState(85)
   const [autoCompact, setAutoCompact] = useState(true)
 
-
-  const runtimeStats = {
-    ids: runtimeDefaults?.runtimes.length ?? 0,
-    providers: new Set(runtimeDefaults?.runtimes.map(r => r.provider) ?? []).size,
-    models: new Set(runtimeDefaults?.runtimes.map(r => r.model) ?? []).size,
-    default: runtimeDefaults?.default_runtime_id ?? '—',
-  }
-
   useEffect(() => {
     let active = true
     void (async () => {

--- a/dashboard/src/lib/runtime-toml-config.test.ts
+++ b/dashboard/src/lib/runtime-toml-config.test.ts
@@ -188,7 +188,7 @@ sangsu = "runpod_mtp.qwen"
     const next = setRuntimeTomlModelField(sourceText, 'qwen', 'max-context', null)
     const env = parseRuntimeTomlEnvironment(next)
     
-    expect(env.models[0].maxContext).toBeNull()
+    expect(env.models[0]?.maxContext).toBeNull()
     expect(next).not.toContain('max-context =')
   })
 


### PR DESCRIPTION
본인 #22346 review(코멘트 4807012292, head 99f7be524f0)가 지적한 Dashboard typecheck 4개 blocker fix: (1) deleteRuntimeTomlSection unused import 제거, (2) runtimeStats unused 선언 제거, (3) mockKeepers 해석불가/unused import 제거, (4) env.models[0] optional chaining. 본인 브랜치 base stacked fix — 본인 merge 결정. CI typecheck로 최종 검증.