### PR TITLE
fix(dashboard): align 1011 websocket reconnect test

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -673,7 +673,7 @@ describe('dashboard websocket route subscriptions', () => {
     expect(mockSockets).toHaveLength(1)
   })
 
-  it('stops reconnecting after a fatal 1011 server error close', async () => {
+  it('reconnects after a transient 1011 server error close', async () => {
     vi.useFakeTimers()
     installWebSocketMocks()
 
@@ -693,7 +693,8 @@ describe('dashboard websocket route subscriptions', () => {
 
     expect(dashboardWsConnected.value).toBe(false)
     expect(dashboardWsReady.value).toBe(false)
-    expect(mockSockets).toHaveLength(1)
+    expect(mockSockets).toHaveLength(2)
+    expect(mockSockets[1]!.url).toBe('ws://localhost:3000/ws')
   })
 
   it('stops reconnecting after a fatal 1002 protocol error close', async () => {


### PR DESCRIPTION
## Summary
- Update dashboard-ws 1011 close test to match the current reconnect contract from #22368.
- Keep 1002/1003/1008 fatal-close expectations unchanged.

## Evidence
- Main CI Dashboard failed on run 28222429850: src/dashboard-ws.test.ts expected one mock socket for 1011, but implementation now reconnects.
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/dashboard-ws.test.ts
- pnpm --dir dashboard run typecheck
- git diff --check

## Notes
- Local Dune build intentionally not run; CI is the build authority for Dune per operator instruction.