### PR TITLE
fix(keeper): type empty task claims as no work

### DIFF
--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -137,7 +137,9 @@ let classify_tool_progress_with_outcome name outcome =
          { reason = No_eligible_tasks { scope_excluded_count; all_goals_excluded } }) ->
     Streak_reset_and_empty_queue_sleep
       { reason = No_eligible_tasks { scope_excluded_count; all_goals_excluded } }
-  | Some (Keeper_tool_outcome.No_progress { reason = Resource_conflict _ | No_work_available })
+  | Some (Keeper_tool_outcome.No_progress { reason = No_work_available }) ->
+    Streak_reset_and_empty_queue_sleep { reason = No_work_to_report }
+  | Some (Keeper_tool_outcome.No_progress { reason = Resource_conflict _ })
   | Some (Keeper_tool_outcome.Progress | Keeper_tool_outcome.Error _)
   | None -> effect_of_progress_class (classify_tool_progress name)
 ;;

--- a/lib/keeper/keeper_tool_progress.mli
+++ b/lib/keeper/keeper_tool_progress.mli
@@ -39,8 +39,9 @@ val effect_of_progress_class : tool_progress_class -> turn_effect
 
 (** Route a tool call through typed-outcome classification.
 
-    When [outcome] is [Some (No_progress (No_eligible_tasks ...))], the result
-    is [Streak_reset_and_empty_queue_sleep]. Other outcomes fall back to
+    [No_progress (No_eligible_tasks ...)] and [No_progress No_work_available]
+    both mean the keeper has no claimable work right now, so they produce
+    [Streak_reset_and_empty_queue_sleep]. Other outcomes fall back to
     [effect_of_progress_class (classify_tool_progress name)]. *)
 val classify_tool_progress_with_outcome
   : string -> Keeper_tool_outcome.t option -> turn_effect

--- a/lib/keeper/keeper_tool_task_runtime.ml
+++ b/lib/keeper/keeper_tool_task_runtime.ml
@@ -780,6 +780,18 @@ let handle_keeper_task_tool
                        ; all_goals_excluded
                        }
                  }) )
+      | Workspace.Claim_next_no_unclaimed ->
+        Some
+          ( "typed_outcome"
+          , Keeper_tool_outcome.to_json
+              (Keeper_tool_outcome.No_progress
+                 { reason = Keeper_tool_outcome.No_work_available }) )
+      | Workspace.Claim_next_error e ->
+        Some
+          ( "typed_outcome"
+          , Keeper_tool_outcome.to_json
+              (Keeper_tool_outcome.Error
+                 { reason = Printf.sprintf "keeper_task_claim rejected: %s" e }) )
       | _ -> None
     in
     Yojson.Safe.to_string

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -4,6 +4,7 @@ module KAR = Masc.Keeper_agent_run
 module KTN = Keeper_tool_name
 module KTP = Masc.Keeper_tool_progress
 module KUS = Masc.Keeper_unified_metrics_support
+module Outcome = Keeper_tool_outcome
 
 (* RFC-0232: a budget-exhausted (Continuation_checkpoint) turn substitutes a
    synthetic continuation notice for the reply text. That text is display-only;
@@ -177,6 +178,20 @@ let test_material_progress_does_not_special_case_worktree_reuse_text () =
           Branch already checked out: feature/task\n")
 ;;
 
+let test_no_work_outcome_maps_to_empty_queue_sleep () =
+  let turn_effect =
+    KTP.classify_tool_progress_with_outcome
+      "keeper_task_claim"
+      (Some (Outcome.No_progress { reason = Outcome.No_work_available }))
+  in
+  match turn_effect with
+  | KTP.Streak_reset_and_empty_queue_sleep { reason = KTP.No_work_to_report } -> ()
+  | KTP.Streak_increment -> fail "expected empty queue sleep, got streak increment"
+  | KTP.Streak_reset -> fail "expected empty queue sleep, got streak reset"
+  | KTP.Streak_reset_and_empty_queue_sleep { reason = KTP.No_eligible_tasks _ } ->
+    fail "expected no-work reason"
+;;
+
 let () =
   run
     "keeper_unified_claim_progress"
@@ -205,6 +220,10 @@ let () =
             "material progress does not special-case worktree reuse text"
             `Quick
             test_material_progress_does_not_special_case_worktree_reuse_text
+        ; test_case
+            "no-work typed outcome maps to empty queue sleep"
+            `Quick
+            test_no_work_outcome_maps_to_empty_queue_sleep
         ] )
     ; ( "preview_precedence"
       , [ test_case

--- a/test/test_keeper_wip_admission.ml
+++ b/test/test_keeper_wip_admission.ml
@@ -224,6 +224,39 @@ let test_keeper_task_claim_wip_cap_reports_claim_admission () =
          (Astring.String.is_infix ~affix:"do not create unrelated repos"
             (json |> U.member "result" |> U.to_string)))
 
+let test_keeper_task_claim_no_unclaimed_emits_no_work_outcome () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let payload =
+         Task_runtime.handle_keeper_task_tool ~config
+           ~meta:
+             (match
+                Masc_test_deps.meta_of_json_fixture
+                  (`Assoc
+                    [ "name", `String "keeper-empty-queue"
+                    ; "agent_name", `String "keeper-empty-queue-agent"
+                    ; "trace_id", `String "trace-empty-queue"
+                    ; "active_goal_ids", `List []
+                    ])
+              with
+              | Ok meta -> meta
+              | Error err -> fail ("meta_of_json_fixture failed: " ^ err))
+           ~name:"keeper_task_claim" ~args:(`Assoc [])
+       in
+       let json = Yojson.Safe.from_string payload in
+       check string "result"
+         "No unclaimed tasks. ACTION: Stop task-checking — nothing to claim."
+         (json |> U.member "result" |> U.to_string);
+       let typed = json |> U.member "typed_outcome" in
+       check string "typed kind" "No_progress"
+         (typed |> U.member "kind" |> U.to_string);
+       check string "reason kind" "No_work_available"
+         (typed |> U.member "reason" |> U.member "kind" |> U.to_string))
+
 let test_active_items_only_include_claimed_or_in_progress () =
   let tasks =
     [ task
@@ -310,6 +343,8 @@ let () =
             test_scope_of_task_uses_repo_goal_and_title_category
         ; test_case "keeper_task_claim reports WIP claim admission cap" `Quick
             test_keeper_task_claim_wip_cap_reports_claim_admission
+        ; test_case "keeper_task_claim no-unclaimed emits no-work outcome" `Quick
+            test_keeper_task_claim_no_unclaimed_emits_no_work_outcome
         ; test_case "active items include active WIP only" `Quick
             test_active_items_only_include_claimed_or_in_progress
         ; test_case "goalless task exempt from goal cap" `Quick


### PR DESCRIPTION
## Summary

- emit `typed_outcome = No_progress No_work_available` when `keeper_task_claim` finds no unclaimed tasks
- emit typed `Error` for claim errors so failed claim attempts do not retain claim-success semantics
- map `No_work_available` through the existing empty-queue sleep helper and add focused regression coverage

## Runtime Evidence

- live keeper board posts `p-a97fe5d55090db92733ea47f1575d19d`, `p-d697109f3adedf96b134595f90606853`, and `p-1292df654de405d2715497f8c99e4fea` showed keepers repeatedly reporting no claimable work / blocked task claiming while continuing to call task tools
- `/Users/dancer/me/.masc/keepers/idealist.json` had no durable `last_blocker` despite repeated “no unclaimed tasks / push blocked” turns
- current code already demotes typed `No_progress` claims in `Keeper_unified_turn_success.claim_bound_work`; the missing piece was the producer leaving `Claim_next_no_unclaimed` untyped

## Verification

- `ocamlformat --check lib/keeper/keeper_tool_task_runtime.ml lib/keeper/keeper_tool_progress.ml lib/keeper/keeper_tool_progress.mli test/test_keeper_wip_admission.ml test/test_keeper_unified_claim_progress.ml`
- `git diff --check`

Blocked locally:

- `scripts/dune-local.sh exec test/test_keeper_wip_admission.exe`
- `scripts/dune-local.sh exec test/test_keeper_unified_claim_progress.exe`

The first focused test attempt was blocked by the repo guard while another session held a bare Dune build:

```text
[dune-local] live Dune process outside scripts/dune-local.sh detected:
[dune-local]   11616 11539 dune build --root . test/test_cdal_evidence_gate.exe
[dune-local] refusing to start another local build while the machine-wide Dune lock is bypassed
```

After the syntax-only fix, the focused test commands queued behind a long-running repo wrapper job and were stopped to avoid sitting on the lock:

```text
[dune-local] waiting for lock /tmp/me-dune-local.lock
[dune-local] Dune lock holder(s):
[dune-local]   19941 74291 S    28:16 lockf -k /tmp/me-dune-local.lock /usr/bin/env MASC_DUNE_LOCK_HELD=1 /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/22333/scripts/dune-local.sh runtest
```
