### PR TITLE
fix(evidence): P0 parse_file_path fail-open + P1 rename/magic/mli + P2 negatives (#22348)

### DIFF
--- a/lib/evidence_ref.ml
+++ b/lib/evidence_ref.ml
@@ -11,8 +11,15 @@ type t =
   | Trace_ref of trace_kind * string
   | File_path of string
 
+(* Minimum length of a git "short" commit id (git's default abbrev). Hex
+   strings shorter than this are not treated as commit refs. *)
 let min_short_commit_hex_len = 7
+(* Maximum length of a commit hex id. 64 = SHA-256 hex; git SHA-1 is 40.
+   Accept the longer form so SHA-256 repos are covered. *)
 let max_commit_hex_len = 64
+(* Upper bound on a plausible file extension (e.g. final segment of
+   ".tar.gz"). Bounds the plausible-extension check in
+   [has_plausible_extension]. *)
 let max_file_extension_len = 12
 
 let starts_with ~prefix value =
@@ -151,9 +158,39 @@ let has_plausible_extension value =
     && String.for_all is_file_ref_char value
     && String.for_all is_extension_char (String.sub value (idx + 1) ext_len)
 
+let is_absolute_path value =
+  String.length value > 0 && Char.equal value.[0] '/'
+
+let contains_parent_segment value =
+  (* Reject ".." as a path segment (parent-dir traversal). Matched only at
+     a segment boundary so a literal ".." inside a file name (e.g. "v1..0")
+     is not falsely rejected. *)
+  let len = String.length value in
+  let rec scan i =
+    if i + 2 > len then false
+    else if
+      Char.equal value.[i] '.'
+      && (i + 1 < len)
+      && Char.equal value.[i + 1] '.'
+      && (i = 0 || Char.equal value.[i - 1] '/')
+      && (i + 2 = len || Char.equal value.[i + 2] '/')
+    then true
+    else scan (i + 1)
+  in
+  scan 0
+
 let parse_file_path value =
+  (* P0 (#22348 review): a concrete artifact reference must not be an
+     absolute path or contain a parent-dir ("..") segment — both are
+     gate-bypass shapes, not legitimate relative artifact refs. NOTE: this
+     is shape validation only; the deeper "candidate vs validated"
+     separation the review asks for (so even a/b and x.txt require a
+     base-path-resolved validated variant before the gate accepts them) is
+     deferred as a follow-up. *)
   if
-    String.for_all is_file_ref_char value
+    not (is_absolute_path value)
+    && not (contains_parent_segment value)
+    && String.for_all is_file_ref_char value
     && has_payload_char value
     && (contains_path_separator value || has_plausible_extension value)
   then Some (File_path value)
@@ -199,4 +236,9 @@ let to_string = function
   | Trace_ref (kind, payload) -> trace_kind_to_string kind ^ ":" ^ payload
   | File_path value -> value
 
-let is_concrete_string value = Option.is_some (of_string value)
+(* Formerly [is_concrete_string]. Renamed (#22348 review P1): the typed
+   variant only recognizes a *shape* (url / commit / pr / file_path / …)
+   — it does NOT semantically validate that the value is a real, existing,
+   base-path-resolved artifact. Callers must not read "true" as "this is a
+   concrete, trusted evidence reference". *)
+let recognizes_evidence_shape value = Option.is_some (of_string value)

--- a/lib/evidence_ref.mli
+++ b/lib/evidence_ref.mli
@@ -20,7 +20,14 @@ type t =
 
 val of_string : string -> t option
 val to_string : t -> string
-val is_concrete_string : string -> bool
+val recognizes_evidence_shape : string -> bool
+(** [recognizes_evidence_shape value] is true when [value] matches a known
+    evidence-reference SHAPE (url / file_uri / pr / commit / trace_ref /
+    file_path). It is a SHAPE HEURISTIC ONLY — it does NOT semantically
+    validate that the value is a real, existing, base-path-resolved
+    artifact. Callers must not read [true] as "this is concrete, trusted
+    evidence"; resolve and validate against the artifact store / base path
+    before gating on it. (Renamed from [is_concrete_string], #22348 review.) *)
 
 val boundary_match : haystack:string -> needle:string -> start:int -> bool
 (** [boundary_match ~haystack ~needle ~start] is true when [needle] appears

--- a/test/test_cdal_evidence_gate.ml
+++ b/test/test_cdal_evidence_gate.ml
@@ -234,6 +234,9 @@ let test_evidence_ref_parser_ssot () =
     ; "bare file URI", "file://"
     ; "bare trace", "trace:"
     ; "bare path separator", "/"
+    ; "absolute path", "/etc/passwd"
+    ; "parent-dir traversal", "../../etc/passwd"
+    ; "parent-dir mid-segment", "logs/../../etc/passwd"
     ]
 
 let test_blank_required_evidence_rejects () =


### PR DESCRIPTION
본인 재재리뷰(4807023700) P0+P1+P2 중 핵심 fix: P0 parse_file_path에 절대경로/parent-traversal(..) 거부 추가(fail-open 닫기), P1 magic number 주석(7=git abbrev, 64=SHA-256, 12=extension) + is_concrete_string→recognizes_evidence_shape rename + mli에 'shape heuristic only, semantic 검증 아님' 명시, P2 negative test(절대/..traversal/mid-segment). 로컬 test_cdal_evidence_gate 17 테스트 통과. **후속 권고(큼, 본인 결정)**: File_path candidate/validated variant 분리(a/b, x.txt too-permissive 근본 해결), SSOT(notes_mention String_util.find_substring, contract_tokens fold_left+String_util tokenizer), 전체 negative suite(deadbeef commit, URL query boundary, UTF-8). 본인 브랜치 base stacked fix.