### PR TITLE
fix(keeper): require evidence for internal prose loops

### DIFF
--- a/docs/rfc/RFC-keeper-proactive-wake-actionability-invariant.md
+++ b/docs/rfc/RFC-keeper-proactive-wake-actionability-invariant.md
@@ -54,7 +54,7 @@ keeper는 메타-자각 상태("I need to stop repeating", "Acknowledged. I was 
 ### 왜 안전망이 안 잡았나
 - 무에러 text 턴은 `terminal_reason: success`(`keeper_unified_metrics_decision.ml:105`)로 종료 → 실패 카운터/에스컬레이션 미발동.
 - `is_noop_cycle = not has_text && ...`(`keeper_unified_metrics_support.ml:285`)은 cooldown multiplier 전용이며, text 턴마다 `consecutive_noop_count`를 0으로 리셋.
-- 무진행 loop detector(`keeper_no_progress_loop_detector.ml`)는 streak 10에 latch하지만 — `classify_delivery`(`keeper_unified_turn_success.ml:110-118`)가 `tools=[] && has_visible_text=true → User_facing → delivery_requires_evidence=false → made_progress=true → streak 리셋`. 자율 no-op text 턴이 매번 진행으로 오분류돼 **영영 latch하지 못한다**.
+- 무진행 loop detector(`keeper_no_progress_loop_detector.ml`)는 streak 10에 latch하지만 — R2a/R3 이전 `classify_delivery`(`keeper_unified_turn_success.ml`)는 `tools=[] && has_visible_text=true → User_facing → delivery_requires_evidence=false → made_progress=true → streak 리셋`이었다. 자율/내부 no-op text 턴이 매번 진행으로 오분류돼 **영영 latch하지 못했다**. 최신 구조는 `reply_delivery`를 닫힌 sum으로 분리해 내부 keeper-cycle prose를 `Internal_prose`로 분류한다.
 - RFC-0246 wake-tombstone은 외부 wake 진입점(`keeper_registry.ml` `wakeup`/`board_wakeup_allowed`)만 게이트하고 **self-cadence `should_run` 경로는 게이트하지 않는다**(검증: `keeper_world_observation.ml`/`keeper_heartbeat_loop_scheduling.ml`에 tombstone 참조 0건).
 
 ## 3. Design
@@ -101,9 +101,9 @@ let verification_drives o = o.pending_verification_count > 0 && affordance_can_m
 
 candidate의 "is_noop_cycle has_text blind spot 수정" 전제는 **반증됨**: (i) `is_noop_cycle`은 cooldown 전용이라 고치면 livelock을 늦출 뿐(금지 cap); (ii) loop detector의 `turn_made_progress`(`keeper_no_progress_loop_detector.ml:57`)는 has_text를 입력으로 받지 않아 이미 올바르다.
 
-진짜 잔존 blind spot은 `classify_delivery`의 `User_facing` 면제다. **구조적 수정**: 닫힌 `turn_delivery` sum을 확장해 *자율(self-cadence, 외부 프롬프트 없는)* 무도구 prose 턴을 evidence-불요 면제에서 분리(예: `Autonomous_prose` variant). `delivery_requires_evidence`는 exhaustive match(no catch-all)라 새 variant가 분류를 컴파일 강제.
+진짜 잔존 blind spot은 `classify_delivery`의 `User_facing` 면제다. **구조적 수정**: 닫힌 `turn_delivery` sum과 `reply_delivery` sum을 함께 사용해 *외부 표면에 실제로 전달된 reactive reply*만 evidence-불요 면제로 남긴다. unified keeper-cycle이 생성한 decision/metrics text는 pending scope message가 있어도 외부 lane을 clear하지 못하므로 `Internal_prose`로 분류하고 evidence를 요구한다. `delivery_requires_evidence`는 exhaustive match(no catch-all)라 새 variant가 분류를 컴파일 강제한다.
 
-**False-positive 가드**: operator-mention에 대한 정당한 no-tool text 응답(`Reply_to_external`)은 면제 유지. 분기는 *외부 프롬프트 부재*에 게이팅.
+**False-positive 가드**: operator-mention에 대한 정당한 no-tool text 응답(`Externally_delivered`)은 면제 유지. 분기는 *프롬프트 존재*가 아니라 *reply delivery route*에 게이팅한다.
 
 ### R2b (defense-in-depth, MANDATORY gap) — wire wake-tombstone into self-cadence should_run
 
@@ -180,7 +180,7 @@ RFC-0246 tombstone은 외부 wake 두 경로(`keeper_registry.ml:364 Heartbeat`,
 |---|---|
 | `affordance_can_mutate` exhaustive match가 `tools_for_affordance`와 drift할 위험 → T2가 pin | High |
 | 845 미포함 시 heartbeat-loop:520 2차 livelock 잔존 | High |
-| R2a `wake_origin`을 `classify_delivery`까지 전달하는 plumbing 비용 | Medium |
+| R2a/R3 `reply_delivery` route가 새 direct-turn 소비자와 drift할 위험 | Medium |
 | orphan surfacer gauge vs Dashboard_attention 선택 | Medium |
 | `turn_delivery` 분할이 다른 소비자에 미치는 영향(exhaustive match가 안전망) | Medium |
 | latch latency ~17분(threshold 고정) — R1g primary라 수용 | High |

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -90,15 +90,20 @@ type turn_delivery =
        no peer/claim tool and no visible text *)
   | User_facing
     (* RFC-0294 R2a [Reply_to_external] concept: non-empty visible reply on a
-       REACTIVE turn — an external prompt is present (pending mention /
-       board-event / scope-message). Exempt from evidence: replying to an
-       external prompt is itself the work. *)
-  | Autonomous_prose
-    (* RFC-0294 R2a: non-empty visible reply on an AUTONOMOUS (self-cadence, no
-       external prompt) turn. Requires evidence — a keeper that wakes on its own
-       clock and only emits prose ("nothing to do") is not progress, and was the
-       residual no-progress blind spot after R1g. *)
+       REACTIVE turn whose reply is externally delivered to the prompting
+       surface. Exempt from evidence: replying to an external prompt is itself
+       the work only when the reply is actually sent back. *)
+  | Internal_prose
+    (* Non-empty prose that is not an externally delivered reactive reply.
+       This includes scheduled-autonomous prose and keeper-cycle internal
+       decision text produced while stale scope messages are pending. Requires
+       evidence: internal prose alone neither clears the external lane nor
+       mutates durable workspace state. *)
   | Task_claim (* task-claim tool *)
+
+type reply_delivery =
+  | Internal_only
+  | Externally_delivered
 
 (* Classify from observable facts. Order is significant: a turn that calls a
    peer-surface tool is [Peer_only] even if it also produced text, because the
@@ -116,33 +121,34 @@ type turn_delivery =
    exactly the "posts to peers without evidence" case RFC-0239 targets. The set
    is pinned in test_no_progress_loop_detector so any axis change forces a
    conscious no-progress review. *)
-let classify_delivery ~is_autonomous ~tools ~has_visible_text =
+let classify_delivery ~is_autonomous ~reply_delivery ~tools ~has_visible_text =
   if Keeper_tool_capability_axis.(supports_any Board_activity tools)
   then Peer_only
   else if Keeper_tool_capability_axis.(supports_any Claim_task tools)
   then Task_claim
   else if has_visible_text
-  then if is_autonomous then Autonomous_prose else User_facing
+  then
+    match is_autonomous, reply_delivery with
+    | false, Externally_delivered -> User_facing
+    | (true | false), Internal_only | true, Externally_delivered -> Internal_prose
   else Peer_only
 ;;
 
-let classify_turn_delivery ~is_autonomous result =
+let classify_turn_delivery ~is_autonomous ~reply_delivery result =
   classify_delivery
     ~is_autonomous
+    ~reply_delivery
     ~tools:(Keeper_agent_result.tool_names result)
     ~has_visible_text:(String.trim result.Keeper_agent_run.response_text <> "")
 ;;
 
-(* A peer-only/silent turn, or an autonomous prose-only turn, must show durable
-   evidence to count as progress; a reactive user-facing reply or a task claim is
-   exempt. Preserves the pre-RFC-0276 surface mapping (peer/broadcast/silent ->
-   true; reactive visible reply/task claim -> false) and adds the RFC-0294 R2a
-   split: an [Autonomous_prose] turn (self-cadence, no external prompt, prose
-   only) now requires evidence. Exhaustive, no [_ ->] catch-all (CLAUDE.md
+(* A peer-only/silent turn, or internal prose-only turn, must show durable
+   evidence to count as progress; an externally delivered reactive user-facing
+   reply or a task claim is exempt. Exhaustive, no [_ ->] catch-all (CLAUDE.md
    anti-pattern #4): a new [turn_delivery] variant must be classified here at
    compile time. *)
 let delivery_requires_evidence = function
-  | Peer_only | Autonomous_prose -> true
+  | Peer_only | Internal_prose -> true
   | User_facing | Task_claim -> false
 ;;
 
@@ -209,18 +215,21 @@ let apply_loop_detectors ~config ~observation updated_meta result =
   (* [Task_claim] is exempt only when a claim bound work; a claim that typed
      [No_progress] (e.g. No_eligible_tasks) now requires evidence and so accrues
      the streak. Other surfaces keep the exhaustive name-based mapping.
-     RFC-0294 R2a: the autonomy of the cycle (external prompt absent) splits a
-     prose-only reply into [Autonomous_prose] (requires evidence) vs the reactive
-     [User_facing] reply (exempt). Derived from the same observation channel the
-     budget override already reads. *)
+     RFC-0294 R2a/R3: a prose-only reply is exempt only when it is a delivered
+     reply to an external prompt. This success handler runs the unified keeper
+     cycle, whose visible text is written to internal decision/metrics artifacts
+     and is not appended to keeper_chat. A pending scope message therefore cannot
+     make internal prose count as progress; otherwise a stale owner line can keep
+     waking the keeper while every text-only response both fails to clear the
+     lane and resets the no-progress streak. *)
   let is_autonomous =
     Keeper_unified_metrics_support.is_scheduled_autonomous_cycle_of_observation
       observation
   in
   let surface_requires_evidence =
-    match classify_turn_delivery ~is_autonomous result with
+    match classify_turn_delivery ~is_autonomous ~reply_delivery:Internal_only result with
     | Task_claim -> not (claim_bound_work calls_with_outcomes)
-    | (Peer_only | User_facing | Autonomous_prose) as delivery ->
+    | (Peer_only | User_facing | Internal_prose) as delivery ->
       delivery_requires_evidence delivery
   in
   let made_progress =
@@ -265,8 +274,12 @@ module For_testing = struct
   type nonrec turn_delivery = turn_delivery =
     | Peer_only
     | User_facing
-    | Autonomous_prose
+    | Internal_prose
     | Task_claim
+
+  type nonrec reply_delivery = reply_delivery =
+    | Internal_only
+    | Externally_delivered
 
   let classify_delivery = classify_delivery
   let delivery_requires_evidence = delivery_requires_evidence

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -19,14 +19,19 @@ module For_testing : sig
       self-declared delivery header as the no-progress detector input). *)
   type turn_delivery =
     | Peer_only
-    | User_facing  (** reactive visible reply (external prompt present); exempt *)
-    | Autonomous_prose
-        (** RFC-0294 R2a: self-cadence prose-only turn (no external prompt);
-            requires evidence *)
+    | User_facing  (** externally delivered reactive visible reply; exempt *)
+    | Internal_prose
+        (** Visible prose not externally delivered to the prompting surface;
+            requires evidence. *)
     | Task_claim
+
+  type reply_delivery =
+    | Internal_only
+    | Externally_delivered
 
   val classify_delivery
     :  is_autonomous:bool
+    -> reply_delivery:reply_delivery
     -> tools:string list
     -> has_visible_text:bool
     -> turn_delivery

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -11,6 +11,7 @@
 module D = Masc.Keeper_no_progress_loop_detector
 module Metrics = Masc.Otel_metric_store
 module Success = Masc.Keeper_unified_turn_success.For_testing
+module Support = Masc.Keeper_unified_metrics_support
 module WO = Masc.Keeper_world_observation
 module Cap = Masc.Keeper_tool_capability_axis
 
@@ -255,21 +256,31 @@ let test_no_progress_board_post_accrues_streak () =
 let delivery_label = function
   | Success.Peer_only -> "peer_only"
   | Success.User_facing -> "user_facing"
-  | Success.Autonomous_prose -> "autonomous_prose"
+  | Success.Internal_prose -> "internal_prose"
   | Success.Task_claim -> "task_claim"
 
-(* [classify] is the reactive cycle (external prompt present): a prose-only reply
-   classifies as [User_facing] (exempt), matching the pre-RFC-0294 mapping. The
-   autonomous (self-cadence, no external prompt) cycle is [classify_auto], which
-   routes a prose-only reply to [Autonomous_prose] (requires evidence). The
-   tool-precedence cases (peer/claim dominate text) are autonomy-independent. *)
-let classify ~tools ~has_visible_text =
+(* [classify_delivered] is the reactive cycle whose reply is externally delivered
+   to the prompting surface: a prose-only reply classifies as [User_facing]
+   (exempt). [classify_internal] is the unified keeper-cycle path, where visible
+   text is an internal decision/metrics artifact; prose-only output is
+   [Internal_prose] and requires evidence even when a stale scope message made
+   the observation channel reactive. The autonomous self-cadence path is
+   [classify_auto]. Tool-precedence cases (peer/claim dominate text) are
+   delivery-independent. *)
+let classify_delivered ~tools ~has_visible_text =
   delivery_label
-    (Success.classify_delivery ~is_autonomous:false ~tools ~has_visible_text)
+    (Success.classify_delivery ~is_autonomous:false
+       ~reply_delivery:Success.Externally_delivered ~tools ~has_visible_text)
+
+let classify_internal ~is_autonomous ~tools ~has_visible_text =
+  delivery_label
+    (Success.classify_delivery ~is_autonomous
+       ~reply_delivery:Success.Internal_only ~tools ~has_visible_text)
 
 let classify_auto ~tools ~has_visible_text =
   delivery_label
-    (Success.classify_delivery ~is_autonomous:true ~tools ~has_visible_text)
+    (Success.classify_delivery ~is_autonomous:true
+       ~reply_delivery:Success.Internal_only ~tools ~has_visible_text)
 
 let test_classify_delivery_mapping () =
   let claim_tool = List.hd Cap.claim_task_tool_names in
@@ -306,12 +317,12 @@ let test_classify_delivery_mapping () =
     (fun t ->
       Alcotest.(check string)
         (Printf.sprintf "peer tool %s -> peer_only" t) "peer_only"
-        (classify ~tools:[ t ] ~has_visible_text:false);
+        (classify_delivered ~tools:[ t ] ~has_visible_text:false);
       Alcotest.(check string)
         (Printf.sprintf "peer tool %s + text -> peer_only (tools dominate text)"
            t)
         "peer_only"
-        (classify ~tools:[ t ] ~has_visible_text:true))
+        (classify_delivered ~tools:[ t ] ~has_visible_text:true))
     expected_peer_tools;
   (* Multi-signal precedence (RFC-0276 §3.2 total derivation): a turn carrying
      both a peer tool and a claim tool, plus text, is Peer_only — peer-posting
@@ -319,23 +330,31 @@ let test_classify_delivery_mapping () =
      inferred_tool_surface if/else-if order so the anti-thrash invariant cannot
      flip to exempt on a multi-signal turn. *)
   Alcotest.(check string) "peer + claim + text -> peer_only" "peer_only"
-    (classify ~tools:[ "keeper_board_post"; claim_tool ] ~has_visible_text:true);
+    (classify_delivered ~tools:[ "keeper_board_post"; claim_tool ]
+       ~has_visible_text:true);
   (* Claim tool is exempt (claiming is progress, RFC-0239); claim dominates
      text. *)
   Alcotest.(check string) "claim tool -> task_claim" "task_claim"
-    (classify ~tools:[ claim_tool ] ~has_visible_text:false);
+    (classify_delivered ~tools:[ claim_tool ] ~has_visible_text:false);
   Alcotest.(check string) "claim + text -> task_claim (claim dominates text)"
     "task_claim"
-    (classify ~tools:[ claim_tool ] ~has_visible_text:true);
-  (* No peer/claim tool + visible text, REACTIVE cycle -> user-facing reply
-     (exempt): replying to an external prompt is the work. *)
-  Alcotest.(check string) "no tool + text (reactive) -> user_facing" "user_facing"
-    (classify ~tools:[] ~has_visible_text:true);
+    (classify_delivered ~tools:[ claim_tool ] ~has_visible_text:true);
+  (* No peer/claim tool + visible text, externally-delivered REACTIVE cycle ->
+     user-facing reply (exempt): replying to an external prompt is the work only
+     when the reply is sent back to that surface. *)
+  Alcotest.(check string)
+    "no tool + text (delivered reactive) -> user_facing" "user_facing"
+    (classify_delivered ~tools:[] ~has_visible_text:true);
+  (* Same reactive observation facts on the unified keeper-cycle path are
+     internal prose, not user-facing: the text is written to internal
+     decision/metrics artifacts and does not clear the prompting lane. *)
+  Alcotest.(check string)
+    "no tool + text (internal reactive) -> internal_prose" "internal_prose"
+    (classify_internal ~is_autonomous:false ~tools:[] ~has_visible_text:true);
   (* RFC-0294 R2a: same surface facts on an AUTONOMOUS cycle (no external prompt)
-     -> autonomous_prose (requires evidence). The autonomy bit is the only
-     difference, so it is the sole discriminator of the split. *)
-  Alcotest.(check string) "no tool + text (autonomous) -> autonomous_prose"
-    "autonomous_prose"
+     -> internal_prose (requires evidence). *)
+  Alcotest.(check string) "no tool + text (autonomous) -> internal_prose"
+    "internal_prose"
     (classify_auto ~tools:[] ~has_visible_text:true);
   (* Tool precedence is autonomy-independent: a peer/claim tool still dominates
      text even on an autonomous cycle (the split only affects prose-only turns). *)
@@ -345,21 +364,21 @@ let test_classify_delivery_mapping () =
      evidence). This is the parse-don't-validate replacement for the old
      DELIVERY_SURFACE: silent header self-declaration. *)
   Alcotest.(check string) "no tool + no text (silent) -> peer_only" "peer_only"
-    (classify ~tools:[] ~has_visible_text:false);
+    (classify_delivered ~tools:[] ~has_visible_text:false);
   (* A non-peer, non-claim tool with no visible text is still routed by surface
      only (Peer_only); strong_evidence (substantive tool calls) is the separate
      channel that lets such a turn count as progress. *)
   let exec_tool = List.hd Cap.shell_command_input_tool_names in
   Alcotest.(check string) "exec-only no text -> peer_only" "peer_only"
-    (classify ~tools:[ exec_tool ] ~has_visible_text:false)
+    (classify_delivered ~tools:[ exec_tool ] ~has_visible_text:false)
 
 let test_delivery_requires_evidence_mapping () =
   Alcotest.(check bool) "peer_only requires evidence" true
     (Success.delivery_requires_evidence Success.Peer_only);
   Alcotest.(check bool) "user_facing exempt" false
     (Success.delivery_requires_evidence Success.User_facing);
-  Alcotest.(check bool) "autonomous_prose requires evidence" true
-    (Success.delivery_requires_evidence Success.Autonomous_prose);
+  Alcotest.(check bool) "internal_prose requires evidence" true
+    (Success.delivery_requires_evidence Success.Internal_prose);
   Alcotest.(check bool) "task_claim exempt" false
     (Success.delivery_requires_evidence Success.Task_claim)
 
@@ -371,8 +390,8 @@ let test_silent_turns_accrue_streak () =
   for _ = 1 to 4 do
     let surface_requires_evidence =
       Success.delivery_requires_evidence
-        (Success.classify_delivery ~is_autonomous:false ~tools:[]
-           ~has_visible_text:false)
+        (Success.classify_delivery ~is_autonomous:false
+           ~reply_delivery:Success.Internal_only ~tools:[] ~has_visible_text:false)
     in
     record_turn ~keeper_name:k
       ~made_progress:
@@ -387,14 +406,14 @@ let test_silent_turns_accrue_streak () =
    residual blind spot after R1g: R1g stops failed_task from *driving* the wake,
    but a keeper that still wakes (e.g. real cooldown elapse) and only says
    "nothing to do" previously reset the streak via the [User_facing] exemption.
-   With the [Autonomous_prose] split it now requires evidence. *)
+   With the [Internal_prose] split it now requires evidence. *)
 let test_autonomous_textonly_noop_accrues_streak () =
-  let k = "r2a_autonomous_prose_thrash" in
+  let k = "r2a_internal_prose_thrash" in
   for _ = 1 to 4 do
     let surface_requires_evidence =
       Success.delivery_requires_evidence
-        (Success.classify_delivery ~is_autonomous:true ~tools:[]
-           ~has_visible_text:true)
+        (Success.classify_delivery ~is_autonomous:true
+           ~reply_delivery:Success.Internal_only ~tools:[] ~has_visible_text:true)
     in
     record_turn ~keeper_name:k
       ~made_progress:
@@ -404,8 +423,8 @@ let test_autonomous_textonly_noop_accrues_streak () =
   Alcotest.(check int) "autonomous prose-only no-evidence turns accrue streak" 4
     (D.current_streak ~keeper_name:k)
 
-(* RFC-0294 R2a false-positive guard: a REACTIVE turn (external prompt present)
-   that replies to an operator/peer with prose and no tool is legitimate work and
+(* RFC-0294 R2a false-positive guard: an externally-delivered REACTIVE turn that
+   replies to an operator/peer with prose and no tool is legitimate work and
    stays exempt — it must NOT accrue the streak. Distinguishes the split from a
    blanket "no-tool prose is no-progress" cap. *)
 let test_operator_mention_textonly_reply_exempt () =
@@ -413,7 +432,8 @@ let test_operator_mention_textonly_reply_exempt () =
   for _ = 1 to 4 do
     let surface_requires_evidence =
       Success.delivery_requires_evidence
-        (Success.classify_delivery ~is_autonomous:false ~tools:[]
+        (Success.classify_delivery ~is_autonomous:false
+           ~reply_delivery:Success.Externally_delivered ~tools:[]
            ~has_visible_text:true)
     in
     record_turn ~keeper_name:k
@@ -422,6 +442,39 @@ let test_operator_mention_textonly_reply_exempt () =
     |> ignore_outcome
   done;
   Alcotest.(check int) "reactive prose reply does not accrue streak" 0
+    (D.current_streak ~keeper_name:k)
+
+(* Regression for the idealist passive-only loop observed on 2026-06-26: an
+   owner-authored scope message stayed pending, but the unified keeper cycle's
+   text response was only an internal decision/metrics artifact, not an
+   assistant row appended to keeper_chat. The observation channel is reactive,
+   yet the reply is not externally delivered, so prose-only output must require
+   evidence and accrue the no-progress streak. *)
+let test_scope_message_internal_textonly_accrues_streak () =
+  let k = "r3_scope_message_internal_prose_thrash" in
+  let observation =
+    { scheduled_observation with
+      pending_scope_messages = [ ("owner", "did you actually use tools?") ]
+    }
+  in
+  let is_autonomous =
+    Support.is_scheduled_autonomous_cycle_of_observation observation
+  in
+  Alcotest.(check bool)
+    "scope-message observation remains reactive" false is_autonomous;
+  for _ = 1 to 4 do
+    let surface_requires_evidence =
+      Success.delivery_requires_evidence
+        (Success.classify_delivery ~is_autonomous
+           ~reply_delivery:Success.Internal_only ~tools:[] ~has_visible_text:true)
+    in
+    record_turn ~keeper_name:k
+      ~made_progress:
+        (D.turn_made_progress ~strong_evidence:false ~surface_requires_evidence)
+    |> ignore_outcome
+  done;
+  Alcotest.(check int)
+    "internal scope-message prose without evidence accrues streak" 4
     (D.current_streak ~keeper_name:k)
 
 (* RFC-0239 / audit D1·D3: the no-progress detector reads the typed outcome
@@ -548,6 +601,9 @@ let () =
           Alcotest.test_case
             "R2a reactive prose reply stays exempt (false-positive guard)"
             `Quick (with_eio test_operator_mention_textonly_reply_exempt);
+          Alcotest.test_case
+            "R3 scope-message internal prose accrues streak"
+            `Quick (with_eio test_scope_message_internal_textonly_accrues_streak);
           Alcotest.test_case "claim exemption is outcome-aware (D3)"
             `Quick test_claim_outcome_aware_exemption;
           Alcotest.test_case "strong evidence drops typed-failure completions (D1)"


### PR DESCRIPTION
## Summary
- split keeper no-progress delivery classification into reply delivery and turn delivery
- make unified keeper-cycle text `Internal_only`, so stale scope-message loops require durable evidence instead of resetting the no-progress streak
- add regression coverage for pending scope-message + text-only internal output, while preserving externally delivered reactive reply exemption
- update the living keeper wake/actionability RFC to match the route-aware behavior

## Evidence
- Live failure shape: idealist had `pending_scope_messages=1`, no task/goal, `turn_lane=tool_optional`, repeated internal text responses, and no assistant rows appended to `keeper_chat/idealist.jsonl`; the scope message stayed pending while no-progress did not latch.
- Local checks: `ocamlformat --check lib/keeper/keeper_unified_turn_success.ml lib/keeper/keeper_unified_turn_success.mli test/test_no_progress_loop_detector.ml`
- Local checks: `git diff --check`
- Local scans: touched files have no `/Users/dancer/me` literal, no new env/getenv usage, no `default_base`, no string-content matching, no stubs/failwith/assert false.
- Local focused Dune build was attempted with `scripts/dune-local.sh build test/test_no_progress_loop_detector.exe` but stopped after waiting on `/tmp/me-dune-local.lock`; another worktree was running `scripts/dune-local.sh runtest`. Per operator instruction, CI is the build authority.
