### PR TITLE
fix(memory): keep diagnostic fallbacks out of recall

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -136,11 +136,16 @@ export function parseMemoryOsFactCategory(raw: string): MemoryOsFactCategory {
 // RFC-0285 §3.1 claim_kind — closed vocabulary, no Unknown arm on the backend.
 // Mirrors claim_kind_of_string: an unrecognized/absent token yields undefined,
 // the backend's own None degrade to the durable path.
-export type MemoryOsClaimKind = 'self_observation' | 'external_state' | 'durable_knowledge'
+export type MemoryOsClaimKind =
+  | 'self_observation'
+  | 'external_state'
+  | 'durable_knowledge'
+  | 'diagnostic'
 const MEMORY_OS_CLAIM_KINDS: readonly MemoryOsClaimKind[] = [
   'self_observation',
   'external_state',
   'durable_knowledge',
+  'diagnostic',
 ]
 export function parseMemoryOsClaimKind(raw: string): MemoryOsClaimKind | undefined {
   const token = raw.trim().toLowerCase()
@@ -168,6 +173,7 @@ export type MemoryOsFact = {
   readonly valid_until_iso: string | null
   readonly last_verified_at: number | null
   readonly current: boolean
+  readonly prompt_recallable: boolean
   readonly claim_kind: MemoryOsClaimKind | null
 }
 
@@ -382,6 +388,7 @@ function decodeMemoryOsFact(raw: unknown): MemoryOsFact | null {
   const first_seen = asNumber(raw.first_seen)
   const reference_time = asNumber(raw.reference_time)
   const current = asBoolean(raw.current)
+  const prompt_recallable = asBoolean(raw.prompt_recallable)
   // Required keys are exactly the always-present ones in memory_os_fact_json.
   // A row missing any of them is a contract violation — dropped here rather
   // than rendered with a guessed default (no silent fabrication).
@@ -392,6 +399,7 @@ function decodeMemoryOsFact(raw: unknown): MemoryOsFact | null {
     || first_seen == null
     || reference_time == null
     || current == null
+    || prompt_recallable == null
   ) {
     return null
   }
@@ -409,6 +417,7 @@ function decodeMemoryOsFact(raw: unknown): MemoryOsFact | null {
     valid_until_iso: asNullableString(raw.valid_until_iso),
     last_verified_at: asNumber(raw.last_verified_at) ?? null,
     current,
+    prompt_recallable,
     claim_kind: claimKindToken ? (parseMemoryOsClaimKind(claimKindToken) ?? null) : null,
   }
 }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -571,10 +571,11 @@ describe('parseMemoryOsFactCategory (SSOT mirror of category_of_string)', () => 
 })
 
 describe('parseMemoryOsClaimKind (SSOT mirror of claim_kind_of_string)', () => {
-  it('maps the three kinds and yields undefined for anything else', () => {
+  it('maps the known kinds and yields undefined for anything else', () => {
     expect(parseMemoryOsClaimKind('self_observation')).toBe('self_observation')
     expect(parseMemoryOsClaimKind('external_state')).toBe('external_state')
     expect(parseMemoryOsClaimKind('durable_knowledge')).toBe('durable_knowledge')
+    expect(parseMemoryOsClaimKind('diagnostic')).toBe('diagnostic')
     expect(parseMemoryOsClaimKind(' DURABLE_KNOWLEDGE ')).toBe('durable_knowledge')
     expect(parseMemoryOsClaimKind('nonsense')).toBeUndefined()
   })
@@ -618,6 +619,7 @@ describe('decodeMemoryOsFact via fetchKeeperTurnRecords (RFC-keeper-memory-panel
                 valid_until_iso: null,
                 last_verified_at: 1_789_500_000,
                 current: true,
+                prompt_recallable: true,
                 claim_kind: 'durable_knowledge',
                 external_ref: { kind: 'pr', id: '22198' },
                 // RFC-0247-deleted score fields: present on the wire here as a
@@ -639,6 +641,7 @@ describe('decodeMemoryOsFact via fetchKeeperTurnRecords (RFC-keeper-memory-panel
                 valid_until_iso: '2026-09-10T...Z',
                 last_verified_at: null,
                 current: false,
+                prompt_recallable: true,
                 // claim_kind omitted entirely → null
               },
               {
@@ -648,6 +651,7 @@ describe('decodeMemoryOsFact via fetchKeeperTurnRecords (RFC-keeper-memory-panel
                 first_seen: 1,
                 reference_time: 1,
                 current: true,
+                prompt_recallable: true,
               },
             ],
           },

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -96,6 +96,7 @@ function turnRecordsPayload() {
             valid_until_iso: null,
             last_verified_at: 1_789_500_000,
             current: true,
+            prompt_recallable: true,
             claim_kind: 'durable_knowledge',
             external_ref: { kind: 'pr', id: '22198' },
           },
@@ -110,6 +111,7 @@ function turnRecordsPayload() {
             valid_until_iso: '2026-09-09T...Z',
             last_verified_at: null,
             current: false,
+            prompt_recallable: true,
           },
         ],
       },
@@ -393,6 +395,7 @@ describe('memory view-model helpers', () => {
       valid_until_iso: null,
       last_verified_at: null,
       current: true,
+      prompt_recallable: true,
       claim_kind: null,
       ...over,
     })
@@ -421,6 +424,7 @@ describe('memory view-model helpers', () => {
       valid_until_iso: null,
       last_verified_at: null,
       current,
+      prompt_recallable: true,
       claim_kind: null,
     })
     expect(sortMemoryFactsForReview([
@@ -442,8 +446,12 @@ describe('memory view-model helpers', () => {
       valid_until_iso: null,
       last_verified_at: null,
       current: true,
+      prompt_recallable: true,
       claim_kind: 'durable_knowledge',
     }
     expect(factSelectionReason(fact)).toBe('active recall candidate · 제약 · durable')
+    expect(factSelectionReason({ ...fact, prompt_recallable: false, claim_kind: 'diagnostic' })).toBe(
+      'diagnostic evidence row · 제약 · diagnostic',
+    )
   })
 })

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -206,6 +206,8 @@ function factClaimKindLabel(fact: MemoryOsFact): string {
       return 'external'
     case 'self_observation':
       return 'self'
+    case 'diagnostic':
+      return 'diagnostic'
     case null:
       return 'untyped'
     default: {
@@ -217,7 +219,9 @@ function factClaimKindLabel(fact: MemoryOsFact): string {
 
 export function factSelectionReason(fact: MemoryOsFact): string {
   const meta = factCategoryMeta(fact.category)
-  const state = fact.current ? 'active recall candidate' : 'expired evidence row'
+  const state = !fact.prompt_recallable
+    ? 'diagnostic evidence row'
+    : fact.current ? 'active recall candidate' : 'expired evidence row'
   return `${state} · ${meta.lbl} · ${factClaimKindLabel(fact)}`
 }
 

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -412,9 +412,10 @@ let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason
     { claim = note
     ; category = Keeper_memory_os_types.Ephemeral
     ; external_ref = None
-    ; (* RFC-0285: a parse-retry fallback note is not a librarian-classified claim;
-         leave it untagged ([None]) so it follows the Ephemeral category horizon. *)
-      claim_kind = None
+    ; (* A parse-retry fallback note is system-authored diagnostic evidence, not a
+         librarian-classified memory claim. Tag it at the producer boundary so recall
+         can exclude it without string-matching the raw claim text. *)
+      claim_kind = Some Keeper_memory_os_types.Diagnostic
     ; source = { trace_id = inp.trace_id; turn = 0; tool_call_id = None }
     ; observed_by = []
     ; first_seen = now
@@ -422,7 +423,7 @@ let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason
         Keeper_memory_os_types.fact_valid_until
           ~now
           ~external_ref:None
-          ~claim_kind:None
+          ~claim_kind:(Some Keeper_memory_os_types.Diagnostic)
           Keeper_memory_os_types.Ephemeral
     ; last_verified_at = Some now
     ; schema_version = Keeper_memory_os_types.schema_version

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -247,7 +247,7 @@ let valid_until_for_group ~now ~external_ref:_ ~claim_kind ~members category =
     (match min_optional_float (List.map (fun (m : fact) -> m.valid_until) members) with
      | Some _ as valid_until -> valid_until
      | None -> Some (now +. self_observation_ttl_seconds))
-  | Some External_state | Some Durable_knowledge | None ->
+  | Some External_state | Some Durable_knowledge | Some Diagnostic | None ->
     (match category with
      | Ephemeral ->
        (match min_optional_float (List.map (fun (m : fact) -> m.valid_until) members) with

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -51,10 +51,16 @@ type contribution =
 (* RFC-0247 (purge): eligibility is purely structural — a promotable category.
    The prior confidence floor (only claims above 0.5 count as corroboration) was
    a score gate and is gone. *)
-(* RFC-0285 §3.5: a [Self_observation] is transient keeper-local self-state, never
-   cross-keeper knowledge — gate it here (the single promotion SSOT) rather than
-   widening [is_promotable]'s exhaustive category signature. *)
-let eligible fact = is_promotable fact.category && fact.claim_kind <> Some Self_observation
+(* RFC-0285 §3.5: only objective claim kinds cross keepers. [Self_observation] is
+   transient keeper-local state, and [Diagnostic] is system-authored evidence for
+   operators, not shared semantic memory. Keep this exhaustive so a future
+   [claim_kind] cannot promote by accident. *)
+let eligible fact =
+  is_promotable fact.category
+  &&
+  match fact.claim_kind with
+  | Some External_state | Some Durable_knowledge | None -> true
+  | Some Self_observation | Some Diagnostic -> false
 
 (* Pick the representative fact for a claim group by a structural total order:
    earliest first_seen, then lexically smallest claim, then keeper id — so

--- a/lib/keeper/keeper_memory_os_policy.ml
+++ b/lib/keeper/keeper_memory_os_policy.ml
@@ -56,7 +56,7 @@ let reobserve_fact ~now ~existing ~incoming:(_ : fact) =
        the cap keep a self-observation as "recently verified" — the opposite of the
        goal. *)
     existing
-  | Some External_state | Some Durable_knowledge | None ->
+  | Some External_state | Some Durable_knowledge | Some Diagnostic | None ->
     (* Non-self-observation re-observe: the librarian re-asserting a claim from
        fresh context is enough to advance the staleness marker. *)
     { existing with last_verified_at = Some now }

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -237,8 +237,15 @@ let truth_anchor (fact : fact) = reference_time fact
 let facts_recency_ranked ~now facts =
   facts
   |> List.filter (fact_is_current ~now)
+  |> List.filter fact_prompt_recallable
   |> List.sort (fun a b -> compare (truth_anchor b) (truth_anchor a))
   |> dedup_by_claim
+;;
+
+let episode_prompt_recallable (episode : episode) =
+  match episode.claims with
+  | [] -> true
+  | claims -> List.exists fact_prompt_recallable claims
 ;;
 
 (* RFC-0264 P2: render_context_exn returns the rendered block alongside the
@@ -319,6 +326,7 @@ let render_context_exn ~keeper_id ~now ~max_facts ~max_episodes () =
       ~keeper_id
       ~n:(max max_episodes episode_tail_scan)
     |> List.filter (episode_is_current ~now)
+    |> List.filter episode_prompt_recallable
     |> take max_episodes
   in
   let injected_fact_keys =

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -85,11 +85,13 @@ type claim_kind =
   | Self_observation (* transient first-person agent state: idle, looping, tool-timeout *)
   | External_state (* about the world/PR/issue; verifiable elsewhere *)
   | Durable_knowledge (* timeless rule / lesson independent of transient state *)
+  | Diagnostic (* system-authored diagnostic artifact; not prompt-recallable knowledge *)
 
 let claim_kind_to_string = function
   | Self_observation -> "self_observation"
   | External_state -> "external_state"
   | Durable_knowledge -> "durable_knowledge"
+  | Diagnostic -> "diagnostic"
 ;;
 
 let claim_kind_of_string s =
@@ -97,6 +99,7 @@ let claim_kind_of_string s =
   | "self_observation" -> Some Self_observation
   | "external_state" -> Some External_state
   | "durable_knowledge" -> Some Durable_knowledge
+  | "diagnostic" -> Some Diagnostic
   | _ -> None
 ;;
 
@@ -173,7 +176,7 @@ let self_observation_ttl_seconds = 3_600.0
 let fact_valid_until ~now ~external_ref:_ ~claim_kind category =
   match claim_kind with
   | Some Self_observation -> Some (now +. self_observation_ttl_seconds)
-  | Some External_state | Some Durable_knowledge | None ->
+  | Some External_state | Some Durable_knowledge | Some Diagnostic | None ->
     category_valid_until ~now category
 ;;
 
@@ -219,6 +222,12 @@ let fact_is_current ~now (fact : fact) =
   match fact.valid_until with
   | None -> true
   | Some ts -> ts >= now
+;;
+
+let fact_prompt_recallable (fact : fact) =
+  match fact.claim_kind with
+  | Some Diagnostic -> false
+  | Some Self_observation | Some External_state | Some Durable_knowledge | None -> true
 ;;
 
 (* RFC-0259 §3.6 (P5): split a fact list into (live, expired-at-[now]) on the

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -65,6 +65,7 @@ type claim_kind =
   | Self_observation
   | External_state
   | Durable_knowledge
+  | Diagnostic
 
 (** Canonical lowercase token (round-trips with [claim_kind_of_string]). *)
 val claim_kind_to_string : claim_kind -> string
@@ -168,6 +169,11 @@ type fact =
 (** Whether a fact's hard-expiry horizon still admits it at [now]. Facts with no
     [valid_until] are durable and current. *)
 val fact_is_current : now:float -> fact -> bool
+
+(** Structural prompt-recall eligibility. Callers still apply {!fact_is_current}
+    for the time horizon; [Diagnostic] rows stay operator evidence, not prompt
+    context. *)
+val fact_prompt_recallable : fact -> bool
 
 (** RFC-0259 §3.6 (P5): partition facts into [(live, expired)] at [now] on the
     [valid_until] boundary ([fact_is_current]). The cap path drops the expired

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -85,6 +85,8 @@ let memory_os_episode_json ~now (episode : Keeper_memory_os_types.episode) =
    RFC-0247): they are absent from the [fact] record, so the type system makes
    re-emitting them unrepresentable. [reference_time] is the shared staleness
    anchor (last_verified_at else first_seen), reused rather than re-inlined.
+   [prompt_recallable] is projected from [fact_prompt_recallable], the same typed
+   SSOT recall uses, so the UI does not infer prompt eligibility from labels.
    [claim_kind] is omitted when [None] so a claim without optional metadata stays a
    minimal row. [external_ref] is intentionally not surfaced; PR/issue text remains
    claim context rather than a machine status field. *)
@@ -97,10 +99,11 @@ let memory_os_fact_json ~now (fact : Keeper_memory_os_types.fact) =
      ; "first_seen_iso", `String (Masc_domain.iso8601_of_unix_seconds fact.first_seen)
      ; "reference_time", `Float (Keeper_memory_os_types.reference_time fact)
      ; "valid_until", json_float_opt fact.valid_until
-     ; "valid_until_iso", json_time_iso_opt fact.valid_until
-     ; "last_verified_at", json_float_opt fact.last_verified_at
-     ; "current", `Bool (memory_os_fact_is_current ~now fact)
-     ]
+	     ; "valid_until_iso", json_time_iso_opt fact.valid_until
+	     ; "last_verified_at", json_float_opt fact.last_verified_at
+	     ; "current", `Bool (memory_os_fact_is_current ~now fact)
+	     ; "prompt_recallable", `Bool (Keeper_memory_os_types.fact_prompt_recallable fact)
+	     ]
      @ (match fact.claim_kind with
         | Some k -> [ "claim_kind", `String (Keeper_memory_os_types.claim_kind_to_string k) ]
         | None -> []))

--- a/reports/memory-os-path-env-audit-2026-06-26.md
+++ b/reports/memory-os-path-env-audit-2026-06-26.md
@@ -1,0 +1,162 @@
+# Memory OS / Path / Env Audit - 2026-06-26
+
+Scope:
+
+- MASC source references: `audit/memory-os-path-env-20260626` at `9b79f1a5ce3`.
+- Live runtime evidence: dashboard/health process at build commit `6f0097221f6`.
+- OAS source references: `ecd509f4b`.
+- No local build was run. This is an audit/evidence note; CI remains the build authority.
+
+External references checked on 2026-06-26 Asia/Seoul:
+
+- OCaml 5.4 manual, parallelism: https://ocaml.org/manual/5.4/parallelism.html
+- OCaml 5.4 `Lazy` API: https://ocaml.org/manual/5.4/api/Lazy.html
+- Eio package docs: https://ocaml.org/p/eio/latest/doc/
+
+## Evidence
+
+Live commands:
+
+- `curl -fsS 'http://127.0.0.1:8935/health?full=1'`
+  - Runtime paths: `effective_base_path=/Users/dancer/me`, `effective_masc_root=/Users/dancer/me/.masc`, `resolution_source=explicit_cli`.
+  - `keeper_fleet_safety.status=ok`, `running_keeper_fiber_count=6`, `failing_keeper_fiber_count=0`.
+- `curl -fsS 'http://127.0.0.1:8935/api/v1/dashboard/keeper-memory-health' | jq '.keepers[] | select(.keeper_id=="sangsu")'`
+  - `facts=163`, `events=178`, `events_to_facts_ratio=4.2430085983804995`, `ttl_expired_on_disk=0`, `near_duplicate=0`.
+- `jq -s '[.[] | select((.claim // "") | startswith("unstructured_note:"))] | length' /Users/dancer/me/.masc/config/keepers/sangsu.facts.jsonl`
+  - `11`
+- `jq -s '[.[] | select((.claim // "") | startswith("unstructured_note:")) | select((.valid_until == null) or (.valid_until > now))] | length' /Users/dancer/me/.masc/config/keepers/sangsu.facts.jsonl`
+  - `11`
+- `rg -c 'librarian_unstructured_fallback' /Users/dancer/me/.masc/config/keepers/sangsu.events.jsonl`
+  - `108`
+
+Key source references:
+
+- `lib/keeper/keeper_librarian_runtime.ml`
+  - Global librarian provider slot: lines 24-90.
+  - Unstructured fallback fact/episode construction: lines 378-450.
+  - Parse retry exhaustion preserving fallback: lines 452-510.
+  - Best-effort post-turn write path and provider-slot-busy skip: lines 650-743.
+- `lib/keeper/keeper_memory_os_types.ml`
+  - Ephemeral TTL: lines 152-178.
+- `lib/keeper/keeper_memory_os_recall.ml`
+  - Recall filters only current facts: lines 237-242.
+  - Prompt block reads persisted facts/episodes: lines 270-350.
+- `lib/keeper/keeper_run_tools_hooks.ml`
+  - Memory OS recall block is appended to keeper prompt context: lines 351-370.
+- `lib/server/server_dashboard_http_keeper_api.ml`
+  - Dashboard serializes stored fact rows: lines 81-107 and 169-230.
+- `dashboard/src/components/memory-inspector.ts`
+  - UI labels `active recall candidate`, category, and `untyped`: lines 177-222.
+- `lib/server/server_bootstrap_maintenance.ml`
+  - Per-keeper maintenance loops catch per-keeper errors: lines 37-96 and 219-299.
+- `lib/config/env_config_keeper.ml`
+  - Memory OS env/TOML precedence and defaults: lines 1-12 and 205-284.
+- `lib/config/env_config_core.ml`
+  - `MASC_BASE_PATH` is required by `base_path ()`: lines 375-382.
+- `lib/server/server_mcp_transport_http_session.ml`
+  - Server default base path delegates to workspace resolver: lines 35-42.
+- `lib/workspace/workspace_utils_backend_setup.ml`
+  - Explicit `MASC_BASE_PATH` wins; absent value fails loud outside tests: lines 161-203.
+- OAS env/debug references:
+  - `lib/llm_provider/complete_sync.ml` lines 103-130: `OAS_DEBUG_REQUEST_BODY=full` is disabled, not a live full-body dump.
+  - `lib/base/util.ml` lines 100-164, `lib/defaults.ml` lines 15-57, `lib/llm_provider/cli_common_env.ml` lines 11-80, `lib/tool_result_store.ml` lines 25-47: multiple env parsing policies remain.
+
+## Findings
+
+### P1 - Parse-failure fallback is persisted as active recall memory
+
+Confirmed current behavior:
+
+- When the librarian provider returns invalid episode JSON after retries, MASC creates a fact whose claim starts with `unstructured_note: librarian parse fallback (...)`.
+- The fallback fact is category `Ephemeral`, has no `claim_kind`, has no `claim_id`, and receives the normal ephemeral TTL.
+- The dashboard displays that row as `active recall candidate - temporary - untyped`.
+- The row is persisted in the keeper fact/event/episode stores, not in a separate temporary cache.
+- The row is eligible for future recall injection while current. It is not used by the same turn that created it because the librarian write happens after the prompt context for that turn has already been built.
+
+This is not silent data loss, and keeping a diagnostic artifact is useful. The problem is that a raw, truncated, invalid provider response is stored in the same semantic fact channel as keeper memory. The live `sangsu` store has 11 current unstructured fallback facts and 108 fallback event markers, so the screenshot is a real current-state symptom.
+
+Production fix direction:
+
+- Keep the diagnostic artifact, but separate it from recallable facts by default.
+- Add a typed parse-failure/diagnostic record or claim kind that the dashboard can show and health can count.
+- Exclude those diagnostic rows from `Keeper_memory_os_recall.render_context_exn` unless an explicit debugging flag asks for them.
+- Preserve metrics/logs and cadence retry behavior so this does not become a silent drop.
+
+Implementation in this branch:
+
+- Added `Keeper_memory_os_types.Diagnostic`.
+- Added `Keeper_memory_os_types.fact_prompt_recallable` as the typed recall-eligibility SSOT.
+- Marked new librarian parse-failure fallback facts as `claim_kind="diagnostic"`.
+- Excluded diagnostic facts and diagnostic-only episodes from prompt recall.
+- Kept diagnostics visible in dashboard decoding/rendering via backend-projected `prompt_recallable=false`.
+- Did not add a legacy prefix-based migration for already-written untyped fallback rows. Those rows retain their existing TTL behavior; reclassifying them needs a separate, explicit migration decision.
+
+### P1/P2 - Fleet-wide librarian provider slot does not stop all keepers, but can drop extraction work under load
+
+The current code is better than the older "one keeper blocks every other keeper" claim:
+
+- The default global slot is 1.
+- A keeper waits only 0.25s for the slot when a clock exists.
+- On timeout it records `MemoryLaneProviderSlotBusy` and skips extraction.
+- Per-keeper errors are caught and do not cancel the keeper fleet.
+
+So this is not a confirmed P0 fleet-stop bug. The remaining risk is fairness/data loss: under provider pressure, some keepers can repeatedly miss post-turn extraction rather than enqueueing a bounded retry. That can amplify the fallback/no-memory behavior shown in the dashboard.
+
+Production fix direction:
+
+- Replace "try for 0.25s then skip" with a bounded fair queue or per-keeper lane scheduler.
+- Surface dropped/deferred extraction counts in health, grouped by keeper.
+- Keep the failure local to the keeper/lane; do not make one provider failure stop the whole fleet.
+
+### P2 - Memory OS read paths still use blocking stdlib filesystem calls inside Eio runtime paths
+
+`keeper_memory_os_io` uses `Sys.readdir`, `Sys.file_exists`, `open_in_bin`, `in_channel_length`, and `really_input_string` in fact/episode read paths. The files are bounded, and this is not an immediate P0, but recall is on the keeper prompt-building path and dashboard reads are operator-facing runtime paths.
+
+Production fix direction:
+
+- Keep pure parsers as they are.
+- Move filesystem access to Eio-native path APIs or an explicit systhread boundary for potentially blocking directory/file reads.
+- Preserve current atomic write semantics through `Fs_compat.save_file_atomic`.
+
+### P2 - OAS env parsing policy is duplicated and inconsistent
+
+No hardcoded `/Users/dancer/me` path was found in the scanned OAS production source. The current risk is policy drift:
+
+- `Util.int_env_or` silently falls back on invalid input.
+- `Defaults.int_env_or` logs invalid input.
+- `Cli_common_env.int` logs invalid input and has its own non-negative policy.
+- `Tool_result_store.int_of_env` accepts any parsed integer and otherwise silently returns `None`.
+
+This is not a P0, but it is exactly the kind of env-surface drift that makes production behavior hard to reason about.
+
+Production fix direction:
+
+- Consolidate env parsing through one OAS helper with explicit invalid-value policy.
+- Make every env-backed setting declare bounds and whether invalid input fails open, fails closed, or logs-and-defaults.
+- Add focused tests for representative invalid/negative/empty values.
+
+## Corrected Non-Findings
+
+### No confirmed production hardcoded `/Users/dancer/me` base path in scanned MASC/OAS code
+
+The live MASC process is running with an explicit base path, and source resolution requires `MASC_BASE_PATH` or a server resolver path. The broad `/Users/dancer/me` hits in MASC are mainly tests/fixtures or documentation. I did not find a current production `let default_base = "/Users/dancer/me"` pattern in the scanned runtime paths.
+
+### Expired Memory OS facts are not recall-injected on current code
+
+The older "GC default off means expired facts accumulate indefinitely into recall" framing is stale:
+
+- write/cap paths drop expired rows,
+- recall filters `fact_is_current`,
+- `sangsu` currently reports `ttl_expired_on_disk=0`.
+
+GC is still default-off for quiet-store disk cleanup, but that is not the same as expired rows being active recall facts.
+
+### OAS full request-body dump is not current behavior
+
+The old `OAS_DEBUG_REQUEST_BODY=full` risk has been removed in current OAS. The code now warns that full dumps are disabled and suggests summary/scrubbed logging instead.
+
+## P0 Judgment
+
+I do not have a confirmed current P0 from this pass.
+
+The strongest issue is P1: unparseable librarian output was preserved as prompt-recallable memory. It becomes P0 only if a plausible path shows those raw diagnostic rows can inject harmful operational instructions into a keeper prompt and drive action without validation. This branch fixes the new-write channel boundary before adding prompt constraints or heuristics.

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1169,6 +1169,10 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
                 true
                 (fact.Types.category = Types.Ephemeral);
               Alcotest.(check (option string))
+                "fallback is diagnostic"
+                (Some "diagnostic")
+                (Option.map Types.claim_kind_to_string fact.Types.claim_kind);
+              Alcotest.(check (option string))
                 "fallback diagnostic does not author claim_id"
                 None
                 fact.Types.claim_id;
@@ -1207,10 +1211,14 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
             "fact persisted as unstructured note"
             true
             (contains "unstructured_note" fact.Types.claim);
+          Alcotest.(check (option string))
+            "persisted fact is diagnostic"
+            (Some "diagnostic")
+            (Option.map Types.claim_kind_to_string fact.Types.claim_kind);
           Alcotest.(check (float 0.001))
             "persisted fact first_seen uses injected clock"
-          fallback_created_at
-          fact.Types.first_seen
+            fallback_created_at
+            fact.Types.first_seen
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
 ;;
 
@@ -1259,6 +1267,10 @@ let test_librarian_unstructured_fallback_uses_exact_text_identity () =
           true
           (List.for_all (fun fact -> Option.is_none fact.Types.claim_id) facts);
         Alcotest.(check bool)
+          "fallback diagnostics are typed diagnostic"
+          true
+          (List.for_all (fun fact -> fact.Types.claim_kind = Some Types.Diagnostic) facts);
+        Alcotest.(check bool)
           "first raw note is preserved"
           true
           (List.exists
@@ -1272,14 +1284,19 @@ let test_librarian_unstructured_fallback_uses_exact_text_identity () =
              facts);
         (match first.Types.claims, second.Types.claims with
          | [ first_fact ], [ second_fact ] ->
-          Alcotest.(check bool)
-            "first result has no claim_id"
-            true
-            (Option.is_none first_fact.Types.claim_id);
-          Alcotest.(check bool)
-            "second result has no claim_id"
-            true
-            (Option.is_none second_fact.Types.claim_id)
+           Alcotest.(check bool)
+             "first result has no claim_id"
+             true
+             (Option.is_none first_fact.Types.claim_id);
+           Alcotest.(check bool)
+             "second result has no claim_id"
+             true
+             (Option.is_none second_fact.Types.claim_id);
+           Alcotest.(check bool)
+             "result fallback facts are diagnostic"
+             true
+             (first_fact.Types.claim_kind = Some Types.Diagnostic
+              && second_fact.Types.claim_kind = Some Types.Diagnostic)
          | first_claims, second_claims ->
            Alcotest.failf
              "expected one fallback fact in each result, got %d/%d"
@@ -1946,6 +1963,44 @@ let test_render_if_enabled_renders_persisted_memory () =
             "block carries the persisted claim"
             true
             (contains "Gated recall should surface saved facts" block))))
+  ;;
+
+let test_render_if_enabled_omits_diagnostic_memory () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun keepers_dir ->
+        let keeper_id = "diagnostic-memory-keeper" in
+        let now = 1_000_000.0 in
+        let fact =
+          { (fact_fixture ~now ()) with
+            Types.claim = "Raw parse-failure fallback should not enter prompt recall"
+          ; Types.category = Types.Ephemeral
+          ; Types.claim_kind = Some Types.Diagnostic
+          ; Types.valid_until = Some (now +. 3600.0)
+          }
+        in
+        let episode =
+          { Types.trace_id = "trace-diagnostic-recall"
+          ; Types.generation = 1
+          ; Types.episode_summary = "diagnostic-only episode should not enter recall"
+          ; Types.claims = [ fact ]
+          ; Types.open_items = []
+          ; Types.constraints = []
+          ; Types.preserved_tool_refs = []
+          ; Types.source_turn_range = Some (1, 2)
+          ; Types.created_at = now
+          ; Types.valid_until = Some (now +. 3600.0)
+          ; Types.terminal_marker = Some "librarian_unstructured_fallback"
+          ; Types.schema_version = Types.schema_version
+          }
+        in
+        Memory_io.append_episode_bundle ~keeper_id episode;
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
+        | None -> ()
+        | Some block ->
+          Alcotest.failf
+            "diagnostic memory leaked into recall block: %s"
+            block)))
 ;;
 
 (* RFC-0239 Q4 window invariant: when the store sits in the
@@ -3319,7 +3374,11 @@ let test_claim_kind_round_trip () =
          (Option.map
             Types.claim_kind_to_string
             (Types.claim_kind_of_string (Types.claim_kind_to_string k))))
-    [ Types.Self_observation; Types.External_state; Types.Durable_knowledge ];
+    [ Types.Self_observation
+    ; Types.External_state
+    ; Types.Durable_knowledge
+    ; Types.Diagnostic
+    ];
   Alcotest.(check bool)
     "unrecognized claim_kind token -> None (durable path)"
     true
@@ -3789,9 +3848,9 @@ let test_dashboard_fact_json_omits_score_keys () =
   let has k = List.mem_assoc k fields in
   List.iter
     (fun k -> Alcotest.(check bool) (Printf.sprintf "present: %s" k) true (has k))
-    [ "claim"; "category"; "source"; "first_seen"; "first_seen_iso"
-    ; "reference_time"; "valid_until"; "last_verified_at"; "current"
-    ; "claim_kind" ];
+	    [ "claim"; "category"; "source"; "first_seen"; "first_seen_iso"
+	    ; "reference_time"; "valid_until"; "last_verified_at"; "current"
+	    ; "prompt_recallable"; "claim_kind" ];
   Alcotest.(check bool) "external_ref not surfaced" false (has "external_ref");
   List.iter
     (fun k -> Alcotest.(check bool) (Printf.sprintf "deleted score key absent: %s" k) false (has k))
@@ -3801,9 +3860,12 @@ let test_dashboard_fact_json_omits_score_keys () =
    | Some (`String s) ->
      Alcotest.(check string) "category is the typed producer string" "validated_approach" s
    | _ -> Alcotest.fail "category must be a string");
-  match List.assoc_opt "current" fields with
-  | Some (`Bool b) -> Alcotest.(check bool) "current when valid_until is in the future" true b
-  | _ -> Alcotest.fail "current must be a bool"
+  (match List.assoc_opt "current" fields with
+   | Some (`Bool b) -> Alcotest.(check bool) "current when valid_until is in the future" true b
+   | _ -> Alcotest.fail "current must be a bool");
+  match List.assoc_opt "prompt_recallable" fields with
+  | Some (`Bool b) -> Alcotest.(check bool) "durable fact is prompt recallable" true b
+  | _ -> Alcotest.fail "prompt_recallable must be a bool"
 ;;
 
 (* Optional [claim_kind] is omitted when [None]; the staleness anchor
@@ -3826,6 +3888,25 @@ let test_dashboard_fact_json_omits_optional_when_none () =
     Alcotest.(check (float 0.001))
       "reference_time falls back to last_verified_at" (now -. 3600.0) t
   | _ -> Alcotest.fail "reference_time must be a float"
+;;
+
+let test_dashboard_fact_json_marks_diagnostic_not_prompt_recallable () =
+  let now = 1_000_000.0 in
+  let fact =
+    { (fact_fixture ~now ()) with
+      Types.category = Types.Ephemeral
+    ; Types.claim_kind = Some Types.Diagnostic
+    ; Types.valid_until = Some (now +. 3600.0)
+    }
+  in
+  let fields =
+    match Server_dashboard_http_keeper_api.memory_os_fact_json ~now fact with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "memory_os_fact_json must be a JSON object"
+  in
+  match List.assoc_opt "prompt_recallable" fields with
+  | Some (`Bool b) -> Alcotest.(check bool) "diagnostic fact is not prompt recallable" false b
+  | _ -> Alcotest.fail "prompt_recallable must be a bool"
 ;;
 
 (* The [items] wiring lives in [memory_os_dashboard_json], not the pure
@@ -4037,6 +4118,10 @@ let () =
             `Quick
             test_dashboard_fact_json_omits_optional_when_none
         ; Alcotest.test_case
+            "dashboard fact json marks diagnostic rows as not prompt recallable"
+            `Quick
+            test_dashboard_fact_json_marks_diagnostic_not_prompt_recallable
+        ; Alcotest.test_case
             "dashboard json wires one facts.items row per persisted fact"
             `Quick
             test_dashboard_json_wires_one_fact_item_per_fact
@@ -4134,6 +4219,10 @@ let () =
             "render_if_enabled renders persisted memory"
             `Quick
             test_render_if_enabled_renders_persisted_memory
+        ; Alcotest.test_case
+            "render_if_enabled omits diagnostic memory"
+            `Quick
+            test_render_if_enabled_omits_diagnostic_memory
         ; Alcotest.test_case
             "recall scans the whole bounded store, not just the tail window"
             `Quick


### PR DESCRIPTION
## Summary
- add typed Memory OS `Diagnostic` claim kind and `fact_prompt_recallable` SSOT
- mark new librarian parse-failure fallback rows as diagnostic and exclude them from prompt recall
- project `prompt_recallable` to the dashboard so diagnostic rows stay visible but are not labeled as recall candidates
- add audit report for Memory OS/path/env findings

## Validation
- `git diff --check`
- `ocamlc -stop-after parsing ...` on touched OCaml files
- dashboard `tsc --noEmit` using existing main checkout dependencies
- focused Vitest: `src/api/dashboard.test.ts`, `src/components/memory-inspector.test.ts` (84 tests)
- attempted `gtimeout 120s scripts/dune-local.sh build test/test_keeper_memory_os.exe`; local Dune target timed out after starting the build, so CI is the build authority for this PR

## Notes
- Existing untyped fallback rows on disk are not migrated by prefix/string matching; this patch fixes the typed boundary for new writes.