### PR TITLE
refactor(evidence): share punctuation token matching

### DIFF
--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -121,6 +121,50 @@ let query_tokens query =
   flush ();
   List.rev !out
 
+let is_ascii_alnum_or_utf8_byte = function
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> true
+  | c -> Char.code c >= 128
+
+let ascii_punctuation_tokens text =
+  let len = String.length text in
+  let rec skip_delimiters i =
+    if i < len && not (is_ascii_alnum_or_utf8_byte text.[i])
+    then skip_delimiters (i + 1)
+    else i
+  in
+  let rec take_token i =
+    if i < len && is_ascii_alnum_or_utf8_byte text.[i]
+    then take_token (i + 1)
+    else i
+  in
+  let rec loop i acc =
+    let start = skip_delimiters i in
+    if start >= len
+    then List.rev acc
+    else
+      let stop = take_token start in
+      let token = String.sub text start (stop - start) |> String.lowercase_ascii in
+      loop stop (token :: acc)
+  in
+  loop 0 []
+
+let contains_contiguous_token_sequence ~haystack ~needle =
+  let rec starts_with haystack needle =
+    match haystack, needle with
+    | _, [] -> true
+    | h :: hs, n :: ns when String.equal h n -> starts_with hs ns
+    | _ -> false
+  in
+  match needle with
+  | [] -> false
+  | _ ->
+    let rec loop = function
+      | [] -> false
+      | _ :: rest as tokens ->
+        if starts_with tokens needle then true else loop rest
+    in
+    loop haystack
+
 (* Token-AND containment: every whitespace-separated token of [query]
    must appear in [haystack] as a case-insensitive substring, in any
    order with arbitrary gaps ("갑오징어 ... 소주" matches the query

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -25,6 +25,20 @@ val query_tokens : string -> string list
     (space, tab, CR, LF) into non-empty tokens. UTF-8 bytes pass
     through opaquely. *)
 
+val ascii_punctuation_tokens : string -> string list
+(** [ascii_punctuation_tokens text] splits on ASCII punctuation and whitespace,
+    lowercases ASCII token bytes, and keeps UTF-8 bytes inside tokens. It is the
+    shared tokenizer for legacy contract/reference text that treats punctuation
+    as token boundaries. *)
+
+val contains_contiguous_token_sequence
+  :  haystack:string list
+  -> needle:string list
+  -> bool
+(** [contains_contiguous_token_sequence ~haystack ~needle] is true when [needle]
+    appears as a contiguous token sequence inside [haystack]. Empty [needle]
+    returns [false]. *)
+
 val contains_all_tokens_ci : string -> string -> bool
 (** [contains_all_tokens_ci haystack query] — token-AND containment:
     every token of [query_tokens query] appears in [haystack] as a

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -599,45 +599,10 @@ let default_evaluator_runtime () =
     ASCII punctuation separates tokens; UTF-8 bytes remain token
     characters so non-English contract items still compare literally
     across ASCII whitespace/punctuation. *)
-let contract_tokens text =
-  let buf = Buffer.create 16 in
-  let out = ref [] in
-  let is_token_char = function
-    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> true
-    | c -> Char.code c >= 128
-  in
-  let flush () =
-    if Buffer.length buf > 0
-    then (
-      out := Buffer.contents buf :: !out;
-      Buffer.clear buf)
-  in
-  String.iter
-    (fun c ->
-       if is_token_char c
-       then Buffer.add_char buf (Char.lowercase_ascii c)
-       else flush ())
-    text;
-  flush ();
-  List.rev !out
+let contract_tokens = String_util.ascii_punctuation_tokens
 ;;
 
-let contains_token_sequence ~haystack ~needle =
-  let rec starts_with needle haystack =
-    match needle, haystack with
-    | [], _ -> true
-    | n :: ns, h :: hs when String.equal n h -> starts_with ns hs
-    | _ -> false
-  in
-  match needle with
-  | [] -> false
-  | _ ->
-    let rec loop = function
-      | [] -> false
-      | _ :: rest as tokens -> starts_with needle tokens || loop rest
-    in
-    loop haystack
-;;
+let contains_token_sequence = String_util.contains_contiguous_token_sequence ;;
 
 (** Check completion notes against a pre-declared contract.
     Returns unmet contract items. A contract item is "met" if its

--- a/test/test_string_util.ml
+++ b/test/test_string_util.ml
@@ -233,6 +233,26 @@ let test_query_tokens_basic () =
   check (list string) "whitespace-only query has no tokens" []
     (SU.query_tokens " \t\n")
 
+let test_ascii_punctuation_tokens_basic () =
+  check (list string) "splits ASCII punctuation and lowercases"
+    [ "gate"; "2"; "src"; "main"; "ml"; "한글" ]
+    (SU.ascii_punctuation_tokens "Gate-2: src/main.ml 한글");
+  check (list string) "empty punctuation-only text has no tokens" []
+    (SU.ascii_punctuation_tokens " -- \t ./ ")
+
+let test_contains_contiguous_token_sequence () =
+  let tokens = SU.ascii_punctuation_tokens "Gate-2 checked src/main.ml and tests" in
+  check bool "contiguous sequence matches" true
+    (SU.contains_contiguous_token_sequence
+       ~haystack:tokens
+       ~needle:(SU.ascii_punctuation_tokens "src/main.ml"));
+  check bool "non-contiguous sequence rejects" false
+    (SU.contains_contiguous_token_sequence
+       ~haystack:tokens
+       ~needle:[ "src"; "tests" ]);
+  check bool "empty needle rejects" false
+    (SU.contains_contiguous_token_sequence ~haystack:tokens ~needle:[])
+
 let test_contains_all_tokens_ci_order_independent () =
   check bool "tokens match in any order with gaps" true
     (SU.contains_all_tokens_ci memory_note "소주 갑오징어");
@@ -349,6 +369,10 @@ let () =
             test_contains_substring_ci_empty_and_literal ] );
       ( "contains_all_tokens_ci",
         [ test_case "query_tokens basic" `Quick test_query_tokens_basic;
+          test_case "ascii punctuation tokens" `Quick
+            test_ascii_punctuation_tokens_basic;
+          test_case "contiguous token sequence" `Quick
+            test_contains_contiguous_token_sequence;
           test_case "order-independent token AND" `Quick
             test_contains_all_tokens_ci_order_independent;
           test_case "ASCII ci and empty query" `Quick


### PR DESCRIPTION
## Summary
- follow-up for #22348 review comments about `anti_rationalization.contract_tokens` duplicating tokenizer logic
- move ASCII-punctuation tokenization and contiguous sequence matching into `String_util`
- replace the local `Buffer`/`ref` tokenizer and recursive sequence matcher in `Anti_rationalization`
- add `String_util` regression coverage for punctuation tokenization, UTF-8 byte preservation, contiguous matches, non-contiguous rejection, and empty needle rejection

## Verification
- `ocamlformat --check lib/core/string_util.ml lib/core/string_util.mli lib/task/anti_rationalization.ml test/test_string_util.ml`
- `ocamlc -stop-after parsing lib/core/string_util.mli lib/core/string_util.ml lib/task/anti_rationalization.ml test/test_string_util.ml`
- `git diff --check origin/main..HEAD`

No Dune or CI check was run locally; CI remains the build authority.