### PR TITLE
fix(goal): persist completion approval requests

### DIFF
--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -141,44 +141,55 @@ let execute_workspace_action (ctx : 'a context) (request : action_request) =
    "team session actions removed: ..." error instead of the cleaner
    "unsupported action_type" path. *)
 
-let goal_decision_payload decision payload =
-  let fields =
-    match payload with
-    | `Assoc fields -> List.remove_assoc "decision" fields
-    | _ -> []
-  in
-  `Assoc (("decision", `String decision) :: fields)
+type goal_completion_decision =
+  | Goal_completion_approve
+  | Goal_completion_reject
 
-let execute_goal_action (_ctx : 'a context) (request : action_request) =
+let parse_goal_completion_decision payload =
+  match payload with
+  | `Assoc _ ->
+    (match get_string_opt payload "decision" with
+     | None -> Error "payload.decision is required"
+     | Some raw ->
+       (match String.trim raw |> String.lowercase_ascii with
+        | "approve" | "confirm" -> Ok Goal_completion_approve
+        | "reject" | "deny" -> Ok Goal_completion_reject
+        | "" -> Error "payload.decision is required"
+        | other -> Error (Printf.sprintf "unsupported goal decision: %s" other)))
+  | _ -> Error "goal decision payload must be an object"
+;;
+
+let goal_completion_transition_action = function
+  | Goal_completion_approve -> "approve_completion"
+  | Goal_completion_reject -> "reject_completion"
+;;
+
+let goal_decision_payload decision payload =
+  match payload with
+  | `Assoc fields ->
+    Ok (`Assoc (("decision", `String decision) :: List.remove_assoc "decision" fields))
+  | _ -> Error "goal decision payload must be an object"
+;;
+
+let execute_goal_action (ctx : 'a context) (request : action_request) =
   match request.action_type with
-  | "goal_completion_decision" ->
-    let* () = validate_target_type "goal" request in
+  | action when String.equal action Operator_action_constants.goal_completion_decision ->
+    let* () = validate_target_type Operator_action_constants.goal_target_type request in
     let* goal_id = require_target_id request in
-    let decision =
-      get_string request.payload "decision" "approve"
-      |> String.trim
-      |> String.lowercase_ascii
-    in
-    let* action =
-      match decision with
-      | "" | "approve" | "confirm" -> Ok "approve_completion"
-      | "reject" | "deny" -> Ok "reject_completion"
-      | other -> Error (Printf.sprintf "unsupported goal decision: %s" other)
-    in
+    let* decision = parse_goal_completion_decision request.payload in
+    let action = goal_completion_transition_action decision in
     let note_fields =
       match get_string_opt request.payload "note" with
       | Some note when String.trim note <> "" -> [ "note", `String note ]
       | _ -> []
     in
     let goal_ctx : Workspace_types.context =
-      { config = _ctx.config; agent_name = request.actor }
+      { config = ctx.config; agent_name = request.actor }
     in
     let result =
       Workspace_goals.handle_goal_transition
-        ~tool_name:"masc_goal_transition"
-        (* NDT-OK: remote operator confirmation executes at the wall-clock boundary;
-           replay uses the emitted Tool_result timestamp rather than this call site. *)
-        ~start_time:(Unix.gettimeofday ())
+        ~tool_name:Operator_action_constants.goal_transition_tool
+        ~start_time:(Eio.Time.now ctx.clock)
         goal_ctx
         (`Assoc
             ([ "goal_id", `String goal_id
@@ -337,7 +348,8 @@ let execute_action (ctx : 'a context) (request : action_request) :
   | "broadcast" | "namespace_pause" | "namespace_resume" | "social_sweep"
   | "task_inject" ->
       execute_workspace_action ctx request
-  | "goal_completion_decision" -> execute_goal_action ctx request
+  | action when String.equal action Operator_action_constants.goal_completion_decision ->
+    execute_goal_action ctx request
   | "keeper_probe" | "keeper_recover" | "keeper_message" ->
       execute_keeper_action ctx request
   | "" -> Error "action_type is required"
@@ -506,20 +518,27 @@ let confirm_json ?actor_hint (ctx : _ context) args :
       | Some entry ->
           if String.equal decision "deny" then (
             let goal_denial_result =
-              if String.equal entry.action_type "goal_completion_decision" then
-                let request =
-                  {
-                    actor = entry.actor;
-                    action_type = entry.action_type;
-                    target_type = entry.target_type;
-                    target_id = entry.target_id;
-                    payload = goal_decision_payload "reject" entry.payload;
-                  }
+              if
+                String.equal
+                  entry.action_type
+                  Operator_action_constants.goal_completion_decision
+              then
+                let* payload =
+                  goal_decision_payload
+                    Operator_action_constants.goal_decision_reject
+                    entry.payload
                 in
-                execute_action ctx request |> Result.map Option.some
+                execute_action
+                  ctx
+                  { actor = entry.actor
+                  ; action_type = entry.action_type
+                  ; target_type = entry.target_type
+                  ; target_id = entry.target_id
+                  ; payload
+                  }
+                |> Result.map Option.some
               else Ok None
             in
-            let* goal_denial_result = goal_denial_result in
             remove_pending_confirm ctx.config confirm_token;
             append_action_log ctx.config
               {
@@ -532,7 +551,8 @@ let confirm_json ?actor_hint (ctx : _ context) args :
                 target_id = entry.target_id;
                 delegated_tool = entry.delegated_tool;
                 confirmation_state = Denied;
-                result_status = ActionOk;
+                result_status =
+                  (match goal_denial_result with Ok _ -> ActionOk | Error _ -> ActionError);
                 latency_ms = 0;
                 created_at = Masc_domain.now_iso ();
               };
@@ -540,16 +560,21 @@ let confirm_json ?actor_hint (ctx : _ context) args :
               ~agent_id:actor ~trace_id:entry.trace_id
               ~decision:Audit_log.Governance_deny ~action_type:entry.action_type
               ~confirmation_state:(confirmation_state_to_string Denied) ();
+            let* goal_denial_result = goal_denial_result in
+            let result_fields =
+              [ "trace_id", `String entry.trace_id
+              ; "decision", `String "deny"
+              ; "tool_name", `String entry.delegated_tool
+              ; "executed_action", pending_confirm_to_yojson entry
+              ]
+            in
+            let result_fields =
+              match goal_denial_result with
+              | Some result -> ("result", result) :: result_fields
+              | None -> ("result_status", `String "not_applicable") :: result_fields
+            in
             Ok
-              (Tool_args.ok_assoc
-                 [
-                   ("trace_id", `String entry.trace_id);
-                   ("decision", `String "deny");
-                   ("tool_name", `String entry.delegated_tool);
-                   (* DET-OK: absent non-goal denial output is encoded as explicit JSON null. *)
-                   ("result", Option.value goal_denial_result ~default:`Null);
-                   ("executed_action", pending_confirm_to_yojson entry);
-                 ]))
+              (Tool_args.ok_assoc result_fields))
           else
             let started_at = Unix.gettimeofday () in
             let request =

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -141,6 +141,55 @@ let execute_workspace_action (ctx : 'a context) (request : action_request) =
    "team session actions removed: ..." error instead of the cleaner
    "unsupported action_type" path. *)
 
+let goal_decision_payload decision payload =
+  let fields =
+    match payload with
+    | `Assoc fields -> List.remove_assoc "decision" fields
+    | _ -> []
+  in
+  `Assoc (("decision", `String decision) :: fields)
+
+let execute_goal_action (_ctx : 'a context) (request : action_request) =
+  match request.action_type with
+  | "goal_completion_decision" ->
+    let* () = validate_target_type "goal" request in
+    let* goal_id = require_target_id request in
+    let decision =
+      get_string request.payload "decision" "approve"
+      |> String.trim
+      |> String.lowercase_ascii
+    in
+    let* action =
+      match decision with
+      | "" | "approve" | "confirm" -> Ok "approve_completion"
+      | "reject" | "deny" -> Ok "reject_completion"
+      | other -> Error (Printf.sprintf "unsupported goal decision: %s" other)
+    in
+    let note_fields =
+      match get_string_opt request.payload "note" with
+      | Some note when String.trim note <> "" -> [ "note", `String note ]
+      | _ -> []
+    in
+    let goal_ctx : Workspace_types.context =
+      { config = _ctx.config; agent_name = request.actor }
+    in
+    let result =
+      Workspace_goals.handle_goal_transition
+        ~tool_name:"masc_goal_transition"
+        ~start_time:(Unix.gettimeofday ())
+        goal_ctx
+        (`Assoc
+            ([ "goal_id", `String goal_id
+             ; "action", `String action
+             ; "actor", `Assoc [ "id", `String request.actor ]
+             ]
+             @ note_fields))
+    in
+    if Tool_result.is_success result
+    then workspace_action_result request (json_of_dispatch_output (Tool_result.message result))
+    else Error (Tool_result.message result)
+  | _ -> Error (Printf.sprintf "not a goal action: %s" request.action_type)
+
 let execute_keeper_action (ctx : 'a context) (request : action_request) =
   match request.action_type with
   | "keeper_probe" ->
@@ -286,6 +335,7 @@ let execute_action (ctx : 'a context) (request : action_request) :
   | "broadcast" | "namespace_pause" | "namespace_resume" | "social_sweep"
   | "task_inject" ->
       execute_workspace_action ctx request
+  | "goal_completion_decision" -> execute_goal_action ctx request
   | "keeper_probe" | "keeper_recover" | "keeper_message" ->
       execute_keeper_action ctx request
   | "" -> Error "action_type is required"
@@ -453,6 +503,21 @@ let confirm_json ?actor_hint (ctx : _ context) args :
           Error "actor is not allowed to confirm this action"
       | Some entry ->
           if String.equal decision "deny" then (
+            let goal_denial_result =
+              if String.equal entry.action_type "goal_completion_decision" then
+                let request =
+                  {
+                    actor = entry.actor;
+                    action_type = entry.action_type;
+                    target_type = entry.target_type;
+                    target_id = entry.target_id;
+                    payload = goal_decision_payload "reject" entry.payload;
+                  }
+                in
+                execute_action ctx request |> Result.map Option.some
+              else Ok None
+            in
+            let* goal_denial_result = goal_denial_result in
             remove_pending_confirm ctx.config confirm_token;
             append_action_log ctx.config
               {
@@ -479,6 +544,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
                    ("trace_id", `String entry.trace_id);
                    ("decision", `String "deny");
                    ("tool_name", `String entry.delegated_tool);
+                   ("result", Option.value goal_denial_result ~default:`Null);
                    ("executed_action", pending_confirm_to_yojson entry);
                  ]))
           else

--- a/lib/operator/operator_control.ml
+++ b/lib/operator/operator_control.ml
@@ -176,6 +176,8 @@ let execute_goal_action (_ctx : 'a context) (request : action_request) =
     let result =
       Workspace_goals.handle_goal_transition
         ~tool_name:"masc_goal_transition"
+        (* NDT-OK: remote operator confirmation executes at the wall-clock boundary;
+           replay uses the emitted Tool_result timestamp rather than this call site. *)
         ~start_time:(Unix.gettimeofday ())
         goal_ctx
         (`Assoc
@@ -544,6 +546,7 @@ let confirm_json ?actor_hint (ctx : _ context) args :
                    ("trace_id", `String entry.trace_id);
                    ("decision", `String "deny");
                    ("tool_name", `String entry.delegated_tool);
+                   (* DET-OK: absent non-goal denial output is encoded as explicit JSON null. *)
                    ("result", Option.value goal_denial_result ~default:`Null);
                    ("executed_action", pending_confirm_to_yojson entry);
                  ]))

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -110,14 +110,15 @@ let normalize_action_target_type target_type =
   let normalized = String.trim target_type |> String.lowercase_ascii in
   if Operator_digest_types.is_root_target_type normalized then Ok "workspace"
   else match normalized with
-  | "keeper" as value -> Ok value
+  | ("keeper" | "goal") as value -> Ok value
   | "" -> Ok ""
-  | _ -> Error "target_type must be root or keeper"
+  | _ -> Error "target_type must be root, keeper, or goal"
 
 let default_target_type_for action_type =
   match action_type with
   | "broadcast" | "namespace_pause" | "namespace_resume" | "task_inject" | "social_sweep"
     -> "workspace"
+  | "goal_completion_decision" -> "goal"
   | "keeper_message" | "keeper_probe" | "keeper_recover" -> "keeper"
   | _ -> ""
 

--- a/lib/operator/operator_control_action.ml
+++ b/lib/operator/operator_control_action.ml
@@ -110,7 +110,8 @@ let normalize_action_target_type target_type =
   let normalized = String.trim target_type |> String.lowercase_ascii in
   if Operator_digest_types.is_root_target_type normalized then Ok "workspace"
   else match normalized with
-  | ("keeper" | "goal") as value -> Ok value
+  | "keeper" -> Ok "keeper"
+  | value when String.equal value Operator_action_constants.goal_target_type -> Ok value
   | "" -> Ok ""
   | _ -> Error "target_type must be root, keeper, or goal"
 
@@ -118,7 +119,8 @@ let default_target_type_for action_type =
   match action_type with
   | "broadcast" | "namespace_pause" | "namespace_resume" | "task_inject" | "social_sweep"
     -> "workspace"
-  | "goal_completion_decision" -> "goal"
+  | action when String.equal action Operator_action_constants.goal_completion_decision ->
+    Operator_action_constants.goal_target_type
   | "keeper_message" | "keeper_probe" | "keeper_recover" -> "keeper"
   | _ -> ""
 

--- a/lib/operator/operator_control_action.mli
+++ b/lib/operator/operator_control_action.mli
@@ -103,9 +103,9 @@ val action_request_of_args :
 val normalize_request_target_type :
   action_request -> (action_request, string) result
 (** [normalize_request_target_type r] returns [r] with [target_type]
-    validated against the allowed set ([root] / [keeper] / [""]).
+    validated against the allowed set ([root] / [keeper] / [goal] / [""]).
     Empty [target_type] is replaced by the action-type default.
-    Returns [Error "target_type must be root or keeper"] on invalid
+    Returns [Error "target_type must be root, keeper, or goal"] on invalid
     inputs. *)
 
 val delegated_tool_for : string -> string

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -243,8 +243,10 @@ let available_actions : available_action list =
     make_available_action ~action_type:"task_inject" ~tool_name:"masc_add_task"
       ~target_type:"workspace"
       ~description:"Inject a backlog task into the namespace.";
-    make_available_action ~action_type:"goal_completion_decision"
-      ~tool_name:"masc_goal_transition" ~target_type:"goal"
+    make_available_action
+      ~action_type:Operator_action_constants.goal_completion_decision
+      ~tool_name:Operator_action_constants.goal_transition_tool
+      ~target_type:Operator_action_constants.goal_target_type
       ~description:"Approve or reject a goal completion approval gate.";
     make_available_action ~action_type:"keeper_message" ~tool_name:"masc_keeper_msg"
       ~target_type:"keeper"

--- a/lib/operator/operator_pending_confirm.ml
+++ b/lib/operator/operator_pending_confirm.ml
@@ -243,6 +243,9 @@ let available_actions : available_action list =
     make_available_action ~action_type:"task_inject" ~tool_name:"masc_add_task"
       ~target_type:"workspace"
       ~description:"Inject a backlog task into the namespace.";
+    make_available_action ~action_type:"goal_completion_decision"
+      ~tool_name:"masc_goal_transition" ~target_type:"goal"
+      ~description:"Approve or reject a goal completion approval gate.";
     make_available_action ~action_type:"keeper_message" ~tool_name:"masc_keeper_msg"
       ~target_type:"keeper"
       ~description:"Send a direct operator message to a keeper.";

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -417,8 +417,8 @@ let () =
          };
        Ok ());
   Atomic.set
-    Workspace_hooks.operator_pending_confirms_remove_by_target_fn
-    Operator_pending_confirm.remove_pending_confirms_by_target;
+    Workspace_hooks.operator_pending_confirm_remove_fn
+    Operator_pending_confirm.remove_pending_confirm;
   Keeper_turn_lifecycle.register_remove_pending_confirms_by_target
     Operator_pending_confirm.remove_pending_confirms_by_target
 ;;

--- a/lib/operator/operator_tool.ml
+++ b/lib/operator/operator_tool.ml
@@ -396,6 +396,29 @@ let () =
           ~disagreement_with_truth ~generated_at ~generated_at_unix ~fresh_until
           ~fresh_until_unix ~keeper_name ()
       ));
+  Atomic.set
+    Workspace_hooks.operator_pending_confirm_trace_id_fn
+    Operator_pending_confirm.trace_id;
+  Atomic.set
+    Workspace_hooks.operator_pending_confirm_upsert_fn
+    (fun config (entry : Workspace_hooks.operator_pending_confirm_request) ->
+       Operator_pending_confirm.upsert_pending_confirm
+         config
+         { token = entry.token
+         ; trace_id = entry.trace_id
+         ; actor = entry.actor
+         ; action_type = entry.action_type
+         ; target_type = entry.target_type
+         ; target_id = entry.target_id
+         ; payload = entry.payload
+         ; delegated_tool = entry.delegated_tool
+         ; created_at = entry.created_at
+         ; expires_at = entry.expires_at
+         };
+       Ok ());
+  Atomic.set
+    Workspace_hooks.operator_pending_confirms_remove_by_target_fn
+    Operator_pending_confirm.remove_pending_confirms_by_target;
   Keeper_turn_lifecycle.register_remove_pending_confirms_by_target
     Operator_pending_confirm.remove_pending_confirms_by_target
 ;;

--- a/lib/operator_action_constants.ml
+++ b/lib/operator_action_constants.ml
@@ -1,0 +1,6 @@
+let goal_completion_decision = "goal_completion_decision"
+let goal_target_type = "goal"
+let goal_transition_tool = "masc_goal_transition"
+let goal_approval_token_prefix = "goal-approval:"
+let goal_decision_approve = "approve"
+let goal_decision_reject = "reject"

--- a/lib/operator_approval.ml
+++ b/lib/operator_approval.ml
@@ -6,12 +6,12 @@
     @since OAS integration Phase F *)
 
 let high_risk_actions =
-  [ "namespace_pause"; "keeper_recover" ]
+  [ "namespace_pause"; "keeper_recover"; "goal_completion_decision" ]
 
 let allowed_actions =
   [ "broadcast"; "namespace_pause"; "namespace_resume"; "social_sweep";
     "keeper_message"; "keeper_probe"; "keeper_recover";
-    "task_inject" ]
+    "task_inject"; "goal_completion_decision" ]
 
 let risk_of_action action_type : Agent_sdk.Approval.risk_level =
   if List.mem action_type high_risk_actions then High

--- a/lib/operator_approval.ml
+++ b/lib/operator_approval.ml
@@ -6,12 +6,19 @@
     @since OAS integration Phase F *)
 
 let high_risk_actions =
-  [ "namespace_pause"; "keeper_recover"; "goal_completion_decision" ]
+  [ "namespace_pause"; "keeper_recover"; Operator_action_constants.goal_completion_decision ]
 
 let allowed_actions =
-  [ "broadcast"; "namespace_pause"; "namespace_resume"; "social_sweep";
-    "keeper_message"; "keeper_probe"; "keeper_recover";
-    "task_inject"; "goal_completion_decision" ]
+  [ "broadcast"
+  ; "namespace_pause"
+  ; "namespace_resume"
+  ; "social_sweep"
+  ; "keeper_message"
+  ; "keeper_probe"
+  ; "keeper_recover"
+  ; "task_inject"
+  ; Operator_action_constants.goal_completion_decision
+  ]
 
 let risk_of_action action_type : Agent_sdk.Approval.risk_level =
   if List.mem action_type high_risk_actions then High

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -169,14 +169,10 @@ let operator_pending_confirm_upsert_fn
     (fun _config _entry ->
       Error "operator pending-confirm callback is not connected")
 
-let operator_pending_confirms_remove_by_target_fn
-  : (Workspace_utils_backend_setup.config ->
-     target_type:string ->
-     target_id:string option ->
-     int)
-      Atomic.t
+let operator_pending_confirm_remove_fn
+  : (Workspace_utils_backend_setup.config -> string -> unit) Atomic.t
   =
-  Atomic.make (fun _config ~target_type:_ ~target_id:_ -> 0)
+  Atomic.make (fun _config _token -> ())
 
 
 (** Auto-subscribe agent to messages on session binding — wraps Subscriptions.SubscriptionStore. *)

--- a/lib/workspace/workspace_hooks.ml
+++ b/lib/workspace/workspace_hooks.ml
@@ -17,6 +17,19 @@ open Masc_domain
     to avoid dependency on Activity_graph from workspace sub-modules. *)
 type activity_entity = { kind: string; id: string }
 
+type operator_pending_confirm_request =
+  { token : string
+  ; trace_id : string
+  ; actor : string
+  ; action_type : string
+  ; target_type : string
+  ; target_id : string option
+  ; payload : Yojson.Safe.t
+  ; delegated_tool : string
+  ; created_at : string
+  ; expires_at : string option
+  }
+
 (* ============================================ *)
 (* Callback refs (migrated from workspace_gc.ml)     *)
 (* ============================================ *)
@@ -140,6 +153,30 @@ let cleanup_board_artifacts_fn
 let on_task_mutation_fn
   : (unit -> unit) Atomic.t
   = Atomic.make (fun () -> ())
+
+let operator_pending_confirm_trace_id_fn
+  : (string -> string) Atomic.t
+  =
+  Atomic.make (fun prefix -> prefix ^ "_unwired")
+
+let operator_pending_confirm_upsert_fn
+  : (Workspace_utils_backend_setup.config ->
+     operator_pending_confirm_request ->
+     (unit, string) result)
+      Atomic.t
+  =
+  Atomic.make
+    (fun _config _entry ->
+      Error "operator pending-confirm callback is not connected")
+
+let operator_pending_confirms_remove_by_target_fn
+  : (Workspace_utils_backend_setup.config ->
+     target_type:string ->
+     target_id:string option ->
+     int)
+      Atomic.t
+  =
+  Atomic.make (fun _config ~target_type:_ ~target_id:_ -> 0)
 
 
 (** Auto-subscribe agent to messages on session binding — wraps Subscriptions.SubscriptionStore. *)

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -9,6 +9,20 @@
 open Masc_domain
 
 type activity_entity = { kind: string; id: string }
+
+type operator_pending_confirm_request = {
+  token : string;
+  trace_id : string;
+  actor : string;
+  action_type : string;
+  target_type : string;
+  target_id : string option;
+  payload : Yojson.Safe.t;
+  delegated_tool : string;
+  created_at : string;
+  expires_at : string option;
+}
+
 type agent_lifecycle_event =
   | Session_bound
   | Session_rebound
@@ -51,6 +65,22 @@ val observe_task_transition_fn : (Workspace_utils_backend_setup.config ->
            Atomic.t
 val cleanup_board_artifacts_fn : (unit -> int) Atomic.t
 val on_task_mutation_fn : (unit -> unit) Atomic.t
+
+val operator_pending_confirm_trace_id_fn : (string -> string) Atomic.t
+
+val operator_pending_confirm_upsert_fn :
+  (Workspace_utils_backend_setup.config ->
+   operator_pending_confirm_request ->
+   (unit, string) result)
+    Atomic.t
+
+val operator_pending_confirms_remove_by_target_fn :
+  (Workspace_utils_backend_setup.config ->
+   target_type:string ->
+   target_id:string option ->
+   int)
+    Atomic.t
+
 val subscribe_messages_fn : (subscriber:string -> unit) Atomic.t
 val fsm_drift_observer_fn : (variant:string -> force:bool -> agent_name:string -> unit)
            Atomic.t

--- a/lib/workspace/workspace_hooks.mli
+++ b/lib/workspace/workspace_hooks.mli
@@ -74,12 +74,8 @@ val operator_pending_confirm_upsert_fn :
    (unit, string) result)
     Atomic.t
 
-val operator_pending_confirms_remove_by_target_fn :
-  (Workspace_utils_backend_setup.config ->
-   target_type:string ->
-   target_id:string option ->
-   int)
-    Atomic.t
+val operator_pending_confirm_remove_fn :
+  (Workspace_utils_backend_setup.config -> string -> unit) Atomic.t
 
 val subscribe_messages_fn : (subscriber:string -> unit) Atomic.t
 val fsm_drift_observer_fn : (variant:string -> force:bool -> agent_name:string -> unit)

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -88,6 +88,51 @@ let operator_action_error action =
     (Goal_phase.action_to_string action)
 ;;
 
+let goal_approval_pending_confirm_token goal_id = "goal-approval:" ^ goal_id
+
+let goal_approval_operator_actor (ctx : context) =
+  match Auth.read_initial_admin ctx.config.base_path with
+  | Some admin when String.trim admin <> "" -> admin
+  | _ ->
+    if caller_is_goal_operator ctx then ctx.agent_name else "operator"
+;;
+
+let goal_approval_pending_confirm_payload ~goal ~opened_by ?request_id () =
+  `Assoc
+    [ "goal_id", `String goal.Goal_store.id
+    ; "goal_title", `String goal.title
+    ; "phase", Goal_phase.to_yojson goal.phase
+    ; "decision", `String "approve"
+    ; "request_id", Json_util.string_opt_to_json request_id
+    ; "opened_by", Goal_verification.goal_principal_to_yojson opened_by
+    ]
+;;
+
+let persist_goal_approval_pending_confirm ctx ~goal ~opened_by ?request_id () =
+  let entry : Operator_pending_confirm.pending_confirm =
+    { token = goal_approval_pending_confirm_token goal.Goal_store.id
+    ; trace_id = Operator_pending_confirm.trace_id "goal"
+    ; actor = goal_approval_operator_actor ctx
+    ; action_type = "goal_completion_decision"
+    ; target_type = "goal"
+    ; target_id = Some goal.Goal_store.id
+    ; payload = goal_approval_pending_confirm_payload ~goal ~opened_by ?request_id ()
+    ; delegated_tool = "masc_goal_transition"
+    ; created_at = Masc_domain.now_iso ()
+    ; expires_at = None
+    }
+  in
+  Operator_pending_confirm.upsert_pending_confirm ctx.config entry
+;;
+
+let clear_goal_approval_pending_confirm ctx ~goal_id =
+  ignore
+    (Operator_pending_confirm.remove_pending_confirms_by_target
+       ctx.config
+       ~target_type:"goal"
+       ~target_id:(Some goal_id))
+;;
+
 let goal_status_strings = [ "active"; "paused"; "done"; "dropped" ]
 
 (* RFC-0089: derive the accepted-value sets from the Goal_phase ADT (the goal
@@ -714,6 +759,11 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                       ~payload:
                         (`Assoc
                             [ "actor", Goal_verification.goal_principal_to_yojson actor ]);
+                    persist_goal_approval_pending_confirm
+                      ctx
+                      ~goal:updated_goal
+                      ~opened_by:actor
+                      ();
                     ok_result
                       ~tool_name
                       ~start_time
@@ -736,6 +786,10 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                   | Error msg ->
                     error_result_typed ~tool_name ~start_time ~code:Internal_error msg
                   | Ok updated_goal ->
+                    if
+                      goal.phase = Goal_phase.Awaiting_approval
+                      && next_phase <> Goal_phase.Awaiting_approval
+                    then clear_goal_approval_pending_confirm ctx ~goal_id;
                     emit_goal_event
                       ctx
                       ~goal_id
@@ -944,7 +998,7 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                            Goal_verification.goal_verification_vote_to_yojson last_vote
                          | [] -> `Null )
                      ]);
-             let finalize ~phase ~event_status =
+             let finalize ?after_update ~phase ~event_status =
                match
                  update_goal_phase
                    ctx
@@ -954,12 +1008,13 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                    ~clear_active_verification_request:true
                    ()
                with
-               | Error msg ->
-                 error_result_typed ~tool_name ~start_time ~code:Internal_error msg
-               | Ok updated_goal ->
-                 emit_goal_event
-                   ctx
-                   ~goal_id
+                 | Error msg ->
+                   error_result_typed ~tool_name ~start_time ~code:Internal_error msg
+                 | Ok updated_goal ->
+                   Option.iter (fun f -> f updated_goal) after_update;
+                   emit_goal_event
+                     ctx
+                     ~goal_id
                    ~event_type:"goal_verification_resolved"
                    ~payload:
                      (`Assoc
@@ -1001,14 +1056,24 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                     , verification_summary_json goal effective_policy (Some request) )
                   ]
               | Goal_verification.Passed ->
-                if goal.require_completion_approval
-                then (
+               if goal.require_completion_approval
+               then (
                   emit_goal_event
                     ctx
                     ~goal_id
                     ~event_type:"goal_approval_opened"
                     ~payload:(`Assoc [ "request_id", `String request.id ]);
-                  finalize ~phase:Goal_phase.Awaiting_approval ~event_status:"approved")
+                  finalize
+                    ~after_update:
+                      (fun updated_goal ->
+                        persist_goal_approval_pending_confirm
+                          ctx
+                          ~goal:updated_goal
+                          ~opened_by:principal
+                          ~request_id:request.id
+                          ())
+                    ~phase:Goal_phase.Awaiting_approval
+                    ~event_status:"approved")
                 else finalize ~phase:Goal_phase.Completed ~event_status:"approved"
               | Goal_verification.Failed ->
                 finalize ~phase:Goal_phase.Executing ~event_status:"rejected"))))

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -108,10 +108,18 @@ let goal_approval_pending_confirm_payload ~goal ~opened_by ?request_id () =
     ]
 ;;
 
+let goal_approval_pending_confirm_goal goal =
+  { goal with
+    Goal_store.phase = Goal_phase.Awaiting_approval
+  ; status = Goal_store.goal_status_of_phase Goal_phase.Awaiting_approval
+  ; active_verification_request_id = None
+  }
+;;
+
 let persist_goal_approval_pending_confirm ctx ~goal ~opened_by ?request_id () =
-  let entry : Operator_pending_confirm.pending_confirm =
+  let entry : Workspace_hooks.operator_pending_confirm_request =
     { token = goal_approval_pending_confirm_token goal.Goal_store.id
-    ; trace_id = Operator_pending_confirm.trace_id "goal"
+    ; trace_id = (Atomic.get Workspace_hooks.operator_pending_confirm_trace_id_fn) "goal"
     ; actor = goal_approval_operator_actor ctx
     ; action_type = "goal_completion_decision"
     ; target_type = "goal"
@@ -122,12 +130,12 @@ let persist_goal_approval_pending_confirm ctx ~goal ~opened_by ?request_id () =
     ; expires_at = None
     }
   in
-  Operator_pending_confirm.upsert_pending_confirm ctx.config entry
+  (Atomic.get Workspace_hooks.operator_pending_confirm_upsert_fn) ctx.config entry
 ;;
 
 let clear_goal_approval_pending_confirm ctx ~goal_id =
   ignore
-    (Operator_pending_confirm.remove_pending_confirms_by_target
+    ((Atomic.get Workspace_hooks.operator_pending_confirms_remove_by_target_fn)
        ctx.config
        ~target_type:"goal"
        ~target_id:(Some goal_id))
@@ -732,15 +740,26 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                                ]))))
                | Ok Goal_phase.Open_approval ->
                  (match
-                    update_goal_phase
+                    persist_goal_approval_pending_confirm
                       ctx
-                      goal
-                      ~phase:Goal_phase.Awaiting_approval
-                      ?note
-                      ~clear_active_verification_request:true
+                      ~goal:(goal_approval_pending_confirm_goal goal)
+                      ~opened_by:actor
                       ()
                   with
                   | Error msg ->
+                    error_result_typed ~tool_name ~start_time ~code:Internal_error msg
+                  | Ok () ->
+                    (match
+                       update_goal_phase
+                         ctx
+                         goal
+                         ~phase:Goal_phase.Awaiting_approval
+                         ?note
+                         ~clear_active_verification_request:true
+                         ()
+                     with
+                  | Error msg ->
+                    clear_goal_approval_pending_confirm ctx ~goal_id;
                     error_result_typed ~tool_name ~start_time ~code:Internal_error msg
                   | Ok updated_goal ->
                     emit_goal_event
@@ -759,11 +778,6 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                       ~payload:
                         (`Assoc
                             [ "actor", Goal_verification.goal_principal_to_yojson actor ]);
-                    persist_goal_approval_pending_confirm
-                      ctx
-                      ~goal:updated_goal
-                      ~opened_by:actor
-                      ();
                     ok_result
                       ~tool_name
                       ~start_time
@@ -772,7 +786,7 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                       ; "goal", Goal_store.goal_to_yojson updated_goal
                       ; ( "verification_summary"
                         , verification_summary_json updated_goal effective_policy None )
-                      ])
+                      ]))
                | Ok Goal_phase.Complete ->
                  (match
                     update_goal_phase
@@ -998,7 +1012,7 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                            Goal_verification.goal_verification_vote_to_yojson last_vote
                          | [] -> `Null )
                      ]);
-             let finalize ?after_update ~phase ~event_status =
+             let finalize ~phase ~event_status =
                match
                  update_goal_phase
                    ctx
@@ -1011,7 +1025,6 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                  | Error msg ->
                    error_result_typed ~tool_name ~start_time ~code:Internal_error msg
                  | Ok updated_goal ->
-                   Option.iter (fun f -> f updated_goal) after_update;
                    emit_goal_event
                      ctx
                      ~goal_id
@@ -1029,8 +1042,8 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                  ok_result
                    ~tool_name
                    ~start_time
-                   [ "goal_id", `String goal_id
-                   ; "goal", Goal_store.goal_to_yojson updated_goal
+                 [ "goal_id", `String goal_id
+                 ; "goal", Goal_store.goal_to_yojson updated_goal
                    ; ( "verification_request"
                      , Goal_verification.goal_verification_request_to_yojson request )
                    ; ( "verification_summary"
@@ -1055,25 +1068,34 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
                   ; ( "verification_summary"
                     , verification_summary_json goal effective_policy (Some request) )
                   ]
-              | Goal_verification.Passed ->
+             | Goal_verification.Passed ->
                if goal.require_completion_approval
                then (
-                  emit_goal_event
-                    ctx
-                    ~goal_id
-                    ~event_type:"goal_approval_opened"
-                    ~payload:(`Assoc [ "request_id", `String request.id ]);
-                  finalize
-                    ~after_update:
-                      (fun updated_goal ->
-                        persist_goal_approval_pending_confirm
-                          ctx
-                          ~goal:updated_goal
-                          ~opened_by:principal
-                          ~request_id:request.id
-                          ())
-                    ~phase:Goal_phase.Awaiting_approval
-                    ~event_status:"approved")
+                 match
+                   persist_goal_approval_pending_confirm
+                     ctx
+                     ~goal:(goal_approval_pending_confirm_goal goal)
+                     ~opened_by:principal
+                     ~request_id:request.id
+                     ()
+                 with
+                 | Error msg ->
+                   error_result_typed ~tool_name ~start_time ~code:Internal_error msg
+                 | Ok () ->
+                   let result =
+                     finalize
+                       ~phase:Goal_phase.Awaiting_approval
+                       ~event_status:"approved"
+                   in
+                   if Tool_result.is_success result
+                   then
+                     emit_goal_event
+                       ctx
+                       ~goal_id
+                       ~event_type:"goal_approval_opened"
+                       ~payload:(`Assoc [ "request_id", `String request.id ])
+                   else clear_goal_approval_pending_confirm ctx ~goal_id;
+                   result)
                 else finalize ~phase:Goal_phase.Completed ~event_status:"approved"
               | Goal_verification.Failed ->
                 finalize ~phase:Goal_phase.Executing ~event_status:"rejected"))))

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -867,6 +867,8 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                   | Error msg ->
                     error_result_typed ~tool_name ~start_time ~code:Internal_error msg
                   | Ok updated_goal ->
+                    if goal.phase = Goal_phase.Awaiting_approval
+                    then clear_goal_approval_pending_confirm ctx ~goal_id;
                     emit_goal_event
                       ctx
                       ~goal_id

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -800,9 +800,7 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                   | Error msg ->
                     error_result_typed ~tool_name ~start_time ~code:Internal_error msg
                   | Ok updated_goal ->
-                    if
-                      goal.phase = Goal_phase.Awaiting_approval
-                      && next_phase <> Goal_phase.Awaiting_approval
+                    if goal.phase = Goal_phase.Awaiting_approval
                     then clear_goal_approval_pending_confirm ctx ~goal_id;
                     emit_goal_event
                       ctx

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -88,7 +88,9 @@ let operator_action_error action =
     (Goal_phase.action_to_string action)
 ;;
 
-let goal_approval_pending_confirm_token goal_id = "goal-approval:" ^ goal_id
+let goal_approval_pending_confirm_token goal_id =
+  Operator_action_constants.goal_approval_token_prefix ^ goal_id
+;;
 
 let goal_approval_operator_actor (ctx : context) =
   match Auth.read_initial_admin ctx.config.base_path with
@@ -102,7 +104,7 @@ let goal_approval_pending_confirm_payload ~goal ~opened_by ?request_id () =
     [ "goal_id", `String goal.Goal_store.id
     ; "goal_title", `String goal.title
     ; "phase", Goal_phase.to_yojson goal.phase
-    ; "decision", `String "approve"
+    ; "decision", `String Operator_action_constants.goal_decision_approve
     ; "request_id", Json_util.string_opt_to_json request_id
     ; "opened_by", Goal_verification.goal_principal_to_yojson opened_by
     ]
@@ -121,11 +123,11 @@ let persist_goal_approval_pending_confirm ctx ~goal ~opened_by ?request_id () =
     { token = goal_approval_pending_confirm_token goal.Goal_store.id
     ; trace_id = (Atomic.get Workspace_hooks.operator_pending_confirm_trace_id_fn) "goal"
     ; actor = goal_approval_operator_actor ctx
-    ; action_type = "goal_completion_decision"
-    ; target_type = "goal"
+    ; action_type = Operator_action_constants.goal_completion_decision
+    ; target_type = Operator_action_constants.goal_target_type
     ; target_id = Some goal.Goal_store.id
     ; payload = goal_approval_pending_confirm_payload ~goal ~opened_by ?request_id ()
-    ; delegated_tool = "masc_goal_transition"
+    ; delegated_tool = Operator_action_constants.goal_transition_tool
     ; created_at = Masc_domain.now_iso ()
     ; expires_at = None
     }
@@ -134,11 +136,9 @@ let persist_goal_approval_pending_confirm ctx ~goal ~opened_by ?request_id () =
 ;;
 
 let clear_goal_approval_pending_confirm ctx ~goal_id =
-  ignore
-    ((Atomic.get Workspace_hooks.operator_pending_confirms_remove_by_target_fn)
-       ctx.config
-       ~target_type:"goal"
-       ~target_id:(Some goal_id))
+  (Atomic.get Workspace_hooks.operator_pending_confirm_remove_fn)
+    ctx.config
+    (goal_approval_pending_confirm_token goal_id)
 ;;
 
 let goal_status_strings = [ "active"; "paused"; "done"; "dropped" ]

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -864,6 +864,153 @@ let test_goal_transition_approval_gate () =
     (List.length (Operator_pending_confirm.read_pending_confirms config))
 ;;
 
+let with_goal_awaiting_completion_approval ~title f =
+  with_operator_pending_confirm_hooks
+  @@ fun () ->
+  with_workspace
+  @@ fun config ->
+  let verifier_policy =
+    { Goal_verification.inherit_mode = Goal_verification.Extend
+    ; principals =
+        [ { id = "agent-alpha"; display_name = Some "agent-alpha" } ]
+    ; required_verdicts = Some 1
+    }
+  in
+  let goal, _kind =
+    match
+      Goal_store.upsert_goal
+        config
+        ~title
+        ~verifier_policy
+        ~require_completion_approval:true
+        ()
+    with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  seed_goal_operator config ~agent_name:"operator";
+  create_done_task config ~goal_id:goal.id ~title:(title ^ " done task");
+  let transitioned =
+    Tool_workspace.dispatch
+      (workspace_ctx config)
+      ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+            [ "goal_id", `String goal.id
+            ; "action", `String "request_complete"
+            ; "actor", principal_json ~id:"planner"
+            ])
+  in
+  let transitioned_json =
+    match transitioned with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_transition not handled"
+  in
+  let request_id =
+    transitioned_json
+    |> Yojson.Safe.Util.member "verification_request"
+    |> fun json -> get_string_field json "id"
+  in
+  let verified =
+    Tool_workspace.dispatch
+      (workspace_ctx ~agent_name:"agent-alpha" config)
+      ~name:"masc_goal_verify"
+      ~args:
+        (`Assoc
+            [ "goal_id", `String goal.id
+            ; "request_id", `String request_id
+            ; "principal", principal_json ~id:"agent-alpha"
+            ; "decision", `String "approve"
+            ])
+  in
+  let verified_json =
+    match verified with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_verify not handled"
+  in
+  check
+    string
+    "fixture phase moved to awaiting_approval"
+    "awaiting_approval"
+    (verified_json
+     |> Yojson.Safe.Util.member "goal"
+     |> fun json -> get_string_field json "phase");
+  check
+    int
+    "fixture approval request persisted"
+    1
+    (List.length (Operator_pending_confirm.read_pending_confirms config));
+  f config goal
+;;
+
+let test_goal_approval_reject_clears_pending_confirm () =
+  with_goal_awaiting_completion_approval
+    ~title:"Reject approval cleanup"
+    (fun config goal ->
+       let rejected =
+         Tool_workspace.dispatch
+           (workspace_ctx ~agent_name:"operator" config)
+           ~name:"masc_goal_transition"
+           ~args:
+             (`Assoc
+                 [ "goal_id", `String goal.id
+                 ; "action", `String "reject_completion"
+                 ; "actor", principal_json ~id:"operator"
+                 ])
+       in
+       let rejected_json =
+         match rejected with
+         | Some result -> parse_json_result result
+         | None -> fail "masc_goal_transition not handled"
+       in
+       check
+         string
+         "reject_completion moves to blocked"
+         "blocked"
+         (rejected_json
+          |> Yojson.Safe.Util.member "goal"
+          |> fun json -> get_string_field json "phase");
+       check
+         int
+         "reject_completion clears approval request"
+         0
+         (List.length (Operator_pending_confirm.read_pending_confirms config)))
+;;
+
+let test_goal_approval_drop_clears_pending_confirm () =
+  with_goal_awaiting_completion_approval
+    ~title:"Drop approval cleanup"
+    (fun config goal ->
+       let dropped =
+         Tool_workspace.dispatch
+           (workspace_ctx ~agent_name:"operator" config)
+           ~name:"masc_goal_transition"
+           ~args:
+             (`Assoc
+                 [ "goal_id", `String goal.id
+                 ; "action", `String "drop"
+                 ; "actor", principal_json ~id:"operator"
+                 ])
+       in
+       let dropped_json =
+         match dropped with
+         | Some result -> parse_json_result result
+         | None -> fail "masc_goal_transition not handled"
+       in
+       check
+         string
+         "drop moves to dropped"
+         "dropped"
+         (dropped_json
+          |> Yojson.Safe.Util.member "goal"
+          |> fun json -> get_string_field json "phase");
+       check
+         int
+         "drop clears approval request"
+         0
+         (List.length (Operator_pending_confirm.read_pending_confirms config)))
+;;
+
 let test_goal_principal_display_name_canonicalized () =
   with_workspace
   @@ fun config ->
@@ -1612,6 +1759,14 @@ let () =
             `Quick
             test_goal_transition_manual_reject_blocks_and_cancels_request
         ; test_case "approval gate" `Quick test_goal_transition_approval_gate
+        ; test_case
+            "approval reject clears pending confirm"
+            `Quick
+            test_goal_approval_reject_clears_pending_confirm
+        ; test_case
+            "approval drop clears pending confirm"
+            `Quick
+            test_goal_approval_drop_clears_pending_confirm
         ; test_case
             "principal display labels are canonicalized"
             `Quick

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -716,6 +716,7 @@ let test_goal_transition_approval_gate () =
     | Ok payload -> payload
     | Error msg -> fail msg
   in
+  seed_goal_operator config ~agent_name:"operator";
   create_done_task config ~goal_id:goal.id ~title:"Approval done task";
   let transitioned =
     Tool_workspace.dispatch
@@ -762,7 +763,24 @@ let test_goal_transition_approval_gate () =
     (verified_json
      |> Yojson.Safe.Util.member "goal"
      |> fun json -> get_string_field json "phase");
-  seed_goal_operator config ~agent_name:"operator";
+  let pending_confirms = Operator_pending_confirm.read_pending_confirms config in
+  check int "approval request persisted" 1 (List.length pending_confirms);
+  let pending_confirm =
+    match pending_confirms with
+    | [ entry ] -> entry
+    | _ -> fail "expected one persisted goal approval request"
+  in
+  check string "approval action type" "goal_completion_decision"
+    pending_confirm.action_type;
+  check string "approval target type" "goal" pending_confirm.target_type;
+  check (option string) "approval target id" (Some goal.id) pending_confirm.target_id;
+  check string "approval delegated tool" "masc_goal_transition"
+    pending_confirm.delegated_tool;
+  check string "approval actor" "operator" pending_confirm.actor;
+  check string "approval request id in payload" request_id
+    (pending_confirm.payload
+     |> Yojson.Safe.Util.member "request_id"
+     |> Yojson.Safe.Util.to_string);
   let approved =
     Tool_workspace.dispatch
       (workspace_ctx ~agent_name:"operator" config)
@@ -785,7 +803,12 @@ let test_goal_transition_approval_gate () =
     "completed"
     (approved_json
      |> Yojson.Safe.Util.member "goal"
-     |> fun json -> get_string_field json "phase")
+     |> fun json -> get_string_field json "phase");
+  check
+    int
+    "approval request cleared"
+    0
+    (List.length (Operator_pending_confirm.read_pending_confirms config))
 ;;
 
 let test_goal_principal_display_name_canonicalized () =
@@ -1427,6 +1450,25 @@ let test_completion_approval_requires_operator_caller () =
     (Goal_phase.to_string saved_goal.phase)
 ;;
 
+let test_goal_approval_operator_action_registered () =
+  check bool "allowed action" true
+    (Operator_approval.is_allowed "goal_completion_decision");
+  check bool "confirm required" true
+    (Operator_approval.confirm_required "goal_completion_decision");
+  let action =
+    List.find_opt
+      (fun (action : Operator_pending_confirm.available_action) ->
+         String.equal action.action_type "goal_completion_decision")
+      Operator_pending_confirm.available_actions
+  in
+  match action with
+  | None -> fail "goal_completion_decision missing from available actions"
+  | Some action ->
+    check string "tool" "masc_goal_transition" action.tool_name;
+    check string "target type" "goal" action.target_type;
+    check bool "registry confirm required" true action.confirm_required
+;;
+
 let () =
   run
     "goal_tools"
@@ -1518,6 +1560,10 @@ let () =
             "approval requires operator caller"
             `Quick
             test_completion_approval_requires_operator_caller
+        ; test_case
+            "approval operator action registered"
+            `Quick
+            test_goal_approval_operator_action_registered
         ] )
     ]
 ;;

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -45,11 +45,22 @@ let workspace_ctx ?(agent_name = "planner") config : Tool_workspace.context =
   { Tool_workspace.config; agent_name }
 ;;
 
+let operator_ctx env sw config agent_name : _ Operator_control.context =
+  { config
+  ; agent_name
+  ; sw
+  ; clock = Eio.Stdenv.clock env
+  ; proc_mgr = Some (Eio.Stdenv.process_mgr env)
+  ; net = Some (Eio.Stdenv.net env)
+  ; mcp_session_id = None
+  }
+;;
+
 let with_operator_pending_confirm_hooks f =
   let previous_trace = Atomic.get Workspace_hooks.operator_pending_confirm_trace_id_fn in
   let previous_upsert = Atomic.get Workspace_hooks.operator_pending_confirm_upsert_fn in
   let previous_remove =
-    Atomic.get Workspace_hooks.operator_pending_confirms_remove_by_target_fn
+    Atomic.get Workspace_hooks.operator_pending_confirm_remove_fn
   in
   Atomic.set
     Workspace_hooks.operator_pending_confirm_trace_id_fn
@@ -72,14 +83,14 @@ let with_operator_pending_confirm_hooks f =
          };
        Ok ());
   Atomic.set
-    Workspace_hooks.operator_pending_confirms_remove_by_target_fn
-    Operator_pending_confirm.remove_pending_confirms_by_target;
+    Workspace_hooks.operator_pending_confirm_remove_fn
+    Operator_pending_confirm.remove_pending_confirm;
   Fun.protect
     ~finally:(fun () ->
       Atomic.set Workspace_hooks.operator_pending_confirm_trace_id_fn previous_trace;
       Atomic.set Workspace_hooks.operator_pending_confirm_upsert_fn previous_upsert;
       Atomic.set
-        Workspace_hooks.operator_pending_confirms_remove_by_target_fn
+        Workspace_hooks.operator_pending_confirm_remove_fn
         previous_remove)
     f
 ;;
@@ -811,11 +822,12 @@ let test_goal_transition_approval_gate () =
     | [ entry ] -> entry
     | _ -> fail "expected one persisted goal approval request"
   in
-  check string "approval action type" "goal_completion_decision"
+  check string "approval action type" Operator_action_constants.goal_completion_decision
     pending_confirm.action_type;
-  check string "approval target type" "goal" pending_confirm.target_type;
+  check string "approval target type" Operator_action_constants.goal_target_type
+    pending_confirm.target_type;
   check (option string) "approval target id" (Some goal.id) pending_confirm.target_id;
-  check string "approval delegated tool" "masc_goal_transition"
+  check string "approval delegated tool" Operator_action_constants.goal_transition_tool
     pending_confirm.delegated_tool;
   check string "approval actor" "operator" pending_confirm.actor;
   check string "approval request id in payload" request_id
@@ -1493,21 +1505,68 @@ let test_completion_approval_requires_operator_caller () =
 
 let test_goal_approval_operator_action_registered () =
   check bool "allowed action" true
-    (Operator_approval.is_allowed "goal_completion_decision");
+    (Operator_approval.is_allowed Operator_action_constants.goal_completion_decision);
   check bool "confirm required" true
-    (Operator_approval.confirm_required "goal_completion_decision");
+    (Operator_approval.confirm_required Operator_action_constants.goal_completion_decision);
   let action =
     List.find_opt
       (fun (action : Operator_pending_confirm.available_action) ->
-         String.equal action.action_type "goal_completion_decision")
+         String.equal
+           action.action_type
+           Operator_action_constants.goal_completion_decision)
       Operator_pending_confirm.available_actions
   in
   match action with
-  | None -> fail "goal_completion_decision missing from available actions"
+  | None ->
+    fail
+      (Operator_action_constants.goal_completion_decision
+       ^ " missing from available actions")
   | Some action ->
-    check string "tool" "masc_goal_transition" action.tool_name;
-    check string "target type" "goal" action.target_type;
+    check string "tool" Operator_action_constants.goal_transition_tool action.tool_name;
+    check string "target type" Operator_action_constants.goal_target_type action.target_type;
     check bool "registry confirm required" true action.confirm_required
+;;
+
+let test_operator_goal_decision_requires_explicit_decision () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  Eio.Switch.run
+  @@ fun sw ->
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       let config = Workspace.default_config dir in
+       ignore (Workspace.init config ~agent_name:(Some "operator"));
+       let ctx = operator_ctx env sw config "operator" in
+       let assert_rejected ~token payload =
+         Operator_pending_confirm.upsert_pending_confirm
+           config
+           { token
+           ; trace_id = "goal_missing_decision"
+           ; actor = "operator"
+           ; action_type = Operator_action_constants.goal_completion_decision
+           ; target_type = Operator_action_constants.goal_target_type
+           ; target_id = Some "goal-1"
+           ; payload
+           ; delegated_tool = Operator_action_constants.goal_transition_tool
+           ; created_at = Masc_domain.now_iso ()
+           ; expires_at = None
+           };
+         match
+           Operator_control.confirm_json
+             ctx
+             (`Assoc
+                 [ "actor", `String "operator"; "confirm_token", `String token ])
+         with
+         | Ok _ -> fail "goal decision without explicit decision should reject"
+         | Error msg -> check string "decision rejection" "payload.decision is required" msg
+       in
+       assert_rejected ~token:"missing-decision" (`Assoc []);
+       assert_rejected
+         ~token:"blank-decision"
+         (`Assoc [ "decision", `String "  " ]))
 ;;
 
 let () =
@@ -1605,6 +1664,10 @@ let () =
             "approval operator action registered"
             `Quick
             test_goal_approval_operator_action_registered
+        ; test_case
+            "operator goal decision requires explicit decision"
+            `Quick
+            test_operator_goal_decision_requires_explicit_decision
         ] )
     ]
 ;;

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -45,6 +45,45 @@ let workspace_ctx ?(agent_name = "planner") config : Tool_workspace.context =
   { Tool_workspace.config; agent_name }
 ;;
 
+let with_operator_pending_confirm_hooks f =
+  let previous_trace = Atomic.get Workspace_hooks.operator_pending_confirm_trace_id_fn in
+  let previous_upsert = Atomic.get Workspace_hooks.operator_pending_confirm_upsert_fn in
+  let previous_remove =
+    Atomic.get Workspace_hooks.operator_pending_confirms_remove_by_target_fn
+  in
+  Atomic.set
+    Workspace_hooks.operator_pending_confirm_trace_id_fn
+    Operator_pending_confirm.trace_id;
+  Atomic.set
+    Workspace_hooks.operator_pending_confirm_upsert_fn
+    (fun config (entry : Workspace_hooks.operator_pending_confirm_request) ->
+       Operator_pending_confirm.upsert_pending_confirm
+         config
+         { token = entry.token
+         ; trace_id = entry.trace_id
+         ; actor = entry.actor
+         ; action_type = entry.action_type
+         ; target_type = entry.target_type
+         ; target_id = entry.target_id
+         ; payload = entry.payload
+         ; delegated_tool = entry.delegated_tool
+         ; created_at = entry.created_at
+         ; expires_at = entry.expires_at
+         };
+       Ok ());
+  Atomic.set
+    Workspace_hooks.operator_pending_confirms_remove_by_target_fn
+    Operator_pending_confirm.remove_pending_confirms_by_target;
+  Fun.protect
+    ~finally:(fun () ->
+      Atomic.set Workspace_hooks.operator_pending_confirm_trace_id_fn previous_trace;
+      Atomic.set Workspace_hooks.operator_pending_confirm_upsert_fn previous_upsert;
+      Atomic.set
+        Workspace_hooks.operator_pending_confirms_remove_by_target_fn
+        previous_remove)
+    f
+;;
+
 let parse_json_result (result : Tool_result.result) =
   if (Tool_result.is_success result)
   then Yojson.Safe.from_string ((Tool_result.message result))
@@ -695,6 +734,8 @@ let test_goal_transition_manual_reject_blocks_and_cancels_request () =
 ;;
 
 let test_goal_transition_approval_gate () =
+  with_operator_pending_confirm_hooks
+  @@ fun () ->
   with_workspace
   @@ fun config ->
   let verifier_policy =


### PR DESCRIPTION
## Summary
- addresses the audit finding that a goal entering `Awaiting_approval` emitted `goal_approval_opened` without any durable operator approval request
- persists goal completion approval requests through a dependency-safe `Workspace_hooks` callback wired by the operator layer, using deterministic `goal-approval:<goal_id>` tokens
- clears the exact goal approval pending-confirm token when the goal leaves `Awaiting_approval`, including direct `reject_completion` and `drop` operator transitions
- registers `goal_completion_decision` as a high-risk operator action targeting `goal`, delegated to `masc_goal_transition`
- hardens operator goal decisions so missing/blank decision payloads reject instead of defaulting to approve, and deny removes the pending confirm before returning execution errors
- centralizes the new goal operator action/tool/target constants in `Operator_action_constants`
- adds regression coverage for approval persistence, approval decision validation, and cleanup on `approve_completion`, `reject_completion`, and `drop`

## RFC Waiver
RFC-WAIVED: This PR is a narrow audit remediation for goal completion approval persistence. It reuses the existing operator pending-confirm ledger, keeps the operator storage implementation owned by the operator layer via `Workspace_hooks`, and does not introduce a new operator-control protocol or approval state machine.

## Verification
- `ocamlformat --check lib/operator_action_constants.ml lib/workspace/workspace_hooks.ml lib/workspace/workspace_hooks.mli lib/operator_approval.ml lib/workspace_goals.ml lib/operator/operator_control_action.ml lib/operator/operator_control.ml lib/operator/operator_pending_confirm.ml lib/operator/operator_tool.ml test/test_goal_tools.ml`
- `ocamlc -stop-after parsing lib/operator_action_constants.ml lib/workspace/workspace_hooks.mli lib/workspace/workspace_hooks.ml lib/operator_approval.ml lib/workspace_goals.ml lib/operator/operator_control_action.ml lib/operator/operator_control.ml lib/operator/operator_pending_confirm.ml lib/operator/operator_tool.ml test/test_goal_tools.ml`
- `ocamlformat --check lib/workspace_goals.ml test/test_goal_tools.ml`
- `ocamlc -stop-after parsing lib/workspace_goals.ml test/test_goal_tools.ml`
- `git diff --check`

No Dune/local build was run; CI remains the build authority.
