### PR TITLE
fix(keeper): report dead health blockers as terminal

### DIFF
--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -381,9 +381,9 @@ let resolve_mentions ~mentions content =
             ; raw_mention = raw
             }
             :: !resolved;
-          (match name_opt with
+          match name_opt with
           | Some name -> "@" ^ name
-          | None -> raw))
+          | None -> raw)
   in
   (content, List.rev !resolved)
 

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -381,9 +381,9 @@ let resolve_mentions ~mentions content =
             ; raw_mention = raw
             }
             :: !resolved;
-          match name_opt with
+          (match name_opt with
           | Some name -> "@" ^ name
-          | None -> raw)
+          | None -> raw))
   in
   (content, List.rev !resolved)
 

--- a/lib/keeper_registry/keeper_state_machine.ml
+++ b/lib/keeper_registry/keeper_state_machine.ml
@@ -7,6 +7,27 @@
    [Keeper_state_machine_types] (godfile decomp). *)
 include Keeper_state_machine_types
 
+(** [is_terminal phase] is true iff [phase] cannot accept new turns.
+
+    Stopped, Dead, and Zombie are terminal: in [can_transition] every
+    outgoing edge from these sources is denied. Centralized here so the
+    FSM, health surfaces, and the mermaid renderer share one source of
+    truth instead of re-matching the terminal triple at each consumer.
+    Exhaustive (no [_] wildcard) so adding a phase variant surfaces a
+    compile-time warning here. *)
+let is_terminal = function
+  | Stopped | Dead | Zombie -> true
+  | Offline
+  | Running
+  | Failing
+  | Overflowed
+  | Compacting
+  | HandingOff
+  | Draining
+  | Paused
+  | Crashed
+  | Restarting -> false
+
 
 (* ── derive_phase ──────────────────────────────────────── *)
 

--- a/lib/keeper_registry/keeper_state_machine.mli
+++ b/lib/keeper_registry/keeper_state_machine.mli
@@ -52,6 +52,12 @@ val phase_to_string : phase -> string
 val phase_of_string : string -> phase option
 val all_phases : phase list
 
+(** [is_terminal phase] is true for Stopped/Dead/Zombie — phases with no
+    outgoing transition (see {!can_transition}). Shared by health surfaces
+    and the mermaid renderer so the terminal triple is defined once in the
+    FSM instead of re-matched at each consumer. *)
+val is_terminal : phase -> bool
+
 (** {1 Observable Conditions (Kubernetes Pattern)} *)
 
 (** Observable boolean conditions computed from keeper state.

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -612,21 +612,6 @@ type blocked_keeper_reason =
   | No_keeper_binding
   | Unknown
 
-let keeper_phase_is_terminal = function
-  | Keeper_state_machine.Stopped
-  | Keeper_state_machine.Dead
-  | Keeper_state_machine.Zombie -> true
-  | Keeper_state_machine.Offline
-  | Keeper_state_machine.Running
-  | Keeper_state_machine.Failing
-  | Keeper_state_machine.Overflowed
-  | Keeper_state_machine.Compacting
-  | Keeper_state_machine.HandingOff
-  | Keeper_state_machine.Draining
-  | Keeper_state_machine.Paused
-  | Keeper_state_machine.Crashed
-  | Keeper_state_machine.Restarting -> false
-
 let blocked_keeper_reason_label = function
   | Durable_paused_autoboot_enabled -> "durable_paused_autoboot_enabled"
   | Meta_read_error -> "meta_read_error"
@@ -711,7 +696,7 @@ let blocked_keeper_detail_json
   let phase_name = Option.map Keeper_state_machine.phase_to_string phase in
   let terminal_phase =
     match phase with
-    | Some phase -> keeper_phase_is_terminal phase
+    | Some phase -> Keeper_state_machine.is_terminal phase
     | None -> false
   in
   let last_failure_fields =

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -1073,13 +1073,6 @@ let keeper_fleet_safety_health_json
     else if active_task_owner_without_executable_fiber then "degraded"
     else "ok"
   in
-  let blocked_count =
-    if no_executable_keeper_fibers then executable_reaction_capacity_shortfall_count
-    else if no_running_fibers || low_running_fiber_margin || reaction_capacity_below_target
-    then reaction_capacity_shortfall_count
-    else if active_task_owner_is_selected_blocker then active_task_owner_without_executable_fiber_count
-    else 0
-  in
   let blocked_keeper_names =
     if no_executable_keeper_fibers then names_not_in executable_names
     else if no_running_fibers || low_running_fiber_margin || reaction_capacity_below_target
@@ -1087,6 +1080,7 @@ let keeper_fleet_safety_health_json
     else if active_task_owner_is_selected_blocker then active_task_owner_blocked_names
     else []
   in
+  let blocked_count = List.length blocked_keeper_names in
   let active_capacity_names =
     if no_executable_keeper_fibers then executable_names
     else if no_running_fibers || low_running_fiber_margin || reaction_capacity_below_target

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -410,7 +410,7 @@ type keeper_phase_snapshot =
   ; running_names : string list
   ; recovering_names : string list
   ; executable_names : string list
-  ; phase_names : (string * string) list
+  ; phase_values : (string * Keeper_state_machine.phase) list
   }
 
 let keeper_phase_snapshot ?base_path () =
@@ -420,9 +420,7 @@ let keeper_phase_snapshot ?base_path () =
           let acc =
             {
               acc with
-              phase_names =
-                (entry.name, Keeper_state_machine.phase_to_string entry.phase)
-                :: acc.phase_names;
+              phase_values = (entry.name, entry.phase) :: acc.phase_values;
             }
           in
           let counts = acc.counts in
@@ -456,7 +454,7 @@ let keeper_phase_snapshot ?base_path () =
               running_names = entry.name :: acc.running_names;
               recovering_names;
               executable_names;
-              phase_names = acc.phase_names;
+              phase_values = acc.phase_values;
             }
           | Keeper_state_machine.Failing ->
             {
@@ -483,7 +481,7 @@ let keeper_phase_snapshot ?base_path () =
          running_names = [];
          recovering_names = [];
          executable_names = [];
-         phase_names = [];
+         phase_values = [];
        }
   |> fun snapshot ->
   {
@@ -491,8 +489,8 @@ let keeper_phase_snapshot ?base_path () =
     running_names = sorted_unique_strings snapshot.running_names;
     recovering_names = sorted_unique_strings snapshot.recovering_names;
     executable_names = sorted_unique_strings snapshot.executable_names;
-    phase_names =
-      List.sort (fun (a, _) (b, _) -> String.compare a b) snapshot.phase_names;
+    phase_values =
+      List.sort (fun (a, _) (b, _) -> String.compare a b) snapshot.phase_values;
   }
 
 let keeper_phase_counts ?base_path () = (keeper_phase_snapshot ?base_path ()).counts
@@ -608,18 +606,33 @@ type blocked_keeper_reason =
   | Meta_read_error
   | Not_bootable
   | Boot_failure of Keeper_runtime.boot_meta_failure_cause
-  | Phase of string
+  | Phase of Keeper_state_machine.phase
   | Not_registered
   | Not_running
   | No_keeper_binding
   | Unknown
+
+let keeper_phase_is_terminal = function
+  | Keeper_state_machine.Stopped
+  | Keeper_state_machine.Dead
+  | Keeper_state_machine.Zombie -> true
+  | Keeper_state_machine.Offline
+  | Keeper_state_machine.Running
+  | Keeper_state_machine.Failing
+  | Keeper_state_machine.Overflowed
+  | Keeper_state_machine.Compacting
+  | Keeper_state_machine.HandingOff
+  | Keeper_state_machine.Draining
+  | Keeper_state_machine.Paused
+  | Keeper_state_machine.Crashed
+  | Keeper_state_machine.Restarting -> false
 
 let blocked_keeper_reason_label = function
   | Durable_paused_autoboot_enabled -> "durable_paused_autoboot_enabled"
   | Meta_read_error -> "meta_read_error"
   | Not_bootable -> "not_bootable"
   | Boot_failure cause -> Keeper_runtime.boot_meta_failure_cause_label cause
-  | Phase phase -> "phase_" ^ phase
+  | Phase phase -> "phase_" ^ Keeper_state_machine.phase_to_string phase
   | Not_registered -> "not_registered"
   | Not_running -> "not_running"
   | No_keeper_binding -> "no_keeper_binding"
@@ -640,7 +653,20 @@ let blocked_keeper_action = function
       "add_goal_or_goal_horizon_to_keeper_toml"
   | Boot_failure Keeper_runtime.Materialization_failed ->
       "inspect_keeper_autoboot_logs"
-  | Phase _
+  | Phase Keeper_state_machine.Dead -> "inspect_dead_keeper_root_cause"
+  | Phase Keeper_state_machine.Zombie -> "repair_terminal_keeper_failure"
+  | Phase Keeper_state_machine.Stopped -> "restart_or_disable_stopped_keeper"
+  | Phase Keeper_state_machine.Paused -> "resume_or_leave_paused"
+  | Phase
+      ( Keeper_state_machine.Offline
+      | Keeper_state_machine.Running
+      | Keeper_state_machine.Failing
+      | Keeper_state_machine.Overflowed
+      | Keeper_state_machine.Compacting
+      | Keeper_state_machine.HandingOff
+      | Keeper_state_machine.Draining
+      | Keeper_state_machine.Crashed
+      | Keeper_state_machine.Restarting )
   | Not_registered ->
       "start_or_recover_keeper"
   | Not_running -> "start_or_recover_keeper"
@@ -682,6 +708,12 @@ let blocked_keeper_detail_json
              | None -> Not_registered)
           else Unknown
   in
+  let phase_name = Option.map Keeper_state_machine.phase_to_string phase in
+  let terminal_phase =
+    match phase with
+    | Some phase -> keeper_phase_is_terminal phase
+    | None -> false
+  in
   let last_failure_fields =
     match last_failure with
     | None ->
@@ -706,7 +738,8 @@ let blocked_keeper_detail_json
        ("name", `String name);
        ("reason", `String (blocked_keeper_reason_label reason));
        ("action", `String (blocked_keeper_action reason));
-       ("phase", Json_util.string_opt_to_json phase);
+       ("phase", Json_util.string_opt_to_json phase_name);
+       ("terminal_phase", `Bool terminal_phase);
        ("bootable", `Bool is_bootable);
        ("reaction_capacity", `Bool is_capacity);
        ("paused", `Bool is_paused);
@@ -976,12 +1009,12 @@ let keeper_fleet_safety_health_json
   let active_task_owner_without_executable_fiber =
     active_task_owner_without_executable_fiber_count > 0
   in
-  let phase_names =
+  let phase_values =
     match phase_snapshot with
-    | Some snapshot -> snapshot.phase_names
+    | Some snapshot -> snapshot.phase_values
     | None -> []
   in
-  let phase_name name = List.assoc_opt name phase_names in
+  let phase_value name = List.assoc_opt name phase_values in
   let minimum_running_fibers =
     if target_count <= 1 then target_count else 2
   in
@@ -1080,7 +1113,7 @@ let keeper_fleet_safety_health_json
            (fun name ->
              blocked_keeper_detail_json
                ?base_path:runtime_base_path
-               ?phase:(phase_name name)
+               ?phase:(phase_value name)
                ~bootable_set
                ~capacity_set
                ~paused_set

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -623,40 +623,89 @@ let blocked_keeper_reason_label = function
   | No_keeper_binding -> "no_keeper_binding"
   | Unknown -> "unknown"
 
+type blocked_keeper_operator_action =
+  | Resume_or_leave_paused
+  | Repair_keeper_meta_file
+  | Add_keeper_toml_or_disable_stale_autoboot_meta
+  | Run_keeper_up_or_recreate_meta
+  | Repair_keeper_toml_config
+  | Add_sandbox_profile_to_keeper_toml
+  | Add_goal_or_goal_horizon_to_keeper_toml
+  | Inspect_keeper_autoboot_logs
+  | Inspect_dead_keeper_root_cause
+  | Repair_terminal_keeper_failure
+  | Restart_or_disable_stopped_keeper
+  | Start_or_recover_keeper
+  | Inspect_capacity_accounting
+  | Repair_failing_keeper
+  | Recover_context_overflow
+  | Wait_for_compaction
+  | Wait_for_handoff
+  | Wait_for_keeper_drain
+  | Inspect_crashed_keeper
+  | Wait_for_keeper_restart
+  | Create_keeper_or_reassign_task
+
+let blocked_keeper_operator_action_to_string = function
+  | Resume_or_leave_paused -> "resume_or_leave_paused"
+  | Repair_keeper_meta_file -> "repair_keeper_meta_file"
+  | Add_keeper_toml_or_disable_stale_autoboot_meta ->
+      "add_keeper_toml_or_disable_stale_autoboot_meta"
+  | Run_keeper_up_or_recreate_meta -> "run_keeper_up_or_recreate_meta"
+  | Repair_keeper_toml_config -> "repair_keeper_toml_config"
+  | Add_sandbox_profile_to_keeper_toml -> "add_sandbox_profile_to_keeper_toml"
+  | Add_goal_or_goal_horizon_to_keeper_toml ->
+      "add_goal_or_goal_horizon_to_keeper_toml"
+  | Inspect_keeper_autoboot_logs -> "inspect_keeper_autoboot_logs"
+  | Inspect_dead_keeper_root_cause -> "inspect_dead_keeper_root_cause"
+  | Repair_terminal_keeper_failure -> "repair_terminal_keeper_failure"
+  | Restart_or_disable_stopped_keeper -> "restart_or_disable_stopped_keeper"
+  | Start_or_recover_keeper -> "start_or_recover_keeper"
+  | Inspect_capacity_accounting -> "inspect_capacity_accounting"
+  | Repair_failing_keeper -> "repair_failing_keeper"
+  | Recover_context_overflow -> "recover_context_overflow"
+  | Wait_for_compaction -> "wait_for_compaction"
+  | Wait_for_handoff -> "wait_for_handoff"
+  | Wait_for_keeper_drain -> "wait_for_keeper_drain"
+  | Inspect_crashed_keeper -> "inspect_crashed_keeper"
+  | Wait_for_keeper_restart -> "wait_for_keeper_restart"
+  | Create_keeper_or_reassign_task -> "create_keeper_or_reassign_task"
+
 let blocked_keeper_action = function
-  | Durable_paused_autoboot_enabled -> "resume_or_leave_paused"
-  | Meta_read_error -> "repair_keeper_meta_file"
-  | Not_bootable -> "add_keeper_toml_or_disable_stale_autoboot_meta"
-  | Boot_failure Keeper_runtime.Missing_meta -> "run_keeper_up_or_recreate_meta"
-  | Boot_failure Keeper_runtime.Meta_read_error -> "repair_keeper_meta_file"
+  | Durable_paused_autoboot_enabled -> Resume_or_leave_paused
+  | Meta_read_error -> Repair_keeper_meta_file
+  | Not_bootable -> Add_keeper_toml_or_disable_stale_autoboot_meta
+  | Boot_failure Keeper_runtime.Missing_meta -> Run_keeper_up_or_recreate_meta
+  | Boot_failure Keeper_runtime.Meta_read_error -> Repair_keeper_meta_file
   | Boot_failure Keeper_runtime.Config_parse_failed
   | Boot_failure Keeper_runtime.Invalid_profile ->
-      "repair_keeper_toml_config"
+      Repair_keeper_toml_config
   | Boot_failure Keeper_runtime.Sandbox_profile_required ->
-      "add_sandbox_profile_to_keeper_toml"
+      Add_sandbox_profile_to_keeper_toml
   | Boot_failure Keeper_runtime.Goal_required ->
-      "add_goal_or_goal_horizon_to_keeper_toml"
+      Add_goal_or_goal_horizon_to_keeper_toml
   | Boot_failure Keeper_runtime.Materialization_failed ->
-      "inspect_keeper_autoboot_logs"
-  | Phase Keeper_state_machine.Dead -> "inspect_dead_keeper_root_cause"
-  | Phase Keeper_state_machine.Zombie -> "repair_terminal_keeper_failure"
-  | Phase Keeper_state_machine.Stopped -> "restart_or_disable_stopped_keeper"
-  | Phase Keeper_state_machine.Paused -> "resume_or_leave_paused"
-  | Phase
-      ( Keeper_state_machine.Offline
-      | Keeper_state_machine.Running
-      | Keeper_state_machine.Failing
-      | Keeper_state_machine.Overflowed
-      | Keeper_state_machine.Compacting
-      | Keeper_state_machine.HandingOff
-      | Keeper_state_machine.Draining
-      | Keeper_state_machine.Crashed
-      | Keeper_state_machine.Restarting )
-  | Not_registered ->
-      "start_or_recover_keeper"
-  | Not_running -> "start_or_recover_keeper"
-  | No_keeper_binding -> "create_keeper_or_reassign_task"
-  | Unknown -> "inspect_keeper_autoboot_logs"
+      Inspect_keeper_autoboot_logs
+  | Phase Keeper_state_machine.Dead -> Inspect_dead_keeper_root_cause
+  | Phase Keeper_state_machine.Zombie -> Repair_terminal_keeper_failure
+  | Phase Keeper_state_machine.Stopped -> Restart_or_disable_stopped_keeper
+  | Phase Keeper_state_machine.Paused -> Resume_or_leave_paused
+  | Phase Keeper_state_machine.Offline -> Start_or_recover_keeper
+  | Phase Keeper_state_machine.Running -> Inspect_capacity_accounting
+  | Phase Keeper_state_machine.Failing -> Repair_failing_keeper
+  | Phase Keeper_state_machine.Overflowed -> Recover_context_overflow
+  | Phase Keeper_state_machine.Compacting -> Wait_for_compaction
+  | Phase Keeper_state_machine.HandingOff -> Wait_for_handoff
+  | Phase Keeper_state_machine.Draining -> Wait_for_keeper_drain
+  | Phase Keeper_state_machine.Crashed -> Inspect_crashed_keeper
+  | Phase Keeper_state_machine.Restarting -> Wait_for_keeper_restart
+  | Not_registered -> Start_or_recover_keeper
+  | Not_running -> Start_or_recover_keeper
+  | No_keeper_binding -> Create_keeper_or_reassign_task
+  | Unknown -> Inspect_keeper_autoboot_logs
+
+let blocked_keeper_action_label reason =
+  reason |> blocked_keeper_action |> blocked_keeper_operator_action_to_string
 
 let active_task_owner_fiber_scan_semantics =
   "reports active task owners without executable keeper fibers; disabled \
@@ -694,10 +743,10 @@ let blocked_keeper_detail_json
           else Unknown
   in
   let phase_name = Option.map Keeper_state_machine.phase_to_string phase in
-  let terminal_phase =
+  let terminal_phase_field =
     match phase with
-    | Some phase -> Keeper_state_machine.is_terminal phase
-    | None -> false
+    | Some phase -> [ ("terminal_phase", `Bool (Keeper_state_machine.is_terminal phase)) ]
+    | None -> []
   in
   let last_failure_fields =
     match last_failure with
@@ -722,14 +771,14 @@ let blocked_keeper_detail_json
        ("keeper", `String name);
        ("name", `String name);
        ("reason", `String (blocked_keeper_reason_label reason));
-       ("action", `String (blocked_keeper_action reason));
+       ("action", `String (blocked_keeper_action_label reason));
        ("phase", Json_util.string_opt_to_json phase_name);
-       ("terminal_phase", `Bool terminal_phase);
        ("bootable", `Bool is_bootable);
        ("reaction_capacity", `Bool is_capacity);
        ("paused", `Bool is_paused);
        ("meta_read_error", `Bool has_read_error);
      ]
+     @ terminal_phase_field
      @ last_failure_fields)
 
 type active_task_owner_without_executable_fiber = {
@@ -771,8 +820,8 @@ let active_task_assignment (task : Masc_domain.task) =
 let active_task_owner_without_executable_fiber_json row =
   let action =
     match row.keeper_name with
-    | Some _ -> blocked_keeper_action Not_running
-    | None -> blocked_keeper_action No_keeper_binding
+    | Some _ -> blocked_keeper_action_label Not_running
+    | None -> blocked_keeper_action_label No_keeper_binding
   in
   `Assoc
     [
@@ -911,7 +960,7 @@ let active_task_owner_blocked_detail_json row =
       ("task_id", `String row.task_id);
       ("task_status", `String row.task_status);
       ("reason", `String (blocked_keeper_reason_label reason));
-      ("action", `String (blocked_keeper_action reason));
+      ("action", `String (blocked_keeper_action_label reason));
     ]
 
 let keeper_fleet_safety_health_json
@@ -1174,8 +1223,13 @@ let keeper_fleet_safety_health_json
       , `Int executable_reaction_capacity_shortfall_count )
     ; "paused_keeper_count", `Int paused_total_count
     ; "paused_autoboot_enabled_keeper_count", `Int paused_autoboot_count
+    ; "blocked_keeper_count", `Int blocked_count
     ; "blocked_count", `Int blocked_count
+    ; ( "blocked_count_semantics"
+      , `String "number of named keepers currently listed in blocked_keeper_names" )
     ; "blocked_keepers", `Int blocked_count
+    ; ( "blocked_keepers_semantics"
+      , `String "legacy alias for blocked_keeper_count" )
     ; ( "blocked_keeper_names"
       , `List (List.map (fun name -> `String name) blocked_keeper_names) )
     ; "blocked_keeper_reasons", `List blocked_keeper_reasons

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -83,7 +83,7 @@ type keeper_phase_snapshot = {
   running_names : string list;
   recovering_names : string list;
   executable_names : string list;
-  phase_names : (string * string) list;
+  phase_values : (string * Keeper_state_machine.phase) list;
 }
 val keeper_phase_snapshot : ?base_path:string -> unit -> keeper_phase_snapshot
 val keeper_phase_counts : ?base_path:string -> unit -> keeper_phase_counts

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1496,7 +1496,7 @@ let test_health_json_ignores_stale_active_task_alias_when_agent_executable () =
             running_names = [ executor.name ];
             recovering_names = [];
             executable_names = [ executor.name ];
-            phase_names = [ (executor.name, "running") ];
+            phase_values = [ (executor.name, Keeper_state_machine.Running) ];
           }
         in
         let fleet_safety =
@@ -1649,7 +1649,7 @@ let test_health_json_preserves_active_task_owner_meta_read_error () =
             running_names = [];
             recovering_names = [];
             executable_names = [];
-            phase_names = [];
+            phase_values = [];
           }
         in
         let fleet_safety =

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1863,6 +1863,60 @@ let test_health_json_explains_phase_paused_capacity_blocker () =
                   ( row |> member "keeper" |> to_string
                   , row |> member "reason" |> to_string ))))))
 
+let test_health_json_explains_dead_capacity_blocker_as_terminal () =
+  with_temp_dir "health-dead-capacity-blocker" (fun dir ->
+    let config_root = make_config_root dir in
+    write_config_root_keeper_toml config_root "dead-capacity";
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        let dead =
+          make_keeper_meta ~name:"dead-capacity" ~trace_id:"trace-dead-capacity" ()
+        in
+        write_keeper_meta_exn config dead;
+        with_running_keeper_metas config [ dead ] (fun () ->
+          Keeper_registry.mark_dead
+            ~base_path:config.Workspace.base_path
+            dead.name
+            ~at:0.0;
+          let request = Httpun.Request.create `GET "/health" in
+          let json = Server_routes_http_runtime.make_health_json request in
+          let open Yojson.Safe.Util in
+          let fleet_safety = json |> member "keeper_fleet_safety" in
+          Alcotest.(check (list string))
+            "health includes dead keeper in blocked targets"
+            [ "dead-capacity"; "example" ]
+            (fleet_safety |> member "blocked_keeper_names" |> to_list
+             |> List.map to_string);
+          Alcotest.(check (list (pair string string)))
+            "health explains dead blocked keeper"
+            [ ("dead-capacity", "phase_dead"); ("example", "not_registered") ]
+            (fleet_safety |> member "blocked_keeper_reasons" |> to_list
+             |> List.map (fun row ->
+                  ( row |> member "keeper" |> to_string
+                  , row |> member "reason" |> to_string )));
+          let dead_detail =
+            fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            |> List.find (fun row ->
+                 row |> member "keeper" |> to_string = "dead-capacity")
+          in
+          Alcotest.(check string) "health reports typed dead phase" "dead"
+            (dead_detail |> member "phase" |> to_string);
+          Alcotest.(check bool) "health marks dead phase terminal" true
+            (dead_detail |> member "terminal_phase" |> to_bool);
+          Alcotest.(check string)
+            "health does not suggest normal start recovery for dead keepers"
+            "inspect_dead_keeper_root_cause"
+            (dead_detail |> member "action" |> to_string))))
+
 let test_health_json_distinguishes_failing_executable_keepers () =
   with_temp_dir "health-failing-executable-keepers" (fun dir ->
     let config_root = make_config_root dir in
@@ -3517,6 +3571,9 @@ let () =
           Alcotest.test_case
             "health json explains phase-paused capacity blocker"
             `Quick test_health_json_explains_phase_paused_capacity_blocker;
+          Alcotest.test_case
+            "health json explains dead capacity blocker as terminal"
+            `Quick test_health_json_explains_dead_capacity_blocker_as_terminal;
           Alcotest.test_case
             "health json distinguishes failing executable keepers"
             `Quick test_health_json_distinguishes_failing_executable_keepers;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1029,6 +1029,8 @@ let make_task ?(title = "Task") ?(description = "") ~id ~status () : Types.task 
     do_not_reclaim_reason = None;
   }
 
+let terminal_fixture_epoch = 0.0
+
 let write_keeper_meta_exn config meta =
   match Keeper_meta_store.write_meta config meta with
   | Ok () -> ()
@@ -1049,18 +1051,31 @@ let with_running_keeper_metas config metas f =
         metas)
     f
 
-let mark_keeper_failing config (meta : Keeper_meta_contract.keeper_meta) =
+let dispatch_keeper_event config (meta : Keeper_meta_contract.keeper_meta) event =
   match
     Keeper_registry.dispatch_event
       ~base_path:config.Workspace.base_path
       meta.name
-      (Keeper_state_machine.Turn_failed { consecutive = 1; max_allowed = 10 })
+      event
   with
   | Ok _ -> ()
   | Error err ->
-    Alcotest.fail
-      ("keeper failing transition failed: "
-       ^ Keeper_state_machine.transition_error_to_string err)
+      Alcotest.fail
+        ("keeper phase transition failed: "
+        ^ Keeper_state_machine.transition_error_to_string err)
+
+let mark_keeper_failing config (meta : Keeper_meta_contract.keeper_meta) =
+  dispatch_keeper_event config meta
+    (Keeper_state_machine.Turn_failed { consecutive = 1; max_allowed = 10 })
+
+let mark_keeper_stopped config (meta : Keeper_meta_contract.keeper_meta) =
+  dispatch_keeper_event config meta Keeper_state_machine.Stop_requested;
+  dispatch_keeper_event config meta Keeper_state_machine.Drain_complete
+
+let mark_keeper_zombie config (meta : Keeper_meta_contract.keeper_meta) =
+  dispatch_keeper_event config meta
+    (Keeper_state_machine.Terminal_failure_detected
+       { reason = "terminal fixture structural failure" })
 
 let exhaust_keeper_restart_budget config (meta : Keeper_meta_contract.keeper_meta) =
   match
@@ -1914,10 +1929,16 @@ let test_health_json_explains_phase_paused_capacity_blocker () =
                   ( row |> member "keeper" |> to_string
                   , row |> member "reason" |> to_string ))))))
 
-let test_health_json_explains_dead_capacity_blocker_as_terminal () =
-  with_temp_dir "health-dead-capacity-blocker" (fun dir ->
+let test_health_json_explains_terminal_capacity_blocker
+    ~dir_name
+    ~keeper_name
+    ~trace_id
+    ~expected_phase
+    ~expected_action
+    mark_terminal =
+  with_temp_dir dir_name (fun dir ->
     let config_root = make_config_root dir in
-    write_config_root_keeper_toml config_root "dead-capacity";
+    write_config_root_keeper_toml config_root keeper_name;
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
     let previous_state = !Server_auth.server_state in
     Config_dir_resolver.reset ();
@@ -1929,44 +1950,72 @@ let test_health_json_explains_dead_capacity_blocker_as_terminal () =
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
-        let dead =
-          make_keeper_meta ~name:"dead-capacity" ~trace_id:"trace-dead-capacity" ()
-        in
-        write_keeper_meta_exn config dead;
-        with_running_keeper_metas config [ dead ] (fun () ->
-          Keeper_registry.mark_dead
-            ~base_path:config.Workspace.base_path
-            dead.name
-            ~at:0.0;
+        let terminal = make_keeper_meta ~name:keeper_name ~trace_id () in
+        write_keeper_meta_exn config terminal;
+        with_running_keeper_metas config [ terminal ] (fun () ->
+          mark_terminal config terminal;
           let request = Httpun.Request.create `GET "/health" in
           let json = Server_routes_http_runtime.make_health_json request in
           let open Yojson.Safe.Util in
           let fleet_safety = json |> member "keeper_fleet_safety" in
           Alcotest.(check (list string))
-            "health includes dead keeper in blocked targets"
-            [ "dead-capacity"; "example" ]
+            "health includes terminal keeper in blocked targets"
+            (List.sort String.compare [ keeper_name; "example" ])
             (fleet_safety |> member "blocked_keeper_names" |> to_list
              |> List.map to_string);
           Alcotest.(check (list (pair string string)))
-            "health explains dead blocked keeper"
-            [ ("dead-capacity", "phase_dead"); ("example", "not_registered") ]
+            "health explains terminal blocked keeper"
+            (List.sort compare
+               [ (keeper_name, "phase_" ^ expected_phase); ("example", "not_registered") ])
             (fleet_safety |> member "blocked_keeper_reasons" |> to_list
              |> List.map (fun row ->
                   ( row |> member "keeper" |> to_string
                   , row |> member "reason" |> to_string )));
-          let dead_detail =
+          let terminal_detail =
             fleet_safety |> member "blocked_keeper_reasons" |> to_list
             |> List.find (fun row ->
-                 row |> member "keeper" |> to_string = "dead-capacity")
+                 row |> member "keeper" |> to_string = keeper_name)
           in
-          Alcotest.(check string) "health reports typed dead phase" "dead"
-            (dead_detail |> member "phase" |> to_string);
-          Alcotest.(check bool) "health marks dead phase terminal" true
-            (dead_detail |> member "terminal_phase" |> to_bool);
+          Alcotest.(check string) "health reports typed terminal phase"
+            expected_phase
+            (terminal_detail |> member "phase" |> to_string);
+          Alcotest.(check bool) "health marks terminal phase terminal" true
+            (terminal_detail |> member "terminal_phase" |> to_bool);
           Alcotest.(check string)
-            "health does not suggest normal start recovery for dead keepers"
-            "inspect_dead_keeper_root_cause"
-            (dead_detail |> member "action" |> to_string))))
+            "health reports terminal keeper action"
+            expected_action
+            (terminal_detail |> member "action" |> to_string))))
+
+let test_health_json_explains_dead_capacity_blocker_as_terminal () =
+  test_health_json_explains_terminal_capacity_blocker
+    ~dir_name:"health-dead-capacity-blocker"
+    ~keeper_name:"dead-capacity"
+    ~trace_id:"trace-dead-capacity"
+    ~expected_phase:"dead"
+    ~expected_action:"inspect_dead_keeper_root_cause"
+    (fun config meta ->
+      Keeper_registry.mark_dead
+        ~base_path:config.Workspace.base_path
+        meta.name
+        ~at:terminal_fixture_epoch)
+
+let test_health_json_explains_stopped_capacity_blocker_as_terminal () =
+  test_health_json_explains_terminal_capacity_blocker
+    ~dir_name:"health-stopped-capacity-blocker"
+    ~keeper_name:"stopped-capacity"
+    ~trace_id:"trace-stopped-capacity"
+    ~expected_phase:"stopped"
+    ~expected_action:"restart_or_disable_stopped_keeper"
+    mark_keeper_stopped
+
+let test_health_json_explains_zombie_capacity_blocker_as_terminal () =
+  test_health_json_explains_terminal_capacity_blocker
+    ~dir_name:"health-zombie-capacity-blocker"
+    ~keeper_name:"zombie-capacity"
+    ~trace_id:"trace-zombie-capacity"
+    ~expected_phase:"zombie"
+    ~expected_action:"repair_terminal_keeper_failure"
+    mark_keeper_zombie
 
 let test_health_json_distinguishes_failing_executable_keepers () =
   with_temp_dir "health-failing-executable-keepers" (fun dir ->
@@ -2064,7 +2113,17 @@ let test_health_json_explains_nonrecoverable_failing_keeper () =
             (fleet_safety |> member "blocked_keeper_reasons" |> to_list
              |> List.map (fun row ->
                   ( row |> member "keeper" |> to_string
-                  , row |> member "reason" |> to_string ))))))
+                  , row |> member "reason" |> to_string )));
+          let failing_detail =
+            fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            |> List.find (fun row ->
+                 row |> member "keeper" |> to_string = "capacity-failing")
+          in
+          Alcotest.(check string) "health reports failing action"
+            "repair_failing_keeper"
+            (failing_detail |> member "action" |> to_string);
+          Alcotest.(check bool) "health marks failing phase non-terminal" false
+            (failing_detail |> member "terminal_phase" |> to_bool))))
 
 let test_health_json_reaction_ledger_cursor_sweep_clears_pending () =
   with_temp_dir "health-reaction-ledger-cursor-sweep" (fun dir ->
@@ -3629,6 +3688,12 @@ let () =
           Alcotest.test_case
             "health json explains dead capacity blocker as terminal"
             `Quick test_health_json_explains_dead_capacity_blocker_as_terminal;
+          Alcotest.test_case
+            "health json explains stopped capacity blocker as terminal"
+            `Quick test_health_json_explains_stopped_capacity_blocker_as_terminal;
+          Alcotest.test_case
+            "health json explains zombie capacity blocker as terminal"
+            `Quick test_health_json_explains_zombie_capacity_blocker_as_terminal;
           Alcotest.test_case
             "health json distinguishes failing executable keepers"
             `Quick test_health_json_distinguishes_failing_executable_keepers;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1777,6 +1777,57 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
             (fleet_safety |> member "operator_action_required" |> to_bool);
           ())))
 
+let test_health_json_blocked_count_matches_blocked_names_with_non_target_capacity () =
+  with_temp_dir "health-blocked-count-non-target-capacity" (fun dir ->
+    let config_root = make_config_root dir in
+    List.iter
+      (write_config_root_keeper_toml config_root)
+      [ "target-missing"; "target-running" ];
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        let target_running =
+          make_keeper_meta ~name:"target-running" ~trace_id:"trace-target-running" ()
+        in
+        let target_missing =
+          make_keeper_meta ~name:"target-missing" ~trace_id:"trace-target-missing" ()
+        in
+        let non_target_running =
+          make_keeper_meta
+            ~name:"non-target-running"
+            ~trace_id:"trace-non-target-running"
+            ()
+        in
+        List.iter
+          (write_keeper_meta_exn config)
+          [ target_running; target_missing; non_target_running ];
+        with_running_keeper_metas config [ target_running; non_target_running ]
+          (fun () ->
+            let request = Httpun.Request.create `GET "/health" in
+            let json = Server_routes_http_runtime.make_health_json request in
+            let open Yojson.Safe.Util in
+            let fleet_safety = json |> member "keeper_fleet_safety" in
+            Alcotest.(check int) "health counts all running capacity" 2
+              (fleet_safety |> member "effective_reaction_capacity_count" |> to_int);
+            Alcotest.(check int) "capacity shortfall remains numeric capacity" 1
+              (fleet_safety |> member "reaction_capacity_shortfall_count" |> to_int);
+            Alcotest.(check (list string)) "health names blocked target keepers"
+              [ "example"; "target-missing" ]
+              (fleet_safety |> member "blocked_keeper_names" |> to_list
+               |> List.map to_string);
+            Alcotest.(check int) "blocked count matches blocked keeper names" 2
+              (fleet_safety |> member "blocked_count" |> to_int);
+            Alcotest.(check int) "blocked_keepers alias matches names" 2
+              (fleet_safety |> member "blocked_keepers" |> to_int))))
+
 let test_health_json_ignores_persisted_only_keeper_for_capacity_target () =
   with_temp_dir "health-persisted-only-keeper-target" (fun dir ->
     let config_root = make_config_root dir in
@@ -3564,6 +3615,10 @@ let () =
           Alcotest.test_case
             "health json degrades when reaction capacity is below target"
             `Quick test_health_json_degrades_when_reaction_capacity_below_target;
+          Alcotest.test_case
+            "health json blocked count matches named target blockers"
+            `Quick
+            test_health_json_blocked_count_matches_blocked_names_with_non_target_capacity;
           Alcotest.test_case
             "health json ignores persisted-only keeper for capacity target"
             `Quick


### PR DESCRIPTION
## Summary

- Preserve keeper fleet-safety phase data as typed `Keeper_state_machine.phase` until JSON rendering.
- Report terminal phase blockers with terminal-specific actions instead of generic `start_or_recover_keeper`.
- Add a health regression for a bootable keeper marked `Dead`, including `terminal_phase=true`.

## Verification

- `ocamlformat --check lib/server/server_routes_http_runtime_fleet_scan.ml lib/server/server_routes_http_runtime_fleet_scan.mli test/test_server_runtime_bootstrap.ml`
- `git diff --check`
- Touched-file risk scan for local path literals, default base hardcoding, env reads, string-contains matching, TODO/FIXME/stub, `failwith`, and `assert false`
- Attempted `scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe` before and after rebasing; both attempts were stopped because `/tmp/me-dune-local.lock` was held by other worktrees (`build @all`, then `runtest`). CI remains the build authority for this slice.
