### PR TITLE
fix(goal): reject inactive verification requests

### DIFF
--- a/lib/goal/goal_verification.ml
+++ b/lib/goal/goal_verification.ml
@@ -274,6 +274,10 @@ type goal_verification_request = {
   resolved_at : string option;
 }
 
+type cancel_request_result =
+  | Cancelled_request of goal_verification_request
+  | Already_resolved_request of goal_verification_request
+
 let goal_verification_request_to_yojson (request : goal_verification_request) =
   `Assoc
     [
@@ -639,13 +643,13 @@ let evaluate_quorum request =
   else
     Pending
 
-let cancel_request config ~(request_id : string) =
+let cancel_request_if_open config ~(request_id : string) =
   let lock_path = requests_path config in
   Workspace_utils.with_file_lock config lock_path (fun () ->
       let state = read_state config in
       match List.find_opt (fun request -> String.equal request.id request_id) state.requests with
       | None -> Error "goal verification request not found"
-      | Some request when request.status <> Open -> Ok request
+      | Some request when request.status <> Open -> Ok (Already_resolved_request request)
       | Some request ->
           let resolved_at = Masc_domain.now_iso () in
           let updated_request =
@@ -663,7 +667,12 @@ let cancel_request config ~(request_id : string) =
           in
           write_state config
             { version = state.version + 1; updated_at = resolved_at; requests };
-          Ok updated_request)
+          Ok (Cancelled_request updated_request))
+
+let cancel_request config ~(request_id : string) =
+  match cancel_request_if_open config ~request_id with
+  | Ok (Cancelled_request request | Already_resolved_request request) -> Ok request
+  | Error msg -> Error msg
 
 let submit_vote config ~(goal_id : string) ~(request_id : string) ~(principal : goal_principal)
     ~(decision : vote_decision) ?note ?(evidence_refs = []) () =

--- a/lib/goal/goal_verification.mli
+++ b/lib/goal/goal_verification.mli
@@ -154,6 +154,10 @@ type goal_verification_request = {
     for future phase gates.  [resolved_at] is set when
     [status] transitions out of [Open]. *)
 
+type cancel_request_result =
+  | Cancelled_request of goal_verification_request
+  | Already_resolved_request of goal_verification_request
+
 val goal_verification_request_to_yojson :
   goal_verification_request -> Yojson.Safe.t
 val goal_verification_request_of_yojson :
@@ -283,6 +287,14 @@ val cancel_request :
     [resolved_at].  Idempotent on already-non-[Open]
     requests (returns [Ok request] without mutation).
     Errors when [request_id] is unknown. *)
+
+val cancel_request_if_open :
+  Workspace_utils.config ->
+  request_id:string ->
+  (cancel_request_result, string) result
+(** Like {!cancel_request}, but reports whether this call performed the
+    [Open] -> [Cancelled] transition or found an already resolved
+    request. *)
 
 val submit_vote :
   Workspace_utils.config ->

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -395,19 +395,21 @@ let cancel_created_verification_request ctx ~goal_id ~request_id ~reason =
     emit_goal_event
       ctx
       ~goal_id
-      ~event_type:"goal_verification_cancelled"
+      ~event_type:"goal_verification_resolved"
       ~payload:
         (`Assoc
             [ "request_id", `String request_id
             ; "reason", `String reason
             ; "status", `String "cancelled"
-            ])
+            ]);
+    Ok ()
   | Error cleanup_msg ->
     Log.Misc.warn
       "goal verification compensation failed for %s after %s: %s"
       request_id
       reason
-      cleanup_msg
+      cleanup_msg;
+    Error cleanup_msg
 ;;
 
 let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.result =
@@ -604,11 +606,22 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                                ()
                            with
                            | Error msg ->
-                             cancel_created_verification_request
-                               ctx
-                               ~goal_id
-                               ~request_id:request.id
-                               ~reason:"goal_phase_update_failed";
+                             let cleanup_result =
+                               cancel_created_verification_request
+                                 ctx
+                                 ~goal_id
+                                 ~request_id:request.id
+                                 ~reason:"goal_phase_update_failed"
+                             in
+                             let msg =
+                               match cleanup_result with
+                               | Ok () -> msg
+                               | Error cleanup_msg ->
+                                 Printf.sprintf
+                                   "%s; verification cleanup failed: %s"
+                                   msg
+                                   cleanup_msg
+                             in
                              error_result_typed
                                ~tool_name
                                ~start_time

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -389,9 +389,16 @@ let update_goal_phase = Workspace_goals_verification.update_goal_phase
 
 let emit_goal_event = Workspace_goals_verification.emit_goal_event
 
+let goal_verification_request_status_label = function
+  | Goal_verification.Open -> "open"
+  | Goal_verification.Approved -> "approved"
+  | Goal_verification.Rejected -> "rejected"
+  | Goal_verification.Cancelled -> "cancelled"
+;;
+
 let cancel_created_verification_request ctx ~goal_id ~request_id ~reason =
-  match Goal_verification.cancel_request ctx.config ~request_id with
-  | Ok _ ->
+  match Goal_verification.cancel_request_if_open ctx.config ~request_id with
+  | Ok (Goal_verification.Cancelled_request _) ->
     emit_goal_event
       ctx
       ~goal_id
@@ -403,6 +410,19 @@ let cancel_created_verification_request ctx ~goal_id ~request_id ~reason =
             ; "status", `String "cancelled"
             ]);
     Ok ()
+  | Ok (Goal_verification.Already_resolved_request request) ->
+    let cleanup_msg =
+      Printf.sprintf
+        "goal verification request %s was already %s"
+        request_id
+        (goal_verification_request_status_label request.status)
+    in
+    Log.Misc.warn
+      "goal verification compensation skipped for %s after %s: %s"
+      request_id
+      reason
+      cleanup_msg;
+    Error cleanup_msg
   | Error cleanup_msg ->
     Log.Misc.warn
       "goal verification compensation failed for %s after %s: %s"
@@ -745,8 +765,8 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                        not a quorum verdict. Seal the open request as cancelled;
                        quorum failure is handled in [handle_goal_verify] as
                        [Rejected] and moves the goal back to [Executing]. *)
-                    (match Goal_verification.cancel_request ctx.config ~request_id with
-                     | Ok _ ->
+                    (match Goal_verification.cancel_request_if_open ctx.config ~request_id with
+                     | Ok (Goal_verification.Cancelled_request _) ->
                        emit_goal_event
                          ctx
                          ~goal_id
@@ -756,6 +776,11 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                                [ "request_id", `String request_id
                                ; "status", `String "cancelled"
                                ])
+                     | Ok (Goal_verification.Already_resolved_request request) ->
+                       Log.Misc.warn
+                         "goal verification cancel_request skipped for %s: already %s"
+                         request_id
+                         (goal_verification_request_status_label request.status)
                      | Error msg ->
                        Log.Misc.warn
                          "goal verification cancel_request failed for %s: %s"

--- a/lib/workspace_goals.ml
+++ b/lib/workspace_goals.ml
@@ -389,6 +389,27 @@ let update_goal_phase = Workspace_goals_verification.update_goal_phase
 
 let emit_goal_event = Workspace_goals_verification.emit_goal_event
 
+let cancel_created_verification_request ctx ~goal_id ~request_id ~reason =
+  match Goal_verification.cancel_request ctx.config ~request_id with
+  | Ok _ ->
+    emit_goal_event
+      ctx
+      ~goal_id
+      ~event_type:"goal_verification_cancelled"
+      ~payload:
+        (`Assoc
+            [ "request_id", `String request_id
+            ; "reason", `String reason
+            ; "status", `String "cancelled"
+            ])
+  | Error cleanup_msg ->
+    Log.Misc.warn
+      "goal verification compensation failed for %s after %s: %s"
+      request_id
+      reason
+      cleanup_msg
+;;
+
 let handle_goal_list ~tool_name ~start_time (ctx : context) args : Tool_result.result =
   match
     ( reject_retired_goal_list_status args
@@ -583,6 +604,11 @@ let handle_goal_transition ~tool_name ~start_time (ctx : context) args : Tool_re
                                ()
                            with
                            | Error msg ->
+                             cancel_created_verification_request
+                               ctx
+                               ~goal_id
+                               ~request_id:request.id
+                               ~reason:"goal_phase_update_failed";
                              error_result_typed
                                ~tool_name
                                ~start_time
@@ -833,17 +859,28 @@ let handle_goal_verify ~tool_name ~start_time (ctx : context) args : Tool_result
             ~code:Conflict
             "goal has no active verification request"
         | Some request_id ->
-          (match
-             Goal_verification.submit_vote
-               ctx.config
-               ~goal_id
-               ~request_id
-               ~principal
-               ~decision
-               ?note
-               ~evidence_refs
-               ()
-           with
+          if
+            goal.phase <> Goal_phase.Awaiting_verification
+            || not
+                 (Option.equal String.equal goal.active_verification_request_id (Some request_id))
+          then
+            error_result_typed
+              ~tool_name
+              ~start_time
+              ~code:Conflict
+              "goal verification request is not active on this goal"
+          else
+            (match
+               Goal_verification.submit_vote
+                 ctx.config
+                 ~goal_id
+                 ~request_id
+                 ~principal
+                 ~decision
+                 ?note
+                 ~evidence_refs
+                 ()
+             with
            | Error msg -> error_result_typed ~tool_name ~start_time ~code:Conflict msg
            | Ok (request, quorum_result) ->
              let goals = Goal_store.list_goals ctx.config () in

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -1096,6 +1096,92 @@ let test_goal_verify_rejects_inactive_request_id () =
     (Goal_phase.to_string saved_goal.phase)
 ;;
 
+let test_goal_verify_rejects_non_active_request_id () =
+  with_workspace
+  @@ fun config ->
+  let verifier = { Goal_verification.id = "agent-alpha"; display_name = None } in
+  let verifier_policy =
+    { Goal_verification.inherit_mode = Goal_verification.Extend
+    ; principals = [ verifier ]
+    ; required_verdicts = Some 1
+    }
+  in
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Reject stale request" ~verifier_policy () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  create_done_task config ~goal_id:goal.id ~title:"Reject stale request task";
+  let transitioned =
+    Tool_workspace.dispatch
+      (workspace_ctx config)
+      ~name:"masc_goal_transition"
+      ~args:
+        (`Assoc
+            [ "goal_id", `String goal.id
+            ; "action", `String "request_complete"
+            ; "actor", principal_json ~id:"planner"
+            ])
+  in
+  let transitioned_json =
+    match transitioned with
+    | Some result -> parse_json_result result
+    | None -> fail "masc_goal_transition not handled"
+  in
+  let active_request_id =
+    transitioned_json
+    |> Yojson.Safe.Util.member "verification_request"
+    |> fun json -> get_string_field json "id"
+  in
+  let policy_snapshot : Goal_verification.policy_snapshot =
+    { principals = [ verifier ]; eligible_principals = [ verifier ]; required_verdicts = 1 }
+  in
+  let stale_request =
+    match
+      Goal_verification.create_request
+        config
+        ~goal_id:goal.id
+        ~requested_by:{ id = "planner"; display_name = None }
+        ~policy_snapshot
+    with
+    | Ok request -> request
+    | Error msg -> fail msg
+  in
+  let rejected =
+    Tool_workspace.dispatch
+      (workspace_ctx ~agent_name:"agent-alpha" config)
+      ~name:"masc_goal_verify"
+      ~args:
+        (`Assoc
+            [ "goal_id", `String goal.id
+            ; "request_id", `String stale_request.id
+            ; "principal", principal_json ~id:"agent-alpha"
+            ; "decision", `String "approve"
+            ])
+  in
+  let error_json = expect_error rejected in
+  check string "non-active request rejected" "conflict"
+    (get_string_field error_json "error_code");
+  check string "non-active request error" "goal verification request is not active on this goal"
+    (get_string_field error_json "error");
+  let saved_goal =
+    match Goal_store.get_goal config ~goal_id:goal.id with
+    | Some goal -> goal
+    | None -> fail "goal missing after stale request vote"
+  in
+  check
+    (option string)
+    "active request unchanged"
+    (Some active_request_id)
+    saved_goal.active_verification_request_id;
+  let saved_stale_request =
+    match Goal_verification.find_request config ~request_id:stale_request.id with
+    | Some request -> request
+    | None -> fail "stale verification request missing after rejected vote"
+  in
+  check int "no stale-request vote written" 0 (List.length saved_stale_request.votes)
+;;
+
 let test_goal_review_removed_from_dispatch () =
   with_workspace
   @@ fun config ->
@@ -1400,6 +1486,10 @@ let () =
             "verify rejects inactive request"
             `Quick
             test_goal_verify_rejects_inactive_request_id
+        ; test_case
+            "verify rejects non-active request"
+            `Quick
+            test_goal_verify_rejects_non_active_request_id
         ; test_case
             "completion requires linked task"
             `Quick

--- a/test/test_goal_tools.ml
+++ b/test/test_goal_tools.ml
@@ -1041,6 +1041,61 @@ let test_goal_verify_rejects_cross_goal_request_id () =
   check int "no cross-goal vote written" 0 (List.length saved_request.votes)
 ;;
 
+let test_goal_verify_rejects_inactive_request_id () =
+  with_workspace
+  @@ fun config ->
+  let goal, _kind =
+    match Goal_store.upsert_goal config ~title:"Inactive request guard" () with
+    | Ok payload -> payload
+    | Error msg -> fail msg
+  in
+  let verifier = { Goal_verification.id = "agent-alpha"; display_name = None } in
+  let policy_snapshot : Goal_verification.policy_snapshot =
+    { principals = [ verifier ]; eligible_principals = [ verifier ]; required_verdicts = 1 }
+  in
+  let request =
+    match
+      Goal_verification.create_request
+        config
+        ~goal_id:goal.id
+        ~requested_by:{ id = "planner"; display_name = None }
+        ~policy_snapshot
+    with
+    | Ok request -> request
+    | Error msg -> fail msg
+  in
+  let rejected =
+    Tool_workspace.dispatch
+      (workspace_ctx ~agent_name:"agent-alpha" config)
+      ~name:"masc_goal_verify"
+      ~args:
+        (`Assoc
+            [ "goal_id", `String goal.id
+            ; "request_id", `String request.id
+            ; "principal", principal_json ~id:"agent-alpha"
+            ; "decision", `String "approve"
+            ])
+  in
+  let error_json = expect_error rejected in
+  check string "inactive request rejected" "conflict"
+    (get_string_field error_json "error_code");
+  check string "inactive request error" "goal verification request is not active on this goal"
+    (get_string_field error_json "error");
+  let saved_request =
+    match Goal_verification.find_request config ~request_id:request.id with
+    | Some request -> request
+    | None -> fail "verification request missing after inactive vote"
+  in
+  check int "no inactive-request vote written" 0 (List.length saved_request.votes);
+  let saved_goal =
+    match Goal_store.get_goal config ~goal_id:goal.id with
+    | Some goal -> goal
+    | None -> fail "goal missing after inactive vote"
+  in
+  check string "phase unchanged" (Goal_phase.to_string goal.phase)
+    (Goal_phase.to_string saved_goal.phase)
+;;
+
 let test_goal_review_removed_from_dispatch () =
   with_workspace
   @@ fun config ->
@@ -1341,6 +1396,10 @@ let () =
             "verify rejects cross-goal request"
             `Quick
             test_goal_verify_rejects_cross_goal_request_id
+        ; test_case
+            "verify rejects inactive request"
+            `Quick
+            test_goal_verify_rejects_inactive_request_id
         ; test_case
             "completion requires linked task"
             `Quick

--- a/test/test_goal_verification.ml
+++ b/test/test_goal_verification.ml
@@ -46,6 +46,14 @@ let request_snapshot ~requested_by =
     required_verdicts = 2;
   }
 
+let single_approver_snapshot ~requested_by =
+  let reviewer = operator "reviewer-1" in
+  {
+    Goal_verification.principals = [ requested_by; reviewer ];
+    eligible_principals = [ reviewer ];
+    required_verdicts = 1;
+  }
+
 let test_cancel_missing_request_does_not_bump () =
   with_workspace @@ fun config ->
   let before = Goal_verification.read_state config in
@@ -85,6 +93,46 @@ let test_invalid_vote_does_not_bump () =
   in
   check int "no votes written" 0 (List.length saved.votes)
 
+let test_cancel_if_open_reports_already_resolved () =
+  with_workspace @@ fun config ->
+  let requested_by = operator "planner" in
+  let reviewer = operator "reviewer-1" in
+  let request =
+    match
+      Goal_verification.create_request config ~goal_id:"goal-1" ~requested_by
+        ~policy_snapshot:(single_approver_snapshot ~requested_by)
+    with
+    | Ok request -> request
+    | Error msg -> fail msg
+  in
+  let approved_request =
+    match
+      Goal_verification.submit_vote config ~request_id:request.id ~goal_id:"goal-1"
+        ~principal:reviewer ~decision:Goal_verification.Approve ()
+    with
+    | Ok (request, _) -> request
+    | Error msg -> fail msg
+  in
+  check bool "fixture approved" true
+    (approved_request.status = Goal_verification.Approved);
+  let before = Goal_verification.read_state config in
+  (match Goal_verification.cancel_request_if_open config ~request_id:request.id with
+   | Ok (Goal_verification.Already_resolved_request resolved) ->
+       check bool "already resolved status preserved" true
+         (resolved.status = Goal_verification.Approved)
+   | Ok (Goal_verification.Cancelled_request _) ->
+       fail "approved request must not report a fresh cancellation"
+   | Error msg -> fail msg);
+  let after = Goal_verification.read_state config in
+  check int "version unchanged on already resolved cancel" before.version after.version;
+  let saved =
+    match Goal_verification.find_request config ~request_id:request.id with
+    | Some request -> request
+    | None -> fail "request missing after already resolved cancel"
+  in
+  check bool "saved status still approved" true
+    (saved.status = Goal_verification.Approved)
+
 let () =
   run "Goal_verification"
     [
@@ -94,5 +142,7 @@ let () =
             test_cancel_missing_request_does_not_bump;
           test_case "invalid vote: no bump" `Quick
             test_invalid_vote_does_not_bump;
+          test_case "cancel if open reports already resolved" `Quick
+            test_cancel_if_open_reports_already_resolved;
         ] );
     ]


### PR DESCRIPTION
## Summary
- addresses part of the audit finding that `goal_verifications.json` and `goals.json` can drift
- rejects `masc_goal_verify` votes unless the goal is currently `Awaiting_verification` and the request id is the goal active request id
- prevents ledger-only/orphan verification requests from receiving votes or driving a goal phase transition
- adds compensation: if request creation succeeds but the goal phase update fails, cancel the newly created verification request and emit the existing `goal_verification_resolved` / `status=cancelled` event shape
- surfaces compensation cleanup failure in the returned error message instead of logging only
- adds `Goal_verification.cancel_request_if_open` so callers can distinguish a fresh `Open -> Cancelled` transition from an already resolved request
- emits cancellation events only for actual cancellation transitions, avoiding store/event drift when compensation races with an already approved/rejected request
- adds regressions for inactive requests, stale/non-active request ids, and already-resolved cancellation races

## Verification
- `ocamlformat --check lib/workspace_goals.ml test/test_goal_tools.ml`
- `ocamlc -stop-after parsing lib/workspace_goals.ml test/test_goal_tools.ml`
- `ocamlformat --check lib/goal/goal_verification.ml lib/goal/goal_verification.mli lib/workspace_goals.ml test/test_goal_verification.ml`
- `ocamlc -stop-after parsing lib/goal/goal_verification.ml lib/goal/goal_verification.mli lib/workspace_goals.ml test/test_goal_verification.ml`
- `git diff --check`

No Dune/local build was run; CI remains the build authority.

## Note
This is a bounded hardening PR, not a full cross-file transaction coordinator. It closes the immediately exploitable vote path for inactive/orphan requests, adds cleanup on the known post-create update failure path, and now makes cleanup failure visible to the caller. Existing historical drift reconciliation remains follow-up work outside this patch.
