### PR TITLE
fix(keeper): expose registry cause in fleet health

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ scripts/run-local.sh --target-dir "$PWD"
 
 ### Run modes
 
-- **`scripts/start-loopback.sh`**: 고정 포트 `8935`로 기동. Keeper 스케줄러를 끄고 순수 로컬 Mock 디버깅용으로 사용한다.
+- **`scripts/start-loopback.sh`**: 고정 포트 `8935`로 기동. Keeper 스케줄러를 끄고 순수 로컬 Mock 디버깅용으로 사용한다. Keeper autoboot가 필요하면 `--with-keeper-bootstrap`을 명시한다.
 - **`scripts/run-local.sh --target-dir /path`**: 지정한 폴더 기준으로 격리 기동. 포트는 폴더 경로 해시를 기반으로 `9100-9999` 범위에서 자동 할당한다.
 - **`./start-masc.sh --http`**: Keeper 스케줄러를 포함한 전체 런타임을 기동한다.
 

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -485,8 +485,6 @@ let keeper_phase_snapshot ?base_path () =
               running_names = entry.name :: acc.running_names;
               recovering_names;
               executable_names;
-              phase_values = acc.phase_values;
-              phase_details = acc.phase_details;
             }
           | Keeper_state_machine.Failing ->
             {
@@ -794,7 +792,8 @@ let blocked_keeper_detail_json
   let is_bootable = String_set.mem name bootable_set in
   let is_capacity = String_set.mem name capacity_set in
   let has_read_error = String_set.mem name read_error_set in
-  let phase = Option.map (fun detail -> detail.phase) phase_detail in
+  let phase_name = Option.map (fun detail -> detail.phase) phase_detail in
+  let phase = Option.bind phase_name Keeper_state_machine.phase_of_string in
   let last_failure =
     match base_path with
     | None -> None
@@ -816,7 +815,6 @@ let blocked_keeper_detail_json
                else Bootstrap_disabled)
           else Unknown
   in
-  let phase_name = Option.map Keeper_state_machine.phase_to_string phase in
   let terminal_phase_field =
     match phase with
     | Some phase -> [ ("terminal_phase", `Bool (Keeper_state_machine.is_terminal phase)) ]

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -641,6 +641,7 @@ type blocked_keeper_reason =
   | Not_bootable
   | Boot_failure of Keeper_runtime.boot_meta_failure_cause
   | Phase of Keeper_state_machine.phase
+  | Bootstrap_disabled
   | Not_registered
   | Not_running
   | No_keeper_binding
@@ -652,6 +653,7 @@ let blocked_keeper_reason_label = function
   | Not_bootable -> "not_bootable"
   | Boot_failure cause -> Keeper_runtime.boot_meta_failure_cause_label cause
   | Phase phase -> "phase_" ^ Keeper_state_machine.phase_to_string phase
+  | Bootstrap_disabled -> "keeper_bootstrap_disabled"
   | Not_registered -> "not_registered"
   | Not_running -> "not_running"
   | No_keeper_binding -> "no_keeper_binding"
@@ -666,6 +668,7 @@ type blocked_keeper_operator_action =
   | Add_sandbox_profile_to_keeper_toml
   | Add_goal_or_goal_horizon_to_keeper_toml
   | Inspect_keeper_autoboot_logs
+  | Enable_keeper_bootstrap_or_start_manually
   | Inspect_dead_keeper_root_cause
   | Repair_terminal_keeper_failure
   | Restart_or_disable_stopped_keeper
@@ -691,6 +694,8 @@ let blocked_keeper_operator_action_to_string = function
   | Add_goal_or_goal_horizon_to_keeper_toml ->
       "add_goal_or_goal_horizon_to_keeper_toml"
   | Inspect_keeper_autoboot_logs -> "inspect_keeper_autoboot_logs"
+  | Enable_keeper_bootstrap_or_start_manually ->
+      "enable_keeper_bootstrap_or_start_manually"
   | Inspect_dead_keeper_root_cause -> "inspect_dead_keeper_root_cause"
   | Repair_terminal_keeper_failure -> "repair_terminal_keeper_failure"
   | Restart_or_disable_stopped_keeper -> "restart_or_disable_stopped_keeper"
@@ -720,6 +725,7 @@ let blocked_keeper_action = function
       Add_goal_or_goal_horizon_to_keeper_toml
   | Boot_failure Keeper_runtime.Materialization_failed ->
       Inspect_keeper_autoboot_logs
+  | Bootstrap_disabled -> Enable_keeper_bootstrap_or_start_manually
   | Phase Keeper_state_machine.Dead -> Inspect_dead_keeper_root_cause
   | Phase Keeper_state_machine.Zombie -> Repair_terminal_keeper_failure
   | Phase Keeper_state_machine.Stopped -> Restart_or_disable_stopped_keeper
@@ -771,6 +777,7 @@ let blocked_keeper_detail_json
     ?base_path
     ?phase
     ?phase_detail
+    ~keeper_bootstrap_enabled
     ~bootable_set
     ~capacity_set
     ~paused_set
@@ -796,7 +803,9 @@ let blocked_keeper_detail_json
           else if not is_capacity then
             (match phase with
              | Some phase -> Phase phase
-             | None -> Not_registered)
+             | None ->
+               if keeper_bootstrap_enabled then Not_registered
+               else Bootstrap_disabled)
           else Unknown
   in
   let phase_name = Option.map Keeper_state_machine.phase_to_string phase in
@@ -804,6 +813,11 @@ let blocked_keeper_detail_json
     match phase with
     | Some phase -> [ ("terminal_phase", `Bool (Keeper_state_machine.is_terminal phase)) ]
     | None -> []
+  in
+  let keeper_bootstrap_blocker =
+    match reason with
+    | Bootstrap_disabled -> Some "keeper_bootstrap_disabled"
+    | _ -> None
   in
   let last_failure_fields =
     match last_failure with
@@ -860,6 +874,9 @@ let blocked_keeper_detail_json
        ("reaction_capacity", `Bool is_capacity);
        ("paused", `Bool is_paused);
        ("meta_read_error", `Bool has_read_error);
+       ("keeper_bootstrap_enabled", `Bool keeper_bootstrap_enabled);
+       ( "keeper_bootstrap_blocker"
+       , Json_util.string_opt_to_json keeper_bootstrap_blocker );
      ]
      @ terminal_phase_field
      @ last_failure_fields
@@ -1053,6 +1070,7 @@ let keeper_fleet_safety_health_json
     ?phase_snapshot
     ?base_path
     ?reaction_capacity_names
+    ?keeper_bootstrap_enabled:keeper_bootstrap_enabled_override
     ~phase_counts
     ~paused_keepers_json
     () =
@@ -1076,6 +1094,11 @@ let keeper_fleet_safety_health_json
   in
   let bootable_count = List.length bootable_names in
   let target_count = List.length autoboot_scan.autoboot_names in
+  let keeper_bootstrap_enabled =
+    match keeper_bootstrap_enabled_override with
+    | Some value -> value
+    | None -> Env_config.KeeperBootstrap.enabled
+  in
   let runtime_base_path =
     match base_path with
     | Some _ as value -> value
@@ -1153,13 +1176,21 @@ let keeper_fleet_safety_health_json
   let reaction_capacity_below_target =
     target_count > 0 && reaction_capacity_shortfall_count > 0
   in
+  let keeper_bootstrap_blocked =
+    (not keeper_bootstrap_enabled)
+    && (no_executable_keeper_fibers
+       || no_running_fibers
+       || low_running_fiber_margin
+       || reaction_capacity_below_target)
+  in
   let active_task_owner_is_selected_blocker =
     active_task_owner_without_executable_fiber
     && not
          (no_executable_keeper_fibers
           || no_running_fibers
           || low_running_fiber_margin
-          || reaction_capacity_below_target)
+          || reaction_capacity_below_target
+          || keeper_bootstrap_blocked)
   in
   let executable_reaction_capacity_shortfall_count =
     max 0 (target_count - phase_counts.executable)
@@ -1233,6 +1264,7 @@ let keeper_fleet_safety_health_json
                ?base_path:runtime_base_path
                ?phase:(phase_value name)
                ?phase_detail:(phase_detail name)
+               ~keeper_bootstrap_enabled
                ~bootable_set
                ~capacity_set
                ~paused_set
@@ -1240,7 +1272,8 @@ let keeper_fleet_safety_health_json
                name)
   in
   let blocker =
-    if no_executable_keeper_fibers then Some "no_executable_keeper_fibers"
+    if keeper_bootstrap_blocked then Some "keeper_bootstrap_disabled"
+    else if no_executable_keeper_fibers then Some "no_executable_keeper_fibers"
     else if no_running_fibers then Some "no_healthy_running_keeper_fibers"
     else if low_running_fiber_margin then Some "low_running_fiber_margin"
     else if reaction_capacity_below_target then Some "reaction_capacity_below_target"
@@ -1252,6 +1285,9 @@ let keeper_fleet_safety_health_json
   `Assoc
     [ "status", `String status
     ; ("blocker", Json_util.string_opt_to_json blocker)
+    ; "keeper_bootstrap_enabled", `Bool keeper_bootstrap_enabled
+    ; ( "keeper_bootstrap_blocker"
+      , if keeper_bootstrap_blocked then `String "keeper_bootstrap_disabled" else `Null )
     ; "bootable_keeper_count", `Int bootable_count
     ; ( "bootable_keeper_names"
       , `List (List.map (fun name -> `String name) bootable_names) )
@@ -1330,5 +1366,6 @@ let keeper_fleet_safety_health_json
            || no_running_fibers
            || low_running_fiber_margin
            || reaction_capacity_below_target
+           || keeper_bootstrap_blocked
            || active_task_owner_without_executable_fiber) )
     ]

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -752,6 +752,13 @@ let active_task_owner_fiber_scan_semantics =
   "reports active task owners without executable keeper fibers; disabled \
    keepers are excluded; matching rows can degrade fleet status"
 
+(* Maximum length of the diagnostic string surfaced on public [/health]
+   fields via [public_health_diagnostic_preview]. Operational limit (UX
+   contract for operator-facing snippets), not a security bound — full
+   redaction happens upstream through [Keeper_secret_redaction] and
+   [Observability_redact.redact_text]; this only truncates the tail. *)
+let max_public_diagnostic_preview_len = 240
+
 let public_health_diagnostic_preview ?base_path ~keeper_name text =
   let text =
     match base_path with
@@ -772,7 +779,7 @@ let public_health_diagnostic_preview ?base_path ~keeper_name text =
         let redaction = Keeper_secret_redaction.snapshot ~base_path ~keeper_name in
         Keeper_secret_redaction.redact_text redaction text
   in
-  Observability_redact.redact_preview ~max_len:240 text
+  Observability_redact.redact_preview ~max_len:max_public_diagnostic_preview_len text
 
 let blocked_keeper_detail_json
     ?base_path
@@ -1238,6 +1245,11 @@ let keeper_fleet_safety_health_json
     else if active_task_owner_is_selected_blocker then active_task_owner_blocked_names
     else []
   in
+  (* Counts unique blocked keeper NAMES, not capacity shortfall. This
+     intentionally differs from pre-#22388 behavior, which reported
+     [executable_reaction_capacity_shortfall_count]; see the PR summary.
+     Consumers should read this as "number of named blockers" rather than
+     missing capacity slots. *)
   let blocked_count = List.length blocked_keeper_names in
   let active_capacity_names =
     if no_executable_keeper_fibers then executable_names

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -745,6 +745,28 @@ let active_task_owner_fiber_scan_semantics =
   "reports active task owners without executable keeper fibers; disabled \
    keepers are excluded; matching rows can degrade fleet status"
 
+let public_health_diagnostic_preview ?base_path ~keeper_name text =
+  let text =
+    match base_path with
+    | None -> text
+    | Some base_path ->
+        let base_path = String.trim base_path in
+        if base_path = "" then text
+        else
+          String_util.replace_substring
+            ~needle:base_path
+            ~by:"[REDACTED_PATH]"
+            text
+  in
+  let text =
+    match base_path with
+    | None -> Observability_redact.redact_text text
+    | Some base_path ->
+        let redaction = Keeper_secret_redaction.snapshot ~base_path ~keeper_name in
+        Keeper_secret_redaction.redact_text redaction text
+  in
+  Observability_redact.redact_preview ~max_len:240 text
+
 let blocked_keeper_detail_json
     ?base_path
     ?phase
@@ -813,13 +835,18 @@ let blocked_keeper_detail_json
           ("latest_crash_reason", `Null);
         ]
     | Some detail ->
+        let diagnostic_preview =
+          public_health_diagnostic_preview ?base_path ~keeper_name:name
+        in
         [
           ("last_failure_reason", Json_util.string_opt_to_json detail.last_failure_reason);
-          ("last_error", Json_util.string_opt_to_json detail.last_error);
+          ("last_error", Json_util.string_opt_to_json (Option.map diagnostic_preview detail.last_error));
           ("restart_count", `Int detail.restart_count);
           ("dead_since_ts", Json_util.float_opt_to_json detail.dead_since_ts);
           ("latest_crash_at", Json_util.float_opt_to_json detail.latest_crash_at);
-          ("latest_crash_reason", Json_util.string_opt_to_json detail.latest_crash_reason);
+          ( "latest_crash_reason"
+          , Json_util.string_opt_to_json
+              (Option.map diagnostic_preview detail.latest_crash_reason) );
         ]
   in
   `Assoc

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -480,6 +480,7 @@ let keeper_phase_snapshot ?base_path () =
           match entry.phase with
           | Keeper_state_machine.Running ->
             {
+              acc with
               counts = { counts with running = counts.running + 1; executable };
               running_names = entry.name :: acc.running_names;
               recovering_names;
@@ -775,7 +776,6 @@ let public_health_diagnostic_preview ?base_path ~keeper_name text =
 
 let blocked_keeper_detail_json
     ?base_path
-    ?phase
     ?phase_detail
     ~keeper_bootstrap_enabled
     ~bootable_set
@@ -787,6 +787,7 @@ let blocked_keeper_detail_json
   let is_bootable = String_set.mem name bootable_set in
   let is_capacity = String_set.mem name capacity_set in
   let has_read_error = String_set.mem name read_error_set in
+  let phase = Option.map (fun detail -> detail.phase) phase_detail in
   let last_failure =
     match base_path with
     | None -> None
@@ -853,7 +854,9 @@ let blocked_keeper_detail_json
           public_health_diagnostic_preview ?base_path ~keeper_name:name
         in
         [
-          ("last_failure_reason", Json_util.string_opt_to_json detail.last_failure_reason);
+          ( "last_failure_reason"
+          , Json_util.string_opt_to_json
+              (Option.map diagnostic_preview detail.last_failure_reason) );
           ("last_error", Json_util.string_opt_to_json (Option.map diagnostic_preview detail.last_error));
           ("restart_count", `Int detail.restart_count);
           ("dead_since_ts", Json_util.float_opt_to_json detail.dead_since_ts);

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -405,22 +405,52 @@ type keeper_phase_counts =
 let empty_keeper_phase_counts =
   { running = 0; failing = 0; recovering = 0; executable = 0 }
 
+type keeper_phase_detail =
+  { phase : string
+  ; last_failure_reason : string option
+  ; last_error : string option
+  ; restart_count : int
+  ; dead_since_ts : float option
+  ; latest_crash_at : float option
+  ; latest_crash_reason : string option
+  }
+
 type keeper_phase_snapshot =
   { counts : keeper_phase_counts
   ; running_names : string list
   ; recovering_names : string list
   ; executable_names : string list
   ; phase_values : (string * Keeper_state_machine.phase) list
+  ; phase_details : (string * keeper_phase_detail) list
+  }
+
+let keeper_phase_detail_of_entry (entry : Keeper_registry.registry_entry) =
+  let latest_crash_at, latest_crash_reason =
+    match entry.crash_log with
+    | (ts, reason) :: _ -> (Some ts, Some reason)
+    | [] -> (None, None)
+  in
+  {
+    phase = Keeper_state_machine.phase_to_string entry.phase;
+    last_failure_reason =
+      Option.map Keeper_registry.failure_reason_to_string entry.last_failure_reason;
+    last_error = entry.last_error;
+    restart_count = entry.restart_count;
+    dead_since_ts = entry.dead_since_ts;
+    latest_crash_at;
+    latest_crash_reason;
   }
 
 let keeper_phase_snapshot ?base_path () =
   Keeper_registry.all ?base_path ()
   |> List.fold_left
        (fun acc (entry : Keeper_registry.registry_entry) ->
-          let acc =
+         let acc =
             {
               acc with
               phase_values = (entry.name, entry.phase) :: acc.phase_values;
+              phase_details =
+                (entry.name, keeper_phase_detail_of_entry entry) :: acc.phase_details;
             }
           in
           let counts = acc.counts in
@@ -455,6 +485,7 @@ let keeper_phase_snapshot ?base_path () =
               recovering_names;
               executable_names;
               phase_values = acc.phase_values;
+              phase_details = acc.phase_details;
             }
           | Keeper_state_machine.Failing ->
             {
@@ -482,6 +513,7 @@ let keeper_phase_snapshot ?base_path () =
          recovering_names = [];
          executable_names = [];
          phase_values = [];
+         phase_details = [];
        }
   |> fun snapshot ->
   {
@@ -491,6 +523,8 @@ let keeper_phase_snapshot ?base_path () =
     executable_names = sorted_unique_strings snapshot.executable_names;
     phase_values =
       List.sort (fun (a, _) (b, _) -> String.compare a b) snapshot.phase_values;
+    phase_details =
+      List.sort (fun (a, _) (b, _) -> String.compare a b) snapshot.phase_details;
   }
 
 let keeper_phase_counts ?base_path () = (keeper_phase_snapshot ?base_path ()).counts
@@ -714,6 +748,7 @@ let active_task_owner_fiber_scan_semantics =
 let blocked_keeper_detail_json
     ?base_path
     ?phase
+    ?phase_detail
     ~bootable_set
     ~capacity_set
     ~paused_set
@@ -766,6 +801,27 @@ let blocked_keeper_detail_json
           ("last_bootstrap_recorded_at", `String failure.Keeper_runtime.recorded_at);
         ]
   in
+  let phase_detail_fields =
+    match phase_detail with
+    | None ->
+        [
+          ("last_failure_reason", `Null);
+          ("last_error", `Null);
+          ("restart_count", `Null);
+          ("dead_since_ts", `Null);
+          ("latest_crash_at", `Null);
+          ("latest_crash_reason", `Null);
+        ]
+    | Some detail ->
+        [
+          ("last_failure_reason", Json_util.string_opt_to_json detail.last_failure_reason);
+          ("last_error", Json_util.string_opt_to_json detail.last_error);
+          ("restart_count", `Int detail.restart_count);
+          ("dead_since_ts", Json_util.float_opt_to_json detail.dead_since_ts);
+          ("latest_crash_at", Json_util.float_opt_to_json detail.latest_crash_at);
+          ("latest_crash_reason", Json_util.string_opt_to_json detail.latest_crash_reason);
+        ]
+  in
   `Assoc
     ([
        ("keeper", `String name);
@@ -779,7 +835,8 @@ let blocked_keeper_detail_json
        ("meta_read_error", `Bool has_read_error);
      ]
      @ terminal_phase_field
-     @ last_failure_fields)
+     @ last_failure_fields
+     @ phase_detail_fields)
 
 type active_task_owner_without_executable_fiber = {
   keeper_name : string option;
@@ -1049,6 +1106,12 @@ let keeper_fleet_safety_health_json
     | None -> []
   in
   let phase_value name = List.assoc_opt name phase_values in
+  let phase_details =
+    match phase_snapshot with
+    | Some snapshot -> snapshot.phase_details
+    | None -> []
+  in
+  let phase_detail name = List.assoc_opt name phase_details in
   let minimum_running_fibers =
     if target_count <= 1 then target_count else 2
   in
@@ -1142,6 +1205,7 @@ let keeper_fleet_safety_health_json
              blocked_keeper_detail_json
                ?base_path:runtime_base_path
                ?phase:(phase_value name)
+               ?phase_detail:(phase_detail name)
                ~bootable_set
                ~capacity_set
                ~paused_set

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -78,12 +78,22 @@ type keeper_phase_counts = {
   recovering : int;
   executable : int;
 }
+type keeper_phase_detail = {
+  phase : string;
+  last_failure_reason : string option;
+  last_error : string option;
+  restart_count : int;
+  dead_since_ts : float option;
+  latest_crash_at : float option;
+  latest_crash_reason : string option;
+}
 type keeper_phase_snapshot = {
   counts : keeper_phase_counts;
   running_names : string list;
   recovering_names : string list;
   executable_names : string list;
   phase_values : (string * Keeper_state_machine.phase) list;
+  phase_details : (string * keeper_phase_detail) list;
 }
 val keeper_phase_snapshot : ?base_path:string -> unit -> keeper_phase_snapshot
 val keeper_phase_counts : ?base_path:string -> unit -> keeper_phase_counts

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -104,6 +104,7 @@ val keeper_fleet_safety_health_json :
   ?phase_snapshot:keeper_phase_snapshot ->
   ?base_path:string ->
   ?reaction_capacity_names:string list ->
+  ?keeper_bootstrap_enabled:bool ->
   phase_counts:keeper_phase_counts ->
   paused_keepers_json:Yojson.Safe.t ->
   unit ->

--- a/scripts/start-loopback.sh
+++ b/scripts/start-loopback.sh
@@ -4,8 +4,33 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Local loopback is the safe single-user path; keepers can still be started
-# explicitly, but do not autoboot a whole keeper set on 8935 unless requested.
-export MASC_KEEPER_BOOTSTRAP_ENABLED="${MASC_KEEPER_BOOTSTRAP_ENABLED:-false}"
+# Local loopback is the safe single-user path. Ignore inherited
+# MASC_KEEPER_BOOTSTRAP_ENABLED by default so a global shell profile cannot
+# accidentally autoboot a whole keeper set on 8935.
+keeper_bootstrap_enabled=false
+args=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --with-keeper-bootstrap)
+      keeper_bootstrap_enabled=true
+      shift
+      ;;
+    --no-keeper-bootstrap)
+      keeper_bootstrap_enabled=false
+      shift
+      ;;
+    --)
+      shift
+      args+=("$@")
+      break
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
+  esac
+done
 
-exec "$REPO_ROOT/start-masc.sh" --http --host 127.0.0.1 --port 8935 "$@"
+export MASC_KEEPER_BOOTSTRAP_ENABLED="$keeper_bootstrap_enabled"
+
+exec "$REPO_ROOT/start-masc.sh" --http --host 127.0.0.1 --port 8935 "${args[@]}"

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1760,15 +1760,20 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
           make_keeper_meta ~name:"capacity-running-b"
             ~trace_id:"trace-capacity-running-b" ()
         in
-        List.iter (write_keeper_meta_exn config) [ paused; running_a; running_b ];
-        with_running_keeper_metas config [ running_a; running_b ] (fun () ->
+        let runtime_only =
+          make_keeper_meta ~name:"runtime-only" ~trace_id:"trace-runtime-only" ()
+        in
+        List.iter
+          (write_keeper_meta_exn config)
+          [ paused; running_a; running_b; runtime_only ];
+        with_running_keeper_metas config [ running_a; running_b; runtime_only ] (fun () ->
           let request = Httpun.Request.create `GET "/health" in
           let json = Server_routes_http_runtime.make_health_json request in
           let open Yojson.Safe.Util in
           let fleet_safety = json |> member "keeper_fleet_safety" in
-          Alcotest.(check int) "health exposes running reaction capacity" 2
+          Alcotest.(check int) "health exposes running reaction capacity" 3
             (fleet_safety |> member "effective_reaction_capacity_count" |> to_int);
-          Alcotest.(check int) "health exposes executable reaction capacity" 2
+          Alcotest.(check int) "health exposes executable reaction capacity" 3
             (fleet_safety |> member "executable_reaction_capacity_count" |> to_int);
           Alcotest.(check int) "health exposes failing keeper count" 0
             (fleet_safety |> member "failing_keeper_fiber_count" |> to_int);
@@ -1780,13 +1785,13 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
             (fleet_safety |> member "low_running_fiber_margin" |> to_bool);
           Alcotest.(check bool) "health marks capacity below target" true
             (fleet_safety |> member "reaction_capacity_below_target" |> to_bool);
-          Alcotest.(check int) "health exposes capacity shortfall" 2
+          Alcotest.(check int) "health exposes capacity shortfall" 1
             (fleet_safety |> member "reaction_capacity_shortfall_count" |> to_int);
-          Alcotest.(check int) "health exposes executable capacity shortfall" 2
+          Alcotest.(check int) "health exposes executable capacity shortfall" 1
             (fleet_safety
              |> member "executable_reaction_capacity_shortfall_count"
              |> to_int);
-          Alcotest.(check int) "health exposes blocked shortfall" 2
+          Alcotest.(check int) "health exposes blocked keeper count" 2
             (fleet_safety |> member "blocked_count" |> to_int);
           Alcotest.(check (list string)) "health exposes blocked keeper names"
             [ "capacity-paused"; "example" ]

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1098,9 +1098,13 @@ let mark_keeper_dead_with_registry_cause config
   Keeper_registry.set_failure_reason ~base_path meta.name
     (Some (Keeper_registry.Fiber_unresolved Keeper_registry.Cancelled_by_parent));
   Keeper_registry.set_last_error_entry ~base_path ~name:meta.name
-    "synthetic cancelled by parent";
+    (Printf.sprintf
+       "synthetic cancelled by parent sk-testsecret at %s/private/state.json"
+       base_path);
   Keeper_registry.record_crash ~base_path meta.name 1780000000.0
-    "synthetic crash record";
+    (Printf.sprintf
+       "synthetic crash record github_pat_secret at %s/crash.log"
+       base_path);
   Keeper_registry.mark_dead ~base_path meta.name ~at:1780000001.0
 
 let test_health_json_surfaces_durable_paused_keepers () =
@@ -1525,6 +1529,19 @@ let test_health_json_ignores_stale_active_task_alias_when_agent_executable () =
             recovering_names = [];
             executable_names = [ executor.name ];
             phase_values = [ (executor.name, Keeper_state_machine.Running) ];
+            phase_details =
+              [
+                ( executor.name
+                , {
+                    phase = "running";
+                    last_failure_reason = None;
+                    last_error = None;
+                    restart_count = 0;
+                    dead_since_ts = None;
+                    latest_crash_at = None;
+                    latest_crash_reason = None;
+                  } );
+              ];
           }
         in
         let fleet_safety =
@@ -1678,6 +1695,7 @@ let test_health_json_preserves_active_task_owner_meta_read_error () =
             recovering_names = [];
             executable_names = [];
             phase_values = [];
+            phase_details = [];
           }
         in
         let fleet_safety =
@@ -1982,9 +2000,17 @@ let test_health_json_exposes_dead_keeper_registry_cause () =
           Alcotest.(check string) "health surfaces registry failure reason"
             "fiber_unresolved(cancelled_by_parent)"
             (detail |> member "last_failure_reason" |> to_string);
-          Alcotest.(check string) "health surfaces registry last error"
-            "synthetic cancelled by parent"
-            (detail |> member "last_error" |> to_string);
+          let last_error = detail |> member "last_error" |> to_string in
+          Alcotest.(check bool) "health preserves last error class" true
+            (contains_substring last_error "synthetic cancelled by parent");
+          Alcotest.(check bool) "health redacts last error token" false
+            (contains_substring last_error "sk-testsecret");
+          Alcotest.(check bool) "health redacts last error base path" false
+            (contains_substring last_error config.Workspace.base_path);
+          Alcotest.(check bool) "health marks redacted last error" true
+            (contains_substring last_error "[REDACTED]");
+          Alcotest.(check bool) "health marks redacted last error path" true
+            (contains_substring last_error "[REDACTED_PATH]");
           Alcotest.(check int) "health surfaces registry restart count" 2
             (detail |> member "restart_count" |> to_int);
           Alcotest.(check (option (float 0.0001)))
@@ -1993,9 +2019,19 @@ let test_health_json_exposes_dead_keeper_registry_cause () =
           Alcotest.(check (option (float 0.0001)))
             "health surfaces latest crash timestamp" (Some 1780000000.0)
             (detail |> member "latest_crash_at" |> to_float_option);
-          Alcotest.(check string) "health surfaces latest crash reason"
-            "synthetic crash record"
-            (detail |> member "latest_crash_reason" |> to_string))))
+          let latest_crash_reason =
+            detail |> member "latest_crash_reason" |> to_string
+          in
+          Alcotest.(check bool) "health preserves crash reason class" true
+            (contains_substring latest_crash_reason "synthetic crash record");
+          Alcotest.(check bool) "health redacts crash reason token" false
+            (contains_substring latest_crash_reason "github_pat_secret");
+          Alcotest.(check bool) "health redacts crash reason base path" false
+            (contains_substring latest_crash_reason config.Workspace.base_path);
+          Alcotest.(check bool) "health marks redacted crash reason" true
+            (contains_substring latest_crash_reason "[REDACTED]");
+          Alcotest.(check bool) "health marks redacted crash reason path" true
+            (contains_substring latest_crash_reason "[REDACTED_PATH]"))))
 
 let test_health_json_explains_terminal_capacity_blocker
     ~dir_name

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1090,6 +1090,19 @@ let exhaust_keeper_restart_budget config (meta : Keeper_meta_contract.keeper_met
       ("keeper restart-budget exhaustion failed: "
        ^ Keeper_state_machine.transition_error_to_string err)
 
+let mark_keeper_dead_with_registry_cause config
+    (meta : Keeper_meta_contract.keeper_meta) =
+  let base_path = config.Workspace.base_path in
+  Keeper_registry.record_restart ~base_path meta.name;
+  Keeper_registry.record_restart ~base_path meta.name;
+  Keeper_registry.set_failure_reason ~base_path meta.name
+    (Some (Keeper_registry.Fiber_unresolved Keeper_registry.Cancelled_by_parent));
+  Keeper_registry.set_last_error_entry ~base_path ~name:meta.name
+    "synthetic cancelled by parent";
+  Keeper_registry.record_crash ~base_path meta.name 1780000000.0
+    "synthetic crash record";
+  Keeper_registry.mark_dead ~base_path meta.name ~at:1780000001.0
+
 let test_health_json_surfaces_durable_paused_keepers () =
   with_temp_dir "health-durable-paused-keepers" (fun dir ->
       let config_root = make_config_root dir in
@@ -1926,8 +1939,63 @@ let test_health_json_explains_phase_paused_capacity_blocker () =
             [ ("example", "not_registered"); ("phase-paused", "phase_paused") ]
             (fleet_safety |> member "blocked_keeper_reasons" |> to_list
              |> List.map (fun row ->
-                  ( row |> member "keeper" |> to_string
-                  , row |> member "reason" |> to_string ))))))
+	                  ( row |> member "keeper" |> to_string
+	                  , row |> member "reason" |> to_string ))))))
+
+let test_health_json_exposes_dead_keeper_registry_cause () =
+  with_temp_dir "health-phase-dead-registry-cause" (fun dir ->
+    let config_root = make_config_root dir in
+    write_config_root_keeper_toml config_root "phase-dead";
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = (Mcp_server.workspace_config state) in
+        let phase_dead =
+          make_keeper_meta ~name:"phase-dead" ~trace_id:"trace-phase-dead" ()
+        in
+        write_keeper_meta_exn config phase_dead;
+        with_running_keeper_metas config [ phase_dead ] (fun () ->
+          mark_keeper_dead_with_registry_cause config phase_dead;
+          let request = Httpun.Request.create `GET "/health" in
+          let json = Server_routes_http_runtime.make_health_json request in
+          let open Yojson.Safe.Util in
+          let fleet_safety = json |> member "keeper_fleet_safety" in
+          let blocked_detail name =
+            fleet_safety |> member "blocked_keeper_reasons" |> to_list
+            |> List.find (fun row -> row |> member "keeper" |> to_string = name)
+          in
+          let detail = blocked_detail "phase-dead" in
+          Alcotest.(check string) "health explains dead keeper reason" "phase_dead"
+            (detail |> member "reason" |> to_string);
+          Alcotest.(check string) "health exposes dead phase" "dead"
+            (detail |> member "phase" |> to_string);
+          Alcotest.(check string) "health suggests dead keeper recovery"
+            "inspect_dead_keeper_root_cause"
+            (detail |> member "action" |> to_string);
+          Alcotest.(check string) "health surfaces registry failure reason"
+            "fiber_unresolved(cancelled_by_parent)"
+            (detail |> member "last_failure_reason" |> to_string);
+          Alcotest.(check string) "health surfaces registry last error"
+            "synthetic cancelled by parent"
+            (detail |> member "last_error" |> to_string);
+          Alcotest.(check int) "health surfaces registry restart count" 2
+            (detail |> member "restart_count" |> to_int);
+          Alcotest.(check (option (float 0.0001)))
+            "health surfaces registry dead timestamp" (Some 1780000001.0)
+            (detail |> member "dead_since_ts" |> to_float_option);
+          Alcotest.(check (option (float 0.0001)))
+            "health surfaces latest crash timestamp" (Some 1780000000.0)
+            (detail |> member "latest_crash_at" |> to_float_option);
+          Alcotest.(check string) "health surfaces latest crash reason"
+            "synthetic crash record"
+            (detail |> member "latest_crash_reason" |> to_string))))
 
 let test_health_json_explains_terminal_capacity_blocker
     ~dir_name
@@ -3694,6 +3762,9 @@ let () =
           Alcotest.test_case
             "health json explains zombie capacity blocker as terminal"
             `Quick test_health_json_explains_zombie_capacity_blocker_as_terminal;
+          Alcotest.test_case
+            "health json exposes dead keeper registry cause"
+            `Quick test_health_json_exposes_dead_keeper_registry_cause;
           Alcotest.test_case
             "health json distinguishes failing executable keepers"
             `Quick test_health_json_distinguishes_failing_executable_keepers;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1096,7 +1096,19 @@ let mark_keeper_dead_with_registry_cause config
   Keeper_registry.record_restart ~base_path meta.name;
   Keeper_registry.record_restart ~base_path meta.name;
   Keeper_registry.set_failure_reason ~base_path meta.name
-    (Some (Keeper_registry.Fiber_unresolved Keeper_registry.Cancelled_by_parent));
+    (Some
+       (Keeper_registry.Provider_runtime_error
+          {
+            code = "provider_http_500";
+            detail =
+              Printf.sprintf
+                "provider cancelled with sk-testsecret at %s/private/provider.json"
+                base_path;
+            provider_id = Some "runpod";
+            http_status = Some 500;
+            runtime_id = Some "runtime-a";
+            reason = None;
+          }));
   Keeper_registry.set_last_error_entry ~base_path ~name:meta.name
     (Printf.sprintf
        "synthetic cancelled by parent sk-testsecret at %s/private/state.json"
@@ -2076,9 +2088,19 @@ let test_health_json_exposes_dead_keeper_registry_cause () =
           Alcotest.(check string) "health suggests dead keeper recovery"
             "inspect_dead_keeper_root_cause"
             (detail |> member "action" |> to_string);
-          Alcotest.(check string) "health surfaces registry failure reason"
-            "fiber_unresolved(cancelled_by_parent)"
-            (detail |> member "last_failure_reason" |> to_string);
+          let last_failure_reason =
+            detail |> member "last_failure_reason" |> to_string
+          in
+          Alcotest.(check bool) "health preserves failure reason class" true
+            (contains_substring last_failure_reason "provider_runtime_error");
+          Alcotest.(check bool) "health redacts failure reason token" false
+            (contains_substring last_failure_reason "sk-testsecret");
+          Alcotest.(check bool) "health redacts failure reason base path" false
+            (contains_substring last_failure_reason config.Workspace.base_path);
+          Alcotest.(check bool) "health marks redacted failure reason" true
+            (contains_substring last_failure_reason "[REDACTED]");
+          Alcotest.(check bool) "health marks redacted failure reason path" true
+            (contains_substring last_failure_reason "[REDACTED_PATH]");
           let last_error = detail |> member "last_error" |> to_string in
           Alcotest.(check bool) "health preserves last error class" true
             (contains_substring last_error "synthetic cancelled by parent");

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1814,6 +1814,10 @@ let test_health_json_degrades_when_reaction_capacity_below_target () =
           Alcotest.(check string) "health suggests unregistered action"
             "start_or_recover_keeper"
             (blocked_detail "example" |> member "action" |> to_string);
+          Alcotest.(check bool) "health reports bootstrap enabled" true
+            (fleet_safety |> member "keeper_bootstrap_enabled" |> to_bool);
+          Alcotest.(check bool) "health has no bootstrap blocker" true
+            (fleet_safety |> member "keeper_bootstrap_blocker" = `Null);
           Alcotest.(check string) "health marks fleet degraded" "degraded"
             (fleet_safety |> member "status" |> to_string);
           Alcotest.(check string) "health marks target-capacity blocker"
@@ -1873,6 +1877,76 @@ let test_health_json_blocked_count_matches_blocked_names_with_non_target_capacit
               (fleet_safety |> member "blocked_count" |> to_int);
             Alcotest.(check int) "blocked_keepers alias matches names" 2
               (fleet_safety |> member "blocked_keepers" |> to_int))))
+
+let test_health_json_exposes_disabled_keeper_bootstrap_blocker () =
+  with_temp_dir "health-keeper-bootstrap-disabled" (fun dir ->
+    let config_root = make_config_root dir in
+    write_config_root_keeper_toml config_root "boot-disabled";
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = (Mcp_server.workspace_config state) in
+        let phase_counts :
+            Server_routes_http_runtime_fleet_scan.keeper_phase_counts =
+          { running = 0; failing = 0; recovering = 0; executable = 0 }
+        in
+        let phase_snapshot :
+            Server_routes_http_runtime_fleet_scan.keeper_phase_snapshot =
+          {
+            counts = phase_counts;
+            running_names = [];
+            recovering_names = [];
+            executable_names = [];
+            phase_values = [];
+            phase_details = [];
+          }
+        in
+        let paused_keepers_json =
+          Server_routes_http_runtime_fleet_scan.durable_paused_keeper_scan config
+          |> Server_routes_http_runtime_fleet_scan
+             .paused_keepers_health_json_of_scan
+               ~running_names:[]
+        in
+        let fleet_safety =
+          Server_routes_http_runtime_fleet_scan.keeper_fleet_safety_health_json
+            ~keeper_bootstrap_enabled:false
+            ~phase_snapshot
+            ~phase_counts
+            ~paused_keepers_json
+            ()
+        in
+        let open Yojson.Safe.Util in
+        Alcotest.(check string) "health selects disabled bootstrap blocker"
+          "keeper_bootstrap_disabled"
+          (fleet_safety |> member "blocker" |> to_string);
+        Alcotest.(check bool) "health reports bootstrap disabled" false
+          (fleet_safety |> member "keeper_bootstrap_enabled" |> to_bool);
+        Alcotest.(check string) "health exposes bootstrap blocker"
+          "keeper_bootstrap_disabled"
+          (fleet_safety |> member "keeper_bootstrap_blocker" |> to_string);
+        let blocked_detail name =
+          fleet_safety |> member "blocked_keeper_reasons" |> to_list
+          |> List.find (fun row -> row |> member "keeper" |> to_string = name)
+        in
+        let detail = blocked_detail "boot-disabled" in
+        Alcotest.(check string) "health explains disabled bootstrap row"
+          "keeper_bootstrap_disabled"
+          (detail |> member "reason" |> to_string);
+        Alcotest.(check string) "health suggests bootstrap recovery"
+          "enable_keeper_bootstrap_or_start_manually"
+          (detail |> member "action" |> to_string);
+        Alcotest.(check bool) "row reports bootstrap disabled" false
+          (detail |> member "keeper_bootstrap_enabled" |> to_bool);
+        Alcotest.(check string) "row exposes bootstrap blocker"
+          "keeper_bootstrap_disabled"
+          (detail |> member "keeper_bootstrap_blocker" |> to_string)))
 
 let test_health_json_ignores_persisted_only_keeper_for_capacity_target () =
   with_temp_dir "health-persisted-only-keeper-target" (fun dir ->
@@ -3782,6 +3856,10 @@ let () =
             "health json blocked count matches named target blockers"
             `Quick
             test_health_json_blocked_count_matches_blocked_names_with_non_target_capacity;
+          Alcotest.test_case
+            "health json exposes disabled keeper bootstrap blocker"
+            `Quick
+            test_health_json_exposes_disabled_keeper_bootstrap_blocker;
           Alcotest.test_case
             "health json ignores persisted-only keeper for capacity target"
             `Quick

--- a/test/test_start_masc_mcp_script.ml
+++ b/test/test_start_masc_mcp_script.ml
@@ -1145,7 +1145,7 @@ exit 1
         (contains_substring stderr
            "HTTP Port 9954 in use, waiting before build/init"))
 
-let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
+let test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in ()
     =
   with_temp_dir "start-loopback-script" (fun dir ->
       let repo_root = Filename.concat dir "repo-root" in
@@ -1166,7 +1166,7 @@ let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
             [
               ("FAKE_CAPTURE_FILE", capture_default);
               ("HOME", home_dir);
-              ("MASC_KEEPER_BOOTSTRAP_ENABLED", "");
+              ("MASC_KEEPER_BOOTSTRAP_ENABLED", "true");
             ]
           [ "--port"; "9961"; "--base-path"; repo_root ]
       in
@@ -1185,15 +1185,15 @@ let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
             [
               ("FAKE_CAPTURE_FILE", capture_override);
               ("HOME", home_dir);
-              ("MASC_KEEPER_BOOTSTRAP_ENABLED", "true");
+              ("MASC_KEEPER_BOOTSTRAP_ENABLED", "");
             ]
-          [ "--port"; "9962"; "--base-path"; repo_root ]
+          [ "--with-keeper-bootstrap"; "--port"; "9962"; "--base-path"; repo_root ]
       in
       if code_override <> 0 then
         failf "loopback script override failed (%d)\nstdout:\n%s\nstderr:\n%s"
           code_override stdout_override stderr_override;
       let captured_override = read_file capture_override in
-      check bool "loopback preserves explicit keeper autoboot override" true
+      check bool "loopback honors explicit keeper autoboot opt-in" true
         (contains_substring captured_override "MASC_KEEPER_BOOTSTRAP_ENABLED=true"))
 
 let () =
@@ -1261,8 +1261,8 @@ let () =
           test_case "worktree prefers local build over workspace build" `Quick
             test_worktree_prefers_local_build_over_workspace_build;
           test_case
-            "loopback disables keeper autoboot by default and preserves override"
+            "loopback disables keeper autoboot by default and requires opt-in"
             `Quick
-            test_loopback_disables_keeper_autoboot_by_default_and_preserves_override;
+            test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in;
         ] );
     ]

--- a/test/test_start_masc_script.ml
+++ b/test/test_start_masc_script.ml
@@ -1145,7 +1145,7 @@ exit 1
         (contains_substring stderr
            "HTTP Port 9954 in use, waiting before build/init"))
 
-let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
+let test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in ()
     =
   with_temp_dir "start-loopback-script" (fun dir ->
       let repo_root = Filename.concat dir "repo-root" in
@@ -1166,7 +1166,7 @@ let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
             [
               ("FAKE_CAPTURE_FILE", capture_default);
               ("HOME", home_dir);
-              ("MASC_KEEPER_BOOTSTRAP_ENABLED", "");
+              ("MASC_KEEPER_BOOTSTRAP_ENABLED", "true");
             ]
           [ "--port"; "9961"; "--base-path"; repo_root ]
       in
@@ -1185,15 +1185,15 @@ let test_loopback_disables_keeper_autoboot_by_default_and_preserves_override ()
             [
               ("FAKE_CAPTURE_FILE", capture_override);
               ("HOME", home_dir);
-              ("MASC_KEEPER_BOOTSTRAP_ENABLED", "true");
+              ("MASC_KEEPER_BOOTSTRAP_ENABLED", "");
             ]
-          [ "--port"; "9962"; "--base-path"; repo_root ]
+          [ "--with-keeper-bootstrap"; "--port"; "9962"; "--base-path"; repo_root ]
       in
       if code_override <> 0 then
         failf "loopback script override failed (%d)\nstdout:\n%s\nstderr:\n%s"
           code_override stdout_override stderr_override;
       let captured_override = read_file capture_override in
-      check bool "loopback preserves explicit keeper autoboot override" true
+      check bool "loopback honors explicit keeper autoboot opt-in" true
         (contains_substring captured_override "MASC_KEEPER_BOOTSTRAP_ENABLED=true"))
 
 let () =
@@ -1261,8 +1261,8 @@ let () =
           test_case "worktree prefers local build over workspace build" `Quick
             test_worktree_prefers_local_build_over_workspace_build;
           test_case
-            "loopback disables keeper autoboot by default and preserves override"
+            "loopback disables keeper autoboot by default and requires opt-in"
             `Quick
-            test_loopback_disables_keeper_autoboot_by_default_and_preserves_override;
+            test_loopback_disables_keeper_autoboot_by_default_and_requires_opt_in;
         ] );
     ]


### PR DESCRIPTION
## Summary
- carry typed keeper registry diagnostics into the fleet health phase snapshot
- expose registry failure fields on blocked keeper rows: last_failure_reason, last_error, restart_count, dead_since_ts, latest_crash_at, latest_crash_reason
- add a /health regression for a configured dead keeper with a latched registry cause

## Validation
- ocamlformat --check lib/server/server_routes_http_runtime_fleet_scan.mli lib/server/server_routes_http_runtime_fleet_scan.ml test/test_server_runtime_bootstrap.ml
- git diff --check origin/main...HEAD
- ocamldep -modules lib/server/server_routes_http_runtime_fleet_scan.ml
- ocamldep -modules test/test_server_runtime_bootstrap.ml
- blocked: scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe could not start because /tmp/me-dune-local.lock is held by another worktree runtest job

## Live evidence
- health checked on 2026-06-26T16:51:50+0900: fleet degraded with mad-improver, nick0cave, verifier blocked as phase_dead while blocked rows omitted registry cause fields
