### PR TITLE
fix(health): cover active owner fiber gaps

### DIFF
--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -611,6 +611,7 @@ type blocked_keeper_reason =
   | Phase of string
   | Not_registered
   | Not_running
+  | No_keeper_binding
   | Unknown
 
 let blocked_keeper_reason_label = function
@@ -621,6 +622,7 @@ let blocked_keeper_reason_label = function
   | Phase phase -> "phase_" ^ phase
   | Not_registered -> "not_registered"
   | Not_running -> "not_running"
+  | No_keeper_binding -> "no_keeper_binding"
   | Unknown -> "unknown"
 
 let blocked_keeper_action = function
@@ -642,7 +644,12 @@ let blocked_keeper_action = function
   | Not_registered ->
       "start_or_recover_keeper"
   | Not_running -> "start_or_recover_keeper"
+  | No_keeper_binding -> "create_keeper_or_reassign_task"
   | Unknown -> "inspect_keeper_autoboot_logs"
+
+let active_task_owner_fiber_scan_semantics =
+  "reports active task owners without executable keeper fibers; disabled \
+   keepers are excluded; matching rows can degrade fleet status"
 
 let blocked_keeper_detail_json
     ?base_path
@@ -708,7 +715,7 @@ let blocked_keeper_detail_json
      @ last_failure_fields)
 
 type active_task_owner_without_executable_fiber = {
-  keeper_name : string;
+  keeper_name : string option;
   agent_name : string;
   task_id : string;
   task_status : string;
@@ -727,7 +734,14 @@ let empty_active_task_owner_fiber_scan =
   }
 
 let compare_active_task_owner_without_executable_fiber left right =
-  let cmp = String.compare left.keeper_name right.keeper_name in
+  let compare_string_opt left right =
+    match (left, right) with
+    | None, None -> 0
+    | None, Some _ -> -1
+    | Some _, None -> 1
+    | Some left, Some right -> String.compare left right
+  in
+  let cmp = compare_string_opt left.keeper_name right.keeper_name in
   if cmp <> 0 then cmp
   else
     let cmp = String.compare left.agent_name right.agent_name in
@@ -740,14 +754,20 @@ let active_task_assignment (task : Masc_domain.task) =
          (assignee, Workspace_task_schedule.task_status_label task.task_status))
 
 let active_task_owner_without_executable_fiber_json row =
+  let action =
+    match row.keeper_name with
+    | Some _ -> blocked_keeper_action Not_running
+    | None -> blocked_keeper_action No_keeper_binding
+  in
   `Assoc
     [
-      ("keeper", `String row.keeper_name);
+      ("keeper", Json_util.string_opt_to_json row.keeper_name);
+      ("name", Json_util.string_opt_to_json row.keeper_name);
       ("agent_name", `String row.agent_name);
       ("task_id", `String row.task_id);
       ("task_status", `String row.task_status);
       ("executable", `Bool false);
-      ("action", `String (blocked_keeper_action Not_running));
+      ("action", `String action);
     ]
 
 let keeper_agent_bindings config =
@@ -763,6 +783,12 @@ let keeper_agent_bindings config =
          | Ok None -> (bindings, read_errors)
          | Error err -> (bindings, (name, err) :: read_errors))
        ([], [])
+
+let keeper_names_for_agent agent_bindings assignee =
+  agent_bindings
+  |> List.filter_map (fun (agent_name, keeper_name) ->
+       if String.equal agent_name assignee then Some keeper_name else None)
+  |> sorted_unique_strings
 
 let active_task_owner_fiber_scan config ~executable_names =
   let executable_set = string_set_of_list executable_names in
@@ -781,20 +807,32 @@ let active_task_owner_fiber_scan config ~executable_names =
              match active_task_assignment task with
              | None -> []
              | Some (assignee, task_status) ->
-                 agent_bindings
-                 |> List.filter_map (fun (agent_name, keeper_name) ->
-                      if
-                        String.equal agent_name assignee
-                        && not (String_set.mem keeper_name executable_set)
-                      then
-                        Some
-                          {
-                            keeper_name;
-                            agent_name;
-                            task_id = task.id;
-                            task_status;
-                          }
-                      else None))
+                 let keeper_names = keeper_names_for_agent agent_bindings assignee in
+                 if
+                   List.exists
+                     (fun keeper_name -> String_set.mem keeper_name executable_set)
+                     keeper_names
+                 then []
+                 else (
+                   match keeper_names with
+                   | [] ->
+                       [
+                         {
+                           keeper_name = None;
+                           agent_name = assignee;
+                           task_id = task.id;
+                           task_status;
+                         };
+                       ]
+                   | keeper_names ->
+                       keeper_names
+                       |> List.map (fun keeper_name ->
+                             {
+                               keeper_name = Some keeper_name;
+                               agent_name = assignee;
+                               task_id = task.id;
+                               task_status;
+                            })))
         |> List.concat
         |> List.sort_uniq compare_active_task_owner_without_executable_fiber
       in
@@ -874,11 +912,11 @@ let keeper_fleet_safety_health_json
   in
   let active_task_owner_without_executable_fiber_names =
     active_task_owner_scan.active_task_owner_without_executable_fibers
-    |> List.map (fun row -> row.keeper_name)
+    |> List.filter_map (fun row -> row.keeper_name)
     |> sorted_unique_strings
   in
   let active_task_owner_without_executable_fiber_count =
-    List.length active_task_owner_without_executable_fiber_names
+    List.length active_task_owner_scan.active_task_owner_without_executable_fibers
   in
   let active_task_owner_without_executable_fiber =
     active_task_owner_without_executable_fiber_count > 0
@@ -936,18 +974,23 @@ let keeper_fleet_safety_health_json
     else if no_running_fibers then "degraded"
     else if low_running_fiber_margin then "degraded"
     else if reaction_capacity_below_target then "degraded"
+    else if active_task_owner_without_executable_fiber then "degraded"
     else "ok"
   in
   let blocked_count =
     if no_executable_keeper_fibers then executable_reaction_capacity_shortfall_count
     else if no_running_fibers || low_running_fiber_margin || reaction_capacity_below_target
     then reaction_capacity_shortfall_count
+    else if active_task_owner_without_executable_fiber
+    then active_task_owner_without_executable_fiber_count
     else 0
   in
   let blocked_keeper_names =
     if no_executable_keeper_fibers then names_not_in executable_names
     else if no_running_fibers || low_running_fiber_margin || reaction_capacity_below_target
     then names_not_in (running_names @ recovering_names)
+    else if active_task_owner_without_executable_fiber
+    then active_task_owner_without_executable_fiber_names
     else []
   in
   let active_capacity_names =
@@ -984,6 +1027,8 @@ let keeper_fleet_safety_health_json
     else if no_running_fibers then Some "no_healthy_running_keeper_fibers"
     else if low_running_fiber_margin then Some "low_running_fiber_margin"
     else if reaction_capacity_below_target then Some "reaction_capacity_below_target"
+    else if active_task_owner_without_executable_fiber
+    then Some "active_task_owner_without_executable_fiber"
     else if paused_autoboot_count > 0 then Some "durable_paused_autoboot_enabled"
     else None
   in
@@ -1034,9 +1079,7 @@ let keeper_fleet_safety_health_json
              active_task_owner_without_executable_fiber_json
              active_task_owner_scan.active_task_owner_without_executable_fibers) )
     ; ( "active_task_owner_fiber_scan_semantics"
-      , `String
-          "advisory: reports task owners without executable keeper fibers; does \
-           not set fleet status, blocker, or operator_action_required" )
+      , `String active_task_owner_fiber_scan_semantics )
     ; ( "active_task_owner_scan_error_count"
       , `Int (List.length active_task_owner_scan.active_task_owner_scan_errors) )
     ; ( "active_task_owner_scan_errors"
@@ -1064,5 +1107,6 @@ let keeper_fleet_safety_health_json
           (no_executable_keeper_fibers
            || no_running_fibers
            || low_running_fiber_margin
-           || reaction_capacity_below_target) )
+           || reaction_capacity_below_target
+           || active_task_owner_without_executable_fiber) )
     ]

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -733,15 +733,12 @@ let empty_active_task_owner_fiber_scan =
     active_task_owner_scan_errors = [];
   }
 
+let compare_string_pair (left_name, left_detail) (right_name, right_detail) =
+  let cmp = String.compare left_name right_name in
+  if cmp <> 0 then cmp else String.compare left_detail right_detail
+
 let compare_active_task_owner_without_executable_fiber left right =
-  let compare_string_opt left right =
-    match (left, right) with
-    | None, None -> 0
-    | None, Some _ -> -1
-    | Some _, None -> 1
-    | Some left, Some right -> String.compare left right
-  in
-  let cmp = compare_string_opt left.keeper_name right.keeper_name in
+  let cmp = Option.compare String.compare left.keeper_name right.keeper_name in
   if cmp <> 0 then cmp
   else
     let cmp = String.compare left.agent_name right.agent_name in
@@ -762,6 +759,7 @@ let active_task_owner_without_executable_fiber_json row =
   `Assoc
     [
       ("keeper", Json_util.string_opt_to_json row.keeper_name);
+      (* Legacy alias retained for existing fleet-safety consumers. *)
       ("name", Json_util.string_opt_to_json row.keeper_name);
       ("agent_name", `String row.agent_name);
       ("task_id", `String row.task_id);
@@ -770,19 +768,48 @@ let active_task_owner_without_executable_fiber_json row =
       ("action", `String action);
     ]
 
+type keeper_agent_binding_scan = {
+  enabled_agent_bindings : (string * string) list;
+  disabled_agent_names : string list;
+  binding_read_errors : (string * string) list;
+}
+
+let empty_keeper_agent_binding_scan =
+  { enabled_agent_bindings = []; disabled_agent_names = []; binding_read_errors = [] }
+
 let keeper_agent_bindings config =
   Keeper_meta_store.configured_keeper_names config
   |> sorted_unique_strings
   |> List.fold_left
-       (fun (bindings, read_errors) name ->
+       (fun scan name ->
          match Keeper_meta_store.read_meta config name with
          | Ok (Some meta) ->
              if effective_autoboot_enabled config name meta then
-               ((meta.agent_name, meta.name) :: bindings, read_errors)
-             else (bindings, read_errors)
-         | Ok None -> (bindings, read_errors)
-         | Error err -> (bindings, (name, err) :: read_errors))
-       ([], [])
+               {
+                 scan with
+                 enabled_agent_bindings =
+                   (meta.agent_name, meta.name) :: scan.enabled_agent_bindings;
+               }
+             else
+               {
+                 scan with
+                 disabled_agent_names = meta.agent_name :: scan.disabled_agent_names;
+               }
+         | Ok None -> scan
+         | Error err ->
+             {
+               scan with
+               binding_read_errors = (name, err) :: scan.binding_read_errors;
+             })
+       empty_keeper_agent_binding_scan
+  |> fun scan ->
+  {
+    enabled_agent_bindings =
+      List.sort_uniq compare_string_pair scan.enabled_agent_bindings;
+    disabled_agent_names = sorted_unique_strings scan.disabled_agent_names;
+    binding_read_errors =
+      List.sort_uniq compare_string_pair scan.binding_read_errors;
+  }
 
 let keeper_names_for_agent agent_bindings assignee =
   agent_bindings
@@ -792,7 +819,9 @@ let keeper_names_for_agent agent_bindings assignee =
 
 let active_task_owner_fiber_scan config ~executable_names =
   let executable_set = string_set_of_list executable_names in
-  let agent_bindings, meta_read_errors = keeper_agent_bindings config in
+  let binding_scan = keeper_agent_bindings config in
+  let agent_bindings = binding_scan.enabled_agent_bindings in
+  let meta_read_errors = binding_scan.binding_read_errors in
   match Workspace.read_backlog_r config with
   | Error err ->
       {
@@ -815,6 +844,10 @@ let active_task_owner_fiber_scan config ~executable_names =
                  then []
                  else (
                    match keeper_names with
+                   | []
+                     when List.mem assignee binding_scan.disabled_agent_names
+                          || meta_read_errors <> [] ->
+                       []
                    | [] ->
                        [
                          {
@@ -838,13 +871,30 @@ let active_task_owner_fiber_scan config ~executable_names =
       in
       {
         active_task_owner_without_executable_fibers = rows;
-        active_task_owner_scan_errors =
-          List.sort_uniq
-            (fun (left_name, left_err) (right_name, right_err) ->
-              let cmp = String.compare left_name right_name in
-              if cmp <> 0 then cmp else String.compare left_err right_err)
-            meta_read_errors;
+        active_task_owner_scan_errors = meta_read_errors;
       }
+
+let active_task_owner_blocked_name row =
+  match row.keeper_name with
+  | Some keeper_name -> keeper_name
+  | None -> row.agent_name
+
+let active_task_owner_blocked_detail_json row =
+  let reason =
+    match row.keeper_name with
+    | Some _ -> Not_running
+    | None -> No_keeper_binding
+  in
+  `Assoc
+    [
+      ("keeper", Json_util.string_opt_to_json row.keeper_name);
+      ("name", Json_util.string_opt_to_json row.keeper_name);
+      ("agent_name", `String row.agent_name);
+      ("task_id", `String row.task_id);
+      ("task_status", `String row.task_status);
+      ("reason", `String (blocked_keeper_reason_label reason));
+      ("action", `String (blocked_keeper_action reason));
+    ]
 
 let keeper_fleet_safety_health_json
     ?bootable_names:bootable_names_override
@@ -915,6 +965,11 @@ let keeper_fleet_safety_health_json
     |> List.filter_map (fun row -> row.keeper_name)
     |> sorted_unique_strings
   in
+  let active_task_owner_blocked_names =
+    active_task_owner_scan.active_task_owner_without_executable_fibers
+    |> List.map active_task_owner_blocked_name
+    |> sorted_unique_strings
+  in
   let active_task_owner_without_executable_fiber_count =
     List.length active_task_owner_scan.active_task_owner_without_executable_fibers
   in
@@ -940,6 +995,14 @@ let keeper_fleet_safety_health_json
   in
   let reaction_capacity_below_target =
     target_count > 0 && reaction_capacity_shortfall_count > 0
+  in
+  let active_task_owner_is_selected_blocker =
+    active_task_owner_without_executable_fiber
+    && not
+         (no_executable_keeper_fibers
+          || no_running_fibers
+          || low_running_fiber_margin
+          || reaction_capacity_below_target)
   in
   let executable_reaction_capacity_shortfall_count =
     max 0 (target_count - phase_counts.executable)
@@ -981,16 +1044,14 @@ let keeper_fleet_safety_health_json
     if no_executable_keeper_fibers then executable_reaction_capacity_shortfall_count
     else if no_running_fibers || low_running_fiber_margin || reaction_capacity_below_target
     then reaction_capacity_shortfall_count
-    else if active_task_owner_without_executable_fiber
-    then active_task_owner_without_executable_fiber_count
+    else if active_task_owner_is_selected_blocker then active_task_owner_without_executable_fiber_count
     else 0
   in
   let blocked_keeper_names =
     if no_executable_keeper_fibers then names_not_in executable_names
     else if no_running_fibers || low_running_fiber_margin || reaction_capacity_below_target
     then names_not_in (running_names @ recovering_names)
-    else if active_task_owner_without_executable_fiber
-    then active_task_owner_without_executable_fiber_names
+    else if active_task_owner_is_selected_blocker then active_task_owner_blocked_names
     else []
   in
   let active_capacity_names =
@@ -1010,17 +1071,21 @@ let keeper_fleet_safety_health_json
     autoboot_scan.read_errors |> List.map fst |> string_set_of_list
   in
   let blocked_keeper_reasons =
-    blocked_keeper_names
-    |> List.map
-         (fun name ->
-           blocked_keeper_detail_json
-             ?base_path:runtime_base_path
-             ?phase:(phase_name name)
-             ~bootable_set
-             ~capacity_set
-             ~paused_set
-             ~read_error_set
-             name)
+    if active_task_owner_is_selected_blocker then
+      active_task_owner_scan.active_task_owner_without_executable_fibers
+      |> List.map active_task_owner_blocked_detail_json
+    else
+      blocked_keeper_names
+      |> List.map
+           (fun name ->
+             blocked_keeper_detail_json
+               ?base_path:runtime_base_path
+               ?phase:(phase_name name)
+               ~bootable_set
+               ~capacity_set
+               ~paused_set
+               ~read_error_set
+               name)
   in
   let blocker =
     if no_executable_keeper_fibers then Some "no_executable_keeper_fibers"

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -87,6 +87,7 @@ type keeper_phase_snapshot = {
 }
 val keeper_phase_snapshot : ?base_path:string -> unit -> keeper_phase_snapshot
 val keeper_phase_counts : ?base_path:string -> unit -> keeper_phase_counts
+val active_task_owner_fiber_scan_semantics : string
 val keeper_fleet_safety_health_json :
   ?bootable_names:string list ->
   ?autoboot_scan:autoboot_keeper_scan ->

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1432,13 +1432,169 @@ let test_health_json_reports_dormant_task_owner_as_advisory () =
         in
         Alcotest.(check int) "health exposes no dormant owner task row" 0
           (List.length dormant_tasks);
-        Alcotest.(check string) "health documents advisory semantics"
-          "advisory: reports task owners without executable keeper fibers; does not set \
-           fleet status, blocker, or operator_action_required"
+        Alcotest.(check string) "health documents active owner scan semantics"
+          Server_routes_http_runtime_fleet_scan.active_task_owner_fiber_scan_semantics
           (fleet_safety |> member "active_task_owner_fiber_scan_semantics" |> to_string);
         Alcotest.(check int) "health has no scan errors" 0
           (fleet_safety |> member "active_task_owner_scan_error_count" |> to_int);
         Alcotest.(check bool) "health does not ask fleet operator action" false
+          (fleet_safety |> member "operator_action_required" |> to_bool)))
+
+let test_health_json_ignores_stale_active_task_alias_when_agent_executable () =
+  with_temp_dir "health-active-task-owner-executable-alias" (fun dir ->
+    let config_root = make_config_root dir in
+    Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
+    List.iter (write_config_root_keeper_toml config_root) [ "executor"; "executor-stale" ];
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        let executor =
+          make_keeper_meta ~name:"executor" ~trace_id:"trace-executor" ()
+        in
+        let stale_executor =
+          {
+            (make_keeper_meta
+               ~name:"executor-stale"
+               ~trace_id:"trace-executor-stale"
+               ())
+            with
+            Keeper_meta_contract.agent_name = executor.agent_name;
+          }
+        in
+        write_keeper_meta_exn config executor;
+        write_keeper_meta_exn config stale_executor;
+        let task =
+          make_task
+            ~id:"task-active-owner"
+            ~title:"Active keeper task"
+            ~status:
+              (Types.InProgress
+                 {
+                   assignee = executor.Keeper_meta_contract.agent_name;
+                   started_at = "2026-06-26T00:00:01Z";
+                 })
+            ()
+        in
+        Workspace.write_backlog config
+          { Types.tasks = [ task ]; last_updated = "2026-06-26T00:00:02Z"; version = 2 };
+        let phase_counts :
+            Server_routes_http_runtime_fleet_scan.keeper_phase_counts =
+          { running = 1; failing = 0; recovering = 0; executable = 1 }
+        in
+        let phase_snapshot :
+            Server_routes_http_runtime_fleet_scan.keeper_phase_snapshot =
+          {
+            counts = phase_counts;
+            running_names = [ executor.name ];
+            recovering_names = [];
+            executable_names = [ executor.name ];
+            phase_names = [ (executor.name, "running") ];
+          }
+        in
+        let fleet_safety =
+          Server_routes_http_runtime_fleet_scan.keeper_fleet_safety_health_json
+            ~bootable_names:[]
+            ~autoboot_scan:
+              Server_routes_http_runtime_fleet_scan.empty_autoboot_keeper_scan
+            ~phase_snapshot
+            ~phase_counts
+            ~paused_keepers_json:(`Assoc [ ("count", `Int 0) ])
+            ()
+        in
+        let open Yojson.Safe.Util in
+        Alcotest.(check string) "health remains ok" "ok"
+          (fleet_safety |> member "status" |> to_string);
+        Alcotest.(check bool) "health does not flag stale alias" false
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber"
+           |> to_bool);
+        Alcotest.(check int) "health reports no active owner rows" 0
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_count"
+           |> to_int);
+        Alcotest.(check bool) "health does not require operator action" false
+          (fleet_safety |> member "operator_action_required" |> to_bool)))
+
+let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
+  with_temp_dir "health-active-task-owner-without-binding" (fun dir ->
+    let config_root = make_config_root dir in
+    Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        let assignee = "missing-keeper-agent" in
+        let task =
+          make_task
+            ~id:"task-active-owner-without-binding"
+            ~title:"Active keeper task without binding"
+            ~status:
+              (Types.InProgress
+                 { assignee; started_at = "2026-06-26T00:00:01Z" })
+            ()
+        in
+        Workspace.write_backlog config
+          { Types.tasks = [ task ]; last_updated = "2026-06-26T00:00:02Z"; version = 2 };
+        let request = Httpun.Request.create `GET "/health" in
+        let json = Server_routes_http_runtime.make_health_json request in
+        let open Yojson.Safe.Util in
+        let fleet_safety = json |> member "keeper_fleet_safety" in
+        Alcotest.(check string) "health marks missing binding degraded"
+          "degraded"
+          (fleet_safety |> member "status" |> to_string);
+        Alcotest.(check string) "health marks missing binding blocker"
+          "active_task_owner_without_executable_fiber"
+          (fleet_safety |> member "blocker" |> to_string);
+        Alcotest.(check bool) "health exposes missing binding flag" true
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber"
+           |> to_bool);
+        Alcotest.(check int) "health exposes missing binding row count" 1
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_count"
+           |> to_int);
+        Alcotest.(check (list string)) "health has no keeper names"
+          []
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_names"
+           |> to_list
+           |> List.map to_string);
+        let active_owner_tasks =
+          fleet_safety
+          |> member "active_task_owner_without_executable_fiber_tasks"
+          |> to_list
+        in
+        Alcotest.(check int) "health exposes missing binding task row" 1
+          (List.length active_owner_tasks);
+        let active_owner_task = List.hd active_owner_tasks in
+        Alcotest.(check bool) "missing binding row keeper null" true
+          (active_owner_task |> member "keeper" = `Null);
+        Alcotest.(check bool) "missing binding row name null" true
+          (active_owner_task |> member "name" = `Null);
+        Alcotest.(check string) "missing binding row agent" assignee
+          (active_owner_task |> member "agent_name" |> to_string);
+        Alcotest.(check string) "missing binding row task id"
+          "task-active-owner-without-binding"
+          (active_owner_task |> member "task_id" |> to_string);
+        Alcotest.(check string) "missing binding action"
+          "create_keeper_or_reassign_task"
+          (active_owner_task |> member "action" |> to_string);
+        Alcotest.(check bool) "health asks operator action" true
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
 let test_health_json_degrades_when_reaction_capacity_below_target () =
@@ -3253,6 +3409,14 @@ let () =
             "health json reports dormant task owner as advisory"
             `Quick
             test_health_json_reports_dormant_task_owner_as_advisory;
+          Alcotest.test_case
+            "health json ignores stale active task alias when agent executable"
+            `Quick
+            test_health_json_ignores_stale_active_task_alias_when_agent_executable;
+          Alcotest.test_case
+            "health json degrades on active task owner without keeper binding"
+            `Quick
+            test_health_json_degrades_on_active_task_owner_without_keeper_binding;
           Alcotest.test_case
             "health json degrades when reaction capacity is below target"
             `Quick test_health_json_degrades_when_reaction_capacity_below_target;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1594,7 +1594,95 @@ let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
         Alcotest.(check string) "missing binding action"
           "create_keeper_or_reassign_task"
           (active_owner_task |> member "action" |> to_string);
+        Alcotest.(check (list string)) "health names missing binding assignee"
+          [ assignee ]
+          (fleet_safety |> member "blocked_keeper_names" |> to_list
+           |> List.map to_string);
+        Alcotest.(check (list (pair string string)))
+          "health explains missing binding blocker"
+          [ (assignee, "no_keeper_binding") ]
+          (fleet_safety |> member "blocked_keeper_reasons" |> to_list
+           |> List.map (fun row ->
+                ( row |> member "agent_name" |> to_string
+                , row |> member "reason" |> to_string )));
         Alcotest.(check bool) "health asks operator action" true
+          (fleet_safety |> member "operator_action_required" |> to_bool)))
+
+let test_health_json_preserves_active_task_owner_meta_read_error () =
+  with_temp_dir "health-active-task-owner-meta-read-error" (fun dir ->
+    let config_root = make_config_root dir in
+    Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
+    write_config_root_keeper_toml config_root "broken";
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        write_file (Keeper_types_profile.keeper_meta_path config "broken")
+          "{ invalid keeper meta";
+        let assignee = "keeper-broken-agent" in
+        let task =
+          make_task
+            ~id:"task-active-owner-corrupt-meta"
+            ~title:"Active keeper task with unreadable keeper meta"
+            ~status:
+              (Types.InProgress
+                 { assignee; started_at = "2026-06-26T00:00:01Z" })
+            ()
+        in
+        Workspace.write_backlog config
+          { Types.tasks = [ task ]; last_updated = "2026-06-26T00:00:02Z"; version = 2 };
+        let phase_counts :
+            Server_routes_http_runtime_fleet_scan.keeper_phase_counts =
+          { running = 0; failing = 0; recovering = 0; executable = 0 }
+        in
+        let phase_snapshot :
+            Server_routes_http_runtime_fleet_scan.keeper_phase_snapshot =
+          {
+            counts = phase_counts;
+            running_names = [];
+            recovering_names = [];
+            executable_names = [];
+            phase_names = [];
+          }
+        in
+        let fleet_safety =
+          Server_routes_http_runtime_fleet_scan.keeper_fleet_safety_health_json
+            ~bootable_names:[]
+            ~autoboot_scan:
+              Server_routes_http_runtime_fleet_scan.empty_autoboot_keeper_scan
+            ~phase_snapshot
+            ~phase_counts
+            ~paused_keepers_json:(`Assoc [ ("count", `Int 0) ])
+            ()
+        in
+        let open Yojson.Safe.Util in
+        Alcotest.(check string) "health leaves incomplete owner scan non-degraded"
+          "ok"
+          (fleet_safety |> member "status" |> to_string);
+        Alcotest.(check bool) "health does not reinterpret read error as owner gap"
+          false
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber"
+           |> to_bool);
+        Alcotest.(check int) "health has no active owner task rows" 0
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_count"
+           |> to_int);
+        Alcotest.(check int) "health preserves active owner scan error" 1
+          (fleet_safety |> member "active_task_owner_scan_error_count" |> to_int);
+        Alcotest.(check (list string)) "health records broken keeper scan error"
+          [ "broken" ]
+          (fleet_safety |> member "active_task_owner_scan_errors" |> to_list
+           |> List.map (fun row -> row |> member "source" |> to_string));
+        Alcotest.(check bool) "health does not ask action for incomplete scan"
+          false
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
 let test_health_json_degrades_when_reaction_capacity_below_target () =
@@ -3417,6 +3505,10 @@ let () =
             "health json degrades on active task owner without keeper binding"
             `Quick
             test_health_json_degrades_on_active_task_owner_without_keeper_binding;
+          Alcotest.test_case
+            "health json preserves active task owner meta read error"
+            `Quick
+            test_health_json_preserves_active_task_owner_meta_read_error;
           Alcotest.test_case
             "health json degrades when reaction capacity is below target"
             `Quick test_health_json_degrades_when_reaction_capacity_below_target;


### PR DESCRIPTION
Follow-up to merged #22333. The active-task-owner health scan still had two review gaps after merge: an active assignee with zero keeper bindings was invisible, and a stale non-executable alias could create a false row even when another binding for the same assignee was executable.

Changes:
- emit zero-binding active-owner rows with keeper/name null and typed create/reassign action
- suppress stale alias rows when any binding for that assignee is executable
- let real active-owner rows degrade fleet health while keeping autoboot-disabled dormant keepers excluded
- move the scan semantics text into a module constant and cover the edge cases in health JSON tests

Validation:
- ocamlformat --check lib/server/server_routes_http_runtime_fleet_scan.ml lib/server/server_routes_http_runtime_fleet_scan.mli test/test_server_runtime_bootstrap.ml
- git diff --check origin/main...HEAD
- ocamlc -stop-after parsing lib/server/server_routes_http_runtime_fleet_scan.ml
- ocamlc -stop-after parsing lib/server/server_routes_http_runtime_fleet_scan.mli
- ocamlc -stop-after parsing test/test_server_runtime_bootstrap.ml
- scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe