### PR TITLE
fix(keeper): fail closed malformed approval rules

### DIFF
--- a/docs/security/approval-rules.md
+++ b/docs/security/approval-rules.md
@@ -1,0 +1,47 @@
+# Approval Rules
+
+Keeper approval rules are persisted allow rules in `.masc/approval-rules.json`.
+They are only loaded when each rule entry parses as a complete rule. Malformed
+entries are ignored, which means they cannot match a future request and cannot
+auto-approve a tool call.
+
+## Fail-Closed Parse Policy
+
+The persisted file must be a JSON list. Each entry must be an object with these
+required fields:
+
+- `id`: non-blank string
+- `keeper_name`: non-blank string
+- `tool_name`: non-blank string
+- `request_fingerprint`: non-blank string
+- `max_risk`: one of `low`, `medium`, `high`, or `critical`
+- `created_at`: number
+- `match_count`: non-negative integer
+
+Optional fields such as `sandbox_profile`, `backend`, `created_by`,
+`last_matched_at`, and `source_approval_id` remain optional. A missing
+`request_fingerprint_preview` is derived from a valid fingerprint.
+
+No malformed required field receives a permissive default. In particular,
+invalid or missing `max_risk` does not default to `high`.
+
+## Rejection Proof
+
+`test/test_keeper_approval_queue_rules.ml` writes a persisted rule whose keeper,
+tool, and request fingerprint would otherwise match a low-risk request, but whose
+`max_risk` is malformed. The test verifies that:
+
+- `list_rules` skips the malformed rule during load
+- `find_matching_rule` returns `None` for the matching request
+- rewriting the same persisted shape with a valid `max_risk` loads and matches
+
+This pins the operational behavior: malformed persisted approval rules are not
+silently allowed.
+
+## Error Variant Boundary
+
+The `InvalidRequest { message; _ }` patterns in keeper runtime/provider error
+handling preserve compatibility with the SDK error record shape. They do not
+load, parse, match, or serialize approval rules. Approval-rule fail-closed
+behavior is owned by `approval_rule_of_yojson`, `list_rules`, and
+`find_matching_rule`.

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -105,11 +105,6 @@ let string_opt_of_json = function
   | _ -> None
 ;;
 
-(* RFC-0145 — narrow the wildcard catch-all to the only exception
-   [Yojson.Safe.Util.member] can raise on non-object inputs.  An
-   unrelated runtime exception (e.g. [Out_of_memory], async failure,
-   unexpected internal contract break) will now propagate to the
-   caller instead of being silently coerced to [None]. *)
 let string_opt_member key json =
   match Json_util.assoc_member_opt key json with
   | Some value -> string_opt_of_json value
@@ -150,7 +145,8 @@ let approval_rule_to_yojson (rule : approval_rule) =
 ;;
 
 let approval_rule_of_yojson json =
-  try
+  match json with
+  | `Assoc _ ->
     let id = (match Json_util.assoc_member_opt "id" json with Some (`String s) -> s | _ -> "") in
     let keeper_name = (match Json_util.assoc_member_opt "keeper_name" json with Some (`String s) -> s | _ -> "") in
     let tool_name = (match Json_util.assoc_member_opt "tool_name" json with Some (`String s) -> s | _ -> "") in
@@ -196,7 +192,5 @@ let approval_rule_of_yojson json =
       ; match_count
       ; source_approval_id
       }
-  with
-  | Eio.Cancel.Cancelled _ as e -> raise e
   | _ -> None
 ;;

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -117,6 +117,12 @@ let bool_member key json ~default =
   | _ -> default
 ;;
 
+let non_negative_int_member key json =
+  match Json_util.get_int json key with
+  | Some value when value >= 0 -> Some value
+  | _ -> None
+;;
+
 let rule_match_to_yojson (matched : rule_match) =
   `Assoc [ "rule_id", `String matched.rule_id; "matched_by", `String matched.matched_by ]
 ;;
@@ -147,14 +153,15 @@ let approval_rule_to_yojson (rule : approval_rule) =
 let approval_rule_of_yojson json =
   match json with
   | `Assoc _ ->
-    let id = (match Json_util.assoc_member_opt "id" json with Some (`String s) -> s | _ -> "") in
-    let keeper_name = (match Json_util.assoc_member_opt "keeper_name" json with Some (`String s) -> s | _ -> "") in
-    let tool_name = (match Json_util.assoc_member_opt "tool_name" json with Some (`String s) -> s | _ -> "") in
+    let ( let* ) = Option.bind in
+    let* id = string_opt_member "id" json in
+    let* keeper_name = string_opt_member "keeper_name" json in
+    let* tool_name = string_opt_member "tool_name" json in
     let sandbox_profile = Json_util.get_string json "sandbox_profile" in
     let backend = Json_util.get_string json "backend" in
-    let request_fingerprint = (match Json_util.assoc_member_opt "request_fingerprint" json with Some (`String s) -> s | _ -> "") in
+    let* request_fingerprint = string_opt_member "request_fingerprint" json in
     let request_fingerprint_preview =
-      Json_util.get_string json "request_fingerprint_preview"
+      string_opt_member "request_fingerprint_preview" json
       |> Option.value
            ~default:
              (String.sub
@@ -162,20 +169,12 @@ let approval_rule_of_yojson json =
                 0
                 (min 12 (String.length request_fingerprint)))
     in
-    let max_risk =
-      (match Json_util.assoc_member_opt "max_risk" json with Some (`String s) -> s | _ -> "")
-      |> risk_level_of_string
-      |> Option.value ~default:High
-    in
-    let created_at =
-      Json_util.get_float json "created_at"
-      |> Option.value ~default:(Unix.gettimeofday ())
-    in
+    let* max_risk_raw = string_opt_member "max_risk" json in
+    let* max_risk = risk_level_of_string max_risk_raw in
+    let* created_at = Json_util.get_float json "created_at" in
     let created_by = Json_util.get_string json "created_by" in
     let last_matched_at = Json_util.get_float json "last_matched_at" in
-    let match_count =
-      Json_util.get_int json "match_count" |> Option.value ~default:0
-    in
+    let* match_count = non_negative_int_member "match_count" json in
     let source_approval_id = Json_util.get_string json "source_approval_id" in
     Some
       { id

--- a/test/dune
+++ b/test/dune
@@ -1914,6 +1914,8 @@
 
 (include stanzas/test_keeper_approval_queue_rules_types.inc)
 
+(include stanzas/test_keeper_approval_queue_rules.inc)
+
 (include stanzas/test_keeper_toml_parser.inc)
 
 (include stanzas/test_keeper_toml_loader.inc)

--- a/test/stanzas/test_keeper_approval_queue_rules.inc
+++ b/test/stanzas/test_keeper_approval_queue_rules.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_approval_queue_rules)
+ (modules test_keeper_approval_queue_rules)
+ (libraries alcotest masc unix yojson))

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -1,0 +1,100 @@
+open Alcotest
+
+module AQ = Masc.Keeper_approval_queue
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_approval_queue_rules_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let cleanup_dir dir =
+  let rec rm_rf path =
+    if Sys.is_directory path
+    then (
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else Sys.remove path
+  in
+  try rm_rf dir with
+  | _ -> ()
+;;
+
+let write_rules ~base_path json =
+  let masc_dir = Filename.concat base_path ".masc" in
+  if not (Sys.file_exists masc_dir) then Unix.mkdir masc_dir 0o755;
+  Out_channel.with_open_text
+    (Filename.concat masc_dir "approval-rules.json")
+    (fun oc -> output_string oc (Yojson.Safe.pretty_to_string json))
+;;
+
+let stored_rule_json ~base_path =
+  match AQ.list_rules_dashboard_json ~base_path () with
+  | `List [ (`Assoc _ as rule_json) ] -> rule_json
+  | json ->
+    fail
+      ("expected exactly one stored approval rule, got: " ^ Yojson.Safe.to_string json)
+;;
+
+let with_max_risk value = function
+  | `Assoc fields -> `Assoc (("max_risk", value) :: List.remove_assoc "max_risk" fields)
+  | json -> json
+;;
+
+let matching_lookup ~base_path ~input () =
+  AQ.find_matching_rule
+    ~base_path
+    ~keeper_name:"keeper"
+    ~tool_name:"tool_execute"
+    ~input
+    ~risk_level:AQ.Low
+    ()
+;;
+
+let test_malformed_persisted_rule_cannot_match () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let input = `Assoc [ "command", `String "deploy"; "args", `List [] ] in
+       let _, created =
+         AQ.upsert_rule
+           ~base_path
+           ~keeper_name:"keeper"
+           ~tool_name:"tool_execute"
+           ~input
+           ~risk_level:AQ.High
+           ()
+       in
+       check bool "fixture rule created" true created;
+       let valid_rule_json = stored_rule_json ~base_path in
+       write_rules
+         ~base_path
+         (`List [ with_max_risk (`String "god-mode") valid_rule_json ]);
+       check int "malformed rule skipped during load" 0 (List.length (AQ.list_rules ~base_path ()));
+       check
+         bool
+         "malformed rule does not auto-approve matching low-risk request"
+         true
+         (Option.is_none (matching_lookup ~base_path ~input ()));
+       write_rules ~base_path (`List [ valid_rule_json ]);
+       check int "valid rule loads" 1 (List.length (AQ.list_rules ~base_path ()));
+       check
+         bool
+         "same persisted shape matches once valid"
+         true
+         (Option.is_some (matching_lookup ~base_path ~input ())))
+;;
+
+let () =
+  run
+    "Keeper_approval_queue_rules"
+    [ ( "persisted rules"
+      , [ test_case
+            "malformed persisted rule cannot match"
+            `Quick
+            test_malformed_persisted_rule_cannot_match
+        ] )
+    ]
+;;

--- a/test/test_keeper_approval_queue_rules_types.ml
+++ b/test/test_keeper_approval_queue_rules_types.ml
@@ -52,6 +52,80 @@ let test_approval_rule_rejects_non_object_json () =
     (Q.approval_rule_of_yojson (`String "not-a-rule"))
 ;;
 
+let test_approval_rule_rejects_malformed_object_json () =
+  let without field =
+    match Q.approval_rule_to_yojson sample_rule with
+    | `Assoc fields -> `Assoc (List.remove_assoc field fields)
+    | json -> json
+  in
+  check
+    (option reject)
+    "missing id"
+    None
+    (Q.approval_rule_of_yojson (without "id"));
+  check
+    (option reject)
+    "blank keeper name"
+    None
+    (Q.approval_rule_of_yojson
+       (`Assoc
+           [ "id", `String "rule-1"
+           ; "keeper_name", `String " "
+           ; "tool_name", `String "tool_execute"
+           ; "request_fingerprint", `String "abcdef"
+           ; "max_risk", `String "high"
+           ; "created_at", `Float 1780587600.0
+           ; "match_count", `Int 0
+           ]));
+  check
+    (option reject)
+    "invalid max risk"
+    None
+    (Q.approval_rule_of_yojson
+       (`Assoc
+           [ "id", `String "rule-1"
+           ; "keeper_name", `String "keeper"
+           ; "tool_name", `String "tool_execute"
+           ; "request_fingerprint", `String "abcdef"
+           ; "max_risk", `String "god-mode"
+           ; "created_at", `Float 1780587600.0
+           ; "match_count", `Int 0
+           ]));
+  check
+    (option reject)
+    "missing max risk"
+    None
+    (Q.approval_rule_of_yojson (without "max_risk"));
+  check
+    (option reject)
+    "invalid match count"
+    None
+    (Q.approval_rule_of_yojson
+       (`Assoc
+           [ "id", `String "rule-1"
+           ; "keeper_name", `String "keeper"
+           ; "tool_name", `String "tool_execute"
+           ; "request_fingerprint", `String "abcdef"
+           ; "max_risk", `String "high"
+           ; "created_at", `Float 1780587600.0
+           ; "match_count", `String "0"
+           ]));
+  check
+    (option reject)
+    "negative match count"
+    None
+    (Q.approval_rule_of_yojson
+       (`Assoc
+           [ "id", `String "rule-1"
+           ; "keeper_name", `String "keeper"
+           ; "tool_name", `String "tool_execute"
+           ; "request_fingerprint", `String "abcdef"
+           ; "max_risk", `String "high"
+           ; "created_at", `Float 1780587600.0
+           ; "match_count", `Int (-1)
+           ]))
+;;
+
 let test_blank_string_json_is_none () =
   check (option string) "blank" None (Q.string_opt_of_json (`String "  "))
 ;;
@@ -67,6 +141,10 @@ let () =
             "approval rule rejects non-object json"
             `Quick
             test_approval_rule_rejects_non_object_json
+        ; test_case
+            "approval rule rejects malformed object json"
+            `Quick
+            test_approval_rule_rejects_malformed_object_json
         ; test_case "blank string is none" `Quick test_blank_string_json_is_none
         ] )
     ]

--- a/test/test_keeper_approval_queue_rules_types.ml
+++ b/test/test_keeper_approval_queue_rules_types.ml
@@ -39,6 +39,19 @@ let test_approval_rule_json_round_trip () =
     check bool "risk" true (parsed.max_risk = Q.High)
 ;;
 
+let test_approval_rule_rejects_non_object_json () =
+  check
+    (option reject)
+    "list input"
+    None
+    (Q.approval_rule_of_yojson (`List []));
+  check
+    (option reject)
+    "string input"
+    None
+    (Q.approval_rule_of_yojson (`String "not-a-rule"))
+;;
+
 let test_blank_string_json_is_none () =
   check (option string) "blank" None (Q.string_opt_of_json (`String "  "))
 ;;
@@ -50,6 +63,10 @@ let () =
       , [ test_case "risk conversions" `Quick test_risk_level_conversions ] )
     ; ( "json"
       , [ test_case "approval rule round trip" `Quick test_approval_rule_json_round_trip
+        ; test_case
+            "approval rule rejects non-object json"
+            `Quick
+            test_approval_rule_rejects_non_object_json
         ; test_case "blank string is none" `Quick test_blank_string_json_is_none
         ] )
     ]


### PR DESCRIPTION
## Summary
- addresses the audit quick-win/high finding for `approval_rule_of_yojson` swallowing parser/runtime failures through `with _ -> None`
- removes the wildcard catch-all from approval-rule parsing
- rejects non-object JSON inputs instead of constructing blank/default approval rules
- rejects malformed object rules when required fields are missing, blank, or invalid (`id`, `keeper_name`, `tool_name`, `request_fingerprint`, `max_risk`, `created_at`, `match_count`)
- keeps optional fields optional while preserving deterministic `request_fingerprint_preview` derivation from a valid fingerprint
- adds regression coverage for list/string non-object inputs and malformed object fields, including invalid/missing `max_risk` and invalid/negative `match_count`
- adds persisted-rule proof that a malformed stored rule with matching identity/fingerprint is skipped by `list_rules` and cannot match through `find_matching_rule`
- keeps the persisted-rule proof on public APIs: `upsert_rule`, `list_rules_dashboard_json`, `list_rules`, and `find_matching_rule`
- documents the approval-rule fail-closed policy and the unrelated `InvalidRequest { message; _ }` error-variant boundary in `docs/security/approval-rules.md`
- rebased onto current `origin/main` and dropped the duplicated `InvalidRequest` compatibility commit from this PR scope

## Verification
- `ocamlformat --check test/test_keeper_approval_queue_rules.ml test/test_keeper_approval_queue_rules_types.ml lib/keeper_contract/keeper_approval_queue_rules_types.ml`
- `ocamlc -stop-after parsing test/test_keeper_approval_queue_rules.ml test/test_keeper_approval_queue_rules_types.ml lib/keeper_contract/keeper_approval_queue_rules_types.ml`
- `git diff --check`
- `rg -n "request_fingerprint|InvalidRequest \\{ message; _ \\}|approval_rule_of_yojson|list_rules|find_matching_rule" test/test_keeper_approval_queue_rules.ml test/stanzas/test_keeper_approval_queue_rules.inc docs/security/approval-rules.md lib/keeper_contract/keeper_approval_queue_rules_types.ml lib/keeper/keeper_approval_queue_rules.ml`
- `git range-diff origin/main..origin/fix/audit-approval-rule-parser-20260626 origin/main..HEAD`
- `git diff origin/main...HEAD --name-only`

No Dune/local build was run; CI remains the build authority.
