### PR TITLE
fix(security): sunset Shell IR path-jail kill-switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   kill-switch. Shell IR execution now always applies the workspace path jail;
   operators should remove the old env override and handle false positives with
   policy/data fixes or rollback instead of disabling path validation.
+  Runtime startup now warns and emits
+  `masc_keeper_shell_ir_effect_total{kind="retired_path_jail_env_ignored"}`
+  when the retired env var is still present. The former
+  `path_jail_disabled` label is retired because the path jail can no longer be
+  disabled at runtime.
 - `dashboard`: documented the Memory OS `external_ref` dashboard API removal.
   Legacy payloads are ignored rather than re-rendered as status tags; producers
   must use future structured origin fields instead of relying on the retired

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
   context for the model, not a machine-readable external-state status tag.
 
 ### Removed
+- `runtime`: removed the temporary `MASC_SHELL_IR_PATH_JAIL_ENABLED`
+  kill-switch. Shell IR execution now always applies the workspace path jail;
+  operators should remove the old env override and handle false positives with
+  policy/data fixes or rollback instead of disabling path validation.
 - `dashboard`: documented the Memory OS `external_ref` dashboard API removal.
   Legacy payloads are ignored rather than re-rendered as status tags; producers
   must use future structured origin fields instead of relying on the retired

--- a/docs/audit/2026-06-21-productization-blockers-adversarial-audit.md
+++ b/docs/audit/2026-06-21-productization-blockers-adversarial-audit.md
@@ -57,26 +57,29 @@ No runtime `let default_base = "/Users/dancer/me"` style default was found in `b
 
 ## Findings
 
-### 1. Shell IR path-jail kill-switch can remove a product safety boundary
+### 1. Shell IR path-jail kill-switch could remove a product safety boundary
 
-**Severity**: P0 when `MASC_SHELL_IR_PATH_JAIL_ENABLED=false`; P1 until the kill-switch has a sunset and policy boundary.
+**Severity**: Historical P0 when `MASC_SHELL_IR_PATH_JAIL_ENABLED=false`; resolved once the P5 sunset removes the kill-switch and makes the path jail unconditional.
 
-**Evidence**:
+**Pre-sunset evidence**:
 
-- `lib/keeper_tooling/keeper_tool_execute_shell_ir.ml:76-84` skips `Exec_policy.validate_shell_ir_paths` entirely when `Env_config_runtime.Shell_ir_path_jail.enabled ()` is false.
-- `lib/config/env_config_runtime.ml:957-968` documents that disabling the flag removes "the only positional write-escape guard on the Host profile".
-- `lib/keeper/keeper_tool_execute_runtime.ml:571-583` logs and counts `path_jail_disabled`, but still proceeds.
+- `lib/keeper_tooling/keeper_tool_execute_shell_ir.ml:76-84` skipped `Exec_policy.validate_shell_ir_paths` entirely when `Env_config_runtime.Shell_ir_path_jail.enabled ()` was false.
+- `lib/config/env_config_runtime.ml:957-968` documented that disabling the flag removed "the only positional write-escape guard on the Host profile".
+- `lib/keeper/keeper_tool_execute_runtime.ml:571-583` logged and counted `path_jail_disabled`, but still proceeded.
 - `lib/exec_policy/exec_policy.ml:631-742` contains the actual path/cwd/redirect validation that gets bypassed.
 
 **Impact**:
 
-For a multi-agent system, this is not just a debug knob. A single process-level env value can move Host-profile Execute from path-validated to path-unvalidated. If a keeper can issue Shell IR on Host while the flag is off, product safety depends on operational discipline instead of an enforceable boundary.
+For a multi-agent system, this was not just a debug knob. A single process-level env value could move Host-profile Execute from path-validated to path-unvalidated. If a keeper could issue Shell IR on Host while the flag was off, product safety depended on operational discipline instead of an enforceable boundary.
 
 **Fix direction**:
 
-- Remove the public steady-state kill-switch, or make it an emergency-only startup valve that requires an explicit local operator approval file/token and emits a fatal startup warning.
-- Add a CI/product gate proving Host-profile Execute cannot run with path-jail disabled outside test binaries.
-- Keep `path_jail_disabled` telemetry, but do not treat telemetry as a control.
+- Resolved by removing the public steady-state kill-switch and making Shell IR
+  path validation unconditional in product runtime.
+- Add or keep CI/product gates proving the retired env knob cannot re-enter the
+  runtime tunables catalog or feature-flag registry.
+- Treat old `path_jail_disabled` telemetry references as historical evidence
+  only; telemetry is not a substitute for an enforced control.
 
 ### 2. Env/config control plane is too wide, and the guard has false negatives
 

--- a/docs/rfc/RFC-0255-shell-ir-path-typed-scope-and-floor-narrow.md
+++ b/docs/rfc/RFC-0255-shell-ir-path-typed-scope-and-floor-narrow.md
@@ -124,13 +124,13 @@ Split `Git_op.Destructive` by **recoverability** (§2.6), not by local/remote:
 
 > **Implementation caveat (M1).** The RFC-0254 claim "the compiler forces every match site" did **not** hold at the floor: `find_destructive_git` used `Git_op.Destructive _ as g` with a `_ :: rest` catch-all under `[@@warning "-4"]`. This PR keeps raw destructive git floored and adds a closed `git_is_floored : Git_op.t -> bool`, so a future top-level `Git_op.t` constructor must receive an explicit floor decision instead of falling through the capability scan.
 
-### 4.6 Path-jail kill-switch (closes §2.4) — valve with a removal obligation
+### 4.6 Path-jail kill-switch (historical valve, sunset at P5)
 
-Introduce `MASC_SHELL_IR_PATH_JAIL_ENABLED` (default `true`, lifecycle `Active`, re-readable per process) gating `validate_shell_ir_paths`, so a path-policy false-positive can be disabled without a rebuild — symmetric with the approval-gate kill-switch.
+Historical P1 introduced `MASC_SHELL_IR_PATH_JAIL_ENABLED` (default `true`, re-readable per process) gating `validate_shell_ir_paths`, so a path-policy false-positive could be disabled without a rebuild — symmetric with the approval-gate kill-switch.
 
 > **Security note (M2).** Disabling this flag removes the **only positional write-escape guard** on the Host profile: `find_write_escape` inspects `Capability.Write_path`, which is emitted only from **redirects**, never positional argv (`capability_check.ml:~36-41`). So a positional write-escape (`cp ../../x /tmp`, `mv` outside the workspace) is caught by nothing but the path jail. Turning the flag off trades write containment for read relief — acceptable as a short-lived valve, not a steady state.
 
-**Removal obligation (CLAUDE.md Override condition):** the flag carries `removal target: P5 landing` and a tracking issue from day one. It is a valve, not the fix; the fix is §4.1–4.4.
+**P5 sunset status:** the flag has been removed. Product runtime always calls `Exec_policy.validate_shell_ir_paths`; a path-policy false-positive now requires a policy/data fix or rollback, not an operator env override. The temporary valve was removed; the path jail graduated into the permanent defense.
 
 ## 5. Non-goals
 
@@ -140,10 +140,10 @@ Introduce `MASC_SHELL_IR_PATH_JAIL_ENABLED` (default `true`, lifecycle `Active`,
 
 ## 6. Implementation plan
 
-1. **P1 — kill-switch (§4.6).** Smallest, unblocks operations. Flag + gate + `removal target: P5` + tracking issue. Ship first so a regression has an env-level mitigation.
+1. **P1 — kill-switch (§4.6, historical).** Smallest, unblocks operations. Flag + gate + `removal target: P5` + tracking issue. Shipped first so a regression had an env-level mitigation.
 2. **P2 — floor classifier hardening (§4.5).** Keep raw destructive git floored, add the closed `git_is_floored` classifier so future `Git_op.t` arms cannot fail open, and document the structured-recovery preconditions required before any future narrowing of `reset --hard` / `branch -D`. Tests per §4.5. Self-contained in `lib/exec`.
 3. **P3+P4 — typed cwd-correct producer + jail consumer, ATOMIC (one PR) (§4.1–4.4).** Thread cwd/mapped-roots through the producer; author per-slot direction metadata; resolve cross-lib ownership; rewrite the jail to consume typed scopes; **land the `Sensitive_path` deny-list (§4.3) in the same PR as the read widening**; delete `looks_like_path_token`/`*_token`. P3 and P4 must not land separately — a half-migrated state runs two classifiers (the RFC-0254 §5.4 anti-pattern). Reconcile `find_write_escape` (§4.4).
-4. **P5 — verification (§7) + remove the kill-switch's removal obligation** (or graduate the flag to permanent if soak demands it, with an explicit decision).
+4. **P5 — verification (§7) + remove the kill-switch.** The path jail graduated to the only product path; the env-level off-switch did not.
 
 P1+P2 resolve the *floor* and the *operational gap* quickly; P3+P4 are the structural root fix and ship as one coherent, atomic change.
 
@@ -157,8 +157,8 @@ P1+P2 resolve the *floor* and the *operational gap* quickly; P3+P4 are the struc
 
 ## 8. Rollout
 
-- P1 kill-switch ships first; if the live false-positive storm recurs, `MASC_SHELL_IR_PATH_JAIL_ENABLED=false` + **restart** is the immediate mitigation (env read at process start; no live flip). Operators must know this also drops the positional write-escape guard (§4.6 M2).
-- P3+P4 graduate behind the same flag: land honoring the flag, soak, then make typed-scope the only path; remove the kill-switch obligation at P5.
+- P1 kill-switch shipped first as a historical mitigation valve. At P5 the env-level mitigation is removed; if a live false-positive storm recurs, operators should roll back or patch policy/data rather than disabling the path jail.
+- P3+P4 graduated behind the same flag historically: land honoring the flag, soak, then make typed-scope the only path; remove the kill-switch at P5.
 - Post-enable verification (`<base-path>/.masc/logs/system_log_*.jsonl`): `path_reject` should drop to genuine write-escapes; `policy_denied` should show raw destructive git (`push --force`/`clean -fd`/`worktree remove`/`reset --hard`/`branch -D`) and structured recovery commands should emit their own proof records if added.
 
 ## 9. Alternatives considered

--- a/docs/rfc/RFC-eliminate-substring-destructive-classifier.md
+++ b/docs/rfc/RFC-eliminate-substring-destructive-classifier.md
@@ -57,12 +57,10 @@ worker 도구는 전부 MCP 프록시(`worker_container.ml:298-332` `build_oas_m
 
 **중요 — caps 는 redirect 만 path cap 을 emit** (`capability_check.mli:13-16`): `rm`/`chmod`/`dd` 의 인자 경로는
 cap 이 아니라 단순 arg 이므로 `find_write_escape`(catastrophic_floor)가 못 본다. 이들의 경로 차단은 오직 path
-jail(3)이 한다. path jail 은 `Shell_ir_path_jail.enabled` 로 끌 수 있으나 **기본값 true**(`env_config_runtime.ml:956`)
-이며 **영구 메커니즘**이다 — RFC-0255 §3 은 "path jail 제거"(대안 C)를 *기각*("the jail is the only write-escape
-guard on Host")하고, P5 는 jail 을 *the only path* 로 graduate(=무조건화)한다. "short-lived valve, not a steady
-state"·`removal target: P5` 가 가리키는 것은 jail 을 **끄는 kill-switch(disabled 상태)**이지 jail 자체가 아니다
-(`keeper_tool_execute_shell_ir.ml:77-81`: "When disabled, … short-lived valve"). 즉 제거되는 건 off-switch 이고,
-그 결과 jail 은 영구화된다.
+jail(3)이 한다. path jail 은 **영구 메커니즘**이다 — RFC-0255 §3 은 "path jail 제거"(대안 C)를 *기각*
+("the jail is the only write-escape guard on Host")하고, P5 는 jail 을 *the only path* 로 graduate(=무조건화)한다.
+"short-lived valve, not a steady state"·`removal target: P5` 가 가리키는 것은 jail 을 **끄던 kill-switch(disabled
+상태)**이지 jail 자체가 아니다. P5 에서 제거되는 건 off-switch 이고, 그 결과 jail 은 영구화된다.
 
 ### 2.4 측정 framing — command-shape only (path jail 은 별개의 영구 축)
 본 RFC 의 harness 와 gap 은 (1)+(2) **command-shape 분류기**만 측정하고 (3) path jail 을 **의도적으로 제외**한다.

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,7 +14,7 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 369 unique knobs across 9 modules.
+**Total**: 368 unique knobs across 9 modules.
 
 **Typed getter classification**: 41/223 tagged (`operator`: 41, `algorithm`: 0, `unclassified`: 182).
 
@@ -204,7 +204,7 @@ the categorization roadmap. Newly-added typed getters in
 |---|---|---|---|---|---|
 | `MASC_OAS_BRIDGE_TIMEOUT_DEFAULT_SEC` | string_literal | n/a | n/a | 99 |  |
 
-## Env_config_runtime (114 knobs; typed classification 5/90)
+## Env_config_runtime (113 knobs; typed classification 5/90)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
@@ -285,7 +285,6 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_SESSION_RATE_LIMIT_WINDOW_SEC` | typed:float | unclassified | unclassified | 40 | Rate limit window (seconds) |
 | `MASC_SESSION_SSE_GRACE_PERIOD_SEC` | typed:float | unclassified | unclassified | 45 | Grace period after SSE disconnect before reaping transport session (seconds). Prevents "Unknown Mcp-Session-Id" error... |
 | `MASC_SHELL_IR_APPROVAL_GATE_ENABLED` | feature_flag | n/a | n/a | 953 | Enable the Shell IR approval policy gate. Default: true (RFC-0254 — the autonomous policy is a strict safety improv... |
-| `MASC_SHELL_IR_PATH_JAIL_ENABLED` | feature_flag | n/a | n/a | 967 | Apply the workspace path jail [Exec_policy.validate_shell_ir_paths] to keeper Execute commands. Default: true. Re-rea... |
 | `MASC_SIDECAR_CONTROL_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 886 | Subprocess timeout (seconds) for sidecar control commands — [stop], [tail], and similar quick housekeeping operatio... |
 | `MASC_SIDECAR_RECONCILE_BACKOFF_SEC` | typed:float | unclassified | unclassified | 874 | Backoff window (seconds) between repeated same-generation [running + unavailable] start dispatches. Default: 30 (matc... |
 | `MASC_SIDECAR_SCHEMA_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 902 | Subprocess timeout (seconds) for sidecar Python schema generation. Wraps [Process_eio.run_argv_with_status] at [serve... |

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -953,18 +953,4 @@ module Shell_ir_approval_gate = struct
     Feature_flag_registry.get_bool "MASC_SHELL_IR_APPROVAL_GATE_ENABLED"
 end
 
-module Shell_ir_path_jail = struct
-  (** Apply the workspace path jail [Exec_policy.validate_shell_ir_paths] to
-      keeper Execute commands. Default: true. Re-readable within the process;
-      set MASC_SHELL_IR_PATH_JAIL_ENABLED=false to disable [path_reject]
-      without recompilation (RFC-0255 section 4.6).
-
-      Trade-off: disabling also removes the only positional write-escape guard
-      on the Host profile ([find_write_escape] covers redirect writes only), so
-      this is a short-lived valve, not a steady state. removal target:
-      RFC-0255 P5 (typed Path-scope landing). *)
-  let enabled () =
-    Feature_flag_registry.get_bool "MASC_SHELL_IR_PATH_JAIL_ENABLED"
-end
-
 (** {1 Internal Safety Configuration} *)

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -366,13 +366,3 @@ module Shell_ir_approval_gate : sig
       operations require explicit approval. Default: [true] (the autonomous
       policy is a strict safety improvement over the no-gate path). *)
 end
-
-module Shell_ir_path_jail : sig
-  val enabled : unit -> bool
-  (** [enabled ()] is true when [MASC_SHELL_IR_PATH_JAIL_ENABLED] is set.
-      Applies the workspace path jail [Exec_policy.validate_shell_ir_paths]
-      to keeper Execute commands. Default: [true]. Kill-switch (RFC-0255
-      section 4.6): set false to disable [path_reject] without a rebuild;
-      this also removes the only positional write-escape guard on the Host
-      profile, so it is a short-lived valve, not a steady state. *)
-end

--- a/lib/config/feature_flag_registry.ml
+++ b/lib/config/feature_flag_registry.ml
@@ -187,12 +187,6 @@ let all_flags : flag list = [
     description = "Route Execute tool calls through the capability-based Shell IR approval policy gate";
     default = true; category = "runtime";
     lifecycle = Active; since = "2.234.0" };
-
-  { env_name = "MASC_SHELL_IR_PATH_JAIL_ENABLED";
-    description = "Apply the Shell IR workspace path jail (validate_shell_ir_paths) to keeper Execute commands. Kill-switch: set false to disable path_reject without a rebuild (RFC-0255 section 4.6); also drops the only positional write-escape guard on Host";
-    default = true; category = "runtime";
-    lifecycle = Active; since = "2.235.0" };
-
   { env_name = "MASC_SLOT_YIELD_ENABLED";
     description = "Release LLM slot during tool execution so other agents can use it";
     default = true; category = "runtime";

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -602,6 +602,9 @@ let handle_tool_execute_typed
                   meta.name
                   (Printexc.to_string exn))
           in
+          Retired_env_warnings.report_shell_ir_path_jail_if_set
+            ~source:"execute"
+            ();
           let dispatch_result =
             if Env_config_runtime.Shell_ir_approval_gate.enabled ()
             then (

--- a/lib/keeper/keeper_tool_execute_runtime.ml
+++ b/lib/keeper/keeper_tool_execute_runtime.ml
@@ -568,19 +568,6 @@ let handle_tool_execute_typed
           let stream_dispatch =
             Sys.getenv_opt "MASC_STREAM_EXECUTE_OUTPUT" <> Some "false"
           in
-          if not (Env_config_runtime.Shell_ir_path_jail.enabled ())
-          then (
-            Log.Keeper.warn
-              ~keeper_name:meta.name
-              "shell_ir path_jail_disabled keeper=%s sandbox=%s cwd=%s cmd=%s"
-              meta.name
-              (Keeper_types_profile_sandbox.sandbox_profile_to_string sandbox_profile)
-              cwd
-              cmd_for_log;
-            Otel_metric_store.inc_counter
-              (Keeper_metrics.to_string Keeper_metrics.ShellIrEffectTotal)
-              ~labels:[ "kind", "path_jail_disabled"; "source", "execute" ]
-              ());
           if stream_dispatch
           then (
             try

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -93,14 +93,7 @@ let rec first_privileged_program = function
 ;;
 
 let validate_paths ?keeper_id ?base_path ~workdir ir =
-  (* RFC-0255 section 4.6: path-jail kill-switch. When disabled, skip the
-     workspace path whitelist entirely. This also removes the only positional
-     write-escape guard on the Host profile ([find_write_escape] covers
-     redirect writes only), so it is a short-lived valve, not a steady state.
-     removal target: RFC-0255 P5. *)
-  if Env_config_runtime.Shell_ir_path_jail.enabled () then
-    Exec_policy.validate_shell_ir_paths ?keeper_id ?base_path ~workdir ir
-  else Ok ()
+  Exec_policy.validate_shell_ir_paths ?keeper_id ?base_path ~workdir ir
 ;;
 
 let tool_execute_command_context ?(allow_pipes = true) command =

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.ml
@@ -92,6 +92,9 @@ let rec first_privileged_program = function
      | None -> first_privileged_program rest)
 ;;
 
+(* Public seam shared by direct Shell IR dispatch and Docker sandbox host-path
+   validation, where container paths are first rewritten for the host policy
+   check.  Keeping the facade here ensures both routes use the same jail. *)
 let validate_paths ?keeper_id ?base_path ~workdir ir =
   Exec_policy.validate_shell_ir_paths ?keeper_id ?base_path ~workdir ir
 ;;

--- a/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
+++ b/lib/keeper_tooling/keeper_tool_execute_shell_ir.mli
@@ -46,7 +46,9 @@ val validate_paths :
   workdir:string ->
   Masc_exec.Shell_ir.t ->
   (unit, string) result
-(** Validate Shell IR path arguments through the keeper Shell IR facade. *)
+(** Validate Shell IR path arguments through the keeper Shell IR facade.
+    Direct Shell IR dispatch and Docker sandbox host-path validation share this
+    seam so both routes apply the same path jail. *)
 
 val tool_execute_command_context :
   ?allow_pipes:bool ->

--- a/lib/retired_env_warnings.ml
+++ b/lib/retired_env_warnings.ml
@@ -1,0 +1,25 @@
+let shell_ir_path_jail_env_key = "MASC_SHELL_IR_PATH_JAIL_ENABLED"
+let shell_ir_path_jail_reported = Atomic.make false
+
+let shell_ir_path_jail_env_configured ?(getenv = Sys.getenv_opt) () =
+  match Option.bind (getenv shell_ir_path_jail_env_key) String_util.trim_to_option with
+  | None -> false
+  | Some _ -> true
+
+let report_shell_ir_path_jail_if_set ?(source = "runtime") () =
+  if
+    shell_ir_path_jail_env_configured ()
+    && not (Atomic.exchange shell_ir_path_jail_reported true)
+  then (
+    Log.Keeper.warn
+      "retired env knob ignored env=%s; Shell IR path jail is permanent and \
+       cannot be disabled at runtime"
+      shell_ir_path_jail_env_key;
+    Otel_metric_store.inc_counter
+      (Keeper_metrics.to_string Keeper_metrics.ShellIrEffectTotal)
+      ~labels:[ "kind", "retired_path_jail_env_ignored"; "source", source ]
+      ())
+
+module For_testing = struct
+  let shell_ir_path_jail_env_configured = shell_ir_path_jail_env_configured
+end

--- a/lib/retired_env_warnings.mli
+++ b/lib/retired_env_warnings.mli
@@ -1,0 +1,11 @@
+(** Runtime warnings for removed environment knobs that operators may still
+    carry in shell profiles or deployment manifests. *)
+
+val report_shell_ir_path_jail_if_set : ?source:string -> unit -> unit
+(** Warn and emit telemetry once per process when the retired
+    [MASC_SHELL_IR_PATH_JAIL_ENABLED] env var is still configured. *)
+
+module For_testing : sig
+  val shell_ir_path_jail_env_configured :
+    ?getenv:(string -> string option) -> unit -> bool
+end

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -327,6 +327,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      span / no [tool_dispatch_total] metric). *)
   Tool_dispatch.set_span_wrapper Tool_telemetry.with_span;
   Otel_metric_store.register_otel_source_once ();
+  Retired_env_warnings.report_shell_ir_path_jail_if_set ~source:"startup" ();
   Otel_runtime_observables.register_once
     ~masc_root:(Workspace.masc_root_dir (Mcp_server.workspace_config state))
     ();

--- a/test/test_destructive_floor_differential.ml
+++ b/test/test_destructive_floor_differential.ml
@@ -27,14 +27,11 @@
     because the path jail is a SEPARATE, PERMANENT policy axis — not because it
     is temporary:
 
-      - The path jail is default-ON ([Shell_ir_path_jail.enabled] defaults to
-        true, env_config_runtime.ml:956). RFC-0255 §3 rejects removing it
-        (alternative C: "the jail is the only write-escape guard on Host"), and
-        RFC-0255 P5 GRADUATES it to the only path — i.e. makes it permanent. The
-        "short-lived valve, not a steady state" with removal target P5 is the
-        kill-switch's DISABLED state (setting the flag to false), NOT the jail.
-        Depending on the path jail is therefore depending on a permanent
-        defense.
+      - RFC-0255 §3 rejects removing the path jail (alternative C: "the jail is
+        the only write-escape guard on Host"), and RFC-0255 P5 graduates it to
+        the only path — i.e. makes it permanent. The former short-lived
+        kill-switch was the temporary part; depending on the path jail is
+        therefore depending on a permanent defense.
       - Command-shape (what binary / git op / redirect) and path-scope (where
         the argument points) are orthogonal axes. A command-shape differential
         that folded in the path jail would conflate the two and could never

--- a/test/test_feature_flag_registry.ml
+++ b/test/test_feature_flag_registry.ml
@@ -105,6 +105,11 @@ let test_hitl_disable_flag_defaults_false () =
   | Some flag -> assert (flag.R.default = false)
   | None -> assert false
 
+let test_path_jail_kill_switch_removed () =
+  match R.find_opt "MASC_SHELL_IR_PATH_JAIL_ENABLED" with
+  | None -> ()
+  | Some _ -> assert false
+
 (* ─── (4) flag_to_json shape ──────────────────────────────────── *)
 
 let test_flag_to_json_eight_fields () =
@@ -212,6 +217,7 @@ let () =
   test_find_opt_unknown ();
   test_find_opt_first_registered ();
   test_hitl_disable_flag_defaults_false ();
+  test_path_jail_kill_switch_removed ();
   test_flag_to_json_eight_fields ();
   test_flag_to_json_canonical_default_is_bool ();
   test_to_json_total_matches_all_flags ();

--- a/test/test_keeper_sandbox_docker_cwd_response.ml
+++ b/test/test_keeper_sandbox_docker_cwd_response.ml
@@ -220,6 +220,19 @@ let test_path_probe_does_not_list_parent_outside_cwd () =
        | Some entries -> check (list string) "outside parent entries hidden" [] entries
        | None -> fail "path probe should include parent_entries")
 
+let test_retired_path_jail_env_detection () =
+  let configured value =
+    Retired_env_warnings.For_testing.shell_ir_path_jail_env_configured
+      ~getenv:(fun name ->
+        if String.equal name "MASC_SHELL_IR_PATH_JAIL_ENABLED"
+        then value
+        else None)
+      ()
+  in
+  check bool "absent retired path jail env" false (configured None);
+  check bool "blank retired path jail env" false (configured (Some "  "));
+  check bool "non-empty retired path jail env" true (configured (Some "false"))
+
 (* Source-level pin: assert that no [("cwd", `String <ident>)]
    literal remains in keeper_sandbox_docker.ml. The four sites
    from #11080's sibling leak class must be wired through
@@ -286,5 +299,11 @@ let () =
         ; test_case
             "absolute missing path outside cwd does not list parent"
             `Quick test_path_probe_does_not_list_parent_outside_cwd
+        ] )
+    ; ( "retired-env"
+      , [
+          test_case
+            "path jail retired env detection ignores blanks"
+            `Quick test_retired_path_jail_env_detection
         ] )
     ]


### PR DESCRIPTION
Addresses PR-D from 2026-06-21 adversarial audit. Makes Host-profile Shell IR path-validation unconditional in product mode by removing the MASC_SHELL_IR_PATH_JAIL_ENABLED env flag.