### PR TITLE
fix(test): use keeper runtime task id projection

### DIFF
--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -217,7 +217,7 @@ let test_current_task_id_for_agent_reconciles_from_empty_registry_task () =
         let current_from_registry =
           match Keeper_registry.get ~base_path:config.Workspace.base_path keeper_name with
           | Some entry ->
-            Option.map Keeper_id.Task_id.to_string entry.meta.current_task_id
+            Keeper_runtime_contract.current_task_id_opt entry.meta
           | None -> None
         in
         check (option string) "registry current task reconciled" (Some task_id)
@@ -225,7 +225,7 @@ let test_current_task_id_for_agent_reconciles_from_empty_registry_task () =
         let current_from_disk =
           match Keeper_meta_store.read_meta config keeper_name with
           | Ok (Some persisted) ->
-            Option.map Keeper_id.Task_id.to_string persisted.current_task_id
+            Keeper_runtime_contract.current_task_id_opt persisted
           | Ok None -> None
           | Error err -> fail ("read_meta failed: " ^ err)
         in


### PR DESCRIPTION
## Summary
- fix CI compile failure in test_smart_heartbeat_keepalive by using the public Keeper_runtime_contract.current_task_id_opt projection
- avoid direct Keeper_id reference from the test target, which depends on masc but not the private keeper id module boundary

## Verification
- ocamlc -stop-after parsing test/test_smart_heartbeat_keepalive.ml
- git diff --check

## CI Context
- Follow-up for main CI failure on 49f99bc: test/test_smart_heartbeat_keepalive.ml referenced unbound Keeper_id in Build and Health jobs.
- Focused local dune wrapper did not complete: first blocked on generated OAS pin doc guard in current main, then Dune shared cache/lock contention; GitHub CI is the build authority for this fix.