### PR TITLE
fix(test): Masc_domain.Task_id path in smart_heartbeat_keepalive (main red)

### DIFF
--- a/test/test_smart_heartbeat_keepalive.ml
+++ b/test/test_smart_heartbeat_keepalive.ml
@@ -217,7 +217,7 @@ let test_current_task_id_for_agent_reconciles_from_empty_registry_task () =
         let current_from_registry =
           match Keeper_registry.get ~base_path:config.Workspace.base_path keeper_name with
           | Some entry ->
-            Option.map Keeper_id.Task_id.to_string entry.meta.current_task_id
+            Option.map Masc_domain.Task_id.to_string entry.meta.current_task_id
           | None -> None
         in
         check (option string) "registry current task reconciled" (Some task_id)
@@ -225,7 +225,7 @@ let test_current_task_id_for_agent_reconciles_from_empty_registry_task () =
         let current_from_disk =
           match Keeper_meta_store.read_meta config keeper_name with
           | Ok (Some persisted) ->
-            Option.map Keeper_id.Task_id.to_string persisted.current_task_id
+            Option.map Masc_domain.Task_id.to_string persisted.current_task_id
           | Ok None -> None
           | Error err -> fail ("read_meta failed: " ^ err)
         in


### PR DESCRIPTION
main red 원인 중 하나 fix: test_smart_heartbeat_keepalive.ml:220,228 이 Keeper_id.Task_id.to_string 참조(Keeper_id=keeper_identity엔 Task_id 서브모듈 없음). 정확한 경로 Masc_domain.Task_id.to_string 로 변경(다른 test 일관 패턴). 별도 main red 축: lib/keeper/keeper_runtime_attempt.ml:228 InvalidRequest record reason 필드 누락(agent_sdk pin bump #22390로 record 구조 변경, 생성처 미업데이트) — 이건 agent_sdk pin 영역, 본인 처리.