### PR TITLE
fix(discord): resolve Discord mentions to display names in dashboard chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
 
 ## Unreleased
 
+### Fixed
+- `gate`: Discord inbound messages now resolve `<@snowflake>` / `<@!snowflake>`
+  user mentions to `@DisplayName` using the structured `mentions` array. This
+  makes Discord-originated chat in the dashboard show human-readable names
+  instead of raw ids. The existing platform surface badge already identifies the
+  message as coming from Discord.
+
 ### Changed
 - `dashboard`: Memory OS fact decoding now emits a development-console warning
   when a legacy wire payload still carries `external_ref`. The field remains

--- a/lib/gate/discord_gateway_client.ml
+++ b/lib/gate/discord_gateway_client.ml
@@ -12,6 +12,18 @@ type intent = Discord_gateway_state.intent =
   | Direct_messages
   | Direct_message_reactions
 
+type mention_kind = Discord_gateway_state.mention_kind =
+  | User_mention
+  | Role_mention
+  | Channel_mention
+
+type resolved_mention = Discord_gateway_state.resolved_mention =
+  { mention_id : string
+  ; mention_name : string option
+  ; mention_kind : mention_kind
+  ; raw_mention : string
+  }
+
 type gateway_event = Discord_gateway_state.dispatched_event =
   | Ready of
       { session_id : string
@@ -25,6 +37,8 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       ; author_id : string
       ; author_name : string option
       ; content : string
+      ; raw_content : string
+      ; resolved_mentions : resolved_mention list
       ; mention_user_ids : string list
       ; mentions_bot : bool
       ; explicit_mentions_bot : bool

--- a/lib/gate/discord_gateway_client.mli
+++ b/lib/gate/discord_gateway_client.mli
@@ -22,6 +22,18 @@ type intent = Discord_gateway_state.intent =
   | Direct_messages
   | Direct_message_reactions
 
+type mention_kind = Discord_gateway_state.mention_kind =
+  | User_mention
+  | Role_mention
+  | Channel_mention
+
+type resolved_mention = Discord_gateway_state.resolved_mention =
+  { mention_id : string
+  ; mention_name : string option
+  ; mention_kind : mention_kind
+  ; raw_mention : string
+  }
+
 type gateway_event = Discord_gateway_state.dispatched_event =
   | Ready of
       { session_id : string
@@ -35,6 +47,8 @@ type gateway_event = Discord_gateway_state.dispatched_event =
       ; author_id : string
       ; author_name : string option
       ; content : string
+      ; raw_content : string
+      ; resolved_mentions : resolved_mention list
       ; mention_user_ids : string list
       ; mentions_bot : bool
       ; explicit_mentions_bot : bool

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -69,6 +69,24 @@ let intent_bit = function
 let intents_bitmask intents =
   List.fold_left (fun acc i -> acc lor (intent_bit i)) 0 intents
 
+(* ── Mention resolution metadata ──────────────────────────────── *)
+
+type mention_kind =
+  | User_mention
+  | Role_mention
+  | Channel_mention
+
+(** A single Discord mention found in message content. [mention_name] is
+    populated for user mentions when the structured [mentions] array
+    included a display name; role/channel mentions stay [None] until a
+    guild cache is wired in. *)
+type resolved_mention =
+  { mention_id : string
+  ; mention_name : string option
+  ; mention_kind : mention_kind
+  ; raw_mention : string
+  }
+
 (* ── Dispatched events ─────────────────────────────────────────── *)
 
 type dispatched_event =
@@ -84,6 +102,15 @@ type dispatched_event =
       ; author_id : string
       ; author_name : string option
       ; content : string
+      ; raw_content : string
+            (* Original message content before mention resolution. Kept so
+               downstream consumers can fall back to snowflakes or render
+               their own mention UI without re-parsing. *)
+      ; resolved_mentions : resolved_mention list
+            (* Structured mentions discovered in [raw_content]. Populated
+               for user mentions when names are available; role/channel
+               mentions are recorded with [mention_name = None] so callers
+               can identify their positions without parsing again. *)
       ; mention_user_ids : string list
             (* RFC-0232 §3.3: the structured [mentions] member ids are
                kept at decode instead of being reduced to a bot bool;
@@ -313,50 +340,50 @@ let content_mentions_user ~user_id content =
    nickname-ping).  The structured [mentions] array carries the matching
    user objects, including [global_name] / [username].  Resolve those
    snowflakes to human-readable [@DisplayName] so downstream consumers
-   (keeper prompt, dashboard chat) see names instead of raw ids.  Unknown
-   ids are left untouched. *)
+   (keeper prompt, dashboard chat) see names instead of raw ids.
+
+   The resolver also records every user/role/channel mention it sees as a
+   structured [resolved_mention], so callers can render tooltips, profile
+   links, or fall back to raw ids without re-parsing the original text. *)
 let user_display_name user_json =
   match field_string_opt "global_name" user_json with
   | Some _ as name -> name
   | None -> field_string_opt "username" user_json
 
+let discord_mention_re =
+  Re.Pcre.re {|<(@!?|@&|#)([0-9]+)>|} |> Re.compile
 
-let resolve_mentions_in_content ~mentions content =
-  let len = String.length content in
-  let buf = Buffer.create len in
-  let rec scan i =
-    if i >= len then Buffer.contents buf
-    else if content.[i] <> '<' then (
-      Buffer.add_char buf content.[i];
-      scan (i + 1))
-    else
-      let id_start, ok =
-        if i + 1 < len && content.[i + 1] = '@' then
-          if i + 2 < len && content.[i + 2] = '!' then (i + 3, true)
-          else (i + 2, true)
-        else (-1, false)
+let mention_kind_of_prefix = function
+  | "@" | "@!" -> User_mention
+  | "@&" -> Role_mention
+  | "#" -> Channel_mention
+  | _ -> User_mention
+
+let resolve_mentions ~mentions content =
+  let resolved = ref [] in
+  let content =
+    Re.replace discord_mention_re content ~f:(fun group ->
+      let raw = Re.Group.get group 0 in
+      let prefix = Re.Group.get group 1 in
+      let id = Re.Group.get group 2 in
+      let kind = mention_kind_of_prefix prefix in
+      let name_opt =
+        match kind with
+        | User_mention -> List.assoc_opt id mentions
+        | Role_mention | Channel_mention -> None
       in
-      if not ok then (
-        Buffer.add_char buf content.[i];
-        scan (i + 1))
-      else
-        let end_i =
-          try String.index_from content id_start '>' with
-          | Not_found -> -1
-        in
-        if end_i < 0 then (
-          Buffer.add_char buf content.[i];
-          scan (i + 1))
-        else
-          let id = String.sub content id_start (end_i - id_start) in
-          (match List.assoc_opt id mentions with
-          | Some name ->
-              Buffer.add_char buf '@';
-              Buffer.add_string buf name
-          | None -> Buffer.add_substring buf content i (end_i - i + 1));
-          scan (end_i + 1)
+      resolved :=
+        { mention_id = id
+        ; mention_name = name_opt
+        ; mention_kind = kind
+        ; raw_mention = raw
+        }
+        :: !resolved;
+      match name_opt with
+      | Some name -> "@" ^ name
+      | None -> raw)
   in
-  scan 0
+  (content, List.rev !resolved)
 
 (* ── Frame parse / encode ──────────────────────────────────────── *)
 
@@ -416,7 +443,7 @@ let decode_message_create ~bot_user_id ~payload =
   let channel_id = field_string_opt "channel_id" payload in
   let guild_id = field_string_opt "guild_id" payload in
   let message_id = field_string_opt "id" payload in
-  let content =
+  let raw_content =
     match field_string_opt "content" payload with
     | Some s -> s
     | None -> ""
@@ -433,25 +460,24 @@ let decode_message_create ~bot_user_id ~payload =
   let author_name =
     match author with
     | None -> None
-    | Some a -> (
-        match field_string_opt "global_name" a with
-        | Some _ as name -> name
-        | None -> field_string_opt "username" a)
+    | Some a -> user_display_name a
   in
   let mentions, mention_user_ids =
     match assoc_opt "mentions" payload with
     | Some (`List items) ->
-        let ids = List.filter_map (fun item -> field_string_opt "id" item) items in
-        let pairs =
-          List.filter_map
-            (fun item ->
+        let pairs, ids =
+          List.fold_right
+            (fun item (pairs, ids) ->
               match field_string_opt "id" item with
-              | Some id -> (
-                  match user_display_name item with
-                  | Some name -> Some (id, name)
-                  | None -> None)
-              | None -> None)
-            items
+              | None -> (pairs, ids)
+              | Some id ->
+                  let pairs =
+                    match user_display_name item with
+                    | Some name -> (id, name) :: pairs
+                    | None -> pairs
+                  in
+                  (pairs, id :: ids))
+            items ([], [])
         in
         (pairs, ids)
     | Some _ | None -> ([], [])
@@ -464,9 +490,9 @@ let decode_message_create ~bot_user_id ~payload =
   let explicit_mentions_bot =
     match bot_user_id with
     | None -> false
-    | Some bot_id -> content_mentions_user ~user_id:bot_id content
+    | Some bot_id -> content_mentions_user ~user_id:bot_id raw_content
   in
-  let content = resolve_mentions_in_content ~mentions content in
+  let content, resolved_mentions = resolve_mentions ~mentions raw_content in
   (* An automated author is either a bot user ([author.bot] = true) or a
      webhook ([webhook_id] present on the message). Discord's own guidance
      is for bots to ignore both so they do not loop on each other. *)
@@ -507,6 +533,8 @@ let decode_message_create ~bot_user_id ~payload =
            ; author_id
            ; author_name
            ; content
+           ; raw_content
+           ; resolved_mentions
            ; mention_user_ids
            ; mentions_bot
            ; explicit_mentions_bot

--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -309,6 +309,55 @@ let content_mentions_user ~user_id content =
   && (contains_substring ~needle:("<@" ^ user_id ^ ">") content
       || contains_substring ~needle:("<@!" ^ user_id ^ ">") content)
 
+(* Discord sends user mentions as [<@snowflake>] (or [<@!snowflake>] for
+   nickname-ping).  The structured [mentions] array carries the matching
+   user objects, including [global_name] / [username].  Resolve those
+   snowflakes to human-readable [@DisplayName] so downstream consumers
+   (keeper prompt, dashboard chat) see names instead of raw ids.  Unknown
+   ids are left untouched. *)
+let user_display_name user_json =
+  match field_string_opt "global_name" user_json with
+  | Some _ as name -> name
+  | None -> field_string_opt "username" user_json
+
+
+let resolve_mentions_in_content ~mentions content =
+  let len = String.length content in
+  let buf = Buffer.create len in
+  let rec scan i =
+    if i >= len then Buffer.contents buf
+    else if content.[i] <> '<' then (
+      Buffer.add_char buf content.[i];
+      scan (i + 1))
+    else
+      let id_start, ok =
+        if i + 1 < len && content.[i + 1] = '@' then
+          if i + 2 < len && content.[i + 2] = '!' then (i + 3, true)
+          else (i + 2, true)
+        else (-1, false)
+      in
+      if not ok then (
+        Buffer.add_char buf content.[i];
+        scan (i + 1))
+      else
+        let end_i =
+          try String.index_from content id_start '>' with
+          | Not_found -> -1
+        in
+        if end_i < 0 then (
+          Buffer.add_char buf content.[i];
+          scan (i + 1))
+        else
+          let id = String.sub content id_start (end_i - id_start) in
+          (match List.assoc_opt id mentions with
+          | Some name ->
+              Buffer.add_char buf '@';
+              Buffer.add_string buf name
+          | None -> Buffer.add_substring buf content i (end_i - i + 1));
+          scan (end_i + 1)
+  in
+  scan 0
+
 (* ── Frame parse / encode ──────────────────────────────────────── *)
 
 let parse_frame (json : Yojson.Safe.t) =
@@ -389,11 +438,23 @@ let decode_message_create ~bot_user_id ~payload =
         | Some _ as name -> name
         | None -> field_string_opt "username" a)
   in
-  let mention_user_ids =
+  let mentions, mention_user_ids =
     match assoc_opt "mentions" payload with
     | Some (`List items) ->
-        List.filter_map (fun item -> field_string_opt "id" item) items
-    | Some _ | None -> []
+        let ids = List.filter_map (fun item -> field_string_opt "id" item) items in
+        let pairs =
+          List.filter_map
+            (fun item ->
+              match field_string_opt "id" item with
+              | Some id -> (
+                  match user_display_name item with
+                  | Some name -> Some (id, name)
+                  | None -> None)
+              | None -> None)
+            items
+        in
+        (pairs, ids)
+    | Some _ | None -> ([], [])
   in
   let mentions_bot =
     match bot_user_id with
@@ -405,6 +466,7 @@ let decode_message_create ~bot_user_id ~payload =
     | None -> false
     | Some bot_id -> content_mentions_user ~user_id:bot_id content
   in
+  let content = resolve_mentions_in_content ~mentions content in
   (* An automated author is either a bot user ([author.bot] = true) or a
      webhook ([webhook_id] present on the message). Discord's own guidance
      is for bots to ignore both so they do not loop on each other. *)

--- a/lib/gate/discord_gateway_state.mli
+++ b/lib/gate/discord_gateway_state.mli
@@ -65,6 +65,24 @@ type intent =
 
 val intents_bitmask : intent list -> int
 
+(** {1 Mention resolution metadata} *)
+
+type mention_kind =
+  | User_mention
+  | Role_mention
+  | Channel_mention
+
+(** Structured mention discovered in message content. [mention_name] is
+    [Some] for user mentions when Discord's [mentions] array supplied a
+    display name; role and channel mentions are currently recorded with
+    [None] until a guild cache is wired in. *)
+type resolved_mention =
+  { mention_id : string
+  ; mention_name : string option
+  ; mention_kind : mention_kind
+  ; raw_mention : string
+  }
+
 (** {1 Dispatched events surfaced to caller} *)
 
 (** Re-exported from Discord_gateway_client. Closed sum. *)
@@ -86,6 +104,10 @@ type dispatched_event =
             [author.username]; [None] only when the payload carries
             neither (RFC-0223 P1). *)
       ; content : string
+      ; raw_content : string
+        (** Original content before mention resolution. *)
+      ; resolved_mentions : resolved_mention list
+        (** Structured mentions found in [raw_content]. *)
       ; mention_user_ids : string list
             (* RFC-0232 §3.3: the structured [mentions] member ids are
                kept at decode instead of being reduced to a bot bool;

--- a/lib/gate/dune
+++ b/lib/gate/dune
@@ -48,6 +48,7 @@
   mirage-crypto-rng
   mirage-crypto-rng.unix
   base64
+  re
   ; existing
   masc_config
   masc_core

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -357,13 +357,28 @@ let message_create_payload
     ~id ~channel_id ~author_id ?guild_id ?username ?global_name
     ?message_reference_channel_id ?message_reference_message_id
     ?referenced_message_author_id ?author_bot ?webhook_id
+    ?(mentions = [])
     ~content ~mention_ids ()
     : Yojson.Safe.t =
-  let mentions =
-    `List
-      (List.map
-         (fun uid -> `Assoc [ ("id", `String uid) ])
-         mention_ids)
+  let mentions_json =
+    if mentions <> [] then
+      `List
+        (List.map
+           (fun (uid, uname, gname) ->
+             `Assoc
+               ([ ("id", `String uid) ]
+                @ (match uname with
+                  | Some u -> [ ("username", `String u) ]
+                  | None -> [])
+                @ match gname with
+                | Some g -> [ ("global_name", `String g) ]
+                | None -> []))
+           mentions)
+    else
+      `List
+        (List.map
+           (fun uid -> `Assoc [ ("id", `String uid) ])
+           mention_ids)
   in
   let author_fields =
     ("id", `String author_id)
@@ -382,7 +397,7 @@ let message_create_payload
     ; ("channel_id", `String channel_id)
     ; ("author", `Assoc author_fields)
     ; ("content", `String content)
-    ; ("mentions", mentions)
+    ; ("mentions", mentions_json)
     ]
     @ (match webhook_id with
        | Some w -> [ ("webhook_id", `String w) ]
@@ -588,6 +603,84 @@ let test_decode_message_create_reply_ping_is_not_explicit_mention () =
         }) ->
       ()
   | Ok _ -> fail "expected reply ping metadata without explicit mention"
+  | Error msg -> fail msg
+
+(* Discord mention -> display-name resolution. *)
+
+let test_decode_message_create_resolves_mention_global_name () =
+  let payload =
+    message_create_payload
+      ~id:"MSG4"
+      ~channel_id:"CH1"
+      ~author_id:"USER1"
+      ~content:"hello <@ALICE>"
+      ~mention_ids:[ "ALICE" ]
+      ~mentions:[ ("ALICE", Some "alice_handle", Some "Alice") ]
+      ()
+  in
+  match
+    S.decode_dispatch
+      ~bot_user_id:(Some "BOT")
+      ~event_name:"MESSAGE_CREATE"
+      ~payload
+  with
+  | Ok
+      (S.Message_create
+        { content = "hello @Alice"
+        ; mentions_bot = false
+        ; explicit_mentions_bot = false
+        ; _
+        }) ->
+      ()
+  | Ok _ -> fail "expected resolved mention using global_name"
+  | Error msg -> fail msg
+
+let test_decode_message_create_resolves_mention_username_fallback () =
+  let payload =
+    message_create_payload
+      ~id:"MSG5"
+      ~channel_id:"CH1"
+      ~author_id:"USER1"
+      ~content:"<@!BOB> check this"
+      ~mention_ids:[ "BOB" ]
+      ~mentions:[ ("BOB", Some "bob_user", None) ]
+      ()
+  in
+  match
+    S.decode_dispatch
+      ~bot_user_id:(Some "BOT")
+      ~event_name:"MESSAGE_CREATE"
+      ~payload
+  with
+  | Ok
+      (S.Message_create
+        { content = "@bob_user check this"
+        ; mentions_bot = false
+        ; explicit_mentions_bot = false
+        ; _
+        }) ->
+      ()
+  | Ok _ -> fail "expected resolved mention using username fallback"
+  | Error msg -> fail msg
+
+let test_decode_message_create_leaves_unknown_mention_untouched () =
+  let payload =
+    message_create_payload
+      ~id:"MSG6"
+      ~channel_id:"CH1"
+      ~author_id:"USER1"
+      ~content:"hey <@UNKNOWN>"
+      ~mention_ids:[]
+      ()
+  in
+  match
+    S.decode_dispatch
+      ~bot_user_id:(Some "BOT")
+      ~event_name:"MESSAGE_CREATE"
+      ~payload
+  with
+  | Ok (S.Message_create { content = "hey <@UNKNOWN>"; _ }) -> ()
+  | Ok _ -> fail "expected unknown mention left as raw snowflake"
   | Error msg -> fail msg
 
 let test_decode_reaction_add_unicode () =
@@ -2010,6 +2103,13 @@ let () =
             test_decode_message_create_preserves_guild_id
         ; test_case "MESSAGE_CREATE reply-ping is not explicit mention"
             `Quick test_decode_message_create_reply_ping_is_not_explicit_mention
+        ; test_case "MESSAGE_CREATE resolves mention to global_name" `Quick
+            test_decode_message_create_resolves_mention_global_name
+        ; test_case "MESSAGE_CREATE resolves mention to username fallback"
+            `Quick
+            test_decode_message_create_resolves_mention_username_fallback
+        ; test_case "MESSAGE_CREATE leaves unknown mention untouched" `Quick
+            test_decode_message_create_leaves_unknown_mention_untouched
         ; test_case "author_name prefers global_name" `Quick
             test_decode_author_name_prefers_global_name
         ; test_case "author_name falls back to username" `Quick

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -361,24 +361,25 @@ let message_create_payload
     ~content ~mention_ids ()
     : Yojson.Safe.t =
   let mentions_json =
-    if mentions <> [] then
-      `List
-        (List.map
-           (fun (uid, uname, gname) ->
-             `Assoc
-               ([ ("id", `String uid) ]
-                @ (match uname with
-                  | Some u -> [ ("username", `String u) ]
-                  | None -> [])
-                @ match gname with
-                | Some g -> [ ("global_name", `String g) ]
-                | None -> []))
-           mentions)
-    else
-      `List
-        (List.map
-           (fun uid -> `Assoc [ ("id", `String uid) ])
-           mention_ids)
+    let full_mentions =
+      List.map
+        (fun (uid, uname, gname) ->
+          `Assoc
+            ([ ("id", `String uid) ]
+             @ (match uname with
+               | Some u -> [ ("username", `String u) ]
+               | None -> [])
+             @ match gname with
+             | Some g -> [ ("global_name", `String g) ]
+             | None -> []))
+        mentions
+    in
+    let mentioned_ids =
+      List.map
+        (fun uid -> `Assoc [ ("id", `String uid) ])
+        mention_ids
+    in
+    `List (full_mentions @ mentioned_ids)
   in
   let author_fields =
     ("id", `String author_id)
@@ -608,14 +609,15 @@ let test_decode_message_create_reply_ping_is_not_explicit_mention () =
 (* Discord mention -> display-name resolution. *)
 
 let test_decode_message_create_resolves_mention_global_name () =
+  let alice_id = "111111111111111111" in
   let payload =
     message_create_payload
       ~id:"MSG4"
       ~channel_id:"CH1"
       ~author_id:"USER1"
-      ~content:"hello <@ALICE>"
-      ~mention_ids:[ "ALICE" ]
-      ~mentions:[ ("ALICE", Some "alice_handle", Some "Alice") ]
+      ~content:("hello <@" ^ alice_id ^ ">")
+      ~mention_ids:[]
+      ~mentions:[ (alice_id, Some "alice_handle", Some "Alice") ]
       ()
   in
   match
@@ -636,14 +638,15 @@ let test_decode_message_create_resolves_mention_global_name () =
   | Error msg -> fail msg
 
 let test_decode_message_create_resolves_mention_username_fallback () =
+  let bob_id = "222222222222222222" in
   let payload =
     message_create_payload
       ~id:"MSG5"
       ~channel_id:"CH1"
       ~author_id:"USER1"
-      ~content:"<@!BOB> check this"
-      ~mention_ids:[ "BOB" ]
-      ~mentions:[ ("BOB", Some "bob_user", None) ]
+      ~content:("<@!" ^ bob_id ^ "> check this")
+      ~mention_ids:[]
+      ~mentions:[ (bob_id, Some "bob_user", None) ]
       ()
   in
   match
@@ -664,12 +667,13 @@ let test_decode_message_create_resolves_mention_username_fallback () =
   | Error msg -> fail msg
 
 let test_decode_message_create_leaves_unknown_mention_untouched () =
+  let unknown_id = "333333333333333333" in
   let payload =
     message_create_payload
       ~id:"MSG6"
       ~channel_id:"CH1"
       ~author_id:"USER1"
-      ~content:"hey <@UNKNOWN>"
+      ~content:("hey <@" ^ unknown_id ^ ">")
       ~mention_ids:[]
       ()
   in
@@ -679,8 +683,90 @@ let test_decode_message_create_leaves_unknown_mention_untouched () =
       ~event_name:"MESSAGE_CREATE"
       ~payload
   with
-  | Ok (S.Message_create { content = "hey <@UNKNOWN>"; _ }) -> ()
+  | Ok (S.Message_create { content; _ })
+    when String.equal content ("hey <@" ^ unknown_id ^ ">") ->
+      ()
   | Ok _ -> fail "expected unknown mention left as raw snowflake"
+  | Error msg -> fail msg
+
+let test_decode_message_create_preserves_raw_content () =
+  let alice_id = "111111111111111111" in
+  let payload =
+    message_create_payload
+      ~id:"MSG7"
+      ~channel_id:"CH1"
+      ~author_id:"USER1"
+      ~content:("hello <@" ^ alice_id ^ ">")
+      ~mention_ids:[]
+      ~mentions:[ (alice_id, Some "alice_handle", Some "Alice") ]
+      ()
+  in
+  match
+    S.decode_dispatch
+      ~bot_user_id:(Some "BOT")
+      ~event_name:"MESSAGE_CREATE"
+      ~payload
+  with
+  | Ok
+      (S.Message_create
+        { content = "hello @Alice"
+        ; raw_content
+        ; _
+        }) when String.equal raw_content ("hello <@" ^ alice_id ^ ">") ->
+      ()
+  | Ok _ -> fail "expected raw_content preserved and content resolved"
+  | Error msg -> fail msg
+
+let test_decode_message_create_records_resolved_mentions () =
+  let alice_id = "111111111111111111" in
+  let channel_id = "444444444444444444" in
+  let role_id = "555555555555555555" in
+  let payload =
+    message_create_payload
+      ~id:"MSG8"
+      ~channel_id:"CH1"
+      ~author_id:"USER1"
+      ~content:
+        ("hi <@" ^ alice_id ^ "> in <#" ^ channel_id ^ "> and <@&"
+       ^ role_id ^ ">")
+      ~mention_ids:[]
+      ~mentions:[ (alice_id, Some "alice_handle", Some "Alice") ]
+      ()
+  in
+  match
+    S.decode_dispatch
+      ~bot_user_id:(Some "BOT")
+      ~event_name:"MESSAGE_CREATE"
+      ~payload
+  with
+  | Ok
+      (S.Message_create
+        { resolved_mentions =
+            [ { mention_id
+              ; mention_name = Some "Alice"
+              ; mention_kind = S.User_mention
+              ; _
+              }
+            ; { mention_id = channel_mention_id
+              ; mention_name = None
+              ; mention_kind = S.Channel_mention
+              ; _
+              }
+            ; { mention_id = role_mention_id
+              ; mention_name = None
+              ; mention_kind = S.Role_mention
+              ; _
+              }
+            ]
+        ; _
+        })
+    when String.equal mention_id alice_id
+         && String.equal channel_mention_id channel_id
+         && String.equal role_mention_id role_id ->
+      ()
+  | Ok (S.Message_create { resolved_mentions; _ }) ->
+      failf "unexpected resolved_mentions: %d items" (List.length resolved_mentions)
+  | Ok _ -> fail "expected Message_create"
   | Error msg -> fail msg
 
 let test_decode_reaction_add_unicode () =
@@ -2110,6 +2196,10 @@ let () =
             test_decode_message_create_resolves_mention_username_fallback
         ; test_case "MESSAGE_CREATE leaves unknown mention untouched" `Quick
             test_decode_message_create_leaves_unknown_mention_untouched
+        ; test_case "MESSAGE_CREATE preserves raw_content" `Quick
+            test_decode_message_create_preserves_raw_content
+        ; test_case "MESSAGE_CREATE records resolved_mentions metadata" `Quick
+            test_decode_message_create_records_resolved_mentions
         ; test_case "author_name prefers global_name" `Quick
             test_decode_author_name_prefers_global_name
         ; test_case "author_name falls back to username" `Quick


### PR DESCRIPTION
## Problem
Discord messages forwarded to the dashboard chat showed raw user mentions like `<@1489985300729172039>` instead of a human-readable name.

## Root cause
`lib/gate/discord_gateway_state.ml` decoded the message `content` field verbatim and only extracted mention ids. No later layer resolved the snowflake to a display name, so the literal `<@...>` string was stored in the keeper chat log and rendered as-is.

## Fix
In `decode_message_create`, build a map from mention snowflake to display name (`global_name` preferred, `username` fallback) using the structured `mentions` array, then replace `<@snowflake>` / `<@!snowflake>` tokens in `content` with `@DisplayName`.

- Bot-mention / trigger-policy detection runs on the raw content before resolution, so behavior is unchanged.
- `mention_user_ids` is computed independently, so detection still works when a mention object lacks a name.
- Unknown ids are left untouched.

## Source platform
The dashboard already renders a Discord surface badge for these messages (via `entry.surface` in `dashboard/src/components/chat/primitives.ts`), so the original platform remains visible.

## Tests
Added unit tests in `test/test_discord_gateway_state.ml` for:
- global_name preference
- username fallback for `<@!id>` nickname pings
- unknown mentions left as raw ids

Also synced the generated OAS pin block in `docs/KEEPER-USER-MANUAL.md` so the local pin-check gate passes.

## Verification

```
MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh runtest test/test_discord_gateway_state.ml
# 91 tests pass
```
