### PR TITLE
fix(board): guard sweep scheduling state

### DIFF
--- a/lib/board/board_core.mli
+++ b/lib/board/board_core.mli
@@ -67,7 +67,7 @@ val flush_interval_sec : float
 (** Builds a fresh empty store with default Hashtbl capacities
     (1024 posts / 4096 comments / 2048 vote-log entries),
     fresh [Eio.Mutex], cold caches, and an [Eio.Stream]
-    [flusher_inbox] capped at 1000 messages. *)
+    [flusher_inbox] capped by the persistence-layer flusher inbox capacity. *)
 val create_store : unit -> store
 
 (** Reset the per-author comment rate-limit tracker.  Test-only. *)

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -13,6 +13,17 @@ include Board_core_payload
 let flush_interval_sec = Env_config.Board.flush_interval_sec
 let flusher_inbox_capacity = 1000
 
+(** Monotonic count of sweep/flush schedule messages skipped because the
+    bounded flusher inbox had no room for the whole batch. *)
+let flusher_schedule_dropped = Atomic.make 0
+let flusher_schedule_dropped_count () = Atomic.get flusher_schedule_dropped
+
+let record_flusher_schedule_drop scheduled_count =
+  for _ = 1 to scheduled_count do
+    Atomic.incr flusher_schedule_dropped
+  done
+;;
+
 (** Monotonic counter of persist failures (disk full, permission errors, etc.). *)
 let persist_errors = Atomic.make 0
 let persist_error_count () = Atomic.get persist_errors
@@ -251,6 +262,7 @@ let rollback_scheduled_msg store scheduled =
 let enqueue_scheduled_msg store scheduled =
   try Eio.Stream.add store.flusher_inbox scheduled.msg
   with
+  | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     let bt = Printexc.get_raw_backtrace () in
     rollback_scheduled_msg store scheduled;
@@ -260,42 +272,61 @@ let enqueue_scheduled_msg store scheduled =
 let enqueue_scheduled_msgs store scheduled =
   let scheduled_count = List.length scheduled in
   let inbox_len = Eio.Stream.length store.flusher_inbox in
-  if inbox_len + scheduled_count > flusher_inbox_capacity
+  if scheduled_count = 0
+  then ()
+  else if scheduled_count > flusher_inbox_capacity - inbox_len
   then (
+    record_flusher_schedule_drop scheduled_count;
     List.iter (rollback_scheduled_msg store) scheduled;
     Log.BoardLog.warn
       "board flusher inbox full; skipped scheduling sweep/flush messages \
        (queued=%d, requested=%d, capacity=%d)"
       inbox_len scheduled_count flusher_inbox_capacity)
-  else List.iter (enqueue_scheduled_msg store) scheduled
+  else (
+    (* [maybe_sweep] is the only producer of these messages and reserves
+       timestamps under [store.mutex] before this check. Once there is room for
+       the whole batch, these adds should not block on capacity. *)
+    List.iter (enqueue_scheduled_msg store) scheduled)
 ;;
 
 let maybe_sweep store =
   let scheduled =
     with_lock store (fun () ->
       let now = Time_compat.now () in
-      let scheduled = ref [] in
-      let schedule msg previous_ts =
-        scheduled := { msg; previous_ts; reserved_ts = now } :: !scheduled
+      let scheduled = [] in
+      let scheduled =
+        if
+          Stdlib.Float.compare
+            (now -. store.last_sweep)
+            (Stdlib.Float.of_int Limits.sweeper_interval_sec)
+          > 0
+        then (
+          let previous_ts = store.last_sweep in
+          store.last_sweep <- now;
+          { msg = Sweep; previous_ts; reserved_ts = now } :: scheduled)
+        else scheduled
       in
-      if
-        Stdlib.Float.compare
-          (now -. store.last_sweep)
-          (Stdlib.Float.of_int Limits.sweeper_interval_sec)
-        > 0
-      then (
-        let previous_ts = store.last_sweep in
-        store.last_sweep <- now;
-        schedule Sweep previous_ts);
-      if
-        Stdlib.Float.compare (now -. store.last_flush) flush_interval_sec > 0
-      then (
-        let previous_ts = store.last_flush in
-        store.last_flush <- now;
-        schedule Flush previous_ts);
-      List.rev !scheduled)
+      let scheduled =
+        if Stdlib.Float.compare (now -. store.last_flush) flush_interval_sec > 0
+        then (
+          let previous_ts = store.last_flush in
+          store.last_flush <- now;
+          { msg = Flush; previous_ts; reserved_ts = now } :: scheduled)
+        else scheduled
+      in
+      List.rev scheduled)
   in
   enqueue_scheduled_msgs store scheduled
+;;
+
+let reset_sweep_schedule_for_test store =
+  with_lock store (fun () ->
+    store.last_sweep <- 0.0;
+    store.last_flush <- 0.0)
+;;
+
+let sweep_schedule_timestamps_for_test store =
+  with_lock store (fun () -> store.last_sweep, store.last_flush)
 ;;
 
 (** {1 Persistence Paths} *)

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -11,6 +11,7 @@ include Board_core_classify
 include Board_core_payload
 
 let flush_interval_sec = Env_config.Board.flush_interval_sec
+let flusher_inbox_capacity = 1000
 
 (** Monotonic counter of persist failures (disk full, permission errors, etc.). *)
 let persist_errors = Atomic.make 0
@@ -36,7 +37,7 @@ let create_store () =
   ; dirty_post_ids = Hashtbl.create 256
   ; dirty_comment_ids = Hashtbl.create 512
   ; last_flush = Time_compat.now ()
-  ; flusher_inbox = Eio.Stream.create 1000
+  ; flusher_inbox = Eio.Stream.create flusher_inbox_capacity
   ; sub_boards = Hashtbl.create 64
   ; sub_boards_by_slug = Hashtbl.create 64
   ; posts_by_turn_ref = Hashtbl.create 256
@@ -230,25 +231,71 @@ let sweep store =
 ;;
 
 (** Auto-sweep if needed, delegates to flusher actor inbox *)
+type scheduled_flusher_msg =
+  { msg : flusher_msg
+  ; previous_ts : float
+  ; reserved_ts : float
+  }
+
+let rollback_scheduled_msg store scheduled =
+  with_lock store (fun () ->
+    match scheduled.msg with
+    | Sweep ->
+      if Stdlib.Float.equal store.last_sweep scheduled.reserved_ts
+      then store.last_sweep <- scheduled.previous_ts
+    | Flush ->
+      if Stdlib.Float.equal store.last_flush scheduled.reserved_ts
+      then store.last_flush <- scheduled.previous_ts)
+;;
+
+let enqueue_scheduled_msg store scheduled =
+  try Eio.Stream.add store.flusher_inbox scheduled.msg
+  with
+  | exn ->
+    let bt = Printexc.get_raw_backtrace () in
+    rollback_scheduled_msg store scheduled;
+    Printexc.raise_with_backtrace exn bt
+;;
+
+let enqueue_scheduled_msgs store scheduled =
+  let scheduled_count = List.length scheduled in
+  let inbox_len = Eio.Stream.length store.flusher_inbox in
+  if inbox_len + scheduled_count > flusher_inbox_capacity
+  then (
+    List.iter (rollback_scheduled_msg store) scheduled;
+    Log.BoardLog.warn
+      "board flusher inbox full; skipped scheduling sweep/flush messages \
+       (queued=%d, requested=%d, capacity=%d)"
+      inbox_len scheduled_count flusher_inbox_capacity)
+  else List.iter (enqueue_scheduled_msg store) scheduled
+;;
+
 let maybe_sweep store =
-  let now = Time_compat.now () in
-  let enqueue_sweep, enqueue_flush =
+  let scheduled =
     with_lock store (fun () ->
-      let enqueue_sweep =
+      let now = Time_compat.now () in
+      let scheduled = ref [] in
+      let schedule msg previous_ts =
+        scheduled := { msg; previous_ts; reserved_ts = now } :: !scheduled
+      in
+      if
         Stdlib.Float.compare
           (now -. store.last_sweep)
           (Stdlib.Float.of_int Limits.sweeper_interval_sec)
         > 0
-      in
-      let enqueue_flush =
+      then (
+        let previous_ts = store.last_sweep in
+        store.last_sweep <- now;
+        schedule Sweep previous_ts);
+      if
         Stdlib.Float.compare (now -. store.last_flush) flush_interval_sec > 0
-      in
-      if enqueue_sweep then store.last_sweep <- now;
-      if enqueue_flush then store.last_flush <- now;
-      enqueue_sweep, enqueue_flush)
+      then (
+        let previous_ts = store.last_flush in
+        store.last_flush <- now;
+        schedule Flush previous_ts);
+      List.rev !scheduled)
   in
-  if enqueue_sweep then Eio.Stream.add store.flusher_inbox Sweep;
-  if enqueue_flush then Eio.Stream.add store.flusher_inbox Flush
+  enqueue_scheduled_msgs store scheduled
 ;;
 
 (** {1 Persistence Paths} *)

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -11,7 +11,7 @@ include Board_core_classify
 include Board_core_payload
 
 let flush_interval_sec = Env_config.Board.flush_interval_sec
-let flusher_inbox_capacity = 1000
+let flusher_inbox_capacity = Env_config.Board.flusher_inbox_capacity
 
 (** Monotonic count of sweep/flush schedule messages skipped because the
     bounded flusher inbox had no room for the whole batch. *)
@@ -19,9 +19,10 @@ let flusher_schedule_dropped = Atomic.make 0
 let flusher_schedule_dropped_count () = Atomic.get flusher_schedule_dropped
 
 let record_flusher_schedule_drop scheduled_count =
-  for _ = 1 to scheduled_count do
-    Atomic.incr flusher_schedule_dropped
-  done
+  (* Single atomic add instead of N increments, so a concurrent reader cannot
+     observe a partial count. [scheduled_count] is a [List.length], so it is
+     non-negative. *)
+  Atomic.fetch_and_add flusher_schedule_dropped scheduled_count |> ignore
 ;;
 
 (** Monotonic counter of persist failures (disk full, permission errors, etc.). *)

--- a/lib/board/board_core_persist.ml
+++ b/lib/board/board_core_persist.ml
@@ -232,18 +232,23 @@ let sweep store =
 (** Auto-sweep if needed, delegates to flusher actor inbox *)
 let maybe_sweep store =
   let now = Time_compat.now () in
-  if
-    Stdlib.Float.compare
-      (now -. store.last_sweep)
-      (Stdlib.Float.of_int Limits.sweeper_interval_sec)
-    > 0
-  then (
-    store.last_sweep <- now;
-    Eio.Stream.add store.flusher_inbox Sweep);
-  if Stdlib.Float.compare (now -. store.last_flush) flush_interval_sec > 0
-  then (
-    store.last_flush <- now;
-    Eio.Stream.add store.flusher_inbox Flush)
+  let enqueue_sweep, enqueue_flush =
+    with_lock store (fun () ->
+      let enqueue_sweep =
+        Stdlib.Float.compare
+          (now -. store.last_sweep)
+          (Stdlib.Float.of_int Limits.sweeper_interval_sec)
+        > 0
+      in
+      let enqueue_flush =
+        Stdlib.Float.compare (now -. store.last_flush) flush_interval_sec > 0
+      in
+      if enqueue_sweep then store.last_sweep <- now;
+      if enqueue_flush then store.last_flush <- now;
+      enqueue_sweep, enqueue_flush)
+  in
+  if enqueue_sweep then Eio.Stream.add store.flusher_inbox Sweep;
+  if enqueue_flush then Eio.Stream.add store.flusher_inbox Flush
 ;;
 
 (** {1 Persistence Paths} *)

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -17,6 +17,13 @@ end
 
 val flush_interval_sec : float
 val flusher_inbox_capacity : int
+(** Capacity of {!store.flusher_inbox}. The scheduler reserves room for a whole
+    sweep/flush batch before enqueueing. *)
+
+val flusher_schedule_dropped_count : unit -> int
+(** Count of sweep/flush schedule messages skipped because the flusher inbox was
+    full. *)
+
 val persist_error_count : unit -> int
 val record_persist_error : where:string -> string -> unit
 
@@ -33,6 +40,11 @@ val with_lock : store -> (unit -> 'a) -> 'a
 val with_persist_lock : store -> (unit -> 'a) -> 'a
 val sweep : store -> int * int
 val maybe_sweep : store -> unit
+val reset_sweep_schedule_for_test : store -> unit
+(** Reset sweep/flush schedule timestamps. Test-only. *)
+
+val sweep_schedule_timestamps_for_test : store -> float * float
+(** Snapshot sweep/flush schedule timestamps under the store mutex. Test-only. *)
 
 val board_base_path : unit -> string
 val board_masc_dir : unit -> string

--- a/lib/board/board_core_persist.mli
+++ b/lib/board/board_core_persist.mli
@@ -16,6 +16,7 @@ include module type of struct
 end
 
 val flush_interval_sec : float
+val flusher_inbox_capacity : int
 val persist_error_count : unit -> int
 val record_persist_error : where:string -> string -> unit
 

--- a/lib/config/env_config_runtime.ml
+++ b/lib/config/env_config_runtime.ml
@@ -469,6 +469,13 @@ module Board = struct
   let flush_interval_sec =
     get_float ~default:30.0 "MASC_BOARD_FLUSH_INTERVAL_SEC"
 
+  (** Capacity of the board flusher inbox (scheduled sweep/flush messages
+      enqueued by the sweeper). Single source of truth shared by the
+      persistence layer, its [.mli] doc, and the stream creation site.
+      Default: 1000. *)
+  let flusher_inbox_capacity =
+    get_int ~default:1000 "MASC_BOARD_FLUSHER_INBOX_CAPACITY"
+
   (** Board backend type as a typed selector (e.g. "jsonl", "pg"). *)
   let backend_opt () =
     Sys.getenv_opt "MASC_BOARD_BACKEND"

--- a/lib/config/env_config_runtime.mli
+++ b/lib/config/env_config_runtime.mli
@@ -231,6 +231,7 @@ module Board : sig
   val backend_of_string : string -> backend
   val backend_to_string : backend -> string
   val flush_interval_sec : float
+  val flusher_inbox_capacity : int
   val backend_opt : unit -> backend option
 end
 

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -111,18 +111,74 @@ let test_sweeper_skips_permanent () =
   let (removed_posts, _) = sweep store in
   Alcotest.(check int) "sweeper removed 0 permanent posts" 0 removed_posts
 
+let reset_sweep_schedule_for_test store =
+  store.last_sweep <- 0.0;
+  store.last_flush <- 0.0
+
+let maybe_sweep_for_test = Masc_board_handlers.Board_core_persist.maybe_sweep
+
+let flusher_inbox_capacity_for_test =
+  Masc_board_handlers.Board_core_persist.flusher_inbox_capacity
+
+let drain_flusher_inbox store =
+  let rec loop acc =
+    match Eio.Stream.take_nonblocking store.flusher_inbox with
+    | None -> List.rev acc
+    | Some msg -> loop (msg :: acc)
+  in
+  loop []
+
+let check_one_sweep_and_flush label messages =
+  let sweep_count, flush_count =
+    List.fold_left
+      (fun (sweeps, flushes) msg ->
+         match msg with
+         | Sweep -> (sweeps + 1, flushes)
+         | Flush -> (sweeps, flushes + 1))
+      (0, 0)
+      messages
+  in
+  Alcotest.(check int) (label ^ " sweep count") 1 sweep_count;
+  Alcotest.(check int) (label ^ " flush count") 1 flush_count
+
 let test_maybe_sweep_updates_schedule_once () =
   let store = create_store () in
-  store.last_sweep <- 0.0;
-  store.last_flush <- 0.0;
-  Masc_board_handlers.Board_core_persist.maybe_sweep store;
+  reset_sweep_schedule_for_test store;
+  maybe_sweep_for_test store;
   let first_sweep = store.last_sweep in
   let first_flush = store.last_flush in
   Alcotest.(check bool) "sweep timestamp updated" true (first_sweep > 0.0);
   Alcotest.(check bool) "flush timestamp updated" true (first_flush > 0.0);
-  Masc_board_handlers.Board_core_persist.maybe_sweep store;
+  maybe_sweep_for_test store;
   Alcotest.(check (float 0.0)) "sweep timestamp unchanged" first_sweep store.last_sweep;
-  Alcotest.(check (float 0.0)) "flush timestamp unchanged" first_flush store.last_flush
+  Alcotest.(check (float 0.0)) "flush timestamp unchanged" first_flush store.last_flush;
+  check_one_sweep_and_flush "sequential" (drain_flusher_inbox store)
+
+let test_maybe_sweep_concurrent_schedules_once () =
+  let store = create_store () in
+  reset_sweep_schedule_for_test store;
+  let callers = List.init 32 Fun.id in
+  let _ =
+    Eio.Fiber.List.map
+      ~max_fibers:32
+      (fun _ -> maybe_sweep_for_test store)
+      callers
+  in
+  check_one_sweep_and_flush "concurrent" (drain_flusher_inbox store)
+
+let test_maybe_sweep_full_inbox_rolls_back_schedule () =
+  let store = create_store () in
+  reset_sweep_schedule_for_test store;
+  for _ = 1 to flusher_inbox_capacity_for_test do
+    Eio.Stream.add store.flusher_inbox Flush
+  done;
+  maybe_sweep_for_test store;
+  Alcotest.(check (float 0.0)) "sweep timestamp rolled back" 0.0 store.last_sweep;
+  Alcotest.(check (float 0.0)) "flush timestamp rolled back" 0.0 store.last_flush;
+  Alcotest.(check int)
+    "full inbox length unchanged"
+    flusher_inbox_capacity_for_test
+    (Eio.Stream.length store.flusher_inbox)
 
 let test_post_kind_direct_default () =
   let store = create_store () in
@@ -233,6 +289,10 @@ let () =
             (with_eio test_sweeper_skips_permanent);
           Alcotest.test_case "maybe_sweep schedules once" `Quick
             (with_eio test_maybe_sweep_updates_schedule_once);
+          Alcotest.test_case "maybe_sweep concurrent schedules once" `Quick
+            (with_eio test_maybe_sweep_concurrent_schedules_once);
+          Alcotest.test_case "maybe_sweep full inbox rolls back schedule" `Quick
+            (with_eio test_maybe_sweep_full_inbox_rolls_back_schedule);
         ] );
       ( "visibility_ssot",
         [

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -111,14 +111,21 @@ let test_sweeper_skips_permanent () =
   let (removed_posts, _) = sweep store in
   Alcotest.(check int) "sweeper removed 0 permanent posts" 0 removed_posts
 
-let reset_sweep_schedule_for_test store =
-  store.last_sweep <- 0.0;
-  store.last_flush <- 0.0
+let schedule_reset_timestamp_for_test = 0.0
+
+let reset_sweep_schedule_for_test =
+  Masc_board_handlers.Board_core_persist.reset_sweep_schedule_for_test
+
+let sweep_schedule_timestamps_for_test =
+  Masc_board_handlers.Board_core_persist.sweep_schedule_timestamps_for_test
 
 let maybe_sweep_for_test = Masc_board_handlers.Board_core_persist.maybe_sweep
 
 let flusher_inbox_capacity_for_test =
   Masc_board_handlers.Board_core_persist.flusher_inbox_capacity
+
+let flusher_schedule_dropped_count_for_test =
+  Masc_board_handlers.Board_core_persist.flusher_schedule_dropped_count
 
 let drain_flusher_inbox store =
   let rec loop acc =
@@ -145,13 +152,13 @@ let test_maybe_sweep_updates_schedule_once () =
   let store = create_store () in
   reset_sweep_schedule_for_test store;
   maybe_sweep_for_test store;
-  let first_sweep = store.last_sweep in
-  let first_flush = store.last_flush in
+  let first_sweep, first_flush = sweep_schedule_timestamps_for_test store in
   Alcotest.(check bool) "sweep timestamp updated" true (first_sweep > 0.0);
   Alcotest.(check bool) "flush timestamp updated" true (first_flush > 0.0);
   maybe_sweep_for_test store;
-  Alcotest.(check (float 0.0)) "sweep timestamp unchanged" first_sweep store.last_sweep;
-  Alcotest.(check (float 0.0)) "flush timestamp unchanged" first_flush store.last_flush;
+  let second_sweep, second_flush = sweep_schedule_timestamps_for_test store in
+  Alcotest.(check (float 0.0)) "sweep timestamp unchanged" first_sweep second_sweep;
+  Alcotest.(check (float 0.0)) "flush timestamp unchanged" first_flush second_flush;
   check_one_sweep_and_flush "sequential" (drain_flusher_inbox store)
 
 let test_maybe_sweep_concurrent_schedules_once () =
@@ -172,9 +179,20 @@ let test_maybe_sweep_full_inbox_rolls_back_schedule () =
   for _ = 1 to flusher_inbox_capacity_for_test do
     Eio.Stream.add store.flusher_inbox Flush
   done;
+  let dropped_before = flusher_schedule_dropped_count_for_test () in
   maybe_sweep_for_test store;
-  Alcotest.(check (float 0.0)) "sweep timestamp rolled back" 0.0 store.last_sweep;
-  Alcotest.(check (float 0.0)) "flush timestamp rolled back" 0.0 store.last_flush;
+  let dropped_after = flusher_schedule_dropped_count_for_test () in
+  let sweep_ts, flush_ts = sweep_schedule_timestamps_for_test store in
+  Alcotest.(check int) "full inbox dropped scheduled messages" 2
+    (dropped_after - dropped_before);
+  Alcotest.(check (float 0.0))
+    "sweep timestamp rolled back"
+    schedule_reset_timestamp_for_test
+    sweep_ts;
+  Alcotest.(check (float 0.0))
+    "flush timestamp rolled back"
+    schedule_reset_timestamp_for_test
+    flush_ts;
   Alcotest.(check int)
     "full inbox length unchanged"
     flusher_inbox_capacity_for_test

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -111,6 +111,19 @@ let test_sweeper_skips_permanent () =
   let (removed_posts, _) = sweep store in
   Alcotest.(check int) "sweeper removed 0 permanent posts" 0 removed_posts
 
+let test_maybe_sweep_updates_schedule_once () =
+  let store = create_store () in
+  store.last_sweep <- 0.0;
+  store.last_flush <- 0.0;
+  Masc.Board_core_persist.maybe_sweep store;
+  let first_sweep = store.last_sweep in
+  let first_flush = store.last_flush in
+  Alcotest.(check bool) "sweep timestamp updated" true (first_sweep > 0.0);
+  Alcotest.(check bool) "flush timestamp updated" true (first_flush > 0.0);
+  Masc.Board_core_persist.maybe_sweep store;
+  Alcotest.(check (float 0.0)) "sweep timestamp unchanged" first_sweep store.last_sweep;
+  Alcotest.(check (float 0.0)) "flush timestamp unchanged" first_flush store.last_flush
+
 let test_post_kind_direct_default () =
   let store = create_store () in
   match
@@ -218,6 +231,8 @@ let () =
             (with_eio test_expiring_post);
           Alcotest.test_case "sweeper skips permanent" `Quick
             (with_eio test_sweeper_skips_permanent);
+          Alcotest.test_case "maybe_sweep schedules once" `Quick
+            (with_eio test_maybe_sweep_updates_schedule_once);
         ] );
       ( "visibility_ssot",
         [

--- a/test/test_board_ttl.ml
+++ b/test/test_board_ttl.ml
@@ -115,12 +115,12 @@ let test_maybe_sweep_updates_schedule_once () =
   let store = create_store () in
   store.last_sweep <- 0.0;
   store.last_flush <- 0.0;
-  Masc.Board_core_persist.maybe_sweep store;
+  Masc_board_handlers.Board_core_persist.maybe_sweep store;
   let first_sweep = store.last_sweep in
   let first_flush = store.last_flush in
   Alcotest.(check bool) "sweep timestamp updated" true (first_sweep > 0.0);
   Alcotest.(check bool) "flush timestamp updated" true (first_flush > 0.0);
-  Masc.Board_core_persist.maybe_sweep store;
+  Masc_board_handlers.Board_core_persist.maybe_sweep store;
   Alcotest.(check (float 0.0)) "sweep timestamp unchanged" first_sweep store.last_sweep;
   Alcotest.(check (float 0.0)) "flush timestamp unchanged" first_flush store.last_flush
 


### PR DESCRIPTION
## Scope note
This PR is not a cross-keeper consensus-threshold change. It is a narrow board
persistence scheduling fix for `Board_core_persist.maybe_sweep`, matching the
current title `fix(board): guard sweep scheduling state`.

## Summary
- addresses logic-gap audit quick-win #6 / finding #16 for `lib/board/board_core_persist.ml`
- moves `maybe_sweep` scheduling decisions and `last_sweep` / `last_flush` timestamp updates under `store.mutex`
- keeps `Eio.Stream.add` outside the store mutex so a full flusher inbox cannot hold the board state lock
- adds a regression that stale scheduling timestamps update once and are not immediately rescheduled on a second call

## Verification
- `ocamlformat --check lib/board/board_core_persist.ml test/test_board_ttl.ml`
- `ocamlc -stop-after parsing lib/board/board_core_persist.ml test/test_board_ttl.ml`
- `git diff --check`
- `rg -n "Stdlib\\.Lazy\\.(force|from_val)|Fun\\.protect|Mutex\\.(lock|unlock)|failwith|assert false|Eio\\.traceln|Sys\\.(readdir|command)" lib/board/board_core_persist.ml test/test_board_ttl.ml`

No Dune/local build was run; CI remains the build authority.
