### PR TITLE
fix(dashboard): stat asset root candidates once

### DIFF
--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -10,7 +10,8 @@
 
 let assets_root () =
   let is_dir path =
-    Sys.file_exists path && Sys.is_directory path
+    try (Unix.stat path).Unix.st_kind = Unix.S_DIR with
+    | Unix.Unix_error _ -> false
   in
   let exe_dir = Filename.dirname Sys.executable_name in
   let inferred_repo_assets =


### PR DESCRIPTION
## Summary
- replace the assets_root Sys.file_exists + Sys.is_directory pair with a single Unix.stat check
- keep the existing candidate order and fallback behavior unchanged

## Verification
- ocamlformat --check lib/web_dashboard.ml
- git diff --check

## Not run locally
- scripts/dune-local.sh build test/test_web_dashboard_coverage.exe: blocked by an existing bare Dune process outside scripts/dune-local.sh; leaving build authority to CI per repo workflow.