### PR TITLE
fix(streamable): parse JSON content type via negotiation

### DIFF
--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -149,6 +149,15 @@ module Http_negotiation = struct
             (type_ = "application" && subtype = "json")
             || (type_ = "*" && subtype = "*"))
 
+  let is_json_content_type = function
+    | None -> false
+    | Some h ->
+        (match Mcp_protocol.Http_negotiation.parse_accept_header h with
+         | [ mt ] ->
+             String.equal (String.lowercase_ascii mt.type_) "application"
+             && String.equal (String.lowercase_ascii mt.subtype) "json"
+         | [] | _ :: _ :: _ -> false)
+
   let accepts_streamable_mcp = function
     | None -> false
     | Some h ->

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.mli
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.mli
@@ -99,6 +99,11 @@ module Http_negotiation : sig
   val accepts_json : string option -> bool
   (** [true] iff the header advertises [application/json] or [*\/*]. *)
 
+  val is_json_content_type : string option -> bool
+  (** [true] iff the Content-Type value is exactly [application/json],
+      allowing media-type parameters such as [charset]. Wildcards and
+      comma-separated Accept-style lists are rejected. *)
+
   val accepts_streamable_mcp : string option -> bool
   (** [true] iff the header advertises both JSON and SSE
       (the Streamable HTTP transport requirement). *)

--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -198,10 +198,8 @@ let is_streamable_request (request : Httpun.Request.t) =
   let headers = request.headers in
   let has_mcp_header = Httpun.Headers.get headers "mcp-session-id" <> None in
   let content_type = Httpun.Headers.get headers "content-type" in
-  let is_json = match content_type with
-    | Some ct -> String.lowercase_ascii ct |> fun s ->
-        String.sub s 0 (min 16 (String.length s)) = "application/json"
-    | None -> false
+  let is_json =
+    Mcp_transport_protocol.Http_negotiation.is_json_content_type content_type
   in
   has_mcp_header || is_json
 

--- a/test/test_mcp_protocol_coverage.ml
+++ b/test/test_mcp_protocol_coverage.ml
@@ -104,6 +104,39 @@ let test_accepts_json_case_insensitive () =
     (Http_negotiation.accepts_json (Some "Application/Json"))
 
 (* ============================================================
+   is_json_content_type Tests
+   ============================================================ *)
+
+let test_json_content_type_none () =
+  check bool "None" false (Http_negotiation.is_json_content_type None)
+
+let test_json_content_type_exact () =
+  check bool "exact" true
+    (Http_negotiation.is_json_content_type (Some "application/json"))
+
+let test_json_content_type_with_params () =
+  check bool "params" true
+    (Http_negotiation.is_json_content_type
+       (Some "application/json; charset=utf-8"))
+
+let test_json_content_type_case_insensitive () =
+  check bool "mixed-case" true
+    (Http_negotiation.is_json_content_type (Some "Application/Json"))
+
+let test_json_content_type_rejects_jsonp () =
+  check bool "jsonp" false
+    (Http_negotiation.is_json_content_type (Some "application/jsonp"))
+
+let test_json_content_type_rejects_wildcard () =
+  check bool "wildcard" false
+    (Http_negotiation.is_json_content_type (Some "*/*"))
+
+let test_json_content_type_rejects_accept_list () =
+  check bool "list" false
+    (Http_negotiation.is_json_content_type
+       (Some "application/json, text/event-stream"))
+
+(* ============================================================
    accepts_sse_header Tests
    ============================================================ *)
 
@@ -239,6 +272,16 @@ let () =
       test_case "wildcard */*" `Quick test_accepts_json_wildcard;
       test_case "in list" `Quick test_accepts_json_in_list;
       test_case "case-insensitive" `Quick test_accepts_json_case_insensitive;
+    ];
+    "is_json_content_type", [
+      test_case "none" `Quick test_json_content_type_none;
+      test_case "exact" `Quick test_json_content_type_exact;
+      test_case "with params" `Quick test_json_content_type_with_params;
+      test_case "case-insensitive" `Quick test_json_content_type_case_insensitive;
+      test_case "rejects jsonp" `Quick test_json_content_type_rejects_jsonp;
+      test_case "rejects wildcard" `Quick test_json_content_type_rejects_wildcard;
+      test_case "rejects accept list" `Quick
+        test_json_content_type_rejects_accept_list;
     ];
     "accepts_sse_header", [
       test_case "none" `Quick test_accepts_sse_none;

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -215,6 +215,45 @@ let test_with_session_header () =
   Alcotest.(check string) "header key" "mcp-session-id" key;
   Alcotest.(check string) "header value" session.id value
 
+let request_with_headers headers =
+  Httpun.Request.create
+    ~headers:(Httpun.Headers.of_list headers)
+    `POST
+    "/mcp"
+
+let check_streamable_request label expected headers =
+  Alcotest.(check bool)
+    label
+    expected
+    (SH.is_streamable_request (request_with_headers headers))
+
+let test_is_streamable_request_json_content_type () =
+  check_streamable_request
+    "json content-type"
+    true
+    [ "content-type", "application/json" ]
+
+let test_is_streamable_request_json_content_type_params () =
+  check_streamable_request
+    "json content-type params"
+    true
+    [ "content-type", "application/json; charset=utf-8" ]
+
+let test_is_streamable_request_rejects_jsonp_content_type () =
+  check_streamable_request
+    "jsonp content-type"
+    false
+    [ "content-type", "application/jsonp" ]
+
+let test_is_streamable_request_rejects_wildcard_content_type () =
+  check_streamable_request "wildcard content-type" false [ "content-type", "*/*" ]
+
+let test_is_streamable_request_accepts_session_header () =
+  check_streamable_request
+    "session header"
+    true
+    [ "mcp-session-id", "session-1"; "content-type", "text/plain" ]
+
 let () =
   (* Initialize RNG for session ID generation *)
   Mirage_crypto_rng_unix.use_default ();
@@ -249,5 +288,17 @@ let () =
     ];
     "Headers", [
       Alcotest.test_case "with_session_header" `Quick test_with_session_header;
+    ];
+    "Request classification", [
+      Alcotest.test_case "json content-type" `Quick
+        test_is_streamable_request_json_content_type;
+      Alcotest.test_case "json content-type params" `Quick
+        test_is_streamable_request_json_content_type_params;
+      Alcotest.test_case "reject jsonp content-type" `Quick
+        test_is_streamable_request_rejects_jsonp_content_type;
+      Alcotest.test_case "reject wildcard content-type" `Quick
+        test_is_streamable_request_rejects_wildcard_content_type;
+      Alcotest.test_case "session header" `Quick
+        test_is_streamable_request_accepts_session_header;
     ];
   ]


### PR DESCRIPTION
Summary
- add Http_negotiation.is_json_content_type as the SSOT for Content-Type JSON media checks
- replace streamable_http's String.sub prefix heuristic with the negotiation helper
- keep application/json; charset=utf-8 accepted, while rejecting application/jsonp, wildcards, and Accept-style lists for Content-Type

Note
- The review note said charset parameters were rejected; current code actually accepted charset but also over-accepted application/json* prefixes. This PR fixes the real current-code failure mode without adding a new parser.

Validation
- ocamlformat --check lib/mcp_transport_protocol/mcp_transport_protocol.ml lib/mcp_transport_protocol/mcp_transport_protocol.mli lib/streamable_http.ml test/test_mcp_protocol_coverage.ml test/test_streamable_http.ml
- git diff --check origin/main...HEAD
- scripts/dune-local.sh build test/test_mcp_protocol_coverage.exe test/test_streamable_http.exe  # stopped after shared MASC dune-local lock wait; CI is the build authority