### PR TITLE
fix(http): delegate legacy zstd compression to codec

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -63,16 +63,12 @@ module Compression = struct
 
   (** Legacy: Standard zstd without dictionary *)
   let compress_zstd ?(level = 3) (data : string) : (string * bool) =
-    if String.length data < 256 then
-      (data, false)
+    if String.length data < 256
+    then data, false
     else
-      try
-        let compressed = Zstd.compress ~level data in
-        if String.length compressed < String.length data then
-          (compressed, true)
-        else
-          (data, false)
-      with Zstd.Error _ -> (data, false)
+      match Compression_codec.compress ~level data with
+      | Compression_codec.Unchanged payload -> payload, false
+      | Compression_codec.Compressed { payload; encoding = _ } -> payload, true
 end
 
 (** Late-response failure classifier (#13059).

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -74,7 +74,9 @@ module Compression : sig
 
   (** [compress_zstd ?level data] is the legacy
       no-dictionary path.  Returns [(payload, did_compress)] —
-      data shorter than 256 bytes is kept as-is. *)
+      data shorter than 256 bytes is kept as-is.  Raw zstd
+      compression is delegated to {!Compression_codec}, which owns
+      compression failure diagnostics. *)
   val compress_zstd : ?level:int -> string -> string * bool
 end
 


### PR DESCRIPTION
Summary
- route Http_server_eio.Compression.compress_zstd through the shared Compression_codec instead of calling Zstd.compress directly
- preserve the legacy 256-byte no-compress threshold and boolean return shape
- remove the silent Zstd.Error catch from the HTTP layer; Compression_codec owns compression failure diagnostics

Validation
- ocamlformat --check lib/http_server_eio.ml lib/http_server_eio.mli
- git diff --check origin/main...HEAD
- rg -n 'Zstd\.compress|with Zstd\.Error|Compression_codec\.compress' lib/http_server_eio.ml
- scripts/dune-local.sh build test/test_http_server_eio_coverage.exe  # stopped after shared MASC dune-local lock wait; CI is the build authority