### PR TITLE
fix(dashboard): wire prompt settings to registry

### DIFF
--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -15,7 +15,7 @@ import { DashboardMain } from './dashboard-shell'
 import { route } from '../router'
 import { connected } from '../sse'
 
-const MOCK_RUNTIME_PATH = '/tmp/.masc/config/runtime.toml'
+const MOCK_RUNTIME_PATH = 'fixture/config/runtime.toml'
 import { dashboardLoading } from '../store'
 import { namespaceTruthInitializing } from '../namespace-truth-store'
 import { resetDevTokenBootstrap } from '../api/dev-token'
@@ -39,7 +39,7 @@ const promptApiMock = vi.hoisted(() => ({
         effective: 'Hello {{keeper}} in {{namespace}}',
         file_value: 'Hello {{keeper}} in {{namespace}}',
         override_value: null,
-        file_path: '/tmp/.masc/config/prompts/keeper.world.md',
+        file_path: 'fixture/config/prompts/keeper.world.md',
         file_exists: true,
         source: 'file' as const,
         has_override: false,

--- a/dashboard/src/components/settings-surface.test.ts
+++ b/dashboard/src/components/settings-surface.test.ts
@@ -26,6 +26,32 @@ const apiMock = vi.hoisted(() => ({
   fetchRuntimeDefaults: vi.fn(),
 }))
 
+const promptApiMock = vi.hoisted(() => ({
+  clearPromptOverride: vi.fn(async () => ({ ok: true, message: 'override cleared' })),
+  fetchDashboardPrompts: vi.fn(async () => ({
+    prompts: [
+      {
+        key: 'keeper.world',
+        category: 'keeper',
+        description: 'Shared world prompt',
+        current: 'Hello {{keeper}} in {{namespace}}',
+        default: 'Hello {{keeper}} in {{namespace}}',
+        effective: 'Hello {{keeper}} in {{namespace}}',
+        file_value: 'Hello {{keeper}} in {{namespace}}',
+        override_value: null,
+        file_path: '/tmp/.masc/config/prompts/keeper.world.md',
+        file_exists: true,
+        source: 'file' as const,
+        has_override: false,
+        char_count: 35,
+        required_file: true,
+        template_variables: ['keeper', 'namespace'],
+      },
+    ],
+  })),
+  savePromptOverride: vi.fn(async () => ({ ok: true, message: 'override set' })),
+}))
+
 vi.mock('../api/dashboard.js', async () => {
   const actual = await vi.importActual<typeof import('../api/dashboard')>('../api/dashboard')
   return {
@@ -33,6 +59,16 @@ vi.mock('../api/dashboard.js', async () => {
     fetchLogs: apiMock.fetchLogs,
     fetchDashboardTools: apiMock.fetchDashboardTools,
     fetchRuntimeDefaults: apiMock.fetchRuntimeDefaults,
+  }
+})
+
+vi.mock('../api', async () => {
+  const actual = await vi.importActual<typeof import('../api')>('../api')
+  return {
+    ...actual,
+    clearPromptOverride: promptApiMock.clearPromptOverride,
+    fetchDashboardPrompts: promptApiMock.fetchDashboardPrompts,
+    savePromptOverride: promptApiMock.savePromptOverride,
   }
 })
 
@@ -127,6 +163,9 @@ describe('SettingsSurface', () => {
     apiMock.fetchLogs.mockReset()
     apiMock.fetchDashboardTools.mockReset()
     apiMock.fetchRuntimeDefaults.mockReset()
+    promptApiMock.clearPromptOverride.mockClear()
+    promptApiMock.fetchDashboardPrompts.mockClear()
+    promptApiMock.savePromptOverride.mockClear()
     stubEmptyApi()
     window.location.hash = '#settings'
     route.value = { tab: 'settings', params: {}, postId: null }
@@ -330,6 +369,26 @@ describe('SettingsSurface', () => {
       expect(container.querySelector('[data-testid="routing-assignments-empty"]')).not.toBeNull()
     })
     expect(container.querySelectorAll('[data-testid="routing-assignment"]').length).toBe(0)
+  })
+
+  it('renders prompt settings from the live prompt registry instead of prototype placeholders', async () => {
+    render(html`<${SettingsSurface} />`, container)
+
+    const promptsNav = container.querySelector('[data-testid="settings-nav-prompts"]') as HTMLElement
+    await fireEvent.click(promptsNav)
+
+    await waitFor(() => {
+      expect(promptApiMock.fetchDashboardPrompts).toHaveBeenCalledTimes(1)
+      expect(container.querySelector('[data-testid="settings-section-state"]')?.textContent).toContain('prompt registry live-backed')
+    })
+
+    expect(container.querySelector('.set-card-b')?.getAttribute('data-preview-locked')).toBe('false')
+    expect(container.querySelector('[data-testid="prompt-registry-panel"]')).not.toBeNull()
+    expect(container.querySelector('[data-prompt-preset-switcher]')).not.toBeNull()
+    expect(container.querySelector('[data-prompt-destinations]')?.textContent).toContain('System rules')
+    expect(container.textContent).toContain('{{keeper}}')
+    expect(container.textContent).not.toContain('System (base) — what a keeper is')
+    expect(container.textContent).not.toContain('World prompt — shared world·rules')
   })
 
   it('log filter chips filter live rows from the ring', async () => {

--- a/dashboard/src/components/settings-surface.ts
+++ b/dashboard/src/components/settings-surface.ts
@@ -15,6 +15,7 @@ import type { DashboardToolInventoryItem, LogEntry, RuntimeDefaultsResponse } fr
 import { envBool } from '../config/env'
 import { RuntimeTomlEditor } from './runtime-toml-editor'
 import { FusionSettingsPanel } from './fusion-settings-panel'
+import { PromptRegistryPanel } from './tools/prompt-registry-panel'
 import { ThemeSwitch } from './theme-switch'
 import type { ComponentChildren } from 'preact'
 
@@ -311,6 +312,18 @@ function RolePill({ children }: { children: ComponentChildren }) {
   return html`<span class="set-rolepill">${children}</span>`
 }
 
+function settingsSectionState(
+  section: SectionId,
+  fusionSettingsWritable: boolean,
+): { live: boolean; label: string } {
+  if (section === 'runtimes') return { live: true, label: 'runtime.toml live-backed' }
+  if (section === 'prompts') return { live: true, label: 'prompt registry live-backed' }
+  if (section === 'fusion' && fusionSettingsWritable) {
+    return { live: true, label: 'runtime.toml live-backed' }
+  }
+  return { live: false, label: 'preview only' }
+}
+
 function LogFilter({
   filter,
   active,
@@ -552,10 +565,6 @@ export function SettingsSurface() {
   const [searchIndex, setSearchIndex] = useState(true)
   const [ideRepo, setIdeRepo] = useState('masc/masc-mcp')
 
-  // prompts
-  const [sysPrompt, setSysPrompt] = useState('')
-  const [worldPrompt, setWorldPrompt] = useState('')
-
   // logs
   const [traceKeep, setTraceKeep] = useState('30일')
   const [logLevel, setLogLevel] = useState('info')
@@ -578,7 +587,7 @@ export function SettingsSurface() {
   const [clock24, setClock24] = useState(true)
 
   const cur = SET_SECTIONS.find(s => s[0] === sec) ?? SET_SECTIONS[0]!
-  const isLiveBackedSection = sec === 'runtimes' || (sec === 'fusion' && fusionSettingsWritable)
+  const sectionState = settingsSectionState(sec, fusionSettingsWritable)
 
   // Resolved runtime options (de-duplicated, derived from the live registry).
   const runtimeEntries = runtimeDefaults?.runtimes ?? []
@@ -628,16 +637,16 @@ export function SettingsSurface() {
           <header class="set-content-h">
             <h1 data-testid="settings-section-title">${cur[2]}</h1>
             <span
-              class=${`set-section-state ${isLiveBackedSection ? 'live' : 'preview'}`}
+              class=${`set-section-state ${sectionState.live ? 'live' : 'preview'}`}
               data-testid="settings-section-state"
             >
-              ${isLiveBackedSection ? 'runtime.toml live-backed' : 'preview only'}
+              ${sectionState.label}
             </span>
           </header>
 
           <div
-            class=${`set-card-b mx-6 my-6 ${sec === 'runtimes' ? 'set-card-b-wide' : 'ss-card'}`}
-            data-preview-locked=${isLiveBackedSection ? 'false' : 'true'}
+            class=${`set-card-b mx-6 my-6 ${sec === 'runtimes' || sec === 'prompts' ? 'set-card-b-wide' : 'ss-card'}`}
+            data-preview-locked=${sectionState.live ? 'false' : 'true'}
           >
             ${sec === 'account' && html`
               <${SetRow} label="Operator" hint="Currently logged-in operator">
@@ -749,29 +758,7 @@ export function SettingsSurface() {
             `}
 
             ${sec === 'prompts' && html`
-              <div class="set-hint" style=${{ marginBottom: '12px' }}>
-                Shared prompt base inherited by every keeper. Keeper-specific persona·instructions layer on top.
-                <span class="mono">{'{{keeper}}'} · {'{{namespace}}'} · {'{{runtime}}'} · {'{{model}}'}</span> are substituted per keeper.
-              </div>
-              <div class="set-sub-h">① System (base) — what a keeper is</div>
-              <textarea
-                class="set-input mono"
-                readOnly
-                style=${{ width: '100%', minHeight: '150px', resize: 'vertical', lineHeight: '1.6', padding: '10px 12px', whiteSpace: 'pre' }}
-                value=${sysPrompt}
-                onInput=${(e: Event) => setSysPrompt((e.target as HTMLTextAreaElement).value)}
-              />
-              <div class="set-sub-h" style=${{ marginTop: '14px' }}>② World prompt — shared world·rules</div>
-              <textarea
-                class="set-input mono"
-                readOnly
-                style=${{ width: '100%', minHeight: '150px', resize: 'vertical', lineHeight: '1.6', padding: '10px 12px', whiteSpace: 'pre' }}
-                value=${worldPrompt}
-                onInput=${(e: Event) => setWorldPrompt((e.target as HTMLTextAreaElement).value)}
-              />
-              <div class="set-mcp-detail mono" style=${{ marginTop: '12px' }}>
-                Effective prompt = ① System + ② World + ③ persona + ④ instructions · inspect composition in the turn inspector.
-              </div>
+              <${PromptRegistryPanel} embedded=${true} />
             `}
 
             ${sec === 'fusion' && html`

--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -6,50 +6,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 void vi
 
 const mocks = vi.hoisted(() => ({
-  fetchDashboardPrompts: vi.fn(async () => ({
-    prompts: [
-      {
-        key: 'keeper.world',
-        category: 'keeper',
-        description: 'world block',
-        current: 'override world',
-        default: 'file world',
-        effective: 'override world',
-        file_value: 'file world',
-        override_value: 'override world',
-        file_path: 'fixture/config/prompts/keeper.world.md',
-        file_exists: true,
-        source: 'override' as const,
-        has_override: true,
-        char_count: 14,
-        required_file: true,
-        template_variables: ['keeper'],
-      },
-      {
-        key: 'governance.dry_run',
-        category: 'governance',
-        description: 'dry run block',
-        current: 'dry run prompt',
-        default: 'dry run prompt',
-        effective: 'dry run prompt',
-        file_value: 'dry run prompt',
-        override_value: null,
-        file_path: 'fixture/config/prompts/governance.dry_run.md',
-        file_exists: true,
-        source: 'file' as const,
-        has_override: false,
-        char_count: 14,
-        required_file: true,
-        template_variables: [],
-      },
-    ],
-  })),
+  clearPromptOverride: vi.fn(async () => ({ ok: true, message: 'override cleared' })),
+  fetchDashboardPrompts: vi.fn(),
+  savePromptOverride: vi.fn(async () => ({ ok: true, message: 'override set' })),
 }))
 
 vi.mock('../../api', () => ({
-  clearPromptOverride: vi.fn(async () => ({ ok: true, message: 'override cleared' })),
+  clearPromptOverride: mocks.clearPromptOverride,
   fetchDashboardPrompts: mocks.fetchDashboardPrompts,
-  savePromptOverride: vi.fn(async () => ({ ok: true, message: 'override set' })),
+  savePromptOverride: mocks.savePromptOverride,
 }))
 
 import type { DashboardPromptItem } from '../../api'
@@ -89,6 +54,41 @@ const HELPER_FIXTURES: DashboardPromptItem[] = [
   }),
 ]
 
+function defaultPromptItems(): DashboardPromptItem[] {
+  return [
+    makePrompt({
+      key: 'keeper.world',
+      category: 'keeper',
+      description: 'world block',
+      current: 'override world',
+      default: 'file world',
+      effective: 'override world',
+      file_value: 'file world',
+      override_value: 'override world',
+      file_path: 'fixture/config/prompts/keeper.world.md',
+      source: 'override',
+      has_override: true,
+      char_count: 14,
+      template_variables: ['keeper'],
+    }),
+    makePrompt({
+      key: 'governance.dry_run',
+      category: 'governance',
+      description: 'dry run block',
+      current: 'dry run prompt',
+      default: 'dry run prompt',
+      effective: 'dry run prompt',
+      file_value: 'dry run prompt',
+      override_value: null,
+      file_path: 'fixture/config/prompts/governance.dry_run.md',
+      source: 'file',
+      has_override: false,
+      char_count: 14,
+      template_variables: [],
+    }),
+  ]
+}
+
 describe('promptSourceCounts', () => {
   it('counts each source and total', () => {
     expect(promptSourceCounts(HELPER_FIXTURES)).toEqual({
@@ -121,7 +121,10 @@ describe('PromptRegistryPanel', () => {
   beforeEach(() => {
     container = document.createElement('div')
     document.body.appendChild(container)
-    mocks.fetchDashboardPrompts.mockClear()
+    mocks.clearPromptOverride.mockClear()
+    mocks.fetchDashboardPrompts.mockReset()
+    mocks.fetchDashboardPrompts.mockResolvedValue({ prompts: defaultPromptItems() })
+    mocks.savePromptOverride.mockClear()
   })
 
   afterEach(() => {
@@ -200,5 +203,37 @@ describe('PromptRegistryPanel', () => {
       window.confirm = originalConfirm
       await fireEvent.input(searchInput(), { target: { value: '' } })
     }
+  })
+
+  it('rebinds the draft when reload removes the selected prompt before saving', async () => {
+    const remainingPrompt = defaultPromptItems()[1]
+    mocks.fetchDashboardPrompts
+      .mockResolvedValueOnce({ prompts: defaultPromptItems() })
+      .mockResolvedValueOnce({ prompts: [remainingPrompt] })
+
+    render(html`<${PromptRegistryPanel} />`, container)
+    await flush()
+    await flush()
+
+    const textarea = () => container.querySelector('textarea') as HTMLTextAreaElement
+    await fireEvent.input(textarea(), { target: { value: 'stale keeper draft' } })
+
+    const refreshButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('새로고침'),
+    ) as HTMLButtonElement
+    await fireEvent.click(refreshButton)
+
+    await waitFor(() => {
+      expect(textarea().value).toBe('dry run prompt')
+    })
+
+    const applyButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('오버라이드 적용'),
+    ) as HTMLButtonElement
+    await fireEvent.click(applyButton)
+
+    await waitFor(() => {
+      expect(mocks.savePromptOverride).toHaveBeenCalledWith('governance.dry_run', 'dry run prompt')
+    })
   })
 })

--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -1,6 +1,6 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
-import { waitFor } from '@testing-library/preact'
+import { fireEvent, waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 void vi
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
         effective: 'override world',
         file_value: 'file world',
         override_value: 'override world',
-        file_path: '/tmp/config/prompts/keeper.world.md',
+        file_path: 'fixture/config/prompts/keeper.world.md',
         file_exists: true,
         source: 'override' as const,
         has_override: true,
@@ -34,7 +34,7 @@ const mocks = vi.hoisted(() => ({
         effective: 'dry run prompt',
         file_value: 'dry run prompt',
         override_value: null,
-        file_path: '/tmp/config/prompts/governance.dry_run.md',
+        file_path: 'fixture/config/prompts/governance.dry_run.md',
         file_exists: true,
         source: 'file' as const,
         has_override: false,
@@ -139,7 +139,7 @@ describe('PromptRegistryPanel', () => {
     expect(container.querySelector('.v2-lab-row')).not.toBeNull()
     expect(container.textContent).toContain('프롬프트 레지스트리')
     expect(container.textContent).toContain('keeper.world')
-    expect(container.textContent).toContain('/tmp/config/prompts/keeper.world.md')
+    expect(container.textContent).toContain('fixture/config/prompts/keeper.world.md')
     expect(container.querySelector('[data-prompt-preset-switcher]')).not.toBeNull()
     expect(container.querySelector('[data-prompt-destinations]')?.textContent).toContain('System rules')
     expect(container.querySelector('[data-prompt-destinations]')?.textContent).toContain('system')
@@ -160,5 +160,45 @@ describe('PromptRegistryPanel', () => {
     await flush()
 
     expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe('dry run prompt')
+  })
+
+  it('keeps dirty draft text across filters and confirms before discarding on row selection', async () => {
+    render(html`<${PromptRegistryPanel} />`, container)
+    await flush()
+    await flush()
+
+    const textarea = () => container.querySelector('textarea') as HTMLTextAreaElement
+    const searchInput = () =>
+      container.querySelector('input[aria-label="프롬프트 검색"]') as HTMLInputElement
+    const governanceButton = () =>
+      Array.from(container.querySelectorAll('button')).find(button =>
+        button.textContent?.includes('governance.dry_run'),
+      ) as HTMLButtonElement | undefined
+
+    await fireEvent.input(textarea(), { target: { value: 'edited unsaved draft' } })
+    await fireEvent.input(searchInput(), { target: { value: 'governance' } })
+    await flush()
+
+    expect(textarea().value).toBe('edited unsaved draft')
+
+    const originalConfirm = window.confirm
+    const confirmSpy = vi.fn(() => false)
+    window.confirm = confirmSpy
+    try {
+      await fireEvent.click(governanceButton()!)
+      await flush()
+
+      expect(confirmSpy).toHaveBeenCalledTimes(1)
+      expect(textarea().value).toBe('edited unsaved draft')
+
+      confirmSpy.mockReturnValue(true)
+      await fireEvent.click(governanceButton()!)
+      await flush()
+
+      expect(textarea().value).toBe('dry run prompt')
+    } finally {
+      window.confirm = originalConfirm
+      await fireEvent.input(searchInput(), { target: { value: '' } })
+    }
   })
 })

--- a/dashboard/src/components/tools/prompt-registry-panel.test.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.test.ts
@@ -23,7 +23,7 @@ const mocks = vi.hoisted(() => ({
         has_override: true,
         char_count: 14,
         required_file: true,
-        template_variables: [],
+        template_variables: ['keeper'],
       },
       {
         key: 'governance.dry_run',
@@ -140,10 +140,18 @@ describe('PromptRegistryPanel', () => {
     expect(container.textContent).toContain('프롬프트 레지스트리')
     expect(container.textContent).toContain('keeper.world')
     expect(container.textContent).toContain('/tmp/config/prompts/keeper.world.md')
+    expect(container.querySelector('[data-prompt-preset-switcher]')).not.toBeNull()
+    expect(container.querySelector('[data-prompt-destinations]')?.textContent).toContain('System rules')
+    expect(container.querySelector('[data-prompt-destinations]')?.textContent).toContain('system')
+    expect(container.textContent).toContain('{{keeper}}')
     await waitFor(() => {
       expect(container.textContent).toContain('file world')
     })
     expect((container.querySelector('textarea') as HTMLTextAreaElement).value).toBe('override world')
+
+    const allPreset = container.querySelector('[data-prompt-preset-switcher] button') as HTMLButtonElement
+    allPreset?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
 
     const governanceButton = Array.from(container.querySelectorAll('button')).find(button =>
       button.textContent?.includes('governance.dry_run'),

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { Markdown } from "../common/markdown"
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useMemo, useState } from 'preact/hooks'
 import {
   clearPromptOverride,
   fetchDashboardPrompts,
@@ -37,7 +37,7 @@ export interface PromptPreset {
 export interface PromptDestination {
   stageTitle: string
   messageSlot: string
-  role: string
+  role: KeeperPromptAssemblyStage['role']
   summary: string
 }
 
@@ -65,6 +65,9 @@ function sourceBadgeClass(source: PromptSource): string {
 }
 
 const STAGE_PRESET_PREFIX = 'stage:'
+const COMPUTED_PROMPT_SOURCE: KeeperPromptAssemblyRow['source'] = 'computed'
+const NOT_SENT_MESSAGE_SLOT = 'not sent'
+const MODEL_INPUT_STAGE_ROLE: KeeperPromptAssemblyStage['role'] = 'model_input'
 
 function stagePresetId(preset: PromptPresetId): string | null {
   if (preset === 'all' || preset === 'attention') return null
@@ -72,7 +75,7 @@ function stagePresetId(preset: PromptPresetId): string | null {
 }
 
 function promptAssemblyRows(stage: KeeperPromptAssemblyStage): KeeperPromptAssemblyRow[] {
-  return stage.rows.filter(row => row.source !== 'computed')
+  return stage.rows.filter(row => row.source !== COMPUTED_PROMPT_SOURCE)
 }
 
 function promptPresetRows(report: KeeperPromptAssemblyReport, preset: PromptPresetId): Set<string> | null {
@@ -84,8 +87,12 @@ function promptPresetRows(report: KeeperPromptAssemblyReport, preset: PromptPres
 }
 
 function stagePresetLabel(stage: KeeperPromptAssemblyStage): string {
-  if (stage.messageSlot === 'not sent') return stage.title
+  if (stage.messageSlot === NOT_SENT_MESSAGE_SLOT) return stage.title
   return `${stage.messageSlot}: ${stage.title}`
+}
+
+function isModelInputDestination(destination: PromptDestination): boolean {
+  return destination.role === MODEL_INPUT_STAGE_ROLE
 }
 
 function presetPromptCount(
@@ -110,11 +117,12 @@ export function promptPresetOptions(
     .filter(stage => promptAssemblyRows(stage).length > 0)
     .map(stage => {
       const id: PromptPresetId = `${STAGE_PRESET_PREFIX}${stage.id}`
+      const stagePromptKeys = new Set(promptAssemblyRows(stage).map(row => row.promptKey))
       return {
         id,
         label: stagePresetLabel(stage),
         description: stage.summary,
-        count: presetPromptCount(prompts, report, id),
+        count: prompts.filter(prompt => stagePromptKeys.has(prompt.key)).length,
       }
     })
 
@@ -122,14 +130,14 @@ export function promptPresetOptions(
     {
       id: 'all',
       label: '전체',
-      description: 'All registered prompt files and overrides.',
+      description: '등록된 모든 프롬프트 파일과 오버라이드.',
       count: prompts.length,
     },
     ...stagePresets,
     {
       id: 'attention',
       label: '수정/누락',
-      description: 'Saved overrides and missing required prompt files.',
+      description: '저장된 오버라이드와 누락된 필수 프롬프트 파일.',
       count: presetPromptCount(prompts, report, 'attention'),
     },
   ]
@@ -154,19 +162,23 @@ function normalizeDraft(prompt: DashboardPromptItem | null): string {
   return prompt.override_value ?? prompt.effective
 }
 
+function draftKeyForPrompt(prompt: DashboardPromptItem | null): string | null {
+  return prompt?.key ?? null
+}
+
 // Pure helper: filter by source + substring search (case-insensitive).
 // Exported for unit testing.
 export function filterPrompts(
   prompts: DashboardPromptItem[],
   source: PromptSourceFilter,
   query: string,
-  report?: KeeperPromptAssemblyReport,
+  report: KeeperPromptAssemblyReport,
   preset: PromptPresetId = 'all',
 ): DashboardPromptItem[] {
   const q = query.trim().toLowerCase()
   const allowedPromptKeys =
     preset !== 'all' && preset !== 'attention'
-      ? report ? promptPresetRows(report, preset) : new Set<string>()
+      ? promptPresetRows(report, preset)
       : null
   return prompts.filter(p => {
     if (preset === 'attention' && !p.has_override && p.source !== 'missing') return false
@@ -207,9 +219,10 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
   const [status, setStatus] = useState<string | null>(null)
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [draft, setDraft] = useState('')
+  const [draftPromptKey, setDraftPromptKey] = useState<string | null>(null)
   const [preset, setPreset] = useState<PromptPresetId>('all')
 
-  const report = buildKeeperPromptAssemblyReport(prompts)
+  const report = useMemo(() => buildKeeperPromptAssemblyReport(prompts), [prompts])
   const presets = promptPresetOptions(prompts, report)
   const activePreset = presets.some(item => item.id === preset) ? preset : 'all'
   const visiblePrompts = filterPrompts(prompts, sourceFilter.value, searchQuery.value, report, activePreset)
@@ -217,7 +230,16 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
     (selectedKey ? prompts.find(prompt => prompt.key === selectedKey) : null) ?? visiblePrompts[0] ?? null
   const selectedDestinations = selectedPrompt ? promptDestinationsForKey(report, selectedPrompt.key) : []
   const counts = promptSourceCounts(prompts)
-  const draftDirty = selectedPrompt ? draft !== normalizeDraft(selectedPrompt) : draft.length > 0
+  const draftDirty = selectedPrompt
+    ? draftPromptKey === selectedPrompt.key
+      ? draft !== normalizeDraft(selectedPrompt)
+      : draft.length > 0
+    : draft.length > 0
+
+  function setDraftForPrompt(prompt: DashboardPromptItem | null) {
+    setDraft(normalizeDraft(prompt))
+    setDraftPromptKey(draftKeyForPrompt(prompt))
+  }
 
   async function loadPrompts(preferredKey?: string | null) {
     setLoading(true)
@@ -232,8 +254,9 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
           : nextPrompts[0]?.key ?? null
       setSelectedKey(nextSelectedKey)
       const nextPrompt = nextPrompts.find(prompt => prompt.key === nextSelectedKey) ?? nextPrompts[0] ?? null
-      setDraft(normalizeDraft(nextPrompt))
+      setDraftForPrompt(nextPrompt)
     } catch (err) {
+      setStatus(null)
       setError(errorToString(err))
     } finally {
       setLoading(false)
@@ -245,27 +268,33 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
   }, [])
 
   useEffect(() => {
-    if (!selectedPrompt) setDraft('')
-  }, [selectedPrompt?.key])
+    const nextDraftPromptKey = draftKeyForPrompt(selectedPrompt)
+    if (draftPromptKey === nextDraftPromptKey) return
+    setDraft(normalizeDraft(selectedPrompt))
+    setDraftPromptKey(nextDraftPromptKey)
+  }, [selectedPrompt, draftPromptKey])
 
   function confirmDiscardDraft(nextPrompt: DashboardPromptItem): boolean {
     if (!selectedPrompt || nextPrompt.key === selectedPrompt.key || !draftDirty) return true
-    return (
-      typeof window === 'undefined' ||
-      typeof window.confirm !== 'function' ||
-      window.confirm('저장하지 않은 override 초안을 버리고 다른 프롬프트를 열까요?')
-    )
+    if (typeof window === 'undefined' || typeof window.confirm !== 'function') return false
+    return window.confirm('저장하지 않은 override 초안을 버리고 다른 프롬프트를 열까요?')
   }
 
   function selectPrompt(prompt: DashboardPromptItem) {
     if (!confirmDiscardDraft(prompt)) return
     setSelectedKey(prompt.key)
-    setDraft(normalizeDraft(prompt))
+    setDraftForPrompt(prompt)
     setStatus(null)
   }
 
   async function applyOverride() {
     if (!selectedPrompt) return
+    if (draftPromptKey !== selectedPrompt.key) {
+      setError('선택된 프롬프트가 바뀌어 초안을 다시 동기화했습니다. 내용을 확인한 뒤 다시 저장하세요.')
+      setStatus(null)
+      setDraftForPrompt(selectedPrompt)
+      return
+    }
     setSaving(true)
     setError(null)
     setStatus(null)
@@ -285,6 +314,7 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
 
   async function clearOverride() {
     if (!selectedPrompt) return
+    if (draftPromptKey !== selectedPrompt.key) setDraftForPrompt(selectedPrompt)
     setSaving(true)
     setError(null)
     setStatus(null)
@@ -455,7 +485,7 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
                   ${selectedDestinations.map(destination => html`
                     <div class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-2">
                       <div class="mb-1 flex flex-wrap items-center gap-2">
-                        <${StatusChip} tone=${destination.role === 'model_input' ? 'info' : 'neutral'} uppercase=${false}>${destination.messageSlot}<//>
+                        <${StatusChip} tone=${isModelInputDestination(destination) ? 'info' : 'neutral'} uppercase=${false}>${destination.messageSlot}<//>
                         <span class="text-xs font-semibold text-[var(--color-fg-primary)]">${destination.stageTitle}</span>
                       </div>
                       <div class="text-2xs leading-relaxed text-[var(--color-fg-muted)]">${destination.summary}</div>
@@ -509,7 +539,7 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
                 오버라이드 제거
               <//>
               <${ActionButton} variant="ghost" size="md" disabled=${saving || loading} onClick=${() => {
-                setDraft(normalizeDraft(selectedPrompt))
+                setDraftForPrompt(selectedPrompt)
                 setStatus(null)
               }}>
                 초안 초기화

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -16,9 +16,29 @@ import { TextArea, TextInput } from '../common/input'
 import { FilterChips } from '../common/filter-chips'
 import { StatusChip } from '../common/status-chip'
 import { errorToString } from '../../lib/format-string'
-import { KeeperPromptAssemblyPanel } from '../keeper-prompt-assembly-panel'
+import {
+  buildKeeperPromptAssemblyReport,
+  KeeperPromptAssemblyPanel,
+  type KeeperPromptAssemblyReport,
+  type KeeperPromptAssemblyStage,
+} from '../keeper-prompt-assembly-panel'
 
-type PromptSourceFilter = 'all' | PromptSource
+export type PromptSourceFilter = 'all' | PromptSource
+export type PromptPresetId = 'all' | 'attention' | `stage:${string}`
+
+export interface PromptPreset {
+  id: PromptPresetId
+  label: string
+  description: string
+  count: number
+}
+
+export interface PromptDestination {
+  stageTitle: string
+  messageSlot: string
+  role: string
+  summary: string
+}
 
 const SOURCE_CHIP_ORDER: PromptSourceFilter[] = ['all', 'file', 'override', 'default', 'missing']
 
@@ -43,6 +63,80 @@ function sourceBadgeClass(source: PromptSource): string {
   }
 }
 
+function promptPresetRows(report: KeeperPromptAssemblyReport, preset: PromptPresetId): Set<string> | null {
+  if (preset === 'all' || preset === 'attention') return null
+  const stageId = preset.replace(/^stage:/, '')
+  const stage = report.stages.find(item => item.id === stageId)
+  if (!stage) return new Set()
+  return new Set(stage.rows.map(row => row.promptKey).filter(key => !key.startsWith('(')))
+}
+
+function stagePresetLabel(stage: KeeperPromptAssemblyStage): string {
+  if (stage.messageSlot === 'not sent') return stage.title
+  return `${stage.messageSlot}: ${stage.title}`
+}
+
+function presetPromptCount(
+  prompts: DashboardPromptItem[],
+  report: KeeperPromptAssemblyReport,
+  preset: PromptPresetId,
+): number {
+  if (preset === 'all') return prompts.length
+  if (preset === 'attention') {
+    return prompts.filter(prompt => prompt.has_override || prompt.source === 'missing').length
+  }
+  const allowed = promptPresetRows(report, preset)
+  if (!allowed || allowed.size === 0) return 0
+  return prompts.filter(prompt => allowed.has(prompt.key)).length
+}
+
+export function promptPresetOptions(
+  prompts: DashboardPromptItem[],
+  report: KeeperPromptAssemblyReport,
+): PromptPreset[] {
+  const stagePresets = report.stages
+    .filter(stage => stage.rows.some(row => !row.promptKey.startsWith('(')))
+    .map(stage => {
+      const id: PromptPresetId = `stage:${stage.id}`
+      return {
+        id,
+        label: stagePresetLabel(stage),
+        description: stage.summary,
+        count: presetPromptCount(prompts, report, id),
+      }
+    })
+
+  return [
+    {
+      id: 'all',
+      label: '전체',
+      description: 'All registered prompt files and overrides.',
+      count: prompts.length,
+    },
+    ...stagePresets,
+    {
+      id: 'attention',
+      label: '수정/누락',
+      description: 'Saved overrides and missing required prompt files.',
+      count: presetPromptCount(prompts, report, 'attention'),
+    },
+  ]
+}
+
+export function promptDestinationsForKey(
+  report: KeeperPromptAssemblyReport,
+  key: string,
+): PromptDestination[] {
+  return report.stages
+    .filter(stage => stage.rows.some(row => row.promptKey === key))
+    .map(stage => ({
+      stageTitle: stage.title,
+      messageSlot: stage.messageSlot,
+      role: stage.role,
+      summary: stage.summary,
+    }))
+}
+
 function normalizeDraft(prompt: DashboardPromptItem | null): string {
   if (!prompt) return ''
   return prompt.override_value ?? prompt.effective
@@ -50,13 +144,20 @@ function normalizeDraft(prompt: DashboardPromptItem | null): string {
 
 // Pure helper: filter by source + substring search (case-insensitive).
 // Exported for unit testing.
-function filterPrompts(
+export function filterPrompts(
   prompts: DashboardPromptItem[],
   source: PromptSourceFilter,
   query: string,
+  report?: KeeperPromptAssemblyReport,
+  preset: PromptPresetId = 'all',
 ): DashboardPromptItem[] {
   const q = query.trim().toLowerCase()
   return prompts.filter(p => {
+    if (preset === 'attention' && !p.has_override && p.source !== 'missing') return false
+    if (preset !== 'all' && preset !== 'attention') {
+      const allowed = report ? promptPresetRows(report, preset) : new Set<string>()
+      if (!allowed || !allowed.has(p.key)) return false
+    }
     if (source !== 'all' && p.source !== source) return false
     if (!q) return true
     return (
@@ -85,7 +186,7 @@ export function promptSourceCounts(
 const sourceFilter = signal<PromptSourceFilter>('all')
 const searchQuery = signal('')
 
-export function PromptRegistryPanel() {
+export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean } = {}) {
   const [prompts, setPrompts] = useState<DashboardPromptItem[]>([])
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -93,9 +194,14 @@ export function PromptRegistryPanel() {
   const [status, setStatus] = useState<string | null>(null)
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [draft, setDraft] = useState('')
+  const [preset, setPreset] = useState<PromptPresetId>('stage:base-system')
 
-  const visiblePrompts = filterPrompts(prompts, sourceFilter.value, searchQuery.value)
-  const selectedPrompt = prompts.find(prompt => prompt.key === selectedKey) ?? prompts[0] ?? null
+  const report = buildKeeperPromptAssemblyReport(prompts)
+  const presets = promptPresetOptions(prompts, report)
+  const activePreset = presets.some(item => item.id === preset) ? preset : 'all'
+  const visiblePrompts = filterPrompts(prompts, sourceFilter.value, searchQuery.value, report, activePreset)
+  const selectedPrompt = visiblePrompts.find(prompt => prompt.key === selectedKey) ?? visiblePrompts[0] ?? null
+  const selectedDestinations = selectedPrompt ? promptDestinationsForKey(report, selectedPrompt.key) : []
   const counts = promptSourceCounts(prompts)
 
   async function loadPrompts(preferredKey?: string | null) {
@@ -124,8 +230,7 @@ export function PromptRegistryPanel() {
   }, [])
 
   useEffect(() => {
-    if (!selectedPrompt) return
-    setDraft(current => (current === '' ? normalizeDraft(selectedPrompt) : current))
+    setDraft(normalizeDraft(selectedPrompt))
   }, [selectedPrompt?.key])
 
   async function applyOverride() {
@@ -166,11 +271,59 @@ export function PromptRegistryPanel() {
     }
   }
 
-  return html`
-    <${SectionCard} label="프롬프트 레지스트리" class="section mb-4">
+  const body = html`
       <div class="mb-4 text-xs text-[var(--color-fg-muted)] leading-relaxed">
         <div>기준 원문은 resolved config root의 <code>prompts/*.md</code>입니다. 경로는 설정 경로 상세 패널에서 확인할 수 있습니다.</div>
         <div>이 화면에서는 현재 effective 값 확인과 runtime override 적용/해제만 합니다.</div>
+      </div>
+
+      <div class="mb-4 grid gap-2 md:grid-cols-4" data-prompt-registry-summary>
+        <div class="v2-lab-card rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">registered</div>
+          <div class="mt-1 font-mono text-sm text-[var(--color-fg-primary)]">${prompts.length}</div>
+        </div>
+        <div class="v2-lab-card rounded-[var(--r-1)] border border-[var(--warn-border)] bg-[var(--warn-soft)] px-3 py-2">
+          <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">overrides</div>
+          <div class="mt-1 font-mono text-sm text-[var(--color-fg-primary)]">${report.stats.overrideRows}</div>
+        </div>
+        <div class="v2-lab-card rounded-[var(--r-1)] border border-[var(--err-border)] bg-[var(--bad-soft)] px-3 py-2">
+          <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">missing</div>
+          <div class="mt-1 font-mono text-sm text-[var(--color-fg-primary)]">${report.stats.missingRows}</div>
+        </div>
+        <div class="v2-lab-card min-w-0 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+          <div class="text-3xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-disabled)]">prompt root</div>
+          <div class="mt-1 truncate font-mono text-xs text-[var(--color-fg-primary)]" title=${report.activePromptRoots[0] ?? ''}>
+            ${report.activePromptRoots[0] ?? '—'}
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-4" data-prompt-preset-switcher>
+        <div class="mb-2 flex items-center justify-between gap-2">
+          <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">프리셋</div>
+          <div class="text-2xs text-[var(--color-fg-muted)]">Turn prompt recipe 기준으로 묶어 봅니다.</div>
+        </div>
+        <div class="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+          ${presets.map(item => html`
+            <button
+              type="button"
+              class=${`prompt-preset-card rounded-[var(--r-1)] border px-3 py-2 text-left transition-colors ${activePreset === item.id
+                ? 'border-[var(--accent-30)] bg-[var(--accent-10)]'
+                : 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:border-[var(--accent-22)] hover:bg-[var(--color-bg-elevated)]'}`}
+              data-active=${activePreset === item.id ? 'true' : 'false'}
+              onClick=${() => {
+                setPreset(item.id)
+                setStatus(null)
+              }}
+            >
+              <div class="mb-1 flex items-center justify-between gap-2">
+                <span class="text-xs font-semibold text-[var(--color-fg-primary)]">${item.label}</span>
+                <${StatusChip} tone=${activePreset === item.id ? 'info' : 'neutral'} uppercase=${false}>${item.count}<//>
+              </div>
+              <div class="prompt-preset-description text-2xs leading-relaxed text-[var(--color-fg-muted)]">${item.description}</div>
+            </button>
+          `)}
+        </div>
       </div>
 
       <${KeeperPromptAssemblyPanel} prompts=${prompts} />
@@ -183,7 +336,7 @@ export function PromptRegistryPanel() {
           <div class="mb-2 flex items-center justify-between gap-2 px-2">
             <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">
               등록된 프롬프트
-              ${sourceFilter.value !== 'all' || searchQuery.value
+              ${activePreset !== 'all' || sourceFilter.value !== 'all' || searchQuery.value
                 ? html`<span class="ml-1 normal-case tracking-normal text-[var(--color-fg-muted)]">${visiblePrompts.length} / ${prompts.length}</span>`
                 : null}
             </div>
@@ -259,12 +412,42 @@ export function PromptRegistryPanel() {
               </div>
             </div>
 
+            <div class="v2-lab-card mb-4 rounded-[var(--r-1)] border border-[var(--accent-22)] bg-[var(--accent-8)] px-3 py-2" data-prompt-destinations>
+              <div class="mb-2 flex flex-wrap items-center gap-2">
+                <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">들어가는 위치</div>
+                ${selectedDestinations.length === 0 ? html`<${StatusChip} tone="neutral">not in keeper recipe<//>` : null}
+              </div>
+              ${selectedDestinations.length === 0 ? html`
+                <div class="text-xs leading-relaxed text-[var(--color-fg-muted)]">
+                  이 프롬프트는 registry에는 있지만 keeper turn prompt recipe의 고정 단계에는 포함되지 않습니다.
+                </div>
+              ` : html`
+                <div class="grid gap-2">
+                  ${selectedDestinations.map(destination => html`
+                    <div class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-2">
+                      <div class="mb-1 flex flex-wrap items-center gap-2">
+                        <${StatusChip} tone=${destination.role === 'model_input' ? 'info' : 'neutral'} uppercase=${false}>${destination.messageSlot}<//>
+                        <span class="text-xs font-semibold text-[var(--color-fg-primary)]">${destination.stageTitle}</span>
+                      </div>
+                      <div class="text-2xs leading-relaxed text-[var(--color-fg-muted)]">${destination.summary}</div>
+                    </div>
+                  `)}
+                </div>
+              `}
+            </div>
+
             ${selectedPrompt.template_variables.length > 0 ? html`
               <div class="v2-lab-card mb-4 rounded-[var(--r-1)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
                 <div class="text-2xs uppercase tracking-[var(--track-caps)] text-[var(--color-fg-muted)]">허용된 플레이스홀더</div>
-                <div class="mt-2 flex flex-wrap gap-2">
+                <div class="mt-1 text-2xs leading-relaxed text-[var(--color-fg-muted)]">
+                  값 치환은 registry render 호출자가 공급하며, 치환된 텍스트는 위 위치로 그대로 들어갑니다.
+                </div>
+                <div class="mt-2 grid gap-2 sm:grid-cols-2">
                   ${selectedPrompt.template_variables.map(variable => html`
-                    <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-0.5 font-mono text-2xs text-[var(--color-fg-primary)]">${`{{${variable}}}`}</span>
+                    <div class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1.5">
+                      <div class="font-mono text-2xs text-[var(--color-fg-primary)]">${`{{${variable}}}`}</div>
+                      <div class="mt-0.5 text-3xs text-[var(--color-fg-muted)]">${selectedDestinations.length > 0 ? `${selectedDestinations.length} prompt recipe slot(s)` : 'registry render variable'}</div>
+                    </div>
                   `)}
                 </div>
               </div>
@@ -310,6 +493,15 @@ export function PromptRegistryPanel() {
           `}
         </div>
       </div>
+  `
+
+  if (embedded) {
+    return html`<div class="prompt-registry-panel prompt-registry-panel-embedded" data-testid="prompt-registry-panel">${body}</div>`
+  }
+
+  return html`
+    <${SectionCard} label="프롬프트 레지스트리" class="section mb-4">
+      <div data-testid="prompt-registry-panel">${body}</div>
     <//>
   `
 }

--- a/dashboard/src/components/tools/prompt-registry-panel.ts
+++ b/dashboard/src/components/tools/prompt-registry-panel.ts
@@ -20,6 +20,7 @@ import {
   buildKeeperPromptAssemblyReport,
   KeeperPromptAssemblyPanel,
   type KeeperPromptAssemblyReport,
+  type KeeperPromptAssemblyRow,
   type KeeperPromptAssemblyStage,
 } from '../keeper-prompt-assembly-panel'
 
@@ -63,12 +64,23 @@ function sourceBadgeClass(source: PromptSource): string {
   }
 }
 
-function promptPresetRows(report: KeeperPromptAssemblyReport, preset: PromptPresetId): Set<string> | null {
+const STAGE_PRESET_PREFIX = 'stage:'
+
+function stagePresetId(preset: PromptPresetId): string | null {
   if (preset === 'all' || preset === 'attention') return null
-  const stageId = preset.replace(/^stage:/, '')
+  return preset.slice(STAGE_PRESET_PREFIX.length)
+}
+
+function promptAssemblyRows(stage: KeeperPromptAssemblyStage): KeeperPromptAssemblyRow[] {
+  return stage.rows.filter(row => row.source !== 'computed')
+}
+
+function promptPresetRows(report: KeeperPromptAssemblyReport, preset: PromptPresetId): Set<string> | null {
+  const stageId = stagePresetId(preset)
+  if (!stageId) return null
   const stage = report.stages.find(item => item.id === stageId)
   if (!stage) return new Set()
-  return new Set(stage.rows.map(row => row.promptKey).filter(key => !key.startsWith('(')))
+  return new Set(promptAssemblyRows(stage).map(row => row.promptKey))
 }
 
 function stagePresetLabel(stage: KeeperPromptAssemblyStage): string {
@@ -95,9 +107,9 @@ export function promptPresetOptions(
   report: KeeperPromptAssemblyReport,
 ): PromptPreset[] {
   const stagePresets = report.stages
-    .filter(stage => stage.rows.some(row => !row.promptKey.startsWith('(')))
+    .filter(stage => promptAssemblyRows(stage).length > 0)
     .map(stage => {
-      const id: PromptPresetId = `stage:${stage.id}`
+      const id: PromptPresetId = `${STAGE_PRESET_PREFIX}${stage.id}`
       return {
         id,
         label: stagePresetLabel(stage),
@@ -152,12 +164,13 @@ export function filterPrompts(
   preset: PromptPresetId = 'all',
 ): DashboardPromptItem[] {
   const q = query.trim().toLowerCase()
+  const allowedPromptKeys =
+    preset !== 'all' && preset !== 'attention'
+      ? report ? promptPresetRows(report, preset) : new Set<string>()
+      : null
   return prompts.filter(p => {
     if (preset === 'attention' && !p.has_override && p.source !== 'missing') return false
-    if (preset !== 'all' && preset !== 'attention') {
-      const allowed = report ? promptPresetRows(report, preset) : new Set<string>()
-      if (!allowed || !allowed.has(p.key)) return false
-    }
+    if (allowedPromptKeys && !allowedPromptKeys.has(p.key)) return false
     if (source !== 'all' && p.source !== source) return false
     if (!q) return true
     return (
@@ -194,15 +207,17 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
   const [status, setStatus] = useState<string | null>(null)
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [draft, setDraft] = useState('')
-  const [preset, setPreset] = useState<PromptPresetId>('stage:base-system')
+  const [preset, setPreset] = useState<PromptPresetId>('all')
 
   const report = buildKeeperPromptAssemblyReport(prompts)
   const presets = promptPresetOptions(prompts, report)
   const activePreset = presets.some(item => item.id === preset) ? preset : 'all'
   const visiblePrompts = filterPrompts(prompts, sourceFilter.value, searchQuery.value, report, activePreset)
-  const selectedPrompt = visiblePrompts.find(prompt => prompt.key === selectedKey) ?? visiblePrompts[0] ?? null
+  const selectedPrompt =
+    (selectedKey ? prompts.find(prompt => prompt.key === selectedKey) : null) ?? visiblePrompts[0] ?? null
   const selectedDestinations = selectedPrompt ? promptDestinationsForKey(report, selectedPrompt.key) : []
   const counts = promptSourceCounts(prompts)
+  const draftDirty = selectedPrompt ? draft !== normalizeDraft(selectedPrompt) : draft.length > 0
 
   async function loadPrompts(preferredKey?: string | null) {
     setLoading(true)
@@ -230,8 +245,24 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
   }, [])
 
   useEffect(() => {
-    setDraft(normalizeDraft(selectedPrompt))
+    if (!selectedPrompt) setDraft('')
   }, [selectedPrompt?.key])
+
+  function confirmDiscardDraft(nextPrompt: DashboardPromptItem): boolean {
+    if (!selectedPrompt || nextPrompt.key === selectedPrompt.key || !draftDirty) return true
+    return (
+      typeof window === 'undefined' ||
+      typeof window.confirm !== 'function' ||
+      window.confirm('저장하지 않은 override 초안을 버리고 다른 프롬프트를 열까요?')
+    )
+  }
+
+  function selectPrompt(prompt: DashboardPromptItem) {
+    if (!confirmDiscardDraft(prompt)) return
+    setSelectedKey(prompt.key)
+    setDraft(normalizeDraft(prompt))
+    setStatus(null)
+  }
 
   async function applyOverride() {
     if (!selectedPrompt) return
@@ -375,9 +406,7 @@ export function PromptRegistryPanel({ embedded = false }: { embedded?: boolean }
                   ? 'border-[var(--accent-30)] bg-[var(--accent-10)]'
                   : 'border-[var(--color-border-default)] bg-[var(--color-bg-surface)] hover:bg-[var(--color-bg-elevated)]'}"
                 onClick=${() => {
-                  setSelectedKey(prompt.key)
-                  setDraft(normalizeDraft(prompt))
-                  setStatus(null)
+                  selectPrompt(prompt)
                 }}
               >
                 <div class="mb-1 flex items-start justify-between gap-2">

--- a/dashboard/src/sse-event-type-parity.test.ts
+++ b/dashboard/src/sse-event-type-parity.test.ts
@@ -57,16 +57,31 @@ const FE_ONLY_OR_EXTERNAL: Record<string, string> = {
 function parseFeRoutedEventTypes(source: string): Set<string> {
   // The exact-match routing forms in sse-store.ts:
   //   event.type === 'X'
+  //   event.type === SSE_SOME_EVENT
   //   routedType === 'X'
   //   normalizeMascEventType(event.type) === 'X'
+  const exportedConstants = parseExportedStringConstants(
+    readFileSync(resolve(process.cwd(), 'src/schemas/sse.ts'), 'utf8'),
+  )
   const re =
-    /(?:event\.type|routedType|normalizeMascEventType\(event\.type\)) === '([a-zA-Z0-9_:/]+)'/g
+    /(?:event\.type|routedType|normalizeMascEventType\(event\.type\)) === (?:'([a-zA-Z0-9_:/]+)'|([A-Z][A-Z0-9_]*))/g
   const found = new Set<string>()
   for (const m of source.matchAll(re)) {
-    const eventType = m[1]
+    const eventType = m[1] ?? exportedConstants.get(m[2] ?? '')
     if (eventType) found.add(eventType)
   }
   return found
+}
+
+function parseExportedStringConstants(source: string): Map<string, string> {
+  const constants = new Map<string, string>()
+  const re = /export const ([A-Z][A-Z0-9_]*) = '([a-zA-Z0-9_:/]+)'/g
+  for (const m of source.matchAll(re)) {
+    const name = m[1]
+    const value = m[2]
+    if (name && value) constants.set(name, value)
+  }
+  return constants
 }
 
 const sseStoreSource = readFileSync(resolve(process.cwd(), 'src/sse-store.ts'), 'utf8')

--- a/dashboard/src/styles/settings-surface.css
+++ b/dashboard/src/styles/settings-surface.css
@@ -900,6 +900,25 @@
   background: var(--volt-wash);
 }
 
+.prompt-registry-panel .prompt-preset-card {
+  min-height: 76px;
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.03);
+}
+
+.prompt-registry-panel .prompt-preset-card[data-active="true"] {
+  box-shadow:
+    inset 3px 0 0 var(--accent),
+    inset 0 1px 0 rgb(255 255 255 / 0.04);
+}
+
+.prompt-registry-panel .prompt-preset-description {
+  display: -webkit-box;
+  min-height: 2.5em;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
 /* Discord trigger radios — keeper-v2 styles/surfaces.css:580-587 (.set-trigger*) */
 .set-trigger {
   display: flex;

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -438,7 +438,7 @@ let restore_supervisor_state ~base_path name ~restart_count ~last_restart_ts ~cr
     ~restart_count
     ~last_restart_ts
     ~crash_log
-    ~update_entry
+    ~update_entry:update_entry_unit
 ;;
 
 (* [dedup_key] is the key under which a board wakeup is deduped. RFC-0239 R4
@@ -485,14 +485,16 @@ let cleanup_tracking ~base_path name =
   let key = registry_key ~base_path name in
   match StringMap.find_opt key (Atomic.get registry) with
   | Some entry ->
-    put_entry
-      key
-      { entry with
-        board_wakeups = StringMap.empty
-      ; tool_usage = StringMap.empty
-      ; board_cursor_ts = 0.0
-      ; board_cursor_post_id = None
-      }
+    ignore
+      (put_entry
+         ~base_path
+         name
+         { entry with
+           board_wakeups = StringMap.empty
+         ; tool_usage = StringMap.empty
+         ; board_cursor_ts = 0.0
+         ; board_cursor_post_id = None
+         })
   | None -> ()
 ;;
 
@@ -738,17 +740,19 @@ let rec dispatch_event_with_audit
            ~new_phase:tr.new_phase
            ~conditions_after:tr.updated_conditions
            ~restart_count:entry.restart_count;
-       put_entry
-         key
-         { entry with
-           phase = tr.new_phase
-         ; conditions = tr.updated_conditions
-         ; dead_since_ts
-         ; transition_seq = new_seq
-         ; last_auto_rules
-         ; pending_turn_measurement
-         ; compaction_stage
-         };
+       ignore
+         (put_entry
+            ~base_path
+            name
+            { entry with
+              phase = tr.new_phase
+            ; conditions = tr.updated_conditions
+            ; dead_since_ts
+            ; transition_seq = new_seq
+            ; last_auto_rules
+            ; pending_turn_measurement
+            ; compaction_stage
+            });
        List.iter
          (execute_entry_action_observability ~name ~phase:tr.new_phase ~ts_unix:now)
          tr.entry_actions;
@@ -829,15 +833,17 @@ let rec dispatch_event_with_audit
            ~new_phase:tr.new_phase
            ~conditions_after:tr.updated_conditions
            ~restart_count:entry.restart_count;
-       put_entry
-         key
-         { entry with
-           conditions = tr.updated_conditions
-         ; transition_seq = new_seq
-         ; last_auto_rules
-         ; pending_turn_measurement
-         ; compaction_stage
-         };
+       ignore
+         (put_entry
+            ~base_path
+            name
+            { entry with
+              conditions = tr.updated_conditions
+            ; transition_seq = new_seq
+            ; last_auto_rules
+            ; pending_turn_measurement
+            ; compaction_stage
+            });
        broadcast_composite_changed ~name ~ts_unix:now;
        Ok tr
      | Error e ->

--- a/test/test_keeper_context_isolation.ml
+++ b/test/test_keeper_context_isolation.ml
@@ -15,6 +15,8 @@ module Ctx = Agent_sdk.Context
 
 (* ── Helpers ─────────────────────────────────────── *)
 
+let create_ctx () = Ctx.create ~eio:false ()
+
 let ctx_has_key ctx k =
   match Ctx.get ctx k with Some _ -> true | None -> false
 
@@ -27,8 +29,8 @@ let ctx_get_string ctx k =
 
 let test_basic_isolation () =
   (* Two keepers, each with their own context *)
-  let ctx_alice = Ctx.create () in
-  let ctx_bob = Ctx.create () in
+  let ctx_alice = create_ctx () in
+  let ctx_bob = create_ctx () in
   (* Each writes keeper-specific state *)
   Ctx.set ctx_alice "keeper" (`String "alice");
   Ctx.set ctx_alice "turn" (`Int 1);
@@ -45,8 +47,8 @@ let test_basic_isolation () =
 (* ── Test: Checkpoint Roundtrip Isolation ─────────── *)
 
 let test_checkpoint_roundtrip_isolation () =
-  let ctx_a = Ctx.create () in
-  let ctx_b = Ctx.create () in
+  let ctx_a = create_ctx () in
+  let ctx_b = create_ctx () in
   Ctx.set ctx_a "state" (`String "working");
   Ctx.set ctx_b "state" (`String "idle");
   (* Simulate checkpoint: serialize both *)
@@ -67,7 +69,7 @@ let test_checkpoint_roundtrip_isolation () =
 
 let test_copy_resume_isolation () =
   (* Simulates Agent.resume path: Context.copy checkpoint.context *)
-  let checkpoint_ctx = Ctx.create () in
+  let checkpoint_ctx = create_ctx () in
   Ctx.set checkpoint_ctx "trace_id" (`String "abc-123");
   Ctx.set checkpoint_ctx "turn_count" (`Int 3);
   (* Two keepers resume from the same checkpoint *)
@@ -89,7 +91,7 @@ let test_copy_resume_isolation () =
 (* ── Test: Scope Isolation Between Keepers ───────── *)
 
 let test_scope_isolation_cross_keeper () =
-  let parent = Ctx.create () in
+  let parent = create_ctx () in
   Ctx.set parent "shared_config" (`String "base");
   (* Keeper A creates a scope for sub-agent delegation *)
   let scope_a = Ctx.create_scope
@@ -121,8 +123,8 @@ let test_scope_isolation_cross_keeper () =
 
 let test_scoped_key_collision () =
   (* Both keepers use the same key name but in different contexts *)
-  let ctx_a = Ctx.create () in
-  let ctx_b = Ctx.create () in
+  let ctx_a = create_ctx () in
+  let ctx_b = create_ctx () in
   Ctx.set_scoped ctx_a Ctx.Session "trace_id" (`String "trace-AAA");
   Ctx.set_scoped ctx_b Ctx.Session "trace_id" (`String "trace-BBB");
   Ctx.set_scoped ctx_a Ctx.User "name" (`String "Alice");
@@ -140,7 +142,7 @@ let test_scoped_key_collision () =
 (* ── Test: Concurrent Scope Merge Order ──────────── *)
 
 let test_merge_order_independence () =
-  let parent = Ctx.create () in
+  let parent = create_ctx () in
   Ctx.set parent "base" (`Int 0);
   let scope1 = Ctx.create_scope
     ~parent ~propagate_down:["base"] ~propagate_up:["r1"] in
@@ -158,8 +160,8 @@ let test_merge_order_independence () =
 (* ── Test: Diff Between Keeper Contexts ──────────── *)
 
 let test_diff_cross_keeper () =
-  let ctx_a = Ctx.create () in
-  let ctx_b = Ctx.create () in
+  let ctx_a = create_ctx () in
+  let ctx_b = create_ctx () in
   Ctx.set ctx_a "shared" (`String "v1");
   Ctx.set ctx_a "a_only" (`Int 1);
   Ctx.set ctx_b "shared" (`String "v2");

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -36,10 +36,6 @@ let fake_response canned =
   }
 ;;
 
-let text_of_response (response : Atypes.api_response) =
-  Atypes.text_of_content response.content
-;;
-
 let fake_complete canned : Runtime.complete_fn =
   fun ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () -> Ok (fake_response canned)
 ;;
@@ -299,7 +295,7 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
                seen_response_format := Some config.Llm_provider.Provider_config.response_format;
                let rendered_prompt =
                  messages
-                 |> List.map text_of_response
+                 |> List.map Atypes.text_of_message
                  |> String.concat "\n"
                  |> String.trim
                in

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -35,7 +35,7 @@ let register name =
 ;;
 
 let health_to_string = KR.registry_entry_validation_error_to_string
-let invalid_trace_id = Masc.Keeper_id.For_testing.unsafe_trace_id_of_string ""
+let invalid_trace_id = Keeper_id.For_testing.unsafe_trace_id_of_string ""
 
 let test_put_entry_rejects_meta_name_mismatch () =
   KR.clear ();


### PR DESCRIPTION
## Summary
- Replace the placeholder Settings > Prompts textareas with the existing PromptRegistryPanel backed by /api/v1/prompts.
- Add prompt stage presets derived from the keeper prompt assembly report, plus selected-prompt destination and placeholder routing context.
- Mark prompt settings as live-backed and widen the settings card for the registry/editor layout.

## Validation
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- pnpm --dir dashboard exec eslint src/components/settings-surface.ts src/components/tools/prompt-registry-panel.ts
- pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/tools/prompt-registry-panel.test.ts src/components/settings-surface.test.ts
- diff --check

## Notes
- Did not run the production dashboard build locally; CI is the build authority for this task.
- Local Playwright against the Vite route served the shell, but the unauthenticated browser stayed on dashboard loading. Live /health?full=1 on 127.0.0.1:8935 was healthy, so the visual route was blocked by auth/session rather than this component failing to render.
- Path/env audit of touched production files found no new hardcoded local path and no new env reads; the only MASC_* hits are pre-existing Discord trigger-policy labels in the settings preview section.