### PR TITLE
fix(bounded-proc): surface timeout diagnostics

### DIFF
--- a/docs/rfc/RFC-0125-bounded-subprocess-discipline.md
+++ b/docs/rfc/RFC-0125-bounded-subprocess-discipline.md
@@ -164,7 +164,19 @@ sangsu `mid_turn_no_progress 307s` 와 masc-improver `oas_timeout_budget 276s` �
 `lib/bounded_proc/bounded_proc.{ml,mli}`:
 
 ```ocaml
-(** Run [argv] as a subprocess with hard wall-clock bound. Inner
+type timeout =
+  { argv : string list
+  ; timeout_s : float
+  ; elapsed_s : float
+  ; stdout : string
+  ; stderr : string
+  }
+
+type outcome =
+  | Done of Unix.process_status * string * string
+  | Timeout of timeout
+
+(** Run [argv] as a subprocess with a hard monotonic-time bound. Inner
     [Switch.run] scope ensures the process is SIGKILLed when the timeout
     fiber wins the race, regardless of whether the process honoured any
     earlier cancellation signal.
@@ -172,25 +184,23 @@ sangsu `mid_turn_no_progress 307s` 와 masc-improver `oas_timeout_budget 276s` �
     Eio guarantees: per https://ocaml.org/p/eio/latest/doc/Eio/Process/
     "The child process will be sent Sys.sigkill when the switch is
     released." This helper relies on that single invariant. *)
-val with_bounded_run :
-  clock:_ Eio.Time.clock ->
+val run_argv_with_timeout :
+  mono_clock:_ Eio.Time.Mono.t ->
   process_mgr:_ Eio.Process.mgr ->
   cwd:_ Eio.Path.t ->
   ?env:string array ->
-  ?stdin_source:_ Eio.Flow.source ->
+  ?stdin_string:string ->
   timeout_s:float ->
   string list ->
-  [ `Done of Unix.process_status * string * string
-  | `Timeout of float (* elapsed *)
-  ]
+  outcome
 ```
 
 구현 핵심 (verifiable):
 
 ```ocaml
-let with_bounded_run ~clock ~process_mgr ~cwd ?env ?stdin_source
+let run_argv_with_timeout ~mono_clock ~process_mgr ~cwd ?env ?stdin_string
     ~timeout_s argv =
-  let start = Eio.Time.now clock in
+  let start = Eio.Time.Mono.now mono_clock in
   Eio.Switch.run @@ fun proc_sw ->
     let stdout_buf = Buffer.create 4096 in
     let stderr_buf = Buffer.create 1024 in
@@ -204,8 +214,13 @@ let with_bounded_run ~clock ~process_mgr ~cwd ?env ?stdin_source
     Eio.Flow.close stderr_w;
     Eio.Fiber.first
       (fun () ->
-        Eio.Time.sleep clock timeout_s;
-        `Timeout (Eio.Time.now clock -. start))
+        Eio.Time.Mono.sleep mono_clock timeout_s;
+        Timeout { argv; timeout_s;
+                  elapsed_s =
+                    seconds_of_span
+                      (Mtime.span start (Eio.Time.Mono.now mono_clock));
+                  stdout = Buffer.contents stdout_buf;
+                  stderr = Buffer.contents stderr_buf })
       (fun () ->
         Eio.Fiber.both
           (fun () ->
@@ -287,7 +302,7 @@ P1+ 머지 조건 (각 Phase 별):
 
 ## 8. Open questions
 
-- helper 의 timeout 발동 시 stdout/stderr buffer 의 *부분 결과* 를 caller 에 surface 해야 하는가? 현재 시그너처는 `\`Timeout of float` 만 — diagnosis 용으로 partial buffer 도 넘겨야 할 수도. P0 review 시 결정.
+- helper 의 timeout 발동 시 stdout/stderr buffer 의 *부분 결과* 를 caller 에 surface 해야 하는가? 2026-06-26 기준 `Timeout of timeout` record 로 반영 완료: `argv`, `timeout_s`, monotonic `elapsed_s`, partial `stdout`/`stderr` 를 caller 에 surface 한다.
 - supervisor 의 `Fun.protect ~finally` (line 401) 를 `Switch.on_release` 로 migrate 하는 것은 P4 에 포함시킬지, 별도 RFC 로 분리할지. memory `software-development.md` 의 "Fun.protect는 finally 예외가 원래 예외를 덮을 수 있음" 원칙과 직결.
 - `with_unix_capture` (Unix fallback path) 도 같은 invariant 가 적용되어야 하는가? `Stdlib.Unix.fork+execv` 기반이라 SIGKILL 직접 보내야 — Phase 별도.
 

--- a/lib/bounded_proc/bounded_proc.ml
+++ b/lib/bounded_proc/bounded_proc.ml
@@ -12,7 +12,9 @@ and timeout =
   ; stderr : string
   }
 
-let seconds_of_span span = Mtime.Span.to_float_ns span /. 1_000_000_000.0
+let ns_per_s = 1_000_000_000.0
+
+let seconds_of_span span = Mtime.Span.to_float_ns span /. ns_per_s
 
 let timeout_payload ~mono_clock ~start ~argv ~timeout_s ~stdout_buf ~stderr_buf =
   { argv

--- a/lib/bounded_proc/bounded_proc.ml
+++ b/lib/bounded_proc/bounded_proc.ml
@@ -2,11 +2,29 @@
 
 type outcome =
   | Done of Unix.process_status * string * string
-  | Timeout of float
+  | Timeout of timeout
 
-let run_argv_with_timeout ~clock ~process_mgr ~cwd ?env ?stdin_string
+and timeout =
+  { argv : string list
+  ; timeout_s : float
+  ; elapsed_s : float
+  ; stdout : string
+  ; stderr : string
+  }
+
+let seconds_of_span span = Mtime.Span.to_float_ns span /. 1_000_000_000.0
+
+let timeout_payload ~mono_clock ~start ~argv ~timeout_s ~stdout_buf ~stderr_buf =
+  { argv
+  ; timeout_s
+  ; elapsed_s = seconds_of_span (Mtime.span start (Eio.Time.Mono.now mono_clock))
+  ; stdout = Buffer.contents stdout_buf
+  ; stderr = Buffer.contents stderr_buf
+  }
+
+let run_argv_with_timeout ~mono_clock ~process_mgr ~cwd ?env ?stdin_string
     ~timeout_s argv =
-  let start = Eio.Time.now clock in
+  let start = Eio.Time.Mono.now mono_clock in
   Eio.Switch.run @@ fun proc_sw ->
   let stdout_buf = Buffer.create 4096 in
   let stderr_buf = Buffer.create 1024 in
@@ -37,7 +55,9 @@ let run_argv_with_timeout ~clock ~process_mgr ~cwd ?env ?stdin_string
     Done (status, Buffer.contents stdout_buf, Buffer.contents stderr_buf)
   in
   let timeout () =
-    Eio.Time.sleep clock timeout_s;
-    Timeout (Eio.Time.now clock -. start)
+    Eio.Time.Mono.sleep mono_clock timeout_s;
+    Timeout
+      (timeout_payload ~mono_clock ~start ~argv ~timeout_s ~stdout_buf
+         ~stderr_buf)
   in
   Eio.Fiber.first timeout drain_and_await

--- a/lib/bounded_proc/bounded_proc.mli
+++ b/lib/bounded_proc/bounded_proc.mli
@@ -1,6 +1,6 @@
 (** RFC-0109 — Bounded subprocess discipline.
 
-    Run a single subprocess with a hard wall-clock bound and capture
+    Run a single subprocess with a hard monotonic-time bound and capture
     stdout/stderr. The implementation relies on a single Eio invariant
     quoted from
     https://ocaml.org/p/eio/latest/doc/Eio/Process/index.html:
@@ -18,18 +18,33 @@
     which is why scope termination is the only reliable termination
     primitive available. *)
 
+(** Diagnostic payload returned when a subprocess exceeds its bound. *)
+type timeout =
+  { argv : string list
+        (** Exact argv passed to {!run_argv_with_timeout}. *)
+  ; timeout_s : float
+        (** Requested timeout budget in seconds. *)
+  ; elapsed_s : float
+        (** Elapsed monotonic time in seconds. *)
+  ; stdout : string
+        (** Partial stdout captured before the timeout won the race. *)
+  ; stderr : string
+        (** Partial stderr captured before the timeout won the race. *)
+  }
+
 (** Outcome of {!run_argv_with_timeout}. *)
 type outcome =
   | Done of Unix.process_status * string * string
       (** Process finished within the timeout. Fields are
           [(status, stdout, stderr)]. *)
-  | Timeout of float
-      (** Timeout fiber won the race. Carries elapsed wall-clock
-          seconds. The subprocess has been SIGKILLed by Eio at the
-          point this constructor is observed. *)
+  | Timeout of timeout
+      (** Timeout fiber won the race. Carries the requested argv, timeout
+          budget, monotonic elapsed time, and partial captured output. The
+          subprocess has been SIGKILLed by Eio at the point this constructor is
+          observed. *)
 
 val run_argv_with_timeout :
-  clock:_ Eio.Time.clock ->
+  mono_clock:_ Eio.Time.Mono.t ->
   process_mgr:_ Eio.Process.mgr ->
   cwd:Eio.Fs.dir_ty Eio.Path.t ->
   ?env:string array ->
@@ -37,9 +52,9 @@ val run_argv_with_timeout :
   timeout_s:float ->
   string list ->
   outcome
-(** [run_argv_with_timeout ~clock ~process_mgr ~cwd ?env ?stdin_string
+(** [run_argv_with_timeout ~mono_clock ~process_mgr ~cwd ?env ?stdin_string
     ~timeout_s argv] spawns [argv] under a fresh internal switch and
-    races the call against [Eio.Time.sleep clock timeout_s].
+    races the call against [Eio.Time.Mono.sleep mono_clock timeout_s].
 
     Returns {!Done} with the captured stdout/stderr if the process
     finishes first, or {!Timeout} otherwise.

--- a/lib/bounded_proc/dune
+++ b/lib/bounded_proc/dune
@@ -7,4 +7,4 @@
  ; RFC-0071 §3.4 Phase 5 ratchet (warning 4)
  (flags
   (:standard -w +4))
- (libraries eio eio.unix unix))
+ (libraries eio eio.unix mtime unix))

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -16,8 +16,8 @@
 # Removal: an entry SHOULD be removed when the spawn site itself is removed,
 # never when a "we'll wrap it later" excuse appears.
 
-# lib/bounded_proc/bounded_proc.ml:17  — the canonical helper itself.
-lib/bounded_proc/bounded_proc.ml:17
+# lib/bounded_proc/bounded_proc.ml:35  — the canonical helper itself.
+lib/bounded_proc/bounded_proc.ml:35
 
 # lib/process/process_eio.ml:483, 521, 570 — `spawn_and_drain_{stdout,both}`
 # and `spawn_and_drain_both_streaming`.

--- a/test/test_bounded_proc.ml
+++ b/test/test_bounded_proc.ml
@@ -71,7 +71,7 @@ let test_timeout_kills_process () =
   in
   (match outcome with
    | Bounded_proc.Timeout timeout ->
-     check (float 1.0) "timeout fired near requested budget" 0.5 timeout.elapsed_s;
+     check (float 0.2) "timeout fired near requested budget" 0.5 timeout.elapsed_s;
      check (float 0.0) "timeout budget preserved" 0.5 timeout.timeout_s;
      check (list string) "argv preserved" argv timeout.argv;
      check string "partial stdout preserved" "partial-out" timeout.stdout;

--- a/test/test_bounded_proc.ml
+++ b/test/test_bounded_proc.ml
@@ -11,10 +11,10 @@ open Alcotest
 
 let with_env f =
   Eio_main.run @@ fun env ->
-  let clock = Eio.Stdenv.clock env in
+  let mono_clock = Eio.Stdenv.mono_clock env in
   let process_mgr = Eio.Stdenv.process_mgr env in
   let cwd = Eio.Stdenv.cwd env in
-  f ~clock ~process_mgr ~cwd
+  f ~mono_clock ~process_mgr ~cwd
 
 (* Process-existence probe: returns [true] when at least one running
    process matches [argv_substring]. Uses [pgrep -f] which scans the
@@ -36,9 +36,9 @@ let process_exists argv_substring =
       | _ -> false)
 
 let test_done_within_timeout () =
-  with_env @@ fun ~clock ~process_mgr ~cwd ->
+  with_env @@ fun ~mono_clock ~process_mgr ~cwd ->
   let outcome =
-    Bounded_proc.run_argv_with_timeout ~clock ~process_mgr ~cwd
+    Bounded_proc.run_argv_with_timeout ~mono_clock ~process_mgr ~cwd
       ~timeout_s:5.0 [ "echo"; "hello" ]
   in
   match outcome with
@@ -51,31 +51,40 @@ let test_done_within_timeout () =
        | Unix.WEXITED n -> Printf.sprintf "WEXITED %d" n
        | Unix.WSIGNALED n -> Printf.sprintf "WSIGNALED %d" n
        | Unix.WSTOPPED n -> Printf.sprintf "WSTOPPED %d" n)
-  | Bounded_proc.Timeout elapsed ->
-    failf "unexpected timeout after %.3fs" elapsed
+  | Bounded_proc.Timeout timeout ->
+    failf "unexpected timeout after %.3fs" timeout.elapsed_s
 
 (* Marker string lets the post-timeout pgrep probe distinguish our
    subprocess from unrelated [sleep] commands on the host. *)
 let test_timeout_kills_process () =
-  with_env @@ fun ~clock ~process_mgr ~cwd ->
+  with_env @@ fun ~mono_clock ~process_mgr ~cwd ->
   let marker = "__bounded_proc_rfc0109_marker__" in
+  let argv =
+    [ "sh"
+    ; "-c"
+    ; Printf.sprintf "printf partial-out; printf partial-err >&2; sleep 10 # %s" marker
+    ]
+  in
   let outcome =
-    Bounded_proc.run_argv_with_timeout ~clock ~process_mgr ~cwd
-      ~timeout_s:0.5
-      [ "sh"; "-c"; Printf.sprintf "sleep 10 # %s" marker ]
+    Bounded_proc.run_argv_with_timeout ~mono_clock ~process_mgr ~cwd
+      ~timeout_s:0.5 argv
   in
   (match outcome with
-   | Bounded_proc.Timeout elapsed ->
-     check (float 1.0) "timeout fired near requested budget" 0.5 elapsed
+   | Bounded_proc.Timeout timeout ->
+     check (float 1.0) "timeout fired near requested budget" 0.5 timeout.elapsed_s;
+     check (float 0.0) "timeout budget preserved" 0.5 timeout.timeout_s;
+     check (list string) "argv preserved" argv timeout.argv;
+     check string "partial stdout preserved" "partial-out" timeout.stdout;
+     check string "partial stderr preserved" "partial-err" timeout.stderr
    | Bounded_proc.Done _ ->
      failf "expected Timeout, got Done");
   check bool "OS process terminated after switch release" false
     (process_exists marker)
 
 let test_stderr_capture () =
-  with_env @@ fun ~clock ~process_mgr ~cwd ->
+  with_env @@ fun ~mono_clock ~process_mgr ~cwd ->
   let outcome =
-    Bounded_proc.run_argv_with_timeout ~clock ~process_mgr ~cwd
+    Bounded_proc.run_argv_with_timeout ~mono_clock ~process_mgr ~cwd
       ~timeout_s:5.0
       [ "sh"; "-c"; "echo out; echo err >&2" ]
   in
@@ -89,14 +98,14 @@ let test_stderr_capture () =
        | Unix.WEXITED n -> Printf.sprintf "WEXITED %d" n
        | Unix.WSIGNALED n -> Printf.sprintf "WSIGNALED %d" n
        | Unix.WSTOPPED n -> Printf.sprintf "WSTOPPED %d" n)
-  | Bounded_proc.Timeout elapsed ->
-    failf "unexpected timeout after %.3fs" elapsed
+  | Bounded_proc.Timeout timeout ->
+    failf "unexpected timeout after %.3fs" timeout.elapsed_s
 
 let test_stdin_delivered () =
-  with_env @@ fun ~clock ~process_mgr ~cwd ->
+  with_env @@ fun ~mono_clock ~process_mgr ~cwd ->
   let payload = "round-trip via stdin\n" in
   let outcome =
-    Bounded_proc.run_argv_with_timeout ~clock ~process_mgr ~cwd
+    Bounded_proc.run_argv_with_timeout ~mono_clock ~process_mgr ~cwd
       ~stdin_string:payload ~timeout_s:5.0 [ "cat" ]
   in
   match outcome with
@@ -108,8 +117,8 @@ let test_stdin_delivered () =
        | Unix.WEXITED n -> Printf.sprintf "WEXITED %d" n
        | Unix.WSIGNALED n -> Printf.sprintf "WSIGNALED %d" n
        | Unix.WSTOPPED n -> Printf.sprintf "WSTOPPED %d" n)
-  | Bounded_proc.Timeout elapsed ->
-    failf "unexpected timeout after %.3fs" elapsed
+  | Bounded_proc.Timeout timeout ->
+    failf "unexpected timeout after %.3fs" timeout.elapsed_s
 
 let () =
   run "Bounded_proc"


### PR DESCRIPTION
## Summary
- replace Bounded_proc.Timeout float payload with a diagnostic timeout record
- breaking API change: downstream callers must update Timeout pattern matches from float to the timeout record and pass the monotonic clock API expected by the new timeout path
- require Eio.Time.Mono.t for subprocess timeout sleep and elapsed measurement
- preserve argv, requested timeout, monotonic elapsed time, and partial stdout/stderr on timeout
- update bounded_proc RFC and tests so the SSOT no longer documents Timeout of float

## Verification
- ocamlformat --check lib/bounded_proc/bounded_proc.ml lib/bounded_proc/bounded_proc.mli test/test_bounded_proc.ml
- git diff --check
- residue scan for old bounded_proc ~clock / Timeout of float API in bounded_proc docs/tests
- attempted scripts/dune-local.sh build test/test_bounded_proc.exe, stopped while waiting on shared /tmp/me-dune-local.lock; GitHub CI remains build authority for this change