### PR TITLE
fix(keeper): report malformed approval rule drops

### DIFF
--- a/docs/security/approval-rules.md
+++ b/docs/security/approval-rules.md
@@ -1,9 +1,11 @@
 # Approval Rules
 
-Keeper approval rules are persisted allow rules in `.masc/approval-rules.json`.
-They are only loaded when each rule entry parses as a complete rule. Malformed
-entries are ignored, which means they cannot match a future request and cannot
-auto-approve a tool call.
+Keeper approval rules are persisted allow rules. The authoritative path is
+`Keeper_approval_queue_rules.rules_path`, which resolves beneath
+`Workspace_utils.masc_dir_from_base_path`. They are only loaded when each rule
+entry parses as a complete rule. Malformed entries are ignored, reported as
+persistence read drops, and cannot match a future request or auto-approve a tool
+call.
 
 ## Fail-Closed Parse Policy
 
@@ -33,10 +35,12 @@ tool, and request fingerprint would otherwise match a low-risk request, but whos
 
 - `list_rules` skips the malformed rule during load
 - `find_matching_rule` returns `None` for the matching request
+- the skipped malformed entry increments the `keeper_approval_rules`
+  `invalid_payload` persistence-read-drop counter
 - rewriting the same persisted shape with a valid `max_risk` loads and matches
 
 This pins the operational behavior: malformed persisted approval rules are not
-silently allowed.
+silently allowed or silently erased.
 
 ## Error Variant Boundary
 

--- a/lib/keeper/keeper_approval_queue_rules.ml
+++ b/lib/keeper/keeper_approval_queue_rules.ml
@@ -104,6 +104,25 @@ let rules_path ~base_path () =
   Filename.concat (Workspace_utils.masc_dir_from_base_path ~base_path) "approval-rules.json"
 ;;
 
+let approval_rules_persistence_surface = "keeper_approval_rules"
+
+let report_rules_read_drop ~reason ~path ~detail =
+  Safe_ops.report_persistence_read_drop
+    ~on_drop:(fun () ->
+      Otel_metric_store.inc_counter
+        Otel_metric_store.metric_persistence_read_drops
+        ~labels:[ "surface", approval_rules_persistence_surface; "reason", reason ]
+        ())
+    ~surface:approval_rules_persistence_surface
+    ~reason
+    ~path
+    ~detail
+;;
+
+let rule_json_preview json =
+  Yojson.Safe.to_string json |> String_util.utf8_prefix ~max_bytes:240
+;;
+
 let stable_request_key_blocklist =
   [ "id"
   ; "turn_id"
@@ -168,9 +187,43 @@ let backend_of_runtime_context ?backend runtime_contract =
 ;;
 
 let load_rules_unlocked ~base_path () =
-  match Safe_ops.read_json_file_safe (rules_path ~base_path ()) with
-  | Ok (`List entries) -> entries |> List.filter_map approval_rule_of_yojson
-  | _ -> []
+  let path = rules_path ~base_path () in
+  let rec parse_entries index acc = function
+    | [] -> List.rev acc
+    | entry :: rest ->
+      (match approval_rule_of_yojson entry with
+       | Some rule -> parse_entries (index + 1) (rule :: acc) rest
+       | None ->
+         report_rules_read_drop
+           ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+           ~path
+           ~detail:
+             (Printf.sprintf
+                "approval rule entry %d rejected: %s"
+                index
+                (rule_json_preview entry));
+         parse_entries (index + 1) acc rest)
+  in
+  if not (Sys.file_exists path)
+  then []
+  else (
+    match Safe_ops.read_json_file_safe path with
+    | Ok (`List entries) -> parse_entries 0 [] entries
+    | Ok json ->
+      report_rules_read_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
+        ~path
+        ~detail:
+          (Printf.sprintf
+             "approval rules file must be a JSON list, got: %s"
+             (rule_json_preview json));
+      []
+    | Error detail ->
+      report_rules_read_drop
+        ~reason:Safe_ops.persistence_read_drop_reason_entry_load_error
+        ~path
+        ~detail;
+      [])
 ;;
 
 let save_rules_unlocked ~base_path rules : (unit, string) result =

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -21,12 +21,30 @@ let cleanup_dir dir =
   | _ -> ()
 ;;
 
+let rules_path ~base_path =
+  Filename.concat
+    (Workspace_utils.masc_dir_from_base_path ~base_path)
+    "approval-rules.json"
+;;
+
 let write_rules ~base_path json =
-  let masc_dir = Filename.concat base_path ".masc" in
+  let masc_dir = Workspace_utils.masc_dir_from_base_path ~base_path in
   if not (Sys.file_exists masc_dir) then Unix.mkdir masc_dir 0o755;
-  Out_channel.with_open_text
-    (Filename.concat masc_dir "approval-rules.json")
-    (fun oc -> output_string oc (Yojson.Safe.pretty_to_string json))
+  Out_channel.with_open_text (rules_path ~base_path) (fun oc ->
+    output_string oc (Yojson.Safe.pretty_to_string json))
+;;
+
+let write_rules_raw ~base_path content =
+  let masc_dir = Workspace_utils.masc_dir_from_base_path ~base_path in
+  if not (Sys.file_exists masc_dir) then Unix.mkdir masc_dir 0o755;
+  Out_channel.with_open_text (rules_path ~base_path) (fun oc -> output_string oc content)
+;;
+
+let read_drop_count reason =
+  Masc.Otel_metric_store.metric_value_or_zero
+    Masc.Otel_metric_store.metric_persistence_read_drops
+    ~labels:[ "surface", "keeper_approval_rules"; "reason", reason ]
+    ()
 ;;
 
 let stored_rule_json ~base_path =
@@ -69,10 +87,21 @@ let test_malformed_persisted_rule_cannot_match () =
        in
        check bool "fixture rule created" true created;
        let valid_rule_json = stored_rule_json ~base_path in
+       let before_invalid_payload =
+         read_drop_count Safe_ops.persistence_read_drop_reason_invalid_payload
+       in
        write_rules
          ~base_path
          (`List [ with_max_risk (`String "god-mode") valid_rule_json ]);
        check int "malformed rule skipped during load" 0 (List.length (AQ.list_rules ~base_path ()));
+       let after_invalid_payload =
+         read_drop_count Safe_ops.persistence_read_drop_reason_invalid_payload
+       in
+       check
+         bool
+         "malformed rule reported"
+         true
+         (after_invalid_payload -. before_invalid_payload >= 1.0);
        check
          bool
          "malformed rule does not auto-approve matching low-risk request"
@@ -87,6 +116,26 @@ let test_malformed_persisted_rule_cannot_match () =
          (Option.is_some (matching_lookup ~base_path ~input ())))
 ;;
 
+let test_corrupt_rules_file_reports_read_drop () =
+  let base_path = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let before_entry_load =
+         read_drop_count Safe_ops.persistence_read_drop_reason_entry_load_error
+       in
+       write_rules_raw ~base_path "{not-json";
+       check int "corrupt file loads no rules" 0 (List.length (AQ.list_rules ~base_path ()));
+       let after_entry_load =
+         read_drop_count Safe_ops.persistence_read_drop_reason_entry_load_error
+       in
+       check
+         bool
+         "corrupt file reported"
+         true
+         (after_entry_load -. before_entry_load >= 1.0))
+;;
+
 let () =
   run
     "Keeper_approval_queue_rules"
@@ -95,6 +144,10 @@ let () =
             "malformed persisted rule cannot match"
             `Quick
             test_malformed_persisted_rule_cannot_match
+        ; test_case
+            "corrupt rules file reports read drop"
+            `Quick
+            test_corrupt_rules_file_reports_read_drop
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- Follow-up to merged #22394 review blocker: fail-closed approval-rule loading now reports malformed/unreadable persisted policy instead of silently returning `[]`.
- Record `keeper_approval_rules` persistence read drops for malformed rule entries/non-list files (`invalid_payload`) and unreadable/corrupt files (`entry_load_error`).
- Keep a missing rules file quiet as normal first-run state.
- Update regression coverage for malformed matching rules and corrupt rules file metric deltas.
- Update approval-rules docs to reference `rules_path` / `Workspace_utils.masc_dir_from_base_path`.

## Verification

- `ocamlformat --check lib/keeper/keeper_approval_queue_rules.ml test/test_keeper_approval_queue_rules.ml lib/keeper_contract/keeper_approval_queue_rules_types.ml test/test_keeper_approval_queue_rules_types.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_approval_queue_rules.ml test/test_keeper_approval_queue_rules.ml lib/keeper_contract/keeper_approval_queue_rules_types.ml test/test_keeper_approval_queue_rules_types.ml`
- `git diff --check origin/main...HEAD`

No Dune/local build was run; CI remains the build authority.
