### PR TITLE
fix(discord): reject unknown mention prefixes

### DIFF
--- a/lib/gate/discord_gateway_state.ml
+++ b/lib/gate/discord_gateway_state.ml
@@ -354,10 +354,10 @@ let discord_mention_re =
   Re.Pcre.re {|<(@!?|@&|#)([0-9]+)>|} |> Re.compile
 
 let mention_kind_of_prefix = function
-  | "@" | "@!" -> User_mention
-  | "@&" -> Role_mention
-  | "#" -> Channel_mention
-  | _ -> User_mention
+  | "@" | "@!" -> Some User_mention
+  | "@&" -> Some Role_mention
+  | "#" -> Some Channel_mention
+  | _ -> None
 
 let resolve_mentions ~mentions content =
   let resolved = ref [] in
@@ -366,22 +366,24 @@ let resolve_mentions ~mentions content =
       let raw = Re.Group.get group 0 in
       let prefix = Re.Group.get group 1 in
       let id = Re.Group.get group 2 in
-      let kind = mention_kind_of_prefix prefix in
-      let name_opt =
-        match kind with
-        | User_mention -> List.assoc_opt id mentions
-        | Role_mention | Channel_mention -> None
-      in
-      resolved :=
-        { mention_id = id
-        ; mention_name = name_opt
-        ; mention_kind = kind
-        ; raw_mention = raw
-        }
-        :: !resolved;
-      match name_opt with
-      | Some name -> "@" ^ name
-      | None -> raw)
+      match mention_kind_of_prefix prefix with
+      | None -> raw
+      | Some kind ->
+          let name_opt =
+            match kind with
+            | User_mention -> List.assoc_opt id mentions
+            | Role_mention | Channel_mention -> None
+          in
+          resolved :=
+            { mention_id = id
+            ; mention_name = name_opt
+            ; mention_kind = kind
+            ; raw_mention = raw
+            }
+            :: !resolved;
+          match name_opt with
+          | Some name -> "@" ^ name
+          | None -> raw)
   in
   (content, List.rev !resolved)
 

--- a/test/test_discord_gateway_state.ml
+++ b/test/test_discord_gateway_state.ml
@@ -689,6 +689,32 @@ let test_decode_message_create_leaves_unknown_mention_untouched () =
   | Ok _ -> fail "expected unknown mention left as raw snowflake"
   | Error msg -> fail msg
 
+let test_decode_message_create_leaves_malformed_mention_unresolved () =
+  let malformed_id = "333333333333333333" in
+  let raw = "hey <@?" ^ malformed_id ^ ">" in
+  let payload =
+    message_create_payload
+      ~id:"MSG6B"
+      ~channel_id:"CH1"
+      ~author_id:"USER1"
+      ~content:raw
+      ~mention_ids:[]
+      ()
+  in
+  match
+    S.decode_dispatch
+      ~bot_user_id:(Some "BOT")
+      ~event_name:"MESSAGE_CREATE"
+      ~payload
+  with
+  | Ok
+      (S.Message_create
+        { content; raw_content; resolved_mentions = []; _ })
+    when String.equal content raw && String.equal raw_content raw ->
+      ()
+  | Ok _ -> fail "expected malformed mention left unresolved"
+  | Error msg -> fail msg
+
 let test_decode_message_create_preserves_raw_content () =
   let alice_id = "111111111111111111" in
   let payload =
@@ -2196,6 +2222,8 @@ let () =
             test_decode_message_create_resolves_mention_username_fallback
         ; test_case "MESSAGE_CREATE leaves unknown mention untouched" `Quick
             test_decode_message_create_leaves_unknown_mention_untouched
+        ; test_case "MESSAGE_CREATE leaves malformed mention unresolved" `Quick
+            test_decode_message_create_leaves_malformed_mention_unresolved
         ; test_case "MESSAGE_CREATE preserves raw_content" `Quick
             test_decode_message_create_preserves_raw_content
         ; test_case "MESSAGE_CREATE records resolved_mentions metadata" `Quick


### PR DESCRIPTION
Summary:
- make Discord mention prefix parsing partial instead of defaulting unknown prefixes to User_mention
- preserve unknown matched mention text without resolved metadata
- add a malformed mention regression fixture

Validation:
- bash scripts/lint/no-unknown-permissive-default.sh
- ocamlc -stop-after parsing lib/gate/discord_gateway_state.ml test/test_discord_gateway_state.ml
- git diff --check

Note:
- Focused Dune exec test/test_discord_gateway_state.exe was attempted but stopped after waiting behind the shared /tmp/me-dune-local.lock for ~60s.