### PR TITLE
fix(evidence): tighten contract-token utility follow-up

### DIFF
--- a/lib/core/string_util.ml
+++ b/lib/core/string_util.ml
@@ -123,7 +123,9 @@ let query_tokens query =
 
 let is_ascii_alnum_or_utf8_byte = function
   | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> true
-  | c -> Char.code c >= 128
+  | c ->
+    (* Non-ASCII UTF-8 bytes have the high bit set; keep them in tokens. *)
+    Char.code c land 0x80 <> 0
 
 let ascii_punctuation_tokens text =
   let len = String.length text in

--- a/lib/core/string_util.mli
+++ b/lib/core/string_util.mli
@@ -28,8 +28,8 @@ val query_tokens : string -> string list
 val ascii_punctuation_tokens : string -> string list
 (** [ascii_punctuation_tokens text] splits on ASCII punctuation and whitespace,
     lowercases ASCII token bytes, and keeps UTF-8 bytes inside tokens. It is the
-    shared tokenizer for legacy contract/reference text that treats punctuation
-    as token boundaries. *)
+    shared tokenizer for anti-rationalization-style contract-token matching,
+    where punctuation is a token boundary. *)
 
 val contains_contiguous_token_sequence
   :  haystack:string list

--- a/lib/task/anti_rationalization.ml
+++ b/lib/task/anti_rationalization.ml
@@ -600,9 +600,8 @@ let default_evaluator_runtime () =
     characters so non-English contract items still compare literally
     across ASCII whitespace/punctuation. *)
 let contract_tokens = String_util.ascii_punctuation_tokens
-;;
 
-let contains_token_sequence = String_util.contains_contiguous_token_sequence ;;
+let contains_token_sequence = String_util.contains_contiguous_token_sequence
 
 (** Check completion notes against a pre-declared contract.
     Returns unmet contract items. A contract item is "met" if its

--- a/test/test_string_util.ml
+++ b/test/test_string_util.ml
@@ -251,7 +251,26 @@ let test_contains_contiguous_token_sequence () =
        ~haystack:tokens
        ~needle:[ "src"; "tests" ]);
   check bool "empty needle rejects" false
-    (SU.contains_contiguous_token_sequence ~haystack:tokens ~needle:[])
+    (SU.contains_contiguous_token_sequence ~haystack:tokens ~needle:[]);
+  check bool "empty haystack rejects" false
+    (SU.contains_contiguous_token_sequence ~haystack:[] ~needle:[ "src" ]);
+  check bool "single token needle matches" true
+    (SU.contains_contiguous_token_sequence ~haystack:tokens ~needle:[ "checked" ]);
+  check bool "needle longer than haystack rejects" false
+    (SU.contains_contiguous_token_sequence ~haystack:[ "src" ]
+       ~needle:[ "src"; "main" ]);
+  check bool "non-ASCII case is byte literal" false
+    (SU.contains_contiguous_token_sequence
+       ~haystack:(SU.ascii_punctuation_tokens "ΔΟΚΙΜΗ")
+       ~needle:(SU.ascii_punctuation_tokens "δοκιμη"));
+  let long_haystack =
+    List.init 20_000 (fun i ->
+      if i = 19_998 then "needle" else "tok" ^ string_of_int i)
+  in
+  check bool "long input remains stack safe" true
+    (SU.contains_contiguous_token_sequence
+       ~haystack:long_haystack
+       ~needle:[ "needle"; "tok19999" ])
 
 let test_contains_all_tokens_ci_order_independent () =
   check bool "tokens match in any order with gaps" true


### PR DESCRIPTION
## Summary

- Follow-up to merged #22384 review comments.
- Replace the contract-token UTF-8 byte check magic number with an explicit high-bit test and comment.
- Clarify `ascii_punctuation_tokens` docs so it is scoped to anti-rationalization contract-token matching, not evidence-ref boundary matching.
- Add edge coverage for empty haystack, single-token needle, needle longer than haystack, byte-literal non-ASCII case behavior, and long-input sequence matching.
- Remove unnecessary `;;` from the `anti_rationalization` helper bindings.

## Verification

- `ocamlformat --check lib/core/string_util.ml lib/core/string_util.mli test/test_string_util.ml lib/task/anti_rationalization.ml`
- `ocamlc -stop-after parsing lib/core/string_util.ml lib/core/string_util.mli test/test_string_util.ml lib/task/anti_rationalization.ml`
- `git diff --check`

No Dune/local build was run; CI remains the build authority.
