### PR TITLE
fix(test): use Common masc dir helper in approval rules

### DIFF
--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -23,19 +23,19 @@ let cleanup_dir dir =
 
 let rules_path ~base_path =
   Filename.concat
-    (Workspace_utils.masc_dir_from_base_path ~base_path)
+    (Common.masc_dir_from_base_path ~base_path)
     "approval-rules.json"
 ;;
 
 let write_rules ~base_path json =
-  let masc_dir = Workspace_utils.masc_dir_from_base_path ~base_path in
+  let masc_dir = Common.masc_dir_from_base_path ~base_path in
   if not (Sys.file_exists masc_dir) then Unix.mkdir masc_dir 0o755;
   Out_channel.with_open_text (rules_path ~base_path) (fun oc ->
     output_string oc (Yojson.Safe.pretty_to_string json))
 ;;
 
 let write_rules_raw ~base_path content =
-  let masc_dir = Workspace_utils.masc_dir_from_base_path ~base_path in
+  let masc_dir = Common.masc_dir_from_base_path ~base_path in
   if not (Sys.file_exists masc_dir) then Unix.mkdir masc_dir 0o755;
   Out_channel.with_open_text (rules_path ~base_path) (fun oc -> output_string oc content)
 ;;


### PR DESCRIPTION
Fixes the merged #22410 test compile break by using Common.masc_dir_from_base_path instead of unqualified Workspace_utils in test/test_keeper_approval_queue_rules.ml.

Validation:
- ocamlformat --check test/test_keeper_approval_queue_rules.ml
- ocamlc -stop-after parsing test/test_keeper_approval_queue_rules.ml
- git diff --check
- bash scripts/lint/no-unknown-permissive-default.sh

Note: scripts/dune-local.sh build test/test_keeper_approval_queue_rules.exe was attempted, but local Dune was blocked by another bare dune process outside scripts/dune-local.sh.