### PR TITLE
fix(test): use public masc dir helper

### DIFF
--- a/test/stanzas/test_keeper_approval_queue_rules.inc
+++ b/test/stanzas/test_keeper_approval_queue_rules.inc
@@ -1,4 +1,4 @@
 (test
  (name test_keeper_approval_queue_rules)
  (modules test_keeper_approval_queue_rules)
- (libraries alcotest masc unix yojson))
+ (libraries alcotest masc masc_test_deps unix yojson))

--- a/test/test_keeper_approval_queue_rules.ml
+++ b/test/test_keeper_approval_queue_rules.ml
@@ -23,19 +23,19 @@ let cleanup_dir dir =
 
 let rules_path ~base_path =
   Filename.concat
-    (Workspace_utils.masc_dir_from_base_path ~base_path)
+    (Common.masc_dir_from_base_path ~base_path)
     "approval-rules.json"
 ;;
 
 let write_rules ~base_path json =
-  let masc_dir = Workspace_utils.masc_dir_from_base_path ~base_path in
+  let masc_dir = Common.masc_dir_from_base_path ~base_path in
   if not (Sys.file_exists masc_dir) then Unix.mkdir masc_dir 0o755;
   Out_channel.with_open_text (rules_path ~base_path) (fun oc ->
     output_string oc (Yojson.Safe.pretty_to_string json))
 ;;
 
 let write_rules_raw ~base_path content =
-  let masc_dir = Workspace_utils.masc_dir_from_base_path ~base_path in
+  let masc_dir = Common.masc_dir_from_base_path ~base_path in
   if not (Sys.file_exists masc_dir) then Unix.mkdir masc_dir 0o755;
   Out_channel.with_open_text (rules_path ~base_path) (fun oc -> output_string oc content)
 ;;


### PR DESCRIPTION
## Summary
- use Masc.Common.masc_dir_from_base_path in keeper approval rules test instead of unqualified Workspace_utils
- keep the test stanza scoped to the existing masc dependency

## Validation
- git diff --check
- ocamlc -stop-after parsing test/test_keeper_approval_queue_rules.ml
- ocamlformat --check test/test_keeper_approval_queue_rules.ml
- scripts/dune-local.sh build test/test_keeper_approval_queue_rules.exe (stopped after waiting on /tmp/me-dune-local.lock held by another worktree build)