### PR TITLE
fix(memory): keep legacy diagnostics out of recall

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -399,9 +399,10 @@ let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason
       (collapse_for_unstructured_note raw)
   in
   let note =
+    let prefix = Keeper_memory_os_types.librarian_unstructured_fallback_claim_prefix in
     if String.equal raw_excerpt ""
-    then Printf.sprintf "unstructured_note: librarian parse fallback (%s): <empty response>" reason
-    else Printf.sprintf "unstructured_note: librarian parse fallback (%s): %s" reason raw_excerpt
+    then Printf.sprintf "%s (%s): <empty response>" prefix reason
+    else Printf.sprintf "%s (%s): %s" prefix reason raw_excerpt
   in
   let source_turn_range =
     match List.length inp.messages with

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -244,7 +244,7 @@ let facts_recency_ranked ~now facts =
 
 let episode_prompt_recallable (episode : episode) =
   match episode.claims with
-  | [] -> true
+  | [] -> false
   | claims -> List.exists fact_prompt_recallable claims
 ;;
 

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -224,10 +224,19 @@ let fact_is_current ~now (fact : fact) =
   | Some ts -> ts >= now
 ;;
 
+let librarian_unstructured_fallback_claim_prefix =
+  "unstructured_note: librarian parse fallback"
+;;
+
+let legacy_unstructured_fallback_claim (claim : string) =
+  String.starts_with ~prefix:librarian_unstructured_fallback_claim_prefix claim
+;;
+
 let fact_prompt_recallable (fact : fact) =
   match fact.claim_kind with
   | Some Diagnostic -> false
-  | Some Self_observation | Some External_state | Some Durable_knowledge | None -> true
+  | Some Self_observation | Some External_state | Some Durable_knowledge -> true
+  | None -> not (legacy_unstructured_fallback_claim fact.claim)
 ;;
 
 (* RFC-0259 §3.6 (P5): split a fact list into (live, expired-at-[now]) on the

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -170,9 +170,15 @@ type fact =
     [valid_until] are durable and current. *)
 val fact_is_current : now:float -> fact -> bool
 
+(** Historical claim prefix used for librarian parse-failure fallback facts.
+    Kept as the SSOT for the producer and the legacy recall-eligibility shim. *)
+val librarian_unstructured_fallback_claim_prefix : string
+
 (** Structural prompt-recall eligibility. Callers still apply {!fact_is_current}
     for the time horizon; [Diagnostic] rows stay operator evidence, not prompt
-    context. *)
+    context. Legacy pre-[Diagnostic] librarian fallback rows are also excluded by
+    their exact historical claim prefix so old stores cannot keep injecting raw
+    parse-failure diagnostics. *)
 val fact_prompt_recallable : fact -> bool
 
 (** RFC-0259 §3.6 (P5): partition facts into [(live, expired)] at [now] on the

--- a/reports/memory-os-path-env-audit-2026-06-26.md
+++ b/reports/memory-os-path-env-audit-2026-06-26.md
@@ -17,16 +17,16 @@ External references checked on 2026-06-26 Asia/Seoul:
 
 Live commands:
 
-- `curl -fsS 'http://127.0.0.1:8935/health?full=1'`
-  - Runtime paths: `effective_base_path=/Users/dancer/me`, `effective_masc_root=/Users/dancer/me/.masc`, `resolution_source=explicit_cli`.
+- `curl -fsS "$MASC_HEALTH_BASE_URL/health?full=1"`
+  - Runtime paths: `effective_base_path=<base-path>`, `effective_masc_root=<base-path>/.masc`, `resolution_source=explicit_cli`.
   - `keeper_fleet_safety.status=ok`, `running_keeper_fiber_count=6`, `failing_keeper_fiber_count=0`.
-- `curl -fsS 'http://127.0.0.1:8935/api/v1/dashboard/keeper-memory-health' | jq '.keepers[] | select(.keeper_id=="sangsu")'`
+- `curl -fsS "$MASC_HEALTH_BASE_URL/api/v1/dashboard/keeper-memory-health" | jq '.keepers[] | select(.keeper_id=="<keeper-id>")'`
   - `facts=163`, `events=178`, `events_to_facts_ratio=4.2430085983804995`, `ttl_expired_on_disk=0`, `near_duplicate=0`.
-- `jq -s '[.[] | select((.claim // "") | startswith("unstructured_note:"))] | length' /Users/dancer/me/.masc/config/keepers/sangsu.facts.jsonl`
+- `jq -s '[.[] | select((.claim // "") | startswith("unstructured_note:"))] | length' <base-path>/.masc/config/keepers/<keeper-id>.facts.jsonl`
   - `11`
-- `jq -s '[.[] | select((.claim // "") | startswith("unstructured_note:")) | select((.valid_until == null) or (.valid_until > now))] | length' /Users/dancer/me/.masc/config/keepers/sangsu.facts.jsonl`
+- `jq -s '[.[] | select((.claim // "") | startswith("unstructured_note:")) | select((.valid_until == null) or (.valid_until > now))] | length' <base-path>/.masc/config/keepers/<keeper-id>.facts.jsonl`
   - `11`
-- `rg -c 'librarian_unstructured_fallback' /Users/dancer/me/.masc/config/keepers/sangsu.events.jsonl`
+- `rg -c 'librarian_unstructured_fallback' <base-path>/.masc/config/keepers/<keeper-id>.events.jsonl`
   - `108`
 
 Key source references:
@@ -73,7 +73,7 @@ Confirmed current behavior:
 - The row is persisted in the keeper fact/event/episode stores, not in a separate temporary cache.
 - The row is eligible for future recall injection while current. It is not used by the same turn that created it because the librarian write happens after the prompt context for that turn has already been built.
 
-This is not silent data loss, and keeping a diagnostic artifact is useful. The problem is that a raw, truncated, invalid provider response is stored in the same semantic fact channel as keeper memory. The live `sangsu` store has 11 current unstructured fallback facts and 108 fallback event markers, so the screenshot is a real current-state symptom.
+This is not silent data loss, and keeping a diagnostic artifact is useful. The problem is that a raw, truncated, invalid provider response is stored in the same semantic fact channel as keeper memory. One live keeper store had 11 current unstructured fallback facts and 108 fallback event markers, so the screenshot is a real current-state symptom.
 
 Production fix direction:
 
@@ -88,8 +88,14 @@ Implementation in this branch:
 - Added `Keeper_memory_os_types.fact_prompt_recallable` as the typed recall-eligibility SSOT.
 - Marked new librarian parse-failure fallback facts as `claim_kind="diagnostic"`.
 - Excluded diagnostic facts and diagnostic-only episodes from prompt recall.
+- Excluded legacy pre-`Diagnostic` fallback facts with the exact historical
+  `unstructured_note: librarian parse fallback` claim prefix from prompt recall,
+  so old stores do not keep injecting raw parse-failure diagnostics.
+- Excluded empty episodes from prompt recall.
 - Kept diagnostics visible in dashboard decoding/rendering via backend-projected `prompt_recallable=false`.
-- Did not add a legacy prefix-based migration for already-written untyped fallback rows. Those rows retain their existing TTL behavior; reclassifying them needs a separate, explicit migration decision.
+- Did not rewrite existing stores. Legacy rows retain their existing TTL and
+  on-disk shape; the compatibility shim only changes prompt-recall eligibility
+  and dashboard `prompt_recallable` projection.
 
 ### P1/P2 - Fleet-wide librarian provider slot does not stop all keepers, but can drop extraction work under load
 
@@ -120,7 +126,7 @@ Production fix direction:
 
 ### P2 - OAS env parsing policy is duplicated and inconsistent
 
-No hardcoded `/Users/dancer/me` path was found in the scanned OAS production source. The current risk is policy drift:
+No hardcoded local absolute path was found in the scanned OAS production source. The current risk is policy drift:
 
 - `Util.int_env_or` silently falls back on invalid input.
 - `Defaults.int_env_or` logs invalid input.
@@ -137,9 +143,9 @@ Production fix direction:
 
 ## Corrected Non-Findings
 
-### No confirmed production hardcoded `/Users/dancer/me` base path in scanned MASC/OAS code
+### No confirmed production hardcoded local base path in scanned MASC/OAS code
 
-The live MASC process is running with an explicit base path, and source resolution requires `MASC_BASE_PATH` or a server resolver path. The broad `/Users/dancer/me` hits in MASC are mainly tests/fixtures or documentation. I did not find a current production `let default_base = "/Users/dancer/me"` pattern in the scanned runtime paths.
+The live MASC process is running with an explicit base path, and source resolution requires `MASC_BASE_PATH` or a server resolver path. Broad local-path hits in MASC are mainly tests/fixtures or documentation. I did not find a current production `let default_base = "<base-path>"` pattern in the scanned runtime paths.
 
 ### Expired Memory OS facts are not recall-injected on current code
 
@@ -147,7 +153,7 @@ The older "GC default off means expired facts accumulate indefinitely into recal
 
 - write/cap paths drop expired rows,
 - recall filters `fact_is_current`,
-- `sangsu` currently reports `ttl_expired_on_disk=0`.
+- The sampled keeper currently reports `ttl_expired_on_disk=0`.
 
 GC is still default-off for quiet-store disk cleanup, but that is not the same as expired rows being active recall facts.
 

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1971,7 +1971,7 @@ let test_render_if_enabled_omits_diagnostic_memory () =
       with_temp_keepers_dir (fun keepers_dir ->
         let keeper_id = "diagnostic-memory-keeper" in
         let now = 1_000_000.0 in
-        let fact =
+        let diagnostic_fact =
           { (fact_fixture ~now ()) with
             Types.claim = "Raw parse-failure fallback should not enter prompt recall"
           ; Types.category = Types.Ephemeral
@@ -1979,11 +1979,21 @@ let test_render_if_enabled_omits_diagnostic_memory () =
           ; Types.valid_until = Some (now +. 3600.0)
           }
         in
-        let episode =
+        let legacy_fact =
+          let prefix = Types.librarian_unstructured_fallback_claim_prefix in
+          { (fact_fixture ~now ()) with
+            Types.claim =
+              Printf.sprintf "%s (invalid_json): raw model text" prefix
+          ; Types.category = Types.Ephemeral
+          ; Types.claim_kind = None
+          ; Types.valid_until = Some (now +. 3600.0)
+          }
+        in
+        let diagnostic_episode =
           { Types.trace_id = "trace-diagnostic-recall"
           ; Types.generation = 1
           ; Types.episode_summary = "diagnostic-only episode should not enter recall"
-          ; Types.claims = [ fact ]
+          ; Types.claims = [ diagnostic_fact ]
           ; Types.open_items = []
           ; Types.constraints = []
           ; Types.preserved_tool_refs = []
@@ -1994,12 +2004,50 @@ let test_render_if_enabled_omits_diagnostic_memory () =
           ; Types.schema_version = Types.schema_version
           }
         in
-        Memory_io.append_episode_bundle ~keeper_id episode;
+        let legacy_episode =
+          { diagnostic_episode with
+            Types.trace_id = "trace-legacy-diagnostic-recall"
+          ; Types.episode_summary = "legacy diagnostic-only episode should not enter recall"
+          ; Types.claims = [ legacy_fact ]
+          }
+        in
+        Memory_io.append_episode_bundle ~keeper_id diagnostic_episode;
+        Memory_io.append_episode_bundle ~keeper_id legacy_episode;
         match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
         | None -> ()
         | Some block ->
           Alcotest.failf
             "diagnostic memory leaked into recall block: %s"
+            block)))
+;;
+
+let test_render_if_enabled_omits_empty_episode_memory () =
+  with_recall_env "true" (fun () ->
+    with_prompt_registry (fun () ->
+      with_temp_keepers_dir (fun keepers_dir ->
+        let keeper_id = "empty-episode-memory-keeper" in
+        let now = 1_000_000.0 in
+        let episode =
+          { Types.trace_id = "trace-empty-episode-recall"
+          ; Types.generation = 1
+          ; Types.episode_summary = "empty episode should not enter recall"
+          ; Types.claims = []
+          ; Types.open_items = []
+          ; Types.constraints = []
+          ; Types.preserved_tool_refs = []
+          ; Types.source_turn_range = Some (1, 2)
+          ; Types.created_at = now
+          ; Types.valid_until = None
+          ; Types.terminal_marker = None
+          ; Types.schema_version = Types.schema_version
+          }
+        in
+        Memory_io.append_episode_bundle ~keeper_id episode;
+        match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
+        | None -> ()
+        | Some block ->
+          Alcotest.failf
+            "empty episode leaked into recall block: %s"
             block)))
 ;;
 
@@ -3909,6 +3957,36 @@ let test_dashboard_fact_json_marks_diagnostic_not_prompt_recallable () =
   | _ -> Alcotest.fail "prompt_recallable must be a bool"
 ;;
 
+let test_dashboard_fact_json_marks_legacy_diagnostic_not_prompt_recallable () =
+  let now = 1_000_000.0 in
+  let fact =
+    let prefix = Types.librarian_unstructured_fallback_claim_prefix in
+    { (fact_fixture ~now ()) with
+      Types.claim =
+        Printf.sprintf "%s (invalid_json): raw model text" prefix
+    ; Types.category = Types.Ephemeral
+    ; Types.claim_kind = None
+    ; Types.valid_until = Some (now +. 3600.0)
+    }
+  in
+  let fields =
+    match Server_dashboard_http_keeper_api.memory_os_fact_json ~now fact with
+    | `Assoc fields -> fields
+    | _ -> Alcotest.fail "memory_os_fact_json must be a JSON object"
+  in
+  Alcotest.(check bool)
+    "legacy diagnostic remains untyped"
+    false
+    (List.mem_assoc "claim_kind" fields);
+  match List.assoc_opt "prompt_recallable" fields with
+  | Some (`Bool b) ->
+    Alcotest.(check bool)
+      "legacy diagnostic fact is not prompt recallable"
+      false
+      b
+  | _ -> Alcotest.fail "prompt_recallable must be a bool"
+;;
+
 (* The [items] wiring lives in [memory_os_dashboard_json], not the pure
    [memory_os_fact_json]; the two fact_json tests above exercise the projection
    in isolation and would stay green if the dashboard payload stopped emitting
@@ -4122,6 +4200,10 @@ let () =
             `Quick
             test_dashboard_fact_json_marks_diagnostic_not_prompt_recallable
         ; Alcotest.test_case
+            "dashboard fact json marks legacy diagnostic rows as not prompt recallable"
+            `Quick
+            test_dashboard_fact_json_marks_legacy_diagnostic_not_prompt_recallable
+        ; Alcotest.test_case
             "dashboard json wires one facts.items row per persisted fact"
             `Quick
             test_dashboard_json_wires_one_fact_item_per_fact
@@ -4223,6 +4305,10 @@ let () =
             "render_if_enabled omits diagnostic memory"
             `Quick
             test_render_if_enabled_omits_diagnostic_memory
+        ; Alcotest.test_case
+            "render_if_enabled omits empty episode memory"
+            `Quick
+            test_render_if_enabled_omits_empty_episode_memory
         ; Alcotest.test_case
             "recall scans the whole bounded store, not just the tail window"
             `Quick


### PR DESCRIPTION
## Summary

- Follow-up to the Memory OS audit / #22382 review: legacy untyped `unstructured_note: librarian parse fallback...` rows are no longer prompt-recallable.
- Move the historical fallback claim prefix into `Keeper_memory_os_types` so the librarian producer and legacy recall shim share one SSOT.
- Treat empty episodes as not prompt-recallable.
- Add regression coverage for:
  - typed diagnostic fallback rows excluded from recall
  - legacy untyped fallback rows excluded from recall
  - empty episodes excluded from recall
  - dashboard `prompt_recallable=false` projection for legacy untyped fallback rows
- Sanitize the committed audit note so local host/path/keeper identifiers are placeholders.

## Verification

- `ocamlformat --check lib/keeper/keeper_memory_os_types.ml lib/keeper/keeper_memory_os_types.mli lib/keeper/keeper_memory_os_recall.ml lib/keeper/keeper_librarian_runtime.ml test/test_keeper_memory_os.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_memory_os_types.ml lib/keeper/keeper_memory_os_types.mli lib/keeper/keeper_memory_os_recall.ml lib/keeper/keeper_librarian_runtime.ml test/test_keeper_memory_os.ml`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_memory_os_types.mli`
- `git diff --check`
- `rg -n "/Users/dancer|sangsu|127\\.0\\.0\\.1:8935" reports/memory-os-path-env-audit-2026-06-26.md` returns no matches.

Attempted focused `scripts/dune-local.sh build test/test_keeper_memory_os.exe`, but stopped when `scripts/dune-local.sh` was waiting on another active Dune lock holder. No full local Dune build was run; CI remains the build authority.

Note: the originally referenced `reports/logic-gap-analysis-2026-06-25.html` is not present in the current checkout or git history I inspected, so this follows the nearest current tracked audit finding: `reports/memory-os-path-env-audit-2026-06-26.md` and the merged #22382 review residual.
