### PR TITLE
fix(dashboard): derive index etag from response content

### DIFF
--- a/lib/server/server_h2_gateway.ml
+++ b/lib/server/server_h2_gateway.ml
@@ -145,7 +145,7 @@ let make_request_handler ~sw ~clock ~server_start_time:_ =
       let index_path = dashboard_index_path () in
       match read_file index_path with
       | Ok body ->
-          let etag_value = "\"" ^ dashboard_etag () ^ "\"" in
+          let etag_value = "\"" ^ dashboard_etag_of_body body ^ "\"" in
           let if_none_match = H2.Headers.get h2_headers "if-none-match" in
           (match if_none_match with
            | Some inm when String.equal inm etag_value ->

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -223,7 +223,7 @@ let dashboard_etag_hex_chars = 12
 
 let dashboard_etag_of_body body =
   let hash = Digest.string body |> Digest.to_hex in
-  String.sub hash 0 dashboard_etag_hex_chars
+  String.sub hash 0 (min dashboard_etag_hex_chars (String.length hash))
 
 let dashboard_index_cache_control = "no-store, max-age=0, must-revalidate"
 

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -219,19 +219,15 @@ let dashboard_asset_root () =
 let dashboard_index_path () =
   Filename.concat (dashboard_asset_root ()) "index.html"
 
+let dashboard_etag_of_body body =
+  let hash = Digest.string body |> Digest.to_hex in
+  String.sub hash 0 12
+
 let dashboard_etag () =
-  try
-    let st = Unix.stat (dashboard_index_path ()) in
-    let hash =
-      Digest.string (string_of_float st.Unix.st_mtime) |> Digest.to_hex
-    in
-    String.sub hash 0 12
-  with
-  | Unix.Unix_error (err, _, _) ->
-      Log.Pages.warn "dashboard_etag stat failed: %s" (Unix.error_message err);
-      "none"
-  | exn ->
-      Log.Pages.warn "dashboard_etag unexpected: %s" (Printexc.to_string exn);
+  match read_file (dashboard_index_path ()) with
+  | Ok body -> dashboard_etag_of_body body
+  | Error msg ->
+      Log.Pages.warn "dashboard_etag read failed: %s" msg;
       "none"
 
 let dashboard_index_cache_control = "no-store, max-age=0, must-revalidate"
@@ -240,7 +236,7 @@ let serve_dashboard_index request reqd =
   match read_file (dashboard_index_path ()) with
   | Ok body ->
       Http.Response.html_cached
-        ~etag:(dashboard_etag ())
+        ~etag:(dashboard_etag_of_body body)
         ~request body reqd
   | Error _ ->
       Http.Response.html

--- a/lib/server/server_routes_http_pages.ml
+++ b/lib/server/server_routes_http_pages.ml
@@ -219,16 +219,11 @@ let dashboard_asset_root () =
 let dashboard_index_path () =
   Filename.concat (dashboard_asset_root ()) "index.html"
 
+let dashboard_etag_hex_chars = 12
+
 let dashboard_etag_of_body body =
   let hash = Digest.string body |> Digest.to_hex in
-  String.sub hash 0 12
-
-let dashboard_etag () =
-  match read_file (dashboard_index_path ()) with
-  | Ok body -> dashboard_etag_of_body body
-  | Error msg ->
-      Log.Pages.warn "dashboard_etag read failed: %s" msg;
-      "none"
+  String.sub hash 0 dashboard_etag_hex_chars
 
 let dashboard_index_cache_control = "no-store, max-age=0, must-revalidate"
 

--- a/lib/server/server_routes_http_pages.mli
+++ b/lib/server/server_routes_http_pages.mli
@@ -114,11 +114,14 @@ val dashboard_index_path : unit -> string
 (** Resolved path to the legacy dashboard's
     [index.html]. *)
 
+val dashboard_etag_of_body : string -> string
+(** Content-derived ETag digest for dashboard [index.html]
+    response bytes (first 12 hex chars). *)
+
 val dashboard_etag : unit -> string
-(** ETag derived from the dashboard index file's mtime
-    digest (first 12 hex chars).  Stable across
-    process restarts as long as the asset bundle is
-    untouched. *)
+(** Content-derived ETag for the dashboard index file
+    (first 12 hex chars).  Returns ["none"] and logs
+    when the file cannot be read. *)
 
 val dashboard_index_cache_control : string
 (** Cache-control header value for the dashboard index

--- a/lib/server/server_routes_http_pages.mli
+++ b/lib/server/server_routes_http_pages.mli
@@ -41,7 +41,7 @@
       {!playground_asset_path},
       {!dashboard_asset_root},
       {!dashboard_index_path},
-      {!dashboard_etag},
+      {!dashboard_etag_of_body},
       {!dashboard_index_cache_control},
       {!favicon_svg}).
     - {b Server-state helpers}
@@ -117,11 +117,6 @@ val dashboard_index_path : unit -> string
 val dashboard_etag_of_body : string -> string
 (** Content-derived ETag digest for dashboard [index.html]
     response bytes (first 12 hex chars). *)
-
-val dashboard_etag : unit -> string
-(** Content-derived ETag for the dashboard index file
-    (first 12 hex chars).  Returns ["none"] and logs
-    when the file cannot be read. *)
 
 val dashboard_index_cache_control : string
 (** Cache-control header value for the dashboard index

--- a/lib/server/server_routes_http_pages.mli
+++ b/lib/server/server_routes_http_pages.mli
@@ -114,9 +114,13 @@ val dashboard_index_path : unit -> string
 (** Resolved path to the legacy dashboard's
     [index.html]. *)
 
+val dashboard_etag_hex_chars : int
+(** Number of hex digest characters included in the
+    dashboard index ETag. *)
+
 val dashboard_etag_of_body : string -> string
 (** Content-derived ETag digest for dashboard [index.html]
-    response bytes (first 12 hex chars). *)
+    response bytes, truncated to [dashboard_etag_hex_chars]. *)
 
 val dashboard_index_cache_control : string
 (** Cache-control header value for the dashboard index

--- a/test/test_http_pages_asset_read.ml
+++ b/test/test_http_pages_asset_read.ml
@@ -12,15 +12,23 @@ open Alcotest
 
 module Pages = Server_routes_http_pages
 
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Array.iter
+        (fun name -> remove_tree (Filename.concat path name))
+        (Sys.readdir path);
+      Unix.rmdir path
+    end else Sys.remove path
+;;
+
 let with_temp_dir f =
   let dir = Filename.temp_file "masc_http_pages_test" "" in
   Sys.remove dir;
   Unix.mkdir dir 0o755;
-  Fun.protect
-    ~finally:(fun () ->
-      Array.iter (fun n -> try Sys.remove (Filename.concat dir n) with _ -> ()) (Sys.readdir dir);
-      try Unix.rmdir dir with _ -> ())
-    (fun () -> f dir)
+  Fun.protect ~finally:(fun () -> remove_tree dir) (fun () -> f dir)
 ;;
 
 let test_read_file_binary_roundtrip () =
@@ -52,7 +60,7 @@ let test_read_file_missing () =
 
 let restore_env name = function
   | Some value -> Unix.putenv name value
-  | None -> Unix.putenv name ""
+  | None -> unsetenv name
 ;;
 
 let with_env vars f =
@@ -62,42 +70,19 @@ let with_env vars f =
     List.iter (fun (name, value) -> restore_env name value) original)
 ;;
 
-let write_file path contents =
-  Out_channel.with_open_bin path (fun oc -> Out_channel.output_string oc contents)
-;;
-
-let with_temp_dashboard f =
-  with_temp_dir (fun dir ->
-    let assets = Filename.concat dir "assets" in
-    let dashboard = Filename.concat assets "dashboard" in
-    Unix.mkdir assets 0o755;
-    Unix.mkdir dashboard 0o755;
-    Fun.protect
-      (fun () -> f ~assets ~dashboard)
-      ~finally:(fun () ->
-        let index = Filename.concat dashboard "index.html" in
-        if Sys.file_exists index then Sys.remove index;
-        if Sys.file_exists dashboard then Unix.rmdir dashboard;
-        if Sys.file_exists assets then Unix.rmdir assets))
-;;
-
-let short_digest body =
-  String.sub (Digest.to_hex (Digest.string body)) 0 12
-;;
-
 let test_dashboard_etag_of_body_content_hash () =
   let first = Pages.dashboard_etag_of_body "first body" in
   let second = Pages.dashboard_etag_of_body "second body" in
-  check string "matches content digest" (short_digest "first body") first;
+  check string "matches content digest" "a97e73ad8da7" first;
   check bool "changes when content changes" true (not (String.equal first second))
 ;;
 
-let test_dashboard_etag_reads_index_content () =
-  with_temp_dashboard (fun ~assets ~dashboard ->
-    with_env [ "MASC_ASSETS_DIR", assets ] (fun () ->
-      let body = "<!doctype html><title>content-etag</title>" in
-      write_file (Filename.concat dashboard "index.html") body;
-      check string "index content digest" (short_digest body) (Pages.dashboard_etag ())))
+let test_with_env_restores_missing_env_as_unset () =
+  let name = "MASC_HTTP_PAGES_TEST_RESTORE_ENV" in
+  unsetenv name;
+  with_env [ name, "temporary" ] (fun () ->
+    check (option string) "set in body" (Some "temporary") (Sys.getenv_opt name));
+  check (option string) "unset after body" None (Sys.getenv_opt name)
 ;;
 
 let () =
@@ -109,7 +94,8 @@ let () =
         ] )
     ; ( "dashboard_etag"
       , [ test_case "body content hash" `Quick test_dashboard_etag_of_body_content_hash
-        ; test_case "index content hash" `Quick test_dashboard_etag_reads_index_content
+        ; test_case "missing env restored as unset" `Quick
+            test_with_env_restores_missing_env_as_unset
         ] )
     ]
 ;;

--- a/test/test_http_pages_asset_read.ml
+++ b/test/test_http_pages_asset_read.ml
@@ -50,12 +50,66 @@ let test_read_file_missing () =
     | Error _ -> ())
 ;;
 
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+;;
+
+let with_env vars f =
+  let original = List.map (fun (name, _) -> (name, Sys.getenv_opt name)) vars in
+  List.iter (fun (name, value) -> Unix.putenv name value) vars;
+  Fun.protect f ~finally:(fun () ->
+    List.iter (fun (name, value) -> restore_env name value) original)
+;;
+
+let write_file path contents =
+  Out_channel.with_open_bin path (fun oc -> Out_channel.output_string oc contents)
+;;
+
+let with_temp_dashboard f =
+  with_temp_dir (fun dir ->
+    let assets = Filename.concat dir "assets" in
+    let dashboard = Filename.concat assets "dashboard" in
+    Unix.mkdir assets 0o755;
+    Unix.mkdir dashboard 0o755;
+    Fun.protect
+      (fun () -> f ~assets ~dashboard)
+      ~finally:(fun () ->
+        let index = Filename.concat dashboard "index.html" in
+        if Sys.file_exists index then Sys.remove index;
+        if Sys.file_exists dashboard then Unix.rmdir dashboard;
+        if Sys.file_exists assets then Unix.rmdir assets))
+;;
+
+let short_digest body =
+  String.sub (Digest.to_hex (Digest.string body)) 0 12
+;;
+
+let test_dashboard_etag_of_body_content_hash () =
+  let first = Pages.dashboard_etag_of_body "first body" in
+  let second = Pages.dashboard_etag_of_body "second body" in
+  check string "matches content digest" (short_digest "first body") first;
+  check bool "changes when content changes" true (not (String.equal first second))
+;;
+
+let test_dashboard_etag_reads_index_content () =
+  with_temp_dashboard (fun ~assets ~dashboard ->
+    with_env [ "MASC_ASSETS_DIR", assets ] (fun () ->
+      let body = "<!doctype html><title>content-etag</title>" in
+      write_file (Filename.concat dashboard "index.html") body;
+      check string "index content digest" (short_digest body) (Pages.dashboard_etag ())))
+;;
+
 let () =
   run "http_pages_asset_read"
     [ ( "read_file"
       , [ test_case "binary round-trip" `Quick test_read_file_binary_roundtrip
         ; test_case "empty file" `Quick test_read_file_empty
         ; test_case "missing file -> Error" `Quick test_read_file_missing
+        ] )
+    ; ( "dashboard_etag"
+      , [ test_case "body content hash" `Quick test_dashboard_etag_of_body_content_hash
+        ; test_case "index content hash" `Quick test_dashboard_etag_reads_index_content
         ] )
     ]
 ;;

--- a/test/test_http_pages_asset_read.ml
+++ b/test/test_http_pages_asset_read.ml
@@ -14,21 +14,11 @@ module Pages = Server_routes_http_pages
 
 external unsetenv : string -> unit = "masc_test_unsetenv"
 
-let rec remove_tree path =
-  if Sys.file_exists path then
-    if Sys.is_directory path then begin
-      Array.iter
-        (fun name -> remove_tree (Filename.concat path name))
-        (Sys.readdir path);
-      Unix.rmdir path
-    end else Sys.remove path
-;;
-
 let with_temp_dir f =
   let dir = Filename.temp_file "masc_http_pages_test" "" in
   Sys.remove dir;
   Unix.mkdir dir 0o755;
-  Fun.protect ~finally:(fun () -> remove_tree dir) (fun () -> f dir)
+  Fun.protect ~finally:(fun () -> Fs_compat.remove_tree dir) (fun () -> f dir)
 ;;
 
 let test_read_file_binary_roundtrip () =
@@ -70,10 +60,27 @@ let with_env vars f =
     List.iter (fun (name, value) -> restore_env name value) original)
 ;;
 
+let expected_dashboard_etag body =
+  let hash = Digest.string body |> Digest.to_hex in
+  String.sub hash 0 (min Pages.dashboard_etag_hex_chars (String.length hash))
+;;
+
+let test_dashboard_asset_root_uses_env_assets_dir () =
+  with_temp_dir (fun assets ->
+    with_env [ "MASC_ASSETS_DIR", assets ] (fun () ->
+      let dashboard = Filename.concat assets "dashboard" in
+      check string "dashboard asset root" dashboard (Pages.dashboard_asset_root ());
+      check
+        string
+        "dashboard index path"
+        (Filename.concat dashboard "index.html")
+        (Pages.dashboard_index_path ())))
+;;
+
 let test_dashboard_etag_of_body_content_hash () =
   let first = Pages.dashboard_etag_of_body "first body" in
   let second = Pages.dashboard_etag_of_body "second body" in
-  check string "matches content digest" "a97e73ad8da7" first;
+  check string "matches content digest" (expected_dashboard_etag "first body") first;
   check bool "changes when content changes" true (not (String.equal first second))
 ;;
 
@@ -92,9 +99,17 @@ let () =
         ; test_case "empty file" `Quick test_read_file_empty
         ; test_case "missing file -> Error" `Quick test_read_file_missing
         ] )
+    ; ( "dashboard_assets"
+      , [ test_case
+            "asset root follows MASC_ASSETS_DIR"
+            `Quick
+            test_dashboard_asset_root_uses_env_assets_dir
+        ] )
     ; ( "dashboard_etag"
       , [ test_case "body content hash" `Quick test_dashboard_etag_of_body_content_hash
-        ; test_case "missing env restored as unset" `Quick
+        ] )
+    ; ( "env_helper"
+      , [ test_case "missing env restored as unset" `Quick
             test_with_env_restores_missing_env_as_unset
         ] )
     ]


### PR DESCRIPTION
Summary:
- derive dashboard index ETags from the actual response bytes instead of file mtime/string_of_float
- use the same content-derived ETag for HTTP/1.1 and H2 dashboard index responses
- add focused coverage for content-hash behavior and env-routed dashboard assets

Verification:
- ocamlformat --check lib/server/server_routes_http_pages.ml lib/server/server_routes_http_pages.mli lib/server/server_h2_gateway.ml test/test_http_pages_asset_read.ml
- git diff --check
- scripts/dune-local.sh build @test/runtest-test_http_pages_asset_read was not completed locally because /tmp/me-dune-local.lock was held by another worktree; CI is the build authority for this change