### PR TITLE
fix(keeper): expose descriptor discovery metadata

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1849,6 +1849,8 @@ let common_policy_json_fields ~readonly_key policy =
   ]
 ;;
 
+(* Route evidence consumers must read fields by key; object field order is not a
+   compatibility contract. *)
 let route_evidence_json d =
   let policy = d.policy in
   `Assoc
@@ -1867,112 +1869,10 @@ let route_evidence_json d =
      @ effect_domain_fields policy.effect_domain)
 ;;
 
-let schema_property_names schema =
-  match Json_util.assoc_member_opt "properties" schema with
-  | None -> [], []
-  | Some (`Assoc properties) -> List.map fst properties, []
-  | Some other ->
-    ( []
-    , [ Printf.sprintf
-          "properties: expected object, got %s"
-          (Json_util.kind_name other)
-      ] )
-;;
-
-let schema_required_names schema =
-  match Json_util.assoc_member_opt "required" schema with
-  | None -> [], []
-  | Some (`List values) ->
-    List.fold_right
-      (fun value (names, errors) ->
-         match value with
-         | `String name when not (String.equal name "") -> name :: names, errors
-         | other ->
-           ( names
-           , Printf.sprintf
-               "required: expected non-empty string, got %s"
-               (Json_util.kind_name other)
-             :: errors ))
-      values
-      ([], [])
-  | Some other ->
-    ( []
-    , [ Printf.sprintf
-          "required: expected string array, got %s"
-          (Json_util.kind_name other)
-      ] )
-
-let schema_one_of_required_names schema =
-  match Json_util.assoc_member_opt "oneOf" schema with
-  | None -> [], []
-  | Some (`List cases) ->
-    let mapped_cases =
-      List.mapi
-        (fun index case ->
-           match case with
-           | `Assoc _ ->
-             let required, errors = schema_required_names case in
-             ( (if required = [] then None else Some (Json_util.json_string_list required))
-             , List.map (Printf.sprintf "oneOf[%d].%s" index) errors )
-           | other ->
-             ( None
-             , [ Printf.sprintf
-                   "oneOf[%d]: expected object, got %s"
-                   index
-                   (Json_util.kind_name other)
-               ] ))
-        cases
-    in
-    let required, errors =
-      List.fold_right
-        (fun (required, errors) (required_acc, error_acc) ->
-           ( match required with
-             | Some required -> required :: required_acc
-             | None -> required_acc )
-           , errors @ error_acc)
-        mapped_cases
-        ([], [])
-    in
-    required, errors
-  | Some other ->
-    ( []
-    , [ Printf.sprintf
-          "oneOf: expected object array, got %s"
-          (Json_util.kind_name other)
-      ] )
-;;
-
-let schema_shape_json schema =
-  let properties, property_errors = schema_property_names schema in
-  let required, required_errors = schema_required_names schema in
-  let one_of_required, one_of_errors = schema_one_of_required_names schema in
-  let errors = property_errors @ required_errors @ one_of_errors in
-  let base =
-    [ "properties", Json_util.json_string_list properties
-    ; "required", Json_util.json_string_list required
-    ]
-  in
-  let fields =
-    if one_of_required = []
-    then base
-    else ("one_of_required", `List one_of_required) :: base
-  in
-  let fields =
-    if errors = []
-    then fields
-    else ("schema_errors", Json_util.json_string_list errors) :: fields
-  in
-  `Assoc fields
-;;
-
 let discovery_policy_json policy =
   `Assoc
     (common_policy_json_fields ~readonly_key:"readonly_hint" policy
-     @ [ "effect_domain", effect_domain_json policy.effect_domain
-       ; ( "policy_group"
-      , Json_util.string_opt_to_json
-          (Option.map Tool_catalog.effect_domain_to_string policy.effect_domain) )
-       ])
+     @ [ "effect_domain", effect_domain_json policy.effect_domain ])
 ;;
 
 let discovery_json d =
@@ -1992,7 +1892,7 @@ let discovery_json d =
      ; "sandbox", `String (sandbox_to_string d.sandbox)
      ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
      ; "policy", discovery_policy_json d.policy
-     ; "schema_shape", schema_shape_json d.input_schema
+     ; "schema_shape", Tool_input_validation.schema_shape_json d.input_schema
      ]
      @ examples_field)
 ;;

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -468,6 +468,7 @@ let descriptor_with_public_aliases
       ~sandbox
       ~runtime_handler
       ~translate
+      ()
   =
   let receipt_labels =
     [ "descriptor_id", id
@@ -512,6 +513,7 @@ let descriptor
       ~sandbox
       ~runtime_handler
       ~translate
+      ()
   =
   descriptor_with_public_aliases
     ~examples
@@ -528,6 +530,7 @@ let descriptor
     ~sandbox
     ~runtime_handler
     ~translate
+    ()
 ;;
 
 let with_eval_tags eval_tags descriptor =
@@ -584,6 +587,7 @@ let public_descriptors =
         ]
       ~validate_translated_input:true
       ~translate:translate_identity
+      ()
   ; descriptor_with_public_aliases
       ~id:"agent.search_files"
       ~public_name:"Grep"
@@ -609,6 +613,7 @@ let public_descriptors =
       ~runtime_handler:Tool_search_files
       ~validate_translated_input:true
       ~translate:translate_search_files
+      ()
   ; descriptor
       ~id:"agent.read_file"
       ~public_name:"Read"
@@ -632,6 +637,7 @@ let public_descriptors =
       ~runtime_handler:Tool_read_file
       ~validate_translated_input:false
       ~translate:translate_read_file
+      ()
   ; descriptor
       ~id:"agent.edit_file"
       ~public_name:"Edit"
@@ -650,6 +656,7 @@ let public_descriptors =
       ~runtime_handler:Tool_edit_file
       ~validate_translated_input:false
       ~translate:translate_edit_file
+      ()
   ; descriptor
       ~id:"agent.write_file"
       ~public_name:"Write"
@@ -668,6 +675,7 @@ let public_descriptors =
       ~runtime_handler:Tool_write_file
       ~validate_translated_input:false
       ~translate:translate_write_file
+      ()
   ; descriptor
       ~id:"agent.search_web"
       ~public_name:"WebSearch"
@@ -692,6 +700,7 @@ let public_descriptors =
       ~runtime_handler:Tool_masc_misc_dispatch
       ~validate_translated_input:true
       ~translate:translate_identity
+      ()
   ; descriptor
       ~id:"agent.fetch_web"
       ~public_name:"WebFetch"
@@ -716,6 +725,7 @@ let public_descriptors =
       ~runtime_handler:Tool_masc_misc_dispatch
       ~validate_translated_input:true
       ~translate:translate_identity
+      ()
   ]
 ;;
 
@@ -1052,6 +1062,7 @@ let in_process_descriptor ~id ~name ~description ~input_schema ~policy ~handler 
     ~runtime_handler:handler
     ~validate_translated_input:true
     ~translate:translate_identity
+    ()
 ;;
 
 (* Cluster-dispatched tools (board / voice / task) share a single

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -89,6 +89,7 @@ type t =
   ; validate_translated_input : bool
   ; receipt_labels : (string * string) list
   ; eval_tags : string list
+  ; examples : Yojson.Safe.t list
   }
 
 let executor_to_string = function
@@ -153,6 +154,20 @@ let runtime_handler_to_string = function
   | Tool_masc_fusion_dispatch -> "tool_masc_fusion_dispatch"
   | Tool_masc_fusion_status -> "tool_masc_fusion_status"
   | Tool_analyze_image -> "tool_analyze_image"
+;;
+
+let discovery_example ~label ?cwd ~executable ~argv () =
+  let input =
+    `Assoc
+      ([ "executable", `String executable
+       ; "argv", Json_util.json_string_list argv
+       ]
+       @
+       match cwd with
+       | Some cwd -> [ "cwd", `String cwd ]
+       | None -> [])
+  in
+  `Assoc [ "label", `String label; "input", input ]
 ;;
 
 let policy ?(visibility = Tool_catalog.Default) ?readonly ?readonly_of_input
@@ -439,6 +454,7 @@ let translate_search_files input =
 let search_files_readonly_of_input _input = Some true
 
 let descriptor_with_public_aliases
+      ?(examples = [])
       ~validate_translated_input
       ~public_aliases
       ~id
@@ -478,10 +494,12 @@ let descriptor_with_public_aliases
   ; validate_translated_input
   ; receipt_labels
   ; eval_tags = []
+  ; examples
   }
 ;;
 
 let descriptor
+      ?(examples = [])
       ~validate_translated_input
       ~id
       ~public_name
@@ -496,6 +514,7 @@ let descriptor
       ~translate
   =
   descriptor_with_public_aliases
+    ~examples
     ~validate_translated_input
     ~public_aliases:[]
     ~id
@@ -537,6 +556,32 @@ let public_descriptors =
       ~backend:Sandbox_process
       ~sandbox:Backend_selected
       ~runtime_handler:Tool_execute
+      ~examples:
+        [ discovery_example
+            ~label:"Inspect pull request metadata"
+            ~cwd:"<repository-root>"
+            ~executable:"gh"
+            ~argv:
+              [ "pr"
+              ; "view"
+              ; "<pull-request-number>"
+              ; "--json"
+              ; "number,state,headRefOid"
+              ]
+            ()
+        ; discovery_example
+            ~label:"Read repository status"
+            ~cwd:"<repository-root>"
+            ~executable:"git"
+            ~argv:[ "status"; "--short" ]
+            ()
+        ; discovery_example
+            ~label:"Search source text"
+            ~cwd:"<repository-root>"
+            ~executable:"rg"
+            ~argv:[ "--line-number"; "<pattern>"; "<path>" ]
+            ()
+        ]
       ~validate_translated_input:true
       ~translate:translate_identity
   ; descriptor_with_public_aliases
@@ -1801,45 +1846,22 @@ let route_evidence_json d =
      @ policy_fields)
 ;;
 
-let assoc_member name = function
-  | `Assoc fields -> List.assoc_opt name fields
-  | _ -> None
-;;
-
-let string_list_json values =
-  `List (List.map (fun value -> `String value) values)
-;;
-
-let string_list_of_json = function
-  | `List values ->
-    List.filter_map
-      (function
-        | `String value -> Some value
-        | _ -> None)
-      values
-  | _ -> []
-;;
-
 let schema_property_names schema =
-  match assoc_member "properties" schema with
+  match Json_util.assoc_member_opt "properties" schema with
   | Some (`Assoc properties) -> List.map fst properties
   | _ -> []
 ;;
 
-let schema_required_names schema =
-  match assoc_member "required" schema with
-  | Some required -> string_list_of_json required
-  | None -> []
-;;
+let schema_required_names schema = Json_util.json_string_list_member "required" schema
 
 let schema_one_of_required_names schema =
-  match assoc_member "oneOf" schema with
+  match Json_util.assoc_member_opt "oneOf" schema with
   | Some (`List cases) ->
     List.filter_map
       (fun case ->
          match schema_required_names case with
          | [] -> None
-         | required -> Some (string_list_json required))
+         | required -> Some (Json_util.json_string_list required))
       cases
   | _ -> []
 ;;
@@ -1847,8 +1869,8 @@ let schema_one_of_required_names schema =
 let schema_shape_json schema =
   let one_of_required = schema_one_of_required_names schema in
   let base =
-    [ "properties", string_list_json (schema_property_names schema)
-    ; "required", string_list_json (schema_required_names schema)
+    [ "properties", Json_util.json_string_list (schema_property_names schema)
+    ; "required", Json_util.json_string_list (schema_required_names schema)
     ]
   in
   let fields =
@@ -1857,50 +1879,6 @@ let schema_shape_json schema =
     else ("one_of_required", `List one_of_required) :: base
   in
   `Assoc fields
-;;
-
-let execute_example ~label ?cwd ~executable ~argv () =
-  let input =
-    `Assoc
-      ([ "executable", `String executable
-       ; "argv", string_list_json argv
-       ]
-       @
-       match cwd with
-       | Some cwd -> [ "cwd", `String cwd ]
-       | None -> [])
-  in
-  `Assoc [ "label", `String label; "input", input ]
-;;
-
-let discovery_examples d =
-  match d.internal_name with
-  | "tool_execute" ->
-    [ execute_example
-        ~label:"GitHub PR metadata"
-        ~cwd:"repos/masc"
-        ~executable:"gh"
-        ~argv:[ "pr"; "view"; "123"; "--json"; "number,state,headRefOid" ]
-        ()
-    ; execute_example
-        ~label:"Git status"
-        ~cwd:"repos/masc"
-        ~executable:"git"
-        ~argv:[ "status"; "--short" ]
-        ()
-    ; execute_example
-        ~label:"Focused OCaml test target"
-        ~cwd:"repos/masc"
-        ~executable:"scripts/dune-local.sh"
-        ~argv:[ "build"; "test/test_keeper_tool_dispatch_runtime.exe" ]
-        ()
-    ]
-  | _ -> []
-;;
-
-let policy_group_of_effect_domain = function
-  | Some effect_domain -> Tool_catalog.effect_domain_to_string effect_domain
-  | None -> "unspecified"
 ;;
 
 let discovery_policy_json policy =
@@ -1913,7 +1891,9 @@ let discovery_policy_json policy =
          | Some effect_domain ->
            `String (Tool_catalog.effect_domain_to_string effect_domain)
          | None -> `Null) )
-    ; "policy_group", `String (policy_group_of_effect_domain policy.effect_domain)
+    ; ( "policy_group"
+      , Json_util.string_opt_to_json
+          (Option.map Tool_catalog.effect_domain_to_string policy.effect_domain) )
     ; "approval", `String (approval_to_string policy.approval)
     ; "retryable", `Bool policy.retryable
     ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope
@@ -1923,18 +1903,23 @@ let discovery_policy_json policy =
 ;;
 
 let discovery_json d =
+  let examples_field =
+    match d.examples with
+    | [] -> []
+    | examples -> [ "examples", `List examples ]
+  in
   `Assoc
-    [ "id", `String d.id
-    ; "public_name", `String d.public_name
-    ; "public_aliases", string_list_json d.public_aliases
-    ; "internal_name", `String d.internal_name
-    ; "description", `String d.description
-    ; "executor", `String (executor_to_string d.executor)
-    ; "backend", `String (backend_to_string d.backend)
-    ; "sandbox", `String (sandbox_to_string d.sandbox)
-    ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
-    ; "policy", discovery_policy_json d.policy
-    ; "schema_shape", schema_shape_json d.input_schema
-    ; "examples", `List (discovery_examples d)
-    ]
+    ([ "id", `String d.id
+     ; "public_name", `String d.public_name
+     ; "public_aliases", Json_util.json_string_list d.public_aliases
+     ; "internal_name", `String d.internal_name
+     ; "description", `String d.description
+     ; "executor", `String (executor_to_string d.executor)
+     ; "backend", `String (backend_to_string d.backend)
+     ; "sandbox", `String (sandbox_to_string d.sandbox)
+     ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
+     ; "policy", discovery_policy_json d.policy
+     ; "schema_shape", schema_shape_json d.input_schema
+     ]
+     @ examples_field)
 ;;

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1800,3 +1800,141 @@ let route_evidence_json d =
      ]
      @ policy_fields)
 ;;
+
+let assoc_member name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+;;
+
+let string_list_json values =
+  `List (List.map (fun value -> `String value) values)
+;;
+
+let string_list_of_json = function
+  | `List values ->
+    List.filter_map
+      (function
+        | `String value -> Some value
+        | _ -> None)
+      values
+  | _ -> []
+;;
+
+let schema_property_names schema =
+  match assoc_member "properties" schema with
+  | Some (`Assoc properties) -> List.map fst properties
+  | _ -> []
+;;
+
+let schema_required_names schema =
+  match assoc_member "required" schema with
+  | Some required -> string_list_of_json required
+  | None -> []
+;;
+
+let schema_one_of_required_names schema =
+  match assoc_member "oneOf" schema with
+  | Some (`List cases) ->
+    List.filter_map
+      (fun case ->
+         match schema_required_names case with
+         | [] -> None
+         | required -> Some (string_list_json required))
+      cases
+  | _ -> []
+;;
+
+let schema_shape_json schema =
+  let one_of_required = schema_one_of_required_names schema in
+  let base =
+    [ "properties", string_list_json (schema_property_names schema)
+    ; "required", string_list_json (schema_required_names schema)
+    ]
+  in
+  let fields =
+    if one_of_required = []
+    then base
+    else ("one_of_required", `List one_of_required) :: base
+  in
+  `Assoc fields
+;;
+
+let execute_example ~label ?cwd ~executable ~argv () =
+  let input =
+    `Assoc
+      ([ "executable", `String executable
+       ; "argv", string_list_json argv
+       ]
+       @
+       match cwd with
+       | Some cwd -> [ "cwd", `String cwd ]
+       | None -> [])
+  in
+  `Assoc [ "label", `String label; "input", input ]
+;;
+
+let discovery_examples d =
+  match d.internal_name with
+  | "tool_execute" ->
+    [ execute_example
+        ~label:"GitHub PR metadata"
+        ~cwd:"repos/masc"
+        ~executable:"gh"
+        ~argv:[ "pr"; "view"; "123"; "--json"; "number,state,headRefOid" ]
+        ()
+    ; execute_example
+        ~label:"Git status"
+        ~cwd:"repos/masc"
+        ~executable:"git"
+        ~argv:[ "status"; "--short" ]
+        ()
+    ; execute_example
+        ~label:"Focused OCaml test target"
+        ~cwd:"repos/masc"
+        ~executable:"scripts/dune-local.sh"
+        ~argv:[ "build"; "test/test_keeper_tool_dispatch_runtime.exe" ]
+        ()
+    ]
+  | _ -> []
+;;
+
+let policy_group_of_effect_domain = function
+  | Some effect_domain -> Tool_catalog.effect_domain_to_string effect_domain
+  | None -> "unspecified"
+;;
+
+let discovery_policy_json policy =
+  `Assoc
+    [ ( "visibility"
+      , `String (Tool_catalog.visibility_to_string policy.visibility) )
+    ; "readonly_hint", Json_util.bool_opt_to_json policy.readonly_hint
+    ; ( "effect_domain"
+      , (match policy.effect_domain with
+         | Some effect_domain ->
+           `String (Tool_catalog.effect_domain_to_string effect_domain)
+         | None -> `Null) )
+    ; "policy_group", `String (policy_group_of_effect_domain policy.effect_domain)
+    ; "approval", `String (approval_to_string policy.approval)
+    ; "retryable", `Bool policy.retryable
+    ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope
+    ; "inline_safe", `Bool policy.inline_safe
+    ; "maintenance_only", `Bool policy.maintenance_only
+    ]
+;;
+
+let discovery_json d =
+  `Assoc
+    [ "id", `String d.id
+    ; "public_name", `String d.public_name
+    ; "public_aliases", string_list_json d.public_aliases
+    ; "internal_name", `String d.internal_name
+    ; "description", `String d.description
+    ; "executor", `String (executor_to_string d.executor)
+    ; "backend", `String (backend_to_string d.backend)
+    ; "sandbox", `String (sandbox_to_string d.sandbox)
+    ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
+    ; "policy", discovery_policy_json d.policy
+    ; "schema_shape", schema_shape_json d.input_schema
+    ; "examples", `List (discovery_examples d)
+    ]
+;;

--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -1827,61 +1827,129 @@ let eval_tags_json d =
   `List (List.map (fun tag -> `String tag) d.eval_tags)
 ;;
 
+let effect_domain_json = function
+  | Some effect_domain -> `String (Tool_catalog.effect_domain_to_string effect_domain)
+  | None -> `Null
+;;
+
+let effect_domain_fields = function
+  | Some domain ->
+    [ "effect_domain", `String (Tool_catalog.effect_domain_to_string domain) ]
+  | None -> []
+;;
+
+let common_policy_json_fields ~readonly_key policy =
+  [ "visibility", `String (Tool_catalog.visibility_to_string policy.visibility)
+  ; readonly_key, Json_util.bool_opt_to_json policy.readonly_hint
+  ; "approval", `String (approval_to_string policy.approval)
+  ; "retryable", `Bool policy.retryable
+  ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope
+  ; "inline_safe", `Bool policy.inline_safe
+  ; "maintenance_only", `Bool policy.maintenance_only
+  ]
+;;
+
 let route_evidence_json d =
   let policy = d.policy in
-  let policy_fields =
-    match policy.effect_domain with
-    | Some domain ->
-      [ "effect_domain", `String (Tool_catalog.effect_domain_to_string domain) ]
-    | None -> []
-  in
   `Assoc
     ([ "descriptor_id", `String d.id
      ; "public_name", `String d.public_name
      ; "canonical_name", `String d.internal_name
      ; "description", `String d.description
-     ; "visibility", `String (Tool_catalog.visibility_to_string policy.visibility)
-     ; "readonly", Json_util.bool_opt_to_json policy.readonly_hint
      ; "executor", `String (executor_to_string d.executor)
      ; "backend", `String (backend_to_string d.backend)
      ; "sandbox", `String (sandbox_to_string d.sandbox)
      ; "runtime_handler", `String (runtime_handler_to_string d.runtime_handler)
      ; "receipt_labels", receipt_labels_json d
      ; "eval_tags", eval_tags_json d
-     ; "approval", `String (approval_to_string policy.approval)
-     ; "retryable", `Bool policy.retryable
-     ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope
-     ; "inline_safe", `Bool policy.inline_safe
-     ; "maintenance_only", `Bool policy.maintenance_only
      ]
-     @ policy_fields)
+     @ common_policy_json_fields ~readonly_key:"readonly" policy
+     @ effect_domain_fields policy.effect_domain)
 ;;
 
 let schema_property_names schema =
   match Json_util.assoc_member_opt "properties" schema with
-  | Some (`Assoc properties) -> List.map fst properties
-  | _ -> []
+  | None -> [], []
+  | Some (`Assoc properties) -> List.map fst properties, []
+  | Some other ->
+    ( []
+    , [ Printf.sprintf
+          "properties: expected object, got %s"
+          (Json_util.kind_name other)
+      ] )
 ;;
 
-let schema_required_names schema = Json_util.json_string_list_member "required" schema
+let schema_required_names schema =
+  match Json_util.assoc_member_opt "required" schema with
+  | None -> [], []
+  | Some (`List values) ->
+    List.fold_right
+      (fun value (names, errors) ->
+         match value with
+         | `String name when not (String.equal name "") -> name :: names, errors
+         | other ->
+           ( names
+           , Printf.sprintf
+               "required: expected non-empty string, got %s"
+               (Json_util.kind_name other)
+             :: errors ))
+      values
+      ([], [])
+  | Some other ->
+    ( []
+    , [ Printf.sprintf
+          "required: expected string array, got %s"
+          (Json_util.kind_name other)
+      ] )
 
 let schema_one_of_required_names schema =
   match Json_util.assoc_member_opt "oneOf" schema with
+  | None -> [], []
   | Some (`List cases) ->
-    List.filter_map
-      (fun case ->
-         match schema_required_names case with
-         | [] -> None
-         | required -> Some (Json_util.json_string_list required))
-      cases
-  | _ -> []
+    let mapped_cases =
+      List.mapi
+        (fun index case ->
+           match case with
+           | `Assoc _ ->
+             let required, errors = schema_required_names case in
+             ( (if required = [] then None else Some (Json_util.json_string_list required))
+             , List.map (Printf.sprintf "oneOf[%d].%s" index) errors )
+           | other ->
+             ( None
+             , [ Printf.sprintf
+                   "oneOf[%d]: expected object, got %s"
+                   index
+                   (Json_util.kind_name other)
+               ] ))
+        cases
+    in
+    let required, errors =
+      List.fold_right
+        (fun (required, errors) (required_acc, error_acc) ->
+           ( match required with
+             | Some required -> required :: required_acc
+             | None -> required_acc )
+           , errors @ error_acc)
+        mapped_cases
+        ([], [])
+    in
+    required, errors
+  | Some other ->
+    ( []
+    , [ Printf.sprintf
+          "oneOf: expected object array, got %s"
+          (Json_util.kind_name other)
+      ] )
 ;;
 
 let schema_shape_json schema =
-  let one_of_required = schema_one_of_required_names schema in
+  let properties, property_errors = schema_property_names schema in
+  let required, required_errors = schema_required_names schema in
+  let one_of_required, one_of_errors = schema_one_of_required_names schema in
+  let errors = property_errors @ required_errors @ one_of_errors in
   let base =
-    [ "properties", Json_util.json_string_list (schema_property_names schema)
-    ; "required", Json_util.json_string_list (schema_required_names schema)
+    [ "properties", Json_util.json_string_list properties
+    ; "required", Json_util.json_string_list required
     ]
   in
   let fields =
@@ -1889,28 +1957,22 @@ let schema_shape_json schema =
     then base
     else ("one_of_required", `List one_of_required) :: base
   in
+  let fields =
+    if errors = []
+    then fields
+    else ("schema_errors", Json_util.json_string_list errors) :: fields
+  in
   `Assoc fields
 ;;
 
 let discovery_policy_json policy =
   `Assoc
-    [ ( "visibility"
-      , `String (Tool_catalog.visibility_to_string policy.visibility) )
-    ; "readonly_hint", Json_util.bool_opt_to_json policy.readonly_hint
-    ; ( "effect_domain"
-      , (match policy.effect_domain with
-         | Some effect_domain ->
-           `String (Tool_catalog.effect_domain_to_string effect_domain)
-         | None -> `Null) )
-    ; ( "policy_group"
+    (common_policy_json_fields ~readonly_key:"readonly_hint" policy
+     @ [ "effect_domain", effect_domain_json policy.effect_domain
+       ; ( "policy_group"
       , Json_util.string_opt_to_json
           (Option.map Tool_catalog.effect_domain_to_string policy.effect_domain) )
-    ; "approval", `String (approval_to_string policy.approval)
-    ; "retryable", `Bool policy.retryable
-    ; "cwd_scope", Json_util.string_opt_to_json policy.cwd_scope
-    ; "inline_safe", `Bool policy.inline_safe
-    ; "maintenance_only", `Bool policy.maintenance_only
-    ]
+       ])
 ;;
 
 let discovery_json d =

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -100,6 +100,9 @@ type t =
   (** Evaluation-only semantic tags emitted in route evidence. These tags
       support replay/harness scoring and are not runtime selection policy. *)
   ; eval_tags : string list
+  ; examples : Yojson.Safe.t list
+  (** Descriptor-owned discovery examples. Empty means the discovery projection
+      omits the [examples] field. *)
   }
 
 val executor_to_string : executor -> string

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -166,5 +166,7 @@ val route_evidence_json : t -> Yojson.Safe.t
 
 (** Read-only discovery projection for capability introspection surfaces.
     Keeps executor, policy, schema-shape, and curated typed examples attached
-    to the descriptor that owns the runtime route. *)
+    to the descriptor that owns the runtime route. The policy [effect_domain] is
+    [null] when a descriptor has no static effect domain; no fallback sentinel
+    string is emitted. *)
 val discovery_json : t -> Yojson.Safe.t

--- a/lib/keeper/keeper_tool_descriptor.mli
+++ b/lib/keeper/keeper_tool_descriptor.mli
@@ -160,3 +160,8 @@ val public_input_schema : string -> Yojson.Safe.t option
 val translate_input : public:string -> Yojson.Safe.t -> Yojson.Safe.t
 val receipt_labels_json : t -> Yojson.Safe.t
 val route_evidence_json : t -> Yojson.Safe.t
+
+(** Read-only discovery projection for capability introspection surfaces.
+    Keeps executor, policy, schema-shape, and curated typed examples attached
+    to the descriptor that owns the runtime route. *)
+val discovery_json : t -> Yojson.Safe.t

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -766,10 +766,13 @@ let descriptor_discovery_json active_name_set descriptor =
     `Assoc
       (fields
        @ [ ( "active_names"
-           , Json_util.json_string_list
-               (descriptor_active_names active_name_set descriptor) )
-         ])
-  | _ -> invalid_arg "Keeper_tool_descriptor.discovery_json must return an object"
+         , Json_util.json_string_list
+             (descriptor_active_names active_name_set descriptor) )
+       ])
+  | _ ->
+    (* [discovery_json] is specified as an object projection; this branch is an
+       internal invariant breach, not user input. *)
+    assert false
 ;;
 
 let keeper_tools_list_json ~(meta : keeper_meta) =

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -751,6 +751,30 @@ let tag_dispatch_fn
   ref (fun ~config:_ ~agent_name:_ ~tag:_ ~name:_ ~args:_ -> None)
 ;;
 
+let json_string_list values =
+  `List (List.map (fun value -> `String value) values)
+;;
+
+let append_assoc_field key value = function
+  | `Assoc fields -> `Assoc (fields @ [ key, value ])
+  | json -> json
+;;
+
+let descriptor_active_names names descriptor =
+  let descriptor_names =
+    Keeper_tool_descriptor.public_names_of_descriptor descriptor
+    @ Keeper_tool_descriptor.internal_names descriptor
+  in
+  List.filter (fun name -> List.mem name names) descriptor_names
+;;
+
+let descriptor_discovery_json names descriptor =
+  Keeper_tool_descriptor.discovery_json descriptor
+  |> append_assoc_field
+       "active_names"
+       (json_string_list (descriptor_active_names names descriptor))
+;;
+
 let keeper_tools_list_json ~(meta : keeper_meta) =
   let names = Keeper_tool_policy.keeper_allowed_tool_names meta in
   let has_prefix prefix name = String.starts_with ~prefix name in
@@ -784,5 +808,10 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
       map
       []
   in
-  Yojson.Safe.to_string (`Assoc assoc)
+  let descriptor_surface =
+    Keeper_tool_descriptor_resolution.descriptors_for_tool_names names
+    |> List.map (descriptor_discovery_json names)
+  in
+  Yojson.Safe.to_string
+    (`Assoc (assoc @ [ "descriptor_surface", `List descriptor_surface ]))
 ;;

--- a/lib/keeper/keeper_tool_shared_runtime.ml
+++ b/lib/keeper/keeper_tool_shared_runtime.ml
@@ -3,6 +3,7 @@ open Keeper_meta_contract
 open Keeper_types_profile
 open Keeper_alerting
 module StringMap = Set_util.StringMap
+module StringSet = Set_util.StringSet
 
 let count_context_tokens (ctx : working_context) = Keeper_context_runtime.token_count ctx
 
@@ -751,32 +752,34 @@ let tag_dispatch_fn
   ref (fun ~config:_ ~agent_name:_ ~tag:_ ~name:_ ~args:_ -> None)
 ;;
 
-let json_string_list values =
-  `List (List.map (fun value -> `String value) values)
-;;
-
-let append_assoc_field key value = function
-  | `Assoc fields -> `Assoc (fields @ [ key, value ])
-  | json -> json
-;;
-
-let descriptor_active_names names descriptor =
+let descriptor_active_names active_name_set descriptor =
   let descriptor_names =
     Keeper_tool_descriptor.public_names_of_descriptor descriptor
     @ Keeper_tool_descriptor.internal_names descriptor
   in
-  List.filter (fun name -> List.mem name names) descriptor_names
+  List.filter (fun name -> StringSet.mem name active_name_set) descriptor_names
 ;;
 
-let descriptor_discovery_json names descriptor =
-  Keeper_tool_descriptor.discovery_json descriptor
-  |> append_assoc_field
-       "active_names"
-       (json_string_list (descriptor_active_names names descriptor))
+let descriptor_discovery_json active_name_set descriptor =
+  match Keeper_tool_descriptor.discovery_json descriptor with
+  | `Assoc fields ->
+    `Assoc
+      (fields
+       @ [ ( "active_names"
+           , Json_util.json_string_list
+               (descriptor_active_names active_name_set descriptor) )
+         ])
+  | _ -> invalid_arg "Keeper_tool_descriptor.discovery_json must return an object"
 ;;
 
 let keeper_tools_list_json ~(meta : keeper_meta) =
   let names = Keeper_tool_policy.keeper_allowed_tool_names meta in
+  let active_name_set =
+    List.fold_left
+      (fun acc name -> StringSet.add name acc)
+      StringSet.empty
+      names
+  in
   let has_prefix prefix name = String.starts_with ~prefix name in
   (* Display-only grouping for the keeper tools list. The typed [tool_group]
      classifier was deleted in the surface-cut refactor; this prefix categorizer
@@ -810,7 +813,7 @@ let keeper_tools_list_json ~(meta : keeper_meta) =
   in
   let descriptor_surface =
     Keeper_tool_descriptor_resolution.descriptors_for_tool_names names
-    |> List.map (descriptor_discovery_json names)
+    |> List.map (descriptor_discovery_json active_name_set)
   in
   Yojson.Safe.to_string
     (`Assoc (assoc @ [ "descriptor_surface", `List descriptor_surface ]))

--- a/lib/keeper/keeper_tool_shared_runtime.mli
+++ b/lib/keeper/keeper_tool_shared_runtime.mli
@@ -198,6 +198,6 @@ val with_registry_meta
   -> string
 
 (** Render the keeper-tools-list JSON envelope: tool names grouped
-    by category (board / voice / workspace / shell / fs / memory
-    / core). *)
+    by category plus descriptor_surface metadata for executor/policy/schema
+    discovery. *)
 val keeper_tools_list_json : meta:Keeper_meta_contract.keeper_meta -> string

--- a/lib/tool_input_validation.ml
+++ b/lib/tool_input_validation.ml
@@ -91,6 +91,132 @@ let schema_property_names schema =
   | _ -> []
 ;;
 
+type schema_shape =
+  { properties : string list
+  ; required : string list
+  ; one_of_required : string list list
+  ; errors : string list
+  }
+
+let validated_property_names schema =
+  match Json_util.assoc_member_opt "properties" schema with
+  | None -> [], []
+  | Some (`Assoc properties) -> List.map fst properties, []
+  | Some other ->
+    ( []
+    , [ Printf.sprintf
+          "properties: expected object, got %s"
+          (Json_util.kind_name other)
+      ] )
+;;
+
+let validated_required_names ?(path = "required") schema =
+  match Json_util.assoc_member_opt "required" schema with
+  | None -> [], []
+  | Some (`List values) ->
+    List.fold_right
+      (fun value (names, errors) ->
+         match value with
+         | `String name ->
+           let name = String.trim name in
+           if String.equal name ""
+           then
+             ( names
+             , Printf.sprintf "%s: expected non-empty string, got string" path
+               :: errors )
+           else name :: names, errors
+         | other ->
+           ( names
+           , Printf.sprintf
+               "%s: expected non-empty string, got %s"
+               path
+               (Json_util.kind_name other)
+             :: errors ))
+      values
+      ([], [])
+  | Some other ->
+    ( []
+    , [ Printf.sprintf
+          "%s: expected string array, got %s"
+          path
+          (Json_util.kind_name other)
+      ] )
+;;
+
+let validated_one_of_required_names schema =
+  match Json_util.assoc_member_opt "oneOf" schema with
+  | None -> [], []
+  | Some (`List cases) ->
+    let mapped_cases =
+      List.mapi
+        (fun index case ->
+           match case with
+           | `Assoc _ ->
+             let required, errors =
+               validated_required_names
+                 ~path:(Printf.sprintf "oneOf[%d].required" index)
+                 case
+             in
+             Some required, errors
+           | other ->
+             ( None
+             , [ Printf.sprintf
+                   "oneOf[%d]: expected object, got %s"
+                   index
+                   (Json_util.kind_name other)
+               ] ))
+        cases
+    in
+    List.fold_right
+      (fun (required, errors) (required_acc, error_acc) ->
+         ( match required with
+           | Some required -> required :: required_acc
+           | None -> required_acc )
+         , errors @ error_acc)
+      mapped_cases
+      ([], [])
+  | Some other ->
+    ( []
+    , [ Printf.sprintf
+          "oneOf: expected object array, got %s"
+          (Json_util.kind_name other)
+      ] )
+;;
+
+let schema_shape schema =
+  let properties, property_errors = validated_property_names schema in
+  let required, required_errors = validated_required_names schema in
+  let one_of_required, one_of_errors = validated_one_of_required_names schema in
+  { properties
+  ; required
+  ; one_of_required
+  ; errors = property_errors @ required_errors @ one_of_errors
+  }
+;;
+
+let schema_shape_json schema =
+  let shape = schema_shape schema in
+  let base =
+    [ "properties", Json_util.json_string_list shape.properties
+    ; "required", Json_util.json_string_list shape.required
+    ]
+  in
+  let fields =
+    if shape.one_of_required = []
+    then base
+    else
+      ( "one_of_required"
+      , `List (List.map Json_util.json_string_list shape.one_of_required) )
+      :: base
+  in
+  let fields =
+    if shape.errors = []
+    then fields
+    else ("schema_errors", Json_util.json_string_list shape.errors) :: fields
+  in
+  `Assoc fields
+;;
+
 let schema_has_property_name schema name = List.mem name (schema_property_names schema)
 
 let is_execute_typed_argv_schema schema =

--- a/lib/tool_input_validation.mli
+++ b/lib/tool_input_validation.mli
@@ -23,3 +23,19 @@ val validate_args :
   args:Yojson.Safe.t ->
   unit ->
   (Yojson.Safe.t, Tool_result.result) result
+
+type schema_shape =
+  { properties : string list
+  ; required : string list
+  ; one_of_required : string list list
+  ; errors : string list
+  }
+
+val schema_shape : Yojson.Safe.t -> schema_shape
+(** Validated JSON-schema shape projection used by dispatch diagnostics and
+    descriptor discovery. Unexpected [properties], [required], or [oneOf]
+    shapes are reported in [errors] instead of silently flattening to [[]]. *)
+
+val schema_shape_json : Yojson.Safe.t -> Yojson.Safe.t
+(** JSON form of {!schema_shape}. Omits [one_of_required] and [schema_errors]
+    when empty. *)

--- a/lib/tool_surface/tool_shard_types_schemas_base.ml
+++ b/lib/tool_surface/tool_shard_types_schemas_base.ml
@@ -142,8 +142,8 @@ let base_tools : Masc_domain.tool_schema list =
          this to answer connector content questions or channel registry questions; use \
          keeper_surface_read only for current connected-surface lane context and state \
          the limitation if a connector-wide registry is unavailable. Returns tool names \
-         organized by category. Includes the active runtime schema/descriptor surface \
-         after denylist filtering."
+         organized by category plus descriptor_surface metadata with executor, policy, \
+         schema-shape, and typed usage examples after denylist filtering."
     ; input_schema = `Assoc [ "type", `String "object"; "properties", `Assoc [] ]
     }
   ]

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -57,7 +57,13 @@ let read_file path =
   Fun.protect ~finally:(fun () -> close_in ic) @@ fun () ->
   really_input_string ic (in_channel_length ic)
 
-let make_meta ?(name = "keeper-exec-tools") ?(policy_voice_enabled = false) ?tool_access () =
+let make_meta
+      ?(name = "keeper-exec-tools")
+      ?(policy_voice_enabled = false)
+      ?tool_access
+      ?(tool_denylist = [])
+      ()
+  =
   let tool_access =
     match tool_access with
     | Some value -> value
@@ -75,6 +81,8 @@ let make_meta ?(name = "keeper-exec-tools") ?(policy_voice_enabled = false) ?too
           ("policy_voice_enabled", `Bool policy_voice_enabled);
           ( "tool_access",
             Json_util.json_string_list tool_access );
+          ( "tool_denylist",
+            Json_util.json_string_list tool_denylist );
         ])
   with
   | Ok meta -> meta
@@ -475,7 +483,7 @@ let test_keeper_tools_list_json_uses_typed_groups () =
   let list_member_contains field expected obj =
     json_list_contains expected Yojson.Safe.Util.(member field obj)
   in
-  let find_descriptor internal_name =
+  let find_descriptor_in descriptor_surface internal_name =
     match
       List.find_opt
         (fun descriptor ->
@@ -484,6 +492,12 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     with
     | Some descriptor -> descriptor
     | None -> fail ("missing descriptor_surface entry for " ^ internal_name)
+  in
+  let find_descriptor = find_descriptor_in descriptor_surface in
+  let descriptor_for_internal internal_name =
+    match KTD.descriptors_for_internal internal_name with
+    | descriptor :: _ -> descriptor
+    | [] -> fail ("missing registered descriptor for " ^ internal_name)
   in
   let execute = find_descriptor "tool_execute" in
   check string "Execute public alias" "Execute"
@@ -495,8 +509,10 @@ let test_keeper_tools_list_json_uses_typed_groups () =
   check bool "Execute active public name listed" true
     (list_member_contains "active_names" "Execute" execute);
   let policy = Yojson.Safe.Util.member "policy" execute in
-  check string "Execute policy group" "playground_write"
-    (string_member "policy_group" policy);
+  check string "Execute effect domain" "playground_write"
+    (string_member "effect_domain" policy);
+  check bool "Execute policy group omitted" true
+    (Yojson.Safe.Util.member "policy_group" policy = `Null);
   let schema_shape = Yojson.Safe.Util.member "schema_shape" execute in
   check bool "Execute schema properties include executable" true
     (list_member_contains "properties" "executable" schema_shape);
@@ -505,6 +521,17 @@ let test_keeper_tools_list_json_uses_typed_groups () =
   check bool "Execute schema has no shape errors" true
     (Yojson.Safe.Util.member "schema_errors" schema_shape = `Null);
   let examples = Yojson.Safe.Util.(member "examples" execute |> to_list) in
+  let execute_properties =
+    Yojson.Safe.Util.(member "properties" schema_shape |> to_list)
+    |> List.map Yojson.Safe.Util.to_string
+  in
+  List.iter
+    (fun example ->
+       Yojson.Safe.Util.(member "input" example |> to_assoc)
+       |> List.iter (fun (key, _) ->
+         check bool ("example input property is declared: " ^ key) true
+           (List.mem key execute_properties)))
+    examples;
   let example_with_executable executable =
     List.exists
       (fun example ->
@@ -530,16 +557,18 @@ let test_keeper_tools_list_json_uses_typed_groups () =
   check bool "non-execute descriptor omits examples field" true
     (Yojson.Safe.Util.member "examples" grep = `Null);
   let grep_policy = Yojson.Safe.Util.member "policy" grep in
-  check string "Grep policy group" "read_only"
-    (string_member "policy_group" grep_policy);
+  check string "Grep effect domain" "read_only"
+    (string_member "effect_domain" grep_policy);
+  check bool "Grep policy group omitted" true
+    (Yojson.Safe.Util.member "policy_group" grep_policy = `Null);
   check bool "Grep active internal name listed" true
     (list_member_contains "active_names" "tool_search_files" grep);
   let malformed_execute =
-    { (List.hd (KTD.descriptors_for_internal "tool_execute")) with
+    { (descriptor_for_internal "tool_execute") with
       KTD.input_schema =
         `Assoc
           [ "properties", `String "not-an-object"
-          ; "required", `List [ `String "ok"; `Int 1 ]
+          ; "required", `List [ `String "ok"; `Int 1; `String "  " ]
           ; "oneOf", `List [ `String "not-an-object"; `Assoc [ "required", `String "bad" ] ]
           ]
     }
@@ -558,6 +587,11 @@ let test_keeper_tools_list_json_uses_typed_groups () =
        "schema_errors"
        "required: expected non-empty string, got int"
        malformed_shape);
+  check bool "malformed schema surfaces whitespace required error" true
+    (list_member_contains
+       "schema_errors"
+       "required: expected non-empty string, got string"
+       malformed_shape);
   check bool "malformed schema surfaces oneOf case error" true
     (list_member_contains
        "schema_errors"
@@ -567,7 +601,60 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     (list_member_contains
        "schema_errors"
        "oneOf[1].required: expected string array, got string"
-       malformed_shape)
+       malformed_shape);
+  let one_of_execute =
+    { (descriptor_for_internal "tool_execute") with
+      KTD.input_schema =
+        `Assoc
+          [ "properties", `Assoc [ "executable", `Assoc []; "pipeline", `Assoc [] ]
+          ; "oneOf"
+          , `List
+              [ `Assoc [ "required", `List [ `String "executable" ] ]
+              ; `Assoc [ "required", `List [] ]
+              ]
+          ]
+    }
+  in
+  let one_of_shape =
+    Yojson.Safe.Util.(KTD.discovery_json one_of_execute |> member "schema_shape")
+  in
+  let one_of_required =
+    Yojson.Safe.Util.(member "one_of_required" one_of_shape |> to_list)
+  in
+  check int "oneOf shape keeps both branches" 2 (List.length one_of_required);
+  (match one_of_required with
+   | [ executable_branch; empty_branch ] ->
+     check bool "oneOf executable branch retained" true
+       (json_list_contains "executable" executable_branch);
+     check int "oneOf empty-required branch retained" 0
+       Yojson.Safe.Util.(empty_branch |> to_list |> List.length)
+   | _ -> fail "expected exactly two oneOf required branches");
+  let empty_shape =
+    Yojson.Safe.Util.(
+      KTD.discovery_json
+        { (descriptor_for_internal "tool_execute") with
+          KTD.input_schema = `Assoc []
+        }
+      |> member "schema_shape")
+  in
+  check int "empty schema has no properties" 0
+    Yojson.Safe.Util.(member "properties" empty_shape |> to_list |> List.length);
+  check int "empty schema has no required names" 0
+    Yojson.Safe.Util.(member "required" empty_shape |> to_list |> List.length);
+  check bool "empty schema has no shape errors" true
+    (Yojson.Safe.Util.member "schema_errors" empty_shape = `Null);
+  let denied_meta = make_meta ~tool_denylist:[ "tool_search_files" ] () in
+  let denied_json =
+    Yojson.Safe.from_string (KES.keeper_tools_list_json ~meta:denied_meta)
+  in
+  let denied_surface =
+    Yojson.Safe.Util.(member "descriptor_surface" denied_json |> to_list)
+  in
+  check bool "denied grep descriptor omitted from discovery surface" true
+    (List.for_all
+       (fun descriptor ->
+          not (String.equal "tool_search_files" (string_member "internal_name" descriptor)))
+       denied_surface)
 
 let test_execute_with_outcome_missing_file_is_failure () =
   with_exec_fixture "keeper_tool_dispatch_runtime_missing_file"

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 module KET = Masc.Keeper_tool_dispatch_runtime
 module KES = Masc.Keeper_tool_shared_runtime
+module KTD = Masc.Keeper_tool_descriptor
 module Workspace = Masc.Workspace
 
 let tool_ok ?(tool_name = "") message =
@@ -501,6 +502,8 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     (list_member_contains "properties" "executable" schema_shape);
   check bool "Execute schema properties include pipeline" true
     (list_member_contains "properties" "pipeline" schema_shape);
+  check bool "Execute schema has no shape errors" true
+    (Yojson.Safe.Util.member "schema_errors" schema_shape = `Null);
   let examples = Yojson.Safe.Util.(member "examples" execute |> to_list) in
   let example_with_executable executable =
     List.exists
@@ -525,7 +528,46 @@ let test_keeper_tools_list_json_uses_typed_groups () =
        examples);
   let grep = find_descriptor "tool_search_files" in
   check bool "non-execute descriptor omits examples field" true
-    (Yojson.Safe.Util.member "examples" grep = `Null)
+    (Yojson.Safe.Util.member "examples" grep = `Null);
+  let grep_policy = Yojson.Safe.Util.member "policy" grep in
+  check string "Grep policy group" "read_only"
+    (string_member "policy_group" grep_policy);
+  check bool "Grep active internal name listed" true
+    (list_member_contains "active_names" "tool_search_files" grep);
+  let malformed_execute =
+    { (List.hd (KTD.descriptors_for_internal "tool_execute")) with
+      KTD.input_schema =
+        `Assoc
+          [ "properties", `String "not-an-object"
+          ; "required", `List [ `String "ok"; `Int 1 ]
+          ; "oneOf", `List [ `String "not-an-object"; `Assoc [ "required", `String "bad" ] ]
+          ]
+    }
+  in
+  let malformed_shape =
+    Yojson.Safe.Util.(
+      KTD.discovery_json malformed_execute |> member "schema_shape")
+  in
+  check bool "malformed schema surfaces property error" true
+    (list_member_contains
+       "schema_errors"
+       "properties: expected object, got string"
+       malformed_shape);
+  check bool "malformed schema surfaces required error" true
+    (list_member_contains
+       "schema_errors"
+       "required: expected non-empty string, got int"
+       malformed_shape);
+  check bool "malformed schema surfaces oneOf case error" true
+    (list_member_contains
+       "schema_errors"
+       "oneOf[0]: expected object, got string"
+       malformed_shape);
+  check bool "malformed schema surfaces oneOf required-shape error" true
+    (list_member_contains
+       "schema_errors"
+       "oneOf[1].required: expected string array, got string"
+       malformed_shape)
 
 let test_execute_with_outcome_missing_file_is_failure () =
   with_exec_fixture "keeper_tool_dispatch_runtime_missing_file"

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -514,8 +514,18 @@ let test_keeper_tools_list_json_uses_typed_groups () =
     (example_with_executable "gh");
   check bool "Execute examples include typed git argv" true
     (example_with_executable "git");
-  check bool "Execute examples include focused test wrapper" true
-    (example_with_executable "scripts/dune-local.sh")
+  check bool "Execute examples include search argv" true
+    (example_with_executable "rg");
+  check bool "Execute examples use neutral cwd placeholders" true
+    (List.for_all
+       (fun example ->
+          String.equal
+            "<repository-root>"
+            Yojson.Safe.Util.(member "input" example |> member "cwd" |> to_string))
+       examples);
+  let grep = find_descriptor "tool_search_files" in
+  check bool "non-execute descriptor omits examples field" true
+    (Yojson.Safe.Util.member "examples" grep = `Null)
 
 let test_execute_with_outcome_missing_file_is_failure () =
   with_exec_fixture "keeper_tool_dispatch_runtime_missing_file"

--- a/test/test_keeper_tool_dispatch_runtime.ml
+++ b/test/test_keeper_tool_dispatch_runtime.ml
@@ -464,7 +464,58 @@ let test_keeper_tools_list_json_uses_typed_groups () =
   check bool "fs tool grouped" true
     (member "fs" "tool_read_file");
   check bool "memory tool grouped" true
-    (member "memory" "keeper_memory_search")
+    (member "memory" "keeper_memory_search");
+  let descriptor_surface =
+    Yojson.Safe.Util.(member "descriptor_surface" json |> to_list)
+  in
+  let string_member field obj =
+    Yojson.Safe.Util.(member field obj |> to_string)
+  in
+  let list_member_contains field expected obj =
+    json_list_contains expected Yojson.Safe.Util.(member field obj)
+  in
+  let find_descriptor internal_name =
+    match
+      List.find_opt
+        (fun descriptor ->
+           String.equal internal_name (string_member "internal_name" descriptor))
+        descriptor_surface
+    with
+    | Some descriptor -> descriptor
+    | None -> fail ("missing descriptor_surface entry for " ^ internal_name)
+  in
+  let execute = find_descriptor "tool_execute" in
+  check string "Execute public alias" "Execute"
+    (string_member "public_name" execute);
+  check string "Execute executor" "shell_ir"
+    (string_member "executor" execute);
+  check bool "Execute active internal name listed" true
+    (list_member_contains "active_names" "tool_execute" execute);
+  check bool "Execute active public name listed" true
+    (list_member_contains "active_names" "Execute" execute);
+  let policy = Yojson.Safe.Util.member "policy" execute in
+  check string "Execute policy group" "playground_write"
+    (string_member "policy_group" policy);
+  let schema_shape = Yojson.Safe.Util.member "schema_shape" execute in
+  check bool "Execute schema properties include executable" true
+    (list_member_contains "properties" "executable" schema_shape);
+  check bool "Execute schema properties include pipeline" true
+    (list_member_contains "properties" "pipeline" schema_shape);
+  let examples = Yojson.Safe.Util.(member "examples" execute |> to_list) in
+  let example_with_executable executable =
+    List.exists
+      (fun example ->
+         String.equal
+           executable
+           Yojson.Safe.Util.(member "input" example |> member "executable" |> to_string))
+      examples
+  in
+  check bool "Execute examples include typed gh argv" true
+    (example_with_executable "gh");
+  check bool "Execute examples include typed git argv" true
+    (example_with_executable "git");
+  check bool "Execute examples include focused test wrapper" true
+    (example_with_executable "scripts/dune-local.sh")
 
 let test_execute_with_outcome_missing_file_is_failure () =
   with_exec_fixture "keeper_tool_dispatch_runtime_missing_file"


### PR DESCRIPTION
## Summary
- add descriptor-owned discovery JSON for executor, backend, sandbox, policy, schema shape, and typed examples
- extend keeper_tools_list_json with descriptor_surface while preserving existing grouped tool-name keys
- cover Execute discovery metadata in the existing keeper_tools_list_json contract test

## Validation
- git diff --check origin/main..HEAD
- ocamlformat --check changed OCaml files
- ocamlc -stop-after parsing changed .ml/.mli files
- Dune build/test: CI authority for this PR; not run locally
