### PR TITLE
fix(server): align fd pressure state path env

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,37 +14,41 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 368 unique knobs across 9 modules.
+**Total**: 372 unique knobs across 9 modules.
 
-**Typed getter classification**: 41/223 tagged (`operator`: 41, `algorithm`: 0, `unclassified`: 182).
+**Typed getter classification**: 41/225 tagged (`operator`: 41, `algorithm`: 0, `unclassified`: 184).
 
-## Env_config_core (24 knobs; typed classification 1/8)
+## Env_config_core (28 knobs; typed classification 1/10)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 438 | SSOT for auth env-var names (issue 8352). |
-| `MASC_BASE_PATH` | string_literal | n/a | n/a | 284 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
-| `MASC_BASE_PATH_INPUT` | string_literal | n/a | n/a | 285 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
-| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 498 | Git commit hash override for build identity. |
+| `MASC_ADMIN_TOKEN` | string_literal | n/a | n/a | 470 | SSOT for auth env-var names (issue 8352). |
+| `MASC_BASE_PATH` | string_literal | n/a | n/a | 316 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
+| `MASC_BASE_PATH_INPUT` | string_literal | n/a | n/a | 317 | Env var names exposed as SSOT constants so out-of-process callers that read/write the variable by name (docker worker... |
+| `MASC_BUILD_GIT_COMMIT` | string_literal | n/a | n/a | 530 | Git commit hash override for build identity. |
 | `MASC_CLUSTER_NAME` | string_literal | n/a | n/a | 230 |  |
-| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 410 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_DATA_DIR` | string_literal | n/a | n/a | 423 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
-| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 492 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
-| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 457 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
-| `MASC_GOVERNANCE_LEVEL` | typed:string | unclassified | unclassified | 483 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
+| `MASC_CONFIG_DIR` | string_literal | n/a | n/a | 442 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_DATA_DIR` | string_literal | n/a | n/a | 455 | SSOT for the MASC_DATA_DIR env-var name (issue 8352). Overrides [<base_path>/data] as the root for CDAL verdicts and ... |
+| `MASC_DISABLE_HITL` | typed:bool | Security | operator | 524 | Whether to disable HITL (human-in-the-loop) approval gates. Default: false. @category Security @ops_class operator |
+| `MASC_GIT_FETCH_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 489 | [git fetch origin] is network-bound and can stall behind a slow Docker bridge or a large remote. Default 120s gives e... |
+| `MASC_GOVERNANCE_LEVEL` | typed:string | unclassified | unclassified | 515 | Governance level. Set at runtime by server_runtime_bootstrap. Valid: "production", "development", etc. Default: "prod... |
 | `MASC_HOST` | string_literal | n/a | n/a | 201 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
+| `MASC_HOST_FD_PRESSURE_POLLER_DISABLED` | typed:bool | unclassified | unclassified | 302 |  |
+| `MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 306 |  |
+| `MASC_HOST_FD_PRESSURE_STATE_FILE` | string_literal | n/a | n/a | 280 | {1 Host pressure integration} |
 | `MASC_HTTP_BASE_URL` | string_literal | n/a | n/a | 243 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 | `MASC_HTTP_PORT` | string_literal | n/a | n/a | 202 | SSOT for MASC_HOST / MASC_HTTP_PORT env-var names (issue 8352). Defined here so in-process readers and out-of-process... |
-| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 509 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
-| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 462 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 463 | SSOT for logging / observability env-var names (issue 8352). |
-| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 406 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
-| `MASC_PARSE_WARN` | typed:bool | unclassified | unclassified | 478 | Whether to log parse warnings. Default: false. |
-| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 411 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
-| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 502 | PubSub max messages per read. Default: 1000. |
-| `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 433 | Whether relay token calibration is enabled. Default: true. |
-| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 474 | Whether telemetry tracking is enabled. Default: true. |
-| `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 343 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
+| `MASC_KEEPER_DEFAULT_SANDBOX_PROFILE` | typed:string | unclassified | unclassified | 541 | Default sandbox profile for keepers. Default: "local". Set to "docker" to default all keepers to containerized execut... |
+| `MASC_LOG_LEVEL` | string_literal | n/a | n/a | 494 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_LOG_ROUTINE_LEVEL` | string_literal | n/a | n/a | 495 | SSOT for logging / observability env-var names (issue 8352). |
+| `MASC_ORCHESTRATOR_ENABLED` | string_literal | n/a | n/a | 438 | SSOT for the MASC_ORCHESTRATOR_ENABLED env-var name (issue 8352). Referenced by feature_flag_registry catalog, env_co... |
+| `MASC_PARSE_WARN` | typed:bool | unclassified | unclassified | 510 | Whether to log parse warnings. Default: false. |
+| `MASC_PERSONAS_DIR` | string_literal | n/a | n/a | 443 | SSOT for MASC_CONFIG_DIR / MASC_PERSONAS_DIR env-var names (issue 8352). Shared by snapshot catalog and docker worker... |
+| `MASC_PUBSUB_MAX_MESSAGES` | typed:int | unclassified | unclassified | 534 | PubSub max messages per read. Default: 1000. |
+| `MASC_RELAY_CALIBRATION_ENABLED` | typed:bool | unclassified | unclassified | 465 | Whether relay token calibration is enabled. Default: true. |
+| `MASC_SYSMON_PRESSURE_STATE` | string_literal | n/a | n/a | 281 | {1 Host pressure integration} |
+| `MASC_TELEMETRY_ENABLED` | typed:bool | unclassified | unclassified | 506 | Whether telemetry tracking is enabled. Default: true. |
+| `MASC_TEST_ALLOW_HOME_BASE_PATH` | string_literal | n/a | n/a | 375 | #9903: production base-path safeguard for test executables. Without this, a test whose [MASC_BASE_PATH] override fail... |
 | `MASC_URL` | string_literal | n/a | n/a | 244 | SSOT for the MASC_HTTP_BASE_URL env-var name (issue 8352). Defined here (above [masc_http_base_url]) so the constant ... |
 
 ## Env_config_governance (33 knobs; typed classification 2/23)

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -298,10 +298,15 @@ let host_fd_pressure_state_file_path () =
      | None -> default_host_fd_pressure_state_file_path)
 ;;
 
+(** Operator policy toggle for disabling host fd pressure polling.
+    @category Policies
+    @ops_class operator *)
 let host_fd_pressure_poller_disabled () =
   get_bool ~default:false host_fd_pressure_poller_disabled_env_key
-;;
 
+(** Operator timeout/interval knob for host fd pressure polling cadence.
+    @category Timeouts
+    @ops_class operator *)
 let host_fd_pressure_poll_interval_sec () =
   get_float ~default:1.0 host_fd_pressure_poll_interval_sec_env_key
   |> Float.max 0.5

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -275,6 +275,19 @@ let get_port ~default name =
       | _ -> default)
   | None -> default
 
+(** {1 Host pressure integration} *)
+
+let host_fd_pressure_state_file_env_key = "MASC_HOST_FD_PRESSURE_STATE_FILE"
+let default_host_fd_pressure_state_file_path = "/tmp/masc-host-pressure.state"
+
+let host_fd_pressure_state_file_path_opt () =
+  raw_value_opt host_fd_pressure_state_file_env_key |> trim_opt
+
+let host_fd_pressure_state_file_path () =
+  match host_fd_pressure_state_file_path_opt () with
+  | Some path -> path
+  | None -> default_host_fd_pressure_state_file_path
+
 (** {1 Core Path / Storage} *)
 
 (** Env var names exposed as SSOT constants so out-of-process callers

--- a/lib/config/env_config_core.ml
+++ b/lib/config/env_config_core.ml
@@ -278,15 +278,34 @@ let get_port ~default name =
 (** {1 Host pressure integration} *)
 
 let host_fd_pressure_state_file_env_key = "MASC_HOST_FD_PRESSURE_STATE_FILE"
+let legacy_host_fd_pressure_state_file_env_key = "MASC_SYSMON_PRESSURE_STATE"
+let host_fd_pressure_poller_disabled_env_key = "MASC_HOST_FD_PRESSURE_POLLER_DISABLED"
+let host_fd_pressure_poll_interval_sec_env_key = "MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC"
 let default_host_fd_pressure_state_file_path = "/tmp/masc-host-pressure.state"
 
 let host_fd_pressure_state_file_path_opt () =
   raw_value_opt host_fd_pressure_state_file_env_key |> trim_opt
 
+let legacy_host_fd_pressure_state_file_path_opt () =
+  raw_value_opt legacy_host_fd_pressure_state_file_env_key |> trim_opt
+
 let host_fd_pressure_state_file_path () =
   match host_fd_pressure_state_file_path_opt () with
   | Some path -> path
-  | None -> default_host_fd_pressure_state_file_path
+  | None ->
+    (match legacy_host_fd_pressure_state_file_path_opt () with
+     | Some path -> path
+     | None -> default_host_fd_pressure_state_file_path)
+;;
+
+let host_fd_pressure_poller_disabled () =
+  get_bool ~default:false host_fd_pressure_poller_disabled_env_key
+;;
+
+let host_fd_pressure_poll_interval_sec () =
+  get_float ~default:1.0 host_fd_pressure_poll_interval_sec_env_key
+  |> Float.max 0.5
+  |> Float.min 60.0
 
 (** {1 Core Path / Storage} *)
 

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -130,6 +130,13 @@ val get_port : default:int -> string -> int
     Returns [default] on missing, empty, out-of-range, or
     non-integer values. *)
 
+(** {1 Host pressure integration} *)
+
+val host_fd_pressure_state_file_env_key : string
+val default_host_fd_pressure_state_file_path : string
+val host_fd_pressure_state_file_path_opt : unit -> string option
+val host_fd_pressure_state_file_path : unit -> string
+
 (** {1 Base path / storage} *)
 
 val base_path_env_key : string

--- a/lib/config/env_config_core.mli
+++ b/lib/config/env_config_core.mli
@@ -133,9 +133,15 @@ val get_port : default:int -> string -> int
 (** {1 Host pressure integration} *)
 
 val host_fd_pressure_state_file_env_key : string
+val legacy_host_fd_pressure_state_file_env_key : string
+val host_fd_pressure_poller_disabled_env_key : string
+val host_fd_pressure_poll_interval_sec_env_key : string
 val default_host_fd_pressure_state_file_path : string
 val host_fd_pressure_state_file_path_opt : unit -> string option
+val legacy_host_fd_pressure_state_file_path_opt : unit -> string option
 val host_fd_pressure_state_file_path : unit -> string
+val host_fd_pressure_poller_disabled : unit -> bool
+val host_fd_pressure_poll_interval_sec : unit -> float
 
 (** {1 Base path / storage} *)
 

--- a/lib/core/dune
+++ b/lib/core/dune
@@ -23,6 +23,7 @@
   domain_pool_ref
   masc_runtime_events
   system_error_class
+  executable_path
   text_similarity
   string_util
   list_util

--- a/lib/dune
+++ b/lib/dune
@@ -141,7 +141,6 @@
   worker_container_types
   worker_container
   worker_container_runners
-  executable_path
   exec_shell_adapter
   ;; keeper_memory sub-modules
   keeper_memory_policy

--- a/lib/keeper_runtime/keeper_fd_pressure.ml
+++ b/lib/keeper_runtime/keeper_fd_pressure.ml
@@ -207,10 +207,9 @@ let degraded_trust_json ?now () =
    adjacent process (Apple Virtualization VM XPC under Docker Desktop)
    while masc's own [nofile] budget stays comfortable.
 
-   The out-of-process [sysmon-fd-oom-disk.sh] daemon emits a JSON state
-   file at [/tmp/masc-host-pressure.state] on WARN/CRIT thresholds; the
-   [Host_fd_pressure_poller] (PR-2) reads it on a 1s cadence and invokes
-   [engage_external].
+   The out-of-process sysmon daemon emits a JSON state file on WARN/CRIT
+   thresholds; [Host_fd_pressure_poller] (PR-2) reads the configured path on a
+   1s cadence and invokes [engage_external].
 
    Monotonic guarantee: stale [ts] produces a smaller [until_ts] than
    the current [cooldown_until], so [cas_monotonic_max] rejects it — no

--- a/lib/server/host_fd_pressure_poller.ml
+++ b/lib/server/host_fd_pressure_poller.ml
@@ -12,10 +12,49 @@
    - Parse failures and missing files are no-ops, not warnings —
      during normal operation the file is *absent* most of the time. *)
 
-let state_file_path () =
-  match Sys.getenv_opt "MASC_HOST_FD_PRESSURE_STATE_FILE" with
-  | Some s when s <> "" -> s
-  | _ -> "/tmp/masc-host-pressure.state"
+let state_file_env = "MASC_HOST_FD_PRESSURE_STATE_FILE"
+let legacy_sysmon_state_file_env = "MASC_SYSMON_PRESSURE_STATE"
+let default_state_file_path = "/tmp/masc-host-pressure.state"
+
+type state_file_source =
+  | Canonical_env
+  | Legacy_sysmon_env
+  | Default
+
+type state_file_resolution =
+  { path : string
+  ; source : state_file_source
+  ; ignored_legacy_path : string option
+  }
+
+let state_file_source_to_string = function
+  | Canonical_env -> state_file_env
+  | Legacy_sysmon_env -> legacy_sysmon_state_file_env
+  | Default -> "default"
+
+let nonempty_env getenv name =
+  match getenv name with
+  | Some value when value <> "" -> Some value
+  | _ -> None
+;;
+
+let resolve_state_file_path ~getenv =
+  match
+    ( nonempty_env getenv state_file_env
+    , nonempty_env getenv legacy_sysmon_state_file_env )
+  with
+  | Some canonical, Some legacy ->
+    { path = canonical
+    ; source = Canonical_env
+    ; ignored_legacy_path =
+        (if String.equal canonical legacy then None else Some legacy)
+    }
+  | Some canonical, None ->
+    { path = canonical; source = Canonical_env; ignored_legacy_path = None }
+  | None, Some legacy ->
+    { path = legacy; source = Legacy_sysmon_env; ignored_legacy_path = None }
+  | None, None ->
+    { path = default_state_file_path; source = Default; ignored_legacy_path = None }
 ;;
 
 let poll_interval_sec () =
@@ -174,11 +213,22 @@ let one_tick path =
 
 let start ~sw ~clock =
   Eio.Fiber.fork ~sw (fun () ->
-    let path = state_file_path () in
+    let resolution = resolve_state_file_path ~getenv:Sys.getenv_opt in
+    let path = resolution.path in
     let interval = poll_interval_sec () in
+    (match resolution.ignored_legacy_path with
+     | None -> ()
+     | Some legacy_path ->
+       Log.Server.warn
+         "host_fd_pressure_poller: ignoring %s=%s because %s=%s is set"
+         legacy_sysmon_state_file_env
+         legacy_path
+         state_file_env
+         path);
     Log.Server.info
-      "host_fd_pressure_poller: started path=%s interval=%.1fs"
+      "host_fd_pressure_poller: started path=%s source=%s interval=%.1fs"
       path
+      (state_file_source_to_string resolution.source)
       interval;
     let rec loop () =
       Eio.Time.sleep clock interval;

--- a/lib/server/host_fd_pressure_poller.ml
+++ b/lib/server/host_fd_pressure_poller.ml
@@ -14,6 +14,7 @@
 
 type state_file_source =
   | Canonical_env
+  | Legacy_env
   | Default
 
 type state_file_resolution =
@@ -23,24 +24,31 @@ type state_file_resolution =
 
 let state_file_source_to_string = function
   | Canonical_env -> Env_config_core.host_fd_pressure_state_file_env_key
+  | Legacy_env -> Env_config_core.legacy_host_fd_pressure_state_file_env_key
   | Default -> "default"
 
 let resolve_state_file_path () =
-  match Env_config_core.host_fd_pressure_state_file_path_opt () with
-  | Some path -> { path; source = Canonical_env }
-  | None ->
-    { path = Env_config_core.default_host_fd_pressure_state_file_path
-    ; source = Default
-    }
+  match
+    ( Env_config_core.host_fd_pressure_state_file_path_opt ()
+    , Env_config_core.legacy_host_fd_pressure_state_file_path_opt () )
+  with
+  | Some path, _ -> { path; source = Canonical_env }
+  | None, Some path -> { path; source = Legacy_env }
+  | None, None ->
+    { path = Env_config_core.default_host_fd_pressure_state_file_path; source = Default }
 ;;
 
-let poll_interval_sec () =
-  Env_config_core.get_float
-    ~default:1.0
-    "MASC_HOST_FD_PRESSURE_POLL_INTERVAL_SEC"
-  |> Float.max 0.5
-  |> Float.min 60.0
+let state_file_env_conflict () =
+  match
+    ( Env_config_core.host_fd_pressure_state_file_path_opt ()
+    , Env_config_core.legacy_host_fd_pressure_state_file_path_opt () )
+  with
+  | Some canonical, Some legacy when not (String.equal canonical legacy) ->
+    Some (canonical, legacy)
+  | _ -> None
 ;;
+
+let poll_interval_sec = Env_config_core.host_fd_pressure_poll_interval_sec
 
 (* iso8601 -> unix epoch seconds. sysmon emits e.g.
    "2026-05-19T22:02:26+0900". We strip the trailing tz offset and
@@ -193,6 +201,16 @@ let start ~sw ~clock =
     let resolution = resolve_state_file_path () in
     let path = resolution.path in
     let interval = poll_interval_sec () in
+    (match state_file_env_conflict () with
+     | Some (canonical, legacy) ->
+       Log.Server.warn
+         "host_fd_pressure_poller: %s=%s overrides legacy %s=%s; set the sysmon \
+          producer to the canonical env to avoid split-brain state files"
+         Env_config_core.host_fd_pressure_state_file_env_key
+         canonical
+         Env_config_core.legacy_host_fd_pressure_state_file_env_key
+         legacy
+     | None -> ());
     Log.Server.info
       "host_fd_pressure_poller: started path=%s source=%s interval=%.1fs"
       path

--- a/lib/server/host_fd_pressure_poller.ml
+++ b/lib/server/host_fd_pressure_poller.ml
@@ -12,49 +12,26 @@
    - Parse failures and missing files are no-ops, not warnings —
      during normal operation the file is *absent* most of the time. *)
 
-let state_file_env = "MASC_HOST_FD_PRESSURE_STATE_FILE"
-let legacy_sysmon_state_file_env = "MASC_SYSMON_PRESSURE_STATE"
-let default_state_file_path = "/tmp/masc-host-pressure.state"
-
 type state_file_source =
   | Canonical_env
-  | Legacy_sysmon_env
   | Default
 
 type state_file_resolution =
   { path : string
   ; source : state_file_source
-  ; ignored_legacy_path : string option
   }
 
 let state_file_source_to_string = function
-  | Canonical_env -> state_file_env
-  | Legacy_sysmon_env -> legacy_sysmon_state_file_env
+  | Canonical_env -> Env_config_core.host_fd_pressure_state_file_env_key
   | Default -> "default"
 
-let nonempty_env getenv name =
-  match getenv name with
-  | Some value when value <> "" -> Some value
-  | _ -> None
-;;
-
-let resolve_state_file_path ~getenv =
-  match
-    ( nonempty_env getenv state_file_env
-    , nonempty_env getenv legacy_sysmon_state_file_env )
-  with
-  | Some canonical, Some legacy ->
-    { path = canonical
-    ; source = Canonical_env
-    ; ignored_legacy_path =
-        (if String.equal canonical legacy then None else Some legacy)
+let resolve_state_file_path () =
+  match Env_config_core.host_fd_pressure_state_file_path_opt () with
+  | Some path -> { path; source = Canonical_env }
+  | None ->
+    { path = Env_config_core.default_host_fd_pressure_state_file_path
+    ; source = Default
     }
-  | Some canonical, None ->
-    { path = canonical; source = Canonical_env; ignored_legacy_path = None }
-  | None, Some legacy ->
-    { path = legacy; source = Legacy_sysmon_env; ignored_legacy_path = None }
-  | None, None ->
-    { path = default_state_file_path; source = Default; ignored_legacy_path = None }
 ;;
 
 let poll_interval_sec () =
@@ -213,18 +190,9 @@ let one_tick path =
 
 let start ~sw ~clock =
   Eio.Fiber.fork ~sw (fun () ->
-    let resolution = resolve_state_file_path ~getenv:Sys.getenv_opt in
+    let resolution = resolve_state_file_path () in
     let path = resolution.path in
     let interval = poll_interval_sec () in
-    (match resolution.ignored_legacy_path with
-     | None -> ()
-     | Some legacy_path ->
-       Log.Server.warn
-         "host_fd_pressure_poller: ignoring %s=%s because %s=%s is set"
-         legacy_sysmon_state_file_env
-         legacy_path
-         state_file_env
-         path);
     Log.Server.info
       "host_fd_pressure_poller: started path=%s source=%s interval=%.1fs"
       path

--- a/lib/server/host_fd_pressure_poller.mli
+++ b/lib/server/host_fd_pressure_poller.mli
@@ -5,8 +5,6 @@
     writes the configured state file (JSON one-line) on WARN/CRIT
     thresholds against [kern.maxfiles]; file absence means OK.
     [MASC_HOST_FD_PRESSURE_STATE_FILE] is the canonical path override.
-    [MASC_SYSMON_PRESSURE_STATE] remains a producer-side compatibility
-    fallback when the canonical override is absent.
 
     This module starts a single Eio fiber that stats the state file
     every 1s. On parse success + advancing [ts] it invokes
@@ -21,21 +19,16 @@
 
 type state_file_source =
   | Canonical_env
-  | Legacy_sysmon_env
   | Default
 
 type state_file_resolution =
   { path : string
   ; source : state_file_source
-  ; ignored_legacy_path : string option
   }
 
-val resolve_state_file_path :
-  getenv:(string -> string option) -> state_file_resolution
-(** Resolve the state-file path from environment lookup [getenv].
-    [MASC_HOST_FD_PRESSURE_STATE_FILE] is authoritative. The legacy
-    producer-side [MASC_SYSMON_PRESSURE_STATE] is used only when the
-    canonical env is absent. *)
+val resolve_state_file_path : unit -> state_file_resolution
+(** Resolve the state-file path via
+    {!Env_config_core.host_fd_pressure_state_file_path}. *)
 
 val start : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit
 (** [start ~sw ~clock] forks the poller fiber under [sw]. Wired from

--- a/lib/server/host_fd_pressure_poller.mli
+++ b/lib/server/host_fd_pressure_poller.mli
@@ -5,8 +5,10 @@
     writes the configured state file (JSON one-line) on WARN/CRIT
     thresholds against [kern.maxfiles]; file absence means OK.
     [MASC_HOST_FD_PRESSURE_STATE_FILE] is the canonical path override.
+    [MASC_SYSMON_PRESSURE_STATE] remains a compatibility fallback when the
+    canonical env is absent.
 
-    This module starts a single Eio fiber that stats the state file
+    This module starts a single Eio fiber that reads the state file
     every 1s. On parse success + advancing [ts] it invokes
     [Keeper_fd_pressure.engage_external] with the matching level.
 
@@ -19,6 +21,7 @@
 
 type state_file_source =
   | Canonical_env
+  | Legacy_env
   | Default
 
 type state_file_resolution =
@@ -29,6 +32,9 @@ type state_file_resolution =
 val resolve_state_file_path : unit -> state_file_resolution
 (** Resolve the state-file path via
     {!Env_config_core.host_fd_pressure_state_file_path}. *)
+
+val state_file_env_conflict : unit -> (string * string) option
+(** [Some (canonical, legacy)] when both env vars are set to different paths. *)
 
 val start : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit
 (** [start ~sw ~clock] forks the poller fiber under [sw]. Wired from

--- a/lib/server/host_fd_pressure_poller.mli
+++ b/lib/server/host_fd_pressure_poller.mli
@@ -1,9 +1,12 @@
 (** Host_fd_pressure_poller — bridges out-of-process host FD pressure
     signal into [Keeper_fd_pressure.engage_external]. (RFC-0137 PR-2)
 
-    The companion [sysmon-fd-oom-disk.sh] daemon atomically writes
-    [/tmp/masc-host-pressure.state] (JSON one-line) on WARN/CRIT
+    The companion [scripts/monitor-system-health.sh] daemon atomically
+    writes the configured state file (JSON one-line) on WARN/CRIT
     thresholds against [kern.maxfiles]; file absence means OK.
+    [MASC_HOST_FD_PRESSURE_STATE_FILE] is the canonical path override.
+    [MASC_SYSMON_PRESSURE_STATE] remains a producer-side compatibility
+    fallback when the canonical override is absent.
 
     This module starts a single Eio fiber that stats the state file
     every 1s. On parse success + advancing [ts] it invokes
@@ -16,8 +19,25 @@
     Failure modes: malformed JSON, partial writes, missing file,
     stat(2) errors — all no-ops. Single throttled WARN log per hour. *)
 
+type state_file_source =
+  | Canonical_env
+  | Legacy_sysmon_env
+  | Default
+
+type state_file_resolution =
+  { path : string
+  ; source : state_file_source
+  ; ignored_legacy_path : string option
+  }
+
+val resolve_state_file_path :
+  getenv:(string -> string option) -> state_file_resolution
+(** Resolve the state-file path from environment lookup [getenv].
+    [MASC_HOST_FD_PRESSURE_STATE_FILE] is authoritative. The legacy
+    producer-side [MASC_SYSMON_PRESSURE_STATE] is used only when the
+    canonical env is absent. *)
+
 val start : sw:Eio.Switch.t -> clock:_ Eio.Time.clock -> unit
 (** [start ~sw ~clock] forks the poller fiber under [sw]. Wired from
     [Server_bootstrap_loops.start_background_maintenance]. Cancelled
     when [sw] terminates. *)
-

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -110,11 +110,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      before kern.maxfiles exhaustion can panic the kernel. Disable via
      [MASC_HOST_FD_PRESSURE_POLLER_DISABLED=1]. Sunsets when RFC-0097
      (sandbox container reuse) reaches steady state — see RFC-0137 §9. *)
-  let poller_disabled =
-    match Sys.getenv_opt "MASC_HOST_FD_PRESSURE_POLLER_DISABLED" with
-    | Some ("1" | "true" | "TRUE") -> true
-    | _ -> false
-  in
+  let poller_disabled = Env_config_core.host_fd_pressure_poller_disabled () in
   if not poller_disabled then Host_fd_pressure_poller.start ~sw ~clock;
   (* Deterministic output budget enforcement: truncate oversized tool outputs
      with structured metadata before metrics/OTEL hooks see them. *)

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -104,8 +104,8 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
     ~on_error:(log_server_fiber_crash "metrics_flush")
     (fun () -> Metrics_store_eio.start_flush_fiber ~clock);
   Shutdown.register ~name:"metrics_flush" ~priority:30 Metrics_store_eio.flush_pending;
-  (* RFC-0137 PR-2: host FD pressure poller. Watches sysmon's pressure state
-     file at /tmp/masc-host-pressure.state every 1s; bridges WARN/CRIT into
+  (* RFC-0137 PR-2: host FD pressure poller. Watches sysmon's configured
+     pressure state file every 1s; bridges WARN/CRIT into
      [Keeper_fd_pressure.engage_external] so the keeper scheduling gates pause
      before kern.maxfiles exhaustion can panic the kernel. Disable via
      [MASC_HOST_FD_PRESSURE_POLLER_DISABLED=1]. Sunsets when RFC-0097

--- a/scripts/monitor-system-health.sh
+++ b/scripts/monitor-system-health.sh
@@ -40,7 +40,7 @@ ALERT_COOLDOWN="${MASC_SYSMON_ALERT_COOLDOWN:-300}"
 # Pressure flag file. masc server (future) is expected to poll this
 # and engage Keeper_fd_pressure when level=CRIT. We always rewrite it
 # atomically so a reader sees a consistent snapshot.
-PRESSURE_STATE_FILE="${MASC_HOST_FD_PRESSURE_STATE_FILE:-/tmp/masc-host-pressure.state}"
+PRESSURE_STATE_FILE="${MASC_HOST_FD_PRESSURE_STATE_FILE:-${MASC_SYSMON_PRESSURE_STATE:-/tmp/masc-host-pressure.state}}"
 PRESSURE_EVENTS_FILE="${MASC_SYSMON_PRESSURE_EVENTS:-/tmp/masc-host-pressure.events.jsonl}"
 
 usage() {

--- a/scripts/monitor-system-health.sh
+++ b/scripts/monitor-system-health.sh
@@ -40,7 +40,7 @@ ALERT_COOLDOWN="${MASC_SYSMON_ALERT_COOLDOWN:-300}"
 # Pressure flag file. masc server (future) is expected to poll this
 # and engage Keeper_fd_pressure when level=CRIT. We always rewrite it
 # atomically so a reader sees a consistent snapshot.
-PRESSURE_STATE_FILE="${MASC_HOST_FD_PRESSURE_STATE_FILE:-${MASC_SYSMON_PRESSURE_STATE:-/tmp/masc-host-pressure.state}}"
+PRESSURE_STATE_FILE="${MASC_HOST_FD_PRESSURE_STATE_FILE:-/tmp/masc-host-pressure.state}"
 PRESSURE_EVENTS_FILE="${MASC_SYSMON_PRESSURE_EVENTS:-/tmp/masc-host-pressure.events.jsonl}"
 
 usage() {
@@ -73,8 +73,7 @@ Pressure flag (for masc server integration, future):
   /tmp/masc-host-pressure.state    latest snapshot when level != OK;
                                    removed when system is OK.
   /tmp/masc-host-pressure.events.jsonl  append-only history.
-  Override state path via MASC_HOST_FD_PRESSURE_STATE_FILE
-  (preferred) or MASC_SYSMON_PRESSURE_STATE (compatibility).
+  Override state path via MASC_HOST_FD_PRESSURE_STATE_FILE.
   Override events path via MASC_SYSMON_PRESSURE_EVENTS.
   Reader contract: parse JSON line for level/kinds/summary/ts/pid.
   Server polls this file (e.g. once per second) and invokes

--- a/scripts/monitor-system-health.sh
+++ b/scripts/monitor-system-health.sh
@@ -40,7 +40,7 @@ ALERT_COOLDOWN="${MASC_SYSMON_ALERT_COOLDOWN:-300}"
 # Pressure flag file. masc server (future) is expected to poll this
 # and engage Keeper_fd_pressure when level=CRIT. We always rewrite it
 # atomically so a reader sees a consistent snapshot.
-PRESSURE_STATE_FILE="${MASC_SYSMON_PRESSURE_STATE:-/tmp/masc-host-pressure.state}"
+PRESSURE_STATE_FILE="${MASC_HOST_FD_PRESSURE_STATE_FILE:-${MASC_SYSMON_PRESSURE_STATE:-/tmp/masc-host-pressure.state}}"
 PRESSURE_EVENTS_FILE="${MASC_SYSMON_PRESSURE_EVENTS:-/tmp/masc-host-pressure.events.jsonl}"
 
 usage() {
@@ -73,7 +73,9 @@ Pressure flag (for masc server integration, future):
   /tmp/masc-host-pressure.state    latest snapshot when level != OK;
                                    removed when system is OK.
   /tmp/masc-host-pressure.events.jsonl  append-only history.
-  Override paths via MASC_SYSMON_PRESSURE_STATE / MASC_SYSMON_PRESSURE_EVENTS.
+  Override state path via MASC_HOST_FD_PRESSURE_STATE_FILE
+  (preferred) or MASC_SYSMON_PRESSURE_STATE (compatibility).
+  Override events path via MASC_SYSMON_PRESSURE_EVENTS.
   Reader contract: parse JSON line for level/kinds/summary/ts/pid.
   Server polls this file (e.g. once per second) and invokes
   Keeper_fd_pressure.engage when level=CRIT. Wiring is RFC-pending

--- a/test/dune
+++ b/test/dune
@@ -73,6 +73,7 @@
   test_session_lifecycle_event
   test_fd_accountant
   test_fd_accountant_state
+  test_host_fd_pressure_poller
   test_operator_control_snapshot_state
   test_operator_control_snapshot
   test_with_cleanups_on_release
@@ -389,6 +390,7 @@
   test_session_lifecycle_event
   test_fd_accountant
   test_fd_accountant_state
+  test_host_fd_pressure_poller
   test_operator_control_snapshot_state
   test_operator_control_snapshot
   test_operator_control_support

--- a/test/test_host_fd_pressure_poller.ml
+++ b/test/test_host_fd_pressure_poller.ml
@@ -1,0 +1,76 @@
+open Alcotest
+
+module Poller = Host_fd_pressure_poller
+
+let canonical_env = "MASC_HOST_FD_PRESSURE_STATE_FILE"
+let legacy_env = "MASC_SYSMON_PRESSURE_STATE"
+let default_path = "/tmp/masc-host-pressure.state"
+
+let getenv bindings name =
+  match List.assoc_opt name bindings with
+  | Some value -> value
+  | None -> None
+;;
+
+let check_resolution label expected_path expected_source expected_ignored bindings =
+  let actual = Poller.resolve_state_file_path ~getenv:(getenv bindings) in
+  check string (label ^ " path") expected_path actual.path;
+  check bool (label ^ " source") true (actual.source = expected_source);
+  check (option string) (label ^ " ignored") expected_ignored actual.ignored_legacy_path
+
+let test_default_path () =
+  check_resolution
+    "default"
+    default_path
+    Poller.Default
+    None
+    []
+
+let test_canonical_env_wins () =
+  check_resolution
+    "canonical"
+    "/var/run/masc/fd-pressure.json"
+    Poller.Canonical_env
+    None
+    [ canonical_env, Some "/var/run/masc/fd-pressure.json" ]
+
+let test_legacy_env_fallback () =
+  check_resolution
+    "legacy"
+    "/tmp/sysmon-pressure.json"
+    Poller.Legacy_sysmon_env
+    None
+    [ legacy_env, Some "/tmp/sysmon-pressure.json" ]
+
+let test_canonical_conflict_reports_ignored_legacy () =
+  check_resolution
+    "conflict"
+    "/var/run/masc/fd-pressure.json"
+    Poller.Canonical_env
+    (Some "/tmp/sysmon-pressure.json")
+    [ canonical_env, Some "/var/run/masc/fd-pressure.json"
+    ; legacy_env, Some "/tmp/sysmon-pressure.json"
+    ]
+
+let test_empty_env_is_absent () =
+  check_resolution
+    "empty"
+    default_path
+    Poller.Default
+    None
+    [ canonical_env, Some ""; legacy_env, Some "" ]
+
+let () =
+  run
+    "Host_fd_pressure_poller"
+    [ ( "state path"
+      , [ test_case "default path" `Quick test_default_path
+        ; test_case "canonical env wins" `Quick test_canonical_env_wins
+        ; test_case "legacy env fallback" `Quick test_legacy_env_fallback
+        ; test_case
+            "canonical conflict reports ignored legacy"
+            `Quick
+            test_canonical_conflict_reports_ignored_legacy
+        ; test_case "empty env is absent" `Quick test_empty_env_is_absent
+        ] )
+    ]

--- a/test/test_host_fd_pressure_poller.ml
+++ b/test/test_host_fd_pressure_poller.ml
@@ -2,63 +2,55 @@ open Alcotest
 
 module Poller = Host_fd_pressure_poller
 
-let canonical_env = "MASC_HOST_FD_PRESSURE_STATE_FILE"
+external unsetenv : string -> unit = "masc_test_unsetenv"
+
+let canonical_env = Env_config_core.host_fd_pressure_state_file_env_key
 let legacy_env = "MASC_SYSMON_PRESSURE_STATE"
-let default_path = "/tmp/masc-host-pressure.state"
+let default_path = Env_config_core.default_host_fd_pressure_state_file_path
 
-let getenv bindings name =
-  match List.assoc_opt name bindings with
-  | Some value -> value
-  | None -> None
-;;
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> unsetenv name
 
-let check_resolution label expected_path expected_source expected_ignored bindings =
-  let actual = Poller.resolve_state_file_path ~getenv:(getenv bindings) in
+let with_env bindings f =
+  let names = List.map fst bindings in
+  let original = List.map (fun name -> name, Sys.getenv_opt name) names in
+  List.iter
+    (fun (name, value) ->
+      match value with
+      | Some value -> Unix.putenv name value
+      | None -> unsetenv name)
+    bindings;
+  Fun.protect f ~finally:(fun () ->
+    List.iter (fun (name, value) -> restore_env name value) original)
+
+let check_resolution label expected_path expected_source =
+  let actual = Poller.resolve_state_file_path () in
   check string (label ^ " path") expected_path actual.path;
-  check bool (label ^ " source") true (actual.source = expected_source);
-  check (option string) (label ^ " ignored") expected_ignored actual.ignored_legacy_path
+  check bool (label ^ " source") true (actual.source = expected_source)
 
 let test_default_path () =
-  check_resolution
-    "default"
-    default_path
-    Poller.Default
-    None
-    []
+  with_env [ canonical_env, None; legacy_env, None ] (fun () ->
+    check_resolution "default" default_path Poller.Default)
 
 let test_canonical_env_wins () =
-  check_resolution
-    "canonical"
-    "/var/run/masc/fd-pressure.json"
-    Poller.Canonical_env
-    None
-    [ canonical_env, Some "/var/run/masc/fd-pressure.json" ]
-
-let test_legacy_env_fallback () =
-  check_resolution
-    "legacy"
-    "/tmp/sysmon-pressure.json"
-    Poller.Legacy_sysmon_env
-    None
-    [ legacy_env, Some "/tmp/sysmon-pressure.json" ]
-
-let test_canonical_conflict_reports_ignored_legacy () =
-  check_resolution
-    "conflict"
-    "/var/run/masc/fd-pressure.json"
-    Poller.Canonical_env
-    (Some "/tmp/sysmon-pressure.json")
+  with_env
     [ canonical_env, Some "/var/run/masc/fd-pressure.json"
     ; legacy_env, Some "/tmp/sysmon-pressure.json"
     ]
+    (fun () ->
+      check_resolution
+        "canonical"
+        "/var/run/masc/fd-pressure.json"
+        Poller.Canonical_env)
+
+let test_legacy_env_is_ignored () =
+  with_env [ canonical_env, None; legacy_env, Some "/tmp/sysmon-pressure.json" ] (fun () ->
+    check_resolution "legacy ignored" default_path Poller.Default)
 
 let test_empty_env_is_absent () =
-  check_resolution
-    "empty"
-    default_path
-    Poller.Default
-    None
-    [ canonical_env, Some ""; legacy_env, Some "" ]
+  with_env [ canonical_env, Some ""; legacy_env, Some "" ] (fun () ->
+    check_resolution "empty" default_path Poller.Default)
 
 let () =
   run
@@ -66,11 +58,7 @@ let () =
     [ ( "state path"
       , [ test_case "default path" `Quick test_default_path
         ; test_case "canonical env wins" `Quick test_canonical_env_wins
-        ; test_case "legacy env fallback" `Quick test_legacy_env_fallback
-        ; test_case
-            "canonical conflict reports ignored legacy"
-            `Quick
-            test_canonical_conflict_reports_ignored_legacy
+        ; test_case "legacy env is ignored" `Quick test_legacy_env_is_ignored
         ; test_case "empty env is absent" `Quick test_empty_env_is_absent
         ] )
     ]

--- a/test/test_host_fd_pressure_poller.ml
+++ b/test/test_host_fd_pressure_poller.ml
@@ -5,7 +5,7 @@ module Poller = Host_fd_pressure_poller
 external unsetenv : string -> unit = "masc_test_unsetenv"
 
 let canonical_env = Env_config_core.host_fd_pressure_state_file_env_key
-let legacy_env = "MASC_SYSMON_PRESSURE_STATE"
+let legacy_env = Env_config_core.legacy_host_fd_pressure_state_file_env_key
 let default_path = Env_config_core.default_host_fd_pressure_state_file_path
 
 let restore_env name = function
@@ -46,7 +46,23 @@ let test_canonical_env_wins () =
 
 let test_legacy_env_is_ignored () =
   with_env [ canonical_env, None; legacy_env, Some "/tmp/sysmon-pressure.json" ] (fun () ->
-    check_resolution "legacy ignored" default_path Poller.Default)
+    check_resolution "legacy" "/tmp/sysmon-pressure.json" Poller.Legacy_env)
+
+let test_conflicting_envs_are_detected () =
+  with_env
+    [ canonical_env, Some "/var/run/masc/fd-pressure.json"
+    ; legacy_env, Some "/tmp/sysmon-pressure.json"
+    ]
+    (fun () ->
+      check_resolution
+        "canonical conflict"
+        "/var/run/masc/fd-pressure.json"
+        Poller.Canonical_env;
+      check
+        (option (pair string string))
+        "conflict"
+        (Some ("/var/run/masc/fd-pressure.json", "/tmp/sysmon-pressure.json"))
+        (Poller.state_file_env_conflict ()))
 
 let test_empty_env_is_absent () =
   with_env [ canonical_env, Some ""; legacy_env, Some "" ] (fun () ->
@@ -58,7 +74,11 @@ let () =
     [ ( "state path"
       , [ test_case "default path" `Quick test_default_path
         ; test_case "canonical env wins" `Quick test_canonical_env_wins
-        ; test_case "legacy env is ignored" `Quick test_legacy_env_is_ignored
+        ; test_case "legacy env falls back" `Quick test_legacy_env_is_ignored
+        ; test_case
+            "conflicting envs are detected"
+            `Quick
+            test_conflicting_envs_are_detected
         ; test_case "empty env is absent" `Quick test_empty_env_is_absent
         ] )
     ]


### PR DESCRIPTION
## Summary

- make `MASC_HOST_FD_PRESSURE_STATE_FILE` the canonical host FD pressure state-file override
- keep `MASC_SYSMON_PRESSURE_STATE` as a compatibility fallback when the canonical env is absent
- log a startup warning when both are set to different paths, instead of silently reading a different file from the sysmon producer
- update sysmon script/docs/comments to use the same state-file path contract
- add focused resolver tests for canonical, legacy, default, conflict, and empty-env cases

## Why

The producer script and the OCaml poller previously used different override names for the same state file. Setting only `MASC_SYSMON_PRESSURE_STATE` moved the producer but left the poller on `/tmp/masc-host-pressure.state`; setting both differently created a silent split-brain path.

## Verification

- `ocamlformat --check lib/server/host_fd_pressure_poller.ml lib/server/host_fd_pressure_poller.mli lib/server/server_bootstrap_maintenance.ml lib/keeper_runtime/keeper_fd_pressure.ml test/test_host_fd_pressure_poller.ml`
- `git diff --check`
- `bash -n scripts/monitor-system-health.sh`

Full build/test is intentionally left to CI per repo workflow.
