### PR TITLE
fix(memory): reject embedded librarian JSON

### DIFF
--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -90,11 +90,7 @@ let optional_string_field key fields =
 let int_field key fields =
   match List.assoc_opt key fields with
   | Some (`Int i) -> Some i
-  | Some (`String s) ->
-    (match int_of_string_opt (String.trim s) with
-     | Some i when i >= 0 -> Some i
-     | Some _ | None -> None)
-  | Some (`Assoc _ | `Bool _ | `Float _ | `Intlit _ | `List _ | `Null)
+  | Some (`Assoc _ | `Bool _ | `Float _ | `Intlit _ | `List _ | `Null | `String _)
   | None -> None
 ;;
 
@@ -119,52 +115,39 @@ let string_list_field_or_empty key fields =
   | Some _ -> string_list_field key fields
 ;;
 
+type parse_error =
+  | Empty_output
+  | Invalid_json of string
+  | Json_string_invalid_json of string
+  | Top_level_not_object
+  | Missing_required_fields
+  | Claim_schema_mismatch
+
+let parse_error_to_string = function
+  | Empty_output -> "empty_output"
+  | Invalid_json msg -> "invalid_json: " ^ msg
+  | Json_string_invalid_json msg -> "json_string_invalid_json: " ^ msg
+  | Top_level_not_object -> "top_level_not_object"
+  | Missing_required_fields -> "missing_required_fields"
+  | Claim_schema_mismatch -> "claim_schema_mismatch"
+;;
+
 let json_of_output raw =
   let raw = String.trim raw in
-  let try_parse s =
-    try Some (Yojson.Safe.from_string (String.trim s)) with
-    | Yojson.Json_error _ -> None
-  in
-  let unwrap_string json =
-    match json with
-    | `String inner -> try_parse inner
-    | _ -> None
-  in
-  let whole_markdown_fence_body s =
-    let lines = String.split_on_char '\n' s in
-    let is_blank line = String.equal (String.trim line) "" in
-    let is_fence line = String.starts_with ~prefix:"```" (String.trim line) in
-    let rec drop_blanks = function
-      | line :: rest when is_blank line -> drop_blanks rest
-      | lines -> lines
+  if String.equal raw ""
+  then Error Empty_output
+  else
+    let try_parse ~on_error s =
+      try Ok (Yojson.Safe.from_string (String.trim s)) with
+      | Yojson.Json_error msg -> Error (on_error msg)
     in
-    let rec rev_drop_blanks = function
-      | line :: rest when is_blank line -> rev_drop_blanks rest
-      | lines -> lines
-    in
-    match drop_blanks lines |> List.rev |> rev_drop_blanks |> List.rev with
-    | open_line :: body_rev when is_fence open_line ->
-      (match List.rev body_rev with
-       | close_line :: body_lines_rev when is_fence close_line ->
-         Some (String.concat "\n" (List.rev body_lines_rev) |> String.trim)
-       | [] | _ :: _ -> None)
-    | [] | _ :: _ -> None
-  in
-  let candidates =
-    match whole_markdown_fence_body raw with
-    | None -> [ raw ]
-    | Some fenced -> [ raw; fenced ]
-  in
-  List.find_map
-    (fun candidate ->
-       if String.equal candidate ""
-       then None
-       else
-         Option.bind (try_parse candidate) (fun json ->
-           match unwrap_string json with
-           | Some inner -> Some inner
-           | None -> Some json))
-    candidates
+    match try_parse raw ~on_error:(fun msg -> Invalid_json msg) with
+    | Error _ as error -> error
+    | Ok (`String inner) ->
+      if String.equal (String.trim inner) ""
+      then Error (Json_string_invalid_json "empty JSON string")
+      else try_parse inner ~on_error:(fun msg -> Json_string_invalid_json msg)
+    | Ok json -> Ok json
 ;;
 
 let claim_source ~trace_id turn tool_call_id =
@@ -237,7 +220,9 @@ let source_turn_range claims =
     Some (lo, hi)
 ;;
 
-let episode_of_output ?now ~generation (inp : input) (raw : string) : episode option =
+let episode_of_output_result ?now ~generation (inp : input) (raw : string) :
+  (episode, parse_error) result
+  =
   let now =
     match now with
     | Some now -> now
@@ -246,12 +231,8 @@ let episode_of_output ?now ~generation (inp : input) (raw : string) : episode op
       Unix.gettimeofday ()
   in
   match json_of_output raw with
-  | None ->
-    Log.Keeper.debug
-      "librarian episode parse failed: not valid JSON (raw: %s)"
-      (truncate_for_log 800 raw);
-    None
-  | Some json ->
+  | Error _ as error -> error
+  | Ok json ->
     (match json with
     | `Assoc fields ->
       (match
@@ -282,19 +263,19 @@ let episode_of_output ?now ~generation (inp : input) (raw : string) : episode op
               ; terminal_marker = None
               ; schema_version
               }
-          | None ->
-            Log.Keeper.debug
-              "librarian episode parse failed: claim objects did not match schema (raw: %s)"
-              (truncate_for_log 800 raw);
-            None)
-       | _ ->
-         Log.Keeper.debug
-           "librarian episode parse failed: JSON object missing required fields (raw: %s)"
-           (truncate_for_log 800 raw);
-         None)
+          | None -> Error Claim_schema_mismatch)
+       | _ -> Error Missing_required_fields)
     | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
-      Log.Keeper.debug
-        "librarian episode parse failed: top-level JSON is not an object (raw: %s)"
-        (truncate_for_log 800 raw);
-      None)
+      Error Top_level_not_object)
+;;
+
+let episode_of_output ?now ~generation inp raw : episode option =
+  match episode_of_output_result ?now ~generation inp raw with
+  | Ok episode -> Some episode
+  | Error error ->
+    Log.Keeper.debug
+      "librarian episode parse failed: %s (raw: %s)"
+      (parse_error_to_string error)
+      (truncate_for_log 800 raw);
+    None
 ;;

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -249,7 +249,7 @@ let episode_of_output_result ?now ~generation (inp : input) (raw : string) :
          , Some preserved_tool_refs ) ->
          (match traverse (fact_of_json ~trace_id:inp.trace_id ~now) claim_items with
           | Some claims ->
-            Some
+            Ok
               { trace_id = inp.trace_id
               ; generation
               ; episode_summary

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -19,6 +19,7 @@ let wire_field_source_turn = "source_turn"
 let wire_field_source_tool_call_id = "source_tool_call_id"
 let wire_field_claim_id = "claim_id"
 let wire_field_claim_kind = "claim_kind"
+let wire_field_schema_version = "schema_version"
 
 let wire_episode_fields =
   [ wire_field_episode_summary
@@ -38,6 +39,8 @@ let wire_claim_fields =
   ; wire_field_claim_kind
   ]
 ;;
+
+let accepted_episode_fields = wire_field_schema_version :: wire_episode_fields
 
 let trim_nonempty s =
   let s = String.trim s in
@@ -146,11 +149,23 @@ let string_list_field_or_empty key fields =
   | Some _ -> string_list_field key fields
 ;;
 
+let field_allowed ~allowed field =
+  List.exists (String.equal field) allowed
+;;
+
+let first_unexpected_field ~allowed fields =
+  List.find_map
+    (fun (field, _) ->
+       if field_allowed ~allowed field then None else Some field)
+    fields
+;;
+
 type parse_error =
   | Empty_output
   | Invalid_json of string
   | Json_string_invalid_json of string
   | Top_level_not_object
+  | Unexpected_field of string
   | Missing_required_fields
   | Claim_schema_mismatch
 
@@ -159,6 +174,7 @@ let parse_error_to_string = function
   | Invalid_json msg -> "invalid_json: " ^ msg
   | Json_string_invalid_json msg -> "json_string_invalid_json: " ^ msg
   | Top_level_not_object -> "top_level_not_object"
+  | Unexpected_field field -> "unexpected_field: " ^ field
   | Missing_required_fields -> "missing_required_fields"
   | Claim_schema_mismatch -> "claim_schema_mismatch"
 ;;
@@ -251,6 +267,11 @@ let source_turn_range claims =
     Some (lo, hi)
 ;;
 
+let unexpected_claim_field = function
+  | `Assoc fields -> first_unexpected_field ~allowed:wire_claim_fields fields
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+;;
+
 let episode_of_output_result ?now ~generation (inp : input) (raw : string) :
   (episode, parse_error) result
   =
@@ -266,36 +287,42 @@ let episode_of_output_result ?now ~generation (inp : input) (raw : string) :
   | Ok json ->
     (match json with
     | `Assoc fields ->
-      (match
-         string_field wire_field_episode_summary fields
-         , List.assoc_opt wire_field_claims fields
-         , string_list_field_or_empty wire_field_open_items fields
-         , string_list_field_or_empty wire_field_constraints fields
-         , string_list_field_or_empty wire_field_preserved_tool_refs fields
-       with
-       | ( Some episode_summary
-         , Some (`List claim_items)
-         , Some open_items
-         , Some constraints
-         , Some preserved_tool_refs ) ->
-         (match traverse (fact_of_json ~trace_id:inp.trace_id ~now) claim_items with
-          | Some claims ->
-            Ok
-              { trace_id = inp.trace_id
-              ; generation
-              ; episode_summary
-              ; claims
-              ; open_items
-              ; constraints
-              ; preserved_tool_refs
-              ; source_turn_range = source_turn_range claims
-              ; created_at = now
-              ; valid_until = None
-              ; terminal_marker = None
-              ; schema_version
-              }
-          | None -> Error Claim_schema_mismatch)
-       | _ -> Error Missing_required_fields)
+      (match first_unexpected_field ~allowed:accepted_episode_fields fields with
+       | Some field -> Error (Unexpected_field field)
+       | None ->
+         (match
+            string_field wire_field_episode_summary fields
+            , List.assoc_opt wire_field_claims fields
+            , string_list_field_or_empty wire_field_open_items fields
+            , string_list_field_or_empty wire_field_constraints fields
+            , string_list_field_or_empty wire_field_preserved_tool_refs fields
+          with
+          | ( Some episode_summary
+            , Some (`List claim_items)
+            , Some open_items
+            , Some constraints
+            , Some preserved_tool_refs ) ->
+            (match List.find_map unexpected_claim_field claim_items with
+             | Some field -> Error (Unexpected_field field)
+             | None ->
+               (match traverse (fact_of_json ~trace_id:inp.trace_id ~now) claim_items with
+                | Some claims ->
+                  Ok
+                    { trace_id = inp.trace_id
+                    ; generation
+                    ; episode_summary
+                    ; claims
+                    ; open_items
+                    ; constraints
+                    ; preserved_tool_refs
+                    ; source_turn_range = source_turn_range claims
+                    ; created_at = now
+                    ; valid_until = None
+                    ; terminal_marker = None
+                    ; schema_version
+                    }
+                | None -> Error Claim_schema_mismatch))
+          | _ -> Error Missing_required_fields))
     | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
       Error Top_level_not_object)
 ;;

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -8,37 +8,20 @@ type input =
   ; messages : Agent_sdk.Types.message list
   }
 
-let wire_field_episode_summary = "episode_summary"
-let wire_field_claims = "claims"
-let wire_field_open_items = "open_items"
-let wire_field_constraints = "constraints"
-let wire_field_preserved_tool_refs = "preserved_tool_refs"
-let wire_field_claim = "claim"
-let wire_field_category = "category"
-let wire_field_source_turn = "source_turn"
-let wire_field_source_tool_call_id = "source_tool_call_id"
-let wire_field_claim_id = "claim_id"
-let wire_field_claim_kind = "claim_kind"
-let wire_field_schema_version = "schema_version"
-
-let wire_episode_fields =
-  [ wire_field_episode_summary
-  ; wire_field_claims
-  ; wire_field_open_items
-  ; wire_field_constraints
-  ; wire_field_preserved_tool_refs
-  ]
-;;
-
-let wire_claim_fields =
-  [ wire_field_claim
-  ; wire_field_category
-  ; wire_field_source_turn
-  ; wire_field_source_tool_call_id
-  ; wire_field_claim_id
-  ; wire_field_claim_kind
-  ]
-;;
+let wire_field_episode_summary = Keeper_memory_os_types.wire_field_episode_summary
+let wire_field_claims = Keeper_memory_os_types.wire_field_claims
+let wire_field_open_items = Keeper_memory_os_types.wire_field_open_items
+let wire_field_constraints = Keeper_memory_os_types.wire_field_constraints
+let wire_field_preserved_tool_refs = Keeper_memory_os_types.wire_field_preserved_tool_refs
+let wire_field_claim = Keeper_memory_os_types.wire_field_claim
+let wire_field_category = Keeper_memory_os_types.wire_field_category
+let wire_field_source_turn = Keeper_memory_os_types.wire_field_source_turn
+let wire_field_source_tool_call_id = Keeper_memory_os_types.wire_field_source_tool_call_id
+let wire_field_claim_id = Keeper_memory_os_types.wire_field_claim_id
+let wire_field_claim_kind = Keeper_memory_os_types.wire_field_claim_kind
+let wire_field_schema_version = Keeper_memory_os_types.wire_field_schema_version
+let wire_episode_fields = Keeper_memory_os_types.wire_librarian_episode_fields
+let wire_claim_fields = Keeper_memory_os_types.wire_librarian_claim_fields
 
 let accepted_episode_fields = wire_field_schema_version :: wire_episode_fields
 

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -130,69 +130,41 @@ let json_of_output raw =
     | `String inner -> try_parse inner
     | _ -> None
   in
-  let strip_markdown_fences s =
+  let whole_markdown_fence_body s =
     let lines = String.split_on_char '\n' s in
+    let is_blank line = String.equal (String.trim line) "" in
     let is_fence line = String.starts_with ~prefix:"```" (String.trim line) in
-    let rec find_open i =
-      if i >= List.length lines
-      then None
-      else if is_fence (List.nth lines i)
-      then Some i
-      else find_open (i + 1)
+    let rec drop_blanks = function
+      | line :: rest when is_blank line -> drop_blanks rest
+      | lines -> lines
     in
-    let rec find_close start i =
-      if i >= List.length lines
-      then None
-      else if i > start && is_fence (List.nth lines i)
-      then Some i
-      else find_close start (i + 1)
+    let rec rev_drop_blanks = function
+      | line :: rest when is_blank line -> rev_drop_blanks rest
+      | lines -> lines
     in
-    match find_open 0 with
-    | None -> s
-    | Some open_idx ->
-      (match find_close open_idx (open_idx + 1) with
-       | None -> s
-       | Some close_idx ->
-         let between =
-           List.filteri (fun idx _ -> idx > open_idx && idx < close_idx) lines
-         in
-         String.concat "\n" between |> String.trim)
+    match drop_blanks lines |> List.rev |> rev_drop_blanks |> List.rev with
+    | open_line :: body_rev when is_fence open_line ->
+      (match List.rev body_rev with
+       | close_line :: body_lines_rev when is_fence close_line ->
+         Some (String.concat "\n" (List.rev body_lines_rev) |> String.trim)
+       | [] | _ :: _ -> None)
+    | [] | _ :: _ -> None
   in
-  let from_parsing =
-    List.find_map
-      (fun candidate ->
-         if String.equal candidate ""
-         then None
-         else
-           Option.bind (try_parse candidate) (fun json ->
-             match unwrap_string json with
-             | Some inner -> Some inner
-             | None -> Some json))
-      [ raw; strip_markdown_fences raw ]
+  let candidates =
+    match whole_markdown_fence_body raw with
+    | None -> [ raw ]
+    | Some fenced -> [ raw; fenced ]
   in
-  match from_parsing with
-  | Some _ as result -> result
-  | None ->
-    (* Fallback: extract the first {...} substring and try to parse it. This
-       recovers from leading/trailing prose that prevented the fenced-path from
-       isolating the JSON object. *)
-    let len = String.length raw in
-    let rec find_from i ch =
-      if i >= len then None else if Char.equal raw.[i] ch then Some i else find_from (i + 1) ch
-    in
-    let rec find_from_right i ch =
-      if i < 0 then None else if Char.equal raw.[i] ch then Some i else find_from_right (i - 1) ch
-    in
-    (match find_from 0 '{', find_from_right (len - 1) '}' with
-     | Some start, Some stop when start < stop ->
-       let candidate = String.sub raw start (stop - start + 1) in
-       (match try_parse candidate with
-        | Some json ->
-          (match unwrap_string json with
+  List.find_map
+    (fun candidate ->
+       if String.equal candidate ""
+       then None
+       else
+         Option.bind (try_parse candidate) (fun json ->
+           match unwrap_string json with
            | Some inner -> Some inner
-           | None -> Some json)
-        | None -> None)
-     | _ -> None)
+           | None -> Some json))
+    candidates
 ;;
 
 let claim_source ~trace_id turn tool_call_id =

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -8,7 +8,6 @@ type input =
   ; messages : Agent_sdk.Types.message list
   }
 
-let wire_field_schema_version = "schema_version"
 let wire_field_episode_summary = "episode_summary"
 let wire_field_claims = "claims"
 let wire_field_open_items = "open_items"

--- a/lib/keeper/keeper_librarian.ml
+++ b/lib/keeper/keeper_librarian.ml
@@ -8,6 +8,38 @@ type input =
   ; messages : Agent_sdk.Types.message list
   }
 
+let wire_field_schema_version = "schema_version"
+let wire_field_episode_summary = "episode_summary"
+let wire_field_claims = "claims"
+let wire_field_open_items = "open_items"
+let wire_field_constraints = "constraints"
+let wire_field_preserved_tool_refs = "preserved_tool_refs"
+let wire_field_claim = "claim"
+let wire_field_category = "category"
+let wire_field_source_turn = "source_turn"
+let wire_field_source_tool_call_id = "source_tool_call_id"
+let wire_field_claim_id = "claim_id"
+let wire_field_claim_kind = "claim_kind"
+
+let wire_episode_fields =
+  [ wire_field_episode_summary
+  ; wire_field_claims
+  ; wire_field_open_items
+  ; wire_field_constraints
+  ; wire_field_preserved_tool_refs
+  ]
+;;
+
+let wire_claim_fields =
+  [ wire_field_claim
+  ; wire_field_category
+  ; wire_field_source_turn
+  ; wire_field_source_tool_call_id
+  ; wire_field_claim_id
+  ; wire_field_claim_kind
+  ]
+;;
+
 let trim_nonempty s =
   let s = String.trim s in
   if String.equal s "" then None else Some s
@@ -158,24 +190,24 @@ let fact_of_json ~trace_id ~now (json : Yojson.Safe.t) : fact option =
   match json with
   | `Assoc fields ->
     (match
-       string_field "claim" fields
-       , string_field "category" fields
-       , int_field "source_turn" fields
+       string_field wire_field_claim fields
+       , string_field wire_field_category fields
+       , int_field wire_field_source_turn fields
      with
      | Some claim, Some category_str, Some turn when turn >= 0 ->
-       let tool_call_id = optional_string_field "source_tool_call_id" fields in
+       let tool_call_id = optional_string_field wire_field_source_tool_call_id fields in
       (* RFC-0259 §3.7 (P6): a stable conclusion slug the model emits so a reworded
          re-extraction of the same conclusion reuses the id and UPSERTs the existing
          row (defect E/F). Pass-through only — absent => [None] (conservative
          fallback to [normalize_claim] keying); we never derive/hash an id in code,
          which would be the string-classifier workaround the RFC rejects. *)
-      let claim_id = optional_string_field "claim_id" fields in
+      let claim_id = optional_string_field wire_field_claim_id fields in
       (* RFC-0285 §3.1/§3.2(a): the producer-emitted origin tag. Pass-through only —
          the librarian LLM classifies at the live-context boundary; deriving
          claim_kind in code would be the read-time string-classifier workaround the
          RFC rejects. Absent/unrecognized => [None], routing to the durable path. *)
       let claim_kind =
-        Option.bind (optional_string_field "claim_kind" fields) claim_kind_of_string
+        Option.bind (optional_string_field wire_field_claim_kind fields) claim_kind_of_string
       in
       (* Parse-once at the producer boundary: the LLM's free-text category becomes
          a typed [category] here, so no surface string reaches the store or the
@@ -236,11 +268,11 @@ let episode_of_output_result ?now ~generation (inp : input) (raw : string) :
     (match json with
     | `Assoc fields ->
       (match
-         string_field "episode_summary" fields
-         , List.assoc_opt "claims" fields
-         , string_list_field_or_empty "open_items" fields
-         , string_list_field_or_empty "constraints" fields
-         , string_list_field_or_empty "preserved_tool_refs" fields
+         string_field wire_field_episode_summary fields
+         , List.assoc_opt wire_field_claims fields
+         , string_list_field_or_empty wire_field_open_items fields
+         , string_list_field_or_empty wire_field_constraints fields
+         , string_list_field_or_empty wire_field_preserved_tool_refs fields
        with
        | ( Some episode_summary
          , Some (`List claim_items)

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -41,6 +41,7 @@ type parse_error =
   | Invalid_json of string
   | Json_string_invalid_json of string
   | Top_level_not_object
+  | Unexpected_field of string
   | Missing_required_fields
   | Claim_schema_mismatch
 

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -12,6 +12,27 @@ type input =
   ; messages : Agent_sdk.Types.message list
   }
 
+val wire_field_schema_version : string
+val wire_field_episode_summary : string
+val wire_field_claims : string
+val wire_field_open_items : string
+val wire_field_constraints : string
+val wire_field_preserved_tool_refs : string
+val wire_field_claim : string
+val wire_field_category : string
+val wire_field_source_turn : string
+val wire_field_source_tool_call_id : string
+val wire_field_claim_id : string
+val wire_field_claim_kind : string
+
+val wire_episode_fields : string list
+(** Canonical episode-object wire field names accepted by the parser and used by
+    retry prompt rendering. *)
+
+val wire_claim_fields : string list
+(** Canonical claim-object wire field names accepted by the parser and used by
+    retry prompt rendering. *)
+
 (** Prompt variables for [keeper.librarian.episode_extraction]. *)
 val prompt_variables : input -> (string * string) list
 
@@ -33,8 +54,10 @@ val parse_error_to_string : parse_error -> string
     - exact JSON string whose contents are a JSON object.
 
     Markdown fences, prose before/after JSON, multiple JSON objects, and schema
-    drift return a structured [parse_error]. [now] is optional so tests can keep
-    timestamps deterministic. *)
+    drift return a structured [parse_error]. A provider-supplied
+    [schema_version] field is ignored if present; persisted episodes always use
+    {!Keeper_memory_os_types.schema_version}. [now] is optional so tests can
+    keep timestamps deterministic. *)
 val episode_of_output_result
   :  ?now:float
   -> generation:int

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -15,10 +15,37 @@ type input =
 (** Prompt variables for [keeper.librarian.episode_extraction]. *)
 val prompt_variables : input -> (string * string) list
 
+(** Structured parse failure for raw librarian output. *)
+type parse_error =
+  | Empty_output
+  | Invalid_json of string
+  | Json_string_invalid_json of string
+  | Top_level_not_object
+  | Missing_required_fields
+  | Claim_schema_mismatch
+
+val parse_error_to_string : parse_error -> string
+
 (** Parse a raw strict-JSON LLM response into an episode.
 
-    [None] means the response was not JSON or violated the extraction schema.
-    [now] is optional so tests can keep timestamps deterministic. *)
+    Accepted wire forms are deliberately narrow:
+    - exact JSON object;
+    - exact JSON string whose contents are a JSON object.
+
+    Markdown fences, prose before/after JSON, multiple JSON objects, and schema
+    drift return a structured [parse_error]. [now] is optional so tests can keep
+    timestamps deterministic. *)
+val episode_of_output_result
+  :  ?now:float
+  -> generation:int
+  -> input
+  -> string
+  -> (Keeper_memory_os_types.episode, parse_error) result
+
+(** Parse a raw strict-JSON LLM response into an episode.
+
+    Compatibility wrapper over {!episode_of_output_result}; [None] means the
+    response was not JSON or violated the extraction schema. *)
 val episode_of_output
   :  ?now:float
   -> generation:int

--- a/lib/keeper/keeper_librarian.mli
+++ b/lib/keeper/keeper_librarian.mli
@@ -12,7 +12,6 @@ type input =
   ; messages : Agent_sdk.Types.message list
   }
 
-val wire_field_schema_version : string
 val wire_field_episode_summary : string
 val wire_field_claims : string
 val wire_field_open_items : string

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -277,17 +277,94 @@ let message role text =
    problem, not the model-output problem this bound addresses. *)
 let librarian_max_parse_retries = 2
 
+let retry_field_episode_summary = "episode_summary"
+let retry_field_claims = "claims"
+let retry_field_open_items = "open_items"
+let retry_field_constraints = "constraints"
+let retry_field_preserved_tool_refs = "preserved_tool_refs"
+
+let parse_retry_episode_fields =
+  [ retry_field_episode_summary
+  ; retry_field_claims
+  ; retry_field_open_items
+  ; retry_field_constraints
+  ; retry_field_preserved_tool_refs
+  ]
+;;
+
+let retry_field_claim = "claim"
+let retry_field_category = "category"
+let retry_field_source_turn = "source_turn"
+let retry_field_source_tool_call_id = "source_tool_call_id"
+let retry_field_claim_kind = "claim_kind"
+
+let parse_retry_claim_fields =
+  [ retry_field_claim
+  ; retry_field_category
+  ; retry_field_source_turn
+  ; retry_field_source_tool_call_id
+  ; retry_field_claim_kind
+  ]
+;;
+
+let parse_retry_claim_categories =
+  [ "fact"
+  ; "preference"
+  ; "blocker"
+  ; "goal"
+  ; "constraint"
+  ; "ephemeral"
+  ; "validated_approach"
+  ; "lesson"
+  ; "code_change"
+  ]
+;;
+
+let parse_retry_claim_kinds =
+  [ "self_observation"; "external_state"; "durable_knowledge" ]
+;;
+
+let parse_retry_claim_shape =
+  let field_shapes =
+    [ "\"string\""
+    ; Printf.sprintf "\"%s\"" (String.concat "|" parse_retry_claim_categories)
+    ; "0"
+    ; "\"optional-string\""
+    ; Printf.sprintf "\"%s\"" (String.concat "|" parse_retry_claim_kinds)
+    ]
+  in
+  List.map2
+    (fun field shape -> Printf.sprintf "\"%s\": %s" field shape)
+    parse_retry_claim_fields
+    field_shapes
+  |> String.concat ", "
+  |> Printf.sprintf "{%s}"
+;;
+
+let parse_retry_episode_shape =
+  let field_shape field =
+    if String.equal field retry_field_episode_summary
+    then Printf.sprintf "\"%s\": \"string\"" field
+    else if String.equal field retry_field_claims
+    then Printf.sprintf "\"%s\": [%s]" field parse_retry_claim_shape
+    else Printf.sprintf "\"%s\": [\"string\"]" field
+  in
+  parse_retry_episode_fields
+  |> List.map field_shape
+  |> String.concat ",\n"
+  |> Printf.sprintf "{%s}"
+;;
+
 let parse_retry_nudge =
-  "Your previous response could not be parsed as the required JSON episode \
-   object. Respond with ONLY a single JSON object — no markdown fences, no \
-   prose. Required shape:\n\
-   {\"episode_summary\": \"string\",\n\
-   \"claims\": [{\"claim\": \"string\", \"category\": \"fact|preference|blocker|goal|constraint|ephemeral|validated_approach|lesson|code_change\", \"source_turn\": 0, \"source_tool_call_id\": \"optional-string\", \"claim_kind\": \"self_observation|external_state|durable_knowledge\"}],\n\
-   \"open_items\": [\"string\"],\n\
-   \"constraints\": [\"string\"],\n\
-   \"preserved_tool_refs\": [\"string\"]}\n\
-   source_turn must be an integer. Do not include a confidence field and do not \
-   add any fields not shown above."
+  Printf.sprintf
+    "Your previous response could not be parsed as the required JSON episode \
+     object. Respond with ONLY a single JSON object — no markdown fences, no \
+     prose. Required shape:\n\
+     %s\n\
+     %s must be an integer. Do not include a confidence field and do not add \
+     any fields not shown above."
+    parse_retry_episode_shape
+    retry_field_source_turn
 
 type attempt_outcome =
   | Parsed of Keeper_memory_os_types.episode

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -301,7 +301,7 @@ let parse_retry_claim_field_shapes =
   ; { name = Keeper_librarian.wire_field_category
     ; shape = union_shape parse_retry_claim_categories
     }
-  ; { name = Keeper_librarian.wire_field_source_turn; shape = "0" }
+  ; { name = Keeper_librarian.wire_field_source_turn; shape = quoted "integer" }
   ; { name = Keeper_librarian.wire_field_source_tool_call_id
     ; shape = quoted "optional-string"
     }

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -478,11 +478,14 @@ let extract_with_provider_classified
           last_unparseable_raw := Some raw;
           Unparseable "librarian provider returned empty response")
         else (
-          match Keeper_librarian.episode_of_output ~generation inp raw with
-          | Some episode -> Parsed episode
-          | None ->
+          match Keeper_librarian.episode_of_output_result ~generation inp raw with
+          | Ok episode -> Parsed episode
+          | Error error ->
             last_unparseable_raw := Some raw;
-            Unparseable "librarian provider returned invalid episode JSON")
+            Unparseable
+              (Printf.sprintf
+                 "librarian provider returned invalid episode JSON (%s)"
+                 (Keeper_librarian.parse_error_to_string error)))
     in
     (match
        run_with_parse_retries

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -277,94 +277,84 @@ let message role text =
    problem, not the model-output problem this bound addresses. *)
 let librarian_max_parse_retries = 2
 
-let retry_field_episode_summary = "episode_summary"
-let retry_field_claims = "claims"
-let retry_field_open_items = "open_items"
-let retry_field_constraints = "constraints"
-let retry_field_preserved_tool_refs = "preserved_tool_refs"
-
-let parse_retry_episode_fields =
-  [ retry_field_episode_summary
-  ; retry_field_claims
-  ; retry_field_open_items
-  ; retry_field_constraints
-  ; retry_field_preserved_tool_refs
-  ]
-;;
-
-let retry_field_claim = "claim"
-let retry_field_category = "category"
-let retry_field_source_turn = "source_turn"
-let retry_field_source_tool_call_id = "source_tool_call_id"
-let retry_field_claim_kind = "claim_kind"
-
-let parse_retry_claim_fields =
-  [ retry_field_claim
-  ; retry_field_category
-  ; retry_field_source_turn
-  ; retry_field_source_tool_call_id
-  ; retry_field_claim_kind
-  ]
-;;
+type retry_field_shape =
+  { name : string
+  ; shape : string
+  }
 
 let parse_retry_claim_categories =
-  [ "fact"
-  ; "preference"
-  ; "blocker"
-  ; "goal"
-  ; "constraint"
-  ; "ephemeral"
-  ; "validated_approach"
-  ; "lesson"
-  ; "code_change"
-  ]
+  Keeper_memory_os_types.all_categories
+  |> List.map Keeper_memory_os_types.category_to_string
 ;;
 
 let parse_retry_claim_kinds =
-  [ "self_observation"; "external_state"; "durable_knowledge" ]
+  Keeper_memory_os_types.librarian_claim_kinds
+  |> List.map Keeper_memory_os_types.claim_kind_to_string
+;;
+
+let quoted value = Printf.sprintf "\"%s\"" value
+let union_shape values = values |> String.concat "|" |> quoted
+let render_retry_field field = Printf.sprintf "\"%s\": %s" field.name field.shape
+
+let parse_retry_claim_field_shapes =
+  [ { name = Keeper_librarian.wire_field_claim; shape = quoted "string" }
+  ; { name = Keeper_librarian.wire_field_category
+    ; shape = union_shape parse_retry_claim_categories
+    }
+  ; { name = Keeper_librarian.wire_field_source_turn; shape = "0" }
+  ; { name = Keeper_librarian.wire_field_source_tool_call_id
+    ; shape = quoted "optional-string"
+    }
+  ; { name = Keeper_librarian.wire_field_claim_id; shape = quoted "optional-string" }
+  ; { name = Keeper_librarian.wire_field_claim_kind
+    ; shape = union_shape parse_retry_claim_kinds
+    }
+  ]
+;;
+
+let parse_retry_claim_fields =
+  List.map (fun field -> field.name) parse_retry_claim_field_shapes
 ;;
 
 let parse_retry_claim_shape =
-  let field_shapes =
-    [ "\"string\""
-    ; Printf.sprintf "\"%s\"" (String.concat "|" parse_retry_claim_categories)
-    ; "0"
-    ; "\"optional-string\""
-    ; Printf.sprintf "\"%s\"" (String.concat "|" parse_retry_claim_kinds)
-    ]
-  in
-  List.map2
-    (fun field shape -> Printf.sprintf "\"%s\": %s" field shape)
-    parse_retry_claim_fields
-    field_shapes
+  parse_retry_claim_field_shapes
+  |> List.map render_retry_field
   |> String.concat ", "
   |> Printf.sprintf "{%s}"
 ;;
 
+let parse_retry_episode_field_shapes =
+  [ { name = Keeper_librarian.wire_field_episode_summary; shape = quoted "string" }
+  ; { name = Keeper_librarian.wire_field_claims
+    ; shape = Printf.sprintf "[%s]" parse_retry_claim_shape
+    }
+  ; { name = Keeper_librarian.wire_field_open_items; shape = "[\"string\"]" }
+  ; { name = Keeper_librarian.wire_field_constraints; shape = "[\"string\"]" }
+  ; { name = Keeper_librarian.wire_field_preserved_tool_refs; shape = "[\"string\"]" }
+  ]
+;;
+
+let parse_retry_episode_fields =
+  List.map (fun field -> field.name) parse_retry_episode_field_shapes
+;;
+
 let parse_retry_episode_shape =
-  let field_shape field =
-    if String.equal field retry_field_episode_summary
-    then Printf.sprintf "\"%s\": \"string\"" field
-    else if String.equal field retry_field_claims
-    then Printf.sprintf "\"%s\": [%s]" field parse_retry_claim_shape
-    else Printf.sprintf "\"%s\": [\"string\"]" field
-  in
-  parse_retry_episode_fields
-  |> List.map field_shape
+  parse_retry_episode_field_shapes
+  |> List.map render_retry_field
   |> String.concat ",\n"
   |> Printf.sprintf "{%s}"
 ;;
 
 let parse_retry_nudge =
-  Printf.sprintf
-    "Your previous response could not be parsed as the required JSON episode \
-     object. Respond with ONLY a single JSON object — no markdown fences, no \
-     prose. Required shape:\n\
-     %s\n\
-     %s must be an integer. Do not include a confidence field and do not add \
-     any fields not shown above."
-    parse_retry_episode_shape
-    retry_field_source_turn
+  String.concat
+    "\n"
+    [ "Your previous response could not be parsed as the required JSON episode object. Respond with ONLY a single JSON object — no markdown fences, no prose."
+    ; "Required shape:"
+    ; parse_retry_episode_shape
+    ; Printf.sprintf
+        "%s must be an integer. Do not include a confidence field and do not add any fields not shown above."
+        Keeper_librarian.wire_field_source_turn
+    ]
 
 type attempt_outcome =
   | Parsed of Keeper_memory_os_types.episode

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -296,16 +296,21 @@ let quoted value = Printf.sprintf "\"%s\"" value
 let union_shape values = values |> String.concat "|" |> quoted
 let render_retry_field field = Printf.sprintf "\"%s\": %s" field.name field.shape
 
+let retry_shape_string = quoted "string"
+let retry_shape_integer = quoted "integer"
+let retry_shape_optional_string = quoted "optional-string"
+let retry_shape_string_list = Printf.sprintf "[%s]" retry_shape_string
+
 let parse_retry_claim_field_shapes =
-  [ { name = Keeper_librarian.wire_field_claim; shape = quoted "string" }
+  [ { name = Keeper_librarian.wire_field_claim; shape = retry_shape_string }
   ; { name = Keeper_librarian.wire_field_category
     ; shape = union_shape parse_retry_claim_categories
     }
-  ; { name = Keeper_librarian.wire_field_source_turn; shape = quoted "integer" }
+  ; { name = Keeper_librarian.wire_field_source_turn; shape = retry_shape_integer }
   ; { name = Keeper_librarian.wire_field_source_tool_call_id
-    ; shape = quoted "optional-string"
+    ; shape = retry_shape_optional_string
     }
-  ; { name = Keeper_librarian.wire_field_claim_id; shape = quoted "optional-string" }
+  ; { name = Keeper_librarian.wire_field_claim_id; shape = retry_shape_optional_string }
   ; { name = Keeper_librarian.wire_field_claim_kind
     ; shape = union_shape parse_retry_claim_kinds
     }
@@ -324,13 +329,15 @@ let parse_retry_claim_shape =
 ;;
 
 let parse_retry_episode_field_shapes =
-  [ { name = Keeper_librarian.wire_field_episode_summary; shape = quoted "string" }
+  [ { name = Keeper_librarian.wire_field_episode_summary; shape = retry_shape_string }
   ; { name = Keeper_librarian.wire_field_claims
     ; shape = Printf.sprintf "[%s]" parse_retry_claim_shape
     }
-  ; { name = Keeper_librarian.wire_field_open_items; shape = "[\"string\"]" }
-  ; { name = Keeper_librarian.wire_field_constraints; shape = "[\"string\"]" }
-  ; { name = Keeper_librarian.wire_field_preserved_tool_refs; shape = "[\"string\"]" }
+  ; { name = Keeper_librarian.wire_field_open_items; shape = retry_shape_string_list }
+  ; { name = Keeper_librarian.wire_field_constraints; shape = retry_shape_string_list }
+  ; { name = Keeper_librarian.wire_field_preserved_tool_refs
+    ; shape = retry_shape_string_list
+    }
   ]
 ;;
 

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -98,6 +98,12 @@ val librarian_max_parse_retries : int
 (** Additional provider attempts after an initial unparseable response before
     [extract_with_provider] gives up (the initial attempt is not counted). *)
 
+val parse_retry_episode_fields : string list
+(** Episode object fields included in the corrective parse-retry shape. *)
+
+val parse_retry_claim_fields : string list
+(** Claim object fields included in the corrective parse-retry shape. *)
+
 val parse_retry_nudge : string
 (** Corrective instruction appended to the message list on each parse-retry. *)
 

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -63,8 +63,9 @@ let category_to_string = function
 ;;
 
 let all_categories =
-  [ Code_change
-  ; Fact
+  (* Prompt-significant order: keep durable/common tokens first so retry nudges
+     bias toward normal memory facts before narrower bookkeeping categories. *)
+  [ Fact
   ; Preference
   ; Blocker
   ; Goal
@@ -72,6 +73,7 @@ let all_categories =
   ; Ephemeral
   ; Validated_approach
   ; Lesson
+  ; Code_change
   ]
 ;;
 

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -62,6 +62,19 @@ let category_to_string = function
   | Unknown s -> s
 ;;
 
+let all_categories =
+  [ Code_change
+  ; Fact
+  ; Preference
+  ; Blocker
+  ; Goal
+  ; Constraint
+  ; Ephemeral
+  ; Validated_approach
+  ; Lesson
+  ]
+;;
+
 let category_of_string s =
   match String.lowercase_ascii (String.trim s) with
   | "code_change" -> Code_change
@@ -92,6 +105,14 @@ let claim_kind_to_string = function
   | External_state -> "external_state"
   | Durable_knowledge -> "durable_knowledge"
   | Diagnostic -> "diagnostic"
+;;
+
+let all_claim_kinds =
+  [ Self_observation; External_state; Durable_knowledge; Diagnostic ]
+;;
+
+let librarian_claim_kinds =
+  [ Self_observation; External_state; Durable_knowledge ]
 ;;
 
 let claim_kind_of_string s =

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -15,6 +15,55 @@ let schema_version = "rfc0259-v1"
    consolidator additionally filters this id out of its source keeper list. *)
 let shared_store_id = "_shared"
 
+(* Canonical JSON wire keys for Memory OS persistence and librarian ingestion.
+   The schema module owns these strings so the parser, retry prompt, persistence
+   codec, and tests cannot drift by maintaining parallel literal sets. *)
+let wire_field_trace_id = "trace_id"
+let wire_field_turn = "turn"
+let wire_field_tool_call_id = "tool_call_id"
+let wire_field_claim = "claim"
+let wire_field_category = "category"
+let wire_field_source = "source"
+let wire_field_first_seen = "first_seen"
+let wire_field_valid_until = "valid_until"
+let wire_field_last_verified_at = "last_verified_at"
+let wire_field_observed_by = "observed_by"
+let wire_field_claim_id = "claim_id"
+let wire_field_claim_kind = "claim_kind"
+let wire_field_schema_version = "schema_version"
+let wire_field_generation = "generation"
+let wire_field_episode_summary = "episode_summary"
+let wire_field_claims = "claims"
+let wire_field_open_items = "open_items"
+let wire_field_constraints = "constraints"
+let wire_field_preserved_tool_refs = "preserved_tool_refs"
+let wire_field_source_turn = "source_turn"
+let wire_field_source_tool_call_id = "source_tool_call_id"
+let wire_field_source_turn_range = "source_turn_range"
+let wire_field_lo = "lo"
+let wire_field_hi = "hi"
+let wire_field_created_at = "created_at"
+let wire_field_terminal_marker = "terminal_marker"
+
+let wire_librarian_episode_fields =
+  [ wire_field_episode_summary
+  ; wire_field_claims
+  ; wire_field_open_items
+  ; wire_field_constraints
+  ; wire_field_preserved_tool_refs
+  ]
+;;
+
+let wire_librarian_claim_fields =
+  [ wire_field_claim
+  ; wire_field_category
+  ; wire_field_source_turn
+  ; wire_field_source_tool_call_id
+  ; wire_field_claim_id
+  ; wire_field_claim_kind
+  ]
+;;
+
 type provenance_event =
   { trace_id : string
   ; turn : int
@@ -366,13 +415,13 @@ let json_string_list_field key (fields : (string * Yojson.Safe.t) list) =
 
 let provenance_event_to_json (e : provenance_event) =
   let base =
-    [ "trace_id", `String e.trace_id
-    ; "turn", `Int e.turn
+    [ wire_field_trace_id, `String e.trace_id
+    ; wire_field_turn, `Int e.turn
     ]
   in
   let tool =
     match e.tool_call_id with
-    | Some id -> [ "tool_call_id", `String id ]
+    | Some id -> [ wire_field_tool_call_id, `String id ]
     | None -> []
   in
   `Assoc (base @ tool)
@@ -381,9 +430,11 @@ let provenance_event_to_json (e : provenance_event) =
 let provenance_event_of_json (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
-    (match json_string_field "trace_id" fields, json_int_field "turn" fields with
+    (match
+       json_string_field wire_field_trace_id fields, json_int_field wire_field_turn fields
+     with
      | Some trace_id, Some turn ->
-       let tool_call_id = json_string_field "tool_call_id" fields in
+       let tool_call_id = json_string_field wire_field_tool_call_id fields in
        Some { trace_id; turn; tool_call_id }
      | (Some _, None) | (None, Some _) | (None, None) -> None)
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
@@ -467,31 +518,32 @@ let optional_float_field key = function
 
 let fact_to_json f =
   let fields =
-    [ "claim", `String f.claim
-    ; "category", `String (category_to_string f.category)
-    ; "source", provenance_event_to_json f.source
-    ; "first_seen", `Float f.first_seen
+    [ wire_field_claim, `String f.claim
+    ; wire_field_category, `String (category_to_string f.category)
+    ; wire_field_source, provenance_event_to_json f.source
+    ; wire_field_first_seen, `Float f.first_seen
 
-    ; "schema_version", `String f.schema_version
+    ; wire_field_schema_version, `String f.schema_version
     ]
-    @ optional_float_field "valid_until" f.valid_until
-    @ optional_float_field "last_verified_at" f.last_verified_at
+    @ optional_float_field wire_field_valid_until f.valid_until
+    @ optional_float_field wire_field_last_verified_at f.last_verified_at
     (* Tier-1 facts carry [], which is omitted so per-keeper stores stay
        byte-identical to pre-RFC-0244; only Tier-2 shared facts emit it. *)
     @ (match f.observed_by with
        | [] -> []
-       | keepers -> [ "observed_by", `List (List.map (fun k -> `String k) keepers) ])
+       | keepers ->
+         [ wire_field_observed_by, `List (List.map (fun k -> `String k) keepers) ])
     (* RFC-0259 §3.7 (P6): the producer-emitted conclusion slug. Omitted when
        [None] so legacy / id-less rows stay byte-identical, and appended LAST to
        keep the prior key order stable for the snapshot fingerprint. *)
     @ (match Option.bind f.claim_id normalize_claim_id with
-       | Some id -> [ "claim_id", `String id ]
+       | Some id -> [ wire_field_claim_id, `String id ]
        | None -> [])
     (* RFC-0285 §3.1: the producer-emitted origin tag. Omitted when [None] so legacy
        rows stay byte-identical, appended LAST to keep the prior key order stable for
        the snapshot fingerprint. *)
     @ (match f.claim_kind with
-       | Some k -> [ "claim_kind", `String (claim_kind_to_string k) ]
+       | Some k -> [ wire_field_claim_kind, `String (claim_kind_to_string k) ]
        | None -> [])
   in
   `Assoc fields
@@ -508,33 +560,39 @@ let fact_of_json (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
     (match
-       ( json_string_field "claim" fields
-       , json_string_field "category" fields
-       , List.assoc_opt "source" fields )
+       ( json_string_field wire_field_claim fields
+       , json_string_field wire_field_category fields
+       , List.assoc_opt wire_field_source fields )
      with
      | Some claim, Some category_str, Some source_json ->
        (match provenance_event_of_json source_json with
         | Some source ->
           (* DET-OK: absent first_seen defaults to epoch for migration safety. *)
-          let first_seen = Option.value (json_float_field "first_seen" fields) ~default:0.0 in
-          let last_verified_at = json_float_field "last_verified_at" fields in
+          let first_seen =
+            Option.value (json_float_field wire_field_first_seen fields) ~default:0.0
+          in
+          let last_verified_at = json_float_field wire_field_last_verified_at fields in
           (* Ignore persisted external_ref metadata. Older rows may carry refs that
              were inferred from prose; preserving them would keep the old forced
              classifier alive. The claim remains model context. *)
           let external_ref = None in
-          let valid_until = json_float_field "valid_until" fields in
+          let valid_until = json_float_field wire_field_valid_until fields in
           (* DET-OK: absent observed_by defaults to empty (Tier-1 / legacy facts). *)
           let observed_by =
-            Option.value (json_string_list_field "observed_by" fields) ~default:[]
+            Option.value (json_string_list_field wire_field_observed_by fields) ~default:[]
           in
           (* RFC-0259 §3.7 (P6): absent on legacy / id-less rows, defaulting to
              [None] so [claim_identity] falls back to [normalize_claim] for them. *)
-          let claim_id = Option.bind (json_string_field "claim_id" fields) normalize_claim_id in
+          let claim_id =
+            Option.bind (json_string_field wire_field_claim_id fields) normalize_claim_id
+          in
           (* RFC-0285 §3.1: absent on legacy rows -> [None] (durable path). Closed sum,
              so an unrecognized string also yields [None] (graceful-degrade). The
              write-side [valid_until] is preserved as-is above; legacy self-observation
              rows are not retrofitted a horizon (RFC §5 non-goal). *)
-          let claim_kind = Option.bind (json_string_field "claim_kind" fields) claim_kind_of_string in
+          let claim_kind =
+            Option.bind (json_string_field wire_field_claim_kind fields) claim_kind_of_string
+          in
           Some
             { claim
             ; (* Parse-once at the read boundary; legacy free-string categories
@@ -549,7 +607,9 @@ let fact_of_json (json : Yojson.Safe.t) =
             ; last_verified_at
             ; schema_version =
                 (* DET-OK: default to current schema for forward compatibility. *)
-                Option.value (json_string_field "schema_version" fields) ~default:schema_version
+                Option.value
+                  (json_string_field wire_field_schema_version fields)
+                  ~default:schema_version
             ; claim_id
             }
         | None -> None)
@@ -563,24 +623,27 @@ let episode_to_json e =
   let range_json =
     match e.source_turn_range with
     | Some (lo, hi) ->
-      [ "source_turn_range", `Assoc [ "lo", `Int lo; "hi", `Int hi ] ]
+      [ wire_field_source_turn_range
+      , `Assoc [ wire_field_lo, `Int lo; wire_field_hi, `Int hi ]
+      ]
     | None -> []
   in
   `Assoc
-    ([ "trace_id", `String e.trace_id
-     ; "generation", `Int e.generation
-     ; "episode_summary", `String e.episode_summary
-     ; "claims", `List (List.map fact_to_json e.claims)
-     ; "open_items", `List (List.map (fun s -> `String s) e.open_items)
-     ; "constraints", `List (List.map (fun s -> `String s) e.constraints)
-     ; "preserved_tool_refs", `List (List.map (fun s -> `String s) e.preserved_tool_refs)
-     ; "created_at", `Float e.created_at
-     ; "schema_version", `String e.schema_version
+    ([ wire_field_trace_id, `String e.trace_id
+     ; wire_field_generation, `Int e.generation
+     ; wire_field_episode_summary, `String e.episode_summary
+     ; wire_field_claims, `List (List.map fact_to_json e.claims)
+     ; wire_field_open_items, `List (List.map (fun s -> `String s) e.open_items)
+     ; wire_field_constraints, `List (List.map (fun s -> `String s) e.constraints)
+     ; ( wire_field_preserved_tool_refs
+       , `List (List.map (fun s -> `String s) e.preserved_tool_refs) )
+     ; wire_field_created_at, `Float e.created_at
+     ; wire_field_schema_version, `String e.schema_version
      ]
      @ range_json
-     @ optional_float_field "valid_until" e.valid_until
+     @ optional_float_field wire_field_valid_until e.valid_until
      @ (match e.terminal_marker with
-        | Some marker -> [ "terminal_marker", `String marker ]
+        | Some marker -> [ wire_field_terminal_marker, `String marker ]
         | None -> []))
 ;;
 
@@ -588,25 +651,31 @@ let episode_of_json (json : Yojson.Safe.t) =
   match json with
   | `Assoc fields ->
     (match
-       ( json_string_field "trace_id" fields
-       , json_int_field "generation" fields
-       , json_string_field "episode_summary" fields
-       , List.assoc_opt "claims" fields )
+       ( json_string_field wire_field_trace_id fields
+       , json_int_field wire_field_generation fields
+       , json_string_field wire_field_episode_summary fields
+       , List.assoc_opt wire_field_claims fields )
      with
      | Some trace_id, Some generation, Some episode_summary, Some (`List claim_items) ->
        let claims = List.filter_map fact_of_json claim_items in
        (* DET-OK: optional list fields default to empty. *)
-       let open_items = Option.value (json_string_list_field "open_items" fields) ~default:[] in
+       let open_items =
+         Option.value (json_string_list_field wire_field_open_items fields) ~default:[]
+       in
        (* DET-OK: optional list fields default to empty. *)
-       let constraints = Option.value (json_string_list_field "constraints" fields) ~default:[] in
+       let constraints =
+         Option.value (json_string_list_field wire_field_constraints fields) ~default:[]
+       in
        (* DET-OK: optional list fields default to empty. *)
        let preserved_tool_refs =
-         Option.value (json_string_list_field "preserved_tool_refs" fields) ~default:[]
+         Option.value
+           (json_string_list_field wire_field_preserved_tool_refs fields)
+           ~default:[]
        in
        let source_turn_range =
-         match List.assoc_opt "source_turn_range" fields with
+         match List.assoc_opt wire_field_source_turn_range fields with
          | Some (`Assoc r) ->
-           (match json_int_field "lo" r, json_int_field "hi" r with
+           (match json_int_field wire_field_lo r, json_int_field wire_field_hi r with
             | Some lo, Some hi -> Some (lo, hi)
             | (Some _, None) | (None, Some _) | (None, None) -> None)
          | Some (`Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _)
@@ -614,10 +683,12 @@ let episode_of_json (json : Yojson.Safe.t) =
            None
        in
        (* DET-OK: absent created_at defaults to epoch for migration safety. *)
-       let created_at = Option.value (json_float_field "created_at" fields) ~default:0.0 in
+       let created_at =
+         Option.value (json_float_field wire_field_created_at fields) ~default:0.0
+       in
        (* DET-OK: legacy episodes had no TTL or terminal marker. *)
-       let valid_until = json_float_field "valid_until" fields in
-       let terminal_marker = json_string_field "terminal_marker" fields in
+       let valid_until = json_float_field wire_field_valid_until fields in
+       let terminal_marker = json_string_field wire_field_terminal_marker fields in
        Some
          { trace_id
          ; generation
@@ -632,7 +703,9 @@ let episode_of_json (json : Yojson.Safe.t) =
          ; terminal_marker
          ; schema_version =
              (* DET-OK: default to current schema for forward compatibility. *)
-             Option.value (json_string_field "schema_version" fields) ~default:schema_version
+             Option.value
+               (json_string_field wire_field_schema_version fields)
+               ~default:schema_version
          }
      | ( Some _
        , Some _

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -12,6 +12,45 @@ val schema_version : string
     collides; the consolidator filters it out of its source keeper list. *)
 val shared_store_id : string
 
+(** Canonical JSON wire field names for Memory OS persistence and librarian
+    ingestion. The schema module owns these strings so parser, retry prompt,
+    persistence codec, and tests share one source. *)
+val wire_field_trace_id : string
+val wire_field_turn : string
+val wire_field_tool_call_id : string
+val wire_field_claim : string
+val wire_field_category : string
+val wire_field_source : string
+val wire_field_first_seen : string
+val wire_field_valid_until : string
+val wire_field_last_verified_at : string
+val wire_field_observed_by : string
+val wire_field_claim_id : string
+val wire_field_claim_kind : string
+val wire_field_schema_version : string
+val wire_field_generation : string
+val wire_field_episode_summary : string
+val wire_field_claims : string
+val wire_field_open_items : string
+val wire_field_constraints : string
+val wire_field_preserved_tool_refs : string
+val wire_field_source_turn : string
+val wire_field_source_tool_call_id : string
+val wire_field_source_turn_range : string
+val wire_field_lo : string
+val wire_field_hi : string
+val wire_field_created_at : string
+val wire_field_terminal_marker : string
+
+(** Episode-object fields accepted from the librarian and rendered in retry
+    prompts. [wire_field_schema_version] is accepted separately for compatibility
+    but is not requested from the provider. *)
+val wire_librarian_episode_fields : string list
+
+(** Claim-object fields accepted from the librarian and rendered in retry
+    prompts. *)
+val wire_librarian_claim_fields : string list
+
 (** Source attribution for a single extracted fact. *)
 type provenance_event =
   { trace_id : string
@@ -90,10 +129,10 @@ val librarian_claim_kinds : claim_kind list
 val claim_kind_of_string : string -> claim_kind option
 
 (** Whether a category may be promoted into the shared semantic tier. Exhaustive
-    over {!category}; only [Fact] and [Constraint] promote (preserving the prior
-    ["fact";"constraint"] whitelist), so a new or typo'd category cannot silently
-    join the promotable set — a future durable kind must be classified here at
-    compile time. *)
+    over {!category}; [Fact], [Constraint], [Validated_approach], and [Lesson]
+    promote. Everything else stays keeper-local, so a new or typo'd category
+    cannot silently join the shared tier — a future durable kind must be
+    classified here at compile time. *)
 val is_promotable : category -> bool
 
 (** Historical RFC-0259 external-ref kind. Kept as a closed sum for source

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -53,6 +53,11 @@ type category =
     [category_of_string] for known variants; [Unknown s] yields [s]). *)
 val category_to_string : category -> string
 
+(** All closed taxonomy categories that can be emitted by the librarian prompt.
+    [Unknown _] is intentionally excluded because it represents parser drift,
+    not an advertised token. *)
+val all_categories : category list
+
 (** Parse a free-text category label (trimmed, case-insensitive on known tokens);
     anything outside the taxonomy becomes [Unknown] carrying the raw label. *)
 val category_of_string : string -> category
@@ -69,6 +74,14 @@ type claim_kind =
 
 (** Canonical lowercase token (round-trips with [claim_kind_of_string]). *)
 val claim_kind_to_string : claim_kind -> string
+
+(** All closed claim-kind tokens. *)
+val all_claim_kinds : claim_kind list
+
+(** Claim-kind tokens the librarian prompt should ask a provider to emit.
+    [Diagnostic] is system-authored and intentionally excluded from the LLM
+    retry contract. *)
+val librarian_claim_kinds : claim_kind list
 
 (** Parse a claim_kind token (trimmed, case-insensitive on known tokens); an
     absent/unrecognized label yields [None], routing to the durable pre-RFC path

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -54,6 +54,7 @@ type category =
 val category_to_string : category -> string
 
 (** All closed taxonomy categories that can be emitted by the librarian prompt.
+    The order is prompt-significant: durable/common categories come first.
     [Unknown _] is intentionally excluded because it represents parser drift,
     not an advertised token. *)
 val all_categories : category list

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -15,7 +15,7 @@ module Types = Agent_sdk.Types
 let field_episode_summary = Lib.wire_field_episode_summary
 let field_claims = Lib.wire_field_claims
 let field_claim = Lib.wire_field_claim
-let field_confidence = "confidence"
+let deprecated_field_confidence = "confidence"
 let field_category = Lib.wire_field_category
 let field_source_turn = Lib.wire_field_source_turn
 let field_source_tool_call_id = Lib.wire_field_source_tool_call_id
@@ -33,7 +33,7 @@ let claim_json ?confidence ?(claim = "c") ?(source_turn = `Int 0) () =
   let fields =
     match confidence with
     | None -> fields
-    | Some confidence -> (field_confidence, confidence) :: fields
+    | Some confidence -> (deprecated_field_confidence, confidence) :: fields
   in
   `Assoc fields
 ;;
@@ -433,7 +433,7 @@ let test_retry_nudge_matches_schema () =
   check bool "nudge episode field list includes preserved refs" true
     (List.mem field_preserved_tool_refs R.parse_retry_episode_fields);
   check bool "nudge field list excludes confidence" false
-    (List.mem field_confidence R.parse_retry_claim_fields);
+    (List.mem deprecated_field_confidence R.parse_retry_claim_fields);
   check bool "nudge field list includes source_turn" true
     (List.mem field_source_turn R.parse_retry_claim_fields);
   check bool "nudge field list includes source_tool_call_id" true

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -254,9 +254,9 @@ let test_cadence_step_keyed () =
     (R.cadence_step_keyed ~cadence:3 ~current_trace:"t2" ~prior:(Some ("t1", 2)))
 
 (* Strict parsing with bounded compatibility for real-world librarian provider
-   drift. We accept exact JSON, exact fenced JSON, and JSON-string wrapping, but
-   prose-wrapped or embedded JSON must fall into the diagnostic fallback path
-   instead of being accepted as a structured episode. *)
+   drift. We accept exact JSON and exact JSON-string wrapping only. Markdown
+   fences, prose-wrapped JSON, and embedded JSON must fall into the diagnostic
+   fallback path instead of being accepted as a structured episode. *)
 
 let parse_ep raw =
   let inp = { Lib.trace_id = "tolerant-t"; generation = 0; messages = [] } in
@@ -280,17 +280,13 @@ let minimal_episode_json ?(claim = "c") () =
     ]
   |> Yojson.Safe.to_string
 
-let test_parses_markdown_wrapped () =
+let test_rejects_markdown_wrapped () =
   let raw =
     "```json\n\
      {\"episode_summary\":\"s\",\"claims\":[],\"open_items\":[],\"constraints\":[],\"preserved_tool_refs\":[]}\n\
      ```"
   in
-  match parse_ep raw with
-  | Some ep ->
-    check string "episode_summary" "s" ep.episode_summary;
-    check int "claims count" 0 (List.length ep.claims)
-  | None -> Alcotest.fail "markdown-wrapped JSON should parse"
+  check bool "markdown-wrapped JSON rejected" true (Option.is_none (parse_ep raw))
 ;;
 
 let test_rejects_prose_wrapped_json () =
@@ -318,17 +314,20 @@ let test_parses_json_string_wrapping () =
   | None -> Alcotest.fail "JSON-string-wrapped object should parse"
 ;;
 
-let test_parses_string_source_turn () =
+let test_rejects_string_source_turn () =
   let raw =
     {|{"episode_summary":"s","claims":[{"claim":"c","category":"fact","source_turn":"3"}],"open_items":[],"constraints":[],"preserved_tool_refs":[]}|}
   in
-  match parse_ep raw with
-  | Some ep ->
-    check int "claims count" 1 (List.length ep.claims);
-    (match ep.claims with
-     | [ claim ] -> check int "source_turn coerced" 3 claim.source.turn
-     | _ -> Alcotest.fail "expected exactly one claim")
-  | None -> Alcotest.fail "string source_turn should coerce to int"
+  check bool "string source_turn rejected" true (Option.is_none (parse_ep raw))
+;;
+
+let test_parse_result_reports_error () =
+  let inp = { Lib.trace_id = "typed-error-t"; generation = 0; messages = [] } in
+  match Lib.episode_of_output_result ~now:1_000_000.0 ~generation:0 inp "not json" with
+  | Error (Lib.Invalid_json _) -> ()
+  | Error error ->
+    Alcotest.failf "expected Invalid_json, got %s" (Lib.parse_error_to_string error)
+  | Ok _ -> Alcotest.fail "expected typed parse error"
 ;;
 
 let test_rejects_multiple_json_objects () =
@@ -431,10 +430,11 @@ let () =
         ] );
       ( "strict_parsing",
         [
-          test_case "parses markdown-wrapped JSON" `Quick test_parses_markdown_wrapped;
+          test_case "rejects markdown-wrapped JSON" `Quick test_rejects_markdown_wrapped;
           test_case "rejects prose-wrapped JSON" `Quick test_rejects_prose_wrapped_json;
           test_case "parses JSON-string-wrapped object" `Quick test_parses_json_string_wrapping;
-          test_case "coerces string source_turn" `Quick test_parses_string_source_turn;
+          test_case "rejects string source_turn" `Quick test_rejects_string_source_turn;
+          test_case "parse result reports typed error" `Quick test_parse_result_reports_error;
           test_case "rejects multiple JSON objects" `Quick test_rejects_multiple_json_objects;
           test_case "rejects model thinking leak" `Quick test_rejects_model_thinking_leak;
           test_case "rejects malformed JSON" `Quick test_rejects_malformed_json;

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -12,16 +12,16 @@ module R = Masc.Keeper_librarian_runtime
 module Lib = Masc.Keeper_librarian
 module Types = Agent_sdk.Types
 
-let field_episode_summary = "episode_summary"
-let field_claims = "claims"
-let field_claim = "claim"
+let field_episode_summary = Lib.wire_field_episode_summary
+let field_claims = Lib.wire_field_claims
+let field_claim = Lib.wire_field_claim
 let field_confidence = "confidence"
-let field_category = "category"
-let field_source_turn = "source_turn"
-let field_source_tool_call_id = "source_tool_call_id"
-let field_open_items = "open_items"
-let field_constraints = "constraints"
-let field_preserved_tool_refs = "preserved_tool_refs"
+let field_category = Lib.wire_field_category
+let field_source_turn = Lib.wire_field_source_turn
+let field_source_tool_call_id = Lib.wire_field_source_tool_call_id
+let field_open_items = Lib.wire_field_open_items
+let field_constraints = Lib.wire_field_constraints
+let field_preserved_tool_refs = Lib.wire_field_preserved_tool_refs
 
 let claim_json ?confidence ?(claim = "c") ?(source_turn = `Int 0) () =
   let fields =
@@ -422,6 +422,12 @@ let test_invalid_source_turn_string_rejected () =
 let test_retry_nudge_matches_schema () =
   (* The old nudge listed "confidence" as a claim field; the parser dropped
      confidence in RFC-0247, so the nudge must no longer ask for it. *)
+  check (list string) "nudge episode fields match parser fields"
+    Lib.wire_episode_fields
+    R.parse_retry_episode_fields;
+  check (list string) "nudge claim fields match parser fields"
+    Lib.wire_claim_fields
+    R.parse_retry_claim_fields;
   check bool "nudge episode field list includes claims" true
     (List.mem field_claims R.parse_retry_episode_fields);
   check bool "nudge episode field list includes preserved refs" true

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -70,9 +70,7 @@ let minimal_episode_json ?(claim = "c") () =
 (* A minimal valid episode, parsed from known-good JSON, reused as the [Parsed]
    payload so the stub does not have to fabricate the record by hand. *)
 let sample_episode () =
-  let raw =
-    episode_json_string ~claims:[ claim_json ~confidence:(`Float 0.9) () ] ()
-  in
+  let raw = episode_json_string ~claims:[ claim_json () ] () in
   let inp = { Lib.trace_id = "t"; generation = 0; messages = [] } in
   match Lib.episode_of_output ~now:1_000_000.0 ~generation:inp.generation inp raw with
   | Some ep -> ep
@@ -355,6 +353,42 @@ let test_rejects_string_source_turn () =
   check bool "string source_turn rejected" true (Option.is_none (parse_ep raw))
 ;;
 
+let expect_unexpected_field field raw =
+  let inp = { Lib.trace_id = "unexpected-field-t"; generation = 0; messages = [] } in
+  match Lib.episode_of_output_result ~now:1_000_000.0 ~generation:0 inp raw with
+  | Error (Lib.Unexpected_field got) -> check string "unexpected field" field got
+  | Error error ->
+    Alcotest.failf
+      "expected Unexpected_field %s, got %s"
+      field
+      (Lib.parse_error_to_string error)
+  | Ok _ -> Alcotest.failf "expected Unexpected_field %s" field
+;;
+
+let test_rejects_unexpected_episode_field () =
+  let raw =
+    `Assoc
+      [ field_episode_summary, `String "s"
+      ; field_claims, `List [ claim_json () ]
+      ; field_open_items, `List []
+      ; field_constraints, `List []
+      ; field_preserved_tool_refs, `List []
+      ; "extra_episode_field", `String "drift"
+      ]
+    |> Yojson.Safe.to_string
+  in
+  expect_unexpected_field "extra_episode_field" raw
+;;
+
+let test_rejects_unexpected_claim_field () =
+  let raw =
+    episode_json_string
+      ~claims:[ claim_json ~confidence:(`Float 0.9) () ]
+      ()
+  in
+  expect_unexpected_field deprecated_field_confidence raw
+;;
+
 let test_parse_result_reports_error () =
   let inp = { Lib.trace_id = "typed-error-t"; generation = 0; messages = [] } in
   match Lib.episode_of_output_result ~now:1_000_000.0 ~generation:0 inp "not json" with
@@ -470,6 +504,9 @@ let () =
         [
           test_case "rejects markdown-wrapped JSON" `Quick test_rejects_markdown_wrapped;
           test_case "rejects prose-wrapped JSON" `Quick test_rejects_prose_wrapped_json;
+          test_case "rejects unexpected episode field" `Quick
+            test_rejects_unexpected_episode_field;
+          test_case "rejects unexpected claim field" `Quick test_rejects_unexpected_claim_field;
           test_case "parses JSON-string-wrapped object" `Quick test_parses_json_string_wrapping;
           test_case "rejects string source_turn" `Quick test_rejects_string_source_turn;
           test_case "parse result reports typed error" `Quick test_parse_result_reports_error;

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -12,11 +12,66 @@ module R = Masc.Keeper_librarian_runtime
 module Lib = Masc.Keeper_librarian
 module Types = Agent_sdk.Types
 
+let field_episode_summary = "episode_summary"
+let field_claims = "claims"
+let field_claim = "claim"
+let field_confidence = "confidence"
+let field_category = "category"
+let field_source_turn = "source_turn"
+let field_source_tool_call_id = "source_tool_call_id"
+let field_open_items = "open_items"
+let field_constraints = "constraints"
+let field_preserved_tool_refs = "preserved_tool_refs"
+
+let claim_json ?confidence ?(claim = "c") ?(source_turn = `Int 0) () =
+  let fields =
+    [ field_claim, `String claim
+    ; field_category, `String "fact"
+    ; field_source_turn, source_turn
+    ]
+  in
+  let fields =
+    match confidence with
+    | None -> fields
+    | Some confidence -> (field_confidence, confidence) :: fields
+  in
+  `Assoc fields
+;;
+
+let string_list_json values = `List (List.map (fun value -> `String value) values)
+
+let episode_json
+      ?(episode_summary = "s")
+      ?(claims = [ claim_json () ])
+      ?(open_items = [])
+      ?(constraints = [])
+      ?(preserved_tool_refs = [])
+      ()
+  =
+  `Assoc
+    [ field_episode_summary, `String episode_summary
+    ; field_claims, `List claims
+    ; field_open_items, string_list_json open_items
+    ; field_constraints, string_list_json constraints
+    ; field_preserved_tool_refs, string_list_json preserved_tool_refs
+    ]
+;;
+
+let episode_json_string ?episode_summary ?claims ?open_items ?constraints
+      ?preserved_tool_refs () =
+  episode_json ?episode_summary ?claims ?open_items ?constraints ?preserved_tool_refs ()
+  |> Yojson.Safe.to_string
+;;
+
+let minimal_episode_json ?(claim = "c") () =
+  episode_json_string ~claims:[ claim_json ~claim () ] ()
+;;
+
 (* A minimal valid episode, parsed from known-good JSON, reused as the [Parsed]
    payload so the stub does not have to fabricate the record by hand. *)
 let sample_episode () =
   let raw =
-    {|{"episode_summary":"s","claims":[{"claim":"c","confidence":0.9,"category":"fact","source_turn":0}],"open_items":[],"constraints":[],"preserved_tool_refs":[]}|}
+    episode_json_string ~claims:[ claim_json ~confidence:(`Float 0.9) () ] ()
   in
   let inp = { Lib.trace_id = "t"; generation = 0; messages = [] } in
   match Lib.episode_of_output ~now:1_000_000.0 ~generation:inp.generation inp raw with
@@ -263,29 +318,8 @@ let parse_ep raw =
   Lib.episode_of_output ~now:1_000_000.0 ~generation:inp.generation inp raw
 ;;
 
-let minimal_episode_json ?(claim = "c") () =
-  `Assoc
-    [ "episode_summary", `String "s"
-    ; ( "claims"
-      , `List
-          [ `Assoc
-              [ "claim", `String claim
-              ; "category", `String "fact"
-              ; "source_turn", `Int 0
-              ]
-          ] )
-    ; "open_items", `List []
-    ; "constraints", `List []
-    ; "preserved_tool_refs", `List []
-    ]
-  |> Yojson.Safe.to_string
-
 let test_rejects_markdown_wrapped () =
-  let raw =
-    "```json\n\
-     {\"episode_summary\":\"s\",\"claims\":[],\"open_items\":[],\"constraints\":[],\"preserved_tool_refs\":[]}\n\
-     ```"
-  in
+  let raw = "```json\n" ^ episode_json_string ~claims:[] () ^ "\n```" in
   check bool "markdown-wrapped JSON rejected" true (Option.is_none (parse_ep raw))
 ;;
 
@@ -305,7 +339,7 @@ let test_rejects_prose_wrapped_json () =
 
 let test_parses_json_string_wrapping () =
   let raw =
-    "\"{\\\"episode_summary\\\":\\\"s\\\",\\\"claims\\\":[],\\\"open_items\\\":[],\\\"constraints\\\":[],\\\"preserved_tool_refs\\\":[]}\""
+    `String (episode_json_string ~claims:[] ()) |> Yojson.Safe.to_string
   in
   match parse_ep raw with
   | Some ep ->
@@ -316,7 +350,7 @@ let test_parses_json_string_wrapping () =
 
 let test_rejects_string_source_turn () =
   let raw =
-    {|{"episode_summary":"s","claims":[{"claim":"c","category":"fact","source_turn":"3"}],"open_items":[],"constraints":[],"preserved_tool_refs":[]}|}
+    episode_json_string ~claims:[ claim_json ~source_turn:(`String "3") () ] ()
   in
   check bool "string source_turn rejected" true (Option.is_none (parse_ep raw))
 ;;
@@ -362,7 +396,11 @@ let test_parses_nested_braces_inside_string () =
 
 let test_missing_lists_default_to_empty () =
   let raw =
-    {|{"episode_summary":"s","claims":[{"claim":"c","category":"fact","source_turn":0}]}|}
+    `Assoc
+      [ field_episode_summary, `String "s"
+      ; field_claims, `List [ claim_json () ]
+      ]
+    |> Yojson.Safe.to_string
   in
   match parse_ep raw with
   | Some ep ->
@@ -374,32 +412,26 @@ let test_missing_lists_default_to_empty () =
 
 let test_invalid_source_turn_string_rejected () =
   let raw =
-    {|{"episode_summary":"s","claims":[{"claim":"c","category":"fact","source_turn":"not-a-number"}],"open_items":[],"constraints":[],"preserved_tool_refs":[]}|}
+    episode_json_string
+      ~claims:[ claim_json ~source_turn:(`String "not-a-number") () ]
+      ()
   in
   check bool "invalid source_turn rejected" true (Option.is_none (parse_ep raw))
-;;
-
-let contains_sub sub s =
-  let sub_len = String.length sub in
-  let s_len = String.length s in
-  let rec aux i =
-    if i + sub_len > s_len
-    then false
-    else if String.equal (String.sub s i sub_len) sub
-    then true
-    else aux (i + 1)
-  in
-  aux 0
 ;;
 
 let test_retry_nudge_matches_schema () =
   (* The old nudge listed "confidence" as a claim field; the parser dropped
      confidence in RFC-0247, so the nudge must no longer ask for it. *)
-  check bool "nudge does not list confidence as a field" false
-    (contains_sub "claim, confidence" R.parse_retry_nudge);
-  check bool "nudge mentions source_turn" true (contains_sub "source_turn" R.parse_retry_nudge);
-  check bool "nudge mentions source_tool_call_id" true
-    (contains_sub "source_tool_call_id" R.parse_retry_nudge)
+  check bool "nudge episode field list includes claims" true
+    (List.mem field_claims R.parse_retry_episode_fields);
+  check bool "nudge episode field list includes preserved refs" true
+    (List.mem field_preserved_tool_refs R.parse_retry_episode_fields);
+  check bool "nudge field list excludes confidence" false
+    (List.mem field_confidence R.parse_retry_claim_fields);
+  check bool "nudge field list includes source_turn" true
+    (List.mem field_source_turn R.parse_retry_claim_fields);
+  check bool "nudge field list includes source_tool_call_id" true
+    (List.mem field_source_tool_call_id R.parse_retry_claim_fields)
 ;;
 
 let () =

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -253,12 +253,32 @@ let test_cadence_step_keyed () =
     (("t2", 3), true)
     (R.cadence_step_keyed ~cadence:3 ~current_trace:"t2" ~prior:(Some ("t1", 2)))
 
-(* Tolerant parsing for real-world librarian provider drift. *)
+(* Strict parsing with bounded compatibility for real-world librarian provider
+   drift. We accept exact JSON, exact fenced JSON, and JSON-string wrapping, but
+   prose-wrapped or embedded JSON must fall into the diagnostic fallback path
+   instead of being accepted as a structured episode. *)
 
 let parse_ep raw =
   let inp = { Lib.trace_id = "tolerant-t"; generation = 0; messages = [] } in
   Lib.episode_of_output ~now:1_000_000.0 ~generation:inp.generation inp raw
 ;;
+
+let minimal_episode_json ?(claim = "c") () =
+  `Assoc
+    [ "episode_summary", `String "s"
+    ; ( "claims"
+      , `List
+          [ `Assoc
+              [ "claim", `String claim
+              ; "category", `String "fact"
+              ; "source_turn", `Int 0
+              ]
+          ] )
+    ; "open_items", `List []
+    ; "constraints", `List []
+    ; "preserved_tool_refs", `List []
+    ]
+  |> Yojson.Safe.to_string
 
 let test_parses_markdown_wrapped () =
   let raw =
@@ -273,19 +293,18 @@ let test_parses_markdown_wrapped () =
   | None -> Alcotest.fail "markdown-wrapped JSON should parse"
 ;;
 
-let test_parses_prose_wrapped () =
+let test_rejects_prose_wrapped_json () =
+  let raw = "Here is the episode you requested:\n" ^ minimal_episode_json () in
+  check bool "prose before JSON rejected" true (Option.is_none (parse_ep raw));
+  let raw = minimal_episode_json () ^ "\nDone." in
+  check bool "prose after JSON rejected" true (Option.is_none (parse_ep raw));
   let raw =
     "Here is the episode you requested:\n\
-     ```json\n\
-     {\"episode_summary\":\"s\",\"claims\":[],\"open_items\":[],\"constraints\":[],\"preserved_tool_refs\":[]}\n\
-     ```\n\
-     Let me know if you need more."
+     ```json\n"
+    ^ minimal_episode_json ()
+    ^ "\n```\nDone."
   in
-  match parse_ep raw with
-  | Some ep ->
-    check string "episode_summary" "s" ep.episode_summary;
-    check int "claims count" 0 (List.length ep.claims)
-  | None -> Alcotest.fail "prose-wrapped JSON should parse"
+  check bool "prose around fenced JSON rejected" true (Option.is_none (parse_ep raw))
 ;;
 
 let test_parses_json_string_wrapping () =
@@ -310,6 +329,36 @@ let test_parses_string_source_turn () =
      | [ claim ] -> check int "source_turn coerced" 3 claim.source.turn
      | _ -> Alcotest.fail "expected exactly one claim")
   | None -> Alcotest.fail "string source_turn should coerce to int"
+;;
+
+let test_rejects_multiple_json_objects () =
+  let raw = minimal_episode_json () ^ "\n" ^ minimal_episode_json ~claim:"d" () in
+  check bool "multiple JSON objects rejected" true (Option.is_none (parse_ep raw))
+;;
+
+let test_rejects_model_thinking_leak () =
+  let raw =
+    "<thinking>I should output JSON now.</thinking>\n" ^ minimal_episode_json ()
+  in
+  check bool "thinking leak before JSON rejected" true (Option.is_none (parse_ep raw))
+;;
+
+let test_rejects_malformed_json () =
+  let raw =
+    {|{"episode_summary":"s","claims":[{"claim":"c","category":"fact","source_turn":0}],|}
+  in
+  check bool "malformed JSON rejected" true (Option.is_none (parse_ep raw))
+;;
+
+let test_parses_nested_braces_inside_string () =
+  let raw = minimal_episode_json ~claim:"Keep literal { braces } in memory" () in
+  match parse_ep raw with
+  | Some ep ->
+    (match ep.claims with
+     | [ claim ] ->
+       check string "claim with braces parsed" "Keep literal { braces } in memory" claim.claim
+     | claims -> Alcotest.failf "expected one claim, got %d" (List.length claims))
+  | None -> Alcotest.fail "valid JSON with braces in a string should parse"
 ;;
 
 let test_missing_lists_default_to_empty () =
@@ -380,12 +429,17 @@ let () =
             test_cadence_table_bounded_under_trace_rotation;
           test_case "cadence_step_keyed rollover decision" `Quick test_cadence_step_keyed;
         ] );
-      ( "tolerant_parsing",
+      ( "strict_parsing",
         [
           test_case "parses markdown-wrapped JSON" `Quick test_parses_markdown_wrapped;
-          test_case "parses prose-wrapped JSON" `Quick test_parses_prose_wrapped;
+          test_case "rejects prose-wrapped JSON" `Quick test_rejects_prose_wrapped_json;
           test_case "parses JSON-string-wrapped object" `Quick test_parses_json_string_wrapping;
           test_case "coerces string source_turn" `Quick test_parses_string_source_turn;
+          test_case "rejects multiple JSON objects" `Quick test_rejects_multiple_json_objects;
+          test_case "rejects model thinking leak" `Quick test_rejects_model_thinking_leak;
+          test_case "rejects malformed JSON" `Quick test_rejects_malformed_json;
+          test_case "parses nested braces inside string" `Quick
+            test_parses_nested_braces_inside_string;
           test_case "missing lists default to empty" `Quick test_missing_lists_default_to_empty;
           test_case "rejects invalid source_turn string" `Quick test_invalid_source_turn_string_rejected;
           test_case "retry nudge matches schema" `Quick test_retry_nudge_matches_schema;

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -507,12 +507,11 @@ let test_librarian_prompt_omits_private_blocks () =
 
 let valid_librarian_output () =
   `Assoc
-    [ "episode_summary", `String "Integer confidence should still persist"
+    [ "episode_summary", `String "Strict librarian output should persist"
     ; ( "claims"
       , `List
           [ `Assoc
-              [ "claim", `String "Integer confidence survives parsing"
-              ; "confidence", `Int 1
+              [ "claim", `String "Strict librarian claim survives parsing"
               ; "category", `String "test"
               ; "source_turn", `Int 0
               ]
@@ -523,30 +522,45 @@ let valid_librarian_output () =
     ]
 ;;
 
-let test_librarian_accepts_integer_confidence () =
+let test_librarian_rejects_extra_confidence_field () =
   let inp : Librarian.input =
-    { Librarian.trace_id = "trace-int-confidence"
+    { Librarian.trace_id = "trace-extra-confidence"
     ; generation = 4
     ; messages = [ text_message "turn-indexed memory" ]
     }
   in
-  let raw = valid_librarian_output () |> Yojson.Safe.to_string in
-  match Librarian.episode_of_output ~now:1_000_000.0 ~generation:inp.generation inp raw with
-  | Some episode ->
-    (match episode.Types.claims with
-     | [ fact ] ->
-       Alcotest.(check string)
-         "claim parsed"
-         "Integer confidence survives parsing"
-         fact.Types.claim;
-       Alcotest.(check int) "source turn parsed" 0 fact.Types.source.turn;
-       Alcotest.(check (float 0.001)) "created_at deterministic" 1_000_000.0 episode.created_at;
-       Alcotest.(check (option (pair int int)))
-         "source range parsed"
-         (Some (0, 0))
-         episode.Types.source_turn_range
-     | claims -> Alcotest.failf "expected one claim, got %d" (List.length claims))
-  | None -> Alcotest.fail "expected librarian output to parse"
+  let raw =
+    `Assoc
+      [ "episode_summary", `String "summary"
+      ; ( "claims"
+        , `List
+            [ `Assoc
+                [ "claim", `String "claim with deprecated confidence"
+                ; "confidence", `Int 1
+                ; "category", `String "fact"
+                ; "source_turn", `Int 0
+                ]
+            ] )
+      ; "open_items", `List []
+      ; "constraints", `List []
+      ; "preserved_tool_refs", `List []
+      ]
+    |> Yojson.Safe.to_string
+  in
+  match
+    Librarian.episode_of_output_result
+      ~now:1_000_000.0
+      ~generation:inp.generation
+      inp
+      raw
+  with
+  | Error (Librarian.Unexpected_field field) ->
+    Alcotest.(check string) "unexpected field" "confidence" field
+  | Error error ->
+    Alcotest.failf
+      "expected Unexpected_field, got %s"
+      (Librarian.parse_error_to_string error)
+  | Ok _ -> Alcotest.fail "expected deprecated confidence field to be rejected"
 ;;
 
 let test_librarian_generation_override () =
@@ -580,13 +594,11 @@ let test_librarian_ephemeral_fact_has_ttl () =
         , `List
             [ `Assoc
                 [ "claim", `String "checkpoint saved for task T-1"
-                ; "confidence", `Float 0.9
                 ; "category", `String "ephemeral"
                 ; "source_turn", `Int 0
                 ]
             ; `Assoc
                 [ "claim", `String "the build uses dune 3.x"
-                ; "confidence", `Float 0.9
                 ; "category", `String "fact"
                 ; "source_turn", `Int 1
                 ]
@@ -684,7 +696,6 @@ let test_librarian_defaults_missing_optional_lists () =
         , `List
             [ `Assoc
                 [ "claim", `String "Minimal output still records a fact."
-                ; "confidence", `Float 0.9
                 ; "category", `String "fact"
                 ; "source_turn", `Int 0
                 ]
@@ -979,7 +990,6 @@ let test_librarian_preserves_admission_memory_text () =
         , `List
             [ `Assoc
                 [ "claim", `String "Goal cap is 3/3, blocking new task claims."
-                ; "confidence", `Float 0.95
                 ; "category", `String "constraint"
                 ; "source_turn", `Int 3
                 ]
@@ -988,7 +998,6 @@ let test_librarian_preserves_admission_memory_text () =
                   , `String
                       "Memory OS holds stale goal_cap information that incorrectly suggests task claiming is blocked."
                   )
-                ; "confidence", `Float 0.9
                 ; "category", `String "fact"
                 ; "source_turn", `Int 4
                 ]
@@ -1056,7 +1065,6 @@ let test_librarian_preserves_pure_admission_episode () =
         , `List
             [ `Assoc
                 [ "claim", `String "Goal cap is 3/3, blocking new task claims."
-                ; "confidence", `Float 0.95
                 ; "category", `String "constraint"
                 ; "source_turn", `Int 3
                 ]
@@ -1106,7 +1114,6 @@ let test_librarian_rejects_invalid_claims () =
          , `List
              [ `Assoc
                  [ "claim", `String ""
-                 ; "confidence", `Float 0.7
                  ; "category", `String "fact"
                  ; "source_turn", `Int 0
                  ]
@@ -1126,7 +1133,6 @@ let test_librarian_rejects_invalid_claims () =
          , `List
              [ `Assoc
                  [ "claim", `String "valid text"
-                 ; "confidence", `Float 0.7
                  ; "category", `String "fact"
                  ]
              ] )
@@ -1239,16 +1245,16 @@ let test_librarian_runtime_appends_episode_bundle () =
           (json_episode_file_count ~keeper_id);
         (match Memory_io.read_events_tail ~keeper_id ~n:1 with
          | [ episode ] ->
-           Alcotest.(check string)
-             "event persisted"
-             "Integer confidence should still persist"
-             episode.Types.episode_summary
+          Alcotest.(check string)
+            "event persisted"
+            "Strict librarian output should persist"
+            episode.Types.episode_summary
          | events -> Alcotest.failf "expected one event, got %d" (List.length events));
         match Memory_io.read_facts_tail ~keeper_id ~n:1 with
         | [ fact ] ->
           Alcotest.(check string)
             "fact persisted"
-            "Integer confidence survives parsing"
+            "Strict librarian claim survives parsing"
             fact.Types.claim
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
 ;;
@@ -4538,9 +4544,9 @@ let () =
             `Quick
             test_librarian_prompt_omits_private_blocks
         ; Alcotest.test_case
-            "librarian accepts integer confidence"
+            "librarian rejects extra confidence field"
             `Quick
-            test_librarian_accepts_integer_confidence
+            test_librarian_rejects_extra_confidence_field
         ; Alcotest.test_case
             "librarian generation override"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -628,9 +628,7 @@ let test_librarian_accepts_wrapped_json_output () =
   in
   let json = valid_librarian_output () |> Yojson.Safe.to_string in
   let cases =
-    [ "fenced", Printf.sprintf "```json\n%s\n```" json
-    ; "json string", Yojson.Safe.to_string (`String json)
-    ]
+    [ "json string", Yojson.Safe.to_string (`String json) ]
   in
   List.iter
     (fun (name, raw) ->
@@ -641,6 +639,34 @@ let test_librarian_accepts_wrapped_json_output () =
            1
            (List.length episode.Types.claims)
        | None -> Alcotest.failf "expected %s librarian output to parse" name)
+    cases
+;;
+
+let test_librarian_rejects_prose_wrapped_json_output () =
+  let inp : Librarian.input =
+    { Librarian.trace_id = "trace-prose-wrapped-json"
+    ; generation = 6
+    ; messages = [ text_message "prose wrapped JSON memory" ]
+    }
+  in
+  let json = valid_librarian_output () |> Yojson.Safe.to_string in
+  let cases =
+    [ "prose before", "Here is the JSON:\n" ^ json
+    ; "prose after", json ^ "\nDone."
+    ; "markdown fenced", Printf.sprintf "```json\n%s\n```" json
+    ]
+  in
+  List.iter
+    (fun (name, raw) ->
+       Alcotest.(check bool)
+         (name ^ " rejected")
+         true
+         (Option.is_none
+            (Librarian.episode_of_output
+               ~now:1_000_000.0
+               ~generation:inp.generation
+               inp
+               raw)))
     cases
 ;;
 
@@ -4527,6 +4553,10 @@ let () =
             "librarian accepts wrapped json output"
             `Quick
             test_librarian_accepts_wrapped_json_output
+        ; Alcotest.test_case
+            "librarian rejects prose wrapped json output"
+            `Quick
+            test_librarian_rejects_prose_wrapped_json_output
         ; Alcotest.test_case
             "librarian defaults missing optional lists"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -629,7 +629,7 @@ let test_librarian_accepts_wrapped_json_output () =
   let json = valid_librarian_output () |> Yojson.Safe.to_string in
   let cases =
     [ "fenced", Printf.sprintf "```json\n%s\n```" json
-    ; "prefixed", Printf.sprintf "Here is the extracted JSON:\n%s" json
+    ; "json string", Yojson.Safe.to_string (`String json)
     ]
   in
   List.iter

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -691,13 +691,14 @@ let test_librarian_defaults_missing_optional_lists () =
   in
   let raw =
     `Assoc
-      [ "episode_summary", `String "Minimal valid librarian output"
-      ; ( "claims"
+      [ Librarian.wire_field_episode_summary, `String "Minimal valid librarian output"
+      ; ( Librarian.wire_field_claims
         , `List
             [ `Assoc
-                [ "claim", `String "Minimal output still records a fact."
-                ; "category", `String "fact"
-                ; "source_turn", `Int 0
+                [ Librarian.wire_field_claim
+                , `String "Minimal output still records a fact."
+                ; Librarian.wire_field_category, `String "fact"
+                ; Librarian.wire_field_source_turn, `Int 0
                 ]
             ] )
       ]


### PR DESCRIPTION
## Summary
- Remove the Memory OS librarian parser's first-{...}-substring recovery path, so prose-wrapped, multi-object, markdown-fenced, or thinking-leaked output no longer becomes a structured episode.
- Keep bounded compatibility only for exact JSON objects and exact JSON strings whose contents are JSON objects.
- Surface structured parse errors through `episode_of_output_result`, while keeping `episode_of_output` as the option compatibility wrapper.
- Keep retry-nudge schema text in sync with the parser/type SSOT: JSON wire field names come from `Keeper_librarian`, and category/claim-kind tokens come from `Keeper_memory_os_types`.
- Add parser/Memory OS coverage for prose before/after JSON, prose around fenced JSON, markdown-fenced rejection, multiple JSON objects, malformed JSON, model thinking leaks, string `source_turn` rejection, typed parse errors, and valid nested braces inside string values.

## Audit Linkage
- Follows up the P1 finding in `docs/audit/2026-06-26-memory-os-production-audit.md`: LLM Output Parsing Still Uses Heuristic Recovery.
- The diagnostic fallback path remains responsible for invalid provider output; this PR stops embedded JSON salvage from bypassing that path.

## Validation
- `ocamlformat --check lib/keeper/keeper_memory_os_types.ml lib/keeper/keeper_memory_os_types.mli lib/keeper/keeper_librarian.ml lib/keeper/keeper_librarian.mli lib/keeper/keeper_librarian_runtime.ml lib/keeper/keeper_librarian_runtime.mli test/test_keeper_librarian_retry.ml test/test_keeper_memory_os.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_memory_os_types.ml lib/keeper/keeper_librarian.ml lib/keeper/keeper_librarian_runtime.ml test/test_keeper_librarian_retry.ml test/test_keeper_memory_os.ml`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_memory_os_types.mli`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_librarian.mli`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_librarian_runtime.mli`
- `git diff --check`

## CI / Dune
- Local Dune build intentionally not run; Dune/build validation should come from CI per repo workflow.
