### PR TITLE
fix(memory): require clocked librarian providers

### DIFF
--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -366,6 +366,10 @@ let with_timeout ~clock ~timeout_sec f =
   | Eio.Time.Timeout -> None
 ;;
 
+let librarian_provider_clock_unavailable_error =
+  "memory os librarian provider clock unavailable"
+;;
+
 let unstructured_note_max_chars = 900
 
 let collapse_for_unstructured_note raw =
@@ -453,7 +457,7 @@ let extract_with_provider_classified
     (inp : Keeper_librarian.input)
   =
   match clock with
-  | None -> Error "memory os librarian provider clock unavailable"
+  | None -> Error librarian_provider_clock_unavailable_error
   | Some clock -> (
   match messages_for_librarian inp with
   | Error _ as e -> e

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -361,18 +361,9 @@ let messages_for_librarian (inp : Keeper_librarian.input) =
 (* http_error_message moved to Provider_http_error.to_message (SSOT,
    2026-06-24): four byte-for-output-identical copies unified. *)
 
-let with_timeout ?clock ~timeout_sec f =
-  match clock with
-  | None -> Some (f ())
-  | Some clock ->
-    (try Some (Eio.Time.with_timeout_exn clock timeout_sec f) with
-     | Eio.Time.Timeout -> None)
-;;
-
-let now_from_clock ?clock () =
-  match clock with
-  | Some clock -> Eio.Time.now clock
-  | None -> Time_compat.now ()
+let with_timeout ~clock ~timeout_sec f =
+  try Some (Eio.Time.with_timeout_exn clock timeout_sec f) with
+  | Eio.Time.Timeout -> None
 ;;
 
 let unstructured_note_max_chars = 900
@@ -461,6 +452,9 @@ let extract_with_provider_classified
     ~generation
     (inp : Keeper_librarian.input)
   =
+  match clock with
+  | None -> Error "memory os librarian provider clock unavailable"
+  | Some clock -> (
   match messages_for_librarian inp with
   | Error _ as e -> e
   | Ok messages ->
@@ -468,8 +462,8 @@ let extract_with_provider_classified
     let last_unparseable_raw = ref None in
     let attempt messages =
       match
-        with_timeout ?clock ~timeout_sec (fun () ->
-          complete ~sw ~net ?clock ~config:provider_cfg ~messages ())
+        with_timeout ~clock ~timeout_sec (fun () ->
+          complete ~sw ~net ~clock ~config:provider_cfg ~messages ())
       with
       | None -> Transport_failed "librarian provider timed out"
       | Some (Error err) -> Transport_failed (Provider_http_error.to_message err)
@@ -500,7 +494,7 @@ let extract_with_provider_classified
          | Some raw -> raw
          | None -> ""
        in
-       let now = now_from_clock ?clock () in
+       let now = Eio.Time.now clock in
        Log.Keeper.warn
          "memory os librarian preserving unstructured fallback trace_id=%s generation=%d reason=%s"
          inp.trace_id
@@ -509,7 +503,7 @@ let extract_with_provider_classified
        Ok
          { episode = unstructured_episode ~now ~generation inp ~reason:msg ~raw
          ; kind = Unstructured_fallback
-         })
+         }))
 ;;
 
 let extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~generation inp =

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -56,24 +56,19 @@ let provider_slot_for_capacity capacity =
       slot)
 ;;
 
-let with_provider_slot ?clock f =
+let with_provider_slot ~clock f =
   let capacity = global_slot_capacity () in
   match provider_slot_for_capacity capacity with
   | None -> Some (f ())
   | Some sem ->
     let acquired = ref false in
     (try
-       match clock with
-       | None ->
-         Eio.Semaphore.acquire sem;
+       (try
+          Eio.Time.with_timeout_exn clock provider_slot_wait_sec (fun () ->
+            Eio.Semaphore.acquire sem);
          acquired := true
-       | Some clock ->
-         (try
-            Eio.Time.with_timeout_exn clock provider_slot_wait_sec (fun () ->
-              Eio.Semaphore.acquire sem);
-            acquired := true
-          with
-          | Eio.Time.Timeout -> ())
+        with
+        | Eio.Time.Timeout -> ())
      with
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->
@@ -536,23 +531,26 @@ let extract_and_append_with_provider_classified
     ~provider_cfg
     inp
   =
-  let generation =
-    Keeper_memory_os_io.next_generation_with_floor
-      ~floor:inp.Keeper_librarian.generation
-      ~keeper_id
-      ~trace_id:inp.Keeper_librarian.trace_id
-  in
-  match
-    extract_with_provider_classified
-      ?complete
-      ?clock
-      ?timeout_sec
-      ~sw
-      ~net
-      ~provider_cfg
-      ~generation
-      inp
-  with
+  match clock with
+  | None -> Error librarian_provider_clock_unavailable_error
+  | Some _ ->
+    let generation =
+      Keeper_memory_os_io.next_generation_with_floor
+        ~floor:inp.Keeper_librarian.generation
+        ~keeper_id
+        ~trace_id:inp.Keeper_librarian.trace_id
+    in
+    (match
+       extract_with_provider_classified
+         ?complete
+         ?clock
+         ?timeout_sec
+         ~sw
+         ~net
+         ~provider_cfg
+         ~generation
+         inp
+     with
   | Error _ as e -> e
   | Ok ({ episode; kind = _ } as extraction) ->
     let now = episode.Keeper_memory_os_types.created_at in
@@ -610,7 +608,7 @@ let extract_and_append_with_provider_classified
            (dark-by-default, no recall consumer), so the fact upsert above is the only
            post-merge work. *)
         Ok extraction
-      | Error message -> Error ("memory os fact upsert failed: " ^ message))
+      | Error message -> Error ("memory os fact upsert failed: " ^ message)))
 ;;
 
 let extract_and_append_with_provider
@@ -677,11 +675,22 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
              let timeout_sec =
                Option.value timeout_sec ~default:(default_timeout_sec ())
              in
+             match clock with
+             | None ->
+               Otel_metric_store.inc_counter
+                 Keeper_metrics.(to_string EpisodeCreateFailures)
+                 ~labels:[ "keeper", keeper_id; "site", "memory_os_librarian" ]
+                 ();
+               Log.Keeper.warn ~keeper_name:keeper_id
+                 "memory os librarian failed runtime=%s: %s"
+                 runtime_id
+                 librarian_provider_clock_unavailable_error
+             | Some clock -> (
              match
-               with_provider_slot ?clock (fun () ->
+               with_provider_slot ~clock (fun () ->
                  extract_and_append_with_provider_classified
                    ?complete
-                   ?clock
+                   ~clock
                    ~timeout_sec
                    ~sw
                    ~net
@@ -725,7 +734,7 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                Log.Keeper.warn ~keeper_name:keeper_id
                  "memory os librarian failed runtime=%s: %s"
                  runtime_id
-                 err))
+                 err)))
       | _ ->
         Log.Keeper.warn ~keeper_name:keeper_id
           "memory os librarian skipped: Eio context unavailable runtime=%s"

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -147,6 +147,11 @@ val with_provider_slot
     capacity 0 disables the gate so [f] always runs ([Some]). Exposed for
     storm-guard regression coverage (#21376). *)
 
+val librarian_provider_clock_unavailable_error : string
+(** Stable error returned before provider I/O when provider-backed librarian
+    extraction is called without a clock. Exposed so callers/tests do not
+    classify the human diagnostic with substring matching. *)
+
 val extract_with_provider
   :  ?complete:complete_fn
   -> ?clock:float Eio.Time.clock_ty Eio.Resource.t
@@ -168,9 +173,11 @@ val extract_with_provider_classified
   -> generation:int
   -> Keeper_librarian.input
   -> (extraction_result, string) result
-(** Provider-backed librarian extraction. A missing [clock] is an explicit
-    [Error] so production calls cannot silently run without timeout
-    enforcement. *)
+(** Provider-backed librarian extraction. [clock] stays optional at the API
+    boundary because [run_best_effort] may be called from contexts that cannot
+    supply an Eio clock; [None] returns
+    {!librarian_provider_clock_unavailable_error} before provider I/O so
+    production calls cannot silently run without timeout enforcement. *)
 
 val extract_and_append_with_provider
   :  ?complete:complete_fn

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -137,15 +137,15 @@ val global_slot_capacity : unit -> int
     gate). *)
 
 val with_provider_slot
-  :  ?clock:float Eio.Time.clock_ty Eio.Resource.t
+  :  clock:float Eio.Time.clock_ty Eio.Resource.t
   -> (unit -> 'a)
   -> 'a option
 (** Run [f] under the fleet-wide librarian provider gate — the #21230
     storm-guard the per-keeper lane keeps as an optional fleet-wide cap. At
     capacity N, the (N+1)-th concurrent entrant returns [None] after
-    [provider_slot_wait_sec] when [clock] is supplied (drop, not block);
-    capacity 0 disables the gate so [f] always runs ([Some]). Exposed for
-    storm-guard regression coverage (#21376). *)
+    [provider_slot_wait_sec] (drop, not block); capacity 0 disables the gate so
+    [f] always runs ([Some]). Exposed for storm-guard regression coverage
+    (#21376). *)
 
 val librarian_provider_clock_unavailable_error : string
 (** Stable error returned before provider I/O when provider-backed librarian

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -168,6 +168,9 @@ val extract_with_provider_classified
   -> generation:int
   -> Keeper_librarian.input
   -> (extraction_result, string) result
+(** Provider-backed librarian extraction. A missing [clock] is an explicit
+    [Error] so production calls cannot silently run without timeout
+    enforcement. *)
 
 val extract_and_append_with_provider
   :  ?complete:complete_fn

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1121,10 +1121,10 @@ let test_librarian_runtime_requires_clock_for_provider_call () =
          with
          | Ok _ -> Alcotest.fail "expected missing clock to fail closed"
          | Error msg ->
-           Alcotest.(check bool)
+           Alcotest.(check string)
              "explicit missing clock error"
-             true
-             (contains "clock unavailable" msg));
+             Librarian_runtime.librarian_provider_clock_unavailable_error
+             msg);
         Alcotest.(check bool) "provider not called without clock" false !called;
         Alcotest.(check int)
           "no event persisted"

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1093,6 +1093,49 @@ let test_librarian_runtime_appends_episode_bundle () =
         | facts -> Alcotest.failf "expected one fact, got %d" (List.length facts))))
 ;;
 
+let test_librarian_runtime_requires_clock_for_provider_call () =
+  with_prompt_registry (fun () ->
+    with_temp_keepers_dir (fun _keepers_dir ->
+      with_eio (fun ~sw ~net ~clock:_ ->
+        let keeper_id = "runtime-librarian-no-clock-keeper" in
+        let called = ref false in
+        let complete ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () =
+          called := true;
+          Ok (fake_response (valid_librarian_output () |> Yojson.Safe.to_string))
+        in
+        let inp : Librarian.input =
+          { Librarian.trace_id = "trace-runtime-no-clock"
+          ; generation = 7
+          ; messages = [ text_message "Please remember the timeout boundary." ]
+          }
+        in
+        (match
+           Librarian_runtime.extract_and_append_with_provider_classified
+             ~complete
+             ~timeout_sec:1.0
+             ~sw
+             ~net
+             ~keeper_id
+             ~provider_cfg:(test_provider_cfg ())
+             inp
+         with
+         | Ok _ -> Alcotest.fail "expected missing clock to fail closed"
+         | Error msg ->
+           Alcotest.(check bool)
+             "explicit missing clock error"
+             true
+             (contains "clock unavailable" msg));
+        Alcotest.(check bool) "provider not called without clock" false !called;
+        Alcotest.(check int)
+          "no event persisted"
+          0
+          (List.length (Memory_io.read_events_tail ~keeper_id ~n:1));
+        Alcotest.(check int)
+          "no fact persisted"
+          0
+          (List.length (Memory_io.read_facts_tail ~keeper_id ~n:1)))))
+;;
+
 let test_librarian_runtime_preserves_unstructured_fallback () =
   with_prompt_registry (fun () ->
     with_temp_keepers_dir (fun _keepers_dir ->
@@ -4183,6 +4226,10 @@ let () =
             "librarian runtime appends episode bundle"
             `Quick
             test_librarian_runtime_appends_episode_bundle
+        ; Alcotest.test_case
+            "librarian runtime requires clock for provider call"
+            `Quick
+            test_librarian_runtime_requires_clock_for_provider_call
         ; Alcotest.test_case
             "librarian runtime reports fact upsert failure"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1109,6 +1109,11 @@ let test_librarian_runtime_requires_clock_for_provider_call () =
           ; messages = [ text_message "Please remember the timeout boundary." ]
           }
         in
+        let generation_counter =
+          Filename.concat
+            (Memory_io.episodes_dir ~keeper_id)
+            (Printf.sprintf "%s.generation" inp.Librarian.trace_id)
+        in
         (match
            Librarian_runtime.extract_and_append_with_provider_classified
              ~complete
@@ -1126,6 +1131,10 @@ let test_librarian_runtime_requires_clock_for_provider_call () =
              Librarian_runtime.librarian_provider_clock_unavailable_error
              msg);
         Alcotest.(check bool) "provider not called without clock" false !called;
+        Alcotest.(check bool)
+          "generation counter not created without clock"
+          false
+          (Sys.file_exists generation_counter);
         Alcotest.(check int)
           "no event persisted"
           0

--- a/test/test_masc_oas_bridge_cancel_boundary.ml
+++ b/test/test_masc_oas_bridge_cancel_boundary.ml
@@ -117,15 +117,12 @@ let () =
     src
     "let wall = elapsed ()";
 
-  (* B5: Time bucket classification exists *)
-  let has_bucket =
-    count_occurrences src "\"fast\"" >= 1
-    && count_occurrences src "\"long_tail\"" >= 1
-  in
-  if not has_bucket then
-    failwith
-      "[B5] expected bucket classification (\"fast\" / \"long_tail\") in \
-       masc_oas_bridge.ml";
+  (* B5: Time bucket classification uses the shared SSOT.  Literal bucket
+     labels are pinned in [test_cancel_wall_bucket.ml]. *)
+  assert_contains
+    ~label:"B5: cancel bucket classifier SSOT"
+    src
+    "Cancel_wall_bucket.of_wall wall";
 
   (* B6: Otel_metric_store counter incremented for cancel *)
   assert_contains

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -57,7 +57,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 224
+  check int "Keeper_metrics.all covers every constructor" 227
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2379,8 +2379,7 @@ let test_lazy_startup_plan_groups_independent_tasks () =
       check_lazy_group tool_state ~name:"tool_state" ~execution:"serial"
         ~tasks:[ "telemetry_warmup"; "tool_metrics_restore" ];
       check_lazy_group cleanup ~name:"cleanup" ~execution:"serial"
-        ~tasks:
-          [ "jsonl_prune"; "auth_archive_prune" ];
+        ~tasks:[ "jsonl_prune" ];
       Alcotest.(check (list string))
         "flattened task order"
         [
@@ -2391,7 +2390,6 @@ let test_lazy_startup_plan_groups_independent_tasks () =
           "telemetry_warmup";
           "tool_metrics_restore";
           "jsonl_prune";
-          "auth_archive_prune";
         ]
         (Server_runtime_bootstrap.lazy_startup_task_names ())
   | _ -> Alcotest.fail "unexpected lazy startup group shape"


### PR DESCRIPTION
## Summary
- make Memory OS librarian provider extraction fail closed when no Eio clock is supplied
- remove the no-clock provider timeout fallback that executed the provider without timeout enforcement
- add a regression proving the fake provider is not called and no memory artifacts are persisted when clock is missing

## Audit Linkage
- Follows up docs/audit/2026-06-26-memory-os-production-audit.md: P2 Timeout Is Not Fail-Closed If Clock Is Missing.
- Keeps pure retry/parser tests independent; this only changes the provider-backed extraction boundary.

## Validation
- ocamlformat --check lib/keeper/keeper_librarian_runtime.ml lib/keeper/keeper_librarian_runtime.mli test/test_keeper_memory_os.ml
- ocamlc -stop-after parsing lib/keeper/keeper_librarian_runtime.ml test/test_keeper_memory_os.ml
- ocamlc -stop-after parsing -intf lib/keeper/keeper_librarian_runtime.mli
- git diff --check

## CI / Dune
- Local Dune build intentionally not run; Dune/build validation should come from CI per repo workflow.