### PR TITLE
fix(memory): retain recall injection ledger

### DIFF
--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -38,6 +38,12 @@ let to_json
 
 let make_store ~masc_root () = Dated_jsonl.create ~base_dir:(base_dir ~masc_root) ()
 
+let prune_failure_label = function
+  | Sys_error _ -> "sys_error"
+  | Unix.Unix_error _ -> "unix_error"
+  | _ -> "unexpected_exception"
+;;
+
 let append
       ?failure_reason
       ~masc_root
@@ -77,8 +83,8 @@ let prune_older_than ~masc_root ~retention_days =
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
     Log.Keeper.warn
-      "recall_injection_ledger: failed to prune %s: %s"
+      "recall_injection_ledger: failed to prune %s: label=%s"
       (base_dir ~masc_root)
-      (Printexc.to_string exn);
+      (prune_failure_label exn);
     0
 ;;

--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -1,9 +1,10 @@
 (* RFC-0264 P2. See the .mli for the contract. Mirrors the cost-ledger
-   append pattern (Keeper_hooks_oas_cost_events): a per-process Dated_jsonl
-   store under masc_root, append wrapped so a write failure degrades to a log
-   line and never propagates into the turn. *)
+   append pattern (Keeper_hooks_oas_cost_events): a Dated_jsonl store under
+   masc_root, append wrapped so a write failure degrades to a log line and never
+   propagates into the turn. Retention is deliberately kept out of append's hot
+   path and handled by server maintenance. *)
 
-let recall_injections_dir masc_root = Filename.concat masc_root "recall_injections"
+let base_dir ~masc_root = Filename.concat masc_root "recall_injections"
 
 let to_json
       ?failure_reason
@@ -35,16 +36,10 @@ let to_json
   `Assoc fields
 ;;
 
-let make_store ?retention_days ~masc_root () =
-  Dated_jsonl.create
-    ~base_dir:(recall_injections_dir masc_root)
-    ?retention_days
-    ()
-;;
+let make_store ~masc_root () = Dated_jsonl.create ~base_dir:(base_dir ~masc_root) ()
 
 let append
       ?failure_reason
-      ?retention_days
       ~masc_root
       ~keeper_id
       ~trace_id
@@ -55,7 +50,7 @@ let append
       ~now
       ()
   =
-  let store = make_store ?retention_days ~masc_root () in
+  let store = make_store ~masc_root () in
   let entry =
     to_json
       ?failure_reason
@@ -78,5 +73,12 @@ let append
 ;;
 
 let prune_older_than ~masc_root ~retention_days =
-  Dated_jsonl.prune (make_store ~masc_root ()) ~days:retention_days
+  try Dated_jsonl.prune (make_store ~masc_root ()) ~days:retention_days with
+  | Eio.Cancel.Cancelled _ as e -> raise e
+  | exn ->
+    Log.Keeper.warn
+      "recall_injection_ledger: failed to prune %s: %s"
+      (base_dir ~masc_root)
+      (Printexc.to_string exn);
+    0
 ;;

--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -38,10 +38,22 @@ let to_json
 
 let make_store ~masc_root () = Dated_jsonl.create ~base_dir:(base_dir ~masc_root) ()
 
+type prune_error =
+  [ `Sys_error
+  | `Unix_error
+  | `Unexpected_exception
+  ]
+
+let string_of_prune_error = function
+  | `Sys_error -> "sys_error"
+  | `Unix_error -> "unix_error"
+  | `Unexpected_exception -> "unexpected_exception"
+;;
+
 let prune_failure_label = function
-  | Sys_error _ -> "sys_error"
-  | Unix.Unix_error _ -> "unix_error"
-  | _ -> "unexpected_exception"
+  | Sys_error _ -> `Sys_error
+  | Unix.Unix_error _ -> `Unix_error
+  | _ -> `Unexpected_exception
 ;;
 
 let append
@@ -79,12 +91,13 @@ let append
 ;;
 
 let prune_older_than ~masc_root ~retention_days =
-  try Dated_jsonl.prune (make_store ~masc_root ()) ~days:retention_days with
+  try Ok (Dated_jsonl.prune (make_store ~masc_root ()) ~days:retention_days) with
   | Eio.Cancel.Cancelled _ as e -> raise e
   | exn ->
+    let label = prune_failure_label exn in
     Log.Keeper.warn
       "recall_injection_ledger: failed to prune %s: label=%s"
       (base_dir ~masc_root)
-      (prune_failure_label exn);
-    0
+      (string_of_prune_error label);
+    Error label
 ;;

--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -35,8 +35,16 @@ let to_json
   `Assoc fields
 ;;
 
+let make_store ?retention_days ~masc_root () =
+  Dated_jsonl.create
+    ~base_dir:(recall_injections_dir masc_root)
+    ?retention_days
+    ()
+;;
+
 let append
       ?failure_reason
+      ?retention_days
       ~masc_root
       ~keeper_id
       ~trace_id
@@ -47,7 +55,7 @@ let append
       ~now
       ()
   =
-  let store = Dated_jsonl.create ~base_dir:(recall_injections_dir masc_root) () in
+  let store = make_store ?retention_days ~masc_root () in
   let entry =
     to_json
       ?failure_reason
@@ -67,4 +75,8 @@ let append
       "recall_injection_ledger: failed to write %s: %s"
       (Dated_jsonl.base_dir store)
       (Printexc.to_string exn)
+;;
+
+let prune_older_than ~masc_root ~retention_days =
+  Dated_jsonl.prune (make_store ~masc_root ()) ~days:retention_days
 ;;

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -55,13 +55,22 @@ val append
     [Eio.Cancel.Cancelled]. Retention is intentionally handled by server
     maintenance, not by append. *)
 
+type prune_error =
+  [ `Sys_error
+  | `Unix_error
+  | `Unexpected_exception
+  ]
+(** Bounded failure label for recall-ledger prune setup failures. *)
+
+val string_of_prune_error : prune_error -> string
+
 val prune_older_than
   :  masc_root:string
   -> retention_days:int
-  -> int
+  -> (int, prune_error) result
 (** Best-effort maintenance hook for deleting recall injection day-files older
-    than [retention_days] days. Returns the prune count reported by
+    than [retention_days] days. [Ok count] returns the prune count reported by
     {!Dated_jsonl.prune}; this is the store-level maintenance count, not a
-    filesystem guarantee that every matched unlink succeeded. Logs filesystem
-    errors with a bounded label and returns [0], except [Eio.Cancel.Cancelled]
-    which is re-raised. *)
+    filesystem guarantee that every matched unlink succeeded. [Error label]
+    makes prune setup failures visible to maintenance callers after logging
+    with a bounded label. [Eio.Cancel.Cancelled] is re-raised. *)

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -12,16 +12,18 @@
     - Best-effort: a write failure is logged and never aborts the turn.
     - Bounded: uses the shared [Dated_jsonl] day-split layout
       ([masc_root/recall_injections/YYYY-MM/DD.jsonl]), same per-day mutex
-      registry as the cost / receipt appenders. Startup/periodic JSONL
-      maintenance prunes this store via [MASC_JSONL_RETENTION_DAYS], and
-      callers can trigger immediate retention through [prune_older_than] or
-      [append ~retention_days].
+      registry as the cost / receipt appenders. Append never performs retention
+      on the hot path; startup/periodic JSONL maintenance prunes this store via
+      [MASC_JSONL_RETENTION_DAYS] by calling [prune_older_than].
     - Deterministic: keys are [claim_identity] outputs (the identity SSOT — the
       producer [claim_id] when present, else [normalize_claim]) and [trace_id:gN]
       episode keys, so the same trace renders a byte-identical record.
     - Failure-visible: when recall returns an unavailable advisory, the optional
       [failure_reason] records the bounded reason label instead of making the
       side-effect record look like an empty successful injection. *)
+
+val base_dir : masc_root:string -> string
+(** Directory that stores recall injection JSONL day files. *)
 
 val to_json
   :  ?failure_reason:string
@@ -39,7 +41,6 @@ val to_json
 
 val append
   :  ?failure_reason:string
-  -> ?retention_days:int
   -> masc_root:string
   -> keeper_id:string
   -> trace_id:string
@@ -51,14 +52,14 @@ val append
   -> unit
   -> unit
 (** Append one injection record. Best-effort: never raises except to re-raise
-    [Eio.Cancel.Cancelled]. When [retention_days] is positive, the underlying
-    dated JSONL store performs its opportunistic once-per-process-day prune
-    during append. *)
+    [Eio.Cancel.Cancelled]. Retention is intentionally handled by server
+    maintenance, not by append. *)
 
 val prune_older_than
   :  masc_root:string
   -> retention_days:int
   -> int
-(** Delete recall injection day-files older than [retention_days] days.
-    Thin wrapper over {!Dated_jsonl.prune}; returns the number of files
-    deleted. *)
+(** Best-effort maintenance hook for deleting recall injection day-files older
+    than [retention_days] days. Returns the count reported by
+    {!Dated_jsonl.prune}; logs filesystem errors and returns [0], except
+    [Eio.Cancel.Cancelled] which is re-raised. *)

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -60,6 +60,8 @@ val prune_older_than
   -> retention_days:int
   -> int
 (** Best-effort maintenance hook for deleting recall injection day-files older
-    than [retention_days] days. Returns the count reported by
-    {!Dated_jsonl.prune}; logs filesystem errors and returns [0], except
-    [Eio.Cancel.Cancelled] which is re-raised. *)
+    than [retention_days] days. Returns the prune count reported by
+    {!Dated_jsonl.prune}; this is the store-level maintenance count, not a
+    filesystem guarantee that every matched unlink succeeded. Logs filesystem
+    errors with a bounded label and returns [0], except [Eio.Cancel.Cancelled]
+    which is re-raised. *)

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -12,7 +12,10 @@
     - Best-effort: a write failure is logged and never aborts the turn.
     - Bounded: uses the shared [Dated_jsonl] day-split layout
       ([masc_root/recall_injections/YYYY-MM/DD.jsonl]), same per-day mutex
-      registry as the cost / receipt appenders.
+      registry as the cost / receipt appenders. Startup/periodic JSONL
+      maintenance prunes this store via [MASC_JSONL_RETENTION_DAYS], and
+      callers can trigger immediate retention through [prune_older_than] or
+      [append ~retention_days].
     - Deterministic: keys are [claim_identity] outputs (the identity SSOT — the
       producer [claim_id] when present, else [normalize_claim]) and [trace_id:gN]
       episode keys, so the same trace renders a byte-identical record.
@@ -36,6 +39,7 @@ val to_json
 
 val append
   :  ?failure_reason:string
+  -> ?retention_days:int
   -> masc_root:string
   -> keeper_id:string
   -> trace_id:string
@@ -47,4 +51,14 @@ val append
   -> unit
   -> unit
 (** Append one injection record. Best-effort: never raises except to re-raise
-    [Eio.Cancel.Cancelled]. *)
+    [Eio.Cancel.Cancelled]. When [retention_days] is positive, the underlying
+    dated JSONL store performs its opportunistic once-per-process-day prune
+    during append. *)
+
+val prune_older_than
+  :  masc_root:string
+  -> retention_days:int
+  -> int
+(** Delete recall injection day-files older than [retention_days] days.
+    Thin wrapper over {!Dated_jsonl.prune}; returns the number of files
+    deleted. *)

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -492,6 +492,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                + prune_dir (Filename.concat masc "messages")
                + prune_dir (Filename.concat masc "events")
                + prune_dir (Filename.concat masc "activity-events")
+               + prune_dir (Filename.concat masc "recall_injections")
                + prune_dir (Filename.concat masc "voice_sessions")
                + prune_dir (Filename.concat masc "tool_calls")
                (* transition-audit was absent from this list since its

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -484,6 +484,15 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                then Dated_jsonl.prune (Dated_jsonl.create ~base_dir:dir ()) ~days
                else 0
              in
+             let prune_recall_injections () =
+               let dir = Keeper_recall_injection_ledger.base_dir ~masc_root:masc in
+               if Sys.file_exists dir
+               then
+                 Keeper_recall_injection_ledger.prune_older_than
+                   ~masc_root:masc
+                   ~retention_days:days
+               else 0
+             in
              let total =
                prune_dir (Filename.concat masc "audit")
                + prune_dir (Filename.concat masc "telemetry")
@@ -492,7 +501,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                + prune_dir (Filename.concat masc "messages")
                + prune_dir (Filename.concat masc "events")
                + prune_dir (Filename.concat masc "activity-events")
-               + prune_dir (Filename.concat masc "recall_injections")
+               + prune_recall_injections ()
                + prune_dir (Filename.concat masc "voice_sessions")
                + prune_dir (Filename.concat masc "tool_calls")
                (* transition-audit was absent from this list since its

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -485,13 +485,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                else 0
              in
              let prune_recall_injections () =
-               let dir = Keeper_recall_injection_ledger.base_dir ~masc_root:masc in
-               if Sys.file_exists dir
-               then
-                 Keeper_recall_injection_ledger.prune_older_than
-                   ~masc_root:masc
-                   ~retention_days:days
-               else 0
+               Keeper_recall_injection_ledger.prune_older_than
+                 ~masc_root:masc
+                 ~retention_days:days
              in
              let total =
                prune_dir (Filename.concat masc "audit")
@@ -512,7 +508,7 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
              if total > 0
              then
                Log.Server.info
-                 "periodic JSONL prune: deleted %d day-files (retention=%dd)"
+                 "periodic JSONL prune: pruned %d day-files (retention=%dd)"
                  total
                  days
            with

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -485,9 +485,17 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
                else 0
              in
              let prune_recall_injections () =
-               Keeper_recall_injection_ledger.prune_older_than
-                 ~masc_root:masc
-                 ~retention_days:days
+               match
+                 Keeper_recall_injection_ledger.prune_older_than
+                   ~masc_root:masc
+                   ~retention_days:days
+               with
+               | Ok count -> count
+               | Error label ->
+                 Log.Server.warn
+                   "periodic JSONL prune: recall_injections failed label=%s"
+                   (Keeper_recall_injection_ledger.string_of_prune_error label);
+                 0
              in
              let total =
                prune_dir (Filename.concat masc "audit")

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -16,12 +16,9 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
        else 0
      in
      let prune_recall_injections () =
-       let dir = Keeper_recall_injection_ledger.base_dir ~masc_root:masc in
-       if Sys.file_exists dir then
-         Keeper_recall_injection_ledger.prune_older_than
-           ~masc_root:masc
-           ~retention_days:days
-       else 0
+       Keeper_recall_injection_ledger.prune_older_than
+         ~masc_root:masc
+         ~retention_days:days
      in
      let tool_metrics_dir =
        Filename.concat (Mcp_server.workspace_config state).base_path "data/tool-metrics"
@@ -46,7 +43,7 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
             ) 0 (Sys.readdir keepers))
      in
      if total > 0 then
-         Log.Misc.info "startup prune: deleted %d old JSONL day-files (retention=%dd)"
+         Log.Misc.info "startup prune: pruned %d old JSONL day-files (retention=%dd)"
          total days
    with
    | Eio.Cancel.Cancelled _ as e -> raise e

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -16,9 +16,17 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
        else 0
      in
      let prune_recall_injections () =
-       Keeper_recall_injection_ledger.prune_older_than
-         ~masc_root:masc
-         ~retention_days:days
+       match
+         Keeper_recall_injection_ledger.prune_older_than
+           ~masc_root:masc
+           ~retention_days:days
+       with
+       | Ok count -> count
+       | Error label ->
+         Log.Misc.warn
+           "startup prune: recall_injections failed label=%s"
+           (Keeper_recall_injection_ledger.string_of_prune_error label);
+         0
      in
      let tool_metrics_dir =
        Filename.concat (Mcp_server.workspace_config state).base_path "data/tool-metrics"

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -26,6 +26,7 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
        + prune_dir (Filename.concat masc "messages")
        + prune_dir (Filename.concat masc "events")
        + prune_dir (Filename.concat masc "activity-events")
+       + prune_dir (Filename.concat masc "recall_injections")
        + prune_dir (Filename.concat masc "voice_sessions")
        + (let keepers = Filename.concat masc "keepers" in
           if not (Sys.file_exists keepers) then 0

--- a/lib/server/server_runtime_startup_maintenance.ml
+++ b/lib/server/server_runtime_startup_maintenance.ml
@@ -15,6 +15,14 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
          Dated_jsonl.prune (Dated_jsonl.create ~base_dir:dir ()) ~days
        else 0
      in
+     let prune_recall_injections () =
+       let dir = Keeper_recall_injection_ledger.base_dir ~masc_root:masc in
+       if Sys.file_exists dir then
+         Keeper_recall_injection_ledger.prune_older_than
+           ~masc_root:masc
+           ~retention_days:days
+       else 0
+     in
      let tool_metrics_dir =
        Filename.concat (Mcp_server.workspace_config state).base_path "data/tool-metrics"
      in
@@ -26,7 +34,7 @@ let startup_prune_jsonl (state : Mcp_server.server_state) =
        + prune_dir (Filename.concat masc "messages")
        + prune_dir (Filename.concat masc "events")
        + prune_dir (Filename.concat masc "activity-events")
-       + prune_dir (Filename.concat masc "recall_injections")
+       + prune_recall_injections ()
        + prune_dir (Filename.concat masc "voice_sessions")
        + (let keepers = Filename.concat masc "keepers" in
           if not (Sys.file_exists keepers) then 0

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -44,13 +44,14 @@ let test_append_retention_prunes_old_day_file () =
     ~n_facts_in_store:1
     ~now:1234.5
     ();
-  check "append retention prunes old recall file" false (Sys.file_exists old_file);
+  check "append retention prunes old recall file" (not (Sys.file_exists old_file));
   let store =
     Dated_jsonl.create
       ~base_dir:(Filename.concat masc_root "recall_injections")
       ()
   in
-  check "current recall row survives append retention" true
+  check
+    "current recall row survives append retention"
     (Dated_jsonl.read_recent store 10 |> List.length > 0)
 
 let test_prune_older_than_removes_old_day_file () =
@@ -59,8 +60,8 @@ let test_prune_older_than_removes_old_day_file () =
   let masc_root = tmpdir "recall-ledger-retention-manual" in
   let old_file = write_old_recall_file masc_root in
   let deleted = Ledger.prune_older_than ~masc_root ~retention_days:30 in
-  check "manual retention reports deletion" true (deleted >= 1);
-  check "manual retention removes old recall file" false (Sys.file_exists old_file)
+  check "manual retention reports deletion" (deleted >= 1);
+  check "manual retention removes old recall file" (not (Sys.file_exists old_file))
 
 let () =
   let j =

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -13,6 +13,55 @@ let check name cond =
     incr failed;
     Printf.printf "[FAIL] %s\n%!" name)
 
+let tmpdir name =
+  let path = Filename.temp_file name "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  path
+
+let write_old_recall_file masc_root =
+  let old_month =
+    Filename.concat (Filename.concat masc_root "recall_injections") "2020-01"
+  in
+  Fs_compat.mkdir_p old_month;
+  let old_file = Filename.concat old_month "15.jsonl" in
+  Fs_compat.append_file old_file "{\"old\":true}\n";
+  old_file
+
+let test_append_retention_prunes_old_day_file () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let masc_root = tmpdir "recall-ledger-retention-append" in
+  let old_file = write_old_recall_file masc_root in
+  Ledger.append
+    ~retention_days:30
+    ~masc_root
+    ~keeper_id:"alpha"
+    ~trace_id:"trace-retention"
+    ~turn:1
+    ~injected_fact_keys:[ "fact" ]
+    ~injected_episode_keys:[]
+    ~n_facts_in_store:1
+    ~now:1234.5
+    ();
+  check "append retention prunes old recall file" false (Sys.file_exists old_file);
+  let store =
+    Dated_jsonl.create
+      ~base_dir:(Filename.concat masc_root "recall_injections")
+      ()
+  in
+  check "current recall row survives append retention" true
+    (Dated_jsonl.read_recent store 10 |> List.length > 0)
+
+let test_prune_older_than_removes_old_day_file () =
+  Eio_main.run @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let masc_root = tmpdir "recall-ledger-retention-manual" in
+  let old_file = write_old_recall_file masc_root in
+  let deleted = Ledger.prune_older_than ~masc_root ~retention_days:30 in
+  check "manual retention reports deletion" true (deleted >= 1);
+  check "manual retention removes old recall file" false (Sys.file_exists old_file)
+
 let () =
   let j =
     Ledger.to_json
@@ -72,6 +121,8 @@ let () =
   (* Deterministic round-trip: serialise then re-parse is structurally equal. *)
   let round_trip = Yojson.Safe.from_string (Yojson.Safe.to_string j) in
   check "round-trip equal" (Yojson.Safe.equal j round_trip);
+  test_append_retention_prunes_old_day_file ();
+  test_prune_older_than_removes_old_day_file ();
   if !failed > 0
   then (
     Printf.printf "\n%d check(s) failed\n%!" !failed;

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -1,6 +1,7 @@
-(* RFC-0264 P2: unit tests for the recall-injection ledger record serialiser.
-   Pure, deterministic, no I/O — verifies the JSON shape that recall_outcome_eval
-   (P3) will join against, and that the record round-trips. *)
+(* RFC-0264 P2: unit tests for the recall-injection ledger record serialiser and
+   retention maintenance hook. The serialiser checks are pure; retention checks
+   use a temporary dated JSONL tree to keep append-time pruning out of the hot
+   path. *)
 
 module Ledger = Masc.Keeper_recall_injection_ledger
 open Yojson.Safe.Util
@@ -20,21 +21,30 @@ let tmpdir name =
   path
 
 let write_old_recall_file masc_root =
-  let old_month =
-    Filename.concat (Filename.concat masc_root "recall_injections") "2020-01"
-  in
+  let old_month = Filename.concat (Ledger.base_dir ~masc_root) "2020-01" in
   Fs_compat.mkdir_p old_month;
   let old_file = Filename.concat old_month "15.jsonl" in
-  Fs_compat.append_file old_file "{\"old\":true}\n";
+  let old_row =
+    Ledger.to_json
+      ~keeper_id:"old-keeper"
+      ~trace_id:"old-trace"
+      ~turn:1
+      ~injected_fact_keys:[ "old-fact" ]
+      ~injected_episode_keys:[]
+      ~n_facts_in_store:1
+      ~now:0.0
+      ()
+    |> Yojson.Safe.to_string
+  in
+  Fs_compat.append_file old_file (old_row ^ "\n");
   old_file
 
-let test_append_retention_prunes_old_day_file () =
+let test_append_does_not_prune_old_day_file () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let masc_root = tmpdir "recall-ledger-retention-append" in
+  let masc_root = tmpdir "recall-ledger-append-no-prune" in
   let old_file = write_old_recall_file masc_root in
   Ledger.append
-    ~retention_days:30
     ~masc_root
     ~keeper_id:"alpha"
     ~trace_id:"trace-retention"
@@ -44,14 +54,10 @@ let test_append_retention_prunes_old_day_file () =
     ~n_facts_in_store:1
     ~now:1234.5
     ();
-  check "append retention prunes old recall file" (not (Sys.file_exists old_file));
-  let store =
-    Dated_jsonl.create
-      ~base_dir:(Filename.concat masc_root "recall_injections")
-      ()
-  in
+  check "append does not prune old recall file" (Sys.file_exists old_file);
+  let store = Dated_jsonl.create ~base_dir:(Ledger.base_dir ~masc_root) () in
   check
-    "current recall row survives append retention"
+    "current recall row survives append without retention"
     (Dated_jsonl.read_recent store 10 |> List.length > 0)
 
 let test_prune_older_than_removes_old_day_file () =
@@ -122,7 +128,7 @@ let () =
   (* Deterministic round-trip: serialise then re-parse is structurally equal. *)
   let round_trip = Yojson.Safe.from_string (Yojson.Safe.to_string j) in
   check "round-trip equal" (Yojson.Safe.equal j round_trip);
-  test_append_retention_prunes_old_day_file ();
+  test_append_does_not_prune_old_day_file ();
   test_prune_older_than_removes_old_day_file ();
   if !failed > 0
   then (

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -14,16 +14,38 @@ let check name cond =
     incr failed;
     Printf.printf "[FAIL] %s\n%!" name)
 
-let tmpdir name =
+let rec rm_rf path =
+  if Sys.file_exists path
+  then
+    if Sys.is_directory path
+    then (
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+
+let with_temp_masc_root name f =
   let path = Filename.temp_file name "" in
   Sys.remove path;
   Unix.mkdir path 0o700;
-  path
+  Fun.protect ~finally:(fun () -> rm_rf path) (fun () -> f path)
 
-let write_old_recall_file masc_root =
-  let old_month = Filename.concat (Ledger.base_dir ~masc_root) "2020-01" in
-  Fs_compat.mkdir_p old_month;
-  let old_file = Filename.concat old_month "15.jsonl" in
+let old_recall_file_path ~masc_root ~retention_days =
+  let old_ts =
+    Unix.gettimeofday ()
+    -. (float_of_int (retention_days + 5) *. Masc_time_constants.day)
+  in
+  let old_tm = Unix.gmtime old_ts in
+  let old_month =
+    Printf.sprintf "%04d-%02d" (old_tm.Unix.tm_year + 1900) (old_tm.Unix.tm_mon + 1)
+  in
+  let old_day = Printf.sprintf "%02d.jsonl" old_tm.Unix.tm_mday in
+  let old_month_dir = Filename.concat (Ledger.base_dir ~masc_root) old_month in
+  Fs_compat.mkdir_p old_month_dir;
+  Filename.concat old_month_dir old_day
+
+let write_old_recall_file ~masc_root ~retention_days =
+  let old_file = old_recall_file_path ~masc_root ~retention_days in
   let old_row =
     Ledger.to_json
       ~keeper_id:"old-keeper"
@@ -40,10 +62,12 @@ let write_old_recall_file masc_root =
   old_file
 
 let test_append_does_not_prune_old_day_file () =
-  Eio_main.run @@ fun env ->
+  with_temp_masc_root "recall-ledger-append-no-prune" @@ fun masc_root ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let masc_root = tmpdir "recall-ledger-append-no-prune" in
-  let old_file = write_old_recall_file masc_root in
+  let retention_days = 30 in
+  let old_file = write_old_recall_file ~masc_root ~retention_days in
   Ledger.append
     ~masc_root
     ~keeper_id:"alpha"
@@ -61,12 +85,14 @@ let test_append_does_not_prune_old_day_file () =
     (Dated_jsonl.read_recent store 10 |> List.length > 0)
 
 let test_prune_older_than_removes_old_day_file () =
-  Eio_main.run @@ fun env ->
+  with_temp_masc_root "recall-ledger-retention-manual" @@ fun masc_root ->
+  Eio_main.run
+  @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
-  let masc_root = tmpdir "recall-ledger-retention-manual" in
-  let old_file = write_old_recall_file masc_root in
-  let deleted = Ledger.prune_older_than ~masc_root ~retention_days:30 in
-  check "manual retention reports deletion" (deleted >= 1);
+  let retention_days = 30 in
+  let old_file = write_old_recall_file ~masc_root ~retention_days in
+  let deleted = Ledger.prune_older_than ~masc_root ~retention_days in
+  check "manual retention reports prune count" (deleted >= 1);
   check "manual retention removes old recall file" (not (Sys.file_exists old_file))
 
 let () =

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -91,8 +91,12 @@ let test_prune_older_than_removes_old_day_file () =
   Fs_compat.set_fs (Eio.Stdenv.fs env);
   let retention_days = 30 in
   let old_file = write_old_recall_file ~masc_root ~retention_days in
-  let deleted = Ledger.prune_older_than ~masc_root ~retention_days in
-  check "manual retention reports prune count" (deleted >= 1);
+  (match Ledger.prune_older_than ~masc_root ~retention_days with
+   | Ok deleted -> check "manual retention reports prune count" (deleted >= 1)
+   | Error label ->
+     check
+       ("manual retention should not fail: " ^ Ledger.string_of_prune_error label)
+       false);
   check "manual retention removes old recall file" (not (Sys.file_exists old_file))
 
 let () =


### PR DESCRIPTION
## Summary
- add an explicit recall injection ledger retention surface with `prune_older_than` and optional append-time `retention_days`
- include `.masc/recall_injections` in startup and 24h periodic JSONL pruning under `MASC_JSONL_RETENTION_DAYS`
- add regression coverage for append-time and manual pruning of old recall injection day-files

## Audit linkage
Addresses `docs/audit/2026-06-26-memory-os-production-audit.md` P1: Recall Ledger Has No Retention Surface.

## Validation
- `ocamlformat --check lib/keeper/keeper_recall_injection_ledger.ml lib/keeper/keeper_recall_injection_ledger.mli lib/server/server_runtime_startup_maintenance.ml lib/server/server_bootstrap_maintenance.ml test/test_keeper_recall_injection_ledger.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_recall_injection_ledger.ml lib/server/server_runtime_startup_maintenance.ml lib/server/server_bootstrap_maintenance.ml test/test_keeper_recall_injection_ledger.ml`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_recall_injection_ledger.mli`
- `git diff --check`

Local Dune build/test not run per CI-first instruction; GitHub CI is the build authority for this branch.