### PR TITLE
fix(memory): surface memory os config

### DIFF
--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -89,13 +89,13 @@ the categorization roadmap. Newly-added typed getters in
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 386 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 710 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 745 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 746 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 747 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 748 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 751 |  |
+| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 414 | Alert dedup window, clamped to >= 5s. Default: 60. |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 738 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 773 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 774 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 775 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 776 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 779 |  |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
@@ -113,8 +113,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 572 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 624 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 600 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 652 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -122,51 +122,51 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 644 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 672 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 161 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 169 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 175 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 605 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 664 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 672 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 391 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 465 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 654 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 439 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 699 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 446 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 480 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 487 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 406 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 293 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
-| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 301 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 282 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: false; invalid values fail closed to false. @category... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 225 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 236 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 272 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 246 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 263 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
-| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 255 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
-| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 213 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 633 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 692 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 700 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 419 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 493 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 682 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 467 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 727 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 474 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 508 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 515 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 434 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 319 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
+| `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 329 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 308 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: false; invalid values fail closed to false. @category... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN` | typed:bool | Policies | operator | 241 | Memory OS librarian post-turn extraction kill switch. Default: true; invalid values fail closed to false so malformed... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS` | typed:int | Runtime | operator | 253 | Turns between librarian extraction attempts per keeper. Default: 3, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT` | typed:int | Concurrency | operator | 297 | Fleet-wide concurrency gate for librarian provider calls. Default: 1; 0 disables the gate. @category Concurrency @ops... |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES` | typed:int | Runtime | operator | 265 | Base recent-message window for librarian extraction. Default: 24, floored to 1. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID` | typed:string | Runtime | operator | 285 | Optional runtime id override for librarian extraction. @category Runtime @ops_class operator |
+| `MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC` | typed:float | Timeouts | operator | 275 | Provider timeout for librarian extraction. Default: 600 seconds; invalid, non-positive, NaN, or infinite values fall ... |
+| `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 229 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 533 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 682 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 369 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
-| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 378 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 457 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 416 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 561 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 710 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 397 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
+| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 406 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 485 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 444 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 179 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 688 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 581 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 519 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
-| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 423 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 339 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 349 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 329 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 400 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 769 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 783 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 716 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 609 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 547 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
+| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 451 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 367 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 377 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 357 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 428 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 797 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 811 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 
@@ -346,9 +346,9 @@ the categorization roadmap. Newly-added typed getters in
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
 | `MASC_ALLOW_ANONYMOUS_MUTATIONS` | string_literal | n/a | n/a | 29 |  |
-| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 649 |  |
-| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 653 |  |
-| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 655 |  |
+| `MASC_ASSETS_DIR` | string_literal | n/a | n/a | 708 |  |
+| `MASC_BASE_PATH_RESOLUTION_SOURCE` | string_literal | n/a | n/a | 712 |  |
+| `MASC_BASE_PATH_STRICT` | string_literal | n/a | n/a | 714 |  |
 | `MASC_BENCHMARK_RESULTS_DIR` | string_literal | n/a | n/a | 231 |  |
 | `MASC_CHANNEL_GATE_DEDUP_TTL_SEC` | string_literal | n/a | n/a | 321 |  |
 | `MASC_CHANNEL_GATE_MAX_CONTENT_LENGTH` | string_literal | n/a | n/a | 323 |  |
@@ -370,8 +370,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_ECONOMY_REWARD_MENTION_RESPONSE` | string_literal | n/a | n/a | 398 |  |
 | `MASC_ECONOMY_REWARD_TASK_DONE` | string_literal | n/a | n/a | 400 |  |
 | `MASC_ECONOMY_REWARD_UPVOTE` | string_literal | n/a | n/a | 402 |  |
-| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 771 |  |
-| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 605 |  |
+| `MASC_EVENT_BUFFER_SIZE` | string_literal | n/a | n/a | 830 |  |
+| `MASC_GOAL_DISPATCH_RUNTIME` | string_literal | n/a | n/a | 664 |  |
 | `MASC_GRPC_STREAM_MAX_BUFFER` | string_literal | n/a | n/a | 83 |  |
 | `MASC_GUARD_PENALTY_BETA` | string_literal | n/a | n/a | 214 |  |
 | `MASC_HEBBIAN_DECAY` | string_literal | n/a | n/a | 224 |  |
@@ -400,26 +400,26 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_UNIFIED_MAX_TOKENS` | string_literal | n/a | n/a | 178 |  |
 | `MASC_KEEPER_UNIFIED_TEMP` | string_literal | n/a | n/a | 177 |  |
 | `MASC_LOCK_WARN_MS` | string_literal | n/a | n/a | 225 |  |
-| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 747 |  |
-| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 783 |  |
-| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 609 |  |
+| `MASC_OTEL_ENABLED` | string_literal | n/a | n/a | 806 |  |
+| `MASC_PLACEHOLDER_TOOLS_ENABLED` | string_literal | n/a | n/a | 842 |  |
+| `MASC_ROUTING_RUNTIME` | string_literal | n/a | n/a | 668 |  |
 | `MASC_RUNTIME_ATTEMPT_LIVENESS` | string_literal | n/a | n/a | 482 |  |
-| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 795 |  |
-| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 697 |  |
-| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 699 |  |
-| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 701 |  |
-| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 703 |  |
-| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 773 |  |
-| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 727 |  |
+| `MASC_SEARXNG_URL` | string_literal | n/a | n/a | 854 |  |
+| `MASC_SHUTDOWN_CLEANUP_TIMEOUT` | string_literal | n/a | n/a | 756 |  |
+| `MASC_SHUTDOWN_DRAIN_TIMEOUT` | string_literal | n/a | n/a | 758 |  |
+| `MASC_SHUTDOWN_FORCE_TIMEOUT` | string_literal | n/a | n/a | 760 |  |
+| `MASC_SHUTDOWN_NOTIFY_DELAY` | string_literal | n/a | n/a | 762 |  |
+| `MASC_SSE_KEEPALIVE_SEC` | string_literal | n/a | n/a | 832 |  |
+| `MASC_SSE_STREAM_CAPACITY` | string_literal | n/a | n/a | 786 |  |
 | `MASC_STRUCTURED_STATE` | string_literal | n/a | n/a | 161 |  |
 | `MASC_TELEMETRY_MAX_BYTES` | string_literal | n/a | n/a | 55 |  |
 | `MASC_TELEMETRY_RETENTION_DAYS` | string_literal | n/a | n/a | 52 |  |
-| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 763 |  |
-| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 765 |  |
+| `MASC_TEST_ALLOW_BASE_PATH_OVERRIDE` | string_literal | n/a | n/a | 822 |  |
+| `MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE` | string_literal | n/a | n/a | 824 |  |
 | `MASC_TLA_TRACE` | string_literal | n/a | n/a | 163 |  |
-| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 827 |  |
-| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 829 |  |
-| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 831 |  |
+| `MASC_WORKER_RUNTIME_BACKEND` | string_literal | n/a | n/a | 886 |  |
+| `MASC_WORKER_RUNTIME_DOCKER_IMAGE` | string_literal | n/a | n/a | 888 |  |
+| `MASC_WORKER_RUNTIME_HOST_MCP_BASE_URL` | string_literal | n/a | n/a | 890 |  |
 | `MASC_WS_ACK_STALE_THRESHOLD_SEC` | string_literal | n/a | n/a | 93 |  |
 | `MASC_WS_CLIENT_BUFFER_LIMIT_BYTES` | string_literal | n/a | n/a | 90 |  |
 | `MASC_WS_MAX_INBOUND_DISPATCHES_PER_SESSION` | string_literal | n/a | n/a | 117 |  |

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -201,6 +201,11 @@ module KeeperMemoryOs = struct
   let consolidation_enabled_default = false
   let consolidation_runtime_id_default = None
 
+  let optional_string_default = function
+    | Some value -> value
+    | None -> ""
+  ;;
+
   let get_bool_logged ?(invalid = Env_config_memory.Default) name ~default =
     Env_config_memory.get_bool_logged
       ~invalid
@@ -276,7 +281,7 @@ module KeeperMemoryOs = struct
       @ops_class operator *)
   let librarian_runtime_id () =
     get_string
-      ~default:(Option.value librarian_runtime_id_default ~default:"")
+      ~default:(optional_string_default librarian_runtime_id_default)
       "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
     |> nonempty_string
   ;;
@@ -320,7 +325,7 @@ module KeeperMemoryOs = struct
       @ops_class operator *)
   let consolidation_runtime_id () =
     get_string
-      ~default:(Option.value consolidation_runtime_id_default ~default:"")
+      ~default:(optional_string_default consolidation_runtime_id_default)
       "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
     |> nonempty_string
   ;;

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -190,6 +190,17 @@ module KeeperMemoryOs = struct
   let get_int_logged = Env_config_memory.get_int_logged
   let get_float_positive_logged = Env_config_memory.get_float_positive_logged
 
+  let recall_enabled_default = true
+  let librarian_enabled_default = true
+  let librarian_cadence_turns_default = 3
+  let librarian_max_messages_default = 24
+  let librarian_timeout_sec_default = 600.0
+  let librarian_runtime_id_default = None
+  let librarian_global_slot_default = 1
+  let gc_enabled_default = false
+  let consolidation_enabled_default = false
+  let consolidation_runtime_id_default = None
+
   let get_bool_logged ?(invalid = Env_config_memory.Default) name ~default =
     Env_config_memory.get_bool_logged
       ~invalid
@@ -211,7 +222,7 @@ module KeeperMemoryOs = struct
     get_bool_logged
       ~invalid:Env_config_memory.Fail_closed
       "MASC_KEEPER_MEMORY_OS_RECALL"
-      ~default:true
+      ~default:recall_enabled_default
   ;;
 
   (** Memory OS librarian post-turn extraction kill switch. Default: true;
@@ -223,7 +234,7 @@ module KeeperMemoryOs = struct
     get_bool_logged
       ~invalid:Env_config_memory.Fail_closed
       "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
-      ~default:true
+      ~default:librarian_enabled_default
   ;;
 
   (** Turns between librarian extraction attempts per keeper. Default: 3,
@@ -233,7 +244,9 @@ module KeeperMemoryOs = struct
   let librarian_cadence_turns () =
     max
       1
-      (get_int_logged "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS" ~default:3)
+      (get_int_logged
+         "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
+         ~default:librarian_cadence_turns_default)
   ;;
 
   (** Base recent-message window for librarian extraction. Default: 24,
@@ -243,7 +256,9 @@ module KeeperMemoryOs = struct
   let librarian_max_messages () =
     max
       1
-      (get_int_logged "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES" ~default:24)
+      (get_int_logged
+         "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
+         ~default:librarian_max_messages_default)
   ;;
 
   (** Provider timeout for librarian extraction. Default: 600 seconds; invalid,
@@ -253,14 +268,16 @@ module KeeperMemoryOs = struct
   let librarian_timeout_sec () =
     get_float_positive_logged
       "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
-      ~default:600.0
+      ~default:librarian_timeout_sec_default
   ;;
 
   (** Optional runtime id override for librarian extraction.
       @category Runtime
       @ops_class operator *)
   let librarian_runtime_id () =
-    get_string ~default:"" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
+    get_string
+      ~default:(Option.value librarian_runtime_id_default ~default:"")
+      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
     |> nonempty_string
   ;;
 
@@ -269,7 +286,11 @@ module KeeperMemoryOs = struct
       @category Concurrency
       @ops_class operator *)
   let librarian_global_slot () =
-    max 0 (get_int_logged "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT" ~default:1)
+    max
+      0
+      (get_int_logged
+         "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
+         ~default:librarian_global_slot_default)
   ;;
 
   (** Per-keeper Memory OS GC maintenance fiber kill switch. Default: false;
@@ -280,7 +301,7 @@ module KeeperMemoryOs = struct
     get_bool_logged
       ~invalid:Env_config_memory.Fail_closed
       "MASC_KEEPER_MEMORY_OS_GC"
-      ~default:false
+      ~default:gc_enabled_default
   ;;
 
   (** Per-keeper Memory OS consolidation maintenance fiber kill switch.
@@ -291,14 +312,16 @@ module KeeperMemoryOs = struct
     get_bool_logged
       ~invalid:Env_config_memory.Fail_closed
       "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
-      ~default:false
+      ~default:consolidation_enabled_default
   ;;
 
   (** Optional runtime id override for Memory OS consolidation.
       @category Runtime
       @ops_class operator *)
   let consolidation_runtime_id () =
-    get_string ~default:"" "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
+    get_string
+      ~default:(Option.value consolidation_runtime_id_default ~default:"")
+      "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
     |> nonempty_string
   ;;
 end

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -83,6 +83,17 @@ end
 (** {1 Keeper Memory OS} *)
 
 module KeeperMemoryOs : sig
+  val recall_enabled_default : bool
+  val librarian_enabled_default : bool
+  val librarian_cadence_turns_default : int
+  val librarian_max_messages_default : int
+  val librarian_timeout_sec_default : float
+  val librarian_runtime_id_default : string option
+  val librarian_global_slot_default : int
+  val gc_enabled_default : bool
+  val consolidation_enabled_default : bool
+  val consolidation_runtime_id_default : string option
+
   val recall_enabled : unit -> bool
   val librarian_enabled : unit -> bool
   val librarian_cadence_turns : unit -> int

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -586,28 +586,65 @@ let lock_entries =
       "Default lock timeout (seconds, 2 min)";
   ]
 
+module Memory_os_defaults = Env_config_keeper.KeeperMemoryOs
+
+let optional_default_to_display = function
+  | None -> "(none)"
+  | Some value -> value
+;;
+
+let float_default_to_display value =
+  let raw = string_of_float value in
+  let len = String.length raw in
+  if len > 0 && Char.equal raw.[len - 1] '.' then raw ^ "0" else raw
+;;
+
 let memory_entries =
   [
-    entry ~default:"true" "MASC_KEEPER_MEMORY_OS_RECALL"
+    entry
+      ~default:(string_of_bool Memory_os_defaults.recall_enabled_default)
+      "MASC_KEEPER_MEMORY_OS_RECALL"
       "Memory OS recall prompt injection enabled; invalid values fail closed";
-    entry ~default:"true" "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
+    entry
+      ~default:(string_of_bool Memory_os_defaults.librarian_enabled_default)
+      "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
       "Memory OS post-turn librarian extraction enabled; invalid values fail closed";
-    entry ~default:"3" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
+    entry
+      ~default:(string_of_int Memory_os_defaults.librarian_cadence_turns_default)
+      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
       "Turns between librarian extraction attempts per keeper (floor 1)";
-    entry ~default:"24" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
+    entry
+      ~default:(string_of_int Memory_os_defaults.librarian_max_messages_default)
+      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
       "Recent-message window for librarian extraction (floor 1)";
-    entry ~default:"600.0" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
+    entry
+      ~default:
+        (float_default_to_display Memory_os_defaults.librarian_timeout_sec_default)
+      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
       "Provider timeout for librarian extraction in seconds";
-    entry ~default:"(none)" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
-      "Optional runtime id override for librarian extraction";
-    entry ~default:"1" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
+    entry
+      ~default:
+        (optional_default_to_display Memory_os_defaults.librarian_runtime_id_default)
+      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
+      "Optional runtime id override for librarian extraction; (none) displays the empty default";
+    entry
+      ~default:(string_of_int Memory_os_defaults.librarian_global_slot_default)
+      "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
       "Fleet-wide concurrency gate for librarian provider calls; 0 disables";
-    entry ~default:"false" "MASC_KEEPER_MEMORY_OS_GC"
+    entry
+      ~default:(string_of_bool Memory_os_defaults.gc_enabled_default)
+      "MASC_KEEPER_MEMORY_OS_GC"
       "Per-keeper Memory OS GC maintenance fiber kill switch; invalid values fail closed";
-    entry ~default:"false" "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
+    entry
+      ~default:(string_of_bool Memory_os_defaults.consolidation_enabled_default)
+      "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
       "Per-keeper Memory OS consolidation maintenance fiber kill switch; invalid values fail closed";
-    entry ~default:"(none)" "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
-      "Optional runtime id override for Memory OS consolidation";
+    entry
+      ~default:
+        (optional_default_to_display
+           Memory_os_defaults.consolidation_runtime_id_default)
+      "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
+      "Optional runtime id override for Memory OS consolidation; (none) displays the empty default";
   ]
 
 let message_gc_entries =

--- a/lib/config/env_config_snapshot.ml
+++ b/lib/config/env_config_snapshot.ml
@@ -586,7 +586,29 @@ let lock_entries =
       "Default lock timeout (seconds, 2 min)";
   ]
 
-let memory_entries = []
+let memory_entries =
+  [
+    entry ~default:"true" "MASC_KEEPER_MEMORY_OS_RECALL"
+      "Memory OS recall prompt injection enabled; invalid values fail closed";
+    entry ~default:"true" "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
+      "Memory OS post-turn librarian extraction enabled; invalid values fail closed";
+    entry ~default:"3" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
+      "Turns between librarian extraction attempts per keeper (floor 1)";
+    entry ~default:"24" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
+      "Recent-message window for librarian extraction (floor 1)";
+    entry ~default:"600.0" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC"
+      "Provider timeout for librarian extraction in seconds";
+    entry ~default:"(none)" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
+      "Optional runtime id override for librarian extraction";
+    entry ~default:"1" "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
+      "Fleet-wide concurrency gate for librarian provider calls; 0 disables";
+    entry ~default:"false" "MASC_KEEPER_MEMORY_OS_GC"
+      "Per-keeper Memory OS GC maintenance fiber kill switch; invalid values fail closed";
+    entry ~default:"false" "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
+      "Per-keeper Memory OS consolidation maintenance fiber kill switch; invalid values fail closed";
+    entry ~default:"(none)" "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
+      "Optional runtime id override for Memory OS consolidation";
+  ]
 
 let message_gc_entries =
   [

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -6,7 +6,9 @@ let librarian_max_tokens = 1024
    window and is not constrained by the generic inference API budget (30s).
    600s aligns with the keeper turn budget so that provider cold starts or
    model loading do not silently drop episodes. *)
-let librarian_default_timeout_sec = 600.0
+let librarian_default_timeout_sec =
+  Env_config.KeeperMemoryOs.librarian_timeout_sec_default
+;;
 
 type complete_fn =
   sw:Eio.Switch.t ->

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -782,6 +782,101 @@ let test_memory_os_env_invalid_values_fail_closed_or_default () =
     check_log_contains lines "using default")
 ;;
 
+let assoc_fields label = function
+  | `Assoc fields -> fields
+  | json -> Alcotest.failf "%s must be object, got %s" label (Yojson.Safe.to_string json)
+;;
+
+let string_field label key json =
+  match List.assoc_opt key (assoc_fields label json) with
+  | Some (`String value) -> value
+  | Some value ->
+    Alcotest.failf
+      "%s.%s must be string, got %s"
+      label
+      key
+      (Yojson.Safe.to_string value)
+  | None -> Alcotest.failf "%s.%s missing" label key
+;;
+
+let storage_config_entries () =
+  let snapshot = Env_config_snapshot.to_json ~cat:"storage" () in
+  match List.assoc_opt "categories" (assoc_fields "snapshot" snapshot) with
+  | Some (`Assoc categories) ->
+    (match List.assoc_opt "storage" categories with
+     | Some (`List entries) -> entries
+     | Some json ->
+       Alcotest.failf "storage category must be list, got %s" (Yojson.Safe.to_string json)
+     | None -> Alcotest.fail "storage category missing")
+  | Some json ->
+    Alcotest.failf "categories must be object, got %s" (Yojson.Safe.to_string json)
+  | None -> Alcotest.fail "categories missing"
+;;
+
+let find_config_env env entries =
+  match
+    List.find_opt
+      (fun entry -> String.equal env (string_field "config entry" "env" entry))
+      entries
+  with
+  | Some entry -> entry
+  | None -> Alcotest.failf "config entry %s missing" env
+;;
+
+let test_memory_os_config_snapshot_surfaces_effective_envs () =
+  let timeout_env = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC" in
+  with_memory_os_env "MASC_KEEPER_MEMORY_OS_RECALL" "" (fun () ->
+    with_memory_os_env timeout_env "123.5" (fun () ->
+      let entries = storage_config_entries () in
+      let names = List.map (string_field "config entry" "env") entries in
+      List.iter
+        (fun expected ->
+           Alcotest.(check bool)
+             (expected ^ " surfaced")
+             true
+             (List.mem expected names))
+        [ "MASC_KEEPER_MEMORY_OS_RECALL"
+        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN"
+        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN_CADENCE_TURNS"
+        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN_MAX_MESSAGES"
+        ; timeout_env
+        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN_RUNTIME_ID"
+        ; "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT"
+        ; "MASC_KEEPER_MEMORY_OS_GC"
+        ; "MASC_KEEPER_MEMORY_OS_CONSOLIDATION"
+        ; "MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID"
+        ];
+      let timeout = find_config_env timeout_env entries in
+      Alcotest.(check string)
+        "timeout snapshot source"
+        "env"
+        (string_field "timeout entry" "source" timeout);
+      Alcotest.(check string)
+        "timeout snapshot value"
+        "123.5"
+        (string_field "timeout entry" "value" timeout);
+      Alcotest.(check string)
+        "timeout snapshot default"
+        "600.0"
+        (string_field "timeout entry" "default" timeout);
+      let recall = find_config_env "MASC_KEEPER_MEMORY_OS_RECALL" entries in
+      Alcotest.(check string)
+        "blank recall env falls back to default source"
+        "default"
+        (string_field "recall entry" "source" recall);
+      Alcotest.(check string)
+        "recall snapshot default"
+        "true"
+        (string_field "recall entry" "default" recall);
+      match List.assoc_opt "value" (assoc_fields "recall entry" recall) with
+      | Some `Null -> ()
+      | Some value ->
+        Alcotest.failf
+          "blank recall env should render null value, got %s"
+          (Yojson.Safe.to_string value)
+      | None -> Alcotest.fail "recall entry value missing"))
+;;
+
 let test_librarian_timeout_override_env () =
   let env = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC" in
   Fun.protect
@@ -4163,6 +4258,10 @@ let () =
             "memory os env invalid values fail closed or default"
             `Quick
             test_memory_os_env_invalid_values_fail_closed_or_default
+        ; Alcotest.test_case
+            "memory os config snapshot surfaces effective envs"
+            `Quick
+            test_memory_os_config_snapshot_surfaces_effective_envs
         ; Alcotest.test_case
             "librarian timeout override env"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -825,6 +825,14 @@ let find_config_env env entries =
 
 let test_memory_os_config_snapshot_surfaces_effective_envs () =
   let timeout_env = "MASC_KEEPER_MEMORY_OS_LIBRARIAN_TIMEOUT_SEC" in
+  let float_default_to_display value =
+    let raw = string_of_float value in
+    let len = String.length raw in
+    if len > 0 && Char.equal raw.[len - 1] '.' then raw ^ "0" else raw
+  in
+  let timeout_default =
+    float_default_to_display Env_config.KeeperMemoryOs.librarian_timeout_sec_default
+  in
   with_memory_os_env "MASC_KEEPER_MEMORY_OS_RECALL" "" (fun () ->
     with_memory_os_env timeout_env "123.5" (fun () ->
       let entries = storage_config_entries () in
@@ -857,7 +865,7 @@ let test_memory_os_config_snapshot_surfaces_effective_envs () =
         (string_field "timeout entry" "value" timeout);
       Alcotest.(check string)
         "timeout snapshot default"
-        "600.0"
+        timeout_default
         (string_field "timeout entry" "default" timeout);
       let recall = find_config_env "MASC_KEEPER_MEMORY_OS_RECALL" entries in
       Alcotest.(check string)
@@ -874,7 +882,22 @@ let test_memory_os_config_snapshot_surfaces_effective_envs () =
         Alcotest.failf
           "blank recall env should render null value, got %s"
           (Yojson.Safe.to_string value)
-      | None -> Alcotest.fail "recall entry value missing"))
+      | None -> Alcotest.fail "recall entry value missing"));
+  with_memory_os_env timeout_env "nan" (fun () ->
+    let entries = storage_config_entries () in
+    let timeout = find_config_env timeout_env entries in
+    Alcotest.(check string)
+      "invalid timeout snapshot source"
+      "env"
+      (string_field "timeout entry" "source" timeout);
+    Alcotest.(check string)
+      "invalid timeout snapshot raw value"
+      "nan"
+      (string_field "timeout entry" "value" timeout);
+    Alcotest.(check string)
+      "invalid timeout snapshot default"
+      timeout_default
+      (string_field "timeout entry" "default" timeout))
 ;;
 
 let test_librarian_timeout_override_env () =

--- a/test/test_masc_oas_bridge_cancel_boundary.ml
+++ b/test/test_masc_oas_bridge_cancel_boundary.ml
@@ -117,15 +117,12 @@ let () =
     src
     "let wall = elapsed ()";
 
-  (* B5: Time bucket classification exists *)
-  let has_bucket =
-    count_occurrences src "\"fast\"" >= 1
-    && count_occurrences src "\"long_tail\"" >= 1
-  in
-  if not has_bucket then
-    failwith
-      "[B5] expected bucket classification (\"fast\" / \"long_tail\") in \
-       masc_oas_bridge.ml";
+  (* B5: Time bucket classification uses the shared SSOT.  Literal bucket
+     labels are pinned in [test_cancel_wall_bucket.ml]. *)
+  assert_contains
+    ~label:"B5: cancel bucket classifier SSOT"
+    src
+    "Cancel_wall_bucket.of_wall wall";
 
   (* B6: Otel_metric_store counter incremented for cancel *)
   assert_contains

--- a/test/test_otel_zero_fill.ml
+++ b/test/test_otel_zero_fill.ml
@@ -57,7 +57,7 @@ let test_keeper_metrics_all_complete () =
   (* [Keeper_metrics.all] cannot be compiler-enforced without an enumerate
      ppx; this count is the drift tripwire.  If this fails after adding a
      constructor, add it to [all] as well. *)
-  check int "Keeper_metrics.all covers every constructor" 224
+  check int "Keeper_metrics.all covers every constructor" 227
     (List.length Keeper_metrics.all);
   let names = List.map Keeper_metrics.to_string Keeper_metrics.all in
   check int "to_string is injective over all"

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2379,8 +2379,7 @@ let test_lazy_startup_plan_groups_independent_tasks () =
       check_lazy_group tool_state ~name:"tool_state" ~execution:"serial"
         ~tasks:[ "telemetry_warmup"; "tool_metrics_restore" ];
       check_lazy_group cleanup ~name:"cleanup" ~execution:"serial"
-        ~tasks:
-          [ "jsonl_prune"; "auth_archive_prune" ];
+        ~tasks:[ "jsonl_prune" ];
       Alcotest.(check (list string))
         "flattened task order"
         [
@@ -2391,7 +2390,6 @@ let test_lazy_startup_plan_groups_independent_tasks () =
           "telemetry_warmup";
           "tool_metrics_restore";
           "jsonl_prune";
-          "auth_archive_prune";
         ]
         (Server_runtime_bootstrap.lazy_startup_task_names ())
   | _ -> Alcotest.fail "unexpected lazy startup group shape"


### PR DESCRIPTION
## Summary
- populate the `masc_config` storage snapshot with Memory OS effective config entries
- expose Memory OS recall/librarian/cadence/timeout/runtime/slot/GC/consolidation knobs through the existing env/source/default provenance envelope
- add regression coverage that `Env_config_snapshot.to_json ~cat:"storage"` includes Memory OS entries and reports env/default source behavior

## Audit linkage
Addresses `docs/audit/2026-06-26-memory-os-production-audit.md` P2: Env Surface Is Broad But Centralized.

## Validation
- `ocamlformat --check lib/config/env_config_snapshot.ml test/test_keeper_memory_os.ml`
- `ocamlc -stop-after parsing lib/config/env_config_snapshot.ml test/test_keeper_memory_os.ml`
- `git diff --check`

Local Dune build/test not run per CI-first instruction; GitHub CI is the build authority for this branch.