### PR TITLE
fix(oas-bridge): fail closed without eio clock

### DIFF
--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -381,7 +381,8 @@ let () =
   let net = Eio.Stdenv.net env in
   (* Capture the Eio handles the OAS/fusion call path reads via
      [Masc_eio_env.get_opt]. Without this, [Masc_oas_bridge.run_safe] finds no
-     clock and runs the panel/judge calls without timeout enforcement. *)
+     clock and rejects panel/judge calls instead of silently bypassing timeout
+     enforcement. *)
   Masc.Masc_eio_env.init ~sw ~net ~clock:(Eio.Stdenv.clock env) ();
   let config_path = Masc.Fusion_config_loader.runtime_toml_path ~base_path in
   (match Runtime.init_default_strict ~config_path with

--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -542,8 +542,8 @@ let () =
     Eio.Switch.run @@ fun sw ->
     let net = Eio.Stdenv.net env in
     (* Capture the Eio handles the OAS call path reads via Masc_eio_env.get_opt.
-       Without this the live LLM call path finds no clock and runs without
-       timeout enforcement. *)
+       Without this the live LLM call path finds no clock and fails closed
+       instead of silently bypassing timeout enforcement. *)
     Masc.Masc_eio_env.init ~sw ~net ~clock:(Eio.Stdenv.clock env) ();
     let config_path = runtime_toml_path ~base_path in
     (match Runtime.init_default_strict ~config_path with

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -77,6 +77,11 @@ module Compression : sig
       data shorter than 256 bytes is kept as-is.  Raw zstd
       compression is delegated to {!Compression_codec}, which owns
       compression failure diagnostics. *)
+  val compress_zstd_result
+    :  original:string
+    -> Compression_codec.compress_result
+    -> string * bool
+
   val compress_zstd : ?level:int -> string -> string * bool
 end
 

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -17,7 +17,10 @@
 let min_timeout_s = 0.0
 
 let run_safe ~caller ~timeout_s fn =
-  if Float.classify_float timeout_s = FP_nan || Float.compare timeout_s 0.0 <= 0 then
+  if
+    Float.classify_float timeout_s = FP_nan
+    || Float.compare timeout_s min_timeout_s <= 0
+  then
     invalid_arg
       (Printf.sprintf
          "Masc_oas_bridge.run_safe: timeout_s must be positive or infinite \
@@ -35,7 +38,7 @@ let run_safe ~caller ~timeout_s fn =
     Log.Misc.error "%s" detail;
     Error
       (Keeper_internal_error.sdk_error_of_masc_internal_error
-         (Keeper_internal_error.Internal_contract_rejected { reason = detail }))
+         (Keeper_internal_error.Internal_bridge_exception { caller; exn_repr = detail }))
   in
   let clock =
     match Masc_eio_env.get_opt () with
@@ -49,7 +52,11 @@ let run_safe ~caller ~timeout_s fn =
   | Ok clock ->
   let t0 = Eio.Time.now clock in
   let elapsed () = Eio.Time.now clock -. t0 in
-  let do_timeout fn = Eio.Time.with_timeout_exn clock timeout_s fn in
+  let do_timeout fn =
+    if Float.classify_float timeout_s = FP_infinite
+    then fn ()
+    else Eio.Time.with_timeout_exn clock timeout_s fn
+  in
   try
     do_timeout fn
   with

--- a/lib/masc_oas_bridge.ml
+++ b/lib/masc_oas_bridge.ml
@@ -3,7 +3,7 @@
     Enforces strict structural timeouts, cancellation safety, and type isolation. *)
 
 (** Safe execution of a generic OAS operation.
-    Applies timeout handling when an Eio clock is available, and converts
+    Applies timeout handling with the initialized Eio clock, and converts
     [Eio.Time.Timeout] into an error result.
     [Eio.Cancel.Cancelled] is always re-raised to preserve structured concurrency.
 
@@ -23,33 +23,33 @@ let run_safe ~caller ~timeout_s fn =
          "Masc_oas_bridge.run_safe: timeout_s must be positive or infinite \
           (got %.6g)"
          timeout_s);
-  let clock_opt =
+  let fail_without_clock ~reason =
+    let detail =
+      Printf.sprintf
+        "masc_oas_bridge: Eio clock unavailable (%s); refusing to run caller=%s \
+         without enforcing timeout_s=%.6g"
+        reason
+        caller
+        timeout_s
+    in
+    Log.Misc.error "%s" detail;
+    Error
+      (Keeper_internal_error.sdk_error_of_masc_internal_error
+         (Keeper_internal_error.Internal_contract_rejected { reason = detail }))
+  in
+  let clock =
     match Masc_eio_env.get_opt () with
-    | Some { clock; _ } -> clock
-    | None -> None
+    | None -> Error (`Missing_env)
+    | Some { clock = None; _ } -> Error (`Missing_clock)
+    | Some { clock = Some clock; _ } -> Ok clock
   in
-  let t0 =
-    match clock_opt with
-    | Some clock -> Eio.Time.now clock
-    | None -> Unix.gettimeofday ()
-  in
-  let elapsed () =
-    match clock_opt with
-    | Some clock -> Eio.Time.now clock -. t0
-    | None -> Unix.gettimeofday () -. t0
-  in
-  let do_timeout fn =
-    match clock_opt with
-    | Some clock -> Eio.Time.with_timeout_exn clock timeout_s fn
-    | None ->
-      (* #18476: defensive — server bootstrap always provides a clock,
-         but if reached without one, the timeout is unenforceable. *)
-      Log.Misc.warn
-        "masc_oas_bridge.run_safe: no Eio clock available, running \
-         without timeout enforcement (caller=%s, budget=%.1fs)"
-        caller timeout_s;
-      fn ()
-  in
+  match clock with
+  | Error `Missing_env -> fail_without_clock ~reason:"env_not_initialized"
+  | Error `Missing_clock -> fail_without_clock ~reason:"clock_not_initialized"
+  | Ok clock ->
+  let t0 = Eio.Time.now clock in
+  let elapsed () = Eio.Time.now clock -. t0 in
+  let do_timeout fn = Eio.Time.with_timeout_exn clock timeout_s fn in
   try
     do_timeout fn
   with

--- a/lib/masc_oas_bridge.mli
+++ b/lib/masc_oas_bridge.mli
@@ -4,10 +4,14 @@
     Enforces strict structural timeouts, cancellation safety, and type isolation. *)
 
 (** Safe execution of a generic OAS operation with a mandatory timeout.
+    Requires an initialized {!Masc_eio_env} carrying an Eio clock; if the clock is
+    unavailable, returns [Agent_sdk.Error.Internal _] without calling the function.
     Catches [Eio.Time.Timeout] and [Eio.Cancel.Cancelled] to perform functional rollback.
     [caller] (#10094) labels the Otel_metric_store timeout counter so the
     operator can attribute timeouts to specific call sites.
-    Raises [Invalid_argument] when [timeout_s] is not positive and finite. *)
+    Raises [Invalid_argument] when [timeout_s] is not positive or is [nan].
+    [Float.infinity] is accepted for advisory callers whose wrapper timeout is
+    intentionally disabled by [Env_config_oas_bridge]. *)
 val run_safe
   :  caller:string
   -> timeout_s:float
@@ -22,9 +26,9 @@ val run_safe
     for the per-caller default table, env-var layout, and invalid-env fallback.
 
     Inherits the [Invalid_argument] contract from [run_safe]: if
-    [Env_config_oas_bridge.timeout_sec] returns a non-positive or
-    non-finite value (e.g. an env override of ["0"], ["-1"], ["nan"], or
-    ["inf"]), the resulting [run_safe] call raises [Invalid_argument].
+    [Env_config_oas_bridge.timeout_sec] returns a non-positive or [nan] value
+    (e.g. an env override of ["0"], ["-1"], or ["nan"]), the resulting [run_safe]
+    call raises [Invalid_argument].
     The env parser already clamps in the documented range, so this only
     surfaces when an operator pins a misconfiguration that bypasses the
     parser. *)

--- a/lib/masc_oas_bridge.mli
+++ b/lib/masc_oas_bridge.mli
@@ -10,8 +10,9 @@
     [caller] (#10094) labels the Otel_metric_store timeout counter so the
     operator can attribute timeouts to specific call sites.
     Raises [Invalid_argument] when [timeout_s] is not positive or is [nan].
-    [Float.infinity] is accepted for advisory callers whose wrapper timeout is
-    intentionally disabled by [Env_config_oas_bridge]. *)
+    [Float.infinity] is accepted as an explicit no-wrapper timeout for advisory
+    callers whose wrapper timeout is intentionally disabled by
+    [Env_config_oas_bridge]. *)
 val run_safe
   :  caller:string
   -> timeout_s:float

--- a/test/test_http_server_eio_coverage.ml
+++ b/test/test_http_server_eio_coverage.ml
@@ -116,12 +116,12 @@ let test_compress_zstd_level () =
 ;;
 
 let test_compress_zstd_dictionary_result_returns_original () =
-  let original = String.make Masc.Compression_codec.legacy_min_size 'd' in
+  let original = String.make Compression_codec.legacy_min_size 'd' in
   let dictionary_payload = "dictionary-compressed-bytes" in
   let result, compressed =
     Compression.compress_zstd_result ~original
-      (Masc.Compression_codec.Compressed
-         { payload = dictionary_payload; encoding = Masc.Compression_codec.Dictionary })
+      (Compression_codec.Compressed
+         { payload = dictionary_payload; encoding = Compression_codec.Dictionary })
   in
   check bool "dictionary not advertised as zstd" false compressed;
   check string "dictionary payload not leaked" original result

--- a/test/test_masc_oas_bridge_timeout_guard.ml
+++ b/test/test_masc_oas_bridge_timeout_guard.ml
@@ -3,8 +3,35 @@ open Masc
 let expected_invalid_timeout timeout_s =
   Invalid_argument
     (Printf.sprintf
-       "Masc_oas_bridge.run_safe: timeout_s must be positive and finite (got %.6g)"
+       "Masc_oas_bridge.run_safe: timeout_s must be positive or infinite (got %.6g)"
        timeout_s)
+;;
+
+let check_internal_contract_rejected label err =
+  match Keeper_internal_error.classify_masc_internal_error err with
+  | Some (Keeper_internal_error.Internal_contract_rejected _) -> ()
+  | Some other ->
+    Alcotest.failf
+      "%s: expected Internal_contract_rejected, got %s"
+      label
+      (Keeper_internal_error.kind_of_masc_internal_error other)
+  | None ->
+    Alcotest.failf "%s: expected structured MASC internal error" label
+;;
+
+let with_masc_eio_env f =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      Masc_eio_env.reset_for_test ();
+      Fun.protect
+        ~finally:Masc_eio_env.reset_for_test
+        (fun () ->
+          Masc_eio_env.init
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            ();
+          f ())))
 ;;
 
 let check_rejects_timeout ~name timeout_s =
@@ -24,16 +51,31 @@ let test_rejects_non_positive_timeout () =
   check_rejects_timeout ~name:"negative timeout rejected" (-0.5)
 ;;
 
-let test_rejects_non_finite_timeout () =
-  check_rejects_timeout ~name:"infinite timeout rejected" Float.infinity;
+let test_rejects_nan_timeout () =
   check_rejects_timeout ~name:"nan timeout rejected" Float.nan
 ;;
 
-let test_accepts_positive_timeout_without_eio_env () =
+let test_accepts_infinite_timeout_with_eio_clock () =
+  with_masc_eio_env (fun () ->
+    let called = ref false in
+    match
+      Masc_oas_bridge.run_safe
+        ~caller:"test_timeout_guard"
+        ~timeout_s:Float.infinity
+        (fun () ->
+          called := true;
+          Ok "ok")
+    with
+    | Ok "ok" -> Alcotest.(check bool) "fn was called" true !called
+    | Ok other -> failwith ("unexpected result: " ^ other)
+    | Error err -> failwith (Agent_sdk.Error.to_string err))
+;;
+
+let test_rejects_positive_timeout_without_eio_clock () =
   match Masc_eio_env.get_opt () with
   | Some _ ->
     failwith
-      "test_accepts_positive_timeout_without_eio_env requires Masc_eio_env.get_opt () = \
+      "test_rejects_positive_timeout_without_eio_clock requires Masc_eio_env.get_opt () = \
        None before calling run_safe"
   | None ->
     let called = ref false in
@@ -42,9 +84,10 @@ let test_accepts_positive_timeout_without_eio_env () =
          called := true;
          Ok "ok")
      with
-     | Ok "ok" -> Alcotest.(check bool) "fn was called" true !called
-     | Ok other -> failwith ("unexpected result: " ^ other)
-     | Error err -> failwith (Agent_sdk.Error.to_string err))
+     | Error err ->
+       Alcotest.(check bool) "fn was not called" false !called;
+       check_internal_contract_rejected "missing clock" err
+     | Ok value -> failwith ("unexpected success: " ^ value))
 ;;
 
 let with_env name value f =
@@ -61,16 +104,17 @@ let with_env name value f =
 let check_run_with_caller_uses_fallback_for_invalid_env ~name raw_value =
   let caller = Env_config_oas_bridge.Anti_rationalization in
   let env_name = Env_config_oas_bridge.per_caller_env_var ~caller in
-  with_env env_name raw_value (fun () ->
-    let called = ref false in
-    match
-      Masc_oas_bridge.run_with_caller ~caller (fun () ->
-        called := true;
-        Ok "ok")
-    with
-    | Ok "ok" -> Alcotest.(check bool) name true !called
-    | Ok other -> failwith ("unexpected result: " ^ other)
-    | Error err -> failwith (Agent_sdk.Error.to_string err))
+  with_masc_eio_env (fun () ->
+    with_env env_name raw_value (fun () ->
+      let called = ref false in
+      match
+        Masc_oas_bridge.run_with_caller ~caller (fun () ->
+          called := true;
+          Ok "ok")
+      with
+      | Ok "ok" -> Alcotest.(check bool) name true !called
+      | Ok other -> failwith ("unexpected result: " ^ other)
+      | Error err -> failwith (Agent_sdk.Error.to_string err)))
 ;;
 
 let test_run_with_caller_rejects_invalid_env_timeouts_at_boundary () =
@@ -91,13 +135,17 @@ let () =
             `Quick
             test_rejects_non_positive_timeout
         ; Alcotest.test_case
-            "rejects non-finite timeout"
+            "rejects nan timeout"
             `Quick
-            test_rejects_non_finite_timeout
+            test_rejects_nan_timeout
         ; Alcotest.test_case
-            "accepts positive timeout without eio env"
+            "accepts infinite timeout with eio clock"
             `Quick
-            test_accepts_positive_timeout_without_eio_env
+            test_accepts_infinite_timeout_with_eio_clock
+        ; Alcotest.test_case
+            "rejects positive timeout without eio clock"
+            `Quick
+            test_rejects_positive_timeout_without_eio_clock
         ; Alcotest.test_case
             "run_with_caller falls back for invalid env timeouts"
             `Quick

--- a/test/test_masc_oas_bridge_timeout_guard.ml
+++ b/test/test_masc_oas_bridge_timeout_guard.ml
@@ -7,30 +7,30 @@ let expected_invalid_timeout timeout_s =
        timeout_s)
 ;;
 
-let check_internal_contract_rejected label err =
+let check_internal_bridge_exception ~label ~caller err =
   match Keeper_internal_error.classify_masc_internal_error err with
-  | Some (Keeper_internal_error.Internal_contract_rejected _) -> ()
+  | Some (Keeper_internal_error.Internal_bridge_exception { caller = actual; _ }) ->
+    Alcotest.(check string) (label ^ " caller") caller actual
   | Some other ->
     Alcotest.failf
-      "%s: expected Internal_contract_rejected, got %s"
+      "%s: expected Internal_bridge_exception, got %s"
       label
       (Keeper_internal_error.kind_of_masc_internal_error other)
   | None ->
     Alcotest.failf "%s: expected structured MASC internal error" label
 ;;
 
-let with_masc_eio_env f =
+let with_masc_eio_env ?(clock = true) f =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       Masc_eio_env.reset_for_test ();
       Fun.protect
         ~finally:Masc_eio_env.reset_for_test
         (fun () ->
-          Masc_eio_env.init
-            ~sw
-            ~net:(Eio.Stdenv.net env)
-            ~clock:(Eio.Stdenv.clock env)
-            ();
+          let net = Eio.Stdenv.net env in
+          if clock
+          then Masc_eio_env.init ~sw ~net ~clock:(Eio.Stdenv.clock env) ()
+          else Masc_eio_env.init ~sw ~net ();
           f ())))
 ;;
 
@@ -71,23 +71,44 @@ let test_accepts_infinite_timeout_with_eio_clock () =
     | Error err -> failwith (Agent_sdk.Error.to_string err))
 ;;
 
-let test_rejects_positive_timeout_without_eio_clock () =
-  match Masc_eio_env.get_opt () with
-  | Some _ ->
-    failwith
-      "test_rejects_positive_timeout_without_eio_clock requires Masc_eio_env.get_opt () = \
-       None before calling run_safe"
-  | None ->
-    let called = ref false in
-    (match
-       Masc_oas_bridge.run_safe ~caller:"test_timeout_guard" ~timeout_s:0.1 (fun () ->
-         called := true;
-         Ok "ok")
-     with
-     | Error err ->
-       Alcotest.(check bool) "fn was not called" false !called;
-       check_internal_contract_rejected "missing clock" err
-     | Ok value -> failwith ("unexpected success: " ^ value))
+let test_rejects_positive_timeout_without_eio_env () =
+  Masc_eio_env.reset_for_test ();
+  Fun.protect
+    ~finally:Masc_eio_env.reset_for_test
+    (fun () ->
+      match Masc_eio_env.get_opt () with
+      | Some _ -> failwith "expected reset Masc_eio_env"
+      | None ->
+        let caller = "test_timeout_guard" in
+        let called = ref false in
+        (match
+           Masc_oas_bridge.run_safe ~caller ~timeout_s:0.1 (fun () ->
+             called := true;
+             Ok "ok")
+         with
+         | Error err ->
+           Alcotest.(check bool) "fn was not called" false !called;
+           check_internal_bridge_exception ~label:"missing env" ~caller err
+         | Ok value -> failwith ("unexpected success: " ^ value)))
+;;
+
+let test_rejects_positive_timeout_with_missing_clock () =
+  with_masc_eio_env ~clock:false (fun () ->
+    match Masc_eio_env.get_opt () with
+    | None -> failwith "expected initialized Masc_eio_env"
+    | Some { clock = Some _; _ } -> failwith "expected Masc_eio_env without clock"
+    | Some { clock = None; _ } ->
+      let caller = "test_timeout_guard" in
+      let called = ref false in
+      (match
+         Masc_oas_bridge.run_safe ~caller ~timeout_s:0.1 (fun () ->
+           called := true;
+           Ok "ok")
+       with
+       | Error err ->
+         Alcotest.(check bool) "fn was not called" false !called;
+         check_internal_bridge_exception ~label:"missing clock" ~caller err
+       | Ok value -> failwith ("unexpected success: " ^ value)))
 ;;
 
 let with_env name value f =
@@ -143,9 +164,13 @@ let () =
             `Quick
             test_accepts_infinite_timeout_with_eio_clock
         ; Alcotest.test_case
-            "rejects positive timeout without eio clock"
+            "rejects positive timeout without eio env"
             `Quick
-            test_rejects_positive_timeout_without_eio_clock
+            test_rejects_positive_timeout_without_eio_env
+        ; Alcotest.test_case
+            "rejects positive timeout with missing eio clock"
+            `Quick
+            test_rejects_positive_timeout_with_missing_clock
         ; Alcotest.test_case
             "run_with_caller falls back for invalid env timeouts"
             `Quick

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -395,28 +395,26 @@ let () = test "task_history_events_json_returns_empty_for_missing_task" (fun () 
   | _ -> failwith "task history payload must be a JSON list"
 )
 let () = test "masc_oas_bridge_rejects_missing_eio_clock" (fun () ->
-  match Masc_eio_env.get_opt () with
-  | Some _ ->
-    failwith
-      "masc_oas_bridge_rejects_missing_eio_clock requires Masc_eio_env.get_opt () = \
-       None before calling run_safe"
-  | None ->
+  Masc_eio_env.reset_for_test ();
+  Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
     let called = ref false in
+    let caller = "test_tool_task_coverage" in
     match
-      Masc_oas_bridge.run_safe ~caller:"test_tool_task_coverage" ~timeout_s:0.1 (fun () ->
+      Masc_oas_bridge.run_safe ~caller ~timeout_s:0.1 (fun () ->
         called := true;
         Ok "ok")
     with
     | Error err ->
       Alcotest.(check bool) "fn was not called" false !called;
       (match Keeper_internal_error.classify_masc_internal_error err with
-       | Some (Keeper_internal_error.Internal_contract_rejected _) -> ()
+       | Some (Keeper_internal_error.Internal_bridge_exception { caller = actual; _ }) ->
+         Alcotest.(check string) "caller" caller actual
        | Some other ->
          Alcotest.failf
-           "expected Internal_contract_rejected, got %s"
+           "expected Internal_bridge_exception, got %s"
            (Keeper_internal_error.kind_of_masc_internal_error other)
        | None -> Alcotest.fail "expected structured MASC internal error")
-    | Ok other -> failwith ("unexpected success: " ^ other)
+    | Ok other -> failwith ("unexpected success: " ^ other))
 )
 
 (* Test dispatch transition claim *)

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -394,19 +394,29 @@ let () = test "task_history_events_json_returns_empty_for_missing_task" (fun () 
   | `List _ -> failwith "missing task should have no history events"
   | _ -> failwith "task history payload must be a JSON list"
 )
-let () = test "masc_oas_bridge_runs_without_eio_env" (fun () ->
+let () = test "masc_oas_bridge_rejects_missing_eio_clock" (fun () ->
   match Masc_eio_env.get_opt () with
   | Some _ ->
     failwith
-      "masc_oas_bridge_runs_without_eio_env requires Masc_eio_env.get_opt () = None before calling run_safe"
+      "masc_oas_bridge_rejects_missing_eio_clock requires Masc_eio_env.get_opt () = \
+       None before calling run_safe"
   | None ->
+    let called = ref false in
     match
       Masc_oas_bridge.run_safe ~caller:"test_tool_task_coverage" ~timeout_s:0.1 (fun () ->
+        called := true;
         Ok "ok")
     with
-    | Ok "ok" -> ()
-    | Ok other -> failwith ("unexpected result: " ^ other)
-    | Error err -> failwith (Agent_sdk.Error.to_string err)
+    | Error err ->
+      Alcotest.(check bool) "fn was not called" false !called;
+      (match Keeper_internal_error.classify_masc_internal_error err with
+       | Some (Keeper_internal_error.Internal_contract_rejected _) -> ()
+       | Some other ->
+         Alcotest.failf
+           "expected Internal_contract_rejected, got %s"
+           (Keeper_internal_error.kind_of_masc_internal_error other)
+       | None -> Alcotest.fail "expected structured MASC internal error")
+    | Ok other -> failwith ("unexpected success: " ^ other)
 )
 
 (* Test dispatch transition claim *)


### PR DESCRIPTION
## Summary

- fail closed in `Masc_oas_bridge.run_safe` when `Masc_eio_env` has no Eio clock
- return a structured `Internal_contract_rejected` payload instead of running the OAS function without timeout enforcement
- update timeout guard coverage so missing-clock paths prove the function is not called
- keep `Float.infinity` accepted for the existing dashboard judge no-timeout SSOT in `Env_config_oas_bridge`

## Verification

- `ocamlformat --check lib/masc_oas_bridge.ml lib/masc_oas_bridge.mli test/test_masc_oas_bridge_timeout_guard.ml test/test_tool_task_coverage.ml`
- `git diff --check`

Per operator instruction, no local Dune build/test was run. Build verification is CI-only.
