### PR TITLE
fix(keeper): capture event bus before async turns

### DIFF
--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -634,6 +634,7 @@ let keeper_msg_body
       Turn.keeper_msg_timeout_override resolved_args
       |> Result.value ~default:None
     in
+    let event_bus = Keeper_event_bus.get () in
     let request_id =
       Keeper_msg_async.submit
         ?timeout_sec
@@ -642,7 +643,7 @@ let keeper_msg_body
         ~base_path:config.base_path
         ~keeper_name:name
         ~f:(fun () ->
-          let result = Turn.handle_keeper_msg keeper_ctx resolved_args in
+          let result = Turn.handle_keeper_msg ?event_bus keeper_ctx resolved_args in
           if tool_result_success result
           then begin
             append_direct_chat_pair_if_reply
@@ -681,6 +682,7 @@ let handle_keeper_msg ctx args : tool_result =
       Turn.keeper_msg_timeout_override resolved_args
       |> Result.value ~default:None
     in
+    let event_bus = Keeper_event_bus.get () in
     let request_id =
       Keeper_msg_async.submit
         ?timeout_sec
@@ -689,7 +691,7 @@ let handle_keeper_msg ctx args : tool_result =
         ~base_path:ctx.config.base_path
         ~keeper_name:name
         ~f:(fun () ->
-          let result = Turn.handle_keeper_msg ctx resolved_args in
+          let result = Turn.handle_keeper_msg ?event_bus ctx resolved_args in
           if tool_result_success result
           then begin
             append_direct_chat_pair_if_reply
@@ -784,8 +786,9 @@ let handle_keeper_msg_stream ?on_text_delta ?on_event ctx args : tool_result =
   match
     let* name = resolve_keeper_name ctx args in
     let resolved_args = with_keeper_name args name in
+    let event_bus = Keeper_event_bus.get () in
     let result =
-      Turn.handle_keeper_msg ?on_text_delta ?on_event ctx resolved_args
+      Turn.handle_keeper_msg ?on_text_delta ?on_event ?event_bus ctx resolved_args
     in
     if not (tool_result_success result) then
       Ok result

--- a/lib/keeper/keeper_tool_surface_ops.ml
+++ b/lib/keeper/keeper_tool_surface_ops.ml
@@ -90,12 +90,33 @@ let rec cached_text_by_key cache_ref ~key ~ttl_s compute =
           Otel_metric_store.metric_tool_keeper_cache_cas_conflicts ();
         cached_text_by_key cache_ref ~key ~ttl_s compute
       end
+
+let submit_keeper_msg_with_captured_event_bus
+      ?timeout_sec
+      ~clock
+      ~sw
+      ~base_path
+      ~keeper_name
+      ~(f : ?event_bus:Agent_sdk.Event_bus.t -> unit -> tool_result)
+      () =
+  let event_bus = Keeper_event_bus.get () in
+  Keeper_msg_async.submit
+    ?timeout_sec
+    ~clock
+    ~sw
+    ~base_path
+    ~keeper_name
+    ~f:(fun () -> f ?event_bus ())
+    ()
+
 module For_testing = struct
   let reset_keeper_list_cache () =
     Atomic.set keeper_list_cache (empty_text_cache ~generation:0)
   let invalidate_keeper_list_cache = invalidate_keeper_list_cache
   let cached_keeper_list_text ~key ~ttl_s compute =
     cached_text_by_key keeper_list_cache ~key ~ttl_s compute
+  let submit_keeper_msg_with_captured_event_bus =
+    submit_keeper_msg_with_captured_event_bus
 end
 let annotate_keeper_json ~runtime_class json =
   match json with
@@ -634,15 +655,14 @@ let keeper_msg_body
       Turn.keeper_msg_timeout_override resolved_args
       |> Result.value ~default:None
     in
-    let event_bus = Keeper_event_bus.get () in
     let request_id =
-      Keeper_msg_async.submit
+      submit_keeper_msg_with_captured_event_bus
         ?timeout_sec
         ~clock
         ~sw
         ~base_path:config.base_path
         ~keeper_name:name
-        ~f:(fun () ->
+        ~f:(fun ?event_bus () ->
           let result = Turn.handle_keeper_msg ?event_bus keeper_ctx resolved_args in
           if tool_result_success result
           then begin
@@ -682,15 +702,14 @@ let handle_keeper_msg ctx args : tool_result =
       Turn.keeper_msg_timeout_override resolved_args
       |> Result.value ~default:None
     in
-    let event_bus = Keeper_event_bus.get () in
     let request_id =
-      Keeper_msg_async.submit
+      submit_keeper_msg_with_captured_event_bus
         ?timeout_sec
         ~clock:ctx.clock
         ~sw:ctx.sw
         ~base_path:ctx.config.base_path
         ~keeper_name:name
-        ~f:(fun () ->
+        ~f:(fun ?event_bus () ->
           let result = Turn.handle_keeper_msg ?event_bus ctx resolved_args in
           if tool_result_success result
           then begin
@@ -786,6 +805,9 @@ let handle_keeper_msg_stream ?on_text_delta ?on_event ctx args : tool_result =
   match
     let* name = resolve_keeper_name ctx args in
     let resolved_args = with_keeper_name args name in
+    (* Stream turns are synchronous today, but still pin the bus visible at the
+       public surface boundary so later refactors cannot reintroduce a nested
+       fallback lookup in the turn body. *)
     let event_bus = Keeper_event_bus.get () in
     let result =
       Turn.handle_keeper_msg ?on_text_delta ?on_event ?event_bus ctx resolved_args

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -372,7 +372,7 @@ let run_direct_turn_with_fsm ~(keeper_name : string) ~(turn_id : int) f =
    [handle_keeper_msg] calls this directly because the validation guard
    below exits first). Do not add keeper-state mutation ahead of the
    validation guards without moving it behind the slot. *)
-let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result =
+let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : tool_result =
   with_span
     ~name:"keeper_turn"
     ~attrs:[
@@ -787,7 +787,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
                          ~generation:meta.runtime.generation
                          ?on_event
                          ~trajectory_acc
-                         ?event_bus:(Keeper_event_bus.get ())
+                         ?event_bus
                          ()))
             in
             match run_result with
@@ -975,18 +975,24 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args : tool_result
 
 ))))))))
 
-let handle_keeper_msg ?on_text_delta ?on_event ctx args : tool_result =
+let handle_keeper_msg ?on_text_delta ?on_event ?event_bus ctx args : tool_result =
+  let event_bus =
+    match event_bus with
+    | Some _ -> event_bus
+    | None -> Keeper_event_bus.get ()
+  in
   let name = get_string args "name" "" in
   if not (validate_name name) then
     (* Invalid input cannot reach run_turn; let the admitted body produce
        its precise validation error without holding the slot. *)
-    run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args
+    run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args
   else
     match
       Keeper_turn_admission.run_serialized
         ~base_path:ctx.config.base_path
         ~keeper_name:name
-        (fun () -> run_keeper_msg_turn_admitted ?on_text_delta ?on_event ctx args)
+        (fun () ->
+          run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args)
     with
     | `Ran result -> result
     | `Rejected { Keeper_turn_admission.waiting; in_flight } ->

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -56,7 +56,12 @@ val surface_context_to_instructions : Yojson.Safe.t -> string option
 val handle_keeper_msg :
   ?on_text_delta:(string -> unit) ->
   ?on_event:(Agent_sdk.Types.sse_event -> unit) ->
+  ?event_bus:Agent_sdk.Event_bus.t ->
   _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result
+(** [event_bus] is captured at the handler boundary and reused by the admitted
+    turn body. Callers that omit it keep the legacy process/domain fallback, but
+    async wrappers should pass an explicit value captured before submitting the
+    background turn. *)
 
 (** Stop a running keeper agent. *)
 val handle_keeper_down : _ Keeper_types_profile.context -> Yojson.Safe.t -> tool_result

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -5,6 +5,8 @@
 open Alcotest
 
 module EB = Masc.Keeper_unified_turn_event_bus
+module Kmsg = Masc.Keeper_msg_async
+module Ops = Masc.Keeper_tool_surface_ops
 
 let dummy_event payload =
   { Agent_sdk.Event_bus.meta =
@@ -164,76 +166,65 @@ let test_keeper_event_bus_is_intentionally_process_wide () =
     (Domain.join worker)
 ;;
 
-let read_source_file rel =
-  let root = Sys.getenv_opt "DUNE_SOURCEROOT" |> Option.value ~default:"." in
-  let path = Filename.concat root rel in
-  let ic = open_in path in
+let temp_dir prefix =
+  let path = Filename.temp_file prefix "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  path
+;;
+
+let wait_for_done ~clock ~base_path request_id =
+  let rec loop remaining =
+    match Kmsg.poll ~base_path request_id with
+    | Kmsg.Found { Kmsg.status = Kmsg.Done { ok = true; _ }; _ } ->
+      ()
+    | Kmsg.Found { Kmsg.status = Kmsg.Done { ok = false; body }; _ } ->
+      Alcotest.failf "keeper_msg request failed: %s" body
+    | _ when remaining <= 0 ->
+      Alcotest.failf "keeper_msg request %s did not complete" request_id
+    | _ ->
+      Eio.Time.sleep clock 0.01;
+      loop (remaining - 1)
+  in
+  loop 100
+;;
+
+let test_keeper_msg_async_submit_uses_captured_event_bus () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir "keeper-msg-event-bus-" in
+  let captured_bus = Agent_sdk.Event_bus.create () in
+  let later_bus = Agent_sdk.Event_bus.create () in
+  let observed_bus = ref None in
+  Keeper_event_bus.set captured_bus;
   Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
+    ~finally:(fun () ->
+      Kmsg.For_testing.clear ();
+      Keeper_event_bus.set captured_bus)
     (fun () ->
-       let rec loop acc =
-         match input_line ic with
-         | line -> loop (line :: acc)
-         | exception End_of_file -> String.concat "\n" (List.rev acc)
+       let request_id =
+         Ops.For_testing.submit_keeper_msg_with_captured_event_bus
+           ~clock:env#clock
+           ~sw
+           ~base_path
+           ~keeper_name:"event-bus-test"
+           ~f:(fun ?event_bus () ->
+             Keeper_event_bus.set later_bus;
+             observed_bus := event_bus;
+             Tool_result.ok ~tool_name:"keeper-event-bus-test" ~start_time:0.0 "{}")
+           ()
        in
-       loop [])
-;;
-
-let contains_substr haystack needle =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop offset =
-    if needle_len = 0
-    then true
-    else if offset + needle_len > haystack_len
-    then false
-    else if String.sub haystack offset needle_len = needle
-    then true
-    else loop (offset + 1)
-  in
-  loop 0
-;;
-
-let substring_between source ~start_marker ~end_marker =
-  match String.index_from_opt source 0 (String.get start_marker 0) with
-  | None -> None
-  | Some first ->
-      let rec find_marker marker offset =
-        if offset + String.length marker > String.length source
-        then None
-        else if String.sub source offset (String.length marker) = marker
-        then Some offset
-        else find_marker marker (offset + 1)
-      in
-      (match find_marker start_marker first with
-       | None -> None
-       | Some start_at ->
-           let body_start = start_at + String.length start_marker in
-           (match find_marker end_marker body_start with
-            | None -> None
-            | Some end_at -> Some (String.sub source body_start (end_at - body_start))))
-;;
-
-let test_keeper_msg_turn_uses_captured_event_bus () =
-  let turn_source = read_source_file "lib/keeper/keeper_turn.ml" in
-  let admitted_body =
-    substring_between
-      turn_source
-      ~start_marker:"let run_keeper_msg_turn_admitted"
-      ~end_marker:"let handle_keeper_msg"
-  in
-  check bool "admitted body found" true (Option.is_some admitted_body);
-  let admitted_body = Option.get admitted_body in
-  check
-    bool
-    "admitted turn body must not perform fallback Event_bus lookup"
-    false
-    (contains_substr admitted_body "Keeper_event_bus.get ()");
-  check bool "admitted body threads captured event_bus" true
-    (contains_substr admitted_body "?event_bus");
-  let surface_source = read_source_file "lib/keeper/keeper_tool_surface_ops.ml" in
-  check bool "async wrapper captures Event_bus before submit" true
-    (contains_substr surface_source "let event_bus = Keeper_event_bus.get ()")
+       wait_for_done ~clock:env#clock ~base_path request_id;
+       check
+         (option pass)
+         "worker received boundary-captured bus"
+         (Some captured_bus)
+         !observed_bus;
+       check
+         (option pass)
+         "worker changed fallback bus after capture"
+         (Some later_bus)
+         (Keeper_event_bus.get ()))
 ;;
 
 let test_take_drain_cancel_clears_active_without_spin () =
@@ -311,8 +302,8 @@ let () =
             test_state_pending_count_integrity_under_concurrent_updates
         ; test_case "event bus is intentionally process-wide" `Quick
             test_keeper_event_bus_is_intentionally_process_wide
-        ; test_case "keeper msg uses captured event bus" `Quick
-            test_keeper_msg_turn_uses_captured_event_bus
+        ; test_case "keeper msg async submit uses captured event bus" `Quick
+            test_keeper_msg_async_submit_uses_captured_event_bus
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -164,6 +164,78 @@ let test_keeper_event_bus_is_intentionally_process_wide () =
     (Domain.join worker)
 ;;
 
+let read_source_file rel =
+  let root = Sys.getenv_opt "DUNE_SOURCEROOT" |> Option.value ~default:"." in
+  let path = Filename.concat root rel in
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let rec loop acc =
+         match input_line ic with
+         | line -> loop (line :: acc)
+         | exception End_of_file -> String.concat "\n" (List.rev acc)
+       in
+       loop [])
+;;
+
+let contains_substr haystack needle =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop offset =
+    if needle_len = 0
+    then true
+    else if offset + needle_len > haystack_len
+    then false
+    else if String.sub haystack offset needle_len = needle
+    then true
+    else loop (offset + 1)
+  in
+  loop 0
+;;
+
+let substring_between source ~start_marker ~end_marker =
+  match String.index_from_opt source 0 (String.get start_marker 0) with
+  | None -> None
+  | Some first ->
+      let rec find_marker marker offset =
+        if offset + String.length marker > String.length source
+        then None
+        else if String.sub source offset (String.length marker) = marker
+        then Some offset
+        else find_marker marker (offset + 1)
+      in
+      (match find_marker start_marker first with
+       | None -> None
+       | Some start_at ->
+           let body_start = start_at + String.length start_marker in
+           (match find_marker end_marker body_start with
+            | None -> None
+            | Some end_at -> Some (String.sub source body_start (end_at - body_start))))
+;;
+
+let test_keeper_msg_turn_uses_captured_event_bus () =
+  let turn_source = read_source_file "lib/keeper/keeper_turn.ml" in
+  let admitted_body =
+    substring_between
+      turn_source
+      ~start_marker:"let run_keeper_msg_turn_admitted"
+      ~end_marker:"let handle_keeper_msg"
+  in
+  check bool "admitted body found" true (Option.is_some admitted_body);
+  let admitted_body = Option.get admitted_body in
+  check
+    bool
+    "admitted turn body must not perform fallback Event_bus lookup"
+    false
+    (contains_substr admitted_body "Keeper_event_bus.get ()");
+  check bool "admitted body threads captured event_bus" true
+    (contains_substr admitted_body "?event_bus");
+  let surface_source = read_source_file "lib/keeper/keeper_tool_surface_ops.ml" in
+  check bool "async wrapper captures Event_bus before submit" true
+    (contains_substr surface_source "let event_bus = Keeper_event_bus.get ()")
+;;
+
 let test_take_drain_cancel_clears_active_without_spin () =
   let open EB.For_testing in
   let t = EB.create ~keeper_name:"k" ~turn_id:1 () in
@@ -239,6 +311,8 @@ let () =
             test_state_pending_count_integrity_under_concurrent_updates
         ; test_case "event bus is intentionally process-wide" `Quick
             test_keeper_event_bus_is_intentionally_process_wide
+        ; test_case "keeper msg uses captured event bus" `Quick
+            test_keeper_msg_turn_uses_captured_event_bus
         ] )
     ; ( "background-drain"
       , [ test_case "continues after first poll" `Quick


### PR DESCRIPTION
## Summary

- add an explicit `?event_bus` boundary to `Keeper_turn.handle_keeper_msg`
- capture the keeper/OAS Event_bus before submitting async keeper turns
- reuse the captured bus inside the admitted turn body instead of looking it up during background execution
- add a regression ratchet covering the admitted-turn no-fallback contract

## Why

This reduces the turn path's dependence on process/domain fallback lookup and keeps async keeper execution tied to the bus visible at submission time. Direct callers that omit `?event_bus` retain the legacy fallback at the public handler boundary.

## Verification

- `ocamlformat --check lib/keeper/keeper_turn.ml lib/keeper/keeper_turn.mli lib/keeper/keeper_tool_surface_ops.ml`
- `ocamlformat --check test/test_keeper_unified_turn_event_bus.ml lib/keeper/keeper_turn.ml lib/keeper/keeper_turn.mli lib/keeper/keeper_tool_surface_ops.ml`
- `git diff --check`

Build/test authority: GitHub CI only per operator instruction.
