### PR TITLE
fix(memory): require strict JSON for consolidation plans

### DIFF
--- a/config/prompts/keeper.librarian.memory_consolidation.md
+++ b/config/prompts/keeper.librarian.memory_consolidation.md
@@ -17,6 +17,8 @@ Facts (index: [category] claim):
 {{numbered_facts}}
 
 Output schema (JSON only, no markdown):
+Return exactly one JSON object. Do not wrap the object in markdown fences, prose, arrays, JSON strings, XML tags, or thinking text.
+
 {
   "groups": [
     { "member_indices": [0, 3], "consolidated_claim": "One sentence merging those facts.", "category": "fact" }

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -144,9 +144,10 @@ let merge_group_of_json json =
   | _ -> None
 ;;
 
-(* Parse the LLM's consolidation output. Unknown/garbled groups are dropped
-   individually (defensive degrade), never aborting the whole plan. A plan that
-   fails to parse at all yields [empty_plan] = a no-op consolidation. *)
+(* Parse the LLM's consolidation plan. Unknown/garbled groups inside a valid
+   object are dropped individually (defensive degrade), never aborting the whole
+   plan. The provider output itself must be an exact JSON object; prose,
+   markdown fences, and substring salvage are rejected at [plan_of_string]. *)
 let plan_of_json (json : Yojson.Safe.t) =
   match json with
   | `Assoc _ ->
@@ -167,43 +168,10 @@ let plan_of_json (json : Yojson.Safe.t) =
 
 let json_of_output raw =
   let raw = String.trim raw in
-  let raw =
-    if String.starts_with ~prefix:"```" raw
-    then (
-      match String.split_on_char '\n' raw with
-      | first :: rest when String.starts_with ~prefix:"```" first ->
-        rest
-        |> List.rev
-        |> (function
-          | last :: rest when String.starts_with ~prefix:"```" (String.trim last) ->
-            List.rev rest
-          | lines -> List.rev lines)
-        |> String.concat "\n"
-        |> String.trim
-      | _ -> raw)
-    else raw
-  in
   match Yojson.Safe.from_string raw with
-  | json -> Some json
-  | exception Yojson.Json_error _ ->
-    let len = String.length raw in
-    let rec find_from i ch =
-      if i >= len then None else if Char.equal raw.[i] ch then Some i else find_from (i + 1) ch
-    in
-    let rec find_from_right i ch =
-      if i < 0
-      then None
-      else if Char.equal raw.[i] ch
-      then Some i
-      else find_from_right (i - 1) ch
-    in
-    (match find_from 0 '{', find_from_right (len - 1) '}' with
-     | Some start, Some stop when start < stop ->
-       let candidate = String.sub raw start (stop - start + 1) in
-       (match Yojson.Safe.from_string candidate with
-        | json -> Some json
-        | exception Yojson.Json_error _ -> None)
-     | _ -> None)
+  | `Assoc _ as json -> Some json
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
+  | exception Yojson.Json_error _ -> None
 ;;
 
 let plan_of_string raw =

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -154,15 +154,28 @@ let merge_group_of_json json =
 ;;
 
 (* Parse the LLM's consolidation plan. Unknown/garbled groups inside a valid
-   object are dropped individually (defensive degrade), never aborting the whole
-   plan. The provider output itself must be an exact JSON object; prose,
-   markdown fences, and substring salvage are rejected at [plan_of_string]. *)
+   object are dropped individually (defensive degrade) with bounded warning
+   telemetry, never aborting the whole plan. The provider output itself must be
+   an exact JSON object; prose, markdown fences, and substring salvage are
+   rejected at [plan_of_string]. *)
+let log_dropped_groups ~dropped ~total =
+  if dropped > 0
+  then
+    Log.Keeper.warn
+      "memory_os_consolidation: dropped malformed merge groups dropped=%d total=%d"
+      dropped
+      total
+;;
+
 let plan_of_json (json : Yojson.Safe.t) =
   match json with
   | `Assoc _ ->
     let groups =
       match assoc_field "groups" json with
-      | Some (`List items) -> List.filter_map merge_group_of_json items
+      | Some (`List items) ->
+        let parsed = List.filter_map merge_group_of_json items in
+        log_dropped_groups ~dropped:(List.length items - List.length parsed) ~total:(List.length items);
+        parsed
       | _ -> []
     in
     let drop_indices =

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -44,6 +44,15 @@ type consolidation_plan =
 
 let empty_plan = { groups = []; drop_indices = [] }
 
+type output_rejection_reason =
+  | Non_json
+  | Non_object_json
+
+let output_rejection_reason_to_string = function
+  | Non_json -> "non_json"
+  | Non_object_json -> "non_object_json"
+;;
+
 (* The numbered fact list the consolidation prompt sees: one 0-based line per
    fact, "[category] claim". The index is the only handle the LLM gets on an
    existing fact, so [apply_plan] reads back the same order. Pure — no IO. *)
@@ -166,18 +175,35 @@ let plan_of_json (json : Yojson.Safe.t) =
     empty_plan
 ;;
 
-let json_of_output raw =
+let json_of_output_result raw =
   let raw = String.trim raw in
   match Yojson.Safe.from_string raw with
-  | `Assoc _ as json -> Some json
-  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ -> None
-  | exception Yojson.Json_error _ -> None
+  | `Assoc _ as json -> Ok json
+  | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
+    Error Non_object_json
+  | exception Yojson.Json_error _ -> Error Non_json
+;;
+
+let json_of_output raw =
+  match json_of_output_result raw with
+  | Ok json -> Some json
+  | Error _ -> None
+;;
+
+let log_rejected_output ~reason ~raw =
+  Log.Keeper.warn
+    "memory_os_consolidation: rejected provider output reason=%s bytes=%d; \
+     expected exact JSON object"
+    (output_rejection_reason_to_string reason)
+    (String.length raw)
 ;;
 
 let plan_of_string raw =
-  match json_of_output raw with
-  | Some json -> Some (plan_of_json json)
-  | None -> None
+  match json_of_output_result raw with
+  | Ok json -> Some (plan_of_json json)
+  | Error reason ->
+    log_rejected_output ~reason ~raw;
+    None
 ;;
 
 (* ---------- Apply (pure, deterministic) ---------- *)

--- a/lib/keeper/keeper_memory_os_consolidation.ml
+++ b/lib/keeper/keeper_memory_os_consolidation.ml
@@ -154,10 +154,10 @@ let merge_group_of_json json =
 ;;
 
 (* Parse the LLM's consolidation plan. Unknown/garbled groups inside a valid
-   object are dropped individually (defensive degrade) with bounded warning
-   telemetry, never aborting the whole plan. The provider output itself must be
-   an exact JSON object; prose, markdown fences, and substring salvage are
-   rejected at [plan_of_string]. *)
+   object are dropped individually (defensive degrade) and emit a warning with
+   dropped/total counts, never aborting the whole plan. The provider output
+   itself must be an exact JSON object; prose, markdown fences, and substring
+   salvage are rejected at [plan_of_string]. *)
 let log_dropped_groups ~dropped ~total =
   if dropped > 0
   then
@@ -195,12 +195,6 @@ let json_of_output_result raw =
   | `Bool _ | `Float _ | `Int _ | `Intlit _ | `List _ | `Null | `String _ ->
     Error Non_object_json
   | exception Yojson.Json_error _ -> Error Non_json
-;;
-
-let json_of_output raw =
-  match json_of_output_result raw with
-  | Ok json -> Some json
-  | Error _ -> None
 ;;
 
 let log_rejected_output ~reason ~raw =

--- a/lib/keeper/keeper_memory_os_consolidation.mli
+++ b/lib/keeper/keeper_memory_os_consolidation.mli
@@ -30,7 +30,8 @@ val empty_plan : consolidation_plan
 val render_numbered_facts : fact list -> string
 
 (** Parse the LLM's consolidation output. Garbled groups degrade individually
-    (dropped, not fatal); a wholly invalid object yields [empty_plan]. *)
+    (dropped with bounded warning telemetry, not fatal); a wholly invalid object
+    yields [empty_plan]. *)
 val plan_of_json : Yojson.Safe.t -> consolidation_plan
 
 (** [plan_of_string raw] is [None] only when [raw] is not an exact JSON object.

--- a/lib/keeper/keeper_memory_os_consolidation.mli
+++ b/lib/keeper/keeper_memory_os_consolidation.mli
@@ -33,8 +33,11 @@ val render_numbered_facts : fact list -> string
     (dropped, not fatal); a wholly invalid object yields [empty_plan]. *)
 val plan_of_json : Yojson.Safe.t -> consolidation_plan
 
-(** [plan_of_string raw] is [None] only when [raw] is not parseable JSON at all;
-    a parseable-but-empty/garbled plan returns [Some empty_plan]-equivalent. *)
+(** [plan_of_string raw] is [None] only when [raw] is not an exact JSON object.
+    Rejections emit a warning with a bounded reason label and byte count so
+    model-provider contract regressions are observable without logging raw
+    provider text. A parseable-but-empty/garbled object returns [Some
+    empty_plan]-equivalent. *)
 val plan_of_string : string -> consolidation_plan option
 
 (** Apply a plan to a keeper's facts, returning the new fact list. Each group of

--- a/lib/keeper/keeper_memory_os_consolidation.mli
+++ b/lib/keeper/keeper_memory_os_consolidation.mli
@@ -30,8 +30,8 @@ val empty_plan : consolidation_plan
 val render_numbered_facts : fact list -> string
 
 (** Parse the LLM's consolidation output. Garbled groups degrade individually
-    (dropped with bounded warning telemetry, not fatal); a wholly invalid object
-    yields [empty_plan]. *)
+    (dropped with warning counts, not fatal); a wholly invalid object yields
+    [empty_plan]. *)
 val plan_of_json : Yojson.Safe.t -> consolidation_plan
 
 (** [plan_of_string raw] is [None] only when [raw] is not an exact JSON object.

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -58,6 +58,11 @@ let min_facts_to_consolidate = 4
    512-token summary budget. *)
 let consolidation_max_tokens = 2048
 
+let bare_json_object_contract =
+  "Return exactly one JSON object. Do not wrap the object in markdown fences, \
+   prose, arrays, JSON strings, XML tags, or thinking text."
+;;
+
 type outcome =
   | Skipped_too_few of int
   | Transport_failed of string
@@ -96,7 +101,7 @@ let provider_for_consolidation (provider_cfg : Llm_provider.Provider_config.t) =
   ; temperature = Some 0.0
   ; tool_choice = None
   ; disable_parallel_tool_use = true
-  ; response_format = Agent_sdk.Types.Off
+  ; response_format = Agent_sdk.Types.JsonMode
   ; output_schema = None
   }
 ;;
@@ -113,7 +118,7 @@ let messages_for_consolidation facts =
     let user = String.trim user in
     if String.equal user ""
     then Error "consolidation prompt rendered empty"
-    else Ok [ user_message user ]
+    else Ok [ user_message (user ^ "\n\n" ^ bare_json_object_contract) ]
 ;;
 
 let rewrite_if_snapshot_current ?clock ~keeper_id ~facts ~survivors ~before ~after () =

--- a/lib/keeper/keeper_memory_os_consolidation_runtime.ml
+++ b/lib/keeper/keeper_memory_os_consolidation_runtime.ml
@@ -58,11 +58,6 @@ let min_facts_to_consolidate = 4
    512-token summary budget. *)
 let consolidation_max_tokens = 2048
 
-let bare_json_object_contract =
-  "Return exactly one JSON object. Do not wrap the object in markdown fences, \
-   prose, arrays, JSON strings, XML tags, or thinking text."
-;;
-
 type outcome =
   | Skipped_too_few of int
   | Transport_failed of string
@@ -118,7 +113,7 @@ let messages_for_consolidation facts =
     let user = String.trim user in
     if String.equal user ""
     then Error "consolidation prompt rendered empty"
-    else Ok [ user_message (user ^ "\n\n" ^ bare_json_object_contract) ]
+    else Ok [ user_message user ]
 ;;
 
 let rewrite_if_snapshot_current ?clock ~keeper_id ~facts ~survivors ~before ~after () =

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -440,7 +440,11 @@ let test_parse_degrades_garbled_group () =
 
 let test_parse_non_json_is_none () =
   Alcotest.(check bool) "non-JSON yields None" true (Consolidation.plan_of_string "not json {{{" = None);
-  Alcotest.(check bool) "non-object JSON yields None" true (Consolidation.plan_of_string "[]" = None)
+  Alcotest.(check bool)
+    "JSON string yields None"
+    true
+    (Consolidation.plan_of_string {|"not an object"|} = None);
+  Alcotest.(check bool) "JSON array yields None" true (Consolidation.plan_of_string "[]" = None)
 ;;
 
 let () =

--- a/test/test_keeper_memory_os_consolidation.ml
+++ b/test/test_keeper_memory_os_consolidation.ml
@@ -412,21 +412,20 @@ let test_parse_rejects_fractional_indices () =
     Alcotest.(check (list int)) "fractional drop ignored" [ 3 ] plan.Consolidation.drop_indices
 ;;
 
-let test_parse_plan_from_fenced_or_prefixed_json () =
+let test_parse_rejects_wrapped_json () =
   let json =
     {|{"groups":[{"member_indices":[0,1],"consolidated_claim":"merged","category":"fact"}],"drop_indices":[]}|}
   in
   [ "fenced", Printf.sprintf "```json\n%s\n```" json
   ; "prefixed", Printf.sprintf "Here is the plan:\n%s" json
+  ; "suffixed", Printf.sprintf "%s\nDone." json
+  ; "multiple objects", Printf.sprintf "%s\n%s" json json
+  ; "thinking leak", Printf.sprintf "<think>merge these</think>\n%s" json
   ]
   |> List.iter (fun (label, raw) ->
     match Consolidation.plan_of_string raw with
-    | None -> Alcotest.failf "%s plan should parse" label
-    | Some plan ->
-      Alcotest.(check int)
-        (label ^ " group count")
-        1
-        (List.length plan.Consolidation.groups))
+    | None -> ()
+    | Some _ -> Alcotest.failf "%s wrapped plan should be rejected" label)
 ;;
 
 (* A garbled group is dropped individually; the rest of the plan stands. *)
@@ -440,7 +439,8 @@ let test_parse_degrades_garbled_group () =
 ;;
 
 let test_parse_non_json_is_none () =
-  Alcotest.(check bool) "non-JSON yields None" true (Consolidation.plan_of_string "not json {{{" = None)
+  Alcotest.(check bool) "non-JSON yields None" true (Consolidation.plan_of_string "not json {{{" = None);
+  Alcotest.(check bool) "non-object JSON yields None" true (Consolidation.plan_of_string "[]" = None)
 ;;
 
 let () =
@@ -476,7 +476,7 @@ let () =
 	    ; ( "parse"
 	      , [ Alcotest.test_case "parses a plan" `Quick test_parse_plan_json
 	        ; Alcotest.test_case "rejects fractional indices" `Quick test_parse_rejects_fractional_indices
-	        ; Alcotest.test_case "parses fenced/prefixed JSON" `Quick test_parse_plan_from_fenced_or_prefixed_json
+	        ; Alcotest.test_case "rejects wrapped JSON" `Quick test_parse_rejects_wrapped_json
 	        ; Alcotest.test_case "degrades a garbled group" `Quick test_parse_degrades_garbled_group
 	        ; Alcotest.test_case "non-JSON is None" `Quick test_parse_non_json_is_none
 	        ] )

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -289,7 +289,7 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
         let expected_prompt =
           match
             Prompt_registry.render_prompt_template
-              Masc.Keeper_prompt_names.librarian_memory_consolidation
+              Keeper_prompt_names.librarian_memory_consolidation
               [ "numbered_facts", Consolidation.render_numbered_facts facts ]
           with
           | Ok text -> String.trim text

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -3,6 +3,7 @@
 
 module Types = Masc.Keeper_memory_os_types
 module Io = Masc.Keeper_memory_os_io
+module Consolidation = Masc.Keeper_memory_os_consolidation
 module Runtime = Masc.Keeper_memory_os_consolidation_runtime
 module Atypes = Agent_sdk.Types
 
@@ -41,16 +42,6 @@ let message_text (message : Atypes.message) =
     | Atypes.Text s -> Some s
     | _ -> None)
   |> String.concat "\n"
-;;
-
-let contains_substring ~needle text =
-  let needle_len = String.length needle in
-  let text_len = String.length text in
-  let rec loop index =
-    index + needle_len <= text_len
-    && (String.equal (String.sub text index needle_len) needle || loop (index + 1))
-  in
-  String.equal needle "" || loop 0
 ;;
 
 let fake_complete canned : Runtime.complete_fn =
@@ -281,32 +272,38 @@ let test_consolidate_rejects_malformed_fact_store () =
         | _ -> Alcotest.fail "expected Unparseable for malformed fact store"))))
 ;;
 
-let test_consolidate_respects_configured_max_tokens () =
+let test_consolidate_respects_provider_config_and_prompt_template () =
   Eio_main.run (fun env ->
     Eio.Switch.run (fun sw ->
       with_prompts (fun () ->
       with_temp_keepers (fun () ->
         let keeper_id = "keeper-1" in
-        List.iter
-          (Io.append_fact ~keeper_id)
-          [ fact "a"; fact "b"; fact "c"; fact "d" ];
+        let facts = [ fact "a"; fact "b"; fact "c"; fact "d" ] in
+        List.iter (Io.append_fact ~keeper_id) facts;
         let seen_max_tokens = ref None in
         let plan =
           {|{"groups":[{"member_indices":[0,1],"consolidated_claim":"ab","category":"fact"}],"drop_indices":[]}|}
         in
         let seen_response_format = ref None in
-        let seen_bare_object_contract = ref false in
+        let seen_prompt_matches_template = ref false in
+        let expected_prompt =
+          match
+            Prompt_registry.render_prompt_template
+              Masc.Keeper_prompt_names.librarian_memory_consolidation
+              [ "numbered_facts", Consolidation.render_numbered_facts facts ]
+          with
+          | Ok text -> String.trim text
+          | Error msg -> Alcotest.failf "failed to render expected prompt: %s" msg
+        in
         let complete =
           fake_complete_with_config
             (fun config messages ->
                seen_max_tokens := config.Llm_provider.Provider_config.max_tokens;
                seen_response_format := Some config.Llm_provider.Provider_config.response_format;
-               let rendered_prompt = messages |> List.map message_text |> String.concat "\n" in
-               seen_bare_object_contract
-               := contains_substring
-                    ~needle:"Return exactly one JSON object"
-                    rendered_prompt
-                  && contains_substring ~needle:"Do not wrap" rendered_prompt)
+               let rendered_prompt =
+                 messages |> List.map message_text |> String.concat "\n" |> String.trim
+               in
+               seen_prompt_matches_template := String.equal expected_prompt rendered_prompt)
             plan
         in
         let outcome =
@@ -331,9 +328,9 @@ let test_consolidate_respects_configured_max_tokens () =
           (Some true)
           (Option.map (fun format -> format = Atypes.JsonMode) !seen_response_format);
         Alcotest.(check bool)
-          "prompt carries bare JSON object contract"
+          "prompt registry output is passed through verbatim"
           true
-          !seen_bare_object_contract))))
+          !seen_prompt_matches_template))))
 ;;
 
 let () =
@@ -346,9 +343,9 @@ let () =
 	        ; Alcotest.test_case "rejects stale snapshots" `Quick test_consolidate_rejects_stale_snapshot
 	        ; Alcotest.test_case "rejects malformed fact store" `Quick test_consolidate_rejects_malformed_fact_store
         ; Alcotest.test_case
-            "respects configured max_tokens cap"
+            "respects provider config and prompt template"
             `Quick
-            test_consolidate_respects_configured_max_tokens
+            test_consolidate_respects_provider_config_and_prompt_template
 	        ] )
     ]
 ;;

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -35,13 +35,31 @@ let fake_response canned =
   }
 ;;
 
+let message_text (message : Atypes.message) =
+  message.content
+  |> List.filter_map (function
+    | Atypes.Text s -> Some s
+    | _ -> None)
+  |> String.concat "\n"
+;;
+
+let contains_substring ~needle text =
+  let needle_len = String.length needle in
+  let text_len = String.length text in
+  let rec loop index =
+    index + needle_len <= text_len
+    && (String.equal (String.sub text index needle_len) needle || loop (index + 1))
+  in
+  String.equal needle "" || loop 0
+;;
+
 let fake_complete canned : Runtime.complete_fn =
   fun ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () -> Ok (fake_response canned)
 ;;
 
 let fake_complete_with_config inspect canned : Runtime.complete_fn =
-  fun ~sw:_ ~net:_ ?clock:_ ~config ~messages:_ () ->
-  inspect config;
+  fun ~sw:_ ~net:_ ?clock:_ ~config ~messages () ->
+  inspect config messages;
   Ok (fake_response canned)
 ;;
 
@@ -276,10 +294,19 @@ let test_consolidate_respects_configured_max_tokens () =
         let plan =
           {|{"groups":[{"member_indices":[0,1],"consolidated_claim":"ab","category":"fact"}],"drop_indices":[]}|}
         in
+        let seen_response_format = ref None in
+        let seen_bare_object_contract = ref false in
         let complete =
           fake_complete_with_config
-            (fun config ->
-               seen_max_tokens := config.Llm_provider.Provider_config.max_tokens)
+            (fun config messages ->
+               seen_max_tokens := config.Llm_provider.Provider_config.max_tokens;
+               seen_response_format := Some config.Llm_provider.Provider_config.response_format;
+               let rendered_prompt = messages |> List.map message_text |> String.concat "\n" in
+               seen_bare_object_contract
+               := contains_substring
+                    ~needle:"Return exactly one JSON object"
+                    rendered_prompt
+                  && contains_substring ~needle:"Do not wrap" rendered_prompt)
             plan
         in
         let outcome =
@@ -298,7 +325,15 @@ let test_consolidate_respects_configured_max_tokens () =
         Alcotest.(check (option int))
           "configured max_tokens cap is preserved"
           (Some 512)
-          !seen_max_tokens))))
+          !seen_max_tokens;
+        Alcotest.(check (option bool))
+          "json mode requested"
+          (Some true)
+          (Option.map (fun format -> format = Atypes.JsonMode) !seen_response_format);
+        Alcotest.(check bool)
+          "prompt carries bare JSON object contract"
+          true
+          !seen_bare_object_contract))))
 ;;
 
 let () =


### PR DESCRIPTION
## Summary
- require Memory OS consolidation provider output to be an exact JSON object
- request provider JSON mode for the consolidation LLM call
- append a bare-JSON-object producer contract to the consolidation prompt payload
- keep markdown fences, prose wrappers, arrays, JSON strings, and malformed JSON rejected instead of substring-salvaged
- surface provider-output and malformed-group contract regressions with bounded warn logs

## Review Response
- addressed the initial P1 parser observability note in `b0e7e45f3d67`
- addressed the follow-up P1/P2 notes in `01ed9d8f8a9`
- `plan_of_string` distinguishes `non_json` from `non_object_json` before returning `None`
- runtime provider config now requests `Agent_sdk.Types.JsonMode`
- prompt messages now carry an explicit "Return exactly one JSON object" / "Do not wrap" contract
- malformed groups inside a valid object now emit a bounded dropped/total warn log before defensive degrade
- explicit JSON string and JSON array rejection coverage remains in the parser tests

## Validation
- `ocamlformat --check lib/keeper/keeper_memory_os_consolidation.ml lib/keeper/keeper_memory_os_consolidation.mli lib/keeper/keeper_memory_os_consolidation_runtime.ml test/test_keeper_memory_os_consolidation.ml test/test_keeper_memory_os_consolidation_runtime.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_memory_os_consolidation.ml lib/keeper/keeper_memory_os_consolidation.mli lib/keeper/keeper_memory_os_consolidation_runtime.ml test/test_keeper_memory_os_consolidation.ml test/test_keeper_memory_os_consolidation_runtime.ml`
- `git diff --check`
- risk search for `response_format = Agent_sdk.Types.Off`, direct unobserved group drops, JSON mode, bare-object prompt contract, and dropped-group warn logging

## Not Run
- Dune build/test and GitHub CI log inspection, per operator instruction to leave build confirmation to CI and handle review comments first
