### PR TITLE
fix(dashboard): hydrate keeper compaction memory views

### DIFF
--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -296,6 +296,7 @@ export type KeeperCompactionSnapshotsResponse = {
   readonly producer: string
   readonly limit: number
   readonly count: number
+  readonly read_errors: { scope: string; error: string }[]
   readonly items: KeeperCompactionSnapshot[]
 }
 
@@ -699,6 +700,16 @@ function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot 
   }
 }
 
+function decodeReadErrors(raw: unknown): { scope: string; error: string }[] {
+  return asRecordArray(raw)
+    .map((item) => {
+      const scope = asString(item.scope)
+      const error = asString(item.error)
+      return scope && error ? { scope, error } : null
+    })
+    .filter((item): item is { scope: string; error: string } => item !== null)
+}
+
 function decodeKeeperCompactionSnapshotsResponse(raw: unknown): KeeperCompactionSnapshotsResponse | null {
   if (!isRecord(raw)) return null
   const schema = asString(raw.schema)
@@ -713,10 +724,18 @@ function decodeKeeperCompactionSnapshotsResponse(raw: unknown): KeeperCompaction
     producer,
     limit: asNumber(raw.limit, 0) ?? 0,
     count: asNumber(raw.count, 0) ?? 0,
+    read_errors: decodeReadErrors(raw.read_errors),
     items: asRecordArray(raw.items)
       .map(decodeKeeperCompactionSnapshot)
       .filter((item): item is KeeperCompactionSnapshot => item !== null),
   }
+}
+
+function limitQueryString(limit?: number): string {
+  const params = new URLSearchParams()
+  if (limit != null) params.set('limit', String(limit))
+  const query = params.toString()
+  return query ? `?${query}` : ''
 }
 
 export function fetchKeeperTurnRecords(
@@ -724,7 +743,7 @@ export function fetchKeeperTurnRecords(
   limit?: number,
   opts?: AbortableRequestOptions,
 ): Promise<TurnRecordsResponse> {
-  const params = limit != null ? `?limit=${limit}` : ''
+  const params = limitQueryString(limit)
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/turn-records${params}`,
     { signal: opts?.signal },
@@ -740,7 +759,7 @@ export function fetchKeeperCompactionSnapshots(
   limit?: number,
   opts?: AbortableRequestOptions,
 ): Promise<KeeperCompactionSnapshotsResponse> {
-  const params = limit != null ? `?limit=${limit}` : ''
+  const params = limitQueryString(limit)
   return get<Record<string, unknown>>(
     `/api/v1/keepers/${encodeURIComponent(name)}/compaction-snapshots${params}`,
     { signal: opts?.signal },

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -264,6 +264,41 @@ export type TurnRecordsResponse = TelemetryFreshnessMetadata & {
   entries: TurnRecordRow[]
 }
 
+export type KeeperCompactionSnapshotLinks = {
+  readonly receipt_path: string | null
+  readonly checkpoint_path: string | null
+  readonly tool_call_log_path: string | null
+}
+
+export type KeeperCompactionSnapshot = {
+  readonly id: string
+  readonly keeper: string
+  readonly ts_iso: string
+  readonly ts_unix: number | null
+  readonly trace_id: string | null
+  readonly keeper_turn_id: number | null
+  readonly source: string
+  readonly trigger: string
+  readonly runtime_id: string | null
+  readonly before_tokens: number | null
+  readonly after_tokens: number | null
+  readonly saved_tokens: number | null
+  readonly compaction_id: string | null
+  readonly compaction_source: string | null
+  readonly status: string
+  readonly links: KeeperCompactionSnapshotLinks
+}
+
+export type KeeperCompactionSnapshotsResponse = {
+  readonly schema: string
+  readonly keeper: string
+  readonly source: string
+  readonly producer: string
+  readonly limit: number
+  readonly count: number
+  readonly items: KeeperCompactionSnapshot[]
+}
+
 function decodeTurnBlock(raw: unknown): TurnBlock | null {
   if (!isRecord(raw)) return null
   const block = asString(raw.block)
@@ -620,6 +655,70 @@ function decodeTurnRecordsResponse(raw: unknown): TurnRecordsResponse | null {
   }
 }
 
+function decodeKeeperCompactionSnapshotLinks(raw: unknown): KeeperCompactionSnapshotLinks {
+  if (!isRecord(raw)) {
+    return { receipt_path: null, checkpoint_path: null, tool_call_log_path: null }
+  }
+  return {
+    receipt_path: asNullableString(raw.receipt_path),
+    checkpoint_path: asNullableString(raw.checkpoint_path),
+    tool_call_log_path: asNullableString(raw.tool_call_log_path),
+  }
+}
+
+function nullableNumber(raw: unknown): number | null {
+  return asNumber(raw) ?? null
+}
+
+function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const keeper = asString(raw.keeper)
+  const ts_iso = asString(raw.ts_iso)
+  const source = asString(raw.source)
+  const trigger = asString(raw.trigger)
+  const status = asString(raw.status)
+  if (!id || !keeper || !ts_iso || !source || !trigger || !status) return null
+  return {
+    id,
+    keeper,
+    ts_iso,
+    ts_unix: nullableNumber(raw.ts_unix),
+    trace_id: asNullableString(raw.trace_id),
+    keeper_turn_id: nullableNumber(raw.keeper_turn_id),
+    source,
+    trigger,
+    runtime_id: asNullableString(raw.runtime_id),
+    before_tokens: nullableNumber(raw.before_tokens),
+    after_tokens: nullableNumber(raw.after_tokens),
+    saved_tokens: nullableNumber(raw.saved_tokens),
+    compaction_id: asNullableString(raw.compaction_id),
+    compaction_source: asNullableString(raw.compaction_source),
+    status,
+    links: decodeKeeperCompactionSnapshotLinks(raw.links),
+  }
+}
+
+function decodeKeeperCompactionSnapshotsResponse(raw: unknown): KeeperCompactionSnapshotsResponse | null {
+  if (!isRecord(raw)) return null
+  const schema = asString(raw.schema)
+  const keeper = asString(raw.keeper)
+  const source = asString(raw.source)
+  const producer = asString(raw.producer)
+  if (!schema || !keeper || !source || !producer) return null
+  return {
+    schema,
+    keeper,
+    source,
+    producer,
+    limit: asNumber(raw.limit, 0) ?? 0,
+    count: asNumber(raw.count, 0) ?? 0,
+    items: asRecordArray(raw.items)
+      .map(decodeKeeperCompactionSnapshot)
+      .filter((item): item is KeeperCompactionSnapshot => item !== null),
+  }
+}
+
 export function fetchKeeperTurnRecords(
   name: string,
   limit?: number,
@@ -632,6 +731,22 @@ export function fetchKeeperTurnRecords(
   ).then((raw) => {
     const decoded = decodeTurnRecordsResponse(raw)
     if (!decoded) throw new Error('유효하지 않은 keeper turn record payload')
+    return decoded
+  })
+}
+
+export function fetchKeeperCompactionSnapshots(
+  name: string,
+  limit?: number,
+  opts?: AbortableRequestOptions,
+): Promise<KeeperCompactionSnapshotsResponse> {
+  const params = limit != null ? `?limit=${limit}` : ''
+  return get<Record<string, unknown>>(
+    `/api/v1/keepers/${encodeURIComponent(name)}/compaction-snapshots${params}`,
+    { signal: opts?.signal },
+  ).then((raw) => {
+    const decoded = decodeKeeperCompactionSnapshotsResponse(raw)
+    if (!decoded) throw new Error('유효하지 않은 keeper compaction snapshot payload')
     return decoded
   })
 }

--- a/dashboard/src/api/dashboard-turn-records.ts
+++ b/dashboard/src/api/dashboard-turn-records.ts
@@ -6,6 +6,9 @@ import { get, type AbortableRequestOptions } from './core'
 import { isRecord, asBoolean, asNumber, asNullableString, asString, asStringArray, asRecordArray } from '../components/common/normalize'
 import { decodeTelemetryFreshnessMetadata, type TelemetryFreshnessMetadata } from './dashboard-shared'
 
+// Mirror of Keeper_memory_os_types.librarian_unstructured_fallback_terminal_marker.
+export const MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER = 'librarian_unstructured_fallback'
+
 // Accepts either a string array or a single string; mirrors the keeper-config
 // normalizeStringList (duplicated here to keep this domain self-contained).
 function normalizeStringList(value: unknown): string[] {
@@ -280,6 +283,7 @@ export type KeeperCompactionSnapshot = {
   readonly source: string
   readonly trigger: string
   readonly runtime_id: string | null
+  readonly display_runtime: string
   readonly before_tokens: number | null
   readonly after_tokens: number | null
   readonly saved_tokens: number | null
@@ -296,7 +300,9 @@ export type KeeperCompactionSnapshotsResponse = {
   readonly producer: string
   readonly limit: number
   readonly count: number
+  readonly read_error_count: number
   readonly read_errors: { scope: string; error: string }[]
+  readonly scan_truncated: boolean
   readonly items: KeeperCompactionSnapshot[]
 }
 
@@ -680,6 +686,8 @@ function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot 
   const trigger = asString(raw.trigger)
   const status = asString(raw.status)
   if (!id || !keeper || !ts_iso || !source || !trigger || !status) return null
+  const runtimeId = asNullableString(raw.runtime_id)
+  const compactionSource = asNullableString(raw.compaction_source)
   return {
     id,
     keeper,
@@ -689,12 +697,13 @@ function decodeKeeperCompactionSnapshot(raw: unknown): KeeperCompactionSnapshot 
     keeper_turn_id: nullableNumber(raw.keeper_turn_id),
     source,
     trigger,
-    runtime_id: asNullableString(raw.runtime_id),
+    runtime_id: runtimeId,
+    display_runtime: asString(raw.display_runtime) || runtimeId || compactionSource || source,
     before_tokens: nullableNumber(raw.before_tokens),
     after_tokens: nullableNumber(raw.after_tokens),
     saved_tokens: nullableNumber(raw.saved_tokens),
     compaction_id: asNullableString(raw.compaction_id),
-    compaction_source: asNullableString(raw.compaction_source),
+    compaction_source: compactionSource,
     status,
     links: decodeKeeperCompactionSnapshotLinks(raw.links),
   }
@@ -724,7 +733,9 @@ function decodeKeeperCompactionSnapshotsResponse(raw: unknown): KeeperCompaction
     producer,
     limit: asNumber(raw.limit, 0) ?? 0,
     count: asNumber(raw.count, 0) ?? 0,
+    read_error_count: asNumber(raw.read_error_count, 0) ?? 0,
     read_errors: decodeReadErrors(raw.read_errors),
+    scan_truncated: asBoolean(raw.scan_truncated) ?? false,
     items: asRecordArray(raw.items)
       .map(decodeKeeperCompactionSnapshot)
       .filter((item): item is KeeperCompactionSnapshot => item !== null),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -555,6 +555,7 @@ describe('keeper tool telemetry fetchers', () => {
         producer: 'keeper_runtime_manifest|keeper_meta_store',
         limit: 2,
         count: 2,
+        read_errors: [{ scope: 'runtime_manifest_row:/tmp/bad.jsonl:1', error: 'bad row' }],
         items: [
           {
             id: 'manifest:trace-a:event_bus_correlated:2026-06-26T03:03:00Z',
@@ -602,6 +603,9 @@ describe('keeper tool telemetry fetchers', () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/keeper-alpha/compaction-snapshots?limit=2')
     expect(result.items[0]?.before_tokens).toBe(210000)
     expect(result.items[0]?.saved_tokens).toBe(90000)
+    expect(result.read_errors).toEqual([
+      { scope: 'runtime_manifest_row:/tmp/bad.jsonl:1', error: 'bad row' },
+    ])
     expect(result.items[0]?.links.receipt_path).toBeNull()
     expect(result.items[1]?.before_tokens).toBeNull()
     expect(result.items[1]?.runtime_id).toBeNull()

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -555,7 +555,9 @@ describe('keeper tool telemetry fetchers', () => {
         producer: 'keeper_runtime_manifest|keeper_meta_store',
         limit: 2,
         count: 2,
+        read_error_count: 1,
         read_errors: [{ scope: 'runtime_manifest_row:/tmp/bad.jsonl:1', error: 'bad row' }],
+        scan_truncated: false,
         items: [
           {
             id: 'manifest:trace-a:event_bus_correlated:2026-06-26T03:03:00Z',
@@ -567,6 +569,7 @@ describe('keeper tool telemetry fetchers', () => {
             source: 'runtime_manifest',
             trigger: 'proactive(85%)',
             runtime_id: 'oas-seoul-1',
+            display_runtime: 'oas-seoul-1',
             before_tokens: 210000,
             after_tokens: 120000,
             saved_tokens: 90000,
@@ -585,6 +588,7 @@ describe('keeper tool telemetry fetchers', () => {
             source: 'runtime_manifest',
             trigger: 'pre_dispatch_hygiene',
             runtime_id: null,
+            display_runtime: 'pre_dispatch_hygiene',
             before_tokens: null,
             after_tokens: null,
             saved_tokens: null,
@@ -603,9 +607,12 @@ describe('keeper tool telemetry fetchers', () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/keeper-alpha/compaction-snapshots?limit=2')
     expect(result.items[0]?.before_tokens).toBe(210000)
     expect(result.items[0]?.saved_tokens).toBe(90000)
+    expect(result.items[0]?.display_runtime).toBe('oas-seoul-1')
+    expect(result.read_error_count).toBe(1)
     expect(result.read_errors).toEqual([
       { scope: 'runtime_manifest_row:/tmp/bad.jsonl:1', error: 'bad row' },
     ])
+    expect(result.scan_truncated).toBe(false)
     expect(result.items[0]?.links.receipt_path).toBeNull()
     expect(result.items[1]?.before_tokens).toBeNull()
     expect(result.items[1]?.runtime_id).toBeNull()

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -20,6 +20,7 @@ import {
   fetchDashboardTools,
   fetchKeeperToolCalls,
   fetchKeeperToolStats,
+  fetchKeeperCompactionSnapshots,
   fetchKeeperTurnRecords,
   parseMemoryOsFactCategory,
   parseMemoryOsClaimKind,
@@ -543,6 +544,68 @@ describe('keeper tool telemetry fetchers', () => {
     expect(result.entries[0]?.record.finish_reason).toBe('completed')
     expect(result.entries[1]?.record.model).toBeUndefined()
     expect(result.entries[1]?.record.finish_reason).toBeUndefined()
+  })
+
+  it('decodes durable compaction snapshots with nullable token fields', async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify({
+        schema: 'keeper.compaction_snapshots.v1',
+        keeper: 'keeper-alpha',
+        source: 'runtime_manifest|keeper_meta',
+        producer: 'keeper_runtime_manifest|keeper_meta_store',
+        limit: 2,
+        count: 2,
+        items: [
+          {
+            id: 'manifest:trace-a:event_bus_correlated:2026-06-26T03:03:00Z',
+            keeper: 'keeper-alpha',
+            ts_iso: '2026-06-26T03:03:00Z',
+            ts_unix: 1_782_444_580,
+            trace_id: 'trace-a',
+            keeper_turn_id: 12,
+            source: 'runtime_manifest',
+            trigger: 'proactive(85%)',
+            runtime_id: 'oas-seoul-1',
+            before_tokens: 210000,
+            after_tokens: 120000,
+            saved_tokens: 90000,
+            compaction_id: 'cmp-42',
+            compaction_source: 'event_bus',
+            status: 'observed',
+            links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+          },
+          {
+            id: 'manifest:trace-b:context_compacted:2026-06-26T04:03:00Z',
+            keeper: 'keeper-alpha',
+            ts_iso: '2026-06-26T04:03:00Z',
+            ts_unix: null,
+            trace_id: 'trace-b',
+            keeper_turn_id: null,
+            source: 'runtime_manifest',
+            trigger: 'pre_dispatch_hygiene',
+            runtime_id: null,
+            before_tokens: null,
+            after_tokens: null,
+            saved_tokens: null,
+            compaction_id: null,
+            compaction_source: 'pre_dispatch_hygiene',
+            status: 'compacted',
+            links: {},
+          },
+        ],
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchKeeperCompactionSnapshots('keeper-alpha', 2)
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/keepers/keeper-alpha/compaction-snapshots?limit=2')
+    expect(result.items[0]?.before_tokens).toBe(210000)
+    expect(result.items[0]?.saved_tokens).toBe(90000)
+    expect(result.items[0]?.links.receipt_path).toBeNull()
+    expect(result.items[1]?.before_tokens).toBeNull()
+    expect(result.items[1]?.runtime_id).toBeNull()
+    expect(result.items[1]?.links.checkpoint_path).toBeNull()
   })
 })
 

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -254,11 +254,15 @@ export type {
   KeeperUserModelItem,
   KeeperUserModelSnapshot,
   TurnRecordsResponse,
+  KeeperCompactionSnapshotLinks,
+  KeeperCompactionSnapshot,
+  KeeperCompactionSnapshotsResponse,
   TurnTranscriptLine,
   TurnTranscript,
 } from './dashboard-turn-records'
 export {
   fetchKeeperTurnRecords,
+  fetchKeeperCompactionSnapshots,
   fetchKeeperTurnTranscript,
   parseMemoryOsFactCategory,
   parseMemoryOsClaimKind,

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -261,6 +261,7 @@ export type {
   TurnTranscript,
 } from './dashboard-turn-records'
 export {
+  MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER,
   fetchKeeperTurnRecords,
   fetchKeeperCompactionSnapshots,
   fetchKeeperTurnTranscript,

--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -11,7 +11,6 @@ import type { VNode } from 'preact'
 import type { Keeper } from '../../types'
 import { fetchKeeperCompactionSnapshots } from '../../api/dashboard'
 import {
-  COMPACTION_SNAPSHOT_DEFAULT_LIMIT,
   hydrateCompactionSnapshots,
   keeperCompactionSnapshots,
   type CompactionSnapshot,
@@ -110,7 +109,7 @@ export function CompactionInspectorOverlay({
     const controller = new AbortController()
     let active = true
     setLoadState({ loading: true, error: null })
-    void fetchKeeperCompactionSnapshots(keeper.name, COMPACTION_SNAPSHOT_DEFAULT_LIMIT, { signal: controller.signal })
+    void fetchKeeperCompactionSnapshots(keeper.name, undefined, { signal: controller.signal })
       .then((payload) => {
         if (!active) return
         hydrateCompactionSnapshots(keeper.name, payload.items)

--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -11,6 +11,7 @@ import type { VNode } from 'preact'
 import type { Keeper } from '../../types'
 import { fetchKeeperCompactionSnapshots } from '../../api/dashboard'
 import {
+  COMPACTION_SNAPSHOT_DEFAULT_LIMIT,
   hydrateCompactionSnapshots,
   keeperCompactionSnapshots,
   type CompactionSnapshot,
@@ -109,7 +110,7 @@ export function CompactionInspectorOverlay({
     const controller = new AbortController()
     let active = true
     setLoadState({ loading: true, error: null })
-    void fetchKeeperCompactionSnapshots(keeper.name, 25, { signal: controller.signal })
+    void fetchKeeperCompactionSnapshots(keeper.name, COMPACTION_SNAPSHOT_DEFAULT_LIMIT, { signal: controller.signal })
       .then((payload) => {
         if (!active) return
         hydrateCompactionSnapshots(keeper.name, payload.items)

--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -1,17 +1,27 @@
 // MASC v2 — Compaction snapshot overlay (from context rail).
 //
-// Ported from rails.jsx CompactionInspector. Uses the client-side
-// compactionSnapshots store; only token counts are guaranteed from live data.
-// Message/trace counts and kept/summarized/dropped details are not yet streamed
-// by the backend, so those sections render an explicit data-gap note.
+// Ported from rails.jsx CompactionInspector. Hydrates durable snapshots from
+// the backend and keeps optimistic SSE/manual entries from the local store.
+// Message/trace counts and kept/summarized/dropped details are not exposed, so
+// those sections render an explicit data-gap note.
 
 import { html } from 'htm/preact'
 import { useEffect, useState } from 'preact/hooks'
 import type { VNode } from 'preact'
 import type { Keeper } from '../../types'
-import { keeperCompactionSnapshots, type CompactionSnapshot } from './compaction-snapshots'
+import { fetchKeeperCompactionSnapshots } from '../../api/dashboard'
+import {
+  hydrateCompactionSnapshots,
+  keeperCompactionSnapshots,
+  type CompactionSnapshot,
+} from './compaction-snapshots'
 
-function fmtTok(n: number): string {
+function isFiniteNumber(n: number | null | undefined): n is number {
+  return typeof n === 'number' && Number.isFinite(n)
+}
+
+function fmtTok(n: number | null | undefined): string {
+  if (!isFiniteNumber(n)) return '미수신'
   return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
 }
 
@@ -60,7 +70,7 @@ function cmpFullCtx(ev: CompactionSnapshot, side: 'before' | 'after'): string {
     `- trace 수: ${ev.before.traces != null && ev.after.traces != null ? String(side === 'before' ? ev.before.traces : ev.after.traces) : '미수신'}`,
     `- 반대쪽: ${fmtTok(otherTok)}`,
     '',
-    '전체 프롬프트 텍스트는 아직 백엔드에서 스트리밍되지 않습니다.',
+    '전체 프롬프트 텍스트는 이 API에서 노출하지 않습니다.',
   ]
   return lines.join('\n')
 }
@@ -79,6 +89,10 @@ export function CompactionInspectorOverlay({
   const events = keeperCompactionSnapshots(keeper.name)
   const [idx, setIdx] = useState(0)
   const [side, setSide] = useState<'before' | 'after'>('after')
+  const [loadState, setLoadState] = useState<{ loading: boolean; error: string | null }>({
+    loading: true,
+    error: null,
+  })
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -91,6 +105,30 @@ export function CompactionInspectorOverlay({
     return () => window.removeEventListener('keydown', onKey)
   }, [onClose])
 
+  useEffect(() => {
+    const controller = new AbortController()
+    let active = true
+    setLoadState({ loading: true, error: null })
+    void fetchKeeperCompactionSnapshots(keeper.name, 25, { signal: controller.signal })
+      .then((payload) => {
+        if (!active) return
+        hydrateCompactionSnapshots(keeper.name, payload.items)
+        setLoadState({ loading: false, error: null })
+      })
+      .catch((err: unknown) => {
+        if (!active) return
+        if (err instanceof DOMException && err.name === 'AbortError') return
+        setLoadState({
+          loading: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [keeper.name])
+
   if (events.length === 0) {
     return html`
       <div class="turn-overlay" onClick=${onClose}>
@@ -101,10 +139,16 @@ export function CompactionInspectorOverlay({
             <button type="button" class="turn-close" onClick=${onClose} title="닫기 (Esc)">${'✕'}</button>
           </div>
           <div class="turn-body">
-            <div class="cmp-empty">
-              아직 이 keeper에서 실행된 컴팩션이 없습니다.<br />
-              컨텍스트가 임계치를 넘으면 자동으로 기록되며, ‘지금 컴팩트’를 눌러 수동 결과를 남길 수 있습니다.
-            </div>
+            ${loadState.loading
+              ? html`<div class="cmp-empty">컴팩션 스냅샷 불러오는 중…</div>`
+              : loadState.error
+                ? html`<div class="mem-read-error" role="alert">${'⚠'} 컴팩션 스냅샷 불러오기 실패 — ${loadState.error}</div>`
+                : html`
+                  <div class="cmp-empty">
+                    아직 이 keeper에서 durable compaction snapshot이 없습니다.<br />
+                    컨텍스트가 임계치를 넘거나 ‘지금 컴팩트’를 실행하면 새 결과가 기록됩니다.
+                  </div>
+                `}
           </div>
         </div>
       </div>
@@ -113,7 +157,10 @@ export function CompactionInspectorOverlay({
 
   const safeIdx = Math.max(0, Math.min(idx, events.length - 1))
   const ev = events[safeIdx]!
-  const reduction = Math.round((1 - ev.after.tok / Math.max(1, ev.before.tok)) * 100)
+  const hasTokenPair = isFiniteNumber(ev.before.tok) && isFiniteNumber(ev.after.tok)
+  const reduction = hasTokenPair && ev.before.tok > 0
+    ? Math.round((1 - ev.after.tok / ev.before.tok) * 100)
+    : null
 
   return html`
     <div class="turn-overlay" onClick=${onClose}>
@@ -137,8 +184,17 @@ export function CompactionInspectorOverlay({
           `)}
         </div>
         <div class="turn-body">
+          ${loadState.loading
+            ? html`<div class="mem-empty mem-disclosure">durable snapshot 새로고침 중…</div>`
+            : loadState.error
+              ? html`<div class="mem-read-error" role="alert">${'⚠'} durable snapshot 새로고침 실패 — ${loadState.error}</div>`
+              : null}
           <div class="cmp-trigger"><span class="sub-k">트리거</span>${ev.trigger}</div>
           <div class="cmp-trigger"><span class="sub-k">수행 런타임</span><span class="mono">${ev.runtime}</span></div>
+          <div class="cmp-trigger"><span class="sub-k">소스</span><span class="mono">${ev.detailSource ?? ev.source}${ev.status ? ` · ${ev.status}` : ''}</span></div>
+          ${ev.traceId
+            ? html`<div class="cmp-trigger"><span class="sub-k">trace</span><span class="mono">${ev.traceId}${ev.keeperTurnId != null ? `#${ev.keeperTurnId}` : ''}</span></div>`
+            : null}
 
           <div class="turn-sec">
             <h4>Before → After</h4>
@@ -146,9 +202,11 @@ export function CompactionInspectorOverlay({
               <span class="mono">${fmtTok(ev.before.tok)}</span>
               <span class="cmp-arrow">${'→'}</span>
               <span class="mono" style=${{ color: 'var(--status-ok)' }}>${fmtTok(ev.after.tok)}</span>
-              <span class="cmp-reduce">${'−'}${reduction}%</span>
+              ${reduction != null ? html`<span class="cmp-reduce">${'−'}${reduction}%</span>` : null}
             </div>
-            <${CmpStat} label="토큰" a=${ev.before.tok} b=${ev.after.tok} unit="k" max=${Math.max(ev.before.tok, 1)} />
+            ${hasTokenPair
+              ? html`<${CmpStat} label="토큰" a=${ev.before.tok} b=${ev.after.tok} unit="k" max=${Math.max(ev.before.tok, 1)} />`
+              : html`<${DataGapNote}>이 snapshot에는 before/after token count가 없습니다.</${DataGapNote}>`}
             ${ev.before.msgs != null && ev.after.msgs != null
               ? html`<${CmpStat} label="메시지" a=${ev.before.msgs} b=${ev.after.msgs} max=${Math.max(ev.before.msgs, 1)} />`
               : null}
@@ -160,7 +218,7 @@ export function CompactionInspectorOverlay({
           <div class="turn-sec">
             <h4>유지 · 요약 · 폐기</h4>
             ${ev.kept.length === 0 && ev.summarized.length === 0 && ev.dropped.length === 0
-              ? html`<${DataGapNote}>백엔드에서 아직 상세 분류(kept / summarized / dropped)를 병렬하지 않습니다.</${DataGapNote}>`
+              ? html`<${DataGapNote}>백엔드 API는 상세 분류(kept / summarized / dropped)와 raw prompt text를 노출하지 않습니다.</${DataGapNote}>`
               : html`
                 <div class="cmp-diff">
                   <div class="cmp-col kept">

--- a/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
@@ -36,7 +36,12 @@ export interface CompactionSnapshot {
 
 type PerKeeperSnapshots = Record<string, CompactionSnapshot[]>
 
+export const COMPACTION_SNAPSHOT_DEFAULT_LIMIT = 25
+export const COMPACTION_SNAPSHOT_MAX_ITEMS = 100
+
 export const compactionSnapshots: Signal<PerKeeperSnapshots> = signal({})
+
+let fallbackIdSeq = 0
 
 function nowHM(): string {
   const d = new Date()
@@ -44,7 +49,10 @@ function nowHM(): string {
 }
 
 function nextId(prefix: string): string {
-  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`
+  const uuid = globalThis.crypto?.randomUUID?.()
+  if (uuid) return `${prefix}_${uuid}`
+  fallbackIdSeq = (fallbackIdSeq + 1) % Number.MAX_SAFE_INTEGER
+  return `${prefix}_${Date.now().toString(36)}_${fallbackIdSeq.toString(36)}`
 }
 
 function finiteNumberOrNull(value: number | null | undefined): number | null {
@@ -73,17 +81,17 @@ function labelFromIso(iso: string): string {
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
 }
 
+function displayRuntimeFromBackendSnapshot(snapshot: BackendCompactionSnapshot): string {
+  return snapshot.runtime_id ?? snapshot.compaction_source ?? snapshot.source
+}
+
 function backendSnapshotToLocal(snapshot: BackendCompactionSnapshot): CompactionSnapshot {
-  const runtime =
-    snapshot.runtime_id
-    ?? snapshot.compaction_source
-    ?? snapshot.source
   return {
     id: snapshot.id,
     at: labelFromIso(snapshot.ts_iso),
     atIso: snapshot.ts_iso,
     trigger: snapshot.trigger,
-    runtime,
+    runtime: displayRuntimeFromBackendSnapshot(snapshot),
     before: { tok: finiteNumberOrNull(snapshot.before_tokens) },
     after: { tok: finiteNumberOrNull(snapshot.after_tokens) },
     savedTokens: finiteNumberOrNull(snapshot.saved_tokens),
@@ -99,12 +107,25 @@ function backendSnapshotToLocal(snapshot: BackendCompactionSnapshot): Compaction
 }
 
 function snapshotSortKey(snapshot: CompactionSnapshot): number {
-  if (snapshot.source !== 'backend') return Number.MAX_SAFE_INTEGER
   if (snapshot.atIso) {
     const parsed = Date.parse(snapshot.atIso)
     if (Number.isFinite(parsed)) return parsed
   }
   return 0
+}
+
+function snapshotSourceRank(snapshot: CompactionSnapshot): number {
+  if (snapshot.source === 'backend') return 2
+  if (snapshot.source === 'sse') return 1
+  return 0
+}
+
+function compareCompactionSnapshots(a: CompactionSnapshot, b: CompactionSnapshot): number {
+  const byTime = snapshotSortKey(b) - snapshotSortKey(a)
+  if (byTime !== 0) return byTime
+  const bySource = snapshotSourceRank(b) - snapshotSourceRank(a)
+  if (bySource !== 0) return bySource
+  return b.id.localeCompare(a.id)
 }
 
 export function hydrateCompactionSnapshots(
@@ -119,8 +140,8 @@ export function hydrateCompactionSnapshots(
     if (!byId.has(snapshot.id)) byId.set(snapshot.id, snapshot)
   }
   const next = [...byId.values()]
-    .sort((a, b) => snapshotSortKey(b) - snapshotSortKey(a))
-    .slice(0, 100)
+    .sort(compareCompactionSnapshots)
+    .slice(0, COMPACTION_SNAPSHOT_MAX_ITEMS)
   compactionSnapshots.value = {
     ...compactionSnapshots.value,
     [keeperName]: next,

--- a/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
@@ -43,8 +43,7 @@ export const compactionSnapshots: Signal<PerKeeperSnapshots> = signal({})
 
 let fallbackIdSeq = 0
 
-function nowHM(): string {
-  const d = new Date()
+function hmLabel(d: Date): string {
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
 }
 
@@ -63,10 +62,12 @@ export function pushCompactionSnapshot(
   keeperName: string,
   snapshot: Omit<CompactionSnapshot, 'id' | 'at'>,
 ): void {
+  const now = new Date()
   const next: CompactionSnapshot = {
     ...snapshot,
     id: nextId(snapshot.source === 'manual' ? 'cmp-m' : 'cmp-s'),
-    at: nowHM(),
+    at: hmLabel(now),
+    atIso: snapshot.atIso ?? now.toISOString(),
   }
   compactionSnapshots.value = {
     ...compactionSnapshots.value,
@@ -81,17 +82,13 @@ function labelFromIso(iso: string): string {
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
 }
 
-function displayRuntimeFromBackendSnapshot(snapshot: BackendCompactionSnapshot): string {
-  return snapshot.runtime_id ?? snapshot.compaction_source ?? snapshot.source
-}
-
 function backendSnapshotToLocal(snapshot: BackendCompactionSnapshot): CompactionSnapshot {
   return {
     id: snapshot.id,
     at: labelFromIso(snapshot.ts_iso),
     atIso: snapshot.ts_iso,
     trigger: snapshot.trigger,
-    runtime: displayRuntimeFromBackendSnapshot(snapshot),
+    runtime: snapshot.display_runtime,
     before: { tok: finiteNumberOrNull(snapshot.before_tokens) },
     after: { tok: finiteNumberOrNull(snapshot.after_tokens) },
     savedTokens: finiteNumberOrNull(snapshot.saved_tokens),

--- a/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
@@ -1,15 +1,16 @@
-// MASC v2 — lightweight client-side log of keeper context compactions.
+// MASC v2 — compaction snapshot log for keeper context compactions.
 //
-// The backend exposes compaction results as discrete events (SSE
-// `keeper_compaction` / `oas:context_compacted` and the manual
-// `masc_keeper_compact` MCP response). It does not yet expose per-event
-// kept/summarized/dropped lists or full before/after message/trace counts, so
-// this store records what we *do* see and surfaces the rest as honest gaps.
+// SSE/manual events are optimistic live updates. The durable backend endpoint
+// (`/api/v1/keepers/:name/compaction-snapshots`) hydrates historical runtime
+// manifest / keeper-meta events after opening the inspector. It still does not
+// expose raw prompt text or kept/summarized/dropped message lists, so the drawer
+// renders those as explicit data gaps.
 
 import { signal, type Signal } from '@preact/signals'
+import type { KeeperCompactionSnapshot as BackendCompactionSnapshot } from '../../api/dashboard'
 
 export interface CompactionSnapshotNumbers {
-  readonly tok: number
+  readonly tok: number | null
   readonly msgs?: number | null
   readonly traces?: number | null
 }
@@ -17,14 +18,20 @@ export interface CompactionSnapshotNumbers {
 export interface CompactionSnapshot {
   readonly id: string
   readonly at: string
+  readonly atIso?: string | null
   readonly trigger: string
   readonly runtime: string
   readonly before: CompactionSnapshotNumbers
   readonly after: CompactionSnapshotNumbers
+  readonly savedTokens?: number | null
+  readonly traceId?: string | null
+  readonly keeperTurnId?: number | null
+  readonly status?: string | null
+  readonly detailSource?: string | null
   readonly kept: readonly string[]
   readonly summarized: readonly string[]
   readonly dropped: readonly string[]
-  readonly source: 'manual' | 'sse'
+  readonly source: 'manual' | 'sse' | 'backend'
 }
 
 type PerKeeperSnapshots = Record<string, CompactionSnapshot[]>
@@ -38,6 +45,10 @@ function nowHM(): string {
 
 function nextId(prefix: string): string {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`
+}
+
+function finiteNumberOrNull(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
 export function pushCompactionSnapshot(
@@ -55,14 +66,75 @@ export function pushCompactionSnapshot(
   }
 }
 
+function labelFromIso(iso: string): string {
+  const ts = Date.parse(iso)
+  if (!Number.isFinite(ts)) return iso
+  const d = new Date(ts)
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+function backendSnapshotToLocal(snapshot: BackendCompactionSnapshot): CompactionSnapshot {
+  const runtime =
+    snapshot.runtime_id
+    ?? snapshot.compaction_source
+    ?? snapshot.source
+  return {
+    id: snapshot.id,
+    at: labelFromIso(snapshot.ts_iso),
+    atIso: snapshot.ts_iso,
+    trigger: snapshot.trigger,
+    runtime,
+    before: { tok: finiteNumberOrNull(snapshot.before_tokens) },
+    after: { tok: finiteNumberOrNull(snapshot.after_tokens) },
+    savedTokens: finiteNumberOrNull(snapshot.saved_tokens),
+    traceId: snapshot.trace_id,
+    keeperTurnId: snapshot.keeper_turn_id,
+    status: snapshot.status,
+    detailSource: snapshot.source,
+    kept: [],
+    summarized: [],
+    dropped: [],
+    source: 'backend',
+  }
+}
+
+function snapshotSortKey(snapshot: CompactionSnapshot): number {
+  if (snapshot.source !== 'backend') return Number.MAX_SAFE_INTEGER
+  if (snapshot.atIso) {
+    const parsed = Date.parse(snapshot.atIso)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return 0
+}
+
+export function hydrateCompactionSnapshots(
+  keeperName: string,
+  snapshots: readonly BackendCompactionSnapshot[],
+): void {
+  const existing = compactionSnapshots.value[keeperName] ?? []
+  const optimistic = existing.filter(snapshot => snapshot.source !== 'backend')
+  const byId = new Map<string, CompactionSnapshot>()
+  for (const snapshot of snapshots.map(backendSnapshotToLocal)) byId.set(snapshot.id, snapshot)
+  for (const snapshot of optimistic) {
+    if (!byId.has(snapshot.id)) byId.set(snapshot.id, snapshot)
+  }
+  const next = [...byId.values()]
+    .sort((a, b) => snapshotSortKey(b) - snapshotSortKey(a))
+    .slice(0, 100)
+  compactionSnapshots.value = {
+    ...compactionSnapshots.value,
+    [keeperName]: next,
+  }
+}
+
 export function recordManualCompaction(
   keeperName: string,
   beforeTokens: number | null | undefined,
   afterTokens: number | null | undefined,
   runtime: string,
 ): void {
-  const before = typeof beforeTokens === 'number' && Number.isFinite(beforeTokens) ? beforeTokens : 0
-  const after = typeof afterTokens === 'number' && Number.isFinite(afterTokens) ? afterTokens : 0
+  const before = finiteNumberOrNull(beforeTokens)
+  const after = finiteNumberOrNull(afterTokens)
   pushCompactionSnapshot(keeperName, {
     trigger: '수동 — operator 요청 (지금 컴팩트)',
     runtime: runtime || '—',
@@ -82,8 +154,8 @@ export function recordSseCompaction(
   trigger: string,
   runtime: string,
 ): void {
-  const before = typeof beforeTokens === 'number' && Number.isFinite(beforeTokens) ? beforeTokens : 0
-  const after = typeof afterTokens === 'number' && Number.isFinite(afterTokens) ? afterTokens : 0
+  const before = finiteNumberOrNull(beforeTokens)
+  const after = finiteNumberOrNull(afterTokens)
   pushCompactionSnapshot(keeperName, {
     trigger: trigger || '자동 — SSE context_compacted',
     runtime: runtime || '—',

--- a/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
@@ -36,9 +36,6 @@ export interface CompactionSnapshot {
 
 type PerKeeperSnapshots = Record<string, CompactionSnapshot[]>
 
-export const COMPACTION_SNAPSHOT_DEFAULT_LIMIT = 25
-export const COMPACTION_SNAPSHOT_MAX_ITEMS = 100
-
 export const compactionSnapshots: Signal<PerKeeperSnapshots> = signal({})
 
 let fallbackIdSeq = 0
@@ -136,9 +133,7 @@ export function hydrateCompactionSnapshots(
   for (const snapshot of optimistic) {
     if (!byId.has(snapshot.id)) byId.set(snapshot.id, snapshot)
   }
-  const next = [...byId.values()]
-    .sort(compareCompactionSnapshots)
-    .slice(0, COMPACTION_SNAPSHOT_MAX_ITEMS)
+  const next = [...byId.values()].sort(compareCompactionSnapshots)
   compactionSnapshots.value = {
     ...compactionSnapshots.value,
     [keeperName]: next,

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -8,7 +8,11 @@ import { requestConfirm } from '../common/confirm-dialog'
 import { KeeperWorkspaceRail } from './keeper-workspace-rail'
 import type { Keeper, Task } from '../../types'
 import { resetRuntimeCatalog } from '../../lib/runtime-catalog-resource'
-import { compactionSnapshots } from './compaction-snapshots'
+import {
+  compactionSnapshots,
+  hydrateCompactionSnapshots,
+  recordManualCompaction,
+} from './compaction-snapshots'
 
 // The recent-tool-calls section now lazy-loads via fetchKeeperToolCalls (rather
 // than rendering keeper.recent_tool_names). Stub it so these rail tests never hit
@@ -31,6 +35,9 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
       producer: 'keeper_runtime_manifest|keeper_meta_store',
       limit: 25,
       count: 1,
+      read_error_count: 0,
+      read_errors: [],
+      scan_truncated: false,
       items: [
         {
           id: 'manifest:trace-cmp:event_bus_correlated:2026-06-26T03:03:00Z',
@@ -42,6 +49,7 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
           source: 'runtime_manifest',
           trigger: 'proactive(85%)',
           runtime_id: 'oas-seoul-1',
+          display_runtime: 'oas-seoul-1',
           before_tokens: 210000,
           after_tokens: 120000,
           saved_tokens: 90000,
@@ -87,6 +95,7 @@ afterEach(() => {
   shellAuthSummary.value = null
   compactionSnapshots.value = {}
   vi.clearAllMocks()
+  vi.useRealTimers()
   resetRuntimeCatalog()
 })
 
@@ -311,6 +320,39 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('proactive(85%)')
     expect(container.textContent).toContain('runtime_manifest · observed')
     expect(container.textContent).toContain('trace-cmp#12')
+  })
+
+  it('keeps newly recorded optimistic compactions above older durable snapshots', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-27T10:00:00Z'))
+
+    recordManualCompaction('masc-improver', 1000, 800, 'runtime-a')
+    hydrateCompactionSnapshots('masc-improver', [
+      {
+        id: 'manifest:old:event_bus_correlated:2026-06-26T03:03:00Z',
+        keeper: 'masc-improver',
+        ts_iso: '2026-06-26T03:03:00Z',
+        ts_unix: 1_782_444_580,
+        trace_id: 'old',
+        keeper_turn_id: 1,
+        source: 'runtime_manifest',
+        trigger: 'proactive(85%)',
+        runtime_id: 'runtime-old',
+        display_runtime: 'runtime-old',
+        before_tokens: 210000,
+        after_tokens: 120000,
+        saved_tokens: 90000,
+        compaction_id: 'cmp-old',
+        compaction_source: 'event_bus',
+        status: 'observed',
+        links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+      },
+    ])
+
+    const snapshots = compactionSnapshots.value['masc-improver'] ?? []
+    expect(snapshots[0]?.source).toBe('manual')
+    expect(snapshots[0]?.atIso).toBe('2026-06-27T10:00:00.000Z')
+    expect(snapshots[1]?.source).toBe('backend')
   })
 
   it('opens the memory inspector overlay from the context rail', () => {

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -8,6 +8,7 @@ import { requestConfirm } from '../common/confirm-dialog'
 import { KeeperWorkspaceRail } from './keeper-workspace-rail'
 import type { Keeper, Task } from '../../types'
 import { resetRuntimeCatalog } from '../../lib/runtime-catalog-resource'
+import { compactionSnapshots } from './compaction-snapshots'
 
 // The recent-tool-calls section now lazy-loads via fetchKeeperToolCalls (rather
 // than rendering keeper.recent_tool_names). Stub it so these rail tests never hit
@@ -23,6 +24,34 @@ vi.mock('../../api/dashboard', async (importOriginal) => {
       entries: [],
     }),
     fetchRuntimeProviders: vi.fn().mockResolvedValue({ providers: [] }),
+    fetchKeeperCompactionSnapshots: vi.fn().mockResolvedValue({
+      schema: 'keeper.compaction_snapshots.v1',
+      keeper: 'masc-improver',
+      source: 'runtime_manifest|keeper_meta',
+      producer: 'keeper_runtime_manifest|keeper_meta_store',
+      limit: 25,
+      count: 1,
+      items: [
+        {
+          id: 'manifest:trace-cmp:event_bus_correlated:2026-06-26T03:03:00Z',
+          keeper: 'masc-improver',
+          ts_iso: '2026-06-26T03:03:00Z',
+          ts_unix: 1_782_444_580,
+          trace_id: 'trace-cmp',
+          keeper_turn_id: 12,
+          source: 'runtime_manifest',
+          trigger: 'proactive(85%)',
+          runtime_id: 'oas-seoul-1',
+          before_tokens: 210000,
+          after_tokens: 120000,
+          saved_tokens: 90000,
+          compaction_id: 'cmp-42',
+          compaction_source: 'event_bus',
+          status: 'observed',
+          links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+        },
+      ],
+    }),
   }
 })
 
@@ -56,6 +85,7 @@ afterEach(() => {
   cleanup()
   tasks.value = []
   shellAuthSummary.value = null
+  compactionSnapshots.value = {}
   vi.clearAllMocks()
   resetRuntimeCatalog()
 })
@@ -268,7 +298,7 @@ describe('KeeperWorkspaceRail', () => {
     expect(callMcpTool).not.toHaveBeenCalled()
   })
 
-  it('opens the compaction inspector overlay from the context rail', () => {
+  it('opens the compaction inspector overlay from the context rail and hydrates durable snapshots', async () => {
     const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} />`)
     const btn = Array.from(container.querySelectorAll('.cmp-open')).find(
       el => el.textContent?.includes('before/after'),
@@ -277,6 +307,10 @@ describe('KeeperWorkspaceRail', () => {
     fireEvent.click(btn as HTMLElement)
     expect(container.querySelector('.turn-overlay')).toBeTruthy()
     expect(container.textContent).toContain('컴팩션 스냅샷')
+    await waitFor(() => expect(container.textContent).toContain('210.0k'))
+    expect(container.textContent).toContain('proactive(85%)')
+    expect(container.textContent).toContain('runtime_manifest · observed')
+    expect(container.textContent).toContain('trace-cmp#12')
   })
 
   it('opens the memory inspector overlay from the context rail', () => {

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -16,7 +16,11 @@ import {
   sortMemoryFactsForReview,
   type MemoryKeeper,
 } from './memory-inspector'
-import type { MemoryOsFact, TurnRecordRow } from '../api/dashboard'
+import {
+  MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER,
+  type MemoryOsFact,
+  type TurnRecordRow,
+} from '../api/dashboard'
 
 afterEach(() => {
   cleanup()
@@ -85,7 +89,7 @@ function turnRecordsPayload() {
             valid_until: null,
             valid_until_iso: null,
             current: true,
-            terminal_marker: 'librarian_unstructured_fallback',
+            terminal_marker: MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER,
             claim_count: 1,
             summary: 'unstructured_note: librarian parse fallback (empty response)',
           },
@@ -252,12 +256,13 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     expect(container.textContent).not.toContain('diagnostic row: operator pin backend source absent')
     expect(container.textContent).not.toContain('librarian parse fallback')
 
-    const diagnosticBtn = [...container.querySelectorAll('.mem-filter')].find(b => b.textContent === '진단/증거 2')
+    const diagnosticBtn = [...container.querySelectorAll('.mem-filter')].find(b => b.textContent === '진단/증거 1')
     expect(diagnosticBtn).toBeTruthy()
     fireEvent.click(diagnosticBtn!)
 
     expect(container.textContent).toContain('diagnostic row: operator pin backend source absent')
     expect(container.textContent).toContain('diagnostic evidence row')
+    expect(container.textContent).not.toContain('amplitude 캐시는 만료됨')
     expect(container.textContent).toContain('진단 fallback · librarian')
     expect(container.textContent).toContain('librarian parse fallback')
   })

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -60,10 +60,10 @@ function turnRecordsPayload() {
       read_errors: [{ scope: 'facts', error: 'one malformed row skipped' }],
       episodes: {
         tail_limit: 12,
-        shown: 1,
-        current: 1,
+        shown: 2,
+        current: 2,
         expired: 0,
-        terminal_markers: 1,
+        terminal_markers: 2,
         items: [
           {
             trace_id: 'trace-ep1',
@@ -77,12 +77,24 @@ function turnRecordsPayload() {
             claim_count: 4,
             summary: '리텐션 코호트 정의를 정리하고 amplitude 쿼리를 표로 캐시함.',
           },
+          {
+            trace_id: 'trace-fallback',
+            generation: 4,
+            created_at: 1_789_950_000,
+            created_at_iso: '2026-09-20T...Z',
+            valid_until: null,
+            valid_until_iso: null,
+            current: true,
+            terminal_marker: 'librarian_unstructured_fallback',
+            claim_count: 1,
+            summary: 'unstructured_note: librarian parse fallback (empty response)',
+          },
         ],
       },
       facts: {
         tail_limit: 384,
-        shown: 2,
-        current: 1,
+        shown: 3,
+        current: 2,
         expired: 1,
         items: [
           {
@@ -99,6 +111,20 @@ function turnRecordsPayload() {
             prompt_recallable: true,
             claim_kind: 'durable_knowledge',
             external_ref: { kind: 'pr', id: '22198' },
+          },
+          {
+            claim: 'diagnostic row: operator pin backend source absent',
+            category: 'fact',
+            source: { trace_id: 'trace-diagnostic', turn: 6, tool_call_id: null },
+            first_seen: 1_789_700_000,
+            first_seen_iso: '2026-09-10T...Z',
+            reference_time: 1_789_700_000,
+            valid_until: null,
+            valid_until_iso: null,
+            last_verified_at: null,
+            current: true,
+            prompt_recallable: false,
+            claim_kind: 'diagnostic',
           },
           {
             claim: 'amplitude 캐시는 만료됨',
@@ -190,12 +216,16 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     stubFetch()
     const { container } = renderInspector()
     await waitFor(() => expect(container.querySelectorAll('.mem-store-row').length).toBeGreaterThan(0))
-    // Default view is active/current only so expired rows do not dominate the drawer.
+    // Default view is prompt-recallable current rows only, so diagnostics and
+    // expired evidence do not dominate the drawer.
     expect(container.textContent).toContain('retention D0 = 가입일, 첫 세션 기준')
     expect(container.textContent).toContain('제약') // constraint chip label
     expect(container.textContent).toContain('저장')
     expect(container.textContent).toContain('검증')
     expect(container.textContent).toContain('active recall candidate')
+    expect(container.textContent).toContain('1/3 recallable')
+    expect(container.textContent).not.toContain('diagnostic row: operator pin backend source absent')
+    expect(container.textContent).not.toContain('librarian parse fallback')
     expect(container.textContent).not.toContain('amplitude 캐시는 만료됨')
   })
 
@@ -203,7 +233,7 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     stubFetch()
     const { container } = renderInspector()
     await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
-    const allBtn = [...container.querySelectorAll('.mem-filter')].find(b => b.textContent === '전체 2')
+    const allBtn = [...container.querySelectorAll('.mem-filter')].find(b => b.textContent === '전체 3')
     expect(allBtn).toBeTruthy()
     fireEvent.click(allBtn!)
     // out-of-vocabulary category surfaces its raw label, not a fabricated kind.
@@ -213,6 +243,23 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     expect(container.textContent).not.toContain('pr 22198')
     // NO salience meter — the deleted score model must not reappear.
     expect(container.querySelector('.mem-sal')).toBeFalsy()
+  })
+
+  it('keeps diagnostic facts and librarian fallback episodes out of the default recall view', async () => {
+    stubFetch()
+    const { container } = renderInspector()
+    await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
+    expect(container.textContent).not.toContain('diagnostic row: operator pin backend source absent')
+    expect(container.textContent).not.toContain('librarian parse fallback')
+
+    const diagnosticBtn = [...container.querySelectorAll('.mem-filter')].find(b => b.textContent === '진단/증거 2')
+    expect(diagnosticBtn).toBeTruthy()
+    fireEvent.click(diagnosticBtn!)
+
+    expect(container.textContent).toContain('diagnostic row: operator pin backend source absent')
+    expect(container.textContent).toContain('diagnostic evidence row')
+    expect(container.textContent).toContain('진단 fallback · librarian')
+    expect(container.textContent).toContain('librarian parse fallback')
   })
 
   it('surfaces selection policy and prompt digest lineage without claiming raw full-prompt storage', async () => {

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -23,6 +23,7 @@ import { useSignal } from '@preact/signals'
 import { formatDateTimeKo, formatTimeAgo, formatTimeUntil } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
 import {
+  MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER,
   fetchKeeperTurnRecords,
   type TurnRecordsResponse,
   type MemoryOsTurnRecordSnapshot,
@@ -185,7 +186,6 @@ export function factTtlLabel(fact: MemoryOsFact): string {
 }
 
 const DEFAULT_FACT_ROW_LIMIT = 12
-const LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER = 'librarian_unstructured_fallback'
 type FactVisibilityFilter = 'recallable' | 'diagnostic' | 'all'
 
 export function sortMemoryFactsForReview(facts: readonly MemoryOsFact[]): MemoryOsFact[] {
@@ -203,7 +203,7 @@ function isPromptRecallableFact(fact: MemoryOsFact): boolean {
 }
 
 function isDiagnosticEvidenceFact(fact: MemoryOsFact): boolean {
-  return !isPromptRecallableFact(fact)
+  return fact.current && !fact.prompt_recallable
 }
 
 function formatFactInstant(ts: number, iso: string | null): string {
@@ -453,10 +453,10 @@ function OneKeeperMemoryReal({
   const diagnosticFacts = facts.filter(isDiagnosticEvidenceFact)
   const allEpisodes = [...snapshot.episodes.items].reverse()
   const episodes = allEpisodes
-    .filter(ep => ep.terminal_marker !== LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER)
+    .filter(ep => ep.terminal_marker !== MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER)
     .slice(0, 5)
   const fallbackEpisodes = allEpisodes
-    .filter(ep => ep.terminal_marker === LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER)
+    .filter(ep => ep.terminal_marker === MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER)
     .slice(0, 5)
   // distinct categories present, in first-seen order, deduped by tag
   const seen = new Set<string>()

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -185,13 +185,24 @@ export function factTtlLabel(fact: MemoryOsFact): string {
 }
 
 const DEFAULT_FACT_ROW_LIMIT = 12
-type FactVisibilityFilter = 'current' | 'all'
+type FactVisibilityFilter = 'recallable' | 'diagnostic' | 'all'
 
 export function sortMemoryFactsForReview(facts: readonly MemoryOsFact[]): MemoryOsFact[] {
   return [...facts].sort((a, b) => {
+    const aRecallable = a.current && a.prompt_recallable
+    const bRecallable = b.current && b.prompt_recallable
+    if (aRecallable !== bRecallable) return aRecallable ? -1 : 1
     if (a.current !== b.current) return a.current ? -1 : 1
     return b.reference_time - a.reference_time
   })
+}
+
+function isPromptRecallableFact(fact: MemoryOsFact): boolean {
+  return fact.current && fact.prompt_recallable
+}
+
+function isDiagnosticEvidenceFact(fact: MemoryOsFact): boolean {
+  return !isPromptRecallableFact(fact)
 }
 
 function formatFactInstant(ts: number, iso: string | null): string {
@@ -280,6 +291,8 @@ function MemoryTrustStrip({
 }) {
   const policy = snapshot.selection_policy
   const memoryBlock = latestMemoryRecallBlock(latestPromptRow)
+  const recallableFacts = snapshot.facts.items.filter(isPromptRecallableFact).length
+  const diagnosticFacts = snapshot.facts.items.filter(isDiagnosticEvidenceFact).length
   const promptTurn = latestPromptRow
     ? `${latestPromptRow.record.trace_id}#${latestPromptRow.record.absolute_turn}`
     : 'none'
@@ -290,8 +303,8 @@ function MemoryTrustStrip({
     <div class="mem-trust">
       <div class="mem-trust-card">
         <span class="mem-trust-k">store</span>
-        <span class="mem-trust-v mono">${snapshot.facts.current}/${snapshot.facts.shown} current</span>
-        <span class="mem-trust-sub mono">${snapshot.source}</span>
+        <span class="mem-trust-v mono">${recallableFacts}/${snapshot.facts.shown} recallable</span>
+        <span class="mem-trust-sub mono">${diagnosticFacts} diagnostic/evidence · ${snapshot.source}</span>
       </div>
       <div class="mem-trust-card">
         <span class="mem-trust-k">scope</span>
@@ -431,11 +444,19 @@ function OneKeeperMemoryReal({
   rows: readonly TurnRecordRow[]
 }) {
   const kindFilter = useSignal<string>('all')
-  const visibilityFilter = useSignal<FactVisibilityFilter>('current')
+  const visibilityFilter = useSignal<FactVisibilityFilter>('recallable')
   const factRowLimit = useSignal(DEFAULT_FACT_ROW_LIMIT)
   const latestPromptRow = latestEntryWithBlocks(rows)
   const facts = sortMemoryFactsForReview(snapshot.facts.items)
-  const episodes = [...snapshot.episodes.items].reverse().slice(0, 5)
+  const recallableFacts = facts.filter(isPromptRecallableFact)
+  const diagnosticFacts = facts.filter(isDiagnosticEvidenceFact)
+  const allEpisodes = [...snapshot.episodes.items].reverse()
+  const episodes = allEpisodes
+    .filter(ep => ep.terminal_marker !== 'librarian_unstructured_fallback')
+    .slice(0, 5)
+  const fallbackEpisodes = allEpisodes
+    .filter(ep => ep.terminal_marker === 'librarian_unstructured_fallback')
+    .slice(0, 5)
   // distinct categories present, in first-seen order, deduped by tag
   const seen = new Set<string>()
   const cats: MemoryOsFactCategory[] = []
@@ -448,11 +469,16 @@ function OneKeeperMemoryReal({
   }
   const filter = kindFilter.value
   const visibilityRows =
-    visibilityFilter.value === 'current' ? facts.filter(f => f.current) : facts
+    visibilityFilter.value === 'recallable'
+      ? recallableFacts
+      : visibilityFilter.value === 'diagnostic'
+        ? diagnosticFacts
+        : facts
   const storeRows =
     filter === 'all' ? visibilityRows : visibilityRows.filter(f => factTag(f) === filter)
   const visibleStoreRows = storeRows.slice(0, factRowLimit.value)
   const hiddenStoreRows = Math.max(0, storeRows.length - visibleStoreRows.length)
+  const showFallbackEpisodes = visibilityFilter.value !== 'recallable'
 
   return html`
     <${Fragment}>
@@ -482,16 +508,20 @@ function OneKeeperMemoryReal({
       <div class="turn-sec">
         <div class="mem-sec-head">
           <h4>장기 메모리 스토어 · memory-os</h4>
-          <span class="mem-n mono">${snapshot.facts.current}/${snapshot.facts.shown}</span>
+          <span class="mem-n mono">${recallableFacts.length}/${snapshot.facts.shown}</span>
         </div>
         ${facts.length
           ? html`
             <${Fragment}>
               <div class="mem-filters">
                 <button
-                  class=${`mem-filter ${visibilityFilter.value === 'current' ? 'on' : ''}`}
-                  onClick=${() => { visibilityFilter.value = 'current'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
-                >활성 ${snapshot.facts.current}</button>
+                  class=${`mem-filter ${visibilityFilter.value === 'recallable' ? 'on' : ''}`}
+                  onClick=${() => { visibilityFilter.value = 'recallable'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
+                >회상 ${recallableFacts.length}</button>
+                <button
+                  class=${`mem-filter ${visibilityFilter.value === 'diagnostic' ? 'on' : ''}`}
+                  onClick=${() => { visibilityFilter.value = 'diagnostic'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
+                >진단/증거 ${diagnosticFacts.length}</button>
                 <button
                   class=${`mem-filter ${visibilityFilter.value === 'all' ? 'on' : ''}`}
                   onClick=${() => { visibilityFilter.value = 'all'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
@@ -531,6 +561,18 @@ function OneKeeperMemoryReal({
             </>`
           : html`<div class="mem-empty">압축(episode) 이력 없음.</div>`}
       </div>
+
+      ${showFallbackEpisodes && fallbackEpisodes.length
+        ? html`
+          <div class="turn-sec">
+            <h4>진단 fallback · librarian</h4>
+            <div class="mem-store">
+              ${fallbackEpisodes.map(ep => html`<${EpisodeRow} key=${ep.trace_id + ep.generation} episode=${ep} />`)}
+            </div>
+            <${DisclosureNote} text="unstructured fallback은 recall 후보가 아니라 librarian 진단 증거로 분리 표시." />
+          </div>
+        `
+        : null}
     </>`
 }
 

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -185,6 +185,7 @@ export function factTtlLabel(fact: MemoryOsFact): string {
 }
 
 const DEFAULT_FACT_ROW_LIMIT = 12
+const LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER = 'librarian_unstructured_fallback'
 type FactVisibilityFilter = 'recallable' | 'diagnostic' | 'all'
 
 export function sortMemoryFactsForReview(facts: readonly MemoryOsFact[]): MemoryOsFact[] {
@@ -452,10 +453,10 @@ function OneKeeperMemoryReal({
   const diagnosticFacts = facts.filter(isDiagnosticEvidenceFact)
   const allEpisodes = [...snapshot.episodes.items].reverse()
   const episodes = allEpisodes
-    .filter(ep => ep.terminal_marker !== 'librarian_unstructured_fallback')
+    .filter(ep => ep.terminal_marker !== LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER)
     .slice(0, 5)
   const fallbackEpisodes = allEpisodes
-    .filter(ep => ep.terminal_marker === 'librarian_unstructured_fallback')
+    .filter(ep => ep.terminal_marker === LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER)
     .slice(0, 5)
   // distinct categories present, in first-seen order, deduped by tag
   const seen = new Set<string>()

--- a/docs/runtime-tunables.md
+++ b/docs/runtime-tunables.md
@@ -14,9 +14,9 @@ the categorization roadmap. Newly-added typed getters in
 `lib/config/env_config_*.ml` must carry nearby `@category` and
 `@ops_class` tags; existing knobs remain in the backfill lane.
 
-**Total**: 364 unique knobs across 9 modules.
+**Total**: 369 unique knobs across 9 modules.
 
-**Typed getter classification**: 36/218 tagged (`operator`: 36, `algorithm`: 0, `unclassified`: 182).
+**Typed getter classification**: 41/223 tagged (`operator`: 41, `algorithm`: 0, `unclassified`: 182).
 
 ## Env_config_core (24 knobs; typed classification 1/8)
 
@@ -85,17 +85,17 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_RATE_LIMIT_ENTRY_MAX_AGE_SEC` | typed:float | unclassified | unclassified | 58 | Max age for rate limit entries before cleanup (seconds) |
 | `MASC_SPAWN_CACHE_POLICY` | typed:string | unclassified | unclassified | 44 | Spawn cache policy: - off - safe_only (GLM direct HTTP only, no MCP-tool side effects) |
 
-## Env_config_keeper (78 knobs; typed classification 15/66)
+## Env_config_keeper (83 knobs; typed classification 20/71)
 
 | Env var | Kind | Category | Ops class | Line | Doc |
 |---|---|---|---|---|---|
-| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 414 | Alert dedup window, clamped to >= 5s. Default: 60. |
-| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 738 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
-| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 773 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 774 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 775 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 776 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
-| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 779 |  |
+| `MASC_ALERT_DEDUP_WINDOW_SEC` | typed:float | unclassified | unclassified | 465 | Alert dedup window, clamped to >= 5s. Default: 60. |
+| `MASC_CONTEXT_RATIO_HARD_CAP` | typed:float | unclassified | unclassified | 789 | {1 Context Ratio Hard Cap} Absolute ceiling for compaction ratio_gate and handoff threshold after multiplier adjustme... |
+| `MASC_DASHBOARD_HEALTH_CTX_CRITICAL` | typed:float | unclassified | unclassified | 824 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_CTX_WARN` | typed:float | unclassified | unclassified | 825 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_CRITICAL` | typed:float | unclassified | unclassified | 826 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_HEALTH_PENALTY_WARN` | typed:float | unclassified | unclassified | 827 | {1 Dashboard Health Thresholds} Thresholds used by the dashboard keeper health scorer and harness health panels.  Dis... |
+| `MASC_DASHBOARD_RUNTIME_WARNING_CTX_RATIO` | typed:float | unclassified | unclassified | 830 |  |
 | `MASC_KEEPER_ALERT_BOARD_AUTHOR` | typed:string | unclassified | unclassified | 108 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_ENABLED` | feature_flag | n/a | n/a | 105 | Board fanout configuration |
 | `MASC_KEEPER_ALERT_BOARD_HEARTH` | typed:string | unclassified | unclassified | 111 |  |
@@ -113,8 +113,8 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_ALERT_SLACK_DM_USER_ID` | typed:string | unclassified | unclassified | 127 |  |
 | `MASC_KEEPER_ALERT_SLACK_ENABLED` | feature_flag | n/a | n/a | 118 | Slack fanout configuration |
 | `MASC_KEEPER_ALERT_SLACK_WEBHOOK_URL` | typed:string | unclassified | unclassified | 120 | Slack fanout configuration |
-| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 600 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
-| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 652 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
+| `MASC_KEEPER_ATTEMPT_WATCHDOG_SAFETY_CAP_SEC` | typed:float | unclassified | unclassified | 651 | Deprecated compatibility knob for the removed whole-run attempt watchdog. The keeper runtime must not apply this as a... |
+| `MASC_KEEPER_BODY_TIMEOUT_SEC` | string_literal | n/a | n/a | 703 | Total HTTP body-consumption deadline for non-streaming OAS completion calls. In agent_sdk this wraps [Complete.comple... |
 | `MASC_KEEPER_BOOTSTRAP_ENABLED` | feature_flag | n/a | n/a | 20 | Enable startup keeper bootstrap scan |
 | `MASC_KEEPER_BOOTSTRAP_LAZY_STARTUP_POLL_INTERVAL_SEC` | typed:float | unclassified | unclassified | 46 | Polling interval (seconds) for the lazy-startup wait loop in [server_bootstrap_loops.ml]. The autoboot fiber wakes up... |
 | `MASC_KEEPER_BOOTSTRAP_LISTENER_RETRY_INTERVAL_SEC` | typed:float | unclassified | unclassified | 58 | Polling interval (seconds) for the keeper-lifecycle listener retry loop in [server_bootstrap_loops.ml]. After a liste... |
@@ -122,22 +122,27 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_BOOTSTRAP_MAX_SCAN` | typed:int | unclassified | unclassified | 28 | Max keeper meta files to scan during bootstrap |
 | `MASC_KEEPER_BOOTSTRAP_POST_STARTUP_SETTLE_SEC` | typed:float | unclassified | unclassified | 70 | Settle delay (seconds) between lazy-startup completion and the keeper bootstrap fan-out. The autoboot fiber sleeps fo... |
 | `MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC` | typed:float | unclassified | unclassified | 24 | Keeper considered stale when last turn exceeds this threshold (seconds) |
-| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 672 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_CLI_SUBPROCESS_IDLE_SEC` | typed:float | Timeouts | operator | 723 | Stdout-idle timeout for CLI subprocess transports (Anthropic CLI today; other CLI providers need an OAS upstream chan... |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT` | typed:int | Runtime | operator | 345 | Default item limit for [GET /keepers/:name/compaction-snapshots]. Default: 25. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER` | typed:int | Runtime | operator | 371 | Multiplier from requested item limit to manifest files scanned. Default: 4. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES` | typed:int | Runtime | operator | 361 | Minimum manifest files scanned before applying [limit * multiplier]. Default: 8. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES` | typed:int | Runtime | operator | 381 | Tail line count read from each selected manifest file. Default: 200. @category Runtime @ops_class operator |
+| `MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT` | typed:int | Runtime | operator | 351 | Maximum accepted item limit for the compaction snapshot endpoint. Default: 100. @category Runtime @ops_class operator |
 | `MASC_KEEPER_CRASH_PERSIST_DRAIN_INTERVAL_SEC` | typed:float | unclassified | unclassified | 161 | Crash persistence drain fiber wake interval in seconds. Drain fiber batches in-memory crash events and persists them ... |
 | `MASC_KEEPER_DEBUG` | feature_flag | n/a | n/a | 169 | Enable keeper debug logging. Default: false. |
 | `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` | typed:float | unclassified | unclassified | 175 | Daily budget for keeper deliberation (USD). Default: 0.10. Re-readable within the process. Live operator control shou... |
-| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 633 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
-| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 692 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
-| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 700 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
-| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 419 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
-| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 493 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
-| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 682 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 467 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 727 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
-| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 474 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 508 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
-| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 515 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
-| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 434 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
+| `MASC_KEEPER_EXECUTION_IDLE_TIMEOUT_SEC` | typed:float | Timeouts | operator | 684 | OAS Agent.run inactivity deadline. This is progress-based rather than cumulative wall-clock: OAS resets the timer whe... |
+| `MASC_KEEPER_GRPC_MAX_RECONNECT` | typed:int | unclassified | unclassified | 743 | Maximum gRPC reconnect attempts before stopping the heartbeat fiber. Default: 5. Range: [1, 20]. |
+| `MASC_KEEPER_GRPC_RECONNECT_BACKOFF_SEC` | typed:float | unclassified | unclassified | 751 | Backoff delay between gRPC reconnect attempts in seconds. Default: 5.0. Range: [1.0, 60.0]. |
+| `MASC_KEEPER_HEARTBEAT_INTERVAL_SEC` | typed:int | unclassified | unclassified | 470 | Shared: keepalive interval, read early so WorkAsHeartbeat can reference it. |
+| `MASC_KEEPER_HEARTBEAT_JITTER_FACTOR` | typed:float | unclassified | unclassified | 544 | Jitter factor applied to heartbeat interval (fraction of base). Default: 0.2 (20%). Range: [0.0, 0.5]. |
+| `MASC_KEEPER_IDLE_SKIP_THRESHOLD` | typed:int | unclassified | unclassified | 733 | Consecutive idle tool repetitions before on_idle hook issues Skip. Below this: graduated Nudge messages. Optional too... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_HB_FAILURES` | typed:int | unclassified | unclassified | 518 | Maximum consecutive heartbeat failures before raising Keeper_fiber_crash (structured crash via dispatch_event). Defau... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TOOL_FAILURES` | typed:int | unclassified | unclassified | 778 | Maximum consecutive failures for the same (tool_name, args_hash) before blocking further attempts. Prevents infinite ... |
+| `MASC_KEEPER_MAX_CONSECUTIVE_TURN_FAILURES` | typed:int | unclassified | unclassified | 525 | Maximum consecutive unified turn failures before marking keeper as crashed. Covers LLM timeout, rate limit, and other... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS` | typed:int | unclassified | unclassified | 559 | Max idle turns for scheduled autonomous keeper turns. Keepers have workspace to explore multi-step tool sequences. 10... |
+| `MASC_KEEPER_MAX_IDLE_TURNS_REACTIVE` | typed:int | unclassified | unclassified | 566 | Max idle turns for reactive (board/mention triggered) keeper turns. Reactive turns have an explicit trigger — more ... |
+| `MASC_KEEPER_MAX_SILENCE_SEC` | typed:float | unclassified | unclassified | 485 | Maximum seconds since last successful workspace heartbeat before presence sync is required again. Floor = keepalive i... |
 | `MASC_KEEPER_MEMORY_OS_CONSOLIDATION` | typed:bool | Policies | operator | 319 | Per-keeper Memory OS consolidation maintenance fiber kill switch. Default: false; invalid values fail closed to false... |
 | `MASC_KEEPER_MEMORY_OS_CONSOLIDATION_RUNTIME_ID` | typed:string | Runtime | operator | 329 | Optional runtime id override for Memory OS consolidation. @category Runtime @ops_class operator |
 | `MASC_KEEPER_MEMORY_OS_GC` | typed:bool | Storage | operator | 308 | Per-keeper Memory OS GC maintenance fiber kill switch. Default: false; invalid values fail closed to false. @category... |
@@ -150,23 +155,23 @@ the categorization roadmap. Newly-added typed getters in
 | `MASC_KEEPER_MEMORY_OS_RECALL` | typed:bool | Policies | operator | 229 | Memory OS recall prompt injection kill switch. Default: true; invalid values fail closed to false so malformed operat... |
 | `MASC_KEEPER_METRICS_MAX_BYTES` | typed:int | unclassified | unclassified | 78 | Maximum metrics file size in bytes before rotation (default: 10MB) |
 | `MASC_KEEPER_METRICS_MAX_ROTATED` | typed:int | unclassified | unclassified | 81 | Number of rotated files to keep (default: 1, i.e. .1 only) |
-| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 561 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
-| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 710 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
-| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 397 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
-| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 406 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
-| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 485 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
-| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 444 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
+| `MASC_KEEPER_OAS_TIMEOUT_SEC` | string_literal | n/a | n/a | 612 | Per-call OAS timeout override in seconds. Legacy/env override value is clamped to the active keepalive retry/admissio... |
+| `MASC_KEEPER_PROACTIVE_MAX_ATTEMPTS` | typed:int | unclassified | unclassified | 761 | Maximum proactive generation attempts before falling back. Default: 3. Range: [1, 10]. |
+| `MASC_KEEPER_REDUCER_CAP_TOKENS` | typed:int | unclassified | unclassified | 448 | Max message tokens retained by {!Agent_sdk.Context_reducer.cap_message_tokens} in the keeper run reducer pipeline.  D... |
+| `MASC_KEEPER_REDUCER_KEEP_RECENT` | typed:int | unclassified | unclassified | 457 | Recent messages kept verbatim by {!Agent_sdk.Context_reducer.cap_message_tokens}.  Default: 3. Range: [1, 20]. Env: [... |
+| `MASC_KEEPER_SLEEP_CHUNK_SEC` | typed:float | unclassified | unclassified | 536 | Interruptible sleep chunk size in seconds. Smaller = faster wakeup response but more CPU polling. Default: 2.0. Range... |
+| `MASC_KEEPER_SMART_HEARTBEAT` | feature_flag | n/a | n/a | 495 | Master switch for adaptive heartbeat scheduling in the keepalive loop. When true, Keeper_heartbeat_smart.should_emit ... |
 | `MASC_KEEPER_SNAPSHOT_SEC` | typed:int | unclassified | unclassified | 179 | Keeper keepalive snapshot interval, clamped to [15, 3600]. Default: 300. |
-| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 716 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
-| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 609 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
-| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 547 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
-| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 451 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 367 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
-| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 377 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
-| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 357 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
-| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 428 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
-| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 797 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
-| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 811 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
+| `MASC_KEEPER_STAGE_TIMING_RING_SIZE` | typed:int | unclassified | unclassified | 767 | Stage timing ring buffer size for Phase 0 profiling. Default: 100. Range: [10, 1000]. |
+| `MASC_KEEPER_STREAM_IDLE_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 660 | Idle-gap timeout for streaming OAS provider responses. This bounds time between streamed lines, not total turn durati... |
+| `MASC_KEEPER_TURN_TIMEOUT_SEC` | typed:float | unclassified | unclassified | 598 | Retry/admission budget in seconds for a single unified turn (including all retries and runtime fallbacks). This value... |
+| `MASC_KEEPER_VISIBILITY_GATE` | feature_flag | n/a | n/a | 502 | Consumer-driven idle backoff: when true, keepers with no dashboard/SSE observer and no pending signal delay proactive... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_BASE_SEC` | typed:float | Timeouts | operator | 418 | Base delay before trying the next vision runtime after a failed provider attempt. A small default avoids tight failov... |
+| `MASC_KEEPER_VISION_CANDIDATE_BACKOFF_MAX_SEC` | typed:float | Timeouts | operator | 428 | Upper bound for the per-candidate vision failover delay. Range: [base, 30] seconds, so a typo cannot exceed the tool'... |
+| `MASC_KEEPER_VISION_MAX_IMAGE_BYTES` | typed:int | Policies | operator | 408 | Maximum raw image bytes accepted by the one-shot vision tool before provider-message construction. Default is 5 MiB t... |
+| `MASC_KEEPER_WORK_AS_HEARTBEAT` | feature_flag | n/a | n/a | 479 | Master switch. When true, successful Workspace.heartbeat after a unified turn counts as presence proof, allowing the ... |
+| `MASC_PAYLOAD_TELEMETRY` | typed:bool | unclassified | unclassified | 848 | Master switch for wake-payload measurement. Default off so the hot path is untouched until a baseline sweep is explic... |
+| `MASC_RUNTIME_SATURATION_SIGNAL_ENABLED` | typed:bool | unclassified | unclassified | 862 | {1 Runtime Saturation Signal (RFC-0153 Phase A.2)} Feature flag for typed [Runtime_saturation_signal.t] emission from... |
 
 ## Env_config_keeper_retry_backoff (4 knobs; typed classification 1/4)
 

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -331,6 +331,57 @@ module KeeperMemoryOs = struct
   ;;
 end
 
+(** {1 Keeper dashboard compaction snapshots}
+
+    Read-side bounds for the dashboard compaction snapshot inspector. These
+    limits only cap filesystem hydration work and response size; they do not
+    alter keeper compaction policy or reducer semantics.
+
+    @category Runtime @ops_class operator *)
+module KeeperCompactionSnapshots = struct
+  (** Default item limit for [GET /keepers/:name/compaction-snapshots].
+      Default: 25. @category Runtime @ops_class operator *)
+  let default_limit =
+    max 1 (get_int_nonneg ~default:25 "MASC_KEEPER_COMPACTION_SNAPSHOT_DEFAULT_LIMIT")
+  ;;
+
+  (** Maximum accepted item limit for the compaction snapshot endpoint.
+      Default: 100. @category Runtime @ops_class operator *)
+  let max_limit =
+    max 1 (get_int_nonneg ~default:100 "MASC_KEEPER_COMPACTION_SNAPSHOT_MAX_LIMIT")
+  ;;
+
+  (** Minimum manifest files scanned before applying [limit * multiplier].
+      Default: 8. @category Runtime @ops_class operator *)
+  let manifest_scan_min_files =
+    max
+      1
+      (get_int_nonneg
+         ~default:8
+         "MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_MIN_FILES")
+  ;;
+
+  (** Multiplier from requested item limit to manifest files scanned.
+      Default: 4. @category Runtime @ops_class operator *)
+  let manifest_scan_limit_multiplier =
+    max
+      1
+      (get_int_nonneg
+         ~default:4
+         "MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_SCAN_LIMIT_MULTIPLIER")
+  ;;
+
+  (** Tail line count read from each selected manifest file. Default: 200.
+      @category Runtime @ops_class operator *)
+  let manifest_tail_max_lines =
+    max
+      1
+      (get_int_nonneg
+         ~default:200
+         "MASC_KEEPER_COMPACTION_SNAPSHOT_MANIFEST_TAIL_MAX_LINES")
+  ;;
+end
+
 (** {1 Keeper Vision Tool Configuration} *)
 
 module KeeperVision = struct

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -106,6 +106,16 @@ module KeeperMemoryOs : sig
   val consolidation_runtime_id : unit -> string option
 end
 
+(** {1 Keeper dashboard compaction snapshots} *)
+
+module KeeperCompactionSnapshots : sig
+  val default_limit : int
+  val max_limit : int
+  val manifest_scan_min_files : int
+  val manifest_scan_limit_multiplier : int
+  val manifest_tail_max_lines : int
+end
+
 (** {1 Keeper vision tool} *)
 
 module KeeperVision : sig

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -439,7 +439,8 @@ let unstructured_episode ~now ~generation (inp : Keeper_librarian.input) ~reason
       Keeper_memory_os_types.category_valid_until
         ~now
         Keeper_memory_os_types.Ephemeral
-  ; terminal_marker = Some "librarian_unstructured_fallback"
+  ; terminal_marker =
+      Some Keeper_memory_os_types.librarian_unstructured_fallback_terminal_marker
   ; schema_version = Keeper_memory_os_types.schema_version
   }
 

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -228,6 +228,10 @@ let librarian_unstructured_fallback_claim_prefix =
   "unstructured_note: librarian parse fallback"
 ;;
 
+let librarian_unstructured_fallback_terminal_marker =
+  "librarian_unstructured_fallback"
+;;
+
 let legacy_unstructured_fallback_claim (claim : string) =
   String.starts_with ~prefix:librarian_unstructured_fallback_claim_prefix claim
 ;;

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -174,6 +174,10 @@ val fact_is_current : now:float -> fact -> bool
     Kept as the SSOT for the producer and the legacy recall-eligibility shim. *)
 val librarian_unstructured_fallback_claim_prefix : string
 
+(** Terminal marker used on episodes that preserve unstructured librarian output
+    after strict JSON parsing fails. *)
+val librarian_unstructured_fallback_terminal_marker : string
+
 (** Structural prompt-recall eligibility. Callers still apply {!fact_is_current}
     for the time horizon; [Diagnostic] rows stay operator evidence, not prompt
     context. Legacy pre-[Diagnostic] librarian fallback rows are also excluded by

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -66,8 +66,19 @@ module StringSet = Set_util.StringSet
 let schema_version = 1
 let manifest_file_suffix = ".jsonl"
 
+type status =
+  | Skipped
+  | Other of string
+
+let status_of_string = function
+  | "skipped" -> Skipped
+  | value -> Other value
+;;
+
 let status_is_skipped manifest =
-  String.equal manifest.status "skipped"
+  match status_of_string manifest.status with
+  | Skipped -> true
+  | Other _ -> false
 ;;
 
 let safe_segment value =

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -64,6 +64,11 @@ type logical_ordering = {
 module StringSet = Set_util.StringSet
 
 let schema_version = 1
+let manifest_file_suffix = ".jsonl"
+
+let status_is_skipped manifest =
+  String.equal manifest.status "skipped"
+;;
 
 let safe_segment value =
   let buf = Buffer.create (String.length value) in
@@ -626,7 +631,7 @@ let base_dir config ~keeper_name =
 
 let path_for_trace config ~keeper_name ~trace_id =
   Filename.concat (base_dir config ~keeper_name)
-    (safe_segment trace_id ^ ".jsonl")
+    (safe_segment trace_id ^ manifest_file_suffix)
 
 include Keeper_runtime_manifest_housekeeping
 
@@ -651,7 +656,8 @@ let append config manifest =
   let base_dir = base_dir config ~keeper_name:manifest.keeper_name in
   match
     append_to_path
-      (Filename.concat base_dir (safe_segment manifest.trace_id ^ ".jsonl"))
+      (Filename.concat base_dir
+         (safe_segment manifest.trace_id ^ manifest_file_suffix))
       manifest
   with
   | Ok () ->

--- a/lib/keeper/keeper_runtime_manifest.ml
+++ b/lib/keeper/keeper_runtime_manifest.ml
@@ -70,9 +70,15 @@ type status =
   | Skipped
   | Other of string
 
-let status_of_string = function
-  | "skipped" -> Skipped
-  | value -> Other value
+let skipped_status = "skipped"
+
+let status_of_string value =
+  if String.equal value skipped_status then Skipped else Other value
+;;
+
+let status_to_string = function
+  | Skipped -> skipped_status
+  | Other value -> value
 ;;
 
 let status_is_skipped manifest =

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -87,6 +87,7 @@ val manifest_file_suffix : string
 val safe_segment : string -> string
 
 val status_of_string : string -> status
+val status_to_string : status -> string
 val status_is_skipped : t -> bool
 
 val clock_refs :

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -79,7 +79,10 @@ val source_clock_of_string : string -> source_clock option
 val source_clock_of_event : event_kind -> source_clock
 
 val schema_version : int
+val manifest_file_suffix : string
 val safe_segment : string -> string
+
+val status_is_skipped : t -> bool
 
 val clock_refs :
   ?edge_id:string ->

--- a/lib/keeper/keeper_runtime_manifest.mli
+++ b/lib/keeper/keeper_runtime_manifest.mli
@@ -69,6 +69,10 @@ type logical_ordering = {
   logical_seq : int option;
 }
 
+type status =
+  | Skipped
+  | Other of string
+
 (** {1 Own-module vals} *)
 
 val payload_role_to_string : payload_role -> string
@@ -82,6 +86,7 @@ val schema_version : int
 val manifest_file_suffix : string
 val safe_segment : string -> string
 
+val status_of_string : string -> status
 val status_is_skipped : t -> bool
 
 val clock_refs :

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -10,11 +10,27 @@ let freshness_slo_s = Server_dashboard_http_core_cache.freshness_slo_s
 
 let keeper_hot_path_cache_ttl_s = 30.0
 let keeper_composite_cache_ttl_s = 5.0
-let compaction_snapshot_default_limit = 25
-let compaction_snapshot_max_limit = 100
-let compaction_snapshot_manifest_scan_min_files = 8
-let compaction_snapshot_manifest_scan_limit_multiplier = 4
-let compaction_snapshot_manifest_tail_max_lines = 200
+
+(* Bounded dashboard hydration defaults for the operator compaction inspector.
+   These cap best-effort filesystem scans; [scan_truncated] in the response makes
+   the bound observable when there are more manifest files/rows than scanned. *)
+let compaction_snapshot_default_limit =
+  Env_config.KeeperCompactionSnapshots.default_limit
+;;
+
+let compaction_snapshot_max_limit = Env_config.KeeperCompactionSnapshots.max_limit
+
+let compaction_snapshot_manifest_scan_min_files =
+  Env_config.KeeperCompactionSnapshots.manifest_scan_min_files
+;;
+
+let compaction_snapshot_manifest_scan_limit_multiplier =
+  Env_config.KeeperCompactionSnapshots.manifest_scan_limit_multiplier
+;;
+
+let compaction_snapshot_manifest_tail_max_lines =
+  Env_config.KeeperCompactionSnapshots.manifest_tail_max_lines
+;;
 
 (* Maximum number of trajectory/trace entries returned per query. *)
 let trajectory_max_limit = 500
@@ -275,7 +291,31 @@ let compaction_snapshot_unix_error_message err fn arg =
   Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err)
 ;;
 
-let safe_regular_mtime path =
+let compaction_snapshot_scope_path ~base_dir path =
+  let base_prefix =
+    if String.ends_with ~suffix:Filename.dir_sep base_dir
+    then base_dir
+    else base_dir ^ Filename.dir_sep
+  in
+  if String.equal path base_dir
+  then "."
+  else if String.starts_with ~prefix:base_prefix path
+  then
+    String.sub path (String.length base_prefix) (String.length path - String.length base_prefix)
+  else Filename.basename path
+;;
+
+let runtime_manifest_file_scope ~base_dir path =
+  "runtime_manifest_file:" ^ compaction_snapshot_scope_path ~base_dir path
+;;
+
+let runtime_manifest_row_scope ~base_dir path line_no =
+  Printf.sprintf "runtime_manifest_row:%s:%d"
+    (compaction_snapshot_scope_path ~base_dir path)
+    line_no
+;;
+
+let safe_regular_mtime ~base_dir path =
   try
     let st = Unix.stat path in
     if st.Unix.st_kind = Unix.S_REG
@@ -287,13 +327,13 @@ let safe_regular_mtime path =
   | Unix.Unix_error (err, fn, arg) ->
     ( None
     , [ compaction_snapshot_read_error
-          ~scope:("runtime_manifest_file:" ^ path)
+          ~scope:(runtime_manifest_file_scope ~base_dir path)
           ~error:(compaction_snapshot_unix_error_message err fn arg)
       ] )
   | exn ->
     ( None
     , [ compaction_snapshot_read_error
-          ~scope:("runtime_manifest_file:" ^ path)
+          ~scope:(runtime_manifest_file_scope ~base_dir path)
           ~error:(Printexc.to_string exn)
       ] )
 ;;
@@ -310,9 +350,10 @@ let runtime_manifest_paths ~config ~keeper_id ~limit =
     then
       ( []
       , [ compaction_snapshot_read_error
-            ~scope:("runtime_manifest_dir:" ^ dir)
+            ~scope:("runtime_manifest_dir:" ^ keeper_id)
             ~error:"path is not a directory"
-        ] )
+        ]
+      , false )
     else
       let entries, read_errors =
         Sys.readdir dir
@@ -323,7 +364,7 @@ let runtime_manifest_paths ~config ~keeper_id ~limit =
         |> List.fold_left
              (fun (entries, read_errors) file ->
         let path = Filename.concat dir file in
-        let mtime, errors = safe_regular_mtime path in
+        let mtime, errors = safe_regular_mtime ~base_dir:dir path in
         let entries =
           match mtime with
           | Some mtime -> (path, mtime) :: entries
@@ -332,29 +373,31 @@ let runtime_manifest_paths ~config ~keeper_id ~limit =
         entries, List.rev_append errors read_errors)
              ([], [])
       in
-      (entries
-      |> List.sort (fun (_, a) (_, b) -> Float.compare b a)
-      |> compaction_snapshot_take scan_limit
-      |> List.map fst
-      , List.rev read_errors)
+      let sorted_entries = List.sort (fun (_, a) (_, b) -> Float.compare b a) entries in
+      let scan_truncated = List.length sorted_entries > scan_limit in
+      ( sorted_entries |> compaction_snapshot_take scan_limit |> List.map fst
+      , List.rev read_errors
+      , scan_truncated )
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | Unix.Unix_error (Unix.ENOENT, _, _) -> [], []
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> [], [], false
   | Unix.Unix_error (err, fn, arg) ->
     ( []
     , [ compaction_snapshot_read_error
-          ~scope:("runtime_manifest_dir:" ^ dir)
+          ~scope:("runtime_manifest_dir:" ^ keeper_id)
           ~error:(compaction_snapshot_unix_error_message err fn arg)
-      ] )
+      ]
+    , false )
   | exn ->
     ( []
     , [ compaction_snapshot_read_error
-          ~scope:("runtime_manifest_dir:" ^ dir)
+          ~scope:("runtime_manifest_dir:" ^ keeper_id)
           ~error:(Printexc.to_string exn)
-      ] )
+      ]
+    , false )
 ;;
 
-let read_runtime_manifest_tail_rows path =
+let read_runtime_manifest_tail_rows ~base_dir path =
   try
     Dated_jsonl.load_tail_lines path
       ~max_lines:compaction_snapshot_manifest_tail_max_lines
@@ -368,7 +411,7 @@ let read_runtime_manifest_tail_rows path =
             | Error msg ->
               loop (line_no + 1) rows
                 (compaction_snapshot_read_error
-                   ~scope:(Printf.sprintf "runtime_manifest_row:%s:%d" path line_no)
+                   ~scope:(runtime_manifest_row_scope ~base_dir path line_no)
                    ~error:msg
                  :: read_errors)
                 rest
@@ -376,20 +419,22 @@ let read_runtime_manifest_tail_rows path =
           | Yojson.Json_error msg | Yojson.Safe.Util.Type_error (msg, _) ->
             loop (line_no + 1) rows
               (compaction_snapshot_read_error
-                 ~scope:(Printf.sprintf "runtime_manifest_row:%s:%d" path line_no)
+                 ~scope:(runtime_manifest_row_scope ~base_dir path line_no)
                  ~error:msg
                :: read_errors)
               rest
     in
-    loop 1 [] [] lines
+    let rows, read_errors = loop 1 [] [] lines in
+    rows, read_errors, List.length lines >= compaction_snapshot_manifest_tail_max_lines
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
     ( []
     , [ compaction_snapshot_read_error
-          ~scope:("runtime_manifest_file:" ^ path)
+          ~scope:(runtime_manifest_file_scope ~base_dir path)
           ~error:(Printexc.to_string exn)
-      ] )
+      ]
+    , false )
 ;;
 
 let compaction_snapshot_clock_refs decision =
@@ -410,6 +455,15 @@ let compaction_snapshot_links_json (links : Keeper_runtime_manifest.links) =
     ; "checkpoint_path", Json_util.string_opt_to_json links.checkpoint_path
     ; "tool_call_log_path", Json_util.string_opt_to_json links.tool_call_log_path
     ]
+;;
+
+let compaction_snapshot_display_runtime ~source ~runtime_id ~compaction_source =
+  match runtime_id with
+  | Some value when String.trim value <> "" -> value
+  | Some _ | None ->
+    (match compaction_source with
+     | Some value when String.trim value <> "" -> value
+     | Some _ | None -> source)
 ;;
 
 let compaction_snapshot_item_json
@@ -440,6 +494,9 @@ let compaction_snapshot_item_json
     ; "source", `String source
     ; "trigger", `String trigger
     ; "runtime_id", Json_util.string_opt_to_json runtime_id
+    ; ( "display_runtime"
+      , `String (compaction_snapshot_display_runtime ~source ~runtime_id ~compaction_source)
+      )
     ; "before_tokens", Json_util.int_opt_to_json before_tokens
     ; "after_tokens", Json_util.int_opt_to_json after_tokens
     ; "saved_tokens", Json_util.int_opt_to_json saved_tokens
@@ -552,13 +609,8 @@ let compaction_snapshot_of_manifest_row ~keeper_id (row : Keeper_runtime_manifes
   | _ -> None
 ;;
 
-let compaction_snapshot_sort_value = function
-  | `Assoc fields ->
-    (match List.assoc_opt "ts_unix" fields with
-     | Some (`Float ts) -> ts
-     | Some (`Int ts) -> float_of_int ts
-     | _ -> 0.0)
-  | _ -> 0.0
+let compaction_snapshot_manifest_sort_value (row : Keeper_runtime_manifest.t) =
+  Option.value ~default:0.0 (Masc_domain.parse_iso8601_opt row.ts)
 ;;
 
 let keeper_meta_compaction_snapshot_json ~config ~keeper_id =
@@ -602,19 +654,31 @@ let keeper_meta_compaction_snapshot_json ~config ~keeper_id =
 
 let compaction_snapshots_json ~config ~keeper_id ~limit =
   let limit = limit |> max 1 |> min compaction_snapshot_max_limit in
-  let manifest_paths, path_read_errors =
+  let manifest_base_dir =
+    Keeper_runtime_manifest.base_dir config ~keeper_name:keeper_id
+  in
+  let manifest_paths, path_read_errors, path_scan_truncated =
     runtime_manifest_paths ~config ~keeper_id ~limit
   in
-  let rows_and_errors = List.map read_runtime_manifest_tail_rows manifest_paths in
-  let manifest_rows = List.concat_map fst rows_and_errors in
-  let manifest_read_errors =
-    path_read_errors @ List.concat_map snd rows_and_errors
+  let rows_and_errors =
+    List.map (read_runtime_manifest_tail_rows ~base_dir:manifest_base_dir) manifest_paths
   in
+  let manifest_rows = List.map (fun (rows, _, _) -> rows) rows_and_errors |> List.concat in
+  let manifest_read_errors =
+    path_read_errors
+    @ (List.map (fun (_, read_errors, _) -> read_errors) rows_and_errors |> List.concat)
+  in
+  let tail_scan_truncated =
+    List.exists (fun (_, _, scan_truncated) -> scan_truncated) rows_and_errors
+  in
+  let scan_truncated = path_scan_truncated || tail_scan_truncated in
   let manifest_items =
     manifest_rows
-    |> List.filter_map (compaction_snapshot_of_manifest_row ~keeper_id)
     |> List.sort (fun a b ->
-      Float.compare (compaction_snapshot_sort_value b) (compaction_snapshot_sort_value a))
+      Float.compare
+        (compaction_snapshot_manifest_sort_value b)
+        (compaction_snapshot_manifest_sort_value a))
+    |> List.filter_map (compaction_snapshot_of_manifest_row ~keeper_id)
     |> compaction_snapshot_take limit
   in
   let items, read_errors =
@@ -638,6 +702,7 @@ let compaction_snapshots_json ~config ~keeper_id ~limit =
     ; "count", `Int (List.length items)
     ; "read_error_count", `Int (List.length read_errors)
     ; "read_errors", compaction_snapshot_read_errors_json read_errors
+    ; "scan_truncated", `Bool scan_truncated
     ; "items", `List items
     ]
 ;;

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -619,7 +619,12 @@ let compaction_snapshot_of_manifest_row ~keeper_id (row : Keeper_runtime_manifes
 ;;
 
 let compaction_snapshot_manifest_sort_value (row : Keeper_runtime_manifest.t) =
-  Option.value ~default:0.0 (Masc_domain.parse_iso8601_opt row.ts)
+  match Masc_domain.parse_iso8601_opt row.ts with
+  | Some ts -> ts
+  (* DET-OK: dashboard projection only. A malformed manifest timestamp is not
+     used for keeper policy; sorting it last keeps the response deterministic
+     while the row-level read_errors surface malformed JSON/shape issues. *)
+  | None -> 0.0
 ;;
 
 let keeper_meta_compaction_snapshot_json ~config ~keeper_id =

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -10,6 +10,8 @@ let freshness_slo_s = Server_dashboard_http_core_cache.freshness_slo_s
 
 let keeper_hot_path_cache_ttl_s = 30.0
 let keeper_composite_cache_ttl_s = 5.0
+let compaction_snapshot_default_limit = 25
+let compaction_snapshot_max_limit = 100
 
 (* Maximum number of trajectory/trace entries returned per query. *)
 let trajectory_max_limit = 500
@@ -230,6 +232,290 @@ let memory_os_dashboard_json ~keeper_id =
                truncated tail is visible, not silent. *)
           ; "items", `List (List.map (memory_os_fact_json ~now) facts)
           ] )
+    ]
+;;
+
+let compaction_snapshot_take n xs =
+  let rec loop remaining acc = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | x :: rest -> loop (remaining - 1) (x :: acc) rest
+  in
+  loop n [] xs
+;;
+
+let safe_regular_mtime path =
+  try
+    let st = Unix.stat path in
+    if st.Unix.st_kind = Unix.S_REG then Some st.Unix.st_mtime else None
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | _ -> None
+;;
+
+let runtime_manifest_paths ~config ~keeper_id ~limit =
+  let dir = Keeper_runtime_manifest.base_dir config ~keeper_name:keeper_id in
+  try
+    let st = Unix.stat dir in
+    if st.Unix.st_kind <> Unix.S_DIR
+    then []
+    else
+      Sys.readdir dir
+      |> Array.to_list
+      |> List.filter (String.ends_with ~suffix:".jsonl")
+      |> List.filter_map (fun file ->
+        let path = Filename.concat dir file in
+        Option.map (fun mtime -> path, mtime) (safe_regular_mtime path))
+      |> List.sort (fun (_, a) (_, b) -> Float.compare b a)
+      |> compaction_snapshot_take (max 8 (limit * 4))
+      |> List.map fst
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | _ -> []
+;;
+
+let read_runtime_manifest_tail_rows path =
+  try
+    Dated_jsonl.load_tail_lines path ~max_lines:200
+    |> List.filter_map (fun line ->
+      try
+        match Yojson.Safe.from_string line |> Keeper_runtime_manifest.of_json with
+        | Ok row -> Some row
+        | Error _ -> None
+      with
+      | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | _ -> []
+;;
+
+let compaction_snapshot_clock_refs decision =
+  match Json_util.assoc_member_opt "clock_refs" decision with
+  | Some (`Assoc _ as clock_refs) -> Some clock_refs
+  | _ -> None
+;;
+
+let compaction_snapshot_clock_string decision key =
+  match compaction_snapshot_clock_refs decision with
+  | Some clock_refs -> Json_util.assoc_string_opt key clock_refs
+  | None -> None
+;;
+
+let compaction_snapshot_links_json (links : Keeper_runtime_manifest.links) =
+  `Assoc
+    [ "receipt_path", Json_util.string_opt_to_json links.receipt_path
+    ; "checkpoint_path", Json_util.string_opt_to_json links.checkpoint_path
+    ; "tool_call_log_path", Json_util.string_opt_to_json links.tool_call_log_path
+    ]
+;;
+
+let compaction_snapshot_item_json
+      ~id
+      ~keeper_id
+      ~ts_iso
+      ~ts_unix
+      ~trace_id
+      ~keeper_turn_id
+      ~source
+      ~trigger
+      ~runtime_id
+      ~before_tokens
+      ~after_tokens
+      ~saved_tokens
+      ~compaction_id
+      ~compaction_source
+      ~status
+      ~links
+  =
+  `Assoc
+    [ "id", `String id
+    ; "keeper", `String keeper_id
+    ; "ts_iso", `String ts_iso
+    ; "ts_unix", Json_util.float_opt_to_json ts_unix
+    ; "trace_id", Json_util.string_opt_to_json trace_id
+    ; "keeper_turn_id", Json_util.int_opt_to_json keeper_turn_id
+    ; "source", `String source
+    ; "trigger", `String trigger
+    ; "runtime_id", Json_util.string_opt_to_json runtime_id
+    ; "before_tokens", Json_util.int_opt_to_json before_tokens
+    ; "after_tokens", Json_util.int_opt_to_json after_tokens
+    ; "saved_tokens", Json_util.int_opt_to_json saved_tokens
+    ; "compaction_id", Json_util.string_opt_to_json compaction_id
+    ; "compaction_source", Json_util.string_opt_to_json compaction_source
+    ; "status", `String status
+    ; "links", links
+    ]
+;;
+
+let compaction_saved_tokens before_tokens after_tokens =
+  match before_tokens, after_tokens with
+  | Some before_tokens, Some after_tokens -> Some (max 0 (before_tokens - after_tokens))
+  | _ -> None
+;;
+
+let compaction_event_bus_snapshot_json ~keeper_id (row : Keeper_runtime_manifest.t) =
+  match Json_util.assoc_member_opt "last_compaction" row.decision with
+  | Some (`Assoc _ as compaction) ->
+    let before_tokens = Json_util.get_int compaction "before_tokens" in
+    let after_tokens = Json_util.get_int compaction "after_tokens" in
+    let saved_tokens =
+      match Json_util.get_int compaction "tokens_freed" with
+      | Some tokens -> Some tokens
+      | None -> compaction_saved_tokens before_tokens after_tokens
+    in
+    let trigger =
+      Json_util.get_string compaction "phase_hint"
+      (* DET-OK: manifest projection fallback only; a missing phase hint maps to
+         a stable UI label and does not drive keeper policy. *)
+      |> Option.value ~default:"event_bus_context_compacted"
+    in
+    Some
+      (compaction_snapshot_item_json
+         ~id:
+           (Printf.sprintf "manifest:%s:%s:%s" row.trace_id
+              (Keeper_runtime_manifest.event_kind_to_string row.event)
+              row.ts)
+         ~keeper_id
+         ~ts_iso:row.ts
+         ~ts_unix:(Masc_domain.parse_iso8601_opt row.ts)
+         ~trace_id:(Some row.trace_id)
+         ~keeper_turn_id:row.keeper_turn_id
+         ~source:"runtime_manifest"
+         ~trigger
+         ~runtime_id:row.runtime_id
+         ~before_tokens
+         ~after_tokens
+         ~saved_tokens
+         ~compaction_id:(compaction_snapshot_clock_string row.decision "compaction_id")
+         ~compaction_source:(compaction_snapshot_clock_string row.decision "compaction_source")
+         ~status:row.status
+         ~links:(compaction_snapshot_links_json row.links))
+  | _ -> None
+;;
+
+let compaction_context_snapshot_json ~keeper_id (row : Keeper_runtime_manifest.t) =
+  (* TEL-OK: read-only dashboard projection; compaction telemetry is emitted by
+     the keeper runtime/event bridge that produced the manifest row. *)
+  let pre_dispatch_compacted =
+    Json_util.get_bool row.decision "pre_dispatch_compacted" = Some true
+  in
+  if (not pre_dispatch_compacted) && String.equal row.status "skipped"
+  then None
+  else
+    let before_tokens =
+      match Json_util.get_int row.decision "before_tokens" with
+      | Some tokens -> Some tokens
+      | None -> Json_util.get_int row.decision "pre_dispatch_compaction_before_tokens"
+    in
+    let after_tokens =
+      match Json_util.get_int row.decision "after_tokens" with
+      | Some tokens -> Some tokens
+      | None -> Json_util.get_int row.decision "pre_dispatch_compaction_after_tokens"
+    in
+    let compaction_source =
+      compaction_snapshot_clock_string row.decision "compaction_source"
+    in
+    Some
+      (compaction_snapshot_item_json
+         ~id:
+           (Printf.sprintf "manifest:%s:%s:%s" row.trace_id
+              (Keeper_runtime_manifest.event_kind_to_string row.event)
+              row.ts)
+         ~keeper_id
+         ~ts_iso:row.ts
+         ~ts_unix:(Masc_domain.parse_iso8601_opt row.ts)
+         ~trace_id:(Some row.trace_id)
+         ~keeper_turn_id:row.keeper_turn_id
+         ~source:"runtime_manifest"
+         (* DET-OK: manifest projection fallback only; a missing source maps to
+            a stable UI label and does not drive keeper policy. *)
+         ~trigger:(Option.value ~default:"pre_dispatch_hygiene" compaction_source)
+         ~runtime_id:row.runtime_id
+         ~before_tokens
+         ~after_tokens
+         ~saved_tokens:(compaction_saved_tokens before_tokens after_tokens)
+         ~compaction_id:(compaction_snapshot_clock_string row.decision "compaction_id")
+         ~compaction_source
+         ~status:row.status
+         ~links:(compaction_snapshot_links_json row.links))
+;;
+
+let compaction_snapshot_of_manifest_row ~keeper_id (row : Keeper_runtime_manifest.t) =
+  match row.event with
+  | Keeper_runtime_manifest.Event_bus_correlated ->
+    compaction_event_bus_snapshot_json ~keeper_id row
+  | Keeper_runtime_manifest.Context_compacted ->
+    compaction_context_snapshot_json ~keeper_id row
+  | _ -> None
+;;
+
+let compaction_snapshot_sort_value = function
+  | `Assoc fields ->
+    (match List.assoc_opt "ts_unix" fields with
+     | Some (`Float ts) -> ts
+     | Some (`Int ts) -> float_of_int ts
+     | _ -> 0.0)
+  | _ -> 0.0
+;;
+
+let keeper_meta_compaction_snapshot_json ~config ~keeper_id =
+  match Keeper_meta_store.read_meta config keeper_id with
+  | Ok (Some meta) ->
+    let rt = meta.runtime.compaction_rt in
+    if rt.count <= 0 || rt.last_ts <= 0.0
+    then None
+    else
+      let before_tokens = Some rt.last_before_tokens in
+      let after_tokens = Some rt.last_after_tokens in
+      Some
+        (compaction_snapshot_item_json
+           ~id:"keeper_meta:last_compaction"
+           ~keeper_id
+           ~ts_iso:(Masc_domain.iso8601_of_unix_seconds rt.last_ts)
+           ~ts_unix:(Some rt.last_ts)
+           ~trace_id:None
+           ~keeper_turn_id:None
+           ~source:"keeper_meta"
+           ~trigger:
+             (Keeper_meta_contract.compaction_runtime_decision_to_string
+                rt.last_decision)
+           ~runtime_id:None
+           ~before_tokens
+           ~after_tokens
+           ~saved_tokens:(compaction_saved_tokens before_tokens after_tokens)
+           ~compaction_id:None
+           ~compaction_source:None
+           ~status:"latest"
+           ~links:(`Assoc []))
+  | Ok None | Error _ -> None
+;;
+
+let compaction_snapshots_json ~config ~keeper_id ~limit =
+  let limit = limit |> max 1 |> min compaction_snapshot_max_limit in
+  let manifest_items =
+    runtime_manifest_paths ~config ~keeper_id ~limit
+    |> List.concat_map read_runtime_manifest_tail_rows
+    |> List.filter_map (compaction_snapshot_of_manifest_row ~keeper_id)
+    |> List.sort (fun a b ->
+      Float.compare (compaction_snapshot_sort_value b) (compaction_snapshot_sort_value a))
+    |> compaction_snapshot_take limit
+  in
+  let items =
+    match manifest_items with
+    | [] ->
+      (match keeper_meta_compaction_snapshot_json ~config ~keeper_id with
+       | Some item -> [ item ]
+       | None -> [])
+    | _ -> manifest_items
+  in
+  `Assoc
+    [ "schema", `String "keeper.compaction_snapshots.v1"
+    ; "keeper", `String keeper_id
+    ; "source", `String "runtime_manifest|keeper_meta"
+    ; "producer", `String "keeper_runtime_manifest|keeper_meta_store"
+    ; "limit", `Int limit
+    ; "count", `Int (List.length items)
+    ; "items", `List items
     ]
 ;;
 
@@ -773,6 +1059,24 @@ let handle_keeper_get_subroutes state req request reqd =
        | Error (`Io msg) ->
          Http.Response.json_value ~status:`Internal_server_error
            (`Assoc [ ("error", `String msg) ]) reqd)
+  else if ends_with "/compaction-snapshots" then
+    let name = extract_name "/compaction-snapshots" in
+    if String.length name = 0 then
+      respond_error reqd "keeper name is required"
+    else if not (Keeper_config.validate_name name) then
+      Http.Response.json_value ~status:`Bad_request
+        (`Assoc
+           [("error", `String (Printf.sprintf "invalid keeper name: %s" name))])
+        reqd
+    else
+      let limit =
+        Server_utils.int_query_param req "limit" ~default:compaction_snapshot_default_limit
+        |> max 1 |> min compaction_snapshot_max_limit
+      in
+      let config = Mcp_server.workspace_config state in
+      Http.Response.json_value ~compress:true ~request:req
+        (compaction_snapshots_json ~config ~keeper_id:name ~limit)
+        reqd
   else if ends_with "/turn-records" then
     (* RFC-0233 §2.3 PR-4: serve TurnRecords with server-side
        consecutive-pair block diffs so the dashboard stays a renderer

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -466,44 +466,50 @@ let compaction_snapshot_display_runtime ~source ~runtime_id ~compaction_source =
      | Some _ | None -> source)
 ;;
 
-let compaction_snapshot_item_json
-      ~id
-      ~keeper_id
-      ~ts_iso
-      ~ts_unix
-      ~trace_id
-      ~keeper_turn_id
-      ~source
-      ~trigger
-      ~runtime_id
-      ~before_tokens
-      ~after_tokens
-      ~saved_tokens
-      ~compaction_id
-      ~compaction_source
-      ~status
-      ~links
-  =
+type compaction_snapshot_item =
+  { id : string
+  ; keeper_id : string
+  ; ts_iso : string
+  ; ts_unix : float option
+  ; trace_id : string option
+  ; keeper_turn_id : int option
+  ; source : string
+  ; trigger : string
+  ; runtime_id : string option
+  ; before_tokens : int option
+  ; after_tokens : int option
+  ; saved_tokens : int option
+  ; compaction_id : string option
+  ; compaction_source : string option
+  ; status : string
+  ; links : Yojson.Safe.t
+  }
+
+let compaction_snapshot_item_json (item : compaction_snapshot_item) =
   `Assoc
-    [ "id", `String id
-    ; "keeper", `String keeper_id
-    ; "ts_iso", `String ts_iso
-    ; "ts_unix", Json_util.float_opt_to_json ts_unix
-    ; "trace_id", Json_util.string_opt_to_json trace_id
-    ; "keeper_turn_id", Json_util.int_opt_to_json keeper_turn_id
-    ; "source", `String source
-    ; "trigger", `String trigger
-    ; "runtime_id", Json_util.string_opt_to_json runtime_id
+    [ "id", `String item.id
+    ; "keeper", `String item.keeper_id
+    ; "ts_iso", `String item.ts_iso
+    ; "ts_unix", Json_util.float_opt_to_json item.ts_unix
+    ; "trace_id", Json_util.string_opt_to_json item.trace_id
+    ; "keeper_turn_id", Json_util.int_opt_to_json item.keeper_turn_id
+    ; "source", `String item.source
+    ; "trigger", `String item.trigger
+    ; "runtime_id", Json_util.string_opt_to_json item.runtime_id
     ; ( "display_runtime"
-      , `String (compaction_snapshot_display_runtime ~source ~runtime_id ~compaction_source)
+      , `String
+          (compaction_snapshot_display_runtime
+             ~source:item.source
+             ~runtime_id:item.runtime_id
+             ~compaction_source:item.compaction_source)
       )
-    ; "before_tokens", Json_util.int_opt_to_json before_tokens
-    ; "after_tokens", Json_util.int_opt_to_json after_tokens
-    ; "saved_tokens", Json_util.int_opt_to_json saved_tokens
-    ; "compaction_id", Json_util.string_opt_to_json compaction_id
-    ; "compaction_source", Json_util.string_opt_to_json compaction_source
-    ; "status", `String status
-    ; "links", links
+    ; "before_tokens", Json_util.int_opt_to_json item.before_tokens
+    ; "after_tokens", Json_util.int_opt_to_json item.after_tokens
+    ; "saved_tokens", Json_util.int_opt_to_json item.saved_tokens
+    ; "compaction_id", Json_util.string_opt_to_json item.compaction_id
+    ; "compaction_source", Json_util.string_opt_to_json item.compaction_source
+    ; "status", `String item.status
+    ; "links", item.links
     ]
 ;;
 
@@ -531,25 +537,27 @@ let compaction_event_bus_snapshot_json ~keeper_id (row : Keeper_runtime_manifest
     in
     Some
       (compaction_snapshot_item_json
-         ~id:
-           (Printf.sprintf "manifest:%s:%s:%s" row.trace_id
-              (Keeper_runtime_manifest.event_kind_to_string row.event)
-              row.ts)
-         ~keeper_id
-         ~ts_iso:row.ts
-         ~ts_unix:(Masc_domain.parse_iso8601_opt row.ts)
-         ~trace_id:(Some row.trace_id)
-         ~keeper_turn_id:row.keeper_turn_id
-         ~source:"runtime_manifest"
-         ~trigger
-         ~runtime_id:row.runtime_id
-         ~before_tokens
-         ~after_tokens
-         ~saved_tokens
-         ~compaction_id:(compaction_snapshot_clock_string row.decision "compaction_id")
-         ~compaction_source:(compaction_snapshot_clock_string row.decision "compaction_source")
-         ~status:row.status
-         ~links:(compaction_snapshot_links_json row.links))
+         { id =
+             Printf.sprintf "manifest:%s:%s:%s" row.trace_id
+               (Keeper_runtime_manifest.event_kind_to_string row.event)
+               row.ts
+         ; keeper_id
+         ; ts_iso = row.ts
+         ; ts_unix = Masc_domain.parse_iso8601_opt row.ts
+         ; trace_id = Some row.trace_id
+         ; keeper_turn_id = row.keeper_turn_id
+         ; source = "runtime_manifest"
+         ; trigger
+         ; runtime_id = row.runtime_id
+         ; before_tokens
+         ; after_tokens
+         ; saved_tokens
+         ; compaction_id = compaction_snapshot_clock_string row.decision "compaction_id"
+         ; compaction_source =
+             compaction_snapshot_clock_string row.decision "compaction_source"
+         ; status = row.status
+         ; links = compaction_snapshot_links_json row.links
+         })
   | _ -> None
 ;;
 
@@ -577,27 +585,28 @@ let compaction_context_snapshot_json ~keeper_id (row : Keeper_runtime_manifest.t
     in
     Some
       (compaction_snapshot_item_json
-         ~id:
-           (Printf.sprintf "manifest:%s:%s:%s" row.trace_id
-              (Keeper_runtime_manifest.event_kind_to_string row.event)
-              row.ts)
-         ~keeper_id
-         ~ts_iso:row.ts
-         ~ts_unix:(Masc_domain.parse_iso8601_opt row.ts)
-         ~trace_id:(Some row.trace_id)
-         ~keeper_turn_id:row.keeper_turn_id
-         ~source:"runtime_manifest"
+         { id =
+             Printf.sprintf "manifest:%s:%s:%s" row.trace_id
+               (Keeper_runtime_manifest.event_kind_to_string row.event)
+               row.ts
+         ; keeper_id
+         ; ts_iso = row.ts
+         ; ts_unix = Masc_domain.parse_iso8601_opt row.ts
+         ; trace_id = Some row.trace_id
+         ; keeper_turn_id = row.keeper_turn_id
+         ; source = "runtime_manifest"
          (* DET-OK: manifest projection fallback only; a missing source maps to
             a stable UI label and does not drive keeper policy. *)
-         ~trigger:(Option.value ~default:"pre_dispatch_hygiene" compaction_source)
-         ~runtime_id:row.runtime_id
-         ~before_tokens
-         ~after_tokens
-         ~saved_tokens:(compaction_saved_tokens before_tokens after_tokens)
-         ~compaction_id:(compaction_snapshot_clock_string row.decision "compaction_id")
-         ~compaction_source
-         ~status:row.status
-         ~links:(compaction_snapshot_links_json row.links))
+         ; trigger = Option.value ~default:"pre_dispatch_hygiene" compaction_source
+         ; runtime_id = row.runtime_id
+         ; before_tokens
+         ; after_tokens
+         ; saved_tokens = compaction_saved_tokens before_tokens after_tokens
+         ; compaction_id = compaction_snapshot_clock_string row.decision "compaction_id"
+         ; compaction_source
+         ; status = row.status
+         ; links = compaction_snapshot_links_json row.links
+         })
 ;;
 
 let compaction_snapshot_of_manifest_row ~keeper_id (row : Keeper_runtime_manifest.t) =
@@ -624,24 +633,25 @@ let keeper_meta_compaction_snapshot_json ~config ~keeper_id =
       let after_tokens = Some rt.last_after_tokens in
       ( Some
           (compaction_snapshot_item_json
-             ~id:"keeper_meta:last_compaction"
-             ~keeper_id
-             ~ts_iso:(Masc_domain.iso8601_of_unix_seconds rt.last_ts)
-             ~ts_unix:(Some rt.last_ts)
-             ~trace_id:None
-             ~keeper_turn_id:None
-             ~source:"keeper_meta"
-             ~trigger:
-               (Keeper_meta_contract.compaction_runtime_decision_to_string
-                  rt.last_decision)
-             ~runtime_id:None
-             ~before_tokens
-             ~after_tokens
-             ~saved_tokens:(compaction_saved_tokens before_tokens after_tokens)
-             ~compaction_id:None
-             ~compaction_source:None
-             ~status:"latest"
-             ~links:(`Assoc []))
+             { id = "keeper_meta:last_compaction"
+             ; keeper_id
+             ; ts_iso = Masc_domain.iso8601_of_unix_seconds rt.last_ts
+             ; ts_unix = Some rt.last_ts
+             ; trace_id = None
+             ; keeper_turn_id = None
+             ; source = "keeper_meta"
+             ; trigger =
+                 Keeper_meta_contract.compaction_runtime_decision_to_string
+                   rt.last_decision
+             ; runtime_id = None
+             ; before_tokens
+             ; after_tokens
+             ; saved_tokens = compaction_saved_tokens before_tokens after_tokens
+             ; compaction_id = None
+             ; compaction_source = None
+             ; status = "latest"
+             ; links = `Assoc []
+             })
       , [] )
   | Ok None -> None, []
   | Error msg ->

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -12,6 +12,9 @@ let keeper_hot_path_cache_ttl_s = 30.0
 let keeper_composite_cache_ttl_s = 5.0
 let compaction_snapshot_default_limit = 25
 let compaction_snapshot_max_limit = 100
+let compaction_snapshot_manifest_scan_min_files = 8
+let compaction_snapshot_manifest_scan_limit_multiplier = 4
+let compaction_snapshot_manifest_tail_max_lines = 200
 
 (* Maximum number of trajectory/trace entries returned per query. *)
 let trajectory_max_limit = 500
@@ -244,49 +247,149 @@ let compaction_snapshot_take n xs =
   loop n [] xs
 ;;
 
+type compaction_snapshot_read_error =
+  { scope : string
+  ; error : string
+  }
+
+let compaction_snapshot_read_error ~scope ~error = { scope; error }
+
+let compaction_snapshot_read_error_json { scope; error } =
+  `Assoc [ "scope", `String scope; "error", `String error ]
+;;
+
+let compaction_snapshot_read_errors_json errors =
+  `List (List.map compaction_snapshot_read_error_json errors)
+;;
+
+let log_compaction_snapshot_read_errors ~keeper_id errors =
+  List.iter
+    (fun { scope; error } ->
+      Log.Dashboard.warn
+        "compaction_snapshots: keeper=%s scope=%s error=%s"
+        keeper_id scope error)
+    errors
+;;
+
+let compaction_snapshot_unix_error_message err fn arg =
+  Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err)
+;;
+
 let safe_regular_mtime path =
   try
     let st = Unix.stat path in
-    if st.Unix.st_kind = Unix.S_REG then Some st.Unix.st_mtime else None
+    if st.Unix.st_kind = Unix.S_REG
+    then Some st.Unix.st_mtime, []
+    else None, []
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | _ -> None
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> None, []
+  | Unix.Unix_error (err, fn, arg) ->
+    ( None
+    , [ compaction_snapshot_read_error
+          ~scope:("runtime_manifest_file:" ^ path)
+          ~error:(compaction_snapshot_unix_error_message err fn arg)
+      ] )
+  | exn ->
+    ( None
+    , [ compaction_snapshot_read_error
+          ~scope:("runtime_manifest_file:" ^ path)
+          ~error:(Printexc.to_string exn)
+      ] )
 ;;
 
 let runtime_manifest_paths ~config ~keeper_id ~limit =
   let dir = Keeper_runtime_manifest.base_dir config ~keeper_name:keeper_id in
+  let scan_limit =
+    max compaction_snapshot_manifest_scan_min_files
+      (limit * compaction_snapshot_manifest_scan_limit_multiplier)
+  in
   try
     let st = Unix.stat dir in
     if st.Unix.st_kind <> Unix.S_DIR
-    then []
+    then
+      ( []
+      , [ compaction_snapshot_read_error
+            ~scope:("runtime_manifest_dir:" ^ dir)
+            ~error:"path is not a directory"
+        ] )
     else
-      Sys.readdir dir
-      |> Array.to_list
-      |> List.filter (String.ends_with ~suffix:".jsonl")
-      |> List.filter_map (fun file ->
+      let entries, read_errors =
+        Sys.readdir dir
+        |> Array.to_list
+        |> List.filter
+             (String.ends_with
+                ~suffix:Keeper_runtime_manifest.manifest_file_suffix)
+        |> List.fold_left
+             (fun (entries, read_errors) file ->
         let path = Filename.concat dir file in
-        Option.map (fun mtime -> path, mtime) (safe_regular_mtime path))
+        let mtime, errors = safe_regular_mtime path in
+        let entries =
+          match mtime with
+          | Some mtime -> (path, mtime) :: entries
+          | None -> entries
+        in
+        entries, List.rev_append errors read_errors)
+             ([], [])
+      in
+      (entries
       |> List.sort (fun (_, a) (_, b) -> Float.compare b a)
-      |> compaction_snapshot_take (max 8 (limit * 4))
+      |> compaction_snapshot_take scan_limit
       |> List.map fst
+      , List.rev read_errors)
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | _ -> []
+  | Unix.Unix_error (Unix.ENOENT, _, _) -> [], []
+  | Unix.Unix_error (err, fn, arg) ->
+    ( []
+    , [ compaction_snapshot_read_error
+          ~scope:("runtime_manifest_dir:" ^ dir)
+          ~error:(compaction_snapshot_unix_error_message err fn arg)
+      ] )
+  | exn ->
+    ( []
+    , [ compaction_snapshot_read_error
+          ~scope:("runtime_manifest_dir:" ^ dir)
+          ~error:(Printexc.to_string exn)
+      ] )
 ;;
 
 let read_runtime_manifest_tail_rows path =
   try
-    Dated_jsonl.load_tail_lines path ~max_lines:200
-    |> List.filter_map (fun line ->
+    Dated_jsonl.load_tail_lines path
+      ~max_lines:compaction_snapshot_manifest_tail_max_lines
+    |> fun lines ->
+    let rec loop line_no rows read_errors = function
+      | [] -> List.rev rows, List.rev read_errors
+      | line :: rest ->
       try
         match Yojson.Safe.from_string line |> Keeper_runtime_manifest.of_json with
-        | Ok row -> Some row
-        | Error _ -> None
+            | Ok row -> loop (line_no + 1) (row :: rows) read_errors rest
+            | Error msg ->
+              loop (line_no + 1) rows
+                (compaction_snapshot_read_error
+                   ~scope:(Printf.sprintf "runtime_manifest_row:%s:%d" path line_no)
+                   ~error:msg
+                 :: read_errors)
+                rest
       with
-      | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None)
+          | Yojson.Json_error msg | Yojson.Safe.Util.Type_error (msg, _) ->
+            loop (line_no + 1) rows
+              (compaction_snapshot_read_error
+                 ~scope:(Printf.sprintf "runtime_manifest_row:%s:%d" path line_no)
+                 ~error:msg
+               :: read_errors)
+              rest
+    in
+    loop 1 [] [] lines
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | _ -> []
+  | exn ->
+    ( []
+    , [ compaction_snapshot_read_error
+          ~scope:("runtime_manifest_file:" ^ path)
+          ~error:(Printexc.to_string exn)
+      ] )
 ;;
 
 let compaction_snapshot_clock_refs decision =
@@ -399,7 +502,7 @@ let compaction_context_snapshot_json ~keeper_id (row : Keeper_runtime_manifest.t
   let pre_dispatch_compacted =
     Json_util.get_bool row.decision "pre_dispatch_compacted" = Some true
   in
-  if (not pre_dispatch_compacted) && String.equal row.status "skipped"
+  if (not pre_dispatch_compacted) && Keeper_runtime_manifest.status_is_skipped row
   then None
   else
     let before_tokens =
@@ -463,51 +566,69 @@ let keeper_meta_compaction_snapshot_json ~config ~keeper_id =
   | Ok (Some meta) ->
     let rt = meta.runtime.compaction_rt in
     if rt.count <= 0 || rt.last_ts <= 0.0
-    then None
+    then None, []
     else
       let before_tokens = Some rt.last_before_tokens in
       let after_tokens = Some rt.last_after_tokens in
-      Some
-        (compaction_snapshot_item_json
-           ~id:"keeper_meta:last_compaction"
-           ~keeper_id
-           ~ts_iso:(Masc_domain.iso8601_of_unix_seconds rt.last_ts)
-           ~ts_unix:(Some rt.last_ts)
-           ~trace_id:None
-           ~keeper_turn_id:None
-           ~source:"keeper_meta"
-           ~trigger:
-             (Keeper_meta_contract.compaction_runtime_decision_to_string
-                rt.last_decision)
-           ~runtime_id:None
-           ~before_tokens
-           ~after_tokens
-           ~saved_tokens:(compaction_saved_tokens before_tokens after_tokens)
-           ~compaction_id:None
-           ~compaction_source:None
-           ~status:"latest"
-           ~links:(`Assoc []))
-  | Ok None | Error _ -> None
+      ( Some
+          (compaction_snapshot_item_json
+             ~id:"keeper_meta:last_compaction"
+             ~keeper_id
+             ~ts_iso:(Masc_domain.iso8601_of_unix_seconds rt.last_ts)
+             ~ts_unix:(Some rt.last_ts)
+             ~trace_id:None
+             ~keeper_turn_id:None
+             ~source:"keeper_meta"
+             ~trigger:
+               (Keeper_meta_contract.compaction_runtime_decision_to_string
+                  rt.last_decision)
+             ~runtime_id:None
+             ~before_tokens
+             ~after_tokens
+             ~saved_tokens:(compaction_saved_tokens before_tokens after_tokens)
+             ~compaction_id:None
+             ~compaction_source:None
+             ~status:"latest"
+             ~links:(`Assoc []))
+      , [] )
+  | Ok None -> None, []
+  | Error msg ->
+    ( None
+    , [ compaction_snapshot_read_error
+          ~scope:("keeper_meta:" ^ keeper_id)
+          ~error:msg
+      ] )
 ;;
 
 let compaction_snapshots_json ~config ~keeper_id ~limit =
   let limit = limit |> max 1 |> min compaction_snapshot_max_limit in
-  let manifest_items =
+  let manifest_paths, path_read_errors =
     runtime_manifest_paths ~config ~keeper_id ~limit
-    |> List.concat_map read_runtime_manifest_tail_rows
+  in
+  let rows_and_errors = List.map read_runtime_manifest_tail_rows manifest_paths in
+  let manifest_rows = List.concat_map fst rows_and_errors in
+  let manifest_read_errors =
+    path_read_errors @ List.concat_map snd rows_and_errors
+  in
+  let manifest_items =
+    manifest_rows
     |> List.filter_map (compaction_snapshot_of_manifest_row ~keeper_id)
     |> List.sort (fun a b ->
       Float.compare (compaction_snapshot_sort_value b) (compaction_snapshot_sort_value a))
     |> compaction_snapshot_take limit
   in
-  let items =
+  let items, read_errors =
     match manifest_items with
     | [] ->
-      (match keeper_meta_compaction_snapshot_json ~config ~keeper_id with
-       | Some item -> [ item ]
-       | None -> [])
-    | _ -> manifest_items
+      let meta_item, meta_read_errors =
+        keeper_meta_compaction_snapshot_json ~config ~keeper_id
+      in
+      (match meta_item with
+       | Some item -> [ item ], manifest_read_errors @ meta_read_errors
+       | None -> [], manifest_read_errors @ meta_read_errors)
+    | _ -> manifest_items, manifest_read_errors
   in
+  log_compaction_snapshot_read_errors ~keeper_id read_errors;
   `Assoc
     [ "schema", `String "keeper.compaction_snapshots.v1"
     ; "keeper", `String keeper_id
@@ -515,6 +636,8 @@ let compaction_snapshots_json ~config ~keeper_id ~limit =
     ; "producer", `String "keeper_runtime_manifest|keeper_meta_store"
     ; "limit", `Int limit
     ; "count", `Int (List.length items)
+    ; "read_error_count", `Int (List.length read_errors)
+    ; "read_errors", compaction_snapshot_read_errors_json read_errors
     ; "items", `List items
     ]
 ;;
@@ -1074,9 +1197,12 @@ let handle_keeper_get_subroutes state req request reqd =
         |> max 1 |> min compaction_snapshot_max_limit
       in
       let config = Mcp_server.workspace_config state in
+      let json =
+        Domain_pool_ref.submit_io_or_inline (fun () ->
+          compaction_snapshots_json ~config ~keeper_id:name ~limit)
+      in
       Http.Response.json_value ~compress:true ~request:req
-        (compaction_snapshots_json ~config ~keeper_id:name ~limit)
-        reqd
+        json reqd
   else if ends_with "/turn-records" then
     (* RFC-0233 §2.3 PR-4: serve TurnRecords with server-side
        consecutive-pair block diffs so the dashboard stays a renderer

--- a/lib/server/server_dashboard_http_keeper_api.mli
+++ b/lib/server/server_dashboard_http_keeper_api.mli
@@ -195,3 +195,11 @@ val memory_os_dashboard_json : keeper_id:string -> Yojson.Safe.t
     from the keeper's on-disk stores. Exported so the test suite can assert the
     facts [items] are wired (one row per persisted fact); [memory_os_fact_json],
     being a pure per-fact projection, cannot guard that wiring on its own. *)
+
+val compaction_snapshots_json :
+  config:Workspace.config -> keeper_id:string -> limit:int -> Yojson.Safe.t
+(** Durable compaction snapshot payload for
+    [GET /api/v1/keepers/:name/compaction-snapshots]. Reads runtime manifests
+    first, then keeper meta as a latest-only fallback, and emits only event
+    metadata/token counts/provenance — never raw prompt or compacted context
+    text. Exported for JSON contract tests. *)

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -10,6 +10,7 @@ module Prompt_names = Keeper_prompt_names
 module Recall = Masc.Keeper_memory_os_recall
 module Consolidator = Masc.Keeper_memory_os_consolidator
 module Metrics = Masc.Otel_metric_store
+module Runtime_manifest = Masc.Keeper_runtime_manifest
 
 external unsetenv : string -> unit = "masc_test_unsetenv"
 
@@ -81,6 +82,13 @@ let with_temp_keepers_dir f =
   let marker = Filename.temp_file "keeper-memory-os-" ".tmp" in
   Sys.remove marker;
   Memory_io.For_testing.with_keepers_dir marker (fun () -> f marker)
+;;
+
+let with_temp_workspace_config f =
+  let marker = Filename.temp_file "keeper-memory-os-workspace-" ".tmp" in
+  Sys.remove marker;
+  Unix.mkdir marker 0o700;
+  f (Masc.Workspace.default_config marker)
 ;;
 
 let render_if_enabled_for_test ~keeper_id ~now ~masc_root () =
@@ -4286,6 +4294,138 @@ let test_dashboard_json_selection_policy_contract () =
       (List.mem_assoc "episode_tail_limit" policy))
 ;;
 
+let json_assoc label = function
+  | `Assoc fields -> fields
+  | other ->
+    Alcotest.failf "%s must be an object (received %s)" label
+      (Yojson.Safe.to_string other)
+;;
+
+let json_object_field label fields key =
+  match List.assoc_opt key fields with
+  | Some (`Assoc nested) -> nested
+  | Some other ->
+    Alcotest.failf "%s.%s must be an object (received %s)" label key
+      (Yojson.Safe.to_string other)
+  | None -> Alcotest.failf "%s.%s missing" label key
+;;
+
+let json_string_field label fields key =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> value
+  | Some other ->
+    Alcotest.failf "%s.%s must be a string (received %s)" label key
+      (Yojson.Safe.to_string other)
+  | None -> Alcotest.failf "%s.%s missing" label key
+;;
+
+let json_int_field label fields key =
+  match List.assoc_opt key fields with
+  | Some (`Int value) -> value
+  | Some other ->
+    Alcotest.failf "%s.%s must be an int (received %s)" label key
+      (Yojson.Safe.to_string other)
+  | None -> Alcotest.failf "%s.%s missing" label key
+;;
+
+let json_item_list label fields key =
+  match List.assoc_opt key fields with
+  | Some (`List items) -> items
+  | Some other ->
+    Alcotest.failf "%s.%s must be a list (received %s)" label key
+      (Yojson.Safe.to_string other)
+  | None -> Alcotest.failf "%s.%s missing" label key
+;;
+
+let test_compaction_snapshots_json_reads_runtime_manifest () =
+  with_temp_workspace_config (fun config ->
+    let keeper_id = "memory-panel-test" in
+    let trace_id = "trace-compaction-dashboard" in
+    let clock_refs =
+      Runtime_manifest.clock_refs
+        ~compaction_id:"cmp-42"
+        ~compaction_source:"event_bus"
+        ()
+    in
+    let decision =
+      Runtime_manifest.with_clock_refs
+        ~clock_refs
+        (Runtime_manifest.with_payload_role
+           ~payload_role:Runtime_manifest.Operator_evidence
+           (`Assoc
+              [ "last_compaction"
+                , `Assoc
+                    [ "before_tokens", `Int 210_000
+                    ; "after_tokens", `Int 120_000
+                    ; "tokens_freed", `Int 90_000
+                    ; "phase_hint", `String "proactive(85%)"
+                    ]
+              ; "context_compacted_count", `Int 1
+              ]))
+    in
+    let row =
+      Runtime_manifest.make
+        ~ts:"2026-06-26T03:03:00Z"
+        ~keeper_name:keeper_id
+        ~trace_id
+        ~keeper_turn_id:12
+        ~event:Runtime_manifest.Event_bus_correlated
+        ~runtime_id:"oas-seoul-1"
+        ~status:"observed"
+        ~decision
+        ()
+    in
+    (match Runtime_manifest.append config row with
+     | Ok () -> ()
+     | Error msg -> Alcotest.failf "runtime manifest append failed: %s" msg);
+    let top =
+      Server_dashboard_http_keeper_api.compaction_snapshots_json
+        ~config
+        ~keeper_id
+        ~limit:10
+      |> json_assoc "compaction_snapshots"
+    in
+    Alcotest.(check string)
+      "schema"
+      "keeper.compaction_snapshots.v1"
+      (json_string_field "compaction_snapshots" top "schema");
+    Alcotest.(check int) "count" 1 (json_int_field "compaction_snapshots" top "count");
+    let item =
+      match json_item_list "compaction_snapshots" top "items" with
+      | [ item ] -> json_assoc "compaction_snapshots.items[0]" item
+      | items -> Alcotest.failf "expected one compaction item, got %d" (List.length items)
+    in
+    Alcotest.(check string)
+      "source"
+      "runtime_manifest"
+      (json_string_field "item" item "source");
+    Alcotest.(check string)
+      "trigger"
+      "proactive(85%)"
+      (json_string_field "item" item "trigger");
+    Alcotest.(check string)
+      "runtime"
+      "oas-seoul-1"
+      (json_string_field "item" item "runtime_id");
+    Alcotest.(check int) "before" 210_000 (json_int_field "item" item "before_tokens");
+    Alcotest.(check int) "after" 120_000 (json_int_field "item" item "after_tokens");
+    Alcotest.(check int) "saved" 90_000 (json_int_field "item" item "saved_tokens");
+    Alcotest.(check string)
+      "compaction id"
+      "cmp-42"
+      (json_string_field "item" item "compaction_id");
+    let links = json_object_field "item" item "links" in
+    Alcotest.(check int) "links object exists" 3 (List.length links);
+    let item_json = Yojson.Safe.to_string (`Assoc item) in
+    List.iter
+      (fun forbidden ->
+        Alcotest.(check bool)
+          ("does not expose " ^ forbidden)
+          false
+          (contains forbidden item_json))
+      [ "before_prompt"; "after_prompt"; "prompt_text"; "context_text" ])
+;;
+
 let () =
   maybe_run_lock_holder_child ();
   Alcotest.run
@@ -4389,6 +4529,10 @@ let () =
             "dashboard json selection_policy pins recall lineage"
             `Quick
             test_dashboard_json_selection_policy_contract
+        ; Alcotest.test_case
+            "dashboard compaction snapshots read runtime manifest metadata only"
+            `Quick
+            test_compaction_snapshots_json_reads_runtime_manifest
         ] )
     ; ( "policy"
       , [ Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -91,6 +91,14 @@ let with_temp_workspace_config f =
   f (Masc.Workspace.default_config marker)
 ;;
 
+let write_text_file path contents =
+  let (_ : string) = Masc.Keeper_fs.ensure_dir (Filename.dirname path) in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc contents)
+;;
+
 let render_if_enabled_for_test ~keeper_id ~now ~masc_root () =
   Recall.render_if_enabled
     ~keeper_id
@@ -4390,6 +4398,10 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       "keeper.compaction_snapshots.v1"
       (json_string_field "compaction_snapshots" top "schema");
     Alcotest.(check int) "count" 1 (json_int_field "compaction_snapshots" top "count");
+    Alcotest.(check int)
+      "read errors"
+      0
+      (List.length (json_item_list "compaction_snapshots" top "read_errors"));
     let item =
       match json_item_list "compaction_snapshots" top "items" with
       | [ item ] -> json_assoc "compaction_snapshots.items[0]" item
@@ -4424,6 +4436,35 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
           false
           (contains forbidden item_json))
       [ "before_prompt"; "after_prompt"; "prompt_text"; "context_text" ])
+;;
+
+let test_compaction_snapshots_json_surfaces_manifest_read_errors () =
+  with_temp_workspace_config (fun config ->
+    let keeper_id = "memory-panel-test" in
+    let path =
+      Runtime_manifest.path_for_trace config
+        ~keeper_name:keeper_id
+        ~trace_id:"trace-corrupt-compaction-dashboard"
+    in
+    write_text_file path "{not-json}\n";
+    let top =
+      Server_dashboard_http_keeper_api.compaction_snapshots_json
+        ~config
+        ~keeper_id
+        ~limit:10
+      |> json_assoc "compaction_snapshots"
+    in
+    Alcotest.(check int) "count" 0 (json_int_field "compaction_snapshots" top "count");
+    let read_errors = json_item_list "compaction_snapshots" top "read_errors" in
+    Alcotest.(check bool)
+      "corrupt manifest row is surfaced"
+      true
+      (List.length read_errors > 0);
+    let error_json = Yojson.Safe.to_string (`List read_errors) in
+    Alcotest.(check bool)
+      "error names runtime manifest row"
+      true
+      (contains "runtime_manifest_row" error_json))
 ;;
 
 let () =
@@ -4533,6 +4574,10 @@ let () =
             "dashboard compaction snapshots read runtime manifest metadata only"
             `Quick
             test_compaction_snapshots_json_reads_runtime_manifest
+        ; Alcotest.test_case
+            "dashboard compaction snapshots surface manifest read errors"
+            `Quick
+            test_compaction_snapshots_json_surfaces_manifest_read_errors
         ] )
     ; ( "policy"
       , [ Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -1342,7 +1342,7 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
              episode.Types.episode_summary;
            Alcotest.(check (option string))
              "fallback marker"
-             (Some "librarian_unstructured_fallback")
+             (Some Types.librarian_unstructured_fallback_terminal_marker)
              episode.Types.terminal_marker;
            (match episode.Types.claims with
             | [ fact ] ->
@@ -1384,7 +1384,7 @@ let test_librarian_runtime_preserves_unstructured_fallback () =
          | [ episode ] ->
            Alcotest.(check (option string))
              "event persisted with fallback marker"
-             (Some "librarian_unstructured_fallback")
+             (Some Types.librarian_unstructured_fallback_terminal_marker)
              episode.Types.terminal_marker;
            Alcotest.(check (float 0.001))
              "event persisted with injected-clock timestamp"
@@ -2186,7 +2186,7 @@ let test_render_if_enabled_omits_diagnostic_memory () =
           ; Types.source_turn_range = Some (1, 2)
           ; Types.created_at = now
           ; Types.valid_until = Some (now +. 3600.0)
-          ; Types.terminal_marker = Some "librarian_unstructured_fallback"
+          ; Types.terminal_marker = Some Types.librarian_unstructured_fallback_terminal_marker
           ; Types.schema_version = Types.schema_version
           }
         in
@@ -4336,6 +4336,15 @@ let json_int_field label fields key =
   | None -> Alcotest.failf "%s.%s missing" label key
 ;;
 
+let json_bool_field label fields key =
+  match List.assoc_opt key fields with
+  | Some (`Bool value) -> value
+  | Some other ->
+    Alcotest.failf "%s.%s must be a bool (received %s)" label key
+      (Yojson.Safe.to_string other)
+  | None -> Alcotest.failf "%s.%s missing" label key
+;;
+
 let json_item_list label fields key =
   match List.assoc_opt key fields with
   | Some (`List items) -> items
@@ -4402,6 +4411,14 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       "read errors"
       0
       (List.length (json_item_list "compaction_snapshots" top "read_errors"));
+    Alcotest.(check int)
+      "read error count"
+      0
+      (json_int_field "compaction_snapshots" top "read_error_count");
+    Alcotest.(check bool)
+      "scan truncated"
+      false
+      (json_bool_field "compaction_snapshots" top "scan_truncated");
     let item =
       match json_item_list "compaction_snapshots" top "items" with
       | [ item ] -> json_assoc "compaction_snapshots.items[0]" item
@@ -4419,6 +4436,10 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       "runtime"
       "oas-seoul-1"
       (json_string_field "item" item "runtime_id");
+    Alcotest.(check string)
+      "display runtime"
+      "oas-seoul-1"
+      (json_string_field "item" item "display_runtime");
     Alcotest.(check int) "before" 210_000 (json_int_field "item" item "before_tokens");
     Alcotest.(check int) "after" 120_000 (json_int_field "item" item "after_tokens");
     Alcotest.(check int) "saved" 90_000 (json_int_field "item" item "saved_tokens");
@@ -4464,7 +4485,15 @@ let test_compaction_snapshots_json_surfaces_manifest_read_errors () =
     Alcotest.(check bool)
       "error names runtime manifest row"
       true
-      (contains "runtime_manifest_row" error_json))
+      (contains "runtime_manifest_row" error_json);
+    Alcotest.(check bool)
+      "error scope does not expose absolute manifest path"
+      false
+      (contains path error_json);
+    Alcotest.(check int)
+      "read error count"
+      (List.length read_errors)
+      (json_int_field "compaction_snapshots" top "read_error_count"))
 ;;
 
 let () =


### PR DESCRIPTION
## Summary
- add a durable keeper compaction snapshots endpoint backed by runtime manifests with keeper-meta fallback
- hydrate the compaction overlay from that endpoint while preserving SSE/manual optimistic entries
- split Memory OS default recallable facts from diagnostic evidence and librarian fallback episodes

## Validation
- scripts/dune-local.sh build test/test_keeper_memory_os.exe test/test_server_dashboard_http_keeper_memory_health.exe
- scripts/dune-local.sh exec test/test_keeper_memory_os.exe -- test '^json$' --quick-tests
- pnpm exec vitest run --config vitest.config.ts src/api/dashboard.test.ts src/components/memory-inspector.test.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts src/sse.test.ts
- pnpm run typecheck
- pnpm run lint
- git diff --check