### PR TITLE
fix(keeper): retry empty direct keeper replies

### DIFF
--- a/lib/keeper/keeper_agent_error.ml
+++ b/lib/keeper/keeper_agent_error.ml
@@ -12,6 +12,10 @@ let sdk_error_kind = function
   | Agent_sdk.Error.Internal _ -> "internal"
 ;;
 
+let sdk_error_kind_for_receipt err =
+  Keeper_execution_receipt.error_kind_of_string (sdk_error_kind err)
+;;
+
 let network_error_kind_user_label = function
   | Llm_provider.Http_client.Connection_refused -> "connection refused"
   | Llm_provider.Http_client.Dns_failure -> "DNS lookup failed"

--- a/lib/keeper/keeper_agent_error.mli
+++ b/lib/keeper/keeper_agent_error.mli
@@ -3,6 +3,11 @@
 (** Coarse categorisation of [Agent_sdk.Error.sdk_error] (for dashboards). *)
 val sdk_error_kind : Agent_sdk.Error.sdk_error -> string
 
+(** Typed receipt error-kind counterpart of {!sdk_error_kind}. *)
+val sdk_error_kind_for_receipt
+  :  Agent_sdk.Error.sdk_error
+  -> Keeper_execution_receipt.error_kind
+
 (** User-facing SDK error message for keeper chat/tool surfaces.
     Keeps low-level SDK prefixes out of persisted keeper replies while
     telemetry and terminal reason codes continue to use structured errors. *)

--- a/lib/keeper/keeper_agent_run_receipt.ml
+++ b/lib/keeper/keeper_agent_run_receipt.ml
@@ -97,7 +97,7 @@ let finalize
     match turn_result with
     | Ok _ -> None, None
     | Error err ->
-      ( Some (Keeper_execution_receipt.error_kind_of_string (Keeper_agent_error.sdk_error_kind err))
+      ( Some (Keeper_agent_error.sdk_error_kind_for_receipt err)
       , Some (Agent_sdk.Error.to_string err) )
   in
   let completion_contract_result

--- a/lib/keeper/keeper_run_context.ml
+++ b/lib/keeper/keeper_run_context.ml
@@ -31,6 +31,43 @@ type run_context =
   ; runtime_config_path : string option
   }
 
+let prompt_profile_default default current =
+  (* DET-OK: keeper TOML/persona profile defaults are the declarative
+     prompt-config boundary; persisted meta is the legacy fallback. *)
+  match default with
+  | Some value -> value
+  | None -> current
+
+let build_base_system_prompt
+      ~(config : Workspace.config)
+      ~(profile_defaults : Keeper_types_profile.keeper_profile_defaults)
+      ~(meta : keeper_meta)
+  =
+  let persona_extended =
+    Keeper_types_profile.resolved_persona_name ~keeper_name:meta.name
+      profile_defaults
+    |> Keeper_types_profile.load_persona_extended
+    |> Option.value ~default:""
+  in
+  let active_goals =
+    List.filter_map
+      (fun goal_id ->
+         match Goal_store.get_goal config ~goal_id with
+         (* RFC-0294: active_goals tuple dropped its horizon element. *)
+         | Some { Goal_store.id; title; _ } -> Some (id, title)
+         | None -> None)
+      meta.active_goal_ids
+  in
+  Keeper_prompt.build_keeper_system_prompt
+    ~goal:(prompt_profile_default profile_defaults.goal meta.goal)
+    ~instructions:
+      (prompt_profile_default profile_defaults.instructions meta.instructions)
+    ~persona_extended
+    ~keeper_name:meta.name
+    ~active_goals
+    ~home_ground:config.base_path
+    ()
+
 let prepare_run_context
       ~(config : Workspace.config)
       ~(meta : keeper_meta)
@@ -117,39 +154,8 @@ let prepare_run_context
     resolution.Config_dir_resolver.config_root.path
   in
   let runtime_config_path = Runtime.config_path () in
-  let persona_extended =
-    Keeper_types_profile.resolved_persona_name ~keeper_name:meta.name
-      profile_defaults
-    |> Keeper_types_profile.load_persona_extended
-    |> Option.value ~default:""
-  in
-  let active_goals =
-    List.filter_map
-      (fun goal_id ->
-         match Goal_store.get_goal config ~goal_id with
-         (* RFC-0294: active_goals tuple dropped its horizon element. *)
-         | Some { Goal_store.id; title; _ } ->
-             Some (id, title)
-         | None -> None)
-      meta.active_goal_ids
-  in
-  let prompt_profile_default default current =
-    (* DET-OK: keeper TOML/persona profile defaults are the declarative
-       prompt-config boundary; persisted meta is the legacy fallback. *)
-    match default with
-    | Some value -> value
-    | None -> current
-  in
   let base_system_prompt =
-    Keeper_prompt.build_keeper_system_prompt
-      ~goal:(prompt_profile_default profile_defaults.goal meta.goal)
-      ~instructions:
-        (prompt_profile_default profile_defaults.instructions meta.instructions)
-      ~persona_extended
-      ~keeper_name:meta.name
-      ~active_goals
-      ~home_ground:config.base_path
-      ()
+    build_base_system_prompt ~config ~profile_defaults ~meta
   in
   (* 4. Create or restore working context, re-apply current prompt *)
   let base_ctx =

--- a/lib/keeper/keeper_run_context.mli
+++ b/lib/keeper/keeper_run_context.mli
@@ -28,6 +28,14 @@ type run_context =
   ; runtime_config_path : string option
   }
 
+val build_base_system_prompt :
+     config:Workspace.config
+  -> profile_defaults:Keeper_types_profile.keeper_profile_defaults
+  -> meta:keeper_meta
+  -> string
+(** Build the keeper base system prompt from the same persisted meta/profile
+    inputs used by {!prepare_run_context}. *)
+
 val prepare_run_context :
      config:Workspace.config
   -> meta:keeper_meta

--- a/lib/keeper/keeper_run_prompt.ml
+++ b/lib/keeper/keeper_run_prompt.ml
@@ -117,6 +117,32 @@ let append_dynamic_context a b =
   | a, "" -> a
   | a, b -> a ^ "\n\n" ^ b
 
+let dynamic_context_with_recent_failures ~keeper_name dynamic_context =
+  Keeper_failure_circuit_breaker.recent_failures_for_prompt ~keeper_name
+  |> render_recent_failure_context
+  |> append_dynamic_context dynamic_context
+
+let estimate_input_tokens
+    ~(prompt_metrics : Keeper_agent_prompt_metrics.prompt_metrics)
+    ~(system_prompt : string)
+    ~(dynamic_context : string)
+    ~(memory_context : string)
+    ~(temporal_context : string)
+    ~(user_message : string)
+    ~(history_messages : Agent_sdk.Types.message list) : int =
+  let composition =
+    Keeper_agent_prompt_metrics.build_ctx_composition_metrics
+      ~system_prompt
+      ~dynamic_context
+      ~memory_context
+      ~temporal_context
+      ~user_message
+      ~history_messages
+      ~actual_input_tokens:None
+  in
+  max prompt_metrics.Keeper_agent_prompt_metrics.estimated_total_tokens
+      composition.Keeper_agent_prompt_metrics.display_total_tokens
+
 let build_turn_context
       ~(ctx : Keeper_run_context.run_context)
       ~(build_turn_prompt :
@@ -144,12 +170,7 @@ let build_turn_context
       ~messages:(Keeper_context_runtime.messages_of_context ctx_work)
   in
   let dynamic_context =
-    let recent_failure_context =
-      Keeper_failure_circuit_breaker.recent_failures_for_prompt
-        ~keeper_name:meta.name
-      |> render_recent_failure_context
-    in
-    append_dynamic_context dynamic_context recent_failure_context
+    dynamic_context_with_recent_failures ~keeper_name:meta.name dynamic_context
   in
   let memory_context = "" in
   let temporal_context =
@@ -194,21 +215,14 @@ let build_turn_context
       (Keeper_context_runtime.messages_of_context ctx_work)
   in
   let estimated_input_tokens =
-    (* Prompt build runs before the LLM call, so the actual input-token
-       count is unknown here; post-response code paths in
-       [Keeper_agent_run] pass the provider-reported value. *)
-    let composition =
-      Keeper_agent_prompt_metrics.build_ctx_composition_metrics
-        ~system_prompt:turn_system_prompt
-        ~dynamic_context
-        ~memory_context
-        ~temporal_context
-        ~user_message
-        ~history_messages
-        ~actual_input_tokens:None
-    in
-    max prompt_metrics.Keeper_agent_prompt_metrics.estimated_total_tokens
-        composition.Keeper_agent_prompt_metrics.display_total_tokens
+    estimate_input_tokens
+      ~prompt_metrics
+      ~system_prompt:turn_system_prompt
+      ~dynamic_context
+      ~memory_context
+      ~temporal_context
+      ~user_message
+      ~history_messages
   in
   let ctx_work = Keeper_context_runtime.append ctx_work user_msg in
   if not is_retry

--- a/lib/keeper/keeper_run_prompt.mli
+++ b/lib/keeper/keeper_run_prompt.mli
@@ -35,6 +35,23 @@ val render_recent_failure_context :
     keeper's recent tool failure signatures. Returns [""] when there is no
     recent failure memory. *)
 
+val dynamic_context_with_recent_failures :
+  keeper_name:string -> string -> string
+(** Append the bounded recent-failure prompt block exactly as turn dispatch
+    does before computing prompt metrics. *)
+
+val estimate_input_tokens :
+  prompt_metrics:Keeper_agent_prompt_metrics.prompt_metrics ->
+  system_prompt:string ->
+  dynamic_context:string ->
+  memory_context:string ->
+  temporal_context:string ->
+  user_message:string ->
+  history_messages:Agent_sdk.Types.message list ->
+  int
+(** Shared pre-call input-token estimate used by retry budget checks and
+    normal turn prompt construction. *)
+
 val build_turn_context
   :  ctx:Keeper_run_context.run_context
   -> build_turn_prompt:(base_system_prompt:string -> messages:Agent_sdk.Types.message list -> Keeper_agent_prompt_metrics.turn_prompt)

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -233,12 +233,218 @@ let next_direct_empty_no_progress_retry_decision
      with
      | Keeper_turn_runtime_budget.Degraded_retry_allowed retry
        when retry_reason_is_empty_no_progress retry ->
-       Keeper_turn_runtime_budget.Degraded_retry_allowed retry
-     | Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
-       when retry_reason_is_empty_no_progress retry ->
-       Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
-     | _ -> Keeper_turn_runtime_budget.No_degraded_retry)
-  | Some _ -> Keeper_turn_runtime_budget.No_degraded_retry
+	       Keeper_turn_runtime_budget.Degraded_retry_allowed retry
+	     | Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
+	       when retry_reason_is_empty_no_progress retry ->
+	       Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
+	     | _ -> Keeper_turn_runtime_budget.No_degraded_retry)
+	  | Some _ -> Keeper_turn_runtime_budget.No_degraded_retry
+
+let run_direct_empty_no_progress_retry_loop
+      ~keeper_name
+      ~base_runtime
+      ~initial_runtime
+      ~initial_max_context
+      ~estimated_input_tokens
+      ~timeout_sec
+      ~remaining_turn_budget_s
+      ~current_turn_phase_elapsed_ms
+      ~now_s
+      ~max_context_resolution_for_retry_runtime
+      ~validate_retry_runtime
+      ~publish_cascade_resolution
+      ~emit_runtime_selected
+      ~emit_runtime_rotation
+      ~record_retry_setup_failure
+      ~before_retry
+      ~run_once
+      ()
+  =
+  let max_context_for_retry_runtime runtime_id =
+    let resolution : Keeper_context_runtime.max_context_resolution =
+      max_context_resolution_for_retry_runtime runtime_id
+    in
+    resolution.turn_budget
+  in
+  let rec run_attempt
+      ~runtime_id
+      ~attempted_runtimes
+      ?degraded_retry
+      ~runtime_rotation_attempts
+      ~attempt
+      ~retry_phase_started_at
+      ~is_retry
+      ()
+    =
+    let degraded_retry_runtime =
+      Option.map
+        (fun (retry : Keeper_error_classify.degraded_retry) ->
+           retry.next_runtime)
+        degraded_retry
+    in
+    let fallback_reason =
+      Option.map
+        (fun (retry : Keeper_error_classify.degraded_retry) ->
+           retry.fallback_reason)
+        degraded_retry
+    in
+    let attempt_max_context =
+      if is_retry then max_context_for_retry_runtime runtime_id
+      else initial_max_context
+    in
+    match
+      run_once
+        ~runtime_id
+        ~max_context:attempt_max_context
+        ~is_retry
+        ~degraded_retry_runtime
+        ~fallback_reason
+        ~runtime_rotation_attempts:(List.rev runtime_rotation_attempts)
+    with
+    | Ok result -> Ok (result, attempt_max_context)
+    | Error err as error ->
+      (match
+         next_direct_empty_no_progress_retry_decision
+           ~base_runtime
+           ~effective_runtime:runtime_id
+           ~attempted_runtimes
+           ~estimated_input_tokens
+           ~time_spent_in_turn_s:(timeout_sec -. remaining_turn_budget_s ())
+           ~remaining_turn_budget_s:(remaining_turn_budget_s ())
+           err
+       with
+       | Keeper_turn_runtime_budget.No_degraded_retry ->
+         if Option.is_some (direct_empty_no_progress_retry_reason err) then
+           publish_cascade_resolution
+             ~runtime_id
+             ~decision:Keeper_unified_turn_cascade_resolution.No_degraded_retry
+             ~reason:"terminal_error_no_degraded_retry"
+             ~next_runtime:None
+             ~attempt
+             err;
+         error
+       | Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry ->
+         let reason =
+           Keeper_error_classify.degraded_retry_reason_to_string
+             retry.fallback_reason
+         in
+         publish_cascade_resolution
+           ~runtime_id
+           ~decision:
+             Keeper_unified_turn_cascade_resolution
+             .Degraded_retry_slot_phase_exhausted
+           ~reason
+           ~next_runtime:(Some retry.next_runtime)
+           ~attempt
+           err;
+         Log.Keeper.warn
+           "%s: direct keeper_msg empty response from runtime=%s suggested \
+            retry to %s (reason=%s), but productive slot phase budget %.1fs \
+            is exhausted after %.1fs"
+           keeper_name
+           runtime_id
+           retry.next_runtime
+           reason
+           Keeper_turn_runtime_budget.degraded_retry_slot_phase_budget_sec
+           (timeout_sec -. remaining_turn_budget_s ());
+         error
+       | Keeper_turn_runtime_budget.Degraded_retry_allowed retry ->
+         let retry =
+           if String.trim retry.next_runtime = "" then
+             { retry with next_runtime = runtime_id }
+           else retry
+         in
+         let reason =
+           Keeper_error_classify.degraded_retry_reason_to_string
+             retry.fallback_reason
+         in
+         publish_cascade_resolution
+           ~runtime_id
+           ~decision:Keeper_unified_turn_cascade_resolution.Degraded_retry_allowed
+           ~reason
+           ~next_runtime:(Some retry.next_runtime)
+           ~attempt
+           err;
+         emit_runtime_selected ~runtime_id:retry.next_runtime
+           ~fallback_reason:reason;
+         emit_runtime_rotation ~from_runtime:runtime_id
+           ~to_runtime:retry.next_runtime ~reason;
+         (match validate_retry_runtime retry.next_runtime with
+          | Error fail_open_err ->
+            let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+              current_turn_phase_elapsed_ms retry_phase_started_at
+            in
+            let rotation_attempt =
+              Keeper_unified_turn_rotation_attempt.build
+                ~recorded_at:(now_iso ())
+                ~productive_phase_elapsed_ms
+                ?retry_phase_elapsed_ms
+                ~from_runtime:runtime_id
+                ~retry
+                ~outcome:Keeper_execution_receipt.Rotation_setup_failed
+                fail_open_err
+            in
+            record_retry_setup_failure
+              ~from_runtime:runtime_id
+              ~retry
+              ~rotation_attempt
+              ~fail_open_err;
+            Error fail_open_err
+          | Ok () ->
+            let retry_phase_started_at =
+              match retry_phase_started_at with
+              | Some _ -> retry_phase_started_at
+              | None -> Some (now_s ())
+            in
+            let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
+              current_turn_phase_elapsed_ms retry_phase_started_at
+            in
+            let rotation_attempt =
+              Keeper_unified_turn_rotation_attempt.build
+                ~recorded_at:(now_iso ())
+                ~productive_phase_elapsed_ms
+                ?retry_phase_elapsed_ms
+                ~from_runtime:runtime_id
+                ~retry
+                ~outcome:Keeper_execution_receipt.Rotation_retry_scheduled
+                err
+            in
+            let retry_resolution =
+              max_context_resolution_for_retry_runtime retry.next_runtime
+            in
+            Log.Keeper.warn
+              "%s: direct keeper_msg empty response from runtime=%s; retrying \
+               runtime=%s reason=%s max_context=%d context_budget=%d \
+               primary_budget=%d requested_override=%s"
+              keeper_name
+              runtime_id
+              retry.next_runtime
+              reason
+              retry_resolution.turn_budget
+              retry_resolution.effective_budget
+              retry_resolution.primary_budget
+              (match retry_resolution.requested_override with
+               | Some requested -> string_of_int requested
+               | None -> "none");
+            before_retry ();
+            run_attempt
+              ~runtime_id:retry.next_runtime
+              ~attempted_runtimes:(retry.next_runtime :: attempted_runtimes)
+              ~degraded_retry:retry
+              ~runtime_rotation_attempts:(rotation_attempt :: runtime_rotation_attempts)
+              ~attempt:(attempt + 1)
+              ~retry_phase_started_at
+              ~is_retry:true
+              ()))
+  in
+  run_attempt
+    ~runtime_id:initial_runtime
+    ~attempted_runtimes:[ initial_runtime ]
+    ~runtime_rotation_attempts:[]
+    ~attempt:1
+    ~retry_phase_started_at:None
+    ~is_retry:false
+    ()
 
 module For_testing = struct
   let direct_owner_conversation_context = direct_owner_conversation_context
@@ -247,6 +453,8 @@ module For_testing = struct
     direct_empty_no_progress_retry_reason
   let direct_empty_no_progress_retry_decision =
     next_direct_empty_no_progress_retry_decision
+  let run_direct_empty_no_progress_retry_loop =
+    run_direct_empty_no_progress_retry_loop
 end
 
 let resolve_turn_runtime_id (meta : keeper_meta) =
@@ -570,17 +778,14 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 	            | None -> ());
 	              resolution.turn_budget
 	            in
-	            let max_context_resolution_for_retry_runtime runtime_id =
-	              Provider_runtime_projection.default_execution_model_strings runtime_id
-	              |> Keeper_context_runtime.resolve_max_context_resolution
-	                   ~requested_override:meta.max_context_override
-	            in
-	            let max_context_for_retry_runtime runtime_id =
-	              (max_context_resolution_for_retry_runtime runtime_id).turn_budget
-	            in
-	            let profile_defaults =
-	              Keeper_types_profile.load_keeper_profile_defaults meta.name
-	            in
+		            let max_context_resolution_for_retry_runtime runtime_id =
+		              Provider_runtime_projection.default_execution_model_strings runtime_id
+		              |> Keeper_context_runtime.resolve_max_context_resolution
+		                   ~requested_override:meta.max_context_override
+		            in
+		            let profile_defaults =
+		              Keeper_types_profile.load_keeper_profile_defaults meta.name
+		            in
             let base_dir =
               let root = session_base_dir ctx.config in
               match channel_session_key with
@@ -886,306 +1091,142 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 	                          | Error e -> Error (Agent_sdk.Error.Internal e)
 	                          | Ok () -> Ok ()))
 	                  in
-	                  run_direct_turn_with_fsm
-	                    ~keeper_name:meta.name
-	                    ~turn_id:keeper_turn_id
-	                    (fun () ->
-	                       let rec run_attempt ~runtime_id ~attempted_runtimes
-	                           ?degraded_retry ~runtime_rotation_attempts ~attempt
-	                           ~retry_phase_started_at ~is_retry
-	                           () =
-	                         let degraded_retry_runtime =
-	                           Option.map
-	                             (fun
-                               (retry : Keeper_error_classify.degraded_retry)
-                             -> retry.next_runtime)
-                             degraded_retry
-                         in
-                         let fallback_reason =
-                           Option.map
-                             (fun
-                               (retry : Keeper_error_classify.degraded_retry)
-                             -> retry.fallback_reason)
-                             degraded_retry
-                         in
-                         let attempt_max_context =
-	                           if is_retry
-	                           then max_context_for_retry_runtime runtime_id
-	                           else max_runtime_context
-	                         in
-	                         match
-	                           Keeper_agent_run.run_turn
-	                             ~config:ctx.config ~meta ~turn_ctx_cell ~base_dir
-	                             ~max_context:attempt_max_context
-                             ~build_turn_prompt
-                             ~user_message:message
-                             ?user_blocks
-                             ~runtime_id
-                             ~world_observation
-	                             ~turn_affordances
-	                             (* A kmsg turn is user-triggered, i.e. reactive: it must
-	                                use the reactive idle budget so the graduated idle hook
-	                                (nudge -> final warning -> graceful Skip) can run its
-	                                course before the OAS loop guard aborts the run. *)
-	                             ~max_idle_turns
-	                             ?oas_timeout_s:keeper_msg_oas_timeout_s
-	                             ~generation:meta.runtime.generation
-	                             ?on_event
-                             ~trajectory_acc
-                             ?degraded_retry_runtime
-                             ?fallback_reason
-                             ~runtime_rotation_attempts:
-                               (List.rev runtime_rotation_attempts)
-                             ~is_retry
-	                             ?event_bus
-	                             ()
-	                         with
-	                         | Ok result -> Ok (result, attempt_max_context)
-	                         | Error err as error ->
-	                           (match
-	                              next_direct_empty_no_progress_retry_decision
-	                                ~base_runtime:turn_runtime_id
-	                                ~effective_runtime:runtime_id
-	                                ~attempted_runtimes
-	                                ~estimated_input_tokens:
-	                                  direct_prompt_estimated_input_tokens
-	                                ~time_spent_in_turn_s:
-	                                  (timeout_sec -. remaining_turn_budget_s ())
-	                                ~remaining_turn_budget_s:
-	                                  (remaining_turn_budget_s ())
-	                                err
-	                            with
-	                            | Keeper_turn_runtime_budget.No_degraded_retry ->
-	                              if
-	                                Option.is_some
-	                                  (direct_empty_no_progress_retry_reason err)
-	                              then
-	                                publish_direct_cascade_resolution
-	                                  ~runtime_id
-	                                  ~decision:
-	                                    Keeper_unified_turn_cascade_resolution
-	                                    .No_degraded_retry
-	                                  ~reason:"terminal_error_no_degraded_retry"
-	                                  ~next_runtime:None
-	                                  ~attempt
-	                                  err;
-	                              error
-	                            | Keeper_turn_runtime_budget
-	                              .Degraded_retry_slot_phase_exhausted retry ->
-	                              let reason =
-	                                Keeper_error_classify
-	                                .degraded_retry_reason_to_string
-	                                  retry.fallback_reason
-	                              in
-	                              publish_direct_cascade_resolution
-	                                ~runtime_id
-	                                ~decision:
-	                                  Keeper_unified_turn_cascade_resolution
-	                                  .Degraded_retry_slot_phase_exhausted
-	                                ~reason
-	                                ~next_runtime:(Some retry.next_runtime)
-	                                ~attempt
-	                                err;
-	                              Log.Keeper.warn
-	                                "%s: direct keeper_msg empty response from \
-	                                 runtime=%s suggested retry to %s \
-	                                 (reason=%s), but productive slot phase \
-	                                 budget %.1fs is exhausted after %.1fs"
-	                                meta.name
-	                                runtime_id
-	                                retry.next_runtime
-	                                reason
-	                                Keeper_turn_runtime_budget
-	                                .degraded_retry_slot_phase_budget_sec
-	                                (timeout_sec -. remaining_turn_budget_s ());
-	                              error
-	                            | Keeper_turn_runtime_budget
-	                              .Degraded_retry_allowed retry ->
-	                              let retry =
-	                                if String.trim retry.next_runtime = ""
-	                                then { retry with next_runtime = runtime_id }
-	                                else retry
-	                              in
-	                              let reason =
-	                                Keeper_error_classify
-	                                .degraded_retry_reason_to_string
-	                                  retry.fallback_reason
-	                              in
-	                              publish_direct_cascade_resolution
-	                                ~runtime_id
-	                                ~decision:
-	                                  Keeper_unified_turn_cascade_resolution
-	                                  .Degraded_retry_allowed
-	                                ~reason
-	                                ~next_runtime:(Some retry.next_runtime)
-	                                ~attempt
-	                                err;
-	                              Otel_metric_store.inc_counter
-	                                Keeper_metrics.(to_string RuntimeSelected)
-	                                ~labels:
-	                                  [ ("keeper", meta.name)
-	                                  ; ("runtime_id", retry.next_runtime)
-	                                  ; ("source", "fallback")
-	                                  ; ("fallback_reason", reason)
-	                                  ]
-	                                ();
-	                              Otel_metric_store.inc_counter
-	                                Keeper_metrics.(to_string RuntimeRotation)
-	                                ~labels:
-	                                  [ ("keeper", meta.name)
-	                                  ; ("from_runtime", runtime_id)
-	                                  ; ("to_runtime", retry.next_runtime)
-	                                  ; ("reason", reason)
-	                                  ]
-	                                ();
-	                              (match
-	                                 validate_direct_retry_runtime
-	                                   retry.next_runtime
-	                               with
-	                               | Error fail_open_err ->
-	                                 let
-	                                   productive_phase_elapsed_ms,
-	                                   retry_phase_elapsed_ms
-	                                 =
-	                                   current_turn_phase_elapsed_ms
-	                                     retry_phase_started_at
-	                                 in
-	                                 let rotation_attempt =
-	                                   Keeper_unified_turn_rotation_attempt.build
-	                                     ~recorded_at:(now_iso ())
-	                                     ~productive_phase_elapsed_ms
-	                                     ?retry_phase_elapsed_ms
-	                                     ~from_runtime:runtime_id
-	                                     ~retry
-	                                     ~outcome:
-	                                       Keeper_execution_receipt
-	                                       .Rotation_setup_failed
-	                                     fail_open_err
-	                                 in
-	                                 let _ = rotation_attempt in
-	                                 Log.Keeper.warn
-	                                   "%s: direct keeper_msg empty response \
-	                                    from runtime=%s suggested retry to %s \
-	                                    (reason=%s), but retry setup failed: %s"
-	                                   meta.name
-	                                   runtime_id
-	                                   retry.next_runtime
-	                                   reason
-	                                   (short_preview
-	                                      (Agent_sdk.Error.to_string
-	                                         fail_open_err));
-	                                 Keeper_turn_helpers.record_pre_dispatch_terminal_observation
-	                                   ~config:ctx.config
-	                                   ~meta
-	                                   ~generation:meta.runtime.generation
-	                                   ~runtime_id:retry.next_runtime
-	                                   ~outcome:`Error
-	                                   ~terminal_reason_code:
-	                                     (Printf.sprintf
-	                                        "direct_retry_setup_%s"
-	                                        (Keeper_agent_error
-	                                         .terminal_reason_code_of_sdk_error
-	                                           fail_open_err))
-	                                   ~activity_kind:
-	                                     "direct_empty_no_progress_retry_setup"
-	                                   ~trajectory_outcome:
-	                                     (Trajectory.Failed
-	                                        (Agent_sdk.Error.to_string
-	                                           fail_open_err))
-	                                   ~error_kind:
-	                                     (Keeper_execution_receipt
-	                                      .error_kind_of_string
-	                                        (Keeper_agent_error.sdk_error_kind
-	                                           fail_open_err))
-	                                   ~error_message:
-	                                     (Agent_sdk.Error.to_string
-	                                        fail_open_err)
-	                                   ~degraded_retry_runtime:
-	                                     retry.next_runtime
-	                                   ~fallback_reason:retry.fallback_reason
-	                                   ~runtime_rotation_attempts:
-	                                     [ rotation_attempt ]
-	                                   ~keeper_turn_id
-	                                   ();
-	                                 Error fail_open_err
-	                               | Ok () ->
-	                                 let retry_phase_started_at =
-	                                   match retry_phase_started_at with
-	                                   | Some _ -> retry_phase_started_at
-	                                   | None -> Some (Eio.Time.now clock)
-	                                 in
-	                                 let
-	                                   productive_phase_elapsed_ms,
-	                                   retry_phase_elapsed_ms
-	                                 =
-	                                   current_turn_phase_elapsed_ms
-	                                     retry_phase_started_at
-	                                 in
-	                                 let rotation_attempt =
-	                                   Keeper_unified_turn_rotation_attempt.build
-	                                     ~recorded_at:(now_iso ())
-	                                     ~productive_phase_elapsed_ms
-	                                     ?retry_phase_elapsed_ms
-	                                     ~from_runtime:runtime_id
-	                                     ~retry
-	                                     ~outcome:
-	                                       Keeper_execution_receipt
-	                                       .Rotation_retry_scheduled
-	                                     err
-	                                 in
-	                                 let retry_resolution =
-	                                   max_context_resolution_for_retry_runtime
-	                                     retry.next_runtime
-	                                 in
-	                                 Log.Keeper.warn
-	                                   "%s: direct keeper_msg empty response \
-	                                    from runtime=%s; retrying runtime=%s \
-	                                    reason=%s max_context=%d \
-	                                    context_budget=%d primary_budget=%d \
-	                                    requested_override=%s"
-	                                   meta.name
-	                                   runtime_id
-	                                   retry.next_runtime
-	                                   reason
-	                                   retry_resolution.turn_budget
-	                                   retry_resolution.effective_budget
-	                                   retry_resolution.primary_budget
-	                                   (match
-	                                      retry_resolution.requested_override
-	                                    with
-	                                    | Some requested ->
-	                                      string_of_int requested
-	                                    | None -> "none");
-	                                 (* Empty accept rejection is a response
-	                                    contract miss, not a transient network
-	                                    failure. Keep the existing cooperative
-	                                    yield instead of borrowing provider
-	                                    backoff reserved for transport errors. *)
-	                                 Eio.Fiber.yield ();
-	                                 run_attempt
-	                                   ~runtime_id:retry.next_runtime
-	                                   ~attempted_runtimes:
-	                                     (retry.next_runtime
-	                                      :: attempted_runtimes)
-	                                   ~degraded_retry:retry
-	                                   ~runtime_rotation_attempts:
-	                                     (rotation_attempt
-	                                      :: runtime_rotation_attempts)
-	                                   ~attempt:1
-	                                   ~retry_phase_started_at
-	                                   ~is_retry:true
-	                                   ()))
-	                       in
-	                       run_attempt
-	                         ~runtime_id:turn_runtime_id
-	                         ~attempted_runtimes:[ turn_runtime_id ]
-	                         ~runtime_rotation_attempts:[]
-	                         ~attempt:1
-	                         ~retry_phase_started_at:None
-	                         ~is_retry:false
-	                         ()))
-	            in
-	            match run_result with
+
+		                  run_direct_turn_with_fsm
+		                    ~keeper_name:meta.name
+		                    ~turn_id:keeper_turn_id
+		                    (fun () ->
+		                       run_direct_empty_no_progress_retry_loop
+		                         ~keeper_name:meta.name
+		                         ~base_runtime:turn_runtime_id
+		                         ~initial_runtime:turn_runtime_id
+		                         ~initial_max_context:max_runtime_context
+		                         ~estimated_input_tokens:
+		                           direct_prompt_estimated_input_tokens
+		                         ~timeout_sec
+		                         ~remaining_turn_budget_s
+		                         ~current_turn_phase_elapsed_ms
+		                         ~now_s:(fun () -> Eio.Time.now clock)
+		                         ~max_context_resolution_for_retry_runtime
+		                         ~validate_retry_runtime:validate_direct_retry_runtime
+		                         ~publish_cascade_resolution:
+		                           publish_direct_cascade_resolution
+		                         ~emit_runtime_selected:
+		                           (fun ~runtime_id ~fallback_reason ->
+		                              Otel_metric_store.inc_counter
+		                                Keeper_metrics.(to_string RuntimeSelected)
+		                                ~labels:
+		                                  [ ("keeper", meta.name)
+		                                  ; ("runtime_id", runtime_id)
+		                                  ; ("source", "fallback")
+		                                  ; ("fallback_reason", fallback_reason)
+		                                  ]
+		                                ())
+		                         ~emit_runtime_rotation:
+		                           (fun ~from_runtime ~to_runtime ~reason ->
+		                              Otel_metric_store.inc_counter
+		                                Keeper_metrics.(to_string RuntimeRotation)
+		                                ~labels:
+		                                  [ ("keeper", meta.name)
+		                                  ; ("from_runtime", from_runtime)
+		                                  ; ("to_runtime", to_runtime)
+		                                  ; ("reason", reason)
+		                                  ]
+		                                ())
+		                         ~record_retry_setup_failure:
+		                           (fun ~from_runtime ~retry ~rotation_attempt
+		                                ~fail_open_err ->
+		                              let reason =
+		                                Keeper_error_classify
+		                                .degraded_retry_reason_to_string
+		                                  retry.fallback_reason
+		                              in
+		                              Log.Keeper.warn
+		                                "%s: direct keeper_msg empty response \
+		                                 from runtime=%s suggested retry to %s \
+		                                 (reason=%s), but retry setup failed: %s"
+		                                meta.name
+		                                from_runtime
+		                                retry.next_runtime
+		                                reason
+		                                (short_preview
+		                                   (Agent_sdk.Error.to_string
+		                                      fail_open_err));
+		                              Keeper_turn_helpers.record_pre_dispatch_terminal_observation
+		                                ~config:ctx.config
+		                                ~meta
+		                                ~generation:meta.runtime.generation
+		                                ~runtime_id:retry.next_runtime
+		                                ~outcome:`Error
+		                                ~terminal_reason_code:
+		                                  (Printf.sprintf
+		                                     "direct_retry_setup_%s"
+		                                     (Keeper_agent_error
+		                                      .terminal_reason_code_of_sdk_error
+		                                        fail_open_err))
+		                                ~activity_kind:
+		                                  "direct_empty_no_progress_retry_setup"
+		                                ~trajectory_outcome:
+		                                  (Trajectory.Failed
+		                                     (Agent_sdk.Error.to_string
+		                                        fail_open_err))
+		                                ~error_kind:
+		                                  (Keeper_execution_receipt
+		                                   .error_kind_of_string
+		                                     (Keeper_agent_error.sdk_error_kind
+		                                        fail_open_err))
+		                                ~error_message:
+		                                  (Agent_sdk.Error.to_string fail_open_err)
+		                                ~degraded_retry_runtime:retry.next_runtime
+		                                ~fallback_reason:retry.fallback_reason
+		                                ~runtime_rotation_attempts:
+		                                  [ rotation_attempt ]
+		                                ~keeper_turn_id
+		                                ())
+		                         ~before_retry:
+		                           (fun () ->
+		                              (* Empty accept rejection is a response
+		                                 contract miss, not a transient network
+		                                 failure. Keep the existing cooperative
+		                                 yield instead of borrowing provider
+		                                 backoff reserved for transport errors. *)
+		                              Eio.Fiber.yield ())
+		                         ~run_once:
+		                           (fun ~runtime_id ~max_context ~is_retry
+		                                ~degraded_retry_runtime ~fallback_reason
+		                                ~runtime_rotation_attempts ->
+		                              Keeper_agent_run.run_turn
+		                                ~config:ctx.config
+		                                ~meta
+		                                ~turn_ctx_cell
+		                                ~base_dir
+		                                ~max_context
+		                                ~build_turn_prompt
+		                                ~user_message:message
+		                                ?user_blocks
+		                                ~runtime_id
+		                                ~world_observation
+		                                ~turn_affordances
+		                                (* A kmsg turn is user-triggered, i.e.
+		                                   reactive: it must use the reactive
+		                                   idle budget so the graduated idle hook
+		                                   (nudge -> final warning -> graceful
+		                                   Skip) can run its course before the
+		                                   OAS loop guard aborts the run. *)
+		                                ~max_idle_turns
+		                                ?oas_timeout_s:keeper_msg_oas_timeout_s
+		                                ~generation:meta.runtime.generation
+		                                ?on_event
+		                                ~trajectory_acc
+		                                ?degraded_retry_runtime
+		                                ?fallback_reason
+		                                ~runtime_rotation_attempts
+		                                ~is_retry
+		                                ?event_bus
+		                                ())
+		                         ()))
+		            in
+		            match run_result with
             | Error err ->
               let e_str = Agent_sdk.Error.to_string err in
               let user_message = Keeper_agent_error.user_message_of_sdk_error err in

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -201,45 +201,52 @@ let direct_empty_no_progress_retry_reason err =
     (match Keeper_turn_driver.accept_no_progress_retry_kind internal_error with
      | Some `Empty_no_progress ->
        Some Keeper_error_classify.Empty_no_progress
-     | Some `Read_only_no_progress
-     | None ->
-       None)
+     | _ -> None)
   | None -> None
 
-let next_direct_empty_no_progress_retry ~base_runtime ~effective_runtime
-    ~attempted_runtimes err =
+let retry_reason_is_empty_no_progress
+    (retry : Keeper_error_classify.degraded_retry) =
+  match retry.fallback_reason with
+  | Keeper_error_classify.Empty_no_progress -> true
+  | _ -> false
+
+let next_direct_empty_no_progress_retry_decision
+    ~base_runtime
+    ~effective_runtime
+    ~attempted_runtimes
+    ~estimated_input_tokens
+    ?time_spent_in_turn_s
+    ~remaining_turn_budget_s
+    err =
   match direct_empty_no_progress_retry_reason err with
-  | None -> None
+  | None -> Keeper_turn_runtime_budget.No_degraded_retry
   | Some Keeper_error_classify.Empty_no_progress ->
     (match
-       Keeper_turn_runtime_budget.next_fail_open_runtime_for_turn
-         ~base_runtime ~effective_runtime ~attempted_runtimes err
+       Keeper_turn_runtime_budget.next_fail_open_runtime_for_turn_with_budget
+         ~base_runtime
+         ~effective_runtime
+         ~attempted_runtimes
+         ~estimated_input_tokens
+         ?time_spent_in_turn_s
+         ~remaining_turn_budget_s
+         err
      with
-     | Some retry
-       when retry.Keeper_error_classify.fallback_reason
-            = Keeper_error_classify.Empty_no_progress ->
-       Some retry
-     | Some _ | None -> None)
-  | Some
-      ( Keeper_error_classify.Hard_quota
-      | Keeper_error_classify.Resumable_cli_session
-      | Keeper_error_classify.Admission_queue_timeout
-      | Keeper_error_classify.Provider_timeout
-      | Keeper_error_classify.Turn_timeout
-      | Keeper_error_classify.Runtime_candidates_filtered
-      | Keeper_error_classify.Runtime_exhausted
-      | Keeper_error_classify.Capacity_backpressure
-      | Keeper_error_classify.Rate_limit
-      | Keeper_error_classify.Server_error
-      | Keeper_error_classify.Auth_error
-      | Keeper_error_classify.Read_only_no_progress ) ->
-    None
+     | Keeper_turn_runtime_budget.Degraded_retry_allowed retry
+       when retry_reason_is_empty_no_progress retry ->
+       Keeper_turn_runtime_budget.Degraded_retry_allowed retry
+     | Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
+       when retry_reason_is_empty_no_progress retry ->
+       Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
+     | _ -> Keeper_turn_runtime_budget.No_degraded_retry)
+  | Some _ -> Keeper_turn_runtime_budget.No_degraded_retry
 
 module For_testing = struct
   let direct_owner_conversation_context = direct_owner_conversation_context
   let surface_context_to_instructions = surface_context_to_instructions
   let direct_empty_no_progress_retry_reason =
     direct_empty_no_progress_retry_reason
+  let direct_empty_no_progress_retry_decision =
+    next_direct_empty_no_progress_retry_decision
 end
 
 let resolve_turn_runtime_id (meta : keeper_meta) =
@@ -548,11 +555,11 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
           | Error e ->
             Progress.stop_tracking turn_task_id;
             tool_result_error ("" ^ e)
-          | Ok () ->
-            let max_runtime_context =
-              let resolution =
-                Keeper_context_runtime.resolve_max_context_resolution
-                  ~requested_override:meta.max_context_override effective_models
+	      | Ok () ->
+	            let max_runtime_context =
+	              let resolution =
+	                Keeper_context_runtime.resolve_max_context_resolution
+	                  ~requested_override:meta.max_context_override effective_models
               in
             (match resolution.requested_override with
             | Some requested ->
@@ -560,16 +567,20 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
                 "%s: using max_context_override=%d context_budget=%d primary_budget=%d effective_budget=%d (manual turn)"
                 meta.name requested resolution.turn_budget resolution.primary_budget
                 resolution.effective_budget
-            | None -> ());
-              resolution.turn_budget
-            in
-            let max_context_for_retry_runtime runtime_id =
-              Provider_runtime_projection.default_execution_model_strings runtime_id
-              |> Keeper_context_runtime.resolve_max_context_resolution
-                   ~requested_override:meta.max_context_override
-              |> fun resolution -> resolution.turn_budget
-            in
-            let final_max_runtime_context = ref max_runtime_context in
+	            | None -> ());
+	              resolution.turn_budget
+	            in
+	            let max_context_resolution_for_retry_runtime runtime_id =
+	              Provider_runtime_projection.default_execution_model_strings runtime_id
+	              |> Keeper_context_runtime.resolve_max_context_resolution
+	                   ~requested_override:meta.max_context_override
+	            in
+	            let max_context_for_retry_runtime runtime_id =
+	              (max_context_resolution_for_retry_runtime runtime_id).turn_budget
+	            in
+	            let profile_defaults =
+	              Keeper_types_profile.load_keeper_profile_defaults meta.name
+	            in
             let base_dir =
               let root = session_base_dir ctx.config in
               match channel_session_key with
@@ -809,19 +820,83 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
                 world_observation
             in
             (* RFC-0225 §3.3: per-run carrier for the chat lane. *)
-            let turn_ctx_cell = Keeper_tool_call_log.create_turn_ctx_cell () in
-            let run_result, latency_ms =
-              Keeper_context_runtime.timed (fun () ->
-                  run_direct_turn_with_fsm
-                    ~keeper_name:meta.name
-                    ~turn_id:keeper_turn_id
-                    (fun () ->
-                       let rec run_attempt ~runtime_id ~attempted_runtimes
-                           ?degraded_retry ~runtime_rotation_attempts ~is_retry
-                           () =
-                         let degraded_retry_runtime =
-                           Option.map
-                             (fun
+	            let turn_ctx_cell = Keeper_tool_call_log.create_turn_ctx_cell () in
+	            let direct_prompt_estimated_input_tokens =
+	              max 1 (Agent_sdk.Context_reducer.estimate_char_tokens message)
+	            in
+	            let run_result, latency_ms =
+	              Keeper_context_runtime.timed (fun () ->
+	                  match Eio_context.get_clock () with
+	                  | Error msg -> Error (Agent_sdk.Error.Internal msg)
+	                  | Ok clock ->
+	                  let { Keeper_unified_turn_retry_setup.timeout_sec
+	                      ; remaining_turn_budget_s
+	                      ; current_turn_phase_elapsed_ms
+	                      ; max_idle_turns
+	                      ; _
+	                      }
+	                    =
+	                    Keeper_unified_turn_retry_setup.build
+	                      ~now:(fun () -> Eio.Time.now clock)
+	                      ~keeper_name:meta.name
+	                      ~channel:Keeper_world_observation.Reactive
+	                      ~turn_affordances
+	                  in
+	                  let publish_direct_cascade_resolution
+	                      ~runtime_id
+	                      ~decision
+	                      ~reason
+	                      ~next_runtime
+	                      ~attempt
+	                      err =
+	                    Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
+	                      ~keeper_name:meta.name
+	                      ~runtime_id
+	                      ~decision
+	                      ~reason
+	                      ~next_runtime
+	                      ~attempt
+	                      ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
+	                      ~error_message:(Some (Agent_sdk.Error.to_string err))
+	                  in
+	                  let validate_direct_retry_runtime runtime_id =
+	                    match
+	                      Keeper_unified_turn_pre_dispatch.build_runtime_execution
+	                        ~meta
+	                        ~profile_defaults
+	                        ~runtime_id
+	                    with
+	                    | Error err -> Error err
+	                    | Ok _ ->
+	                      let retry_models =
+	                        Provider_runtime_projection
+	                        .default_execution_model_strings
+	                          runtime_id
+	                      in
+	                      (match
+	                         Keeper_types_support.ensure_api_keys_for_labels
+	                           retry_models
+	                       with
+	                       | Error e -> Error (Agent_sdk.Error.Internal e)
+	                       | Ok () ->
+	                         (match
+	                            Keeper_turn_helpers.ensure_local_discovery_ready
+	                              retry_models
+	                          with
+	                          | Error e -> Error (Agent_sdk.Error.Internal e)
+	                          | Ok () -> Ok ()))
+	                  in
+	                  run_direct_turn_with_fsm
+	                    ~keeper_name:meta.name
+	                    ~turn_id:keeper_turn_id
+	                    (fun () ->
+	                       let rec run_attempt ~runtime_id ~attempted_runtimes
+	                           ?degraded_retry ~runtime_rotation_attempts ~attempt
+	                           ~retry_phase_started_at ~is_retry
+	                           () =
+	                         let degraded_retry_runtime =
+	                           Option.map
+	                             (fun
                                (retry : Keeper_error_classify.degraded_retry)
                              -> retry.next_runtime)
                              degraded_retry
@@ -834,90 +909,283 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
                              degraded_retry
                          in
                          let attempt_max_context =
-                           if is_retry
-                           then max_context_for_retry_runtime runtime_id
-                           else max_runtime_context
-                         in
-                         final_max_runtime_context := attempt_max_context;
-                         match
-                           Keeper_agent_run.run_turn
-                             ~config:ctx.config ~meta ~turn_ctx_cell ~base_dir
-                             ~max_context:attempt_max_context
+	                           if is_retry
+	                           then max_context_for_retry_runtime runtime_id
+	                           else max_runtime_context
+	                         in
+	                         match
+	                           Keeper_agent_run.run_turn
+	                             ~config:ctx.config ~meta ~turn_ctx_cell ~base_dir
+	                             ~max_context:attempt_max_context
                              ~build_turn_prompt
                              ~user_message:message
                              ?user_blocks
                              ~runtime_id
                              ~world_observation
-                             ~turn_affordances
-                             (* A kmsg turn is user-triggered, i.e. reactive: it must
-                                use the reactive idle budget so the graduated idle hook
-                                (nudge -> final warning -> graceful Skip) can run its
-                                course before the OAS loop guard aborts the run. *)
-                             ~max_idle_turns:
-                               (Keeper_runtime_resolved.reactive_max_idle_turns ())
-                             ?oas_timeout_s:keeper_msg_oas_timeout_s
-                             ~generation:meta.runtime.generation
-                             ?on_event
+	                             ~turn_affordances
+	                             (* A kmsg turn is user-triggered, i.e. reactive: it must
+	                                use the reactive idle budget so the graduated idle hook
+	                                (nudge -> final warning -> graceful Skip) can run its
+	                                course before the OAS loop guard aborts the run. *)
+	                             ~max_idle_turns
+	                             ?oas_timeout_s:keeper_msg_oas_timeout_s
+	                             ~generation:meta.runtime.generation
+	                             ?on_event
                              ~trajectory_acc
                              ?degraded_retry_runtime
                              ?fallback_reason
                              ~runtime_rotation_attempts:
                                (List.rev runtime_rotation_attempts)
                              ~is_retry
-                             ?event_bus
-                             ()
-                         with
-                         | Ok _ as ok -> ok
-                         | Error err as error ->
-                           (match
-                              next_direct_empty_no_progress_retry
-                                ~base_runtime:turn_runtime_id
-                                ~effective_runtime:runtime_id
-                                ~attempted_runtimes
-                                err
-                            with
-                            | None -> error
-                            | Some retry ->
-                              let rotation_attempt =
-                                Keeper_unified_turn_rotation_attempt.build
-                                  ~recorded_at:(now_iso ())
-                                  ~from_runtime:runtime_id
-                                  ~retry
-                                  ~outcome:
-                                    Keeper_execution_receipt.Rotation_retry_scheduled
-                                  err
-                              in
-                              let reason =
-                                Keeper_error_classify.degraded_retry_reason_to_string
-                                  retry.fallback_reason
-                              in
-                              Log.Keeper.warn
-                                "%s: direct keeper_msg empty response from \
-                                 runtime=%s; retrying runtime=%s reason=%s"
-                                meta.name
-                                runtime_id
-                                retry.next_runtime
-                                reason;
-                              Eio.Fiber.yield ();
-                              run_attempt
-                                ~runtime_id:retry.next_runtime
-                                ~attempted_runtimes:
-                                  (retry.next_runtime :: attempted_runtimes)
-                                ~degraded_retry:retry
-                                ~runtime_rotation_attempts:
-                                  (rotation_attempt
-                                   :: runtime_rotation_attempts)
-                                ~is_retry:true
-                                ())
-                       in
-                       run_attempt
-                         ~runtime_id:turn_runtime_id
-                         ~attempted_runtimes:[ turn_runtime_id ]
-                         ~runtime_rotation_attempts:[]
-                         ~is_retry:false
-                         ()))
-            in
-            match run_result with
+	                             ?event_bus
+	                             ()
+	                         with
+	                         | Ok result -> Ok (result, attempt_max_context)
+	                         | Error err as error ->
+	                           (match
+	                              next_direct_empty_no_progress_retry_decision
+	                                ~base_runtime:turn_runtime_id
+	                                ~effective_runtime:runtime_id
+	                                ~attempted_runtimes
+	                                ~estimated_input_tokens:
+	                                  direct_prompt_estimated_input_tokens
+	                                ~time_spent_in_turn_s:
+	                                  (timeout_sec -. remaining_turn_budget_s ())
+	                                ~remaining_turn_budget_s:
+	                                  (remaining_turn_budget_s ())
+	                                err
+	                            with
+	                            | Keeper_turn_runtime_budget.No_degraded_retry ->
+	                              if
+	                                Option.is_some
+	                                  (direct_empty_no_progress_retry_reason err)
+	                              then
+	                                publish_direct_cascade_resolution
+	                                  ~runtime_id
+	                                  ~decision:
+	                                    Keeper_unified_turn_cascade_resolution
+	                                    .No_degraded_retry
+	                                  ~reason:"terminal_error_no_degraded_retry"
+	                                  ~next_runtime:None
+	                                  ~attempt
+	                                  err;
+	                              error
+	                            | Keeper_turn_runtime_budget
+	                              .Degraded_retry_slot_phase_exhausted retry ->
+	                              let reason =
+	                                Keeper_error_classify
+	                                .degraded_retry_reason_to_string
+	                                  retry.fallback_reason
+	                              in
+	                              publish_direct_cascade_resolution
+	                                ~runtime_id
+	                                ~decision:
+	                                  Keeper_unified_turn_cascade_resolution
+	                                  .Degraded_retry_slot_phase_exhausted
+	                                ~reason
+	                                ~next_runtime:(Some retry.next_runtime)
+	                                ~attempt
+	                                err;
+	                              Log.Keeper.warn
+	                                "%s: direct keeper_msg empty response from \
+	                                 runtime=%s suggested retry to %s \
+	                                 (reason=%s), but productive slot phase \
+	                                 budget %.1fs is exhausted after %.1fs"
+	                                meta.name
+	                                runtime_id
+	                                retry.next_runtime
+	                                reason
+	                                Keeper_turn_runtime_budget
+	                                .degraded_retry_slot_phase_budget_sec
+	                                (timeout_sec -. remaining_turn_budget_s ());
+	                              error
+	                            | Keeper_turn_runtime_budget
+	                              .Degraded_retry_allowed retry ->
+	                              let retry =
+	                                if String.trim retry.next_runtime = ""
+	                                then { retry with next_runtime = runtime_id }
+	                                else retry
+	                              in
+	                              let reason =
+	                                Keeper_error_classify
+	                                .degraded_retry_reason_to_string
+	                                  retry.fallback_reason
+	                              in
+	                              publish_direct_cascade_resolution
+	                                ~runtime_id
+	                                ~decision:
+	                                  Keeper_unified_turn_cascade_resolution
+	                                  .Degraded_retry_allowed
+	                                ~reason
+	                                ~next_runtime:(Some retry.next_runtime)
+	                                ~attempt
+	                                err;
+	                              Otel_metric_store.inc_counter
+	                                Keeper_metrics.(to_string RuntimeSelected)
+	                                ~labels:
+	                                  [ ("keeper", meta.name)
+	                                  ; ("runtime_id", retry.next_runtime)
+	                                  ; ("source", "fallback")
+	                                  ; ("fallback_reason", reason)
+	                                  ]
+	                                ();
+	                              Otel_metric_store.inc_counter
+	                                Keeper_metrics.(to_string RuntimeRotation)
+	                                ~labels:
+	                                  [ ("keeper", meta.name)
+	                                  ; ("from_runtime", runtime_id)
+	                                  ; ("to_runtime", retry.next_runtime)
+	                                  ; ("reason", reason)
+	                                  ]
+	                                ();
+	                              (match
+	                                 validate_direct_retry_runtime
+	                                   retry.next_runtime
+	                               with
+	                               | Error fail_open_err ->
+	                                 let
+	                                   productive_phase_elapsed_ms,
+	                                   retry_phase_elapsed_ms
+	                                 =
+	                                   current_turn_phase_elapsed_ms
+	                                     retry_phase_started_at
+	                                 in
+	                                 let rotation_attempt =
+	                                   Keeper_unified_turn_rotation_attempt.build
+	                                     ~recorded_at:(now_iso ())
+	                                     ~productive_phase_elapsed_ms
+	                                     ?retry_phase_elapsed_ms
+	                                     ~from_runtime:runtime_id
+	                                     ~retry
+	                                     ~outcome:
+	                                       Keeper_execution_receipt
+	                                       .Rotation_setup_failed
+	                                     fail_open_err
+	                                 in
+	                                 let _ = rotation_attempt in
+	                                 Log.Keeper.warn
+	                                   "%s: direct keeper_msg empty response \
+	                                    from runtime=%s suggested retry to %s \
+	                                    (reason=%s), but retry setup failed: %s"
+	                                   meta.name
+	                                   runtime_id
+	                                   retry.next_runtime
+	                                   reason
+	                                   (short_preview
+	                                      (Agent_sdk.Error.to_string
+	                                         fail_open_err));
+	                                 Keeper_turn_helpers.record_pre_dispatch_terminal_observation
+	                                   ~config:ctx.config
+	                                   ~meta
+	                                   ~generation:meta.runtime.generation
+	                                   ~runtime_id:retry.next_runtime
+	                                   ~outcome:`Error
+	                                   ~terminal_reason_code:
+	                                     (Printf.sprintf
+	                                        "direct_retry_setup_%s"
+	                                        (Keeper_agent_error
+	                                         .terminal_reason_code_of_sdk_error
+	                                           fail_open_err))
+	                                   ~activity_kind:
+	                                     "direct_empty_no_progress_retry_setup"
+	                                   ~trajectory_outcome:
+	                                     (Trajectory.Failed
+	                                        (Agent_sdk.Error.to_string
+	                                           fail_open_err))
+	                                   ~error_kind:
+	                                     (Keeper_execution_receipt
+	                                      .error_kind_of_string
+	                                        (Keeper_agent_error.sdk_error_kind
+	                                           fail_open_err))
+	                                   ~error_message:
+	                                     (Agent_sdk.Error.to_string
+	                                        fail_open_err)
+	                                   ~degraded_retry_runtime:
+	                                     retry.next_runtime
+	                                   ~fallback_reason:retry.fallback_reason
+	                                   ~runtime_rotation_attempts:
+	                                     [ rotation_attempt ]
+	                                   ~keeper_turn_id
+	                                   ();
+	                                 Error fail_open_err
+	                               | Ok () ->
+	                                 let retry_phase_started_at =
+	                                   match retry_phase_started_at with
+	                                   | Some _ -> retry_phase_started_at
+	                                   | None -> Some (Eio.Time.now clock)
+	                                 in
+	                                 let
+	                                   productive_phase_elapsed_ms,
+	                                   retry_phase_elapsed_ms
+	                                 =
+	                                   current_turn_phase_elapsed_ms
+	                                     retry_phase_started_at
+	                                 in
+	                                 let rotation_attempt =
+	                                   Keeper_unified_turn_rotation_attempt.build
+	                                     ~recorded_at:(now_iso ())
+	                                     ~productive_phase_elapsed_ms
+	                                     ?retry_phase_elapsed_ms
+	                                     ~from_runtime:runtime_id
+	                                     ~retry
+	                                     ~outcome:
+	                                       Keeper_execution_receipt
+	                                       .Rotation_retry_scheduled
+	                                     err
+	                                 in
+	                                 let retry_resolution =
+	                                   max_context_resolution_for_retry_runtime
+	                                     retry.next_runtime
+	                                 in
+	                                 Log.Keeper.warn
+	                                   "%s: direct keeper_msg empty response \
+	                                    from runtime=%s; retrying runtime=%s \
+	                                    reason=%s max_context=%d \
+	                                    context_budget=%d primary_budget=%d \
+	                                    requested_override=%s"
+	                                   meta.name
+	                                   runtime_id
+	                                   retry.next_runtime
+	                                   reason
+	                                   retry_resolution.turn_budget
+	                                   retry_resolution.effective_budget
+	                                   retry_resolution.primary_budget
+	                                   (match
+	                                      retry_resolution.requested_override
+	                                    with
+	                                    | Some requested ->
+	                                      string_of_int requested
+	                                    | None -> "none");
+	                                 (* Empty accept rejection is a response
+	                                    contract miss, not a transient network
+	                                    failure. Keep the existing cooperative
+	                                    yield instead of borrowing provider
+	                                    backoff reserved for transport errors. *)
+	                                 Eio.Fiber.yield ();
+	                                 run_attempt
+	                                   ~runtime_id:retry.next_runtime
+	                                   ~attempted_runtimes:
+	                                     (retry.next_runtime
+	                                      :: attempted_runtimes)
+	                                   ~degraded_retry:retry
+	                                   ~runtime_rotation_attempts:
+	                                     (rotation_attempt
+	                                      :: runtime_rotation_attempts)
+	                                   ~attempt:1
+	                                   ~retry_phase_started_at
+	                                   ~is_retry:true
+	                                   ()))
+	                       in
+	                       run_attempt
+	                         ~runtime_id:turn_runtime_id
+	                         ~attempted_runtimes:[ turn_runtime_id ]
+	                         ~runtime_rotation_attempts:[]
+	                         ~attempt:1
+	                         ~retry_phase_started_at:None
+	                         ~is_retry:false
+	                         ()))
+	            in
+	            match run_result with
             | Error err ->
               let e_str = Agent_sdk.Error.to_string err in
               let user_message = Keeper_agent_error.user_message_of_sdk_error err in
@@ -930,7 +1198,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
               start_keepalive ctx meta;
               Progress.stop_tracking turn_task_id;
               tool_result_error user_message
-            | Ok result ->
+	            | Ok (result, final_max_runtime_context) ->
               (try
                  let _ = Trajectory.finalize trajectory_acc
                    Trajectory.Completed in
@@ -960,9 +1228,9 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
                       ~origin:Keeper_registry.Post_turn_lifecycle
                       ~keeper_name:meta.name
                       Keeper_state_machine.Handoff_started)
-                  ~meta
-                  ~model:result.model_used
-                  ~primary_model_max_tokens:!final_max_runtime_context
+	                  ~meta
+	                  ~model:result.model_used
+	                  ~primary_model_max_tokens:final_max_runtime_context
                   ~current_turn_blocker_info:None
                   ~checkpoint:result.checkpoint
                 |> resilience_handles.sync_lifecycle_meta

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -195,9 +195,51 @@ let surface_context_to_instructions (ctx : Yojson.Safe.t) : string option =
         (Printf.sprintf "[Co-view context]\n%s"
            (Yojson.Safe.pretty_to_string json))
 
+let direct_empty_no_progress_retry_reason err =
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some internal_error ->
+    (match Keeper_turn_driver.accept_no_progress_retry_kind internal_error with
+     | Some `Empty_no_progress ->
+       Some Keeper_error_classify.Empty_no_progress
+     | Some `Read_only_no_progress
+     | None ->
+       None)
+  | None -> None
+
+let next_direct_empty_no_progress_retry ~base_runtime ~effective_runtime
+    ~attempted_runtimes err =
+  match direct_empty_no_progress_retry_reason err with
+  | None -> None
+  | Some Keeper_error_classify.Empty_no_progress ->
+    (match
+       Keeper_turn_runtime_budget.next_fail_open_runtime_for_turn
+         ~base_runtime ~effective_runtime ~attempted_runtimes err
+     with
+     | Some retry
+       when retry.Keeper_error_classify.fallback_reason
+            = Keeper_error_classify.Empty_no_progress ->
+       Some retry
+     | Some _ | None -> None)
+  | Some
+      ( Keeper_error_classify.Hard_quota
+      | Keeper_error_classify.Resumable_cli_session
+      | Keeper_error_classify.Admission_queue_timeout
+      | Keeper_error_classify.Provider_timeout
+      | Keeper_error_classify.Turn_timeout
+      | Keeper_error_classify.Runtime_candidates_filtered
+      | Keeper_error_classify.Runtime_exhausted
+      | Keeper_error_classify.Capacity_backpressure
+      | Keeper_error_classify.Rate_limit
+      | Keeper_error_classify.Server_error
+      | Keeper_error_classify.Auth_error
+      | Keeper_error_classify.Read_only_no_progress ) ->
+    None
+
 module For_testing = struct
   let direct_owner_conversation_context = direct_owner_conversation_context
   let surface_context_to_instructions = surface_context_to_instructions
+  let direct_empty_no_progress_retry_reason =
+    direct_empty_no_progress_retry_reason
 end
 
 let resolve_turn_runtime_id (meta : keeper_meta) =
@@ -491,8 +533,8 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
       let effective_models =
         if direct_reply then
           Provider_runtime_projection.default_execution_model_strings
-            (               (turn_runtime_id))
-              else
+            turn_runtime_id
+        else
           effective_model_labels_for_turn meta
       in
       Progress.Tracker.step turn_tracker ~message:"Validating API keys" ();
@@ -507,11 +549,11 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
             Progress.stop_tracking turn_task_id;
             tool_result_error ("" ^ e)
           | Ok () ->
-         let max_runtime_context =
-           let resolution =
-             Keeper_context_runtime.resolve_max_context_resolution
-               ~requested_override:meta.max_context_override effective_models
-           in
+            let max_runtime_context =
+              let resolution =
+                Keeper_context_runtime.resolve_max_context_resolution
+                  ~requested_override:meta.max_context_override effective_models
+              in
             (match resolution.requested_override with
             | Some requested ->
               Log.Keeper.debug
@@ -519,8 +561,15 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
                 meta.name requested resolution.turn_budget resolution.primary_budget
                 resolution.effective_budget
             | None -> ());
-           resolution.turn_budget
-         in
+              resolution.turn_budget
+            in
+            let max_context_for_retry_runtime runtime_id =
+              Provider_runtime_projection.default_execution_model_strings runtime_id
+              |> Keeper_context_runtime.resolve_max_context_resolution
+                   ~requested_override:meta.max_context_override
+              |> fun resolution -> resolution.turn_budget
+            in
+            let final_max_runtime_context = ref max_runtime_context in
             let base_dir =
               let root = session_base_dir ctx.config in
               match channel_session_key with
@@ -767,27 +816,105 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
                     ~keeper_name:meta.name
                     ~turn_id:keeper_turn_id
                     (fun () ->
-                       Keeper_agent_run.run_turn
-                         ~config:ctx.config ~meta ~turn_ctx_cell ~base_dir
-                         ~max_context:max_runtime_context
-                         ~build_turn_prompt
-                         ~user_message:message
-                         ?user_blocks
-                         ~runtime_id:
-                           (                         (turn_runtime_id))
-                         ~world_observation
-                         ~turn_affordances
-                         (* A kmsg turn is user-triggered, i.e. reactive: it must
-                            use the reactive idle budget so the graduated idle hook
-                            (nudge -> final warning -> graceful Skip) can run its
-                            course before the OAS loop guard aborts the run. *)
-                         ~max_idle_turns:
-                           (Keeper_runtime_resolved.reactive_max_idle_turns ())
-                         ?oas_timeout_s:keeper_msg_oas_timeout_s
-                         ~generation:meta.runtime.generation
-                         ?on_event
-                         ~trajectory_acc
-                         ?event_bus
+                       let rec run_attempt ~runtime_id ~attempted_runtimes
+                           ?degraded_retry ~runtime_rotation_attempts ~is_retry
+                           () =
+                         let degraded_retry_runtime =
+                           Option.map
+                             (fun
+                               (retry : Keeper_error_classify.degraded_retry)
+                             -> retry.next_runtime)
+                             degraded_retry
+                         in
+                         let fallback_reason =
+                           Option.map
+                             (fun
+                               (retry : Keeper_error_classify.degraded_retry)
+                             -> retry.fallback_reason)
+                             degraded_retry
+                         in
+                         let attempt_max_context =
+                           if is_retry
+                           then max_context_for_retry_runtime runtime_id
+                           else max_runtime_context
+                         in
+                         final_max_runtime_context := attempt_max_context;
+                         match
+                           Keeper_agent_run.run_turn
+                             ~config:ctx.config ~meta ~turn_ctx_cell ~base_dir
+                             ~max_context:attempt_max_context
+                             ~build_turn_prompt
+                             ~user_message:message
+                             ?user_blocks
+                             ~runtime_id
+                             ~world_observation
+                             ~turn_affordances
+                             (* A kmsg turn is user-triggered, i.e. reactive: it must
+                                use the reactive idle budget so the graduated idle hook
+                                (nudge -> final warning -> graceful Skip) can run its
+                                course before the OAS loop guard aborts the run. *)
+                             ~max_idle_turns:
+                               (Keeper_runtime_resolved.reactive_max_idle_turns ())
+                             ?oas_timeout_s:keeper_msg_oas_timeout_s
+                             ~generation:meta.runtime.generation
+                             ?on_event
+                             ~trajectory_acc
+                             ?degraded_retry_runtime
+                             ?fallback_reason
+                             ~runtime_rotation_attempts:
+                               (List.rev runtime_rotation_attempts)
+                             ~is_retry
+                             ?event_bus
+                             ()
+                         with
+                         | Ok _ as ok -> ok
+                         | Error err as error ->
+                           (match
+                              next_direct_empty_no_progress_retry
+                                ~base_runtime:turn_runtime_id
+                                ~effective_runtime:runtime_id
+                                ~attempted_runtimes
+                                err
+                            with
+                            | None -> error
+                            | Some retry ->
+                              let rotation_attempt =
+                                Keeper_unified_turn_rotation_attempt.build
+                                  ~recorded_at:(now_iso ())
+                                  ~from_runtime:runtime_id
+                                  ~retry
+                                  ~outcome:
+                                    Keeper_execution_receipt.Rotation_retry_scheduled
+                                  err
+                              in
+                              let reason =
+                                Keeper_error_classify.degraded_retry_reason_to_string
+                                  retry.fallback_reason
+                              in
+                              Log.Keeper.warn
+                                "%s: direct keeper_msg empty response from \
+                                 runtime=%s; retrying runtime=%s reason=%s"
+                                meta.name
+                                runtime_id
+                                retry.next_runtime
+                                reason;
+                              Eio.Fiber.yield ();
+                              run_attempt
+                                ~runtime_id:retry.next_runtime
+                                ~attempted_runtimes:
+                                  (retry.next_runtime :: attempted_runtimes)
+                                ~degraded_retry:retry
+                                ~runtime_rotation_attempts:
+                                  (rotation_attempt
+                                   :: runtime_rotation_attempts)
+                                ~is_retry:true
+                                ())
+                       in
+                       run_attempt
+                         ~runtime_id:turn_runtime_id
+                         ~attempted_runtimes:[ turn_runtime_id ]
+                         ~runtime_rotation_attempts:[]
+                         ~is_retry:false
                          ()))
             in
             match run_result with
@@ -835,7 +962,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
                       Keeper_state_machine.Handoff_started)
                   ~meta
                   ~model:result.model_used
-                  ~primary_model_max_tokens:max_runtime_context
+                  ~primary_model_max_tokens:!final_max_runtime_context
                   ~current_turn_blocker_info:None
                   ~checkpoint:result.checkpoint
                 |> resilience_handles.sync_lifecycle_meta

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -250,7 +250,10 @@ let run_direct_empty_no_progress_retry_loop
       ~remaining_turn_budget_s
       ~current_turn_phase_elapsed_ms
       ~now_s
-      ~setup_retry_runtime
+      ~(setup_retry_runtime :
+         string ->
+         (Keeper_turn_runtime_budget.runtime_execution, Agent_sdk.Error.sdk_error)
+         result)
       ~publish_cascade_resolution
       ~emit_runtime_selected
       ~emit_runtime_rotation
@@ -1014,17 +1017,50 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
             in
             (* RFC-0225 §3.3: per-run carrier for the chat lane. *)
 	            let turn_ctx_cell = Keeper_tool_call_log.create_turn_ctx_cell () in
+	            let direct_history_messages =
+	              let (_session, ctx_opt) =
+	                Keeper_context_runtime.load_context_from_checkpoint
+	                  ~max_checkpoint_messages:
+	                    meta.compaction.max_checkpoint_messages
+	                  ~trace_id:
+	                    (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+	                  ~primary_model_max_tokens:max_runtime_context
+	                  ~base_dir
+	              in
+	              match ctx_opt with
+	              | None -> []
+	              | Some ctx ->
+	                Keeper_context_runtime.messages_of_context ctx
+	                |> Keeper_context_core.repair_broken_tool_call_pairs
+	            in
 	            let direct_prompt_for_estimate =
-	              build_turn_prompt ~base_system_prompt ~messages:[]
+	              build_turn_prompt
+	                ~base_system_prompt
+	                ~messages:direct_history_messages
+	            in
+	            let direct_dynamic_context =
+	              Keeper_run_prompt.dynamic_context_with_recent_failures
+	                ~keeper_name:meta.name
+	                direct_prompt_for_estimate.dynamic_context
+	            in
+	            let direct_user_message_for_estimate =
+	              Keeper_run_prompt.sanitize_user_message message
 	            in
 	            let direct_prompt_metrics =
 	              Keeper_agent_run.build_prompt_metrics
 	                ~system_prompt:direct_prompt_for_estimate.system_prompt
-	                ~dynamic_context:direct_prompt_for_estimate.dynamic_context
-	                ~user_message:message
+	                ~dynamic_context:direct_dynamic_context
+	                ~user_message:direct_user_message_for_estimate
 	            in
 	            let direct_prompt_estimated_input_tokens =
-	              max 1 direct_prompt_metrics.estimated_total_tokens
+	              Keeper_run_prompt.estimate_input_tokens
+	                ~prompt_metrics:direct_prompt_metrics
+	                ~system_prompt:direct_prompt_for_estimate.system_prompt
+	                ~dynamic_context:direct_dynamic_context
+	                ~memory_context:""
+	                ~temporal_context:""
+	                ~user_message:direct_user_message_for_estimate
+	                ~history_messages:direct_history_messages
 	            in
 	            let run_result, latency_ms =
 	              Keeper_context_runtime.timed (fun () ->
@@ -1151,6 +1187,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 		                                     fail_open_err)
 		                                ~error_message:
 		                                  (Agent_sdk.Error.to_string fail_open_err)
+		                                ~degraded_retry_applied:true
 		                                ~degraded_retry_runtime:retry.next_runtime
 		                                ~fallback_reason:retry.fallback_reason
 		                                ~runtime_rotation_attempts:

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -250,8 +250,7 @@ let run_direct_empty_no_progress_retry_loop
       ~remaining_turn_budget_s
       ~current_turn_phase_elapsed_ms
       ~now_s
-      ~max_context_resolution_for_retry_runtime
-      ~validate_retry_runtime
+      ~setup_retry_runtime
       ~publish_cascade_resolution
       ~emit_runtime_selected
       ~emit_runtime_rotation
@@ -260,14 +259,9 @@ let run_direct_empty_no_progress_retry_loop
       ~run_once
       ()
   =
-  let max_context_for_retry_runtime runtime_id =
-    let resolution : Keeper_context_runtime.max_context_resolution =
-      max_context_resolution_for_retry_runtime runtime_id
-    in
-    resolution.turn_budget
-  in
   let rec run_attempt
       ~runtime_id
+      ?runtime_execution
       ~attempted_runtimes
       ?degraded_retry
       ~runtime_rotation_attempts
@@ -289,8 +283,9 @@ let run_direct_empty_no_progress_retry_loop
         degraded_retry
     in
     let attempt_max_context =
-      if is_retry then max_context_for_retry_runtime runtime_id
-      else initial_max_context
+      match runtime_execution with
+      | Some execution -> execution.Keeper_turn_runtime_budget.max_context
+      | None -> initial_max_context
     in
     match
       run_once
@@ -314,14 +309,21 @@ let run_direct_empty_no_progress_retry_loop
            err
        with
        | Keeper_turn_runtime_budget.No_degraded_retry ->
-         if Option.is_some (direct_empty_no_progress_retry_reason err) then
-           publish_cascade_resolution
-             ~runtime_id
-             ~decision:Keeper_unified_turn_cascade_resolution.No_degraded_retry
-             ~reason:"terminal_error_no_degraded_retry"
-             ~next_runtime:None
-             ~attempt
-             err;
+         let reason =
+           match direct_empty_no_progress_retry_reason err with
+           | Some retry_reason ->
+             Printf.sprintf
+               "terminal_%s_no_degraded_retry"
+               (Keeper_error_classify.degraded_retry_reason_to_string retry_reason)
+           | None -> "terminal_error_not_degraded_retry_eligible"
+         in
+         publish_cascade_resolution
+           ~runtime_id
+           ~decision:Keeper_unified_turn_cascade_resolution.No_degraded_retry
+           ~reason
+           ~next_runtime:None
+           ~attempt
+           err;
          error
        | Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry ->
          let reason =
@@ -358,7 +360,7 @@ let run_direct_empty_no_progress_retry_loop
               ~publish_cascade_resolution
               ~emit_runtime_selected
               ~emit_runtime_rotation
-              ~setup_runtime:validate_retry_runtime
+              ~setup_runtime:setup_retry_runtime
           with
           | Keeper_turn_runtime_budget.Degraded_retry_setup_failed
               { retry; fail_open_err; _ } ->
@@ -382,7 +384,7 @@ let run_direct_empty_no_progress_retry_loop
               ~fail_open_err;
             Error fail_open_err
           | Keeper_turn_runtime_budget.Degraded_retry_prepared
-              { retry; reason; next = () } ->
+              { retry; reason; next = next_execution } ->
             let retry_phase_started_at =
               match retry_phase_started_at with
               | Some _ -> retry_phase_started_at
@@ -401,18 +403,16 @@ let run_direct_empty_no_progress_retry_loop
                 ~outcome:Keeper_execution_receipt.Rotation_retry_scheduled
                 err
             in
-            let retry_resolution =
-              max_context_resolution_for_retry_runtime retry.next_runtime
-            in
+            let retry_resolution = next_execution.max_context_resolution in
             Log.Keeper.warn
               "%s: direct keeper_msg empty response from runtime=%s; retrying \
                runtime=%s reason=%s max_context=%d context_budget=%d \
                primary_budget=%d requested_override=%s"
               keeper_name
               runtime_id
-              retry.next_runtime
+              next_execution.runtime_id
               reason
-              retry_resolution.turn_budget
+              next_execution.max_context
               retry_resolution.effective_budget
               retry_resolution.primary_budget
               (match retry_resolution.requested_override with
@@ -420,11 +420,12 @@ let run_direct_empty_no_progress_retry_loop
                | None -> "none");
             before_retry ();
             run_attempt
-              ~runtime_id:retry.next_runtime
-              ~attempted_runtimes:(retry.next_runtime :: attempted_runtimes)
+              ~runtime_id:next_execution.runtime_id
+              ~runtime_execution:next_execution
+              ~attempted_runtimes:(next_execution.runtime_id :: attempted_runtimes)
               ~degraded_retry:retry
               ~runtime_rotation_attempts:(rotation_attempt :: runtime_rotation_attempts)
-              ~attempt:(attempt + 1)
+              ~attempt:1
               ~retry_phase_started_at
               ~is_retry:true
               ()))
@@ -770,11 +771,6 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 	            | None -> ());
 	              resolution.turn_budget
 	            in
-		            let max_context_resolution_for_retry_runtime runtime_id =
-		              Provider_runtime_projection.default_execution_model_strings runtime_id
-		              |> Keeper_context_runtime.resolve_max_context_resolution
-		                   ~requested_override:meta.max_context_override
-		            in
 		            let profile_defaults =
 		              Keeper_types_profile.load_keeper_profile_defaults meta.name
 		            in
@@ -1019,7 +1015,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
             (* RFC-0225 §3.3: per-run carrier for the chat lane. *)
 	            let turn_ctx_cell = Keeper_tool_call_log.create_turn_ctx_cell () in
 	            let direct_prompt_for_estimate =
-	              build_turn_prompt ~base_system_prompt:"" ~messages:[]
+	              build_turn_prompt ~base_system_prompt ~messages:[]
 	            in
 	            let direct_prompt_metrics =
 	              Keeper_agent_run.build_prompt_metrics
@@ -1065,32 +1061,11 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 	                      ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
 	                      ~error_message:(Some (Agent_sdk.Error.to_string err))
 	                  in
-	                  let validate_direct_retry_runtime runtime_id =
-	                    match
-	                      Keeper_unified_turn_pre_dispatch.build_runtime_execution
-	                        ~meta
-	                        ~profile_defaults
-	                        ~runtime_id
-	                    with
-	                    | Error err -> Error err
-	                    | Ok _ ->
-	                      let retry_models =
-	                        Provider_runtime_projection
-	                        .default_execution_model_strings
-	                          runtime_id
-	                      in
-	                      (match
-	                         Keeper_types_support.ensure_api_keys_for_labels
-	                           retry_models
-	                       with
-	                       | Error e -> Error (Agent_sdk.Error.Internal e)
-	                       | Ok () ->
-	                         (match
-	                            Keeper_turn_helpers.ensure_local_discovery_ready
-	                              retry_models
-	                          with
-	                          | Error e -> Error (Agent_sdk.Error.Internal e)
-	                          | Ok () -> Ok ()))
+	                  let setup_direct_retry_runtime runtime_id =
+	                    Keeper_unified_turn_pre_dispatch.build_runtime_execution
+	                      ~meta
+	                      ~profile_defaults
+	                      ~runtime_id
 	                  in
 
 		                  run_direct_turn_with_fsm
@@ -1108,8 +1083,7 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 		                         ~remaining_turn_budget_s
 		                         ~current_turn_phase_elapsed_ms
 		                         ~now_s:(fun () -> Eio.Time.now clock)
-		                         ~max_context_resolution_for_retry_runtime
-		                         ~validate_retry_runtime:validate_direct_retry_runtime
+		                         ~setup_retry_runtime:setup_direct_retry_runtime
 		                         ~publish_cascade_resolution:
 		                           publish_direct_cascade_resolution
 		                         ~emit_runtime_selected:

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -1033,9 +1033,15 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 	                Keeper_context_runtime.messages_of_context ctx
 	                |> Keeper_context_core.repair_broken_tool_call_pairs
 	            in
+	            let direct_base_system_prompt =
+	              Keeper_run_context.build_base_system_prompt
+	                ~config:ctx.config
+	                ~profile_defaults
+	                ~meta
+	            in
 	            let direct_prompt_for_estimate =
 	              build_turn_prompt
-	                ~base_system_prompt
+	                ~base_system_prompt:direct_base_system_prompt
 	                ~messages:direct_history_messages
 	            in
 	            let direct_dynamic_context =

--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -233,12 +233,12 @@ let next_direct_empty_no_progress_retry_decision
      with
      | Keeper_turn_runtime_budget.Degraded_retry_allowed retry
        when retry_reason_is_empty_no_progress retry ->
-	       Keeper_turn_runtime_budget.Degraded_retry_allowed retry
-	     | Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
-	       when retry_reason_is_empty_no_progress retry ->
-	       Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
-	     | _ -> Keeper_turn_runtime_budget.No_degraded_retry)
-	  | Some _ -> Keeper_turn_runtime_budget.No_degraded_retry
+       Keeper_turn_runtime_budget.Degraded_retry_allowed retry
+     | Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
+       when retry_reason_is_empty_no_progress retry ->
+       Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
+     | _ -> Keeper_turn_runtime_budget.No_degraded_retry)
+  | _ -> Keeper_turn_runtime_budget.No_degraded_retry
 
 let run_direct_empty_no_progress_retry_loop
       ~keeper_name
@@ -349,28 +349,19 @@ let run_direct_empty_no_progress_retry_loop
            (timeout_sec -. remaining_turn_budget_s ());
          error
        | Keeper_turn_runtime_budget.Degraded_retry_allowed retry ->
-         let retry =
-           if String.trim retry.next_runtime = "" then
-             { retry with next_runtime = runtime_id }
-           else retry
-         in
-         let reason =
-           Keeper_error_classify.degraded_retry_reason_to_string
-             retry.fallback_reason
-         in
-         publish_cascade_resolution
-           ~runtime_id
-           ~decision:Keeper_unified_turn_cascade_resolution.Degraded_retry_allowed
-           ~reason
-           ~next_runtime:(Some retry.next_runtime)
-           ~attempt
-           err;
-         emit_runtime_selected ~runtime_id:retry.next_runtime
-           ~fallback_reason:reason;
-         emit_runtime_rotation ~from_runtime:runtime_id
-           ~to_runtime:retry.next_runtime ~reason;
-         (match validate_retry_runtime retry.next_runtime with
-          | Error fail_open_err ->
+         (match
+            Keeper_turn_runtime_budget.prepare_degraded_retry_allowed
+              ~current_runtime_id:runtime_id
+              ~attempt
+              ~err
+              ~retry
+              ~publish_cascade_resolution
+              ~emit_runtime_selected
+              ~emit_runtime_rotation
+              ~setup_runtime:validate_retry_runtime
+          with
+          | Keeper_turn_runtime_budget.Degraded_retry_setup_failed
+              { retry; fail_open_err; _ } ->
             let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
               current_turn_phase_elapsed_ms retry_phase_started_at
             in
@@ -390,7 +381,8 @@ let run_direct_empty_no_progress_retry_loop
               ~rotation_attempt
               ~fail_open_err;
             Error fail_open_err
-          | Ok () ->
+          | Keeper_turn_runtime_budget.Degraded_retry_prepared
+              { retry; reason; next = () } ->
             let retry_phase_started_at =
               match retry_phase_started_at with
               | Some _ -> retry_phase_started_at
@@ -1026,8 +1018,17 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
             in
             (* RFC-0225 §3.3: per-run carrier for the chat lane. *)
 	            let turn_ctx_cell = Keeper_tool_call_log.create_turn_ctx_cell () in
+	            let direct_prompt_for_estimate =
+	              build_turn_prompt ~base_system_prompt:"" ~messages:[]
+	            in
+	            let direct_prompt_metrics =
+	              Keeper_agent_run.build_prompt_metrics
+	                ~system_prompt:direct_prompt_for_estimate.system_prompt
+	                ~dynamic_context:direct_prompt_for_estimate.dynamic_context
+	                ~user_message:message
+	            in
 	            let direct_prompt_estimated_input_tokens =
-	              max 1 (Agent_sdk.Context_reducer.estimate_char_tokens message)
+	              max 1 direct_prompt_metrics.estimated_total_tokens
 	            in
 	            let run_result, latency_ms =
 	              Keeper_context_runtime.timed (fun () ->
@@ -1171,10 +1172,9 @@ let run_keeper_msg_turn_admitted ?on_text_delta ?on_event ?event_bus ctx args : 
 		                                     (Agent_sdk.Error.to_string
 		                                        fail_open_err))
 		                                ~error_kind:
-		                                  (Keeper_execution_receipt
-		                                   .error_kind_of_string
-		                                     (Keeper_agent_error.sdk_error_kind
-		                                        fail_open_err))
+		                                  (Keeper_agent_error
+		                                   .sdk_error_kind_for_receipt
+		                                     fail_open_err)
 		                                ~error_message:
 		                                  (Agent_sdk.Error.to_string fail_open_err)
 		                                ~degraded_retry_runtime:retry.next_runtime

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -70,10 +70,9 @@ module For_testing : sig
     remaining_turn_budget_s:(unit -> float) ->
     current_turn_phase_elapsed_ms:(float option -> int * int option) ->
     now_s:(unit -> float) ->
-    max_context_resolution_for_retry_runtime:
-      (string -> Keeper_context_runtime.max_context_resolution) ->
-    validate_retry_runtime:
-      (string -> (unit, Agent_sdk.Error.sdk_error) result) ->
+    setup_retry_runtime:
+      (string ->
+       (Keeper_turn_runtime_budget.runtime_execution, Agent_sdk.Error.sdk_error) result) ->
     publish_cascade_resolution:
       (runtime_id:string ->
        decision:Keeper_unified_turn_cascade_resolution.cascade_decision_kind ->

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -55,10 +55,58 @@ module For_testing : sig
     estimated_input_tokens:int ->
     ?time_spent_in_turn_s:float ->
     remaining_turn_budget_s:float ->
-    Agent_sdk.Error.sdk_error ->
-    Keeper_turn_runtime_budget.degraded_retry_budget_decision
-  (** Shared-budget retry decision for direct-message empty no-progress accept
-      rejections. Non-empty/read-only accept rejections remain terminal here. *)
+	    Agent_sdk.Error.sdk_error ->
+	    Keeper_turn_runtime_budget.degraded_retry_budget_decision
+	  (** Shared-budget retry decision for direct-message empty no-progress accept
+	      rejections. Non-empty/read-only accept rejections remain terminal here. *)
+
+  val run_direct_empty_no_progress_retry_loop :
+    keeper_name:string ->
+    base_runtime:string ->
+    initial_runtime:string ->
+    initial_max_context:int ->
+    estimated_input_tokens:int ->
+    timeout_sec:float ->
+    remaining_turn_budget_s:(unit -> float) ->
+    current_turn_phase_elapsed_ms:(float option -> int * int option) ->
+    now_s:(unit -> float) ->
+    max_context_resolution_for_retry_runtime:
+      (string -> Keeper_context_runtime.max_context_resolution) ->
+    validate_retry_runtime:
+      (string -> (unit, Agent_sdk.Error.sdk_error) result) ->
+    publish_cascade_resolution:
+      (runtime_id:string ->
+       decision:Keeper_unified_turn_cascade_resolution.cascade_decision_kind ->
+       reason:string ->
+       next_runtime:string option ->
+       attempt:int ->
+       Agent_sdk.Error.sdk_error ->
+       unit) ->
+    emit_runtime_selected:
+      (runtime_id:string -> fallback_reason:string -> unit) ->
+    emit_runtime_rotation:
+      (from_runtime:string -> to_runtime:string -> reason:string -> unit) ->
+    record_retry_setup_failure:
+      (from_runtime:string ->
+       retry:Keeper_error_classify.degraded_retry ->
+       rotation_attempt:Keeper_execution_receipt.runtime_rotation_attempt ->
+       fail_open_err:Agent_sdk.Error.sdk_error ->
+       unit) ->
+    before_retry:(unit -> unit) ->
+    run_once:
+      (runtime_id:string ->
+       max_context:int ->
+       is_retry:bool ->
+       degraded_retry_runtime:string option ->
+       fallback_reason:Keeper_error_classify.degraded_retry_reason option ->
+       runtime_rotation_attempts:
+         Keeper_execution_receipt.runtime_rotation_attempt list ->
+       ('a, Agent_sdk.Error.sdk_error) result) ->
+    unit ->
+    ('a * int, Agent_sdk.Error.sdk_error) result
+  (** Execute the direct-message empty-response retry loop with injected side
+      effects. Exposed only to verify that fallback selection reaches the next
+      keeper run attempt. *)
 end
 
 (** Format a dashboard co-view context object ({ label, route, scene, fields })

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -42,6 +42,11 @@ module For_testing : sig
   val surface_context_to_instructions : Yojson.Safe.t -> string option
   (** Format a dashboard co-view context object ({ label, route, scene, fields })
       into turn instructions when no explicit [turn_instructions] is supplied. *)
+
+  val direct_empty_no_progress_retry_reason :
+    Agent_sdk.Error.sdk_error -> Keeper_error_classify.degraded_retry_reason option
+  (** Return [Some Empty_no_progress] only for direct-message accept rejections
+      that are safe to rotate before surfacing an error. *)
 end
 
 (** Format a dashboard co-view context object ({ label, route, scene, fields })

--- a/lib/keeper/keeper_turn.mli
+++ b/lib/keeper/keeper_turn.mli
@@ -47,6 +47,18 @@ module For_testing : sig
     Agent_sdk.Error.sdk_error -> Keeper_error_classify.degraded_retry_reason option
   (** Return [Some Empty_no_progress] only for direct-message accept rejections
       that are safe to rotate before surfacing an error. *)
+
+  val direct_empty_no_progress_retry_decision :
+    base_runtime:string ->
+    effective_runtime:string ->
+    attempted_runtimes:string list ->
+    estimated_input_tokens:int ->
+    ?time_spent_in_turn_s:float ->
+    remaining_turn_budget_s:float ->
+    Agent_sdk.Error.sdk_error ->
+    Keeper_turn_runtime_budget.degraded_retry_budget_decision
+  (** Shared-budget retry decision for direct-message empty no-progress accept
+      rejections. Non-empty/read-only accept rejections remain terminal here. *)
 end
 
 (** Format a dashboard co-view context object ({ label, route, scene, fields })

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -199,6 +199,7 @@ let record_pre_dispatch_terminal_observation
       ~(trajectory_outcome : Trajectory.trajectory_outcome)
       ?error_kind
       ?error_message
+      ?(degraded_retry_applied = false)
       ?degraded_retry_runtime
       ?fallback_reason
       ?(runtime_rotation_attempts = [])
@@ -217,11 +218,6 @@ let record_pre_dispatch_terminal_observation
   in
   finalize_trajectory_acc ~config ~keeper_name:meta.name trajectory_acc trajectory_outcome;
   let ended_at = now_iso () in
-  let degraded_retry_applied =
-    match degraded_retry_runtime, fallback_reason, runtime_rotation_attempts with
-    | None, None, [] -> false
-    | _ -> true
-  in
   let receipt : Keeper_execution_receipt.t =
     { keeper_name = meta.name
     ; agent_name = meta.agent_name

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -199,6 +199,9 @@ let record_pre_dispatch_terminal_observation
       ~(trajectory_outcome : Trajectory.trajectory_outcome)
       ?error_kind
       ?error_message
+      ?degraded_retry_runtime
+      ?fallback_reason
+      ?(runtime_rotation_attempts = [])
       ?keeper_turn_id
       ()
   : unit
@@ -214,6 +217,11 @@ let record_pre_dispatch_terminal_observation
   in
   finalize_trajectory_acc ~config ~keeper_name:meta.name trajectory_acc trajectory_outcome;
   let ended_at = now_iso () in
+  let degraded_retry_applied =
+    match degraded_retry_runtime, fallback_reason, runtime_rotation_attempts with
+    | None, None, [] -> false
+    | _ -> true
+  in
   let receipt : Keeper_execution_receipt.t =
     { keeper_name = meta.name
     ; agent_name = meta.agent_name
@@ -242,10 +250,10 @@ let record_pre_dispatch_terminal_observation
     ; runtime_attempt_count = 0
     ; runtime_fallback_applied = false
     ; runtime_outcome = Keeper_execution_receipt.Runtime_not_dispatched
-    ; degraded_retry_applied = false
-    ; degraded_retry_runtime = None
-    ; fallback_reason = None
-    ; runtime_rotation_attempts = []
+    ; degraded_retry_applied
+    ; degraded_retry_runtime
+    ; fallback_reason
+    ; runtime_rotation_attempts
     ; stop_reason = None
     ; error_kind
     ; error_message

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -74,6 +74,9 @@ val record_pre_dispatch_terminal_observation :
   trajectory_outcome:Trajectory.trajectory_outcome ->
   ?error_kind:Keeper_execution_receipt.error_kind ->
   ?error_message:string ->
+  ?degraded_retry_runtime:string ->
+  ?fallback_reason:Keeper_error_classify.degraded_retry_reason ->
+  ?runtime_rotation_attempts:Keeper_execution_receipt.runtime_rotation_attempt list ->
   ?keeper_turn_id:int ->
   unit -> unit
 (** Record a terminal observation (receipt + activity graph event) for a

--- a/lib/keeper/keeper_turn_helpers.mli
+++ b/lib/keeper/keeper_turn_helpers.mli
@@ -74,6 +74,7 @@ val record_pre_dispatch_terminal_observation :
   trajectory_outcome:Trajectory.trajectory_outcome ->
   ?error_kind:Keeper_execution_receipt.error_kind ->
   ?error_message:string ->
+  ?degraded_retry_applied:bool ->
   ?degraded_retry_runtime:string ->
   ?fallback_reason:Keeper_error_classify.degraded_retry_reason ->
   ?runtime_rotation_attempts:Keeper_execution_receipt.runtime_rotation_attempt list ->

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -89,6 +89,65 @@ type degraded_retry_budget_decision =
   | Degraded_retry_slot_phase_exhausted of EC.degraded_retry
   | Degraded_retry_allowed of EC.degraded_retry
 
+type 'a degraded_retry_prepare_result =
+  | Degraded_retry_prepared of {
+      retry : EC.degraded_retry;
+      reason : string;
+      next : 'a;
+    }
+  | Degraded_retry_setup_failed of {
+      retry : EC.degraded_retry;
+      reason : string;
+      fail_open_err : Agent_sdk.Error.sdk_error;
+    }
+
+let empty_degraded_retry_runtime_error =
+  Agent_sdk.Error.Internal "degraded retry selected empty next_runtime"
+
+let prepare_degraded_retry_allowed
+      ~current_runtime_id
+      ~attempt
+      ~err
+      ~(retry : EC.degraded_retry)
+      ~publish_cascade_resolution
+      ~emit_runtime_selected
+      ~emit_runtime_rotation
+      ~setup_runtime
+  =
+  let reason = EC.degraded_retry_reason_to_string retry.fallback_reason in
+  match String.trim retry.next_runtime with
+  | "" ->
+    publish_cascade_resolution
+      ~runtime_id:current_runtime_id
+      ~decision:Keeper_unified_turn_cascade_resolution.No_degraded_retry
+      ~reason:"empty_degraded_retry_runtime"
+      ~next_runtime:None
+      ~attempt
+      err;
+    Degraded_retry_setup_failed {
+      retry;
+      reason;
+      fail_open_err = empty_degraded_retry_runtime_error;
+    }
+  | next_runtime ->
+    let retry = { retry with next_runtime } in
+    publish_cascade_resolution
+      ~runtime_id:current_runtime_id
+      ~decision:Keeper_unified_turn_cascade_resolution.Degraded_retry_allowed
+      ~reason
+      ~next_runtime:(Some retry.next_runtime)
+      ~attempt
+      err;
+    emit_runtime_selected ~runtime_id:retry.next_runtime ~fallback_reason:reason;
+    emit_runtime_rotation
+      ~from_runtime:current_runtime_id
+      ~to_runtime:retry.next_runtime
+      ~reason;
+    (match setup_runtime retry.next_runtime with
+     | Ok next -> Degraded_retry_prepared { retry; reason; next }
+     | Error fail_open_err ->
+       Degraded_retry_setup_failed { retry; reason; fail_open_err })
+
 let next_fail_open_runtime_for_turn_with_budget
     ~(base_runtime : string)
     ~(effective_runtime : string)

--- a/lib/keeper/keeper_turn_runtime_budget.ml
+++ b/lib/keeper/keeper_turn_runtime_budget.ml
@@ -138,13 +138,14 @@ let prepare_degraded_retry_allowed
       ~next_runtime:(Some retry.next_runtime)
       ~attempt
       err;
-    emit_runtime_selected ~runtime_id:retry.next_runtime ~fallback_reason:reason;
-    emit_runtime_rotation
-      ~from_runtime:current_runtime_id
-      ~to_runtime:retry.next_runtime
-      ~reason;
     (match setup_runtime retry.next_runtime with
-     | Ok next -> Degraded_retry_prepared { retry; reason; next }
+     | Ok next ->
+       emit_runtime_selected ~runtime_id:retry.next_runtime ~fallback_reason:reason;
+       emit_runtime_rotation
+         ~from_runtime:current_runtime_id
+         ~to_runtime:retry.next_runtime
+         ~reason;
+       Degraded_retry_prepared { retry; reason; next }
      | Error fail_open_err ->
        Degraded_retry_setup_failed { retry; reason; fail_open_err })
 

--- a/lib/keeper/keeper_turn_runtime_budget.mli
+++ b/lib/keeper/keeper_turn_runtime_budget.mli
@@ -82,6 +82,18 @@ type degraded_retry_budget_decision =
   | Degraded_retry_slot_phase_exhausted of EC.degraded_retry
   | Degraded_retry_allowed of EC.degraded_retry
 
+type 'a degraded_retry_prepare_result =
+  | Degraded_retry_prepared of {
+      retry : EC.degraded_retry;
+      reason : string;
+      next : 'a;
+    }
+  | Degraded_retry_setup_failed of {
+      retry : EC.degraded_retry;
+      reason : string;
+      fail_open_err : Agent_sdk.Error.sdk_error;
+    }
+
 val next_fail_open_runtime_for_turn_with_budget :
   base_runtime:string ->
   effective_runtime:string ->
@@ -91,6 +103,27 @@ val next_fail_open_runtime_for_turn_with_budget :
   remaining_turn_budget_s:float ->
   Agent_sdk.Error.sdk_error ->
   degraded_retry_budget_decision
+
+val prepare_degraded_retry_allowed :
+  current_runtime_id:string ->
+  attempt:int ->
+  err:Agent_sdk.Error.sdk_error ->
+  retry:EC.degraded_retry ->
+  publish_cascade_resolution:
+    (runtime_id:string ->
+     decision:Keeper_unified_turn_cascade_resolution.cascade_decision_kind ->
+     reason:string ->
+     next_runtime:string option ->
+     attempt:int ->
+     Agent_sdk.Error.sdk_error ->
+     unit) ->
+  emit_runtime_selected:(runtime_id:string -> fallback_reason:string -> unit) ->
+  emit_runtime_rotation:(from_runtime:string -> to_runtime:string -> reason:string -> unit) ->
+  setup_runtime:(string -> ('a, Agent_sdk.Error.sdk_error) result) ->
+  'a degraded_retry_prepare_result
+(** Shared setup path for allowed degraded-runtime retries. The selector must
+    provide a non-empty [next_runtime]; an empty target is converted into a
+    setup failure instead of falling back to the current runtime. *)
 
 type turn_event_bus_overflow = {
   estimated_tokens : int;

--- a/lib/keeper/keeper_unified_turn_execution.ml
+++ b/lib/keeper/keeper_unified_turn_execution.ml
@@ -414,49 +414,54 @@ let run (ctx : ctx)
             err
         with
         | Degraded_retry_allowed degraded_retry ->
-          let fallback_reason =
-            EC.degraded_retry_reason_to_string degraded_retry.fallback_reason
-          in
-          Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
-            ~keeper_name:meta.name
-            ~runtime_id:execution.runtime_id
-            ~decision:Degraded_retry_allowed
-            ~reason:fallback_reason
-            ~next_runtime:(Some degraded_retry.next_runtime)
-            ~attempt
-            ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
-            ~error_message:(Some (Agent_sdk.Error.to_string err));
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string RuntimeSelected)
-            ~labels:
-              [ ("keeper", meta.name)
-              ; ("runtime_id", degraded_retry.next_runtime)
-              ; ("source", "fallback")
-              ; ("fallback_reason", fallback_reason)
-              ]
-            ();
-          Otel_metric_store.inc_counter
-            Keeper_metrics.(to_string RuntimeRotation)
-            ~labels:
-              [ ("keeper", meta.name)
-              ; ("from_runtime", execution.runtime_id)
-              ; ("to_runtime", degraded_retry.next_runtime)
-              ; ("reason", fallback_reason)
-              ]
-            ();
           (match
-             Keeper_unified_turn_pre_dispatch
-             .build_runtime_execution
-               ~meta
-               ~profile_defaults
-               ~runtime_id:
-                 (* RFC-0206: raw runtime id (no prefix validation); keep the
-                    empty→fallback behaviour only. *)
-                 (if String.trim degraded_retry.next_runtime = ""
-                  then execution.runtime_id
-                  else degraded_retry.next_runtime)
+             Keeper_turn_runtime_budget.prepare_degraded_retry_allowed
+               ~current_runtime_id:execution.runtime_id
+               ~attempt
+               ~err
+               ~retry:degraded_retry
+               ~publish_cascade_resolution:
+                 (fun ~runtime_id ~decision ~reason ~next_runtime ~attempt err ->
+                    Keeper_unified_turn_cascade_resolution.publish_cascade_resolution
+                      ~keeper_name:meta.name
+                      ~runtime_id
+                      ~decision
+                      ~reason
+                      ~next_runtime
+                      ~attempt
+                      ~error_kind:(Some (Keeper_agent_error.sdk_error_kind err))
+                      ~error_message:(Some (Agent_sdk.Error.to_string err)))
+               ~emit_runtime_selected:
+                 (fun ~runtime_id ~fallback_reason ->
+                    Otel_metric_store.inc_counter
+                      Keeper_metrics.(to_string RuntimeSelected)
+                      ~labels:
+                        [ ("keeper", meta.name)
+                        ; ("runtime_id", runtime_id)
+                        ; ("source", "fallback")
+                        ; ("fallback_reason", fallback_reason)
+                        ]
+                      ())
+               ~emit_runtime_rotation:
+                 (fun ~from_runtime ~to_runtime ~reason ->
+                    Otel_metric_store.inc_counter
+                      Keeper_metrics.(to_string RuntimeRotation)
+                      ~labels:
+                        [ ("keeper", meta.name)
+                        ; ("from_runtime", from_runtime)
+                        ; ("to_runtime", to_runtime)
+                        ; ("reason", reason)
+                        ]
+                      ())
+               ~setup_runtime:
+                 (fun runtime_id ->
+                    Keeper_unified_turn_pre_dispatch.build_runtime_execution
+                      ~meta
+                      ~profile_defaults
+                      ~runtime_id)
            with
-           | Error fail_open_err ->
+           | Keeper_turn_runtime_budget.Degraded_retry_setup_failed
+               { retry = degraded_retry; reason = fallback_reason; fail_open_err } ->
              let productive_phase_elapsed_ms, retry_phase_elapsed_ms =
                current_turn_phase_elapsed_ms turn_state.retry_phase_started_at
              in
@@ -478,13 +483,13 @@ let run (ctx : ctx)
                meta.name
                execution_runtime_id
                degraded_retry.next_runtime
-               (EC.degraded_retry_reason_to_string
-                  degraded_retry.fallback_reason)
+               fallback_reason
                (short_preview
                   (Agent_sdk.Error.to_string fail_open_err));
              mark_terminal_error fail_open_err;
              Error fail_open_err, turn_state
-           | Ok next_execution ->
+           | Keeper_turn_runtime_budget.Degraded_retry_prepared
+               { retry = degraded_retry; reason = fallback_reason; next = next_execution } ->
              let next_execution_runtime_id =
                next_execution.runtime_id
              in
@@ -512,14 +517,13 @@ let run (ctx : ctx)
              in
              Log.Keeper.warn
                "%s: recoverable runtime failure in %s; rotation \
-                retry on runtime=%s reason=%s max_context=%d \
+               retry on runtime=%s reason=%s max_context=%d \
                 context_budget=%d primary_budget=%d \
                 requested_override=%s: %s"
                meta.name
                execution_runtime_id
                next_execution_runtime_id
-               (EC.degraded_retry_reason_to_string
-                  degraded_retry.fallback_reason)
+               fallback_reason
                next_execution.max_context
                next_execution.max_context_resolution.effective_budget
                next_execution.max_context_resolution.primary_budget

--- a/lib/keeper/keeper_unified_turn_pre_dispatch.ml
+++ b/lib/keeper/keeper_unified_turn_pre_dispatch.ml
@@ -30,6 +30,10 @@ let build_runtime_execution
     , Agent_sdk.Error.sdk_error )
     result
   =
+  let runtime_id = String.trim runtime_id in
+  if String.equal runtime_id "" then
+    Error (Agent_sdk.Error.Internal "runtime_id must be non-empty")
+  else
   let model_labels =
     Keeper_context_runtime.effective_model_labels_for_turn meta
   in

--- a/lib/keeper/keeper_unified_turn_rotation_attempt.ml
+++ b/lib/keeper/keeper_unified_turn_rotation_attempt.ml
@@ -16,10 +16,7 @@ let build
   ; outcome
   ; productive_phase_elapsed_ms
   ; retry_phase_elapsed_ms
-  ; error_kind =
-      Some
-        (Keeper_execution_receipt.error_kind_of_string
-           (Keeper_agent_error.sdk_error_kind err))
+  ; error_kind = Some (Keeper_agent_error.sdk_error_kind_for_receipt err)
   ; error_message = Some (Agent_sdk.Error.to_string err)
   ; recorded_at
   }

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -958,12 +958,12 @@ let test_prepare_degraded_retry_reports_setup_failure () =
       (Agent_sdk.Error.to_string setup_err)
       (Agent_sdk.Error.to_string fail_open_err);
     Alcotest.(check (list (pair string string)))
-      "runtime-selected metric emitted after non-empty target"
-      [ "runtime.fallback", "empty_no_progress" ]
+      "no runtime-selected metric on setup failure"
+      []
       (List.rev !selected);
     Alcotest.(check (list (triple string string string)))
-      "rotation metric emitted after non-empty target"
-      [ "runtime.direct-empty", "runtime.fallback", "empty_no_progress" ]
+      "no rotation metric on setup failure"
+      []
       (List.rev !rotated);
     (match List.rev !published with
      | [ (_runtime_id, decision, reason, next_runtime, attempt) ] ->

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -77,6 +77,11 @@ let accept_no_progress_retry_kind_string err =
       | `Read_only_no_progress -> "read_only_no_progress")
     kind
 
+let direct_empty_no_progress_retry_reason_string err =
+  Option.map
+    Masc.Keeper_error_classify.degraded_retry_reason_to_string
+    (Masc.Keeper_turn.For_testing.direct_empty_no_progress_retry_reason err)
+
 let test_keeper_hook_relaxes_strict_tool_choice () =
   let open Agent_sdk.Types in
   let relax = Masc.Keeper_run_tools_hooks.relax_strict_tool_choice_for_keeper in
@@ -674,6 +679,10 @@ let test_read_only_retry_uses_typed_context_not_reason_tokens () =
     (Option.map
        Masc.Keeper_error_classify.degraded_retry_reason_to_string
        (Masc.Keeper_error_classify.recoverable_runtime_failure_reason typed_err));
+  Alcotest.(check (option string))
+    "direct keeper_msg does not rotate read-only no-progress"
+    None
+    (direct_empty_no_progress_retry_reason_string typed_err);
   let string_only_err =
     accept_rejected_sdk_error
       ~response_shape:None
@@ -879,7 +888,11 @@ let test_empty_non_end_turn_response_is_rejected () =
      Alcotest.failf
        "expected completion_contract_violation blocker, got %s"
        (Masc.Keeper_meta_contract.blocker_class_to_string other)
-   | None -> Alcotest.fail "expected accept rejection blocker class")
+   | None -> Alcotest.fail "expected accept rejection blocker class");
+  Alcotest.(check (option string))
+    "direct keeper_msg rotates empty no-progress"
+    (Some "empty_no_progress")
+    (direct_empty_no_progress_retry_reason_string err)
 
 let test_empty_after_workspace_mutation_stays_terminal () =
   let checkpoint =
@@ -917,7 +930,11 @@ let test_empty_after_workspace_mutation_stays_terminal () =
     None
     (Option.map
        Masc.Keeper_error_classify.degraded_retry_reason_to_string
-       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err));
+  Alcotest.(check (option string))
+    "direct keeper_msg does not rotate after mutation"
+    None
+    (direct_empty_no_progress_retry_reason_string err)
 
 let test_blank_text_non_end_turn_response_is_rejected () =
   let result =

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -1012,6 +1012,14 @@ let test_direct_empty_no_progress_retry_loop_runs_fallback_attempt () =
     let validated = ref [] in
     let setup_failures = ref [] in
     let yielded = ref 0 in
+    let retry_execution runtime_id : Masc.Keeper_turn_runtime_budget.runtime_execution =
+      { runtime_id
+      ; max_context_resolution = retry_context_resolution
+      ; max_context = retry_context_resolution.turn_budget
+      ; temperature = 0.0
+      ; max_tokens = 1024
+      }
+    in
     let result =
       Masc.Keeper_turn.For_testing.run_direct_empty_no_progress_retry_loop
         ~keeper_name:"keeper-test"
@@ -1025,15 +1033,9 @@ let test_direct_empty_no_progress_retry_loop_runs_fallback_attempt () =
           | None -> 7, None
           | Some _ -> 7, Some 0)
         ~now_s:(fun () -> 10.0)
-        ~max_context_resolution_for_retry_runtime:(fun runtime_id ->
-          Alcotest.(check string)
-            "retry context resolved for fallback"
-            expected_retry_runtime
-            runtime_id;
-          retry_context_resolution)
-        ~validate_retry_runtime:(fun runtime_id ->
+        ~setup_retry_runtime:(fun runtime_id ->
           validated := runtime_id :: !validated;
-          Ok ())
+          Ok (retry_execution runtime_id))
         ~publish_cascade_resolution:
           (fun ~runtime_id ~decision ~reason ~next_runtime ~attempt _err ->
              published :=
@@ -1158,6 +1160,72 @@ let test_direct_empty_no_progress_retry_loop_runs_fallback_attempt () =
      | published ->
        Alcotest.failf "expected one cascade event, got %d"
          (List.length published)))
+
+let test_direct_retry_loop_publishes_non_retry_terminal_cascade () =
+  let terminal_err = Agent_sdk.Error.Internal "not retryable" in
+  let published = ref [] in
+  let run_count = ref 0 in
+  let result =
+    Masc.Keeper_turn.For_testing.run_direct_empty_no_progress_retry_loop
+      ~keeper_name:"keeper-test"
+      ~base_runtime:"runtime.initial"
+      ~initial_runtime:"runtime.initial"
+      ~initial_max_context:2048
+      ~estimated_input_tokens:1
+      ~timeout_sec:60.0
+      ~remaining_turn_budget_s:(fun () -> 60.0)
+      ~current_turn_phase_elapsed_ms:(fun _ -> 3, None)
+      ~now_s:(fun () -> 10.0)
+      ~setup_retry_runtime:(fun _ ->
+        Alcotest.fail "non-retryable terminal errors must not set up a retry")
+      ~publish_cascade_resolution:
+        (fun ~runtime_id ~decision ~reason ~next_runtime ~attempt _err ->
+           published :=
+             ( runtime_id
+             , cascade_decision_to_string decision
+             , reason
+             , next_runtime
+             , attempt )
+             :: !published)
+      ~emit_runtime_selected:(fun ~runtime_id:_ ~fallback_reason:_ ->
+        Alcotest.fail "non-retryable terminal errors must not emit selection")
+      ~emit_runtime_rotation:(fun ~from_runtime:_ ~to_runtime:_ ~reason:_ ->
+        Alcotest.fail "non-retryable terminal errors must not emit rotation")
+      ~record_retry_setup_failure:
+        (fun ~from_runtime:_ ~retry:_ ~rotation_attempt:_ ~fail_open_err:_ ->
+           Alcotest.fail "non-retryable terminal errors must not record setup failure")
+      ~before_retry:(fun () ->
+        Alcotest.fail "non-retryable terminal errors must not yield before retry")
+      ~run_once:
+        (fun ~runtime_id ~max_context ~is_retry ~degraded_retry_runtime:_
+             ~fallback_reason:_ ~runtime_rotation_attempts:_ ->
+           incr run_count;
+           Alcotest.(check string) "initial runtime" "runtime.initial" runtime_id;
+           Alcotest.(check int) "initial max context" 2048 max_context;
+           Alcotest.(check bool) "not retry" false is_retry;
+           Error terminal_err)
+      ()
+  in
+  (match result with
+   | Ok _ -> Alcotest.fail "terminal error should be returned"
+   | Error err ->
+     Alcotest.(check string)
+       "terminal error propagated"
+       (Agent_sdk.Error.to_string terminal_err)
+       (Agent_sdk.Error.to_string err));
+  Alcotest.(check int) "only initial attempt runs" 1 !run_count;
+  match List.rev !published with
+  | [ (runtime_id, decision, reason, next_runtime, attempt) ] ->
+    Alcotest.(check string) "published from initial runtime" "runtime.initial" runtime_id;
+    Alcotest.(check string) "terminal decision" "no_degraded_retry" decision;
+    Alcotest.(check string)
+      "terminal reason"
+      "terminal_error_not_degraded_retry_eligible"
+      reason;
+    Alcotest.(check (option string)) "no next runtime" None next_runtime;
+    Alcotest.(check int) "attempt" 1 attempt
+  | rows ->
+    Alcotest.failf "expected one cascade event, got %d" (List.length rows)
 
 let test_thinking_with_text_is_accepted () =
   let result =
@@ -1567,6 +1635,10 @@ let () =
 	            "direct empty no-progress retry runs fallback attempt"
 	            `Quick
 	            test_direct_empty_no_progress_retry_loop_runs_fallback_attempt;
+          Alcotest.test_case
+            "direct retry publishes terminal non-retry cascade"
+            `Quick
+            test_direct_retry_loop_publishes_non_retry_terminal_cascade;
 	          Alcotest.test_case "thinking plus text is accepted" `Quick
 	            test_thinking_with_text_is_accepted;
           Alcotest.test_case "thinking plus tool use is accepted" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -829,6 +829,154 @@ let cascade_decision_to_string
   | No_degraded_retry -> "no_degraded_retry"
   | Transient_network_retry -> "transient_network_retry"
 
+let prepare_retry_observers () =
+  let published = ref [] in
+  let selected = ref [] in
+  let rotated = ref [] in
+  let publish_cascade_resolution
+      ~runtime_id ~decision ~reason ~next_runtime ~attempt _err =
+    published :=
+      ( runtime_id
+      , cascade_decision_to_string decision
+      , reason
+      , next_runtime
+      , attempt )
+      :: !published
+  in
+  let emit_runtime_selected ~runtime_id ~fallback_reason =
+    selected := (runtime_id, fallback_reason) :: !selected
+  in
+  let emit_runtime_rotation ~from_runtime ~to_runtime ~reason =
+    rotated := (from_runtime, to_runtime, reason) :: !rotated
+  in
+  published, selected, rotated, publish_cascade_resolution,
+  emit_runtime_selected, emit_runtime_rotation
+
+let test_prepare_degraded_retry_rejects_empty_runtime () =
+  let published, selected, rotated, publish_cascade_resolution,
+      emit_runtime_selected, emit_runtime_rotation =
+    prepare_retry_observers ()
+  in
+  let setup_called = ref false in
+  let err = Agent_sdk.Error.Internal "empty direct response" in
+  let retry : Masc.Keeper_error_classify.degraded_retry =
+    {
+      next_runtime = " \t ";
+      fallback_reason = Masc.Keeper_error_classify.Empty_no_progress;
+    }
+  in
+  match
+    Masc.Keeper_turn_runtime_budget.prepare_degraded_retry_allowed
+      ~current_runtime_id:"runtime.direct-empty"
+      ~attempt:1
+      ~err
+      ~retry
+      ~publish_cascade_resolution
+      ~emit_runtime_selected
+      ~emit_runtime_rotation
+      ~setup_runtime:(fun _ ->
+        setup_called := true;
+        Ok ())
+  with
+  | Masc.Keeper_turn_runtime_budget.Degraded_retry_prepared _ ->
+    Alcotest.fail "empty next_runtime must not prepare a retry"
+  | Masc.Keeper_turn_runtime_budget.Degraded_retry_setup_failed
+      { reason; fail_open_err; _ } ->
+    Alcotest.(check string) "reason preserved" "empty_no_progress" reason;
+    Alcotest.(check bool) "setup not called" false !setup_called;
+    Alcotest.(check bool)
+      "failure is explicit"
+      true
+      (contains
+         ~needle:"degraded retry selected empty next_runtime"
+         (Agent_sdk.Error.to_string fail_open_err));
+    Alcotest.(check (list (pair string string)))
+      "no runtime-selected metric for empty target"
+      []
+      (List.rev !selected);
+    Alcotest.(check (list (triple string string string)))
+      "no rotation metric for empty target"
+      []
+      (List.rev !rotated);
+    (match List.rev !published with
+     | [ (runtime_id, decision, reason, next_runtime, attempt) ] ->
+       Alcotest.(check string)
+         "published from current runtime"
+         "runtime.direct-empty"
+         runtime_id;
+       Alcotest.(check string)
+         "empty target publishes terminal decision"
+         "no_degraded_retry"
+         decision;
+       Alcotest.(check string)
+         "publish reason identifies empty target"
+         "empty_degraded_retry_runtime"
+         reason;
+       Alcotest.(check (option string)) "no next runtime" None next_runtime;
+       Alcotest.(check int) "attempt" 1 attempt
+     | rows ->
+       Alcotest.failf "expected one cascade event, got %d" (List.length rows))
+
+let test_prepare_degraded_retry_reports_setup_failure () =
+  let published, selected, rotated, publish_cascade_resolution,
+      emit_runtime_selected, emit_runtime_rotation =
+    prepare_retry_observers ()
+  in
+  let err = Agent_sdk.Error.Internal "empty direct response" in
+  let setup_err = Agent_sdk.Error.Internal "retry setup failed" in
+  let retry : Masc.Keeper_error_classify.degraded_retry =
+    {
+      next_runtime = " runtime.fallback ";
+      fallback_reason = Masc.Keeper_error_classify.Empty_no_progress;
+    }
+  in
+  match
+    Masc.Keeper_turn_runtime_budget.prepare_degraded_retry_allowed
+      ~current_runtime_id:"runtime.direct-empty"
+      ~attempt:2
+      ~err
+      ~retry
+      ~publish_cascade_resolution
+      ~emit_runtime_selected
+      ~emit_runtime_rotation
+      ~setup_runtime:(fun runtime_id ->
+        Alcotest.(check string)
+          "setup sees normalized runtime"
+          "runtime.fallback"
+          runtime_id;
+        Error setup_err)
+  with
+  | Masc.Keeper_turn_runtime_budget.Degraded_retry_prepared _ ->
+    Alcotest.fail "setup failure must not prepare a retry"
+  | Masc.Keeper_turn_runtime_budget.Degraded_retry_setup_failed
+      { retry; reason; fail_open_err } ->
+    Alcotest.(check string) "normalized retry runtime" "runtime.fallback"
+      retry.next_runtime;
+    Alcotest.(check string) "reason" "empty_no_progress" reason;
+    Alcotest.(check string)
+      "failure propagated"
+      (Agent_sdk.Error.to_string setup_err)
+      (Agent_sdk.Error.to_string fail_open_err);
+    Alcotest.(check (list (pair string string)))
+      "runtime-selected metric emitted after non-empty target"
+      [ "runtime.fallback", "empty_no_progress" ]
+      (List.rev !selected);
+    Alcotest.(check (list (triple string string string)))
+      "rotation metric emitted after non-empty target"
+      [ "runtime.direct-empty", "runtime.fallback", "empty_no_progress" ]
+      (List.rev !rotated);
+    (match List.rev !published with
+     | [ (_runtime_id, decision, reason, next_runtime, attempt) ] ->
+       Alcotest.(check string) "decision" "degraded_retry_allowed" decision;
+       Alcotest.(check string) "publish reason" "empty_no_progress" reason;
+       Alcotest.(check (option string))
+         "next runtime"
+         (Some "runtime.fallback")
+         next_runtime;
+       Alcotest.(check int) "attempt" 2 attempt
+     | rows ->
+       Alcotest.failf "expected one cascade event, got %d" (List.length rows))
+
 let test_direct_empty_no_progress_retry_loop_runs_fallback_attempt () =
   with_direct_retry_runtime (fun () ->
     let empty_err =
@@ -1407,6 +1555,14 @@ let () =
 	            "direct empty no-progress retry uses shared budget decision"
 	            `Quick
 	            test_direct_empty_no_progress_retry_uses_shared_budget_decision;
+          Alcotest.test_case
+            "degraded retry rejects empty runtime target"
+            `Quick
+            test_prepare_degraded_retry_rejects_empty_runtime;
+          Alcotest.test_case
+            "degraded retry reports setup failure"
+            `Quick
+            test_prepare_degraded_retry_reports_setup_failure;
 	          Alcotest.test_case
 	            "direct empty no-progress retry runs fallback attempt"
 	            `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -132,6 +132,15 @@ let direct_empty_no_progress_retry_decision ?time_spent_in_turn_s err =
     ~remaining_turn_budget_s:60.0
     err
 
+type direct_retry_observed_attempt =
+  { observed_runtime_id : string
+  ; observed_max_context : int
+  ; observed_is_retry : bool
+  ; observed_degraded_retry_runtime : string option
+  ; observed_fallback_reason : string option
+  ; observed_rotation_attempt_count : int
+  }
+
 let test_keeper_hook_relaxes_strict_tool_choice () =
   let open Agent_sdk.Types in
   let relax = Masc.Keeper_run_tools_hooks.relax_strict_tool_choice_for_keeper in
@@ -808,9 +817,199 @@ let test_direct_empty_no_progress_retry_uses_shared_budget_decision () =
       true
       (match direct_empty_no_progress_retry_decision read_only_err with
        | Masc.Keeper_turn_runtime_budget.No_degraded_retry -> true
-       | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed _
-       | Masc.Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted _ ->
-         false))
+	       | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed _
+	       | Masc.Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted _ ->
+	         false))
+
+let cascade_decision_to_string
+    (decision : Masc.Keeper_unified_turn_cascade_resolution.cascade_decision_kind) =
+  match decision with
+  | Degraded_retry_allowed -> "degraded_retry_allowed"
+  | Degraded_retry_slot_phase_exhausted -> "degraded_retry_slot_phase_exhausted"
+  | No_degraded_retry -> "no_degraded_retry"
+  | Transient_network_retry -> "transient_network_retry"
+
+let test_direct_empty_no_progress_retry_loop_runs_fallback_attempt () =
+  with_direct_retry_runtime (fun () ->
+    let empty_err =
+      accept_rejected_sdk_error
+        ~response_shape:(Some Keeper_internal_error.Accept_response_empty)
+        ~last_tool_effect:None
+        ~reason:"shape=empty"
+        ()
+    in
+    let expected_retry_runtime =
+      match direct_empty_no_progress_retry_decision empty_err with
+      | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed retry ->
+        retry.next_runtime
+      | Masc.Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted _ ->
+        Alcotest.fail
+          "fresh direct empty retry should not exhaust slot phase before loop"
+      | Masc.Keeper_turn_runtime_budget.No_degraded_retry ->
+        Alcotest.fail "fresh direct empty retry should select a fallback runtime"
+    in
+    let retry_context_resolution
+        : Masc.Keeper_context_runtime.max_context_resolution =
+      { requested_override = None
+      ; primary_budget = 4096
+      ; runtime_budget = 4096
+      ; turn_budget = 4096
+      ; effective_budget = 4096
+      }
+    in
+    let attempts = ref [] in
+    let published = ref [] in
+    let selected = ref [] in
+    let rotated = ref [] in
+    let validated = ref [] in
+    let setup_failures = ref [] in
+    let yielded = ref 0 in
+    let result =
+      Masc.Keeper_turn.For_testing.run_direct_empty_no_progress_retry_loop
+        ~keeper_name:"keeper-test"
+        ~base_runtime:"test_provider.test_model"
+        ~initial_runtime:"runtime.direct-empty"
+        ~initial_max_context:1024
+        ~estimated_input_tokens:1
+        ~timeout_sec:60.0
+        ~remaining_turn_budget_s:(fun () -> 60.0)
+        ~current_turn_phase_elapsed_ms:(function
+          | None -> 7, None
+          | Some _ -> 7, Some 0)
+        ~now_s:(fun () -> 10.0)
+        ~max_context_resolution_for_retry_runtime:(fun runtime_id ->
+          Alcotest.(check string)
+            "retry context resolved for fallback"
+            expected_retry_runtime
+            runtime_id;
+          retry_context_resolution)
+        ~validate_retry_runtime:(fun runtime_id ->
+          validated := runtime_id :: !validated;
+          Ok ())
+        ~publish_cascade_resolution:
+          (fun ~runtime_id ~decision ~reason ~next_runtime ~attempt _err ->
+             published :=
+               ( runtime_id
+               , cascade_decision_to_string decision
+               , reason
+               , next_runtime
+               , attempt )
+               :: !published)
+        ~emit_runtime_selected:(fun ~runtime_id ~fallback_reason ->
+          selected := (runtime_id, fallback_reason) :: !selected)
+        ~emit_runtime_rotation:(fun ~from_runtime ~to_runtime ~reason ->
+          rotated := (from_runtime, to_runtime, reason) :: !rotated)
+        ~record_retry_setup_failure:(fun ~from_runtime ~retry:_ ~rotation_attempt:_
+                                      ~fail_open_err:_ ->
+          setup_failures := from_runtime :: !setup_failures)
+        ~before_retry:(fun () -> yielded := !yielded + 1)
+        ~run_once:
+          (fun ~runtime_id ~max_context ~is_retry ~degraded_retry_runtime
+               ~fallback_reason ~runtime_rotation_attempts ->
+             attempts :=
+               { observed_runtime_id = runtime_id
+               ; observed_max_context = max_context
+               ; observed_is_retry = is_retry
+               ; observed_degraded_retry_runtime = degraded_retry_runtime
+               ; observed_fallback_reason =
+                   Option.map
+                     Masc.Keeper_error_classify.degraded_retry_reason_to_string
+                     fallback_reason
+               ; observed_rotation_attempt_count =
+                   List.length runtime_rotation_attempts
+               }
+               :: !attempts;
+             if is_retry then Ok ("ok:" ^ runtime_id) else Error empty_err)
+        ()
+    in
+    (match result with
+     | Error err ->
+       Alcotest.failf
+         "retry loop should succeed on fallback runtime: %s"
+         (Agent_sdk.Error.to_string err)
+     | Ok (value, final_max_context) ->
+       Alcotest.(check string)
+         "retry result comes from fallback runtime"
+         ("ok:" ^ expected_retry_runtime)
+         value;
+       Alcotest.(check int)
+         "final max context comes from fallback runtime"
+         4096
+         final_max_context);
+    (match List.rev !attempts with
+     | [ first; second ] ->
+       Alcotest.(check string)
+         "first attempt uses initial runtime"
+         "runtime.direct-empty"
+         first.observed_runtime_id;
+       Alcotest.(check int)
+         "first attempt uses initial max context"
+         1024
+         first.observed_max_context;
+       Alcotest.(check bool) "first attempt is not retry" false
+         first.observed_is_retry;
+       Alcotest.(check (option string))
+         "first attempt has no degraded runtime"
+         None
+         first.observed_degraded_retry_runtime;
+       Alcotest.(check string)
+         "second attempt uses fallback runtime"
+         expected_retry_runtime
+         second.observed_runtime_id;
+       Alcotest.(check int)
+         "second attempt uses fallback max context"
+         4096
+         second.observed_max_context;
+       Alcotest.(check bool) "second attempt is retry" true
+         second.observed_is_retry;
+       Alcotest.(check (option string))
+         "second attempt carries degraded retry runtime"
+         (Some expected_retry_runtime)
+         second.observed_degraded_retry_runtime;
+       Alcotest.(check (option string))
+         "second attempt carries fallback reason"
+         (Some "empty_no_progress")
+         second.observed_fallback_reason;
+       Alcotest.(check int)
+         "second attempt receives scheduled rotation attempt"
+         1
+         second.observed_rotation_attempt_count
+     | attempts ->
+       Alcotest.failf "expected exactly two attempts, got %d"
+         (List.length attempts));
+    Alcotest.(check (list string))
+      "fallback runtime was validated"
+      [ expected_retry_runtime ]
+      (List.rev !validated);
+    Alcotest.(check (list (pair string string)))
+      "runtime selected metric emitted"
+      [ expected_retry_runtime, "empty_no_progress" ]
+      (List.rev !selected);
+    Alcotest.(check (list (triple string string string)))
+      "runtime rotation metric emitted"
+      [ "runtime.direct-empty", expected_retry_runtime, "empty_no_progress" ]
+      (List.rev !rotated);
+    Alcotest.(check int) "cooperative retry yield runs once" 1 !yielded;
+    Alcotest.(check (list string)) "no setup failure recorded" [] !setup_failures;
+    (match List.rev !published with
+     | [ (runtime_id, decision, reason, next_runtime, attempt) ] ->
+       Alcotest.(check string)
+         "cascade published from initial runtime"
+         "runtime.direct-empty"
+         runtime_id;
+       Alcotest.(check string)
+         "cascade records allowed retry"
+         "degraded_retry_allowed"
+         decision;
+       Alcotest.(check string) "cascade reason" "empty_no_progress" reason;
+       Alcotest.(check (option string))
+         "cascade next runtime"
+         (Some expected_retry_runtime)
+         next_runtime;
+       Alcotest.(check int) "cascade attempt" 1 attempt
+     | published ->
+       Alcotest.failf "expected one cascade event, got %d"
+         (List.length published)))
 
 let test_thinking_with_text_is_accepted () =
   let result =
@@ -1204,12 +1403,16 @@ let () =
             "read-only retry uses typed context, not reason tokens"
             `Quick
             test_read_only_retry_uses_typed_context_not_reason_tokens;
-          Alcotest.test_case
-            "direct empty no-progress retry uses shared budget decision"
-            `Quick
-            test_direct_empty_no_progress_retry_uses_shared_budget_decision;
-          Alcotest.test_case "thinking plus text is accepted" `Quick
-            test_thinking_with_text_is_accepted;
+	          Alcotest.test_case
+	            "direct empty no-progress retry uses shared budget decision"
+	            `Quick
+	            test_direct_empty_no_progress_retry_uses_shared_budget_decision;
+	          Alcotest.test_case
+	            "direct empty no-progress retry runs fallback attempt"
+	            `Quick
+	            test_direct_empty_no_progress_retry_loop_runs_fallback_attempt;
+	          Alcotest.test_case "thinking plus text is accepted" `Quick
+	            test_thinking_with_text_is_accepted;
           Alcotest.test_case "thinking plus tool use is accepted" `Quick
             test_thinking_with_tool_use_is_accepted;
           Alcotest.test_case "accept delegates to OAS response shape" `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -82,6 +82,56 @@ let direct_empty_no_progress_retry_reason_string err =
     Masc.Keeper_error_classify.degraded_retry_reason_to_string
     (Masc.Keeper_turn.For_testing.direct_empty_no_progress_retry_reason err)
 
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
+let direct_retry_runtime_toml =
+  {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+|}
+
+let with_direct_retry_runtime f =
+  let snapshot = Runtime.For_testing.snapshot () in
+  let path = Filename.temp_file "direct_retry_runtime_" ".toml" in
+  write_file path direct_retry_runtime_toml;
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore snapshot;
+      try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+       match Runtime.init_default ~config_path:path with
+       | Ok () -> f ()
+       | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e)
+
+let direct_empty_no_progress_retry_decision ?time_spent_in_turn_s err =
+  Masc.Keeper_turn.For_testing.direct_empty_no_progress_retry_decision
+    ~base_runtime:"test_provider.test_model"
+    ~effective_runtime:"runtime.direct-empty"
+    ~attempted_runtimes:[ "runtime.direct-empty" ]
+    ~estimated_input_tokens:1
+    ?time_spent_in_turn_s
+    ~remaining_turn_budget_s:60.0
+    err
+
 let test_keeper_hook_relaxes_strict_tool_choice () =
   let open Agent_sdk.Types in
   let relax = Masc.Keeper_run_tools_hooks.relax_strict_tool_choice_for_keeper in
@@ -697,13 +747,70 @@ let test_read_only_retry_uses_typed_context_not_reason_tokens () =
     (Masc.Keeper_turn_driver.For_testing
      .accept_no_progress_read_only_should_try_next
        string_only_err);
-  Alcotest.(check (option string))
-    "legacy reason tokens alone are not runtime-recoverable"
-    None
-    (Option.map
-       Masc.Keeper_error_classify.degraded_retry_reason_to_string
-       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason
-          string_only_err))
+	  Alcotest.(check (option string))
+	    "legacy reason tokens alone are not runtime-recoverable"
+	    None
+	    (Option.map
+	       Masc.Keeper_error_classify.degraded_retry_reason_to_string
+	       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason
+	          string_only_err))
+
+let test_direct_empty_no_progress_retry_uses_shared_budget_decision () =
+  with_direct_retry_runtime (fun () ->
+    let empty_err =
+      accept_rejected_sdk_error
+        ~response_shape:(Some Keeper_internal_error.Accept_response_empty)
+        ~last_tool_effect:None
+        ~reason:"shape=empty"
+        ()
+    in
+    (match direct_empty_no_progress_retry_decision empty_err with
+     | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed retry ->
+       Alcotest.(check string)
+         "allowed reason"
+         "empty_no_progress"
+         (Masc.Keeper_error_classify.degraded_retry_reason_to_string
+            retry.fallback_reason)
+     | Masc.Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted _ ->
+       Alcotest.fail "fresh direct empty retry should not exhaust slot phase"
+     | Masc.Keeper_turn_runtime_budget.No_degraded_retry ->
+       Alcotest.fail "fresh direct empty retry should rotate");
+    let exhausted_after =
+      Masc.Keeper_turn_runtime_budget.degraded_retry_slot_phase_budget_sec +. 1.0
+    in
+    (match
+       direct_empty_no_progress_retry_decision
+         ~time_spent_in_turn_s:exhausted_after
+         empty_err
+     with
+     | Masc.Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted retry
+       ->
+       Alcotest.(check string)
+         "slot-exhausted reason"
+         "empty_no_progress"
+         (Masc.Keeper_error_classify.degraded_retry_reason_to_string
+            retry.fallback_reason)
+     | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed _ ->
+       Alcotest.fail "exhausted direct empty retry should not rotate"
+     | Masc.Keeper_turn_runtime_budget.No_degraded_retry ->
+       Alcotest.fail "exhausted direct empty retry should report slot exhaustion");
+    let read_only_err =
+      accept_rejected_sdk_error
+        ~response_shape:(Some Keeper_internal_error.Accept_response_thinking_only)
+        ~last_tool_effect:(Some Keeper_internal_error.Tool_effect_read_only)
+        ~any_mutating_tool:false
+        ~tool_effects_seen:[ Keeper_internal_error.Tool_effect_read_only ]
+        ~reason:"shape=thinking_only"
+        ()
+    in
+    Alcotest.(check bool)
+      "direct read-only no-progress remains terminal"
+      true
+      (match direct_empty_no_progress_retry_decision read_only_err with
+       | Masc.Keeper_turn_runtime_budget.No_degraded_retry -> true
+       | Masc.Keeper_turn_runtime_budget.Degraded_retry_allowed _
+       | Masc.Keeper_turn_runtime_budget.Degraded_retry_slot_phase_exhausted _ ->
+         false))
 
 let test_thinking_with_text_is_accepted () =
   let result =
@@ -1097,6 +1204,10 @@ let () =
             "read-only retry uses typed context, not reason tokens"
             `Quick
             test_read_only_retry_uses_typed_context_not_reason_tokens;
+          Alcotest.test_case
+            "direct empty no-progress retry uses shared budget decision"
+            `Quick
+            test_direct_empty_no_progress_retry_uses_shared_budget_decision;
           Alcotest.test_case "thinking plus text is accepted" `Quick
             test_thinking_with_text_is_accepted;
           Alcotest.test_case "thinking plus tool use is accepted" `Quick


### PR DESCRIPTION
## Summary
- Retry direct keeper_msg turns through the existing degraded-runtime budget decision when the provider returns a typed empty no-progress accept rejection.
- Keep read-only no-progress and post-mutation no-progress terminal for direct messages, matching the existing safety boundary.
- Publish cascade resolution metrics, validate retry runtime setup, persist retry setup-failure metadata on terminal receipts, and pass scheduled rotation attempts to the retried run receipt.

## Failure evidence
- Live failure shape: typed accept_rejected / no_usable_progress / empty response from runpod_fable5.gemma4-coder-fable5.
- The original evidence came from local keeper runtime logs on 2026-06-26; absolute machine-local paths are intentionally omitted from the PR body.

## Current branch state
- Rebased onto current origin/main at 25cb158fd14 after #22461/#22476/#22477 landed.
- GitHub reports the PR as mergeable after the rebase.

## Validation
- ocamlformat --check on all 17 touched OCaml/test files.
- git diff --check origin/main..HEAD.
- conflict-marker scan over lib/keeper and test/test_keeper_turn_driver_accept.ml.
- Focused local build is currently blocked before #22434-specific verification by base/environment issues:
  - #22474 / #22479: current main fatal warning 4 in lib/core/executable_path.ml.
  - Shared opam switch floor is recorded at agent_sdk 0.207.10 while current main declares 0.207.9; the repo pin script correctly refused a downgrade.
  - A partial MASC_SKIP_PIN_CHECK=1 compile therefore runs against the newer local SDK and reports expected API drift outside this PR scope.

## CI
- Fresh checks attached after the rebase push and are queued.