### PR TITLE
fix(masc): keeper stability — idle false positives, typed contract reasons, SSOT paths

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -147,7 +147,7 @@
  (modules masc_completion_trust_audit)
  (public_name masc-completion-trust-audit)
  (package masc)
- (libraries unix yojson masc.completion_trust_audit))
+ (libraries unix yojson masc.completion_trust_audit masc.config_dir_resolver))
 
 ;; RFC-0262 §9 PR-C: live-LLM behavioural eval for completion-trust.
 ;; Drives a real keeper through the masc runtime, so it links the same
@@ -220,7 +220,7 @@
  (modules masc_trace)
  (public_name masc-trace)
  (package masc)
- (libraries yojson))
+ (libraries yojson masc.config_dir_resolver))
 
 ;; TUI Dashboard - Terminal interface for multi-agent workspace
 

--- a/bin/dune
+++ b/bin/dune
@@ -13,6 +13,7 @@
   masc.operator
   masc.server
   masc.config
+  masc.config_dir_resolver
   masc.embedded_config
   masc.host_config
   masc.mcp_session

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -933,7 +933,7 @@ let seed_one ~target_root ~force tally rel =
 let init_cmd_exit base_path force =
   let base_path = Env_config.normalize_masc_base_path_input base_path in
   let target_root =
-    Filename.concat (Workspace_utils.masc_dir_from_base_path ~base_path) "config"
+    (Config_dir_resolver.resolve_for_base_path ~base_path).config_root.path
   in
   Fs_compat.mkdir_p target_root;
   let result =

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -932,7 +932,9 @@ let seed_one ~target_root ~force tally rel =
 
 let init_cmd_exit base_path force =
   let base_path = Env_config.normalize_masc_base_path_input base_path in
-  let target_root = Filename.concat (Filename.concat base_path ".masc") "config" in
+  let target_root =
+    Filename.concat (Workspace_utils.masc_dir_from_base_path ~base_path) "config"
+  in
   Fs_compat.mkdir_p target_root;
   let result =
     List.fold_left

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -932,8 +932,10 @@ let seed_one ~target_root ~force tally rel =
 
 let init_cmd_exit base_path force =
   let base_path = Env_config.normalize_masc_base_path_input base_path in
+  (* [init] seeds the explicitly requested workspace; runtime resolution may
+     honor [MASC_CONFIG_DIR], but bootstrap materialization must not. *)
   let target_root =
-    (Config_dir_resolver.resolve_for_base_path ~base_path).config_root.path
+    Filename.concat (Config_dir_resolver.masc_root ~base_path) "config"
   in
   Fs_compat.mkdir_p target_root;
   let result =

--- a/bin/masc_completion_trust_audit.ml
+++ b/bin/masc_completion_trust_audit.ml
@@ -38,7 +38,8 @@ let error msg =
 
 let default_events_dir () =
   match Sys.getenv_opt "MASC_BASE_PATH" with
-  | Some p when String.trim p <> "" -> Some (Filename.concat (Filename.concat p ".masc") "events")
+  | Some p when String.trim p <> "" ->
+    Some (Filename.concat (Config_dir_resolver.masc_root ~base_path:p) "events")
   | Some _ | None -> None
 ;;
 

--- a/bin/masc_trace.ml
+++ b/bin/masc_trace.ml
@@ -54,19 +54,21 @@ let decision_string_field json key =
   Yojson.Safe.Util.member "decision" json |> fun decision ->
   string_field decision key
 
+let masc_root ~base_path = Config_dir_resolver.masc_root ~base_path
+
 let receipts_dir ~base_path ~keeper =
-  List.fold_left Filename.concat base_path
-    [ ".masc"; "keepers"; keeper; "execution-receipts" ]
+  List.fold_left Filename.concat (masc_root ~base_path)
+    [ "keepers"; keeper; "execution-receipts" ]
 
 let runtime_manifests_dir ~base_path ~keeper =
-  List.fold_left Filename.concat base_path
-    [ ".masc"; "keepers"; keeper; "runtime-manifests" ]
+  List.fold_left Filename.concat (masc_root ~base_path)
+    [ "keepers"; keeper; "runtime-manifests" ]
 
 let logs_dir ~base_path =
-  List.fold_left Filename.concat base_path [ ".masc"; "logs" ]
+  List.fold_left Filename.concat (masc_root ~base_path) [ "logs" ]
 
 let tool_calls_dir ~base_path =
-  List.fold_left Filename.concat base_path [ ".masc"; "tool_calls" ]
+  List.fold_left Filename.concat (masc_root ~base_path) [ "tool_calls" ]
 
 (** Naive substring check — avoids pulling in [Str] for one call. *)
 let contains_substring s sub =

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -84,13 +84,13 @@ describe('KeeperRuntimeAlertStrip', () => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({
         needs_attention: true,
-        attention_reason: 'completion_contract_result:passive_only',
+        attention_reason: 'passive_only',
       }),
     }))
 
     const text = container.textContent ?? ''
     expect(text).toContain('수동 응답만 있음')
-    expect(text).not.toContain('completion_contract_result:passive_only')
+    expect(text).not.toContain('passive_only')
   })
 
   // First-class status_bridge reasons keep their OWN labels — they are no

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -568,7 +568,7 @@ describe('deriveKeeperAttentionReason', () => {
   it('humanizes known completion-contract composite reason codes', () => {
     const reason = deriveKeeperAttentionReason(makeKeeper({
       name: 'composite',
-      attention_reason: 'completion_contract_result:passive_only',
+      attention_reason: 'passive_only',
     }))
     expect(reason.text).toBe('수동 응답만 있음')
   })

--- a/dashboard/src/lib/keeper-attention-labels.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.test.ts
@@ -18,6 +18,13 @@ describe('keeper attention labels', () => {
     expect(warn).not.toHaveBeenCalled()
   })
 
+  it('labels known bare completion-contract tokens without warning', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(completionContractAttentionReasonLabel('passive_only')).toBe('수동 응답만 있음')
+    expect(attentionReasonLabel('passive_only', false)).toBe('수동 응답만 있음')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
   it('keeps unknown completion-contract composite reasons visible and warned', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/dashboard/src/lib/keeper-attention-labels.ts
+++ b/dashboard/src/lib/keeper-attention-labels.ts
@@ -92,9 +92,10 @@ const TRUST_RUNTIME_FAILURE_ALIASES: ReadonlySet<string> = new Set([
 ])
 
 // Mirrors the completion_contract_result arms that
-// keeper_runtime_trust_snapshot.ml can promote into an attention_reason via
-// `completion_contract_result:<reason>`. The satisfied_* receipt results are
-// intentionally absent because they are not attention reasons.
+// keeper_runtime_trust_snapshot.ml can promote into an attention_reason, either
+// as bare tokens or via the legacy `completion_contract_result:<reason>`
+// composite form. The satisfied_* receipt results are intentionally absent
+// because they are not attention reasons.
 export const ATTENTION_COMPLETION_CONTRACT_RESULTS = [
   'violated',
   'claim_only_after_owned_task',
@@ -106,8 +107,6 @@ export const ATTENTION_COMPLETION_CONTRACT_RESULTS = [
   'no_capable_provider',
 ] as const
 export type AttentionCompletionContractResult = typeof ATTENTION_COMPLETION_CONTRACT_RESULTS[number]
-export type CompletionContractAttentionReason =
-  `completion_contract_result:${AttentionCompletionContractResult}`
 
 const COMPLETION_CONTRACT_ATTENTION_REASON_LABELS: Record<AttentionCompletionContractResult, string> = {
   violated: '완료 계약 위반',
@@ -128,8 +127,7 @@ export function isAttentionCompletionContractResult(
 
 export function completionContractAttentionReasonLabel(reason: string): string | null {
   const prefix = 'completion_contract_result:'
-  if (!reason.startsWith(prefix)) return null
-  const result = reason.slice(prefix.length)
+  const result = reason.startsWith(prefix) ? reason.slice(prefix.length) : reason
   if (!isAttentionCompletionContractResult(result)) return null
   return COMPLETION_CONTRACT_ATTENTION_REASON_LABELS[result]
 }

--- a/lib/fd_accountant/fd_accountant.ml
+++ b/lib/fd_accountant/fd_accountant.ml
@@ -74,7 +74,7 @@ type fd_holding_state =
 type slot_state =
   { cap : int
   ; sem : Eio.Semaphore.t
-  ; mutex : Eio.Mutex.t
+  ; mutex : Stdlib.Mutex.t
   ; mutable holding_state : fd_holding_state
   ; mutable next_hold_id : int
   }
@@ -92,7 +92,7 @@ let _state_for_kind : (kind * slot_state) list =
       let cap = read_cap kind in
       (kind, { cap
               ; sem = Eio.Semaphore.make cap
-              ; mutex = Eio.Mutex.create ()
+              ; mutex = Stdlib.Mutex.create ()
               ; holding_state = Idle
               ; next_hold_id = 0
               }))
@@ -100,15 +100,16 @@ let _state_for_kind : (kind * slot_state) list =
 
 let state_of kind = List.assoc kind _state_for_kind
 
-(* Typed-state transitions under the per-slot mutex.  The mutex scope is one
-   record update; it does not span the caller's [f ()] so contention is
-   bounded.  [Eio.Mutex.use_rw ~protect:true] is the runtime contract here:
-   this accountant is installed in Eio server paths, and cancellation while
-   entering/leaving the state machine must not strand the lock. *)
+(* Typed-state transitions under the per-slot mutex. The mutex scope is one
+   record update and this state is read by both Eio fibers and worker domains,
+   so use [Stdlib.Mutex] rather than an Eio-owned mutex. *)
 (* Internal per-slot state-record form.  Not exported -- callers
    go through the kind-level entry points below. *)
+let with_slot_mutex state f =
+  Stdlib.Mutex.protect state.mutex f
+
 let mark_acquire_slot state =
-  Eio.Mutex.use_rw ~protect:true state.mutex (fun () ->
+  with_slot_mutex state (fun () ->
       let hold_id = state.next_hold_id in
       state.next_hold_id <- hold_id + 1;
       let acquired_at = Unix.gettimeofday () in
@@ -116,13 +117,13 @@ let mark_acquire_slot state =
       hold_id)
 
 let mark_release_slot state ~hold_id =
-  Eio.Mutex.use_rw ~protect:true state.mutex (fun () ->
+  with_slot_mutex state (fun () ->
       match state.holding_state with
       | Idle -> ()
       | In_flight _ -> state.holding_state <- Idle)
 
 let read_holding_slot state =
-  Eio.Mutex.use_rw ~protect:true state.mutex (fun () ->
+  with_slot_mutex state (fun () ->
       match state.holding_state with
       | Idle -> 0 | In_flight _ -> 1)
 

--- a/lib/keeper/keeper_execution_receipt_types.ml
+++ b/lib/keeper/keeper_execution_receipt_types.ml
@@ -136,6 +136,20 @@ let completion_contract_result_to_string = function
   | Contract_satisfied_execution -> "satisfied_execution"
 ;;
 
+let completion_contract_result_of_string = function
+  | "unknown" -> Some Contract_unknown
+  | "not_dispatched" -> Some Contract_not_dispatched
+  | "violated" -> Some Contract_violated
+  | "surface_mismatch" -> Some Contract_surface_mismatch
+  | "no_capable_provider" -> Some Contract_no_capable_provider
+  | "claim_only_after_owned_task" -> Some Contract_claim_only_after_owned_task
+  | "needs_execution_progress" -> Some Contract_needs_execution_progress
+  | "passive_only" -> Some Contract_passive_only
+  | "satisfied_completion" -> Some Contract_satisfied_completion
+  | "satisfied_execution" -> Some Contract_satisfied_execution
+  | _ -> None
+;;
+
 (* Lift the typed [Keeper_contract_classifier.contract_status] into the
    receipt-level [completion_contract_result].  Bridges the six classifier
    outcomes; the four boundary states are emitted only by producer sites

--- a/lib/keeper/keeper_execution_receipt_types.mli
+++ b/lib/keeper/keeper_execution_receipt_types.mli
@@ -43,6 +43,7 @@ type completion_contract_result =
   | Contract_satisfied_completion
   | Contract_satisfied_execution
 val completion_contract_result_to_string : completion_contract_result -> string
+val completion_contract_result_of_string : string -> completion_contract_result option
 val completion_contract_result_of_contract_status :
   Keeper_contract_classifier.contract_status -> completion_contract_result
 val encode_tool_list : string list -> string

--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -249,7 +249,10 @@ let run_keepalive_unified_turn
            Keeper_registry.record_skip_reasons
              ~base_path:ctx.config.base_path
              meta_after_triage.name
-             ~reasons:verdict_strs
+             ~reasons:verdict_strs;
+           Keeper_registry.touch_last_turn_ts
+             ~base_path:ctx.config.base_path
+             meta_after_triage.name
          | Runtime_backpressured { runtime_id; reason } ->
            record_runtime_backpressure_observation
              ~base_path:ctx.config.base_path

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -68,26 +68,21 @@ let terminal_reason_from_decision json =
 
 let terminal_reason_from_receipt receipt =
   let terminal_reason_code = json_string_opt_member "terminal_reason_code" receipt in
-  let operator_disposition =
-    json_string_opt_member "operator_disposition" receipt
-    |> Option.map String.lowercase_ascii
-  in
   let operator_disposition_reason =
     json_string_opt_member "operator_disposition_reason" receipt
     |> Option.map String.lowercase_ascii
   in
   let completion_contract_result =
-    json_string_opt_member "completion_contract_result" receipt
-    |> Option.map String.lowercase_ascii
+    Option.bind
+      (json_string_opt_member "completion_contract_result" receipt
+       |> Option.map String.lowercase_ascii)
+      (fun s -> Keeper_execution_receipt_types.completion_contract_result_of_string s)
   in
   let receipt_requires_tool_attention =
-    match operator_disposition, operator_disposition_reason, completion_contract_result with
-    | _, Some "tool_route_recoverable_failure", _
-    | _, _, Some "needs_execution_progress"
-    | _, _, Some "surface_mismatch"
-    | _, _, Some "no_capable_provider"
-    | _, _, Some "passive_only"
-    | _, _, Some "violated" ->
+    match operator_disposition_reason, completion_contract_result with
+    | Some "tool_route_recoverable_failure", _ -> true
+    | _, Some (Contract_needs_execution_progress | Contract_surface_mismatch
+               | Contract_no_capable_provider | Contract_passive_only | Contract_violated) ->
         true
     | _ -> false
   in
@@ -108,8 +103,10 @@ let terminal_reason_from_receipt receipt =
 
 let receipt_contract_attention_reason receipt =
   let completion_contract_result =
-    json_string_opt_member "completion_contract_result" receipt
-    |> Option.map (fun value -> String.lowercase_ascii (String.trim value))
+    Option.bind
+      (json_string_opt_member "completion_contract_result" receipt
+       |> Option.map (fun value -> String.lowercase_ascii (String.trim value)))
+      (fun s -> Keeper_execution_receipt_types.completion_contract_result_of_string s)
   in
   let terminal_reason_code =
     json_string_opt_member "terminal_reason_code" receipt
@@ -122,15 +119,14 @@ let receipt_contract_attention_reason receipt =
   in
   match completion_contract_result with
   | Some
-      ( ("violated" | "claim_only_after_owned_task" | "needs_execution_progress"
-        | "passive_only")
-        as reason ) ->
-      Some ("completion_contract_result:" ^ reason)
+      ((Contract_violated | Contract_claim_only_after_owned_task
+       | Contract_needs_execution_progress | Contract_passive_only) as result) ->
+      Some (Keeper_execution_receipt_types.completion_contract_result_to_string result)
   | Some
-      ( ("unknown" | "not_dispatched" | "surface_mismatch" | "no_capable_provider")
-        as reason )
+      ((Contract_unknown | Contract_not_dispatched | Contract_surface_mismatch
+       | Contract_no_capable_provider) as result)
     when turn_budget_exhausted ->
-      Some ("completion_contract_result:" ^ reason)
+      Some (Keeper_execution_receipt_types.completion_contract_result_to_string result)
   | Some _ | None -> None
 
 (* JSON-deserialization boundary: maps a runtime_blocker_class wire
@@ -589,6 +585,12 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
   let completion_contract_result =
     Option.bind latest_receipt (json_string_opt_member "completion_contract_result")
   in
+  let completion_contract_result_typed =
+    Option.bind
+      (Option.map (fun value -> String.lowercase_ascii (String.trim value))
+         completion_contract_result)
+      (fun s -> Keeper_execution_receipt_types.completion_contract_result_of_string s)
+  in
   let runtime_json =
     match latest_receipt with
     | Some receipt -> json_member "runtime" receipt
@@ -615,11 +617,12 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
     | json -> json_string_opt_member "selected_model" json
   in
   let mutation_guard_summary =
-    match completion_contract_result with
-    | Some "violated" -> "mutation_contract_violated"
-    | Some ("satisfied" | "satisfied_execution" | "satisfied_completion") ->
+    match completion_contract_result_typed with
+    | Some Contract_violated -> "mutation_contract_violated"
+    | Some (Contract_satisfied_completion | Contract_satisfied_execution) ->
         "mutation_contract_satisfied"
-    | Some other -> other
+    | Some result ->
+        Keeper_execution_receipt_types.completion_contract_result_to_string result
     | None -> "mutation_contract_not_observed"
   in
   `Assoc

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -585,6 +585,11 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
   let completion_contract_result =
     Option.bind latest_receipt (json_string_opt_member "completion_contract_result")
   in
+  let completion_contract_result_raw =
+    match Option.map String.trim completion_contract_result with
+    | Some value when value <> "" -> Some value
+    | Some _ | None -> None
+  in
   let completion_contract_result_typed =
     Option.bind
       (Option.map (fun value -> String.lowercase_ascii (String.trim value))
@@ -623,7 +628,10 @@ let execution_summary_json ~(meta : Keeper_meta_contract.keeper_meta) ~latest_re
         "mutation_contract_satisfied"
     | Some result ->
         Keeper_execution_receipt_types.completion_contract_result_to_string result
-    | None -> "mutation_contract_not_observed"
+    | None -> (
+        match completion_contract_result_raw with
+        | Some raw -> "unknown_completion_contract_result:" ^ raw
+        | None -> "mutation_contract_not_observed")
   in
   `Assoc
     [

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -193,6 +193,37 @@ let claim_bound_work (calls : (string * Keeper_tool_outcome.t option) list) =
     calls
 ;;
 
+let legitimate_no_work_passive_only
+      ~observation
+      ~(tool_calls : (string * Keeper_tool_outcome.t option) list)
+      ~had_owned_active_task
+  =
+  let actionable_signal =
+    Keeper_contract_classifier.classify_actionable_signal
+      (Keeper_contract_classifier.of_keeper_world_observation observation)
+  in
+  let passive_status_tool name =
+    match Keeper_tool_progress.classify_tool_progress name with
+    | Keeper_tool_progress.Passive_status -> true
+    | Keeper_tool_progress.Claim_context
+    | Keeper_tool_progress.Execution
+    | Keeper_tool_progress.Completion -> false
+  in
+  let non_material_outcome_effect name outcome =
+    match Keeper_tool_progress.classify_tool_progress_with_outcome name outcome with
+    | Keeper_tool_progress.Streak_increment
+    | Keeper_tool_progress.Streak_reset_and_empty_queue_sleep _ -> true
+    | Keeper_tool_progress.Streak_reset -> false
+  in
+  (not had_owned_active_task)
+  && tool_calls <> []
+  && List.for_all
+       (fun (name, outcome) ->
+          passive_status_tool name && non_material_outcome_effect name outcome)
+       tool_calls
+  && actionable_signal = Keeper_contract_classifier.No_actionable_signal
+;;
+
 let apply_loop_detectors ~config ~observation ~meta updated_meta result =
   (* RFC-0239 §3 R3 / RFC-0276 §3.2: feed the loop detector a semantic
      no-progress verdict derived from observed turn facts, not the LLM
@@ -235,22 +266,9 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
   let had_owned_active_task_at_turn_start =
     Option.is_some meta.Keeper_meta_contract.current_task_id
   in
-  let completion_contract =
-    Keeper_agent_run.completion_contract_result_for_progress_evidence
-      ~had_owned_active_task_at_turn_start
-      ~actual_keeper_tool_names:(Keeper_agent_result.tool_names result)
-  in
-  let actionable_signal =
-    Keeper_contract_classifier.classify_actionable_signal
-      (Keeper_contract_classifier.of_keeper_world_observation observation)
-  in
-  (* task-5: the exemption applies to any tool classified as [Passive_status]
-     by [Keeper_tool_progress.classify_tool_progress], including peer-surface
-     tools when the turn observed no work and owned no active task. *)
   let legitimate_no_work_passive_only =
-    (not had_owned_active_task_at_turn_start)
-    && completion_contract = Keeper_execution_receipt.Contract_passive_only
-    && actionable_signal = Keeper_contract_classifier.No_actionable_signal
+    legitimate_no_work_passive_only ~observation ~tool_calls:calls_with_outcomes
+      ~had_owned_active_task:had_owned_active_task_at_turn_start
   in
   let made_progress =
     Keeper_no_progress_loop_detector.turn_made_progress
@@ -307,20 +325,9 @@ module For_testing = struct
   let has_substantive_tool_calls_with_outcome = has_substantive_tool_calls_with_outcome
   let claim_bound_work = claim_bound_work
 
-  let legitimate_no_work_passive_only ~observation ~tool_names ~had_owned_active_task =
-    let completion_contract =
-      Keeper_agent_run.completion_contract_result_for_progress_evidence
-        ~had_owned_active_task_at_turn_start:had_owned_active_task
-        ~actual_keeper_tool_names:tool_names
-    in
-    let actionable_signal =
-      Keeper_contract_classifier.classify_actionable_signal
-        (Keeper_contract_classifier.of_keeper_world_observation observation)
-    in
-    (not had_owned_active_task)
-    && completion_contract = Keeper_execution_receipt.Contract_passive_only
-    && actionable_signal = Keeper_contract_classifier.No_actionable_signal
-  ;;
+  let legitimate_no_work_passive_only = legitimate_no_work_passive_only
+
+  let apply_loop_detectors = apply_loop_detectors
 end
 
 let append_metrics_snapshot

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -193,7 +193,7 @@ let claim_bound_work (calls : (string * Keeper_tool_outcome.t option) list) =
     calls
 ;;
 
-let apply_loop_detectors ~config ~observation updated_meta result =
+let apply_loop_detectors ~config ~observation ~meta updated_meta result =
   (* RFC-0239 §3 R3 / RFC-0276 §3.2: feed the loop detector a semantic
      no-progress verdict derived from observed turn facts, not the LLM
      self-declared header. A turn makes progress if it produced durable
@@ -232,10 +232,31 @@ let apply_loop_detectors ~config ~observation updated_meta result =
     | (Peer_only | User_facing | Internal_prose) as delivery ->
       delivery_requires_evidence delivery
   in
+  let had_owned_active_task_at_turn_start =
+    Option.is_some meta.Keeper_meta_contract.current_task_id
+  in
+  let completion_contract =
+    Keeper_agent_run.completion_contract_result_for_progress_evidence
+      ~had_owned_active_task_at_turn_start
+      ~actual_keeper_tool_names:(Keeper_agent_result.tool_names result)
+  in
+  let actionable_signal =
+    Keeper_contract_classifier.classify_actionable_signal
+      (Keeper_contract_classifier.of_keeper_world_observation observation)
+  in
+  (* task-5: the exemption applies to any tool classified as [Passive_status]
+     by [Keeper_tool_progress.classify_tool_progress], including peer-surface
+     tools when the turn observed no work and owned no active task. *)
+  let legitimate_no_work_passive_only =
+    (not had_owned_active_task_at_turn_start)
+    && completion_contract = Keeper_execution_receipt.Contract_passive_only
+    && actionable_signal = Keeper_contract_classifier.No_actionable_signal
+  in
   let made_progress =
     Keeper_no_progress_loop_detector.turn_made_progress
       ~strong_evidence
       ~surface_requires_evidence
+    || legitimate_no_work_passive_only
   in
   let threshold_override =
     no_work_budget_threshold_override
@@ -285,6 +306,21 @@ module For_testing = struct
   let delivery_requires_evidence = delivery_requires_evidence
   let has_substantive_tool_calls_with_outcome = has_substantive_tool_calls_with_outcome
   let claim_bound_work = claim_bound_work
+
+  let legitimate_no_work_passive_only ~observation ~tool_names ~had_owned_active_task =
+    let completion_contract =
+      Keeper_agent_run.completion_contract_result_for_progress_evidence
+        ~had_owned_active_task_at_turn_start:had_owned_active_task
+        ~actual_keeper_tool_names:tool_names
+    in
+    let actionable_signal =
+      Keeper_contract_classifier.classify_actionable_signal
+        (Keeper_contract_classifier.of_keeper_world_observation observation)
+    in
+    (not had_owned_active_task)
+    && completion_contract = Keeper_execution_receipt.Contract_passive_only
+    && actionable_signal = Keeper_contract_classifier.No_actionable_signal
+  ;;
 end
 
 let append_metrics_snapshot
@@ -639,7 +675,7 @@ let handle
       result
   in
   let updated_meta =
-    apply_loop_detectors ~config ~observation updated_meta result
+    apply_loop_detectors ~config ~observation ~meta updated_meta result
   in
   append_metrics_snapshot
     ~config

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -49,6 +49,16 @@ module For_testing : sig
       turn is no longer exempt from the no-progress streak. *)
   val claim_bound_work
     : (string * Keeper_tool_outcome.t option) list -> bool
+
+  (** task-5: a passive-only no-work exemption. A turn that only called tools
+      classified as [Passive_status] by [Keeper_tool_progress.classify_tool_progress]
+      and observed no actionable work at turn start is legitimately idle and must
+      not accrue the no-progress streak. *)
+  val legitimate_no_work_passive_only
+    :  observation:Keeper_world_observation.world_observation
+    -> tool_names:string list
+    -> had_owned_active_task:bool
+    -> bool
 end
 
 val handle

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -51,14 +51,22 @@ module For_testing : sig
     : (string * Keeper_tool_outcome.t option) list -> bool
 
   (** task-5: a passive-only no-work exemption. A turn that only called tools
-      classified as [Passive_status] by [Keeper_tool_progress.classify_tool_progress]
-      and observed no actionable work at turn start is legitimately idle and must
-      not accrue the no-progress streak. *)
+      classified as [Passive_status] and whose typed outcomes do not prove
+      material progress, while observing no actionable work at turn start, is
+      legitimately idle and must not accrue the no-progress streak. *)
   val legitimate_no_work_passive_only
     :  observation:Keeper_world_observation.world_observation
-    -> tool_names:string list
+    -> tool_calls:(string * Keeper_tool_outcome.t option) list
     -> had_owned_active_task:bool
     -> bool
+
+  val apply_loop_detectors
+    :  config:Workspace.config
+    -> observation:Keeper_world_observation.world_observation
+    -> meta:Keeper_meta_contract.keeper_meta
+    -> Keeper_meta_contract.keeper_meta
+    -> Keeper_agent_run.run_result
+    -> Keeper_meta_contract.keeper_meta
 end
 
 val handle

--- a/lib/repo_manager/keeper_repo_mapping.ml
+++ b/lib/repo_manager/keeper_repo_mapping.ml
@@ -201,7 +201,7 @@ type playground_path =
 
 let playground_path_of_path ~base_path ~path =
   let playground_root =
-    Filename.concat (Filename.concat base_path ".masc") "playground"
+    Filename.concat (Config_dir_resolver.masc_root ~base_path) "playground"
   in
   match relative_under ~root:playground_root path with
   | None -> None

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -223,6 +223,14 @@ let lower_string_opt =
   Option.map (fun value -> String.lowercase_ascii (String.trim value))
 ;;
 
+let completion_contract_result_of_execution execution =
+  match json_string "completion_contract_result" execution with
+  | Some raw ->
+    Keeper_execution_receipt_types.completion_contract_result_of_string
+      (String.lowercase_ascii (String.trim raw))
+  | None -> None
+;;
+
 let string_opt_is_any value candidates =
   match lower_string_opt value with
   | Some value -> List.mem value candidates
@@ -315,10 +323,10 @@ let composite_execution_contract_blocker_reason execution =
   if not recoverable_disposition
   then None
   else
-    match lower_string_opt (json_string "completion_contract_result" execution) with
-    | Some ("surface_mismatch" as reason) | Some ("no_capable_provider" as reason) ->
-      Some ("completion_contract_result:" ^ reason)
-    | _ -> None
+    match completion_contract_result_of_execution execution with
+    | Some ((Contract_surface_mismatch | Contract_no_capable_provider) as result) ->
+      Some (Keeper_execution_receipt_types.completion_contract_result_to_string result)
+    | Some _ | None -> None
 ;;
 
 let composite_execution_contract_blocked execution =
@@ -337,24 +345,23 @@ let composite_execution_config_drift execution =
 let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_activation_readiness_json
 
 let composite_execution_completion_unsatisfied_reason execution =
-  match lower_string_opt (json_string "completion_contract_result" execution) with
+  match completion_contract_result_of_execution execution with
   | Some
-      ( ("violated" | "claim_only_after_owned_task" | "needs_execution_progress"
-        | "passive_only")
-        as reason ) -> Some ("completion_contract_result:" ^ reason)
-  | Some _
-  | None -> None
+      ((Contract_violated | Contract_claim_only_after_owned_task
+       | Contract_needs_execution_progress | Contract_passive_only) as result) ->
+    Some (Keeper_execution_receipt_types.completion_contract_result_to_string result)
+  | Some _ | None -> None
 ;;
 
 let composite_execution_budget_unsatisfied_reason execution =
-  match lower_string_opt (json_string "completion_contract_result" execution) with
+  match completion_contract_result_of_execution execution with
   | Some
-      ( ("unknown" | "not_dispatched" | "violated" | "surface_mismatch"
-        | "no_capable_provider" | "claim_only_after_owned_task" | "needs_execution_progress"
-        | "passive_only")
-        as reason ) -> Some ("completion_contract_result:" ^ reason)
-  | Some _
-  | None -> None
+      ((Contract_unknown | Contract_not_dispatched | Contract_violated
+       | Contract_surface_mismatch | Contract_no_capable_provider
+       | Contract_claim_only_after_owned_task | Contract_needs_execution_progress
+       | Contract_passive_only) as result) ->
+    Some (Keeper_execution_receipt_types.completion_contract_result_to_string result)
+  | Some _ | None -> None
 ;;
 
 let composite_execution_turn_budget_exhausted execution =

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -162,7 +162,9 @@ let profile_of_string = function
 
 let sessions_file_path () =
   let base = default_base_path () in
-  Filename.concat (Filename.concat base ".masc") "mcp_transport_sessions.json"
+  Filename.concat
+    (Workspace_utils.masc_dir_from_base_path ~base_path:base)
+    "mcp_transport_sessions.json"
 
 (** Serialize current session state to JSON and write to disk atomically.
     Uses write-then-rename to avoid partial writes on crash. *)

--- a/lib/server/server_mcp_transport_http_session.ml
+++ b/lib/server/server_mcp_transport_http_session.ml
@@ -163,7 +163,7 @@ let profile_of_string = function
 let sessions_file_path () =
   let base = default_base_path () in
   Filename.concat
-    (Workspace_utils.masc_dir_from_base_path ~base_path:base)
+    (Config_dir_resolver.masc_root ~base_path:base)
     "mcp_transport_sessions.json"
 
 (** Serialize current session state to JSON and write to disk atomically.

--- a/scripts/check-ssot.sh
+++ b/scripts/check-ssot.sh
@@ -65,11 +65,11 @@ check_rule() {
 # SSOT-R1 — .masc path concat bypasses Workspace_utils.masc_dir helper.
 # Tracked: #8355 (37 files at filing; current ratchet from main).
 # Excluded: the helper impl + backend setters where the literal IS the SSOT.
-check_rule "R1-masc-path" 2 \
+check_rule "R1-masc-path" 0 \
   "Workspace_utils.masc_dir <config>" \
   'Filename\.concat\s+[a-zA-Z_]+\s+"\.masc"' \
   'workspace_utils_paths_backend|workspace_utils_backend_setup|workspace_eio' \
-  lib
+  lib bin
 
 # SSOT-R2 — loopback literal bypasses Masc_network_defaults.masc_http_default_host.
 # Tracked: #8387.

--- a/scripts/check-ssot.sh
+++ b/scripts/check-ssot.sh
@@ -100,7 +100,7 @@ check_rule "R5-health-path" 0 \
 
 # SSOT-R6 — no home-anchored MASC runtime root. Runtime state must resolve
 # from an explicit base path and then append .masc.
-check_rule "R6-home-masc-root" 9 \
+check_rule "R6-home-masc-root" 3 \
   "<base-path>/.masc with explicit MASC_BASE_PATH or --base-path" \
   '(\$HOME|\$\{HOME[^}]*\}|~)/[^[:space:]`'\''"]*\.masc([/[:space:]`'\''".,)]|$)' \
   '' \

--- a/test/keeper_tool_retry_state/test_keeper_tool_retry_state.ml
+++ b/test/keeper_tool_retry_state/test_keeper_tool_retry_state.ml
@@ -192,7 +192,7 @@ let test_distinct_tool_names_independent () =
     record ~tool_name:"tool_execute" ~error_signature:sig_ ~attempt:2 ()
   in
   let out =
-    record ~tool_name:"tool_execute" ~error_signature:sig_ ~attempt:1 ()
+    record ~tool_name:"masc_transition" ~error_signature:sig_ ~attempt:1 ()
   in
   match out with
   | `First -> ()

--- a/test/test_keeper_idle_threshold_contract.ml
+++ b/test/test_keeper_idle_threshold_contract.ml
@@ -15,8 +15,46 @@
     10-15) ended via Skip. *)
 
 open Alcotest
+module Reg = Masc.Keeper_registry
+module Sup = Masc.Keeper_supervisor
+module KSM = Keeper_state_machine
+module Keeper_meta_json_parse = Masc.Keeper_meta_json_parse
 
 let skip_at = Env_config_keeper.KeeperKeepalive.idle_skip_threshold
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_keeper_idle_threshold_contract_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path
+    then
+      if Sys.is_directory path
+      then (
+        Sys.readdir path |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let make_meta name =
+  let json =
+    `Assoc
+      [ ("name", `String name)
+      ; ("agent_name", `String ("agent-" ^ name))
+      ; ("trace_id", `String ("trace-" ^ name))
+      ; ("goal", `String "test")
+      ; ("sandbox_profile", `String "local")
+      ; ("network_mode", `String "inherit")
+      ; ("tool_access", `List [])
+      ]
+  in
+  match Keeper_meta_json_parse.meta_of_json json with
+  | Ok meta -> meta
+  | Error err -> fail ("make_meta: " ^ err)
 
 let test_reactive_guard_above_skip () =
   let guard = Masc.Keeper_runtime_resolved.reactive_max_idle_turns () in
@@ -88,6 +126,76 @@ let test_env_override_cannot_lower_guard_below_skip () =
       true
       (guard > skip_at))
 
+(* Regression: the heartbeat-loop Runtime_admitted skip branch must refresh
+   last_turn_ts so the stale watchdog does not misclassify a legitimate
+   no-work keeper as Idle_turn. The branch performs:
+     1. record_skip_reasons
+     2. touch_last_turn_ts
+   Without step 2, the old timestamp stays in place and assess_stale_run
+   returns Some (Stale_turn_timeout (Idle_turn _)). *)
+let test_runtime_admitted_skip_refreshes_last_turn_ts () =
+  let bp = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir bp)
+    (fun () ->
+      let name = "skip-touch-keeper" in
+      let meta = make_meta name in
+      let entry = Reg.register ~base_path:bp name meta in
+      let stale_ts = 100.0 in
+      let now = 300.0 in
+      let threshold = 150.0 in
+      (* touch_last_turn_ts uses wall-clock time, so fresh_ts will be far larger than now,
+         keeping the keeper inside the threshold. *)
+      (* Keeper completed a turn long ago. *)
+      let stale_meta =
+        let runtime = entry.meta.runtime in
+        let usage = runtime.usage in
+        { entry.meta with
+          runtime = { runtime with usage = { usage with last_turn_ts = stale_ts } }
+        }
+      in
+      Reg.update_meta ~base_path:bp name stale_meta;
+      (* Model the Runtime_admitted skip branch: record reasons, then touch. *)
+      let admitted_skip ~base_path name ~reasons =
+        Reg.record_skip_reasons ~base_path name ~reasons;
+        Reg.touch_last_turn_ts ~base_path name
+      in
+      (* Step 1 alone leaves last_turn_ts stale -> Idle_turn. *)
+      Reg.record_skip_reasons ~base_path:bp name ~reasons:[ "no_signal" ];
+      (match
+         Sup.assess_stale_run
+           ~phase:KSM.Running
+           ~in_turn:None
+           ~last_turn_ts:stale_ts
+           ~now
+           ~threshold
+       with
+       | Some (Reg.Stale_turn_timeout (Reg.Idle_turn _)) -> ()
+       | other ->
+         fail
+           (Printf.sprintf
+              "record_skip_reasons alone should leave keeper stale (Idle_turn), got %s"
+              (match other with
+               | Some r -> Reg.failure_reason_to_string r
+               | None -> "None")));
+      (* Step 2 is the regression fix: touch_last_turn_ts refreshes activity. *)
+      admitted_skip ~base_path:bp name ~reasons:[ "no_signal" ];
+      match Reg.get ~base_path:bp name with
+      | None -> fail "keeper should still be registered after admitted skip"
+      | Some entry ->
+        let fresh_ts = entry.meta.runtime.usage.last_turn_ts in
+        check bool "touch_last_turn_ts advances last_turn_ts" true (fresh_ts > stale_ts);
+        check bool
+          "after admitted skip touch, assess_stale_run returns None"
+          true
+          (Option.is_none
+             (Sup.assess_stale_run
+                ~phase:KSM.Running
+                ~in_turn:None
+                ~last_turn_ts:fresh_ts
+                ~now
+                ~threshold)))
+
 let () =
   Alcotest.run
     "Keeper_idle_threshold_contract"
@@ -102,5 +210,9 @@ let () =
             "env override cannot lower guard below skip"
             `Quick
             test_env_override_cannot_lower_guard_below_skip
+        ; test_case
+            "Runtime_admitted skip refreshes last_turn_ts"
+            `Quick
+            test_runtime_admitted_skip_refreshes_last_turn_ts
         ] )
     ]

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -213,6 +213,42 @@ let test_budget_not_dispatched_receipt_marks_attention () =
          (snapshot |> member "operator_disposition_reason" |> to_string))
 ;;
 
+let test_unknown_completion_contract_result_stays_visible () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       let keeper_name = "runtime-trust-unknown-contract" in
+       let meta = make_meta keeper_name in
+       let receipt_store =
+         Masc.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+       in
+       Dated_jsonl.append
+         receipt_store
+         (`Assoc
+             [ "ended_at", `String "2026-06-01T00:00:00Z"
+             ; "completion_contract_result", `String "future_state"
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       Alcotest.(check string)
+         "raw completion contract result remains on execution summary"
+         "future_state"
+         (snapshot |> member "execution" |> member "completion_contract_result"
+          |> to_string);
+       Alcotest.(check string)
+         "unknown result is visible instead of collapsed to not observed"
+         "unknown_completion_contract_result:future_state"
+         (snapshot |> member "execution" |> member "mutation_guard_summary"
+          |> to_string))
+;;
+
 let test_model_observability_uses_runtime_trust_selected_model () =
   let runtime_trust =
     `Assoc
@@ -310,6 +346,10 @@ let () =
             "budget not-dispatched receipt marks runtime-trust attention"
             `Quick
             test_budget_not_dispatched_receipt_marks_attention
+        ; Alcotest.test_case
+            "unknown completion-contract result remains visible"
+            `Quick
+            test_unknown_completion_contract_result_stays_visible
         ; Alcotest.test_case
             "status model observability reuses runtime-trust execution selected model"
             `Quick

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -197,7 +197,7 @@ let test_budget_not_dispatched_receipt_marks_attention () =
          (snapshot |> member "disposition" |> to_string);
        Alcotest.(check string)
          "display reason"
-         "completion_contract_result:not_dispatched"
+         "not_dispatched"
          (snapshot |> member "disposition_reason" |> to_string);
        Alcotest.(check bool)
          "needs attention"

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -477,6 +477,52 @@ let test_scope_message_internal_textonly_accrues_streak () =
     "internal scope-message prose without evidence accrues streak" 4
     (D.current_streak ~keeper_name:k)
 
+(* task-5 keeper-stability: a passive-only turn that observed no actionable
+   work and did not own an active task is legitimately idle. It must not accrue
+   the no-progress streak even when the surface otherwise requires evidence.
+   The exemption applies to any tool classified as [Passive_status] by
+   [Keeper_tool_progress.classify_tool_progress], including peer-surface tools
+   when no work/owned task exists. *)
+let test_passive_only_no_work_does_not_accrue () =
+  D.reset_all_for_test ();
+  let k = "passive-no-work" in
+  (* The classifier uses [claimable_task_count] to decide whether there is an
+     actionable signal, so [unclaimed_task_count] is omitted here. *)
+  let observation =
+    { scheduled_observation with
+      claimable_task_count = 0
+    }
+  in
+  let is_legitimate tool_names had_owned_active_task =
+    Success.legitimate_no_work_passive_only
+      ~observation
+      ~tool_names
+      ~had_owned_active_task
+  in
+  Alcotest.(check bool) "passive-only no-work is legitimate" true
+    (is_legitimate [ "keeper_surface_read" ] false);
+  Alcotest.(check bool) "owned active task breaks legitimacy" false
+    (is_legitimate [ "keeper_surface_read" ] true);
+  Alcotest.(check bool) "actionable signal breaks legitimacy" false
+    (Success.legitimate_no_work_passive_only
+       ~observation:{ observation with claimable_task_count = 1 }
+       ~tool_names:[ "keeper_surface_read" ]
+       ~had_owned_active_task:false);
+  (* [classify_tool_progress] currently treats [tool_execute] as [Passive_status],
+     so the negative case for a non-passive tool uses a claim tool instead. *)
+  Alcotest.(check bool) "non-passive tool breaks legitimacy" false
+    (is_legitimate [ List.hd Cap.claim_task_tool_names ] false);
+  for _ = 1 to D.threshold () do
+    let surface_requires_evidence = true in
+    record_turn ~keeper_name:k
+      ~made_progress:
+        (D.turn_made_progress ~strong_evidence:false ~surface_requires_evidence
+         || is_legitimate [ "keeper_surface_read" ] false)
+    |> ignore_outcome
+  done;
+  Alcotest.(check int) "streak stays 0" 0 (D.current_streak ~keeper_name:k)
+;;
+
 (* RFC-0239 / audit D1·D3: the no-progress detector reads the typed outcome
    recorded on each tool call, not just the tool name. *)
 module Outcome = Keeper_tool_outcome
@@ -604,6 +650,9 @@ let () =
           Alcotest.test_case
             "R3 scope-message internal prose accrues streak"
             `Quick (with_eio test_scope_message_internal_textonly_accrues_streak);
+          Alcotest.test_case
+            "passive-only no-work does not accrue streak (task-5)"
+            `Quick (with_eio test_passive_only_no_work_does_not_accrue);
           Alcotest.test_case "claim exemption is outcome-aware (D3)"
             `Quick test_claim_outcome_aware_exemption;
           Alcotest.test_case "strong evidence drops typed-failure completions (D1)"

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -20,6 +20,21 @@ module Cap = Masc.Keeper_tool_capability_axis
    context, so wrap each Alcotest body in Eio_main.run. *)
 let with_eio f () = Eio_main.run @@ fun _env -> f ()
 
+let rec remove_tree path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Sys.readdir path |> Array.iter (fun name -> remove_tree (Filename.concat path name));
+      Unix.rmdir path)
+    else Sys.remove path
+
+let with_temp_config f =
+  let base_path = Filename.temp_file "test_no_progress_loop_" "" in
+  Unix.unlink base_path;
+  Unix.mkdir base_path 0o755;
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_path)
+    (fun () -> f (Masc.Workspace.default_config base_path))
+
 let detected_count keeper =
   Metrics.metric_value_or_zero
     "masc_keeper_no_progress_loop_detected_total"
@@ -493,31 +508,31 @@ let test_passive_only_no_work_does_not_accrue () =
       claimable_task_count = 0
     }
   in
-  let is_legitimate tool_names had_owned_active_task =
+  let is_legitimate tool_calls had_owned_active_task =
     Success.legitimate_no_work_passive_only
       ~observation
-      ~tool_names
+      ~tool_calls
       ~had_owned_active_task
   in
   Alcotest.(check bool) "passive-only no-work is legitimate" true
-    (is_legitimate [ "keeper_surface_read" ] false);
+    (is_legitimate [ ("keeper_surface_read", None) ] false);
   Alcotest.(check bool) "owned active task breaks legitimacy" false
-    (is_legitimate [ "keeper_surface_read" ] true);
+    (is_legitimate [ ("keeper_surface_read", None) ] true);
   Alcotest.(check bool) "actionable signal breaks legitimacy" false
     (Success.legitimate_no_work_passive_only
        ~observation:{ observation with claimable_task_count = 1 }
-       ~tool_names:[ "keeper_surface_read" ]
+       ~tool_calls:[ ("keeper_surface_read", None) ]
        ~had_owned_active_task:false);
   (* [classify_tool_progress] currently treats [tool_execute] as [Passive_status],
      so the negative case for a non-passive tool uses a claim tool instead. *)
   Alcotest.(check bool) "non-passive tool breaks legitimacy" false
-    (is_legitimate [ List.hd Cap.claim_task_tool_names ] false);
+    (is_legitimate [ (List.hd Cap.claim_task_tool_names, None) ] false);
   for _ = 1 to D.threshold () do
     let surface_requires_evidence = true in
     record_turn ~keeper_name:k
       ~made_progress:
         (D.turn_made_progress ~strong_evidence:false ~surface_requires_evidence
-         || is_legitimate [ "keeper_surface_read" ] false)
+         || is_legitimate [ ("keeper_surface_read", None) ] false)
     |> ignore_outcome
   done;
   Alcotest.(check int) "streak stays 0" 0 (D.current_streak ~keeper_name:k)
@@ -537,6 +552,67 @@ let no_eligible_outcome =
           ; all_goals_excluded = false
           }
     }
+
+let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+          [ "name", `String name
+          ; "trace_id", `String ("trace-" ^ name)
+          ; "goal", `String "test no-progress detector"
+          ])
+  with
+  | Ok meta -> meta
+  | Error err -> Alcotest.fail ("meta fixture failed: " ^ err)
+
+let prompt_metrics =
+  Masc.Keeper_agent_prompt_metrics.build_prompt_metrics ~system_prompt:""
+    ~dynamic_context:"" ~user_message:""
+
+let ctx_composition : Masc.Keeper_agent_prompt_metrics.ctx_composition_metrics =
+  { actual_input_tokens = None
+  ; display_total_tokens = 0
+  ; estimated_known_tokens = 0
+  ; segments = []
+  }
+
+let tool_surface : Masc.Keeper_agent_tool_surface.tool_surface_metrics =
+  { turn_lane = Masc.Keeper_agent_tool_surface.Lane_tool_optional
+  ; config_root = ""
+  ; runtime_config_path = None
+  }
+
+let tool_call ?typed_outcome tool_name : Masc.Keeper_agent_result.tool_call_detail =
+  { tool_name
+  ; provider = "test"
+  ; outcome = "ok"
+  ; typed_outcome
+  ; latency_ms = 0.0
+  ; task_id = None
+  ; route_evidence = None
+  }
+
+let run_result tool_calls : Masc.Keeper_agent_run.run_result =
+  { response_text = ""
+  ; model_used = "test-model"
+  ; prompt_metrics
+  ; ctx_composition
+  ; runtime_observation = None
+  ; turn_count = 1
+  ; usage = Masc.Inference_utils.zero_usage
+  ; usage_reported = true
+  ; tool_calls
+  ; checkpoint = None
+  ; trace_ref = None
+  ; run_validation = None
+  ; stop_reason = Runtime_agent.Completed
+  ; inference_telemetry = None
+  ; tool_surface
+  ; pre_dispatch_compacted = false
+  ; pre_dispatch_compaction_trigger = None
+  ; pre_dispatch_compaction_before_tokens = None
+  ; pre_dispatch_compaction_after_tokens = None
+  }
 
 (* audit D3: a [Task_claim] turn is exempt only when a claim bound work. A claim
    that typed [No_eligible_tasks] did not bind work (the sangsu claim-idle loop,
@@ -587,6 +663,33 @@ let test_sangsu_claim_idle_loop_accrues () =
   Alcotest.(check bool) "claim that bound work stays exempt" true
     (D.turn_made_progress ~strong_evidence:false
        ~surface_requires_evidence:(not (Success.claim_bound_work bound)))
+
+let test_apply_loop_detectors_passive_only_no_work_does_not_accrue () =
+  D.reset_all_for_test ();
+  with_temp_config @@ fun config ->
+  let keeper = "apply-passive-no-work" in
+  let meta = make_meta keeper in
+  let result = run_result [ tool_call "keeper_surface_read" ] in
+  for _ = 1 to D.threshold () do
+    ignore
+      (Success.apply_loop_detectors ~config ~observation:scheduled_observation
+         ~meta meta result)
+  done;
+  Alcotest.(check int) "production detector path keeps passive no-work at zero" 0
+    (D.current_streak ~keeper_name:keeper)
+
+let test_apply_loop_detectors_claim_no_eligible_accrues () =
+  D.reset_all_for_test ();
+  with_temp_config @@ fun config ->
+  let keeper = "apply-claim-no-eligible" in
+  let meta = make_meta keeper in
+  let claim = List.hd Cap.claim_task_tool_names in
+  let result = run_result [ tool_call ~typed_outcome:no_eligible_outcome claim ] in
+  ignore
+    (Success.apply_loop_detectors ~config ~observation:scheduled_observation ~meta
+       meta result);
+  Alcotest.(check int) "production detector path accrues typed no-eligible claim" 1
+    (D.current_streak ~keeper_name:keeper)
 
 (* RFC-0289 / SSOT: [Keeper_tool_outcome.is_nonprogress] is the single owner of
    the outcome gate (previously inlined in [typed_outcome_is_nonprogress], now a
@@ -659,6 +762,12 @@ let () =
             `Quick test_strong_evidence_outcome_aware;
           Alcotest.test_case "sangsu claim-idle loop accrues streak"
             `Quick test_sangsu_claim_idle_loop_accrues;
+          Alcotest.test_case
+            "apply_loop_detectors passive-only no-work stays reset"
+            `Quick (with_eio test_apply_loop_detectors_passive_only_no_work_does_not_accrue);
+          Alcotest.test_case
+            "apply_loop_detectors typed no-eligible claim accrues"
+            `Quick (with_eio test_apply_loop_detectors_claim_no_eligible_accrues);
           Alcotest.test_case "is_nonprogress 4-arm mapping (RFC-0289 SSOT)"
             `Quick test_is_nonprogress_branches;
         ] );

--- a/test/test_server_dashboard_composite_attention.ml
+++ b/test/test_server_dashboard_composite_attention.ml
@@ -93,7 +93,7 @@ let test_contract_blocker_marks_attention () =
   check
     (option string)
     "reason"
-    (Some "completion_contract_result:surface_mismatch")
+    (Some "surface_mismatch")
     attention.cra_reason
 ;;
 
@@ -154,7 +154,7 @@ let test_passive_budget_exhaustion_is_blocked () =
   check
     (option string)
     "reason"
-    (Some "completion_contract_result:passive_only")
+    (Some "passive_only")
     attention.cra_reason
 ;;
 
@@ -170,7 +170,7 @@ let test_completed_passive_receipt_is_blocked () =
   check
     (option string)
     "reason"
-    (Some "completion_contract_result:passive_only")
+    (Some "passive_only")
     attention.cra_reason
 ;;
 
@@ -186,7 +186,7 @@ let test_not_dispatched_budget_exhaustion_is_blocked () =
   check
     (option string)
     "reason"
-    (Some "completion_contract_result:not_dispatched")
+    (Some "not_dispatched")
     attention.cra_reason
 ;;
 


### PR DESCRIPTION
## Summary
- Touch last_turn_ts on Runtime_admitted keepalive skip to avoid false-positive Idle_turn.
- Exempt passive-only no-work turns from the no-progress streak when there is no owned task and no actionable signal.
- Replace completion_contract_result:* composite-string attention reasons with typed variant matching and emit bare tokens.
- Route remaining .masc/config path concatenations through SSOT helpers and ratchet R1 baseline to 0.

## Test Plan
- Targeted OCaml tests pass (idle threshold, no-progress loop detector, runtime trust snapshot, dashboard composite attention).
- Dashboard full suite passes (8,086 tests).
- scripts/check-ssot.sh reports R1-masc-path: 0 occurrences (baseline 0).
- Full CI green required before merge.