### PR TITLE
fix(memory): surface legacy keeper inventory

### DIFF
--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -369,6 +369,9 @@ let resolve_for_base_path ~base_path =
 let keepers_dir_for_base_path ~base_path =
   (resolve_for_base_path ~base_path).keepers.path
 
+let keeper_runtime_store_of_dirname =
+  Common.keeper_runtime_store_of_dirname
+
 let personas_dir_opt () =
   let resolution = resolve () in
   match resolution.config_root.source with

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -91,6 +91,10 @@ val keepers_dir_for_base_path : base_path:string -> string
 (** [keepers_dir_for_base_path ~base_path] returns the keepers directory for an
     explicit workspace base path. *)
 
+val keeper_runtime_store_of_dirname : string -> Common.keeper_runtime_store option
+(** Base-path-independent resolver for canonical child-store names under
+    [Common.keepers_runtime_dirname]. *)
+
 val personas_dirs_for_base_path : base_path:string -> string list
 (** Base-path-scoped variant of {!personas_dirs}. *)
 

--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -56,6 +56,42 @@ let masc_dir_from_base_path ~base_path =
 let keepers_runtime_dir_of_base ~base_path =
   Filename.concat (masc_dir_from_base_path ~base_path) keepers_runtime_dirname
 
+type keeper_runtime_store =
+  | Keeper_tool_usage
+  | Keeper_runtime_manifests
+  | Keeper_metrics
+  | Keeper_execution_receipts
+  | Keeper_turn_records
+  | Keeper_reaction_ledger
+  | Keeper_trajectories
+
+let keeper_runtime_store_dirname = function
+  | Keeper_tool_usage -> "tool_usage"
+  | Keeper_runtime_manifests -> "runtime-manifests"
+  | Keeper_metrics -> "metrics"
+  | Keeper_execution_receipts -> "execution-receipts"
+  | Keeper_turn_records -> "turn-records"
+  | Keeper_reaction_ledger -> "reaction-ledger"
+  | Keeper_trajectories -> "trajectories"
+
+let keeper_runtime_stores =
+  [ Keeper_tool_usage
+  ; Keeper_runtime_manifests
+  ; Keeper_metrics
+  ; Keeper_execution_receipts
+  ; Keeper_turn_records
+  ; Keeper_reaction_ledger
+  ; Keeper_trajectories
+  ]
+
+let keeper_runtime_store_dirnames =
+  List.map keeper_runtime_store_dirname keeper_runtime_stores
+
+let keeper_runtime_store_of_dirname name =
+  List.find_opt
+    (fun store -> String.equal name (keeper_runtime_store_dirname store))
+    keeper_runtime_stores
+
 let auth_dir_from_base_path ~base_path =
   Filename.concat (masc_dir_from_base_path ~base_path) "auth"
 

--- a/lib/core/common.mli
+++ b/lib/core/common.mli
@@ -54,6 +54,20 @@ val keepers_runtime_dir_of_base : base_path:string -> string
     (default cluster). Low-level SSOT that avoids the Workspace dependency cycle
     the cluster-aware [Workspace.keepers_runtime_dir] would impose. *)
 
+type keeper_runtime_store =
+  | Keeper_tool_usage
+  | Keeper_runtime_manifests
+  | Keeper_metrics
+  | Keeper_execution_receipts
+  | Keeper_turn_records
+  | Keeper_reaction_ledger
+  | Keeper_trajectories
+(** Canonical child-store names under {!keepers_runtime_dirname}. *)
+
+val keeper_runtime_store_dirname : keeper_runtime_store -> string
+val keeper_runtime_store_of_dirname : string -> keeper_runtime_store option
+val keeper_runtime_store_dirnames : string list
+
 val auth_dir_from_base_path : base_path:string -> string
 (** [<base_path>/.masc/auth]. SSOT path so {!Auth} and
     {!Keeper_identity} can both compute it without depending on each

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -83,12 +83,28 @@ let events_path_for_keepers_dir ~keepers_dir ~keeper_id =
   Filename.concat keepers_dir (keeper_id ^ ".events.jsonl")
 ;;
 
+type legacy_memory_file =
+  | Legacy_facts
+  | Legacy_events
+
+let supported_legacy_memory_files = [ Legacy_facts; Legacy_events ]
+
+let legacy_memory_filename = function
+  | Legacy_facts -> "facts.jsonl"
+  | Legacy_events -> "events.jsonl"
+;;
+
+let legacy_memory_file_of_filename filename =
+  List.find_opt
+    (fun legacy_file -> String.equal filename (legacy_memory_filename legacy_file))
+    supported_legacy_memory_files
+;;
+
 let current_path_for_legacy_memory_filename ~keepers_dir ~keeper_id ~filename =
-  if String.equal filename "facts.jsonl"
-  then Some (facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
-  else if String.equal filename "events.jsonl"
-  then Some (events_path_for_keepers_dir ~keepers_dir ~keeper_id)
-  else None
+  match legacy_memory_file_of_filename filename with
+  | Some Legacy_facts -> Some (facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+  | Some Legacy_events -> Some (events_path_for_keepers_dir ~keepers_dir ~keeper_id)
+  | None -> None
 ;;
 
 let events_path ~keeper_id =

--- a/lib/keeper/keeper_memory_os_io.ml
+++ b/lib/keeper/keeper_memory_os_io.ml
@@ -83,6 +83,14 @@ let events_path_for_keepers_dir ~keepers_dir ~keeper_id =
   Filename.concat keepers_dir (keeper_id ^ ".events.jsonl")
 ;;
 
+let current_path_for_legacy_memory_filename ~keepers_dir ~keeper_id ~filename =
+  if String.equal filename "facts.jsonl"
+  then Some (facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
+  else if String.equal filename "events.jsonl"
+  then Some (events_path_for_keepers_dir ~keepers_dir ~keeper_id)
+  else None
+;;
+
 let events_path ~keeper_id =
   events_path_for_keepers_dir ~keepers_dir:(keepers_dir ()) ~keeper_id
 ;;

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -21,6 +21,13 @@ val list_fact_store_keeper_ids_for_base_path : base_path:string -> string list
 
 val events_path : keeper_id:string -> string
 val events_path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
+
+type legacy_memory_file =
+  | Legacy_facts
+  | Legacy_events
+
+val supported_legacy_memory_files : legacy_memory_file list
+val legacy_memory_filename : legacy_memory_file -> string
 val current_path_for_legacy_memory_filename :
   keepers_dir:string -> keeper_id:string -> filename:string -> string option
 (** Map a legacy per-keeper Memory OS filename under [.masc/keepers/<keeper>/]

--- a/lib/keeper/keeper_memory_os_io.mli
+++ b/lib/keeper/keeper_memory_os_io.mli
@@ -21,6 +21,11 @@ val list_fact_store_keeper_ids_for_base_path : base_path:string -> string list
 
 val events_path : keeper_id:string -> string
 val events_path_for_keepers_dir : keepers_dir:string -> keeper_id:string -> string
+val current_path_for_legacy_memory_filename :
+  keepers_dir:string -> keeper_id:string -> filename:string -> string option
+(** Map a legacy per-keeper Memory OS filename under [.masc/keepers/<keeper>/]
+    to the current store path under [keepers_dir], when the filename is a
+    supported legacy memory artifact. *)
 val episodes_dir : keeper_id:string -> string
 val tool_results_dir : keeper_id:string -> string
 val tool_result_path : keeper_id:string -> tool_call_id:string -> string

--- a/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
+++ b/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
@@ -22,6 +22,20 @@ type entry =
   ; reason : string
   }
 
+type scan_error =
+  { path : string
+  ; operation : string
+  ; message : string
+  }
+
+type scan_result =
+  { entries : entry list
+  ; truncated : bool
+  ; visited : int
+  ; errors : scan_error list
+  ; exists : bool
+  }
+
 let default_max_depth = 4
 let default_max_entries = 5_000
 
@@ -48,20 +62,7 @@ let split_relative rel =
 
 let has_suffix name suffix = String.ends_with ~suffix name
 
-let is_backup_name name =
-  has_suffix name ".bak"
-  || has_suffix name ".backup"
-  || has_suffix name ".old"
-  || has_suffix name "~"
-;;
-
-let is_orphan_temp_name name =
-  String.equal name "PYEOF"
-  || (String.starts_with ~prefix:".atomic_" name && has_suffix name ".tmp")
-  || has_suffix name ".tmp"
-;;
-
-let live_top_level_dirs =
+let live_runtime_store_dirs =
   [ "tool_usage"
   ; "runtime-manifests"
   ; "metrics"
@@ -72,48 +73,54 @@ let live_top_level_dirs =
   ]
 ;;
 
-let live_keeper_child_dirs =
-  [ "metrics"
-  ; "execution-receipts"
-  ; "turn-records"
-  ; "reaction-ledger"
-  ; "runtime-manifests"
-  ; "trajectories"
-  ; "tool_usage"
-  ]
+let member name names = List.exists (String.equal name) names
+
+let regular_path_exists_no_follow path =
+  try
+    match (Unix.lstat path).Unix.st_kind with
+    | Unix.S_REG -> true
+    | Unix.S_DIR | Unix.S_LNK | Unix.S_CHR | Unix.S_BLK | Unix.S_FIFO | Unix.S_SOCK ->
+      false
+  with
+  | Unix.Unix_error _ -> false
 ;;
 
-let memory_os_filenames = [ "facts.jsonl"; "events.jsonl"; "episodes.jsonl" ]
-
-let member name names = List.exists (String.equal name) names
+let migrated_memory_path_for_legacy_filename ~current_keepers_dir ~keeper_id filename =
+  if String.equal filename "facts.jsonl"
+  then
+    Some
+      (Keeper_memory_os_io.facts_path_for_keepers_dir
+         ~keepers_dir:current_keepers_dir
+         ~keeper_id)
+  else if String.equal filename "events.jsonl"
+  then
+    Some
+      (Keeper_memory_os_io.events_path_for_keepers_dir
+         ~keepers_dir:current_keepers_dir
+         ~keeper_id)
+  else None
+;;
 
 let migrated_memory_path_exists ~current_keepers_dir parts =
   match parts with
-  | keeper_id :: filename :: [] when member filename memory_os_filenames ->
-    Sys.file_exists (Filename.concat (Filename.concat current_keepers_dir keeper_id) filename)
+  | keeper_id :: filename :: [] ->
+    (match migrated_memory_path_for_legacy_filename ~current_keepers_dir ~keeper_id filename with
+     | Some path -> regular_path_exists_no_follow path
+     | None -> false)
   | _ -> false
 ;;
 
 let classify ~current_keepers_dir ~rel ~kind =
   let parts = split_relative rel in
-  let name =
-    match List.rev parts with
-    | [] -> rel
-    | hd :: _ -> hd
-  in
-  if is_orphan_temp_name name
-  then Orphaned, "orphaned_temp_or_marker"
-  else if is_backup_name name
-  then Backup, "backup_suffix"
-  else if migrated_memory_path_exists ~current_keepers_dir parts
+  if migrated_memory_path_exists ~current_keepers_dir parts
   then Migrated, "memory_os_file_already_present_under_config_keepers"
   else (
     match parts with
     | [ top ] when String.equal kind "file" && has_suffix top ".json" ->
       Live, "legacy_keeper_meta_json"
-    | top :: _ when member top live_top_level_dirs ->
+    | top :: _ when member top live_runtime_store_dirs ->
       Live, "known_top_level_runtime_store"
-    | _keeper :: child :: _ when member child live_keeper_child_dirs ->
+    | _keeper :: child :: _ when member child live_runtime_store_dirs ->
       Live, "known_keeper_runtime_store"
     | _ -> Unknown, "unclassified_legacy_path")
 ;;
@@ -129,27 +136,54 @@ let stat_kind st =
   | Unix.S_SOCK -> "socket"
 ;;
 
-let safe_lstat path =
-  try Some (Unix.lstat path) with
-  | Unix.Unix_error _ -> None
+let error_message = function
+  | Unix.Unix_error (err, _, _) -> Unix.error_message err
+  | Sys_error msg -> msg
+  | exn -> Printexc.to_string exn
 ;;
 
-let sorted_readdir path =
-  try Sys.readdir path |> Array.to_list |> List.sort String.compare with
-  | Sys_error _ -> []
+let display_path ~root path =
+  if String.equal path root then "." else relative_path ~root path
+;;
+
+let record_error errors ~root ~operation path exn =
+  let error =
+    { path = display_path ~root path; operation; message = error_message exn }
+  in
+  errors := error :: !errors;
+  Log.Dashboard.warn
+    "legacy keeper inventory %s failed for %s: %s"
+    operation
+    error.path
+    error.message
+;;
+
+let lstat_result errors ~root path =
+  try Ok (Unix.lstat path) with
+  | Unix.Unix_error _ as exn ->
+    record_error errors ~root ~operation:"lstat" path exn;
+    Error ()
+;;
+
+let sorted_readdir_result errors ~root path =
+  try Ok (Sys.readdir path |> Array.to_list |> List.sort String.compare) with
+  | Sys_error _ as exn ->
+    record_error errors ~root ~operation:"readdir" path exn;
+    Error ()
 ;;
 
 let scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
   let entries = ref [] in
   let visited = ref 0 in
   let truncated = ref false in
+  let errors = ref [] in
   let rec visit ~depth path =
     if !visited >= max_entries
     then truncated := true
     else (
-      match safe_lstat path with
-      | None -> ()
-      | Some st ->
+      match lstat_result errors ~root:legacy_dir path with
+      | Error () -> ()
+      | Ok st ->
         incr visited;
         let kind = stat_kind st in
         let rel = relative_path ~root:legacy_dir path in
@@ -164,18 +198,49 @@ let scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
            }
            :: !entries;
         if String.equal kind "dir" && depth < max_depth
-        then
-          sorted_readdir path
-          |> List.iter (fun name -> visit ~depth:(depth + 1) (Filename.concat path name)))
+        then (
+          match sorted_readdir_result errors ~root:legacy_dir path with
+          | Error () -> ()
+          | Ok names ->
+            names
+            |> List.iter (fun name -> visit ~depth:(depth + 1) (Filename.concat path name))))
   in
-  if Sys.file_exists legacy_dir
-  then
-    sorted_readdir legacy_dir
-    |> List.iter (fun name -> visit ~depth:0 (Filename.concat legacy_dir name));
-  List.rev !entries, !truncated, !visited
+  let exists =
+    match
+      try Ok (Unix.lstat legacy_dir) with
+      | Unix.Unix_error (Unix.ENOENT, _, _)
+      | Unix.Unix_error (Unix.ENOTDIR, _, _) -> Error `Missing
+      | Unix.Unix_error _ as exn -> Error (`Failure exn)
+    with
+    | Error `Missing -> false
+    | Error (`Failure exn) ->
+      record_error errors ~root:legacy_dir ~operation:"lstat" legacy_dir exn;
+      false
+    | Ok st when st.Unix.st_kind = Unix.S_DIR ->
+      (match sorted_readdir_result errors ~root:legacy_dir legacy_dir with
+       | Error () -> true
+       | Ok names ->
+         names |> List.iter (fun name -> visit ~depth:0 (Filename.concat legacy_dir name));
+         true)
+    | Ok st ->
+      record_error
+        errors
+        ~root:legacy_dir
+        ~operation:"readdir"
+        legacy_dir
+        (Sys_error
+           (Printf.sprintf "expected directory, found %s" (stat_kind st)));
+      true
+  in
+  { entries = List.rev !entries
+  ; truncated = !truncated
+  ; visited = !visited
+  ; errors = List.rev !errors
+  ; exists
+  }
 ;;
 
-let entry_to_json entry =
+let entry_to_json (entry : entry) =
   `Assoc
     [ "path", `String entry.path
     ; "depth", `Int entry.depth
@@ -183,6 +248,14 @@ let entry_to_json entry =
     ; "bytes", `Int entry.bytes
     ; "class", `String (class_to_string entry.classification)
     ; "reason", `String entry.reason
+    ]
+;;
+
+let scan_error_to_json (error : scan_error) =
+  `Assoc
+    [ "path", `String error.path
+    ; "operation", `String error.operation
+    ; "message", `String error.message
     ]
 ;;
 
@@ -202,44 +275,54 @@ let class_totals entries =
     class_to_string cls, `Assoc [ "count", `Int count; "bytes", `Int bytes ])
 ;;
 
-let cleanup_candidate_class = function
-  | Orphaned | Backup -> true
-  | Live | Migrated | Unknown -> false
-;;
-
-let cleanup_plan_json entries =
-  let candidates = List.filter (fun entry -> cleanup_candidate_class entry.classification) entries in
-  let bytes = List.fold_left (fun acc entry -> acc + entry.bytes) 0 candidates in
+let cleanup_plan_json () =
   `Assoc
     [ "delete_allowed", `Bool false
     ; "requires_operator_approval", `Bool true
-    ; "candidate_classes", `List [ `String "orphaned"; `String "backup" ]
-    ; "candidate_count", `Int (List.length candidates)
-    ; "candidate_bytes", `Int bytes
-    ; "candidates", `List (List.map entry_to_json candidates)
+    ; "candidate_policy", `String "disabled_until_owner_verified"
+    ; "candidate_classes", `List []
+    ; "candidate_count", `Int 0
+    ; "candidate_bytes", `Int 0
+    ; "candidates", `List []
     ]
+;;
+
+let redacted_workspace_path ~base_path path =
+  let base_prefix =
+    if String.ends_with ~suffix:"/" base_path then base_path else base_path ^ "/"
+  in
+  if String.equal path base_path
+  then "."
+  else if String.starts_with ~prefix:base_prefix path
+  then
+    String.sub path (String.length base_prefix) (String.length path - String.length base_prefix)
+  else if String.equal (Filename.basename path) Common.keepers_runtime_dirname
+  then Filename.concat "<config>" Common.keepers_runtime_dirname
+  else "<external>"
 ;;
 
 let legacy_keeper_inventory_http_json ~base_path ?(max_depth = default_max_depth)
       ?(max_entries = default_max_entries) () =
-  let masc_root = Config_dir_resolver.masc_root ~base_path in
-  let legacy_dir = Filename.concat masc_root "keepers" in
+  let legacy_dir = Common.keepers_runtime_dir_of_base ~base_path in
   let current_keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path in
-  let entries, truncated, visited =
+  let result =
     scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries
   in
   `Assoc
-    [ "base_path", `String base_path
-    ; "legacy_keepers_path", `String legacy_dir
-    ; "current_config_keepers_path", `String current_keepers_dir
-    ; "exists", `Bool (Sys.file_exists legacy_dir)
+    [ "path_scope", `String "workspace_relative"
+    ; "legacy_keepers_path", `String (redacted_workspace_path ~base_path legacy_dir)
+    ; ( "current_config_keepers_path"
+      , `String (redacted_workspace_path ~base_path current_keepers_dir) )
+    ; "exists", `Bool result.exists
     ; "read_only", `Bool true
     ; "max_depth", `Int max_depth
     ; "max_entries", `Int max_entries
-    ; "visited_entries", `Int visited
-    ; "truncated", `Bool truncated
-    ; "class_totals", `Assoc (class_totals entries)
-    ; "entries", `List (List.map entry_to_json entries)
-    ; "dry_run_cleanup_plan", cleanup_plan_json entries
+    ; "visited_entries", `Int result.visited
+    ; "truncated", `Bool result.truncated
+    ; "scan_complete", `Bool ((not result.truncated) && result.errors = [])
+    ; "scan_errors", `List (List.map scan_error_to_json result.errors)
+    ; "class_totals", `Assoc (class_totals result.entries)
+    ; "entries", `List (List.map entry_to_json result.entries)
+    ; "dry_run_cleanup_plan", cleanup_plan_json ()
     ]
 ;;

--- a/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
+++ b/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
@@ -47,33 +47,41 @@ let class_to_string = function
   | Unknown -> "unknown"
 ;;
 
+let normalize_path path =
+  path
+  |> Env_config_core.normalize_path_lexically
+  |> Env_config_core.strip_path_trailing_slashes
+;;
+
+let path_components_under_root ~root path =
+  let root = normalize_path root in
+  let path = normalize_path path in
+  let rec loop acc current =
+    if String.equal current root
+    then Some acc
+    else (
+      let parent = Filename.dirname current in
+      if String.equal parent current
+      then None
+      else loop (Filename.basename current :: acc) parent)
+  in
+  loop [] path
+;;
+
+let path_of_components = function
+  | [] -> "."
+  | first :: rest -> List.fold_left Filename.concat first rest
+;;
+
 let relative_path ~root path =
-  let root_prefix = if String.ends_with ~suffix:"/" root then root else root ^ "/" in
-  if String.starts_with ~prefix:root_prefix path
-  then String.sub path (String.length root_prefix) (String.length path - String.length root_prefix)
-  else path
+  match path_components_under_root ~root path with
+  | Some parts -> path_of_components parts
+  | None -> path
 ;;
 
-let split_relative rel =
-  rel
-  |> String.split_on_char '/'
-  |> List.filter (fun part -> not (String.equal part ""))
+let is_runtime_store_dir name =
+  Option.is_some (Config_dir_resolver.keeper_runtime_store_of_dirname name)
 ;;
-
-let has_suffix name suffix = String.ends_with ~suffix name
-
-let live_runtime_store_dirs =
-  [ "tool_usage"
-  ; "runtime-manifests"
-  ; "metrics"
-  ; "execution-receipts"
-  ; "turn-records"
-  ; "reaction-ledger"
-  ; "trajectories"
-  ]
-;;
-
-let member name names = List.exists (String.equal name) names
 
 let regular_path_exists_no_follow path =
   try
@@ -110,17 +118,16 @@ let migrated_memory_path_exists ~current_keepers_dir parts =
   | _ -> false
 ;;
 
-let classify ~current_keepers_dir ~rel ~kind =
-  let parts = split_relative rel in
+let classify ~current_keepers_dir ~parts ~kind =
   if migrated_memory_path_exists ~current_keepers_dir parts
   then Migrated, "memory_os_file_already_present_under_config_keepers"
   else (
     match parts with
-    | [ top ] when String.equal kind "file" && has_suffix top ".json" ->
+    | [ top ] when String.equal kind "file" && Keeper_meta_store.is_keeper_meta_file top ->
       Live, "legacy_keeper_meta_json"
-    | top :: _ when member top live_runtime_store_dirs ->
+    | top :: _ when is_runtime_store_dir top ->
       Live, "known_top_level_runtime_store"
-    | _keeper :: child :: _ when member child live_runtime_store_dirs ->
+    | _keeper :: child :: _ when is_runtime_store_dir child ->
       Live, "known_keeper_runtime_store"
     | _ -> Unknown, "unclassified_legacy_path")
 ;;
@@ -139,7 +146,9 @@ let stat_kind st =
 let error_message = function
   | Unix.Unix_error (err, _, _) -> Unix.error_message err
   | Sys_error msg -> msg
-  | exn -> Printexc.to_string exn
+  | Invalid_argument _ -> "invalid_argument"
+  | Failure _ -> "failure"
+  | _ -> "unexpected_exception"
 ;;
 
 let display_path ~root path =
@@ -186,8 +195,12 @@ let scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
       | Ok st ->
         incr visited;
         let kind = stat_kind st in
-        let rel = relative_path ~root:legacy_dir path in
-        let classification, reason = classify ~current_keepers_dir ~rel ~kind in
+        let parts =
+          path_components_under_root ~root:legacy_dir path
+          |> Option.value ~default:[ path ]
+        in
+        let rel = path_of_components parts in
+        let classification, reason = classify ~current_keepers_dir ~parts ~kind in
         entries
         := { path = rel
            ; depth
@@ -288,17 +301,12 @@ let cleanup_plan_json () =
 ;;
 
 let redacted_workspace_path ~base_path path =
-  let base_prefix =
-    if String.ends_with ~suffix:"/" base_path then base_path else base_path ^ "/"
-  in
-  if String.equal path base_path
-  then "."
-  else if String.starts_with ~prefix:base_prefix path
-  then
-    String.sub path (String.length base_prefix) (String.length path - String.length base_prefix)
-  else if String.equal (Filename.basename path) Common.keepers_runtime_dirname
-  then Filename.concat "<config>" Common.keepers_runtime_dirname
-  else "<external>"
+  match path_components_under_root ~root:base_path path with
+  | Some parts -> path_of_components parts
+  | None ->
+    if String.equal (Filename.basename path) Common.keepers_runtime_dirname
+    then Filename.concat "<config>" Common.keepers_runtime_dirname
+    else "<external>"
 ;;
 
 let legacy_keeper_inventory_http_json ~base_path ?(max_depth = default_max_depth)

--- a/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
+++ b/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
@@ -167,6 +167,15 @@ let record_error errors ~root ~operation path exn =
     error.message
 ;;
 
+let record_scan_error errors ~operation ~path ~message =
+  errors := { path; operation; message } :: !errors;
+  Log.Dashboard.warn
+    "legacy keeper inventory %s failed for %s: %s"
+    operation
+    path
+    message
+;;
+
 let lstat_result errors ~root path =
   try Ok (Unix.lstat path) with
   | Unix.Unix_error _ as exn ->
@@ -195,28 +204,33 @@ let scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
       | Ok st ->
         incr visited;
         let kind = stat_kind st in
-        let parts =
-          path_components_under_root ~root:legacy_dir path
-          |> Option.value ~default:[ path ]
-        in
-        let rel = path_of_components parts in
-        let classification, reason = classify ~current_keepers_dir ~parts ~kind in
-        entries
-        := { path = rel
-           ; depth
-           ; kind
-           ; bytes = st.Unix.st_size
-           ; classification
-           ; reason
-           }
-           :: !entries;
-        if String.equal kind "dir" && depth < max_depth
-        then (
-          match sorted_readdir_result errors ~root:legacy_dir path with
-          | Error () -> ()
-          | Ok names ->
-            names
-            |> List.iter (fun name -> visit ~depth:(depth + 1) (Filename.concat path name))))
+        (match path_components_under_root ~root:legacy_dir path with
+         | None ->
+           record_scan_error
+             errors
+             ~operation:"relative_path"
+             ~path:"<outside-legacy-root>"
+             ~message:"visited path is not under legacy keeper root"
+         | Some parts ->
+           let rel = path_of_components parts in
+           let classification, reason = classify ~current_keepers_dir ~parts ~kind in
+           entries
+           := { path = rel
+              ; depth
+              ; kind
+              ; bytes = st.Unix.st_size
+              ; classification
+              ; reason
+              }
+              :: !entries;
+           if String.equal kind "dir" && depth < max_depth
+           then (
+             match sorted_readdir_result errors ~root:legacy_dir path with
+             | Error () -> ()
+             | Ok names ->
+               names
+               |> List.iter (fun name ->
+                 visit ~depth:(depth + 1) (Filename.concat path name)))))
   in
   let exists =
     match

--- a/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
+++ b/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
@@ -1,0 +1,245 @@
+(** Legacy keeper-store inventory dashboard helper.
+
+    Current Memory OS fact stores live under [.masc/config/keepers]. Older
+    runtime data under [.masc/keepers] can still contain live runtime stores,
+    migrated memory artifacts, backups, and orphaned temp files. This helper is
+    intentionally read-only: it classifies a bounded scan and emits a dry-run
+    cleanup plan with operator approval required. *)
+
+type inventory_class =
+  | Live
+  | Migrated
+  | Orphaned
+  | Backup
+  | Unknown
+
+type entry =
+  { path : string
+  ; depth : int
+  ; kind : string
+  ; bytes : int
+  ; classification : inventory_class
+  ; reason : string
+  }
+
+let default_max_depth = 4
+let default_max_entries = 5_000
+
+let class_to_string = function
+  | Live -> "live"
+  | Migrated -> "migrated"
+  | Orphaned -> "orphaned"
+  | Backup -> "backup"
+  | Unknown -> "unknown"
+;;
+
+let relative_path ~root path =
+  let root_prefix = if String.ends_with ~suffix:"/" root then root else root ^ "/" in
+  if String.starts_with ~prefix:root_prefix path
+  then String.sub path (String.length root_prefix) (String.length path - String.length root_prefix)
+  else path
+;;
+
+let split_relative rel =
+  rel
+  |> String.split_on_char '/'
+  |> List.filter (fun part -> not (String.equal part ""))
+;;
+
+let has_suffix name suffix = String.ends_with ~suffix name
+
+let is_backup_name name =
+  has_suffix name ".bak"
+  || has_suffix name ".backup"
+  || has_suffix name ".old"
+  || has_suffix name "~"
+;;
+
+let is_orphan_temp_name name =
+  String.equal name "PYEOF"
+  || (String.starts_with ~prefix:".atomic_" name && has_suffix name ".tmp")
+  || has_suffix name ".tmp"
+;;
+
+let live_top_level_dirs =
+  [ "tool_usage"
+  ; "runtime-manifests"
+  ; "metrics"
+  ; "execution-receipts"
+  ; "turn-records"
+  ; "reaction-ledger"
+  ; "trajectories"
+  ]
+;;
+
+let live_keeper_child_dirs =
+  [ "metrics"
+  ; "execution-receipts"
+  ; "turn-records"
+  ; "reaction-ledger"
+  ; "runtime-manifests"
+  ; "trajectories"
+  ; "tool_usage"
+  ]
+;;
+
+let memory_os_filenames = [ "facts.jsonl"; "events.jsonl"; "episodes.jsonl" ]
+
+let member name names = List.exists (String.equal name) names
+
+let migrated_memory_path_exists ~current_keepers_dir parts =
+  match parts with
+  | keeper_id :: filename :: [] when member filename memory_os_filenames ->
+    Sys.file_exists (Filename.concat (Filename.concat current_keepers_dir keeper_id) filename)
+  | _ -> false
+;;
+
+let classify ~current_keepers_dir ~rel ~kind =
+  let parts = split_relative rel in
+  let name =
+    match List.rev parts with
+    | [] -> rel
+    | hd :: _ -> hd
+  in
+  if is_orphan_temp_name name
+  then Orphaned, "orphaned_temp_or_marker"
+  else if is_backup_name name
+  then Backup, "backup_suffix"
+  else if migrated_memory_path_exists ~current_keepers_dir parts
+  then Migrated, "memory_os_file_already_present_under_config_keepers"
+  else (
+    match parts with
+    | [ top ] when String.equal kind "file" && has_suffix top ".json" ->
+      Live, "legacy_keeper_meta_json"
+    | top :: _ when member top live_top_level_dirs ->
+      Live, "known_top_level_runtime_store"
+    | _keeper :: child :: _ when member child live_keeper_child_dirs ->
+      Live, "known_keeper_runtime_store"
+    | _ -> Unknown, "unclassified_legacy_path")
+;;
+
+let stat_kind st =
+  match st.Unix.st_kind with
+  | Unix.S_REG -> "file"
+  | Unix.S_DIR -> "dir"
+  | Unix.S_LNK -> "symlink"
+  | Unix.S_CHR -> "char"
+  | Unix.S_BLK -> "block"
+  | Unix.S_FIFO -> "fifo"
+  | Unix.S_SOCK -> "socket"
+;;
+
+let safe_lstat path =
+  try Some (Unix.lstat path) with
+  | Unix.Unix_error _ -> None
+;;
+
+let sorted_readdir path =
+  try Sys.readdir path |> Array.to_list |> List.sort String.compare with
+  | Sys_error _ -> []
+;;
+
+let scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
+  let entries = ref [] in
+  let visited = ref 0 in
+  let truncated = ref false in
+  let rec visit ~depth path =
+    if !visited >= max_entries
+    then truncated := true
+    else (
+      match safe_lstat path with
+      | None -> ()
+      | Some st ->
+        incr visited;
+        let kind = stat_kind st in
+        let rel = relative_path ~root:legacy_dir path in
+        let classification, reason = classify ~current_keepers_dir ~rel ~kind in
+        entries
+        := { path = rel
+           ; depth
+           ; kind
+           ; bytes = st.Unix.st_size
+           ; classification
+           ; reason
+           }
+           :: !entries;
+        if String.equal kind "dir" && depth < max_depth
+        then
+          sorted_readdir path
+          |> List.iter (fun name -> visit ~depth:(depth + 1) (Filename.concat path name)))
+  in
+  if Sys.file_exists legacy_dir
+  then
+    sorted_readdir legacy_dir
+    |> List.iter (fun name -> visit ~depth:0 (Filename.concat legacy_dir name));
+  List.rev !entries, !truncated, !visited
+;;
+
+let entry_to_json entry =
+  `Assoc
+    [ "path", `String entry.path
+    ; "depth", `Int entry.depth
+    ; "kind", `String entry.kind
+    ; "bytes", `Int entry.bytes
+    ; "class", `String (class_to_string entry.classification)
+    ; "reason", `String entry.reason
+    ]
+;;
+
+let class_totals entries =
+  let classes = [ Live; Migrated; Orphaned; Backup; Unknown ] in
+  classes
+  |> List.map (fun cls ->
+    let count, bytes =
+      List.fold_left
+        (fun (count, bytes) entry ->
+           if entry.classification = cls
+           then count + 1, bytes + entry.bytes
+           else count, bytes)
+        (0, 0)
+        entries
+    in
+    class_to_string cls, `Assoc [ "count", `Int count; "bytes", `Int bytes ])
+;;
+
+let cleanup_candidate_class = function
+  | Orphaned | Backup -> true
+  | Live | Migrated | Unknown -> false
+;;
+
+let cleanup_plan_json entries =
+  let candidates = List.filter (fun entry -> cleanup_candidate_class entry.classification) entries in
+  let bytes = List.fold_left (fun acc entry -> acc + entry.bytes) 0 candidates in
+  `Assoc
+    [ "delete_allowed", `Bool false
+    ; "requires_operator_approval", `Bool true
+    ; "candidate_classes", `List [ `String "orphaned"; `String "backup" ]
+    ; "candidate_count", `Int (List.length candidates)
+    ; "candidate_bytes", `Int bytes
+    ; "candidates", `List (List.map entry_to_json candidates)
+    ]
+;;
+
+let legacy_keeper_inventory_http_json ~base_path ?(max_depth = default_max_depth)
+      ?(max_entries = default_max_entries) () =
+  let masc_root = Config_dir_resolver.masc_root ~base_path in
+  let legacy_dir = Filename.concat masc_root "keepers" in
+  let current_keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path in
+  let entries, truncated, visited =
+    scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries
+  in
+  `Assoc
+    [ "base_path", `String base_path
+    ; "legacy_keepers_path", `String legacy_dir
+    ; "current_config_keepers_path", `String current_keepers_dir
+    ; "exists", `Bool (Sys.file_exists legacy_dir)
+    ; "read_only", `Bool true
+    ; "max_depth", `Int max_depth
+    ; "max_entries", `Int max_entries
+    ; "visited_entries", `Int visited
+    ; "truncated", `Bool truncated
+    ; "class_totals", `Assoc (class_totals entries)
+    ; "entries", `List (List.map entry_to_json entries)
+    ; "dry_run_cleanup_plan", cleanup_plan_json entries
+    ]
+;;

--- a/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
+++ b/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
@@ -76,7 +76,7 @@ let path_of_components = function
 let relative_path ~root path =
   match path_components_under_root ~root path with
   | Some parts -> path_of_components parts
-  | None -> path
+  | None -> "<external>"
 ;;
 
 let is_runtime_store_dir name =
@@ -339,31 +339,12 @@ let class_totals entries =
     class_to_string cls, `Assoc [ "count", `Int count; "bytes", `Int bytes ])
 ;;
 
-let cleanup_candidate_classes = [ Orphaned; Backup ]
-
-let is_cleanup_candidate entry =
-  List.exists
-    (fun candidate_class -> entry.classification = candidate_class)
-    cleanup_candidate_classes
-;;
-
-let cleanup_plan_json entries =
-  let candidates = List.filter is_cleanup_candidate entries in
-  let candidate_bytes =
-    List.fold_left (fun total entry -> total + entry.bytes) 0 candidates
-  in
+let cleanup_plan_json () =
   `Assoc
     [ "delete_allowed", `Bool false
     ; "requires_operator_approval", `Bool true
-    ; "candidate_policy", `String "disabled_until_owner_verified"
-    ; ( "candidate_classes"
-      , `List
-          (List.map
-             (fun candidate_class -> `String (class_to_string candidate_class))
-             cleanup_candidate_classes) )
-    ; "candidate_count", `Int (List.length candidates)
-    ; "candidate_bytes", `Int candidate_bytes
-    ; "candidates", `List (List.map entry_to_json candidates)
+    ; "candidate_policy", `String "not_available_until_owner_verified"
+    ; "candidate_source", `String "inventory_only"
     ]
 ;;
 
@@ -389,6 +370,6 @@ let legacy_keeper_inventory_http_json ~base_path ?(max_depth = default_max_depth
     ; "scan_errors", `List (List.map scan_error_to_json result.errors)
     ; "class_totals", `Assoc (class_totals result.entries)
     ; "entries", `List (List.map entry_to_json result.entries)
-    ; "dry_run_cleanup_plan", cleanup_plan_json result.entries
+    ; "dry_run_cleanup_plan", cleanup_plan_json ()
     ]
 ;;

--- a/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
+++ b/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
@@ -83,53 +83,64 @@ let is_runtime_store_dir name =
   Option.is_some (Config_dir_resolver.keeper_runtime_store_of_dirname name)
 ;;
 
+type regular_path_status =
+  | Regular_exists
+  | Missing_or_not_regular
+  | Access_error of exn
+
 let regular_path_exists_no_follow path =
   try
     match (Unix.lstat path).Unix.st_kind with
-    | Unix.S_REG -> true
+    | Unix.S_REG -> Regular_exists
     | Unix.S_DIR | Unix.S_LNK | Unix.S_CHR | Unix.S_BLK | Unix.S_FIFO | Unix.S_SOCK ->
-      false
+      Missing_or_not_regular
   with
-  | Unix.Unix_error _ -> false
+  | Unix.Unix_error (Unix.ENOENT, _, _)
+  | Unix.Unix_error (Unix.ENOTDIR, _, _) -> Missing_or_not_regular
+  | Unix.Unix_error _ as exn -> Access_error exn
 ;;
 
-let migrated_memory_path_for_legacy_filename ~current_keepers_dir ~keeper_id filename =
-  if String.equal filename "facts.jsonl"
-  then
-    Some
-      (Keeper_memory_os_io.facts_path_for_keepers_dir
-         ~keepers_dir:current_keepers_dir
-         ~keeper_id)
-  else if String.equal filename "events.jsonl"
-  then
-    Some
-      (Keeper_memory_os_io.events_path_for_keepers_dir
-         ~keepers_dir:current_keepers_dir
-         ~keeper_id)
-  else None
-;;
+type migrated_memory_status =
+  | Migrated_present
+  | Migrated_absent
+  | Migrated_access_error of
+      { current_path : string
+      ; exn : exn
+      }
 
-let migrated_memory_path_exists ~current_keepers_dir parts =
+let migrated_memory_status ~current_keepers_dir parts =
   match parts with
   | keeper_id :: filename :: [] ->
-    (match migrated_memory_path_for_legacy_filename ~current_keepers_dir ~keeper_id filename with
-     | Some path -> regular_path_exists_no_follow path
-     | None -> false)
-  | _ -> false
+    (match
+       Keeper_memory_os_io.current_path_for_legacy_memory_filename
+         ~keepers_dir:current_keepers_dir
+         ~keeper_id
+         ~filename
+     with
+     | None -> Migrated_absent
+     | Some current_path ->
+       (match regular_path_exists_no_follow current_path with
+        | Regular_exists -> Migrated_present
+        | Missing_or_not_regular -> Migrated_absent
+        | Access_error exn -> Migrated_access_error { current_path; exn }))
+  | _ -> Migrated_absent
 ;;
 
-let classify ~current_keepers_dir ~parts ~kind =
-  if migrated_memory_path_exists ~current_keepers_dir parts
-  then Migrated, "memory_os_file_already_present_under_config_keepers"
-  else (
-    match parts with
-    | [ top ] when String.equal kind "file" && Keeper_meta_store.is_keeper_meta_file top ->
-      Live, "legacy_keeper_meta_json"
-    | top :: _ when is_runtime_store_dir top ->
-      Live, "known_top_level_runtime_store"
-    | _keeper :: child :: _ when is_runtime_store_dir child ->
-      Live, "known_keeper_runtime_store"
-    | _ -> Unknown, "unclassified_legacy_path")
+let classify ~current_keepers_dir ~record_access_error ~parts ~kind =
+  match migrated_memory_status ~current_keepers_dir parts with
+  | Migrated_present -> Migrated, "memory_os_file_already_present_under_config_keepers"
+  | Migrated_access_error { current_path; exn } ->
+    record_access_error current_path exn;
+    Unknown, "memory_os_current_store_access_error"
+  | Migrated_absent ->
+    (match parts with
+     | [ top ] when String.equal kind "file" && Keeper_meta_store.is_keeper_meta_file top ->
+       Live, "legacy_keeper_meta_json"
+     | top :: _ when is_runtime_store_dir top ->
+       Live, "known_top_level_runtime_store"
+     | _keeper :: child :: _ when is_runtime_store_dir child ->
+       Live, "known_keeper_runtime_store"
+     | _ -> Unknown, "unclassified_legacy_path")
 ;;
 
 let stat_kind st =
@@ -148,16 +159,30 @@ let error_message = function
   | Sys_error msg -> msg
   | Invalid_argument _ -> "invalid_argument"
   | Failure _ -> "failure"
-  | _ -> "unexpected_exception"
+  | exn -> "unexpected_exception:" ^ Printexc.exn_slot_name exn
 ;;
 
-let display_path ~root path =
-  if String.equal path root then "." else relative_path ~root path
+let redacted_workspace_path ~base_path path =
+  match path_components_under_root ~root:base_path path with
+  | Some parts -> path_of_components parts
+  | None ->
+    if String.equal (Filename.basename path) Common.keepers_runtime_dirname
+    then Filename.concat "<config>" Common.keepers_runtime_dirname
+    else "<external>"
 ;;
 
-let record_error errors ~root ~operation path exn =
+let display_path ~base_path ~root path =
+  if String.equal path root
+  then "."
+  else (
+    match path_components_under_root ~root path with
+    | Some parts -> path_of_components parts
+    | None -> redacted_workspace_path ~base_path path)
+;;
+
+let record_error errors ~base_path ~root ~operation path exn =
   let error =
-    { path = display_path ~root path; operation; message = error_message exn }
+    { path = display_path ~base_path ~root path; operation; message = error_message exn }
   in
   errors := error :: !errors;
   Log.Dashboard.warn
@@ -176,30 +201,39 @@ let record_scan_error errors ~operation ~path ~message =
     message
 ;;
 
-let lstat_result errors ~root path =
+let lstat_result errors ~base_path ~root path =
   try Ok (Unix.lstat path) with
   | Unix.Unix_error _ as exn ->
-    record_error errors ~root ~operation:"lstat" path exn;
+    record_error errors ~base_path ~root ~operation:"lstat" path exn;
     Error ()
 ;;
 
-let sorted_readdir_result errors ~root path =
+let sorted_readdir_result errors ~base_path ~root path =
   try Ok (Sys.readdir path |> Array.to_list |> List.sort String.compare) with
   | Sys_error _ as exn ->
-    record_error errors ~root ~operation:"readdir" path exn;
+    record_error errors ~base_path ~root ~operation:"readdir" path exn;
     Error ()
 ;;
 
-let scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
+let scan_entries ~base_path ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
   let entries = ref [] in
   let visited = ref 0 in
   let truncated = ref false in
   let errors = ref [] in
+  let record_access_error path exn =
+    record_error
+      errors
+      ~base_path
+      ~root:legacy_dir
+      ~operation:"lstat_current_memory"
+      path
+      exn
+  in
   let rec visit ~depth path =
     if !visited >= max_entries
     then truncated := true
     else (
-      match lstat_result errors ~root:legacy_dir path with
+      match lstat_result errors ~base_path ~root:legacy_dir path with
       | Error () -> ()
       | Ok st ->
         incr visited;
@@ -213,7 +247,9 @@ let scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
              ~message:"visited path is not under legacy keeper root"
          | Some parts ->
            let rel = path_of_components parts in
-           let classification, reason = classify ~current_keepers_dir ~parts ~kind in
+           let classification, reason =
+             classify ~current_keepers_dir ~record_access_error ~parts ~kind
+           in
            entries
            := { path = rel
               ; depth
@@ -225,7 +261,7 @@ let scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
               :: !entries;
            if String.equal kind "dir" && depth < max_depth
            then (
-             match sorted_readdir_result errors ~root:legacy_dir path with
+             match sorted_readdir_result errors ~base_path ~root:legacy_dir path with
              | Error () -> ()
              | Ok names ->
                names
@@ -241,10 +277,10 @@ let scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
     with
     | Error `Missing -> false
     | Error (`Failure exn) ->
-      record_error errors ~root:legacy_dir ~operation:"lstat" legacy_dir exn;
+      record_error errors ~base_path ~root:legacy_dir ~operation:"lstat" legacy_dir exn;
       false
     | Ok st when st.Unix.st_kind = Unix.S_DIR ->
-      (match sorted_readdir_result errors ~root:legacy_dir legacy_dir with
+      (match sorted_readdir_result errors ~base_path ~root:legacy_dir legacy_dir with
        | Error () -> true
        | Ok names ->
          names |> List.iter (fun name -> visit ~depth:0 (Filename.concat legacy_dir name));
@@ -252,6 +288,7 @@ let scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries =
     | Ok st ->
       record_error
         errors
+        ~base_path
         ~root:legacy_dir
         ~operation:"readdir"
         legacy_dir
@@ -302,25 +339,32 @@ let class_totals entries =
     class_to_string cls, `Assoc [ "count", `Int count; "bytes", `Int bytes ])
 ;;
 
-let cleanup_plan_json () =
+let cleanup_candidate_classes = [ Orphaned; Backup ]
+
+let is_cleanup_candidate entry =
+  List.exists
+    (fun candidate_class -> entry.classification = candidate_class)
+    cleanup_candidate_classes
+;;
+
+let cleanup_plan_json entries =
+  let candidates = List.filter is_cleanup_candidate entries in
+  let candidate_bytes =
+    List.fold_left (fun total entry -> total + entry.bytes) 0 candidates
+  in
   `Assoc
     [ "delete_allowed", `Bool false
     ; "requires_operator_approval", `Bool true
     ; "candidate_policy", `String "disabled_until_owner_verified"
-    ; "candidate_classes", `List []
-    ; "candidate_count", `Int 0
-    ; "candidate_bytes", `Int 0
-    ; "candidates", `List []
+    ; ( "candidate_classes"
+      , `List
+          (List.map
+             (fun candidate_class -> `String (class_to_string candidate_class))
+             cleanup_candidate_classes) )
+    ; "candidate_count", `Int (List.length candidates)
+    ; "candidate_bytes", `Int candidate_bytes
+    ; "candidates", `List (List.map entry_to_json candidates)
     ]
-;;
-
-let redacted_workspace_path ~base_path path =
-  match path_components_under_root ~root:base_path path with
-  | Some parts -> path_of_components parts
-  | None ->
-    if String.equal (Filename.basename path) Common.keepers_runtime_dirname
-    then Filename.concat "<config>" Common.keepers_runtime_dirname
-    else "<external>"
 ;;
 
 let legacy_keeper_inventory_http_json ~base_path ?(max_depth = default_max_depth)
@@ -328,7 +372,7 @@ let legacy_keeper_inventory_http_json ~base_path ?(max_depth = default_max_depth
   let legacy_dir = Common.keepers_runtime_dir_of_base ~base_path in
   let current_keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path in
   let result =
-    scan_entries ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries
+    scan_entries ~base_path ~legacy_dir ~current_keepers_dir ~max_depth ~max_entries
   in
   `Assoc
     [ "path_scope", `String "workspace_relative"
@@ -345,6 +389,6 @@ let legacy_keeper_inventory_http_json ~base_path ?(max_depth = default_max_depth
     ; "scan_errors", `List (List.map scan_error_to_json result.errors)
     ; "class_totals", `Assoc (class_totals result.entries)
     ; "entries", `List (List.map entry_to_json result.entries)
-    ; "dry_run_cleanup_plan", cleanup_plan_json ()
+    ; "dry_run_cleanup_plan", cleanup_plan_json result.entries
     ]
 ;;

--- a/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
+++ b/lib/server/server_dashboard_http_legacy_keeper_inventory.ml
@@ -39,13 +39,25 @@ type scan_result =
 let default_max_depth = 4
 let default_max_entries = 5_000
 
+(* HTTP response schema constants. Keep these stable for dashboard clients and
+   tests that inspect the JSON contract. *)
+let class_live = "live"
+let class_migrated = "migrated"
+let class_orphaned = "orphaned"
+let class_backup = "backup"
+let class_unknown = "unknown"
+let cleanup_candidate_policy = "not_available_until_owner_verified"
+let cleanup_candidate_source = "inventory_only"
+
 let class_to_string = function
-  | Live -> "live"
-  | Migrated -> "migrated"
-  | Orphaned -> "orphaned"
-  | Backup -> "backup"
-  | Unknown -> "unknown"
+  | Live -> class_live
+  | Migrated -> class_migrated
+  | Orphaned -> class_orphaned
+  | Backup -> class_backup
+  | Unknown -> class_unknown
 ;;
+
+let inventory_classes = [ Live; Migrated; Orphaned; Backup; Unknown ]
 
 let normalize_path path =
   path
@@ -323,18 +335,31 @@ let scan_error_to_json (error : scan_error) =
     ]
 ;;
 
+module Class_map = Map.Make (struct
+    type t = inventory_class
+
+    let compare = Stdlib.compare
+  end)
+
 let class_totals entries =
-  let classes = [ Live; Migrated; Orphaned; Backup; Unknown ] in
-  classes
+  let counts =
+    List.fold_left
+      (fun counts entry ->
+         let count, bytes =
+           match Class_map.find_opt entry.classification counts with
+           | Some totals -> totals
+           | None -> 0, 0
+         in
+         Class_map.add entry.classification (count + 1, bytes + entry.bytes) counts)
+      Class_map.empty
+      entries
+  in
+  inventory_classes
   |> List.map (fun cls ->
     let count, bytes =
-      List.fold_left
-        (fun (count, bytes) entry ->
-           if entry.classification = cls
-           then count + 1, bytes + entry.bytes
-           else count, bytes)
-        (0, 0)
-        entries
+      match Class_map.find_opt cls counts with
+      | Some totals -> totals
+      | None -> 0, 0
     in
     class_to_string cls, `Assoc [ "count", `Int count; "bytes", `Int bytes ])
 ;;
@@ -343,8 +368,8 @@ let cleanup_plan_json () =
   `Assoc
     [ "delete_allowed", `Bool false
     ; "requires_operator_approval", `Bool true
-    ; "candidate_policy", `String "not_available_until_owner_verified"
-    ; "candidate_source", `String "inventory_only"
+    ; "candidate_policy", `String cleanup_candidate_policy
+    ; "candidate_source", `String cleanup_candidate_source
     ]
 ;;
 

--- a/lib/server/server_dashboard_http_legacy_keeper_inventory.mli
+++ b/lib/server/server_dashboard_http_legacy_keeper_inventory.mli
@@ -4,6 +4,9 @@
     dry-run cleanup plan so operators can decide ownership before any destructive
     action. *)
 
+val default_max_depth : int
+val default_max_entries : int
+
 val legacy_keeper_inventory_http_json :
   base_path:string ->
   ?max_depth:int ->

--- a/lib/server/server_dashboard_http_legacy_keeper_inventory.mli
+++ b/lib/server/server_dashboard_http_legacy_keeper_inventory.mli
@@ -1,0 +1,12 @@
+(** Read-only inventory for legacy [.masc/keepers].
+
+    This does not delete or move files. It reports bounded classification and a
+    dry-run cleanup plan so operators can decide ownership before any destructive
+    action. *)
+
+val legacy_keeper_inventory_http_json :
+  base_path:string ->
+  ?max_depth:int ->
+  ?max_entries:int ->
+  unit ->
+  Yojson.Safe.t

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -699,14 +699,38 @@ let add_routes ~sw ~clock router =
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/legacy-keeper-inventory" (fun request reqd ->
-       with_public_read (fun state req reqd ->
+       with_permission_auth ~permission:Masc_domain.CanAdmin (fun state req reqd ->
          let base_path = (Mcp_server.workspace_config state).base_path in
-         let cache_key = Printf.sprintf "legacy_keeper_inventory:%s" base_path in
+         let max_depth =
+           Server_utils.int_query_param
+             req
+             "max_depth"
+             ~default:
+               Server_dashboard_http_legacy_keeper_inventory.default_max_depth
+           |> Server_utils.clamp ~min_v:0 ~max_v:8
+         in
+         let max_entries =
+           Server_utils.int_query_param
+             req
+             "max_entries"
+             ~default:
+               Server_dashboard_http_legacy_keeper_inventory.default_max_entries
+           |> Server_utils.clamp ~min_v:1 ~max_v:50_000
+         in
+         let cache_key =
+           Printf.sprintf
+             "legacy_keeper_inventory:%s:%d:%d"
+             base_path
+             max_depth
+             max_entries
+         in
          let json =
            Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
-             Domain_pool_ref.submit_io_or_inline (fun () ->
+             Executor_pool_ref.submit_or_inline (fun () ->
                Server_dashboard_http_legacy_keeper_inventory.legacy_keeper_inventory_http_json
                  ~base_path
+                 ~max_depth
+                 ~max_entries
                  ()))
          in
          Http.Response.json_value ~compress:true ~request:req json reqd

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -718,9 +718,13 @@ let add_routes ~sw ~clock router =
            |> Server_utils.clamp ~min_v:1 ~max_v:50_000
          in
          let cache_key =
+           let base_hash =
+             Digestif.SHA256.(digest_string base_path |> to_hex)
+             |> fun hex -> String.sub hex 0 16
+           in
            Printf.sprintf
              "legacy_keeper_inventory:%s:%d:%d"
-             base_path
+             base_hash
              max_depth
              max_entries
          in

--- a/lib/server/server_routes_http_routes_dashboard.ml
+++ b/lib/server/server_routes_http_routes_dashboard.ml
@@ -698,6 +698,19 @@ let add_routes ~sw ~clock router =
          in
          Http.Response.json_value ~compress:true ~request:req json reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/legacy-keeper-inventory" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_path = (Mcp_server.workspace_config state).base_path in
+         let cache_key = Printf.sprintf "legacy_keeper_inventory:%s" base_path in
+         let json =
+           Dashboard_cache.get_or_compute cache_key ~ttl:standard_cache_ttl_s (fun () ->
+             Domain_pool_ref.submit_io_or_inline (fun () ->
+               Server_dashboard_http_legacy_keeper_inventory.legacy_keeper_inventory_http_json
+                 ~base_path
+                 ()))
+         in
+         Http.Response.json_value ~compress:true ~request:req json reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/governance" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let base_path = (Mcp_server.workspace_config state).base_path in

--- a/test/dune
+++ b/test/dune
@@ -101,6 +101,7 @@
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime
   test_server_bootstrap_maintenance_memory_os
+  test_server_dashboard_http_legacy_keeper_inventory
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state
@@ -418,6 +419,7 @@
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime
   test_server_bootstrap_maintenance_memory_os
+  test_server_dashboard_http_legacy_keeper_inventory
   eval_memory_os_value
   test_keeper_reconcile_state
   test_attempt_state

--- a/test/test_server_dashboard_http_legacy_keeper_inventory.ml
+++ b/test/test_server_dashboard_http_legacy_keeper_inventory.ml
@@ -149,6 +149,19 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
     "candidate policy"
     "disabled_until_owner_verified"
     (string_field "candidate_policy" plan);
+  let candidate_classes = list_field "candidate_classes" plan in
+  Alcotest.(check int)
+    "cleanup candidate classes"
+    2
+    (List.length candidate_classes);
+  Alcotest.(check bool)
+    "orphaned cleanup class exposed"
+    true
+    (List.mem (`String "orphaned") candidate_classes);
+  Alcotest.(check bool)
+    "backup cleanup class exposed"
+    true
+    (List.mem (`String "backup") candidate_classes);
   Alcotest.(check int) "cleanup candidates" 0 (int_field "candidate_count" plan);
   Alcotest.(check int) "cleanup candidate list" 0 (List.length (list_field "candidates" plan))
 ;;

--- a/test/test_server_dashboard_http_legacy_keeper_inventory.ml
+++ b/test/test_server_dashboard_http_legacy_keeper_inventory.ml
@@ -1,0 +1,139 @@
+(** Regression tests for legacy [.masc/keepers] inventory. *)
+
+module Inventory = Server_dashboard_http_legacy_keeper_inventory
+
+let fresh_dir prefix = Filename.temp_dir prefix ""
+
+let ensure_dir path =
+  if not (Sys.file_exists path) then Unix.mkdir path 0o755
+;;
+
+let write_file path contents =
+  let oc = Out_channel.open_text path in
+  Fun.protect
+    ~finally:(fun () -> Out_channel.close oc)
+    (fun () -> Out_channel.output_string oc contents)
+;;
+
+let assoc_field name = function
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+;;
+
+let int_field name json =
+  match assoc_field name json with
+  | Some (`Int n) -> n
+  | _ -> Alcotest.failf "expected int field %S" name
+;;
+
+let bool_field name json =
+  match assoc_field name json with
+  | Some (`Bool b) -> b
+  | _ -> Alcotest.failf "expected bool field %S" name
+;;
+
+let object_field name json =
+  match assoc_field name json with
+  | Some (`Assoc _ as obj) -> obj
+  | _ -> Alcotest.failf "expected object field %S" name
+;;
+
+let list_field name json =
+  match assoc_field name json with
+  | Some (`List xs) -> xs
+  | _ -> Alcotest.failf "expected list field %S" name
+;;
+
+let class_count class_name json =
+  let totals = object_field "class_totals" json in
+  match assoc_field class_name totals with
+  | Some obj -> int_field "count" obj
+  | None -> Alcotest.failf "missing class total %S" class_name
+;;
+
+let entry_classes json =
+  list_field "entries" json
+  |> List.filter_map (function
+    | `Assoc fields ->
+      (match List.assoc_opt "path" fields, List.assoc_opt "class" fields with
+       | Some (`String path), Some (`String cls) -> Some (path, cls)
+       | _ -> None)
+    | _ -> None)
+;;
+
+let test_classifies_legacy_paths_and_dry_run_candidates () =
+  let base = fresh_dir "masc-legacy-keeper-inventory" in
+  let legacy = Filename.concat (Filename.concat base ".masc") "keepers" in
+  let current = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  ensure_dir (Filename.concat base ".masc");
+  ensure_dir legacy;
+  ensure_dir (Filename.dirname current);
+  ensure_dir current;
+  ensure_dir (Filename.concat legacy "alpha");
+  ensure_dir (Filename.concat legacy "alpha/metrics");
+  ensure_dir (Filename.concat current "alpha");
+  write_file (Filename.concat legacy "alpha/.atomic_dead.tmp") "orphan";
+  write_file (Filename.concat legacy "PYEOF") "marker";
+  write_file (Filename.concat legacy "alpha/old.backup") "backup";
+  write_file (Filename.concat legacy "alpha/facts.jsonl") "{}\n";
+  write_file (Filename.concat current "alpha/facts.jsonl") "{}\n";
+  write_file (Filename.concat legacy "alpha/metrics/2026.jsonl") "{}\n";
+  write_file (Filename.concat legacy "mystery.bin") "?";
+  let json =
+    Inventory.legacy_keeper_inventory_http_json
+      ~base_path:base
+      ~max_depth:4
+      ~max_entries:100
+      ()
+  in
+  Alcotest.(check bool) "inventory is read-only" true (bool_field "read_only" json);
+  Alcotest.(check bool) "not truncated" false (bool_field "truncated" json);
+  Alcotest.(check int) "orphaned count" 2 (class_count "orphaned" json);
+  Alcotest.(check int) "backup count" 1 (class_count "backup" json);
+  Alcotest.(check int) "migrated count" 1 (class_count "migrated" json);
+  Alcotest.(check bool)
+    "live metric classified"
+    true
+    (List.mem ("alpha/metrics/2026.jsonl", "live") (entry_classes json));
+  Alcotest.(check bool)
+    "unknown file classified"
+    true
+    (List.mem ("mystery.bin", "unknown") (entry_classes json));
+  let plan = object_field "dry_run_cleanup_plan" json in
+  Alcotest.(check bool) "delete disabled" false (bool_field "delete_allowed" plan);
+  Alcotest.(check bool)
+    "operator approval required"
+    true
+    (bool_field "requires_operator_approval" plan);
+  Alcotest.(check int) "cleanup candidates" 3 (int_field "candidate_count" plan)
+;;
+
+let test_scan_cap_marks_truncation () =
+  let base = fresh_dir "masc-legacy-keeper-inventory-cap" in
+  let legacy = Filename.concat (Filename.concat base ".masc") "keepers" in
+  ensure_dir (Filename.concat base ".masc");
+  ensure_dir legacy;
+  write_file (Filename.concat legacy "a.tmp") "a";
+  write_file (Filename.concat legacy "b.tmp") "b";
+  let json =
+    Inventory.legacy_keeper_inventory_http_json
+      ~base_path:base
+      ~max_depth:4
+      ~max_entries:1
+      ()
+  in
+  Alcotest.(check bool) "truncated" true (bool_field "truncated" json);
+  Alcotest.(check int) "visited cap" 1 (int_field "visited_entries" json)
+;;
+
+let () =
+  Alcotest.run
+    "server_dashboard_http_legacy_keeper_inventory"
+    [ ( "inventory"
+      , [ Alcotest.test_case
+            "classifies legacy paths and dry-run candidates"
+            `Quick
+            test_classifies_legacy_paths_and_dry_run_candidates
+        ; Alcotest.test_case "scan cap marks truncation" `Quick test_scan_cap_marks_truncation
+        ] )
+    ]

--- a/test/test_server_dashboard_http_legacy_keeper_inventory.ml
+++ b/test/test_server_dashboard_http_legacy_keeper_inventory.ml
@@ -77,6 +77,8 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
   ensure_dir current;
   ensure_dir (Filename.concat legacy "alpha");
   ensure_dir (Filename.concat legacy "alpha/metrics");
+  write_file (Filename.concat legacy "alpha.json") "{}\n";
+  write_file (Filename.concat legacy "alpha.dataset.json") "{}\n";
   write_file (Filename.concat legacy "alpha/.atomic_dead.tmp") "orphan";
   write_file (Filename.concat legacy "PYEOF") "marker";
   write_file (Filename.concat legacy "alpha/old.backup") "backup";
@@ -109,6 +111,14 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
   Alcotest.(check int) "orphaned count" 0 (class_count "orphaned" json);
   Alcotest.(check int) "backup count" 0 (class_count "backup" json);
   Alcotest.(check int) "migrated count" 1 (class_count "migrated" json);
+  Alcotest.(check bool)
+    "keeper meta json classified"
+    true
+    (List.mem ("alpha.json", "live") (entry_classes json));
+  Alcotest.(check bool)
+    "keeper meta sidecar stays unknown"
+    true
+    (List.mem ("alpha.dataset.json", "unknown") (entry_classes json));
   Alcotest.(check bool)
     "live metric classified"
     true

--- a/test/test_server_dashboard_http_legacy_keeper_inventory.ml
+++ b/test/test_server_dashboard_http_legacy_keeper_inventory.ml
@@ -2,7 +2,23 @@
 
 module Inventory = Server_dashboard_http_legacy_keeper_inventory
 
-let fresh_dir prefix = Filename.temp_dir prefix ""
+let rec rm_rf path =
+  match Unix.lstat path with
+  | exception Unix.Unix_error _ -> ()
+  | { Unix.st_kind = Unix.S_DIR; _ } ->
+    Sys.readdir path
+    |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+    (try Unix.rmdir path with
+     | Unix.Unix_error _ -> ())
+  | _ ->
+    (try Unix.unlink path with
+     | Unix.Unix_error _ -> ())
+;;
+
+let with_temp_dir prefix f =
+  let dir = Filename.temp_dir prefix "" in
+  Fun.protect ~finally:(fun () -> rm_rf dir) (fun () -> f dir)
+;;
 
 let ensure_dir path =
   if not (Sys.file_exists path) then Unix.mkdir path 0o755
@@ -68,7 +84,7 @@ let entry_classes json =
 ;;
 
 let test_classifies_legacy_paths_and_dry_run_candidates () =
-  let base = fresh_dir "masc-legacy-keeper-inventory" in
+  with_temp_dir "masc-legacy-keeper-inventory" @@ fun base ->
   let legacy = Filename.concat (Filename.concat base ".masc") "keepers" in
   let current = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
   ensure_dir (Filename.concat base ".masc");
@@ -85,6 +101,7 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
   write_file (Filename.concat legacy "alpha/facts.jsonl") "{}\n";
   write_file (Filename.concat current "alpha.facts.jsonl") "{}\n";
   write_file (Filename.concat legacy "alpha/metrics/2026.jsonl") "{}\n";
+  write_file (Filename.concat legacy "alpha/metrics/data.tmp") "runtime scratch";
   write_file (Filename.concat legacy "mystery.bin") "?";
   let json =
     Inventory.legacy_keeper_inventory_http_json
@@ -124,6 +141,10 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
     true
     (List.mem ("alpha/metrics/2026.jsonl", "live") (entry_classes json));
   Alcotest.(check bool)
+    "tmp under runtime store stays live"
+    true
+    (List.mem ("alpha/metrics/data.tmp", "live") (entry_classes json));
+  Alcotest.(check bool)
     "unknown file classified"
     true
     (List.mem ("mystery.bin", "unknown") (entry_classes json));
@@ -156,7 +177,7 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
 ;;
 
 let test_scan_cap_marks_truncation () =
-  let base = fresh_dir "masc-legacy-keeper-inventory-cap" in
+  with_temp_dir "masc-legacy-keeper-inventory-cap" @@ fun base ->
   let legacy = Filename.concat (Filename.concat base ".masc") "keepers" in
   ensure_dir (Filename.concat base ".masc");
   ensure_dir legacy;
@@ -174,7 +195,7 @@ let test_scan_cap_marks_truncation () =
 ;;
 
 let test_reports_scan_errors_for_invalid_legacy_root () =
-  let base = fresh_dir "masc-legacy-keeper-inventory-error" in
+  with_temp_dir "masc-legacy-keeper-inventory-error" @@ fun base ->
   let masc = Filename.concat base ".masc" in
   ensure_dir masc;
   write_file (Filename.concat masc "keepers") "not a directory";

--- a/test/test_server_dashboard_http_legacy_keeper_inventory.ml
+++ b/test/test_server_dashboard_http_legacy_keeper_inventory.ml
@@ -32,6 +32,12 @@ let bool_field name json =
   | _ -> Alcotest.failf "expected bool field %S" name
 ;;
 
+let string_field name json =
+  match assoc_field name json with
+  | Some (`String s) -> s
+  | _ -> Alcotest.failf "expected string field %S" name
+;;
+
 let object_field name json =
   match assoc_field name json with
   | Some (`Assoc _ as obj) -> obj
@@ -71,12 +77,11 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
   ensure_dir current;
   ensure_dir (Filename.concat legacy "alpha");
   ensure_dir (Filename.concat legacy "alpha/metrics");
-  ensure_dir (Filename.concat current "alpha");
   write_file (Filename.concat legacy "alpha/.atomic_dead.tmp") "orphan";
   write_file (Filename.concat legacy "PYEOF") "marker";
   write_file (Filename.concat legacy "alpha/old.backup") "backup";
   write_file (Filename.concat legacy "alpha/facts.jsonl") "{}\n";
-  write_file (Filename.concat current "alpha/facts.jsonl") "{}\n";
+  write_file (Filename.concat current "alpha.facts.jsonl") "{}\n";
   write_file (Filename.concat legacy "alpha/metrics/2026.jsonl") "{}\n";
   write_file (Filename.concat legacy "mystery.bin") "?";
   let json =
@@ -88,8 +93,21 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
   in
   Alcotest.(check bool) "inventory is read-only" true (bool_field "read_only" json);
   Alcotest.(check bool) "not truncated" false (bool_field "truncated" json);
-  Alcotest.(check int) "orphaned count" 2 (class_count "orphaned" json);
-  Alcotest.(check int) "backup count" 1 (class_count "backup" json);
+  Alcotest.(check bool) "scan complete" true (bool_field "scan_complete" json);
+  Alcotest.(check string)
+    "path scope"
+    "workspace_relative"
+    (string_field "path_scope" json);
+  Alcotest.(check string)
+    "legacy path redacted"
+    ".masc/keepers"
+    (string_field "legacy_keepers_path" json);
+  Alcotest.(check string)
+    "config keepers path redacted"
+    ".masc/config/keepers"
+    (string_field "current_config_keepers_path" json);
+  Alcotest.(check int) "orphaned count" 0 (class_count "orphaned" json);
+  Alcotest.(check int) "backup count" 0 (class_count "backup" json);
   Alcotest.(check int) "migrated count" 1 (class_count "migrated" json);
   Alcotest.(check bool)
     "live metric classified"
@@ -99,13 +117,30 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
     "unknown file classified"
     true
     (List.mem ("mystery.bin", "unknown") (entry_classes json));
+  Alcotest.(check bool)
+    "temp file requires owner proof"
+    true
+    (List.mem ("alpha/.atomic_dead.tmp", "unknown") (entry_classes json));
+  Alcotest.(check bool)
+    "marker file requires owner proof"
+    true
+    (List.mem ("PYEOF", "unknown") (entry_classes json));
+  Alcotest.(check bool)
+    "backup file requires owner proof"
+    true
+    (List.mem ("alpha/old.backup", "unknown") (entry_classes json));
   let plan = object_field "dry_run_cleanup_plan" json in
   Alcotest.(check bool) "delete disabled" false (bool_field "delete_allowed" plan);
   Alcotest.(check bool)
     "operator approval required"
     true
     (bool_field "requires_operator_approval" plan);
-  Alcotest.(check int) "cleanup candidates" 3 (int_field "candidate_count" plan)
+  Alcotest.(check string)
+    "candidate policy"
+    "disabled_until_owner_verified"
+    (string_field "candidate_policy" plan);
+  Alcotest.(check int) "cleanup candidates" 0 (int_field "candidate_count" plan);
+  Alcotest.(check int) "cleanup candidate list" 0 (List.length (list_field "candidates" plan))
 ;;
 
 let test_scan_cap_marks_truncation () =
@@ -126,6 +161,39 @@ let test_scan_cap_marks_truncation () =
   Alcotest.(check int) "visited cap" 1 (int_field "visited_entries" json)
 ;;
 
+let test_reports_scan_errors_for_invalid_legacy_root () =
+  let base = fresh_dir "masc-legacy-keeper-inventory-error" in
+  let masc = Filename.concat base ".masc" in
+  ensure_dir masc;
+  write_file (Filename.concat masc "keepers") "not a directory";
+  let json =
+    Inventory.legacy_keeper_inventory_http_json
+      ~base_path:base
+      ~max_depth:4
+      ~max_entries:100
+      ()
+  in
+  Alcotest.(check bool) "legacy root exists" true (bool_field "exists" json);
+  Alcotest.(check bool) "scan incomplete" false (bool_field "scan_complete" json);
+  let errors = list_field "scan_errors" json in
+  Alcotest.(check int) "scan error count" 1 (List.length errors);
+  (match List.hd errors with
+   | `Assoc fields ->
+     Alcotest.(check (option string))
+       "error path"
+       (Some ".")
+       (match List.assoc_opt "path" fields with
+        | Some (`String path) -> Some path
+        | _ -> None);
+     Alcotest.(check (option string))
+       "error operation"
+       (Some "readdir")
+       (match List.assoc_opt "operation" fields with
+        | Some (`String operation) -> Some operation
+        | _ -> None)
+   | _ -> Alcotest.fail "scan error must be an object")
+;;
+
 let () =
   Alcotest.run
     "server_dashboard_http_legacy_keeper_inventory"
@@ -135,5 +203,9 @@ let () =
             `Quick
             test_classifies_legacy_paths_and_dry_run_candidates
         ; Alcotest.test_case "scan cap marks truncation" `Quick test_scan_cap_marks_truncation
+        ; Alcotest.test_case
+            "reports scan errors"
+            `Quick
+            test_reports_scan_errors_for_invalid_legacy_root
         ] )
     ]

--- a/test/test_server_dashboard_http_legacy_keeper_inventory.ml
+++ b/test/test_server_dashboard_http_legacy_keeper_inventory.ml
@@ -147,23 +147,12 @@ let test_classifies_legacy_paths_and_dry_run_candidates () =
     (bool_field "requires_operator_approval" plan);
   Alcotest.(check string)
     "candidate policy"
-    "disabled_until_owner_verified"
+    "not_available_until_owner_verified"
     (string_field "candidate_policy" plan);
-  let candidate_classes = list_field "candidate_classes" plan in
-  Alcotest.(check int)
-    "cleanup candidate classes"
-    2
-    (List.length candidate_classes);
-  Alcotest.(check bool)
-    "orphaned cleanup class exposed"
-    true
-    (List.mem (`String "orphaned") candidate_classes);
-  Alcotest.(check bool)
-    "backup cleanup class exposed"
-    true
-    (List.mem (`String "backup") candidate_classes);
-  Alcotest.(check int) "cleanup candidates" 0 (int_field "candidate_count" plan);
-  Alcotest.(check int) "cleanup candidate list" 0 (List.length (list_field "candidates" plan))
+  Alcotest.(check string)
+    "candidate source"
+    "inventory_only"
+    (string_field "candidate_source" plan)
 ;;
 
 let test_scan_cap_marks_truncation () =


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/dashboard/legacy-keeper-inventory` as a read-only legacy `.masc/keepers` inventory surface.
- Classify bounded scan entries as `live`, `migrated`, `orphaned`, `backup`, or `unknown`.
- Return per-class count/byte totals plus an explicitly disabled cleanup surface. Cleanup candidates are intentionally not emitted until owner-verification logic exists.

## Review Response Notes

- Legacy Memory OS filename mapping is routed through `Keeper_memory_os_io.current_path_for_legacy_memory_filename`.
- Supported legacy memory filenames are represented by `Keeper_memory_os_io.legacy_memory_file` plus `supported_legacy_memory_files`, rather than dashboard-owned raw string checks.
- The cleanup plan no longer advertises always-zero `candidate_count` / `candidates`; it reports `candidate_policy=not_available_until_owner_verified` and `candidate_source=inventory_only`.
- Current-store access failures are surfaced as `scan_errors` via `lstat_current_memory` and classify the entry as `unknown`.
- Unexpected exception messages use a bounded exception slot label instead of `Printexc.to_string`.
- The dashboard cache key uses a SHA256 base-path hash prefix instead of embedding the raw workspace path.
- `relative_path` no longer falls back to returning a raw absolute path for paths outside the scan root.

## Audit Mapping

Addresses the P1 Memory OS audit gap:

- `docs/audit/2026-06-26-memory-os-production-audit.md`: "Legacy `.masc/keepers` Garbage Is Outside Current Cleanup"

This PR does not delete, move, or archive any legacy file. It only reports inventory. Cleanup candidate selection remains disabled until owner-verification logic is implemented.

## Validation

- `ocamlformat --check lib/keeper/keeper_memory_os_io.ml lib/keeper/keeper_memory_os_io.mli lib/server/server_dashboard_http_legacy_keeper_inventory.ml lib/server/server_dashboard_http_legacy_keeper_inventory.mli lib/server/server_routes_http_routes_dashboard.ml test/test_server_dashboard_http_legacy_keeper_inventory.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_memory_os_io.ml lib/server/server_dashboard_http_legacy_keeper_inventory.ml lib/server/server_routes_http_routes_dashboard.ml test/test_server_dashboard_http_legacy_keeper_inventory.ml`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_memory_os_io.mli lib/server/server_dashboard_http_legacy_keeper_inventory.mli`
- `git diff --check HEAD~1 HEAD`
- `scripts/audit-path-ssot.sh`
- targeted `rg` check for stale cleanup-candidate, legacy filename, raw-base-path cache, and raw absolute-path fallback patterns

Not run per current instruction:

- Dune build/test
- CI/check-log inspection
