### PR TITLE
[codex] Harden fusion empty responses and output budgets

### DIFF
--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -49,7 +49,7 @@ let string_of_failure (f : Fusion_types.panel_failure) : string =
   match f with
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Provider_error msg -> "provider_error: " ^ msg
-  | Fusion_types.Empty_response -> "empty_response"
+  | Fusion_types.Empty_response _ -> "empty_response"
 
 let string_of_decision (d : Fusion_types.judge_decision) : string =
   match d with

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -49,7 +49,9 @@ let string_of_failure (f : Fusion_types.panel_failure) : string =
   match f with
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Provider_error msg -> "provider_error: " ^ msg
-  | Fusion_types.Empty_response _ -> "empty_response"
+  | Fusion_types.Empty_response detail -> "empty_response: " ^ detail
+  | Fusion_types.Invalid_max_output_tokens n ->
+    Printf.sprintf "invalid_max_output_tokens: %d" n
 
 let string_of_decision (d : Fusion_types.judge_decision) : string =
   match d with

--- a/dashboard/src/lib/fusion-meta.test.ts
+++ b/dashboard/src/lib/fusion-meta.test.ts
@@ -38,6 +38,12 @@ describe('normalizeFusionPanelReason', () => {
     expect(normalizeFusionPanelReason('gpt-5', '( Fusion_types.Empty_response )')).toBe(
       'empty response',
     )
+    expect(
+      normalizeFusionPanelReason(
+        'gpt-5',
+        'Fusion_types.Empty_response "empty response (stop_reason=max_tokens)"',
+      ),
+    ).toBe('empty response (stop_reason=max_tokens)')
   })
 
   it('passes through plain reasons', () => {

--- a/dashboard/src/lib/fusion-meta.test.ts
+++ b/dashboard/src/lib/fusion-meta.test.ts
@@ -46,6 +46,12 @@ describe('normalizeFusionPanelReason', () => {
     ).toBe('empty response (stop_reason=max_tokens)')
   })
 
+  it('normalizes Invalid_max_output_tokens without provider attribution', () => {
+    expect(
+      normalizeFusionPanelReason('gpt-5', '( Fusion_types.Invalid_max_output_tokens 0 )'),
+    ).toBe('invalid max_output_tokens 0')
+  })
+
   it('passes through plain reasons', () => {
     expect(normalizeFusionPanelReason('gpt-5', 'context too long')).toBe('context too long')
   })

--- a/dashboard/src/lib/fusion-meta.ts
+++ b/dashboard/src/lib/fusion-meta.ts
@@ -22,8 +22,10 @@ function normalizeProviderAttribution(model: string, reason: string): string {
 }
 
 /**
- * Unwrap OCaml `Fusion_types.Provider_error / Timeout / Empty_response`
- * literals and re-attribute `Provider 'unknown'` failures to the real model id.
+ * Normalize panel failure reasons. Current `fusion_sink.ml` emits structured
+ * `reason_code`/`reason_detail`; the OCaml constructor parsing below is a
+ * legacy fallback for older board/meta payloads and direct show-derived
+ * fixtures.
  */
 export function normalizeFusionPanelReason(model: string, reason: string | undefined): string | undefined {
   if (!reason) return undefined

--- a/dashboard/src/lib/fusion-meta.ts
+++ b/dashboard/src/lib/fusion-meta.ts
@@ -33,7 +33,10 @@ export function normalizeFusionPanelReason(model: string, reason: string | undef
     return normalizeProviderAttribution(model, decodeOcamlStringLiteral(providerMatch[1] ?? '').trim())
   }
   if (/^\(?\s*Fusion_types\.Timeout\s*\)?$/.test(trimmed)) return 'timeout'
-  if (/^\(?\s*Fusion_types\.Empty_response\s*\)?$/.test(trimmed)) return 'empty response'
+  const emptyMatch = trimmed.match(/^\(?\s*Fusion_types\.Empty_response(?:\s+"([\s\S]*)")?\s*\)?$/)
+  if (emptyMatch) {
+    return decodeOcamlStringLiteral(emptyMatch[1] ?? '').trim() || 'empty response'
+  }
   return normalizeProviderAttribution(model, trimmed)
 }
 

--- a/dashboard/src/lib/fusion-meta.ts
+++ b/dashboard/src/lib/fusion-meta.ts
@@ -37,6 +37,12 @@ export function normalizeFusionPanelReason(model: string, reason: string | undef
   if (emptyMatch) {
     return decodeOcamlStringLiteral(emptyMatch[1] ?? '').trim() || 'empty response'
   }
+  const invalidMaxOutputTokensMatch = trimmed.match(
+    /^\(?\s*Fusion_types\.Invalid_max_output_tokens\s+(-?\d+)\s*\)?$/,
+  )
+  if (invalidMaxOutputTokensMatch) {
+    return `invalid max_output_tokens ${invalidMaxOutputTokensMatch[1]}`
+  }
   return normalizeProviderAttribution(model, trimmed)
 }
 

--- a/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
+++ b/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
@@ -257,10 +257,13 @@ panel_system_prompt = "..."           # 행동 정의 — 코드 default 없음,
 judge_system_prompt = "..."
 panel_timeout_s = 120.0               # 생략 시 default_timeout_s
 judge_timeout_s = 120.0
+max_output_tokens_per_panel = 4096    # 생략 시 Runtime_agent 기본 출력 예산
+judge_max_output_tokens = 4096        # 생략 시 Runtime_agent 기본 출력 예산
 ```
 
 - panel/judge 모델 식별자는 기존 `provider.model` opaque 문자열(runtime.toml bindings와 동일 컨벤션). 미존재 모델 → parse/resolve 에러(fail-fast).
 - 패널 1–8 모델 제한 검증. 알 수 없는 preset/모델은 silent default로 압축하지 않는다(CLAUDE.md §Unknown→Permissive 회피).
+- `max_output_tokens_per_panel`, `judge_max_output_tokens`, `[[...judges]].max_output_tokens`는 optional positive int다. 생략하면 기존 Runtime_agent 기본값을 보존하고, 0 이하 값은 config load에서 fail-fast한다.
 - `Runtime_toml` 파서 확장(또는 별도 `Fusion_config` 파서)로 `[fusion.*]` 로드 → `Fusion_policy.t`.
 
 ---

--- a/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
+++ b/docs/rfc/RFC-0252-fusion-panel-judge-deliberation.md
@@ -90,7 +90,7 @@ end
 type panel_failure =
   | Timeout
   | Provider_error of string
-  | Empty_response
+  | Empty_response of string
   | Budget_exhausted
 
 type panel_outcome =

--- a/docs/rfc/RFC-0277-fusion-heterogeneous-panels.md
+++ b/docs/rfc/RFC-0277-fusion-heterogeneous-panels.md
@@ -79,6 +79,7 @@ web_tools = false
 panel = ["careful1"]
 web_tools = true
 max_tool_calls_per_panel = 4
+max_output_tokens_per_panel = 4096
 panel_timeout_s = 180.0
 ```
 
@@ -112,6 +113,7 @@ RFC-0252 §6은 비용을 예측 가능하게 통제하려고 `per_hour_budget`(
 - `panel_outer_timeout_of groups` = 그룹 timeout 중 max (단일이면 그 그룹 timeout = `panel_timeout_s`).
 - `judge_web_tools_of ~req_web_tools groups` = `req || (어느 그룹이든 web_tools)` (단일이면 `req || group.web_tools` = 오늘).
 - `judge_tool_budget_of groups` = 0(무제한)이 흡수자, 그 외 그룹 max (단일이면 그 그룹 값 = 오늘).
+- `max_output_tokens_per_panel`은 group-local이다. 심판 출력 예산은 `judge_max_output_tokens`와 `[[...judges]].max_output_tokens`가 소유하므로, 그룹별 패널 예산이 심판 호출에 암묵 전파되지 않는다.
 
 검증: `test/fusion_core/test_fusion.ml`의 `config/panels_golden`(flat == 단일 그룹 `equal_preset`)과 `judge_args/single_group_identity`(derive 함수 == 오늘 매핑)가 이 불변식을 핀한다.
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -357,6 +357,25 @@ runtime authoring surface에서 모델 binding, preset, 동시성 cap을 함께 
 | `max_concurrent_judges` | int >= 1 | `3` | `judge_of_judges` 계열 judge wave fan-out 상한. 패널 backpressure와 독립 |
 | `staged_judge_group_size` | int >= 2 | `3` | `staged_judge_of_judges`가 1차 심판을 묶는 고정 reducer group 크기 |
 
+Preset-level keys:
+
+| TOML key | Type | Default | 의미 |
+|----------|------|---------|------|
+| `panel` | string[] | required | legacy flat panel model list |
+| `judge` | string | required | simple/refine/conditional judge and JOJ meta judge runtime id |
+| `panel_system_prompt` | string | required | legacy flat panel system prompt |
+| `judge_system_prompt` | string | required | judge system prompt |
+| `panel_timeout_s` | float | `300.0` | legacy flat panel structural timeout |
+| `judge_timeout_s` | float | `300.0` | judge structural timeout |
+| `max_tool_calls_per_panel` | int 0..16 | `0` | panel tool-call budget; `0` means unlimited |
+| `max_output_tokens_per_panel` | int > 0 | runtime default | panel output token budget override |
+| `judge_max_output_tokens` | int > 0 | runtime default | simple/refine/meta judge output token budget override |
+| `min_answered` | int 1..panel count | `1` | judge 실행에 필요한 answered panel quorum |
+
+In `[[fusion.presets.<name>.panels]]`, `max_output_tokens_per_panel` is group-local.
+In `[[fusion.presets.<name>.judges]]`, `max_output_tokens` controls that first
+judge's output budget. Omitted output-token keys preserve the Runtime_agent default.
+
 `max_concurrent_judges`는 topology를 늘리는 값이 아니라 독립 judge 호출을 동시에 몇 개까지
 실행할지 정하는 cap이다. Topology는 `masc_fusion.topology` 문자열로 선택한다.
 

--- a/docs/spec/14-configuration.md
+++ b/docs/spec/14-configuration.md
@@ -357,7 +357,7 @@ runtime authoring surface에서 모델 binding, preset, 동시성 cap을 함께 
 | `max_concurrent_judges` | int >= 1 | `3` | `judge_of_judges` 계열 judge wave fan-out 상한. 패널 backpressure와 독립 |
 | `staged_judge_group_size` | int >= 2 | `3` | `staged_judge_of_judges`가 1차 심판을 묶는 고정 reducer group 크기 |
 
-Preset-level keys:
+Legacy flat preset-level keys:
 
 | TOML key | Type | Default | 의미 |
 |----------|------|---------|------|
@@ -372,9 +372,15 @@ Preset-level keys:
 | `judge_max_output_tokens` | int > 0 | runtime default | simple/refine/meta judge output token budget override |
 | `min_answered` | int 1..panel count | `1` | judge 실행에 필요한 answered panel quorum |
 
-In `[[fusion.presets.<name>.panels]]`, `max_output_tokens_per_panel` is group-local.
-In `[[fusion.presets.<name>.judges]]`, `max_output_tokens` controls that first
-judge's output budget. Omitted output-token keys preserve the Runtime_agent default.
+Heterogeneous presets move model lists into group tables:
+
+- `[[fusion.presets.<name>.panels]]`: each group owns `models`,
+  `system_prompt`, `max_tool_calls_per_panel`, `max_output_tokens_per_panel`,
+  and optional routing labels.
+- `[[fusion.presets.<name>.judges]]`: each judge owns `model`,
+  `system_prompt`, `max_tool_calls`, and `max_output_tokens`.
+
+Omitted output-token keys preserve the Runtime_agent default.
 
 `max_concurrent_judges`는 topology를 늘리는 값이 아니라 독립 judge 호출을 동시에 몇 개까지
 실행할지 정하는 cap이다. Topology는 `masc_fusion.topology` 문자열로 선택한다.

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -123,15 +123,15 @@ let attach_usage
    에러도 usage를 동반한다: 토큰을 태운 뒤 실패(빈 응답/파싱 실패)는 소비분을, 토큰
    소비 전 실패(빌드/실행/빈 결과/provider 에러)는 [zero_usage]를 싣는다. 호출자는
    실패 경로에서도 비용을 회계할 수 있다. *)
-let run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tools
-    ~max_tool_calls ~prompt () :
+let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model
+    ~web_tools ~max_tool_calls ~prompt () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , string * Fusion_types.usage )
     result =
   let tools = if web_tools then Fusion_oas.web_tool_bundle () else [] in
   match
     Fusion_oas.build_agent ~sw ~net ~system_prompt:judge_system_prompt ~tools
-      ~max_tool_calls ~timeout_s judge_model
+      ~max_tool_calls ~timeout_s ?max_tokens judge_model
   with
   | Error reason ->
     Error
@@ -155,7 +155,7 @@ let run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tool
        (* 응답은 받았으므로 소비 토큰을 회계한다 — 빈 응답이든 파싱 실패든 동일. *)
        let usage = Fusion_oas.usage_of resp in
        if String.length (String.trim text) = 0 then
-         Error ("judge: empty response", usage)
+         Error ("judge: " ^ Fusion_oas.empty_response_detail resp, usage)
        else
          (* 성공 종합·파싱 실패 모두에 심판이 소비한 토큰을 묶는다(panel_answer.usage와 대칭). *)
          attach_usage (Fusion_judge_parse.of_string text) usage
@@ -166,26 +166,26 @@ let run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tool
                (Agent_sdk.Error.to_string e)
          , Fusion_types.zero_usage ))
 
-let run ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question ~panel
-    ~web_tools ~max_tool_calls () :
+let run ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
+    ~panel ~web_tools ~max_tool_calls () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , string * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
     ~max_tool_calls ~prompt:(compose_prompt ~question ~panel) ()
 
-let run_refine ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question
+let run_refine ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
     ~panel ~prior ~web_tools ~max_tool_calls () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , string * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
     ~max_tool_calls ~prompt:(compose_refine_prompt ~question ~panel ~prior) ()
 
-let run_meta ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~question
+let run_meta ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
     ~panel ~priors ~web_tools ~max_tool_calls () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
     , string * Fusion_types.usage )
     result =
-  run_composed ~sw ~net ~timeout_s ~judge_system_prompt ~judge_model ~web_tools
+  run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
     ~max_tool_calls ~prompt:(compose_meta_prompt ~question ~panel ~priors) ()

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -18,6 +18,7 @@ val compose_prompt : question:string -> panel:Fusion_types.panel_outcome list ->
     구성해 실행하고, 응답 텍스트를 {!Fusion_judge_parse.of_string}으로 파싱한다.
     [web_tools=true]면 심판 에이전트에 web_search/web_fetch를 주입한다.
     [max_tool_calls]: 0이면 무제한, 양수면 심판의 [max_turns]로 근approximate.
+    [max_tokens]는 출력 토큰 예산이다. 생략하면 Runtime_agent 기본값을 보존한다.
     빌드/실행/빈응답/파싱 실패는 [Error (msg, usage)]. 전체는 [Masc_oas_bridge.run_safe]로
     감싼다. 성공 시 종합 + 소비 토큰 [usage]를 반환하고(panel과 대칭, 비용 회계 RFC §10),
     실패 시에도 usage를 동반한다 — 응답을 받은 뒤 실패(빈 응답/파싱 실패)는 소비분을,
@@ -27,6 +28,7 @@ val run
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> timeout_s:float
+  -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string
@@ -57,6 +59,7 @@ val run_refine
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> timeout_s:float
+  -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string
@@ -97,6 +100,7 @@ val run_meta
   :  sw:Eio.Switch.t
   -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
   -> timeout_s:float
+  -> ?max_tokens:int
   -> judge_system_prompt:string
   -> judge_model:string
   -> question:string

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -9,50 +9,48 @@ let answer_text (resp : Agent_sdk.Types.api_response) : string =
   |> List.filter_map (function Agent_sdk.Types.Text s -> Some s | _ -> None)
   |> String.concat "\n"
 
-let stop_reason_label : Agent_sdk.Types.stop_reason -> string = function
-  | EndTurn -> "end_turn"
-  | StopToolUse -> "tool_use"
-  | MaxTokens -> "max_tokens"
-  | StopSequence -> "stop_sequence"
-  | Refusal -> "refusal"
-  | PauseTurn -> "pause_turn"
-  | Compaction -> "compaction"
-  | ContextWindowExceeded -> "context_window_exceeded"
-  | Unknown s ->
-    let s = String.trim s in
-    if String.equal s "" then "unknown"
-    else
-      let escaped = String.escaped s in
-      let max_len = 80 in
-      let safe =
-        if String.length escaped <= max_len then escaped
-        else String.sub escaped 0 max_len ^ "..."
-      in
-      "unknown:" ^ safe
+let stop_reason_label = Keeper_hooks_oas_types.stop_reason_to_label
+
+type empty_response_content_counts =
+  { text_blocks : int
+  ; text_chars : int
+  ; tool_use_count : int
+  ; tool_result_count : int
+  ; image_count : int
+  ; document_count : int
+  ; audio_count : int
+  }
+
+let zero_empty_response_content_counts =
+  { text_blocks = 0
+  ; text_chars = 0
+  ; tool_use_count = 0
+  ; tool_result_count = 0
+  ; image_count = 0
+  ; document_count = 0
+  ; audio_count = 0
+  }
+
+let empty_response_content_counts content =
+  List.fold_left
+    (fun acc -> function
+      | Agent_sdk.Types.Text s ->
+        { acc with
+          text_blocks = acc.text_blocks + 1
+        ; text_chars = acc.text_chars + String.length s
+        }
+      | Thinking _ | RedactedThinking _ -> acc
+      | ToolUse _ -> { acc with tool_use_count = acc.tool_use_count + 1 }
+      | ToolResult _ ->
+        { acc with tool_result_count = acc.tool_result_count + 1 }
+      | Image _ -> { acc with image_count = acc.image_count + 1 }
+      | Document _ -> { acc with document_count = acc.document_count + 1 }
+      | Audio _ -> { acc with audio_count = acc.audio_count + 1 })
+    zero_empty_response_content_counts content
 
 let empty_response_detail (resp : Agent_sdk.Types.api_response) : string =
-  let text_blocks = ref 0 in
-  let text_chars = ref 0 in
-  let thinking_blocks = ref 0 in
-  let redacted_thinking_blocks = ref 0 in
-  let tool_use_count = ref 0 in
-  let tool_result_count = ref 0 in
-  let image_count = ref 0 in
-  let document_count = ref 0 in
-  let audio_count = ref 0 in
-  List.iter
-    (function
-      | Agent_sdk.Types.Text s ->
-        incr text_blocks;
-        text_chars := !text_chars + String.length s
-      | Thinking _ -> incr thinking_blocks
-      | RedactedThinking _ -> incr redacted_thinking_blocks
-      | ToolUse _ -> incr tool_use_count
-      | ToolResult _ -> incr tool_result_count
-      | Image _ -> incr image_count
-      | Document _ -> incr document_count
-      | Audio _ -> incr audio_count)
-    resp.content;
+  let counts = empty_response_content_counts resp.content in
+  let thinking = Keeper_hooks_oas_types.summarize_thinking_blocks resp.content in
   let input_tokens, output_tokens =
     match resp.usage with
     | Some u -> string_of_int u.input_tokens, string_of_int u.output_tokens
@@ -60,20 +58,23 @@ let empty_response_detail (resp : Agent_sdk.Types.api_response) : string =
   in
   Printf.sprintf
     "empty response (stop_reason=%s content_blocks=%d text_blocks=%d \
-     text_chars=%d thinking_blocks=%d redacted_thinking_blocks=%d \
-     tool_use_count=%d tool_result_count=%d image_count=%d document_count=%d \
-     audio_count=%d input_tokens=%s output_tokens=%s)"
+     text_chars=%d thinking_kind=%s thinking_blocks=%d thinking_chars=%d \
+     redacted_thinking_blocks=%d tool_use_count=%d tool_result_count=%d \
+     image_count=%d document_count=%d audio_count=%d input_tokens=%s \
+     output_tokens=%s)"
     (stop_reason_label resp.stop_reason)
     (List.length resp.content)
-    !text_blocks
-    !text_chars
-    !thinking_blocks
-    !redacted_thinking_blocks
-    !tool_use_count
-    !tool_result_count
-    !image_count
-    !document_count
-    !audio_count
+    counts.text_blocks
+    counts.text_chars
+    thinking.Keeper_hooks_oas_types.thinking_kind
+    thinking.Keeper_hooks_oas_types.thinking_blocks
+    thinking.Keeper_hooks_oas_types.thinking_chars
+    thinking.Keeper_hooks_oas_types.redacted_thinking_blocks
+    counts.tool_use_count
+    counts.tool_result_count
+    counts.image_count
+    counts.document_count
+    counts.audio_count
     input_tokens
     output_tokens
 

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -20,7 +20,15 @@ let stop_reason_label : Agent_sdk.Types.stop_reason -> string = function
   | ContextWindowExceeded -> "context_window_exceeded"
   | Unknown s ->
     let s = String.trim s in
-    if String.equal s "" then "unknown" else "unknown:" ^ s
+    if String.equal s "" then "unknown"
+    else
+      let escaped = String.escaped s in
+      let max_len = 80 in
+      let safe =
+        if String.length escaped <= max_len then escaped
+        else String.sub escaped 0 max_len ^ "..."
+      in
+      "unknown:" ^ safe
 
 let empty_response_detail (resp : Agent_sdk.Types.api_response) : string =
   let text_blocks = ref 0 in
@@ -98,11 +106,14 @@ let panel_failure_code = function
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Provider_error _ -> "provider_error"
   | Fusion_types.Empty_response _ -> "empty_response"
+  | Fusion_types.Invalid_max_output_tokens _ -> "invalid_max_output_tokens"
 
 let panel_failure_detail ~runtime_id = function
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Provider_error detail -> provider_error_detail ~runtime_id detail
   | Fusion_types.Empty_response detail -> detail
+  | Fusion_types.Invalid_max_output_tokens n ->
+    Printf.sprintf "invalid max_output_tokens %d" n
 
 (* 이미 attribution된 실패를 재-attribution 없이 렌더한다. Provider_error의 detail은
    실패 시점(panel outcome_of_result / build_agent)에 provider_error_detail
@@ -114,6 +125,8 @@ let panel_failure_text = function
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Provider_error detail -> detail
   | Fusion_types.Empty_response detail -> detail
+  | Fusion_types.Invalid_max_output_tokens n ->
+    Printf.sprintf "invalid max_output_tokens %d" n
 
 let timeout_budget_opt timeout_s =
   if Float.is_finite timeout_s && timeout_s > 0.0 then Some timeout_s else None
@@ -184,11 +197,9 @@ let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0)
     let base_config =
       match max_tokens with
       | None -> Ok base_config
-      | Some n when n > 0 -> Ok { base_config with max_tokens = n }
-      | Some n ->
-        Error
-          (Fusion_types.Provider_error
-             (Printf.sprintf "%s: invalid max_tokens %d" model n))
+      | Some n when Fusion_policy.valid_max_output_tokens (Some n) ->
+        Ok { base_config with max_tokens = n }
+      | Some n -> Error (Fusion_types.Invalid_max_output_tokens n)
     in
     Result.bind base_config (fun base_config ->
     (* max_tool_calls는 OpenRouter Fusion의 per-panel tool budget에 대응.

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -9,6 +9,66 @@ let answer_text (resp : Agent_sdk.Types.api_response) : string =
   |> List.filter_map (function Agent_sdk.Types.Text s -> Some s | _ -> None)
   |> String.concat "\n"
 
+let stop_reason_label : Agent_sdk.Types.stop_reason -> string = function
+  | EndTurn -> "end_turn"
+  | StopToolUse -> "tool_use"
+  | MaxTokens -> "max_tokens"
+  | StopSequence -> "stop_sequence"
+  | Refusal -> "refusal"
+  | PauseTurn -> "pause_turn"
+  | Compaction -> "compaction"
+  | ContextWindowExceeded -> "context_window_exceeded"
+  | Unknown s ->
+    let s = String.trim s in
+    if String.equal s "" then "unknown" else "unknown:" ^ s
+
+let empty_response_detail (resp : Agent_sdk.Types.api_response) : string =
+  let text_blocks = ref 0 in
+  let text_chars = ref 0 in
+  let thinking_blocks = ref 0 in
+  let redacted_thinking_blocks = ref 0 in
+  let tool_use_count = ref 0 in
+  let tool_result_count = ref 0 in
+  let image_count = ref 0 in
+  let document_count = ref 0 in
+  let audio_count = ref 0 in
+  List.iter
+    (function
+      | Agent_sdk.Types.Text s ->
+        incr text_blocks;
+        text_chars := !text_chars + String.length s
+      | Thinking _ -> incr thinking_blocks
+      | RedactedThinking _ -> incr redacted_thinking_blocks
+      | ToolUse _ -> incr tool_use_count
+      | ToolResult _ -> incr tool_result_count
+      | Image _ -> incr image_count
+      | Document _ -> incr document_count
+      | Audio _ -> incr audio_count)
+    resp.content;
+  let input_tokens, output_tokens =
+    match resp.usage with
+    | Some u -> string_of_int u.input_tokens, string_of_int u.output_tokens
+    | None -> "unknown", "unknown"
+  in
+  Printf.sprintf
+    "empty response (stop_reason=%s content_blocks=%d text_blocks=%d \
+     text_chars=%d thinking_blocks=%d redacted_thinking_blocks=%d \
+     tool_use_count=%d tool_result_count=%d image_count=%d document_count=%d \
+     audio_count=%d input_tokens=%s output_tokens=%s)"
+    (stop_reason_label resp.stop_reason)
+    (List.length resp.content)
+    !text_blocks
+    !text_chars
+    !thinking_blocks
+    !redacted_thinking_blocks
+    !tool_use_count
+    !tool_result_count
+    !image_count
+    !document_count
+    !audio_count
+    input_tokens
+    output_tokens
+
 let usage_of (resp : Agent_sdk.Types.api_response) : Fusion_types.usage =
   match resp.usage with
   | Some u ->
@@ -37,12 +97,12 @@ let provider_error_detail ~runtime_id detail =
 let panel_failure_code = function
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Provider_error _ -> "provider_error"
-  | Fusion_types.Empty_response -> "empty_response"
+  | Fusion_types.Empty_response _ -> "empty_response"
 
 let panel_failure_detail ~runtime_id = function
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Provider_error detail -> provider_error_detail ~runtime_id detail
-  | Fusion_types.Empty_response -> "empty response"
+  | Fusion_types.Empty_response detail -> detail
 
 (* 이미 attribution된 실패를 재-attribution 없이 렌더한다. Provider_error의 detail은
    실패 시점(panel outcome_of_result / build_agent)에 provider_error_detail
@@ -53,7 +113,7 @@ let panel_failure_detail ~runtime_id = function
 let panel_failure_text = function
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Provider_error detail -> detail
-  | Fusion_types.Empty_response -> "empty response"
+  | Fusion_types.Empty_response detail -> detail
 
 let timeout_budget_opt timeout_s =
   if Float.is_finite timeout_s && timeout_s > 0.0 then Some timeout_s else None
@@ -103,7 +163,7 @@ let web_tool_bundle () : Agent_sdk.Tool.t list =
   |> List.filter_map oas_tool_of_descriptor
 
 let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0)
-    ?timeout_s ?name (model : string)
+    ?timeout_s ?max_tokens ?name (model : string)
   : (Agent_sdk.Agent.t, Fusion_types.panel_failure) result
   =
   (* 카드명(Async_agent.all이 결과 키로 반환)은 패널 정체성([name], 예 "skeptic (claude)").
@@ -121,6 +181,16 @@ let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0)
       Runtime_agent.default_config ~name:card_name ~provider_cfg ~system_prompt ~tools
     in
     let base_config = apply_timeout_budget ?timeout_s base_config in
+    let base_config =
+      match max_tokens with
+      | None -> Ok base_config
+      | Some n when n > 0 -> Ok { base_config with max_tokens = n }
+      | Some n ->
+        Error
+          (Fusion_types.Provider_error
+             (Printf.sprintf "%s: invalid max_tokens %d" model n))
+    in
+    Result.bind base_config (fun base_config ->
     (* max_tool_calls는 OpenRouter Fusion의 per-panel tool budget에 대응.
        Runtime_agent의 max_turns로 근사: tool 호출 횟수 + 최종 답변 1턴. *)
     let config =
@@ -132,8 +202,9 @@ let build_agent ~sw ~net ~system_prompt ?(tools = []) ?(max_tool_calls = 0)
      | Error e ->
        Error
          (Fusion_types.Provider_error
-            (provider_error_detail ~runtime_id:model (Agent_sdk.Error.to_string e))))
+            (provider_error_detail ~runtime_id:model (Agent_sdk.Error.to_string e)))))
 
 module For_testing = struct
   let apply_timeout_budget = apply_timeout_budget
+  let empty_response_detail = empty_response_detail
 end

--- a/lib/fusion/fusion_oas.mli
+++ b/lib/fusion/fusion_oas.mli
@@ -11,6 +11,8 @@
     [tools]를 주면 패널/심판이 tool call을 할 수 있다.
     [max_tool_calls] > 0이면 에이전트의 [max_turns]를 해당 횟수+1로 제한해
     OpenRouter Fusion의 per-panel tool budget을 근사한다.
+    [max_tokens]는 지정된 패널/심판 호출의 출력 토큰 예산이다. 생략하면
+    Runtime_agent 기본값을 보존한다.
     [timeout_s]는 OAS transport idle/body budget에만 매핑한다. Fusion의 구조적
     wall-clock budget은 호출자가 [Masc_oas_bridge.run_safe]로 소유하며, OAS
     [max_execution_time_s]에는 매핑하지 않는다.
@@ -25,6 +27,7 @@ val build_agent
   -> ?tools:Agent_sdk.Tool.t list
   -> ?max_tool_calls:int
   -> ?timeout_s:float
+  -> ?max_tokens:int
   -> ?name:string
   -> string
   -> (Agent_sdk.Agent.t, Fusion_types.panel_failure) result
@@ -37,6 +40,8 @@ module For_testing : sig
     :  ?timeout_s:float
     -> Runtime_agent.config
     -> Runtime_agent.config
+
+  val empty_response_detail : Agent_sdk.Types.api_response -> string
 end
 
 (** Attach Fusion's runtime id to an OAS provider error string.
@@ -55,6 +60,10 @@ val panel_failure_detail : runtime_id:string -> Fusion_types.panel_failure -> st
     detail 그대로(실패 시점에 raw model로 정규화됨), Timeout/Empty는 사람용 문자열.
     panelist 정체성을 [Provider '...'] 슬롯에 다시 입히지 않는다 (RFC-0278). *)
 val panel_failure_text : Fusion_types.panel_failure -> string
+
+(** Empty text response diagnostics. This records stop_reason, token usage, and
+    content block counts only; it never exposes reasoning/thinking content. *)
+val empty_response_detail : Agent_sdk.Types.api_response -> string
 
 (** [masc_web_search] / [masc_web_fetch]를 [Agent_sdk.Tool.t]로 변환한 목록.
     [Keeper_tool_descriptor]에서 descriptor를 찾지 못하면 빈 목록을 반환한다. *)

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -56,6 +56,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           let run_single_judge () =
             Fusion_judge.run ~sw ~net
               ~timeout_s:preset.Fusion_policy.judge_timeout_s
+              ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
               ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
               ~judge_model:preset.Fusion_policy.judge
               ~question:req.Fusion_types.prompt ~panel ~web_tools:judge_web_tools
@@ -76,6 +77,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             match
               Fusion_judge.run_refine ~sw ~net
                 ~timeout_s:preset.Fusion_policy.judge_timeout_s
+                ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                 ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                 ~judge_model:preset.Fusion_policy.judge
                 ~question:req.Fusion_types.prompt ~panel ~prior:s1
@@ -107,6 +109,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                 let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
                 ( id
                 , Fusion_judge.run ~sw ~net ~timeout_s:j.jtimeout_s
+                    ?max_tokens:j.jmax_output_tokens
                     ~judge_system_prompt:j.jsystem_prompt ~judge_model:j.jmodel
                     ~question:req.Fusion_types.prompt ~panel ~web_tools:j.jweb_tools
                     ~max_tool_calls:j.jmax_tool_calls () ))
@@ -180,6 +183,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  (match
                     Fusion_judge.run_meta ~sw ~net
                       ~timeout_s:preset.Fusion_policy.judge_timeout_s
+                      ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                       ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                       ~judge_model:preset.Fusion_policy.judge
                       ~question:req.Fusion_types.prompt ~panel ~priors
@@ -251,6 +255,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                   (match
                      Fusion_judge.run_meta ~sw ~net
                        ~timeout_s:preset.Fusion_policy.judge_timeout_s
+                       ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                        ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                        ~judge_model:preset.Fusion_policy.judge
                        ~question:req.Fusion_types.prompt ~panel ~priors
@@ -303,6 +308,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  (match
                     Fusion_judge.run_meta ~sw ~net
                       ~timeout_s:preset.Fusion_policy.judge_timeout_s
+                      ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
                       ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
                       ~judge_model:preset.Fusion_policy.judge
                       ~question:req.Fusion_types.prompt ~panel ~priors

--- a/lib/fusion/fusion_panel.ml
+++ b/lib/fusion/fusion_panel.ml
@@ -20,7 +20,9 @@ let outcome_of_result ~(panelist : string) ~(model : string)
     let answer = Fusion_oas.answer_text resp in
     if String.length (String.trim answer) = 0 then
       Fusion_types.Failed
-        { failed_model = panelist; reason = Fusion_types.Empty_response }
+        { failed_model = panelist
+        ; reason = Fusion_types.Empty_response (Fusion_oas.empty_response_detail resp)
+        }
     else
       Fusion_types.Answered
         { model = panelist; answer; usage = Fusion_oas.usage_of resp }
@@ -51,6 +53,7 @@ let run ~sw ~net ~max_fibers ~outer_timeout_s ~groups ~prompt ()
             match
               Fusion_oas.build_agent ~sw ~net ~system_prompt:g.system_prompt ~tools
                 ~max_tool_calls:g.max_tool_calls ~timeout_s:g.timeout_s
+                ?max_tokens:g.max_output_tokens
                 ~name:panelist model
             with
             | Ok agent -> ((agent, panelist, model) :: oks, fails)

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -13,6 +13,7 @@ type config_error =
   | Invalid_max_concurrent_judges of int
   | Invalid_staged_judge_group_size of int
   | Invalid_max_tool_calls of string * int
+  | Invalid_max_output_tokens of string * int
   | Missing_default_preset of string
   | Judge_panel_prompt_missing of string  (** preset 이름; JOJ 1차 심판 prompt 누락 (RFC-0283) *)
   | Duplicate_judge of string * string  (** (preset 이름, 중복 judge 정체성) (RFC-0283) *)
@@ -44,6 +45,8 @@ let parse_group (tbl : Otoml.t) : Fusion_policy.panel_group =
   ; web_tools = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "web_tools" ]
   ; max_tool_calls =
       Otoml.find_or ~default:0 tbl Otoml.get_integer [ "max_tool_calls_per_panel" ]
+  ; max_output_tokens =
+      Otoml.find_opt tbl Otoml.get_integer [ "max_output_tokens_per_panel" ]
   ; timeout_s =
       Otoml.find_or ~default:Fusion_policy.default_timeout_s tbl Otoml.get_float
         [ "panel_timeout_s" ]
@@ -61,6 +64,7 @@ let parse_judge_spec (tbl : Otoml.t) : Fusion_policy.judge_spec =
   ; jweb_tools = Otoml.find_or ~default:false tbl Otoml.get_boolean [ "web_tools" ]
   ; jmax_tool_calls =
       Otoml.find_or ~default:0 tbl Otoml.get_integer [ "max_tool_calls" ]
+  ; jmax_output_tokens = Otoml.find_opt tbl Otoml.get_integer [ "max_output_tokens" ]
   ; jtimeout_s =
       Otoml.find_or ~default:Fusion_policy.default_timeout_s tbl Otoml.get_float
         [ "timeout_s" ]
@@ -88,6 +92,9 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
     Otoml.find_or ~default:Fusion_policy.default_timeout_s tbl Otoml.get_float
       [ "judge_timeout_s" ]
   in
+  let judge_max_output_tokens =
+    Otoml.find_opt tbl Otoml.get_integer [ "judge_max_output_tokens" ]
+  in
   let judges =
     match Otoml.find_opt tbl (Otoml.get_array Otoml.get_value) [ "judges" ] with
     | Some entries -> List.map parse_judge_spec entries
@@ -97,7 +104,15 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
      허용 범위는 1 이상 패널 모델 총합 이하; 검증 SSOT는 Validated_preset.of_preset. *)
   Result.bind (parse_min_answered name tbl) (fun min_answered ->
     let p : Fusion_policy.preset =
-      { name; panels; judge; judge_system_prompt; judge_timeout_s; judges; min_answered }
+      { name
+      ; panels
+      ; judge
+      ; judge_system_prompt
+      ; judge_timeout_s
+      ; judge_max_output_tokens
+      ; judges
+      ; min_answered
+      }
     in
     (* 검증 SSOT는 Validated_preset.of_preset (RFC-0280). config는 그 [invalid]에 preset
      이름을 붙여 자기 [config_error]로 매핑만 한다 (운영자에게 어느 preset인지 알림).
@@ -115,6 +130,8 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
            Duplicate_panelist (name, id)
          | Fusion_policy.Validated_preset.Bad_max_tool_calls v ->
            Invalid_max_tool_calls (name, v)
+         | Fusion_policy.Validated_preset.Bad_max_output_tokens v ->
+           Invalid_max_output_tokens (name, v)
          | Fusion_policy.Validated_preset.Judge_panel_prompt_missing ->
            Judge_panel_prompt_missing name
          | Fusion_policy.Validated_preset.Duplicate_judge id ->

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -29,6 +29,8 @@ type config_error =
       (** staged_judge_group_size < Fusion_policy.min_staged_judge_group_size *)
   | Invalid_max_tool_calls of string * int
       (** (preset 이름, 값) — 0..16 범위 위반 *)
+  | Invalid_max_output_tokens of string * int
+      (** (preset 이름, 값) — max_output_tokens override는 양수여야 함 *)
   | Missing_default_preset of string
       (** enabled인데 default_preset가 비었거나 presets에 없음. 빈 문자엏도 거부 —
           preset 생략 호출이 default_preset로 폭빽하는데 ""는 항상 Preset_unknown로
@@ -61,6 +63,7 @@ val disabled : Fusion_policy.t
     - max_concurrent_judges < 1 → [Error [Invalid_max_concurrent_judges _]].
     - staged_judge_group_size < 2 → [Error [Invalid_staged_judge_group_size _]].
     - max_tool_calls_per_panel이 0..16 범위 밖 → [Error [Invalid_max_tool_calls _]].
+    - max_output_tokens override가 0 이하 → [Error [Invalid_max_output_tokens _]].
     - min_answered가 1..패널 모델 총합 범위 밖 → [Error [Invalid_min_answered _]].
     - default_preset가 presets에 없음 → [Error [Missing_default_preset _]].
     - 필드 타입 불일치 → [Error [Toml_type_error _]].

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -14,6 +14,7 @@ type panel_group =
   ; system_prompt : string  (** 그룹 패널 모델 system prompt (config 필수) *)
   ; web_tools : bool  (** 그룹에 web_search/web_fetch 주입 여부 *)
   ; max_tool_calls : int  (** 그룹 모델당 최대 tool 호출 수 (0=무제한) *)
+  ; max_output_tokens : int option  (** 그룹 모델당 출력 토큰 예산 override *)
   ; timeout_s : float  (** 그룹 패널 호출 구조적 타임아웃 (초) *)
   }
 [@@deriving show, eq]
@@ -27,6 +28,7 @@ type judge_spec =
   ; jsystem_prompt : string  (** 이 1차 심판의 lens (config 필수) *)
   ; jweb_tools : bool  (** web_search/web_fetch 주입 여부 *)
   ; jmax_tool_calls : int  (** 최대 tool 호출 수 (0=무제한) *)
+  ; jmax_output_tokens : int option  (** 출력 토큰 예산 override *)
   ; jtimeout_s : float  (** 호출 구조적 타임아웃 (초) *)
   }
 [@@deriving show, eq]
@@ -38,6 +40,7 @@ type preset =
       (** simple/refine/conditional 심판이자 JOJ의 meta-judge(reducer). (RFC-0283) *)
   ; judge_system_prompt : string
   ; judge_timeout_s : float
+  ; judge_max_output_tokens : int option
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
@@ -57,6 +60,10 @@ let default_staged_judge_group_size = 3
 (* 그룹 모델당 max_tool_calls 상한 (0..max). 0=무제한, 그 외 양수는 에이전트
    max_turns에 근사. SSOT 상수 (Magic Number 회피, RFC-0280에서 검증을 한 곳으로 모음). *)
 let max_tool_calls_ceiling = 16
+
+let valid_max_output_tokens = function
+  | None -> true
+  | Some n -> n > 0
 
 (* 패널/심판 호출 구조적 타임아웃 기본값 (preset이 명시 안 할 때). 운영 노브 —
    행동 휴리스틱이 아니므로 named SSOT 상수로 둔다 (Magic Number 회피). *)
@@ -243,6 +250,8 @@ module Validated_preset = struct
     | Duplicate_panelist of string  (** 두 패널이 같은 정체성(panelist_id) *)
     | Bad_max_tool_calls of int
         (** 그룹 또는 JOJ 1차 심판 max_tool_calls가 0..max_tool_calls_ceiling 밖 *)
+    | Bad_max_output_tokens of int
+        (** 그룹/심판 출력 토큰 예산 override가 양수가 아님 *)
     | Judge_panel_prompt_missing  (** JOJ 1차 심판 system prompt 비어있음 (RFC-0283) *)
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성(judge_id) (RFC-0283) *)
     | Min_answered_below_min of int
@@ -251,8 +260,9 @@ module Validated_preset = struct
         (** [min_answered]가 패널 모델 총합을 초과. *)
 
   (* 검증 순서는 config 로드 시점과 동일(byte-identical config_error): size → 패널 prompt →
-     judge model → 패널 정체성 중복 → 패널 max_tool_calls 범위 → (RFC-0283) 1차 심판 prompt
-     → 1차 심판 정체성 중복 → 1차 심판 max_tool_calls 범위 → min_answered.
+     judge model → 패널 정체성 중복 → 패널 max_tool_calls 범위 → 패널 max_output_tokens
+     범위 → (RFC-0283) 1차 심판 prompt → 1차 심판 정체성 중복 → 1차 심판
+     max_tool_calls 범위 → 심판 max_output_tokens 범위 → min_answered.
      judges=[]면 1차 심판 관련 셋은 통과(simple/refine/conditional preset은 기존과 동일
      결과 = byte-identity). *)
   let of_preset (p : preset) : (t, invalid) result =
@@ -271,26 +281,45 @@ module Validated_preset = struct
          with
          | Some g -> Error (Bad_max_tool_calls g.max_tool_calls)
          | None ->
-           if not (preset_judge_prompts_present p) then Error Judge_panel_prompt_missing
-           else (
-             match preset_duplicate_judge p with
-             | Some id -> Error (Duplicate_judge id)
-             | None ->
-               (match
-                  List.find_opt
-                    (fun (j : judge_spec) ->
-                      j.jmax_tool_calls < 0
-                      || j.jmax_tool_calls > max_tool_calls_ceiling)
-                    p.judges
-                with
-                | Some j -> Error (Bad_max_tool_calls j.jmax_tool_calls)
+           (match
+              List.find_map
+                (fun (g : panel_group) ->
+                  match g.max_output_tokens with
+                  | Some n when not (valid_max_output_tokens (Some n)) -> Some n
+                  | _ -> None)
+                p.panels
+            with
+            | Some n -> Error (Bad_max_output_tokens n)
+            | None ->
+              if not (preset_judge_prompts_present p) then Error Judge_panel_prompt_missing
+              else (
+                match preset_duplicate_judge p with
+                | Some id -> Error (Duplicate_judge id)
                 | None ->
-                  let total = List.length (preset_models p) in
-                  if p.min_answered < min_answered_floor
-                  then Error (Min_answered_below_min p.min_answered)
-                  else if p.min_answered > total
-                  then Error (Min_answered_above_max p.min_answered)
-                  else Ok p)))
+                  (match
+                     List.find_opt
+                       (fun (j : judge_spec) ->
+                         j.jmax_tool_calls < 0
+                         || j.jmax_tool_calls > max_tool_calls_ceiling)
+                       p.judges
+                   with
+                   | Some j -> Error (Bad_max_tool_calls j.jmax_tool_calls)
+                   | None ->
+                     (match
+                        p.judge_max_output_tokens
+                        :: List.map
+                             (fun (j : judge_spec) -> j.jmax_output_tokens)
+                             p.judges
+                        |> List.find_opt (fun v -> not (valid_max_output_tokens v))
+                      with
+                      | Some (Some n) -> Error (Bad_max_output_tokens n)
+                      | Some None | None ->
+                        let total = List.length (preset_models p) in
+                        if p.min_answered < min_answered_floor
+                        then Error (Min_answered_below_min p.min_answered)
+                        else if p.min_answered > total
+                        then Error (Min_answered_above_max p.min_answered)
+                        else Ok p)))))
 
   let preset (t : t) : preset = t
 

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -18,6 +18,8 @@ type panel_group =
       (** 그룹 패널 모델 system prompt — config에서 필수(코드 default 없음). *)
   ; web_tools : bool  (** 그룹에 web_search/web_fetch 주입 여부. *)
   ; max_tool_calls : int  (** 그룹 모델당 최대 tool 호출 수 (0=무제한). *)
+  ; max_output_tokens : int option
+      (** 그룹 모델당 출력 토큰 예산 override. [None]이면 Runtime_agent 기본값. *)
   ; timeout_s : float  (** 그룹 패널 호출 구조적 타임아웃 (초). *)
   }
 [@@deriving show, eq]
@@ -31,6 +33,8 @@ type judge_spec =
   ; jsystem_prompt : string  (** 이 1차 심판의 lens — config에서 필수(코드 default 없음). *)
   ; jweb_tools : bool  (** web_search/web_fetch 주입 여부. *)
   ; jmax_tool_calls : int  (** 최대 tool 호출 수 (0=무제한). *)
+  ; jmax_output_tokens : int option
+      (** 출력 토큰 예산 override. [None]이면 Runtime_agent 기본값. *)
   ; jtimeout_s : float  (** 호출 구조적 타임아웃 (초). *)
   }
 [@@deriving show, eq]
@@ -47,6 +51,8 @@ type preset =
   ; judge_system_prompt : string
       (** 심판 모델 system prompt — config에서 필수(코드 default 없음). *)
   ; judge_timeout_s : float  (** 심판 호출 구조적 타임아웃 (초). *)
+  ; judge_max_output_tokens : int option
+      (** 단일/refine/meta 심판 출력 토큰 예산 override. [None]이면 기본값. *)
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
@@ -84,6 +90,9 @@ val min_staged_judge_group_size : int
 
 (** 그룹 모델당 [max_tool_calls] 상한 (0..이 값). 0=무제한. named SSOT. *)
 val max_tool_calls_ceiling : int
+
+(** Optional max-output-token overrides must be positive when present. *)
+val valid_max_output_tokens : int option -> bool
 
 (** 패널/심판 타임아웃 기본값 (config 미지정 시). 운영 노브 — named SSOT. *)
 val default_timeout_s : float
@@ -182,6 +191,8 @@ module Validated_preset : sig
     | Duplicate_panelist of string  (** 두 패널이 같은 정체성({!panelist_id}) *)
     | Bad_max_tool_calls of int
         (** 그룹 또는 JOJ 1차 심판 max_tool_calls가 0..[max_tool_calls_ceiling] 밖 *)
+    | Bad_max_output_tokens of int
+        (** 그룹/심판 max_output_tokens override가 양수가 아님 *)
     | Judge_panel_prompt_missing  (** JOJ 1차 심판 system prompt 비어있음 (RFC-0283) *)
     | Duplicate_judge of string  (** 두 JOJ 1차 심판이 같은 정체성 (RFC-0283) *)
     | Min_answered_below_min of int
@@ -189,8 +200,9 @@ module Validated_preset : sig
     | Min_answered_above_max of int
         (** [min_answered]가 패널 모델 총합을 초과. *)
 
-  (** 검증 순서: size → prompt → judge → 정체성 중복 → max_tool_calls → 1차 심판
-      prompt/정체성/max_tool_calls → min_answered. 통과 시 [Ok vp], 첫 위반에서
+  (** 검증 순서: size → prompt → judge → 정체성 중복 → max_tool_calls →
+      max_output_tokens → 1차 심판 prompt/정체성/max_tool_calls/max_output_tokens
+      → min_answered. 통과 시 [Ok vp], 첫 위반에서
       [Error invalid]. config 로드의 검증 순서와 동일. *)
   val of_preset : preset -> (t, invalid) result
 

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -65,7 +65,21 @@ type panel_failure =
   | Timeout
   | Provider_error of string
   | Empty_response of string
-[@@deriving yojson, show, eq]
+  | Invalid_max_output_tokens of int
+[@@deriving to_yojson, show, eq]
+
+let panel_failure_of_yojson = function
+  | `String "Timeout" -> Ok Timeout
+  | `String "Empty_response" -> Ok (Empty_response "empty response")
+  | `List [ `String "Provider_error"; `String detail ] -> Ok (Provider_error detail)
+  | `List [ `String "Empty_response"; `String detail ] -> Ok (Empty_response detail)
+  | `List [ `String "Invalid_max_output_tokens"; `Int value ] ->
+    Ok (Invalid_max_output_tokens value)
+  | json ->
+    Error
+      (Printf.sprintf
+         "Fusion_types.panel_failure_of_yojson: unsupported shape %s"
+         (Yojson.Safe.to_string json))
 
 type panel_answer =
   { model : string

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -64,7 +64,7 @@ end
 type panel_failure =
   | Timeout
   | Provider_error of string
-  | Empty_response
+  | Empty_response of string
 [@@deriving yojson, show, eq]
 
 type panel_answer =

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -70,7 +70,11 @@ type panel_failure =
   | Empty_response of string
       (** 모델이 빈 응답. detail에는 stop_reason/usage/content shape만 보존하고,
           reasoning/thinking 본문은 노출하지 않는다. *)
-[@@deriving yojson, show, eq]
+  | Invalid_max_output_tokens of int
+      (** Runtime defense-in-depth: output token override must be positive. *)
+[@@deriving to_yojson, show, eq]
+
+val panel_failure_of_yojson : Yojson.Safe.t -> (panel_failure, string) result
 
 (** 성공한 패널 한 명의 답. (variant inline record는 ppx_deriving_yojson 비호환이라
     named record로 분리한다.) *)

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -67,7 +67,9 @@ end
 type panel_failure =
   | Timeout  (** 구조적 타임아웃 (Masc_oas_bridge) *)
   | Provider_error of string  (** provider/transport 에러, 메시지 보존 *)
-  | Empty_response  (** 모델이 빈 응답 (keeper_librarian 빈응답 전례) *)
+  | Empty_response of string
+      (** 모델이 빈 응답. detail에는 stop_reason/usage/content shape만 보존하고,
+          reasoning/thinking 본문은 노출하지 않는다. *)
 [@@deriving yojson, show, eq]
 
 (** 성공한 패널 한 명의 답. (variant inline record는 ppx_deriving_yojson 비호환이라

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -598,10 +598,10 @@ max_tool_calls_per_panel = 17
   match Fusion_config.of_toml (parse s) with
   | Error es ->
     Alcotest.(check bool) "Invalid_max_tool_calls present" true
-	      (List.exists
-	         (function Fusion_config.Invalid_max_tool_calls _ -> true | _ -> false)
-	         es)
-	  | Ok _ -> Alcotest.fail "expected Error Invalid_max_tool_calls"
+      (List.exists
+         (function Fusion_config.Invalid_max_tool_calls _ -> true | _ -> false)
+         es)
+  | Ok _ -> Alcotest.fail "expected Error Invalid_max_tool_calls"
 
 let test_config_invalid_max_output_tokens () =
   let s =
@@ -1319,13 +1319,13 @@ let () =
         ; Alcotest.test_case "bad_concurrency" `Quick test_config_bad_concurrency
         ; Alcotest.test_case "bad_judge_concurrency" `Quick
             test_config_bad_judge_concurrency
-	        ; Alcotest.test_case "bad_staged_judge_group_size" `Quick
-	            test_config_bad_staged_judge_group_size
-	        ; Alcotest.test_case "invalid_max_tool_calls" `Quick
-	            test_config_invalid_max_tool_calls
-	        ; Alcotest.test_case "invalid_max_output_tokens" `Quick
-	            test_config_invalid_max_output_tokens
-	        ; Alcotest.test_case "empty_default_preset" `Quick test_config_empty_default_preset
+        ; Alcotest.test_case "bad_staged_judge_group_size" `Quick
+            test_config_bad_staged_judge_group_size
+        ; Alcotest.test_case "invalid_max_tool_calls" `Quick
+            test_config_invalid_max_tool_calls
+        ; Alcotest.test_case "invalid_max_output_tokens" `Quick
+            test_config_invalid_max_output_tokens
+        ; Alcotest.test_case "empty_default_preset" `Quick test_config_empty_default_preset
         ; Alcotest.test_case "disabled_with_preset" `Quick test_config_disabled_with_preset
         ; Alcotest.test_case "judges_parse" `Quick test_config_judges_parse
         ; Alcotest.test_case "no_judges" `Quick test_config_no_judges
@@ -1333,21 +1333,21 @@ let () =
     ; ( "validated_preset"
       , [ Alcotest.test_case "ok" `Quick test_validated_ok
         ; Alcotest.test_case "bad_size" `Quick test_validated_bad_size
-	        ; Alcotest.test_case "missing_prompt" `Quick test_validated_missing_prompt
-	        ; Alcotest.test_case "missing_judge" `Quick test_validated_missing_judge
-	        ; Alcotest.test_case "duplicate_panelist" `Quick test_validated_duplicate_panelist
-	        ; Alcotest.test_case "bad_max_tool_calls" `Quick test_validated_bad_max_tool_calls
-	        ; Alcotest.test_case "bad_max_output_tokens" `Quick
-	            test_validated_bad_max_output_tokens
+        ; Alcotest.test_case "missing_prompt" `Quick test_validated_missing_prompt
+        ; Alcotest.test_case "missing_judge" `Quick test_validated_missing_judge
+        ; Alcotest.test_case "duplicate_panelist" `Quick test_validated_duplicate_panelist
+        ; Alcotest.test_case "bad_max_tool_calls" `Quick test_validated_bad_max_tool_calls
+        ; Alcotest.test_case "bad_max_output_tokens" `Quick
+            test_validated_bad_max_output_tokens
         ; Alcotest.test_case "judges_empty_ok" `Quick test_validated_judges_empty_ok
         ; Alcotest.test_case "judges_ok" `Quick test_validated_judges_ok
         ; Alcotest.test_case "judge_prompt_missing" `Quick test_validated_judge_prompt_missing
-	        ; Alcotest.test_case "duplicate_judge" `Quick test_validated_duplicate_judge
-	        ; Alcotest.test_case "judge_bad_max_tool_calls" `Quick
-	            test_validated_judge_bad_max_tool_calls
-	        ; Alcotest.test_case "judge_bad_max_output_tokens" `Quick
-	            test_validated_judge_bad_max_output_tokens
-	        ] )
+        ; Alcotest.test_case "duplicate_judge" `Quick test_validated_duplicate_judge
+        ; Alcotest.test_case "judge_bad_max_tool_calls" `Quick
+            test_validated_judge_bad_max_tool_calls
+        ; Alcotest.test_case "judge_bad_max_output_tokens" `Quick
+            test_validated_judge_bad_max_output_tokens
+        ] )
     ; ( "staged_judge_groups"
       , [ Alcotest.test_case "exact_3x3" `Quick test_staged_judge_groups_exact_3x3
         ; Alcotest.test_case "too_few" `Quick test_staged_judge_groups_too_few

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -19,6 +19,7 @@ let base_group : Fusion_policy.panel_group =
   ; system_prompt = "panel"
   ; web_tools = false
   ; max_tool_calls = 0
+  ; max_output_tokens = None
   ; timeout_s = 300.0
   }
 
@@ -45,6 +46,7 @@ let base_policy : Fusion_policy.t =
           ; judge = "a"
           ; judge_system_prompt = "judge"
           ; judge_timeout_s = 300.0
+          ; judge_max_output_tokens = None
           ; judges = []
           ; min_answered = Fusion_policy.default_min_answered
           }
@@ -131,7 +133,9 @@ let test_config_valid () =
        (match preset.Fusion_policy.panels with
         | [ g ] ->
           Alcotest.(check bool) "web_tools" false g.Fusion_policy.web_tools;
-          Alcotest.(check int) "max_tool_calls" 0 g.Fusion_policy.max_tool_calls
+          Alcotest.(check int) "max_tool_calls" 0 g.Fusion_policy.max_tool_calls;
+          Alcotest.(check (option int)) "max_output_tokens default" None
+            g.Fusion_policy.max_output_tokens
         | _ -> Alcotest.fail "expected one group")
      | _ -> Alcotest.fail "expected exactly one preset")
   | Error es ->
@@ -148,12 +152,14 @@ default_preset = "p"
 [fusion.presets.p]
 web_tools = true
 max_tool_calls_per_panel = 4
+max_output_tokens_per_panel = 2048
 panel_timeout_s = 123.0
 panel = ["a", "b", "c"]
 judge = "j"
 panel_system_prompt = "answer independently"
 judge_system_prompt = "synthesize"
 judge_timeout_s = 99.0
+judge_max_output_tokens = 1024
 |}
 
 let golden_single_group_toml =
@@ -165,11 +171,13 @@ default_preset = "p"
 judge = "j"
 judge_system_prompt = "synthesize"
 judge_timeout_s = 99.0
+judge_max_output_tokens = 1024
 [[fusion.presets.p.panels]]
 panel = ["a", "b", "c"]
 panel_system_prompt = "answer independently"
 web_tools = true
 max_tool_calls_per_panel = 4
+max_output_tokens_per_panel = 2048
 panel_timeout_s = 123.0
 |}
 
@@ -226,6 +234,8 @@ let test_config_heterogeneous () =
           Alcotest.(check bool) "g1 no web" false g1.Fusion_policy.web_tools;
           Alcotest.(check bool) "g2 web" true g2.Fusion_policy.web_tools;
           Alcotest.(check int) "g2 tool budget" 4 g2.Fusion_policy.max_tool_calls;
+          Alcotest.(check (option int)) "g1 default max output" None
+            g1.Fusion_policy.max_output_tokens;
           Alcotest.(check (float 0.001)) "g2 timeout" 180.0 g2.Fusion_policy.timeout_s;
           Alcotest.(check (float 0.001)) "g1 default timeout"
             Fusion_policy.default_timeout_s g1.Fusion_policy.timeout_s
@@ -588,10 +598,33 @@ max_tool_calls_per_panel = 17
   match Fusion_config.of_toml (parse s) with
   | Error es ->
     Alcotest.(check bool) "Invalid_max_tool_calls present" true
+	      (List.exists
+	         (function Fusion_config.Invalid_max_tool_calls _ -> true | _ -> false)
+	         es)
+	  | Ok _ -> Alcotest.fail "expected Error Invalid_max_tool_calls"
+
+let test_config_invalid_max_output_tokens () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p1"
+[fusion.presets.p1]
+panel = ["a", "b"]
+judge = "a"
+panel_system_prompt = "p"
+judge_system_prompt = "j"
+max_output_tokens_per_panel = 0
+judge_max_output_tokens = -1
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    Alcotest.(check bool) "Invalid_max_output_tokens present" true
       (List.exists
-         (function Fusion_config.Invalid_max_tool_calls _ -> true | _ -> false)
+         (function Fusion_config.Invalid_max_output_tokens _ -> true | _ -> false)
          es)
-  | Ok _ -> Alcotest.fail "expected Error Invalid_max_tool_calls"
+  | Ok _ -> Alcotest.fail "expected Error Invalid_max_output_tokens"
 
 (* enabled인데 default_preset 생략(="") → preset 생략 호출이 폭빽할 default가 없어
    항상 Preset_unknown ""로 deny. 빈 default_preset도 로드 거부. *)
@@ -671,6 +704,7 @@ let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthe
   ; judge
   ; judge_system_prompt = judge_prompt
   ; judge_timeout_s = 300.0
+  ; judge_max_output_tokens = None
   ; judges
   ; min_answered
   }
@@ -718,6 +752,12 @@ let test_validated_bad_max_tool_calls () =
     Alcotest.(check int) "over-ceiling value reported" 17 v
   | _ -> Alcotest.fail "expected Bad_max_tool_calls over ceiling"
 
+let test_validated_bad_max_output_tokens () =
+  let bad = { base_group with Fusion_policy.max_output_tokens = Some 0 } in
+  match Fusion_policy.Validated_preset.of_preset (mk_preset ~panels:[ bad ] "mot") with
+  | Error (Fusion_policy.Validated_preset.Bad_max_output_tokens 0) -> ()
+  | _ -> Alcotest.fail "expected Bad_max_output_tokens 0"
+
 (* --- JOJ 1차 심판 목록 검증 (RFC-0283) --- *)
 
 let base_judge : Fusion_policy.judge_spec =
@@ -726,6 +766,7 @@ let base_judge : Fusion_policy.judge_spec =
   ; jsystem_prompt = "lens"
   ; jweb_tools = false
   ; jmax_tool_calls = 0
+  ; jmax_output_tokens = None
   ; jtimeout_s = 300.0
   }
 
@@ -771,6 +812,12 @@ let test_validated_judge_bad_max_tool_calls () =
   match Fusion_policy.Validated_preset.of_preset (mk_preset ~judges:[ over ] "jmtc") with
   | Error (Fusion_policy.Validated_preset.Bad_max_tool_calls 17) -> ()
   | _ -> Alcotest.fail "expected Bad_max_tool_calls 17 for over-ceiling judge"
+
+let test_validated_judge_bad_max_output_tokens () =
+  let bad = { base_judge with Fusion_policy.jmax_output_tokens = Some (-1) } in
+  match Fusion_policy.Validated_preset.of_preset (mk_preset ~judges:[ bad ] "jmot") with
+  | Error (Fusion_policy.Validated_preset.Bad_max_output_tokens (-1)) -> ()
+  | _ -> Alcotest.fail "expected Bad_max_output_tokens -1 for judge"
 
 let judge_named model = { base_judge with Fusion_policy.jmodel = model }
 
@@ -832,6 +879,7 @@ label = "strict"
 system_prompt = "lens A"
 web_tools = true
 max_tool_calls = 3
+max_output_tokens = 1536
 timeout_s = 222.0
 [[fusion.presets.joj.judges]]
 model = "judge-b"
@@ -852,12 +900,16 @@ let test_config_judges_parse () =
           Alcotest.(check string) "ja prompt" "lens A" ja.Fusion_policy.jsystem_prompt;
           Alcotest.(check bool) "ja web" true ja.Fusion_policy.jweb_tools;
           Alcotest.(check int) "ja tool budget" 3 ja.Fusion_policy.jmax_tool_calls;
+          Alcotest.(check (option int)) "ja max output" (Some 1536)
+            ja.Fusion_policy.jmax_output_tokens;
           Alcotest.(check (float 0.001)) "ja timeout" 222.0 ja.Fusion_policy.jtimeout_s;
           (* judge-b: 누락 키는 find_or default 경로 (web=false / budget=0 / timeout=default). *)
           Alcotest.(check string) "jb model" "judge-b" jb.Fusion_policy.jmodel;
           Alcotest.(check string) "jb prompt" "lens B" jb.Fusion_policy.jsystem_prompt;
           Alcotest.(check bool) "jb web default" false jb.Fusion_policy.jweb_tools;
           Alcotest.(check int) "jb budget default" 0 jb.Fusion_policy.jmax_tool_calls;
+          Alcotest.(check (option int)) "jb max output default" None
+            jb.Fusion_policy.jmax_output_tokens;
           Alcotest.(check (float 0.001)) "jb timeout default"
             Fusion_policy.default_timeout_s jb.Fusion_policy.jtimeout_s
         | _ -> Alcotest.fail "expected exactly two parsed judges")
@@ -889,6 +941,7 @@ let g_web4 : Fusion_policy.panel_group =
   ; system_prompt = "p"
   ; web_tools = true
   ; max_tool_calls = 4
+  ; max_output_tokens = None
   ; timeout_s = 123.0
   }
 
@@ -1266,11 +1319,13 @@ let () =
         ; Alcotest.test_case "bad_concurrency" `Quick test_config_bad_concurrency
         ; Alcotest.test_case "bad_judge_concurrency" `Quick
             test_config_bad_judge_concurrency
-        ; Alcotest.test_case "bad_staged_judge_group_size" `Quick
-            test_config_bad_staged_judge_group_size
-        ; Alcotest.test_case "invalid_max_tool_calls" `Quick
-            test_config_invalid_max_tool_calls
-        ; Alcotest.test_case "empty_default_preset" `Quick test_config_empty_default_preset
+	        ; Alcotest.test_case "bad_staged_judge_group_size" `Quick
+	            test_config_bad_staged_judge_group_size
+	        ; Alcotest.test_case "invalid_max_tool_calls" `Quick
+	            test_config_invalid_max_tool_calls
+	        ; Alcotest.test_case "invalid_max_output_tokens" `Quick
+	            test_config_invalid_max_output_tokens
+	        ; Alcotest.test_case "empty_default_preset" `Quick test_config_empty_default_preset
         ; Alcotest.test_case "disabled_with_preset" `Quick test_config_disabled_with_preset
         ; Alcotest.test_case "judges_parse" `Quick test_config_judges_parse
         ; Alcotest.test_case "no_judges" `Quick test_config_no_judges
@@ -1278,17 +1333,21 @@ let () =
     ; ( "validated_preset"
       , [ Alcotest.test_case "ok" `Quick test_validated_ok
         ; Alcotest.test_case "bad_size" `Quick test_validated_bad_size
-        ; Alcotest.test_case "missing_prompt" `Quick test_validated_missing_prompt
-        ; Alcotest.test_case "missing_judge" `Quick test_validated_missing_judge
-        ; Alcotest.test_case "duplicate_panelist" `Quick test_validated_duplicate_panelist
-        ; Alcotest.test_case "bad_max_tool_calls" `Quick test_validated_bad_max_tool_calls
+	        ; Alcotest.test_case "missing_prompt" `Quick test_validated_missing_prompt
+	        ; Alcotest.test_case "missing_judge" `Quick test_validated_missing_judge
+	        ; Alcotest.test_case "duplicate_panelist" `Quick test_validated_duplicate_panelist
+	        ; Alcotest.test_case "bad_max_tool_calls" `Quick test_validated_bad_max_tool_calls
+	        ; Alcotest.test_case "bad_max_output_tokens" `Quick
+	            test_validated_bad_max_output_tokens
         ; Alcotest.test_case "judges_empty_ok" `Quick test_validated_judges_empty_ok
         ; Alcotest.test_case "judges_ok" `Quick test_validated_judges_ok
         ; Alcotest.test_case "judge_prompt_missing" `Quick test_validated_judge_prompt_missing
-        ; Alcotest.test_case "duplicate_judge" `Quick test_validated_duplicate_judge
-        ; Alcotest.test_case "judge_bad_max_tool_calls" `Quick
-            test_validated_judge_bad_max_tool_calls
-        ] )
+	        ; Alcotest.test_case "duplicate_judge" `Quick test_validated_duplicate_judge
+	        ; Alcotest.test_case "judge_bad_max_tool_calls" `Quick
+	            test_validated_judge_bad_max_tool_calls
+	        ; Alcotest.test_case "judge_bad_max_output_tokens" `Quick
+	            test_validated_judge_bad_max_output_tokens
+	        ] )
     ; ( "staged_judge_groups"
       , [ Alcotest.test_case "exact_3x3" `Quick test_staged_judge_groups_exact_3x3
         ; Alcotest.test_case "too_few" `Quick test_staged_judge_groups_too_few

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -114,7 +114,7 @@ let test_empty_response_detail_summarizes_shape () =
     (String_util.string_contains_substring ~needle:"secret chain" detail)
 ;;
 
-let test_empty_response_detail_escapes_unknown_stop_reason () =
+let test_empty_response_detail_uses_canonical_unknown_stop_reason () =
   let response : Agent_sdk.Types.api_response =
     { id = "r"
     ; model = "m"
@@ -125,9 +125,8 @@ let test_empty_response_detail_escapes_unknown_stop_reason () =
     }
   in
   let detail = Fusion_oas.For_testing.empty_response_detail response in
-  Alcotest.(check bool) "unknown stop reason escaped" true
-    (String_util.string_contains_substring ~needle:"stop_reason=unknown:line\\nquote\\\""
-       detail);
+  Alcotest.(check bool) "unknown stop reason uses canonical label" true
+    (String_util.string_contains_substring ~needle:"stop_reason=unknown" detail);
   Alcotest.(check bool) "raw newline not embedded" false
     (String_util.string_contains_substring ~needle:"line\nquote" detail)
 ;;
@@ -191,9 +190,9 @@ let () =
             `Quick
             test_empty_response_detail_summarizes_shape
         ; Alcotest.test_case
-            "empty response detail escapes unknown stop reason"
+            "empty response detail uses canonical unknown stop reason"
             `Quick
-            test_empty_response_detail_escapes_unknown_stop_reason
+            test_empty_response_detail_uses_canonical_unknown_stop_reason
         ; Alcotest.test_case
             "panel failure yojson accepts legacy empty response"
             `Quick

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -108,6 +108,10 @@ let test_empty_response_detail_summarizes_shape () =
     (String_util.string_contains_substring ~needle:"stop_reason=max_tokens" detail);
   Alcotest.(check bool) "thinking block counted" true
     (String_util.string_contains_substring ~needle:"thinking_blocks=1" detail);
+  Alcotest.(check bool) "thinking kind summarized" true
+    (String_util.string_contains_substring ~needle:"thinking_kind=thinking" detail);
+  Alcotest.(check bool) "thinking chars summarized" true
+    (String_util.string_contains_substring ~needle:"thinking_chars=12" detail);
   Alcotest.(check bool) "output tokens included" true
     (String_util.string_contains_substring ~needle:"output_tokens=32" detail);
   Alcotest.(check bool) "reasoning body not leaked" false

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -1,5 +1,15 @@
 open Masc
 
+let contains ~needle haystack =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop i =
+    i + needle_len <= haystack_len
+    && (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
+  in
+  String.equal needle "" || loop 0
+;;
+
 let provider_cfg () =
   Llm_provider.Provider_config.make
     ~kind:Llm_provider.Provider_config.Anthropic
@@ -80,8 +90,38 @@ let test_panel_failure_text_no_reattribution () =
     (Fusion_oas.panel_failure_text Fusion_types.Timeout);
   Alcotest.(check string)
     "empty response"
-    "empty response"
-    (Fusion_oas.panel_failure_text Fusion_types.Empty_response)
+    "empty response (stop_reason=max_tokens)"
+    (Fusion_oas.panel_failure_text
+       (Fusion_types.Empty_response "empty response (stop_reason=max_tokens)"))
+;;
+
+let test_empty_response_detail_summarizes_shape () =
+  let response : Agent_sdk.Types.api_response =
+    { id = "r"
+    ; model = "m"
+    ; stop_reason = Agent_sdk.Types.MaxTokens
+    ; content =
+        [ Agent_sdk.Types.Thinking { thinking_type = "reasoning"; content = "secret chain" } ]
+    ; usage =
+        Some
+          { input_tokens = 21
+          ; output_tokens = 32
+          ; cache_creation_input_tokens = 0
+          ; cache_read_input_tokens = 0
+          ; cost_usd = None
+          }
+    ; telemetry = None
+    }
+  in
+  let detail = Fusion_oas.For_testing.empty_response_detail response in
+  Alcotest.(check bool) "stop reason included" true
+    (contains ~needle:"stop_reason=max_tokens" detail);
+  Alcotest.(check bool) "thinking block counted" true
+    (contains ~needle:"thinking_blocks=1" detail);
+  Alcotest.(check bool) "output tokens included" true
+    (contains ~needle:"output_tokens=32" detail);
+  Alcotest.(check bool) "reasoning body not leaked" false
+    (contains ~needle:"secret chain" detail)
 ;;
 
 let test_timeout_budget_does_not_set_total_execution_ceiling () =
@@ -128,6 +168,10 @@ let () =
             "panel failure text does not re-attribute"
             `Quick
             test_panel_failure_text_no_reattribution
+        ; Alcotest.test_case
+            "empty response detail summarizes shape"
+            `Quick
+            test_empty_response_detail_summarizes_shape
         ; Alcotest.test_case
             "timeout budget does not arm OAS total execution ceiling"
             `Quick

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -1,15 +1,5 @@
 open Masc
 
-let contains ~needle haystack =
-  let needle_len = String.length needle in
-  let haystack_len = String.length haystack in
-  let rec loop i =
-    i + needle_len <= haystack_len
-    && (String.equal (String.sub haystack i needle_len) needle || loop (i + 1))
-  in
-  String.equal needle "" || loop 0
-;;
-
 let provider_cfg () =
   Llm_provider.Provider_config.make
     ~kind:Llm_provider.Provider_config.Anthropic
@@ -115,13 +105,41 @@ let test_empty_response_detail_summarizes_shape () =
   in
   let detail = Fusion_oas.For_testing.empty_response_detail response in
   Alcotest.(check bool) "stop reason included" true
-    (contains ~needle:"stop_reason=max_tokens" detail);
+    (String_util.string_contains_substring ~needle:"stop_reason=max_tokens" detail);
   Alcotest.(check bool) "thinking block counted" true
-    (contains ~needle:"thinking_blocks=1" detail);
+    (String_util.string_contains_substring ~needle:"thinking_blocks=1" detail);
   Alcotest.(check bool) "output tokens included" true
-    (contains ~needle:"output_tokens=32" detail);
+    (String_util.string_contains_substring ~needle:"output_tokens=32" detail);
   Alcotest.(check bool) "reasoning body not leaked" false
-    (contains ~needle:"secret chain" detail)
+    (String_util.string_contains_substring ~needle:"secret chain" detail)
+;;
+
+let test_empty_response_detail_escapes_unknown_stop_reason () =
+  let response : Agent_sdk.Types.api_response =
+    { id = "r"
+    ; model = "m"
+    ; stop_reason = Agent_sdk.Types.Unknown "line\nquote\""
+    ; content = []
+    ; usage = None
+    ; telemetry = None
+    }
+  in
+  let detail = Fusion_oas.For_testing.empty_response_detail response in
+  Alcotest.(check bool) "unknown stop reason escaped" true
+    (String_util.string_contains_substring ~needle:"stop_reason=unknown:line\\nquote\\\""
+       detail);
+  Alcotest.(check bool) "raw newline not embedded" false
+    (String_util.string_contains_substring ~needle:"line\nquote" detail)
+;;
+
+let test_panel_failure_yojson_accepts_legacy_empty_response () =
+  match Fusion_types.panel_failure_of_yojson (`String "Empty_response") with
+  | Ok (Fusion_types.Empty_response detail) ->
+    Alcotest.(check string) "legacy detail" "empty response" detail
+  | Ok other ->
+    Alcotest.failf "unexpected panel failure: %s"
+      (Fusion_types.show_panel_failure other)
+  | Error err -> Alcotest.fail err
 ;;
 
 let test_timeout_budget_does_not_set_total_execution_ceiling () =
@@ -172,6 +190,14 @@ let () =
             "empty response detail summarizes shape"
             `Quick
             test_empty_response_detail_summarizes_shape
+        ; Alcotest.test_case
+            "empty response detail escapes unknown stop reason"
+            `Quick
+            test_empty_response_detail_escapes_unknown_stop_reason
+        ; Alcotest.test_case
+            "panel failure yojson accepts legacy empty response"
+            `Quick
+            test_panel_failure_yojson_accepts_legacy_empty_response
         ; Alcotest.test_case
             "timeout budget does not arm OAS total execution ceiling"
             `Quick


### PR DESCRIPTION
## Summary

Fixes Fusion handling for reasoning-heavy runtimes that can spend their output budget on thinking/reasoning chunks before producing any text.

- Adds optional Fusion output-token budget knobs:
  - `max_output_tokens_per_panel`
  - `judge_max_output_tokens`
  - `[[fusion.presets.<name>.judges]].max_output_tokens`
- Preserves Runtime_agent defaults when these knobs are omitted, and rejects non-positive overrides at config load / validated policy boundaries.
- Replaces opaque `empty_response` panel failures with diagnostics that include stop reason, content-block counts, and token usage without leaking thinking/reasoning text.
- Applies the budget through panel, single/refine/meta judge, JOJ, and staged-JOJ paths.
- Keeps legacy `"Empty_response"` JSON deserialization compatible while writing the new detail-carrying form.
- Updates Fusion dashboard meta normalization, config docs, and RFC notes.

## Root Cause

Fusion correctly accepts only `Text` content blocks as panel/judge answers, but it collapsed no-text output into a bare `empty_response`. Reasoning-heavy OpenAI-compatible runtimes can return thinking/reasoning blocks and no `Text` when the output budget is exhausted, so operators could neither tune Fusion's per-call output budget nor see whether an empty answer was caused by `max_tokens` or by another provider stop condition.

## Validation

Local/focused checks on this PR branch:

- `scripts/dune-local.sh build @test/fusion_core/runtest test/test_fusion_oas_error_detail.exe test/test_masc_oas_bridge_cancel_boundary.exe`
- `git diff --check`
- `ocamlformat --check test/fusion_core/test_fusion.ml`
- `bash scripts/check-doc-truth.sh`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/lib/fusion-meta.test.ts`
- `pnpm --dir dashboard typecheck`

GitHub checks passing on head `bd4980a4336659f2e39ef2e184a809cf84b383d7`:

- Dashboard
- Lint
- Health
- Meta Guards
- TLA+ Model Checking
- ocamlformat-check
- OCaml Structure Ratchet
- Shell IR Consumption Ratchet
- all fundamental/advisory ratchets shown in the PR check rollup

## CI Status

The PR is still draft. GitHub CI is blocked only by the repo-wide Build and Test quick-suite failure tracked in #22452, not by the Fusion-focused changes. Latest PR #22438 evidence from run `28281255843` / job `83797407916` is attached here: https://github.com/jeong-sik/masc/issues/22452#issuecomment-4815804109
