### PR TITLE
fix(keeper): surface empty accept rejection and resume no-progress loops

### DIFF
--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -39,19 +39,25 @@ let get_bus () = Keeper_event_bus.get ()
 
 (* ── gRPC directive processing ── *)
 
-let with_keeper_entry_by_identity ~identity ~on_missing f =
+let keeper_entry_by_identity_opt identity =
   match Keeper_registry_lookup.find_by_agent_name identity with
-  | Some entry -> f entry
+  | Some entry -> Some entry
   | None ->
     (match Keeper_registry_lookup.find_by_name identity with
-     | Some entry -> f entry
+     | Some entry -> Some entry
      | None ->
        (match Keeper_identity.canonical_keeper_name_from_agent_name identity with
         | Some keeper_name ->
           (match Keeper_registry_lookup.find_by_name keeper_name with
-           | Some entry -> f entry
-           | None -> on_missing ())
-        | None -> on_missing ()))
+           | Some entry -> Some entry
+           | None -> None)
+        | None -> None))
+;;
+
+let with_keeper_entry_by_identity ~identity ~on_missing f =
+  match keeper_entry_by_identity_opt identity with
+  | Some entry -> f entry
+  | None -> on_missing ()
 ;;
 
 let persist_directive_meta_update
@@ -265,7 +271,7 @@ let process_directive ~agent_name directive =
        guard fires.  In both cases a wakeup should start from a fresh counter
        instead of immediately re-blocking the same turn. *)
     let entry_paused =
-      match Keeper_registry_lookup.find_by_agent_name agent_name with
+      match keeper_entry_by_identity_opt agent_name with
       | Some e -> e.meta.paused
       | None ->
         (match Keeper_tool_shared_runtime.find_registry_meta
@@ -275,12 +281,12 @@ let process_directive ~agent_name directive =
          | Some meta -> meta.paused
          | None -> false)
     in
-    (match Keeper_registry_lookup.find_by_agent_name agent_name with
+    (match keeper_entry_by_identity_opt agent_name with
      | Some e ->
        Keeper_turn_livelock.reset_keeper_livelock
          ~base_path:e.base_path
-         ~keeper:agent_name;
-       let _updated_meta = clear_no_progress_loop_for_operator_resume e in
+         ~keeper:e.name;
+       let (_ : keeper_meta) = clear_no_progress_loop_for_operator_resume e in
        ()
      | None -> ());
     if entry_paused

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -119,6 +119,17 @@ let directive_paused_meta (meta : keeper_meta) paused =
   }
 ;;
 
+let clear_no_progress_loop_for_operator_resume (entry : Keeper_registry.registry_entry) =
+  let updated_meta =
+    Keeper_unified_turn_no_progress.clear_for_operator_resume
+      ~base_path:entry.base_path
+      entry.meta
+  in
+  if not (updated_meta == entry.meta) then
+    persist_directive_meta_update entry ~updated_meta;
+  updated_meta
+;;
+
 let log_directive_agent_not_in_registry ~agent_name ~action =
   let known_keeper () =
     match Keeper_tool_shared_runtime.find_registry_meta ~keeper_name:agent_name ~source_layer:"directive" with
@@ -163,7 +174,10 @@ let set_keeper_paused_state ~agent_name paused =
         ();
       log_directive_agent_not_in_registry ~agent_name ~action)
     (fun entry ->
-       let updated_meta = directive_paused_meta entry.meta paused in
+       let directive_source_meta =
+         if paused then entry.meta else clear_no_progress_loop_for_operator_resume entry
+       in
+       let updated_meta = directive_paused_meta directive_source_meta paused in
        persist_directive_meta_update entry ~updated_meta;
        Keeper_registry.dispatch_event_unit
          ~base_path:entry.base_path
@@ -265,7 +279,9 @@ let process_directive ~agent_name directive =
      | Some e ->
        Keeper_turn_livelock.reset_keeper_livelock
          ~base_path:e.base_path
-         ~keeper:agent_name
+         ~keeper:agent_name;
+       let _updated_meta = clear_no_progress_loop_for_operator_resume e in
+       ()
      | None -> ());
     if entry_paused
     then (

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -186,19 +186,21 @@ let runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
     latest_receipt =
   match assoc_string_opt "runtime_blocker_class" runtime_blocker_fields with
   | None -> false
-  | Some "completion_contract_violation"
-    when Option.is_some
-           (Option.bind latest_receipt receipt_contract_attention_reason) ->
-      true
-  | Some _ -> (
+  | Some raw_blocker_class -> (
+    match Keeper_meta_contract.blocker_class_of_serialized_string raw_blocker_class with
+    | Some Keeper_meta_contract.Completion_contract_violation
+      when Option.is_some
+             (Option.bind latest_receipt receipt_contract_attention_reason) ->
+        true
+    | _ -> (
       match latest_receipt with
       | None -> true
       | Some receipt -> (
           match receipt_ended_at_unix receipt with
           | Some receipt_ts ->
-              meta.runtime.usage.last_turn_ts
-              > receipt_ts +. runtime_blocker_receipt_timestamp_epsilon_sec
-          | None -> meta.runtime.usage.last_turn_ts > 0.0))
+            meta.runtime.usage.last_turn_ts
+            > receipt_ts +. runtime_blocker_receipt_timestamp_epsilon_sec
+          | None -> meta.runtime.usage.last_turn_ts > 0.0)))
 
 let current_receipt_for_runtime_state ~meta ~runtime_blocker_fields
     latest_receipt =

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -186,6 +186,10 @@ let runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
     latest_receipt =
   match assoc_string_opt "runtime_blocker_class" runtime_blocker_fields with
   | None -> false
+  | Some "completion_contract_violation"
+    when Option.is_some
+           (Option.bind latest_receipt receipt_contract_attention_reason) ->
+      true
   | Some _ -> (
       match latest_receipt with
       | None -> true

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -38,7 +38,7 @@ let blocker_class_of_sdk_error (err : Agent_sdk.Error.sdk_error) : blocker_class
   | Some (Keeper_turn_driver.Runtime_exhausted { reason; _ }) ->
     Some (Runtime_exhausted (blocker_reason_of_turn_driver_reason reason))
   | Some (Keeper_turn_driver.Resumable_cli_session _) -> None
-  | Some (Keeper_turn_driver.Accept_rejected _) -> None
+  | Some (Keeper_turn_driver.Accept_rejected _) -> Some Completion_contract_violation
   | Some (Keeper_turn_driver.Admission_queue_timeout _) ->
     Some Admission_queue_wait_timeout
   | Some (Keeper_turn_driver.Admission_queue_rejected _) -> None

--- a/lib/keeper/keeper_unified_metrics_failure.ml
+++ b/lib/keeper/keeper_unified_metrics_failure.ml
@@ -83,7 +83,11 @@ let update_metrics_from_failure (meta : keeper_meta) ~(latency_ms : int)
             match Keeper_turn_driver.summary_of_masc_internal_error err with
             | Some summary -> summary
             | None -> reason)
-        | _ -> reason)
+        | Some err ->
+            Option.value
+              ~default:reason
+              (Keeper_turn_driver.summary_of_masc_internal_error err)
+        | None -> reason)
     | None -> reason
   in
   let failure_counts_for_proactive_backoff =

--- a/lib/keeper/keeper_unified_turn_no_progress.ml
+++ b/lib/keeper/keeper_unified_turn_no_progress.ml
@@ -1,5 +1,7 @@
 (** No-progress loop recovery helpers for the unified keeper turn. *)
 
+let failure_reason_code = "no_progress_loop"
+
 (* RFC-0020: the no-progress recovery stimulus carries no data — the consumer
    only branches on the kind. streak/threshold are recorded in the failure
    reason / blocker detail by the caller, not in the stimulus payload. *)
@@ -20,7 +22,7 @@ let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
   in
   let failure_reason =
     Keeper_registry.Provider_runtime_error
-      { code = "no_progress_loop"
+      { code = failure_reason_code
       ; detail
       ; provider_id = None
       ; http_status = None
@@ -103,7 +105,7 @@ let clear_if_recovered ~(config : Workspace.config) meta ~previous_streak ~was_l
                Some (Keeper_registry.Provider_runtime_error { code; _ })
            ; _
            }
-      when String.equal code "no_progress_loop" ->
+      when String.equal code failure_reason_code ->
       Keeper_registry.set_failure_reason
         ~base_path:config.base_path
         meta.name
@@ -131,7 +133,7 @@ let clear_for_operator_resume ~base_path meta =
                Some (Keeper_registry.Provider_runtime_error { code; _ })
            ; _
            }
-      when String.equal code "no_progress_loop" ->
+      when String.equal code failure_reason_code ->
       Keeper_registry.set_failure_reason ~base_path keeper_name None;
       true
     | _ -> false

--- a/lib/keeper/keeper_unified_turn_no_progress.ml
+++ b/lib/keeper/keeper_unified_turn_no_progress.ml
@@ -14,7 +14,7 @@ let recovery_stimulus ~now ~keeper_name =
 let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
   let detail =
     Printf.sprintf
-      "no_progress loop detected: streak=%d threshold=%d; manual pause applied"
+      "no_progress loop detected: streak=%d threshold=%d; keeper paused until operator resume clears the no-progress latch"
       streak
       threshold
   in
@@ -119,4 +119,37 @@ let clear_if_recovered ~(config : Workspace.config) meta ~previous_streak ~was_l
   | Some { Keeper_meta_contract.klass = Keeper_meta_contract.No_progress_loop; _ } ->
     Keeper_meta_contract.map_runtime (fun rt -> { rt with last_blocker = None }) meta
   | _ -> meta
+;;
+
+let clear_for_operator_resume ~base_path meta =
+  let keeper_name = meta.Keeper_meta_contract.name in
+  let was_latched = Keeper_no_progress_loop_detector.is_latched ~keeper_name in
+  Keeper_no_progress_loop_detector.reset ~keeper_name;
+  let cleared_failure_reason =
+    match Keeper_registry.get ~base_path keeper_name with
+    | Some { Keeper_registry.last_failure_reason =
+               Some (Keeper_registry.Provider_runtime_error { code; _ })
+           ; _
+           }
+      when String.equal code "no_progress_loop" ->
+      Keeper_registry.set_failure_reason ~base_path keeper_name None;
+      true
+    | _ -> false
+  in
+  let cleared_meta_blocker =
+    match meta.runtime.last_blocker with
+    | Some { Keeper_meta_contract.klass = Keeper_meta_contract.No_progress_loop; _ } ->
+      true
+    | _ -> false
+  in
+  if was_latched || cleared_failure_reason || cleared_meta_blocker then
+    Log.Keeper.info
+      "%s: operator resume cleared no_progress loop latch/blocker (latched=%b failure_reason=%b meta_blocker=%b)"
+      keeper_name
+      was_latched
+      cleared_failure_reason
+      cleared_meta_blocker;
+  if cleared_meta_blocker then
+    Keeper_meta_contract.map_runtime (fun rt -> { rt with last_blocker = None }) meta
+  else meta
 ;;

--- a/lib/keeper/keeper_unified_turn_no_progress.mli
+++ b/lib/keeper/keeper_unified_turn_no_progress.mli
@@ -13,3 +13,8 @@ val clear_if_recovered
   -> previous_streak:int
   -> was_latched:bool
   -> Keeper_meta_contract.keeper_meta
+
+val clear_for_operator_resume
+  :  base_path:string
+  -> Keeper_meta_contract.keeper_meta
+  -> Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_unified_turn_no_progress.mli
+++ b/lib/keeper/keeper_unified_turn_no_progress.mli
@@ -1,5 +1,7 @@
 (** No-progress loop recovery helpers for the unified keeper turn. *)
 
+val failure_reason_code : string
+
 val mark_loop_detected
   :  config:Workspace.config
   -> Keeper_meta_contract.keeper_meta

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -504,6 +504,22 @@ let summarize_list ?(empty = "none") values =
   | [] -> empty
   | _ -> String.concat ", " values
 
+let short_accept_rejection_reason reason =
+  String_util.utf8_safe ~max_bytes:180 ~suffix:"..." (String.trim reason)
+  |> String_util.to_string
+
+let nonempty_or_unknown value =
+  let value = String.trim value in
+  if String.equal value "" then "unknown" else value
+
+let accept_rejection_kind_display = function
+  | Some kind -> accept_rejection_kind_to_string kind
+  | None -> "unknown"
+
+let accept_response_shape_display = function
+  | Some shape -> accept_response_shape_to_string shape
+  | None -> "unknown"
+
 let summary_of_masc_internal_error = function
   | Capacity_backpressure { runtime_id; source; detail; retry_after } ->
       let retry_after_suffix =
@@ -549,9 +565,62 @@ let summary_of_masc_internal_error = function
          requested_max_tokens
          provider_ceiling
          reason)
+  | Accept_rejected
+      {
+        scope;
+        reason_kind = Some Accept_no_usable_progress;
+        response_shape = Some Accept_response_empty;
+        last_tool_effect = None;
+        any_mutating_tool = None;
+        tool_effects_seen = [];
+        _;
+      } ->
+    Some
+      (Printf.sprintf
+         "Provider returned an empty assistant turn for runtime %s; no text or tool progress was produced."
+         (nonempty_or_unknown scope))
+  | Accept_rejected
+      {
+        scope;
+        reason_kind = Some Accept_no_usable_progress;
+        response_shape = Some Accept_response_thinking_only;
+        last_tool_effect = Some Tool_effect_read_only;
+        any_mutating_tool = Some false;
+        tool_effects_seen;
+        _;
+      }
+    when tool_effects_seen <> [] ->
+    Some
+      (Printf.sprintf
+         "Provider produced only read-only tool activity for runtime %s; no mutating keeper progress was accepted."
+         (nonempty_or_unknown scope))
+  | Accept_rejected
+      {
+        scope;
+        reason_kind = Some Accept_predicate_rejected;
+        response_shape;
+        reason;
+        _;
+      } ->
+    let shape = accept_response_shape_display response_shape in
+    Some
+      (Printf.sprintf
+         "Provider response for runtime %s was rejected by the accept predicate; response_shape=%s; reason=%s"
+         (nonempty_or_unknown scope)
+         shape
+         (short_accept_rejection_reason reason))
+  | Accept_rejected { scope; reason_kind; response_shape; reason; _ } ->
+    let reason_kind = accept_rejection_kind_display reason_kind in
+    let response_shape = accept_response_shape_display response_shape in
+    Some
+      (Printf.sprintf
+         "Provider response for runtime %s was rejected by the keeper accept contract; reason_kind=%s; response_shape=%s; reason=%s"
+         (nonempty_or_unknown scope)
+         reason_kind
+         response_shape
+         (short_accept_rejection_reason reason))
   | Runtime_exhausted _
   | Resumable_cli_session _
-  | Accept_rejected _
   | Admission_queue_timeout _
   | Admission_queue_rejected _
   | Turn_timeout _
@@ -584,7 +653,8 @@ let runtime_id_of_masc_internal_error = function
       let runtime_id = runtime_id_to_string runtime_id in
       if String.equal (String.trim runtime_id) "" then "unknown"
       else runtime_id
-  | Accept_rejected _
+  | Accept_rejected { scope; _ } ->
+      nonempty_or_unknown scope
   | Admission_queue_rejected _
   | Turn_timeout _
   | Provider_timeout _

--- a/lib/keeper_runtime/keeper_internal_error.ml
+++ b/lib/keeper_runtime/keeper_internal_error.ml
@@ -504,8 +504,15 @@ let summarize_list ?(empty = "none") values =
   | [] -> empty
   | _ -> String.concat ", " values
 
+let accept_rejection_summary_max_bytes = 180
+
 let short_accept_rejection_reason reason =
-  String_util.utf8_safe ~max_bytes:180 ~suffix:"..." (String.trim reason)
+  (* Keep accept-rejection summaries below the 200-byte narrative blocker cap
+     so the full summary fits when it is embedded in blocker detail. *)
+  String_util.utf8_safe
+    ~max_bytes:accept_rejection_summary_max_bytes
+    ~suffix:"..."
+    (String.trim reason)
   |> String_util.to_string
 
 let nonempty_or_unknown value =
@@ -519,6 +526,30 @@ let accept_rejection_kind_display = function
 let accept_response_shape_display = function
   | Some shape -> accept_response_shape_to_string shape
   | None -> "unknown"
+
+let accept_rejection_is_empty_no_progress
+    ~reason_kind
+    ~response_shape
+    ~last_tool_effect
+    ~any_mutating_tool
+    ~tool_effects_seen =
+  reason_kind = Some Accept_no_usable_progress
+  && response_shape = Some Accept_response_empty
+  && Option.is_none last_tool_effect
+  && Option.is_none any_mutating_tool
+  && tool_effects_seen = []
+
+let accept_rejection_is_read_only_no_progress
+    ~reason_kind
+    ~response_shape
+    ~last_tool_effect
+    ~any_mutating_tool
+    ~tool_effects_seen =
+  reason_kind = Some Accept_no_usable_progress
+  && response_shape = Some Accept_response_thinking_only
+  && last_tool_effect = Some Tool_effect_read_only
+  && any_mutating_tool = Some false
+  && tool_effects_seen <> []
 
 let summary_of_masc_internal_error = function
   | Capacity_backpressure { runtime_id; source; detail; retry_after } ->
@@ -568,13 +599,19 @@ let summary_of_masc_internal_error = function
   | Accept_rejected
       {
         scope;
-        reason_kind = Some Accept_no_usable_progress;
-        response_shape = Some Accept_response_empty;
-        last_tool_effect = None;
-        any_mutating_tool = None;
+        reason_kind;
+        response_shape;
+        last_tool_effect;
+        any_mutating_tool;
         tool_effects_seen = [];
         _;
-      } ->
+      }
+    when accept_rejection_is_empty_no_progress
+           ~reason_kind
+           ~response_shape
+           ~last_tool_effect
+           ~any_mutating_tool
+           ~tool_effects_seen:[] ->
     Some
       (Printf.sprintf
          "Provider returned an empty assistant turn for runtime %s; no text or tool progress was produced."
@@ -582,14 +619,19 @@ let summary_of_masc_internal_error = function
   | Accept_rejected
       {
         scope;
-        reason_kind = Some Accept_no_usable_progress;
-        response_shape = Some Accept_response_thinking_only;
-        last_tool_effect = Some Tool_effect_read_only;
-        any_mutating_tool = Some false;
+        reason_kind;
+        response_shape;
+        last_tool_effect;
+        any_mutating_tool;
         tool_effects_seen;
         _;
       }
-    when tool_effects_seen <> [] ->
+    when accept_rejection_is_read_only_no_progress
+           ~reason_kind
+           ~response_shape
+           ~last_tool_effect
+           ~any_mutating_tool
+           ~tool_effects_seen ->
     Some
       (Printf.sprintf
          "Provider produced only read-only tool activity for runtime %s; no mutating keeper progress was accepted."
@@ -666,24 +708,36 @@ let runtime_id_of_masc_internal_error = function
 let accept_no_progress_retry_kind = function
   | Accept_rejected
       {
-        reason_kind = Some Accept_no_usable_progress;
-        response_shape = Some Accept_response_empty;
-        last_tool_effect = None;
-        any_mutating_tool = None;
-        tool_effects_seen = [];
+        reason_kind;
+        response_shape;
+        last_tool_effect;
+        any_mutating_tool;
+        tool_effects_seen;
         _;
-      } ->
+      }
+    when accept_rejection_is_empty_no_progress
+           ~reason_kind
+           ~response_shape
+           ~last_tool_effect
+           ~any_mutating_tool
+           ~tool_effects_seen ->
     Some `Empty_no_progress
   | Accept_rejected
       {
-        reason_kind = Some Accept_no_usable_progress;
-        response_shape = Some Accept_response_thinking_only;
-        last_tool_effect = Some Tool_effect_read_only;
-        any_mutating_tool = Some false;
         tool_effects_seen;
+        reason_kind;
+        response_shape;
+        last_tool_effect;
+        any_mutating_tool;
         _;
-      } ->
-    if tool_effects_seen = [] then None else Some `Read_only_no_progress
+      }
+    when accept_rejection_is_read_only_no_progress
+           ~reason_kind
+           ~response_shape
+           ~last_tool_effect
+           ~any_mutating_tool
+           ~tool_effects_seen ->
+    Some `Read_only_no_progress
   | Accept_rejected _
   | Runtime_exhausted _
   | Capacity_backpressure _

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -173,7 +173,7 @@ let test_no_progress_loop_detection_pauses_keeper () =
           check
             string
             "blocker detail"
-            "no_progress loop detected: streak=10 threshold=10; manual pause applied"
+            "no_progress loop detected: streak=10 threshold=10; keeper paused until operator resume clears the no-progress latch"
             detail
         | Some _ -> fail "expected No_progress_loop blocker"
         | None -> fail "expected no_progress loop blocker");
@@ -182,7 +182,76 @@ let test_no_progress_loop_detection_pauses_keeper () =
          check bool "registry meta paused" true entry.Masc.Keeper_registry.meta.paused
        | None -> fail "expected registered keeper")
 
+let test_operator_resume_clears_no_progress_loop_latch () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-no-progress-resume-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_no_progress_loop_detector.reset_all_for_test ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "no-progress-resume" in
+       let blocker =
+         Keeper_meta_contract.blocker_info_of_class
+           ~detail:"latched"
+           Keeper_meta_contract.No_progress_loop
+       in
+       let meta =
+         make_meta keeper_name
+         |> Keeper_meta_contract.map_runtime (fun rt ->
+           { rt with last_blocker = Some blocker })
+       in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       ignore
+         (Masc.Keeper_no_progress_loop_detector.record_turn
+            ~threshold_override:1
+            ~keeper_name
+            ~made_progress:false
+            ());
+       Masc.Keeper_registry.set_failure_reason
+         ~base_path:config.base_path
+         keeper_name
+         (Some
+            (Masc.Keeper_registry.Provider_runtime_error
+               { code = "no_progress_loop"
+               ; detail = "latched"
+               ; provider_id = None
+               ; http_status = None
+               ; runtime_id = None
+               ; reason = None
+               }));
+       check bool
+         "detector latched before resume"
+         true
+         (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
+       let resumed_meta =
+         Masc.Keeper_unified_turn_no_progress.clear_for_operator_resume
+           ~base_path:config.base_path
+           meta
+       in
+       check bool
+         "detector reset by operator resume"
+         false
+         (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
+       (match resumed_meta.runtime.last_blocker with
+        | None -> ()
+        | Some _ -> fail "expected no_progress meta blocker to clear");
+       match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+         (match entry.Masc.Keeper_registry.last_failure_reason with
+          | None -> ()
+          | Some _ -> fail "expected no_progress failure reason to clear")
+       | None -> fail "expected registered keeper")
+
 let test_idle_detected_repeated_failure_pauses_keeper () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
   let base_path = temp_dir "masc-idle-detected-pause-" in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_path)
@@ -287,6 +356,8 @@ let () =
         [
           test_case "loop detection pauses keeper for manual resume" `Quick
             test_no_progress_loop_detection_pauses_keeper;
+          test_case "operator resume clears no-progress latch" `Quick
+            test_operator_resume_clears_no_progress_loop_latch;
         ] );
       ( "idle-detected loop",
         [

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -179,7 +179,16 @@ let test_no_progress_loop_detection_pauses_keeper () =
         | None -> fail "expected no_progress loop blocker");
        match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
        | Some entry ->
-         check bool "registry meta paused" true entry.Masc.Keeper_registry.meta.paused
+         check bool "registry meta paused" true entry.Masc.Keeper_registry.meta.paused;
+         (match entry.Masc.Keeper_registry.last_failure_reason with
+          | Some (Masc.Keeper_registry.Provider_runtime_error { code; _ }) ->
+            check
+              string
+              "registry no-progress failure code"
+              Masc.Keeper_unified_turn_no_progress.failure_reason_code
+              code
+          | Some _ -> fail "expected no_progress provider-runtime failure reason"
+          | None -> fail "expected no_progress failure reason")
        | None -> fail "expected registered keeper")
 
 let test_operator_resume_clears_no_progress_loop_latch () =
@@ -218,7 +227,7 @@ let test_operator_resume_clears_no_progress_loop_latch () =
          keeper_name
          (Some
             (Masc.Keeper_registry.Provider_runtime_error
-               { code = "no_progress_loop"
+               { code = Masc.Keeper_unified_turn_no_progress.failure_reason_code
                ; detail = "latched"
                ; provider_id = None
                ; http_status = None
@@ -246,6 +255,54 @@ let test_operator_resume_clears_no_progress_loop_latch () =
          (match entry.Masc.Keeper_registry.last_failure_reason with
           | None -> ()
           | Some _ -> fail "expected no_progress failure reason to clear")
+       | None -> fail "expected registered keeper")
+
+let test_wakeup_directive_persists_no_progress_meta_clear () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-no-progress-wakeup-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_no_progress_loop_detector.reset_all_for_test ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "no-progress-wakeup" in
+       let blocker =
+         Keeper_meta_contract.blocker_info_of_class
+           ~detail:"latched"
+           Keeper_meta_contract.No_progress_loop
+       in
+       let meta =
+         make_meta keeper_name
+         |> Keeper_meta_contract.map_runtime (fun rt ->
+           { rt with last_blocker = Some blocker })
+       in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       Masc.Keeper_registry.set_failure_reason
+         ~base_path:config.base_path
+         keeper_name
+         (Some
+            (Masc.Keeper_registry.Provider_runtime_error
+               { code = Masc.Keeper_unified_turn_no_progress.failure_reason_code
+               ; detail = "latched"
+               ; provider_id = None
+               ; http_status = None
+               ; runtime_id = None
+               ; reason = None
+               }));
+       Masc.Keeper_keepalive.process_directive ~agent_name:keeper_name "wakeup";
+       match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+         (match entry.Masc.Keeper_registry.meta.runtime.last_blocker with
+          | None -> ()
+          | Some _ -> fail "expected wakeup to persist no_progress meta clear");
+         (match entry.Masc.Keeper_registry.last_failure_reason with
+          | None -> ()
+          | Some _ -> fail "expected wakeup to clear no_progress failure reason")
        | None -> fail "expected registered keeper")
 
 let test_idle_detected_repeated_failure_pauses_keeper () =
@@ -358,6 +415,8 @@ let () =
             test_no_progress_loop_detection_pauses_keeper;
           test_case "operator resume clears no-progress latch" `Quick
             test_operator_resume_clears_no_progress_loop_latch;
+          test_case "wakeup directive persists no-progress meta clear" `Quick
+            test_wakeup_directive_persists_no_progress_meta_clear;
         ] );
       ( "idle-detected loop",
         [

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -35,6 +35,37 @@ let write_file path content =
   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () -> output_string oc content)
 ;;
 
+let runtime_toml =
+  {|
+version = 1
+
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+max-concurrent = 1
+|}
+;;
+
+let init_runtime_default_for_tests () =
+  let path = Filename.temp_file "runtime_trust_snapshot_runtime_" ".toml" in
+  write_file path runtime_toml;
+  match Runtime.init_default ~config_path:path with
+  | Ok () -> ()
+  | Error e -> Alcotest.failf "Runtime.init_default failed: %s" e
+;;
+
 let with_env name value f =
   let old = Sys.getenv_opt name in
   Unix.putenv name value;
@@ -249,6 +280,72 @@ let test_unknown_completion_contract_result_stays_visible () =
           |> to_string))
 ;;
 
+let test_completion_blocker_supersedes_passive_only_receipt () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       init_runtime_default_for_tests ();
+       let keeper_name = "runtime-trust-accept-empty" in
+       let blocker_detail =
+         "Provider returned an empty assistant turn for runtime runpod_fable5.gemma4-coder-fable5; no text or tool progress was produced."
+       in
+       let blocker =
+         Masc.Keeper_meta_contract.blocker_info_of_class
+           ~detail:blocker_detail
+           Masc.Keeper_meta_contract.Completion_contract_violation
+       in
+       let meta =
+         make_meta keeper_name
+         |> Masc.Keeper_meta_contract.map_runtime (fun rt ->
+           { rt with last_blocker = Some blocker })
+       in
+       let receipt_store =
+         Masc.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+       in
+       Dated_jsonl.append
+         receipt_store
+         (`Assoc
+             [ "ended_at", `String "2026-06-01T00:00:00Z"
+             ; "operator_disposition", `String "pass"
+             ; "operator_disposition_reason", `String "healthy"
+             ; "terminal_reason_code", `String "completed"
+             ; "completion_contract_result", `String "passive_only"
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       Alcotest.(check string)
+         "runtime blocker class"
+         "completion_contract_violation"
+         (snapshot
+          |> member "runtime_blockers"
+          |> member "runtime_blocker_class"
+          |> to_string);
+       Alcotest.(check string)
+         "passive-only receipt does not become display reason"
+         "fsm_invariant"
+         (snapshot |> member "disposition_reason" |> to_string);
+       Alcotest.(check string)
+         "attention follows runtime blocker"
+         "runtime_blocked"
+         (snapshot |> member "attention_reason" |> to_string);
+       Alcotest.(check bool)
+         "runtime blocker summary names empty provider turn"
+         true
+         (String.equal
+            blocker_detail
+            (snapshot
+             |> member "runtime_blockers"
+             |> member "runtime_blocker_summary"
+             |> to_string)))
+;;
+
 let test_model_observability_uses_runtime_trust_selected_model () =
   let runtime_trust =
     `Assoc
@@ -350,6 +447,10 @@ let () =
             "unknown completion-contract result remains visible"
             `Quick
             test_unknown_completion_contract_result_stays_visible
+        ; Alcotest.test_case
+            "runtime blocker supersedes passive-only receipt"
+            `Quick
+            test_completion_blocker_supersedes_passive_only_receipt
         ; Alcotest.test_case
             "status model observability reuses runtime-trust execution selected model"
             `Quick

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -857,7 +857,29 @@ let test_empty_non_end_turn_response_is_rejected () =
     (Some "empty_no_progress")
     (Option.map
        Masc.Keeper_error_classify.degraded_retry_reason_to_string
-       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err))
+       (Masc.Keeper_error_classify.recoverable_runtime_failure_reason err));
+  (match Masc.Keeper_turn_driver.classify_masc_internal_error err with
+   | Some internal_error ->
+     Alcotest.(check string)
+       "accept rejection runtime id uses scope"
+       "runtime.empty-stop-sequence"
+       (Masc.Keeper_turn_driver.runtime_id_of_masc_internal_error internal_error);
+     Alcotest.(check bool)
+       "summary describes provider empty turn"
+       true
+       (Option.value
+          ~default:false
+          (Option.map
+             (contains ~needle:"empty assistant turn")
+             (Masc.Keeper_turn_driver.summary_of_masc_internal_error internal_error)))
+   | None -> Alcotest.fail "expected typed accept rejection");
+  (match Masc.Keeper_status_bridge.blocker_class_of_sdk_error err with
+   | Some Masc.Keeper_meta_contract.Completion_contract_violation -> ()
+   | Some other ->
+     Alcotest.failf
+       "expected completion_contract_violation blocker, got %s"
+       (Masc.Keeper_meta_contract.blocker_class_to_string other)
+   | None -> Alcotest.fail "expected accept rejection blocker class")
 
 let test_empty_after_workspace_mutation_stays_terminal () =
   let checkpoint =


### PR DESCRIPTION
## Root Cause
- OAS already reports the provider response accurately as response_shape=empty with stop_reason=end_turn and no content blocks.
- MASC then lost the useful meaning: Accept_rejected had no human summary, runtime_id_of_masc_internal_error returned unknown, and blocker_class_of_sdk_error ignored Accept_rejected.
- Because the runtime blocker was not authoritative, the dashboard could surface an older or same-turn execution receipt as completion_contract_result:passive_only, making a provider-empty turn look like passive keeper behavior.
- Play/resume also reset the generic turn-livelock counter only. It did not clear the no-progress detector latch or no_progress_loop failure reason, so a manually resumed keeper could immediately fall back into the same tombstone.

## Changes
- Give Accept_rejected empty/read-only no-progress failures human-readable summaries and preserve the originating runtime id from scope.
- Map Accept_rejected to completion_contract_violation so it becomes a visible runtime blocker instead of raw internal JSON or a masked passive-only receipt.
- Prefer a concrete completion-contract runtime blocker over same-turn receipt attention such as completion_contract_result:passive_only.
- Clear the no-progress detector latch, meta blocker, and no_progress_loop failure reason on operator resume/wakeup.
- Update no_progress_loop text so it describes the latch and operator-resume clearing behavior.

## Verification
- git diff --check
- scripts/dune-local.sh build test/test_keeper_turn_driver_accept.exe test/test_keeper_auto_pause_blocker_persist_12683.exe test/test_keeper_runtime_trust_snapshot.exe
- ./_build/default/test/test_keeper_turn_driver_accept.exe
- ./_build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe
- ./_build/default/test/test_keeper_runtime_trust_snapshot.exe

## OAS Audit
- No OAS patch in this PR. The OAS response-shape layer already emits shape=empty for the provider-empty turn; the incorrect operational meaning was introduced in the MASC status/recovery layer.