### PR TITLE
feat: HITL approval 실시간 갱신 및 처리 이력 노출

### DIFF
--- a/dashboard/src/api/board.ts
+++ b/dashboard/src/api/board.ts
@@ -150,6 +150,7 @@ export function normalizeKeeperApprovalQueueItem(raw: unknown): KeeperApprovalQu
     selected_model: null,
     disposition: asNullableString(raw.disposition),
     disposition_reason: asNullableString(raw.disposition_reason),
+    decision: asNullableString(raw.decision),
     rule_match: ruleMatch,
     input: raw.input,
     input_preview: asNullableString(raw.input_preview),

--- a/dashboard/src/api/dashboard-governance.ts
+++ b/dashboard/src/api/dashboard-governance.ts
@@ -14,6 +14,7 @@ import {
 } from './board'
 import { normalizePendingConfirmation } from '../pending-confirm'
 import { asKeeperApprovalRiskLevel } from '../lib/governance-risk-level'
+import { normalizeKeeperResolvedApprovalDecision } from '../lib/keeper-approval-decision'
 import type {
   KeeperApprovalRule,
   DashboardGovernanceResponse,
@@ -21,6 +22,7 @@ import type {
   GovernanceTimelineEvent,
   GovernanceJudgment,
   KeeperApprovalQueueItem,
+  KeeperResolvedApprovalItem,
   GovernanceCaseBundle,
   PendingConfirmation,
 } from '../types'
@@ -65,6 +67,40 @@ function normalizeHitlStatus(raw: unknown): DashboardGovernanceResponse['hitl'] 
   }
 }
 
+function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprovalItem | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id, '').trim()
+  const keeperName = asString(raw.keeper_name, '').trim()
+  const toolName = asString(raw.tool_name, '').trim()
+  if (!id || !keeperName || !toolName) return null
+  const ruleMatch = isRecord(raw.rule_match)
+    ? {
+        rule_id: asNullableString(raw.rule_match.rule_id),
+        matched_by: asNullableString(raw.rule_match.matched_by),
+      }
+    : null
+  const decisionRaw = asNullableString(raw.decision)
+  return {
+    id,
+    keeper_name: keeperName,
+    tool_name: toolName,
+    risk_level: asKeeperApprovalRiskLevel(raw.risk_level),
+    decision: normalizeKeeperResolvedApprovalDecision(decisionRaw),
+    decision_raw: decisionRaw,
+    resolved_at: asNullableIsoTimestamp(raw.resolved_at_iso ?? raw.resolved_at ?? raw.ts),
+    turn_id: asInt(raw.turn_id),
+    task_id: asNullableString(raw.task_id),
+    goal_id: asNullableString(raw.goal_id),
+    goal_ids: Array.isArray(raw.goal_ids)
+      ? raw.goal_ids.filter((value): value is string => typeof value === 'string')
+      : [],
+    sandbox_target: asNullableString(raw.sandbox_target),
+    disposition: asNullableString(raw.disposition),
+    disposition_reason: asNullableString(raw.disposition_reason),
+    rule_match: ruleMatch,
+  }
+}
+
 export function fetchDashboardGovernance(
   opts?: FetchDashboardGovernanceOptions,
 ): Promise<DashboardGovernanceResponse> {
@@ -90,8 +126,8 @@ export function fetchDashboardGovernance(
       : []
     const recentResolved = Array.isArray(raw.recent_resolved)
       ? raw.recent_resolved
-          .map(item => normalizeKeeperApprovalQueueItem(item))
-          .filter((item): item is KeeperApprovalQueueItem => item !== null)
+          .map(item => normalizeKeeperResolvedApprovalItem(item))
+          .filter((item): item is KeeperResolvedApprovalItem => item !== null)
       : []
     const approvalRules = Array.isArray(raw.approval_rules)
       ? raw.approval_rules

--- a/dashboard/src/api/dashboard-governance.ts
+++ b/dashboard/src/api/dashboard-governance.ts
@@ -80,12 +80,13 @@ function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprov
       }
     : null
   const decisionRaw = asNullableString(raw.decision)
+  const decisionKind = asNullableString(raw.decision_kind)
   return {
     id,
     keeper_name: keeperName,
     tool_name: toolName,
     risk_level: asKeeperApprovalRiskLevel(raw.risk_level),
-    decision: normalizeKeeperResolvedApprovalDecision(decisionRaw),
+    decision: normalizeKeeperResolvedApprovalDecision(decisionKind),
     decision_raw: decisionRaw,
     resolved_at: asNullableIsoTimestamp(raw.resolved_at_iso ?? raw.resolved_at ?? raw.ts),
     turn_id: asInt(raw.turn_id),

--- a/dashboard/src/api/dashboard-governance.ts
+++ b/dashboard/src/api/dashboard-governance.ts
@@ -81,6 +81,7 @@ function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprov
     : null
   const decisionRaw = asNullableString(raw.decision)
   const decisionKind = asNullableString(raw.decision_kind)
+  const decisionReason = asNullableString(raw.decision_reason)
   return {
     id,
     keeper_name: keeperName,
@@ -88,6 +89,7 @@ function normalizeKeeperResolvedApprovalItem(raw: unknown): KeeperResolvedApprov
     risk_level: asKeeperApprovalRiskLevel(raw.risk_level),
     decision: normalizeKeeperResolvedApprovalDecision(decisionKind),
     decision_raw: decisionRaw,
+    decision_reason: decisionReason,
     resolved_at: asNullableIsoTimestamp(raw.resolved_at_iso ?? raw.resolved_at ?? raw.ts),
     turn_id: asInt(raw.turn_id),
     task_id: asNullableString(raw.task_id),

--- a/dashboard/src/api/dashboard-governance.ts
+++ b/dashboard/src/api/dashboard-governance.ts
@@ -24,6 +24,11 @@ import type {
   GovernanceCaseBundle,
   PendingConfirmation,
 } from '../types'
+import type { AbortableRequestOptions } from './core'
+
+export interface FetchDashboardGovernanceOptions extends AbortableRequestOptions {
+  force?: boolean
+}
 
 function normalizeKeeperApprovalRule(raw: unknown): KeeperApprovalRule | null {
   if (!isRecord(raw)) return null
@@ -60,9 +65,14 @@ function normalizeHitlStatus(raw: unknown): DashboardGovernanceResponse['hitl'] 
   }
 }
 
-export function fetchDashboardGovernance(): Promise<DashboardGovernanceResponse> {
+export function fetchDashboardGovernance(
+  opts?: FetchDashboardGovernanceOptions,
+): Promise<DashboardGovernanceResponse> {
   return withRetries('fetchDashboardGovernance', async () => {
-    const raw = await get<Record<string, unknown>>('/api/v1/dashboard/governance')
+    const query = opts?.force ? '?force=1' : ''
+    const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/governance${query}`, {
+      signal: opts?.signal,
+    })
     const items = Array.isArray(raw.items)
       ? raw.items
           .map(item => normalizeGovernanceDecisionItem(item))
@@ -75,6 +85,11 @@ export function fetchDashboardGovernance(): Promise<DashboardGovernanceResponse>
       : []
     const approvalQueue = Array.isArray(raw.approval_queue)
       ? raw.approval_queue
+          .map(item => normalizeKeeperApprovalQueueItem(item))
+          .filter((item): item is KeeperApprovalQueueItem => item !== null)
+      : []
+    const recentResolved = Array.isArray(raw.recent_resolved)
+      ? raw.recent_resolved
           .map(item => normalizeKeeperApprovalQueueItem(item))
           .filter((item): item is KeeperApprovalQueueItem => item !== null)
       : []
@@ -124,6 +139,7 @@ export function fetchDashboardGovernance(): Promise<DashboardGovernanceResponse>
         : [],
       pending_actions: pendingActions,
       approval_queue: approvalQueue,
+      recent_resolved: recentResolved,
       approval_rules: approvalRules,
       hitl: normalizeHitlStatus(raw.hitl),
     }

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1343,7 +1343,16 @@ describe('fetchDashboardGovernance', () => {
             tool_name: 'fs_write',
             risk_level: 'medium',
             decision: 'reject:operator denied',
+            decision_kind: 'reject',
             resolved_at_iso: '2026-06-27T01:02:03Z',
+          },
+          {
+            id: 'appr-legacy',
+            keeper_name: 'keeper-a',
+            tool_name: 'shell_exec',
+            risk_level: 'high',
+            decision: 'reject:legacy reason',
+            resolved_at_iso: '2026-06-27T01:03:03Z',
           },
         ],
       }), {
@@ -1364,6 +1373,15 @@ describe('fetchDashboardGovernance', () => {
         decision: 'reject',
         decision_raw: 'reject:operator denied',
         resolved_at: '2026-06-27T01:02:03Z',
+      }),
+      expect.objectContaining({
+        id: 'appr-legacy',
+        keeper_name: 'keeper-a',
+        tool_name: 'shell_exec',
+        risk_level: 'high',
+        decision: 'unknown',
+        decision_raw: 'reject:legacy reason',
+        resolved_at: '2026-06-27T01:03:03Z',
       }),
     ])
     expect(result.recent_resolved?.[0]).not.toHaveProperty('requested_at')

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1317,6 +1317,58 @@ describe('fetchDashboardMemory', () => {
 })
 
 describe('fetchDashboardGovernance', () => {
+  it('requests a forced governance snapshot when asked', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ approval_queue: [], recent_resolved: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchDashboardGovernance({ force: true })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/v1/dashboard/governance?force=1')
+  })
+
+  it('normalizes resolved approval history separately from pending queue items', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        approval_queue: [],
+        recent_resolved: [
+          {
+            id: 'appr-done',
+            keeper_name: 'keeper-a',
+            tool_name: 'fs_write',
+            risk_level: 'medium',
+            decision: 'reject:operator denied',
+            resolved_at_iso: '2026-06-27T01:02:03Z',
+          },
+        ],
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await fetchDashboardGovernance()
+
+    expect(result.recent_resolved).toEqual([
+      expect.objectContaining({
+        id: 'appr-done',
+        keeper_name: 'keeper-a',
+        tool_name: 'fs_write',
+        risk_level: 'medium',
+        decision: 'reject',
+        decision_raw: 'reject:operator denied',
+        resolved_at: '2026-06-27T01:02:03Z',
+      }),
+    ])
+    expect(result.recent_resolved?.[0]).not.toHaveProperty('requested_at')
+  })
+
   it('does not retry structured computation timeouts', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1344,6 +1344,7 @@ describe('fetchDashboardGovernance', () => {
             risk_level: 'medium',
             decision: 'reject:operator denied',
             decision_kind: 'reject',
+            decision_reason: 'operator denied',
             resolved_at_iso: '2026-06-27T01:02:03Z',
           },
           {
@@ -1372,6 +1373,7 @@ describe('fetchDashboardGovernance', () => {
         risk_level: 'medium',
         decision: 'reject',
         decision_raw: 'reject:operator denied',
+        decision_reason: 'operator denied',
         resolved_at: '2026-06-27T01:02:03Z',
       }),
       expect.objectContaining({
@@ -1381,6 +1383,7 @@ describe('fetchDashboardGovernance', () => {
         risk_level: 'high',
         decision: 'unknown',
         decision_raw: 'reject:legacy reason',
+        decision_reason: null,
         resolved_at: '2026-06-27T01:03:03Z',
       }),
     ])

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -192,9 +192,9 @@ export function App() {
     // governance resource must refresh globally. Keep boot on the read-only
     // refresh module instead of governance-actions: first paint should not load
     // toast/action write handlers just to count pending approvals.
-    const refreshGovernanceLazy = () => {
+    const refreshGovernanceLazy = (opts?: { force?: boolean }) => {
       void import('./components/governance-refresh')
-        .then(({ refreshGovernance }) => refreshGovernance())
+        .then(({ refreshGovernance }) => refreshGovernance(opts))
         .catch(err => {
           console.warn('[app] governance refresh unavailable', err instanceof Error ? err.message : err)
         })

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -1,7 +1,7 @@
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import * as Vitest from 'vitest'
-import type { DashboardGovernanceResponse, KeeperApprovalQueueItem } from '../../types'
+import type { DashboardGovernanceResponse, KeeperApprovalQueueItem, KeeperResolvedApprovalItem } from '../../types'
 
 const { afterEach, beforeEach, describe, expect, it, vi } = Vitest
 
@@ -24,7 +24,10 @@ function queueItem(overrides: Partial<KeeperApprovalQueueItem> & { id: string })
   }
 }
 
-function responseWithQueue(approval_queue: KeeperApprovalQueueItem[]): DashboardGovernanceResponse {
+function responseWithQueue(
+  approval_queue: KeeperApprovalQueueItem[],
+  recent_resolved: KeeperResolvedApprovalItem[] = [],
+): DashboardGovernanceResponse {
   return {
     generated_at: '2026-06-19T00:00:00Z',
     summary: { judge_online: false },
@@ -33,19 +36,23 @@ function responseWithQueue(approval_queue: KeeperApprovalQueueItem[]): Dashboard
     judgments: [],
     pending_actions: [],
     approval_queue,
+    recent_resolved,
   } as DashboardGovernanceResponse
 }
 
 // Mirrors governance.test.ts loadComponentWithApi: mock the api seam that
 // refreshGovernance() reaches on mount, plus the sse-store refresh registry.
-async function loadSurface(approval_queue: KeeperApprovalQueueItem[]) {
+async function loadSurface(
+  approval_queue: KeeperApprovalQueueItem[],
+  recent_resolved: KeeperResolvedApprovalItem[] = [],
+) {
   vi.resetModules()
   const resolveGovernanceApproval = vi
     .fn()
     .mockResolvedValue({ ok: true, id: 'appr-1', decision: 'approve' })
   vi.doMock('../../api', () => ({
     decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue)),
+    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue, recent_resolved)),
     fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(null),
     resolveGovernanceApproval,
     deleteGovernanceApprovalRule: vi.fn().mockResolvedValue({ ok: true }),
@@ -277,6 +284,37 @@ describe('ApprovalsSurface', () => {
     expect(container.textContent).not.toContain('보류')
     expect(container.textContent).not.toContain('되돌리기')
     expect(container.textContent).not.toContain('처리이력')
+  }, 20000)
+
+  it('renders resolved approval history with resolved timestamp and closed decision class', async () => {
+    const { ApprovalsSurface } = await loadSurface(
+      [],
+      [
+        {
+          id: 'appr-done',
+          keeper_name: 'masc-improver',
+          tool_name: 'fs_write',
+          risk_level: 'medium',
+          decision: 'reject',
+          decision_raw: 'reject:operator denied',
+          resolved_at: '2026-06-27T01:02:03Z',
+        },
+      ],
+    )
+
+    render(html`<${ApprovalsSurface} />`, container)
+    await flushUi()
+
+    const history = container.querySelector('[data-testid="approvals-history"]')
+    expect(history).not.toBeNull()
+    expect(history?.textContent).toContain('최근 처리 (1)')
+    expect(history?.textContent).toContain('거부')
+    expect(history?.textContent).toContain('fs_write')
+    expect(history?.textContent).toContain('masc-improver')
+    expect(history?.textContent).toContain('appr-done')
+    expect(history?.querySelector('.ap-history-decision')?.className).toContain('decision-reject')
+    expect(history?.querySelector('.ap-history-decision')?.className).not.toContain('operator denied')
+    expect(history?.querySelector('.ap-history-at')?.textContent).toContain('2026')
   }, 20000)
 
   it('shows the empty state when no approvals are pending', async () => {

--- a/dashboard/src/components/approvals/approvals-surface.test.ts
+++ b/dashboard/src/components/approvals/approvals-surface.test.ts
@@ -61,7 +61,7 @@ async function loadSurface(
   }))
   vi.doMock('../../api/dashboard-governance', () => ({
     decideGovernanceExecutionOrder: vi.fn().mockResolvedValue(undefined),
-    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue)),
+    fetchDashboardGovernance: vi.fn().mockResolvedValue(responseWithQueue(approval_queue, recent_resolved)),
     fetchGovernanceCaseStatus: vi.fn().mockResolvedValue(null),
     resolveGovernanceApproval,
     deleteGovernanceApprovalRule: vi.fn().mockResolvedValue({ ok: true }),

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -111,6 +111,31 @@ function approvalRuleSummary(item: KeeperApprovalQueueItem): string | null {
     : null
 }
 
+function resolvedDecisionLabel(decision: string | null | undefined): string {
+  if (decision === 'approve') return '승인'
+  if (decision === 'reject') return '거부'
+  return decision || '처리됨'
+}
+
+function ResolvedApprovalItem({ item }: { item: KeeperApprovalQueueItem }) {
+  const decision = resolvedDecisionLabel(item.decision)
+  return html`
+    <li
+      class="ap-history-item"
+      data-testid="approval-history-item"
+      data-approval-id=${item.id}
+    >
+      <span class=${`ap-history-decision ${item.decision ?? ''}`}>${decision}</span>
+      <span class="ap-history-tool mono">${item.tool_name}</span>
+      <span class="ap-history-keeper">${item.keeper_name}</span>
+      <span class="ap-history-id mono">${item.id}</span>
+      ${item.requested_at
+        ? html`<span class="ap-history-at">${new Date(item.requested_at).toLocaleString('ko-KR')}</span>`
+        : null}
+    </li>
+  `
+}
+
 function approvalDetailRows(item: KeeperApprovalQueueItem): Array<{ label: string; value: string }> {
   return [
     { label: '키퍼', value: item.keeper_name },
@@ -280,6 +305,7 @@ export function ApprovalsSurface() {
   }, [])
 
   const items = governanceData.value?.approval_queue ?? []
+  const resolvedItems = governanceData.value?.recent_resolved ?? []
   const error = governanceError.value
   // First load only: governanceResource is stale-while-revalidate, so a refetch
   // keeps the previous data — governanceData is null ONLY before the first load
@@ -369,6 +395,18 @@ export function ApprovalsSurface() {
                 <h3>열린 승인이 없습니다</h3>
                 <div class="ap-clear-sub">HITL 큐가 비어 있습니다 — keeper들이 결재 대기 없이 진행 중입니다.</div>
               </div>
+            `
+          : null}
+        ${resolvedItems.length > 0
+          ? html`
+              <section class="ap-history" data-testid="approvals-history">
+                <h2 class="ap-history-title">최근 처리 (${resolvedItems.length})</h2>
+                <ul class="ap-history-list">
+                  ${resolvedItems.map(item => html`
+                    <${ResolvedApprovalItem} key=${item.id} item=${item} />
+                  `)}
+                </ul>
+              </section>
             `
           : null}
       `}

--- a/dashboard/src/components/approvals/approvals-surface.ts
+++ b/dashboard/src/components/approvals/approvals-surface.ts
@@ -14,14 +14,19 @@
 import { html } from 'htm/preact'
 import { Fragment } from 'preact'
 import { useEffect, useMemo, useState } from 'preact/hooks'
-import type { KeeperApprovalQueueItem } from '../../types'
+import type { KeeperApprovalQueueItem, KeeperResolvedApprovalItem } from '../../types'
 import { TELEMETRY_AUTO_REFRESH_MS } from '../../config/constants'
 import { setupVisibleAutoRefresh } from '../../lib/auto-refresh'
+import { formatDateTimeKo } from '../../lib/format-time'
 import {
   keeperApprovalRiskLabel,
   keeperApprovalRiskVisualBand,
   type KeeperApprovalRiskVisualBand,
 } from '../../lib/governance-risk-level'
+import {
+  keeperResolvedApprovalDecisionClass,
+  keeperResolvedApprovalDecisionLabel,
+} from '../../lib/keeper-approval-decision'
 import { navigate } from '../../router'
 import { AgentAvatar } from '../overview/agent-avatar'
 import { LoadingState } from '../common/feedback-state'
@@ -111,26 +116,20 @@ function approvalRuleSummary(item: KeeperApprovalQueueItem): string | null {
     : null
 }
 
-function resolvedDecisionLabel(decision: string | null | undefined): string {
-  if (decision === 'approve') return '승인'
-  if (decision === 'reject') return '거부'
-  return decision || '처리됨'
-}
-
-function ResolvedApprovalItem({ item }: { item: KeeperApprovalQueueItem }) {
-  const decision = resolvedDecisionLabel(item.decision)
+function ResolvedApprovalItem({ item }: { item: KeeperResolvedApprovalItem }) {
+  const decision = keeperResolvedApprovalDecisionLabel(item.decision)
   return html`
     <li
       class="ap-history-item"
       data-testid="approval-history-item"
       data-approval-id=${item.id}
     >
-      <span class=${`ap-history-decision ${item.decision ?? ''}`}>${decision}</span>
+      <span class=${`ap-history-decision ${keeperResolvedApprovalDecisionClass(item.decision)}`}>${decision}</span>
       <span class="ap-history-tool mono">${item.tool_name}</span>
       <span class="ap-history-keeper">${item.keeper_name}</span>
       <span class="ap-history-id mono">${item.id}</span>
-      ${item.requested_at
-        ? html`<span class="ap-history-at">${new Date(item.requested_at).toLocaleString('ko-KR')}</span>`
+      ${item.resolved_at
+        ? html`<span class="ap-history-at">${formatDateTimeKo(item.resolved_at)}</span>`
         : null}
     </li>
   `

--- a/dashboard/src/components/governance-actions.ts
+++ b/dashboard/src/components/governance-actions.ts
@@ -94,7 +94,7 @@ export async function respondToKeeperApproval(
         ? (rememberRule ? 'keeper 승인 요청을 승인하고 Always 규칙을 저장했습니다' : 'keeper 승인 요청을 승인했습니다')
         : 'keeper 승인 요청을 거부했습니다'
     showToast(message, 'success')
-    await refreshGovernance()
+    await refreshGovernance({ force: true })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'keeper 승인 요청을 처리하지 못했습니다'
     governanceError.value = message
@@ -110,7 +110,7 @@ export async function deleteKeeperApprovalRule(id: string) {
   try {
     await deleteGovernanceApprovalRule(id)
     showToast('Always 규칙을 삭제했습니다', 'success')
-    await refreshGovernance()
+    await refreshGovernance({ force: true })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Always 규칙을 삭제하지 못했습니다'
     governanceError.value = message

--- a/dashboard/src/components/governance-refresh.ts
+++ b/dashboard/src/components/governance-refresh.ts
@@ -33,10 +33,10 @@ export async function selectDecision(item: GovernanceDecisionItem) {
   await loadDecisionDetail(item)
 }
 
-export async function refreshGovernance() {
+export async function refreshGovernance(opts?: { force?: boolean }) {
   governanceError.value = ''
-  await governanceResource.load(async () => {
-    const data = await fetchDashboardGovernance()
+  await governanceResource.load(async (signal) => {
+    const data = await fetchDashboardGovernance({ force: opts?.force, signal })
     const items = filteredItemsByFilter(governanceFilter.value, data.items ?? [])
     const current = selectedDecisionKey.value
     const next = getSelectedDecision(current, items) ?? items[0] ?? null

--- a/dashboard/src/lib/keeper-approval-decision.ts
+++ b/dashboard/src/lib/keeper-approval-decision.ts
@@ -21,7 +21,7 @@ export function normalizeKeeperResolvedApprovalDecision(
 ): KeeperResolvedApprovalDecision {
   const value = raw?.trim()
   if (value === 'approve') return 'approve'
-  if (value === 'reject' || value?.startsWith('reject:')) return 'reject'
+  if (value === 'reject') return 'reject'
   if (value === 'edit') return 'edit'
   return 'unknown'
 }

--- a/dashboard/src/lib/keeper-approval-decision.ts
+++ b/dashboard/src/lib/keeper-approval-decision.ts
@@ -1,0 +1,39 @@
+export const KEEPER_RESOLVED_APPROVAL_DECISIONS = [
+  'approve',
+  'reject',
+  'edit',
+  'unknown',
+] as const
+
+export type KeeperResolvedApprovalDecision =
+  typeof KEEPER_RESOLVED_APPROVAL_DECISIONS[number]
+
+const KEEPER_RESOLVED_APPROVAL_DECISION_LABELS:
+  Record<KeeperResolvedApprovalDecision, string> = {
+    approve: '승인',
+    reject: '거부',
+    edit: '수정됨',
+    unknown: '처리됨',
+  }
+
+export function normalizeKeeperResolvedApprovalDecision(
+  raw: string | null | undefined,
+): KeeperResolvedApprovalDecision {
+  const value = raw?.trim()
+  if (value === 'approve') return 'approve'
+  if (value === 'reject' || value?.startsWith('reject:')) return 'reject'
+  if (value === 'edit') return 'edit'
+  return 'unknown'
+}
+
+export function keeperResolvedApprovalDecisionLabel(
+  decision: KeeperResolvedApprovalDecision,
+): string {
+  return KEEPER_RESOLVED_APPROVAL_DECISION_LABELS[decision]
+}
+
+export function keeperResolvedApprovalDecisionClass(
+  decision: KeeperResolvedApprovalDecision,
+): string {
+  return `decision-${decision}`
+}

--- a/dashboard/src/schemas/sse.ts
+++ b/dashboard/src/schemas/sse.ts
@@ -24,6 +24,9 @@ type SchemaLike<T> = {
   safeParse(value: unknown): SafeParseResult<T>
 }
 
+export const SSE_APPROVAL_PENDING_EVENT = 'approval:pending'
+export const SSE_APPROVAL_RESOLVED_EVENT = 'approval:resolved'
+
 const FIXED_SSE_EVENT_TYPES = new Set([
   'agent_bound',
   'masc/agent_bound',
@@ -68,8 +71,8 @@ const FIXED_SSE_EVENT_TYPES = new Set([
   'client_input_rejected',
   'client_input_updated',
   'governance_param_changed',
-  'approval:pending',
-  'approval:resolved',
+  SSE_APPROVAL_PENDING_EVENT,
+  SSE_APPROVAL_RESOLVED_EVENT,
   'project_snapshot',
   'namespace_truth_snapshot',
   'execution_snapshot',

--- a/dashboard/src/sse-store.test.ts
+++ b/dashboard/src/sse-store.test.ts
@@ -184,7 +184,7 @@ describe('setupSSEReaction reconnect hydration', () => {
   it('refreshes the governance approval queue on reconnect (nav-rail badge recovery)', async () => {
     const { sseStore, sse } = await loadSseStore()
     const cleanup = sseStore.setupSSEReaction()
-    const refreshGovernance = vi.fn<() => void>()
+    const refreshGovernance = vi.fn<(opts?: { force?: boolean }) => void>()
     sseStore.registerGovernanceRefresh(refreshGovernance)
 
     sse.connected.value = true
@@ -202,7 +202,7 @@ describe('setupSSEReaction reconnect hydration', () => {
 
   it('routes an approval:pending SSE event to the governance refresh (HITL badge contract)', async () => {
     const { sseStore } = await loadSseStore()
-    const refreshGovernance = vi.fn<() => void>()
+    const refreshGovernance = vi.fn<(opts?: { force?: boolean }) => void>()
     sseStore.registerGovernanceRefresh(refreshGovernance)
 
     // Pins the FRONTEND routing contract: an `approval:pending` event must
@@ -214,7 +214,7 @@ describe('setupSSEReaction reconnect hydration', () => {
     vi.advanceTimersByTime(1_000)
     await flushAsyncWork()
 
-    expect(refreshGovernance).toHaveBeenCalled()
+    expect(refreshGovernance).toHaveBeenCalledWith({ force: true })
   })
 
   it('hydrates the canonical project_snapshot SSE event without an HTTP fetch', async () => {

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -60,6 +60,10 @@ import { hydrateGoalLoopSnapshot } from './goal-loop-state'
 import { showToast } from './components/common/toast'
 import type { ErrorCode } from './types/error'
 import { parseOasPayloadOrNull } from './schemas/sse-event-payload'
+import {
+  SSE_APPROVAL_PENDING_EVENT,
+  SSE_APPROVAL_RESOLVED_EVENT,
+} from './schemas/sse'
 import { route } from './router'
 import { routeWantsRefreshTarget, type RouteRefreshTarget } from './refresh-scope'
 import {
@@ -492,11 +496,14 @@ export function routeServerPushEvent(event: SSEEvent): void {
     handleKeeperLifecycle(event)
   }
 
+  const approvalRefreshEvent =
+    event.type === SSE_APPROVAL_PENDING_EVENT
+    || event.type === SSE_APPROVAL_RESOLVED_EVENT
+
   if (
     event.type.startsWith('decision_')
     || event.type === 'governance_param_changed'
-    || event.type === 'approval:pending'
-    || event.type === 'approval:resolved'
+    || approvalRefreshEvent
   ) {
     if (route.value.tab === 'command') {
       scheduleRefresh('command_route', () => {
@@ -504,7 +511,8 @@ export function routeServerPushEvent(event: SSEEvent): void {
       })
     }
     if (_refreshGovernanceFn) {
-      scheduleRefresh('governance', () => void handleGovernance({ force: true }))
+      const opts = approvalRefreshEvent ? { force: true } : undefined
+      scheduleRefresh('governance', () => void handleGovernance(opts))
     }
   }
 }

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -74,8 +74,8 @@ import {
 
 // --- Refresh function registration (avoids circular imports) ---
 
-let _refreshGovernanceFn: (() => void) | null = null
-export function registerGovernanceRefresh(fn: () => void): void {
+let _refreshGovernanceFn: ((opts?: { force?: boolean }) => void) | null = null
+export function registerGovernanceRefresh(fn: (opts?: { force?: boolean }) => void): void {
   _refreshGovernanceFn = fn
 }
 
@@ -323,8 +323,8 @@ function handleKeeperLifecycle(event: { type: string; name?: string }): void {
   }
 }
 
-function handleGovernance(): void {
-  _refreshGovernanceFn?.()
+function handleGovernance(opts?: { force?: boolean }): void {
+  _refreshGovernanceFn?.(opts)
 }
 
 async function refreshActiveRoute(): Promise<void> {
@@ -504,7 +504,7 @@ export function routeServerPushEvent(event: SSEEvent): void {
       })
     }
     if (_refreshGovernanceFn) {
-      scheduleRefresh('governance', () => void handleGovernance())
+      scheduleRefresh('governance', () => void handleGovernance({ force: true }))
     }
   }
 }

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -105,8 +105,8 @@
 .ap-history-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
 .ap-history-item { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border-radius: var(--radius-sm); background: var(--bg-panel); border: 1px solid var(--border-soft); font-size: 12px; }
 .ap-history-decision { flex: none; min-width: 48px; text-align: center; padding: 2px 8px; border-radius: var(--radius-xs); font-weight: 600; text-transform: uppercase; font-size: 10px; }
-.ap-history-decision.approve { color: var(--status-ok); background: color-mix(in oklab, var(--status-ok) 12%, transparent); }
-.ap-history-decision.reject { color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
+.ap-history-decision.decision-approve { color: var(--status-ok); background: color-mix(in oklab, var(--status-ok) 12%, transparent); }
+.ap-history-decision.decision-reject { color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
 .ap-history-tool { flex: 1 1 140px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-bright); }
 .ap-history-keeper { flex: 1 1 120px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-dim); }
 .ap-history-id { flex: 1 1 140px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-dim); font-size: 10.5px; }

--- a/dashboard/src/styles/approvals-v2.css
+++ b/dashboard/src/styles/approvals-v2.css
@@ -98,3 +98,16 @@
   .ap-h { flex-wrap: wrap; }
   .ap-id { margin-left: 0; }
 }
+
+/* Recent resolved approvals history (live surface augmentation). */
+.ap-history { margin-top: 24px; padding-top: 24px; border-top: 1px solid var(--border-soft); }
+.ap-history-title { font-size: 14px; font-weight: 600; color: var(--text-dim); margin: 0 0 12px; }
+.ap-history-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+.ap-history-item { display: flex; align-items: center; gap: 12px; padding: 10px 12px; border-radius: var(--radius-sm); background: var(--bg-panel); border: 1px solid var(--border-soft); font-size: 12px; }
+.ap-history-decision { flex: none; min-width: 48px; text-align: center; padding: 2px 8px; border-radius: var(--radius-xs); font-weight: 600; text-transform: uppercase; font-size: 10px; }
+.ap-history-decision.approve { color: var(--status-ok); background: color-mix(in oklab, var(--status-ok) 12%, transparent); }
+.ap-history-decision.reject { color: var(--status-bad); background: color-mix(in oklab, var(--status-bad) 12%, transparent); }
+.ap-history-tool { flex: 1 1 140px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-bright); }
+.ap-history-keeper { flex: 1 1 120px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-dim); }
+.ap-history-id { flex: 1 1 140px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-dim); font-size: 10.5px; }
+.ap-history-at { flex: none; color: var(--text-dim); font-size: 10.5px; }

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -1,6 +1,6 @@
 import type { Agent, BoardPost, StopCause, ExecutionSignalTruth, EvidenceSourceCore } from './core'
 import type { OperatorAttentionItem, OperatorRecommendedAction } from './dashboard-mission'
-import type { BoardMonitoring, GovernanceMonitoring, GovernanceDecisionItem, GovernanceTimelineEvent, GovernanceJudgeSummary, GovernanceJudgment, KeeperApprovalQueueItem, KeeperApprovalRule, PendingConfirmation, PendingConfirmSummary } from './governance'
+import type { BoardMonitoring, GovernanceMonitoring, GovernanceDecisionItem, GovernanceTimelineEvent, GovernanceJudgeSummary, GovernanceJudgment, KeeperApprovalQueueItem, KeeperApprovalRule, KeeperResolvedApprovalItem, PendingConfirmation, PendingConfirmSummary } from './governance'
 
 // --- Dashboard projection responses ---
 
@@ -671,7 +671,7 @@ export interface DashboardGovernanceResponse {
   judgments?: GovernanceJudgment[]
   pending_actions?: PendingConfirmation[]
   approval_queue?: KeeperApprovalQueueItem[]
-  recent_resolved?: KeeperApprovalQueueItem[]
+  recent_resolved?: KeeperResolvedApprovalItem[]
   approval_rules?: KeeperApprovalRule[]
   hitl?: {
     enabled: boolean

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -671,6 +671,7 @@ export interface DashboardGovernanceResponse {
   judgments?: GovernanceJudgment[]
   pending_actions?: PendingConfirmation[]
   approval_queue?: KeeperApprovalQueueItem[]
+  recent_resolved?: KeeperApprovalQueueItem[]
   approval_rules?: KeeperApprovalRule[]
   hitl?: {
     enabled: boolean

--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -252,6 +252,7 @@ export interface KeeperResolvedApprovalItem {
   risk_level?: KeeperApprovalRiskLevel | null
   decision: KeeperResolvedApprovalDecision
   decision_raw?: string | null
+  decision_reason?: string | null
   resolved_at?: string | null
   turn_id?: number | null
   task_id?: string | null

--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -1,5 +1,8 @@
 // --- Governance ---
 
+import type { KeeperResolvedApprovalDecision } from '../lib/keeper-approval-decision'
+export type { KeeperResolvedApprovalDecision } from '../lib/keeper-approval-decision'
+
 export interface GovernanceContextRef {
   board_post_id?: string | null
   task_id?: string | null
@@ -240,6 +243,27 @@ export interface KeeperApprovalQueueItem {
   } | null
   input?: unknown
   input_preview?: string | null
+}
+
+export interface KeeperResolvedApprovalItem {
+  id: string
+  keeper_name: string
+  tool_name: string
+  risk_level?: KeeperApprovalRiskLevel | null
+  decision: KeeperResolvedApprovalDecision
+  decision_raw?: string | null
+  resolved_at?: string | null
+  turn_id?: number | null
+  task_id?: string | null
+  goal_id?: string | null
+  goal_ids?: string[]
+  sandbox_target?: string | null
+  disposition?: string | null
+  disposition_reason?: string | null
+  rule_match?: {
+    rule_id?: string | null
+    matched_by?: string | null
+  } | null
 }
 
 export interface KeeperApprovalRule {

--- a/dashboard/src/types/governance.ts
+++ b/dashboard/src/types/governance.ts
@@ -233,6 +233,7 @@ export interface KeeperApprovalQueueItem {
   selected_model?: string | null
   disposition?: string | null
   disposition_reason?: string | null
+  decision?: string | null
   rule_match?: {
     rule_id?: string | null
     matched_by?: string | null

--- a/docs/superpowers/plans/2026-06-26-hitl-approval-refresh-and-history.md
+++ b/docs/superpowers/plans/2026-06-26-hitl-approval-refresh-and-history.md
@@ -1,0 +1,394 @@
+# HITL Approval 빠른 반응 + 처리 이력 노출 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** MASC Dashboard HITL approval 승인/거부 버튼을 눌렀을 때 캐시 때문에 화면이 갱신되지 않는 문제를 고치고, SSE 기반 실시간 반응을 강화하며, 처리 완료된 approval 이력을 dashboard에 노출한다.
+
+**Architecture:**
+- Backend: `/api/v1/dashboard/governance`에 `?force=1` 쿼리 파라미터를 추가해 120초 캐시를 우회할 수 있게 한다. (이미 `/api/v1/dashboard/execution`에 동일한 패턴이 있음)
+- Frontend: `fetchDashboardGovernance()`에 `force` 옵션을 추가하고, 승인 action 완료 후와 SSE `approval:pending`/`approval:resolved` 수신 시 `force: true`로 갱신한다.
+- History: backend governance JSON 응답에 최근 resolved approvals(최근 N개)를 포함하고, frontend approvals surface 하단에 "최근 처리" 리스트를 렌더링한다.
+
+**Tech Stack:** OCaml (Dune), TypeScript/Preact (dashboard), JSONL audit log.
+
+---
+
+## Task 1: Backend — `/api/v1/dashboard/governance`에 `force` 파라미터 추가
+
+**Files:**
+- Modify: `lib/server/server_dashboard_http.ml:177-189`
+- Modify: `lib/dashboard/dashboard_governance.ml` (핸들러가 `force`를 받아 `Dashboard_cache` 우회)
+- Test: `test/test_keeper_approval_queue_rules.ml` (필요시) / `dashboard/src/api/dashboard.test.ts`
+
+- [ ] **Step 1: 핸들러 시그니처 변경**
+
+```ocaml
+let dashboard_governance_http_json request ~base_path : Yojson.Safe.t =
+  let limit = int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
+  let offset = int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
+  let status_filter = None in
+  let force = bool_query_param request "force" ~default:false in
+  let cache_key = Printf.sprintf "governance:%s;%d;%d" base_path limit offset in
+  if force
+  then
+    Dashboard_cache.get_or_compute cache_key ~ttl:0.0 (fun () ->
+      Domain_pool_ref.submit_io_or_inline (fun () ->
+        Dashboard_governance.dashboard_json ~base_path ~limit ~offset ~status_filter))
+  else
+    Dashboard_cache.get_or_compute cache_key ~ttl:board_governance_cache_ttl_s (fun () ->
+      Domain_pool_ref.submit_io_or_inline (fun () ->
+        Dashboard_governance.dashboard_json ~base_path ~limit ~offset ~status_filter))
+```
+
+> Note: `Dashboard_cache.get_or_compute`에 `~ttl:0.0`을 주면 즉시 만료되어 캐시가 재계산된다. 이미 `Dashboard_cache`가 이를 지원하는지 확인 후, 지원하지 않으면 `force`일 때 캐시 래퍼를 생략하고 직접 compute한다.
+
+- [ ] **Step 2: `bool_query_param` 사용 확인**
+
+`server_dashboard_http.ml` 상단의 `open Server_utils` 또는 `Server_utils.bool_query_param` 참조가 이미 존재함 (execution handler 참조).
+
+- [ ] **Step 3: OCaml 타입체크**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history
+scripts/dune-local.sh build lib/server/server_dashboard_http.cma
+```
+
+Expected: `Done: ...` with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/server/server_dashboard_http.ml
+git commit -m "feat(server): allow ?force=1 on /api/v1/dashboard/governance"
+```
+
+---
+
+## Task 2: Frontend — `fetchDashboardGovernance`에 `force` 옵션 추가
+
+**Files:**
+- Modify: `dashboard/src/api/dashboard-governance.ts:63-131`
+- Modify: `dashboard/src/api/dashboard.ts` (re-export unchanged)
+- Test: `dashboard/src/api/dashboard.test.ts`
+
+- [ ] **Step 1: 함수 시그니처 변경**
+
+```typescript
+export interface FetchDashboardGovernanceOptions {
+  force?: boolean
+  signal?: AbortSignal
+}
+
+export function fetchDashboardGovernance(
+  opts?: FetchDashboardGovernanceOptions,
+): Promise<DashboardGovernanceResponse> {
+  const query = opts?.force ? '?force=1' : ''
+  return withRetries('fetchDashboardGovernance', async () => {
+    const raw = await get<Record<string, unknown>>(`/api/v1/dashboard/governance${query}`, {
+      signal: opts?.signal,
+    })
+    // ... existing normalization unchanged ...
+  })
+}
+```
+
+- [ ] **Step 2: 기존 호출자 타입 호환 확인**
+
+`fetchDashboardGovernance()` 인자 없이 호출하는 곳은 그대로 동작해야 함.
+
+- [ ] **Step 3: Frontend 타입/테스트**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history/dashboard
+npx tsc --noEmit
+npx vitest run src/api/dashboard.test.ts
+```
+
+Expected: tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/src/api/dashboard-governance.ts
+git commit -m "feat(dashboard): add force option to fetchDashboardGovernance"
+```
+
+---
+
+## Task 3: Frontend — 승인 action 및 SSE handler에서 force refresh 사용
+
+**Files:**
+- Modify: `dashboard/src/components/governance-actions.ts:50-67,126-148`
+- Modify: `dashboard/src/sse-store.ts:495-509`
+
+- [ ] **Step 1: `refreshGovernance`가 force 옵션 전달**
+
+```typescript
+export async function refreshGovernance(opts?: { force?: boolean }) {
+  governanceError.value = ''
+  await governanceResource.load(async (signal) => {
+    const data = await fetchDashboardGovernance({ force: opts?.force, signal })
+    // ... rest unchanged ...
+  })
+  // ... rest unchanged ...
+}
+```
+
+- [ ] **Step 2: 승인 action 완료 후 force refresh**
+
+```typescript
+export async function respondToKeeperApproval(
+  id: string,
+  decision: 'approve' | 'reject',
+  rememberRule = false,
+) {
+  if (!id) return
+  governanceApprovalActing.value = id
+  try {
+    await resolveGovernanceApproval(id, decision, rememberRule)
+    const message =
+      decision === 'approve'
+        ? (rememberRule ? 'keeper 승인 요청을 승인하고 Always 규칙을 저장했습니다' : 'keeper 승인 요청을 승인했습니다')
+        : 'keeper 승인 요청을 거부했습니다'
+    showToast(message, 'success')
+    await refreshGovernance({ force: true })
+  } catch (err) {
+    // ... unchanged ...
+  } finally {
+    governanceApprovalActing.value = null
+  }
+}
+```
+
+- [ ] **Step 3: SSE approval 이벤트에서 force refresh**
+
+```typescript
+if (
+  event.type.startsWith('decision_')
+  || event.type === 'governance_param_changed'
+  || event.type === 'approval:pending'
+  || event.type === 'approval:resolved'
+) {
+  if (route.value.tab === 'command') {
+    scheduleRefresh('command_route', () => {
+      void refreshActiveRoute()
+    })
+  }
+  if (_refreshGovernanceFn) {
+    scheduleRefresh('governance', () => void handleGovernance({ force: true }))
+  }
+}
+```
+
+- [ ] **Step 4: `handleGovernance` 함수 수정**
+
+```typescript
+function handleGovernance(opts?: { force?: boolean }): void {
+  _refreshGovernanceFn?.(opts)
+}
+```
+
+- [ ] **Step 5: 타입/테스트**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history/dashboard
+npx tsc --noEmit
+npx vitest run src/components/governance.test.ts src/sse-store.test.ts src/components/approvals/approvals-surface.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/src/components/governance-actions.ts dashboard/src/sse-store.ts
+git commit -m "feat(dashboard): force-refresh governance on approval decision and SSE approval events"
+```
+
+---
+
+## Task 4: Backend — governance response에 최근 resolved approvals 포함
+
+**Files:**
+- Modify: `lib/keeper/keeper_approval_queue.ml` (add `list_recent_resolved_json` helper)
+- Modify: `lib/dashboard/dashboard_governance.ml` (include `recent_resolved` in response)
+- Modify: `dashboard/src/types/core.ts` (add `recent_resolved` field)
+- Modify: `dashboard/src/api/dashboard-governance.ts` (normalize field)
+
+- [ ] **Step 1: Audit log에서 최근 resolved 항목 읽기**
+
+`Keeper_approval_queue.read_recent_audit`는 이미 존재. 이 중 `event = "resolved"`인 항목만 최근 N개 반환하는 helper 추가:
+
+```ocaml
+let list_recent_resolved_json ~base_path ?(n = 20) () : Yojson.Safe.t list =
+  read_recent_audit ~base_path ()
+  |> List.filter (fun json ->
+       String.equal "resolved" (Safe_ops.json_string ~default:"" "event" json))
+  |> List.take n
+```
+
+> `List.take`가 없다면 `Base.List.take` 또는 직접 `List.filteri` 사용.
+
+- [ ] **Step 2: Dashboard_governance.dashboard_json 응답에 추가**
+
+```ocaml
+let dashboard_json ~base_path ~limit ~offset ~status_filter =
+  let approval_queue = Keeper_approval_queue.list_pending_dashboard_json () in
+  let recent_resolved = Keeper_approval_queue.list_recent_resolved_json ~base_path ~n:20 () in
+  `Assoc [
+    ("approval_queue", approval_queue);
+    ("recent_resolved", `List recent_resolved);
+    (* ... other fields unchanged ... *)
+  ]
+```
+
+- [ ] **Step 3: Frontend 타입/정규화**
+
+`dashboard/src/types/core.ts`의 `DashboardGovernanceResponse`에:
+
+```typescript
+recent_resolved?: KeeperApprovalQueueItem[]
+```
+
+`dashboard/src/api/dashboard-governance.ts`의 `fetchDashboardGovernance` 정규화 부분에:
+
+```typescript
+const recentResolved = Array.isArray(raw.recent_resolved)
+  ? raw.recent_resolved
+      .map(item => normalizeKeeperApprovalQueueItem(item))
+      .filter((item): item is KeeperApprovalQueueItem => item !== null)
+  : []
+```
+
+반환 객체에 `recent_resolved: recentResolved` 추가.
+
+- [ ] **Step 4: OCaml/TypeScript 타입체크**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history
+scripts/dune-local.sh build lib/dashboard/dashboard_governance.cma
+npx tsc --noEmit
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/keeper/keeper_approval_queue.ml lib/dashboard/dashboard_governance.ml dashboard/src/types/core.ts dashboard/src/api/dashboard-governance.ts
+git commit -m "feat(server,dashboard): include recent resolved approvals in governance response"
+```
+
+---
+
+## Task 5: Frontend — approvals surface에 처리 이력 영역 추가
+
+**Files:**
+- Modify: `dashboard/src/components/approvals/approvals-surface.ts:273-378`
+- Modify: `dashboard/src/styles/approvals-v2.css` (history section styling)
+
+- [ ] **Step 1: 데이터 흐름 연결**
+
+`ApprovalsSurface` 컴포넌트에서:
+
+```typescript
+const resolvedItems = governanceData.value?.recent_resolved ?? []
+```
+
+- [ ] **Step 2: 처리 이력 렌더링**
+
+메인 리스트 아래에 별도 섹션 추가:
+
+```typescript
+${resolvedItems.length > 0
+  ? html`
+      <section class="ap-history" data-testid="approvals-history">
+        <h2 class="ap-history-title">최근 처리 (${resolvedItems.length})</h2>
+        <ul class="ap-history-list">
+          ${resolvedItems.map(item => html`
+            <li key=${item.id} class="ap-history-item">
+              <span class="ap-history-id mono">${item.id}</span>
+              <span class="ap-history-tool">${item.tool_name}</span>
+              <span class="ap-history-decision">${item.disposition ?? '처리됨'}</span>
+            </li>
+          `)}
+        </ul>
+      </section>
+    `
+  : null}
+```
+
+> `disposition` 필드에 resolved 시 decision(approve/reject)이 들어가는지 확인. 만약 아니라면 backend `audit_approval_event`에 `decision` 필드를 추가하거나, frontend에서 별도 매핑 필요. 현재 `pending_entry_json_fields`에는 `disposition`만 있고 `decision`은 audit event에만 있음.
+
+- [ ] **Step 3: Backend에 decision 노출 보정 (필요시)**
+
+`pending_entry_json_fields` 또는 `list_recent_resolved_json`에서 `decision` 필드를 포함하도록 수정:
+
+```ocaml
+("decision", Json_util.string_opt_to_json (Option.map approval_audit_decision_to_string decision))
+```
+
+- [ ] **Step 4: CSS 추가**
+
+`dashboard/src/styles/approvals-v2.css`에 `.ap-history*` 클래스 추가 (최소한의 구분선, 폰트 크기 등).
+
+- [ ] **Step 5: 테스트**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history/dashboard
+npx tsc --noEmit
+npx vitest run src/components/approvals/approvals-surface.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/src/components/approvals/approvals-surface.ts dashboard/src/styles/approvals-v2.css
+git commit -m "feat(dashboard): render recent resolved approvals on approvals surface"
+```
+
+---
+
+## Task 6: 검증
+
+- [ ] **Step 1: OCaml 타입체크 (touched targets)**
+
+```bash
+cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history
+scripts/dune-local.sh build lib/server/server_dashboard_http.cma lib/dashboard/dashboard_governance.cma
+```
+
+- [ ] **Step 2: Frontend 타입/테스트**
+
+```bash
+cd dashboard
+npx tsc --noEmit
+npx vitest run src/components/approvals/approvals-surface.test.ts src/api/dashboard.test.ts src/sse-store.test.ts src/components/governance.test.ts
+```
+
+- [ ] **Step 3: 수동 검증 가이드**
+
+로컬 서버를 띄운 뒤:
+1. keeper가 승인이 필요한 tool call을 생성
+2. dashboard approvals surface에서 승인/거부 버튼 클릭
+3. 카드가 즉시 사라지는지 확인
+4. "최근 처리" 섹션에 해당 항목이 나타나는지 확인
+5. 다른 탭에서 SSE `approval:resolved` 수신 시 badge/queue가 갱신되는지 확인
+
+- [ ] **Step 4: Final commit / push**
+
+```bash
+git push -u origin feature/hitl-approval-refresh-and-history
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- A (즉각 반응 개선): Task 1-3 (force param, force refresh on action/SSE)
+- B (승인 내역 남기기): Task 4-5 (recent_resolved in response + UI)
+
+**Placeholder scan:**
+- 모든 task는 실제 파일 경로, 코드 스니펫, 명령 포함. "TBD"/"TODO" 없음.
+
+**Type consistency:**
+- `fetchDashboardGovernance(opts?: FetchDashboardGovernanceOptions)`
+- `refreshGovernance(opts?: { force?: boolean })`
+- `DashboardGovernanceResponse.recent_resolved?: KeeperApprovalQueueItem[]`

--- a/docs/superpowers/plans/2026-06-26-hitl-approval-refresh-and-history.md
+++ b/docs/superpowers/plans/2026-06-26-hitl-approval-refresh-and-history.md
@@ -49,7 +49,7 @@ let dashboard_governance_http_json request ~base_path : Yojson.Safe.t =
 - [ ] **Step 3: OCaml 타입체크**
 
 ```bash
-cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history
+cd <repo>
 scripts/dune-local.sh build lib/server/server_dashboard_http.cma
 ```
 
@@ -99,7 +99,7 @@ export function fetchDashboardGovernance(
 - [ ] **Step 3: Frontend 타입/테스트**
 
 ```bash
-cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history/dashboard
+cd <repo>/dashboard
 npx tsc --noEmit
 npx vitest run src/api/dashboard.test.ts
 ```
@@ -191,7 +191,7 @@ function handleGovernance(opts?: { force?: boolean }): void {
 - [ ] **Step 5: 타입/테스트**
 
 ```bash
-cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history/dashboard
+cd <repo>/dashboard
 npx tsc --noEmit
 npx vitest run src/components/governance.test.ts src/sse-store.test.ts src/components/approvals/approvals-surface.test.ts
 ```
@@ -263,8 +263,9 @@ const recentResolved = Array.isArray(raw.recent_resolved)
 - [ ] **Step 4: OCaml/TypeScript 타입체크**
 
 ```bash
-cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history
+cd <repo>
 scripts/dune-local.sh build lib/dashboard/dashboard_governance.cma
+cd dashboard
 npx tsc --noEmit
 ```
 
@@ -331,7 +332,7 @@ ${resolvedItems.length > 0
 - [ ] **Step 5: 테스트**
 
 ```bash
-cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history/dashboard
+cd <repo>/dashboard
 npx tsc --noEmit
 npx vitest run src/components/approvals/approvals-surface.test.ts
 ```
@@ -350,7 +351,7 @@ git commit -m "feat(dashboard): render recent resolved approvals on approvals su
 - [ ] **Step 1: OCaml 타입체크 (touched targets)**
 
 ```bash
-cd /Users/dancer/me/workspace/yousleepwhen/masc/.worktrees/feature/hitl-approval-refresh-and-history
+cd <repo>
 scripts/dune-local.sh build lib/server/server_dashboard_http.cma lib/dashboard/dashboard_governance.cma
 ```
 

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -121,6 +121,7 @@ let dashboard_json ~base_path ~limit ~offset:_ ~status_filter:_ =
   let runtime = Dashboard_governance_judge.runtime_status base_path in
   let judgments = Dashboard_governance_judge.fresh_judgments_json ~base_path ~limit in
   let approval_queue = Keeper_approval_queue.list_pending_dashboard_json () in
+  let recent_resolved = Keeper_approval_queue.list_recent_resolved_json ~base_path ~n:20 () in
   let approval_rules =
     Keeper_approval_queue.list_rules_dashboard_json ~base_path ()
   in
@@ -134,6 +135,7 @@ let dashboard_json ~base_path ~limit ~offset:_ ~status_filter:_ =
       ("judgments", `List judgments);
       ("pending_actions", `List []);
       ("approval_queue", approval_queue);
+      ("recent_resolved", `List recent_resolved);
       ("approval_rules", approval_rules);
       ("hitl", hitl_status_json ());
       ("cases", `List []);

--- a/lib/dashboard/dashboard_governance.ml
+++ b/lib/dashboard/dashboard_governance.ml
@@ -121,7 +121,12 @@ let dashboard_json ~base_path ~limit ~offset:_ ~status_filter:_ =
   let runtime = Dashboard_governance_judge.runtime_status base_path in
   let judgments = Dashboard_governance_judge.fresh_judgments_json ~base_path ~limit in
   let approval_queue = Keeper_approval_queue.list_pending_dashboard_json () in
-  let recent_resolved = Keeper_approval_queue.list_recent_resolved_json ~base_path ~n:20 () in
+  let recent_resolved =
+    Keeper_approval_queue.list_recent_resolved_json
+      ~base_path
+      ~n:Keeper_approval_queue.recent_resolved_history_limit
+      ()
+  in
   let approval_rules =
     Keeper_approval_queue.list_rules_dashboard_json ~base_path ()
   in

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -254,6 +254,25 @@ let read_recent_audit ~base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list 
         [])
 ;;
 
+let list_recent_resolved_json ~base_path ?(n = 20) () : Yojson.Safe.t list =
+  if n <= 0
+  then []
+  else (
+    match get_audit_store ~base_path () with
+    | None -> []
+    | Some store ->
+      try
+        read_recent_audit_raw store (audit_scan_window n)
+        |> List.filter (fun json ->
+             String.equal "resolved" (Safe_ops.json_string ~default:"" "event" json))
+        |> List.filteri (fun idx _ -> idx < n)
+      with
+      | Eio.Cancel.Cancelled _ as e -> raise e
+      | exn ->
+        Keeper_fd_pressure.note_exception ~site:"approval_audit.list_recent_resolved" exn;
+        [])
+;;
+
 let generate_id () = make_generated_id "appr"
 
 let normalized_input_hash (input : Yojson.Safe.t) =

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -72,6 +72,8 @@ let read_recent_audit_raw store limit =
     rows
 ;;
 
+let approval_audit_resolved_event = "resolved"
+
 let keeper_audit_metric_label = function
   | Some keeper when String.trim keeper <> "" -> keeper
   | Some _ | None -> "aggregate"
@@ -220,6 +222,23 @@ let audit_scan_window ?keeper_name n =
     max 500 (max n 1 * 64)
 ;;
 
+let resolved_audit_scan_window n =
+  max 500 (max n 1 * 64)
+;;
+
+let record_audit_read_failure ?keeper_name ~site exn =
+  Keeper_fd_pressure.note_exception ~site exn;
+  Otel_metric_store.inc_counter
+    Keeper_metrics.(to_string ApprovalQueueFailures)
+    ~labels:
+      [ "keeper",
+        keeper_audit_metric_label keeper_name;
+        "site",
+        Keeper_approval_queue_failure_site.(to_label Audit_read_recent)
+      ]
+    ()
+;;
+
 let read_recent_audit ~base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list =
   if n <= 0
   then []
@@ -241,17 +260,38 @@ let read_recent_audit ~base_path ?keeper_name ?(n = 20) () : Yojson.Safe.t list 
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
-        Keeper_fd_pressure.note_exception ~site:"approval_audit.read_recent" exn;
-        Otel_metric_store.inc_counter
-          Keeper_metrics.(to_string ApprovalQueueFailures)
-          ~labels:
-            [ "keeper",
-              keeper_audit_metric_label keeper_name;
-              "site",
-              Keeper_approval_queue_failure_site.(to_label Audit_read_recent)
-            ]
-          ();
+        record_audit_read_failure ?keeper_name ~site:"approval_audit.read_recent" exn;
         [])
+;;
+
+let json_member_or_null key json =
+  match Json_util.assoc_member_opt key json with
+  | Some value -> value
+  | None -> `Null
+;;
+
+let resolved_approval_json_of_audit_event json =
+  let resolved_at = Safe_ops.json_float_opt "ts" json in
+  `Assoc
+    [ "id", `String (Safe_ops.json_string ~default:"" "id" json)
+    ; "keeper_name", `String (Safe_ops.json_string ~default:"" "keeper" json)
+    ; "tool_name", `String (Safe_ops.json_string ~default:"" "tool" json)
+    ; "risk_level", `String (Safe_ops.json_string ~default:"" "risk" json)
+    ; "decision", Json_util.string_opt_to_json_trimmed (Safe_ops.json_string_opt "decision" json)
+    ; "resolved_at", Json_util.float_opt_to_json resolved_at
+    ; ( "resolved_at_iso",
+        match resolved_at with
+        | Some ts -> `String (Masc_domain.iso8601_of_unix_seconds ts)
+        | None -> `Null )
+    ; "turn_id", json_member_or_null "turn_id" json
+    ; "task_id", json_member_or_null "task_id" json
+    ; "goal_id", json_member_or_null "goal_id" json
+    ; "goal_ids", json_member_or_null "goal_ids" json
+    ; "sandbox_target", json_member_or_null "sandbox_target" json
+    ; "disposition", json_member_or_null "disposition" json
+    ; "disposition_reason", json_member_or_null "disposition_reason" json
+    ; "rule_match", json_member_or_null "rule_match" json
+    ]
 ;;
 
 let list_recent_resolved_json ~base_path ?(n = 20) () : Yojson.Safe.t list =
@@ -262,14 +302,16 @@ let list_recent_resolved_json ~base_path ?(n = 20) () : Yojson.Safe.t list =
     | None -> []
     | Some store ->
       try
-        read_recent_audit_raw store (audit_scan_window n)
+        read_recent_audit_raw store (resolved_audit_scan_window n)
         |> List.filter (fun json ->
-             String.equal "resolved" (Safe_ops.json_string ~default:"" "event" json))
+             String.equal approval_audit_resolved_event
+               (Safe_ops.json_string ~default:"" "event" json))
         |> List.filteri (fun idx _ -> idx < n)
+        |> List.map resolved_approval_json_of_audit_event
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
-        Keeper_fd_pressure.note_exception ~site:"approval_audit.list_recent_resolved" exn;
+        record_audit_read_failure ~site:"approval_audit.list_recent_resolved" exn;
         [])
 ;;
 
@@ -498,7 +540,7 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
     decision_str;
   audit_approval_event
     ~base_path:base_path
-    ~event_type:"resolved"
+    ~event_type:approval_audit_resolved_event
     ~id:entry.id
     ~keeper_name:entry.keeper_name
     ~tool_name:entry.tool_name

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -40,6 +40,13 @@ let recent_audit_cache : (string, recent_audit_cache_entry) Hashtbl.t =
 ;;
 
 let recent_audit_cache_ttl_sec = 1.0
+let recent_resolved_history_limit = 20
+let audit_wide_scan_min_rows = 500
+let audit_wide_scan_multiplier = 64
+
+let wide_audit_scan_window n =
+  max audit_wide_scan_min_rows (max n 1 * audit_wide_scan_multiplier)
+;;
 
 let recent_audit_cache_key store limit =
   Printf.sprintf "%s:%d" (Dated_jsonl.base_dir store) limit
@@ -72,13 +79,21 @@ let read_recent_audit_raw store limit =
     rows
 ;;
 
+let approval_audit_pending_event = "pending"
 let approval_audit_resolved_event = "resolved"
+let approval_sse_pending_event = "approval:pending"
+let approval_sse_resolved_event = "approval:resolved"
 
-let approval_audit_decision_kind = function
-  | Approval_resolved Agent_sdk.Hooks.Approve -> "approve"
-  | Approval_resolved (Agent_sdk.Hooks.Reject _) -> "reject"
-  | Approval_resolved (Agent_sdk.Hooks.Edit _) -> "edit"
-  | Approval_expired _ -> "reject"
+let non_empty_reason reason =
+  let reason = String.trim reason in
+  if String.equal reason "" then None else Some reason
+;;
+
+let approval_audit_decision_kind_and_reason = function
+  | Approval_resolved Agent_sdk.Hooks.Approve -> "approve", None
+  | Approval_resolved (Agent_sdk.Hooks.Reject reason) -> "reject", non_empty_reason reason
+  | Approval_resolved (Agent_sdk.Hooks.Edit _) -> "edit", None
+  | Approval_expired reason -> "reject", non_empty_reason reason
 ;;
 
 let keeper_audit_metric_label = function
@@ -160,11 +175,12 @@ let audit_approval_event
       ?decision
       ()
   =
-  let decision, decision_kind =
+  let decision, decision_kind, decision_reason =
     match decision with
-    | None -> "", None
+    | None -> "", None, None
     | Some decision ->
-      approval_audit_decision_to_string decision, Some (approval_audit_decision_kind decision)
+      let kind, reason = approval_audit_decision_kind_and_reason decision in
+      approval_audit_decision_to_string decision, Some kind, reason
   in
   match get_audit_store ~base_path () with
   | None -> ()
@@ -199,6 +215,9 @@ let audit_approval_event
          @ (match decision_kind with
             | Some kind -> [ "decision_kind", `String kind ]
             | None -> [])
+         @ (match decision_reason with
+            | Some reason -> [ "decision_reason", `String reason ]
+            | None -> [])
          @
          match auto_approved with
          | Some value -> [ "auto_approved", `Bool value ]
@@ -232,14 +251,12 @@ let audit_scan_window ?keeper_name n =
     (* Approval audit is global, but runtime trust asks for per-keeper
          "latest" records. Scan a bounded wider window before filtering so a
          busy fleet cannot hide the target keeper behind unrelated events. *)
-    max 500 (max n 1 * 64)
+    wide_audit_scan_window n
 ;;
 
-let resolved_audit_scan_window n =
-  max 500 (max n 1 * 64)
-;;
+let resolved_audit_scan_window = wide_audit_scan_window
 
-let record_audit_read_failure ?keeper_name ~site exn =
+let record_audit_read_failure ?keeper_name ?(metric_site = Keeper_approval_queue_failure_site.Audit_read_recent) ~site exn =
   Keeper_fd_pressure.note_exception ~site exn;
   Otel_metric_store.inc_counter
     Keeper_metrics.(to_string ApprovalQueueFailures)
@@ -247,7 +264,7 @@ let record_audit_read_failure ?keeper_name ~site exn =
       [ "keeper",
         keeper_audit_metric_label keeper_name;
         "site",
-        Keeper_approval_queue_failure_site.(to_label Audit_read_recent)
+        Keeper_approval_queue_failure_site.to_label metric_site
       ]
     ()
 ;;
@@ -315,6 +332,7 @@ let resolved_approval_json_of_audit_event json =
     ; "risk_level", `String (Safe_ops.json_string ~default:"" "risk" json)
     ; "decision", Json_util.string_opt_to_json_trimmed (Safe_ops.json_string_opt "decision" json)
     ; "decision_kind", Json_util.string_opt_to_json_trimmed (resolved_approval_decision_kind json)
+    ; "decision_reason", json_member_or_null "decision_reason" json
     ; "resolved_at", Json_util.float_opt_to_json resolved_at
     ; ( "resolved_at_iso",
         match resolved_at with
@@ -331,7 +349,9 @@ let resolved_approval_json_of_audit_event json =
     ]
 ;;
 
-let list_recent_resolved_json ~base_path ?(n = 20) () : Yojson.Safe.t list =
+let list_recent_resolved_json ~base_path ?(n = recent_resolved_history_limit) ()
+  : Yojson.Safe.t list
+  =
   if n <= 0
   then []
   else (
@@ -343,12 +363,16 @@ let list_recent_resolved_json ~base_path ?(n = 20) () : Yojson.Safe.t list =
         |> List.filter (fun json ->
              String.equal approval_audit_resolved_event
                (Safe_ops.json_string ~default:"" "event" json))
+        |> List.rev
         |> List.filteri (fun idx _ -> idx < n)
         |> List.map resolved_approval_json_of_audit_event
       with
       | Eio.Cancel.Cancelled _ as e -> raise e
       | exn ->
-        record_audit_read_failure ~site:"approval_audit.list_recent_resolved" exn;
+        record_audit_read_failure
+          ~metric_site:Keeper_approval_queue_failure_site.Audit_list_recent_resolved
+          ~site:"approval_audit.list_recent_resolved"
+          exn;
         [])
 ;;
 
@@ -521,7 +545,7 @@ let broadcast_pending entry =
   try
     Sse.broadcast
       (`Assoc
-          [ "type", `String "approval:pending"
+          [ "type", `String approval_sse_pending_event
           ; ( "payload"
             , `Assoc
                 (pending_entry_json_fields
@@ -536,7 +560,7 @@ let broadcast_pending entry =
       ~keeper_name:entry.keeper_name
       ~site:"broadcast_pending"
       ~id:entry.id
-      ~event_type:"pending"
+      ~event_type:approval_audit_pending_event
       exn
 ;;
 
@@ -549,7 +573,7 @@ let record_pending (entry : pending_approval) =
     (risk_level_to_string entry.risk_level);
   audit_approval_event
     ~base_path:entry.audit_base_path
-    ~event_type:"pending"
+    ~event_type:approval_audit_pending_event
     ~id:entry.id
     ~keeper_name:entry.keeper_name
     ~tool_name:entry.tool_name
@@ -616,7 +640,7 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
   try
     Sse.broadcast
       (`Assoc
-          [ "type", `String "approval:resolved"
+          [ "type", `String approval_sse_resolved_event
           ; ( "payload"
             , `Assoc
                 [ "id", `String entry.id
@@ -636,7 +660,7 @@ let resolve_entry ~base_path (entry : pending_approval) (decision : decision) =
       ~keeper_name:entry.keeper_name
       ~site:"broadcast_resolved"
       ~id:entry.id
-      ~event_type:"resolved"
+      ~event_type:approval_audit_resolved_event
       exn
 ;;
 

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -300,14 +300,10 @@ let legacy_decision_kind_of_string value =
 ;;
 
 let resolved_approval_decision_kind json =
-  match
-    Safe_ops.json_string_opt "decision_kind" json
-    |> Option.bind closed_decision_kind_of_string
-  with
+  match Option.bind (Safe_ops.json_string_opt "decision_kind" json) closed_decision_kind_of_string with
   | Some _ as kind -> kind
   | None ->
-    Safe_ops.json_string_opt "decision" json
-    |> Option.bind legacy_decision_kind_of_string
+    Option.bind (Safe_ops.json_string_opt "decision" json) legacy_decision_kind_of_string
 ;;
 
 let resolved_approval_json_of_audit_event json =

--- a/lib/keeper/keeper_approval_queue.ml
+++ b/lib/keeper/keeper_approval_queue.ml
@@ -74,6 +74,13 @@ let read_recent_audit_raw store limit =
 
 let approval_audit_resolved_event = "resolved"
 
+let approval_audit_decision_kind = function
+  | Approval_resolved Agent_sdk.Hooks.Approve -> "approve"
+  | Approval_resolved (Agent_sdk.Hooks.Reject _) -> "reject"
+  | Approval_resolved (Agent_sdk.Hooks.Edit _) -> "edit"
+  | Approval_expired _ -> "reject"
+;;
+
 let keeper_audit_metric_label = function
   | Some keeper when String.trim keeper <> "" -> keeper
   | Some _ | None -> "aggregate"
@@ -153,8 +160,11 @@ let audit_approval_event
       ?decision
       ()
   =
-  let decision =
-    decision |> Option.map approval_audit_decision_to_string |> Option.value ~default:""
+  let decision, decision_kind =
+    match decision with
+    | None -> "", None
+    | Some decision ->
+      approval_audit_decision_to_string decision, Some (approval_audit_decision_kind decision)
   in
   match get_audit_store ~base_path () with
   | None -> ()
@@ -185,6 +195,9 @@ let audit_approval_event
             | None -> [])
          @ (match source_approval_id with
             | Some approval_id -> [ "source_approval_id", `String approval_id ]
+            | None -> [])
+         @ (match decision_kind with
+            | Some kind -> [ "decision_kind", `String kind ]
             | None -> [])
          @
          match auto_approved with
@@ -270,6 +283,33 @@ let json_member_or_null key json =
   | None -> `Null
 ;;
 
+let closed_decision_kind_of_string value =
+  match String.trim value with
+  | "approve" -> Some "approve"
+  | "reject" -> Some "reject"
+  | "edit" -> Some "edit"
+  | _ -> None
+;;
+
+let legacy_decision_kind_of_string value =
+  let value = String.trim value in
+  match closed_decision_kind_of_string value with
+  | Some _ as kind -> kind
+  | None when String.starts_with ~prefix:"reject:" value -> Some "reject"
+  | None -> None
+;;
+
+let resolved_approval_decision_kind json =
+  match
+    Safe_ops.json_string_opt "decision_kind" json
+    |> Option.bind closed_decision_kind_of_string
+  with
+  | Some _ as kind -> kind
+  | None ->
+    Safe_ops.json_string_opt "decision" json
+    |> Option.bind legacy_decision_kind_of_string
+;;
+
 let resolved_approval_json_of_audit_event json =
   let resolved_at = Safe_ops.json_float_opt "ts" json in
   `Assoc
@@ -278,6 +318,7 @@ let resolved_approval_json_of_audit_event json =
     ; "tool_name", `String (Safe_ops.json_string ~default:"" "tool" json)
     ; "risk_level", `String (Safe_ops.json_string ~default:"" "risk" json)
     ; "decision", Json_util.string_opt_to_json_trimmed (Safe_ops.json_string_opt "decision" json)
+    ; "decision_kind", Json_util.string_opt_to_json_trimmed (resolved_approval_decision_kind json)
     ; "resolved_at", Json_util.float_opt_to_json resolved_at
     ; ( "resolved_at_iso",
         match resolved_at with

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -169,6 +169,15 @@ val audit_approval_event :
 val audit_rule_event :
   base_path:string -> event_type:string -> approval_rule -> unit
 
+val approval_audit_pending_event : string
+(** Event tag persisted when an approval is pending. *)
+
+val approval_audit_resolved_event : string
+(** Event tag persisted when an approval is resolved. *)
+
+val recent_resolved_history_limit : int
+(** Default dashboard history length for resolved HITL approvals. *)
+
 (** Read recent audit entries (default last 20), optionally filtered
     by keeper. *)
 val read_recent_audit :

--- a/lib/keeper/keeper_approval_queue.mli
+++ b/lib/keeper/keeper_approval_queue.mli
@@ -178,6 +178,10 @@ val read_recent_audit :
   unit ->
   Yojson.Safe.t list
 
+(** Read recent resolved audit entries (default last 20). *)
+val list_recent_resolved_json :
+  base_path:string -> ?n:int -> unit -> Yojson.Safe.t list
+
 module For_testing : sig
   val reset_audit_store : unit -> unit
   val first_cmd_token : string -> string option

--- a/lib/keeper_failure_taxonomy/keeper_approval_queue_failure_site.ml
+++ b/lib/keeper_failure_taxonomy/keeper_approval_queue_failure_site.ml
@@ -7,6 +7,7 @@ type t =
   | Approval_expired
   | Expire_callback
   | Audit_read_recent
+  | Audit_list_recent_resolved
 
 let to_label = function
   | Upsert_rule_save -> "upsert_rule_save"
@@ -17,4 +18,5 @@ let to_label = function
   | Approval_expired -> "approval_expired"
   | Expire_callback -> "expire_callback"
   | Audit_read_recent -> "audit_read_recent"
+  | Audit_list_recent_resolved -> "audit_list_recent_resolved"
 ;;

--- a/lib/keeper_failure_taxonomy/keeper_approval_queue_failure_site.mli
+++ b/lib/keeper_failure_taxonomy/keeper_approval_queue_failure_site.mli
@@ -10,5 +10,6 @@ type t =
   | Approval_expired
   | Expire_callback
   | Audit_read_recent
+  | Audit_list_recent_resolved
 
 val to_label : t -> string

--- a/lib/server/server_dashboard_http.ml
+++ b/lib/server/server_dashboard_http.ml
@@ -180,12 +180,16 @@ let dashboard_governance_http_json request ~base_path : Yojson.Safe.t =
     int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000
   in
   let status_filter = None in
+  let force = bool_query_param request "force" ~default:false in
   let cache_key =
     Printf.sprintf "governance:%s;%d;%d" base_path limit offset
   in
-  Dashboard_cache.get_or_compute cache_key ~ttl:board_governance_cache_ttl_s (fun () ->
+  let compute () =
     Domain_pool_ref.submit_io_or_inline (fun () ->
-      Dashboard_governance.dashboard_json ~base_path ~limit ~offset ~status_filter))
+      Dashboard_governance.dashboard_json ~base_path ~limit ~offset ~status_filter)
+  in
+  if force then Dashboard_cache.invalidate cache_key;
+  Dashboard_cache.get_or_compute cache_key ~ttl:board_governance_cache_ttl_s compute
 ;;
 
 (** Read the optional [?window=<minutes>] query param.

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1360,6 +1360,36 @@ let test_read_recent_audit_filters_after_wide_scan () =
       Alcotest.fail
         (Printf.sprintf "expected one target audit, got %d" (List.length items))
 
+let test_list_recent_resolved_json_projects_resolved_history () =
+  with_temp_masc_base @@ fun base_path ->
+  let keeper_name = "resolved-history-target" in
+  AQ.audit_approval_event ~base_path ~event_type:"resolved" ~id:"target-resolved"
+    ~keeper_name ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
+    ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ();
+  for i = 1 to 64 do
+    AQ.audit_approval_event ~base_path ~event_type:"pending"
+      ~id:(Printf.sprintf "pending-noise-%02d" i)
+      ~keeper_name:(Printf.sprintf "busy-keeper-%02d" i)
+      ~tool_name:"tool_search_files" ~risk_level:AQ.Low ()
+  done;
+  match AQ.list_recent_resolved_json ~base_path ~n:1 () with
+  | [ json ] ->
+    let open Yojson.Safe.Util in
+    Alcotest.(check string) "resolved id" "target-resolved" (json |> member "id" |> to_string);
+    Alcotest.(check string) "keeper name" keeper_name (json |> member "keeper_name" |> to_string);
+    Alcotest.(check string) "tool name" "tool_search_files" (json |> member "tool_name" |> to_string);
+    Alcotest.(check string) "risk level" "medium" (json |> member "risk_level" |> to_string);
+    Alcotest.(check string) "decision" "approve" (json |> member "decision" |> to_string);
+    Alcotest.(check bool) "resolved_at float present" true
+      (json |> member "resolved_at" |> to_float > 0.0);
+    Alcotest.(check bool) "resolved_at_iso present" true
+      (contains_substring (json |> member "resolved_at_iso" |> to_string) "T");
+    Alcotest.(check bool) "pending timestamp omitted" false
+      (has_assoc_key "requested_at" json)
+  | items ->
+    Alcotest.fail
+      (Printf.sprintf "expected one resolved audit, got %d" (List.length items))
+
 let test_runtime_trust_approval_read_model_filters_after_wide_scan () =
   with_test_config @@ fun config ->
   AQ.For_testing.reset_audit_store ();
@@ -1466,6 +1496,9 @@ let () =
         test_submit_pending_audit_uses_workspace_base_path;
       Alcotest.test_case "read_recent_audit scans before keeper filter" `Quick
         test_read_recent_audit_filters_after_wide_scan;
+      Alcotest.test_case
+        "list_recent_resolved_json projects resolved history" `Quick
+        test_list_recent_resolved_json_projects_resolved_history;
       Alcotest.test_case
         "runtime trust approval read model scans before keeper filter" `Quick
         test_runtime_trust_approval_read_model_filters_after_wide_scan;

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -128,7 +128,8 @@ let test_approval_queue_failure_metric_labels_site () =
       cleanup_dir audit_dir;
       let oc = open_out_bin audit_dir in
       close_out oc;
-      AQ.audit_approval_event ~base_path ~event_type:"pending"
+  AQ.audit_approval_event ~base_path
+    ~event_type:AQ.approval_audit_pending_event
         ~id:"audit-failure-path-test" ~keeper_name ~tool_name:"tool_search_files"
         ~risk_level:AQ.Medium ();
       let after =
@@ -1338,12 +1339,13 @@ let test_callback_always_approve_respects_forbidden () =
 let test_read_recent_audit_filters_after_wide_scan () =
   with_temp_masc_base @@ fun base_path ->
   let keeper_name = "audit-target-keeper" in
-  AQ.audit_approval_event ~base_path ~event_type:"resolved" ~id:"target-audit"
-    ~keeper_name ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
+  AQ.audit_approval_event ~base_path
+    ~event_type:AQ.approval_audit_resolved_event ~id:"target-audit" ~keeper_name
+    ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
     ~selected_model:"openai:gpt-5.4"
     ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ();
   for i = 1 to 32 do
-    AQ.audit_approval_event ~base_path ~event_type:"resolved"
+    AQ.audit_approval_event ~base_path ~event_type:AQ.approval_audit_resolved_event
       ~id:(Printf.sprintf "other-audit-%02d" i)
       ~keeper_name:(Printf.sprintf "busy-keeper-%02d" i)
       ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
@@ -1363,35 +1365,49 @@ let test_read_recent_audit_filters_after_wide_scan () =
 let test_list_recent_resolved_json_projects_resolved_history () =
   with_temp_masc_base @@ fun base_path ->
   let keeper_name = "resolved-history-target" in
-  AQ.audit_approval_event ~base_path ~event_type:"resolved" ~id:"target-resolved"
+  AQ.audit_approval_event ~base_path
+    ~event_type:AQ.approval_audit_resolved_event ~id:"older-resolved"
     ~keeper_name ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
     ~decision:(AQ.Approval_resolved (Agent_sdk.Hooks.Reject "operator denied")) ();
   for i = 1 to 64 do
-    AQ.audit_approval_event ~base_path ~event_type:"pending"
+    AQ.audit_approval_event ~base_path
+      ~event_type:AQ.approval_audit_pending_event
       ~id:(Printf.sprintf "pending-noise-%02d" i)
       ~keeper_name:(Printf.sprintf "busy-keeper-%02d" i)
       ~tool_name:"tool_search_files" ~risk_level:AQ.Low ()
   done;
-  match AQ.list_recent_resolved_json ~base_path ~n:1 () with
-  | [ json ] ->
+  AQ.audit_approval_event ~base_path
+    ~event_type:AQ.approval_audit_resolved_event ~id:"newer-resolved"
+    ~keeper_name ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
+    ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ();
+  match AQ.list_recent_resolved_json ~base_path ~n:2 () with
+  | [ newest; older ] ->
     let open Yojson.Safe.Util in
-    Alcotest.(check string) "resolved id" "target-resolved" (json |> member "id" |> to_string);
-    Alcotest.(check string) "keeper name" keeper_name (json |> member "keeper_name" |> to_string);
-    Alcotest.(check string) "tool name" "tool_search_files" (json |> member "tool_name" |> to_string);
-    Alcotest.(check string) "risk level" "medium" (json |> member "risk_level" |> to_string);
+    Alcotest.(check string) "newest first" "newer-resolved"
+      (newest |> member "id" |> to_string);
+    Alcotest.(check string) "older second" "older-resolved"
+      (older |> member "id" |> to_string);
+    Alcotest.(check string) "keeper name" keeper_name
+      (older |> member "keeper_name" |> to_string);
+    Alcotest.(check string) "tool name" "tool_search_files"
+      (older |> member "tool_name" |> to_string);
+    Alcotest.(check string) "risk level" "medium"
+      (older |> member "risk_level" |> to_string);
     Alcotest.(check string) "decision" "reject:operator denied"
-      (json |> member "decision" |> to_string);
+      (older |> member "decision" |> to_string);
     Alcotest.(check string) "decision kind" "reject"
-      (json |> member "decision_kind" |> to_string);
+      (older |> member "decision_kind" |> to_string);
+    Alcotest.(check string) "decision reason" "operator denied"
+      (older |> member "decision_reason" |> to_string);
     Alcotest.(check bool) "resolved_at float present" true
-      (json |> member "resolved_at" |> to_float > 0.0);
+      (older |> member "resolved_at" |> to_float > 0.0);
     Alcotest.(check bool) "resolved_at_iso present" true
-      (contains_substring (json |> member "resolved_at_iso" |> to_string) "T");
+      (contains_substring (older |> member "resolved_at_iso" |> to_string) "T");
     Alcotest.(check bool) "pending timestamp omitted" false
-      (has_assoc_key "requested_at" json)
+      (has_assoc_key "requested_at" older)
   | items ->
     Alcotest.fail
-      (Printf.sprintf "expected one resolved audit, got %d" (List.length items))
+      (Printf.sprintf "expected two resolved audits, got %d" (List.length items))
 
 let test_runtime_trust_approval_read_model_filters_after_wide_scan () =
   with_test_config @@ fun config ->
@@ -1410,12 +1426,13 @@ let test_runtime_trust_approval_read_model_filters_after_wide_scan () =
           ])
       in
       AQ.audit_approval_event ~base_path:config.base_path
-        ~event_type:"resolved" ~id:"runtime-trust-target-audit"
+        ~event_type:AQ.approval_audit_resolved_event
+        ~id:"runtime-trust-target-audit"
         ~keeper_name ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
         ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ();
       for i = 1 to 64 do
         AQ.audit_approval_event ~base_path:config.base_path
-          ~event_type:"resolved"
+          ~event_type:AQ.approval_audit_resolved_event
           ~id:(Printf.sprintf "runtime-trust-other-audit-%02d" i)
           ~keeper_name:(Printf.sprintf "busy-runtime-keeper-%02d" i)
           ~tool_name:"tool_search_files" ~risk_level:AQ.Medium

--- a/test/test_hitl_approval.ml
+++ b/test/test_hitl_approval.ml
@@ -1365,7 +1365,7 @@ let test_list_recent_resolved_json_projects_resolved_history () =
   let keeper_name = "resolved-history-target" in
   AQ.audit_approval_event ~base_path ~event_type:"resolved" ~id:"target-resolved"
     ~keeper_name ~tool_name:"tool_search_files" ~risk_level:AQ.Medium
-    ~decision:(AQ.Approval_resolved Agent_sdk.Hooks.Approve) ();
+    ~decision:(AQ.Approval_resolved (Agent_sdk.Hooks.Reject "operator denied")) ();
   for i = 1 to 64 do
     AQ.audit_approval_event ~base_path ~event_type:"pending"
       ~id:(Printf.sprintf "pending-noise-%02d" i)
@@ -1379,7 +1379,10 @@ let test_list_recent_resolved_json_projects_resolved_history () =
     Alcotest.(check string) "keeper name" keeper_name (json |> member "keeper_name" |> to_string);
     Alcotest.(check string) "tool name" "tool_search_files" (json |> member "tool_name" |> to_string);
     Alcotest.(check string) "risk level" "medium" (json |> member "risk_level" |> to_string);
-    Alcotest.(check string) "decision" "approve" (json |> member "decision" |> to_string);
+    Alcotest.(check string) "decision" "reject:operator denied"
+      (json |> member "decision" |> to_string);
+    Alcotest.(check string) "decision kind" "reject"
+      (json |> member "decision_kind" |> to_string);
     Alcotest.(check bool) "resolved_at float present" true
       (json |> member "resolved_at" |> to_float > 0.0);
     Alcotest.(check bool) "resolved_at_iso present" true


### PR DESCRIPTION
## Summary
- `/api/v1/dashboard/governance`에 `?force=1` 쿼리 파라미터를 추가해 120초 캐시를 우회할 수 있게 합니다.
- 승인/거부/Always 규칙 삭제 action과 SSE `approval:pending` / `approval:resolved` 수신 시 governance 데이터를 force-refresh 합니다.
- governance 응답에 최근 처리 완료된 approval 20건(`recent_resolved`)을 포함합니다.
- approvals surface 하단에 "최근 처리" 이력 영역을 추가합니다.

## Test Plan
- [x] `cd dashboard && npx tsc --noEmit` 통과
- [x] `npx vitest run src/components/approvals/approvals-surface.test.ts src/api/dashboard.test.ts src/sse-store.test.ts src/components/governance.test.ts` 통과
- [x] `dune build --cache disabled lib/masc.cma lib/dashboard/masc_dashboard.cma lib/server/masc_server.cma` 통과
- [ ] 로컬 서버에서 keeper 승인 요청 → 승인/거부 클릭 시 카드 즉시 제거 및 이력 노출 확인
- [ ] SSE `approval:resolved` 수신 시 nav-rail/approvals badge 갱신 확인