### PR TITLE
fix(memory): add gc dry-run command

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -953,6 +953,57 @@ let init_cmd =
   let info = Cmd.info "init" ~doc in
   Cmd.v info Term.(const init_cmd_exit $ base_path $ init_force)
 
+let memory_os_gc_keeper =
+  let doc =
+    "Only dry-run the given keeper id. Repeatable. When omitted, all existing \
+     non-shared keeper fact stores are scanned."
+  in
+  Arg.(value & opt_all string [] & info ["keeper"] ~docv:"KEEPER" ~doc)
+
+let memory_os_gc_json =
+  let doc = "Emit machine-readable JSON instead of text output" in
+  Arg.(value & flag & info ["json"] ~doc)
+
+let memory_os_gc_dry_run_cmd_exit base_path keeper_ids as_json =
+  let base_path = Env_config.normalize_masc_base_path_input base_path in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path in
+  let report =
+    Eio_main.run
+    @@ fun env ->
+    let now = Eio.Time.now (Eio.Stdenv.clock env) in
+    match keeper_ids with
+    | [] ->
+      Masc.Keeper_memory_os_gc_dry_run_report.run_for_keepers_dir
+        ~keepers_dir
+        ~now
+        ()
+    | ids ->
+      Masc.Keeper_memory_os_gc_dry_run_report.run_for_keepers_dir
+        ~keepers_dir
+        ~keeper_ids:ids
+        ~now
+        ()
+  in
+  if as_json
+  then
+    print_endline
+      (Yojson.Safe.pretty_to_string
+         (Masc.Keeper_memory_os_gc_dry_run_report.to_json report))
+  else
+    print_string (Masc.Keeper_memory_os_gc_dry_run_report.render_text report);
+  if report.error_count > 0 then 1 else 0
+
+let memory_os_gc_dry_run_cmd =
+  let doc =
+    "Run the Memory OS fact-store GC in dry-run mode and print the TTL/dedup \
+     report without rewriting stores."
+  in
+  let info = Cmd.info "memory-os-gc-dry-run" ~doc in
+  Cmd.v info
+    Term.(
+      const memory_os_gc_dry_run_cmd_exit $ base_path $ memory_os_gc_keeper
+      $ memory_os_gc_json)
+
 let setup_gc () =
   (* OCaml 5 defaults to a 2 MiB minor heap per active domain.  Sampling
      main_eio.exe showed heavy stop-the-world minor-GC pressure from JSON
@@ -973,7 +1024,7 @@ let cmd =
   let doc = "MASC MCP Server and operator diagnostics" in
   let info = Cmd.info "masc" ~version:Masc.Version.version ~doc in
   Cmd.group ~default:Term.(const run_cmd_exit $ host $ port $ base_path)
-    info [ init_cmd; login_cmd ]
+    info [ init_cmd; login_cmd; memory_os_gc_dry_run_cmd ]
 
 let () =
   setup_gc ();

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -996,7 +996,8 @@ let memory_os_gc_dry_run_cmd_exit base_path keeper_ids as_json =
 let memory_os_gc_dry_run_cmd =
   let doc =
     "Run the Memory OS fact-store GC in dry-run mode and print the TTL/dedup \
-     report without rewriting stores."
+     report without rewriting stores. The scan still takes each keeper fact-store \
+     lock; contended stores are reported as per-keeper errors."
   in
   let info = Cmd.info "memory-os-gc-dry-run" ~doc in
   Cmd.v info

--- a/lib/dune
+++ b/lib/dune
@@ -191,6 +191,7 @@
   meta_cognition_interpret
   meta_cognition_digest
   keeper_memory_os_gc
+  keeper_memory_os_gc_dry_run_report
   keeper_memory_os_hebbian
   keeper_memory_os_io keeper_user_model
   keeper_memory_os_recall)

--- a/lib/dune
+++ b/lib/dune
@@ -190,8 +190,7 @@
   meta_cognition_parse
   meta_cognition_interpret
   meta_cognition_digest
-  keeper_memory_os_gc
-  keeper_memory_os_gc_dry_run_report
+  keeper_memory_os_gc keeper_memory_os_gc_dry_run_report
   keeper_memory_os_hebbian
   keeper_memory_os_io keeper_user_model
   keeper_memory_os_recall)

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -9,6 +9,9 @@ module Int_set = Set.Make (Int)
 type gc_report =
   { total_input : int
   ; ttl_expired : int
+  ; ttl_expired_ephemeral : int
+  ; ttl_expired_non_ephemeral : int
+  ; ttl_expired_by_category : (string * int) list
   ; dedup_removed : int
   ; written : int
   ; dry_run : bool
@@ -25,6 +28,37 @@ let ttl_expired ~now (fact : fact) =
   match fact.valid_until with
   | None -> false
   | Some ts -> now > ts
+;;
+
+let bump_count key counts =
+  let current = Option.value (String_map.find_opt key counts) ~default:0 in
+  String_map.add key (current + 1) counts
+;;
+
+let expired_category_counts expired =
+  let ephemeral, non_ephemeral, by_category =
+    List.fold_left
+      (fun (ephemeral, non_ephemeral, by_category) item ->
+         let category = item.fact.category in
+         let category_key = category_to_string category in
+         let ephemeral, non_ephemeral =
+           match category with
+           | Ephemeral -> ephemeral + 1, non_ephemeral
+           | Fact
+           | Constraint
+           | Preference
+           | Code_change
+           | Validated_approach
+           | Lesson
+           | Blocker
+           | Goal
+           | Unknown _ -> ephemeral, non_ephemeral + 1
+         in
+         ephemeral, non_ephemeral, bump_count category_key by_category)
+      (0, 0, String_map.empty)
+      expired
+  in
+  ephemeral, non_ephemeral, String_map.bindings by_category
 ;;
 
 (* Claim identity uses the shared SSOT [claim_identity] (RFC-0259 §3.7: the
@@ -117,11 +151,17 @@ let run_gc_with_store
       let live, expired =
         List.partition (fun item -> not (ttl_expired ~now item.fact)) indexed
       in
+      let ttl_expired_ephemeral, ttl_expired_non_ephemeral, ttl_expired_by_category =
+        expired_category_counts expired
+      in
       let deduped = dedup_by_claim live in
       let survivors = List.map (fun item -> item.fact) deduped in
       if not dry_run then rewrite_facts_atomically survivors;
       { total_input = List.length facts
       ; ttl_expired = List.length expired
+      ; ttl_expired_ephemeral
+      ; ttl_expired_non_ephemeral
+      ; ttl_expired_by_category
       ; dedup_removed = List.length live - List.length deduped
       ; written = List.length survivors
       ; dry_run

--- a/lib/keeper/keeper_memory_os_gc.ml
+++ b/lib/keeper/keeper_memory_os_gc.ml
@@ -31,7 +31,11 @@ let ttl_expired ~now (fact : fact) =
 ;;
 
 let bump_count key counts =
-  let current = Option.value (String_map.find_opt key counts) ~default:0 in
+  let current =
+    match String_map.find_opt key counts with
+    | Some count -> count
+    | None -> 0
+  in
   String_map.add key (current + 1) counts
 ;;
 

--- a/lib/keeper/keeper_memory_os_gc.mli
+++ b/lib/keeper/keeper_memory_os_gc.mli
@@ -5,6 +5,9 @@ open Keeper_memory_os_types
 type gc_report =
   { total_input : int
   ; ttl_expired : int
+  ; ttl_expired_ephemeral : int
+  ; ttl_expired_non_ephemeral : int
+  ; ttl_expired_by_category : (string * int) list
   ; dedup_removed : int
   ; written : int
   ; dry_run : bool

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
@@ -1,0 +1,171 @@
+(** Read-only operator report for Memory OS fact-store GC dry-runs. *)
+
+type keeper_result =
+  | Keeper_ok of
+      { keeper_id : string
+      ; total_input : int
+      ; ttl_expired : int
+      ; dedup_removed : int
+      ; written : int
+      }
+  | Keeper_error of
+      { keeper_id : string
+      ; message : string
+      }
+
+type t =
+  { keepers_dir : string
+  ; results : keeper_result list
+  ; total_input : int
+  ; ttl_expired : int
+  ; dedup_removed : int
+  ; written : int
+  ; error_count : int
+  }
+
+let unique_sorted xs =
+  xs
+  |> List.filter_map (fun s ->
+    let s = String.trim s in
+    if String.equal s "" then None else Some s)
+  |> List.sort_uniq String.compare
+;;
+
+let fact_store_missing_error ~keepers_dir ~keeper_id =
+  let path = Keeper_memory_os_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
+  Keeper_error
+    { keeper_id
+    ; message = Printf.sprintf "fact store not found: %s" path
+    }
+;;
+
+let run_one ~keepers_dir ~explicit ~keeper_id ~now =
+  let facts_path =
+    Keeper_memory_os_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id
+  in
+  if explicit && not (Sys.file_exists facts_path)
+  then fact_store_missing_error ~keepers_dir ~keeper_id
+  else (
+    try
+      let report =
+        Keeper_memory_os_gc.run_gc_for_keepers_dir
+          ~keepers_dir
+          ~dry_run:true
+          ~keeper_id
+          ~now
+          ()
+      in
+      Keeper_ok
+        { keeper_id
+        ; total_input = report.total_input
+        ; ttl_expired = report.ttl_expired
+        ; dedup_removed = report.dedup_removed
+        ; written = report.written
+        }
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Keeper_error { keeper_id; message = Printexc.to_string exn })
+;;
+
+let run_for_keepers_dir ~keepers_dir ?keeper_ids ~now () =
+  let explicit, keeper_ids =
+    match keeper_ids with
+    | Some ids -> true, unique_sorted ids
+    | None ->
+      ( false
+      , Keeper_memory_os_io.list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir )
+  in
+  let results =
+    List.map (fun keeper_id -> run_one ~keepers_dir ~explicit ~keeper_id ~now) keeper_ids
+  in
+  let total_input, ttl_expired, dedup_removed, written, error_count =
+    List.fold_left
+      (fun (total_input, ttl_expired, dedup_removed, written, error_count) -> function
+         | Keeper_ok row ->
+           ( total_input + row.total_input
+           , ttl_expired + row.ttl_expired
+           , dedup_removed + row.dedup_removed
+           , written + row.written
+           , error_count )
+         | Keeper_error _ ->
+           total_input, ttl_expired, dedup_removed, written, error_count + 1)
+      (0, 0, 0, 0, 0)
+      results
+  in
+  { keepers_dir
+  ; results
+  ; total_input
+  ; ttl_expired
+  ; dedup_removed
+  ; written
+  ; error_count
+  }
+;;
+
+let result_to_json = function
+  | Keeper_ok row ->
+    `Assoc
+      [ "keeper_id", `String row.keeper_id
+      ; "status", `String "ok"
+      ; "dry_run", `Bool true
+      ; "total_input", `Int row.total_input
+      ; "ttl_expired", `Int row.ttl_expired
+      ; "dedup_removed", `Int row.dedup_removed
+      ; "written", `Int row.written
+      ]
+  | Keeper_error row ->
+    `Assoc
+      [ "keeper_id", `String row.keeper_id
+      ; "status", `String "error"
+      ; "dry_run", `Bool true
+      ; "error", `String row.message
+      ]
+;;
+
+let to_json report =
+  `Assoc
+    [ "keepers_dir", `String report.keepers_dir
+    ; "dry_run", `Bool true
+    ; "keeper_count", `Int (List.length report.results)
+    ; "error_count", `Int report.error_count
+    ; "total_input", `Int report.total_input
+    ; "ttl_expired", `Int report.ttl_expired
+    ; "dedup_removed", `Int report.dedup_removed
+    ; "written", `Int report.written
+    ; "keepers", `List (List.map result_to_json report.results)
+    ]
+;;
+
+let render_result = function
+  | Keeper_ok row ->
+    Printf.sprintf
+      "%s\tok\ttotal=%d\tttl_expired=%d\tdedup_removed=%d\twould_write=%d\n"
+      row.keeper_id
+      row.total_input
+      row.ttl_expired
+      row.dedup_removed
+      row.written
+  | Keeper_error row -> Printf.sprintf "%s\terror\t%s\n" row.keeper_id row.message
+;;
+
+let render_text report =
+  let body =
+    match report.results with
+    | [] -> "no keeper fact stores found\n"
+    | rows -> rows |> List.map render_result |> String.concat ""
+  in
+  Printf.sprintf
+    "Memory OS GC dry-run\n\
+     keepers_dir: %s\n\
+     keepers: %d, errors: %d\n\
+     totals: total=%d ttl_expired=%d dedup_removed=%d would_write=%d\n\
+     %s"
+    report.keepers_dir
+    (List.length report.results)
+    report.error_count
+    report.total_input
+    report.ttl_expired
+    report.dedup_removed
+    report.written
+    body
+;;

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
@@ -81,7 +81,11 @@ module String_map = Map.Make (String)
 
 let merge_category_counts left right =
   let add counts (category, count) =
-    let current = Option.value (String_map.find_opt category counts) ~default:0 in
+    let current =
+      match String_map.find_opt category counts with
+      | Some current -> current
+      | None -> 0
+    in
     String_map.add category (current + count) counts
   in
   List.fold_left add String_map.empty (left @ right) |> String_map.bindings

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
@@ -4,6 +4,11 @@ type keeper_error =
   | Missing_fact_store of { facts_path : string }
   | Corrupt_fact_store of { message : string }
   | Fact_store_access_error of { message : string }
+  | Fact_store_locked of
+      { caller : string
+      ; lock_path : string
+      ; attempts : int
+      }
 
 type keeper_result =
   | Keeper_ok of
@@ -57,12 +62,19 @@ let access_error_message = function
 let keeper_error_message = function
   | Missing_fact_store { facts_path } -> Printf.sprintf "fact store not found: %s" facts_path
   | Corrupt_fact_store { message } | Fact_store_access_error { message } -> message
+  | Fact_store_locked { caller; lock_path; attempts } ->
+    Printf.sprintf
+      "fact store lock timeout: caller=%s lock_path=%s attempts=%d"
+      caller
+      lock_path
+      attempts
 ;;
 
 let keeper_error_code = function
   | Missing_fact_store _ -> "fact_store_missing"
   | Corrupt_fact_store _ -> "fact_store_corrupt"
   | Fact_store_access_error _ -> "fact_store_access_error"
+  | Fact_store_locked _ -> "fact_store_locked"
 ;;
 
 module String_map = Map.Make (String)
@@ -75,7 +87,16 @@ let merge_category_counts left right =
   List.fold_left add String_map.empty (left @ right) |> String_map.bindings
 ;;
 
-let run_one ~keepers_dir ~explicit ~keeper_id ~now =
+let default_run_gc_for_keepers_dir ~keepers_dir ~dry_run ~keeper_id ~now () =
+  Keeper_memory_os_gc.run_gc_for_keepers_dir
+    ~keepers_dir
+    ~dry_run
+    ~keeper_id
+    ~now
+    ()
+;;
+
+let run_one ~keepers_dir ~run_gc_for_keepers_dir ~explicit ~keeper_id ~now =
   let facts_path =
     Keeper_memory_os_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id
   in
@@ -84,7 +105,7 @@ let run_one ~keepers_dir ~explicit ~keeper_id ~now =
   else (
     try
       let report =
-        Keeper_memory_os_gc.run_gc_for_keepers_dir
+        run_gc_for_keepers_dir
           ~keepers_dir
           ~dry_run:true
           ~keeper_id
@@ -103,6 +124,9 @@ let run_one ~keepers_dir ~explicit ~keeper_id ~now =
         }
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | File_lock_eio.Flock_timeout { caller; path; attempts } ->
+      Keeper_error
+        { keeper_id; error = Fact_store_locked { caller; lock_path = path; attempts } }
     | Keeper_memory_os_gc.Fact_store_corrupt message ->
       Keeper_error { keeper_id; error = Corrupt_fact_store { message } }
     | exn ->
@@ -111,7 +135,13 @@ let run_one ~keepers_dir ~explicit ~keeper_id ~now =
        | None -> raise exn))
 ;;
 
-let run_for_keepers_dir ~keepers_dir ?keeper_ids ~now () =
+let run_for_keepers_dir_with_runner
+      ~keepers_dir
+      ~run_gc_for_keepers_dir
+      ?keeper_ids
+      ~now
+      ()
+  =
   let explicit, keeper_ids =
     match keeper_ids with
     | Some ids -> true, unique_sorted ids
@@ -120,7 +150,10 @@ let run_for_keepers_dir ~keepers_dir ?keeper_ids ~now () =
       , Keeper_memory_os_io.list_fact_store_keeper_ids_for_keepers_dir ~keepers_dir )
   in
   let results =
-    List.map (fun keeper_id -> run_one ~keepers_dir ~explicit ~keeper_id ~now) keeper_ids
+    List.map
+      (fun keeper_id ->
+         run_one ~keepers_dir ~run_gc_for_keepers_dir ~explicit ~keeper_id ~now)
+      keeper_ids
   in
   let
     total_input,
@@ -177,15 +210,34 @@ let run_for_keepers_dir ~keepers_dir ?keeper_ids ~now () =
   }
 ;;
 
+let run_for_keepers_dir ~keepers_dir ?keeper_ids ~now () =
+  run_for_keepers_dir_with_runner
+    ~keepers_dir
+    ~run_gc_for_keepers_dir:default_run_gc_for_keepers_dir
+    ?keeper_ids
+    ~now
+    ()
+;;
+
+module For_testing = struct
+  let run_for_keepers_dir ~keepers_dir ~run_gc_for_keepers_dir ?keeper_ids ~now () =
+    run_for_keepers_dir_with_runner
+      ~keepers_dir
+      ~run_gc_for_keepers_dir
+      ?keeper_ids
+      ~now
+      ()
+  ;;
+end
+
 let category_counts_to_json rows =
   `Assoc (List.map (fun (category, count) -> category, `Int count) rows)
 ;;
 
 let result_to_json = function
   | Keeper_ok row ->
-    `Assoc
+    Tool_args.ok_assoc
       [ "keeper_id", `String row.keeper_id
-      ; "status", `String "ok"
       ; "dry_run", `Bool true
       ; "total_input", `Int row.total_input
       ; "ttl_expired", `Int row.ttl_expired

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
@@ -1,5 +1,10 @@
 (** Read-only operator report for Memory OS fact-store GC dry-runs. *)
 
+type keeper_error =
+  | Missing_fact_store of { facts_path : string }
+  | Corrupt_fact_store of { message : string }
+  | Fact_store_access_error of { message : string }
+
 type keeper_result =
   | Keeper_ok of
       { keeper_id : string
@@ -10,7 +15,7 @@ type keeper_result =
       }
   | Keeper_error of
       { keeper_id : string
-      ; message : string
+      ; error : keeper_error
       }
 
 type t =
@@ -33,10 +38,25 @@ let unique_sorted xs =
 
 let fact_store_missing_error ~keepers_dir ~keeper_id =
   let path = Keeper_memory_os_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id in
-  Keeper_error
-    { keeper_id
-    ; message = Printf.sprintf "fact store not found: %s" path
-    }
+  Keeper_error { keeper_id; error = Missing_fact_store { facts_path = path } }
+;;
+
+let access_error_message = function
+  | Sys_error message -> Some message
+  | Unix.Unix_error (error, fn, arg) ->
+    Some (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message error))
+  | _ -> None
+;;
+
+let keeper_error_message = function
+  | Missing_fact_store { facts_path } -> Printf.sprintf "fact store not found: %s" facts_path
+  | Corrupt_fact_store { message } | Fact_store_access_error { message } -> message
+;;
+
+let keeper_error_code = function
+  | Missing_fact_store _ -> "fact_store_missing"
+  | Corrupt_fact_store _ -> "fact_store_corrupt"
+  | Fact_store_access_error _ -> "fact_store_access_error"
 ;;
 
 let run_one ~keepers_dir ~explicit ~keeper_id ~now =
@@ -64,7 +84,12 @@ let run_one ~keepers_dir ~explicit ~keeper_id ~now =
         }
     with
     | Eio.Cancel.Cancelled _ as exn -> raise exn
-    | exn -> Keeper_error { keeper_id; message = Printexc.to_string exn })
+    | Keeper_memory_os_gc.Fact_store_corrupt message ->
+      Keeper_error { keeper_id; error = Corrupt_fact_store { message } }
+    | exn ->
+      (match access_error_message exn with
+       | Some message -> Keeper_error { keeper_id; error = Fact_store_access_error { message } }
+       | None -> raise exn))
 ;;
 
 let run_for_keepers_dir ~keepers_dir ?keeper_ids ~now () =
@@ -114,11 +139,11 @@ let result_to_json = function
       ; "written", `Int row.written
       ]
   | Keeper_error row ->
-    `Assoc
+    Tool_args.error_assoc
       [ "keeper_id", `String row.keeper_id
-      ; "status", `String "error"
       ; "dry_run", `Bool true
-      ; "error", `String row.message
+      ; "error_code", `String (keeper_error_code row.error)
+      ; "message", `String (keeper_error_message row.error)
       ]
 ;;
 
@@ -145,7 +170,12 @@ let render_result = function
       row.ttl_expired
       row.dedup_removed
       row.written
-  | Keeper_error row -> Printf.sprintf "%s\terror\t%s\n" row.keeper_id row.message
+  | Keeper_error row ->
+    Printf.sprintf
+      "%s\t%s\t%s\n"
+      row.keeper_id
+      (keeper_error_code row.error)
+      (keeper_error_message row.error)
 ;;
 
 let render_text report =

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
@@ -10,6 +10,9 @@ type keeper_result =
       { keeper_id : string
       ; total_input : int
       ; ttl_expired : int
+      ; ttl_expired_ephemeral : int
+      ; ttl_expired_non_ephemeral : int
+      ; ttl_expired_by_category : (string * int) list
       ; dedup_removed : int
       ; written : int
       }
@@ -23,6 +26,9 @@ type t =
   ; results : keeper_result list
   ; total_input : int
   ; ttl_expired : int
+  ; ttl_expired_ephemeral : int
+  ; ttl_expired_non_ephemeral : int
+  ; ttl_expired_by_category : (string * int) list
   ; dedup_removed : int
   ; written : int
   ; error_count : int
@@ -59,6 +65,16 @@ let keeper_error_code = function
   | Fact_store_access_error _ -> "fact_store_access_error"
 ;;
 
+module String_map = Map.Make (String)
+
+let merge_category_counts left right =
+  let add counts (category, count) =
+    let current = Option.value (String_map.find_opt category counts) ~default:0 in
+    String_map.add category (current + count) counts
+  in
+  List.fold_left add String_map.empty (left @ right) |> String_map.bindings
+;;
+
 let run_one ~keepers_dir ~explicit ~keeper_id ~now =
   let facts_path =
     Keeper_memory_os_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id
@@ -79,6 +95,9 @@ let run_one ~keepers_dir ~explicit ~keeper_id ~now =
         { keeper_id
         ; total_input = report.total_input
         ; ttl_expired = report.ttl_expired
+        ; ttl_expired_ephemeral = report.ttl_expired_ephemeral
+        ; ttl_expired_non_ephemeral = report.ttl_expired_non_ephemeral
+        ; ttl_expired_by_category = report.ttl_expired_by_category
         ; dedup_removed = report.dedup_removed
         ; written = report.written
         }
@@ -103,28 +122,63 @@ let run_for_keepers_dir ~keepers_dir ?keeper_ids ~now () =
   let results =
     List.map (fun keeper_id -> run_one ~keepers_dir ~explicit ~keeper_id ~now) keeper_ids
   in
-  let total_input, ttl_expired, dedup_removed, written, error_count =
+  let
+    total_input,
+    ttl_expired,
+    ttl_expired_ephemeral,
+    ttl_expired_non_ephemeral,
+    ttl_expired_by_category,
+    dedup_removed,
+    written,
+    error_count
+    =
     List.fold_left
-      (fun (total_input, ttl_expired, dedup_removed, written, error_count) -> function
+      (fun
+        ( total_input
+        , ttl_expired
+        , ttl_expired_ephemeral
+        , ttl_expired_non_ephemeral
+        , ttl_expired_by_category
+        , dedup_removed
+        , written
+        , error_count )
+        -> function
          | Keeper_ok row ->
            ( total_input + row.total_input
            , ttl_expired + row.ttl_expired
+           , ttl_expired_ephemeral + row.ttl_expired_ephemeral
+           , ttl_expired_non_ephemeral + row.ttl_expired_non_ephemeral
+           , merge_category_counts ttl_expired_by_category row.ttl_expired_by_category
            , dedup_removed + row.dedup_removed
            , written + row.written
            , error_count )
          | Keeper_error _ ->
-           total_input, ttl_expired, dedup_removed, written, error_count + 1)
-      (0, 0, 0, 0, 0)
+           ( total_input
+           , ttl_expired
+           , ttl_expired_ephemeral
+           , ttl_expired_non_ephemeral
+           , ttl_expired_by_category
+           , dedup_removed
+           , written
+           , error_count + 1 ))
+      (0, 0, 0, 0, [], 0, 0, 0)
       results
   in
   { keepers_dir
   ; results
   ; total_input
   ; ttl_expired
+  ; ttl_expired_ephemeral
+  ; ttl_expired_non_ephemeral
+  ; ttl_expired_by_category
   ; dedup_removed
   ; written
   ; error_count
   }
+;;
+
+let category_counts_to_json rows =
+  `Assoc (List.map (fun (category, count) -> category, `Int count) rows)
 ;;
 
 let result_to_json = function
@@ -135,6 +189,10 @@ let result_to_json = function
       ; "dry_run", `Bool true
       ; "total_input", `Int row.total_input
       ; "ttl_expired", `Int row.ttl_expired
+      ; "ttl_expired_ephemeral", `Int row.ttl_expired_ephemeral
+      ; "ttl_expired_non_ephemeral", `Int row.ttl_expired_non_ephemeral
+      ; "ttl_expired_by_category", category_counts_to_json row.ttl_expired_by_category
+      ; "migration_candidate_expired", `Int row.ttl_expired_non_ephemeral
       ; "dedup_removed", `Int row.dedup_removed
       ; "written", `Int row.written
       ]
@@ -155,6 +213,10 @@ let to_json report =
     ; "error_count", `Int report.error_count
     ; "total_input", `Int report.total_input
     ; "ttl_expired", `Int report.ttl_expired
+    ; "ttl_expired_ephemeral", `Int report.ttl_expired_ephemeral
+    ; "ttl_expired_non_ephemeral", `Int report.ttl_expired_non_ephemeral
+    ; "ttl_expired_by_category", category_counts_to_json report.ttl_expired_by_category
+    ; "migration_candidate_expired", `Int report.ttl_expired_non_ephemeral
     ; "dedup_removed", `Int report.dedup_removed
     ; "written", `Int report.written
     ; "keepers", `List (List.map result_to_json report.results)
@@ -164,10 +226,12 @@ let to_json report =
 let render_result = function
   | Keeper_ok row ->
     Printf.sprintf
-      "%s\tok\ttotal=%d\tttl_expired=%d\tdedup_removed=%d\twould_write=%d\n"
+      "%s\tok\ttotal=%d\tttl_expired=%d\tephemeral_expired=%d\tmigration_candidates=%d\tdedup_removed=%d\twould_write=%d\n"
       row.keeper_id
       row.total_input
       row.ttl_expired
+      row.ttl_expired_ephemeral
+      row.ttl_expired_non_ephemeral
       row.dedup_removed
       row.written
   | Keeper_error row ->
@@ -188,13 +252,15 @@ let render_text report =
     "Memory OS GC dry-run\n\
      keepers_dir: %s\n\
      keepers: %d, errors: %d\n\
-     totals: total=%d ttl_expired=%d dedup_removed=%d would_write=%d\n\
+     totals: total=%d ttl_expired=%d ephemeral_expired=%d migration_candidates=%d dedup_removed=%d would_write=%d\n\
      %s"
     report.keepers_dir
     (List.length report.results)
     report.error_count
     report.total_input
     report.ttl_expired
+    report.ttl_expired_ephemeral
+    report.ttl_expired_non_ephemeral
     report.dedup_removed
     report.written
     body

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.mli
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.mli
@@ -1,0 +1,40 @@
+(** Read-only operator report for Memory OS fact-store GC dry-runs. *)
+
+type keeper_result =
+  | Keeper_ok of
+      { keeper_id : string
+      ; total_input : int
+      ; ttl_expired : int
+      ; dedup_removed : int
+      ; written : int
+      }
+  | Keeper_error of
+      { keeper_id : string
+      ; message : string
+      }
+
+type t =
+  { keepers_dir : string
+  ; results : keeper_result list
+  ; total_input : int
+  ; ttl_expired : int
+  ; dedup_removed : int
+  ; written : int
+  ; error_count : int
+  }
+
+val run_for_keepers_dir
+  :  keepers_dir:string
+  -> ?keeper_ids:string list
+  -> now:float
+  -> unit
+  -> t
+(** Scan keeper fact stores and run {!Keeper_memory_os_gc.run_gc_for_keepers_dir}
+    with [dry_run:true]. Must be called inside an Eio context because the GC
+    path takes the per-keeper facts lock. If [keeper_ids] is omitted, every
+    existing non-shared [*.facts.jsonl] store in [keepers_dir] is scanned. If it
+    is provided, missing stores are reported as per-keeper errors instead of
+    silently returning an empty report. *)
+
+val to_json : t -> Yojson.Safe.t
+val render_text : t -> string

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.mli
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.mli
@@ -1,5 +1,10 @@
 (** Read-only operator report for Memory OS fact-store GC dry-runs. *)
 
+type keeper_error =
+  | Missing_fact_store of { facts_path : string }
+  | Corrupt_fact_store of { message : string }
+  | Fact_store_access_error of { message : string }
+
 type keeper_result =
   | Keeper_ok of
       { keeper_id : string
@@ -10,7 +15,7 @@ type keeper_result =
       }
   | Keeper_error of
       { keeper_id : string
-      ; message : string
+      ; error : keeper_error
       }
 
 type t =

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.mli
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.mli
@@ -10,6 +10,9 @@ type keeper_result =
       { keeper_id : string
       ; total_input : int
       ; ttl_expired : int
+      ; ttl_expired_ephemeral : int
+      ; ttl_expired_non_ephemeral : int
+      ; ttl_expired_by_category : (string * int) list
       ; dedup_removed : int
       ; written : int
       }
@@ -23,6 +26,9 @@ type t =
   ; results : keeper_result list
   ; total_input : int
   ; ttl_expired : int
+  ; ttl_expired_ephemeral : int
+  ; ttl_expired_non_ephemeral : int
+  ; ttl_expired_by_category : (string * int) list
   ; dedup_removed : int
   ; written : int
   ; error_count : int

--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.mli
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.mli
@@ -4,6 +4,11 @@ type keeper_error =
   | Missing_fact_store of { facts_path : string }
   | Corrupt_fact_store of { message : string }
   | Fact_store_access_error of { message : string }
+  | Fact_store_locked of
+      { caller : string
+      ; lock_path : string
+      ; attempts : int
+      }
 
 type keeper_result =
   | Keeper_ok of
@@ -46,6 +51,22 @@ val run_for_keepers_dir
     existing non-shared [*.facts.jsonl] store in [keepers_dir] is scanned. If it
     is provided, missing stores are reported as per-keeper errors instead of
     silently returning an empty report. *)
+
+module For_testing : sig
+  val run_for_keepers_dir
+    :  keepers_dir:string
+    -> run_gc_for_keepers_dir:
+         (keepers_dir:string
+          -> dry_run:bool
+          -> keeper_id:string
+          -> now:float
+          -> unit
+          -> Keeper_memory_os_gc.gc_report)
+    -> ?keeper_ids:string list
+    -> now:float
+    -> unit
+    -> t
+end
 
 val to_json : t -> Yojson.Safe.t
 val render_text : t -> string

--- a/test/dune
+++ b/test/dune
@@ -95,6 +95,7 @@
   test_keeper_turn_disposition
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os
+  test_keeper_memory_os_gc_dry_run_report
   test_keeper_user_model
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime

--- a/test/dune
+++ b/test/dune
@@ -411,6 +411,7 @@
   test_keeper_turn_disposition
   test_keeper_turn_terminal_disposition_field
   test_keeper_memory_os
+  test_keeper_memory_os_gc_dry_run_report
   test_keeper_user_model
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime

--- a/test/test_keeper_memory_os_gc_dry_run_report.ml
+++ b/test/test_keeper_memory_os_gc_dry_run_report.ml
@@ -1,5 +1,6 @@
 module Types = Masc.Keeper_memory_os_types
 module Memory_io = Masc.Keeper_memory_os_io
+module GC = Masc.Keeper_memory_os_gc
 module Report = Masc.Keeper_memory_os_gc_dry_run_report
 
 let fact_fixture ~now ~claim =
@@ -78,7 +79,9 @@ let test_report_summarizes_dry_run_without_rewrite () =
            | Report.Missing_fact_store { facts_path } ->
              Printf.sprintf "missing %s" facts_path
            | Report.Corrupt_fact_store { message }
-           | Report.Fact_store_access_error { message } -> message)
+           | Report.Fact_store_access_error { message } -> message
+           | Report.Fact_store_locked { lock_path; _ } ->
+             Printf.sprintf "locked %s" lock_path)
       | None -> Alcotest.fail "missing alpha result"))
 ;;
 
@@ -102,7 +105,9 @@ let test_explicit_missing_keeper_is_error () =
         (match row.error with
          | Report.Missing_fact_store { facts_path } ->
            Alcotest.(check string) "missing fact store path" expected_path facts_path
-         | Report.Corrupt_fact_store _ | Report.Fact_store_access_error _ ->
+         | Report.Corrupt_fact_store _
+         | Report.Fact_store_access_error _
+         | Report.Fact_store_locked _ ->
            Alcotest.fail "expected structured missing fact store error");
         (match Report.to_json report with
          | `Assoc fields ->
@@ -126,6 +131,108 @@ let test_explicit_missing_keeper_is_error () =
       | None -> Alcotest.fail "missing explicit keeper result"))
 ;;
 
+let fake_gc_report ?(total_input = 1) ?(ttl_expired = 0) ?(written = 1) () =
+  { GC.total_input = total_input
+  ; ttl_expired
+  ; ttl_expired_ephemeral = 0
+  ; ttl_expired_non_ephemeral = ttl_expired
+  ; ttl_expired_by_category = (if ttl_expired > 0 then [ "fact", ttl_expired ] else [])
+  ; dedup_removed = 0
+  ; written
+  ; dry_run = true
+  }
+;;
+
+let seed_keeper ~now keeper_id =
+  Memory_io.append_fact ~keeper_id (fact_fixture ~now ~claim:(keeper_id ^ " fact"))
+;;
+
+let test_lock_timeout_is_per_keeper_error () =
+  with_eio (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      let now = 1_000.0 in
+      seed_keeper ~now "locked";
+      let run_gc_for_keepers_dir ~keepers_dir:_ ~dry_run:_ ~keeper_id:_ ~now:_ () =
+        raise
+          (File_lock_eio.Flock_timeout
+             { caller = "unit-test"; path = "/tmp/facts.jsonl.lock"; attempts = 3 })
+      in
+      let report =
+        Report.For_testing.run_for_keepers_dir
+          ~keepers_dir
+          ~run_gc_for_keepers_dir
+          ~keeper_ids:[ "locked" ]
+          ~now
+          ()
+      in
+      Alcotest.(check int) "one per-keeper error" 1 report.error_count;
+      match result_for "locked" report with
+      | Some (Report.Keeper_error { error = Report.Fact_store_locked row; _ }) ->
+        Alcotest.(check string) "caller" "unit-test" row.caller;
+        Alcotest.(check int) "attempts" 3 row.attempts
+      | Some (Report.Keeper_error _) -> Alcotest.fail "expected lock timeout error"
+      | Some (Report.Keeper_ok _) -> Alcotest.fail "expected locked keeper error"
+      | None -> Alcotest.fail "missing locked result"))
+;;
+
+let test_corrupt_store_is_per_keeper_error () =
+  with_eio (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      let now = 1_000.0 in
+      seed_keeper ~now "corrupt";
+      let run_gc_for_keepers_dir ~keepers_dir:_ ~dry_run:_ ~keeper_id:_ ~now:_ () =
+        raise (GC.Fact_store_corrupt "bad row")
+      in
+      let report =
+        Report.For_testing.run_for_keepers_dir
+          ~keepers_dir
+          ~run_gc_for_keepers_dir
+          ~keeper_ids:[ "corrupt" ]
+          ~now
+          ()
+      in
+      Alcotest.(check int) "one corrupt error" 1 report.error_count;
+      match result_for "corrupt" report with
+      | Some (Report.Keeper_error { error = Report.Corrupt_fact_store { message }; _ }) ->
+        Alcotest.(check string) "message" "bad row" message
+      | Some (Report.Keeper_error _) -> Alcotest.fail "expected corrupt store error"
+      | Some (Report.Keeper_ok _) -> Alcotest.fail "expected corrupt keeper error"
+      | None -> Alcotest.fail "missing corrupt result"))
+;;
+
+let test_mixed_results_keep_ok_totals_and_errors () =
+  with_eio (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      let now = 1_000.0 in
+      List.iter (seed_keeper ~now) [ "alpha"; "broken" ];
+      let run_gc_for_keepers_dir ~keepers_dir:_ ~dry_run:_ ~keeper_id ~now:_ () =
+        if String.equal keeper_id "broken"
+        then raise (GC.Fact_store_corrupt "broken")
+        else fake_gc_report ~total_input:2 ~ttl_expired:1 ~written:1 ()
+      in
+      let report =
+        Report.For_testing.run_for_keepers_dir
+          ~keepers_dir
+          ~run_gc_for_keepers_dir
+          ~keeper_ids:[ "alpha"; "broken" ]
+          ~now
+          ()
+      in
+      Alcotest.(check int) "two results" 2 (List.length report.results);
+      Alcotest.(check int) "one error" 1 report.error_count;
+      Alcotest.(check int) "ok total input only" 2 report.total_input;
+      Alcotest.(check int) "ok ttl only" 1 report.ttl_expired))
+;;
+
+let test_empty_scan_is_empty_report () =
+  with_eio (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      let report = Report.run_for_keepers_dir ~keepers_dir ~now:1_000.0 () in
+      Alcotest.(check int) "no keepers" 0 (List.length report.results);
+      Alcotest.(check int) "no errors" 0 report.error_count;
+      Alcotest.(check int) "no input" 0 report.total_input))
+;;
+
 let () =
   Alcotest.run
     "keeper_memory_os_gc_dry_run_report"
@@ -138,6 +245,22 @@ let () =
             "explicit missing keeper is an error"
             `Quick
             test_explicit_missing_keeper_is_error
+        ; Alcotest.test_case
+            "lock timeout is per-keeper error"
+            `Quick
+            test_lock_timeout_is_per_keeper_error
+        ; Alcotest.test_case
+            "corrupt store is per-keeper error"
+            `Quick
+            test_corrupt_store_is_per_keeper_error
+        ; Alcotest.test_case
+            "mixed results keep ok totals and errors"
+            `Quick
+            test_mixed_results_keep_ok_totals_and_errors
+        ; Alcotest.test_case
+            "empty scan is empty report"
+            `Quick
+            test_empty_scan_is_empty_report
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_os_gc_dry_run_report.ml
+++ b/test/test_keeper_memory_os_gc_dry_run_report.ml
@@ -1,0 +1,103 @@
+module Types = Masc.Keeper_memory_os_types
+module Memory_io = Masc.Keeper_memory_os_io
+module Report = Masc.Keeper_memory_os_gc_dry_run_report
+
+let fact_fixture ~now ~claim =
+  { Types.claim
+  ; category = Types.Fact
+  ; external_ref = None
+  ; claim_kind = None
+  ; source = { Types.trace_id = "trace-gc-dry-run"; turn = 1; tool_call_id = None }
+  ; observed_by = []
+  ; first_seen = now -. 60.0
+  ; valid_until = None
+  ; last_verified_at = Some now
+  ; schema_version = Types.schema_version
+  ; claim_id = None
+  }
+;;
+
+let with_temp_keepers_dir f =
+  let marker = Filename.temp_file "keeper-memory-os-gc-dry-run-" ".tmp" in
+  Sys.remove marker;
+  Memory_io.For_testing.with_keepers_dir marker (fun () -> f marker)
+;;
+
+let with_eio f = Eio_main.run @@ fun _env -> f ()
+
+let result_for keeper_id report =
+  List.find_opt
+    (function
+      | Report.Keeper_ok row -> String.equal row.keeper_id keeper_id
+      | Report.Keeper_error row -> String.equal row.keeper_id keeper_id)
+    report.Report.results
+;;
+
+let test_report_summarizes_dry_run_without_rewrite () =
+  with_eio (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      let now = 1_000.0 in
+      let live = fact_fixture ~now ~claim:"keep this fact" in
+      let expired =
+        { live with
+          Types.claim = "expired fact"
+        ; Types.valid_until = Some (now -. 1.0)
+        }
+      in
+      List.iter (Memory_io.append_fact ~keeper_id:"alpha") [ live; expired ];
+      Memory_io.append_fact ~keeper_id:"beta" (fact_fixture ~now ~claim:"beta fact");
+      let report = Report.run_for_keepers_dir ~keepers_dir ~now () in
+      Alcotest.(check int) "keeper count" 2 (List.length report.results);
+      Alcotest.(check int) "total input" 3 report.total_input;
+      Alcotest.(check int) "ttl expired" 1 report.ttl_expired;
+      Alcotest.(check int) "error count" 0 report.error_count;
+      Alcotest.(check int)
+        "alpha file unchanged by dry-run"
+        2
+        (List.length (Memory_io.read_facts_all ~keeper_id:"alpha"));
+      match result_for "alpha" report with
+      | Some (Report.Keeper_ok row) ->
+        Alcotest.(check int) "alpha ttl expired" 1 row.ttl_expired;
+        Alcotest.(check int) "alpha would write" 1 row.written
+      | Some (Report.Keeper_error row) ->
+        Alcotest.failf "unexpected alpha error: %s" row.message
+      | None -> Alcotest.fail "missing alpha result"))
+;;
+
+let test_explicit_missing_keeper_is_error () =
+  with_eio (fun () ->
+    with_temp_keepers_dir (fun keepers_dir ->
+      let report =
+        Report.run_for_keepers_dir
+          ~keepers_dir
+          ~keeper_ids:[ "missing"; "missing" ]
+          ~now:1_000.0
+          ()
+      in
+      Alcotest.(check int) "deduped explicit keeper" 1 (List.length report.results);
+      Alcotest.(check int) "error count" 1 report.error_count;
+      match result_for "missing" report with
+      | Some (Report.Keeper_error row) ->
+        Alcotest.(check bool)
+          "message names missing fact store"
+          true
+          (String.starts_with ~prefix:"fact store not found:" row.message)
+      | Some (Report.Keeper_ok _) -> Alcotest.fail "expected missing keeper error"
+      | None -> Alcotest.fail "missing explicit keeper result"))
+;;
+
+let () =
+  Alcotest.run
+    "keeper_memory_os_gc_dry_run_report"
+    [ ( "report"
+      , [ Alcotest.test_case
+            "summarizes dry-run without rewrite"
+            `Quick
+            test_report_summarizes_dry_run_without_rewrite
+        ; Alcotest.test_case
+            "explicit missing keeper is an error"
+            `Quick
+            test_explicit_missing_keeper_is_error
+        ] )
+    ]
+;;

--- a/test/test_keeper_memory_os_gc_dry_run_report.ml
+++ b/test/test_keeper_memory_os_gc_dry_run_report.ml
@@ -50,6 +50,10 @@ let test_report_summarizes_dry_run_without_rewrite () =
       Alcotest.(check int) "keeper count" 2 (List.length report.results);
       Alcotest.(check int) "total input" 3 report.total_input;
       Alcotest.(check int) "ttl expired" 1 report.ttl_expired;
+      Alcotest.(check int)
+        "non-ephemeral expired is a migration candidate"
+        1
+        report.ttl_expired_non_ephemeral;
       Alcotest.(check int) "error count" 0 report.error_count;
       Alcotest.(check int)
         "alpha file unchanged by dry-run"
@@ -58,6 +62,14 @@ let test_report_summarizes_dry_run_without_rewrite () =
       match result_for "alpha" report with
       | Some (Report.Keeper_ok row) ->
         Alcotest.(check int) "alpha ttl expired" 1 row.ttl_expired;
+        Alcotest.(check int)
+          "alpha migration candidates"
+          1
+          row.ttl_expired_non_ephemeral;
+        Alcotest.(check (list (pair string int)))
+          "alpha expired by category"
+          [ "fact", 1 ]
+          row.ttl_expired_by_category;
         Alcotest.(check int) "alpha would write" 1 row.written
       | Some (Report.Keeper_error row) ->
         Alcotest.failf

--- a/test/test_keeper_memory_os_gc_dry_run_report.ml
+++ b/test/test_keeper_memory_os_gc_dry_run_report.ml
@@ -60,7 +60,13 @@ let test_report_summarizes_dry_run_without_rewrite () =
         Alcotest.(check int) "alpha ttl expired" 1 row.ttl_expired;
         Alcotest.(check int) "alpha would write" 1 row.written
       | Some (Report.Keeper_error row) ->
-        Alcotest.failf "unexpected alpha error: %s" row.message
+        Alcotest.failf
+          "unexpected alpha error: %s"
+          (match row.error with
+           | Report.Missing_fact_store { facts_path } ->
+             Printf.sprintf "missing %s" facts_path
+           | Report.Corrupt_fact_store { message }
+           | Report.Fact_store_access_error { message } -> message)
       | None -> Alcotest.fail "missing alpha result"))
 ;;
 
@@ -78,10 +84,32 @@ let test_explicit_missing_keeper_is_error () =
       Alcotest.(check int) "error count" 1 report.error_count;
       match result_for "missing" report with
       | Some (Report.Keeper_error row) ->
-        Alcotest.(check bool)
-          "message names missing fact store"
-          true
-          (String.starts_with ~prefix:"fact store not found:" row.message)
+        let expected_path =
+          Memory_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id:"missing"
+        in
+        (match row.error with
+         | Report.Missing_fact_store { facts_path } ->
+           Alcotest.(check string) "missing fact store path" expected_path facts_path
+         | Report.Corrupt_fact_store _ | Report.Fact_store_access_error _ ->
+           Alcotest.fail "expected structured missing fact store error");
+        (match Report.to_json report with
+         | `Assoc fields ->
+           (match List.assoc_opt "keepers" fields with
+            | Some (`List [ `Assoc keeper_fields ]) ->
+              Alcotest.(check (option string))
+                "canonical error status"
+                (Some "error")
+                (Option.bind
+                   (List.assoc_opt "status" keeper_fields)
+                   (function `String s -> Some s | _ -> None));
+              Alcotest.(check (option string))
+                "structured error code"
+                (Some "fact_store_missing")
+                (Option.bind
+                   (List.assoc_opt "error_code" keeper_fields)
+                   (function `String s -> Some s | _ -> None))
+            | Some _ | None -> Alcotest.fail "missing keeper JSON row")
+         | _ -> Alcotest.fail "report JSON must be an object")
       | Some (Report.Keeper_ok _) -> Alcotest.fail "expected missing keeper error"
       | None -> Alcotest.fail "missing explicit keeper result"))
 ;;


### PR DESCRIPTION
## Summary

- add `masc memory-os-gc-dry-run` as a read-only operator command for Memory OS fact-store GC reports
- scan all non-shared keeper fact stores by default, or target repeated `--keeper` values explicitly
- return typed per-keeper error rows for missing/corrupt/access/locked stores, with non-zero exit when any keeper fails
- keep a contended keeper lock local to that keeper instead of aborting the fleet-wide dry-run
- expose `ttl_expired_ephemeral`, `ttl_expired_non_ephemeral`, `ttl_expired_by_category`, and `migration_candidate_expired` so non-ephemeral expired facts are surfaced as migration/policy findings
- document in CLI help that dry-run still takes per-keeper fact-store locks
- keep the report module private and covered by focused unit tests

## Audit Link

Addresses the 2026-06-26 Memory OS production audit item: add a GC dry-run command before enabling destructive GC by default.

The follow-up migration surface is intentional: expired non-ephemeral categories should be reviewed before automatic deletion is trusted.

## Review Response

- fixed `test/dune` so `test_keeper_memory_os_gc_dry_run_report` is present in both `(names ...)` and `(modules ...)`
- mapped `File_lock_eio.Flock_timeout` to `Fact_store_locked` per-keeper error rows
- added corrupt-store, lock-timeout, mixed OK/error aggregation, and empty-scan tests
- switched OK JSON rows to `Tool_args.ok_assoc`; error rows use `Tool_args.error_assoc`
- added `keeper_memory_os_gc_dry_run_report` to `lib/dune` `private_modules`

## Validation

- `ocamlformat --check lib/keeper/keeper_memory_os_gc_dry_run_report.ml lib/keeper/keeper_memory_os_gc_dry_run_report.mli test/test_keeper_memory_os_gc_dry_run_report.ml bin/main_eio.ml test/dune`
- `ocamlc -stop-after parsing lib/keeper/keeper_memory_os_gc_dry_run_report.ml test/test_keeper_memory_os_gc_dry_run_report.ml bin/main_eio.ml`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_memory_os_gc_dry_run_report.mli`
- `git diff --check`
- `scripts/lint/no-inline-error-envelope.sh`
- `scripts/lint/no-inline-ok-envelope.sh`
- targeted `rg` checks for module registration, private module entry, lock error handling, canonical envelope helpers, and removed broad/stringly error patterns

Per operator instruction, I did not run local Dune build/tests or inspect CI/check logs.
