### PR TITLE
fix(memory): add local recall outcome eval

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -116,6 +116,15 @@
   agent_sdk
   agent_sdk.llm_provider))
 
+;; RFC-0264 P3 local substrate: recall ledger ⨝ execution receipts, no network.
+
+(executable
+ (name masc_recall_outcome_eval)
+ (modules masc_recall_outcome_eval)
+ (public_name masc-recall-outcome-eval)
+ (package masc)
+ (libraries masc masc.config masc_core unix yojson))
+
 (executable
  (name public_tool_manifest)
  (modules public_tool_manifest)

--- a/bin/masc_recall_outcome_eval.ml
+++ b/bin/masc_recall_outcome_eval.ml
@@ -7,6 +7,8 @@ let default_base_path () =
 let base_path = ref (default_base_path ())
 let json = ref false
 let trace_limit = ref 50
+let fact_key_limit = ref 50
+let summary_index_path = ref ""
 
 let specs =
   [ ( "--base-path"
@@ -14,6 +16,10 @@ let specs =
     , "PATH Workspace root; runtime state is read from PATH/.masc" )
   ; "--json", Arg.Set json, "Emit JSON"
   ; "--trace-limit", Arg.Set_int trace_limit, "N Number of joined trace rows to print"
+  ; "--fact-key-limit", Arg.Set_int fact_key_limit, "N Number of fact-key summary rows to print"
+  ; ( "--summary-index-path"
+    , Arg.Set_string summary_index_path
+    , "PATH Write compact fact-key outcome summary JSONL to PATH" )
   ]
 ;;
 
@@ -23,11 +29,22 @@ let () =
   let base_path = Env_config.normalize_masc_base_path_input !base_path in
   let masc_root = Common.masc_dir_from_base_path ~base_path in
   let trace_limit = max 0 !trace_limit in
+  let fact_key_limit = max 0 !fact_key_limit in
   let report = Masc.Keeper_recall_outcome_eval.evaluate ~masc_root in
+  if String.trim !summary_index_path <> ""
+  then Masc.Keeper_recall_outcome_eval.write_summary_index ~path:!summary_index_path report;
   if !json
   then
     print_endline
       (Yojson.Safe.pretty_to_string
-         (Masc.Keeper_recall_outcome_eval.to_json ~trace_limit report))
-  else print_string (Masc.Keeper_recall_outcome_eval.render_text ~trace_limit report)
+         (Masc.Keeper_recall_outcome_eval.to_json
+            ~trace_limit
+            ~fact_key_limit
+            report))
+  else
+    print_string
+      (Masc.Keeper_recall_outcome_eval.render_text
+         ~trace_limit
+         ~fact_key_limit
+         report)
 ;;

--- a/bin/masc_recall_outcome_eval.ml
+++ b/bin/masc_recall_outcome_eval.ml
@@ -2,31 +2,55 @@ let default_base_path_opt () =
   Config_dir_resolver.current_env_base_path_opt ()
 ;;
 
-let base_path = ref (Option.value (default_base_path_opt ()) ~default:"")
-let json = ref false
-let trace_limit = ref 50
-let fact_key_limit = ref 50
-let summary_index_path = ref ""
+let nonempty_opt value =
+  match String.trim value with
+  | "" -> None
+  | value -> Some value
+;;
 
-let specs =
-  [ ( "--base-path"
-    , Arg.Set_string base_path
-    , "PATH Workspace root; runtime state is read from PATH/.masc" )
-  ; "--json", Arg.Set json, "Emit JSON"
-  ; "--trace-limit", Arg.Set_int trace_limit, "N Number of joined trace rows to print"
-  ; "--fact-key-limit", Arg.Set_int fact_key_limit, "N Number of fact-key summary rows to print"
-  ; ( "--summary-index-path"
-    , Arg.Set_string summary_index_path
-    , "PATH Write compact fact-key outcome summary JSONL to PATH" )
-  ]
+type cli_config =
+  { base_path : string
+  ; json : bool
+  ; trace_limit : int
+  ; fact_key_limit : int
+  ; summary_index_path : string option
+  }
+
+let default_config () =
+  { base_path = Option.value (default_base_path_opt ()) ~default:""
+  ; json = false
+  ; trace_limit = 50
+  ; fact_key_limit = 50
+  ; summary_index_path = None
+  }
 ;;
 
 let () =
+  let config = ref (default_config ()) in
+  let update f = config := f !config in
+  let specs =
+    [ ( "--base-path"
+      , Arg.String (fun base_path -> update (fun c -> { c with base_path }))
+      , "PATH Workspace root; runtime state is read from PATH/.masc" )
+    ; "--json", Arg.Unit (fun () -> update (fun c -> { c with json = true })), "Emit JSON"
+    ; ( "--trace-limit"
+      , Arg.Int (fun trace_limit -> update (fun c -> { c with trace_limit }))
+      , "N Number of joined trace rows to print" )
+    ; ( "--fact-key-limit"
+      , Arg.Int (fun fact_key_limit -> update (fun c -> { c with fact_key_limit }))
+      , "N Number of fact-key summary rows to print" )
+    ; ( "--summary-index-path"
+      , Arg.String
+          (fun value ->
+             update (fun c -> { c with summary_index_path = nonempty_opt value }))
+      , "PATH Write compact fact-key outcome summary JSONL to PATH" )
+    ]
+  in
   Arg.parse specs (fun arg -> raise (Arg.Bad ("unexpected argument: " ^ arg)))
     "masc-recall-outcome-eval [--base-path PATH] [--json] [--trace-limit N] \
      [--fact-key-limit N] [--summary-index-path PATH]";
   let base_path =
-    match String.trim !base_path with
+    match String.trim (!config).base_path with
     | "" ->
       prerr_endline
         "masc-recall-outcome-eval: --base-path is required when \
@@ -35,12 +59,13 @@ let () =
     | value -> Env_config.normalize_masc_base_path_input value
   in
   let masc_root = Common.masc_dir_from_base_path ~base_path in
-  let trace_limit = max 0 !trace_limit in
-  let fact_key_limit = max 0 !fact_key_limit in
+  let trace_limit = max 0 (!config).trace_limit in
+  let fact_key_limit = max 0 (!config).fact_key_limit in
   let report = Masc.Keeper_recall_outcome_eval.evaluate ~masc_root in
-  if String.trim !summary_index_path <> ""
-  then Masc.Keeper_recall_outcome_eval.write_summary_index ~path:!summary_index_path report;
-  if !json
+  Option.iter
+    (fun path -> Masc.Keeper_recall_outcome_eval.write_summary_index ~path report)
+    (!config).summary_index_path;
+  if (!config).json
   then
     print_endline
       (Yojson.Safe.pretty_to_string

--- a/bin/masc_recall_outcome_eval.ml
+++ b/bin/masc_recall_outcome_eval.ml
@@ -1,10 +1,8 @@
-let default_base_path () =
-  match Sys.getenv_opt "MASC_BASE_PATH" with
-  | Some path when String.trim path <> "" -> path
-  | _ -> Sys.getcwd ()
+let default_base_path_opt () =
+  Config_dir_resolver.current_env_base_path_opt ()
 ;;
 
-let base_path = ref (default_base_path ())
+let base_path = ref (Option.value (default_base_path_opt ()) ~default:"")
 let json = ref false
 let trace_limit = ref 50
 let fact_key_limit = ref 50
@@ -25,8 +23,17 @@ let specs =
 
 let () =
   Arg.parse specs (fun arg -> raise (Arg.Bad ("unexpected argument: " ^ arg)))
-    "masc-recall-outcome-eval [--base-path PATH] [--json] [--trace-limit N]";
-  let base_path = Env_config.normalize_masc_base_path_input !base_path in
+    "masc-recall-outcome-eval [--base-path PATH] [--json] [--trace-limit N] \
+     [--fact-key-limit N] [--summary-index-path PATH]";
+  let base_path =
+    match String.trim !base_path with
+    | "" ->
+      prerr_endline
+        "masc-recall-outcome-eval: --base-path is required when \
+         MASC_BASE_PATH_INPUT/MASC_BASE_PATH is unset";
+      exit 2
+    | value -> Env_config.normalize_masc_base_path_input value
+  in
   let masc_root = Common.masc_dir_from_base_path ~base_path in
   let trace_limit = max 0 !trace_limit in
   let fact_key_limit = max 0 !fact_key_limit in

--- a/bin/masc_recall_outcome_eval.ml
+++ b/bin/masc_recall_outcome_eval.ml
@@ -1,0 +1,33 @@
+let default_base_path () =
+  match Sys.getenv_opt "MASC_BASE_PATH" with
+  | Some path when String.trim path <> "" -> path
+  | _ -> Sys.getcwd ()
+;;
+
+let base_path = ref (default_base_path ())
+let json = ref false
+let trace_limit = ref 50
+
+let specs =
+  [ ( "--base-path"
+    , Arg.Set_string base_path
+    , "PATH Workspace root; runtime state is read from PATH/.masc" )
+  ; "--json", Arg.Set json, "Emit JSON"
+  ; "--trace-limit", Arg.Set_int trace_limit, "N Number of joined trace rows to print"
+  ]
+;;
+
+let () =
+  Arg.parse specs (fun arg -> raise (Arg.Bad ("unexpected argument: " ^ arg)))
+    "masc-recall-outcome-eval [--base-path PATH] [--json] [--trace-limit N]";
+  let base_path = Env_config.normalize_masc_base_path_input !base_path in
+  let masc_root = Common.masc_dir_from_base_path ~base_path in
+  let trace_limit = max 0 !trace_limit in
+  let report = Masc.Keeper_recall_outcome_eval.evaluate ~masc_root in
+  if !json
+  then
+    print_endline
+      (Yojson.Safe.pretty_to_string
+         (Masc.Keeper_recall_outcome_eval.to_json ~trace_limit report))
+  else print_string (Masc.Keeper_recall_outcome_eval.render_text ~trace_limit report)
+;;

--- a/lib/dune
+++ b/lib/dune
@@ -190,7 +190,7 @@
   meta_cognition_parse
   meta_cognition_interpret
   meta_cognition_digest
-  keeper_memory_os_gc keeper_memory_os_gc_dry_run_report
+  keeper_recall_outcome_eval keeper_memory_os_gc keeper_memory_os_gc_dry_run_report
   keeper_memory_os_hebbian
   keeper_memory_os_io keeper_user_model
   keeper_memory_os_recall)

--- a/lib/keeper/keeper_agent_run_receipt_append.ml
+++ b/lib/keeper/keeper_agent_run_receipt_append.ml
@@ -29,8 +29,10 @@ let append_with_coverage_gap
          ~producer:"keeper_agent_run.execution_receipt"
          ~durable_store:
            (Filename.concat
-              (Filename.concat (Filename.concat masc_root "keepers") keeper_name)
-              "execution-receipts")
+              (Filename.concat
+                 (Filename.concat masc_root Common.keepers_runtime_dirname)
+                 keeper_name)
+              Keeper_types_support.execution_receipts_dirname)
          ~dashboard_surface:"/api/v1/dashboard/execution-trust"
          ~stale_reason:"execution_receipt_append_failed"
          ~keeper_name

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -434,7 +434,7 @@ let to_json (receipt : t) =
       ()
   in
   `Assoc
-    [ "schema", `String "keeper.execution_receipt.v1"
+    [ "schema", `String Keeper_types_support.execution_receipt_schema
     ; "recorded_at", `String receipt.ended_at
     ; "keeper_name", `String receipt.keeper_name
     ; "agent_name", `String receipt.agent_name

--- a/lib/keeper/keeper_recall_outcome_eval.ml
+++ b/lib/keeper/keeper_recall_outcome_eval.ml
@@ -103,40 +103,87 @@ let merge_load_stats a b =
 
 let jsonl_suffix = ".jsonl"
 
-let is_dir path = try Sys.is_directory path with Sys_error _ -> false
+type directory_status =
+  | Directory
+  | Not_directory
+  | Missing
+  | Directory_access_error of string
+
+let directory_status path =
+  try
+    match (Unix.lstat path).Unix.st_kind with
+    | Unix.S_DIR -> Directory
+    | _ -> Not_directory
+  with
+  | Unix.Unix_error (Unix.ENOENT, _, _)
+  | Unix.Unix_error (Unix.ENOTDIR, _, _) -> Missing
+  | Unix.Unix_error (err, _, _) -> Directory_access_error (Unix.error_message err)
+;;
+
+let load_stats_error ~operation path message =
+  { empty_load_stats with
+    read_error_count = 1
+  ; errors = [ Printf.sprintf "%s: %s failed: %s" path operation message ]
+  }
+;;
+
+let sorted_readdir path =
+  try Ok (Sys.readdir path |> Array.to_list |> List.sort String.compare) with
+  | Sys_error msg -> Error msg
+;;
 
 let rec find_jsonl dir =
-  if Sys.file_exists dir && is_dir dir
-  then
-    Sys.readdir dir
-    |> Array.to_list
-    |> List.sort String.compare
-    |> List.concat_map (fun name ->
-      let path = Filename.concat dir name in
-      if is_dir path
-      then find_jsonl path
-      else if Filename.check_suffix path jsonl_suffix
-      then [ path ]
-      else [])
-  else []
+  match directory_status dir with
+  | Missing | Not_directory -> [], empty_load_stats
+  | Directory_access_error message -> [], load_stats_error ~operation:"lstat" dir message
+  | Directory ->
+    (match sorted_readdir dir with
+     | Error message -> [], load_stats_error ~operation:"readdir" dir message
+     | Ok names ->
+       List.fold_left
+         (fun (files, stats) name ->
+            let path = Filename.concat dir name in
+            match directory_status path with
+            | Directory ->
+              let child_files, child_stats = find_jsonl path in
+              files @ child_files, merge_load_stats stats child_stats
+            | Not_directory ->
+              if Filename.check_suffix path jsonl_suffix
+              then files @ [ path ], stats
+              else files, stats
+            | Missing -> files, stats
+            | Directory_access_error message ->
+              files, merge_load_stats stats (load_stats_error ~operation:"lstat" path message))
+         ([], empty_load_stats)
+         names)
 ;;
 
 let find_receipt_jsonl keepers_dir =
-  if Sys.file_exists keepers_dir && is_dir keepers_dir
-  then
-    Sys.readdir keepers_dir
-    |> Array.to_list
-    |> List.sort String.compare
-    |> List.concat_map (fun keeper_name ->
-      let keeper_dir = Filename.concat keepers_dir keeper_name in
-      if is_dir keeper_dir
-      then
-        find_jsonl
-          (Filename.concat
-             keeper_dir
-             Keeper_types_support.execution_receipts_dirname)
-      else [])
-  else []
+  match directory_status keepers_dir with
+  | Missing | Not_directory -> [], empty_load_stats
+  | Directory_access_error message ->
+    [], load_stats_error ~operation:"lstat" keepers_dir message
+  | Directory ->
+    (match sorted_readdir keepers_dir with
+     | Error message -> [], load_stats_error ~operation:"readdir" keepers_dir message
+     | Ok names ->
+       List.fold_left
+         (fun (files, stats) keeper_name ->
+            let keeper_dir = Filename.concat keepers_dir keeper_name in
+            match directory_status keeper_dir with
+            | Directory ->
+              let receipt_files, receipt_stats =
+                find_jsonl
+                  (Filename.concat
+                     keeper_dir
+                     Keeper_types_support.execution_receipts_dirname)
+              in
+              files @ receipt_files, merge_load_stats stats receipt_stats
+            | Not_directory | Missing -> files, stats
+            | Directory_access_error message ->
+              files, merge_load_stats stats (load_stats_error ~operation:"lstat" keeper_dir message))
+         ([], empty_load_stats)
+         names)
 ;;
 
 let read_lines path =
@@ -280,7 +327,11 @@ let load_records_from_files files parse =
   List.rev records, stats
 ;;
 
-let load_records dir parse = load_records_from_files (find_jsonl dir) parse
+let load_records dir parse =
+  let files, scan_stats = find_jsonl dir in
+  let records, load_stats = load_records_from_files files parse in
+  records, merge_load_stats scan_stats load_stats
+;;
 
 let newer_receipt candidate existing =
   match candidate.ended_at_unix, existing.ended_at_unix with
@@ -360,6 +411,17 @@ let trace_row_of_group
       if by_turn <> 0 then by_turn else String.compare a.keeper_id b.keeper_id
   in
   let records = List.sort compare_record records in
+  let latest_record =
+    match records with
+    | [] -> None
+    | first :: rest ->
+      Some
+        (List.fold_left
+           (fun latest record ->
+              if compare_record latest record <= 0 then record else latest)
+           first
+           rest)
+  in
   let receipt = String_map.find_opt trace_id receipts in
   let outcome_bucket = outcome_bucket_of_receipt receipt in
   let fact_keys =
@@ -369,9 +431,9 @@ let trace_row_of_group
   in
   { trace_id
   ; keeper_id =
-      (match List.rev records with
-       | r :: _ -> Some r.keeper_id
-       | [] -> None)
+      (match latest_record with
+       | Some record -> Some record.keeper_id
+       | None -> None)
   ; recall_records = List.length records
   ; fact_keys
   ; injected_fact_keys =
@@ -491,7 +553,9 @@ let evaluate ~masc_root =
   let receipts_dir = Filename.concat masc_root Common.keepers_runtime_dirname in
   let recall_records, recall_stats = load_records recall_dir parse_recall_json in
   let receipts, receipt_stats =
-    load_records_from_files (find_receipt_jsonl receipts_dir) parse_receipt_json
+    let files, scan_stats = find_receipt_jsonl receipts_dir in
+    let records, load_stats = load_records_from_files files parse_receipt_json in
+    records, merge_load_stats scan_stats load_stats
   in
   let receipts_by_trace = receipt_map receipts in
   let traces =
@@ -653,8 +717,8 @@ let render_trace row =
   in
   let terminal =
     match row.receipt with
-    | Some receipt when receipt.terminal_reason_code <> "" -> receipt.terminal_reason_code
-    | Some _ | None -> "-"
+    | Some receipt -> receipt.terminal_reason_code
+    | None -> "-"
   in
   Printf.sprintf
     "%s\t%s\trecall=%d\tfacts=%d\tfailures=%d\ttask=%s\tterminal=%s\n"

--- a/lib/keeper/keeper_recall_outcome_eval.ml
+++ b/lib/keeper/keeper_recall_outcome_eval.ml
@@ -2,11 +2,13 @@
     receipt outcomes. *)
 
 module String_map = Map.Make (String)
+module String_set = Set.Make (String)
 
 type recall_record =
   { keeper_id : string
   ; trace_id : string
   ; turn : int
+  ; injected_fact_keys : string list
   ; injected_fact_key_count : int
   ; injected_episode_key_count : int
   ; failure_reason : string option
@@ -34,10 +36,25 @@ type trace_row =
   { trace_id : string
   ; keeper_id : string option
   ; recall_records : int
+  ; fact_keys : string list
   ; injected_fact_keys : int
   ; recall_failure_records : int
   ; receipt : receipt_record option
   ; outcome_bucket : outcome_bucket
+  }
+
+type fact_key_summary =
+  { fact_key : string
+  ; injected_count : int
+  ; recall_records : int
+  ; recall_failure_records : int
+  ; trace_count : int
+  ; outcome_ok : int
+  ; outcome_skipped : int
+  ; outcome_error : int
+  ; outcome_cancelled : int
+  ; outcome_unknown : int
+  ; outcome_missing_receipt : int
   }
 
 type t =
@@ -55,6 +72,7 @@ type t =
   ; outcome_error : int
   ; outcome_cancelled : int
   ; outcome_unknown : int
+  ; fact_key_summaries : fact_key_summary list
   ; traces : trace_row list
   }
 
@@ -116,7 +134,7 @@ let assoc_string_list fields key =
   match List.assoc_opt key fields with
   | Some (`List items) ->
     List.filter_map (function
-      | `String s -> Some s
+      | `String s when String.trim s <> "" -> Some s
       | _ -> None)
       items
   | _ -> []
@@ -132,12 +150,13 @@ let parse_recall_json = function
   | `Assoc fields ->
     (match assoc_string fields "keeper_id", assoc_string fields "trace_id" with
      | Some keeper_id, Some trace_id ->
+       let injected_fact_keys = assoc_string_list fields "injected_fact_keys" in
        Some
          { keeper_id
          ; trace_id
          ; turn = Option.value (assoc_int fields "turn") ~default:0
-         ; injected_fact_key_count =
-             List.length (assoc_string_list fields "injected_fact_keys")
+         ; injected_fact_keys
+         ; injected_fact_key_count = List.length injected_fact_keys
          ; injected_episode_key_count =
              List.length (assoc_string_list fields "injected_episode_keys")
          ; failure_reason = assoc_string fields "failure_reason"
@@ -179,9 +198,9 @@ let newer_receipt candidate existing =
   | None, None -> String.compare candidate.keeper_name existing.keeper_name < 0
 ;;
 
-let receipt_map receipts =
+let receipt_map (receipts : receipt_record list) : receipt_record String_map.t =
   List.fold_left
-    (fun acc receipt ->
+    (fun (acc : receipt_record String_map.t) (receipt : receipt_record) ->
        match String_map.find_opt receipt.trace_id acc with
        | None -> String_map.add receipt.trace_id receipt acc
        | Some existing when newer_receipt receipt existing ->
@@ -220,13 +239,29 @@ let outcome_bucket_to_string = function
   | Outcome_missing_receipt -> "missing_receipt"
 ;;
 
-let trace_row_of_group receipts trace_id records =
+let unique_sorted xs =
+  xs
+  |> List.fold_left
+       (fun acc x -> if String.trim x = "" then acc else String_set.add x acc)
+       String_set.empty
+  |> String_set.elements
+;;
+
+let trace_row_of_group
+      (receipts : receipt_record String_map.t)
+      trace_id
+      (records : recall_record list)
+  =
   let records = List.rev records in
   let receipt = String_map.find_opt trace_id receipts in
   let outcome_bucket = outcome_bucket_of_receipt receipt in
+  let fact_keys =
+    records |> List.concat_map (fun r -> r.injected_fact_keys) |> unique_sorted
+  in
   { trace_id
   ; keeper_id = (match records with r :: _ -> Some r.keeper_id | [] -> None)
   ; recall_records = List.length records
+  ; fact_keys
   ; injected_fact_keys =
       List.fold_left (fun acc r -> acc + r.injected_fact_key_count) 0 records
   ; recall_failure_records =
@@ -237,6 +272,102 @@ let trace_row_of_group receipts trace_id records =
   ; receipt
   ; outcome_bucket
   }
+;;
+
+let empty_fact_key_summary fact_key =
+  { fact_key
+  ; injected_count = 0
+  ; recall_records = 0
+  ; recall_failure_records = 0
+  ; trace_count = 0
+  ; outcome_ok = 0
+  ; outcome_skipped = 0
+  ; outcome_error = 0
+  ; outcome_cancelled = 0
+  ; outcome_unknown = 0
+  ; outcome_missing_receipt = 0
+  }
+;;
+
+let update_fact_key_summary fact_key f acc =
+  let current =
+    Option.value
+      (String_map.find_opt fact_key acc)
+      ~default:(empty_fact_key_summary fact_key)
+  in
+  String_map.add fact_key (f current) acc
+;;
+
+let key_counts keys =
+  List.fold_left
+    (fun acc key ->
+       let current = Option.value (String_map.find_opt key acc) ~default:0 in
+       String_map.add key (current + 1) acc)
+    String_map.empty
+    keys
+;;
+
+let add_record_to_fact_summaries acc record =
+  let counts = key_counts record.injected_fact_keys in
+  String_map.fold
+    (fun fact_key count acc ->
+       update_fact_key_summary
+         fact_key
+         (fun row ->
+            { row with
+              injected_count = row.injected_count + count
+            ; recall_records = row.recall_records + 1
+            ; recall_failure_records =
+                row.recall_failure_records
+                + if Option.is_some record.failure_reason then 1 else 0
+            })
+         acc)
+    counts
+    acc
+;;
+
+let add_outcome_to_fact_summary bucket row =
+  match bucket with
+  | Outcome_ok -> { row with outcome_ok = row.outcome_ok + 1 }
+  | Outcome_skipped -> { row with outcome_skipped = row.outcome_skipped + 1 }
+  | Outcome_error -> { row with outcome_error = row.outcome_error + 1 }
+  | Outcome_cancelled -> { row with outcome_cancelled = row.outcome_cancelled + 1 }
+  | Outcome_unknown -> { row with outcome_unknown = row.outcome_unknown + 1 }
+  | Outcome_missing_receipt ->
+    { row with outcome_missing_receipt = row.outcome_missing_receipt + 1 }
+;;
+
+let add_trace_to_fact_summaries acc row =
+  List.fold_left
+    (fun acc fact_key ->
+       update_fact_key_summary
+         fact_key
+         (fun summary ->
+            summary
+            |> add_outcome_to_fact_summary row.outcome_bucket
+            |> fun summary -> { summary with trace_count = summary.trace_count + 1 })
+         acc)
+    acc
+    row.fact_keys
+;;
+
+let compare_fact_key_summary a b =
+  let by_trace = compare b.trace_count a.trace_count in
+  if by_trace <> 0
+  then by_trace
+  else (
+    let by_injected = compare b.injected_count a.injected_count in
+    if by_injected <> 0 then by_injected else String.compare a.fact_key b.fact_key)
+;;
+
+let fact_key_summaries recall_records traces =
+  let from_records =
+    List.fold_left add_record_to_fact_summaries String_map.empty recall_records
+  in
+  List.fold_left add_trace_to_fact_summaries from_records traces
+  |> String_map.bindings
+  |> List.map snd
+  |> List.sort compare_fact_key_summary
 ;;
 
 let evaluate ~masc_root =
@@ -258,6 +389,7 @@ let evaluate ~masc_root =
       0
       traces
   in
+  let fact_key_summaries = fact_key_summaries recall_records traces in
   { masc_root
   ; recall_dir
   ; receipts_dir
@@ -278,6 +410,7 @@ let evaluate ~masc_root =
   ; outcome_error = count_bucket Outcome_error
   ; outcome_cancelled = count_bucket Outcome_cancelled
   ; outcome_unknown = count_bucket Outcome_unknown
+  ; fact_key_summaries
   ; traces
   }
 ;;
@@ -303,6 +436,7 @@ let trace_row_to_json row =
     [ "trace_id", `String row.trace_id
     ; "keeper_id", string_opt_to_json row.keeper_id
     ; "recall_records", `Int row.recall_records
+    ; "fact_keys", `List (List.map (fun key -> `String key) row.fact_keys)
     ; "injected_fact_keys", `Int row.injected_fact_keys
     ; "recall_failure_records", `Int row.recall_failure_records
     ; "outcome_bucket", `String (outcome_bucket_to_string row.outcome_bucket)
@@ -310,6 +444,25 @@ let trace_row_to_json row =
       , match row.receipt with
         | Some receipt -> receipt_to_json receipt
         | None -> `Null )
+    ]
+;;
+
+let fact_key_summary_to_json row =
+  `Assoc
+    [ "fact_key", `String row.fact_key
+    ; "injected_count", `Int row.injected_count
+    ; "recall_records", `Int row.recall_records
+    ; "recall_failure_records", `Int row.recall_failure_records
+    ; "trace_count", `Int row.trace_count
+    ; ( "outcomes"
+      , `Assoc
+          [ "ok", `Int row.outcome_ok
+          ; "skipped", `Int row.outcome_skipped
+          ; "error", `Int row.outcome_error
+          ; "cancelled", `Int row.outcome_cancelled
+          ; "unknown", `Int row.outcome_unknown
+          ; "missing_receipt", `Int row.outcome_missing_receipt
+          ] )
     ]
 ;;
 
@@ -322,7 +475,7 @@ let take n xs =
   loop n [] xs
 ;;
 
-let to_json ?(trace_limit = 50) report =
+let to_json ?(trace_limit = 50) ?(fact_key_limit = 50) report =
   `Assoc
     [ "masc_root", `String report.masc_root
     ; "recall_dir", `String report.recall_dir
@@ -341,6 +494,17 @@ let to_json ?(trace_limit = 50) report =
           ; "cancelled", `Int report.outcome_cancelled
           ; "unknown", `Int report.outcome_unknown
           ; "missing_receipt", `Int report.traces_without_receipt
+          ] )
+    ; ( "fact_key_summary_index"
+      , `Assoc
+          [ "indexed_by", `List [ `String "fact_key"; `String "trace_outcome" ]
+          ; "total_fact_keys", `Int (List.length report.fact_key_summaries)
+          ; "fact_key_limit", `Int fact_key_limit
+          ; ( "rows"
+            , `List
+                (List.map
+                   fact_key_summary_to_json
+                   (take fact_key_limit report.fact_key_summaries)) )
           ] )
     ; "trace_limit", `Int trace_limit
     ; "traces", `List (List.map trace_row_to_json (take trace_limit report.traces))
@@ -369,12 +533,33 @@ let render_trace row =
     terminal
 ;;
 
-let render_text ?(trace_limit = 50) report =
+let render_fact_key_summary row =
+  Printf.sprintf
+    "%s\ttraces=%d\tinjections=%d\tfailures=%d\tok=%d\tskipped=%d\terror=%d\tcancelled=%d\tunknown=%d\tmissing=%d\n"
+    row.fact_key
+    row.trace_count
+    row.injected_count
+    row.recall_failure_records
+    row.outcome_ok
+    row.outcome_skipped
+    row.outcome_error
+    row.outcome_cancelled
+    row.outcome_unknown
+    row.outcome_missing_receipt
+;;
+
+let render_text ?(trace_limit = 50) ?(fact_key_limit = 50) report =
   let traces = take trace_limit report.traces in
   let trace_lines =
     match traces with
     | [] -> "no recall traces found\n"
     | rows -> rows |> List.map render_trace |> String.concat ""
+  in
+  let fact_key_rows = take fact_key_limit report.fact_key_summaries in
+  let fact_key_lines =
+    match fact_key_rows with
+    | [] -> "no injected fact keys found\n"
+    | rows -> rows |> List.map render_fact_key_summary |> String.concat ""
   in
   Printf.sprintf
     "Memory OS recall outcome eval (local receipts only)\n\
@@ -383,6 +568,8 @@ let render_text ?(trace_limit = 50) report =
      joined: with_receipt=%d without_receipt=%d\n\
      injected_fact_keys=%d recall_failure_records=%d\n\
      outcomes: ok=%d skipped=%d error=%d cancelled=%d unknown=%d missing_receipt=%d\n\
+     fact_key_summary_index: total_fact_keys=%d fact_key_limit=%d\n\
+     %s\
      trace_limit=%d\n\
      %s"
     report.masc_root
@@ -398,6 +585,34 @@ let render_text ?(trace_limit = 50) report =
     report.outcome_cancelled
     report.outcome_unknown
     report.traces_without_receipt
+    (List.length report.fact_key_summaries)
+    fact_key_limit
+    fact_key_lines
     trace_limit
     trace_lines
+;;
+
+let rec mkdir_p path =
+  if path = "" || path = Filename.current_dir_name
+  then ()
+  else if Sys.file_exists path
+  then ()
+  else (
+    let parent = Filename.dirname path in
+    if not (String.equal parent path) then mkdir_p parent;
+    Unix.mkdir path 0o755)
+;;
+
+let write_summary_index ~path report =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+       List.iter
+         (fun row ->
+            output_string oc (Yojson.Safe.to_string (fact_key_summary_to_json row));
+            output_char oc '\n')
+         report.fact_key_summaries;
+       close_out oc)
 ;;

--- a/lib/keeper/keeper_recall_outcome_eval.ml
+++ b/lib/keeper/keeper_recall_outcome_eval.ml
@@ -1,0 +1,403 @@
+(** Offline, read-only join from recall-injection ledger rows to local execution
+    receipt outcomes. *)
+
+module String_map = Map.Make (String)
+
+type recall_record =
+  { keeper_id : string
+  ; trace_id : string
+  ; turn : int
+  ; injected_fact_key_count : int
+  ; injected_episode_key_count : int
+  ; failure_reason : string option
+  ; ts : float option
+  }
+
+type receipt_record =
+  { keeper_name : string
+  ; trace_id : string
+  ; outcome : string
+  ; terminal_reason_code : string
+  ; current_task_id : string option
+  ; ended_at : string option
+  }
+
+type outcome_bucket =
+  | Outcome_ok
+  | Outcome_skipped
+  | Outcome_error
+  | Outcome_cancelled
+  | Outcome_unknown
+  | Outcome_missing_receipt
+
+type trace_row =
+  { trace_id : string
+  ; keeper_id : string option
+  ; recall_records : int
+  ; injected_fact_keys : int
+  ; recall_failure_records : int
+  ; receipt : receipt_record option
+  ; outcome_bucket : outcome_bucket
+  }
+
+type t =
+  { masc_root : string
+  ; recall_dir : string
+  ; receipts_dir : string
+  ; recall_records : int
+  ; recall_traces : int
+  ; traces_with_receipt : int
+  ; traces_without_receipt : int
+  ; injected_fact_keys : int
+  ; recall_failure_records : int
+  ; outcome_ok : int
+  ; outcome_skipped : int
+  ; outcome_error : int
+  ; outcome_cancelled : int
+  ; outcome_unknown : int
+  ; traces : trace_row list
+  }
+
+let is_dir path = try Sys.is_directory path with Sys_error _ -> false
+
+let rec find_jsonl dir =
+  if Sys.file_exists dir && is_dir dir
+  then
+    Sys.readdir dir
+    |> Array.to_list
+    |> List.sort String.compare
+    |> List.concat_map (fun name ->
+      let path = Filename.concat dir name in
+      if is_dir path
+      then find_jsonl path
+      else if Filename.check_suffix path ".jsonl"
+      then [ path ]
+      else [])
+  else []
+;;
+
+let read_lines path =
+  try
+    let ic = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+         let rec loop acc =
+           match input_line ic with
+           | line -> loop (line :: acc)
+           | exception End_of_file -> List.rev acc
+         in
+         loop [])
+  with
+  | Sys_error _ -> []
+;;
+
+let assoc_string fields key =
+  match List.assoc_opt key fields with
+  | Some (`String s) when String.trim s <> "" -> Some s
+  | _ -> None
+;;
+
+let assoc_int fields key =
+  match List.assoc_opt key fields with
+  | Some (`Int i) -> Some i
+  | Some (`Float f) -> Some (int_of_float f)
+  | _ -> None
+;;
+
+let assoc_float fields key =
+  match List.assoc_opt key fields with
+  | Some (`Float f) -> Some f
+  | Some (`Int i) -> Some (float_of_int i)
+  | _ -> None
+;;
+
+let assoc_string_list fields key =
+  match List.assoc_opt key fields with
+  | Some (`List items) ->
+    List.filter_map (function
+      | `String s -> Some s
+      | _ -> None)
+      items
+  | _ -> []
+;;
+
+let parse_json_line line =
+  match Yojson.Safe.from_string line with
+  | json -> Some json
+  | exception Yojson.Json_error _ -> None
+;;
+
+let parse_recall_json = function
+  | `Assoc fields ->
+    (match assoc_string fields "keeper_id", assoc_string fields "trace_id" with
+     | Some keeper_id, Some trace_id ->
+       Some
+         { keeper_id
+         ; trace_id
+         ; turn = Option.value (assoc_int fields "turn") ~default:0
+         ; injected_fact_key_count =
+             List.length (assoc_string_list fields "injected_fact_keys")
+         ; injected_episode_key_count =
+             List.length (assoc_string_list fields "injected_episode_keys")
+         ; failure_reason = assoc_string fields "failure_reason"
+         ; ts = assoc_float fields "ts"
+         }
+     | _ -> None)
+  | _ -> None
+;;
+
+let parse_receipt_json = function
+  | `Assoc fields ->
+    (match assoc_string fields "trace_id" with
+     | Some trace_id ->
+       Some
+         { keeper_name = Option.value (assoc_string fields "keeper_name") ~default:""
+         ; trace_id
+         ; outcome = Option.value (assoc_string fields "outcome") ~default:""
+         ; terminal_reason_code =
+             Option.value (assoc_string fields "terminal_reason_code") ~default:""
+         ; current_task_id = assoc_string fields "current_task_id"
+         ; ended_at = assoc_string fields "ended_at"
+         }
+     | None -> None)
+  | _ -> None
+;;
+
+let load_records dir parse =
+  find_jsonl dir
+  |> List.concat_map read_lines
+  |> List.filter_map parse_json_line
+  |> List.filter_map parse
+;;
+
+let newer_receipt candidate existing =
+  match candidate.ended_at, existing.ended_at with
+  | Some a, Some b -> String.compare a b > 0
+  | Some _, None -> true
+  | None, Some _ -> false
+  | None, None -> String.compare candidate.keeper_name existing.keeper_name < 0
+;;
+
+let receipt_map receipts =
+  List.fold_left
+    (fun acc receipt ->
+       match String_map.find_opt receipt.trace_id acc with
+       | None -> String_map.add receipt.trace_id receipt acc
+       | Some existing when newer_receipt receipt existing ->
+         String_map.add receipt.trace_id receipt acc
+       | Some _ -> acc)
+    String_map.empty
+    receipts
+;;
+
+let recall_groups records =
+  List.fold_left
+    (fun acc record ->
+       let existing = Option.value (String_map.find_opt record.trace_id acc) ~default:[] in
+       String_map.add record.trace_id (record :: existing) acc)
+    String_map.empty
+    records
+;;
+
+let outcome_bucket_of_receipt = function
+  | None -> Outcome_missing_receipt
+  | Some receipt ->
+    (match String.lowercase_ascii receipt.outcome with
+     | "receipt_done" | "ok" -> Outcome_ok
+     | "receipt_skipped" | "skipped" -> Outcome_skipped
+     | "receipt_failed" | "error" -> Outcome_error
+     | "receipt_cancelled" | "cancelled" -> Outcome_cancelled
+     | _ -> Outcome_unknown)
+;;
+
+let outcome_bucket_to_string = function
+  | Outcome_ok -> "ok"
+  | Outcome_skipped -> "skipped"
+  | Outcome_error -> "error"
+  | Outcome_cancelled -> "cancelled"
+  | Outcome_unknown -> "unknown"
+  | Outcome_missing_receipt -> "missing_receipt"
+;;
+
+let trace_row_of_group receipts trace_id records =
+  let records = List.rev records in
+  let receipt = String_map.find_opt trace_id receipts in
+  let outcome_bucket = outcome_bucket_of_receipt receipt in
+  { trace_id
+  ; keeper_id = (match records with r :: _ -> Some r.keeper_id | [] -> None)
+  ; recall_records = List.length records
+  ; injected_fact_keys =
+      List.fold_left (fun acc r -> acc + r.injected_fact_key_count) 0 records
+  ; recall_failure_records =
+      List.fold_left
+        (fun acc r -> if Option.is_some r.failure_reason then acc + 1 else acc)
+        0
+        records
+  ; receipt
+  ; outcome_bucket
+  }
+;;
+
+let evaluate ~masc_root =
+  let recall_dir = Filename.concat masc_root "recall_injections" in
+  let receipts_dir = Filename.concat masc_root "keepers" in
+  let recall_records = load_records recall_dir parse_recall_json in
+  let receipts = load_records receipts_dir parse_receipt_json in
+  let receipts_by_trace = receipt_map receipts in
+  let traces =
+    recall_groups recall_records
+    |> String_map.bindings
+    |> List.map (fun (trace_id, records) ->
+      trace_row_of_group receipts_by_trace trace_id records)
+    |> List.sort (fun a b -> String.compare a.trace_id b.trace_id)
+  in
+  let count_bucket bucket =
+    List.fold_left
+      (fun acc row -> if row.outcome_bucket = bucket then acc + 1 else acc)
+      0
+      traces
+  in
+  { masc_root
+  ; recall_dir
+  ; receipts_dir
+  ; recall_records = List.length recall_records
+  ; recall_traces = List.length traces
+  ; traces_with_receipt =
+      List.fold_left
+        (fun acc row -> if Option.is_some row.receipt then acc + 1 else acc)
+        0
+        traces
+  ; traces_without_receipt = count_bucket Outcome_missing_receipt
+  ; injected_fact_keys =
+      List.fold_left (fun acc row -> acc + row.injected_fact_keys) 0 traces
+  ; recall_failure_records =
+      List.fold_left (fun acc row -> acc + row.recall_failure_records) 0 traces
+  ; outcome_ok = count_bucket Outcome_ok
+  ; outcome_skipped = count_bucket Outcome_skipped
+  ; outcome_error = count_bucket Outcome_error
+  ; outcome_cancelled = count_bucket Outcome_cancelled
+  ; outcome_unknown = count_bucket Outcome_unknown
+  ; traces
+  }
+;;
+
+let string_opt_to_json = function
+  | Some s -> `String s
+  | None -> `Null
+;;
+
+let receipt_to_json receipt =
+  `Assoc
+    [ "keeper_name", `String receipt.keeper_name
+    ; "trace_id", `String receipt.trace_id
+    ; "outcome", `String receipt.outcome
+    ; "terminal_reason_code", `String receipt.terminal_reason_code
+    ; "current_task_id", string_opt_to_json receipt.current_task_id
+    ; "ended_at", string_opt_to_json receipt.ended_at
+    ]
+;;
+
+let trace_row_to_json row =
+  `Assoc
+    [ "trace_id", `String row.trace_id
+    ; "keeper_id", string_opt_to_json row.keeper_id
+    ; "recall_records", `Int row.recall_records
+    ; "injected_fact_keys", `Int row.injected_fact_keys
+    ; "recall_failure_records", `Int row.recall_failure_records
+    ; "outcome_bucket", `String (outcome_bucket_to_string row.outcome_bucket)
+    ; ( "receipt"
+      , match row.receipt with
+        | Some receipt -> receipt_to_json receipt
+        | None -> `Null )
+    ]
+;;
+
+let take n xs =
+  let rec loop remaining acc = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | x :: rest -> loop (remaining - 1) (x :: acc) rest
+  in
+  loop n [] xs
+;;
+
+let to_json ?(trace_limit = 50) report =
+  `Assoc
+    [ "masc_root", `String report.masc_root
+    ; "recall_dir", `String report.recall_dir
+    ; "receipts_dir", `String report.receipts_dir
+    ; "recall_records", `Int report.recall_records
+    ; "recall_traces", `Int report.recall_traces
+    ; "traces_with_receipt", `Int report.traces_with_receipt
+    ; "traces_without_receipt", `Int report.traces_without_receipt
+    ; "injected_fact_keys", `Int report.injected_fact_keys
+    ; "recall_failure_records", `Int report.recall_failure_records
+    ; ( "outcomes"
+      , `Assoc
+          [ "ok", `Int report.outcome_ok
+          ; "skipped", `Int report.outcome_skipped
+          ; "error", `Int report.outcome_error
+          ; "cancelled", `Int report.outcome_cancelled
+          ; "unknown", `Int report.outcome_unknown
+          ; "missing_receipt", `Int report.traces_without_receipt
+          ] )
+    ; "trace_limit", `Int trace_limit
+    ; "traces", `List (List.map trace_row_to_json (take trace_limit report.traces))
+    ]
+;;
+
+let render_trace row =
+  let task =
+    match row.receipt with
+    | Some { current_task_id = Some task; _ } -> task
+    | Some _ | None -> "-"
+  in
+  let terminal =
+    match row.receipt with
+    | Some receipt when receipt.terminal_reason_code <> "" -> receipt.terminal_reason_code
+    | Some _ | None -> "-"
+  in
+  Printf.sprintf
+    "%s\t%s\trecall=%d\tfacts=%d\tfailures=%d\ttask=%s\tterminal=%s\n"
+    row.trace_id
+    (outcome_bucket_to_string row.outcome_bucket)
+    row.recall_records
+    row.injected_fact_keys
+    row.recall_failure_records
+    task
+    terminal
+;;
+
+let render_text ?(trace_limit = 50) report =
+  let traces = take trace_limit report.traces in
+  let trace_lines =
+    match traces with
+    | [] -> "no recall traces found\n"
+    | rows -> rows |> List.map render_trace |> String.concat ""
+  in
+  Printf.sprintf
+    "Memory OS recall outcome eval (local receipts only)\n\
+     masc_root: %s\n\
+     recall_records: %d, recall_traces: %d\n\
+     joined: with_receipt=%d without_receipt=%d\n\
+     injected_fact_keys=%d recall_failure_records=%d\n\
+     outcomes: ok=%d skipped=%d error=%d cancelled=%d unknown=%d missing_receipt=%d\n\
+     trace_limit=%d\n\
+     %s"
+    report.masc_root
+    report.recall_records
+    report.recall_traces
+    report.traces_with_receipt
+    report.traces_without_receipt
+    report.injected_fact_keys
+    report.recall_failure_records
+    report.outcome_ok
+    report.outcome_skipped
+    report.outcome_error
+    report.outcome_cancelled
+    report.outcome_unknown
+    report.traces_without_receipt
+    trace_limit
+    trace_lines
+;;

--- a/lib/keeper/keeper_recall_outcome_eval.ml
+++ b/lib/keeper/keeper_recall_outcome_eval.ml
@@ -22,6 +22,7 @@ type receipt_record =
   ; terminal_reason_code : string
   ; current_task_id : string option
   ; ended_at : string option
+  ; ended_at_unix : float option
   }
 
 type outcome_bucket =
@@ -61,6 +62,11 @@ type t =
   { masc_root : string
   ; recall_dir : string
   ; receipts_dir : string
+  ; read_error_count : int
+  ; malformed_jsonl_rows : int
+  ; invalid_recall_rows : int
+  ; invalid_receipt_rows : int
+  ; load_errors : string list
   ; recall_records : int
   ; recall_traces : int
   ; traces_with_receipt : int
@@ -76,6 +82,27 @@ type t =
   ; traces : trace_row list
   }
 
+type load_stats =
+  { read_error_count : int
+  ; malformed_jsonl_rows : int
+  ; invalid_rows : int
+  ; errors : string list
+  }
+
+let empty_load_stats =
+  { read_error_count = 0; malformed_jsonl_rows = 0; invalid_rows = 0; errors = [] }
+;;
+
+let merge_load_stats a b =
+  { read_error_count = a.read_error_count + b.read_error_count
+  ; malformed_jsonl_rows = a.malformed_jsonl_rows + b.malformed_jsonl_rows
+  ; invalid_rows = a.invalid_rows + b.invalid_rows
+  ; errors = a.errors @ b.errors
+  }
+;;
+
+let jsonl_suffix = ".jsonl"
+
 let is_dir path = try Sys.is_directory path with Sys_error _ -> false
 
 let rec find_jsonl dir =
@@ -88,8 +115,26 @@ let rec find_jsonl dir =
       let path = Filename.concat dir name in
       if is_dir path
       then find_jsonl path
-      else if Filename.check_suffix path ".jsonl"
+      else if Filename.check_suffix path jsonl_suffix
       then [ path ]
+      else [])
+  else []
+;;
+
+let find_receipt_jsonl keepers_dir =
+  if Sys.file_exists keepers_dir && is_dir keepers_dir
+  then
+    Sys.readdir keepers_dir
+    |> Array.to_list
+    |> List.sort String.compare
+    |> List.concat_map (fun keeper_name ->
+      let keeper_dir = Filename.concat keepers_dir keeper_name in
+      if is_dir keeper_dir
+      then
+        find_jsonl
+          (Filename.concat
+             keeper_dir
+             Keeper_types_support.execution_receipts_dirname)
       else [])
   else []
 ;;
@@ -105,94 +150,141 @@ let read_lines path =
            | line -> loop (line :: acc)
            | exception End_of_file -> List.rev acc
          in
-         loop [])
+         Ok (loop []))
   with
-  | Sys_error _ -> []
+  | Sys_error msg ->
+    Error (Printf.sprintf "%s: %s" path msg)
 ;;
 
-let assoc_string fields key =
-  match List.assoc_opt key fields with
-  | Some (`String s) when String.trim s <> "" -> Some s
-  | _ -> None
-;;
-
-let assoc_int fields key =
-  match List.assoc_opt key fields with
-  | Some (`Int i) -> Some i
-  | Some (`Float f) -> Some (int_of_float f)
-  | _ -> None
-;;
-
-let assoc_float fields key =
-  match List.assoc_opt key fields with
-  | Some (`Float f) -> Some f
-  | Some (`Int i) -> Some (float_of_int i)
-  | _ -> None
-;;
-
-let assoc_string_list fields key =
-  match List.assoc_opt key fields with
-  | Some (`List items) ->
-    List.filter_map (function
-      | `String s when String.trim s <> "" -> Some s
-      | _ -> None)
-      items
-  | _ -> []
-;;
-
-let parse_json_line line =
+let parse_json_line ~path ~line_no line =
   match Yojson.Safe.from_string line with
-  | json -> Some json
-  | exception Yojson.Json_error _ -> None
+  | json -> Ok json
+  | exception Yojson.Json_error msg ->
+    Error (Printf.sprintf "%s:%d: malformed JSONL row: %s" path line_no msg)
 ;;
 
 let parse_recall_json = function
-  | `Assoc fields ->
-    (match assoc_string fields "keeper_id", assoc_string fields "trace_id" with
-     | Some keeper_id, Some trace_id ->
-       let injected_fact_keys = assoc_string_list fields "injected_fact_keys" in
+  | `Assoc _ as json ->
+    (match
+       ( Json_util.get_string_nonempty json "keeper_id"
+       , Json_util.get_string_nonempty json "trace_id"
+       , Json_util.get_int json "turn" )
+     with
+     | Some keeper_id, Some trace_id, Some turn ->
+       let injected_fact_keys = Json_util.get_string_list json "injected_fact_keys" in
+       let injected_episode_keys =
+         Json_util.get_string_list json "injected_episode_keys"
+       in
        Some
          { keeper_id
          ; trace_id
-         ; turn = Option.value (assoc_int fields "turn") ~default:0
+         ; turn
          ; injected_fact_keys
-         ; injected_fact_key_count = List.length injected_fact_keys
+         ; injected_fact_key_count =
+             Option.value
+               (Json_util.get_int json "injected_fact_key_count")
+               ~default:(List.length injected_fact_keys)
          ; injected_episode_key_count =
-             List.length (assoc_string_list fields "injected_episode_keys")
-         ; failure_reason = assoc_string fields "failure_reason"
-         ; ts = assoc_float fields "ts"
+             Option.value
+               (Json_util.get_int json "injected_episode_key_count")
+               ~default:(List.length injected_episode_keys)
+         ; failure_reason = Json_util.get_string_nonempty json "failure_reason"
+         ; ts = Json_util.get_float json "ts"
          }
      | _ -> None)
   | _ -> None
 ;;
 
-let parse_receipt_json = function
-  | `Assoc fields ->
-    (match assoc_string fields "trace_id" with
-     | Some trace_id ->
-       Some
-         { keeper_name = Option.value (assoc_string fields "keeper_name") ~default:""
-         ; trace_id
-         ; outcome = Option.value (assoc_string fields "outcome") ~default:""
-         ; terminal_reason_code =
-             Option.value (assoc_string fields "terminal_reason_code") ~default:""
-         ; current_task_id = assoc_string fields "current_task_id"
-         ; ended_at = assoc_string fields "ended_at"
-         }
+let parse_ended_at json =
+  match Json_util.get_string json "ended_at" with
+  | None -> Some (None, None)
+  | Some raw when String.trim raw = "" -> Some (Some raw, None)
+  | Some raw ->
+    (match Masc_domain.parse_iso8601_opt raw with
+     | Some ts -> Some (Some raw, Some ts)
      | None -> None)
+;;
+
+let parse_receipt_json = function
+  | `Assoc _ as json ->
+    (match
+       ( Json_util.get_string_nonempty json "schema"
+       , Json_util.get_string_nonempty json "keeper_name"
+       , Json_util.get_string_nonempty json "trace_id"
+       , Json_util.get_string_nonempty json "outcome"
+       , Json_util.get_string_nonempty json "terminal_reason_code"
+       , parse_ended_at json )
+     with
+     | ( Some schema
+       , Some keeper_name
+       , Some trace_id
+       , Some outcome
+       , Some terminal_reason_code
+       , Some (ended_at, ended_at_unix) )
+       when String.equal schema Keeper_types_support.execution_receipt_schema ->
+       Some
+         { keeper_name
+         ; trace_id
+         ; outcome
+         ; terminal_reason_code
+         ; current_task_id = Json_util.get_string json "current_task_id"
+         ; ended_at
+         ; ended_at_unix
+         }
+     | _ -> None)
   | _ -> None
 ;;
 
-let load_records dir parse =
-  find_jsonl dir
-  |> List.concat_map read_lines
-  |> List.filter_map parse_json_line
-  |> List.filter_map parse
+let load_records_from_files files parse =
+  let load_line path line_no (records, stats) line =
+    match parse_json_line ~path ~line_no line with
+    | Error error ->
+      ( records
+      , { stats with
+          malformed_jsonl_rows = stats.malformed_jsonl_rows + 1
+        ; errors = stats.errors @ [ error ]
+        } )
+    | Ok json ->
+      (match parse json with
+       | Some record -> record :: records, stats
+       | None ->
+         ( records
+         , { stats with
+             invalid_rows = stats.invalid_rows + 1
+           ; errors =
+               stats.errors
+               @ [ Printf.sprintf "%s:%d: invalid row schema" path line_no ]
+           } ))
+  in
+  let load_file (records, stats) path =
+    match read_lines path with
+    | Error error ->
+      ( records
+      , { stats with
+          read_error_count = stats.read_error_count + 1
+        ; errors = stats.errors @ [ error ]
+        } )
+    | Ok lines ->
+      let records, line_stats =
+        lines
+        |> List.mapi (fun idx line -> idx + 1, line)
+        |> List.fold_left
+             (fun acc (line_no, line) -> load_line path line_no acc line)
+             (records, empty_load_stats)
+      in
+      records, merge_load_stats stats line_stats
+  in
+  let records, stats =
+    files |> List.fold_left load_file ([], empty_load_stats)
+  in
+  List.rev records, stats
 ;;
 
+let load_records dir parse = load_records_from_files (find_jsonl dir) parse
+
 let newer_receipt candidate existing =
-  match candidate.ended_at, existing.ended_at with
-  | Some a, Some b -> String.compare a b > 0
+  match candidate.ended_at_unix, existing.ended_at_unix with
+  | Some a, Some b -> Float.compare a b > 0
   | Some _, None -> true
   | None, Some _ -> false
   | None, None -> String.compare candidate.keeper_name existing.keeper_name < 0
@@ -213,7 +305,11 @@ let receipt_map (receipts : receipt_record list) : receipt_record String_map.t =
 let recall_groups (records : recall_record list) : recall_record list String_map.t =
   List.fold_left
     (fun acc (record : recall_record) ->
-       let existing = Option.value (String_map.find_opt record.trace_id acc) ~default:[] in
+       let existing =
+         match String_map.find_opt record.trace_id acc with
+         | Some records -> records
+         | None -> []
+       in
        String_map.add record.trace_id (record :: existing) acc)
     String_map.empty
     records
@@ -222,12 +318,12 @@ let recall_groups (records : recall_record list) : recall_record list String_map
 let outcome_bucket_of_receipt = function
   | None -> Outcome_missing_receipt
   | Some receipt ->
-    (match String.lowercase_ascii receipt.outcome with
-     | "receipt_done" | "ok" -> Outcome_ok
-     | "receipt_skipped" | "skipped" -> Outcome_skipped
-     | "receipt_failed" | "error" -> Outcome_error
-     | "receipt_cancelled" | "cancelled" -> Outcome_cancelled
-     | _ -> Outcome_unknown)
+    (match Keeper_execution_receipt.outcome_kind_of_string receipt.outcome with
+     | Some `Ok -> Outcome_ok
+     | Some `Skipped -> Outcome_skipped
+     | Some `Error -> Outcome_error
+     | Some `Cancelled -> Outcome_cancelled
+     | None -> Outcome_unknown)
 ;;
 
 let outcome_bucket_to_string = function
@@ -252,7 +348,18 @@ let trace_row_of_group
       trace_id
       (records : recall_record list)
   =
-  let records = List.rev records in
+  let compare_record (a : recall_record) (b : recall_record) =
+    match a.ts, b.ts with
+    | Some a, Some b ->
+      let by_ts = Float.compare a b in
+      if by_ts <> 0 then by_ts else compare a.turn b.turn
+    | Some _, None -> 1
+    | None, Some _ -> -1
+    | None, None ->
+      let by_turn = compare a.turn b.turn in
+      if by_turn <> 0 then by_turn else String.compare a.keeper_id b.keeper_id
+  in
+  let records = List.sort compare_record records in
   let receipt = String_map.find_opt trace_id receipts in
   let outcome_bucket = outcome_bucket_of_receipt receipt in
   let fact_keys =
@@ -261,7 +368,10 @@ let trace_row_of_group
     |> unique_sorted
   in
   { trace_id
-  ; keeper_id = (match records with r :: _ -> Some r.keeper_id | [] -> None)
+  ; keeper_id =
+      (match List.rev records with
+       | r :: _ -> Some r.keeper_id
+       | [] -> None)
   ; recall_records = List.length records
   ; fact_keys
   ; injected_fact_keys =
@@ -303,7 +413,11 @@ let update_fact_key_summary fact_key f acc =
 let key_counts keys =
   List.fold_left
     (fun acc key ->
-       let current = Option.value (String_map.find_opt key acc) ~default:0 in
+       let current =
+         match String_map.find_opt key acc with
+         | Some count -> count
+         | None -> 0
+       in
        String_map.add key (current + 1) acc)
     String_map.empty
     keys
@@ -373,10 +487,12 @@ let fact_key_summaries recall_records traces =
 ;;
 
 let evaluate ~masc_root =
-  let recall_dir = Filename.concat masc_root "recall_injections" in
-  let receipts_dir = Filename.concat masc_root "keepers" in
-  let recall_records = load_records recall_dir parse_recall_json in
-  let receipts = load_records receipts_dir parse_receipt_json in
+  let recall_dir = Keeper_recall_injection_ledger.base_dir ~masc_root in
+  let receipts_dir = Filename.concat masc_root Common.keepers_runtime_dirname in
+  let recall_records, recall_stats = load_records recall_dir parse_recall_json in
+  let receipts, receipt_stats =
+    load_records_from_files (find_receipt_jsonl receipts_dir) parse_receipt_json
+  in
   let receipts_by_trace = receipt_map receipts in
   let traces =
     recall_groups recall_records
@@ -396,6 +512,12 @@ let evaluate ~masc_root =
   { masc_root
   ; recall_dir
   ; receipts_dir
+  ; read_error_count = recall_stats.read_error_count + receipt_stats.read_error_count
+  ; malformed_jsonl_rows =
+      recall_stats.malformed_jsonl_rows + receipt_stats.malformed_jsonl_rows
+  ; invalid_recall_rows = recall_stats.invalid_rows
+  ; invalid_receipt_rows = receipt_stats.invalid_rows
+  ; load_errors = recall_stats.errors @ receipt_stats.errors
   ; recall_records = List.length recall_records
   ; recall_traces = List.length traces
   ; traces_with_receipt =
@@ -438,6 +560,7 @@ let receipt_to_json receipt =
     ; "terminal_reason_code", `String receipt.terminal_reason_code
     ; "current_task_id", string_opt_to_json receipt.current_task_id
     ; "ended_at", string_opt_to_json receipt.ended_at
+    ; "ended_at_unix", (match receipt.ended_at_unix with Some ts -> `Float ts | None -> `Null)
     ]
 ;;
 
@@ -476,20 +599,21 @@ let fact_key_summary_to_json row =
     ]
 ;;
 
-let take n xs =
-  let rec loop remaining acc = function
-    | _ when remaining <= 0 -> List.rev acc
-    | [] -> List.rev acc
-    | x :: rest -> loop (remaining - 1) (x :: acc) rest
-  in
-  loop n [] xs
-;;
+let take n xs = if n <= 0 then [] else List.take n xs
 
 let to_json ?(trace_limit = 50) ?(fact_key_limit = 50) report =
   `Assoc
     [ "masc_root", `String report.masc_root
     ; "recall_dir", `String report.recall_dir
     ; "receipts_dir", `String report.receipts_dir
+    ; ( "load_diagnostics"
+      , `Assoc
+          [ "read_error_count", `Int report.read_error_count
+          ; "malformed_jsonl_rows", `Int report.malformed_jsonl_rows
+          ; "invalid_recall_rows", `Int report.invalid_recall_rows
+          ; "invalid_receipt_rows", `Int report.invalid_receipt_rows
+          ; "errors", `List (List.map (fun error -> `String error) report.load_errors)
+          ] )
     ; "recall_records", `Int report.recall_records
     ; "recall_traces", `Int report.recall_traces
     ; "traces_with_receipt", `Int report.traces_with_receipt
@@ -574,6 +698,7 @@ let render_text ?(trace_limit = 50) ?(fact_key_limit = 50) report =
   Printf.sprintf
     "Memory OS recall outcome eval (local receipts only)\n\
      masc_root: %s\n\
+     load_diagnostics: read_errors=%d malformed_jsonl_rows=%d invalid_recall_rows=%d invalid_receipt_rows=%d\n\
      recall_records: %d, recall_traces: %d\n\
      joined: with_receipt=%d without_receipt=%d\n\
      injected_fact_keys=%d recall_failure_records=%d\n\
@@ -583,6 +708,10 @@ let render_text ?(trace_limit = 50) ?(fact_key_limit = 50) report =
      trace_limit=%d\n\
      %s"
     report.masc_root
+    report.read_error_count
+    report.malformed_jsonl_rows
+    report.invalid_recall_rows
+    report.invalid_receipt_rows
     report.recall_records
     report.recall_traces
     report.traces_with_receipt
@@ -602,27 +731,26 @@ let render_text ?(trace_limit = 50) ?(fact_key_limit = 50) report =
     trace_lines
 ;;
 
-let rec mkdir_p path =
-  if path = "" || path = Filename.current_dir_name
-  then ()
-  else if Sys.file_exists path
-  then ()
-  else (
-    let parent = Filename.dirname path in
-    if not (String.equal parent path) then mkdir_p parent;
-    Unix.mkdir path 0o755)
-;;
-
 let write_summary_index ~path report =
-  mkdir_p (Filename.dirname path);
+  Fs_compat.mkdir_p (Filename.dirname path);
   let oc = open_out_bin path in
+  let closed = ref false in
+  let close_propagating () =
+    try
+      close_out oc;
+      closed := true
+    with exn ->
+      close_out_noerr oc;
+      closed := true;
+      raise exn
+  in
   Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
+    ~finally:(fun () -> if not !closed then close_out_noerr oc)
     (fun () ->
        List.iter
          (fun row ->
             output_string oc (Yojson.Safe.to_string (fact_key_summary_to_json row));
             output_char oc '\n')
          report.fact_key_summaries;
-       close_out oc)
+       close_propagating ())
 ;;

--- a/lib/keeper/keeper_recall_outcome_eval.ml
+++ b/lib/keeper/keeper_recall_outcome_eval.ml
@@ -210,9 +210,9 @@ let receipt_map (receipts : receipt_record list) : receipt_record String_map.t =
     receipts
 ;;
 
-let recall_groups records =
+let recall_groups (records : recall_record list) : recall_record list String_map.t =
   List.fold_left
-    (fun acc record ->
+    (fun acc (record : recall_record) ->
        let existing = Option.value (String_map.find_opt record.trace_id acc) ~default:[] in
        String_map.add record.trace_id (record :: existing) acc)
     String_map.empty
@@ -256,7 +256,9 @@ let trace_row_of_group
   let receipt = String_map.find_opt trace_id receipts in
   let outcome_bucket = outcome_bucket_of_receipt receipt in
   let fact_keys =
-    records |> List.concat_map (fun r -> r.injected_fact_keys) |> unique_sorted
+    records
+    |> List.concat_map (fun (r : recall_record) -> r.injected_fact_keys)
+    |> unique_sorted
   in
   { trace_id
   ; keeper_id = (match records with r :: _ -> Some r.keeper_id | [] -> None)
@@ -307,7 +309,7 @@ let key_counts keys =
     keys
 ;;
 
-let add_record_to_fact_summaries acc record =
+let add_record_to_fact_summaries acc (record : recall_record) =
   let counts = key_counts record.injected_fact_keys in
   String_map.fold
     (fun fact_key count acc ->
@@ -326,7 +328,7 @@ let add_record_to_fact_summaries acc record =
     acc
 ;;
 
-let add_outcome_to_fact_summary bucket row =
+let add_outcome_to_fact_summary bucket (row : fact_key_summary) =
   match bucket with
   | Outcome_ok -> { row with outcome_ok = row.outcome_ok + 1 }
   | Outcome_skipped -> { row with outcome_skipped = row.outcome_skipped + 1 }
@@ -385,7 +387,8 @@ let evaluate ~masc_root =
   in
   let count_bucket bucket =
     List.fold_left
-      (fun acc row -> if row.outcome_bucket = bucket then acc + 1 else acc)
+      (fun acc (row : trace_row) ->
+         if row.outcome_bucket = bucket then acc + 1 else acc)
       0
       traces
   in
@@ -397,14 +400,21 @@ let evaluate ~masc_root =
   ; recall_traces = List.length traces
   ; traces_with_receipt =
       List.fold_left
-        (fun acc row -> if Option.is_some row.receipt then acc + 1 else acc)
+        (fun acc (row : trace_row) ->
+           if Option.is_some row.receipt then acc + 1 else acc)
         0
         traces
   ; traces_without_receipt = count_bucket Outcome_missing_receipt
   ; injected_fact_keys =
-      List.fold_left (fun acc row -> acc + row.injected_fact_keys) 0 traces
+      List.fold_left
+        (fun acc (row : trace_row) -> acc + row.injected_fact_keys)
+        0
+        traces
   ; recall_failure_records =
-      List.fold_left (fun acc row -> acc + row.recall_failure_records) 0 traces
+      List.fold_left
+        (fun acc (row : trace_row) -> acc + row.recall_failure_records)
+        0
+        traces
   ; outcome_ok = count_bucket Outcome_ok
   ; outcome_skipped = count_bucket Outcome_skipped
   ; outcome_error = count_bucket Outcome_error

--- a/lib/keeper/keeper_recall_outcome_eval.mli
+++ b/lib/keeper/keeper_recall_outcome_eval.mli
@@ -1,0 +1,70 @@
+(** Offline, read-only join from recall-injection ledger rows to local execution
+    receipt outcomes.
+
+    This is the deterministic local substrate for RFC-0264 P3. It intentionally
+    does not query forge/CI/human-feedback state; those outcome sources are a
+    later layer over the trace rows produced here. *)
+
+type recall_record =
+  { keeper_id : string
+  ; trace_id : string
+  ; turn : int
+  ; injected_fact_key_count : int
+  ; injected_episode_key_count : int
+  ; failure_reason : string option
+  ; ts : float option
+  }
+
+type receipt_record =
+  { keeper_name : string
+  ; trace_id : string
+  ; outcome : string
+  ; terminal_reason_code : string
+  ; current_task_id : string option
+  ; ended_at : string option
+  }
+
+type outcome_bucket =
+  | Outcome_ok
+  | Outcome_skipped
+  | Outcome_error
+  | Outcome_cancelled
+  | Outcome_unknown
+  | Outcome_missing_receipt
+
+type trace_row =
+  { trace_id : string
+  ; keeper_id : string option
+  ; recall_records : int
+  ; injected_fact_keys : int
+  ; recall_failure_records : int
+  ; receipt : receipt_record option
+  ; outcome_bucket : outcome_bucket
+  }
+
+type t =
+  { masc_root : string
+  ; recall_dir : string
+  ; receipts_dir : string
+  ; recall_records : int
+  ; recall_traces : int
+  ; traces_with_receipt : int
+  ; traces_without_receipt : int
+  ; injected_fact_keys : int
+  ; recall_failure_records : int
+  ; outcome_ok : int
+  ; outcome_skipped : int
+  ; outcome_error : int
+  ; outcome_cancelled : int
+  ; outcome_unknown : int
+  ; traces : trace_row list
+  }
+
+val evaluate : masc_root:string -> t
+(** Read [masc_root/recall_injections/**/*.jsonl] and
+    [masc_root/keepers/*/execution-receipts/**/*.jsonl], joining on [trace_id].
+    Malformed JSONL rows are skipped rather than failing the whole report. *)
+
+val outcome_bucket_to_string : outcome_bucket -> string
+val to_json : ?trace_limit:int -> t -> Yojson.Safe.t
+val render_text : ?trace_limit:int -> t -> string

--- a/lib/keeper/keeper_recall_outcome_eval.mli
+++ b/lib/keeper/keeper_recall_outcome_eval.mli
@@ -23,6 +23,7 @@ type receipt_record =
   ; terminal_reason_code : string
   ; current_task_id : string option
   ; ended_at : string option
+  ; ended_at_unix : float option
   }
 
 type outcome_bucket =
@@ -62,6 +63,11 @@ type t =
   { masc_root : string
   ; recall_dir : string
   ; receipts_dir : string
+  ; read_error_count : int
+  ; malformed_jsonl_rows : int
+  ; invalid_recall_rows : int
+  ; invalid_receipt_rows : int
+  ; load_errors : string list
   ; recall_records : int
   ; recall_traces : int
   ; traces_with_receipt : int
@@ -80,7 +86,8 @@ type t =
 val evaluate : masc_root:string -> t
 (** Read [masc_root/recall_injections/**/*.jsonl] and
     [masc_root/keepers/*/execution-receipts/**/*.jsonl], joining on [trace_id].
-    Malformed JSONL rows are skipped rather than failing the whole report. *)
+    Malformed/unreadable/invalid rows are excluded from aggregation and surfaced
+    through the load-diagnostic counters and [load_errors]. *)
 
 val outcome_bucket_to_string : outcome_bucket -> string
 val to_json : ?trace_limit:int -> ?fact_key_limit:int -> t -> Yojson.Safe.t

--- a/lib/keeper/keeper_recall_outcome_eval.mli
+++ b/lib/keeper/keeper_recall_outcome_eval.mli
@@ -86,8 +86,9 @@ type t =
 val evaluate : masc_root:string -> t
 (** Read [masc_root/recall_injections/**/*.jsonl] and
     [masc_root/keepers/*/execution-receipts/**/*.jsonl], joining on [trace_id].
-    Malformed/unreadable/invalid rows are excluded from aggregation and surfaced
-    through the load-diagnostic counters and [load_errors]. *)
+    Directory scan failures plus malformed/unreadable/invalid rows are excluded
+    from aggregation and surfaced through the load-diagnostic counters and
+    [load_errors]. *)
 
 val outcome_bucket_to_string : outcome_bucket -> string
 val to_json : ?trace_limit:int -> ?fact_key_limit:int -> t -> Yojson.Safe.t

--- a/lib/keeper/keeper_recall_outcome_eval.mli
+++ b/lib/keeper/keeper_recall_outcome_eval.mli
@@ -9,6 +9,7 @@ type recall_record =
   { keeper_id : string
   ; trace_id : string
   ; turn : int
+  ; injected_fact_keys : string list
   ; injected_fact_key_count : int
   ; injected_episode_key_count : int
   ; failure_reason : string option
@@ -36,10 +37,25 @@ type trace_row =
   { trace_id : string
   ; keeper_id : string option
   ; recall_records : int
+  ; fact_keys : string list
   ; injected_fact_keys : int
   ; recall_failure_records : int
   ; receipt : receipt_record option
   ; outcome_bucket : outcome_bucket
+  }
+
+type fact_key_summary =
+  { fact_key : string
+  ; injected_count : int
+  ; recall_records : int
+  ; recall_failure_records : int
+  ; trace_count : int
+  ; outcome_ok : int
+  ; outcome_skipped : int
+  ; outcome_error : int
+  ; outcome_cancelled : int
+  ; outcome_unknown : int
+  ; outcome_missing_receipt : int
   }
 
 type t =
@@ -57,6 +73,7 @@ type t =
   ; outcome_error : int
   ; outcome_cancelled : int
   ; outcome_unknown : int
+  ; fact_key_summaries : fact_key_summary list
   ; traces : trace_row list
   }
 
@@ -66,5 +83,9 @@ val evaluate : masc_root:string -> t
     Malformed JSONL rows are skipped rather than failing the whole report. *)
 
 val outcome_bucket_to_string : outcome_bucket -> string
-val to_json : ?trace_limit:int -> t -> Yojson.Safe.t
-val render_text : ?trace_limit:int -> t -> string
+val to_json : ?trace_limit:int -> ?fact_key_limit:int -> t -> Yojson.Safe.t
+val render_text : ?trace_limit:int -> ?fact_key_limit:int -> t -> string
+val write_summary_index : path:string -> t -> unit
+(** Write the complete fact-key outcome summary as compact JSONL rows.
+    The file is replaced by this local CLI helper; the live runtime does not
+    call it. *)

--- a/lib/keeper/keeper_turn_helpers.ml
+++ b/lib/keeper/keeper_turn_helpers.ml
@@ -117,8 +117,10 @@ let record_execution_receipt_gap
       ~producer:"keeper_unified_turn.pre_dispatch"
       ~durable_store:
         (Filename.concat
-           (Filename.concat (Filename.concat masc_root "keepers") meta.name)
-           "execution-receipts")
+           (Filename.concat
+              (Filename.concat masc_root Common.keepers_runtime_dirname)
+              meta.name)
+           Keeper_types_support.execution_receipts_dirname)
       ~dashboard_surface:"/api/v1/dashboard/execution-trust"
       ~stale_reason
       ~keeper_name:meta.name

--- a/lib/keeper/keeper_types_support.ml
+++ b/lib/keeper/keeper_types_support.ml
@@ -50,9 +50,12 @@ let execution_receipt_store_cache : (string, Dated_jsonl.t) Hashtbl.t =
 
 let execution_receipt_store_mu = Eio.Mutex.create ()
 
+let execution_receipt_schema = "keeper.execution_receipt.v1"
+let execution_receipts_dirname = "execution-receipts"
+
 let keeper_execution_receipt_store config name : Dated_jsonl.t =
   let dir =
-    Filename.concat (keeper_dir_ config) (name ^ "/execution-receipts")
+    Filename.concat (Filename.concat (keeper_dir_ config) name) execution_receipts_dirname
   in
   let lookup () =
     match Hashtbl.find_opt execution_receipt_store_cache dir with

--- a/lib/keeper/keeper_types_support.mli
+++ b/lib/keeper/keeper_types_support.mli
@@ -25,6 +25,13 @@ val keeper_metrics_path : Workspace.config -> string -> string
     Cached per keeper name so all callers share the same Eio.Mutex. *)
 val keeper_metrics_store : Workspace.config -> string -> Dated_jsonl.t
 
+val execution_receipts_dirname : string
+(** Runtime subdirectory under each keeper directory for date-split execution
+    receipt JSONL. *)
+
+val execution_receipt_schema : string
+(** JSONL schema tag for execution receipt rows. *)
+
 (** Date-split execution-receipt store:
     [.masc/keepers/<name>/execution-receipts/YYYY-MM/DD.jsonl]. *)
 val keeper_execution_receipt_store : Workspace.config -> string -> Dated_jsonl.t

--- a/test/dune
+++ b/test/dune
@@ -97,6 +97,7 @@
   test_keeper_memory_os
   test_keeper_memory_os_gc_dry_run_report
   test_keeper_user_model
+  test_keeper_recall_outcome_eval
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime
   test_server_bootstrap_maintenance_memory_os

--- a/test/dune
+++ b/test/dune
@@ -414,6 +414,7 @@
   test_keeper_memory_os
   test_keeper_memory_os_gc_dry_run_report
   test_keeper_user_model
+  test_keeper_recall_outcome_eval
   test_keeper_memory_os_consolidation
   test_keeper_memory_os_consolidation_runtime
   test_server_bootstrap_maintenance_memory_os

--- a/test/test_keeper_recall_outcome_eval.ml
+++ b/test/test_keeper_recall_outcome_eval.ml
@@ -24,6 +24,19 @@ let write_lines path lines =
        close_out oc)
 ;;
 
+let read_lines path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+       let rec loop acc =
+         match input_line ic with
+         | line -> loop (line :: acc)
+         | exception End_of_file -> List.rev acc
+       in
+       loop [])
+;;
+
 let with_temp_masc_root f =
   let marker = Filename.temp_file "recall-outcome-eval-" ".tmp" in
   Sys.remove marker;

--- a/test/test_keeper_recall_outcome_eval.ml
+++ b/test/test_keeper_recall_outcome_eval.ml
@@ -1,27 +1,23 @@
 module Eval = Masc.Keeper_recall_outcome_eval
 
-let mkdir_p path =
-  let rec loop path =
-    if path = "" || path = Filename.current_dir_name
-    then ()
-    else if Sys.file_exists path
-    then ()
-    else (
-      let parent = Filename.dirname path in
-      if not (String.equal parent path) then loop parent;
-      Unix.mkdir path 0o755)
-  in
-  loop path
-;;
-
 let write_lines path lines =
-  mkdir_p (Filename.dirname path);
+  Fs_compat.mkdir_p (Filename.dirname path);
   let oc = open_out_bin path in
+  let closed = ref false in
+  let close_propagating () =
+    try
+      close_out oc;
+      closed := true
+    with exn ->
+      close_out_noerr oc;
+      closed := true;
+      raise exn
+  in
   Fun.protect
-    ~finally:(fun () -> close_out_noerr oc)
+    ~finally:(fun () -> if not !closed then close_out_noerr oc)
     (fun () ->
        List.iter (fun line -> output_string oc line; output_char oc '\n') lines;
-       close_out oc)
+       close_propagating ())
 ;;
 
 let read_lines path =
@@ -40,7 +36,7 @@ let read_lines path =
 let with_temp_masc_root f =
   let marker = Filename.temp_file "recall-outcome-eval-" ".tmp" in
   Sys.remove marker;
-  mkdir_p marker;
+  Fs_compat.mkdir_p marker;
   f marker
 ;;
 
@@ -56,9 +52,13 @@ let test_joins_recall_to_receipts () =
       (Filename.concat
          masc_root
          "keepers/alpha/execution-receipts/2026-06/27.jsonl")
-      [ {|{"keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_done","terminal_reason_code":"completed","current_task_id":"T-1","ended_at":"2026-06-27T00:00:00Z"}|}
+      [ {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_done","terminal_reason_code":"completed","current_task_id":"T-1","ended_at":"2026-06-27T00:00:00Z"}|}
       ];
     let report = Eval.evaluate ~masc_root in
+    Alcotest.(check int) "read errors" 0 report.read_error_count;
+    Alcotest.(check int) "malformed rows" 0 report.malformed_jsonl_rows;
+    Alcotest.(check int) "invalid recall rows" 0 report.invalid_recall_rows;
+    Alcotest.(check int) "invalid receipt rows" 0 report.invalid_receipt_rows;
     Alcotest.(check int) "recall records" 3 report.recall_records;
     Alcotest.(check int) "recall traces" 2 report.recall_traces;
     Alcotest.(check int) "joined traces" 1 report.traces_with_receipt;
@@ -83,8 +83,60 @@ let test_joins_recall_to_receipts () =
         "ok"
         (Eval.outcome_bucket_to_string row.outcome_bucket);
       Alcotest.(check (list string)) "trace fact keys" [ "a"; "b" ] row.fact_keys;
-      Alcotest.(check int) "trace recall count" 2 row.recall_records
+      Alcotest.(check int) "trace recall count" 2 row.recall_records;
+      (match row.receipt with
+       | Some receipt ->
+         Alcotest.(check bool) "receipt ended_at parsed" true
+           (Option.is_some receipt.ended_at_unix)
+       | None -> Alcotest.fail "missing receipt")
     | None -> Alcotest.fail "missing trace-1")
+;;
+
+let test_surfaces_bad_rows_and_uses_typed_outcome () =
+  with_temp_masc_root (fun masc_root ->
+    write_lines
+      (Filename.concat masc_root "recall_injections/2026-06/27.jsonl")
+      [ {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":["a"],"injected_fact_key_count":7,"injected_episode_keys":[],"ts":1.0}|}
+      ; {|{"keeper_id":"alpha","turn":2,"injected_fact_keys":[],"injected_episode_keys":[]}|}
+      ; {|{"keeper_id":|}
+      ];
+    write_lines
+      (Filename.concat
+         masc_root
+         "keepers/alpha/execution-receipts/2026-06/27.jsonl")
+      [ {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_cancelled","terminal_reason_code":"cancelled","ended_at":"2026-06-27T00:00:00Z"}|}
+      ; {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-2","outcome":"receipt_done","ended_at":"not-a-time"}|}
+      ];
+    write_lines
+      (Filename.concat masc_root "keepers/alpha/metrics/2026-06/27.jsonl")
+      [ {|{"trace_id":"trace-ignored","outcome":"receipt_failed"}|} ];
+    let report = Eval.evaluate ~masc_root in
+    Alcotest.(check int) "recall records" 1 report.recall_records;
+    Alcotest.(check int) "typed cancelled outcome" 1 report.outcome_cancelled;
+    Alcotest.(check int) "explicit injected count" 7 report.injected_fact_keys;
+    Alcotest.(check int) "malformed rows" 1 report.malformed_jsonl_rows;
+    Alcotest.(check int) "invalid recall rows" 1 report.invalid_recall_rows;
+    Alcotest.(check int) "invalid receipt rows" 1 report.invalid_receipt_rows;
+    Alcotest.(check int) "receipt metrics rows ignored" 0 report.outcome_error;
+    Alcotest.(check bool) "load error details" true (report.load_errors <> []))
+;;
+
+let test_selects_newest_receipt_by_timestamp () =
+  with_temp_masc_root (fun masc_root ->
+    write_lines
+      (Filename.concat masc_root "recall_injections/2026-06/27.jsonl")
+      [ {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":[],"injected_episode_keys":[],"ts":1.0}|}
+      ];
+    write_lines
+      (Filename.concat
+         masc_root
+         "keepers/alpha/execution-receipts/2026-06/27.jsonl")
+      [ {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_failed","terminal_reason_code":"error","ended_at":"2026-06-27T00:00:02Z"}|}
+      ; {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_done","terminal_reason_code":"completed","ended_at":"2026-06-27T00:00:03Z"}|}
+      ];
+    let report = Eval.evaluate ~masc_root in
+    Alcotest.(check int) "ok newest outcome" 1 report.outcome_ok;
+    Alcotest.(check int) "older error ignored" 0 report.outcome_error)
 ;;
 
 let test_json_respects_trace_limit () =
@@ -116,8 +168,8 @@ let test_writes_fact_key_summary_index () =
       (Filename.concat
          masc_root
          "keepers/alpha/execution-receipts/2026-06/27.jsonl")
-      [ {|{"keeper_name":"alpha","trace_id":"trace-ok","outcome":"receipt_done","terminal_reason_code":"completed","ended_at":"2026-06-27T00:00:00Z"}|}
-      ; {|{"keeper_name":"beta","trace_id":"trace-err","outcome":"receipt_failed","terminal_reason_code":"error","ended_at":"2026-06-27T00:00:01Z"}|}
+      [ {|{"schema":"keeper.execution_receipt.v1","keeper_name":"alpha","trace_id":"trace-ok","outcome":"receipt_done","terminal_reason_code":"completed","ended_at":"2026-06-27T00:00:00Z"}|}
+      ; {|{"schema":"keeper.execution_receipt.v1","keeper_name":"beta","trace_id":"trace-err","outcome":"receipt_failed","terminal_reason_code":"error","ended_at":"2026-06-27T00:00:01Z"}|}
       ];
     let report = Eval.evaluate ~masc_root in
     let path = Filename.concat masc_root "summary-index/facts.jsonl" in
@@ -158,6 +210,14 @@ let () =
     [ ( "eval"
       , [ Alcotest.test_case "joins recall to receipts" `Quick test_joins_recall_to_receipts
         ; Alcotest.test_case "json respects trace limit" `Quick test_json_respects_trace_limit
+        ; Alcotest.test_case
+            "surfaces bad rows and uses typed outcome"
+            `Quick
+            test_surfaces_bad_rows_and_uses_typed_outcome
+        ; Alcotest.test_case
+            "selects newest receipt by timestamp"
+            `Quick
+            test_selects_newest_receipt_by_timestamp
         ; Alcotest.test_case
             "writes fact-key summary index"
             `Quick

--- a/test/test_keeper_recall_outcome_eval.ml
+++ b/test/test_keeper_recall_outcome_eval.ml
@@ -1,0 +1,90 @@
+module Eval = Masc.Keeper_recall_outcome_eval
+
+let mkdir_p path =
+  let rec loop path =
+    if path = "" || path = Filename.current_dir_name
+    then ()
+    else if Sys.file_exists path
+    then ()
+    else (
+      let parent = Filename.dirname path in
+      if not (String.equal parent path) then loop parent;
+      Unix.mkdir path 0o755)
+  in
+  loop path
+;;
+
+let write_lines path lines =
+  mkdir_p (Filename.dirname path);
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+       List.iter (fun line -> output_string oc line; output_char oc '\n') lines;
+       close_out oc)
+;;
+
+let with_temp_masc_root f =
+  let marker = Filename.temp_file "recall-outcome-eval-" ".tmp" in
+  Sys.remove marker;
+  mkdir_p marker;
+  f marker
+;;
+
+let test_joins_recall_to_receipts () =
+  with_temp_masc_root (fun masc_root ->
+    write_lines
+      (Filename.concat masc_root "recall_injections/2026-06/27.jsonl")
+      [ {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":["a","b"],"injected_episode_keys":[],"n_facts_in_store":2,"ts":1.0}|}
+      ; {|{"keeper_id":"alpha","trace_id":"trace-1","turn":2,"injected_fact_keys":["a"],"injected_episode_keys":["trace-1:g0"],"n_facts_in_store":2,"ts":2.0}|}
+      ; {|{"keeper_id":"beta","trace_id":"trace-2","turn":1,"injected_fact_keys":[],"injected_episode_keys":[],"n_facts_in_store":0,"failure_reason":"prompt_render_error","ts":3.0}|}
+      ];
+    write_lines
+      (Filename.concat
+         masc_root
+         "keepers/alpha/execution-receipts/2026-06/27.jsonl")
+      [ {|{"keeper_name":"alpha","trace_id":"trace-1","outcome":"receipt_done","terminal_reason_code":"completed","current_task_id":"T-1","ended_at":"2026-06-27T00:00:00Z"}|}
+      ];
+    let report = Eval.evaluate ~masc_root in
+    Alcotest.(check int) "recall records" 3 report.recall_records;
+    Alcotest.(check int) "recall traces" 2 report.recall_traces;
+    Alcotest.(check int) "joined traces" 1 report.traces_with_receipt;
+    Alcotest.(check int) "missing receipt" 1 report.traces_without_receipt;
+    Alcotest.(check int) "fact keys" 3 report.injected_fact_keys;
+    Alcotest.(check int) "recall failures" 1 report.recall_failure_records;
+    Alcotest.(check int) "ok outcomes" 1 report.outcome_ok;
+    match List.find_opt (fun row -> String.equal row.Eval.trace_id "trace-1") report.traces with
+    | Some row ->
+      Alcotest.(check string)
+        "bucket"
+        "ok"
+        (Eval.outcome_bucket_to_string row.outcome_bucket);
+      Alcotest.(check int) "trace recall count" 2 row.recall_records
+    | None -> Alcotest.fail "missing trace-1")
+;;
+
+let test_json_respects_trace_limit () =
+  with_temp_masc_root (fun masc_root ->
+    write_lines
+      (Filename.concat masc_root "recall_injections/2026-06/27.jsonl")
+      [ {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":[],"injected_episode_keys":[],"n_facts_in_store":0}|}
+      ; {|{"keeper_id":"alpha","trace_id":"trace-2","turn":1,"injected_fact_keys":[],"injected_episode_keys":[],"n_facts_in_store":0}|}
+      ];
+    let json = Eval.evaluate ~masc_root |> Eval.to_json ~trace_limit:1 in
+    match json with
+    | `Assoc fields ->
+      (match List.assoc_opt "traces" fields with
+       | Some (`List [ _ ]) -> ()
+       | _ -> Alcotest.fail "expected one trace in limited JSON")
+    | _ -> Alcotest.fail "expected JSON object")
+;;
+
+let () =
+  Alcotest.run
+    "keeper_recall_outcome_eval"
+    [ ( "eval"
+      , [ Alcotest.test_case "joins recall to receipts" `Quick test_joins_recall_to_receipts
+        ; Alcotest.test_case "json respects trace limit" `Quick test_json_respects_trace_limit
+        ] )
+    ]
+;;

--- a/test/test_keeper_recall_outcome_eval.ml
+++ b/test/test_keeper_recall_outcome_eval.ml
@@ -53,12 +53,23 @@ let test_joins_recall_to_receipts () =
     Alcotest.(check int) "fact keys" 3 report.injected_fact_keys;
     Alcotest.(check int) "recall failures" 1 report.recall_failure_records;
     Alcotest.(check int) "ok outcomes" 1 report.outcome_ok;
+    (match
+       List.find_opt
+         (fun row -> String.equal row.Eval.fact_key "a")
+         report.fact_key_summaries
+     with
+     | Some row ->
+       Alcotest.(check int) "fact a trace count" 1 row.trace_count;
+       Alcotest.(check int) "fact a injections" 2 row.injected_count;
+       Alcotest.(check int) "fact a ok outcomes" 1 row.outcome_ok
+     | None -> Alcotest.fail "missing fact key summary a");
     match List.find_opt (fun row -> String.equal row.Eval.trace_id "trace-1") report.traces with
     | Some row ->
       Alcotest.(check string)
         "bucket"
         "ok"
         (Eval.outcome_bucket_to_string row.outcome_bucket);
+      Alcotest.(check (list string)) "trace fact keys" [ "a"; "b" ] row.fact_keys;
       Alcotest.(check int) "trace recall count" 2 row.recall_records
     | None -> Alcotest.fail "missing trace-1")
 ;;
@@ -70,7 +81,9 @@ let test_json_respects_trace_limit () =
       [ {|{"keeper_id":"alpha","trace_id":"trace-1","turn":1,"injected_fact_keys":[],"injected_episode_keys":[],"n_facts_in_store":0}|}
       ; {|{"keeper_id":"alpha","trace_id":"trace-2","turn":1,"injected_fact_keys":[],"injected_episode_keys":[],"n_facts_in_store":0}|}
       ];
-    let json = Eval.evaluate ~masc_root |> Eval.to_json ~trace_limit:1 in
+    let json =
+      Eval.evaluate ~masc_root |> Eval.to_json ~trace_limit:1 ~fact_key_limit:0
+    in
     match json with
     | `Assoc fields ->
       (match List.assoc_opt "traces" fields with
@@ -79,12 +92,63 @@ let test_json_respects_trace_limit () =
     | _ -> Alcotest.fail "expected JSON object")
 ;;
 
+let test_writes_fact_key_summary_index () =
+  with_temp_masc_root (fun masc_root ->
+    write_lines
+      (Filename.concat masc_root "recall_injections/2026-06/27.jsonl")
+      [ {|{"keeper_id":"alpha","trace_id":"trace-ok","turn":1,"injected_fact_keys":["shared:a"],"injected_episode_keys":[]}|}
+      ; {|{"keeper_id":"beta","trace_id":"trace-err","turn":1,"injected_fact_keys":["shared:a"],"injected_episode_keys":[]}|}
+      ];
+    write_lines
+      (Filename.concat
+         masc_root
+         "keepers/alpha/execution-receipts/2026-06/27.jsonl")
+      [ {|{"keeper_name":"alpha","trace_id":"trace-ok","outcome":"receipt_done","terminal_reason_code":"completed","ended_at":"2026-06-27T00:00:00Z"}|}
+      ; {|{"keeper_name":"beta","trace_id":"trace-err","outcome":"receipt_failed","terminal_reason_code":"error","ended_at":"2026-06-27T00:00:01Z"}|}
+      ];
+    let report = Eval.evaluate ~masc_root in
+    let path = Filename.concat masc_root "summary-index/facts.jsonl" in
+    Eval.write_summary_index ~path report;
+    match read_lines path with
+    | [ line ] ->
+      (match Yojson.Safe.from_string line with
+       | `Assoc fields ->
+         Alcotest.(check string)
+           "fact key"
+           "shared:a"
+           (match List.assoc_opt "fact_key" fields with
+            | Some (`String value) -> value
+            | _ -> Alcotest.fail "missing fact_key");
+         (match List.assoc_opt "outcomes" fields with
+          | Some (`Assoc outcome_fields) ->
+            Alcotest.(check int)
+              "ok"
+              1
+              (match List.assoc_opt "ok" outcome_fields with
+               | Some (`Int value) -> value
+               | _ -> Alcotest.fail "missing ok");
+            Alcotest.(check int)
+              "error"
+              1
+              (match List.assoc_opt "error" outcome_fields with
+               | Some (`Int value) -> value
+               | _ -> Alcotest.fail "missing error")
+          | _ -> Alcotest.fail "missing outcomes")
+       | _ -> Alcotest.fail "expected JSON object")
+    | lines ->
+      Alcotest.failf "expected one summary-index row, got %d" (List.length lines))
+;;
+
 let () =
   Alcotest.run
     "keeper_recall_outcome_eval"
     [ ( "eval"
       , [ Alcotest.test_case "joins recall to receipts" `Quick test_joins_recall_to_receipts
         ; Alcotest.test_case "json respects trace limit" `Quick test_json_respects_trace_limit
+        ; Alcotest.test_case
+            "writes fact-key summary index"
+            `Quick
+            test_writes_fact_key_summary_index
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary

- add `Keeper_recall_outcome_eval`, a local join from `recall_injections` to keeper `execution-receipts`
- preserve injected fact keys and derive a `fact_key_summary_index` keyed by `fact_key` and trace outcome
- add `--fact-key-limit` and `--summary-index-path` so operators can emit a compact JSONL fact-key outcome snapshot instead of relying on indefinite raw recall JSONL retention
- keep output bounded for trace rows and fact-key summary rows
- harden the local substrate against silent bad inputs: directory scan failures plus malformed/unreadable/invalid JSONL rows now surface through load diagnostics instead of disappearing
- scope receipt scanning to keeper `execution-receipts` stores and validate the execution receipt schema tag

## Audit Link

Moves the 2026-06-26 Memory OS production audit outcome-evaluation item forward by wiring the deterministic local substrate: recall ledger rows joined to execution receipt terminal outcomes by `trace_id`.

This also addresses the recall-ledger retention follow-up that asks for a summary index keyed by fact key / trace outcome, so evaluation can survive raw JSONL retention/compaction.

Scope boundary: this does not query forge/CI/human-feedback state. Those sources remain the next layer on top of the local trace outcome rows.

## Review Response

- replaced local receipt outcome string bucketing with the existing typed receipt outcome parser
- replaced local JSON field helpers with `Json_util`
- stopped scanning all keeper JSONL files; receipt loading is limited to `keepers/<name>/execution-receipts`
- moved recall/keeper/receipt layout strings onto existing or new SSOT helpers
- made directory scan failures, malformed JSONL, unreadable files, and invalid recall/receipt rows visible through diagnostic counters and `load_errors`
- parse `ended_at` into numeric time for receipt tie-breaks
- sort recall records by timestamp/turn before choosing keeper context; keeper selection no longer depends on insertion-order `List.rev`
- use `Config_dir_resolver.current_env_base_path_opt ()` for CLI default base-path resolution
- updated CLI usage for `--fact-key-limit` and `--summary-index-path`
- changed CLI option parsing to use a local config record and `summary_index_path : string option`, removing the empty-string write sentinel
- removed local mkdir recursion and normal-path double close in summary/test writers
- kept the CLI-only eval module in `private_modules`

## Validation

- `ocamlformat --check bin/masc_recall_outcome_eval.ml lib/dune lib/keeper/keeper_agent_run_receipt_append.ml lib/keeper/keeper_execution_receipt.ml lib/keeper/keeper_recall_outcome_eval.ml lib/keeper/keeper_recall_outcome_eval.mli lib/keeper/keeper_turn_helpers.ml lib/keeper/keeper_types_support.ml lib/keeper/keeper_types_support.mli test/test_keeper_recall_outcome_eval.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_recall_outcome_eval.ml bin/masc_recall_outcome_eval.ml test/test_keeper_recall_outcome_eval.ml lib/keeper/keeper_agent_run_receipt_append.ml lib/keeper/keeper_execution_receipt.ml lib/keeper/keeper_turn_helpers.ml lib/keeper/keeper_types_support.ml`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_recall_outcome_eval.mli lib/keeper/keeper_types_support.mli`
- `git diff --check HEAD~1 HEAD`
- `scripts/lint/no-inline-error-envelope.sh`
- `scripts/lint/no-inline-ok-envelope.sh`
- `scripts/audit-path-ssot.sh`
- `scripts/lint/no-keeper-behavior-hardcoding.sh`
- targeted `rg` checks for removed local outcome parsing, JSON helper duplication, path/env bypasses, silent parse/read drops, broad empty-string defaulting, summary-index empty sentinel, and double-close patterns

Only remaining targeted `List.rev records` hit is the loader accumulator restoring file input order, not keeper-context selection.

Per operator instruction, I did not run local Dune build/tests or inspect CI/check logs.
