### PR TITLE
refactor(bin): route MASC CLI base-path and retention env lookups through SSOT

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -90,6 +90,8 @@
  (libraries
   masc
   masc_core
+  masc.host_config
+  masc.config_dir_resolver
   unix
   yojson
   masc_types
@@ -137,7 +139,15 @@
  (modules masc_compaction_audit)
  (public_name masc-compaction-audit)
  (package masc)
- (libraries masc masc_core unix eio eio_main))
+ (libraries
+  masc
+  masc_core
+  masc.host_config
+  masc.config_dir_resolver
+  masc.config
+  unix
+  eio
+  eio_main))
 
 ;; Completion-trust audit CLI (RFC-0262 §9): fold .masc/events/ transition log
 ;; for foreign-task completions. Pure auditor only — no masc runtime link.
@@ -239,6 +249,8 @@
   masc.dashboard
   masc.server
   masc.config
+  masc.host_config
+  masc.config_dir_resolver
   unix
   yojson
   masc_core

--- a/bin/dune
+++ b/bin/dune
@@ -142,9 +142,7 @@
  (libraries
   masc
   masc_core
-  masc.host_config
   masc.config_dir_resolver
-  masc.config
   unix
   eio
   eio_main))

--- a/bin/masc_compaction_audit.ml
+++ b/bin/masc_compaction_audit.ml
@@ -48,19 +48,20 @@ let parse_date_arg name s =
   | _ -> error (Printf.sprintf "invalid %s: %S (expected YYYY-MM-DD)" name s)
 
 let base_path () =
-  (* sb/main_eio uses Masc.Env_config.base_path.
-     Replicating the env lookup avoids pulling heavy deps into this CLI. *)
-  match Sys.getenv_opt "MASC_BASE_PATH" with
-  | Some p when String.trim p <> "" -> p
-  | _ -> Sys.getcwd ()
+  (* Route env-derived base path through Host_config SSOT, and fall back to
+     Config_dir_resolver's cwd helper when it is unset/empty. *)
+  match (Host_config.from_env ()).base_path with
+  | Some p -> p
+  | None ->
+      (* MASC_BASE_PATH is unset or empty; fall back to the cwd resolver
+         SSOT, which handles a deleted working directory gracefully. *)
+      Config_dir_resolver.current_working_dir ()
 
 let retention_from_env default =
-  match Sys.getenv_opt "MASC_COMPACTION_AUDIT_RETENTION_DAYS" with
-  | Some s ->
-    (match int_of_string_opt s with
-     | Some n when n >= 1 && n <= 365 -> n
-     | _ -> default)
-  | None -> default
+  (* Parse through Env_config_core SSOT, then clamp to the documented
+     1..365 day retention range. *)
+  let raw = Env_config_core.get_int ~default "MASC_COMPACTION_AUDIT_RETENTION_DAYS" in
+  max 1 (min 365 raw)
 
 (* ── Argument parsing ─────────────────────────────────────────── *)
 

--- a/bin/masc_compaction_audit.ml
+++ b/bin/masc_compaction_audit.ml
@@ -15,7 +15,7 @@ Options:
   --keeper NAME        filter to a single keeper/agent name
   --orphans-only       show only Orphan_start / Orphan_complete rows
   --prune              run retention sweep (default 14 days) and exit
-  --retention-days N   days to retain (used by --prune; default 14,
+  --retention-days N   days to retain, 1..3650 (used by --prune; default 14,
                        env override: MASC_COMPACTION_AUDIT_RETENTION_DAYS)
   -h, --help           print this help
 
@@ -23,6 +23,8 @@ Exit codes:
   0  listing succeeded (rows may be empty)
   1  invalid argument / IO error
 |}
+
+module KCA = Masc.Keeper_compact_audit
 
 let error msg =
   prerr_endline msg;
@@ -32,9 +34,9 @@ let parse_date_arg name s =
   match String.length s with
   | 10 ->
     (match
-       int_of_string_opt (String.sub s 0 4),
-       int_of_string_opt (String.sub s 5 2),
-       int_of_string_opt (String.sub s 8 2)
+       ( int_of_string_opt (String.sub s 0 4),
+         int_of_string_opt (String.sub s 5 2),
+         int_of_string_opt (String.sub s 8 2) )
      with
      | Some year, Some mon, Some day ->
        let tm : Unix.tm = {
@@ -47,21 +49,15 @@ let parse_date_arg name s =
      | _ -> error (Printf.sprintf "invalid %s: %S (expected YYYY-MM-DD)" name s))
   | _ -> error (Printf.sprintf "invalid %s: %S (expected YYYY-MM-DD)" name s)
 
-let base_path () =
-  (* Route env-derived base path through Host_config SSOT, and fall back to
-     Config_dir_resolver's cwd helper when it is unset/empty. *)
-  match (Host_config.from_env ()).base_path with
-  | Some p -> p
-  | None ->
-      (* MASC_BASE_PATH is unset or empty; fall back to the cwd resolver
-         SSOT, which handles a deleted working directory gracefully. *)
-      Config_dir_resolver.current_working_dir ()
+let base_path = Config_dir_resolver.base_path_or_cwd
 
 let retention_from_env default =
-  (* Parse through Env_config_core SSOT, then clamp to the documented
-     1..365 day retention range. *)
-  let raw = Env_config_core.get_int ~default "MASC_COMPACTION_AUDIT_RETENTION_DAYS" in
-  max 1 (min 365 raw)
+  KCA.resolve_retention_outcome ~default |> KCA.effective_days_of_outcome
+
+let parse_retention_days_arg raw =
+  match int_of_string_opt (String.trim raw) with
+  | Some n when n >= KCA.retention_min_days && n <= KCA.retention_max_days -> n
+  | _ -> error (Printf.sprintf "invalid --retention-days: %s" raw)
 
 (* ── Argument parsing ─────────────────────────────────────────── *)
 
@@ -95,10 +91,8 @@ let rec parse_args argv i cfg =
     | "--prune" ->
       parse_args argv (i + 1) { cfg with prune = true }
     | "--retention-days" when i + 1 < Array.length argv ->
-      (match int_of_string_opt argv.(i+1) with
-       | Some n when n >= 1 && n <= 365 ->
-         parse_args argv (i + 2) { cfg with retention_days = n }
-       | _ -> error (Printf.sprintf "invalid --retention-days: %s" argv.(i+1)))
+      parse_args argv (i + 2)
+        { cfg with retention_days = parse_retention_days_arg argv.(i+1) }
     | arg -> error (Printf.sprintf "unknown argument: %S\n\n%s" arg usage)
 
 let initial_cfg () = {
@@ -117,8 +111,6 @@ let format_ts ts =
   Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
     (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
     tm.tm_hour tm.tm_min tm.tm_sec
-
-module KCA = Masc.Keeper_compact_audit
 
 let print_paired ~(pre : KCA.start_record) ~(post : KCA.complete_record) =
   let delta = post.before_tokens - post.after_tokens in

--- a/bin/masc_cost.ml
+++ b/bin/masc_cost.ml
@@ -18,11 +18,14 @@ type cost_entry = {
 (** Get MASC root directory *)
 let get_masc_root () =
   let base_path =
-    match Sys.getenv_opt "MASC_BASE_PATH" with
-    | Some path when String.trim path <> "" -> String.trim path
-    | _ -> Sys.getcwd ()
+    match (Host_config.from_env ()).base_path with
+    | Some path -> path
+    | None ->
+        (* MASC_BASE_PATH is unset or empty; fall back to the cwd resolver
+           SSOT, which handles a deleted working directory gracefully. *)
+        Config_dir_resolver.current_working_dir ()
   in
-  Filename.concat base_path Common.masc_dirname
+  Common.masc_dir_from_base_path ~base_path
 
 (** Get costs file path *)
 let costs_file () = Filename.concat (get_masc_root ()) "costs.jsonl"

--- a/bin/masc_cost.ml
+++ b/bin/masc_cost.ml
@@ -17,15 +17,8 @@ type cost_entry = {
 
 (** Get MASC root directory *)
 let get_masc_root () =
-  let base_path =
-    match (Host_config.from_env ()).base_path with
-    | Some path -> path
-    | None ->
-        (* MASC_BASE_PATH is unset or empty; fall back to the cwd resolver
-           SSOT, which handles a deleted working directory gracefully. *)
-        Config_dir_resolver.current_working_dir ()
-  in
-  Common.masc_dir_from_base_path ~base_path
+  let base_path = Config_dir_resolver.base_path_or_cwd () in
+  Config_dir_resolver.masc_root ~base_path
 
 (** Get costs file path *)
 let costs_file () = Filename.concat (get_masc_root ()) "costs.jsonl"

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -114,14 +114,11 @@ let parse_args () =
 
   (* Resolve base path *)
   let base =
-    if !base_path <> "" then !base_path
-    else
-      match (Host_config.from_env ()).base_path with
-      | Some p -> p
-      | None ->
-          (* MASC_BASE_PATH is unset or empty; fall back to the cwd resolver
-             SSOT, which handles a deleted working directory gracefully. *)
-          Config_dir_resolver.current_working_dir ()
+    if !base_path <> "" then (
+      match Env_config_core.normalize_masc_base_path_input !base_path with
+      | "" -> Config_dir_resolver.base_path_or_cwd ()
+      | p -> p)
+    else Config_dir_resolver.base_path_or_cwd ()
   in
 
   (* Resolve workspace *)

--- a/bin/masc_tui.ml
+++ b/bin/masc_tui.ml
@@ -116,9 +116,12 @@ let parse_args () =
   let base =
     if !base_path <> "" then !base_path
     else
-      match Sys.getenv_opt "MASC_BASE_PATH" with
-      | Some p when String.trim p <> "" -> p
-      | _ -> Sys.getcwd ()
+      match (Host_config.from_env ()).base_path with
+      | Some p -> p
+      | None ->
+          (* MASC_BASE_PATH is unset or empty; fall back to the cwd resolver
+             SSOT, which handles a deleted working directory gracefully. *)
+          Config_dir_resolver.current_working_dir ()
   in
 
   (* Resolve workspace *)

--- a/lib/config_dir_resolver/config_dir_resolver.ml
+++ b/lib/config_dir_resolver/config_dir_resolver.ml
@@ -145,6 +145,11 @@ let current_working_dir () =
   try Sys.getcwd () with
   | Sys_error _ -> fallback_cwd_from_env ()
 
+let base_path_or_cwd () =
+  match (Host_config.from_env ()).base_path with
+  | Some path -> path
+  | None -> current_working_dir ()
+
 let absolute_path path =
   if Filename.is_relative path then Filename.concat (current_working_dir ()) path
   else path

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -57,6 +57,9 @@ val current_working_dir : unit -> string
 (** Current working directory, falling back to an absolute host root when the
     process cwd has been deleted. *)
 
+val base_path_or_cwd : unit -> string
+(** [MASC_BASE_PATH] from host config, or {!current_working_dir} when unset. *)
+
 val resolve : unit -> resolution
 (** Cached resolution. First call evaluates, subsequent calls return the cache. *)
 

--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -1,7 +1,6 @@
-(* Mirrors [Env_config_core.get_bool ~default:false], which lives in
-   [masc.config].  [masc_core] cannot depend on [masc.config] because
-   [masc.config] already depends on [masc_core], so the helper is kept
-   here as a thin alias for the boolean-env parsing logic. *)
+(* Local boolean-env helper for [masc_core]. It intentionally treats only
+   1/true/yes/on as true and every other value as false; it does not mirror
+   the richer [Env_config_core.get_bool] surface in [masc.config]. *)
 let env_true name =
   match Sys.getenv_opt name with
   | None -> false

--- a/lib/core/common.ml
+++ b/lib/core/common.ml
@@ -1,3 +1,7 @@
+(* Mirrors [Env_config_core.get_bool ~default:false], which lives in
+   [masc.config].  [masc_core] cannot depend on [masc.config] because
+   [masc.config] already depends on [masc_core], so the helper is kept
+   here as a thin alias for the boolean-env parsing logic. *)
 let env_true name =
   match Sys.getenv_opt name with
   | None -> false

--- a/lib/keeper/keeper_compact_audit.mli
+++ b/lib/keeper/keeper_compact_audit.mli
@@ -81,6 +81,22 @@ val persist_complete
 
 (** {1 Retention} *)
 
+(** Accepted retention-day bounds for
+    [MASC_COMPACTION_AUDIT_RETENTION_DAYS] and manual prune arguments. *)
+val retention_min_days : int
+val retention_max_days : int
+
+(** Resolve [MASC_COMPACTION_AUDIT_RETENTION_DAYS] without side effects,
+    returning the typed outcome. Reads from process env at call time. *)
+val resolve_retention_outcome
+  :  default:int
+  -> Keeper_compact_audit_retention_outcome.t
+
+(** Extract the effective day count from a retention resolution outcome. *)
+val effective_days_of_outcome
+  :  Keeper_compact_audit_retention_outcome.t
+  -> int
+
 (** Delete [.jsonl] day-files in [{base_path}/data/harness-compact/]
     whose date is older than [retention_days] days ago. Thin wrapper
     over {!Dated_jsonl.prune}; returns the count of files deleted. *)


### PR DESCRIPTION
## Summary

Centralises base-path and retention-days lookups in MASC CLI entry points through existing SSOT modules.

- `bin/masc_cost`, `bin/masc_tui`, `bin/masc_compaction_audit` no longer call `Sys.getenv_opt "MASC_BASE_PATH"` or `Sys.getcwd ()` directly.
- They now obtain the configured base path from `Host_config.from_env ().base_path`, falling back to `Config_dir_resolver.current_working_dir ()` (the SSOT cwd handler).
- `.masc` directory construction uses `Common.masc_dir_from_base_path` with `Common.masc_dirname`.
- `masc_compaction_audit` retention days now parse through `Env_config_core.get_int` instead of hand-rolled `int_of_string_opt` + `Sys.getenv_opt`.
- Added a comment in `lib/core/common.ml` explaining why `env_true` stays a local helper (`masc_core` cannot depend on `masc.config`).

## Validation

- `scripts/dune-local.sh build bin/masc_cost.exe bin/masc_tui.exe bin/masc_compaction_audit.exe` :white_check_mark:
- `scripts/dune-local.sh test test/test_common.exe test/test_config_dir_resolver.exe test/test_rfc_0085_pr6_host_config_from_env.exe test/test_keeper_compact_audit.exe` :white_check_mark:
