### PR TITLE
fix(memory): migrate legacy external_state category

### DIFF
--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -175,6 +175,15 @@ let claim_kind_of_string s =
   | _ -> None
 ;;
 
+let legacy_external_state_category = "external_state"
+
+let category_and_claim_kind_of_persisted_row ~category_str ~claim_kind =
+  match String.lowercase_ascii (String.trim category_str) with
+  | s when String.equal s legacy_external_state_category ->
+    Fact, Some (Option.value claim_kind ~default:External_state)
+  | _ -> category_of_string category_str, claim_kind
+;;
+
 (* Exhaustive promotability: only objective, durable claim kinds cross keepers.
    Extends the prior [Fact; Constraint] whitelist with the two outcome-derived
    kinds [Validated_approach] and [Lesson] — a validated approach and a hard-won
@@ -593,11 +602,17 @@ let fact_of_json (json : Yojson.Safe.t) =
           let claim_kind =
             Option.bind (json_string_field wire_field_claim_kind fields) claim_kind_of_string
           in
+          let category, claim_kind =
+            category_and_claim_kind_of_persisted_row ~category_str ~claim_kind
+          in
           Some
             { claim
             ; (* Parse-once at the read boundary; legacy free-string categories
-                 on disk map to their arm or [Unknown] (graceful-degrade). *)
-              category = category_of_string category_str
+                 on disk map to their arm or [Unknown] (graceful-degrade). The
+                 legacy [external_state] category is an exact structured token,
+                 so decode it into the modern [Fact] + [claim_kind=External_state]
+                 shape rather than inferring from claim prose. *)
+              category
             ; external_ref
             ; claim_kind
             ; source

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -143,8 +143,10 @@ let category_of_string s =
 (* RFC-0285 §3.1: producer-emitted origin tag, orthogonal to [category] (a [Lesson]
    can be a self-observation). A closed sum classified ONCE at the librarian write
    boundary — not a read-time string match (the project's workaround signature #2).
-   An absent/unrecognized tag yields [None] in [claim_kind_of_string], which routes
-   to the durable pre-RFC path (safe), never to wrong-volatile. *)
+   An absent/unrecognized tag yields [None] in [claim_kind_of_string]. For normal
+   categories that routes to the durable pre-RFC path (safe), never to
+   wrong-volatile; legacy category migrations may reject invalid structured tags
+   instead of guessing. *)
 type claim_kind =
   | Self_observation (* transient first-person agent state: idle, looping, tool-timeout *)
   | External_state (* about the world/PR/issue; verifiable elsewhere *)
@@ -175,15 +177,41 @@ let claim_kind_of_string s =
   | _ -> None
 ;;
 
-let legacy_external_state_category = "external_state"
+type persisted_claim_kind =
+  | Persisted_claim_kind_absent
+  | Persisted_claim_kind_valid of claim_kind
+  | Persisted_claim_kind_invalid
+
+let persisted_claim_kind_of_json fields =
+  match List.assoc_opt wire_field_claim_kind fields with
+  | None -> Persisted_claim_kind_absent
+  | Some (`String raw) ->
+    (match claim_kind_of_string raw with
+     | Some claim_kind -> Persisted_claim_kind_valid claim_kind
+     | None -> Persisted_claim_kind_invalid)
+  | Some _ -> Persisted_claim_kind_invalid
+;;
+
+let legacy_external_state_category = claim_kind_to_string External_state
 
 let category_and_claim_kind_of_persisted_row ~category_str ~claim_kind =
   match String.lowercase_ascii (String.trim category_str) with
   | s when String.equal s legacy_external_state_category ->
-    Fact, Some (Option.value claim_kind ~default:External_state)
-  | _ -> category_of_string category_str, claim_kind
+    (match claim_kind with
+     | Persisted_claim_kind_absent
+     | Persisted_claim_kind_valid External_state
+     | Persisted_claim_kind_valid Self_observation
+     | Persisted_claim_kind_valid Durable_knowledge
+     | Persisted_claim_kind_valid Diagnostic -> Some (Fact, Some External_state)
+     | Persisted_claim_kind_invalid -> None)
+  | _ ->
+    let claim_kind =
+      match claim_kind with
+      | Persisted_claim_kind_absent | Persisted_claim_kind_invalid -> None
+      | Persisted_claim_kind_valid claim_kind -> Some claim_kind
+    in
+    Some (category_of_string category_str, claim_kind)
 ;;
-
 (* Exhaustive promotability: only objective, durable claim kinds cross keepers.
    Extends the prior [Fact; Constraint] whitelist with the two outcome-derived
    kinds [Validated_approach] and [Lesson] — a validated approach and a hard-won
@@ -595,38 +623,32 @@ let fact_of_json (json : Yojson.Safe.t) =
           let claim_id =
             Option.bind (json_string_field wire_field_claim_id fields) normalize_claim_id
           in
-          (* RFC-0285 §3.1: absent on legacy rows -> [None] (durable path). Closed sum,
-             so an unrecognized string also yields [None] (graceful-degrade). The
-             write-side [valid_until] is preserved as-is above; legacy self-observation
-             rows are not retrofitted a horizon (RFC §5 non-goal). *)
-          let claim_kind =
-            Option.bind (json_string_field wire_field_claim_kind fields) claim_kind_of_string
-          in
-          let category, claim_kind =
-            category_and_claim_kind_of_persisted_row ~category_str ~claim_kind
-          in
-          Some
-            { claim
-            ; (* Parse-once at the read boundary; legacy free-string categories
-                 on disk map to their arm or [Unknown] (graceful-degrade). The
-                 legacy [external_state] category is an exact structured token,
-                 so decode it into the modern [Fact] + [claim_kind=External_state]
-                 shape rather than inferring from claim prose. *)
-              category
-            ; external_ref
-            ; claim_kind
-            ; source
-            ; observed_by
-            ; first_seen
-            ; valid_until
-            ; last_verified_at
-            ; schema_version =
-                (* DET-OK: default to current schema for forward compatibility. *)
-                Option.value
-                  (json_string_field wire_field_schema_version fields)
-                  ~default:schema_version
-            ; claim_id
-            }
+          let claim_kind = persisted_claim_kind_of_json fields in
+          (match category_and_claim_kind_of_persisted_row ~category_str ~claim_kind with
+           | None -> None
+           | Some (category, claim_kind) ->
+             Some
+               { claim
+               ; (* Parse-once at the read boundary; legacy free-string categories
+                    on disk map to their arm or [Unknown] (graceful-degrade). The
+                    legacy [external_state] category is an exact structured token,
+                    so decode it into the modern [Fact] + [claim_kind=External_state]
+                    shape rather than inferring from claim prose. *)
+                 category
+               ; external_ref
+               ; claim_kind
+               ; source
+               ; observed_by
+               ; first_seen
+               ; valid_until
+               ; last_verified_at
+               ; schema_version =
+                   (* DET-OK: default to current schema for forward compatibility. *)
+                   Option.value
+                     (json_string_field wire_field_schema_version fields)
+                     ~default:schema_version
+               ; claim_id
+               })
         | None -> None)
      | (Some _, Some _, None)
      | (Some _, None, _)

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -195,7 +195,7 @@ let persisted_claim_kind_of_json fields =
 let legacy_external_state_category = claim_kind_to_string External_state
 
 let category_and_claim_kind_of_persisted_row ~category_str ~claim_kind =
-  match String.lowercase_ascii (String.trim category_str) with
+  match category_str with
   | s when String.equal s legacy_external_state_category ->
     (match claim_kind with
      | Persisted_claim_kind_absent

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3771,6 +3771,43 @@ let test_fact_of_json_does_not_infer_external_ref_from_legacy_prose () =
       f.Types.valid_until
 ;;
 
+let test_fact_of_json_migrates_legacy_external_state_category () =
+  let first_seen = 1_000_000.0 in
+  let legacy =
+    `Assoc
+      [ "claim", `String "PR #21363 is OPEN, MERGEABLE, and BLOCKED"
+      ; "category", `String "external_state"
+      ; "source", `Assoc [ "trace_id", `String "t"; "turn", `Int 1 ]
+      ; "first_seen", `Float first_seen
+      ; "schema_version", `String "rfc0231-v2"
+      ]
+  in
+  match Types.fact_of_json legacy with
+  | None -> Alcotest.fail "legacy external_state row failed to decode"
+  | Some f ->
+    Alcotest.(check string)
+      "legacy external_state category migrates to fact"
+      "fact"
+      (Types.category_to_string f.Types.category);
+    Alcotest.(check (option string))
+      "legacy external_state category becomes claim_kind"
+      (Some "external_state")
+      (Option.map Types.claim_kind_to_string f.Types.claim_kind);
+    Alcotest.(check bool)
+      "migration does not reintroduce external_ref inference"
+      true
+      (Option.is_none f.Types.external_ref);
+    let json = Yojson.Safe.to_string (Types.fact_to_json f) in
+    Alcotest.(check bool)
+      "rewritten row no longer persists external_state as category"
+      false
+      (contains {|"category":"external_state"|} json);
+    Alcotest.(check bool)
+      "rewritten row persists external_state as claim_kind"
+      true
+      (contains {|"claim_kind":"external_state"|} json)
+;;
+
 let test_fact_to_json_drops_external_ref_surface () =
   let now = 1_000_000.0 in
   let f = fact_fixture ~now () in
@@ -4930,6 +4967,10 @@ let () =
             "fact_of_json does not infer external_ref from legacy prose"
             `Quick
             test_fact_of_json_does_not_infer_external_ref_from_legacy_prose
+        ; Alcotest.test_case
+            "fact_of_json migrates legacy external_state category"
+            `Quick
+            test_fact_of_json_migrates_legacy_external_state_category
         ; Alcotest.test_case
             "fact_to_json drops external_ref surface"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3797,15 +3797,62 @@ let test_fact_of_json_migrates_legacy_external_state_category () =
       "migration does not reintroduce external_ref inference"
       true
       (Option.is_none f.Types.external_ref);
-    let json = Yojson.Safe.to_string (Types.fact_to_json f) in
-    Alcotest.(check bool)
+    let json = Types.fact_to_json f in
+    let string_field key =
+      match json with
+      | `Assoc fields ->
+        (match List.assoc_opt key fields with
+         | Some (`String value) -> Some value
+         | Some _ | None -> None)
+      | _ -> None
+    in
+    Alcotest.(check (option string))
       "rewritten row no longer persists external_state as category"
-      false
-      (contains {|"category":"external_state"|} json);
-    Alcotest.(check bool)
+      (Some "fact")
+      (string_field "category");
+    Alcotest.(check (option string))
       "rewritten row persists external_state as claim_kind"
+      (Some "external_state")
+      (string_field "claim_kind")
+;;
+
+let test_fact_of_json_rejects_invalid_external_state_claim_kind () =
+  let first_seen = 1_000_000.0 in
+  let legacy =
+    `Assoc
+      [ "claim", `String "PR #21363 is OPEN, MERGEABLE, and BLOCKED"
+      ; "category", `String "external_state"
+      ; "claim_kind", `String "not_a_kind"
+      ; "source", `Assoc [ "trace_id", `String "t"; "turn", `Int 1 ]
+      ; "first_seen", `Float first_seen
+      ; "schema_version", `String "rfc0231-v2"
+      ]
+  in
+  Alcotest.(check bool)
+    "invalid claim_kind on legacy external_state is rejected"
+    true
+    (Option.is_none (Types.fact_of_json legacy))
+;;
+
+let test_fact_of_json_forces_legacy_external_state_claim_kind () =
+  let first_seen = 1_000_000.0 in
+  let legacy =
+    `Assoc
+      [ "claim", `String "PR #21363 is OPEN, MERGEABLE, and BLOCKED"
+      ; "category", `String "external_state"
+      ; "claim_kind", `String "self_observation"
+      ; "source", `Assoc [ "trace_id", `String "t"; "turn", `Int 1 ]
+      ; "first_seen", `Float first_seen
+      ; "schema_version", `String "rfc0231-v2"
+      ]
+  in
+  match Types.fact_of_json legacy with
+  | None -> Alcotest.fail "legacy external_state row with conflicting claim_kind failed"
+  | Some f ->
+    Alcotest.(check bool)
+      "legacy external_state category wins over inconsistent claim_kind"
       true
-      (contains {|"claim_kind":"external_state"|} json)
+      (f.Types.claim_kind = Some Types.External_state)
 ;;
 
 let test_fact_to_json_drops_external_ref_surface () =
@@ -4971,6 +5018,14 @@ let () =
             "fact_of_json migrates legacy external_state category"
             `Quick
             test_fact_of_json_migrates_legacy_external_state_category
+        ; Alcotest.test_case
+            "fact_of_json rejects invalid legacy external_state claim_kind"
+            `Quick
+            test_fact_of_json_rejects_invalid_external_state_claim_kind
+        ; Alcotest.test_case
+            "fact_of_json forces legacy external_state claim_kind"
+            `Quick
+            test_fact_of_json_forces_legacy_external_state_claim_kind
         ; Alcotest.test_case
             "fact_to_json drops external_ref surface"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3816,6 +3816,34 @@ let test_fact_of_json_migrates_legacy_external_state_category () =
       (string_field "claim_kind")
 ;;
 
+let test_fact_of_json_does_not_normalize_legacy_external_state_category () =
+  let first_seen = 1_000_000.0 in
+  let category = " External_State " in
+  let legacy =
+    `Assoc
+      [ "claim", `String "PR #21363 is OPEN, MERGEABLE, and BLOCKED"
+      ; "category", `String category
+      ; "source", `Assoc [ "trace_id", `String "t"; "turn", `Int 1 ]
+      ; "first_seen", `Float first_seen
+      ; "schema_version", `String "rfc0231-v2"
+      ]
+  in
+  match Types.fact_of_json legacy with
+  | None -> Alcotest.fail "legacy row with non-exact external_state category failed"
+  | Some f ->
+    (match f.Types.category with
+     | Types.Unknown raw ->
+       Alcotest.(check string)
+         "non-exact legacy external_state stays unknown"
+         category
+         raw
+     | _ -> Alcotest.fail "non-exact legacy external_state category migrated");
+    Alcotest.(check (option string))
+      "non-exact legacy external_state does not set claim_kind"
+      None
+      (Option.map Types.claim_kind_to_string f.Types.claim_kind)
+;;
+
 let test_fact_of_json_rejects_invalid_external_state_claim_kind () =
   let first_seen = 1_000_000.0 in
   let legacy =
@@ -5018,6 +5046,10 @@ let () =
             "fact_of_json migrates legacy external_state category"
             `Quick
             test_fact_of_json_migrates_legacy_external_state_category
+        ; Alcotest.test_case
+            "fact_of_json keeps non-exact external_state category unknown"
+            `Quick
+            test_fact_of_json_does_not_normalize_legacy_external_state_category
         ; Alcotest.test_case
             "fact_of_json rejects invalid legacy external_state claim_kind"
             `Quick


### PR DESCRIPTION
## Summary

- Decode persisted exact `category: "external_state"` facts into the modern `category = Fact` plus `claim_kind = External_state` shape.
- Keep the existing no-prose-inference boundary: this migration is driven only by the exact structured legacy category token and still ignores legacy `external_ref` metadata.
- Derive the legacy category token from `claim_kind_to_string External_state` instead of duplicating a raw string literal.
- Reject legacy `external_state` rows that carry an invalid/non-string `claim_kind` instead of silently defaulting them to `External_state`.
- Force valid but inconsistent legacy `claim_kind` values under exact `category:"external_state"` back to `External_state`, so the category migration has one canonical meaning.
- Do not normalize whitespace/case variants of the legacy category token; non-exact `external_state`-like values remain unknown data-quality issues.
- Add regression coverage for happy-path migration, invalid claim-kind rejection, inconsistent claim-kind normalization, non-exact category rejection, and structured JSON output fields.

## Audit Mapping

Addresses `docs/audit/2026-06-26-memory-os-production-audit.md` Next item:

- Add migration for legacy `rfc0231-v2` rows and unknown categories like `external_state`.

## Validation

Source-level only per current instruction:

- `ocamlformat --check lib/keeper/keeper_memory_os_types.ml test/test_keeper_memory_os.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_memory_os_types.ml test/test_keeper_memory_os.ml`
- `git diff --check`
- targeted `rg` found no remaining `Option.value claim_kind`, raw `legacy_external_state_category = "external_state"`, normalized `category_str` migration gate, or string `contains` checks for rewritten `category` / `claim_kind`

Not run or inspected here:

- Dune build/test
- CI/check logs
