### PR TITLE
fix(memory): gate shared promotion on outcome evidence

### DIFF
--- a/docs/rfc/RFC-0247-memory-os-associative-graph-forgetting-brain.md
+++ b/docs/rfc/RFC-0247-memory-os-associative-graph-forgetting-brain.md
@@ -263,7 +263,9 @@ Once re-enabled, extend the consolidator's single sweep to do the brain's three
 nightly jobs:
 
 1. **Promote** (already in #21237): claims held by ≥2 distinct keepers → `_shared`,
-   noisy-OR confidence — now over a closed-sum, promotable-only category set.
+   noisy-OR confidence — now over a closed-sum, promotable-only category set plus
+   the stricter `is_outcome_positive_for_shared_promotion` gate. That gate is a
+   temporary category proxy until #22447 outcome-eval metadata replaces it.
 2. **Link**: run the deterministic edge producers (§2.1) over the batch, so links
    are built off the hot path.
 3. **Forget**: run the lifecycle/GC pass (§2.3).
@@ -353,9 +355,11 @@ offline/no-embedding tenet and slot onto the organs above (full extract:
 
 - **Earned promotion, not declared confidence** (OpenClaw `minRecallCount=3 /
   minUniqueQueries=2`; Hermes trust-on-reobserve). A fact becomes `_shared` canon
-  only after demonstrated re-retrieval — gate #21237 promotion on the recall/access
-  counters (RFC-0243 already mutates them) instead of trusting the producer's
-  confidence. Directly kills the uniform-0.988 confidence-inversion failure mode.
+  only after demonstrated re-retrieval/outcome usefulness. Current code gates
+  #21237 promotion with `is_promotable` plus the stricter
+  `is_outcome_positive_for_shared_promotion` category proxy until #22447 supplies
+  explicit outcome-eval metadata. Directly kills the uniform-0.988
+  confidence-inversion failure mode.
 - **Read-time age + staleness reminder, not write-time confidence mutation**
   (claude-code `memoryAge` + freshness `<system-reminder>`; OpenClaw read-time
   `exp(-ln2/halfLife·age)` multiplier with evergreen exemption). An alternative/

--- a/docs/rfc/RFC-0247-purge-implementation-plan.md
+++ b/docs/rfc/RFC-0247-purge-implementation-plan.md
@@ -71,7 +71,7 @@ The field removals from the `fact` record (`types.ml:100-120`) and their codec h
 3. **Consolidate (LLM judgment)** — the LLM merges near-duplicate facts in a group into one durable topic-fact, **rewrites relative→absolute dates**, and marks contradicted older facts for deletion. This is where differently-worded-same-meaning claims finally merge (today they never do). Output is the merged claim text + which source facts it supersedes.
 4. **Prune/index** — keep the store bounded by a *judgment keep-decision* ("which facts are still load-bearing"), not `score_fact` truncation.
 
-The promoted shared fact's `confidence`/`noisy_or` recompute is **deleted**; `observed_by` (distinct keeper set) and `is_promotable` gate survive. Promotion eligibility moves from "`confidence >= 0.5` floor" to "`is_promotable` AND the judgment pass chose to surface it cross-keeper."
+The promoted shared fact's `confidence`/`noisy_or` recompute is **deleted**; `observed_by` (distinct keeper set), `is_promotable`, and the stricter outcome-positive shared gate survive. Promotion eligibility moves from "`confidence >= 0.5` floor" to "`is_promotable` AND `is_outcome_positive_for_shared_promotion` AND the judgment pass chose to surface it cross-keeper." `is_outcome_positive_for_shared_promotion` is a temporary category proxy pending #22447 outcome-eval metadata.
 
 ### FORGET — delete-on-contradiction + ephemeral drop, by judgment (no TTL-decay verdict)
 

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -21,15 +21,12 @@ open Keeper_memory_os_types
 
 module Io = Keeper_memory_os_io
 
-(* Which categories are objective enough to share across keepers is a
-   compile-time property of the closed [category] taxonomy
-   (Keeper_memory_os_types.is_promotable: only Fact/Constraint), not a runtime
-   list. Default-deny is structural: a new arm (e.g. the [Ephemeral]
-   coordination-boilerplate kind, RFC-0247 §2.5 / #21244) cannot leak into the
-   shared tier unless it is classified promotable at the type level. This
-   strengthens #21241's typed [category list] into an exhaustive predicate, so a
-   future arm forces a compile-time promotability decision rather than silently
-   defaulting out of a list. *)
+(* Which categories are durable enough to consider, and which are
+   outcome-positive enough to cross keepers, are compile-time properties of the
+   closed [category] taxonomy. Default-deny is structural: a new arm (e.g. the
+   [Ephemeral] coordination-boilerplate kind, RFC-0247 §2.5 / #21244) cannot leak
+   into the shared tier unless it is classified both promotable and
+   outcome-positive at the type level. *)
 
 (* Minimum distinct keepers that must hold a claim before it is shared. Two is
    the smallest set that distinguishes corroboration from a single keeper's echo
@@ -49,17 +46,6 @@ type contribution =
   ; fact : fact
   }
 
-(* Audit 2026-06-26: `_shared` must be corroborated AND outcome-positive. Until a
-   dedicated outcome-eval signal is joined into facts, the only structural source
-   of outcome-positive evidence is the outcome-derived category pair. Plain
-   [Fact]/[Constraint] remains keeper-local even when repeated by multiple
-   keepers. *)
-let outcome_positive_for_shared_promotion = function
-  | Validated_approach | Lesson -> true
-  | Code_change | Fact | Preference | Blocker | Goal | Constraint | Ephemeral | Unknown _ ->
-    false
-;;
-
 (* RFC-0247 (purge): eligibility is structural — a promotable, outcome-positive
    category. The prior confidence floor (only claims above 0.5 count as
    corroboration) was a score gate and is gone. *)
@@ -70,7 +56,7 @@ let outcome_positive_for_shared_promotion = function
    accident. *)
 let eligible fact =
   is_promotable fact.category
-  && outcome_positive_for_shared_promotion fact.category
+  && is_outcome_positive_for_shared_promotion fact.category
   &&
   match fact.claim_kind with
   | Some Durable_knowledge | None -> true

--- a/lib/keeper/keeper_memory_os_consolidator.ml
+++ b/lib/keeper/keeper_memory_os_consolidator.ml
@@ -11,10 +11,11 @@
     Determinism (the memory-os offline/reproducible tenet): the output is a pure
     function of the input facts, emitted in normalized-claim order, so a test can
     assert exact output and a re-run on an unchanged fleet rewrites the same file.
-    RFC-0247 (purge): corroboration is structural — a claim is shared when
-    [>= min_keepers] DISTINCT keepers hold it on a promotable category. The prior
-    confidence floor and noisy-OR aggregation were removed with the score; there
-    is no confidence number to recompute. *)
+    RFC-0247 (purge): corroboration is structural. The prior confidence floor and
+    noisy-OR aggregation were removed with the score; there is no confidence
+    number to recompute. Shared promotion is additionally limited to categories
+    that already encode outcome-derived knowledge, so `_shared` does not amplify
+    merely repeated facts before the outcome evaluator can prove usefulness. *)
 
 open Keeper_memory_os_types
 
@@ -48,19 +49,32 @@ type contribution =
   ; fact : fact
   }
 
-(* RFC-0247 (purge): eligibility is purely structural — a promotable category.
-   The prior confidence floor (only claims above 0.5 count as corroboration) was
-   a score gate and is gone. *)
+(* Audit 2026-06-26: `_shared` must be corroborated AND outcome-positive. Until a
+   dedicated outcome-eval signal is joined into facts, the only structural source
+   of outcome-positive evidence is the outcome-derived category pair. Plain
+   [Fact]/[Constraint] remains keeper-local even when repeated by multiple
+   keepers. *)
+let outcome_positive_for_shared_promotion = function
+  | Validated_approach | Lesson -> true
+  | Code_change | Fact | Preference | Blocker | Goal | Constraint | Ephemeral | Unknown _ ->
+    false
+;;
+
+(* RFC-0247 (purge): eligibility is structural — a promotable, outcome-positive
+   category. The prior confidence floor (only claims above 0.5 count as
+   corroboration) was a score gate and is gone. *)
 (* RFC-0285 §3.5: only objective claim kinds cross keepers. [Self_observation] is
-   transient keeper-local state, and [Diagnostic] is system-authored evidence for
-   operators, not shared semantic memory. Keep this exhaustive so a future
-   [claim_kind] cannot promote by accident. *)
+   transient keeper-local state, [External_state] is time-sensitive world state,
+   and [Diagnostic] is system-authored evidence for operators, not shared semantic
+   memory. Keep this exhaustive so a future [claim_kind] cannot promote by
+   accident. *)
 let eligible fact =
   is_promotable fact.category
+  && outcome_positive_for_shared_promotion fact.category
   &&
   match fact.claim_kind with
-  | Some External_state | Some Durable_knowledge | None -> true
-  | Some Self_observation | Some Diagnostic -> false
+  | Some Durable_knowledge | None -> true
+  | Some Self_observation | Some External_state | Some Diagnostic -> false
 
 (* Pick the representative fact for a claim group by a structural total order:
    earliest first_seen, then lexically smallest claim, then keeper id — so

--- a/lib/keeper/keeper_memory_os_consolidator.mli
+++ b/lib/keeper/keeper_memory_os_consolidator.mli
@@ -1,12 +1,13 @@
 (** Keeper_memory_os_consolidator — RFC-0244 Tier 2 cross-keeper consolidation.
 
     Reads per-keeper Tier-1 stores read-only and promotes claims corroborated by
-    [>= min_keepers] distinct keepers on a [Keeper_memory_os_types.is_promotable]
-    category into the shared Tier-2 store
-    ([Keeper_memory_os_types.shared_store_id]). Additive: it never mutates a
-    keeper's own store. Pure and deterministic — [promote_facts] is a function of
-    its inputs, emitted in normalized-claim order. RFC-0247 removed the confidence
-    floor and the noisy-OR confidence aggregation: corroboration is structural. *)
+    [>= min_keepers] distinct keepers only when the category is both promotable
+    and outcome-derived ([Validated_approach] or [Lesson]) into the shared Tier-2
+    store ([Keeper_memory_os_types.shared_store_id]). Additive: it never mutates
+    a keeper's own store. Pure and deterministic — [promote_facts] is a function
+    of its inputs, emitted in normalized-claim order. RFC-0247 removed the
+    confidence floor and the noisy-OR confidence aggregation: corroboration is
+    structural. *)
 
 open Keeper_memory_os_types
 

--- a/lib/keeper/keeper_memory_os_consolidator.mli
+++ b/lib/keeper/keeper_memory_os_consolidator.mli
@@ -2,12 +2,13 @@
 
     Reads per-keeper Tier-1 stores read-only and promotes claims corroborated by
     [>= min_keepers] distinct keepers only when the category is both promotable
-    and outcome-derived ([Validated_approach] or [Lesson]) into the shared Tier-2
-    store ([Keeper_memory_os_types.shared_store_id]). Additive: it never mutates
-    a keeper's own store. Pure and deterministic — [promote_facts] is a function
-    of its inputs, emitted in normalized-claim order. RFC-0247 removed the
-    confidence floor and the noisy-OR confidence aggregation: corroboration is
-    structural. *)
+    and outcome-positive ([Validated_approach] or [Lesson]) and the claim kind is
+    objective ([Durable_knowledge] or legacy [None]). Promoted facts are written
+    into the shared Tier-2 store ([Keeper_memory_os_types.shared_store_id]).
+    Additive: it never mutates a keeper's own store. Pure and deterministic —
+    [promote_facts] is a function of its inputs, emitted in normalized-claim
+    order. RFC-0247 removed the confidence floor and the noisy-OR confidence
+    aggregation: corroboration is structural. *)
 
 open Keeper_memory_os_types
 

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -212,18 +212,27 @@ let category_and_claim_kind_of_persisted_row ~category_str ~claim_kind =
     in
     Some (category_of_string category_str, claim_kind)
 ;;
-(* Exhaustive promotability: only objective, durable claim kinds cross keepers.
-   Extends the prior [Fact; Constraint] whitelist with the two outcome-derived
-   kinds [Validated_approach] and [Lesson] — a validated approach and a hard-won
-   lesson are exactly the knowledge worth sharing fleet-wide. Everything else —
-   including [Ephemeral] and any [Unknown] label — stays keeper-local. Exhaustive
-   match (not a runtime [category list]) so a future durable kind must be
-   classified here at compile time rather than silently defaulting to
-   non-promotable, the no-silent-omission property RFC-0247 §2.5 argues for over
-   the prompt-suppression approach. *)
+
+(* Exhaustive category promotability. This is a necessary category whitelist for
+   durable promotion decisions, not the complete `_shared` gate. The consolidator
+   additionally requires [is_outcome_positive_for_shared_promotion] so repeated
+   plain [Fact]/[Constraint] rows remain keeper-local until outcome evaluation
+   upgrades them. Exhaustive match (not a runtime [category list]) so a future
+   durable kind must be classified here at compile time rather than silently
+   defaulting to non-promotable, the no-silent-omission property RFC-0247 §2.5
+   argues for over the prompt-suppression approach. *)
 let is_promotable = function
   | Fact | Constraint | Validated_approach | Lesson -> true
   | Code_change | Preference | Blocker | Goal | Ephemeral | Unknown _ -> false
+;;
+
+(* Shared Tier-2 promotion is stricter than generic category promotability:
+   repeated plain facts/constraints stay keeper-local until outcome evaluation
+   turns them into a validated approach or lesson. *)
+let is_outcome_positive_for_shared_promotion = function
+  | Validated_approach | Lesson -> true
+  | Code_change | Fact | Preference | Blocker | Goal | Constraint | Ephemeral | Unknown _ ->
+    false
 ;;
 
 (* RFC-0259 §3.2(b): an explicitly structured reference to verifiable external

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -228,7 +228,9 @@ let is_promotable = function
 
 (* Shared Tier-2 promotion is stricter than generic category promotability:
    repeated plain facts/constraints stay keeper-local until outcome evaluation
-   turns them into a validated approach or lesson. *)
+   turns them into a validated approach or lesson.
+   TODO(#22447): replace this category proxy with explicit recall-outcome
+   metadata once the local outcome evaluator is joined into fact metadata. *)
 let is_outcome_positive_for_shared_promotion = function
   | Validated_approach | Lesson -> true
   | Code_change | Fact | Preference | Blocker | Goal | Constraint | Ephemeral | Unknown _ ->

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -128,12 +128,16 @@ val librarian_claim_kinds : claim_kind list
     (safe), never to wrong-volatile. *)
 val claim_kind_of_string : string -> claim_kind option
 
-(** Whether a category may be promoted into the shared semantic tier. Exhaustive
-    over {!category}; [Fact], [Constraint], [Validated_approach], and [Lesson]
-    promote. Everything else stays keeper-local, so a new or typo'd category
-    cannot silently join the shared tier — a future durable kind must be
-    classified here at compile time. *)
+(** Whether a category may participate in durable promotion decisions. This is
+    necessary but not sufficient for the shared semantic tier: the consolidator
+    also requires {!is_outcome_positive_for_shared_promotion}. Exhaustive over
+    {!category}; a future durable kind must be classified here at compile time. *)
 val is_promotable : category -> bool
+
+(** Whether a category is outcome-positive enough to cross keepers into the
+    shared semantic tier. Plain [Fact] and [Constraint] remain keeper-local until
+    outcome evaluation turns them into [Validated_approach] or [Lesson]. *)
+val is_outcome_positive_for_shared_promotion : category -> bool
 
 (** Historical RFC-0259 external-ref kind. Kept as a closed sum for source
     compatibility; current Memory OS code does not infer or act on it. *)

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -134,9 +134,11 @@ val claim_kind_of_string : string -> claim_kind option
     {!category}; a future durable kind must be classified here at compile time. *)
 val is_promotable : category -> bool
 
-(** Whether a category is outcome-positive enough to cross keepers into the
-    shared semantic tier. Plain [Fact] and [Constraint] remain keeper-local until
-    outcome evaluation turns them into [Validated_approach] or [Lesson]. *)
+(** Category proxy for whether a fact is outcome-positive enough to cross
+    keepers into the shared semantic tier. Plain [Fact] and [Constraint] remain
+    keeper-local until outcome evaluation turns them into [Validated_approach] or
+    [Lesson]. TODO(#22447): replace this proxy with explicit recall-outcome
+    metadata once the local evaluator is joined into fact metadata. *)
 val is_outcome_positive_for_shared_promotion : category -> bool
 
 (** Historical RFC-0259 external-ref kind. Kept as a closed sum for source

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -177,8 +177,10 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      dead-code-with-a-switch -- an unproven fiber should not run, a proven one
      needs no switch. The noise the #21244 dry-run found (ephemeral boilerplate
      promoted into shared recall) predates the fixes built to stop it: the typed
-     [Ephemeral] category + [is_promotable] gate (#21241) -- the consolidator now
-     structurally skips non-promotable facts -- and the durability-gate
+     [Ephemeral] category + [is_promotable] gate (#21241) plus the stricter
+     [is_outcome_positive_for_shared_promotion] shared-tier proxy -- the
+     consolidator now structurally skips non-promotable and not-yet-outcome-positive
+     facts -- and the durability-gate
      librarian prompt (#21257) that labels coordination boilerplate "ephemeral",
      both merged after that dry-run. Off the keeper hot path: each [interval]s it
      reads each keeper's Tier-1 store and rewrites the shared semantic store

--- a/test/memory_os_brain_harness.ml
+++ b/test/memory_os_brain_harness.ml
@@ -161,40 +161,62 @@ let scenario_consolidation_gate () =
   section "S1 consolidation typed-gate (#21244) — non-vacuity + teeth";
   let now = 1_000_000.0 in
   let eph c = mk_fact ~now ~category:Types.Ephemeral c in
-  let fct c = mk_fact ~now ~category:Types.Fact c in
-  let con c = mk_fact ~now ~category:Types.Constraint c in
+  let approach c =
+    mk_fact
+      ~now
+      ~category:Types.Validated_approach
+      ~claim_kind:(Some Types.Durable_knowledge)
+      c
+  in
+  let lesson c =
+    mk_fact
+      ~now
+      ~category:Types.Lesson
+      ~claim_kind:(Some Types.Durable_knowledge)
+      c
+  in
   (* Modelled on the #21244 live finding: the ONLY >=2-keeper-corroborated claims
      were ephemeral lifecycle boilerplate. Here two ephemeral claims AND two
-     durable claims each clear the 2-keeper bar; single-keeper noise must never
-     promote regardless of category. *)
+     outcome-positive durable claims each clear the 2-keeper bar; single-keeper
+     noise must never promote regardless of category. *)
   let keeper_facts =
-    [ "alpha", [ eph "checkpoint saved"; eph "no tasks pending"; fct "build is driven by dune"; fct "alpha local scratch note" ]
-    ; "beta", [ eph "checkpoint saved"; eph "no tasks pending"; fct "build is driven by dune"; con "must not push directly to main" ]
-    ; "gamma", [ eph "checkpoint saved"; con "must not push directly to main" ]
-    ; "delta", [ fct "build is driven by dune" ]
+    [ "alpha", [ eph "checkpoint saved"; eph "no tasks pending"; approach "dune cache disabled fixes stale cmx"; approach "alpha local scratch note" ]
+    ; "beta", [ eph "checkpoint saved"; eph "no tasks pending"; approach "dune cache disabled fixes stale cmx"; lesson "must not push directly to main" ]
+    ; "gamma", [ eph "checkpoint saved"; lesson "must not push directly to main" ]
+    ; "delta", [ approach "dune cache disabled fixes stale cmx" ]
     ]
   in
   note "non-vacuity: ephemeral corroborated by >=2 keepers = {checkpoint saved (3), no tasks pending (2)} = 2 present";
-  note "non-vacuity: durable corroborated by >=2 keepers = {build is driven by dune (3 Fact), must not push directly to main (2 Constraint)} = 2 present";
+  note "non-vacuity: outcome-positive durable corroborated by >=2 keepers = {dune cache disabled fixes stale cmx (3 Validated_approach), must not push directly to main (2 Lesson)} = 2 present";
   let _considered, promoted = Consolidator.promote_facts ~now ~keeper_facts () in
   let promoted_claims = List.map (fun f -> f.Types.claim) promoted |> List.sort String.compare in
   check "exactly 2 claims promoted (completeness — not '>= something')" (List.length promoted = 2);
   check
-    "promoted set is exactly the two durable claims"
-    (promoted_claims = [ "build is driven by dune"; "must not push directly to main" ]);
+    "promoted set is exactly the two outcome-positive durable claims"
+    (promoted_claims = [ "dune cache disabled fixes stale cmx"; "must not push directly to main" ]);
   check
-    "no promoted fact is non-promotable (zero ephemeral leaked cross-keeper)"
-    (List.for_all (fun f -> Types.is_promotable f.Types.category) promoted);
+    "no promoted fact is outside the shared outcome-positive gate"
+    (List.for_all
+       (fun f ->
+          Types.is_promotable f.Types.category
+          && Types.is_outcome_positive_for_shared_promotion f.Types.category)
+       promoted);
   (* Teeth: reproduce the #21244 pathology by mislabelling the SAME ephemeral
-     claims as fact (what the LLM producer actually did). If they now promote,
-     the gate's decision provably hinges on the category label. *)
+     claims as validated approaches. If they now promote, the gate's decision
+     provably hinges on the category label. *)
   let relabel f =
-    if f.Types.category = Types.Ephemeral then { f with Types.category = Types.Fact } else f
+    if f.Types.category = Types.Ephemeral
+    then
+      { f with
+        Types.category = Types.Validated_approach
+      ; Types.claim_kind = Some Types.Durable_knowledge
+      }
+    else f
   in
   let mislabeled = List.map (fun (k, fs) -> (k, List.map relabel fs)) keeper_facts in
   let _c2, promoted_bug = Consolidator.promote_facts ~now ~keeper_facts:mislabeled () in
   check
-    "TEETH: mislabel ephemeral->fact and they leak (promoted 2 -> 4) — gate is real, label is load-bearing"
+    "TEETH: mislabel ephemeral->validated_approach and they leak (promoted 2 -> 4) — gate is real, label is load-bearing"
     (List.length promoted_bug = 4);
   note "=> verifies the GATE, not the PRODUCER. Whether the LLM labels boilerplate 'ephemeral' is unverified here."
 ;;
@@ -206,7 +228,14 @@ let scenario_forgetting_composition () =
   with_temp_keepers_dir (fun _dir ->
     let now = 2_000_000.0 in
     let expired = mk_fact ~now ~category:Types.Ephemeral ~valid_until:(Some (now -. 10.0)) "scheduled tick alpha" in
-    let durable = mk_fact ~now ~category:Types.Fact ~valid_until:None "dune build invariant holds" in
+    let durable =
+      mk_fact
+        ~now
+        ~category:Types.Lesson
+        ~claim_kind:(Some Types.Durable_knowledge)
+        ~valid_until:None
+        "dune build invariant holds"
+    in
     Memory_io.append_fact ~keeper_id:"alpha" expired;
     Memory_io.append_fact ~keeper_id:"alpha" durable;
     Memory_io.append_fact ~keeper_id:"beta" durable;

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3114,14 +3114,15 @@ let mk_shared_fixture ~now ?(category = "fact") claim =
   }
 ;;
 
-(* Two distinct keepers holding the same whitelisted claim are promoted into one
-   shared fact whose observed_by is the sorted keeper set. RFC-0247: corroboration
-   is structural (distinct-keeper count); there is no confidence aggregation. *)
+(* Two distinct keepers holding the same outcome-positive claim are promoted into
+   one shared fact whose observed_by is the sorted keeper set. RFC-0247:
+   corroboration is structural (distinct-keeper count); there is no confidence
+   aggregation. *)
 let test_consolidator_promotes_corroborated () =
   let now = 1_000_000.0 in
   let keeper_facts =
-    [ "beta", [ mk_shared_fixture ~now "shared system invariant" ]
-    ; "alpha", [ mk_shared_fixture ~now "shared system invariant" ]
+    [ "beta", [ mk_shared_fixture ~now ~category:"validated_approach" "shared system invariant" ]
+    ; "alpha", [ mk_shared_fixture ~now ~category:"validated_approach" "shared system invariant" ]
     ]
   in
   let _considered, shared = Consolidator.promote_facts ~now ~keeper_facts () in
@@ -3137,8 +3138,8 @@ let test_consolidator_promotes_corroborated () =
       (Some now)
       f.Types.last_verified_at;
     Alcotest.(check string)
-      "whitelisted category carried"
-      "fact"
+      "outcome-positive category carried"
+      "validated_approach"
       (Types.category_to_string f.Types.category)
   | _ -> Alcotest.fail "expected one shared fact"
 ;;
@@ -3151,7 +3152,9 @@ let test_consolidator_promotes_corroborated () =
 let test_consolidator_promotes_carries_claim_id () =
   let now = 1_000_000.0 in
   let with_id claim =
-    { (mk_shared_fixture ~now claim) with Types.claim_id = Some "pr-321-merged" }
+    { (mk_shared_fixture ~now ~category:"lesson" claim) with
+      Types.claim_id = Some "pr-321-merged"
+    }
   in
   let keeper_facts =
     [ "beta", [ with_id "PR #321 merged" ]
@@ -3175,7 +3178,9 @@ let test_consolidator_promotes_carries_claim_id () =
 (* A claim held by a single keeper is never shared (below min_keepers). *)
 let test_consolidator_solo_not_promoted () =
   let now = 1_000_000.0 in
-  let keeper_facts = [ "alpha", [ mk_shared_fixture ~now "solo only claim" ] ] in
+  let keeper_facts =
+    [ "alpha", [ mk_shared_fixture ~now ~category:"lesson" "solo only claim" ] ]
+  in
   let _considered, shared = Consolidator.promote_facts ~now ~keeper_facts () in
   Alcotest.(check int) "solo claim not promoted" 0 (List.length shared)
 ;;
@@ -3186,8 +3191,8 @@ let test_consolidator_same_keeper_repeat_no_inflate () =
   let now = 1_000_000.0 in
   let keeper_facts =
     [ ( "alpha"
-      , [ mk_shared_fixture ~now "repeated claim"
-        ; mk_shared_fixture ~now "repeated claim"
+      , [ mk_shared_fixture ~now ~category:"lesson" "repeated claim"
+        ; mk_shared_fixture ~now ~category:"lesson" "repeated claim"
         ] )
     ]
   in
@@ -3206,6 +3211,27 @@ let test_consolidator_category_default_deny () =
   in
   let _considered, shared = Consolidator.promote_facts ~now ~keeper_facts () in
   Alcotest.(check int) "non-whitelisted category not shared" 0 (List.length shared)
+;;
+
+(* Audit 2026-06-26: `_shared` should not amplify repeated facts before outcome
+   evaluation proves they helped. Fact/Constraint remain keeper-local even when
+   structurally corroborated; outcome-derived categories are the only current
+   structural positive signal. *)
+let test_consolidator_fact_constraint_wait_for_outcome_positive () =
+  let now = 1_000_000.0 in
+  let keeper_facts =
+    [ ( "alpha"
+      , [ mk_shared_fixture ~now ~category:"fact" "plain fact repeated"
+        ; mk_shared_fixture ~now ~category:"constraint" "plain constraint repeated"
+        ] )
+    ; ( "beta"
+      , [ mk_shared_fixture ~now ~category:"fact" "plain fact repeated"
+        ; mk_shared_fixture ~now ~category:"constraint" "plain constraint repeated"
+        ] )
+    ]
+  in
+  let _considered, shared = Consolidator.promote_facts ~now ~keeper_facts () in
+  Alcotest.(check int) "fact/constraint wait for outcome-positive evidence" 0 (List.length shared)
 ;;
 
 (* RFC-0247 §6: outcome-derived knowledge crosses keepers. A validated_approach
@@ -3358,8 +3384,14 @@ let test_consolidator_ephemeral_not_promoted () =
 let test_consolidator_deterministic () =
   let now = 1_000_000.0 in
   let forward =
-    [ "alpha", [ mk_shared_fixture ~now "zulu claim"; mk_shared_fixture ~now "alpha claim" ]
-    ; "beta", [ mk_shared_fixture ~now "zulu claim"; mk_shared_fixture ~now "alpha claim" ]
+    [ ( "alpha"
+      , [ mk_shared_fixture ~now ~category:"lesson" "zulu claim"
+        ; mk_shared_fixture ~now ~category:"lesson" "alpha claim"
+        ] )
+    ; ( "beta"
+      , [ mk_shared_fixture ~now ~category:"lesson" "zulu claim"
+        ; mk_shared_fixture ~now ~category:"lesson" "alpha claim"
+        ] )
     ]
   in
   let reversed = List.rev forward in
@@ -3380,8 +3412,12 @@ let test_recall_surfaces_shared_after_consolidation () =
       with_temp_keepers_dir (fun _keepers_dir ->
         let now = 1_000_000.0 in
         let shared_claim = "deployment uses blue green rollout" in
-        Memory_io.append_fact ~keeper_id:"alpha" (mk_shared_fixture ~now shared_claim);
-        Memory_io.append_fact ~keeper_id:"beta" (mk_shared_fixture ~now shared_claim);
+        Memory_io.append_fact
+          ~keeper_id:"alpha"
+          (mk_shared_fixture ~now ~category:"validated_approach" shared_claim);
+        Memory_io.append_fact
+          ~keeper_id:"beta"
+          (mk_shared_fixture ~now ~category:"validated_approach" shared_claim);
         let report = Consolidator.run ~keeper_ids:[ "alpha"; "beta" ] ~now () in
         Alcotest.(check int) "one claim promoted to shared store" 1 report.Consolidator.promoted;
         Memory_io.append_fact
@@ -3477,8 +3513,12 @@ let test_consolidator_waits_for_shared_store_lock () =
     with_eio_guard (fun () ->
       with_temp_keepers_dir (fun _keepers_dir ->
         let now = 1_000_000.0 in
-        Memory_io.append_fact ~keeper_id:"alpha" (mk_shared_fixture ~now "locked shared claim");
-        Memory_io.append_fact ~keeper_id:"beta" (mk_shared_fixture ~now "locked shared claim");
+        Memory_io.append_fact
+          ~keeper_id:"alpha"
+          (mk_shared_fixture ~now ~category:"lesson" "locked shared claim");
+        Memory_io.append_fact
+          ~keeper_id:"beta"
+          (mk_shared_fixture ~now ~category:"lesson" "locked shared claim");
         let result = ref None in
         let started, resolve_started = Eio.Promise.create () in
         File_lock_eio.with_lock
@@ -3722,7 +3762,7 @@ let test_self_observation_not_promoted () =
   let durable marker =
     { (fact_fixture ~now ()) with
       Types.claim = "merging requires two approvals (" ^ marker ^ ")"
-    ; Types.category = Types.Constraint
+    ; Types.category = Types.Lesson
     ; Types.claim_kind = Some Types.Durable_knowledge
     ; Types.claim_id = Some "two-approvals-rule"
     }
@@ -3740,7 +3780,7 @@ let test_self_observation_not_promoted () =
        (fun (f : Types.fact) -> f.Types.claim_kind = Some Types.Self_observation)
        shared);
   Alcotest.(check bool)
-    "durable knowledge with two keepers IS promoted"
+    "outcome-positive durable knowledge with two keepers IS promoted"
     true
     (List.exists
        (fun (f : Types.fact) -> f.Types.claim_id = Some "two-approvals-rule")
@@ -4954,6 +4994,10 @@ let () =
             "non-whitelisted category default-denied"
             `Quick
             test_consolidator_category_default_deny
+        ; Alcotest.test_case
+            "fact/constraint wait for outcome-positive promotion evidence"
+            `Quick
+            test_consolidator_fact_constraint_wait_for_outcome_positive
         ; Alcotest.test_case
             "unknown category default-denied (#21241)"
             `Quick

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3338,6 +3338,9 @@ let test_is_promotable_durable_kinds () =
     blocked
 ;;
 
+(* TODO(#22447): this test pins the temporary category proxy. Replace it with
+   explicit outcome-eval metadata coverage when recall outcome rows are joined
+   into fact metadata. *)
 let test_shared_promotion_outcome_positive_kinds () =
   let outcome_positive = [ Types.Validated_approach; Types.Lesson ] in
   let blocked =
@@ -5066,7 +5069,7 @@ let () =
             `Quick
             test_category_codec_roundtrip
         ; Alcotest.test_case
-            "durable kinds promote incl. validated_approach/lesson (RFC-0247 §6)"
+            "durable categories are promotable incl. validated_approach/lesson (RFC-0247 §6)"
             `Quick
             test_is_promotable_durable_kinds
         ; Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3338,6 +3338,29 @@ let test_is_promotable_durable_kinds () =
     blocked
 ;;
 
+let test_shared_promotion_outcome_positive_kinds () =
+  let outcome_positive = [ Types.Validated_approach; Types.Lesson ] in
+  let blocked =
+    [ Types.Fact; Types.Constraint; Types.Preference; Types.Blocker; Types.Goal
+    ; Types.Code_change; Types.Ephemeral; Types.Unknown "novel"
+    ]
+  in
+  List.iter
+    (fun c ->
+       Alcotest.(check bool)
+         (Types.category_to_string c ^ " outcome-positive")
+         true
+         (Types.is_outcome_positive_for_shared_promotion c))
+    outcome_positive;
+  List.iter
+    (fun c ->
+       Alcotest.(check bool)
+         (Types.category_to_string c ^ " not outcome-positive")
+         false
+         (Types.is_outcome_positive_for_shared_promotion c))
+    blocked
+;;
+
 (* RFC-0247 §2.3: retention is category-driven. Only Ephemeral gets a finite TTL;
    every durable arm returns None (never hard-expires). Exhaustive so a new
    category must be classified here. The companion lifetime-cycles (truth-decay
@@ -3767,8 +3790,28 @@ let test_self_observation_not_promoted () =
     ; Types.claim_id = Some "two-approvals-rule"
     }
   in
+  let denied_claim_kind claim_kind claim_id marker =
+    { (fact_fixture ~now ()) with
+      Types.claim = claim_id ^ " (" ^ marker ^ ")"
+    ; Types.category = Types.Lesson
+    ; Types.claim_kind = Some claim_kind
+    ; Types.claim_id = Some claim_id
+    }
+  in
   let keeper_facts =
-    [ "k1", [ self_obs "k1"; durable "k1" ]; "k2", [ self_obs "k2"; durable "k2" ] ]
+    [ ( "k1"
+      , [ self_obs "k1"
+        ; denied_claim_kind Types.External_state "external-state-pr-status" "k1"
+        ; denied_claim_kind Types.Diagnostic "diagnostic-ratio-alert" "k1"
+        ; durable "k1"
+        ] )
+    ; ( "k2"
+      , [ self_obs "k2"
+        ; denied_claim_kind Types.External_state "external-state-pr-status" "k2"
+        ; denied_claim_kind Types.Diagnostic "diagnostic-ratio-alert" "k2"
+        ; durable "k2"
+        ] )
+    ]
   in
   let _considered, shared =
     Consolidator.promote_facts ~min_keepers:2 ~now ~keeper_facts ()
@@ -3778,6 +3821,18 @@ let test_self_observation_not_promoted () =
     false
     (List.exists
        (fun (f : Types.fact) -> f.Types.claim_kind = Some Types.Self_observation)
+       shared);
+  Alcotest.(check bool)
+    "external-state claim kind is never promoted to the shared tier"
+    false
+    (List.exists
+       (fun (f : Types.fact) -> f.Types.claim_id = Some "external-state-pr-status")
+       shared);
+  Alcotest.(check bool)
+    "diagnostic claim kind is never promoted to the shared tier"
+    false
+    (List.exists
+       (fun (f : Types.fact) -> f.Types.claim_id = Some "diagnostic-ratio-alert")
        shared);
   Alcotest.(check bool)
     "outcome-positive durable knowledge with two keepers IS promoted"
@@ -5014,6 +5069,10 @@ let () =
             "durable kinds promote incl. validated_approach/lesson (RFC-0247 §6)"
             `Quick
             test_is_promotable_durable_kinds
+        ; Alcotest.test_case
+            "shared promotion outcome-positive kinds are stricter than promotable"
+            `Quick
+            test_shared_promotion_outcome_positive_kinds
         ; Alcotest.test_case
             "retention TTL/lifetime is category-driven (RFC-0247 §2.3)"
             `Quick


### PR DESCRIPTION
## Summary

Addresses the Memory OS production-audit follow-up: “Promote facts to `_shared` only when corroborated and outcome-positive.”

Current `_shared` promotion used structural corroboration plus `is_promotable`, so repeated `fact`/`constraint` rows could enter the shared tier before the outcome evaluator proves that recall was useful. This patch tightens the production promotion gate:

- `_shared` promotion now requires a promotable category and an outcome-derived category proxy (`validated_approach` or `lesson`).
- The proxy is explicitly marked `TODO(#22447)` until recall outcome-eval metadata is joined into fact metadata.
- Plain `fact` / `constraint` stays keeper-local even when repeated by multiple keepers.
- `External_state`, `Self_observation`, and `Diagnostic` claim kinds are blocked from shared promotion; only `Durable_knowledge` and legacy `None` can pass the claim-kind gate.
- Maintenance comments, test labels, and RFC docs now describe the shared gate as `is_promotable` plus `is_outcome_positive_for_shared_promotion`.

## Audit mapping

- Source: `docs/audit/2026-06-26-memory-os-production-audit.md`, Production Plan / Next item 3.
- This is intentionally separate from #22447 outcome-eval reporting. Until that evaluator is joined into fact metadata, the only structural positive signal is the existing outcome-derived taxonomy proxy.

## Validation

Source-level only per current instruction; Dune build/test and CI/check logs were not run or inspected.

- `ocamlformat --check lib/keeper/keeper_memory_os_types.ml lib/keeper/keeper_memory_os_types.mli lib/server/server_bootstrap_maintenance.ml test/test_keeper_memory_os.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_memory_os_types.ml lib/server/server_bootstrap_maintenance.ml test/test_keeper_memory_os.ml`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_memory_os_types.mli`
- `git diff --check`
- targeted `rg` confirmed the `TODO(#22447)` proxy markers, renamed test label, and updated RFC/maintenance references.
