### PR TITLE
fix(keeper): pin turn event bus subscription

### DIFF
--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -30,6 +30,7 @@ type drain_cancel_state =
 type t =
   { keeper_name : string
   ; turn_id : int
+  ; event_bus : Agent_sdk.Event_bus.t option
   ; event_bus_sub : Agent_sdk_metrics_bridge.handle option
   ; drain_cancel : drain_cancel_state Atomic.t
   ; state : event_bus_state Atomic.t
@@ -37,8 +38,9 @@ type t =
   }
 
 let create ?(on_pending_count_change = fun _ -> ()) ~keeper_name ~turn_id () =
+  let event_bus = Keeper_event_bus.get () in
   let event_bus_sub =
-    match Keeper_event_bus.get () with
+    match event_bus with
     | Some bus ->
       Some
         (Agent_sdk_metrics_bridge.subscribe
@@ -49,6 +51,7 @@ let create ?(on_pending_count_change = fun _ -> ()) ~keeper_name ~turn_id () =
   in
   { keeper_name
   ; turn_id
+  ; event_bus
   ; event_bus_sub
   ; drain_cancel = Atomic.make Inactive
   ; state =
@@ -132,9 +135,9 @@ let emit_fsm_transition ~keeper_name ~turn_id ~pending_count transition =
 
 let drain ?(site = "unspecified") t =
   let events =
-    match t.event_bus_sub, Keeper_event_bus.get () with
-    | Some sub, Some _bus -> Agent_sdk_metrics_bridge.drain sub
-    | _ -> []
+    match t.event_bus_sub with
+    | Some sub -> Agent_sdk_metrics_bridge.drain sub
+    | None -> []
   in
   let outcome = if events = [] then "empty" else "drained" in
   Otel_metric_store.inc_counter
@@ -265,7 +268,7 @@ let unsubscribe t =
          t.keeper_name
          msg));
   ignore (drain ~site:"unsubscribe_final" t);
-  match t.event_bus_sub, Keeper_event_bus.get () with
+  match t.event_bus_sub, t.event_bus with
   | Some sub, Some bus -> Agent_sdk_metrics_bridge.unsubscribe bus sub
   | _ -> ()
 ;;

--- a/lib/keeper/keeper_unified_turn_event_bus.ml
+++ b/lib/keeper/keeper_unified_turn_event_bus.ml
@@ -27,32 +27,39 @@ type drain_cancel_state =
   | Active of Eio.Cancel.t
   | Closed
 
+type event_bus_subscription =
+  | No_event_bus
+  | Subscribed of
+      { event_bus : Agent_sdk.Event_bus.t
+      ; event_bus_sub : Agent_sdk_metrics_bridge.handle
+      }
+
 type t =
   { keeper_name : string
   ; turn_id : int
-  ; event_bus : Agent_sdk.Event_bus.t option
-  ; event_bus_sub : Agent_sdk_metrics_bridge.handle option
+  ; event_bus_subscription : event_bus_subscription
   ; drain_cancel : drain_cancel_state Atomic.t
   ; state : event_bus_state Atomic.t
   ; on_pending_count_change : int -> unit
   }
 
 let create ?(on_pending_count_change = fun _ -> ()) ~keeper_name ~turn_id () =
-  let event_bus = Keeper_event_bus.get () in
-  let event_bus_sub =
-    match event_bus with
-    | Some bus ->
-      Some
-        (Agent_sdk_metrics_bridge.subscribe
+  let event_bus_subscription =
+    match Keeper_event_bus.get () with
+    | Some event_bus ->
+      Subscribed
+        { event_bus
+        ; event_bus_sub =
+            Agent_sdk_metrics_bridge.subscribe
            ~purpose:"keeper_turn"
            ~filter:(Agent_sdk.Event_bus.filter_agent keeper_name)
-           bus)
-    | None -> None
+              event_bus
+        }
+    | None -> No_event_bus
   in
   { keeper_name
   ; turn_id
-  ; event_bus
-  ; event_bus_sub
+  ; event_bus_subscription
   ; drain_cancel = Atomic.make Inactive
   ; state =
       Atomic.make
@@ -135,9 +142,9 @@ let emit_fsm_transition ~keeper_name ~turn_id ~pending_count transition =
 
 let drain ?(site = "unspecified") t =
   let events =
-    match t.event_bus_sub with
-    | Some sub -> Agent_sdk_metrics_bridge.drain sub
-    | None -> []
+    match t.event_bus_subscription with
+    | Subscribed { event_bus_sub; _ } -> Agent_sdk_metrics_bridge.drain event_bus_sub
+    | No_event_bus -> []
   in
   let outcome = if events = [] then "empty" else "drained" in
   Otel_metric_store.inc_counter
@@ -200,8 +207,8 @@ let integrity_error t =
 ;;
 
 let start_background_drain ~clock t =
-  match t.event_bus_sub, Eio_context.get_switch_opt () with
-  | Some _, Some sw ->
+  match t.event_bus_subscription, Eio_context.get_switch_opt () with
+  | Subscribed _, Some sw ->
     Eio.Fiber.fork ~sw (fun () ->
       Eio.Cancel.sub (fun cc ->
         match Atomic.compare_and_set t.drain_cancel Inactive (Active cc) with
@@ -268,9 +275,10 @@ let unsubscribe t =
          t.keeper_name
          msg));
   ignore (drain ~site:"unsubscribe_final" t);
-  match t.event_bus_sub, t.event_bus with
-  | Some sub, Some bus -> Agent_sdk_metrics_bridge.unsubscribe bus sub
-  | _ -> ()
+  match t.event_bus_subscription with
+  | Subscribed { event_bus; event_bus_sub } ->
+    Agent_sdk_metrics_bridge.unsubscribe event_bus event_bus_sub
+  | No_event_bus -> ()
 ;;
 
 module For_testing = struct

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -166,6 +166,42 @@ let test_keeper_event_bus_is_intentionally_process_wide () =
     (Domain.join worker)
 ;;
 
+let test_turn_event_bus_uses_creation_bus_after_fallback_changes () =
+  Eio_main.run @@ fun _env ->
+  let captured_bus = Agent_sdk.Event_bus.create () in
+  let later_bus = Agent_sdk.Event_bus.create () in
+  Keeper_event_bus.set captured_bus;
+  let t = EB.create ~keeper_name:"a" ~turn_id:1 () in
+  let unsubscribed = ref false in
+  let unsubscribe_once () =
+    if not !unsubscribed
+    then (
+      unsubscribed := true;
+      EB.unsubscribe t)
+  in
+  Fun.protect
+    ~finally:(fun () ->
+      unsubscribe_once ();
+      Keeper_event_bus.set captured_bus)
+    (fun () ->
+       Keeper_event_bus.set later_bus;
+       Agent_sdk.Event_bus.publish captured_bus (tool_called "captured");
+       Agent_sdk.Event_bus.publish later_bus (tool_called "later");
+       let summary = EB.drain ~site:"test_creation_bus" t in
+       check int "captured bus only" 1 summary.event_count;
+       check
+         int
+         "pending count from captured bus"
+         1
+         (EB.For_testing.get_state t).pending_tool_count;
+       unsubscribe_once ();
+       Agent_sdk.Event_bus.publish captured_bus (tool_called "after-unsubscribe");
+       let summary_after_unsubscribe =
+         EB.drain ~site:"test_after_unsubscribe" t
+       in
+       check int "captured subscription removed" 1 summary_after_unsubscribe.event_count)
+;;
+
 let temp_dir prefix =
   let path = Filename.temp_file prefix "" in
   Sys.remove path;
@@ -302,6 +338,8 @@ let () =
             test_state_pending_count_integrity_under_concurrent_updates
         ; test_case "event bus is intentionally process-wide" `Quick
             test_keeper_event_bus_is_intentionally_process_wide
+        ; test_case "turn event bus keeps creation bus" `Quick
+            test_turn_event_bus_uses_creation_bus_after_fallback_changes
         ; test_case "keeper msg async submit uses captured event bus" `Quick
             test_keeper_msg_async_submit_uses_captured_event_bus
         ] )

--- a/test/test_keeper_unified_turn_event_bus.ml
+++ b/test/test_keeper_unified_turn_event_bus.ml
@@ -199,7 +199,7 @@ let test_turn_event_bus_uses_creation_bus_after_fallback_changes () =
        let summary_after_unsubscribe =
          EB.drain ~site:"test_after_unsubscribe" t
        in
-       check int "captured subscription removed" 1 summary_after_unsubscribe.event_count)
+       check int "captured subscription removed" 0 summary_after_unsubscribe.event_count)
 ;;
 
 let temp_dir prefix =


### PR DESCRIPTION
## Summary
- capture the Keeper event bus once when a turn event-bus state is created
- stop `drain` and `unsubscribe` from re-reading the process-wide fallback bus
- add a regression test for fallback bus drift and captured-subscription cleanup

## Validation
- `ocamlformat --check lib/keeper/keeper_unified_turn_event_bus.ml test/test_keeper_unified_turn_event_bus.ml`
- `git diff --check`
- local Dune build intentionally not run; CI is the requested build authority for this hardening queue
