### PR TITLE
fix(memory): surface recall quality dashboard

### DIFF
--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -553,10 +553,18 @@ let normalize_claim_id raw =
    author here (RFC-0259 §3.7 and RFC-0247 §3 reject deriving it in code). This is
    the single dedup SSOT: the write upsert, recall dedup, GC dedup, and Tier-2
    consolidation MUST all key on this one function. *)
+let claim_identity_of_claim_text claim = "claim:" ^ normalize_claim claim
+
 let claim_identity (f : fact) =
   match Option.bind f.claim_id normalize_claim_id with
   | Some id -> "id:" ^ id
-  | None -> "claim:" ^ normalize_claim f.claim
+  | None -> claim_identity_of_claim_text f.claim
+;;
+
+let legacy_unstructured_fallback_claim_key key =
+  String.starts_with
+    ~prefix:(claim_identity_of_claim_text librarian_unstructured_fallback_claim_prefix)
+    key
 ;;
 
 let optional_float_field key = function

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -237,6 +237,12 @@ val librarian_unstructured_fallback_claim_prefix : string
     after strict JSON parsing fails. *)
 val librarian_unstructured_fallback_terminal_marker : string
 
+val legacy_unstructured_fallback_claim_key : string -> bool
+(** Whether a persisted pre-[Diagnostic] recall key identifies a legacy
+    librarian parse-failure fallback fact. This centralizes the historical
+    [claim_identity] fallback-key shape so read-only compatibility surfaces do
+    not reconstruct ["claim:"] keys themselves. *)
+
 (** Structural prompt-recall eligibility. Callers still apply {!fact_is_current}
     for the time horizon; [Diagnostic] rows stay operator evidence, not prompt
     context. Legacy pre-[Diagnostic] librarian fallback rows are also excluded by

--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -14,6 +14,9 @@ let field_injected_episode_keys = "injected_episode_keys"
 let field_n_facts_in_store = "n_facts_in_store"
 let field_ts = "ts"
 let field_failure_reason = "failure_reason"
+let failure_reason_read_error = "read_error"
+let failure_reason_prompt_render_error = "prompt_render_error"
+let failure_reason_unknown_label = "unknown_failure_reason"
 
 type record =
   { keeper_id : string
@@ -22,35 +25,67 @@ type record =
   ; failure_reason : string option
   }
 
-let json_string_field fields key =
+type decode_error =
+  [ `Expected_object
+  | `Missing_field of string
+  | `Invalid_field of string
+  ]
+
+let json_required_string_field fields key =
   match List.assoc_opt key fields with
-  | Some (`String value) -> Some value
-  | _ -> None
+  | Some (`String value) -> Ok value
+  | Some _ -> Error (`Invalid_field key)
+  | None -> Error (`Missing_field key)
 ;;
 
-let json_string_list_field fields key =
+let json_required_string_list_field fields key =
   match List.assoc_opt key fields with
   | Some (`List items) ->
-    List.filter_map
-      (function
-        | `String value -> Some value
-        | _ -> None)
-      items
-  | _ -> []
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | `String value :: rest -> loop (value :: acc) rest
+      | _ :: _ -> Error (`Invalid_field key)
+    in
+    loop [] items
+  | Some _ -> Error (`Invalid_field key)
+  | None -> Error (`Missing_field key)
 ;;
 
-let record_of_json = function
+let json_optional_string_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> Ok (Some value)
+  | Some _ -> Error (`Invalid_field key)
+  | None -> Ok None
+;;
+
+let record_of_json_result = function
   | `Assoc fields ->
-    (match json_string_field fields field_keeper_id with
-     | None -> None
-     | Some keeper_id ->
-       Some
-         { keeper_id
-         ; injected_fact_keys = json_string_list_field fields field_injected_fact_keys
-         ; injected_episode_keys = json_string_list_field fields field_injected_episode_keys
-         ; failure_reason = json_string_field fields field_failure_reason
-         })
-  | _ -> None
+    (match
+       ( json_required_string_field fields field_keeper_id
+       , json_required_string_list_field fields field_injected_fact_keys
+       , json_required_string_list_field fields field_injected_episode_keys
+       , json_optional_string_field fields field_failure_reason )
+     with
+     | Ok keeper_id, Ok injected_fact_keys, Ok injected_episode_keys, Ok failure_reason ->
+       Ok { keeper_id; injected_fact_keys; injected_episode_keys; failure_reason }
+     | Error err, _, _, _
+     | _, Error err, _, _
+     | _, _, Error err, _
+     | _, _, _, Error err -> Error err)
+  | _ -> Error `Expected_object
+;;
+
+let record_of_json json =
+  match record_of_json_result json with
+  | Ok record -> Some record
+  | Error _ -> None
+;;
+
+let bounded_failure_reason_label = function
+  | reason
+    when String.equal reason failure_reason_read_error
+         || String.equal reason failure_reason_prompt_render_error -> reason
+  | _ -> failure_reason_unknown_label
 ;;
 
 let to_json
@@ -107,7 +142,10 @@ let prune_failure_label = function
   | _ -> `Unexpected_exception
 ;;
 
-let error_label_of_exn exn = exn |> prune_failure_label |> string_of_prune_error
+let error_label_of_exn exn =
+  exn
+  |> Keeper_memory_recall_exn_class.classify
+  |> Keeper_memory_recall_exn_class.to_label
 ;;
 
 let append

--- a/lib/keeper/keeper_recall_injection_ledger.ml
+++ b/lib/keeper/keeper_recall_injection_ledger.ml
@@ -6,6 +6,53 @@
 
 let base_dir ~masc_root = Filename.concat masc_root "recall_injections"
 
+let field_keeper_id = "keeper_id"
+let field_trace_id = "trace_id"
+let field_turn = "turn"
+let field_injected_fact_keys = "injected_fact_keys"
+let field_injected_episode_keys = "injected_episode_keys"
+let field_n_facts_in_store = "n_facts_in_store"
+let field_ts = "ts"
+let field_failure_reason = "failure_reason"
+
+type record =
+  { keeper_id : string
+  ; injected_fact_keys : string list
+  ; injected_episode_keys : string list
+  ; failure_reason : string option
+  }
+
+let json_string_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> Some value
+  | _ -> None
+;;
+
+let json_string_list_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`List items) ->
+    List.filter_map
+      (function
+        | `String value -> Some value
+        | _ -> None)
+      items
+  | _ -> []
+;;
+
+let record_of_json = function
+  | `Assoc fields ->
+    (match json_string_field fields field_keeper_id with
+     | None -> None
+     | Some keeper_id ->
+       Some
+         { keeper_id
+         ; injected_fact_keys = json_string_list_field fields field_injected_fact_keys
+         ; injected_episode_keys = json_string_list_field fields field_injected_episode_keys
+         ; failure_reason = json_string_field fields field_failure_reason
+         })
+  | _ -> None
+;;
+
 let to_json
       ?failure_reason
       ~keeper_id
@@ -19,19 +66,20 @@ let to_json
   : Yojson.Safe.t
   =
   let fields =
-    [ "keeper_id", `String keeper_id
-    ; "trace_id", `String trace_id
-    ; "turn", `Int turn
-    ; "injected_fact_keys", `List (List.map (fun k -> `String k) injected_fact_keys)
-    ; "injected_episode_keys", `List (List.map (fun k -> `String k) injected_episode_keys)
-    ; "n_facts_in_store", `Int n_facts_in_store
-    ; "ts", `Float now
+    [ field_keeper_id, `String keeper_id
+    ; field_trace_id, `String trace_id
+    ; field_turn, `Int turn
+    ; field_injected_fact_keys, `List (List.map (fun k -> `String k) injected_fact_keys)
+    ; ( field_injected_episode_keys
+      , `List (List.map (fun k -> `String k) injected_episode_keys) )
+    ; field_n_facts_in_store, `Int n_facts_in_store
+    ; field_ts, `Float now
     ]
   in
   let fields =
     match failure_reason with
     | None -> fields
-    | Some reason -> fields @ [ "failure_reason", `String reason ]
+    | Some reason -> fields @ [ field_failure_reason, `String reason ]
   in
   `Assoc fields
 ;;
@@ -41,19 +89,25 @@ let make_store ~masc_root () = Dated_jsonl.create ~base_dir:(base_dir ~masc_root
 type prune_error =
   [ `Sys_error
   | `Unix_error
+  | `Json_error
   | `Unexpected_exception
   ]
 
 let string_of_prune_error = function
   | `Sys_error -> "sys_error"
   | `Unix_error -> "unix_error"
+  | `Json_error -> "json_error"
   | `Unexpected_exception -> "unexpected_exception"
 ;;
 
 let prune_failure_label = function
   | Sys_error _ -> `Sys_error
   | Unix.Unix_error _ -> `Unix_error
+  | Yojson.Json_error _ -> `Json_error
   | _ -> `Unexpected_exception
+;;
+
+let error_label_of_exn exn = exn |> prune_failure_label |> string_of_prune_error
 ;;
 
 let append

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -35,7 +35,24 @@ type record =
     surfaces. Field ownership stays here so consumers do not duplicate ledger
     JSON field names. *)
 
+type decode_error =
+  [ `Expected_object
+  | `Missing_field of string
+  | `Invalid_field of string
+  ]
+(** Bounded decode failure for read-only consumers that must surface schema
+    drift instead of silently dropping malformed rows. *)
+
+val record_of_json_result : Yojson.Safe.t -> (record, decode_error) result
 val record_of_json : Yojson.Safe.t -> record option
+(** Compatibility wrapper over {!record_of_json_result}. New read paths that need
+    observability should use the result-returning decoder. *)
+
+val failure_reason_unknown_label : string
+val bounded_failure_reason_label : string -> string
+(** Collapse recall failure labels to the bounded producer set. Unknown producer
+    strings are grouped as {!failure_reason_unknown_label} to avoid high-cardinality
+    dashboard output. *)
 
 val to_json
   :  ?failure_reason:string
@@ -77,8 +94,7 @@ type prune_error =
 
 val string_of_prune_error : prune_error -> string
 val error_label_of_exn : exn -> string
-(** Bounded error label shared by recall-ledger maintenance and read-only
-    dashboard consumers. *)
+(** Bounded read-side error label for read-only dashboard consumers. *)
 
 val prune_older_than
   :  masc_root:string

--- a/lib/keeper/keeper_recall_injection_ledger.mli
+++ b/lib/keeper/keeper_recall_injection_ledger.mli
@@ -25,6 +25,18 @@
 val base_dir : masc_root:string -> string
 (** Directory that stores recall injection JSONL day files. *)
 
+type record =
+  { keeper_id : string
+  ; injected_fact_keys : string list
+  ; injected_episode_keys : string list
+  ; failure_reason : string option
+  }
+(** Typed subset of the append schema consumed by read-only dashboard/eval
+    surfaces. Field ownership stays here so consumers do not duplicate ledger
+    JSON field names. *)
+
+val record_of_json : Yojson.Safe.t -> record option
+
 val to_json
   :  ?failure_reason:string
   -> keeper_id:string
@@ -58,11 +70,15 @@ val append
 type prune_error =
   [ `Sys_error
   | `Unix_error
+  | `Json_error
   | `Unexpected_exception
   ]
 (** Bounded failure label for recall-ledger prune setup failures. *)
 
 val string_of_prune_error : prune_error -> string
+val error_label_of_exn : exn -> string
+(** Bounded error label shared by recall-ledger maintenance and read-only
+    dashboard consumers. *)
 
 val prune_older_than
   :  masc_root:string

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -413,7 +413,11 @@ let recall_quality_summary_json ~sample_limit ~top_key_limit summary =
     ]
 ;;
 
-let compute_memory_quality_dashboard_json ~config ~sample_limit ~top_key_limit =
+let compute_memory_quality_dashboard_json
+      ~(config : Workspace_utils.config)
+      ~sample_limit
+      ~top_key_limit
+  =
   match load_recall_quality_records ~config ~sample_limit with
   | Ok rows ->
     rows
@@ -424,7 +428,11 @@ let compute_memory_quality_dashboard_json ~config ~sample_limit ~top_key_limit =
     |> recall_quality_summary_json ~sample_limit ~top_key_limit
 ;;
 
-let memory_quality_dashboard_json ~config ~sample_limit ~top_key_limit =
+let memory_quality_dashboard_json
+      ~(config : Workspace_utils.config)
+      ~sample_limit
+      ~top_key_limit
+  =
   (* NDT-OK: wall-clock read only gates the dashboard quality cache TTL. *)
   let now = Unix.gettimeofday () in
   let cache_matches = function

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -210,48 +210,6 @@ let compute_hebbian ~base_path ~now () =
 let memory_quality_recent_limit = 500
 let memory_quality_top_key_limit = 10
 
-type recall_quality_record =
-  { injected_fact_keys : string list
-  ; injected_episode_keys : string list
-  ; failure_reason : string option
-  }
-
-let json_string_field fields key =
-  match List.assoc_opt key fields with
-  | Some (`String value) -> Some value
-  | _ -> None
-;;
-
-let json_string_list_field fields key =
-  match List.assoc_opt key fields with
-  | Some (`List items) ->
-    List.filter_map (function
-      | `String value -> Some value
-      | _ -> None)
-      items
-  | _ -> []
-;;
-
-let recall_quality_record_of_json = function
-  | `Assoc fields ->
-    (match json_string_field fields "keeper_id" with
-     | None -> None
-     | Some _keeper_id ->
-       Some
-         { injected_fact_keys = json_string_list_field fields "injected_fact_keys"
-         ; injected_episode_keys = json_string_list_field fields "injected_episode_keys"
-         ; failure_reason = json_string_field fields "failure_reason"
-         })
-  | _ -> None
-;;
-
-let memory_quality_error_label = function
-  | Sys_error _ -> "sys_error"
-  | Unix.Unix_error _ -> "unix_error"
-  | Yojson.Json_error _ -> "json_error"
-  | _ -> "unexpected_exception"
-;;
-
 let load_recall_quality_records ~(config : Workspace_utils.config) =
   try
     let masc_root = Workspace_utils.masc_dir config in
@@ -262,10 +220,10 @@ let load_recall_quality_records ~(config : Workspace_utils.config) =
     in
     Ok
       (Dated_jsonl.read_recent store memory_quality_recent_limit
-       |> List.filter_map recall_quality_record_of_json)
+       |> List.filter_map Keeper_recall_injection_ledger.record_of_json)
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
-  | exn -> Error (memory_quality_error_label exn)
+  | exn -> Error (Keeper_recall_injection_ledger.error_label_of_exn exn)
 ;;
 
 let increment_count tbl key =
@@ -291,21 +249,7 @@ let count_rows_by ?(limit = max_int) pairs =
     `Assoc [ "key", `String key; "count", `Int count ])
 ;;
 
-let legacy_unstructured_fallback_key_prefix =
-  "claim:"
-  ^ Keeper_memory_os_types.normalize_claim
-      Keeper_memory_os_types.librarian_unstructured_fallback_claim_prefix
-;;
-
-(* Dashboard-only compatibility metric for legacy pre-[Diagnostic] fallback
-   rows. Prompt recall and retention decisions use typed fact fields upstream;
-   this counts old injected fact keys after they have already reached the
-   read-only recall ledger. *)
-let is_legacy_unstructured_fallback_key key =
-  String.starts_with ~prefix:legacy_unstructured_fallback_key_prefix key
-;;
-
-let recall_quality_json records =
+let recall_quality_json (records : Keeper_recall_injection_ledger.record list) =
   let fact_counts = Hashtbl.create 256 in
   let failure_counts = Hashtbl.create 16 in
   let total_fact_injections = ref 0 in
@@ -316,7 +260,7 @@ let recall_quality_json records =
        List.iter
          (fun key ->
             incr total_fact_injections;
-            if is_legacy_unstructured_fallback_key key
+            if Keeper_memory_os_types.legacy_unstructured_fallback_claim_key key
             then incr diagnostic_fallback_key_injections;
             increment_count fact_counts key)
          record.injected_fact_keys)

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -2,6 +2,8 @@
 
 open Server_utils
 
+module StringMap = Map.Make (String)
+
 let memory_subsystems_entry_cache_ttl_sec = 30.0
 
 (* RFC-0149 §3.1: cache holds typed errors alongside successful rows so the
@@ -22,6 +24,22 @@ let memory_subsystems_entry_cache
     itself is an [Atomic.t] so readers can check the TTL without contending for
     the lock; only a miss contends and one fiber performs the expensive IO. *)
 let memory_subsystems_entry_cache_mu = Eio.Mutex.create ()
+;;
+
+let memory_quality_default_recent_limit = 500
+let memory_quality_max_recent_limit = 2_000
+let memory_quality_default_top_key_limit = 10
+let memory_quality_max_top_key_limit = 100
+let memory_quality_schema = "masc.memory_quality.recall_ledger.v1"
+let memory_quality_source = "recall_injections"
+
+let memory_quality_cache
+  : (string * int * int * float * Yojson.Safe.t) option Atomic.t
+  =
+  Atomic.make None
+;;
+
+let memory_quality_cache_mu = Eio.Mutex.create ()
 ;;
 
 let dashboard_memory_subsystems_include_entries request =
@@ -207,10 +225,28 @@ let compute_hebbian ~base_path ~now () =
     `Assoc [ "synapses", `List []; "last_consolidation", `Float 0.0 ]
 ;;
 
-let memory_quality_recent_limit = 500
-let memory_quality_top_key_limit = 10
+let dashboard_memory_quality_recent_limit request =
+  int_query_param
+    request
+    "memory_quality_limit"
+    ~default:memory_quality_default_recent_limit
+  |> clamp ~min_v:1 ~max_v:memory_quality_max_recent_limit
+;;
 
-let load_recall_quality_records ~(config : Workspace_utils.config) =
+let dashboard_memory_quality_top_key_limit request =
+  int_query_param
+    request
+    "memory_quality_top_key_limit"
+    ~default:memory_quality_default_top_key_limit
+  |> clamp ~min_v:1 ~max_v:memory_quality_max_top_key_limit
+;;
+
+type memory_quality_rows =
+  { records : Keeper_recall_injection_ledger.record list
+  ; decode_error_records : int
+  }
+
+let load_recall_quality_records ~(config : Workspace_utils.config) ~sample_limit =
   try
     let masc_root = Workspace_utils.masc_dir config in
     let store =
@@ -218,25 +254,35 @@ let load_recall_quality_records ~(config : Workspace_utils.config) =
         ~base_dir:(Keeper_recall_injection_ledger.base_dir ~masc_root)
         ()
     in
-    Ok
-      (Dated_jsonl.read_recent store memory_quality_recent_limit
-       |> List.filter_map Keeper_recall_injection_ledger.record_of_json)
+    let records, decode_error_records =
+      Dated_jsonl.read_recent_lines store sample_limit
+      |> List.fold_left
+           (fun (records_acc, decode_errors) line ->
+              match Yojson.Safe.from_string line with
+              | exception Yojson.Json_error _ -> records_acc, decode_errors + 1
+              | json ->
+                (match Keeper_recall_injection_ledger.record_of_json_result json with
+                 | Ok record -> record :: records_acc, decode_errors
+                 | Error _ -> records_acc, decode_errors + 1))
+           ([], 0)
+    in
+    Ok { records = List.rev records; decode_error_records }
   with
   | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn -> Error (Keeper_recall_injection_ledger.error_label_of_exn exn)
 ;;
 
-let increment_count tbl key =
+let increment_count key counts =
   let next =
-    match Hashtbl.find_opt tbl key with
+    match StringMap.find_opt key counts with
     | Some count -> count + 1
     | None -> 1
   in
-  Hashtbl.replace tbl key next
+  StringMap.add key next counts
 ;;
 
-let sorted_counts tbl =
-  Hashtbl.fold (fun key count acc -> (key, count) :: acc) tbl []
+let sorted_counts counts =
+  StringMap.bindings counts
   |> List.sort (fun (key_a, count_a) (key_b, count_b) ->
     let count_order = compare count_b count_a in
     if count_order <> 0 then count_order else String.compare key_a key_b)
@@ -249,23 +295,79 @@ let count_rows_by ?(limit = max_int) pairs =
     `Assoc [ "key", `String key; "count", `Int count ])
 ;;
 
-let recall_quality_json (records : Keeper_recall_injection_ledger.record list) =
-  let fact_counts = Hashtbl.create 256 in
-  let failure_counts = Hashtbl.create 16 in
-  let total_fact_injections = ref 0 in
-  let diagnostic_fallback_key_injections = ref 0 in
-  List.iter
-    (fun record ->
-       Option.iter (increment_count failure_counts) record.failure_reason;
-       List.iter
-         (fun key ->
-            incr total_fact_injections;
-            if Keeper_memory_os_types.legacy_unstructured_fallback_claim_key key
-            then incr diagnostic_fallback_key_injections;
-            increment_count fact_counts key)
-         record.injected_fact_keys)
-    records;
-  let fact_count_rows = sorted_counts fact_counts in
+type recall_quality_summary =
+  { sampled_records : int
+  ; records_with_recall : int
+  ; failure_records : int
+  ; decode_error_records : int
+  ; fact_counts : int StringMap.t
+  ; failure_counts : int StringMap.t
+  ; total_fact_injections : int
+  ; diagnostic_fallback_key_injections : int
+  ; error : string option
+  }
+
+let empty_recall_quality_summary ~decode_error_records ~error =
+  { sampled_records = 0
+  ; records_with_recall = 0
+  ; failure_records = 0
+  ; decode_error_records
+  ; fact_counts = StringMap.empty
+  ; failure_counts = StringMap.empty
+  ; total_fact_injections = 0
+  ; diagnostic_fallback_key_injections = 0
+  ; error
+  }
+;;
+
+let summarize_recall_quality ({ records; decode_error_records } : memory_quality_rows) =
+  let initial = empty_recall_quality_summary ~decode_error_records ~error:None in
+  List.fold_left
+    (fun summary (record : Keeper_recall_injection_ledger.record) ->
+       let failure_counts =
+         match record.failure_reason with
+         | None -> summary.failure_counts
+         | Some reason ->
+           let reason =
+             Keeper_recall_injection_ledger.bounded_failure_reason_label reason
+           in
+           increment_count reason summary.failure_counts
+       in
+       let has_recall =
+         record.injected_fact_keys <> [] || record.injected_episode_keys <> []
+       in
+       let fact_counts, total_fact_injections, diagnostic_fallback_key_injections =
+         List.fold_left
+           (fun (counts, total, diagnostic_total) key ->
+              let diagnostic_total =
+                if Keeper_memory_os_types.legacy_unstructured_fallback_claim_key key
+                then diagnostic_total + 1
+                else diagnostic_total
+              in
+              increment_count key counts, total + 1, diagnostic_total)
+           ( summary.fact_counts
+           , summary.total_fact_injections
+           , summary.diagnostic_fallback_key_injections )
+           record.injected_fact_keys
+       in
+       { summary with
+         sampled_records = summary.sampled_records + 1
+       ; records_with_recall =
+           summary.records_with_recall + (if has_recall then 1 else 0)
+       ; failure_records =
+           summary.failure_records
+           + (if Option.is_some record.failure_reason then 1 else 0)
+       ; failure_counts
+       ; fact_counts
+       ; total_fact_injections
+       ; diagnostic_fallback_key_injections
+       })
+    initial
+    records
+;;
+
+let recall_quality_summary_json ~sample_limit ~top_key_limit summary =
+  let fact_count_rows = sorted_counts summary.fact_counts in
   let echoed_fact_keys =
     List.fold_left
       (fun acc (_key, count) -> if count > 1 then acc + 1 else acc)
@@ -277,42 +379,29 @@ let recall_quality_json (records : Keeper_recall_injection_ledger.record list) =
     | (_key, count) :: _ -> count
     | [] -> 0
   in
-  let records_with_recall =
-    List.fold_left
-      (fun acc record ->
-         if record.injected_fact_keys <> [] || record.injected_episode_keys <> []
-         then acc + 1
-         else acc)
-      0
-      records
-  in
-  let failure_records =
-    List.fold_left
-      (fun acc record -> if Option.is_some record.failure_reason then acc + 1 else acc)
-      0
-      records
-  in
   `Assoc
-    [ "schema", `String "masc.memory_quality.recall_ledger.v1"
-    ; "source", `String "recall_injections"
-    ; "sample_limit", `Int memory_quality_recent_limit
-    ; "sampled_records", `Int (List.length records)
-    ; "records_with_recall", `Int records_with_recall
-    ; "empty_recall_records", `Int (List.length records - records_with_recall)
-    ; "failure_records", `Int failure_records
-    ; "failure_reasons", `List (count_rows_by (sorted_counts failure_counts))
+    [ "schema", `String memory_quality_schema
+    ; "source", `String memory_quality_source
+    ; "sample_limit", `Int sample_limit
+    ; "sampled_records", `Int summary.sampled_records
+    ; "records_with_recall", `Int summary.records_with_recall
+    ; ( "empty_recall_records"
+      , `Int (summary.sampled_records - summary.records_with_recall) )
+    ; "failure_records", `Int summary.failure_records
+    ; "decode_error_records", `Int summary.decode_error_records
+    ; "failure_reasons", `List (count_rows_by (sorted_counts summary.failure_counts))
     ; ( "fact_injections"
       , `Assoc
-          [ "total", `Int !total_fact_injections
+          [ "total", `Int summary.total_fact_injections
           ; "unique_fact_keys", `Int (List.length fact_count_rows)
           ; "echoed_fact_keys", `Int echoed_fact_keys
           ; "max_fact_echo_count", `Int max_fact_echo_count
           ; ( "diagnostic_fallback_key_injections"
-            , `Int !diagnostic_fallback_key_injections )
+            , `Int summary.diagnostic_fallback_key_injections )
           ; ( "top_echoed_fact_keys"
             , `List
                 (count_rows_by
-                   ~limit:memory_quality_top_key_limit
+                   ~limit:top_key_limit
                    (List.filter (fun (_key, count) -> count > 1) fact_count_rows))
             )
           ] )
@@ -320,38 +409,48 @@ let recall_quality_json (records : Keeper_recall_injection_ledger.record list) =
     ; "useful_recalls", `Null
     ; "stale_recalls", `Null
     ; "loop_reductions", `Null
-    ; "error", `Null
+    ; "error", (match summary.error with Some label -> `String label | None -> `Null)
     ]
 ;;
 
-let memory_quality_dashboard_json ~(config : Workspace_utils.config) =
-  match load_recall_quality_records ~config with
-  | Ok records -> recall_quality_json records
+let compute_memory_quality_dashboard_json ~config ~sample_limit ~top_key_limit =
+  match load_recall_quality_records ~config ~sample_limit with
+  | Ok rows ->
+    rows
+    |> summarize_recall_quality
+    |> recall_quality_summary_json ~sample_limit ~top_key_limit
   | Error label ->
-    `Assoc
-      [ "schema", `String "masc.memory_quality.recall_ledger.v1"
-      ; "source", `String "recall_injections"
-      ; "sample_limit", `Int memory_quality_recent_limit
-      ; "sampled_records", `Int 0
-      ; "records_with_recall", `Int 0
-      ; "empty_recall_records", `Int 0
-      ; "failure_records", `Int 0
-      ; "failure_reasons", `List []
-      ; ( "fact_injections"
-        , `Assoc
-            [ "total", `Int 0
-            ; "unique_fact_keys", `Int 0
-            ; "echoed_fact_keys", `Int 0
-            ; "max_fact_echo_count", `Int 0
-            ; "diagnostic_fallback_key_injections", `Int 0
-            ; "top_echoed_fact_keys", `List []
-            ] )
-      ; "outcome_joined", `Bool false
-      ; "useful_recalls", `Null
-      ; "stale_recalls", `Null
-      ; "loop_reductions", `Null
-      ; "error", `String label
-      ]
+    empty_recall_quality_summary ~decode_error_records:0 ~error:(Some label)
+    |> recall_quality_summary_json ~sample_limit ~top_key_limit
+;;
+
+let memory_quality_dashboard_json ~config ~sample_limit ~top_key_limit =
+  (* NDT-OK: wall-clock read only gates the dashboard quality cache TTL. *)
+  let now = Unix.gettimeofday () in
+  let cache_matches = function
+    | Some (base_path, cached_sample_limit, cached_top_key_limit, cached_at, _json) ->
+      String.equal base_path config.base_path
+      && cached_sample_limit = sample_limit
+      && cached_top_key_limit = top_key_limit
+      && now -. cached_at < memory_subsystems_entry_cache_ttl_sec
+    | None -> false
+  in
+  match Atomic.get memory_quality_cache with
+  | Some (_base_path, _sample_limit, _top_key_limit, _cached_at, json) as cached
+    when cache_matches cached -> json
+  | _ ->
+    Eio.Mutex.use_rw ~protect:true memory_quality_cache_mu
+    @@ fun () ->
+    (match Atomic.get memory_quality_cache with
+     | Some (_base_path, _sample_limit, _top_key_limit, _cached_at, json) as cached
+       when cache_matches cached -> json
+     | _ ->
+       let json =
+         compute_memory_quality_dashboard_json ~config ~sample_limit ~top_key_limit
+       in
+       Atomic.set memory_quality_cache
+         (Some (config.base_path, sample_limit, top_key_limit, now, json));
+       json)
 ;;
 
 let dashboard_memory_subsystems_http_json
@@ -366,6 +465,8 @@ let dashboard_memory_subsystems_http_json
       ~default:(dashboard_memory_subsystems_include_entries request)
   in
   let limit = int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:500 in
+  let memory_quality_limit = dashboard_memory_quality_recent_limit request in
+  let memory_quality_top_key_limit = dashboard_memory_quality_top_key_limit request in
   let keeper_filter =
     query_param request "keeper"
     |> Option.map String.trim
@@ -602,7 +703,11 @@ let dashboard_memory_subsystems_http_json
   `Assoc
     [ "generated_at", `String (Masc_domain.now_iso ())
     ; "hebbian", hebbian
-    ; "memory_quality", memory_quality_dashboard_json ~config
+    ; ( "memory_quality"
+      , memory_quality_dashboard_json
+          ~config
+          ~sample_limit:memory_quality_limit
+          ~top_key_limit:memory_quality_top_key_limit )
     ; ( "episodes"
       , `Assoc
           [ "total", `Int total

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -207,6 +207,209 @@ let compute_hebbian ~base_path ~now () =
     `Assoc [ "synapses", `List []; "last_consolidation", `Float 0.0 ]
 ;;
 
+let memory_quality_recent_limit = 500
+let memory_quality_top_key_limit = 10
+
+type recall_quality_record =
+  { injected_fact_keys : string list
+  ; injected_episode_keys : string list
+  ; failure_reason : string option
+  }
+
+let json_string_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`String value) -> Some value
+  | _ -> None
+;;
+
+let json_string_list_field fields key =
+  match List.assoc_opt key fields with
+  | Some (`List items) ->
+    List.filter_map (function
+      | `String value -> Some value
+      | _ -> None)
+      items
+  | _ -> []
+;;
+
+let recall_quality_record_of_json = function
+  | `Assoc fields ->
+    (match json_string_field fields "keeper_id" with
+     | None -> None
+     | Some _keeper_id ->
+       Some
+         { injected_fact_keys = json_string_list_field fields "injected_fact_keys"
+         ; injected_episode_keys = json_string_list_field fields "injected_episode_keys"
+         ; failure_reason = json_string_field fields "failure_reason"
+         })
+  | _ -> None
+;;
+
+let memory_quality_error_label = function
+  | Sys_error _ -> "sys_error"
+  | Unix.Unix_error _ -> "unix_error"
+  | Yojson.Json_error _ -> "json_error"
+  | _ -> "unexpected_exception"
+;;
+
+let load_recall_quality_records ~(config : Workspace_utils.config) =
+  try
+    let masc_root = Workspace_utils.masc_dir config in
+    let store =
+      Dated_jsonl.create
+        ~base_dir:(Keeper_recall_injection_ledger.base_dir ~masc_root)
+        ()
+    in
+    Ok
+      (Dated_jsonl.read_recent store memory_quality_recent_limit
+       |> List.filter_map recall_quality_record_of_json)
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn -> Error (memory_quality_error_label exn)
+;;
+
+let increment_count tbl key =
+  let next =
+    match Hashtbl.find_opt tbl key with
+    | Some count -> count + 1
+    | None -> 1
+  in
+  Hashtbl.replace tbl key next
+;;
+
+let sorted_counts tbl =
+  Hashtbl.fold (fun key count acc -> (key, count) :: acc) tbl []
+  |> List.sort (fun (key_a, count_a) (key_b, count_b) ->
+    let count_order = compare count_b count_a in
+    if count_order <> 0 then count_order else String.compare key_a key_b)
+;;
+
+let count_rows_by ?(limit = max_int) pairs =
+  pairs
+  |> List.filteri (fun i _ -> i < limit)
+  |> List.map (fun (key, count) ->
+    `Assoc [ "key", `String key; "count", `Int count ])
+;;
+
+let legacy_unstructured_fallback_key_prefix =
+  "claim:"
+  ^ Keeper_memory_os_types.normalize_claim
+      Keeper_memory_os_types.librarian_unstructured_fallback_claim_prefix
+;;
+
+(* Dashboard-only compatibility metric for legacy pre-[Diagnostic] fallback
+   rows. Prompt recall and retention decisions use typed fact fields upstream;
+   this counts old injected fact keys after they have already reached the
+   read-only recall ledger. *)
+let is_legacy_unstructured_fallback_key key =
+  String.starts_with ~prefix:legacy_unstructured_fallback_key_prefix key
+;;
+
+let recall_quality_json records =
+  let fact_counts = Hashtbl.create 256 in
+  let failure_counts = Hashtbl.create 16 in
+  let total_fact_injections = ref 0 in
+  let diagnostic_fallback_key_injections = ref 0 in
+  List.iter
+    (fun record ->
+       Option.iter (increment_count failure_counts) record.failure_reason;
+       List.iter
+         (fun key ->
+            incr total_fact_injections;
+            if is_legacy_unstructured_fallback_key key
+            then incr diagnostic_fallback_key_injections;
+            increment_count fact_counts key)
+         record.injected_fact_keys)
+    records;
+  let fact_count_rows = sorted_counts fact_counts in
+  let echoed_fact_keys =
+    List.fold_left
+      (fun acc (_key, count) -> if count > 1 then acc + 1 else acc)
+      0
+      fact_count_rows
+  in
+  let max_fact_echo_count =
+    match fact_count_rows with
+    | (_key, count) :: _ -> count
+    | [] -> 0
+  in
+  let records_with_recall =
+    List.fold_left
+      (fun acc record ->
+         if record.injected_fact_keys <> [] || record.injected_episode_keys <> []
+         then acc + 1
+         else acc)
+      0
+      records
+  in
+  let failure_records =
+    List.fold_left
+      (fun acc record -> if Option.is_some record.failure_reason then acc + 1 else acc)
+      0
+      records
+  in
+  `Assoc
+    [ "schema", `String "masc.memory_quality.recall_ledger.v1"
+    ; "source", `String "recall_injections"
+    ; "sample_limit", `Int memory_quality_recent_limit
+    ; "sampled_records", `Int (List.length records)
+    ; "records_with_recall", `Int records_with_recall
+    ; "empty_recall_records", `Int (List.length records - records_with_recall)
+    ; "failure_records", `Int failure_records
+    ; "failure_reasons", `List (count_rows_by (sorted_counts failure_counts))
+    ; ( "fact_injections"
+      , `Assoc
+          [ "total", `Int !total_fact_injections
+          ; "unique_fact_keys", `Int (List.length fact_count_rows)
+          ; "echoed_fact_keys", `Int echoed_fact_keys
+          ; "max_fact_echo_count", `Int max_fact_echo_count
+          ; ( "diagnostic_fallback_key_injections"
+            , `Int !diagnostic_fallback_key_injections )
+          ; ( "top_echoed_fact_keys"
+            , `List
+                (count_rows_by
+                   ~limit:memory_quality_top_key_limit
+                   (List.filter (fun (_key, count) -> count > 1) fact_count_rows))
+            )
+          ] )
+    ; "outcome_joined", `Bool false
+    ; "useful_recalls", `Null
+    ; "stale_recalls", `Null
+    ; "loop_reductions", `Null
+    ; "error", `Null
+    ]
+;;
+
+let memory_quality_dashboard_json ~(config : Workspace_utils.config) =
+  match load_recall_quality_records ~config with
+  | Ok records -> recall_quality_json records
+  | Error label ->
+    `Assoc
+      [ "schema", `String "masc.memory_quality.recall_ledger.v1"
+      ; "source", `String "recall_injections"
+      ; "sample_limit", `Int memory_quality_recent_limit
+      ; "sampled_records", `Int 0
+      ; "records_with_recall", `Int 0
+      ; "empty_recall_records", `Int 0
+      ; "failure_records", `Int 0
+      ; "failure_reasons", `List []
+      ; ( "fact_injections"
+        , `Assoc
+            [ "total", `Int 0
+            ; "unique_fact_keys", `Int 0
+            ; "echoed_fact_keys", `Int 0
+            ; "max_fact_echo_count", `Int 0
+            ; "diagnostic_fallback_key_injections", `Int 0
+            ; "top_echoed_fact_keys", `List []
+            ] )
+      ; "outcome_joined", `Bool false
+      ; "useful_recalls", `Null
+      ; "stale_recalls", `Null
+      ; "loop_reductions", `Null
+      ; "error", `String label
+      ]
+;;
+
 let dashboard_memory_subsystems_http_json
       ~(config : Workspace_utils.config)
       ?include_memory_entries
@@ -455,6 +658,7 @@ let dashboard_memory_subsystems_http_json
   `Assoc
     [ "generated_at", `String (Masc_domain.now_iso ())
     ; "hebbian", hebbian
+    ; "memory_quality", memory_quality_dashboard_json ~config
     ; ( "episodes"
       , `Assoc
           [ "total", `Int total

--- a/test/test_keeper_recall_injection_ledger.ml
+++ b/test/test_keeper_recall_injection_ledger.ml
@@ -158,6 +158,35 @@ let () =
   (* Deterministic round-trip: serialise then re-parse is structurally equal. *)
   let round_trip = Yojson.Safe.from_string (Yojson.Safe.to_string j) in
   check "round-trip equal" (Yojson.Safe.equal j round_trip);
+  (match Ledger.record_of_json_result round_trip with
+   | Ok record ->
+     check "typed decoder preserves keeper_id" (record.keeper_id = "alpha");
+     check
+       "typed decoder preserves fact keys"
+       (record.injected_fact_keys = [ "fact one"; "fact two" ])
+   | Error _ -> check "typed decoder accepts own schema" false);
+  (match Ledger.record_of_json_result (`Assoc []) with
+   | Error (`Missing_field "keeper_id") -> check "missing keeper_id is visible" true
+   | _ -> check "missing keeper_id is visible" false);
+  (match
+     Ledger.record_of_json_result
+       (`Assoc
+         [ "keeper_id", `String "alpha"
+         ; "injected_fact_keys", `List [ `Int 1 ]
+         ; "injected_episode_keys", `List []
+         ])
+   with
+   | Error (`Invalid_field "injected_fact_keys") ->
+     check "invalid fact key list is visible" true
+   | _ -> check "invalid fact key list is visible" false);
+  check
+    "known recall failure label stays stable"
+    (Ledger.bounded_failure_reason_label "prompt_render_error"
+     = "prompt_render_error");
+  check
+    "unknown recall failure label is bounded"
+    (Ledger.bounded_failure_reason_label "free-form provider detail"
+     = Ledger.failure_reason_unknown_label);
   test_append_does_not_prune_old_day_file ();
   test_prune_older_than_removes_old_day_file ();
   if !failed > 0

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -5,6 +5,7 @@ module Memory_subsystems = Server_dashboard_http_memory_subsystems
 module Memory_io = Masc.Keeper_memory_os_io
 module P = Masc.Procedural_memory
 module Projection = Masc.Skill_candidate_projection
+module Recall_ledger = Masc.Keeper_recall_injection_ledger
 module Store = Masc.Skill_candidate_store
 module Delegation_request = Masc.Keeper_delegation_request
 module Delegation_store = Masc.Keeper_delegation_request_store
@@ -296,6 +297,123 @@ let shared_fact ?(observed_by = []) ?(last_verified_at = 10.0) claim : Types.fac
   }
 ;;
 
+let append_recall_record
+      ?failure_reason
+      ~(config : Workspace_utils.config)
+      ~keeper_id
+      ~trace_id
+      ~turn
+      ~injected_fact_keys
+      ~injected_episode_keys
+      ~n_facts_in_store
+      ()
+  =
+  let masc_root = Workspace_utils.masc_dir config in
+  let store =
+    Dated_jsonl.create
+      ~base_dir:(Recall_ledger.base_dir ~masc_root)
+      ()
+  in
+  Recall_ledger.to_json
+    ?failure_reason
+    ~keeper_id
+    ~trace_id
+    ~turn
+    ~injected_fact_keys
+    ~injected_episode_keys
+    ~n_facts_in_store
+    ~now:(float_of_int turn)
+    ()
+  |> Dated_jsonl.append store
+;;
+
+let legacy_unstructured_fallback_fact_key () =
+  "claim:"
+  ^ Types.normalize_claim
+      (Types.librarian_unstructured_fallback_claim_prefix ^ " (provider): raw")
+;;
+
+let test_http_json_surfaces_memory_quality_summary () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       let config = Workspace_utils.default_config dir in
+       let fallback_key = legacy_unstructured_fallback_fact_key () in
+       append_recall_record
+         ~config
+         ~keeper_id:"keeper-a"
+         ~trace_id:"trace-1"
+         ~turn:1
+         ~injected_fact_keys:[ "id:stable"; fallback_key ]
+         ~injected_episode_keys:[]
+         ~n_facts_in_store:10
+         ();
+       append_recall_record
+         ~config
+         ~keeper_id:"keeper-a"
+         ~trace_id:"trace-2"
+         ~turn:2
+         ~injected_fact_keys:[ "id:stable" ]
+         ~injected_episode_keys:[ "trace-2:g0" ]
+         ~n_facts_in_store:10
+         ();
+       append_recall_record
+         ~failure_reason:"prompt_render_error"
+         ~config
+         ~keeper_id:"keeper-b"
+         ~trace_id:"trace-3"
+         ~turn:3
+         ~injected_fact_keys:[]
+         ~injected_episode_keys:[]
+         ~n_facts_in_store:0
+         ();
+       let json =
+         Memory_subsystems.dashboard_memory_subsystems_http_json
+           ~config
+           ~include_memory_entries:false
+           (request "/dashboard/memory-subsystems?limit=100")
+       in
+       let quality = Json.(json |> member "memory_quality") in
+       check string "quality schema" "masc.memory_quality.recall_ledger.v1"
+         Json.(quality |> member "schema" |> to_string);
+       check int "sampled records" 3
+         Json.(quality |> member "sampled_records" |> to_int);
+       check int "records with recall" 2
+         Json.(quality |> member "records_with_recall" |> to_int);
+       check int "empty recall records" 1
+         Json.(quality |> member "empty_recall_records" |> to_int);
+       check int "failure records" 1
+         Json.(quality |> member "failure_records" |> to_int);
+       check bool "outcome not joined in dashboard summary" false
+         Json.(quality |> member "outcome_joined" |> to_bool);
+       let fact_injections = Json.(quality |> member "fact_injections") in
+       check int "total fact injections" 3
+         Json.(fact_injections |> member "total" |> to_int);
+       check int "unique fact keys" 2
+         Json.(fact_injections |> member "unique_fact_keys" |> to_int);
+       check int "echoed fact keys" 1
+         Json.(fact_injections |> member "echoed_fact_keys" |> to_int);
+       check int "max fact echo count" 2
+         Json.(fact_injections |> member "max_fact_echo_count" |> to_int);
+       check int "legacy diagnostic fallback injections" 1
+         Json.(fact_injections |> member "diagnostic_fallback_key_injections" |> to_int);
+       let echoed = Json.(fact_injections |> member "top_echoed_fact_keys" |> to_list) in
+       check int "one echoed top key" 1 (List.length echoed);
+       let top_echo = List.hd echoed in
+       check string "top echoed key" "id:stable"
+         Json.(top_echo |> member "key" |> to_string);
+       check int "top echoed count" 2
+         Json.(top_echo |> member "count" |> to_int);
+       let reasons = Json.(quality |> member "failure_reasons" |> to_list) in
+       check int "one failure reason" 1 (List.length reasons);
+       let reason = List.hd reasons in
+       check string "failure reason key" "prompt_render_error"
+         Json.(reason |> member "key" |> to_string);
+       check int "failure reason count" 1
+         Json.(reason |> member "count" |> to_int))
+;;
+
 let test_http_json_hebbian_derives_from_shared_facts () =
   let dir = temp_dir () in
   Fun.protect
@@ -413,6 +531,10 @@ let () =
             "hebbian derives from shared facts"
             `Quick
             test_http_json_hebbian_derives_from_shared_facts
+        ; test_case
+            "surfaces memory quality summary"
+            `Quick
+            test_http_json_surfaces_memory_quality_summary
         ; test_case
             "hebbian empty without shared facts"
             `Quick

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -328,9 +328,8 @@ let append_recall_record
 ;;
 
 let legacy_unstructured_fallback_fact_key () =
-  "claim:"
-  ^ Types.normalize_claim
-      (Types.librarian_unstructured_fallback_claim_prefix ^ " (provider): raw")
+  Types.claim_identity
+    (fact (Types.librarian_unstructured_fallback_claim_prefix ^ " (provider): raw"))
 ;;
 
 let test_http_json_surfaces_memory_quality_summary () =

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -327,6 +327,22 @@ let append_recall_record
   |> Dated_jsonl.append store
 ;;
 
+let append_malformed_recall_record ~(config : Workspace_utils.config) =
+  let masc_root = Workspace_utils.masc_dir config in
+  let store =
+    Dated_jsonl.create
+      ~base_dir:(Recall_ledger.base_dir ~masc_root)
+      ()
+  in
+  Dated_jsonl.append
+    store
+    (`Assoc
+      [ "keeper_id", `String "keeper-bad"
+      ; "injected_fact_keys", `List [ `Int 1 ]
+      ; "injected_episode_keys", `List []
+      ])
+;;
+
 let legacy_unstructured_fallback_fact_key () =
   Types.claim_identity
     (fact (Types.librarian_unstructured_fallback_claim_prefix ^ " (provider): raw"))
@@ -384,6 +400,8 @@ let test_http_json_surfaces_memory_quality_summary () =
          Json.(quality |> member "empty_recall_records" |> to_int);
        check int "failure records" 1
          Json.(quality |> member "failure_records" |> to_int);
+       check int "decode error records" 0
+         Json.(quality |> member "decode_error_records" |> to_int);
        check bool "outcome not joined in dashboard summary" false
          Json.(quality |> member "outcome_joined" |> to_bool);
        let fact_injections = Json.(quality |> member "fact_injections") in
@@ -411,6 +429,57 @@ let test_http_json_surfaces_memory_quality_summary () =
          Json.(reason |> member "key" |> to_string);
        check int "failure reason count" 1
          Json.(reason |> member "count" |> to_int))
+;;
+
+let test_http_json_surfaces_memory_quality_decode_errors () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf dir)
+    (fun () ->
+       let config = Workspace_utils.default_config dir in
+       append_recall_record
+         ~failure_reason:"free-form provider detail that must not become a label"
+         ~config
+         ~keeper_id:"keeper-a"
+         ~trace_id:"trace-1"
+         ~turn:1
+         ~injected_fact_keys:[ "id:stable" ]
+         ~injected_episode_keys:[]
+         ~n_facts_in_store:1
+         ();
+       append_malformed_recall_record ~config;
+       let json =
+         Memory_subsystems.dashboard_memory_subsystems_http_json
+           ~config
+           ~include_memory_entries:false
+           (request
+              "/dashboard/memory-subsystems?limit=100&memory_quality_limit=10&memory_quality_top_key_limit=1")
+       in
+       let quality = Json.(json |> member "memory_quality") in
+       check int "sample limit from query" 10
+         Json.(quality |> member "sample_limit" |> to_int);
+       check int "one decoded record" 1
+         Json.(quality |> member "sampled_records" |> to_int);
+       check int "one decode error record" 1
+         Json.(quality |> member "decode_error_records" |> to_int);
+       let reasons = Json.(quality |> member "failure_reasons" |> to_list) in
+       check int "one bounded failure reason" 1 (List.length reasons);
+       let reason = List.hd reasons in
+       check
+         string
+         "unknown reason is grouped"
+         Recall_ledger.failure_reason_unknown_label
+         Json.(reason |> member "key" |> to_string);
+       check int "unknown reason count" 1
+         Json.(reason |> member "count" |> to_int);
+       let top_echoed =
+         Json.(
+           quality
+           |> member "fact_injections"
+           |> member "top_echoed_fact_keys"
+           |> to_list)
+       in
+       check int "top key limit applies" 0 (List.length top_echoed))
 ;;
 
 let test_http_json_hebbian_derives_from_shared_facts () =
@@ -534,6 +603,10 @@ let () =
             "surfaces memory quality summary"
             `Quick
             test_http_json_surfaces_memory_quality_summary
+        ; test_case
+            "surfaces memory quality decode errors"
+            `Quick
+            test_http_json_surfaces_memory_quality_decode_errors
         ; test_case
             "hebbian empty without shared facts"
             `Quick


### PR DESCRIPTION
## Summary

- add a read-only `memory_quality` block to `/api/v1/dashboard/memory-subsystems`
- summarize recent `recall_injections` rows for empty recalls, recall render failures, echoed fact keys, and legacy diagnostic fallback key injections
- route recall ledger JSON decoding through `Keeper_recall_injection_ledger.record_of_json` so dashboard code does not own ledger field names
- route recall ledger read error labels through `Keeper_recall_injection_ledger.error_label_of_exn`
- route legacy fallback key classification through `Keeper_memory_os_types.legacy_unstructured_fallback_claim_key`
- keep outcome-dependent fields explicit but unset: `outcome_joined=false`, `useful_recalls/stale_recalls/loop_reductions=null`, so the dashboard does not claim causal usefulness before the outcome evaluator is joined

## Validation

Source-level only per current instruction:

- `ocamlformat --check lib/keeper/keeper_memory_os_types.ml lib/keeper/keeper_memory_os_types.mli lib/keeper/keeper_recall_injection_ledger.ml lib/keeper/keeper_recall_injection_ledger.mli lib/server/server_dashboard_http_memory_subsystems.ml test/test_server_dashboard_http_memory_subsystems.ml`
- `ocamlc -stop-after parsing lib/keeper/keeper_memory_os_types.ml lib/keeper/keeper_recall_injection_ledger.ml lib/server/server_dashboard_http_memory_subsystems.ml test/test_server_dashboard_http_memory_subsystems.ml`
- `ocamlc -stop-after parsing -intf lib/keeper/keeper_memory_os_types.mli lib/keeper/keeper_recall_injection_ledger.mli`
- `git diff --check`
- `scripts/audit-path-ssot.sh`
- targeted `rg` check; remaining field-name / fallback-key hits are in SSOT modules, not dashboard-local parsers/classifiers

Not run/inspected per current instruction:

- local Dune build/test
- GitHub CI/check logs
