### PR TITLE
perf(dashboard): defer rich chat markdown bundles

### DIFF
--- a/dashboard/src/components/chat/code-blocks.test.ts
+++ b/dashboard/src/components/chat/code-blocks.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 // ChatMermaidBlock renders mermaid via DOMPurify + a viewport-gated render
-// (useMermaidInView). Under happy-dom DOMPurify fails its support check and
+// (useInViewOnce). Under happy-dom DOMPurify fails its support check and
 // IntersectionObserver never fires, so the diagram stays a placeholder. jsdom
 // (no IntersectionObserver -> immediate render, DOMPurify supported) exercises
 // the real render path, matching markdown-renderer.test.ts / dompurify.test.ts.

--- a/dashboard/src/components/chat/markdown-blocks.ts
+++ b/dashboard/src/components/chat/markdown-blocks.ts
@@ -2,6 +2,7 @@ import { marked, type Token, type Tokens } from 'marked'
 import { sanitizeHtml as purifyHtml } from '../../lib/dompurify'
 import type { ChatBlock, ChatCalloutSeverity, ChatTableCellValue } from '../../types'
 import { linkifyHtmlReferences } from './chat-linkify'
+import { FENCE_OPEN_RE, STANDALONE_URL_RE, isSvgDocument } from './markdown-cue'
 
 function escapeHtml(raw: string): string {
   return raw.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
@@ -11,7 +12,6 @@ function escapeHtml(raw: string): string {
 // matching the line-based parser in lib/chat-blocks.ts so this rich parser is a
 // strict superset of it (no link-card regression when it supersedes the simple
 // parser on the assistant/system render path).
-const STANDALONE_URL_RE = /^https?:\/\/\S+$/i
 const IMAGE_URL_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'])
 
 function isImageUrl(url: string): boolean {
@@ -90,7 +90,7 @@ function parseParagraph(token: Tokens.Paragraph): ChatBlock | ChatBlock[] | null
     return { t: 'image', src: img.href, cap: img.text || img.title || undefined }
   }
   const trimmed = token.text.trim()
-  if (/^<svg\b[\s\S]*<\/svg>$/i.test(trimmed)) {
+  if (isSvgDocument(trimmed)) {
     return { t: 'svg', svg: trimmed, cap: undefined }
   }
   const urlBlock = standaloneUrlBlock(trimmed)
@@ -134,8 +134,6 @@ function parseParagraph(token: Tokens.Paragraph): ChatBlock | ChatBlock[] | null
 // marked, verified against 18.0.3) absorbs every following line — including
 // plain prose — into the single code token. The resulting code block traps the
 // prose in a monospace box, which is the user-reported symptom.
-const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})/
-
 function hasMatchingClosingFence(raw: string, opener: string): boolean {
   const fenceChar = opener[0]
   const lines = raw.trimEnd().split(/\r?\n/)
@@ -201,7 +199,7 @@ function parseTable(token: Tokens.Table): ChatBlock {
 
 function parseHtml(token: Tokens.HTML): ChatBlock | null {
   const trimmed = token.text.trim()
-  if (/^<svg\b[\s\S]*<\/svg>$/i.test(trimmed)) {
+  if (isSvgDocument(trimmed)) {
     return { t: 'svg', svg: trimmed, cap: undefined }
   }
   // Treat other top-level HTML as a paragraph after sanitization.

--- a/dashboard/src/components/chat/markdown-cue.test.ts
+++ b/dashboard/src/components/chat/markdown-cue.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { hasMarkdownRenderCue } from './markdown-cue'
+
+describe('hasMarkdownRenderCue', () => {
+  it('covers parser-backed block and inline markdown forms', () => {
+    expect(hasMarkdownRenderCue('```ts\nconst x = 1\n```')).toBe(true)
+    expect(hasMarkdownRenderCue('> [!NOTE]\n> pay attention')).toBe(true)
+    expect(hasMarkdownRenderCue('- first\n- second')).toBe(true)
+    expect(hasMarkdownRenderCue('| a | b |\n|---|---|')).toBe(true)
+    expect(hasMarkdownRenderCue('Summary with **bold** and `code`.')).toBe(true)
+    expect(hasMarkdownRenderCue('https://example.com/image.png')).toBe(true)
+    expect(hasMarkdownRenderCue('<svg viewBox="0 0 1 1"></svg>')).toBe(true)
+  })
+
+  it('does not route plain prose through rich markdown loading', () => {
+    expect(hasMarkdownRenderCue('plain assistant prose with a normal URL https://example.com/a')).toBe(false)
+    expect(hasMarkdownRenderCue('')).toBe(false)
+    expect(hasMarkdownRenderCue('   ')).toBe(false)
+  })
+})

--- a/dashboard/src/components/chat/markdown-cue.ts
+++ b/dashboard/src/components/chat/markdown-cue.ts
@@ -1,0 +1,37 @@
+export const STANDALONE_URL_RE = /^https?:\/\/\S+$/i
+export const FENCE_OPEN_RE = /^ {0,3}(`{3,}|~{3,})/m
+
+const STANDALONE_URL_LINE_RE = /^https?:\/\/\S+$/im
+const HEADING_RE = /^ {0,3}#{1,6}\s+\S/m
+const BLOCKQUOTE_RE = /^ {0,3}>/m
+const LIST_RE = /^ {0,3}(?:[-*+]\s+|\d+[.)]\s+)/m
+const HR_RE = /^ {0,3}([-*_])(?:\s*\1){2,}\s*$/m
+const TABLE_ROW_RE = /^\s*\|.+\|\s*$/m
+const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{3,}:?\s*\|/m
+const MARKDOWN_LINK_OR_IMAGE_RE = /!?\[[^\]]+]\([^)]+\)/
+const INLINE_CODE_RE = /`[^`\n]+`/
+const STRONG_RE = /(?:\*\*|__)\S[\s\S]*?\S(?:\*\*|__)/
+const EMPHASIS_RE = /(^|[\s(])(?:\*|_)\S[^\n]*?\S(?:\*|_)(?=$|[\s).,!?;:])/
+
+export function isSvgDocument(text: string): boolean {
+  return /^<svg\b[\s\S]*<\/svg>$/i.test(text.trim())
+}
+
+export function hasMarkdownRenderCue(text: string): boolean {
+  const trimmed = text.trim()
+  if (!trimmed) return false
+  return (
+    FENCE_OPEN_RE.test(text)
+    || HEADING_RE.test(text)
+    || BLOCKQUOTE_RE.test(text)
+    || LIST_RE.test(text)
+    || HR_RE.test(text)
+    || (TABLE_ROW_RE.test(text) && TABLE_SEPARATOR_RE.test(text))
+    || MARKDOWN_LINK_OR_IMAGE_RE.test(text)
+    || INLINE_CODE_RE.test(text)
+    || STRONG_RE.test(text)
+    || EMPHASIS_RE.test(text)
+    || STANDALONE_URL_LINE_RE.test(text)
+    || isSvgDocument(trimmed)
+  )
+}

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -2551,6 +2551,22 @@ describe('ChatMessageBubble — rich markdown rendering of assistant prose', () 
     expect(code?.textContent).toContain('const x = 1')
   })
 
+  it('routes inline markdown and lists through the rich parser', async () => {
+    renderEntries([
+      entry({
+        id: 'a-inline',
+        role: 'assistant',
+        source: 'direct_assistant',
+        text: 'Summary with **bold** and `code`.\n\n- first\n- second',
+      }),
+    ])
+
+    await waitFor(() => expect(container.querySelector('[data-chat-blocks] strong')?.textContent).toBe('bold'))
+    expect(container.querySelector('[data-chat-blocks] code')?.textContent).toBe('code')
+    const items = Array.from(container.querySelectorAll('[data-chat-blocks] li')).map((node) => node.textContent)
+    expect(items).toEqual(['first', 'second'])
+  })
+
   it('re-parses richly even when the backend supplied a degraded p-only block', async () => {
     // The backend persists a line-based parse (escaped <p>); the render path
     // must still recover the structured code block from the message text.

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -2,7 +2,7 @@
 
 import { html } from 'htm/preact'
 import { render, options } from 'preact'
-import { fireEvent } from '@testing-library/preact'
+import { fireEvent, waitFor } from '@testing-library/preact'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ChatBlock, KeeperConversationAttachment, KeeperConversationEntry } from '../../types'
 import type { ToolCallEntry } from '../../api/dashboard'
@@ -1914,7 +1914,7 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(bundle?.querySelector('[data-chat-trace-step="chat"]')?.textContent).toContain('곧 답합니다')
   })
 
-  it('renders thinking text as sanitized markdown with newlines preserved', () => {
+  it('renders thinking text as sanitized markdown with newlines preserved', async () => {
     render(
       html`<${ChatTranscript}
         entries=${[
@@ -1939,7 +1939,7 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
     expect(think.className).toContain('whitespace-pre-wrap')
     expect(think.className).toContain('markdown-body')
     // Markdown is rendered, not shown as literal `**강조**`.
-    expect(think.querySelector('strong')?.textContent).toBe('강조')
+    await waitFor(() => expect(think.querySelector('strong')?.textContent).toBe('강조'))
     // Both source lines survive the round-trip.
     expect(think.textContent).toContain('첫째 줄')
     expect(think.textContent).toContain('둘째 줄')
@@ -2536,7 +2536,7 @@ describe('ChatMessageBubble — rich markdown rendering of assistant prose', () 
     render(html`<${ChatTranscript} entries=${entries} emptyText="empty" />`, container)
   }
 
-  it('renders a code fence in assistant prose as a code block', () => {
+  it('renders a code fence in assistant prose as a code block', async () => {
     renderEntries([
       entry({
         id: 'a1',
@@ -2545,12 +2545,13 @@ describe('ChatMessageBubble — rich markdown rendering of assistant prose', () 
         text: 'Here you go:\n\n```ts\nconst x = 1\n```',
       }),
     ])
+    await waitFor(() => expect(container.querySelector('[data-chat-block="code"]')).not.toBeNull())
     const code = container.querySelector('[data-chat-block="code"]')
     expect(code).not.toBeNull()
     expect(code?.textContent).toContain('const x = 1')
   })
 
-  it('re-parses richly even when the backend supplied a degraded p-only block', () => {
+  it('re-parses richly even when the backend supplied a degraded p-only block', async () => {
     // The backend persists a line-based parse (escaped <p>); the render path
     // must still recover the structured code block from the message text.
     renderEntries([
@@ -2566,7 +2567,7 @@ describe('ChatMessageBubble — rich markdown rendering of assistant prose', () 
         ],
       }),
     ])
-    expect(container.querySelector('[data-chat-block="code"]')).not.toBeNull()
+    await waitFor(() => expect(container.querySelector('[data-chat-block="code"]')).not.toBeNull())
   })
 
   it('keeps server blocks as-is when the message carries a non-text card/clip', () => {

--- a/dashboard/src/components/chat/primitives.test.ts
+++ b/dashboard/src/components/chat/primitives.test.ts
@@ -1363,6 +1363,7 @@ describe('ChatComposer multimodal', () => {
 
   afterEach(() => {
     render(null, container)
+    vi.runAllTimers()
     container.remove()
     vi.useRealTimers()
   })
@@ -1933,18 +1934,24 @@ describe('ChatTranscript — tool-call grouping (turn timeline)', () => {
       container,
     )
 
-    const think = container.querySelector('[data-chat-trace-step="think"] .chat-block-tstep-text') as HTMLElement
+    const findThink = () =>
+      container.querySelector('[data-chat-trace-step="think"] .chat-block-tstep-text') as HTMLElement | null
+    const think = findThink()
     expect(think).not.toBeNull()
     // Newline-preserving container (raw interpolation folded these to one line).
-    expect(think.className).toContain('whitespace-pre-wrap')
-    expect(think.className).toContain('markdown-body')
+    expect(think?.className).toContain('whitespace-pre-wrap')
+    expect(think?.className).toContain('markdown-body')
     // Markdown is rendered, not shown as literal `**강조**`.
-    await waitFor(() => expect(think.querySelector('strong')?.textContent).toBe('강조'))
+    await waitFor(
+      () => expect(findThink()?.querySelector('strong')?.textContent).toBe('강조'),
+      { timeout: 3000 },
+    )
+    const renderedThink = findThink()
     // Both source lines survive the round-trip.
-    expect(think.textContent).toContain('첫째 줄')
-    expect(think.textContent).toContain('둘째 줄')
+    expect(renderedThink?.textContent).toContain('첫째 줄')
+    expect(renderedThink?.textContent).toContain('둘째 줄')
     // Untrusted model markup is stripped (no executable script element).
-    expect(think.querySelector('script')).toBeNull()
+    expect(renderedThink?.querySelector('script')).toBeNull()
   })
 
   it('renders board post ids in assistant prose as board detail links', () => {
@@ -2565,6 +2572,32 @@ describe('ChatMessageBubble — rich markdown rendering of assistant prose', () 
     expect(container.querySelector('[data-chat-blocks] code')?.textContent).toBe('code')
     const items = Array.from(container.querySelectorAll('[data-chat-blocks] li')).map((node) => node.textContent)
     expect(items).toEqual(['first', 'second'])
+  })
+
+  it('keeps prior rich blocks visible while streaming text is re-parsed', async () => {
+    renderEntries([
+      entry({
+        id: 'a-stream',
+        role: 'assistant',
+        source: 'direct_assistant',
+        text: '```ts\nconst before = 1\n```',
+      }),
+    ])
+
+    await waitFor(() => expect(container.querySelector('[data-chat-block="code"]')?.textContent).toContain('before'))
+
+    renderEntries([
+      entry({
+        id: 'a-stream',
+        role: 'assistant',
+        source: 'direct_assistant',
+        delivery: 'streaming',
+        text: '```ts\nconst after = 2\n```',
+      }),
+    ])
+
+    expect(container.querySelector('[data-chat-block="code"]')?.textContent).toContain('before')
+    await waitFor(() => expect(container.querySelector('[data-chat-block="code"]')?.textContent).toContain('after'))
   })
 
   it('re-parses richly even when the backend supplied a degraded p-only block', async () => {

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1,5 +1,5 @@
 import { html } from 'htm/preact'
-import type { ComponentChildren, RefObject, VNode } from 'preact'
+import type { ComponentChildren, VNode } from 'preact'
 import { JsonViewerCard } from '../common/json-viewer'
 import { sanitizeHtml as purifyHtml } from '../../lib/dompurify'
 import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks'
@@ -26,6 +26,8 @@ import { lookupToolCallOutput, toolCallIdFromToolEntryId, toolCallOutputsById, t
 import { Sigil } from '../common/sigil-chip'
 import { SuggestionChip } from '../common/suggestion-chip'
 import { StatusDot } from '../common/status-dot'
+import { useInViewOnce } from '../common/use-in-view'
+import { hasMarkdownRenderCue } from './markdown-cue'
 import type { JSX } from 'preact'
 import { navigate } from '../../router'
 import { normalizeFusionPanelReason } from '../../lib/fusion-meta'
@@ -524,7 +526,7 @@ function AsyncMarkdownDiv({
 }) {
   const [rendered, setRendered] = useState<string | null>(null)
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     let active = true
     setRendered(null)
     void (async () => {
@@ -707,36 +709,10 @@ async function copyWithToast(text: string, successMessage: string): Promise<void
   showToast(ok ? successMessage : '복사하지 못했습니다', ok ? 'success' : 'error')
 }
 
-function useLazyInView<T extends HTMLElement>(
-  rootMargin = '200px',
-): [RefObject<T>, boolean] {
-  const ref = useRef<T>(null)
-  const [inView, setInView] = useState(() => typeof IntersectionObserver === 'undefined')
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el || inView) return undefined
-    if (typeof IntersectionObserver === 'undefined') {
-      setInView(true)
-      return undefined
-    }
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting) setInView(true)
-      },
-      { rootMargin },
-    )
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [inView, rootMargin])
-
-  return [ref, inView]
-}
-
 function ChatCodeBlock({ cap, html: htmlContent, source }: { cap?: string; html: string; source?: string }) {
   const [highlighted, setHighlighted] = useState<string | null>(null)
   const [failed, setFailed] = useState(false)
-  const [containerRef, shouldHighlight] = useLazyInView<HTMLDivElement>('300px')
+  const [containerRef, shouldHighlight] = useInViewOnce<HTMLDivElement>('300px')
   const codeId = useId()
 
   useEffect(() => {
@@ -1191,7 +1167,7 @@ function ChatSvgBlock({ svg, cap }: { svg: string; cap?: string }) {
 
 function ChatMermaidBlock({ source, caption }: ChatMermaidBlock) {
   const id = useId()
-  const [containerRef, shouldRender] = useLazyInView<HTMLElement>('200px')
+  const [containerRef, shouldRender] = useInViewOnce<HTMLElement>('200px')
   const [svg, setSvg] = useState<string | null>(null)
   const [error, setError] = useState(false)
 
@@ -1901,25 +1877,6 @@ const CARD_BLOCK_TYPES: ReadonlySet<ChatBlock['t']> = new Set([
   'shell',
 ])
 
-function hasRichBlockMarkdownCue(text: string): boolean {
-  const trimmed = text.trim()
-  if (!trimmed) return false
-  return (
-    /^ {0,3}(```|~~~)/m.test(text)
-    || /^ {0,3}#{1,6}\s+\S/m.test(text)
-    || /^ {0,3}>/m.test(text)
-    || /^ {0,3}(?:[-*+]\s+|\d+[.)]\s+)/m.test(text)
-    || /^ {0,3}([-*_])(?:\s*\1){2,}\s*$/m.test(text)
-    || (/^\s*\|.+\|\s*$/m.test(text) && /^\s*\|?\s*:?-{3,}:?\s*\|/m.test(text))
-    || /!?\[[^\]]+]\([^)]+\)/.test(text)
-    || /`[^`\n]+`/.test(text)
-    || /(?:\*\*|__)\S[\s\S]*?\S(?:\*\*|__)/.test(text)
-    || /(^|[\s(])(?:\*|_)\S[^\n]*?\S(?:\*|_)(?=$|[\s).,!?;:])/.test(text)
-    || /^https?:\/\/\S+$/im.test(text)
-    || /^<svg\b[\s\S]*<\/svg>$/i.test(trimmed)
-  )
-}
-
 // Memoized message bubble. A streaming reply re-renders the conversation panel
 // on every SSE event; the transcript reconcile preserves the entry reference of
 // every settled message (keeper-state.ts), and KeeperConversationPanel hoists
@@ -1953,7 +1910,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const [messageCollapsed, setMessageCollapsed] = useState(true)
   const expanded = showMetadata && expandedRaw
   const rawExpanded = showMetadata && rawExpandedRaw
-  const [bubbleRef, bubbleInView] = useLazyInView<HTMLElement>('300px')
+  const [bubbleRef, bubbleInView] = useInViewOnce<HTMLElement>('300px')
   const liveLabel = liveMessageLabel(entry)
   const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
@@ -1969,7 +1926,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
     && hasRealText
     && !hasCardBlock
     && bubbleInView
-    && hasRichBlockMarkdownCue(entry.text ?? '')
+    && hasMarkdownRenderCue(entry.text ?? '')
   // Re-parse assistant/system prose so markdown (code fences, tables, callouts)
   // renders as structured blocks. The backend persists only a line-based parse
   // (lib/keeper/keeper_chat_blocks.ml -> escaped <p>), so without this the rich

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -1,13 +1,10 @@
 import { html } from 'htm/preact'
-import type { ComponentChildren, VNode } from 'preact'
-import { marked } from 'marked'
+import type { ComponentChildren, RefObject, VNode } from 'preact'
 import { JsonViewerCard } from '../common/json-viewer'
 import { sanitizeHtml as purifyHtml } from '../../lib/dompurify'
-import { renderMermaidSvg, useMermaidInView } from '../common/mermaid-graph'
 import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { ringFocusClasses } from '../common/ring'
 import { collectAttachments } from './attachments'
-import { parseMarkdownToBlocks } from './markdown-blocks'
 import { linkifyHtmlReferences } from './chat-linkify'
 import { showToast } from '../common/toast'
 import { copyToClipboard } from '../common/copyable-code'
@@ -478,12 +475,7 @@ function ChatArtifactPreview({
   if (type === 'md') {
     return html`
       <${ChatPreviewModal} title=${name} onClose=${onClose}>
-        <div
-          class="chat-lightbox-md markdown-body"
-          dangerouslySetInnerHTML=${{
-            __html: purifyHtml(marked.parse(text) as string),
-          }}
-        />
+        <${AsyncMarkdownDiv} text=${text} className="chat-lightbox-md markdown-body" />
       <//>
     `
   }
@@ -504,19 +496,55 @@ function sanitizeSvg(raw: string): string {
   return purifyHtml(raw, { USE_PROFILES: { svg: true } })
 }
 
+type MarkedApi = typeof import('marked')['marked']
+type SanitizeConfig = Parameters<typeof purifyHtml>[1]
+
+let markedPromise: Promise<MarkedApi> | null = null
+
+function loadMarked(): Promise<MarkedApi> {
+  if (!markedPromise) {
+    markedPromise = import('marked').then((module) => module.marked)
+  }
+  return markedPromise
+}
+
+function AsyncMarkdownDiv({
+  text,
+  className,
+  sanitizeConfig,
+}: {
+  text: string
+  className: string
+  sanitizeConfig?: SanitizeConfig
+}) {
+  const [rendered, setRendered] = useState<string | null>(null)
+
+  useLayoutEffect(() => {
+    let active = true
+    setRendered(null)
+    void (async () => {
+      try {
+        const marked = await loadMarked()
+        const next = purifyHtml(marked.parse(text) as string, sanitizeConfig)
+        if (active) setRendered(next)
+      } catch {
+        if (active) setRendered(null)
+      }
+    })()
+    return () => { active = false }
+  }, [text, sanitizeConfig])
+
+  return rendered === null
+    ? html`<div class=${className}>${text}</div>`
+    : html`<div class=${className} dangerouslySetInnerHTML=${{ __html: rendered }} />`
+}
+
 function renderInlineHtml(raw: string): { __html: string } {
   return { __html: sanitizeHtml(linkifyHtmlReferences(raw)) }
 }
 
-// Trace-step thinking text: render through the same sanitized markdown path the
-// assistant message body uses (purifyHtml(marked.parse(...))) so newlines and
-// inline formatting survive. Raw `${step.text}` interpolation collapsed both —
-// the model emits multi-line reasoning and the single-span layout folded it into
-// one run-on line. purifyHtml strips untrusted model markup (XSS coverage in
-// primitives.test.ts); `whitespace-pre-wrap` on the container preserves the
-// newlines marked leaves between paragraphs.
-function traceStepMarkdown(raw: string): { __html: string } {
-  return { __html: purifyHtml(marked.parse(raw) as string) }
+function renderPlainLinkedHtml(raw: string): { __html: string } {
+  return { __html: sanitizeHtml(linkifyHtmlReferences(escapeHtml(raw))) }
 }
 
 function highlightJson(obj: unknown): string {
@@ -673,10 +701,36 @@ async function copyWithToast(text: string, successMessage: string): Promise<void
   showToast(ok ? successMessage : '복사하지 못했습니다', ok ? 'success' : 'error')
 }
 
+function useLazyInView<T extends HTMLElement>(
+  rootMargin = '200px',
+): [RefObject<T>, boolean] {
+  const ref = useRef<T>(null)
+  const [inView, setInView] = useState(() => typeof IntersectionObserver === 'undefined')
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el || inView) return undefined
+    if (typeof IntersectionObserver === 'undefined') {
+      setInView(true)
+      return undefined
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) setInView(true)
+      },
+      { rootMargin },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [inView, rootMargin])
+
+  return [ref, inView]
+}
+
 function ChatCodeBlock({ cap, html: htmlContent, source }: { cap?: string; html: string; source?: string }) {
   const [highlighted, setHighlighted] = useState<string | null>(null)
   const [failed, setFailed] = useState(false)
-  const [containerRef, shouldHighlight] = useMermaidInView<HTMLDivElement>('300px')
+  const [containerRef, shouldHighlight] = useLazyInView<HTMLDivElement>('300px')
   const codeId = useId()
 
   useEffect(() => {
@@ -1131,7 +1185,7 @@ function ChatSvgBlock({ svg, cap }: { svg: string; cap?: string }) {
 
 function ChatMermaidBlock({ source, caption }: ChatMermaidBlock) {
   const id = useId()
-  const [containerRef, shouldRender] = useMermaidInView<HTMLElement>('200px')
+  const [containerRef, shouldRender] = useLazyInView<HTMLElement>('200px')
   const [svg, setSvg] = useState<string | null>(null)
   const [error, setError] = useState(false)
 
@@ -1146,6 +1200,7 @@ function ChatMermaidBlock({ source, caption }: ChatMermaidBlock) {
         // to avoid SVG corruption, and returns DOMPurify-sanitized output.
         // Re-running DOMPurify per chat block added ~1s+ of main-thread work
         // for large diagrams (see dashboard perf audit).
+        const { renderMermaidSvg } = await import('../common/mermaid-graph')
         const rendered = await renderMermaidSvg(source, `mermaid-${id}`)
         if (active) setSvg(rendered)
       } catch {
@@ -1183,9 +1238,9 @@ function ChatTraceStep({ step }: { step: ChatTraceStep }) {
           <div class="chat-block-tstep-row">
             <span class="chat-block-tstep-kind">Thinking</span>
           </div>
-          <div
-            class="chat-block-tstep-text markdown-body whitespace-pre-wrap break-words"
-            dangerouslySetInnerHTML=${traceStepMarkdown(step.text)}
+          <${AsyncMarkdownDiv}
+            text=${step.text}
+            className="chat-block-tstep-text markdown-body whitespace-pre-wrap break-words"
           />
         </div>
       </div>
@@ -1418,11 +1473,9 @@ function asFusionTotalOutputTokens(meta: unknown): number | undefined {
 
 // Render untrusted model/judge markdown through the same sanitized path the rest
 // of the transcript uses (DOMPurify over marked) — never inject raw model output.
+// Marked is loaded lazily so closed fusion panels do not tax initial keeper load.
 function FusionMarkdown({ text }: { text: string }) {
-  return html`<div
-    class="markdown-body text-xs leading-relaxed"
-    dangerouslySetInnerHTML=${{ __html: purifyHtml(marked.parse(text) as string) }}
-  />`
+  return html`<${AsyncMarkdownDiv} text=${text} className="markdown-body text-xs leading-relaxed" />`
 }
 
 // One panel model's contribution. Collapsed by default so three verbose model
@@ -1842,6 +1895,19 @@ const CARD_BLOCK_TYPES: ReadonlySet<ChatBlock['t']> = new Set([
   'shell',
 ])
 
+function hasRichBlockMarkdownCue(text: string): boolean {
+  const trimmed = text.trim()
+  if (!trimmed) return false
+  return (
+    /^ {0,3}(```|~~~)/m.test(text)
+    || /^ {0,3}#{1,6}\s+\S/m.test(text)
+    || /^ {0,3}>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION|DANGER|WARN|ERROR)\]/im.test(text)
+    || (/^\s*\|.+\|\s*$/m.test(text) && /^\s*\|?\s*:?-{3,}:?\s*\|/m.test(text))
+    || /!\[[^\]]*]\([^)]+\)/.test(text)
+    || /^<svg\b[\s\S]*<\/svg>$/i.test(trimmed)
+  )
+}
+
 // Memoized message bubble. A streaming reply re-renders the conversation panel
 // on every SSE event; the transcript reconcile preserves the entry reference of
 // every settled message (keeper-state.ts), and KeeperConversationPanel hoists
@@ -1875,6 +1941,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const [messageCollapsed, setMessageCollapsed] = useState(true)
   const expanded = showMetadata && expandedRaw
   const rawExpanded = showMetadata && rawExpandedRaw
+  const [bubbleRef, bubbleInView] = useLazyInView<HTMLElement>('300px')
   const liveLabel = liveMessageLabel(entry)
   const messageText = liveLabel ? '' : entry.text || '(empty reply)'
   const messageLength = messageText.length
@@ -1884,16 +1951,35 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const richTextRole = entry.role === 'assistant' || entry.role === 'system'
   const hasRealText = !liveLabel && !!entry.text && entry.text.trim().length > 0
   const hasCardBlock = (entry.blocks ?? []).some((b) => CARD_BLOCK_TYPES.has(b.t))
+  const shouldParseRichBlocks =
+    !isFailureMessage
+    && richTextRole
+    && hasRealText
+    && !hasCardBlock
+    && bubbleInView
+    && hasRichBlockMarkdownCue(entry.text ?? '')
   // Re-parse assistant/system prose so markdown (code fences, tables, callouts)
   // renders as structured blocks. The backend persists only a line-based parse
   // (lib/keeper/keeper_chat_blocks.ml -> escaped <p>), so without this the rich
   // renderer never receives a code/table block. Skipped when the message owns a
   // card/clip the text cannot reproduce (CARD_BLOCK_TYPES) — those server blocks
   // render as-is.
-  const parsedBlocks = useMemo(() => {
-    if (isFailureMessage || !richTextRole || !hasRealText || hasCardBlock) return null
-    return parseMarkdownToBlocks(entry.text ?? '')
-  }, [isFailureMessage, richTextRole, hasRealText, hasCardBlock, entry.text])
+  const [parsedBlocks, setParsedBlocks] = useState<ChatBlock[] | null>(null)
+  useEffect(() => {
+    let active = true
+    setParsedBlocks(null)
+    if (!shouldParseRichBlocks) return () => { active = false }
+    void (async () => {
+      try {
+        const { parseMarkdownToBlocks } = await import('./markdown-blocks')
+        const next = parseMarkdownToBlocks(entry.text ?? '')
+        if (active) setParsedBlocks(next)
+      } catch {
+        if (active) setParsedBlocks(null)
+      }
+    })()
+    return () => { active = false }
+  }, [shouldParseRichBlocks, entry.text])
   const effectiveBlocks = isFailureMessage ? [] : (parsedBlocks ?? entry.blocks ?? [])
   const hasEffectiveBlocks = effectiveBlocks.length > 0
   const collapseThreshold = 1200
@@ -1912,6 +1998,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
 
   return html`
     <article
+      ref=${bubbleRef}
       class=${`chat-bubble ${tone} flex w-full flex-col backdrop-blur-sm ${
         isMessenger
           ? 'max-w-[82%] gap-2.5 rounded-[var(--radius-xl)] px-4 py-3.5'
@@ -2104,12 +2191,7 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
               : html`
                   <div
                     class=${`markdown-body whitespace-pre-wrap break-words text-base leading-airy text-[var(--color-fg-primary)] ${isCollapsible && messageCollapsed ? 'max-h-96 overflow-hidden' : ''}`}
-                    dangerouslySetInnerHTML=${{
-                      __html: purifyHtml(
-                        marked.parse(messageText) as string,
-                        { ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'code', 'pre', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'blockquote', 'a', 'hr'] }
-                      )
-                    }}
+                    dangerouslySetInnerHTML=${renderPlainLinkedHtml(messageText)}
                   />
                 `}
             ${entry.delivery === 'streaming'

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -503,7 +503,12 @@ let markedPromise: Promise<MarkedApi> | null = null
 
 function loadMarked(): Promise<MarkedApi> {
   if (!markedPromise) {
-    markedPromise = import('marked').then((module) => module.marked)
+    markedPromise = import('marked')
+      .then((module) => module.marked)
+      .catch((err) => {
+        markedPromise = null
+        throw err
+      })
   }
   return markedPromise
 }
@@ -527,7 +532,8 @@ function AsyncMarkdownDiv({
         const marked = await loadMarked()
         const next = purifyHtml(marked.parse(text) as string, sanitizeConfig)
         if (active) setRendered(next)
-      } catch {
+      } catch (err) {
+        console.warn('[chat] markdown render failed', err instanceof Error ? err.message : err)
         if (active) setRendered(null)
       }
     })()
@@ -535,7 +541,7 @@ function AsyncMarkdownDiv({
   }, [text, sanitizeConfig])
 
   return rendered === null
-    ? html`<div class=${className}>${text}</div>`
+    ? html`<div class=${className} dangerouslySetInnerHTML=${renderPlainLinkedHtml(text)} />`
     : html`<div class=${className} dangerouslySetInnerHTML=${{ __html: rendered }} />`
 }
 
@@ -1901,9 +1907,15 @@ function hasRichBlockMarkdownCue(text: string): boolean {
   return (
     /^ {0,3}(```|~~~)/m.test(text)
     || /^ {0,3}#{1,6}\s+\S/m.test(text)
-    || /^ {0,3}>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION|DANGER|WARN|ERROR)\]/im.test(text)
+    || /^ {0,3}>/m.test(text)
+    || /^ {0,3}(?:[-*+]\s+|\d+[.)]\s+)/m.test(text)
+    || /^ {0,3}([-*_])(?:\s*\1){2,}\s*$/m.test(text)
     || (/^\s*\|.+\|\s*$/m.test(text) && /^\s*\|?\s*:?-{3,}:?\s*\|/m.test(text))
-    || /!\[[^\]]*]\([^)]+\)/.test(text)
+    || /!?\[[^\]]+]\([^)]+\)/.test(text)
+    || /`[^`\n]+`/.test(text)
+    || /(?:\*\*|__)\S[\s\S]*?\S(?:\*\*|__)/.test(text)
+    || /(^|[\s(])(?:\*|_)\S[^\n]*?\S(?:\*|_)(?=$|[\s).,!?;:])/.test(text)
+    || /^https?:\/\/\S+$/im.test(text)
     || /^<svg\b[\s\S]*<\/svg>$/i.test(trimmed)
   )
 }
@@ -1967,14 +1979,17 @@ const ChatMessageBubble = memo(function ChatMessageBubble({
   const [parsedBlocks, setParsedBlocks] = useState<ChatBlock[] | null>(null)
   useEffect(() => {
     let active = true
-    setParsedBlocks(null)
-    if (!shouldParseRichBlocks) return () => { active = false }
+    if (!shouldParseRichBlocks) {
+      setParsedBlocks(null)
+      return () => { active = false }
+    }
     void (async () => {
       try {
         const { parseMarkdownToBlocks } = await import('./markdown-blocks')
         const next = parseMarkdownToBlocks(entry.text ?? '')
         if (active) setParsedBlocks(next)
-      } catch {
+      } catch (err) {
+        console.warn('[chat] rich markdown parse failed', err instanceof Error ? err.message : err)
         if (active) setParsedBlocks(null)
       }
     })()

--- a/dashboard/src/components/common/mermaid-graph.ts
+++ b/dashboard/src/components/common/mermaid-graph.ts
@@ -5,6 +5,7 @@ import { EmptyState } from './feedback-state'
 import { sanitizeHtml } from '../../lib/dompurify.js'
 import { memoizeLru } from '../../lib/lru-cache'
 import { loadMermaid, type MermaidApi } from './mermaid-loader'
+import { useInViewOnce } from './use-in-view'
 
 /**
  * Observe whether an element is in (or near) the viewport.
@@ -16,29 +17,7 @@ import { loadMermaid, type MermaidApi } from './mermaid-loader'
 export function useMermaidInView<T extends HTMLElement>(
   rootMargin = '200px',
 ): [RefObject<T>, boolean] {
-  const ref = useRef<T>(null)
-  const [inView, setInView] = useState(false)
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el || inView) return
-    if (typeof IntersectionObserver === 'undefined') {
-      setInView(true)
-      return
-    }
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry?.isIntersecting) {
-          setInView(true)
-        }
-      },
-      { rootMargin },
-    )
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [inView, rootMargin])
-
-  return [ref, inView]
+  return useInViewOnce<T>(rootMargin)
 }
 
 let mermaidConfigured = false

--- a/dashboard/src/components/common/use-in-view.ts
+++ b/dashboard/src/components/common/use-in-view.ts
@@ -1,0 +1,28 @@
+import type { RefObject } from 'preact'
+import { useEffect, useRef, useState } from 'preact/hooks'
+
+export function useInViewOnce<T extends HTMLElement>(
+  rootMargin = '200px',
+): [RefObject<T>, boolean] {
+  const ref = useRef<T>(null)
+  const [inView, setInView] = useState(() => typeof IntersectionObserver === 'undefined')
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el || inView) return undefined
+    if (typeof IntersectionObserver === 'undefined') {
+      setInView(true)
+      return undefined
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) setInView(true)
+      },
+      { rootMargin },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [inView, rootMargin])
+
+  return [ref, inView]
+}


### PR DESCRIPTION
## Summary
- defer chat `marked`/rich markdown block parsing until a message bubble with block-level markdown is in or near view
- lazy-load `mermaid-graph` from chat mermaid blocks instead of importing it with core chat primitives
- keep safe plain/linkified fallback text visible immediately, preserving board-post links without loading `marked`

## Validation
- `pnpm --dir dashboard exec tsc --noEmit --pretty false`
- `pnpm --dir dashboard exec vitest run --config vitest.config.ts src/components/chat/primitives.test.ts src/components/chat/code-blocks.test.ts src/components/chat/media-artifact-ux.test.ts src/components/keeper-workspace/keeper-chat-blocks.test.ts --no-file-parallelism --maxWorkers=1` (124 tests)
- `pnpm --dir dashboard run build`
- `pnpm --dir dashboard run lint`
- `git diff --check`
- Production preview `http://127.0.0.1:5182/dashboard/#keepers` with Playwright fallback:
  - initial heavy resources: `dompurify`/`purify.es` only; no `marked.esm`, `markdown-blocks`, or `mermaid-graph`
  - desktop/mobile screenshots: `/private/tmp/masc-dashboard-keepers-desktop.png`, `/private/tmp/masc-dashboard-keepers-mobile.png`
  - interaction proof: Tweaks opened and density controls appeared; screenshot `/private/tmp/masc-dashboard-keepers-tweaks-open.png`
- Local Dune build intentionally not run; Dune/build validation should come from CI per workflow.