### PR TITLE
fix(dashboard): mirror prototype label on chat suggestion blocks

### DIFF
--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -919,19 +919,27 @@ function ChatChartBlock({ title, series, labels, xLabel, yMax }: ChatChartBlock)
 }
 
 function ChatSuggestionsBlock({ items }: ChatSuggestionsBlock) {
+  // Mirrors prototype messages.jsx:135-147 (.suggest container with the
+  // "추천 후속 질문" label above a chip row). The label is a readability cue:
+  // the block is inline in the message bubble, so without an explicit heading
+  // readers mistake the chips for message content. The row uses the existing
+  // .chat-block-suggestion-chip styling unchanged.
   return html`
     <div class="chat-block-suggestions" data-chat-block="suggestions">
-      ${items.map((it, i) => html`
-        <button
-          key=${i}
-          type="button"
-          class="chat-block-suggestion-chip"
-          data-action=${it.action ?? ''}
-        >
-          <span class="chat-block-suggestion-pre">${it.icon ?? '▸'}</span>
-          <span class="chat-block-suggestion-label">${it.label}</span>
-        </button>
-      `)}
+      <span class="chat-block-suggestions-label">추천 후속 질문</span>
+      <div class="chat-block-suggestions-row">
+        ${items.map((it, i) => html`
+          <button
+            key=${i}
+            type="button"
+            class="chat-block-suggestion-chip"
+            data-action=${it.action ?? ''}
+          >
+            <span class="chat-block-suggestion-pre">${it.icon ?? '▸'}</span>
+            <span class="chat-block-suggestion-label">${it.label}</span>
+          </button>
+        `)}
+      </div>
     </div>
   `
 }

--- a/dashboard/src/components/chat/primitives.ts
+++ b/dashboard/src/components/chat/primitives.ts
@@ -69,6 +69,8 @@ const TRACE_TOOL_STATUS_UI: Record<TraceToolStatus, { className: 'ok' | 'bad' | 
   err: { className: 'bad', title: '실패' },
 }
 
+export const CHAT_SUGGESTIONS_LABEL = '추천 후속 질문'
+
 function traceToolStatusUi(status: ChatTraceToolStep['status']): { className: 'ok' | 'bad' | 'pending'; title: string } {
   return TRACE_TOOL_STATUS_UI[status ?? 'pending']
 }
@@ -919,25 +921,20 @@ function ChatChartBlock({ title, series, labels, xLabel, yMax }: ChatChartBlock)
 }
 
 function ChatSuggestionsBlock({ items }: ChatSuggestionsBlock) {
-  // Mirrors prototype messages.jsx:135-147 (.suggest container with the
-  // "추천 후속 질문" label above a chip row). The label is a readability cue:
-  // the block is inline in the message bubble, so without an explicit heading
-  // readers mistake the chips for message content. The row uses the existing
-  // .chat-block-suggestion-chip styling unchanged.
+  const labelId = useId()
+  // Mirrors the keeper-v2 prototype suggestion block: label above a chip row.
+  // The label is a readability cue for inline message-bubble content.
   return html`
     <div class="chat-block-suggestions" data-chat-block="suggestions">
-      <span class="chat-block-suggestions-label">추천 후속 질문</span>
-      <div class="chat-block-suggestions-row">
+      <span class="chat-block-suggestions-label" id=${labelId}>${CHAT_SUGGESTIONS_LABEL}</span>
+      <div class="chat-block-suggestions-row" role="group" aria-labelledby=${labelId}>
         ${items.map((it, i) => html`
-          <button
+          <${ChatSuggestionChip}
             key=${i}
-            type="button"
+            pre=${it.icon ?? '\u25b8'}
             class="chat-block-suggestion-chip"
             data-action=${it.action ?? ''}
-          >
-            <span class="chat-block-suggestion-pre">${it.icon ?? '▸'}</span>
-            <span class="chat-block-suggestion-label">${it.label}</span>
-          </button>
+          >${it.label}<//>
         `)}
       </div>
     </div>

--- a/dashboard/src/components/keeper-workspace/keeper-chat-blocks.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-chat-blocks.test.ts
@@ -4,7 +4,7 @@ import { html } from 'htm/preact'
 import { render } from 'preact'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { ChatBlock, KeeperConversationEntry } from '../../types'
-import { ChatTranscript } from '../chat/primitives'
+import { CHAT_SUGGESTIONS_LABEL, ChatTranscript } from '../chat/primitives'
 
 function entry(
   overrides: Partial<KeeperConversationEntry> & Pick<KeeperConversationEntry, 'id' | 'text'>,
@@ -77,12 +77,16 @@ describe('Keeper chat rich blocks', () => {
 
     const suggestions = container.querySelector('[data-chat-block="suggestions"]')
     expect(suggestions).not.toBeNull()
-    // Mirrors prototype messages.jsx:139 — "추천 후속 질문" label precedes the chip row.
-    expect(suggestions?.querySelector('.chat-block-suggestions-label')?.textContent).toBe('추천 후속 질문')
+    // Mirrors the prototype suggestion label above the chip row.
+    const label = suggestions?.querySelector('.chat-block-suggestions-label')
+    expect(label?.textContent).toBe(CHAT_SUGGESTIONS_LABEL)
     const row = suggestions?.querySelector('.chat-block-suggestions-row')
     expect(row).not.toBeNull()
+    expect(row?.getAttribute('role')).toBe('group')
+    expect(row?.getAttribute('aria-labelledby')).toBe(label?.id)
     const buttons = [...(row?.querySelectorAll('button') ?? [])]
     expect(buttons).toHaveLength(3)
+    expect(buttons.every((b) => b.classList.contains('suggestion-chip'))).toBe(true)
     expect(buttons.map((b) => b.textContent?.trim())).toEqual([
       '▸PR #7763 열기',
       '✦open_fds 패널 추가',

--- a/dashboard/src/components/keeper-workspace/keeper-chat-blocks.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-chat-blocks.test.ts
@@ -77,7 +77,11 @@ describe('Keeper chat rich blocks', () => {
 
     const suggestions = container.querySelector('[data-chat-block="suggestions"]')
     expect(suggestions).not.toBeNull()
-    const buttons = [...(suggestions?.querySelectorAll('button') ?? [])]
+    // Mirrors prototype messages.jsx:139 — "추천 후속 질문" label precedes the chip row.
+    expect(suggestions?.querySelector('.chat-block-suggestions-label')?.textContent).toBe('추천 후속 질문')
+    const row = suggestions?.querySelector('.chat-block-suggestions-row')
+    expect(row).not.toBeNull()
+    const buttons = [...(row?.querySelectorAll('button') ?? [])]
     expect(buttons).toHaveLength(3)
     expect(buttons.map((b) => b.textContent?.trim())).toEqual([
       '▸PR #7763 열기',

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -1688,31 +1688,31 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 }
 
 .kw-chat .chat-block-suggestions {
-  /* Prototype messages.jsx:135-147: vertical stack — label above, chip row below.
+  /* Keeper-v2 prototype suggestion block: label above, chip row below.
      The label is a readability cue (inline block would read like message body). */
   display: flex;
   flex-direction: column;
-  gap: 7px;
-  margin-top: 4px;
+  gap: var(--sp-1h);
+  margin-top: var(--sp-1);
 }
 .kw-chat .chat-block-suggestions-label {
-  font-size: 10px;
-  letter-spacing: 0.16em;
+  font-size: var(--fs-10);
+  letter-spacing: var(--track-caps);
   text-transform: uppercase;
   color: var(--text-dim);
 }
 .kw-chat .chat-block-suggestions-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--sp-2);
 }
 .kw-chat .chat-block-suggestion-chip {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  padding: 7px 13px;
+  gap: var(--sp-1h);
+  padding: var(--sp-1h) var(--sp-3);
   border: 1px solid var(--border-main);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--bg-panel);
   color: var(--text-primary);
   font-size: var(--fs-13);
@@ -1723,11 +1723,11 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   border-color: var(--color-accent-fg);
   color: var(--accent-brass-bright);
 }
-.kw-chat .chat-block-suggestion-pre {
+.kw-chat .chat-block-suggestion-chip .suggestion-chip-pre {
   color: var(--accent-brass-bright);
   font-size: var(--fs-11);
 }
-.kw-chat .chat-block-suggestion-label {
+.kw-chat .chat-block-suggestion-chip {
   line-height: 1.3;
 }
 

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -1688,6 +1688,20 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 }
 
 .kw-chat .chat-block-suggestions {
+  /* Prototype messages.jsx:135-147: vertical stack — label above, chip row below.
+     The label is a readability cue (inline block would read like message body). */
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin-top: 4px;
+}
+.kw-chat .chat-block-suggestions-label {
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.kw-chat .chat-block-suggestions-row {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;


### PR DESCRIPTION
## Summary

ChatSuggestionsBlock renders inline in the message bubble, so without an explicit heading readers mistake the chip row for message body. Prototype messages.jsx:135-147 wraps the chips in a .suggest column container with a "추천 후속 질문" label above.

## Changes

- `dashboard/src/components/chat/primitives.ts`: Add label span + row wrapper; switch container to flex-column.
- `dashboard/src/styles/keeper-workspace.css`: Add `.chat-block-suggestions` column-flex, `.chat-block-suggestions-label` typography, `.chat-block-suggestions-row` flex-wrap row.
- `dashboard/src/components/keeper-workspace/keeper-chat-blocks.test.ts`: Test label text + row selector + chip count.

## Scope

Chat surface only (3 files). No Fleet/RuntimeBand changes.

## Prototype Reference

- `~/Downloads/v2 4/project/keeper-v2/messages.jsx:135-147` (.suggest container)
- `~/Downloads/v2 4/project/keeper-v2/styles/v2.css:1222-1244` (.suggest/.suggest-row)

## Backlog

Closes design fidelity gap `ideas-backlog.md` #1 (Suggestions 후속 액션 칩 — UX gap).
The OnPick callback remains a backend contract gap (deferred).

## Verification

- `pnpm typecheck`: clean
- `pnpm lint`: clean
- `pnpm vitest run keeper-chat-blocks`: 4/4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
