### PR TITLE
fix(memory): type gc dry-run runner report

### DIFF
--- a/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
+++ b/lib/keeper/keeper_memory_os_gc_dry_run_report.ml
@@ -108,7 +108,7 @@ let run_one ~keepers_dir ~run_gc_for_keepers_dir ~explicit ~keeper_id ~now =
   then fact_store_missing_error ~keepers_dir ~keeper_id
   else (
     try
-      let report =
+      let (report : Keeper_memory_os_gc.gc_report) =
         run_gc_for_keepers_dir
           ~keepers_dir
           ~dry_run:true


### PR DESCRIPTION
## Summary
- Add an explicit `Keeper_memory_os_gc.gc_report` annotation for the GC dry-run runner result.
- Prevent OCaml record-label inference from treating the runner result as this module's aggregate report type `t`.

## Evidence
- Found from CI Health failure on #22441: `lib/keeper/keeper_memory_os_gc_dry_run_report.ml:220` expected runner return `t` while `default_run_gc_for_keepers_dir` returns `Keeper_memory_os_gc.gc_report`.
- Local lightweight checks only, per workflow that builds are CI-owned:
  - `git diff --check`
  - `ocamlformat --check lib/keeper/keeper_memory_os_gc_dry_run_report.ml`
  - `ocamlc -stop-after parsing lib/keeper/keeper_memory_os_gc_dry_run_report.ml`

Full type/build verification is left to GitHub CI.