### PR TITLE
feat(masc): FUSION adaptive timeout / task-1516 P0 hardening

### DIFF
--- a/.ci/ml-line-cap-exceptions.txt
+++ b/.ci/ml-line-cap-exceptions.txt
@@ -15,3 +15,7 @@ lib/keeper/keeper_run_tools_hooks.ml
 lib/keeper/keeper_run_tools_setup.ml
 lib/keeper/keeper_turn_driver_try_runtime.ml
 lib/keeper/keeper_unified_turn_execution.ml
+# Fusion core test monolith pre-dates the adaptive-timeout schema expansion.
+# New focused cases live in test/test_fusion_adaptive_timeout.ml; full extraction
+# should happen separately from the feature hardening branch.
+test/fusion_core/test_fusion.ml

--- a/bin/fusion_run.ml
+++ b/bin/fusion_run.ml
@@ -122,7 +122,8 @@ let synthesize ~sw ~net ~(preset : Fusion_policy.preset) ~(prompt : string)
          preset.Fusion_policy.panels)
     ~max_tool_calls:(Fusion_policy.judge_tool_budget_of preset.Fusion_policy.panels)
     ()
-  |> Result.map_error fst
+  |> Result.map_error (fun (failure, _usage) ->
+    Fusion_types.judge_failure_text failure)
 
 (* Print a judge arm and return (resolved_answer, judge_in_tokens, judge_out_tokens). *)
 let print_judge_arm ~(tag : string)

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -116,9 +116,21 @@ let attach_usage
   | Ok synthesis -> Ok (synthesis, usage)
   | Error msg -> Error (Fusion_types.Parse_error msg, usage)
 
+let sdk_error_detail (e : Agent_sdk.Error.sdk_error) : string =
+  match e with
+  | Agent_sdk.Error.Api api_error -> Agent_sdk.Error.Retry.error_message api_error
+  | Agent_sdk.Error.Provider provider_error ->
+    Llm_provider.Error.to_string provider_error
+  | Agent_sdk.Error.Agent _ | Agent_sdk.Error.Mcp _ | Agent_sdk.Error.Config _
+  | Agent_sdk.Error.Serialization _ | Agent_sdk.Error.Io _
+  | Agent_sdk.Error.Orchestration _ | Agent_sdk.Error.Internal _ ->
+    Agent_sdk.Error.to_string e
+
 (* [Agent_sdk.Error.sdk_error]를 typed {!judge_failure}로 변환한다. [Api (Retry.Timeout _)]
    를 잡아 [Timeout]으로 propagate하고, 그 외는 [Provider_error]에 사람-가독 detail을
-   보존한다. 이 match가 "to_string 직렬화 → substring 역분류" round-trip 안티패턴의 근본
+   보존한다. Non-timeout detail은 표시용이며 재분류에 쓰지 않는다; provider 오류는
+   [Llm_provider.Error.to_string] 경로로 렌더해 provider/status/retry/phase metadata를
+   유지한다. 이 match가 "to_string 직렬화 → substring 역분류" round-trip 안티패턴의 근본
    해소다: timeout 분류가 컴파일 타입에 묶인다. [prefix]는 호출 context(run 실패 vs
    provider 에러)의 로그/관측 prefix를 보존한다. *)
 let failure_of_sdk_error ~runtime_id ~prefix (e : Agent_sdk.Error.sdk_error) :
@@ -127,9 +139,7 @@ let failure_of_sdk_error ~runtime_id ~prefix (e : Agent_sdk.Error.sdk_error) :
   | Agent_sdk.Error.Api (Agent_sdk.Error.Retry.Timeout _) -> Timeout
   | _ ->
     Provider_error
-      (prefix
-       ^ Fusion_oas.provider_error_detail ~runtime_id
-           (Agent_sdk.Error.to_string e))
+      (prefix ^ Fusion_oas.provider_error_detail ~runtime_id (sdk_error_detail e))
 
 (* 합성된 프롬프트를 받아 심판 에이전트를 빌드·실행·파싱한다. [run]/[run_refine]가
    서로 다른 [compose_*]로 만든 프롬프트를 넘기는 공유 본체 — 프롬프트 구성만 다르고

--- a/lib/fusion/fusion_judge.ml
+++ b/lib/fusion/fusion_judge.ml
@@ -110,11 +110,26 @@ let attach_usage
     (parsed : (Fusion_types.judge_synthesis, string) result)
     (usage : Fusion_types.usage) :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
-    , string * Fusion_types.usage )
+    , Fusion_types.judge_failure * Fusion_types.usage )
     result =
   match parsed with
   | Ok synthesis -> Ok (synthesis, usage)
-  | Error msg -> Error (msg, usage)
+  | Error msg -> Error (Fusion_types.Parse_error msg, usage)
+
+(* [Agent_sdk.Error.sdk_error]를 typed {!judge_failure}로 변환한다. [Api (Retry.Timeout _)]
+   를 잡아 [Timeout]으로 propagate하고, 그 외는 [Provider_error]에 사람-가독 detail을
+   보존한다. 이 match가 "to_string 직렬화 → substring 역분류" round-trip 안티패턴의 근본
+   해소다: timeout 분류가 컴파일 타입에 묶인다. [prefix]는 호출 context(run 실패 vs
+   provider 에러)의 로그/관측 prefix를 보존한다. *)
+let failure_of_sdk_error ~runtime_id ~prefix (e : Agent_sdk.Error.sdk_error) :
+    Fusion_types.judge_failure =
+  match e with
+  | Agent_sdk.Error.Api (Agent_sdk.Error.Retry.Timeout _) -> Timeout
+  | _ ->
+    Provider_error
+      (prefix
+       ^ Fusion_oas.provider_error_detail ~runtime_id
+           (Agent_sdk.Error.to_string e))
 
 (* 합성된 프롬프트를 받아 심판 에이전트를 빌드·실행·파싱한다. [run]/[run_refine]가
    서로 다른 [compose_*]로 만든 프롬프트를 넘기는 공유 본체 — 프롬프트 구성만 다르고
@@ -126,7 +141,7 @@ let attach_usage
 let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model
     ~web_tools ~max_tool_calls ~prompt () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
-    , string * Fusion_types.usage )
+    , Fusion_types.judge_failure * Fusion_types.usage )
     result =
   let tools = if web_tools then Fusion_oas.web_tool_bundle () else [] in
   match
@@ -135,8 +150,9 @@ let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_mod
   with
   | Error reason ->
     Error
-      ( Printf.sprintf "judge build failed: %s"
-          (Fusion_oas.panel_failure_detail ~runtime_id:judge_model reason)
+      ( Fusion_types.Build_error
+          (Printf.sprintf "judge build failed: %s"
+             (Fusion_oas.panel_failure_detail ~runtime_id:judge_model reason))
       , Fusion_types.zero_usage )
   | Ok agent ->
     (match
@@ -145,31 +161,30 @@ let run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_mod
      with
      | Error e ->
        Error
-         ( "judge run failed: "
-           ^ Fusion_oas.provider_error_detail ~runtime_id:judge_model
-               (Agent_sdk.Error.to_string e)
+         ( failure_of_sdk_error ~runtime_id:judge_model ~prefix:"judge run failed: " e
          , Fusion_types.zero_usage )
-     | Ok [] -> Error ("judge: empty result", Fusion_types.zero_usage)
+     | Ok [] -> Error (Fusion_types.Empty_result, Fusion_types.zero_usage)
      | Ok ((_name, Ok resp) :: _) ->
        let text = Fusion_oas.answer_text resp in
        (* 응답은 받았으므로 소비 토큰을 회계한다 — 빈 응답이든 파싱 실패든 동일. *)
        let usage = Fusion_oas.usage_of resp in
        if String.length (String.trim text) = 0 then
-         Error ("judge: " ^ Fusion_oas.empty_response_detail resp, usage)
+         Error
+           ( Empty_response ("judge: " ^ Fusion_oas.empty_response_detail resp)
+           , usage )
        else
          (* 성공 종합·파싱 실패 모두에 심판이 소비한 토큰을 묶는다(panel_answer.usage와 대칭). *)
          attach_usage (Fusion_judge_parse.of_string text) usage
      | Ok ((_name, Error e) :: _) ->
        Error
-         ( "judge provider error: "
-           ^ Fusion_oas.provider_error_detail ~runtime_id:judge_model
-               (Agent_sdk.Error.to_string e)
+         ( failure_of_sdk_error ~runtime_id:judge_model
+             ~prefix:"judge provider error: " e
          , Fusion_types.zero_usage ))
 
 let run ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
     ~panel ~web_tools ~max_tool_calls () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
-    , string * Fusion_types.usage )
+    , Fusion_types.judge_failure * Fusion_types.usage )
     result =
   run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
     ~max_tool_calls ~prompt:(compose_prompt ~question ~panel) ()
@@ -177,7 +192,7 @@ let run ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~quest
 let run_refine ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
     ~panel ~prior ~web_tools ~max_tool_calls () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
-    , string * Fusion_types.usage )
+    , Fusion_types.judge_failure * Fusion_types.usage )
     result =
   run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
     ~max_tool_calls ~prompt:(compose_refine_prompt ~question ~panel ~prior) ()
@@ -185,7 +200,7 @@ let run_refine ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model
 let run_meta ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~question
     ~panel ~priors ~web_tools ~max_tool_calls () :
     ( Fusion_types.judge_synthesis * Fusion_types.usage
-    , string * Fusion_types.usage )
+    , Fusion_types.judge_failure * Fusion_types.usage )
     result =
   run_composed ~sw ~net ~timeout_s ?max_tokens ~judge_system_prompt ~judge_model ~web_tools
     ~max_tool_calls ~prompt:(compose_meta_prompt ~question ~panel ~priors) ()

--- a/lib/fusion/fusion_judge.mli
+++ b/lib/fusion/fusion_judge.mli
@@ -37,7 +37,7 @@ val run
   -> max_tool_calls:int
   -> unit
   -> ( Fusion_types.judge_synthesis * Fusion_types.usage
-     , string * Fusion_types.usage )
+     , Fusion_types.judge_failure * Fusion_types.usage )
      result
 
 (** REFINE 위상의 2차 심판 프롬프트를 구성한다. [compose_prompt]의 질문+패널 블록에
@@ -69,7 +69,7 @@ val run_refine
   -> max_tool_calls:int
   -> unit
   -> ( Fusion_types.judge_synthesis * Fusion_types.usage
-     , string * Fusion_types.usage )
+     , Fusion_types.judge_failure * Fusion_types.usage )
      result
 
 (** [attach_usage parsed usage]는 심판 응답 파싱 결과에 그 호출이 소비한 [usage]를 성공·
@@ -79,7 +79,7 @@ val attach_usage
   :  (Fusion_types.judge_synthesis, string) result
   -> Fusion_types.usage
   -> ( Fusion_types.judge_synthesis * Fusion_types.usage
-     , string * Fusion_types.usage )
+     , Fusion_types.judge_failure * Fusion_types.usage )
      result
 
 (** JOJ(judge-of-judges, RFC-0283) meta 심판 프롬프트를 구성한다. [compose_refine_prompt]와
@@ -110,5 +110,5 @@ val run_meta
   -> max_tool_calls:int
   -> unit
   -> ( Fusion_types.judge_synthesis * Fusion_types.usage
-     , string * Fusion_types.usage )
+     , Fusion_types.judge_failure * Fusion_types.usage )
      result

--- a/lib/fusion/fusion_metrics.ml
+++ b/lib/fusion/fusion_metrics.ml
@@ -12,6 +12,10 @@ let metric_fusion_invocations_total =
 let metric_fusion_judge_executions_total =
   Otel_metric_store_core.declare_counter "masc_fusion_judge_executions_total"
 
+let metric_fusion_adaptive_timeout_extensions_total =
+  Otel_metric_store_core.declare_counter
+    "masc_fusion_adaptive_timeout_extensions_total"
+
 let topology_label = function
   | Simple -> "simple"
   | Refine -> "refine"
@@ -55,4 +59,9 @@ let record_invocation ~topology outcome =
   Otel_metric_store_core.inc_counter
     metric_fusion_invocations_total
     ~labels:[ "topology", topology_label topology; "outcome", outcome_label ]
+    ()
+
+let record_adaptive_timeout () =
+  Otel_metric_store_core.inc_counter
+    metric_fusion_adaptive_timeout_extensions_total
     ()

--- a/lib/fusion/fusion_metrics.mli
+++ b/lib/fusion/fusion_metrics.mli
@@ -2,6 +2,7 @@
 
 val metric_fusion_invocations_total : string
 val metric_fusion_judge_executions_total : string
+val metric_fusion_adaptive_timeout_extensions_total : string
 
 val topology_label : Fusion_types.fusion_topology -> string
 val judge_role_label : Fusion_types.judge_role -> string
@@ -16,3 +17,7 @@ val record_judge_execution : topology:Fusion_types.fusion_topology -> Fusion_typ
 val record_invocation : topology:Fusion_types.fusion_topology -> [< `Denied | `Sink_failed | `Completed ] -> unit
 (** Emit a counter increment for one fusion invocation.
     Labels: [topology], [outcome] \in {denied, sink_failed, completed}. *)
+
+val record_adaptive_timeout : unit -> unit
+(** Emit a counter increment when an adaptive timeout extension is applied to a
+    first-judge recovery pass. *)

--- a/lib/fusion/fusion_oas.ml
+++ b/lib/fusion/fusion_oas.ml
@@ -103,14 +103,16 @@ let provider_error_detail ~runtime_id detail =
     then detail
     else Printf.sprintf "%s: %s" runtime_id detail
 
-let panel_failure_code = function
+let panel_failure_code (failure : Fusion_types.panel_failure) : string =
+  match failure with
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error _ -> "bridge_error"
   | Fusion_types.Provider_error _ -> "provider_error"
   | Fusion_types.Empty_response _ -> "empty_response"
   | Fusion_types.Invalid_max_output_tokens _ -> "invalid_max_output_tokens"
 
-let panel_failure_detail ~runtime_id = function
+let panel_failure_detail ~runtime_id (failure : Fusion_types.panel_failure) : string =
+  match failure with
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error detail -> Printf.sprintf "Bridge error: %s" detail
   | Fusion_types.Provider_error detail -> provider_error_detail ~runtime_id detail
@@ -124,7 +126,8 @@ let panel_failure_detail ~runtime_id = function
    panelist(정체성, 예 "skeptic (claude)")가 "Provider '...'" 슬롯에 새거나 중복
    prefix가 붙는다 (RFC-0278). panelist는 panel_answer.model/failed_model에만 두고
    provider attribution은 detail 안에 이미 박혀 있는 raw model을 쓴다. *)
-let panel_failure_text = function
+let panel_failure_text (failure : Fusion_types.panel_failure) : string =
+  match failure with
   | Fusion_types.Timeout -> "timeout"
   | Fusion_types.Bridge_error detail -> Printf.sprintf "Bridge error: %s" detail
   | Fusion_types.Provider_error detail -> detail

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -90,48 +90,231 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                     { Fusion_types.role = Refine_pass; synthesis = s2; usage = u2 }
                 ] )
             | Error (msg, u2) ->
-              (* 2차 심판이 토큰을 태운 뒤 파싱 실패해도 그 usage(u2)를 버리지 않고
-                 1차와 합산한다 — degrade가 비용을 undercount하지 않도록 (적대 리뷰
-                 #22087 §1). 실패해도 실행 노드(Judge_failed)는 관측에 정직히 남긴다(RFC-0284). *)
               Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
                 "fusion run %s refine judge failed, keeping first synthesis: %s"
                 req.Fusion_types.run_id msg;
               ( Ok (s1, Fusion_types.add_usage u1 u2)
               , [ single_node
                 ; Fusion_types.Judge_failed
-                    { Fusion_types.failed_role = Refine_pass; error = msg; usage = u2 }
+                    { Fusion_types.failed_role = Refine_pass
+                    ; error = msg
+                    ; usage = u2
+                    ; elapsed_s = 0.0
+                    ; timed_out = false
+                    }
                 ] )
           in
-          let run_first_judges judges =
-            Eio.Fiber.List.map
-              ~max_fibers:policy.Fusion_policy.max_concurrent_judges
-              (fun (j : Fusion_policy.judge_spec) ->
-                let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
-                ( id
-                , Fusion_judge.run ~sw ~net ~timeout_s:j.jtimeout_s
-                    ?max_tokens:j.jmax_output_tokens
-                    ~judge_system_prompt:j.jsystem_prompt ~judge_model:j.jmodel
-                    ~question:req.Fusion_types.prompt ~panel ~web_tools:j.jweb_tools
-                    ~max_tool_calls:j.jmax_tool_calls () ))
-              judges
+          (* Adaptive timeout: wave-wide wall-clock budget and per-judge extension.
+             We snapshot t0 before the first-judge wave; each fiber reads the clock
+             just before/after its judge call.  Masc_eio_env.clock is optional; tests
+             and stdio callers may initialise without one, so we fall back to
+             Unix.gettimeofday rather than fail closed. NDT-OK: the wall clock only
+             sizes runtime timeout windows for external judge calls. *)
+          let env = Masc_eio_env.get () in
+          let now () =
+            match env.clock with
+            | Some c -> Eio.Time.now c
+            | None ->
+              (* NDT-OK: boundary fallback when no Eio clock is installed. *)
+              Unix.gettimeofday ()
           in
-          let first_judge_nodes firsts =
+          let t0 = now () in
+          let str_contains ~needle haystack =
+            let nl = String.length needle and hl = String.length haystack in
+            if nl = 0
+            then true
+            else
+              let rec scan i =
+                if i + nl > hl
+                then false
+                else if String.equal (String.sub haystack i nl) needle
+                then true
+                else scan (i + 1)
+              in
+              scan 0
+          in
+          let is_timeout_error msg =
+            str_contains ~needle:"Execution timed out after" msg
+          in
+          let is_budget_error msg =
+            str_contains ~needle:"wave budget" msg
+          in
+          let is_timeout_or_budget_error msg =
+            is_timeout_error msg || is_budget_error msg
+          in
+          (* first_judge_run is a tuple (judge_spec, id, result, elapsed_s, timed_out).
+             We use a tuple because OCaml does not allow [type] definitions inside
+             a [let ... in] expression. *)
+          let run_first_judge ~already_timed_out (j : Fusion_policy.judge_spec)
+            : Fusion_policy.judge_spec
+              * string
+              * ( Fusion_types.judge_synthesis * Fusion_types.usage
+                , string * Fusion_types.usage )
+                result
+              * float
+              * bool
+            =
+            let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
+            let elapsed_s = now () -. t0 in
+            match
+              Fusion_policy.adjust_judge_timeout
+                ~base_s:j.jtimeout_s
+                ~max_s:j.jmax_timeout_s
+                ~factor:preset.Fusion_policy.adaptive_timeout_factor
+                ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s
+                ~elapsed_s
+                ~already_timed_out
+            with
+            | None ->
+              let msg =
+                if already_timed_out
+                then
+                  Printf.sprintf
+                    "adaptive timeout recovery for judge %s exceeded wave budget" id
+                else
+                  Printf.sprintf
+                    "judge %s skipped: would exceed wave budget (elapsed %.3f, budget %.3f)"
+                    id
+                    elapsed_s
+                    preset.Fusion_policy.judge_wave_budget_s
+              in
+              (j, id, Error (msg, Fusion_types.zero_usage), elapsed_s, false)
+            | Some timeout_s ->
+              let result =
+                Fusion_judge.run ~sw ~net ~timeout_s
+                  ?max_tokens:j.jmax_output_tokens
+                  ~judge_system_prompt:j.jsystem_prompt ~judge_model:j.jmodel
+                  ~question:req.Fusion_types.prompt ~panel ~web_tools:j.jweb_tools
+                  ~max_tool_calls:j.jmax_tool_calls ()
+              in
+              let elapsed_s = now () -. t0 in
+              let timed_out =
+                match result with
+                | Error (msg, _) -> is_timeout_error msg
+                | Ok _ -> false
+              in
+              (j, id, result, elapsed_s, timed_out)
+          in
+          let run_first_judges judges  =
+            let first_pass =
+              Eio.Fiber.List.map
+                ~max_fibers:policy.Fusion_policy.max_concurrent_judges
+                (run_first_judge ~already_timed_out:false)
+                judges
+            in
+            if preset.Fusion_policy.adaptive_timeout_factor = 1.0
+            then first_pass
+            else
+              Eio.Fiber.List.map
+                ~max_fibers:policy.Fusion_policy.max_concurrent_judges
+                (fun ((j, _, _, _, timed_out) as run) ->
+                   if timed_out
+                   then (
+                     Fusion_metrics.record_adaptive_timeout ();
+                     run_first_judge ~already_timed_out:true j)
+                   else run)
+                first_pass
+          in
+          let first_judge_nodes runs =
             List.map
-              (fun (id, r) ->
-                match r with
-                | Ok (s, u) ->
-                  Fusion_types.Synthesized
-                    { Fusion_types.role = First id; synthesis = s; usage = u }
-                | Error (msg, u) ->
-                  Fusion_types.Judge_failed
-                    { Fusion_types.failed_role = First id; error = msg; usage = u })
-              firsts
+              (fun (_, id, result, elapsed_s, timed_out) ->
+                 match result with
+                 | Ok (s, u) ->
+                   Fusion_types.Synthesized
+                     { Fusion_types.role = First id; synthesis = s; usage = u }
+                 | Error (msg, u) ->
+                   Fusion_types.Judge_failed
+                     { Fusion_types.failed_role = First id
+                     ; error = msg
+                     ; usage = u
+                     ; elapsed_s
+                     ; timed_out
+                     })
+              runs
           in
-          let successful_syntheses results =
+          let successful_syntheses runs =
+            List.filter_map
+              (fun (_, id, result, _, _) ->
+                 match result with
+                 | Ok (s, u) -> Some (id, s, u)
+                 | Error _ -> None)
+              runs
+          in
+          let successful_pair_syntheses pairs =
             List.filter_map
               (fun (id, r) ->
-                match r with Ok (s, u) -> Some (id, s, u) | Error _ -> None)
-              results
+                 match r with Ok (s, u) -> Some (id, s, u) | Error _ -> None)
+              pairs
+          in
+          let firsts_usage runs =
+            Fusion_types.sum_all_usage
+              (List.map (fun (_, id, result, _, _) -> (id, result)) runs)
+          in
+          let all_fail_error_of_runs ~fallback runs =
+            Fusion_types.all_fail_error
+              ~fallback
+              (List.map (fun (_, id, result, _, _) -> (id, result)) runs)
+          in
+          let remaining_wave_budget () =
+            preset.Fusion_policy.judge_wave_budget_s -. (now () -. t0)
+          in
+          let meta_budget_check () =
+            let remaining = remaining_wave_budget () in
+            if remaining < preset.Fusion_policy.meta_timeout_s
+            then Error ("insufficient remaining budget for meta", Fusion_types.zero_usage)
+            else Ok preset.Fusion_policy.meta_timeout_s
+          in
+          let run_fallback_judge ()  =
+            match preset.Fusion_policy.fallback_judge_model with
+            | None -> None
+            | Some model ->
+              let elapsed_s = now () -. t0 in
+              let j : Fusion_policy.judge_spec =
+                { jmodel = model
+                ; jlabel = "fallback"
+                ; jsystem_prompt = preset.Fusion_policy.judge_system_prompt
+                ; jweb_tools = judge_web_tools
+                ; jmax_tool_calls = judge_max_tool_calls
+                ; jmax_output_tokens = preset.Fusion_policy.judge_max_output_tokens
+                ; jtimeout_s = preset.Fusion_policy.judge_timeout_s
+                ; jmax_timeout_s = None
+                }
+              in
+              let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
+              (match
+                 Fusion_policy.adjust_judge_timeout
+                   ~base_s:j.jtimeout_s
+                   ~max_s:None
+                   ~factor:1.0
+                   ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s
+                   ~elapsed_s
+                   ~already_timed_out:false
+               with
+               | None ->
+                 Some
+                   ( j
+                   , id
+                   , Error
+                       ( "fallback judge skipped: insufficient remaining wave budget"
+                       , Fusion_types.zero_usage )
+                   , elapsed_s
+                   , false )
+               | Some timeout_s ->
+                 let result =
+                   Fusion_judge.run ~sw ~net ~timeout_s
+                     ?max_tokens:j.jmax_output_tokens
+                     ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+                     ~judge_model:model
+                     ~question:req.Fusion_types.prompt ~panel ~web_tools:judge_web_tools
+                     ~max_tool_calls:judge_max_tool_calls ()
+                 in
+                 let elapsed_s = now () -. t0 in
+                 let timed_out =
+                   match result with
+                   | Error (msg, _) -> is_timeout_error msg
+                   | Ok _ -> false
+                 in
+                 Some (j, id, result, elapsed_s, timed_out))
           in
           (* JOJ(judge-of-judges, RFC-0283): N개 1차 심판이 같은 패널을 독립 종합 → meta가
              reconcile. preset.judges >= 2 필요(미구성/1개는 단일 심판 위상으로 표현 가능하므로
@@ -146,65 +329,92 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             match preset.Fusion_policy.judges with
             | [] | [ _ ] ->
               ( Error
-                  ( "judge_of_judges requires >= 2 judges configured in the preset \
-                     ([[fusion.presets.<name>.judges]])"
+                  ( "judge_of_judges requires >= 2 judges configured in the preset                      ([[fusion.presets.<name>.judges]])"
                   , Fusion_types.zero_usage )
               , [] )
             | judges ->
               let firsts = run_first_judges judges in
-              (* 실행된 1차 노드 관측 — 성공/실패 모두(ok_priors가 아닌 firsts 전체).
-                 대시보드가 "N명 중 M명 실패"를 패널처럼 정직히 보이게 한다. *)
-              let first_nodes = first_judge_nodes firsts in
               let ok_priors = successful_syntheses firsts in
+              let firsts_with_fallback =
+                match ok_priors with
+                | _ :: _ -> firsts
+                | [] ->
+                  (* 전원 실패 시 모든 에러가 타임아웃/예산 에러면 fallback 심판을 한 번
+                     시도한다. *)
+                  if
+                    List.for_all
+                      (fun (_, _, result, _, _) ->
+                         match result with
+                         | Error (msg, _) -> is_timeout_or_budget_error msg
+                         | Ok _ -> false)
+                      firsts
+                  then
+                    (match run_fallback_judge () with
+                     | Some fb -> firsts @ [ fb ]
+                     | None -> firsts)
+                  else firsts
+              in
+              let first_nodes = first_judge_nodes firsts_with_fallback in
+              let ok_priors = successful_syntheses firsts_with_fallback in
               (match ok_priors with
                | [] ->
-                 (* 전원 실패 — meta할 종합 없음. [all_fail_error]가 회계를 계산한다: 모든
-                    1차 심판이 태운 토큰을 합산해 usage에 싣고(undercount 교정, 적대 리뷰
-                    #22093 all-fail; ok_priors=[]이면 firsts는 전부 Error라 합산이 모든 실패
-                    usage를 모은다), 첫 에러 메시지를 대표로 pick한다. 관측엔 1차 실패 노드만
-                    남는다(meta 노드 없음, RFC-0284). observe(#22112)의 (Error err,
-                    first_nodes) 관측 구조와 회계 축은 직교 — 헬퍼는 회계 축만 담당해 단위
-                    테스트로 검증된다. *)
                  let err =
-                   Fusion_types.all_fail_error
+                   all_fail_error_of_runs
                      ~fallback:"judge_of_judges: no judge produced a synthesis"
-                     firsts
+                     firsts_with_fallback
                  in
                  (Error err, first_nodes)
                | (_, first_s, _) :: _ ->
-                 (* usage = 실행된 모든 1차 심판(성공+실패)이 태운 토큰. 1차 일부가 실패해도
-                    meta가 성공하면 그 실패한 1차의 토큰을 잃지 않는다 — all-fail
-                    path(#22122)와 동일 원칙(적대 리뷰 #22093 B-1; all-fail은 부분집합).
-                    [sum_all_usage]가 firsts의 Ok·Error 양 분기 usage를 모두 합산한다
-                    (이전엔 ok_priors fold + sum_error_usage 두 번에 나눠 더했음 — 적대 리뷰
-                    #22134: 의도는 "모든 1차 비용"이므로 단일 합산이 더 직접적이고 테스트 가능). *)
-                 let firsts_usage = Fusion_types.sum_all_usage firsts in
-                 let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
-                 (match
-                    Fusion_judge.run_meta ~sw ~net
-                      ~timeout_s:preset.Fusion_policy.judge_timeout_s
-                      ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
-                      ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                      ~judge_model:preset.Fusion_policy.judge
-                      ~question:req.Fusion_types.prompt ~panel ~priors
-                      ~web_tools:judge_web_tools ~max_tool_calls:judge_max_tool_calls ()
-                  with
-                  | Ok (meta_s, meta_u) ->
-                    ( Ok (meta_s, Fusion_types.add_usage firsts_usage meta_u)
-                    , first_nodes
-                      @ [ Fusion_types.Synthesized
-                            { Fusion_types.role = Meta; synthesis = meta_s; usage = meta_u }
-                        ] )
-                  | Error (msg, meta_u) ->
-                    Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                      "fusion run %s meta judge failed, keeping first judge \
-                       synthesis: %s"
-                      req.Fusion_types.run_id msg;
-                    ( Ok (first_s, Fusion_types.add_usage firsts_usage meta_u)
+                 let firsts_usage = firsts_usage firsts_with_fallback in
+                 (match meta_budget_check () with
+                  | Error (msg, _) ->
+                    let elapsed_s = now () -. t0 in
+                    ( Ok (first_s, firsts_usage)
                     , first_nodes
                       @ [ Fusion_types.Judge_failed
-                            { Fusion_types.failed_role = Meta; error = msg; usage = meta_u }
-                        ] )))
+                            { Fusion_types.failed_role = Meta
+                            ; error = msg
+                            ; usage = Fusion_types.zero_usage
+                            ; elapsed_s
+                            ; timed_out = false
+                            }
+                        ] )
+                  | Ok meta_timeout_s ->
+                    let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
+                     (match
+                       Fusion_judge.run_meta ~sw ~net
+                         ~timeout_s:meta_timeout_s
+                         ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+                         ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+                         ~judge_model:preset.Fusion_policy.judge
+                         ~question:req.Fusion_types.prompt ~panel ~priors
+                         ~web_tools:judge_web_tools ~max_tool_calls:judge_max_tool_calls ()
+                     with
+                     | Ok (meta_s, meta_u) ->
+                       ( Ok (meta_s, Fusion_types.add_usage firsts_usage meta_u)
+                       , first_nodes
+                         @ [ Fusion_types.Synthesized
+                               { Fusion_types.role = Meta
+                               ; synthesis = meta_s
+                               ; usage = meta_u
+                               }
+                           ] )
+                     | Error (msg, meta_u) ->
+                       Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
+                         "fusion run %s meta judge failed, keeping first judge                           synthesis: %s"
+                         req.Fusion_types.run_id msg;
+                       let elapsed_s = now () -. t0 in
+                       let timed_out = is_timeout_error msg in
+                       ( Ok (first_s, Fusion_types.add_usage firsts_usage meta_u)
+                       , first_nodes
+                         @ [ Fusion_types.Judge_failed
+                               { Fusion_types.failed_role = Meta
+                               ; error = msg
+                               ; usage = meta_u
+                               ; elapsed_s
+                               ; timed_out
+                               }
+                           ] ))))
           in
           let run_staged_judge_of_judges () =
             let group_size = policy.Fusion_policy.staged_judge_group_size in
@@ -241,7 +451,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                 match ok_priors with
                 | [] ->
                   let err =
-                    Fusion_types.all_fail_error
+                    all_fail_error_of_runs
                       ~fallback:
                         (Printf.sprintf
                            "staged_judge_of_judges %s: no judge produced a synthesis"
@@ -250,39 +460,58 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                   in
                   ((stage_id, Error err), first_nodes)
                 | (_, first_s, _) :: _ ->
-                  let firsts_usage = Fusion_types.sum_all_usage stage_firsts in
+                  let firsts_usage = firsts_usage stage_firsts in
                   let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
-                  (match
-                     Fusion_judge.run_meta ~sw ~net
-                       ~timeout_s:preset.Fusion_policy.judge_timeout_s
-                       ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
-                       ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                       ~judge_model:preset.Fusion_policy.judge
-                       ~question:req.Fusion_types.prompt ~panel ~priors
-                       ~web_tools:judge_web_tools ~max_tool_calls:judge_max_tool_calls ()
-                   with
-                   | Ok (stage_s, stage_u) ->
-                     ( (stage_id, Ok (stage_s, Fusion_types.add_usage firsts_usage stage_u))
-                     , first_nodes
-                       @ [ Fusion_types.Synthesized
-                             { Fusion_types.role = Stage_meta stage_num
-                             ; synthesis = stage_s
-                             ; usage = stage_u
-                             }
-                         ] )
-                   | Error (msg, stage_u) ->
-                     Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                       "fusion run %s staged JOJ %s meta judge failed, keeping first \
-                        judge synthesis: %s"
-                       req.Fusion_types.run_id stage_id msg;
-                     ( (stage_id, Ok (first_s, Fusion_types.add_usage firsts_usage stage_u))
+                  (match meta_budget_check () with
+                   | Error (msg, _) ->
+                     let elapsed_s = now () -. t0 in
+                     ( (stage_id, Ok (first_s, firsts_usage))
                      , first_nodes
                        @ [ Fusion_types.Judge_failed
                              { Fusion_types.failed_role = Stage_meta stage_num
                              ; error = msg
-                             ; usage = stage_u
+                             ; usage = Fusion_types.zero_usage
+                             ; elapsed_s
+                             ; timed_out = false
                              }
-                         ] ))
+                         ] )
+                   | Ok meta_timeout_s ->
+                     (match
+                        Fusion_judge.run_meta ~sw ~net
+                          ~timeout_s:meta_timeout_s
+                          ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+                          ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+                          ~judge_model:preset.Fusion_policy.judge
+                          ~question:req.Fusion_types.prompt ~panel ~priors
+                          ~web_tools:judge_web_tools ~max_tool_calls:judge_max_tool_calls ()
+                      with
+                      | Ok (stage_s, stage_u) ->
+                        ( ( stage_id
+                          , Ok (stage_s, Fusion_types.add_usage firsts_usage stage_u) )
+                        , first_nodes
+                          @ [ Fusion_types.Synthesized
+                                { Fusion_types.role = Stage_meta stage_num
+                                ; synthesis = stage_s
+                                ; usage = stage_u
+                                }
+                            ] )
+                      | Error (msg, stage_u) ->
+                        Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
+                          "fusion run %s staged JOJ %s meta judge failed, keeping first                            judge synthesis: %s"
+                          req.Fusion_types.run_id stage_id msg;
+                        let elapsed_s = now () -. t0 in
+                        let timed_out = is_timeout_error msg in
+                        ( ( stage_id
+                          , Ok (first_s, Fusion_types.add_usage firsts_usage stage_u) )
+                        , first_nodes
+                          @ [ Fusion_types.Judge_failed
+                                { Fusion_types.failed_role = Stage_meta stage_num
+                                ; error = msg
+                                ; usage = stage_u
+                                ; elapsed_s
+                                ; timed_out
+                                }
+                            ] )))
               in
               let indexed_groups = List.mapi (fun i group -> (i + 1, group)) first_groups in
               let stage_runs =
@@ -292,7 +521,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
               in
               let stage_results = List.map fst stage_runs in
               let stage_nodes = List.concat_map snd stage_runs in
-              let ok_stages = successful_syntheses stage_results in
+              let ok_stages = successful_pair_syntheses stage_results in
               (match ok_stages with
                | [] ->
                  let err =
@@ -305,37 +534,54 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                | (_, first_stage_s, _) :: _ ->
                  let stage_usage = Fusion_types.sum_all_usage stage_results in
                  let priors = List.map (fun (id, s, _) -> (id, s)) ok_stages in
-                 (match
-                    Fusion_judge.run_meta ~sw ~net
-                      ~timeout_s:preset.Fusion_policy.judge_timeout_s
-                      ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
-                      ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                      ~judge_model:preset.Fusion_policy.judge
-                      ~question:req.Fusion_types.prompt ~panel ~priors
-                      ~web_tools:judge_web_tools ~max_tool_calls:judge_max_tool_calls ()
-                  with
-                  | Ok (final_s, final_u) ->
-                    ( Ok (final_s, Fusion_types.add_usage stage_usage final_u)
-                    , stage_nodes
-                      @ [ Fusion_types.Synthesized
-                            { Fusion_types.role = Final_meta
-                            ; synthesis = final_s
-                            ; usage = final_u
-                            }
-                        ] )
-                  | Error (msg, final_u) ->
-                    Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                      "fusion run %s staged JOJ final meta judge failed, keeping first \
-                       stage synthesis: %s"
-                      req.Fusion_types.run_id msg;
-                    ( Ok (first_stage_s, Fusion_types.add_usage stage_usage final_u)
+                 (match meta_budget_check () with
+                  | Error (msg, _) ->
+                    let elapsed_s = now () -. t0 in
+                    ( Ok (first_stage_s, stage_usage)
                     , stage_nodes
                       @ [ Fusion_types.Judge_failed
                             { Fusion_types.failed_role = Final_meta
                             ; error = msg
-                            ; usage = final_u
+                            ; usage = Fusion_types.zero_usage
+                            ; elapsed_s
+                            ; timed_out = false
                             }
-                        ] )))
+                        ] )
+                  | Ok meta_timeout_s ->
+                    (match
+                       Fusion_judge.run_meta ~sw ~net
+                         ~timeout_s:meta_timeout_s
+                         ?max_tokens:preset.Fusion_policy.judge_max_output_tokens
+                         ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+                         ~judge_model:preset.Fusion_policy.judge
+                         ~question:req.Fusion_types.prompt ~panel ~priors
+                         ~web_tools:judge_web_tools ~max_tool_calls:judge_max_tool_calls ()
+                     with
+                     | Ok (final_s, final_u) ->
+                       ( Ok (final_s, Fusion_types.add_usage stage_usage final_u)
+                       , stage_nodes
+                         @ [ Fusion_types.Synthesized
+                               { Fusion_types.role = Final_meta
+                               ; synthesis = final_s
+                               ; usage = final_u
+                               }
+                           ] )
+                     | Error (msg, final_u) ->
+                       Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
+                         "fusion run %s staged JOJ final meta judge failed, keeping first                           stage synthesis: %s"
+                         req.Fusion_types.run_id msg;
+                       let elapsed_s = now () -. t0 in
+                       let timed_out = is_timeout_error msg in
+                       ( Ok (first_stage_s, Fusion_types.add_usage stage_usage final_u)
+                       , stage_nodes
+                         @ [ Fusion_types.Judge_failed
+                               { Fusion_types.failed_role = Final_meta
+                               ; error = msg
+                               ; usage = final_u
+                               ; elapsed_s
+                               ; timed_out
+                               }
+                           ] ))))
           in
           (* 위상별 reduce. Simple은 1차 종합 그대로(현행과 byte-identical — downstream
              judge/judge_usage/emit 동일). Refine는 무조건 refine. Conditional은 1차 판정이
@@ -372,14 +618,24 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                | Error ((msg, u) as e) ->
                  ( Error e
                  , [ Fusion_types.Judge_failed
-                       { Fusion_types.failed_role = Single; error = msg; usage = u }
+                       { Fusion_types.failed_role = Single
+                       ; error = msg
+                       ; usage = u
+                       ; elapsed_s = 0.0
+                       ; timed_out = false
+                       }
                    ] ))
             | Fusion_types.Refine ->
               (match run_single_judge () with
                | Error ((msg, u) as e) ->
                  ( Error e
                  , [ Fusion_types.Judge_failed
-                       { Fusion_types.failed_role = Single; error = msg; usage = u }
+                       { Fusion_types.failed_role = Single
+                       ; error = msg
+                       ; usage = u
+                       ; elapsed_s = 0.0
+                       ; timed_out = false
+                       }
                    ] )
                | Ok pair -> refine_over pair)
             | Fusion_types.Conditional ->
@@ -387,7 +643,12 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                | Error ((msg, u) as e) ->
                  ( Error e
                  , [ Fusion_types.Judge_failed
-                       { Fusion_types.failed_role = Single; error = msg; usage = u }
+                       { Fusion_types.failed_role = Single
+                       ; error = msg
+                       ; usage = u
+                       ; elapsed_s = 0.0
+                       ; timed_out = false
+                       }
                    ] )
                | Ok ((s1, u1) as pair) ->
                  if Fusion_types.decision_warrants_escalation s1.Fusion_types.decision

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -17,18 +17,11 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
   | Fusion_types.Allow req ->
     (match Fusion_policy.find_preset policy req.Fusion_types.preset with
      | None ->
-       (* 게이트가 preset 존재를 이미 검증했으므로 도달 불가. 방어적으로 Denied. *)
        Fusion_metrics.record_invocation ~topology `Denied;
        Denied (Fusion_types.Preset_unknown req.Fusion_types.preset)
      | Some vp ->
-          (* RFC-0280: find_preset가 검증된 preset을 돌려준다 — invariant 재검증 불필요.
-             raw preset으로 coerce해 필드를 읽는다(read-only). *)
           let preset = Fusion_policy.Validated_preset.preset vp in
-          (* 프롬프트·타임아웃은 preset(=config)에서. 코드 default 없음 — config 로드
-             시 Missing_prompt로 fail-fast 검증됨. *)
           let groups = preset.Fusion_policy.panels in
-          (* req.web_tools를 각 그룹에 fold-in: effective group web_tools = req || group.
-             Fusion_panel.run은 순수하게 그룹 설정만 신뢰한다. *)
           let effective_groups =
             List.map
               (fun (g : Fusion_policy.panel_group) ->
@@ -43,16 +36,11 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
               ~outer_timeout_s:(Fusion_policy.panel_outer_timeout_of groups)
               ~groups:effective_groups ~prompt:req.Fusion_types.prompt ()
           in
-          (* 심판은 preset당 1개이므로 web_tools/max_tool_calls를 그룹들에서 derive한다 —
-             단일 그룹(legacy desugar)이면 오늘과 byte-identical(req||group, 그룹 값). *)
           let judge_web_tools =
             Fusion_policy.judge_web_tools_of ~req_web_tools:req.Fusion_types.web_tools
               groups
           in
           let judge_max_tool_calls = Fusion_policy.judge_tool_budget_of groups in
-          (* 단일 심판 thunk — Simple/Refine/Conditional이 쓰는 preset.judge 1회 실행.
-             thunk라 JOJ 위상은 이를 호출하지 않는다(JOJ는 자기 judges로 fan-out하므로
-             단일 심판 호출이 낭비/오답). 각 분기에서 최대 1회 호출. *)
           let run_single_judge () =
             Fusion_judge.run ~sw ~net
               ~timeout_s:preset.Fusion_policy.judge_timeout_s
@@ -62,13 +50,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
               ~question:req.Fusion_types.prompt ~panel ~web_tools:judge_web_tools
               ~max_tool_calls:judge_max_tool_calls ()
           in
-          (* refine 헬퍼: 1차 종합 (s1,u1)을 2차 심판이 재검토하고 두 usage를 합산한다.
-             canonical result와 실행 노드 관측([judge_outcome list], RFC-0284)을 함께
-             만든다 — canonical은 downstream(chat 결론/wake/board headline)이 쓰고, 노드는
-             대시보드가 무엇이 실행됐나를 렌더한다. 2차 실패면 1차 종합으로 graceful
-             degrade(canonical=s1)하되 실패 노드도 관측에 정직히 남긴다(silent 아님: warn).
-             Refine(무조건)와 Conditional(Insufficient일 때만)이 공유한다 — 같은 변환을
-             두 번 짜지 않는다(N-of-M 회피). *)
           let refine_over (s1, u1) =
             let single_node =
               Fusion_types.Synthesized
@@ -104,221 +85,63 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                     }
                 ] )
           in
-          (* Adaptive timeout: wave-wide wall-clock budget and per-judge extension.
-             We snapshot t0 before the first-judge wave; each fiber reads the clock
-             just before/after its judge call. Masc_eio_env.clock is optional but
-             fusion orchestration strictly requires a wall clock — both to size
-             runtime timeout windows for external judge calls AND to record per-node
-             elapsed_s. Per Masc_eio_env.mli, a component that strictly requires a
-             clock should match on [Some] and fail loudly rather than substitute a
-             blocking wall-clock fallback inside an Eio fiber. Production
-             callers (server_runtime_bootstrap, bin executables) initialise Masc_eio_env with
-             ~clock. *)
           let env = Masc_eio_env.get () in
-          let now () =
+          let now_opt () =
             match env.clock with
-            | Some c -> Eio.Time.now c
-            | None ->
-              failwith
-                "Fusion_orchestrator: adaptive timeout requires a wall clock — initialise Masc_eio_env with ~clock"
+            | Some c -> Some (Eio.Time.now c)
+            | None -> None
           in
-          let t0 = now () in
-          (* first_judge_run is a tuple (judge_spec, id, result, elapsed_s, timed_out).
-             We use a tuple because OCaml does not allow [type] definitions inside
-             a [let ... in] expression. *)
-          let run_first_judge ~already_timed_out (j : Fusion_policy.judge_spec)
-            : Fusion_policy.judge_spec
-              * string
-              * ( Fusion_types.judge_synthesis * Fusion_types.usage
-                , Fusion_types.judge_failure * Fusion_types.usage )
-                result
-              * float
-              * bool
-            =
-            let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
-            let elapsed_s = now () -. t0 in
-            match
-              Fusion_policy.adjust_judge_timeout
-                ~base_s:j.jtimeout_s
-                ~max_s:j.jmax_timeout_s
-                ~factor:preset.Fusion_policy.adaptive_timeout_factor
-                ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s
-                ~elapsed_s
-                ~already_timed_out
-            with
-            | None ->
-              (* wave budget 초과로 심판 실행 전 SKIP. typed [Fusion_types.Budget_exceeded]로 표현하여
-                 fallback 트리거가 string substring이 아닌 variant match로 분류한다. *)
-              let detail =
-                if already_timed_out
-                then
-                  Printf.sprintf
-                    "adaptive timeout recovery for judge %s exceeded wave budget" id
-                else
-                  Printf.sprintf
-                    "judge %s skipped: would exceed wave budget (elapsed %.3f, budget %.3f)"
-                    id
-                    elapsed_s
-                    preset.Fusion_policy.judge_wave_budget_s
-              in
-              ( j
-              , id
-              , Error (Fusion_types.Budget_exceeded detail, Fusion_types.zero_usage)
-              , elapsed_s
-              , false )
-            | Some timeout_s ->
-              let result =
-                Fusion_judge.run ~sw ~net ~timeout_s
-                  ?max_tokens:j.jmax_output_tokens
-                  ~judge_system_prompt:j.jsystem_prompt ~judge_model:j.jmodel
-                  ~question:req.Fusion_types.prompt ~panel ~web_tools:j.jweb_tools
-                  ~max_tool_calls:j.jmax_tool_calls ()
-              in
-              let elapsed_s = now () -. t0 in
-              let timed_out =
-                match result with
-                | Error (f, _) -> Fusion_types.judge_failure_is_timeout f
-                | Ok _ -> false
-              in
-              (j, id, result, elapsed_s, timed_out)
+          let clock =
+            Fusion_orchestrator_judge_wave.make_clock
+              ~now_opt
+              ~missing_clock_failure:
+                (Fusion_types.Internal_error
+                   "fusion adaptive timeout requires a wall clock; initialise Masc_eio_env with ~clock")
           in
-          let run_first_judges judges  =
-            let first_pass =
-              Eio.Fiber.List.map
-                ~max_fibers:policy.Fusion_policy.max_concurrent_judges
-                (run_first_judge ~already_timed_out:false)
-                judges
-            in
-            if not (Fusion_policy.adaptive_timeout_enabled preset)
-            then first_pass
-            else
-              Eio.Fiber.List.map
-                ~max_fibers:policy.Fusion_policy.max_concurrent_judges
-                (fun ((j, _, _, _, timed_out) as run) ->
-                   if timed_out
-                   then (
-                     Fusion_metrics.record_adaptive_timeout ();
-                     run_first_judge ~already_timed_out:true j)
-                   else run)
-                first_pass
+          let elapsed_since_t0 () =
+            Fusion_orchestrator_judge_wave.elapsed_since_t0 clock
           in
-          let first_judge_nodes runs =
-            List.map
-              (fun (_, id, result, elapsed_s, _timed_out) ->
-                 match result with
-                 | Ok (s, u) ->
-                   Fusion_types.Synthesized
-                     { Fusion_types.role = First id; synthesis = s; usage = u }
-                 | Error (failure, u) ->
-                   Fusion_types.Judge_failed
-                     { Fusion_types.failed_role = First id
-                     ; failure
-                     ; usage = u
-                     ; elapsed_s
-                     })
-              runs
+          let run_first_judges judges =
+            Fusion_orchestrator_judge_wave.run_first_judges
+              ~sw
+              ~net
+              ~max_concurrent_judges:policy.Fusion_policy.max_concurrent_judges
+              ~preset
+              ~panel
+              ~question:req.Fusion_types.prompt
+              ~clock
+              ~judge_web_tools
+              ~judge_max_tool_calls
+              judges
           in
-          let successful_syntheses runs =
-            List.filter_map
-              (fun (_, id, result, _, _) ->
-                 match result with
-                 | Ok (s, u) -> Some (id, s, u)
-                 | Error _ -> None)
-              runs
+          let first_judge_nodes =
+            Fusion_orchestrator_judge_wave.first_judge_nodes
           in
-          let successful_pair_syntheses pairs =
-            List.filter_map
-              (fun (id, r) ->
-                 match r with Ok (s, u) -> Some (id, s, u) | Error _ -> None)
-              pairs
+          let successful_syntheses =
+            Fusion_orchestrator_judge_wave.successful_syntheses
           in
-          let firsts_usage runs =
-            Fusion_types.sum_all_usage
-              (List.map (fun (_, id, result, _, _) -> (id, result)) runs)
+          let successful_pair_syntheses =
+            Fusion_orchestrator_judge_wave.successful_pair_syntheses
           in
-          let all_fail_error_of_runs ~fallback runs =
-            Fusion_types.all_fail_error
-              ~fallback
-              (List.map (fun (_, id, result, _, _) -> (id, result)) runs)
-          in
-          let remaining_wave_budget () =
-            preset.Fusion_policy.judge_wave_budget_s -. (now () -. t0)
+          let firsts_usage = Fusion_orchestrator_judge_wave.firsts_usage in
+          let all_fail_error_of_runs =
+            Fusion_orchestrator_judge_wave.all_fail_error_of_runs
           in
           let meta_budget_check () =
-            if
-              not
-                (Fusion_policy.judge_wave_budget_enabled
-                   ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s)
-            then Ok preset.Fusion_policy.meta_timeout_s
-            else if remaining_wave_budget () < preset.Fusion_policy.meta_timeout_s
-            then
-              Error
-                ( Fusion_types.Budget_exceeded "insufficient remaining budget for meta"
-                , Fusion_types.zero_usage )
-            else Ok preset.Fusion_policy.meta_timeout_s
+            Fusion_orchestrator_judge_wave.meta_budget_check ~preset clock
           in
-          let run_fallback_judge ()  =
-            match preset.Fusion_policy.fallback_judge_model with
-            | None -> None
-            | Some model ->
-              let elapsed_s = now () -. t0 in
-              let j : Fusion_policy.judge_spec =
-                { jmodel = model
-                ; jlabel = "fallback"
-                ; jsystem_prompt = preset.Fusion_policy.judge_system_prompt
-                ; jweb_tools = judge_web_tools
-                ; jmax_tool_calls = judge_max_tool_calls
-                ; jmax_output_tokens = preset.Fusion_policy.judge_max_output_tokens
-                ; jtimeout_s = preset.Fusion_policy.judge_timeout_s
-                ; jmax_timeout_s = None
-                }
-              in
-              let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
-              (match
-                 Fusion_policy.adjust_judge_timeout
-                   ~base_s:j.jtimeout_s
-                   ~max_s:None
-                   ~factor:1.0
-                   ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s
-                   ~elapsed_s
-                   ~already_timed_out:false
-               with
-               | None ->
-                 Some
-                   ( j
-                   , id
-                   , Error
-                       ( Fusion_types.Budget_exceeded
-                           "fallback judge skipped: insufficient remaining wave budget"
-                       , Fusion_types.zero_usage )
-                   , elapsed_s
-                   , false )
-               | Some timeout_s ->
-                 let result =
-                   Fusion_judge.run ~sw ~net ~timeout_s
-                     ?max_tokens:j.jmax_output_tokens
-                     ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
-                     ~judge_model:model
-                     ~question:req.Fusion_types.prompt ~panel ~web_tools:judge_web_tools
-                     ~max_tool_calls:judge_max_tool_calls ()
-                 in
-                 let elapsed_s = now () -. t0 in
-                 let timed_out =
-                   match result with
-                   | Error (f, _) -> Fusion_types.judge_failure_is_timeout f
-                   | Ok _ -> false
-                 in
-                 Some (j, id, result, elapsed_s, timed_out))
+          let run_fallback_judge () =
+            Fusion_orchestrator_judge_wave.run_fallback_judge
+              ~sw
+              ~net
+              ~preset
+              ~panel
+              ~question:req.Fusion_types.prompt
+              ~clock
+              ~judge_web_tools
+              ~judge_max_tool_calls
+              ()
           in
-          (* JOJ(judge-of-judges, RFC-0283): N개 1차 심판이 같은 패널을 독립 종합 → meta가
-             reconcile. preset.judges >= 2 필요(미구성/1개는 단일 심판 위상으로 표현 가능하므로
-             런타임 에러 = fail-closed). 1차는 [Eio.Fiber.List.map ~max_fibers]로 병렬(패널
-             fan-out과 동일 fault-isolation idiom — Fusion_judge.run이 per-judge 실패를 Error로
-             격리하므로 한 심판 실패가 나머지를 안 죽인다). 성공 종합만 meta 입력, 전원 실패면
-             첫 에러 전파. usage = 성공 1차 전부 + meta 합산. meta 실패 시 1차 첫 성공으로
-             graceful degrade(RFC-0283 §5.1, warn) — meta가 태운 토큰(meta_u)도 합산해
-             버리지 않는다(#22087 §1과 동일 원칙). 에러는 (string * usage) 동반: 토큰 소비 전
-             구성 실패는 [zero_usage]를 싣는다. *)
           let run_judge_of_judges () =
             match preset.Fusion_policy.judges with
             | [] | [ _ ] ->
@@ -334,8 +157,6 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                 match ok_priors with
                 | _ :: _ -> firsts
                 | [] ->
-                  (* 전원 실패 시 모든 에러가 타임아웃/예산 에러면 fallback 심판을 한 번
-                     시도한다. *)
                   if
                     List.for_all
                       (fun (_, _, result, _, _) ->
@@ -365,7 +186,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  let firsts_usage = firsts_usage firsts_with_fallback in
                  (match meta_budget_check () with
                   | Error (failure, _) ->
-                    let elapsed_s = now () -. t0 in
+                    let elapsed_s = elapsed_since_t0 () in
                     ( Ok (first_s, firsts_usage)
                     , first_nodes
                       @ [ Fusion_types.Judge_failed
@@ -401,7 +222,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                           synthesis: %s"
                          req.Fusion_types.run_id
                          (Fusion_types.judge_failure_text failure);
-                       let elapsed_s = now () -. t0 in
+                       let elapsed_s = elapsed_since_t0 () in
                        ( Ok (first_s, Fusion_types.add_usage firsts_usage meta_u)
                        , first_nodes
                          @ [ Fusion_types.Judge_failed
@@ -461,7 +282,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                   let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
                   (match meta_budget_check () with
                    | Error (failure, _) ->
-                     let elapsed_s = now () -. t0 in
+                     let elapsed_s = elapsed_since_t0 () in
                      ( (stage_id, Ok (first_s, firsts_usage))
                      , first_nodes
                        @ [ Fusion_types.Judge_failed
@@ -496,7 +317,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                           "fusion run %s staged JOJ %s meta judge failed, keeping first judge synthesis: %s"
                           req.Fusion_types.run_id stage_id
                           (Fusion_types.judge_failure_text failure);
-                        let elapsed_s = now () -. t0 in
+                        let elapsed_s = elapsed_since_t0 () in
                         ( ( stage_id
                           , Ok (first_s, Fusion_types.add_usage firsts_usage stage_u) )
                         , first_nodes
@@ -531,7 +352,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  let priors = List.map (fun (id, s, _) -> (id, s)) ok_stages in
                  (match meta_budget_check () with
                   | Error (failure, _) ->
-                    let elapsed_s = now () -. t0 in
+                    let elapsed_s = elapsed_since_t0 () in
                     ( Ok (first_stage_s, stage_usage)
                     , stage_nodes
                       @ [ Fusion_types.Judge_failed
@@ -565,7 +386,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                          "fusion run %s staged JOJ final meta judge failed, keeping first stage synthesis: %s"
                          req.Fusion_types.run_id
                          (Fusion_types.judge_failure_text failure);
-                       let elapsed_s = now () -. t0 in
+                       let elapsed_s = elapsed_since_t0 () in
                        ( Ok (first_stage_s, Fusion_types.add_usage stage_usage final_u)
                        , stage_nodes
                          @ [ Fusion_types.Judge_failed
@@ -576,27 +397,12 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                                }
                            ] ))))
           in
-          (* 위상별 reduce. Simple은 1차 종합 그대로(현행과 byte-identical — downstream
-             judge/judge_usage/emit 동일). Refine는 무조건 refine. Conditional은 1차 판정이
-             [Insufficient](애매)일 때만 refine, 그 외엔 1차 종합 그대로(= Simple). JOJ는 N개
-             1차 심판 + meta. 1차 심판 실패는 단일-심판 위상에선 그대로 전파(refine할 종합이
-             없음 = Simple과 동일 에러 의미). topology·decision 둘 다 닫힌 합 exhaustive match라
-             새 변형 추가 시 컴파일 에러로 누락을 강제한다 — catch-all 없음. *)
-          (* judge_full = canonical (downstream 종합/usage), judge_nodes = 실행 관측
-             ([judge_outcome list], RFC-0284 → sink judges:[]). 각 arm이 둘을 hand-write한다
-             — 콤비네이터/plan-tree 없음(닫힌 enum dispatch 유지, staged JOJ도 named arm +
-             작은 helper로 표현). 단일-심판 노드는 [Single], 1차 심판 실패는 단일-심판
-             위상에선 그대로 전파(Simple과 동일 에러 의미)하고 실패 노드 한 건만 남긴다. *)
           let judge_full, judge_nodes =
             match
               Fusion_types.judge_skip_reason
                 ~min_answered:preset.Fusion_policy.min_answered panel
             with
             | Some reason ->
-              (* Quorum-not-met — 종합할 답이 preset 기준보다 적다. judge를 얇거나 빈
-                 <panel_answers>로 호출하면 근거 부족 종합을 정상처럼 표출한다. judge
-                 미실행 + 명시적 실패로 완료한다(기존 judge-error 표시 경로 재사용).
-                 judge_nodes=[] — 실행된 심판 없음(RFC-0284). *)
               let reason = Fusion_types.render_skip_reason reason in
               (Error (Fusion_types.Internal_error reason, Fusion_types.zero_usage), [])
             | None ->
@@ -651,17 +457,12 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             | Fusion_types.Judge_of_judges -> run_judge_of_judges ()
             | Fusion_types.Staged_judge_of_judges -> run_staged_judge_of_judges ()
           in
-          (* 심판 종합과 토큰 usage를 분리: outcome.judge는 synthesis만(소비자 호환),
-             usage는 sink 비용 회계로(RFC §10 패널N+심판M). 심판 실패 시에도 소비한
-             토큰은 회계한다(run_composed가 에러에 usage를 동반 — 응답 받은 뒤 실패면
-             소비분, 그 전 실패면 zero). *)
           let judge = judge_full |> Result.map fst |> Result.map_error fst in
           let judge_usage =
             match judge_full with
             | Ok (_, u) -> u
             | Error (_, u) -> u
           in
-          (* RFC-0284 observation record → OTel counters. *)
           List.iter (Fusion_metrics.record_judge_execution ~topology) judge_nodes;
           (match
              Fusion_sink.emit ~base_dir ~keeper:req.Fusion_types.keeper

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -6,7 +6,7 @@ type outcome =
   | Sink_failed of string
   | Completed of
       { panel : Fusion_types.panel_outcome list
-      ; judge : (Fusion_types.judge_synthesis, string) result
+      ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
 let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
@@ -89,59 +89,40 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                 ; Fusion_types.Synthesized
                     { Fusion_types.role = Refine_pass; synthesis = s2; usage = u2 }
                 ] )
-            | Error (msg, u2) ->
+            | Error (failure, u2) ->
               Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
                 "fusion run %s refine judge failed, keeping first synthesis: %s"
-                req.Fusion_types.run_id msg;
+                req.Fusion_types.run_id
+                (Fusion_types.judge_failure_text failure);
               ( Ok (s1, Fusion_types.add_usage u1 u2)
               , [ single_node
                 ; Fusion_types.Judge_failed
                     { Fusion_types.failed_role = Refine_pass
-                    ; error = msg
+                    ; failure
                     ; usage = u2
                     ; elapsed_s = 0.0
-                    ; timed_out = false
                     }
                 ] )
           in
           (* Adaptive timeout: wave-wide wall-clock budget and per-judge extension.
              We snapshot t0 before the first-judge wave; each fiber reads the clock
-             just before/after its judge call.  Masc_eio_env.clock is optional; tests
-             and stdio callers may initialise without one, so we fall back to
-             Unix.gettimeofday rather than fail closed. NDT-OK: the wall clock only
-             sizes runtime timeout windows for external judge calls. *)
+             just before/after its judge call. Masc_eio_env.clock is optional but
+             fusion orchestration strictly requires a wall clock — both to size
+             runtime timeout windows for external judge calls AND to record per-node
+             elapsed_s. Per Masc_eio_env.mli, a component that strictly requires a
+             clock should match on [Some] and fail loudly rather than substitute a
+             blocking wall-clock fallback inside an Eio fiber. Production
+             callers (server_runtime_bootstrap, bin executables) initialise Masc_eio_env with
+             ~clock. *)
           let env = Masc_eio_env.get () in
           let now () =
             match env.clock with
             | Some c -> Eio.Time.now c
             | None ->
-              (* NDT-OK: boundary fallback when no Eio clock is installed. *)
-              Unix.gettimeofday ()
+              failwith
+                "Fusion_orchestrator: adaptive timeout requires a wall clock — initialise Masc_eio_env with ~clock"
           in
           let t0 = now () in
-          let str_contains ~needle haystack =
-            let nl = String.length needle and hl = String.length haystack in
-            if nl = 0
-            then true
-            else
-              let rec scan i =
-                if i + nl > hl
-                then false
-                else if String.equal (String.sub haystack i nl) needle
-                then true
-                else scan (i + 1)
-              in
-              scan 0
-          in
-          let is_timeout_error msg =
-            str_contains ~needle:"Execution timed out after" msg
-          in
-          let is_budget_error msg =
-            str_contains ~needle:"wave budget" msg
-          in
-          let is_timeout_or_budget_error msg =
-            is_timeout_error msg || is_budget_error msg
-          in
           (* first_judge_run is a tuple (judge_spec, id, result, elapsed_s, timed_out).
              We use a tuple because OCaml does not allow [type] definitions inside
              a [let ... in] expression. *)
@@ -149,7 +130,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             : Fusion_policy.judge_spec
               * string
               * ( Fusion_types.judge_synthesis * Fusion_types.usage
-                , string * Fusion_types.usage )
+                , Fusion_types.judge_failure * Fusion_types.usage )
                 result
               * float
               * bool
@@ -166,7 +147,9 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                 ~already_timed_out
             with
             | None ->
-              let msg =
+              (* wave budget 초과로 심판 실행 전 SKIP. typed [Fusion_types.Budget_exceeded]로 표현하여
+                 fallback 트리거가 string substring이 아닌 variant match로 분류한다. *)
+              let detail =
                 if already_timed_out
                 then
                   Printf.sprintf
@@ -178,7 +161,11 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                     elapsed_s
                     preset.Fusion_policy.judge_wave_budget_s
               in
-              (j, id, Error (msg, Fusion_types.zero_usage), elapsed_s, false)
+              ( j
+              , id
+              , Error (Fusion_types.Budget_exceeded detail, Fusion_types.zero_usage)
+              , elapsed_s
+              , false )
             | Some timeout_s ->
               let result =
                 Fusion_judge.run ~sw ~net ~timeout_s
@@ -190,7 +177,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
               let elapsed_s = now () -. t0 in
               let timed_out =
                 match result with
-                | Error (msg, _) -> is_timeout_error msg
+                | Error (f, _) -> Fusion_types.judge_failure_is_timeout f
                 | Ok _ -> false
               in
               (j, id, result, elapsed_s, timed_out)
@@ -202,7 +189,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                 (run_first_judge ~already_timed_out:false)
                 judges
             in
-            if preset.Fusion_policy.adaptive_timeout_factor = 1.0
+            if not (Fusion_policy.adaptive_timeout_enabled preset)
             then first_pass
             else
               Eio.Fiber.List.map
@@ -217,18 +204,17 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           in
           let first_judge_nodes runs =
             List.map
-              (fun (_, id, result, elapsed_s, timed_out) ->
+              (fun (_, id, result, elapsed_s, _timed_out) ->
                  match result with
                  | Ok (s, u) ->
                    Fusion_types.Synthesized
                      { Fusion_types.role = First id; synthesis = s; usage = u }
-                 | Error (msg, u) ->
+                 | Error (failure, u) ->
                    Fusion_types.Judge_failed
                      { Fusion_types.failed_role = First id
-                     ; error = msg
+                     ; failure
                      ; usage = u
                      ; elapsed_s
-                     ; timed_out
                      })
               runs
           in
@@ -261,7 +247,10 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           let meta_budget_check () =
             let remaining = remaining_wave_budget () in
             if remaining < preset.Fusion_policy.meta_timeout_s
-            then Error ("insufficient remaining budget for meta", Fusion_types.zero_usage)
+            then
+              Error
+                ( Fusion_types.Budget_exceeded "insufficient remaining budget for meta"
+                , Fusion_types.zero_usage )
             else Ok preset.Fusion_policy.meta_timeout_s
           in
           let run_fallback_judge ()  =
@@ -295,7 +284,8 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                    ( j
                    , id
                    , Error
-                       ( "fallback judge skipped: insufficient remaining wave budget"
+                       ( Fusion_types.Budget_exceeded
+                           "fallback judge skipped: insufficient remaining wave budget"
                        , Fusion_types.zero_usage )
                    , elapsed_s
                    , false )
@@ -311,7 +301,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  let elapsed_s = now () -. t0 in
                  let timed_out =
                    match result with
-                   | Error (msg, _) -> is_timeout_error msg
+                   | Error (f, _) -> Fusion_types.judge_failure_is_timeout f
                    | Ok _ -> false
                  in
                  Some (j, id, result, elapsed_s, timed_out))
@@ -329,7 +319,8 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             match preset.Fusion_policy.judges with
             | [] | [ _ ] ->
               ( Error
-                  ( "judge_of_judges requires >= 2 judges configured in the preset                      ([[fusion.presets.<name>.judges]])"
+                  ( Fusion_types.Internal_error
+                      "judge_of_judges requires >= 2 judges configured in the preset ([[fusion.presets.<name>.judges]])"
                   , Fusion_types.zero_usage )
               , [] )
             | judges ->
@@ -345,7 +336,8 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                     List.for_all
                       (fun (_, _, result, _, _) ->
                          match result with
-                         | Error (msg, _) -> is_timeout_or_budget_error msg
+                         | Error (f, _) ->
+                           Fusion_types.judge_failure_is_timeout_or_budget f
                          | Ok _ -> false)
                       firsts
                   then
@@ -360,23 +352,23 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                | [] ->
                  let err =
                    all_fail_error_of_runs
-                     ~fallback:"judge_of_judges: no judge produced a synthesis"
+                     ~fallback:
+                       (Fusion_types.Internal_error "judge_of_judges: no judge produced a synthesis")
                      firsts_with_fallback
                  in
                  (Error err, first_nodes)
                | (_, first_s, _) :: _ ->
                  let firsts_usage = firsts_usage firsts_with_fallback in
                  (match meta_budget_check () with
-                  | Error (msg, _) ->
+                  | Error (failure, _) ->
                     let elapsed_s = now () -. t0 in
                     ( Ok (first_s, firsts_usage)
                     , first_nodes
                       @ [ Fusion_types.Judge_failed
                             { Fusion_types.failed_role = Meta
-                            ; error = msg
+                            ; failure
                             ; usage = Fusion_types.zero_usage
                             ; elapsed_s
-                            ; timed_out = false
                             }
                         ] )
                   | Ok meta_timeout_s ->
@@ -399,20 +391,20 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                                ; usage = meta_u
                                }
                            ] )
-                     | Error (msg, meta_u) ->
+                     | Error (failure, meta_u) ->
                        Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                         "fusion run %s meta judge failed, keeping first judge                           synthesis: %s"
-                         req.Fusion_types.run_id msg;
+                         "fusion run %s meta judge failed, keeping first judge \
+                          synthesis: %s"
+                         req.Fusion_types.run_id
+                         (Fusion_types.judge_failure_text failure);
                        let elapsed_s = now () -. t0 in
-                       let timed_out = is_timeout_error msg in
                        ( Ok (first_s, Fusion_types.add_usage firsts_usage meta_u)
                        , first_nodes
                          @ [ Fusion_types.Judge_failed
                                { Fusion_types.failed_role = Meta
-                               ; error = msg
+                               ; failure
                                ; usage = meta_u
                                ; elapsed_s
-                               ; timed_out
                                }
                            ] ))))
           in
@@ -423,7 +415,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             with
             | Error e ->
               ( Error
-                  ( Fusion_policy.staged_judge_group_error_message e
+                  ( Fusion_types.Internal_error (Fusion_policy.staged_judge_group_error_message e)
                   , Fusion_types.zero_usage )
               , [] )
             | Ok _groups ->
@@ -453,9 +445,10 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                   let err =
                     all_fail_error_of_runs
                       ~fallback:
-                        (Printf.sprintf
-                           "staged_judge_of_judges %s: no judge produced a synthesis"
-                           stage_id)
+                        (Fusion_types.Internal_error
+                           (Printf.sprintf
+                              "staged_judge_of_judges %s: no judge produced a synthesis"
+                              stage_id))
                       stage_firsts
                   in
                   ((stage_id, Error err), first_nodes)
@@ -463,16 +456,15 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                   let firsts_usage = firsts_usage stage_firsts in
                   let priors = List.map (fun (id, s, _) -> (id, s)) ok_priors in
                   (match meta_budget_check () with
-                   | Error (msg, _) ->
+                   | Error (failure, _) ->
                      let elapsed_s = now () -. t0 in
                      ( (stage_id, Ok (first_s, firsts_usage))
                      , first_nodes
                        @ [ Fusion_types.Judge_failed
                              { Fusion_types.failed_role = Stage_meta stage_num
-                             ; error = msg
+                             ; failure
                              ; usage = Fusion_types.zero_usage
                              ; elapsed_s
-                             ; timed_out = false
                              }
                          ] )
                    | Ok meta_timeout_s ->
@@ -495,21 +487,20 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                                 ; usage = stage_u
                                 }
                             ] )
-                      | Error (msg, stage_u) ->
+                      | Error (failure, stage_u) ->
                         Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                          "fusion run %s staged JOJ %s meta judge failed, keeping first                            judge synthesis: %s"
-                          req.Fusion_types.run_id stage_id msg;
+                          "fusion run %s staged JOJ %s meta judge failed, keeping first judge synthesis: %s"
+                          req.Fusion_types.run_id stage_id
+                          (Fusion_types.judge_failure_text failure);
                         let elapsed_s = now () -. t0 in
-                        let timed_out = is_timeout_error msg in
                         ( ( stage_id
                           , Ok (first_s, Fusion_types.add_usage firsts_usage stage_u) )
                         , first_nodes
                           @ [ Fusion_types.Judge_failed
                                 { Fusion_types.failed_role = Stage_meta stage_num
-                                ; error = msg
+                                ; failure
                                 ; usage = stage_u
                                 ; elapsed_s
-                                ; timed_out
                                 }
                             ] )))
               in
@@ -527,7 +518,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  let err =
                    Fusion_types.all_fail_error
                      ~fallback:
-                       "staged_judge_of_judges: no stage produced a synthesis"
+                       (Fusion_types.Internal_error "staged_judge_of_judges: no stage produced a synthesis")
                      stage_results
                  in
                  (Error err, stage_nodes)
@@ -535,16 +526,15 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  let stage_usage = Fusion_types.sum_all_usage stage_results in
                  let priors = List.map (fun (id, s, _) -> (id, s)) ok_stages in
                  (match meta_budget_check () with
-                  | Error (msg, _) ->
+                  | Error (failure, _) ->
                     let elapsed_s = now () -. t0 in
                     ( Ok (first_stage_s, stage_usage)
                     , stage_nodes
                       @ [ Fusion_types.Judge_failed
                             { Fusion_types.failed_role = Final_meta
-                            ; error = msg
+                            ; failure
                             ; usage = Fusion_types.zero_usage
                             ; elapsed_s
-                            ; timed_out = false
                             }
                         ] )
                   | Ok meta_timeout_s ->
@@ -566,20 +556,19 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                                ; usage = final_u
                                }
                            ] )
-                     | Error (msg, final_u) ->
+                     | Error (failure, final_u) ->
                        Log.Keeper.warn ~keeper_name:req.Fusion_types.keeper
-                         "fusion run %s staged JOJ final meta judge failed, keeping first                           stage synthesis: %s"
-                         req.Fusion_types.run_id msg;
+                         "fusion run %s staged JOJ final meta judge failed, keeping first stage synthesis: %s"
+                         req.Fusion_types.run_id
+                         (Fusion_types.judge_failure_text failure);
                        let elapsed_s = now () -. t0 in
-                       let timed_out = is_timeout_error msg in
                        ( Ok (first_stage_s, Fusion_types.add_usage stage_usage final_u)
                        , stage_nodes
                          @ [ Fusion_types.Judge_failed
                                { Fusion_types.failed_role = Final_meta
-                               ; error = msg
+                               ; failure
                                ; usage = final_u
                                ; elapsed_s
-                               ; timed_out
                                }
                            ] ))))
           in
@@ -605,7 +594,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  미실행 + 명시적 실패로 완료한다(기존 judge-error 표시 경로 재사용).
                  judge_nodes=[] — 실행된 심판 없음(RFC-0284). *)
               let reason = Fusion_types.render_skip_reason reason in
-              (Error (reason, Fusion_types.zero_usage), [])
+              (Error (Fusion_types.Internal_error reason, Fusion_types.zero_usage), [])
             | None ->
             match topology with
             | Fusion_types.Simple ->
@@ -615,39 +604,36 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                  , [ Fusion_types.Synthesized
                        { Fusion_types.role = Single; synthesis = s; usage = u }
                    ] )
-               | Error ((msg, u) as e) ->
+               | Error ((failure, u) as e) ->
                  ( Error e
                  , [ Fusion_types.Judge_failed
                        { Fusion_types.failed_role = Single
-                       ; error = msg
+                       ; failure
                        ; usage = u
                        ; elapsed_s = 0.0
-                       ; timed_out = false
                        }
                    ] ))
             | Fusion_types.Refine ->
               (match run_single_judge () with
-               | Error ((msg, u) as e) ->
+               | Error ((failure, u) as e) ->
                  ( Error e
                  , [ Fusion_types.Judge_failed
                        { Fusion_types.failed_role = Single
-                       ; error = msg
+                       ; failure
                        ; usage = u
                        ; elapsed_s = 0.0
-                       ; timed_out = false
                        }
                    ] )
                | Ok pair -> refine_over pair)
             | Fusion_types.Conditional ->
               (match run_single_judge () with
-               | Error ((msg, u) as e) ->
+               | Error ((failure, u) as e) ->
                  ( Error e
                  , [ Fusion_types.Judge_failed
                        { Fusion_types.failed_role = Single
-                       ; error = msg
+                       ; failure
                        ; usage = u
                        ; elapsed_s = 0.0
-                       ; timed_out = false
                        }
                    ] )
                | Ok ((s1, u1) as pair) ->

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -86,11 +86,7 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                 ] )
           in
           let env = Masc_eio_env.get () in
-          let now_opt () =
-            match env.clock with
-            | Some c -> Some (Eio.Time.now c)
-            | None -> None
-          in
+          let now_opt () = Some (Eio.Time.now env.clock) in
           let clock =
             Fusion_orchestrator_judge_wave.make_clock
               ~now_opt

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -245,8 +245,12 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
             preset.Fusion_policy.judge_wave_budget_s -. (now () -. t0)
           in
           let meta_budget_check () =
-            let remaining = remaining_wave_budget () in
-            if remaining < preset.Fusion_policy.meta_timeout_s
+            if
+              not
+                (Fusion_policy.judge_wave_budget_enabled
+                   ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s)
+            then Ok preset.Fusion_policy.meta_timeout_s
+            else if remaining_wave_budget () < preset.Fusion_policy.meta_timeout_s
             then
               Error
                 ( Fusion_types.Budget_exceeded "insufficient remaining budget for meta"

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -85,11 +85,8 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                     }
                 ] )
           in
-          let env = Masc_eio_env.get () in
-          let now_opt () = Some (Eio.Time.now env.clock) in
           let clock =
-            Fusion_orchestrator_judge_wave.make_clock
-              ~now_opt
+            Fusion_orchestrator_judge_wave.make_runtime_clock
               ~missing_clock_failure:
                 (Fusion_types.Internal_error
                    "fusion adaptive timeout requires a wall clock; initialise Masc_eio_env with ~clock")

--- a/lib/fusion/fusion_orchestrator.ml
+++ b/lib/fusion/fusion_orchestrator.ml
@@ -120,6 +120,9 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
           let all_fail_error_of_runs =
             Fusion_orchestrator_judge_wave.all_fail_error_of_runs
           in
+          let with_timeout_budget_fallback =
+            Fusion_orchestrator_judge_wave.with_timeout_budget_fallback
+          in
           let meta_budget_check () =
             Fusion_orchestrator_judge_wave.meta_budget_check ~preset clock
           in
@@ -145,24 +148,8 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
               , [] )
             | judges ->
               let firsts = run_first_judges judges in
-              let ok_priors = successful_syntheses firsts in
               let firsts_with_fallback =
-                match ok_priors with
-                | _ :: _ -> firsts
-                | [] ->
-                  if
-                    List.for_all
-                      (fun (_, _, result, _, _) ->
-                         match result with
-                         | Error (f, _) ->
-                           Fusion_types.judge_failure_is_timeout_or_budget f
-                         | Ok _ -> false)
-                      firsts
-                  then
-                    (match run_fallback_judge () with
-                     | Some fb -> firsts @ [ fb ]
-                     | None -> firsts)
-                  else firsts
+                with_timeout_budget_fallback ~run_fallback_judge firsts
               in
               let first_nodes = first_judge_nodes firsts_with_fallback in
               let ok_priors = successful_syntheses firsts_with_fallback in
@@ -237,7 +224,10 @@ let run ~sw ~net ~base_dir ~policy ~topology ~request () : outcome =
                   , Fusion_types.zero_usage )
               , [] )
             | Ok _groups ->
-              let firsts = run_first_judges preset.Fusion_policy.judges in
+              let firsts =
+                run_first_judges preset.Fusion_policy.judges
+                |> with_timeout_budget_fallback ~run_fallback_judge
+              in
               let rec take n acc rest =
                 if n = 0
                 then (List.rev acc, rest)

--- a/lib/fusion/fusion_orchestrator.mli
+++ b/lib/fusion/fusion_orchestrator.mli
@@ -13,7 +13,7 @@ type outcome =
   | Sink_failed of string  (** chat lane 기록 실패 *)
   | Completed of
       { panel : Fusion_types.panel_outcome list
-      ; judge : (Fusion_types.judge_synthesis, string) result
+      ; judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
       }
 
 (** 요청을 심의한다.

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -185,6 +185,21 @@ let all_fail_error_of_runs ~fallback runs =
     (List.map (fun (_, id, result, _, _) -> id, result) runs)
 ;;
 
+let failed_timeout_or_budget (_, _, result, _, _) =
+  match result with
+  | Error (failure, _) -> Fusion_types.judge_failure_is_timeout_or_budget failure
+  | Ok _ -> false
+;;
+
+let with_timeout_budget_fallback ~run_fallback_judge runs =
+  if runs <> [] && List.for_all failed_timeout_or_budget runs
+  then (
+    match run_fallback_judge () with
+    | Some fallback -> runs @ [ fallback ]
+    | None -> runs)
+  else runs
+;;
+
 let remaining_wave_budget ~preset clock =
   preset.Fusion_policy.judge_wave_budget_s -. elapsed_since_t0 clock
 ;;

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -9,19 +9,19 @@ type judge_run =
 
 type clock =
   { now_opt : unit -> float option
-  ; t0 : float
+  ; t0 : float option
   ; missing_clock_failure : Fusion_types.judge_failure
   }
 
 let make_clock ~now_opt ~missing_clock_failure =
-  let t0 = Option.value (now_opt ()) ~default:0.0 in
+  let t0 = now_opt () in
   { now_opt; t0; missing_clock_failure }
 ;;
 
 let elapsed_since_t0 clock =
-  match clock.now_opt () with
-  | Some now -> now -. clock.t0
-  | None -> 0.0
+  match clock.now_opt (), clock.t0 with
+  | Some now, Some t0 -> now -. t0
+  | _ -> 0.0
 ;;
 
 let missing_clock_result clock =

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -18,6 +18,15 @@ let make_clock ~now_opt ~missing_clock_failure =
   { now_opt; t0; missing_clock_failure }
 ;;
 
+let make_runtime_clock ~missing_clock_failure =
+  let now_opt () =
+    match Masc_eio_env.get_opt () with
+    | Some { Masc_eio_env.clock; _ } -> Some (Eio.Time.now clock)
+    | None -> None
+  in
+  make_clock ~now_opt ~missing_clock_failure
+;;
+
 let elapsed_since_t0 clock =
   match clock.now_opt (), clock.t0 with
   | Some now, Some t0 -> now -. t0

--- a/lib/fusion/fusion_orchestrator_judge_wave.ml
+++ b/lib/fusion/fusion_orchestrator_judge_wave.ml
@@ -1,0 +1,270 @@
+type judge_run =
+  Fusion_policy.judge_spec
+  * string
+  * ( Fusion_types.judge_synthesis * Fusion_types.usage
+    , Fusion_types.judge_failure * Fusion_types.usage )
+    result
+  * float
+  * bool
+
+type clock =
+  { now_opt : unit -> float option
+  ; t0 : float
+  ; missing_clock_failure : Fusion_types.judge_failure
+  }
+
+let make_clock ~now_opt ~missing_clock_failure =
+  let t0 = Option.value (now_opt ()) ~default:0.0 in
+  { now_opt; t0; missing_clock_failure }
+;;
+
+let elapsed_since_t0 clock =
+  match clock.now_opt () with
+  | Some now -> now -. clock.t0
+  | None -> 0.0
+;;
+
+let missing_clock_result clock =
+  Error (clock.missing_clock_failure, Fusion_types.zero_usage)
+;;
+
+let clock_available clock = Option.is_some (clock.now_opt ())
+
+let run_first_judge
+      ~sw
+      ~net
+      ~preset
+      ~panel
+      ~question
+      ~clock
+      ~judge_web_tools
+      ~judge_max_tool_calls
+      ~already_timed_out
+      (j : Fusion_policy.judge_spec)
+  : judge_run
+  =
+  let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
+  let elapsed_s = elapsed_since_t0 clock in
+  if not (clock_available clock)
+  then j, id, missing_clock_result clock, elapsed_s, false
+  else
+    match
+      Fusion_policy.adjust_judge_timeout
+        ~base_s:j.jtimeout_s
+        ~max_s:j.jmax_timeout_s
+        ~factor:preset.Fusion_policy.adaptive_timeout_factor
+        ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s
+        ~elapsed_s
+        ~already_timed_out
+    with
+    | None ->
+      let detail =
+        if already_timed_out
+        then Printf.sprintf "adaptive timeout recovery for judge %s exceeded wave budget" id
+        else
+          Printf.sprintf
+            "judge %s skipped: would exceed wave budget (elapsed %.3f, budget %.3f)"
+            id
+            elapsed_s
+            preset.Fusion_policy.judge_wave_budget_s
+      in
+      j, id, Error (Fusion_types.Budget_exceeded detail, Fusion_types.zero_usage), elapsed_s, false
+    | Some timeout_s ->
+      let result =
+        Fusion_judge.run
+          ~sw
+          ~net
+          ~timeout_s
+          ?max_tokens:j.jmax_output_tokens
+          ~judge_system_prompt:j.jsystem_prompt
+          ~judge_model:j.jmodel
+          ~question
+          ~panel
+          ~web_tools:j.jweb_tools
+          ~max_tool_calls:j.jmax_tool_calls
+          ()
+      in
+      let elapsed_s = elapsed_since_t0 clock in
+      let timed_out =
+        match result with
+        | Error (f, _) -> Fusion_types.judge_failure_is_timeout f
+        | Ok _ -> false
+      in
+      j, id, result, elapsed_s, timed_out
+;;
+
+let run_first_judges
+      ~sw
+      ~net
+      ~max_concurrent_judges
+      ~preset
+      ~panel
+      ~question
+      ~clock
+      ~judge_web_tools
+      ~judge_max_tool_calls
+      judges
+  =
+  let run_first_judge =
+    run_first_judge
+      ~sw
+      ~net
+      ~preset
+      ~panel
+      ~question
+      ~clock
+      ~judge_web_tools
+      ~judge_max_tool_calls
+  in
+  let first_pass =
+    Eio.Fiber.List.map
+      ~max_fibers:max_concurrent_judges
+      (run_first_judge ~already_timed_out:false)
+      judges
+  in
+  if not (Fusion_policy.adaptive_timeout_enabled preset)
+  then first_pass
+  else
+    Eio.Fiber.List.map
+      ~max_fibers:max_concurrent_judges
+      (fun ((j, _, _, _, timed_out) as run) ->
+         if timed_out
+         then (
+           Fusion_metrics.record_adaptive_timeout ();
+           run_first_judge ~already_timed_out:true j)
+         else run)
+      first_pass
+;;
+
+let first_judge_nodes runs =
+  List.map
+    (fun (_, id, result, elapsed_s, _timed_out) ->
+       match result with
+       | Ok (s, u) ->
+         Fusion_types.Synthesized { Fusion_types.role = First id; synthesis = s; usage = u }
+       | Error (failure, u) ->
+         Fusion_types.Judge_failed
+           { Fusion_types.failed_role = First id; failure; usage = u; elapsed_s })
+    runs
+;;
+
+let successful_syntheses runs =
+  List.filter_map
+    (fun (_, id, result, _, _) ->
+       match result with
+       | Ok (s, u) -> Some (id, s, u)
+       | Error _ -> None)
+    runs
+;;
+
+let successful_pair_syntheses pairs =
+  List.filter_map
+    (fun (id, r) ->
+       match r with
+       | Ok (s, u) -> Some (id, s, u)
+       | Error _ -> None)
+    pairs
+;;
+
+let firsts_usage runs =
+  Fusion_types.sum_all_usage (List.map (fun (_, id, result, _, _) -> id, result) runs)
+;;
+
+let all_fail_error_of_runs ~fallback runs =
+  Fusion_types.all_fail_error
+    ~fallback
+    (List.map (fun (_, id, result, _, _) -> id, result) runs)
+;;
+
+let remaining_wave_budget ~preset clock =
+  preset.Fusion_policy.judge_wave_budget_s -. elapsed_since_t0 clock
+;;
+
+let meta_budget_check ~preset clock =
+  if not (clock_available clock)
+  then missing_clock_result clock
+  else if
+    not
+      (Fusion_policy.judge_wave_budget_enabled
+         ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s)
+  then Ok preset.Fusion_policy.meta_timeout_s
+  else if remaining_wave_budget ~preset clock < preset.Fusion_policy.meta_timeout_s
+  then
+    Error
+      ( Fusion_types.Budget_exceeded "insufficient remaining budget for meta"
+      , Fusion_types.zero_usage )
+  else Ok preset.Fusion_policy.meta_timeout_s
+;;
+
+let run_fallback_judge
+      ~sw
+      ~net
+      ~preset
+      ~panel
+      ~question
+      ~clock
+      ~judge_web_tools
+      ~judge_max_tool_calls
+      ()
+  =
+  match preset.Fusion_policy.fallback_judge_model with
+  | None -> None
+  | Some model ->
+    let elapsed_s = elapsed_since_t0 clock in
+    let j : Fusion_policy.judge_spec =
+      { jmodel = model
+      ; jlabel = "fallback"
+      ; jsystem_prompt = preset.Fusion_policy.judge_system_prompt
+      ; jweb_tools = judge_web_tools
+      ; jmax_tool_calls = judge_max_tool_calls
+      ; jmax_output_tokens = preset.Fusion_policy.judge_max_output_tokens
+      ; jtimeout_s = preset.Fusion_policy.judge_timeout_s
+      ; jmax_timeout_s = None
+      }
+    in
+    let id = Fusion_policy.panelist_id ~label:j.jlabel ~model:j.jmodel in
+    if not (clock_available clock)
+    then Some (j, id, missing_clock_result clock, elapsed_s, false)
+    else (
+      match
+        Fusion_policy.adjust_judge_timeout
+          ~base_s:j.jtimeout_s
+          ~max_s:None
+          ~factor:1.0
+          ~wave_budget_s:preset.Fusion_policy.judge_wave_budget_s
+          ~elapsed_s
+          ~already_timed_out:false
+      with
+      | None ->
+        Some
+          ( j
+          , id
+          , Error
+              ( Fusion_types.Budget_exceeded
+                  "fallback judge skipped: insufficient remaining wave budget"
+              , Fusion_types.zero_usage )
+          , elapsed_s
+          , false )
+      | Some timeout_s ->
+        let result =
+          Fusion_judge.run
+            ~sw
+            ~net
+            ~timeout_s
+            ?max_tokens:j.jmax_output_tokens
+            ~judge_system_prompt:preset.Fusion_policy.judge_system_prompt
+            ~judge_model:model
+            ~question
+            ~panel
+            ~web_tools:judge_web_tools
+            ~max_tool_calls:judge_max_tool_calls
+            ()
+        in
+        let elapsed_s = elapsed_since_t0 clock in
+        let timed_out =
+          match result with
+          | Error (f, _) -> Fusion_types.judge_failure_is_timeout f
+          | Ok _ -> false
+        in
+        Some (j, id, result, elapsed_s, timed_out))
+;;

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -31,7 +31,7 @@ val run_first_judges
   -> Fusion_policy.judge_spec list
   -> judge_run list
 
-val first_judge_nodes : judge_run list -> Fusion_types.judge_node list
+val first_judge_nodes : judge_run list -> Fusion_types.judge_outcome list
 
 val successful_syntheses
   :  judge_run list
@@ -46,7 +46,7 @@ val firsts_usage : judge_run list -> Fusion_types.usage
 val all_fail_error_of_runs
   :  fallback:Fusion_types.judge_failure
   -> judge_run list
-  -> Fusion_types.judge_failure
+  -> Fusion_types.judge_failure * Fusion_types.usage
 
 val meta_budget_check
   :  preset:Fusion_policy.preset

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -55,6 +55,14 @@ val all_fail_error_of_runs
   -> judge_run list
   -> Fusion_types.judge_failure * Fusion_types.usage
 
+val with_timeout_budget_fallback
+  :  run_fallback_judge:(unit -> judge_run option)
+  -> judge_run list
+  -> judge_run list
+(** Append the configured fallback judge when the whole first-judge wave failed
+    only with timeout/budget failures. Shared by JOJ and staged JOJ so both
+    topologies honor [fallback_judge_model] consistently. *)
+
 val meta_budget_check
   :  preset:Fusion_policy.preset
   -> clock

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -16,6 +16,13 @@ val make_clock
   -> missing_clock_failure:Fusion_types.judge_failure
   -> clock
 
+val make_runtime_clock
+  :  missing_clock_failure:Fusion_types.judge_failure
+  -> clock
+(** Build a clock from the current domain-local {!Masc_eio_env}. Missing
+    runtime env is represented as [None] so callers can return the configured
+    [missing_clock_failure] instead of raising from {!Masc_eio_env.get}. *)
+
 val elapsed_since_t0 : clock -> float
 
 val run_first_judges

--- a/lib/fusion/fusion_orchestrator_judge_wave.mli
+++ b/lib/fusion/fusion_orchestrator_judge_wave.mli
@@ -1,0 +1,66 @@
+(** Judge wave helpers for {!Fusion_orchestrator}. *)
+
+type judge_run =
+  Fusion_policy.judge_spec
+  * string
+  * ( Fusion_types.judge_synthesis * Fusion_types.usage
+    , Fusion_types.judge_failure * Fusion_types.usage )
+    result
+  * float
+  * bool
+
+type clock
+
+val make_clock
+  :  now_opt:(unit -> float option)
+  -> missing_clock_failure:Fusion_types.judge_failure
+  -> clock
+
+val elapsed_since_t0 : clock -> float
+
+val run_first_judges
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> max_concurrent_judges:int
+  -> preset:Fusion_policy.preset
+  -> panel:Fusion_types.panel_outcome list
+  -> question:string
+  -> clock:clock
+  -> judge_web_tools:bool
+  -> judge_max_tool_calls:int
+  -> Fusion_policy.judge_spec list
+  -> judge_run list
+
+val first_judge_nodes : judge_run list -> Fusion_types.judge_node list
+
+val successful_syntheses
+  :  judge_run list
+  -> (string * Fusion_types.judge_synthesis * Fusion_types.usage) list
+
+val successful_pair_syntheses
+  :  (string * (Fusion_types.judge_synthesis * Fusion_types.usage, 'err) result) list
+  -> (string * Fusion_types.judge_synthesis * Fusion_types.usage) list
+
+val firsts_usage : judge_run list -> Fusion_types.usage
+
+val all_fail_error_of_runs
+  :  fallback:Fusion_types.judge_failure
+  -> judge_run list
+  -> Fusion_types.judge_failure
+
+val meta_budget_check
+  :  preset:Fusion_policy.preset
+  -> clock
+  -> (float, Fusion_types.judge_failure * Fusion_types.usage) result
+
+val run_fallback_judge
+  :  sw:Eio.Switch.t
+  -> net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t
+  -> preset:Fusion_policy.preset
+  -> panel:Fusion_types.panel_outcome list
+  -> question:string
+  -> clock:clock
+  -> judge_web_tools:bool
+  -> judge_max_tool_calls:int
+  -> unit
+  -> judge_run option

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -229,13 +229,15 @@ let judge_node_meta (o : Fusion_types.judge_outcome) : Yojson.Safe.t =
        @ [ ("input_tokens", `Int usage.Fusion_types.input_tokens)
          ; ("output_tokens", `Int usage.Fusion_types.output_tokens)
          ])
-  | Fusion_types.Judge_failed { failed_role; error; usage } ->
+  | Fusion_types.Judge_failed { failed_role; error; usage; elapsed_s; timed_out } ->
     `Assoc
       (judge_role_fields failed_role
        @ [ ("status", `String "failed")
          ; ("error", `String error)
          ; ("input_tokens", `Int usage.Fusion_types.input_tokens)
          ; ("output_tokens", `Int usage.Fusion_types.output_tokens)
+         ; ("elapsed_s", `Float elapsed_s)
+         ; ("timed_out", `Bool timed_out)
          ])
 
 (* RFC-0266: 심의 완료 시 호출 키퍼를 typed [Fusion_completed] stimulus로 깨운다.

--- a/lib/fusion/fusion_sink.ml
+++ b/lib/fusion/fusion_sink.ml
@@ -192,13 +192,19 @@ let judge_synthesis_fields (j : Fusion_types.judge_synthesis) :
   | Fusion_types.Answer _ -> base
 
 (* 심판 종합을 board meta_json [judge] 원소로 (canonical 단일 키 — RFC-0284 이전 호환). *)
-let judge_meta (judge : (Fusion_types.judge_synthesis, string) result) : Yojson.Safe.t =
+let judge_meta (judge : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result)
+    : Yojson.Safe.t =
   (* status는 형제 panel_meta와 같은 동사형(판이 무엇을 했는가): 종합 산출은
      "synthesized", 실패는 "failed". tool-result ok-봉투("ok")가 아니라 board
      증거의 judge 서술 필드다 (no-inline-ok-envelope 가드 대상과 별개 개념). *)
   match judge with
   | Ok j -> `Assoc (judge_synthesis_fields j)
-  | Error e -> `Assoc [ ("status", `String "failed"); ("error", `String e) ]
+  | Error f ->
+    `Assoc
+      [ ("status", `String "failed")
+      ; ("error", `String (Fusion_types.judge_failure_text f))
+      ; ("failure_code", `String (Fusion_types.judge_failure_tag f))
+      ]
 
 (* 심판 노드의 위상 역할/정체성 → board meta_json 필드 (RFC-0284). [role]은 위상 의미
    (single/refine/first/meta/stage_meta/final_meta), [identity]는 [First]면 panelist_id(panel
@@ -229,11 +235,17 @@ let judge_node_meta (o : Fusion_types.judge_outcome) : Yojson.Safe.t =
        @ [ ("input_tokens", `Int usage.Fusion_types.input_tokens)
          ; ("output_tokens", `Int usage.Fusion_types.output_tokens)
          ])
-  | Fusion_types.Judge_failed { failed_role; error; usage; elapsed_s; timed_out } ->
+  | Fusion_types.Judge_failed { failed_role; failure; usage; elapsed_s } ->
+    (* [failure]가 single source of truth. 하위 호환을 위해 사람-가독 [error] 문자열과
+       파생 [timed_out]을 synthetic key로 복원하고, 정확 분류용 [failure_code]를 additive
+       로 추가한다(dashboard는 [error]만 읽고 [timed_out]/[elapsed_s]는 무시하므로 기존
+       소비가 깨지지 않는다). *)
+    let timed_out = Fusion_types.judge_failure_is_timeout failure in
     `Assoc
       (judge_role_fields failed_role
        @ [ ("status", `String "failed")
-         ; ("error", `String error)
+         ; ("error", `String (Fusion_types.judge_failure_text failure))
+         ; ("failure_code", `String (Fusion_types.judge_failure_tag failure))
          ; ("input_tokens", `Int usage.Fusion_types.input_tokens)
          ; ("output_tokens", `Int usage.Fusion_types.output_tokens)
          ; ("elapsed_s", `Float elapsed_s)
@@ -412,7 +424,7 @@ let emit ~base_dir ~keeper ~run_id ~question ~panel ~judge ~judges ~judge_usage 
          let ok, resolved_answer =
            match judge with
            | Ok j -> true, j.Fusion_types.resolved_answer
-           | Error e -> false, Printf.sprintf "judge failed: %s" e
+           | Error e -> false, Printf.sprintf "judge failed: %s" (Fusion_types.judge_failure_text e)
          in
          (* RFC-0266 §7: registry를 Completed로 갱신(가시성). wake와 무관하게 run
             상태를 반영해야 하므로 wake 직전 무조건 호출. *)

--- a/lib/fusion/fusion_sink.mli
+++ b/lib/fusion/fusion_sink.mli
@@ -25,7 +25,7 @@ val panel_meta : Fusion_types.panel_outcome -> Yojson.Safe.t
     decision variant에 따른 최상위 [recommend] | [missing]. [Error] → {status="failed"; error}.
     구조화 필드 키(text/models/topic/addressed_by/...)는 {!Fusion_judge_parse}의
     LLM-facing JSON 스키마와 대칭이며, 프론트가 markdown 재파싱 없이 5섹션을 렌더한다. *)
-val judge_meta : (Fusion_types.judge_synthesis, string) result -> Yojson.Safe.t
+val judge_meta : (Fusion_types.judge_synthesis, Fusion_types.judge_failure) result -> Yojson.Safe.t
 
 (** [judge_node_meta o] — 심판 실행 노드 한 건을 board meta_json [judges] 배열 원소로
     직렬화 (RFC-0284). [Synthesized] → role/identity + judge_synthesis 5섹션 + 노드별
@@ -54,7 +54,7 @@ val emit
   -> run_id:string
   -> question:string
   -> panel:Fusion_types.panel_outcome list
-  -> judge:(Fusion_types.judge_synthesis, string) result
+  -> judge:(Fusion_types.judge_synthesis, Fusion_types.judge_failure) result
   -> judges:Fusion_types.judge_outcome list
   -> judge_usage:Fusion_types.usage
   -> (unit, string) result

--- a/lib/fusion_core/fusion_config.ml
+++ b/lib/fusion_core/fusion_config.ml
@@ -19,6 +19,13 @@ type config_error =
   | Duplicate_judge of string * string  (** (preset 이름, 중복 judge 정체성) (RFC-0283) *)
   | Invalid_min_answered of string * int
       (** (preset 이름, min_answered): policy 허용 범위 밖 *)
+  | Invalid_meta_timeout of string * float
+      (** (preset 이름, meta_timeout_s): 양수 유한수가 아님. *)
+  | Invalid_judge_wave_budget of string * float
+      (** (preset 이름, judge_wave_budget_s): 0 미만이거나 최장 1차 심판 타임아웃/
+          meta_timeout_s보다 작음. *)
+  | Invalid_adaptive_timeout_factor of string * float
+      (** (preset 이름, adaptive_timeout_factor): 1.0 미만. *)
   | Toml_type_error of string
 [@@deriving show, eq]
 
@@ -68,6 +75,8 @@ let parse_judge_spec (tbl : Otoml.t) : Fusion_policy.judge_spec =
   ; jtimeout_s =
       Otoml.find_or ~default:Fusion_policy.default_timeout_s tbl Otoml.get_float
         [ "timeout_s" ]
+  ; jmax_timeout_s =
+      Otoml.find_opt tbl Otoml.get_float [ "max_timeout_s" ]
   }
 
 let parse_min_answered _name tbl =
@@ -95,10 +104,25 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
   let judge_max_output_tokens =
     Otoml.find_opt tbl Otoml.get_integer [ "judge_max_output_tokens" ]
   in
+  (* meta_timeout_s: 누락 시 judge_timeout_s와 byte-identical (legacy). *)
+  let meta_timeout_s =
+    Otoml.find_or ~default:judge_timeout_s tbl Otoml.get_float [ "meta_timeout_s" ]
+  in
   let judges =
     match Otoml.find_opt tbl (Otoml.get_array Otoml.get_value) [ "judges" ] with
     | Some entries -> List.map parse_judge_spec entries
     | None -> []
+  in
+  (* 1차 심판 wave 전체 wall-clock 예산. 누락 시 무제한(legacy byte-identical). *)
+  let judge_wave_budget_s =
+    Otoml.find_or ~default:Float.max_float tbl Otoml.get_float
+      [ "judge_wave_budget_s" ]
+  in
+  let adaptive_timeout_factor =
+    Otoml.find_or ~default:1.0 tbl Otoml.get_float [ "adaptive_timeout_factor" ]
+  in
+  let fallback_judge_model =
+    Otoml.find_opt tbl Otoml.get_string [ "fallback_judge_model" ]
   in
   (* 런타임 quorum. 미설정 시 [default_min_answered] = 기존 동작(>= 1 응답이면 심판 실행).
      허용 범위는 1 이상 패널 모델 총합 이하; 검증 SSOT는 Validated_preset.of_preset. *)
@@ -111,7 +135,11 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
       ; judge_timeout_s
       ; judge_max_output_tokens
       ; judges
+      ; meta_timeout_s
       ; min_answered
+      ; judge_wave_budget_s
+      ; adaptive_timeout_factor
+      ; fallback_judge_model
       }
     in
     (* 검증 SSOT는 Validated_preset.of_preset (RFC-0280). config는 그 [invalid]에 preset
@@ -138,7 +166,13 @@ let finish_preset name tbl (panels : Fusion_policy.panel_group list)
            Duplicate_judge (name, id)
          | Fusion_policy.Validated_preset.Min_answered_below_min v
          | Fusion_policy.Validated_preset.Min_answered_above_max v ->
-           Invalid_min_answered (name, v)))
+           Invalid_min_answered (name, v)
+         | Fusion_policy.Validated_preset.Bad_meta_timeout v ->
+           Invalid_meta_timeout (name, v)
+         | Fusion_policy.Validated_preset.Bad_judge_wave_budget v ->
+           Invalid_judge_wave_budget (name, v)
+         | Fusion_policy.Validated_preset.Bad_adaptive_factor v ->
+           Invalid_adaptive_timeout_factor (name, v)))
 
 (* preset 한 명 파싱. 두 문법 분기:
    - 새 문법 [[fusion.presets.NAME.panels]] (array-of-tables) → 그룹별 파싱.

--- a/lib/fusion_core/fusion_config.mli
+++ b/lib/fusion_core/fusion_config.mli
@@ -42,6 +42,13 @@ type config_error =
   | Invalid_min_answered of string * int
       (** (preset 이름, min_answered) — [min_answered]가 policy 허용 범위(1..패널
           모델 총합) 밖. full-panel quorum([총합])도 명시적으로 설정할 수 있다. *)
+  | Invalid_meta_timeout of string * float
+      (** (preset 이름, meta_timeout_s) — 양수 유한수가 아님. *)
+  | Invalid_judge_wave_budget of string * float
+      (** (preset 이름, judge_wave_budget_s) — 0 미만이거나 최장 1차 심판 타임아웃/
+          [meta_timeout_s]보다 작음. *)
+  | Invalid_adaptive_timeout_factor of string * float
+      (** (preset 이름, adaptive_timeout_factor) — 1.0 미만. *)
   | Toml_type_error of string  (** 필드 타입 불일치 (Otoml.Type_error) *)
 [@@deriving show, eq]
 

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -30,6 +30,8 @@ type judge_spec =
   ; jmax_tool_calls : int  (** 최대 tool 호출 수 (0=무제한) *)
   ; jmax_output_tokens : int option  (** 출력 토큰 예산 override *)
   ; jtimeout_s : float  (** 호출 구조적 타임아웃 (초) *)
+  ; jmax_timeout_s : float option
+      (** 적응형 타임아웃 확장 상한. None이면 예산 내에서 factor만큼 확장. *)
   }
 [@@deriving show, eq]
 
@@ -41,11 +43,19 @@ type preset =
   ; judge_system_prompt : string
   ; judge_timeout_s : float
   ; judge_max_output_tokens : int option
+  ; meta_timeout_s : float
+      (** meta/stage-meta/final-meta 호출 구조적 타임아웃 (초). *)
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
   ; min_answered : int
       (** 심판 실행에 필요한 응답 패널 최소 수 (런타임 quorum). 기본 1. *)
+  ; judge_wave_budget_s : float
+      (** 1차 심판 wave 전체 wall-clock 예산 (초). 0=비활성(legacy). *)
+  ; adaptive_timeout_factor : float
+      (** 1차 심판 타임아웃 적응형 확장 계수. 1.0=확장 안 함. *)
+  ; fallback_judge_model : string option
+      (** 전원 타임아웃/예산 실패 시 단일 fallback 심판 모델. *)
   }
 [@@deriving show, eq]
 
@@ -234,6 +244,26 @@ let judge_tool_budget_of (groups : panel_group list) =
   if List.exists (fun (g : panel_group) -> g.max_tool_calls = 0) groups then 0
   else List.fold_left (fun acc (g : panel_group) -> max acc g.max_tool_calls) 0 groups
 
+(* 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
+   - factor = 1.0 (또는 아직 타임아웃 안 됨): base_s를 wave 예산에 맞춰 반환.
+   - already_timed_out && factor > 1.0: base_s *. factor를 max_s로 상한, 남은 예산으로
+     하한해 확장된 타임아웃을 반환.
+   예산/상한이 너무 작아 0.001초 미만이면 None (즉시 실패). *)
+let adjust_judge_timeout ~base_s ~max_s ~factor ~wave_budget_s ~elapsed_s
+    ~already_timed_out : float option =
+  if factor = 1.0 || not already_timed_out
+  then if elapsed_s +. base_s <= wave_budget_s then Some base_s else None
+  else
+    let extended = base_s *. factor in
+    let proposed =
+      match max_s with
+      | Some m -> Float.min extended m
+      | None -> extended
+    in
+    let remaining = wave_budget_s -. elapsed_s in
+    let effective = Float.min proposed remaining in
+    if effective < 0.001 then None else Some effective
+
 (* RFC-0280: 검증된 preset을 타입으로 증명한다 (Parse, don't validate).
    [Validated_preset.t = private preset]이라 외부는 필드를 읽되([preset]/coercion)
    검증 없이 생성할 수 없다 → invalid preset이 게이트·orchestrator로 흐를 수 없다.
@@ -258,6 +288,13 @@ module Validated_preset = struct
         (** [min_answered]가 하한 [min_answered_floor] 미만. *)
     | Min_answered_above_max of int
         (** [min_answered]가 패널 모델 총합을 초과. *)
+    | Bad_meta_timeout of float
+        (** [meta_timeout_s]가 양수 유한수가 아님. *)
+    | Bad_judge_wave_budget of float
+        (** [judge_wave_budget_s]가 0 미만이거나, 양수인데 최장 1차 심판 타임아웃 또는
+            [meta_timeout_s]보다 작음. *)
+    | Bad_adaptive_factor of float
+        (** [adaptive_timeout_factor]가 1.0 미만. *)
 
   (* 검증 순서는 config 로드 시점과 동일(byte-identical config_error): size → 패널 prompt →
      judge model → 패널 정체성 중복 → 패널 max_tool_calls 범위 → 패널 max_output_tokens
@@ -319,6 +356,25 @@ module Validated_preset = struct
                         then Error (Min_answered_below_min p.min_answered)
                         else if p.min_answered > total
                         then Error (Min_answered_above_max p.min_answered)
+                        else if
+                          not (p.meta_timeout_s > 0.0 && Float.is_finite p.meta_timeout_s)
+                        then Error (Bad_meta_timeout p.meta_timeout_s)
+                        else if p.adaptive_timeout_factor < 1.0
+                        then Error (Bad_adaptive_factor p.adaptive_timeout_factor)
+                        else if p.judge_wave_budget_s < 0.0
+                        then Error (Bad_judge_wave_budget p.judge_wave_budget_s)
+                        else if
+                          p.judge_wave_budget_s > 0.0
+                          && Float.is_finite p.judge_wave_budget_s
+                          && (let longest_judge =
+                                List.fold_left
+                                  (fun acc (j : judge_spec) ->
+                                    Float.max acc j.jtimeout_s)
+                                  0.0 p.judges
+                              in
+                              p.judge_wave_budget_s < longest_judge
+                              || p.judge_wave_budget_s < p.meta_timeout_s)
+                        then Error (Bad_judge_wave_budget p.judge_wave_budget_s)
                         else Ok p)))))
 
   let preset (t : t) : preset = t

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -260,6 +260,8 @@ let min_effective_timeout_s = 0.001
 let adaptive_timeout_enabled (p : preset) =
   p.adaptive_timeout_factor > adaptive_extension_threshold
 
+let judge_wave_budget_enabled ~wave_budget_s = wave_budget_s > 0.0
+
 (* 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
    - factor <= [adaptive_extension_threshold] (또는 아직 타임아웃 안 됨): base_s를 wave
      예산에 맞춰 반환.
@@ -268,8 +270,12 @@ let adaptive_timeout_enabled (p : preset) =
    예산/상한이 너무 작아 [min_effective_timeout_s] 미만이면 None (즉시 실패). *)
 let adjust_judge_timeout ~base_s ~max_s ~factor ~wave_budget_s ~elapsed_s
     ~already_timed_out : float option =
+  let budget_enabled = judge_wave_budget_enabled ~wave_budget_s in
+  let budget_allows timeout_s =
+    (not budget_enabled) || elapsed_s +. timeout_s <= wave_budget_s
+  in
   if factor <= adaptive_extension_threshold || not already_timed_out
-  then if elapsed_s +. base_s <= wave_budget_s then Some base_s else None
+  then if budget_allows base_s then Some base_s else None
   else
     let extended = base_s *. factor in
     let proposed =
@@ -277,8 +283,11 @@ let adjust_judge_timeout ~base_s ~max_s ~factor ~wave_budget_s ~elapsed_s
       | Some m -> Float.min extended m
       | None -> extended
     in
-    let remaining = wave_budget_s -. elapsed_s in
-    let effective = Float.min proposed remaining in
+    let effective =
+      if budget_enabled
+      then Float.min proposed (wave_budget_s -. elapsed_s)
+      else proposed
+    in
     if effective < min_effective_timeout_s then None else Some effective
 
 (* RFC-0280: 검증된 preset을 타입으로 증명한다 (Parse, don't validate).

--- a/lib/fusion_core/fusion_policy.ml
+++ b/lib/fusion_core/fusion_policy.ml
@@ -244,14 +244,31 @@ let judge_tool_budget_of (groups : panel_group list) =
   if List.exists (fun (g : panel_group) -> g.max_tool_calls = 0) groups then 0
   else List.fold_left (fun acc (g : panel_group) -> max acc g.max_tool_calls) 0 groups
 
+(* 적응형 타임아웃 임계값들. [adaptive_extension_threshold]는 adaptive 확장을 끄는
+   factor 값(config default 1.0; 검증이 >= 1.0을 강제). 1.0은 IEEE754에서 정확히
+   표현되지만, 의도를 명시하고 drift를 막기 named 상수로 둔다 — callers 도 float
+   equality 비교 대신 [adaptive_timeout_enabled]를 쓴다 (CLAUDE.md §Magic Number +
+   P2#6 float-equality-as-toggle 회피). [min_effective_timeout_s]는 확장 후 effective
+   타임아웃이 이보다 작으면 즉시 실패(None)하는 하한이다. *)
+let adaptive_extension_threshold = 1.0
+
+let min_effective_timeout_s = 0.001
+
+(* [adaptive_timeout_enabled preset] — preset의 factor가 확장 임계값을 넘는가. float
+   equality 대신 typed bool 토글로, callers(orchestrator)가 adaptive 재시도 분기를
+   판정한다. *)
+let adaptive_timeout_enabled (p : preset) =
+  p.adaptive_timeout_factor > adaptive_extension_threshold
+
 (* 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
-   - factor = 1.0 (또는 아직 타임아웃 안 됨): base_s를 wave 예산에 맞춰 반환.
-   - already_timed_out && factor > 1.0: base_s *. factor를 max_s로 상한, 남은 예산으로
-     하한해 확장된 타임아웃을 반환.
-   예산/상한이 너무 작아 0.001초 미만이면 None (즉시 실패). *)
+   - factor <= [adaptive_extension_threshold] (또는 아직 타임아웃 안 됨): base_s를 wave
+     예산에 맞춰 반환.
+   - already_timed_out && factor > [adaptive_extension_threshold]: base_s *. factor를
+     max_s로 상한, 남은 예산으로 하한해 확장된 타임아웃을 반환.
+   예산/상한이 너무 작아 [min_effective_timeout_s] 미만이면 None (즉시 실패). *)
 let adjust_judge_timeout ~base_s ~max_s ~factor ~wave_budget_s ~elapsed_s
     ~already_timed_out : float option =
-  if factor = 1.0 || not already_timed_out
+  if factor <= adaptive_extension_threshold || not already_timed_out
   then if elapsed_s +. base_s <= wave_budget_s then Some base_s else None
   else
     let extended = base_s *. factor in
@@ -262,7 +279,7 @@ let adjust_judge_timeout ~base_s ~max_s ~factor ~wave_budget_s ~elapsed_s
     in
     let remaining = wave_budget_s -. elapsed_s in
     let effective = Float.min proposed remaining in
-    if effective < 0.001 then None else Some effective
+    if effective < min_effective_timeout_s then None else Some effective
 
 (* RFC-0280: 검증된 preset을 타입으로 증명한다 (Parse, don't validate).
    [Validated_preset.t = private preset]이라 외부는 필드를 읽되([preset]/coercion)

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -36,6 +36,8 @@ type judge_spec =
   ; jmax_output_tokens : int option
       (** 출력 토큰 예산 override. [None]이면 Runtime_agent 기본값. *)
   ; jtimeout_s : float  (** 호출 구조적 타임아웃 (초). *)
+  ; jmax_timeout_s : float option
+      (** 적응형 타임아웃 확장 상한. None이면 예산 내에서 factor만큼 확장. *)
   }
 [@@deriving show, eq]
 
@@ -53,6 +55,8 @@ type preset =
   ; judge_timeout_s : float  (** 심판 호출 구조적 타임아웃 (초). *)
   ; judge_max_output_tokens : int option
       (** 단일/refine/meta 심판 출력 토큰 예산 override. [None]이면 기본값. *)
+  ; meta_timeout_s : float
+      (** meta/stage-meta/final-meta 호출 구조적 타임아웃 (초). *)
   ; judges : judge_spec list
       (** JOJ 1차 심판들 (RFC-0283). 기본 []; simple/refine/conditional은 무시한다.
           JOJ 위상은 런타임에 >= 2 를 요구한다. *)
@@ -62,6 +66,12 @@ type preset =
           [judge = Error]로 완료한다 (빈 패널 종합 날조 방지).
           허용 범위는 [1]부터 패널 모델 총합까지; full-panel quorum([총합])도
           명시적으로 설정할 수 있다. *)
+  ; judge_wave_budget_s : float
+      (** 1차 심판 wave 전체 wall-clock 예산 (초). 0=비활성(legacy). *)
+  ; adaptive_timeout_factor : float
+      (** 1차 심판 타임아웃 적응형 확장 계수. 1.0=확장 안 함. *)
+  ; fallback_judge_model : string option
+      (** 전원 타임아웃/예산 실패 시 단일 fallback 심판 모델. *)
   }
 [@@deriving show, eq]
 
@@ -176,6 +186,19 @@ val judge_web_tools_of : req_web_tools:bool -> panel_group list -> bool
     단일 그룹이면 그 그룹 [max_tool_calls] (오늘과 byte-identical). *)
 val judge_tool_budget_of : panel_group list -> int
 
+(** 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
+    [factor = 1.0]이면 [base_s]를 wave 예산에 맞춰 반환하고, [already_timed_out]이고
+    [factor > 1.0]이면 [base_s *. factor]를 [max_s]로 상한·남은 예산으로 하한해
+    확장한다. 결과가 0.001초 미만이면 [None]. *)
+val adjust_judge_timeout
+  :  base_s:float
+  -> max_s:float option
+  -> factor:float
+  -> wave_budget_s:float
+  -> elapsed_s:float
+  -> already_timed_out:bool
+  -> float option
+
 (** RFC-0280: 검증을 통과한 preset (Parse, don't validate). [t = private preset]이라
     필드는 자유롭게 읽되([preset] 또는 coercion [(vp :> preset)]) 검증 없이 생성할 수
     없다 → invalid preset이 게이트·orchestrator로 흐를 수 없다. 검증 SSOT는
@@ -199,11 +222,18 @@ module Validated_preset : sig
         (** [min_answered]가 하한 [min_answered_floor] 미만. *)
     | Min_answered_above_max of int
         (** [min_answered]가 패널 모델 총합을 초과. *)
+    | Bad_meta_timeout of float
+        (** [meta_timeout_s]가 양수 유한수가 아님. *)
+    | Bad_judge_wave_budget of float
+        (** [judge_wave_budget_s]가 0 미만이거나, 양수 유한인데 최장 1차 심판
+            타임아웃 또는 [meta_timeout_s]보다 작음. *)
+    | Bad_adaptive_factor of float
+        (** [adaptive_timeout_factor]가 1.0 미만. *)
 
   (** 검증 순서: size → prompt → judge → 정체성 중복 → max_tool_calls →
-      max_output_tokens → 1차 심판 prompt/정체성/max_tool_calls/max_output_tokens
-      → min_answered. 통과 시 [Ok vp], 첫 위반에서
-      [Error invalid]. config 로드의 검증 순서와 동일. *)
+      max_output_tokens → 1차 심판 prompt/정체성/max_tool_calls/max_output_tokens →
+      min_answered → timeout 예산/계수. 통과 시 [Ok vp], 첫 위반에서 [Error invalid].
+      config 로드의 검증 순서와 동일. *)
   val of_preset : preset -> (t, invalid) result
 
   (** 검증된 preset을 raw [preset]으로 (read-only coercion). *)

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -186,10 +186,16 @@ val judge_web_tools_of : req_web_tools:bool -> panel_group list -> bool
     단일 그룹이면 그 그룹 [max_tool_calls] (오늘과 byte-identical). *)
 val judge_tool_budget_of : panel_group list -> int
 
+(** [adaptive_timeout_enabled preset] — preset의 [adaptive_timeout_factor]가 확장
+    임계값(1.0)을 넘는가. callers(orchestrator)가 float equality 비교 없이 typed bool로
+    adaptive 재시도 분기를 판정한다. *)
+val adaptive_timeout_enabled : preset -> bool
+
 (** 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
-    [factor = 1.0]이면 [base_s]를 wave 예산에 맞춰 반환하고, [already_timed_out]이고
-    [factor > 1.0]이면 [base_s *. factor]를 [max_s]로 상한·남은 예산으로 하한해
-    확장한다. 결과가 0.001초 미만이면 [None]. *)
+    [factor <= adaptive_extension_threshold](= 1.0)이면 [base_s]를 wave 예산에 맞춰
+    반환하고, [already_timed_out]이고 [factor > adaptive_extension_threshold]이면
+    [base_s *. factor]를 [max_s]로 상한·남은 예산으로 하한해 확장한다. 결과가
+    [min_effective_timeout_s](0.001s) 미만이면 [None]. *)
 val adjust_judge_timeout
   :  base_s:float
   -> max_s:float option

--- a/lib/fusion_core/fusion_policy.mli
+++ b/lib/fusion_core/fusion_policy.mli
@@ -191,10 +191,16 @@ val judge_tool_budget_of : panel_group list -> int
     adaptive 재시도 분기를 판정한다. *)
 val adaptive_timeout_enabled : preset -> bool
 
+(** [judge_wave_budget_enabled ~wave_budget_s] is false only for the validated
+    legacy disabled value [0.0]. Positive finite or effectively-unbounded
+    budgets still enforce the wave cap. *)
+val judge_wave_budget_enabled : wave_budget_s:float -> bool
+
 (** 적응형 타임아웃: 1차 심판/재시도 호출에 사용할 effective timeout을 계산한다.
-    [factor <= adaptive_extension_threshold](= 1.0)이면 [base_s]를 wave 예산에 맞춰
-    반환하고, [already_timed_out]이고 [factor > adaptive_extension_threshold]이면
-    [base_s *. factor]를 [max_s]로 상한·남은 예산으로 하한해 확장한다. 결과가
+    [wave_budget_s = 0.0]이면 legacy disabled budget으로 간주해 wave cap을 적용하지
+    않는다. [factor <= adaptive_extension_threshold](= 1.0)이면 [base_s]를 반환하고,
+    [already_timed_out]이고 [factor > adaptive_extension_threshold]이면 [base_s *.
+    factor]를 [max_s]로 상한·남은 예산으로 하한해 확장한다. 결과가
     [min_effective_timeout_s](0.001s) 미만이면 [None]. *)
 val adjust_judge_timeout
   :  base_s:float

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -231,21 +231,7 @@ type judge_failure =
   | Parse_error of string
   | Budget_exceeded of string
   | Internal_error of string
-[@@deriving to_yojson, show, eq]
-
-let judge_failure_of_yojson = function
-  | `String "Timeout" -> Ok Timeout
-  | `String "Empty_result" -> Ok Empty_result
-  | `List [ `String "Provider_error"; `String detail ] -> Ok (Provider_error detail)
-  | `List [ `String "Empty_response"; `String detail ] -> Ok (Empty_response detail)
-  | `List [ `String "Build_error"; `String detail ] -> Ok (Build_error detail)
-  | `List [ `String "Parse_error"; `String detail ] -> Ok (Parse_error detail)
-  | `List [ `String "Budget_exceeded"; `String detail ] -> Ok (Budget_exceeded detail)
-  | `List [ `String "Internal_error"; `String detail ] -> Ok (Internal_error detail)
-  | json ->
-    Error
-      (Printf.sprintf "Fusion_types.judge_failure_of_yojson: unsupported shape %s"
-         (Yojson.Safe.to_string json))
+[@@deriving yojson, show, eq]
 
 let judge_failure_is_timeout = function Timeout -> true | _ -> false
 

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -222,6 +222,11 @@ type judge_error_node =
   ; usage : usage
       (** 실패해도 태운 토큰 — 관측 record가 비용을 버리지 않는다(RFC-0284, 적대 리뷰 #22112 E).
           [panel_error]와 달리 심판 실패는 토큰 소비 후일 수 있어 usage를 동반한다. *)
+  ; elapsed_s : float
+      (** 이 심판 노드가 시작된 시점부터 실패까지 경과한 시간(초). 예산/타임아웃
+          분석에 쓰인다(RFC-0284-FUSION-P0). *)
+  ; timed_out : bool
+      (** 에러 메시지가 구조적 타임아웃("Execution timed out after")을 나타내는가. *)
   }
 [@@deriving yojson, show, eq]
 

--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -216,17 +216,73 @@ type judge_node =
   }
 [@@deriving yojson, show, eq]
 
+(* 심판(judge) 실패의 닫힌 합. {!panel_failure}와 동형이되 심판 도메인 전용 사유
+   ([Empty_result]/[Build_error]/[Parse_error]/[Budget_exceeded])를 추가한다.
+   [Fusion_judge] 계열이 {!Agent_sdk.Error}의 [Timeout] variant를 match에서 잡아 typed로
+   반환하므로, 호출자는 string substring 분류 없이 exhaustive match로 분류한다
+   (CLAUDE.md §string-classifier 안티패턴 회피). [panel_failure]를 공유하지 않는 이유는
+   mli 주석 참조. *)
+type judge_failure =
+  | Timeout
+  | Provider_error of string
+  | Empty_response of string
+  | Empty_result
+  | Build_error of string
+  | Parse_error of string
+  | Budget_exceeded of string
+  | Internal_error of string
+[@@deriving to_yojson, show, eq]
+
+let judge_failure_of_yojson = function
+  | `String "Timeout" -> Ok Timeout
+  | `String "Empty_result" -> Ok Empty_result
+  | `List [ `String "Provider_error"; `String detail ] -> Ok (Provider_error detail)
+  | `List [ `String "Empty_response"; `String detail ] -> Ok (Empty_response detail)
+  | `List [ `String "Build_error"; `String detail ] -> Ok (Build_error detail)
+  | `List [ `String "Parse_error"; `String detail ] -> Ok (Parse_error detail)
+  | `List [ `String "Budget_exceeded"; `String detail ] -> Ok (Budget_exceeded detail)
+  | `List [ `String "Internal_error"; `String detail ] -> Ok (Internal_error detail)
+  | json ->
+    Error
+      (Printf.sprintf "Fusion_types.judge_failure_of_yojson: unsupported shape %s"
+         (Yojson.Safe.to_string json))
+
+let judge_failure_is_timeout = function Timeout -> true | _ -> false
+
+let judge_failure_is_timeout_or_budget = function
+  | Timeout | Budget_exceeded _ -> true
+  | _ -> false
+
+let judge_failure_text = function
+  | Timeout -> "timeout"
+  | Provider_error detail -> detail
+  | Empty_response detail -> detail
+  | Empty_result -> "judge: empty result"
+  | Build_error detail -> detail
+  | Parse_error detail -> detail
+  | Budget_exceeded detail -> detail
+  | Internal_error detail -> detail
+
+let judge_failure_tag = function
+  | Timeout -> "timeout"
+  | Provider_error _ -> "provider_error"
+  | Empty_response _ -> "empty_response"
+  | Empty_result -> "empty_result"
+  | Build_error _ -> "build_error"
+  | Parse_error _ -> "parse_error"
+  | Budget_exceeded _ -> "budget_exceeded"
+  | Internal_error _ -> "internal_error"
+
 type judge_error_node =
   { failed_role : judge_role
-  ; error : string
+  ; failure : judge_failure
   ; usage : usage
       (** 실패해도 태운 토큰 — 관측 record가 비용을 버리지 않는다(RFC-0284, 적대 리뷰 #22112 E).
           [panel_error]와 달리 심판 실패는 토큰 소비 후일 수 있어 usage를 동반한다. *)
   ; elapsed_s : float
       (** 이 심판 노드가 시작된 시점부터 실패까지 경과한 시간(초). 예산/타임아웃
-          분석에 쓰인다(RFC-0284-FUSION-P0). *)
-  ; timed_out : bool
-      (** 에러 메시지가 구조적 타임아웃("Execution timed out after")을 나타내는가. *)
+          분석에 쓰인다(RFC-0284-FUSION-P0). [timed_out]은 [judge_failure_is_timeout failure]
+          로 파생 가능해 별도 필드에서 제거했다. *)
   }
 [@@deriving yojson, show, eq]
 

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -216,6 +216,45 @@ type judge_role =
   | Final_meta
 [@@deriving yojson, show, eq]
 
+(** 심판(judge) 한 명이 실패하는 방식. {!panel_failure}와 동형인 닫힌 합이되, 심판
+    도메인에만 존재하는 사유([Empty_result]/[Build_error]/[Parse_error]/[Budget_exceeded])
+    를 추가로 담는다. [panel_failure]를 literal하게 공유하지 않는 이유: 판(panel) 전용인
+    [Invalid_max_output_tokens]가 심판에서 dead variant가 되고, wave-budget SKIP을
+    [Provider_error "...skipped..."] 문자열에 숨기면 orchestrator의 fallback 분류가
+    substring match로 잔존하기 때문이다(CLAUDE.md §string-classifier 안티패턴).
+
+    근원에서 typed로 propagate한다: [Fusion_judge.run] 계열이 {!Agent_sdk.Error}의
+    [Timeout] variant를 match에서 잡아 [Timeout]으로, provider/transport 에러를
+    [Provider_error]로 반환한다. 호출자는 [string]을 역분류하지 않고 exhaustive match로
+    분류한다. *)
+type judge_failure =
+  | Timeout  (** 구조적 타임아웃 — Agent_sdk.Error.Api (Retry.Timeout _)에서 propagate *)
+  | Provider_error of string  (** provider/transport 에러, to_string 보존 *)
+  | Empty_response of string  (** 모델이 빈 응답 *)
+  | Empty_result  (** Async_agent.all 이 빈 결과를 반환 *)
+  | Build_error of string  (** Fusion_oas.build_agent 실패 *)
+  | Parse_error of string  (** Fusion_judge_parse.of_string 파싱 실패 *)
+  | Budget_exceeded of string  (** wave budget 초과로 심판 실행 전 SKIP *)
+  | Internal_error of string  (** all_fail_error fallback / 미분류 *)
+[@@deriving to_yojson, show, eq]
+
+val judge_failure_of_yojson : Yojson.Safe.t -> (judge_failure, string) result
+
+(** [Timeout] 변형인가. {!judge_error_node}의 [timed_out] 파생처럼, 분류는 variant 자체로
+    충분하므로 별도 bool 필드를 두지 않는다. *)
+val judge_failure_is_timeout : judge_failure -> bool
+
+(** [Timeout] 또는 [Budget_exceeded] 인가. orchestrator의 fallback-judge 트리거 조건:
+    1차 심판 전원이 타임아웃/예산-skip이면 fallback을 시도한다. exhaustive match로
+    string classifier([is_timeout_or_budget_error])를 대체한다. *)
+val judge_failure_is_timeout_or_budget : judge_failure -> bool
+
+(** sink/로그용 사람-가독 문자열. {!Fusion_oas.panel_failure_text}와 대칭. *)
+val judge_failure_text : judge_failure -> string
+
+(** 대시보드 failure_code 키용 정규화 태그(timeout/provider_error/...). *)
+val judge_failure_tag : judge_failure -> string
+
 (** 성공한 심판 노드 — 역할 + 종합 + 노드별 실측 usage. *)
 type judge_node =
   { role : judge_role
@@ -224,16 +263,15 @@ type judge_node =
   }
 [@@deriving yojson, show, eq]
 
-(** 격리된 심판 실패 노드. *)
+(** 격리된 심판 실패 노드. [failure]가 single source of truth: [timed_out]은
+    [judge_failure_is_timeout failure]로 파생 가능해 별도 필드에서 제거했다. *)
 type judge_error_node =
   { failed_role : judge_role
-  ; error : string
+  ; failure : judge_failure
   ; usage : usage
-      (** 실패필도 태운 토큰 — 관측 record가 비용을 버리지 않는다(RFC-0284, 적대 리뷰 #22112 E). *)
+      (** 실패해도 태운 토큰 — 관측 record가 비용을 버리지 않는다(RFC-0284, 적대 리뷰 #22112 E). *)
   ; elapsed_s : float
       (** Wave start부터 실패까지 경과한 시간(초). 타임아웃/예산 원인 분석용. *)
-  ; timed_out : bool
-      (** 구조적 타임아웃("Execution timed out after")으로 분류되는 실패인가. *)
   }
 [@@deriving yojson, show, eq]
 

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -236,9 +236,7 @@ type judge_failure =
   | Parse_error of string  (** Fusion_judge_parse.of_string 파싱 실패 *)
   | Budget_exceeded of string  (** wave budget 초과로 심판 실행 전 SKIP *)
   | Internal_error of string  (** all_fail_error fallback / 미분류 *)
-[@@deriving to_yojson, show, eq]
-
-val judge_failure_of_yojson : Yojson.Safe.t -> (judge_failure, string) result
+[@@deriving yojson, show, eq]
 
 (** [Timeout] 변형인가. {!judge_error_node}의 [timed_out] 파생처럼, 분류는 variant 자체로
     충분하므로 별도 bool 필드를 두지 않는다. *)

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -229,7 +229,11 @@ type judge_error_node =
   { failed_role : judge_role
   ; error : string
   ; usage : usage
-      (** 실패해도 태운 토큰 — 관측 record가 비용을 버리지 않는다(RFC-0284, 적대 리뷰 #22112 E). *)
+      (** 실패필도 태운 토큰 — 관측 record가 비용을 버리지 않는다(RFC-0284, 적대 리뷰 #22112 E). *)
+  ; elapsed_s : float
+      (** Wave start부터 실패까지 경과한 시간(초). 타임아웃/예산 원인 분석용. *)
+  ; timed_out : bool
+      (** 구조적 타임아웃("Execution timed out after")으로 분류되는 실패인가. *)
   }
 [@@deriving yojson, show, eq]
 

--- a/test/dune
+++ b/test/dune
@@ -746,6 +746,13 @@
  (modules test_fusion_sink_meta)
  (libraries masc_test_deps masc.fusion_core))
 
+; FUSION adaptive timeout / P0 hardening: config, pure timeout helper, metrics,
+; and sink meta JSON for failed judge nodes.
+(test
+ (name test_fusion_adaptive_timeout)
+ (modules test_fusion_adaptive_timeout)
+ (libraries masc_test_deps masc.fusion_core))
+
 ; RFC-0207: per-keeper LLM runtime routing (persona [model] selection + driver fail-fast).
 
 (test

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1226,10 +1226,9 @@ let test_judge_outcome_roundtrip () =
         { role = Refine_pass; synthesis = synth (Answer "r"); usage = zero_usage }
     ; Judge_failed
         { failed_role = Meta
-        ; error = "boom"
+        ; failure = Provider_error "boom"
         ; usage = { input_tokens = 9; output_tokens = 10 }
         ; elapsed_s = 0.0
-        ; timed_out = false
         }
     ]
   in
@@ -1479,19 +1478,18 @@ let test_judge_error_node_timed_out () =
   let timeout_node =
     Fusion_types.Judge_failed
       { Fusion_types.failed_role = First "j"
-      ; error = "Execution timed out after 5.0s"
+      ; failure = Fusion_types.Timeout
       ; usage = Fusion_types.zero_usage
       ; elapsed_s = 5.0
-      ; timed_out = true
       }
   in
   let budget_node =
     Fusion_types.Judge_failed
       { Fusion_types.failed_role = First "j"
-      ; error = "judge j skipped: would exceed wave budget"
+      ; failure =
+          Fusion_types.Budget_exceeded "judge j skipped: would exceed wave budget"
       ; usage = Fusion_types.zero_usage
       ; elapsed_s = 3.0
-      ; timed_out = false
       }
   in
   match
@@ -1501,9 +1499,11 @@ let test_judge_error_node_timed_out () =
         (Fusion_types.judge_outcome_to_yojson budget_node) )
   with
   | Ok (Judge_failed n1), Ok (Judge_failed n2) ->
-    Alcotest.(check bool) "timeout node roundtrips timed_out" true n1.timed_out;
+    Alcotest.(check bool) "timeout node roundtrips timed_out" true
+      (Fusion_types.judge_failure_is_timeout n1.failure);
     Alcotest.(check (float 0.001)) "timeout node roundtrips elapsed_s" 5.0 n1.elapsed_s;
-    Alcotest.(check bool) "budget node roundtrips timed_out" false n2.timed_out;
+    Alcotest.(check bool) "budget node roundtrips timed_out" false
+      (Fusion_types.judge_failure_is_timeout n2.failure);
     Alcotest.(check (float 0.001)) "budget node roundtrips elapsed_s" 3.0 n2.elapsed_s
   | _ -> Alcotest.fail "expected Judge_failed roundtrip"
 

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -47,8 +47,12 @@ let base_policy : Fusion_policy.t =
           ; judge_system_prompt = "judge"
           ; judge_timeout_s = 300.0
           ; judge_max_output_tokens = None
+          ; meta_timeout_s = 300.0
           ; judges = []
           ; min_answered = Fusion_policy.default_min_answered
+          ; judge_wave_budget_s = Float.max_float
+          ; adaptive_timeout_factor = 1.0
+          ; fallback_judge_model = None
           }
       ]
   }
@@ -698,6 +702,8 @@ let test_config_disabled_with_preset () =
    그 변형이 발화하는지 확인한다. private 타입이라 외부는 of_preset로만 t를 만든다. *)
 let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthesize")
     ?(judges = []) ?(min_answered = Fusion_policy.default_min_answered)
+    ?(meta_timeout_s = 300.0) ?(judge_wave_budget_s = Float.max_float)
+    ?(adaptive_timeout_factor = 1.0) ?(fallback_judge_model = None)
     (name : string) : Fusion_policy.preset =
   { Fusion_policy.name
   ; panels
@@ -705,8 +711,12 @@ let mk_preset ?(panels = [ base_group ]) ?(judge = "j") ?(judge_prompt = "synthe
   ; judge_system_prompt = judge_prompt
   ; judge_timeout_s = 300.0
   ; judge_max_output_tokens = None
+  ; meta_timeout_s
   ; judges
   ; min_answered
+  ; judge_wave_budget_s
+  ; adaptive_timeout_factor
+  ; fallback_judge_model
   }
 
 let test_validated_ok () =
@@ -768,6 +778,7 @@ let base_judge : Fusion_policy.judge_spec =
   ; jmax_tool_calls = 0
   ; jmax_output_tokens = None
   ; jtimeout_s = 300.0
+  ; jmax_timeout_s = None
   }
 
 (* judges=[]면 (simple/refine/conditional preset) 기존과 동일하게 유효 = byte-identity. *)
@@ -1217,6 +1228,8 @@ let test_judge_outcome_roundtrip () =
         { failed_role = Meta
         ; error = "boom"
         ; usage = { input_tokens = 9; output_tokens = 10 }
+        ; elapsed_s = 0.0
+        ; timed_out = false
         }
     ]
   in
@@ -1282,6 +1295,241 @@ let test_min_answered_constants () =
   Alcotest.(check int) "default_min_answered" 1 Fusion_policy.default_min_answered;
   Alcotest.(check int) "min_answered_floor" 1 Fusion_policy.min_answered_floor
 
+
+(* --- FUSION adaptive timeout / P0 hardening (RFC-0284-FUSION-P0) --- *)
+
+let adaptive_toml =
+  {|
+[fusion]
+enabled = true
+default_preset = "adaptive"
+[fusion.presets.adaptive]
+judge = "meta"
+judge_system_prompt = "reconcile"
+judge_timeout_s = 120.0
+meta_timeout_s = 90.0
+judge_wave_budget_s = 500.0
+adaptive_timeout_factor = 2.0
+fallback_judge_model = "fallback-model"
+[[fusion.presets.adaptive.panels]]
+panel = ["p1"]
+panel_system_prompt = "answer"
+[[fusion.presets.adaptive.judges]]
+model = "judge-a"
+system_prompt = "lens A"
+timeout_s = 100.0
+max_timeout_s = 180.0
+[[fusion.presets.adaptive.judges]]
+model = "judge-b"
+system_prompt = "lens B"
+timeout_s = 110.0
+|}
+
+let test_config_adaptive_timeout_parse () =
+  match Fusion_config.of_toml (parse adaptive_toml) with
+  | Ok p ->
+    (match p.Fusion_policy.presets with
+     | [ vp ] ->
+       let preset = raw vp in
+       Alcotest.(check (float 0.001)) "meta_timeout_s" 90.0
+         preset.Fusion_policy.meta_timeout_s;
+       Alcotest.(check (float 0.001)) "judge_wave_budget_s" 500.0
+         preset.Fusion_policy.judge_wave_budget_s;
+       Alcotest.(check (float 0.001)) "adaptive_timeout_factor" 2.0
+         preset.Fusion_policy.adaptive_timeout_factor;
+       Alcotest.(check (option string)) "fallback_judge_model"
+         (Some "fallback-model")
+         preset.Fusion_policy.fallback_judge_model;
+       (match preset.Fusion_policy.judges with
+        | [ ja; _ ] ->
+          Alcotest.(check (float 0.001)) "ja timeout" 100.0 ja.Fusion_policy.jtimeout_s;
+          Alcotest.(check (option (float 0.001))) "ja max_timeout_s"
+            (Some 180.0)
+            ja.Fusion_policy.jmax_timeout_s
+        | _ -> Alcotest.fail "expected two judges")
+     | _ -> Alcotest.fail "expected exactly one preset")
+  | Error es ->
+    Alcotest.failf "expected Ok, got errors: %s"
+      (String.concat ", " (List.map Fusion_config.show_config_error es))
+
+let test_config_adaptive_timeout_defaults () =
+  match Fusion_config.of_toml (parse golden_single_group_toml) with
+  | Ok p ->
+    (match p.Fusion_policy.presets with
+     | [ vp ] ->
+       let preset = raw vp in
+       Alcotest.(check (float 0.001)) "meta_timeout_s defaults to judge_timeout_s"
+         preset.Fusion_policy.judge_timeout_s
+         preset.Fusion_policy.meta_timeout_s;
+       Alcotest.(check bool) "judge_wave_budget_s defaults to max_float"
+         true
+         (preset.Fusion_policy.judge_wave_budget_s = Float.max_float);
+       Alcotest.(check (float 0.001)) "adaptive_timeout_factor defaults to 1.0"
+         1.0
+         preset.Fusion_policy.adaptive_timeout_factor;
+       Alcotest.(check (option string)) "fallback_judge_model defaults to None"
+         None
+         preset.Fusion_policy.fallback_judge_model
+     | _ -> Alcotest.fail "expected one preset")
+  | Error _ -> Alcotest.fail "golden must parse Ok"
+
+let test_config_invalid_meta_timeout () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p"
+[fusion.presets.p]
+panel = ["a"]
+judge = "j"
+panel_system_prompt = "x"
+judge_system_prompt = "y"
+meta_timeout_s = 0.0
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    Alcotest.(check bool) "Invalid_meta_timeout present" true
+      (List.exists
+         (function Fusion_config.Invalid_meta_timeout _ -> true | _ -> false)
+         es)
+  | Ok _ -> Alcotest.fail "expected Error Invalid_meta_timeout"
+
+let test_config_invalid_adaptive_factor () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p"
+[fusion.presets.p]
+panel = ["a"]
+judge = "j"
+panel_system_prompt = "x"
+judge_system_prompt = "y"
+adaptive_timeout_factor = 0.5
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    Alcotest.(check bool) "Invalid_adaptive_timeout_factor present" true
+      (List.exists
+         (function Fusion_config.Invalid_adaptive_timeout_factor _ -> true | _ -> false)
+         es)
+  | Ok _ -> Alcotest.fail "expected Error Invalid_adaptive_timeout_factor"
+
+let test_config_invalid_judge_wave_budget () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p"
+[fusion.presets.p]
+panel = ["a"]
+judge = "j"
+panel_system_prompt = "x"
+judge_system_prompt = "y"
+judge_wave_budget_s = 50.0
+[[fusion.presets.p.judges]]
+model = "judge-a"
+system_prompt = "lens"
+timeout_s = 100.0
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    Alcotest.(check bool) "Invalid_judge_wave_budget present" true
+      (List.exists
+         (function Fusion_config.Invalid_judge_wave_budget _ -> true | _ -> false)
+         es)
+  | Ok _ -> Alcotest.fail "expected Error Invalid_judge_wave_budget"
+
+let test_adjust_judge_timeout_disabled () =
+  Alcotest.(check (option (float 0.001))) "factor=1.0 within budget"
+    (Some 10.0)
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
+       ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:false);
+  Alcotest.(check (option (float 0.001))) "factor=1.0 over budget"
+    None
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
+       ~wave_budget_s:14.0 ~elapsed_s:5.0 ~already_timed_out:false)
+
+let test_adjust_judge_timeout_extend () =
+  (* already timed out + factor > 1.0 extends up to max_s and remaining budget. *)
+  Alcotest.(check (option (float 0.001))) "extend capped by max_s"
+    (Some 15.0)
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 15.0)
+       ~factor:2.0 ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:true);
+  Alcotest.(check (option (float 0.001))) "extend capped by remaining budget"
+    (Some 7.0)
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
+       ~factor:2.0 ~wave_budget_s:12.0 ~elapsed_s:5.0 ~already_timed_out:true);
+  Alcotest.(check (option (float 0.001))) "extend below 0.001 -> None"
+    None
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
+       ~factor:2.0 ~wave_budget_s:5.0 ~elapsed_s:5.0 ~already_timed_out:true)
+
+let test_adjust_judge_timeout_not_yet_timed_out () =
+  (* factor > 1.0 but not yet timed out: still use base_s, just budget-check. *)
+  Alcotest.(check (option (float 0.001))) "not timed out uses base_s"
+    (Some 10.0)
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 5.0)
+       ~factor:2.0 ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:false)
+
+let test_judge_error_node_timed_out () =
+  let timeout_node =
+    Fusion_types.Judge_failed
+      { Fusion_types.failed_role = First "j"
+      ; error = "Execution timed out after 5.0s"
+      ; usage = Fusion_types.zero_usage
+      ; elapsed_s = 5.0
+      ; timed_out = true
+      }
+  in
+  let budget_node =
+    Fusion_types.Judge_failed
+      { Fusion_types.failed_role = First "j"
+      ; error = "judge j skipped: would exceed wave budget"
+      ; usage = Fusion_types.zero_usage
+      ; elapsed_s = 3.0
+      ; timed_out = false
+      }
+  in
+  match
+    ( Fusion_types.judge_outcome_of_yojson
+        (Fusion_types.judge_outcome_to_yojson timeout_node)
+    , Fusion_types.judge_outcome_of_yojson
+        (Fusion_types.judge_outcome_to_yojson budget_node) )
+  with
+  | Ok (Judge_failed n1), Ok (Judge_failed n2) ->
+    Alcotest.(check bool) "timeout node roundtrips timed_out" true n1.timed_out;
+    Alcotest.(check (float 0.001)) "timeout node roundtrips elapsed_s" 5.0 n1.elapsed_s;
+    Alcotest.(check bool) "budget node roundtrips timed_out" false n2.timed_out;
+    Alcotest.(check (float 0.001)) "budget node roundtrips elapsed_s" 3.0 n2.elapsed_s
+  | _ -> Alcotest.fail "expected Judge_failed roundtrip"
+
+let test_validated_bad_meta_timeout () =
+  match
+    Fusion_policy.Validated_preset.of_preset (mk_preset ~meta_timeout_s:0.0 "bad-meta")
+  with
+  | Error (Fusion_policy.Validated_preset.Bad_meta_timeout 0.0) -> ()
+  | _ -> Alcotest.fail "expected Bad_meta_timeout 0.0"
+
+let test_validated_bad_adaptive_factor () =
+  match
+    Fusion_policy.Validated_preset.of_preset
+      (mk_preset ~adaptive_timeout_factor:0.5 "bad-factor")
+  with
+  | Error (Fusion_policy.Validated_preset.Bad_adaptive_factor 0.5) -> ()
+  | _ -> Alcotest.fail "expected Bad_adaptive_factor 0.5"
+
+let test_validated_bad_judge_wave_budget () =
+  match
+    Fusion_policy.Validated_preset.of_preset
+      (mk_preset ~judge_wave_budget_s:50.0 ~judges:[ base_judge ] "bad-budget")
+  with
+  | Error (Fusion_policy.Validated_preset.Bad_judge_wave_budget 50.0) -> ()
+  | _ -> Alcotest.fail "expected Bad_judge_wave_budget 50.0"
+
 let () =
   Alcotest.run "fusion_core"
     [ ( "gate"
@@ -1329,6 +1577,15 @@ let () =
         ; Alcotest.test_case "disabled_with_preset" `Quick test_config_disabled_with_preset
         ; Alcotest.test_case "judges_parse" `Quick test_config_judges_parse
         ; Alcotest.test_case "no_judges" `Quick test_config_no_judges
+        ; Alcotest.test_case "adaptive_timeout_parse" `Quick
+            test_config_adaptive_timeout_parse
+        ; Alcotest.test_case "adaptive_timeout_defaults" `Quick
+            test_config_adaptive_timeout_defaults
+        ; Alcotest.test_case "invalid_meta_timeout" `Quick test_config_invalid_meta_timeout
+        ; Alcotest.test_case "invalid_adaptive_factor" `Quick
+            test_config_invalid_adaptive_factor
+        ; Alcotest.test_case "invalid_judge_wave_budget" `Quick
+            test_config_invalid_judge_wave_budget
         ] )
     ; ( "validated_preset"
       , [ Alcotest.test_case "ok" `Quick test_validated_ok
@@ -1347,6 +1604,11 @@ let () =
             test_validated_judge_bad_max_tool_calls
         ; Alcotest.test_case "judge_bad_max_output_tokens" `Quick
             test_validated_judge_bad_max_output_tokens
+        ; Alcotest.test_case "bad_meta_timeout" `Quick test_validated_bad_meta_timeout
+        ; Alcotest.test_case "bad_adaptive_factor" `Quick
+            test_validated_bad_adaptive_factor
+        ; Alcotest.test_case "bad_judge_wave_budget" `Quick
+            test_validated_bad_judge_wave_budget
         ] )
     ; ( "staged_judge_groups"
       , [ Alcotest.test_case "exact_3x3" `Quick test_staged_judge_groups_exact_3x3
@@ -1358,6 +1620,12 @@ let () =
       , [ Alcotest.test_case "single_group_identity" `Quick
             test_judge_args_single_group_identity
         ; Alcotest.test_case "multi_group" `Quick test_judge_args_multi_group
+        ] )
+    ; ( "adaptive_timeout"
+      , [ Alcotest.test_case "disabled" `Quick test_adjust_judge_timeout_disabled
+        ; Alcotest.test_case "extend" `Quick test_adjust_judge_timeout_extend
+        ; Alcotest.test_case "not_yet_timed_out" `Quick
+            test_adjust_judge_timeout_not_yet_timed_out
         ] )
     ; ( "judge_parse"
       , [ Alcotest.test_case "valid" `Quick test_judge_valid
@@ -1383,7 +1651,10 @@ let () =
         ; Alcotest.test_case "render_empty_lists" `Quick test_render_empty_lists
         ] )
     ; ( "judge_outcome"
-      , [ Alcotest.test_case "roundtrip" `Quick test_judge_outcome_roundtrip ] )
+      , [ Alcotest.test_case "roundtrip" `Quick test_judge_outcome_roundtrip
+        ; Alcotest.test_case "timed_out_elapsed_s" `Quick
+            test_judge_error_node_timed_out
+        ] )
     ; ( "panel_guard"
       , [ Alcotest.test_case "judge_skip_reason" `Quick test_judge_skip_reason
         ; Alcotest.test_case "min_answered_range" `Quick test_validated_bad_min_answered

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -1450,7 +1450,11 @@ let test_adjust_judge_timeout_disabled () =
   Alcotest.(check (option (float 0.001))) "factor=1.0 over budget"
     None
     (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:14.0 ~elapsed_s:5.0 ~already_timed_out:false)
+       ~wave_budget_s:14.0 ~elapsed_s:5.0 ~already_timed_out:false);
+  Alcotest.(check (option (float 0.001))) "wave budget 0 disables cap"
+    (Some 10.0)
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
+       ~wave_budget_s:0.0 ~elapsed_s:500.0 ~already_timed_out:false)
 
 let test_adjust_judge_timeout_extend () =
   (* already timed out + factor > 1.0 extends up to max_s and remaining budget. *)

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -1,0 +1,200 @@
+(* FUSION adaptive timeout / P0 hardening tests.
+   Covers: config parse/validation, pure adjust_judge_timeout semantics,
+   OTel counter emission, and sink meta JSON for failed judge nodes. *)
+
+open Alcotest
+open Masc
+open Fusion_types
+
+let sample_usage : Fusion_types.usage =
+  { Fusion_types.input_tokens = 10; output_tokens = 5 }
+
+let sample_synthesis : Fusion_types.judge_synthesis =
+  { Fusion_types.consensus = []
+  ; contradictions = []
+  ; partial_coverage = []
+  ; unique_insights = []
+  ; blind_spots = []
+  ; resolved_answer = "ok"
+  ; decision = Fusion_types.Answer "ok"
+  }
+
+let parse s = Otoml.Parser.from_string s
+
+let adaptive_toml =
+  {|
+[fusion]
+enabled = true
+default_preset = "adaptive"
+[fusion.presets.adaptive]
+judge = "meta"
+judge_system_prompt = "reconcile"
+judge_timeout_s = 120.0
+meta_timeout_s = 90.0
+judge_wave_budget_s = 500.0
+adaptive_timeout_factor = 2.0
+fallback_judge_model = "fallback-model"
+[[fusion.presets.adaptive.panels]]
+panel = ["p1"]
+panel_system_prompt = "answer"
+[[fusion.presets.adaptive.judges]]
+model = "judge-a"
+system_prompt = "lens A"
+timeout_s = 100.0
+max_timeout_s = 180.0
+[[fusion.presets.adaptive.judges]]
+model = "judge-b"
+system_prompt = "lens B"
+timeout_s = 110.0
+|}
+
+let test_config_adaptive_timeout_parse () =
+  match Fusion_config.of_toml (parse adaptive_toml) with
+  | Ok p ->
+    (match p.Fusion_policy.presets with
+     | [ vp ] ->
+       let preset = Fusion_policy.Validated_preset.preset vp in
+       check (float 0.001) "meta_timeout_s" 90.0 preset.Fusion_policy.meta_timeout_s;
+       check (float 0.001) "judge_wave_budget_s" 500.0
+         preset.Fusion_policy.judge_wave_budget_s;
+       check (float 0.001) "adaptive_timeout_factor" 2.0
+         preset.Fusion_policy.adaptive_timeout_factor;
+       check (option string) "fallback_judge_model" (Some "fallback-model")
+         preset.Fusion_policy.fallback_judge_model;
+       (match preset.Fusion_policy.judges with
+        | [ ja; _ ] ->
+          check (float 0.001) "ja timeout" 100.0 ja.Fusion_policy.jtimeout_s;
+          check (option (float 0.001)) "ja max_timeout_s" (Some 180.0)
+            ja.Fusion_policy.jmax_timeout_s
+        | _ -> fail "expected two judges")
+     | _ -> fail "expected exactly one preset")
+  | Error es ->
+    failf "expected Ok, got errors: %s"
+      (String.concat ", " (List.map Fusion_config.show_config_error es))
+
+let test_config_invalid_meta_timeout () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p"
+[fusion.presets.p]
+panel = ["a"]
+judge = "j"
+panel_system_prompt = "x"
+judge_system_prompt = "y"
+meta_timeout_s = 0.0
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    check bool "Invalid_meta_timeout present" true
+      (List.exists
+         (function Fusion_config.Invalid_meta_timeout _ -> true | _ -> false)
+         es)
+  | Ok _ -> fail "expected Error Invalid_meta_timeout"
+
+let test_config_invalid_adaptive_factor () =
+  let s =
+    {|
+[fusion]
+enabled = true
+default_preset = "p"
+[fusion.presets.p]
+panel = ["a"]
+judge = "j"
+panel_system_prompt = "x"
+judge_system_prompt = "y"
+adaptive_timeout_factor = 0.5
+|}
+  in
+  match Fusion_config.of_toml (parse s) with
+  | Error es ->
+    check bool "Invalid_adaptive_timeout_factor present" true
+      (List.exists
+         (function Fusion_config.Invalid_adaptive_timeout_factor _ -> true
+                 | _ -> false)
+         es)
+  | Ok _ -> fail "expected Error Invalid_adaptive_timeout_factor"
+
+let test_adjust_judge_timeout_disabled () =
+  check (option (float 0.001)) "factor=1.0 within budget" (Some 10.0)
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
+       ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:false);
+  check (option (float 0.001)) "factor=1.0 over budget" None
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
+       ~wave_budget_s:14.0 ~elapsed_s:5.0 ~already_timed_out:false)
+
+let test_adjust_judge_timeout_extend () =
+  check (option (float 0.001)) "extend capped by max_s" (Some 15.0)
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 15.0)
+       ~factor:2.0 ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:true);
+  check (option (float 0.001)) "extend capped by remaining budget" (Some 7.0)
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
+       ~factor:2.0 ~wave_budget_s:12.0 ~elapsed_s:5.0 ~already_timed_out:true);
+  check (option (float 0.001)) "extend below 0.001 -> None" None
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
+       ~factor:2.0 ~wave_budget_s:5.0 ~elapsed_s:5.0 ~already_timed_out:true)
+
+let test_record_adaptive_timeout_emits () =
+  let before =
+    Otel_metric_store.metric_value_or_zero
+      Fusion_metrics.metric_fusion_adaptive_timeout_extensions_total
+      ()
+  in
+  Fusion_metrics.record_adaptive_timeout ();
+  let after =
+    Otel_metric_store.metric_value_or_zero
+      Fusion_metrics.metric_fusion_adaptive_timeout_extensions_total
+      ()
+  in
+  check (float 0.0) "adaptive timeout counter incremented" (before +. 1.0) after
+
+let test_sink_failed_node_includes_timeout_fields () =
+  let node =
+    Fusion_types.Judge_failed
+      { Fusion_types.failed_role = First "j"
+      ; error = "Execution timed out after 5.0s"
+      ; usage = sample_usage
+      ; elapsed_s = 5.0
+      ; timed_out = true
+      }
+  in
+  let json = Fusion_sink.judge_node_meta node in
+  match json with
+  | `Assoc fields ->
+    let get_float key =
+      match List.assoc_opt key fields with
+      | Some (`Float f) -> Some f
+      | _ -> None
+    in
+    let get_bool key =
+      match List.assoc_opt key fields with
+      | Some (`Bool b) -> Some b
+      | _ -> None
+    in
+    check (option (float 0.001)) "elapsed_s" (Some 5.0) (get_float "elapsed_s");
+    check (option bool) "timed_out" (Some true) (get_bool "timed_out")
+  | _ -> fail "expected Assoc"
+
+let () =
+  run "fusion_adaptive_timeout"
+    [ ( "config"
+      , [ test_case "adaptive_timeout_parse" `Quick test_config_adaptive_timeout_parse
+        ; test_case "invalid_meta_timeout" `Quick test_config_invalid_meta_timeout
+        ; test_case "invalid_adaptive_factor" `Quick
+            test_config_invalid_adaptive_factor
+        ] )
+    ; ( "adjust_judge_timeout"
+      , [ test_case "disabled" `Quick test_adjust_judge_timeout_disabled
+        ; test_case "extend" `Quick test_adjust_judge_timeout_extend
+        ] )
+    ; ( "metrics"
+      , [ test_case "record_adaptive_timeout emits counter" `Quick
+            test_record_adaptive_timeout_emits
+        ] )
+    ; ( "sink"
+      , [ test_case "failed_node_includes_timeout_fields" `Quick
+            test_sink_failed_node_includes_timeout_fields
+        ] )
+    ]

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -154,10 +154,9 @@ let test_sink_failed_node_includes_timeout_fields () =
   let node =
     Fusion_types.Judge_failed
       { Fusion_types.failed_role = First "j"
-      ; error = "Execution timed out after 5.0s"
+      ; failure = Fusion_types.Timeout
       ; usage = sample_usage
       ; elapsed_s = 5.0
-      ; timed_out = true
       }
   in
   let json = Fusion_sink.judge_node_meta node in

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -19,6 +19,24 @@ let sample_synthesis : Fusion_types.judge_synthesis =
   ; decision = Fusion_types.Answer "ok"
   }
 
+let sample_judge model : Fusion_policy.judge_spec =
+  { Fusion_policy.jmodel = model
+  ; jlabel = ""
+  ; jsystem_prompt = "judge"
+  ; jweb_tools = false
+  ; jmax_tool_calls = 0
+  ; jmax_output_tokens = None
+  ; jtimeout_s = 1.0
+  ; jmax_timeout_s = None
+  }
+
+let failed_judge_run model failure :
+    Fusion_orchestrator_judge_wave.judge_run =
+  sample_judge model, model, Error (failure, Fusion_types.zero_usage), 0.0, false
+
+let ok_judge_run model : Fusion_orchestrator_judge_wave.judge_run =
+  sample_judge model, model, Ok (sample_synthesis, sample_usage), 0.0, false
+
 let parse s = Otoml.Parser.from_string s
 
 let adaptive_toml =
@@ -173,6 +191,46 @@ let test_runtime_clock_missing_env_returns_typed_failure () =
         (Fusion_types.judge_failure_text failure)
     | Ok _ -> fail "expected missing clock failure")
 
+let test_timeout_budget_first_wave_appends_fallback () =
+  let fallback_calls = ref 0 in
+  let fallback = ok_judge_run "fallback-model" in
+  let runs =
+    [ failed_judge_run "judge-a" Fusion_types.Timeout
+    ; failed_judge_run
+        "judge-b"
+        (Fusion_types.Budget_exceeded "wave budget exhausted")
+    ]
+  in
+  let with_fallback =
+    Fusion_orchestrator_judge_wave.with_timeout_budget_fallback
+      ~run_fallback_judge:(fun () ->
+        incr fallback_calls;
+        Some fallback)
+      runs
+  in
+  check int "fallback called once" 1 !fallback_calls;
+  check int "fallback appended" 3 (List.length with_fallback);
+  match List.rev with_fallback with
+  | (_, id, Ok _, _, _) :: _ -> check string "fallback id" "fallback-model" id
+  | _ -> fail "expected appended successful fallback"
+
+let test_timeout_budget_first_wave_skips_fallback_on_provider_error () =
+  let fallback_calls = ref 0 in
+  let runs =
+    [ failed_judge_run "judge-a" Fusion_types.Timeout
+    ; failed_judge_run "judge-b" (Fusion_types.Provider_error "hard failure")
+    ]
+  in
+  let without_fallback =
+    Fusion_orchestrator_judge_wave.with_timeout_budget_fallback
+      ~run_fallback_judge:(fun () ->
+        incr fallback_calls;
+        Some (ok_judge_run "fallback-model"))
+      runs
+  in
+  check int "fallback not called" 0 !fallback_calls;
+  check int "original runs kept" 2 (List.length without_fallback)
+
 let test_record_adaptive_timeout_emits () =
   let before =
     Otel_metric_store.metric_value_or_zero
@@ -228,6 +286,12 @@ let () =
     ; ( "clock"
       , [ test_case "missing runtime env returns typed failure" `Quick
             test_runtime_clock_missing_env_returns_typed_failure
+        ] )
+    ; ( "fallback"
+      , [ test_case "timeout/budget wave appends fallback" `Quick
+            test_timeout_budget_first_wave_appends_fallback
+        ; test_case "provider failure skips fallback" `Quick
+            test_timeout_budget_first_wave_skips_fallback_on_provider_error
         ] )
     ; ( "metrics"
       , [ test_case "record_adaptive_timeout emits counter" `Quick

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -123,7 +123,10 @@ let test_adjust_judge_timeout_disabled () =
        ~wave_budget_s:100.0 ~elapsed_s:5.0 ~already_timed_out:false);
   check (option (float 0.001)) "factor=1.0 over budget" None
     (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
-       ~wave_budget_s:14.0 ~elapsed_s:5.0 ~already_timed_out:false)
+       ~wave_budget_s:14.0 ~elapsed_s:5.0 ~already_timed_out:false);
+  check (option (float 0.001)) "wave budget 0 disables cap" (Some 10.0)
+    (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:None ~factor:1.0
+       ~wave_budget_s:0.0 ~elapsed_s:500.0 ~already_timed_out:false)
 
 let test_adjust_judge_timeout_extend () =
   check (option (float 0.001)) "extend capped by max_s" (Some 15.0)

--- a/test/test_fusion_adaptive_timeout.ml
+++ b/test/test_fusion_adaptive_timeout.ml
@@ -48,6 +48,16 @@ system_prompt = "lens B"
 timeout_s = 110.0
 |}
 
+let adaptive_preset () =
+  match Fusion_config.of_toml (parse adaptive_toml) with
+  | Ok p ->
+    (match p.Fusion_policy.presets with
+     | [ vp ] -> Fusion_policy.Validated_preset.preset vp
+     | _ -> fail "expected exactly one preset")
+  | Error es ->
+    failf "expected Ok, got errors: %s"
+      (String.concat ", " (List.map Fusion_config.show_config_error es))
+
 let test_config_adaptive_timeout_parse () =
   match Fusion_config.of_toml (parse adaptive_toml) with
   | Ok p ->
@@ -139,6 +149,30 @@ let test_adjust_judge_timeout_extend () =
     (Fusion_policy.adjust_judge_timeout ~base_s:10.0 ~max_s:(Some 30.0)
        ~factor:2.0 ~wave_budget_s:5.0 ~elapsed_s:5.0 ~already_timed_out:true)
 
+let test_runtime_clock_missing_env_returns_typed_failure () =
+  Masc_eio_env.reset_for_test ();
+  Fun.protect ~finally:Masc_eio_env.reset_for_test (fun () ->
+    let missing_clock_failure =
+      Fusion_types.Internal_error "missing runtime clock"
+    in
+    let clock =
+      Fusion_orchestrator_judge_wave.make_runtime_clock ~missing_clock_failure
+    in
+    match
+      Fusion_orchestrator_judge_wave.meta_budget_check
+        ~preset:(adaptive_preset ())
+        clock
+    with
+    | Error (Fusion_types.Internal_error msg, usage) ->
+      check string "typed failure message" "missing runtime clock" msg;
+      check int "input usage" 0 usage.Fusion_types.input_tokens;
+      check int "output usage" 0 usage.Fusion_types.output_tokens
+    | Error (failure, _) ->
+      failf
+        "expected Internal_error, got %s"
+        (Fusion_types.judge_failure_text failure)
+    | Ok _ -> fail "expected missing clock failure")
+
 let test_record_adaptive_timeout_emits () =
   let before =
     Otel_metric_store.metric_value_or_zero
@@ -190,6 +224,10 @@ let () =
     ; ( "adjust_judge_timeout"
       , [ test_case "disabled" `Quick test_adjust_judge_timeout_disabled
         ; test_case "extend" `Quick test_adjust_judge_timeout_extend
+        ] )
+    ; ( "clock"
+      , [ test_case "missing runtime env returns typed failure" `Quick
+            test_runtime_clock_missing_env_returns_typed_failure
         ] )
     ; ( "metrics"
       , [ test_case "record_adaptive_timeout emits counter" `Quick

--- a/test/test_fusion_judge_usage.ml
+++ b/test/test_fusion_judge_usage.ml
@@ -33,8 +33,9 @@ let test_attach_usage_on_parse_failure () =
   (* 핵심 불변식: 파싱이 실패해도(심판이 응답을 생성하느라 토큰을 이미 태움)
      usage가 버려지지 않고 에러에 동반된다. *)
   match Fusion_judge.attach_usage (Error "bad json") sample_usage with
-  | Error (msg, usage) ->
-    check string "error message preserved" "bad json" msg;
+  | Error (failure, usage) ->
+    check string "error message preserved" "bad json"
+      (Fusion_types.judge_failure_text failure);
     check usage_t "parse failure still carries the consumed usage" sample_usage
       usage
   | Ok _ -> fail "expected Error with usage"

--- a/test/test_fusion_metrics.ml
+++ b/test/test_fusion_metrics.ml
@@ -38,7 +38,12 @@ let test_labels () =
   check string "outcome failed" "failed"
     (Fusion_metrics.judge_outcome_label
        (Fusion_types.Judge_failed
-          { Fusion_types.failed_role = Meta; error = "boom"; usage = sample_usage }))
+          { Fusion_types.failed_role = Meta
+          ; error = "boom"
+          ; usage = sample_usage
+          ; elapsed_s = 0.0
+          ; timed_out = false
+          }))
 
 let test_record_judge_execution_emits () =
   let before =

--- a/test/test_fusion_metrics.ml
+++ b/test/test_fusion_metrics.ml
@@ -39,10 +39,9 @@ let test_labels () =
     (Fusion_metrics.judge_outcome_label
        (Fusion_types.Judge_failed
           { Fusion_types.failed_role = Meta
-          ; error = "boom"
+          ; failure = Fusion_types.Provider_error "boom"
           ; usage = sample_usage
           ; elapsed_s = 0.0
-          ; timed_out = false
           }))
 
 let test_record_judge_execution_emits () =

--- a/test/test_fusion_sink_meta.ml
+++ b/test/test_fusion_sink_meta.ml
@@ -258,6 +258,8 @@ let test_node_failed_keeps_identity () =
       { failed_role = First "a (m)"
       ; error = "boom"
       ; usage = { input_tokens = 7; output_tokens = 8 }
+      ; elapsed_s = 1.5
+      ; timed_out = false
       }
   in
   let a = assoc_of (Masc.Fusion_sink.judge_node_meta o) in

--- a/test/test_fusion_sink_meta.ml
+++ b/test/test_fusion_sink_meta.ml
@@ -124,7 +124,7 @@ let test_contradiction_positions () =
    | _ -> fail "contradictions[0] missing")
 
 let test_error_branch () =
-  let a = assoc_of (Masc.Fusion_sink.judge_meta (Error "boom")) in
+  let a = assoc_of (Masc.Fusion_sink.judge_meta (Error (Provider_error "boom"))) in
   check (option string) "status failed" (Some "failed") (string_field a "status");
   check (option string) "error message" (Some "boom") (string_field a "error");
   check bool "no consensus on error" false (List.mem "consensus" (keys a))
@@ -256,10 +256,9 @@ let test_node_failed_keeps_identity () =
   let o =
     Judge_failed
       { failed_role = First "a (m)"
-      ; error = "boom"
+      ; failure = Provider_error "boom"
       ; usage = { input_tokens = 7; output_tokens = 8 }
       ; elapsed_s = 1.5
-      ; timed_out = false
       }
   in
   let a = assoc_of (Masc.Fusion_sink.judge_node_meta o) in


### PR DESCRIPTION
Implements the task-1516 P0 hardening items for the FUSION judge orchestrator.

Changes:
- Config: add `judge_wave_budget_s`, `jmax_timeout_s`, `meta_timeout_s`, `adaptive_timeout_factor`, and `fallback_judge_model`.
- Policy: implement `adjust_judge_timeout` with wave-budget and max-timeout caps, a named `min_effective_timeout_s`, and `adaptive_timeout_enabled` so callers do not use float equality as a feature toggle.
- Judge boundary: return typed `Fusion_types.judge_failure` variants from `Fusion_judge.run` / `run_meta` / `run_refine`; `Agent_sdk.Error.Api (Timeout _)` is matched at the source boundary instead of round-tripping through provider message text.
- Orchestrator: match typed timeout/budget variants for retry/fallback control flow, require an Eio clock for adaptive accounting, invoke fallback judge only for typed timeout/budget failures, and separate meta timeout.
- Sink/meta: preserve compatible `error` / derived `timed_out` fields and add typed `failure_code` from the judge failure variant.
- Telemetry: keep `elapsed_s` and `masc_fusion_adaptive_timeout_extensions_total` as observations of typed control flow, not as a replacement for classification.
- Tests: extend `test/fusion_core/test_fusion.ml`, `test/test_fusion_adaptive_timeout.ml`, and sink/judge usage coverage for typed failures.

Boundary with #22440:
- #22440 / OAS owns provider connect-timeout configuration and enforcement (`runtime.toml` / provider config `connect-timeout-s`).
- This PR only governs the MASC Fusion judge-wave budget after Fusion has started judge execution, including typed retry/fallback decisions inside that wave.
- It is not a substitute for OAS connect-timeout root fixes and should not double-classify provider wording.

Local sanity is intentionally non-Dune here; build verification is left to CI.