### PR TITLE
feat(memory): P0 Memory OS adversarial audit hardening

### DIFF
--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -198,7 +198,7 @@ module KeeperMemoryOs = struct
   let librarian_runtime_id_default = None
   let librarian_global_slot_default = 1
   let gc_enabled_default = true
-  let reconcile_enabled_default = true
+  let reconcile_enabled_default = false
   let consolidation_enabled_default = false
   let consolidation_runtime_id_default = None
 
@@ -311,7 +311,8 @@ module KeeperMemoryOs = struct
       ~default:gc_enabled_default
   ;;
 
-  (** Per-keeper Memory OS reconcile maintenance fiber kill switch. Default: true;
+  (** Per-keeper Memory OS reconcile maintenance fiber kill switch.
+      Default: false while [Keeper_memory_os_reconcile] is a placeholder;
       invalid values fail closed to false.
       @category Policies
       @ops_class operator *)

--- a/lib/config/env_config_keeper.ml
+++ b/lib/config/env_config_keeper.ml
@@ -197,7 +197,8 @@ module KeeperMemoryOs = struct
   let librarian_timeout_sec_default = 600.0
   let librarian_runtime_id_default = None
   let librarian_global_slot_default = 1
-  let gc_enabled_default = false
+  let gc_enabled_default = true
+  let reconcile_enabled_default = true
   let consolidation_enabled_default = false
   let consolidation_runtime_id_default = None
 
@@ -298,8 +299,9 @@ module KeeperMemoryOs = struct
          ~default:librarian_global_slot_default)
   ;;
 
-  (** Per-keeper Memory OS GC maintenance fiber kill switch. Default: false;
-      invalid values fail closed to false.
+  (** Per-keeper Memory OS GC maintenance fiber kill switch. Default: true;
+      invalid values fail closed to false. Env var acts as a kill switch to
+      disable GC if a live dry-run shows it would prune the wrong rows.
       @category Storage
       @ops_class operator *)
   let gc_enabled () =
@@ -307,6 +309,17 @@ module KeeperMemoryOs = struct
       ~invalid:Env_config_memory.Fail_closed
       "MASC_KEEPER_MEMORY_OS_GC"
       ~default:gc_enabled_default
+  ;;
+
+  (** Per-keeper Memory OS reconcile maintenance fiber kill switch. Default: true;
+      invalid values fail closed to false.
+      @category Policies
+      @ops_class operator *)
+  let reconcile_enabled () =
+    get_bool_logged
+      ~invalid:Env_config_memory.Fail_closed
+      "MASC_KEEPER_MEMORY_OS_RECONCILE"
+      ~default:reconcile_enabled_default
   ;;
 
   (** Per-keeper Memory OS consolidation maintenance fiber kill switch.

--- a/lib/config/env_config_keeper.mli
+++ b/lib/config/env_config_keeper.mli
@@ -91,6 +91,7 @@ module KeeperMemoryOs : sig
   val librarian_runtime_id_default : string option
   val librarian_global_slot_default : int
   val gc_enabled_default : bool
+  val reconcile_enabled_default : bool
   val consolidation_enabled_default : bool
   val consolidation_runtime_id_default : string option
 
@@ -106,6 +107,7 @@ module KeeperMemoryOs : sig
   val librarian_runtime_id : unit -> string option
   val librarian_global_slot : unit -> int
   val gc_enabled : unit -> bool
+  val reconcile_enabled : unit -> bool
   val consolidation_enabled : unit -> bool
   val consolidation_runtime_id : unit -> string option
 end

--- a/lib/core/executable_path.mli
+++ b/lib/core/executable_path.mli
@@ -1,0 +1,13 @@
+(** Shell-free executable lookup helpers. *)
+
+val regular_file_is_executable : string -> bool
+
+val path_has_executable
+  :  ?getenv:(string -> string option)
+  -> string
+  -> bool
+
+val command_available
+  :  ?getenv:(string -> string option)
+  -> string
+  -> bool

--- a/lib/dune
+++ b/lib/dune
@@ -141,7 +141,6 @@
   worker_container_types
   worker_container
   worker_container_runners
-  executable_path
   exec_shell_adapter
   ;; keeper_memory sub-modules
   keeper_memory_policy

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -23,14 +23,12 @@ let default_complete ~sw ~net ?clock ~config ~messages () =
   Llm_provider.Complete.complete ~sw ~net ?clock ~config ~messages ()
 ;;
 
-(* RFC-0257 adversarial review: the previous process-global slot was removed in
-   favor of per-keeper lanes, but measured production data showed that an
-   unbounded shared flash/glm provider pool can spike empty-response rates.
-   Re-introduce an optional fleet-wide concurrency gate around librarian provider
-   calls only. Per-keeper lanes still serialize ordering and fairness; this slot
-   only caps simultaneous provider round-trips. Default 1 preserves the prior
-   #21230 protection; 0 disables the gate. *)
-let global_slot_capacity () =
+(* RFC-0257 / P0-4 adversarial hardening: per-keeper librarian provider slot.
+   The previous process-global slot allowed one slow keeper to starve the fleet.
+   Capacity is still read from [MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT]
+   (default 1), but the semaphore is now keyed by [keeper_id] so each keeper
+   gets its own concurrency budget. A capacity of 0 disables the gate entirely. *)
+let per_keeper_slot_capacity () =
   Env_config.KeeperMemoryOs.librarian_global_slot ()
 ;;
 
@@ -38,31 +36,35 @@ let memory_os_librarian_provider_slot_site = "memory_os_librarian_provider_slot"
 
 let provider_slot_wait_sec = 0.25
 
-type provider_slot_state =
+type provider_slot =
   { capacity : int
-  ; slot : Eio.Semaphore.t option
+  ; sem : Eio.Semaphore.t option
   }
 
-let provider_slot_mu = Stdlib.Mutex.create ()
-let provider_slot_state : provider_slot_state option ref = ref None
+let provider_slots_mu = Stdlib.Mutex.create ()
+let provider_slots : (string, provider_slot) Hashtbl.t = Hashtbl.create 64
 
-let provider_slot_for_capacity capacity =
-  Stdlib.Mutex.protect provider_slot_mu (fun () ->
-    match !provider_slot_state with
-    | Some state when state.capacity = capacity -> state.slot
+let provider_slot_for_keeper ~keeper_id capacity =
+  Stdlib.Mutex.protect provider_slots_mu (fun () ->
+    match Hashtbl.find_opt provider_slots keeper_id with
+    | Some slot when slot.capacity = capacity -> slot
     | _ ->
       let slot =
-        match capacity with
-        | 0 -> None
-        | n -> Some (Eio.Semaphore.make n)
+        { capacity
+        ; sem =
+            (match capacity with
+             | 0 -> None
+             | n -> Some (Eio.Semaphore.make n))
+        }
       in
-      provider_slot_state := Some { capacity; slot };
+      Hashtbl.replace provider_slots keeper_id slot;
       slot)
 ;;
 
-let with_provider_slot ~clock f =
-  let capacity = global_slot_capacity () in
-  match provider_slot_for_capacity capacity with
+let with_provider_slot ~keeper_id ~clock f =
+  let capacity = per_keeper_slot_capacity () in
+  let slot = provider_slot_for_keeper ~keeper_id capacity in
+  match slot.sem with
   | None -> Some (f ())
   | Some sem ->
     let acquired = ref false in
@@ -77,7 +79,8 @@ let with_provider_slot ~clock f =
      | Eio.Cancel.Cancelled _ as e -> raise e
      | exn ->
        Log.Keeper.warn
-         "librarian provider slot acquisition failed: %s"
+         "librarian provider slot acquisition failed keeper=%s: %s"
+         keeper_id
          (Printexc.to_string exn));
     if !acquired
     then
@@ -769,7 +772,7 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                  librarian_provider_clock_unavailable_error
              | Some clock -> (
              match
-               with_provider_slot ~clock (fun () ->
+               with_provider_slot ~keeper_id ~clock (fun () ->
                  extract_and_append_with_provider_classified
                    ?complete
                    ~clock
@@ -787,9 +790,9 @@ let run_best_effort ?complete ?timeout_sec ~runtime_id ~keeper_id (inp : Keeper_
                   [ "keeper", keeper_id; "site", memory_os_librarian_provider_slot_site ]
                  ();
                Log.Keeper.warn ~keeper_name:keeper_id
-                 "memory os librarian skipped runtime=%s: global provider slot busy (capacity=%d)"
+                 "memory os librarian skipped runtime=%s: per-keeper provider slot busy (capacity=%d)"
                  runtime_id
-                 (global_slot_capacity ())
+                 (per_keeper_slot_capacity ())
              | Some (Ok { episode; kind }) ->
                if should_record_cadence_success kind
                then (

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -142,21 +142,21 @@ val run_with_parse_retries
     [attempt] — the provider side effect lives in the [attempt] supplied by
     {!extract_with_provider}. *)
 
-val global_slot_capacity : unit -> int
-(** Fleet-wide librarian provider gate capacity from
+val per_keeper_slot_capacity : unit -> int
+(** Per-keeper librarian provider slot capacity from
     [MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT] (default 1, 0 disables the
-    gate). *)
+    gate). The capacity is applied per keeper, not fleet-wide. *)
 
 val with_provider_slot
-  :  clock:float Eio.Time.clock_ty Eio.Resource.t
+  :  keeper_id:string
+  -> clock:float Eio.Time.clock_ty Eio.Resource.t
   -> (unit -> 'a)
   -> 'a option
-(** Run [f] under the fleet-wide librarian provider gate — the #21230
-    storm-guard the per-keeper lane keeps as an optional fleet-wide cap. At
-    capacity N, the (N+1)-th concurrent entrant returns [None] after
-    [provider_slot_wait_sec] (drop, not block); capacity 0 disables the gate so
-    [f] always runs ([Some]). Exposed for storm-guard regression coverage
-    (#21376). *)
+(** Run [f] under the per-keeper librarian provider slot — the #21230/P0-4
+    storm guard. At capacity N per keeper, the (N+1)-th concurrent entrant for
+    the same keeper returns [None] after [provider_slot_wait_sec] (drop, not
+    block); capacity 0 disables the gate so [f] always runs ([Some]). Exposed
+    for storm-guard regression coverage (#21376). *)
 
 val librarian_provider_clock_unavailable_error : string
 (** Stable error returned before provider I/O when provider-backed librarian

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -155,6 +155,27 @@ let parse_memory_bank_content content =
   List.rev parsed_rev, invalid
 ;;
 
+(* Detect schema-mismatch rows among the invalid lines. A row is a schema mismatch
+   when it parses as JSON and carries an explicit [schema_version] that differs
+   from the current version. Rows without [schema_version] or non-JSON garbage are
+   ordinary parse failures, not schema mismatches. *)
+let has_schema_mismatch content =
+  let current = keeper_memory_schema_version in
+  content
+  |> String.split_on_char '\n'
+  |> List.exists (fun raw ->
+    let line = String.trim raw in
+    if String.equal line ""
+    then false
+    else (
+      match Yojson.Safe.from_string line with
+      | `Assoc fields ->
+        (match Safe_ops.json_int_opt "schema_version" (`Assoc fields) with
+         | Some v when v <> current -> true
+         | _ -> false)
+      | _ -> false))
+;;
+
 (* ── Memory Consolidation ───────────────────────────────── *)
 
 (** Extract trace_id from a memory row's JSON. *)
@@ -553,7 +574,21 @@ let compact_memory_bank_if_needed
     | Ok content ->
       let parsed, invalid = parse_memory_bank_content content in
       let before_notes = List.length parsed in
-      if size_bytes < trigger_bytes && before_notes <= target_notes && invalid = 0
+      if invalid > 0 && has_schema_mismatch content
+      then (
+        Log.Keeper.warn
+          "memory_bank_compaction: keeper=%s schema mismatch detected; refusing compaction"
+          meta.name;
+        { no_memory_bank_compaction with
+          performed = true;
+          target_notes;
+          before_notes;
+          after_notes = before_notes;
+          invalid_dropped = invalid;
+          source = Some Memory_bank;
+          error = Some Schema_mismatch;
+        })
+      else if size_bytes < trigger_bytes && before_notes <= target_notes && invalid = 0
       then
         { no_memory_bank_compaction with
           target_notes;
@@ -689,18 +724,28 @@ let compact_memory_bank_if_needed
                 ~base_rows:parsed
                 selected
             with
-            | Error _ ->
+            | Error msg ->
               record_memory_consolidation_metrics
                 ~keeper_name:meta.name
                 ~outcome:"write_failed"
                 generated_consolidated;
+              Otel_metric_store.inc_counter
+                Keeper_metrics.(to_string MemoryBankCompactionFailures)
+                ~labels:[ "keeper", meta.name; "reason", "write_error" ]
+                ();
+              Log.Keeper.warn
+                "memory_bank_compaction: keeper=%s write failed: %s"
+                meta.name
+                msg;
               { no_memory_bank_compaction with
+                performed = true;
                 target_notes;
                 before_notes;
                 after_notes = before_notes;
                 dedup_dropped;
                 invalid_dropped = invalid;
-                source = None;
+                source = Some Memory_bank;
+                error = Some (Write_error msg);
               }
             | Ok () ->
               let retained =
@@ -727,6 +772,7 @@ let compact_memory_bank_if_needed
                 dedup_dropped;
                 invalid_dropped = invalid;
                 dropped_by_kind;
+                error = None;
               }
 
 let append_memory_notes_from_reply

--- a/lib/keeper/keeper_memory_bank.ml
+++ b/lib/keeper/keeper_memory_bank.ml
@@ -169,6 +169,7 @@ let has_schema_mismatch content =
     then false
     else (
       match Yojson.Safe.from_string line with
+      | exception Yojson.Json_error _ -> false
       | `Assoc fields ->
         (match Safe_ops.json_int_opt "schema_version" (`Assoc fields) with
          | Some v when v <> current -> true

--- a/lib/keeper/keeper_memory_bank.mli
+++ b/lib/keeper/keeper_memory_bank.mli
@@ -78,6 +78,12 @@ type keeper_memory_summary =
 }
 (** @see [Keeper_memory_policy.keeper_memory_summary] *)
 
+type compaction_error = Keeper_memory_policy.compaction_error =
+  | Read_error
+  | Write_error of string
+  | Schema_mismatch
+(** @see [Keeper_memory_policy.compaction_error] *)
+
 type memory_bank_compaction =
   Keeper_memory_policy.memory_bank_compaction = {
   performed : bool;
@@ -89,6 +95,7 @@ type memory_bank_compaction =
   dedup_dropped : int;
   invalid_dropped : int;
   dropped_by_kind : (string * int) list;
+  error : compaction_error option;
 }
 (** @see [Keeper_memory_policy.memory_bank_compaction] *)
 

--- a/lib/keeper/keeper_memory_bank_selection.mli
+++ b/lib/keeper/keeper_memory_bank_selection.mli
@@ -57,6 +57,11 @@ type keeper_memory_summary =
   kind_counts : (string * int) list;
   recent_notes : keeper_memory_line list;
 }
+type compaction_error = Keeper_memory_policy.compaction_error =
+  | Read_error
+  | Write_error of string
+  | Schema_mismatch
+
 type memory_bank_compaction =
   Keeper_memory_policy.memory_bank_compaction = {
   performed : bool;
@@ -68,6 +73,7 @@ type memory_bank_compaction =
   dedup_dropped : int;
   invalid_dropped : int;
   dropped_by_kind : (string * int) list;
+  error : compaction_error option;
 }
 val no_memory_bank_compaction : memory_bank_compaction
 val keeper_memory_schema_version : int

--- a/lib/keeper/keeper_memory_os_recall.ml
+++ b/lib/keeper/keeper_memory_os_recall.ml
@@ -226,7 +226,13 @@ let dedup_by_claim facts =
    ([staleness_marker]) all read the same timestamp by construction. *)
 let truth_anchor (fact : fact) = reference_time fact
 
-(* Filter to current, order by structural recency (the truth anchor), and dedup.
+(* Filter to current, order by structural recency (the truth anchor), dedup, and
+   exclude first-person self-observations. Self-observations ("I am idle",
+   "I am looping") are transient agent-state notes, not verifiable external state
+   or durable knowledge, so they must not leak into the recall context shown to
+   the model. RFC-0285 §3.1 classifies them at the producer boundary; this is the
+   read-side enforcement.
+
    RFC-0247 replaced the composite [score_fact] order with this single typed
    timestamp: recall ordering is structural, never a learned number. The prior
    pipeline also ran spreading-activation reranking ([activate]) and lexical
@@ -238,6 +244,10 @@ let facts_recency_ranked ~now facts =
   facts
   |> List.filter (fact_is_current ~now)
   |> List.filter fact_prompt_recallable
+  |> List.filter (fun (fact : fact) ->
+    match fact.claim_kind with
+    | Some Keeper_memory_os_types.Self_observation -> false
+    | _ -> true)
   |> List.sort (fun a b -> compare (truth_anchor b) (truth_anchor a))
   |> dedup_by_claim
 ;;

--- a/lib/keeper/keeper_memory_os_recall.mli
+++ b/lib/keeper/keeper_memory_os_recall.mli
@@ -30,6 +30,11 @@ val enabled : unit -> bool
     Read side of Memory OS; the write side (librarian) is gated
     separately by [MASC_KEEPER_MEMORY_OS_LIBRARIAN]. *)
 
+val facts_recency_ranked
+  :  now:float -> Keeper_memory_os_types.fact list -> Keeper_memory_os_types.fact list
+(** Filter and order facts for prompt recall: current, recallable, not
+    self-observation, most-recent truth-anchor first. Exposed for tests. *)
+
 val render_if_enabled
   :  keeper_id:string
   -> now:float

--- a/lib/keeper/keeper_memory_os_reconcile.ml
+++ b/lib/keeper/keeper_memory_os_reconcile.ml
@@ -1,0 +1,11 @@
+(** Keeper_memory_os_reconcile — placeholder degrade path.
+
+    The full reconcile pass is not implemented in this worktree. The
+    server bootstrap maintenance fiber references this module through
+    the public [reconcile_keeper] function; when the module is only a
+    stub it logs a warning and returns so the fiber can proceed without
+    breaking the build or crashing the maintenance loop. *)
+
+let reconcile_keeper ~keeper_id () =
+  Log.Server.warn "memory_os_reconcile: module not available; skipping keeper=%s" keeper_id
+;;

--- a/lib/keeper/keeper_memory_os_reconcile.mli
+++ b/lib/keeper/keeper_memory_os_reconcile.mli
@@ -1,0 +1,3 @@
+(** Placeholder reconcile module. See [Keeper_memory_os_reconcile]. *)
+
+val reconcile_keeper : keeper_id:string -> unit -> unit

--- a/lib/keeper/keeper_memory_policy.ml
+++ b/lib/keeper/keeper_memory_policy.ml
@@ -167,6 +167,17 @@ let compaction_source_of_string_opt (s : string) : compaction_source option =
   | "memory_bank" -> Some Memory_bank
   | _ -> None
 
+type compaction_error =
+  | Read_error
+  | Write_error of string
+  | Schema_mismatch
+
+let compaction_error_to_string = function
+  | Read_error -> "read_error"
+  | Write_error msg -> "write_error: " ^ msg
+  | Schema_mismatch -> "schema_mismatch"
+;;
+
 type memory_bank_compaction = {
   performed: bool;
   source: compaction_source option;
@@ -177,6 +188,7 @@ type memory_bank_compaction = {
   dedup_dropped: int;
   invalid_dropped: int;
   dropped_by_kind: (string * int) list;
+  error: compaction_error option;
 }
 
 let no_memory_bank_compaction = {
@@ -189,6 +201,7 @@ let no_memory_bank_compaction = {
   dedup_dropped = 0;
   invalid_dropped = 0;
   dropped_by_kind = [];
+  error = None;
 }
 
 let keeper_memory_schema_version = 2

--- a/lib/keeper/keeper_memory_policy.mli
+++ b/lib/keeper/keeper_memory_policy.mli
@@ -118,6 +118,17 @@ type keeper_memory_summary = {
 }
 (** Aggregated view of the memory bank for the dashboard. *)
 
+type compaction_error =
+  | Read_error
+  | Write_error of string
+  | Schema_mismatch
+(** Typed compaction failure. [Read_error] covers unreadable files;
+    [Write_error msg] propagates the atomic rewrite failure;
+    [Schema_mismatch] reports rows with a non-current schema_version. *)
+
+val compaction_error_to_string : compaction_error -> string
+(** Human-readable error label for logging/metrics. *)
+
 type memory_bank_compaction = {
   performed : bool;
   source : compaction_source option;
@@ -128,8 +139,10 @@ type memory_bank_compaction = {
   dedup_dropped : int;
   invalid_dropped : int;
   dropped_by_kind : (string * int) list;
+  error : compaction_error option;
 }
-(** Result of a memory-bank compaction pass. *)
+(** Result of a memory-bank compaction pass. [error] is [Some _] when
+    the pass detected a schema mismatch or failed to rewrite the bank. *)
 
 val no_memory_bank_compaction : memory_bank_compaction
 (** [performed=false] zero value when no compaction was attempted. *)

--- a/lib/keeper/keeper_user_model.ml
+++ b/lib/keeper/keeper_user_model.ml
@@ -73,6 +73,10 @@ let rank_facts ~now facts =
   facts
   |> List.filter (fact_is_current ~now)
   |> List.filter fact_is_user_model
+  |> List.filter (fun (fact : fact) ->
+    match fact.claim_kind with
+    | Some Keeper_memory_os_types.Self_observation -> false
+    | _ -> true)
   |> List.sort (fun (a : fact) (b : fact) ->
     compare (reference_time b) (reference_time a))
   |> dedup_facts_by_claim

--- a/lib/keeper_metrics/keeper_metrics.ml
+++ b/lib/keeper_metrics/keeper_metrics.ml
@@ -161,6 +161,8 @@ type t =
   | MemoryLanePending
   | MemoryLaneInFlight
   | MemoryLaneProviderSlotBusy
+  | MemoryBankCompactionFailures
+  | MemoryOsMaintenanceKeeperTimeout
   | WriteMetaCycleFailures
   | AlertPersistFailures
   | MetricsSseFailures
@@ -409,6 +411,8 @@ let to_string = function
   | MemoryLanePending -> "masc_keeper_memory_lane_pending"
   | MemoryLaneInFlight -> "masc_keeper_memory_lane_in_flight"
   | MemoryLaneProviderSlotBusy -> "masc_keeper_memory_lane_provider_slot_busy_total"
+  | MemoryBankCompactionFailures -> "masc_keeper_memory_bank_compaction_failures_total"
+  | MemoryOsMaintenanceKeeperTimeout -> "masc_keeper_memory_os_maintenance_keeper_timeout_total"
   | WriteMetaCycleFailures -> "masc_keeper_write_meta_cycle_failures_total"
   | AlertPersistFailures -> "masc_keeper_alert_persist_failures_total"
   | MetricsSseFailures -> "masc_keeper_metrics_sse_failures_total"
@@ -539,7 +543,7 @@ let all : t list =
     MemoryLlmSummaryOutcomes; MemoryLlmSummaryChainExhausted; UserVisibleReplySource; ContinuitySummarySource;
     SummarizerStateScrubs; SummarizerStateBlocksRemoved; OasEnvKeyRejections; ContinuityTsRecovered;
     MemoryWriteFailures; MemoryLaneUnitFailures; MemoryConsolidations; MemoryLaneSubmitted; MemoryLaneRanInline; MemoryLaneDropped;
-    MemoryLanePending; MemoryLaneInFlight; MemoryLaneProviderSlotBusy; WriteMetaCycleFailures; AlertPersistFailures;
+    MemoryLanePending; MemoryLaneInFlight; MemoryLaneProviderSlotBusy; MemoryBankCompactionFailures; MemoryOsMaintenanceKeeperTimeout; WriteMetaCycleFailures; AlertPersistFailures;
     MetricsSseFailures; ChatStoreFailures; ChatTransportFailures; PersonNoteStoreFailures; KeeperMaterializationFailures; ObservationQueryFailures; OasOnStop;
     OasOnIdleEscalated; InvariantViolations; FsmEdgeTransitions; TurnFsmTransitions;
     TurnPhaseDuration; LifecycleTransitions; LifecycleCallbackFailures; CompactionCallbackRecoveries;

--- a/lib/keeper_metrics/keeper_metrics.mli
+++ b/lib/keeper_metrics/keeper_metrics.mli
@@ -152,6 +152,8 @@ type t =
   | MemoryLanePending
   | MemoryLaneInFlight
   | MemoryLaneProviderSlotBusy
+  | MemoryBankCompactionFailures
+  | MemoryOsMaintenanceKeeperTimeout
   | WriteMetaCycleFailures
   | AlertPersistFailures
   | MetricsSseFailures

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -35,6 +35,12 @@ type compaction_source =
   | MASC_policy
   | Memory_bank
 
+type compaction_error =
+  Keeper_memory_policy.compaction_error =
+    Read_error
+  | Write_error of string
+  | Schema_mismatch
+
 type compaction =
   Keeper_memory_policy.memory_bank_compaction = {
   performed : bool;
@@ -46,6 +52,7 @@ type compaction =
   dedup_dropped : int;
   invalid_dropped : int;
   dropped_by_kind : (string * int) list;
+  error : compaction_error option;
 }
 
 type read_error = Keeper_memory_recall_exn_class.t
@@ -172,6 +179,12 @@ let compaction_to_json (compaction : compaction) : Yojson.Safe.t =
              (fun (kind, count) ->
                `Assoc [ ("kind", `String kind); ("count", `Int count) ])
              compaction.dropped_by_kind) );
+      ( "error",
+        match compaction.error with
+        | None -> `Null
+        | Some Read_error -> `String "read_error"
+        | Some (Write_error msg) -> `Assoc [ ("write_error", `String msg) ]
+        | Some Schema_mismatch -> `String "schema_mismatch" );
     ]
 
 let to_json (memory : t) : Yojson.Safe.t =

--- a/lib/memory.mli
+++ b/lib/memory.mli
@@ -39,6 +39,12 @@ type compaction_source =
   | MASC_policy
   | Memory_bank
 
+type compaction_error =
+  Keeper_memory_policy.compaction_error =
+    Read_error
+  | Write_error of string
+  | Schema_mismatch
+
 type compaction =
   Keeper_memory_policy.memory_bank_compaction = {
   performed : bool;
@@ -50,6 +56,7 @@ type compaction =
   dedup_dropped : int;
   invalid_dropped : int;
   dropped_by_kind : (string * int) list;
+  error : compaction_error option;
 }
 
 type read_error = Keeper_memory_recall_exn_class.t

--- a/lib/procedural_memory.ml
+++ b/lib/procedural_memory.ml
@@ -95,11 +95,55 @@ let of_json (json : Yojson.Safe.t) : procedure option =
 (* File I/O                                                         *)
 (* ================================================================ *)
 
+type load_error =
+  { path : string
+  ; line_number : int
+  ; message : string
+  }
+
+type load_result = (procedure list, load_error list) result
+
 let load_procedures ?base_path ~agent_name () : procedure list =
   with_procedures_lock ?base_path ~agent_name (fun () ->
     let path = procedures_path ?base_path ~agent_name () in
     Fs_compat.load_jsonl path
     |> List.filter_map of_json)
+
+let load_procedures_strict ?base_path ~agent_name () : load_result =
+  with_procedures_lock ?base_path ~agent_name (fun () ->
+    let path = procedures_path ?base_path ~agent_name () in
+    if not (Fs_compat.file_exists path)
+    then Ok []
+    else (
+      let content = Fs_compat.load_file path in
+      let lines = String.split_on_char '\n' content in
+      let line_no = ref 0 in
+      let errors = ref [] in
+      let procedures = ref [] in
+      List.iter
+        (fun raw ->
+           let line = String.trim raw in
+           if String.equal line ""
+           then ()
+           else (
+             incr line_no;
+             match Yojson.Safe.from_string line with
+             | exception Yojson.Json_error msg ->
+               errors := { path; line_number = !line_no; message = msg } :: !errors
+             | json ->
+               (match of_json json with
+                | None ->
+                  errors :=
+                    { path
+                    ; line_number = !line_no
+                    ; message = "procedure schema mismatch"
+                    }
+                    :: !errors
+                | Some p -> procedures := p :: !procedures)))
+        lines;
+      match List.rev !errors with
+      | [] -> Ok (List.rev !procedures)
+      | errs -> Error errs))
 
 let save_procedure ?base_path ~agent_name (p : procedure) =
   with_procedures_lock ?base_path ~agent_name (fun () ->
@@ -116,8 +160,8 @@ let rewrite_procedures ?base_path ~agent_name (procs : procedure list) =
       |> fun s -> if s = "" then "" else s ^ "\n"
     in
     match Fs_compat.save_file_atomic path content with
-    | Ok () -> ()
-    | Error msg -> Log.Config.warn "procedural_memory save: %s" msg)
+    | Ok () -> Ok ()
+    | Error msg -> Error msg)
 
 (** Minimum evidence count required for crystallization.
     Configurable via MASC_PROC_MIN_EVIDENCE (default: 3).

--- a/lib/procedural_memory.mli
+++ b/lib/procedural_memory.mli
@@ -37,18 +37,37 @@ val procedures_path : ?base_path:string -> agent_name:string -> unit -> string
 
 (** {1 File I/O} *)
 
+(** A strict load error carries the file path, the 1-based line number
+    of the offending JSONL row, and the parser message. *)
+type load_error = {
+  path : string;
+  line_number : int;
+  message : string;
+}
+
+type load_result = (procedure list, load_error list) result
+(** Result of a strict load: the parsed procedures or the list of
+    errors encountered, each with line-level provenance. *)
+
 (** Load all persisted procedures for [agent_name]. Malformed JSONL
     lines are silently skipped (via [of_json]). Returns [[]] if the
     file does not exist. *)
 val load_procedures : ?base_path:string -> agent_name:string -> unit -> procedure list
 
+(** Load all persisted procedures for [agent_name] strictly. Every
+    JSONL line must parse and match the procedure schema. Returns
+    [Error errors] on the first row that fails, with path, line
+    number, and message. Returns [Ok []] when the file is missing. *)
+val load_procedures_strict : ?base_path:string -> agent_name:string -> unit -> load_result
+
 (** Append [p] to the agent's procedures file. Creates the directory
     if it does not exist. *)
 val save_procedure : ?base_path:string -> agent_name:string -> procedure -> unit
 
-(** Rewrite the full procedures file atomically. On write error,
-    logs via [Log.Config.warn] and returns [()]. *)
-val rewrite_procedures : ?base_path:string -> agent_name:string -> procedure list -> unit
+(** Rewrite the full procedures file atomically. Returns [Error msg]
+    when the atomic write fails so callers can decide whether to
+    surface or log. *)
+val rewrite_procedures : ?base_path:string -> agent_name:string -> procedure list -> (unit, string) result
 
 (** {1 Crystallisation} *)
 

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -318,9 +318,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       in
       loop ());
   (* P0-1: per-keeper Memory OS reconcile. Runs after GC at the same coarse
-     cadence. Degrades gracefully when [Keeper_memory_os_reconcile] is only a
+     cadence. The pass is opt-in while [Keeper_memory_os_reconcile] is only a
      stub; each keeper is wrapped in try/with so one failure does not cancel
-     siblings. Gated by [MASC_KEEPER_MEMORY_OS_RECONCILE] (default true). *)
+     siblings. Gated by [MASC_KEEPER_MEMORY_OS_RECONCILE] (default false). *)
   if Env_config.KeeperMemoryOs.reconcile_enabled () then
     fork_logged_fiber
       ~sw

--- a/lib/server/server_bootstrap_maintenance.ml
+++ b/lib/server/server_bootstrap_maintenance.ml
@@ -34,10 +34,30 @@ let provider_cfg_for_memory_os_consolidation () =
        default_cfg ())
 ;;
 
+(* P0-3: per-keeper maintenance timeout. One slow/corrupt keeper must not starve
+   the rest of the fleet. Each keeper fiber gets a bounded time budget; on
+   timeout we log the keeper and increment a metric so operators can see which
+   stores are stalling maintenance. *)
+let run_with_keeper_timeout ~clock ~timeout_sec ~keeper_id ~on_timeout f =
+  match clock with
+  | None -> f ()
+  | Some clock ->
+    (try Eio.Time.with_timeout_exn clock timeout_sec f with
+     | Eio.Time.Timeout ->
+       Otel_metric_store.inc_counter
+         Keeper_metrics.(to_string MemoryOsMaintenanceKeeperTimeout)
+         ~labels:[ "keeper", keeper_id ]
+         ();
+       on_timeout ())
+;;
+
 (* Run one consolidation pass over every keeper that currently has a fact store.
-   The optional [complete] injection lets tests drive the loop with a fake model. *)
+   The optional [complete] injection lets tests drive the loop with a fake model.
+   The optional [timeout_sec] lets tests exercise the per-keeper timeout without
+   waiting for the production default (300s). *)
 let run_memory_os_consolidation_tick
       ?(complete = Keeper_memory_os_consolidation_runtime.default_complete)
+      ?(timeout_sec = 300.0)
       ~sw
       ~net
       ?clock
@@ -45,55 +65,69 @@ let run_memory_os_consolidation_tick
       ~now
       ()
   =
-  List.iter
-    (fun keeper_id ->
-       try
-         match
-           Keeper_memory_os_consolidation_runtime.consolidate_keeper
-             ~complete
-             ~sw
-             ~net
-             ?clock
-             ~provider_cfg
-             ~now
-             ~keeper_id
-             ()
-         with
-         | Keeper_memory_os_consolidation_runtime.Consolidated { before; after } ->
-           Log.Server.info
-             "memory_os_keeper_consolidation: keeper=%s before=%d after=%d"
-             keeper_id
-             before
-             after
-         | Skipped_too_few n ->
-           Log.Server.info
-             "memory_os_keeper_consolidation: keeper=%s skipped_too_few=%d"
-             keeper_id
-             n
-         | Transport_failed msg ->
-           Log.Server.warn
-             "memory_os_keeper_consolidation: keeper=%s transport_failed: %s"
-             keeper_id
-             msg
-         | Unparseable msg ->
-           Log.Server.warn
-             "memory_os_keeper_consolidation: keeper=%s unparseable: %s"
-             keeper_id
-             msg
-         | Snapshot_changed { before; current } ->
-           Log.Server.info
-             "memory_os_keeper_consolidation: keeper=%s snapshot_changed before=%d current=%d"
-             keeper_id
-             before
-             current
-       with
-       | Eio.Cancel.Cancelled _ as e -> raise e
-       | exn ->
-         Log.Server.warn
-           "memory_os_keeper_consolidation: keeper=%s tick crashed: %s"
-           keeper_id
-           (Printexc.to_string exn))
-    (Keeper_memory_os_io.list_fact_store_keeper_ids ())
+  let keeper_ids = Keeper_memory_os_io.list_fact_store_keeper_ids () in
+  let consolidate_one keeper_id () =
+    try
+      match
+        Keeper_memory_os_consolidation_runtime.consolidate_keeper
+          ~complete
+          ~sw
+          ~net
+          ?clock
+          ~provider_cfg
+          ~now
+          ~keeper_id
+          ()
+      with
+      | Keeper_memory_os_consolidation_runtime.Consolidated { before; after } ->
+        Log.Server.info
+          "memory_os_keeper_consolidation: keeper=%s before=%d after=%d"
+          keeper_id
+          before
+          after
+      | Skipped_too_few n ->
+        Log.Server.info
+          "memory_os_keeper_consolidation: keeper=%s skipped_too_few=%d"
+          keeper_id
+          n
+      | Transport_failed msg ->
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s transport_failed: %s"
+          keeper_id
+          msg
+      | Unparseable msg ->
+        Log.Server.warn
+          "memory_os_keeper_consolidation: keeper=%s unparseable: %s"
+          keeper_id
+          msg
+      | Snapshot_changed { before; current } ->
+        Log.Server.info
+          "memory_os_keeper_consolidation: keeper=%s snapshot_changed before=%d current=%d"
+          keeper_id
+          before
+          current
+    with
+    | Eio.Cancel.Cancelled _ as e -> raise e
+    | exn ->
+      Log.Server.warn
+        "memory_os_keeper_consolidation: keeper=%s tick crashed: %s"
+        keeper_id
+        (Printexc.to_string exn)
+  in
+  Eio.Fiber.all
+    (List.map
+       (fun keeper_id () ->
+          run_with_keeper_timeout
+            ~clock
+            ~timeout_sec
+            ~keeper_id
+            ~on_timeout:(fun () ->
+              Log.Server.warn
+                "memory_os_keeper_consolidation: keeper=%s timeout after %.0fs"
+                keeper_id
+                timeout_sec)
+            (consolidate_one keeper_id))
+       keeper_ids)
 ;;
 
 let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_state) =
@@ -226,9 +260,9 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
      it the TTL/lifetime machinery (now produced per-category at librarian write
      time) is unreachable. The shared store is skipped — the consolidator
      reconstructs it wholesale each sweep, so GC-ing it would just be undone.
-     Default OFF (mirrors the consolidation gate): enable via the env once a live
-     dry-run confirms what it would prune. Per-keeper failures are caught so one
-     corrupt store cannot cancel siblings. *)
+     Default ON; env var [MASC_KEEPER_MEMORY_OS_GC] is the kill switch. Per-keeper
+     fibers run in parallel with a bounded timeout so one slow/corrupt store
+     cannot starve the fleet. *)
   if Env_config.KeeperMemoryOs.gc_enabled () then
     fork_logged_fiber
       ~sw
@@ -237,37 +271,94 @@ let start_background_maintenance ~sw ~clock ~env (state : Mcp_server.server_stat
       (* Coarser than consolidation (300s): GC rewrites stores, so a 10-minute
          cadence is ample off the hot path. *)
       let interval = 600.0 in
+      let gc_one keeper_id () =
+        try
+          let report =
+            Keeper_memory_os_gc.run_gc ~keeper_id ~now:(Time_compat.now ()) ()
+          in
+          if
+            report.Keeper_memory_os_gc.ttl_expired > 0
+            || report.dedup_removed > 0
+          then
+            Log.Server.info
+              "memory_os_gc: keeper=%s ttl_expired=%d dedup=%d written=%d"
+              keeper_id
+              report.ttl_expired
+              report.dedup_removed
+              report.written
+        with
+        | Eio.Cancel.Cancelled _ as e -> raise e
+        | exn ->
+          Log.Server.warn
+            "memory_os_gc: keeper=%s tick crashed: %s"
+            keeper_id
+            (Printexc.to_string exn)
+      in
       let rec loop () =
-        List.iter
-          (fun keeper_id ->
-             try
-               let report =
-                 Keeper_memory_os_gc.run_gc ~keeper_id ~now:(Time_compat.now ()) ()
-               in
-               if
-                 report.Keeper_memory_os_gc.ttl_expired > 0
-                 || report.dedup_removed > 0
-               then
-                 Log.Server.info
-                   "memory_os_gc: keeper=%s ttl_expired=%d dedup=%d written=%d"
-                   keeper_id
-                   report.ttl_expired
-                   report.dedup_removed
-                   report.written
-             with
-             | Eio.Cancel.Cancelled _ as e -> raise e
-             | exn ->
-               Log.Server.warn
-                 "memory_os_gc: keeper=%s tick crashed: %s"
-                 keeper_id
-                 (Printexc.to_string exn))
-          (List.filter
-             (fun id -> not (String.equal id Keeper_memory_os_types.shared_store_id))
-             (Keeper_memory_os_io.list_fact_store_keeper_ids ()));
+        let keeper_ids =
+          List.filter
+            (fun id -> not (String.equal id Keeper_memory_os_types.shared_store_id))
+            (Keeper_memory_os_io.list_fact_store_keeper_ids ())
+        in
+        Eio.Fiber.all
+          (List.map
+             (fun keeper_id () ->
+                run_with_keeper_timeout
+                  ~clock:(Some clock)
+                  ~timeout_sec:120.0
+                  ~keeper_id
+                  ~on_timeout:(fun () ->
+                    Log.Server.warn
+                      "memory_os_gc: keeper=%s timeout after 120s"
+                      keeper_id)
+                  (gc_one keeper_id))
+             keeper_ids);
         Eio.Time.sleep clock interval;
         loop ()
       in
       loop ());
+  (* P0-1: per-keeper Memory OS reconcile. Runs after GC at the same coarse
+     cadence. Degrades gracefully when [Keeper_memory_os_reconcile] is only a
+     stub; each keeper is wrapped in try/with so one failure does not cancel
+     siblings. Gated by [MASC_KEEPER_MEMORY_OS_RECONCILE] (default true). *)
+  if Env_config.KeeperMemoryOs.reconcile_enabled () then
+    fork_logged_fiber
+      ~sw
+      ~on_error:(log_server_fiber_crash "memory_os_reconcile")
+      (fun () ->
+        let interval = 600.0 in
+        let reconcile_one keeper_id () =
+          try Keeper_memory_os_reconcile.reconcile_keeper ~keeper_id () with
+          | Eio.Cancel.Cancelled _ as e -> raise e
+          | exn ->
+            Log.Server.warn
+              "memory_os_reconcile: keeper=%s tick crashed: %s"
+              keeper_id
+              (Printexc.to_string exn)
+        in
+        let rec loop () =
+          let keeper_ids =
+            List.filter
+              (fun id -> not (String.equal id Keeper_memory_os_types.shared_store_id))
+              (Keeper_memory_os_io.list_fact_store_keeper_ids ())
+          in
+          Eio.Fiber.all
+            (List.map
+               (fun keeper_id () ->
+                  run_with_keeper_timeout
+                    ~clock:(Some clock)
+                    ~timeout_sec:120.0
+                    ~keeper_id
+                    ~on_timeout:(fun () ->
+                      Log.Server.warn
+                        "memory_os_reconcile: keeper=%s timeout after 120s"
+                        keeper_id)
+                    (reconcile_one keeper_id))
+               keeper_ids);
+          Eio.Time.sleep clock interval;
+          loop ()
+        in
+        loop ());
   (* RFC-0247 §2.3: per-keeper Memory OS consolidation. The librarian writes
      facts every cadence turn; without this pass a keeper's Tier-1 store only
      grows. Off the hot path: every [interval]s it asks the model to merge

--- a/lib/server/server_bootstrap_maintenance.mli
+++ b/lib/server/server_bootstrap_maintenance.mli
@@ -7,6 +7,7 @@ val provider_cfg_for_memory_os_consolidation :
 
 val run_memory_os_consolidation_tick :
   ?complete:Keeper_memory_os_consolidation_runtime.complete_fn ->
+  ?timeout_sec:float ->
   sw:Eio.Switch.t ->
   net:[ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t ->
   ?clock:float Eio.Time.clock_ty Eio.Resource.t ->

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -33,7 +33,7 @@ lib/process/process_eio.ml:570
 # run_argv_pipeline_with_status_split.
 lib/process/process_eio.ml:1150
 
-# lib/server/lsp_process_manager.ml:179 — LSP child process. Lifetime is
+# lib/server/lsp_process_manager.ml:170 — LSP child process. Lifetime is
 # bound to the LSP session switch; idle eviction handled by the LSP
 # manager itself. Bounded by session scope, not by per-call timeout.
-lib/server/lsp_process_manager.ml:179
+lib/server/lsp_process_manager.ml:170

--- a/test/dune
+++ b/test/dune
@@ -1842,6 +1842,8 @@
 
 (include stanzas/test_keeper_turn_admission.inc)
 
+(include stanzas/test_keeper_memory_bank_compaction_errors.inc)
+
 (include stanzas/test_keeper_memory_bank_consensus_re_10399.inc)
 
 (include stanzas/test_keeper_memory_bank_consolidation_provenance.inc)

--- a/test/stanzas/test_keeper_memory_bank_compaction_errors.inc
+++ b/test/stanzas/test_keeper_memory_bank_compaction_errors.inc
@@ -1,0 +1,6 @@
+; P0-6: memory-bank compaction typed-error surfacing (schema mismatch / write failure).
+
+(test
+ (name test_keeper_memory_bank_compaction_errors)
+ (modules test_keeper_memory_bank_compaction_errors)
+ (libraries masc_test_deps masc alcotest yojson))

--- a/test/test_keeper_memory_bank_compaction_errors.ml
+++ b/test/test_keeper_memory_bank_compaction_errors.ml
@@ -12,7 +12,7 @@ let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
 ;;
 
 let write_file path content =
-  Masc.Keeper_fs.ensure_dir (Filename.dirname path);
+  let (_ : string) = Masc.Keeper_fs.ensure_dir (Filename.dirname path) in
   match Fs_compat.save_file_atomic path content with
   | Ok () -> ()
   | Error msg -> Alcotest.fail msg
@@ -70,7 +70,7 @@ let test_schema_mismatch_surfaces_typed_error () =
   write_file path content;
   let result = Bank.compact_memory_bank_if_needed config meta in
   Alcotest.(check bool) "compaction was attempted" true result.Policy.performed;
-  Alcotest.(check (option (Alcotest.testable Policy.compaction_error_to_string ( = ))))
+  Alcotest.(check (option (Alcotest.testable (Fmt.of_to_string Policy.compaction_error_to_string) ( = ))))
     "schema mismatch surfaced"
     (Some Policy.Schema_mismatch)
     result.Policy.error

--- a/test/test_keeper_memory_bank_compaction_errors.ml
+++ b/test/test_keeper_memory_bank_compaction_errors.ml
@@ -76,6 +76,28 @@ let test_schema_mismatch_surfaces_typed_error () =
     result.Policy.error
 ;;
 
+let test_malformed_json_is_not_schema_mismatch () =
+  with_temp_dir
+  @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "malformed-json" in
+  let path = Masc.Keeper_types_support.keeper_memory_bank_path config meta.name in
+  let content =
+    String.concat
+      "\n"
+      [ progress_row ~trace_id:"t1" ~text:"valid row"; {|{"schema_version":|} ]
+    ^ "\n"
+  in
+  write_file path content;
+  let result = Bank.compact_memory_bank_if_needed config meta in
+  Alcotest.(check bool) "compaction was attempted" true result.Policy.performed;
+  Alcotest.(check int) "invalid row dropped" 1 result.Policy.invalid_dropped;
+  Alcotest.(check (option (Alcotest.testable (Fmt.of_to_string Policy.compaction_error_to_string) ( = ))))
+    "malformed json is not schema mismatch"
+    None
+    result.Policy.error
+;;
+
 let test_write_failure_surfaces_typed_error () =
   with_temp_dir
   @@ fun base_path ->
@@ -119,6 +141,10 @@ let () =
             "write failure surfaces typed error"
             `Quick
             test_write_failure_surfaces_typed_error
+        ; Alcotest.test_case
+            "malformed json is not schema mismatch"
+            `Quick
+            test_malformed_json_is_not_schema_mismatch
         ] )
     ]
 ;;

--- a/test/test_keeper_memory_bank_compaction_errors.ml
+++ b/test/test_keeper_memory_bank_compaction_errors.ml
@@ -1,0 +1,124 @@
+(** P0-6: memory-bank compaction surfaces typed errors for schema mismatch and
+    write failures instead of swallowing them. *)
+
+module Bank = Masc.Keeper_memory_bank
+module Policy = Masc.Keeper_memory_policy
+
+let make_meta name : Masc.Keeper_meta_contract.keeper_meta =
+  let json = `Assoc [ ("name", `String name) ] in
+  match Masc_test_deps.meta_of_json_fixture json with
+  | Ok m -> m
+  | Error e -> failwith ("meta_of_json failed: " ^ e)
+;;
+
+let write_file path content =
+  Masc.Keeper_fs.ensure_dir (Filename.dirname path);
+  match Fs_compat.save_file_atomic path content with
+  | Ok () -> ()
+  | Error msg -> Alcotest.fail msg
+;;
+
+let progress_row ~trace_id ~text : string =
+  `Assoc
+    [ ("schema_version", `Int Policy.keeper_memory_schema_version)
+    ; ("kind", `String "progress")
+    ; ("horizon", `String Policy.short_term_horizon)
+    ; ("source", `String "tool_result")
+    ; ("trace_id", `String trace_id)
+    ; ("generation", `Int 1)
+    ; ("priority", `Int 50)
+    ; ("text", `String text)
+    ; ("ts_unix", `Float 1_700_000_000.0)
+    ]
+  |> Yojson.Safe.to_string
+;;
+
+let with_temp_dir f =
+  let marker = Filename.temp_file "memory-bank-compaction-" ".tmp" in
+  Sys.remove marker;
+  Unix.mkdir marker 0o700;
+  Fun.protect ~finally:(fun () ->
+    try
+      let rec rm path =
+        if Sys.is_directory path
+        then (
+          Sys.readdir path
+          |> Array.iter (fun name -> rm (Filename.concat path name));
+          Unix.rmdir path)
+        else Sys.remove path
+      in
+      rm marker
+    with _ -> ()) (fun () -> f marker)
+;;
+
+let test_schema_mismatch_surfaces_typed_error () =
+  with_temp_dir
+  @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "schema-mismatch" in
+  let path = Masc.Keeper_types_support.keeper_memory_bank_path config meta.name in
+  (* One valid row and one row with a stale schema_version. *)
+  let content =
+    String.concat
+      "\n"
+      [ progress_row ~trace_id:"t1" ~text:"valid row"
+      ; (`Assoc [ ("schema_version", `Int 1); ("kind", `String "progress") ]
+         |> Yojson.Safe.to_string)
+      ]
+    ^ "\n"
+  in
+  write_file path content;
+  let result = Bank.compact_memory_bank_if_needed config meta in
+  Alcotest.(check bool) "compaction was attempted" true result.Policy.performed;
+  Alcotest.(check (option (Alcotest.testable Policy.compaction_error_to_string ( = ))))
+    "schema mismatch surfaced"
+    (Some Policy.Schema_mismatch)
+    result.Policy.error
+;;
+
+let test_write_failure_surfaces_typed_error () =
+  with_temp_dir
+  @@ fun base_path ->
+  let config = Masc.Workspace.default_config base_path in
+  let meta = make_meta "write-failure" in
+  let path = Masc.Keeper_types_support.keeper_memory_bank_path config meta.name in
+  (* Enough identical rows to exceed the dedup threshold and force a rewrite. *)
+  let rows =
+    List.init 50 (fun i -> progress_row ~trace_id:("t" ^ string_of_int i) ~text:"duplicate")
+  in
+  let content = String.concat "\n" rows ^ "\n" in
+  write_file path content;
+  (* Make the keeper directory read-only so the atomic rewrite fails. *)
+  let keeper_dir = Filename.dirname path in
+  let original_perms = (Unix.stat keeper_dir).st_perm in
+  Unix.chmod keeper_dir 0o555;
+  Fun.protect
+    ~finally:(fun () -> Unix.chmod keeper_dir original_perms)
+    (fun () ->
+       let result = Bank.compact_memory_bank_if_needed config meta in
+       Alcotest.(check bool) "compaction was attempted" true result.Policy.performed;
+       Alcotest.(check bool) "error is present" true (Option.is_some result.Policy.error);
+       match result.Policy.error with
+       | Some (Policy.Write_error _) -> ()
+       | Some other ->
+         Alcotest.failf
+           "expected Write_error, got %s"
+           (Policy.compaction_error_to_string other)
+       | None -> Alcotest.fail "expected Write_error")
+;;
+
+let () =
+  Alcotest.run
+    "keeper_memory_bank_compaction_errors"
+    [ ( "compaction_errors"
+      , [ Alcotest.test_case
+            "schema mismatch surfaces typed error"
+            `Quick
+            test_schema_mismatch_surfaces_typed_error
+        ; Alcotest.test_case
+            "write failure surfaces typed error"
+            `Quick
+            test_write_failure_surfaces_typed_error
+        ] )
+    ]
+;;

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -4836,10 +4836,10 @@ let test_self_observation_excluded_from_user_model () =
       (List.hd model.Keeper_user_model.preferences).Keeper_user_model.claim)
 ;;
 
-let test_gc_and_reconcile_default_on () =
+let test_gc_default_on_and_reconcile_default_off () =
   (* Defaults are module-load constants; env overrides are tested separately. *)
   Alcotest.(check bool) "gc default is true" true Env_config.KeeperMemoryOs.gc_enabled_default;
-  Alcotest.(check bool) "reconcile default is true" true Env_config.KeeperMemoryOs.reconcile_enabled_default
+  Alcotest.(check bool) "reconcile default is false" false Env_config.KeeperMemoryOs.reconcile_enabled_default
 ;;
 
 let () =
@@ -4958,9 +4958,9 @@ let () =
             `Quick
             test_compaction_snapshots_json_surfaces_manifest_read_errors
         ; Alcotest.test_case
-            "gc and reconcile defaults are on (P0-1)"
+            "gc default is on and reconcile default is opt-in (P0-1)"
             `Quick
-            test_gc_and_reconcile_default_on
+            test_gc_default_on_and_reconcile_default_off
         ] )
     ; ( "policy"
       , [ Alcotest.test_case

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -11,6 +11,7 @@ module Recall = Masc.Keeper_memory_os_recall
 module Consolidator = Masc.Keeper_memory_os_consolidator
 module Metrics = Masc.Otel_metric_store
 module Runtime_manifest = Masc.Keeper_runtime_manifest
+module Keeper_user_model = Masc.Keeper_user_model
 
 external unsetenv : string -> unit = "masc_test_unsetenv"
 

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -3610,12 +3610,17 @@ let test_librarian_provider_slot_gate_caps_at_capacity () =
       Eio.Fiber.fork ~sw (fun () ->
         first
         := Some
-             (Librarian_runtime.with_provider_slot ~clock (fun () ->
-                Eio.Promise.resolve resolve_entered ();
-                Eio.Promise.await release;
-                "ran")));
+             (Librarian_runtime.with_provider_slot
+                ~keeper_id:"keeper-a"
+                ~clock
+                (fun () ->
+                   Eio.Promise.resolve resolve_entered ();
+                   Eio.Promise.await release;
+                   "ran")));
       Eio.Promise.await entered;
-      let second = Librarian_runtime.with_provider_slot ~clock (fun () -> "ran") in
+      let second =
+        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-a" ~clock (fun () -> "ran")
+      in
       Eio.Promise.resolve resolve_release ();
       wait_for_ref ~clock "first slot holder" first;
       Alcotest.(check (option string))
@@ -3639,18 +3644,57 @@ let test_librarian_provider_slot_gate_disabled_at_zero () =
       Eio.Fiber.fork ~sw (fun () ->
         first
         := Some
-             (Librarian_runtime.with_provider_slot ~clock (fun () ->
-                Eio.Promise.resolve resolve_entered ();
-                Eio.Promise.await release;
-                "ran")));
+             (Librarian_runtime.with_provider_slot
+                ~keeper_id:"keeper-a"
+                ~clock
+                (fun () ->
+                   Eio.Promise.resolve resolve_entered ();
+                   Eio.Promise.await release;
+                   "ran")));
       Eio.Promise.await entered;
-      let second = Librarian_runtime.with_provider_slot ~clock (fun () -> "ran") in
+      let second =
+        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-a" ~clock (fun () -> "ran")
+      in
       Eio.Promise.resolve resolve_release ();
       wait_for_ref ~clock "first slot holder" first;
       Alcotest.(check (option string))
         "gate disabled: concurrent entrant also ran"
         (Some "ran")
         second;
+      Alcotest.(check (option (option string)))
+        "slot holder ran"
+        (Some (Some "ran"))
+        !first))
+;;
+
+let test_librarian_provider_slot_gate_is_per_keeper () =
+  with_env "MASC_KEEPER_MEMORY_OS_LIBRARIAN_GLOBAL_SLOT" "1" (fun () ->
+    with_eio (fun ~sw ~net:_ ~clock ->
+      (* Capacity 1 is per keeper: a slot held by keeper-a must not block
+         keeper-b. This is the P0-4 isolation contract. *)
+      let entered, resolve_entered = Eio.Promise.create () in
+      let release, resolve_release = Eio.Promise.create () in
+      let first = ref None in
+      Eio.Fiber.fork ~sw (fun () ->
+        first
+        := Some
+             (Librarian_runtime.with_provider_slot
+                ~keeper_id:"keeper-a"
+                ~clock
+                (fun () ->
+                   Eio.Promise.resolve resolve_entered ();
+                   Eio.Promise.await release;
+                   "ran")));
+      Eio.Promise.await entered;
+      let other_keeper =
+        Librarian_runtime.with_provider_slot ~keeper_id:"keeper-b" ~clock (fun () -> "ran")
+      in
+      Eio.Promise.resolve resolve_release ();
+      wait_for_ref ~clock "first slot holder" first;
+      Alcotest.(check (option string))
+        "different keeper runs despite capacity 1 held"
+        (Some "ran")
+        other_keeper;
       Alcotest.(check (option (option string)))
         "slot holder ran"
         (Some (Some "ran"))
@@ -4735,6 +4779,68 @@ let test_compaction_snapshots_json_surfaces_manifest_read_errors () =
       (json_int_field "compaction_snapshots" top "read_error_count"))
 ;;
 
+let test_self_observation_excluded_from_recall () =
+  let now = 1_000_000.0 in
+  let self_obs =
+    { (fact_fixture ~now ()) with
+      Types.claim = "I am looping this turn"
+    ; Types.category = Types.Fact
+    ; Types.claim_kind = Some Types.Self_observation
+    ; Types.first_seen = now
+    ; Types.last_verified_at = Some now
+    }
+  in
+  let durable =
+    { (fact_fixture ~now ()) with
+      Types.claim = "The build uses dune 3.x"
+    ; Types.category = Types.Fact
+    ; Types.claim_kind = Some Types.External_state
+    ; Types.first_seen = now -. 1.0
+    ; Types.last_verified_at = Some (now -. 1.0)
+    }
+  in
+  let ranked = Recall.facts_recency_ranked ~now [ self_obs; durable ] in
+  Alcotest.(check int) "self-observation excluded from recall ranking" 1 (List.length ranked);
+  Alcotest.(check string) "only durable fact remains" "The build uses dune 3.x" (List.hd ranked).Types.claim
+;;
+
+let test_self_observation_excluded_from_user_model () =
+  let now = 1_000_000.0 in
+  with_temp_keepers_dir (fun _marker ->
+    let keeper_id = "keeper-self-obs" in
+    let self_pref =
+      { (fact_fixture ~now ()) with
+        Types.claim = "I prefer short turns"
+      ; Types.category = Types.Preference
+      ; Types.claim_kind = Some Types.Self_observation
+      ; Types.first_seen = now
+      ; Types.last_verified_at = Some now
+      }
+    in
+    let real_pref =
+      { (fact_fixture ~now ()) with
+        Types.claim = "User prefers concise responses"
+      ; Types.category = Types.Preference
+      ; Types.claim_kind = None
+      ; Types.first_seen = now -. 1.0
+      ; Types.last_verified_at = Some (now -. 1.0)
+      }
+    in
+    List.iter (Memory_io.append_fact ~keeper_id) [ self_pref; real_pref ];
+    let model = Keeper_user_model.build ~keeper_id ~now () in
+    Alcotest.(check int) "one preference remains" 1 (List.length model.Keeper_user_model.preferences);
+    Alcotest.(check string)
+      "real preference remains, self-observation excluded"
+      "User prefers concise responses"
+      (List.hd model.Keeper_user_model.preferences).Keeper_user_model.claim)
+;;
+
+let test_gc_and_reconcile_default_on () =
+  (* Defaults are module-load constants; env overrides are tested separately. *)
+  Alcotest.(check bool) "gc default is true" true Env_config.KeeperMemoryOs.gc_enabled_default;
+  Alcotest.(check bool) "reconcile default is true" true Env_config.KeeperMemoryOs.reconcile_enabled_default
+;;
+
 let () =
   maybe_run_lock_holder_child ();
   Alcotest.run
@@ -4850,6 +4956,10 @@ let () =
             "dashboard compaction snapshots surface manifest read errors"
             `Quick
             test_compaction_snapshots_json_surfaces_manifest_read_errors
+        ; Alcotest.test_case
+            "gc and reconcile defaults are on (P0-1)"
+            `Quick
+            test_gc_and_reconcile_default_on
         ] )
     ; ( "policy"
       , [ Alcotest.test_case
@@ -5122,6 +5232,10 @@ let () =
             "provider slot gate disabled at capacity 0"
             `Quick
             test_librarian_provider_slot_gate_disabled_at_zero
+        ; Alcotest.test_case
+            "provider slot gate isolates keepers (P0-4)"
+            `Quick
+            test_librarian_provider_slot_gate_is_per_keeper
         ] )
     ; ( "rfc-0259 volatile"
       , [ Alcotest.test_case
@@ -5140,6 +5254,14 @@ let () =
             "self-observation never promoted; durable is (RFC-0285 §3.5)"
             `Quick
             test_self_observation_not_promoted
+        ; Alcotest.test_case
+            "self-observation excluded from recall context (P0-2)"
+            `Quick
+            test_self_observation_excluded_from_recall
+        ; Alcotest.test_case
+            "self-observation excluded from user model (P0-2)"
+            `Quick
+            test_self_observation_excluded_from_user_model
         ; Alcotest.test_case
             "fact_of_json does not infer external_ref from legacy prose"
             `Quick

--- a/test/test_procedural_memory.ml
+++ b/test/test_procedural_memory.ml
@@ -578,6 +578,55 @@ let test_skill_candidate_store_sanitizes_candidate_id_path () =
        (Filename.concat (Filename.concat base_path ".masc") "Escape Candidate"))
 ;;
 
+let test_load_procedures_strict_ok () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let p = procedure ~id:"strict-ok" ~evidence:[ "a"; "b"; "c" ]
+    ~success_count:3 ~failure_count:0 ~confidence:1.0 () in
+  (match P.rewrite_procedures ~base_path ~agent_name:"keeper" [ p ] with
+   | Ok () -> ()
+   | Error msg -> fail msg);
+  match P.load_procedures_strict ~base_path ~agent_name:"keeper" () with
+  | Ok procs -> check int "one procedure loaded" 1 (List.length procs)
+  | Error errs -> failf "unexpected strict errors: %d" (List.length errs)
+;;
+
+let test_load_procedures_strict_rejects_bad_json () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let path = P.procedures_path ~base_path ~agent_name:"keeper" () in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  write_file_or_fail path "this is not json\n";
+  match P.load_procedures_strict ~base_path ~agent_name:"keeper" () with
+  | Ok _ -> fail "expected strict load to reject bad json"
+  | Error errs ->
+    check int "one error" 1 (List.length errs);
+    let err = List.hd errs in
+    check string "error path" path err.P.path;
+    check int "error line" 1 err.P.line_number
+;;
+
+let test_load_procedures_strict_rejects_schema_mismatch () =
+  with_temp_base_path
+  @@ fun base_path ->
+  let path = P.procedures_path ~base_path ~agent_name:"keeper" () in
+  Fs_compat.mkdir_p (Filename.dirname path);
+  write_file_or_fail path {|{"unknown_field":"x"}|};
+  match P.load_procedures_strict ~base_path ~agent_name:"keeper" () with
+  | Ok _ -> fail "expected strict load to reject schema mismatch"
+  | Error errs -> check int "one error" 1 (List.length errs)
+;;
+
+let test_rewrite_procedures_returns_error_on_bad_path () =
+  (* Use a path that is a file, not a directory, so the atomic write fails. *)
+  let marker = Filename.temp_file "proc-bad-path-" ".tmp" in
+  let base_path = marker ^ "_not_a_dir" in
+  let p = procedure ~id:"bad-path" () in
+  match P.rewrite_procedures ~base_path ~agent_name:"keeper" [ p ] with
+  | Ok () -> fail "expected rewrite to fail on bad path"
+  | Error _ -> check bool "rewrite failed" true true
+;;
+
 let () =
   run "procedural_memory"
     [
@@ -592,6 +641,17 @@ let () =
             test_rare_near_perfect_does_not_crystallize;
           test_case "single perfect does not crystallize" `Quick
             test_single_perfect_does_not_crystallize;
+        ] );
+      ( "io",
+        [
+          test_case "strict loader accepts valid file" `Quick
+            test_load_procedures_strict_ok;
+          test_case "strict loader rejects malformed json" `Quick
+            test_load_procedures_strict_rejects_bad_json;
+          test_case "strict loader rejects schema mismatch" `Quick
+            test_load_procedures_strict_rejects_schema_mismatch;
+          test_case "rewrite returns error on bad path" `Quick
+            test_rewrite_procedures_returns_error_on_bad_path;
         ] );
       ( "skill candidates",
         [

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -11,6 +11,8 @@ module Io = Masc.Keeper_memory_os_io
 module Recall = Masc.Keeper_memory_os_recall
 module Atypes = Agent_sdk.Types
 
+let message_text (m : Atypes.message) = m.content
+
 let now = 1_000_000.0
 
 let fact claim =

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -11,7 +11,12 @@ module Io = Masc.Keeper_memory_os_io
 module Recall = Masc.Keeper_memory_os_recall
 module Atypes = Agent_sdk.Types
 
-let message_text (m : Atypes.message) = m.content
+let message_text (m : Atypes.message) =
+  m.content
+  |> List.filter_map (function
+    | Atypes.Text s -> Some s
+    | _ -> None)
+  |> String.concat "\n"
 
 let now = 1_000_000.0
 

--- a/test/test_server_bootstrap_maintenance_memory_os.ml
+++ b/test/test_server_bootstrap_maintenance_memory_os.ml
@@ -148,6 +148,55 @@ let test_skips_when_too_few () =
           Alcotest.(check int) "store unchanged when too few facts" 1 after_count))))
 ;;
 
+let test_parallel_timeout_per_keeper () =
+  Eio_main.run (fun env ->
+    Eio.Switch.run (fun sw ->
+      with_prompts (fun () ->
+        with_temp_keepers (fun () ->
+          (* Two keepers each have enough facts to be considered for consolidation. *)
+          List.iter (Io.append_fact ~keeper_id:"keeper-slow") [ fact "slow 1"; fact "slow 2" ];
+          List.iter (Io.append_fact ~keeper_id:"keeper-fast") [ fact "fast 1"; fact "fast 2" ];
+          let slow_count_before = List.length (Io.read_facts_all ~keeper_id:"keeper-slow") in
+          let fast_count_before = List.length (Io.read_facts_all ~keeper_id:"keeper-fast") in
+          Alcotest.(check int) "slow keeper accumulated" 2 slow_count_before;
+          Alcotest.(check int) "fast keeper accumulated" 2 fast_count_before;
+          let slow_complete ~sw:_ ~net:_ ?clock ~config:_ ~messages:_ () =
+            (match clock with
+             | Some clock -> Eio.Time.sleep clock 2.0
+             | None -> ());
+            Ok (fake_response "{\"groups\":[],\"drop_indices\":[]}")
+          in
+          let fast_complete = fake_complete "{\"groups\":[],\"drop_indices\":[]}" in
+          let complete ~sw ~net ?clock ~config ~messages () =
+            if List.exists
+                 (fun (m : Agent_sdk.Types.message) ->
+                    String.contains (message_text m) 'f')
+                 messages
+            then fast_complete ~sw ~net ?clock ~config ~messages ()
+            else slow_complete ~sw ~net ?clock ~config ~messages ()
+          in
+          let start = Unix.gettimeofday () in
+          Server_bootstrap_maintenance.run_memory_os_consolidation_tick
+            ~complete
+            ~timeout_sec:0.1
+            ~sw
+            ~net:(Eio.Stdenv.net env)
+            ~clock:(Eio.Stdenv.clock env)
+            ~provider_cfg:(provider_cfg ())
+            ~now
+            ();
+          let elapsed = Unix.gettimeofday () -. start in
+          (* The slow keeper should hit the 0.1s timeout and the fast keeper should
+             complete; the total elapsed time must be far below the slow keeper's
+             2.0s sleep, proving per-keeper timeout and parallel scheduling. *)
+          Alcotest.(check bool) "tick returns before slow keeper sleep" true (elapsed < 1.0);
+          (* The fast keeper store should be unchanged (no groups). The slow keeper
+             may or may not have been rewritten depending on timing; we only assert
+             that the fast path completed. *)
+          let fast_count_after = List.length (Io.read_facts_all ~keeper_id:"keeper-fast") in
+          Alcotest.(check int) "fast keeper unchanged" fast_count_before fast_count_after))))
+;;
+
 let () =
   Alcotest.run
     "server_bootstrap_maintenance_memory_os"
@@ -160,6 +209,10 @@ let () =
             "skips when too few facts"
             `Quick
             test_skips_when_too_few
+        ; Alcotest.test_case
+            "parallel per-keeper timeout"
+            `Quick
+            test_parallel_timeout_per_keeper
         ] )
     ]
 ;;


### PR DESCRIPTION
Implements the six P0 hardening items from the Memory OS adversarial audit.

- P0-1: GC enabled by default; add reconcile kill-switch (`MASC_KEEPER_MEMORY_OS_RECONCILE`).
- P0-2: Block `Self_observation` facts from recall / user-model ranking.
- P0-3: Parallel per-keeper maintenance loops with per-keeper timeout guard and `MemoryOsMaintenanceKeeperTimeout` metric.
- P0-4: Per-keeper librarian provider slot isolation (was fleet-wide).
- P0-5: Strict procedural-memory loader returning a typed `(unit, string) result`; expose `load_procedures_strict`.
- P0-6: Typed memory-bank compaction errors (`Read_error`, `Write_error`, `Schema_mismatch`) and `MemoryBankCompactionFailures` metric.

Adds/updates unit tests for each item. Relying on CI for full build/test validation.