### PR TITLE
feat(keeper): P0 registry hardening with typed health and validated writes

### DIFF
--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -340,6 +340,8 @@ let spawn_slots_available () =
 ;;
 
 module For_testing = struct
+  let unsafe_put_entry = unsafe_put_entry
+
   let spawn_slots_decision ?fd_admitted () =
     spawn_slots_decision_internal ?fd_admitted ()
   ;;

--- a/lib/keeper/keeper_registry.mli
+++ b/lib/keeper/keeper_registry.mli
@@ -72,25 +72,6 @@ val get : base_path:string -> string -> registry_entry option
 (** Return all registered keepers. *)
 val all : ?base_path:string -> unit -> registry_entry list
 
-type registry_entry_validation_error =
-  | Registry_key_malformed of
-      { key : string
-      ; reason : string
-      }
-  | Registry_base_path_mismatch of
-      { expected : string
-      ; actual : string
-      }
-  | Registry_name_mismatch of
-      { expected : string
-      ; actual : string
-      }
-  | Registry_meta_name_mismatch of
-      { expected : string
-      ; actual : string
-      }
-  | Registry_meta_agent_name_empty
-
 val registry_entry_validation_error_to_string :
   registry_entry_validation_error -> string
 
@@ -99,6 +80,44 @@ val validate_registry_entry :
   string ->
   registry_entry ->
   (unit, registry_entry_validation_error) result
+
+(** Health verdict for a single entry.  Pure: does not read the registry. *)
+val health_of_entry :
+  base_path:string -> string -> registry_entry -> registry_entry_health
+
+(** Like [get] but returns the entry together with its health verdict.
+    Returns [Some _] even when the entry is corrupted, so callers can decide
+    whether to consume it. *)
+val get_with_health :
+  base_path:string -> string -> (registry_entry * registry_entry_health) option
+
+(** Insert or replace a registry entry.  Validates [entry] before installing;
+    on validation error returns the health reason and emits
+    [RegistryInvalidEntry] with [operation="put"]. *)
+val put_entry :
+  base_path:string ->
+  string ->
+  registry_entry ->
+  (unit, registry_entry_validation_error) result
+
+(** Result-returning update: validates [f entry] before installing.  On
+    validation error returns the health reason, emits
+    [RegistryInvalidEntry] with [operation="update"], and leaves the original
+    entry untouched.  Only CAS conflicts retry. *)
+val update_entry :
+  base_path:string ->
+  string ->
+  (registry_entry -> registry_entry) ->
+  (unit, registry_entry_validation_error) result
+
+(** Update a registered entry and return [true] only when a validated write
+    was installed.  Missing keepers, no-op closures, and validation failures
+    return [false]. *)
+val update_entry_if_registered :
+  base_path:string ->
+  string ->
+  (registry_entry -> registry_entry * bool) ->
+  bool
 
 (** Update the meta for a registered keeper. No-op if not found. *)
 val update_meta : base_path:string -> string -> keeper_meta -> unit
@@ -316,6 +335,11 @@ val record_spawn_slot_denied :
   keeper_name:string -> surface:string -> spawn_slot_denial_reason -> unit
 
 module For_testing : sig
+  (** Test-only bypass: install an entry without validation so tests can seed
+      corrupted registry state. *)
+  val unsafe_put_entry :
+    base_path:string -> string -> registry_entry -> unit
+
   val spawn_slots_decision :
     ?fd_admitted:bool ->
     unit ->

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -4,6 +4,7 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_meta_store
 open Keeper_types_profile
+open Keeper_id
 
 (** Failure-reason cluster re-included from Keeper_registry_types for backward compatibility. *)
 include Keeper_registry_types
@@ -14,83 +15,99 @@ module Orphan_drops = Keeper_registry_orphan_drops
 module Spawn_slots = Keeper_registry_spawn_slots
 module Error_tracking = Keeper_registry_error_tracking
 
-type registry_entry_validation_error =
-  | Registry_key_malformed of
-      { key : string
-      ; reason : string
-      }
-  | Registry_base_path_mismatch of
-      { expected : string
-      ; actual : string
-      }
-  | Registry_name_mismatch of
-      { expected : string
-      ; actual : string
-      }
-  | Registry_meta_name_mismatch of
-      { expected : string
-      ; actual : string
-      }
-  | Registry_meta_agent_name_empty
-
 let registry_entry_validation_error_label = function
-  | Registry_key_malformed _ -> "key_malformed"
-  | Registry_base_path_mismatch _ -> "entry_base_path_mismatch"
-  | Registry_name_mismatch _ -> "entry_name_mismatch"
-  | Registry_meta_name_mismatch _ -> "meta_name_mismatch"
-  | Registry_meta_agent_name_empty -> "meta_agent_name_empty"
+  | Healthy -> "healthy"
+  | Meta_validation_failed _ -> "meta_validation_failed"
+  | Required_field_missing _ -> "required_field_missing"
+  | Base_path_mismatch _ -> "base_path_mismatch"
+  | Name_mismatch _ -> "name_mismatch"
+;;
 
 let registry_entry_validation_error_to_string = function
-  | Registry_key_malformed { key; reason } ->
-      Printf.sprintf "registry key %S is malformed: %s" key reason
-  | Registry_base_path_mismatch { expected; actual } ->
+  | Healthy -> "registry entry is healthy"
+  | Meta_validation_failed { reason } ->
+      Printf.sprintf "registry entry meta validation failed: %s" reason
+  | Required_field_missing { field } ->
+      Printf.sprintf "registry entry required field missing: %s" field
+  | Base_path_mismatch { expected; actual } ->
       Printf.sprintf
         "registry entry base_path mismatch: expected %S, got %S"
         expected
         actual
-  | Registry_name_mismatch { expected; actual } ->
+  | Name_mismatch { expected; actual } ->
       Printf.sprintf
         "registry entry name mismatch: expected %S, got %S"
         expected
         actual
-  | Registry_meta_name_mismatch { expected; actual } ->
-      Printf.sprintf
-        "registry entry meta.name mismatch: expected %S, got %S"
-        expected
-        actual
-  | Registry_meta_agent_name_empty ->
-      "registry entry meta.agent_name is empty"
+;;
 
 let registry_key_parts = Keeper_registry_types.registry_key_parts
+
+let has_blank_tool_name names =
+  List.exists (fun name -> String.equal (String.trim name) "") names
+;;
+
+let has_duplicate_tool_name names =
+  let rec loop seen = function
+    | [] -> false
+    | name :: rest ->
+      let trimmed = String.trim name in
+      if String.equal trimmed ""
+      then loop seen rest
+      else if Set_util.StringSet.mem trimmed seen
+      then true
+      else loop (Set_util.StringSet.add trimmed seen) rest
+  in
+  loop Set_util.StringSet.empty names
+;;
+
+let validate_tool_name_list field names =
+  if has_blank_tool_name names
+  then Error (Meta_validation_failed { reason = field ^ " contains blank entries" })
+  else if has_duplicate_tool_name names
+  then Error (Meta_validation_failed { reason = field ^ " contains duplicate entries" })
+  else Ok ()
+;;
+
+let validate_runtime_fields (runtime : agent_runtime_state) =
+  if String.equal (Trace_id.to_string runtime.trace_id) ""
+  then Error (Required_field_missing { field = "trace_id" })
+  else if runtime.generation < 0
+  then Error (Required_field_missing { field = "generation" })
+  else if runtime.usage.total_turns < 0
+  then Error (Required_field_missing { field = "usage.total_turns" })
+  else if runtime.usage.total_tokens < 0
+  then Error (Required_field_missing { field = "usage.total_tokens" })
+  else validate_tool_name_list "trace_history" runtime.trace_history
+;;
 
 let validate_registry_entry ~base_path name (entry : registry_entry) =
   let expected_name = String.trim name in
   if not (String.equal entry.base_path base_path)
-  then
-    Error
-      (Registry_base_path_mismatch
-         { expected = base_path; actual = entry.base_path })
+  then Error (Base_path_mismatch { expected = base_path; actual = entry.base_path })
   else if not (String.equal entry.name expected_name)
-  then
-    Error (Registry_name_mismatch { expected = expected_name; actual = entry.name })
-  else if not (String.equal entry.meta.name expected_name)
-  then
-    Error
-      (Registry_meta_name_mismatch
-         { expected = expected_name; actual = entry.meta.name })
+  then Error (Name_mismatch { expected = expected_name; actual = entry.name })
+  else if not (String.equal (String.trim entry.meta.name) expected_name)
+  then Error (Name_mismatch { expected = expected_name; actual = entry.meta.name })
   else if String.equal (String.trim entry.meta.agent_name) ""
-  then Error Registry_meta_agent_name_empty
-  else Ok ()
+  then Error (Meta_validation_failed { reason = "meta.agent_name is empty" })
+  else
+    match validate_runtime_fields entry.meta.runtime with
+    | Error _ as err -> err
+    | Ok () ->
+      (match validate_tool_name_list "tool_access" entry.meta.tool_access with
+       | Error _ as err -> err
+       | Ok () -> validate_tool_name_list "tool_denylist" entry.meta.tool_denylist)
+;;
 
-let validate_registry_meta name (meta : keeper_meta) =
+let validate_registry_meta ~base_path:_ name (meta : keeper_meta) =
   let expected_name = String.trim name in
-  if not (String.equal meta.name expected_name)
-  then
-    Error
-      (Registry_meta_name_mismatch { expected = expected_name; actual = meta.name })
+  if not (String.equal (String.trim meta.name) expected_name)
+  then Error (Name_mismatch { expected = expected_name; actual = meta.name })
   else if String.equal (String.trim meta.agent_name) ""
-  then Error Registry_meta_agent_name_empty
+  then Error (Meta_validation_failed { reason = "meta.agent_name is empty" })
   else Ok ()
+;;
 
 let record_invalid_registry_entry ~operation ~name reason =
   Otel_metric_store.inc_counter
@@ -108,9 +125,9 @@ let record_invalid_registry_entry ~operation ~name reason =
     (registry_entry_validation_error_to_string reason)
 
 let canonicalize_registry_meta ~operation ~base_path name (meta : keeper_meta) =
-  match validate_registry_meta name meta with
+  match validate_registry_meta ~base_path name meta with
   | Ok () -> meta
-  | Error reason ->
+  | Error (Name_mismatch _ | Meta_validation_failed _) as original_error ->
       let expected_name = String.trim name in
       let expected_agent_name = Keeper_identity.keeper_agent_name expected_name in
       let repaired =
@@ -122,12 +139,16 @@ let canonicalize_registry_meta ~operation ~base_path name (meta : keeper_meta) =
              else meta.agent_name)
         }
       in
-      record_invalid_registry_entry ~operation ~name reason;
-      (match validate_registry_meta name repaired with
+      record_invalid_registry_entry ~operation ~name original_error;
+      (match validate_registry_meta ~base_path name repaired with
        | Ok () -> repaired
        | Error repair_reason ->
            record_invalid_registry_entry ~operation ~name repair_reason;
            meta)
+  | Error reason ->
+      record_invalid_registry_entry ~operation ~name reason;
+      meta
+;;
 
 (** CAS loop for clamped decrement.  [Atomic.fetch_and_add _ (-1)] can leave the counter negative if increment/decrement paths interleave, so we retry until we successfully install [max 0 (cur - 1)]. *)
 let decr_running_count_clamped () =
@@ -141,16 +162,37 @@ let decr_running_count_clamped () =
 
 (** Lock-free CAS loop for registry writes. Atomic.t used instead of Eio.Mutex for non-Eio context compatibility (#7011 pattern). *)
 
-let put_entry key entry =
+let put_entry ~base_path name entry =
+  match validate_registry_entry ~base_path name entry with
+  | Error err ->
+    record_invalid_registry_entry ~operation:"put" ~name err;
+    Error err
+  | Ok () ->
+    let key = registry_key ~base_path name in
+    let rec loop () =
+      let current = Atomic.get registry in
+      let updated = StringMap.add key entry current in
+      if Atomic.compare_and_set registry current updated then Ok () else loop ()
+    in
+    loop ()
+;;
+
+(** Test-only bypass: install an entry without validation so tests can seed
+    corrupted registry state for [get] / [get_with_health] hardening checks. *)
+let unsafe_put_entry ~base_path name entry =
+  let key = registry_key ~base_path name in
   let rec loop () =
     let current = Atomic.get registry in
     let updated = StringMap.add key entry current in
-    if not (Atomic.compare_and_set registry current updated) then loop ()
+    if Atomic.compare_and_set registry current updated then () else loop ()
   in
   loop ()
 ;;
 
-(** Apply [f entry] and write back.  No-op if key absent.  The find + apply + write is serialised via CAS so that concurrent [update_entry] calls on the same key cannot both operate on a stale [entry] ... *)
+(** Apply [f entry] and write back.  No-op if key absent.  Validates the
+    result of [f entry] before installing; on validation error returns the
+    health reason, emits [RegistryInvalidEntry] with [operation="update"], and
+    leaves the original entry untouched.  Only CAS conflicts retry. *)
 let update_entry ~base_path name f =
   let key = registry_key ~base_path name in
   let rec loop () =
@@ -182,14 +224,27 @@ let update_entry ~base_path name f =
            (count=%d)"
           name
           base_path
-          count
+          count;
+      Ok ()
     | Some entry ->
-      let updated = StringMap.add key (f entry) current in
-      if not (Atomic.compare_and_set registry current updated)
-      then loop ()
-      else Orphan_drops.clear ~base_path name
+      let new_entry = f entry in
+      (match validate_registry_entry ~base_path name new_entry with
+       | Error err ->
+         record_invalid_registry_entry ~operation:"update" ~name err;
+         Error err
+       | Ok () ->
+         let updated = StringMap.add key new_entry current in
+         if Atomic.compare_and_set registry current updated
+         then (
+           Orphan_drops.clear ~base_path name;
+           Ok ())
+         else loop ())
   in
   loop ()
+;;
+
+let update_entry_unit ~base_path name f =
+  ignore (update_entry ~base_path name f)
 ;;
 
 let update_entry_if_registered ~base_path name f =
@@ -202,15 +257,24 @@ let update_entry_if_registered ~base_path name f =
       let new_entry, changed = f entry in
       if not changed
       then false
-      else (
-        let updated = StringMap.add key new_entry current in
-        if Atomic.compare_and_set registry current updated
-        then (
-          Orphan_drops.clear ~base_path name;
-          true)
-        else loop ())
+      else
+        match validate_registry_entry ~base_path name new_entry with
+        | Error err ->
+          record_invalid_registry_entry ~operation:"update" ~name err;
+          false
+        | Ok () ->
+          let updated = StringMap.add key new_entry current in
+          if Atomic.compare_and_set registry current updated
+          then (
+            Orphan_drops.clear ~base_path name;
+            true)
+          else loop ()
   in
   loop ()
+;;
+
+let update_entry_if_registered_unit ~base_path name f =
+  ignore (update_entry_if_registered ~base_path name (fun entry -> f entry, true))
 ;;
 
 let rec queue_contains_stimulus queue stimulus =
@@ -315,7 +379,7 @@ let register_with_state
     ; compaction_stage = Packed Compaction_accumulating
     }
   in
-  put_entry key entry;
+  ignore (put_entry ~base_path name entry);
   if phase = Running then Atomic.incr running_count_atomic;
   Log.Keeper.debug
     "registry: keeper registered name=%s running_count=%d"
@@ -462,18 +526,27 @@ let unregister ~base_path name =
     Log.Keeper.warn "registry: attempted to unregister non-existent keeper name=%s" name
 ;;
 
-let get ~base_path name =
-  let result = StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) in
-  match result with
+let health_of_entry ~base_path name entry =
+  match validate_registry_entry ~base_path name entry with
+  | Ok () -> Healthy
+  | Error health -> health
+;;
+
+let get_with_health ~base_path name =
+  match StringMap.find_opt (registry_key ~base_path name) (Atomic.get registry) with
   | None ->
       Log.Keeper.debug "registry: lookup miss name=%s base_path=%s" name base_path;
       None
-  | Some entry -> (
-      match validate_registry_entry ~base_path name entry with
-      | Ok () -> Some entry
-      | Error reason ->
-          record_invalid_registry_entry ~operation:"get" ~name reason;
-          None)
+  | Some entry -> Some (entry, health_of_entry ~base_path name entry)
+;;
+
+let get ~base_path name =
+  match get_with_health ~base_path name with
+  | None -> None
+  | Some (entry, Healthy) -> Some entry
+  | Some (_, reason) ->
+      record_invalid_registry_entry ~operation:"get" ~name reason;
+      None
 ;;
 
 let all ?base_path () =
@@ -484,7 +557,7 @@ let all ?base_path () =
            record_invalid_registry_entry
              ~operation:"all"
              ~name:v.name
-             (Registry_key_malformed { key; reason });
+             (Meta_validation_failed { reason });
            acc
        | Ok (key_base_path, key_name) ->
            (match base_path with
@@ -500,11 +573,11 @@ let all ?base_path () =
 ;;
 
 let update_meta ~base_path name meta =
-  match validate_registry_meta name meta with
+  match validate_registry_meta ~base_path name meta with
   | Error reason ->
       record_invalid_registry_entry ~operation:"update_meta" ~name reason
   | Ok () ->
-      update_entry ~base_path name (fun e -> { e with base_path; name; meta })
+      update_entry_unit ~base_path name (fun e -> { e with base_path; name; meta })
 ;;
 
 let reload_meta_from_disk ~base_path name =
@@ -517,7 +590,7 @@ let reload_meta_from_disk ~base_path name =
       match effective_meta_of_profile_defaults defaults meta with
       | Error msg -> Error msg
       | Ok effective_meta -> (
-          match validate_registry_meta name effective_meta with
+          match validate_registry_meta ~base_path name effective_meta with
           | Error reason ->
               record_invalid_registry_entry ~operation:"reload_meta_from_disk" ~name reason;
               Error (registry_entry_validation_error_to_string reason)
@@ -532,7 +605,7 @@ let reload_meta_from_disk ~base_path name =
 (* Runtime-attempt cluster (runtime_attempt_merge / meta_for_runtime_attempt / record_runtime_attempt / runtime_attempt_suffix / last_runtime_attempt / runtime_attempt_freshness_threshold_sec / enrich... *)
 
 let sync_meta_if_registered ~base_path name meta =
-  match validate_registry_meta name meta with
+  match validate_registry_meta ~base_path name meta with
   | Error reason ->
       record_invalid_registry_entry ~operation:"sync_meta_if_registered" ~name reason
   | Ok () ->
@@ -561,29 +634,29 @@ let mark_dead ~base_path name ~at =
     name
     ~at
     ~decr_running_count_clamped
-    ~update_entry
+    ~update_entry:update_entry_unit
 ;;
 
 let record_restart ~base_path name =
-  Error_tracking.record_restart ~base_path name ~update_entry
+  Error_tracking.record_restart ~base_path name ~update_entry:update_entry_unit
 ;;
 
 let set_last_error_entry ~base_path ~name err =
-  Error_tracking.set_last_error_entry ~base_path ~name err ~update_entry
+  Error_tracking.set_last_error_entry ~base_path ~name err ~update_entry:update_entry_unit
 ;;
 
 (* record_error (MASC/OAS Error-Warn Reduction Goal §P6 dedup logic) moved to Keeper_registry_error_recording. No alias here — it would create a cycle via [Keeper_registry.set_last_error_entry], so ca... *)
 
 let clear_error ~base_path name =
-  Error_tracking.clear_error ~base_path name ~update_entry
+  Error_tracking.clear_error ~base_path name ~update_entry:update_entry_unit
 ;;
 
 let set_failure_reason ~base_path name reason =
-  Error_tracking.set_failure_reason ~base_path name reason ~update_entry
+  Error_tracking.set_failure_reason ~base_path name reason ~update_entry:update_entry_unit
 ;;
 
 let set_last_correlation_id ~base_path name cid =
-  Error_tracking.set_last_correlation_id ~base_path name cid ~update_entry
+  Error_tracking.set_last_correlation_id ~base_path name cid ~update_entry:update_entry_unit
 ;;
 
 (* SSE broadcast helpers (broadcast_composite_changed / record_phase_broadcast_failure) moved to Keeper_registry_broadcast. *)

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -244,6 +244,7 @@ let update_entry ~base_path name f =
 ;;
 
 let update_entry_unit ~base_path name f =
+  (* fire-and-forget: unit wrapper discards Ok/Error; callers only need side effects and logged metrics. *)
   ignore (update_entry ~base_path name f)
 ;;
 
@@ -274,6 +275,8 @@ let update_entry_if_registered ~base_path name f =
 ;;
 
 let update_entry_if_registered_unit ~base_path name f =
+  (* fire-and-forget: bool wrapper discards whether a validated write was
+     installed; callers only need side effects and logged metrics. *)
   ignore (update_entry_if_registered ~base_path name (fun entry -> f entry, true))
 ;;
 
@@ -379,6 +382,7 @@ let register_with_state
     ; compaction_stage = Packed Compaction_accumulating
     }
   in
+  (* fire-and-forget: put_entry validates and logs on failure; the constructed entry is always used. *)
   ignore (put_entry ~base_path name entry);
   if phase = Running then Atomic.incr running_count_atomic;
   Log.Keeper.debug

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -127,7 +127,7 @@ let record_invalid_registry_entry ~operation ~name reason =
 let canonicalize_registry_meta ~operation ~base_path name (meta : keeper_meta) =
   match validate_registry_meta ~base_path name meta with
   | Ok () -> meta
-  | Error (Name_mismatch _ | Meta_validation_failed _) as original_error ->
+  | Error ((Name_mismatch _ | Meta_validation_failed _) as reason) ->
       let expected_name = String.trim name in
       let expected_agent_name = Keeper_identity.keeper_agent_name expected_name in
       let repaired =
@@ -139,7 +139,7 @@ let canonicalize_registry_meta ~operation ~base_path name (meta : keeper_meta) =
              else meta.agent_name)
         }
       in
-      record_invalid_registry_entry ~operation ~name original_error;
+      record_invalid_registry_entry ~operation ~name reason;
       (match validate_registry_meta ~base_path name repaired with
        | Ok () -> repaired
        | Error repair_reason ->

--- a/lib/keeper/keeper_registry_setup.ml
+++ b/lib/keeper/keeper_registry_setup.ml
@@ -275,8 +275,7 @@ let update_entry_if_registered ~base_path name f =
 ;;
 
 let update_entry_if_registered_unit ~base_path name f =
-  (* fire-and-forget: bool wrapper discards whether a validated write was
-     installed; callers only need side effects and logged metrics. *)
+  (* fire-and-forget: discard whether the validated registry write was installed. *)
   ignore (update_entry_if_registered ~base_path name (fun entry -> f entry, true))
 ;;
 

--- a/lib/keeper/keeper_registry_types.ml
+++ b/lib/keeper/keeper_registry_types.ml
@@ -146,6 +146,15 @@ type done_resolve_result =
       ; previous : done_resolution
       }
 
+type registry_entry_health =
+  | Healthy
+  | Meta_validation_failed of { reason : string }
+  | Required_field_missing of { field : string }
+  | Base_path_mismatch of { expected : string; actual : string }
+  | Name_mismatch of { expected : string; actual : string }
+
+type registry_entry_validation_error = registry_entry_health
+
 let resolve_done entry ~source (value : done_resolution) =
   match Eio.Promise.peek entry.done_p with
   | Some previous -> Done_already_resolved { source; previous }

--- a/lib/keeper/keeper_registry_types.mli
+++ b/lib/keeper/keeper_registry_types.mli
@@ -549,6 +549,21 @@ type done_resolve_result =
       previous : done_resolution;
     }
 
+(** Structured health verdict for a registry entry.  Used both as the public
+    [health_of_entry] / [get_with_health] result and as the validation-error
+    type returned by [validate_registry_entry] and the CAS write helpers. *)
+type registry_entry_health =
+  | Healthy
+  | Meta_validation_failed of { reason : string }
+  | Required_field_missing of { field : string }
+  | Base_path_mismatch of { expected : string; actual : string }
+  | Name_mismatch of { expected : string; actual : string }
+
+(** Alias kept so the CAS write helpers can return
+    [(unit, registry_entry_validation_error) result] without duplicating the
+    health variant. *)
+type registry_entry_validation_error = registry_entry_health
+
 (** Resolve a keeper run completion promise at most once.
 
     [source] identifies the lifecycle branch attempting the resolve. The

--- a/lib/keeper/keeper_tool_dispatch_runtime.ml
+++ b/lib/keeper/keeper_tool_dispatch_runtime.ml
@@ -479,8 +479,26 @@ let execute_keeper_tool_call_with_outcome
   =
   let args = input in
   let meta =
-    match Keeper_registry.get ~base_path:config.base_path meta.name with
-    | Some entry -> entry.meta
+    match Keeper_registry.get_with_health ~base_path:config.base_path meta.name with
+    | Some (entry, Keeper_registry.Healthy) -> entry.meta
+    | Some (_, health) ->
+      let reason_label =
+        match health with
+        | Keeper_registry.Healthy -> "healthy"
+        | Keeper_registry.Meta_validation_failed _ -> "meta_validation_failed"
+        | Keeper_registry.Required_field_missing _ -> "required_field_missing"
+        | Keeper_registry.Base_path_mismatch _ -> "base_path_mismatch"
+        | Keeper_registry.Name_mismatch _ -> "name_mismatch"
+      in
+      Otel_metric_store.inc_counter
+        Keeper_metrics.(to_string RegistryInvalidEntry)
+        ~labels:
+          [ "operation", "tool_dispatch_fallback"
+          ; "name", meta.name
+          ; "reason", reason_label
+          ]
+        ();
+      meta
     | None -> meta
   in
   let apply_circuit_breaker (result : executed_tool_result) =

--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -16,8 +16,8 @@
 # Removal: an entry SHOULD be removed when the spawn site itself is removed,
 # never when a "we'll wrap it later" excuse appears.
 
-# lib/bounded_proc/bounded_proc.ml:35  — the canonical helper itself.
-lib/bounded_proc/bounded_proc.ml:35
+# lib/bounded_proc/bounded_proc.ml:37  — the canonical helper itself.
+lib/bounded_proc/bounded_proc.ml:37
 
 # lib/process/process_eio.ml:483, 521, 570 — `spawn_and_drain_{stdout,both}`
 # and `spawn_and_drain_both_streaming`.
@@ -33,7 +33,7 @@ lib/process/process_eio.ml:570
 # run_argv_pipeline_with_status_split.
 lib/process/process_eio.ml:1150
 
-# lib/server/lsp_process_manager.ml:179 — LSP child process. Lifetime is
+# lib/server/lsp_process_manager.ml:170 — LSP child process. Lifetime is
 # bound to the LSP session switch; idle eviction handled by the LSP
 # manager itself. Bounded by session scope, not by per-call timeout.
-lib/server/lsp_process_manager.ml:179
+lib/server/lsp_process_manager.ml:170

--- a/test/dune
+++ b/test/dune
@@ -196,6 +196,7 @@
   test_keeper_generation_lineage
   test_keeper_deliberation
   test_keeper_registry_provenance
+  test_keeper_registry_hardening
   test_keeper_fd_pressure_fleet
   test_docker_spawn_throttle
   test_keeper_supervisor
@@ -515,6 +516,7 @@
   test_keeper_generation_lineage
   test_keeper_deliberation
   test_keeper_registry_provenance
+  test_keeper_registry_hardening
   test_keeper_fd_pressure_fleet
   test_docker_spawn_throttle
   test_keeper_supervisor

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -1,0 +1,180 @@
+(** P0 keeper registry hardening tests.
+
+    Verify typed validation errors on put/update, health-aware get, and the
+    tool-dispatch fallback path that uses the original meta when the registry
+    entry is corrupted. *)
+
+open Alcotest
+
+module KR = Masc.Keeper_registry
+module KET = Masc.Keeper_tool_dispatch_runtime
+
+let base_path = "/tmp/test_keeper_registry_hardening"
+
+let make_meta ?(tool_access = []) name =
+  match
+    Masc_test_deps.meta_of_json_fixture
+      (`Assoc
+        [
+          ("name", `String name);
+          ("agent_name", `String ("agent-" ^ name));
+          ("trace_id", `String ("trace-" ^ name));
+          ("goal", `String "test keeper");
+          ("allowed_paths", `List [ `String "*" ]);
+          ("tool_access", Json_util.json_string_list tool_access);
+          ("autoboot_enabled", `Bool false);
+        ])
+  with
+  | Ok m -> m
+  | Error e -> failwith ("make_meta failed: " ^ e)
+;;
+
+let register name =
+  let meta = make_meta name in
+  KR.register ~base_path meta.name meta
+;;
+
+let health_to_string = KR.registry_entry_validation_error_to_string
+
+let test_put_entry_rejects_meta_name_mismatch () =
+  KR.clear ();
+  let entry = register "alice" in
+  let corrupted = { entry with meta = { entry.meta with name = "bob" } } in
+  match KR.put_entry ~base_path "alice" corrupted with
+  | Ok () -> fail "put_entry accepted a meta.name mismatch"
+  | Error (KR.Name_mismatch { expected; actual }) ->
+    check string "expected name" "alice" expected;
+    check string "actual name" "bob" actual
+  | Error other -> fail ("unexpected validation error: " ^ health_to_string other)
+;;
+
+let test_update_entry_rejects_corrupted_result () =
+  KR.clear ();
+  let entry = register "alice" in
+  let original_base_path = entry.base_path in
+  (match
+     KR.update_entry ~base_path "alice" (fun e -> { e with base_path = "wrong" })
+   with
+   | Ok () -> fail "update_entry accepted a corrupted closure result"
+   | Error (KR.Base_path_mismatch _) -> ()
+   | Error other -> fail ("unexpected validation error: " ^ health_to_string other));
+  match KR.get ~base_path "alice" with
+  | None -> fail "original entry disappeared after rejected update"
+  | Some e -> check string "original base_path preserved" original_base_path e.base_path
+;;
+
+let test_get_filters_corrupted_entry () =
+  KR.clear ();
+  let entry = register "alice" in
+  let corrupted =
+    { entry with
+      meta =
+        { entry.meta with
+          runtime = { entry.meta.runtime with trace_id = "" }
+        }
+    }
+  in
+  KR.For_testing.unsafe_put_entry ~base_path "alice" corrupted;
+  (match KR.get ~base_path "alice" with
+   | None -> ()
+   | Some _ -> fail "get returned a corrupted entry");
+  match KR.get_with_health ~base_path "alice" with
+  | None -> fail "get_with_health returned None for an existing (corrupted) entry"
+  | Some (e, KR.Required_field_missing { field }) ->
+    check string "missing field" "trace_id" field;
+    check string "entry base_path" base_path e.base_path
+  | Some (_, other) -> fail ("unexpected health: " ^ health_to_string other)
+;;
+
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let cleanup_dir path =
+  let rec rm target =
+    if Sys.file_exists target
+    then
+      if Sys.is_directory target
+      then (
+        Sys.readdir target |> Array.iter (fun name -> rm (Filename.concat target name));
+        Unix.rmdir target)
+      else Unix.unlink target
+  in
+  try rm path with _ -> ()
+;;
+
+let contains_substring text needle =
+  let text_len = String.length text in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    idx + needle_len <= text_len
+    && (String.sub text idx needle_len = needle || loop (idx + 1))
+  in
+  needle_len = 0 || loop 0
+;;
+
+let test_tool_dispatch_fallback_uses_original_meta () =
+  let dir = temp_dir "registry_fallback" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+       Eio_main.run @@ fun env ->
+       Fs_compat.set_fs (Eio.Stdenv.fs env);
+       let config = Masc.Workspace.default_config dir in
+       let meta = make_meta "fallback-keeper" in
+       let ctx_work = Masc.Keeper_context_runtime.create ~system_prompt:"test" ~max_tokens:4000 in
+       ignore (KR.register ~base_path:config.base_path meta.name meta);
+       Fun.protect
+         ~finally:(fun () -> KR.unregister ~base_path:config.base_path meta.name)
+         (fun () ->
+            (match KR.get_with_health ~base_path:config.base_path meta.name with
+             | None -> fail "registered entry not found"
+             | Some (entry, _) ->
+               let corrupted_meta =
+                 { entry.meta with
+                   name = "wrong-name"
+                 ; tool_denylist = [ "Read" ]
+                 }
+               in
+               let corrupted = { entry with meta = corrupted_meta } in
+               KR.For_testing.unsafe_put_entry ~base_path:config.base_path meta.name corrupted);
+            let result =
+              KET.execute_keeper_tool_call_with_outcome
+                ~config
+                ~meta
+                ~ctx_work
+                ~exec_cache:None
+                ~name:"Read"
+                ~input:(`Assoc [ ("file_path", `String "config/tool_policy.toml") ])
+                ()
+            in
+            check
+              bool
+              "fallback used original meta (Read not denied by corrupted registry entry)"
+              false
+              (contains_substring result.raw_output "\"error\":\"tool_not_allowed\"")))
+;;
+
+let () =
+  run
+    "keeper_registry_hardening"
+    [ ( "put_entry"
+      , [ test_case "rejects meta name mismatch" `Quick test_put_entry_rejects_meta_name_mismatch ]
+      )
+    ; ( "update_entry"
+      , [ test_case
+            "rejects corrupted closure result and preserves original"
+            `Quick
+            test_update_entry_rejects_corrupted_result
+        ] )
+    ; ( "get_with_health"
+      , [ test_case "get filters corrupted entry" `Quick test_get_filters_corrupted_entry ] )
+    ; ( "tool_dispatch_fallback"
+      , [ test_case "uses original meta on corrupted registry entry" `Quick
+            test_tool_dispatch_fallback_uses_original_meta
+        ] )
+    ]
+;;


### PR DESCRIPTION
- Add typed registry_entry_health / registry_entry_validation_error.
- Validate base_path, name, agent_name, runtime fields, and tool lists on put/update; reject invalid entries before CAS install.
- Add get_with_health and health_of_entry for corrupted-entry handling.
- Replace raw registry_key reads in Keeper_registry with validated get.
- Harden tool-dispatch fallback: use get_with_health, emit metric on invalid entries, and fall back to original meta.
- Add unit tests for put/update rejection, corrupted get/health, and fallback behavior.

Relying on CI for full dune build/test; local dune lock is contended.