### PR TITLE
fix(lsp): require executable PATH entries

### DIFF
--- a/lib/core/executable_path.ml
+++ b/lib/core/executable_path.ml
@@ -1,0 +1,37 @@
+(** Executable_path — shell-free executable lookup helpers.
+
+    These helpers intentionally do not mirror shell quirks such as treating an
+    empty PATH entry as the current directory. Callers use them only for a
+    pre-spawn availability check; the actual spawn path remains the authority. *)
+
+let regular_file_is_executable path =
+  try
+    let stat = Unix.stat path in
+    match stat.Unix.st_kind with
+    | Unix.S_REG ->
+      Unix.access path [ Unix.X_OK ];
+      true
+    | _ -> false
+  with
+  | Unix.Unix_error _ | Sys_error _ -> false
+;;
+
+let path_has_executable ?(getenv = Sys.getenv_opt) name =
+  match getenv "PATH" with
+  | None -> false
+  | Some raw_path ->
+    raw_path
+    |> String.split_on_char ':'
+    |> List.exists (fun dir ->
+      (not (String.equal dir ""))
+      && regular_file_is_executable (Filename.concat dir name))
+;;
+
+let command_available ?(getenv = Sys.getenv_opt) name =
+  let name = String.trim name in
+  if String.equal name ""
+  then false
+  else if String.contains name '/'
+  then regular_file_is_executable name
+  else path_has_executable ~getenv name
+;;

--- a/lib/dune
+++ b/lib/dune
@@ -141,6 +141,7 @@
   worker_container_types
   worker_container
   worker_container_runners
+  executable_path
   exec_shell_adapter
   ;; keeper_memory sub-modules
   keeper_memory_policy

--- a/lib/keeper/keeper_tool_execute_path.ml
+++ b/lib/keeper/keeper_tool_execute_path.ml
@@ -168,32 +168,8 @@ let resolve_tool_read_path
         ~raw_for_error:raw_path
         ~projected_path
 
-let executable_file path =
-  try
-    let st = Unix.stat path in
-    st.Unix.st_kind = Unix.S_REG
-    &&
-    (Unix.access path [ Unix.X_OK ];
-     true)
-  with
-  | Unix.Unix_error _ | Sys_error _ -> false
-
-let path_has_executable name =
-  match Sys.getenv_opt "PATH" with
-  | None -> false
-  | Some path ->
-    path
-    |> String.split_on_char ':'
-    |> List.exists (fun dir ->
-      (* Do not mirror the shell's empty-PATH current-directory fallback
-         for keeper probes; only explicit directories are trusted. *)
-      dir <> "" && executable_file (Filename.concat dir name))
-
 let shell_command_available name =
-  let name = String.trim name in
-  if name = "" then false
-  else if String.contains name '/' then executable_file name
-  else path_has_executable name
+  Executable_path.command_available name
 
 let normalize_for_containment path =
   Keeper_alerting_path.normalize_path_for_check path

--- a/lib/server/lsp_process_manager.ml
+++ b/lib/server/lsp_process_manager.ml
@@ -61,16 +61,7 @@ let lang_of_path file_path =
 
 (** Check that an executable exists on [PATH]. *)
 let command_exists cmd =
-  try
-    let _ = Unix.getenv "PATH" in
-    let paths = String.split_on_char ':' (Unix.getenv "PATH") in
-    List.exists
-      (fun dir ->
-         let full = Filename.concat dir cmd in
-         Sys.file_exists full)
-      paths
-  with
-  | Not_found -> false
+  Executable_path.path_has_executable cmd
 ;;
 
 (** Allocate a fresh JSON-RPC request ID for this process. *)

--- a/test/test_lsp_process_manager.ml
+++ b/test/test_lsp_process_manager.ml
@@ -1,5 +1,68 @@
 open Alcotest
 
+let temp_dir prefix =
+  let path = Filename.temp_file prefix "" in
+  Sys.remove path;
+  Unix.mkdir path 0o700;
+  path
+;;
+
+let with_path path f =
+  let prior = Sys.getenv_opt "PATH" in
+  Unix.putenv "PATH" path;
+  Fun.protect
+    ~finally:(fun () ->
+      match prior with
+      | Some value -> Unix.putenv "PATH" value
+      | None -> Unix.putenv "PATH" "")
+    f
+;;
+
+let check_ocamllsp_command_not_found ~path =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  with_path path (fun () ->
+    match
+      Lsp_process_manager.spawn
+        ~sw
+        ~lang_id:"ocaml"
+        ~workspace_root:path
+        (Eio.Stdenv.process_mgr env)
+    with
+    | Error (Lsp_process_manager.Command_not_found "ocamllsp") -> ()
+    | Error err ->
+      failf
+        "expected Command_not_found ocamllsp, got %s"
+        (Format.asprintf "%a" Lsp_process_manager.pp_spawn_error err)
+    | Ok proc ->
+      Lsp_process_manager.shutdown proc;
+      fail "expected non-executable PATH entry to be rejected before spawn")
+;;
+
+let test_spawn_rejects_non_executable_path_entry () =
+  let dir = temp_dir "lsp-path-nonexec-" in
+  let cmd = Filename.concat dir "ocamllsp" in
+  let oc = open_out cmd in
+  close_out oc;
+  Unix.chmod cmd 0o600;
+  Fun.protect
+    ~finally:(fun () ->
+      (try Sys.remove cmd with Sys_error _ -> ());
+      try Unix.rmdir dir with Unix.Unix_error _ -> ())
+    (fun () -> check_ocamllsp_command_not_found ~path:dir)
+;;
+
+let test_spawn_rejects_directory_path_entry () =
+  let dir = temp_dir "lsp-path-dir-" in
+  let cmd_dir = Filename.concat dir "ocamllsp" in
+  Unix.mkdir cmd_dir 0o700;
+  Fun.protect
+    ~finally:(fun () ->
+      (try Unix.rmdir cmd_dir with Unix.Unix_error _ -> ());
+      try Unix.rmdir dir with Unix.Unix_error _ -> ())
+    (fun () -> check_ocamllsp_command_not_found ~path:dir)
+;;
+
 (* [shutdown] must close ALL THREE held pipe FDs (stdin_w, stdout_r, stderr_r),
    not just two. RFC-0261 / #21546: a missing [stderr_r] close leaks 1 FD per
    failed init, still climbing monotonically and tripping the FD admission gate.
@@ -78,7 +141,17 @@ let test_shutdown_signals_child_and_closes_held_pipes () =
 let () =
   run
     "lsp_process_manager"
-    [ ( "shutdown"
+    [ ( "path-resolution"
+      , [ test_case
+            "rejects non-executable PATH file before spawn"
+            `Quick
+            test_spawn_rejects_non_executable_path_entry
+        ; test_case
+            "rejects PATH directory before spawn"
+            `Quick
+            test_spawn_rejects_directory_path_entry
+        ] )
+    ; ( "shutdown"
       , [ test_case
             "signals child and closes held pipes"
             `Quick


### PR DESCRIPTION
## Summary
- add a shared Executable_path helper for shell-free executable lookup
- make LSP spawn preflight require a regular executable file on PATH
- reuse the same helper from keeper shell command availability checks
- add LSP regressions for non-executable files and directories named ocamllsp

## Validation
- ocamlformat --check lib/core/executable_path.ml lib/server/lsp_process_manager.ml lib/keeper/keeper_tool_execute_path.ml test/test_lsp_process_manager.ml
- git diff --cached --check
- local Dune/build intentionally not run; CI is the build authority for this queue