### PR TITLE
[dashboard] refactor: lift FleetTone SSOT (lib/fleet-tone.ts) and align workspace tone (busy)

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -72,6 +72,7 @@ import {
 // the list while detail showed `턴 진행 중 · executing live`).
 import { deriveKeeperOperationalState } from '../lib/keeper-operational-state'
 import { isKeeperPaused } from '../lib/keeper-predicates'
+import { FL_TONE_LABEL, type FleetTone } from '../lib/fleet-tone'
 import type { KeeperCompositeSnapshot } from '../api/schemas/keeper-composite'
 import { buildCompositeByKeeperKey, fleetCompositeSnapshot } from '../composite-signals'
 
@@ -311,17 +312,9 @@ export function rosterBlockerDisplay(
 // chip / rail / aside-state on a 5-value tone vocabulary
 // (ok/warn/bad/busy/idle). RFC-0295 brings masc's RuntimeBand to the same 5
 // values via ROSTER_BAND_TONE (transient → busy); the Korean tone label
-// below is the same `FL_TONE_LABEL` the prototype shipped, used for the
-// aside "selected runtime" state line.
-type FleetTone = 'ok' | 'warn' | 'bad' | 'busy' | 'idle'
-
-const FL_TONE_LABEL: Record<FleetTone, string> = {
-  ok: '실행',
-  warn: '대기',
-  bad: '주의',
-  busy: '전이',
-  idle: '정지',
-}
+// is the SSOT `FL_TONE_LABEL` from `lib/fleet-tone.ts` (shared with
+// `keeper-workspace-shared.ts`), used for the aside "selected runtime"
+// state line. Do not redeclare here — see fleet-tone.ts.
 
 // CTX pressure threshold the prototype paints `hot` at (>=85%). Mirrors the
 // existing live threshold used in the aside CTX meter so both surfaces agree.

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -268,7 +268,10 @@ describe('KeeperWorkspaceRail', () => {
 
   it('runs overflow compaction without force through the existing MCP tool', async () => {
     shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
-    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, phase: 'Overflowed' })} />`)
+    // Use lifecycle_phase (the canonical wire field per Keeper type —
+    // `phaseTokenFromKeeper` reads `keeperDisplayStatus(keeper)` which
+    // routes through `lifecycle_phase`, not the deprecated `phase` alias).
+    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, lifecycle_phase: 'Overflowed' })} />`)
     fireEvent.click(getByRole('button', { name: /지금 컴팩트/ }))
 
     await waitFor(() => {
@@ -282,7 +285,7 @@ describe('KeeperWorkspaceRail', () => {
 
   it('confirms before forcing compaction on running keepers', async () => {
     shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
-    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, phase: 'Running' })} />`)
+    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, lifecycle_phase: 'Running' })} />`)
     fireEvent.click(getByRole('button', { name: /지금 컴팩트/ }))
 
     await waitFor(() => {
@@ -300,7 +303,7 @@ describe('KeeperWorkspaceRail', () => {
   it('does not compact running keepers when force confirmation is cancelled', async () => {
     vi.mocked(requestConfirm).mockResolvedValueOnce(false)
     shellAuthSummary.value = { effective_role: 'worker', default_role: 'worker' } as typeof shellAuthSummary.value
-    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, phase: 'Running' })} />`)
+    const { getByRole } = render(html`<${KeeperWorkspaceRail} keeper=${mkKeeper({ ...keeper, lifecycle_phase: 'Running' })} />`)
     fireEvent.click(getByRole('button', { name: /지금 컴팩트/ }))
 
     await waitFor(() => expect(requestConfirm).toHaveBeenCalled())

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -21,7 +21,7 @@ import {
   keeperFleetTone,
   keeperModelLabel,
   keeperPhaseLabel,
-  keeperPhaseToken,
+  phaseTokenFromKeeper,
   keeperRuntimeLabel,
 } from './keeper-workspace-shared'
 import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
@@ -356,7 +356,7 @@ function compactionGatePct(keeper: Keeper): number {
 }
 
 function compactRequiresForce(keeper: Keeper): boolean {
-  const phase = keeperPhaseToken(keeper)
+  const phase = phaseTokenFromKeeper(keeper)
   if (phase === 'overflowed' || phase === 'paused' || phase === 'compacting') return false
   if (phase === 'running' || phase === 'failing') return true
   const status = keeper.status.toLowerCase()

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
@@ -8,6 +8,7 @@ import {
   keeperModelLabel,
   keeperRuntimeLabel,
   keeperPhaseLabel,
+  phaseTokenFromKeeper,
   WorkspaceSigil,
 } from './keeper-workspace-shared'
 import { html } from 'htm/preact'
@@ -46,14 +47,24 @@ describe('keeperStatusTone', () => {
     expect(keeperStatusTone(mk({ lifecycle_phase: 'Dead' }))).toBe('bad')
     expect(keeperStatusTone(mk({ lifecycle_phase: 'Zombie' }))).toBe('bad')
   })
-  it('maps transient phases to info (working-through, not paused)', () => {
-    // Prototype fleet.jsx vocabulary distinguishes paused(warn) from
-    // transient(info). Compacting / HandingOff / Draining / Restarting are
-    // mid-phase movement, not operator-initiated pause — they render blue.
-    expect(keeperStatusTone(mk({ lifecycle_phase: 'Compacting' }))).toBe('info')
-    expect(keeperStatusTone(mk({ lifecycle_phase: 'HandingOff' }))).toBe('info')
-    expect(keeperStatusTone(mk({ lifecycle_phase: 'Draining' }))).toBe('info')
-    expect(keeperStatusTone(mk({ lifecycle_phase: 'Restarting' }))).toBe('info')
+  it('maps transient phases to busy (working-through, not paused)', () => {
+    // Fleet SSOT PHASE_TONE (lib/fleet-tone.ts) classifies the transient
+    // FSM phases (Compacting / HandingOff / Restarting) as `busy` — the
+    // blue rail, not the amber pause pill. They are operator-initiated
+    // movement, not a stopped runtime.
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Compacting' }))).toBe('busy')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'HandingOff' }))).toBe('busy')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Restarting' }))).toBe('busy')
+  })
+  it('maps operator-initiated Draining to warn (not busy)', () => {
+    // The prototype PHASE_TONE table treats Draining as `warn` (operator
+    // intent via the `stop` action's danger:true via-phase), distinct
+    // from the auto-movement busy phase. This is the P2 gap the
+    // adversarial reviewer flagged: TRANSIENT_KEEPER_PHASES in
+    // monitoring-runtime.ts includes Draining as a transient band, but
+    // the workspace tone must follow the prototype's `warn` classification
+    // so the rail does not paint an operator-initiated stop as "moving".
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Draining' }))).toBe('warn')
   })
   it('maps operator-initiated pause to warn (amber, distinct from transient blue)', () => {
     expect(keeperStatusTone(mk({ status: 'running', paused: true }))).toBe('warn')
@@ -63,6 +74,9 @@ describe('keeperStatusTone', () => {
     expect(keeperStatusTone(mk({ status: 'stopped' }))).toBe('idle')
     expect(keeperStatusTone(mk({ lifecycle_phase: 'Offline' }))).toBe('idle')
   })
+  it('collapses unknown tokens to idle (closed-sum fallback)', () => {
+    expect(keeperStatusTone(mk({ status: 'bootstrapping' }))).toBe('idle')
+  })
 })
 
 describe('statePillTone', () => {
@@ -70,7 +84,7 @@ describe('statePillTone', () => {
     expect(statePillTone('ok')).toBe('run')
     expect(statePillTone('warn')).toBe('warn')
     expect(statePillTone('bad')).toBe('bad')
-    expect(statePillTone('info')).toBe('info')
+    expect(statePillTone('busy')).toBe('busy')
     expect(statePillTone('idle')).toBe('off')
   })
 })
@@ -98,10 +112,14 @@ describe('keeperPhaseLabel', () => {
     expect(keeperPhaseLabel(mk({ lifecycle_phase: 'Compacting' }))).toBe('압축 중')
     expect(keeperPhaseLabel(mk({ lifecycle_phase: 'Failing' }))).toBe('오류 발생')
     expect(keeperPhaseLabel(mk({ lifecycle_phase: 'HandingOff' }))).toBe('인계 중')
+    expect(keeperPhaseLabel(mk({ lifecycle_phase: 'Zombie' }))).toBe('응답 없음')
   })
-  it('falls back to the status token when no friendly label exists', () => {
-    // keeperDisplayStatus returns the raw status string for unmapped tokens.
-    expect(keeperPhaseLabel(mk({ status: 'bootstrapping' }))).toBe('bootstrapping')
+  it('collapses unknown tokens to the 알 수 없음 fallback (no raw wire string leak)', () => {
+    // Closed-sum SSOT: phaseTokenFromKeeper returns 'unknown' for unmapped
+    // wire tokens, and PHASE_LABEL_KO['unknown'] is the canonical
+    // '알 수 없음' label. The old behavior leaked raw status strings
+    // like 'bootstrapping' into the UI — that's a wire-format leak.
+    expect(keeperPhaseLabel(mk({ status: 'bootstrapping' }))).toBe('알 수 없음')
   })
 })
 
@@ -131,5 +149,18 @@ describe('keeperFleetTone', () => {
   it('falls back to the canonical status tone when no fleet attention is present', () => {
     expect(keeperFleetTone(mk({ status: 'running', lifecycle_phase: 'Running' }))).toBe('ok')
     expect(keeperFleetTone(mk({ status: 'running', lifecycle_phase: 'Paused', paused: true }))).toBe('warn')
+    expect(keeperFleetTone(mk({ status: 'running', lifecycle_phase: 'Compacting' }))).toBe('busy')
+  })
+})
+
+describe('phaseTokenFromKeeper', () => {
+  it('lowercases PascalCase lifecycle_phase to the closed token space', () => {
+    expect(phaseTokenFromKeeper(mk({ lifecycle_phase: 'Compacting' }))).toBe('compacting')
+    expect(phaseTokenFromKeeper(mk({ lifecycle_phase: 'HandingOff' }))).toBe('handoff')
+    expect(phaseTokenFromKeeper(mk({ lifecycle_phase: 'Draining' }))).toBe('draining')
+    expect(phaseTokenFromKeeper(mk({ lifecycle_phase: 'Zombie' }))).toBe('zombie')
+  })
+  it('returns unknown for tokens outside the closed sum', () => {
+    expect(phaseTokenFromKeeper(mk({ status: 'bootstrapping' }))).toBe('unknown')
   })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
@@ -163,4 +163,19 @@ describe('phaseTokenFromKeeper', () => {
   it('returns unknown for tokens outside the closed sum', () => {
     expect(phaseTokenFromKeeper(mk({ status: 'bootstrapping' }))).toBe('unknown')
   })
+  it('rejects Object.prototype member names as wire tokens', () => {
+    // Regression: the prior guard was `value in PHASE_TONE`, which walks
+    // the prototype chain and accepts inherited property names like
+    // `constructor`, `toString`, `__proto__`. A backend that emits one of
+    // those strings (or any future JS reserved name) used to bypass the
+    // `'unknown'` fallback and surface inherited members in
+    // `keeperStatusTone` / `keeperPhaseLabel`. The new guard uses
+    // own-property checks against a null-prototype map, so all of these
+    // collapse to `'unknown'`.
+    expect(phaseTokenFromKeeper(mk({ status: 'constructor' }))).toBe('unknown')
+    expect(phaseTokenFromKeeper(mk({ status: 'toString' }))).toBe('unknown')
+    expect(phaseTokenFromKeeper(mk({ status: '__proto__' }))).toBe('unknown')
+    expect(phaseTokenFromKeeper(mk({ status: 'hasOwnProperty' }))).toBe('unknown')
+    expect(phaseTokenFromKeeper(mk({ status: 'valueOf' }))).toBe('unknown')
+  })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.test.ts
@@ -46,10 +46,18 @@ describe('keeperStatusTone', () => {
     expect(keeperStatusTone(mk({ lifecycle_phase: 'Dead' }))).toBe('bad')
     expect(keeperStatusTone(mk({ lifecycle_phase: 'Zombie' }))).toBe('bad')
   })
-  it('maps transient / attention phases to warn', () => {
+  it('maps transient phases to info (working-through, not paused)', () => {
+    // Prototype fleet.jsx vocabulary distinguishes paused(warn) from
+    // transient(info). Compacting / HandingOff / Draining / Restarting are
+    // mid-phase movement, not operator-initiated pause — they render blue.
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Compacting' }))).toBe('info')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'HandingOff' }))).toBe('info')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Draining' }))).toBe('info')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Restarting' }))).toBe('info')
+  })
+  it('maps operator-initiated pause to warn (amber, distinct from transient blue)', () => {
     expect(keeperStatusTone(mk({ status: 'running', paused: true }))).toBe('warn')
-    expect(keeperStatusTone(mk({ lifecycle_phase: 'Compacting' }))).toBe('warn')
-    expect(keeperStatusTone(mk({ lifecycle_phase: 'HandingOff' }))).toBe('warn')
+    expect(keeperStatusTone(mk({ lifecycle_phase: 'Paused', paused: true }))).toBe('warn')
   })
   it('maps stopped / unbooted to idle', () => {
     expect(keeperStatusTone(mk({ status: 'stopped' }))).toBe('idle')
@@ -62,6 +70,7 @@ describe('statePillTone', () => {
     expect(statePillTone('ok')).toBe('run')
     expect(statePillTone('warn')).toBe('warn')
     expect(statePillTone('bad')).toBe('bad')
+    expect(statePillTone('info')).toBe('info')
     expect(statePillTone('idle')).toBe('off')
   })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -18,12 +18,13 @@ export function keeperBucket(keeper: Keeper): KeeperBucket {
   return 'running'
 }
 
-export type DotTone = 'ok' | 'warn' | 'bad' | 'idle'
+export type DotTone = 'ok' | 'warn' | 'bad' | 'info' | 'idle'
 
 const DOT_CLASS: Record<DotTone, string> = {
   ok: 'kw-dot ok',
   warn: 'kw-dot warn',
   bad: 'kw-dot bad',
+  info: 'kw-dot info',
   idle: 'kw-dot',
 }
 
@@ -92,8 +93,13 @@ export function keeperPhaseLabel(keeper: Keeper): string {
 
 /** Error phases that must not render as a healthy green dot. */
 const ERROR_STATUS_TOKENS = new Set(['failing', 'overflowed', 'crashed', 'dead', 'zombie'])
-/** Transient / attention phases that warrant a warn (amber) dot. */
-const WARN_STATUS_TOKENS = new Set(['paused', 'compacting', 'handoff', 'draining', 'restarting'])
+/** Operator-initiated pause — warn (amber). Distinct from transient below so the
+ *  Fleet surfaces can show "stopped by operator" apart from "working through a
+ *  phase", matching the prototype fleet.jsx 5-tone vocabulary. */
+const WARN_STATUS_TOKENS = new Set(['paused'])
+/** Transient phases — info (blue). The keeper is moving through Compacting /
+ *  HandingOff / Draining / Restarting, which is working state, not paused. */
+const INFO_STATUS_TOKENS = new Set(['compacting', 'handoff', 'draining', 'restarting'])
 
 /** Canonical lower-cased phase token, preferring the FSM lifecycle_phase and
  *  falling back to the legacy phase field. Used whenever logic (rather than
@@ -120,6 +126,7 @@ export function isTerminalPhase(keeper: Keeper): boolean {
 export function keeperStatusTone(keeper: Keeper): DotTone {
   const token = keeperDisplayStatus(keeper)
   if (ERROR_STATUS_TOKENS.has(token)) return 'bad'
+  if (INFO_STATUS_TOKENS.has(token)) return 'info'
   if (WARN_STATUS_TOKENS.has(token)) return 'warn'
   if (token === 'running') return 'ok'
   return 'idle'
@@ -139,11 +146,14 @@ export function keeperFleetTone(keeper: Keeper): DotTone {
 }
 
 /** The state-pill modifier class for the chat header, derived from the health
- *  tone so error phases get the `bad` pill rather than collapsing to `off`. */
-export function statePillTone(tone: DotTone): 'run' | 'warn' | 'bad' | 'off' {
+ *  tone so error phases get the `bad` pill rather than collapsing to `off`.
+ *  Transient (info) phases get the dedicated `info` pill so the header shows
+ *  "compacting" as working-through, not stopped. */
+export function statePillTone(tone: DotTone): 'run' | 'warn' | 'bad' | 'info' | 'off' {
   if (tone === 'ok') return 'run'
   if (tone === 'warn') return 'warn'
   if (tone === 'bad') return 'bad'
+  if (tone === 'info') return 'info'
   return 'off'
 }
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -7,6 +7,12 @@ import type { VNode } from 'preact'
 import { kSlot, kSigil } from '../keeper-badge'
 import { keeperDisplayStatus } from '../../lib/keeper-runtime-display'
 import { isKeeperOffline, isKeeperPaused } from '../../lib/keeper-predicates'
+import {
+  PHASE_LABEL_KO,
+  PHASE_TONE,
+  type FleetTone,
+  type KeeperPhaseToken,
+} from '../../lib/fleet-tone'
 import type { Keeper } from '../../types'
 
 /** Coarse lifecycle bucket used both for the dot tone and roster grouping. */
@@ -18,17 +24,15 @@ export function keeperBucket(keeper: Keeper): KeeperBucket {
   return 'running'
 }
 
-export type DotTone = 'ok' | 'warn' | 'bad' | 'info' | 'idle'
-
-const DOT_CLASS: Record<DotTone, string> = {
+const DOT_CLASS: Readonly<Record<FleetTone, string>> = {
   ok: 'kw-dot ok',
   warn: 'kw-dot warn',
   bad: 'kw-dot bad',
-  info: 'kw-dot info',
+  busy: 'kw-dot busy',
   idle: 'kw-dot',
 }
 
-export function StatusDot({ tone, pulse }: { tone: DotTone; pulse?: boolean }): VNode {
+export function StatusDot({ tone, pulse }: { tone: FleetTone; pulse?: boolean }): VNode {
   return html`<span class=${`${DOT_CLASS[tone]}${pulse ? ' pulse' : ''}`} aria-hidden="true"></span>`
 }
 
@@ -59,84 +63,64 @@ export function WorkspaceSigil({
   return html`<span class=${`kw-sigil${beat ? ' kw-sigil-beat' : ''}`} style=${style} title=${id} aria-label=${id}>${sigil}</span>`
 }
 
-/** Friendly (Korean) label per canonical status token. Keyed on the tokens
- *  keeperDisplayStatus emits (lib/keeper-runtime-display.ts keeperLifecycleStatus),
- *  so the roster row + header pill read the same vocabulary as the rest of the
- *  dashboard instead of the raw PascalCase FSM enum (e.g. "Compacting"). */
-const PHASE_LABEL_KO: Record<string, string> = {
-  running: '실행 중',
-  paused: '일시정지',
-  compacting: '압축 중',
-  handoff: '인계 중',
-  draining: '정리 중',
-  restarting: '재시작 중',
-  failing: '오류 발생',
-  overflowed: '컨텍스트 초과',
-  stopped: '중지됨',
-  unbooted: '미기동',
-  crashed: '비정상 종료',
-  dead: '종료됨',
-  zombie: '응답 없음',
-  idle: '유휴',
-  unknown: '알 수 없음',
+/** Normalize the canonical status token (from `keeperDisplayStatus`) into
+ *  the closed `KeeperPhaseToken` keyspace. Unknown tokens collapse to
+ *  `'unknown'` so `PHASE_TONE` / `PHASE_LABEL_KO` lookups are total.
+ *
+ *  Previously this was `keeperPhaseToken` reading from `lifecycle_phase`
+ *  directly. That returned the raw `lifecycle_phase ?? phase` value
+ *  (PascalCase) — incompatible with the lowercase-keyed SSOT in
+ *  `fleet-tone.ts`. Routing through `keeperDisplayStatus` (which already
+ *  applies the lowercasing + isKeeperPaused short-circuit) means there is
+ *  exactly one mapping table from `KeeperPhase` to lowercase token (in
+ *  `keeper-runtime-display.ts:197` `keeperLifecycleStatus`). */
+export function phaseTokenFromKeeper(keeper: Keeper): KeeperPhaseToken {
+  const token = keeperDisplayStatus(keeper).trim().toLowerCase()
+  return isKeeperPhaseToken(token) ? token : 'unknown'
+}
+
+/** Closed-sum guard. `keeperDisplayStatus` returns a `string` (its
+ *  signature is intentionally permissive because callers pass through
+ *  arbitrary backend status values), so we narrow here against the
+ *  declared token union. New tokens from the wire that are not yet in
+ *  `KeeperPhaseToken` collapse to `'unknown'` via this fallback. */
+function isKeeperPhaseToken(value: string): value is KeeperPhaseToken {
+  return value in PHASE_TONE
 }
 
 /** Phase label shown in the roster sub-row and the chat header state pill.
  *  Routes through keeperDisplayStatus so error/transient phases surface with
  *  the same token vocabulary the rest of the dashboard uses, then maps to a
- *  Korean label. Previously returned the raw `lifecycle_phase` enum, which
- *  leaked "Running"/"Compacting"/"HandingOff" into the UI. */
+ *  Korean label from the fleet-tone SSOT (no parallel PHASE_LABEL_KO here —
+ *  that table moved to `lib/fleet-tone.ts`). Previously returned the raw
+ *  `lifecycle_phase` enum, which leaked "Running"/"Compacting"/"HandingOff"
+ *  into the UI. */
 export function keeperPhaseLabel(keeper: Keeper): string {
-  const token = keeperDisplayStatus(keeper)
+  const token = phaseTokenFromKeeper(keeper)
   return PHASE_LABEL_KO[token] ?? token
 }
 
-/** Error phases that must not render as a healthy green dot. */
-const ERROR_STATUS_TOKENS = new Set(['failing', 'overflowed', 'crashed', 'dead', 'zombie'])
-/** Operator-initiated pause — warn (amber). Distinct from transient below so the
- *  Fleet surfaces can show "stopped by operator" apart from "working through a
- *  phase", matching the prototype fleet.jsx 5-tone vocabulary. */
-const WARN_STATUS_TOKENS = new Set(['paused'])
-/** Transient phases — info (blue). The keeper is moving through Compacting /
- *  HandingOff / Draining / Restarting, which is working state, not paused. */
-const INFO_STATUS_TOKENS = new Set(['compacting', 'handoff', 'draining', 'restarting'])
-
-/** Canonical lower-cased phase token, preferring the FSM lifecycle_phase and
- *  falling back to the legacy phase field. Used whenever logic (rather than
- *  display text) needs a normalized phase. */
-export function keeperPhaseToken(keeper: Keeper): string {
-  return (keeper.lifecycle_phase ?? keeper.phase ?? '').toLowerCase()
-}
-
-/** True for phases the backend treats as terminal/unrecoverable. Kept in the
- *  same SSOT module as ERROR_STATUS_TOKENS so roster / rail / chat do not
- *  re-implement this with inline literal comparisons. */
-export function isTerminalPhase(keeper: Keeper): boolean {
-  return ERROR_STATUS_TOKENS.has(keeperPhaseToken(keeper))
-}
-
-/** Health tone for the status dot + header pill.
+/** Health tone for the status dot + header pill. One-line closed-map lookup
+ *  against the fleet-tone SSOT (PHASE_TONE) — no parallel Set<string>
+ *  classifier. The fleet-tone module owns the KeeperPhase → tone mapping
+ *  (lifted from the prototype's PHASE_TONE table at
+ *  ~/Downloads/v2 4/project/keeper-v2/data.jsx:36-39), so adding a new
+ *  phase forces the compiler to flag a missing entry there.
  *
- *  Distinct from keeperBucket, which only groups running/paused/offline for
- *  the roster: a Failing or Overflowed keeper is neither offline nor paused,
- *  so the bucket classifies it as "running" and it would render a green dot
- *  while actually degraded. This maps the canonical status token to a tone so
- *  error phases surface as `bad` (the .kw-dot.bad / .kw-state-pill.bad styles
- *  that were otherwise unreachable). */
-export function keeperStatusTone(keeper: Keeper): DotTone {
-  const token = keeperDisplayStatus(keeper)
-  if (ERROR_STATUS_TOKENS.has(token)) return 'bad'
-  if (INFO_STATUS_TOKENS.has(token)) return 'info'
-  if (WARN_STATUS_TOKENS.has(token)) return 'warn'
-  if (token === 'running') return 'ok'
-  return 'idle'
+ *  Distinct from keeperBucket, which only groups running/paused/offline
+ *  for the roster: a Failing or Overflowed keeper is neither offline nor
+ *  paused, so the bucket classifies it as "running" and it would render a
+ *  green dot while actually degraded. PHASE_TONE handles this — Failing /
+ *  Overflowed both map to `bad`. */
+export function keeperStatusTone(keeper: Keeper): FleetTone {
+  return PHASE_TONE[phaseTokenFromKeeper(keeper)]
 }
 
 /** Fleet surfaces are attention-first: a keeper with blocked work or an
  *  approval gate should not look healthy just because its runtime is still
- *  technically running. Kept here so roster rows and the selected-runtime rail
- *  cannot silently diverge. */
-export function keeperFleetTone(keeper: Keeper): DotTone {
+ *  technically running. Kept here so roster rows and the selected-runtime
+ *  rail cannot silently diverge. */
+export function keeperFleetTone(keeper: Keeper): FleetTone {
   if (
     keeper.needs_attention === true
     || (keeper.blocked_task_count ?? 0) > 0
@@ -145,15 +129,21 @@ export function keeperFleetTone(keeper: Keeper): DotTone {
   return keeperStatusTone(keeper)
 }
 
-/** The state-pill modifier class for the chat header, derived from the health
- *  tone so error phases get the `bad` pill rather than collapsing to `off`.
- *  Transient (info) phases get the dedicated `info` pill so the header shows
- *  "compacting" as working-through, not stopped. */
-export function statePillTone(tone: DotTone): 'run' | 'warn' | 'bad' | 'info' | 'off' {
+/** The state-pill modifier class for the chat header, derived from the
+ *  health tone so error phases get the `bad` pill rather than collapsing
+ *  to `off`. Transient (busy) phases get the dedicated `busy` pill so the
+ *  header shows "compacting" as working-through, not stopped.
+ *
+ *  Note: this is a 1:1 type mapping, not a classifier. Same `FleetTone`
+ *  keyspace → CSS class suffix. Kept as a function (not a constant table)
+ *  because TypeScript `Record<FleetTone, PillClass>` would already be
+ *  total, and the explicit `if` chain is easier for maintainers to read
+ *  at the call site. */
+export function statePillTone(tone: FleetTone): 'run' | 'warn' | 'bad' | 'busy' | 'off' {
   if (tone === 'ok') return 'run'
   if (tone === 'warn') return 'warn'
   if (tone === 'bad') return 'bad'
-  if (tone === 'info') return 'info'
+  if (tone === 'busy') return 'busy'
   return 'off'
 }
 

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -83,9 +83,19 @@ export function phaseTokenFromKeeper(keeper: Keeper): KeeperPhaseToken {
  *  signature is intentionally permissive because callers pass through
  *  arbitrary backend status values), so we narrow here against the
  *  declared token union. New tokens from the wire that are not yet in
- *  `KeeperPhaseToken` collapse to `'unknown'` via this fallback. */
+ *  `KeeperPhaseToken` collapse to `'unknown'` via this fallback.
+ *
+ *  Why `Object.prototype.hasOwnProperty.call` instead of `value in PHASE_TONE`:
+ *  the `in` operator walks the prototype chain. Although `PHASE_TONE` is
+ *  now built with `Object.create(null)` (see `lib/fleet-tone.ts`) so
+ *  this specific leak no longer applies, the `hasOwnProperty` form is
+ *  defensive against future refactors that switch the map to a plain
+ *  object literal or a `Map`. Either backend leak mode would let a
+ *  wire token like `'constructor'` or `'toString'` slip past the
+ *  `'unknown'` fallback and surface inherited `Object.prototype`
+ *  members in `keeperStatusTone` / `keeperPhaseLabel`. */
 function isKeeperPhaseToken(value: string): value is KeeperPhaseToken {
-  return value in PHASE_TONE
+  return Object.prototype.hasOwnProperty.call(PHASE_TONE, value)
 }
 
 /** Phase label shown in the roster sub-row and the chat header state pill.

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
@@ -112,10 +112,9 @@ export function keeperPhaseLabel(keeper: Keeper): string {
 
 /** Health tone for the status dot + header pill. One-line closed-map lookup
  *  against the fleet-tone SSOT (PHASE_TONE) — no parallel Set<string>
- *  classifier. The fleet-tone module owns the KeeperPhase → tone mapping
- *  (lifted from the prototype's PHASE_TONE table at
- *  ~/Downloads/v2 4/project/keeper-v2/data.jsx:36-39), so adding a new
- *  phase forces the compiler to flag a missing entry there.
+ *  classifier. The repo-owned fleet-tone module owns the KeeperPhase →
+ *  tone mapping, so adding a new phase forces the compiler to flag a
+ *  missing entry there.
  *
  *  Distinct from keeperBucket, which only groups running/paused/offline
  *  for the roster: a Failing or Overflowed keeper is neither offline nor

--- a/dashboard/src/lib/fleet-tone.ts
+++ b/dashboard/src/lib/fleet-tone.ts
@@ -68,45 +68,66 @@ export type KeeperPhaseToken =
  *  transient FSM phase. We follow the prototype — Draining is operator
  *  intent (the `stop` action's danger:true via-phase), not a working-
  *  through state. The RuntimeBand `transient` band divergence is out of
- *  scope here (deferred to a separate PR per the iter-3 plan). */
-export const PHASE_TONE: Readonly<Record<KeeperPhaseToken, FleetTone>> = {
-  running: 'ok',
-  paused: 'warn',
-  draining: 'warn',
-  compacting: 'busy',
-  handoff: 'busy',
-  restarting: 'busy',
-  failing: 'bad',
-  overflowed: 'bad',
-  stopped: 'idle',
-  unbooted: 'idle',
-  crashed: 'bad',
-  dead: 'bad',
-  zombie: 'bad',
-  unknown: 'idle',
-}
+ *  scope here (deferred to a separate PR per the iter-3 plan).
+ *
+ *  Why `Object.create(null)` instead of a plain object literal: the
+ *  `isKeeperPhaseToken` guard uses own-property checks, and JS `in` /
+ *  bracket-access on a plain object leak `Object.prototype` members
+ *  (`constructor`, `toString`, `__proto__`, `hasOwnProperty`, …). A
+ *  malformed wire token like `'constructor'` would otherwise bypass
+ *  the `'unknown'` fallback and surface inherited members in
+ *  `keeperStatusTone` / `keeperPhaseLabel`. The null-prototype factory
+ *  closes that hole at the data-structure level so future lookup style
+ *  changes (e.g. switching from `hasOwnProperty` to `Map.get`) cannot
+ *  silently re-introduce it. The `Object.freeze` makes the map truly
+ *  immutable at runtime — there is no legitimate path that mutates it. */
+export const PHASE_TONE: Readonly<Record<KeeperPhaseToken, FleetTone>> =
+  Object.freeze(
+    Object.assign(Object.create(null), {
+      running: 'ok',
+      paused: 'warn',
+      draining: 'warn',
+      compacting: 'busy',
+      handoff: 'busy',
+      restarting: 'busy',
+      failing: 'bad',
+      overflowed: 'bad',
+      stopped: 'idle',
+      unbooted: 'idle',
+      crashed: 'bad',
+      dead: 'bad',
+      zombie: 'bad',
+      unknown: 'idle',
+    }) as Record<KeeperPhaseToken, FleetTone>,
+  )
 
 /** Korean phase label shown in roster sub-rows + chat header state pills.
  *  Keyed on the same lowercase tokens as `PHASE_TONE` so the two tables
  *  cannot drift. Previously lived at the bottom of `keeper-workspace-
  *  shared.ts` and missed `Overflowed` / `Restarting` variants; lifted here
- *  so agent-roster can share it. */
-export const PHASE_LABEL_KO: Readonly<Record<KeeperPhaseToken, string>> = {
-  running: '실행 중',
-  paused: '일시정지',
-  compacting: '압축 중',
-  handoff: '인계 중',
-  draining: '정리 중',
-  restarting: '재시작 중',
-  failing: '오류 발생',
-  overflowed: '컨텍스트 초과',
-  stopped: '중지됨',
-  unbooted: '미기동',
-  crashed: '비정상 종료',
-  dead: '종료됨',
-  zombie: '응답 없음',
-  unknown: '알 수 없음',
-}
+ *  so agent-roster can share it.
+ *
+ *  Same null-prototype + freeze rationale as `PHASE_TONE` — closed-sum
+ *  boundary must hold for arbitrary backend wire strings. */
+export const PHASE_LABEL_KO: Readonly<Record<KeeperPhaseToken, string>> =
+  Object.freeze(
+    Object.assign(Object.create(null), {
+      running: '실행 중',
+      paused: '일시정지',
+      compacting: '압축 중',
+      handoff: '인계 중',
+      draining: '정리 중',
+      restarting: '재시작 중',
+      failing: '오류 발생',
+      overflowed: '컨텍스트 초과',
+      stopped: '중지됨',
+      unbooted: '미기동',
+      crashed: '비정상 종료',
+      dead: '종료됨',
+      zombie: '응답 없음',
+      unknown: '알 수 없음',
+    }) as Record<KeeperPhaseToken, string>,
+  )
 
 // The runtime helper `phaseTokenFromPhase` is defined in the workspace
 // surface (keeper-workspace-shared.ts) because it depends on

--- a/dashboard/src/lib/fleet-tone.ts
+++ b/dashboard/src/lib/fleet-tone.ts
@@ -1,0 +1,114 @@
+// Fleet tone vocabulary — the single SSOT for the 5-tone health badge /
+// dot / pill / aside tone that the keeper workspace + agent-roster share.
+//
+// Two prior surfaces re-declared this vocabulary in parallel:
+//   - dashboard/src/components/agent-roster.ts (PR #22441, MERGED):
+//       `type FleetTone = 'ok' | 'warn' | 'bad' | 'busy' | 'idle'`
+//       `FL_TONE_LABEL = { ok:'실행', warn:'대기', bad:'주의', busy:'전이', idle:'정지' }`
+//   - dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
+//     (iter-2 PR #22466, DRAFT): local `DotTone = 'ok' | 'warn' | 'bad' | 'info' | 'idle'`
+//
+// The 'info' name is a drift — agent-roster already shipped 'busy', the
+// vendored fleet.css and the prototype (~/Downloads/v2 4/project/keeper-v2/
+// data.jsx:36-39 / fleet.jsx:28) both use 'busy'. Lifting the SSOT here
+// makes the broader convention win.
+
+/** 5-tone health vocabulary shared across the Fleet surfaces. */
+export type FleetTone = 'ok' | 'warn' | 'bad' | 'busy' | 'idle'
+
+/** Korean tone label, used as the aside "selected runtime" state line. */
+export const FL_TONE_LABEL: Readonly<Record<FleetTone, string>> = {
+  ok: '실행',
+  warn: '대기',
+  bad: '주의',
+  busy: '전이',
+  idle: '정지',
+}
+
+/** Canonical lower-cased phase token emitted by `keeperDisplayStatus`
+ *  (`lib/keeper-runtime-display.ts:180`). The labels in PHASE_LABEL_KO and
+ *  the tones in PHASE_TONE key on these tokens, NOT on the PascalCase
+ *  `KeeperPhase` enum. This union is closed: any new lowercase token added
+ *  by `keeperLifecycleStatus` (or any future status surface) forces the
+ *  compiler to flag a missing entry here.
+ *
+ *  Derivation: `KeeperPhase` (13 variants) collapses via `keeperLifecycleStatus`
+ *  to 13 lowercase tokens, plus `unknown` for the fallback path. We
+ *  promote `Zombie` to a first-class entry even though the prototype
+ *  `PHASE_TONE` table only has 12 — the live wire emits `Zombie` as a
+ *  distinct phase (`KeeperPhase | null`), so the closed sum must cover it.
+ *  Zombie is classified as `bad` (degraded, operator must act).
+ */
+export type KeeperPhaseToken =
+  | 'running'
+  | 'paused'
+  | 'compacting'
+  | 'handoff'
+  | 'draining'
+  | 'restarting'
+  | 'failing'
+  | 'overflowed'
+  | 'stopped'
+  | 'unbooted'
+  | 'crashed'
+  | 'dead'
+  | 'zombie'
+  | 'unknown'
+
+/** Closed tone map. Keys MUST match `KeeperPhaseToken` and MUST be kept in
+ *  sync with `PHASE_LABEL_KO` below (same keyspace, different value shape).
+ *
+ *  Authoritative SSOT: the prototype (~/Downloads/v2 4/project/keeper-v2/
+ *  data.jsx:36-39) `PHASE_TONE` table. Lowercased here to match the live
+ *  `keeperDisplayStatus` wire tokens.
+ *
+ *  Notable divergence from prototype: prototype marks `Draining` as `warn`
+ *  (operator-initiated destructive stop), while
+ *  `monitoring-runtime.ts:171` `TRANSIENT_KEEPER_PHASES` treats it as a
+ *  transient FSM phase. We follow the prototype — Draining is operator
+ *  intent (the `stop` action's danger:true via-phase), not a working-
+ *  through state. The RuntimeBand `transient` band divergence is out of
+ *  scope here (deferred to a separate PR per the iter-3 plan). */
+export const PHASE_TONE: Readonly<Record<KeeperPhaseToken, FleetTone>> = {
+  running: 'ok',
+  paused: 'warn',
+  draining: 'warn',
+  compacting: 'busy',
+  handoff: 'busy',
+  restarting: 'busy',
+  failing: 'bad',
+  overflowed: 'bad',
+  stopped: 'idle',
+  unbooted: 'idle',
+  crashed: 'bad',
+  dead: 'bad',
+  zombie: 'bad',
+  unknown: 'idle',
+}
+
+/** Korean phase label shown in roster sub-rows + chat header state pills.
+ *  Keyed on the same lowercase tokens as `PHASE_TONE` so the two tables
+ *  cannot drift. Previously lived at the bottom of `keeper-workspace-
+ *  shared.ts` and missed `Overflowed` / `Restarting` variants; lifted here
+ *  so agent-roster can share it. */
+export const PHASE_LABEL_KO: Readonly<Record<KeeperPhaseToken, string>> = {
+  running: '실행 중',
+  paused: '일시정지',
+  compacting: '압축 중',
+  handoff: '인계 중',
+  draining: '정리 중',
+  restarting: '재시작 중',
+  failing: '오류 발생',
+  overflowed: '컨텍스트 초과',
+  stopped: '중지됨',
+  unbooted: '미기동',
+  crashed: '비정상 종료',
+  dead: '종료됨',
+  zombie: '응답 없음',
+  unknown: '알 수 없음',
+}
+
+// The runtime helper `phaseTokenFromPhase` is defined in the workspace
+// surface (keeper-workspace-shared.ts) because it depends on
+// `KeeperPhase | null | undefined` normalization rules that belong to
+// the runtime display layer. This module stays pure data.

--- a/dashboard/src/lib/fleet-tone.ts
+++ b/dashboard/src/lib/fleet-tone.ts
@@ -8,10 +8,9 @@
 //   - dashboard/src/components/keeper-workspace/keeper-workspace-shared.ts
 //     (iter-2 PR #22466, DRAFT): local `DotTone = 'ok' | 'warn' | 'bad' | 'info' | 'idle'`
 //
-// The 'info' name is a drift — agent-roster already shipped 'busy', the
-// vendored fleet.css and the prototype (~/Downloads/v2 4/project/keeper-v2/
-// data.jsx:36-39 / fleet.jsx:28) both use 'busy'. Lifting the SSOT here
-// makes the broader convention win.
+// The 'info' name is a drift: agent-roster and the repo-owned keeper-v2
+// fleet.css already shipped 'busy'. Lifting the SSOT here makes that
+// checked-in convention win.
 
 /** 5-tone health vocabulary shared across the Fleet surfaces. */
 export type FleetTone = 'ok' | 'warn' | 'bad' | 'busy' | 'idle'
@@ -34,10 +33,9 @@ export const FL_TONE_LABEL: Readonly<Record<FleetTone, string>> = {
  *
  *  Derivation: `KeeperPhase` (13 variants) collapses via `keeperLifecycleStatus`
  *  to 13 lowercase tokens, plus `unknown` for the fallback path. We
- *  promote `Zombie` to a first-class entry even though the prototype
- *  `PHASE_TONE` table only has 12 — the live wire emits `Zombie` as a
- *  distinct phase (`KeeperPhase | null`), so the closed sum must cover it.
- *  Zombie is classified as `bad` (degraded, operator must act).
+ *  promote `Zombie` to a first-class entry because the live wire emits it
+ *  as a distinct phase (`KeeperPhase | null`), so the closed sum must cover
+ *  it. Zombie is classified as `bad` (degraded, operator must act).
  */
 export type KeeperPhaseToken =
   | 'running'
@@ -58,17 +56,15 @@ export type KeeperPhaseToken =
 /** Closed tone map. Keys MUST match `KeeperPhaseToken` and MUST be kept in
  *  sync with `PHASE_LABEL_KO` below (same keyspace, different value shape).
  *
- *  Authoritative SSOT: the prototype (~/Downloads/v2 4/project/keeper-v2/
- *  data.jsx:36-39) `PHASE_TONE` table. Lowercased here to match the live
- *  `keeperDisplayStatus` wire tokens.
+ *  Runtime SSOT: this repo-owned table. Keys are lowercased to match the
+ *  live `keeperDisplayStatus` wire tokens, and consumers import this module
+ *  instead of keeping parallel string classifiers.
  *
- *  Notable divergence from prototype: prototype marks `Draining` as `warn`
- *  (operator-initiated destructive stop), while
- *  `monitoring-runtime.ts:171` `TRANSIENT_KEEPER_PHASES` treats it as a
- *  transient FSM phase. We follow the prototype — Draining is operator
- *  intent (the `stop` action's danger:true via-phase), not a working-
- *  through state. The RuntimeBand `transient` band divergence is out of
- *  scope here (deferred to a separate PR per the iter-3 plan).
+ *  `Draining` is `warn` here because it represents operator intent via
+ *  the `stop` action's danger:true via-phase. `monitoring-runtime.ts:171`
+ *  `TRANSIENT_KEEPER_PHASES` treats it as a transient FSM phase; that
+ *  RuntimeBand divergence is out of scope here and should be reconciled in
+ *  a separate typed-runtime-state change.
  *
  *  Why `Object.create(null)` instead of a plain object literal: the
  *  `isKeeperPhaseToken` guard uses own-property checks, and JS `in` /

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -317,7 +317,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-kp-row[data-tone="ok"] { --kw-row-rail: var(--color-status-ok); }
 .kw-kp-row[data-tone="warn"] { --kw-row-rail: var(--color-status-warn); }
 .kw-kp-row[data-tone="bad"] { --kw-row-rail: var(--color-status-err); }
-.kw-kp-row[data-tone="info"] { --kw-row-rail: var(--color-accent-fg); }
+.kw-kp-row[data-tone="busy"] { --kw-row-rail: var(--color-status-info); }
 .kw-kp-row[data-tone="idle"] { --kw-row-rail: color-mix(in oklab, var(--color-fg-muted) 54%, transparent); }
 .kw-kp-row::before {
   content: "";
@@ -534,7 +534,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-dot.ok { background: var(--color-status-ok); box-shadow: 0 0 7px var(--color-status-ok); }
 .kw-dot.warn { background: var(--color-status-warn); box-shadow: 0 0 7px var(--color-status-warn); }
 .kw-dot.bad { background: var(--color-status-err); box-shadow: 0 0 7px var(--color-status-err); }
-.kw-dot.info { background: var(--color-accent-fg); box-shadow: 0 0 7px var(--color-accent-fg-dim); }
+.kw-dot.busy { background: var(--color-status-info); box-shadow: 0 0 7px var(--color-status-info); }
 .kw-dot.pulse { animation: kw-dot-pulse 1.8s ease-in-out infinite; }
 @keyframes kw-dot-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
 
@@ -597,7 +597,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-state-pill.run { color: var(--color-status-ok); border-color: rgb(var(--color-status-ok-glow) / 0.45); background: rgb(var(--color-status-ok-glow) / 0.10); }
 .kw-state-pill.warn { color: var(--color-status-warn); border-color: rgb(var(--color-status-warn-glow) / 0.45); background: rgb(var(--color-status-warn-glow) / 0.10); }
 .kw-state-pill.bad { color: var(--color-status-err); border-color: rgb(var(--color-status-err-glow) / 0.50); background: rgb(var(--color-status-err-glow) / 0.12); }
-.kw-state-pill.info { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); background: var(--accent-10); }
+.kw-state-pill.busy { color: var(--color-status-info); border-color: rgb(var(--color-info-glow) / 0.45); background: rgb(var(--color-info-glow) / 0.10); }
 .kw-state-pill.off { color: var(--color-fg-muted); }
 
 .kw-chat-actions { display: flex; gap: 8px; align-items: center; flex: none; }
@@ -1894,11 +1894,11 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
     radial-gradient(circle at 12% 0%, rgba(248, 113, 113, 0.18), transparent 32%),
     linear-gradient(160deg, rgba(30, 18, 24, 0.94), rgba(2, 6, 23, 0.84));
 }
-.kw-fleet-aside[data-tone="info"] {
-  border-color: rgba(217, 167, 96, 0.34);
+.kw-fleet-aside[data-tone="busy"] {
+  border-color: rgb(var(--color-info-glow) / 0.34);
   background:
-    radial-gradient(circle at 12% 0%, rgba(217, 167, 96, 0.16), transparent 32%),
-    linear-gradient(160deg, rgba(28, 22, 14, 0.94), rgba(2, 6, 23, 0.84));
+    radial-gradient(circle at 12% 0%, rgb(var(--color-info-glow) / 0.16), transparent 32%),
+    linear-gradient(160deg, rgba(14, 22, 36, 0.94), rgba(2, 6, 23, 0.84));
 }
 
 .kw-fleet-aside-head {

--- a/dashboard/src/styles/keeper-workspace.css
+++ b/dashboard/src/styles/keeper-workspace.css
@@ -534,6 +534,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-dot.ok { background: var(--color-status-ok); box-shadow: 0 0 7px var(--color-status-ok); }
 .kw-dot.warn { background: var(--color-status-warn); box-shadow: 0 0 7px var(--color-status-warn); }
 .kw-dot.bad { background: var(--color-status-err); box-shadow: 0 0 7px var(--color-status-err); }
+.kw-dot.info { background: var(--color-accent-fg); box-shadow: 0 0 7px var(--color-accent-fg-dim); }
 .kw-dot.pulse { animation: kw-dot-pulse 1.8s ease-in-out infinite; }
 @keyframes kw-dot-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
 
@@ -596,6 +597,7 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
 .kw-state-pill.run { color: var(--color-status-ok); border-color: rgb(var(--color-status-ok-glow) / 0.45); background: rgb(var(--color-status-ok-glow) / 0.10); }
 .kw-state-pill.warn { color: var(--color-status-warn); border-color: rgb(var(--color-status-warn-glow) / 0.45); background: rgb(var(--color-status-warn-glow) / 0.10); }
 .kw-state-pill.bad { color: var(--color-status-err); border-color: rgb(var(--color-status-err-glow) / 0.50); background: rgb(var(--color-status-err-glow) / 0.12); }
+.kw-state-pill.info { color: var(--color-accent-fg); border-color: var(--color-accent-fg-dim); background: var(--accent-10); }
 .kw-state-pill.off { color: var(--color-fg-muted); }
 
 .kw-chat-actions { display: flex; gap: 8px; align-items: center; flex: none; }
@@ -1891,6 +1893,12 @@ body.kw-resizing { cursor: col-resize; user-select: none; }
   background:
     radial-gradient(circle at 12% 0%, rgba(248, 113, 113, 0.18), transparent 32%),
     linear-gradient(160deg, rgba(30, 18, 24, 0.94), rgba(2, 6, 23, 0.84));
+}
+.kw-fleet-aside[data-tone="info"] {
+  border-color: rgba(217, 167, 96, 0.34);
+  background:
+    radial-gradient(circle at 12% 0%, rgba(217, 167, 96, 0.16), transparent 32%),
+    linear-gradient(160deg, rgba(28, 22, 14, 0.94), rgba(2, 6, 23, 0.84));
 }
 
 .kw-fleet-aside-head {


### PR DESCRIPTION
## Summary

PR #22441 (agent-roster 5-tone health pills) introduced `FleetTone` and
`FL_TONE_LABEL` as a private declaration inside `agent-roster.ts`. PR
#22466 iteration-2 added a parallel `DotTone = 'ok' | 'warn' | 'bad' |
'info' | 'idle'` to `keeper-workspace-shared.ts` that forked the
established vocabulary. The adversarial reviewer flagged this as a P0
SSOT fracture.

This iteration-3 closes the SSOT gap:

- New `dashboard/src/lib/fleet-tone.ts`: single source of truth for
  `FleetTone`, `FL_TONE_LABEL`, `PHASE_TONE` (a closed
  `Record<KeeperPhaseToken, FleetTone>`) and `PHASE_LABEL_KO`. The
  Record forces compile-time exhaustiveness over all 14 lowercase
  phase tokens, replacing the iter-2 `Set<string>` classifier that the
  reviewer flagged as P1.
- `agent-roster.ts`: drops its private `FleetTone` and `FL_TONE_LABEL`;
  imports from the new SSOT. No behavioral change for that surface.
- `keeper-workspace-shared.ts`: drops `DotTone`, `DOT_CLASS`, and the
  `ERROR/WARN/INFO_STATUS_TOKENS` Sets. `keeperStatusTone` becomes a
  single `PHASE_TONE` lookup. `keeperPhaseLabel` reads from
  `PHASE_LABEL_KO`.
- `keeper-workspace.css`: rename `.kw-dot.info`,
  `.kw-state-pill.info`, and `.kw-fleet-aside[data-tone="info"]` →
  `busy`; replace the hardcoded brass `rgba(217, 167, 96, ...)`
  gradient with theme tokens (`--color-status-info`,
  `--color-info-glow`) so the rail color matches the prototype's blue
  `info`/`busy` family.

The vocabulary `busy` (not `info`) is the convention already in use by
the prototype (`fleet.jsx:28`, vendored `fleet.css:47-48,98,133`), the
agent-roster pills, and `PHASE_TONE` itself. Aligning to `busy` is
forced by the SSOT lift — iter-2's `info` is a one-place rename, not a
design choice.

## Verification

- `npx vitest run src/components/keeper-workspace/` → all green
- `npx vitest run` (whole dashboard) → 2325 / 2325 pass
- `npx tsc --noEmit` → clean
- `npx eslint src/...` → no warnings on changed files
- CI checks: pending, will settle via `gh pr checks 22466 --watch`

## Design decisions (with rationale)

1. **`busy` (not `info`)** — The vendored fleet.css and
   `agent-roster.ts` both use `busy`. Iter-2's `info` was a
   divergence, not a preference. The Record<KeeperPhaseToken, FleetTone>
   forces a single source of truth.
2. **Lowercase `KeeperPhaseToken` keys** — These match the wire output
   of `keeperLifecycleStatus` (`lib/keeper-runtime-display.ts:197`),
   which is the canonical PascalCase→lowercase mapping. PascalCase
   would have required a redundant mapping layer; lowercase collapses
   it.
3. **Closed `Record` over open `Set`** — Adding a new phase now
   triggers a compile error at `PHASE_TONE` and `PHASE_LABEL_KO`,
   eliminating the iter-2 risk of a new phase silently mapping to
   `idle` because no Set membership existed.
4. **`Unknown → '알 수 없음'` collapse** — Iter-2 leaked raw wire
   strings (`'bootstrapping'`) into the UI; the new behavior collapses
   unknown tokens to the closed-sum fallback label. Verified by the
   updated test fixture.
5. **Theme tokens over hardcoded RGBA** — Iter-2 introduced
   `rgba(217, 167, 96, ...)` for the `info` aside gradient. The
   replacement uses `rgb(var(--color-info-glow) / N)` so the rail color
   follows the theme rather than a per-PR literal.

## Hidden coupling surfaced (and fixed)

The iter-2 `keeperPhaseToken` function read `lifecycle_phase ??
phase`, masking a stale field usage in `keeper-workspace-rail.test.ts`.
The SSOT lift renamed the function to `phaseTokenFromKeeper` and made
it route through `keeperDisplayStatus(keeper)` — which only reads the
canonical `lifecycle_phase`. This forced three test fixtures to switch
from the deprecated `phase` alias to `lifecycle_phase`, surfacing the
coupling. No production code change required.

## Out of scope

- `monitoring-runtime.ts:166-171` `TRANSIENT_KEEPER_PHASES` includes
  `Draining`. The prototype treats `Draining` as `warn`, not `busy`.
  This is a pre-existing divergence between `monitoring-runtime.ts`
  and the prototype's `PHASE_TONE`. Fixing it requires changes to
  `RuntimeBand` semantics and the agent-roster's `ROSTER_BAND_TONE`,
  expanding the PR to a refactor of those modules. Defer to a separate
  PR.
- `v2/keeper-fsm.ts:62-79` `PHASE_PULSE` / `PHASE_INFO` duplicates
  (same SSOT data as the prototype's tables). Lifting these to
  `fleet-tone.ts` is tempting but expands the PR blast radius.
  Defer.
- `compositePhaseTone` (3-tone, in `keeper-operational-state.ts`) is
  the FSM-graph node renderer SSOT, not the workspace surface. The
  workspace tone is intentionally surface-specific. Keep as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
