### PR TITLE
fix: repair main build after recall outcome eval changes

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -123,7 +123,7 @@
  (modules masc_recall_outcome_eval)
  (public_name masc-recall-outcome-eval)
  (package masc)
- (libraries masc masc.config masc_core unix yojson))
+ (libraries masc masc.config masc.config_dir_resolver masc_core unix yojson))
 
 (executable
  (name public_tool_manifest)

--- a/lib/keeper/keeper_recall_outcome_eval.ml
+++ b/lib/keeper/keeper_recall_outcome_eval.ml
@@ -401,8 +401,8 @@ let trace_row_of_group
   =
   let compare_record (a : recall_record) (b : recall_record) =
     match a.ts, b.ts with
-    | Some a, Some b ->
-      let by_ts = Float.compare a b in
+    | Some a_ts, Some b_ts ->
+      let by_ts = Float.compare a_ts b_ts in
       if by_ts <> 0 then by_ts else compare a.turn b.turn
     | Some _, None -> 1
     | None, Some _ -> -1


### PR DESCRIPTION
- Fix variable shadowing in keeper_recall_outcome_eval.ml that caused a.turn to be typed as float.
- Add missing masc.config_dir_resolver dependency to masc-recall-outcome-eval executable.

Verification:
- dune build @install passes locally.
- dune build @check passes locally.
- test/test_keeper_recall_outcome_eval.exe passes (5/5).