### PR TITLE
fix(http): address P1 follow-ups from #22406 and #22407

### DIFF
--- a/lib/compression/compression_codec.ml
+++ b/lib/compression/compression_codec.ml
@@ -18,6 +18,7 @@ type compress_result =
   | Compressed of compressed
 
 let min_size = 32
+let legacy_min_size = 256
 let max_dict_size = 2048
 
 let should_use_dict (size : int) : bool =

--- a/lib/compression/compression_codec.mli
+++ b/lib/compression/compression_codec.mli
@@ -24,6 +24,11 @@ type compress_result =
 val min_size : int
 (** Minimum payload size (bytes) below which compression is skipped. *)
 
+val legacy_min_size : int
+(** Minimum payload size (bytes) for the legacy standard-zstd path.
+    The main {!min_size} floor is used by the dictionary-aware path; the
+    legacy path keeps its own higher floor to avoid tiny-response overhead. *)
+
 val max_dict_size : int
 (** Upper bound reserved for dictionary payloads. *)
 

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -61,14 +61,25 @@ module Compression = struct
     | Compression_codec.Compressed { payload; encoding } ->
         (payload, Some (Compression_codec.content_encoding encoding))
 
-  (** Legacy: Standard zstd without dictionary *)
-  let compress_zstd ?(level = 3) (data : string) : (string * bool) =
-    if String.length data < 256
+  (** Legacy: Standard zstd without dictionary.
+
+      The [bool] returned here tracks whether the caller should emit a
+      [Content-Encoding: zstd] header. It may be [false] either because the
+      payload was incompressible or because compression failed and
+      [Compression_codec.compress] silently fell back to the original payload
+      after logging the failure. *)
+  let compress_zstd ?(level = 3) (data : string) : string * bool =
+    if String.length data < Compression_codec.legacy_min_size
     then data, false
     else
       match Compression_codec.compress ~level data with
       | Compression_codec.Unchanged payload -> payload, false
-      | Compression_codec.Compressed { payload; encoding = _ } -> payload, true
+      | Compression_codec.Compressed { payload; encoding = Standard } ->
+        payload, true
+      | Compression_codec.Compressed { payload; encoding = Dictionary } ->
+        (* Legacy path does not advertise dictionary support; emit the
+           uncompressed payload instead of dictionary-compressed bytes. *)
+        payload, false
 end
 
 (** Late-response failure classifier (#13059).

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -65,21 +65,22 @@ module Compression = struct
 
       The [bool] returned here tracks whether the caller should emit a
       [Content-Encoding: zstd] header. It may be [false] either because the
-      payload was incompressible or because compression failed and
-      [Compression_codec.compress] silently fell back to the original payload
-      after logging the failure. *)
+      payload was unchanged, because compression failed and returned
+      [Unchanged], or because a dictionary-compressed result cannot be served
+      through this legacy standard-zstd path. *)
+  let compress_zstd_result ~original = function
+    | Compression_codec.Unchanged payload -> payload, false
+    | Compression_codec.Compressed { payload; encoding = Standard } ->
+      payload, true
+    | Compression_codec.Compressed { encoding = Dictionary; _ } ->
+      original, false
+
   let compress_zstd ?(level = 3) (data : string) : string * bool =
     if String.length data < Compression_codec.legacy_min_size
     then data, false
     else
-      match Compression_codec.compress ~level data with
-      | Compression_codec.Unchanged payload -> payload, false
-      | Compression_codec.Compressed { payload; encoding = Standard } ->
-        payload, true
-      | Compression_codec.Compressed { payload; encoding = Dictionary } ->
-        (* Legacy path does not advertise dictionary support; emit the
-           uncompressed payload instead of dictionary-compressed bytes. *)
-        payload, false
+      Compression_codec.compress ~level data
+      |> compress_zstd_result ~original:data
 end
 
 (** Late-response failure classifier (#13059).

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -149,14 +149,50 @@ module Http_negotiation = struct
             (type_ = "application" && subtype = "json")
             || (type_ = "*" && subtype = "*"))
 
+  (* Content-Type is a single media type (no comma-separated list, no q
+     parameter). Parse it locally rather than reusing the Accept-list parser,
+     which splits on commas and understands quality values. *)
+  type parsed_content_type =
+    { type_ : string
+    ; subtype : string
+    }
+
+  let parse_content_type s =
+    let s = String.trim s in
+    if String.equal s ""
+    then None
+    else (
+      match String.split_on_char ';' s with
+      | [] -> None
+      | media :: params ->
+        (match String.split_on_char '/' (String.trim media) with
+         | [ type_; subtype ] ->
+           let type_ = String.trim type_ |> String.lowercase_ascii in
+           let subtype = String.trim subtype |> String.lowercase_ascii in
+           if String.equal type_ "" || String.equal subtype ""
+           then None
+           else (
+             let has_q =
+               List.exists
+                 (fun p ->
+                    match String.index_opt p '=' with
+                    | None -> false
+                    | Some i ->
+                      let name =
+                        String.sub p 0 i |> String.trim |> String.lowercase_ascii
+                      in
+                      String.equal name "q")
+                 params
+             in
+             if has_q then None else Some { type_; subtype })
+         | _ -> None))
+
   let is_json_content_type = function
     | None -> false
     | Some h ->
-        (match Mcp_protocol.Http_negotiation.parse_accept_header h with
-         | [ mt ] ->
-             String.equal (String.lowercase_ascii mt.type_) "application"
-             && String.equal (String.lowercase_ascii mt.subtype) "json"
-         | [] | _ :: _ :: _ -> false)
+        (match parse_content_type h with
+         | Some { type_ = "application"; subtype = "json" } -> true
+         | Some _ | None -> false)
 
   let accepts_streamable_mcp = function
     | None -> false

--- a/lib/mcp_transport_protocol/mcp_transport_protocol.ml
+++ b/lib/mcp_transport_protocol/mcp_transport_protocol.ml
@@ -157,35 +157,73 @@ module Http_negotiation = struct
     ; subtype : string
     }
 
+  let split_content_type_segments s =
+    let len = String.length s in
+    let segment start stop = String.sub s start (stop - start) in
+    let rec loop i start in_quote escaped acc =
+      if i >= len
+      then if in_quote then None else Some (List.rev (segment start len :: acc))
+      else
+        match s.[i], in_quote, escaped with
+        | _, _, true -> loop (i + 1) start in_quote false acc
+        | '\\', true, false -> loop (i + 1) start in_quote true acc
+        | '"', _, false -> loop (i + 1) start (not in_quote) false acc
+        | ';', false, false ->
+          loop (i + 1) (i + 1) false false (segment start i :: acc)
+        | ',', false, false -> None
+        | _ -> loop (i + 1) start in_quote false acc
+    in
+    loop 0 0 false false []
+
+  let parse_media_type media =
+    let media = String.trim media in
+    match String.index_opt media '/' with
+    | None -> None
+    | Some slash -> (
+      if slash + 1 >= String.length media
+         || (String.index_from_opt media (slash + 1) '/' |> Option.is_some)
+      then None
+      else
+        let type_ =
+          String.sub media 0 slash |> String.trim |> String.lowercase_ascii
+        in
+        let subtype =
+          String.sub media (slash + 1) (String.length media - slash - 1)
+          |> String.trim
+          |> String.lowercase_ascii
+        in
+        if String.equal type_ "" || String.equal subtype ""
+        then None
+        else Some { type_; subtype })
+
+  let valid_content_type_parameter param =
+    let param = String.trim param in
+    if String.equal param ""
+    then true
+    else
+      match String.index_opt param '=' with
+      | None -> false
+      | Some eq ->
+        let name =
+          String.sub param 0 eq |> String.trim |> String.lowercase_ascii
+        in
+        let value =
+          String.sub param (eq + 1) (String.length param - eq - 1)
+          |> String.trim
+        in
+        (not (String.equal name ""))
+        && (not (String.equal name "q"))
+        && not (String.equal value "")
+
   let parse_content_type s =
     let s = String.trim s in
     if String.equal s ""
     then None
-    else (
-      match String.split_on_char ';' s with
-      | [] -> None
-      | media :: params ->
-        (match String.split_on_char '/' (String.trim media) with
-         | [ type_; subtype ] ->
-           let type_ = String.trim type_ |> String.lowercase_ascii in
-           let subtype = String.trim subtype |> String.lowercase_ascii in
-           if String.equal type_ "" || String.equal subtype ""
-           then None
-           else (
-             let has_q =
-               List.exists
-                 (fun p ->
-                    match String.index_opt p '=' with
-                    | None -> false
-                    | Some i ->
-                      let name =
-                        String.sub p 0 i |> String.trim |> String.lowercase_ascii
-                      in
-                      String.equal name "q")
-                 params
-             in
-             if has_q then None else Some { type_; subtype })
-         | _ -> None))
+    else
+      match split_content_type_segments s with
+      | Some (media :: params) when List.for_all valid_content_type_parameter params ->
+        parse_media_type media
+      | Some _ | None -> None
 
   let is_json_content_type = function
     | None -> false

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -44,6 +44,24 @@ let test_classify_mcp_accept () =
     (classify_mcp_accept (Some "text/event-stream"));
   ()
 
+let test_is_json_content_type () =
+  let open Mcp_transport_protocol.Http_negotiation in
+  let check_json label expected value =
+    check bool label expected (is_json_content_type (Some value))
+  in
+  check bool "missing content-type" false (is_json_content_type None);
+  check_json "exact" true "application/json";
+  check_json "with charset" true "application/json; charset=utf-8";
+  check_json "case-insensitive" true "Application/JSON";
+  check_json "quoted param with comma" true "application/json; boundary=\"a,b\"";
+  check_json "reject q param" false "application/json;q=0.5";
+  check_json "reject comma list" false "application/json, text/plain";
+  check_json "reject json-seq suffix" false "application/json-seq";
+  check_json "reject json5 suffix" false "application/json5";
+  check_json "reject ld+json suffix" false "application/ld+json";
+  check_json "reject text/plain" false "text/plain";
+  ()
+
 let test_protocol_continuity_allows_missing_header () =
   Eio_main.run @@ fun env ->
   Fs_compat.set_fs (Eio.Stdenv.fs env);
@@ -290,6 +308,7 @@ let () =
       ("accepts_sse_header", [test_case "parses Accept" `Quick test_accepts_sse_header]);
       ("accepts_streamable_mcp", [test_case "requires json+sse" `Quick test_accepts_streamable_mcp]);
       ("classify_mcp_accept", [test_case "strict classification" `Quick test_classify_mcp_accept]);
+      ("is_json_content_type", [test_case "content-type contract" `Quick test_is_json_content_type]);
       ("protocol_continuity", [
         test_case "missing header falls back to session" `Quick test_protocol_continuity_allows_missing_header;
         test_case "remembered session version is reused" `Quick test_protocol_version_for_session_falls_back_to_negotiated_version;

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -54,7 +54,10 @@ let test_is_json_content_type () =
   check_json "with charset" true "application/json; charset=utf-8";
   check_json "case-insensitive" true "Application/JSON";
   check_json "quoted param with comma" true "application/json; boundary=\"a,b\"";
+  check_json "quoted param with semicolon" true "application/json; boundary=\"a;b\"";
   check_json "reject q param" false "application/json;q=0.5";
+  check_json "reject malformed q param" false "application/json; q";
+  check_json "reject malformed param" false "application/json; boundary";
   check_json "reject comma list" false "application/json, text/plain";
   check_json "reject json-seq suffix" false "application/json-seq";
   check_json "reject json5 suffix" false "application/json5";

--- a/test/test_http_server_eio_coverage.ml
+++ b/test/test_http_server_eio_coverage.ml
@@ -115,6 +115,18 @@ let test_compress_zstd_level () =
   check bool "level 19 result exists" true (String.length result9 > 0)
 ;;
 
+let test_compress_zstd_dictionary_result_returns_original () =
+  let original = String.make Masc.Compression_codec.legacy_min_size 'd' in
+  let dictionary_payload = "dictionary-compressed-bytes" in
+  let result, compressed =
+    Compression.compress_zstd_result ~original
+      (Masc.Compression_codec.Compressed
+         { payload = dictionary_payload; encoding = Masc.Compression_codec.Dictionary })
+  in
+  check bool "dictionary not advertised as zstd" false compressed;
+  check string "dictionary payload not leaked" original result
+;;
+
 let test_compress_wrapper_small_data () =
   let small_data = "hello" in
   let result, encoding = Compression.compress small_data in
@@ -158,6 +170,8 @@ let () =
         ; test_case "empty" `Quick test_compress_zstd_empty
         ; test_case "below threshold" `Quick test_compress_zstd_below_threshold
         ; test_case "level" `Quick test_compress_zstd_level
+        ; test_case "dictionary result returns original" `Quick
+            test_compress_zstd_dictionary_result_returns_original
         ] )
     ; ( "compress"
       , [ test_case "small data" `Quick test_compress_wrapper_small_data


### PR DESCRIPTION
## Summary

Addresses outstanding P1 (and related P2) review comments from PRs #22406 and #22407 that were merged in the last 24 hours.

## Changes

- **PR #22406 P1** — Stop parsing [Content-Type] with the Accept-list parser. Parse it as a single media type, reject [q] parameters and comma-separated lists, and add contract tests for invalid suffixes and quoted parameters.
- **PR #22407 P1** — Centralize the legacy standard-zstd minimum-size threshold as [Compression_codec.legacy_min_size] and preserve the no-dictionary contract by matching the returned encoding in [Http_server_eio.compress_zstd].

## Verification

- [x] [ocamlformat --check] passes on changed files
- [x] [git diff --check] passes
- [x] [scripts/dune-local.sh build lib/mcp_transport_protocol lib/compression lib/] passes
- [x] [test/test_http_negotiation.exe] passes (16 tests)