### PR TITLE
fix(approval-rules): address P1 follow-ups from #22394

### DIFF
--- a/lib/keeper/keeper_approval_queue_rules.ml
+++ b/lib/keeper/keeper_approval_queue_rules.ml
@@ -158,15 +158,20 @@ let request_fingerprint (input : Yojson.Safe.t) =
 ;;
 
 let request_fingerprint_preview fingerprint =
-  String.sub fingerprint 0 (min 12 (String.length fingerprint))
+  String.sub
+    fingerprint
+    0
+    (min fingerprint_preview_length (String.length fingerprint))
 ;;
 
 let sandbox_profile_of_runtime_contract runtime_contract =
-  Option.bind runtime_contract (string_opt_member "sandbox_profile")
+  Option.bind runtime_contract (fun json ->
+    Json_util.get_string_nonempty json "sandbox_profile")
 ;;
 
 let backend_of_runtime_contract runtime_contract =
-  Option.bind runtime_contract (string_opt_member "backend")
+  Option.bind runtime_contract (fun json ->
+    Json_util.get_string_nonempty json "backend")
 ;;
 
 let nonempty_string_opt = function
@@ -191,16 +196,17 @@ let load_rules_unlocked ~base_path () =
   let rec parse_entries index acc = function
     | [] -> List.rev acc
     | entry :: rest ->
-      (match approval_rule_of_yojson entry with
-       | Some rule -> parse_entries (index + 1) (rule :: acc) rest
-       | None ->
+      (match approval_rule_of_yojson_with_error entry with
+       | Ok rule -> parse_entries (index + 1) (rule :: acc) rest
+       | Error reason ->
          report_rules_read_drop
            ~reason:Safe_ops.persistence_read_drop_reason_invalid_payload
            ~path
            ~detail:
              (Printf.sprintf
-                "approval rule entry %d rejected: %s"
+                "approval rule entry %d rejected (%s): %s"
                 index
+                reason
                 (rule_json_preview entry));
          parse_entries (index + 1) acc rest)
   in

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -72,6 +72,12 @@ let risk_level_to_string = function
   | Critical -> "critical"
 ;;
 
+let allowed_risk_levels = [ Low; Medium; High; Critical ]
+
+let allowed_risk_level_values = List.map risk_level_to_string allowed_risk_levels
+
+let allowed_risk_level_values_label = String.concat "/" allowed_risk_level_values
+
 let risk_level_to_int = function
   | Low -> 1
   | Medium -> 2
@@ -175,7 +181,12 @@ let approval_rule_of_yojson_with_error json =
     let* max_risk =
       match risk_level_of_string max_risk_raw with
       | Some level -> Ok level
-      | None -> Error (Printf.sprintf "max_risk %S is not low/medium/high/critical" max_risk_raw)
+      | None ->
+        Error
+          (Printf.sprintf
+             "max_risk %S is not %s"
+             max_risk_raw
+             allowed_risk_level_values_label)
     in
     let* created_at =
       match Json_util.get_float json "created_at" with

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.ml
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.ml
@@ -98,17 +98,14 @@ let approval_audit_decision_to_string = function
   | Approval_expired reason -> "reject:" ^ reason
 ;;
 
+let fingerprint_preview_length = 12
+;;
+
 let string_opt_of_json = function
   | `String value ->
     let trimmed = String.trim value in
     if trimmed = "" then None else Some trimmed
   | _ -> None
-;;
-
-let string_opt_member key json =
-  match Json_util.assoc_member_opt key json with
-  | Some value -> string_opt_of_json value
-  | None -> None
 ;;
 
 let bool_member key json ~default =
@@ -150,33 +147,50 @@ let approval_rule_to_yojson (rule : approval_rule) =
     ]
 ;;
 
-let approval_rule_of_yojson json =
+let approval_rule_of_yojson_with_error json =
   match json with
   | `Assoc _ ->
-    let ( let* ) = Option.bind in
-    let* id = string_opt_member "id" json in
-    let* keeper_name = string_opt_member "keeper_name" json in
-    let* tool_name = string_opt_member "tool_name" json in
+    let ( let* ) = Result.bind in
+    let require field json =
+      match Json_util.get_string_nonempty json field with
+      | Some value -> Ok value
+      | None -> Error (Printf.sprintf "%s must be a non-blank string" field)
+    in
+    let* id = require "id" json in
+    let* keeper_name = require "keeper_name" json in
+    let* tool_name = require "tool_name" json in
     let sandbox_profile = Json_util.get_string json "sandbox_profile" in
     let backend = Json_util.get_string json "backend" in
-    let* request_fingerprint = string_opt_member "request_fingerprint" json in
+    let* request_fingerprint = require "request_fingerprint" json in
     let request_fingerprint_preview =
-      string_opt_member "request_fingerprint_preview" json
+      Json_util.get_string_nonempty json "request_fingerprint_preview"
       |> Option.value
            ~default:
              (String.sub
                 request_fingerprint
                 0
-                (min 12 (String.length request_fingerprint)))
+                (min fingerprint_preview_length (String.length request_fingerprint)))
     in
-    let* max_risk_raw = string_opt_member "max_risk" json in
-    let* max_risk = risk_level_of_string max_risk_raw in
-    let* created_at = Json_util.get_float json "created_at" in
+    let* max_risk_raw = require "max_risk" json in
+    let* max_risk =
+      match risk_level_of_string max_risk_raw with
+      | Some level -> Ok level
+      | None -> Error (Printf.sprintf "max_risk %S is not low/medium/high/critical" max_risk_raw)
+    in
+    let* created_at =
+      match Json_util.get_float json "created_at" with
+      | Some value -> Ok value
+      | None -> Error "created_at must be a number"
+    in
     let created_by = Json_util.get_string json "created_by" in
     let last_matched_at = Json_util.get_float json "last_matched_at" in
-    let* match_count = non_negative_int_member "match_count" json in
+    let* match_count =
+      match non_negative_int_member "match_count" json with
+      | Some value -> Ok value
+      | None -> Error "match_count must be a non-negative integer"
+    in
     let source_approval_id = Json_util.get_string json "source_approval_id" in
-    Some
+    Ok
       { id
       ; keeper_name
       ; tool_name
@@ -191,5 +205,11 @@ let approval_rule_of_yojson json =
       ; match_count
       ; source_approval_id
       }
-  | _ -> None
+  | _ -> Error "approval rule must be a JSON object"
+;;
+
+let approval_rule_of_yojson json =
+  match approval_rule_of_yojson_with_error json with
+  | Ok rule -> Some rule
+  | Error _ -> None
 ;;

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -66,9 +66,17 @@ val risk_level_of_string : string -> risk_level option
 val approval_decision_to_string : decision -> string
 
 val approval_audit_decision_to_string : approval_audit_decision -> string
+val fingerprint_preview_length : int
+(** Length (bytes) of the human-readable fingerprint preview. *)
+
 val string_opt_of_json : Yojson.Safe.t -> string option
-val string_opt_member : string -> Yojson.Safe.t -> string option
 val bool_member : string -> Yojson.Safe.t -> default:bool -> bool
 val rule_match_to_yojson : rule_match -> Yojson.Safe.t
 val approval_rule_to_yojson : approval_rule -> Yojson.Safe.t
+
+val approval_rule_of_yojson_with_error :
+  Yojson.Safe.t -> (approval_rule, string) Stdlib.result
+(** Parse an approval rule, returning the first validation failure reason.
+    The legacy {!approval_rule_of_yojson} variant silently discards the reason. *)
+
 val approval_rule_of_yojson : Yojson.Safe.t -> approval_rule option

--- a/lib/keeper_contract/keeper_approval_queue_rules_types.mli
+++ b/lib/keeper_contract/keeper_approval_queue_rules_types.mli
@@ -61,6 +61,7 @@ type rule_match =
 type resolution_result = { remembered_rule : approval_rule option }
 
 val risk_level_to_string : risk_level -> string
+val allowed_risk_level_values_label : string
 val risk_level_to_int : risk_level -> int
 val risk_level_of_string : string -> risk_level option
 val approval_decision_to_string : decision -> string

--- a/test/test_keeper_approval_queue_rules_types.ml
+++ b/test/test_keeper_approval_queue_rules_types.ml
@@ -123,6 +123,60 @@ let test_approval_rule_rejects_malformed_object_json () =
            ; "max_risk", `String "high"
            ; "created_at", `Float 1780587600.0
            ; "match_count", `Int (-1)
+           ]));
+  check
+    (option reject)
+    "blank tool name"
+    None
+    (Q.approval_rule_of_yojson
+       (`Assoc
+           [ "id", `String "rule-1"
+           ; "keeper_name", `String "keeper"
+           ; "tool_name", `String " "
+           ; "request_fingerprint", `String "abcdef"
+           ; "max_risk", `String "high"
+           ; "created_at", `Float 1780587600.0
+           ; "match_count", `Int 0
+           ]));
+  check
+    (option reject)
+    "blank request fingerprint"
+    None
+    (Q.approval_rule_of_yojson
+       (`Assoc
+           [ "id", `String "rule-1"
+           ; "keeper_name", `String "keeper"
+           ; "tool_name", `String "tool_execute"
+           ; "request_fingerprint", `String "  "
+           ; "max_risk", `String "high"
+           ; "created_at", `Float 1780587600.0
+           ; "match_count", `Int 0
+           ]));
+  check
+    (option reject)
+    "missing created_at"
+    None
+    (Q.approval_rule_of_yojson
+       (`Assoc
+           [ "id", `String "rule-1"
+           ; "keeper_name", `String "keeper"
+           ; "tool_name", `String "tool_execute"
+           ; "request_fingerprint", `String "abcdef"
+           ; "max_risk", `String "high"
+           ; "match_count", `Int 0
+           ]));
+  check
+    (option reject)
+    "missing match_count"
+    None
+    (Q.approval_rule_of_yojson
+       (`Assoc
+           [ "id", `String "rule-1"
+           ; "keeper_name", `String "keeper"
+           ; "tool_name", `String "tool_execute"
+           ; "request_fingerprint", `String "abcdef"
+           ; "max_risk", `String "high"
+           ; "created_at", `Float 1780587600.0
            ]))
 ;;
 

--- a/test/test_keeper_approval_queue_rules_types.ml
+++ b/test/test_keeper_approval_queue_rules_types.ml
@@ -180,6 +180,71 @@ let test_approval_rule_rejects_malformed_object_json () =
            ]))
 ;;
 
+let valid_rule_json ?(max_risk = `String "high") ?(created_at = `Float 1780587600.0)
+    ?(match_count = `Int 0) ?request_fingerprint_preview () =
+  let fields =
+    [ "id", `String "rule-1"
+    ; "keeper_name", `String "keeper"
+    ; "tool_name", `String "tool_execute"
+    ; "request_fingerprint", `String "abcdef1234567890"
+    ; "max_risk", max_risk
+    ; "created_at", created_at
+    ; "match_count", match_count
+    ]
+  in
+  let fields =
+    match request_fingerprint_preview with
+    | None -> fields
+    | Some value -> ("request_fingerprint_preview", value) :: fields
+  in
+  `Assoc fields
+;;
+
+let without_field field json =
+  match json with
+  | `Assoc fields -> `Assoc (List.remove_assoc field fields)
+  | json -> json
+;;
+
+let check_parse_error name expected json =
+  match Q.approval_rule_of_yojson_with_error json with
+  | Ok _ -> fail (name ^ ": expected parse error")
+  | Error actual -> check string name expected actual
+;;
+
+let test_approval_rule_error_reasons () =
+  check_parse_error
+    "max_risk reason"
+    (Printf.sprintf "max_risk %S is not %s" "god-mode" Q.allowed_risk_level_values_label)
+    (valid_rule_json ~max_risk:(`String "god-mode") ());
+  check_parse_error
+    "created_at reason"
+    "created_at must be a number"
+    (without_field "created_at" (valid_rule_json ()));
+  check_parse_error
+    "match_count reason"
+    "match_count must be a non-negative integer"
+    (valid_rule_json ~match_count:(`Int (-1)) ());
+  check_parse_error
+    "blank id reason"
+    "id must be a non-blank string"
+    (valid_rule_json () |> without_field "id")
+;;
+
+let test_request_fingerprint_preview_fallback () =
+  match
+    Q.approval_rule_of_yojson_with_error
+      (valid_rule_json ~request_fingerprint_preview:(`String " ") ())
+  with
+  | Error reason -> fail ("expected approval rule to parse: " ^ reason)
+  | Ok parsed ->
+    check
+      string
+      "preview fallback"
+      "abcdef123456"
+      parsed.Q.request_fingerprint_preview
+;;
+
 let test_blank_string_json_is_none () =
   check (option string) "blank" None (Q.string_opt_of_json (`String "  "))
 ;;
@@ -199,6 +264,14 @@ let () =
             "approval rule rejects malformed object json"
             `Quick
             test_approval_rule_rejects_malformed_object_json
+        ; test_case
+            "approval rule error reasons"
+            `Quick
+            test_approval_rule_error_reasons
+        ; test_case
+            "request fingerprint preview fallback"
+            `Quick
+            test_request_fingerprint_preview_fallback
         ; test_case "blank string is none" `Quick test_blank_string_json_is_none
         ] )
     ]


### PR DESCRIPTION
## Summary

Addresses outstanding P1 review comments from PR #22394 that were merged in the last 24 hours. The P0 telemetry for malformed rules and I/O errors was already present in main via Safe_ops.report_persistence_read_drop; this PR completes the remaining P1 items.

## Changes

- **Parse-error context** — Add [approval_rule_of_yojson_with_error] returning [(rule, reason)] so [load_rules_unlocked] can log which field failed validation.
- **Magic-number SSOT** — Centralize the fingerprint preview length as [fingerprint_preview_length].
- **Helper dedup** — Remove [string_opt_member] and use [Json_util.get_string_nonempty] instead.
- **Test matrix** — Add negative cases for blank [tool_name], blank [request_fingerprint], missing [created_at], and missing [match_count].

## Verification

- [x] [ocamlformat --check] passes on changed files
- [x] [git diff --check] passes
- [x] [scripts/dune-local.sh build lib/keeper_contract lib/keeper] passes
- [x] [test/test_keeper_approval_queue_rules_types.exe] passes (5 tests)