### PR TITLE
[codex] Pin fusion panel failure wire contracts

### DIFF
--- a/lib/fusion_core/fusion_types.ml
+++ b/lib/fusion_core/fusion_types.ml
@@ -71,6 +71,7 @@ type panel_failure =
 let panel_failure_of_yojson = function
   | `String "Timeout" -> Ok Timeout
   | `String "Empty_response" -> Ok (Empty_response "empty response")
+  | `List [ `String "Timeout" ] -> Ok Timeout
   | `List [ `String "Provider_error"; `String detail ] -> Ok (Provider_error detail)
   | `List [ `String "Empty_response"; `String detail ] -> Ok (Empty_response detail)
   | `List [ `String "Invalid_max_output_tokens"; `Int value ] ->

--- a/lib/fusion_core/fusion_types.mli
+++ b/lib/fusion_core/fusion_types.mli
@@ -75,6 +75,8 @@ type panel_failure =
 [@@deriving to_yojson, show, eq]
 
 val panel_failure_of_yojson : Yojson.Safe.t -> (panel_failure, string) result
+(** Accepts the current ppx-style tagged-list encoding and the legacy bare
+    string encodings for [Timeout] / [Empty_response]. *)
 
 (** 성공한 패널 한 명의 답. (variant inline record는 ppx_deriving_yojson 비호환이라
     named record로 분리한다.) *)

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -145,6 +145,36 @@ let test_panel_failure_yojson_accepts_legacy_empty_response () =
   | Error err -> Alcotest.fail err
 ;;
 
+let test_panel_failure_yojson_round_trips_current_shapes () =
+  let check_round_trip label failure =
+    let json = Fusion_types.panel_failure_to_yojson failure in
+    match Fusion_types.panel_failure_of_yojson json with
+    | Ok actual ->
+      Alcotest.(check string)
+        label
+        (Fusion_types.show_panel_failure failure)
+        (Fusion_types.show_panel_failure actual)
+    | Error err -> Alcotest.failf "%s failed to decode: %s" label err
+  in
+  check_round_trip "timeout" Fusion_types.Timeout;
+  check_round_trip "provider error"
+    (Fusion_types.Provider_error "Provider 'runtime': quota");
+  check_round_trip "empty response"
+    (Fusion_types.Empty_response "empty response (stop_reason=max_tokens)");
+  check_round_trip "invalid max output tokens"
+    (Fusion_types.Invalid_max_output_tokens 0);
+  Alcotest.(check bool)
+    "detail empty response serializes as tagged payload, not legacy string"
+    true
+    (Yojson.Safe.equal
+       (`List
+         [ `String "Empty_response"
+         ; `String "empty response (stop_reason=max_tokens)"
+         ])
+       (Fusion_types.panel_failure_to_yojson
+          (Fusion_types.Empty_response "empty response (stop_reason=max_tokens)")))
+;;
+
 let test_timeout_budget_does_not_set_total_execution_ceiling () =
   let config =
     Fusion_oas.For_testing.apply_timeout_budget
@@ -201,6 +231,10 @@ let () =
             "panel failure yojson accepts legacy empty response"
             `Quick
             test_panel_failure_yojson_accepts_legacy_empty_response
+        ; Alcotest.test_case
+            "panel failure yojson round-trips current shapes"
+            `Quick
+            test_panel_failure_yojson_round_trips_current_shapes
         ; Alcotest.test_case
             "timeout budget does not arm OAS total execution ceiling"
             `Quick

--- a/test/test_fusion_oas_error_detail.ml
+++ b/test/test_fusion_oas_error_detail.ml
@@ -136,13 +136,23 @@ let test_empty_response_detail_uses_canonical_unknown_stop_reason () =
 ;;
 
 let test_panel_failure_yojson_accepts_legacy_empty_response () =
-  match Fusion_types.panel_failure_of_yojson (`String "Empty_response") with
-  | Ok (Fusion_types.Empty_response detail) ->
-    Alcotest.(check string) "legacy detail" "empty response" detail
-  | Ok other ->
-    Alcotest.failf "unexpected panel failure: %s"
-      (Fusion_types.show_panel_failure other)
-  | Error err -> Alcotest.fail err
+  let decode json =
+    match Fusion_types.panel_failure_of_yojson json with
+    | Ok failure -> failure
+    | Error err -> Alcotest.fail err
+  in
+  let legacy_detail =
+    match decode (`String "Empty_response") with
+    | Fusion_types.Empty_response detail -> detail
+    | other ->
+      Alcotest.failf "unexpected panel failure: %s"
+        (Fusion_types.show_panel_failure other)
+  in
+  Alcotest.(check string) "legacy detail" "empty response" legacy_detail;
+  Alcotest.(check string)
+    "legacy timeout"
+    (Fusion_types.show_panel_failure Fusion_types.Timeout)
+    (Fusion_types.show_panel_failure (decode (`String "Timeout")))
 ;;
 
 let test_panel_failure_yojson_round_trips_current_shapes () =

--- a/test/test_fusion_sink_meta.ml
+++ b/test/test_fusion_sink_meta.ml
@@ -165,6 +165,30 @@ let test_panel_meta_timeout_text () =
   check (option string) "timeout reason_code" (Some "timeout")
     (string_field a "reason_code")
 
+let test_panel_meta_empty_response_text () =
+  let detail = "empty response (stop_reason=max_tokens)" in
+  let o =
+    Failed { failed_model = "skeptic (claude)"; reason = Empty_response detail }
+  in
+  let a = assoc_of (Masc.Fusion_sink.panel_meta o) in
+  check (option string) "empty response reason_detail" (Some detail)
+    (string_field a "reason_detail");
+  check (option string) "empty response reason mirrors detail" (Some detail)
+    (string_field a "reason");
+  check (option string) "empty response reason_code" (Some "empty_response")
+    (string_field a "reason_code")
+
+let test_panel_meta_invalid_max_output_tokens_text () =
+  let o =
+    Failed
+      { failed_model = "skeptic (claude)"; reason = Invalid_max_output_tokens 0 }
+  in
+  let a = assoc_of (Masc.Fusion_sink.panel_meta o) in
+  check (option string) "invalid max tokens reason_detail"
+    (Some "invalid max_output_tokens 0") (string_field a "reason_detail");
+  check (option string) "invalid max tokens reason_code"
+    (Some "invalid_max_output_tokens") (string_field a "reason_code")
+
 (* --- RFC-0284: judge_node_meta — 관측 record를 board [judges] 배열 원소로 직렬화 ---
    role(위상 의미) + identity(First는 panelist_id) + judge_meta와 동일한 5섹션 스키마
    공유 + 노드별 usage 를 핀한다. 값-핀(value-blind coverage 회피): role/identity가
@@ -270,6 +294,9 @@ let () =
             test_panel_meta_failure_keeps_raw_provider
         ; test_case "answered_uses_identity" `Quick test_panel_meta_answered_uses_identity
         ; test_case "timeout_text" `Quick test_panel_meta_timeout_text
+        ; test_case "empty_response_text" `Quick test_panel_meta_empty_response_text
+        ; test_case "invalid_max_output_tokens_text" `Quick
+            test_panel_meta_invalid_max_output_tokens_text
         ] )
     ; ( "judge_node_meta_observation"
       , [ test_case "first_carries_panelist_identity" `Quick


### PR DESCRIPTION
## Summary
- Add explicit round-trip coverage for current `panel_failure` JSON shapes while retaining legacy `Timeout` / `Empty_response` decode compatibility.
- Pin `fusion_sink.panel_meta` structured `reason_code` / `reason_detail` output for `Empty_response` and `Invalid_max_output_tokens`.
- Split this out after #22438 was merged at head `b45b9de`; these post-merge test/compat hardenings were not included in that merge commit.

## Validation
- `ocamlformat --check lib/fusion_core/fusion_types.ml lib/fusion_core/fusion_types.mli test/test_fusion_oas_error_detail.ml test/test_fusion_sink_meta.ml`
- `git diff --check origin/main..HEAD`
- Attempted `scripts/dune-local.sh build test/test_fusion_sink_meta.exe test/test_fusion_oas_error_detail.exe`; blocked by live bare Dune process outside `scripts/dune-local.sh` (`dune build --root .../oas/.worktrees/pr-2200-p1-current ...`). I did not bypass the machine-wide Dune guard.
