### PR TITLE
fix: refresh spawn bounded allowlist on main

### DIFF
--- a/scripts/lint-spawn-bounded.allowlist
+++ b/scripts/lint-spawn-bounded.allowlist
@@ -16,8 +16,8 @@
 # Removal: an entry SHOULD be removed when the spawn site itself is removed,
 # never when a "we'll wrap it later" excuse appears.
 
-# lib/bounded_proc/bounded_proc.ml:35  — the canonical helper itself.
-lib/bounded_proc/bounded_proc.ml:35
+# lib/bounded_proc/bounded_proc.ml:37  — the canonical helper itself.
+lib/bounded_proc/bounded_proc.ml:37
 
 # lib/process/process_eio.ml:483, 521, 570 — `spawn_and_drain_{stdout,both}`
 # and `spawn_and_drain_both_streaming`.


### PR DESCRIPTION
Fixes the main Fundamental Check / Spawn-bounded ratchet line-drift failure by updating the bounded_proc allowlist entry from line 35 to line 37. Validation: bash scripts/lint-spawn-bounded.sh; git diff --check.