### PR TITLE
fix(build): register executable path helper in core

### DIFF
--- a/lib/core/dune
+++ b/lib/core/dune
@@ -28,6 +28,7 @@
   list_util
   set_util
   atomic_util
+  executable_path
   read_drop_reason
   tool_name_alias_axis
   eval_tool_selector)

--- a/lib/dune
+++ b/lib/dune
@@ -141,7 +141,6 @@
   worker_container_types
   worker_container
   worker_container_runners
-  executable_path
   exec_shell_adapter
   ;; keeper_memory sub-modules
   keeper_memory_policy


### PR DESCRIPTION
## Summary

- Fix the post-merge main build break from `#22462`.
- Register `Executable_path` in the `masc_core` sub-library where the file actually lives.
- Remove the stale top-level `lib/dune` module entry that made Dune look for `lib/executable_path.ml`.

## Evidence

Main CI run `28285446374`, Build and Test job `83808537552`, failed during `opam exec -- dune build` with:

```text
File "lib/dune", line 144, characters 2-17:
144 |   executable_path
        ^^^^^^^^^^^^^^^
Error: Module Executable_path doesn't exist.
```

`lib/core/executable_path.ml` exists, while `lib/executable_path.ml` does not.

## Verification

- `git diff --check`

Per workflow direction, build validation is left to CI.
