### PR TITLE
fix(core): enumerate executable path file kinds

### DIFF
--- a/lib/core/executable_path.ml
+++ b/lib/core/executable_path.ml
@@ -11,7 +11,12 @@ let regular_file_is_executable path =
     | Unix.S_REG ->
       Unix.access path [ Unix.X_OK ];
       true
-    | _ -> false
+    | Unix.S_DIR
+    | Unix.S_CHR
+    | Unix.S_BLK
+    | Unix.S_LNK
+    | Unix.S_FIFO
+    | Unix.S_SOCK -> false
   with
   | Unix.Unix_error _ | Sys_error _ -> false
 ;;


### PR DESCRIPTION
## Summary
- replace the wildcard Unix.file_kind branch in Executable_path with explicit non-regular constructors
- keep command availability behavior unchanged while satisfying fatal warning 4

Fixes #22474

## Validation
- ocamlformat --check lib/core/executable_path.ml
- git diff --check origin/main..HEAD
- env DUNE_CACHE=disabled scripts/dune-local.sh build test/test_keeper_turn_driver_accept.exe
- _build/default/test/test_keeper_turn_driver_accept.exe --show-errors (23 tests)

## Notes
- Initial validation without DUNE_CACHE=disabled reached this fix but failed on a local Dune cache temp-directory cleanup error under ~/.cache/dune. The source validation above reran with cache disabled, matching the repo CI helper pattern for cache artifact mismatches.