### PR TITLE
fix(dashboard): reconnect on skipped websocket notification

### DIFF
--- a/dashboard/src/dashboard-ws.test.ts
+++ b/dashboard/src/dashboard-ws.test.ts
@@ -1227,6 +1227,33 @@ describe('dashboard websocket route subscriptions', () => {
     expect(mockSockets[1]!.readyState).toBe(MockWebSocket.CONNECTING)
   })
 
+  it('reconnects when a delta ack notification sees a non-open socket', async () => {
+    vi.useFakeTimers()
+    installWebSocketMocks()
+
+    const socket = await connectReadyDashboard()
+    expect(dashboardWsReady.value).toBe(true)
+    const sentBeforeDelta = socket.sent.length
+    socket.readyState = MockWebSocket.CLOSING
+
+    socket.receive({
+      jsonrpc: '2.0',
+      method: 'dashboard/delta',
+      params: { seq: 45, slice: 'execution', payload: { agents: [] } },
+    })
+
+    expect(socket.sent).toHaveLength(sentBeforeDelta)
+    expect(dashboardWsConnected.value).toBe(false)
+    expect(dashboardWsReady.value).toBe(false)
+    expect(dashboardWsLastError.value).toContain('state=CLOSING')
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await flushPromises()
+
+    expect(mockSockets).toHaveLength(2)
+    expect(mockSockets[1]!.readyState).toBe(MockWebSocket.CONNECTING)
+  })
+
   it('ignores stale subscribe snapshots that arrive after a newer route subscription', async () => {
     installWebSocketMocks()
 

--- a/dashboard/src/dashboard-ws.ts
+++ b/dashboard/src/dashboard-ws.ts
@@ -465,6 +465,22 @@ function formatCloseEventError(event: CloseEvent): string {
   return `dashboard websocket closed (${parts.join(', ')})`
 }
 
+function websocketReadyStateName(state: number): string {
+  if (typeof WebSocket !== 'undefined') {
+    switch (state) {
+      case WebSocket.CONNECTING:
+        return 'CONNECTING'
+      case WebSocket.OPEN:
+        return 'OPEN'
+      case WebSocket.CLOSING:
+        return 'CLOSING'
+      case WebSocket.CLOSED:
+        return 'CLOSED'
+    }
+  }
+  return `UNKNOWN(${state})`
+}
+
 // WebSocket reconnect uses an explicit 500ms base (half of the SSE
 // RECONNECT_BASE_MS) so transient socket churn recovers faster. Derive the
 // exp clamp from the configured cap so a future operator bump of
@@ -584,8 +600,17 @@ function sendRpc(method: string, params: JsonObject, timeoutMs = DASHBOARD_WS_RP
 }
 
 function sendNotification(method: string, params: JsonObject): void {
-  if (!socket || socket.readyState !== WebSocket.OPEN) return
   const currentSocket = socket
+  if (!currentSocket) return
+  if (currentSocket.readyState !== WebSocket.OPEN) {
+    reconnectAfterCurrentSocketFailure(
+      currentSocket,
+      new Error(
+        `dashboard websocket notification send skipped while socket state=${websocketReadyStateName(currentSocket.readyState)}: ${method}`,
+      ),
+    )
+    return
+  }
   try {
     currentSocket.send(JSON.stringify({ jsonrpc: '2.0', method, params }))
   } catch (err) {


### PR DESCRIPTION
## Summary
- Treat dashboard WebSocket notification sends against a non-open current socket as a transport failure instead of silently dropping the notification.
- Reuse the existing reconnectAfterCurrentSocketFailure path so the stale socket is closed, readiness is cleared, lastError is observable, and reconnect is scheduled.
- Add a regression test for the delta ack path when the current socket has already moved to CLOSING.

## Validation
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/dashboard-ws.test.ts
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty false
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/eslint src/dashboard-ws.ts src/dashboard-ws.test.ts
- git diff --check origin/main..HEAD

## Notes
- Rebased onto current origin/main after #22471 merged.
- No local production build was run; CI remains the build authority for this queue.
- Browser plugin is not available in this session, so rendered browser QA was not run for this internal WebSocket state-machine change.