### PR TITLE
fix(dashboard): hydrate compaction and memory recall views

### DIFF
--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -293,7 +293,9 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     expect(container.textContent).toContain('trace-a#7')
     expect(container.textContent).toContain('cccc2222dddd')
     expect(container.textContent).toContain('800B')
-    expect([...container.querySelectorAll('.mem-disclosure')].some(d => (d.textContent ?? '').includes('Phase 3'))).toBe(false)
+    const recallSection = [...container.querySelectorAll('.turn-sec')].find(sec => (sec.querySelector('h4')?.textContent ?? '') === '최근 회상 · 주입')
+    expect(recallSection?.querySelector('.mem-tl-row')?.textContent).toContain('cccc2222dddd')
+    expect(recallSection?.querySelector('.mem-disclosure')).toBeFalsy()
   })
 
   it('surfaces read_errors and renders honest disclosures for the unbacked pin section', async () => {

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -13,6 +13,7 @@ import {
   memFmtBytes,
   memFmtTok,
   promptBlockMeta,
+  recentMemoryRecallInjections,
   sortMemoryFactsForReview,
   type MemoryKeeper,
 } from './memory-inspector'
@@ -28,8 +29,8 @@ afterEach(() => {
 })
 
 // A turn-records payload exercising the two real-data sections (composition,
-// facts), the episode-backed 압축 section, and read_errors. The unbacked
-// sections (핀 / 회상) render disclosures regardless of payload.
+// facts), the episode-backed 압축 section, recall-block timeline, and read_errors.
+// The unbacked pin section renders a disclosure regardless of payload.
 function turnRecordsPayload() {
   return {
     keeper: 'masc-improver',
@@ -285,19 +286,27 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     expect(container.textContent).toContain('cccc2222dddd')
   })
 
-  it('surfaces read_errors and renders honest disclosures for the unbacked sections', async () => {
+  it('renders recent recall injection rows from real memory_os_recall prompt blocks', async () => {
+    stubFetch()
+    const { container } = renderInspector()
+    await waitFor(() => expect(container.querySelector('.mem-tl-row')).toBeTruthy())
+    expect(container.textContent).toContain('trace-a#7')
+    expect(container.textContent).toContain('cccc2222dddd')
+    expect(container.textContent).toContain('800B')
+    expect([...container.querySelectorAll('.mem-disclosure')].some(d => (d.textContent ?? '').includes('Phase 3'))).toBe(false)
+  })
+
+  it('surfaces read_errors and renders honest disclosures for the unbacked pin section', async () => {
     stubFetch()
     const { container } = renderInspector()
     await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
     // read_errors visible (no silent failure)
     expect(container.querySelector('.mem-read-error')?.textContent).toContain('one malformed row skipped')
-    // pins → Phase 2 disclosure, timeline → Phase 3 disclosure (no fabricated rows)
+    // pins → Phase 2 disclosure (no fabricated pin rows)
     const disclosures = [...container.querySelectorAll('.mem-disclosure')].map(d => d.textContent ?? '')
     expect(disclosures.some(t => t.includes('Phase 2'))).toBe(true)
-    expect(disclosures.some(t => t.includes('Phase 3'))).toBe(true)
     // no prototype fixture leakage
     expect(container.querySelector('.mem-pin')).toBeFalsy()
-    expect(container.querySelector('.mem-tl-row')).toBeFalsy()
   })
 
   it('renders the compaction section from real episodes (summary + terminal marker)', async () => {
@@ -414,6 +423,30 @@ describe('memory view-model helpers', () => {
     // empty input → null, not a fabricated row
     expect(latestEntryWithBlocks([])).toBeNull()
     expect(latestEntryWithBlocks([errorTail])).toBeNull()
+  })
+
+  it('recentMemoryRecallInjections returns newest real memory_os_recall blocks only', () => {
+    const mkRow = (turn: number, block: string, bytes: number): TurnRecordRow => ({
+      record: {
+        keeper: 'k',
+        trace_id: `trace-${turn}`,
+        absolute_turn: turn,
+        ts: turn,
+        runtime_profile: 'local',
+        blocks: [{ block, bytes, digest: `digest-${turn}` }],
+        execution_ids: [],
+      },
+      diff_vs_prev: null,
+    })
+    expect(recentMemoryRecallInjections([
+      mkRow(1, 'memory_os_recall', 100),
+      mkRow(2, 'persona', 200),
+      mkRow(3, 'memory_os_recall', 0),
+      mkRow(4, 'memory_os_recall', 400),
+    ])).toEqual([
+      { traceId: 'trace-4', turn: 4, ts: 4, bytes: 400, digest: 'digest-4' },
+      { traceId: 'trace-1', turn: 1, ts: 1, bytes: 100, digest: 'digest-1' },
+    ])
   })
 
   it('promptBlockMeta maps known Prompt_block_id tokens and keeps unknown tokens raw', () => {

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -12,8 +12,8 @@
 //   장기 메모리 스토어    ← real memory_os.facts.items (typed category, provenance, TTL)
 //   압축 유지·요약        ← real memory_os.episodes.items (summary + terminal_marker)
 //   핀 고정 사실          ⓘ Phase 2 (operator pins — no backend source yet)
-//   최근 회상·주입        ⓘ Phase 3 (per-op timeline — no event feed yet)
-// The two ⓘ sections render an honest "연결 예정" disclosure, never fabricated
+//   최근 회상·주입        ← real memory_os_recall prompt blocks (entries[*].blocks)
+// The remaining ⓘ sections render an honest "연결 예정" disclosure, never fabricated
 // rows (no-stub): they DISCLOSE absence rather than fake presence.
 
 import { Fragment } from 'preact'
@@ -131,6 +131,34 @@ export function latestEntryWithBlocks(rows: readonly TurnRecordRow[]): TurnRecor
     if (row && row.record.blocks.length > 0) return row
   }
   return null
+}
+
+export interface MemoryRecallInjection {
+  readonly traceId: string
+  readonly turn: number
+  readonly ts: number
+  readonly bytes: number
+  readonly digest: string
+}
+
+export function recentMemoryRecallInjections(
+  rows: readonly TurnRecordRow[],
+  limit = 5,
+): readonly MemoryRecallInjection[] {
+  const injections: MemoryRecallInjection[] = []
+  for (let i = rows.length - 1; i >= 0 && injections.length < limit; i--) {
+    const row = rows[i]
+    const block = row?.record.blocks.find(b => b.block === 'memory_os_recall' && b.bytes > 0)
+    if (!row || !block) continue
+    injections.push({
+      traceId: row.record.trace_id,
+      turn: row.record.absolute_turn,
+      ts: row.record.ts,
+      bytes: block.bytes,
+      digest: block.digest,
+    })
+  }
+  return injections
 }
 
 // ── fact category meta (real, exhaustive over the typed union) ──
@@ -373,6 +401,28 @@ function MemoryPromptEvidence({
   `
 }
 
+function RecentRecallTimeline({ rows }: { rows: readonly TurnRecordRow[] }) {
+  const injections = recentMemoryRecallInjections(rows)
+  if (injections.length === 0) {
+    return html`<div class="mem-empty">최근 memory_os_recall 주입 없음.</div>`
+  }
+  return html`
+    <div class="mem-store">
+      ${injections.map(inj => html`
+        <div class="mem-tl-row" key=${`${inj.traceId}:${inj.turn}:${inj.digest}`}>
+          <span class="mem-kind">회상</span>
+          <span class="mem-tl-at">${formatTimeAgo(inj.ts)}</span>
+          <span class="mem-tl-text">
+            <span class="mono">${inj.traceId}#${inj.turn}</span>
+            <span class="mono"> · ${inj.digest}</span>
+          </span>
+          <span class="mem-tl-tok">${memFmtBytes(inj.bytes)}</span>
+        </div>
+      `)}
+    </div>
+  `
+}
+
 function FactRow({ fact }: { fact: MemoryOsFact }) {
   const meta = factCategoryMeta(fact.category)
   const provenance = `${fact.source.trace_id}#${fact.source.turn}`
@@ -547,7 +597,7 @@ function OneKeeperMemoryReal({
 
       <div class="turn-sec">
         <h4>최근 회상 · 주입</h4>
-        <${DisclosureNote} text="회상·주입 op 타임라인은 Phase 3에서 연결 예정 — 현재 event feed 없음." />
+        <${RecentRecallTimeline} rows=${rows} />
       </div>
 
       <div class="turn-sec">

--- a/lib/server/server_dashboard_http_keeper_api.ml
+++ b/lib/server/server_dashboard_http_keeper_api.ml
@@ -402,11 +402,33 @@ let read_runtime_manifest_tail_rows ~base_dir path =
     Dated_jsonl.load_tail_lines path
       ~max_lines:compaction_snapshot_manifest_tail_max_lines
     |> fun lines ->
+    let compaction_snapshot_manifest_event_name = function
+      | `Assoc fields -> (
+          match List.assoc_opt "event" fields with
+          | Some (`String event) -> Some event
+          | _ -> None)
+      | _ -> None
+    in
+    let compaction_snapshot_manifest_event_is_relevant event =
+      String.equal
+        event
+        (Keeper_runtime_manifest.event_kind_to_string
+           Keeper_runtime_manifest.Event_bus_correlated)
+      || String.equal
+           event
+           (Keeper_runtime_manifest.event_kind_to_string
+              Keeper_runtime_manifest.Context_compacted)
+    in
     let rec loop line_no rows read_errors = function
       | [] -> List.rev rows, List.rev read_errors
       | line :: rest ->
       try
-        match Yojson.Safe.from_string line |> Keeper_runtime_manifest.of_json with
+        let json = Yojson.Safe.from_string line in
+        match compaction_snapshot_manifest_event_name json with
+        | Some event when not (compaction_snapshot_manifest_event_is_relevant event) ->
+          loop (line_no + 1) rows read_errors rest
+        | _ -> (
+        match Keeper_runtime_manifest.of_json json with
             | Ok row -> loop (line_no + 1) (row :: rows) read_errors rest
             | Error msg ->
               loop (line_no + 1) rows
@@ -414,7 +436,7 @@ let read_runtime_manifest_tail_rows ~base_dir path =
                    ~scope:(runtime_manifest_row_scope ~base_dir path line_no)
                    ~error:msg
                  :: read_errors)
-                rest
+                rest)
       with
           | Yojson.Json_error msg | Yojson.Safe.Util.Type_error (msg, _) ->
             loop (line_no + 1) rows

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -4743,6 +4743,63 @@ let test_compaction_snapshots_json_reads_runtime_manifest () =
       [ "before_prompt"; "after_prompt"; "prompt_text"; "context_text" ])
 ;;
 
+let test_compaction_snapshots_json_skips_unrelated_manifest_events () =
+  with_temp_workspace_config (fun config ->
+    let keeper_id = "memory-panel-test" in
+    let trace_id = "trace-compaction-dashboard-skip-unrelated" in
+    let row =
+      Runtime_manifest.make
+        ~ts:"2026-06-26T03:03:00Z"
+        ~keeper_name:keeper_id
+        ~trace_id
+        ~keeper_turn_id:12
+        ~event:Runtime_manifest.Event_bus_correlated
+        ~runtime_id:"oas-seoul-1"
+        ~status:"observed"
+        ~decision:
+          (Runtime_manifest.with_clock_refs
+             ~clock_refs:
+               (Runtime_manifest.clock_refs
+                  ~compaction_id:"cmp-unknown-skip"
+                  ~compaction_source:"event_bus"
+                  ())
+             (`Assoc [ "context_compacted_count", `Int 1 ]))
+        ()
+    in
+    let row_json = Runtime_manifest.to_json row in
+    let unrelated_json =
+      match row_json with
+      | `Assoc fields ->
+        `Assoc
+          (List.map
+             (fun (key, value) ->
+               if String.equal key "event" then key, `String "memory_injected"
+               else key, value)
+             fields)
+      | _ -> Alcotest.fail "runtime manifest row must encode as object"
+    in
+    let path = Runtime_manifest.path_for_trace config ~keeper_name:keeper_id ~trace_id in
+    write_text_file
+      path
+      (Yojson.Safe.to_string unrelated_json ^ "\n" ^ Yojson.Safe.to_string row_json ^ "\n");
+    let top =
+      Server_dashboard_http_keeper_api.compaction_snapshots_json
+        ~config
+        ~keeper_id
+        ~limit:10
+      |> json_assoc "compaction_snapshots"
+    in
+    Alcotest.(check int) "count" 1 (json_int_field "compaction_snapshots" top "count");
+    Alcotest.(check int)
+      "read errors"
+      0
+      (List.length (json_item_list "compaction_snapshots" top "read_errors"));
+    Alcotest.(check int)
+      "read error count"
+      0
+      (json_int_field "compaction_snapshots" top "read_error_count"))
+;;
+
 let test_compaction_snapshots_json_surfaces_manifest_read_errors () =
   with_temp_workspace_config (fun config ->
     let keeper_id = "memory-panel-test" in
@@ -4953,6 +5010,10 @@ let () =
             "dashboard compaction snapshots read runtime manifest metadata only"
             `Quick
             test_compaction_snapshots_json_reads_runtime_manifest
+        ; Alcotest.test_case
+            "dashboard compaction snapshots skip unrelated manifest events"
+            `Quick
+            test_compaction_snapshots_json_skips_unrelated_manifest_events
         ; Alcotest.test_case
             "dashboard compaction snapshots surface manifest read errors"
             `Quick


### PR DESCRIPTION
## Summary
- Make the dashboard compaction snapshot reader parse only compaction-relevant runtime manifest events.
- Skip unrelated valid manifest events such as `memory_injected` instead of surfacing them as read errors.
- Keep corrupt JSON rows as read errors.
- Replace the Memory OS inspector's "recent recall/injection pending" placeholder with a real timeline from `memory_os_recall` prompt blocks in keeper turn records.

## Live evidence
- `GET /api/v1/keepers/rondo/compaction-snapshots` returned snapshots, but also `read_error_count=298` from valid unrelated manifest events like `memory_injected`, `memory_flushed`, `tool_lineage_recorded`, and `tool_surface_selected`.

## Verification
- `git diff --check origin/main...HEAD`
- `ocamlformat --check lib/server/server_dashboard_http_keeper_api.ml test/test_keeper_memory_os.ml`
- `scripts/ci/check-ignore-without-comment-diff.sh --base origin/main --head HEAD`
- `bash scripts/ci/check-determinism-contract.sh --base origin/main --head HEAD`

## Local verification notes
- Skipped local Dune build per operator instruction; CI is the build authority.
- Dashboard targeted `vitest` and `typecheck` could not run locally because this worktree has no `dashboard/node_modules` (`vitest`/`tsc` not found). CI dashboard checks are the verification source for the frontend follow-up.
