### PR TITLE
fix(build): cover agent_sdk 0.207.10 test fallout

### DIFF
--- a/lib/keeper_registry/keeper_id.ml
+++ b/lib/keeper_registry/keeper_id.ml
@@ -112,6 +112,10 @@ module Uid = struct
              (Json_util.kind_name other))
 end
 
+module For_testing = struct
+  let unsafe_trace_id_of_string s = s
+end
+
 (** Polymorphic variants for use in keeper_meta without depending on a
     specific JSON library.  Callers wrap/unwrap at the boundary. *)
 let uid_to_yojson s = `String s

--- a/lib/keeper_registry/keeper_id.mli
+++ b/lib/keeper_registry/keeper_id.mli
@@ -32,5 +32,9 @@ module Uid : sig
   val compare : t -> t -> int
 end
 
+module For_testing : sig
+  val unsafe_trace_id_of_string : string -> Trace_id.t
+end
+
 val uid_to_yojson : Uid.t -> [> `String of string ]
 val uid_of_yojson : [ `String of string | `Null ] -> (Uid.t, string) result

--- a/test/test_keeper_memory_os_consolidation_runtime.ml
+++ b/test/test_keeper_memory_os_consolidation_runtime.ml
@@ -36,6 +36,10 @@ let fake_response canned =
   }
 ;;
 
+let text_of_response (response : Atypes.api_response) =
+  Atypes.text_of_content response.content
+;;
+
 let fake_complete canned : Runtime.complete_fn =
   fun ~sw:_ ~net:_ ?clock:_ ~config:_ ~messages:_ () -> Ok (fake_response canned)
 ;;
@@ -295,7 +299,7 @@ let test_consolidate_respects_provider_config_and_prompt_template () =
                seen_response_format := Some config.Llm_provider.Provider_config.response_format;
                let rendered_prompt =
                  messages
-                 |> List.map Agent_sdk_response.text_of_response
+                 |> List.map text_of_response
                  |> String.concat "\n"
                  |> String.trim
                in

--- a/test/test_keeper_registry_hardening.ml
+++ b/test/test_keeper_registry_hardening.ml
@@ -35,6 +35,7 @@ let register name =
 ;;
 
 let health_to_string = KR.registry_entry_validation_error_to_string
+let invalid_trace_id = Masc.Keeper_id.For_testing.unsafe_trace_id_of_string ""
 
 let test_put_entry_rejects_meta_name_mismatch () =
   KR.clear ();
@@ -70,7 +71,7 @@ let test_get_filters_corrupted_entry () =
     { entry with
       meta =
         { entry.meta with
-          runtime = { entry.meta.runtime with trace_id = "" }
+          runtime = { entry.meta.runtime with trace_id = invalid_trace_id }
         }
     }
   in


### PR DESCRIPTION
## Summary
- remove a test-only dependency on Agent_sdk_response from memory consolidation runtime tests
- add an explicit Keeper_id.For_testing unsafe trace-id constructor for corrupted registry fixtures
- update the registry hardening fixture to use the typed test helper instead of raw string construction

## Context
- Follow-up for #22484, which merged the agent_sdk 0.207.10 MASC call-site adaptation but CI Health found additional test compile fallout.

## Verification
- scripts/check-oas-pin.sh --local-only
- scripts/ci/check-ignore-without-comment-diff.sh --base origin/main
- git diff --check
- opam exec -- ocamlformat --check <changed OCaml files>
- Dune build/test: deferred to GitHub CI per request