### PR TITLE
fix(build): cover remaining agent_sdk 0.207.10 fallout

### DIFF
--- a/lib/cdal_runtime/direct_evidence.ml
+++ b/lib/cdal_runtime/direct_evidence.ml
@@ -123,8 +123,7 @@ let tool_contracts_to_json tools =
             |> Option.value ~default:[]
           in
           let mutation_class =
-            descriptor
-            |> Option.bind (fun d -> d.mutation_class)
+            Option.bind descriptor (fun d -> d.mutation_class)
             |> Option.map Agent_sdk.Tool.mutation_class_to_string
             |> Json_util.string_opt_to_json
           in

--- a/lib/keeper/keeper_registry.ml
+++ b/lib/keeper/keeper_registry.ml
@@ -301,7 +301,10 @@ let count_running ?base_path () =
 ;;
 
 let record_crash ~base_path name ts msg =
-  Error_tracking.record_crash ~base_path name ts msg ~update_entry
+  let update_entry_unit ~base_path name f =
+    ignore (update_entry ~base_path name f)
+  in
+  Error_tracking.record_crash ~base_path name ts msg ~update_entry:update_entry_unit
 ;;
 
 let set_grpc_close ~base_path name close_fn =


### PR DESCRIPTION
## Summary
- fix direct evidence mutation_class optional extraction after agent_sdk 0.207.10
- adapt keeper registry crash recording to the unit update callback shape expected by error tracking

## Evidence
- CI failure source: #22487 Health/Lint logs after merge, failing on lib/cdal_runtime/direct_evidence.ml and lib/keeper/keeper_registry.ml
- Local: opam exec -- ocamlformat --check lib/cdal_runtime/direct_evidence.ml lib/keeper/keeper_registry.ml
- Local: git diff --check
- Local: scripts/check-oas-pin.sh --local-only
- Local: scripts/ci/check-ignore-without-comment-diff.sh --base origin/main

Dune build is intentionally left to PR CI.