### PR TITLE
docs(eio): align env contract with domain-local storage

### DIFF
--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -72,6 +72,13 @@ module Compression : sig
       identifies the content-encoding header value to set. *)
   val compress : ?level:int -> string -> string * string option
 
+  (** [compress_zstd_result ~original result] adapts a {!Compression_codec}
+      result to the legacy zstd-only response contract. Dictionary-compressed
+      payloads are rejected back to [original] because this path can only
+      advertise [Content-Encoding: zstd]. *)
+  val compress_zstd_result :
+    original:string -> Compression_codec.compress_result -> string * bool
+
   (** [compress_zstd ?level data] is the legacy
       no-dictionary path.  Returns [(payload, did_compress)] —
       data shorter than 256 bytes is kept as-is.  Raw zstd

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -72,13 +72,6 @@ module Compression : sig
       identifies the content-encoding header value to set. *)
   val compress : ?level:int -> string -> string * string option
 
-  (** [compress_zstd_result ~original result] adapts a {!Compression_codec}
-      result to the legacy zstd-only response contract. Dictionary-compressed
-      payloads are rejected back to [original] because this path can only
-      advertise [Content-Encoding: zstd]. *)
-  val compress_zstd_result :
-    original:string -> Compression_codec.compress_result -> string * bool
-
   (** [compress_zstd ?level data] is the legacy
       no-dictionary path.  Returns [(payload, did_compress)] —
       data shorter than 256 bytes is kept as-is.  Raw zstd

--- a/lib/masc_eio_env.mli
+++ b/lib/masc_eio_env.mli
@@ -8,11 +8,9 @@
     Every consumer that needs to issue an HTTP call later reaches
     the captured handles via {!get} or {!get_opt}.
 
-    Internal storage is hidden. The current domain's [Domain.DLS]
-    value is preferred. A process-wide fallback preserves legacy
-    lookup semantics for domains that have not been explicitly
-    initialised yet; callers that use the returned [Eio.Switch] or net
-    handle across domains still need an ownership audit. *)
+    Internal storage is hidden and domain-local. There is no
+    process-wide fallback; an OCaml domain that performs OAS HTTP
+    calls must call {!init} with handles owned by that domain. *)
 
 type t = {
   sw : Eio.Switch.t;
@@ -32,9 +30,9 @@ val init :
   unit ->
   unit
 (** Capture the runtime handles for the current OCaml domain.
-    Last-writer-wins for both the domain-local slot and the process-wide
-    compatibility fallback. Intended to be called at startup; re-init is
-    permitted by harness tests and standalone executables. *)
+    Last-writer-wins for the current domain-local slot. Intended to be called
+    at startup; re-init is permitted by harness tests and standalone
+    executables. *)
 
 val reset_for_test : unit -> unit
 (** Clear the captured environment for direct test executable runs. *)
@@ -48,7 +46,7 @@ val get : unit -> t
 
 val get_opt : unit -> t option
 (** Read the captured environment without raising. Returns
-    [None] only when {!init} has not run in the process. Used by tests and
-    by code paths that must degrade gracefully (runtime catalog runtime,
+    [None] when {!init} has not run in the current OCaml domain. Used by tests
+    and by code paths that must degrade gracefully (runtime catalog runtime,
     masc_oas_bridge fallback, local-runtime probes, oas_worker_named
     scheduler). *)


### PR DESCRIPTION
## Summary

- align `Masc_eio_env` interface docs with the current Domain.DLS-only implementation
- remove stale process-wide fallback wording from the public contract
- clarify that each OCaml domain performing OAS HTTP calls must call `init` with handles owned by that domain

## Validation

- `ocamlformat --check lib/masc_eio_env.mli`
- `git diff --check`
- `rg -n "process-wide fallback|compatibility fallback|fallback preserves legacy|has not run in the process" lib/masc_eio_env.mli lib/masc_eio_env.ml`

Build/test authority: CI, per current workflow.
