### PR TITLE
fix(memory): skip empty librarian fallback notes

### DIFF
--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -180,6 +180,28 @@ function stubFetch(payload: unknown = turnRecordsPayload()) {
   return fetchMock
 }
 
+function turnRecordsPayloadWithEmptyFallbackFact() {
+  const payload = turnRecordsPayload()
+  const fact = {
+    claim: 'unstructured_note: librarian parse fallback (librarian provider returned empty response): <empty response>',
+    category: 'ephemeral',
+    source: { trace_id: 'trace-empty-fallback', turn: 9, tool_call_id: null },
+    first_seen: 1_789_800_000,
+    first_seen_iso: '2026-09-10T...Z',
+    reference_time: 1_789_800_000,
+    valid_until: null,
+    valid_until_iso: null,
+    last_verified_at: null,
+    current: true,
+    prompt_recallable: false,
+    claim_kind: 'diagnostic',
+  }
+  payload.memory_os.facts.items.splice(1, 0, fact)
+  payload.memory_os.facts.shown = 4
+  payload.memory_os.facts.current = 3
+  return payload
+}
+
 const improver: MemoryKeeper = { id: 'masc-improver', ctx: 0.86, status: 'run' }
 
 function renderInspector(keeper: MemoryKeeper = improver, onClose = vi.fn()) {
@@ -266,6 +288,23 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     expect(container.textContent).not.toContain('amplitude 캐시는 만료됨')
     expect(container.textContent).toContain('진단 fallback · librarian')
     expect(container.textContent).toContain('librarian parse fallback')
+  })
+
+  it('does not leak empty librarian fallback categories into the default recall filter', async () => {
+    stubFetch(turnRecordsPayloadWithEmptyFallbackFact())
+    const { container } = renderInspector()
+    await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
+
+    expect(container.textContent).toContain('1/4 recallable')
+    expect(container.textContent).not.toContain('<empty response>')
+    expect([...container.querySelectorAll('.mem-filter')].map(b => b.textContent)).not.toContain('◌ 임시')
+
+    const diagnosticBtn = [...container.querySelectorAll('.mem-filter')].find(b => b.textContent === '진단/증거 2')
+    expect(diagnosticBtn).toBeTruthy()
+    fireEvent.click(diagnosticBtn!)
+
+    expect(container.textContent).toContain('<empty response>')
+    expect([...container.querySelectorAll('.mem-filter')].map(b => b.textContent)).toContain('◌ 임시')
   })
 
   it('surfaces selection policy and prompt digest lineage without claiming raw full-prompt storage', async () => {

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -508,10 +508,18 @@ function OneKeeperMemoryReal({
   const fallbackEpisodes = allEpisodes
     .filter(ep => ep.terminal_marker === MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER)
     .slice(0, 5)
-  // distinct categories present, in first-seen order, deduped by tag
+  const visibilityRows =
+    visibilityFilter.value === 'recallable'
+      ? recallableFacts
+      : visibilityFilter.value === 'diagnostic'
+        ? diagnosticFacts
+        : facts
+  // Category chips follow the current visibility lane. Otherwise diagnostic-only
+  // fallback categories (for example ephemeral librarian parse failures) still
+  // look selectable in the default recall view even though their rows are hidden.
   const seen = new Set<string>()
   const cats: MemoryOsFactCategory[] = []
-  for (const f of facts) {
+  for (const f of visibilityRows) {
     const tag = factTag(f)
     if (!seen.has(tag)) {
       seen.add(tag)
@@ -519,14 +527,9 @@ function OneKeeperMemoryReal({
     }
   }
   const filter = kindFilter.value
-  const visibilityRows =
-    visibilityFilter.value === 'recallable'
-      ? recallableFacts
-      : visibilityFilter.value === 'diagnostic'
-        ? diagnosticFacts
-        : facts
+  const effectiveFilter = filter === 'all' || seen.has(filter) ? filter : 'all'
   const storeRows =
-    filter === 'all' ? visibilityRows : visibilityRows.filter(f => factTag(f) === filter)
+    effectiveFilter === 'all' ? visibilityRows : visibilityRows.filter(f => factTag(f) === effectiveFilter)
   const visibleStoreRows = storeRows.slice(0, factRowLimit.value)
   const hiddenStoreRows = Math.max(0, storeRows.length - visibleStoreRows.length)
   const showFallbackEpisodes = visibilityFilter.value !== 'recallable'
@@ -567,18 +570,18 @@ function OneKeeperMemoryReal({
               <div class="mem-filters">
                 <button
                   class=${`mem-filter ${visibilityFilter.value === 'recallable' ? 'on' : ''}`}
-                  onClick=${() => { visibilityFilter.value = 'recallable'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
+                  onClick=${() => { visibilityFilter.value = 'recallable'; kindFilter.value = 'all'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
                 >회상 ${recallableFacts.length}</button>
                 <button
                   class=${`mem-filter ${visibilityFilter.value === 'diagnostic' ? 'on' : ''}`}
-                  onClick=${() => { visibilityFilter.value = 'diagnostic'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
+                  onClick=${() => { visibilityFilter.value = 'diagnostic'; kindFilter.value = 'all'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
                 >진단/증거 ${diagnosticFacts.length}</button>
                 <button
                   class=${`mem-filter ${visibilityFilter.value === 'all' ? 'on' : ''}`}
-                  onClick=${() => { visibilityFilter.value = 'all'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
+                  onClick=${() => { visibilityFilter.value = 'all'; kindFilter.value = 'all'; factRowLimit.value = DEFAULT_FACT_ROW_LIMIT }}
                 >전체 ${facts.length}</button>
               </div>
-              <${CategoryFilters} cats=${cats} active=${filter} onPick=${(t: string) => { kindFilter.value = t }} />
+              <${CategoryFilters} cats=${cats} active=${effectiveFilter} onPick=${(t: string) => { kindFilter.value = t }} />
               <div class="mem-store">${visibleStoreRows.map(f => html`<${FactRow} key=${factTag(f) + f.source.trace_id + f.source.turn + f.claim} fact=${f} />`)}</div>
               ${hiddenStoreRows > 0
                 ? html`

--- a/lib/keeper/keeper_librarian_runtime.ml
+++ b/lib/keeper/keeper_librarian_runtime.ml
@@ -390,6 +390,10 @@ let should_record_cadence_success = function
   | Unstructured_fallback -> false
 ;;
 
+let should_preserve_unstructured_fallback raw =
+  not (String.equal (String.trim raw) "")
+;;
+
 let rec run_with_parse_retries ~max_retries ~attempt messages =
   match attempt messages with
   | Parsed episode -> Ok episode
@@ -578,16 +582,19 @@ let extract_with_provider_classified
          | Some raw -> raw
          | None -> ""
        in
-       let now = Eio.Time.now clock in
-       Log.Keeper.warn
-         "memory os librarian preserving unstructured fallback trace_id=%s generation=%d reason=%s"
-         inp.trace_id
-         generation
-         msg;
-       Ok
-         { episode = unstructured_episode ~now ~generation inp ~reason:msg ~raw
-         ; kind = Unstructured_fallback
-         }))
+       if not (should_preserve_unstructured_fallback raw)
+       then Error msg
+       else (
+         let now = Eio.Time.now clock in
+         Log.Keeper.warn
+           "memory os librarian preserving unstructured fallback trace_id=%s generation=%d reason=%s"
+           inp.trace_id
+           generation
+           msg;
+         Ok
+          { episode = unstructured_episode ~now ~generation inp ~reason:msg ~raw
+          ; kind = Unstructured_fallback
+          })))
 ;;
 
 let extract_with_provider ?complete ?clock ?timeout_sec ~sw ~net ~provider_cfg ~generation inp =

--- a/lib/keeper/keeper_librarian_runtime.mli
+++ b/lib/keeper/keeper_librarian_runtime.mli
@@ -130,6 +130,11 @@ val should_record_cadence_success : extraction_kind -> bool
     Unstructured fallback episodes are durable diagnostics, but they mean the
     provider still failed to produce structured memory. *)
 
+val should_preserve_unstructured_fallback : string -> bool
+(** Whether raw unparseable provider output is worth preserving as a diagnostic
+    fallback fact. Empty output carries no evidence and should remain a provider
+    failure instead of polluting memory. *)
+
 val run_with_parse_retries
   :  max_retries:int
   -> attempt:(Agent_sdk.Types.message list -> attempt_outcome)

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -1158,12 +1158,6 @@ let keeper_fleet_safety_health_json
   let active_task_owner_without_executable_fiber =
     active_task_owner_without_executable_fiber_count > 0
   in
-  let phase_values =
-    match phase_snapshot with
-    | Some snapshot -> snapshot.phase_values
-    | None -> []
-  in
-  let phase_value name = List.assoc_opt name phase_values in
   let phase_details =
     match phase_snapshot with
     | Some snapshot -> snapshot.phase_details
@@ -1275,7 +1269,6 @@ let keeper_fleet_safety_health_json
            (fun name ->
              blocked_keeper_detail_json
                ?base_path:runtime_base_path
-               ?phase:(phase_value name)
                ?phase_detail:(phase_detail name)
                ~keeper_bootstrap_enabled
                ~bootable_set

--- a/test/test_keeper_librarian_retry.ml
+++ b/test/test_keeper_librarian_retry.ml
@@ -217,6 +217,14 @@ let test_cadence_success_policy () =
   check bool "unstructured fallback stays due" false
     (R.should_record_cadence_success R.Unstructured_fallback)
 
+let test_unstructured_fallback_preservation_policy () =
+  check bool "empty response is not preserved" false
+    (R.should_preserve_unstructured_fallback "");
+  check bool "whitespace response is not preserved" false
+    (R.should_preserve_unstructured_fallback " \n\t ");
+  check bool "invalid text response is preserved" true
+    (R.should_preserve_unstructured_fallback "not json, but evidence")
+
 (* [cadence_due] drives the real per-(keeper, trace) counter table (the gate
    [run_best_effort] uses). A fresh pair is due immediately, and failures are
    left due until [cadence_record_success] is called. Asserted as
@@ -492,6 +500,8 @@ let () =
           test_case "step transitions" `Quick test_cadence_step_transitions;
           test_case "record success resets" `Quick test_cadence_record_success_resets;
           test_case "success policy excludes fallback" `Quick test_cadence_success_policy;
+          test_case "fallback preservation policy" `Quick
+            test_unstructured_fallback_preservation_policy;
           test_case "cadence_due fires once per period" `Quick test_cadence_due_periodic;
           test_case "cadence_due is per-keeper" `Quick test_cadence_due_independent_keepers;
           test_case "cadence_due resets on trace rollover" `Quick


### PR DESCRIPTION
## Summary
- stop preserving empty librarian provider responses as unstructured memory facts
- keep non-empty invalid output fallback behavior intact
- hide diagnostic/ephemeral fallback memory categories from the default recall lane while leaving them visible in the diagnostic lane
- keep the rebased PR aligned with current main by removing the stale fleet-scan `?phase` call after blocked keeper detail moved to phase-detail input

## Why
The librarian fallback path was preserving empty or whitespace-only provider responses as durable `unstructured_note` facts. That creates memory noise without evidence. Empty output should remain a provider failure; only non-empty unparseable output is useful enough to preserve as a diagnostic fallback. The dashboard change keeps those fallback diagnostics out of the default recall view unless the diagnostic lane is selected.

## Validation
- git diff --check
- ocamlformat --check lib/keeper/keeper_librarian_runtime.ml lib/keeper/keeper_librarian_runtime.mli test/test_keeper_librarian_retry.ml lib/server/server_routes_http_runtime_fleet_scan.ml
- scripts/dune-local.sh build test/test_keeper_librarian_retry.exe
- ./_build/default/test/test_keeper_librarian_retry.exe (30 tests)
- pnpm vitest memory-inspector targeted run (26 tests)
- pnpm tsc --noEmit against clean dashboard tsconfig
- GitHub checks queued on head b796aebc9d6
