### PR TITLE
fix(keeper): try next provider after no-progress accept reject

### DIFF
--- a/dashboard/src/components/fleet-health-panel.test.ts
+++ b/dashboard/src/components/fleet-health-panel.test.ts
@@ -168,8 +168,8 @@ describe('FleetHealthPanel', () => {
             paused_elapsed_sec: 12,
             auto_resume_remaining_sec: 48,
             last_blocker: {
-              klass: 'turn_timeout',
-              detail: 'turn exceeded budget',
+              klass: 'no_progress_loop',
+              detail: 'no_progress loop detected: streak=10 threshold=10; manual pause applied',
             },
             missing_pause_root_cause: false,
           }],
@@ -247,6 +247,8 @@ describe('FleetHealthPanel', () => {
     expect(screen.getByTestId('runtime-blocker-board')).toBeTruthy()
     expect(screen.getByText('8/17')).toBeTruthy()
     expect(screen.getByText('analyst')).toBeTruthy()
+    expect(screen.getByText(/blocker=no-progress safety pause/)).toBeTruthy()
+    expect(screen.queryByText(/manual pause applied/)).toBeNull()
     expect(screen.getAllByText('proof_store_incomplete').length).toBeGreaterThan(0)
     expect(screen.getByText(/contract-stale-a/)).toBeTruthy()
   })

--- a/dashboard/src/components/fleet-health-panel.ts
+++ b/dashboard/src/components/fleet-health-panel.ts
@@ -359,12 +359,22 @@ function blockerClassText(row: DashboardPausedKeeperDetail): string | null {
   return klass?.name ?? null
 }
 
+const NO_PROGRESS_LOOP_DISPLAY =
+  'progress-safety latch · repeated no-evidence turns; resume clears the latch'
+
+function blockerClassDisplayText(row: DashboardPausedKeeperDetail): string | null {
+  const blockerClass = blockerClassText(row)
+  if (blockerClass === 'no_progress_loop') return 'no-progress safety pause'
+  return blockerClass
+}
+
 function blockerDetailText(row: DashboardPausedKeeperDetail): string | null {
+  if (blockerClassText(row) === 'no_progress_loop') return NO_PROGRESS_LOOP_DISPLAY
   return row.last_blocker?.detail ?? null
 }
 
 function pausedKindText(row: DashboardPausedKeeperDetail): string {
-  const blockerClass = blockerClassText(row)
+  const blockerClass = blockerClassDisplayText(row)
   const parts = [
     row.pause_kind ?? 'unknown',
     blockerClass ? `blocker=${blockerClass}` : null,

--- a/dashboard/src/components/fleet-telemetry-utils.test.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.test.ts
@@ -249,6 +249,23 @@ describe('buildFleetRows runtime labels', () => {
       summary: 'no provider can satisfy tool surface',
     })
   })
+
+  it('normalizes legacy no-progress blocker text before building fleet rows', () => {
+    const [row] = buildFleetRows([
+      {
+        name: 'latched-keeper',
+        status: 'paused',
+        keepalive_running: true,
+        runtime_blocker_class: 'no_progress_loop',
+        last_blocker: 'no_progress loop detected: streak=10 threshold=10; manual pause applied',
+      },
+    ], EMPTY_TOOL_QUALITY)
+
+    expect(row?.runtime_blocker_summary).toContain('progress-safety latch')
+    expect(row?.runtime_blocker_summary).not.toContain('manual pause applied')
+    expect(row?.stop_cause?.summary).toContain('progress-safety latch')
+    expect(row?.stop_cause?.summary).not.toContain('manual pause applied')
+  })
 })
 
 describe('uniqueStrings', () => {

--- a/dashboard/src/components/fleet-telemetry-utils.ts
+++ b/dashboard/src/components/fleet-telemetry-utils.ts
@@ -7,6 +7,7 @@ import { firstNonEmptyString } from '../lib/format-string'
 import { normalizeStopCause } from '../lib/stop-cause'
 import {
   keeperActivityDisplay,
+  normalizeKeeperBlockerText,
   type KeeperActivitySource,
 } from '../lib/keeper-runtime-display'
 
@@ -397,9 +398,12 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
           const recentTools = keeperRecentTools(keeper)
           const toolCalls = keeperToolCallCount(keeper, toolQualityForKeeper?.calls)
           const activity = keeperActivityDisplay(keeper, keeper.agent?.last_seen)
+          const runtimeBlockerSummary = normalizeKeeperBlockerText(
+            firstNonEmptyString(keeper.runtime_blocker_summary, keeper.last_blocker),
+          )
           const stopCause = keeper.stop_cause ?? normalizeStopCause({
             runtime_blocker_class: keeper.runtime_blocker_class ?? null,
-            runtime_blocker_summary: keeper.runtime_blocker_summary ?? keeper.last_blocker ?? null,
+            runtime_blocker_summary: runtimeBlockerSummary,
             terminal_reason_code: keeper.trust?.latest_terminal_reason?.code ?? null,
             terminal_reason_summary: keeper.trust?.latest_terminal_reason?.summary ?? null,
             terminal_reason_severity: keeper.trust?.latest_terminal_reason?.severity ?? null,
@@ -429,8 +433,7 @@ export function buildFleetRows(keepers: Keeper[], toolQuality: ToolQualityRespon
             tool_activity_known: keeperHasToolTelemetry(keeper, toolCalls, recentTools),
             recent_tools: recentTools,
             runtime_blocker_class: keeper.runtime_blocker_class ?? null,
-            runtime_blocker_summary:
-              firstNonEmptyString(keeper.runtime_blocker_summary, keeper.last_blocker) ?? null,
+            runtime_blocker_summary: runtimeBlockerSummary,
             runtime_trust_attention: keeper.trust?.needs_attention === true,
             runtime_trust_reason:
               firstNonEmptyString(

--- a/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.test.ts
@@ -47,6 +47,21 @@ describe('IdeKeeperWorkPanel', () => {
     expect(summary.activeTaskCount).toBe(1)
   })
 
+  it('normalizes legacy no-progress blocker text in keeper work summaries', () => {
+    const summary = keeperWorkSummary(
+      'rondo',
+      [{
+        name: 'rondo',
+        status: 'paused',
+        last_blocker: 'no_progress loop detected: streak=10 threshold=10; manual pause applied',
+      } as Keeper],
+      [],
+    )
+
+    expect(summary.runtimeBlocker).toContain('progress-safety latch')
+    expect(summary.runtimeBlocker).not.toContain('manual pause applied')
+  })
+
   it('keeps runtime current_task visible when the task row is absent', () => {
     const summary = keeperWorkSummary('sangsu', [keeperFixture()], [])
 

--- a/dashboard/src/components/ide/ide-keeper-work-panel.ts
+++ b/dashboard/src/components/ide/ide-keeper-work-panel.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'preact/hooks'
 import type { Goal, Keeper, Task } from '../../types'
 import { goals, keepers, tasks } from '../../store'
 import { firstNonEmptyString } from '../../lib/format-string'
+import { normalizeKeeperBlockerText } from '../../lib/keeper-runtime-display'
 import { KeeperBadge } from '../keeper-badge'
 import {
   formatProgressPct,
@@ -341,6 +342,17 @@ export function keeperWorkSummary(
   )
   const trust = keeper?.trust ?? null
   const latestTerminal = trust?.latest_terminal_reason ?? null
+  const terminalSummary = normalizeKeeperBlockerText(
+    firstNonEmptyString(
+      latestTerminal?.summary,
+      keeper?.runtime_blocker_summary,
+      trust?.attention_reason,
+      keeper?.attention_reason,
+    ),
+  )
+  const runtimeBlocker = normalizeKeeperBlockerText(
+    firstNonEmptyString(keeper?.runtime_blocker_summary, keeper?.last_blocker),
+  )
   return {
     displayName,
     keeper,
@@ -350,12 +362,7 @@ export function keeperWorkSummary(
     activeTasks,
     activeTaskCount: currentTaskId && activeTasks.length === 0 ? 1 : activeTasks.length,
     terminalCode: firstNonEmptyString(latestTerminal?.code, keeper?.runtime_blocker_class),
-    terminalSummary: firstNonEmptyString(
-      latestTerminal?.summary,
-      keeper?.runtime_blocker_summary,
-      trust?.attention_reason,
-      keeper?.attention_reason,
-    ),
+    terminalSummary,
     nextAction: firstNonEmptyString(
       latestTerminal?.next_action,
       trust?.latest_next_action,
@@ -368,7 +375,7 @@ export function keeperWorkSummary(
       keeper?.last_proactive_preview,
     ),
     recentTools: keeper?.recent_tool_names ?? keeper?.latest_tool_names ?? EMPTY_TOOLS,
-    runtimeBlocker: firstNonEmptyString(keeper?.runtime_blocker_summary, keeper?.last_blocker),
+    runtimeBlocker,
   }
 }
 

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -108,7 +108,7 @@ describe('KeeperRuntimeAlertStrip', () => {
     }))
 
     const text = container.textContent ?? ''
-    expect(text).toContain('수동 응답만 있음')
+    expect(text).toContain('진행 작업 없는 수동 응답')
     expect(text).not.toContain('passive_only')
   })
 

--- a/dashboard/src/components/keeper-detail-alert-strip.test.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.test.ts
@@ -289,6 +289,23 @@ describe('KeeperRuntimeAlertStrip', () => {
     expect(text).not.toContain('깨우기')
   })
 
+  it('normalizes legacy no-progress last_blocker text before rendering blocker details', () => {
+    const { container } = render(h(KeeperRuntimeAlertStrip, {
+      keeper: keeper({
+        paused: true,
+        keepalive_running: true,
+        needs_attention: true,
+        last_blocker: 'no_progress loop detected: streak=10 threshold=10; manual pause applied',
+      }),
+    }))
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('progress-safety latch')
+    expect(text).toContain('Resume')
+    expect(text).not.toContain('manual pause applied')
+    expect(text).not.toContain('no_progress loop detected')
+  })
+
   it('uses lifecycle action visibility SSOT to show wake for non-paused blocked keepers', () => {
     const { container } = render(h(KeeperRuntimeAlertStrip, {
       keeper: keeper({

--- a/dashboard/src/components/keeper-detail-alert-strip.ts
+++ b/dashboard/src/components/keeper-detail-alert-strip.ts
@@ -3,6 +3,7 @@ import { signal } from '@preact/signals'
 import { ActionButton } from './common/button'
 import {
   keeperActivityDisplay,
+  normalizeKeeperBlockerText,
   keeperRuntimeBlockerLabel,
   keeperRuntimeBlockerHint,
 } from '../lib/keeper-runtime-display'
@@ -143,7 +144,7 @@ export function KeeperRuntimeAlertStrip({ keeper }: { keeper: Keeper }) {
   const persistedPolicyCount = keeper.approval_policy_effective?.persisted_rules
   const goalLinkedTasks = keeper.goal_progress?.linked_task_count
   const goalConvergence = keeper.goal_progress?.convergence
-  const blocker = keeper.last_blocker?.trim()
+  const blocker = normalizeKeeperBlockerText(keeper.last_blocker)
   const pendingFirst = keeper.trust?.approval_state?.pending_first ?? null
   const pendingApprovalId = pendingFirst?.id?.trim() || null
   const pendingApprovalTool = pendingFirst?.tool_name?.trim() || null

--- a/dashboard/src/components/keeper-detail-helpers.ts
+++ b/dashboard/src/components/keeper-detail-helpers.ts
@@ -1,7 +1,7 @@
 import { currentDashboardActor, runOperatorAction } from '../api'
 import { invalidateDashboardCache, refreshDashboard, refreshKeeperRuntimeStatus } from '../store'
 import { showToast } from './common/toast'
-import { keeperRuntimeBlockerHint } from '../lib/keeper-runtime-display'
+import { keeperRuntimeBlockerHint, normalizeKeeperBlockerText } from '../lib/keeper-runtime-display'
 import type { Keeper } from '../types'
 
 export async function runSocialSweep(): Promise<void> {
@@ -41,7 +41,7 @@ export async function refreshAfterRuntimeAction(): Promise<void> {
 export function keeperNeedsDiagnosticAttention(keeper: Keeper): boolean {
   if (typeof keeper.needs_attention === 'boolean') return keeper.needs_attention
   const runtimeBlocker = keeperRuntimeBlockerHint(keeper)
-  const blocker = keeper.last_blocker?.trim()
+  const blocker = normalizeKeeperBlockerText(keeper.last_blocker)
   const hbTs = keeper.last_heartbeat ? Date.parse(keeper.last_heartbeat) : null
   const hbAgeMs = hbTs != null && !Number.isNaN(hbTs) ? Date.now() - hbTs : null
   const hbStale = hbAgeMs != null && hbAgeMs > 300_000

--- a/dashboard/src/components/overview/overview.test.ts
+++ b/dashboard/src/components/overview/overview.test.ts
@@ -572,7 +572,7 @@ describe('deriveKeeperAttentionReason', () => {
       name: 'composite',
       attention_reason: 'passive_only',
     }))
-    expect(reason.text).toBe('수동 응답만 있음')
+    expect(reason.text).toBe('진행 작업 없는 수동 응답')
   })
 })
 

--- a/dashboard/src/lib/keeper-attention-labels.test.ts
+++ b/dashboard/src/lib/keeper-attention-labels.test.ts
@@ -13,16 +13,16 @@ describe('keeper attention labels', () => {
   it('labels known completion-contract composite reasons without warning', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    expect(completionContractAttentionReasonLabel('completion_contract_result:passive_only')).toBe('수동 응답만 있음')
-    expect(attentionReasonLabel('completion_contract_result:passive_only', false)).toBe('수동 응답만 있음')
+    expect(completionContractAttentionReasonLabel('completion_contract_result:passive_only')).toBe('진행 작업 없는 수동 응답')
+    expect(attentionReasonLabel('completion_contract_result:passive_only', false)).toBe('진행 작업 없는 수동 응답')
     expect(attentionReasonLabel('completion_contract_result:no_capable_provider', false)).toBe('사용 가능한 provider 없음')
     expect(warn).not.toHaveBeenCalled()
   })
 
   it('labels known bare completion-contract tokens without warning', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    expect(completionContractAttentionReasonLabel('passive_only')).toBe('수동 응답만 있음')
-    expect(attentionReasonLabel('passive_only', false)).toBe('수동 응답만 있음')
+    expect(completionContractAttentionReasonLabel('passive_only')).toBe('진행 작업 없는 수동 응답')
+    expect(attentionReasonLabel('passive_only', false)).toBe('진행 작업 없는 수동 응답')
     expect(warn).not.toHaveBeenCalled()
   })
 

--- a/dashboard/src/lib/keeper-attention-labels.ts
+++ b/dashboard/src/lib/keeper-attention-labels.ts
@@ -135,7 +135,7 @@ const COMPLETION_CONTRACT_ATTENTION_REASON_LABELS: Record<AttentionCompletionCon
   violated: '완료 계약 위반',
   claim_only_after_owned_task: '작업 소유 없는 claim',
   needs_execution_progress: '실행 진행 증거 부족',
-  passive_only: '수동 응답만 있음',
+  passive_only: '진행 작업 없는 수동 응답',
   unknown: '완료 계약 결과 불명',
   not_dispatched: '도구 미실행',
   surface_mismatch: '실행 표면 불일치',

--- a/dashboard/src/lib/keeper-runtime-display.test.ts
+++ b/dashboard/src/lib/keeper-runtime-display.test.ts
@@ -8,6 +8,7 @@ import {
   keeperPauseDisplay,
   keeperRuntimeBlockerHint,
   keeperRuntimeBlockerLabel,
+  keeperRuntimeHint,
   keeperWorkPreview,
 } from './keeper-runtime-display'
 
@@ -277,6 +278,30 @@ describe('keeperRuntimeBlockerHint', () => {
         runtime_blocker_summary: 'admission_queue_wait_timeout',
       })),
     ).toBe('Keeper admission FIFO 대기 시간이 초과되었습니다.')
+  })
+
+  it('explains no-progress loop as a safety latch cleared by resume', () => {
+    expect(
+      keeperRuntimeBlockerHint(makeKeeper({
+        runtime_blocker_class: 'no_progress_loop',
+        runtime_blocker_summary: 'no_progress_loop',
+      })),
+    ).toBe(
+      '반복된 무증거 턴으로 자동 정지된 progress-safety latch입니다. provider 실패가 아니며 Resume이 latch를 해제합니다.',
+    )
+  })
+
+  it('normalizes legacy no-progress pause detail before rendering runtime hints', () => {
+    const hint = keeperRuntimeHint(makeKeeper({
+      status: 'paused',
+      paused: true,
+      last_blocker: 'no_progress loop detected: streak=10 threshold=10; manual pause applied',
+    }))
+
+    expect(hint).toBe(
+      '일시정지 · 반복된 무증거 턴으로 자동 정지된 progress-safety latch입니다. provider 실패가 아니며 Resume이 latch를 해제합니다.',
+    )
+    expect(hint).not.toContain('manual pause applied')
   })
 
   const registryBlockerHintCases: Array<[KeeperRuntimeBlockerClass, string]> = [

--- a/dashboard/src/lib/keeper-runtime-display.ts
+++ b/dashboard/src/lib/keeper-runtime-display.ts
@@ -74,6 +74,22 @@ function trimmed(value: string | null | undefined): string | null {
   return text ? text : null
 }
 
+const NO_PROGRESS_LOOP_HINT =
+  '반복된 무증거 턴으로 자동 정지된 progress-safety latch입니다. provider 실패가 아니며 Resume이 latch를 해제합니다.'
+const IDLE_LOOP_HINT =
+  '반복 idle 턴으로 자동 정지되었습니다. provider 실패가 아니며 최근 실행 상태 확인 후 재개하세요.'
+
+export function normalizeKeeperBlockerText(value: string | null | undefined): string | null {
+  const text = trimmed(value)
+  if (!text) return null
+  const lower = text.toLowerCase()
+  if (lower.includes('no_progress loop detected') || lower.includes('no-progress loop')) {
+    return NO_PROGRESS_LOOP_HINT
+  }
+  if (lower.includes('idle loop detected')) return IDLE_LOOP_HINT
+  return text
+}
+
 export function keeperDisplayModel(
   _source: KeeperModelDisplaySource | null | undefined,
 ): KeeperModelDisplay | null {
@@ -383,7 +399,7 @@ function socialModelFallbackHint(keeper: Keeper): string | null {
 }
 
 function continueGateHint(keeper: Keeper): string {
-  const detail = keeper.runtime_blocker_summary?.trim()
+  const detail = normalizeKeeperBlockerText(keeper.runtime_blocker_summary)
   if (detail) return `계속 진행 승인 대기 · ${detail}`
   if (keeper.runtime_blocker_class === 'ambiguous_post_commit_timeout') {
     return '계속 진행 승인 대기 · 변경 이후 응답이 끊겨 상태 확인이 필요합니다.'
@@ -439,7 +455,7 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
   if (!keeper) return null
   if (keeper.runtime_blocker_continue_gate) return continueGateHint(keeper)
   const blockerClass = keeper.runtime_blocker_class
-  const runtimeBlocker = keeper.runtime_blocker_summary?.trim()
+  const runtimeBlocker = normalizeKeeperBlockerText(keeper.runtime_blocker_summary)
   if (runtimeBlocker && runtimeBlocker !== blockerClass) {
     return runtimeBlocker
   }
@@ -507,9 +523,7 @@ export function keeperRuntimeBlockerHint(keeper: Keeper | null | undefined): str
     return 'Keeper가 관찰 또는 대기만 계획하고 있어 다음 실행 지시가 필요할 수 있습니다.'
   }
   if (blockerClass === 'no_progress_loop') {
-    // keeper_unified_turn_no_progress.ml: consecutive no-progress turns above
-    // threshold latch the blocker. Auto-clears on first progress turn.
-    return 'Keeper가 연속으로 진행 없는 턴을 내고 있어 정지된 것 같습니다. 다음 실제 진행이 나오면 자동 해제됩니다.'
+    return NO_PROGRESS_LOOP_HINT
   }
   return null
 }
@@ -548,7 +562,7 @@ export function keeperRuntimeHint(keeper: Keeper | null | undefined): string | n
   }
   const socialFallback = socialModelFallbackHint(keeper)
   if (socialFallback) return socialFallback
-  const blocker = keeper.last_blocker?.trim()
+  const blocker = normalizeKeeperBlockerText(keeper.last_blocker)
   if (paused && autoRecover) return blocker ? `자동 재시도 대기 · ${blocker}` : '자동 재시도 대기'
   if (paused && blocker) return `일시정지 · ${blocker}`
   if (paused && keeper.keepalive_running) return '일시정지 · 하트비트만 유지 중'

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -77,11 +77,6 @@ module Compression : sig
       data shorter than 256 bytes is kept as-is.  Raw zstd
       compression is delegated to {!Compression_codec}, which owns
       compression failure diagnostics. *)
-  val compress_zstd_result
-    :  original:string
-    -> Compression_codec.compress_result
-    -> string * bool
-
   val compress_zstd : ?level:int -> string -> string * bool
 
   (** [compress_zstd_result ~original result] adapts the shared codec result to

--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -77,6 +77,11 @@ module Compression : sig
       data shorter than 256 bytes is kept as-is.  Raw zstd
       compression is delegated to {!Compression_codec}, which owns
       compression failure diagnostics. *)
+  val compress_zstd_result
+    :  original:string
+    -> Compression_codec.compress_result
+    -> string * bool
+
   val compress_zstd : ?level:int -> string -> string * bool
 
   (** [compress_zstd_result ~original result] adapts the shared codec result to

--- a/lib/keeper/keeper_execution_receipt.ml
+++ b/lib/keeper/keeper_execution_receipt.ml
@@ -169,6 +169,17 @@ let completion_contract_unsatisfied = function
   | Contract_satisfied_execution -> false
 ;;
 
+let passive_only_without_work_scope receipt =
+  receipt.completion_contract_result = Contract_passive_only
+  && Option.is_none receipt.current_task_id
+  && receipt.goal_ids = []
+;;
+
+let terminal_reason_is_success receipt =
+  let code = String.lowercase_ascii (String.trim receipt.terminal_reason_code) in
+  String.equal code "completed" || String.equal code "success"
+;;
+
 let operator_disposition (receipt : t)
   : operator_disposition_kind * operator_disposition_reason
   =
@@ -318,8 +329,14 @@ let operator_disposition (receipt : t)
       | Other _ -> false
     then
       if completion_contract_satisfied receipt.completion_contract_result
+         || (passive_only_without_work_scope receipt && receipt.outcome = `Ok)
       then Disp_pass, Reason_turn_budget_exhausted
       else Disp_alert_exhausted, Reason_turn_budget_exhausted
+    else if passive_only_without_work_scope receipt
+            && receipt.outcome = `Ok
+            && receipt.runtime_outcome = Runtime_completed
+            && terminal_reason_is_success receipt
+    then Disp_pass, Reason_healthy
     else if completion_contract_unsatisfied receipt.completion_contract_result
     then Disp_pause_human, Reason_completion_contract_unsatisfied
     else if

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -74,6 +74,16 @@ let terminal_reason_from_decision json =
           Keeper_turn_terminal.of_code ~source:"decision_log" code)
         (json_string_opt_member "terminal_reason_code" json)
 
+let receipt_passive_only_without_work_scope receipt =
+  match
+    json_string_opt_member "completion_contract_result" receipt
+    |> Option.map (fun value -> String.lowercase_ascii (String.trim value))
+  with
+  | Some "passive_only" ->
+      Option.is_none (json_string_opt_member "current_task_id" receipt)
+      && goal_ids_of_json receipt = []
+  | Some _ | None -> false
+
 let terminal_reason_from_receipt receipt =
   let terminal_reason_code = json_string_opt_member "terminal_reason_code" receipt in
   let operator_disposition_reason =
@@ -82,12 +92,12 @@ let terminal_reason_from_receipt receipt =
   in
   let completion_contract_result = completion_contract_result_from_receipt receipt in
   let receipt_requires_tool_attention =
-    match operator_disposition_reason with
-    | Some "tool_route_recoverable_failure" -> true
-    | _ ->
-        (match completion_contract_result with
-         | Some result -> Completion_contract_result.requires_attention result
-         | None -> false)
+    match operator_disposition_reason, completion_contract_result with
+    | Some "tool_route_recoverable_failure", _ -> true
+    | _, Some Completion_contract_result.Passive_only ->
+      not (receipt_passive_only_without_work_scope receipt)
+    | _, Some result -> Completion_contract_result.requires_attention result
+    | _ -> false
   in
   match terminal_reason_code with
   | Some code when receipt_requires_tool_attention
@@ -119,6 +129,9 @@ let receipt_contract_attention_reason receipt =
     "completion_contract_result:" ^ Completion_contract_result.to_string result
   in
   match completion_contract_result with
+  | Some Completion_contract_result.Passive_only
+    when receipt_passive_only_without_work_scope receipt ->
+      None
   | Some
       ( Completion_contract_result.Violated
       | Completion_contract_result.Claim_only_after_owned_task
@@ -193,9 +206,7 @@ let runtime_blocker_supersedes_receipt ~meta ~runtime_blocker_fields
   | None -> false
   | Some raw_blocker_class -> (
     match Keeper_meta_contract.blocker_class_of_serialized_string raw_blocker_class with
-    | Some Keeper_meta_contract.Completion_contract_violation
-      when Option.is_some
-             (Option.bind latest_receipt receipt_contract_attention_reason) ->
+    | Some Keeper_meta_contract.Completion_contract_violation ->
         true
     | _ -> (
       match latest_receipt with

--- a/lib/keeper/keeper_status_bridge_blocker.ml
+++ b/lib/keeper/keeper_status_bridge_blocker.ml
@@ -115,6 +115,10 @@ let is_fiber_unresolved_blocker_class blocker_class =
   String.equal blocker_class (blocker_class_to_string Fiber_unresolved)
 ;;
 
+let no_progress_loop_summary =
+  "Keeper auto-paused after repeated no-evidence turns; this is a progress-safety latch, not a provider failure. Operator resume clears the latch."
+;;
+
 let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
   : runtime_blocker_surface
   =
@@ -154,6 +158,7 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
       then
         "Provider response violated the completion contract after dispatch."
       else summary
+    | No_progress_loop -> no_progress_loop_summary
     (* All remaining blocker_class variants carry no class-specific summary
        transformation — fall back to the live summary or the typed name. *)
     | Ambiguous_post_commit_timeout
@@ -161,7 +166,6 @@ let runtime_blocker_surface_of_typed_class ?(summary = "") (cls : blocker_class)
     | Admission_queue_wait_timeout
     | Turn_timeout_after_queue_wait
     | Turn_timeout
-    | No_progress_loop
     | Stale_fleet_batch
     | Sdk_max_turns_exceeded
     | Sdk_token_budget_exceeded

--- a/lib/keeper/keeper_turn_driver.ml
+++ b/lib/keeper/keeper_turn_driver.ml
@@ -398,4 +398,8 @@ module For_testing = struct
   let accept_no_progress_read_only_should_try_next =
     Keeper_turn_driver_try_runtime.For_testing
     .accept_no_progress_read_only_should_try_next
+
+  let accept_rejected_result_should_try_next =
+    Keeper_turn_driver_try_runtime.For_testing
+    .accept_rejected_result_should_try_next
 end

--- a/lib/keeper/keeper_turn_driver.mli
+++ b/lib/keeper/keeper_turn_driver.mli
@@ -182,4 +182,7 @@ module For_testing : sig
 
   val accept_no_progress_read_only_should_try_next :
     Agent_sdk.Error.sdk_error -> bool
+
+  val accept_rejected_result_should_try_next :
+    is_last:bool -> Agent_sdk.Error.sdk_error -> bool
 end

--- a/lib/keeper/keeper_turn_driver_try_runtime.ml
+++ b/lib/keeper/keeper_turn_driver_try_runtime.ml
@@ -79,6 +79,20 @@ let accept_no_progress_read_only_should_try_next err =
       err
   | None -> false
 
+let accept_no_progress_retry_kind err =
+  match Keeper_internal_error.classify_masc_internal_error err with
+  | Some err -> Keeper_internal_error.accept_no_progress_retry_kind err
+  | None -> None
+
+let accept_rejected_result_should_try_next ~is_last err =
+  (not is_last) && accept_no_progress_should_try_next err
+
+let checkpoint_for_accept_rejected_retry ~resume_checkpoint ~checkpoint_after err =
+  match accept_no_progress_retry_kind err with
+  | Some `Empty_no_progress -> resume_checkpoint
+  | Some `Read_only_no_progress -> checkpoint_after
+  | None -> checkpoint_after
+
 let http_status_of_http_error = function
   | Some (Llm_provider.Http_client.HttpError { code; _ }) -> Some code
   | _ -> None
@@ -227,7 +241,21 @@ let run
            ~keeper_name:ctx.keeper_name
            candidate
            ~reason;
-         Error err
+         if accept_rejected_result_should_try_next ~is_last err
+         then
+           let checkpoint_for_retry =
+             checkpoint_for_accept_rejected_retry
+               ~resume_checkpoint
+               ~checkpoint_after
+               err
+           in
+           let next_last_err =
+             match sdk_error_to_http_error err with
+             | Some http_err -> Some http_err
+             | None -> last_err
+           in
+           loop checkpoint_for_retry next_last_err rest
+         else Error err
        | Error err ->
          Keeper_turn_driver_provider_attempt.record_candidate_health_error
            ~keeper_name:ctx.keeper_name
@@ -259,4 +287,7 @@ module For_testing = struct
 
   let accept_no_progress_read_only_should_try_next =
     accept_no_progress_read_only_should_try_next
+
+  let accept_rejected_result_should_try_next =
+    accept_rejected_result_should_try_next
 end

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -19,7 +19,8 @@ let is_idle_detected_error = function
 let idle_detected_blocker_detail = function
   | Agent_sdk.Error.Agent (Agent_sdk.Error.IdleDetected { consecutive_idle_turns }) ->
     Printf.sprintf
-      "idle loop detected: consecutive_idle_turns=%d; manual pause applied"
+      "idle loop detected: consecutive_idle_turns=%d; auto-paused after \
+       repeated idle turns; operator resume clears the idle latch"
       consecutive_idle_turns
   | Agent_sdk.Error.Api _
   | Agent_sdk.Error.Provider _
@@ -30,7 +31,8 @@ let idle_detected_blocker_detail = function
   | Agent_sdk.Error.Io _
   | Agent_sdk.Error.Orchestration _
   | Agent_sdk.Error.Internal _ ->
-    "idle loop detected; manual pause applied"
+    "idle loop detected; auto-paused after repeated idle turns; operator \
+     resume clears the idle latch"
 ;;
 
 let record_failure_and_maybe_escalate

--- a/lib/keeper/keeper_unified_turn_no_progress.ml
+++ b/lib/keeper/keeper_unified_turn_no_progress.ml
@@ -16,7 +16,7 @@ let recovery_stimulus ~now ~keeper_name =
 let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
   let detail =
     Printf.sprintf
-      "no_progress loop detected: streak=%d threshold=%d; keeper paused until operator resume clears the no-progress latch"
+      "no_progress loop detected: streak=%d threshold=%d; auto-paused after repeated no-evidence turns; operator resume clears the no-progress latch"
       streak
       threshold
   in
@@ -74,7 +74,7 @@ let mark_loop_detected ~(config : Workspace.config) meta ~streak ~threshold =
   with
   | Ok paused_meta ->
     Log.Keeper.warn
-      "%s: no_progress loop escalated to blocker and manual pause \
+      "%s: no_progress loop escalated to blocker and operator-resume pause \
        (streak=%d threshold=%d)"
       meta.name
       streak

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -61,11 +61,16 @@ let no_work_budget_threshold_override
     | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
   in
   let no_work_scope = (not has_current_task) && active_goal_ids = [] in
+  let actionable_signal =
+    Keeper_contract_classifier.classify_actionable_signal
+      (Keeper_contract_classifier.of_keeper_world_observation observation)
+  in
   if
     budget_exhausted
     && no_work_scope
     && (not strong_evidence)
     && surface_requires_evidence
+    && actionable_signal <> Keeper_contract_classifier.No_actionable_signal
     && Keeper_unified_metrics_support.is_scheduled_autonomous_cycle_of_observation
          observation
   then Some 1

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -346,8 +346,19 @@ let composite_execution_config_drift execution =
 
 let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_activation_readiness_json
 
+let composite_execution_passive_only_without_work_scope execution =
+  match completion_contract_result_of_execution execution with
+  | Some Contract_passive_only ->
+    Option.is_none (json_string "current_task_id" execution)
+    && Json_util.json_string_list_member "goal_ids" execution = []
+  | Some _ | None -> false
+;;
+
 let composite_execution_completion_unsatisfied_reason execution =
   match completion_contract_result_of_execution execution with
+  | Some Contract_passive_only
+    when composite_execution_passive_only_without_work_scope execution ->
+    None
   | Some
       ( Completion_contract_result.Violated
       | Completion_contract_result.Claim_only_after_owned_task
@@ -360,6 +371,9 @@ let composite_execution_completion_unsatisfied_reason execution =
 
 let composite_execution_budget_unsatisfied_reason execution =
   match completion_contract_result_of_execution execution with
+  | Some Contract_passive_only
+    when composite_execution_passive_only_without_work_scope execution ->
+    None
   | Some
       (* TEL-OK: pure dashboard classifier; maps typed receipt labels to a
          display reason without performing an action. *)

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -173,7 +173,7 @@ let test_no_progress_loop_detection_pauses_keeper () =
           check
             string
             "blocker detail"
-            "no_progress loop detected: streak=10 threshold=10; keeper paused until operator resume clears the no-progress latch"
+            "no_progress loop detected: streak=10 threshold=10; auto-paused after repeated no-evidence turns; operator resume clears the no-progress latch"
             detail
         | Some _ -> fail "expected No_progress_loop blocker"
         | None -> fail "expected no_progress loop blocker");

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -165,9 +165,9 @@ let test_no_progress_loop_detection_pauses_keeper () =
        check bool "returned meta paused" true paused_meta.paused;
        check
          (option (float 0.001))
-         "manual pause has no auto-resume"
+         "safety pause has no auto-resume"
          None
-       paused_meta.auto_resume_after_sec;
+         paused_meta.auto_resume_after_sec;
        (match paused_meta.runtime.last_blocker with
         | Some { Keeper_meta_contract.klass = No_progress_loop; detail } ->
           check
@@ -338,7 +338,7 @@ let test_idle_detected_repeated_failure_pauses_keeper () =
          check bool "registry meta paused" true paused_meta.paused;
          check
            (option (float 0.001))
-           "manual pause has no auto-resume"
+           "safety pause has no auto-resume"
            None
            paused_meta.auto_resume_after_sec;
          (match paused_meta.runtime.last_blocker with
@@ -346,7 +346,7 @@ let test_idle_detected_repeated_failure_pauses_keeper () =
             check
               string
               "blocker detail"
-              "idle loop detected: consecutive_idle_turns=4; manual pause applied"
+              "idle loop detected: consecutive_idle_turns=4; auto-paused after repeated idle turns; operator resume clears the idle latch"
               detail
           | Some _ -> fail "expected Sdk_idle_detected blocker"
           | None -> fail "expected idle-detected blocker")

--- a/test/test_keeper_runtime_trust_snapshot.ml
+++ b/test/test_keeper_runtime_trust_snapshot.ml
@@ -351,6 +351,56 @@ let test_legacy_satisfied_completion_contract_result_is_unknown () =
          (snapshot |> member "execution" |> member "mutation_guard_summary" |> to_string))
 ;;
 
+let test_passive_only_no_work_receipt_does_not_mark_attention () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> remove_tree base_dir)
+    (fun () ->
+       with_env "MASC_BASE_PATH" base_dir
+       @@ fun () ->
+       let config = Masc.Workspace.default_config base_dir in
+       init_runtime_default_for_tests ();
+       let keeper_name = "runtime-trust-passive-only-no-work" in
+       let meta = make_meta keeper_name in
+       let receipt_store =
+         Masc.Keeper_types_support.keeper_execution_receipt_store config keeper_name
+       in
+       Dated_jsonl.append
+         receipt_store
+         (`Assoc
+             [ "ended_at", `String "2026-06-01T00:00:00Z"
+             ; "operator_disposition", `String "pass"
+             ; "operator_disposition_reason", `String "healthy"
+             ; "terminal_reason_code", `String "completed"
+             ; "completion_contract_result", `String "passive_only"
+             ; "current_task_id", `Null
+             ; "goal_ids", `List []
+             ]);
+       let snapshot = K.snapshot_json ~config ~meta in
+       let open Yojson.Safe.Util in
+       Alcotest.(check string)
+         "display disposition"
+         "Pass"
+         (snapshot |> member "disposition" |> to_string);
+       Alcotest.(check string)
+         "display reason"
+         "healthy"
+         (snapshot |> member "disposition_reason" |> to_string);
+       Alcotest.(check bool)
+         "needs attention"
+         false
+         (snapshot |> member "needs_attention" |> to_bool);
+       Alcotest.(check bool)
+         "attention reason omitted"
+         true
+         (match snapshot |> member "attention_reason" with
+          | `Null -> true
+          | _ -> false))
+;;
+
 let test_completion_blocker_supersedes_passive_only_receipt () =
   Eio_main.run
   @@ fun env ->
@@ -555,6 +605,10 @@ let () =
             "unknown completion-contract result remains visible"
             `Quick
             test_unknown_completion_contract_result_stays_visible
+        ; Alcotest.test_case
+            "passive-only no-work receipt does not mark attention"
+            `Quick
+            test_passive_only_no_work_receipt_does_not_mark_attention
         ; Alcotest.test_case
             "runtime blocker supersedes passive-only receipt"
             `Quick

--- a/test/test_keeper_status_bridge.ml
+++ b/test/test_keeper_status_bridge.ml
@@ -20,6 +20,21 @@ let blocker_of_summary summary =
   Keeper_status_bridge.runtime_blocker_surface_opt config (meta_with_summary summary)
 ;;
 
+let blocker_of_typed_last_blocker klass ~detail =
+  let config = Workspace.default_config "/tmp/masc-test-status-bridge" in
+  let meta = meta_with_summary "" in
+  let meta =
+    { meta with
+      runtime =
+        { meta.runtime with
+          last_blocker =
+            Some (Keeper_meta_contract.blocker_info_of_class ~detail klass)
+        }
+    }
+  in
+  Keeper_status_bridge.runtime_blocker_surface_opt config meta
+;;
+
 let write_file path content =
   let oc = open_out path in
   Fun.protect
@@ -76,6 +91,30 @@ let test_synthetic_narrative_is_not_runtime_blocker_source () =
     (Option.map (fun b -> b.Keeper_status_bridge.blocker_class) (blocker_of_summary summary))
 ;;
 
+let test_no_progress_loop_summary_normalizes_legacy_detail () =
+  let legacy_detail =
+    "no_progress loop detected: streak=10 threshold=10; manual pause applied"
+  in
+  match
+    blocker_of_typed_last_blocker Keeper_meta_contract.No_progress_loop
+      ~detail:legacy_detail
+  with
+  | Some blocker ->
+    Alcotest.(check string)
+      "blocker class"
+      "no_progress_loop"
+      blocker.Keeper_status_bridge.blocker_class;
+    Alcotest.(check bool)
+      "normalizes legacy manual pause text"
+      false
+      (String_util.contains_substring_ci blocker.summary "manual pause");
+    Alcotest.(check bool)
+      "names progress safety latch"
+      true
+      (String_util.contains_substring_ci blocker.summary "progress-safety latch")
+  | None -> Alcotest.fail "expected no_progress_loop blocker"
+;;
+
 let defaults_with_prompt_fields =
   { Keeper_types_profile.empty_keeper_profile_defaults with
     manifest_path = Some "/tmp/keeper.toml";
@@ -130,6 +169,10 @@ let () =
             "synthetic narrative is not blocker source"
             `Quick
             test_synthetic_narrative_is_not_runtime_blocker_source;
+          Alcotest.test_case
+            "no-progress loop summary normalizes legacy detail"
+            `Quick
+            test_no_progress_loop_summary_normalizes_legacy_detail;
         ] );
       ( "profile default override provenance",
         [

--- a/test/test_keeper_terminal_reason_typed.ml
+++ b/test/test_keeper_terminal_reason_typed.ml
@@ -395,6 +395,24 @@ let disp_pair_to_string (d, r) =
     (R.operator_disposition_reason_to_string r)
 ;;
 
+let intentional_passive_only_no_work_policy_change (receipt : R.t) got =
+  if
+    receipt.completion_contract_result = R.Contract_passive_only
+    && Option.is_none receipt.current_task_id
+    && receipt.goal_ids = []
+  then (
+    let terminal_reason = String.lowercase_ascii receipt.terminal_reason_code in
+    match terminal_reason, receipt.outcome, got with
+    | code, `Ok, (R.Disp_pass, R.Reason_turn_budget_exhausted)
+      when String.starts_with ~prefix:"turn_budget_exhausted" code ->
+      true
+    | ("completed" | "success"), `Ok, (R.Disp_pass, R.Reason_healthy)
+      when receipt.runtime_outcome = R.Runtime_completed ->
+      true
+    | _ -> false)
+  else false
+;;
+
 (* To keep the product bounded we vary the most behaviour-determining axes
    fully and pin the others to representative values per code, plus a
    focused sub-matrix over the provider/route axes. *)
@@ -434,6 +452,10 @@ let () =
                                        R.operator_disposition receipt
                                      in
                                      if want <> got
+                                        && not
+                                             (intentional_passive_only_no_work_policy_change
+                                                receipt
+                                                got)
                                      then (
                                        incr mismatches;
                                        if !mismatches <= 20
@@ -501,10 +523,21 @@ let () =
     }
   in
   let got = R.operator_disposition passive_receipt in
+  let want = R.Disp_pass, R.Reason_turn_budget_exhausted in
+  check
+    (Printf.sprintf
+       "no-work passive turn budget exhaustion want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want);
+  let active_passive_receipt =
+    { passive_receipt with current_task_id = Some "TASK-1" }
+  in
+  let got = R.operator_disposition active_passive_receipt in
   let want = R.Disp_alert_exhausted, R.Reason_turn_budget_exhausted in
   check
     (Printf.sprintf
-       "passive turn budget exhaustion want=%s got=%s"
+       "active passive turn budget exhaustion want=%s got=%s"
        (disp_pair_to_string want)
        (disp_pair_to_string got))
     (got = want);
@@ -533,10 +566,19 @@ let () =
     }
   in
   let got = R.operator_disposition receipt in
+  let want = R.Disp_pass, R.Reason_healthy in
+  check
+    (Printf.sprintf
+       "completed no-work passive-only receipt want=%s got=%s"
+       (disp_pair_to_string want)
+       (disp_pair_to_string got))
+    (got = want);
+  let active_receipt = { receipt with current_task_id = Some "TASK-1" } in
+  let got = R.operator_disposition active_receipt in
   let want = R.Disp_pause_human, R.Reason_completion_contract_unsatisfied in
   check
     (Printf.sprintf
-       "completed passive-only receipt want=%s got=%s"
+       "completed active passive-only receipt want=%s got=%s"
        (disp_pair_to_string want)
        (disp_pair_to_string got))
     (got = want)

--- a/test/test_keeper_turn_driver_accept.ml
+++ b/test/test_keeper_turn_driver_accept.ml
@@ -630,6 +630,12 @@ let test_historical_mutation_does_not_block_current_read_only_retry () =
     (Masc.Keeper_turn_driver.For_testing
      .accept_no_progress_read_only_should_try_next
        err);
+  Alcotest.(check bool)
+    "non-last read-only accept rejection advances provider candidate"
+    true
+    (Masc.Keeper_turn_driver.For_testing.accept_rejected_result_should_try_next
+       ~is_last:false
+       err);
   Alcotest.(check (option string))
     "current read-only no-progress classified by internal-error SSOT"
     (Some "read_only_no_progress")
@@ -696,6 +702,12 @@ let test_thinking_only_after_read_only_webfetch_can_try_next_candidate () =
     true
     (Masc.Keeper_turn_driver.For_testing
      .accept_no_progress_read_only_should_try_next
+       err);
+  Alcotest.(check bool)
+    "non-last read-only WebFetch accept rejection advances provider candidate"
+    true
+    (Masc.Keeper_turn_driver.For_testing.accept_rejected_result_should_try_next
+       ~is_last:false
        err);
   Alcotest.(check (option string))
     "thinking-only after read-only tool is runtime-recoverable"
@@ -1594,6 +1606,18 @@ let test_empty_non_end_turn_response_is_rejected () =
     true
     (Masc.Keeper_turn_driver.For_testing.accept_no_progress_should_try_next err);
   Alcotest.(check bool)
+    "non-last empty accept rejection advances provider candidate"
+    true
+    (Masc.Keeper_turn_driver.For_testing.accept_rejected_result_should_try_next
+       ~is_last:false
+       err);
+  Alcotest.(check bool)
+    "last empty accept rejection stays terminal"
+    false
+    (Masc.Keeper_turn_driver.For_testing.accept_rejected_result_should_try_next
+       ~is_last:true
+       err);
+  Alcotest.(check bool)
     "empty no-progress is not a read-only retry"
     false
     (Masc.Keeper_turn_driver.For_testing
@@ -1667,6 +1691,12 @@ let test_empty_after_workspace_mutation_stays_terminal () =
     "empty response after mutation does not try next candidate"
     false
     (Masc.Keeper_turn_driver.For_testing.accept_no_progress_should_try_next err);
+  Alcotest.(check bool)
+    "mutating accept rejection does not advance provider candidate"
+    false
+    (Masc.Keeper_turn_driver.For_testing.accept_rejected_result_should_try_next
+       ~is_last:false
+       err);
   Alcotest.(check (option string))
     "empty response after mutation is not runtime-recoverable"
     None

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -138,9 +138,15 @@ let test_threshold_override_fires_early () =
   Alcotest.(check int) "streak retained" 1 (D.current_streak ~keeper_name:k)
 
 let test_no_work_budget_override_predicate () =
-  Alcotest.(check (option int)) "scheduled no-work budget exhaustion fast-fails"
-    (Some 1)
+  Alcotest.(check (option int)) "scheduled no-work budget exhaustion keeps default threshold"
+    None
     (no_work_budget_override scheduled_observation);
+  let actionable_observation =
+    { scheduled_observation with claimable_task_count = 1 }
+  in
+  Alcotest.(check (option int)) "scheduled actionable budget exhaustion fast-fails"
+    (Some 1)
+    (no_work_budget_override actionable_observation);
   let reactive_observation =
     { scheduled_observation with pending_mentions = [ ("operator", "wake") ] }
   in

--- a/test/test_server_dashboard_composite_attention.ml
+++ b/test/test_server_dashboard_composite_attention.ml
@@ -48,6 +48,24 @@ let passive_budget_execution =
     ; "operator_disposition", `String "pass"
     ; "operator_disposition_reason", `String "healthy"
     ; "terminal_reason_code", `String "turn_budget_exhausted:1070/1070"
+    ; "current_task_id", `Null
+    ; "goal_ids", `List []
+    ; "error", `Null
+    ; "claim_scope", `Assoc [ "status", `String "ok" ]
+    ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
+    ]
+;;
+
+let active_passive_budget_execution =
+  `Assoc
+    [ "latest_receipt_present", `Bool true
+    ; "recorded_at", `String "2999-01-01T00:00:00Z"
+    ; "completion_contract_result", `String "passive_only"
+    ; "operator_disposition", `String "pass"
+    ; "operator_disposition_reason", `String "healthy"
+    ; "terminal_reason_code", `String "turn_budget_exhausted:1070/1070"
+    ; "current_task_id", `String "TASK-1"
+    ; "goal_ids", `List []
     ; "error", `Null
     ; "claim_scope", `Assoc [ "status", `String "ok" ]
     ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
@@ -62,6 +80,24 @@ let completed_passive_execution =
     ; "operator_disposition", `String "pass"
     ; "operator_disposition_reason", `String "healthy"
     ; "terminal_reason_code", `String "completed"
+    ; "current_task_id", `Null
+    ; "goal_ids", `List []
+    ; "error", `Null
+    ; "claim_scope", `Assoc [ "status", `String "ok" ]
+    ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
+    ]
+;;
+
+let active_completed_passive_execution =
+  `Assoc
+    [ "latest_receipt_present", `Bool true
+    ; "recorded_at", `String "2999-01-01T00:00:00Z"
+    ; "completion_contract_result", `String "passive_only"
+    ; "operator_disposition", `String "pass"
+    ; "operator_disposition_reason", `String "healthy"
+    ; "terminal_reason_code", `String "completed"
+    ; "current_task_id", `String "TASK-1"
+    ; "goal_ids", `List []
     ; "error", `Null
     ; "claim_scope", `Assoc [ "status", `String "ok" ]
     ; "config_drift", `Assoc [ "runtime_override", `Bool false ]
@@ -153,11 +189,23 @@ let test_completed_budget_exhaustion_is_not_blocked () =
   check (option string) "reason" None attention.cra_reason
 ;;
 
-let test_passive_budget_exhaustion_is_blocked () =
+let test_passive_budget_exhaustion_without_work_scope_is_not_blocked () =
   let attention =
     Server_dashboard_http_composite.composite_runtime_attention
       ~snapshot
       ~execution:passive_budget_execution
+  in
+  check bool "blocked" false attention.cra_blocked;
+  check bool "needs_attention" false attention.cra_needs_attention;
+  check string "state" "ok" attention.cra_state;
+  check (option string) "reason" None attention.cra_reason
+;;
+
+let test_active_passive_budget_exhaustion_is_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:active_passive_budget_execution
   in
   check bool "blocked" true attention.cra_blocked;
   check bool "needs_attention" true attention.cra_needs_attention;
@@ -169,11 +217,23 @@ let test_passive_budget_exhaustion_is_blocked () =
     attention.cra_reason
 ;;
 
-let test_completed_passive_receipt_is_blocked () =
+let test_completed_passive_receipt_without_work_scope_is_not_blocked () =
   let attention =
     Server_dashboard_http_composite.composite_runtime_attention
       ~snapshot
       ~execution:completed_passive_execution
+  in
+  check bool "blocked" false attention.cra_blocked;
+  check bool "needs_attention" false attention.cra_needs_attention;
+  check string "state" "ok" attention.cra_state;
+  check (option string) "reason" None attention.cra_reason
+;;
+
+let test_active_completed_passive_receipt_is_blocked () =
+  let attention =
+    Server_dashboard_http_composite.composite_runtime_attention
+      ~snapshot
+      ~execution:active_completed_passive_execution
   in
   check bool "blocked" true attention.cra_blocked;
   check bool "needs_attention" true attention.cra_needs_attention;
@@ -217,13 +277,21 @@ let () =
             `Quick
             test_completed_budget_exhaustion_is_not_blocked
         ; test_case
-            "passive turn-budget exhaustion is blocked"
+            "passive turn-budget exhaustion without work scope is not blocked"
             `Quick
-            test_passive_budget_exhaustion_is_blocked
+            test_passive_budget_exhaustion_without_work_scope_is_not_blocked
         ; test_case
-            "completed passive receipt is blocked"
+            "active passive turn-budget exhaustion is blocked"
             `Quick
-            test_completed_passive_receipt_is_blocked
+            test_active_passive_budget_exhaustion_is_blocked
+        ; test_case
+            "completed passive receipt without work scope is not blocked"
+            `Quick
+            test_completed_passive_receipt_without_work_scope_is_not_blocked
+        ; test_case
+            "active completed passive receipt is blocked"
+            `Quick
+            test_active_completed_passive_receipt_is_blocked
         ; test_case
             "not-dispatched turn-budget exhaustion is blocked"
             `Quick


### PR DESCRIPTION
## Summary
- continue the runtime provider candidate loop when a provider returns a response that fails the accept contract with typed no-progress recovery hints
- treat passive-only turns with no current task and no active goals as idle/no-work receipts instead of operator-blocking completion-contract failures
- keep active task/goal passive-only receipts blocked, and keep explicit runtime blockers authoritative over benign idle receipts
- avoid immediate no-progress latch on scheduled no-work budget exhaustion unless the world observation has an actionable signal
- normalize no-progress / idle safety-pause blocker summaries so legacy persisted `manual pause applied` / raw latch details do not surface as fake provider/runtime failures in dashboard surfaces

## Why
Live keepers can surface accept_rejected / no_usable_progress with response_shape=empty as a terminal keeper request failure even when other provider candidates are available. Separately, a scheduled no-work/passive-only turn could be promoted into alert_exhausted / pause_human and `attention_reason=passive_only`, which made Play look like it immediately paused on a serious runtime error. Persisted no-progress blockers could also keep showing stale "manual pause" wording after the underlying classification changed.

## Validation
- rebased onto `origin/main` `0b1432a368c`
- `git diff --check`
- `ocamlformat --check` on touched OCaml files
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty false`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/lib/keeper-attention-labels.test.ts src/components/overview/overview.test.ts src/components/keeper-detail-alert-strip.test.ts src/components/fleet-health-panel.test.ts src/components/fleet-telemetry-utils.test.ts src/components/ide/ide-keeper-work-panel.test.ts src/lib/keeper-runtime-display.test.ts src/components/mission-agent-cards.test.ts` (288 tests)
- earlier focused Dune suite before the final rebase passed:
  - `scripts/dune-local.sh build test/test_no_progress_loop_detector.exe test/test_keeper_terminal_reason_typed.exe test/test_keeper_runtime_trust_snapshot.exe test/test_server_dashboard_composite_attention.exe test/test_keeper_auto_pause_blocker_persist_12683.exe test/test_keeper_status_bridge.exe`
  - `./_build/default/test/test_no_progress_loop_detector.exe` (26 tests)
  - `./_build/default/test/test_keeper_terminal_reason_typed.exe` (matrix cases=224640 mismatches=0)
  - `./_build/default/test/test_keeper_runtime_trust_snapshot.exe` (8 tests)
  - `./_build/default/test/test_server_dashboard_composite_attention.exe` (8 tests)
  - `./_build/default/test/test_keeper_auto_pause_blocker_persist_12683.exe` (11 tests)
  - `./_build/default/test/test_keeper_status_bridge.exe` (5 tests)
- final post-rebase Dune rerun was not forced locally because `scripts/dune-local.sh` detected unrelated bare `dune build .` process `14893`; CI is the build authority for head `b9588d2d6e3`
