### PR TITLE
[iter-4] refactor(dashboard): lift keeper FSM lookup tables to KeeperPhase closed-sum

### DIFF
--- a/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts
@@ -32,11 +32,11 @@ import { Pill } from '../v2/primitives-v2'
 import {
   WorkspaceSigil,
   StatusDot,
-  keeperBucket,
   keeperStatusTone,
   keeperPhaseLabel,
   statePillTone,
 } from './keeper-workspace-shared'
+import { phasePulse } from '../v2/keeper-fsm'
 
 const LazySharedTurnInspectorDrawer = lazy(async () => ({
   default: (await import('../keeper-turn-inspector-drawer')).TurnInspectorDrawer,
@@ -319,10 +319,9 @@ function ChatHeader({
   onOpenRail?: () => void
   onOpenConfig?: () => void
 }): VNode {
-  const bucket = keeperBucket(keeper)
   const tone = keeperStatusTone(keeper)
   const pill = statePillTone(tone)
-  const live = bucket === 'running'
+  const live = phasePulse(keeper.lifecycle_phase)
 
   // Single-row header: identity + status + actions only. Runtime / model /
   // throughput / scope live in the context rail (ThroughputSection) — the

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts
@@ -24,6 +24,7 @@ import {
   phaseTokenFromKeeper,
   keeperRuntimeLabel,
 } from './keeper-workspace-shared'
+import { phasePulse } from '../v2/keeper-fsm'
 import { runKeeperAction, type KeeperActionKey } from '../keeper-action-panel'
 import { CountBadge } from '../v2/primitives-v2'
 import { callMcpTool } from '../../api/mcp'
@@ -177,16 +178,19 @@ function FleetSelectedSection({ keeper }: { keeper: Keeper }): VNode {
   const phase = keeperPhaseLabel(keeper)
   const model = keeperModelLabel(keeper)
   const runtime = keeperRuntimeLabel(keeper)
-  const bucket = keeperBucket(keeper)
   const tone = keeperFleetTone(keeper)
   const lifecycle = keeper.phase || keeper.lifecycle_phase || keeper.status
+  // Phase-driven beat (prototype PHASE_PULSE SSOT). Coarse `bucket === 'running'`
+  // used to mark Draining as beating, which is wrong: Draining is warn-tone
+  // but static. phasePulse is the canonical 5-phase pulsing set.
+  const beat = phasePulse(lifecycle)
   const actions = fleetLifecycleActions(keeper).filter(action => action !== 'shutdown').slice(0, 3)
   const [pendingAction, setPendingAction] = useState<KeeperActionKey | null>(null)
 
   return html`
     <div class="kw-fleet-aside" data-tone=${tone}>
       <div class="kw-fleet-aside-head">
-        <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${bucket === 'running'} />
+        <${WorkspaceSigil} id=${keeper.name} size=${40} beat=${beat} />
         <div class="kw-fleet-aside-title">
           <span class="kw-fleet-aside-kicker">Selected runtime</span>
           <strong title=${keeper.agent_name || keeper.name}>${keeper.koreanName || keeper.agent_name || keeper.name}</strong>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.test.ts
@@ -455,4 +455,56 @@ describe('KeeperWorkspaceRoster', () => {
     fireEvent.scroll(document)
     expect(host.querySelector('[data-testid="kw-roster-menu"]')).toBeNull()
   })
+
+  // Regression coverage for the iter-4 PHASE_PULSE SSOT migration. The
+  // row head sigil and the row StatusDot must derive their pulse/beat state
+  // from `phasePulse(lifecycle_phase)` (closed-sum SSOT in keeper-fsm.ts),
+  // NOT from the coarse `status === 'running'` predicate. The Draining case
+  // is the load-bearing one: status='running' but lifecycle_phase='Draining'
+  // — the old coarse predicate would have incorrectly pulsed it.
+  it('does not pulse the row StatusDot or head sigil for a Draining keeper', () => {
+    keepers.value = [mk({ name: 'draining', status: 'running', lifecycle_phase: 'Draining' })]
+    render(html`<${KeeperWorkspaceRoster} activeName="draining" />`, host)
+
+    const row = host.querySelector('.kw-kp-row.kp-row') as HTMLElement
+    expect(row).not.toBeNull()
+
+    const dot = row.querySelector('.kw-kp-state > span') as HTMLElement
+    expect(dot).not.toBeNull()
+    expect(dot.className).toMatch(/\bkw-dot\b/)
+    expect(dot.className).not.toMatch(/\bpulse\b/)
+
+    const headSigil = row.querySelector(':scope > .kw-sigil') as HTMLElement
+    expect(headSigil).not.toBeNull()
+    expect(headSigil.className).toMatch(/\bkw-sigil\b/)
+    expect(headSigil.className).not.toMatch(/kw-sigil-beat/)
+  })
+
+  it('does not beat the menu-head WorkspaceSigil for a Draining keeper', () => {
+    keepers.value = [mk({ name: 'draining', status: 'running', lifecycle_phase: 'Draining' })]
+    render(html`<${KeeperWorkspaceRoster} activeName="draining" />`, host)
+
+    fireEvent.click(host.querySelector('[data-testid="kw-roster-menu-draining"]') as HTMLButtonElement)
+
+    const menuHead = host.querySelector('[data-testid="kw-roster-menu"] .kw-kp-menu-head') as HTMLElement
+    expect(menuHead).not.toBeNull()
+    const sigil = menuHead.querySelector('.kw-sigil') as HTMLElement
+    expect(sigil).not.toBeNull()
+    expect(sigil.className).toMatch(/\bkw-sigil\b/)
+    expect(sigil.className).not.toMatch(/kw-sigil-beat/)
+  })
+
+  it('pulses the row sigil and StatusDot for an actively Running keeper (positive control)', () => {
+    keepers.value = [mk({ name: 'active', status: 'running', lifecycle_phase: 'Running' })]
+    render(html`<${KeeperWorkspaceRoster} activeName="active" />`, host)
+
+    const row = host.querySelector('.kw-kp-row.kp-row') as HTMLElement
+    expect(row).not.toBeNull()
+
+    const headSigil = row.querySelector(':scope > .kw-sigil') as HTMLElement
+    expect(headSigil.className).toMatch(/kw-sigil-beat/)
+
+    const dot = row.querySelector('.kw-kp-state > span') as HTMLElement
+    expect(dot.className).toMatch(/\bpulse\b/)
+  })
 })

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -37,6 +37,7 @@ import {
   keeperPhaseLabel,
   type KeeperBucket,
 } from './keeper-workspace-shared'
+import { phasePulse } from '../v2/keeper-fsm'
 
 type RosterFilter = 'all' | 'run' | 'att'
 type RosterSort = 'status' | 'name' | 'att'
@@ -263,6 +264,7 @@ function RosterRow({
   const activityText = rosterActivityText(activity)
   const recentTool = keeperRecentTool(keeper)
   const phaseLabel = keeperPhaseLabel(keeper)
+  const beat = phasePulse(keeper.lifecycle_phase)
   const select = () => onSelect(keeper.name)
   return html`
     <div
@@ -280,7 +282,7 @@ function RosterRow({
         select()
       }}
     >
-      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
+      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${beat} />
       <div class="kw-kp-meta">
         <div class="kw-kp-name">${keeper.koreanName ?? keeper.name}</div>
         <div class="kw-kp-sub">
@@ -337,8 +339,9 @@ function MiniRosterRow({
   onSelect: (name: string) => void
   onMenu: (keeper: Keeper, event: MouseEvent) => void
 }) {
-  const bucket = keeperBucket(keeper)
   const tone = keeperStatusTone(keeper)
+  const lifecycle = keeper.phase || keeper.lifecycle_phase
+  const beat = phasePulse(lifecycle)
   const label = `${keeper.name} · ${keeperPhaseLabel(keeper)}`
   return html`
     <button
@@ -350,8 +353,8 @@ function MiniRosterRow({
       onClick=${() => onSelect(keeper.name)}
       onContextMenu=${(event: MouseEvent) => onMenu(keeper, event)}
     >
-      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${bucket === 'running'} />
-      <${StatusDot} tone=${tone} pulse=${bucket === 'running'} />
+      <${WorkspaceSigil} id=${keeper.name} size=${38} beat=${beat} />
+      <${StatusDot} tone=${tone} pulse=${beat} />
     </button>
   `
 }

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts
@@ -245,7 +245,6 @@ function RosterRow({
   onMenu: (keeper: Keeper, event: MouseEvent) => void
   style?: string
 }) {
-  const bucket = keeperBucket(keeper)
   const tone = keeperFleetTone(keeper)
   const att = attentionCount(keeper)
   const scope = keeperScope(keeper)
@@ -286,7 +285,7 @@ function RosterRow({
       <div class="kw-kp-meta">
         <div class="kw-kp-name">${keeper.koreanName ?? keeper.name}</div>
         <div class="kw-kp-sub">
-          <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${bucket === 'running'} />${phaseLabel}</span>
+          <span class="kw-kp-state"><${StatusDot} tone=${tone} pulse=${beat} />${phaseLabel}</span>
           ${handle ? html`<span aria-hidden="true">·</span><span class="kw-kp-handle kp-handle" title=${handleTitle}>${handle}</span>` : null}
         </div>
         ${contextPct !== null
@@ -420,7 +419,7 @@ function KeeperRosterMenu({
       data-testid="kw-roster-menu"
     >
       <div class="kw-kp-menu-head v2-monitoring-toolbar">
-        <${WorkspaceSigil} id=${keeper.name} size=${22} beat=${keeperBucket(keeper) === 'running'} />
+        <${WorkspaceSigil} id=${keeper.name} size=${22} beat=${phasePulse(keeper.lifecycle_phase)} />
         <span>${keeper.name}</span>
       </div>
       <button type="button" role="menuitem" class="kw-kp-menu-item" onClick=${select} data-testid="kw-roster-menu-open-chat">

--- a/dashboard/src/components/v2/keeper-fsm.test.ts
+++ b/dashboard/src/components/v2/keeper-fsm.test.ts
@@ -1,0 +1,146 @@
+// Closed-sum regression test for the keeper FSM SSOT lift.
+//
+// The four lookup tables (PHASE_TONE, PHASE_PULSE, PHASE_INFO, FSM_ACTIONS) and
+// the two coarse sets (RUN_PHASES, PAUSE_PHASES) MUST cover every variant of
+// `KeeperPhase` (types/core.ts). A new variant added to `KeeperPhase` without
+// updating `keeper-fsm.ts` will (a) fail `tsc --noEmit` for `Record<KeeperPhase,
+// …>` tables and (b) fail this test which enumerates them at runtime.
+//
+// Why: prototype `data.jsx:36-45` ships 12 phases; the live wire adds `Zombie`
+// as a 13th. Without the closed-sum guard, a wire string like 'constructor'
+// would slip through `phase in PHASE_TONE` via the JS prototype chain (the
+// very bug the iter-4 SSOT lift closed in fleet-tone.ts). The
+// `isKeeperPhase` registry closes the same hole here.
+import { describe, expect, it } from 'vitest'
+import type { KeeperPhase } from '../../types/core'
+import {
+  FSM_STATES,
+  phaseInfo,
+  phasePulse,
+  phaseStatus,
+  phaseTone,
+  fsmActions,
+} from './keeper-fsm'
+
+// The 13 canonical PascalCase tokens of `KeeperPhase` (live wire).
+const ALL_PHASES: readonly KeeperPhase[] = [
+  'Offline',
+  'Restarting',
+  'Running',
+  'Compacting',
+  'HandingOff',
+  'Failing',
+  'Overflowed',
+  'Draining',
+  'Paused',
+  'Stopped',
+  'Crashed',
+  'Dead',
+  'Zombie',
+]
+
+describe('keeper-fsm SSOT closed-sum', () => {
+  it('FSM_STATES matches the prototype 12-phase set (no Zombie)', () => {
+    expect(new Set(FSM_STATES)).toEqual(new Set([
+      'Offline', 'Restarting', 'Running', 'Compacting', 'HandingOff',
+      'Failing', 'Overflowed', 'Draining', 'Paused', 'Stopped',
+      'Crashed', 'Dead',
+    ]))
+  })
+
+  it.each(ALL_PHASES)('phaseTone(%s) returns a FleetTone', (phase) => {
+    const tone = phaseTone(phase)
+    expect(['ok', 'warn', 'bad', 'busy', 'idle']).toContain(tone)
+  })
+
+  it.each(ALL_PHASES)('phasePulse(%s) returns a boolean', (phase) => {
+    const pulse = phasePulse(phase)
+    expect(typeof pulse).toBe('boolean')
+  })
+
+  it('PHASE_PULSE: only the 5 active/transient phases pulse (prototype verbatim)', () => {
+    const expectedPulsing = new Set<KeeperPhase>([
+      'Running', 'Compacting', 'HandingOff', 'Restarting', 'Failing',
+    ])
+    for (const phase of ALL_PHASES) {
+      expect(phasePulse(phase)).toBe(expectedPulsing.has(phase))
+    }
+  })
+
+  it.each(ALL_PHASES)('phaseInfo(%s) returns a non-empty Korean gloss', (phase) => {
+    const info = phaseInfo(phase)
+    expect(typeof info).toBe('string')
+    expect(info.length).toBeGreaterThan(0)
+    expect(info).not.toBe('알 수 없음') // closed-sum means no fallback hit
+  })
+
+  it.each(ALL_PHASES)('phaseStatus(%s) returns a coarse bucket', (phase) => {
+    const status = phaseStatus(phase)
+    expect(['run', 'pause', 'off']).toContain(status)
+  })
+
+  it('phaseStatus buckets: run/pause/off partition (prototype PHASE_STATUS)', () => {
+    const expectedRun = new Set<KeeperPhase>([
+      'Running', 'Compacting', 'HandingOff', 'Restarting', 'Failing',
+    ])
+    const expectedPause = new Set<KeeperPhase>(['Paused', 'Draining'])
+    for (const phase of ALL_PHASES) {
+      if (expectedRun.has(phase)) expect(phaseStatus(phase)).toBe('run')
+      else if (expectedPause.has(phase)) expect(phaseStatus(phase)).toBe('pause')
+      else expect(phaseStatus(phase)).toBe('off')
+    }
+  })
+
+  it.each(ALL_PHASES)('fsmActions(%s) returns a readonly array', (phase) => {
+    const actions = fsmActions(phase)
+    expect(Array.isArray(actions)).toBe(true)
+    // transient / terminal phases expose no actions
+    const transientOrTerminal: ReadonlySet<KeeperPhase> = new Set([
+      'Compacting', 'HandingOff', 'Draining', 'Restarting', 'Dead', 'Zombie',
+    ])
+    if (transientOrTerminal.has(phase)) {
+      expect(actions).toHaveLength(0)
+    }
+  })
+
+  it('rejects unknown wire strings (no prototype-chain leak)', () => {
+    // These are all `Object.prototype` members / arbitrary strings that would
+    // pass `phase in PHASE_xxx` if the lookup tables used plain object
+    // literals instead of `Record<KeeperPhase, …>` + the null-prototype
+    // `isKeeperPhase` guard. They MUST fall back, never throw, never return a
+    // prototype-inherited value.
+    const garbage = [
+      'constructor', 'toString', 'hasOwnProperty', '__proto__',
+      '__defineGetter__', 'valueOf',
+      'unknown-phase', 'RUNNING', 'running', // case-sensitive PascalCase only
+    ]
+    for (const phase of garbage) {
+      // All lookups must return the fallback default (never throw, never
+      // surface an inherited member).
+      expect(['ok', 'warn', 'bad', 'busy', 'idle']).toContain(phaseTone(phase))
+      expect(phasePulse(phase)).toBe(false)
+      expect(['run', 'pause', 'off']).toContain(phaseStatus(phase))
+      expect(fsmActions(phase)).toEqual([])
+      // phaseInfo echoes the unknown raw phase string so the operator still
+      // sees what the wire emitted (debug-friendly).
+      expect(phaseInfo(phase)).toBe(phase)
+    }
+    // Empty string is falsy and falls through to the '알 수 없음' default.
+    // Whitespace and other truthy-but-unknown strings echo back so the
+    // operator can see what the wire emitted.
+    expect(phaseInfo('')).toBe('알 수 없음')
+    for (const phase of [' ', 'phantom']) {
+      expect(phaseInfo(phase)).toBe(phase)
+    }
+  })
+
+  it('null/undefined input returns the display-default fallback', () => {
+    for (const phase of [null, undefined]) {
+      expect(phaseTone(phase)).toBe('idle')
+      expect(phasePulse(phase)).toBe(false)
+      expect(phaseStatus(phase)).toBe('off')
+      expect(fsmActions(phase)).toEqual([])
+      expect(phaseInfo(phase)).toBe('알 수 없음')
+    }
+  })
+})

--- a/dashboard/src/components/v2/keeper-fsm.ts
+++ b/dashboard/src/components/v2/keeper-fsm.ts
@@ -6,6 +6,17 @@
 // `Zombie`, so these tables map directly onto live keeper data. Unknown /
 // null phases fall back to the idle/off bucket (a total display default —
 // the prototype used the same `?? 'idle'` pattern), never throwing.
+//
+// All four lookup tables (PHASE_TONE / PHASE_PULSE / PHASE_INFO / FSM_ACTIONS)
+// key on `KeeperPhase` (PascalCase, 13 entries from types/core.ts:1090). The
+// closed-sum shape means: a future `KeeperPhase` variant added in core.ts
+// fails TypeScript compilation here until this surface catches up — which
+// is the whole point of the SSOT lift in iter-4. Public function signatures
+// still accept `string | null | undefined` so live callers (which may emit
+// unknown wire strings during rollout) keep working; the table access is
+// type-guarded at the read site.
+
+import type { KeeperPhase } from '../../types/core'
 
 export type KeeperTone = 'ok' | 'warn' | 'bad' | 'busy' | 'idle'
 export type KeeperCoarseStatus = 'run' | 'pause' | 'off'
@@ -42,7 +53,7 @@ export const FSM_STATES = [
 ] as const
 
 // phase → status-dot tone (12 phases collapse into 5 buckets).
-const PHASE_TONE: Readonly<Record<string, KeeperTone>> = {
+const PHASE_TONE: Readonly<Record<KeeperPhase, KeeperTone>> = {
   Running: 'ok',
   Paused: 'warn',
   Draining: 'warn',
@@ -59,16 +70,26 @@ const PHASE_TONE: Readonly<Record<string, KeeperTone>> = {
 }
 
 // phase → whether the dot breathes (active/transient phases only).
-const PHASE_PULSE: Readonly<Record<string, boolean>> = {
+// Verbatim from prototype data.jsx:43-45 — 5 of 13 phases pulse.
+const PHASE_PULSE: Readonly<Record<KeeperPhase, boolean>> = {
   Running: true,
   Compacting: true,
   HandingOff: true,
   Restarting: true,
   Failing: true,
+  Paused: false,
+  Draining: false,
+  Overflowed: false,
+  Crashed: false,
+  Dead: false,
+  Stopped: false,
+  Offline: false,
+  Zombie: false,
 }
 
-// phase → KR hover gloss.
-const PHASE_INFO: Readonly<Record<string, string>> = {
+// phase → KR hover gloss. 12 entries verbatim from prototype data.jsx:19-32
+// plus `Zombie` (live-wire-only; classified as bad by PHASE_TONE above).
+const PHASE_INFO: Readonly<Record<KeeperPhase, string>> = {
   Offline: '오프라인 — 실행 중이 아님',
   Restarting: '재시작 중',
   Running: '실행 중 — 작업/라운드 순환',
@@ -90,7 +111,7 @@ const A_STOP: FsmAction = { id: 'stop', label: '중지', glyph: '⏹', via: 'Dra
 // phase → ordered operator actions. Phases absent here (Compacting,
 // HandingOff, Draining, Restarting, Dead, Zombie) expose no action — they are
 // transient or terminal.
-const FSM_ACTIONS: Readonly<Record<string, readonly FsmAction[]>> = {
+const FSM_ACTIONS: Readonly<Partial<Record<KeeperPhase, readonly FsmAction[]>>> = {
   Running: [
     { id: 'pause', label: '일시정지', glyph: '⏸', to: 'Paused', hint: '슈퍼바이저가 잠시 멈춤 — 컨텍스트·소유 태스크 보존, 즉시 재개 가능' },
     { id: 'compact', label: '컴팩션', glyph: '◉', via: 'Compacting', to: 'Running', ms: 1700, hint: '컨텍스트를 지금 압축하고 실행 복귀' },
@@ -120,28 +141,60 @@ const FSM_ACTIONS: Readonly<Record<string, readonly FsmAction[]>> = {
   ],
 }
 
-const RUN_PHASES = new Set(['Running', 'Compacting', 'HandingOff', 'Restarting', 'Failing'])
-const PAUSE_PHASES = new Set(['Paused', 'Draining'])
+const RUN_PHASES: ReadonlySet<KeeperPhase> = new Set<KeeperPhase>([
+  'Running',
+  'Compacting',
+  'HandingOff',
+  'Restarting',
+  'Failing',
+])
+const PAUSE_PHASES: ReadonlySet<KeeperPhase> = new Set<KeeperPhase>(['Paused', 'Draining'])
 
 /** phase → coarse status bucket (mirrors prototype phaseStatus). */
 export function phaseStatus(phase: string | null | undefined): KeeperCoarseStatus {
-  if (phase && RUN_PHASES.has(phase)) return 'run'
-  if (phase && PAUSE_PHASES.has(phase)) return 'pause'
+  if (phase && isKeeperPhase(phase) && RUN_PHASES.has(phase)) return 'run'
+  if (phase && isKeeperPhase(phase) && PAUSE_PHASES.has(phase)) return 'pause'
   return 'off'
 }
 
 export function phaseTone(phase: string | null | undefined): KeeperTone {
-  return (phase && PHASE_TONE[phase]) || 'idle'
+  return (phase && isKeeperPhase(phase) && PHASE_TONE[phase]) || 'idle'
 }
 
 export function phasePulse(phase: string | null | undefined): boolean {
-  return !!(phase && PHASE_PULSE[phase])
+  return !!(phase && isKeeperPhase(phase) && PHASE_PULSE[phase])
 }
 
 export function phaseInfo(phase: string | null | undefined): string {
-  return (phase && PHASE_INFO[phase]) || phase || '알 수 없음'
+  return (phase && isKeeperPhase(phase) && PHASE_INFO[phase]) || phase || '알 수 없음'
 }
 
 export function fsmActions(phase: string | null | undefined): readonly FsmAction[] {
-  return (phase && FSM_ACTIONS[phase]) || []
+  return (phase && isKeeperPhase(phase) && FSM_ACTIONS[phase]) || []
 }
+
+// Closed-sum guard. `phase` arrives from the live wire as `string | null`; we
+// accept only the canonical 13 PascalCase tokens of `KeeperPhase`. Unknown /
+// null falls through to the function-level fallback. Own-property check via
+// a null-prototype registry keeps the closed-sum boundary honest (rejects
+// 'constructor', '__proto__', etc. that would otherwise pass `in KeeperPhase`).
+function isKeeperPhase(phase: string): phase is KeeperPhase {
+  return phase in KEEPER_PHASE_REGISTRY
+}
+const KEEPER_PHASE_REGISTRY: Readonly<Record<string, true>> = Object.freeze(
+  Object.assign(Object.create(null), {
+    Offline: true,
+    Restarting: true,
+    Running: true,
+    Compacting: true,
+    HandingOff: true,
+    Failing: true,
+    Overflowed: true,
+    Draining: true,
+    Paused: true,
+    Stopped: true,
+    Crashed: true,
+    Dead: true,
+    Zombie: true,
+  } as Record<string, true>),
+)


### PR DESCRIPTION
## Summary

`dashboard/src/components/v2/keeper-fsm.ts`의 4개 lookup table과 2개 coarse set을 `Record<string, …>` / `Set<string>` → `Record<KeeperPhase, …>` / `Set<KeeperPhase>`로 SSOT lift. 새 `KeeperPhase` variant 추가 시 컴파일 에러, 프로토타입 체인 누출 (`'constructor'`, `'__proto__'`) 차단.

## 변경 파일 (5 files, +227 / -22)

| 파일 | 변경 |
|------|------|
| `dashboard/src/components/v2/keeper-fsm.ts` | PHASE_TONE/PHASE_PULSE/PHASE_INFO/FSM_ACTIONS `Record<KeeperPhase, …>` + RUN_PHASES/PAUSE_PHASES `Set<KeeperPhase>` + `isKeeperPhase` null-prototype 가드 |
| `dashboard/src/components/v2/keeper-fsm.test.ts` (NEW) | 13×6 closed-sum + prototype-chain leak 가드 + null/undefined fallback 테스트 (70 tests) |
| `dashboard/src/components/keeper-workspace/keeper-workspace-rail.ts` | `beat=${bucket === 'running'}` → `phasePulse(lifecycle)` |
| `dashboard/src/components/keeper-workspace/keeper-workspace-roster.ts` | 동일 패턴 2 callsite (large row + mini row) |
| `dashboard/src/components/keeper-workspace/keeper-workspace-chat.ts` | 동일 패턴 1 callsite (header sigil) |

## 핵심 SSOT 변경

### 1. Closed-sum 컴파일 강제
```ts
// before: 컴파일러가 새 variant 추가 시 silent undefined
const PHASE_TONE: Readonly<Record<string, KeeperTone>> = { ... }

// after: 새 variant 누락 시 컴파일 에러
const PHASE_TONE: Readonly<Record<KeeperPhase, KeeperTone>> = { ... }
```

### 2. Prototype-chain 누출 차단
```ts
// before: 'constructor' in PHASE_TONE → true (Object.prototype)
// after: null-prototype registry로 own-property only 체크
function isKeeperPhase(phase: string): phase is KeeperPhase {
  return phase in KEEPER_PHASE_REGISTRY
}
const KEEPER_PHASE_REGISTRY = Object.freeze(
  Object.assign(Object.create(null), { ... })
)
```

### 3. PHASE_PULSE 13 entry 명시화
이전 코드는 5개 `true`만 정의 → 나머지 8 phase (`Paused`, `Draining`, `Overflowed`, `Crashed`, `Dead`, `Stopped`, `Offline`, `Zombie`)는 `undefined` → `!!undefined` = false 우회. `Record<KeeperPhase, boolean>` closed-sum으로 13개 모두 명시. Prototype `data.jsx:43-45` verbatim.

### 4. 시각적 drift fix (Draining sigil beat)
이전 `beat=${bucket === 'running'}` coarse 매핑은 Draining (warn 톤)을 beat 표시. Prototype과 일치하지 않음. `phasePulse(lifecycle)` 도입 → Draining은 정적 (warn), 5 active/transient phase만 pulse.

## 검증

```bash
cd dashboard && npx tsc --noEmit          # 0 errors
cd dashboard && npx vitest run src/components/v2/keeper-fsm.test.ts src/store-optimistic-keeper.test.ts
                                            # 79/79 passed
cd dashboard && npx eslint src/components/v2/keeper-fsm.ts ...  # 0 errors
```

빌드는 CI에서 확인합니다.

## 의존성

- PR #22466 MERGED (FleetTone SSOT lift) — `KeeperPhaseToken` lowercase 토큰, 본 PR의 PascalCase SSOT와 별개 표면
- types/core.ts `KeeperPhase` 13 entries (PascalCase, line 1090)
- Figma prototype `~/Downloads/v2 4/project/keeper-v2/data.jsx` PHASE_TONE/PHASE_PULSE/PHASE_INFO verbatim

## 관련 메모

- `project-masc-pixel-perfect-iter4-phase-pulse-blocked-20260628` — iter-4 pre-analysis
- `project-masc-pixel-perfect-pr-merge-order-20260628` — 머지 순서 결정

🤖 Generated with [Claude Code](https://claude.com/claude-code)