### PR TITLE
perf(http): build response headers in reverse

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -155,14 +155,21 @@ module Response = struct
   let html_content_type = "text/html; charset=utf-8"
   let json_content_type = "application/json; charset=utf-8"
 
+  let rev_prepend_headers headers acc =
+    List.fold_left (fun acc header -> header :: acc) acc headers
+
   let content_headers ?(before_headers = []) ?(after_headers = [])
       ?(tail_headers = []) ~content_type body =
     let content_length = string_of_int (String.length body) in
-    Httpun.Headers.of_list
-      (before_headers
-       @ [("content-type", content_type); ("content-length", content_length)]
-       @ after_headers
-       @ tail_headers)
+    let headers_rev =
+      let base = rev_prepend_headers before_headers [] in
+      let base =
+        ("content-length", content_length) :: ("content-type", content_type) :: base
+      in
+      let base = rev_prepend_headers after_headers base in
+      rev_prepend_headers tail_headers base
+    in
+    Httpun.Headers.of_rev_list headers_rev
 
   let response ?before_headers ?after_headers ?tail_headers ~content_type status body =
     Httpun.Response.create

--- a/test/test_http_server_eio.ml
+++ b/test/test_http_server_eio.ml
@@ -379,6 +379,46 @@ let test_request_header () =
     (Request.header request "x-custom")
 ;;
 
+let test_response_content_headers_preserve_all_segments () =
+  let headers =
+    Response.content_headers
+      ~before_headers:[ "vary", "accept-encoding" ]
+      ~after_headers:[ "etag", "\"abc\"" ]
+      ~tail_headers:[ "content-encoding", "zstd" ]
+      ~content_type:Response.json_content_type
+      "{}"
+  in
+  Alcotest.(check (list (pair string string)))
+    "header order"
+    [ "vary", "accept-encoding"
+    ; "content-type", Response.json_content_type
+    ; "content-length", "2"
+    ; "etag", "\"abc\""
+    ; "content-encoding", "zstd"
+    ]
+    (Httpun.Headers.to_list headers);
+  Alcotest.(check (option string))
+    "before header"
+    (Some "accept-encoding")
+    (Httpun.Headers.get headers "vary");
+  Alcotest.(check (option string))
+    "content-type"
+    (Some Response.json_content_type)
+    (Httpun.Headers.get headers "content-type");
+  Alcotest.(check (option string))
+    "content-length"
+    (Some "2")
+    (Httpun.Headers.get headers "content-length");
+  Alcotest.(check (option string))
+    "after header"
+    (Some "\"abc\"")
+    (Httpun.Headers.get headers "etag");
+  Alcotest.(check (option string))
+    "tail header"
+    (Some "zstd")
+    (Httpun.Headers.get headers "content-encoding")
+;;
+
 (* ===== Unit Tests for Compression (Compact Protocol v4) ===== *)
 
 let test_compression_skip_small () =
@@ -541,6 +581,13 @@ let request_tests =
   ]
 ;;
 
+let response_tests =
+  [ ( "content_headers preserve all header segments"
+    , `Quick
+    , test_response_content_headers_preserve_all_segments )
+  ]
+;;
+
 (* ===== Late_response classifier (#13059) ===== *)
 
 (* Behavioural regression for the cancellation-vs-late-write race.
@@ -636,6 +683,7 @@ let () =
       "router", router_tests
     ; "config", config_tests
     ; "request", request_tests
+    ; "response", response_tests
     ; "late_response", late_response_tests
     ]
 ;;


### PR DESCRIPTION
## Summary
- build Http_server_eio response headers directly in Httpun's reversed representation
- preserve before/content/after/tail header order without the prior @ concat chain
- add a regression test for segment preservation and header order

## Verification
- git diff --check
- opam exec -- ocamlformat --check lib/http_server_eio.ml test/test_http_server_eio.ml

Full build/test is intentionally left to GitHub CI.