### PR TITLE
fix(eval): anchor verdict store paths to base path

### DIFF
--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -524,10 +524,11 @@ let () =
       error "missing --runtime ID (required for a live run; use --list to inspect the corpus)";
     let base_path = resolve_base cfg.base in
     (* Fail fast: --record-verdicts must target an isolated store, never the live
-       ledger ($MASC_BASE_PATH/data/verdicts). Resolve before any heavy init. *)
+       ledger ($MASC_BASE_PATH/data/verdicts). Relative store paths resolve from
+       the explicit workspace base path, not ambient process cwd. *)
     let verdict_store =
       match
-        Cal.resolve_record_verdicts_store ~cwd:(Sys.getcwd ())
+        Cal.resolve_record_verdicts_store ~cwd:base_path
           ~record_verdicts:cfg.record_verdicts
           ~verdict_store_dir:cfg.verdict_store_dir
           ~live_store_dir:(Some (Filename.concat base_path "data/verdicts"))

--- a/bin/masc_completion_trust_eval.ml
+++ b/bin/masc_completion_trust_eval.ml
@@ -497,10 +497,10 @@ let print_corpus (scenarios : EH.scenario list) =
 ;;
 
 let resolve_base = function
-  | Some p -> p
+  | Some p -> Cal.absolute_workspace_base_path p
   | None -> (
     match Config_dir_resolver.current_env_base_path_opt () with
-    | Some p -> p
+    | Some p -> Cal.absolute_workspace_base_path p
     | None ->
       error "no workspace base path: set MASC_BASE_PATH or pass --base PATH")
 ;;

--- a/lib/eval_calibration.ml
+++ b/lib/eval_calibration.ml
@@ -179,6 +179,12 @@ let normalize_for_store_collision ?cwd raw =
   raw |> lexical_abs ?cwd |> realpath_existing_prefix |> lexical_normalize_abs
 ;;
 
+let absolute_workspace_base_path ?cwd raw =
+  raw
+  |> Env_config_core.normalize_masc_base_path_input
+  |> normalize_for_store_collision ?cwd
+;;
+
 let same_or_child_path ~parent child =
   String.equal child parent
   || (not (String.equal parent "/")

--- a/lib/eval_calibration.mli
+++ b/lib/eval_calibration.mli
@@ -79,6 +79,11 @@ val set_store : base_dir:string -> unit
 val set_store_for_testing : base_dir:string -> unit
 (** Compatibility alias for [set_store] used by tests. *)
 
+val absolute_workspace_base_path : ?cwd:string -> string -> string
+(** Normalize a workspace base path into the absolute path expected by offline
+    eval runners before they derive verdict-store roots from it. Relative paths
+    resolve from [cwd] when supplied, or from the process cwd otherwise. *)
+
 val resolve_record_verdicts_store :
   ?cwd:string ->
   record_verdicts:bool ->

--- a/test/test_eval_calibration.ml
+++ b/test/test_eval_calibration.ml
@@ -522,6 +522,23 @@ let test_store_rejects_live_aliases () =
       | Ok _ -> fail (name ^ " should be rejected as a live-store alias"))
     cases
 
+let test_store_rejects_live_alias_with_relative_base () =
+  let cwd = tmpdir () in
+  let base_path = Cal.absolute_workspace_base_path ~cwd "repo" in
+  match
+    Cal.resolve_record_verdicts_store ~cwd:base_path
+      ~record_verdicts:true
+      ~verdict_store_dir:(Some "data/verdicts")
+      ~live_store_dir:(Some (Filename.concat base_path "data/verdicts"))
+      ()
+  with
+  | Error msg ->
+    check bool "mentions live store" true (contains ~sub:"live" msg);
+    check bool "base path is absolute" false (Filename.is_relative base_path)
+  | Ok _ ->
+    fail
+      "expected relative --base plus relative live verdict dir to be rejected"
+
 let test_store_rejects_live_child () =
   let child = Filename.concat live_store "eval-scratch" in
   match
@@ -656,6 +673,8 @@ let () =
       test_case "rejects empty store dir" `Quick test_store_rejects_empty_dir;
       test_case "rejects live store" `Quick test_store_rejects_live;
       test_case "rejects live store aliases" `Quick test_store_rejects_live_aliases;
+      test_case "rejects relative-base live alias" `Quick
+        test_store_rejects_live_alias_with_relative_base;
       test_case "rejects live store child" `Quick test_store_rejects_live_child;
       test_case "accepts isolated" `Quick test_store_accepts_isolated;
       test_case "no live store -> no collision" `Quick test_store_no_live_no_collision;


### PR DESCRIPTION
## Summary

- Resolve `--record-verdicts --verdict-store-dir` relative paths against the explicit workspace `base_path` instead of ambient `Sys.getcwd ()`.
- Clarify the completion-trust eval comment so the isolation guard's path root is explicit.

This is the first Path SSOT code reduction after the evidence-gate slice from `/private/tmp/masc-oas-adversarial-plan-2026-06-28.html`.

## Validation

- `git diff --check`
- `rg -n "Sys\\.getcwd|resolve_record_verdicts_store ~cwd" bin/masc_completion_trust_eval.ml` now reports only `Cal.resolve_record_verdicts_store ~cwd:base_path`.

## Local Dune Status

Attempted focused local validation:

- `scripts/dune-local.sh build bin/masc_completion_trust_eval.exe`
- `scripts/dune-local.sh build test/test_eval_calibration.exe`

The binary build hit a Dune shared-cache cleanup error:

```text
rmdir(/Users/dancer/.cache/dune/db/temp/dune_520b15_artifacts): Directory not empty
```

The test build then refused to start because an unrelated bare `dune build .` process was already running outside `scripts/dune-local.sh`:

```text
[dune-local] live Dune process outside scripts/dune-local.sh detected: 14893 ... dune build .
```

I did not kill that process or bypass the wrapper guard; CI should be treated as the compile authority for this draft.