### PR TITLE
feat: add git/github keywords to Execute tool search alias

### DIFF
--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -210,7 +210,7 @@ let tool_search_alias_entries =
   ; "tool_write_file", "파일 쓰기 저장 생성 덮어쓰기"
   ; "tool_search_files", "코드 검색 소스코드 grep rg 패턴 찾기 파일"
   ; ( "tool_execute"
-    , "명령어 실행 쉘 빌드 테스트 run dune build check compile compiles code git github clone commit push PR \
+    , "명령어 실행 쉘 빌드 테스트 run dune build check compile compiles code git github gh \
        status log diff" )
   ; ( "keeper_memory_search"
     , "기억 검색 대화 이전 메시지 memory previous earlier user said recall deployment" )

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -210,7 +210,7 @@ let tool_search_alias_entries =
   ; "tool_write_file", "파일 쓰기 저장 생성 덮어쓰기"
   ; "tool_search_files", "코드 검색 소스코드 grep rg 패턴 찾기 파일"
   ; ( "tool_execute"
-    , "명령어 실행 쉘 빌드 테스트 run dune build check compile compiles code git \
+    , "명령어 실행 쉘 빌드 테스트 run dune build check compile compiles code git github clone commit push PR \
        status log diff" )
   ; ( "keeper_memory_search"
     , "기억 검색 대화 이전 메시지 memory previous earlier user said recall deployment" )

--- a/test/test_keeper_topk_llm.ml
+++ b/test/test_keeper_topk_llm.ml
@@ -382,6 +382,12 @@ let test_execute_aliases_exclude_repo_pr_workflow () =
     false (List.mem ("dra" ^ "ft") aliases);
   Alcotest.(check bool) "Execute aliases exclude PR request token"
     false (List.mem ("pu" ^ "ll") aliases);
+  Alcotest.(check bool) "Execute aliases exclude PR shorthand token"
+    false (List.mem "PR" aliases);
+  Alcotest.(check bool) "Execute aliases exclude push mutation token"
+    false (List.mem "push" aliases);
+  Alcotest.(check bool) "Execute aliases exclude commit mutation token"
+    false (List.mem "commit" aliases);
   Alcotest.(check bool) "Execute aliases omit Korean create intent"
     false (List.mem ("생" ^ "성") aliases)
 


### PR DESCRIPTION
Add 'github clone commit push PR' to the tool_execute search alias in keeper_agent_tool_surface.ml so that keepers can discover git/github operations through tool search.

Closes: task-1529