### PR TITLE
fix(keeper): persist direct resume before side effects

### DIFF
--- a/lib/keeper/keeper_turn.ml
+++ b/lib/keeper/keeper_turn.ml
@@ -107,6 +107,12 @@ let has_direct_success_no_progress_pause ~(config : Workspace.config)
       || Keeper_no_progress_loop_detector.is_latched ~keeper_name:meta.name
       || has_no_progress_failure_reason ~base_path:config.base_path meta.name)
 
+let clear_no_progress_meta_blocker (meta : keeper_meta) =
+  match meta.runtime.last_blocker with
+  | Some { Keeper_meta_contract.klass = Keeper_meta_contract.No_progress_loop; _ } ->
+    Keeper_meta_contract.map_runtime (fun rt -> { rt with last_blocker = None }) meta
+  | _ -> meta
+
 let persist_direct_success_no_progress_resume ~base_path (resumed_meta : keeper_meta) =
   match
     Keeper_registry.update_entry
@@ -124,12 +130,13 @@ let persist_direct_success_no_progress_resume ~base_path (resumed_meta : keeper_
         ; turn_consecutive_failures = 0
         })
   with
-  | Ok () -> ()
+  | Ok () -> Ok ()
   | Error err ->
     Log.Keeper.warn
       "%s: direct keeper_msg success could not persist no_progress resume state: %s"
       resumed_meta.name
-      (Keeper_registry.registry_entry_validation_error_to_string err)
+      (Keeper_registry.registry_entry_validation_error_to_string err);
+    Error err
 
 let clear_direct_success_no_progress_pause
       ~(config : Workspace.config)
@@ -140,24 +147,7 @@ let clear_direct_success_no_progress_pause
   if not (has_direct_success_no_progress_pause ~config pre_turn_meta)
   then meta
   else
-    match
-      Keeper_registry.dispatch_event_and_log
-        ~base_path:config.base_path
-        meta.name
-        Keeper_state_machine.Operator_resume
-    with
-    | Error err ->
-      Log.Keeper.warn
-        "%s: direct keeper_msg success could not dispatch Operator_resume after no_progress recovery signal: %s"
-        meta.name
-        (Keeper_state_machine.transition_error_to_string err);
-      meta
-    | Ok _ ->
-    let cleared_meta =
-      Keeper_unified_turn_no_progress.clear_for_operator_resume
-        ~base_path:config.base_path
-        meta
-    in
+    let cleared_meta = clear_no_progress_meta_blocker meta in
     let resumed_meta =
       { cleared_meta with
         paused = false
@@ -165,17 +155,34 @@ let clear_direct_success_no_progress_pause
       ; updated_at = now_iso ()
       }
     in
-    persist_direct_success_no_progress_resume
-      ~base_path:config.base_path
-      resumed_meta;
-    Keeper_turn_livelock.reset_keeper_livelock
-      ~base_path:config.base_path
-      ~keeper:resumed_meta.name;
-    Keeper_livelock_state.reset_for_keeper ~keeper:resumed_meta.name;
-    Log.Keeper.info
-      "%s: direct keeper_msg success cleared no_progress pause/blocker"
-      resumed_meta.name;
-    resumed_meta
+    match
+      persist_direct_success_no_progress_resume
+        ~base_path:config.base_path
+        resumed_meta
+    with
+    | Error _ -> meta
+    | Ok () ->
+      (match
+         Keeper_registry.dispatch_event_and_log
+           ~base_path:config.base_path
+           meta.name
+           Keeper_state_machine.Operator_resume
+       with
+       | Error err ->
+         Log.Keeper.warn
+           "%s: direct keeper_msg success could not dispatch Operator_resume after persisted no_progress recovery: %s"
+           meta.name
+           (Keeper_state_machine.transition_error_to_string err)
+       | Ok _ -> ());
+      Keeper_no_progress_loop_detector.reset ~keeper_name:resumed_meta.name;
+      Keeper_turn_livelock.reset_keeper_livelock
+        ~base_path:config.base_path
+        ~keeper:resumed_meta.name;
+      Keeper_livelock_state.reset_for_keeper ~keeper:resumed_meta.name;
+      Log.Keeper.info
+        "%s: direct keeper_msg success cleared no_progress pause/blocker"
+        resumed_meta.name;
+      resumed_meta
 
 let direct_turn_observation ~(config : Workspace.config) (meta : keeper_meta) :
     Keeper_world_observation.world_observation =

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -451,7 +451,122 @@ let test_direct_success_clears_no_progress_pause_after_blocker_overwrite () =
            entry.Masc.Keeper_registry.meta.paused;
          (match entry.Masc.Keeper_registry.last_failure_reason with
           | None -> ()
-          | Some _ -> fail "expected overwritten no-progress failure reason to clear")
+         | Some _ -> fail "expected overwritten no-progress failure reason to clear")
+       | None -> fail "expected registered keeper")
+
+let test_direct_success_persist_failure_keeps_no_progress_pause () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-no-progress-direct-success-persist-fail-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_no_progress_loop_detector.reset_all_for_test ();
+      Masc.Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "no-progress-direct-success-persist-fail" in
+       let blocker =
+         Keeper_meta_contract.blocker_info_of_class
+           ~detail:"latched"
+           Keeper_meta_contract.No_progress_loop
+       in
+       let meta =
+         { (make_meta keeper_name
+            |> Keeper_meta_contract.map_runtime (fun rt ->
+              { rt with last_blocker = Some blocker }))
+           with
+           paused = true
+         }
+       in
+       Masc.Keeper_registry.clear ();
+       let entry =
+         Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta
+       in
+       let paused_entry =
+         { entry with
+           phase = Masc.Keeper_state_machine.Paused
+         ; conditions =
+             { entry.conditions with
+               Masc.Keeper_state_machine.operator_paused = true
+             }
+         }
+       in
+       (match
+          Masc.Keeper_registry.put_entry
+            ~base_path:config.base_path
+            keeper_name
+            paused_entry
+        with
+        | Ok () -> ()
+        | Error err ->
+          fail
+            ("seed paused registry entry: "
+             ^ Masc.Keeper_registry.registry_entry_validation_error_to_string err));
+       ignore
+         (Masc.Keeper_turn_livelock.record_turn_start
+            ~base_path:config.base_path
+            ~keeper:keeper_name
+            ~turn_id:42);
+       ignore
+         (Masc.Keeper_no_progress_loop_detector.record_turn
+            ~threshold_override:1
+            ~keeper_name
+            ~made_progress:false
+            ());
+       Masc.Keeper_registry.set_failure_reason
+         ~base_path:config.base_path
+         keeper_name
+         (Some
+            (Masc.Keeper_registry.Provider_runtime_error
+               { code = Masc.Keeper_unified_turn_no_progress.failure_reason_code
+               ; detail = "latched"
+               ; provider_id = None
+               ; http_status = None
+               ; runtime_id = None
+               ; reason = None
+               }));
+       let invalid_meta = { meta with agent_name = "" } in
+       let recovered_meta =
+         Masc.Keeper_turn.For_testing.clear_direct_success_no_progress_pause
+           ~config
+           ~pre_turn_meta:invalid_meta
+           invalid_meta
+       in
+       check bool "failed persistence keeps returned meta paused" true recovered_meta.paused;
+       check bool
+         "failed persistence keeps detector latched"
+         true
+         (Masc.Keeper_no_progress_loop_detector.is_latched ~keeper_name);
+       (match
+          Masc.Keeper_turn_livelock.current_state
+            ~base_path:config.base_path
+            ~keeper:keeper_name
+        with
+        | Some _ -> ()
+        | None -> fail "expected failed persistence to keep livelock state");
+       (match Masc.Keeper_registry.get_phase ~base_path:config.base_path keeper_name with
+        | Some Masc.Keeper_state_machine.Paused -> ()
+        | Some phase ->
+          fail
+            ("expected failed persistence to avoid Operator_resume, got phase "
+             ^ Masc.Keeper_state_machine.phase_to_string phase)
+        | None -> fail "expected registry phase");
+       match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+         check bool
+           "registry meta remains paused"
+           true
+           entry.Masc.Keeper_registry.meta.paused;
+         (match entry.Masc.Keeper_registry.last_failure_reason with
+          | Some (Masc.Keeper_registry.Provider_runtime_error { code; _ })
+            when String.equal
+                   code
+                   Masc.Keeper_unified_turn_no_progress.failure_reason_code -> ()
+          | Some _ -> fail "expected no_progress failure reason to remain"
+          | None -> fail "expected failed persistence to keep failure reason")
        | None -> fail "expected registered keeper")
 
 let test_direct_success_leaves_unrelated_pause_intact () =
@@ -634,6 +749,10 @@ let () =
             "direct success clears no-progress pause after blocker overwrite"
             `Quick
             test_direct_success_clears_no_progress_pause_after_blocker_overwrite;
+          test_case
+            "direct success persistence failure keeps no-progress pause"
+            `Quick
+            test_direct_success_persist_failure_keeps_no_progress_pause;
           test_case "direct success leaves unrelated pause intact" `Quick
             test_direct_success_leaves_unrelated_pause_intact;
         ] );


### PR DESCRIPTION
Follow-up to merged #22497.

This closes the remaining direct no-progress resume ordering gap by committing the registry resume state before emitting Operator_resume or resetting no-progress/livelock side effects. If registry persistence fails, the helper returns the original paused meta and leaves the no-progress latch, failure reason, phase, and livelock state intact.

Validation:
- git diff --check origin/main...HEAD
- ocamlformat --check lib/keeper/keeper_turn.ml test/test_keeper_auto_pause_blocker_persist_12683.ml
- ocamlc -stop-after parsing lib/keeper/keeper_turn.ml
- ocamlc -stop-after parsing test/test_keeper_auto_pause_blocker_persist_12683.ml

Per queue policy, local Dune was not run; CI is the build authority.