### PR TITLE
fix(dashboard): clean compaction snapshot hydration

### DIFF
--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -126,7 +126,13 @@ export function CompactionInspectorOverlay({
   keeper: Keeper
   onClose: () => void
 }): VNode {
-  const events = keeperCompactionSnapshots(keeper.name)
+  const globalEvents = keeperCompactionSnapshots(keeper.name)
+  const [hydratedState, setHydratedState] = useState<{ keeperName: string; events: CompactionSnapshot[] }>({
+    keeperName: keeper.name,
+    events: [],
+  })
+  const hydratedEvents = hydratedState.keeperName === keeper.name ? hydratedState.events : []
+  const events = globalEvents.length > 0 ? globalEvents : hydratedEvents
   const [idx, setIdx] = useState(0)
   const [side, setSide] = useState<'before' | 'after'>('after')
   const [loadState, setLoadState] = useState<CompactionSnapshotLoadState>({
@@ -158,10 +164,12 @@ export function CompactionInspectorOverlay({
       readErrors: [],
       scanTruncated: false,
     })
+    setHydratedState({ keeperName: keeper.name, events: [] })
     void fetchKeeperCompactionSnapshots(keeper.name, undefined, { signal: controller.signal })
       .then((payload) => {
         if (!active) return
-        hydrateCompactionSnapshots(keeper.name, payload.items)
+        const next = hydrateCompactionSnapshots(keeper.name, payload.items)
+        setHydratedState({ keeperName: keeper.name, events: next })
         setLoadState({
           loading: false,
           error: null,

--- a/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-snapshots.ts
@@ -128,7 +128,7 @@ function compareCompactionSnapshots(a: CompactionSnapshot, b: CompactionSnapshot
 export function hydrateCompactionSnapshots(
   keeperName: string,
   snapshots: readonly BackendCompactionSnapshot[],
-): void {
+): CompactionSnapshot[] {
   const existing = compactionSnapshots.value[keeperName] ?? []
   const optimistic = existing.filter(snapshot => snapshot.source !== 'backend')
   const byId = new Map<string, CompactionSnapshot>()
@@ -141,6 +141,7 @@ export function hydrateCompactionSnapshots(
     ...compactionSnapshots.value,
     [keeperName]: next,
   }
+  return next
 }
 
 export function recordManualCompaction(

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -327,6 +327,59 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('trace-cmp#12')
   })
 
+  it('renders live durable compaction snapshots even when token counts are missing', async () => {
+    vi.mocked(fetchKeeperCompactionSnapshots).mockResolvedValueOnce({
+      schema: 'keeper.compaction_snapshots.v1',
+      keeper: 'masc-improver',
+      source: 'runtime_manifest|keeper_meta',
+      producer: 'keeper_runtime_manifest|keeper_meta_store',
+      limit: 25,
+      count: 1,
+      read_error_count: 1,
+      read_errors: [
+        { scope: 'runtime_manifest_row:trace-cmp.jsonl:1', error: 'unknown event: "old_event"' },
+      ],
+      scan_truncated: true,
+      items: [
+        {
+          id: 'manifest:trace-live:context_compacted:2026-06-03T11:01:24Z',
+          keeper: 'masc-improver',
+          ts_iso: '2026-06-03T11:01:24Z',
+          ts_unix: 1_780_464_084,
+          trace_id: 'trace-live',
+          keeper_turn_id: null,
+          source: 'runtime_manifest',
+          trigger: 'pre_dispatch_hygiene',
+          runtime_id: null,
+          display_runtime: 'pre_dispatch_hygiene',
+          before_tokens: null,
+          after_tokens: null,
+          saved_tokens: null,
+          compaction_id: null,
+          compaction_source: 'pre_dispatch_hygiene',
+          status: 'compacted',
+          links: { receipt_path: null, checkpoint_path: null, tool_call_log_path: null },
+        },
+      ],
+    })
+
+    const { container, findByTestId } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} />`)
+    const btn = Array.from(container.querySelectorAll('.cmp-open')).find(
+      el => el.textContent?.includes('before/after'),
+    ) as HTMLElement | undefined
+    expect(btn).toBeTruthy()
+    fireEvent.click(btn as HTMLElement)
+
+    const diagnostics = await findByTestId('compaction-scan-diagnostics')
+    expect(diagnostics.textContent).toContain('manifest row 1개')
+    expect(diagnostics.textContent).toContain('limit')
+    expect(container.textContent).toContain('pre_dispatch_hygiene')
+    expect(container.textContent).toContain('runtime_manifest · compacted')
+    expect(container.textContent).toContain('trace-live')
+    expect(container.textContent).toContain('before/after token count가 없습니다')
+    expect(container.textContent).not.toContain('아직 이 keeper에서 durable compaction snapshot이 없습니다.')
+  })
+
   it('surfaces compaction snapshot scan diagnostics when successful payload has no items', async () => {
     vi.mocked(fetchKeeperCompactionSnapshots).mockResolvedValueOnce({
       schema: 'keeper.compaction_snapshots.v1',

--- a/lib/keeper_registry/keeper_runtime_manifest_types.ml
+++ b/lib/keeper_registry/keeper_runtime_manifest_types.ml
@@ -105,7 +105,11 @@ let classify_compaction_snapshot_typed_event = function
 
 let classify_compaction_snapshot_event event =
   match event with
-  | "memory_injected" | "memory_flushed" ->
+  | "memory_injected"
+  | "memory_flushed"
+  | "tool_lineage_recorded"
+  | "tool_surface_selected"
+  | "cascade_routed" ->
       Compaction_snapshot_known_unrelated
   | _ -> (
       match event_kind_of_string event with

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -4692,6 +4692,13 @@ let test_compaction_snapshot_event_classifier_covers_typed_events () =
     "legacy memory_injected"
     Runtime_manifest.Compaction_snapshot_known_unrelated
     (Runtime_manifest.classify_compaction_snapshot_event "memory_injected");
+  List.iter
+    (fun event_name ->
+       check_compaction_snapshot_event_class
+         ("runtime manifest non-compaction event " ^ event_name)
+         Runtime_manifest.Compaction_snapshot_known_unrelated
+         (Runtime_manifest.classify_compaction_snapshot_event event_name))
+    [ "tool_lineage_recorded"; "tool_surface_selected"; "cascade_routed" ];
   check_compaction_snapshot_event_class
     "unknown typed-like future event"
     Runtime_manifest.Compaction_snapshot_unknown
@@ -4845,13 +4852,24 @@ let test_compaction_snapshots_json_skips_unrelated_manifest_events () =
         ()
     in
     let row_json = Runtime_manifest.to_json row in
-    let unrelated_json =
-      runtime_manifest_json_with_event row_json "memory_injected"
+    let unrelated_json = runtime_manifest_json_with_event row_json "memory_injected" in
+    let tool_surface_json =
+      runtime_manifest_json_with_event row_json "tool_surface_selected"
     in
+    let lineage_json = runtime_manifest_json_with_event row_json "tool_lineage_recorded" in
+    let cascade_json = runtime_manifest_json_with_event row_json "cascade_routed" in
     let path = Runtime_manifest.path_for_trace config ~keeper_name:keeper_id ~trace_id in
     write_text_file
       path
-      (Yojson.Safe.to_string unrelated_json ^ "\n" ^ Yojson.Safe.to_string row_json ^ "\n");
+      (String.concat
+         "\n"
+         [ Yojson.Safe.to_string unrelated_json
+         ; Yojson.Safe.to_string tool_surface_json
+         ; Yojson.Safe.to_string lineage_json
+         ; Yojson.Safe.to_string cascade_json
+         ; Yojson.Safe.to_string row_json
+         ; ""
+         ]);
     let top =
       Server_dashboard_http_keeper_api.compaction_snapshots_json
         ~config


### PR DESCRIPTION
## Summary

- Stop treating normal runtime manifest events (`tool_lineage_recorded`, `tool_surface_selected`, `cascade_routed`) as compaction snapshot scan errors.
- Keep hydrated durable compaction snapshots in overlay-local state as well as the global signal, keyed by keeper, so a successful API response cannot render as an empty drawer.
- Add a live-shaped dashboard regression where durable snapshot items have nullable token counts and scan diagnostics.

## Evidence

- Live probe before patch: `GET /api/v1/keepers/rondo/compaction-snapshots?limit=5` returned `count: 2` with `context_compacted` items, but also `read_error_count: 47`; read errors included normal manifest events like `tool_lineage_recorded`, `tool_surface_selected`, and `cascade_routed`.
- `ocamlformat --check lib/keeper_registry/keeper_runtime_manifest_types.ml test/test_keeper_memory_os.ml`
- `git diff --check`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty false`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/keeper-workspace/keeper-workspace-rail.test.ts src/api/dashboard.test.ts` (`2 passed`, `90 passed`)

## Not Run

- `scripts/dune-local.sh build test/test_keeper_memory_os.exe` was attempted once, but it waited on `/tmp/me-dune-local.lock`; the lock holder was another focused Dune build in `.worktrees/event-bus-owner-thread-20260628`. Per operator instruction, full/build validation is left to CI.
