### PR TITLE
fix(observability): persist victoriametrics data via named volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,8 @@ services:
       - "8428:8428"
     command:
       - "-retentionPeriod=7d"
+    volumes:
+      - victoriametrics-data:/victoria-metrics-data
     restart: unless-stopped
 
   loki:
@@ -111,4 +113,6 @@ services:
 
 volumes:
   masc-state:
+    driver: local
+  victoriametrics-data:
     driver: local


### PR DESCRIPTION
## Context
`masc-victoriametrics` was stuck in a panic-restart loop, breaking the metrics pipeline (otel-collector → VM → grafana). Root cause: VictoriaMetrics panicked on startup reading a corrupted `parts.json` (NULL byte in `2026_06/small`), and VM does not auto-recover from corrupted parts.

Additionally, victoriametrics had **no volume mount** — data lived in the container filesystem, so it was non-persistent (any recreate wiped it).

## Changes
- Mount named volume `victoriametrics-data` at `/victoria-metrics-data` so data survives recreate/restart.
- Register `victoriametrics-data` in the top-level `volumes:` section.

## Immediate recovery (already applied)
`docker compose up -d --force-recreate victoriametrics` cleared the corrupted container-fs data; VM is now Up and ingesting (~476 series). This PR makes that data persistent so the corruption/recurrence doesn't wipe history.

## Verification
- `docker compose -f docker-compose.yml config -q` passes.
- Single file, +4 lines.

## Apply after merge
```
cd ~/me/workspace/yousleepwhen/masc && git pull --rebase origin main
docker compose up -d --force-recreate victoriametrics   # picks up the new volume mount
```

## Out of scope
Some `otel_export_*` metrics are rejected with "too small timestamp" (suspected seconds-vs-ms unit bug in the OCaml otel exporter). VM ingests the rest normally. Separate issue.

Co-Authored-By: Claude <noreply@anthropic.com>
