### PR TITLE
fix(dashboard): match passive-only completion label

### DIFF
--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -348,7 +348,7 @@ let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_a
 
 let composite_execution_passive_only_without_work_scope execution =
   match completion_contract_result_of_execution execution with
-  | Some Contract_passive_only ->
+  | Some Completion_contract_result.Passive_only ->
     Option.is_none (json_string "current_task_id" execution)
     && Json_util.json_string_list_member "goal_ids" execution = []
   | Some _ | None -> false
@@ -356,7 +356,7 @@ let composite_execution_passive_only_without_work_scope execution =
 
 let composite_execution_completion_unsatisfied_reason execution =
   match completion_contract_result_of_execution execution with
-  | Some Contract_passive_only
+  | Some Completion_contract_result.Passive_only
     when composite_execution_passive_only_without_work_scope execution ->
     None
   | Some
@@ -371,7 +371,7 @@ let composite_execution_completion_unsatisfied_reason execution =
 
 let composite_execution_budget_unsatisfied_reason execution =
   match completion_contract_result_of_execution execution with
-  | Some Contract_passive_only
+  | Some Completion_contract_result.Passive_only
     when composite_execution_passive_only_without_work_scope execution ->
     None
   | Some


### PR DESCRIPTION
## Summary

- Fix the merged-main Lint failure from #22500 by matching the typed `Keeper_completion_contract_result_label.t` constructor.
- Replace unqualified `Contract_passive_only` patterns with `Completion_contract_result.Passive_only` in the composite execution classifiers.

## Evidence

- CI failure source: #22500 Lint failed in `lib/server/server_dashboard_http_composite_claims.ml` with `There is no constructor Contract_passive_only within type Completion_contract_result.t`.
- `ocamlformat --check lib/server/server_dashboard_http_composite_claims.ml`
- `git diff --check`

## Not Run

- Focused Dune compile was attempted in the #22500 worktree, but `scripts/dune-local.sh` refused because an unrelated bare `dune build .` process is running outside the wrapper. Per operator instruction, build validation is left to CI.
