### PR TITLE
fix(http): expose response header helper in interface

### DIFF
--- a/lib/http_server_eio.mli
+++ b/lib/http_server_eio.mli
@@ -92,6 +92,22 @@ end
     [httpun] streaming API.  Every helper closes the response
     body except the 304 path in [html_cached]. *)
 module Response : sig
+  (** JSON response content type used by {!json} and header-order
+      regression tests. *)
+  val json_content_type : string
+
+  (** Build deterministic content headers around the mandatory
+      [content-type] / [content-length] pair.  Optional header segments
+      preserve caller order as [before_headers], core headers,
+      [after_headers], then [tail_headers]. *)
+  val content_headers
+    :  ?before_headers:(string * string) list
+    -> ?after_headers:(string * string) list
+    -> ?tail_headers:(string * string) list
+    -> content_type:string
+    -> string
+    -> Httpun.Headers.t
+
   (** Plain-text response.  Default status [`OK].  Sets
       [content-type: text/plain; charset=utf-8] +
       [content-length]. *)


### PR DESCRIPTION
## Summary
- expose `Response.json_content_type` and `Response.content_headers` from `http_server_eio.mli`
- fixes the current CI compile failure where `test_http_server_eio.ml` references implementation helpers hidden by the interface

## Validation
- `ocamlformat --check lib/http_server_eio.mli`
- `git diff --check origin/main...HEAD`
- `ocamlc -stop-after parsing lib/http_server_eio.mli`

Dune build is intentionally left to GitHub CI per workflow.
