### PR TITLE
fix(runtime): reject unknown runtime table keys

### DIFF
--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -738,40 +738,107 @@ let parse_pause_threshold (toml : Otoml.t) : Runtime_schema.pause_threshold =
   }
 ;;
 
+type runtime_section =
+  { default_runtime_id : string option
+  ; librarian_runtime_id : string option
+  ; cross_verifier_runtime_id : string option
+  ; media_failover : string list
+  }
+
+let empty_runtime_section =
+  { default_runtime_id = None
+  ; librarian_runtime_id = None
+  ; cross_verifier_runtime_id = None
+  ; media_failover = []
+  }
+;;
+
+let parse_runtime_string_leaf ~path ~key value =
+  match value with
+  | Otoml.TomlString value -> Ok value
+  | _ -> Error (error path (key ^ " must be a string runtime id"))
+;;
+
+let parse_runtime_media_failover value =
+  (* RFC-0265 — ordered runtime ids for modality-gated reroute. RFC-0145:
+     narrow to the [Otoml.get_array] wrong-type exception; a malformed value
+     degrades to [] (→ derive-from-declared-caps), and any id typo is caught
+     loudly at load by {!Runtime.validate_media_failover}. *)
+  try Otoml.get_array Otoml.get_string value with
+  | Otoml.Type_error _ ->
+    Log.Runtime.warn
+      "runtime_toml: [runtime].media_failover — expected string array, ignoring";
+    []
+;;
+
+let parse_runtime_section (toml : Otoml.t) : (runtime_section, parse_error list) result =
+  match Otoml.find_opt toml Fun.id [ "runtime" ] with
+  | None -> Ok empty_runtime_section
+  | Some (Otoml.TomlTable entries | Otoml.TomlInlineTable entries) ->
+    let section, errs =
+      List.fold_left
+        (fun (section, errs) (key, value) ->
+           match key with
+           | "default" ->
+             (match parse_runtime_string_leaf ~path:"runtime.default" ~key value with
+              | Ok default_runtime_id ->
+                { section with default_runtime_id = Some default_runtime_id }, errs
+              | Error e -> section, errs @ e)
+           | "librarian" ->
+             (match parse_runtime_string_leaf ~path:"runtime.librarian" ~key value with
+              | Ok librarian_runtime_id ->
+                { section with librarian_runtime_id = Some librarian_runtime_id }, errs
+              | Error e -> section, errs @ e)
+           | "cross_verifier" ->
+             (match
+                parse_runtime_string_leaf ~path:"runtime.cross_verifier" ~key value
+              with
+              | Ok cross_verifier_runtime_id ->
+                { section with cross_verifier_runtime_id = Some cross_verifier_runtime_id },
+                errs
+              | Error e -> section, errs @ e)
+           | "media_failover" ->
+             { section with media_failover = parse_runtime_media_failover value }, errs
+           | "assignments" ->
+             (* Parsed by [parse_keeper_assignments], including table-shape
+                validation. It is still recognized here so a malformed scalar
+                does not get reported as an unknown key first. *)
+             section, errs
+           | _ when is_toml_table value ->
+             (* [runtime.<profile>] tables are reserved for runtime profiles and
+                intentionally ignored by this parser layer. *)
+             section, errs
+           | _ ->
+             ( section
+             , errs
+               @ error
+                   ("runtime." ^ key)
+                   (Printf.sprintf
+                      "unknown [runtime] key %S; expected default, librarian, \
+                       cross_verifier, media_failover, [runtime.assignments], or \
+                       a table-valued [runtime.<profile>]"
+                      key) )
+        )
+        (empty_runtime_section, [])
+        entries
+    in
+    if errs <> [] then Error errs else Ok section
+  | Some _ -> Error (error "runtime" "[runtime] must be a TOML table")
+;;
+
 let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) result =
   let providers_result = parse_providers toml in
   let models_result = parse_models toml in
+  let runtime_section_result = parse_runtime_section toml in
   let assignments_result = parse_keeper_assignments toml in
   let bindings_result = parse_bindings toml in
   let errs = function Ok _ -> [] | Error errs -> errs in
   let all_errors =
     errs providers_result
     @ errs models_result
+    @ errs runtime_section_result
     @ errs assignments_result
     @ errs bindings_result
-  in
-  let default_runtime_id =
-    Otoml.find_opt toml Otoml.get_string [ "runtime"; "default" ]
-  in
-  let librarian_runtime_id =
-    Otoml.find_opt toml Otoml.get_string [ "runtime"; "librarian" ]
-  in
-  let cross_verifier_runtime_id =
-    Otoml.find_opt toml Otoml.get_string [ "runtime"; "cross_verifier" ]
-  in
-  let media_failover =
-    (* RFC-0265 — ordered runtime ids for modality-gated reroute. RFC-0145:
-       narrow to the [Otoml.get_array] wrong-type exception; a malformed value
-       degrades to [] (→ derive-from-declared-caps), and any id typo is caught
-       loudly at load by {!Runtime.validate_media_failover}. *)
-    match Otoml.find_opt toml Fun.id [ "runtime"; "media_failover" ] with
-    | None -> []
-    | Some v ->
-      (try Otoml.get_array Otoml.get_string v with
-       | Otoml.Type_error _ ->
-         Log.Runtime.warn
-           "runtime_toml: [runtime].media_failover — expected string array, ignoring";
-         [])
   in
   if all_errors <> []
   then Error all_errors
@@ -786,16 +853,19 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
     let bindings =
       extract_after_all_errors_guard ~label:"bindings" bindings_result
     in
+    let runtime_section =
+      extract_after_all_errors_guard ~label:"runtime" runtime_section_result
+    in
     let pause_threshold = parse_pause_threshold toml in
     Ok
       { Runtime_schema.providers
       ; models
       ; bindings
-      ; default_runtime_id
-      ; librarian_runtime_id
-      ; cross_verifier_runtime_id
+      ; default_runtime_id = runtime_section.default_runtime_id
+      ; librarian_runtime_id = runtime_section.librarian_runtime_id
+      ; cross_verifier_runtime_id = runtime_section.cross_verifier_runtime_id
       ; keeper_assignments
-      ; media_failover
+      ; media_failover = runtime_section.media_failover
       ; pause_threshold
       })
 ;;

--- a/test/test_runtime_config_validity.ml
+++ b/test/test_runtime_config_validity.ml
@@ -652,6 +652,74 @@ let test_runtime_toml_reserves_web_search_namespace () =
     check (option string) "default runtime" (Some "local.sample")
       cfg.Runtime_schema.default_runtime_id
 
+let test_runtime_toml_rejects_unknown_runtime_key () =
+  let content =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.sample]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.sample\"\n\
+     defualt = \"local.typo\"\n"
+  in
+  match Runtime_toml.parse_string content with
+  | Ok _ -> failf "unknown [runtime] key should fail parse"
+  | Error errs ->
+    let rendered =
+      errs
+      |> List.map (fun (err : Runtime_toml.parse_error) ->
+        Printf.sprintf "%s: %s" err.path err.message)
+      |> String.concat "\n"
+    in
+    check bool "error mentions runtime.defualt" true
+      (String_util.contains_substring rendered "runtime.defualt");
+    check bool "error explains unknown runtime key" true
+      (String_util.contains_substring rendered "unknown [runtime] key")
+
+let test_runtime_toml_allows_runtime_profile_tables () =
+  let content =
+    "[providers.local]\n\
+     protocol = \"openai-compatible-http\"\n\
+     endpoint = \"http://127.0.0.1:1/v1\"\n\
+     \n\
+     [models.sample]\n\
+     api-name = \"sample\"\n\
+     max-context = 1024\n\
+     \n\
+     [local.sample]\n\
+     \n\
+     [runtime]\n\
+     default = \"local.sample\"\n\
+     \n\
+     [runtime.primary_profile]\n\
+     members = [\"local.sample\"]\n\
+     tiers = [\"primary_profile\"]\n\
+     \n\
+     [runtime.secondary_profile]\n\
+     members = [\"local.sample\"]\n\
+     tiers = [\"secondary_profile\"]\n"
+  in
+  match Runtime_toml.parse_string content with
+  | Error errs ->
+    let rendered =
+      errs
+      |> List.map (fun (err : Runtime_toml.parse_error) ->
+        Printf.sprintf "%s: %s" err.path err.message)
+      |> String.concat "\n"
+    in
+    failf "runtime TOML should allow [runtime.<profile>] tables:\n%s" rendered
+  | Ok cfg ->
+    check (option string) "default runtime" (Some "local.sample")
+      cfg.Runtime_schema.default_runtime_id;
+    check int "profile tables are not provider bindings" 1
+      (List.length cfg.Runtime_schema.bindings)
+
 (** The runtime singletons were migrated from plain [ref]s to [Atomic.t] so
     that reads from worker domains on OCaml 5 see published writes.  This test
     exercises the public getter surface after [init_default] to ensure the
@@ -976,6 +1044,10 @@ let () =
             `Quick test_toml_catalog_resolves_web_search_keys;
           test_case "web_search is a reserved runtime TOML namespace" `Quick
             test_runtime_toml_reserves_web_search_namespace;
+          test_case "runtime table rejects unknown keys" `Quick
+            test_runtime_toml_rejects_unknown_runtime_key;
+          test_case "runtime table allows profile tables" `Quick
+            test_runtime_toml_allows_runtime_profile_tables;
           test_case "atomic runtime getters are consistent after init" `Quick
             test_runtime_atomic_getters_are_consistent_after_init;
           test_case "max-concurrent is optional opt-in" `Quick


### PR DESCRIPTION
## Summary
- reject unknown scalar keys inside `[runtime]` in `runtime.toml` instead of silently ignoring typoed control-plane settings
- derive validation from the runtime parser pass (`parse_runtime_section`) rather than a separate hardcoded allowlist
- preserve compatibility for `[runtime.assignments]` and table-valued `[runtime.<profile>]` profile tables
- add focused regression coverage for `[runtime].defualt` reporting `runtime.defualt`, and for valid profile tables continuing to parse

## Current diff
- `lib/runtime/runtime_toml.ml`
- `test/test_runtime_config_validity.ml`

## Validation
- `ocamlformat --check lib/runtime/runtime_toml.ml test/test_runtime_config_validity.ml`
- `git diff --check`
- `ocamlc -stop-after parsing -impl lib/runtime/runtime_toml.ml`
- `ocamlc -stop-after parsing -impl test/test_runtime_config_validity.ml`

CI remains the build authority for this draft PR.