### PR TITLE
fix(build): sync callsites for variant rename + module path (main build break)

### DIFF
--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -348,7 +348,7 @@ let keeper_activation_readiness_json = Server_dashboard_fleet_readiness.keeper_a
 
 let composite_execution_passive_only_without_work_scope execution =
   match completion_contract_result_of_execution execution with
-  | Some Contract_passive_only ->
+  | Some Completion_contract_result.Passive_only ->
     Option.is_none (json_string "current_task_id" execution)
     && Json_util.json_string_list_member "goal_ids" execution = []
   | Some _ | None -> false
@@ -356,7 +356,7 @@ let composite_execution_passive_only_without_work_scope execution =
 
 let composite_execution_completion_unsatisfied_reason execution =
   match completion_contract_result_of_execution execution with
-  | Some Contract_passive_only
+  | Some Completion_contract_result.Passive_only
     when composite_execution_passive_only_without_work_scope execution ->
     None
   | Some
@@ -371,7 +371,7 @@ let composite_execution_completion_unsatisfied_reason execution =
 
 let composite_execution_budget_unsatisfied_reason execution =
   match completion_contract_result_of_execution execution with
-  | Some Contract_passive_only
+  | Some Completion_contract_result.Passive_only
     when composite_execution_passive_only_without_work_scope execution ->
     None
   | Some

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -487,10 +487,10 @@ let test_direct_success_persist_failure_keeps_no_progress_pause () =
        in
        let paused_entry =
          { entry with
-           phase = Masc.Keeper_state_machine.Paused
+           phase = Keeper_state_machine.Paused
          ; conditions =
              { entry.conditions with
-               Masc.Keeper_state_machine.operator_paused = true
+               Keeper_state_machine.operator_paused = true
              }
          }
        in
@@ -548,11 +548,11 @@ let test_direct_success_persist_failure_keeps_no_progress_pause () =
         | Some _ -> ()
         | None -> fail "expected failed persistence to keep livelock state");
        (match Masc.Keeper_registry.get_phase ~base_path:config.base_path keeper_name with
-        | Some Masc.Keeper_state_machine.Paused -> ()
+        | Some Keeper_state_machine.Paused -> ()
         | Some phase ->
           fail
             ("expected failed persistence to avoid Operator_resume, got phase "
-             ^ Masc.Keeper_state_machine.phase_to_string phase)
+             ^ Keeper_state_machine.phase_to_string phase)
         | None -> fail "expected registry phase");
        match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
        | Some entry ->


### PR DESCRIPTION
## 목적

main 빌드 고장(build break) 3개 에러 중 callsite 동기화 누락 2건 수정. 사용자 직접 요청(`dune build .` 에러).

## 변경

### 1. `lib/server/server_dashboard_http_composite_claims.ml` — variant rename 동기화
- `Contract_passive_only` → `Completion_contract_result.Passive_only` (3 callsites: `:351`, `:359`, `:374`)
- 근거: 같은 파일 `:366`/`:387`은 이미 새 이름(`Passive_only`) 사용 중. variant가 rename됐는데 3 callsite만 못 따라감.
- match 대상 = `completion_contract_result_of_execution` → `Completion_contract_result.t option`.

### 2. `test/test_keeper_auto_pause_blocker_persist_12683.ml` — module path 동기화
- `Masc.Keeper_state_machine` → `Keeper_state_machine` (`:490` `.Paused`, `:493` `.operator_paused`, `:548` 영역)
- 근거: `lib/masc.ml`/`.mli`에 `Keeper_state_machine` alias 없음. sibling test(`test_server_runtime_bootstrap.ml:1065+`)은 `Keeper_state_machine.` 직접 참조. 이 test만 `Masc.` prefix 잔존.

## 에러 1 (`test_http_server_eio.ml:384 Response.content_headers`) — 별도 조치 불필요 (예상)
- `lib/http_server_eio.ml:154 module Response = struct` + `:164 let content_headers` + `:324 Response.content_headers` — 최신 main에서 `content_headers`가 Response 모듈 안에 존재. 사용자 에러는 stale main 기준으로 추정. CI가 확증.

## 검증
- 로컬 빌드 금지 원칙 → CI `Build and Test`로 3개 에러 해소 확인.

## 워크어라운드 게이트
이 변경은 variant rename / module path 변경에 대한 **callsite 동기화** (워크어라운드 시그니처 3종 해당 없음 — silent failure / N-of-M / string classifier 아님).

## 연계
본인(autocoder)이 무관 PR을 계속 머지하며 main build break를 방치한 상태에서 사용자가 직접 개입. broadcast로 선점 선언 완료.

Co-Authored-By: Claude <noreply@anthropic.com>
