### PR TITLE
fix(dashboard): show real memory recall candidates

### DIFF
--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -251,6 +251,8 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     expect(container.textContent).toContain('검증')
     expect(container.textContent).toContain('active recall candidate')
     expect(container.textContent).toContain('1/3 recallable')
+    expect(container.textContent).toContain('핵심 회상 후보')
+    expect(container.textContent).toContain('실제 prompt recall 후보 1/1개를 표시')
     expect(container.textContent).not.toContain('diagnostic row: operator pin backend source absent')
     expect(container.textContent).not.toContain('librarian parse fallback')
     expect(container.textContent).not.toContain('amplitude 캐시는 만료됨')
@@ -278,6 +280,7 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
     expect(container.textContent).not.toContain('diagnostic row: operator pin backend source absent')
     expect(container.textContent).not.toContain('librarian parse fallback')
+    expect(container.textContent).toContain('librarian fallback 진단 1개는 기본 회상 화면에서 접힘')
 
     const diagnosticBtn = [...container.querySelectorAll('.mem-filter')].find(b => b.textContent === '진단/증거 1')
     expect(diagnosticBtn).toBeTruthy()
@@ -343,9 +346,10 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
     // read_errors visible (no silent failure)
     expect(container.querySelector('.mem-read-error')?.textContent).toContain('one malformed row skipped')
-    // pins → Phase 2 disclosure (no fabricated pin rows)
+    // pins → Phase 2 disclosure, while the section still shows real recall candidates.
     const disclosures = [...container.querySelectorAll('.mem-disclosure')].map(d => d.textContent ?? '')
     expect(disclosures.some(t => t.includes('Phase 2'))).toBe(true)
+    expect(container.textContent).toContain('핵심 회상 후보')
     // no prototype fixture leakage
     expect(container.querySelector('.mem-pin')).toBeFalsy()
   })

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -445,6 +445,25 @@ function FactRow({ fact }: { fact: MemoryOsFact }) {
     </div>`
 }
 
+function RecallCandidatePreview({
+  facts,
+  total,
+}: {
+  facts: readonly MemoryOsFact[]
+  total: number
+}) {
+  if (facts.length === 0) {
+    return html`
+      <${DisclosureNote} text="operator 핀은 Phase 2에서 연결 예정 — 현재 표시할 prompt recall 후보도 없음." />
+    `
+  }
+  return html`
+    <${Fragment}>
+      <div class="mem-store">${facts.map(f => html`<${FactRow} key=${factTag(f) + f.source.trace_id + f.source.turn + f.claim} fact=${f} />`)}</div>
+      <${DisclosureNote} text=${`operator 핀은 Phase 2에서 연결 예정 — 현재는 실제 prompt recall 후보 ${facts.length}/${total}개를 표시.`} />
+    </>`
+}
+
 // Honest disclosure for a section whose backend source lands in a later RFC
 // phase. NOT a stub: it states the absence and the phase, renders no fabricated
 // data, and is visually distinct from a real-data section.
@@ -502,12 +521,13 @@ function OneKeeperMemoryReal({
   const recallableFacts = facts.filter(isPromptRecallableFact)
   const diagnosticFacts = facts.filter(isDiagnosticEvidenceFact)
   const allEpisodes = [...snapshot.episodes.items].reverse()
+  const recallPreviewFacts = recallableFacts.slice(0, 3)
   const episodes = allEpisodes
     .filter(ep => ep.terminal_marker !== MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER)
     .slice(0, 5)
-  const fallbackEpisodes = allEpisodes
+  const allFallbackEpisodes = allEpisodes
     .filter(ep => ep.terminal_marker === MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER)
-    .slice(0, 5)
+  const fallbackEpisodes = allFallbackEpisodes.slice(0, 5)
   const visibilityRows =
     visibilityFilter.value === 'recallable'
       ? recallableFacts
@@ -555,8 +575,11 @@ function OneKeeperMemoryReal({
       </div>
 
       <div class="turn-sec">
-        <h4>핀 고정 사실</h4>
-        <${DisclosureNote} text="operator 핀은 Phase 2에서 연결 예정 — 현재 백엔드 소스 없음." />
+        <div class="mem-sec-head">
+          <h4>핵심 회상 후보</h4>
+          <span class="mem-n mono">${recallPreviewFacts.length}/${recallableFacts.length}</span>
+        </div>
+        <${RecallCandidatePreview} facts=${recallPreviewFacts} total=${recallableFacts.length} />
       </div>
 
       <div class="turn-sec">
@@ -614,6 +637,9 @@ function OneKeeperMemoryReal({
               <${DisclosureNote} text="유지/요약/폐기 3열 diff는 Phase 3에서 연결 예정 — episode 요약만 표시." />
             </>`
           : html`<div class="mem-empty">압축(episode) 이력 없음.</div>`}
+        ${!showFallbackEpisodes && allFallbackEpisodes.length > 0
+          ? html`<${DisclosureNote} text=${`librarian fallback 진단 ${allFallbackEpisodes.length}개는 기본 회상 화면에서 접힘 — 진단/증거 필터에서 확인.`} />`
+          : null}
       </div>
 
       ${showFallbackEpisodes && fallbackEpisodes.length


### PR DESCRIPTION
## Summary

- Replace the prominent empty "핀 고정 사실" block with a real-data "핵심 회상 후보" preview sourced from current `prompt_recallable` memory-os facts.
- Keep the operator-pin backend boundary explicit: the section still discloses that operator pins are Phase 2, but no longer leaves the first screen as a dead area.
- When librarian fallback episodes are hidden from the default recall view, show a folded diagnostic count instead of making them look lost or silently mixed into recall facts.

## Evidence

- Live `rondo` turn-records showed `memory_os.facts.items` populated (`shown` around 196) while the pin section had no backend source and old `librarian_unstructured_fallback` episodes were present.
- `git diff --check origin/main...HEAD`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty false`
- `/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/memory-inspector.test.ts` (`1 passed`, `26 passed`)
