### PR TITLE
fix(sidecar): require explicit runtime base path

### DIFF
--- a/lib/server/server_routes_http_routes_sidecar.mli
+++ b/lib/server/server_routes_http_routes_sidecar.mli
@@ -29,8 +29,12 @@ val trim_opt : string option -> string option
 (** {1 Base-path / project root resolution} *)
 
 val runtime_base_path : ?base_path:string -> unit -> string
-(** Effective [base_path] for runtime path resolution.  Defaults to
-    the configured server base when not provided. *)
+(** Effective [base_path] for runtime path resolution. Raises when no
+    explicit or env-derived base path is available. *)
+
+val runtime_base_path_result : ?base_path:string -> unit -> (string, string) result
+(** Effective [base_path] for runtime path resolution. The request-scoped
+    [base_path] wins; otherwise the resolver's env-derived base path wins. *)
 
 val request_base_path : Mcp_server.server_state -> string
 (** Base path bound to the server state for the current process. *)

--- a/lib/server/server_routes_http_sidecar_paths.ml
+++ b/lib/server/server_routes_http_sidecar_paths.ml
@@ -30,7 +30,7 @@ let runtime_base_path_result ?base_path () =
   | Some path -> Ok path
   | None ->
     (match Config_dir_resolver.current_env_base_path_opt () with
-     | Some path -> Ok path
+     | Some path -> Ok (Config_dir_resolver.absolute_path path)
      | None -> Error unresolved_runtime_base_path_message)
 ;;
 

--- a/lib/server/server_routes_http_sidecar_paths.ml
+++ b/lib/server/server_routes_http_sidecar_paths.ml
@@ -18,10 +18,26 @@ let parse_name request = validate_name (Server_utils.query_param request "name")
 
 let trim_opt = Env_config_core.trim_opt
 
-let runtime_base_path ?base_path () =
+let unresolved_runtime_base_path_message =
+  Printf.sprintf
+    "sidecar runtime base path is unresolved; pass the request workspace \
+     base_path or set %s"
+    Env_config_core.base_path_env_key
+;;
+
+let runtime_base_path_result ?base_path () =
   match trim_opt base_path with
-  | Some path -> path
-  | None -> Config_dir_resolver.base_path_or_cwd ()
+  | Some path -> Ok path
+  | None ->
+    (match Config_dir_resolver.current_env_base_path_opt () with
+     | Some path -> Ok path
+     | None -> Error unresolved_runtime_base_path_message)
+;;
+
+let runtime_base_path ?base_path () =
+  match runtime_base_path_result ?base_path () with
+  | Ok path -> path
+  | Error msg -> invalid_arg msg
 ;;
 
 let request_base_path state = (Mcp_server.workspace_config state).base_path
@@ -266,24 +282,26 @@ let today_log_file ?sidecar_root ?project_root ~base_path id =
 ;;
 
 let runtime_sidecar_dir_result ?base_path id =
-  let runtime_base_path = runtime_base_path ?base_path () in
-  let configured_sidecar_root = sidecar_root () in
-  let project_root = project_root_from_executable () in
-  match
-    resolve_existing_sidecar_dir
-      ?sidecar_root:configured_sidecar_root
-      ?project_root
-      ~base_path:runtime_base_path
-      id
-  with
-  | Some dir -> Ok dir
-  | None ->
-    Error
-      (missing_sidecar_dir_message
+  match runtime_base_path_result ?base_path () with
+  | Error _ as error -> error
+  | Ok runtime_base_path ->
+    let configured_sidecar_root = sidecar_root () in
+    let project_root = project_root_from_executable () in
+    (match
+       resolve_existing_sidecar_dir
          ?sidecar_root:configured_sidecar_root
          ?project_root
          ~base_path:runtime_base_path
-         id)
+         id
+     with
+     | Some dir -> Ok dir
+     | None ->
+       Error
+         (missing_sidecar_dir_message
+            ?sidecar_root:configured_sidecar_root
+            ?project_root
+            ~base_path:runtime_base_path
+            id))
 ;;
 
 let runtime_sidecar_script_result ?base_path id =

--- a/lib/server/server_routes_http_sidecar_paths.mli
+++ b/lib/server/server_routes_http_sidecar_paths.mli
@@ -6,7 +6,14 @@ val parse_name : Httpun.Request.t -> (string, string) result
 
 val trim_opt : string option -> string option
 
+val runtime_base_path_result : ?base_path:string -> unit -> (string, string) result
+(** Effective [base_path] for runtime path resolution. The request-scoped
+    [base_path] wins; otherwise the resolver's env-derived base path wins. *)
+
 val runtime_base_path : ?base_path:string -> unit -> string
+(** Effective [base_path] for runtime path resolution. Raises when no
+    explicit or env-derived base path is available. *)
+
 val request_base_path : Mcp_server.server_state -> string
 val dir_exists : string -> bool
 val project_root_from_executable : unit -> string option

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -308,6 +308,23 @@ let test_runtime_base_path_uses_resolver_precedence () =
     (Routes.runtime_base_path ~base_path:" /tmp/explicit-runtime " ())
 ;;
 
+let test_runtime_base_path_anchors_relative_env_base () =
+  with_temp_dir "sidecar-runtime-relative-env" (fun dir ->
+    let previous_cwd = Sys.getcwd () in
+    Fun.protect
+      ~finally:(fun () ->
+        Sys.chdir previous_cwd;
+        Config_dir_resolver.reset ())
+      (fun () ->
+         Sys.chdir dir;
+         with_env Env_config_core.base_path_input_env_key None (fun () ->
+           with_env Env_config_core.base_path_env_key (Some "relative-root") (fun () ->
+             Config_dir_resolver.reset ();
+             let expected = Ok (Filename.concat dir "relative-root") in
+             let actual = Routes.runtime_base_path_result () in
+             check result_t "relative env base anchors to cwd" expected actual))))
+;;
+
 let test_status_file_prefers_existing_project_root_candidate () =
   with_temp_dir "sidecar-status-project-fallback" (fun dir ->
     let base_path = Filename.concat dir "runtime-root" in
@@ -1042,6 +1059,10 @@ let () =
             "runtime base path follows resolver precedence"
             `Quick
             test_runtime_base_path_uses_resolver_precedence
+        ; test_case
+            "runtime base path anchors relative env base"
+            `Quick
+            test_runtime_base_path_anchors_relative_env_base
         ; test_case
             "status file falls back to project root candidate"
             `Quick

--- a/test/test_sidecar_lifecycle_routes.ml
+++ b/test/test_sidecar_lifecycle_routes.ml
@@ -68,6 +68,20 @@ let env_values key env =
     else None)
 ;;
 
+let with_env key value f =
+  let previous = Sys.getenv_opt key in
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some existing -> Unix.putenv key existing
+      | None -> Unix.putenv key "")
+    (fun () ->
+      (match value with
+       | Some next -> Unix.putenv key next
+       | None -> Unix.putenv key "");
+      f ())
+;;
+
 let with_temp_dir prefix f =
   let dir = Filename.temp_file prefix "" in
   Sys.remove dir;
@@ -216,6 +230,28 @@ let test_resolve_existing_sidecar_dir_falls_back_to_project_root () =
       "project root used when base path is missing sidecars"
       (Some project_dir)
       (Routes.resolve_existing_sidecar_dir ~project_root ~base_path "discord"))
+;;
+
+let test_runtime_base_path_result_prefers_explicit_base_path () =
+  check
+    result_t
+    "explicit request base path wins"
+    (Ok "/tmp/runtime-root")
+    (Routes.runtime_base_path_result ~base_path:" /tmp/runtime-root " ())
+;;
+
+let test_runtime_base_path_result_fails_without_base_path () =
+  with_env Env_config_core.base_path_env_key None @@ fun () ->
+  with_env Env_config_core.base_path_input_env_key None @@ fun () ->
+  match Routes.runtime_sidecar_dir_result "discord" with
+  | Ok dir -> failf "expected missing base path error, got %s" dir
+  | Error msg ->
+    check bool "mentions request base path" true (contains_substring msg "base_path");
+    check
+      bool
+      "mentions env base path"
+      true
+      (contains_substring msg Env_config_core.base_path_env_key)
 ;;
 
 let test_missing_sidecar_dir_message_mentions_sidecar_root_hint () =
@@ -990,6 +1026,14 @@ let () =
             "project root fallback when base path misses sidecars"
             `Quick
             test_resolve_existing_sidecar_dir_falls_back_to_project_root
+        ; test_case
+            "runtime base path prefers explicit request scope"
+            `Quick
+            test_runtime_base_path_result_prefers_explicit_base_path
+        ; test_case
+            "runtime base path fails closed without request or env base"
+            `Quick
+            test_runtime_base_path_result_fails_without_base_path
         ; test_case
             "missing directory message includes setup hint"
             `Quick


### PR DESCRIPTION
## Summary
- add a result-returning sidecar runtime base-path resolver
- route env fallback through Config_dir_resolver.current_env_base_path_opt instead of raw MASC_BASE_PATH / cwd fallback
- fail runtime sidecar lookup closed when neither request base_path nor env base path is available
- add lifecycle-route regression coverage for explicit request scope and missing-base errors

## Validation
- ocamlformat --check lib/server/server_routes_http_sidecar_paths.ml lib/server/server_routes_http_sidecar_paths.mli lib/server/server_routes_http_routes_sidecar.mli test/test_sidecar_lifecycle_routes.ml
- git diff --check
- rg -n "Sys\.getcwd|Sys\.getenv_opt Env_config_core\.base_path_env_key" lib/server/server_routes_http_sidecar_paths.ml lib/server/server_routes_http_sidecar_paths.mli lib/server/server_routes_http_routes_sidecar.mli test/test_sidecar_lifecycle_routes.ml || true

Dune build/test intentionally left to GitHub CI per operator instruction; local Dune is not used as the blocking authority for this slice.