### PR TITLE
perf(dashboard): bound governance ring append without rescans

### DIFF
--- a/lib/dashboard/dashboard_governance_metrics.ml
+++ b/lib/dashboard/dashboard_governance_metrics.ml
@@ -32,8 +32,17 @@ let max_ring_size = 43200
     the largest dashboard window (720m). *)
 
 let ring_mu = Eio.Mutex.create ()
-let ring : rejection_event list ref = ref []
-(** Most recent first; truncated to [max_ring_size]. *)
+
+type rejection_ring = {
+  events : rejection_event list;
+  count : int;
+}
+
+let empty_ring = { events = []; count = 0 }
+
+let ring : rejection_ring ref = ref empty_ring
+(** [events] is most recent first; truncated to [max_ring_size].
+    [count] is the linearized length so appends do not rescan the full ring. *)
 
 let record_failure_callback_label =
   "dashboard_governance_tool_skipped_record"
@@ -49,13 +58,14 @@ let record_tool_skipped_failure exn =
 
 let append_rejection_event event =
   Eio.Mutex.use_rw ~protect:true ring_mu (fun () ->
-    let next = event :: !ring in
-    let truncated =
-      if List.length next > max_ring_size
-      then List.filteri (fun i _ -> i < max_ring_size) next
-      else next
-    in
-    ring := truncated)
+    let current = !ring in
+    if current.count < max_ring_size
+    then ring := { events = event :: current.events; count = current.count + 1 }
+    else
+      ring :=
+        { events = event :: List.take (max_ring_size - 1) current.events
+        ; count = max_ring_size
+        })
 
 let record_tool_skipped_with_append ~append
     ~keeper_name ~tool_name ~reason_code =
@@ -83,15 +93,20 @@ let record_tool_skipped ~keeper_name ~tool_name ~reason_code =
 (** Reset the ring. Test-only helper — exposed because the alcotest cases
     need to start from a clean state regardless of test order. *)
 let reset_for_testing () =
-  ring := []
+  ring := empty_ring
 
 let snapshot_ring () =
   Safe_ops.protect ~default:[] (fun () ->
-    Eio.Mutex.use_ro ring_mu (fun () -> !ring))
+    Eio.Mutex.use_ro ring_mu (fun () -> (!ring).events))
 
 let inject_for_testing ~keeper_name ~tool_name ~reason_code ~ts =
   let event = { ts; tool_name; reason_code; keeper_name } in
-  ring := event :: !ring
+  append_rejection_event event
+
+let max_ring_size_for_testing = max_ring_size
+
+let ring_size_for_testing () =
+  Eio.Mutex.use_ro ring_mu (fun () -> (!ring).count)
 
 let record_tool_skipped_with_append_for_testing
     ~append ~keeper_name ~tool_name ~reason_code =
@@ -234,4 +249,3 @@ let () =
     ignore (record_tool_skipped ~keeper_name ~tool_name ~reason_code)
   )
 ;;
-

--- a/lib/dashboard/dashboard_governance_metrics.mli
+++ b/lib/dashboard/dashboard_governance_metrics.mli
@@ -56,6 +56,13 @@ val inject_for_testing :
     the production [record_tool_skipped] path so tests can backdate
     [ts] for window-boundary assertions. *)
 
+val max_ring_size_for_testing : int
+(** Production ring cap, exposed only so tests do not duplicate the
+    bounded-buffer constant. *)
+
+val ring_size_for_testing : unit -> int
+(** Current bounded ring size. *)
+
 val record_tool_skipped_with_append_for_testing :
   append:(unit -> unit) ->
   keeper_name:string ->

--- a/test/test_dashboard_governance_metrics.ml
+++ b/test/test_dashboard_governance_metrics.ml
@@ -47,6 +47,20 @@ let test_deterministic_sort () =
   let (second_tool, _, _) = List.nth counts 1 in
   check string "tie-break: tool asc" "zz_tool" second_tool
 
+let test_ring_caps_oldest_event () =
+  let max_ring_size = GM.max_ring_size_for_testing in
+  inject ~tool:"bash" ~reason:"oldest" ();
+  for _ = 1 to max_ring_size do
+    inject ~tool:"bash" ~reason:"kept" ()
+  done;
+  check int "ring size remains capped" max_ring_size (GM.ring_size_for_testing ());
+  let counts = GM.tool_rejection_counts ~now_ts:(now +. 1.0) ~window_minutes:60 () in
+  check int "only kept reason remains" 1 (List.length counts);
+  let (tool, reason, count) = List.hd counts in
+  check string "tool" "bash" tool;
+  check string "oldest reason pruned" "kept" reason;
+  check int "kept count" max_ring_size count
+
 let test_approval_summary_empty () =
   let summary = GM.approval_queue_summary () in
   check int "empty queue depth" 0 summary.depth;
@@ -97,6 +111,7 @@ let () =
       test_case "single rejection" `Quick (with_fresh test_single_rejection);
       test_case "window filter" `Quick (with_fresh test_window_filter);
       test_case "deterministic sort" `Quick (with_fresh test_deterministic_sort);
+      test_case "ring caps oldest event" `Quick (with_fresh test_ring_caps_oldest_event);
     ];
     "approval_queue", [
       test_case "empty queue summary" `Quick test_approval_summary_empty;


### PR DESCRIPTION
## Summary\n- Replace the dashboard governance rejection ring's list-only state with an immutable state record carrying both events and count.\n- Avoid `List.length` on every `record_tool_skipped` append; under-cap appends are now O(1), and tail copying happens only once the ring is full.\n- Add a regression test proving the oldest event is pruned and the ring size remains capped without duplicating the production cap constant in the test.\n\n## Why\nThis matches the same bounded hot-path concern as the SSE replay buffer review item: a bounded buffer should not rescan the full list for every append when the authoritative size can be carried in the state.\n\n## Local checks\n- `opam exec -- ocamlformat --check lib/dashboard/dashboard_governance_metrics.ml lib/dashboard/dashboard_governance_metrics.mli test/test_dashboard_governance_metrics.ml`\n- `git diff --check origin/main...HEAD`\n\nBuild/test authority remains GitHub CI.