### PR TITLE
chore(pin): sync agent_sdk lockfile fingerprint

### DIFF
--- a/masc.opam.locked
+++ b/masc.opam.locked
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "masc"
-version: "0.19.50"
+version: "0.19.51"
 synopsis: "Multi-Agent Shared Context MCP Server in OCaml"
 description:
   "MASC Protocol: File-based workspace collaboration for Claude, Gemini, and Codex agents"
@@ -11,7 +11,7 @@ homepage: "https://github.com/jeong-sik/masc"
 doc: "https://github.com/jeong-sik/masc"
 bug-reports: "https://github.com/jeong-sik/masc/issues"
 depends: [
-  "agent_sdk" {= "0.207.11"}
+  "agent_sdk" {= "0.207.12"}
   "alcotest" {= "1.9.1" & with-test}
   "ambient-context" {= "0.2"}
   "ambient-context-eio" {= "0.2"}
@@ -217,8 +217,8 @@ build: [
 dev-repo: "git+https://github.com/jeong-sik/masc.git"
 pin-depends: [
   [
-  "agent_sdk.0.207.11"
-  "git+https://github.com/jeong-sik/oas.git#e56a78c6b6d307230b2573c858c73a31f7f466cb"
+  "agent_sdk.0.207.12"
+  "git+https://github.com/jeong-sik/oas.git#e34178964349fa171ffb58839b3fe316308b800a"
 ]
   [
     "bisect_ppx.2.8.3"

--- a/scripts/oas-api-surface.json
+++ b/scripts/oas-api-surface.json
@@ -1,6 +1,6 @@
 {
-  "pinned_sha": "e56a78c6b6d307230b2573c858c73a31f7f466cb",
-  "pinned_version": "v0.207.11",
+  "pinned_sha": "e34178964349fa171ffb58839b3fe316308b800a",
+  "pinned_version": "v0.207.12",
   "surfaces": {
     "event_bus_payload_variants": [
       "AgentCompleted",


### PR DESCRIPTION
## Summary
- Sync masc.opam.locked to the already-merged agent_sdk 0.207.12 pin.
- Refresh scripts/oas-api-surface.json metadata to the same OAS SHA/version.

## Context
- OAS release PR jeong-sik/oas#2206 is merged.
- MASC release/pin PR #22525 is merged, but main still had the lockfile and OAS surface fingerprint on 0.207.11.
- Closed PR #22528 covered the broader pin bump and is not reused here; this PR is only the residual lockfile/fingerprint alignment.

## Validation
- scripts/check-oas-pin.sh --local-only
- bash scripts/oas-drift-check.sh
- bash ci/check-oas-pin.sh
- git diff --check
- rg confirmed no 0.207.11/e56a78c6/v0.207.11 residue in the touched pin/fingerprint surfaces.

Full Dune build is left to GitHub CI per current workflow.