### PR TITLE
fix(sandbox): resolve docker launch cwd centrally

### DIFF
--- a/lib/keeper/keeper_sandbox_runtime_setup.ml
+++ b/lib/keeper/keeper_sandbox_runtime_setup.ml
@@ -40,6 +40,8 @@ let docker_image_missing_next_action =
   "Run scripts/build-keeper-sandbox-image.sh to build the default keeper sandbox image."
 ;;
 
+let docker_command_cwd () = Config_dir_resolver.current_working_dir ()
+
 (* RFC-0107 Phase E step 2 — branch on MASC_DOCKER_TRANSPORT env flag here.
    When set to "api", route through [Sandbox.Docker_api] (UDS HTTP) instead
    of forking a [docker] subprocess; the subprocess path stays as the
@@ -51,7 +53,7 @@ let run_docker_argv_with_status ~summary ~timeout_sec argv =
       ~raw_source:(String.concat " " argv)
       ~summary
       ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
-      ~cwd:(Sys.getcwd ())
+      ~cwd:(docker_command_cwd ())
       ~timeout_sec
       argv)
 ;;


### PR DESCRIPTION
## Summary
- route keeper sandbox Docker launch cwd through Config_dir_resolver.current_working_dir
- remove the raw Sys.getcwd call from run_docker_argv_with_status
- keep subprocess fallback behavior unchanged while centralizing deleted-cwd fallback

## Validation
- ocamlformat --check lib/keeper/keeper_sandbox_runtime_setup.ml
- git diff --check
- rg -n "Sys\.getcwd|docker_command_cwd|Config_dir_resolver.current_working_dir" lib/keeper/keeper_sandbox_runtime_setup.ml

Dune build/test intentionally left to GitHub CI per operator instruction; local Dune is not the blocking authority for this slice.