### PR TITLE
fix(keeper): resolve sandbox launch cwd centrally

### DIFF
--- a/lib/keeper/keeper_sandbox_control.ml
+++ b/lib/keeper/keeper_sandbox_control.ml
@@ -226,7 +226,7 @@ let start_managed_container
                         ~raw_source:(String.concat " " argv)
                         ~summary:"keeper sandbox control exec"
                         ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
-                        ~cwd:(Sys.getcwd ())
+                        ~cwd:(Config_dir_resolver.current_working_dir ())
                         ~timeout_sec
                         argv)
                   in

--- a/lib/keeper/keeper_sandbox_docker.ml
+++ b/lib/keeper/keeper_sandbox_docker.ml
@@ -198,7 +198,7 @@ let cleanup_oneshot_container ~container_name =
         ~raw_source:(String.concat " " argv)
         ~summary:"keeper docker oneshot cleanup"
         ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
-        ~cwd:(Sys.getcwd ())
+        ~cwd:(Config_dir_resolver.current_working_dir ())
         ~timeout_sec:(docker_cleanup_rm_timeout_sec ())
         argv)
   in
@@ -587,7 +587,7 @@ let run_docker_shell_command_with_status_internal
                                    ~env:
                                      (Env_keeper_scrub.filter_environment
                                         (Unix.environment ()))
-                                   ~cwd:(Sys.getcwd ())
+                                   ~cwd:(Config_dir_resolver.current_working_dir ())
                                    ~timeout_sec
                                    ~stdin_content:cmd
                                    argv)

--- a/lib/keeper/keeper_sandbox_read_backend.ml
+++ b/lib/keeper/keeper_sandbox_read_backend.ml
@@ -186,7 +186,7 @@ let run_command_with_status ?turn_sandbox_factory
                    ~raw_source:(String.concat " " argv)
                    ~summary:"keeper docker read sandboxed command"
                    ~env:(Env_keeper_scrub.filter_environment (Unix.environment ()))
-                   ~cwd:(Sys.getcwd ())
+                   ~cwd:(Config_dir_resolver.current_working_dir ())
                    ~timeout_sec
                    argv))
         in

--- a/lib/keeper/keeper_turn_sandbox_runtime.ml
+++ b/lib/keeper/keeper_turn_sandbox_runtime.ml
@@ -224,7 +224,7 @@ let run_argv_with_status_retry_eintr ?timeout_sec argv =
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox command"
           ~env:(Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()))
-          ~cwd:(Sys.getcwd ())
+          ~cwd:(Config_dir_resolver.current_working_dir ())
           argv
       in
       match st with
@@ -554,7 +554,7 @@ let run_argv_with_status_split_retry_eintr
       ~run_attempt:(fun ?on_stdout_chunk ?on_stderr_chunk () ->
         let raw_source = String.concat " " argv in
         let env = Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()) in
-        let cwd = Sys.getcwd () in
+        let cwd = Config_dir_resolver.current_working_dir () in
         match on_stdout_chunk, on_stderr_chunk with
         | None, None ->
           Masc_exec.Exec_gate.run_argv_with_status_split
@@ -597,7 +597,7 @@ let run_argv_with_stdin_and_status_retry_eintr ?timeout_sec ~stdin_content argv 
           ~raw_source:(String.concat " " argv)
           ~summary:"keeper turn sandbox stdin command"
           ~env:(Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()))
-          ~cwd:(Sys.getcwd ())
+          ~cwd:(Config_dir_resolver.current_working_dir ())
           ~stdin_content
           argv
       in
@@ -625,7 +625,7 @@ let run_argv_with_stdin_and_status_split_retry_eintr
       ~run_attempt:(fun ?on_stdout_chunk ?on_stderr_chunk () ->
         let raw_source = String.concat " " argv in
         let env = Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()) in
-        let cwd = Sys.getcwd () in
+        let cwd = Config_dir_resolver.current_working_dir () in
         Masc_exec.Exec_gate.run_argv_with_stdin_and_status_split
           ?timeout_sec
           ~actor:`System_sandbox
@@ -1058,7 +1058,10 @@ let run_exec_pipeline_with_status_once
           let cwd = Option.value stage_cwd ~default:cwd in
           let container_cwd = container_cwd_of_host t ~host_cwd:cwd in
           let argv = docker_exec_pipeline_argv t ~container_name ~container_cwd command_argv in
-          { Process_eio.argv; env = Some (Env_keeper_scrub.filter_environment_c_messages (Unix.environment ())); cwd = Some (Sys.getcwd ()) })
+          { Process_eio.argv
+          ; env = Some (Env_keeper_scrub.filter_environment_c_messages (Unix.environment ()))
+          ; cwd = Some (Config_dir_resolver.current_working_dir ())
+          })
         stages
     in
     Ok


### PR DESCRIPTION
## Summary
- route keeper sandbox control/docker/read/turn launch cwd snapshots through Config_dir_resolver.current_working_dir
- remove raw Sys.getcwd calls from the touched sandbox launch paths
- keep argv/env/timeout behavior unchanged

## Validation
- ocamlformat --check lib/keeper/keeper_sandbox_control.ml lib/keeper/keeper_sandbox_docker.ml lib/keeper/keeper_sandbox_read_backend.ml lib/keeper/keeper_turn_sandbox_runtime.ml
- git diff --check
- rg -n "Sys\.getcwd|Config_dir_resolver.current_working_dir" lib/keeper/keeper_sandbox_control.ml lib/keeper/keeper_sandbox_docker.ml lib/keeper/keeper_sandbox_read_backend.ml lib/keeper/keeper_turn_sandbox_runtime.ml

Dune build/test intentionally left to GitHub CI per operator instruction; local Dune is not the blocking authority for this slice.