### PR TITLE
fix(keeper): clear no-progress resume latch

### DIFF
--- a/lib/keeper/keeper_reaction_ledger.ml
+++ b/lib/keeper/keeper_reaction_ledger.ml
@@ -380,6 +380,13 @@ let bool_field name json =
   | _ -> false
 ;;
 
+let string_list_field name json =
+  list_field name json
+  |> List.filter_map (function
+    | `String value -> Some value
+    | _ -> None)
+;;
+
 let nested_string_field outer inner json =
   match assoc_field outer json with
   | Some nested -> string_field inner nested
@@ -399,6 +406,28 @@ let reaction_receipt_field name row =
      | Some receipt -> string_field name receipt
      | None -> None)
   | None -> None
+;;
+
+let reaction_field name row =
+  match assoc_field "reaction" row with
+  | Some reaction -> assoc_field name reaction
+  | None -> None
+;;
+
+let reaction_current_task_id row =
+  match reaction_field "current_task_id" row with
+  | Some (`String value) when String.trim value <> "" -> Some value
+  | _ -> None
+;;
+
+let reaction_goal_ids row =
+  match assoc_field "reaction" row with
+  | Some reaction -> string_list_field "goal_ids" reaction
+  | None -> []
+;;
+
+let passive_only_without_work_scope row =
+  Option.is_none (reaction_current_task_id row) && reaction_goal_ids row = []
 ;;
 
 let summary_schema = "keeper.reaction_ledger.summary.v1"
@@ -593,6 +622,8 @@ let summarize_rows ~keeper_name ~limit rows =
       (match Receipt_result.of_string result with
        | Some typed ->
          (match contract_result_attention_of_typed typed with
+          | Contract_attention { result = Receipt_result.Passive_only; _ }
+            when passive_only_without_work_scope row -> ()
           | Contract_attention { result; label } ->
             note_contract_attention_label ~result ~label
           | Contract_no_attention -> ())

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -168,7 +168,14 @@ let update_keeper ?(preserve_prompt_defaults = false)
     Log.Keeper.warn
       "update_keeper kept %s paused because an approval/reconcile gate is pending"
       old.name;
-  let updated = { old with
+  let source_meta =
+    if resume_paused_keeper then
+      Keeper_unified_turn_no_progress.clear_for_operator_resume
+        ~base_path:ctx.config.base_path
+        old
+    else old
+  in
+  let updated = { source_meta with
     goal;
     instructions =
       (match p.instructions_arg with
@@ -194,10 +201,10 @@ let update_keeper ?(preserve_prompt_defaults = false)
     runtime =
       (if resume_paused_keeper then
          {
-           old.runtime with
+           source_meta.runtime with
            last_blocker = None;
          }
-       else old.runtime);
+       else source_meta.runtime);
     mention_targets;
     telemetry_feedback_enabled =
       Dashboard_utils.first_some p.profile_defaults.telemetry_feedback_enabled

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -83,10 +83,19 @@ let handle_keeper_lifecycle_post ?body_str ~sw ~clock ~tool_name ~action
       match Keeper_meta_store.read_meta config name with
       | Ok (Some meta) when Bool.equal meta.paused paused -> ()
       | Ok (Some meta) ->
+          let source_meta =
+            if paused then meta
+            else
+              Keeper_unified_turn_no_progress.clear_for_operator_resume
+                ~base_path:config.base_path
+                meta
+          in
           let updated_meta =
             {
-              meta with
+              source_meta with
               paused;
+              auto_resume_after_sec =
+                (if paused then source_meta.auto_resume_after_sec else None);
               updated_at = Keeper_meta_contract.now_iso ();
             }
           in

--- a/test/test_keeper_pause_silent_failure_source.ml
+++ b/test/test_keeper_pause_silent_failure_source.ml
@@ -31,6 +31,7 @@ let target_files =
   ]
 
 let status_detail_file = "lib/keeper/keeper_status_detail.ml"
+let keeper_up_update_file = "lib/keeper/keeper_turn_up_update.ml"
 
 let metric_name = "Keeper_metrics.(to_string PausedStatePersistErrors)"
 
@@ -167,6 +168,22 @@ let test_counter_inc_calls () =
        src
      >= 6)
 
+let test_resume_paths_clear_no_progress_latch () =
+  let lifecycle_src =
+    load_source "lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml"
+  in
+  let update_src = load_source keeper_up_update_file in
+  check bool "boot resume clears no-progress latch" true
+    (count_occurrences
+       ~needle:"Keeper_unified_turn_no_progress.clear_for_operator_resume"
+       lifecycle_src
+     >= 1);
+  check bool "masc_keeper_up resume clears no-progress latch" true
+    (count_occurrences
+       ~needle:"Keeper_unified_turn_no_progress.clear_for_operator_resume"
+       update_src
+     >= 1)
+
 let test_keeper_status_disposition_mirrors_runtime_trust () =
   let src = load_source status_detail_file in
   check bool "keeper status builds runtime_trust" true
@@ -203,6 +220,8 @@ let () =
             test_error_branch_observable
         ; test_case "counter inc calls present" `Quick
             test_counter_inc_calls
+        ; test_case "resume paths clear no-progress latch" `Quick
+            test_resume_paths_clear_no_progress_latch
         ; test_case "keeper status mirrors runtime-trust disposition" `Quick
             test_keeper_status_disposition_mirrors_runtime_trust
         ] )

--- a/test/test_keeper_reaction_ledger.ml
+++ b/test/test_keeper_reaction_ledger.ml
@@ -379,6 +379,56 @@ let test_completion_contract_result_canonical_roundtrip () =
      |> Option.map Receipt.completion_contract_result_to_string)
 ;;
 
+let test_summary_ignores_passive_only_without_work_scope () =
+  with_temp_base @@ fun base_path ->
+  let config = Workspace.default_config base_path in
+  let keeper_name = "passive-no-work-keeper" in
+  let receipt_json =
+    `Assoc
+      [ "schema", `String "keeper.execution_receipt.v1"
+      ; "trace_id", `String "trace-passive-no-work"
+      ; "outcome", `String "receipt_done"
+      ; "terminal_reason_code", `String "completed"
+      ; "operator_disposition", `String "pass"
+      ; "operator_disposition_reason", `String "healthy"
+      ; "completion_contract_result", `String "passive_only"
+      ]
+  in
+  Keeper_reaction_ledger.record_execution_receipt_reaction
+    config
+    ~keeper_name
+    ~trace_id:"trace-passive-no-work"
+    ~turn_count:1
+    ~current_task_id:None
+    ~goal_ids:[]
+    ~outcome:"receipt_done"
+    ~terminal_reason_code:"completed"
+    ~receipt_json
+    ();
+  let summary =
+    Keeper_reaction_ledger.summary_for_keeper ~base_path ~keeper_name ~limit:10
+  in
+  check int "passive-only no-work attention not counted" 0
+    (summary |> member "completion_contract_attention_count" |> to_int);
+  check int "passive-only no-work passive count not counted" 0
+    (summary |> member "completion_contract_passive_only_count" |> to_int);
+  check
+    string
+    "passive-only no-work summary remains ok"
+    "ok"
+    (summary |> member "status" |> to_string);
+  let fleet =
+    Keeper_reaction_ledger.fleet_summary_json
+      ~base_path
+      ~keeper_names:[ keeper_name ]
+      ~limit_per_keeper:10
+  in
+  check int "fleet passive-only no-work attention not counted" 0
+    (fleet |> member "completion_contract_attention_count" |> to_int);
+  check int "fleet passive-only no-work passive count not counted" 0
+    (fleet |> member "completion_contract_passive_only_count" |> to_int)
+;;
+
 let test_summary_marks_unreacted_and_reacted_stimuli () =
   with_temp_base @@ fun base_path ->
   let keeper_name = "summary-keeper" in
@@ -751,6 +801,10 @@ let () =
             "completion-contract parser and attention use canonical receipt type"
             `Quick
             test_completion_contract_result_canonical_roundtrip
+        ; test_case
+            "summary ignores passive-only receipts without work scope"
+            `Quick
+            test_summary_ignores_passive_only_without_work_scope
         ; test_case
             "summary marks unreacted and reacted stimuli"
             `Quick


### PR DESCRIPTION
## Summary
- clear the no-progress latch/blocker when dashboard boot/Play resumes a paused keeper
- clear the same latch when masc_keeper_up resumes a paused keeper
- make reaction-ledger passive_only attention scope-aware so no-work passive-only receipts do not keep the fleet degraded

## Evidence
- live health before patch showed durable paused keepers with last_blocker=no_progress_loop and threshold=1
- scripts/dune-local.sh build test/test_keeper_reaction_ledger.exe
- scripts/dune-local.sh build test/test_keeper_pause_silent_failure_source.exe
- ./_build/default/test/test_keeper_reaction_ledger.exe
- ./_build/default/test/test_keeper_pause_silent_failure_source.exe
- git diff --check
- after rebase onto origin/main: git diff --check origin/main...HEAD

## Notes
- Rebase after local validation was clean. Re-running the focused builds after rebase was stopped because another worktree held the shared Dune lock; CI is the build authority for the final result.