### PR TITLE
fix(build): export absolute_path + validate_path (.mli sync)

### DIFF
--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -174,6 +174,13 @@ val config_signature_exists : string -> bool
     [MASC_TEST_ALLOW_CONFIG_PATH_OVERRIDE]. *)
 
 val current_env_base_path_opt : unit -> string option
+
+(** [absolute_path path] returns [path] as an absolute path, resolving
+    relative [path] against the process cwd via [current_working_dir]. Prefer
+    [absolute_path_from ~cwd] when the caller has an explicit anchor so the
+    anchor stays the SSOT. *)
+val absolute_path : string -> string
+
 val current_env_config_dir_opt : unit -> string option
 val current_env_personas_dir_opt : unit -> string option
 

--- a/lib/exec_policy/exec_policy.mli
+++ b/lib/exec_policy/exec_policy.mli
@@ -51,6 +51,12 @@ val simple_literal_args : Masc_exec.Shell_ir.simple -> string list option
 
 val path_argument_values : string -> string list -> string list
 
+(** [validate_path ~keeper_id ~base_path ~workdir path] checks [path] against
+    the exec policy path rules (tmp/workspace scoping). Returns [true] when the
+    path is admissible. *)
+val validate_path :
+  ?keeper_id:string -> ?base_path:string -> ?workdir:string -> string -> bool
+
 val existing_dir_path_values_of_shell_ir : Masc_exec.Shell_ir.t -> string list
 
 val existing_sibling_dirs_hint : ?workdir:string -> string -> string option


### PR DESCRIPTION
## 목적

main 빌드 고장 2건 (`.mli` export 누락) 수정. 사용자 직접 요청(`dune build .` 에러).

## 에러

1. `lib/server/server_routes_http_sidecar_paths.ml:33` — `Config_dir_resolver.absolute_path` Unbound value
2. `test/test_keeper_tool_policy_paths.ml:218` — `Exec_policy.Paths` Unbound module

## 근본 원인

두 함수 모두 **구현(`.ml`)은 존재**하지만 **`.mli`에 export가 누락**:
- `config_dir_resolver.ml:157 let absolute_path` — `.mli`에 없음. `current_env_base_path_opt`(:176)는 export됨.
- `exec_policy.ml:13 let validate_path = Paths.validate_path` (=`Exec_policy_paths.validate_path`) — `.mli`에 없음. `path_argument_values`/`validate_shell_ir_paths`는 export됨.

본인이 #22444 / #22468 등으로 `.ml`에 추가 후 `.mli` 동기화 누락.

## 변경

- `config_dir_resolver.mli`: `val absolute_path : string -> string` 추가 (impl 시그니처와 일치).
- `exec_policy.mli`: `val validate_path : ?keeper_id:string -> ?base_path:string -> ?workdir:string -> string -> bool` 추가.

callsite 수정 없이 `.mli` export만 추가 — 구현 의도(외부 사용)에 부합.

## 검증
- 로컬 빌드 금지 원칙 → CI `Build and Test`로 Unbound 에러 해소 확인.

## 워크어라운드 게이트
`.mli` export 동기화 — 워크어라운드 시그니처 3종 해당 없음.

## 연계
본인이 main 고속 머지 중 callsite/export 누락 누적. broadcast 선점 완료.

Co-Authored-By: Claude <noreply@anthropic.com>
