### PR TITLE
fix(dashboard): persist keeper config controls

### DIFF
--- a/dashboard/src/api/dashboard-keeper-config.ts
+++ b/dashboard/src/api/dashboard-keeper-config.ts
@@ -146,6 +146,8 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
   return {
     name: asNullableString(data.name) ?? requestedName,
     active_goal_ids: normalizeStringList(data.active_goal_ids),
+    autoboot_enabled: asLooseBoolean(data.autoboot_enabled, true),
+    max_context_override: asInt(data.max_context_override) ?? null,
     sandbox_profile: asNullableString(data.sandbox_profile) ?? '(unknown sandbox_profile)',
     network_mode: asNullableString(data.network_mode) ?? '(unknown network_mode)',
     sandbox_last_error: asNullableString(data.sandbox_last_error),
@@ -283,12 +285,13 @@ export function fetchKeeperConfig(name: string): Promise<KeeperConfig> {
 
 export type SandboxProfile = 'local' | 'docker'
 export type SandboxNetworkMode = 'none' | 'inherit'
-export type SharedMemoryScope = 'disabled' | 'workspace'
 
 export type KeeperConfigUpdatePayload = {
   runtime_id?: string
   active_goal_ids?: string[]
   mention_targets?: string[]
+  autoboot_enabled?: boolean
+  max_context_override?: number | null
   allowed_paths?: string[]
   // Sandbox
   sandbox_profile?: SandboxProfile
@@ -301,6 +304,7 @@ export type KeeperConfigUpdatePayload = {
   proactive_idle_sec?: number
   proactive_cooldown_sec?: number
   // Compaction
+  compaction_profile?: string
   compaction_ratio_gate?: number
   compaction_message_gate?: number
   compaction_token_gate?: number
@@ -324,11 +328,9 @@ export async function patchKeeperConfig(
 
 // Tool policy is set atomically (tool_access + denylist) via the dedicated
 // /tools endpoint with action=set_policy — a different mutation shape from the
-// /config PATCH above. The caller should echo the current tool_access so that
-// editing only the denylist preserves the operator's configured allowlist
-// record (which feeds tool visibility + assignment telemetry). Runtime
-// execution gating keys only off the denylist, not tool_access. The endpoint
-// returns the updated tools block (not the full config), so we re-fetch the
+// /config PATCH above. The endpoint overwrites both tool_access and denylist,
+// and runtime execution gating keys only off the denylist, not tool_access.
+// It returns the updated tools block (not the full config), so we re-fetch the
 // config to get a consistent normalized snapshot.
 export async function setKeeperToolPolicy(
   name: string,

--- a/dashboard/src/api/dashboard-keeper-config.ts
+++ b/dashboard/src/api/dashboard-keeper-config.ts
@@ -140,6 +140,7 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
   const tools = isRecord(data.tools) ? data.tools : {}
   const sources = isRecord(data.sources) ? data.sources : {}
   const metrics = isRecord(data.metrics) ? data.metrics : {}
+  const limits = isRecord(data.limits) ? data.limits : {}
   const perProviderTimeoutSec = asLooseNullableNumber(execution.per_provider_timeout_sec)
   const lastLatencyMs = asInt(metrics.last_latency_ms)
 
@@ -148,6 +149,10 @@ function normalizeKeeperConfig(raw: unknown, requestedName: string): KeeperConfi
     active_goal_ids: normalizeStringList(data.active_goal_ids),
     autoboot_enabled: asLooseBoolean(data.autoboot_enabled, true),
     max_context_override: asInt(data.max_context_override) ?? null,
+    limits: {
+      min_context_override_tokens: asInt(limits.min_context_override_tokens) ?? null,
+      max_context_override_tokens: asInt(limits.max_context_override_tokens) ?? null,
+    },
     sandbox_profile: asNullableString(data.sandbox_profile) ?? '(unknown sandbox_profile)',
     network_mode: asNullableString(data.network_mode) ?? '(unknown network_mode)',
     sandbox_last_error: asNullableString(data.sandbox_last_error),

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1903,6 +1903,8 @@ describe('fetchKeeperConfig', () => {
     const rawResponse = {
       name: 'keeper-sangsu',
       active_goal_ids: ['goal-runtime'],
+      autoboot_enabled: 'false',
+      max_context_override: '64000',
       sandbox_profile: 'docker',
       network_mode: 'none',
       sandbox_last_error: 'sandbox docker exec failed',
@@ -2038,6 +2040,8 @@ describe('fetchKeeperConfig', () => {
     const result = await fetchKeeperConfig('keeper-sangsu')
 
     expect(result.allowed_paths).toEqual(['/tmp/workspace'])
+    expect(result.autoboot_enabled).toBe(false)
+    expect(result.max_context_override).toBe(64000)
     expect(result.sandbox_profile).toBe('docker')
     expect(result.network_mode).toBe('none')
     expect(result.sandbox_last_error).toBe('sandbox docker exec failed')

--- a/dashboard/src/api/dashboard.test.ts
+++ b/dashboard/src/api/dashboard.test.ts
@@ -1905,6 +1905,10 @@ describe('fetchKeeperConfig', () => {
       active_goal_ids: ['goal-runtime'],
       autoboot_enabled: 'false',
       max_context_override: '64000',
+      limits: {
+        min_context_override_tokens: '64000',
+        max_context_override_tokens: '1000000',
+      },
       sandbox_profile: 'docker',
       network_mode: 'none',
       sandbox_last_error: 'sandbox docker exec failed',
@@ -2042,6 +2046,10 @@ describe('fetchKeeperConfig', () => {
     expect(result.allowed_paths).toEqual(['/tmp/workspace'])
     expect(result.autoboot_enabled).toBe(false)
     expect(result.max_context_override).toBe(64000)
+    expect(result.limits).toEqual({
+      min_context_override_tokens: 64000,
+      max_context_override_tokens: 1000000,
+    })
     expect(result.sandbox_profile).toBe('docker')
     expect(result.network_mode).toBe('none')
     expect(result.sandbox_last_error).toBe('sandbox docker exec failed')

--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -208,7 +208,6 @@ export {
 export type {
   SandboxProfile,
   SandboxNetworkMode,
-  SharedMemoryScope,
   KeeperConfigUpdatePayload,
 } from './dashboard-keeper-config'
 export {

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -9,6 +9,7 @@ import {
   filterHookSlots,
   hookSlotDetails,
   initRuntimeDraftFromConfig,
+  MAX_CONTEXT_OVERRIDE_TOKENS,
   type HookSlotEntry,
   type RuntimeDraft,
 } from './keeper-config-panel'
@@ -531,6 +532,14 @@ describe('buildRuntimePayload — sandbox diffing', () => {
       max_context_override: 0,
     }), c)
     expect(payload.max_context_override).toBeNull()
+  })
+
+  it('clamps max_context_override to the backend keeper bound before PATCH', () => {
+    const c = makeKeeperConfigForSandbox({ max_context_override: null })
+    const payload = buildRuntimePayload(draftFrom(c, {
+      max_context_override: MAX_CONTEXT_OVERRIDE_TOKENS + 1,
+    }), c)
+    expect(payload.max_context_override).toBe(MAX_CONTEXT_OVERRIDE_TOKENS)
   })
 })
 

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -6,7 +6,6 @@ import {
   buildRuntimePayload,
   coerceNetworkMode,
   coerceSandboxProfile,
-  coerceSharedMemoryScope,
   filterHookSlots,
   hookSlotDetails,
   initRuntimeDraftFromConfig,
@@ -28,6 +27,8 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
   return {
     name: 'keeper-sangsu',
     active_goal_ids: ['goal-runtime'],
+    autoboot_enabled: true,
+    max_context_override: null,
     sandbox_profile: 'local',
     network_mode: 'inherit',
     sandbox_last_error: null,
@@ -261,18 +262,14 @@ describe('sandbox coerce helpers', () => {
     expect(coerceNetworkMode(undefined)).toBe('inherit')
   })
 
-  it('coerceSharedMemoryScope maps workspace, falls back to disabled otherwise', () => {
-    expect(coerceSharedMemoryScope('workspace')).toBe('workspace')
-    expect(coerceSharedMemoryScope('disabled')).toBe('disabled')
-    expect(coerceSharedMemoryScope('unknown')).toBe('disabled')
-    expect(coerceSharedMemoryScope(undefined)).toBe('disabled')
-  })
 })
 
 function makeKeeperConfigForSandbox(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
   const base: KeeperConfig = {
     name: 'test-keeper',
     active_goal_ids: [],
+    autoboot_enabled: true,
+    max_context_override: null,
     sandbox_profile: 'local',
     network_mode: 'inherit',
     allowed_paths: [],
@@ -504,6 +501,36 @@ describe('buildRuntimePayload — sandbox diffing', () => {
       compaction_token_gate: 32000,
     }), c)
     expect(payload.compaction_token_gate).toBe(32000)
+  })
+
+  it('emits compaction_profile, autoboot, and max_context_override edits', () => {
+    const c = makeKeeperConfigForSandbox({
+      autoboot_enabled: true,
+      max_context_override: null,
+      compaction: {
+        profile: 'balanced',
+        ratio_gate: 0.8,
+        message_gate: 0,
+        token_gate: 24000,
+        cooldown_sec: 0,
+      },
+    })
+    const payload = buildRuntimePayload(draftFrom(c, {
+      autoboot_enabled: false,
+      max_context_override: 64000,
+      compaction_profile: 'conservative',
+    }), c)
+    expect(payload.autoboot_enabled).toBe(false)
+    expect(payload.max_context_override).toBe(64000)
+    expect(payload.compaction_profile).toBe('conservative')
+  })
+
+  it('emits null to clear max_context_override when draft is zero', () => {
+    const c = makeKeeperConfigForSandbox({ max_context_override: 64000 })
+    const payload = buildRuntimePayload(draftFrom(c, {
+      max_context_override: 0,
+    }), c)
+    expect(payload.max_context_override).toBeNull()
   })
 })
 
@@ -814,6 +841,43 @@ describe('KeeperConfigPanel', () => {
     })
   })
 
+  it('saves edited tool_access and denylist together via set_policy', async () => {
+    mocks.setKeeperToolPolicy.mockClear()
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    selectKcfTab(container, '실행 정책')
+    await flush()
+
+    const toolAccess = container.querySelector(
+      'textarea[aria-label="tool_access"]',
+    ) as HTMLTextAreaElement | null
+    const denylist = container.querySelector(
+      'textarea[aria-label="tool_denylist"]',
+    ) as HTMLTextAreaElement | null
+    expect(toolAccess).not.toBeNull()
+    expect(denylist).not.toBeNull()
+
+    toolAccess!.value = 'tool_read_file\nmasc_status\ntool_read_file\n'
+    toolAccess!.dispatchEvent(new Event('input', { bubbles: true }))
+    denylist!.value = 'Execute\nDangerTool\nExecute\n'
+    denylist!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('정책 저장'),
+    )
+    saveButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+
+    expect(mocks.setKeeperToolPolicy).toHaveBeenCalledWith('keeper-sangsu', {
+      tool_access: ['tool_read_file', 'masc_status'],
+      deny: ['Execute', 'DangerTool'],
+    })
+  })
+
   it('patches runtime_id from the dashboard panel', async () => {
     mocks.patchKeeperConfig.mockResolvedValueOnce(
       makeKeeperConfig({
@@ -952,6 +1016,61 @@ describe('KeeperConfigPanel', () => {
       expect.objectContaining({
         mention_targets: ['alpha', 'beta'],
         compaction_token_gate: 32000,
+      }),
+    )
+  })
+
+  it('patches compaction profile, autoboot, and max-context override from the dashboard panel', async () => {
+    const base = makeKeeperConfig()
+    mocks.patchKeeperConfig.mockResolvedValueOnce(
+      makeKeeperConfig({
+        autoboot_enabled: false,
+        max_context_override: 64000,
+        compaction: {
+          ...base.compaction,
+          profile: 'conservative',
+        },
+      }),
+    )
+
+    render(html`<${KeeperConfigPanel} keeperName="keeper-sangsu" />`, container)
+    await flush()
+    await flush()
+
+    selectKcfTab(container, '런타임')
+    await flush()
+    const maxContext = container.querySelector('input[aria-label="컨텍스트 오버라이드"]') as HTMLInputElement | null
+    expect(maxContext).not.toBeNull()
+    maxContext!.value = '64000'
+    maxContext!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flush()
+
+    selectKcfTab(container, '실행 정책')
+    await flush()
+    const compactionProfile = container.querySelector('select[aria-label="compaction_profile"]') as HTMLSelectElement | null
+    expect(compactionProfile).not.toBeNull()
+    compactionProfile!.value = 'conservative'
+    compactionProfile!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+
+    const autoboot = container.querySelector('button[aria-label="자동 부팅"]') as HTMLButtonElement | null
+    expect(autoboot).not.toBeNull()
+    autoboot!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(button =>
+      button.textContent?.includes('런타임 설정 저장'),
+    )
+    saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    await flush()
+
+    expect(mocks.patchKeeperConfig).toHaveBeenCalledWith(
+      'keeper-sangsu',
+      expect.objectContaining({
+        autoboot_enabled: false,
+        max_context_override: 64000,
+        compaction_profile: 'conservative',
       }),
     )
   })

--- a/dashboard/src/components/keeper-config-panel.test.ts
+++ b/dashboard/src/components/keeper-config-panel.test.ts
@@ -9,7 +9,6 @@ import {
   filterHookSlots,
   hookSlotDetails,
   initRuntimeDraftFromConfig,
-  MAX_CONTEXT_OVERRIDE_TOKENS,
   type HookSlotEntry,
   type RuntimeDraft,
 } from './keeper-config-panel'
@@ -30,6 +29,10 @@ function makeKeeperConfig(overrides: Partial<KeeperConfig> = {}): KeeperConfig {
     active_goal_ids: ['goal-runtime'],
     autoboot_enabled: true,
     max_context_override: null,
+    limits: {
+      min_context_override_tokens: 64_000,
+      max_context_override_tokens: 1_000_000,
+    },
     sandbox_profile: 'local',
     network_mode: 'inherit',
     sandbox_last_error: null,
@@ -271,6 +274,10 @@ function makeKeeperConfigForSandbox(overrides: Partial<KeeperConfig> = {}): Keep
     active_goal_ids: [],
     autoboot_enabled: true,
     max_context_override: null,
+    limits: {
+      min_context_override_tokens: 64_000,
+      max_context_override_tokens: 1_000_000,
+    },
     sandbox_profile: 'local',
     network_mode: 'inherit',
     allowed_paths: [],
@@ -535,11 +542,17 @@ describe('buildRuntimePayload — sandbox diffing', () => {
   })
 
   it('clamps max_context_override to the backend keeper bound before PATCH', () => {
-    const c = makeKeeperConfigForSandbox({ max_context_override: null })
+    const c = makeKeeperConfigForSandbox({
+      max_context_override: null,
+      limits: {
+        min_context_override_tokens: 64_000,
+        max_context_override_tokens: 128_000,
+      },
+    })
     const payload = buildRuntimePayload(draftFrom(c, {
-      max_context_override: MAX_CONTEXT_OVERRIDE_TOKENS + 1,
+      max_context_override: 128_001,
     }), c)
-    expect(payload.max_context_override).toBe(MAX_CONTEXT_OVERRIDE_TOKENS)
+    expect(payload.max_context_override).toBe(128_000)
   })
 })
 

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -179,11 +179,13 @@ function formatRelativeTime(date: Date): string {
 }
 
 // Runtime config draft for sandbox/proactive/compaction/handoff inline editing
-export const MAX_CONTEXT_OVERRIDE_TOKENS = 1_000_000
-
-export function normalizeMaxContextOverrideDraft(value: number): number {
+export function normalizeMaxContextOverrideDraft(value: number, maxTokens?: number | null): number {
   if (!Number.isFinite(value)) return 0
-  return Math.min(MAX_CONTEXT_OVERRIDE_TOKENS, Math.max(0, Math.trunc(value)))
+  const normalized = Math.max(0, Math.trunc(value))
+  const max = Number.isFinite(maxTokens) && (maxTokens ?? 0) > 0
+    ? Math.trunc(maxTokens as number)
+    : null
+  return max == null ? normalized : Math.min(max, normalized)
 }
 
 export type RuntimeDraft = {
@@ -272,7 +274,10 @@ export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
   return {
     runtime_id: c.execution.selected_runtime_id ?? '',
     autoboot_enabled: c.autoboot_enabled,
-    max_context_override: normalizeMaxContextOverrideDraft(c.max_context_override ?? 0),
+    max_context_override: normalizeMaxContextOverrideDraft(
+      c.max_context_override ?? 0,
+      c.limits.max_context_override_tokens,
+    ),
     sandbox_profile: coerceSandboxProfile(c.sandbox_profile),
     active_goal_ids: c.workspace.active_goal_ids.length > 0
       ? c.workspace.active_goal_ids
@@ -304,7 +309,10 @@ export function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): Ke
     : orig.active_goal_ids
   if (draft.runtime_id.trim() !== (orig.execution.selected_runtime_id ?? '').trim()) payload.runtime_id = draft.runtime_id.trim()
   if (draft.autoboot_enabled !== orig.autoboot_enabled) payload.autoboot_enabled = draft.autoboot_enabled
-  const draftMaxContextOverride = normalizeMaxContextOverrideDraft(draft.max_context_override)
+  const draftMaxContextOverride = normalizeMaxContextOverrideDraft(
+    draft.max_context_override,
+    orig.limits.max_context_override_tokens,
+  )
   if (draftMaxContextOverride !== (orig.max_context_override ?? 0)) {
     payload.max_context_override = draftMaxContextOverride > 0 ? draftMaxContextOverride : null
   }
@@ -853,6 +861,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
   const dirtyFlags = rd ? computeRuntimeDirtyFlags(rd, c) : {}
 
   const runtimeHasChanges = rd ? Object.keys(buildRuntimePayload(rd, c)).length > 0 : false
+  const maxContextOverrideTokens = c.limits.max_context_override_tokens ?? undefined
   const runtimeOptions = rd
     ? dedupeStrings([
         rd.runtime_id,
@@ -1102,8 +1111,8 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
       ]} />
       ${rd ? html`
         <${InlineNumberRow} label="컨텍스트 오버라이드" value=${rd.max_context_override}
-          onChange=${(v: number) => updateRuntimeDraft('max_context_override', normalizeMaxContextOverrideDraft(v))}
-          min=${0} max=${MAX_CONTEXT_OVERRIDE_TOKENS} step=${1000} suffix="tok"
+          onChange=${(v: number) => updateRuntimeDraft('max_context_override', normalizeMaxContextOverrideDraft(v, c.limits.max_context_override_tokens))}
+          min=${0} max=${maxContextOverrideTokens} step=${1000} suffix="tok"
           dirty=${dirtyFlags.max_context_override} />
       ` : c.max_context_override != null ? html`
         <${ConfigRow} label="컨텍스트 오버라이드" value=${formatTokens(c.max_context_override)} />
@@ -1140,7 +1149,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         dirty=${dirtyFlags.compaction_message_gate} />
       <${InlineNumberRow} label="토큰 게이트" value=${rd.compaction_token_gate}
         onChange=${(v: number) => updateRuntimeDraft('compaction_token_gate', v)}
-        min=${0} max=${1000000} step=${1000} suffix="tok"
+        min=${0} max=${maxContextOverrideTokens} step=${1000} suffix="tok"
         dirty=${dirtyFlags.compaction_token_gate} />
       <${InlineNumberRow} label="쿨다운 (초)" value=${rd.compaction_cooldown_sec}
         onChange=${(v: number) => updateRuntimeDraft('compaction_cooldown_sec', v)}

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -10,7 +10,7 @@ import {
   patchKeeperConfig,
   setKeeperToolPolicy,
 } from '../api/dashboard'
-import type { KeeperConfigUpdatePayload, SandboxProfile, SandboxNetworkMode, SharedMemoryScope } from '../api/dashboard'
+import type { KeeperConfigUpdatePayload, SandboxProfile, SandboxNetworkMode } from '../api/dashboard'
 import type { GoalTreeNode, KeeperConfig, KeeperHookSlot } from '../types'
 import { formatTokens, formatPct, formatCost } from '../lib/format-number'
 import { isVerifierRoleKeeper } from '../lib/keeper-utils'
@@ -182,6 +182,8 @@ function formatRelativeTime(date: Date): string {
 
 export type RuntimeDraft = {
   runtime_id: string
+  autoboot_enabled: boolean
+  max_context_override: number
   sandbox_profile: SandboxProfile
   active_goal_ids: string[]
   mention_targets_text: string
@@ -190,6 +192,7 @@ export type RuntimeDraft = {
   proactive_enabled: boolean
   proactive_idle_sec: number
   proactive_cooldown_sec: number
+  compaction_profile: string
   compaction_ratio_gate: number
   compaction_message_gate: number
   compaction_token_gate: number
@@ -201,9 +204,10 @@ export type RuntimeDraft = {
 
 const runtimeDraft = signal<RuntimeDraft | null>(null)
 const runtimeSaving = signal(false)
-// Tool denylist is saved via the separate /tools set_policy endpoint (not the
+// Tool policy is saved via the separate /tools set_policy endpoint (not the
 // /config PATCH), so it has its own draft/saving state. null draft = "show the
-// live denylist"; a string = the operator's in-progress edit.
+// live policy"; a string = the operator's in-progress edit.
+const toolAccessDraftText = signal<string | null>(null)
 const denylistDraftText = signal<string | null>(null)
 const denylistSaving = signal(false)
 
@@ -216,6 +220,7 @@ function resetKeeperConfigPanelDrafts(): void {
   promptPreviewTab.value = 'blocks'
   runtimeDraft.value = null
   runtimeSaving.value = false
+  toolAccessDraftText.value = null
   denylistDraftText.value = null
   denylistSaving.value = false
   hookFilterQuery.value = ''
@@ -257,13 +262,11 @@ export function coerceNetworkMode(raw: string | undefined): SandboxNetworkMode {
   return raw === 'none' ? 'none' : 'inherit'
 }
 
-export function coerceSharedMemoryScope(raw: string | undefined): SharedMemoryScope {
-  return raw === 'workspace' ? 'workspace' : 'disabled'
-}
-
 export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
   return {
     runtime_id: c.execution.selected_runtime_id ?? '',
+    autoboot_enabled: c.autoboot_enabled,
+    max_context_override: c.max_context_override ?? 0,
     sandbox_profile: coerceSandboxProfile(c.sandbox_profile),
     active_goal_ids: c.workspace.active_goal_ids.length > 0
       ? c.workspace.active_goal_ids
@@ -274,6 +277,7 @@ export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
     proactive_enabled: c.proactive.enabled,
     proactive_idle_sec: c.proactive.idle_sec,
     proactive_cooldown_sec: c.proactive.cooldown_sec,
+    compaction_profile: c.compaction.profile,
     compaction_ratio_gate: c.compaction.ratio_gate,
     compaction_message_gate: c.compaction.message_gate,
     compaction_token_gate: c.compaction.token_gate,
@@ -293,6 +297,10 @@ export function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): Ke
     ? orig.workspace.active_goal_ids
     : orig.active_goal_ids
   if (draft.runtime_id.trim() !== (orig.execution.selected_runtime_id ?? '').trim()) payload.runtime_id = draft.runtime_id.trim()
+  if (draft.autoboot_enabled !== orig.autoboot_enabled) payload.autoboot_enabled = draft.autoboot_enabled
+  if (draft.max_context_override !== (orig.max_context_override ?? 0)) {
+    payload.max_context_override = draft.max_context_override > 0 ? Math.trunc(draft.max_context_override) : null
+  }
   if (!sameStringArray(draft.active_goal_ids, origActiveGoalIds)) payload.active_goal_ids = draft.active_goal_ids
   if (!sameStringArray(newMentionTargets, orig.workspace.mention_targets)) payload.mention_targets = newMentionTargets
   if (!sameStringArray(newPaths, origPaths)) payload.allowed_paths = newPaths
@@ -301,6 +309,7 @@ export function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): Ke
   if (draft.proactive_enabled !== orig.proactive.enabled) payload.proactive_enabled = draft.proactive_enabled
   if (draft.proactive_idle_sec !== orig.proactive.idle_sec) payload.proactive_idle_sec = draft.proactive_idle_sec
   if (draft.proactive_cooldown_sec !== orig.proactive.cooldown_sec) payload.proactive_cooldown_sec = draft.proactive_cooldown_sec
+  if (draft.compaction_profile !== orig.compaction.profile) payload.compaction_profile = draft.compaction_profile
   if (draft.compaction_ratio_gate !== orig.compaction.ratio_gate) payload.compaction_ratio_gate = draft.compaction_ratio_gate
   if (draft.compaction_message_gate !== orig.compaction.message_gate) payload.compaction_message_gate = draft.compaction_message_gate
   if (draft.compaction_token_gate !== orig.compaction.token_gate) payload.compaction_token_gate = draft.compaction_token_gate
@@ -337,6 +346,8 @@ function computeRuntimeDirtyFlags(rd: RuntimeDraft, c: KeeperConfig): Record<str
   const payload = buildRuntimePayload(rd, c)
   return {
     runtime_id: 'runtime_id' in payload,
+    autoboot_enabled: 'autoboot_enabled' in payload,
+    max_context_override: 'max_context_override' in payload,
     active_goal_ids: 'active_goal_ids' in payload,
     mention_targets: 'mention_targets' in payload,
     allowed_paths: 'allowed_paths' in payload,
@@ -345,6 +356,7 @@ function computeRuntimeDirtyFlags(rd: RuntimeDraft, c: KeeperConfig): Record<str
     proactive_enabled: 'proactive_enabled' in payload,
     proactive_idle_sec: 'proactive_idle_sec' in payload,
     proactive_cooldown_sec: 'proactive_cooldown_sec' in payload,
+    compaction_profile: 'compaction_profile' in payload,
     compaction_ratio_gate: 'compaction_ratio_gate' in payload,
     compaction_message_gate: 'compaction_message_gate' in payload,
     compaction_token_gate: 'compaction_token_gate' in payload,
@@ -864,30 +876,26 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     runtimeDraft.value = initRuntimeDraftFromConfig(c)
   }
 
-  // Parse the denylist textarea into a deduped, trimmed tool-name list.
-  function parseDenylistDraft(text: string): string[] {
+  // Parse tool policy textareas into deduped, trimmed tool-name lists.
+  function parseToolPolicyListDraft(text: string): string[] {
     return [...new Set(text.split('\n').map((s) => s.trim()).filter(Boolean))]
   }
 
-  async function saveToolDenylist() {
-    const text = denylistDraftText.value
-    if (text === null) return
-    const deny = parseDenylistDraft(text)
+  async function saveToolPolicy() {
+    const accessText = toolAccessDraftText.value ?? c.tools.tool_access.join('\n')
+    const denyText = denylistDraftText.value ?? c.tools.tool_denylist.join('\n')
+    const toolAccess = parseToolPolicyListDraft(accessText)
+    const deny = parseToolPolicyListDraft(denyText)
     denylistSaving.value = true
     try {
-      // set_policy overwrites tool_access AND tool_denylist atomically, so echo
-      // the current tool_access to preserve the operator's configured allowlist
-      // record (consumed by tool visibility + assignment telemetry). Runtime
-      // EXECUTION gating keys only off the denylist, not tool_access — see
-      // keeper_tool_policy.ml ("tool_access does NOT gate execution"; empty
-      // tool_access means "all candidates", not "no access").
       const updated = await setKeeperToolPolicy(keeperName, {
-        tool_access: c.tools.tool_access,
+        tool_access: toolAccess,
         deny,
       })
       applyKeeperConfigUpdate(keeperName, updated)
+      toolAccessDraftText.value = null
       denylistDraftText.value = null
-      showToast('도구 거부 목록 저장 완료', 'success')
+      showToast('도구 정책 저장 완료', 'success')
     } catch (err) {
       showToast(err instanceof Error ? err.message : '저장 실패', 'error')
     } finally {
@@ -1085,6 +1093,14 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         ['활성 런타임', c.execution.active_model ? 'runtime' : null],
         ['runtime timeout', perProviderTimeoutLabel(c.execution), true],
       ]} />
+      ${rd ? html`
+        <${InlineNumberRow} label="컨텍스트 오버라이드" value=${rd.max_context_override}
+          onChange=${(v: number) => updateRuntimeDraft('max_context_override', Math.max(0, Math.trunc(v)))}
+          min=${0} max=${10000000} step=${1000} suffix="tok"
+          dirty=${dirtyFlags.max_context_override} />
+      ` : c.max_context_override != null ? html`
+        <${ConfigRow} label="컨텍스트 오버라이드" value=${formatTokens(c.max_context_override)} />
+      ` : null}
       <div style="margin-top:14px;">
         <div class="kcf-tf-h"><label>런타임 후보</label></div>
         <${RuntimeList} runtimes=${c.execution.models} />
@@ -1092,14 +1108,20 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     </${KcfSec}>
   `
 
-  // policy ⚖ — verify gate + compaction + proactive + handoff + tool denylist
+  // policy ⚖ — verify gate + compaction + proactive + handoff + tool policy
   const policyTab = html`
     <${MajorSectionHeader} title="검증" />
     <${BoolRow} label="검증" value=${c.execution.verify} />
 
     <${SectionHeader} title="컴팩션" />
-    <${ConfigRow} label="프로필" value=${c.compaction.profile || MISSING_DATA_DASH} />
     ${rd ? html`
+      <${InlineSelectRow}
+        label="compaction_profile"
+        value=${rd.compaction_profile}
+        options=${['aggressive', 'balanced', 'conservative', 'custom'] as const}
+        onChange=${(value: string) => updateRuntimeDraft('compaction_profile', value)}
+        dirty=${dirtyFlags.compaction_profile}
+      />
       <${SetRow} label="비율 게이트" hint="컨텍스트 사용률 %" dirty=${dirtyFlags.compaction_ratio_gate}>
         <${SetSeg} ariaLabel="비율 게이트" value=${Math.round(rd.compaction_ratio_gate * 100)}
           options=${[75, 80, 85, 90]}
@@ -1118,6 +1140,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         min=${0} max=${3600} step=${30} suffix="s"
         dirty=${dirtyFlags.compaction_cooldown_sec} />
     ` : html`
+      <${ConfigRow} label="프로필" value=${c.compaction.profile || MISSING_DATA_DASH} />
       <${ConfigRow} label="비율 게이트" value=${formatPct(c.compaction.ratio_gate)} />
       <${ConfigRow} label="메시지 게이트" value=${String(c.compaction.message_gate)} />
       <${ConfigRow} label="토큰 게이트" value=${formatTokens(c.compaction.token_gate)} />
@@ -1126,6 +1149,10 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
 
     <${SectionHeader} title="프로액티브" />
     ${rd ? html`
+      <${SetRow} label="자동 부팅" hint="서버 시작 시 keeper 등록" dirty=${dirtyFlags.autoboot_enabled}>
+        <${SetToggle} ariaLabel="자동 부팅" on=${rd.autoboot_enabled}
+          onChange=${(v: boolean) => updateRuntimeDraft('autoboot_enabled', v)} />
+      </${SetRow}>
       <${SetRow} label="활성" hint="유휴 시 keeper 자가 기동" dirty=${dirtyFlags.proactive_enabled}>
         <${SetToggle} ariaLabel="프로액티브 활성" on=${rd.proactive_enabled}
           onChange=${(v: boolean) => updateRuntimeDraft('proactive_enabled', v)} />
@@ -1139,6 +1166,7 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
         min=${10} max=${3600} step=${10} suffix="s"
         dirty=${dirtyFlags.proactive_cooldown_sec} />
     ` : html`
+      <${BoolRow} label="자동 부팅" value=${c.autoboot_enabled} />
       <${BoolRow} label="활성" value=${c.proactive.enabled} />
       <${ConfigRow} label="유휴 트리거" value=${c.proactive.idle_sec + 's'} />
       <${ConfigRow} label="쿨다운" value=${c.proactive.cooldown_sec + 's'} />
@@ -1166,15 +1194,33 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
     `}
 
     ${(() => {
+      const accessText = toolAccessDraftText.value ?? c.tools.tool_access.join('\n')
       const denyText = denylistDraftText.value ?? c.tools.tool_denylist.join('\n')
-      const deduped = parseDenylistDraft(denyText)
-      const changed = JSON.stringify(deduped) !== JSON.stringify(c.tools.tool_denylist)
+      const accessDeduped = parseToolPolicyListDraft(accessText)
+      const denyDeduped = parseToolPolicyListDraft(denyText)
+      const changed =
+        JSON.stringify(accessDeduped) !== JSON.stringify(c.tools.tool_access)
+        || JSON.stringify(denyDeduped) !== JSON.stringify(c.tools.tool_denylist)
       return html`
-        <${SectionHeader} title="도구 거부 목록 (정책)" />
+        <${SectionHeader} title="도구 정책" />
         <p class="text-3xs text-text-muted mb-2 px-1 leading-relaxed">
-          이 keeper가 사용할 수 없는 도구 이름(한 줄에 하나). 저장 시 set_policy 로 적용되며 현재 도구 접근(tool_access ${c.tools.tool_access.length}개)은 보존됩니다.
+          저장 시 set_policy 로 tool_access 와 tool_denylist 를 함께 적용합니다. tool_access 는 후보 프로필이고 실행 차단은 denylist가 담당합니다.
         </p>
         <div class="py-2.5 px-4 rounded-[var(--r-1)] bg-[var(--color-bg-surface)] mb-2 ${changed ? 'border-l-4 border-l-[var(--color-accent-fg)]' : ''} v2-monitoring-panel">
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-sm text-[var(--color-fg-secondary)]">tool_access</span>
+            <span class="text-xs text-[var(--color-fg-muted)]">${accessDeduped.length}개</span>
+          </div>
+          <textarea aria-label="tool_access" class="w-full text-sm font-mono bg-[var(--color-bg-hover)] border border-[var(--color-border-default)] rounded-[var(--r-1)] px-3 py-2 text-[var(--color-fg-secondary)] resize-y mb-3"
+            rows=${3}
+            value=${accessText}
+            placeholder="예: tool_read_file"
+            onInput=${(e: Event) => { toolAccessDraftText.value = (e.target as HTMLTextAreaElement).value }}
+          ></textarea>
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-sm text-[var(--color-fg-secondary)]">tool_denylist</span>
+            <span class="text-xs text-[var(--color-fg-muted)]">${denyDeduped.length}개</span>
+          </div>
           <textarea aria-label="tool_denylist" class="w-full text-sm font-mono bg-[var(--color-bg-hover)] border border-[var(--color-border-default)] rounded-[var(--r-1)] px-3 py-2 text-[var(--color-fg-secondary)] resize-y"
             rows=${4}
             value=${denyText}
@@ -1182,17 +1228,17 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
             onInput=${(e: Event) => { denylistDraftText.value = (e.target as HTMLTextAreaElement).value }}
           ></textarea>
           <div class="flex items-center gap-2 mt-2">
-            <span class="text-3xs text-text-muted">${deduped.length} deny</span>
+            <span class="text-3xs text-text-muted">${accessDeduped.length} access · ${denyDeduped.length} deny</span>
             <div class="flex-1"></div>
             <button type="button"
               class="${BTN_FILLED_BASE} bg-[var(--color-status-ok)] text-[var(--color-fg-on-ok)] text-xs"
-              onClick=${saveToolDenylist}
+              onClick=${saveToolPolicy}
               disabled=${denylistSaving.value || !changed}
             >${denylistSaving.value ? '저장 중...' : '정책 저장'}</button>
             <button type="button"
               class="${BTN_FILLED_BASE} bg-[var(--color-bg-hover)] text-[var(--color-fg-secondary)] text-xs"
-              title="초기화: 편집한 거부 목록을 서버 값으로 되돌립니다"
-              onClick=${() => { denylistDraftText.value = null }}
+              title="초기화: 편집한 도구 정책을 서버 값으로 되돌립니다"
+              onClick=${() => { toolAccessDraftText.value = null; denylistDraftText.value = null }}
               disabled=${denylistSaving.value || !changed}
             >초기화하기</button>
           </div>

--- a/dashboard/src/components/keeper-config-panel.ts
+++ b/dashboard/src/components/keeper-config-panel.ts
@@ -179,6 +179,12 @@ function formatRelativeTime(date: Date): string {
 }
 
 // Runtime config draft for sandbox/proactive/compaction/handoff inline editing
+export const MAX_CONTEXT_OVERRIDE_TOKENS = 1_000_000
+
+export function normalizeMaxContextOverrideDraft(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.min(MAX_CONTEXT_OVERRIDE_TOKENS, Math.max(0, Math.trunc(value)))
+}
 
 export type RuntimeDraft = {
   runtime_id: string
@@ -266,7 +272,7 @@ export function initRuntimeDraftFromConfig(c: KeeperConfig): RuntimeDraft {
   return {
     runtime_id: c.execution.selected_runtime_id ?? '',
     autoboot_enabled: c.autoboot_enabled,
-    max_context_override: c.max_context_override ?? 0,
+    max_context_override: normalizeMaxContextOverrideDraft(c.max_context_override ?? 0),
     sandbox_profile: coerceSandboxProfile(c.sandbox_profile),
     active_goal_ids: c.workspace.active_goal_ids.length > 0
       ? c.workspace.active_goal_ids
@@ -298,8 +304,9 @@ export function buildRuntimePayload(draft: RuntimeDraft, orig: KeeperConfig): Ke
     : orig.active_goal_ids
   if (draft.runtime_id.trim() !== (orig.execution.selected_runtime_id ?? '').trim()) payload.runtime_id = draft.runtime_id.trim()
   if (draft.autoboot_enabled !== orig.autoboot_enabled) payload.autoboot_enabled = draft.autoboot_enabled
-  if (draft.max_context_override !== (orig.max_context_override ?? 0)) {
-    payload.max_context_override = draft.max_context_override > 0 ? Math.trunc(draft.max_context_override) : null
+  const draftMaxContextOverride = normalizeMaxContextOverrideDraft(draft.max_context_override)
+  if (draftMaxContextOverride !== (orig.max_context_override ?? 0)) {
+    payload.max_context_override = draftMaxContextOverride > 0 ? draftMaxContextOverride : null
   }
   if (!sameStringArray(draft.active_goal_ids, origActiveGoalIds)) payload.active_goal_ids = draft.active_goal_ids
   if (!sameStringArray(newMentionTargets, orig.workspace.mention_targets)) payload.mention_targets = newMentionTargets
@@ -1095,8 +1102,8 @@ export function KeeperConfigPanel({ keeperName, onClose }: { keeperName: string;
       ]} />
       ${rd ? html`
         <${InlineNumberRow} label="컨텍스트 오버라이드" value=${rd.max_context_override}
-          onChange=${(v: number) => updateRuntimeDraft('max_context_override', Math.max(0, Math.trunc(v)))}
-          min=${0} max=${10000000} step=${1000} suffix="tok"
+          onChange=${(v: number) => updateRuntimeDraft('max_context_override', normalizeMaxContextOverrideDraft(v))}
+          min=${0} max=${MAX_CONTEXT_OVERRIDE_TOKENS} step=${1000} suffix="tok"
           dirty=${dirtyFlags.max_context_override} />
       ` : c.max_context_override != null ? html`
         <${ConfigRow} label="컨텍스트 오버라이드" value=${formatTokens(c.max_context_override)} />

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1521,6 +1521,11 @@ interface KeeperConfigMetrics {
   compaction_count: number
 }
 
+interface KeeperConfigLimits {
+  min_context_override_tokens: number | null
+  max_context_override_tokens: number | null
+}
+
 export interface KeeperHookSlot {
   active: boolean
   source: string
@@ -1543,6 +1548,7 @@ export interface KeeperConfig {
   active_goal_ids: string[]
   autoboot_enabled: boolean
   max_context_override: number | null
+  limits: KeeperConfigLimits
   sandbox_profile?: 'local' | 'docker' | string
   network_mode?: 'none' | 'inherit' | string
   sandbox_last_error?: string | null

--- a/dashboard/src/types/core.ts
+++ b/dashboard/src/types/core.ts
@@ -1541,6 +1541,8 @@ interface KeeperHookIntrospection {
 export interface KeeperConfig {
   name: string
   active_goal_ids: string[]
+  autoboot_enabled: boolean
+  max_context_override: number | null
   sandbox_profile?: 'local' | 'docker' | string
   network_mode?: 'none' | 'inherit' | string
   sandbox_last_error?: string | null

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -291,6 +291,14 @@ let keeper_config_json (config : Workspace.config) (name : string)
          ("active_goal_ids", active_goal_ids_json);
          ("autoboot_enabled", `Bool m.autoboot_enabled);
          ("max_context_override", Json_util.int_opt_to_json m.max_context_override);
+         ( "limits",
+           `Assoc
+             [
+               ( "min_context_override_tokens",
+                 `Int Keeper_config.min_keeper_context_tokens );
+               ( "max_context_override_tokens",
+                 `Int Keeper_config.max_keeper_context_tokens );
+             ] );
          ("sandbox_profile", `String (Keeper_types_profile_sandbox.sandbox_profile_to_string m.sandbox_profile));
          ("network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string m.network_mode));         ("sandbox_last_error", Json_util.string_opt_to_json sandbox_last_error);
          ("allowed_paths",

--- a/lib/dashboard/dashboard_http_keeper_snapshot.ml
+++ b/lib/dashboard/dashboard_http_keeper_snapshot.ml
@@ -289,6 +289,8 @@ let keeper_config_json (config : Workspace.config) (name : string)
        `Assoc [
          ("name", `String m.name);
          ("active_goal_ids", active_goal_ids_json);
+         ("autoboot_enabled", `Bool m.autoboot_enabled);
+         ("max_context_override", Json_util.int_opt_to_json m.max_context_override);
          ("sandbox_profile", `String (Keeper_types_profile_sandbox.sandbox_profile_to_string m.sandbox_profile));
          ("network_mode", `String (Keeper_types_profile_sandbox.network_mode_to_string m.network_mode));         ("sandbox_last_error", Json_util.string_opt_to_json sandbox_last_error);
          ("allowed_paths",

--- a/lib/keeper/keeper_schema.ml
+++ b/lib/keeper/keeper_schema.ml
@@ -160,7 +160,7 @@ let keeper_schemas : tool_schema list = [
         ]);
         ("max_context_override", `Assoc [
           ("type", `String "integer");
-          ("description", `String "Optional: absolute context token limit override for this keeper. Use to bypass global or discovered limits.");
+          ("description", `String "Optional: absolute context token limit override for this keeper. Use 0 to clear the override.");
         ]);
         ("proactive_enabled", `Assoc [
           ("type", `String "boolean");

--- a/lib/keeper/keeper_turn_up_args.ml
+++ b/lib/keeper/keeper_turn_up_args.ml
@@ -19,6 +19,7 @@ type parsed_args = {
   mention_targets_opt : string list option;
   active_goal_ids_opt : string list option;
   max_context_override_opt : int option;
+  max_context_override_present : bool;
   proactive_enabled_opt : bool option;
   proactive_idle_sec_opt : int option;
   proactive_cooldown_sec_opt : int option;
@@ -105,6 +106,44 @@ let parse_runtime_id_opt args =
            "runtime_id must be a string (received %s)"
            (Json_util.kind_name other))
 
+let normalize_max_context_override_value v =
+  let min_keeper_context = Keeper_config.min_keeper_context_tokens in
+  let max_keeper_context = Keeper_config.max_keeper_context_tokens in
+  if v = 0 then Ok None
+  else if v >= min_keeper_context && v <= max_keeper_context then Ok (Some v)
+  else if v > 0 && v < min_keeper_context then (
+    Log.Misc.warn
+      "max_context_override=%d below minimum %d, clamped to %d"
+      v min_keeper_context min_keeper_context;
+    Ok (Some min_keeper_context))
+  else
+    Error
+      (Printf.sprintf "max_context_override=%d out of range (0 or %d..%d)"
+         v min_keeper_context max_keeper_context)
+
+let parse_max_context_override args =
+  match Json_util.assoc_member_opt "max_context_override" args with
+  | None -> Ok (false, None)
+  | Some `Null -> Ok (true, None)
+  | Some (`Int v) ->
+      Result.map (fun value -> (true, value))
+        (normalize_max_context_override_value v)
+  | Some (`Intlit raw) -> (
+      match int_of_string_opt raw with
+      | Some v ->
+          Result.map (fun value -> (true, value))
+            (normalize_max_context_override_value v)
+      | None ->
+          Error
+            (Printf.sprintf
+               "max_context_override must be an integer or null (received %s)"
+               raw))
+  | Some other ->
+      Error
+        (Printf.sprintf
+           "max_context_override must be an integer or null (received %s)"
+           (Json_util.kind_name other))
+
 let resolve_tool_name_list ~preferred ~fallback =
   Dashboard_utils.first_some preferred fallback
   |> Option.value ~default:[]
@@ -162,24 +201,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       Ok runtime_id_opt ->
     let goal_opt = get_string_opt args "goal" in
     let autoboot_enabled_opt = get_bool_opt args "autoboot_enabled" in
-    let max_context_override_opt =
-      let min_keeper_context = Keeper_config.min_keeper_context_tokens in
-      let max_keeper_context = Keeper_config.max_keeper_context_tokens in
-      match Safe_ops.json_int_opt "max_context_override" args with
-      | None -> None
-      | Some v when v >= min_keeper_context && v <= max_keeper_context ->
-          Some v
-      | Some v when v > 0 && v < min_keeper_context ->
-          Log.Misc.warn
-            "max_context_override=%d below minimum %d, clamped to %d"
-            v min_keeper_context min_keeper_context;
-          Some min_keeper_context
-      | Some v ->
-          Log.Misc.warn
-            "max_context_override=%d out of range (%d..%d), ignored"
-            v min_keeper_context max_keeper_context;
-          None
-    in
+    let max_context_override_res = parse_max_context_override args in
     let proactive_enabled_opt = get_bool_opt args "proactive_enabled" in
     let proactive_idle_sec_opt = Safe_ops.json_int_opt "proactive_idle_sec" args in
     let proactive_cooldown_sec_opt = Safe_ops.json_int_opt "proactive_cooldown_sec" args in
@@ -220,10 +242,11 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       | Some _ -> instructions_arg
       | None -> profile_defaults.instructions
     in
-    match sandbox_profile_error, tool_denylist_opt_res with
-    | Some msg, _ -> Error (tool_result_error msg)
-    | None, Error msg -> Error (tool_result_error msg)
-    | None, Ok tool_denylist_opt ->
+    match sandbox_profile_error, tool_denylist_opt_res, max_context_override_res with
+    | Some msg, _, _ -> Error (tool_result_error msg)
+    | None, Error msg, _ -> Error (tool_result_error msg)
+    | None, _, Error msg -> Error (tool_result_error msg)
+    | None, Ok tool_denylist_opt, Ok (max_context_override_present, max_context_override_opt) ->
     Ok {
       name;
       compaction_profile_opt;
@@ -234,6 +257,7 @@ let parse (ctx : _ context) (args : Yojson.Safe.t) : (parsed_args, tool_result) 
       autoboot_enabled_opt;
       mention_targets_opt;
       max_context_override_opt;
+      max_context_override_present;
       proactive_enabled_opt;
       proactive_idle_sec_opt;
       proactive_cooldown_sec_opt;

--- a/lib/keeper/keeper_turn_up_args.mli
+++ b/lib/keeper/keeper_turn_up_args.mli
@@ -8,9 +8,11 @@ open Keeper_types
 open Keeper_meta_contract
 open Keeper_types_profile
 
-(** Parsed [keeper_up] tool arguments. Every optional field is
-    [None] when the JSON arg was absent or [`Null]; non-optional
-    fields default to [""], [[]], or the profile-default. *)
+(** Parsed [keeper_up] tool arguments. Optional fields are [None] when the
+    JSON arg was absent or [`Null], except [max_context_override_opt], whose
+    paired [max_context_override_present] distinguishes explicit clear from
+    omission on update. Non-optional fields default to [""], [[]], or the
+    profile-default. *)
 type parsed_args =
   { name : string
   ; compaction_profile_opt : string option
@@ -21,6 +23,7 @@ type parsed_args =
   ; mention_targets_opt : string list option
   ; active_goal_ids_opt : string list option
   ; max_context_override_opt : int option
+  ; max_context_override_present : bool
   ; proactive_enabled_opt : bool option
   ; proactive_idle_sec_opt : int option
   ; proactive_cooldown_sec_opt : int option

--- a/lib/keeper/keeper_turn_up_update.ml
+++ b/lib/keeper/keeper_turn_up_update.ml
@@ -255,7 +255,9 @@ let update_keeper ?(preserve_prompt_defaults = false)
     auto_handoff = Option.value ~default:old.auto_handoff p.auto_handoff_opt;
     handoff_threshold = Option.value ~default:old.handoff_threshold p.handoff_threshold_opt;
     handoff_cooldown_sec = Option.value ~default:old.handoff_cooldown_sec p.handoff_cooldown_sec_opt;
-    max_context_override = (match p.max_context_override_opt with Some _ as v -> v | None -> old.max_context_override);
+    max_context_override =
+      (if p.max_context_override_present then p.max_context_override_opt
+       else old.max_context_override);
     updated_at = now_iso ();
   } in
   match


### PR DESCRIPTION
## Summary
- expose and persist keeper config controls that the modal previously could not save: autoboot, max context override, compaction profile, and tool_access
- remove stale shared_memory_scope frontend surface left after backend removal
- let max_context_override=0/null clear the override instead of collapsing into an omitted no-op

## Validation
- ocamlformat --check lib/keeper/keeper_schema.ml lib/keeper/keeper_turn_up_args.ml lib/keeper/keeper_turn_up_args.mli lib/keeper/keeper_turn_up_update.ml lib/dashboard/dashboard_http_keeper_snapshot.ml
- ocamlc -stop-after parsing lib/keeper/keeper_schema.ml lib/keeper/keeper_turn_up_args.ml lib/keeper/keeper_turn_up_args.mli lib/keeper/keeper_turn_up_update.ml lib/dashboard/dashboard_http_keeper_snapshot.ml
- pnpm --dir dashboard exec vitest run src/components/keeper-config-panel.test.ts src/api/dashboard.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1
- pnpm --dir dashboard exec tsc --noEmit --pretty false
- git diff --check HEAD~1..HEAD