### PR TITLE
fix(dashboard): aggregate memory inspector keepers

### DIFF
--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -371,18 +371,25 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
 })
 
 describe('MemoryInspector — scope toggle', () => {
-  it('switches to the aggregate (전체) view showing the real roster + a deferral note', async () => {
-    stubFetch()
+  it('switches to the aggregate (전체) view and fetches real keeper memory rows', async () => {
+    const fetchMock = stubFetch()
     const { container } = renderInspector()
     await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
     const allBtn = [...container.querySelectorAll('.mem-scope button')].find(b => b.textContent === '전체')
     expect(allBtn).toBeTruthy()
     fireEvent.click(allBtn!)
     expect(container.querySelector('.tid')?.textContent).toBe('전체 keeper')
-    // roster table = one row per default keeper (ids + status are real)
-    expect(container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)').length).toBe(DEFAULT_MEMORY_KEEPERS.length)
-    // aggregate memory totals are deferred, disclosed — not fabricated
-    expect([...container.querySelectorAll('.mem-disclosure')].some(d => (d.textContent ?? '').includes('추후 연결'))).toBe(true)
+    await waitFor(() =>
+      expect(container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)').length)
+        .toBe(DEFAULT_MEMORY_KEEPERS.length))
+    expect(fetchMock.mock.calls.some(call =>
+      String(call[0]).includes('/api/v1/keepers/nick0cave/turn-records?limit=12'))).toBe(true)
+    expect(container.textContent).toContain('전체 memory-os')
+    expect(container.textContent).toContain(`${DEFAULT_MEMORY_KEEPERS.length}/${DEFAULT_MEMORY_KEEPERS.length} loaded`)
+    expect(container.textContent).toContain(`${DEFAULT_MEMORY_KEEPERS.length}/18 recallable`)
+    expect(container.textContent).toContain('800B · trace-a#7')
+    expect([...container.querySelectorAll('.mem-disclosure')].some(d => (d.textContent ?? '').includes('읽기 전용 집계'))).toBe(true)
+    expect(container.textContent).not.toContain('추후 연결')
   })
 
   it('maps roster status to dot state run→ok / pause→idle / off→bad', async () => {
@@ -390,6 +397,9 @@ describe('MemoryInspector — scope toggle', () => {
     const { container } = renderInspector()
     await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
     fireEvent.click([...container.querySelectorAll('.mem-scope button')].find(b => b.textContent === '전체')!)
+    await waitFor(() =>
+      expect(container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)').length)
+        .toBe(DEFAULT_MEMORY_KEEPERS.length))
     const dotClassFor = (id: string): string | undefined => {
       const row = [...container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)')].find(r =>
         (r.querySelector('.mem-td-id .mono')?.textContent ?? '') === id)

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -180,6 +180,22 @@ function stubFetch(payload: unknown = turnRecordsPayload()) {
   return fetchMock
 }
 
+function abortablePendingResponse(init?: RequestInit): Promise<Response> {
+  return new Promise((_, reject) => {
+    const signal = init?.signal
+    const abort = () => {
+      const error = new Error('Aborted')
+      error.name = 'AbortError'
+      reject(error)
+    }
+    if (signal?.aborted) {
+      abort()
+      return
+    }
+    signal?.addEventListener('abort', abort, { once: true })
+  })
+}
+
 function turnRecordsPayloadWithEmptyFallbackFact() {
   const payload = turnRecordsPayload()
   const fact = {
@@ -390,6 +406,34 @@ describe('MemoryInspector — scope toggle', () => {
     expect(container.textContent).toContain('800B · trace-a#7')
     expect([...container.querySelectorAll('.mem-disclosure')].some(d => (d.textContent ?? '').includes('읽기 전용 집계'))).toBe(true)
     expect(container.textContent).not.toContain('추후 연결')
+  })
+
+  it('shows completed aggregate rows while one keeper request is still pending', async () => {
+    const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input)
+      if (path.includes('/api/v1/keepers/drifter/turn-records?limit=12')) {
+        return abortablePendingResponse(init)
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(turnRecordsPayload()), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container } = renderInspector()
+    await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
+    fireEvent.click([...container.querySelectorAll('.mem-scope button')].find(b => b.textContent === '전체')!)
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('.mem-table .mem-tr:not(.mem-th)').length)
+        .toBe(DEFAULT_MEMORY_KEEPERS.length - 1))
+    expect(container.textContent).toContain(`${DEFAULT_MEMORY_KEEPERS.length - 1}/${DEFAULT_MEMORY_KEEPERS.length} loaded`)
+    expect(container.textContent).toContain('전체 keeper memory-os 집계 불러오는 중')
+    expect([...container.querySelectorAll('.mem-td-id .mono')].map(cell => cell.textContent))
+      .not.toContain('drifter')
   })
 
   it('maps roster status to dot state run→ok / pause→idle / off→bad', async () => {

--- a/dashboard/src/components/memory-inspector.test.ts
+++ b/dashboard/src/components/memory-inspector.test.ts
@@ -356,15 +356,16 @@ describe('MemoryInspector — one-keeper scope (real data)', () => {
     expect(recallSection?.querySelector('.mem-disclosure')).toBeFalsy()
   })
 
-  it('surfaces read_errors and renders honest disclosures for the unbacked pin section', async () => {
+  it('surfaces read_errors and renders recall candidates without pin placeholders', async () => {
     stubFetch()
     const { container } = renderInspector()
     await waitFor(() => expect(container.querySelector('.mem-bar')).toBeTruthy())
     // read_errors visible (no silent failure)
     expect(container.querySelector('.mem-read-error')?.textContent).toContain('one malformed row skipped')
-    // pins → Phase 2 disclosure, while the section still shows real recall candidates.
+    // The section shows real recall candidates without the old unbacked operator-pin disclosure.
     const disclosures = [...container.querySelectorAll('.mem-disclosure')].map(d => d.textContent ?? '')
-    expect(disclosures.some(t => t.includes('Phase 2'))).toBe(true)
+    expect(disclosures.some(t => t.includes('Phase 2'))).toBe(false)
+    expect(disclosures.some(t => t.includes('실제 prompt recall 후보 1/1개를 표시'))).toBe(true)
     expect(container.textContent).toContain('핵심 회상 후보')
     // no prototype fixture leakage
     expect(container.querySelector('.mem-pin')).toBeFalsy()

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -11,10 +11,10 @@
 //   컨텍스트 구성        ← real prompt-assembly block bytes (entries[latest].blocks)
 //   장기 메모리 스토어    ← real memory_os.facts.items (typed category, provenance, TTL)
 //   압축 유지·요약        ← real memory_os.episodes.items (summary + terminal_marker)
-//   핀 고정 사실          ⓘ Phase 2 (operator pins — no backend source yet)
+//   핵심 회상 후보        ← real memory_os.facts.items where prompt_recallable=true
 //   최근 회상·주입        ← real memory_os_recall prompt blocks (entries[*].blocks)
-// The remaining ⓘ sections render an honest "연결 예정" disclosure, never fabricated
-// rows (no-stub): they DISCLOSE absence rather than fake presence.
+// Any future-only section must render an honest disclosure rather than fabricated
+// rows (no-stub): disclose absence instead of faking presence.
 
 import { Fragment } from 'preact'
 import { html } from 'htm/preact'
@@ -455,13 +455,13 @@ function RecallCandidatePreview({
 }) {
   if (facts.length === 0) {
     return html`
-      <${DisclosureNote} text="operator 핀은 Phase 2에서 연결 예정 — 현재 표시할 prompt recall 후보도 없음." />
+      <${DisclosureNote} text="현재 표시할 prompt recall 후보 없음." />
     `
   }
   return html`
     <${Fragment}>
       <div class="mem-store">${facts.map(f => html`<${FactRow} key=${factTag(f) + f.source.trace_id + f.source.turn + f.claim} fact=${f} />`)}</div>
-      <${DisclosureNote} text=${`operator 핀은 Phase 2에서 연결 예정 — 현재는 실제 prompt recall 후보 ${facts.length}/${total}개를 표시.`} />
+      <${DisclosureNote} text=${`실제 prompt recall 후보 ${facts.length}/${total}개를 표시.`} />
     </>`
 }
 

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -756,18 +756,35 @@ function aggregateMemoryErrorRow(keeper: MemoryKeeper, error: unknown): Aggregat
   }
 }
 
+type AggregateRowsUpdate = (rows: readonly AggregateMemoryRow[]) => void
+
+function materializedAggregateRows(
+  rows: readonly (AggregateMemoryRow | null)[],
+): readonly AggregateMemoryRow[] {
+  return rows.filter((row): row is AggregateMemoryRow => row !== null)
+}
+
 async function fetchAggregateMemoryRows(
   keepers: readonly MemoryKeeper[],
   signal: AbortSignal,
+  onRows?: AggregateRowsUpdate,
 ): Promise<readonly AggregateMemoryRow[]> {
-  return Promise.all(keepers.map(async keeper => {
+  let rows: readonly (AggregateMemoryRow | null)[] = keepers.map(() => null)
+  const publishRows = () => {
+    if (!signal.aborted) onRows?.(materializedAggregateRows(rows))
+  }
+  return Promise.all(keepers.map(async (keeper, index) => {
+    let row: AggregateMemoryRow
     try {
       const response = await fetchKeeperTurnRecords(keeper.id, 12, { signal })
-      return aggregateMemoryRowFromResponse(keeper, response)
+      row = aggregateMemoryRowFromResponse(keeper, response)
     } catch (error) {
       if (isAbortError(error)) throw error
-      return aggregateMemoryErrorRow(keeper, error)
+      row = aggregateMemoryErrorRow(keeper, error)
     }
+    rows = rows.map((current, rowIndex) => rowIndex === index ? row : current)
+    publishRows()
+    return row
   }))
 }
 
@@ -889,7 +906,11 @@ export function MemoryInspector({
       aggregateResource.cancel()
       return
     }
-    void aggregateResource.load(async (signal) => fetchAggregateMemoryRows(keepers, signal))
+    aggregateResource.reset([])
+    void aggregateResource.load(async (signal) =>
+      fetchAggregateMemoryRows(keepers, signal, (rows) => {
+        aggregateResource.state.value = { data: rows, loading: true, error: null }
+      }))
     return () => {
       aggregateResource.cancel()
     }

--- a/dashboard/src/components/memory-inspector.ts
+++ b/dashboard/src/components/memory-inspector.ts
@@ -22,6 +22,7 @@ import { useEffect } from 'preact/hooks'
 import { useSignal } from '@preact/signals'
 import { formatDateTimeKo, formatTimeAgo, formatTimeUntil } from '../lib/format-time'
 import { useManagedAsyncResource } from '../lib/use-managed-async-resource'
+import { isAbortError } from '../lib/async-state'
 import {
   MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER,
   fetchKeeperTurnRecords,
@@ -676,26 +677,172 @@ function EpisodeRow({ episode }: { episode: MemoryOsEpisodeSummary }) {
     </div>`
 }
 
-// Aggregate (전체) scope: real keeper roster (id + status dot are real) with an
-// honest note that per-keeper memory aggregation needs N× turn-records fetches
-// and lands later. No fabricated memory totals.
-function AggregateDeferred({ keepers }: { keepers: readonly MemoryKeeper[] }) {
+interface AggregateMemoryRow {
+  readonly keeper: MemoryKeeper
+  readonly memoryPresent: boolean
+  readonly error: string | null
+  readonly source: string
+  readonly recallableFacts: number
+  readonly diagnosticFacts: number
+  readonly shownFacts: number
+  readonly episodes: number
+  readonly fallbackEpisodes: number
+  readonly recallBlockBytes: number
+  readonly latestPrompt: string
+  readonly readErrors: number
+}
+
+function aggregateMemoryRowFromResponse(
+  keeper: MemoryKeeper,
+  response: TurnRecordsResponse,
+): AggregateMemoryRow {
+  const latestPromptRow = latestEntryWithBlocks(response.entries)
+  const memoryBlock = latestMemoryRecallBlock(latestPromptRow)
+  const latestPrompt = latestPromptRow
+    ? `${latestPromptRow.record.trace_id}#${latestPromptRow.record.absolute_turn}`
+    : 'none'
+  const snapshot = response.memory_os
+  if (!snapshot) {
+    return {
+      keeper,
+      memoryPresent: false,
+      error: null,
+      source: response.source ?? 'turn_record',
+      recallableFacts: 0,
+      diagnosticFacts: 0,
+      shownFacts: 0,
+      episodes: 0,
+      fallbackEpisodes: 0,
+      recallBlockBytes: memoryBlock?.bytes ?? 0,
+      latestPrompt,
+      readErrors: 0,
+    }
+  }
+  const recallableFacts = snapshot.facts.items.filter(isPromptRecallableFact).length
+  const diagnosticFacts = snapshot.facts.items.filter(isDiagnosticEvidenceFact).length
+  const fallbackEpisodes = snapshot.episodes.items
+    .filter(ep => ep.terminal_marker === MEMORY_OS_LIBRARIAN_UNSTRUCTURED_FALLBACK_MARKER)
+    .length
+  return {
+    keeper,
+    memoryPresent: true,
+    error: null,
+    source: snapshot.source,
+    recallableFacts,
+    diagnosticFacts,
+    shownFacts: snapshot.facts.shown,
+    episodes: Math.max(0, snapshot.episodes.items.length - fallbackEpisodes),
+    fallbackEpisodes,
+    recallBlockBytes: memoryBlock?.bytes ?? 0,
+    latestPrompt,
+    readErrors: snapshot.read_errors.length,
+  }
+}
+
+function aggregateMemoryErrorRow(keeper: MemoryKeeper, error: unknown): AggregateMemoryRow {
+  return {
+    keeper,
+    memoryPresent: false,
+    error: error instanceof Error ? error.message : String(error),
+    source: 'fetch_error',
+    recallableFacts: 0,
+    diagnosticFacts: 0,
+    shownFacts: 0,
+    episodes: 0,
+    fallbackEpisodes: 0,
+    recallBlockBytes: 0,
+    latestPrompt: 'none',
+    readErrors: 0,
+  }
+}
+
+async function fetchAggregateMemoryRows(
+  keepers: readonly MemoryKeeper[],
+  signal: AbortSignal,
+): Promise<readonly AggregateMemoryRow[]> {
+  return Promise.all(keepers.map(async keeper => {
+    try {
+      const response = await fetchKeeperTurnRecords(keeper.id, 12, { signal })
+      return aggregateMemoryRowFromResponse(keeper, response)
+    } catch (error) {
+      if (isAbortError(error)) throw error
+      return aggregateMemoryErrorRow(keeper, error)
+    }
+  }))
+}
+
+function AggregateMemoryReal({
+  keepers,
+  rows,
+  loading,
+  error,
+}: {
+  keepers: readonly MemoryKeeper[]
+  rows: readonly AggregateMemoryRow[] | null
+  loading: boolean
+  error: string | null
+}) {
+  const data = rows ?? []
+  const loadedCount = data.length
+  const failedCount = data.filter(row => row.error != null).length
+  const noMemoryCount = data.filter(row => row.error == null && !row.memoryPresent).length
+  const recallableTotal = data.reduce((sum, row) => sum + row.recallableFacts, 0)
+  const shownTotal = data.reduce((sum, row) => sum + row.shownFacts, 0)
+  const diagnosticTotal = data.reduce((sum, row) => sum + row.diagnosticFacts, 0)
+  const episodeTotal = data.reduce((sum, row) => sum + row.episodes, 0)
+  const fallbackTotal = data.reduce((sum, row) => sum + row.fallbackEpisodes, 0)
+  const linkedCount = data.filter(row => row.recallBlockBytes > 0).length
+  const recallBytes = data.reduce((sum, row) => sum + row.recallBlockBytes, 0)
   return html`
     <${Fragment}>
       <div class="turn-sec">
-        <h4>전체 keeper</h4>
-        <${DisclosureNote} text="전체 집계는 keeper별 turn-records를 모아야 하므로 추후 연결 — 현재는 단일 keeper 실데이터만." />
+        <h4>전체 memory-os</h4>
+        <div class="mem-trust">
+          <div class="mem-trust-card">
+            <span class="mem-trust-k">keepers</span>
+            <span class="mem-trust-v mono">${loadedCount}/${keepers.length} loaded</span>
+            <span class="mem-trust-sub mono">${failedCount} failed · ${noMemoryCount} no memory_os</span>
+          </div>
+          <div class="mem-trust-card">
+            <span class="mem-trust-k">facts</span>
+            <span class="mem-trust-v mono">${recallableTotal}/${shownTotal} recallable</span>
+            <span class="mem-trust-sub mono">${diagnosticTotal} diagnostic/evidence</span>
+          </div>
+          <div class="mem-trust-card">
+            <span class="mem-trust-k">prompt links</span>
+            <span class="mem-trust-v mono">${linkedCount}/${loadedCount} linked</span>
+            <span class="mem-trust-sub mono">${memFmtBytes(recallBytes)} memory_os_recall</span>
+          </div>
+        </div>
+        ${loading ? html`<${DisclosureNote} text="전체 keeper memory-os 집계 불러오는 중." />` : null}
+        ${error ? html`<div class="mem-read-error" role="alert">${'⚠'} 전체 집계 실패 — ${error}</div>` : null}
       </div>
       <div class="turn-sec">
-        <h4>keeper 로스터 · ${keepers.length}</h4>
+        <h4>keeper별 메모리 · ${keepers.length}</h4>
         <div class="mem-table">
-          <div class="mem-tr mem-th"><span>keeper</span><span>상태</span></div>
-          ${keepers.map(k => html`
-            <div key=${k.id} class="mem-tr">
-              <span class="mem-td-id"><span class=${`mem-dot ${memDotState(k.status)}`}></span><span class="mono">${k.id}</span></span>
-              <span class="mono">${k.status}</span>
+          <div class="mem-tr mem-th"><span>keeper</span><span>회상</span><span>진단</span><span>episode</span><span>prompt link</span></div>
+          ${data.map(row => html`
+            <div key=${row.keeper.id} class="mem-tr" title=${row.error ?? row.source}>
+              <span class="mem-td-id"><span class=${`mem-dot ${memDotState(row.keeper.status)}`}></span><span class="mono">${row.keeper.id}</span></span>
+              ${row.error
+                ? html`
+                  <span class="mono">error</span>
+                  <span class="mono">-</span>
+                  <span class="mono">-</span>
+                  <span class="mono">${row.error}</span>
+                `
+                : html`
+                  <span class="mono">${row.recallableFacts}/${row.shownFacts}</span>
+                  <span class="mono">${row.diagnosticFacts}${row.readErrors > 0 ? html` · err ${row.readErrors}` : null}</span>
+                  <span class="mono">${row.episodes}${row.fallbackEpisodes > 0 ? html` +${row.fallbackEpisodes} diag` : null}</span>
+                  <span class="mono">${row.recallBlockBytes > 0 ? html`${memFmtBytes(row.recallBlockBytes)} · ${row.latestPrompt}` : html`no memory block · ${row.latestPrompt}`}</span>
+                `}
             </div>`)}
         </div>
+        ${!loading && data.length === 0
+          ? html`<div class="mem-empty">집계할 keeper memory-os 행 없음.</div>`
+          : null}
+        <${DisclosureNote} text=${`전체 탭은 keeper별 turn-records를 직접 조회한 읽기 전용 집계 — episodes ${episodeTotal}, librarian fallback 진단 ${fallbackTotal}.`} />
       </div>
     </>`
 }
@@ -713,7 +860,9 @@ export function MemoryInspector({
 }: MemoryInspectorProps) {
   const scope = useSignal<'one' | 'all'>('one')
   const resource = useManagedAsyncResource<TurnRecordsResponse | null>(null)
+  const aggregateResource = useManagedAsyncResource<readonly AggregateMemoryRow[]>([])
   const activeId = keeper.id
+  const keepersKey = keepers.map(k => `${k.id}:${k.status}`).join('|')
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -734,8 +883,21 @@ export function MemoryInspector({
   }, [activeId, resource])
 
   const isOne = scope.value === 'one'
+
+  useEffect(() => {
+    if (isOne) {
+      aggregateResource.cancel()
+      return
+    }
+    void aggregateResource.load(async (signal) => fetchAggregateMemoryRows(keepers, signal))
+    return () => {
+      aggregateResource.cancel()
+    }
+  }, [isOne, keepersKey, aggregateResource])
+
   const state = resource.state.value
   const response = state.data
+  const aggregateState = aggregateResource.state.value
 
   return html`
     <div class="turn-overlay" onClick=${onClose}>
@@ -751,7 +913,12 @@ export function MemoryInspector({
         </div>
         <div class="turn-body">
           ${!isOne
-            ? html`<${AggregateDeferred} keepers=${keepers} />`
+            ? html`<${AggregateMemoryReal}
+                keepers=${keepers}
+                rows=${aggregateState.data}
+                loading=${aggregateState.loading}
+                error=${aggregateState.error}
+              />`
             : state.loading
               ? html`<div class="mem-empty">메모리 불러오는 중…</div>`
               : state.error


### PR DESCRIPTION
## Summary
- replace the MemoryInspector 전체 tab deferral with real per-keeper turn-record fetches
- show aggregate recallable/diagnostic fact counts, episode counts, fallback diagnostic counts, and memory_os_recall prompt links
- keep per-keeper fetch failures row-scoped so one broken memory source does not blank the aggregate view
- remove the stale operator-pin Phase 2 placeholder and label the section as real prompt recall candidates

## Validation
- git diff --check origin/main...HEAD
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/tsc --noEmit --pretty false
- /Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin/vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/memory-inspector.test.ts