### PR TITLE
fix(build): Exec_policy.Paths module export + normalize callsite (#22540 잔존)

### DIFF
--- a/lib/exec_policy/exec_policy.mli
+++ b/lib/exec_policy/exec_policy.mli
@@ -51,11 +51,9 @@ val simple_literal_args : Masc_exec.Shell_ir.simple -> string list option
 
 val path_argument_values : string -> string list -> string list
 
-(** [validate_path ~keeper_id ~base_path ~workdir path] checks [path] against
-    the exec policy path rules (tmp/workspace scoping). Returns [true] when the
-    path is admissible. *)
-val validate_path :
-  ?keeper_id:string -> ?base_path:string -> ?workdir:string -> string -> bool
+(** Filesystem path normalization and allowlist checks. Exposed so callers can
+    reach [validate_path] via [Exec_policy.Paths] (e.g. test keepers). *)
+module Paths = Exec_policy_paths
 
 val existing_dir_path_values_of_shell_ir : Masc_exec.Shell_ir.t -> string list
 

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -118,6 +118,11 @@ val sandbox_component_label_value : string
     label value: hex MD5 of the normalised base path. Pure. *)
 val base_path_hash : string -> string
 
+(** [normalize_base_path_for_hash base_path] resolves relative base paths
+    against the current working directory before hashing. Pure apart from
+    [Sys.getcwd] for relative inputs. *)
+val normalize_base_path_for_hash : string -> string
+
 (** [sanitize_label_value v] maps any character outside
     [[A-Za-z0-9_.-]] to ['_']. Pure. *)
 val sanitize_label_value : string -> string

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -955,7 +955,7 @@ let test_base_path_hash_relative_input_anchors_to_cwd_not_env_base () =
        Alcotest.(check string)
          "relative base hash anchor"
          (Filename.concat cwd "relative-base")
-         (Keeper_sandbox_runtime.normalize_base_path_for_hash "relative-base"))
+         (Keeper_sandbox_runtime_setup.normalize_base_path_for_hash "relative-base"))
 
 let test_sandbox_container_label_args_include_managed_ttl () =
   let args =

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -955,7 +955,7 @@ let test_base_path_hash_relative_input_anchors_to_cwd_not_env_base () =
        Alcotest.(check string)
          "relative base hash anchor"
          (Filename.concat cwd "relative-base")
-         (Keeper_sandbox_runtime_setup.normalize_base_path_for_hash "relative-base"))
+         (Keeper_sandbox_runtime.normalize_base_path_for_hash "relative-base"))
 
 let test_sandbox_container_label_args_include_managed_ttl () =
   let args =


### PR DESCRIPTION
## 목적

main CI Health/Build compile failure unblocker. After #22540, two exported-interface mismatches still broke unrelated PR CI.

## CI error fixed

1. `test/test_keeper_tool_policy_paths.ml:218` — `Exec_policy.Paths` was not exported.
2. `test/test_keeper_sandbox_read_backend.ml:958` — `Keeper_sandbox_runtime.normalize_base_path_for_hash` existed in the implementation include path but was missing from the public `.mli`.

## 변경

- `lib/exec_policy/exec_policy.mli`: exports `module Paths = Exec_policy_paths` so callers can use `Exec_policy.Paths.validate_path`.
- `lib/keeper/keeper_sandbox_runtime.mli`: exports `normalize_base_path_for_hash`.
- `test/test_keeper_sandbox_read_backend.ml`: keeps the test on the public `Keeper_sandbox_runtime` wrapper instead of depending on the private setup module.

## 검증

- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_sandbox_runtime.mli test/test_keeper_sandbox_read_backend.ml`
- Full compile/build remains CI-owned per operator instruction.

Co-Authored-By: Claude <noreply@anthropic.com>
