### PR TITLE
[keeper] typed reason pass-through + pause/resume correctness

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -899,6 +899,31 @@ nick0cave = "ollama.gemma4-26b-a4b-qat"
 [discord]
 trigger_policy = "mention_or_thread"
 
+# ── Keeper pause / resume threshold knobs (Plan §runtime.toml [pause] SSOT) ──
+# lib/keeper/keeper_behavioral_regime.ml 의 hardcoded threshold 들을 외부 설정으로
+# 옮기기 위한 SSOT. 현재 구현은 default fallback 으로만 동작하며, 이 섹션이
+# 있어도 기존 behavior 와 동일 — 차이는 향후 caller 가 Env_config_pause.get_*
+# 호출로 변경될 때 override 로 적용된다는 점.
+#
+# 변경 의미:
+# - turn_fail_streak_threshold: 동일 keeper 가 연속 turn_failure 를 N 회
+#   겪으면 no_progress_loop regime 으로 분류. RFC-0225 §3.2 의 monotonic
+#   counter 보호와 직접 연결.
+# - recent_restart_window_sec / recent_restart_count_threshold: 짧은 시간 안에
+#   N 회 restart 가 발생하면 recent_restart_streak regime 으로 분류. 자체-preservation
+#   loop 보호.
+# - tool_failure_count_threshold / tool_failure_ratio_threshold: 도구 호출의
+#   연속 실패 횟수 + 비율이 임계치를 넘으면 unhealthy_tool_chain regime.
+#
+# 누락 시 default 값 사용 (현재 default 와 동일). 잘못된 type (예: string) 은
+# load 단계에서 warn + ignore.
+[pause]
+turn_fail_streak_threshold = 3
+recent_restart_window_sec = 300.0
+recent_restart_count_threshold = 2
+tool_failure_count_threshold = 3
+tool_failure_ratio_threshold = 0.7
+
 # ── Fusion 패널+심판 심의 (RFC-0252) ─────────────────────────────────
 # masc_fusion 도구의 out-of-band 심의 루프 설정. 개인 dev 카나리로 기본 ON.
 # harness(RFC-0252 §11) 미검증 — 카나리 출력(panel 답 + judge 종합)으로 사후 판단.

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -901,9 +901,8 @@ trigger_policy = "mention_or_thread"
 
 # ── Keeper pause / resume threshold knobs (Plan §runtime.toml [pause] SSOT) ──
 # lib/keeper/keeper_behavioral_regime.ml 의 hardcoded threshold 들을 외부 설정으로
-# 옮기기 위한 SSOT. 현재 구현은 default fallback 으로만 동작하며, 이 섹션이
-# 있어도 기존 behavior 와 동일 — 차이는 향후 caller 가 Env_config_pause.get_*
-# 호출로 변경될 때 override 로 적용된다는 점.
+# 옮기기 위한 SSOT. Runtime.pause_threshold() 를 통해 auto-pause decision path가
+# 이 값을 읽고, 누락/잘못된 타입은 default fallback 으로 동작한다.
 #
 # 변경 의미:
 # - turn_fail_streak_threshold: 동일 keeper 가 연속 turn_failure 를 N 회

--- a/lib/exec_policy/exec_policy.mli
+++ b/lib/exec_policy/exec_policy.mli
@@ -61,6 +61,11 @@ module Paths = Exec_policy_paths
 val validate_path :
   ?keeper_id:string -> ?base_path:string -> ?workdir:string -> string -> bool
 
+module Paths : sig
+  val validate_path :
+    ?keeper_id:string -> ?base_path:string -> ?workdir:string -> string -> bool
+end
+
 val existing_dir_path_values_of_shell_ir : Masc_exec.Shell_ir.t -> string list
 
 val existing_sibling_dirs_hint : ?workdir:string -> string -> string option

--- a/lib/exec_policy/exec_policy.mli
+++ b/lib/exec_policy/exec_policy.mli
@@ -61,11 +61,6 @@ module Paths = Exec_policy_paths
 val validate_path :
   ?keeper_id:string -> ?base_path:string -> ?workdir:string -> string -> bool
 
-module Paths : sig
-  val validate_path :
-    ?keeper_id:string -> ?base_path:string -> ?workdir:string -> string -> bool
-end
-
 val existing_dir_path_values_of_shell_ir : Masc_exec.Shell_ir.t -> string list
 
 val existing_sibling_dirs_hint : ?workdir:string -> string -> string option

--- a/lib/keeper/keeper_behavioral_regime.ml
+++ b/lib/keeper/keeper_behavioral_regime.ml
@@ -42,7 +42,13 @@ type snapshot = {
 }
 
 (* ── Thresholds (exposed for tests) ─────────────────────── *)
-
+(* SSOT: [config/runtime.toml] [\[pause\]] section, mirrored verbatim by
+   [Runtime_schema.pause_threshold_default]. The numbers below are the
+   in-code fallback only — runtime.toml override requires the Phase 2 caller
+   migration (separate PR) which changes these top-level vals into
+   [Keeper_behavioral_regime.config.pause_threshold.*] lookups.
+   Field names + types MUST stay in sync with [Runtime_schema.pause_threshold]
+   or the SSOT will silently desync. *)
 let turn_fail_streak_threshold = 3
 let recent_restart_window_sec = 300.0
 let recent_restart_count_threshold = 2

--- a/lib/keeper/keeper_behavioral_regime.ml
+++ b/lib/keeper/keeper_behavioral_regime.ml
@@ -41,14 +41,11 @@ type snapshot = {
   updated_at : float;
 }
 
-(* ── Thresholds (exposed for tests) ─────────────────────── *)
-(* SSOT: [config/runtime.toml] [\[pause\]] section, mirrored verbatim by
-   [Runtime_schema.pause_threshold_default]. The numbers below are the
-   in-code fallback only — runtime.toml override requires the Phase 2 caller
-   migration (separate PR) which changes these top-level vals into
-   [Keeper_behavioral_regime.config.pause_threshold.*] lookups.
-   Field names + types MUST stay in sync with [Runtime_schema.pause_threshold]
-   or the SSOT will silently desync. *)
+(* ── Thresholds (exposed for pure tests) ─────────────────────── *)
+(* Default fallback values mirrored by [Runtime_schema.pause_threshold_default].
+   Operational pause decision paths read the runtime.toml [pause] section via
+   [Runtime.pause_threshold]; keep these top-level vals as pure defaults for
+   legacy regime tests and call sites that do not carry runtime config. *)
 let turn_fail_streak_threshold = 3
 let recent_restart_window_sec = 300.0
 let recent_restart_count_threshold = 2

--- a/lib/keeper/keeper_keepalive.ml
+++ b/lib/keeper/keeper_keepalive.ml
@@ -183,7 +183,14 @@ let set_keeper_paused_state ~agent_name paused =
        let directive_source_meta =
          if paused then entry.meta else clear_no_progress_loop_for_operator_resume entry
        in
-       let updated_meta = directive_paused_meta directive_source_meta paused in
+       let cleared_completion_contract =
+         if paused then directive_source_meta
+         else
+           Keeper_unified_turn_completion_contract.clear_for_operator_resume
+             ~base_path:entry.base_path
+             directive_source_meta
+       in
+       let updated_meta = directive_paused_meta cleared_completion_contract paused in
        persist_directive_meta_update entry ~updated_meta;
        Keeper_registry.dispatch_event_unit
          ~base_path:entry.base_path

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -104,26 +104,29 @@ let terminal_reason_from_receipt receipt =
                    && (String.equal code "completed"
                        || String.equal code "success") ->
       Some
-        (Keeper_turn_terminal.of_code ~source:"execution_receipt"
-           "completion_contract_unsatisfied")
+        (Keeper_turn_terminal.of_disposition
+           ~source:"execution_receipt"
+           Keeper_turn_disposition.Completion_contract_unsatisfied)
   | Some code ->
       Some (Keeper_turn_terminal.of_code ~source:"execution_receipt" code)
   | None when receipt_requires_tool_attention ->
       Some
-        (Keeper_turn_terminal.of_code ~source:"execution_receipt"
-           "completion_contract_unsatisfied")
+        (Keeper_turn_terminal.of_disposition
+           ~source:"execution_receipt"
+           Keeper_turn_disposition.Completion_contract_unsatisfied)
   | None -> None
 
 let receipt_contract_attention_reason receipt =
   let completion_contract_result = completion_contract_result_from_receipt receipt in
-  let terminal_reason_code =
-    json_string_opt_member "terminal_reason_code" receipt
-    |> Option.map (fun value -> String.lowercase_ascii (String.trim value))
-  in
   let turn_budget_exhausted =
-    match terminal_reason_code with
-    | Some code -> String.starts_with ~prefix:"turn_budget_exhausted" code
-    | None -> false
+    json_string_opt_member "terminal_reason_code" receipt
+    |> Option.map ~f:(fun value ->
+      String.lowercase_ascii (String.trim value))
+    |> Option.map ~f:Keeper_turn_disposition.of_wire
+    |> Option.value ~default:Keeper_turn_disposition.(Unknown { raw_error = "" })
+    |> function
+    | Keeper_turn_disposition.Turn_budget_exhausted _ -> true
+    | _ -> false
   in
   let attention_reason result =
     "completion_contract_result:" ^ Completion_contract_result.to_string result

--- a/lib/keeper/keeper_runtime_trust_snapshot.ml
+++ b/lib/keeper/keeper_runtime_trust_snapshot.ml
@@ -119,14 +119,12 @@ let terminal_reason_from_receipt receipt =
 let receipt_contract_attention_reason receipt =
   let completion_contract_result = completion_contract_result_from_receipt receipt in
   let turn_budget_exhausted =
-    json_string_opt_member "terminal_reason_code" receipt
-    |> Option.map ~f:(fun value ->
-      String.lowercase_ascii (String.trim value))
-    |> Option.map ~f:Keeper_turn_disposition.of_wire
-    |> Option.value ~default:Keeper_turn_disposition.(Unknown { raw_error = "" })
-    |> function
-    | Keeper_turn_disposition.Turn_budget_exhausted _ -> true
-    | _ -> false
+    match json_string_opt_member "terminal_reason_code" receipt with
+    | Some value ->
+      (match Keeper_turn_disposition.of_wire (String.lowercase_ascii (String.trim value)) with
+       | Keeper_turn_disposition.Turn_budget_exhausted _ -> true
+       | _ -> false)
+    | None -> false
   in
   let attention_reason result =
     "completion_contract_result:" ^ Completion_contract_result.to_string result

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -121,6 +121,7 @@ val normalize_base_path_for_hash : string -> string
 
 (** [base_path_hash base_path] = the {!sandbox_base_path_hash_label_key}
     label value: hex MD5 of the normalised base path. Pure. *)
+val normalize_base_path_for_hash : string -> string
 val base_path_hash : string -> string
 
 (** [sanitize_label_value v] maps any character outside

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -121,7 +121,6 @@ val normalize_base_path_for_hash : string -> string
 
 (** [base_path_hash base_path] = the {!sandbox_base_path_hash_label_key}
     label value: hex MD5 of the normalised base path. Pure. *)
-val normalize_base_path_for_hash : string -> string
 val base_path_hash : string -> string
 
 (** [sanitize_label_value v] maps any character outside

--- a/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
+++ b/lib/keeper/keeper_supervisor_resume_reconcile_gate.ml
@@ -24,6 +24,16 @@ let resume_keeper_after_reconcile_gate
     | Ok (Some latest) -> latest
     | _ -> meta
   in
+  (* RFC-0047 §3.2 / plan hypothesis B: clear the completion-contract
+     detector latch *before* the paused/last_blocker reset so the helper
+     sees the un-mutated disk klass. Otherwise the unconditional
+     [runtime.last_blocker = None] below hides the violation and the
+     helper becomes a no-op. *)
+  let latest_meta =
+    Keeper_unified_turn_completion_contract.clear_for_operator_resume
+      ~base_path:ctx.config.base_path
+      latest_meta
+  in
   let resumed_meta =
     { latest_meta with
       paused = false

--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -14,6 +14,8 @@ type t =
   | Input_required
   | Turn_wall_clock_timeout
   | Runtime_attempts_exhausted
+  | Completion_contract_unsatisfied
+  | Completion_contract_no_progress
   | Post_commit_ambiguous
   | Provider_error of Code.t
   | Unknown of { raw_error : string }
@@ -30,6 +32,8 @@ let severity = function
   | External_cancel
   | Turn_wall_clock_timeout
   | Runtime_attempts_exhausted -> Warn
+  | Completion_contract_unsatisfied
+  | Completion_contract_no_progress
   | Post_commit_ambiguous
   | Provider_error _ -> Bad
   | Unknown _ -> Unknown_bad
@@ -43,6 +47,10 @@ let summary = function
     "keeper turn hit a stale/no-progress timeout"
   | Runtime_attempts_exhausted ->
     "runtime attempts exhausted; inspect per-attempt root causes"
+  | Completion_contract_unsatisfied ->
+    "completion contract was not satisfied; review the contract or the runtime"
+  | Completion_contract_no_progress ->
+    "no progress was made on the contract; operator resume clears the no-progress latch"
   | Post_commit_ambiguous ->
     "provider failed after a mutating tool may have committed side effects"
   | Provider_error code -> Printf.sprintf "keeper turn ended with %s" (Code.to_wire code)
@@ -57,6 +65,8 @@ let next_action = function
   | External_cancel -> Some "rerun_if_still_relevant"
   | Turn_wall_clock_timeout -> Some "inspect_turn_timeout"
   | Runtime_attempts_exhausted -> Some "inspect_runtime_attempts"
+  | Completion_contract_unsatisfied -> Some "inspect_completion_contract"
+  | Completion_contract_no_progress -> Some "resume_or_inspect_completion_contract"
   | Post_commit_ambiguous -> Some "reconcile_partial_commit"
   | Provider_error _ | Unknown _ -> Some "inspect_latest_error"
 ;;
@@ -67,6 +77,8 @@ let to_wire = function
   | External_cancel -> "external_cancel"
   | Turn_wall_clock_timeout -> "turn_wall_clock_timeout"
   | Runtime_attempts_exhausted -> "runtime_attempts_exhausted"
+  | Completion_contract_unsatisfied -> "completion_contract_unsatisfied"
+  | Completion_contract_no_progress -> "completion_contract_no_progress"
   | Post_commit_ambiguous -> "post_commit_ambiguous"
   | Provider_error code -> Code.to_wire code
   | Unknown { raw_error = "" } -> "unknown_error"
@@ -109,6 +121,8 @@ let of_wire = function
   | "external_cancel" -> External_cancel
   | "turn_wall_clock_timeout" -> Turn_wall_clock_timeout
   | "runtime_attempts_exhausted" -> Runtime_attempts_exhausted
+  | "completion_contract_unsatisfied" -> Completion_contract_unsatisfied
+  | "completion_contract_no_progress" -> Completion_contract_no_progress
   | "post_commit_ambiguous" -> Post_commit_ambiguous
   | "unknown_error" -> Unknown { raw_error = "" }
   | other ->
@@ -124,17 +138,21 @@ let equal a b =
   | External_cancel, External_cancel
   | Turn_wall_clock_timeout, Turn_wall_clock_timeout
   | Runtime_attempts_exhausted, Runtime_attempts_exhausted
+  | Completion_contract_unsatisfied, Completion_contract_unsatisfied
+  | Completion_contract_no_progress, Completion_contract_no_progress
   | Post_commit_ambiguous, Post_commit_ambiguous -> true
   | Provider_error a, Provider_error b -> String.equal (Code.to_wire a) (Code.to_wire b)
   | Unknown a, Unknown b -> String.equal a.raw_error b.raw_error
-  | Success, _
-  | Input_required, _
-  | External_cancel, _
-  | Turn_wall_clock_timeout, _
-  | Runtime_attempts_exhausted, _
-  | Post_commit_ambiguous, _
-  | Provider_error _, _
-  | Unknown _, _ -> false
+  | ( Success
+    | Input_required
+    | External_cancel
+    | Turn_wall_clock_timeout
+    | Runtime_attempts_exhausted
+    | Completion_contract_unsatisfied
+    | Completion_contract_no_progress
+    | Post_commit_ambiguous
+    | Provider_error _
+    | Unknown _ ), _ -> false
 ;;
 
 let pp fmt t = Format.pp_print_string fmt (to_wire t)

--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -8,6 +8,23 @@
 
 module Code = Keeper_turn_terminal_code
 
+let chop_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  let value_len = String.length value in
+  if value_len >= prefix_len && String.sub value 0 prefix_len = prefix
+  then Some (String.sub value prefix_len (value_len - prefix_len))
+  else None
+;;
+
+let chop_suffix ~suffix value =
+  let suffix_len = String.length suffix in
+  let value_len = String.length value in
+  if value_len >= suffix_len
+     && String.sub value (value_len - suffix_len) suffix_len = suffix
+  then Some (String.sub value 0 (value_len - suffix_len))
+  else None
+;;
+
 type t =
   | Success
   | External_cancel
@@ -173,30 +190,28 @@ let of_wire_turn_budget_exhausted wire =
     | "user_config" -> Some `User_config
     | _ -> None
   in
-  match String.chop_prefix ~prefix:"turn_budget_exhausted(" wire with
+  match chop_prefix ~prefix:"turn_budget_exhausted(" wire with
   | None -> None
   | Some body ->
-    let body = String.chop_suffix ~suffix:")" body |> Option.value ~default:body in
-    let parts = String.split_on_char ':' body in
-    Option.bind (List.nth_opt parts 0) ~f:(fun dim_str ->
-      Option.bind (List.nth_opt parts 1) ~f:(fun src_str ->
-        Option.bind (List.nth_opt parts 2) ~f:(fun counts_str ->
-          Option.bind (parse_dimension dim_str) ~f:(fun dim ->
-            Option.bind (parse_source src_str) ~f:(fun src ->
-              let count_parts = String.split_on_char '/' counts_str in
-              Option.bind (List.nth_opt count_parts 0) ~f:(fun used_str ->
-                Option.bind (List.nth_opt count_parts 1) ~f:(fun limit_str ->
-                  Option.bind (Int.of_string_opt used_str) ~f:(fun used ->
-                    Option.bind (Int.of_string_opt limit_str) ~f:(fun limit ->
-                      Some (Turn_budget_exhausted
-                              { dimension = dim
-                              ; used
-                              ; limit
-                              ; source = src }))))))))))
+    (match chop_suffix ~suffix:")" body with
+     | None -> None
+     | Some body ->
+       (match String.split_on_char ':' body with
+        | [ dim_str; src_str; counts_str ] ->
+          (match
+             parse_dimension dim_str, parse_source src_str, String.split_on_char '/' counts_str
+           with
+           | Some dim, Some src, [ used_str; limit_str ] ->
+             (match int_of_string_opt used_str, int_of_string_opt limit_str with
+              | Some used, Some limit ->
+                Some (Turn_budget_exhausted { dimension = dim; used; limit; source = src })
+              | _ -> None)
+           | _ -> None)
+        | _ -> None))
 ;;
 
 let of_wire wire =
-  match String.chop_prefix ~prefix:"turn_budget_exhausted" wire with
+  match chop_prefix ~prefix:"turn_budget_exhausted" wire with
   | Some _ ->
     (match of_wire_turn_budget_exhausted wire with
      | Some disposition -> disposition

--- a/lib/keeper/keeper_turn_disposition.ml
+++ b/lib/keeper/keeper_turn_disposition.ml
@@ -17,6 +17,12 @@ type t =
   | Completion_contract_unsatisfied
   | Completion_contract_no_progress
   | Post_commit_ambiguous
+  | Turn_budget_exhausted of
+      { dimension : [ `Turns | `Wall_clock_seconds | `Idle_turns ]
+      ; used : int
+      ; limit : int
+      ; source : [ `Oas_sdk | `Keeper_runtime | `User_config ]
+      }
   | Provider_error of Code.t
   | Unknown of { raw_error : string }
 
@@ -35,7 +41,8 @@ let severity = function
   | Completion_contract_unsatisfied
   | Completion_contract_no_progress
   | Post_commit_ambiguous
-  | Provider_error _ -> Bad
+  | Provider_error _
+  | Turn_budget_exhausted _ -> Bad
   | Unknown _ -> Unknown_bad
 ;;
 
@@ -53,6 +60,19 @@ let summary = function
     "no progress was made on the contract; operator resume clears the no-progress latch"
   | Post_commit_ambiguous ->
     "provider failed after a mutating tool may have committed side effects"
+  | Turn_budget_exhausted { dimension; used; limit; source } ->
+    Printf.sprintf
+      "%s budget exhausted (%d/%d, source=%s)"
+      (match dimension with
+       | `Turns -> "turn"
+       | `Wall_clock_seconds -> "wall_clock_seconds"
+       | `Idle_turns -> "idle_turn")
+      used
+      limit
+      (match source with
+       | `Oas_sdk -> "oas_sdk"
+       | `Keeper_runtime -> "keeper_runtime"
+       | `User_config -> "user_config")
   | Provider_error code -> Printf.sprintf "keeper turn ended with %s" (Code.to_wire code)
   | Unknown { raw_error = "" } ->
     "keeper turn failed without a classified terminal reason"
@@ -68,6 +88,7 @@ let next_action = function
   | Completion_contract_unsatisfied -> Some "inspect_completion_contract"
   | Completion_contract_no_progress -> Some "resume_or_inspect_completion_contract"
   | Post_commit_ambiguous -> Some "reconcile_partial_commit"
+  | Turn_budget_exhausted _ -> Some "inspect_turn_budget"
   | Provider_error _ | Unknown _ -> Some "inspect_latest_error"
 ;;
 
@@ -80,6 +101,19 @@ let to_wire = function
   | Completion_contract_unsatisfied -> "completion_contract_unsatisfied"
   | Completion_contract_no_progress -> "completion_contract_no_progress"
   | Post_commit_ambiguous -> "post_commit_ambiguous"
+  | Turn_budget_exhausted { dimension; used; limit; source } ->
+    Printf.sprintf
+      "turn_budget_exhausted(%s:%s:%d/%d)"
+      (match dimension with
+       | `Turns -> "turns"
+       | `Wall_clock_seconds -> "wall_clock_seconds"
+       | `Idle_turns -> "idle_turns")
+      (match source with
+       | `Oas_sdk -> "oas_sdk"
+       | `Keeper_runtime -> "keeper_runtime"
+       | `User_config -> "user_config")
+      used
+      limit
   | Provider_error code -> Code.to_wire code
   | Unknown { raw_error = "" } -> "unknown_error"
   | Unknown { raw_error } -> raw_error
@@ -115,20 +149,73 @@ let of_termination_code (c : Code.t) : t =
   | Code.Sdk_error _ -> Provider_error c
 ;;
 
-let of_wire = function
-  | "success" -> Success
-  | "input_required" -> Input_required
-  | "external_cancel" -> External_cancel
-  | "turn_wall_clock_timeout" -> Turn_wall_clock_timeout
-  | "runtime_attempts_exhausted" -> Runtime_attempts_exhausted
-  | "completion_contract_unsatisfied" -> Completion_contract_unsatisfied
-  | "completion_contract_no_progress" -> Completion_contract_no_progress
-  | "post_commit_ambiguous" -> Post_commit_ambiguous
-  | "unknown_error" -> Unknown { raw_error = "" }
-  | other ->
-    (match Code.of_wire other with
-     | Some c -> of_termination_code c
-     | None -> Unknown { raw_error = other })
+(* Wire→typed parser for the [Turn_budget_exhausted] record.
+
+   The legacy free-text form is
+   ["turn_budget_exhausted(<dim>:<source>:<used>/<limit>)"].
+   Unknown dimension/source tags or unparseable integers fall back to
+   [Unknown { raw_error = original }] — fail-closed, never permissive.
+
+   Parsing policy mirrors the [Completion_contract_*] constructors:
+   the typed schema is the SSOT; wire strings that don't conform are
+   carried verbatim for diagnostic surfacing rather than being
+   silently collapsed. *)
+let of_wire_turn_budget_exhausted wire =
+  let parse_dimension = function
+    | "turns" -> Some `Turns
+    | "wall_clock_seconds" -> Some `Wall_clock_seconds
+    | "idle_turns" -> Some `Idle_turns
+    | _ -> None
+  in
+  let parse_source = function
+    | "oas_sdk" -> Some `Oas_sdk
+    | "keeper_runtime" -> Some `Keeper_runtime
+    | "user_config" -> Some `User_config
+    | _ -> None
+  in
+  match String.chop_prefix ~prefix:"turn_budget_exhausted(" wire with
+  | None -> None
+  | Some body ->
+    let body = String.chop_suffix ~suffix:")" body |> Option.value ~default:body in
+    let parts = String.split_on_char ':' body in
+    Option.bind (List.nth_opt parts 0) ~f:(fun dim_str ->
+      Option.bind (List.nth_opt parts 1) ~f:(fun src_str ->
+        Option.bind (List.nth_opt parts 2) ~f:(fun counts_str ->
+          Option.bind (parse_dimension dim_str) ~f:(fun dim ->
+            Option.bind (parse_source src_str) ~f:(fun src ->
+              let count_parts = String.split_on_char '/' counts_str in
+              Option.bind (List.nth_opt count_parts 0) ~f:(fun used_str ->
+                Option.bind (List.nth_opt count_parts 1) ~f:(fun limit_str ->
+                  Option.bind (Int.of_string_opt used_str) ~f:(fun used ->
+                    Option.bind (Int.of_string_opt limit_str) ~f:(fun limit ->
+                      Some (Turn_budget_exhausted
+                              { dimension = dim
+                              ; used
+                              ; limit
+                              ; source = src }))))))))))
+;;
+
+let of_wire wire =
+  match String.chop_prefix ~prefix:"turn_budget_exhausted" wire with
+  | Some _ ->
+    (match of_wire_turn_budget_exhausted wire with
+     | Some disposition -> disposition
+     | None -> Unknown { raw_error = wire })
+  | None ->
+    (match wire with
+     | "success" -> Success
+     | "input_required" -> Input_required
+     | "external_cancel" -> External_cancel
+     | "turn_wall_clock_timeout" -> Turn_wall_clock_timeout
+     | "runtime_attempts_exhausted" -> Runtime_attempts_exhausted
+     | "completion_contract_unsatisfied" -> Completion_contract_unsatisfied
+     | "completion_contract_no_progress" -> Completion_contract_no_progress
+     | "post_commit_ambiguous" -> Post_commit_ambiguous
+     | "unknown_error" -> Unknown { raw_error = "" }
+     | other ->
+       (match Code.of_wire other with
+        | Some c -> of_termination_code c
+        | None -> Unknown { raw_error = other }))
 ;;
 
 let equal a b =
@@ -141,6 +228,11 @@ let equal a b =
   | Completion_contract_unsatisfied, Completion_contract_unsatisfied
   | Completion_contract_no_progress, Completion_contract_no_progress
   | Post_commit_ambiguous, Post_commit_ambiguous -> true
+  | Turn_budget_exhausted a, Turn_budget_exhausted b ->
+    a.dimension = b.dimension
+    && a.used = b.used
+    && a.limit = b.limit
+    && a.source = b.source
   | Provider_error a, Provider_error b -> String.equal (Code.to_wire a) (Code.to_wire b)
   | Unknown a, Unknown b -> String.equal a.raw_error b.raw_error
   | ( Success
@@ -151,6 +243,7 @@ let equal a b =
     | Completion_contract_unsatisfied
     | Completion_contract_no_progress
     | Post_commit_ambiguous
+    | Turn_budget_exhausted _
     | Provider_error _
     | Unknown _ ), _ -> false
 ;;

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -53,6 +53,19 @@ type t =
   | Post_commit_ambiguous
   (** Provider failed after a mutating tool may have committed side
           effects. Reconcile required. *)
+  | Turn_budget_exhausted of
+      { dimension : [ `Turns | `Wall_clock_seconds | `Idle_turns ]
+      ; used : int
+      ; limit : int
+      ; source : [ `Oas_sdk | `Keeper_runtime | `User_config ]
+      }
+  (** Typed vocabulary for the legacy "turn_budget_exhausted(%d/%d)"
+      free-text label that was emitted across 4+ call sites. The
+      dimension/source tags make it impossible to misattribute a
+      keeper-runtime cooloff to an OAS SDK max-turns ceiling.
+
+      Wire form: ["turn_budget_exhausted(<dim>:<source>:<used>/<limit>)"]
+      for backward-compatibility with dashboards and OTEL queries. *)
   | Provider_error of Keeper_turn_terminal_code.t
   (** Runtime-layer termination promoted to operator-facing
           disposition. The inner code preserves the typed runtime cause

--- a/lib/keeper/keeper_turn_disposition.mli
+++ b/lib/keeper/keeper_turn_disposition.mli
@@ -37,6 +37,19 @@ type t =
   (** Runtime aggregate outcome: all candidate attempts were exhausted.
           Operators should inspect per-attempt root causes instead of treating
           this as the root cause. *)
+  | Completion_contract_unsatisfied
+  (** The keeper turn completed its tool-use block but did not satisfy
+      the completion contract. Distinct from
+      [Completion_contract_no_progress] (no progress at all) and from
+      [Post_commit_ambiguous] (a tool may have committed side effects).
+      Operator action: review the contract and either widen the turn
+      or adjust the runtime. *)
+  | Completion_contract_no_progress
+  (** The keeper turn neither progressed nor produced a tool call. The
+      supervisor's no-progress latch fires on this condition. Operator
+      action: same as [Completion_contract_unsatisfied]; once the
+      operator resumes, the latch is cleared by
+      [Keeper_unified_turn_completion_contract.clear_for_operator_resume]. *)
   | Post_commit_ambiguous
   (** Provider failed after a mutating tool may have committed side
           effects. Reconcile required. *)

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -60,15 +60,11 @@ let of_disposition ?source ?summary ?next_action disposition =
 ;;
 
 let success () = make ~source:"turn_result" "success"
-let contains_ci text needle = String_util.contains_substring_ci text needle
-
-let contract_code_from_error_text raw_error =
-  if
-    contains_ci raw_error "no ToolUse block"
-    || contains_ci raw_error "returned no keeper tool"
-  then "completion_contract_no_progress"
-  else "completion_contract_unsatisfied"
-;;
+(* WORKAROUND removed: [contract_code_from_error_text] was a substring
+   classifier emitting one of two wire strings. It had zero callers
+   (verified by rg, 2026-06-28) and was a textbook anti-pattern #2
+   (string classifier where typed variant is possible). Removed in
+   commit 3 of the keeper typed-reason series. *)
 
 let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_error err =
   if post_commit_ambiguous
@@ -88,20 +84,16 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
         Keeper_turn_disposition.Runtime_attempts_exhausted
     | Some (Keeper_turn_driver.Turn_timeout _) ->
       make ~source:"typed_error" "turn_wall_clock_timeout"
-    | _ ->
-      (match err with
-       | _ ->
-         (* RFC-0047 follow-up: emit typed [Provider_error] directly via
-            [Keeper_agent_error.terminal_reason_code_of_sdk_error_typed]
-            so [registry_failure_reason_of_terminal_reason] can match
-            exhaustively on disposition without a substring guard for
-            "api_error_*" wires. The typed bridge encapsulates the
-            [Sdk_error _] wrapping; the consumer no longer touches a
-            raw wire string. *)
-         of_disposition
-           ~source:"typed_error"
-           (Keeper_turn_disposition.Provider_error
-              (Keeper_agent_error.terminal_reason_code_of_sdk_error_typed err))))
+    | None ->
+      (* The driver classifier returned None, meaning err is a generic
+         [Agent_sdk.Error.t] not in the masc_internal_error family.
+         Route through the typed bridge instead of catching [_ ->
+         ...] silently (anti-pattern #2). The bridge matches every
+         [Agent_sdk.Error.t] variant exhaustively. *)
+      of_disposition
+        ~source:"typed_error"
+        (Keeper_turn_disposition.Provider_error
+           (Keeper_agent_error.terminal_reason_code_of_sdk_error_typed err)))
 ;;
 
 let of_code ?source ?summary ?next_action code =

--- a/lib/keeper/keeper_turn_terminal.ml
+++ b/lib/keeper/keeper_turn_terminal.ml
@@ -84,6 +84,20 @@ let of_failure ?(post_commit_ambiguous = false) ?(tool_call_count = 0) ~raw_erro
         Keeper_turn_disposition.Runtime_attempts_exhausted
     | Some (Keeper_turn_driver.Turn_timeout _) ->
       make ~source:"typed_error" "turn_wall_clock_timeout"
+    | Some
+        ( Keeper_turn_driver.Resumable_cli_session _
+        | Keeper_turn_driver.Accept_rejected _
+        | Keeper_turn_driver.Admission_queue_timeout _
+        | Keeper_turn_driver.Admission_queue_rejected _
+        | Keeper_turn_driver.Max_tokens_ceiling_violation _
+        | Keeper_turn_driver.Ambiguous_post_commit _
+        | Keeper_turn_driver.Internal_unhandled_exception _
+        | Keeper_turn_driver.Internal_bridge_exception _
+        | Keeper_turn_driver.Internal_contract_rejected _ ) ->
+      of_disposition
+        ~source:"typed_error"
+        (Keeper_turn_disposition.Provider_error
+           (Keeper_agent_error.terminal_reason_code_of_sdk_error_typed err))
     | None ->
       (* The driver classifier returned None, meaning err is a generic
          [Agent_sdk.Error.t] not in the masc_internal_error family.

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -272,7 +272,14 @@ let append_decision_record
                   match r.stop_reason with
                   | Runtime_agent.Completed -> "completed"
                   | Runtime_agent.TurnBudgetExhausted { turns_used; limit } ->
-                      Printf.sprintf "turn_budget_exhausted(%d/%d)" turns_used limit
+                      Keeper_turn_disposition.(
+                        to_wire
+                          (Turn_budget_exhausted
+                             { dimension = `Turns
+                             ; used = turns_used
+                             ; limit
+                             ; source = `Oas_sdk
+                             }))
                   | Runtime_agent.MutationBoundaryReached { turns_used; tool_name } ->
                       (match tool_name with
                        | Some tool ->

--- a/lib/keeper/keeper_unified_turn_completion_contract.ml
+++ b/lib/keeper/keeper_unified_turn_completion_contract.ml
@@ -1,0 +1,73 @@
+(** Completion-contract latch recovery for the unified keeper turn.
+
+    Parallel of {!Keeper_unified_turn_no_progress} but for the
+    completion-contract violation branch.
+
+    Problem (RFC-0047 §3.2 / plan hypothesis B): an operator-triggered
+    resume on a keeper latched by a completion-contract violation
+    previously cleared [paused], [last_blocker], [failure_reason],
+    [turn_consecutive_failures] — but did *not* clear the
+    completion-contract detector state. On the very next cycle the
+    detector fired again, the 3-strike gate re-engaged, and the keeper
+    re-paused within seconds. Operators reported "resume doesn't stick".
+
+    Fix: surface a typed recovery helper parallel to
+    [Keeper_unified_turn_no_progress.clear_for_operator_resume] so the
+    resume path can clear both latches in one shot.
+
+    This module is purely additive: it does NOT introduce new pause or
+    escalation behavior. New automatic pause/escalation logic is
+    deliberately out of scope for this PR. *)
+
+let failure_reason_code = "completion_contract_violation"
+
+(** Clear the completion-contract latch for an operator-driven resume.
+
+    Resets:
+    - The [Keeper_registry.last_failure_reason] when its code matches
+      ["completion_contract_violation"].
+    - The [Keeper_meta_contract.runtime.last_blocker] when its klass
+      is [Completion_contract_violation].
+
+    Returns the (possibly mutated) meta. Does not touch paused state,
+    turn_consecutive_failures, or any other field — those are the
+    resume_reconcile_gate's responsibility.
+
+    @param base_path  Keeper registry on-disk root.
+    @param meta       Current keeper meta snapshot. *)
+let clear_for_operator_resume ~base_path meta =
+  let keeper_name = meta.Keeper_meta_contract.name in
+  let cleared_failure_reason =
+    match Keeper_registry.get ~base_path keeper_name with
+    | Some { Keeper_registry.last_failure_reason =
+               Some (Keeper_registry.Provider_runtime_error { code; _ })
+           ; _
+           } ->
+      if String.equal code failure_reason_code then begin
+        Keeper_registry.set_failure_reason ~base_path keeper_name None;
+        true
+      end
+      else false
+    | _ -> false
+  in
+  let cleared_meta_blocker =
+    match meta.runtime.last_blocker with
+    | Some { Keeper_meta_contract.klass =
+                Keeper_meta_contract.Completion_contract_violation
+            ; _
+            } ->
+      true
+    | _ -> false
+  in
+  if cleared_failure_reason || cleared_meta_blocker then
+    Log.Keeper.info
+      "%s: operator resume cleared completion_contract_violation latch \
+       (failure_reason=%b meta_blocker=%b)"
+      keeper_name
+      cleared_failure_reason
+      cleared_meta_blocker;
+  if cleared_meta_blocker then
+    Keeper_meta_contract.map_runtime (fun rt -> { rt with last_blocker = None }) meta
+  else
+    meta
+;;

--- a/lib/keeper/keeper_unified_turn_completion_contract.mli
+++ b/lib/keeper/keeper_unified_turn_completion_contract.mli
@@ -1,0 +1,24 @@
+(** Completion-contract latch recovery for the unified keeper turn.
+
+    Parallel of {!Keeper_unified_turn_no_progress} for the
+    completion-contract violation branch. See [.ml] for the
+    rationale (RFC-0047 §3.2 / plan hypothesis B: "resume doesn't
+    stick" symptom).
+
+    This module is purely additive — no new pause or escalation
+    behavior. *)
+
+(** Clear the completion-contract latch on operator resume.
+
+    Resets [Keeper_registry.last_failure_reason] (when its code is
+    ["completion_contract_violation"]) and the
+    [Keeper_meta_contract.runtime.last_blocker] (when its klass is
+    [Completion_contract_violation]). Other resume state —
+    [paused], [turn_consecutive_failures] — is owned by
+    [Keeper_supervisor_resume_reconcile_gate] and is not touched here.
+
+    Returns the (possibly mutated) meta. *)
+val clear_for_operator_resume
+  :  base_path:string
+  -> Keeper_meta_contract.keeper_meta
+  -> Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_unified_turn_completion_contract.mli
+++ b/lib/keeper/keeper_unified_turn_completion_contract.mli
@@ -18,6 +18,9 @@
     [Keeper_supervisor_resume_reconcile_gate] and is not touched here.
 
     Returns the (possibly mutated) meta. *)
+val failure_reason_code : string
+(** Provider-runtime failure code owned by this latch clear path. *)
+
 val clear_for_operator_resume
   :  base_path:string
   -> Keeper_meta_contract.keeper_meta

--- a/lib/keeper/keeper_unified_turn_failure.ml
+++ b/lib/keeper/keeper_unified_turn_failure.ml
@@ -62,6 +62,10 @@ let record_failure_and_maybe_escalate
   let threshold =
     Runtime_params.get Governance_registry.keeper_max_turn_failures
   in
+  let pause_threshold = Runtime.pause_threshold () in
+  let turn_fail_streak_threshold =
+    pause_threshold.Runtime_schema.turn_fail_streak_threshold
+  in
   if EC.is_runtime_exhausted_error err && count > 0
   then
     Keeper_registry.set_failure_reason
@@ -70,17 +74,17 @@ let record_failure_and_maybe_escalate
       (Some (Keeper_registry.Turn_consecutive_failures count));
   let runtime_auto_paused =
     EC.is_runtime_exhausted_error err
-    && count >= Keeper_behavioral_regime.turn_fail_streak_threshold
+    && count >= turn_fail_streak_threshold
     && not updated_meta.paused
   in
   let completion_contract_auto_paused =
     EC.is_accept_no_usable_progress_error err
-    && count >= Keeper_behavioral_regime.turn_fail_streak_threshold
+    && count >= turn_fail_streak_threshold
     && not updated_meta.paused
   in
   let idle_detected_auto_paused =
     is_idle_detected_error err
-    && count >= Keeper_behavioral_regime.turn_fail_streak_threshold
+    && count >= turn_fail_streak_threshold
     && not updated_meta.paused
   in
   let auto_pause_succeeded =
@@ -135,7 +139,7 @@ let record_failure_and_maybe_escalate
              runtime fix"
             meta.name
             count
-            Keeper_behavioral_regime.turn_fail_streak_threshold
+            turn_fail_streak_threshold
             threshold
         else
           if completion_contract_auto_paused
@@ -146,7 +150,7 @@ let record_failure_and_maybe_escalate
                must inspect provider/model reasoning output before resuming"
               meta.name
               count
-              Keeper_behavioral_regime.turn_fail_streak_threshold
+              turn_fail_streak_threshold
               threshold
               "none"
           else
@@ -156,7 +160,7 @@ let record_failure_and_maybe_escalate
                repeated tool/thinking behavior before resuming"
               meta.name
               count
-              Keeper_behavioral_regime.turn_fail_streak_threshold
+              turn_fail_streak_threshold
               threshold;
         true
       | Error sync_err ->

--- a/lib/keeper/keeper_unified_turn_types.ml
+++ b/lib/keeper/keeper_unified_turn_types.ml
@@ -214,6 +214,9 @@ let registry_failure_reason_of_terminal_reason
   | Keeper_turn_disposition.External_cancel
   | Keeper_turn_disposition.Input_required
   | Keeper_turn_disposition.Turn_wall_clock_timeout
+  | Keeper_turn_disposition.Completion_contract_unsatisfied
+  | Keeper_turn_disposition.Completion_contract_no_progress
+  | Keeper_turn_disposition.Turn_budget_exhausted _
   | Keeper_turn_disposition.Post_commit_ambiguous
   | Keeper_turn_disposition.Unknown _ -> None
 ;;

--- a/lib/keeper_runtime/dune
+++ b/lib/keeper_runtime/dune
@@ -19,6 +19,7 @@
   keeper_binding_health_config
   keeper_recording_error_state
   keeper_internal_error
+  keeper_latched_reason
   keeper_event_queue
   keeper_event_queue_persistence)
  (libraries

--- a/lib/keeper_runtime/keeper_latched_reason.ml
+++ b/lib/keeper_runtime/keeper_latched_reason.ml
@@ -1,0 +1,564 @@
+(* RFC-0042 PR-5 / SSOT-1: typed SSOT for "why a keeper is latched".
+
+   Wire form is informational only and is parsed by [of_wire] into a
+   closed sum; never used as a classifier by consumers in this repo.
+
+   Equality and hashing are typed ([equal] / [hash]); the wire string is
+   a derived view, never the source of truth. *)
+
+open! Core
+
+type contract_violation_detail =
+  { reason_code :
+      [ `No_tool_use_block
+      | `No_keeper_tool_returned
+      | `Repeated_text_only_response
+      | `Unspecified
+      ]
+  ; raw_error_summary : string
+  }
+
+type runtime_exhaustion_reason =
+  | All_providers_failed
+  | No_providers_available
+  | Structural_attempt_timeout of { stage : string }
+  | Unspecified_runtime
+
+type t =
+  | No_progress_loop of
+      { consecutive_idle_cycles : int
+      ; detector_kind :
+          [ `Consecutive_idle_turns
+          | `Consecutive_no_progress
+          | `Both
+          ]
+      }
+  | Completion_contract_violation of contract_violation_detail
+  | Idle_detected of { consecutive_idle_turns : int }
+  | Runtime_exhausted of runtime_exhaustion_reason
+  | Turn_budget_exhausted of
+      { dimension :
+          [ `Turns
+          | `Wall_clock_seconds
+          | `Idle_turns
+          ]
+      ; used : int
+      ; limit : int
+      ; source :
+          [ `Oas_sdk
+          | `Keeper_runtime
+          | `User_config
+          ]
+      }
+  | Stale_storm
+  | Provider_timeout_loop of { consecutive_timeouts : int }
+  | Operator_paused of { operator_actor : string }
+
+(* -------------------------------------------------------------------- *)
+(* Polymorphic-variant equality helpers (closed set; new variants are a  *)
+(* compile-time change).                                                  *)
+(* -------------------------------------------------------------------- *)
+
+let poly_equal a b =
+  match (a, b) with
+  | `Turns, `Turns -> true
+  | `Wall_clock_seconds, `Wall_clock_seconds -> true
+  | `Idle_turns, `Idle_turns -> true
+  | `Turns, _ | `Wall_clock_seconds, _ | `Idle_turns, _ -> false
+;;
+
+let poly_equal_source a b =
+  match (a, b) with
+  | `Oas_sdk, `Oas_sdk -> true
+  | `Keeper_runtime, `Keeper_runtime -> true
+  | `User_config, `User_config -> true
+  | `Oas_sdk, _ | `Keeper_runtime, _ | `User_config, _ -> false
+;;
+
+let poly_equal_reason_code a b =
+  match (a, b) with
+  | `No_tool_use_block, `No_tool_use_block -> true
+  | `No_keeper_tool_returned, `No_keeper_tool_returned -> true
+  | `Repeated_text_only_response, `Repeated_text_only_response -> true
+  | `Unspecified, `Unspecified -> true
+  | (`No_tool_use_block | `No_keeper_tool_returned | `Repeated_text_only_response | `Unspecified), _
+    ->
+    false
+;;
+
+let poly_equal_detector a b =
+  match (a, b) with
+  | `Consecutive_idle_turns, `Consecutive_idle_turns -> true
+  | `Consecutive_no_progress, `Consecutive_no_progress -> true
+  | `Both, `Both -> true
+  | (`Consecutive_idle_turns | `Consecutive_no_progress | `Both), _ -> false
+;;
+
+(* -------------------------------------------------------------------- *)
+(* Equal / hash                                                          *)
+(* -------------------------------------------------------------------- *)
+
+let equal a b =
+  match (a, b) with
+  | ( No_progress_loop { consecutive_idle_cycles = c1; detector_kind = d1 }
+    , No_progress_loop { consecutive_idle_cycles = c2; detector_kind = d2 } ) ->
+    Int.equal c1 c2 && poly_equal_detector d1 d2
+  | Completion_contract_violation d1, Completion_contract_violation d2 ->
+    poly_equal_reason_code d1.reason_code d2.reason_code
+    && String.equal d1.raw_error_summary d2.raw_error_summary
+  | Idle_detected { consecutive_idle_turns = i1 }, Idle_detected { consecutive_idle_turns = i2 } ->
+    Int.equal i1 i2
+  | Runtime_exhausted r1, Runtime_exhausted r2 ->
+    (match (r1, r2) with
+     | All_providers_failed, All_providers_failed -> true
+     | No_providers_available, No_providers_available -> true
+     | Structural_attempt_timeout { stage = s1 }, Structural_attempt_timeout { stage = s2 } ->
+       String.equal s1 s2
+     | Unspecified_runtime, Unspecified_runtime -> true
+     | ( All_providers_failed | No_providers_available | Structural_attempt_timeout _
+       | Unspecified_runtime )
+     , _ ->
+       false)
+  | ( Turn_budget_exhausted
+        { dimension = d1; used = u1; limit = l1; source = s1 }
+    , Turn_budget_exhausted
+        { dimension = d2; used = u2; limit = l2; source = s2 } ) ->
+    poly_equal d1 d2 && Int.equal u1 u2 && Int.equal l1 l2 && poly_equal_source s1 s2
+  | Stale_storm, Stale_storm -> true
+  | ( Provider_timeout_loop { consecutive_timeouts = c1 }
+    , Provider_timeout_loop { consecutive_timeouts = c2 } ) ->
+    Int.equal c1 c2
+  | Operator_paused { operator_actor = a1 }, Operator_paused { operator_actor = a2 } ->
+    String.equal a1 a2
+  | ( ( No_progress_loop _
+      | Completion_contract_violation _
+      | Idle_detected _
+      | Runtime_exhausted _
+      | Turn_budget_exhausted _
+      | Stale_storm
+      | Provider_timeout_loop _
+      | Operator_paused _ )
+    , _ ) ->
+    false
+;;
+
+(* Closed sum: pattern-match every variant, no [hash] reuse from
+   external libraries. Hash by [Hashtbl.hash] of structural fields. *)
+let hash = function
+  | No_progress_loop { consecutive_idle_cycles; detector_kind } ->
+    Hashtbl.hash
+      ( 0
+      , consecutive_idle_cycles
+      , match detector_kind with
+        | `Consecutive_idle_turns -> 0
+        | `Consecutive_no_progress -> 1
+        | `Both -> 2 )
+  | Completion_contract_violation d ->
+    Hashtbl.hash
+      ( 1
+      , match d.reason_code with
+        | `No_tool_use_block -> 0
+        | `No_keeper_tool_returned -> 1
+        | `Repeated_text_only_response -> 2
+        | `Unspecified -> 3
+      , d.raw_error_summary )
+  | Idle_detected { consecutive_idle_turns } -> Hashtbl.hash (2, consecutive_idle_turns)
+  | Runtime_exhausted r ->
+    Hashtbl.hash
+      ( 3
+      , match r with
+        | All_providers_failed -> 0
+        | No_providers_available -> 1
+        | Structural_attempt_timeout { stage } -> Hashtbl.hash (2, stage)
+        | Unspecified_runtime -> 3 )
+  | Turn_budget_exhausted { dimension; used; limit; source } ->
+    Hashtbl.hash
+      ( 4
+      , match dimension with `Turns -> 0 | `Wall_clock_seconds -> 1 | `Idle_turns -> 2
+      , used
+      , limit
+      , match source with `Oas_sdk -> 0 | `Keeper_runtime -> 1 | `User_config -> 2 )
+  | Stale_storm -> 5
+  | Provider_timeout_loop { consecutive_timeouts } -> Hashtbl.hash (6, consecutive_timeouts)
+  | Operator_paused { operator_actor } -> Hashtbl.hash (7, operator_actor)
+;;
+
+(* -------------------------------------------------------------------- *)
+(* pp                                                                    *)
+(* -------------------------------------------------------------------- *)
+
+let pp_dim = function
+  | `Turns -> "turns"
+  | `Wall_clock_seconds -> "wall_clock_seconds"
+  | `Idle_turns -> "idle_turns"
+;;
+
+let pp_source = function
+  | `Oas_sdk -> "oas_sdk"
+  | `Keeper_runtime -> "keeper_runtime"
+  | `User_config -> "user_config"
+;;
+
+let pp_reason_code = function
+  | `No_tool_use_block -> "no_tool_use_block"
+  | `No_keeper_tool_returned -> "no_keeper_tool_returned"
+  | `Repeated_text_only_response -> "repeated_text_only_response"
+  | `Unspecified -> "unspecified"
+;;
+
+let pp_detector = function
+  | `Consecutive_idle_turns -> "consecutive_idle_turns"
+  | `Consecutive_no_progress -> "consecutive_no_progress"
+  | `Both -> "both"
+;;
+
+let pp_runtime_exhaustion ppf = function
+  | All_providers_failed -> Format.fprintf ppf "all_providers_failed"
+  | No_providers_available -> Format.fprintf ppf "no_providers_available"
+  | Structural_attempt_timeout { stage } ->
+    Format.fprintf ppf "structural_attempt_timeout{stage=%s}" stage
+  | Unspecified_runtime -> Format.fprintf ppf "unspecified_runtime"
+;;
+
+let pp ppf = function
+  | No_progress_loop { consecutive_idle_cycles; detector_kind } ->
+    Format.fprintf
+      ppf
+      "No_progress_loop{cycles=%d,detector=%s}"
+      consecutive_idle_cycles
+      (pp_detector detector_kind)
+  | Completion_contract_violation { reason_code; raw_error_summary } ->
+    Format.fprintf
+      ppf
+      "Completion_contract_violation{code=%s,summary=%S}"
+      (pp_reason_code reason_code)
+      raw_error_summary
+  | Idle_detected { consecutive_idle_turns } ->
+    Format.fprintf ppf "Idle_detected{idle_turns=%d}" consecutive_idle_turns
+  | Runtime_exhausted r ->
+    Format.fprintf ppf "Runtime_exhausted{";
+    pp_runtime_exhaustion ppf r;
+    Format.fprintf ppf "}"
+  | Turn_budget_exhausted { dimension; used; limit; source } ->
+    Format.fprintf
+      ppf
+      "Turn_budget_exhausted{dim=%s,used=%d,limit=%d,source=%s}"
+      (pp_dim dimension)
+      used
+      limit
+      (pp_source source)
+  | Stale_storm -> Format.fprintf ppf "Stale_storm"
+  | Provider_timeout_loop { consecutive_timeouts } ->
+    Format.fprintf ppf "Provider_timeout_loop{count=%d}" consecutive_timeouts
+  | Operator_paused { operator_actor } ->
+    Format.fprintf ppf "Operator_paused{actor=%s}" operator_actor
+;;
+
+(* -------------------------------------------------------------------- *)
+(* Wire format                                                           *)
+(* -------------------------------------------------------------------- *)
+
+(* Stdlib Result helpers (kept local so the module has no external
+   dependency on a project-specific [R] module). *)
+let ( let* ) = Result.bind
+let ( let+ ) = Result.map
+let int_of_string_exn s =
+  match int_of_string s with
+  | n -> Ok n
+  | exception Failure _ -> Error (Printf.sprintf "int_of_string: %S" s)
+;;
+
+let to_wire = function
+  | No_progress_loop { consecutive_idle_cycles; detector_kind } ->
+    Printf.sprintf "no_progress_loop:cycles=%d:detector=%s" consecutive_idle_cycles (pp_detector detector_kind)
+  | Completion_contract_violation { reason_code; raw_error_summary } ->
+    Printf.sprintf "completion_contract_violation:code=%s:summary=%S" (pp_reason_code reason_code) raw_error_summary
+  | Idle_detected { consecutive_idle_turns } ->
+    Printf.sprintf "idle_detected:idle_turns=%d" consecutive_idle_turns
+  | Runtime_exhausted r ->
+    Printf.sprintf "runtime_exhausted:%a" pp_runtime_exhaustion r
+  | Turn_budget_exhausted { dimension; used; limit; source } ->
+    Printf.sprintf
+      "turn_budget_exhausted:dim=%s:used=%d:limit=%d:source=%s"
+      (pp_dim dimension)
+      used
+      limit
+      (pp_source source)
+  | Stale_storm -> "stale_storm"
+  | Provider_timeout_loop { consecutive_timeouts } ->
+    Printf.sprintf "provider_timeout_loop:count=%d" consecutive_timeouts
+  | Operator_paused { operator_actor } ->
+    Printf.sprintf "operator_paused:actor=%s" operator_actor
+;;
+
+(* Fail-closed parser. The wire form is append-only information; any
+   unknown shape yields [Error] rather than a permissive catch-all
+   ([Keeper_terminal_reason.t] uses prefix matching for legacy wire
+   compatibility — that layer is intentionally permissive; this layer
+   is intentionally strict). *)
+let of_wire wire =
+  
+  match String.split_on_char ':' wire with
+  | [ "no_progress_loop"; payload ] ->
+    (match String.split_on_char '=' payload with
+     | [ "cycles"; c ] :: [ "detector"; d ] :: [] ->
+       let+ cycles = int_of_string_exn c in
+       let detector =
+         match d with
+         | "consecutive_idle_turns" -> `Consecutive_idle_turns
+         | "consecutive_no_progress" -> `Consecutive_no_progress
+         | "both" -> `Both
+         | _ -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: unknown detector %S" d
+       in
+       No_progress_loop { consecutive_idle_cycles = cycles; detector_kind = detector }
+     | _ -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: malformed no_progress_loop payload %S" payload)
+  | "completion_contract_violation" :: "code=" :: _ :: _
+  | "completion_contract_violation" :: _ ->
+    (* Payload-bearing variants with embedded ':' (e.g. summary quoting)
+       are reconstructed byte-for-byte. *)
+    let code =
+      let stripped = String.chop_prefix ~prefix:"completion_contract_violation:code=" wire in
+      match stripped with
+      | Some s ->
+        (match String.split_on_char ':' s with
+         | code_str :: _ -> code_str
+         | [] -> "")
+      | None -> ""
+    in
+    let reason_code =
+      match code with
+      | "no_tool_use_block" -> `No_tool_use_block
+      | "no_keeper_tool_returned" -> `No_keeper_tool_returned
+      | "repeated_text_only_response" -> `Repeated_text_only_response
+      | _ -> `Unspecified
+    in
+    let summary =
+      let prefix = Printf.sprintf "completion_contract_violation:code=%s:summary=" code in
+      String.chop_prefix ~prefix wire |> Option.value ~default:""
+    in
+    Ok (Completion_contract_violation { reason_code; raw_error_summary = summary })
+  | [ "idle_detected"; payload ] ->
+    (match String.split_on_char '=' payload with
+     | [ "idle_turns"; t ] :: [] ->
+       let+ idle_turns = int_of_string_exn t in
+       Idle_detected { consecutive_idle_turns = idle_turns }
+     | _ -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: malformed idle_detected payload %S" payload)
+  | "runtime_exhausted" :: "all_providers_failed" :: [] ->
+    Ok (Runtime_exhausted All_providers_failed)
+  | "runtime_exhausted" :: "no_providers_available" :: [] ->
+    Ok (Runtime_exhausted No_providers_available)
+  | "runtime_exhausted" :: "structural_attempt_timeout" :: "stage=" :: stage :: [] ->
+    Ok (Runtime_exhausted (Structural_attempt_timeout { stage }))
+  | [ "runtime_exhausted"; "unspecified_runtime" ] ->
+    Ok (Runtime_exhausted Unspecified_runtime)
+  | "turn_budget_exhausted" :: "dim=" :: _ :: _ ->
+    let+ dim =
+      let prefix = "turn_budget_exhausted:dim=" in
+      let stripped = String.chop_prefix ~prefix wire |> Option.value ~default:"" in
+      match String.split_on_char ':' stripped with
+      | d :: _ ->
+        (match d with
+         | "turns" -> Ok `Turns
+         | "wall_clock_seconds" -> Ok `Wall_clock_seconds
+         | "idle_turns" -> Ok `Idle_turns
+         | _ ->
+           Error (Printf.sprintf "Keeper_latched_reason.of_wire: unknown dimension %S" d)
+      | [] -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: missing dimension"
+    in
+    (* Use typed accessor for the remaining fields; full parse via
+       sub-functions rather than ad-hoc string splits. *)
+    let parse_int_field prefix =
+      let stripped = String.chop_prefix ~prefix wire |> Option.value ~default:"" in
+      match String.split_on_char ':' stripped with
+      | _ :: rest ->
+        (match rest with
+         | v :: _ -> int_of_string_exn v
+         | [] -> Error (Printf.sprintf "missing int after %s" prefix)
+      | [] -> Error (Printf.sprintf "missing field %s" prefix
+    in
+    let* used = parse_int_field "turn_budget_exhausted:dim=turns:used=" in
+    let* limit = parse_int_field (Printf.sprintf "turn_budget_exhausted:dim=%s:used=%d:limit=" (pp_dim dim) used) in
+    let* source =
+      let stripped =
+        String.chop_prefix
+          ~prefix:(Printf.sprintf "turn_budget_exhausted:dim=%s:used=%d:limit=%d:source=" (pp_dim dim) used limit)
+          wire
+        |> Option.value ~default:""
+      in
+      match stripped with
+      | "oas_sdk" -> Ok `Oas_sdk
+      | "keeper_runtime" -> Ok `Keeper_runtime
+      | "user_config" -> Ok `User_config
+      | _ -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: unknown source %S" stripped
+    in
+    Ok (Turn_budget_exhausted { dimension = dim; used; limit; source })
+  | [ "stale_storm" ] -> Ok Stale_storm
+  | [ "provider_timeout_loop"; payload ] ->
+    (match String.split_on_char '=' payload with
+     | [ "count"; c ] :: [] ->
+       let+ count = int_of_string_exn c in
+       Provider_timeout_loop { consecutive_timeouts = count }
+     | _ -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: malformed provider_timeout_loop payload %S" payload)
+  | "operator_paused" :: "actor=" :: _ :: _ ->
+    let actor = String.chop_prefix ~prefix:"operator_paused:actor=" wire |> Option.value ~default:"" in
+    Ok (Operator_paused { operator_actor = actor })
+  | _ ->
+    Error (Printf.sprintf "Keeper_latched_reason.of_wire: unknown wire form %S" wire
+;;
+
+(* -------------------------------------------------------------------- *)
+(* Yojson round-trip                                                     *)
+(* -------------------------------------------------------------------- *)
+
+module Stable = struct
+  let string_of_dim = function
+    | `Turns -> "turns"
+    | `Wall_clock_seconds -> "wall_clock_seconds"
+    | `Idle_turns -> "idle_turns"
+  ;;
+
+  let dim_of_string s =
+    match s with
+    | "turns" -> Ok `Turns
+    | "wall_clock_seconds" -> Ok `Wall_clock_seconds
+    | "idle_turns" -> Ok `Idle_turns
+    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown dimension %S" s
+  ;;
+
+  let string_of_source = function
+    | `Oas_sdk -> "oas_sdk"
+    | `Keeper_runtime -> "keeper_runtime"
+    | `User_config -> "user_config"
+  ;;
+
+  let source_of_string s =
+    match s with
+    | "oas_sdk" -> Ok `Oas_sdk
+    | "keeper_runtime" -> Ok `Keeper_runtime
+    | "user_config" -> Ok `User_config
+    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown source %S" s
+  ;;
+
+  let string_of_reason_code = function
+    | `No_tool_use_block -> "no_tool_use_block"
+    | `No_keeper_tool_returned -> "no_keeper_tool_returned"
+    | `Repeated_text_only_response -> "repeated_text_only_response"
+    | `Unspecified -> "unspecified"
+  ;;
+
+  let reason_code_of_string s =
+    match s with
+    | "no_tool_use_block" -> Ok `No_tool_use_block
+    | "no_keeper_tool_returned" -> Ok `No_keeper_tool_returned
+    | "repeated_text_only_response" -> Ok `Repeated_text_only_response
+    | "unspecified" -> Ok `Unspecified
+    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown reason_code %S" s
+  ;;
+
+  let string_of_detector = function
+    | `Consecutive_idle_turns -> "consecutive_idle_turns"
+    | `Consecutive_no_progress -> "consecutive_no_progress"
+    | `Both -> "both"
+  ;;
+
+  let detector_of_string s =
+    match s with
+    | "consecutive_idle_turns" -> Ok `Consecutive_idle_turns
+    | "consecutive_no_progress" -> Ok `Consecutive_no_progress
+    | "both" -> Ok `Both
+    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown detector %S" s
+  ;;
+
+  let runtime_to_yojson r : Yojson.Safe.t =
+    match r with
+    | All_providers_failed -> `Assoc [ "kind", `String "all_providers_failed" ]
+    | No_providers_available -> `Assoc [ "kind", `String "no_providers_available" ]
+    | Structural_attempt_timeout { stage } ->
+      `Assoc [ "kind", `String "structural_attempt_timeout"; "stage", `String stage ]
+    | Unspecified_runtime -> `Assoc [ "kind", `String "unspecified_runtime" ]
+  ;;
+
+  let runtime_of_yojson (j : Yojson.Safe.t) =
+    match j with
+    | `Assoc [ "kind", `String "all_providers_failed" ] -> Ok (All_providers_failed)
+    | `Assoc [ "kind", `String "no_providers_available" ] -> Ok No_providers_available
+    | `Assoc [ "kind", `String "structural_attempt_timeout"; "stage", `String stage ] ->
+      Ok (Structural_attempt_timeout { stage })
+    | `Assoc [ "kind", `String "unspecified_runtime" ] -> Ok Unspecified_runtime
+    | _ ->
+      Error (Printf.sprintf "Keeper_latched_reason: unknown runtime_exhaustion shape: %s"
+        (Yojson.Safe.to_string j)
+  ;;
+
+  let to_yojson t : Yojson.Safe.t =
+    match t with
+    | No_progress_loop { consecutive_idle_cycles; detector_kind } ->
+      `Assoc
+        [ "kind", `String "no_progress_loop"
+        ; "consecutive_idle_cycles", `Int consecutive_idle_cycles
+        ; "detector_kind", `String (string_of_detector detector_kind)
+        ]
+    | Completion_contract_violation { reason_code; raw_error_summary } ->
+      `Assoc
+        [ "kind", `String "completion_contract_violation"
+        ; "reason_code", `String (string_of_reason_code reason_code)
+        ; "raw_error_summary", `String raw_error_summary
+        ]
+    | Idle_detected { consecutive_idle_turns } ->
+      `Assoc
+        [ "kind", `String "idle_detected"
+        ; "consecutive_idle_turns", `Int consecutive_idle_turns
+        ]
+    | Runtime_exhausted r -> `Assoc [ "kind", `String "runtime_exhausted"; "detail", runtime_to_yojson r ]
+    | Turn_budget_exhausted { dimension; used; limit; source } ->
+      `Assoc
+        [ "kind", `String "turn_budget_exhausted"
+        ; "dimension", `String (string_of_dim dimension)
+        ; "used", `Int used
+        ; "limit", `Int limit
+        ; "source", `String (string_of_source source)
+        ]
+    | Stale_storm -> `Assoc [ "kind", `String "stale_storm" ]
+    | Provider_timeout_loop { consecutive_timeouts } ->
+      `Assoc
+        [ "kind", `String "provider_timeout_loop"
+        ; "consecutive_timeouts", `Int consecutive_timeouts
+        ]
+    | Operator_paused { operator_actor } ->
+      `Assoc [ "kind", `String "operator_paused"; "actor", `String operator_actor ]
+  ;;
+
+  let of_yojson (j : Yojson.Safe.t) =
+    match j with
+    | `Assoc [ "kind", `String "no_progress_loop"
+             ; "consecutive_idle_cycles", `Int n
+             ; "detector_kind", `String d ] ->
+      let+ detector = detector_of_string d in
+      No_progress_loop { consecutive_idle_cycles = n; detector_kind = detector }
+    | `Assoc [ "kind", `String "completion_contract_violation"
+             ; "reason_code", `String c
+             ; "raw_error_summary", `String summary ] ->
+      let+ rc = reason_code_of_string c in
+      Completion_contract_violation { reason_code = rc; raw_error_summary = summary }
+    | `Assoc [ "kind", `String "idle_detected"; "consecutive_idle_turns", `Int n ] ->
+      Ok (Idle_detected { consecutive_idle_turns = n })
+    | `Assoc [ "kind", `String "runtime_exhausted"; "detail", detail ] ->
+      let+ r = runtime_of_yojson detail in
+      Runtime_exhausted r
+    | `Assoc [ "kind", `String "turn_budget_exhausted"
+             ; "dimension", `String d
+             ; "used", `Int u
+             ; "limit", `Int l
+             ; "source", `String s ] ->
+      let* dim = dim_of_string d in
+      let* src = source_of_string s in
+      Ok (Turn_budget_exhausted { dimension = dim; used = u; limit = l; source = src })
+    | `Assoc [ "kind", `String "stale_storm" ] -> Ok Stale_storm
+    | `Assoc [ "kind", `String "provider_timeout_loop"; "consecutive_timeouts", `Int n ] ->
+      Ok (Provider_timeout_loop { consecutive_timeouts = n })
+    | `Assoc [ "kind", `String "operator_paused"; "actor", `String actor ] ->
+      Ok (Operator_paused { operator_actor = actor })
+    | _ ->
+      Error (Printf.sprintf "Keeper_latched_reason.of_yojson: unknown shape: %s" (Yojson.Safe.to_string j)
+  ;;
+end

--- a/lib/keeper_runtime/keeper_latched_reason.ml
+++ b/lib/keeper_runtime/keeper_latched_reason.ml
@@ -6,8 +6,6 @@
    Equality and hashing are typed ([equal] / [hash]); the wire string is
    a derived view, never the source of truth. *)
 
-open! Core
-
 type contract_violation_detail =
   { reason_code :
       [ `No_tool_use_block
@@ -149,35 +147,35 @@ let hash = function
     Hashtbl.hash
       ( 0
       , consecutive_idle_cycles
-      , match detector_kind with
-        | `Consecutive_idle_turns -> 0
-        | `Consecutive_no_progress -> 1
-        | `Both -> 2 )
+      , (match detector_kind with
+         | `Consecutive_idle_turns -> 0
+         | `Consecutive_no_progress -> 1
+         | `Both -> 2) )
   | Completion_contract_violation d ->
     Hashtbl.hash
       ( 1
-      , match d.reason_code with
-        | `No_tool_use_block -> 0
-        | `No_keeper_tool_returned -> 1
-        | `Repeated_text_only_response -> 2
-        | `Unspecified -> 3
+      , (match d.reason_code with
+         | `No_tool_use_block -> 0
+         | `No_keeper_tool_returned -> 1
+         | `Repeated_text_only_response -> 2
+         | `Unspecified -> 3)
       , d.raw_error_summary )
   | Idle_detected { consecutive_idle_turns } -> Hashtbl.hash (2, consecutive_idle_turns)
   | Runtime_exhausted r ->
     Hashtbl.hash
       ( 3
-      , match r with
-        | All_providers_failed -> 0
-        | No_providers_available -> 1
-        | Structural_attempt_timeout { stage } -> Hashtbl.hash (2, stage)
-        | Unspecified_runtime -> 3 )
+      , (match r with
+         | All_providers_failed -> 0
+         | No_providers_available -> 1
+         | Structural_attempt_timeout { stage } -> Hashtbl.hash (2, stage)
+         | Unspecified_runtime -> 3) )
   | Turn_budget_exhausted { dimension; used; limit; source } ->
     Hashtbl.hash
       ( 4
-      , match dimension with `Turns -> 0 | `Wall_clock_seconds -> 1 | `Idle_turns -> 2
+      , (match dimension with `Turns -> 0 | `Wall_clock_seconds -> 1 | `Idle_turns -> 2)
       , used
       , limit
-      , match source with `Oas_sdk -> 0 | `Keeper_runtime -> 1 | `User_config -> 2 )
+      , (match source with `Oas_sdk -> 0 | `Keeper_runtime -> 1 | `User_config -> 2) )
   | Stale_storm -> 5
   | Provider_timeout_loop { consecutive_timeouts } -> Hashtbl.hash (6, consecutive_timeouts)
   | Operator_paused { operator_actor } -> Hashtbl.hash (7, operator_actor)
@@ -261,7 +259,27 @@ let pp ppf = function
 (* Stdlib Result helpers (kept local so the module has no external
    dependency on a project-specific [R] module). *)
 let ( let* ) = Result.bind
-let ( let+ ) = Result.map
+let ( let+ ) result f = Result.map f result
+
+let errorf fmt = Printf.ksprintf (fun msg -> Error msg) fmt
+
+let chop_prefix ~prefix value =
+  let prefix_len = String.length prefix in
+  let value_len = String.length value in
+  if value_len >= prefix_len && String.sub value 0 prefix_len = prefix
+  then Some (String.sub value prefix_len (value_len - prefix_len))
+  else None
+;;
+
+let chop_suffix ~suffix value =
+  let suffix_len = String.length suffix in
+  let value_len = String.length value in
+  if value_len >= suffix_len
+     && String.sub value (value_len - suffix_len) suffix_len = suffix
+  then Some (String.sub value 0 (value_len - suffix_len))
+  else None
+;;
+
 let int_of_string_exn s =
   match int_of_string s with
   | n -> Ok n
@@ -276,7 +294,7 @@ let to_wire = function
   | Idle_detected { consecutive_idle_turns } ->
     Printf.sprintf "idle_detected:idle_turns=%d" consecutive_idle_turns
   | Runtime_exhausted r ->
-    Printf.sprintf "runtime_exhausted:%a" pp_runtime_exhaustion r
+    Format.asprintf "runtime_exhausted:%a" pp_runtime_exhaustion r
   | Turn_budget_exhausted { dimension; used; limit; source } ->
     Printf.sprintf
       "turn_budget_exhausted:dim=%s:used=%d:limit=%d:source=%s"
@@ -297,113 +315,124 @@ let to_wire = function
    compatibility — that layer is intentionally permissive; this layer
    is intentionally strict). *)
 let of_wire wire =
-  
+  let parse_dim = function
+    | "turns" -> Ok `Turns
+    | "wall_clock_seconds" -> Ok `Wall_clock_seconds
+    | "idle_turns" -> Ok `Idle_turns
+    | other -> errorf "Keeper_latched_reason.of_wire: unknown dimension %S" other
+  in
+  let parse_source = function
+    | "oas_sdk" -> Ok `Oas_sdk
+    | "keeper_runtime" -> Ok `Keeper_runtime
+    | "user_config" -> Ok `User_config
+    | other -> errorf "Keeper_latched_reason.of_wire: unknown source %S" other
+  in
+  let parse_detector = function
+    | "consecutive_idle_turns" -> Ok `Consecutive_idle_turns
+    | "consecutive_no_progress" -> Ok `Consecutive_no_progress
+    | "both" -> Ok `Both
+    | other -> errorf "Keeper_latched_reason.of_wire: unknown detector %S" other
+  in
+  let parse_reason_code = function
+    | "no_tool_use_block" -> Ok `No_tool_use_block
+    | "no_keeper_tool_returned" -> Ok `No_keeper_tool_returned
+    | "repeated_text_only_response" -> Ok `Repeated_text_only_response
+    | "unspecified" -> Ok `Unspecified
+    | other -> errorf "Keeper_latched_reason.of_wire: unknown reason_code %S" other
+  in
+  let parse_field name field =
+    match chop_prefix ~prefix:(name ^ "=") field with
+    | Some value -> Ok value
+    | None -> errorf "Keeper_latched_reason.of_wire: expected %s= field, got %S" name field
+  in
+  let parse_string_literal s =
+    let len = String.length s in
+    if len >= 2 && Char.equal s.[0] '"' && Char.equal s.[len - 1] '"'
+    then (
+      let body = String.sub s 1 (len - 2) in
+      match Scanf.unescaped body with
+      | decoded -> Ok decoded
+      | exception Scanf.Scan_failure msg ->
+        errorf "Keeper_latched_reason.of_wire: malformed quoted summary %S: %s" s msg
+      | exception Failure msg ->
+        errorf "Keeper_latched_reason.of_wire: malformed quoted summary %S: %s" s msg
+      | exception Invalid_argument msg ->
+        errorf "Keeper_latched_reason.of_wire: malformed quoted summary %S: %s" s msg)
+    else errorf "Keeper_latched_reason.of_wire: summary must be quoted, got %S" s
+  in
   match String.split_on_char ':' wire with
-  | [ "no_progress_loop"; payload ] ->
-    (match String.split_on_char '=' payload with
-     | [ "cycles"; c ] :: [ "detector"; d ] :: [] ->
-       let+ cycles = int_of_string_exn c in
-       let detector =
-         match d with
-         | "consecutive_idle_turns" -> `Consecutive_idle_turns
-         | "consecutive_no_progress" -> `Consecutive_no_progress
-         | "both" -> `Both
-         | _ -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: unknown detector %S" d
-       in
-       No_progress_loop { consecutive_idle_cycles = cycles; detector_kind = detector }
-     | _ -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: malformed no_progress_loop payload %S" payload)
-  | "completion_contract_violation" :: "code=" :: _ :: _
+  | [ "no_progress_loop"; cycles_field; detector_field ] ->
+    let* cycles_str = parse_field "cycles" cycles_field in
+    let* detector_str = parse_field "detector" detector_field in
+    let* cycles = int_of_string_exn cycles_str in
+    let+ detector = parse_detector detector_str in
+    No_progress_loop { consecutive_idle_cycles = cycles; detector_kind = detector }
   | "completion_contract_violation" :: _ ->
-    (* Payload-bearing variants with embedded ':' (e.g. summary quoting)
-       are reconstructed byte-for-byte. *)
-    let code =
-      let stripped = String.chop_prefix ~prefix:"completion_contract_violation:code=" wire in
-      match stripped with
-      | Some s ->
-        (match String.split_on_char ':' s with
-         | code_str :: _ -> code_str
-         | [] -> "")
-      | None -> ""
+    let prefix = "completion_contract_violation:code=" in
+    let* rest =
+      match chop_prefix ~prefix wire with
+      | Some rest -> Ok rest
+      | None ->
+        errorf "Keeper_latched_reason.of_wire: malformed completion contract wire %S" wire
     in
-    let reason_code =
-      match code with
-      | "no_tool_use_block" -> `No_tool_use_block
-      | "no_keeper_tool_returned" -> `No_keeper_tool_returned
-      | "repeated_text_only_response" -> `Repeated_text_only_response
-      | _ -> `Unspecified
+    let* code, summary_wire =
+      match String.index_opt rest ':' with
+      | Some idx ->
+        let code = String.sub rest 0 idx in
+        let summary_wire =
+          String.sub rest (idx + 1) (String.length rest - idx - 1)
+        in
+        Ok (code, summary_wire)
+      | None ->
+        errorf "Keeper_latched_reason.of_wire: missing completion summary in %S" wire
     in
-    let summary =
-      let prefix = Printf.sprintf "completion_contract_violation:code=%s:summary=" code in
-      String.chop_prefix ~prefix wire |> Option.value ~default:""
-    in
-    Ok (Completion_contract_violation { reason_code; raw_error_summary = summary })
-  | [ "idle_detected"; payload ] ->
-    (match String.split_on_char '=' payload with
-     | [ "idle_turns"; t ] :: [] ->
-       let+ idle_turns = int_of_string_exn t in
-       Idle_detected { consecutive_idle_turns = idle_turns }
-     | _ -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: malformed idle_detected payload %S" payload)
-  | "runtime_exhausted" :: "all_providers_failed" :: [] ->
+    let* reason_code = parse_reason_code code in
+    let* summary_encoded = parse_field "summary" summary_wire in
+    let+ summary = parse_string_literal summary_encoded in
+    Completion_contract_violation
+      { reason_code; raw_error_summary = summary }
+  | [ "idle_detected"; idle_field ] ->
+    let* idle_str = parse_field "idle_turns" idle_field in
+    let+ idle_turns = int_of_string_exn idle_str in
+    Idle_detected { consecutive_idle_turns = idle_turns }
+  | [ "runtime_exhausted"; "all_providers_failed" ] ->
     Ok (Runtime_exhausted All_providers_failed)
-  | "runtime_exhausted" :: "no_providers_available" :: [] ->
+  | [ "runtime_exhausted"; "no_providers_available" ] ->
     Ok (Runtime_exhausted No_providers_available)
-  | "runtime_exhausted" :: "structural_attempt_timeout" :: "stage=" :: stage :: [] ->
-    Ok (Runtime_exhausted (Structural_attempt_timeout { stage }))
   | [ "runtime_exhausted"; "unspecified_runtime" ] ->
     Ok (Runtime_exhausted Unspecified_runtime)
-  | "turn_budget_exhausted" :: "dim=" :: _ :: _ ->
-    let+ dim =
-      let prefix = "turn_budget_exhausted:dim=" in
-      let stripped = String.chop_prefix ~prefix wire |> Option.value ~default:"" in
-      match String.split_on_char ':' stripped with
-      | d :: _ ->
-        (match d with
-         | "turns" -> Ok `Turns
-         | "wall_clock_seconds" -> Ok `Wall_clock_seconds
-         | "idle_turns" -> Ok `Idle_turns
-         | _ ->
-           Error (Printf.sprintf "Keeper_latched_reason.of_wire: unknown dimension %S" d)
-      | [] -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: missing dimension"
-    in
-    (* Use typed accessor for the remaining fields; full parse via
-       sub-functions rather than ad-hoc string splits. *)
-    let parse_int_field prefix =
-      let stripped = String.chop_prefix ~prefix wire |> Option.value ~default:"" in
-      match String.split_on_char ':' stripped with
-      | _ :: rest ->
-        (match rest with
-         | v :: _ -> int_of_string_exn v
-         | [] -> Error (Printf.sprintf "missing int after %s" prefix)
-      | [] -> Error (Printf.sprintf "missing field %s" prefix
-    in
-    let* used = parse_int_field "turn_budget_exhausted:dim=turns:used=" in
-    let* limit = parse_int_field (Printf.sprintf "turn_budget_exhausted:dim=%s:used=%d:limit=" (pp_dim dim) used) in
-    let* source =
-      let stripped =
-        String.chop_prefix
-          ~prefix:(Printf.sprintf "turn_budget_exhausted:dim=%s:used=%d:limit=%d:source=" (pp_dim dim) used limit)
-          wire
-        |> Option.value ~default:""
-      in
-      match stripped with
-      | "oas_sdk" -> Ok `Oas_sdk
-      | "keeper_runtime" -> Ok `Keeper_runtime
-      | "user_config" -> Ok `User_config
-      | _ -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: unknown source %S" stripped
-    in
-    Ok (Turn_budget_exhausted { dimension = dim; used; limit; source })
+  | [ "runtime_exhausted"; detail ] ->
+    let prefix = "structural_attempt_timeout{stage=" in
+    (match chop_prefix ~prefix detail with
+     | Some tail ->
+       (match chop_suffix ~suffix:"}" tail with
+        | Some stage -> Ok (Runtime_exhausted (Structural_attempt_timeout { stage }))
+        | None ->
+          errorf "Keeper_latched_reason.of_wire: malformed runtime detail %S" detail)
+     | None ->
+       errorf "Keeper_latched_reason.of_wire: unknown runtime detail %S" detail)
+  | [ "turn_budget_exhausted"; dim_field; used_field; limit_field; source_field ] ->
+    let* dim_str = parse_field "dim" dim_field in
+    let* used_str = parse_field "used" used_field in
+    let* limit_str = parse_field "limit" limit_field in
+    let* source_str = parse_field "source" source_field in
+    let* dimension = parse_dim dim_str in
+    let* used = int_of_string_exn used_str in
+    let* limit = int_of_string_exn limit_str in
+    let+ source = parse_source source_str in
+    Turn_budget_exhausted { dimension; used; limit; source }
   | [ "stale_storm" ] -> Ok Stale_storm
-  | [ "provider_timeout_loop"; payload ] ->
-    (match String.split_on_char '=' payload with
-     | [ "count"; c ] :: [] ->
-       let+ count = int_of_string_exn c in
-       Provider_timeout_loop { consecutive_timeouts = count }
-     | _ -> Error (Printf.sprintf "Keeper_latched_reason.of_wire: malformed provider_timeout_loop payload %S" payload)
-  | "operator_paused" :: "actor=" :: _ :: _ ->
-    let actor = String.chop_prefix ~prefix:"operator_paused:actor=" wire |> Option.value ~default:"" in
-    Ok (Operator_paused { operator_actor = actor })
+  | [ "provider_timeout_loop"; count_field ] ->
+    let* count_str = parse_field "count" count_field in
+    let+ consecutive_timeouts = int_of_string_exn count_str in
+    Provider_timeout_loop { consecutive_timeouts }
+  | "operator_paused" :: _ ->
+    let prefix = "operator_paused:actor=" in
+    (match chop_prefix ~prefix wire with
+     | Some operator_actor -> Ok (Operator_paused { operator_actor })
+     | None -> errorf "Keeper_latched_reason.of_wire: malformed operator pause wire %S" wire)
   | _ ->
-    Error (Printf.sprintf "Keeper_latched_reason.of_wire: unknown wire form %S" wire
+    errorf "Keeper_latched_reason.of_wire: unknown wire form %S" wire
 ;;
 
 (* -------------------------------------------------------------------- *)
@@ -422,7 +451,7 @@ module Stable = struct
     | "turns" -> Ok `Turns
     | "wall_clock_seconds" -> Ok `Wall_clock_seconds
     | "idle_turns" -> Ok `Idle_turns
-    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown dimension %S" s
+    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown dimension %S" s)
   ;;
 
   let string_of_source = function
@@ -436,7 +465,7 @@ module Stable = struct
     | "oas_sdk" -> Ok `Oas_sdk
     | "keeper_runtime" -> Ok `Keeper_runtime
     | "user_config" -> Ok `User_config
-    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown source %S" s
+    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown source %S" s)
   ;;
 
   let string_of_reason_code = function
@@ -452,7 +481,7 @@ module Stable = struct
     | "no_keeper_tool_returned" -> Ok `No_keeper_tool_returned
     | "repeated_text_only_response" -> Ok `Repeated_text_only_response
     | "unspecified" -> Ok `Unspecified
-    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown reason_code %S" s
+    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown reason_code %S" s)
   ;;
 
   let string_of_detector = function
@@ -466,7 +495,7 @@ module Stable = struct
     | "consecutive_idle_turns" -> Ok `Consecutive_idle_turns
     | "consecutive_no_progress" -> Ok `Consecutive_no_progress
     | "both" -> Ok `Both
-    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown detector %S" s
+    | _ -> Error (Printf.sprintf "Keeper_latched_reason: unknown detector %S" s)
   ;;
 
   let runtime_to_yojson r : Yojson.Safe.t =
@@ -487,7 +516,7 @@ module Stable = struct
     | `Assoc [ "kind", `String "unspecified_runtime" ] -> Ok Unspecified_runtime
     | _ ->
       Error (Printf.sprintf "Keeper_latched_reason: unknown runtime_exhaustion shape: %s"
-        (Yojson.Safe.to_string j)
+               (Yojson.Safe.to_string j))
   ;;
 
   let to_yojson t : Yojson.Safe.t =
@@ -559,6 +588,9 @@ module Stable = struct
     | `Assoc [ "kind", `String "operator_paused"; "actor", `String actor ] ->
       Ok (Operator_paused { operator_actor = actor })
     | _ ->
-      Error (Printf.sprintf "Keeper_latched_reason.of_yojson: unknown shape: %s" (Yojson.Safe.to_string j)
+      Error
+        (Printf.sprintf
+           "Keeper_latched_reason.of_yojson: unknown shape: %s"
+           (Yojson.Safe.to_string j))
   ;;
 end

--- a/lib/keeper_runtime/keeper_latched_reason.mli
+++ b/lib/keeper_runtime/keeper_latched_reason.mli
@@ -1,0 +1,97 @@
+(** Typed SSOT for "why a keeper is latched (paused / blocked)".
+
+    Producer: typed only. Consumer: exhaustive match. No string
+    classifiers allowed at call sites.
+
+    Distinct from {!Keeper_turn_disposition} (turn outcome) and
+    {!Keeper_terminal_reason} (terminal-reason classifier). This type
+    answers the operator-facing question: "why did the supervisor latch
+    this keeper and refuse to advance the FSM until an external signal?"
+
+    See docs/superpowers/specs/2026-06-28-masc-oas-p0-infra-hardening-design.md
+    §3 (Keeper_latched_reason.t) for the design rationale.
+
+    {1 Construction}
+
+    The polymorphic variants [dimension], [source], [reason_code] make
+    the closed set of possibilities explicit. Adding a new axis is a
+    compile-time change, not a runtime one — readers can use
+    [assert_never] to detect forgotten arms. *)
+
+type t =
+  | No_progress_loop of
+      { consecutive_idle_cycles : int
+      ; detector_kind :
+          [ `Consecutive_idle_turns
+          | `Consecutive_no_progress
+          | `Both
+          ]
+      }
+  | Completion_contract_violation of contract_violation_detail
+  | Idle_detected of { consecutive_idle_turns : int }
+  | Runtime_exhausted of runtime_exhaustion_reason
+  | Turn_budget_exhausted of
+      { dimension :
+          [ `Turns                       (** OAS SDK [max_turns] cap *)
+          | `Wall_clock_seconds          (** env-sourced turn_timeout_sec *)
+          | `Idle_turns                  (** env-sourced idle watchdog *)
+          ]
+      ; used : int
+      ; limit : int
+      ; source :
+          [ `Oas_sdk
+          | `Keeper_runtime
+          | `User_config
+          ]
+      }
+  | Stale_storm
+  | Provider_timeout_loop of { consecutive_timeouts : int }
+  | Operator_paused of { operator_actor : string }
+
+and contract_violation_detail =
+  { reason_code :
+      [ `No_tool_use_block
+      | `No_keeper_tool_returned
+      | `Repeated_text_only_response
+      | `Unspecified
+      ]
+  ; raw_error_summary : string  (** display only, never classified *)
+  }
+
+and runtime_exhaustion_reason =
+  | All_providers_failed
+  | No_providers_available
+  | Structural_attempt_timeout of { stage : string }
+  | Unspecified_runtime
+
+(** {1 Wire format}
+
+    Used for log/dashboard events. Wire is a closed set of names with
+    structured payload encoded as a single tail segment after [":"]. The
+    reverse direction is a fail-closed [result] — never returns
+    [Unknown] silently. *)
+
+val to_wire : t -> string
+(** [to_wire t] returns a stable string suitable for the dashboard
+    payload. The wire form is informational only; consumers in this
+    repo must use [of_wire] or pattern-match on the typed value
+    directly. *)
+
+val of_wire : string -> (t, [> R.msg ]) result
+(** [of_wire s] parses [s] into a typed [t]. Returns [Error] when [s]
+    is not a known wire form. Never falls back to a permissive
+    default. *)
+
+(** {1 Equality & hashing (typed, no string comparison)} *)
+
+val equal : t -> t -> bool
+val hash : t -> int
+
+(** {1 Display} *)
+
+val pp : Format.formatter -> t -> unit
+
+module Stable : sig
+  val to_yojson : t -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (t, [> R.msg ]) result
+end

--- a/lib/keeper_runtime/keeper_latched_reason.mli
+++ b/lib/keeper_runtime/keeper_latched_reason.mli
@@ -77,7 +77,7 @@ val to_wire : t -> string
     repo must use [of_wire] or pattern-match on the typed value
     directly. *)
 
-val of_wire : string -> (t, [> R.msg ]) result
+val of_wire : string -> (t, string) result
 (** [of_wire s] parses [s] into a typed [t]. Returns [Error] when [s]
     is not a known wire form. Never falls back to a permissive
     default. *)
@@ -93,5 +93,5 @@ val pp : Format.formatter -> t -> unit
 
 module Stable : sig
   val to_yojson : t -> Yojson.Safe.t
-  val of_yojson : Yojson.Safe.t -> (t, [> R.msg ]) result
+  val of_yojson : Yojson.Safe.t -> (t, string) result
 end

--- a/lib/runtime/runtime.ml
+++ b/lib/runtime/runtime.ml
@@ -275,6 +275,7 @@ type loaded_state =
   ; librarian_runtime_id : string option
   ; cross_verifier_runtime_id : string option
   ; media_failover : string list
+  ; config_path : string option
   }
 
 let empty_loaded_state =
@@ -284,6 +285,7 @@ let empty_loaded_state =
   ; librarian_runtime_id = None
   ; cross_verifier_runtime_id = None
   ; media_failover = []
+  ; config_path = None
   }
 
 let loaded_state_ref : loaded_state Atomic.t = Atomic.make empty_loaded_state
@@ -291,6 +293,7 @@ let loaded_state_ref : loaded_state Atomic.t = Atomic.make empty_loaded_state
 let runtime_ids runtimes = List.map (fun (rt : t) -> rt.id) runtimes
 
 let set_loaded
+    ~config_path
     (runtimes, rt, assignments, librarian_id, cross_verifier_id, media_failover) =
   Atomic.set loaded_state_ref
     { default_runtime = Some rt
@@ -299,11 +302,12 @@ let set_loaded
     ; librarian_runtime_id = librarian_id
     ; cross_verifier_runtime_id = cross_verifier_id
     ; media_failover
+    ; config_path = Some config_path
     }
 
 let init_default ~config_path =
   let* loaded = load_list ~config_path in
-  set_loaded loaded;
+  set_loaded ~config_path loaded;
   Ok ()
 
 (* Startup entry point: [load_list] (RFC-0206 routing validation) PLUS the OAS
@@ -318,7 +322,7 @@ let init_default_strict ~config_path =
     (match validate_runtime_model_capabilities ~config_path runtimes with
      | Error _ as e -> e
      | Ok () ->
-       set_loaded loaded;
+       set_loaded ~config_path loaded;
        Ok ())
 
 let runtime_state () = Atomic.get loaded_state_ref
@@ -434,6 +438,26 @@ let config_path () : string option =
       in
       if Sys.file_exists path then Some path else None
   | Invalid_env | Missing -> None
+;;
+
+let pause_threshold () =
+  let runtime_config_path =
+    match (runtime_state ()).config_path with
+    | Some path -> Some path
+    | None -> config_path ()
+  in
+  match runtime_config_path with
+  | None -> Runtime_schema.pause_threshold_default
+  | Some config_path ->
+    (match Runtime_toml.parse_file config_path with
+     | Ok cfg -> cfg.pause_threshold
+     | Error errs ->
+       Log.Runtime.warn
+         "runtime: failed to parse [pause] thresholds from %s (%d error(s)); \
+          using defaults"
+         config_path
+         (List.length errs);
+       Runtime_schema.pause_threshold_default)
 ;;
 
 let runtime_config_path_result ?runtime_config_path () =

--- a/lib/runtime/runtime.mli
+++ b/lib/runtime/runtime.mli
@@ -118,6 +118,12 @@ val media_failover : unit -> string list
     from declared [\[models.*.capabilities\]] in declaration order. Every entry is
     validated at load so each resolves to a configured runtime. *)
 
+val pause_threshold : unit -> pause_threshold
+(** [\[pause\]] threshold knobs from runtime.toml, or
+    {!Runtime_schema.pause_threshold_default} when runtime.toml is unavailable or
+    invalid. Operational pause decision paths use this accessor instead of the
+    legacy top-level fallback constants. *)
+
 val get_runtime_by_id : string -> t option
 (** [get_runtime_by_id id] is the materialized runtime whose binding-key id
     ["provider.model"] equals [id], or [None] if no such runtime is configured.

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -169,6 +169,32 @@ type binding =
   }
 [@@deriving show, eq]
 
+(** {1 Pause threshold knobs}
+
+    Typed record mirroring the [\[pause\]] runtime.toml section.  All fields
+    are [int] or [float] — primitive thresholds, not reason classifiers, so
+    polymorphic variants / closed-sum types are not warranted here. *)
+type pause_threshold =
+  { turn_fail_streak_threshold : int
+  ; recent_restart_window_sec : float
+  ; recent_restart_count_threshold : int
+  ; tool_failure_count_threshold : int
+  ; tool_failure_ratio_threshold : float
+  }
+[@@deriving show, eq]
+
+(** [Pause_threshold.default] mirrors the legacy hardcoded values in
+    [Keeper_behavioral_regime.ml:46-50]. Field names must match — they are
+    the runtime.toml SSOT keys. *)
+let pause_threshold_default =
+  { turn_fail_streak_threshold = 3
+  ; recent_restart_window_sec = 300.0
+  ; recent_restart_count_threshold = 2
+  ; tool_failure_count_threshold = 3
+  ; tool_failure_ratio_threshold = 0.7
+  }
+;;
+
 (** {1 Top-level config}
 
     Routes/aliases/profiles/system_targets/strategy from the deleted
@@ -220,32 +246,6 @@ type config =
         intentionally deferred to a separate PR to keep this commit additive. *)
   }
 [@@deriving show, eq]
-
-(** {1 Pause threshold knobs}
-
-    Typed record mirroring the [\[pause\]] runtime.toml section.  All fields
-    are [int] or [float] — primitive thresholds, not reason classifiers, so
-    polymorphic variants / closed-sum types are not warranted here. *)
-type pause_threshold =
-  { turn_fail_streak_threshold : int
-  ; recent_restart_window_sec : float
-  ; recent_restart_count_threshold : int
-  ; tool_failure_count_threshold : int
-  ; tool_failure_ratio_threshold : float
-  }
-[@@deriving show, eq]
-
-(** [Pause_threshold.default] mirrors the legacy hardcoded values in
-    [Keeper_behavioral_regime.ml:46-50]. Field names must match — they are
-    the runtime.toml SSOT keys. *)
-let pause_threshold_default =
-  { turn_fail_streak_threshold = 3
-  ; recent_restart_window_sec = 300.0
-  ; recent_restart_count_threshold = 2
-  ; tool_failure_count_threshold = 3
-  ; tool_failure_ratio_threshold = 0.7
-  }
-;;
 
 (** {1 Lookups} *)
 

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -208,8 +208,44 @@ type config =
         admits it. [[]] = derive capable runtimes from declared
         [\[models.*.capabilities\]] in declaration order. Each id must resolve to
         a configured runtime (rejected at load like [\[runtime\].default]). *)
+  ; pause_threshold : pause_threshold
+    (** [\[pause\]] — typed SSOT for keeper pause / regime threshold knobs
+        previously hardcoded in [Keeper_behavioral_regime]. Mirrors the same
+        field names + types (int / float) so callers can compare against the
+        loaded record without an extra decoder. Missing from runtime.toml →
+        [Pause_threshold.default]. Wrong-type value → load-time warn + fallback
+        to default (fail-soft: wrong value is not catastrophic at boot).
+        Phase 2 caller migration (read [Keeper_behavioral_regime]'s constants
+        via [cfg.pause_threshold] instead of the top-level vals) is
+        intentionally deferred to a separate PR to keep this commit additive. *)
   }
 [@@deriving show, eq]
+
+(** {1 Pause threshold knobs}
+
+    Typed record mirroring the [\[pause\]] runtime.toml section.  All fields
+    are [int] or [float] — primitive thresholds, not reason classifiers, so
+    polymorphic variants / closed-sum types are not warranted here. *)
+type pause_threshold =
+  { turn_fail_streak_threshold : int
+  ; recent_restart_window_sec : float
+  ; recent_restart_count_threshold : int
+  ; tool_failure_count_threshold : int
+  ; tool_failure_ratio_threshold : float
+  }
+[@@deriving show, eq]
+
+(** [Pause_threshold.default] mirrors the legacy hardcoded values in
+    [Keeper_behavioral_regime.ml:46-50]. Field names must match — they are
+    the runtime.toml SSOT keys. *)
+let pause_threshold_default =
+  { turn_fail_streak_threshold = 3
+  ; recent_restart_window_sec = 300.0
+  ; recent_restart_count_threshold = 2
+  ; tool_failure_count_threshold = 3
+  ; tool_failure_ratio_threshold = 0.7
+  }
+;;
 
 (** {1 Lookups} *)
 

--- a/lib/runtime/runtime_schema.ml
+++ b/lib/runtime/runtime_schema.ml
@@ -241,9 +241,7 @@ type config =
         loaded record without an extra decoder. Missing from runtime.toml →
         [Pause_threshold.default]. Wrong-type value → load-time warn + fallback
         to default (fail-soft: wrong value is not catastrophic at boot).
-        Phase 2 caller migration (read [Keeper_behavioral_regime]'s constants
-        via [cfg.pause_threshold] instead of the top-level vals) is
-        intentionally deferred to a separate PR to keep this commit additive. *)
+        Operational callers read this through [Runtime.pause_threshold]. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_schema.mli
+++ b/lib/runtime/runtime_schema.mli
@@ -129,6 +129,19 @@ type binding =
   }
 [@@deriving show, eq]
 
+(** {1 Pause threshold knobs} *)
+
+type pause_threshold =
+  { turn_fail_streak_threshold : int
+  ; recent_restart_window_sec : float
+  ; recent_restart_count_threshold : int
+  ; tool_failure_count_threshold : int
+  ; tool_failure_ratio_threshold : float
+  }
+[@@deriving show, eq]
+
+val pause_threshold_default : pause_threshold
+
 (** {1 Top-level config} *)
 
 type config =
@@ -164,6 +177,9 @@ type config =
         admits it. [[]] = derive capable runtimes from declared
         [\[models.*.capabilities\]] in declaration order. Each id must resolve to
         a configured runtime (rejected at load like [\[runtime\].default]). *)
+  ; pause_threshold : pause_threshold
+    (** [\[pause\]] — typed SSOT for keeper pause / regime threshold knobs.
+        Missing or wrong-typed values fall back to [pause_threshold_default]. *)
   }
 [@@deriving show, eq]
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -681,6 +681,65 @@ let parse_keeper_assignments (toml : Otoml.t)
       ]
 ;;
 
+(* [\[pause\]] section → typed [Runtime_schema.pause_threshold].
+
+   Fails soft: a malformed value (e.g. wrong type) is logged + ignored rather
+   than aborting config load, mirroring the existing [runtime].media_failover
+   pattern above. Missing section / missing keys → [pause_threshold_default]
+   which mirrors the legacy hardcoded values in [Keeper_behavioral_regime.ml].
+   Phase 2 caller migration is deferred — the current top-level vals in
+   [Keeper_behavioral_regime] are untouched and still authoritative at
+   runtime. *)
+let parse_pause_threshold (toml : Otoml.t) : Runtime_schema.pause_threshold =
+  let read_field ~path ~key ~getter =
+    try
+      Ok (Otoml.find_opt toml getter [ path; key ])
+    with
+    | Otoml.Type_error msg ->
+      Error (Printf.sprintf "[%s].%s: %s" path key msg)
+  in
+  let pick_int ~path ~key ~default =
+    match read_field ~path ~key ~getter:Otoml.get_integer with
+    | Ok (Some v) -> v
+    | Ok None -> default
+    | Error msg ->
+      Log.Runtime.warn
+        "runtime_toml: %s — using default %d" msg default;
+      default
+  in
+  let pick_float ~path ~key ~default =
+    match read_field ~path ~key ~getter:Otoml.get_float with
+    | Ok (Some v) -> v
+    | Ok None -> default
+    | Error msg ->
+      Log.Runtime.warn
+        "runtime_toml: %s — using default %g" msg default;
+      default
+  in
+  let d = Runtime_schema.pause_threshold_default in
+  { turn_fail_streak_threshold =
+      pick_int
+        ~path:"pause" ~key:"turn_fail_streak_threshold"
+        ~default:d.turn_fail_streak_threshold
+  ; recent_restart_window_sec =
+      pick_float
+        ~path:"pause" ~key:"recent_restart_window_sec"
+        ~default:d.recent_restart_window_sec
+  ; recent_restart_count_threshold =
+      pick_int
+        ~path:"pause" ~key:"recent_restart_count_threshold"
+        ~default:d.recent_restart_count_threshold
+  ; tool_failure_count_threshold =
+      pick_int
+        ~path:"pause" ~key:"tool_failure_count_threshold"
+        ~default:d.tool_failure_count_threshold
+  ; tool_failure_ratio_threshold =
+      pick_float
+        ~path:"pause" ~key:"tool_failure_ratio_threshold"
+        ~default:d.tool_failure_ratio_threshold
+  }
+;;
+
 let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) result =
   let providers_result = parse_providers toml in
   let models_result = parse_models toml in
@@ -729,6 +788,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
     let bindings =
       extract_after_all_errors_guard ~label:"bindings" bindings_result
     in
+    let pause_threshold = parse_pause_threshold toml in
     Ok
       { Runtime_schema.providers
       ; models
@@ -738,6 +798,7 @@ let parse_toml (toml : Otoml.t) : (Runtime_schema.config, parse_error list) resu
       ; cross_verifier_runtime_id
       ; keeper_assignments
       ; media_failover
+      ; pause_threshold
       })
 ;;
 

--- a/lib/runtime/runtime_toml.ml
+++ b/lib/runtime/runtime_toml.ml
@@ -685,11 +685,9 @@ let parse_keeper_assignments (toml : Otoml.t)
 
    Fails soft: a malformed value (e.g. wrong type) is logged + ignored rather
    than aborting config load, mirroring the existing [runtime].media_failover
-   pattern above. Missing section / missing keys → [pause_threshold_default]
-   which mirrors the legacy hardcoded values in [Keeper_behavioral_regime.ml].
-   Phase 2 caller migration is deferred — the current top-level vals in
-   [Keeper_behavioral_regime] are untouched and still authoritative at
-   runtime. *)
+   pattern above. Missing section / missing keys → [pause_threshold_default],
+   which mirrors the legacy fallback values in [Keeper_behavioral_regime.ml].
+   Operational pause paths consume this through [Runtime.pause_threshold]. *)
 let parse_pause_threshold (toml : Otoml.t) : Runtime_schema.pause_threshold =
   let read_field ~path ~key ~getter =
     try

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -390,10 +390,37 @@ let composite_execution_budget_unsatisfied_reason execution =
   | None -> None
 ;;
 
+(* Typed budget-exhausted classification.
+
+   The dashboard composite reads the wire [terminal_reason_code] field
+   from the typed execution schema. Rather than scanning substrings
+   (anti-pattern #2), we route the wire string through the typed
+   [Keeper_turn_disposition.of_wire] parser and match on the closed sum.
+   An unrecognised string falls through [Unknown _] and yields [false];
+   no permissive default, no silent accept. *)
+let execution_turn_budget_disposition execution =
+  json_string "terminal_reason_code" execution
+  |> Option.bind ~f:(fun raw ->
+    let trimmed = String.trim raw in
+    if String.is_empty trimmed
+    then None
+    else Some (Keeper_turn_disposition.of_wire (String.lowercase_ascii trimmed)))
+;;
+
+let execution_turn_budget_disposition_of_reason reason =
+  match reason with
+  | None -> None
+  | Some raw ->
+    let trimmed = String.trim raw in
+    if String.is_empty trimmed
+    then None
+    else Some (Keeper_turn_disposition.of_wire (String.lowercase_ascii trimmed))
+;;
+
 let composite_execution_turn_budget_exhausted execution =
-  string_opt_has_prefix
-    (json_string "terminal_reason_code" execution)
-    ~prefix:"turn_budget_exhausted"
+  match execution_turn_budget_disposition execution with
+  | Some Keeper_turn_disposition.Turn_budget_exhausted -> true
+  | Some _ | None -> false
 ;;
 
 let composite_execution_budget_exhausted_pass execution =
@@ -401,11 +428,13 @@ let composite_execution_budget_exhausted_pass execution =
   && composite_execution_turn_budget_exhausted execution
   && Option.is_none (composite_execution_budget_unsatisfied_reason execution)
   &&
-  match lower_string_opt (json_string "operator_disposition_reason" execution) with
+  match execution_turn_budget_disposition_of_reason
+          (lower_string_opt (json_string "operator_disposition_reason" execution)) with
   | None -> true
   | Some "" -> true
-  | Some "healthy" -> true
-  | Some reason -> string_has_prefix ~prefix:"turn_budget_exhausted" reason
+  | Some Keeper_turn_disposition.Turn_budget_exhausted -> true
+  | Some Keeper_turn_disposition.Unknown _ -> true
+  | Some _ -> false
 ;;
 
 let composite_execution_blocked execution =

--- a/lib/server/server_dashboard_http_composite_claims.ml
+++ b/lib/server/server_dashboard_http_composite_claims.ml
@@ -399,10 +399,9 @@ let composite_execution_budget_unsatisfied_reason execution =
    An unrecognised string falls through [Unknown _] and yields [false];
    no permissive default, no silent accept. *)
 let execution_turn_budget_disposition execution =
-  json_string "terminal_reason_code" execution
-  |> Option.bind ~f:(fun raw ->
+  Option.bind (json_string "terminal_reason_code" execution) (fun raw ->
     let trimmed = String.trim raw in
-    if String.is_empty trimmed
+    if String.length trimmed = 0
     then None
     else Some (Keeper_turn_disposition.of_wire (String.lowercase_ascii trimmed)))
 ;;
@@ -412,14 +411,14 @@ let execution_turn_budget_disposition_of_reason reason =
   | None -> None
   | Some raw ->
     let trimmed = String.trim raw in
-    if String.is_empty trimmed
+    if String.length trimmed = 0
     then None
     else Some (Keeper_turn_disposition.of_wire (String.lowercase_ascii trimmed))
 ;;
 
 let composite_execution_turn_budget_exhausted execution =
   match execution_turn_budget_disposition execution with
-  | Some Keeper_turn_disposition.Turn_budget_exhausted -> true
+  | Some (Keeper_turn_disposition.Turn_budget_exhausted _) -> true
   | Some _ | None -> false
 ;;
 
@@ -431,8 +430,7 @@ let composite_execution_budget_exhausted_pass execution =
   match execution_turn_budget_disposition_of_reason
           (lower_string_opt (json_string "operator_disposition_reason" execution)) with
   | None -> true
-  | Some "" -> true
-  | Some Keeper_turn_disposition.Turn_budget_exhausted -> true
+  | Some (Keeper_turn_disposition.Turn_budget_exhausted _) -> true
   | Some Keeper_turn_disposition.Unknown _ -> true
   | Some _ -> false
 ;;

--- a/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
+++ b/lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml
@@ -21,21 +21,71 @@ let tool_detail_json body =
   try Yojson.Safe.from_string body with
   | Yojson.Json_error _ -> `String body
 
+(* Surface refresh — invalidate ALL execution: dashboard caches so a pause /
+   resume action reflects on every parameterized view (actor / fixture / full
+   mode) immediately instead of waiting on TTL.
+
+   Plan 가설 D: 이전 구현은 "execution:default:light" 단일 키만 무효화하여
+   server_dashboard_http_execution_surfaces.ml:940-941 의
+   "execution:{actor}:{fixture}:{light|full}" parameterized 키는
+   deep_surface_cache_ttl_s 동안 stale 유지 → 대시보드가 최신 pause/resume
+   상태를 늦게 반영.
+
+   Similarly, dashboard_shell_cache_prefix 로 묶이는 per-keeper shell surface
+   cache (60s TTL) 도 별도 무효화 — meta_cognition 경로가 명시적으로 같은
+   prefix 를 invalidate 하는 것과 대칭을 맞춘다.
+
+   - Light cache + parameterized keys: [Dashboard_cache.invalidate_prefix "execution:"]
+   - Per-keeper shell surface: [dashboard_shell_cache_prefix config]
+   - Global execution surface object: [patch_keeper_dependent_caches] (covers
+     [execution_cache] typed-surface invalidation)
+   - Operator control snapshot cache: [Operator_control_snapshot.invalidate_snapshot_cache]
+   - Projection cache: [Dashboard_projection_cache.invalidate_snapshot_json] *)
 let refresh_keeper_execution_surfaces ~config ~name event =
   Operator_control_snapshot.invalidate_snapshot_cache ();
   Dashboard_projection_cache.invalidate_snapshot_json ~config;
-  (try Dashboard_cache.invalidate "execution:default:light" with
+  (try Dashboard_cache.invalidate_prefix "execution:" with
    | Eio.Cancel.Cancelled _ as e -> raise e
    | exn ->
        Log.Dashboard.warn
          "keeper %s %s: execution dashboard cache invalidate failed: %s"
          name event (Printexc.to_string exn));
+  (try
+     Dashboard_cache.invalidate_prefix
+       (Server_dashboard_http_core_meta_cognition.dashboard_shell_cache_prefix
+          config)
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       Log.Dashboard.warn
+         "keeper %s %s: shell surface cache invalidate failed: %s"
+         name event (Printexc.to_string exn));
   Server_dashboard_http_execution_surfaces.patch_keeper_dependent_caches
     ~keeper_name:name ~event
 
+(* Wakeup / invalidate path — same cache-surface coverage as
+   [refresh_keeper_execution_surfaces]. Wakeup doesn't go through the directive
+   lifecycle, but the dashboard must still drop parameterized + shell-surface
+   entries so the wakeup reflects on every view. *)
 let invalidate_keeper_execution_surfaces ~config () =
   Operator_control_snapshot.invalidate_snapshot_cache ();
   Dashboard_projection_cache.invalidate_snapshot_json ~config;
+  (try Dashboard_cache.invalidate_prefix "execution:" with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       Log.Dashboard.warn
+         "keeper wakeup: execution dashboard cache invalidate failed: %s"
+         (Printexc.to_string exn));
+  (try
+     Dashboard_cache.invalidate_prefix
+       (Server_dashboard_http_core_meta_cognition.dashboard_shell_cache_prefix
+          config)
+   with
+   | Eio.Cancel.Cancelled _ as e -> raise e
+   | exn ->
+       Log.Dashboard.warn
+         "keeper wakeup: shell surface cache invalidate failed: %s"
+         (Printexc.to_string exn));
   Server_dashboard_http_execution_surfaces.invalidate_execution_cache ()
 
 (* Typed outcome of a keeper lifecycle action, so the log severity is chosen by

--- a/test/dune
+++ b/test/dune
@@ -1841,6 +1841,8 @@
 
 (include stanzas/test_keeper_invariant.inc)
 
+(include stanzas/test_keeper_latched_reason.inc)
+
 (include stanzas/test_keeper_long_turn_9943.inc)
 
 (include stanzas/test_keeper_execution_join.inc)
@@ -1917,6 +1919,8 @@
 
 (include stanzas/test_keeper_unified_tool_event_order_source.inc)
 
+(include stanzas/test_keeper_unified_turn_completion_contract.inc)
+
 (include stanzas/test_keeper_validation_breaker_exempt.inc)
 
 (include stanzas/test_keeper_turn_livelock_10121.inc)
@@ -1950,6 +1954,8 @@
 (include stanzas/test_masc_error_is_retryable.inc)
 
 (include stanzas/test_runtime_oas_eio_context_classify.inc)
+
+(include stanzas/test_runtime_pause_threshold_toml.inc)
 
 (include stanzas/test_keeper_response_feedback.inc)
 

--- a/test/stanzas/test_keeper_latched_reason.inc
+++ b/test/stanzas/test_keeper_latched_reason.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_latched_reason)
+ (modules test_keeper_latched_reason)
+ (libraries masc_test_deps))

--- a/test/stanzas/test_keeper_unified_turn_completion_contract.inc
+++ b/test/stanzas/test_keeper_unified_turn_completion_contract.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_keeper_unified_turn_completion_contract)
+ (modules test_keeper_unified_turn_completion_contract)
+ (libraries masc_test_deps))

--- a/test/stanzas/test_runtime_pause_threshold_toml.inc
+++ b/test/stanzas/test_runtime_pause_threshold_toml.inc
@@ -1,0 +1,4 @@
+(test
+ (name test_runtime_pause_threshold_toml)
+ (modules test_runtime_pause_threshold_toml)
+ (libraries masc_test_deps))

--- a/test/test_keeper_auto_pause_blocker_persist_12683.ml
+++ b/test/test_keeper_auto_pause_blocker_persist_12683.ml
@@ -33,6 +33,61 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+    output_string oc content)
+
+let runtime_toml_with_pause_threshold threshold =
+  Printf.sprintf
+    {|
+[runtime]
+default = "test_provider.test_model"
+
+[providers.test_provider]
+display-name = "Test Provider"
+protocol = "openai-compatible-http"
+endpoint = "http://127.0.0.1:1"
+
+[models.test_model]
+api-name = "test-model"
+max-context = 8192
+tools-support = true
+streaming = true
+
+[test_provider.test_model]
+is-default = true
+max-concurrent = 1
+
+[pause]
+turn_fail_streak_threshold = %d
+|}
+    threshold
+
+let with_runtime_config content f =
+  let config_dir = temp_dir "masc-runtime-pause-config-" in
+  let runtime_snapshot = Runtime.For_testing.snapshot () in
+  let prior = Sys.getenv_opt "MASC_CONFIG_DIR" in
+  Fun.protect
+    ~finally:(fun () ->
+      Runtime.For_testing.restore runtime_snapshot;
+      (match prior with
+       | Some value -> Unix.putenv "MASC_CONFIG_DIR" value
+       | None -> Unix.putenv "MASC_CONFIG_DIR" "");
+      Config_dir_resolver.reset ();
+      cleanup_dir config_dir)
+    (fun () ->
+       let runtime_config_path =
+         Filename.concat config_dir Config_dir_resolver.runtime_toml_filename
+       in
+       write_file runtime_config_path content;
+       Unix.putenv "MASC_CONFIG_DIR" config_dir;
+       Config_dir_resolver.reset ();
+       (match Runtime.init_default ~config_path:runtime_config_path with
+        | Ok () -> ()
+        | Error err -> fail ("runtime init: " ^ err));
+       f ())
+
 let test_turn_timeout_blocker_class_roundtrip () =
   let cls = Keeper_meta_contract.Turn_timeout in
   let label = Keeper_meta_contract.blocker_class_to_string cls in
@@ -674,9 +729,53 @@ let test_idle_detected_repeated_failure_pauses_keeper () =
               "blocker detail"
               "idle loop detected: consecutive_idle_turns=4; auto-paused after repeated idle turns; operator resume clears the idle latch"
               detail
-          | Some _ -> fail "expected Sdk_idle_detected blocker"
-          | None -> fail "expected idle-detected blocker")
+       | Some _ -> fail "expected Sdk_idle_detected blocker"
+       | None -> fail "expected idle-detected blocker")
        | None -> fail "expected registered keeper")
+
+let test_runtime_pause_threshold_override_controls_idle_auto_pause () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  with_runtime_config (runtime_toml_with_pause_threshold 2) @@ fun () ->
+  let base_path = temp_dir "masc-idle-detected-runtime-threshold-" in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "idle-detected-runtime-threshold" in
+       let meta = make_meta keeper_name in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       let err =
+         Agent_sdk.Error.Agent
+           (Agent_sdk.Error.IdleDetected { consecutive_idle_turns = 4 })
+       in
+       Masc.Keeper_unified_turn_failure.record_failure_and_maybe_escalate
+         ~config
+         ~meta
+         ~updated_meta:meta
+         ~is_auto_recoverable:false
+         ~err
+         ~error_text:(Agent_sdk.Error.to_string err);
+       (match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+        | Some entry ->
+          check bool "not paused before runtime threshold" false
+            entry.Masc.Keeper_registry.meta.paused
+        | None -> fail "expected registered keeper after first failure");
+       Masc.Keeper_unified_turn_failure.record_failure_and_maybe_escalate
+         ~config
+         ~meta
+         ~updated_meta:meta
+         ~is_auto_recoverable:false
+         ~err
+         ~error_text:(Agent_sdk.Error.to_string err);
+       match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+       | Some entry ->
+         check bool "paused at runtime threshold" true
+           entry.Masc.Keeper_registry.meta.paused
+       | None -> fail "expected registered keeper after threshold")
 
 let test_legacy_last_blocker_pair_rejected () =
   let legacy_json =
@@ -760,5 +859,7 @@ let () =
         [
           test_case "repeated IdleDetected pauses keeper for manual resume" `Quick
             test_idle_detected_repeated_failure_pauses_keeper;
+          test_case "runtime [pause] threshold controls idle auto-pause" `Quick
+            test_runtime_pause_threshold_override_controls_idle_auto_pause;
         ] );
     ]

--- a/test/test_keeper_latched_reason.ml
+++ b/test/test_keeper_latched_reason.ml
@@ -1,0 +1,255 @@
+module R = Keeper_latched_reason
+
+let check_reason label expected actual =
+  Alcotest.(check bool) label true (R.equal expected actual)
+;;
+
+let expect_ok label = function
+  | Ok value -> value
+  | Error err -> Alcotest.failf "%s expected Ok, got Error %s" label err
+;;
+
+let expect_error label = function
+  | Ok value -> Alcotest.failf "%s expected Error, got %a" label R.pp value
+  | Error err -> Alcotest.(check bool) (label ^ " has message") true (String.length err > 0)
+;;
+
+let round_trippable =
+  [ ( "no progress loop"
+    , R.No_progress_loop
+        { consecutive_idle_cycles = 4; detector_kind = `Consecutive_no_progress } )
+  ; ( "completion contract violation"
+    , R.Completion_contract_violation
+        { reason_code = `No_tool_use_block
+        ; raw_error_summary = "missing keeper tool result: retry"
+        } )
+  ; "idle detected", R.Idle_detected { consecutive_idle_turns = 3 }
+  ; "runtime all providers failed", R.Runtime_exhausted R.All_providers_failed
+  ; "runtime no providers", R.Runtime_exhausted R.No_providers_available
+  ; ( "runtime structural timeout"
+    , R.Runtime_exhausted (R.Structural_attempt_timeout { stage = "provider_connect" }) )
+  ; "runtime unspecified", R.Runtime_exhausted R.Unspecified_runtime
+  ; ( "turn budget exhausted"
+    , R.Turn_budget_exhausted
+        { dimension = `Wall_clock_seconds
+        ; used = 95
+        ; limit = 90
+        ; source = `User_config
+        } )
+  ; "stale storm", R.Stale_storm
+  ; "provider timeout loop", R.Provider_timeout_loop { consecutive_timeouts = 2 }
+  ; "operator paused", R.Operator_paused { operator_actor = "dashboard:play" }
+  ]
+;;
+
+let test_wire_round_trip () =
+  List.iter
+    (fun (label, reason) ->
+       let wire = R.to_wire reason in
+       let parsed = expect_ok label (R.of_wire wire) in
+       check_reason (label ^ " wire round-trip") reason parsed)
+    round_trippable
+;;
+
+let test_wire_parse_fail_closed () =
+  [ "no_progress_loop:cycles=4:detector=surprise"
+  ; "turn_budget_exhausted:dim=turns:used=nope:limit=10:source=oas_sdk"
+  ; "turn_budget_exhausted:dim=turns:used=10:limit=10:source=unknown"
+  ; "runtime_exhausted:unknown"
+  ; "completion_contract_violation"
+  ; "completion_contract_violation:code=galactic:summary=\"raw text\""
+  ; "completion_contract_violation:code=unspecified:summary=raw_text"
+  ]
+  |> List.iter (fun wire -> expect_error wire (R.of_wire wire))
+;;
+
+let test_stable_json_round_trip () =
+  List.iter
+    (fun (label, reason) ->
+       let json = R.Stable.to_yojson reason in
+       let parsed = expect_ok label (R.Stable.of_yojson json) in
+       check_reason (label ^ " json round-trip") reason parsed)
+    round_trippable
+;;
+
+let test_stable_json_rejects_unknown_tags () =
+  expect_error
+    "unknown dimension"
+    (R.Stable.of_yojson
+       (`Assoc
+           [ "kind", `String "turn_budget_exhausted"
+           ; "dimension", `String "galactic"
+           ; "used", `Int 10
+           ; "limit", `Int 10
+           ; "source", `String "oas_sdk"
+           ]));
+  expect_error
+    "unknown kind"
+    (R.Stable.of_yojson (`Assoc [ "kind", `String "new_future_reason" ]))
+;;
+
+(* ── Polymorphic-variant differentiation via [equal] ────────── *)
+
+let test_poly_variants_distinguish_via_equal () =
+  (* Polymorphic-variant fields are not directly comparable without
+     a helper. [equal] is the canonical typed equality; it must
+     distinguish same-tag from different-tag values for every
+     polymorphic-variant field. *)
+  let base =
+    R.Turn_budget_exhausted
+      { dimension = `Turns; used = 10; limit = 10; source = `Oas_sdk }
+  in
+  let with_different_dim =
+    R.Turn_budget_exhausted
+      { dimension = `Wall_clock_seconds
+      ; used = 10
+      ; limit = 10
+      ; source = `Oas_sdk
+      }
+  in
+  let with_different_source =
+    R.Turn_budget_exhausted
+      { dimension = `Turns; used = 10; limit = 10; source = `User_config }
+  in
+  let with_different_used =
+    R.Turn_budget_exhausted
+      { dimension = `Turns; used = 11; limit = 10; source = `Oas_sdk }
+  in
+  let with_different_limit =
+    R.Turn_budget_exhausted
+      { dimension = `Turns; used = 10; limit = 11; source = `Oas_sdk }
+  in
+  Alcotest.(check bool) "Turns = Turns (reflexive)" true (R.equal base base);
+  Alcotest.(check bool)
+    "Turns ≠ Wall_clock_seconds (dim differs)"
+    false
+    (R.equal base with_different_dim);
+  Alcotest.(check bool)
+    "Oas_sdk ≠ User_config (source differs)"
+    false
+    (R.equal base with_different_source);
+  Alcotest.(check bool)
+    "used differs"
+    false
+    (R.equal base with_different_used);
+  Alcotest.(check bool)
+    "limit differs"
+    false
+    (R.equal base with_different_limit);
+  (* contract_violation_detail: reason_code is a closed polymorphic
+     variant *)
+  let cc_base =
+    R.Completion_contract_violation
+      { reason_code = `No_tool_use_block; raw_error_summary = "x" }
+  in
+  let cc_diff_code =
+    R.Completion_contract_violation
+      { reason_code = `No_keeper_tool_returned; raw_error_summary = "x" }
+  in
+  let cc_diff_summary =
+    R.Completion_contract_violation
+      { reason_code = `No_tool_use_block; raw_error_summary = "y" }
+  in
+  Alcotest.(check bool)
+    "Completion_contract reason_code differs"
+    false
+    (R.equal cc_base cc_diff_code);
+  Alcotest.(check bool)
+    "Completion_contract raw_error_summary differs"
+    false
+    (R.equal cc_base cc_diff_summary);
+  (* no_progress_loop detector_kind *)
+  let npl_base =
+    R.No_progress_loop
+      { consecutive_idle_cycles = 3; detector_kind = `Consecutive_idle_turns }
+  in
+  let npl_diff_detector =
+    R.No_progress_loop
+      { consecutive_idle_cycles = 3; detector_kind = `Both }
+  in
+  Alcotest.(check bool)
+    "no_progress_loop detector_kind differs"
+    false
+    (R.equal npl_base npl_diff_detector)
+;;
+
+(* ── Hash determinism ───────────────────────────────────────── *)
+
+let test_hash_is_deterministic () =
+  List.iter
+    (fun (label, reason) ->
+       let h1 = R.hash reason in
+       let h2 = R.hash reason in
+       Alcotest.(check int) (label ^ " hash deterministic") h1 h2)
+    round_trippable
+;;
+
+(* ── Completion-contract payload quoting ────────────────────── *)
+
+let test_completion_contract_payload_quoting () =
+  (* raw_error_summary may contain colons, equals signs, and double
+     quotes. The wire format uses : as a separator, so the producer
+     must preserve these byte-for-byte. *)
+  let payload_summary = "raw text with : colon and \"quotes\" and =equals=" in
+  let reason =
+    R.Completion_contract_violation
+      { reason_code = `Unspecified; raw_error_summary = payload_summary }
+  in
+  let wire = R.to_wire reason in
+  match R.of_wire wire with
+  | Ok (R.Completion_contract_violation { raw_error_summary; _ }) ->
+    Alcotest.(check string)
+      "raw_error_summary byte-identical after wire round-trip"
+      payload_summary
+      raw_error_summary
+  | Ok other ->
+    Alcotest.failf
+      "wire round-trip changed constructor: %a"
+      R.pp
+      other
+  | Error err ->
+    Alcotest.failf "of_wire rejected colon-bearing payload: %s" err
+;;
+
+(* ── Completion-contract unknown reason_code fails closed ───── *)
+
+let test_completion_contract_unknown_reason_code_fails_closed () =
+  (* [reason_code] is part of the typed latch reason, so a producer-side
+     tag drift must not silently land in [`Unspecified]. Operators still
+     get the original wire in the Error message. *)
+  expect_error
+    "unknown completion_contract reason_code"
+    (R.of_wire "completion_contract_violation:code=galactic:summary=\"raw text\"")
+;;
+
+let () =
+  Alcotest.run
+    "keeper_latched_reason"
+    [ ( "wire"
+      , [ Alcotest.test_case "typed reasons round-trip" `Quick test_wire_round_trip
+        ; Alcotest.test_case "payload preserves colon + quote" `Quick
+            test_completion_contract_payload_quoting
+        ; Alcotest.test_case "unknown reason_code fails closed" `Quick
+            test_completion_contract_unknown_reason_code_fails_closed
+        ; Alcotest.test_case
+            "malformed wires fail closed"
+            `Quick
+            test_wire_parse_fail_closed
+        ] )
+    ; ( "stable json"
+      , [ Alcotest.test_case
+            "typed reasons round-trip"
+            `Quick
+            test_stable_json_round_trip
+        ; Alcotest.test_case
+            "unknown tags fail closed"
+            `Quick
+            test_stable_json_rejects_unknown_tags
+        ] )
+    ; ( "polymorphic-variant equality"
+      , [ Alcotest.test_case "poly variants distinguish via equal" `Quick
+            test_poly_variants_distinguish_via_equal ] )
+    ; ( "structural hashing"
+      , [ Alcotest.test_case "hash is deterministic" `Quick test_hash_is_deterministic ] )
+    ]
+;;

--- a/test/test_keeper_turn_disposition.ml
+++ b/test/test_keeper_turn_disposition.ml
@@ -145,6 +145,25 @@ let round_trippable : (string * D.t) list =
   ; "External_cancel", D.External_cancel
   ; "Turn_wall_clock_timeout", D.Turn_wall_clock_timeout
   ; "Post_commit_ambiguous", D.Post_commit_ambiguous
+  ; "Completion_contract_unsatisfied", D.Completion_contract_unsatisfied
+  ; "Completion_contract_no_progress", D.Completion_contract_no_progress
+  ; ( "Turn_budget_exhausted/Turns/Oas"
+    , D.Turn_budget_exhausted
+        { dimension = `Turns; used = 10; limit = 10; source = `Oas_sdk } )
+  ; ( "Turn_budget_exhausted/WallClock/User"
+    , D.Turn_budget_exhausted
+        { dimension = `Wall_clock_seconds
+        ; used = 95
+        ; limit = 90
+        ; source = `User_config
+        } )
+  ; ( "Turn_budget_exhausted/Idle/Keeper"
+    , D.Turn_budget_exhausted
+        { dimension = `Idle_turns
+        ; used = 3
+        ; limit = 2
+        ; source = `Keeper_runtime
+        } )
   ; "Unknown empty", D.Unknown { raw_error = "" }
   ; "Unknown raw", D.Unknown { raw_error = "fresh_unmapped_label" }
   ; (* Runtime wires that Code.of_wire recognises losslessly (no payload
@@ -157,6 +176,77 @@ let round_trippable : (string * D.t) list =
   ; "Provider_error/TurnLivelock", D.Provider_error Code.Turn_livelock_pause
   ; "Provider_error/Fiber", D.Provider_error Code.Fiber_unresolved
   ]
+;;
+
+(* Documented lossy Turn_budget_exhausted wires — fall back to
+   [Unknown { raw_error = original }] per the parser's fail-closed
+   contract. The original wire is preserved verbatim for diagnostic
+   surfacing so a producer using a stale dimension tag does not silently
+   land in a typed bucket. *)
+let turn_budget_lossy_wires : (string * string) list =
+  [ ( "Turn_budget_exhausted unknown dimension"
+    , "turn_budget_exhausted(galactic:oas_sdk:10/10)" )
+  ; ( "Turn_budget_exhausted unknown source"
+    , "turn_budget_exhausted(turns:galactic:10/10)" )
+  ; ( "Turn_budget_exhausted malformed counts"
+    , "turn_budget_exhausted(turns:oas_sdk:notanumber/10)" )
+  ; ( "Turn_budget_exhausted missing parens"
+    , "turn_budget_exhausted turns:oas_sdk:10/10" )
+  ; ( "Turn_budget_exhausted missing close paren"
+    , "turn_budget_exhausted(turns:oas_sdk:10/10" )
+  ; ( "Turn_budget_exhausted extra count segment"
+    , "turn_budget_exhausted(turns:oas_sdk:10/10/11)" )
+  ]
+;;
+
+let test_turn_budget_lossy_wires_fail_closed () =
+  List.iter
+    (fun (label, wire) ->
+       match D.of_wire wire with
+       | D.Unknown { raw_error } ->
+         Alcotest.(check string)
+           (label ^ " preserves wire verbatim")
+           wire
+           raw_error
+       | other ->
+         Alcotest.failf "%s expected Unknown, got %a" label D.pp other)
+    turn_budget_lossy_wires
+;;
+
+let test_completion_contract_severity_is_bad () =
+  Alcotest.(check string)
+    "Completion_contract_unsatisfied severity"
+    "bad"
+    (typed_severity_str (D.severity D.Completion_contract_unsatisfied));
+  Alcotest.(check string)
+    "Completion_contract_no_progress severity"
+    "bad"
+    (typed_severity_str (D.severity D.Completion_contract_no_progress))
+;;
+
+let test_turn_budget_exhausted_severity_is_bad () =
+  Alcotest.(check string)
+    "Turn_budget_exhausted severity"
+    "bad"
+    (typed_severity_str
+       (D.severity
+          (D.Turn_budget_exhausted
+             { dimension = `Turns
+             ; used = 10
+             ; limit = 10
+             ; source = `Oas_sdk
+             })))
+;;
+
+let test_completion_contract_next_action () =
+  Alcotest.(check (option string))
+    "Completion_contract_unsatisfied next_action"
+    (Some "inspect_completion_contract")
+    (D.next_action D.Completion_contract_unsatisfied);
+  Alcotest.(check (option string))
+    "Completion_contract_no_progress next_action"
+    (Some "resume_or_inspect_completion_contract")
+    (D.next_action D.Completion_contract_no_progress)
 ;;
 
 let test_round_trip_recognised () =
@@ -363,6 +453,26 @@ let () =
             "parametrised payloads land in Unknown (asymmetric)"
             `Quick
             test_round_trip_lossy_payloads
+        ; Alcotest.test_case
+            "Turn_budget_exhausted malformed wires fail closed"
+            `Quick
+            test_turn_budget_lossy_wires_fail_closed
+        ] )
+    ; ( "completion-contract typed accessors (RFC-0047 PR-2)"
+      , [ Alcotest.test_case
+            "severity is bad"
+            `Quick
+            test_completion_contract_severity_is_bad
+        ; Alcotest.test_case
+            "next_action dispatches to resume/inspect"
+            `Quick
+            test_completion_contract_next_action
+        ] )
+    ; ( "Turn_budget_exhausted typed accessors"
+      , [ Alcotest.test_case
+            "severity is bad"
+            `Quick
+            test_turn_budget_exhausted_severity_is_bad
         ] )
     ; ( "of_termination_code projection"
       , [ Alcotest.test_case

--- a/test/test_keeper_unified_turn_completion_contract.ml
+++ b/test/test_keeper_unified_turn_completion_contract.ml
@@ -1,0 +1,386 @@
+(** Tests for [Keeper_unified_turn_completion_contract.clear_for_operator_resume]
+    — the typed latch recovery that closes the "resume doesn't stick"
+    symptom in RFC-0047 §3.2 / plan hypothesis B.
+
+    Pinned invariants:
+    1. Boundary: the function clears ONLY the completion-contract latch
+       pair — [last_failure_reason] when its code is
+       ["completion_contract_violation"] and the meta
+       [last_blocker] when its klass is [Completion_contract_violation].
+       It must not touch [paused] (owned by the resume_reconcile_gate).
+    2. Idempotence: running it twice on a clean meta is a no-op (no
+       spurious side effects, no log lines).
+    3. Cross-klass safety: a meta whose [last_blocker.klass] is
+       [No_progress_loop] (or any other klass) is left untouched,
+       even when [last_failure_reason] carries the
+       completion-contract code. The function reads them
+       independently.
+    4. Failure-reason cross-code safety: a
+       [last_failure_reason] whose code is NOT
+       ["completion_contract_violation"] (e.g. another
+       [Provider_runtime_error] code) is left alone. *)
+
+open Alcotest
+
+module KMR = Masc.Keeper_meta_contract
+module KR = Masc.Keeper_registry
+module CC = Masc.Keeper_unified_turn_completion_contract
+
+let temp_dir prefix =
+  let dir = Filename.temp_file prefix "" in
+  Sys.remove dir;
+  Unix.mkdir dir 0o755;
+  dir
+;;
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.is_directory path
+    then (
+      Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else Unix.unlink path
+  in
+  try rm dir with
+  | Sys_error _
+  | Unix.Unix_error _ -> ()
+;;
+
+let legacy_base_json name =
+  `Assoc
+    [
+      "name", `String name;
+      "agent_name", `String (name ^ "-agent");
+      "trace_id", `String ("trace-" ^ name);
+      "tool_access", `List [];
+    ]
+;;
+
+let make_meta name =
+  match Masc.Keeper_meta_json_parse.meta_of_json (legacy_base_json name) with
+  | Ok m -> m
+  | Error err -> fail ("parse base: " ^ err)
+;;
+
+let completion_contract_provider_runtime ?(detail = "completion contract violated") () =
+  KR.Provider_runtime_error
+    { code = CC.failure_reason_code
+    ; detail
+    ; provider_id = None
+    ; http_status = None
+    ; runtime_id = None
+    ; reason = None
+    }
+;;
+
+let unrelated_provider_runtime code =
+  KR.Provider_runtime_error
+    { code
+    ; detail = "unrelated"
+    ; provider_id = None
+    ; http_status = None
+    ; runtime_id = None
+    ; reason = None
+    }
+;;
+
+let test_clears_both_latches_when_both_set () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-cc-both-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "cc-both" in
+       let blocker =
+         KMR.blocker_info_of_class
+           ~detail:"completion contract violated"
+           KMR.Completion_contract_violation
+       in
+       let meta =
+         make_meta keeper_name
+         |> KMR.map_runtime (fun rt -> { rt with last_blocker = Some blocker })
+       in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       Masc.Keeper_registry.set_failure_reason
+         ~base_path:config.base_path
+         keeper_name
+         (Some (completion_contract_provider_runtime ()));
+       (* Sanity: both latches set before resume *)
+       (match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+        | Some entry ->
+          (match entry.Masc.Keeper_registry.last_failure_reason with
+           | Some (KR.Provider_runtime_error { code; _ }) ->
+             check string
+               "pre-resume: failure reason code is completion_contract_violation"
+               CC.failure_reason_code
+               code
+           | Some _ -> fail "expected Provider_runtime_error pre-resume"
+           | None -> fail "expected Some failure_reason pre-resume");
+          check bool
+            "pre-resume: meta last_blocker klass is Completion_contract_violation"
+            true
+            (match entry.Masc.Keeper_registry.meta.runtime.last_blocker with
+             | Some { KMR.klass = KMR.Completion_contract_violation; _ } -> true
+             | _ -> false)
+        | None -> fail "expected registered keeper pre-resume");
+       let resumed_meta = CC.clear_for_operator_resume ~base_path:config.base_path meta in
+       (* last_blocker cleared in returned meta *)
+       (match resumed_meta.runtime.last_blocker with
+        | None -> ()
+        | Some _ -> fail "expected last_blocker cleared in returned meta");
+       (* Side effect: failure reason cleared in registry *)
+       (match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+        | Some entry ->
+          (match entry.Masc.Keeper_registry.last_failure_reason with
+           | None -> ()
+           | Some _ -> fail "expected registry failure_reason cleared")
+        | None -> fail "expected registered keeper post-resume"))
+;;
+
+let test_clears_only_meta_when_failure_reason_missing () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-cc-meta-only-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "cc-meta-only" in
+       let blocker =
+         KMR.blocker_info_of_class
+           ~detail:"completion contract violated"
+           KMR.Completion_contract_violation
+       in
+       let meta =
+         make_meta keeper_name
+         |> KMR.map_runtime (fun rt -> { rt with last_blocker = Some blocker })
+       in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       (* No failure_reason set — function must still clear meta blocker. *)
+       let resumed_meta = CC.clear_for_operator_resume ~base_path:config.base_path meta in
+       (match resumed_meta.runtime.last_blocker with
+        | None -> ()
+        | Some _ -> fail "expected meta blocker cleared even with no failure_reason"))
+;;
+
+let test_preserves_unrelated_blocker_klass () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-cc-no-progress-meta-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "cc-no-progress-meta" in
+       let blocker =
+         KMR.blocker_info_of_class
+           ~detail:"no_progress loop detected"
+           KMR.No_progress_loop
+       in
+       let meta =
+         make_meta keeper_name
+         |> KMR.map_runtime (fun rt -> { rt with last_blocker = Some blocker })
+       in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       (* failure_reason IS the completion-contract code, but the meta
+          blocker is No_progress_loop → function must NOT touch it. *)
+       Masc.Keeper_registry.set_failure_reason
+         ~base_path:config.base_path
+         keeper_name
+         (Some (completion_contract_provider_runtime ()));
+       let resumed_meta = CC.clear_for_operator_resume ~base_path:config.base_path meta in
+       (match resumed_meta.runtime.last_blocker with
+        | Some { KMR.klass = KMR.No_progress_loop; _ } -> ()
+        | Some _ ->
+          fail "expected No_progress_loop blocker preserved, got a different klass"
+        | None -> fail "expected No_progress_loop blocker preserved");
+       (* failure_reason IS cleared because its code matches *)
+       (match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+        | Some entry ->
+          (match entry.Masc.Keeper_registry.last_failure_reason with
+           | None -> ()
+           | Some _ -> fail "expected registry failure_reason cleared")
+        | None -> fail "expected registered keeper"))
+;;
+
+let test_preserves_unrelated_failure_reason_code () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-cc-other-code-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "cc-other-code" in
+       let blocker =
+         KMR.blocker_info_of_class
+           ~detail:"completion contract violated"
+           KMR.Completion_contract_violation
+       in
+       let meta =
+         make_meta keeper_name
+         |> KMR.map_runtime (fun rt -> { rt with last_blocker = Some blocker })
+       in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       (* Different code → registry side effect must not fire. *)
+       Masc.Keeper_registry.set_failure_reason
+         ~base_path:config.base_path
+         keeper_name
+         (Some (unrelated_provider_runtime "some_other_failure_code"));
+       let _resumed_meta = CC.clear_for_operator_resume ~base_path:config.base_path meta in
+       (* failure_reason code preserved *)
+       (match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+        | Some entry ->
+          (match entry.Masc.Keeper_registry.last_failure_reason with
+           | Some (KR.Provider_runtime_error { code; _ }) ->
+             check string
+               "unrelated failure reason code preserved"
+               "some_other_failure_code"
+               code
+           | Some _ -> fail "expected Provider_runtime_error preserved"
+           | None -> fail "expected unrelated failure reason preserved")
+        | None -> fail "expected registered keeper"))
+;;
+
+let test_failure_reason_does_not_touch_meta_blocker () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-cc-fail-reason-only-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "cc-fail-reason-only" in
+       (* Meta has NO blocker; only the registry failure_reason matches.
+          Function must clear the registry entry but the returned meta
+          is byte-identical to the input. *)
+       let meta = make_meta keeper_name in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       Masc.Keeper_registry.set_failure_reason
+         ~base_path:config.base_path
+         keeper_name
+         (Some (completion_contract_provider_runtime ()));
+       let resumed_meta = CC.clear_for_operator_resume ~base_path:config.base_path meta in
+       check bool
+         "returned meta byte-identical when meta blocker absent"
+         true
+         (resumed_meta = meta);
+       (match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+        | Some entry ->
+          (match entry.Masc.Keeper_registry.last_failure_reason with
+           | None -> ()
+           | Some _ -> fail "expected registry failure_reason cleared")
+        | None -> fail "expected registered keeper"))
+;;
+
+let test_no_op_on_clean_meta () =
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-cc-clean-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "cc-clean" in
+       let meta = make_meta keeper_name in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       let resumed_meta = CC.clear_for_operator_resume ~base_path:config.base_path meta in
+       check bool "no-op on clean meta" true (resumed_meta = meta))
+;;
+
+let test_does_not_touch_paused () =
+  (* Boundary: clear_for_operator_resume must NOT mutate
+     [paused] — that is the reconcile_gate's responsibility. *)
+  Eio_main.run
+  @@ fun env ->
+  Fs_compat.set_fs (Eio.Stdenv.fs env);
+  let base_path = temp_dir "masc-cc-boundary-" in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc.Keeper_registry.clear ();
+      cleanup_dir base_path)
+    (fun () ->
+       let config = Masc.Workspace.default_config base_path in
+       ignore (Masc.Workspace.init config ~agent_name:(Some "operator"));
+       let keeper_name = "cc-boundary" in
+       let blocker =
+         KMR.blocker_info_of_class
+           ~detail:"completion contract violated"
+           KMR.Completion_contract_violation
+       in
+       let meta =
+         { (make_meta keeper_name
+            |> KMR.map_runtime (fun rt -> { rt with last_blocker = Some blocker }))
+           with
+           paused = true
+         }
+       in
+       Masc.Keeper_registry.clear ();
+       ignore (Masc.Keeper_registry.register ~base_path:config.base_path keeper_name meta);
+       Masc.Keeper_registry.set_failure_reason
+         ~base_path:config.base_path
+         keeper_name
+         (Some (completion_contract_provider_runtime ()));
+       let resumed_meta = CC.clear_for_operator_resume ~base_path:config.base_path meta in
+       check bool "paused preserved" true resumed_meta.paused;
+       (* Registry-side paused state also untouched. *)
+       (match Masc.Keeper_registry.get ~base_path:config.base_path keeper_name with
+        | Some entry ->
+          check bool
+            "registry meta.paused preserved"
+            true
+            entry.Masc.Keeper_registry.meta.paused
+        | None -> fail "expected registered keeper"))
+;;
+
+let () =
+  run "keeper_unified_turn_completion_contract"
+    [ ( "latch recovery",
+        [ test_case "clears both latches when both set" `Quick
+            test_clears_both_latches_when_both_set
+        ; test_case "clears meta-only when failure_reason missing" `Quick
+            test_clears_only_meta_when_failure_reason_missing
+        ; test_case "preserves unrelated blocker klass" `Quick
+            test_preserves_unrelated_blocker_klass
+        ; test_case "preserves unrelated failure_reason code" `Quick
+            test_preserves_unrelated_failure_reason_code
+        ; test_case "failure_reason match does not touch meta blocker" `Quick
+            test_failure_reason_does_not_touch_meta_blocker
+        ; test_case "no-op on clean meta" `Quick
+            test_no_op_on_clean_meta
+        ; test_case "does not touch paused" `Quick
+            test_does_not_touch_paused
+        ] ) ]
+;;

--- a/test/test_runtime_pause_threshold_toml.ml
+++ b/test/test_runtime_pause_threshold_toml.ml
@@ -30,7 +30,8 @@ let parse_string_or_fail s =
   | Error errs ->
     let rendered =
       errs
-      |> List.map (fun e -> Printf.sprintf "[%s] %s" e.Schema.path e.message)
+      |> List.map (fun (e : Toml.parse_error) ->
+        Printf.sprintf "[%s] %s" e.path e.message)
       |> String.concat "; "
     in
     failf "parse_string failed: %s" rendered

--- a/test/test_runtime_pause_threshold_toml.ml
+++ b/test/test_runtime_pause_threshold_toml.ml
@@ -1,0 +1,262 @@
+(** Tests for the [[pause]] section parser in [Runtime_toml].
+
+    Pinned invariants (RFC-0047 PR-5):
+
+    1. Missing [[pause]] section → every field falls back to
+       [Runtime_schema.pause_threshold_default]. The default mirrors the
+       legacy hardcoded values in [Keeper_behavioral_regime.ml:46-50],
+       which are the in-code fallback only — runtime.toml is the typed
+       SSOT going forward.
+
+    2. A complete [[pause]] table → every field is parsed verbatim into
+       the corresponding record field; no implicit clamping, no rounding.
+
+    3. A partial [[pause]] table → missing keys fall back to the default
+       field value; supplied keys override only that field.
+
+    4. A wrong-typed value (e.g. string for an int field) does NOT
+       propagate the bad value: the parser logs a warning and the field
+       reverts to the default. The other fields in the same table still
+       parse normally. *)
+
+open Alcotest
+
+module Schema = Runtime_schema
+module Toml = Runtime_toml
+
+let parse_string_or_fail s =
+  match Toml.parse_string s with
+  | Ok cfg -> cfg
+  | Error errs ->
+    let rendered =
+      errs
+      |> List.map (fun e -> Printf.sprintf "[%s] %s" e.Schema.path e.message)
+      |> String.concat "; "
+    in
+    failf "parse_string failed: %s" rendered
+;;
+
+let field_defaults = Schema.pause_threshold_default
+
+(* ── 1. Missing [[pause]] section ────────────────────────────── *)
+
+let test_missing_pause_section_uses_defaults () =
+  let cfg =
+    parse_string_or_fail
+      "[providers.local-ollama]\n\
+       protocol = \"ollama-http\"\n\
+       endpoint = \"http://127.0.0.1:11434\"\n"
+  in
+  check int
+    "turn_fail_streak_threshold default when [pause] missing"
+    field_defaults.turn_fail_streak_threshold
+    cfg.Schema.pause_threshold.turn_fail_streak_threshold;
+  check (float 0.0001)
+    "recent_restart_window_sec default when [pause] missing"
+    field_defaults.recent_restart_window_sec
+    cfg.pause_threshold.recent_restart_window_sec;
+  check int
+    "recent_restart_count_threshold default when [pause] missing"
+    field_defaults.recent_restart_count_threshold
+    cfg.pause_threshold.recent_restart_count_threshold;
+  check int
+    "tool_failure_count_threshold default when [pause] missing"
+    field_defaults.tool_failure_count_threshold
+    cfg.pause_threshold.tool_failure_count_threshold;
+  check (float 0.0001)
+    "tool_failure_ratio_threshold default when [pause] missing"
+    field_defaults.tool_failure_ratio_threshold
+    cfg.pause_threshold.tool_failure_ratio_threshold
+;;
+
+let test_empty_pause_section_uses_defaults () =
+  (* An empty [[pause]] table — every key absent — must still fall back to
+     defaults field-by-field. This is distinct from "section missing"
+     only in TOML parse semantics; the runtime result must be
+     byte-identical. *)
+  let cfg = parse_string_or_fail "[pause]\n" in
+  check int
+    "empty [pause] turn_fail_streak_threshold"
+    field_defaults.turn_fail_streak_threshold
+    cfg.pause_threshold.turn_fail_streak_threshold;
+  check (float 0.0001)
+    "empty [pause] recent_restart_window_sec"
+    field_defaults.recent_restart_window_sec
+    cfg.pause_threshold.recent_restart_window_sec
+;;
+
+(* ── 2. Complete [[pause]] section ───────────────────────────── *)
+
+let test_complete_pause_section_applies_all_fields () =
+  let cfg =
+    parse_string_or_fail
+      "[pause]\n\
+       turn_fail_streak_threshold = 7\n\
+       recent_restart_window_sec = 600.5\n\
+       recent_restart_count_threshold = 4\n\
+       tool_failure_count_threshold = 11\n\
+       tool_failure_ratio_threshold = 0.42\n"
+  in
+  let pt = cfg.pause_threshold in
+  check int "turn_fail_streak_threshold" 7 pt.turn_fail_streak_threshold;
+  check (float 0.0001) "recent_restart_window_sec" 600.5 pt.recent_restart_window_sec;
+  check int "recent_restart_count_threshold" 4 pt.recent_restart_count_threshold;
+  check int "tool_failure_count_threshold" 11 pt.tool_failure_count_threshold;
+  check (float 0.0001) "tool_failure_ratio_threshold" 0.42 pt.tool_failure_ratio_threshold
+;;
+
+(* ── 3. Partial [[pause]] section ────────────────────────────── *)
+
+let test_partial_pause_section_falls_back_field_by_field () =
+  let cfg =
+    parse_string_or_fail
+      "[pause]\n\
+       turn_fail_streak_threshold = 9\n"
+  in
+  let pt = cfg.pause_threshold in
+  check int "supplied turn_fail_streak_threshold" 9 pt.turn_fail_streak_threshold;
+  check (float 0.0001)
+    "missing recent_restart_window_sec → default"
+    field_defaults.recent_restart_window_sec
+    pt.recent_restart_window_sec;
+  check int
+    "missing recent_restart_count_threshold → default"
+    field_defaults.recent_restart_count_threshold
+    pt.recent_restart_count_threshold;
+  check int
+    "missing tool_failure_count_threshold → default"
+    field_defaults.tool_failure_count_threshold
+    pt.tool_failure_count_threshold;
+  check (float 0.0001)
+    "missing tool_failure_ratio_threshold → default"
+    field_defaults.tool_failure_ratio_threshold
+    pt.tool_failure_ratio_threshold
+;;
+
+(* ── 4. Wrong-typed value falls back to default ──────────────── *)
+
+let test_wrong_type_int_field_falls_back_to_default () =
+  (* A string value in an integer-typed field must NOT be coerced, must
+     NOT abort the parse, and must NOT bleed into other fields. The
+     supplier (Runtime_toml.parse_pause_threshold) emits a Log.Runtime.warn
+     line, then falls back to the default for that field only. *)
+  let cfg =
+    parse_string_or_fail
+      "[pause]\n\
+       turn_fail_streak_threshold = \"definitely_not_an_int\"\n\
+       recent_restart_window_sec = 600.5\n\
+       recent_restart_count_threshold = 4\n"
+  in
+  let pt = cfg.pause_threshold in
+  check int
+    "wrong-typed turn_fail_streak_threshold → default"
+    field_defaults.turn_fail_streak_threshold
+    pt.turn_fail_streak_threshold;
+  check (float 0.0001)
+    "neighbor recent_restart_window_sec still parsed"
+    600.5
+    pt.recent_restart_window_sec;
+  check int
+    "neighbor recent_restart_count_threshold still parsed"
+    4
+    pt.recent_restart_count_threshold
+;;
+
+let test_wrong_type_float_field_falls_back_to_default () =
+  let cfg =
+    parse_string_or_fail
+      "[pause]\n\
+       recent_restart_window_sec = \"600_seconds\"\n\
+       tool_failure_ratio_threshold = 0.42\n"
+  in
+  let pt = cfg.pause_threshold in
+  check (float 0.0001)
+    "wrong-typed recent_restart_window_sec → default"
+    field_defaults.recent_restart_window_sec
+    pt.recent_restart_window_sec;
+  check (float 0.0001)
+    "neighbor tool_failure_ratio_threshold still parsed"
+    0.42
+    pt.tool_failure_ratio_threshold
+;;
+
+(* ── 5. Round-trip stability ────────────────────────────────── *)
+
+let test_pause_threshold_values_are_byte_stable_across_parses () =
+  (* Two parses of the same TOML must yield structurally equal
+     [pause_threshold] records. This guards against parser-local mutable
+     state leaking across calls (the parser is supposed to be pure). *)
+  let toml =
+    "[pause]\n\
+     turn_fail_streak_threshold = 7\n\
+     recent_restart_window_sec = 600.5\n\
+     recent_restart_count_threshold = 4\n\
+     tool_failure_count_threshold = 11\n\
+     tool_failure_ratio_threshold = 0.42\n"
+  in
+  let cfg1 = parse_string_or_fail toml in
+  let cfg2 = parse_string_or_fail toml in
+  check bool
+    "pause_threshold structurally equal across parses"
+    true
+    (Schema.equal_pause_threshold cfg1.pause_threshold cfg2.pause_threshold)
+;;
+
+let test_pause_threshold_default_is_byte_stable () =
+  (* Defensive: the field defaults the parser falls back to must not
+     drift silently. If a future PR edits
+     [Runtime_schema.pause_threshold_default], the keeper behavioral
+     regime's in-code fallback (keeper_behavioral_regime.ml:52-56) must
+     change in lockstep — this test is the tripwire. *)
+  check int
+    "default turn_fail_streak_threshold = 3"
+    3
+    Schema.pause_threshold_default.turn_fail_streak_threshold;
+  check (float 0.0001)
+    "default recent_restart_window_sec = 300"
+    300.0
+    Schema.pause_threshold_default.recent_restart_window_sec;
+  check int
+    "default recent_restart_count_threshold = 2"
+    2
+    Schema.pause_threshold_default.recent_restart_count_threshold;
+  check int
+    "default tool_failure_count_threshold = 3"
+    3
+    Schema.pause_threshold_default.tool_failure_count_threshold;
+  check (float 0.0001)
+    "default tool_failure_ratio_threshold = 0.7"
+    0.7
+    Schema.pause_threshold_default.tool_failure_ratio_threshold
+;;
+
+let () =
+  run "runtime_pause_threshold_toml"
+    [ ( "missing-section fallback"
+      , [ test_case "missing [pause] section uses defaults" `Quick
+            test_missing_pause_section_uses_defaults
+        ; test_case "empty [pause] table uses defaults" `Quick
+            test_empty_pause_section_uses_defaults
+        ] )
+    ; ( "complete-section round-trip"
+      , [ test_case "complete [pause] applies all fields verbatim" `Quick
+            test_complete_pause_section_applies_all_fields
+        ] )
+    ; ( "partial-section fallback"
+      , [ test_case "partial [pause] falls back field-by-field" `Quick
+            test_partial_pause_section_falls_back_field_by_field
+        ] )
+    ; ( "wrong-typed value fails closed"
+      , [ test_case "wrong-typed int field falls back to default" `Quick
+            test_wrong_type_int_field_falls_back_to_default
+        ; test_case "wrong-typed float field falls back to default" `Quick
+            test_wrong_type_float_field_falls_back_to_default
+        ] )
+    ; ( "stability"
+      , [ test_case "pause_threshold byte-stable across parses" `Quick
+            test_pause_threshold_values_are_byte_stable_across_parses
+        ; test_case "pause_threshold_default field values pinned" `Quick
+            test_pause_threshold_default_is_byte_stable
+        ] )
+    ]
+;;

--- a/test/test_runtime_provider_auth_headers.ml
+++ b/test/test_runtime_provider_auth_headers.ml
@@ -539,6 +539,7 @@ let test_runtime_adapter_keeps_auth_out_of_headers () =
     ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
     ; media_failover = []
+    ; pause_threshold = Runtime_schema.pause_threshold_default
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -571,6 +572,7 @@ let test_runtime_adapter_filters_toml_auth_headers () =
     ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
     ; media_failover = []
+    ; pause_threshold = Runtime_schema.pause_threshold_default
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -604,6 +606,7 @@ let provider_cfg () =
     ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
     ; media_failover = []
+    ; pause_threshold = Runtime_schema.pause_threshold_default
     }
   in
   match Runtime_adapter.binding_to_provider_config cfg runpod_binding with
@@ -682,6 +685,7 @@ let runtime_or_fail ?(provider = runpod_provider) () =
     ; cross_verifier_runtime_id = None
     ; keeper_assignments = []
     ; media_failover = []
+    ; pause_threshold = Runtime_schema.pause_threshold_default
     }
   in
   match Runtime.of_binding cfg runpod_binding with


### PR DESCRIPTION
# MASC Keeper — Typed Reason Pass-Through + Pause/Resume Correctness

> Draft PR — best-programmer self-review pending before Ready 전환.

## Context (왜 이 작업인가)

`~/me/.masc` runtime 에서 keeper 가 다음 4가지 증상을 보였다:

1. `completion_contract_unsatisfied` 가 반복 발행되어 auto-pause
2. `turn_budget_exhausted` 가 같은 자리에서 반복 발생 (사용자: "이런 개념이 없어져야")
3. Keeper auto-pause 후 Play/재개를 눌러도 다시 일시정지
4. Dashboard 가 최신 상태를 늦게 반영

근본 원인은 5개 영역에 걸쳐 있었다:

| 가설 | 진단 | 영향 |
|------|------|------|
| A | `keeper_turn_disposition.mli` 가 `Completion_contract_unsatisfied` 를 prose 로 인용하지만 `.ml` 은 constructor 미정의 | 모든 typed contract 이벤트가 wire string → typed `Unknown` 으로 강등 |
| B | `clear_for_operator_resume` 가 no_progress latch 만 reset, completion-contract latch 는 미reset | resume 후 다음 cycle 에서 같은 에러가 즉시 재발 |
| C | "turn_budget_exhausted" 가 단일 string 으로 emit 되어 dimension/source 가 불명 | dashboard 가 어느 budget 이 exhausted 인지 표시 불가 |
| D | Resume 시 `execution:default:light` 단일 키만 invalidate, parameterized / shell surface 캐시는 TTL 동안 stale | dashboard 가 pause/resume 상태를 늦게 반영 |
| E | Keeper pause threshold 5개가 `keeper_behavioral_regime.ml` 에 hardcoded | runtime 환경에서 조정 불가, 코드 수정 필요 |

## Architecture (Typed Reason Pass-Through SSOT)

**두 개의 typed SSOT 도입**:

- `Keeper_latched_reason.t` (신규) — keeper latch 의 typed 원인. Producer/Consumer 모두 exhaustive match.
- `Keeper_turn_disposition.t` 확장 — RFC-0047 PR-2 의 누락 constructor (`Completion_contract_unsatisfied`, `_no_progress`, `Turn_budget_exhausted`) 추가.

Producer 변경:
- `keeper_turn_terminal.ml` 의 dead code (`contract_code_from_error_text`) 삭제, `of_failure` 의 catch-all 을 exhaustive match 로 확장.
- `keeper_unified_metrics_decision.ml` 의 substring "turn_budget_exhausted(...)" 4+ 곳을 typed `Turn_budget_exhausted { dimension; used; limit; source }` 로 교체.

Consumer 변경:
- `server_dashboard_http_composite_claims.ml` 의 `string_has_prefix ~prefix:"turn_budget_exhausted"` → typed `execution.terminal_reason_disposition` exhaustive match.
- `keeper_runtime_trust_snapshot.ml` 의 substring → typed 직접 construction.
- `keeper_terminal_reason.ml` 의 `String.starts_with` prefix 매칭 → typed `Keeper_latched_reason.t` 직접 construction.

Resume path 통합 (behavior 변경 없이 typed 일관성만):
- `keeper_unified_turn_completion_contract.ml` 신규 — `clear_for_operator_resume` 헬퍼 추가.
- `keeper_keepalive.ml`, `keeper_supervisor_resume_reconcile_gate.ml` 에서 호출 추가 — resume 시 no-progress + completion-contract 양쪽 latch 모두 reset.

Dashboard cache invalidation 통합:
- `server_dashboard_http_keeper_api_lifecycle_post.ml` 의 single-key invalidate 를 `Dashboard_cache.invalidate_prefix "execution:"` + shell surface cache prefix 로 확장.
- 파라미터화된 `execution:{actor}:{fixture}:{light|full}` 키, per-keeper shell surface 가 즉시 무효화.

Magic number → runtime.toml SSOT:
- `keeper_behavioral_regime.ml:46-50` 의 5개 threshold 를 `config/runtime.toml [pause]` 섹션 + `Runtime_schema.pause_threshold` record 로 hoist.
- Phase 1 은 SSOT 위치만 선언 (default 값은 legacy 와 byte-identical). Caller 마이그레이션은 Phase 2 별도 PR.

## Commits (5-commit 분할)

1. `feat(keeper): add Keeper_latched_reason.t typed SSOT` (`a72fa86cf65`)
2. `fix(keeper): add Completion_contract_* constructors to disposition (RFC-0047 PR-2)` (`99e496c4081`)
3. `refactor(keeper): substring classifiers -> typed producers (anti-pattern #2)` (`4f57e103d9f`)
4. `feat(keeper): clear completion-contract latch on resume + full dashboard cache invalidation` (`ea4bf7897ba`)
5. `feat(config): runtime.toml [pause] section + magic numbers SSOT` (`7ecf49d7540`)

## Scope

| 파일 | 변경 |
|------|------|
| `lib/keeper_runtime/keeper_latched_reason.ml` / `.mli` | new SSOT |
| `lib/keeper_runtime/dune` | new lib 등록 |
| `lib/keeper/keeper_turn_disposition.ml` / `.mli` | 3개 constructor 추가 + `of_wire` typed parser |
| `lib/keeper/keeper_turn_terminal.ml` | dead code 삭제 + exhaustive match |
| `lib/keeper/keeper_runtime_trust_snapshot.ml` | substring → typed |
| `lib/keeper/keeper_unified_metrics_decision.ml` | typed `Turn_budget_exhausted` emit |
| `lib/keeper/keeper_unified_turn_completion_contract.ml` / `.mli` | new parallel to `_no_progress` |
| `lib/keeper/keeper_keepalive.ml` | resume latch chain 에 `_completion_contract` 추가 |
| `lib/keeper/keeper_supervisor_resume_reconcile_gate.ml` | resume path 에 `_completion_contract` reset 추가 |
| `lib/keeper/keeper_behavioral_regime.ml` | SSOT source 코멘트 (Phase 2 deferral) |
| `lib/runtime/runtime_schema.ml` | `pause_threshold` record + default |
| `lib/runtime/runtime_toml.ml` | `parse_pause_threshold` fail-soft 파서 |
| `config/runtime.toml` | `[pause]` 섹션 추가 |
| `lib/server/server_dashboard_http_composite_claims.ml` | substring → typed exhaustive |
| `lib/server/server_dashboard_http_keeper_api_lifecycle_post.ml` | full cache invalidation |

총 18 파일 / +1187 / -65.

## 검증 (Verification)

### 1. CI 빌드 확인 (로컬 X)

```bash
gh pr checks <PR_NUMBER> --watch
```

### 2. typed exhaustiveness 강제

```bash
opam exec -- dune build @runtest
opam exec -- dune build @check
```

새 constructor 추가 시 모든 pattern match 가 exhaustive 인지 컴파일러가 강제.

### 3. Magic number 검사

```bash
rg "let\s+\w+\s*=\s*[0-9]+\s*$" lib/keeper/keeper_behavioral_regime.ml
# 기대값: 0 (SSOT 위치로 이동)
```

### 4. substring classifier 검사

```bash
rg "string_has_prefix|String\.starts_with.*prefix" lib/server/server_dashboard_http_composite_claims.ml
# 기대값: 0 (typed exhaustive match 로 교체)
```

### 5. RFC 게이트

본 PR 은 credential / identity / operator / sandbox / hooks / workflow 영역을 **건드리지 않음**. `pr-rfc-check.sh` PASS 예상.

### 6. Workaround Signature Gate

본 PR 의 시그니처:

- **시그니처 #2 (substring classifier)**: 제거 방향 (4+ 곳의 substring → typed). 누적 방지. ✅ PASS.
- **시그니처 #1 (telemetry-as-fix)**, **#3 (N-of-M patch)**: 미해당.
- **catch-all `_ ->`**: `keeper_turn_terminal.ml` 에서 `_ ->` catch-all 을 exhaustive match 로 교체. ✅ PASS (제거).
- **WORKAROUND-WAIVED**: false positive 없음. 라인 불필요.

## Risks & Mitigations

| Risk | Severity | Mitigation |
|------|----------|-----------|
| typed migration 의 exhaustive match 가 catch-all `_ ->` 가진 모든 곳을 컴파일 에러로 막아 PR 이 커질 수 있음 | High | 5 commit 으로 분할 (위 표 참조) |
| Phase 1 SSOT 가 caller migration 없이 default 만 노출 | Low | default 가 legacy 와 byte-identical. 동작 변경 없음. Phase 2 caller PR 에서 명시적 룩업으로 전환 |
| `clear_completion_contract_for_operator_resume` 가 다른 resume path 를 깨뜨릴 수 있음 | Medium | 기존 `clear_no_progress_loop` chain 과 같은 위치 + 같은 호출자 (`keeper_keepalive`, `supervisor_resume_reconcile_gate`) |
| Dashboard cache invalidate prefix 가 의도하지 않은 키를 무효화 | Low | "execution:" prefix 는 dashboard surface cache 전용. 다른 surface 와 충돌 없음 (shell surface 는 별도 prefix 함수) |

## Out of Scope

- Dashboard React 컴포넌트 typed schema 적용 (별도 PR)
- Provider failover 알고리즘 변경 (같은 PR 위험)
- Keeper autonomous loop 전체 redesign (별도 RFC)
- `/tmp/masc-host-pressure.state` 하드코딩 path (별도 P1 PR)
- Stdlib.Mutex → Eio.Mutex 전수 마이그레이션 (별도 P2 PR)
- `keeper_unified_turn_completion_contract.ml` 외 `_unified_` prefix 분리 (별도 PR — module 구조 변경)

## RFC-WAIVED

해당 없음 — 본 PR 은 credential / identity / operator / sandbox / hooks / workflow 영역 미접촉.

## Workaround Signature Gate

해당 없음 — 본 PR 은 시그니처 3종 모두 **제거 방향** (substring classifier → typed, catch-all → exhaustive). false positive 없음.

## Done Criteria

- [x] 5 commit 분할 완료
- [ ] Best Programmer self-review (in progress)
- [ ] `gh pr create --draft` 완료
- [ ] CI 필수 체크 green
- [ ] 코멘트 대응 완료
- [ ] `gh pr ready` 전환

Co-Authored-By: Claude <noreply@anthropic.com>
