### PR TITLE
fix(dashboard): count Draining-phase keepers under pausedKeepers (iter-6 count/rail reconciliation)

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -579,6 +579,60 @@ describe('countRuntimeKinds', () => {
     })
   })
 
+  it('counts Draining-phase keepers under pausedKeepers (band SSOT, not isKeeperPaused)', () => {
+    // RFC-0295 §5.3 (iter-6): The Draining phase routes to the `paused` band
+    // in `keeperBand()` and the rail paint, filter chip, and count chip must
+    // all derive from the same `band` SSOT. `isKeeperPaused()` is the
+    // action-layer predicate (operator-pause vs. operator-stop) and does
+    // NOT include Draining — so a Draining keeper is `isKeeperPaused =
+    // false` but `band === 'paused'`. The count must follow the band.
+    const result = countRuntimeKinds(
+      [],
+      [
+        {
+          name: 'runner',
+          status: 'active',
+          phase: 'Running',
+          pipeline_stage: 'idle',
+          keepalive_running: true,
+        } as Keeper,
+        {
+          name: 'drain',
+          // Crucially NO `paused: true` flag, NO `phase: 'Paused'`, NO
+          // `pipeline_stage: 'paused'` — Draining is operator-initiated
+          // stop, not pause.
+          status: 'busy',
+          phase: 'Draining',
+          pipeline_stage: 'draining',
+          keepalive_running: true,
+        } as Keeper,
+        {
+          name: 'rester',
+          status: 'paused',
+          phase: 'Paused',
+          pipeline_stage: 'paused',
+          paused: true,
+          keepalive_running: false,
+        } as Keeper,
+      ],
+    )
+
+    // Drain band = paused → counted under pausedKeepers.
+    // Rester band = paused → counted under pausedKeepers.
+    // Runner band = active → counted under keepers (runningKeepers).
+    // No transient (Draining is not in TRANSIENT_KEEPER_PHASES after iter-5).
+    // No offline.
+    expect(result).toEqual({
+      agents: 0,
+      keepers: 1,
+      pausedKeepers: 2,
+      transientKeepers: 0,
+      offlineKeepers: 0,
+      keeperRows: 3,
+      totalRuntimes: 3,
+    })
+  })
+
   it('uses composite snapshots when counting transient keeper rows', () => {
     const composite = makeCompositeSnapshot({
       keeper: 'compact',

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -705,9 +705,18 @@ export function countRuntimeKinds(
   // RFC-0295: transient band rows (Compacting / HandingOff / Restarting)
   // are now part of the breakdown. Exposed so consumers can reconcile
   // `keepers + pausedKeepers + transientKeepers + offlineKeepers` against
-  // `keeperRows` without guessing where the missing rows went. Draining is
-  // NOT counted here — it routes to the `paused` band (RFC-0295 §5.3),
-  // matching the prototype's `warn`/`pause` pairing in `data.jsx`.
+  // `keeperRows` without guessing where the missing rows went.
+  // RFC-0295 §5.3 (pixel-perfect Fleet tone rail, iter-6): Draining is
+  // counted under `pausedKeepers` here, NOT under `transientKeepers`.
+  // The Draining phase routes to the `paused` band in `keeperBand()`
+  // (`monitoring-runtime.ts`), and the rail paint, filter chip, and
+  // count chip are all derived from the same `band` SSOT — so the
+  // count must follow the band, not the raw `isKeeperPaused` predicate.
+  // `isKeeperPaused` is the *action*-layer predicate (it does not
+  // include operator-initiated Draining), while `band === 'paused'` is
+  // the *presentation*-layer predicate (it does, by design). The two
+  // remain deliberately orthogonal; this count is a presentation
+  // surface, so it follows the band.
   transientKeepers: number
   offlineKeepers: number
   keeperRows: number
@@ -717,10 +726,12 @@ export function countRuntimeKinds(
   const rosterAgents = buildAgentRoster(agentList, runtimeKeepers)
   const keeperLookup = buildKeeperRuntimeLookup(runtimeKeepers)
   const allKeepers = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeepers, 'keeper-only', keeperLookup)
-  // Hydrate the Keeper from the lookup before asking whether it is paused.
-  // Agent rows only carry `keeper_id`/`keeper_name`, not the full Keeper, so
-  // `a.keeper` was undefined here and `isKeeperPaused(undefined)` silently
-  // returned false, leaving the paused count stuck at 0.
+  // Drive the count from the same `band` SSOT that drives the rail paint
+  // (`runtimeBandMetaForAgent`) and the filter chip (`countAgentsByStatus`).
+  // Before iter-6 the `pausedKeepers` count used `isKeeperPaused(keeper)`
+  // while the rail/filter used `band === 'paused'`; the two diverged on
+  // Draining-phase keepers (rail+chip=2, count=1). Routing through `band`
+  // closes the gap so the chip count and the rail paint always agree.
   let pausedKeepers = 0
   let runningKeepers = 0
   let transientKeepers = 0
@@ -730,7 +741,7 @@ export function countRuntimeKinds(
     const band = keeper ? runtimeBandMetaForAgent(row, keeper, composite).key : null
     if (band === 'transient') {
       transientKeepers += 1
-    } else if (keeper && isKeeperPaused(keeper)) {
+    } else if (band === 'paused') {
       pausedKeepers += 1
     } else if (keeperRowLooksRunning(keeper)) {
       runningKeepers += 1
@@ -785,8 +796,11 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   // Derive runtime kind counts from memoized roster (avoids duplicate buildAgentRoster call)
   const liveRuntimeCounts = useMemo(() => {
     const allKeepers = scopeAgentsByKeeperFilter(rosterAgents, runtimeKeeperList, 'keeper-only', keeperRuntimeLookup)
-    // See countRuntimeKinds(): Agent rows expose only keeper identifiers, so
-    // `a.keeper` is undefined and isKeeperPaused needs the hydrated Keeper.
+    // Count via the same `band` SSOT that the rail paint and filter chip
+    // use. RFC-0295 §5.3 + iter-6 reconciliation: `Draining` phase
+    // contributes to `pausedCount` because `keeperBand()` routes it to
+    // the `paused` band. The duplicated count block in `countRuntimeKinds`
+    // carries the same logic; keep them structurally aligned.
     let pausedCount = 0
     let runningCount = 0
     let transientCount = 0
@@ -797,7 +811,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         : null
       if (band === 'transient') {
         transientCount += 1
-      } else if (keeper && isKeeperPaused(keeper)) {
+      } else if (band === 'paused') {
         pausedCount += 1
       } else if (keeperRowLooksRunning(keeper)) {
         runningCount += 1


### PR DESCRIPTION
## Context

iter-5 PR #22541 MERGED 2026-06-28 — Draining phase routes to the `paused` band in `keeperBand()` so the rail paint (warn), filter chip (일시정지), and band label all agree on the prototype `data.jsx:37,49` `warn`/`pause` pairing.

But iter-5 left a *count* surface that still used the action-layer `isKeeperPaused(keeper)` predicate, which deliberately does NOT include Draining (operator-initiated stop, not operator-pause — see `keeper-predicates.ts:47-55`).

Drift symptom (rail-paint test in `agent-roster.test.ts`, 7 keepers incl. `drain`):

| Surface | drain | Value |
|---|---|---|
| Rail tone (`runtimeBandMetaForAgent` → `band.key`) | `paused` | warn ✓ |
| Filter chip (`countAgentsByStatus` → `counts[band]`) | `paused` | 2 ✓ |
| **Runtime count** (`countRuntimeKinds` via `isKeeperPaused`) | `false` | **1** ✗ |
| **Live count** (`liveRuntimeCounts` useMemo via `isKeeperPaused`) | `false` | **1** ✗ |

Direct-confirmed via isolated `countRuntimeKinds([], testKeepers, null)`:
```
{ agents: 0, keepers: 2, pausedKeepers: 1, transientKeepers: 3, offlineKeepers: 1, keeperRows: 7 }
```
vs rendered `일시정지 2 / 전이 3 / 오프라인 1` from `countAgentsByStatus` (same 7 keepers). Operator-visible chip disagreement.

## Design choice: count via `band === 'paused'`, NOT `isKeeperPaused`

`isKeeperPaused` and `band === 'paused'` are deliberately orthogonal:

| Predicate | Layer | Includes Draining? | Used by |
|---|---|---|---|
| `isKeeperPaused(keeper)` | Action (canPause/canResume/operator-targetable) | No | `keeper-action-panel.ts`, `isKeeperOperatorTargetable` |
| `keeperBand().key === 'paused'` | Presentation (rail/filter/count chip) | Yes | `runtimeBandMetaForAgent`, `countAgentsByStatus` |

After iter-5 the rail/filter chip already routes through `band`. The fix is to align the count chip with the same SSOT: `band === 'paused'` instead of `isKeeperPaused(keeper)`. The two predicates stay orthogonal; only the count surface (a presentation surface) follows the band.

## Files

- `dashboard/src/components/agent-roster.ts` —
  - `countRuntimeKinds()` (line 692): replace `isKeeperPaused` check with `band === 'paused'`. Update RFC-0295 §5.3 docblock.
  - `liveRuntimeCounts` `useMemo` (line 786): identical change, structurally aligned with `countRuntimeKinds`.
- `dashboard/src/components/agent-roster.test.ts` —
  - New regression test: 3 keepers (runner + drain + rester) → `pausedKeepers: 2`. Locks in the band-vs-predicate distinction.

## Verification

- `tsc --noEmit`: clean
- `eslint src/components/agent-roster.{ts,test.ts}`: 0 errors
- `vitest` iter-6 touched: 110/110 PASS
- `vitest` full dashboard suite: 8166/8166 PASS
- Rail-paint test already asserts `일시정지 2` (drain + rester) via the new path through the live component render.
- New direct-call test asserts `countRuntimeKinds` returns `pausedKeepers: 2` for the same 3 keepers.

## iter-7 candidate

`rawPausedKeepers = keeperList.filter(isKeeperPaused).length` (line 958) still uses `isKeeperPaused`. After iter-6, `livePausedKeepers = 2` (drain + rester) but `rawPausedKeepers = 1` (rester only). Defer to iter-7.

## Cross-PR collision check

- Open PRs touching `dashboard/`: none at iter-6 push time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
