### PR TITLE
[codex] fix build path API visibility

### DIFF
--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -57,10 +57,6 @@ val current_working_dir : unit -> string
 (** Current working directory, falling back to an absolute host root when the
     process cwd has been deleted. *)
 
-val absolute_path : string -> string
-(** [absolute_path path] resolves a relative [path] against
-    {!current_working_dir}; absolute paths are returned unchanged. *)
-
 val base_path_or_cwd : unit -> string
 (** [MASC_BASE_PATH] from host config, or {!current_working_dir} when unset. *)
 

--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -57,6 +57,10 @@ val current_working_dir : unit -> string
 (** Current working directory, falling back to an absolute host root when the
     process cwd has been deleted. *)
 
+val absolute_path : string -> string
+(** [absolute_path path] resolves a relative [path] against
+    {!current_working_dir}; absolute paths are returned unchanged. *)
+
 val base_path_or_cwd : unit -> string
 (** [MASC_BASE_PATH] from host config, or {!current_working_dir} when unset. *)
 

--- a/lib/keeper/keeper_sandbox_runtime.mli
+++ b/lib/keeper/keeper_sandbox_runtime.mli
@@ -114,15 +114,14 @@ val sandbox_turn_id_label_key : string
 (** Value of {!sandbox_component_label_key} ([= "keeper-sandbox"]). *)
 val sandbox_component_label_value : string
 
-(** [base_path_hash base_path] = the {!sandbox_base_path_hash_label_key}
-    label value: hex MD5 of the normalised base path. Pure. *)
-val normalize_base_path_for_hash : string -> string
-val base_path_hash : string -> string
-
 (** [normalize_base_path_for_hash base_path] resolves relative base paths
     against the current working directory before hashing. Pure apart from
     [Sys.getcwd] for relative inputs. *)
 val normalize_base_path_for_hash : string -> string
+
+(** [base_path_hash base_path] = the {!sandbox_base_path_hash_label_key}
+    label value: hex MD5 of the normalised base path. Pure. *)
+val base_path_hash : string -> string
 
 (** [sanitize_label_value v] maps any character outside
     [[A-Za-z0-9_.-]] to ['_']. Pure. *)

--- a/test/test_keeper_sandbox_read_backend.ml
+++ b/test/test_keeper_sandbox_read_backend.ml
@@ -952,9 +952,14 @@ let test_base_path_hash_relative_input_anchors_to_cwd_not_env_base () =
     ~finally:(fun () -> Sys.chdir saved_cwd)
     (fun () ->
        Sys.chdir cwd;
+       let expected =
+         Filename.concat
+           (Config_dir_resolver.current_working_dir ())
+           "relative-base"
+       in
        Alcotest.(check string)
          "relative base hash anchor"
-         (Filename.concat (Unix.realpath cwd) "relative-base")
+         expected
          (Keeper_sandbox_runtime.normalize_base_path_for_hash "relative-base"))
 
 let test_sandbox_container_label_args_include_managed_ttl () =


### PR DESCRIPTION
## Summary

Fixes the local build break caused by public interface drift around path helper APIs.

- Exposes `Config_dir_resolver.absolute_path` because `server_routes_http_sidecar_paths` calls it through the module interface.
- Normalizes the duplicated `Keeper_sandbox_runtime.normalize_base_path_for_hash` interface declaration on current `main` so the public contract is documented once and `base_path_hash` remains documented separately.
- Makes the relative base-path hash test compare against `Config_dir_resolver.current_working_dir ()`, avoiding macOS `/var` vs `/private/var` canonicalization drift.

## Root Cause

The `Config_dir_resolver.absolute_path` implementation existed, but the `.mli` hid it from callers. During rebase, current `main` already exposed `normalize_base_path_for_hash`, but with a duplicated declaration around `base_path_hash`; this PR keeps one public declaration and preserves the hash API docs.

## Validation

Before rebasing onto latest `origin/main`:

- `scripts/dune-local.sh build lib/config_dir_resolver lib/keeper lib/server test/test_keeper_tool_policy_paths.exe test/test_keeper_sandbox_read_backend.exe`
- `_build/default/test/test_keeper_tool_policy_paths.exe`
- `_build/default/test/test_keeper_sandbox_read_backend.exe`

After rebasing onto latest `origin/main`, the same focused wrapper build was attempted, but `scripts/dune-local.sh` refused to start because unrelated bare Dune processes were active outside the wrapper (`dune build bin/env_knob_catalog.exe`). CI should be treated as the post-rebase build authority for this draft.
