### PR TITLE
fix(ci): restore SSE reconnect and shared test contracts

### DIFF
--- a/lib/dashboard/dashboard_surface_readiness.ml
+++ b/lib/dashboard/dashboard_surface_readiness.ml
@@ -219,6 +219,28 @@ let all_entries =
       ~tool_name:"masc_operator_snapshot"
       ()
   ; entry
+      ~id:"monitoring.journey"
+      ~label:"Journey Map"
+      ~exposure_status:"diagnostic"
+      ~hidden_from_nav:true
+      ~meets_main_gate:false
+      ~rationale:"Execution-flow drill-down reachable from monitoring diagnostics."
+      ~route_hash:"#monitoring?section=journey"
+      ~live_spotcheck:"/api/v1/dashboard/journey"
+      ~tool_name:"masc_operator_snapshot"
+      ()
+  ; entry
+      ~id:"monitoring.cognition"
+      ~label:"Keeper Cognition"
+      ~exposure_status:"diagnostic"
+      ~hidden_from_nav:true
+      ~meets_main_gate:false
+      ~rationale:"Keeper cognition and memory drill-down reachable from monitoring diagnostics."
+      ~route_hash:"#monitoring?section=cognition"
+      ~live_spotcheck:"/api/v1/dashboard/cognition"
+      ~tool_name:"masc_operator_snapshot"
+      ()
+  ; entry
       ~id:"keepers"
       ~label:"Keepers"
       ~exposure_status:"main"
@@ -269,61 +291,6 @@ let all_entries =
       ~rationale:"Panel and judge deliberation registry emitted by masc_fusion."
       ~route_hash:"#fusion"
       ~live_spotcheck:"/api/v1/dashboard/fusion-runs"
-      ()
-  ; entry
-      ~id:"keepers"
-      ~label:"Keepers"
-      ~exposure_status:"main"
-      ~hidden_from_nav:false
-      ~meets_main_gate:true
-      ~rationale:"Dedicated keeper roster, conversation, and context workspace."
-      ~route_hash:"#keepers"
-      ~live_spotcheck:"/api/v1/dashboard/keepers"
-      ~tool_name:"masc_keeper_list"
-      ()
-  ; entry
-      ~id:"board"
-      ~label:"Board"
-      ~exposure_status:"main"
-      ~hidden_from_nav:false
-      ~meets_main_gate:true
-      ~rationale:"Top-level board surface for human, agent, automation, and system posts."
-      ~route_hash:"#board"
-      ~live_spotcheck:"/api/v1/dashboard/board"
-      ~tool_name:"masc_board_list"
-      ()
-  ; entry
-      ~id:"schedule"
-      ~label:"Schedule"
-      ~exposure_status:"main"
-      ~hidden_from_nav:false
-      ~meets_main_gate:true
-      ~rationale:"Scheduled keeper automation and wake signals."
-      ~route_hash:"#schedule"
-      ~live_spotcheck:"/api/v1/dashboard/schedule"
-      ~tool_name:"masc_surface_audit"
-      ()
-  ; entry
-      ~id:"approvals"
-      ~label:"Approvals"
-      ~exposure_status:"main"
-      ~hidden_from_nav:false
-      ~meets_main_gate:true
-      ~rationale:"Keeper HITL approval queue and pending tool-call gates."
-      ~route_hash:"#approvals"
-      ~live_spotcheck:"/api/v1/dashboard/briefing"
-      ~tool_name:"masc_operator_snapshot"
-      ()
-  ; entry
-      ~id:"fusion"
-      ~label:"Fusion"
-      ~exposure_status:"main"
-      ~hidden_from_nav:false
-      ~meets_main_gate:true
-      ~rationale:"Panel and judge deliberations emitted by masc_fusion."
-      ~route_hash:"#fusion"
-      ~live_spotcheck:"/api/v1/dashboard/fusion"
-      ~tool_name:"masc_surface_audit"
       ()
   ; entry
       ~id:"command.operations"

--- a/lib/keeper/keeper_agent_tool_surface.ml
+++ b/lib/keeper/keeper_agent_tool_surface.ml
@@ -211,7 +211,7 @@ let tool_search_alias_entries =
   ; "tool_search_files", "코드 검색 소스코드 grep rg 패턴 찾기 파일"
   ; ( "tool_execute"
     , "명령어 실행 쉘 빌드 테스트 run dune build check compile compiles code git github gh \
-       status log diff" )
+       status log diff 깃허브 이슈 풀리퀘스트 워크트리 브랜치" )
   ; ( "keeper_memory_search"
     , "기억 검색 대화 이전 메시지 memory previous earlier user said recall deployment" )
   ; "keeper_library_search", "라이브러리 지식 문서 검색"

--- a/lib/keeper/keeper_runtime.ml
+++ b/lib/keeper/keeper_runtime.ml
@@ -337,9 +337,6 @@ let keeper_meta_persistent_drift_categories
       drift_if "tool_access" (current.tool_access <> target.tool_access);
       drift_if "instructions"
         (not (personality_text_equal current.instructions target.instructions));
-      drift_if "active_goal_ids"
-        (Option.is_some defaults.active_goal_ids
-         && current.active_goal_ids <> target.active_goal_ids);
       drift_if "oas_env" (current.oas_env <> target.oas_env);
     ]
 
@@ -351,6 +348,9 @@ let keeper_meta_overlay_drift_categories
     [
       drift_if "proactive" (current.proactive <> target.proactive);
       drift_if "tool_denylist" (current.tool_denylist <> target.tool_denylist);
+      drift_if "active_goal_ids"
+        (Option.is_some defaults.active_goal_ids
+         && current.active_goal_ids <> target.active_goal_ids);
       drift_if "goal" (not (goal_text_equal current.goal target.goal));
       drift_if "autoboot_enabled"
         (current.autoboot_enabled <> target.autoboot_enabled);

--- a/test/shell_parse_site_baseline.txt
+++ b/test/shell_parse_site_baseline.txt
@@ -2,7 +2,7 @@
 #   <relpath>:<line>  # <owner_label>
 # Refresh: MASC_SHELL_PARSE_SITE_DUMP=1 dune exec test/test_shell_parse_site_ratchet.exe
 # Labels — closed set documented in test/test_shell_parse_site_ratchet.ml
-lib/build_identity.ml:56  # argv_subsystem
+lib/build_identity.ml:57  # argv_subsystem
 lib/chronicle_ingest.ml:33  # argv_subsystem
 lib/chronicle_validate.ml:35  # argv_subsystem
 lib/dashboard/dashboard_branches.ml:232  # argv_workspace
@@ -22,11 +22,12 @@ lib/keeper/keeper_alerting.ml:383  # argv_keeper
 lib/keeper/keeper_alerting.ml:477  # argv_keeper
 lib/keeper/keeper_sandbox_control.ml:224  # argv_keeper
 lib/keeper/keeper_sandbox_control.ml:325  # argv_keeper
+lib/keeper/keeper_sandbox_control.ml:446  # argv_keeper
 lib/keeper/keeper_sandbox_docker.ml:196  # argv_keeper
 lib/keeper/keeper_sandbox_docker.ml:583  # argv_keeper
 lib/keeper/keeper_sandbox_read_backend.ml:184  # argv_keeper
 lib/keeper/keeper_sandbox_runner.ml:167  # argv_keeper
-lib/keeper/keeper_sandbox_runtime_setup.ml:49  # argv_keeper
+lib/keeper/keeper_sandbox_runtime_setup.ml:51  # argv_keeper
 lib/keeper/keeper_tools_oas_handler_exec.ml:76  # argv_keeper
 lib/keeper/keeper_turn_sandbox_runtime.ml:221  # argv_keeper
 lib/keeper/keeper_turn_sandbox_runtime.ml:560  # argv_keeper

--- a/test/test_dashboard_governance_metrics.ml
+++ b/test/test_dashboard_governance_metrics.ml
@@ -6,8 +6,9 @@ module P = Masc.Otel_metric_store
 open Alcotest
 
 let with_fresh f () =
-  GM.reset_for_testing ();
-  f ()
+  Eio_main.run (fun _env ->
+    GM.reset_for_testing ();
+    f ())
 
 let now = 1_000_000.0
 

--- a/test/test_dashboard_surface_readiness.ml
+++ b/test/test_dashboard_surface_readiness.ml
@@ -167,10 +167,16 @@ let test_live_spotcheck_keeps_script_values_as_scripts () =
            check string "live_spotcheck kind" "script"
              Yojson.Safe.Util.(ref_json |> member "kind" |> to_string))
 
-let test_redirect_only_cognition_is_not_readiness_surface () =
+let test_cognition_drilldown_is_hidden_diagnostic_surface () =
   let json = Dashboard_surface_readiness.json ~surface_id:"monitoring.cognition" () in
-  let surfaces = Yojson.Safe.Util.(json |> member "surfaces" |> to_list) in
-  check int "redirect-only surface omitted" 0 (List.length surfaces)
+  let surfaces = load_surface_contracts_from_json json in
+  match surfaces with
+  | [ surface ] ->
+      check string "surface id" "monitoring.cognition" surface.id;
+      check string "exposure_status" "diagnostic" surface.exposure_status;
+      check bool "hidden_from_nav" true surface.hidden_from_nav;
+      check bool "meets_main_gate" false surface.meets_main_gate
+  | _ -> fail "expected one cognition diagnostic surface"
 
 let test_runtime_readiness_uses_provider_read_model () =
   let json = Dashboard_surface_readiness.json ~surface_id:"monitoring.runtime" () in
@@ -290,6 +296,8 @@ let test_hidden_diagnostic_surfaces_are_not_main_gate () =
       "cockpit";
       "monitoring.transport-health";
       "monitoring.feature-health";
+      "monitoring.journey";
+      "monitoring.cognition";
       "workspace.board";
       "workspace.sub-boards";
       "workspace.moderation";
@@ -308,8 +316,8 @@ let () =
             test_live_spotcheck_serializes_route_values_as_routes;
           test_case "script live spotchecks stay scripts" `Quick
             test_live_spotcheck_keeps_script_values_as_scripts;
-          test_case "redirect-only cognition is not readiness surface" `Quick
-            test_redirect_only_cognition_is_not_readiness_surface;
+          test_case "cognition drilldown is hidden diagnostic surface" `Quick
+            test_cognition_drilldown_is_hidden_diagnostic_surface;
           test_case "runtime readiness uses provider read model" `Quick
             test_runtime_readiness_uses_provider_read_model;
           test_case "code ide readiness uses ide presence read model" `Quick

--- a/test/test_keeper_runtime_denylist.ml
+++ b/test/test_keeper_runtime_denylist.ml
@@ -164,7 +164,7 @@ tool_denylist = ["toml-tool-x", "toml-tool-y"]
         (before_overlay_drift +. 1.0)
         (overlay_drift_counter_value ~keeper:keeper_name ~field:"tool_denylist"))
 
-let test_ensure_keeper_meta_overlays_active_goal_ids_and_persists () =
+let test_ensure_keeper_meta_overlays_active_goal_ids_from_toml () =
   with_runtime_default @@ fun () ->
   with_temp_dir "keeper-runtime-active-goal-workspace" @@ fun workspace_dir ->
   with_config_dir @@ fun config_dir ->
@@ -202,6 +202,9 @@ active_goal_ids = ["goal-runtime"]
   let initial_persisted_version =
     (read_persisted_meta config keeper_name).Keeper_meta_contract.meta_version
   in
+  let before_overlay_drift =
+    overlay_drift_counter_value ~keeper:keeper_name ~field:"active_goal_ids"
+  in
   (match Keeper_runtime.ensure_keeper_meta config keeper_name with
   | Error e -> fail ("ensure_keeper_meta failed: " ^ e)
   | Ok updated ->
@@ -216,12 +219,16 @@ active_goal_ids = ["goal-runtime"]
       | Ok (Some persisted) ->
           check
             (list string)
-            "persisted meta stores TOML active_goal_ids"
-            [ "goal-runtime" ]
+            "persisted meta does not store TOML active_goal_ids"
+            []
             persisted.Keeper_meta_contract.active_goal_ids;
-          check int "TOML-owned active_goal_ids writes once"
-            (initial_persisted_version + 1)
-            persisted.Keeper_meta_contract.meta_version))
+          check int "no TOML-only active_goal_ids write bump"
+            initial_persisted_version persisted.Keeper_meta_contract.meta_version);
+      check
+        (float 0.0001)
+        "TOML-only active_goal_ids drift is observable"
+        (before_overlay_drift +. 1.0)
+        (overlay_drift_counter_value ~keeper:keeper_name ~field:"active_goal_ids"))
 
 let () =
   run "Keeper_runtime denylist resync"
@@ -233,8 +240,8 @@ let () =
             `Quick
             test_ensure_keeper_meta_overlays_denylist_from_toml;
           test_case
-            "overlays active_goal_ids from TOML and persists"
+            "overlays active_goal_ids from TOML without persisting config fields"
             `Quick
-            test_ensure_keeper_meta_overlays_active_goal_ids_and_persists;
+            test_ensure_keeper_meta_overlays_active_goal_ids_from_toml;
         ] );
     ]

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -1017,13 +1017,13 @@ let test_spawn_admission_denial_does_not_register_or_fork () =
   check (float 0.001) "keepalive denial metric increments"
     (keepalive_denials_before +. 1.0)
     (denial_count "keepalive");
-  let supervisor_denials_before = denial_count supervisor_agent_name in
+  let supervisor_denials_before = denial_count "supervisor" in
   Sup.supervise_keepalive ~proactive_warmup_sec:0 ctx meta;
   check bool "supervisor denial does not register keeper" false
     (Reg.is_registered ~base_path:config.base_path name);
   check (float 0.001) "supervisor denial metric increments"
     (supervisor_denials_before +. 1.0)
-    (denial_count supervisor_agent_name);
+    (denial_count "supervisor");
   check (float 0.001) "spawn denial does not fork heartbeat" fork_before (fork_total ())
 
 let test_active_supervision_keeper_count_uses_current_entries () =
@@ -1678,9 +1678,9 @@ let test_max_restarts_exhaustion_preserves_current_task_when_owned_task_query_fa
       in
       Reg.restore_supervisor_state ~base_path:config.base_path name
         ~restart_count:max_restarts ~last_restart_ts:0.0 ~crash_log:[];
-      let oc = open_out (Masc.Workspace.backlog_path config) in
-      output_string oc "{ not valid json";
-      close_out oc;
+      let backlog_path = Masc.Workspace.backlog_path config in
+      write_file backlog_path "{ not valid json";
+      write_file (backlog_path ^ ".last-good") "{ not valid json";
       let ctx : _ Keeper_types_profile.context =
         {
           config;

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -2467,8 +2467,8 @@ let test_health_json_redacts_registry_failure_reason () =
                 (contains_substring reason base_path);
               Alcotest.(check bool) "retains explicit redaction marker" true
                 (contains_substring reason "[REDACTED]");
-              Alcotest.(check bool) "retains workspace placeholder" true
-                (contains_substring reason "<workspace>"))))
+              Alcotest.(check bool) "retains workspace path redaction marker" true
+                (contains_substring reason "[REDACTED_PATH]"))))
 
 let test_health_json_uses_crash_log_when_restore_clears_failure_reason () =
   with_temp_dir "health-restored-crash-log-keeper" (fun dir ->

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -2,6 +2,7 @@ open Alcotest
 
 type http_result = {
   status: int option;
+  headers: (string * string) list;
   body: string;
   curl_exit: int;
   stderr: string;
@@ -83,7 +84,7 @@ let parse_headers raw =
       (status, headers)
   | Some [] -> (None, [])
 
-let run_curl ?(headers=[]) ?max_time ~port ~path () =
+let run_curl ?(headers=[]) ?max_time ?(method_="GET") ?body ~port ~path () =
   let header_file = Filename.temp_file "sse-storm-header-" ".txt" in
   let body_file = Filename.temp_file "sse-storm-body-" ".txt" in
   let url = Printf.sprintf "http://127.0.0.1:%d%s" port path in
@@ -97,20 +98,25 @@ let run_curl ?(headers=[]) ?max_time ~port ~path () =
       (fun (k, v) -> ["-H"; Printf.sprintf "%s: %s" k v])
       headers
   in
+  let body_args =
+    match body with
+    | None -> []
+    | Some body -> [ "--data-binary"; body ]
+  in
   let args =
     [|
       "curl";
       "-sS";
       "--http1.1";
       "-X";
-      "GET";
+      method_;
       "-o";
       body_file;
       "-D";
       header_file;
     |]
     |> Array.to_list
-    |> fun base -> base @ max_time_args @ header_args @ [url]
+    |> fun base -> base @ max_time_args @ header_args @ body_args @ [url]
     |> Array.of_list
   in
   let (ic, oc, ec) = Unix.open_process_args_full "curl" args (Unix.environment ()) in
@@ -127,8 +133,14 @@ let run_curl ?(headers=[]) ?max_time ~port ~path () =
   let body = read_file body_file in
   (try Sys.remove header_file with _ -> ());
   (try Sys.remove body_file with _ -> ());
-  let (status, _headers) = parse_headers header_raw in
-  { status; body; curl_exit; stderr }
+  let (status, headers) = parse_headers header_raw in
+  { status; headers; body; curl_exit; stderr }
+
+let header_value result name =
+  let name = String.lowercase_ascii name in
+  result.headers
+  |> List.find_map (fun (key, value) ->
+    if String.equal (String.lowercase_ascii key) name then Some value else None)
 
 let find_main_eio_exe () =
   let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in
@@ -240,6 +252,40 @@ let dashboard_dev_token ~port =
       fail
         (Printf.sprintf
            "dashboard dev-token missing HTTP status (curl_exit=%d stderr=%s body=%s)"
+           result.curl_exit result.stderr result.body)
+
+let initialize_mcp_session ~port ~auth_token =
+  let body =
+    {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"sse-storm-e2e","version":"1.0"},"capabilities":{}}}|}
+  in
+  let result =
+    run_curl
+      ~headers:
+        [
+          ("Content-Type", "application/json");
+          ("Accept", "application/json, text/event-stream");
+          ("Authorization", "Bearer " ^ auth_token);
+        ]
+      ~method_:"POST" ~body ~max_time:2.0 ~port ~path:"/mcp" ()
+  in
+  (match result.status with
+  | Some 200 -> ()
+  | Some code ->
+      fail
+        (Printf.sprintf
+           "initialize returned HTTP %d (curl_exit=%d stderr=%s body=%s)"
+           code result.curl_exit result.stderr result.body)
+  | None ->
+      fail
+        (Printf.sprintf
+           "initialize missing HTTP status (curl_exit=%d stderr=%s body=%s)"
+           result.curl_exit result.stderr result.body));
+  match header_value result "mcp-session-id" with
+  | Some sid when String.trim sid <> "" -> sid
+  | _ ->
+      fail
+        (Printf.sprintf
+           "initialize response missing Mcp-Session-Id (curl_exit=%d stderr=%s body=%s)"
            result.curl_exit result.stderr result.body)
 
 let merge_env_overrides overrides =
@@ -405,7 +451,7 @@ let check_status label expected result =
 
 let test_mcp_reconnect_stays_accepted () =
   with_server @@ fun ~port ~auth_token ->
-  let sid = Printf.sprintf "storm-mcp-%06d" (Random.int 1_000_000) in
+  let sid = initialize_mcp_session ~port ~auth_token in
   let headers =
     [
       ("Accept", "text/event-stream");
@@ -422,7 +468,7 @@ let test_mcp_reconnect_stays_accepted () =
 
 let test_ag_ui_rejects_reconnect_then_recovers () =
   with_server @@ fun ~port ~auth_token ->
-  let sid = Printf.sprintf "storm-agui-%06d" (Random.int 1_000_000) in
+  let sid = initialize_mcp_session ~port ~auth_token in
   (* /ag-ui/events uses the observer SSE auth path; mirror /mcp by passing the
      dashboard dev token explicitly. *)
   let headers =


### PR DESCRIPTION
## Summary
- initialize the SSE reconnect e2e path with a real MCP session before replaying `/mcp` and `/ag-ui/events`
- rescope this PR as a shared CI/test-contract repair: dashboard readiness entries and live spotcheck routes, tool search aliases, runtime `active_goal_ids` overlay semantics, redaction marker expectations, and shell parse baseline drift
- keep the unknown/stale-session behavior from #22543 intact: random client session IDs no longer imply a valid SSE session

## Scope note
This PR is no longer only `test/test_sse_storm_e2e.ml`. The later commits intentionally repair current shared CI contracts that were causing downstream draft PRs to inherit the same Build/Test failures. Review should treat it as a multi-surface CI repair rather than a narrow SSE-only PR.

## Verification
- `git diff --check origin/main...HEAD`
- GitHub CI is the build authority for this branch
- Current `Build and Test` is still running; quick-suite step has reported failure and logs will be inspected once GitHub exposes the completed job log
