### PR TITLE
perf(sse): bound replay buffer with immutable map

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -225,7 +225,7 @@ let sync_transport_snapshot ?(force = false) () =
            let by_idle = Float.compare right.idle_seconds left.idle_seconds in
            if by_idle <> 0 then by_idle
            else String.compare left.session_id right.session_id)
-    |> take 3
+    |> List.take 3
     |> List.map (fun (session : session_snapshot) ->
          {
            Transport_metrics.session_id = session.session_id;

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -60,6 +60,7 @@ let registration_error_to_string = function
 
 (** Classification of an SSE session's traffic role. *)
 module SMap = Set_util.StringMap
+module IntMap = Map.Make (Int)
 
 (* Test-only hooks for forcing a CAS retry in white-box unit tests. *)
 let register_commit_test_hook : (unit -> unit) option Atomic.t = Atomic.make None
@@ -147,8 +148,6 @@ let session_kind_to_string = function
   | Observer -> "observer"
   | Agent_stream -> "agent_stream"
   | Presence -> "presence"
-
-let take = List.take
 
 (** Minimum interval between full transport snapshot computations (seconds).
     The snapshot iterates all SSE clients and builds per-session records;
@@ -256,8 +255,9 @@ let event_counter = Atomic.make 0
 
     [event_buffer] is written by every [broadcast_impl] / [send_to] and
     drained by the periodic [cleanup_expired_events] background fiber.
-    The buffer is a newest-first persistent list behind [Atomic.t];
-    all mutations are pure list rewrites committed via CAS.
+    The buffer is an immutable [event_id -> event] map plus a linearized
+    count behind one [Atomic.t]; all mutations are pure map rewrites committed
+    via CAS.
 
     Read from [MASC_SSE_REPLAY_BUFFER_SIZE] (default 1000, clamped 50..1000).
     Sized to bound replay work for clients reconnecting with [Last-Event-Id]
@@ -272,28 +272,57 @@ let max_buffer_size =
   clamp
     (Env_config_core.get_int ~default "MASC_SSE_REPLAY_BUFFER_SIZE")
 let buffer_ttl_seconds = Env_config.InternalTimers.sse_buffer_ttl_sec
-let event_buffer : (int * string * float) list Atomic.t = Atomic.make []
+
+type buffered_event = int * string * float
+
+type event_buffer_state = {
+  events_by_id : buffered_event IntMap.t;
+  count : int;
+}
+
+let empty_event_buffer_state = { events_by_id = IntMap.empty; count = 0 }
+
+let event_buffer : event_buffer_state Atomic.t =
+  Atomic.make empty_event_buffer_state
+
+let event_buffer_state_of_events events =
+  let events_by_id =
+    List.fold_left
+      (fun acc (((event_id, _, _) as event) : buffered_event) ->
+         IntMap.add event_id event acc)
+      IntMap.empty events
+  in
+  { events_by_id; count = IntMap.cardinal events_by_id }
+
+let event_buffer_events_newest_first state =
+  state.events_by_id |> IntMap.bindings |> List.rev_map snd
+
+let event_buffer_events_for_test () =
+  Atomic.get event_buffer |> event_buffer_events_newest_first
+
+let set_event_buffer_for_test events =
+  Atomic.set event_buffer (event_buffer_state_of_events events)
+
+let rewrite_event_buffer_for_test () =
+  Lockfree_atomic.update event_buffer (fun state ->
+    { state with count = state.count })
 
 (** Add event to buffer, maintaining max size *)
 let buffer_event event_id event_str =
-  Lockfree_atomic.update_with_commit event_buffer (fun lst ->
+  Lockfree_atomic.update_with_commit event_buffer (fun state ->
     run_test_hook buffer_commit_test_hook;
     let timestamp = Time_compat.now () in
-    let next = (event_id, event_str, timestamp) :: lst in
-    (* [buffer_event] runs on the broadcast hot path. [List.take] always
-       allocates a fresh list up to [max_buffer_size], so calling it
-       unconditionally pays an O(max_buffer_size) copy on every broadcast
-       even when the buffer is well below the cap (startup, after cleanup,
-       low-traffic periods). [List.compare_length_with] only walks the list
-       and short-circuits at the threshold with no allocation, so gate the
-       [take] copy behind it and reuse the existing list on the under-cap
-       path. *)
-    let trimmed =
-      if List.compare_length_with next max_buffer_size > 0 then
-        take max_buffer_size next
-      else next
+    let event = (event_id, event_str, timestamp) in
+    let replacing = IntMap.mem event_id state.events_by_id in
+    let events_by_id = IntMap.add event_id event state.events_by_id in
+    let count = if replacing then state.count else state.count + 1 in
+    let events_by_id, count =
+      if count <= max_buffer_size then events_by_id, count
+      else
+        let oldest_id, _oldest = IntMap.min_binding events_by_id in
+        IntMap.remove oldest_id events_by_id, count - 1
     in
-    { next_state = trimmed; result = () })
+    { next_state = { events_by_id; count }; result = () })
 
 let event_matches_session_kind kind event =
   match kind with
@@ -303,19 +332,9 @@ let event_matches_session_kind kind event =
 
 (** Get events after given ID for replay (MCP spec MUST) *)
 let get_events_after last_id =
-  let lst = Atomic.get event_buffer in
-  (* [event_buffer] is newest-first (each [buffer_event] [cons]es onto
-     the head).  Folding it left-to-right and prepending every match to
-     [acc] visits newest first and pushes oldest last, so [acc] ends as
-     oldest-first directly — no surrounding [List.rev] needed.
-
-     The previous shape was [List.rev lst |> fold prepend |> List.rev],
-     which walked the buffer three times to produce the same result.
-     Each SSE replay (client reconnect with [Last-Event-Id]) saves
-     2 × O(buffer) over the old form; max_buffer_size=1000. *)
-  List.fold_left (fun acc (id, ev, _ts) ->
-    if id > last_id then ev :: acc else acc
-  ) [] lst
+  let state = Atomic.get event_buffer in
+  let _older_or_equal, _at_last_id, newer = IntMap.split last_id state.events_by_id in
+  newer |> IntMap.bindings |> List.map (fun (_id, (_event_id, ev, _ts)) -> ev)
 
 let get_events_after_for_kind kind last_id =
   get_events_after last_id
@@ -325,18 +344,19 @@ let get_events_after_for_kind kind last_id =
     Returns count of evicted events. *)
 let cleanup_expired_events () =
   let now = Time_compat.now () in
-  Lockfree_atomic.update_with_commit event_buffer (fun lst ->
-    let remaining_oldest_first, evicted =
-      List.fold_left
-        (fun (kept, evicted) (((_id, _ev, ts) as item) : int * string * float) ->
+  Lockfree_atomic.update_with_commit event_buffer (fun state ->
+    let events_by_id, evicted =
+      IntMap.fold
+        (fun id (((_event_id, _ev, ts) as item) : buffered_event) (kept, evicted) ->
           if now -. ts > buffer_ttl_seconds then
             (kept, evicted + 1)
           else
-            (item :: kept, evicted))
-        ([], 0) lst
+            (IntMap.add id item kept, evicted))
+        state.events_by_id
+        (IntMap.empty, 0)
     in
     {
-      next_state = List.rev remaining_oldest_first;
+      next_state = { events_by_id; count = IntMap.cardinal events_by_id };
       result = evicted;
     })
 

--- a/lib/sse.mli
+++ b/lib/sse.mli
@@ -149,7 +149,8 @@ val remove_external_subscribers : string list -> string list * int
 (** {1 Event Buffer} *)
 
 val clients : client_registry_state Atomic.t
-val event_buffer : (int * string * float) list Atomic.t
+type buffered_event = int * string * float
+
 val buffer_event : int -> string -> unit
 val get_events_after : int -> string list
 val get_events_after_for_kind : session_kind -> int -> string list
@@ -157,6 +158,9 @@ val get_events_after_for_kind : session_kind -> int -> string list
     replay only returns JSON-RPC messages; observer replay keeps all durable
     events; presence replay is empty. *)
 val cleanup_expired_events : unit -> int
+val event_buffer_events_for_test : unit -> buffered_event list
+val set_event_buffer_for_test : buffered_event list -> unit
+val rewrite_event_buffer_for_test : unit -> unit
 
 (** {1 Snapshots} *)
 

--- a/test/test_sse_coverage.ml
+++ b/test/test_sse_coverage.ml
@@ -271,31 +271,26 @@ let test_buffer_event_and_retrieve () =
   check bool "has event" true (List.length events >= 1)
 
 let test_buffer_event_timestamps_successful_commit_after_retry () =
-  let original_buffer = Atomic.get Sse.event_buffer in
+  let original_buffer = Sse.event_buffer_events_for_test () in
   let original_hook = Atomic.get Sse.buffer_commit_test_hook in
   let forced_retry = Atomic.make false in
   let retry_barrier = ref 0.0 in
   Fun.protect
     ~finally:(fun () ->
       Atomic.set Sse.buffer_commit_test_hook original_hook;
-      Atomic.set Sse.event_buffer original_buffer)
+      Sse.set_event_buffer_for_test original_buffer)
     (fun () ->
-      Atomic.set Sse.event_buffer [ (777_000, "marker", Unix.gettimeofday ()) ];
+      Sse.set_event_buffer_for_test [ (777_000, "marker", Unix.gettimeofday ()) ];
       Atomic.set Sse.buffer_commit_test_hook
         (Some (fun () ->
            if Atomic.compare_and_set forced_retry false true then begin
-             ignore
-               (Lockfree_atomic.update_with_commit Sse.event_buffer (fun buffer ->
-                    {
-                      next_state = List.map (fun item -> item) buffer;
-                      result = ();
-                    }));
+             Sse.rewrite_event_buffer_for_test ();
              ignore (Unix.select [] [] [] 0.02);
              retry_barrier := Unix.gettimeofday ()
            end));
       Sse.buffer_event 777_001 "fresh";
       check bool "forced retry triggered" true (Atomic.get forced_retry);
-      match Atomic.get Sse.event_buffer with
+      match Sse.event_buffer_events_for_test () with
       | (event_id, _event, ts) :: _ ->
           check int "new event inserted at head" 777_001 event_id;
           check bool "timestamp captured after retry barrier" true
@@ -304,22 +299,22 @@ let test_buffer_event_timestamps_successful_commit_after_retry () =
           fail "buffer should contain the fresh event")
 
 let test_get_events_after_filters () =
-  let original_buffer = Atomic.get Sse.event_buffer in
+  let original_buffer = Sse.event_buffer_events_for_test () in
   Fun.protect
-    ~finally:(fun () -> Atomic.set Sse.event_buffer original_buffer)
+    ~finally:(fun () -> Sse.set_event_buffer_for_test original_buffer)
     (fun () ->
-      Atomic.set Sse.event_buffer [];
+      Sse.set_event_buffer_for_test [];
       Sse.buffer_event 802_000 "event A";
       Sse.buffer_event 802_001 "event B";
       check (list string) "filtered exact replay" [ "event B" ]
         (Sse.get_events_after 802_000))
 
 let test_get_events_after_preserves_oldest_first_order () =
-  let original_buffer = Atomic.get Sse.event_buffer in
+  let original_buffer = Sse.event_buffer_events_for_test () in
   Fun.protect
-    ~finally:(fun () -> Atomic.set Sse.event_buffer original_buffer)
+    ~finally:(fun () -> Sse.set_event_buffer_for_test original_buffer)
     (fun () ->
-      Atomic.set Sse.event_buffer [];
+      Sse.set_event_buffer_for_test [];
       Sse.buffer_event 803_000 "event A";
       Sse.buffer_event 803_001 "event B";
       Sse.buffer_event 803_002 "event C";
@@ -330,16 +325,16 @@ let test_get_events_after_preserves_oldest_first_order () =
         (Sse.get_events_after 803_000))
 
 let test_buffer_event_caps_replay_buffer () =
-  let original_buffer = Atomic.get Sse.event_buffer in
+  let original_buffer = Sse.event_buffer_events_for_test () in
   Fun.protect
-    ~finally:(fun () -> Atomic.set Sse.event_buffer original_buffer)
+    ~finally:(fun () -> Sse.set_event_buffer_for_test original_buffer)
     (fun () ->
-      Atomic.set Sse.event_buffer [];
+      Sse.set_event_buffer_for_test [];
       let base = Sse.current_id () + Sse.max_buffer_size + 1 in
       for index = 0 to Sse.max_buffer_size + 4 do
         Sse.buffer_event (base + index) (Printf.sprintf "event-%d" index)
       done;
-      let buffered = Atomic.get Sse.event_buffer in
+      let buffered = Sse.event_buffer_events_for_test () in
       let expected_newest_first_indexes =
         List.init Sse.max_buffer_size (fun offset ->
           Sse.max_buffer_size + 4 - offset)
@@ -366,7 +361,7 @@ let test_get_events_after_empty () =
   check int "empty for future id" 0 (List.length events)
 
 let test_cleanup_expired_events_exact_under_domain_contention () =
-  let original_buffer = Atomic.get Sse.event_buffer in
+  let original_buffer = Sse.event_buffer_events_for_test () in
   let now = Unix.gettimeofday () in
   let expired_count = 32 in
   let expired_items =
@@ -375,15 +370,16 @@ let test_cleanup_expired_events_exact_under_domain_contention () =
        now -. Sse.buffer_ttl_seconds -. 10.0))
   in
   Fun.protect
-    ~finally:(fun () -> Atomic.set Sse.event_buffer original_buffer)
+    ~finally:(fun () -> Sse.set_event_buffer_for_test original_buffer)
     (fun () ->
-      Atomic.set Sse.event_buffer expired_items;
+      Sse.set_event_buffer_for_test expired_items;
       let total_removed = Atomic.make 0 in
       run_domains_together 2 (fun _index ->
         ignore (Atomic.fetch_and_add total_removed (Sse.cleanup_expired_events ())));
       check int "each expired event counted once" expired_count
         (Atomic.get total_removed);
-      check int "buffer emptied once" 0 (List.length (Atomic.get Sse.event_buffer)))
+      check int "buffer emptied once" 0
+        (List.length (Sse.event_buffer_events_for_test ())))
 
 (* ============================================================
    client Type Tests

--- a/test/test_sse_stream.ml
+++ b/test/test_sse_stream.ml
@@ -191,14 +191,14 @@ let test_broadcast_all_excludes_presence_sessions ~auth () =
 
 let test_broadcast_presence_is_live_only ~auth () =
   reset ();
-  let original_buffer = Atomic.get Sse.event_buffer in
+  let original_buffer = Sse.event_buffer_events_for_test () in
   Fun.protect
     ~finally:(fun () ->
-      Atomic.set Sse.event_buffer original_buffer;
+      Sse.set_event_buffer_for_test original_buffer;
       Sse.unregister "s-presence";
       Sse.unregister "s-observer")
     (fun () ->
-      Atomic.set Sse.event_buffer [];
+      Sse.set_event_buffer_for_test [];
       ignore (register_exn ~auth ~kind:Presence "s-presence" ~last_event_id:0);
       ignore (register_exn ~auth ~kind:Observer "s-observer" ~last_event_id:0);
       let before_id = Sse.current_id () in


### PR DESCRIPTION
## Summary
- Replace the SSE replay buffer's newest-first list with a single immutable IntMap+count atomic state.
- Keep replay output oldest-first via IntMap.split on Last-Event-Id.
- Replace direct test access to the buffer atomic with explicit test helpers.

## Verification
- opam exec -- ocamlformat --check lib/sse.ml lib/sse.mli test/test_sse_coverage.ml test/test_sse_stream.ml
- git diff --check

Dune/build intentionally left to CI per workflow instruction.