### PR TITLE
task-1543: harden Execute descriptor — explicitly declare filesystem access

### DIFF
--- a/lib/keeper/keeper_tool_descriptor.ml
+++ b/lib/keeper/keeper_tool_descriptor.ml
@@ -543,14 +543,16 @@ let public_descriptors =
       ~public_name:"Execute"
       ~internal_name:"tool_execute"
       ~description:
-        "Execute one typed command through deterministic execution gates. Git and \
-         GitHub CLI commands are supported through typed argv when Execute is visible \
-         and the call is scoped to an allowed repo cwd; repo-hosting mutations remain \
-         subject to Shell IR/policy and keeper-scoped credentials. Provide executable \
-         plus argv arguments after the executable, or pipeline. Do not repeat \
-         executable as argv[0]. Examples: executable='git' argv=['status', \
-         '--short']; executable='gh' argv=['pr', 'list', '--repo', 'owner/name']. \
-         Use cwd for repo-scoped operations."
+        "Execute one typed command through deterministic execution gates with \
+         sandbox/policy-scoped filesystem access for allowed read, write, and \
+         execute operations. Git and GitHub CLI commands are supported through \
+         typed argv when Execute is visible and the call is scoped to an allowed \
+         repo cwd; repo-hosting mutations remain subject to Shell IR/policy and \
+         keeper-scoped credentials. Provide executable plus argv arguments after \
+         the executable, or pipeline. Do not repeat executable as argv[0]. \
+         Examples: executable='git' argv=['status', '--short']; executable='gh' \
+         argv=['pr', 'list', '--repo', 'owner/name']. Use cwd for repo-scoped \
+         operations."
       ~input_schema:execute_schema
       ~policy:
         (policy

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -397,33 +397,7 @@ let test_read_descriptor_spells_out_path_basis () =
     (string_contains ~sub:"does not inherit Execute cwd" file_path_description)
 ;;
 
-let test_execute_descriptor_spells_out_argv_basis () =
-  let descriptor = required_public_descriptor "Execute" in
-  let argv_description =
-    schema_property_description descriptor.input_schema "argv"
-    |> Option.value ~default:""
-  in
-  Alcotest.(check bool)
-    "Execute description says argv follows executable"
-    true
-    (string_contains ~sub:"argv arguments after the executable" descriptor.description);
-  Alcotest.(check bool)
-    "Execute description forbids duplicate argv0"
-    true
-    (string_contains ~sub:"Do not repeat executable as argv[0]" descriptor.description);
-  Alcotest.(check bool)
-    "Execute description includes git example"
-    true
-    (string_contains ~sub:"executable='git' argv=['status', '--short']" descriptor.description);
-  Alcotest.(check bool)
-    "Execute argv schema repeats argv0 warning"
-    true
-    (string_contains ~sub:"Do not repeat executable as argv[0]" argv_description);
-  Alcotest.(check bool)
-    "Execute argv schema includes grep example"
-    true
-    (string_contains ~sub:"executable='grep', argv=['-rn', 'pattern', 'lib']" argv_description)
-;;
+
 
 let test_board_descriptions_disambiguate_post_id_flow () =
   let get_descriptor = required_internal_descriptor "keeper_board_post_get" in
@@ -960,10 +934,7 @@ let () =
             "Read path basis is explicit"
             `Quick
             test_read_descriptor_spells_out_path_basis
-        ; test_case
-            "Execute argv basis is explicit"
-            `Quick
-            test_execute_descriptor_spells_out_argv_basis
+
         ; test_case
             "Board get/list descriptions disambiguate post_id flow"
             `Quick

--- a/test/test_keeper_tool_descriptor_registry_integrity.ml
+++ b/test/test_keeper_tool_descriptor_registry_integrity.ml
@@ -397,7 +397,37 @@ let test_read_descriptor_spells_out_path_basis () =
     (string_contains ~sub:"does not inherit Execute cwd" file_path_description)
 ;;
 
-
+let test_execute_descriptor_spells_out_argv_and_filesystem_basis () =
+  let descriptor = required_public_descriptor "Execute" in
+  let argv_description =
+    schema_property_description descriptor.input_schema "argv"
+    |> Option.value ~default:""
+  in
+  check_contains
+    "Execute description says filesystem access is policy-scoped"
+    ~sub:"sandbox/policy-scoped filesystem access"
+    descriptor.description;
+  check_contains
+    "Execute description says argv follows executable"
+    ~sub:"argv arguments after the executable"
+    descriptor.description;
+  check_contains
+    "Execute description forbids duplicate argv0"
+    ~sub:"Do not repeat executable as argv[0]"
+    descriptor.description;
+  check_contains
+    "Execute description includes git example"
+    ~sub:"executable='git' argv=['status', '--short']"
+    descriptor.description;
+  check_contains
+    "Execute argv schema repeats argv0 warning"
+    ~sub:"Do not repeat executable as argv[0]"
+    argv_description;
+  check_contains
+    "Execute argv schema includes grep example"
+    ~sub:"executable='grep', argv=['-rn', 'pattern', 'lib']"
+    argv_description
+;;
 
 let test_board_descriptions_disambiguate_post_id_flow () =
   let get_descriptor = required_internal_descriptor "keeper_board_post_get" in
@@ -934,7 +964,10 @@ let () =
             "Read path basis is explicit"
             `Quick
             test_read_descriptor_spells_out_path_basis
-
+        ; test_case
+            "Execute argv/filesystem basis is explicit"
+            `Quick
+            test_execute_descriptor_spells_out_argv_and_filesystem_basis
         ; test_case
             "Board get/list descriptions disambiguate post_id flow"
             `Quick


### PR DESCRIPTION
Clarify the Execute tool description so keepers understand that filesystem operations are available through the sandbox and policy-scoped Execute path.

The contract is sandbox/policy-scoped access for allowed read, write, and execute operations. It does not grant unrestricted host filesystem access; Shell IR, Sandbox_process, Backend_selected, effect_domain=Playground_write, and cwd_scope=keeper_sandbox_or_allowed_path still define the boundary.

Root cause: keepers misread the tool schema and falsely conclude they lack filesystem access.

Fixes: task-1543