### PR TITLE
[codex] Disable local Dune shared cache by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ scripts/dune-local.sh build bin/main_eio.exe
 scripts/run-local.sh --target-dir "$PWD"
 ```
 
-`scripts/dune-local.sh`는 worktree 간 동시 빌드 충돌을 막기 위해 글로벌 락 파일(`/tmp/me-dune-local.lock`)을 사용한다.
+`scripts/dune-local.sh`는 worktree 간 동시 빌드 충돌을 막기 위해 글로벌 락 파일(`/tmp/me-dune-local.lock`)을 사용하고, 로컬 기본값으로 Dune shared cache를 끈다. shared opam pin이 움직인 뒤 stale native artifact가 섞이는 경우를 피하기 위한 기본값이며, 필요하면 `MASC_DUNE_CACHE=enabled`로 명시적으로 다시 켤 수 있다.
 
 ### Run modes
 

--- a/scripts/dune-local.sh
+++ b/scripts/dune-local.sh
@@ -13,12 +13,14 @@ Local Dune wrapper for multi-agent development:
   - serializes local Dune invocations with a machine-wide lock
   - serializes opam switch validation with opam pin mutations
   - defaults local concurrency to DUNE_LOCAL_JOBS, or 2
+  - disables the shared Dune artifact cache by default for local builds
   - injects --root <repo-root> unless --root is already present
   - asserts agent_sdk opam pin matches the repo SSOT before each build
   - asserts core opam dependencies are installed in the active switch
   - asserts OCaml is at or above the repo floor (5.4)
 
 Set MASC_DUNE_THROTTLE=0 to bypass the local lock.
+Set MASC_DUNE_CACHE=enabled or enabled-except-user-rules to opt into the shared Dune cache.
 Set MASC_OPAM_LOCK=0 or MASC_SKIP_OPAM_LOCK=1 to bypass the shared opam switch lock.
 Set MASC_OPAM_LOCK_PATH=/path/to/lock to override the shared opam lock path.
 Set MASC_OPAM_LOCK_AFTER_DUNE_TIMEOUT=seconds to bound opam-lock wait after the Dune lock (0 = wait forever).
@@ -376,6 +378,11 @@ fi
 if [[ "${GITHUB_ACTIONS:-}" != "true" ]]; then
   export DUNE_JOBS="${DUNE_JOBS:-${DUNE_LOCAL_JOBS:-2}}"
   export DUNE_BUILD_DIR="${DUNE_BUILD_DIR:-$repo_root/_build}"
+  # The shared Dune cache can return native artifacts compiled against an
+  # older local opam pin, which then link with fresh CMIs and fail with
+  # "make inconsistent assumptions over interface". Local wrapper builds
+  # favor deterministic rebuilds; operators can opt back in explicitly.
+  export DUNE_CACHE="${MASC_DUNE_CACHE:-disabled}"
 fi
 
 # --- stale Dune lock/RPC cleanup ----------------------------------------
@@ -689,8 +696,8 @@ if [[ "${GITHUB_ACTIONS:-}" != "true" \
 fi
 # -----------------------------------------------------------------------
 
-printf '[dune-local] DUNE_JOBS=%s DUNE_BUILD_DIR=%s\n' \
-  "${DUNE_JOBS:-auto}" "${DUNE_BUILD_DIR:-_build}" >&2
+printf '[dune-local] DUNE_JOBS=%s DUNE_BUILD_DIR=%s DUNE_CACHE=%s\n' \
+  "${DUNE_JOBS:-auto}" "${DUNE_BUILD_DIR:-_build}" "${DUNE_CACHE:-default}" >&2
 printf '[dune-local] command:' >&2
 printf ' %q' "${cmd[@]}" >&2
 printf '\n' >&2


### PR DESCRIPTION
## Summary

- Default `scripts/dune-local.sh` local builds to `DUNE_CACHE=disabled`.
- Add `MASC_DUNE_CACHE=enabled` / `enabled-except-user-rules` as an explicit opt-in for the shared Dune artifact cache.
- Document the local build wrapper behavior in `README.md`.

## Root Cause

Local `dune build .` was able to link stale native artifacts from the shared Dune cache after the shared opam `agent_sdk` pin moved. That produced mixed interface assumptions such as `Masc__Keeper_sandbox_runtime` CRC mismatches between `lib/masc.cmxa` and `lib/server/masc_server.cmxa`.

The repo wrapper already serializes local builds and checks the opam pin. This change makes the wrapper avoid the shared artifact cache by default as well, so local wrapper builds prefer deterministic rebuilds over cross-worktree cache reuse.

## Validation

- `bash -n scripts/dune-local.sh`
- `MASC_DUNE_DRY_RUN=1 scripts/dune-local.sh build .` shows `DUNE_CACHE=disabled`
- `MASC_DUNE_DRY_RUN=1 MASC_DUNE_CACHE=enabled scripts/dune-local.sh build .` shows `DUNE_CACHE=enabled`
- `scripts/check-oas-pin.sh --local-only`
- `git diff --check -- README.md scripts/dune-local.sh`

Full `dune build .` was not run for this PR because the operator said they would run the build locally.