### PR TITLE
fix(keeper): type accept rejection contract classification

### DIFF
--- a/lib/keeper/keeper_error_classify.ml
+++ b/lib/keeper/keeper_error_classify.ml
@@ -636,8 +636,25 @@ let filter_rate_limit_rotation_candidates
     or different runtime will not satisfy the contract. Non-contract
     errors (provider timeout, rate limit, server error) are transient
     and should allow cycling through candidates again. *)
-let is_completion_contract_violation (_ : Agent_sdk.Error.sdk_error) : bool =
-  false
+let is_completion_contract_violation (err : Agent_sdk.Error.sdk_error) : bool =
+  match Keeper_turn_driver.classify_masc_internal_error err with
+  | Some (Keeper_turn_driver.Accept_rejected _) ->
+    not (is_recoverable_no_progress_accept_rejection err)
+  | Some
+      ( Keeper_turn_driver.Runtime_exhausted _
+      | Keeper_turn_driver.Capacity_backpressure _
+      | Keeper_turn_driver.Resumable_cli_session _
+      | Keeper_turn_driver.Admission_queue_timeout _
+      | Keeper_turn_driver.Admission_queue_rejected _
+      | Keeper_turn_driver.Turn_timeout _
+      | Keeper_turn_driver.Provider_timeout _
+      | Keeper_turn_driver.Max_tokens_ceiling_violation _
+      | Keeper_turn_driver.Ambiguous_post_commit _
+      | Keeper_turn_driver.Internal_unhandled_exception _
+      | Keeper_turn_driver.Internal_bridge_exception _
+      | Keeper_turn_driver.Internal_contract_rejected _ )
+  | None ->
+    false
 
 let degraded_reason_allows_candidate_cycle = function
   | Hard_quota | Rate_limit | Read_only_no_progress | Empty_no_progress -> false

--- a/lib/keeper/keeper_error_classify.mli
+++ b/lib/keeper/keeper_error_classify.mli
@@ -72,7 +72,9 @@ val is_context_overflow : Agent_sdk.Error.sdk_error -> bool
 
 (** [true] when the error is a completion contract violation.
     Contract violations should cap rotation because retrying the same
-    or different runtime will not satisfy the contract. *)
+    or different runtime will not satisfy the contract. Narrow no-progress
+    accept rejections that carry an explicit empty/read-only recovery hint are
+    handled by the degraded retry path instead. *)
 val is_completion_contract_violation : Agent_sdk.Error.sdk_error -> bool
 
 (** [true] when the error is an OAS [InputRequired] — the agent paused

--- a/test/test_keeper_sdk_error_typed_bridge.ml
+++ b/test/test_keeper_sdk_error_typed_bridge.ml
@@ -438,6 +438,51 @@ let read_only_no_progress_err ~scope =
        })
 ;;
 
+let generic_accept_rejected_err ~scope =
+  KTD.sdk_error_of_masc_internal_error
+    (KTD.Accept_rejected
+       { scope
+       ; model = None
+       ; reason_kind = Some KTD.Accept_predicate_rejected
+       ; response_shape = Some KTD.Accept_response_mixed_without_deliverable_content
+       ; last_tool_effect = None
+       ; any_mutating_tool = Some false
+       ; tool_effects_seen = []
+       ; reason =
+           "response rejected by accept: predicate failed without accepted \
+            deliverable content"
+       })
+;;
+
+let test_generic_accept_rejected_is_completion_contract_violation () =
+  let err = generic_accept_rejected_err ~scope:"same.a" in
+  Alcotest.(check bool)
+    "generic accept rejection is a contract violation"
+    true
+    (EC.is_completion_contract_violation err);
+  match EC.recoverable_runtime_failure_reason err with
+  | None -> ()
+  | Some reason ->
+    Alcotest.failf
+      "generic accept rejection should not be recoverable, got %s"
+      (EC.degraded_retry_reason_to_string reason)
+;;
+
+let test_read_only_no_progress_remains_recoverable_not_contract () =
+  let err = read_only_no_progress_err ~scope:"same.a" in
+  Alcotest.(check bool)
+    "read-only no-progress keeps recovery path"
+    false
+    (EC.is_completion_contract_violation err);
+  match EC.recoverable_runtime_failure_reason err with
+  | Some EC.Read_only_no_progress -> ()
+  | Some reason ->
+    Alcotest.failf
+      "expected read_only_no_progress, got %s"
+      (EC.degraded_retry_reason_to_string reason)
+  | None -> Alcotest.fail "expected read_only_no_progress recoverable reason"
+;;
+
 let test_soft_rate_limit_skips_same_credential_pool () =
   init_rate_limit_pool_runtime ();
   let retry =
@@ -679,6 +724,14 @@ let () =
             "provider unavailable records server_error cooldown"
             `Quick
             test_provider_unavailable_records_server_error_cooldown
+        ; Alcotest.test_case
+            "generic accept rejection is completion contract violation"
+            `Quick
+            test_generic_accept_rejected_is_completion_contract_violation
+        ; Alcotest.test_case
+            "read-only no-progress remains recoverable"
+            `Quick
+            test_read_only_no_progress_remains_recoverable_not_contract
         ; Alcotest.test_case
             "read-only no-progress accept rejection rotates to default runtime"
             `Quick


### PR DESCRIPTION
## Summary
- Replace the `is_completion_contract_violation` stub with typed `Accept_rejected` classification.
- Preserve the explicit empty/read-only no-progress recovery exceptions so direct degraded retry behavior stays intentional.
- Add regression coverage for generic accept rejection vs read-only no-progress accept rejection.

## Verification
- `ocamlformat --check lib/keeper/keeper_error_classify.ml lib/keeper/keeper_error_classify.mli test/test_keeper_sdk_error_typed_bridge.ml`
- `git diff --check origin/main..HEAD`
- Not run: local Dune build/tests, per operator instruction to use GitHub CI as build authority.

## Review context
Follow-up from the recent adversarial sweep: current `main` documented completion-contract violations as a typed cap but implemented the predicate as `false`. This patch removes that stub without widening string/prose classifiers.
