### PR TITLE
fix(keeper): guard stale restart lifetime

### DIFF
--- a/docs/audit/2026-06-28-keeper-restart-stale-turn-audit.md
+++ b/docs/audit/2026-06-28-keeper-restart-stale-turn-audit.md
@@ -1,0 +1,143 @@
+# Keeper restart stale-turn audit - 2026-06-28
+
+status: draft_pr_ready
+last_verified: 2026-06-28T19:43:33+09:00
+runtime_window_utc: 2026-06-27T10:34:00Z..2026-06-28T10:34:00Z
+runtime_root: `<RUNTIME_ROOT>`
+repo_head: `92d1df5d1d4`
+live_runtime_head: `0830676537f`
+
+## Evidence
+
+- [근거] Live health: `curl -fsS '<MASC_HTTP_BASE>/health?full=1'`, checked 2026-06-28T19:34+09:00, confidence High. Runtime reported `version=0.19.51`, `keeper_fibers=1`, `keeper_fleet_safety.status=degraded`, `blocker=low_running_fiber_margin`, running keeper `sangsu`, and multiple blocked/dead keepers with `stale_turn_timeout(idle_turn(...))`.
+- [근거] 24h system-log aggregation: parsed `<RUNTIME_ROOT>/logs/system_log_2026-06-27.jsonl` and `system_log_2026-06-28.jsonl` with cutoff `2026-06-27T10:34:00Z`, checked 2026-06-28T19:36+09:00, confidence High. WARN/ERROR dominant classes included stale-turn recovery, SSE unknown sessions, empty librarian responses, prompt fallback, anti-rationalization empty approvals, and compaction manifest unknown events.
+- [근거] Restart timeline: exact `rondo`, `nick0cave`, and `sangsu` log slices showed each keeper restarted, consumed `bootstrap`, then was killed by `stale_turn_timeout(idle_turn(...))` roughly one sweep later while retaining the pre-restart `last_turn_ts`; checked 2026-06-28T19:38+09:00, confidence High.
+- [근거] Source trace: `lib/keeper/keeper_supervisor.ml`, `lib/keeper/keeper_registry_setup.ml`, `lib/keeper/keeper_registry.ml`, and `test/test_keeper_supervisor.ml`, checked 2026-06-28T19:43+09:00, confidence High.
+- [근거] OCaml 5.4 manual: `https://ocaml.org/releases/5.4/index.html` and effect handler chapter `https://ocaml.org/releases/5.4/effects.html`, checked 2026-06-28T19:40+09:00, confidence High.
+- [근거] Eio API docs: `https://ocaml-multicore.github.io/eio/eio/Eio/Switch/index.html` and `https://ocaml-multicore.github.io/eio/eio/Eio/Fiber/index.html`, checked 2026-06-28T19:39+09:00, confidence High.
+- [근거] Jane Street Base README: `https://raw.githubusercontent.com/janestreet/base/master/README.org`, checked 2026-06-28T19:41+09:00, confidence Medium as a library/style signal rather than a MASC dependency rule.
+- [근거] OCaml Forum Eio discussions: `https://discuss.ocaml.org/t/understanding-cancellation-in-eio/9369` and `https://discuss.ocaml.org/t/i-roughly-translated-real-world-ocamls-async-concurrency-chapter-to-eio/14548`, checked 2026-06-28T19:42+09:00, confidence Medium because they are design discussion, not normative API documentation.
+
+## Primary Finding
+
+P0: restarted keepers inherit old completed-turn metadata and immediately burn restart budget.
+
+- Symptom: `rondo`, `nick0cave`, and `sangsu` all restarted successfully, then died one sweep later with `stale_turn_timeout(idle_turn(...))`; repeated attempts exhausted `max_restarts`.
+- Root point: `register_restarting` creates a fresh registry entry with fresh `started_at`, but preserves `meta.runtime.usage.last_turn_ts`. `assess_stale_run` used only `last_turn_ts`, so a newly launched fiber could be classified as stale before its current supervised lifetime had exceeded the stale threshold.
+- Fix in this branch: `assess_stale_run` now requires both the last completed turn and the current supervised lifetime anchor to exceed the same configured threshold. It does not mutate `last_turn_ts`, does not add a new env knob, and does not add prompt constraints.
+- Code: `lib/keeper/keeper_supervisor.ml`, `lib/keeper/keeper_supervisor.mli`, `test/test_keeper_supervisor.ml`, `test/test_keeper_idle_threshold_contract.ml`.
+
+## Runtime Findings
+
+1. P0 restart-budget false exhaustion
+   - Root: stale-run helper ignored `entry.started_at`.
+   - Surface: `lib/keeper/keeper_supervisor.ml`, `lib/keeper/keeper_registry_setup.ml`.
+   - Status: fixed in this branch.
+
+2. P0 fleet reaction capacity collapse
+   - Root: multiple keepers reached Dead/paused while only `sangsu` remained executable.
+   - Surface: `lib/server/server_routes_http_runtime_fleet_scan.ml`.
+   - Status: follow-up; fix P0 restart false-positive first.
+
+3. P0 self-preservation suppression amplifies false cohort
+   - Root: stale-turn cohort dominated restart candidates because the root stale classifier was wrong.
+   - Surface: `lib/keeper/keeper_supervisor_self_preservation.ml`.
+   - Status: re-evaluate after this fix is deployed.
+
+4. P1 pending no-progress recovery for non-executable keepers
+   - Root: reaction ledger can retain pending stimuli for dead/paused/no-fiber keepers.
+   - Surface: `lib/keeper/keeper_reaction_ledger*`, fleet health scan.
+   - Status: follow-up; do not solve by prompt constraints.
+
+5. P1 event queue restores `bootstrap` repeatedly after restart
+   - Root: restart path restores durable event queue snapshot, then launch enqueues bootstrap again.
+   - Surface: `lib/keeper/keeper_registry_setup.ml`, `lib/keeper/keeper_supervisor_launch.ml`.
+   - Status: follow-up with event ack/tombstone proof.
+
+6. P1 no real turn before stale sweep after restart
+   - Root: bootstrap consumption alone is not proof that the restarted keeper completed a turn.
+   - Surface: `lib/keeper/keeper_supervisor_launch.ml`, keeper heartbeat loop.
+   - Status: covered by lifetime gate; deeper admission proof remains follow-up.
+
+7. P1 paused/autoboot/dead state interaction is hard to reason about
+   - Root: durable pause, autoboot config, and supervisor restart recovery all contribute to bootability.
+   - Surface: `lib/server/server_routes_http_runtime_fleet_scan.ml`, keeper TOML parsing.
+   - Status: follow-up; keep scope per keeper.
+
+8. P1 active task owner without executable fiber
+   - Root: health reports active owner state where the registry has no matching executable keeper fiber.
+   - Surface: `lib/server/server_routes_http_runtime_fleet_scan.ml`.
+   - Status: follow-up; release/quarantine must be explicit.
+
+9. P1 anti-rationalization empty text approves by liveness
+   - Root: empty evaluator output can produce approval fallback.
+   - Surface: `lib/task/anti_rationalization.ml`.
+   - Status: follow-up; this is a silent-failure risk.
+
+10. P1 memory librarian empty response and timeout fallback
+    - Root: provider returned empty/unparseable output or timed out; global slot capacity also skipped work.
+    - Surface: `lib/keeper/keeper_librarian_runtime.ml`.
+    - Status: follow-up; validate against current deployed head before tuning.
+
+11. P1 prompt SSOT fallback
+    - Root: externalized prompt `keeper.turn_intent.task_create_guidance` resolved empty and binary fallback was used.
+    - Surface: prompt resolver/config prompt store.
+    - Status: follow-up; binary fallback is an SSOT risk if the external prompt is required.
+
+12. P1 compaction manifest event schema drift
+    - Root: dashboard reader surfaced unknown manifest events `memory_injected` / `memory_flushed`.
+    - Surface: `lib/keeper/keeper_runtime_manifest.ml`, `lib/keeper_registry/keeper_runtime_manifest_types.ml`, `lib/server/server_dashboard_http_keeper_api.ml`.
+    - Status: follow-up; current source appears to know these event names, so verify live binary freshness.
+
+13. P1 source entries accept-and-ignore invalid shape
+    - Root: `source_entries_arg` ignores null/non-object/non-list sources instead of rejecting caller shape.
+    - Surface: `lib/board_tool_adapter/board_tool_format.ml`.
+    - Status: follow-up; schema should decide whether null is valid.
+
+14. P1 correction pipeline still invalid after deterministic fixes
+    - Root: deterministic repair can exit invalid without a typed terminal reason visible in the top-level log.
+    - Surface: correction pipeline modules; exact owner needs focused trace.
+    - Status: follow-up.
+
+15. P2 SSE unknown-session noise
+    - Root: stale dashboard/session clients repeatedly attempted SSE registration with unknown session IDs.
+    - Surface: `lib/sse.ml`, MCP/SSE transport tests.
+    - Status: follow-up outside keeper restart.
+
+16. P2 dashboard token mismatch fallback
+    - Root: token mismatch fallback is frequent enough to obscure Keeper logs.
+    - Surface: dashboard auth/server paths.
+    - Status: follow-up outside keeper restart.
+
+17. P2 Discord heartbeat ack timeout outside Connected state
+    - Root: state machine receives ack timeout after leaving Connected; ignored by design.
+    - Surface: `lib/gate/discord_gateway_state.ml`.
+    - Status: monitor; not a Keeper restart root cause.
+
+18. P2 resume directive names not in registry
+    - Root: directives use agent identifiers such as `keeper-*-agent` while registry lookup expects current keeper names.
+    - Surface: `lib/keeper/keeper_keepalive.ml`.
+    - Status: follow-up; avoid string-name drift.
+
+19. P2 tool/path readiness failures in keeper playground
+    - Root: keeper attempted unavailable repo path or denied repository access.
+    - Surface: tool repository access and playground path mapping.
+    - Status: follow-up; keep path guards strict.
+
+20. P2 path/env audit remains live risk
+    - Root: health reported config subpaths from env while runtime base/root came from explicit CLI; path ownership is correct but still fragile under mixed startup surfaces.
+    - Surface: config resolver and runtime health path reporting.
+    - Status: follow-up; no hardcoded `<MASC_BASE_PATH>` runtime default was introduced here.
+
+## Design Check
+
+- OCaml 5.4/Eio: the fix is a pure decision helper and does not add long-lived blocking I/O, a new switch, an unstructured cancellation path, or a wall-clock provider/tool timeout. This matches Eio's resource ownership model: switches own resources/fibers and cancellation belongs at the right ownership boundary.
+- Jane Street/Base signal: use explicit module origins and typed operations. This patch keeps `Stdlib.Float.max` explicit and extends the typed helper interface rather than hiding a defaulted optional parameter.
+- OCaml Forum signal: cancellation and timeout behavior should be tied to resource/fiber ownership, not arbitrary external invalidation. The patch uses the current supervised lifetime as ownership evidence instead of force-touching metadata or adding a side-channel knob.
+
+## Verification State
+
+- `git diff --check`: passed.
+- `ocamlformat --check lib/keeper/keeper_supervisor.ml lib/keeper/keeper_supervisor.mli test/test_keeper_supervisor.ml test/test_keeper_idle_threshold_contract.ml`: passed.
+- Local Dune build: intentionally not run; CI is the requested build authority for this repo.
+- Remaining proof: draft PR CI, then deploy/restart and re-run the exact stale-turn log slice for `rondo`, `nick0cave`, and `sangsu`.

--- a/lib/keeper/keeper_supervisor.ml
+++ b/lib/keeper/keeper_supervisor.ml
@@ -22,25 +22,33 @@ include Keeper_supervisor_launch
     when the keeper is [Running], is not in a turn ([in_turn = None], the
     exact [Idle_turn] doc contract), has completed at least one turn
     ([last_turn_ts > 0], so a fresh-start keeper is not mis-stamped), and
-    [now] exceeds [last_turn_ts] by more than [threshold]. Returns [None]
-    otherwise (alive, in-turn, or fresh-start).
+    [now] exceeds both the last completed turn and the current supervised
+    lifetime by more than [threshold]. The lifetime gate prevents a restarted
+    fiber from immediately inheriting an old completed-turn timestamp and
+    burning its restart budget before it has had one stale window to make
+    progress. Returns [None] otherwise (alive, in-turn, fresh-start, or
+    recently restarted).
 
     Pure: the caller stamps the reason via [Keeper_registry.set_failure_reason]
     and invokes [Keeper_execution_receipt.emit_stale_keeper_broadcast]. Keys on
-    [last_turn_ts], never on active-tool duration, so it does not re-introduce
-    the deliberately-removed per-turn wall-clock watchdog. *)
+    [last_turn_ts] for the reported stall while using [started_at] only as a
+    current-lifetime grace anchor. It never keys on active-tool duration, so it
+    does not re-introduce the deliberately-removed per-turn wall-clock
+    watchdog. *)
 let assess_stale_run
     ~(phase : Keeper_state_machine.phase)
     ~(in_turn : 'a option)
     ~(last_turn_ts : float)
+    ~(started_at : float)
     ~(now : float)
     ~(threshold : float)
     : Keeper_registry.failure_reason option
   =
+  let idle_anchor_ts = Stdlib.Float.max last_turn_ts started_at in
   if Bool.( phase = Keeper_state_machine.Running
             && Option.is_none in_turn
             && last_turn_ts > 0.0
-            && now -. last_turn_ts > threshold )
+            && now -. idle_anchor_ts > threshold )
   then
     let stall = now -. last_turn_ts in
     Some
@@ -509,6 +517,7 @@ let sweep_and_recover ~load_or_materialize_keeper_meta (ctx : _ context) =
                ~phase:entry.phase
                ~in_turn:entry.current_turn_observation
                ~last_turn_ts:entry.meta.runtime.usage.last_turn_ts
+               ~started_at:entry.started_at
                ~now
                ~threshold
          in

--- a/lib/keeper/keeper_supervisor.mli
+++ b/lib/keeper/keeper_supervisor.mli
@@ -91,6 +91,7 @@ val assess_stale_run :
      phase:Keeper_state_machine.phase
   -> in_turn:'a option
   -> last_turn_ts:float
+  -> started_at:float
   -> now:float
   -> threshold:float
   -> Keeper_registry.failure_reason option
@@ -98,8 +99,11 @@ val assess_stale_run :
     [Some (Stale_turn_timeout (Idle_turn { stall_seconds }))] — the
     [Idle_turn] variant's first real producer — when [phase = Running], the
     keeper is not in a turn ([in_turn = None]), has completed at least one
-    turn ([last_turn_ts > 0]), and [now] exceeds [last_turn_ts] by more than
-    [threshold]. [None] otherwise. Exposed for regression tests. *)
+    turn ([last_turn_ts > 0]), and [now] exceeds both [last_turn_ts] and the
+    current supervised lifetime [started_at] by more than [threshold]. The
+    lifetime gate prevents a restart from immediately inheriting stale metadata
+    and exhausting restart budget before one idle window elapses. [None]
+    otherwise. Exposed for regression tests. *)
 
 val assess_in_turn_progress :
      phase:Keeper_state_machine.phase

--- a/test/test_keeper_idle_threshold_contract.ml
+++ b/test/test_keeper_idle_threshold_contract.ml
@@ -168,6 +168,7 @@ let test_runtime_admitted_skip_refreshes_last_turn_ts () =
            ~phase:KSM.Running
            ~in_turn:None
            ~last_turn_ts:stale_ts
+           ~started_at:0.0
            ~now
            ~threshold
        with
@@ -194,6 +195,7 @@ let test_runtime_admitted_skip_refreshes_last_turn_ts () =
                 ~phase:KSM.Running
                 ~in_turn:None
                 ~last_turn_ts:fresh_ts
+                ~started_at:0.0
                 ~now
                 ~threshold)))
 
@@ -239,6 +241,7 @@ let test_smart_idle_sleep_refreshes_last_turn_ts () =
                 ~phase:KSM.Running
                 ~in_turn:None
                 ~last_turn_ts:fresh_ts
+                ~started_at:0.0
                 ~now
                 ~threshold)))
 

--- a/test/test_keeper_supervisor.ml
+++ b/test/test_keeper_supervisor.ml
@@ -2847,6 +2847,7 @@ let test_assess_stale_run () =
        ~phase:KSM.Running
        ~in_turn:None
        ~last_turn_ts:100.0
+       ~started_at:0.0
        ~now:300.0
        ~threshold:150.0
    with
@@ -2861,8 +2862,35 @@ let test_assess_stale_run () =
           ~phase:KSM.Running
           ~in_turn:None
           ~last_turn_ts:290.0
+          ~started_at:0.0
           ~now:300.0
           ~threshold:150.0));
+  (* fresh restart: metadata says the last completed turn is old, but the
+     current supervised fiber has not had a full stale window yet. *)
+  check bool "fresh restart with stale metadata -> None" true
+    (Option.is_none
+       (Sup.assess_stale_run
+          ~phase:KSM.Running
+          ~in_turn:None
+          ~last_turn_ts:100.0
+          ~started_at:280.0
+          ~now:300.0
+          ~threshold:150.0));
+  (* restarted and stale: once the current supervised lifetime also exceeds the
+     threshold, preserve the original stall value from last_turn_ts. *)
+  (match
+     Sup.assess_stale_run
+       ~phase:KSM.Running
+       ~in_turn:None
+       ~last_turn_ts:100.0
+       ~started_at:120.0
+       ~now:300.0
+       ~threshold:150.0
+   with
+   | Some (Reg.Stale_turn_timeout (Reg.Idle_turn { stall_seconds })) ->
+     check int "restarted stale preserves last_turn stall=200" 200
+       (int_of_float stall_seconds)
+   | _ -> check bool "restarted stale must stamp Idle_turn{200}" false true);
   (* in-turn: a turn is live (Some _) → None — Idle_turn contract needs None. *)
   check bool "in-turn → None" true
     (Option.is_none
@@ -2870,6 +2898,7 @@ let test_assess_stale_run () =
           ~phase:KSM.Running
           ~in_turn:(Some ())
           ~last_turn_ts:100.0
+          ~started_at:0.0
           ~now:300.0
           ~threshold:150.0));
   (* fresh-start: last_turn_ts = 0 → None — never mis-stamp a just-started keeper. *)
@@ -2879,6 +2908,7 @@ let test_assess_stale_run () =
           ~phase:KSM.Running
           ~in_turn:None
           ~last_turn_ts:0.0
+          ~started_at:290.0
           ~now:300.0
           ~threshold:150.0));
   (* not-running: Crashed → None. *)
@@ -2888,6 +2918,7 @@ let test_assess_stale_run () =
           ~phase:KSM.Crashed
           ~in_turn:None
           ~last_turn_ts:100.0
+          ~started_at:0.0
           ~now:300.0
           ~threshold:150.0));
   (* boundary: stall exactly == threshold → None (strict >). *)
@@ -2897,6 +2928,7 @@ let test_assess_stale_run () =
           ~phase:KSM.Running
           ~in_turn:None
           ~last_turn_ts:150.0
+          ~started_at:0.0
           ~now:300.0
           ~threshold:150.0))
 
@@ -3234,7 +3266,7 @@ let () =
     ];
     "stale_run_window", [
       test_case
-        "assess_stale_run covers frozen/fresh/in-turn/fresh-start/not-running/boundary"
+        "assess_stale_run covers frozen/fresh/restart/in-turn/fresh-start/not-running/boundary"
         `Quick test_assess_stale_run;
     ];
     "mid_turn_progress_window", [


### PR DESCRIPTION
## Summary

- guard `assess_stale_run` with the current supervised `started_at` lifetime so a restarted keeper cannot immediately inherit stale `last_turn_ts` and exhaust restart budget before one configured stale window elapses
- keep `last_turn_ts` semantics intact as "last completed turn"; the reported stall still uses that timestamp
- add regression coverage for fresh restart with stale metadata and for restarted keepers that remain stale after the threshold
- add `docs/audit/2026-06-28-keeper-restart-stale-turn-audit.md` with the live 24h timeline, 20 traced runtime findings, and upstream OCaml/Eio evidence

## Verification

- `git diff --check`
- `ocamlformat --check lib/keeper/keeper_supervisor.ml lib/keeper/keeper_supervisor.mli test/test_keeper_supervisor.ml test/test_keeper_idle_threshold_contract.ml`
- `bash /Users/dancer/me/scripts/procedural-memory/validate-evidence-record.sh --warn docs/audit/2026-06-28-keeper-restart-stale-turn-audit.md`

Local Dune build was intentionally not run; CI is the build authority for this repo per operator instruction.
