### PR TITLE
fix: Use task.assignee as SSOT for task assignment rendering

### DIFF
--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -381,17 +381,17 @@ function TaskRow({ task, onClaim }: { task: Task; onClaim: (id: string) => void 
         </span>
         <span class="wk-spacer"></span>
         <span class=${`wk-task-state ${state.cls}`}>${state.label}</span>
-        ${keeper
+        ${task.assignee
           ? html`
             <button
               type="button"
-              class="wk-task-kp"
+              class=${`wk-task-kp${keeper ? '' : ' offline'}`}
               data-testid="job-keeper"
-              onClick=${(e: Event) => { e.stopPropagation(); openKeeperWorkspace(keeper.name) }}
-              title=${`${keeper.name} 대화 열기`}
+              onClick=${(e: Event) => { e.stopPropagation(); openKeeperWorkspace(task.assignee!) }}
+              title=${`${task.assignee} 대화 열기${keeper ? '' : ' (Offline)'}`}
             >
-              <${KeeperBadge} id=${keeper.name} size="sm" variant="sigil" />
-              <span class="mono">${keeper.name}</span>
+              <${KeeperBadge} id=${task.assignee} size="sm" variant="sigil" />
+              <span class="mono">${task.assignee}</span>
             </button>
           `
           : task.status === 'todo'
@@ -725,15 +725,15 @@ function KanbanCard({
       ${blocker ? html`<div class="wk-kcard-block">⚠ ${blocker}</div>` : null}
       ${hasDescription ? html`<p class="wk-kcard-desc">${description}</p>` : null}
       <div class="wk-kcard-foot">
-        ${keeper
+        ${task.assignee
           ? html`
             <button
               type="button"
-              class="wk-kcard-kp"
-              title=${`${keeper.name} 대화 열기`}
-              onClick=${(e: Event) => { e.stopPropagation(); openKeeperWorkspace(keeper.name) }}
+              class=${`wk-kcard-kp${keeper ? '' : ' offline'}`}
+              title=${`${task.assignee} 대화 열기${keeper ? '' : ' (Offline)'}`}
+              onClick=${(e: Event) => { e.stopPropagation(); openKeeperWorkspace(task.assignee!) }}
             >
-              <${KeeperBadge} id=${keeper.name} size="sm" variant="sigil" />
+              <${KeeperBadge} id=${task.assignee} size="sm" variant="sigil" />
             </button>
           `
           : task.status === 'todo'


### PR DESCRIPTION
## Description
Fixes a boundary bug where tasks assigned to offline or crashed Keepers were incorrectly rendered as `미배정` (Unassigned). 

### Root Cause
The UI was relying on `keepers.value` (which represents the currently active keeper processes) as the source of truth for assignment. This violated SSOT principles since `task.assignee` is the actual persisted domain state. If a keeper went offline or failed to report its status (e.g., due to registry corruption exception in OCaml backend, which correctly filters out only that keeper), the UI ignored the `task.assignee` value and rendered `미배정`.

### Changes
- Changed conditionals in `TaskRow` and `KCard` to depend on `task.assignee` instead of `keeper`.
- If `task.assignee` is set but the keeper is not currently active, it now properly shows the assignee's name and visually degrades (adds an `offline` indicator/title).
- Avoids heuristic parsing or silent failures.