### PR TITLE
fix: Resolve additional keeper boundary bugs for offline states

### DIFF
--- a/dashboard/src/components/goals/task-detail-state.ts
+++ b/dashboard/src/components/goals/task-detail-state.ts
@@ -211,11 +211,12 @@ async function loadActivity(task: Task): Promise<void> {
   try {
     const keeper = findKeeper(task.assignee)
     const timelineName = keeper?.agent_name ?? task.assignee
-    const trajectoryName = keeper?.name ?? null
+    const isKeeper = task.assignee_kind === 'keeper' || keeper !== null
+    const trajectoryName = isKeeper ? task.assignee : null
 
     const [timeline, trajectory] = await Promise.all([
       fetchAgentTimeline(timelineName, 24, 200),
-      trajectoryName ? fetchKeeperTrajectory(trajectoryName, 100) : Promise.resolve(null),
+      trajectoryName ? fetchKeeperTrajectory(trajectoryName, 100).catch(() => null) : Promise.resolve(null),
     ])
 
     if (activityFetchToken.value !== token) return
@@ -235,7 +236,7 @@ export function hasActivityTab(task: Task): boolean {
 
 /** Whether the assignee is a keeper (affects tool call visibility). */
 export function isKeeperAssignee(task: Task): boolean {
-  return task.assignee ? findKeeper(task.assignee) !== null : false
+  return task.assignee_kind === 'keeper' || (task.assignee ? findKeeper(task.assignee) !== null : false)
 }
 
 // -- Goal relationship (keeper's active goals) ----------------------

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -157,9 +157,9 @@ function keeperByName(name: string | null | undefined): Keeper | undefined {
   return keepers.value.find(k => k.name === name)
 }
 
-function leadKeeperForGoal(goal: Goal): Keeper | undefined {
+function leadNameForGoal(goal: Goal): string | undefined {
   const active = keepers.value.find(k => k.active_goal_ids?.includes(goal.id))
-  if (active) return active
+  if (active) return active.name
 
   const goalTasks = tasks.value.filter(t => t.goal_id === goal.id)
   const counts = new Map<string, number>()
@@ -174,7 +174,7 @@ function leadKeeperForGoal(goal: Goal): Keeper | undefined {
       topCount = count
     }
   }
-  return topName ? keeperByName(topName) : undefined
+  return topName
 }
 
 function openKeeperWorkspace(name: string): void {
@@ -439,7 +439,7 @@ function GoalCard({
   onClaim: (id: string) => void
 }) {
   const progress = goalProgressCounts(goalTasks)
-  const lead = leadKeeperForGoal(goal)
+  const leadName = leadNameForGoal(goal)
 
   // Border tint by goal status (prototype .wk-goal.st-warn/.st-bad/.st-volt,
   // v2.css:812-814): at_risk→amber, blocked→bad, verifying→volt. `st-ok`
@@ -460,9 +460,9 @@ function GoalCard({
           ? html`<span class="wk-approval" title="완료 승인 필요">✓ 완료 승인</span>`
           : null}
         ${goal.due_date ? html`<span class="wk-due mono">${goal.due_date}</span>` : null}
-        ${lead ? html`
-          <span class="wk-lead" title=${`리드 · ${lead.name}`}>
-            <${KeeperBadge} id=${lead.name} size="md" variant="sigil" />
+        ${leadName ? html`
+          <span class=${`wk-lead${keeperByName(leadName) ? '' : ' offline'}`} title=${`리드 · ${leadName}${keeperByName(leadName) ? '' : ' (Offline)'}`}>
+            <${KeeperBadge} id=${leadName} size="md" variant="sigil" />
           </span>
         ` : null}
       </button>


### PR DESCRIPTION
## Description
Fixes two additional cases where the UI incorrectly relied on the active keeper runtime list (`keepers.value`) to infer domain facts, resulting in silent failures when a keeper is offline.

### Bugs Fixed
1. **Goal Lead Keeper Badge Disappearance**: `GoalCard` used `keeperByName` to find the lead keeper object. If the keeper was offline, the badge completely disappeared. Fixed by changing the function to `leadNameForGoal` and using the name as SSOT, gracefully degrading to an `(Offline)` state.
2. **Missing Task Trace (Trajectory) Fetch**: `task-detail-state.ts` failed to fetch the tool call trajectory of an offline keeper because it relied on `keeper?.name ?? null`. Traces are persistent on disk and should be fetched regardless of the process state. Fixed by relying on `task.assignee_kind === 'keeper'` and using `task.assignee` as the trajectory name fallback.

### Related
Extracted from PR #22568 to keep logical fixes separate.