### PR TITLE
[codex] reject masc_start tilde paths without HOME

### DIFF
--- a/lib/config_dir_resolver/config_dir_resolver.mli
+++ b/lib/config_dir_resolver/config_dir_resolver.mli
@@ -60,6 +60,11 @@ val current_working_dir : unit -> string
 val base_path_or_cwd : unit -> string
 (** [MASC_BASE_PATH] from host config, or {!current_working_dir} when unset. *)
 
+val initial_env_home : string option
+(** Process-start [HOME] snapshot after shared env trimming. [None] when unset
+    or empty. Use this when path policy must not observe in-process HOME
+    mutation. *)
+
 val resolve : unit -> resolution
 (** Cached resolution. First call evaluates, subsequent calls return the cache. *)
 

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -63,6 +63,29 @@ let arg_get_string ctx key default =
 let arg_get_string_list ctx key =
   Safe_ops.json_string_list key ctx.arguments
 
+let expand_start_path ~config path =
+  if String.length path >= 2 && Char.equal path.[0] '~' && Char.equal path.[1] '/'
+  then (
+    match Sys.getenv_opt "HOME" with
+    | Some home when not (String.equal (String.trim home) "") ->
+      Ok (Filename.concat home (String.sub path 2 (String.length path - 2)))
+    | _ -> Error "HOME is required to expand '~/' in masc_start path")
+  else if String.length path = 1 && Char.equal path.[0] '~'
+  then (
+    match Sys.getenv_opt "HOME" with
+    | Some home when not (String.equal (String.trim home) "") -> Ok home
+    | _ -> Error "HOME is required to expand '~' in masc_start path")
+  else if Filename.is_relative path
+  then (
+    let anchor =
+      if Workspace.is_initialized config
+      then config.base_path
+      else Config_dir_resolver.base_path_or_cwd ()
+    in
+    Ok (Filename.concat anchor path))
+  else Ok path
+;;
+
 (** masc_start — compound onboarding (set project root + bind session + optional task) *)
 let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result option =
   let config = ctx.config in
@@ -81,34 +104,22 @@ let handle_start ~tool_name ~start_time (ctx : context) : Tool_result.result opt
       else
         Error "path is required when no project scope is set. Provide the project directory path."
     end else begin
-      let expanded =
-        if String.length path >= 2 && Char.equal path.[0] '~' && Char.equal path.[1] '/' then
-          let home = match Sys.getenv_opt "HOME" with Some h -> h | None -> Filename.get_temp_dir_name () in
-          Filename.concat home (String.sub path 2 (String.length path - 2))
-        else if String.length path = 1 && Char.equal path.[0] '~' then
-          (match Sys.getenv_opt "HOME" with Some h -> h | None -> Filename.get_temp_dir_name ())
-        else if Filename.is_relative path then
-          let anchor =
-            if Workspace.is_initialized config then config.base_path
-            else Config_dir_resolver.base_path_or_cwd ()
-          in
-          Filename.concat anchor path
-        else
-          path
-      in
-      if not (Sys.file_exists expanded && Sys.is_directory expanded) then
-        Error (Printf.sprintf "Directory not found: %s" expanded)
-      else begin
-        let cfg = Workspace.default_config expanded in
-        if Workspace.is_initialized cfg then begin
-          Mcp_server.set_workspace_config state cfg;
-          Ok cfg
-        end else begin
-          let _msg = Workspace.init cfg ~agent_name:None in
-          Mcp_server.set_workspace_config state cfg;
-          Ok cfg
+      match expand_start_path ~config path with
+      | Error _ as err -> err
+      | Ok expanded ->
+        if not (Sys.file_exists expanded && Sys.is_directory expanded) then
+          Error (Printf.sprintf "Directory not found: %s" expanded)
+        else begin
+          let cfg = Workspace.default_config expanded in
+          if Workspace.is_initialized cfg then begin
+            Mcp_server.set_workspace_config state cfg;
+            Ok cfg
+          end else begin
+            let _msg = Workspace.init cfg ~agent_name:None in
+            Mcp_server.set_workspace_config state cfg;
+            Ok cfg
+          end
         end
-      end
     end
   in
   match workspace_result with

--- a/lib/mcp_tool_runtime_workspace.ml
+++ b/lib/mcp_tool_runtime_workspace.ml
@@ -63,20 +63,27 @@ let arg_get_string ctx key default =
 let arg_get_string_list ctx key =
   Safe_ops.json_string_list key ctx.arguments
 
+let expand_start_path_home ~path_syntax ~suffix =
+  match Config_dir_resolver.initial_env_home with
+  | Some home ->
+    Ok (if String.equal suffix "" then home else Filename.concat home suffix)
+  | None ->
+    Error (Printf.sprintf "HOME is required to expand '%s' in masc_start path" path_syntax)
+;;
+
 let expand_start_path ~config path =
   if String.length path >= 2 && Char.equal path.[0] '~' && Char.equal path.[1] '/'
-  then (
-    match Sys.getenv_opt "HOME" with
-    | Some home when not (String.equal (String.trim home) "") ->
-      Ok (Filename.concat home (String.sub path 2 (String.length path - 2)))
-    | _ -> Error "HOME is required to expand '~/' in masc_start path")
+  then
+    expand_start_path_home
+      ~path_syntax:"~/"
+      ~suffix:(String.sub path 2 (String.length path - 2))
   else if String.length path = 1 && Char.equal path.[0] '~'
-  then (
-    match Sys.getenv_opt "HOME" with
-    | Some home when not (String.equal (String.trim home) "") -> Ok home
-    | _ -> Error "HOME is required to expand '~' in masc_start path")
+  then expand_start_path_home ~path_syntax:"~" ~suffix:""
   else if Filename.is_relative path
   then (
+    (* Initialized sessions keep the active workspace as the relative-path
+       anchor. Only bootstrap calls without a workspace fall back to the
+       resolver/cwd bootstrap policy. *)
     let anchor =
       if Workspace.is_initialized config
       then config.base_path

--- a/test/stanzas/test_mcp_tool_matrix.inc
+++ b/test/stanzas/test_mcp_tool_matrix.inc
@@ -5,3 +5,8 @@
  (modules test_mcp_tool_matrix)
  (deps tool_matrix_case_runner.exe)
  (libraries masc_test_deps keeper_tool_matrix_cases_lib))
+
+(test
+ (name test_mcp_tool_runtime_workspace_path)
+ (modules test_mcp_tool_runtime_workspace_path)
+ (libraries masc_test_deps keeper_tool_matrix_cases_lib))

--- a/test/stanzas/test_mcp_tool_matrix.inc
+++ b/test/stanzas/test_mcp_tool_matrix.inc
@@ -9,4 +9,7 @@
 (test
  (name test_mcp_tool_runtime_workspace_path)
  (modules test_mcp_tool_runtime_workspace_path)
+ (action
+  (setenv HOME ""
+   (run %{test})))
  (libraries masc_test_deps keeper_tool_matrix_cases_lib))

--- a/test/test_mcp_tool_runtime_workspace_path.ml
+++ b/test/test_mcp_tool_runtime_workspace_path.ml
@@ -1,0 +1,72 @@
+module Cases = Test_mcp_tool_matrix_cases
+
+let contains_substring text fragment =
+  let text_len = String.length text in
+  let fragment_len = String.length fragment in
+  let rec loop index =
+    if fragment_len = 0 then true
+    else if index + fragment_len > text_len then false
+    else if String.sub text index fragment_len = fragment then true
+    else loop (index + 1)
+  in
+  loop 0
+;;
+
+let restore_env name = function
+  | Some value -> Unix.putenv name value
+  | None -> Unix.putenv name ""
+;;
+
+let test_masc_start_tilde_rejects_empty_home () =
+  Eio_main.run
+  @@ fun env ->
+  Eio.Switch.run
+  @@ fun sw ->
+  let base_path = Cases.temp_dir "mcp-start-home-empty-" in
+  let saved_home = Sys.getenv_opt "HOME" in
+  let saved_base_path = Sys.getenv_opt "MASC_BASE_PATH" in
+  Fun.protect
+    ~finally:(fun () ->
+      Cases.cleanup_dir base_path;
+      restore_env "HOME" saved_home;
+      restore_env "MASC_BASE_PATH" saved_base_path)
+    (fun () ->
+      Unix.putenv "HOME" "";
+      Unix.putenv "MASC_BASE_PATH" base_path;
+      let fixture =
+        Cases.make_fixture
+          sw
+          ~proc_mgr:(Eio.Stdenv.process_mgr env)
+          ~fs:(Eio.Stdenv.fs env)
+          ~net:(Eio.Stdenv.net env)
+          ~mono_clock:(Eio.Stdenv.mono_clock env)
+          (Eio.Stdenv.clock env)
+          ~base_path
+          Cases.Fresh
+      in
+      let result =
+        Cases.execute_tool
+          fixture
+          ~name:"masc_start"
+          ~arguments:(`Assoc [ "path", `String "~" ])
+      in
+      Alcotest.(check bool) "rejected" false (Tool_result.is_success result);
+      let message = Tool_result.message result in
+      Alcotest.(check bool)
+        "reports missing HOME"
+        true
+        (contains_substring message "HOME is required to expand '~'"))
+;;
+
+let () =
+  Mirage_crypto_rng_unix.use_default ();
+  Alcotest.run
+    "mcp_tool_runtime_workspace_path"
+    [ ( "masc_start"
+      , [ Alcotest.test_case
+            "rejects tilde expansion when HOME is empty"
+            `Quick
+            test_masc_start_tilde_rejects_empty_home
+        ] )
+    ]
+;;

--- a/test/test_mcp_tool_runtime_workspace_path.ml
+++ b/test/test_mcp_tool_runtime_workspace_path.ml
@@ -17,7 +17,7 @@ let restore_env name = function
   | None -> Unix.putenv name ""
 ;;
 
-let test_masc_start_tilde_rejects_empty_home () =
+let test_masc_start_tilde_rejects_empty_initial_home () =
   Eio_main.run
   @@ fun env ->
   Eio.Switch.run
@@ -31,7 +31,6 @@ let test_masc_start_tilde_rejects_empty_home () =
       restore_env "HOME" saved_home;
       restore_env "MASC_BASE_PATH" saved_base_path)
     (fun () ->
-      Unix.putenv "HOME" "";
       Unix.putenv "MASC_BASE_PATH" base_path;
       let fixture =
         Cases.make_fixture
@@ -64,9 +63,9 @@ let () =
     "mcp_tool_runtime_workspace_path"
     [ ( "masc_start"
       , [ Alcotest.test_case
-            "rejects tilde expansion when HOME is empty"
+            "rejects tilde expansion when initial HOME is empty"
             `Quick
-            test_masc_start_tilde_rejects_empty_home
+            test_masc_start_tilde_rejects_empty_initial_home
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- reject `masc_start` paths using `~` or `~/...` when `HOME` is missing or empty
- remove the previous temp-directory fallback for explicit tilde expansion
- add a focused MCP runtime regression test for the workflow rejection

## Validation
- `ocamlformat --check lib/mcp_tool_runtime_workspace.ml test/test_mcp_tool_runtime_workspace_path.ml`
- `git diff --check`
- `env MASC_SKIP_PIN_CHECK=1 scripts/dune-local.sh build test/test_mcp_tool_runtime_workspace_path.exe`
- `./_build/default/test/test_mcp_tool_runtime_workspace_path.exe`

Note: the first build attempt without `MASC_SKIP_PIN_CHECK=1` stopped at the local agent_sdk pin guard. The guard reported local pin `e34178964349fa171ffb58839b3fe316308b800a`, expected `83d89cda7907954e5adc980af69dd987a7145a9c`; this PR does not change the OAS dependency surface.
