### PR TITLE
fix(health): classify non-keeper task owners as advisory

### DIFF
--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -75,6 +75,12 @@ let canonical_keeper_name_from_agent_name agent_name =
       else
         None
 
+let is_keeper_principal_agent_name agent_name =
+  let trimmed = String.trim agent_name in
+  is_keeper_agent_alias trimmed
+  || (Nickname.is_dictionary_generated_nickname trimmed
+      && Option.is_some (canonical_keeper_name_from_agent_name trimmed))
+
 (** Phase A F5 (2026-04-27): single source of truth for the
     ["keeper-<name>"] prefix pattern.  Two call sites used to embed
     [String.sub trimmed 0 7 = "keeper-"] manually; both now go through

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -9,6 +9,12 @@ val generate_trace_id : ?now:float -> unit -> string
 val keeper_name_from_agent_name : string -> string option
 val is_keeper_agent_alias : string -> bool
 val canonical_keeper_name_from_agent_name : string -> string option
+val is_keeper_principal_agent_name : string -> bool
+(** [is_keeper_principal_agent_name name] returns true for task-owner
+    principals that should be treated as keeper-owned work: canonical
+    [keeper-<name>-agent] aliases and dictionary-generated keeper nicknames.
+    It intentionally rejects arbitrary three-part client names such as
+    [codex-mcp-client]. *)
 val canonical_keeper_name : string -> string option
 
 val strip_keeper_prefix : string -> string option

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -826,8 +826,10 @@ let phase_supports_crash_log_failure_reason = function
       false
 
 let active_task_owner_fiber_scan_semantics =
-  "reports active task owners without executable keeper fibers; disabled \
-   keepers are excluded; matching rows can degrade fleet status"
+  "reports keeper-shaped active task owners without executable keeper fibers; \
+   disabled keepers are excluded; matching keeper rows can degrade fleet \
+   status; non-keeper client task owners are reported separately as advisory \
+   rows"
 
 let paused_keeper_last_blocker_json paused_keepers_json name =
   match paused_keepers_json with
@@ -1043,15 +1045,23 @@ type active_task_owner_without_executable_fiber = {
   task_status : string;
 }
 
+type non_keeper_active_task_owner = {
+  agent_name : string;
+  task_id : string;
+  task_status : string;
+}
+
 type active_task_owner_fiber_scan = {
   active_task_owner_without_executable_fibers :
     active_task_owner_without_executable_fiber list;
+  non_keeper_active_task_owners : non_keeper_active_task_owner list;
   active_task_owner_scan_errors : (string * string) list;
 }
 
 let empty_active_task_owner_fiber_scan =
   {
     active_task_owner_without_executable_fibers = [];
+    non_keeper_active_task_owners = [];
     active_task_owner_scan_errors = [];
   }
 
@@ -1066,6 +1076,10 @@ let compare_active_task_owner_without_executable_fiber left right =
     let cmp = String.compare left.agent_name right.agent_name in
     if cmp <> 0 then cmp
     else String.compare left.task_id right.task_id
+
+let compare_non_keeper_active_task_owner left right =
+  let cmp = String.compare left.agent_name right.agent_name in
+  if cmp <> 0 then cmp else String.compare left.task_id right.task_id
 
 let active_task_assignment (task : Masc_domain.task) =
   Masc_domain.task_assignee_of_status task.task_status
@@ -1088,6 +1102,17 @@ let active_task_owner_without_executable_fiber_json row =
       ("task_status", `String row.task_status);
       ("executable", `Bool false);
       ("action", `String action);
+    ]
+
+let non_keeper_active_task_owner_json row =
+  `Assoc
+    [
+      ("agent_name", `String row.agent_name);
+      ("task_id", `String row.task_id);
+      ("task_status", `String row.task_status);
+      ("owner_kind", `String "non_keeper_client");
+      ("fleet_blocking", `Bool false);
+      ("action", `String "track_client_task_or_release_when_done");
     ]
 
 type keeper_agent_binding_scan = {
@@ -1148,51 +1173,74 @@ let active_task_owner_fiber_scan config ~executable_names =
   | Error err ->
       {
         active_task_owner_without_executable_fibers = [];
+        non_keeper_active_task_owners = [];
         active_task_owner_scan_errors =
           ("backlog", err) :: meta_read_errors;
       }
   | Ok backlog ->
-      let rows =
+      let blocking_rows, non_keeper_rows =
         backlog.tasks
-        |> List.map (fun task ->
+        |> List.fold_left
+             (fun (blocking_rows, non_keeper_rows) task ->
              match active_task_assignment task with
-             | None -> []
+             | None -> (blocking_rows, non_keeper_rows)
              | Some (assignee, task_status) ->
                  let keeper_names = keeper_names_for_agent agent_bindings assignee in
                  if
                    List.exists
                      (fun keeper_name -> String_set.mem keeper_name executable_set)
                      keeper_names
-                 then []
+                 then (blocking_rows, non_keeper_rows)
                  else (
                    match keeper_names with
                    | []
                      when List.mem assignee binding_scan.disabled_agent_names
                           || meta_read_errors <> [] ->
-                       []
+                       (blocking_rows, non_keeper_rows)
+                   | []
+                     when not
+                            (Keeper_identity.is_keeper_principal_agent_name assignee) ->
+                       ( blocking_rows
+                       , {
+                           agent_name = assignee;
+                           task_id = task.id;
+                           task_status;
+                         }
+                         :: non_keeper_rows )
                    | [] ->
-                       [
-                         {
+                       ( {
                            keeper_name = None;
                            agent_name = assignee;
                            task_id = task.id;
                            task_status;
-                         };
-                       ]
+                         }
+                         :: blocking_rows
+                       , non_keeper_rows )
                    | keeper_names ->
-                       keeper_names
-                       |> List.map (fun keeper_name ->
-                             {
-                               keeper_name = Some keeper_name;
-                               agent_name = assignee;
-                               task_id = task.id;
-                               task_status;
-                            })))
-        |> List.concat
+                       ( keeper_names
+                         |> List.fold_left
+                              (fun rows keeper_name ->
+                                {
+                                  keeper_name = Some keeper_name;
+                                  agent_name = assignee;
+                                  task_id = task.id;
+                                  task_status;
+                                }
+                                :: rows)
+                              blocking_rows
+                       , non_keeper_rows )))
+             ([], [])
+      in
+      let rows =
+        blocking_rows
         |> List.sort_uniq compare_active_task_owner_without_executable_fiber
+      in
+      let non_keeper_rows =
+        non_keeper_rows |> List.sort_uniq compare_non_keeper_active_task_owner
       in
       {
         active_task_owner_without_executable_fibers = rows;
+        non_keeper_active_task_owners = non_keeper_rows;
         active_task_owner_scan_errors = meta_read_errors;
       }
 
@@ -1300,6 +1348,9 @@ let keeper_fleet_safety_health_json
   in
   let active_task_owner_without_executable_fiber_count =
     List.length active_task_owner_scan.active_task_owner_without_executable_fibers
+  in
+  let non_keeper_active_task_owner_count =
+    List.length active_task_owner_scan.non_keeper_active_task_owners
   in
   let active_task_owner_without_executable_fiber =
     active_task_owner_without_executable_fiber_count > 0
@@ -1484,6 +1535,17 @@ let keeper_fleet_safety_health_json
           (List.map
              active_task_owner_without_executable_fiber_json
              active_task_owner_scan.active_task_owner_without_executable_fibers) )
+    ; ( "non_keeper_active_task_owner_count"
+      , `Int non_keeper_active_task_owner_count )
+    ; ( "non_keeper_active_task_owners"
+      , `List
+          (List.map
+             non_keeper_active_task_owner_json
+             active_task_owner_scan.non_keeper_active_task_owners) )
+    ; ( "non_keeper_active_task_owner_semantics"
+      , `String
+          "active tasks owned by non-keeper MCP clients; visible for operators \
+           but not keeper fleet blockers" )
     ; ( "active_task_owner_fiber_scan_semantics"
       , `String active_task_owner_fiber_scan_semantics )
     ; ( "active_task_owner_scan_error_count"

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1613,7 +1613,7 @@ let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
         let state = Mcp_server.create_state ~base_path:dir in
         Server_auth.server_state := Some state;
         let config = Mcp_server.workspace_config state in
-        let assignee = "missing-keeper-agent" in
+        let assignee = "keeper-missing-agent" in
         let task =
           make_task
             ~id:"task-active-owner-without-binding"
@@ -1681,6 +1681,88 @@ let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
                 ( row |> member "agent_name" |> to_string
                 , row |> member "reason" |> to_string )));
         Alcotest.(check bool) "health asks operator action" true
+          (fleet_safety |> member "operator_action_required" |> to_bool)))
+
+let test_health_json_reports_non_keeper_active_task_owner_as_advisory () =
+  with_temp_dir "health-non-keeper-active-task-owner-advisory" (fun dir ->
+    let config_root = make_config_root dir in
+    Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        let assignee = "codex-mcp-client" in
+        let task =
+          make_task
+            ~id:"task-client-owned-active"
+            ~title:"Active task owned by MCP client"
+            ~status:
+              (Types.Claimed
+                 { assignee; claimed_at = "2026-06-26T00:00:01Z" })
+            ()
+        in
+        Workspace.write_backlog config
+          { Types.tasks = [ task ]; last_updated = "2026-06-26T00:00:02Z"; version = 2 };
+        let request = Httpun.Request.create `GET "/health" in
+        let json = Server_routes_http_runtime.make_health_json request in
+        let open Yojson.Safe.Util in
+        let fleet_safety = json |> member "keeper_fleet_safety" in
+        Alcotest.(check string)
+          "health stays ok for non-keeper client owner"
+          "ok"
+          (fleet_safety |> member "status" |> to_string);
+        Alcotest.(check (option string))
+          "health keeps blocker empty"
+          None
+          (fleet_safety |> member "blocker" |> to_string_option);
+        Alcotest.(check bool)
+          "non-keeper client is not a keeper-fiber blocker"
+          false
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber"
+           |> to_bool);
+        Alcotest.(check int)
+          "health exposes no blocking keeper-owner rows"
+          0
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_count"
+           |> to_int);
+        Alcotest.(check int)
+          "health exposes one non-keeper owner row"
+          1
+          (fleet_safety |> member "non_keeper_active_task_owner_count" |> to_int);
+        let owners =
+          fleet_safety |> member "non_keeper_active_task_owners" |> to_list
+        in
+        Alcotest.(check int) "one advisory owner row" 1 (List.length owners);
+        let owner = List.hd owners in
+        Alcotest.(check string)
+          "advisory row agent"
+          assignee
+          (owner |> member "agent_name" |> to_string);
+        Alcotest.(check string)
+          "advisory row owner kind"
+          "non_keeper_client"
+          (owner |> member "owner_kind" |> to_string);
+        Alcotest.(check bool)
+          "advisory row does not block fleet"
+          false
+          (owner |> member "fleet_blocking" |> to_bool);
+        Alcotest.(check (list string))
+          "blocked keeper names stay empty"
+          []
+          (fleet_safety |> member "blocked_keeper_names" |> to_list
+           |> List.map to_string);
+        Alcotest.(check bool)
+          "health does not ask fleet operator action"
+          false
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
 let test_health_json_preserves_active_task_owner_meta_read_error () =
@@ -4077,6 +4159,10 @@ let () =
             "health json degrades on active task owner without keeper binding"
             `Quick
             test_health_json_degrades_on_active_task_owner_without_keeper_binding;
+          Alcotest.test_case
+            "health json reports non-keeper active task owner as advisory"
+            `Quick
+            test_health_json_reports_non_keeper_active_task_owner_as_advisory;
           Alcotest.test_case
             "health json preserves active task owner meta read error"
             `Quick


### PR DESCRIPTION
## Summary

- Split active task owner fleet-safety scan into blocking keeper-owner rows and advisory non-keeper client-owner rows.
- Add `Keeper_identity.is_keeper_principal_agent_name` using canonical keeper aliases plus strict dictionary-generated nicknames, so structured client names such as `codex-mcp-client` are not folded into fake keeper names.
- Surface `non_keeper_active_task_owner_count` / `non_keeper_active_task_owners` in health JSON while keeping keeper-fleet status unblocked for client-owned work.

## Runtime Evidence

- Live `/health?full=1` on 2026-06-28 reported:
  - `keeper_fleet_safety.status=degraded`
  - `blocker=active_task_owner_without_executable_fiber`
  - `task_id=task-1547`
  - `agent_name=codex-mcp-client`
  - `reason=no_keeper_binding`
- Backlog record confirms `task-1547` is a claimed client/operator task owned by `codex-mcp-client`, not a configured keeper fiber.

## Evidence

- Local static checks:
  - `ocamlformat --check lib/keeper/keeper_identity.ml lib/keeper/keeper_identity.mli lib/server/server_routes_http_runtime_fleet_scan.ml test/test_server_runtime_bootstrap.ml`
  - `git diff --check`
  - `git diff --cached --check`
- Local Dune build/test intentionally not run: operator requested CI as the OCaml build authority for this investigation.

Follow-up for #22567.
