### PR TITLE
[codex] clarify dashboard fleet runtime labels

### DIFF
--- a/dashboard/src/components/agent-roster.test.ts
+++ b/dashboard/src/components/agent-roster.test.ts
@@ -768,6 +768,36 @@ describe('AgentRoster live-only cards', () => {
     expect(container.textContent).not.toContain('old blocker that should stay out of the roster')
   })
 
+  it('labels workspace agents, keeper fibers, configured keepers, and task owners as separate surfaces', async () => {
+    agents.value = [
+      makeAgent({
+        name: 'dashboard',
+        status: 'active',
+      }),
+    ]
+    keepers.value = [
+      {
+        name: 'sangsu',
+        agent_name: 'keeper-sangsu-agent',
+        status: 'active',
+        phase: 'Running',
+        pipeline_stage: 'idle',
+        keepalive_running: true,
+      } as Keeper,
+    ]
+
+    await act(async () => {
+      render(html`<${AgentRoster} />`, container)
+    })
+    await flushUi()
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('workspace agents ≠ keeper fibers')
+    expect(text).toContain('configured keeper ≠ running fiber')
+    expect(text).toContain('task owner ≠ live agent')
+    expect(text).toContain('runtime rows')
+  })
+
   it('treats keeper-only rows as first-class runtime rows when agent registry is empty', async () => {
     agents.value = []
     keepers.value = [
@@ -906,10 +936,10 @@ describe('AgentRoster live-only cards', () => {
     }
     const text = container.textContent ?? ''
     expect(text).toContain('전이 중 · 3')
-    expect(text).toContain('일시정지 2')
-    expect(text).toContain('전이 3')
+    expect(text).toContain('일시정지 rows 2')
+    expect(text).toContain('전이 rows 3')
     expect(text).toContain('transient')
-    expect(text).toContain('오프라인 1')
+    expect(text).toContain('오프라인 rows 1')
   })
 
   it('does not show keeper boot hints on offline non-keeper agent rows', async () => {

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -1,6 +1,7 @@
-// MASC Dashboard — Unified Agent Roster
-// All entities are agents. Keeper = agent with persistent runtime.
-// Keeper state (CTX gauge, autonomy) shown inline on the card.
+// MASC Dashboard — Runtime Roster
+// Workspace agents, keeper runtime fibers, configured keepers, and task owners
+// are separate surfaces. This roster may display them together, but labels
+// must not imply they are the same namespace.
 
 import { html } from 'htm/preact'
 import { useMemo, useState } from 'preact/hooks'
@@ -967,7 +968,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         configuredKeepers,
       })
     : keeperFilter === 'agent-only'
-      ? `일반 에이전트 런타임 가동 ${runtimeCounts.live.agents}`
+      ? `workspace agents ${runtimeCounts.live.agents}`
       : formatRuntimeRosterCount(runtimeCounts)
   const keeperStateHints = (
     keeperFilter === 'keeper-only'
@@ -1243,16 +1244,21 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
 
   return html`
     <div class="v2-monitoring-surface fl-shell agent-page">
-      <section class="monitor-surface-card monitor-surface-card-strong v2-monitoring-card p-5" aria-label="에이전트 디렉터리">
+      <section class="monitor-surface-card monitor-surface-card-strong v2-monitoring-card p-5" aria-label="runtime surface directory">
         <div class="flex flex-col gap-5">
           <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px] xl:items-end">
             <div class="flex min-w-0 flex-col gap-2.5">
               <div class="fl-health">
-                <span class="fl-hpill ok">런타임 가동 <b>${healthRun}</b></span>
-                ${healthTransient > 0 ? html`<span class="fl-hpill busy">전이 <b>${healthTransient}</b></span>` : null}
-                <span class="fl-hpill warn">일시정지 <b>${healthPaused}</b></span>
-                <span class="fl-hpill">오프라인 <b>${healthOffline}</b></span>
+                <span class="fl-hpill ok">실행 rows <b>${healthRun}</b></span>
+                ${healthTransient > 0 ? html`<span class="fl-hpill busy">전이 rows <b>${healthTransient}</b></span>` : null}
+                <span class="fl-hpill warn">일시정지 rows <b>${healthPaused}</b></span>
+                <span class="fl-hpill">오프라인 rows <b>${healthOffline}</b></span>
                 ${healthAttention > 0 ? html`<span class="fl-hpill bad">주의 <b>${healthAttention}</b></span>` : null}
+              </div>
+              <div class="flex flex-wrap items-center gap-2 text-2xs text-[var(--color-fg-muted)]">
+                <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5">workspace agents ≠ keeper fibers</span>
+                <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5">configured keeper ≠ running fiber</span>
+                <span class="rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 py-0.5">task owner ≠ live agent</span>
               </div>
               <span class="inline-flex w-fit items-center rounded-[var(--r-0)] border border-[var(--color-border-default)] bg-[var(--color-accent-soft)] px-2.5 py-1 text-2xs font-medium text-[var(--color-fg-secondary)]">${resultCountLabel}</span>
             </div>
@@ -1262,9 +1268,9 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               <${TextInput}
                 class="rounded-[var(--r-1)] bg-[var(--color-bg-surface)] px-4 py-3 text-base text-[var(--color-fg-primary)] shadow-[inset_0_1px_0_var(--color-border-default)] focus:border-[var(--color-accent-fg)] focus:shadow-[0_0_0_2px_var(--color-accent-soft)]"
                 name="agent_search"
-                ariaLabel="에이전트 이름 · 작업 검색"
+                ariaLabel="runtime row 이름 · task owner 검색"
                 autoComplete="off"
-                placeholder="이름 · 작업으로 찾기"
+                placeholder="이름 · task owner로 찾기"
                 value=${search}
                 onInput=${(e: Event) => setSearch((e.target as HTMLInputElement).value)}
               />
@@ -1338,10 +1344,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
               <div class="px-6 py-10">
                 <${EmptyState}
                   message=${normalizedSearch && scopedAgents.length > 0
-                    ? `필터 결과 없음 (${scopedAgents.length} items)`
+                      ? `필터 결과 없음 (${scopedAgents.length} items)`
                     : showExecutionFallbackState && expectedScopedCount > 0
                       ? `${fallbackStateTitle}: ${scopeLabel}가 있지만, 현재 조건에 맞는 항목은 아직 없습니다.`
-                      : '조건에 맞는 에이전트가 없습니다.'}
+                      : '조건에 맞는 runtime row가 없습니다.'}
                   compact
                 />
               </div>
@@ -1352,7 +1358,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
         <aside class="fl-aside monitor-surface-card monitor-surface-card-medium v2-monitoring-panel" aria-label="Selected keeper detail">
           ${selectedRow ? html`
             <div class="fl-as-head">
-              <span class="fl-as-ey">selected runtime</span>
+              <span class="fl-as-ey">${selectedRow.isKeeper ? 'selected keeper runtime' : 'selected workspace agent'}</span>
               <span class="fl-as-state">
                 <span class="inline-block h-1.5 w-1.5 rounded-full" style="background:currentColor" aria-hidden="true"></span>
                 ${FL_TONE_LABEL[selectedTone]}
@@ -1514,10 +1520,10 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       </div>
 
       <div class="fl-foot">
-        <span class="fl-tick"><span class="k">keepers</span><span class="v">fresh ${healthRun}/${rosterRows.length}</span></span>
-        <span class="fl-tick"><span class="k">transient</span><span class="v">${healthTransient}</span></span>
-        <span class="fl-tick"><span class="k">paused</span><span class="v">${healthPaused}</span></span>
-        <span class="fl-tick"><span class="k">offline</span><span class="v">${healthOffline}</span></span>
+        <span class="fl-tick"><span class="k">runtime rows</span><span class="v">active ${healthRun}/${rosterRows.length}</span></span>
+        <span class="fl-tick"><span class="k">transient rows</span><span class="v">${healthTransient}</span></span>
+        <span class="fl-tick"><span class="k">paused rows</span><span class="v">${healthPaused}</span></span>
+        <span class="fl-tick"><span class="k">offline rows</span><span class="v">${healthOffline}</span></span>
         <span class="fl-tick"><span class="k">attention</span><span class="v ${healthAttention ? 'warn' : 'ok'}">${healthAttention}</span></span>
       </div>
     </div>

--- a/dashboard/src/components/agents-unified.test.ts
+++ b/dashboard/src/components/agents-unified.test.ts
@@ -72,8 +72,8 @@ vi.mock('../namespace-truth-store', () => ({
   namespaceTruth: { value: null },
 }))
 vi.mock('../runtime-counts', () => ({
-  formatKeeperRosterCount: vi.fn(() => '상세 16 / 런타임 가동 4 / 일시정지 12 / 설정 16'),
-  formatRuntimeRosterCount: vi.fn(() => '상세 20 / 런타임 가동 8 / 키퍼 설정 16'),
+  formatKeeperRosterCount: vi.fn(() => 'keeper 행 16 / keeper 실행 fiber 4 / 일시정지 keeper 12 / configured keeper 16'),
+  formatRuntimeRosterCount: vi.fn(() => 'runtime 행 20 / keeper 실행 fiber 4 / workspace agents 4 / 일시정지 keeper 12 / configured keeper 16'),
   resolveRuntimeCounts: vi.fn(() => ({
     live: { agents: 4, keepers: 4, pausedKeepers: 12, transientKeepers: 0, offlineKeepers: 0, keeperRows: 16, tasks: 0, totalRuntimes: 8, available: true },
     configured: { keepers: 16, totalRuntimes: 8, source: 'namespace-truth' },
@@ -120,15 +120,17 @@ describe('AgentsUnified', () => {
     expect(roster!.getAttribute('data-filter')).toBe('all')
     expect(container.querySelector('[data-testid="keeper-spawn-panel"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="chip-count-all"]')?.textContent)
-      .toBe('상세 20 / 런타임 가동 8 / 키퍼 설정 16')
+      .toBe('runtime 행 20 / keeper 실행 fiber 4 / workspace agents 4 / 일시정지 keeper 12 / configured keeper 16')
     expect(container.querySelector('[data-testid="chip-count-keepers"]')?.textContent)
-      .toBe('상세 16 / 런타임 가동 4 / 일시정지 12 / 설정 16')
+      .toBe('keeper 행 16 / keeper 실행 fiber 4 / 일시정지 keeper 12 / configured keeper 16')
+    expect(container.querySelector('[data-testid="chip-count-agents"]')?.textContent)
+      .toBe('workspace agents 4')
   })
 
   it('switches to agents view via filter chips', async () => {
     render(h(AgentsUnified, null), container)
     const btn = Array.from(container.querySelectorAll('button')).find(
-      b => b.textContent?.includes('Agents'),
+      b => b.textContent?.includes('Workspace Agents'),
     )
     expect(btn).not.toBeUndefined()
     await act(async () => {

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -1,6 +1,6 @@
-// MASC Dashboard — Keeper Fleet
-// Absorbs: agent-roster + execution + keeper-roster + FSM hub into one
-// operator-first board. Cognition stays available through keeper detail links.
+// MASC Dashboard — Keeper Fleet / Workspace Agents
+// The route hosts multiple live namespaces. Do not collapse workspace agents,
+// keeper runtime fibers, configured keepers, and task owners into one count.
 
 import { html } from 'htm/preact'
 import { useMemo, useState } from 'preact/hooks'
@@ -37,10 +37,10 @@ const activeView = computed<AgentsView>(() => {
 })
 
 const CHIPS: { id: AgentsView; label: string; description: string }[] = [
-  { id: 'all', label: 'Keeper Ops', description: '키퍼와 일반 에이전트를 attention-first 운영 목록으로 봅니다.' },
-  { id: 'agents', label: 'Agents', description: '키퍼가 연결되지 않은 일반 에이전트만 봅니다.' },
-  { id: 'keepers', label: 'Keepers', description: '키퍼만 따로 봅니다.' },
-  { id: 'fsm', label: 'FSM', description: '키퍼 composite FSM lifecycle 상태를 봅니다.' },
+  { id: 'all', label: 'Runtime Ops', description: 'workspace agents와 keeper runtime 행을 함께 보되 count surface는 분리합니다.' },
+  { id: 'agents', label: 'Workspace Agents', description: '/api/v1/agents workspace presence만 봅니다. keeper fiber나 task owner가 아닙니다.' },
+  { id: 'keepers', label: 'Keeper Runtime', description: 'keeper 실행 fiber, runtime detail row, configured keeper inventory를 봅니다.' },
+  { id: 'fsm', label: 'Keeper FSM', description: '키퍼 composite FSM lifecycle 상태를 봅니다.' },
 ]
 
 export function AgentsUnified() {
@@ -93,7 +93,7 @@ export function AgentsUnified() {
   })
   function chipCount(id: AgentsView): number | string | null {
     if (id === 'all') return formatRuntimeRosterCount(runtimeCounts)
-    if (id === 'agents') return `런타임 가동 ${runtimeCounts.live.agents}`
+    if (id === 'agents') return `workspace agents ${runtimeCounts.live.agents}`
     if (id === 'keepers') return formatKeeperRosterCount(runtimeCounts)
     return null
   }

--- a/dashboard/src/components/dashboard-shell.test.ts
+++ b/dashboard/src/components/dashboard-shell.test.ts
@@ -206,9 +206,9 @@ describe('dashboardHealthChips', () => {
       'execution-error',
     ])
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
-      .toBe('키퍼 런타임 가동 1 / 일시정지 1 / 설정 2')
+      .toBe('keeper 실행 fiber 1 / 일시정지 keeper 1 / configured keeper 2')
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
-      .toBe('런타임 가동=shell; 일시정지=재개 대기 lifecycle row; 오프라인=프로세스/하트비트 없음으로 기동 필요 row; 설정=shell keeper 설정.')
+      .toBe('keeper 실행 fiber=shell; 일시정지 keeper=재개 대기 lifecycle row; 오프라인 keeper=프로세스/하트비트 없음으로 기동 필요 row; configured keeper=shell keeper 설정.')
     expect(chips.find(chip => chip.key === 'paused-keepers')?.label)
       .toBe('일시정지 keeper 1')
     expect(chips.find(chip => chip.key === 'paused-keepers')?.detail)
@@ -321,9 +321,9 @@ describe('dashboardHealthChips', () => {
     })
 
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
-      .toBe('키퍼 런타임 가동 2 / 설정 16')
+      .toBe('keeper 실행 fiber 2 / configured keeper 16')
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
-      .toBe('런타임 가동=shell; 일시정지=재개 대기 lifecycle row; 오프라인=프로세스/하트비트 없음으로 기동 필요 row; 설정=project snapshot keeper 설정.')
+      .toBe('keeper 실행 fiber=shell; 일시정지 keeper=재개 대기 lifecycle row; 오프라인 keeper=프로세스/하트비트 없음으로 기동 필요 row; configured keeper=project snapshot keeper 설정.')
   })
 
   it('uses runtime health as the paused keeper count authority when detail rows are absent', () => {
@@ -353,9 +353,9 @@ describe('dashboardHealthChips', () => {
     })
 
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.label)
-      .toBe('키퍼 런타임 가동 0 / 일시정지 3 / 설정 13')
+      .toBe('keeper 실행 fiber 0 / 일시정지 keeper 3 / configured keeper 13')
     expect(chips.find(chip => chip.key === 'keeper-count-basis')?.detail)
-      .toBe('런타임 가동=runtime health; 일시정지=runtime health; 오프라인=runtime health only; execution offline rows not mixed; 설정=shell keeper 설정.')
+      .toBe('keeper 실행 fiber=runtime health; 일시정지 keeper=runtime health; 오프라인 keeper=runtime health only; execution offline rows not mixed; configured keeper=shell keeper 설정.')
     expect(chips.find(chip => chip.key === 'paused-keepers')?.label)
       .toBe('일시정지 keeper 3')
     expect(chips.find(chip => chip.key === 'no-keeper-rows')).toBeUndefined()

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -605,7 +605,7 @@ export function dashboardHealthChips(input: DashboardHealthInput): DashboardHeal
         offlineKeepers: runtimeCounts.live.offlineKeepers,
         configuredKeepers: configured,
       }),
-      detail: `런타임 가동=${runningCountSource}; 일시정지=${pausedCountSource}; 오프라인=${offlineCountSource}; 설정=${configuredCountSourceLabel(runtimeCounts.configured.source)} keeper 설정.`,
+      detail: `keeper 실행 fiber=${runningCountSource}; 일시정지 keeper=${pausedCountSource}; 오프라인 keeper=${offlineCountSource}; configured keeper=${configuredCountSourceLabel(runtimeCounts.configured.source)} keeper 설정.`,
       tone: 'muted',
     })
   }

--- a/dashboard/src/runtime-counts.test.ts
+++ b/dashboard/src/runtime-counts.test.ts
@@ -140,7 +140,7 @@ describe('resolveRuntimeCounts', () => {
   it('reports both 2 live and 16 configured keepers in the fluctuation scenario without picking a winner', () => {
     // Real-world reproduction: composite API returns 2 running fiber keepers
     // while .masc/keepers/ holds 16 persona registrations. Both must surface
-    // simultaneously so the UI can render "런타임 가동 2 / 설정 16" instead of swapping.
+    // simultaneously so the UI can render "keeper 실행 fiber 2 / configured keeper 16" instead of swapping.
     expect(resolveRuntimeCounts({
       executionLoaded: true,
       agentsCount: 0,
@@ -408,12 +408,12 @@ describe('keeperRowLooksRunning', () => {
 })
 
 describe('formatActiveOverConfigured', () => {
-  it('formats keeper counts as "런타임 가동 N / 설정 M"', () => {
+  it('formats keeper counts as separate running-fiber and configured-keeper surfaces', () => {
     const counts = {
       live: { agents: 0, keepers: 2, pausedKeepers: 0, offlineKeepers: 0, transientKeepers: 0, keeperRows: 2, tasks: 0, totalRuntimes: 2, available: true },
       configured: { keepers: 16, totalRuntimes: 16, source: 'namespace-truth' as const },
     }
-    expect(formatActiveOverConfigured(counts, 'keeper')).toBe('런타임 가동 2 / 설정 16')
+    expect(formatActiveOverConfigured(counts, 'keeper')).toBe('keeper 실행 fiber 2 / configured keeper 16')
   })
 
   it('includes paused count in keeper formatting when paused keepers exist', () => {
@@ -421,7 +421,7 @@ describe('formatActiveOverConfigured', () => {
       live: { agents: 0, keepers: 4, pausedKeepers: 3, offlineKeepers: 0, transientKeepers: 0, keeperRows: 7, tasks: 0, totalRuntimes: 4, available: true },
       configured: { keepers: 24, totalRuntimes: 24, source: 'namespace-truth' as const },
     }
-    expect(formatActiveOverConfigured(counts, 'keeper')).toBe('런타임 가동 4 / 일시정지 3 / 설정 24')
+    expect(formatActiveOverConfigured(counts, 'keeper')).toBe('keeper 실행 fiber 4 / 일시정지 keeper 3 / configured keeper 24')
   })
 
   it('includes transient keeper count in keeper formatting when transient keepers exist', () => {
@@ -430,15 +430,15 @@ describe('formatActiveOverConfigured', () => {
       configured: { keepers: 10, totalRuntimes: 10, source: 'namespace-truth' as const },
     }
     expect(formatActiveOverConfigured(counts, 'keeper'))
-      .toBe('런타임 가동 4 / 일시정지 1 / 전이 2 / 오프라인 3 / 설정 10')
+      .toBe('keeper 실행 fiber 4 / 일시정지 keeper 1 / 전이 keeper 2 / 오프라인 keeper 3 / configured keeper 10')
   })
 
-  it('formats runtime totals as "런타임 가동 N / 설정 M"', () => {
+  it('formats runtime totals without merging workspace agents into keeper fibers', () => {
     const counts = {
       live: { agents: 3, keepers: 2, pausedKeepers: 0, offlineKeepers: 0, transientKeepers: 0, keeperRows: 2, tasks: 0, totalRuntimes: 5, available: true },
       configured: { keepers: 16, totalRuntimes: 20, source: 'namespace-truth' as const },
     }
-    expect(formatActiveOverConfigured(counts, 'runtime')).toBe('런타임 가동 5 / 설정 20')
+    expect(formatActiveOverConfigured(counts, 'runtime')).toBe('keeper 실행 fiber 2 / workspace agents 3 / configured runtimes 20')
   })
 
   it('defaults kind to "keeper" when omitted', () => {
@@ -446,7 +446,7 @@ describe('formatActiveOverConfigured', () => {
       live: { agents: 0, keepers: 0, pausedKeepers: 0, offlineKeepers: 0, transientKeepers: 0, keeperRows: 0, tasks: 0, totalRuntimes: 0, available: false },
       configured: { keepers: 0, totalRuntimes: 0, source: 'none' as const },
     }
-    expect(formatActiveOverConfigured(counts)).toBe('런타임 가동 0 / 설정 0')
+    expect(formatActiveOverConfigured(counts)).toBe('keeper 실행 fiber 0 / configured keeper 0')
   })
 })
 
@@ -475,7 +475,7 @@ describe('runtime count role helpers', () => {
       liveKeepers: 4,
       pausedKeepers: 12,
       configuredKeepers: 16,
-    })).toBe('키퍼 런타임 가동 4 / 일시정지 12 / 설정 16')
+    })).toBe('keeper 실행 fiber 4 / 일시정지 keeper 12 / configured keeper 16')
   })
 
   it('formats transient keeper rows separately from offline inventory', () => {
@@ -485,7 +485,7 @@ describe('runtime count role helpers', () => {
       transientKeepers: 2,
       offlineKeepers: 3,
       configuredKeepers: 10,
-    })).toBe('키퍼 런타임 가동 4 / 일시정지 1 / 전이 2 / 오프라인 3 / 설정 10')
+    })).toBe('keeper 실행 fiber 4 / 일시정지 keeper 1 / 전이 keeper 2 / 오프라인 keeper 3 / configured keeper 10')
   })
 
   it('formats roster chips with transient rows visible in breakdowns', () => {
@@ -494,14 +494,14 @@ describe('runtime count role helpers', () => {
       configured: { keepers: 10, totalRuntimes: 10, source: 'namespace-truth' as const },
     }
     expect(formatKeeperRosterCount(transientCounts))
-      .toBe('상세 10 / 런타임 가동 4 / 일시정지 1 / 전이 2 / 오프라인 3 / 설정 10')
+      .toBe('keeper 행 10 / keeper 실행 fiber 4 / 일시정지 keeper 1 / 전이 keeper 2 / 오프라인 keeper 3 / configured keeper 10')
     expect(formatRuntimeRosterCount(transientCounts))
-      .toBe('상세 10 / 런타임 가동 4 / 전이 2 / 키퍼 설정 10')
+      .toBe('runtime 행 10 / keeper 실행 fiber 4 / workspace agents 0 / 일시정지 keeper 1 / 전이 keeper 2 / 오프라인 keeper 3 / configured keeper 10')
   })
 
   it('formats roster chips with detail rows, running runtimes, and configured inventory', () => {
-    expect(formatKeeperRosterCount(counts)).toBe('상세 16 / 런타임 가동 4 / 일시정지 12 / 설정 16')
-    expect(formatRuntimeRosterCount(counts)).toBe('상세 20 / 런타임 가동 8 / 키퍼 설정 16')
+    expect(formatKeeperRosterCount(counts)).toBe('keeper 행 16 / keeper 실행 fiber 4 / 일시정지 keeper 12 / configured keeper 16')
+    expect(formatRuntimeRosterCount(counts)).toBe('runtime 행 20 / keeper 실행 fiber 4 / workspace agents 4 / 일시정지 keeper 12 / configured keeper 16')
   })
 
   it('surfaces offline keeper detail rows separately from running capacity', () => {
@@ -511,8 +511,8 @@ describe('runtime count role helpers', () => {
     }
 
     expect(keeperDetailRows(splitCounts)).toBe(17)
-    expect(formatKeeperRosterCount(splitCounts)).toBe('상세 17 / 런타임 가동 2 / 일시정지 6 / 오프라인 9 / 설정 17')
-    expect(formatRuntimeRosterCount(splitCounts)).toBe('상세 17 / 런타임 가동 2 / 키퍼 설정 17')
+    expect(formatKeeperRosterCount(splitCounts)).toBe('keeper 행 17 / keeper 실행 fiber 2 / 일시정지 keeper 6 / 오프라인 keeper 9 / configured keeper 17')
+    expect(formatRuntimeRosterCount(splitCounts)).toBe('runtime 행 17 / keeper 실행 fiber 2 / workspace agents 0 / 일시정지 keeper 6 / 오프라인 keeper 9 / configured keeper 17')
   })
 
   it('formats command target sections as mission targets, not live runtime counts', () => {

--- a/dashboard/src/runtime-counts.ts
+++ b/dashboard/src/runtime-counts.ts
@@ -360,14 +360,18 @@ export function formatActiveOverConfigured(
     const transient = counts.live.transientKeepers
     const offline = counts.live.offlineKeepers
     const configured = counts.configured.keepers
-    const parts = [`런타임 가동 ${running}`]
-    if (paused > 0) parts.push(`일시정지 ${paused}`)
-    if (transient > 0) parts.push(`전이 ${transient}`)
-    if (offline > 0) parts.push(`오프라인 ${offline}`)
-    parts.push(`설정 ${configured}`)
+    const parts = [`keeper 실행 fiber ${running}`]
+    if (paused > 0) parts.push(`일시정지 keeper ${paused}`)
+    if (transient > 0) parts.push(`전이 keeper ${transient}`)
+    if (offline > 0) parts.push(`오프라인 keeper ${offline}`)
+    parts.push(`configured keeper ${configured}`)
     return parts.join(' / ')
   }
-  return `런타임 가동 ${counts.live.totalRuntimes} / 설정 ${counts.configured.totalRuntimes}`
+  return [
+    `keeper 실행 fiber ${counts.live.keepers}`,
+    `workspace agents ${counts.live.agents}`,
+    `configured runtimes ${counts.configured.totalRuntimes}`,
+  ].join(' / ')
 }
 
 export function keeperDetailRows(counts: Pick<RuntimeCounts, 'live'>): number {
@@ -393,37 +397,40 @@ export function formatKeeperCountBreakdown({
   offlineKeepers = 0,
   configuredKeepers,
 }: KeeperCountBreakdownInput): string {
-  const parts = [`키퍼 런타임 가동 ${normalizeCount(liveKeepers)}`]
+  const parts = [`keeper 실행 fiber ${normalizeCount(liveKeepers)}`]
   const paused = normalizeCount(pausedKeepers)
   const transient = normalizeCount(transientKeepers)
   const offline = normalizeCount(offlineKeepers)
-  if (paused > 0) parts.push(`일시정지 ${paused}`)
-  if (transient > 0) parts.push(`전이 ${transient}`)
-  if (offline > 0) parts.push(`오프라인 ${offline}`)
-  parts.push(`설정 ${normalizeCount(configuredKeepers)}`)
+  if (paused > 0) parts.push(`일시정지 keeper ${paused}`)
+  if (transient > 0) parts.push(`전이 keeper ${transient}`)
+  if (offline > 0) parts.push(`오프라인 keeper ${offline}`)
+  parts.push(`configured keeper ${normalizeCount(configuredKeepers)}`)
   return parts.join(' / ')
 }
 
 export function formatKeeperRosterCount(counts: Pick<RuntimeCounts, 'live' | 'configured'>): string {
   return [
-    `상세 ${keeperDetailRows(counts)}`,
+    `keeper 행 ${keeperDetailRows(counts)}`,
     formatKeeperCountBreakdown({
       liveKeepers: counts.live.keepers,
       pausedKeepers: counts.live.pausedKeepers,
       transientKeepers: counts.live.transientKeepers,
       offlineKeepers: counts.live.offlineKeepers,
       configuredKeepers: counts.configured.keepers,
-    }).replace(/^키퍼 /, ''),
+    }),
   ].join(' / ')
 }
 
 export function formatRuntimeRosterCount(counts: Pick<RuntimeCounts, 'live' | 'configured'>): string {
   const parts = [
-    `상세 ${runtimeDetailRows(counts)}`,
-    `런타임 가동 ${counts.live.totalRuntimes}`,
+    `runtime 행 ${runtimeDetailRows(counts)}`,
+    `keeper 실행 fiber ${counts.live.keepers}`,
+    `workspace agents ${counts.live.agents}`,
   ]
-  if (counts.live.transientKeepers > 0) parts.push(`전이 ${counts.live.transientKeepers}`)
-  parts.push(`키퍼 설정 ${counts.configured.keepers}`)
+  if (counts.live.pausedKeepers > 0) parts.push(`일시정지 keeper ${counts.live.pausedKeepers}`)
+  if (counts.live.transientKeepers > 0) parts.push(`전이 keeper ${counts.live.transientKeepers}`)
+  if (counts.live.offlineKeepers > 0) parts.push(`오프라인 keeper ${counts.live.offlineKeepers}`)
+  parts.push(`configured keeper ${counts.configured.keepers}`)
   return parts.join(' / ')
 }
 


### PR DESCRIPTION
## Summary

- Clarify dashboard copy so workspace agents, keeper runtime fibers, configured keepers, and task owners are not presented as the same namespace.
- Update fleet chips, roster health pills, dashboard health chips, search/empty-state text, and runtime count formatters to name each surface explicitly.
- Remove a duplicate keeper attention label key that blocked dashboard typechecking.

## Why

The fleet page previously used generic agent/runtime labels for several different data surfaces. That made `/api/v1/agents` presence, keeper execution fibers, configured keeper inventory, and task ownership look interchangeable even when they disagree.

## Validation

- `vitest run src/runtime-counts.test.ts src/components/agents-unified.test.ts src/components/agent-roster.test.ts src/components/dashboard-shell.test.ts src/lib/keeper-attention-labels.test.ts src/lib/keeper-attention-labels.drift.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `tsc --noEmit --pretty false`
- `eslint src`
- `git diff --check`
- Playwright desktop/mobile render probe for `/dashboard/#monitoring?section=agents` with required copy present and zero console errors
- CI Dashboard initially failed on stale `dashboard-shell.test.ts` expectations; updated and re-pushed in `30f067f`