### PR TITLE
fix(board): treat null sources as omitted

### DIFF
--- a/lib/board_tool_adapter/board_tool_format.ml
+++ b/lib/board_tool_adapter/board_tool_format.ml
@@ -490,12 +490,13 @@ let source_entries_arg args =
        | _ -> None)
     | _ -> None
   in
-  match Option.value ~default:(`Null) (Json_util.assoc_member_opt "sources" args) with
-  | `List values ->
+  match Json_util.assoc_member_opt "sources" args with
+  | None | Some `Null -> None
+  | Some (`List values) ->
     (match List.filter_map source_entry values with
      | [] -> None
      | entries -> Some entries)
-  | `Assoc fields ->
+  | Some (`Assoc fields) ->
     (* Single Assoc sent instead of a List — wrap it. *)
     (match source_entry (`Assoc fields) with
      | Some entry ->
@@ -503,7 +504,7 @@ let source_entries_arg args =
          "source_entries_arg: wrapped single Assoc into List for sources";
        Some [ entry ]
      | None -> None)
-  | other ->
+  | Some other ->
     Log.BoardLog.warn
       "source_entries_arg: ignoring non-List/non-Object sources: %s"
       (Json_util.kind_name other);

--- a/test/test_yojson_type_error_board.ml
+++ b/test/test_yojson_type_error_board.ml
@@ -29,7 +29,7 @@ let test_source_entries_non_list_returns_none () =
   check (option (list yojson)) "non-list sources return None" None result
 
 let test_source_entries_null_returns_none () =
-  (* "sources" is null instead of a list *)
+  (* "sources" is null: treat it as an omitted optional field. *)
   let args = args_of_list [ "sources", `Null ] in
   let result = Board_tool_format.source_entries_arg args in
   check (option (list yojson)) "null sources return None" None result


### PR DESCRIPTION
## Summary
- Treat absent or null board post `sources` as omitted optional evidence instead of malformed input.
- Keep warnings for non-null wrong shapes, and keep single-object compatibility wrapping.
- Update the boundary test comment to document the null-as-omitted contract.

## Evidence
- Runtime logs since 2026-06-27T12:00:00Z showed 64 repeated WARN lines: `source_entries_arg: ignoring non-List/non-Object sources: null`.
- Local checks: `ocamlformat --check lib/board_tool_adapter/board_tool_format.ml test/test_yojson_type_error_board.ml`; `git diff --check`; `git diff --cached --check`.
- Full build/test left to GitHub CI per repo workflow.