### PR TITLE
Fix keeper identity drift for autoboot-disabled keepers

### DIFF
--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -533,9 +533,15 @@ let string_set_of_list values =
 
 let json_string_list values = Json_util.json_string_list values
 
-let configured_keeper_is_materializable name =
+let configured_keeper_is_materializable config name =
+  Keeper_meta_store.declarative_autoboot_enabled_by_default config name
+  &&
   try
-    let defaults = Keeper_types_profile.load_keeper_profile_defaults name in
+    let defaults =
+      Keeper_types_profile.load_keeper_profile_defaults_for_base_path
+        ~base_path:config.Workspace.base_path
+        name
+    in
     (* Exclude loader-only TOMLs such as base.toml from identity drift. *)
     Option.is_some defaults.persona_name
     || Option.is_some defaults.goal
@@ -553,7 +559,7 @@ let keeper_identity_drift_scan config =
   in
   let materializable_configured_names =
     configured_names
-    |> List.filter configured_keeper_is_materializable
+    |> List.filter (configured_keeper_is_materializable config)
     |> sorted_unique_strings
   in
   let configured_set = string_set_of_list materializable_configured_names in

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -562,7 +562,7 @@ let keeper_identity_drift_scan config =
     |> List.filter (configured_keeper_is_materializable config)
     |> sorted_unique_strings
   in
-  let configured_set = string_set_of_list materializable_configured_names in
+  let configured_set = string_set_of_list configured_names in
   let persisted_set = string_set_of_list persisted_meta_names in
   {
     configured_names;

--- a/lib/server/server_routes_http_runtime_fleet_scan.mli
+++ b/lib/server/server_routes_http_runtime_fleet_scan.mli
@@ -65,7 +65,7 @@ val sort_paused_keeper_details :
 val keeper_fleet_meta_scan :
   ?include_paused_details:bool ->
   Workspace.config -> keeper_fleet_meta_scan
-val configured_keeper_is_materializable : string -> bool
+val configured_keeper_is_materializable : Workspace.config -> string -> bool
 val keeper_identity_drift_scan : Workspace.config -> keeper_identity_drift_scan
 val keeper_identity_drift_health_json_of_scan :
   keeper_identity_drift_scan -> Yojson.Safe.t

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1317,6 +1317,9 @@ let test_keeper_identity_drift_health_json_surfaces_config_meta_split () =
     let config_root = make_config_root dir in
     Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
     write_config_root_keeper_toml config_root "mad-improver";
+    write_file
+      (Filename.concat (Filename.concat config_root "keepers") "operator.toml")
+      "[keeper]\ngoal = \"operator\"\nautoboot_enabled = false\n";
     with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
     let previous_state = !Server_auth.server_state in
     Config_dir_resolver.reset ();
@@ -1346,6 +1349,10 @@ let test_keeper_identity_drift_health_json_surfaces_config_meta_split () =
           (json |> member "terminal_reason" |> to_string);
         Alcotest.(check bool) "drift asks operator action" true
           (json |> member "operator_action_required" |> to_bool);
+        Alcotest.(check (list string)) "configured names include disabled keepers"
+          [ "mad-improver"; "operator" ]
+          (json |> member "configured_keeper_names" |> to_list
+           |> List.map to_string);
         Alcotest.(check (list string)) "materializable configured names"
           [ "mad-improver" ]
           (json |> member "materializable_configured_keeper_names" |> to_list

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1333,6 +1333,8 @@ let test_keeper_identity_drift_health_json_surfaces_config_meta_split () =
         let config = Mcp_server.workspace_config state in
         write_keeper_meta_exn config
           (make_keeper_meta ~name:"masc-improver" ~trace_id:"trace-masc-improver" ());
+        write_keeper_meta_exn config
+          (make_keeper_meta ~name:"operator" ~trace_id:"trace-operator" ());
         let json =
           Server_routes_http_runtime_fleet_scan.keeper_identity_drift_health_json
             config
@@ -1357,6 +1359,9 @@ let test_keeper_identity_drift_health_json_surfaces_config_meta_split () =
           [ "mad-improver" ]
           (json |> member "materializable_configured_keeper_names" |> to_list
            |> List.map to_string);
+        Alcotest.(check (list string)) "persisted meta includes disabled keeper"
+          [ "masc-improver"; "operator" ]
+          (json |> member "persisted_meta_names" |> to_list |> List.map to_string);
         Alcotest.(check (list string)) "configured without meta"
           [ "mad-improver" ]
           (json |> member "configured_without_meta_names" |> to_list


### PR DESCRIPTION
## Summary
- exclude `autoboot_enabled=false` keeper TOMLs from identity-drift materialization pressure
- keep stale-meta detection based on all configured keeper TOMLs, so disabled keepers with persisted meta are not misreported as missing TOML
- extend the health JSON drift test so disabled keepers remain configured but do not require runtime meta

Fixes #22580

## Stack status
- stacked on #22596 (`codex/export-librarian-fallback-claim`)
- rebased after #22598/#22600 moved the interface exports to `main`; this branch now contains only the fleet-scan changes over the updated #22596 base

## Verification
- `ocamlformat --check lib/server/server_routes_http_runtime_fleet_scan.ml lib/server/server_routes_http_runtime_fleet_scan.mli test/test_server_runtime_bootstrap.ml`
- `git diff --check origin/codex/export-librarian-fallback-claim...HEAD`
- `rg -n "legacy_unstructured_fallback_claim|stop_reason_is_turn_budget_exhausted" lib/keeper/*.mli` confirmed no duplicated interface declarations

Full OCaml build remains CI authority per current workflow.