### PR TITLE
Ignore credentialed external task owners in fleet safety

### DIFF
--- a/lib/keeper/keeper_identity.ml
+++ b/lib/keeper/keeper_identity.ml
@@ -75,6 +75,12 @@ let canonical_keeper_name_from_agent_name agent_name =
       else
         None
 
+let is_keeper_principal_agent_name agent_name =
+  let trimmed = String.trim agent_name in
+  is_keeper_agent_alias trimmed
+  || (Nickname.is_dictionary_generated_nickname trimmed
+      && Option.is_some (canonical_keeper_name_from_agent_name trimmed))
+
 (** Phase A F5 (2026-04-27): single source of truth for the
     ["keeper-<name>"] prefix pattern.  Two call sites used to embed
     [String.sub trimmed 0 7 = "keeper-"] manually; both now go through

--- a/lib/keeper/keeper_identity.mli
+++ b/lib/keeper/keeper_identity.mli
@@ -9,6 +9,12 @@ val generate_trace_id : ?now:float -> unit -> string
 val keeper_name_from_agent_name : string -> string option
 val is_keeper_agent_alias : string -> bool
 val canonical_keeper_name_from_agent_name : string -> string option
+val is_keeper_principal_agent_name : string -> bool
+(** [is_keeper_principal_agent_name name] returns true for task-owner
+    principals that should be treated as keeper-owned work: canonical
+    [keeper-<name>-agent] aliases and dictionary-generated keeper nicknames.
+    It intentionally rejects arbitrary three-part client names such as
+    [codex-mcp-client]. *)
 val canonical_keeper_name : string -> string option
 
 val strip_keeper_prefix : string -> string option

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -826,8 +826,9 @@ let phase_supports_crash_log_failure_reason = function
       false
 
 let active_task_owner_fiber_scan_semantics =
-  "reports active task owners without executable keeper fibers; disabled \
-   keepers are excluded; matching rows can degrade fleet status"
+  "reports active keeper task owners without executable keeper fibers; disabled \
+   keepers and credentialed non-keeper external clients are excluded; matching \
+   rows can degrade fleet status"
 
 let paused_keeper_last_blocker_json paused_keepers_json name =
   match paused_keepers_json with
@@ -1139,6 +1140,13 @@ let keeper_names_for_agent agent_bindings assignee =
        if String.equal agent_name assignee then Some keeper_name else None)
   |> sorted_unique_strings
 
+let is_credentialed_external_client config assignee =
+  (not (Keeper_identity.is_keeper_agent_alias assignee))
+  &&
+  match Auth.load_credential config.Workspace_utils_backend_setup.base_path assignee with
+  | Some _ -> true
+  | None -> false
+
 let active_task_owner_fiber_scan config ~executable_names =
   let executable_set = string_set_of_list executable_names in
   let binding_scan = keeper_agent_bindings config in
@@ -1166,6 +1174,9 @@ let active_task_owner_fiber_scan config ~executable_names =
                  then []
                  else (
                    match keeper_names with
+                   | []
+                     when is_credentialed_external_client config assignee ->
+                       []
                    | []
                      when List.mem assignee binding_scan.disabled_agent_names
                           || meta_read_errors <> [] ->

--- a/lib/server/server_routes_http_runtime_fleet_scan.ml
+++ b/lib/server/server_routes_http_runtime_fleet_scan.ml
@@ -826,9 +826,10 @@ let phase_supports_crash_log_failure_reason = function
       false
 
 let active_task_owner_fiber_scan_semantics =
-  "reports active keeper task owners without executable keeper fibers; disabled \
-   keepers and credentialed non-keeper external clients are excluded; matching \
-   rows can degrade fleet status"
+  "reports keeper-shaped active task owners without executable keeper fibers; \
+   disabled keepers are excluded; matching keeper rows can degrade fleet \
+   status; credentialed non-keeper client task owners are reported separately \
+   as advisory rows"
 
 let paused_keeper_last_blocker_json paused_keepers_json name =
   match paused_keepers_json with
@@ -1044,15 +1045,23 @@ type active_task_owner_without_executable_fiber = {
   task_status : string;
 }
 
+type non_keeper_active_task_owner = {
+  agent_name : string;
+  task_id : string;
+  task_status : string;
+}
+
 type active_task_owner_fiber_scan = {
   active_task_owner_without_executable_fibers :
     active_task_owner_without_executable_fiber list;
+  non_keeper_active_task_owners : non_keeper_active_task_owner list;
   active_task_owner_scan_errors : (string * string) list;
 }
 
 let empty_active_task_owner_fiber_scan =
   {
     active_task_owner_without_executable_fibers = [];
+    non_keeper_active_task_owners = [];
     active_task_owner_scan_errors = [];
   }
 
@@ -1067,6 +1076,10 @@ let compare_active_task_owner_without_executable_fiber left right =
     let cmp = String.compare left.agent_name right.agent_name in
     if cmp <> 0 then cmp
     else String.compare left.task_id right.task_id
+
+let compare_non_keeper_active_task_owner left right =
+  let cmp = String.compare left.agent_name right.agent_name in
+  if cmp <> 0 then cmp else String.compare left.task_id right.task_id
 
 let active_task_assignment (task : Masc_domain.task) =
   Masc_domain.task_assignee_of_status task.task_status
@@ -1089,6 +1102,17 @@ let active_task_owner_without_executable_fiber_json row =
       ("task_status", `String row.task_status);
       ("executable", `Bool false);
       ("action", `String action);
+    ]
+
+let non_keeper_active_task_owner_json row =
+  `Assoc
+    [
+      ("agent_name", `String row.agent_name);
+      ("task_id", `String row.task_id);
+      ("task_status", `String row.task_status);
+      ("owner_kind", `String "non_keeper_client");
+      ("fleet_blocking", `Bool false);
+      ("action", `String "track_client_task_or_release_when_done");
     ]
 
 type keeper_agent_binding_scan = {
@@ -1141,7 +1165,7 @@ let keeper_names_for_agent agent_bindings assignee =
   |> sorted_unique_strings
 
 let is_credentialed_external_client config assignee =
-  (not (Keeper_identity.is_keeper_agent_alias assignee))
+  (not (Keeper_identity.is_keeper_principal_agent_name assignee))
   &&
   match Auth.load_credential config.Workspace_utils_backend_setup.base_path assignee with
   | Some _ -> true
@@ -1156,54 +1180,73 @@ let active_task_owner_fiber_scan config ~executable_names =
   | Error err ->
       {
         active_task_owner_without_executable_fibers = [];
+        non_keeper_active_task_owners = [];
         active_task_owner_scan_errors =
           ("backlog", err) :: meta_read_errors;
       }
   | Ok backlog ->
-      let rows =
+      let blocking_rows, non_keeper_rows =
         backlog.tasks
-        |> List.map (fun task ->
+        |> List.fold_left
+             (fun (blocking_rows, non_keeper_rows) task ->
              match active_task_assignment task with
-             | None -> []
+             | None -> (blocking_rows, non_keeper_rows)
              | Some (assignee, task_status) ->
                  let keeper_names = keeper_names_for_agent agent_bindings assignee in
                  if
                    List.exists
                      (fun keeper_name -> String_set.mem keeper_name executable_set)
                      keeper_names
-                 then []
+                 then (blocking_rows, non_keeper_rows)
                  else (
                    match keeper_names with
                    | []
                      when is_credentialed_external_client config assignee ->
-                       []
+                       ( blocking_rows
+                       , {
+                           agent_name = assignee;
+                           task_id = task.id;
+                           task_status;
+                         }
+                         :: non_keeper_rows )
                    | []
                      when List.mem assignee binding_scan.disabled_agent_names
                           || meta_read_errors <> [] ->
-                       []
+                       (blocking_rows, non_keeper_rows)
                    | [] ->
-                       [
-                         {
+                       ( {
                            keeper_name = None;
                            agent_name = assignee;
                            task_id = task.id;
                            task_status;
-                         };
-                       ]
+                         }
+                         :: blocking_rows
+                       , non_keeper_rows )
                    | keeper_names ->
-                       keeper_names
-                       |> List.map (fun keeper_name ->
-                             {
-                               keeper_name = Some keeper_name;
-                               agent_name = assignee;
-                               task_id = task.id;
-                               task_status;
-                            })))
-        |> List.concat
+                       ( keeper_names
+                         |> List.fold_left
+                              (fun rows keeper_name ->
+                                {
+                                  keeper_name = Some keeper_name;
+                                  agent_name = assignee;
+                                  task_id = task.id;
+                                  task_status;
+                                }
+                                :: rows)
+                              blocking_rows
+                       , non_keeper_rows )))
+             ([], [])
+      in
+      let rows =
+        blocking_rows
         |> List.sort_uniq compare_active_task_owner_without_executable_fiber
+      in
+      let non_keeper_rows =
+        non_keeper_rows |> List.sort_uniq compare_non_keeper_active_task_owner
       in
       {
         active_task_owner_without_executable_fibers = rows;
+        non_keeper_active_task_owners = non_keeper_rows;
         active_task_owner_scan_errors = meta_read_errors;
       }
 
@@ -1311,6 +1354,9 @@ let keeper_fleet_safety_health_json
   in
   let active_task_owner_without_executable_fiber_count =
     List.length active_task_owner_scan.active_task_owner_without_executable_fibers
+  in
+  let non_keeper_active_task_owner_count =
+    List.length active_task_owner_scan.non_keeper_active_task_owners
   in
   let active_task_owner_without_executable_fiber =
     active_task_owner_without_executable_fiber_count > 0
@@ -1495,6 +1541,17 @@ let keeper_fleet_safety_health_json
           (List.map
              active_task_owner_without_executable_fiber_json
              active_task_owner_scan.active_task_owner_without_executable_fibers) )
+    ; ( "non_keeper_active_task_owner_count"
+      , `Int non_keeper_active_task_owner_count )
+    ; ( "non_keeper_active_task_owners"
+      , `List
+          (List.map
+             non_keeper_active_task_owner_json
+             active_task_owner_scan.non_keeper_active_task_owners) )
+    ; ( "non_keeper_active_task_owner_semantics"
+      , `String
+          "active tasks owned by credentialed non-keeper clients; visible for \
+           operators but not keeper fleet blockers" )
     ; ( "active_task_owner_fiber_scan_semantics"
       , `String active_task_owner_fiber_scan_semantics )
     ; ( "active_task_owner_scan_error_count"

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1683,7 +1683,7 @@ let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
         Alcotest.(check bool) "health asks operator action" true
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
-let test_health_json_ignores_non_keeper_active_task_owner_without_binding () =
+let test_health_json_reports_non_keeper_active_task_owner_as_advisory () =
   with_temp_dir "health-non-keeper-active-task-owner" (fun dir ->
     let config_root = make_config_root dir in
     Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
@@ -1729,14 +1729,29 @@ let test_health_json_ignores_non_keeper_active_task_owner_without_binding () =
           (fleet_safety |> member "status" |> to_string);
         Alcotest.(check (option string)) "health has no blocker" None
           (fleet_safety |> member "blocker" |> to_string_option);
-        Alcotest.(check bool) "health does not expose external client owner" false
+        Alcotest.(check bool) "external client owner is not a keeper blocker" false
           (fleet_safety
            |> member "active_task_owner_without_executable_fiber"
            |> to_bool);
-        Alcotest.(check int) "health exposes no external client owner rows" 0
+        Alcotest.(check int) "health exposes no blocking owner rows" 0
           (fleet_safety
            |> member "active_task_owner_without_executable_fiber_count"
            |> to_int);
+        Alcotest.(check int) "health exposes one advisory owner row" 1
+          (fleet_safety |> member "non_keeper_active_task_owner_count" |> to_int);
+        let owners =
+          fleet_safety |> member "non_keeper_active_task_owners" |> to_list
+        in
+        Alcotest.(check int) "one advisory owner row" 1 (List.length owners);
+        let owner = List.hd owners in
+        Alcotest.(check string) "advisory row agent" assignee
+          (owner |> member "agent_name" |> to_string);
+        Alcotest.(check string) "advisory row task id" "task-external-owner"
+          (owner |> member "task_id" |> to_string);
+        Alcotest.(check string) "advisory row owner kind" "non_keeper_client"
+          (owner |> member "owner_kind" |> to_string);
+        Alcotest.(check bool) "advisory row does not block fleet" false
+          (owner |> member "fleet_blocking" |> to_bool);
         Alcotest.(check (list string)) "health has no blocked keeper names"
           []
           (fleet_safety |> member "blocked_keeper_names" |> to_list
@@ -4139,9 +4154,9 @@ let () =
             `Quick
             test_health_json_degrades_on_active_task_owner_without_keeper_binding;
           Alcotest.test_case
-            "health json ignores non-keeper active task owner without binding"
+            "health json reports non-keeper active task owner as advisory"
             `Quick
-            test_health_json_ignores_non_keeper_active_task_owner_without_binding;
+            test_health_json_reports_non_keeper_active_task_owner_as_advisory;
           Alcotest.test_case
             "health json preserves active task owner meta read error"
             `Quick

--- a/test/test_server_runtime_bootstrap.ml
+++ b/test/test_server_runtime_bootstrap.ml
@@ -1683,6 +1683,67 @@ let test_health_json_degrades_on_active_task_owner_without_keeper_binding () =
         Alcotest.(check bool) "health asks operator action" true
           (fleet_safety |> member "operator_action_required" |> to_bool)))
 
+let test_health_json_ignores_non_keeper_active_task_owner_without_binding () =
+  with_temp_dir "health-non-keeper-active-task-owner" (fun dir ->
+    let config_root = make_config_root dir in
+    Sys.remove (Filename.concat (Filename.concat config_root "keepers") "example.toml");
+    with_env "MASC_CONFIG_DIR" (Some config_root) @@ fun () ->
+    let previous_state = !Server_auth.server_state in
+    Config_dir_resolver.reset ();
+    Fun.protect
+      ~finally:(fun () ->
+        Server_auth.server_state := previous_state;
+        Config_dir_resolver.reset ())
+      (fun () ->
+        let state = Mcp_server.create_state ~base_path:dir in
+        Server_auth.server_state := Some state;
+        let config = Mcp_server.workspace_config state in
+        let assignee = "codex-mcp-client" in
+        (match
+           Auth.save_raw_token_credential
+             config.Workspace_utils_backend_setup.base_path
+             ~agent_name:assignee ~role:Masc_domain.Worker
+             ~raw_token:"codex-mcp-client-token"
+         with
+        | Ok _ -> ()
+        | Error err ->
+            Alcotest.failf "failed to seed external client credential: %s"
+              (Masc_domain.masc_error_to_string err));
+        let task =
+          make_task
+            ~id:"task-external-owner"
+            ~title:"External client-owned task"
+            ~status:
+              (Types.InProgress
+                 { assignee; started_at = "2026-06-26T00:00:01Z" })
+            ()
+        in
+        Workspace.write_backlog config
+          { Types.tasks = [ task ]; last_updated = "2026-06-26T00:00:02Z"; version = 2 };
+        let request = Httpun.Request.create `GET "/health" in
+        let json = Server_routes_http_runtime.make_health_json request in
+        let open Yojson.Safe.Util in
+        let fleet_safety = json |> member "keeper_fleet_safety" in
+        Alcotest.(check string) "health ignores external client task owner"
+          "ok"
+          (fleet_safety |> member "status" |> to_string);
+        Alcotest.(check (option string)) "health has no blocker" None
+          (fleet_safety |> member "blocker" |> to_string_option);
+        Alcotest.(check bool) "health does not expose external client owner" false
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber"
+           |> to_bool);
+        Alcotest.(check int) "health exposes no external client owner rows" 0
+          (fleet_safety
+           |> member "active_task_owner_without_executable_fiber_count"
+           |> to_int);
+        Alcotest.(check (list string)) "health has no blocked keeper names"
+          []
+          (fleet_safety |> member "blocked_keeper_names" |> to_list
+           |> List.map to_string);
+        Alcotest.(check bool) "health does not ask operator action" false
+          (fleet_safety |> member "operator_action_required" |> to_bool)))
+
 let test_health_json_preserves_active_task_owner_meta_read_error () =
   with_temp_dir "health-active-task-owner-meta-read-error" (fun dir ->
     let config_root = make_config_root dir in
@@ -4077,6 +4138,10 @@ let () =
             "health json degrades on active task owner without keeper binding"
             `Quick
             test_health_json_degrades_on_active_task_owner_without_keeper_binding;
+          Alcotest.test_case
+            "health json ignores non-keeper active task owner without binding"
+            `Quick
+            test_health_json_ignores_non_keeper_active_task_owner_without_binding;
           Alcotest.test_case
             "health json preserves active task owner meta read error"
             `Quick


### PR DESCRIPTION
## Summary
- exclude credentialed non-keeper external clients from active-task-owner keeper-fiber blockers
- keep real keeper task owners without executable fibers degraded
- add health JSON regression coverage for `codex-mcp-client` token credentials

Fixes #22587

## Verification
- `ocamlformat --check lib/server/server_routes_http_runtime_fleet_scan.ml test/test_server_runtime_bootstrap.ml`
- `git diff --check HEAD~1..HEAD`
- `scripts/dune-local.sh build test/test_server_runtime_bootstrap.exe` could not run locally because `scripts/dune-local.sh` detected an unrelated bare `dune build @fmt --root .` process (PID 75646); build verification is left to CI per current workflow.