### PR TITLE
fix(keeper): retry heartbeat presence meta writes

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop_presence.ml
+++ b/lib/keeper/keeper_heartbeat_loop_presence.ml
@@ -152,7 +152,12 @@ let sync_keeper_presence
       ~labels:[ "keeper", meta_current.name ]
       ();
     note_turn_failures_preserved_after_heartbeat ~ctx ~meta:meta_current;
-    match write_meta ctx.config synced with
+    match
+      write_meta_with_merge
+        ~merge:Keeper_meta_merge.heartbeat_fields_from_disk
+        ctx.config
+        synced
+    with
     | Ok () -> synced
     | Error e ->
       Otel_metric_store.inc_counter

--- a/test/test_keeper_pause_silent_failure_source.ml
+++ b/test/test_keeper_pause_silent_failure_source.ml
@@ -32,6 +32,7 @@ let target_files =
 
 let status_detail_file = "lib/keeper/keeper_status_detail.ml"
 let keeper_up_update_file = "lib/keeper/keeper_turn_up_update.ml"
+let heartbeat_presence_file = "lib/keeper/keeper_heartbeat_loop_presence.ml"
 
 let metric_name = "Keeper_metrics.(to_string PausedStatePersistErrors)"
 
@@ -305,6 +306,18 @@ let test_keeper_status_disposition_mirrors_runtime_trust () =
        src
     >= 1)
 
+let test_heartbeat_presence_uses_cas_retry_merge () =
+  let src = load_source heartbeat_presence_file in
+  check bool "heartbeat presence uses CAS retry writer" true
+    (count_occurrences ~needle:"write_meta_with_merge" src >= 1);
+  check bool "heartbeat presence preserves disk-owned heartbeat fields" true
+    (count_occurrences
+       ~needle:"Keeper_meta_merge.heartbeat_fields_from_disk"
+       src
+     >= 1);
+  check int "plain heartbeat write_meta call removed" 0
+    (count_occurrences ~needle:"match write_meta ctx.config synced" src)
+
 let () =
   run "keeper_pause_silent_failure_source"
     [ ( "issue-8391-high-1"
@@ -331,5 +344,7 @@ let () =
             test_bulk_directive_partial_failure_observable
         ; test_case "keeper status mirrors runtime-trust disposition" `Quick
             test_keeper_status_disposition_mirrors_runtime_trust
+        ; test_case "heartbeat presence uses CAS retry merge" `Quick
+            test_heartbeat_presence_uses_cas_retry_merge
         ] )
     ]


### PR DESCRIPTION
## Summary
- route heartbeat presence meta writes through `write_meta_with_merge`
- use the existing `Keeper_meta_merge.heartbeat_fields_from_disk` merge so heartbeat writes retry CAS conflicts without stealing disk-owned pause/runtime fields
- add a structural guard covering the presence-sync writer

## Root Cause
Current runtime logs showed:

`write_meta failed (heartbeat): meta version conflict for executor: expected 31760, disk has 31758`

`sync_keeper_presence` still used plain `write_meta`, even though adjacent turn/heartbeat writers already use `write_meta_with_merge ~merge:Keeper_meta_merge.heartbeat_fields_from_disk`. A transient heartbeat CAS conflict should use the existing field-level retry path instead of surfacing as a failed heartbeat write.

## Validation
- `ocamlformat --check lib/keeper/keeper_heartbeat_loop_presence.ml test/test_keeper_pause_silent_failure_source.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_pause_silent_failure_source.exe` was attempted but refused because bare Dune processes are already holding the shared Dune lane:
  - `64408 64393 dune build --root . --no-print-directory`
  - `75646 61767 dune build @fmt --root .`

Per repo workflow for this machine, CI is the build authority rather than overriding shared local Dune contention.
