### PR TITLE
fix(dashboard): avoid goal-loop refresh timeout clamp

### DIFF
--- a/lib/server/server_dashboard_http_goal_loop_broadcast.ml
+++ b/lib/server/server_dashboard_http_goal_loop_broadcast.ml
@@ -28,6 +28,7 @@ let goal_loop_broadcast_event_type = "goal_loop_status"
    TTL cache ([Dashboard_goal_loop.goal_loop_cache_ttl_s]); a shorter tick
    would only re-read the same cached value. *)
 let goal_loop_broadcast_interval_s = 5.0
+let goal_loop_broadcast_timeout_s = goal_loop_broadcast_interval_s *. 0.8
 
 (* Per-write volatiles excluded from the change fingerprint. The Python
    writer stamps a fresh [generated_at] on every write (and the OCaml read
@@ -94,9 +95,11 @@ let start_goal_loop_refresh_loop ~state ~sw ~clock =
   Proactive_refresh.start
     ~sw
     ~clock
-    ~config:
-      (Proactive_refresh.default_config
-         ~label:"goal_loop_status"
-         ~interval_s:goal_loop_broadcast_interval_s)
+	~config:
+	  { (Proactive_refresh.default_config
+	       ~label:"goal_loop_status"
+	       ~interval_s:goal_loop_broadcast_interval_s) with
+	    timeout_s = goal_loop_broadcast_timeout_s
+	  }
     ~compute:(fun () -> goal_loop_status_for_state state)
     ~on_result:(fun status -> ignore (broadcast_goal_loop_status status))

--- a/lib/server/server_dashboard_http_goal_loop_broadcast.mli
+++ b/lib/server/server_dashboard_http_goal_loop_broadcast.mli
@@ -20,6 +20,14 @@ val goal_loop_broadcast_event_type : string
     [dashboard_slice_for_sse_type] bridge entry in [Server_mcp_transport_ws]
     that maps it onto the "goals" slice. *)
 
+val goal_loop_broadcast_interval_s : float
+(** Periodic refresh interval for the goal-loop status broadcast. *)
+
+val goal_loop_broadcast_timeout_s : float
+(** Per-refresh compute timeout. Must stay below
+    {!goal_loop_broadcast_interval_s} so {!Proactive_refresh.start} does not
+    clamp and warn on startup. *)
+
 val goal_loop_snapshot_event : Yojson.Safe.t -> Yojson.Safe.t
 (** [goal_loop_snapshot_event status] wraps [status] in the SSE envelope
     ([type] / [payload] / [ts_unix]) that {!broadcast_goal_loop_status} emits.

--- a/test/test_goal_loop_broadcast.ml
+++ b/test/test_goal_loop_broadcast.ml
@@ -38,6 +38,13 @@ let test_event_shape () =
         "event carries payload" true (List.mem_assoc "payload" fields)
   | _ -> Alcotest.fail "event must be a JSON object"
 
+let test_refresh_timeout_below_interval () =
+  Alcotest.(check bool)
+    "timeout stays below interval to avoid Proactive_refresh clamp"
+    true
+    (Broadcast.goal_loop_broadcast_timeout_s
+     < Broadcast.goal_loop_broadcast_interval_s)
+
 let drain session_id =
   let rec loop n =
     match Sse.try_pop session_id with Some _ -> loop (n + 1) | None -> n
@@ -94,7 +101,11 @@ let test_change_gated_broadcast () =
 
 let () =
   Alcotest.run "goal_loop_broadcast"
-    [ ("event", [ Alcotest.test_case "shape" `Quick test_event_shape ])
+    [ ( "event"
+      , [ Alcotest.test_case "shape" `Quick test_event_shape
+        ; Alcotest.test_case "refresh timeout below interval" `Quick
+            test_refresh_timeout_below_interval
+        ] )
     ; ( "change_gate"
       , [ Alcotest.test_case "broadcast" `Quick test_change_gated_broadcast ] )
     ]


### PR DESCRIPTION
## Summary
- make the goal-loop refresh timeout explicit at `interval * 0.8`
- expose the interval/timeout constants as a testable contract
- add a regression asserting the timeout remains below the interval so `Proactive_refresh` does not clamp and warn on startup

## Root Cause
Current runtime logs showed:

`goal_loop_status: timeout_s (10) >= interval_s (5), clamping to 4s`

`start_goal_loop_refresh_loop` used `Proactive_refresh.default_config ~interval_s:5.0`, whose default timeout is `10.0`. The generic clamp was correct, but this caller should not enter the warning path on every startup.

## Validation
- `ocamlformat --check lib/server/server_dashboard_http_goal_loop_broadcast.ml lib/server/server_dashboard_http_goal_loop_broadcast.mli test/test_goal_loop_broadcast.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_goal_loop_broadcast.exe` was attempted but refused because a bare Dune process is already holding the shared Dune lane:
  - `75646 61767 dune build @fmt --root .`

Per repo workflow for this machine, CI is the build authority rather than overriding shared local Dune contention.
