### PR TITLE
Surface librarian fallback facts in memory health

### DIFF
--- a/dashboard/src/api/dashboard-misc.ts
+++ b/dashboard/src/api/dashboard-misc.ts
@@ -201,6 +201,7 @@ export type KeeperMemoryHealthAlertCode =
   | 'near_duplicate'
   | 'events_to_facts_ratio_high'
   | 'provider_slot_busy'
+  | 'librarian_fallback_facts'
 
 export type KeeperMemoryHealthAlertSeverity = 'warn'
 
@@ -209,6 +210,7 @@ export type KeeperMemoryHealthAlertTarget =
   | 'near_duplicate'
   | 'events_to_facts_ratio'
   | 'provider_slot_busy'
+  | 'librarian_fallback_facts'
 
 export interface KeeperMemoryHealthAlert {
   code: KeeperMemoryHealthAlertCode
@@ -230,6 +232,7 @@ export interface KeeperMemoryHealthKeeperEntry {
   ttl_expired_on_disk: number
   near_duplicate: number
   provider_slot_busy: number
+  librarian_fallback_facts: number
   alerts: KeeperMemoryHealthAlert[]
 }
 
@@ -244,6 +247,7 @@ export interface KeeperMemoryHealthResponse {
     ttl_expired_on_disk: number
     near_duplicate: number
     provider_slot_busy: number
+    librarian_fallback_facts: number
   }
   alert_summary: {
     total_alerts: number
@@ -253,11 +257,13 @@ export interface KeeperMemoryHealthResponse {
     near_duplicate_keepers: number
     high_event_ratio_keepers: number
     provider_slot_busy_keepers: number
+    librarian_fallback_fact_keepers: number
     thresholds: {
       ttl_expired_on_disk: number
       near_duplicate: number
       events_to_facts_ratio: number
       provider_slot_busy: number
+      librarian_fallback_facts: number
     }
   }
 }

--- a/dashboard/src/components/memory/keeper-memory-health.test.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.test.ts
@@ -35,6 +35,7 @@ function makeEntry(
     ttl_expired_on_disk: 0,
     near_duplicate: 0,
     provider_slot_busy: 0,
+    librarian_fallback_facts: 0,
     alerts: [],
     ...overrides,
   }
@@ -56,6 +57,7 @@ function makeResponse(
       ttl_expired_on_disk: 0,
       near_duplicate: 0,
       provider_slot_busy: 0,
+      librarian_fallback_facts: 0,
       ...totalsOverrides,
     },
     alert_summary: alertSummary ?? makeAlertSummary(),
@@ -73,11 +75,13 @@ function makeAlertSummary(
     near_duplicate_keepers: 0,
     high_event_ratio_keepers: 0,
     provider_slot_busy_keepers: 0,
+    librarian_fallback_fact_keepers: 0,
     thresholds: {
       ttl_expired_on_disk: 0,
       near_duplicate: 0,
       events_to_facts_ratio: 0,
       provider_slot_busy: 0,
+      librarian_fallback_facts: 0,
     },
     ...overrides,
   }
@@ -278,6 +282,37 @@ describe('KeeperMemoryHealth', () => {
 
       expect(screen.getByText('슬롯')).not.toBeNull()
       expect(statValue(container, 'provider-slot-busy')).toBe('3')
+    })
+
+    it('surfaces librarian fallback fact alerts per keeper', async () => {
+      mockFetch.mockResolvedValue({
+        ...makeResponse([
+          makeEntry({
+            keeper_id: 'fallback-heavy',
+            librarian_fallback_facts: 2,
+            alerts: [{
+              code: 'librarian_fallback_facts',
+              severity: 'warn',
+              target: 'librarian_fallback_facts',
+              label: '폴백',
+              message: 'Librarian fallback diagnostic fact rows remain on disk',
+              value: 2,
+              threshold: 0,
+            }],
+          }),
+        ], { librarian_fallback_facts: 2 }),
+        alert_summary: makeAlertSummary({
+          total_alerts: 1,
+          warn_alerts: 1,
+          keepers_with_alerts: 1,
+          librarian_fallback_fact_keepers: 1,
+        }),
+      })
+      const { container } = render(html`<${KeeperMemoryHealth} />`)
+      await waitFor(() => expect(screen.getByText('fallback-heavy')).not.toBeNull())
+
+      expect(screen.getByText('폴백')).not.toBeNull()
+      expect(statValue(container, 'librarian-fallback-facts')).toBe('2')
     })
   })
 

--- a/dashboard/src/components/memory/keeper-memory-health.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.ts
@@ -20,6 +20,7 @@ const EVENT_RATIO_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'events_to_facts
 const TTL_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'ttl_expired_on_disk'
 const NEAR_DUPLICATE_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'near_duplicate'
 const PROVIDER_SLOT_BUSY_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'provider_slot_busy'
+const LIBRARIAN_FALLBACK_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'librarian_fallback_facts'
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -51,6 +52,7 @@ function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
   const ttlWarn = hasTargetAlert(alerts, TTL_ALERT_TARGET)
   const nearDuplicateWarn = hasTargetAlert(alerts, NEAR_DUPLICATE_ALERT_TARGET)
   const providerSlotBusyWarn = hasTargetAlert(alerts, PROVIDER_SLOT_BUSY_ALERT_TARGET)
+  const librarianFallbackWarn = hasTargetAlert(alerts, LIBRARIAN_FALLBACK_ALERT_TARGET)
   const providerSlotBusyCount = providerSlotBusy(entry)
 
   return html`
@@ -77,6 +79,11 @@ function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
         ${providerSlotBusyWarn
           ? html`<span class="kmh-badge kmh-badge--warn">${providerSlotBusyCount}</span>`
           : html`<span class="kmh-badge kmh-badge--ok">${providerSlotBusyCount}</span>`}
+      </td>
+      <td>
+        ${librarianFallbackWarn
+          ? html`<span class="kmh-badge kmh-badge--warn">${entry.librarian_fallback_facts}</span>`
+          : html`<span class="kmh-badge kmh-badge--ok">${entry.librarian_fallback_facts}</span>`}
       </td>
       <td>
         ${alerts.length > 0
@@ -151,6 +158,7 @@ export function KeeperMemoryHealth() {
   const totalAlerts = data.alert_summary.total_alerts
   const ttlExpiredWarn = data.alert_summary.ttl_expired_keepers > 0
   const providerSlotBusyWarn = data.alert_summary.provider_slot_busy_keepers > 0
+  const librarianFallbackWarn = data.alert_summary.librarian_fallback_fact_keepers > 0
   const totalProviderSlotBusy = data.totals.provider_slot_busy
 
   return html`
@@ -184,6 +192,12 @@ export function KeeperMemoryHealth() {
             <span class="kmh-stat-label">슬롯 실패</span>
             <span class=${`kmh-stat-value${providerSlotBusyWarn ? ' kmh-stat-value--warn' : ''}`}>
               ${totalProviderSlotBusy}
+            </span>
+          </div>
+          <div class="kmh-stat" data-stat-key="librarian-fallback-facts">
+            <span class="kmh-stat-label">폴백 진단</span>
+            <span class=${`kmh-stat-value${librarianFallbackWarn ? ' kmh-stat-value--warn' : ''}`}>
+              ${data.totals.librarian_fallback_facts}
             </span>
           </div>
           <div class="kmh-stat" data-stat-key="alerts">
@@ -220,6 +234,7 @@ export function KeeperMemoryHealth() {
                   <th>만료(디스크)</th>
                   <th>근접중복</th>
                   <th>슬롯 실패</th>
+                  <th>폴백 진단</th>
                   <th>경보</th>
                 </tr>
               </thead>

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -26,6 +26,7 @@ type keeper_health =
   ; ttl_expired_on_disk : int
   ; near_duplicate : int
   ; provider_slot_busy : int
+  ; librarian_fallback_facts : int
   }
 
 type alert_code =
@@ -33,6 +34,7 @@ type alert_code =
   | Near_duplicate
   | Events_to_facts_ratio_high
   | Provider_slot_busy
+  | Librarian_fallback_facts
 
 type alert_severity = Warn
 
@@ -41,6 +43,7 @@ type alert_target =
   | Near_duplicate_target
   | Events_to_facts_ratio_target
   | Provider_slot_busy_target
+  | Librarian_fallback_facts_target
 
 type keeper_alert =
   { code : alert_code
@@ -64,6 +67,7 @@ let events_to_facts_ratio_warn_threshold =
 ;;
 
 let provider_slot_busy_threshold = 0.0
+let librarian_fallback_facts_threshold = 0.0
 
 let provider_slot_busy_metric = Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
 let provider_slot_busy_site = Keeper_librarian_runtime.memory_os_librarian_provider_slot_site
@@ -73,6 +77,7 @@ let alert_code_to_string = function
   | Near_duplicate -> "near_duplicate"
   | Events_to_facts_ratio_high -> "events_to_facts_ratio_high"
   | Provider_slot_busy -> "provider_slot_busy"
+  | Librarian_fallback_facts -> "librarian_fallback_facts"
 ;;
 
 let alert_severity_to_string = function
@@ -84,6 +89,7 @@ let alert_target_to_string = function
   | Near_duplicate_target -> "near_duplicate"
   | Events_to_facts_ratio_target -> "events_to_facts_ratio"
   | Provider_slot_busy_target -> "provider_slot_busy"
+  | Librarian_fallback_facts_target -> "librarian_fallback_facts"
 ;;
 
 (* Alert labels are endpoint-owned wire copy for this backend-defined diagnostic
@@ -94,6 +100,7 @@ let alert_label = function
   | Near_duplicate -> "중복"
   | Events_to_facts_ratio_high -> "비율"
   | Provider_slot_busy -> "슬롯"
+  | Librarian_fallback_facts -> "폴백"
 ;;
 
 let alert ~code ~target ~message ~value ~threshold =
@@ -145,6 +152,18 @@ let keeper_alerts h =
           "Memory OS librarian provider slot was busy; extraction was skipped and remains due."
         ~value:(float_of_int h.provider_slot_busy)
         ~threshold:provider_slot_busy_threshold
+      :: alerts
+    else alerts)
+  |> (fun alerts ->
+    if h.librarian_fallback_facts > 0
+    then
+      alert
+        ~code:Librarian_fallback_facts
+        ~target:Librarian_fallback_facts_target
+        ~message:
+          "Librarian fallback diagnostic fact rows remain on disk; they are hidden from prompt recall but indicate extraction failures."
+        ~value:(float_of_int h.librarian_fallback_facts)
+        ~threshold:librarian_fallback_facts_threshold
       :: alerts
     else alerts)
   |> List.rev
@@ -201,13 +220,20 @@ let provider_slot_busy_for_keeper keeper_id =
 ;;
 
 let keeper_health ~keepers_dir ~now keeper_id =
-  let facts_count =
+  let facts =
     (* [read_facts_all] raises on malformed JSONL — treated as a read failure
        for this keeper; the caller catches and skips it. *)
-    let fs =
-      Keeper_memory_os_io.read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id
-    in
-    List.length fs
+    Keeper_memory_os_io.read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id
+  in
+  let facts_count = List.length facts in
+  let librarian_fallback_facts =
+    facts
+    |> List.fold_left
+         (fun count (fact : Keeper_memory_os_types.fact) ->
+           if Keeper_memory_os_types.legacy_unstructured_fallback_claim fact.claim
+           then count + 1
+           else count)
+         0
   in
   let facts_bytes =
     file_size_bytes
@@ -237,6 +263,7 @@ let keeper_health ~keepers_dir ~now keeper_id =
   ; ttl_expired_on_disk = gc_report.ttl_expired
   ; near_duplicate = gc_report.dedup_removed
   ; provider_slot_busy = provider_slot_busy_for_keeper keeper_id
+  ; librarian_fallback_facts
   }
 ;;
 
@@ -251,6 +278,7 @@ let keeper_health_entry_to_json (h, alerts) : Yojson.Safe.t =
     ; "ttl_expired_on_disk", `Int h.ttl_expired_on_disk
     ; "near_duplicate", `Int h.near_duplicate
     ; "provider_slot_busy", `Int h.provider_slot_busy
+    ; "librarian_fallback_facts", `Int h.librarian_fallback_facts
     ; "alerts", `List (List.map keeper_alert_to_json alerts)
     ]
 ;;
@@ -298,6 +326,8 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
           ; "ttl_expired_on_disk", `Int (sum (fun h -> h.ttl_expired_on_disk))
           ; "near_duplicate", `Int (sum (fun h -> h.near_duplicate))
           ; "provider_slot_busy", `Int (sum (fun h -> h.provider_slot_busy))
+          ; ( "librarian_fallback_facts"
+            , `Int (sum (fun h -> h.librarian_fallback_facts)) )
           ] )
     ; ( "alert_summary"
       , `Assoc
@@ -317,12 +347,15 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
           ; ( "high_event_ratio_keepers"
             , `Int (alert_count_by_code Events_to_facts_ratio_high) )
           ; "provider_slot_busy_keepers", `Int (alert_count_by_code Provider_slot_busy)
+          ; ( "librarian_fallback_fact_keepers"
+            , `Int (alert_count_by_code Librarian_fallback_facts) )
           ; ( "thresholds"
             , `Assoc
                 [ "ttl_expired_on_disk", `Float ttl_expired_on_disk_threshold
                 ; "near_duplicate", `Float near_duplicate_threshold
                 ; "events_to_facts_ratio", `Float events_to_facts_ratio_warn_threshold
                 ; "provider_slot_busy", `Float provider_slot_busy_threshold
+                ; "librarian_fallback_facts", `Float librarian_fallback_facts_threshold
                 ] )
           ] )
     ]

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -30,6 +30,13 @@ let fact ?(valid_until = None) ~now claim =
   }
 ;;
 
+let librarian_fallback_fact ~now claim =
+  { (fact ~now claim) with
+    Types.category = Types.Ephemeral
+  ; claim_kind = Some Types.Diagnostic
+  }
+;;
+
 let keeper_ids json =
   match json with
   | `Assoc fields ->
@@ -177,6 +184,10 @@ let test_reports_per_keeper_metric_values () =
   Alcotest.(check int) "nothing expired" 0 (int_field "ttl_expired_on_disk" k);
   Alcotest.(check int) "no duplicates" 0 (int_field "near_duplicate" k);
   Alcotest.(check int) "no provider slot busy skips" 0 (int_field "provider_slot_busy" k);
+  Alcotest.(check int)
+    "no librarian fallback facts"
+    0
+    (int_field "librarian_fallback_facts" k);
   Alcotest.(check int) "no keeper alerts" 0 (List.length (list_field "alerts" k));
   Alcotest.(check int) "totals.facts" 2 (int_field "facts" (totals json));
   Alcotest.(check bool)
@@ -283,6 +294,51 @@ let test_reports_provider_slot_busy_metric_as_alert () =
   Alcotest.(check int) "summary total alerts" 1 (int_field "total_alerts" summary)
 ;;
 
+let test_reports_librarian_fallback_facts_as_alert () =
+  Eio_main.run
+  @@ fun _env ->
+  let now = test_now in
+  let base = fresh_dir "masc-memory-health-librarian-fallback" in
+  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
+  let fallback_claim =
+    Types.librarian_unstructured_fallback_claim_prefix
+    ^ " (librarian provider returned empty response): <empty response>"
+  in
+  Io.rewrite_facts_atomically_for_keepers_dir
+    ~keepers_dir
+    ~keeper_id:"fallback"
+    [ fact ~now "ordinary durable row"; librarian_fallback_fact ~now fallback_claim ];
+  let json = Health.keeper_memory_health_http_json ~base_path:base in
+  let k = keeper_obj "fallback" json in
+  Alcotest.(check int)
+    "librarian fallback facts projected"
+    1
+    (int_field "librarian_fallback_facts" k);
+  Alcotest.(check int)
+    "totals librarian fallback facts"
+    1
+    (int_field "librarian_fallback_facts" (totals json));
+  let alerts = list_field "alerts" k in
+  Alcotest.(check (list string))
+    "librarian fallback alert code"
+    [ "librarian_fallback_facts" ]
+    (List.map (string_field "code") alerts);
+  Alcotest.(check (list string))
+    "librarian fallback alert target"
+    [ "librarian_fallback_facts" ]
+    (List.map (string_field "target") alerts);
+  Alcotest.(check (list string))
+    "librarian fallback alert label"
+    [ "폴백" ]
+    (List.map (string_field "label") alerts);
+  let summary = alert_summary json in
+  Alcotest.(check int)
+    "summary librarian fallback keepers"
+    1
+    (int_field "librarian_fallback_fact_keepers" summary);
+  Alcotest.(check int) "summary total alerts" 1 (int_field "total_alerts" summary)
+;;
+
 let test_sorts_keepers_by_facts_bytes_desc () =
   Eio_main.run
   @@ fun _env ->
@@ -358,6 +414,10 @@ let () =
             "reports provider slot busy metric as alert"
             `Quick
             test_reports_provider_slot_busy_metric_as_alert
+        ; Alcotest.test_case
+            "reports librarian fallback facts as alert"
+            `Quick
+            test_reports_librarian_fallback_facts_as_alert
         ; Alcotest.test_case
             "sorts keepers by facts_bytes descending"
             `Quick


### PR DESCRIPTION
## Summary
- add per-keeper and total librarian fallback fact counts to keeper-memory-health
- emit backend-owned warning alerts for fallback diagnostic fact rows
- render the new count in the dashboard health table and summary strip

## Verification
- ocamlformat --check lib/server/server_dashboard_http_keeper_memory_health.ml test/test_server_dashboard_http_keeper_memory_health.ml
- git diff --check origin/main...HEAD
- env PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules/.bin:$PATH NODE_PATH=/Users/dancer/me/workspace/yousleepwhen/masc/dashboard/node_modules vitest run --config vitest.config.ts --no-file-parallelism --maxWorkers=1 src/components/memory/keeper-memory-health.test.ts

## Notes
- Local focused Dune build was skipped because scripts/dune-local.sh refused to run while a bare Dune process is holding the machine-wide lock; CI is the build authority for this slice.