### PR TITLE
fix(keeper): touch smart-idle liveness before sleep

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -605,6 +605,9 @@ let run_smart_heartbeat_gate
     | Keeper_heartbeat_smart.Skip_idle next_time ->
       let wait = Float.max 1.0 (next_time -. Time_compat.now ()) in
       Log.Keeper.debug "smart heartbeat: skip (idle, next in %.1fs)" wait;
+      Observations.record_smart_idle_sleep_admission
+        ~base_path:config.base_path
+        ~keeper_name:meta_current.name;
       let jitter = wait *. 0.1 *. Random.float 1.0 in
       let outcome =
         Keeper_keepalive_signal.interruptible_sleep ~clock ~stop ~wakeup (wait +. jitter)

--- a/lib/keeper/keeper_heartbeat_loop_observations.ml
+++ b/lib/keeper/keeper_heartbeat_loop_observations.ml
@@ -16,6 +16,18 @@ let smart_idle_sleep_observation_reasons =
   [ "smart_heartbeat_skip_idle"; "idle_sleep_timeout" ]
 ;;
 
+let smart_idle_sleep_admission_reasons =
+  [ "smart_heartbeat_skip_idle"; "idle_sleep_admitted" ]
+;;
+
+let record_smart_idle_sleep_admission ~base_path ~keeper_name =
+  Keeper_registry.record_skip_reasons
+    ~base_path
+    keeper_name
+    ~reasons:smart_idle_sleep_admission_reasons;
+  Keeper_registry.touch_last_turn_ts ~base_path keeper_name
+;;
+
 let record_smart_idle_sleep_observation ~base_path ~keeper_name =
   Keeper_registry.record_skip_reasons
     ~base_path

--- a/lib/keeper/keeper_heartbeat_loop_observations.mli
+++ b/lib/keeper/keeper_heartbeat_loop_observations.mli
@@ -9,6 +9,13 @@ val record_provider_timeout_observation
 
 val smart_idle_sleep_observation_reasons : string list
 
+val smart_idle_sleep_admission_reasons : string list
+
+val record_smart_idle_sleep_admission
+  :  base_path:string
+  -> keeper_name:string
+  -> unit
+
 val record_smart_idle_sleep_observation
   :  base_path:string
   -> keeper_name:string

--- a/test/test_keeper_idle_threshold_contract.ml
+++ b/test/test_keeper_idle_threshold_contract.ml
@@ -245,6 +245,53 @@ let test_smart_idle_sleep_refreshes_last_turn_ts () =
                 ~now
                 ~threshold)))
 
+let test_smart_idle_admission_refreshes_last_turn_ts_before_sleep () =
+  let bp = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir bp)
+    (fun () ->
+      let name = "smart-idle-admission-touch-keeper" in
+      let meta = make_meta name in
+      let entry = Reg.register ~base_path:bp name meta in
+      let stale_ts = 100.0 in
+      let now = 300.0 in
+      let threshold = 150.0 in
+      let stale_meta =
+        let runtime = entry.meta.runtime in
+        let usage = runtime.usage in
+        { entry.meta with
+          runtime = { runtime with usage = { usage with last_turn_ts = stale_ts } }
+        }
+      in
+      Reg.update_meta ~base_path:bp name stale_meta;
+      Observations.record_smart_idle_sleep_admission ~base_path:bp ~keeper_name:name;
+      match Reg.get ~base_path:bp name with
+      | None -> fail "keeper should still be registered after smart idle admission"
+      | Some entry ->
+        let fresh_ts = entry.meta.runtime.usage.last_turn_ts in
+        check bool "smart idle admission touch advances last_turn_ts" true
+          (fresh_ts > stale_ts);
+        (match entry.last_skip_observation with
+         | Some (skip_ts, reasons) ->
+           check bool "smart idle admission timestamp is fresh" true (skip_ts > stale_ts);
+           check
+             (list string)
+             "smart idle admission reasons recorded"
+             Observations.smart_idle_sleep_admission_reasons
+             reasons
+         | None -> fail "smart idle admission observation missing");
+        check bool
+          "after smart idle admission touch, assess_stale_run returns None"
+          true
+          (Option.is_none
+             (Sup.assess_stale_run
+                ~phase:KSM.Running
+                ~in_turn:None
+                ~last_turn_ts:fresh_ts
+                ~started_at:0.0
+                ~now
+                ~threshold)))
+
 let () =
   Alcotest.run
     "Keeper_idle_threshold_contract"
@@ -267,5 +314,9 @@ let () =
             "smart idle sleep refreshes last_turn_ts"
             `Quick
             test_smart_idle_sleep_refreshes_last_turn_ts
+        ; test_case
+            "smart idle admission refreshes last_turn_ts before sleep"
+            `Quick
+            test_smart_idle_admission_refreshes_last_turn_ts_before_sleep
         ] )
     ]


### PR DESCRIPTION
## Summary
- Record smart-idle sleep admission before entering interruptible_sleep.
- Keep the existing timeout observation for the actual timeout outcome.
- Add a regression proving the pre-sleep touch keeps assess_stale_run from stamping Idle_turn while the keeper is intentionally idle.

## Runtime evidence
- Live post-start log at 2026-06-28T13:08:33Z emitted stale_keeper_broadcast for idealist and sangsu, followed by registry crash/error records for stale_turn_timeout(idle_turn(...)).
- Source gap: Skip_idle only touched last_turn_ts after the idle sleep timed out, allowing the supervisor to fire while the keeper was asleep.

## Validation
- ocamlformat --check lib/keeper/keeper_heartbeat_loop.ml lib/keeper/keeper_heartbeat_loop_observations.ml lib/keeper/keeper_heartbeat_loop_observations.mli test/test_keeper_idle_threshold_contract.ml
- git diff --check HEAD~1..HEAD
- scripts/dune-local.sh build test/test_keeper_idle_threshold_contract.exe attempted but refused because bare Dune processes are already running; CI remains build authority.