### PR TITLE
fix(keeper): stop budget checkpoint self-accumulation

### DIFF
--- a/lib/keeper/keeper_agent_run_finalize_response.ml
+++ b/lib/keeper/keeper_agent_run_finalize_response.ml
@@ -43,6 +43,10 @@ let finalize
     ~pre_dispatch_compaction_after_tokens
     ~raw_response_text
     () =
+  let budget_exhausted =
+    Keeper_agent_run_response_text.stop_reason_is_turn_budget_exhausted
+      result.stop_reason
+  in
   let reported_state_snapshot =
     reported_state_snapshot_from_checkpoint result.checkpoint
   in
@@ -90,34 +94,42 @@ let finalize
       ~state_snapshot
       ~state_snapshot_source
       ~resume_merge
-      ~append_manifest
-      ()
+    ~append_manifest
+    ()
   in
-  receipt_response_text_present_ref := true;
+  receipt_response_text_present_ref := String.trim response_text <> "";
   let assistant_msg =
-    Agent_sdk.Types.make_message
-      ~role:Agent_sdk.Types.Assistant
-      ~metadata:
-        [ ( Keeper_memory_policy.replay_metadata_key
-          , Keeper_memory_policy.replay_metadata_of_snapshot
-              state_snapshot )
-        ]
-      [ Agent_sdk.Types.Text response_text ]
+    if budget_exhausted
+    then None
+    else
+      Some
+        (Agent_sdk.Types.make_message
+           ~role:Agent_sdk.Types.Assistant
+           ~metadata:
+             [ ( Keeper_memory_policy.replay_metadata_key
+               , Keeper_memory_policy.replay_metadata_of_snapshot
+                   state_snapshot )
+             ]
+           [ Agent_sdk.Types.Text response_text ])
   in
-  Keeper_context_runtime.persist_message
-    ~source:history_assistant_source
-    session
+  Option.iter
+    (Keeper_context_runtime.persist_message
+       ~source:history_assistant_source
+       session)
     assistant_msg;
   let saved_checkpoint_result =
     match result.checkpoint with
     | Some checkpoint ->
       let patched =
-        Keeper_context_core.patch_checkpoint_last_assistant
-          checkpoint
-          ~session_id:
-            (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
-          ~response_text
-          ~snapshot:state_snapshot
+        if budget_exhausted
+        then checkpoint
+        else
+          Keeper_context_core.patch_checkpoint_last_assistant
+            checkpoint
+            ~session_id:
+              (Keeper_id.Trace_id.to_string meta.runtime.trace_id)
+            ~response_text
+            ~snapshot:state_snapshot
       in
       (match
          Keeper_checkpoint_store.save_oas_classified
@@ -187,7 +199,7 @@ let finalize
     let librarian_messages =
       match saved_checkpoint with
       | Some checkpoint -> checkpoint.Agent_sdk.Checkpoint.messages
-      | None -> [ assistant_msg ]
+      | None -> Option.to_list assistant_msg
     in
     Keeper_agent_run_post_turn_memory.run
       ~config

--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -15,6 +15,11 @@ let stop_reason_label = function
      | None -> "mutation_boundary")
 ;;
 
+let stop_reason_is_turn_budget_exhausted = function
+  | Runtime_agent.TurnBudgetExhausted _ -> true
+  | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
+;;
+
 let state_snapshot ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_names
       ~stop_reason ~raw_response_text
       ()
@@ -74,6 +79,8 @@ let finalize ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_nam
       ~stop_reason ~raw_response_text
       ()
   =
+  let budget_exhausted = stop_reason_is_turn_budget_exhausted stop_reason in
+  let raw_response_text = if budget_exhausted then "" else raw_response_text in
   let state_snapshot, state_snapshot_source =
     state_snapshot
       ~reported_state_snapshot
@@ -87,5 +94,8 @@ let finalize ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_tool_nam
   let response_text =
     response_text ~state_snapshot ~state_snapshot_source ~raw_response_text
   in
-  { state_snapshot; state_snapshot_source; response_text }
+  { state_snapshot
+  ; state_snapshot_source
+  ; response_text = if budget_exhausted then "" else response_text
+  }
 ;;

--- a/lib/keeper/keeper_registry_event_queue.ml
+++ b/lib/keeper/keeper_registry_event_queue.ml
@@ -13,7 +13,9 @@ open Keeper_registry_types
 let rec queue_contains queue stimulus =
   match Keeper_event_queue.dequeue queue with
   | None -> false
-  | Some (head, rest) -> head = stimulus || queue_contains rest stimulus
+  | Some (head, rest) ->
+    Keeper_event_queue.stimulus_identity_equal head stimulus
+    || queue_contains rest stimulus
 ;;
 
 let enqueue_if_missing queue stimulus =
@@ -44,7 +46,7 @@ let enqueue ~base_path name stimulus =
     Keeper_event_queue_persistence.update
       ~base_path
       ~keeper_name:name
-      (fun cur -> Keeper_event_queue.enqueue cur stimulus);
+      (fun cur -> enqueue_if_missing cur stimulus);
     (match Keeper_registry.get ~base_path name with
      | None -> ()
      | Some entry ->
@@ -61,8 +63,10 @@ let enqueue ~base_path name stimulus =
   | Some entry ->
     let rec loop () =
       let cur = Atomic.get entry.event_queue in
-      let next = Keeper_event_queue.enqueue cur stimulus in
-      if Atomic.compare_and_set entry.event_queue cur next
+      let next = enqueue_if_missing cur stimulus in
+      if next = cur
+      then ()
+      else if Atomic.compare_and_set entry.event_queue cur next
       then persist_live_queue ~base_path entry name
       else loop ()
     in

--- a/lib/keeper/keeper_unified_metrics_decision.ml
+++ b/lib/keeper/keeper_unified_metrics_decision.ml
@@ -38,7 +38,11 @@ let append_decision_record
   in
   let response_preview =
     match result with
-    | Some r when String.trim r.response_text <> "" ->
+    | Some r
+      when String.trim r.response_text <> ""
+           && Keeper_turn_outcome.equal
+                (Keeper_turn_outcome.of_stop_reason r.stop_reason)
+                Keeper_turn_outcome.Visible_reply ->
         Some (short_preview r.response_text)
     | _ -> None
   in

--- a/lib/keeper/keeper_unified_turn_success.ml
+++ b/lib/keeper/keeper_unified_turn_success.ml
@@ -47,10 +47,8 @@ let apply_lifecycle ~config ~base_dir ~meta ~final_execution ~current_turn_block
   lifecycle
 ;;
 
-let no_work_budget_threshold_override
+let budget_exhausted_no_progress_threshold_override
       ~stop_reason
-      ~has_current_task
-      ~active_goal_ids
       ~strong_evidence
       ~surface_requires_evidence
       ~observation
@@ -60,17 +58,10 @@ let no_work_budget_threshold_override
     | Runtime_agent.TurnBudgetExhausted _ -> true
     | Runtime_agent.Completed | Runtime_agent.MutationBoundaryReached _ -> false
   in
-  let no_work_scope = (not has_current_task) && active_goal_ids = [] in
-  let actionable_signal =
-    Keeper_contract_classifier.classify_actionable_signal
-      (Keeper_contract_classifier.of_keeper_world_observation observation)
-  in
   if
     budget_exhausted
-    && no_work_scope
     && (not strong_evidence)
     && surface_requires_evidence
-    && actionable_signal <> Keeper_contract_classifier.No_actionable_signal
     && Keeper_unified_metrics_support.is_scheduled_autonomous_cycle_of_observation
          observation
   then Some 1
@@ -282,10 +273,8 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
     || legitimate_no_work_passive_only
   in
   let threshold_override =
-    no_work_budget_threshold_override
+    budget_exhausted_no_progress_threshold_override
       ~stop_reason:result.Keeper_agent_run.stop_reason
-      ~has_current_task:(Option.is_some updated_meta.Keeper_meta_contract.current_task_id)
-      ~active_goal_ids:updated_meta.Keeper_meta_contract.active_goal_ids
       ~strong_evidence
       ~surface_requires_evidence
       ~observation
@@ -313,7 +302,8 @@ let apply_loop_detectors ~config ~observation ~meta updated_meta result =
 ;;
 
 module For_testing = struct
-  let no_work_budget_threshold_override = no_work_budget_threshold_override
+  let budget_exhausted_no_progress_threshold_override =
+    budget_exhausted_no_progress_threshold_override
 
   type nonrec turn_delivery = turn_delivery =
     | Peer_only
@@ -590,6 +580,20 @@ let emit_usage_metrics_and_log
     outcome_str
 ;;
 
+type decision_outcome =
+  | Decision_success
+  | Decision_checkpoint
+
+let decision_outcome_of_stop_reason = function
+  | Runtime_agent.Completed -> Decision_success
+  | Runtime_agent.TurnBudgetExhausted _
+  | Runtime_agent.MutationBoundaryReached _ ->
+    Decision_checkpoint
+
+let decision_outcome_to_label = function
+  | Decision_success -> "success"
+  | Decision_checkpoint -> "checkpoint"
+
 let persist_success_meta ~config ~original_meta ~updated_meta =
   let updated_meta =
     if updated_meta.auto_resume_after_sec <> None
@@ -636,11 +640,11 @@ let reset_turn_failures_for_stop_reason ~config ~updated_meta result =
   in
   match result.Keeper_agent_run.stop_reason with
   | Runtime_agent.TurnBudgetExhausted { turns_used; limit } ->
-    Log.Keeper.info ~keeper_name:updated_meta.name
-      "turn budget exhausted (%d/%d), checkpoint saved — will resume next cycle"
+    Log.Keeper.warn ~keeper_name:updated_meta.name
+      "turn budget exhausted (%d/%d), checkpoint saved; not recording health success \
+       or clearing turn-failure state"
       turns_used
-      limit;
-    reset_failure_state ()
+      limit
   | Runtime_agent.MutationBoundaryReached { tool_name; _ } ->
     Log.Keeper.info ~keeper_name:updated_meta.name
       "mutation boundary reached after %s, checkpoint saved — will resume next cycle"
@@ -735,7 +739,9 @@ let handle
     ~turn_ctx_cell
     ~observation
     ~latency_ms
-    ~outcome:"success"
+    ~outcome:
+      (decision_outcome_to_label
+         (decision_outcome_of_stop_reason result.Keeper_agent_run.stop_reason))
     ~degraded_retry_applied
     ?degraded_retry_runtime
     ?fallback_reason:(Option.map Keeper_error_classify.degraded_retry_reason_to_string fallback_reason)

--- a/lib/keeper/keeper_unified_turn_success.mli
+++ b/lib/keeper/keeper_unified_turn_success.mli
@@ -6,10 +6,8 @@
     [Keeper_unified_turn.run_keeper_cycle] is the expected caller. *)
 
 module For_testing : sig
-  val no_work_budget_threshold_override
+  val budget_exhausted_no_progress_threshold_override
     :  stop_reason:Runtime_agent.stop_reason
-    -> has_current_task:bool
-    -> active_goal_ids:string list
     -> strong_evidence:bool
     -> surface_requires_evidence:bool
     -> observation:Keeper_world_observation.world_observation

--- a/lib/keeper_runtime/keeper_event_queue.ml
+++ b/lib/keeper_runtime/keeper_event_queue.ml
@@ -99,6 +99,9 @@ let is_empty q = q.length = 0
 let enqueue (queue : t) (s : stimulus) : t =
   { queue with back_rev = s :: queue.back_rev; length = queue.length + 1 }
 
+let stimulus_identity_equal a b =
+  String.equal a.post_id b.post_id && a.urgency = b.urgency && a.payload = b.payload
+
 let to_list (queue : t) : stimulus list =
   match queue.back_rev with
   | [] -> queue.front
@@ -134,10 +137,15 @@ let remove_by_post_id post_id queue =
 
 let uniq_stimuli stimuli =
   List.fold_left
-    (fun acc stimulus -> if List.exists (( = ) stimulus) acc then acc else stimulus :: acc)
+    (fun acc stimulus ->
+       if List.exists (stimulus_identity_equal stimulus) acc
+       then acc
+       else stimulus :: acc)
     []
     stimuli
   |> List.rev
+
+let dedup_by_identity queue = queue |> to_list |> uniq_stimuli |> of_list
 
 let remove_by_post_id_pair post_id left right =
   let left_removed, left' = remove_by_post_id post_id left in

--- a/lib/keeper_runtime/keeper_event_queue.mli
+++ b/lib/keeper_runtime/keeper_event_queue.mli
@@ -127,6 +127,11 @@ val is_empty : t -> bool
 val enqueue : t -> stimulus -> t
 (** [enqueue q s] appends [s] to the back of [q] in O(1). Always succeeds. *)
 
+val stimulus_identity_equal : stimulus -> stimulus -> bool
+(** [true] when two stimuli describe the same durable event. The comparison
+    intentionally ignores [arrived_at], so restart/bootstrap re-enqueues do
+    not create an unbounded backlog of otherwise identical stimuli. *)
+
 val to_list : t -> stimulus list
 (** Return the FIFO contents. *)
 
@@ -146,7 +151,11 @@ val remove_by_post_id : post_id -> t -> stimulus list * t
     removed stimuli in FIFO order plus the remaining queue. *)
 
 val uniq_stimuli : stimulus list -> stimulus list
-(** Remove duplicate stimuli while preserving the first occurrence order. *)
+(** Remove duplicate stimuli by {!stimulus_identity_equal} while preserving the
+    first occurrence order. *)
+
+val dedup_by_identity : t -> t
+(** Collapse duplicate durable-event identities in a queue. *)
 
 val remove_by_post_id_pair : post_id -> t -> t -> stimulus list * t * t
 (** Remove matching stimuli from two queues and return the de-duplicated

--- a/lib/keeper_runtime/keeper_event_queue_persistence.ml
+++ b/lib/keeper_runtime/keeper_event_queue_persistence.ml
@@ -51,7 +51,9 @@ let inflight_path ~base_path ~keeper_name =
 let rec queue_contains queue stimulus =
   match Keeper_event_queue.dequeue queue with
   | None -> false
-  | Some (head, rest) -> head = stimulus || queue_contains rest stimulus
+  | Some (head, rest) ->
+    Keeper_event_queue.stimulus_identity_equal head stimulus
+    || queue_contains rest stimulus
 
 let append_missing queue stimuli =
   List.fold_left
@@ -73,7 +75,11 @@ let remove_stimuli queue stimuli =
   match stimuli with
   | [] -> queue
   | _ ->
-    let remove stimulus = List.exists (fun target -> target = stimulus) stimuli in
+    let remove stimulus =
+      List.exists
+        (fun target -> Keeper_event_queue.stimulus_identity_equal target stimulus)
+        stimuli
+    in
     queue
     |> Keeper_event_queue.to_list
     |> List.filter (fun stimulus -> not (remove stimulus))
@@ -101,13 +107,24 @@ let load_from_path ~keeper_name path =
            msg;
          Keeper_event_queue.empty
        | Ok queue ->
-         if not (Keeper_event_queue.is_empty queue)
+         let deduped = Keeper_event_queue.dedup_by_identity queue in
+         let dropped =
+           Keeper_event_queue.length queue - Keeper_event_queue.length deduped
+         in
+         if dropped > 0
+         then
+           Log.Keeper.warn
+             "event_queue_snapshot: dropped %d duplicate stimulus identity rows for keeper=%s path=%s"
+             dropped
+             keeper_name
+             path;
+         if not (Keeper_event_queue.is_empty deduped)
          then
            Log.Keeper.info
              "event_queue_snapshot: restored %s for keeper=%s"
-             (Keeper_event_queue.summary queue)
+             (Keeper_event_queue.summary deduped)
              keeper_name;
-         queue))
+         deduped))
 
 let load_unlocked ~base_path ~keeper_name =
   match snapshot_path ~base_path ~keeper_name, inflight_path ~base_path ~keeper_name with

--- a/lib/runtime/runtime_agent.ml
+++ b/lib/runtime/runtime_agent.ml
@@ -859,7 +859,7 @@ let run_duration_ms_since started_at =
 
 let dashboard_status_of_stop_reason = function
   | Completed -> Dashboard_oas_bridge.Success
-  | TurnBudgetExhausted _ -> Dashboard_oas_bridge.Success
+  | TurnBudgetExhausted _ -> Dashboard_oas_bridge.Error { transient = false }
   | MutationBoundaryReached _ ->
       Dashboard_oas_bridge.Cancelled { reason = "mutation_boundary_reached" }
 

--- a/lib/runtime/runtime_agent.mli
+++ b/lib/runtime/runtime_agent.mli
@@ -35,10 +35,12 @@ type stop_reason = Runtime_agent_context.stop_reason =
     }
 (** Why this single OAS call yielded control. [Completed] is the
     model's success path; [TurnBudgetExhausted] means the per-call
-    turn budget checkpoint was reached and the keeper should continue
-    from the persisted checkpoint on the next cycle; [MutationBoundaryReached]
-    fires when the keeper hit a mutation tool while in read-only mode
-    (the [tool_name] surfaces which tool triggered the gate). *)
+    turn budget checkpoint was reached. It is not a completed
+    deliverable; callers must classify it from typed stop reason plus
+    durable-progress evidence before deciding whether to continue from
+    the persisted checkpoint. [MutationBoundaryReached] fires when the
+    keeper hit a mutation tool while in read-only mode (the [tool_name]
+    surfaces which tool triggered the gate). *)
 
 (** {1 Config} *)
 

--- a/test/test_keeper_event_queue.ml
+++ b/test/test_keeper_event_queue.ml
@@ -120,6 +120,9 @@ let () =
   let bootstrap_stim =
     { post_id = "bootstrap"; urgency = Normal; arrived_at = 0.0; payload = Bootstrap }
   in
+  let duplicate_bootstrap_stim =
+    { bootstrap_stim with arrived_at = 42.0 }
+  in
   let ghost_stim =
     { post_id = "ghost"; urgency = Low; arrived_at = 0.0; payload = No_progress_recovery }
   in
@@ -128,6 +131,8 @@ let () =
   let q = enqueue q board_stim in
   let q = enqueue q bootstrap_stim in
   assert (length q = 2);
+  assert (stimulus_identity_equal bootstrap_stim duplicate_bootstrap_stim);
+  assert (List.length (uniq_stimuli [ bootstrap_stim; duplicate_bootstrap_stim ]) = 1);
   let stim, q =
     match dequeue q with
     | Some s -> s
@@ -268,6 +273,25 @@ let () =
       Keeper_event_queue_persistence.persist ~base_path ~keeper_name rest;
       assert (is_empty (Keeper_event_queue_persistence.load ~base_path ~keeper_name)));
 
+  (* --- durable snapshot load collapses legacy duplicates that differ only by
+         arrival time. --- *)
+  let base_path = temp_dir "keeper-event-queue-load-dedup" in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_path)
+    (fun () ->
+      let keeper_name = "keeper-event-queue-load-dedup-test" in
+      let duplicated =
+        empty
+        |> fun q -> enqueue q bootstrap_stim
+        |> fun q -> enqueue q duplicate_bootstrap_stim
+      in
+      Keeper_event_queue_persistence.persist ~base_path ~keeper_name duplicated;
+      let restored = Keeper_event_queue_persistence.load ~base_path ~keeper_name in
+      assert (length restored = 1);
+      let only, rest = Option.get (dequeue restored) in
+      assert (String.equal only.post_id "bootstrap");
+      assert (is_empty rest));
+
   (* --- durable in-flight store: ack removes only consumed stimuli --- *)
   let base_path = temp_dir "keeper-event-queue-inflight-partial-ack" in
   Fun.protect
@@ -377,6 +401,8 @@ let () =
       Masc.Keeper_registry.clear ();
       ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
+      Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
+      assert (length (Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name) = 1);
       assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
       Masc.Keeper_registry.clear ();
       ignore (Masc.Keeper_registry.register ~base_path keeper_name meta);
@@ -402,7 +428,12 @@ let () =
       let meta = meta_for_keeper keeper_name "trace-event-queue-unregistered-test" in
       Masc.Keeper_registry.clear ();
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
+      Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name board_stim;
       Masc.Keeper_registry_event_queue.enqueue ~base_path keeper_name bootstrap_stim;
+      Masc.Keeper_registry_event_queue.enqueue
+        ~base_path
+        keeper_name
+        duplicate_bootstrap_stim;
       assert (Sys.file_exists (snapshot_path ~base_path ~keeper_name));
       let pending = Masc.Keeper_registry_event_queue.snapshot ~base_path keeper_name in
       assert (length pending = 2);

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -424,6 +424,31 @@ let test_budget_synthesis_does_not_invent_next_items () =
     []
     snapshot.decisions
 
+let test_budget_finalizer_drops_synthetic_response_text () =
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:None
+      ~keeper_name:"test"
+      ~goal:"Fix task"
+      ~actual_keeper_tool_names:[]
+      ~stop_reason:(Runtime_agent.TurnBudgetExhausted { turns_used = 3; limit = 3 })
+      ~raw_response_text:
+        "Continuation checkpoint saved; keeper remains scheduled"
+      ()
+  in
+  Alcotest.(check string)
+    "budget checkpoint has no model-authored response text"
+    ""
+    finalized.response_text;
+  Alcotest.(check string)
+    "synthetic state source"
+    "synthesized"
+    (KMP.state_snapshot_source_to_string finalized.state_snapshot_source);
+  Alcotest.(check (list string))
+    "budget continuation does not preserve synthetic text as a decision"
+    []
+    finalized.state_snapshot.decisions
+
 (* ── Test runner ─────────────────────────────────────────────────── *)
 
 let () =
@@ -473,5 +498,9 @@ let () =
             "budget synthesis does not invent next items"
             `Quick
             test_budget_synthesis_does_not_invent_next_items;
+          Alcotest.test_case
+            "budget finalizer drops synthetic response text"
+            `Quick
+            test_budget_finalizer_drops_synthetic_response_text;
         ] );
     ]

--- a/test/test_no_progress_loop_detector.ml
+++ b/test/test_no_progress_loop_detector.ml
@@ -65,18 +65,14 @@ let scheduled_observation : WO.world_observation =
   ; connected_surfaces = []
   }
 
-let no_work_budget_override
+let budget_exhausted_no_progress_override
       ?(stop_reason = Runtime_agent.TurnBudgetExhausted { turns_used = 1; limit = 1 })
-      ?(has_current_task = false)
-      ?(active_goal_ids = [])
       ?(strong_evidence = false)
       ?(surface_requires_evidence = true)
       observation
   =
-  Success.no_work_budget_threshold_override
+  Success.budget_exhausted_no_progress_threshold_override
     ~stop_reason
-    ~has_current_task
-    ~active_goal_ids
     ~strong_evidence
     ~surface_requires_evidence
     ~observation
@@ -138,36 +134,34 @@ let test_threshold_override_fires_early () =
   Alcotest.(check int) "streak retained" 1 (D.current_streak ~keeper_name:k)
 
 let test_no_work_budget_override_predicate () =
-  Alcotest.(check (option int)) "scheduled no-work budget exhaustion keeps default threshold"
-    None
-    (no_work_budget_override scheduled_observation);
+  Alcotest.(check (option int)) "scheduled no-evidence budget exhaustion fast-fails"
+    (Some 1)
+    (budget_exhausted_no_progress_override scheduled_observation);
   let actionable_observation =
     { scheduled_observation with claimable_task_count = 1 }
   in
   Alcotest.(check (option int)) "scheduled actionable budget exhaustion fast-fails"
     (Some 1)
-    (no_work_budget_override actionable_observation);
+    (budget_exhausted_no_progress_override actionable_observation);
   let reactive_observation =
     { scheduled_observation with pending_mentions = [ ("operator", "wake") ] }
   in
   Alcotest.(check (option int)) "reactive observation keeps default threshold"
     None
-    (no_work_budget_override reactive_observation);
-  Alcotest.(check (option int)) "active task keeps default threshold"
-    None
-    (no_work_budget_override ~has_current_task:true scheduled_observation);
-  Alcotest.(check (option int)) "active goal keeps default threshold"
-    None
-    (no_work_budget_override ~active_goal_ids:[ "goal-1" ] scheduled_observation);
+    (budget_exhausted_no_progress_override reactive_observation);
   Alcotest.(check (option int)) "strong evidence keeps default threshold"
     None
-    (no_work_budget_override ~strong_evidence:true scheduled_observation);
+    (budget_exhausted_no_progress_override ~strong_evidence:true scheduled_observation);
   Alcotest.(check (option int)) "visible reply keeps default threshold"
     None
-    (no_work_budget_override ~surface_requires_evidence:false scheduled_observation);
+    (budget_exhausted_no_progress_override
+       ~surface_requires_evidence:false
+       scheduled_observation);
   Alcotest.(check (option int)) "completed stop keeps default threshold"
     None
-    (no_work_budget_override ~stop_reason:Runtime_agent.Completed scheduled_observation)
+    (budget_exhausted_no_progress_override
+       ~stop_reason:Runtime_agent.Completed
+       scheduled_observation)
 
 let test_latched_no_repeat_while_streak_grows () =
   D.reset_all_for_test ();


### PR DESCRIPTION
## Summary
- Prevent OAS turn-budget checkpoint notices from being persisted back into keeper assistant history/checkpoints/memory as model-authored output.
- Treat budget-exhausted/no-evidence scheduled turns as immediate no-progress latch candidates, and stop recording those checkpoints as success/health success.
- Deduplicate event-queue stimuli by durable identity so repeated bootstrap enqueue/load does not grow a keeper backlog when only arrived_at changes.

## Verification
- ocamlformat --check on touched OCaml files
- git diff --check origin/main..HEAD
- scripts/stringly-boundary-ratchet.sh --print
- scripts/silent-failure-ratchet.sh --print
- bash scripts/hardening-ratchet.sh --check fails on wildcard_silent_defaults +3; verified the same failure on clean origin/main (6d359ae462a), so not introduced by this branch

Build/test authority: CI, per request; no local Dune build was run.