### PR TITLE
fix(memory): export librarian fallback predicate

### DIFF
--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -233,6 +233,11 @@ val fact_is_current : now:float -> fact -> bool
     Kept as the SSOT for the producer and the legacy recall-eligibility shim. *)
 val librarian_unstructured_fallback_claim_prefix : string
 
+(** Whether raw claim text carries the historical librarian parse-failure
+    fallback prefix. Read-only compatibility and operator evidence surfaces use
+    this; new producer-side rows should rely on [Diagnostic] claim_kind. *)
+val legacy_unstructured_fallback_claim : string -> bool
+
 (** Terminal marker used on episodes that preserve unstructured librarian output
     after strict JSON parsing fails. *)
 val librarian_unstructured_fallback_terminal_marker : string


### PR DESCRIPTION
Follow-up for #22593. CI Lint failed because Server_dashboard_http_keeper_memory_health called Keeper_memory_os_types.legacy_unstructured_fallback_claim, but the helper was implemented only in the .ml and not exported by the .mli. This exports the existing central predicate rather than duplicating the historical prefix check in the dashboard path. Local checks: ocamlformat --check lib/keeper/keeper_memory_os_types.mli; git diff --check.