### PR TITLE
fix(build): export stop_reason_is_turn_budget_exhausted (.mli sync) + 에러 2 플래그

### DIFF
--- a/lib/keeper/keeper_agent_run_response_text.mli
+++ b/lib/keeper/keeper_agent_run_response_text.mli
@@ -8,6 +8,11 @@ type finalized = {
 
 val stop_reason_label : Runtime_agent.stop_reason -> string
 
+(** [stop_reason_is_turn_budget_exhausted sr] is true when the turn ended due
+    to the runtime turn budget being exhausted (vs a clean Complete or
+    mutation-boundary stop). Used by finalize to tag budget-limited turns. *)
+val stop_reason_is_turn_budget_exhausted : Runtime_agent.stop_reason -> bool
+
 val finalize :
   reported_state_snapshot:Keeper_memory_policy.keeper_state_snapshot option ->
   keeper_name:string ->


### PR DESCRIPTION
## fix(build): export stop_reason_is_turn_budget_exhausted + 에러 2 플래그

### 에러 1 (이 PR이 fix)
`keeper_agent_run_finalize_response.ml:47` — `Keeper_agent_run_response_text.stop_reason_is_turn_budget_exhausted` Unbound. 구현은 `.ml:18`에 있고 `.mli` export 누락. `Runtime_agent.stop_reason -> bool` val 추가.

### 에러 2 (본인 확인 요청 — fix 안 함)
`server_dashboard_http_keeper_memory_health.ml:233` — `Keeper_memory_os_types.legacy_unstructured_fallback_claim fact.claim` **Unbound (정의가 lib/ 어디에도 없음)**.

- `fact.claim`은 **string**(`type fact = { claim : string; ...; claim_kind : claim_kind option }`).
- callsite가 `fact.claim`(string)을 받으므로, 함수가 string 기반 판단 → /goal "노 스트링 매치" 위반 가능.
- **제안**: `fact.claim_kind`(typed) 기반으로 판단 (`Some Unstructured` 또는 fallback marker variant). 본인 #22593이 callsite만 넣고 정의를 누락한 것으로 보임.

이 PR은 에러 1만 고침. 에러 2는 본인 설계 결정(claim string vs claim_kind typed) 필요.

Co-Authored-By: Claude <noreply@anthropic.com>
