### PR TITLE
fix(keeper): classify execution tools as progress

### DIFF
--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -237,6 +237,10 @@ val librarian_unstructured_fallback_claim_prefix : string
     after strict JSON parsing fails. *)
 val librarian_unstructured_fallback_terminal_marker : string
 
+val legacy_unstructured_fallback_claim : string -> bool
+(** Whether a fact claim carries the historical librarian parse-failure fallback
+    prefix. *)
+
 val legacy_unstructured_fallback_claim_key : string -> bool
 (** Whether a persisted pre-[Diagnostic] recall key identifies a legacy
     librarian parse-failure fallback fact. This centralizes the historical

--- a/lib/keeper/keeper_tool_progress.ml
+++ b/lib/keeper/keeper_tool_progress.ml
@@ -117,6 +117,13 @@ let classify_tool_progress name =
     then Completion
     else if is_claim_context_tool_name name
     then Claim_context
+    else if
+      Keeper_tool_capability_axis.supports Board_activity name
+      ||
+      match effect_domain_for_tool_name name with
+      | Some (Tool_catalog.Playground_write | Tool_catalog.Host_repo_write) -> true
+      | Some Tool_catalog.Masc_workspace | Some Tool_catalog.Read_only | None -> false
+    then Execution
     else Passive_status)
 ;;
 

--- a/test/test_keeper_unified_claim_progress.ml
+++ b/test/test_keeper_unified_claim_progress.ml
@@ -125,6 +125,31 @@ let test_claim_contract_result_counts_initial_claim_as_execution () =
   ()
 ;;
 
+let test_execution_tools_satisfy_contract_progress () =
+  let result tools =
+    KAR.completion_contract_result_for_progress_evidence
+      ~had_owned_active_task_at_turn_start:true
+      ~actual_keeper_tool_names:tools
+    |> Masc.Keeper_execution_receipt.completion_contract_result_to_string
+  in
+  check
+    string
+    "execute tool counts as execution progress"
+    "satisfied_execution"
+    (result [ "tool_execute" ]);
+  check
+    string
+    "board write counts as execution progress"
+    "satisfied_execution"
+    (result [ "keeper_board_post" ]);
+  check
+    string
+    "passive status tools remain passive"
+    "passive_only"
+    (result [ "keeper_tasks_list" ]);
+  ()
+;;
+
 let tool_call_detail ?(outcome = "ok") tool_name : KAR.tool_call_detail =
   { tool_name
   ; provider = "test"
@@ -212,6 +237,10 @@ let () =
             "initial claim counts as contract progress"
             `Quick
             test_claim_contract_result_counts_initial_claim_as_execution
+        ; test_case
+            "execution tools satisfy contract progress"
+            `Quick
+            test_execution_tools_satisfy_contract_progress
         ; test_case
             "contract progress filters no-progress tool results"
             `Quick


### PR DESCRIPTION
## Summary
- classify keeper write-domain tools as `Execution` progress for completion-contract receipts
- keep observation/read-only tools classified as `Passive_status`
- add regression coverage for `tool_execute`, `keeper_board_post`, and `keeper_tasks_list`

## Why
Live idealist receipt for `task-1537` had `stop_reason=completed`, response text, and execution ids but still recorded `completion_contract_result=passive_only`, which caused `pause_human`. The classifier had an `Execution` variant but never returned it for ordinary write-domain tools.

## Stack
- stacked on #22596 until the fallback predicate export hotfix lands

## Verification
- `ocamlformat --check lib/keeper/keeper_tool_progress.ml test/test_keeper_unified_claim_progress.ml`
- `git diff --check`
- `scripts/dune-local.sh build test/test_keeper_unified_claim_progress.exe` was blocked by an unrelated bare `dune build @fmt --root .` process; build/test verification is left to CI per current workflow.