### PR TITLE
feat(memory): split fallback health buckets

### DIFF
--- a/dashboard/src/api/dashboard-misc.ts
+++ b/dashboard/src/api/dashboard-misc.ts
@@ -233,6 +233,8 @@ export interface KeeperMemoryHealthKeeperEntry {
   near_duplicate: number
   provider_slot_busy: number
   librarian_fallback_facts: number
+  librarian_fallback_empty_response_facts: number
+  librarian_fallback_nonempty_facts: number
   alerts: KeeperMemoryHealthAlert[]
 }
 
@@ -248,6 +250,8 @@ export interface KeeperMemoryHealthResponse {
     near_duplicate: number
     provider_slot_busy: number
     librarian_fallback_facts: number
+    librarian_fallback_empty_response_facts: number
+    librarian_fallback_nonempty_facts: number
   }
   alert_summary: {
     total_alerts: number

--- a/dashboard/src/components/memory/keeper-memory-health.test.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.test.ts
@@ -36,6 +36,8 @@ function makeEntry(
     near_duplicate: 0,
     provider_slot_busy: 0,
     librarian_fallback_facts: 0,
+    librarian_fallback_empty_response_facts: 0,
+    librarian_fallback_nonempty_facts: 0,
     alerts: [],
     ...overrides,
   }
@@ -58,6 +60,8 @@ function makeResponse(
       near_duplicate: 0,
       provider_slot_busy: 0,
       librarian_fallback_facts: 0,
+      librarian_fallback_empty_response_facts: 0,
+      librarian_fallback_nonempty_facts: 0,
       ...totalsOverrides,
     },
     alert_summary: alertSummary ?? makeAlertSummary(),
@@ -290,6 +294,8 @@ describe('KeeperMemoryHealth', () => {
           makeEntry({
             keeper_id: 'fallback-heavy',
             librarian_fallback_facts: 2,
+            librarian_fallback_empty_response_facts: 1,
+            librarian_fallback_nonempty_facts: 1,
             alerts: [{
               code: 'librarian_fallback_facts',
               severity: 'warn',
@@ -300,7 +306,11 @@ describe('KeeperMemoryHealth', () => {
               threshold: 0,
             }],
           }),
-        ], { librarian_fallback_facts: 2 }),
+        ], {
+          librarian_fallback_facts: 2,
+          librarian_fallback_empty_response_facts: 1,
+          librarian_fallback_nonempty_facts: 1,
+        }),
         alert_summary: makeAlertSummary({
           total_alerts: 1,
           warn_alerts: 1,
@@ -313,6 +323,7 @@ describe('KeeperMemoryHealth', () => {
 
       expect(screen.getByText('폴백')).not.toBeNull()
       expect(statValue(container, 'librarian-fallback-facts')).toBe('2')
+      expect(container.textContent).toContain('빈 1 · 원문 1')
     })
   })
 

--- a/dashboard/src/components/memory/keeper-memory-health.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.ts
@@ -54,6 +54,8 @@ function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
   const providerSlotBusyWarn = hasTargetAlert(alerts, PROVIDER_SLOT_BUSY_ALERT_TARGET)
   const librarianFallbackWarn = hasTargetAlert(alerts, LIBRARIAN_FALLBACK_ALERT_TARGET)
   const providerSlotBusyCount = providerSlotBusy(entry)
+  const fallbackDetail = `빈 ${entry.librarian_fallback_empty_response_facts} · 원문 ${entry.librarian_fallback_nonempty_facts}`
+  const fallbackTitle = `empty ${entry.librarian_fallback_empty_response_facts} / non-empty ${entry.librarian_fallback_nonempty_facts}`
 
   return html`
     <tr class=${warn ? 'kmh-row--warn' : ''}>
@@ -82,8 +84,11 @@ function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
       </td>
       <td>
         ${librarianFallbackWarn
-          ? html`<span class="kmh-badge kmh-badge--warn">${entry.librarian_fallback_facts}</span>`
-          : html`<span class="kmh-badge kmh-badge--ok">${entry.librarian_fallback_facts}</span>`}
+          ? html`<span class="kmh-badge kmh-badge--warn" title=${fallbackTitle}>${entry.librarian_fallback_facts}</span>`
+          : html`<span class="kmh-badge kmh-badge--ok" title=${fallbackTitle}>${entry.librarian_fallback_facts}</span>`}
+        ${entry.librarian_fallback_facts > 0
+          ? html`<span class="kmh-stat-detail">${fallbackDetail}</span>`
+          : null}
       </td>
       <td>
         ${alerts.length > 0
@@ -198,6 +203,9 @@ export function KeeperMemoryHealth() {
             <span class="kmh-stat-label">폴백 진단</span>
             <span class=${`kmh-stat-value${librarianFallbackWarn ? ' kmh-stat-value--warn' : ''}`}>
               ${data.totals.librarian_fallback_facts}
+            </span>
+            <span class="kmh-stat-detail">
+              빈 ${data.totals.librarian_fallback_empty_response_facts} · 원문 ${data.totals.librarian_fallback_nonempty_facts}
             </span>
           </div>
           <div class="kmh-stat" data-stat-key="alerts">

--- a/dashboard/src/styles/keeper-memory-health-v2.css
+++ b/dashboard/src/styles/keeper-memory-health-v2.css
@@ -57,6 +57,14 @@
   color: var(--accent-warn, #e0a82e);
 }
 
+.kmh-stat-detail {
+  display: inline-block;
+  margin-left: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
 .kmh-table-wrap {
   overflow-x: auto;
 }

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -356,6 +356,11 @@ let legacy_unstructured_fallback_claim (claim : string) =
   String.starts_with ~prefix:librarian_unstructured_fallback_claim_prefix claim
 ;;
 
+let legacy_unstructured_fallback_empty_response_claim (claim : string) =
+  legacy_unstructured_fallback_claim claim
+  && String.ends_with ~suffix:": <empty response>" claim
+;;
+
 let fact_prompt_recallable (fact : fact) =
   match fact.claim_kind with
   | Some Diagnostic -> false

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -241,6 +241,10 @@ val legacy_unstructured_fallback_claim : string -> bool
 (** Whether a fact claim carries the historical librarian parse-failure fallback
     prefix. *)
 
+val legacy_unstructured_fallback_empty_response_claim : string -> bool
+(** Whether a legacy librarian parse-failure fallback claim records an empty
+    provider response. *)
+
 val legacy_unstructured_fallback_claim_key : string -> bool
 (** Whether a persisted pre-[Diagnostic] recall key identifies a legacy
     librarian parse-failure fallback fact. This centralizes the historical

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -27,6 +27,8 @@ type keeper_health =
   ; near_duplicate : int
   ; provider_slot_busy : int
   ; librarian_fallback_facts : int
+  ; librarian_fallback_empty_response_facts : int
+  ; librarian_fallback_nonempty_facts : int
   }
 
 type alert_code =
@@ -226,14 +228,27 @@ let keeper_health ~keepers_dir ~now keeper_id =
     Keeper_memory_os_io.read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id
   in
   let facts_count = List.length facts in
-  let librarian_fallback_facts =
+  let librarian_fallback_facts, librarian_fallback_empty_response_facts =
     facts
     |> List.fold_left
-         (fun count (fact : Keeper_memory_os_types.fact) ->
+         (fun (total, empty_response) (fact : Keeper_memory_os_types.fact) ->
            if Keeper_memory_os_types.legacy_unstructured_fallback_claim fact.claim
-           then count + 1
-           else count)
-         0
+           then (
+             let empty_response =
+               empty_response
+               + if
+                 Keeper_memory_os_types
+                 .legacy_unstructured_fallback_empty_response_claim
+                   fact.claim
+               then 1
+               else 0
+             in
+             total + 1, empty_response)
+           else (total, empty_response))
+         (0, 0)
+  in
+  let librarian_fallback_nonempty_facts =
+    librarian_fallback_facts - librarian_fallback_empty_response_facts
   in
   let facts_bytes =
     file_size_bytes
@@ -264,6 +279,8 @@ let keeper_health ~keepers_dir ~now keeper_id =
   ; near_duplicate = gc_report.dedup_removed
   ; provider_slot_busy = provider_slot_busy_for_keeper keeper_id
   ; librarian_fallback_facts
+  ; librarian_fallback_empty_response_facts
+  ; librarian_fallback_nonempty_facts
   }
 ;;
 
@@ -279,6 +296,9 @@ let keeper_health_entry_to_json (h, alerts) : Yojson.Safe.t =
     ; "near_duplicate", `Int h.near_duplicate
     ; "provider_slot_busy", `Int h.provider_slot_busy
     ; "librarian_fallback_facts", `Int h.librarian_fallback_facts
+    ; ( "librarian_fallback_empty_response_facts"
+      , `Int h.librarian_fallback_empty_response_facts )
+    ; "librarian_fallback_nonempty_facts", `Int h.librarian_fallback_nonempty_facts
     ; "alerts", `List (List.map keeper_alert_to_json alerts)
     ]
 ;;
@@ -328,6 +348,10 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
           ; "provider_slot_busy", `Int (sum (fun h -> h.provider_slot_busy))
           ; ( "librarian_fallback_facts"
             , `Int (sum (fun h -> h.librarian_fallback_facts)) )
+          ; ( "librarian_fallback_empty_response_facts"
+            , `Int (sum (fun h -> h.librarian_fallback_empty_response_facts)) )
+          ; ( "librarian_fallback_nonempty_facts"
+            , `Int (sum (fun h -> h.librarian_fallback_nonempty_facts)) )
           ] )
     ; ( "alert_summary"
       , `Assoc

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -188,6 +188,14 @@ let test_reports_per_keeper_metric_values () =
     "no librarian fallback facts"
     0
     (int_field "librarian_fallback_facts" k);
+  Alcotest.(check int)
+    "no empty response fallback facts"
+    0
+    (int_field "librarian_fallback_empty_response_facts" k);
+  Alcotest.(check int)
+    "no nonempty fallback facts"
+    0
+    (int_field "librarian_fallback_nonempty_facts" k);
   Alcotest.(check int) "no keeper alerts" 0 (List.length (list_field "alerts" k));
   Alcotest.(check int) "totals.facts" 2 (int_field "facts" (totals json));
   Alcotest.(check bool)
@@ -304,20 +312,43 @@ let test_reports_librarian_fallback_facts_as_alert () =
     Types.librarian_unstructured_fallback_claim_prefix
     ^ " (librarian provider returned empty response): <empty response>"
   in
+  let invalid_json_fallback_claim =
+    Types.librarian_unstructured_fallback_claim_prefix
+    ^ " (librarian provider returned invalid episode JSON (invalid_json)): raw"
+  in
   Io.rewrite_facts_atomically_for_keepers_dir
     ~keepers_dir
     ~keeper_id:"fallback"
-    [ fact ~now "ordinary durable row"; librarian_fallback_fact ~now fallback_claim ];
+    [ fact ~now "ordinary durable row"
+    ; librarian_fallback_fact ~now fallback_claim
+    ; librarian_fallback_fact ~now invalid_json_fallback_claim
+    ];
   let json = Health.keeper_memory_health_http_json ~base_path:base in
   let k = keeper_obj "fallback" json in
   Alcotest.(check int)
     "librarian fallback facts projected"
-    1
+    2
     (int_field "librarian_fallback_facts" k);
   Alcotest.(check int)
-    "totals librarian fallback facts"
+    "empty response fallback facts projected"
     1
+    (int_field "librarian_fallback_empty_response_facts" k);
+  Alcotest.(check int)
+    "nonempty fallback facts projected"
+    1
+    (int_field "librarian_fallback_nonempty_facts" k);
+  Alcotest.(check int)
+    "totals librarian fallback facts"
+    2
     (int_field "librarian_fallback_facts" (totals json));
+  Alcotest.(check int)
+    "totals empty response fallback facts"
+    1
+    (int_field "librarian_fallback_empty_response_facts" (totals json));
+  Alcotest.(check int)
+    "totals nonempty fallback facts"
+    1
+    (int_field "librarian_fallback_nonempty_facts" (totals json));
   let alerts = list_field "alerts" k in
   Alcotest.(check (list string))
     "librarian fallback alert code"


### PR DESCRIPTION
## Summary
- split keeper memory-health fallback diagnostics into empty-response and non-empty buckets
- expose the bucket counts in backend JSON totals/per-keeper rows and dashboard typing
- render the bucket split beside the existing fallback diagnostic total

## Live observation
- current live fact store has 90 librarian fallback diagnostics across keepers
- only 2 are '<empty response>'; most are non-empty invalid JSON fallback rows

## Verification
- ocamlformat --check lib/keeper/keeper_memory_os_types.ml lib/keeper/keeper_memory_os_types.mli lib/server/server_dashboard_http_keeper_memory_health.ml test/test_server_dashboard_http_keeper_memory_health.ml
- npx tsc --noEmit --pretty (dashboard)
- npx vitest run --config vitest.config.ts src/components/memory/keeper-memory-health.test.ts --no-file-parallelism --maxWorkers=1 (dashboard)
- git diff --check

## Notes
- stacked on #22596 because main currently needs the keeper interface export recovery before CI can build this path