### PR TITLE
fix(ci): repair base OCaml compile breaks

### DIFF
--- a/lib/dashboard/dashboard_interaction_judge.ml
+++ b/lib/dashboard/dashboard_interaction_judge.ml
@@ -102,10 +102,10 @@ let prompt_for_facts facts_json =
      [Printf.sprintf "%s\n\nFacts:\n%s" template facts_str] 였는데 template 이
      format string 이 아니라 *인자*라 template 내부의 %s 가 치환되지 않은 채
      LLM 에게 literal "%s" 로 전달되었다(schema 위반의 근본 원인).
-     치환은 printf format 이 아니라 문자열 split/concat 으로 처리한다 —
+     치환은 printf format 이 아니라 문자열 replace 로 처리한다 —
      markdown 에 literal % (예 백분율) 가 추가돼도 [sprintf] 의 Invalid_arg
      로 judge 가 크래시하지 않는다(리뷰 nit). *)
-  String.concat facts_str (String.split_on_string "%s" template)
+  String_util.replace_substring ~needle:"%s" ~by:facts_str template
 
 let compute_judgments ~build_facts =
   let runtime_id = Runtime.get_default_runtime_id () in

--- a/lib/runtime/runtime_wire_overlay.ml
+++ b/lib/runtime/runtime_wire_overlay.ml
@@ -65,7 +65,6 @@ let agent_capabilities_of_llm_capabilities
   ; supports_code_execution = caps.supports_code_execution
   ; emits_usage_tokens = caps.emits_usage_tokens
   ; supported_models = caps.supported_models
-  ; reasoning_visibility_override = caps.reasoning_visibility_override
   }
 ;;
 


### PR DESCRIPTION
## Summary
- Remove the duplicate reasoning_visibility_override record field assignment in runtime_wire_overlay.
- Replace the nonexistent String.split_on_string call in dashboard_interaction_judge with the existing String_util.replace_substring helper.

## Validation
- ocamlformat --check lib/runtime/runtime_wire_overlay.ml lib/dashboard/dashboard_interaction_judge.ml
- ocamlc -stop-after parsing -impl lib/runtime/runtime_wire_overlay.ml
- ocamlc -stop-after parsing -impl lib/dashboard/dashboard_interaction_judge.ml
- git diff --check

## Local build note
- scripts/dune-local.sh build @check was blocked by the repo guard because unrelated bare Dune processes were already running on the machine, so this PR is relying on CI for full build/type validation.