### PR TITLE
fix(dashboard): show compaction snapshot coverage

### DIFF
--- a/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
+++ b/dashboard/src/components/keeper-workspace/compaction-inspector-overlay.ts
@@ -28,6 +28,7 @@ type CompactionSnapshotLoadState = {
   readonly decodedCount: number | null
   readonly payloadSource: string | null
   readonly payloadProducer: string | null
+  readonly payloadLimit: number | null
   readonly readErrorCount: number
   readonly readErrors: readonly CompactionReadError[]
   readonly scanTruncated: boolean
@@ -108,7 +109,7 @@ function CompactionScanDiagnostics({
     <div class="mem-read-error" role="status" data-testid="compaction-scan-diagnostics">
       <strong>스캔 진단</strong>
       ${loadState.readErrorCount > 0 ? html`<span>manifest row ${loadState.readErrorCount}개를 읽지 못했습니다.</span>` : null}
-      ${loadState.scanTruncated ? html`<span>응답이 limit에 의해 잘렸습니다.</span>` : null}
+      ${loadState.scanTruncated ? html`<span>manifest scan budget에 도달했습니다.</span>` : null}
       ${shownErrors.length > 0
         ? html`
           <ul>
@@ -119,6 +120,35 @@ function CompactionScanDiagnostics({
         `
         : null}
       ${hiddenErrorCount > 0 ? html`<span class="mono">+${hiddenErrorCount} more</span>` : null}
+    </div>
+  `
+}
+
+function CompactionCoverageStatus({
+  loadState,
+}: {
+  loadState: CompactionSnapshotLoadState
+}): VNode | null {
+  if (loadState.loading || loadState.error) return null
+  const payloadCount = loadState.payloadCount ?? 0
+  const decodedCount = loadState.decodedCount ?? 0
+  const source = loadState.payloadSource ?? 'unknown_source'
+  const producer = loadState.payloadProducer ?? 'unknown_producer'
+  const limit = loadState.payloadLimit ?? 0
+  return html`
+    <div class=${`cmp-coverage${loadState.scanTruncated ? ' warn' : ''}`} data-testid="compaction-coverage-status">
+      <div class="cmp-coverage-main">
+        <strong>durable hydrate</strong>
+        <span>표시 ${decodedCount}/${payloadCount}</span>
+        <span class="mono">source=${source}</span>
+      </div>
+      <div class="cmp-coverage-meta">
+        <span class="mono">producer=${producer}</span>
+        <span class="mono">limit=${limit}</span>
+      </div>
+      ${loadState.scanTruncated
+        ? html`<div class="cmp-coverage-note">manifest scan이 모두 끝나기 전에 중단되어 더 오래된 snapshot은 누락될 수 있습니다.</div>`
+        : null}
     </div>
   `
 }
@@ -170,6 +200,7 @@ export function CompactionInspectorOverlay({
     decodedCount: null,
     payloadSource: null,
     payloadProducer: null,
+    payloadLimit: null,
     readErrorCount: 0,
     readErrors: [],
     scanTruncated: false,
@@ -196,6 +227,7 @@ export function CompactionInspectorOverlay({
       decodedCount: null,
       payloadSource: null,
       payloadProducer: null,
+      payloadLimit: null,
       readErrorCount: 0,
       readErrors: [],
       scanTruncated: false,
@@ -213,6 +245,7 @@ export function CompactionInspectorOverlay({
           decodedCount: payload.items.length,
           payloadSource: payload.source,
           payloadProducer: payload.producer,
+          payloadLimit: payload.limit,
           readErrorCount: payload.read_error_count,
           readErrors: payload.read_errors,
           scanTruncated: payload.scan_truncated,
@@ -228,6 +261,7 @@ export function CompactionInspectorOverlay({
           decodedCount: null,
           payloadSource: null,
           payloadProducer: null,
+          payloadLimit: null,
           readErrorCount: 0,
           readErrors: [],
           scanTruncated: false,
@@ -254,6 +288,7 @@ export function CompactionInspectorOverlay({
               : loadState.error
                 ? html`<div class="mem-read-error" role="alert">${'⚠'} 컴팩션 스냅샷 불러오기 실패 — ${loadState.error}</div>`
                 : html`
+                  <${CompactionCoverageStatus} loadState=${loadState} />
                   <${CompactionScanDiagnostics} loadState=${loadState} />
                   <${CompactionEmptyState} keeperName=${keeper.name} loadState=${loadState} />
                 `}
@@ -296,7 +331,10 @@ export function CompactionInspectorOverlay({
             ? html`<div class="mem-empty mem-disclosure">durable snapshot 새로고침 중…</div>`
             : loadState.error
               ? html`<div class="mem-read-error" role="alert">${'⚠'} durable snapshot 새로고침 실패 — ${loadState.error}</div>`
-              : html`<${CompactionScanDiagnostics} loadState=${loadState} />`}
+              : html`
+                <${CompactionCoverageStatus} loadState=${loadState} />
+                <${CompactionScanDiagnostics} loadState=${loadState} />
+              `}
           <div class="cmp-trigger"><span class="sub-k">트리거</span>${ev.trigger}</div>
           <div class="cmp-trigger"><span class="sub-k">수행 런타임</span><span class="mono">${ev.runtime}</span></div>
           <div class="cmp-trigger"><span class="sub-k">소스</span><span class="mono">${ev.detailSource ?? ev.source}${ev.status ? ` · ${ev.status}` : ''}</span></div>

--- a/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
+++ b/dashboard/src/components/keeper-workspace/keeper-workspace-rail.test.ts
@@ -312,7 +312,7 @@ describe('KeeperWorkspaceRail', () => {
   })
 
   it('opens the compaction inspector overlay from the context rail and hydrates durable snapshots', async () => {
-    const { container } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} />`)
+    const { container, findByTestId } = render(html`<${KeeperWorkspaceRail} keeper=${keeper} />`)
     const btn = Array.from(container.querySelectorAll('.cmp-open')).find(
       el => el.textContent?.includes('before/after'),
     ) as HTMLElement | undefined
@@ -322,6 +322,10 @@ describe('KeeperWorkspaceRail', () => {
     expect(container.textContent).toContain('컴팩션 스냅샷')
     await waitFor(() => expect(container.textContent).toContain('210.0k'))
     expect(container.querySelector('[data-testid="compaction-scan-diagnostics"]')).toBeNull()
+    const coverage = await findByTestId('compaction-coverage-status')
+    expect(coverage.textContent).toContain('표시 1/1')
+    expect(coverage.textContent).toContain('source=runtime_manifest|keeper_meta')
+    expect(coverage.textContent).toContain('producer=keeper_runtime_manifest|keeper_meta_store')
     expect(container.textContent).toContain('proactive(85%)')
     expect(container.textContent).toContain('runtime_manifest · observed')
     expect(container.textContent).toContain('trace-cmp#12')
@@ -372,7 +376,10 @@ describe('KeeperWorkspaceRail', () => {
 
     const diagnostics = await findByTestId('compaction-scan-diagnostics')
     expect(diagnostics.textContent).toContain('manifest row 1개')
-    expect(diagnostics.textContent).toContain('limit')
+    expect(diagnostics.textContent).toContain('scan budget')
+    const coverage = await findByTestId('compaction-coverage-status')
+    expect(coverage.textContent).toContain('표시 1/1')
+    expect(coverage.textContent).toContain('더 오래된 snapshot은 누락')
     expect(container.textContent).toContain('pre_dispatch_hygiene')
     expect(container.textContent).toContain('runtime_manifest · compacted')
     expect(container.textContent).toContain('trace-live')
@@ -407,7 +414,9 @@ describe('KeeperWorkspaceRail', () => {
     const diagnostics = await findByTestId('compaction-scan-diagnostics')
     expect(diagnostics.textContent).toContain('manifest row 2개')
     expect(diagnostics.textContent).toContain('unknown event: "memory_injected"')
-    expect(diagnostics.textContent).toContain('limit')
+    expect(diagnostics.textContent).toContain('scan budget')
+    const coverage = await findByTestId('compaction-coverage-status')
+    expect(coverage.textContent).toContain('표시 0/0')
     expect(container.textContent).toContain('아직 이 keeper에서 durable compaction snapshot이 없습니다.')
     expect(container.textContent).toContain('api_count=0 · decoded=0')
   })
@@ -434,6 +443,7 @@ describe('KeeperWorkspaceRail', () => {
     fireEvent.click(btn as HTMLElement)
 
     await waitFor(() => expect(container.textContent).toContain('API는 masc-improver snapshot 2건을 보고'))
+    expect(container.querySelector('[data-testid="compaction-coverage-status"]')?.textContent).toContain('표시 0/2')
     expect(container.textContent).toContain('api_count=2 · decoded=0')
     expect(container.textContent).toContain('source=runtime_manifest|keeper_meta')
   })

--- a/dashboard/src/styles/keeper-v2/v2.css
+++ b/dashboard/src/styles/keeper-v2/v2.css
@@ -1276,6 +1276,41 @@
 
 /* compaction inspector body */
 .cmp-empty { font-size: 12.5px; line-height: 1.7; color: var(--text-dim); text-align: center; padding: 30px 12px; }
+.cmp-coverage {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 9px 11px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text-dim);
+  font-size: 11.5px;
+  line-height: 1.45;
+}
+.cmp-coverage.warn {
+  border-color: color-mix(in oklab, var(--status-warn) 38%, var(--border-soft));
+  background: color-mix(in oklab, var(--status-warn) 8%, var(--bg-card));
+}
+.cmp-coverage-main,
+.cmp-coverage-meta {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.cmp-coverage-main strong {
+  color: var(--text-mid);
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.cmp-coverage-note {
+  color: var(--status-warn);
+}
 .cmp-trigger { font-size: 12px; color: var(--text-mid); margin-bottom: 4px; }
 .cmp-trigger .sub-k { margin-right: 6px; }
 .cmp-headline { display: flex; align-items: center; gap: 10px; font-size: 20px; margin-bottom: 12px; }


### PR DESCRIPTION
## Summary
- show durable compaction snapshot coverage in the inspector, including decoded/API counts and source/producer
- clarify scan truncation as manifest scan budget rather than a response limit cut
- cover hydrated, truncated, empty, and schema-drift states in the rail test

## Verification
- npx tsc --noEmit --pretty
- npx vitest run --config vitest.config.ts src/components/keeper-workspace/keeper-workspace-rail.test.ts --no-file-parallelism --maxWorkers=1
- git diff --check