### PR TITLE
fix(dashboard): render interaction judge prompt via registry

### DIFF
--- a/config/prompts/dashboard_interaction_judge.md
+++ b/config/prompts/dashboard_interaction_judge.md
@@ -1,5 +1,11 @@
+---
+description: interaction judge prompt for dashboard collaboration surface
+category: dashboard
+template_variables: [facts_json]
+---
+
 You are the MASC Interaction Judge. Analyze the following workspace facts and logs:
-%s
+{{facts_json}}
 
 Evaluate two things based on the facts:
 1. Stigmergy Intensity (0.0 to 1.0): How much did each Keeper's actions alter the shared environment/tasks?

--- a/lib/dashboard/dashboard_interaction_judge.ml
+++ b/lib/dashboard/dashboard_interaction_judge.ml
@@ -1,6 +1,7 @@
 open Eio.Std
 
 let keeper_name = "interaction-judge"
+let prompt_dashboard_interaction_judge = "dashboard_interaction_judge"
 
 type interaction = {
   source : string;
@@ -94,30 +95,27 @@ let fresh_interactions_json ~base_path =
   )
 
 let prompt_for_facts facts_json =
-  let facts_str = Yojson.Safe.to_string facts_json in
-  let template =
-    In_channel.with_open_text "config/prompts/dashboard_interaction_judge.md" In_channel.input_all
-  in
-  (* template 은 facts 자리에 %s placeholder(L2)를 가진다. 이전 코드는
-     [Printf.sprintf "%s\n\nFacts:\n%s" template facts_str] 였는데 template 이
-     format string 이 아니라 *인자*라 template 내부의 %s 가 치환되지 않은 채
-     LLM 에게 literal "%s" 로 전달되었다(schema 위반의 근본 원인).
-     치환은 printf format 이 아니라 문자열 replace 로 처리한다 —
-     markdown 에 literal % (예 백분율) 가 추가돼도 [sprintf] 의 Invalid_arg
-     로 judge 가 크래시하지 않는다(리뷰 nit). *)
-  String_util.replace_substring ~needle:"%s" ~by:facts_str template
+  Prompt_registry.render_prompt_template prompt_dashboard_interaction_judge
+    [ ("facts_json", Yojson.Safe.to_string facts_json) ]
+  |> Result.map_error (fun msg ->
+         Agent_sdk.Error.Internal
+           ("dashboard_interaction_judge prompt render failed: " ^ msg))
 
 let compute_judgments ~build_facts =
   let runtime_id = Runtime.get_default_runtime_id () in
-  Masc_oas_bridge.run_with_caller ~caller:Env_config_oas_bridge.Operator_judge (fun () ->
-    let factual_json = build_facts () in
-    let prompt = prompt_for_facts factual_json in
-    Keeper_turn_driver_wrappers.run_named_with_masc_tools ~runtime_id
-      ~goal:prompt ~masc_tools:[] ~dispatch:(fun ~name ~args:_ -> Tool_result.error ~tool_name:name ~start_time:0.0 "no tools")
-      ~accept:Keeper_tool_response.response_has_text_or_tool_progress
-      ~approval:Approval_callbacks.auto_approve
-      ()
-  )
+  Masc_oas_bridge.run_with_caller
+    ~caller:Env_config_oas_bridge.Operator_judge
+    (fun () ->
+      let factual_json = build_facts () in
+      match prompt_for_facts factual_json with
+      | Error err -> Error err
+      | Ok prompt ->
+          Keeper_turn_driver_wrappers.run_named_with_masc_tools ~runtime_id
+            ~goal:prompt ~masc_tools:[]
+            ~dispatch:(fun ~name ~args:_ ->
+              Tool_result.error ~tool_name:name ~start_time:0.0 "no tools")
+            ~accept:Keeper_tool_response.response_has_text_or_tool_progress
+            ~approval:Approval_callbacks.auto_approve ())
 
 let refresh_once st build_facts =
   Eio_guard.with_mutex st.mu (fun () ->

--- a/test/test_prompt_registry_defaults.ml
+++ b/test/test_prompt_registry_defaults.ml
@@ -33,7 +33,9 @@ let prompt_metadata key =
   | "keeper.deliberation" ->
       ("test prompt for " ^ key,
        [ "keeper_name"; "soul_profile"; "goal"; "triggers"; "world_state" ])
-  | "dashboard.operator_judge" | "dashboard.governance_judge" ->
+  | "dashboard.operator_judge"
+  | "dashboard.governance_judge"
+  | "dashboard_interaction_judge" ->
       ("test prompt for " ^ key, [ "facts_json" ])
   | _ -> ("test prompt for " ^ key, [])
 
@@ -68,6 +70,7 @@ let fixtures =
     ("governance.dry_run", "DRY RUN governance prompt");
     ("dashboard.operator_judge", "operator facts {{facts_json}}");
     ("dashboard.governance_judge", "governance facts {{facts_json}}");
+    ("dashboard_interaction_judge", "interaction facts {{facts_json}}");
     ("test.unlisted.vars", "template body still has {{missing_var}}");
   ]
 
@@ -119,7 +122,7 @@ let () =
           test_case "all markdown-backed prompts are registered" `Quick (fun () ->
               with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
               let prompts = Prompt_registry.list_prompts () in
-              check int "registered prompt count" 10 (List.length prompts));
+              check int "registered prompt count" 11 (List.length prompts));
           test_case "get_prompt resolves markdown content" `Quick (fun () ->
               with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
               check string "keeper.constitution"
@@ -177,6 +180,18 @@ let () =
                             rendered 0);
                        true
                      with Not_found -> false)
+              | Error msg -> fail msg);
+          test_case "interaction judge prompt renders from registry" `Quick
+            (fun () ->
+              with_registry @@ fun ~dir:_ ~prompts_dir:_ ->
+              match
+                Prompt_registry.render_prompt_template "dashboard_interaction_judge"
+                  [ ("facts_json", {|{"keepers":[]}|}) ]
+              with
+              | Ok rendered ->
+                  check string "rendered interaction prompt"
+                    {|interaction facts {"keepers":[]}|}
+                    rendered
               | Error msg -> fail msg);
           test_case "render_prompt_template replaces whitespace placeholders" `Quick
             (fun () ->


### PR DESCRIPTION
## Summary
- Move dashboard interaction judge prompt rendering onto Prompt_registry SSOT
- Convert the prompt file from literal %s placeholder to registered {{facts_json}} template metadata
- Propagate prompt render failures through Agent_sdk.Error instead of silently sending an unresolved prompt
- Add prompt registry coverage for the interaction judge key

## Verification
- ocamlformat --check lib/dashboard/dashboard_interaction_judge.ml test/test_prompt_registry_defaults.ml
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build bin/main_eio.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_prompt_registry_defaults.exe
- ./_build/default/test/test_prompt_registry_defaults.exe

## Notes
- This is intentionally separate from #22602. #22602 repaired the base compile failure, but kept direct prompt-file I/O plus string replacement in this path.
