### PR TITLE
fix(keeper): schedule event queue stimuli as typed triggers

### DIFF
--- a/lib/keeper/keeper_heartbeat_loop.ml
+++ b/lib/keeper/keeper_heartbeat_loop.ml
@@ -53,6 +53,7 @@ type heartbeat_event_intake = Stimulus_intake.heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
+  event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
 let consume_single_heartbeat_stimulus = Stimulus_intake.consume_single_heartbeat_stimulus
@@ -202,6 +203,7 @@ let run_keepalive_unified_turn
       let scheduling =
         decide_keepalive_scheduling
           ~reactive_wake
+          ~event_queue_triggers:event_intake.event_queue_triggers
           ~keeper_resilience_of_name:(fun keeper_name ->
             if Health.is_healthy ~agent_name:keeper_name then None
             else Some "unhealthy")

--- a/lib/keeper/keeper_heartbeat_loop.mli
+++ b/lib/keeper/keeper_heartbeat_loop.mli
@@ -52,6 +52,7 @@ type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
+  event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
 val heartbeat_event_intake :
@@ -74,6 +75,7 @@ val decide_keepalive_scheduling :
   ?runtime_resilience_of_name:(string -> string option) ->
   ?keeper_resilience_of_name:(string -> string option) ->
   ?reactive_wake:bool ->
+  ?event_queue_triggers:Keeper_world_observation.event_queue_trigger list ->
   ?wake_tombstone_decide:
     (origin:Keeper_wake_tombstone.wake_origin ->
      keeper_name:string ->

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.ml
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.ml
@@ -29,13 +29,18 @@ let decide_keepalive_scheduling
       ?(runtime_resilience_of_name = fun _ -> None)
       ?(keeper_resilience_of_name = fun _ -> None)
       ?(reactive_wake = false)
+      ?(event_queue_triggers = [])
       ?(wake_tombstone_decide = Keeper_wake_tombstone.decide)
       ~stop
       ~meta
       obs
   =
   let turn_decision =
-    Keeper_world_observation.keeper_cycle_decision ~reactive_wake ~meta obs
+    Keeper_world_observation.keeper_cycle_decision
+      ~reactive_wake
+      ~event_queue_triggers
+      ~meta
+      obs
   in
   let requested_should_run_turn =
     (not (Atomic.get stop)) && turn_decision.should_run

--- a/lib/keeper/keeper_heartbeat_loop_scheduling.mli
+++ b/lib/keeper/keeper_heartbeat_loop_scheduling.mli
@@ -14,6 +14,7 @@ val decide_keepalive_scheduling :
   ?runtime_resilience_of_name:(string -> string option) ->
   ?keeper_resilience_of_name:(string -> string option) ->
   ?reactive_wake:bool ->
+  ?event_queue_triggers:Keeper_world_observation.event_queue_trigger list ->
   ?wake_tombstone_decide:
     (origin:Keeper_wake_tombstone.wake_origin ->
      keeper_name:string ->

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.ml
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.ml
@@ -55,7 +55,19 @@ type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
+  event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
+
+let event_queue_trigger_of_stimulus (stim : Keeper_event_queue.stimulus) =
+  match stim.payload with
+  | Keeper_event_queue.Bootstrap -> Some Keeper_world_observation.Bootstrap_stimulus
+  | Keeper_event_queue.No_progress_recovery ->
+    Some Keeper_world_observation.No_progress_recovery_stimulus
+  | Keeper_event_queue.Board_signal _
+  | Keeper_event_queue.Fusion_completed _
+  | Keeper_event_queue.Bg_completed _ ->
+    None
+;;
 
 let consume_single_heartbeat_stimulus
       ~(ctx : _ context)
@@ -163,6 +175,7 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
     | batch -> consume_board_stimulus_batch ~meta_after_triage batch, batch
   in
   let consumed_stimulus_count = List.length consumed_stimuli in
+  let event_queue_triggers = List.filter_map event_queue_trigger_of_stimulus consumed_stimuli in
   let pending_board_events =
     List.fold_left
       (fun acc (event : Keeper_world_observation.pending_board_event) ->
@@ -183,5 +196,5 @@ let heartbeat_event_intake ~ctx ~meta_after_triage ~pending_board_events =
       pending_board_events
       (List.rev queued_observations)
   in
-  { pending_board_events; consumed_stimulus_count; consumed_stimuli }
+  { pending_board_events; consumed_stimulus_count; consumed_stimuli; event_queue_triggers }
 ;;

--- a/lib/keeper/keeper_heartbeat_stimulus_intake.mli
+++ b/lib/keeper/keeper_heartbeat_stimulus_intake.mli
@@ -36,6 +36,7 @@ type heartbeat_event_intake = {
   pending_board_events : Keeper_world_observation.pending_board_event list;
   consumed_stimulus_count : int;
   consumed_stimuli : Keeper_event_queue.stimulus list;
+  event_queue_triggers : Keeper_world_observation.event_queue_trigger list;
 }
 
 (** [consume_single_heartbeat_stimulus ~ctx ~meta_after_triage stim]

--- a/lib/keeper/keeper_world_observation.ml
+++ b/lib/keeper/keeper_world_observation.ml
@@ -101,10 +101,17 @@ type keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
 
+type event_queue_trigger =
+  Keeper_world_observation_turn_types.event_queue_trigger =
+  | Bootstrap_stimulus
+  | No_progress_recovery_stimulus
+
 type turn_reason = Keeper_world_observation_turn_types.turn_reason =
   | Mention_pending
   | Board_event_pending
   | Scope_message_pending
+  | Bootstrap_stimulus_pending
+  | No_progress_recovery_stimulus_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of
@@ -135,6 +142,8 @@ type turn_verdict = Keeper_world_observation_turn_types.turn_verdict =
 
 let turn_reason_to_string =
   Keeper_world_observation_turn_types.turn_reason_to_string
+let turn_reason_of_event_queue_trigger =
+  Keeper_world_observation_turn_types.turn_reason_of_event_queue_trigger
 let skip_reason_to_string =
   Keeper_world_observation_turn_types.skip_reason_to_string
 let channel_to_string = Keeper_world_observation_turn_types.channel_to_string
@@ -995,9 +1004,13 @@ let effective_scheduled_autonomous_cooldown
 let keeper_cycle_decision
       ?(provider_cooldown_remaining_sec = provider_cooldown_remaining_sec_for_runtime)
       ?(reactive_wake = false)
+      ?(event_queue_triggers = [])
       ~(meta : keeper_meta)
       (observation : world_observation)
   =
+  let event_queue_reactive_triggers =
+    List.map turn_reason_of_event_queue_trigger event_queue_triggers
+  in
   let reactive_triggers =
     [ (if observation.pending_mentions <> [] then Some Mention_pending else None)
     ; (if observation.pending_board_events <> [] then Some Board_event_pending else None)
@@ -1006,6 +1019,7 @@ let keeper_cycle_decision
        else None)
     ]
     |> List.filter_map Fun.id
+    |> fun triggers -> triggers @ event_queue_reactive_triggers
   in
   let blocked_channel =
     match reactive_triggers with

--- a/lib/keeper/keeper_world_observation.mli
+++ b/lib/keeper/keeper_world_observation.mli
@@ -153,12 +153,18 @@ type keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
 
+type event_queue_trigger =
+  | Bootstrap_stimulus
+  | No_progress_recovery_stimulus
+
 (** Typed reason for running a keeper cycle. Each variant corresponds to
     exactly one code path in {!keeper_cycle_decision}. *)
 type turn_reason =
   | Mention_pending
   | Board_event_pending
   | Scope_message_pending
+  | Bootstrap_stimulus_pending
+  | No_progress_recovery_stimulus_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of { idle_sec : int; cooldown : int }
@@ -190,6 +196,9 @@ type turn_verdict =
     The tag is a stable snake_case form of the typed variant.
     Variant payloads are intentionally omitted. *)
 val turn_reason_to_string : turn_reason -> string
+
+(** Convert an Event Queue stimulus trigger into the corresponding run reason. *)
+val turn_reason_of_event_queue_trigger : event_queue_trigger -> turn_reason
 
 (** Convert a single skip reason to a flat string tag.
     The tag is a stable snake_case form of the typed variant.
@@ -370,6 +379,7 @@ val keeper_cycle_decision :
   ?provider_cooldown_remaining_sec:
     (keeper_name:string -> runtime_id:string -> int option) ->
   ?reactive_wake:bool ->
+  ?event_queue_triggers:event_queue_trigger list ->
   meta:Keeper_meta_contract.keeper_meta -> world_observation -> keeper_cycle_decision
 (** [reactive_wake] (default [false]) marks evaluations triggered by an external
     broadcast wakeup rather than the keeper's own cadence timer. When set, a

--- a/lib/keeper_contract/keeper_world_observation_turn_types.ml
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.ml
@@ -26,10 +26,16 @@ type keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
 
+type event_queue_trigger =
+  | Bootstrap_stimulus
+  | No_progress_recovery_stimulus
+
 type turn_reason =
   | Mention_pending
   | Board_event_pending
   | Scope_message_pending
+  | Bootstrap_stimulus_pending
+  | No_progress_recovery_stimulus_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of
@@ -62,6 +68,8 @@ let turn_reason_to_string = function
   | Mention_pending -> "mention_pending"
   | Board_event_pending -> "board_event_pending"
   | Scope_message_pending -> "scope_message_pending"
+  | Bootstrap_stimulus_pending -> "bootstrap_stimulus_pending"
+  | No_progress_recovery_stimulus_pending -> "no_progress_recovery_stimulus_pending"
   | Scheduled_autonomous_turn -> "scheduled_autonomous_turn"
   | Scheduled_automation_due -> "scheduled_automation_due"
   | Idle_cooldown_elapsed _ -> "idle_cooldown_elapsed"
@@ -70,6 +78,11 @@ let turn_reason_to_string = function
   | Task_reactive_cooldown_elapsed -> "task_reactive_cooldown_elapsed"
   | Never_started -> "never_started"
   | Min_interval_elapsed -> "min_interval_elapsed"
+;;
+
+let turn_reason_of_event_queue_trigger = function
+  | Bootstrap_stimulus -> Bootstrap_stimulus_pending
+  | No_progress_recovery_stimulus -> No_progress_recovery_stimulus_pending
 ;;
 
 let skip_reason_to_string = function

--- a/lib/keeper_contract/keeper_world_observation_turn_types.mli
+++ b/lib/keeper_contract/keeper_world_observation_turn_types.mli
@@ -4,10 +4,16 @@ type keeper_cycle_channel =
   | Reactive
   | Scheduled_autonomous
 
+type event_queue_trigger =
+  | Bootstrap_stimulus
+  | No_progress_recovery_stimulus
+
 type turn_reason =
   | Mention_pending
   | Board_event_pending
   | Scope_message_pending
+  | Bootstrap_stimulus_pending
+  | No_progress_recovery_stimulus_pending
   | Scheduled_autonomous_turn
   | Scheduled_automation_due
   | Idle_cooldown_elapsed of
@@ -37,6 +43,7 @@ type turn_verdict =
   | Skip of { reasons : skip_reason * skip_reason list }
 
 val turn_reason_to_string : turn_reason -> string
+val turn_reason_of_event_queue_trigger : event_queue_trigger -> turn_reason
 val skip_reason_to_string : skip_reason -> string
 val channel_to_string : keeper_cycle_channel -> string
 

--- a/test/test_keeper_no_signal_silence.ml
+++ b/test/test_keeper_no_signal_silence.ml
@@ -161,6 +161,14 @@ let schedule_ready_meta () =
   }
 ;;
 
+let run_reasons d =
+  match d.WO.verdict with
+  | WO.Run { reasons = first, rest } -> first :: rest
+  | WO.Skip _ -> []
+;;
+
+let has_run_reason reason d = List.exists (( = ) reason) (run_reasons d)
+
 (* Core invariant (PR #21685): a warm keeper with no signal and no backlog
    stays silent. The removed [Entropic_oscillation] trigger was the only path
    that ran a turn in this state; deleting it makes [should_run] deterministically
@@ -196,9 +204,39 @@ let test_scheduled_automation_attention_runs_after_task_cooldown () =
   in
   check bool "scheduled automation attention runs" true d.should_run;
   check bool "reason includes scheduled_automation_due" true
-    (List.mem
-       "scheduled_automation_due"
-       (WO.verdict_reasons_to_strings d.verdict))
+    (has_run_reason WO.Scheduled_automation_due d)
+
+let test_bootstrap_event_queue_trigger_runs_warm_keeper () =
+  let meta = warm_meta () in
+  let d =
+    WO.keeper_cycle_decision
+      ~provider_cooldown_remaining_sec:no_provider_cooldown
+      ~reactive_wake:false
+      ~event_queue_triggers:[ WO.Bootstrap_stimulus ]
+      ~meta
+      no_signal_obs
+  in
+  check bool "bootstrap event queue trigger runs" true d.should_run;
+  check bool "bootstrap trigger stays reactive" true
+    (match d.channel with
+     | WO.Reactive -> true
+     | WO.Scheduled_autonomous -> false);
+  check bool "reason includes bootstrap stimulus" true
+    (has_run_reason WO.Bootstrap_stimulus_pending d)
+
+let test_no_progress_event_queue_trigger_runs_warm_keeper () =
+  let meta = warm_meta () in
+  let d =
+    WO.keeper_cycle_decision
+      ~provider_cooldown_remaining_sec:no_provider_cooldown
+      ~reactive_wake:false
+      ~event_queue_triggers:[ WO.No_progress_recovery_stimulus ]
+      ~meta
+      no_signal_obs
+  in
+  check bool "no-progress event queue trigger runs" true d.should_run;
+  check bool "reason includes no-progress stimulus" true
+    (has_run_reason WO.No_progress_recovery_stimulus_pending d)
 
 let () = init_runtime_default_for_tests ()
 
@@ -218,6 +256,14 @@ let () =
             "scheduled automation attention runs after task cooldown"
             `Quick
             test_scheduled_automation_attention_runs_after_task_cooldown
+        ; test_case
+            "bootstrap event queue trigger runs warm keeper"
+            `Quick
+            test_bootstrap_event_queue_trigger_runs_warm_keeper
+        ; test_case
+            "no-progress event queue trigger runs warm keeper"
+            `Quick
+            test_no_progress_event_queue_trigger_runs_warm_keeper
         ] )
     ]
 ;;


### PR DESCRIPTION
## Summary
- Add typed Event Queue scheduling triggers for Bootstrap and No_progress_recovery stimuli.
- Pass consumed non-board stimulus triggers from heartbeat intake into keeper_cycle_decision.
- Preserve the no-signal warm-keeper silence invariant while proving warm bootstrap/no-progress stimuli run and can be acked after a completed turn.

## Runtime Evidence
- Live runtime at 95dfb59cae0 repeatedly consumed bootstrap stimuli after restart without writing any post-restart decision rows.
- albini queue dedupe reduced persisted duplicate rows, but bootstrap was still leased/requeued because Bootstrap produced no pending_board_event and scheduling returned No_signal.

## Verification
- ocamlformat --check changed OCaml files
- git diff --check
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_no_signal_silence.exe
- ./_build/default/test/test_keeper_no_signal_silence.exe
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build bin/main_eio.exe
