### PR TITLE
refactor(config): remove dead autoboot_max config mapping

### DIFF
--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -11,7 +11,6 @@ let key_to_env =
     "bootstrap.stale_turn_sec",         "MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC";
     "bootstrap.max_scan",               "MASC_KEEPER_BOOTSTRAP_MAX_SCAN";
     "bootstrap.max_active_keepers",     "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS";
-    "bootstrap.autoboot_max",           "MASC_KEEPER_AUTOBOOT_MAX";
     (* [autonomous] *)
     "autonomous.fairness_cooldown_sec", "MASC_KEEPER_AUTONOMOUS_FAIRNESS_COOLDOWN_SEC";
     "autonomous.max_idle_turns",        "MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS";


### PR DESCRIPTION
## Context

`bootstrap.autoboot_max` (`MASC_KEEPER_AUTOBOOT_MAX`) is a **dead config** — it exists only as an env→key mapping in `keeper_runtime_config.ml` and a `[bootstrap]` entry in runtime.toml, but the value is **never read anywhere** (no consumer in env_config, bootstrap loops, or keeper runtime). Operators setting it has no effect.

Removing it per the dead-config / hardcoding-and-legacy-zero-tolerance bar.

## Changes

- `lib/keeper_runtime/keeper_runtime_config.ml`: drop the `"bootstrap.autoboot_max" → "MASC_KEEPER_AUTOBOOT_MAX"` mapping line.
- runtime.toml `[bootstrap] autoboot_max = 5`: removed separately as operational config (local .masc).

## Verification

- `dune build lib/masc.cma` EXIT 0 (no consumer → no compile impact).
- `rg AUTOBOOT_MAX lib/` → no remaining functional refs (only a legacy AUTOBOT_MAX-typo comment in env_config_core, unrelated).

No behavior change.

Co-Authored-By: Claude <noreply@anthropic.com>
