### PR TITLE
feat(fusion): add staged_judge_of_judges preset (6 ollama_cloud judges)

### DIFF
--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -1004,11 +1004,11 @@ model = "ollama_cloud.ollama-cloud-deepseek-v4-pro"
 label = "synthesizer"
 system_prompt = "Synthesize the panel answers: consensus, contradictions, partial coverage, unique insights, blind spots. Give one resolved answer. Respond with ONLY the requested JSON object, no prose, no code fences."
 [[fusion.presets.staged_joj.judges]]
-model = "ollama_cloud.minimax-m3"
+model = "ollama_cloud.ollama-cloud-minimax-m3"
 label = "consensus-builder"
 system_prompt = "Focus on points of consensus across the panel; resolve contradictions conservatively. Give one resolved answer. Respond with ONLY the requested JSON object, no prose, no code fences."
 [[fusion.presets.staged_joj.judges]]
-model = "ollama_cloud.kimi-k2-6"
+model = "ollama_cloud.ollama-cloud-kimi-k2-7-code"
 label = "devils-advocate"
 system_prompt = "Challenge the panel's dominant view; surface blind spots and unstated assumptions. Then give one resolved answer. Respond with ONLY the requested JSON object, no prose, no code fences."
 [[fusion.presets.staged_joj.judges]]

--- a/config/runtime.toml
+++ b/config/runtime.toml
@@ -972,3 +972,54 @@ judge_timeout_s = 300.0
 web_tools = false
 # 패널 모델당 최대 tool 호출 수 (0 = 무제한, OpenRouter Fusion 허용 범위 0..16).
 max_tool_calls_per_panel = 0
+
+[fusion.presets.staged_joj]
+# judge_of_judges 연쇄(staged): 1차 심판 6개(ollama_cloud 개별) → 그룹별 종합 →
+# 메타 심판 최종 종합. keeper가 fusion tool에 topology="staged_judge_of_judges"로 호출.
+panel = [
+  "ollama_cloud.deepseek-v4-flash",
+  "glm-coding.glm-5-turbo",
+  "ollama_cloud.minimax-m3",
+]
+judge = "deepseek.deepseek-v4-pro"
+panel_system_prompt = """
+You are an expert panelist. Answer the user's question directly and concisely \
+with your best independent analysis. Do not defer to other models; give your \
+own view.
+"""
+judge_system_prompt = """
+You are the final meta-judge. You are given per-group syntheses of a panel of \
+model answers. Reconcile them into one resolved answer: identify cross-group \
+consensus, contradictions, and the strongest synthesis, then give one resolved \
+answer. Respond with ONLY the requested JSON object, no prose and no code fences.
+"""
+panel_timeout_s = 300.0
+judge_timeout_s = 300.0
+web_tools = false
+max_tool_calls_per_panel = 0
+staged_judge_group_size = 3
+
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.ollama-cloud-deepseek-v4-pro"
+label = "synthesizer"
+system_prompt = "Synthesize the panel answers: consensus, contradictions, partial coverage, unique insights, blind spots. Give one resolved answer. Respond with ONLY the requested JSON object, no prose, no code fences."
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.minimax-m3"
+label = "consensus-builder"
+system_prompt = "Focus on points of consensus across the panel; resolve contradictions conservatively. Give one resolved answer. Respond with ONLY the requested JSON object, no prose, no code fences."
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.kimi-k2-6"
+label = "devils-advocate"
+system_prompt = "Challenge the panel's dominant view; surface blind spots and unstated assumptions. Then give one resolved answer. Respond with ONLY the requested JSON object, no prose, no code fences."
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.ollama-cloud-glm-5-2"
+label = "evidence-checker"
+system_prompt = "Ground the synthesis in the panel's strongest evidence; flag unsupported claims. Give one resolved answer. Respond with ONLY the requested JSON object, no prose, no code fences."
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.ollama-cloud-gpt-oss-120b"
+label = "synthesizer-2"
+system_prompt = "Synthesize the panel answers: consensus, contradictions, unique insights. Give one resolved answer. Respond with ONLY the requested JSON object, no prose, no code fences."
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.ollama-cloud-gemini-3-flash-preview"
+label = "synthesizer-3"
+system_prompt = "Synthesize the panel answers into one resolved answer. Respond with ONLY the requested JSON object, no prose, no code fences."

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -929,6 +929,92 @@ let test_config_judges_parse () =
     Alcotest.failf "expected Ok, got errors: %s"
       (String.concat ", " (List.map Fusion_config.show_config_error es))
 
+let staged_joj_toml =
+  {|
+[fusion]
+enabled = true
+default_preset = "staged_joj"
+max_concurrent_panels = 2
+max_concurrent_judges = 3
+staged_judge_group_size = 3
+[fusion.presets.staged_joj]
+panel = [
+  "ollama_cloud.deepseek-v4-flash",
+  "glm-coding.glm-5-turbo",
+  "ollama_cloud.minimax-m3",
+]
+judge = "deepseek.deepseek-v4-pro"
+panel_system_prompt = "answer independently"
+judge_system_prompt = "synthesize staged judge groups"
+panel_timeout_s = 300.0
+judge_timeout_s = 300.0
+web_tools = false
+max_tool_calls_per_panel = 0
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.ollama-cloud-deepseek-v4-pro"
+label = "synthesizer"
+system_prompt = "Synthesize the panel answers."
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.minimax-m3"
+label = "consensus-builder"
+system_prompt = "Focus on consensus."
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.kimi-k2-6"
+label = "devils-advocate"
+system_prompt = "Challenge the dominant view."
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.ollama-cloud-glm-5-2"
+label = "evidence-checker"
+system_prompt = "Check evidence."
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.ollama-cloud-gpt-oss-120b"
+label = "synthesizer-2"
+system_prompt = "Synthesize again."
+[[fusion.presets.staged_joj.judges]]
+model = "ollama_cloud.ollama-cloud-gemini-3-flash-preview"
+label = "synthesizer-3"
+system_prompt = "Synthesize into one answer."
+|}
+
+let test_config_staged_joj_preset () =
+  match Fusion_config.of_toml (parse staged_joj_toml) with
+  | Ok p ->
+    Alcotest.(check bool) "enabled" true p.Fusion_policy.enabled;
+    Alcotest.(check string) "default preset" "staged_joj"
+      p.Fusion_policy.default_preset;
+    Alcotest.(check int) "judge concurrency" 3 p.Fusion_policy.max_concurrent_judges;
+    Alcotest.(check int) "staged group size" 3 p.Fusion_policy.staged_judge_group_size;
+    (match p.Fusion_policy.presets with
+     | [ vp ] ->
+       let preset = raw vp in
+       Alcotest.(check string) "preset name" "staged_joj" preset.Fusion_policy.name;
+       Alcotest.(check int) "panel size" 3
+         (List.length (Fusion_policy.preset_models preset));
+       Alcotest.(check (list string)) "judge labels"
+         [ "synthesizer"
+         ; "consensus-builder"
+         ; "devils-advocate"
+         ; "evidence-checker"
+         ; "synthesizer-2"
+         ; "synthesizer-3"
+         ]
+         (List.map (fun j -> j.Fusion_policy.jlabel) preset.Fusion_policy.judges);
+       (match
+          Fusion_policy.staged_judge_groups
+            ~group_size:p.Fusion_policy.staged_judge_group_size
+            preset.Fusion_policy.judges
+        with
+        | Ok groups ->
+          Alcotest.(check (list int)) "two full judge groups" [ 3; 3 ]
+            (List.map List.length groups)
+        | Error e ->
+          Alcotest.failf "expected staged groups, got %s"
+            (Fusion_policy.show_staged_judge_group_error e))
+     | _ -> Alcotest.fail "expected exactly one staged_joj preset")
+  | Error es ->
+    Alcotest.failf "expected Ok, got errors: %s"
+      (String.concat ", " (List.map Fusion_config.show_config_error es))
+
 (* judges sub-table 없는 preset → preset.judges = [] (단일 심판 위상 config). *)
 let test_config_no_judges () =
   match Fusion_config.of_toml (parse golden_single_group_toml) with
@@ -1580,6 +1666,7 @@ let () =
         ; Alcotest.test_case "empty_default_preset" `Quick test_config_empty_default_preset
         ; Alcotest.test_case "disabled_with_preset" `Quick test_config_disabled_with_preset
         ; Alcotest.test_case "judges_parse" `Quick test_config_judges_parse
+        ; Alcotest.test_case "staged_joj_preset" `Quick test_config_staged_joj_preset
         ; Alcotest.test_case "no_judges" `Quick test_config_no_judges
         ; Alcotest.test_case "adaptive_timeout_parse" `Quick
             test_config_adaptive_timeout_parse

--- a/test/fusion_core/test_fusion.ml
+++ b/test/fusion_core/test_fusion.ml
@@ -955,11 +955,11 @@ model = "ollama_cloud.ollama-cloud-deepseek-v4-pro"
 label = "synthesizer"
 system_prompt = "Synthesize the panel answers."
 [[fusion.presets.staged_joj.judges]]
-model = "ollama_cloud.minimax-m3"
+model = "ollama_cloud.ollama-cloud-minimax-m3"
 label = "consensus-builder"
 system_prompt = "Focus on consensus."
 [[fusion.presets.staged_joj.judges]]
-model = "ollama_cloud.kimi-k2-6"
+model = "ollama_cloud.ollama-cloud-kimi-k2-7-code"
 label = "devils-advocate"
 system_prompt = "Challenge the dominant view."
 [[fusion.presets.staged_joj.judges]]
@@ -999,6 +999,15 @@ let test_config_staged_joj_preset () =
          ; "synthesizer-3"
          ]
          (List.map (fun j -> j.Fusion_policy.jlabel) preset.Fusion_policy.judges);
+       Alcotest.(check (list string)) "judge model ids"
+         [ "ollama_cloud.ollama-cloud-deepseek-v4-pro"
+         ; "ollama_cloud.ollama-cloud-minimax-m3"
+         ; "ollama_cloud.ollama-cloud-kimi-k2-7-code"
+         ; "ollama_cloud.ollama-cloud-glm-5-2"
+         ; "ollama_cloud.ollama-cloud-gpt-oss-120b"
+         ; "ollama_cloud.ollama-cloud-gemini-3-flash-preview"
+         ]
+         (List.map (fun j -> j.Fusion_policy.jmodel) preset.Fusion_policy.judges);
        (match
           Fusion_policy.staged_judge_groups
             ~group_size:p.Fusion_policy.staged_judge_group_size


### PR DESCRIPTION
## Summary
Adds `[fusion.presets.staged_joj]` so a keeper can run the **staged judge_of_judges** (fusion→fusion→fusion cascade) topology via the existing fusion tool.

- panel: trio (deepseek-v4-flash / glm-5-turbo / minimax-m3)
- meta-judge: deepseek-v4-pro (final reducer)
- **6 individual ollama_cloud first-round judges**, grouped by `staged_judge_group_size = 3` (→ 2 groups):
  - deepseek-v4-pro (synthesizer), minimax-m3 (consensus-builder), kimi-k2-6 (devil's-advocate), glm-5-2 (evidence-checker), gpt-oss:120b (synthesizer-2), gemini-3-flash-preview (synthesizer-3)

## Usage (already supported — no code change)
A keeper calls the fusion tool with:
```
preset = "staged_joj"
topology = "staged_judge_of_judges"
```
The tool → orchestrator.run(~topology) path already exists (RFC-0252 §13 P2), so this PR only adds the preset.

## Why
The cascade (per-group synthesis → meta-judge reconciliation) was implemented in code (`run_staged_judge_of_judges`) but had **no preset to exercise it** — trio is single-judge. This wires it up.

## Validation
- all 6 judge model ids resolve to `[ollama_cloud.<key>]` ✓ (verified)
- TOML syntax OK (python tomllib)
- `staged_judge_group_size=3`, judges=6 → 6%3==0 and 6>=2×3 (Fusion_policy staged constraints satisfied)
- canary (RFC-0252 §11): keeper-driven fusion run with the above params is the post-merge check
- full Build & Test + Test Coverage Check: CI

Refs: RFC-0283 (judge-of-judges), RFC-0252 §11/§13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
