### PR TITLE
refactor(memory): purge legacy unstructured fallback string classifier

### DIFF
--- a/dashboard/src/api/dashboard-misc.ts
+++ b/dashboard/src/api/dashboard-misc.ts
@@ -201,7 +201,6 @@ export type KeeperMemoryHealthAlertCode =
   | 'near_duplicate'
   | 'events_to_facts_ratio_high'
   | 'provider_slot_busy'
-  | 'librarian_fallback_facts'
 
 export type KeeperMemoryHealthAlertSeverity = 'warn'
 
@@ -210,7 +209,6 @@ export type KeeperMemoryHealthAlertTarget =
   | 'near_duplicate'
   | 'events_to_facts_ratio'
   | 'provider_slot_busy'
-  | 'librarian_fallback_facts'
 
 export interface KeeperMemoryHealthAlert {
   code: KeeperMemoryHealthAlertCode
@@ -232,7 +230,6 @@ export interface KeeperMemoryHealthKeeperEntry {
   ttl_expired_on_disk: number
   near_duplicate: number
   provider_slot_busy: number
-  librarian_fallback_facts: number
   alerts: KeeperMemoryHealthAlert[]
 }
 
@@ -247,7 +244,6 @@ export interface KeeperMemoryHealthResponse {
     ttl_expired_on_disk: number
     near_duplicate: number
     provider_slot_busy: number
-    librarian_fallback_facts: number
   }
   alert_summary: {
     total_alerts: number
@@ -257,13 +253,11 @@ export interface KeeperMemoryHealthResponse {
     near_duplicate_keepers: number
     high_event_ratio_keepers: number
     provider_slot_busy_keepers: number
-    librarian_fallback_fact_keepers: number
     thresholds: {
       ttl_expired_on_disk: number
       near_duplicate: number
       events_to_facts_ratio: number
       provider_slot_busy: number
-      librarian_fallback_facts: number
     }
   }
 }

--- a/dashboard/src/components/memory/keeper-memory-health.test.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.test.ts
@@ -35,7 +35,6 @@ function makeEntry(
     ttl_expired_on_disk: 0,
     near_duplicate: 0,
     provider_slot_busy: 0,
-    librarian_fallback_facts: 0,
     alerts: [],
     ...overrides,
   }
@@ -57,7 +56,6 @@ function makeResponse(
       ttl_expired_on_disk: 0,
       near_duplicate: 0,
       provider_slot_busy: 0,
-      librarian_fallback_facts: 0,
       ...totalsOverrides,
     },
     alert_summary: alertSummary ?? makeAlertSummary(),
@@ -75,13 +73,11 @@ function makeAlertSummary(
     near_duplicate_keepers: 0,
     high_event_ratio_keepers: 0,
     provider_slot_busy_keepers: 0,
-    librarian_fallback_fact_keepers: 0,
     thresholds: {
       ttl_expired_on_disk: 0,
       near_duplicate: 0,
       events_to_facts_ratio: 0,
       provider_slot_busy: 0,
-      librarian_fallback_facts: 0,
     },
     ...overrides,
   }
@@ -284,36 +280,6 @@ describe('KeeperMemoryHealth', () => {
       expect(statValue(container, 'provider-slot-busy')).toBe('3')
     })
 
-    it('surfaces librarian fallback fact alerts per keeper', async () => {
-      mockFetch.mockResolvedValue({
-        ...makeResponse([
-          makeEntry({
-            keeper_id: 'fallback-heavy',
-            librarian_fallback_facts: 2,
-            alerts: [{
-              code: 'librarian_fallback_facts',
-              severity: 'warn',
-              target: 'librarian_fallback_facts',
-              label: '폴백',
-              message: 'Librarian fallback diagnostic fact rows remain on disk',
-              value: 2,
-              threshold: 0,
-            }],
-          }),
-        ], { librarian_fallback_facts: 2 }),
-        alert_summary: makeAlertSummary({
-          total_alerts: 1,
-          warn_alerts: 1,
-          keepers_with_alerts: 1,
-          librarian_fallback_fact_keepers: 1,
-        }),
-      })
-      const { container } = render(html`<${KeeperMemoryHealth} />`)
-      await waitFor(() => expect(screen.getByText('fallback-heavy')).not.toBeNull())
-
-      expect(screen.getByText('폴백')).not.toBeNull()
-      expect(statValue(container, 'librarian-fallback-facts')).toBe('2')
-    })
   })
 
   // ── render states ─────────────────────────────────────

--- a/dashboard/src/components/memory/keeper-memory-health.ts
+++ b/dashboard/src/components/memory/keeper-memory-health.ts
@@ -20,7 +20,6 @@ const EVENT_RATIO_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'events_to_facts
 const TTL_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'ttl_expired_on_disk'
 const NEAR_DUPLICATE_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'near_duplicate'
 const PROVIDER_SLOT_BUSY_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'provider_slot_busy'
-const LIBRARIAN_FALLBACK_ALERT_TARGET: KeeperMemoryHealthAlertTarget = 'librarian_fallback_facts'
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`
@@ -52,7 +51,6 @@ function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
   const ttlWarn = hasTargetAlert(alerts, TTL_ALERT_TARGET)
   const nearDuplicateWarn = hasTargetAlert(alerts, NEAR_DUPLICATE_ALERT_TARGET)
   const providerSlotBusyWarn = hasTargetAlert(alerts, PROVIDER_SLOT_BUSY_ALERT_TARGET)
-  const librarianFallbackWarn = hasTargetAlert(alerts, LIBRARIAN_FALLBACK_ALERT_TARGET)
   const providerSlotBusyCount = providerSlotBusy(entry)
 
   return html`
@@ -79,11 +77,6 @@ function KeeperRow({ entry }: { entry: KeeperMemoryHealthKeeperEntry }) {
         ${providerSlotBusyWarn
           ? html`<span class="kmh-badge kmh-badge--warn">${providerSlotBusyCount}</span>`
           : html`<span class="kmh-badge kmh-badge--ok">${providerSlotBusyCount}</span>`}
-      </td>
-      <td>
-        ${librarianFallbackWarn
-          ? html`<span class="kmh-badge kmh-badge--warn">${entry.librarian_fallback_facts}</span>`
-          : html`<span class="kmh-badge kmh-badge--ok">${entry.librarian_fallback_facts}</span>`}
       </td>
       <td>
         ${alerts.length > 0
@@ -158,7 +151,6 @@ export function KeeperMemoryHealth() {
   const totalAlerts = data.alert_summary.total_alerts
   const ttlExpiredWarn = data.alert_summary.ttl_expired_keepers > 0
   const providerSlotBusyWarn = data.alert_summary.provider_slot_busy_keepers > 0
-  const librarianFallbackWarn = data.alert_summary.librarian_fallback_fact_keepers > 0
   const totalProviderSlotBusy = data.totals.provider_slot_busy
 
   return html`
@@ -192,12 +184,6 @@ export function KeeperMemoryHealth() {
             <span class="kmh-stat-label">슬롯 실패</span>
             <span class=${`kmh-stat-value${providerSlotBusyWarn ? ' kmh-stat-value--warn' : ''}`}>
               ${totalProviderSlotBusy}
-            </span>
-          </div>
-          <div class="kmh-stat" data-stat-key="librarian-fallback-facts">
-            <span class="kmh-stat-label">폴백 진단</span>
-            <span class=${`kmh-stat-value${librarianFallbackWarn ? ' kmh-stat-value--warn' : ''}`}>
-              ${data.totals.librarian_fallback_facts}
             </span>
           </div>
           <div class="kmh-stat" data-stat-key="alerts">
@@ -234,7 +220,6 @@ export function KeeperMemoryHealth() {
                   <th>만료(디스크)</th>
                   <th>근접중복</th>
                   <th>슬롯 실패</th>
-                  <th>폴백 진단</th>
                   <th>경보</th>
                 </tr>
               </thead>

--- a/lib/keeper/keeper_memory_os_types.ml
+++ b/lib/keeper/keeper_memory_os_types.ml
@@ -352,15 +352,17 @@ let librarian_unstructured_fallback_terminal_marker =
   "librarian_unstructured_fallback"
 ;;
 
-let legacy_unstructured_fallback_claim (claim : string) =
-  String.starts_with ~prefix:librarian_unstructured_fallback_claim_prefix claim
-;;
-
 let fact_prompt_recallable (fact : fact) =
+  (* [claim_kind] is the sole recall-eligibility signal: the producer
+     ([Keeper_librarian_runtime.unstructured_episode]) tags fallback notes as
+     [Diagnostic] at the write boundary, so recall excludes them by type without
+     string-matching [claim]. Rows lacking [claim_kind] are ordinary recallable
+     facts; their [valid_until] horizon ([fact_is_current]) bounds any stale
+     pre-[Diagnostic] rows still on disk. *)
   match fact.claim_kind with
   | Some Diagnostic -> false
   | Some Self_observation | Some External_state | Some Durable_knowledge -> true
-  | None -> not (legacy_unstructured_fallback_claim fact.claim)
+  | None -> true
 ;;
 
 (* RFC-0259 §3.6 (P5): split a fact list into (live, expired-at-[now]) on the
@@ -559,12 +561,6 @@ let claim_identity (f : fact) =
   match Option.bind f.claim_id normalize_claim_id with
   | Some id -> "id:" ^ id
   | None -> claim_identity_of_claim_text f.claim
-;;
-
-let legacy_unstructured_fallback_claim_key key =
-  String.starts_with
-    ~prefix:(claim_identity_of_claim_text librarian_unstructured_fallback_claim_prefix)
-    key
 ;;
 
 let optional_float_field key = function

--- a/lib/keeper/keeper_memory_os_types.mli
+++ b/lib/keeper/keeper_memory_os_types.mli
@@ -229,29 +229,20 @@ type fact =
     [valid_until] are durable and current. *)
 val fact_is_current : now:float -> fact -> bool
 
-(** Historical claim prefix used for librarian parse-failure fallback facts.
-    Kept as the SSOT for the producer and the legacy recall-eligibility shim. *)
+(** Claim prefix used by the producer for librarian parse-failure fallback
+    facts. The producer tags these [Diagnostic] at the write boundary, so this
+    prefix is a display label only — recall eligibility is decided by
+    [claim_kind], not by string-matching [claim]. *)
 val librarian_unstructured_fallback_claim_prefix : string
 
 (** Terminal marker used on episodes that preserve unstructured librarian output
     after strict JSON parsing fails. *)
 val librarian_unstructured_fallback_terminal_marker : string
 
-val legacy_unstructured_fallback_claim : string -> bool
-(** Whether a fact claim carries the historical librarian parse-failure fallback
-    prefix. *)
-
-val legacy_unstructured_fallback_claim_key : string -> bool
-(** Whether a persisted pre-[Diagnostic] recall key identifies a legacy
-    librarian parse-failure fallback fact. This centralizes the historical
-    [claim_identity] fallback-key shape so read-only compatibility surfaces do
-    not reconstruct ["claim:"] keys themselves. *)
-
 (** Structural prompt-recall eligibility. Callers still apply {!fact_is_current}
     for the time horizon; [Diagnostic] rows stay operator evidence, not prompt
-    context. Legacy pre-[Diagnostic] librarian fallback rows are also excluded by
-    their exact historical claim prefix so old stores cannot keep injecting raw
-    parse-failure diagnostics. *)
+    context. Rows missing [claim_kind] use the durable pre-RFC path; old fallback
+    diagnostics are bounded only by their stored [valid_until] horizon. *)
 val fact_prompt_recallable : fact -> bool
 
 (** RFC-0259 §3.6 (P5): partition facts into [(live, expired)] at [now] on the

--- a/lib/server/server_dashboard_http_keeper_memory_health.ml
+++ b/lib/server/server_dashboard_http_keeper_memory_health.ml
@@ -26,7 +26,6 @@ type keeper_health =
   ; ttl_expired_on_disk : int
   ; near_duplicate : int
   ; provider_slot_busy : int
-  ; librarian_fallback_facts : int
   }
 
 type alert_code =
@@ -34,7 +33,6 @@ type alert_code =
   | Near_duplicate
   | Events_to_facts_ratio_high
   | Provider_slot_busy
-  | Librarian_fallback_facts
 
 type alert_severity = Warn
 
@@ -43,7 +41,6 @@ type alert_target =
   | Near_duplicate_target
   | Events_to_facts_ratio_target
   | Provider_slot_busy_target
-  | Librarian_fallback_facts_target
 
 type keeper_alert =
   { code : alert_code
@@ -67,7 +64,6 @@ let events_to_facts_ratio_warn_threshold =
 ;;
 
 let provider_slot_busy_threshold = 0.0
-let librarian_fallback_facts_threshold = 0.0
 
 let provider_slot_busy_metric = Keeper_metrics.(to_string MemoryLaneProviderSlotBusy)
 let provider_slot_busy_site = Keeper_librarian_runtime.memory_os_librarian_provider_slot_site
@@ -77,7 +73,6 @@ let alert_code_to_string = function
   | Near_duplicate -> "near_duplicate"
   | Events_to_facts_ratio_high -> "events_to_facts_ratio_high"
   | Provider_slot_busy -> "provider_slot_busy"
-  | Librarian_fallback_facts -> "librarian_fallback_facts"
 ;;
 
 let alert_severity_to_string = function
@@ -89,7 +84,6 @@ let alert_target_to_string = function
   | Near_duplicate_target -> "near_duplicate"
   | Events_to_facts_ratio_target -> "events_to_facts_ratio"
   | Provider_slot_busy_target -> "provider_slot_busy"
-  | Librarian_fallback_facts_target -> "librarian_fallback_facts"
 ;;
 
 (* Alert labels are endpoint-owned wire copy for this backend-defined diagnostic
@@ -100,7 +94,6 @@ let alert_label = function
   | Near_duplicate -> "중복"
   | Events_to_facts_ratio_high -> "비율"
   | Provider_slot_busy -> "슬롯"
-  | Librarian_fallback_facts -> "폴백"
 ;;
 
 let alert ~code ~target ~message ~value ~threshold =
@@ -152,18 +145,6 @@ let keeper_alerts h =
           "Memory OS librarian provider slot was busy; extraction was skipped and remains due."
         ~value:(float_of_int h.provider_slot_busy)
         ~threshold:provider_slot_busy_threshold
-      :: alerts
-    else alerts)
-  |> (fun alerts ->
-    if h.librarian_fallback_facts > 0
-    then
-      alert
-        ~code:Librarian_fallback_facts
-        ~target:Librarian_fallback_facts_target
-        ~message:
-          "Librarian fallback diagnostic fact rows remain on disk; they are hidden from prompt recall but indicate extraction failures."
-        ~value:(float_of_int h.librarian_fallback_facts)
-        ~threshold:librarian_fallback_facts_threshold
       :: alerts
     else alerts)
   |> List.rev
@@ -226,15 +207,6 @@ let keeper_health ~keepers_dir ~now keeper_id =
     Keeper_memory_os_io.read_facts_all_for_keepers_dir ~keepers_dir ~keeper_id
   in
   let facts_count = List.length facts in
-  let librarian_fallback_facts =
-    facts
-    |> List.fold_left
-         (fun count (fact : Keeper_memory_os_types.fact) ->
-           if Keeper_memory_os_types.legacy_unstructured_fallback_claim fact.claim
-           then count + 1
-           else count)
-         0
-  in
   let facts_bytes =
     file_size_bytes
       (Keeper_memory_os_io.facts_path_for_keepers_dir ~keepers_dir ~keeper_id)
@@ -263,7 +235,6 @@ let keeper_health ~keepers_dir ~now keeper_id =
   ; ttl_expired_on_disk = gc_report.ttl_expired
   ; near_duplicate = gc_report.dedup_removed
   ; provider_slot_busy = provider_slot_busy_for_keeper keeper_id
-  ; librarian_fallback_facts
   }
 ;;
 
@@ -278,7 +249,6 @@ let keeper_health_entry_to_json (h, alerts) : Yojson.Safe.t =
     ; "ttl_expired_on_disk", `Int h.ttl_expired_on_disk
     ; "near_duplicate", `Int h.near_duplicate
     ; "provider_slot_busy", `Int h.provider_slot_busy
-    ; "librarian_fallback_facts", `Int h.librarian_fallback_facts
     ; "alerts", `List (List.map keeper_alert_to_json alerts)
     ]
 ;;
@@ -326,8 +296,6 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
           ; "ttl_expired_on_disk", `Int (sum (fun h -> h.ttl_expired_on_disk))
           ; "near_duplicate", `Int (sum (fun h -> h.near_duplicate))
           ; "provider_slot_busy", `Int (sum (fun h -> h.provider_slot_busy))
-          ; ( "librarian_fallback_facts"
-            , `Int (sum (fun h -> h.librarian_fallback_facts)) )
           ] )
     ; ( "alert_summary"
       , `Assoc
@@ -347,15 +315,12 @@ let keeper_memory_health_http_json ~base_path : Yojson.Safe.t =
           ; ( "high_event_ratio_keepers"
             , `Int (alert_count_by_code Events_to_facts_ratio_high) )
           ; "provider_slot_busy_keepers", `Int (alert_count_by_code Provider_slot_busy)
-          ; ( "librarian_fallback_fact_keepers"
-            , `Int (alert_count_by_code Librarian_fallback_facts) )
           ; ( "thresholds"
             , `Assoc
                 [ "ttl_expired_on_disk", `Float ttl_expired_on_disk_threshold
                 ; "near_duplicate", `Float near_duplicate_threshold
                 ; "events_to_facts_ratio", `Float events_to_facts_ratio_warn_threshold
                 ; "provider_slot_busy", `Float provider_slot_busy_threshold
-                ; "librarian_fallback_facts", `Float librarian_fallback_facts_threshold
                 ] )
           ] )
     ]

--- a/lib/server/server_dashboard_http_memory_subsystems.ml
+++ b/lib/server/server_dashboard_http_memory_subsystems.ml
@@ -303,7 +303,6 @@ type recall_quality_summary =
   ; fact_counts : int StringMap.t
   ; failure_counts : int StringMap.t
   ; total_fact_injections : int
-  ; diagnostic_fallback_key_injections : int
   ; error : string option
   }
 
@@ -315,7 +314,6 @@ let empty_recall_quality_summary ~decode_error_records ~error =
   ; fact_counts = StringMap.empty
   ; failure_counts = StringMap.empty
   ; total_fact_injections = 0
-  ; diagnostic_fallback_key_injections = 0
   ; error
   }
 ;;
@@ -336,18 +334,10 @@ let summarize_recall_quality ({ records; decode_error_records } : memory_quality
        let has_recall =
          record.injected_fact_keys <> [] || record.injected_episode_keys <> []
        in
-       let fact_counts, total_fact_injections, diagnostic_fallback_key_injections =
+       let fact_counts, total_fact_injections =
          List.fold_left
-           (fun (counts, total, diagnostic_total) key ->
-              let diagnostic_total =
-                if Keeper_memory_os_types.legacy_unstructured_fallback_claim_key key
-                then diagnostic_total + 1
-                else diagnostic_total
-              in
-              increment_count key counts, total + 1, diagnostic_total)
-           ( summary.fact_counts
-           , summary.total_fact_injections
-           , summary.diagnostic_fallback_key_injections )
+           (fun (counts, total) key -> increment_count key counts, total + 1)
+           (summary.fact_counts, summary.total_fact_injections)
            record.injected_fact_keys
        in
        { summary with
@@ -360,7 +350,6 @@ let summarize_recall_quality ({ records; decode_error_records } : memory_quality
        ; failure_counts
        ; fact_counts
        ; total_fact_injections
-       ; diagnostic_fallback_key_injections
        })
     initial
     records
@@ -396,8 +385,6 @@ let recall_quality_summary_json ~sample_limit ~top_key_limit summary =
           ; "unique_fact_keys", `Int (List.length fact_count_rows)
           ; "echoed_fact_keys", `Int echoed_fact_keys
           ; "max_fact_echo_count", `Int max_fact_echo_count
-          ; ( "diagnostic_fallback_key_injections"
-            , `Int summary.diagnostic_fallback_key_injections )
           ; ( "top_echoed_fact_keys"
             , `List
                 (count_rows_by

--- a/test/test_keeper_memory_os.ml
+++ b/test/test_keeper_memory_os.ml
@@ -2202,16 +2202,6 @@ let test_render_if_enabled_omits_diagnostic_memory () =
           ; Types.valid_until = Some (now +. 3600.0)
           }
         in
-        let legacy_fact =
-          let prefix = Types.librarian_unstructured_fallback_claim_prefix in
-          { (fact_fixture ~now ()) with
-            Types.claim =
-              Printf.sprintf "%s (invalid_json): raw model text" prefix
-          ; Types.category = Types.Ephemeral
-          ; Types.claim_kind = None
-          ; Types.valid_until = Some (now +. 3600.0)
-          }
-        in
         let diagnostic_episode =
           { Types.trace_id = "trace-diagnostic-recall"
           ; Types.generation = 1
@@ -2227,15 +2217,7 @@ let test_render_if_enabled_omits_diagnostic_memory () =
           ; Types.schema_version = Types.schema_version
           }
         in
-        let legacy_episode =
-          { diagnostic_episode with
-            Types.trace_id = "trace-legacy-diagnostic-recall"
-          ; Types.episode_summary = "legacy diagnostic-only episode should not enter recall"
-          ; Types.claims = [ legacy_fact ]
-          }
-        in
         Memory_io.append_episode_bundle ~keeper_id diagnostic_episode;
-        Memory_io.append_episode_bundle ~keeper_id legacy_episode;
         match render_if_enabled_for_test ~keeper_id ~now ~masc_root:keepers_dir () with
         | None -> ()
         | Some block ->
@@ -4434,15 +4416,13 @@ let test_dashboard_fact_json_marks_diagnostic_not_prompt_recallable () =
   | _ -> Alcotest.fail "prompt_recallable must be a bool"
 ;;
 
-let test_dashboard_fact_json_marks_legacy_diagnostic_not_prompt_recallable () =
+let test_dashboard_fact_json_marks_diagnostic_not_prompt_recallable () =
   let now = 1_000_000.0 in
   let fact =
-    let prefix = Types.librarian_unstructured_fallback_claim_prefix in
     { (fact_fixture ~now ()) with
-      Types.claim =
-        Printf.sprintf "%s (invalid_json): raw model text" prefix
+      Types.claim = "Raw parse-failure fallback should not enter prompt recall"
     ; Types.category = Types.Ephemeral
-    ; Types.claim_kind = None
+    ; Types.claim_kind = Some Types.Diagnostic
     ; Types.valid_until = Some (now +. 3600.0)
     }
   in
@@ -4451,14 +4431,18 @@ let test_dashboard_fact_json_marks_legacy_diagnostic_not_prompt_recallable () =
     | `Assoc fields -> fields
     | _ -> Alcotest.fail "memory_os_fact_json must be a JSON object"
   in
+  (* The producer tags fallback notes as [Diagnostic] at the write boundary, so
+     recall eligibility is decided by [claim_kind] — not by string-matching
+     [claim]. Rows lacking [claim_kind] are ordinary recallable facts; their
+     [valid_until] horizon bounds any stale pre-[Diagnostic] rows on disk. *)
   Alcotest.(check bool)
-    "legacy diagnostic remains untyped"
-    false
+    "diagnostic is typed via claim_kind"
+    true
     (List.mem_assoc "claim_kind" fields);
   match List.assoc_opt "prompt_recallable" fields with
   | Some (`Bool b) ->
     Alcotest.(check bool)
-      "legacy diagnostic fact is not prompt recallable"
+      "diagnostic fact is not prompt recallable"
       false
       b
   | _ -> Alcotest.fail "prompt_recallable must be a bool"
@@ -5129,7 +5113,7 @@ let () =
         ; Alcotest.test_case
             "dashboard fact json marks legacy diagnostic rows as not prompt recallable"
             `Quick
-            test_dashboard_fact_json_marks_legacy_diagnostic_not_prompt_recallable
+            test_dashboard_fact_json_marks_diagnostic_not_prompt_recallable
         ; Alcotest.test_case
             "dashboard json wires one facts.items row per persisted fact"
             `Quick

--- a/test/test_server_dashboard_http_keeper_memory_health.ml
+++ b/test/test_server_dashboard_http_keeper_memory_health.ml
@@ -30,13 +30,6 @@ let fact ?(valid_until = None) ~now claim =
   }
 ;;
 
-let librarian_fallback_fact ~now claim =
-  { (fact ~now claim) with
-    Types.category = Types.Ephemeral
-  ; claim_kind = Some Types.Diagnostic
-  }
-;;
-
 let keeper_ids json =
   match json with
   | `Assoc fields ->
@@ -184,10 +177,6 @@ let test_reports_per_keeper_metric_values () =
   Alcotest.(check int) "nothing expired" 0 (int_field "ttl_expired_on_disk" k);
   Alcotest.(check int) "no duplicates" 0 (int_field "near_duplicate" k);
   Alcotest.(check int) "no provider slot busy skips" 0 (int_field "provider_slot_busy" k);
-  Alcotest.(check int)
-    "no librarian fallback facts"
-    0
-    (int_field "librarian_fallback_facts" k);
   Alcotest.(check int) "no keeper alerts" 0 (List.length (list_field "alerts" k));
   Alcotest.(check int) "totals.facts" 2 (int_field "facts" (totals json));
   Alcotest.(check bool)
@@ -294,51 +283,6 @@ let test_reports_provider_slot_busy_metric_as_alert () =
   Alcotest.(check int) "summary total alerts" 1 (int_field "total_alerts" summary)
 ;;
 
-let test_reports_librarian_fallback_facts_as_alert () =
-  Eio_main.run
-  @@ fun _env ->
-  let now = test_now in
-  let base = fresh_dir "masc-memory-health-librarian-fallback" in
-  let keepers_dir = Config_dir_resolver.keepers_dir_for_base_path ~base_path:base in
-  let fallback_claim =
-    Types.librarian_unstructured_fallback_claim_prefix
-    ^ " (librarian provider returned empty response): <empty response>"
-  in
-  Io.rewrite_facts_atomically_for_keepers_dir
-    ~keepers_dir
-    ~keeper_id:"fallback"
-    [ fact ~now "ordinary durable row"; librarian_fallback_fact ~now fallback_claim ];
-  let json = Health.keeper_memory_health_http_json ~base_path:base in
-  let k = keeper_obj "fallback" json in
-  Alcotest.(check int)
-    "librarian fallback facts projected"
-    1
-    (int_field "librarian_fallback_facts" k);
-  Alcotest.(check int)
-    "totals librarian fallback facts"
-    1
-    (int_field "librarian_fallback_facts" (totals json));
-  let alerts = list_field "alerts" k in
-  Alcotest.(check (list string))
-    "librarian fallback alert code"
-    [ "librarian_fallback_facts" ]
-    (List.map (string_field "code") alerts);
-  Alcotest.(check (list string))
-    "librarian fallback alert target"
-    [ "librarian_fallback_facts" ]
-    (List.map (string_field "target") alerts);
-  Alcotest.(check (list string))
-    "librarian fallback alert label"
-    [ "폴백" ]
-    (List.map (string_field "label") alerts);
-  let summary = alert_summary json in
-  Alcotest.(check int)
-    "summary librarian fallback keepers"
-    1
-    (int_field "librarian_fallback_fact_keepers" summary);
-  Alcotest.(check int) "summary total alerts" 1 (int_field "total_alerts" summary)
-;;
-
 let test_sorts_keepers_by_facts_bytes_desc () =
   Eio_main.run
   @@ fun _env ->
@@ -414,10 +358,6 @@ let () =
             "reports provider slot busy metric as alert"
             `Quick
             test_reports_provider_slot_busy_metric_as_alert
-        ; Alcotest.test_case
-            "reports librarian fallback facts as alert"
-            `Quick
-            test_reports_librarian_fallback_facts_as_alert
         ; Alcotest.test_case
             "sorts keepers by facts_bytes descending"
             `Quick

--- a/test/test_server_dashboard_http_memory_subsystems.ml
+++ b/test/test_server_dashboard_http_memory_subsystems.ml
@@ -413,8 +413,6 @@ let test_http_json_surfaces_memory_quality_summary () =
          Json.(fact_injections |> member "echoed_fact_keys" |> to_int);
        check int "max fact echo count" 2
          Json.(fact_injections |> member "max_fact_echo_count" |> to_int);
-       check int "legacy diagnostic fallback injections" 1
-         Json.(fact_injections |> member "diagnostic_fallback_key_injections" |> to_int);
        let echoed = Json.(fact_injections |> member "top_echoed_fact_keys" |> to_list) in
        check int "one echoed top key" 1 (List.length echoed);
        let top_echo = List.hd echoed in


### PR DESCRIPTION
## Summary

#22416 added `legacy_unstructured_fallback_claim` / `_key` (string `starts_with` prefix match) to keep pre-`Diagnostic` fallback rows out of recall. But the producer (`Keeper_librarian_runtime.unstructured_episode`) already tags fallback notes as `Diagnostic` at the write boundary — recall eligibility is decided by the typed `claim_kind`. The string classifier is redundant and is exactly **workaround-signature #2 (string/substring classifier)** from CLAUDE.md.

This removes it, instead of papering over the build error by re-exporting the value from the `.mli`.

## Changes
- `fact_prompt_recallable`: drop the legacy `None -> not (legacy_...)` branch → `None -> true`. `claim_kind` is the sole recall-eligibility SSOT.
- Remove `legacy_unstructured_fallback_claim` / `legacy_unstructured_fallback_claim_key` (`.ml` + `.mli`).
- Remove the dashboard counts that depended on the classifier:
  - `librarian_fallback_facts` (keeper memory health backend + FE + tests)
  - `diagnostic_fallback_key_injections` (recall-quality subsystems + test)
  - The subsystems count is **key-based** and cannot migrate to typed `claim_kind` without reconstructing a new classifier, so it is removed rather than re-shimmed.
- Producer still uses `librarian_unstructured_fallback_claim_prefix` / `_terminal_marker` as the claim label and episode marker — those stay.
- Expose `stop_reason_is_turn_budget_exhausted` in `keeper_agent_run_response_text.mli` (unrelated `.mli` gap that broke the same build).

## Side effect (confirmed with operator)
Pre-`Diagnostic` fallback rows on disk (`claim_kind = None`) now re-enter recall. These are volatile (`Ephemeral` + `valid_until`), at most ~2 days of data post #22416; the producer emits typed `Diagnostic` for all new fallbacks. Operator chose pure purge over an episode-level `terminal_marker` exclusion alternative.

## Not a workaround introduction
This **removes** workaround-signature #2 (string/substring classifier). No `WORKAROUND:` / RFC override line required.

## Validation
- `dune build --root .`: green
- `test_keeper_memory_os`: 118/118
- `test_server_dashboard_http_keeper_memory_health`: 7/7
- `test_server_dashboard_http_memory_subsystems`: 12/12
- dashboard `typecheck` + `lint`: green
- dashboard `keeper-memory-health` vitest: 13/13

Note: full `dune runtest` has a pre-existing flaky failure in `Bounded_proc` (`Unix.Unix_error(EINTR, waitpid)`) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)