### PR TITLE
[codex] purge dashboard legacy compatibility fallbacks

### DIFF
--- a/dashboard/src/api/keeper.test.ts
+++ b/dashboard/src/api/keeper.test.ts
@@ -398,8 +398,7 @@ describe('streamKeeperMessage', () => {
 
   it('refreshes a stale loopback dev token once and retries on typed invalid_token code', async () => {
     stubStaleToken()
-    // The message is a generic string that would NOT match the legacy
-    // substring matcher; the typed auth_error_code drives the retry.
+    // The message is generic; the typed auth_error_code drives the retry.
     const fetchMock = stubStreamRetryFetch({
       error: 'authentication failed',
       auth_error_code: 'invalid_token',
@@ -466,17 +465,17 @@ describe('streamKeeperMessage', () => {
     ])
   })
 
-  it('falls back to the legacy substring match for servers without auth_error_code', async () => {
+  it('does NOT retry servers without typed auth_error_code', async () => {
     stubStaleToken()
     const fetchMock = stubStreamRetryFetch({
       error: '[AuthError] Invalid token: Token mismatch',
     })
 
-    await streamKeeperMessage('sangsu', 'ping', { onEvent: () => {} })
+    await expect(
+      streamKeeperMessage('sangsu', 'ping', { onEvent: () => {} }),
+    ).rejects.toThrow()
 
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
-      '/api/v1/keepers/chat/stream',
-      '/api/v1/dashboard/dev-token',
       '/api/v1/keepers/chat/stream',
     ])
   })

--- a/dashboard/src/api/keeper.ts
+++ b/dashboard/src/api/keeper.ts
@@ -479,16 +479,9 @@ function isStaleTokenAuthError(raw: string): boolean {
       return STALE_TOKEN_AUTH_CODES.has(code as DashboardAuthErrorCode)
     }
   } catch {
-    // Not JSON — fall through to the legacy substring fallback below.
+    return false
   }
-  // WORKAROUND: legacy server fallback for servers that predate the typed
-  // `auth_error_code` 401 body. The substring shape comes from
-  // `Auth_error.InvalidToken "Token mismatch"` rendered as
-  // "[AuthError] Invalid token: Token mismatch". removal target: next release.
-  const normalized = raw.toLowerCase()
-  return normalized.includes('autherror')
-    && normalized.includes('invalid token')
-    && normalized.includes('token mismatch')
+  return false
 }
 
 async function refreshLoopbackDevTokenAfterMismatch(): Promise<boolean> {

--- a/dashboard/src/cockpit-entrypoints.test.ts
+++ b/dashboard/src/cockpit-entrypoints.test.ts
@@ -5,7 +5,6 @@ import {
   COGNITIVE_MODE_STATES,
   COGNITIVE_MODE_TARGETS,
   COCKPIT_ENTRYPOINTS,
-  COCKPIT_LEGACY_ENTRYPOINTS,
   COCKPIT_MODE_TARGETS,
   cognitiveModeForCockpitMode,
   cognitiveModeForRoute,
@@ -17,7 +16,6 @@ import { sectionItemsForTab } from './config/navigation'
 
 describe('cockpit entrypoint registry', () => {
   const visibleAliases = () => COCKPIT_ENTRYPOINTS.flatMap(entrypoint => entrypoint.aliases)
-  const legacyAliases = () => COCKPIT_LEGACY_ENTRYPOINTS.flatMap(entrypoint => entrypoint.aliases)
 
   it('keeps every prototype plane mode mapped to a production route', () => {
     expect(Object.keys(COCKPIT_MODE_TARGETS)).toEqual([
@@ -82,16 +80,6 @@ describe('cockpit entrypoint registry', () => {
     expect(aliases).not.toContain('pr-thread')
   })
 
-  it('keeps old prototype aliases as legacy redirects instead of visible commands', () => {
-    const visible = new Set(visibleAliases())
-    const legacy = legacyAliases()
-
-    for (const alias of ['ct-lat', 'cs-deep', 'pr-thread', 'dc-mem', 'acc-led']) {
-      expect(visible.has(alias)).toBe(false)
-      expect(legacy).toContain(alias)
-    }
-  })
-
   it('normalizes cognitive mode aliases from cockpit routes', () => {
     expect(normalizeCognitiveMode(' CODE ')).toBe('code')
     expect(cognitiveModeForCockpitMode('Work')).toBe('cockpit')
@@ -115,8 +103,8 @@ describe('cockpit entrypoint registry', () => {
     expect(normalizeCockpitEntrypoint('Keeper / Tool Access')).toBe('keeper-tool-access')
   })
 
-  it('targets registered dashboard sections for primary and legacy entrypoints', () => {
-    for (const entrypoint of [...COCKPIT_ENTRYPOINTS, ...COCKPIT_LEGACY_ENTRYPOINTS]) {
+  it('targets registered dashboard sections for primary entrypoints', () => {
+    for (const entrypoint of COCKPIT_ENTRYPOINTS) {
       const section = entrypoint.target.params?.section
       if (!section) continue
       const knownSections = sectionItemsForTab(entrypoint.target.tab).map(item => item.params.section)
@@ -150,74 +138,30 @@ describe('cockpit entrypoint registry', () => {
     })
   })
 
-  it('keeps legacy prototype subtabs routeable without re-exposing them in the command map', () => {
-    expect(cockpitTargetForParams({ mode: 'IDE', tab: 'edit' })).toEqual({
-      tab: 'code',
-      params: { section: 'ide-shell', view: 'source' },
-    })
-    expect(cockpitTargetForParams({ mode: 'IDE', tab: 'split-diff' })).toEqual({
-      tab: 'code',
-      params: { section: 'ide-shell', view: 'split-diff' },
-    })
+  it('ignores retired prototype subtab aliases', () => {
     expect(cockpitTargetForParams({ mode: 'EXPLODE' })).toEqual({
       tab: 'workspace',
       params: { section: 'repositories' },
     })
-    expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'dc-str' })).toEqual({
-      tab: 'monitoring',
-      params: { section: 'agents', view: 'decisions' },
-    })
-    expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'ki-bdi' })).toEqual({
-      tab: 'monitoring',
-      params: { section: 'agents', view: 'keeper', focus: 'bdi' },
-    })
     expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'keeper-tool-access' })).toEqual({
       tab: 'monitoring',
-      params: { section: 'agents', view: 'keeper', focus: 'tool-access' },
-    })
-    expect(cockpitTargetForParams({ mode: 'Cognition', tab: 'dc-mem' })).toEqual({
-      tab: 'monitoring',
-      params: { section: 'agents', view: 'memory', focus: 'entries' },
-    })
-    expect(cockpitTargetForParams({ mode: 'Observe', tab: 'sa-dash' })).toEqual({
-      tab: 'command',
-      params: { section: 'operations', view: 'safety' },
+      params: { section: 'agents' },
     })
     expect(cockpitTargetForParams({ mode: 'IDE', tab: 'pr-thread' })).toEqual({
       tab: 'code',
-      params: { section: 'ide-shell', view: 'unified', focus: 'review' },
+      params: { section: 'ide-shell', view: 'source' },
     })
     expect(cockpitTargetForParams({ mode: 'Observe', tab: 'au-act' })).toEqual({
       tab: 'monitoring',
-      params: { section: 'runtime', view: 'audit', focus: 'actor' },
-    })
-    expect(cockpitTargetForParams({ mode: 'Observe', tab: 'audit-summary' })).toEqual({
-      tab: 'monitoring',
-      params: { section: 'runtime', view: 'audit', focus: 'summary' },
-    })
-    expect(cockpitTargetForParams({ mode: 'IDE', tab: 'find' })).toEqual({
-      tab: 'code',
-      params: { section: 'ide-shell', view: 'source', find: 'open' },
-    })
-    expect(cockpitTargetForParams({ mode: 'Comms', tab: 'cm-bc' })).toEqual({
-      tab: 'command',
-      params: { section: 'operations', view: 'ops', focus: 'broadcast' },
-    })
-    expect(cockpitTargetForParams({ mode: 'Comms', tab: 'bd-thr' })).toEqual({
-      tab: 'board',
-      params: { focus: 'thread' },
+      params: { section: 'runtime' },
     })
     expect(cockpitTargetForParams({ mode: 'Work', tab: 'acc-led' })).toEqual({
       tab: 'workspace',
-      params: { section: 'planning', focus: 'accountability-ledger' },
+      params: { section: 'planning' },
     })
     expect(cockpitTargetForParams({ mode: 'Observe', tab: 'ct-lat' })).toEqual({
       tab: 'monitoring',
-      params: { section: 'runtime', view: 'cost', focus: 'latency' },
-    })
-    expect(cockpitTargetForParams({ mode: 'Observe', tab: 'runtime-compare' })).toEqual({
-      tab: 'monitoring',
-      params: { section: 'runtime', view: 'inspector', focus: 'compare' },
+      params: { section: 'runtime' },
     })
   })
 })

--- a/dashboard/src/cockpit-entrypoints.ts
+++ b/dashboard/src/cockpit-entrypoints.ts
@@ -163,59 +163,9 @@ export const COCKPIT_ENTRYPOINTS: CockpitEntrypoint[] = [
   },
 ]
 
-export const COCKPIT_LEGACY_ENTRYPOINTS: CockpitEntrypoint[] = [
-  // Work Plane legacy design subtabs.
-  { mode: 'work', aliases: ['goal-h', 'goal-t', 'goal-tree'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree' } }, coverage: 'covered' },
-  { mode: 'work', aliases: ['goal-d', 'goal-snapshot', 'goal-snapshot-diff'], target: { tab: 'workspace', params: { section: 'planning', view: 'goal-tree', focus: 'snapshot' } }, coverage: 'backend-blocked' },
-  { mode: 'work', aliases: ['task-bl', 'task-backlog'], target: { tab: 'workspace', params: { section: 'planning', view: 'default' } }, coverage: 'covered' },
-  { mode: 'work', aliases: ['task-st', 'task-stale'], target: { tab: 'workspace', params: { section: 'planning', view: 'default', focus: 'stale' } }, coverage: 'covered' },
-  { mode: 'work', aliases: ['task-w', 'task-wall'], target: { tab: 'workspace', params: { section: 'planning', view: 'default' } }, coverage: 'covered' },
-  { mode: 'work', aliases: ['acc-led', 'accountability-ledger'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-ledger' } }, coverage: 'covered' },
-  { mode: 'work', aliases: ['acc-mtx', 'accountability-matrix'], target: { tab: 'workspace', params: { section: 'planning', focus: 'accountability-matrix' } }, coverage: 'covered' },
-
-  // Comms Plane legacy design subtabs.
-  { mode: 'comms', aliases: ['bd-feed'], target: { tab: 'board' }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['bd-thr', 'board-thread'], target: { tab: 'board', params: { focus: 'thread' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['bd-tog', 'board-direct-automation'], target: { tab: 'board', params: { focus: 'automation' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['ms-rm', 'messages-workspace'], target: { tab: 'board', params: { focus: 'messages-workspace' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['ms-inb', 'messages-mention-inbox'], target: { tab: 'board', params: { focus: 'mention-inbox' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['ms-st', 'messages-state-block'], target: { tab: 'board', params: { focus: 'state-block' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['cm-bc', 'composer-broadcast'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'broadcast' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['cm-mn', 'composer-mention'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'mention' } }, coverage: 'covered' },
-  { mode: 'comms', aliases: ['cm-st', 'composer-state'], target: { tab: 'command', params: { section: 'operations', view: 'ops', focus: 'state' } }, coverage: 'covered' },
-
-  // Observe Plane legacy design subtabs.
-  { mode: 'observe', aliases: ['cs-deep', 'runtime-deep-dive'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'inspector', focus: 'deep-dive' } }, coverage: 'covered' },
-  { mode: 'observe', aliases: ['cs-cmp', 'runtime-compare'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'inspector', focus: 'compare' } }, coverage: 'covered' },
-  { mode: 'observe', aliases: ['au-led', 'audit-ledger'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'audit' } }, coverage: 'covered' },
-  { mode: 'observe', aliases: ['au-act', 'audit-by-actor'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'audit', focus: 'actor' } }, coverage: 'covered' },
-  { mode: 'observe', aliases: ['au-sum', 'audit-summary'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'audit', focus: 'summary' } }, coverage: 'covered' },
-  { mode: 'observe', aliases: ['sa-dash', 'safe-auto-dashboard'], target: { tab: 'command', params: { section: 'operations', view: 'safety' } }, coverage: 'covered' },
-  { mode: 'observe', aliases: ['sa-kpr', 'safe-auto-by-keeper'], target: { tab: 'command', params: { section: 'operations', view: 'safety', focus: 'keeper' } }, coverage: 'covered' },
-  { mode: 'observe', aliases: ['sa-trd', 'safe-auto-trend'], target: { tab: 'command', params: { section: 'operations', view: 'safety', focus: 'trend' } }, coverage: 'covered' },
-  { mode: 'observe', aliases: ['ct-agt', 'cost-per-agent'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cost', focus: 'agent' } }, coverage: 'covered' },
-  { mode: 'observe', aliases: ['ct-mtx', 'cost-matrix'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cost', focus: 'matrix' } }, coverage: 'covered' },
-  { mode: 'observe', aliases: ['ct-lat', 'cost-latency'], target: { tab: 'monitoring', params: { section: 'runtime', view: 'cost', focus: 'latency' } }, coverage: 'covered' },
-
-  // Cognition Plane legacy design subtabs.
-  { mode: 'cognition', aliases: ['ki-bdi', 'keeper-bdi'], target: { tab: 'monitoring', params: { section: 'agents', view: 'keeper', focus: 'bdi' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['ki-acc', 'keeper-tool-access'], target: { tab: 'monitoring', params: { section: 'agents', view: 'keeper', focus: 'tool-access' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['ki-stat', 'keeper-token-stats'], target: { tab: 'monitoring', params: { section: 'agents', view: 'token-stats' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['dc-str', 'decisions-stream'], target: { tab: 'monitoring', params: { section: 'agents', view: 'decisions' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['dc-mem', 'memory-entries'], target: { tab: 'monitoring', params: { section: 'agents', view: 'memory', focus: 'entries' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['ep-card', 'episodes-cards'], target: { tab: 'monitoring', params: { section: 'agents', view: 'episodes' } }, coverage: 'covered' },
-  { mode: 'cognition', aliases: ['ep-lrn', 'episodes-learnings'], target: { tab: 'monitoring', params: { section: 'agents', view: 'episodes' } }, coverage: 'covered' },
-
-  // IDE Plane legacy design subtabs.
-  { mode: 'ide', aliases: ['edit'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source' } }, coverage: 'covered' },
-  { mode: 'ide', aliases: ['review', 'pr-thread'], target: { tab: 'code', params: { section: 'ide-shell', view: 'unified', focus: 'review' } }, coverage: 'covered' },
-  { mode: 'ide', aliases: ['merge', 'split', 'split-diff'], target: { tab: 'code', params: { section: 'ide-shell', view: 'split-diff' } }, coverage: 'covered' },
-  { mode: 'ide', aliases: ['search', 'find'], target: { tab: 'code', params: { section: 'ide-shell', view: 'source', find: 'open' } }, coverage: 'covered' },
-]
-
 const ENTRYPOINT_TARGETS = new Map<string, CockpitRouteTarget>()
 
-for (const entrypoint of [...COCKPIT_ENTRYPOINTS, ...COCKPIT_LEGACY_ENTRYPOINTS]) {
+for (const entrypoint of COCKPIT_ENTRYPOINTS) {
   for (const alias of entrypoint.aliases) {
     ENTRYPOINT_TARGETS.set(`${entrypoint.mode}:${normalizeCockpitEntrypoint(alias)}`, entrypoint.target)
   }

--- a/dashboard/src/router.test.ts
+++ b/dashboard/src/router.test.ts
@@ -232,45 +232,47 @@ describe('navigate', () => {
     expect(route.value.params.mode).toBe('Cognition')
   })
 
-  it('maps cockpit cognition subtabs to explicit agents views', () => {
+  it('does not map retired cockpit cognition subtabs to legacy views', () => {
     window.location.hash = '#mode=Cognition&tab=dc-str'
     window.dispatchEvent(new HashChangeEvent('hashchange'))
 
     expect(route.value.tab).toBe('monitoring')
     expect(route.value.params.section).toBe('agents')
-    expect(route.value.params.view).toBe('decisions')
+    expect(route.value.params.view).toBeUndefined()
+    expect(route.value.params.tab).toBe('dc-str')
     expect(window.location.hash).toContain('section=agents')
-    expect(window.location.hash).toContain('view=decisions')
+    expect(window.location.hash).toContain('tab=dc-str')
   })
 
-  it('maps observe safe-auto subtabs across surfaces without dropping context', () => {
+  it('does not map retired observe safe-auto subtabs across surfaces', () => {
     window.location.hash = '#repo=viewer&mode=Observe&tab=sa-dash'
-    window.dispatchEvent(new HashChangeEvent('hashchange'))
-
-    expect(route.value.tab).toBe('command')
-    expect(route.value.params.section).toBe('operations')
-    expect(route.value.params.view).toBe('safety')
-    expect(route.value.params.repo).toBe('viewer')
-  })
-
-  it.each([
-    ['ct-agt', 'agent'],
-    ['ct-mtx', 'matrix'],
-    ['ct-lat', 'latency'],
-  ])('maps observe cost subtab %s without dropping context', (tab, focus) => {
-    window.location.hash = `#repo=viewer&mode=Observe&tab=${tab}&q=latency`
     window.dispatchEvent(new HashChangeEvent('hashchange'))
 
     expect(route.value.tab).toBe('monitoring')
     expect(route.value.params.section).toBe('runtime')
-    expect(route.value.params.view).toBe('cost')
-    expect(route.value.params.focus).toBe(focus)
+    expect(route.value.params.view).toBeUndefined()
     expect(route.value.params.repo).toBe('viewer')
     expect(route.value.params.mode).toBe('Observe')
-    expect(route.value.params.tab).toBe(tab)
-    expect(route.value.params.q).toBe('latency')
-    expect(window.location.hash).toContain(`tab=${tab}`)
+    expect(route.value.params.tab).toBe('sa-dash')
   })
+
+  it.each(['ct-agt', 'ct-mtx', 'ct-lat'])(
+    'does not map retired observe cost subtab %s to cost focus',
+    tab => {
+      window.location.hash = `#repo=viewer&mode=Observe&tab=${tab}&q=latency`
+      window.dispatchEvent(new HashChangeEvent('hashchange'))
+
+      expect(route.value.tab).toBe('monitoring')
+      expect(route.value.params.section).toBe('runtime')
+      expect(route.value.params.view).toBeUndefined()
+      expect(route.value.params.focus).toBeUndefined()
+      expect(route.value.params.repo).toBe('viewer')
+      expect(route.value.params.mode).toBe('Observe')
+      expect(route.value.params.tab).toBe(tab)
+      expect(route.value.params.q).toBe('latency')
+      expect(window.location.hash).toContain(`tab=${tab}`)
+    },
+  )
 
   it('replaceRoute writes a canonical hash while preserving the current search params', () => {
     window.history.replaceState(null, '', '/dashboard?theme=paper#overview')


### PR DESCRIPTION
## Summary

Hard-cuts dashboard-only legacy compatibility behavior in MASC.

- Removes the cockpit legacy entrypoint alias table so only canonical cockpit aliases route directly.
- Stops retrying keeper chat auth failures from substring matching; token refresh now requires the typed `auth_error_code` field.
- Updates the focused dashboard tests to assert canonical-only behavior.

## Validation

- `pnpm install --offline --frozen-lockfile`
- `pnpm exec vitest run src/cockpit-entrypoints.test.ts src/api/keeper.test.ts --config vitest.config.ts --no-file-parallelism --maxWorkers=1`
- `pnpm run typecheck`
- `bash scripts/lint/no-legacy-tool-surface-name.sh`
- `bash ci/lint-no-direct-dispatch.sh`