### PR TITLE
fix(config): restore autoboot max TOML mapping

### DIFF
--- a/lib/keeper_runtime/keeper_runtime_config.ml
+++ b/lib/keeper_runtime/keeper_runtime_config.ml
@@ -11,6 +11,7 @@ let key_to_env =
     "bootstrap.stale_turn_sec",         "MASC_KEEPER_BOOTSTRAP_STALE_TURN_SEC";
     "bootstrap.max_scan",               "MASC_KEEPER_BOOTSTRAP_MAX_SCAN";
     "bootstrap.max_active_keepers",     "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS";
+    "bootstrap.autoboot_max",           "MASC_KEEPER_AUTOBOOT_MAX";
     (* [autonomous] *)
     "autonomous.fairness_cooldown_sec", "MASC_KEEPER_AUTONOMOUS_FAIRNESS_COOLDOWN_SEC";
     "autonomous.max_idle_turns",        "MASC_KEEPER_MAX_IDLE_TURNS_AUTONOMOUS";


### PR DESCRIPTION
## Summary
- restore bootstrap.autoboot_max -> MASC_KEEPER_AUTOBOOT_MAX runtime TOML mapping
- align implementation with existing docs and test_runtime_toml_overrides coverage after #22607
- keep the canonical env var path instead of deleting a documented config key without migration

## Verification
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_runtime_toml_overrides.exe
- ./_build/default/test/test_runtime_toml_overrides.exe
- ocamlformat --check lib/keeper_runtime/keeper_runtime_config.ml
- git diff --check

Note: the local Dune guard override was only needed because an unrelated long-running bare Dune process was active in an OAS worktree. GitHub CI remains the build authority.