### PR TITLE
fix(keeper): keep synthetic raw text out of replay

### DIFF
--- a/lib/keeper/keeper_agent_run_response_text.ml
+++ b/lib/keeper/keeper_agent_run_response_text.ml
@@ -52,10 +52,11 @@ let state_snapshot ~reported_state_snapshot ~keeper_name ~goal ~actual_keeper_to
 ;;
 
 let response_text ~state_snapshot ~state_snapshot_source ~raw_response_text =
-  let is_structured_reply =
+  let is_structured_reply, is_synthesized =
     match (state_snapshot_source : Keeper_memory_policy.state_snapshot_source) with
-    | Structured_state_reply -> true
-    | Structured_state_tool | State_block | Synthesized -> false
+    | Structured_state_reply -> true, false
+    | Synthesized -> false, true
+    | Structured_state_tool | State_block -> false, false
   in
   let fallback =
     match
@@ -66,7 +67,7 @@ let response_text ~state_snapshot ~state_snapshot_source ~raw_response_text =
       Some "State updated."
     | None -> None
   in
-  if is_structured_reply then
+  if is_structured_reply || is_synthesized then
     Keeper_text_processing.user_visible_reply_text ?fallback ""
   else
     match fallback with

--- a/test/test_keeper_state_snapshot_json.ml
+++ b/test/test_keeper_state_snapshot_json.ml
@@ -449,6 +449,41 @@ let test_budget_finalizer_drops_synthetic_response_text () =
     []
     finalized.state_snapshot.decisions
 
+let test_synthetic_finalizer_drops_raw_response_text () =
+  let raw_response_text =
+    String.concat
+      "\n"
+      [
+        "The system context changed without new user input.";
+        "What should I do next?";
+        "Check keeper_tasks_list again.";
+        "What should I do next?";
+        "Check keeper_tasks_list again.";
+      ]
+  in
+  let finalized =
+    KRT.finalize
+      ~reported_state_snapshot:None
+      ~keeper_name:"test"
+      ~goal:"Monitor keeper work"
+      ~actual_keeper_tool_names:["keeper_tasks_list"]
+      ~stop_reason:Runtime_agent.Completed
+      ~raw_response_text
+      ()
+  in
+  Alcotest.(check string)
+    "synthetic state source"
+    "synthesized"
+    (KMP.state_snapshot_source_to_string finalized.state_snapshot_source);
+  Alcotest.(check string)
+    "synthetic response uses typed fallback instead of raw text"
+    "Used: keeper_tasks_list"
+    finalized.response_text;
+  Alcotest.(check bool)
+    "raw repeated text not persisted as response"
+    false
+    (contains_substring finalized.response_text "What should I do next?")
+
 (* ── Test runner ─────────────────────────────────────────────────── *)
 
 let () =
@@ -502,5 +537,9 @@ let () =
             "budget finalizer drops synthetic response text"
             `Quick
             test_budget_finalizer_drops_synthetic_response_text;
+          Alcotest.test_case
+            "synthetic finalizer drops raw response text"
+            `Quick
+            test_synthetic_finalizer_drops_raw_response_text;
         ] );
     ]


### PR DESCRIPTION
## Summary
- prevent synthesized keeper state turns from persisting raw model text as replay/checkpoint response text
- keep typed fallback summaries for synthetic turns while retaining bounded synthetic decision hints
- add regression coverage for repeated raw response text not being replay-persisted

## Why
Runtime logs show Thinking/self-accumulation is not provider-specific. A live idealist trace had history.internal.jsonl with repeated internal assistant text and later turns with very large thinking blocks. The unsafe path is typed: when no structured state is emitted, the finalizer marks the state as Synthesized but still used raw_response_text as persisted response text.

## Verification
- ocamlformat --check lib/keeper/keeper_agent_run_response_text.ml test/test_keeper_state_snapshot_json.ml
- env MASC_DUNE_ALLOW_BARE_DUNE=1 scripts/dune-local.sh build test/test_keeper_state_snapshot_json.exe
- ./_build/default/test/test_keeper_state_snapshot_json.exe
- git diff --check